### PR TITLE
fix: handle empty index after runtime file stripping in squash-merge

### DIFF
--- a/src/resources/extensions/gsd/git-service.ts
+++ b/src/resources/extensions/gsd/git-service.ts
@@ -839,7 +839,15 @@ export class GitServiceImpl {
     }
 
     if (strategy === "squash") {
-      this.git(["commit", "-F", "-"], { input: message });
+      // After stripping runtime files, there may be nothing left to commit.
+      // This happens when the only changes in the slice were runtime artifacts.
+      const stagedDiff = this.git(["diff", "--cached", "--stat"], { allowFailure: true });
+      if (stagedDiff?.trim()) {
+        this.git(["commit", "-F", "-"], { input: message });
+      } else {
+        // Nothing to commit — clean up the squash-merge state
+        this.git(["reset", "HEAD"], { allowFailure: true });
+      }
     } else {
       // --no-ff already committed; amend to include runtime file removal
       const runtimeDiff = this.git(["diff", "--cached", "--stat"], { allowFailure: true });


### PR DESCRIPTION
## Summary

- Fixes the recurring "Slice merge failed — stopping auto-mode" error caused by `git commit -F -` failing when there are no staged changes after runtime file stripping
- After squash-merging a slice branch, runtime files (`.gsd/activity/`, `.gsd/runtime/`, etc.) are removed from the index before committing. If the slice contained **only** runtime artifacts, the index becomes empty and `git commit -F -` exits non-zero
- Adds a `git diff --cached --stat` check before the commit (matching the pattern already used in `commit()` and the `--no-ff` merge path). If nothing is staged, the squash-merge state is reset cleanly instead of throwing

## Test plan

- [ ] Create a slice branch with only runtime file changes (e.g., `.gsd/activity/` updates), mark it done, and verify auto-mode merges it without error
- [ ] Create a slice branch with real code changes + runtime files and verify the squash-merge still commits correctly
- [ ] Verify the `--no-ff` merge strategy path is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)