### PR TITLE
feat: add claude-opus-4-6[1m] model with 1M context window

### DIFF
--- a/packages/pi-ai/src/models.generated.ts
+++ b/packages/pi-ai/src/models.generated.ts
@@ -1724,6 +1724,23 @@ export const MODELS = {
 			contextWindow: 200000,
 			maxTokens: 128000,
 		} satisfies Model<"anthropic-messages">,
+		"claude-opus-4-6[1m]": {
+			id: "claude-opus-4-6[1m]",
+			name: "Claude Opus 4.6 (1M)",
+			api: "anthropic-messages",
+			provider: "anthropic",
+			baseUrl: "https://api.anthropic.com",
+			reasoning: true,
+			input: ["text", "image"],
+			cost: {
+				input: 5,
+				output: 25,
+				cacheRead: 0.5,
+				cacheWrite: 6.25,
+			},
+			contextWindow: 1000000,
+			maxTokens: 128000,
+		} satisfies Model<"anthropic-messages">,
 		"claude-sonnet-4-0": {
 			id: "claude-sonnet-4-0",
 			name: "Claude Sonnet 4 (latest)",

--- a/packages/pi-coding-agent/src/core/model-resolver.ts
+++ b/packages/pi-coding-agent/src/core/model-resolver.ts
@@ -214,6 +214,18 @@ export async function resolveModelScope(patterns: string[], modelRegistry: Model
 	const scopedModels: ScopedModel[] = [];
 
 	for (const pattern of patterns) {
+		// Try exact match first (handles model IDs containing glob chars like [1m])
+		const exactResult = parseModelPattern(pattern, availableModels);
+		if (exactResult.model) {
+			if (exactResult.warning) {
+				console.warn(chalk.yellow(`Warning: ${exactResult.warning}`));
+			}
+			if (!scopedModels.find((sm) => modelsAreEqual(sm.model, exactResult.model!))) {
+				scopedModels.push({ model: exactResult.model, thinkingLevel: exactResult.thinkingLevel });
+			}
+			continue;
+		}
+
 		// Check if pattern contains glob characters
 		if (pattern.includes("*") || pattern.includes("?") || pattern.includes("[")) {
 			// Extract optional thinking level suffix (e.g., "provider/*:high")


### PR DESCRIPTION
## Summary
- Add `claude-opus-4-6[1m]` model entry to the Anthropic provider registry with `contextWindow: 1000000`
- Fix `resolveModelScope` to try exact match before glob detection, preventing model IDs with `[` (like `[1m]`) from being misinterpreted as glob patterns

## Test plan
- [ ] `--list-models` shows `claude-opus-4-6[1m]` with 1M context
- [ ] Selecting `claude-opus-4-6[1m]` via model selector resolves correctly
- [ ] Glob patterns (`*sonnet*`, `anthropic/*`) still work as before
- [ ] Build passes with no type errors