### PR TITLE
feat: wire native truncation module into tool output truncation

### DIFF
--- a/packages/pi-coding-agent/src/core/tools/truncate.ts
+++ b/packages/pi-coding-agent/src/core/tools/truncate.ts
@@ -5,6 +5,12 @@
  * - Line limit (default: 2000 lines)
  * - Byte limit (default: 50KB)
  *
+ * When the native Rust truncation module (@gsd/native/truncate) is available,
+ * byte-level truncation is delegated to it for performance. Line-limit
+ * enforcement and the partial-line edge case are handled in JS on top of the
+ * native result. Falls back to a pure-JS implementation when native is
+ * unavailable.
+ *
  * Never returns partial lines (except bash tail truncation edge case).
  */
 
@@ -44,6 +50,45 @@ export interface TruncationOptions {
 	maxBytes?: number;
 }
 
+// ── Native module loader ────────────────────────────────────────────────
+
+interface NativeTruncateResult {
+	text: string;
+	truncated: boolean;
+	originalLines: number;
+	keptLines: number;
+}
+
+interface NativeTruncateModule {
+	truncateTail: (text: string, maxBytes: number) => NativeTruncateResult;
+	truncateHead: (text: string, maxBytes: number) => NativeTruncateResult;
+}
+
+let nativeModule: NativeTruncateModule | null | undefined; // undefined = not yet attempted
+
+async function getNativeModule(): Promise<NativeTruncateModule | null> {
+	if (nativeModule !== undefined) {
+		return nativeModule;
+	}
+	try {
+		// @ts-expect-error - module provided by @gsd/native when native truncate is built
+		const mod = (await import("@gsd/native/truncate")) as NativeTruncateModule;
+		// Verify the functions exist
+		if (typeof mod.truncateTail === "function" && typeof mod.truncateHead === "function") {
+			nativeModule = mod;
+			return mod;
+		}
+		nativeModule = null;
+		return null;
+	} catch {
+		nativeModule = null;
+		return null;
+	}
+}
+
+// Eagerly kick off the native load (fire-and-forget)
+void getNativeModule();
+
 /**
  * Format bytes as human-readable size.
  */
