### PR TITLE
fix: use version ranges for native engine optional dependencies

### DIFF
--- a/native/scripts/sync-platform-versions.cjs
+++ b/native/scripts/sync-platform-versions.cjs
@@ -44,22 +44,10 @@ for (const platform of platformPackages) {
   }
 }
 
-// Update optionalDependencies in root package.json
-let rootChanged = false;
-const optDeps = rootPkg.optionalDependencies || {};
-for (const platform of platformPackages) {
-  const depName = `@gsd-build/engine-${platform}`;
-  if (optDeps[depName] && optDeps[depName] !== version) {
-    console.log(`  root optionalDependencies ${depName}: ${optDeps[depName]} -> ${version}`);
-    optDeps[depName] = version;
-    rootChanged = true;
-  }
-}
-
-if (rootChanged) {
-  rootPkg.optionalDependencies = optDeps;
-  fs.writeFileSync(rootPkgPath, JSON.stringify(rootPkg, null, 2) + "\n");
-  console.log("  Updated root package.json optionalDependencies");
-}
+// Skip updating root optionalDependencies — they use a >=2.10.2 range
+// intentionally so that npm can fall back to the latest available
+// platform binary when the exact version hasn't been published yet
+// (e.g. main package published before native CI finishes).
+console.log("  root optionalDependencies: using range specifiers (not updating)");
 
 console.log("[sync-platform-versions] Done.");

--- a/package.json
+++ b/package.json
@@ -82,11 +82,11 @@
     "typescript": "^5.4.0"
   },
   "optionalDependencies": {
-    "@gsd-build/engine-darwin-arm64": "2.10.5",
-    "@gsd-build/engine-darwin-x64": "2.10.5",
-    "@gsd-build/engine-linux-x64-gnu": "2.10.5",
-    "@gsd-build/engine-linux-arm64-gnu": "2.10.5",
-    "@gsd-build/engine-win32-x64-msvc": "2.10.5",
+    "@gsd-build/engine-darwin-arm64": ">=2.10.2",
+    "@gsd-build/engine-darwin-x64": ">=2.10.2",
+    "@gsd-build/engine-linux-x64-gnu": ">=2.10.2",
+    "@gsd-build/engine-linux-arm64-gnu": ">=2.10.2",
+    "@gsd-build/engine-win32-x64-msvc": ">=2.10.2",
     "fsevents": "~2.3.3"
   },
   "overrides": {


### PR DESCRIPTION
## Summary

- Changes `optionalDependencies` for `@gsd-build/engine-*` from exact version (`2.10.5`) to range (`>=2.10.2`)
- Stops `sync-platform-versions.cjs` from overwriting ranges back to exact versions

## Problem

`gsd-pi@2.10.5` crashes on startup with:

```
Error: Failed to load gsd_engine native addon for darwin-arm64.
Tried:
  - @gsd-build/engine-darwin-arm64: Cannot find module
```

The main package was published to npm before the native CI workflow built and published the platform-specific packages. Since `optionalDependencies` pinned `@gsd-build/engine-darwin-arm64: "2.10.5"` (which doesn't exist on npm), npm silently skips it, and the native loader throws a fatal error.

## Fix

Use `>=2.10.2` range so npm installs the latest available binary. The native N-API interface is stable across patch versions — a 2.10.4 binary works fine with the 2.10.5 JS code.

## Test plan

- [x] `npm install -g gsd-pi@2.10.5` with this fix → installs `@gsd-build/engine-darwin-arm64@2.10.4` (latest available)
- [x] `gsd --version` works without native addon crash
- [x] `sync-platform-versions.cjs` still syncs platform package.json versions but no longer overwrites root optionalDeps ranges