### PR TITLE
fix: execute-task stuck retry when summary exists but checkbox unmarked

### DIFF
--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -1312,6 +1312,26 @@ async function dispatchNextUnit(
   }
   unitDispatchCount.set(dispatchKey, prevCount + 1);
   if (prevCount > 0) {
+    // Self-repair: if summary exists but checkbox not marked, fix it and re-derive
+    if (unitType === "execute-task") {
+      const status = await inspectExecuteTaskDurability(basePath, unitId);
+      if (status?.summaryExists && !status.taskChecked) {
+        const [mid, sid, tid] = unitId.split("/");
+        if (mid && sid && tid) {
+          const repaired = skipExecuteTask(basePath, mid, sid, tid, status, "self-repair", 0);
+          if (repaired) {
+            ctx.ui.notify(
+              `Self-repaired ${unitId}: summary existed but checkbox was unmarked. Marked [x] and advancing.`,
+              "warning",
+            );
+            unitDispatchCount.delete(dispatchKey);
+            await new Promise(r => setImmediate(r));
+            await dispatchNextUnit(ctx, pi);
+            return;
+          }
+        }
+      }
+    }
     ctx.ui.notify(
       `${unitType} ${unitId} didn't produce expected artifact. Retrying (${prevCount + 1}/${MAX_UNIT_DISPATCHES}).`,
       "warning",
@@ -2771,6 +2791,23 @@ function verifyExpectedArtifact(unitType: string, unitId: string, base: string):
   const absPath = resolveExpectedArtifactPath(unitType, unitId, base);
   if (!absPath) return true;
   if (!existsSync(absPath)) return false;
+
+  // execute-task must also have its checkbox marked [x] in the slice plan
+  if (unitType === "execute-task") {
+    const parts = unitId.split("/");
+    const mid = parts[0];
+    const sid = parts[1];
+    const tid = parts[2];
+    if (mid && sid && tid) {
+      const planAbs = resolveSliceFile(base, mid, sid, "PLAN");
+      if (planAbs && existsSync(planAbs)) {
+        const planContent = readFileSync(planAbs, "utf-8");
+        const escapedTid = tid.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+        const re = new RegExp(`^- \\[[xX]\\] \\*\\*${escapedTid}:`, "m");
+        if (!re.test(planContent)) return false;
+      }
+    }
+  }
 
   // complete-slice must also produce a UAT file
   if (unitType === "complete-slice") {


### PR DESCRIPTION
## Summary
- `verifyExpectedArtifact` now checks both the task summary file AND the `[x]` checkbox in the slice plan for `execute-task` units, aligning it with how `deriveState` determines task completion
- At retry time (`prevCount > 0`), if the summary exists but the checkbox is unmarked, the dispatch logic self-repairs by marking the checkbox via `skipExecuteTask` and re-derives state instead of re-dispatching the same stuck unit
- Fixes the root cause where the agent writes a summary but omits the checkbox mark, causing an infinite retry loop that halts after `MAX_UNIT_DISPATCHES`

Closes #133

## Test plan
- [ ] Simulate a state where a task summary file exists but the checkbox in the slice plan is unchecked — verify `verifyExpectedArtifact` returns `false`
- [ ] Verify that on retry, the self-repair path triggers: checkbox gets marked `[x]`, dispatch count resets, and the next unit is dispatched
- [ ] Confirm normal flow (summary + checkbox both present) is unaffected
- [ ] Confirm normal retry flow (neither summary nor checkbox) still retries as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)