### PR TITLE
feat: add /exit command to kill GSD process immediately

### DIFF
--- a/src/resources/extensions/gsd/index.ts
+++ b/src/resources/extensions/gsd/index.ts
@@ -63,6 +63,14 @@ export default function (pi: ExtensionAPI) {
   registerGSDCommand(pi);
   registerWorktreeCommand(pi);
 
+  // ── /exit — kill the process immediately ──────────────────────────────
+  pi.registerCommand("exit", {
+    description: "Exit GSD immediately",
+    handler: async (_ctx) => {
+      process.exit(0);
+    },
+  });
+
   // ── Dynamic-cwd bash tool with default timeout ────────────────────────
   // The built-in bash tool captures cwd at startup. This replacement uses
   // a spawnHook to read process.cwd() dynamically so that process.chdir()


### PR DESCRIPTION
Adds `/exit` as a slash command that immediately terminates GSD via `process.exit(0)`.

### Changes
- **`src/resources/extensions/gsd/index.ts`** — Registers `/exit` command

### Behavior
- `/exit` kills the process immediately
- Quick alternative to `/quit`
- Run `/reload` to pick it up