### PR TITLE
fix: sync pkg/package.json version with pi-coding-agent to prevent false update banner

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "test": "node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test 'src/resources/extensions/gsd/tests/*.test.ts' 'src/resources/extensions/gsd/tests/*.test.mjs' 'src/tests/*.test.ts'",
     "dev": "tsc --watch",
     "postinstall": "node scripts/postinstall.js",
-    "prepublishOnly": "npm run build"
+    "sync-pkg-version": "node scripts/sync-pkg-version.cjs",
+    "prepublishOnly": "npm run sync-pkg-version && npm run build"
   },
   "dependencies": {
     "@mariozechner/pi-coding-agent": "^0.57.1",

--- a/pkg/package.json
+++ b/pkg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@glittercowboy/gsd",
-  "version": "0.1.0",
+  "version": "0.57.1",
   "piConfig": {
     "name": "gsd",
     "configDir": ".gsd"

--- a/scripts/sync-pkg-version.cjs
+++ b/scripts/sync-pkg-version.cjs
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+/**
+ * Sync pkg/package.json version with the installed @mariozechner/pi-coding-agent version.
+ *
+ * gsd-pi sets PI_PACKAGE_DIR=pkg/ so that pi's config.js reads piConfig from
+ * pkg/package.json (for branding: name="gsd", configDir=".gsd"). However, config.js
+ * also reads `version` from that same file and uses it for the update check
+ * (comparing against npm registry). If pkg/package.json has a stale version,
+ * pi's update banner fires even when the user is already on the latest release.
+ *
+ * This script reads the actual installed pi-coding-agent version and writes it
+ * into pkg/package.json so VERSION is always correct at publish time.
+ */
+const { readFileSync, writeFileSync } = require('fs')
+const { resolve, join } = require('path')
+
+const root = resolve(__dirname, '..')
+const piPkgPath = join(root, 'node_modules', '@mariozechner', 'pi-coding-agent', 'package.json')
+const gsdPkgPath = join(root, 'pkg', 'package.json')
+
+const piPkg = JSON.parse(readFileSync(piPkgPath, 'utf-8'))
+const gsdPkg = JSON.parse(readFileSync(gsdPkgPath, 'utf-8'))
+
+if (gsdPkg.version !== piPkg.version) {
+  console.log(`[sync-pkg-version] Updating pkg/package.json version: ${gsdPkg.version} → ${piPkg.version}`)
+  gsdPkg.version = piPkg.version
+  writeFileSync(gsdPkgPath, JSON.stringify(gsdPkg, null, 2) + '\n')
+} else {
+  console.log(`[sync-pkg-version] pkg/package.json version already matches: ${piPkg.version}`)
+}


### PR DESCRIPTION
## Problem

`gsd-pi` sets `PI_PACKAGE_DIR=pkg/` so that pi's `config.js` reads `piConfig` from `pkg/package.json` (for branding). However, `config.js` also reads `version` from that same file and uses it for the update check — comparing it against the npm registry.

`pkg/package.json` had a hardcoded `"version": "0.1.0"` that was never updated when new versions were published. This means:

- `VERSION` in pi's internals is always `0.1.0`
- The update check compares `0.1.0` against the latest npm version (e.g. `0.57.1`)
- Result: **"Update Available" banner always appears**, even when the user is already on the latest release

![Update Available banner showing despite being on latest version](https://github.com/user-attachments/assets/placeholder)

> Note: `PI_SKIP_VERSION_CHECK=1` was added in a recent commit and suppresses this in newer releases, but the root cause (stale version) remains and could cause issues anywhere `VERSION` is used.

## Fix

1. **Updated `pkg/package.json` version** to match the current pi-coding-agent dependency (`0.57.1`)
2. **Added `scripts/sync-pkg-version.cjs`** — reads the installed `@mariozechner/pi-coding-agent` version and writes it into `pkg/package.json`
3. **Integrated into `prepublishOnly`** so the version is automatically synced on every `npm publish`

## Testing

```bash
# Script correctly detects and updates stale version
$ node scripts/sync-pkg-version.cjs
[sync-pkg-version] Updating pkg/package.json version: 0.1.0 → 0.57.1

# Script is idempotent when version already matches
$ node scripts/sync-pkg-version.cjs
[sync-pkg-version] pkg/package.json version already matches: 0.57.1
```

## Affected versions

All published versions of gsd-pi (0.1.x through 0.2.8) show the false update banner when `PI_SKIP_VERSION_CHECK` is not set.