### PR TITLE
fix: copy lsp defaults.json to dist during build

### DIFF
--- a/packages/pi-coding-agent/package.json
+++ b/packages/pi-coding-agent/package.json
@@ -21,7 +21,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json && npm run copy-assets",
-    "copy-assets": "node -e \"const{mkdirSync,cpSync}=require('fs');mkdirSync('dist/modes/interactive/theme',{recursive:true});cpSync('src/modes/interactive/theme','dist/modes/interactive/theme',{recursive:true,filter:(s)=>!s.endsWith('.ts')});mkdirSync('dist/core/export-html/vendor',{recursive:true});cpSync('src/core/export-html/template.html','dist/core/export-html/template.html');cpSync('src/core/export-html/template.css','dist/core/export-html/template.css');cpSync('src/core/export-html/template.js','dist/core/export-html/template.js');cpSync('src/core/export-html/vendor','dist/core/export-html/vendor',{recursive:true,filter:(s)=>!s.endsWith('.ts')})\""
+    "copy-assets": "node -e \"const{mkdirSync,cpSync}=require('fs');mkdirSync('dist/modes/interactive/theme',{recursive:true});cpSync('src/modes/interactive/theme','dist/modes/interactive/theme',{recursive:true,filter:(s)=>!s.endsWith('.ts')});mkdirSync('dist/core/export-html/vendor',{recursive:true});cpSync('src/core/export-html/template.html','dist/core/export-html/template.html');cpSync('src/core/export-html/template.css','dist/core/export-html/template.css');cpSync('src/core/export-html/template.js','dist/core/export-html/template.js');cpSync('src/core/export-html/vendor','dist/core/export-html/vendor',{recursive:true,filter:(s)=>!s.endsWith('.ts')});mkdirSync('dist/core/lsp',{recursive:true});cpSync('src/core/lsp/defaults.json','dist/core/lsp/defaults.json')\""
   },
   "dependencies": {
     "@gsd/pi-agent-core": "*",


### PR DESCRIPTION
## Summary
- Adds `cpSync` call to the `copy-assets` script in `packages/pi-coding-agent/package.json` to copy `src/core/lsp/defaults.json` to `dist/core/lsp/defaults.json`
- Fixes runtime `MODULE_NOT_FOUND` crash when `dist/core/lsp/config.js` requires `./defaults.json`

Closes #221

## Test plan
- [x] Ran `npm run copy-assets` — `dist/core/lsp/defaults.json` now exists after build

🤖 Generated with [Claude Code](https://claude.com/claude-code)