### PR TITLE
fix: truncate long lines in fullRender to prevent TUI crash

### DIFF
--- a/packages/pi-tui/src/tui.ts
+++ b/packages/pi-tui/src/tui.ts
@@ -903,7 +903,9 @@ export class TUI extends Container {
 			if (clear) buffer += "\x1b[3J\x1b[2J\x1b[H"; // Clear scrollback, screen, and home
 			for (let i = 0; i < newLines.length; i++) {
 				if (i > 0) buffer += "\r\n";
-				buffer += newLines[i];
+				const isImage = isImageLine(newLines[i]);
+				const line = (!isImage && visibleWidth(newLines[i]) > width) ? truncateToWidth(newLines[i], width) : newLines[i];
+				buffer += line;
 			}
 			buffer += "\x1b[?2026l"; // End synchronized output
 			this.terminal.write(buffer);


### PR DESCRIPTION
## Summary
- Adds line truncation to the `fullRender` path in `tui.ts`, matching the existing pattern used in the diff-render path
- Prevents crash when rendering code blocks containing very long lines (e.g., minified JS) that exceed terminal width
- Uses the same `isImageLine` / `visibleWidth` / `truncateToWidth` guards already used at line 1074

## Test plan
- [ ] Open pi-tui and render a markdown file containing a code block with a line >1000 chars
- [ ] Verify no crash occurs and the line is truncated at terminal width
- [ ] Verify image lines are not truncated
- [ ] Verify normal content renders unchanged

Fixes #332

🤖 Generated with [Claude Code](https://claude.com/claude-code)