### PR TITLE
fix: wizard repeats on every launch when optional keys are skipped

### DIFF
--- a/src/wizard.ts
+++ b/src/wizard.ts
@@ -78,7 +78,7 @@ export function loadStoredEnvKeys(authStorage: AuthStorage): void {
   for (const [provider, envVar] of providers) {
     if (!process.env[envVar]) {
       const cred = authStorage.get(provider)
-      if (cred?.type === 'api_key') {
+      if (cred?.type === 'api_key' && cred.key) {
         process.env[envVar] = cred.key as string
       }
     }
@@ -167,6 +167,7 @@ export async function runWizardIfNeeded(authStorage: AuthStorage): Promise<void>
       process.stdout.write(`  ${green}✓${reset} ${key.label} saved\n\n`)
       savedCount++
     } else {
+      authStorage.set(key.provider, { type: 'api_key', key: '' })
       process.stdout.write(`  ${dim}↷  ${key.label} skipped${reset}\n\n`)
     }
   }


### PR DESCRIPTION
## Summary
- When optional API keys (Brave, Context7, Jina) are skipped during the wizard, nothing is stored in `auth.json`. On the next launch, `authStorage.has()` returns `false` for those providers, causing the wizard to prompt again every time.
- This stores an empty-key sentinel (`{ type: 'api_key', key: '' }`) for skipped providers so `authStorage.has()` returns `true` on subsequent launches.
- Also adds a guard in `loadStoredEnvKeys` to prevent injecting empty strings into `process.env`.

## Test plan
- [ ] Run `gsd`, skip all optional keys by pressing Enter
- [ ] Run `gsd` again, verify the wizard does not appear
- [ ] Confirm tools that rely on these keys still work when keys are later added via `auth.json`