### PR TITLE
2.10.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [2.10.8] - 2026-03-14
+
+### Fixed
+- Publish verification checks `dist/loader.js` is non-empty (`-s`) and uses `--ignore-scripts` on `npm pack --dry-run` to match actual publish behaviour (#298)
+
 ## [2.10.7] - 2026-03-14
 
 ### Added
@@ -23,7 +28,6 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Eliminated branch checkout during slice merge that caused STATE.md conflicts (#307)
 - Removed infinite delivery retry loop for background job completions (#301)
 - Display ⌥ instead of Alt for keybindings on macOS (#299)
-- Publish verification checks `dist/loader.js` is non-empty (`-s`) and uses `--ignore-scripts` on `npm pack --dry-run` to match actual publish behaviour (#298)
 
 ### Removed
 - Deprecated legacy dead code from OAuth module
@@ -454,7 +458,8 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Changed
 - License updated to MIT
 
-[Unreleased]: https://github.com/gsd-build/gsd-2/compare/v2.10.7...HEAD
+[Unreleased]: https://github.com/gsd-build/gsd-2/compare/v2.10.8...HEAD
+[2.10.8]: https://github.com/gsd-build/gsd-2/compare/v2.10.7...v2.10.8
 [2.10.7]: https://github.com/gsd-build/gsd-2/compare/v2.10.6...v2.10.7
 [2.10.6]: https://github.com/gsd-build/gsd-2/compare/v2.10.5...v2.10.6
 [2.10.5]: https://github.com/gsd-build/gsd-2/compare/v2.10.4...v2.10.5

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gsd-pi",
-  "version": "2.10.7",
+  "version": "2.10.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gsd-pi",
-      "version": "2.10.7",
+      "version": "2.10.8",
       "bundleDependencies": [
         "@gsd/native",
         "@gsd/pi-agent-core",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gsd-pi",
-  "version": "2.10.7",
+  "version": "2.10.8",
   "description": "GSD — Get Shit Done coding agent",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary
- Version bump to 2.10.8
- CHANGELOG entry for publish verification hardening (#298)

## Test plan
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)