@@ -67,8 +112,108 @@ export function formatSize(bytes: number): string {
 export function truncateHead(content: string, options: TruncationOptions = {}): TruncationResult {
 	const maxLines = options.maxLines ?? DEFAULT_MAX_LINES;
 	const maxBytes = options.maxBytes ?? DEFAULT_MAX_BYTES;
-
 	const totalBytes = Buffer.byteLength(content, "utf-8");
+
+	// Fast path: no truncation needed (check bytes first to avoid splitting)
+	if (totalBytes <= maxBytes) {
+		const totalLines = countLines(content);
+		if (totalLines <= maxLines) {
+			return {
+				content,
+				truncated: false,
+				truncatedBy: null,
+				totalLines,
+				totalBytes,
+				outputLines: totalLines,
+				outputBytes: totalBytes,
+				lastLinePartial: false,
+				firstLineExceedsLimit: false,
+				maxLines,
+				maxBytes,
+			};
+		}
+	}
+
+	// Try native byte-level truncation
+	const native = nativeModule;
+	if (native) {
+		return truncateHeadNative(native, content, maxLines, maxBytes, totalBytes);
+	}
+
+	// JS fallback
+	return truncateHeadJS(content, maxLines, maxBytes, totalBytes);
+}
+
+/**
+ * Native path for truncateHead (keep beginning).
+ * Native `truncateTail` keeps the first N bytes of complete lines.
+ */
+function truncateHeadNative(
+	native: NativeTruncateModule,
+	content: string,
+	maxLines: number,
+	maxBytes: number,
+	totalBytes: number,
+): TruncationResult {
+	// Step 1: byte-level truncation via native
+	const nResult = native.truncateTail(content, maxBytes);
+	const totalLines = nResult.originalLines;
+
+	// Handle firstLineExceedsLimit: native returns empty text with keptLines=0
+	if (nResult.truncated && nResult.keptLines === 0) {
+		return {
+			content: "",
+			truncated: true,
+			truncatedBy: "bytes",
+			totalLines,
+			totalBytes,
+			outputLines: 0,
+			outputBytes: 0,
+			lastLinePartial: false,
+			firstLineExceedsLimit: true,
+			maxLines,
+			maxBytes,
+		};
+	}
+
+	let outputContent = nResult.text;
+	let outputLineCount = nResult.keptLines;
+	let truncatedBy: "lines" | "bytes" | null = nResult.truncated ? "bytes" : null;
+
+	// Step 2: apply line limit on top of the byte-truncated result
+	if (outputLineCount > maxLines) {
+		const lines = outputContent.split("\n");
+		outputContent = lines.slice(0, maxLines).join("\n");
+		outputLineCount = maxLines;
+		truncatedBy = "lines";
+	}
+
+	const outputBytes = Buffer.byteLength(outputContent, "utf-8");
+
+	return {
+		content: outputContent,
+		truncated: truncatedBy !== null,
+		truncatedBy,
+		totalLines,
+		totalBytes,
+		outputLines: outputLineCount,
+		outputBytes,
+		lastLinePartial: false,
+		firstLineExceedsLimit: false,
+		maxLines,
+		maxBytes,
+	};
+}
+
+/**
+ * Pure-JS fallback for truncateHead.
+ */
+function truncateHeadJS(
+	content: string,
+	maxLines: number,
+	maxBytes: number,
+	totalBytes: number,
+): TruncationResult {
 	const lines = content.split("\n");
 	const totalLines = lines.length;
 
@@ -157,8 +302,98 @@ export function truncateHead(content: string, options: TruncationOptions = {}): 
 export function truncateTail(content: string, options: TruncationOptions = {}): TruncationResult {
 	const maxLines = options.maxLines ?? DEFAULT_MAX_LINES;
 	const maxBytes = options.maxBytes ?? DEFAULT_MAX_BYTES;
-
 	const totalBytes = Buffer.byteLength(content, "utf-8");
+
+	// Fast path: no truncation needed
+	if (totalBytes <= maxBytes) {
+		const totalLines = countLines(content);
+		if (totalLines <= maxLines) {
+			return {
+				content,
+				truncated: false,
+				truncatedBy: null,
+				totalLines,
+				totalBytes,
+				outputLines: totalLines,
+				outputBytes: totalBytes,
+				lastLinePartial: false,
+				firstLineExceedsLimit: false,
+				maxLines,
+				maxBytes,
+			};
+		}
+	}
+
+	// Try native byte-level truncation
+	const native = nativeModule;
+	if (native) {
+		return truncateTailNative(native, content, maxLines, maxBytes, totalBytes);
+	}
+
+	// JS fallback
+	return truncateTailJS(content, maxLines, maxBytes, totalBytes);
+}
+
+/**
+ * Native path for truncateTail (keep end).
+ * Native `truncateHead` keeps the last N bytes of complete lines.
+ */
+function truncateTailNative(
+	native: NativeTruncateModule,
+	content: string,
+	maxLines: number,
+	maxBytes: number,
+	totalBytes: number,
+): TruncationResult {
+	// Step 1: byte-level truncation via native
+	const nResult = native.truncateHead(content, maxBytes);
+	const totalLines = nResult.originalLines;
+
+	// Handle edge case: last line exceeds byte limit.
+	// Native returns empty text — but JS truncateTail takes the partial end of the line.
+	// Fall back to JS for this edge case to preserve behavior.
+	if (nResult.truncated && nResult.keptLines === 0) {
+		return truncateTailJS(content, maxLines, maxBytes, totalBytes);
+	}
+
+	let outputContent = nResult.text;
+	let outputLineCount = nResult.keptLines;
+	let truncatedBy: "lines" | "bytes" | null = nResult.truncated ? "bytes" : null;
+
+	// Step 2: apply line limit — keep only the last maxLines lines
+	if (outputLineCount > maxLines) {
+		const lines = outputContent.split("\n");
+		outputContent = lines.slice(lines.length - maxLines).join("\n");
+		outputLineCount = maxLines;
+		truncatedBy = "lines";
+	}
+
+	const outputBytes = Buffer.byteLength(outputContent, "utf-8");
+
+	return {
+		content: outputContent,
+		truncated: truncatedBy !== null,
+		truncatedBy,
+		totalLines,
+		totalBytes,
+		outputLines: outputLineCount,
+		outputBytes,
+		lastLinePartial: false,
+		firstLineExceedsLimit: false,
+		maxLines,
+		maxBytes,
+	};
+}
+
+/**
+ * Pure-JS fallback for truncateTail.
+ */
+function truncateTailJS(
+	content: string,
+	maxLines: number,
+	maxBytes: number,
+	totalBytes: number,
+): TruncationResult {
 	const lines = content.split("\n");
 	const totalLines = lines.length;
 
@@ -248,6 +483,23 @@ function truncateStringToBytesFromEnd(str: string, maxBytes: number): string {
 	}
 
 	return buf.slice(start).toString("utf-8");
+}
+
+/**
+ * Count lines in a string. Matches the convention used by the native module:
+ * a trailing newline does not add an extra line, empty string returns 0.
+ * For compatibility with the existing JS split("\n").length behavior,
+ * this returns the split count.
+ */
+function countLines(content: string): number {
+	if (content.length === 0) return 0;
+	let count = 1;
+	for (let i = 0; i < content.length; i++) {
+		if (content.charCodeAt(i) === 10) count++;
+	}
+	// split("\n") on "a\n" returns ["a", ""] which is length 2.
+	// This matches that behavior.
+	return count;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Wires the native Rust truncation module (`@gsd/native/truncate`) into `packages/pi-coding-agent/src/core/tools/truncate.ts` using a graceful fallback pattern
- Byte-level truncation is delegated to native `truncateTail`/`truncateHead` when the module is available; line-limit enforcement and the partial-line edge case remain in JS on top
- Native module is loaded eagerly on startup and cached; if unavailable, the existing pure-JS implementation is used transparently
- Depends on PR #268 (`feat/native-truncate` branch) which provides the native Rust module and `@gsd/native/truncate` export path

## Design notes
- The native module only supports byte-based truncation (no line limits), so the wiring applies native byte truncation first, then layers JS line-count enforcement on top
- For `truncateTail`'s partial-line edge case (last line exceeds byte limit), the native module returns empty text — the code falls back to JS for this case to preserve existing behavior
- A `countLines()` helper avoids `content.split("\n")` allocation on the fast path (no truncation needed)

## Test plan
- [ ] Verify existing truncation behavior is unchanged when native module is not available (current state)
- [ ] Once `feat/native-truncate` is merged, verify native path is taken and produces equivalent results
- [ ] Test edge cases: empty content, single line exceeding byte limit, content at exact boundary, multi-byte UTF-8

🤖 Generated with [Claude Code](https://claude.com/claude-code)