### PR TITLE
fix: separate access/unlink error handling in delete path

### DIFF
--- a/packages/pi-coding-agent/src/core/tools/hashline-edit.ts
+++ b/packages/pi-coding-agent/src/core/tools/hashline-edit.ts
@@ -177,15 +177,18 @@ export function createHashlineEditTool(cwd: string, options?: HashlineEditToolOp
 					try {
 						// Handle delete
 						if (deleteFile) {
+							let fileExists = true;
 							try {
 								await ops.access(absolutePath);
-								await ops.unlink(absolutePath);
 							} catch {
-								// File doesn't exist, that's fine for delete
+								fileExists = false;
+							}
+							if (fileExists) {
+								await ops.unlink(absolutePath);
 							}
 							if (signal) signal.removeEventListener("abort", onAbort);
 							resolve({
-								content: [{ type: "text", text: `Deleted ${path}` }],
+								content: [{ type: "text", text: fileExists ? `Deleted ${path}` : `File not found, nothing to delete: ${path}` }],
 								details: { diff: "" },
 							});
 							return;


### PR DESCRIPTION
## Summary
- Partial fix for #219 (item 1)
- Separates the `access()` and `unlink()` error handling in the delete operation of `hashline-edit.ts`
- `access()` failure now correctly reports "File not found, nothing to delete" instead of silently reporting "Deleted"
- `unlink()` failures now propagate to the caller via the outer catch/reject instead of being silently swallowed

## Test plan
- [ ] Attempt to delete a file without write permissions — should surface an error instead of falsely reporting "Deleted"
- [ ] Delete a non-existent file — should report "File not found, nothing to delete"
- [ ] Delete an existing file normally — should work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)