### PR TITLE
fix: untrack runtime files from slice branch before squash-merge (#218)

### DIFF
--- a/src/resources/extensions/gsd/git-service.ts
+++ b/src/resources/extensions/gsd/git-service.ts
@@ -649,6 +649,18 @@ export class GitServiceImpl {
       this.git(["commit", "-m", "chore: untrack .gsd/ runtime files before merge"], { allowFailure: true });
     }
 
+    // Also untrack runtime files from the slice branch to prevent
+    // modify/delete conflicts during squash-merge (#218)
+    this.git(["checkout", branch]);
+    for (const exclusion of RUNTIME_EXCLUSION_PATHS) {
+      this.git(["rm", "--cached", "-r", "--ignore-unmatch", exclusion], { allowFailure: true });
+    }
+    const branchUntrackDiff = this.git(["diff", "--cached", "--stat"], { allowFailure: true });
+    if (branchUntrackDiff?.trim()) {
+      this.git(["commit", "-m", "chore: untrack .gsd/ runtime files before merge"], { allowFailure: true });
+    }
+    this.git(["checkout", mainBranch]);
+
     // Merge slice branch — strategy is configurable via git.merge_strategy
     // preference. Default: "squash" (preserves existing behavior).
     // "merge" uses --no-ff which is more resilient to conflicts from
@@ -671,7 +683,7 @@ export class GitServiceImpl {
         if (allRuntime) {
           // Runtime-only conflicts: take ours and remove from index
           for (const f of conflictedFiles) {
-            this.git(["checkout", "--ours", "--", f], { allowFailure: true });
+            this.git(["checkout", "--theirs", "--", f], { allowFailure: true });
             this.git(["rm", "--cached", "--ignore-unmatch", f], { allowFailure: true });
           }
           this.git(["add", "-A"], { allowFailure: true });


### PR DESCRIPTION
## Summary
- Untrack `.gsd/` runtime files from the **slice branch** before squash-merge, preventing modify/delete conflicts in `metrics.json` and `completed-units.json`
- Switch runtime conflict auto-resolution fallback from `--ours` to `--theirs` for semantic correctness
- Existing safety nets (main-branch untrack, runtime conflict auto-resolution) are preserved

## Root Cause
The pre-merge untrack block only ran on main. When squash-merging, git sees the slice branch still tracking runtime files that main has untracked, causing modify/delete conflicts.

## Test plan
- [ ] Verify existing GSD tests still pass (all 44 test files currently fail with pre-existing `defaults.json` build artifact issue unrelated to this change)
- [ ] Manual test: create a slice branch where `.gsd/metrics.json` gets committed, complete the slice, confirm squash-merge succeeds without conflict

Closes #218

🤖 Generated with [Claude Code](https://claude.com/claude-code)