### PR TITLE
fix: use gemini-2.5-flash in google-search extension

### DIFF
--- a/src/resources/extensions/google-search/index.ts
+++ b/src/resources/extensions/google-search/index.ts
@@ -141,7 +141,7 @@ export default function (pi: ExtensionAPI) {
 			try {
 				const ai = getClient();
 				const response = await ai.models.generateContent({
-					model: "gemini-3-flash-preview",
+					model: "gemini-2.5-flash",
 					contents: params.query,
 					config: {
 						tools: [{ googleSearch: {} }],


### PR DESCRIPTION
## Summary
- Changes google-search extension model from `gemini-3-flash-preview` to `gemini-2.5-flash`
- `gemini-3-flash-preview` is not available on Vertex AI (404 error) and has stricter rate limits on the Gemini Developer API
- `gemini-2.5-flash` is the stable model, available on both Vertex AI and Gemini API

## Test plan
- [ ] Verify google_search works with Vertex AI (`GOOGLE_CLOUD_PROJECT` set)
- [ ] Verify google_search works with Gemini API (`GEMINI_API_KEY` set)