### PR TITLE
fix: use getExpandedText() to preserve large paste content in notes

### DIFF
--- a/src/resources/extensions/shared/interview-ui.ts
+++ b/src/resources/extensions/shared/interview-ui.ts
@@ -235,7 +235,7 @@ export async function showInterviewRound(
 		}
 
 		function saveEditorToState() {
-			states[currentIdx].notes = getEditor().getText().trim();
+			states[currentIdx].notes = getEditor().getExpandedText().trim();
 		}
 
 		function loadStateToEditor() {


### PR DESCRIPTION
## Summary

Fixes #152

## Problem

`ask_user_questions` notes silently replace user input with paste markers when content exceeds 1000 characters or 10 lines. The LLM receives `user_note: [paste #1 2033 chars]` instead of the actual text — **all user depth is lost**.

## Fix

One-line change in `src/resources/extensions/shared/interview-ui.ts` line 238:

```diff
- states[currentIdx].notes = getEditor().getText().trim();
+ states[currentIdx].notes = getEditor().getExpandedText().trim();
```

`getExpandedText()` already exists on the Editor class for exactly this purpose — it expands paste markers back to their stored content. It was just not being called in this code path.

## Scope

- 1 file changed, 1 line
- Zero risk of regression — `getExpandedText()` is a strict superset of `getText()` (identical when no pastes exist)