### PR TITLE
fix: register dynamic-cwd write/read/edit tools for worktree support

### DIFF
--- a/src/resources/extensions/gsd/index.ts
+++ b/src/resources/extensions/gsd/index.ts
@@ -22,7 +22,7 @@ import type {
   ExtensionAPI,
   ExtensionContext,
 } from "@mariozechner/pi-coding-agent";
-import { createBashTool } from "@mariozechner/pi-coding-agent";
+import { createBashTool, createWriteTool, createReadTool, createEditTool } from "@mariozechner/pi-coding-agent";
 
 import { registerGSDCommand } from "./commands.js";
 import { registerWorktreeCommand, getWorktreeOriginalCwd, getActiveWorktreeName } from "./worktree-command.js";
@@ -101,6 +101,59 @@ export default function (pi: ExtensionAPI) {
     },
   };
   pi.registerTool(dynamicBash as any);
+
+  // ── Dynamic-cwd file tools (write, read, edit) ────────────────────────
+  // The built-in file tools capture cwd at startup. When process.chdir()
+  // moves us into a worktree, relative paths still resolve against the
+  // original launch directory. These replacements delegate to freshly-
+  // created tools on each call so that process.cwd() is read dynamically.
+  const baseWrite = createWriteTool(process.cwd());
+  const dynamicWrite = {
+    ...baseWrite,
+    execute: async (
+      toolCallId: string,
+      params: { path: string; content: string },
+      signal?: AbortSignal,
+      onUpdate?: any,
+      ctx?: any,
+    ) => {
+      const fresh = createWriteTool(process.cwd());
+      return fresh.execute(toolCallId, params, signal, onUpdate, ctx);
+    },
+  };
+  pi.registerTool(dynamicWrite as any);
+
+  const baseRead = createReadTool(process.cwd());
+  const dynamicRead = {
+    ...baseRead,
+    execute: async (
+      toolCallId: string,
+      params: { path: string; offset?: number; limit?: number },
+      signal?: AbortSignal,
+      onUpdate?: any,
+      ctx?: any,
+    ) => {
+      const fresh = createReadTool(process.cwd());
+      return fresh.execute(toolCallId, params, signal, onUpdate, ctx);
+    },
+  };
+  pi.registerTool(dynamicRead as any);
+
+  const baseEdit = createEditTool(process.cwd());
+  const dynamicEdit = {
+    ...baseEdit,
+    execute: async (
+      toolCallId: string,
+      params: { path: string; oldText: string; newText: string },
+      signal?: AbortSignal,
+      onUpdate?: any,
+      ctx?: any,
+    ) => {
+      const fresh = createEditTool(process.cwd());
+      return fresh.execute(toolCallId, params, signal, onUpdate, ctx);
+    },
+  };
+  pi.registerTool(dynamicEdit as any);
 
   // ── session_start: render branded GSD header + remote channel status ──
   pi.on("session_start", async (_event, ctx) => {


### PR DESCRIPTION
## Problem

When using `/worktree switch` to move into a GSD worktree, the built-in `write`, `read`, and `edit` tools still resolve relative paths against the **original launch directory** (main project root). This causes GSD auto-mode to write `.gsd/` artifacts (plans, research, summaries) to the main project's `.gsd/` instead of the worktree's `.gsd/`.

The `bash` tool was already patched with a `spawnHook` for dynamic CWD — but the file tools were missed.

## Root Cause

All three file tools (`createWriteTool`, `createReadTool`, `createEditTool`) call `resolveToCwd(path, cwd)` where `cwd` is captured **once** at tool creation time. When `/worktree switch` calls `process.chdir()`, these tools still use the stale CWD.

The agent gets a system prompt saying "your CWD is the worktree path" and bash commands work correctly, but any `write`/`read`/`edit` with a relative path (like `.gsd/milestones/...`) resolves against the original launch directory.

## Fix

Register dynamic-CWD replacements for `write`, `read`, and `edit` — same pattern as the existing bash tool patch. Each replacement's `execute()` creates a fresh tool instance with `createXTool(process.cwd())` on every call, so relative paths always resolve against the current working directory.

## Changes

- `src/resources/extensions/gsd/index.ts` — import `createWriteTool`, `createReadTool`, `createEditTool` and register dynamic-CWD wrappers for each (+54 lines)

## Risk

Low. The constructors are trivial (no I/O, no heavy init). When not in a worktree, `process.cwd()` never changes so behavior is identical to before.