### PR TITLE
Avoid sudo prompts during postinstall browser setup

### DIFF
--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -33,23 +33,52 @@ const banner =
   `  ${green}✓${reset} Installed successfully\n` +
   `  ${dim}Run ${reset}${cyan}gsd${reset}${dim} to get started.${reset}\n`
 
+function run(command, options = {}) {
+  return execSync(command, {
+    cwd: resolve(__dirname, '..'),
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    ...options,
+  })
+}
+
+function printCaptured(output) {
+  if (output) process.stderr.write(output)
+}
+
 process.stderr.write(banner)
 
 // Apply patches to upstream dependencies (non-fatal)
 try {
-  execSync('npx patch-package', { stdio: 'inherit', cwd: resolve(__dirname, '..') })
+  const output = run('npx patch-package')
+  printCaptured(output)
   process.stderr.write(`\n  ${green}✓${reset} Patches applied\n`)
-} catch {
+} catch (error) {
+  printCaptured(error.stdout)
+  printCaptured(error.stderr)
   process.stderr.write(`\n  ${yellow}⚠${reset}  Failed to apply patches — run ${cyan}npx patch-package${reset} manually\n`)
 }
 
-// Install Playwright chromium for browser tools (non-fatal)
+// Install Playwright chromium for browser tools (non-fatal).
+// We intentionally avoid --with-deps here because install scripts should not
+// block on interactive sudo prompts. Playwright validates host requirements
+// after download; if Linux libs are missing, suggest the explicit follow-up.
 try {
-  execSync('npx playwright install chromium', { stdio: 'inherit' })
+  const output = run('npx playwright install chromium')
+  printCaptured(output)
   process.stderr.write(`\n  ${green}✓${reset} Browser tools ready\n\n`)
-} catch {
-  const hint = os.platform() === 'linux'
-    ? `${cyan}npx playwright install --with-deps chromium${reset}`
-    : `${cyan}npx playwright install chromium${reset}`
-  process.stderr.write(`\n  ${yellow}⚠${reset}  Browser tools unavailable — run ${hint} to enable\n\n`)
+} catch (error) {
+  const output = `${error.stdout ?? ''}${error.stderr ?? ''}`
+  printCaptured(output)
+
+  if (os.platform() === 'linux' && output.includes('Host system is missing dependencies to run browsers.')) {
+    process.stderr.write(
+      `\n  ${yellow}⚠${reset}  Browser downloaded, but Linux system dependencies are missing.\n` +
+      `  ${dim}Run ${reset}${cyan}sudo npx playwright install-deps chromium${reset}${dim} to finish setup.${reset}\n\n`
+    )
+  } else {
+    process.stderr.write(
+      `\n  ${yellow}⚠${reset}  Browser tools unavailable — run ${cyan}npx playwright install chromium${reset} to enable\n\n`
+    )
+  }
 }

--- a/src/tests/app-smoke.test.ts
+++ b/src/tests/app-smoke.test.ts
@@ -308,6 +308,28 @@ test("tarball installs and gsd binary resolves", async () => {
   }
 });
 
+test("postinstall avoids sudo during browser setup and suggests install-deps only when needed", () => {
+  const postinstall = readFileSync(join(projectRoot, "scripts", "postinstall.js"), "utf-8");
+
+  assert.doesNotMatch(
+    postinstall,
+    /playwright install chromium[^\n]*--with-deps/,
+    "postinstall does not request sudo-backed Playwright deps during npm install",
+  );
+  assert.ok(
+    postinstall.includes("npx playwright install chromium"),
+    "postinstall downloads Chromium during install",
+  );
+  assert.ok(
+    postinstall.includes("Host system is missing dependencies to run browsers."),
+    "postinstall detects Playwright's missing Linux dependency warning",
+  );
+  assert.ok(
+    postinstall.includes("sudo npx playwright install-deps chromium"),
+    "postinstall suggests the explicit follow-up command only when Linux deps are missing",
+  );
+});
+
 // ═══════════════════════════════════════════════════════════════════════════
 // 8. Launch → extensions load → no errors on stderr
 // ═══════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary
- stop using `playwright install chromium --with-deps` during postinstall
- let Playwright download Chromium and validate host requirements normally
- only suggest `sudo npx playwright install-deps chromium` when Playwright reports missing Linux dependencies
- add a regression test covering the new postinstall behavior

## Why
Installing `gsd-pi` globally on Linux could appear to hang because the postinstall script tried to trigger a sudo-backed Playwright dependency install. This keeps the install non-interactive while still guiding users to the explicit follow-up command when their host is actually missing libraries.

## Tested
- `node --check scripts/postinstall.js`
- `node --test --test-name-pattern='postinstall avoids sudo' src/tests/app-smoke.test.ts`
- `npm install`
- `npm run build`
- local tarball install with foreground scripts enabled
