### PR TITLE
fix: handle secrets skip gracefully in auto mode (#296)

### DIFF
--- a/src/resources/extensions/get-secrets-from-user.ts
+++ b/src/resources/extensions/get-secrets-from-user.ts
@@ -286,12 +286,12 @@ export async function showSecretsSummary(
 
 	const existingSet = new Set(existingKeys);
 
-	await (ctx.ui.custom as Function)((tui: any, theme: Theme, _kb: any, done: () => void) => {
+	await ctx.ui.custom((tui: any, theme: Theme, _kb: any, done: (r: null) => void) => {
 		let cachedLines: string[] | undefined;
 
 		function handleInput(_data: string) {
-			// Any key dismisses
-			done();
+			// Any key dismisses — pass null to satisfy the typed done() callback
+			done(null);
 		}
 
 		function render(width: number): string[] {

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -505,14 +505,18 @@ export async function startAuto(
     const manifestStatus = await getManifestStatus(base, mid);
     if (manifestStatus && manifestStatus.pending.length > 0) {
       const result = await collectSecretsFromManifest(base, mid, ctx);
-      ctx.ui.notify(
-        `Secrets collected: ${result.applied.length} applied, ${result.skipped.length} skipped, ${result.existingSkipped.length} already set.`,
-        "info",
-      );
+      if (result && result.applied && result.skipped && result.existingSkipped) {
+        ctx.ui.notify(
+          `Secrets collected: ${result.applied.length} applied, ${result.skipped.length} skipped, ${result.existingSkipped.length} already set.`,
+          "info",
+        );
+      } else {
+        ctx.ui.notify("Secrets collection skipped.", "info");
+      }
     }
   } catch (err) {
     ctx.ui.notify(
-      `Secrets collection error: ${err instanceof Error ? err.message : String(err)}`,
+      `Secrets collection error: ${err instanceof Error ? err.message : String(err)}. Continuing with next task.`,
       "warning",
     );
   }
@@ -1287,14 +1291,18 @@ async function dispatchNextUnit(
       const manifestStatus = await getManifestStatus(basePath, mid);
       if (manifestStatus && manifestStatus.pending.length > 0) {
         const result = await collectSecretsFromManifest(basePath, mid, ctx);
-        ctx.ui.notify(
-          `Secrets collected: ${result.applied.length} applied, ${result.skipped.length} skipped, ${result.existingSkipped.length} already set.`,
-          "info",
-        );
+        if (result && result.applied && result.skipped && result.existingSkipped) {
+          ctx.ui.notify(
+            `Secrets collected: ${result.applied.length} applied, ${result.skipped.length} skipped, ${result.existingSkipped.length} already set.`,
+            "info",
+          );
+        } else {
+          ctx.ui.notify("Secrets collection skipped.", "info");
+        }
       }
     } catch (err) {
       ctx.ui.notify(
-        `Secrets collection error: ${err instanceof Error ? err.message : String(err)}`,
+        `Secrets collection error: ${err instanceof Error ? err.message : String(err)}. Continuing with next task.`,
         "warning",
       );
     }


### PR DESCRIPTION
## Summary
- Removed unsafe `as Function` cast in `showSecretsSummary` and properly typed the `done` callback to pass `null` instead of `undefined`, preventing TUI framework errors during component lifecycle/focus management
- Added defensive null checks around `collectSecretsFromManifest` return value in both secrets gate locations in `auto.ts` (lines ~504 and ~1285), so auto-mode continues gracefully when secrets are skipped
- Updated error notification messages to clarify that auto-mode will continue despite secrets collection errors

## Test plan
- [x] All 12 existing tests pass (`auto-secrets-gate.test.ts` and `collect-from-manifest.test.ts`)
- [ ] Manual: run `/gsd auto` on a milestone with pending secrets, skip all secrets at the prompt, verify no crash and auto-mode continues

Fixes #296

🤖 Generated with [Claude Code](https://claude.com/claude-code)