### PR TITLE
fix: prevent move from silently overwriting files

### DIFF
--- a/packages/pi-coding-agent/src/core/tools/hashline-edit.ts
+++ b/packages/pi-coding-agent/src/core/tools/hashline-edit.ts
@@ -256,6 +256,20 @@ export function createHashlineEditTool(cwd: string, options?: HashlineEditToolOp
 						// Write result
 						const finalContent = bom + restoreLineEndings(result.lines, originalEnding);
 						const writePath = move ? resolveToCwd(move, cwd) : absolutePath;
+
+						// Prevent silent overwrite when moving to an existing file
+						if (move && writePath !== absolutePath) {
+							try {
+								await ops.access(writePath);
+								// If access succeeds, the file exists — refuse the move
+								throw new Error(`Destination file already exists: ${writePath}. Use a different path or delete the existing file first.`);
+							} catch (err: any) {
+								// Re-throw our own error; swallow only "file not found"
+								if (err.message?.startsWith("Destination file already exists:")) throw err;
+								// File doesn't exist — safe to proceed
+							}
+						}
+
 						await ops.writeFile(writePath, finalContent);
 
 						// If moved, delete original


### PR DESCRIPTION
## Summary
- Adds an existence check before the move/rename operation in `hashline-edit.ts`
- If the destination file already exists, the operation now returns an error instead of silently overwriting it
- Partial fix for #219 (item 2)

## Test plan
- [ ] Move a file to a path that does not exist — should succeed as before
- [ ] Move a file to a path that already exists — should return error: "Destination file already exists: ..."
- [ ] Move a file to itself (same resolved path) — should behave as a normal edit (no move check triggered)

🤖 Generated with [Claude Code](https://claude.com/claude-code)