### PR TITLE
fix: break research phase infinite loop and sync state on stop

### DIFF
--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -257,6 +257,11 @@ export async function stopAuto(ctx?: ExtensionContext, pi?: ExtensionAPI): Promi
     ctx?.ui.notify("Auto-mode stopped.", "info");
   }
 
+  // Sync disk state so next resume starts from accurate state
+  if (basePath) {
+    try { await rebuildState(basePath); } catch { /* non-fatal */ }
+  }
+
   resetMetrics();
   active = false;
   paused = false;
@@ -1181,7 +1186,7 @@ async function dispatchNextUnit(
 
       // Research before roadmap if no research exists
       const researchFile = resolveMilestoneFile(basePath, mid, "RESEARCH");
-      const hasResearch = !!(researchFile && await loadFile(researchFile));
+      const hasResearch = !!researchFile;
 
       if (!hasResearch) {
         unitType = "research-milestone";
@@ -1198,13 +1203,13 @@ async function dispatchNextUnit(
       const sid = state.activeSlice!.id;
       const sTitle = state.activeSlice!.title;
       const researchFile = resolveSliceFile(basePath, mid, sid, "RESEARCH");
-      const hasResearch = !!(researchFile && await loadFile(researchFile));
+      const hasResearch = !!researchFile;
 
       if (!hasResearch) {
         // Skip slice research for S01 when milestone research already exists —
         // the milestone research already covers the same ground for the first slice.
         const milestoneResearchFile = resolveMilestoneFile(basePath, mid, "RESEARCH");
-        const hasMilestoneResearch = !!(milestoneResearchFile && await loadFile(milestoneResearchFile));
+        const hasMilestoneResearch = !!milestoneResearchFile;
         if (hasMilestoneResearch && sid === "S01") {
           unitType = "plan-slice";
           unitId = `${mid}/${sid}`;


### PR DESCRIPTION
## Summary
- **Bug 1 (research loop):** `resolveMilestoneFile`/`resolveSliceFile` already verify file existence on disk via `readdirSync`. The additional `loadFile` content check created an infinite loop: empty research files passed `existsSync` (marking research complete) but failed `loadFile` (re-dispatching research). Removed the redundant `loadFile` check so file existence alone is authoritative.
- **Bug 2 (state sync on stop):** `stopAuto` now calls `rebuildState` before clearing in-memory state, matching `pauseAuto`'s pattern and preventing stale state on next resume.

Fixes #126

## Test plan
- [ ] Run auto mode through a milestone research phase; confirm it advances to planning after research completes (no loop)
- [ ] Create an empty research file on disk; confirm auto mode treats it as existing and skips re-dispatch
- [ ] Stop auto mode mid-run, then resume; confirm state is consistent with disk artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)