### PR TITLE
feat: native BPE tokenizer replacing chars/4 heuristic

### DIFF
--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -37,6 +37,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
 name = "arboard"
 version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -62,7 +68,7 @@ version = "0.39.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "057ae90e7256ebf85f840b1638268df0142c9d19467d500b790631fd301acc27"
 dependencies = [
- "bit-set",
+ "bit-set 0.8.0",
  "regex",
  "thiserror",
  "tree-sitter",
@@ -85,6 +91,12 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -100,12 +112,27 @@ dependencies = [
 
 [[package]]
 name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec 0.6.3",
+]
+
+[[package]]
+name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.8.0",
 ]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bit-vec"
@@ -324,11 +351,22 @@ checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
 name = "fancy-regex"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "531e46835a22af56d1e3b66f04844bed63158bc094a628bec1d321d9b4c44bf2"
+dependencies = [
+ "bit-set 0.5.3",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "fancy-regex"
 version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "998b056554fbe42e03ae0e152895cd1a7e1002aec800fdc6635d20270260c46f"
 dependencies = [
- "bit-set",
+ "bit-set 0.8.0",
  "regex-automata",
  "regex-syntax",
 ]
@@ -547,6 +585,7 @@ dependencies = [
  "similar",
  "smallvec",
  "syntect",
+ "tiktoken-rs",
  "unicode-segmentation",
  "unicode-width",
 ]
@@ -607,7 +646,7 @@ checksum = "3f9377e16af590b764fd98fd176027cf8831c5335f8964f3f643753e38913a4e"
 dependencies = [
  "ahash",
  "astral-tl",
- "base64",
+ "base64 0.22.1",
  "html-escape",
  "html5ever",
  "lru",
@@ -686,6 +725,12 @@ name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
@@ -1120,6 +1165,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1274,7 +1325,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "656b45c05d95a5704399aeef6bd0ddec7b2b3531b7c9e900abbf7c4d2190c925"
 dependencies = [
  "bincode",
- "fancy-regex",
+ "fancy-regex 0.16.2",
  "flate2",
  "fnv",
  "once_cell",
@@ -1327,6 +1378,22 @@ dependencies = [
  "quick-error",
  "weezl",
  "zune-jpeg",
+]
+
+[[package]]
+name = "tiktoken-rs"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44075987ee2486402f0808505dd65692163d243a337fc54363d49afac41087f6"
+dependencies = [
+ "anyhow",
+ "base64 0.21.7",
+ "bstr",
+ "fancy-regex 0.13.0",
+ "lazy_static",
+ "parking_lot",
+ "regex",
+ "rustc-hash",
 ]
 
 [[package]]

--- a/native/crates/engine/Cargo.toml
+++ b/native/crates/engine/Cargo.toml
@@ -30,6 +30,7 @@ regex = "1"
 similar = "2"
 smallvec = "1"
 syntect = { version = "5", default-features = false, features = ["default-syntaxes", "default-themes", "regex-fancy"] }
+tiktoken-rs = "0.6"
 unicode-segmentation = "1"
 unicode-width = "0.2"
 

--- a/native/crates/engine/src/lib.rs
+++ b/native/crates/engine/src/lib.rs
@@ -23,3 +23,4 @@ mod text;
 mod ttsr;
 mod gsd_parser;
 mod image;
+mod tokenizer;

--- a/native/crates/engine/src/tokenizer.rs
+++ b/native/crates/engine/src/tokenizer.rs
@@ -1,0 +1,160 @@
+//! BPE token counting via tiktoken-rs.
+//!
+//! Lazily initializes the cl100k_base encoding (used by Claude, GPT-4, etc.)
+//! on first call. Subsequent calls reuse the cached encoder.
+
+use napi::bindgen_prelude::*;
+use napi::{JsObject, JsUnknown, ValueType};
+use napi_derive::napi;
+use std::sync::OnceLock;
+use tiktoken_rs::CoreBPE;
+
+/// Cached encoder — initialized once on first use.
+static ENCODER: OnceLock<CoreBPE> = OnceLock::new();
+
+fn get_encoder() -> &'static CoreBPE {
+    ENCODER.get_or_init(|| {
+        tiktoken_rs::cl100k_base().expect("failed to initialize cl100k_base tokenizer")
+    })
+}
+
+/// Count the number of BPE tokens in a string.
+#[napi]
+pub fn count_tokens(text: String) -> u32 {
+    get_encoder().encode_ordinary(&text).len() as u32
+}
+
+/// Count BPE tokens for each string in a batch.
+#[napi]
+pub fn count_tokens_batch(texts: Vec<String>) -> Vec<u32> {
+    let enc = get_encoder();
+    texts
+        .iter()
+        .map(|t| enc.encode_ordinary(t).len() as u32)
+        .collect()
+}
+
+/// Helper: get a string property from a JS object, returning None if missing or wrong type.
+fn get_string_prop(obj: &JsObject, key: &str) -> Result<Option<String>> {
+    match obj.get_named_property::<JsUnknown>(key) {
+        Ok(val) => {
+            if val.get_type()? == ValueType::String {
+                let s: String = val.coerce_to_string()?.into_utf8()?.as_str()?.to_owned();
+                Ok(Some(s))
+            } else {
+                Ok(None)
+            }
+        }
+        Err(_) => Ok(None),
+    }
+}
+
+/// Count tokens in a string using the cached encoder.
+fn count_str(text: &str) -> usize {
+    get_encoder().encode_ordinary(text).len()
+}
+
+/// Process a content block (object with `type` field).
+fn process_content_block(env: &Env, block: &JsObject) -> Result<usize> {
+    let block_type = get_string_prop(block, "type")?;
+    let block_type = block_type.as_deref().unwrap_or("");
+
+    match block_type {
+        "text" => {
+            if let Some(t) = get_string_prop(block, "text")? {
+                Ok(count_str(&t))
+            } else {
+                Ok(0)
+            }
+        }
+        "thinking" => {
+            if let Some(t) = get_string_prop(block, "thinking")? {
+                Ok(count_str(&t))
+            } else {
+                Ok(0)
+            }
+        }
+        "toolCall" => {
+            let mut n = 0;
+            if let Some(name) = get_string_prop(block, "name")? {
+                n += count_str(&name);
+            }
+            // Stringify the arguments object
+            if let Ok(args_val) = block.get_named_property::<JsUnknown>("arguments") {
+                if args_val.get_type()? == ValueType::Object {
+                    // Use JSON.stringify equivalent — serialize via napi env
+                    let global = env.get_global()?;
+                    let json: JsObject = global.get_named_property("JSON")?;
+                    let stringify: napi::JsFunction = json.get_named_property("stringify")?;
+                    let result = stringify.call(Some(&json), &[args_val])?;
+                    if result.get_type()? == ValueType::String {
+                        let s: String = result.coerce_to_string()?.into_utf8()?.as_str()?.to_owned();
+                        n += count_str(&s);
+                    }
+                }
+            }
+            Ok(n)
+        }
+        "image" => Ok(1200),
+        _ => {
+            // Unknown block — try text field
+            if let Some(t) = get_string_prop(block, "text")? {
+                Ok(count_str(&t))
+            } else {
+                Ok(0)
+            }
+        }
+    }
+}
+
+/// Estimate the token count of a chat message object.
+///
+/// Accepts a JS object with `role` and `content` fields. Content can be a
+/// string or an array of content blocks. Adds a small overhead per message
+/// for role/framing tokens.
+#[napi(ts_args_type = "message: { role: string; content: unknown; [key: string]: unknown }")]
+pub fn estimate_message_tokens(env: Env, message: JsObject) -> Result<u32> {
+    let mut total: usize = 4; // per-message framing overhead
+
+    let role = get_string_prop(&message, "role")?;
+    let role_str = role.as_deref().unwrap_or("");
+
+    // Process content field
+    if let Ok(content_val) = message.get_named_property::<JsUnknown>("content") {
+        match content_val.get_type()? {
+            ValueType::String => {
+                let s: String = content_val.coerce_to_string()?.into_utf8()?.as_str()?.to_owned();
+                total += count_str(&s);
+            }
+            ValueType::Object => {
+                // Check if it's an array
+                let content_obj: JsObject = unsafe { content_val.cast() };
+                if content_obj.is_array()? {
+                    let len = content_obj.get_array_length()?;
+                    for i in 0..len {
+                        let block: JsObject = content_obj.get_element(i)?;
+                        total += process_content_block(&env, &block)?;
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    // Handle bashExecution messages
+    if role_str == "bashExecution" {
+        if let Some(cmd) = get_string_prop(&message, "command")? {
+            total += count_str(&cmd);
+        }
+        if let Some(output) = get_string_prop(&message, "output")? {
+            total += count_str(&output);
+        }
+    }
+
+    // Handle summary messages (branchSummary, compactionSummary)
+    if let Some(summary) = get_string_prop(&message, "summary")? {
+        total += count_str(&summary);
+    }
+
+    Ok(total as u32)
+}

--- a/packages/native/src/__tests__/tokenizer.test.mjs
+++ b/packages/native/src/__tests__/tokenizer.test.mjs
@@ -1,0 +1,97 @@
+import { describe, it, expect } from "vitest";
+import { countTokens, countTokensBatch, estimateMessageTokens } from "../index.js";
+
+describe("tokenizer", () => {
+  describe("countTokens", () => {
+    it("returns 0 for empty string", () => {
+      expect(countTokens("")).toBe(0);
+    });
+
+    it("counts tokens for simple text", () => {
+      const count = countTokens("Hello, world!");
+      expect(count).toBeGreaterThan(0);
+      expect(count).toBeLessThan(10);
+    });
+
+    it("counts tokens for longer text", () => {
+      const short = countTokens("Hi");
+      const long = countTokens("This is a much longer sentence with many more words in it.");
+      expect(long).toBeGreaterThan(short);
+    });
+
+    it("handles unicode text", () => {
+      const count = countTokens("Hello 世界! 🌍");
+      expect(count).toBeGreaterThan(0);
+    });
+  });
+
+  describe("countTokensBatch", () => {
+    it("returns empty array for empty input", () => {
+      expect(countTokensBatch([])).toEqual([]);
+    });
+
+    it("counts tokens for multiple strings", () => {
+      const results = countTokensBatch(["Hello", "World", "Hello, world!"]);
+      expect(results).toHaveLength(3);
+      for (const r of results) {
+        expect(r).toBeGreaterThan(0);
+      }
+    });
+
+    it("matches individual countTokens calls", () => {
+      const texts = ["foo bar", "The quick brown fox", ""];
+      const batch = countTokensBatch(texts);
+      const individual = texts.map(t => countTokens(t));
+      expect(batch).toEqual(individual);
+    });
+  });
+
+  describe("estimateMessageTokens", () => {
+    it("estimates tokens for a user message with string content", () => {
+      const count = estimateMessageTokens({
+        role: "user",
+        content: "What is the meaning of life?",
+      });
+      // 4 overhead + actual tokens
+      expect(count).toBeGreaterThan(4);
+    });
+
+    it("estimates tokens for a user message with array content", () => {
+      const count = estimateMessageTokens({
+        role: "user",
+        content: [{ type: "text", text: "Hello world" }],
+      });
+      expect(count).toBeGreaterThan(4);
+    });
+
+    it("estimates tokens for an assistant message with tool calls", () => {
+      const count = estimateMessageTokens({
+        role: "assistant",
+        content: [
+          { type: "text", text: "Let me help." },
+          { type: "toolCall", name: "read", arguments: { path: "/foo/bar.ts" } },
+        ],
+      });
+      expect(count).toBeGreaterThan(4);
+    });
+
+    it("estimates tokens for bashExecution messages", () => {
+      const count = estimateMessageTokens({
+        role: "bashExecution",
+        content: "",
+        command: "ls -la",
+        output: "total 42\ndrwxr-xr-x  5 user staff 160 Jan 1 00:00 .",
+      });
+      expect(count).toBeGreaterThan(4);
+    });
+
+    it("handles image blocks with fixed estimate", () => {
+      const count = estimateMessageTokens({
+        role: "user",
+        content: [{ type: "image" }],
+      });
+      // 4 overhead + 1200 image estimate
+      expect(count).toBe(1204);
+    });
+  });
+});

--- a/packages/native/src/index.ts
+++ b/packages/native/src/index.ts
@@ -94,6 +94,12 @@ export type { NativeImageHandle } from "./image/index.js";
 export { ttsrCompileRules, ttsrCheckBuffer, ttsrFreeRules } from "./ttsr/index.js";
 export type { TtsrHandle, TtsrRuleInput } from "./ttsr/index.js";
 export {
+  countTokens,
+  countTokensBatch,
+  estimateMessageTokens,
+} from "./tokenizer/index.js";
+
+export {
   parseFrontmatter,
   extractSection as nativeExtractSection,
   extractAllSections,

--- a/packages/native/src/native.ts
+++ b/packages/native/src/native.ts
@@ -129,4 +129,7 @@ export const native = loadNative() as {
   extractAllSections: (content: string, level?: number) => string;
   batchParseGsdFiles: (directory: string) => unknown;
   parseRoadmapFile: (content: string) => unknown;
+  countTokens: (text: string) => number;
+  countTokensBatch: (texts: string[]) => number[];
+  estimateMessageTokens: (message: { role: string; content: unknown; [key: string]: unknown }) => number;
 };

--- a/packages/native/src/tokenizer/index.ts
+++ b/packages/native/src/tokenizer/index.ts
@@ -1,0 +1,35 @@
+/**
+ * BPE token counting via native tiktoken-rs (cl100k_base encoding).
+ *
+ * The encoder is initialized lazily on first call and cached for the
+ * lifetime of the process.
+ */
+
+import { native } from "../native.js";
+
+/**
+ * Count BPE tokens in a string using cl100k_base encoding.
+ */
+export function countTokens(text: string): number {
+  return native.countTokens(text);
+}
+
+/**
+ * Count BPE tokens for each string in a batch.
+ */
+export function countTokensBatch(texts: string[]): number[] {
+  return native.countTokensBatch(texts);
+}
+
+/**
+ * Estimate the token count of a chat message object.
+ *
+ * Handles string and array content (text, thinking, toolCall, image blocks),
+ * bashExecution messages, and summary messages. Adds per-message framing
+ * overhead.
+ */
+export function estimateMessageTokens(
+  message: { role: string; content: unknown; [key: string]: unknown },
+): number {
+  return native.estimateMessageTokens(message);
+}

--- a/packages/pi-coding-agent/src/core/compaction/compaction.ts
+++ b/packages/pi-coding-agent/src/core/compaction/compaction.ts
@@ -8,6 +8,7 @@
 import type { AgentMessage } from "@gsd/pi-agent-core";
 import type { AssistantMessage, Model, Usage } from "@gsd/pi-ai";
 import { completeSimple } from "@gsd/pi-ai";
+import { estimateMessageTokens } from "@gsd/native";
 import {
 	convertToLlm,
 	createBranchSummaryMessage,
@@ -219,67 +220,13 @@ export function shouldCompact(contextTokens: number, contextWindow: number, sett
 // ============================================================================
 
 /**
- * Estimate token count for a message using chars/4 heuristic.
- * This is conservative (overestimates tokens).
+ * Estimate token count for a message using native BPE tokenization (cl100k_base).
+ *
+ * Delegates to the Rust tiktoken-rs encoder via @gsd/native for accurate
+ * token counts. The encoder is lazily initialized on first call.
  */
 export function estimateTokens(message: AgentMessage): number {
-	let chars = 0;
-
-	switch (message.role) {
-		case "user": {
-			const content = (message as { content: string | Array<{ type: string; text?: string }> }).content;
-			if (typeof content === "string") {
-				chars = content.length;
-			} else if (Array.isArray(content)) {
-				for (const block of content) {
-					if (block.type === "text" && block.text) {
-						chars += block.text.length;
-					}
-				}
-			}
-			return Math.ceil(chars / 4);
-		}
-		case "assistant": {
-			const assistant = message as AssistantMessage;
-			for (const block of assistant.content) {
-				if (block.type === "text") {
-					chars += block.text.length;
-				} else if (block.type === "thinking") {
-					chars += block.thinking.length;
-				} else if (block.type === "toolCall") {
-					chars += block.name.length + JSON.stringify(block.arguments).length;
-				}
-			}
-			return Math.ceil(chars / 4);
-		}
-		case "custom":
-		case "toolResult": {
-			if (typeof message.content === "string") {
-				chars = message.content.length;
-			} else {
-				for (const block of message.content) {
-					if (block.type === "text" && block.text) {
-						chars += block.text.length;
-					}
-					if (block.type === "image") {
-						chars += 4800; // Estimate images as 4000 chars, or 1200 tokens
-					}
-				}
-			}
-			return Math.ceil(chars / 4);
-		}
-		case "bashExecution": {
-			chars = message.command.length + message.output.length;
-			return Math.ceil(chars / 4);
-		}
-		case "branchSummary":
-		case "compactionSummary": {
-			chars = message.summary.length;
-			return Math.ceil(chars / 4);
-		}
-	}
-
-	return 0;
+	return estimateMessageTokens(message as { role: string; content: unknown; [key: string]: unknown });
 }
 
 /**


### PR DESCRIPTION
## Summary
- Adds `tiktoken-rs` (cl100k_base encoding) to the native Rust engine for accurate BPE token counting, replacing the `chars/4` heuristic in compaction
- Exposes `countTokens`, `countTokensBatch`, and `estimateMessageTokens` via `@gsd/native` with lazy encoder initialization
- Wires `estimateMessageTokens` into `compaction.ts` `estimateTokens()` so compaction decisions use real token counts
- Binary size increases ~4MB due to bundled BPE vocabulary data (acceptable tradeoff)

## Changed files
- `native/crates/engine/Cargo.toml` — added `tiktoken-rs` dependency
- `native/crates/engine/src/tokenizer.rs` — new Rust module with BPE token counting
- `native/crates/engine/src/lib.rs` — register tokenizer module
- `packages/native/src/tokenizer/index.ts` — TypeScript wrapper
- `packages/native/src/native.ts` — native type declarations
- `packages/native/src/index.ts` — re-exports
- `packages/pi-coding-agent/src/core/compaction/compaction.ts` — replaced chars/4 with native tokenizer
- `packages/native/src/__tests__/tokenizer.test.mjs` — tests

## Test plan
- [ ] `cargo check -p gsd-engine` passes (verified locally)
- [ ] `cargo build -p gsd-engine` passes (verified locally)
- [ ] Run tokenizer tests: `vitest packages/native/src/__tests__/tokenizer.test.mjs`
- [ ] Run compaction tests to verify no regressions
- [ ] Verify compaction triggers at appropriate thresholds with real token counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)