### PR TITLE
fix: /gsd-run uses hardcoded ~/.pi/ path instead of GSD_WORKFLOW_PATH

### DIFF
--- a/src/resources/extensions/slash-commands/gsd-run.ts
+++ b/src/resources/extensions/slash-commands/gsd-run.ts
@@ -6,7 +6,7 @@ export default function gsdRun(pi: ExtensionAPI) {
   pi.registerCommand("gsd-run", {
     description: "Read GSD-WORKFLOW.md and execute — lightweight protocol-driven GSD",
     async handler(args: string, ctx: ExtensionCommandContext) {
-      const workflowPath = join(process.env.HOME ?? "~", ".pi", "GSD-WORKFLOW.md");
+      const workflowPath = process.env.GSD_WORKFLOW_PATH ?? join(process.env.HOME ?? "~", ".pi", "GSD-WORKFLOW.md");
 
       let workflow: string;
       try {


### PR DESCRIPTION
`/gsd-run` fails with `Error: Cannot read ~/.pi/GSD-WORKFLOW.md` because it hardcodes the old `~/.pi/` path instead of reading `GSD_WORKFLOW_PATH` env var.

The other GSD commands (`/gsd`, doctor heal) already use `process.env.GSD_WORKFLOW_PATH ?? fallback` — this slash command was missed.

**Fix:** One-line change — check `GSD_WORKFLOW_PATH` before falling back to the hardcoded path.

Related to #23 (same class of leftover `~/.pi/` references).