### PR TITLE
feat: native git operations via libgit2

### DIFF
--- a/native/crates/engine/Cargo.toml
+++ b/native/crates/engine/Cargo.toml
@@ -24,6 +24,7 @@ image = { version = "0.25", default-features = false, features = [
   "gif",
   "webp",
 ] }
+git2 = { version = "0.19", features = ["vendored"] }
 napi = { version = "2", features = ["napi8"] }
 napi-derive = "2"
 regex = "1"

--- a/native/crates/engine/src/git.rs
+++ b/native/crates/engine/src/git.rs
@@ -1,0 +1,236 @@
+//! Native git operations via libgit2.
+
+use napi_derive::napi;
+
+#[napi(object)]
+pub struct GitStatusResult {
+    pub staged: Vec<String>,
+    pub unstaged: Vec<String>,
+    pub untracked: Vec<String>,
+}
+
+#[napi(object)]
+pub struct GitLogEntry {
+    pub hash: String,
+    pub short_hash: String,
+    pub message: String,
+    pub author_name: String,
+    pub author_email: String,
+    pub timestamp: i64,
+}
+
+#[napi]
+pub fn git_status(repo_path: String) -> napi::Result<GitStatusResult> {
+    let repo = git2::Repository::open(&repo_path)
+        .map_err(|e| napi::Error::from_reason(e.to_string()))?;
+
+    let mut opts = git2::StatusOptions::new();
+    opts.include_untracked(true).recurse_untracked_dirs(true);
+
+    let statuses = repo
+        .statuses(Some(&mut opts))
+        .map_err(|e| napi::Error::from_reason(e.to_string()))?;
+
+    let mut staged = Vec::new();
+    let mut unstaged = Vec::new();
+    let mut untracked = Vec::new();
+
+    for entry in statuses.iter() {
+        let path = entry.path().unwrap_or("").to_string();
+        let s = entry.status();
+
+        if s.intersects(
+            git2::Status::INDEX_NEW
+                | git2::Status::INDEX_MODIFIED
+                | git2::Status::INDEX_DELETED
+                | git2::Status::INDEX_RENAMED
+                | git2::Status::INDEX_TYPECHANGE,
+        ) {
+            staged.push(path.clone());
+        }
+
+        if s.intersects(
+            git2::Status::WT_MODIFIED
+                | git2::Status::WT_DELETED
+                | git2::Status::WT_TYPECHANGE
+                | git2::Status::WT_RENAMED,
+        ) {
+            unstaged.push(path.clone());
+        }
+
+        if s.contains(git2::Status::WT_NEW) {
+            untracked.push(path);
+        }
+    }
+
+    Ok(GitStatusResult { staged, unstaged, untracked })
+}
+
+#[napi]
+pub fn git_diff(repo_path: String, staged: Option<bool>) -> napi::Result<String> {
+    let repo = git2::Repository::open(&repo_path)
+        .map_err(|e| napi::Error::from_reason(e.to_string()))?;
+
+    let diff = if staged.unwrap_or(false) {
+        let head = repo.head().ok().and_then(|h| h.peel_to_commit().ok());
+        let head_tree = head.as_ref().and_then(|c| c.tree().ok());
+        repo.diff_tree_to_index(head_tree.as_ref(), None, None)
+            .map_err(|e| napi::Error::from_reason(e.to_string()))?
+    } else {
+        repo.diff_index_to_workdir(None, None)
+            .map_err(|e| napi::Error::from_reason(e.to_string()))?
+    };
+
+    let mut output = String::new();
+    diff.print(git2::DiffFormat::Patch, |_delta, _hunk, line| {
+        let origin = line.origin();
+        if origin == '+' || origin == '-' || origin == ' ' {
+            output.push(origin);
+        }
+        if let Ok(s) = std::str::from_utf8(line.content()) {
+            output.push_str(s);
+        }
+        true
+    })
+    .map_err(|e| napi::Error::from_reason(e.to_string()))?;
+
+    Ok(output)
+}
+
+#[napi]
+pub fn git_log(repo_path: String, max_count: Option<u32>) -> napi::Result<Vec<GitLogEntry>> {
+    let repo = git2::Repository::open(&repo_path)
+        .map_err(|e| napi::Error::from_reason(e.to_string()))?;
+
+    let mut revwalk = repo
+        .revwalk()
+        .map_err(|e| napi::Error::from_reason(e.to_string()))?;
+
+    revwalk
+        .push_head()
+        .map_err(|e| napi::Error::from_reason(e.to_string()))?;
+
+    let limit = max_count.unwrap_or(50) as usize;
+    let mut entries = Vec::new();
+
+    for oid in revwalk.take(limit) {
+        let oid = oid.map_err(|e| napi::Error::from_reason(e.to_string()))?;
+        let commit = repo
+            .find_commit(oid)
+            .map_err(|e| napi::Error::from_reason(e.to_string()))?;
+
+        let hash = oid.to_string();
+        let short_hash = hash[..8].to_string();
+        let message = commit.message().unwrap_or("").trim().to_string();
+        let author = commit.author();
+        let author_name = author.name().unwrap_or("").to_string();
+        let author_email = author.email().unwrap_or("").to_string();
+        let timestamp = author.when().seconds();
+
+        entries.push(GitLogEntry {
+            hash,
+            short_hash,
+            message,
+            author_name,
+            author_email,
+            timestamp,
+        });
+    }
+
+    Ok(entries)
+}
+
+#[napi]
+pub fn git_current_branch(repo_path: String) -> napi::Result<String> {
+    let repo = git2::Repository::open(&repo_path)
+        .map_err(|e| napi::Error::from_reason(e.to_string()))?;
+
+    let head = repo.head().map_err(|e| napi::Error::from_reason(e.to_string()))?;
+
+    if head.is_branch() {
+        Ok(head.shorthand().unwrap_or("HEAD").to_string())
+    } else {
+        Ok("HEAD".to_string())
+    }
+}
+
+#[napi]
+pub fn git_is_clean(repo_path: String) -> napi::Result<bool> {
+    let repo = git2::Repository::open(&repo_path)
+        .map_err(|e| napi::Error::from_reason(e.to_string()))?;
+
+    let mut opts = git2::StatusOptions::new();
+    opts.include_untracked(true);
+
+    let statuses = repo
+        .statuses(Some(&mut opts))
+        .map_err(|e| napi::Error::from_reason(e.to_string()))?;
+
+    Ok(statuses.is_empty())
+}
+
+#[napi]
+pub fn git_stage_files(repo_path: String, paths: Vec<String>) -> napi::Result<()> {
+    let repo = git2::Repository::open(&repo_path)
+        .map_err(|e| napi::Error::from_reason(e.to_string()))?;
+
+    let mut index = repo
+        .index()
+        .map_err(|e| napi::Error::from_reason(e.to_string()))?;
+
+    for path in &paths {
+        index
+            .add_path(std::path::Path::new(path))
+            .map_err(|e| napi::Error::from_reason(format!("{}: {}", path, e)))?;
+    }
+
+    index
+        .write()
+        .map_err(|e| napi::Error::from_reason(e.to_string()))?;
+
+    Ok(())
+}
+
+#[napi]
+pub fn git_commit(
+    repo_path: String,
+    message: String,
+    author_name: String,
+    author_email: String,
+) -> napi::Result<String> {
+    let repo = git2::Repository::open(&repo_path)
+        .map_err(|e| napi::Error::from_reason(e.to_string()))?;
+
+    let sig = git2::Signature::now(&author_name, &author_email)
+        .map_err(|e| napi::Error::from_reason(e.to_string()))?;
+
+    let mut index = repo
+        .index()
+        .map_err(|e| napi::Error::from_reason(e.to_string()))?;
+
+    let tree_oid = index
+        .write_tree()
+        .map_err(|e| napi::Error::from_reason(e.to_string()))?;
+
+    let tree = repo
+        .find_tree(tree_oid)
+        .map_err(|e| napi::Error::from_reason(e.to_string()))?;
+
+    let parent_commits: Vec<git2::Commit> = match repo.head() {
+        Ok(head) => {
+            let commit = head
+                .peel_to_commit()
+                .map_err(|e| napi::Error::from_reason(e.to_string()))?;
+            vec![commit]
+        }
+        Err(_) => vec![],
+    };
+
+    let parents: Vec<&git2::Commit> = parent_commits.iter().collect();
+
+    let oid = repo
+        .commit(Some("HEAD"), &sig, &sig, &message, &tree, &parents)
+        .map_err(|e| napi::Error::from_reason(e.to_string()))?;
+
+    Ok(oid.to_string())
+}

