### PR TITLE
fix: ask_user_questions notes silently discard pasted content >1000 chars

### DIFF
--- a/src/resources/extensions/shared/interview-ui.ts
+++ b/src/resources/extensions/shared/interview-ui.ts
@@ -235,7 +235,7 @@ export async function showInterviewRound(
 		}
 
 		function saveEditorToState() {
-			states[currentIdx].notes = getEditor().getText().trim();
+			states[currentIdx].notes = getEditor().getExpandedText().trim();
 		}
 
 		function loadStateToEditor() {


### PR DESCRIPTION
Fixes #152

## Problem

`ask_user_questions` notes silently replace user input with paste markers when content exceeds 1000 characters or 10 lines. The LLM receives `user_note: [paste #1 2033 chars]` instead of the actual text — **all user depth is lost**.

The Editor component in `pi-tui` stores large pastes as compact markers (e.g. `[paste #1 2033 chars]`) for display, keeping actual content in an internal map. Two retrieval methods exist:

- `getText()` — returns text **with** paste markers (for display)
- `getExpandedText()` — returns text with markers **expanded** to actual content (for submission)

`interview-ui.ts` `saveEditorToState()` (line 238) calls `getText()` instead of `getExpandedText()`.

### How it surfaces

This affects anyone using the notes field (Tab) in `ask_user_questions` with substantial input:

- **Voice transcripts** — dictating responses naturally produces 500–2000+ characters, easily exceeding the 1000-char paste-marker threshold
- **Detailed explanations** — enriching option selections with context, nuance, or corrections
- **Paste from external editor** — copying in a prepared response

The agent sees a marker string where user input should be. Every enrichment above the threshold is silently destroyed.

## Fix

One-line change in `src/resources/extensions/shared/interview-ui.ts` line 238:

```diff
- states[currentIdx].notes = getEditor().getText().trim();
+ states[currentIdx].notes = getEditor().getExpandedText().trim();
```

`getExpandedText()` already exists on the Editor class for exactly this purpose — it expands paste markers back to their stored content. It was just not being called in this code path.

## Testing

Verified with 3 tests (`src/tests/interview-paste-fix.test.ts` on the fork):

1. **Source-level assertion** — confirms `saveEditorToState()` calls `getExpandedText()`, not `getText()`. Also verifies the inverse: test **fails** when `getText()` is used (regression-tested both directions).
2. **Expansion algorithm verification** — replicates the Editor's paste expansion logic: a 1500-char paste stored as `[paste #1 1500 chars]` marker is correctly expanded back to the original content.
3. **Threshold verification** — confirms the >1000 char / >10 line threshold that triggers paste marker creation.

Additionally verified:
- `saveEditorToState()` is the **only** write path to `states[].notes` — the fix covers all `ask_user_questions` notes across every question type
- `tsc --noEmit` passes clean — `getExpandedText()` is properly typed on the Editor class
- No behavioral change for notes under the threshold — `getExpandedText()` returns identical output to `getText()` when no paste markers exist

## Scope

- 1 file changed, 1 line
- Zero risk of regression — `getExpandedText()` is a strict superset of `getText()` (identical when no pastes exist)