### PR TITLE
fix: hoist workspace deps into root dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Fallback `--backend=local` for offline faster-whisper on CPU
 - Venv-aware Python detection (`~/.gsd/voice-venv/bin/python3`)
 
+## [2.10.11] - 2026-03-14
+
+### Fixed
+- Hoist workspace package dependencies (undici, anthropic SDK, openai, etc.) into root `dependencies` so they're installed when users run `npm install gsd-pi`. v2.10.10 removed `bundleDependencies` but didn't promote the transitive deps.
+
 ## [2.10.10] - 2026-03-14
 
 ### Fixed
@@ -491,7 +496,8 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Changed
 - License updated to MIT
 
-[Unreleased]: https://github.com/gsd-build/gsd-2/compare/v2.10.10...HEAD
+[Unreleased]: https://github.com/gsd-build/gsd-2/compare/v2.10.11...HEAD
+[2.10.11]: https://github.com/gsd-build/gsd-2/compare/v2.10.10...v2.10.11
 [2.10.10]: https://github.com/gsd-build/gsd-2/compare/v2.10.9...v2.10.10
 [2.10.9]: https://github.com/gsd-build/gsd-2/compare/v2.10.8...v2.10.9
 [2.10.8]: https://github.com/gsd-build/gsd-2/compare/v2.10.7...v2.10.8

