### PR TITLE
fix: increase timeout for z.ai provider (#379)

### DIFF
--- a/packages/pi-ai/src/providers/openai-completions.ts
+++ b/packages/pi-ai/src/providers/openai-completions.ts
@@ -357,11 +357,14 @@ function createClient(
 		Object.assign(headers, optionsHeaders);
 	}
 
+	const isZai = model.provider === "zai" || model.baseUrl.includes("api.z.ai");
+
 	return new OpenAI({
 		apiKey,
 		baseURL: model.baseUrl,
 		dangerouslyAllowBrowser: true,
 		defaultHeaders: headers,
+		...(isZai && { timeout: 100_000, maxRetries: 4 }),
 	});
 }
 


### PR DESCRIPTION
## Summary
- Increases OpenAI SDK `timeout` to 100,000ms and `maxRetries` to 4 for z.ai provider
- Detects z.ai via `model.provider === "zai"` or `baseUrl.includes("api.z.ai")`, matching existing detection in `detectCompat`
- Fixes network_error failures caused by z.ai API latency spikes

Closes #379

## Test plan
- [ ] Verify z.ai provider connections no longer fail with network_error on slow responses
- [ ] Verify non-z.ai providers retain default timeout/retry behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)