### PR TITLE
fix: auto-resolve .gsd/ planning artifact conflicts during slice merge

### DIFF
--- a/src/resources/extensions/gsd/git-service.ts
+++ b/src/resources/extensions/gsd/git-service.ts
@@ -673,10 +673,11 @@ export class GitServiceImpl {
     try {
       this.git(mergeArgs);
     } catch (mergeError) {
-      // Check if conflicts are limited to runtime files we can auto-resolve (#189)
+      // Check if conflicts can be auto-resolved (#189, #218)
       const conflicted = this.git(["diff", "--name-only", "--diff-filter=U"], { allowFailure: true });
       if (conflicted) {
         const conflictedFiles = conflicted.split("\n").filter(Boolean);
+        const allGsd = conflictedFiles.every(f => f.startsWith(".gsd/"));
         const allRuntime = conflictedFiles.every(f =>
           RUNTIME_EXCLUSION_PATHS.some(excl => f.startsWith(excl.replace(/\/$/, ""))),
         );
@@ -688,12 +689,21 @@ export class GitServiceImpl {
           }
           this.git(["add", "-A"], { allowFailure: true });
           // Don't throw — let the merge proceed
+        } else if (allGsd) {
+          // Non-runtime .gsd/ conflicts (DECISIONS.md, REQUIREMENTS.md, ROADMAP.md, etc.):
+          // The slice branch has the authoritative .gsd/ state since the LLM just finished
+          // updating these artifacts during complete-slice. Take theirs (the slice branch).
+          for (const f of conflictedFiles) {
+            this.git(["checkout", "--theirs", "--", f], { allowFailure: true });
+          }
+          this.git(["add", "-A"], { allowFailure: true });
+          // Don't throw — let the merge proceed
         } else {
-          // Non-runtime conflicts: reset and throw as before
+          // Non-.gsd/ conflicts: reset and throw as before
           this.git(["reset", "--hard", "HEAD"], { allowFailure: true });
           const msg = mergeError instanceof Error ? mergeError.message : String(mergeError);
           throw new Error(
-            `${strategy === "merge" ? "Merge" : "Squash-merge"} of "${branch}" into "${mainBranch}" failed with conflicts. ` +
+            `${strategy === "merge" ? "Merge" : "Squash-merge"} of "${branch}" into "${mainBranch}" failed with conflicts in non-.gsd/ files. ` +
             `Working tree has been reset to a clean state. ` +
             `Resolve manually: git checkout ${mainBranch} && git merge ${strategy === "merge" ? "--no-ff" : "--squash"} ${branch}\n` +
             `Original error: ${msg}`,

--- a/src/resources/extensions/gsd/tests/git-service.test.ts
+++ b/src/resources/extensions/gsd/tests/git-service.test.ts
@@ -953,6 +953,42 @@ async function main(): Promise<void> {
     rmSync(repo, { recursive: true, force: true });
   }
 
+  // ─── mergeSliceToMain: auto-resolve .gsd/ planning artifact conflicts ──
+
+  console.log("\n=== mergeSliceToMain: auto-resolve .gsd/ planning conflicts ===");
+
+  {
+    const repo = initBranchTestRepo();
+    const svc = new GitServiceImpl(repo);
+
+    // Create a .gsd/ planning artifact on main (simulates reassess-roadmap)
+    createFile(repo, ".gsd/DECISIONS.md", "# Decisions\n\n- D001: Original decision\n");
+    run("git add -A", repo);
+    run("git commit -m 'add decisions on main'", repo);
+
+    // Create slice branch and modify the same .gsd/ file differently
+    svc.ensureSliceBranch("M001", "S01");
+    createFile(repo, ".gsd/DECISIONS.md", "# Decisions\n\n- D001: Original decision\n- D002: New decision from slice\n");
+    createFile(repo, "src/feature.ts", "export const x = 1;");
+    run("git add -A", repo);
+    run("git commit -m 'slice work with .gsd/ changes'", repo);
+
+    // Back on main, modify the same .gsd/ file to create a conflict
+    svc.switchToMain();
+    createFile(repo, ".gsd/DECISIONS.md", "# Decisions\n\n- D001: Updated decision on main\n");
+    run("git add -A", repo);
+    run("git commit -m 'update decisions on main'", repo);
+
+    // Merge should auto-resolve .gsd/ conflicts by taking theirs (slice branch)
+    const result = svc.mergeSliceToMain("M001", "S01", "Feature with .gsd/ conflicts");
+    assertEq(result.deletedBranch, true, ".gsd/ conflict auto-resolved: branch deleted");
+
+    // Verify the merge succeeded and src file is present
+    assert(existsSync(join(repo, "src/feature.ts")), ".gsd/ conflict auto-resolved: src file merged");
+
+    rmSync(repo, { recursive: true, force: true });
+  }
+
   // ═══════════════════════════════════════════════════════════════════════
   // S05: Enhanced features — merge guards, snapshots, auto-push, rich commits
   // ═══════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

- Extends merge conflict auto-resolution in `mergeSliceToMain()` to cover ALL `.gsd/` files, not just `RUNTIME_EXCLUSION_PATHS`
- Planning artifacts (DECISIONS.md, REQUIREMENTS.md, PROJECT.md, ROADMAP.md) now auto-resolve by taking the slice branch version (`--theirs`)
- Prevents auto-mode loop when both main and slice branch modify `.gsd/` planning files

## Problem

When `mergeSliceToMain()` encounters merge conflicts, it checks if all conflicted files are in `RUNTIME_EXCLUSION_PATHS`. If so, it auto-resolves. But planning artifacts like `.gsd/DECISIONS.md`, `.gsd/REQUIREMENTS.md`, `.gsd/milestones/*/ROADMAP.md` are NOT in that list. When these conflict (e.g., reassess-roadmap modifies them on main, then the next slice also modifies them), the merge fails, resets `--hard`, and auto-mode retries — creating an infinite loop that burns tokens.

## Fix

Added a second check: if all conflicted files are under `.gsd/` (but not necessarily runtime), auto-resolve by taking `--theirs` (the slice branch version). This is correct because the slice branch has the most recently updated `.gsd/` state from the LLM's `complete-slice` work.

Priority order:
1. Runtime-only conflicts → checkout theirs + rm from index (existing behavior)
2. All-.gsd/ conflicts → checkout theirs (new)
3. Non-.gsd/ conflicts → reset and throw (existing behavior)

## Test plan

- [x] New test: `mergeSliceToMain: auto-resolve .gsd/ planning conflicts` — creates divergent `.gsd/DECISIONS.md` on main and slice branch, verifies merge succeeds
- [x] All 196 existing git-service tests pass