### PR TITLE
ci: cache native Rust builds per platform

### DIFF
--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -49,6 +49,13 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
+      - name: Cache Rust build artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: native-${{ matrix.platform }}
+          workspaces: |
+            native -> target
+
       - name: Install cross-compilation tools (Linux ARM64)
         if: matrix.cross
         run: |


### PR DESCRIPTION
## Summary
Add explicit per-platform Rust build caching to the native binary workflow.

## Changes
- add `Swatinem/rust-cache@v2` to `.github/workflows/build-native.yml`
- use an explicit platform-scoped cache key:
  - `shared-key: native-${{ matrix.platform }}`
- scope workspace target caching to the native workspace:
  - `workspaces: |
      native -> target`

## Why
The expensive part of this workflow is the repeated Rust/Cargo build for each target in the native matrix. This cache makes reuse explicit per platform while keeping caches isolated across the matrix.

## Scope
This PR only changes the GitHub Actions workflow cache behavior. No product/runtime code changes.