### PR TITLE
fix: show TAB hint for notes input in discuss-mode survey (#192)

### DIFF
--- a/src/resources/extensions/shared/interview-ui.ts
+++ b/src/resources/extensions/shared/interview-ui.ts
@@ -105,7 +105,7 @@ export interface WrapUpOptions {
 // ─── Constants ────────────────────────────────────────────────────────────────
 
 const OTHER_OPTION_LABEL = "None of the above";
-const OTHER_OPTION_DESCRIPTION = "Optionally, add details in notes below.";
+const OTHER_OPTION_DESCRIPTION = "Press TAB to add optional notes.";
 
 // ─── Wrap-up screen ───────────────────────────────────────────────────────────
 
@@ -593,7 +593,7 @@ export async function showInterviewRound(
 				hints.push("tab to add notes");
 				hints.push(isLast && allAnswered() ? "enter to review" : "enter to next");
 			} else {
-				if (st.committedIndex !== null || !isMultiQuestion) hints.push("tab to add notes");
+				hints.push("tab to add notes");
 				if (isMultiQuestion) hints.push("←/→ navigate");
 				hints.push(isLast && allAnswered() ? "enter to review" : "enter to next");
 			}


### PR DESCRIPTION
## Summary
- Updated `OTHER_OPTION_DESCRIPTION` from "Optionally, add details in notes below." to "Press TAB to add optional notes." so users know how to reveal the hidden notes input.
- Made the footer "tab to add notes" hint always visible in single-select mode (was previously gated on `committedIndex !== null`).

Fixes #192

## Test plan
- [ ] Open a discuss-mode survey with single-select questions — verify "tab to add notes" appears in footer hints immediately (not only after selecting an option)
- [ ] Select "None of the above" — verify description reads "Press TAB to add optional notes."
- [ ] Press TAB — verify notes input appears and hint changes to "tab or esc to close notes"

🤖 Generated with [Claude Code](https://claude.com/claude-code)