### PR TITLE
feat: add role-based model routing system

### DIFF
--- a/packages/pi-coding-agent/src/cli/args.ts
+++ b/packages/pi-coding-agent/src/cli/args.ts
@@ -16,6 +16,9 @@ export interface Args {
 	systemPrompt?: string;
 	appendSystemPrompt?: string;
 	thinking?: ThinkingLevel;
+	smol?: string;
+	slow?: string;
+	plan?: string;
 	continue?: boolean;
 	resume?: boolean;
 	help?: boolean;
@@ -108,6 +111,12 @@ export function parseArgs(args: string[], extensionFlags?: Map<string, { type: "
 				}
 			}
 			result.tools = validTools;
+		} else if (arg === "--smol" && i + 1 < args.length) {
+			result.smol = args[++i];
+		} else if (arg === "--slow" && i + 1 < args.length) {
+			result.slow = args[++i];
+		} else if (arg === "--plan" && i + 1 < args.length) {
+			result.plan = args[++i];
 		} else if (arg === "--thinking" && i + 1 < args.length) {
 			const level = args[++i];
 			if (isValidThinkingLevel(level)) {
@@ -208,6 +217,9 @@ ${chalk.bold("Options:")}
   --no-tools                     Disable all built-in tools
   --tools <tools>                Comma-separated list of tools to enable (default: read,bash,edit,write)
                                  Available: read, bash, edit, write, grep, find, ls
+  --smol <pattern>               Override the "smol" model role (fast/cheap model)
+  --slow <pattern>               Override the "slow" model role (large reasoning model)
+  --plan <pattern>               Override the "plan" model role (planning model)
   --thinking <level>             Set thinking level: off, minimal, low, medium, high, xhigh
   --extension, -e <path>         Load an extension file (can be used multiple times)
   --no-extensions, -ne           Disable extension discovery (explicit -e paths still work)

--- a/packages/pi-coding-agent/src/core/model-resolver.ts
+++ b/packages/pi-coding-agent/src/core/model-resolver.ts
@@ -9,6 +9,8 @@ import { minimatch } from "minimatch";
 import { isValidThinkingLevel } from "../cli/args.js";
 import { DEFAULT_THINKING_LEVEL } from "./defaults.js";
 import type { ModelRegistry } from "./model-registry.js";
+import { type ModelRole, extractRoleFromAlias, isRoleAlias } from "./model-roles.js";
+import type { SettingsManager } from "./settings-manager.js";
 
 /** Default model IDs for each known provider */
 export const defaultModelPerProvider: Record<KnownProvider, string> = {
@@ -591,4 +593,154 @@ export async function restoreModelFromSession(
 
 	// No models available
 	return { model: undefined, fallbackMessage: undefined };
+}
+
+// ---------------------------------------------------------------------------
+// Model Role Resolution
+// ---------------------------------------------------------------------------
+
+export interface ResolvedRoleModel {
+	model: Model<Api>;
+	thinkingLevel?: ThinkingLevel;
+}
+
+/**
+ * Expand a role alias (e.g., "pi/smol") to a concrete model value.
+ * Returns the configured model string for the role, or undefined if no mapping exists.
+ */
+export function expandRoleAlias(value: string, settings: SettingsManager): string | undefined {
+	const role = extractRoleFromAlias(value);
+	if (!role) return undefined;
+	return settings.getModelRole(role);
+}
+
+/** Fallback patterns for auto-discovering models by role when no explicit mapping is configured. */
+const PRIORITY_CHAINS: Record<string, string[]> = {
+	smol: ["haiku-4-5", "haiku", "flash", "mini"],
+	slow: ["opus-4.6", "gpt-5.4", "pro"],
+};
+
+/**
+ * Find a model matching one of the fuzzy priority patterns for a role.
+ * Patterns are matched as substrings against available model IDs (case-insensitive).
+ */
+function findModelByPriorityChain(
+	role: "smol" | "slow",
+	availableModels: Model<Api>[],
+): Model<Api> | undefined {
+	const patterns = PRIORITY_CHAINS[role];
+	if (!patterns) return undefined;
+
+	for (const pattern of patterns) {
+		const lower = pattern.toLowerCase();
+		const match = availableModels.find((m) => m.id.toLowerCase().includes(lower));
+		if (match) return match;
+	}
+	return undefined;
+}
+
+/**
+ * Find the "smol" model from available models using priority chain fallback.
+ */
+export function findSmolModel(availableModels: Model<Api>[]): Model<Api> | undefined {
+	return findModelByPriorityChain("smol", availableModels);
+}
+
+/**
+ * Find the "slow" model from available models using priority chain fallback.
+ */
+export function findSlowModel(availableModels: Model<Api>[]): Model<Api> | undefined {
+	return findModelByPriorityChain("slow", availableModels);
+}
+
+/**
+ * Resolve a model role value to a concrete model.
+ *
+ * Resolution order:
+ * 1. If the value is a role alias ("pi/smol"), look up the role mapping in settings
+ * 2. Try to match the value (or resolved alias) against available models
+ * 3. For "smol" and "slow" roles with no explicit mapping, use priority chain fallback
+ *
+ * @param value - Model pattern, role alias ("pi/smol"), or concrete model ID
+ * @param settings - Settings manager for role lookups
+ * @param modelRegistry - Model registry for available models
+ * @returns Resolved model and optional thinking level, or undefined
+ */
+export function resolveModelRoleValue(
+	value: string,
+	settings: SettingsManager,
+	modelRegistry: ModelRegistry,
+): ResolvedRoleModel | undefined {
+	const availableModels = modelRegistry.getAvailable();
+
+	// Check if it's a role alias
+	let effectiveValue = value;
+	const role = extractRoleFromAlias(value);
+	if (role) {
+		const configured = settings.getModelRole(role);
+		if (configured) {
+			effectiveValue = configured;
+		} else {
+			// No explicit mapping — use fallback discovery for smol/slow
+			if (role === "smol") {
+				const model = findSmolModel(availableModels);
+				return model ? { model } : undefined;
+			}
+			if (role === "slow") {
+				const model = findSlowModel(availableModels);
+				return model ? { model } : undefined;
+			}
+			// For other roles without a mapping, fall back to default model
+			return undefined;
+		}
+	}
+
+	// Parse and resolve the effective value as a model pattern
+	const { model, thinkingLevel } = parseModelPattern(effectiveValue, availableModels);
+	if (model) {
+		return { model, thinkingLevel };
+	}
+
+	return undefined;
+}
+
+/**
+ * Resolve a model override for subagent spawning.
+ *
+ * Handles:
+ * - Role aliases ("pi/smol", "pi/slow")
+ * - Regular model patterns with optional thinking level ("sonnet:high")
+ * - Comma-separated lists (first match wins)
+ *
+ * @param patterns - Model pattern string or array
+ * @param settings - Settings manager for role lookups
+ * @param modelRegistry - Model registry for available models
+ * @returns Resolved model and optional thinking level, or undefined
+ */
+export function resolveModelOverride(
+	patterns: string | string[],
+	settings: SettingsManager,
+	modelRegistry: ModelRegistry,
+): ResolvedRoleModel | undefined {
+	const patternList = typeof patterns === "string" ? patterns.split(",").map((s) => s.trim()) : patterns;
+
+	for (const pattern of patternList) {
+		if (!pattern) continue;
+
+		// Try role alias resolution first
+		if (isRoleAlias(pattern)) {
+			const result = resolveModelRoleValue(pattern, settings, modelRegistry);
+			if (result) return result;
+			continue;
+		}
+
+		// Regular model pattern resolution
+		const availableModels = modelRegistry.getAvailable();
+		const { model, thinkingLevel } = parseModelPattern(pattern, availableModels);
+		if (model) {
+			return { model, thinkingLevel };
+		}
+	}
+
+	return undefined;
 }

--- a/packages/pi-coding-agent/src/core/model-roles.ts
+++ b/packages/pi-coding-agent/src/core/model-roles.ts
@@ -1,0 +1,65 @@
+/**
+ * Model role definitions for role-based model routing.
+ *
+ * Named roles (default, smol, slow, vision, plan, commit) map to specific models,
+ * allowing different subsystems to use appropriately-sized models.
+ */
+
+export type ModelRole = "default" | "smol" | "slow" | "vision" | "plan" | "commit";
+
+export const MODEL_ROLES: Record<ModelRole, { tag: string; displayName: string; description: string }> = {
+	default: {
+		tag: "default",
+		displayName: "Default",
+		description: "Primary model for general coding tasks",
+	},
+	smol: {
+		tag: "smol",
+		displayName: "Small",
+		description: "Fast, cheap model for simple tasks (titles, summaries, commit messages)",
+	},
+	slow: {
+		tag: "slow",
+		displayName: "Slow",
+		description: "Large reasoning model for complex analysis and planning",
+	},
+	vision: {
+		tag: "vision",
+		displayName: "Vision",
+		description: "Model with image understanding capabilities",
+	},
+	plan: {
+		tag: "plan",
+		displayName: "Plan",
+		description: "Model for planning and architectural decisions",
+	},
+	commit: {
+		tag: "commit",
+		displayName: "Commit",
+		description: "Model for generating commit messages and changelogs",
+	},
+};
+
+export const MODEL_ROLE_IDS: ModelRole[] = Object.keys(MODEL_ROLES) as ModelRole[];
+
+/** Check if a string is a valid model role */
+export function isModelRole(value: string): value is ModelRole {
+	return MODEL_ROLE_IDS.includes(value as ModelRole);
+}
+
+/** Role alias prefix used in model specifications (e.g., "pi/smol") */
+export const ROLE_ALIAS_PREFIX = "pi/";
+
+/** Check if a model value is a role alias (e.g., "pi/smol") */
+export function isRoleAlias(value: string): boolean {
+	if (!value.startsWith(ROLE_ALIAS_PREFIX)) return false;
+	const role = value.slice(ROLE_ALIAS_PREFIX.length);
+	return isModelRole(role);
+}
+
+/** Extract the role from a role alias (e.g., "pi/smol" -> "smol") */
+export function extractRoleFromAlias(value: string): ModelRole | undefined {
+	if (!value.startsWith(ROLE_ALIAS_PREFIX)) return undefined;
+	const role = value.slice(ROLE_ALIAS_PREFIX.length);
+	return isModelRole(role) ? role : undefined;
+}

--- a/packages/pi-coding-agent/src/core/settings-manager.ts
+++ b/packages/pi-coding-agent/src/core/settings-manager.ts
@@ -3,6 +3,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
 import { dirname, join } from "path";
 import lockfile from "proper-lockfile";
 import { CONFIG_DIR_NAME, getAgentDir } from "../config.js";
+import type { ModelRole } from "./model-roles.js";
 
 export interface CompactionSettings {
 	enabled?: boolean; // default: true
@@ -93,6 +94,7 @@ export interface Settings {
 	autocompleteMaxVisible?: number; // Max visible items in autocomplete dropdown (default: 5)
 	showHardwareCursor?: boolean; // Show terminal cursor while still positioning it for IME
 	markdown?: MarkdownSettings;
+	modelRoles?: Partial<Record<ModelRole, string>>;
 }
 
 /** Deep merge settings: project/overrides take precedence, nested objects merge recursively */
@@ -226,6 +228,7 @@ export class SettingsManager {
 	private globalSettings: Settings;
 	private projectSettings: Settings;
 	private settings: Settings;
+	private modelRoleOverrides: Partial<Record<ModelRole, string>> = {};
 	private modifiedFields = new Set<keyof Settings>(); // Track global fields modified during session
 	private modifiedNestedFields = new Map<keyof Settings, Set<string>>(); // Track global nested field modifications
 	private modifiedProjectFields = new Set<keyof Settings>(); // Track project fields modified during session
@@ -938,5 +941,34 @@ export class SettingsManager {
 
 	getCodeBlockIndent(): string {
 		return this.settings.markdown?.codeBlockIndent ?? "  ";
+	}
+
+	/** Get the model for a role. Checks: in-memory overrides -> settings.modelRoles -> undefined */
+	getModelRole(role: ModelRole): string | undefined {
+		return this.modelRoleOverrides[role] ?? this.settings.modelRoles?.[role];
+	}
+
+	/** Persist a model role mapping to settings.json */
+	setModelRole(role: ModelRole, value: string): void {
+		if (!this.globalSettings.modelRoles) {
+			this.globalSettings.modelRoles = {};
+		}
+		this.globalSettings.modelRoles[role] = value;
+		this.markModified("modelRoles", role);
+		this.save();
+	}
+
+	/** Apply in-memory-only model role overrides (e.g., from CLI flags). Not persisted. */
+	overrideModelRoles(overrides: Partial<Record<ModelRole, string>>): void {
+		for (const [role, value] of Object.entries(overrides)) {
+			if (value !== undefined) {
+				this.modelRoleOverrides[role as ModelRole] = value;
+			}
+		}
+	}
+
+	/** Get all configured model roles (merged: overrides + settings) */
+	getModelRoles(): Partial<Record<ModelRole, string>> {
+		return { ...this.settings.modelRoles, ...this.modelRoleOverrides };
 	}
 }

--- a/packages/pi-coding-agent/src/index.ts
+++ b/packages/pi-coding-agent/src/index.ts
@@ -144,6 +144,23 @@ export {
 export type { ReadonlyFooterDataProvider } from "./core/footer-data-provider.js";
 export { convertToLlm } from "./core/messages.js";
 export { ModelRegistry } from "./core/model-registry.js";
+// Model roles and role-based resolution
+export {
+	type ModelRole,
+	MODEL_ROLES,
+	MODEL_ROLE_IDS,
+	isModelRole,
+	isRoleAlias,
+	extractRoleFromAlias,
+} from "./core/model-roles.js";
+export {
+	expandRoleAlias,
+	findSmolModel,
+	findSlowModel,
+	resolveModelRoleValue,
+	resolveModelOverride,
+	type ResolvedRoleModel,
+} from "./core/model-resolver.js";
 export type {
 	PackageManager,
 	PathMetadata,

--- a/packages/pi-coding-agent/src/main.ts
+++ b/packages/pi-coding-agent/src/main.ts
@@ -605,6 +605,15 @@ export async function main(args: string[]) {
 	const authStorage = AuthStorage.create();
 	const modelRegistry = new ModelRegistry(authStorage, getModelsPath());
 
+	// Apply model role overrides from CLI flags (in-memory only, not persisted)
+	const roleOverrides: Record<string, string> = {};
+	if (firstPass.smol) roleOverrides.smol = firstPass.smol;
+	if (firstPass.slow) roleOverrides.slow = firstPass.slow;
+	if (firstPass.plan) roleOverrides.plan = firstPass.plan;
+	if (Object.keys(roleOverrides).length > 0) {
+		settingsManager.overrideModelRoles(roleOverrides);
+	}
+
 	const resourceLoader = new DefaultResourceLoader({
 		cwd,
 		agentDir,

--- a/src/resources/extensions/subagent/index.ts
+++ b/src/resources/extensions/subagent/index.ts
@@ -17,9 +17,16 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import type { AgentToolResult } from "@gsd/pi-agent-core";
-import type { Message } from "@gsd/pi-ai";
+import type { Api, Message, Model } from "@gsd/pi-ai";
 import { StringEnum } from "@gsd/pi-ai";
-import { type ExtensionAPI, getMarkdownTheme } from "@gsd/pi-coding-agent";
+import {
+	type ExtensionAPI,
+	getMarkdownTheme,
+	isRoleAlias,
+	extractRoleFromAlias,
+	findSmolModel,
+	findSlowModel,
+} from "@gsd/pi-coding-agent";
 import { Container, Markdown, Spacer, Text } from "@gsd/pi-tui";
 import { Type } from "@sinclair/typebox";
 import { type AgentConfig, type AgentScope, discoverAgents } from "./agents.js";
@@ -213,6 +220,31 @@ function writePromptToTempFile(agentName: string, prompt: string): { dir: string
 	const filePath = path.join(tmpDir, `prompt-${safeName}.md`);
 	fs.writeFileSync(filePath, prompt, { encoding: "utf-8", mode: 0o600 });
 	return { dir: tmpDir, filePath };
+}
+
+/**
+ * Resolve a "pi/<role>" model alias to a concrete model ID.
+ * Falls back to priority chain discovery for smol/slow roles.
+ */
+function resolveAgentModelAlias(modelValue: string | undefined, availableModels: Model<Api>[]): string | undefined {
+	if (!modelValue || !isRoleAlias(modelValue)) return modelValue;
+
+	const role = extractRoleFromAlias(modelValue);
+	if (!role) return modelValue;
+
+	let resolved: Model<Api> | undefined;
+	if (role === "smol") {
+		resolved = findSmolModel(availableModels);
+	} else if (role === "slow") {
+		resolved = findSlowModel(availableModels);
+	}
+
+	if (resolved) {
+		return `${resolved.provider}/${resolved.id}`;
+	}
+
+	// No suitable model found for this role — return undefined so the subprocess picks its own default
+	return undefined;
 }
 
 type OnUpdateCallback = (partial: AgentToolResult<SubagentDetails>) => void;
@@ -451,8 +483,14 @@ export default function (pi: ExtensionAPI) {
 		async execute(_toolCallId, params, signal, onUpdate, ctx) {
 			const agentScope: AgentScope = params.agentScope ?? "both";
 			const discovery = discoverAgents(ctx.cwd, agentScope);
-			const agents = discovery.agents;
 			const confirmProjectAgents = params.confirmProjectAgents ?? false;
+
+			// Resolve "pi/<role>" model aliases in agent configs to concrete model IDs
+			const availableModels = ctx.modelRegistry.getAvailable();
+			const agents: AgentConfig[] = discovery.agents.map((agent) => {
+				const resolvedModel = resolveAgentModelAlias(agent.model, availableModels);
+				return resolvedModel !== agent.model ? { ...agent, model: resolvedModel } : agent;
+			});
 
 			const hasChain = (params.chain?.length ?? 0) > 0;
 			const hasTasks = (params.tasks?.length ?? 0) > 0;


### PR DESCRIPTION
## Summary
- Adds a **Model Roles** system that maps named roles (`default`, `smol`, `slow`, `vision`, `plan`, `commit`) to specific models, enabling different subsystems to use appropriately-sized models
- Roles can be configured in `settings.json` via `modelRoles`, overridden per-session with `--smol`, `--slow`, `--plan` CLI flags, or referenced in subagent frontmatter as `pi/smol`
- Includes priority-chain fallback discovery (e.g., `smol` tries haiku -> flash -> mini across available models)

## Changes
- **New:** `packages/pi-coding-agent/src/core/model-roles.ts` — `ModelRole` type, `MODEL_ROLES` constants, `pi/` alias utilities
- **Modified:** `settings-manager.ts` — `modelRoles` setting with `getModelRole()`, `setModelRole()`, `overrideModelRoles()` methods
- **Modified:** `model-resolver.ts` — `expandRoleAlias()`, `resolveModelRoleValue()`, `resolveModelOverride()`, `findSmolModel()`/`findSlowModel()` with priority chain fallback
- **Modified:** `cli/args.ts` — `--smol <pattern>`, `--slow <pattern>`, `--plan <pattern>` CLI flags
- **Modified:** `main.ts` — Wires CLI role overrides to settings at startup
- **Modified:** `subagent/index.ts` — Resolves `pi/smol` aliases to concrete models at spawn time
- **Modified:** `index.ts` — Exports new model role APIs for extensions

## Test plan
- [ ] `npm run build` succeeds
- [ ] `npx tsc --noEmit` passes for both pi-coding-agent and extensions tsconfigs
- [ ] `--smol haiku` CLI flag resolves to a haiku model when available
- [ ] Subagent with `model: "pi/smol"` in frontmatter resolves to a small model
- [ ] `settings.json` with `"modelRoles": { "smol": "anthropic/claude-haiku-4-5" }` is respected
- [ ] Existing model selection (defaultProvider/defaultModel) continues working unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)