### PR TITLE
fix: restore version 2.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gsd-pi",
-  "version": "2.10.12",
+  "version": "2.11.0",
   "description": "GSD — Get Shit Done coding agent",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Copilot Autofix (1ab0d07a) reverted the version bump from 2.11.0 back to 2.10.12 during the release PR. This restores it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)