### PR TITLE
🚨 URGENT: release v2.11.1 — auto-mode hard-stops on research-slice/plan-slice (stale dir cache)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [2.11.1] - 2026-03-15
+
+### Fixed
+- **URGENT: auto-mode loops on research-slice and plan-slice** — `handleAgentEnd` called `invalidateStateCache()` but not `clearPathCache()` or `clearParseCache()`. The in-process directory listing cache in `paths.ts` retained the pre-subagent empty directory snapshot, so `resolveSliceFile()` returned `null` for artifacts the subagent had just written. This caused `dispatchNextUnit` to re-dispatch the same unit (`research-slice` or `plan-slice`) instead of advancing, incrementing the dispatch counter until the `MAX_UNIT_DISPATCHES=3` limit triggered a hard stop with "Loop detected" (#421)
+
 ## [2.11.0] - 2026-03-14
 
 ### Added

--- a/native/npm/darwin-arm64/package.json
+++ b/native/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gsd-build/engine-darwin-arm64",
-  "version": "2.11.0",
+  "version": "2.11.1",
   "description": "GSD native engine binary for macOS ARM64",
   "os": [
     "darwin"

--- a/native/npm/darwin-x64/package.json
+++ b/native/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gsd-build/engine-darwin-x64",
-  "version": "2.11.0",
+  "version": "2.11.1",
   "description": "GSD native engine binary for macOS Intel",
   "os": [
     "darwin"

--- a/native/npm/linux-arm64-gnu/package.json
+++ b/native/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gsd-build/engine-linux-arm64-gnu",
-  "version": "2.11.0",
+  "version": "2.11.1",
   "description": "GSD native engine binary for Linux ARM64 (glibc)",
   "os": [
     "linux"

--- a/native/npm/linux-x64-gnu/package.json
+++ b/native/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gsd-build/engine-linux-x64-gnu",
-  "version": "2.11.0",
+  "version": "2.11.1",
   "description": "GSD native engine binary for Linux x64 (glibc)",
   "os": [
     "linux"

--- a/native/npm/win32-x64-msvc/package.json
+++ b/native/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gsd-build/engine-win32-x64-msvc",
-  "version": "2.11.0",
+  "version": "2.11.1",
   "description": "GSD native engine binary for Windows x64 (MSVC)",
   "os": [
     "win32"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gsd-pi",
-  "version": "2.11.0",
+  "version": "2.11.1",
   "description": "GSD — Get Shit Done coding agent",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## 🚨 Urgent — Production Regression in v2.11.0

**Every auto-mode run hard-stops after the first or second unit** with:

```
Error: Loop detected: research-slice M001/S01 dispatched 4 times total. Expected artifact not found.
   Expected: .gsd/milestones/M001/slices/S01/S01-RESEARCH.md (slice research)
```

or

```
Error: Loop detected: plan-slice M001/S01 dispatched 4 times total. Expected artifact not found.
   Expected: .gsd/milestones/M001/slices/S01/S01-PLAN.md (slice plan)
```

The artifact **exists on disk and is committed to git**. The loop detector is firing because of a stale in-process cache, not a real failure.

---

## Root Cause

v2.11.0 introduced a **session-scoped directory listing cache** in `paths.ts` (`cachedReaddir`) to speed up the `deriveState()` hotpath. The bug: it was **never cleared between dispatch cycles**.

**What happens at runtime:**

1. `dispatchNextUnit` calls `resolveSliceFile()` to check if the research artifact exists. The `S01/` directory is empty — `cachedReaddir` reads it, caches `[]`. Correct — nothing written yet.
2. `research-slice` dispatches. Subagent runs, **writes `S01-RESEARCH.md` to disk**, auto-committed.
3. `handleAgentEnd` fires. Calls `invalidateStateCache()` to reset `deriveState` memoization — **but never calls `clearPathCache()`**. The `dirListCache` Map entry for `S01/` still holds `[]`.
4. `dispatchNextUnit` runs again. `resolveSliceFile()` → stale cache → `S01/` still looks empty → returns `null` → `hasResearch = false` → dispatches `research-slice` **again**.
5. `closeoutKey === incomingKey` (same unit) → `persistCompletedKey` is **skipped**. Dispatch counter increments.
6. After 3 retries → "Loop detected. Expected artifact not found."

Same sequence repeats for `plan-slice` on the next run.

**Confirmed by activity logs:** all three `research-slice` sessions wrote the file successfully (10KB, 11KB, 27KB respectively, all verifiable in git commits). The pipeline never saw the writes.

---

## The Fix

`clearPathCache()` was added in commit `56d03d37` (merged as PR #421) — **after the v2.11.0 tag**. The published npm package does not include it.

### What the fix does

Every `invalidateStateCache()` call is now paired with `clearPathCache()` and `clearParseCache()`. Four callsites in `auto.ts`:

| Location | When |
|---|---|
| `handleAgentEnd` | After every unit completes — **the primary fix** |
| `startAuto` self-heal path | On startup, after clearing stale runtime records |
| Post-fix-merge re-derive | After resolving merge conflicts |
| Post-slice-merge re-derive | After squash-merging a completed slice branch |

---

## Impact

- **Severity:** Critical. Blocks all auto-mode usage after the first unit on a fresh milestone.
- **Affected version:** v2.11.0 only (cache was introduced in this release).
- **Fix already merged to main:** Yes — commit `56d03d37` / PR #421.
- **This PR:** Version bump + changelog only. Zero new code changes.

---

## Changes

- `CHANGELOG.md` — v2.11.1 entry
- `package.json` — 2.11.0 → 2.11.1
- `native/npm/*/package.json` — 2.11.0 → 2.11.1 (5 platform packages)

The actual code fix is already in main via #421. This is a release-cut PR only.