### PR TITLE
fix: auto-switch model after /login and /logout (#124)

### DIFF
--- a/packages/pi-coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/interactive-mode.ts
@@ -3695,6 +3695,21 @@ export class InteractiveMode {
 							this.session.modelRegistry.authStorage.logout(providerId);
 							this.session.modelRegistry.refresh();
 							await this.updateAvailableProviderCount();
+
+							// Auto-switch model if current model belongs to the logged-out provider
+							const currentModel = this.session.model;
+							if (currentModel?.provider === providerId) {
+								try {
+									const available = this.session.modelRegistry.getAvailable();
+									const fallback = available.find((m) => m.provider !== providerId);
+									if (fallback) {
+										await this.session.setModel(fallback);
+									}
+								} catch {
+									// Model switch failed — user can manually switch via /model
+								}
+							}
+
 							this.showStatus(`Logged out of ${providerName}`);
 						} catch (error: unknown) {
 							this.showError(`Logout failed: ${error instanceof Error ? error.message : String(error)}`);
@@ -3789,6 +3804,26 @@ export class InteractiveMode {
 			restoreEditor();
 			this.session.modelRegistry.refresh();
 			await this.updateAvailableProviderCount();
+
+			// Auto-switch model if current model has no valid API key
+			try {
+				const currentModel = this.session.model;
+				if (currentModel) {
+					const currentKey = await this.session.modelRegistry.getApiKey(currentModel);
+					if (!currentKey) {
+						const available = this.session.modelRegistry.getAvailable();
+						const newProviderModel = available.find((m) => m.provider === providerId);
+						if (newProviderModel) {
+							await this.session.setModel(newProviderModel);
+						} else if (available.length > 0) {
+							await this.session.setModel(available[0]);
+						}
+					}
+				}
+			} catch (error: unknown) {
+				// Model switch failed — user can manually switch via /model
+			}
+
 			this.showStatus(`Logged in to ${providerName}. Credentials saved to ${getAuthPath()}`);
 		} catch (error: unknown) {
 			restoreEditor();


### PR DESCRIPTION
## Summary
- After `/login`, checks if the current model has a valid API key. If not, auto-switches to a model from the newly authenticated provider (fixes the "No API key found" error when using Codex after login).
- After `/logout`, checks if the current model belongs to the logged-out provider. If so, auto-switches to a fallback model from a different provider.
- Both operations are wrapped in try/catch so failures degrade gracefully (user can still manually switch via `/model`).

Closes #124

## Test plan
- [ ] Log in with Codex while an Anthropic model is selected — verify model auto-switches to a Codex model
- [ ] Log out of Codex while a Codex model is selected — verify model auto-switches to an Anthropic model
- [ ] Log in with a provider when current model already has a valid key — verify no model switch occurs

🤖 Generated with [Claude Code](https://claude.com/claude-code)