### PR TITLE
feat: add /clear as alias for /new slash command

### DIFF
--- a/src/resources/extensions/slash-commands/clear.ts
+++ b/src/resources/extensions/slash-commands/clear.ts
@@ -1,0 +1,10 @@
+import type { ExtensionAPI, ExtensionCommandContext } from "@mariozechner/pi-coding-agent";
+
+export default function clearCommand(pi: ExtensionAPI) {
+  pi.registerCommand("clear", {
+    description: "Alias for /new — start a new session",
+    async handler(_args: string, ctx: ExtensionCommandContext) {
+      await ctx.newSession();
+    },
+  });
+}

--- a/src/resources/extensions/slash-commands/index.ts
+++ b/src/resources/extensions/slash-commands/index.ts
@@ -3,10 +3,12 @@ import createSlashCommand from "./create-slash-command.js";
 import createExtension from "./create-extension.js";
 import auditCommand from "./audit.js";
 import gsdRun from "./gsd-run.js";
+import clearCommand from "./clear.js";
 
 export default function slashCommands(pi: ExtensionAPI) {
   createSlashCommand(pi);
   createExtension(pi);
   auditCommand(pi);
   gsdRun(pi);
+  clearCommand(pi);
 }


### PR DESCRIPTION
Adds `/clear` as a slash command that starts a new session, identical to `/new`.

### Changes
- **`src/resources/extensions/slash-commands/clear.ts`** — Registers `/clear` calling `ctx.newSession()`
- **`src/resources/extensions/slash-commands/index.ts`** — Imports and registers the new command

### Behavior
- `/clear` starts a new session just like `/new`
- Appears in autocomplete when typing `/cl` with description "Alias for /new"
- Run `/reload` to pick it up