### PR TITLE
fix: search provider preference not persisting on update

### DIFF
--- a/src/resources/extensions/search-the-web/provider.ts
+++ b/src/resources/extensions/search-the-web/provider.ts
@@ -58,6 +58,7 @@ export function getSearchProviderPreference(authPath?: string): SearchProviderPr
  */
 export function setSearchProviderPreference(pref: SearchProviderPreference, authPath?: string): void {
   const auth = AuthStorage.create(authPath ?? authFilePath)
+  auth.remove(PREFERENCE_KEY)
   auth.set(PREFERENCE_KEY, { type: 'api_key', key: pref })
 }
 


### PR DESCRIPTION
## Summary
- `setSearchProviderPreference` used `AuthStorage.set()` which appends `api_key` credentials instead of replacing them
- Setting 'brave' then 'tavily' resulted in both stored, with `get()` always returning the first ('brave')
- Fix: call `auth.remove()` before `auth.set()` to clear stale value

Root cause of the test failure blocking #304.

## Test plan
- [x] `setSearchProviderPreference writes to auth.json via AuthStorage` test now passes (was failing)
- [x] All other tests unaffected (259 pass, 3 expected local-only failures for npm pack tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)