### PR TITLE
feat: add `gsd update` subcommand

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -74,6 +74,7 @@ function parseCliArgs(argv: string[]): CliFlags {
       process.stdout.write('  --help, -h               Print this help and exit\n')
       process.stdout.write('\nSubcommands:\n')
       process.stdout.write('  config                   Re-run the setup wizard\n')
+      process.stdout.write('  update                   Update GSD to the latest version\n')
       process.exit(0)
     } else if (!arg.startsWith('--') && !arg.startsWith('-')) {
       flags.messages.push(arg)
@@ -89,6 +90,13 @@ const isPrintMode = cliFlags.print || cliFlags.mode !== undefined
 if (cliFlags.messages[0] === 'config') {
   const authStorage = AuthStorage.create(authFilePath)
   await runOnboarding(authStorage)
+  process.exit(0)
+}
+
+// `gsd update` — update to the latest version via npm
+if (cliFlags.messages[0] === 'update') {
+  const { runUpdate } = await import('./update-cmd.js')
+  await runUpdate()
   process.exit(0)
 }
 

--- a/src/update-cmd.ts
+++ b/src/update-cmd.ts
@@ -1,0 +1,45 @@
+import { execSync } from 'node:child_process'
+import { compareSemver } from './update-check.js'
+
+const NPM_PACKAGE = 'gsd-pi'
+
+export async function runUpdate(): Promise<void> {
+  const current = process.env.GSD_VERSION || '0.0.0'
+  const bold = '\x1b[1m'
+  const dim = '\x1b[2m'
+  const green = '\x1b[32m'
+  const yellow = '\x1b[33m'
+  const reset = '\x1b[0m'
+
+  process.stdout.write(`${dim}Current version:${reset} v${current}\n`)
+  process.stdout.write(`${dim}Checking npm registry...${reset}\n`)
+
+  // Fetch latest version
+  let latest: string
+  try {
+    latest = execSync(`npm view ${NPM_PACKAGE} version`, {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim()
+  } catch {
+    process.stderr.write(`${yellow}Failed to reach npm registry.${reset}\n`)
+    process.exit(1)
+  }
+
+  if (compareSemver(latest, current) <= 0) {
+    process.stdout.write(`${green}Already up to date.${reset}\n`)
+    return
+  }
+
+  process.stdout.write(`${dim}Updating:${reset} v${current} → ${bold}v${latest}${reset}\n`)
+
+  try {
+    execSync(`npm install -g ${NPM_PACKAGE}@latest`, {
+      stdio: 'inherit',
+    })
+    process.stdout.write(`\n${green}${bold}Updated to v${latest}${reset}\n`)
+  } catch {
+    process.stderr.write(`\n${yellow}Update failed. Try manually: npm install -g ${NPM_PACKAGE}@latest${reset}\n`)
+    process.exit(1)
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `gsd update` CLI subcommand that self-updates via npm
- Checks npm registry for latest version, compares with current, runs `npm install -g gsd-pi@latest`
- Registered in help text under Subcommands
- Uses existing `compareSemver` from `update-check.ts`

## Details

The update banner already tells users to run `npm update -g gsd-pi or /gsd:update`. This PR adds `gsd update` as a first-class subcommand so users don't need to remember the npm package name.

**Files:**
- `src/update-cmd.ts` — `runUpdate()` implementation
- `src/cli.ts` — subcommand dispatch + help text

## Test plan

- [x] `gsd update` when already up to date → prints "Already up to date"
- [x] `gsd update` when behind → runs npm install and prints success
- [x] `gsd --help` shows `update` subcommand
- [x] `gsd update` with no network → prints failure message with manual command