### PR TITLE
fix(gsd-auto): require prior slices complete on main

### DIFF
--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -68,6 +68,7 @@ import {
   mergeSliceToMain,
 } from "./worktree.ts";
 import { GitServiceImpl } from "./git-service.ts";
+import { getPriorSliceCompletionBlocker } from "./dispatch-guard.ts";
 import type { GitPreferences } from "./git-service.ts";
 import { truncateToWidth, visibleWidth } from "@gsd/pi-tui";
 import { makeUI, GLYPH, INDENT } from "../shared/ui.js";
@@ -1252,6 +1253,13 @@ async function dispatchNextUnit(
       ctx.ui.notify(`Unexpected phase: ${state.phase}. Stopping auto-mode.`, "warning");
       return;
     }
+  }
+
+  const priorSliceBlocker = getPriorSliceCompletionBlocker(basePath, getMainBranch(basePath), unitType, unitId);
+  if (priorSliceBlocker) {
+    await stopAuto(ctx, pi);
+    ctx.ui.notify(priorSliceBlocker, "error");
+    return;
   }
 
   await emitObservabilityWarnings(ctx, unitType, unitId);

--- a/src/resources/extensions/gsd/dispatch-guard.ts
+++ b/src/resources/extensions/gsd/dispatch-guard.ts
@@ -1,0 +1,65 @@
+import { execSync } from "node:child_process";
+import { relMilestoneFile } from "./paths.js";
+import { parseRoadmapSlices } from "./roadmap-slices.ts";
+
+const SLICE_DISPATCH_TYPES = new Set([
+  "research-slice",
+  "plan-slice",
+  "replan-slice",
+  "execute-task",
+  "complete-slice",
+]);
+
+function readTrackedFileFromBranch(base: string, branch: string, relPath: string): string | null {
+  try {
+    return execSync(`git show ${branch}:${relPath}`, {
+      cwd: base,
+      stdio: ["ignore", "pipe", "pipe"],
+      encoding: "utf-8",
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+function milestoneIdFromNumber(num: number): string {
+  return `M${String(num).padStart(3, "0")}`;
+}
+
+export function getPriorSliceCompletionBlocker(base: string, mainBranch: string, unitType: string, unitId: string): string | null {
+  if (!SLICE_DISPATCH_TYPES.has(unitType)) return null;
+
+  const [targetMid, targetSid] = unitId.split("/");
+  if (!targetMid || !targetSid) return null;
+
+  const targetMidNumber = Number.parseInt(targetMid.slice(1), 10);
+  if (!Number.isFinite(targetMidNumber)) return null;
+
+  for (let milestoneNumber = 1; milestoneNumber <= targetMidNumber; milestoneNumber += 1) {
+    const mid = milestoneIdFromNumber(milestoneNumber);
+    const roadmapRel = relMilestoneFile(base, mid, "ROADMAP");
+    if (!roadmapRel) continue;
+
+    const roadmapContent = readTrackedFileFromBranch(base, mainBranch, roadmapRel);
+    if (!roadmapContent) continue;
+
+    const slices = parseRoadmapSlices(roadmapContent);
+    if (mid !== targetMid) {
+      const incomplete = slices.find(slice => !slice.done);
+      if (incomplete) {
+        return `Cannot dispatch ${unitType} ${unitId}: earlier slice ${mid}/${incomplete.id} is not complete on ${mainBranch}.`;
+      }
+      continue;
+    }
+
+    const targetIndex = slices.findIndex(slice => slice.id === targetSid);
+    if (targetIndex === -1) return null;
+
+    const incomplete = slices.slice(0, targetIndex).find(slice => !slice.done);
+    if (incomplete) {
+      return `Cannot dispatch ${unitType} ${unitId}: earlier slice ${targetMid}/${incomplete.id} is not complete on ${mainBranch}.`;
+    }
+  }
+
+  return null;
+}

--- a/src/resources/extensions/gsd/files.ts
+++ b/src/resources/extensions/gsd/files.ts
@@ -1,14 +1,14 @@
-// GSD Extension — File Parsing and I/O
+// GSD Extension - File Parsing and I/O
 // Parsers for roadmap, plan, summary, and continue files.
 // Used by state derivation and the status widget.
-// Pure functions, zero Pi dependencies — uses only Node built-ins.
+// Pure functions, zero Pi dependencies - uses only Node built-ins.
 
 import { promises as fs, readdirSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { milestonesDir, resolveMilestoneFile, relMilestoneFile } from './paths.js';
 
 import type {
-  Roadmap, RoadmapSliceEntry, BoundaryMapEntry, RiskLevel,
+  Roadmap, BoundaryMapEntry,
   SlicePlan, TaskPlanEntry,
   Summary, SummaryFrontmatter, SummaryRequires, FileModified,
   Continue, ContinueFrontmatter, ContinueStatus,
@@ -18,6 +18,7 @@ import type {
 } from './types.ts';
 
 import { checkExistingEnvKeys } from '../get-secrets-from-user.ts';
+import { parseRoadmapSlices } from './roadmap-slices.ts';
 
 // ─── Helpers ───────────────────────────────────────────────────────────────
 
@@ -199,40 +200,8 @@ export function parseRoadmap(content: string): Roadmap {
     })();
   const successCriteria = scSection ? parseBullets(scSection) : [];
 
-  // Slices
-  const slicesSection = extractSection(content, 'Slices');
-  const slices: RoadmapSliceEntry[] = [];
-
-  if (slicesSection) {
-    const checkboxItems = slicesSection.split('\n');
-    let currentSlice: RoadmapSliceEntry | null = null;
-
-    for (const line of checkboxItems) {
-      const cbMatch = line.match(/^-\s+\[([ xX])\]\s+\*\*(\w+):\s+(.+?)\*\*\s*(.*)/);
-      if (cbMatch) {
-        if (currentSlice) slices.push(currentSlice);
-
-        const done = cbMatch[1].toLowerCase() === 'x';
-        const id = cbMatch[2];
-        const sliceTitle = cbMatch[3];
-        const rest = cbMatch[4];
-
-        const riskMatch = rest.match(/`risk:(\w+)`/);
-        const risk = (riskMatch ? riskMatch[1] : 'low') as RiskLevel;
-
-        const depsMatch = rest.match(/`depends:\[([^\]]*)\]`/);
-        const depends = depsMatch && depsMatch[1].trim()
-          ? depsMatch[1].split(',').map(s => s.trim())
-          : [];
-
-        currentSlice = { id, title: sliceTitle, risk, depends, done, demo: '' };
-      } else if (currentSlice && line.trim().startsWith('>')) {
-        const demoText = line.trim().replace(/^>\s*/, '').replace(/^After this:\s*/i, '');
-        currentSlice.demo = demoText;
-      }
-    }
-    if (currentSlice) slices.push(currentSlice);
-  }
+  // Slices  
+  const slices = parseRoadmapSlices(content);
 
   // Boundary map
   const boundaryMap: BoundaryMapEntry[] = [];
@@ -657,7 +626,7 @@ export function parseTaskPlanMustHaves(content: string): Array<{ text: string; c
         checked: cbMatch[1].toLowerCase() === 'x',
       };
     }
-    // No checkbox — treat as unchecked with full line as text
+    // No checkbox - treat as unchecked with full line as text
     return { text: line.trim(), checked: false };
   });
 }
@@ -732,7 +701,7 @@ export type UatType = 'artifact-driven' | 'live-runtime' | 'human-experience' | 
 /**
  * Extract the UAT type from a UAT file's raw content.
  *
- * UAT files have no YAML frontmatter — pass raw file content directly.
+ * UAT files have no YAML frontmatter - pass raw file content directly.
  * Classification is leading-keyword-only: e.g. `mixed (artifact-driven + live-runtime)` → `'mixed'`.
  *
  * Returns `undefined` when:
@@ -811,7 +780,7 @@ export async function inlinePriorMilestoneSummary(mid: string, base: string): Pr
  * with the current environment (.env + process.env).
  *
  * Returns `null` when no manifest file exists (path resolution failure or
- * file not on disk) — callers can distinguish "no manifest" from "empty manifest".
+ * file not on disk) - callers can distinguish "no manifest" from "empty manifest".
  */
 export async function getManifestStatus(
   base: string, milestoneId: string,

--- a/src/resources/extensions/gsd/roadmap-slices.ts
+++ b/src/resources/extensions/gsd/roadmap-slices.ts
@@ -1,0 +1,50 @@
+import type { RoadmapSliceEntry, RiskLevel } from "./types.ts";
+
+function extractSlicesSection(content: string): string {
+  const headingMatch = /^## Slices\s*$/m.exec(content);
+  if (!headingMatch || headingMatch.index == null) return "";
+
+  const start = headingMatch.index + headingMatch[0].length;
+  const rest = content.slice(start).replace(/^\r?\n/, "");
+  const nextHeading = /^##\s+/m.exec(rest);
+  return (nextHeading ? rest.slice(0, nextHeading.index) : rest).trimEnd();
+}
+
+export function parseRoadmapSlices(content: string): RoadmapSliceEntry[] {
+  const slicesSection = extractSlicesSection(content);
+  const slices: RoadmapSliceEntry[] = [];
+  if (!slicesSection) return slices;
+
+  const checkboxItems = slicesSection.split("\n");
+  let currentSlice: RoadmapSliceEntry | null = null;
+
+  for (const line of checkboxItems) {
+    const cbMatch = line.match(/^\s*-\s+\[([ xX])\]\s+\*\*(\w+):\s+(.+?)\*\*\s*(.*)/);
+    if (cbMatch) {
+      if (currentSlice) slices.push(currentSlice);
+
+      const done = cbMatch[1].toLowerCase() === "x";
+      const id = cbMatch[2]!;
+      const title = cbMatch[3]!;
+      const rest = cbMatch[4] ?? "";
+
+      const riskMatch = rest.match(/`risk:(\w+)`/);
+      const risk = (riskMatch ? riskMatch[1] : "low") as RiskLevel;
+
+      const depsMatch = rest.match(/`depends:\[([^\]]*)\]`/);
+      const depends = depsMatch && depsMatch[1]!.trim()
+        ? depsMatch[1]!.split(",").map(s => s.trim())
+        : [];
+
+      currentSlice = { id, title, risk, depends, done, demo: "" };
+      continue;
+    }
+
+    if (currentSlice && line.trim().startsWith(">")) {
+      currentSlice.demo = line.trim().replace(/^>\s*/, "").replace(/^After this:\s*/i, "");
+    }
+  }
+
+  if (currentSlice) slices.push(currentSlice);
+  return slices;
+}

--- a/src/resources/extensions/gsd/tests/dispatch-guard.test.ts
+++ b/src/resources/extensions/gsd/tests/dispatch-guard.test.ts
@@ -1,0 +1,102 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { execSync } from "node:child_process";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { getPriorSliceCompletionBlocker } from "../dispatch-guard.ts";
+
+let passed = 0;
+let failed = 0;
+
+function assertEq<T>(actual: T, expected: T, message: string): void {
+  if (JSON.stringify(actual) === JSON.stringify(expected)) {
+    passed += 1;
+    return;
+  }
+  failed += 1;
+  console.error(`FAIL: ${message} — expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+}
+
+function run(command: string, cwd: string): void {
+  execSync(command, { cwd, stdio: ["ignore", "pipe", "pipe"] });
+}
+
+const repo = mkdtempSync(join(tmpdir(), "gsd-dispatch-guard-"));
+try {
+  mkdirSync(join(repo, ".gsd", "milestones", "M002"), { recursive: true });
+  mkdirSync(join(repo, ".gsd", "milestones", "M003"), { recursive: true });
+
+  writeFileSync(join(repo, ".gsd", "milestones", "M002", "M002-ROADMAP.md"), [
+    "# M002: Previous",
+    "",
+    "## Slices",
+    "- [x] **S01: Done** `risk:low` `depends:[]`",
+    "- [ ] **S02: Pending** `risk:low` `depends:[S01]`",
+    "",
+  ].join("\n"));
+
+  writeFileSync(join(repo, ".gsd", "milestones", "M003", "M003-ROADMAP.md"), [
+    "# M003: Current",
+    "",
+    "## Slices",
+    "- [ ] **S01: First** `risk:low` `depends:[]`",
+    "- [ ] **S02: Second** `risk:low` `depends:[S01]`",
+    "",
+  ].join("\n"));
+
+  run("git init -b main", repo);
+  run("git config user.email test@example.com", repo);
+  run("git config user.name Test", repo);
+  run("git add .", repo);
+  run("git commit -m init", repo);
+
+  assertEq(
+    getPriorSliceCompletionBlocker(repo, "main", "plan-slice", "M003/S01"),
+    "Cannot dispatch plan-slice M003/S01: earlier slice M002/S02 is not complete on main.",
+    "blocks first slice of next milestone when prior milestone is incomplete on main",
+  );
+
+  writeFileSync(join(repo, ".gsd", "milestones", "M002", "M002-ROADMAP.md"), [
+    "# M002: Previous",
+    "",
+    "## Slices",
+    "- [x] **S01: Done** `risk:low` `depends:[]`",
+    "- [x] **S02: Done** `risk:low` `depends:[S01]`",
+    "",
+  ].join("\n"));
+  run("git add .", repo);
+  run("git commit -m complete-m002", repo);
+
+  assertEq(
+    getPriorSliceCompletionBlocker(repo, "main", "execute-task", "M003/S02/T01"),
+    "Cannot dispatch execute-task M003/S02/T01: earlier slice M003/S01 is not complete on main.",
+    "blocks later slice in same milestone when an earlier slice is incomplete on main",
+  );
+
+  writeFileSync(join(repo, ".gsd", "milestones", "M003", "M003-ROADMAP.md"), [
+    "# M003: Current",
+    "",
+    "## Slices",
+    "- [x] **S01: First** `risk:low` `depends:[]`",
+    "- [ ] **S02: Second** `risk:low` `depends:[S01]`",
+    "",
+  ].join("\n"));
+  run("git add .", repo);
+  run("git commit -m complete-m003-s01", repo);
+
+  assertEq(
+    getPriorSliceCompletionBlocker(repo, "main", "execute-task", "M003/S02/T01"),
+    null,
+    "allows dispatch when all earlier slices are complete on main",
+  );
+
+  assertEq(
+    getPriorSliceCompletionBlocker(repo, "main", "plan-milestone", "M003"),
+    null,
+    "does not affect non-slice dispatch types",
+  );
+} finally {
+  rmSync(repo, { recursive: true, force: true });
+}
+
+console.log(`Passed: ${passed}, Failed: ${failed}`);
+if (failed > 0) process.exit(1);

--- a/src/resources/extensions/gsd/tests/roadmap-slices.test.ts
+++ b/src/resources/extensions/gsd/tests/roadmap-slices.test.ts
@@ -1,0 +1,59 @@
+import { parseRoadmap } from "../files.ts";
+import { parseRoadmapSlices } from "../roadmap-slices.ts";
+
+let passed = 0;
+let failed = 0;
+
+function assert(condition: boolean, message: string): void {
+  if (condition) passed += 1;
+  else {
+    failed += 1;
+    console.error(`FAIL: ${message}`);
+  }
+}
+
+function assertEq<T>(actual: T, expected: T, message: string): void {
+  if (JSON.stringify(actual) === JSON.stringify(expected)) passed += 1;
+  else {
+    failed += 1;
+    console.error(`FAIL: ${message} — expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+  }
+}
+
+const content = `# M003: Current
+
+**Vision:** Build the thing.
+
+## Slices
+- [x] **S01: First Slice** \`risk:low\` \`depends:[]\`
+  > After this: First demo works.
+- [ ] **S02: Second Slice** \`risk:medium\` \`depends:[S01]\`
+- [x] **S03: Third Slice** \`depends:[S01, S02]\`
+  > After this: Third demo works.
+
+## Boundary Map
+### S01 → S02
+Produces:
+  foo.ts
+`;
+
+console.log("\n=== parseRoadmapSlices ===");
+const slices = parseRoadmapSlices(content);
+assertEq(slices.length, 3, "slice count");
+assertEq(slices[0]?.id, "S01", "first id");
+assertEq(slices[0]?.done, true, "first done");
+assertEq(slices[0]?.demo, "First demo works.", "first demo");
+assertEq(slices[1]?.depends, ["S01"], "second depends");
+assertEq(slices[1]?.risk, "medium", "second risk");
+assertEq(slices[2]?.risk, "low", "missing risk defaults to low");
+assertEq(slices[2]?.depends, ["S01", "S02"], "third depends");
+
+console.log("\n=== parseRoadmap integration ===");
+const roadmap = parseRoadmap(content);
+assertEq(roadmap.slices, slices, "parseRoadmap uses extracted slice parser");
+assertEq(roadmap.title, "M003: Current", "roadmap title preserved");
+assertEq(roadmap.vision, "Build the thing.", "roadmap vision preserved");
+assert(roadmap.boundaryMap.length === 1, "boundary map still parsed");
+
+console.log(`Passed: ${passed}, Failed: ${failed}`);
+if (failed > 0) process.exit(1);


### PR DESCRIPTION
## Summary
Add one hard guard in GSD auto-mode:

- before dispatching slice work, read roadmap state from the derived main branch
- if any earlier slice is still incomplete there, stop instead of dispatching the target slice

## Why
The thrash came from allowing later slice work to continue from stale branch state even though prior slice completion had not been serialized onto the main branch yet.

The real invariant is simple:

> do not dispatch work for a slice unless all earlier slices are complete on the main branch

## Implementation
- add a tiny helper in `src/resources/extensions/gsd/dispatch-guard.ts`
- keep `auto.ts` minimal: derive main branch, call helper before dispatch, stop on blocker
- extract roadmap slice parsing into `src/resources/extensions/gsd/roadmap-slices.ts`
- have both `files.ts` and `dispatch-guard.ts` use that shared parser logic

## Tests
Added:
- `src/resources/extensions/gsd/tests/dispatch-guard.test.ts`
- `src/resources/extensions/gsd/tests/roadmap-slices.test.ts`

Verified existing coverage still passes after the refactor:
- `src/resources/extensions/gsd/tests/parsers.test.ts` → 377 passed
- `src/resources/extensions/gsd/tests/migrate-writer.test.ts` → 79 passed

Verified new focused tests:
- `src/resources/extensions/gsd/tests/dispatch-guard.test.ts` → 4 passed
- `src/resources/extensions/gsd/tests/roadmap-slices.test.ts` → 12 passed

## Scope
This PR intentionally does **not** include the broader runtime/crash/state-reconciliation changes.
It is just the minimal main-based prior-slice completion guard, with the shared roadmap-slice parser extracted so the new guard does not duplicate parsing logic.