### PR TITLE
fix: remove duplicate getCurrentBranch import in auto.ts

### DIFF
--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -64,7 +64,6 @@ import {
   getSliceBranchName,
   switchToMain,
   mergeSliceToMain,
-  getCurrentBranch,
 } from "./worktree.ts";
 import { truncateToWidth, visibleWidth } from "@mariozechner/pi-tui";
 import { makeUI, GLYPH, INDENT } from "../shared/ui.js";


### PR DESCRIPTION
## Summary

- Removes a duplicate `getCurrentBranch` entry from the `worktree.ts` import block in `auto.ts`
- The duplicate causes `ParseError: Identifier 'getCurrentBranch' has already been declared` on extension load, preventing GSD from starting

`getCurrentBranch` was imported once at line 63 (original), then again at line 67 — introduced alongside `mergeSliceToMain` when the general merge guard was added in #71.

## Changes

- `src/resources/extensions/gsd/auto.ts` — remove duplicate `getCurrentBranch` import (1 line)

## Test plan

- [ ] Extension loads without `ParseError` on startup
- [ ] Auto-mode starts and the progress widget renders git branch correctly