### PR TITLE
fix: increase timeout for z.ai provider (#379)

### DIFF
--- a/packages/pi-ai/src/providers/openai-completions.ts
+++ b/packages/pi-ai/src/providers/openai-completions.ts
@@ -357,11 +357,14 @@ function createClient(
 		Object.assign(headers, optionsHeaders);
 	}
 
+	const isZai = model.provider === "zai" || model.baseUrl.includes("api.z.ai");
+
 	return new OpenAI({
 		apiKey,
 		baseURL: model.baseUrl,
 		dangerouslyAllowBrowser: true,
 		defaultHeaders: headers,
+		...(isZai && { timeout: 100_000, maxRetries: 4 }),
 	});
 }
 


### PR DESCRIPTION
## Summary
- Detects z.ai provider via `model.provider === "zai"` or `baseUrl` containing `api.z.ai`
- Sets `timeout: 100_000` (100s) and `maxRetries: 4` for z.ai clients only
- Other providers keep default SDK timeout/retry behavior

Fixes #379