### PR TITLE
fix(guided-flow): add self-heal for stale runtime records on wizard start

### DIFF
--- a/src/resources/extensions/gsd/guided-flow.ts
+++ b/src/resources/extensions/gsd/guided-flow.ts
@@ -13,6 +13,8 @@ import { loadPrompt, inlineTemplate } from "./prompt-loader.js";
 import { deriveState } from "./state.js";
 import { startAuto } from "./auto.js";
 import { readCrashLock, clearLock, formatCrashInfo } from "./crash-recovery.js";
+import { listUnitRuntimeRecords, clearUnitRuntimeRecord } from "./unit-runtime.js";
+import { resolveExpectedArtifactPath } from "./auto.js";
 import {
   gsdRoot, milestonesDir, resolveMilestoneFile, resolveMilestonePath,
   resolveSliceFile, resolveSlicePath, resolveGsdRootFile, relGsdRootFile,
@@ -518,6 +520,42 @@ export async function showDiscuss(
 /**
  * The one wizard. Reads state, shows contextual options, dispatches into the workflow doc.
  */
+/**
+ * Self-heal: scan runtime records and clear stale ones left behind when
+ * auto-mode crashed mid-unit. auto.ts has its own selfHealRuntimeRecords()
+ * but guided-flow (manual /gsd mode) never called it — meaning stale records
+ * persisted until the next /gsd auto run.  This ensures the wizard always
+ * starts from a clean state regardless of how the previous session ended.
+ */
+function selfHealRuntimeRecords(basePath: string, ctx: ExtensionContext): { cleared: number } {
+  try {
+    const records = listUnitRuntimeRecords(basePath);
+    let cleared = 0;
+    for (const record of records) {
+      const { unitType, unitId, phase } = record;
+      // Clear records whose expected artifact already exists (completed but not cleaned up)
+      const artifactPath = resolveExpectedArtifactPath(unitType, unitId, basePath);
+      if (artifactPath && existsSync(artifactPath)) {
+        clearUnitRuntimeRecord(basePath, unitType, unitId);
+        cleared++;
+        continue;
+      }
+      // Clear records stuck in dispatched or timeout phase (process died mid-unit)
+      if (phase === "dispatched" || phase === "timeout") {
+        clearUnitRuntimeRecord(basePath, unitType, unitId);
+        cleared++;
+      }
+    }
+    if (cleared > 0) {
+      ctx.ui.notify(`Self-heal: cleared ${cleared} stale runtime record(s) from a previous session.`, "info");
+    }
+    return { cleared };
+  } catch {
+    // Non-fatal — self-heal should never block the wizard
+    return { cleared: 0 };
+  }
+}
+
 export async function showSmartEntry(
   ctx: ExtensionCommandContext,
   pi: ExtensionAPI,
@@ -555,6 +593,9 @@ export async function showSmartEntry(
       // nothing to commit — that's fine
     }
   }
+
+  // ── Self-heal stale runtime records from crashed auto-mode sessions ──
+  selfHealRuntimeRecords(basePath, ctx);
 
   // Check for crash from previous auto-mode session
   const crashLock = readCrashLock(basePath);


### PR DESCRIPTION
## Problem

`auto.ts` has `selfHealRuntimeRecords()` which cleans up stale `.gsd/runtime/units/` records when `/gsd auto` starts. However, `guided-flow.ts` (used by `/gsd` manual mode) has **zero awareness of runtime records** — it only checks `auto.lock`.

This means if auto-mode crashes mid-unit, the stale runtime records persist until the next `/gsd auto` run. Users who:
- Alternate between manual and auto mode
- Only use manual mode after a crash

...would accumulate stale records that could cause spurious re-dispatch or confusing state.

## Fix

Add `selfHealRuntimeRecords()` to `guided-flow.ts` that:
1. **Clears records where the expected artifact already exists** — unit completed but closeout didn't finish
2. **Clears records stuck in `dispatched` or `timeout` phase** — process died mid-unit
3. **Notifies the user** how many stale records were cleaned

Called in `showSmartEntry()` before the crash lock check, so the wizard always starts from a clean state regardless of how the previous session ended.

## Changes

- `src/resources/extensions/gsd/guided-flow.ts` — added imports for `listUnitRuntimeRecords`, `clearUnitRuntimeRecord`, and `resolveExpectedArtifactPath`; added `selfHealRuntimeRecords()` function; called it at the top of `showSmartEntry()`

## Verification

- TypeScript compiles cleanly (`tsc --noEmit` passes)
- Non-fatal: wrapped in try/catch so self-heal never blocks wizard startup