### PR TITLE
fix: pause auto-mode on provider errors to prevent reassess-roadmap loop

### DIFF
--- a/src/resources/extensions/gsd/index.ts
+++ b/src/resources/extensions/gsd/index.ts
@@ -325,11 +325,21 @@ export default function (pi: ExtensionAPI) {
     // If auto-mode is already running, advance to next unit
     if (!isAutoActive()) return;
 
-    // If the agent was aborted (user pressed Escape), pause auto-mode
-    // instead of advancing. This preserves the conversation so the user
-    // can inspect what happened, interact with the agent, or resume.
+    // If the agent was aborted (user pressed Escape) or hit a provider
+    // error (fetch failure, rate limit, etc.), pause auto-mode instead of
+    // advancing. This preserves the conversation so the user can inspect
+    // what happened, interact with the agent, or resume.
     const lastMsg = event.messages[event.messages.length - 1];
     if (lastMsg && "stopReason" in lastMsg && lastMsg.stopReason === "aborted") {
+      await pauseAuto(ctx, pi);
+      return;
+    }
+    if (lastMsg && "stopReason" in lastMsg && lastMsg.stopReason === "error") {
+      const errorDetail =
+        "errorMessage" in lastMsg && lastMsg.errorMessage
+          ? `: ${lastMsg.errorMessage}`
+          : "";
+      ctx.log(`Auto-mode paused due to provider error${errorDetail}`);
       await pauseAuto(ctx, pi);
       return;
     }


### PR DESCRIPTION
## Summary
- Fixes #95: state machine getting stuck in a reassess-roadmap loop when a provider returns fetch errors
- The `agent_end` hook now checks for `stopReason === "error"` in addition to `"aborted"`, pausing auto-mode and logging the error detail so the user sees what went wrong instead of silently looping

## Root cause
The `agent_end` hook only handled `stopReason === "aborted"` (user pressing Escape). When a provider fetch failed with `stopReason === "error"`, the hook fell through to `handleAgentEnd()`, which proceeded as if the dispatch succeeded. State derivation then found the artifact still missing and re-dispatched, creating a loop until stuck detection fired.

## Test plan
- [ ] Simulate a provider fetch error (e.g., invalid API key or network block) during auto-mode and verify auto-mode pauses with an error message instead of looping
- [ ] Verify normal auto-mode advancement still works when agent ends successfully
- [ ] Verify Escape (abort) still pauses auto-mode as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)