### PR TITLE
fix(ci): smoke test handles banner output

### DIFF
--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -220,13 +220,16 @@ jobs:
             if npm install "gsd-pi@${VERSION}" 2>&1 | tee /tmp/install-output.txt; then
               echo "  ✓ Install succeeded"
               # Run version check via node directly (npx may resolve wrong binary)
-              ACTUAL=$(node node_modules/gsd-pi/dist/loader.js --version 2>&1 || echo "FAILED")
+              # Strip ANSI escape codes and match version on any line (--version prints a banner)
+              RAW=$(node node_modules/gsd-pi/dist/loader.js --version 2>&1 || echo "FAILED")
+              ACTUAL=$(echo "$RAW" | sed 's/\x1b\[[0-9;]*m//g' | grep -oE "^${VERSION}$" | head -1)
               if [ "$ACTUAL" = "$VERSION" ]; then
                 echo "  ✓ gsd --version = ${VERSION}"
                 echo "Published package is functional"
                 exit 0
               else
-                echo "::error::Version mismatch: expected ${VERSION}, got ${ACTUAL}"
+                echo "::error::Version mismatch: expected ${VERSION} in output:"
+                echo "$RAW"
                 exit 1
               fi
             fi


### PR DESCRIPTION
## Summary
- Strip ANSI escape codes from `--version` output before matching
- Grep for version on any line instead of comparing entire output
- Prevents false-negative failures on every release since the banner was added

## Test plan
- [ ] Next `v*` tag push should pass the smoke test step

🤖 Generated with [Claude Code](https://claude.com/claude-code)