--- a/native/npm/darwin-arm64/package.json
+++ b/native/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gsd-build/engine-darwin-arm64",
-  "version": "2.10.10",
+  "version": "2.10.11",
   "description": "GSD native engine binary for macOS ARM64",
   "os": [
     "darwin"

--- a/native/npm/darwin-x64/package.json
+++ b/native/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gsd-build/engine-darwin-x64",
-  "version": "2.10.10",
+  "version": "2.10.11",
   "description": "GSD native engine binary for macOS Intel",
   "os": [
     "darwin"

--- a/native/npm/linux-arm64-gnu/package.json
+++ b/native/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gsd-build/engine-linux-arm64-gnu",
-  "version": "2.10.10",
+  "version": "2.10.11",
   "description": "GSD native engine binary for Linux ARM64 (glibc)",
   "os": [
     "linux"

--- a/native/npm/linux-x64-gnu/package.json
+++ b/native/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gsd-build/engine-linux-x64-gnu",
-  "version": "2.10.10",
+  "version": "2.10.11",
   "description": "GSD native engine binary for Linux x64 (glibc)",
   "os": [
     "linux"

--- a/native/npm/win32-x64-msvc/package.json
+++ b/native/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gsd-build/engine-win32-x64-msvc",
-  "version": "2.10.10",
+  "version": "2.10.11",
   "description": "GSD native engine binary for Windows x64 (MSVC)",
   "os": [
     "win32"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,23 +1,52 @@
 {
   "name": "gsd-pi",
-  "version": "2.10.10",
+  "version": "2.10.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gsd-pi",
-      "version": "2.10.10",
+      "version": "2.10.11",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [
         "packages/*"
       ],
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.73.0",
+        "@aws-sdk/client-bedrock-runtime": "^3.983.0",
         "@clack/prompts": "^1.1.0",
+        "@google/genai": "^1.40.0",
+        "@mariozechner/jiti": "^2.6.2",
+        "@mistralai/mistralai": "1.14.1",
+        "@silvia-odwyer/photon-node": "^0.3.4",
+        "@sinclair/typebox": "^0.34.41",
+        "@types/mime-types": "^2.1.4",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "chalk": "^5.5.0",
+        "diff": "^8.0.2",
+        "extract-zip": "^2.0.1",
+        "file-type": "^21.1.1",
+        "get-east-asian-width": "^1.3.0",
+        "glob": "^13.0.1",
+        "hosted-git-info": "^9.0.2",
+        "ignore": "^7.0.5",
+        "marked": "^15.0.12",
+        "mime-types": "^3.0.1",
+        "minimatch": "^10.2.3",
+        "openai": "6.26.0",
         "picocolors": "^1.1.1",
         "picomatch": "^4.0.3",
         "playwright": "^1.58.2",
-        "sharp": "^0.34.5"
+        "proper-lockfile": "^4.1.2",
+        "proxy-agent": "^6.5.0",
+        "sharp": "^0.34.5",
+        "sql.js": "^1.14.1",
+        "strip-ansi": "^7.1.0",
+        "undici": "^7.19.1",
+        "yaml": "^2.8.2",
+        "zod-to-json-schema": "^3.24.6"
       },
       "bin": {
         "gsd": "dist/loader.js",
@@ -38,7 +67,8 @@
         "@gsd-build/engine-linux-arm64-gnu": ">=2.10.2",
         "@gsd-build/engine-linux-x64-gnu": ">=2.10.2",
         "@gsd-build/engine-win32-x64-msvc": ">=2.10.2",
-        "fsevents": "~2.3.3"
+        "fsevents": "~2.3.3",
+        "koffi": "^2.9.0"
       }
     },
     "node_modules/@anthropic-ai/sdk": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gsd-pi",
-  "version": "2.10.10",
+  "version": "2.10.11",
   "description": "GSD — Get Shit Done coding agent",
   "license": "MIT",
   "repository": {
@@ -62,11 +62,40 @@
     "prepublishOnly": "npm run sync-pkg-version && npm run sync-platform-versions && git diff --exit-code || (echo 'ERROR: version sync changed files — commit them before publishing' && exit 1) && npm run build && npm run validate-pack"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.73.0",
+    "@aws-sdk/client-bedrock-runtime": "^3.983.0",
     "@clack/prompts": "^1.1.0",
+    "@google/genai": "^1.40.0",
+    "@mariozechner/jiti": "^2.6.2",
+    "@mistralai/mistralai": "1.14.1",
+    "@silvia-odwyer/photon-node": "^0.3.4",
+    "@sinclair/typebox": "^0.34.41",
+    "@types/mime-types": "^2.1.4",
+    "ajv": "^8.17.1",
+    "ajv-formats": "^3.0.1",
+    "chalk": "^5.5.0",
+    "diff": "^8.0.2",
+    "extract-zip": "^2.0.1",
+    "file-type": "^21.1.1",
+    "get-east-asian-width": "^1.3.0",
+    "glob": "^13.0.1",
+    "hosted-git-info": "^9.0.2",
+    "ignore": "^7.0.5",
+    "marked": "^15.0.12",
+    "mime-types": "^3.0.1",
+    "minimatch": "^10.2.3",
+    "openai": "6.26.0",
     "picocolors": "^1.1.1",
     "picomatch": "^4.0.3",
     "playwright": "^1.58.2",
-    "sharp": "^0.34.5"
+    "proper-lockfile": "^4.1.2",
+    "proxy-agent": "^6.5.0",
+    "sharp": "^0.34.5",
+    "sql.js": "^1.14.1",
+    "strip-ansi": "^7.1.0",
+    "undici": "^7.19.1",
+    "yaml": "^2.8.2",
+    "zod-to-json-schema": "^3.24.6"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",
@@ -80,7 +109,8 @@
     "@gsd-build/engine-linux-x64-gnu": ">=2.10.2",
     "@gsd-build/engine-linux-arm64-gnu": ">=2.10.2",
     "@gsd-build/engine-win32-x64-msvc": ">=2.10.2",
-    "fsevents": "~2.3.3"
+    "fsevents": "~2.3.3",
+    "koffi": "^2.9.0"
   },
   "overrides": {
     "gaxios": "7.1.4"


### PR DESCRIPTION
## Summary
- v2.10.10 removed `bundleDependencies` but didn't promote transitive deps into root `dependencies`
- Users got `ERR_MODULE_NOT_FOUND: Cannot find package 'undici'` on install
- Hoists all 29 workspace package deps (undici, anthropic SDK, openai, chalk, etc.) into root dependencies
- Bumps to v2.10.11

## Test plan
- [x] `npm run validate-pack` passes (272 packages install cleanly)
- [x] `npm run build` succeeds
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)