### PR TITLE
fix: /resume shows sessions from all projects instead of current directory

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,6 +6,7 @@ import {
   createAgentSession,
   InteractiveMode,
 } from '@mariozechner/pi-coding-agent'
+import { join } from 'path'
 import { agentDir, sessionsDir, authFilePath } from './app-paths.js'
 import { buildResourceLoader, initResources } from './resource-loader.js'
 import { loadStoredEnvKeys, runWizardIfNeeded } from './wizard.js'
@@ -53,7 +54,12 @@ if (!settingsManager.getCollapseChangelog()) {
   settingsManager.setCollapseChangelog(true)
 }
 
-const sessionManager = SessionManager.create(process.cwd(), sessionsDir)
+// Per-directory session storage — same encoding as the upstream SDK so that
+// /resume only shows sessions from the current working directory.
+const cwd = process.cwd()
+const safePath = `--${cwd.replace(/^[/\\]/, '').replace(/[/\\:]/g, '-')}--`
+const projectSessionsDir = join(sessionsDir, safePath)
+const sessionManager = SessionManager.create(cwd, projectSessionsDir)
 
 initResources(agentDir)
 const resourceLoader = buildResourceLoader(agentDir)


### PR DESCRIPTION
## Summary
- Sessions are stored in a single flat `~/.gsd/sessions/` directory, so `/resume` lists sessions from every project, not just the current one.
- Uses per-cwd subdirectories (`~/.gsd/sessions/--path-segments--/`) with the same encoding the upstream SDK uses in `getDefaultSessionDir()`.
- New sessions go into the scoped directory. Existing sessions in the flat dir are unaffected (they just won't appear in the per-directory listing).

## Test plan
- [ ] Run `gsd` in folder A, have a conversation, exit
- [ ] Run `gsd` in folder B, have a conversation, exit
- [ ] Run `gsd` in folder A, use `/resume`, verify only folder A sessions appear
- [ ] Run `gsd` in folder B, use `/resume`, verify only folder B sessions appear