### PR TITLE
fix: show 'keep current' option in `gsd config` when already authenticated

### DIFF
--- a/src/onboarding.ts
+++ b/src/onboarding.ts
@@ -257,17 +257,30 @@ async function runLlmStep(p: ClackModule, pc: PicoModule, authStorage: AuthStora
   const oauthProviders = authStorage.getOAuthProviders()
   const oauthMap = new Map(oauthProviders.map(op => [op.id, op]))
 
+  // Check if already authenticated
+  const existingAuth = LLM_PROVIDER_IDS.find(id => authStorage.hasAuth(id))
+
   // ── Step 1: How do you want to authenticate? ─────────────────────────────
+  type AuthOption = { value: string; label: string; hint?: string }
+  const authOptions: AuthOption[] = []
+
+  if (existingAuth) {
+    authOptions.push({ value: 'keep', label: `Keep current (${existingAuth})`, hint: 'already configured' })
+  }
+
+  authOptions.push(
+    { value: 'browser', label: 'Sign in with your browser', hint: 'recommended — same login as claude.ai / ChatGPT' },
+    { value: 'api-key', label: 'Paste an API key', hint: 'from your provider dashboard' },
+    { value: 'skip', label: 'Skip for now', hint: 'use /login inside GSD later' },
+  )
+
   const method = await p.select({
-    message: 'How do you want to sign in?',
-    options: [
-      { value: 'browser', label: 'Sign in with your browser', hint: 'recommended — same login as claude.ai / ChatGPT' },
-      { value: 'api-key', label: 'Paste an API key', hint: 'from your provider dashboard' },
-      { value: 'skip', label: 'Skip for now', hint: 'use /login inside GSD later' },
-    ],
+    message: existingAuth ? `LLM provider: ${existingAuth} — change it?` : 'How do you want to sign in?',
+    options: authOptions,
   })
 
   if (p.isCancel(method) || method === 'skip') return false
+  if (method === 'keep') return true
 
   // ── Step 2: Which provider? ──────────────────────────────────────────────
   if (method === 'browser') {
@@ -416,9 +429,18 @@ async function runWebSearchStep(
   const authed = authStorage.list().filter(id => LLM_PROVIDER_IDS.includes(id))
   const isAnthropic = isAnthropicAuth && authed.includes('anthropic')
 
+  // Check if web search is already configured
+  const hasBrave = !!process.env.BRAVE_API_KEY || authStorage.has('brave')
+  const hasTavily = !!process.env.TAVILY_API_KEY || authStorage.has('tavily')
+  const existingSearch = hasBrave ? 'Brave Search' : hasTavily ? 'Tavily' : null
+
   // Build options based on what's available
   type SearchOption = { value: string; label: string; hint?: string }
   const options: SearchOption[] = []
+
+  if (existingSearch) {
+    options.push({ value: 'keep', label: `Keep current (${existingSearch})`, hint: 'already configured' })
+  }
 
   if (isAnthropic) {
     options.push({
@@ -440,6 +462,7 @@ async function runWebSearchStep(
   })
 
   if (p.isCancel(choice) || choice === 'skip') return null
+  if (choice === 'keep') return existingSearch
 
   if (choice === 'anthropic-native') {
     p.log.success(`Web search: ${pc.green('Anthropic built-in')} — works out of the box`)


### PR DESCRIPTION
## Summary

- When running `gsd config` with an existing LLM provider or web search already configured, shows a **Keep current (provider)** option at the top
- Prevents users from having to re-authenticate when they just want to change other settings

## Problem

Running `gsd config` after initial setup forces users through the full auth flow again, even if they only want to change tool keys or web search. There's no way to say "keep what I have".

## After

```
? LLM provider: anthropic — change it?
  ● Keep current (anthropic)        — already configured
  ○ Sign in with your browser
  ○ Paste an API key
  ○ Skip for now

? How do you want to search the web?
  ● Keep current (Brave Search)     — already configured
  ○ Anthropic built-in web search
  ○ Brave Search
  ○ Tavily
  ○ Skip for now
```

## Test plan

- [x] `gsd config` with existing Anthropic auth → shows "Keep current (anthropic)" as first option
- [x] `gsd config` with existing Brave key → shows "Keep current (Brave Search)" in web search step
- [x] Selecting "Keep current" skips re-auth, proceeds to next step
- [x] `gsd config` with no auth → original flow unchanged (no "Keep current" shown)