### PR TITLE
perf: reduce dispatch gap timeout from 30s to 5s

### DIFF
--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -171,7 +171,7 @@ let idleWatchdogHandle: ReturnType<typeof setInterval> | null = null;
  *  re-evaluation. Covers the case where dispatchNextUnit silently fails or
  *  an unhandled error kills the dispatch chain. */
 let dispatchGapHandle: ReturnType<typeof setTimeout> | null = null;
-const DISPATCH_GAP_TIMEOUT_MS = 30_000; // 30 seconds
+const DISPATCH_GAP_TIMEOUT_MS = 5_000; // 5 seconds
 
 /** SIGTERM handler registered while auto-mode is active — cleared on stop/pause. */
 let _sigtermHandler: (() => void) | null = null;


### PR DESCRIPTION
## Summary
- Reduces `DISPATCH_GAP_TIMEOUT_MS` from 30s to 5s in `src/resources/extensions/gsd/auto.ts`
- This timeout is a safety watchdog for when the dispatch chain silently breaks — 5s is sufficient to detect a stall without making failures feel sluggish

## Test plan
- [ ] Verify build passes (confirmed locally)
- [ ] Run auto-mode and confirm dispatch gap recovery still triggers correctly at 5s

🤖 Generated with [Claude Code](https://claude.com/claude-code)