### PR TITLE
fix: add missing front matter to github-workflows skill

### DIFF
--- a/src/resources/skills/github-workflows/SKILL.md
+++ b/src/resources/skills/github-workflows/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: github-workflows
+description: Work with GitHub Actions CI/CD workflows - read live syntax, monitor runs, and debug failures. Use when writing, running, or debugging GitHub Actions workflows.
+---
+
 # GitHub Workflows
 
 **Mission:** Work with GitHub Actions without using stale training data. All syntax, versions, and parameters come from live sources.


### PR DESCRIPTION
Reproduce:

```
gsd
/gsd prefs
```

Error:
<img width="653" height="253" alt="CleanShot 2026-03-14 at 15 14 55" src="https://github.com/user-attachments/assets/95a322f1-63ac-4c05-b25d-b9da67ce1372" />


Adds required YAML front matter metadata to the github-workflows skill definition.

The skill was not loading because the required front matter (name, description) was missing from the skill file. This commit adds the necessary metadata block to enable proper skill registration and discovery.
