### PR TITLE
fix(voice): check GROQ_API_KEY before entering voice mode

### DIFF
--- a/src/resources/extensions/voice/index.ts
+++ b/src/resources/extensions/voice/index.ts
@@ -44,6 +44,12 @@ let linuxReady = false;
 function ensureLinuxReady(ctx: ExtensionContext): boolean {
 	if (linuxReady) return true;
 
+	// Check GROQ_API_KEY is available
+	if (!process.env.GROQ_API_KEY) {
+		ctx.ui.notify("Voice: GROQ_API_KEY not set — run 'gsd config' to configure", "error");
+		return false;
+	}
+
 	// Check python3 exists
 	try {
 		execSync("which python3", { stdio: "pipe" });
@@ -211,21 +217,8 @@ export default function (pi: ExtensionAPI) {
 		onReady: () => void,
 	) {
 		if (IS_LINUX) {
-			// Pass GROQ_API_KEY to the Python process — check process.env, then .env file
-			const spawnEnv = { ...process.env };
-			if (!spawnEnv.GROQ_API_KEY) {
-				try {
-					const envPath = path.join(process.cwd(), ".env");
-					const envContent = fs.readFileSync(envPath, "utf-8");
-					const match = envContent.match(/^GROQ_API_KEY=(.+)$/m);
-					if (match) spawnEnv.GROQ_API_KEY = match[1].trim();
-				} catch {
-					// .env not found — Python script will emit ERROR if key needed
-				}
-			}
 			recognizerProcess = spawn(linuxPython(), [PYTHON_SCRIPT], {
 				stdio: ["pipe", "pipe", "pipe"],
-				env: spawnEnv,
 			});
 		} else {
 			recognizerProcess = spawn(RECOGNIZER_BIN, [], { stdio: ["pipe", "pipe", "pipe"] });


### PR DESCRIPTION
## What

- Pre-check `GROQ_API_KEY` in `ensureLinuxReady()` before opening the voice UI
- Remove `.env` file reading hack from `startRecognizer()`

## Why

Without the pre-check, Ctrl+Alt+V opens the voice footer and starts the Python process, which then fails with an error. Now it shows a notification and blocks immediately — the voice UI never opens.

The `.env` reading was a dev workaround. The proper path is `gsd config` → authStorage → `loadStoredEnvKeys()` → `process.env`, which was wired in #366.

## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [x] Tested on Linux (Ubuntu 24.04 — verified voice UI does not open when key is missing, notification shows correctly)

## Checklist

- [x] Follows GSD style (no enterprise patterns, no filler)
- [x] Updates CHANGELOG.md for user-facing changes — N/A (minor fix, no user-visible behavior change beyond better error timing)
- [x] No unnecessary dependencies added
- [ ] Works on Windows (backslash paths tested) — N/A, Linux voice only

## Breaking Changes

None