### PR TITLE
fix: alias @mariozechner/* imports to @gsd/* for external PI ecosystem packages

### DIFF
--- a/packages/pi-coding-agent/src/core/extensions/loader.ts
+++ b/packages/pi-coding-agent/src/core/extensions/loader.ts
@@ -46,6 +46,12 @@ const VIRTUAL_MODULES: Record<string, unknown> = {
 	"@gsd/pi-ai": _bundledPiAi,
 	"@gsd/pi-ai/oauth": _bundledPiAiOauth,
 	"@gsd/pi-coding-agent": _bundledPiCodingAgent,
+	// Aliases for external PI ecosystem packages that import from the original scope
+	"@mariozechner/pi-agent-core": _bundledPiAgentCore,
+	"@mariozechner/pi-tui": _bundledPiTui,
+	"@mariozechner/pi-ai": _bundledPiAi,
+	"@mariozechner/pi-ai/oauth": _bundledPiAiOauth,
+	"@mariozechner/pi-coding-agent": _bundledPiCodingAgent,
 };
 
 const require = createRequire(import.meta.url);
@@ -80,6 +86,12 @@ function getAliases(): Record<string, string> {
 		"@gsd/pi-ai": resolveWorkspaceOrImport("ai/dist/index.js", "@gsd/pi-ai"),
 		"@gsd/pi-ai/oauth": resolveWorkspaceOrImport("ai/dist/oauth.js", "@gsd/pi-ai/oauth"),
 		"@sinclair/typebox": typeboxRoot,
+		// Aliases for external PI ecosystem packages that import from the original scope
+		"@mariozechner/pi-coding-agent": packageIndex,
+		"@mariozechner/pi-agent-core": resolveWorkspaceOrImport("agent/dist/index.js", "@gsd/pi-agent-core"),
+		"@mariozechner/pi-tui": resolveWorkspaceOrImport("tui/dist/index.js", "@gsd/pi-tui"),
+		"@mariozechner/pi-ai": resolveWorkspaceOrImport("ai/dist/index.js", "@gsd/pi-ai"),
+		"@mariozechner/pi-ai/oauth": resolveWorkspaceOrImport("ai/dist/oauth.js", "@gsd/pi-ai/oauth"),
 	};
 
 	return _aliases;


### PR DESCRIPTION
## Summary

- Adds `@mariozechner/*` → `@gsd/*` aliases in both jiti resolution paths (virtualModules for Bun binary, getAliases for Node.js) so external PI ecosystem packages resolve correctly
- External packages (pi-rtk, pi-context, pi-agent-browser, etc.) import from the original `@mariozechner/pi-*` scope which GSD forked to `@gsd/pi-*`

Closes #161

## Test plan

- [ ] External PI package importing `@mariozechner/pi-coding-agent` resolves via jiti alias
- [ ] Build succeeds (change is additive — string keys in existing Record objects)