### PR TITLE
fix/gsd-graceful-exit: make /exit use graceful shutdown

### DIFF
--- a/src/resources/extensions/gsd/exit-command.ts
+++ b/src/resources/extensions/gsd/exit-command.ts
@@ -1,10 +1,18 @@
-import type { ExtensionAPI, ExtensionCommandContext } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI, ExtensionCommandContext } from "@gsd/pi-coding-agent";
 
-export function registerExitCommand(pi: Pick<ExtensionAPI, "registerCommand">): void {
+type StopAutoFn = (ctx: ExtensionCommandContext, pi: ExtensionAPI) => Promise<void>;
+
+export function registerExitCommand(
+  pi: ExtensionAPI,
+  deps: { stopAuto?: StopAutoFn } = {},
+): void {
   pi.registerCommand("exit", {
     description: "Exit GSD gracefully",
     handler: async (_args: string, ctx: ExtensionCommandContext) => {
-      await ctx.shutdown();
+      // Stop auto-mode first so locks and activity state are cleaned up before shutdown.
+      const stopAuto = deps.stopAuto ?? (await import("./auto.js")).stopAuto;
+      await stopAuto(ctx, pi);
+      ctx.shutdown();
     },
   });
 }

--- a/src/resources/extensions/gsd/index.ts
+++ b/src/resources/extensions/gsd/index.ts
@@ -20,11 +20,13 @@
 
 import type {
   ExtensionAPI,
+  ExtensionCommandContext,
   ExtensionContext,
 } from "@gsd/pi-coding-agent";
 import { createBashTool, createWriteTool, createReadTool, createEditTool } from "@gsd/pi-coding-agent";
 
 import { registerGSDCommand } from "./commands.js";
+import { registerExitCommand } from "./exit-command.js";
 import { registerWorktreeCommand, getWorktreeOriginalCwd, getActiveWorktreeName } from "./worktree-command.js";
 import { saveFile, formatContinue, loadFile, parseContinue, parseSummary } from "./files.js";
 import { loadPrompt } from "./prompt-loader.js";
@@ -63,22 +65,12 @@ const GSD_LOGO_LINES = [
 export default function (pi: ExtensionAPI) {
   registerGSDCommand(pi);
   registerWorktreeCommand(pi);
-
-  // ── /exit — graceful exit (cleanup auto-mode, save state) ──────────────
-  pi.registerCommand("exit", {
-    description: "Exit GSD gracefully (saves auto-mode state)",
-    handler: async (_ctx) => {
-      // Gracefully stop auto-mode if running (saves activity log, clears locks)
-      const { stopAuto } = await import("./auto.js");
-      await stopAuto(_ctx, pi);
-      process.exit(0);
-    },
-  });
+  registerExitCommand(pi);
 
   // ── /kill — immediate exit (bypass cleanup) ─────────────────────────────
   pi.registerCommand("kill", {
     description: "Exit GSD immediately (no cleanup)",
-    handler: async (_ctx) => {
+    handler: async (_args: string, _ctx: ExtensionCommandContext) => {
       process.exit(0);
     },
   });

--- a/src/resources/extensions/gsd/tests/exit-command.test.ts
+++ b/src/resources/extensions/gsd/tests/exit-command.test.ts
@@ -18,7 +18,12 @@ test("/exit requests graceful shutdown instead of process.exit", async () => {
     },
   };
 
-  registerExitCommand(pi as any);
+  let stopAutoCalls = 0;
+  registerExitCommand(pi as any, {
+    async stopAuto() {
+      stopAutoCalls += 1;
+    },
+  });
 
   const exit = commands.get("exit");
   assert.ok(exit, "registerExitCommand should register /exit");
@@ -40,5 +45,6 @@ test("/exit requests graceful shutdown instead of process.exit", async () => {
     process.exit = originalExit;
   }
 
+  assert.equal(stopAutoCalls, 1, "handler should stop auto-mode exactly once before shutdown");
   assert.equal(shutdownCalls, 1, "handler should request graceful shutdown exactly once");
 });


### PR DESCRIPTION
  ## Issue
  fixes #132 

  ## Summary

  Make `/exit` use graceful shutdown instead of `process.exit(0)`.

  ## Why

  Direct process exit can bypass terminal cleanup in interactive mode. In Ghostty this can leave kitty keyboard mode enabled and cause stray `...u` fragments in the shell after GSD exits.

  ## Changes

  - switch `/exit` to `ctx.shutdown()`
  - add regression coverage for `/exit`
  - update README and changelog

  ## Notes

  Full npm test still reports unrelated existing failures in idle-recovery.test.ts and app-smoke.test.ts.