### PR TITLE
fix: general merge guard prevents infinite loop when complete-slice is bypassed

### DIFF
--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -60,6 +60,8 @@ import { execSync } from "node:child_process";
 import {
   autoCommitCurrentBranch,
   ensureSliceBranch,
+  getCurrentBranch,
+  getSliceBranchName,
   switchToMain,
   mergeSliceToMain,
 } from "./worktree.ts";
@@ -787,39 +789,53 @@ async function dispatchNextUnit(
     return;
   }
 
-  // ── Post-completion merge: merge the slice branch after complete-slice finishes ──
-  // The complete-slice unit writes the summary, UAT, marks roadmap [x], and commits.
-  // Now we switch to main and squash-merge the slice branch.
-  if (currentUnit?.type === "complete-slice") {
-    try {
-      const [completedMid, completedSid] = currentUnit.id.split("/");
-      // Look up actual slice title from roadmap (on current branch, before switching)
-      const roadmapFile = resolveMilestoneFile(basePath, completedMid!, "ROADMAP");
+  // ── General merge guard: merge completed slice branches before advancing ──
+  // If we're on a gsd/MID/SID branch and that slice is done (roadmap [x]),
+  // merge to main before dispatching the next unit. This handles:
+  //   - Normal complete-slice → merge → reassess flow
+  //   - LLM writes summary during task execution, skipping complete-slice
+  //   - Doctor post-hook marks everything done, skipping complete-slice
+  //   - complete-milestone runs on a slice branch (last slice bypass)
+  {
+    const currentBranch = getCurrentBranch(basePath);
+    const branchMatch = currentBranch.match(/^gsd\/(M\d+)\/(S\d+)$/);
+    if (branchMatch) {
+      const branchMid = branchMatch[1]!;
+      const branchSid = branchMatch[2]!;
+      // Check if this slice is marked done in the roadmap
+      const roadmapFile = resolveMilestoneFile(basePath, branchMid, "ROADMAP");
       const roadmapContent = roadmapFile ? await loadFile(roadmapFile) : null;
-      let sliceTitleForMerge = completedSid!;
       if (roadmapContent) {
         const roadmap = parseRoadmap(roadmapContent);
-        const sliceEntry = roadmap.slices.find(s => s.id === completedSid);
-        if (sliceEntry) sliceTitleForMerge = sliceEntry.title;
+        const sliceEntry = roadmap.slices.find(s => s.id === branchSid);
+        if (sliceEntry?.done) {
+          try {
+            const sliceTitleForMerge = sliceEntry.title || branchSid;
+            switchToMain(basePath);
+            const mergeResult = mergeSliceToMain(
+              basePath, branchMid, branchSid, sliceTitleForMerge,
+            );
+            ctx.ui.notify(
+              `Merged ${mergeResult.branch} → main.`,
+              "info",
+            );
+            // Re-derive state from main so downstream logic sees merged state
+            state = await deriveState(basePath);
+            mid = state.activeMilestone?.id;
+            midTitle = state.activeMilestone?.title;
+          } catch (error) {
+            const message = error instanceof Error ? error.message : String(error);
+            ctx.ui.notify(
+              `Slice merge failed: ${message}`,
+              "error",
+            );
+            // Re-derive state so dispatch can figure out what to do
+            state = await deriveState(basePath);
+            mid = state.activeMilestone?.id;
+            midTitle = state.activeMilestone?.title;
+          }
+        }
       }
-      switchToMain(basePath);
-      const mergeResult = mergeSliceToMain(
-        basePath, completedMid!, completedSid!, sliceTitleForMerge,
-      );
-      ctx.ui.notify(
-        `Merged ${mergeResult.branch} → main.`,
-        "info",
-      );
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      ctx.ui.notify(
-        `Slice merge failed: ${message}`,
-        "error",
-      );
-      // Re-derive state so dispatch can figure out what to do
-      state = await deriveState(basePath);
-      mid = state.activeMilestone?.id;
-      midTitle = state.activeMilestone?.title;
     }
   }
 


### PR DESCRIPTION
## Problem

Auto-mode enters an infinite loop when `complete-slice` is bypassed, alternating between researching two milestones forever.

### How it was discovered

Auto-mode ran for 12+ hours stuck in a loop. The activity logs showed it alternating between `research-slice M006/S06` and `research-slice M007/S01` — the same two units, over and over:

```
152-research-slice-M006-S06.jsonl
153-research-slice-M007-S01.jsonl
154-research-slice-M006-S06.jsonl
155-research-slice-M007-S01.jsonl
...
```

### Root cause

The slice-to-main merge **only** triggered when `currentUnit.type === "complete-slice"`. But when the LLM completed slice bookkeeping during task execution (the task was literally named "Write slice summary, advance requirements, update state"), `deriveState` saw the slice as already done and skipped `complete-slice` entirely, jumping straight to `completing-milestone`.

The sequence:

1. M006's final slice (S06) had task T03 write the slice summary and mark the roadmap `[x]` during execution
2. `deriveState` saw all tasks `[x]`, summary exists, roadmap `[x]` → skipped `summarizing` phase → jumped to `completing-milestone`
3. `complete-milestone` wrote M006-SUMMARY.md — all on the `gsd/M006/S06` branch
4. After `complete-milestone` finished, the merge check only fires for `complete-slice` → **no merge happened**
5. M007/S01 branched from `main`, which never received M006-SUMMARY.md
6. On `gsd/M007/S01`, `deriveState` saw M006 as incomplete (no summary on this branch) → dispatched `research-slice M006/S06`
7. Switching to `gsd/M006/S06` branch where M006 *was* complete → dispatched `research-slice M007/S01` → **infinite loop**

### Why the stuck detector didn't catch it

The stuck detector compares `(unitType, unitId)` pairs. Each dispatch alternated between two different units (`M006/S06` and `M007/S01`), so it never saw the same unit twice in a row.

## Solution

Replace the narrow `if (currentUnit?.type === "complete-slice")` merge check with a general merge guard. Before dispatching any unit, check: are we on a `gsd/MID/SID` branch where the slice's roadmap entry is `[x]`? If so, merge to main and re-derive state.

This catches all bypass paths:
- **Normal flow**: `complete-slice` → merge → reassess (still works)
- **LLM writes summary during task execution**: `complete-slice` skipped → merge still fires
- **Doctor post-hook completes bookkeeping**: `complete-slice` skipped → merge still fires
- **Last slice in milestone**: jumps to `complete-milestone` on slice branch → merge fires before next milestone starts

## Changes

- `src/resources/extensions/gsd/auto.ts` — replaced `complete-slice`-specific merge block with branch-aware general merge guard in `dispatchNextUnit()`
- Added `getCurrentBranch` and `getSliceBranchName` to the worktree imports (already exported, just not imported here)
