### PR TITLE
fix: restore scoped models from settings on new session startup

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -72,5 +72,48 @@ if (extensionsResult.errors.length > 0) {
   }
 }
 
+// Restore scoped models from settings on startup.
+// The upstream InteractiveMode reads enabledModels from settings when /scoped-models is opened,
+// but doesn't apply them to the session at startup — so Ctrl+P cycles all models instead of
+// just the saved selection until the user re-runs /scoped-models.
+const enabledModelPatterns = settingsManager.getEnabledModels()
+if (enabledModelPatterns && enabledModelPatterns.length > 0) {
+  const availableModels = modelRegistry.getAvailable()
+  const scopedModels: Array<{ model: (typeof availableModels)[number] }> = []
+  const seen = new Set<string>()
+
+  for (const pattern of enabledModelPatterns) {
+    // Patterns are "provider/modelId" exact strings saved by /scoped-models
+    const slashIdx = pattern.indexOf('/')
+    if (slashIdx !== -1) {
+      const provider = pattern.substring(0, slashIdx)
+      const modelId = pattern.substring(slashIdx + 1)
+      const model = availableModels.find((m) => m.provider === provider && m.id === modelId)
+      if (model) {
+        const key = `${model.provider}/${model.id}`
+        if (!seen.has(key)) {
+          seen.add(key)
+          scopedModels.push({ model })
+        }
+      }
+    } else {
+      // Fallback: match by model id alone
+      const model = availableModels.find((m) => m.id === pattern)
+      if (model) {
+        const key = `${model.provider}/${model.id}`
+        if (!seen.has(key)) {
+          seen.add(key)
+          scopedModels.push({ model })
+        }
+      }
+    }
+  }
+
+  // Only apply if we resolved some models and it's a genuine subset
+  if (scopedModels.length > 0 && scopedModels.length < availableModels.length) {
+    session.setScopedModels(scopedModels)
+  }
+}
+
 const interactiveMode = new InteractiveMode(session)
 await interactiveMode.run()


### PR DESCRIPTION
Fixes https://github.com/gsd-build/GSD-2/issues/18

## Problem

When `/scoped-models` saves a model selection and the user starts a new session, Ctrl+P cycles through **all** available models instead of just the saved selection. The workaround is to re-run `/scoped-models`, toggle any model, and save again — after which Ctrl+P works correctly for that session.

## Root Cause

The upstream `InteractiveMode` reads `enabledModels` from `settings.json` only when `/scoped-models` is opened (to populate the UI), but never loads them into `session.scopedModels` at startup. The session always starts with `scopedModels: []`, so `cycleModel` (Ctrl+P) sees no scope and cycles all available models.

## Fix

After `createAgentSession()`, read `enabledModels` patterns from `settingsManager.getEnabledModels()`, resolve them against `modelRegistry.getAvailable()`, and call `session.setScopedModels()` before entering interactive mode.

The patterns saved by `/scoped-models` are exact `provider/modelId` strings, so resolution is a simple lookup — no glob matching needed. Models that are no longer available (e.g., provider logged out) are silently skipped.