--- a/native/crates/engine/src/lib.rs
+++ b/native/crates/engine/src/lib.rs
@@ -23,3 +23,4 @@ mod text;
 mod ttsr;
 mod gsd_parser;
 mod image;
+pub mod git;

--- a/packages/native/src/__tests__/git.test.mjs
+++ b/packages/native/src/__tests__/git.test.mjs
@@ -1,0 +1,141 @@
+import { execSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { strict as assert } from "node:assert";
+
+// These tests require the native addon to be built.
+// Run: cd native && npm run build
+let native;
+try {
+  const mod = await import("../native.js");
+  native = mod.native;
+} catch {
+  console.log("Native addon not built — skipping git tests.");
+  process.exit(0);
+}
+
+function makeRepo() {
+  const dir = mkdtempSync(join(tmpdir(), "gsd-git-test-"));
+  execSync("git init", { cwd: dir });
+  execSync('git config user.email "test@test.com"', { cwd: dir });
+  execSync('git config user.name "Test"', { cwd: dir });
+  return dir;
+}
+
+function cleanup(dir) {
+  rmSync(dir, { recursive: true, force: true });
+}
+
+// Test: gitCurrentBranch
+{
+  const dir = makeRepo();
+  try {
+    writeFileSync(join(dir, "a.txt"), "hello");
+    execSync("git add a.txt", { cwd: dir });
+    execSync('git commit -m "init"', { cwd: dir });
+    const branch = native.gitCurrentBranch(dir);
+    assert.ok(typeof branch === "string" && branch.length > 0, "branch should be a non-empty string");
+    console.log("✓ gitCurrentBranch:", branch);
+  } finally {
+    cleanup(dir);
+  }
+}
+
+// Test: gitIsClean
+{
+  const dir = makeRepo();
+  try {
+    writeFileSync(join(dir, "a.txt"), "hello");
+    execSync("git add a.txt", { cwd: dir });
+    execSync('git commit -m "init"', { cwd: dir });
+    const clean = native.gitIsClean(dir);
+    assert.equal(clean, true, "repo should be clean after commit");
+    writeFileSync(join(dir, "b.txt"), "dirty");
+    const dirty = native.gitIsClean(dir);
+    assert.equal(dirty, false, "repo should be dirty with untracked file");
+    console.log("✓ gitIsClean");
+  } finally {
+    cleanup(dir);
+  }
+}
+
+// Test: gitStatus
+{
+  const dir = makeRepo();
+  try {
+    writeFileSync(join(dir, "a.txt"), "hello");
+    execSync("git add a.txt", { cwd: dir });
+    execSync('git commit -m "init"', { cwd: dir });
+    writeFileSync(join(dir, "b.txt"), "untracked");
+    writeFileSync(join(dir, "a.txt"), "modified");
+    execSync("git add a.txt", { cwd: dir });
+    const status = native.gitStatus(dir);
+    assert.ok(Array.isArray(status.staged), "staged should be array");
+    assert.ok(Array.isArray(status.unstaged), "unstaged should be array");
+    assert.ok(Array.isArray(status.untracked), "untracked should be array");
+    assert.ok(status.staged.includes("a.txt"), "a.txt should be staged");
+    assert.ok(status.untracked.includes("b.txt"), "b.txt should be untracked");
+    console.log("✓ gitStatus");
+  } finally {
+    cleanup(dir);
+  }
+}
+
+// Test: gitLog
+{
+  const dir = makeRepo();
+  try {
+    writeFileSync(join(dir, "a.txt"), "hello");
+    execSync("git add a.txt", { cwd: dir });
+    execSync('git commit -m "first commit"', { cwd: dir });
+    const log = native.gitLog(dir, 10);
+    assert.ok(Array.isArray(log), "log should be array");
+    assert.ok(log.length >= 1, "should have at least one entry");
+    const entry = log[0];
+    assert.ok(typeof entry.hash === "string" && entry.hash.length === 40, "hash should be 40 chars");
+    assert.ok(typeof entry.shortHash === "string" && entry.shortHash.length === 8, "shortHash should be 8 chars");
+    assert.ok(entry.message.includes("first commit"), "message mismatch");
+    console.log("✓ gitLog");
+  } finally {
+    cleanup(dir);
+  }
+}
+
+// Test: gitStageFiles + gitCommit
+{
+  const dir = makeRepo();
+  try {
+    writeFileSync(join(dir, "a.txt"), "hello");
+    execSync("git add a.txt", { cwd: dir });
+    execSync('git commit -m "init"', { cwd: dir });
+    writeFileSync(join(dir, "c.txt"), "new file");
+    native.gitStageFiles(dir, ["c.txt"]);
+    const oid = native.gitCommit(dir, "add c.txt", "Test", "test@test.com");
+    assert.ok(typeof oid === "string" && oid.length === 40, "commit oid should be 40 chars");
+    const log = native.gitLog(dir, 1);
+    assert.ok(log[0].message.includes("add c.txt"), "commit message mismatch");
+    console.log("✓ gitStageFiles + gitCommit");
+  } finally {
+    cleanup(dir);
+  }
+}
+
+// Test: gitDiff
+{
+  const dir = makeRepo();
+  try {
+    writeFileSync(join(dir, "a.txt"), "line1\n");
+    execSync("git add a.txt", { cwd: dir });
+    execSync('git commit -m "init"', { cwd: dir });
+    writeFileSync(join(dir, "a.txt"), "line1\nline2\n");
+    const diff = native.gitDiff(dir, false);
+    assert.ok(typeof diff === "string", "diff should be string");
+    assert.ok(diff.includes("line2"), "diff should mention new content");
+    console.log("✓ gitDiff (unstaged)");
+  } finally {
+    cleanup(dir);
+  }
+}
+
+console.log("\nAll git tests passed.");

--- a/packages/native/src/git/index.ts
+++ b/packages/native/src/git/index.ts
@@ -1,0 +1,37 @@
+import { native } from "../native.js";
+import type { GitStatusResult, GitLogEntry } from "./types.js";
+
+export type { GitStatusResult, GitLogEntry };
+
+export function gitStatus(repoPath: string): GitStatusResult {
+  return native.gitStatus(repoPath) as GitStatusResult;
+}
+
+export function gitDiff(repoPath: string, staged?: boolean): string {
+  return native.gitDiff(repoPath, staged) as string;
+}
+
+export function gitLog(repoPath: string, maxCount?: number): GitLogEntry[] {
+  return native.gitLog(repoPath, maxCount) as GitLogEntry[];
+}
+
+export function gitCurrentBranch(repoPath: string): string {
+  return native.gitCurrentBranch(repoPath) as string;
+}
+
+export function gitIsClean(repoPath: string): boolean {
+  return native.gitIsClean(repoPath) as boolean;
+}
+
+export function gitStageFiles(repoPath: string, paths: string[]): void {
+  native.gitStageFiles(repoPath, paths);
+}
+
+export function gitCommit(
+  repoPath: string,
+  message: string,
+  authorName: string,
+  authorEmail: string,
+): string {
+  return native.gitCommit(repoPath, message, authorName, authorEmail) as string;
+}

--- a/packages/native/src/git/types.ts
+++ b/packages/native/src/git/types.ts
@@ -1,0 +1,14 @@
+export interface GitStatusResult {
+  staged: string[];
+  unstaged: string[];
+  untracked: string[];
+}
+
+export interface GitLogEntry {
+  hash: string;
+  shortHash: string;
+  message: string;
+  authorName: string;
+  authorEmail: string;
+  timestamp: number;
+}

--- a/packages/native/src/index.ts
+++ b/packages/native/src/index.ts
@@ -94,6 +94,17 @@ export type { NativeImageHandle } from "./image/index.js";
 export { ttsrCompileRules, ttsrCheckBuffer, ttsrFreeRules } from "./ttsr/index.js";
 export type { TtsrHandle, TtsrRuleInput } from "./ttsr/index.js";
 export {
+  gitStatus,
+  gitDiff,
+  gitLog,
+  gitCurrentBranch,
+  gitIsClean,
+  gitStageFiles,
+  gitCommit,
+} from "./git/index.js";
+export type { GitStatusResult, GitLogEntry } from "./git/index.js";
+
+export {
   parseFrontmatter,
   extractSection as nativeExtractSection,
   extractAllSections,

--- a/packages/native/src/native.ts
+++ b/packages/native/src/native.ts
@@ -129,4 +129,11 @@ export const native = loadNative() as {
   extractAllSections: (content: string, level?: number) => string;
   batchParseGsdFiles: (directory: string) => unknown;
   parseRoadmapFile: (content: string) => unknown;
+  gitStatus: (repoPath: string) => unknown;
+  gitDiff: (repoPath: string, staged?: boolean) => string;
+  gitLog: (repoPath: string, maxCount?: number) => unknown;
+  gitCurrentBranch: (repoPath: string) => string;
+  gitIsClean: (repoPath: string) => boolean;
+  gitStageFiles: (repoPath: string, paths: string[]) => void;
+  gitCommit: (repoPath: string, message: string, authorName: string, authorEmail: string) => string;
 };


### PR DESCRIPTION
## Summary
- Adds `git2` Rust crate (vendored libgit2) to `native/crates/engine/Cargo.toml`
- Implements `gitStatus`, `gitDiff`, `gitLog`, `gitCurrentBranch`, `gitIsClean`, `gitStageFiles`, `gitCommit` in `native/crates/engine/src/git.rs`
- Exports all functions through `packages/native/src/git/` with full TypeScript types
- Eliminates git CLI process spawning for common operations

## Test plan
- [ ] Build native addon: `cd native && npm run build`
- [ ] Run git tests: `node packages/native/src/__tests__/git.test.mjs`
- [ ] Verify all 5 test cases pass (branch, isClean, status, log, stage+commit, diff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)