### PR TITLE
fix: clear cachedReaddir before dispatch and artifact verification

### DIFF
--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -1380,6 +1380,9 @@ async function dispatchNextUnit(
     return;
   }
 
+  // Clear stale directory listing cache so deriveState sees fresh disk state (#431)
+  clearPathCache();
+
   let state = await deriveState(basePath);
   let mid = state.activeMilestone?.id;
   let midTitle = state.activeMilestone?.title;
@@ -3555,6 +3558,9 @@ export function resolveExpectedArtifactPath(unitType: string, unitId: string, ba
  * skipped writing the UAT file (see #176).
  */
 export function verifyExpectedArtifact(unitType: string, unitId: string, base: string): boolean {
+  // Clear stale directory listing cache so artifact checks see fresh disk state (#431)
+  clearPathCache();
+
   // fix-merge has no file artifact — verify by checking git state
   if (unitType === "fix-merge") {
     const unmerged = runGit(base, ["diff", "--name-only", "--diff-filter=U"], { allowFailure: true });


### PR DESCRIPTION
## Summary
- Adds `clearPathCache()` at the top of `dispatchNextUnit()` before `deriveState()` so each dispatch cycle reads fresh directory listings from disk
- Adds `clearPathCache()` at the top of `verifyExpectedArtifact()` so artifact checks see newly written files
- Fixes infinite dispatch loop when `complete-milestone` (or any unit) writes a file that the next `deriveState` call needs to detect

## Root Cause
`cachedReaddir()` in `paths.ts` uses a process-lifetime `Map` with no TTL and no invalidation in production. When a unit writes a new file (e.g. `MXXX-SUMMARY.md`), the stale cache causes `deriveState` to miss it, re-dispatching the same unit until `MAX_UNIT_DISPATCHES` fires.

## Test plan
- [x] Build passes
- [x] `unit-runtime` tests pass
- [ ] Verify in auto-mode that `complete-milestone` no longer loops

Closes #431

🤖 Generated with [Claude Code](https://claude.com/claude-code)