### PR TITLE
feat: add native BLAKE3 content hasher module

### DIFF
--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -37,6 +37,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
 name = "arboard"
 version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -55,6 +61,18 @@ dependencies = [
  "windows-sys 0.60.2",
  "x11rb",
 ]
+
+[[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "ast-grep-core"
@@ -118,6 +136,20 @@ name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
+name = "blake3"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2468ef7d57b3fb7e16b576e8377cdbde2320c60e1491e961d11da40fc4f02a2d"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+ "cpufeatures",
+]
 
 [[package]]
 name = "bstr"
@@ -188,10 +220,16 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.17",
  "once_cell",
  "tiny-keccak",
 ]
+
+[[package]]
+name = "constant_time_eq"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "convert_case"
@@ -200,6 +238,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
 dependencies = [
  "unicode-segmentation",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -392,6 +439,12 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
@@ -415,6 +468,19 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -532,6 +598,7 @@ name = "gsd-engine"
 version = "0.1.0"
 dependencies = [
  "arboard",
+ "blake3",
  "dashmap",
  "globset",
  "gsd-ast",
@@ -543,12 +610,15 @@ dependencies = [
  "napi",
  "napi-build",
  "napi-derive",
+ "rayon",
  "regex",
  "similar",
  "smallvec",
  "syntect",
+ "tempfile",
  "unicode-segmentation",
  "unicode-width",
+ "xxhash-rust",
 ]
 
 [[package]]
@@ -581,14 +651,29 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.2.0",
 ]
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "html-escape"
@@ -625,6 +710,12 @@ dependencies = [
  "log",
  "markup5ever",
 ]
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "ignore"
@@ -679,6 +770,8 @@ checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -686,6 +779,12 @@ name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -1032,6 +1131,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1060,6 +1169,12 @@ checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rayon"
@@ -1283,6 +1398,19 @@ dependencies = [
  "serde_derive",
  "thiserror",
  "walkdir",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1747,6 +1875,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1779,6 +1913,58 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
 
 [[package]]
 name = "web_atoms"
@@ -1897,6 +2083,94 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
+
+[[package]]
 name = "x11rb"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1912,6 +2186,12 @@ name = "x11rb-protocol"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
+name = "xxhash-rust"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
 
 [[package]]
 name = "zerocopy"

--- a/native/crates/engine/Cargo.toml
+++ b/native/crates/engine/Cargo.toml
@@ -32,6 +32,12 @@ smallvec = "1"
 syntect = { version = "5", default-features = false, features = ["default-syntaxes", "default-themes", "regex-fancy"] }
 unicode-segmentation = "1"
 unicode-width = "0.2"
+xxhash-rust = { version = "0.8", features = ["xxh32"] }
+blake3 = "1"
+rayon = "1"
+
+[dev-dependencies]
+tempfile = "3"
 
 [build-dependencies]
 napi-build = "2"

--- a/native/crates/engine/src/hasher.rs
+++ b/native/crates/engine/src/hasher.rs
@@ -1,0 +1,229 @@
+//! BLAKE3 content hashing exposed to JS via N-API.
+//!
+//! Provides ultra-fast content hashing (~GB/s) for:
+//! - File change detection between agent loops
+//! - Cache invalidation for parsed results
+//! - Content deduplication across worktrees
+//! - Quick content comparison without reading full files
+
+use napi::bindgen_prelude::*;
+use napi_derive::napi;
+use rayon::prelude::*;
+use std::collections::HashMap;
+use std::path::Path;
+
+/// BLAKE3 hash of a UTF-8 string, returned as lowercase hex (64 chars).
+#[napi(js_name = "hashString")]
+pub fn hash_string(text: String) -> String {
+	blake3::hash(text.as_bytes()).to_hex().to_string()
+}
+
+/// BLAKE3 hash of a file's contents, returned as lowercase hex (64 chars).
+#[napi(js_name = "hashFile")]
+pub fn hash_file(path: String) -> Result<String> {
+	let data = std::fs::read(&path)
+		.map_err(|e| Error::new(Status::GenericFailure, format!("Failed to read {path}: {e}")))?;
+	Ok(blake3::hash(&data).to_hex().to_string())
+}
+
+/// BLAKE3 hash of multiple files in parallel via rayon.
+/// Returns a map of path -> hex hash. Skips files that fail to read.
+#[napi(js_name = "hashFiles")]
+pub fn hash_files(paths: Vec<String>) -> HashMap<String, String> {
+	paths
+		.into_par_iter()
+		.filter_map(|p| {
+			let data = std::fs::read(&p).ok()?;
+			let hex = blake3::hash(&data).to_hex().to_string();
+			Some((p, hex))
+		})
+		.collect()
+}
+
+/// Options for `hashDirectory`.
+#[napi(object)]
+pub struct HashDirectoryOptions {
+	/// Glob pattern to filter files (e.g. "**/*.ts"). Defaults to all files.
+	pub glob: Option<String>,
+	/// Whether to respect .gitignore rules. Defaults to true.
+	pub gitignore: Option<bool>,
+}
+
+/// BLAKE3 hash all files in a directory (optionally filtered by glob).
+/// Uses the `ignore` crate for .gitignore support and rayon for parallelism.
+/// Returns a map of relative path -> hex hash.
+#[napi(js_name = "hashDirectory")]
+pub fn hash_directory(
+	dir_path: String,
+	options: Option<HashDirectoryOptions>,
+) -> Result<HashMap<String, String>> {
+	let dir = Path::new(&dir_path);
+	if !dir.is_dir() {
+		return Err(Error::new(
+			Status::GenericFailure,
+			format!("Not a directory: {dir_path}"),
+		));
+	}
+
+	let gitignore = options.as_ref().and_then(|o| o.gitignore).unwrap_or(true);
+	let glob_pattern = options.as_ref().and_then(|o| o.glob.clone());
+
+	let mut builder = ignore::WalkBuilder::new(dir);
+	builder.git_ignore(gitignore).hidden(false);
+
+	if let Some(ref pat) = glob_pattern {
+		let mut types = ignore::types::TypesBuilder::new();
+		types.add("custom", pat).map_err(|e| {
+			Error::new(Status::GenericFailure, format!("Invalid glob pattern: {e}"))
+		})?;
+		types.select("custom");
+		builder.types(types.build().map_err(|e| {
+			Error::new(Status::GenericFailure, format!("Failed to build types: {e}"))
+		})?);
+	}
+
+	let entries: Vec<_> = builder
+		.build()
+		.filter_map(|e| e.ok())
+		.filter(|e| e.file_type().map_or(false, |ft| ft.is_file()))
+		.map(|e| e.into_path())
+		.collect();
+
+	let results: HashMap<String, String> = entries
+		.into_par_iter()
+		.filter_map(|path| {
+			let data = std::fs::read(&path).ok()?;
+			let hex = blake3::hash(&data).to_hex().to_string();
+			let rel = path
+				.strip_prefix(dir)
+				.unwrap_or(&path)
+				.to_string_lossy()
+				.to_string();
+			Some((rel, hex))
+		})
+		.collect();
+
+	Ok(results)
+}
+
+/// Given a map of path -> previous hash, re-hash each file and return
+/// the list of paths whose content has changed (or no longer exists).
+#[napi(js_name = "didFilesChange")]
+pub fn did_files_change(hashes: HashMap<String, String>) -> Vec<String> {
+	hashes
+		.into_par_iter()
+		.filter(|(path, old_hash)| {
+			match std::fs::read(path) {
+				Ok(data) => {
+					let current = blake3::hash(&data).to_hex().to_string();
+					current != *old_hash
+				}
+				// File gone or unreadable = changed
+				Err(_) => true,
+			}
+		})
+		.map(|(path, _)| path)
+		.collect()
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use std::fs;
+
+	#[test]
+	fn hash_string_deterministic() {
+		let h1 = hash_string("hello world".into());
+		let h2 = hash_string("hello world".into());
+		assert_eq!(h1, h2);
+		assert_eq!(h1.len(), 64);
+	}
+
+	#[test]
+	fn hash_string_different_inputs() {
+		let h1 = hash_string("hello".into());
+		let h2 = hash_string("world".into());
+		assert_ne!(h1, h2);
+	}
+
+	#[test]
+	fn hash_string_empty() {
+		let h = hash_string(String::new());
+		assert_eq!(h.len(), 64);
+		assert_eq!(
+			h,
+			"af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262"
+		);
+	}
+
+	#[test]
+	fn hash_file_works() {
+		let dir = tempfile::tempdir().unwrap();
+		let file = dir.path().join("test.txt");
+		fs::write(&file, "hello world").unwrap();
+
+		let h = hash_file(file.to_string_lossy().to_string()).unwrap();
+		let expected = hash_string("hello world".into());
+		assert_eq!(h, expected);
+	}
+
+	#[test]
+	fn hash_file_missing() {
+		let result = hash_file("/nonexistent/path/file.txt".into());
+		assert!(result.is_err());
+	}
+
+	#[test]
+	fn hash_files_parallel() {
+		let dir = tempfile::tempdir().unwrap();
+		let f1 = dir.path().join("a.txt");
+		let f2 = dir.path().join("b.txt");
+		fs::write(&f1, "aaa").unwrap();
+		fs::write(&f2, "bbb").unwrap();
+
+		let result = hash_files(vec![
+			f1.to_string_lossy().to_string(),
+			f2.to_string_lossy().to_string(),
+			"/nonexistent".into(),
+		]);
+
+		assert_eq!(result.len(), 2);
+		assert!(result.contains_key(&f1.to_string_lossy().to_string()));
+		assert!(result.contains_key(&f2.to_string_lossy().to_string()));
+	}
+
+	#[test]
+	fn did_files_change_detects_changes() {
+		let dir = tempfile::tempdir().unwrap();
+		let f1 = dir.path().join("stable.txt");
+		let f2 = dir.path().join("changed.txt");
+		fs::write(&f1, "same").unwrap();
+		fs::write(&f2, "original").unwrap();
+
+		let h1 = hash_file(f1.to_string_lossy().to_string()).unwrap();
+		let h2 = hash_file(f2.to_string_lossy().to_string()).unwrap();
+
+		fs::write(&f2, "modified").unwrap();
+
+		let mut prev = HashMap::new();
+		prev.insert(f1.to_string_lossy().to_string(), h1);
+		prev.insert(f2.to_string_lossy().to_string(), h2);
+		prev.insert("/gone/file.txt".into(), "abc123".into());
+
+		let changed = did_files_change(prev);
+		assert!(changed.contains(&f2.to_string_lossy().to_string()));
+		assert!(changed.contains(&"/gone/file.txt".to_string()));
+		assert!(!changed.contains(&f1.to_string_lossy().to_string()));
+	}
+
+	#[test]
+	fn hash_directory_works() {
+		let dir = tempfile::tempdir().unwrap();
+		fs::write(dir.path().join("a.txt"), "aaa").unwrap();
+		fs::create_dir(dir.path().join("sub")).unwrap();
+		fs::write(dir.path().join("sub/b.txt"), "bbb").unwrap();
+
+		let result = hash_directory(dir.path().to_string_lossy().to_string(), None).unwrap();
+		assert!(result.len() >= 2);
+	}
+}

--- a/native/crates/engine/src/lib.rs
+++ b/native/crates/engine/src/lib.rs
@@ -9,6 +9,7 @@
 
 mod ast;
 mod clipboard;
+mod hasher;
 mod diff;
 mod fd;
 mod fs_cache;

--- a/packages/native/src/hasher/index.ts
+++ b/packages/native/src/hasher/index.ts
@@ -1,0 +1,53 @@
+/**
+ * Native BLAKE3 content hashing — Rust implementation via napi-rs.
+ *
+ * Provides ultra-fast content hashing (~GB/s) using BLAKE3 with automatic
+ * SIMD acceleration (AVX2, SSE4.1, NEON). All hashes are lowercase hex,
+ * 64 characters (256-bit).
+ */
+
+import { native } from "../native.js";
+
+export interface HashDirectoryOptions {
+  /** Glob pattern to filter files (e.g. "**\/*.ts"). Defaults to all files. */
+  glob?: string;
+  /** Whether to respect .gitignore rules. Defaults to true. */
+  gitignore?: boolean;
+}
+
+/** BLAKE3 hash of a UTF-8 string, returned as lowercase 64-char hex. */
+export function hashString(text: string): string {
+  return native.hashString(text);
+}
+
+/** BLAKE3 hash of a file's contents, returned as lowercase 64-char hex. */
+export function hashFile(path: string): string {
+  return native.hashFile(path);
+}
+
+/**
+ * BLAKE3 hash of multiple files in parallel.
+ * Returns a map of path -> hex hash. Silently skips unreadable files.
+ */
+export function hashFiles(paths: string[]): Record<string, string> {
+  return native.hashFiles(paths);
+}
+
+/**
+ * BLAKE3 hash all files in a directory, optionally filtered by glob.
+ * Returns a map of relative path -> hex hash.
+ */
+export function hashDirectory(
+  dirPath: string,
+  options?: HashDirectoryOptions,
+): Record<string, string> {
+  return native.hashDirectory(dirPath, options);
+}
+
+/**
+ * Given previous hashes (path -> hex), re-hash each file and return
+ * paths whose content changed or no longer exist.
+ */
+export function didFilesChange(hashes: Record<string, string>): string[] {
+  return native.didFilesChange(hashes);
+}

--- a/packages/native/src/index.ts
+++ b/packages/native/src/index.ts
@@ -93,6 +93,16 @@ export type { NativeImageHandle } from "./image/index.js";
 
 export { ttsrCompileRules, ttsrCheckBuffer, ttsrFreeRules } from "./ttsr/index.js";
 export type { TtsrHandle, TtsrRuleInput } from "./ttsr/index.js";
+
+export {
+  hashString,
+  hashFile,
+  hashFiles,
+  hashDirectory,
+  didFilesChange,
+} from "./hasher/index.js";
+export type { HashDirectoryOptions } from "./hasher/index.js";
+
 export {
   parseFrontmatter,
   extractSection as nativeExtractSection,

--- a/packages/native/src/native.ts
+++ b/packages/native/src/native.ts
@@ -129,4 +129,9 @@ export const native = loadNative() as {
   extractAllSections: (content: string, level?: number) => string;
   batchParseGsdFiles: (directory: string) => unknown;
   parseRoadmapFile: (content: string) => unknown;
+  hashString: (text: string) => string;
+  hashFile: (path: string) => string;
+  hashFiles: (paths: string[]) => Record<string, string>;
+  hashDirectory: (dirPath: string, options?: { glob?: string; gitignore?: boolean }) => Record<string, string>;
+  didFilesChange: (hashes: Record<string, string>) => string[];
 };


### PR DESCRIPTION
## Summary
- Adds a new `hasher` module to the native Rust engine using BLAKE3 (~GB/s, SIMD-accelerated)
- Exposes 5 functions: `hashString`, `hashFile`, `hashFiles` (parallel via rayon), `hashDirectory` (.gitignore-aware), `didFilesChange` (diff against previous snapshot)
- TypeScript wrapper at `packages/native/src/hasher/` with full type exports

## Use cases
- Detecting which files changed since last agent loop
- Cache invalidation for parsed results
- Content deduplication across worktrees

## Test plan
- [x] Rust builds clean (`cargo build` -- no errors)
- [ ] Full integration test after next native addon rebuild (`npm run build:native`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)