### PR TITLE
fix: add fsevents as optional dep to fix install on Linux

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,9 @@
       },
       "engines": {
         "node": ">=20.6.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
       }
     },
     "node_modules/@anthropic-ai/sdk": {
@@ -3560,7 +3563,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -70,6 +70,9 @@
     "@types/node": "^22.0.0",
     "typescript": "^5.4.0"
   },
+  "optionalDependencies": {
+    "fsevents": "~2.3.2"
+  },
   "overrides": {
     "gaxios": "7.1.4"
   }


### PR DESCRIPTION
fsevents is a macOS-only native module that comes as a transitive optional dependency of playwright. On Linux, npm tries to build it via node-gyp which fails fatally, breaking 'npm install -g gsd-pi'.

Adding fsevents as an explicit optionalDependency at the root level ensures npm gracefully skips it on non-macOS platforms. This is the standard pattern used by vite, webpack, and chokidar.