### PR TITLE
fix(native): load and package native addon correctly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ tmp/
 # ── Workspace packages ──
 packages/*/dist/
 packages/*/node_modules/
+packages/native/addon/*.node
 
 # ── GSD baseline (auto-generated) ──
 dist/

--- a/native/scripts/build.js
+++ b/native/scripts/build.js
@@ -21,6 +21,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const nativeRoot = path.resolve(__dirname, "..");
 const engineDir = path.join(nativeRoot, "crates", "engine");
 const addonDir = path.join(nativeRoot, "addon");
+const packageAddonDir = path.resolve(nativeRoot, "..", "packages", "native", "addon");
 
 const isDev = process.argv.includes("--dev");
 const profile = isDev ? "debug" : "release";
@@ -66,12 +67,18 @@ if (!fs.existsSync(sourcePath)) {
 }
 
 fs.mkdirSync(addonDir, { recursive: true });
+fs.mkdirSync(packageAddonDir, { recursive: true });
 
 const destFilename = isDev
   ? "gsd_engine.dev.node"
   : `gsd_engine.${platformTag}.node`;
-const destPath = path.join(addonDir, destFilename);
+const destPaths = [
+  path.join(addonDir, destFilename),
+  path.join(packageAddonDir, destFilename),
+];
 
-fs.copyFileSync(sourcePath, destPath);
-console.log(`Installed: ${destPath}`);
+for (const destPath of destPaths) {
+  fs.copyFileSync(sourcePath, destPath);
+  console.log(`Installed: ${destPath}`);
+}
 console.log("Build complete.");

--- a/packages/native/package.json
+++ b/packages/native/package.json
@@ -54,7 +54,8 @@
     }
   },
   "files": [
-    "dist"
+    "dist",
+    "addon"
   ],
   "license": "MIT"
 }

--- a/packages/native/src/native.ts
+++ b/packages/native/src/native.ts
@@ -12,13 +12,19 @@ import { fileURLToPath } from "node:url";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const require = createRequire(import.meta.url);
 
-const addonDir = path.resolve(__dirname, "..", "..", "..", "native", "addon");
 const platformTag = `${process.platform}-${process.arch}`;
 
-const candidates = [
+const addonDirs = [
+  // Published package layout: @gsd/native/addon
+  path.resolve(__dirname, "..", "addon"),
+  // Monorepo layout during local development
+  path.resolve(__dirname, "..", "..", "..", "native", "addon"),
+];
+
+const candidates = addonDirs.flatMap((addonDir) => [
   path.join(addonDir, `gsd_engine.${platformTag}.node`),
   path.join(addonDir, "gsd_engine.dev.node"),
-];
+]);
 
 function loadNative(): Record<string, unknown> {
   const errors: string[] = [];


### PR DESCRIPTION
Fixes Linux startup failure where gsd crashes with:
Error: Failed to load gsd_engine native addon for linux-x64 (Cannot find module gsd_engine.linux-x64.node).
Closes #251 