### PR TITLE
fix: 2.10.5 — correct optionalDependencies version sync (#276)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [2.10.5] - 2026-03-13
+
+### Fixed
+- `optionalDependencies` in published `gsd-pi@2.10.4` were still pinned to `2.10.2`, causing users to install the broken engine binaries that 2.10.4 was meant to fix (#276)
+
 ## [2.10.4] - 2026-03-13
 
 ### Fixed

--- a/native/npm/darwin-arm64/package.json
+++ b/native/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gsd-build/engine-darwin-arm64",
-  "version": "2.10.3",
+  "version": "2.10.5",
   "description": "GSD native engine binary for macOS ARM64",
   "os": [
     "darwin"

--- a/native/npm/darwin-x64/package.json
+++ b/native/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gsd-build/engine-darwin-x64",
-  "version": "2.10.3",
+  "version": "2.10.5",
   "description": "GSD native engine binary for macOS Intel",
   "os": [
     "darwin"

--- a/native/npm/linux-arm64-gnu/package.json
+++ b/native/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gsd-build/engine-linux-arm64-gnu",
-  "version": "2.10.3",
+  "version": "2.10.5",
   "description": "GSD native engine binary for Linux ARM64 (glibc)",
   "os": [
     "linux"

--- a/native/npm/linux-x64-gnu/package.json
+++ b/native/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gsd-build/engine-linux-x64-gnu",
-  "version": "2.10.3",
+  "version": "2.10.5",
   "description": "GSD native engine binary for Linux x64 (glibc)",
   "os": [
     "linux"

--- a/native/npm/win32-x64-msvc/package.json
+++ b/native/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gsd-build/engine-win32-x64-msvc",
-  "version": "2.10.3",
+  "version": "2.10.5",
   "description": "GSD native engine binary for Windows x64 (MSVC)",
   "os": [
     "win32"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gsd-pi",
-  "version": "2.10.4",
+  "version": "2.10.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gsd-pi",
-      "version": "2.10.4",
+      "version": "2.10.5",
       "bundleDependencies": [
         "@gsd/native",
         "@gsd/pi-agent-core",
@@ -44,11 +44,11 @@
         "node": ">=20.6.0"
       },
       "optionalDependencies": {
-        "@gsd-build/engine-darwin-arm64": "2.10.2",
-        "@gsd-build/engine-darwin-x64": "2.10.2",
-        "@gsd-build/engine-linux-arm64-gnu": "2.10.2",
-        "@gsd-build/engine-linux-x64-gnu": "2.10.2",
-        "@gsd-build/engine-win32-x64-msvc": "2.10.2",
+        "@gsd-build/engine-darwin-arm64": "2.10.5",
+        "@gsd-build/engine-darwin-x64": "2.10.5",
+        "@gsd-build/engine-linux-arm64-gnu": "2.10.5",
+        "@gsd-build/engine-linux-x64-gnu": "2.10.5",
+        "@gsd-build/engine-win32-x64-msvc": "2.10.5",
         "fsevents": "~2.3.3"
       }
     },
@@ -837,71 +837,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/@gsd-build/engine-darwin-arm64": {
-      "version": "2.10.2",
-      "resolved": "https://registry.npmjs.org/@gsd-build/engine-darwin-arm64/-/engine-darwin-arm64-2.10.2.tgz",
-      "integrity": "sha512-P+NZReK9FMQM7Nh/z/wX2oZcf+ho5TNlajo/+PuUoVjJZ+XeBCBGXo5j5NgOcNtxUnWL5kStKHFswxDdG8ysMg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@gsd-build/engine-darwin-x64": {
-      "version": "2.10.2",
-      "resolved": "https://registry.npmjs.org/@gsd-build/engine-darwin-x64/-/engine-darwin-x64-2.10.2.tgz",
-      "integrity": "sha512-1TAB1l5MKeKhFLpTcHqHeulIgcoHY3tHoHpXfoImjD6Bto0hsmufikjDoLUobzaJ+5wsqAFH8tL9tGC7LrOEcg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@gsd-build/engine-linux-arm64-gnu": {
-      "version": "2.10.2",
-      "resolved": "https://registry.npmjs.org/@gsd-build/engine-linux-arm64-gnu/-/engine-linux-arm64-gnu-2.10.2.tgz",
-      "integrity": "sha512-NonJ4yUEfYxAUCAtJChtpyOYZJgJh+FTthG2dfQ1wpggoFui4M12kPOSGPwVy3baRojUu5pdI04x8tXs+s7mgA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@gsd-build/engine-linux-x64-gnu": {
-      "version": "2.10.2",
-      "resolved": "https://registry.npmjs.org/@gsd-build/engine-linux-x64-gnu/-/engine-linux-x64-gnu-2.10.2.tgz",
-      "integrity": "sha512-99RiUk0YaK1AsW6UdUq/iAJr+oAPR2nvl9T8JW4MLOjDc3GO2BtGqOC5yzNBGXkcY3CJEOSJI/BuVhdbvSauQQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@gsd-build/engine-win32-x64-msvc": {
-      "version": "2.10.2",
-      "resolved": "https://registry.npmjs.org/@gsd-build/engine-win32-x64-msvc/-/engine-win32-x64-msvc-2.10.2.tgz",
-      "integrity": "sha512-Cu7nFkLqfp/YX7gTiHafV6qP0FfBOKc368feIWH5oG2BNHiptmc9OHrKZTkqycaeT8FWUUmvgac/07tuWwfGyg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
     },
     "node_modules/@gsd/native": {
       "resolved": "packages/native",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gsd-pi",
-  "version": "2.10.4",
+  "version": "2.10.5",
   "description": "GSD — Get Shit Done coding agent",
   "license": "MIT",
   "repository": {
@@ -82,11 +82,11 @@
     "typescript": "^5.4.0"
   },
   "optionalDependencies": {
-    "@gsd-build/engine-darwin-arm64": "2.10.2",
-    "@gsd-build/engine-darwin-x64": "2.10.2",
-    "@gsd-build/engine-linux-x64-gnu": "2.10.2",
-    "@gsd-build/engine-linux-arm64-gnu": "2.10.2",
-    "@gsd-build/engine-win32-x64-msvc": "2.10.2",
+    "@gsd-build/engine-darwin-arm64": "2.10.5",
+    "@gsd-build/engine-darwin-x64": "2.10.5",
+    "@gsd-build/engine-linux-x64-gnu": "2.10.5",
+    "@gsd-build/engine-linux-arm64-gnu": "2.10.5",
+    "@gsd-build/engine-win32-x64-msvc": "2.10.5",
     "fsevents": "~2.3.3"
   },
   "overrides": {


### PR DESCRIPTION
## Summary
- `gsd-pi@2.10.4` shipped with `optionalDependencies` still pinned to `2.10.2` — the broken engine version that 2.10.4 was meant to fix
- Users installing `2.10.4` got `@gsd-build/engine-*@2.10.2` (missing `.node` binaries) instead of `2.10.4` (fixed)
- Bumps to `2.10.5` with all platform package versions and `optionalDependencies` correctly synced

## Root Cause
The `sync-platform-versions.cjs` script was run during `prepublishOnly` but its changes to `package.json` were never committed to the repo before publishing. The 2.10.4 version bump commit only changed `"version": "2.10.4"` in `package.json`, leaving `optionalDependencies` pointing at `2.10.2`.

## Test plan
- [ ] `npm view gsd-pi@2.10.5 optionalDependencies` should show all engine packages at `2.10.5`
- [ ] Fresh install: `npm i -g gsd-pi` loads native addon without error on macOS/Linux/Windows
- [ ] Closes #276

🤖 Generated with [Claude Code](https://claude.com/claude-code)