### PR TITLE
feat: add /exit command to kill GSD process immediately

### DIFF
--- a/src/resources/extensions/gsd/index.ts
+++ b/src/resources/extensions/gsd/index.ts
@@ -63,6 +63,14 @@ export default function (pi: ExtensionAPI) {
   registerGSDCommand(pi);
   registerWorktreeCommand(pi);
 
+  // ── /exit — kill the process immediately ──────────────────────────────
+  pi.registerCommand("exit", {
+    description: "Exit GSD immediately",
+    handler: async (_ctx) => {
+      process.exit(0);
+    },
+  });
+
   // ── Dynamic-cwd bash tool with default timeout ────────────────────────
   // The built-in bash tool captures cwd at startup. This replacement uses
   // a spawnHook to read process.cwd() dynamically so that process.chdir()


### PR DESCRIPTION
Adds a `/exit` slash command that calls `process.exit(0)` to terminate GSD immediately.

### Changes

- `src/resources/extensions/gsd/index.ts` — registers `/exit` command alongside existing `/gsd` and `/worktree`

### Why

Currently there's no quick way to kill GSD from the prompt. `/exit` gives users a clean, discoverable way to quit.