### PR TITLE
fix: bundle workspace deps for npm registry installs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,12 @@
     "": {
       "name": "gsd-pi",
       "version": "2.7.0",
+      "bundleDependencies": [
+        "@gsd/pi-agent-core",
+        "@gsd/pi-ai",
+        "@gsd/pi-coding-agent",
+        "@gsd/pi-tui"
+      ],
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [
@@ -14,6 +20,10 @@
       ],
       "dependencies": {
         "@clack/prompts": "^1.1.0",
+        "@gsd/pi-agent-core": "*",
+        "@gsd/pi-ai": "*",
+        "@gsd/pi-coding-agent": "*",
+        "@gsd/pi-tui": "*",
         "picocolors": "^1.1.1",
         "playwright": "^1.58.2"
       },
@@ -3550,6 +3560,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -53,9 +53,19 @@
   },
   "dependencies": {
     "@clack/prompts": "^1.1.0",
+    "@gsd/pi-agent-core": "*",
+    "@gsd/pi-ai": "*",
+    "@gsd/pi-coding-agent": "*",
+    "@gsd/pi-tui": "*",
     "picocolors": "^1.1.1",
     "playwright": "^1.58.2"
   },
+  "bundleDependencies": [
+    "@gsd/pi-agent-core",
+    "@gsd/pi-ai",
+    "@gsd/pi-coding-agent",
+    "@gsd/pi-tui"
+  ],
   "devDependencies": {
     "@types/node": "^22.0.0",
     "typescript": "^5.4.0"


### PR DESCRIPTION
## Summary

- `npm install -g gsd-pi` fails with `ERR_MODULE_NOT_FOUND: Cannot find package '@gsd/pi-coding-agent'` because workspace packages are shipped in the tarball (via `files: ["packages"]`) but npm doesn't recreate workspace symlinks when installing from the registry
- Adds workspace packages (`@gsd/pi-agent-core`, `@gsd/pi-ai`, `@gsd/pi-coding-agent`, `@gsd/pi-tui`) to both `dependencies` and `bundleDependencies` so npm correctly places them in `node_modules/@gsd/` within the tarball

## Reproduction

```
npm install -g gsd-pi
gsd --version
# → ERR_MODULE_NOT_FOUND: Cannot find package '@gsd/pi-coding-agent'
```

## Test plan

- [ ] `npm pack` produces tarball with `node_modules/@gsd/*` packages included
- [ ] `npm install -g ./gsd-pi-*.tgz` resolves `@gsd/pi-coding-agent` without error
- [ ] `gsd --version` runs successfully after install

🤖 Generated with [Claude Code](https://claude.com/claude-code)