### PR TITLE
feat(gsd): import Claude skills and plugins into GSD/Pi config

### DIFF
--- a/src/resources/extensions/gsd/claude-import.ts
+++ b/src/resources/extensions/gsd/claude-import.ts
@@ -1,0 +1,305 @@
+import type { ExtensionCommandContext } from "@gsd/pi-coding-agent";
+import { SettingsManager, getAgentDir } from "@gsd/pi-coding-agent";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { basename, dirname, join, relative, resolve } from "node:path";
+import { homedir } from "node:os";
+
+export interface ClaudeSkillCandidate {
+  type: "skill";
+  name: string;
+  path: string;
+  root: string;
+  sourceLabel: string;
+}
+
+export interface ClaudePluginCandidate {
+  type: "plugin";
+  name: string;
+  path: string;
+  root: string;
+  sourceLabel: string;
+  packageName?: string;
+}
+
+const SKIP_DIRS = new Set([
+  ".git",
+  "node_modules",
+  ".worktrees",
+  "dist",
+  "build",
+  ".next",
+  ".turbo",
+  "cache",
+  ".cache",
+]);
+
+function uniqueExistingDirs(paths: string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const candidate of paths) {
+    const resolvedPath = resolve(candidate);
+    if (seen.has(resolvedPath)) continue;
+    seen.add(resolvedPath);
+    if (existsSync(resolvedPath)) out.push(resolvedPath);
+  }
+  return out;
+}
+
+export function getClaudeSearchRoots(cwd: string): { skillRoots: string[]; pluginRoots: string[] } {
+  const home = homedir();
+  const parent = resolve(cwd, "..");
+  const grandparent = resolve(cwd, "..", "..");
+
+  const skillRoots = uniqueExistingDirs([
+    join(home, ".claude", "skills"),
+    join(home, "repos", "claude_skills"),
+    join(home, "repos", "skills"),
+    join(parent, "claude_skills"),
+    join(parent, "skills"),
+    join(grandparent, "claude_skills"),
+    join(grandparent, "skills"),
+  ]);
+
+  const pluginRoots = uniqueExistingDirs([
+    join(home, ".claude", "plugins"),
+    join(home, "repos", "claude-plugins-official"),
+    join(home, "repos", "claude_skills"),
+    join(parent, "claude-plugins-official"),
+    join(parent, "claude_skills"),
+    join(grandparent, "claude-plugins-official"),
+    join(grandparent, "claude_skills"),
+  ]);
+
+  return { skillRoots, pluginRoots };
+}
+
+function sourceLabel(path: string): string {
+  const home = homedir();
+  if (path.startsWith(join(home, ".claude"))) return "claude-home";
+  if (path.startsWith(join(home, "repos"))) return "repos";
+  return "local";
+}
+
+function walkDirs(root: string, visit: (dir: string, depth: number) => void, maxDepth = 4): void {
+  function walk(dir: string, depth: number) {
+    visit(dir, depth);
+    if (depth >= maxDepth) return;
+    let entries: Array<{ name: string; isDirectory: () => boolean }> = [];
+    try {
+      entries = readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      if (SKIP_DIRS.has(entry.name)) continue;
+      walk(join(dir, entry.name), depth + 1);
+    }
+  }
+  walk(root, 0);
+}
+
+export function discoverClaudeSkills(cwd: string): ClaudeSkillCandidate[] {
+  const { skillRoots } = getClaudeSearchRoots(cwd);
+  const results: ClaudeSkillCandidate[] = [];
+  const seen = new Set<string>();
+
+  for (const root of skillRoots) {
+    walkDirs(root, (dir) => {
+      const skillFile = join(dir, "SKILL.md");
+      if (!existsSync(skillFile)) return;
+      const resolvedDir = resolve(dir);
+      if (seen.has(resolvedDir)) return;
+      seen.add(resolvedDir);
+      results.push({
+        type: "skill",
+        name: basename(dir),
+        path: resolvedDir,
+        root,
+        sourceLabel: sourceLabel(root),
+      });
+    }, 5);
+  }
+
+  return results.sort((a, b) => a.name.localeCompare(b.name) || a.path.localeCompare(b.path));
+}
+
+export function discoverClaudePlugins(cwd: string): ClaudePluginCandidate[] {
+  const { pluginRoots } = getClaudeSearchRoots(cwd);
+  const results: ClaudePluginCandidate[] = [];
+  const seen = new Set<string>();
+
+  for (const root of pluginRoots) {
+    walkDirs(root, (dir) => {
+      const pkgPath = join(dir, "package.json");
+      if (!existsSync(pkgPath)) return;
+      const resolvedDir = resolve(dir);
+      if (seen.has(resolvedDir)) return;
+      seen.add(resolvedDir);
+      let packageName: string | undefined;
+      try {
+        const pkg = JSON.parse(readFileSync(pkgPath, "utf8")) as { name?: string };
+        packageName = pkg.name;
+      } catch {
+        packageName = undefined;
+      }
+      results.push({
+        type: "plugin",
+        name: packageName || basename(dir),
+        packageName,
+        path: resolvedDir,
+        root,
+        sourceLabel: sourceLabel(root),
+      });
+    }, 4);
+  }
+
+  return results.sort((a, b) => a.name.localeCompare(b.name) || a.path.localeCompare(b.path));
+}
+
+async function chooseMany<T extends { name: string; path: string; root: string; sourceLabel: string }>(
+  ctx: ExtensionCommandContext,
+  title: string,
+  candidates: T[],
+): Promise<T[]> {
+  if (candidates.length === 0) return [];
+
+  const mode = await ctx.ui.select(`${title} (${candidates.length} found)`, [
+    "Import all discovered",
+    "Select individually",
+    "Cancel",
+  ]);
+
+  if (!mode || mode === "Cancel") return [];
+  if (mode === "Import all discovered") return candidates;
+
+  const remaining = [...candidates];
+  const selected: T[] = [];
+  while (remaining.length > 0) {
+    const options = [
+      ...remaining.map((item) => `${item.name} — ${item.sourceLabel} — ${relative(item.root, item.path) || "."}`),
+      "Done selecting",
+    ];
+    const picked = await ctx.ui.select(`${title}: choose an item`, options);
+    if (!picked || picked === "Done selecting") break;
+    const idx = options.indexOf(picked);
+    if (idx < 0 || idx >= remaining.length) break;
+    selected.push(remaining[idx]!);
+    remaining.splice(idx, 1);
+  }
+  return selected;
+}
+
+function mergeStringList(existing: unknown, additions: string[]): string[] {
+  const list = Array.isArray(existing) ? existing.filter((v): v is string => typeof v === "string") : [];
+  const seen = new Set(list);
+  for (const item of additions) {
+    if (!seen.has(item)) {
+      list.push(item);
+      seen.add(item);
+    }
+  }
+  return list;
+}
+
+function mergePackageSources(existing: unknown, additions: string[]): Array<string | { source: string }> {
+  const current = Array.isArray(existing)
+    ? existing.filter((v): v is string | { source: string } => typeof v === "string" || (typeof v === "object" && v !== null && typeof (v as { source?: unknown }).source === "string"))
+    : [];
+
+  const seen = new Set(current.map((entry) => typeof entry === "string" ? entry : entry.source));
+  const merged = [...current];
+  for (const add of additions) {
+    if (!seen.has(add)) {
+      merged.push(add);
+      seen.add(add);
+    }
+  }
+  return merged;
+}
+
+export async function runClaudeImportFlow(
+  ctx: ExtensionCommandContext,
+  scope: "global" | "project",
+  readPrefs: () => Record<string, unknown>,
+  writePrefs: (prefs: Record<string, unknown>) => Promise<void>,
+): Promise<void> {
+  const cwd = process.cwd();
+  const settingsManager = SettingsManager.create(cwd, getAgentDir());
+
+  const assetChoice = await ctx.ui.select("Import Claude assets into GSD/Pi config", [
+    "Skills + plugins",
+    "Skills only",
+    "Plugins only",
+    "Cancel",
+  ]);
+  if (!assetChoice || assetChoice === "Cancel") return;
+
+  const importSkills = assetChoice !== "Plugins only";
+  const importPlugins = assetChoice !== "Skills only";
+
+  const discoveredSkills = importSkills ? discoverClaudeSkills(cwd) : [];
+  const discoveredPlugins = importPlugins ? discoverClaudePlugins(cwd) : [];
+
+  const selectedSkills = importSkills
+    ? await chooseMany(ctx, `Claude skills → ${scope} preferences`, discoveredSkills)
+    : [];
+  const selectedPlugins = importPlugins
+    ? await chooseMany(ctx, `Claude plugins/packages → ${scope} Pi settings`, discoveredPlugins)
+    : [];
+
+  if (selectedSkills.length === 0 && selectedPlugins.length === 0) {
+    ctx.ui.notify("Claude import cancelled or nothing selected.", "info");
+    return;
+  }
+
+  if (selectedSkills.length > 0) {
+    const prefMode = await ctx.ui.select("How should GSD treat the imported skills?", [
+      "Always use when relevant",
+      "Prefer when relevant",
+      "Do not modify skill preferences",
+    ]);
+
+    const prefs = readPrefs();
+    const skillPaths = selectedSkills.map((skill) => skill.path);
+    if (prefMode === "Always use when relevant") {
+      prefs.always_use_skills = mergeStringList(prefs.always_use_skills, skillPaths);
+    } else if (prefMode === "Prefer when relevant") {
+      prefs.prefer_skills = mergeStringList(prefs.prefer_skills, skillPaths);
+    }
+
+    await writePrefs(prefs);
+
+    if (scope === "project") {
+      settingsManager.setProjectSkillPaths(mergeStringList(settingsManager.getProjectSettings().skills, skillPaths));
+    } else {
+      settingsManager.setSkillPaths(mergeStringList(settingsManager.getGlobalSettings().skills, skillPaths));
+    }
+  }
+
+  if (selectedPlugins.length > 0) {
+    const pluginPaths = selectedPlugins.map((plugin) => plugin.path);
+    if (scope === "project") {
+      settingsManager.setProjectPackages(mergePackageSources(settingsManager.getProjectSettings().packages, pluginPaths));
+    } else {
+      settingsManager.setPackages(mergePackageSources(settingsManager.getGlobalSettings().packages, pluginPaths));
+    }
+  }
+
+  await ctx.waitForIdle();
+  await ctx.reload();
+
+  const lines = [
+    `Imported Claude assets into ${scope} config:`,
+    `- Skills: ${selectedSkills.length}`,
+    `- Plugins/packages: ${selectedPlugins.length}`,
+  ];
+  if (selectedSkills.length > 0) {
+    lines.push(`- Skill paths added to Pi settings (${scope}) for availability`);
+    lines.push(`- Skill refs added to GSD preferences (${scope}) when selected`);
+  }
+  if (selectedPlugins.length > 0) {
+    lines.push(`- Plugin/package paths added to Pi settings (${scope}) packages`);
+  }
+  ctx.ui.notify(lines.join("\n"), "info");
+}

--- a/src/resources/extensions/gsd/commands.ts
+++ b/src/resources/extensions/gsd/commands.ts
@@ -21,7 +21,8 @@ import {
   loadEffectiveGSDPreferences,
   resolveAllSkillReferences,
 } from "./preferences.js";
-import { loadFile, saveFile } from "./files.js";
+import { loadFile, saveFile, splitFrontmatter, parseFrontmatterMap } from "./files.js";
+import { runClaudeImportFlow } from "./claude-import.js";
 import {
   formatDoctorIssuesForPrompt,
   formatDoctorReport,
@@ -74,7 +75,7 @@ export function registerGSDCommand(pi: ExtensionAPI): void {
 
       if (parts[0] === "prefs" && parts.length <= 2) {
         const subPrefix = parts[1] ?? "";
-        return ["global", "project", "status", "wizard", "setup"]
+        return ["global", "project", "status", "wizard", "setup", "import-claude"]
           .filter((cmd) => cmd.startsWith(subPrefix))
           .map((cmd) => ({ value: `prefs ${cmd}`, label: cmd }));
       }
@@ -174,7 +175,7 @@ export function registerGSDCommand(pi: ExtensionAPI): void {
       }
 
       ctx.ui.notify(
-        `Unknown: /gsd ${trimmed}. Use /gsd, /gsd next, /gsd auto, /gsd stop, /gsd status, /gsd queue, /gsd discuss, /gsd prefs [global|project|status|wizard|setup], /gsd hooks, /gsd doctor [audit|fix|heal] [M###/S##], /gsd migrate <path>, or /gsd remote [slack|discord|status|disconnect].`,
+        `Unknown: /gsd ${trimmed}. Use /gsd, /gsd next, /gsd auto, /gsd stop, /gsd status, /gsd queue, /gsd discuss, /gsd prefs [global|project|status|wizard|setup|import-claude [global|project]], /gsd hooks, /gsd doctor [audit|fix|heal] [M###/S##], /gsd migrate <path>, or /gsd remote [slack|discord|status|disconnect].`,
         "warning",
       );
     },
@@ -232,6 +233,15 @@ async function handlePrefs(args: string, ctx: ExtensionCommandContext): Promise<
     return;
   }
 
+  if (trimmed === "import-claude" || trimmed === "import-claude global") {
+    await handleImportClaude(ctx, "global");
+    return;
+  }
+
+  if (trimmed === "import-claude project") {
+    await handleImportClaude(ctx, "project");
+    return;
+  }
   if (trimmed === "status") {
     const globalPrefs = loadGlobalGSDPreferences();
     const projectPrefs = loadProjectGSDPreferences();
@@ -262,7 +272,38 @@ async function handlePrefs(args: string, ctx: ExtensionCommandContext): Promise<
     return;
   }
 
-  ctx.ui.notify("Usage: /gsd prefs [global|project|status|wizard|setup]", "info");
+  ctx.ui.notify("Usage: /gsd prefs [global|project|status|wizard|setup|import-claude [global|project]]", "info");
+}
+
+async function handleImportClaude(ctx: ExtensionCommandContext, scope: "global" | "project"): Promise<void> {
+  const path = scope === "project" ? getProjectGSDPreferencesPath() : getGlobalGSDPreferencesPath();
+  if (!existsSync(path)) {
+    await ensurePreferencesFile(path, ctx, scope);
+  }
+
+  const readPrefs = (): Record<string, unknown> => {
+    if (!existsSync(path)) return { version: 1 };
+    const content = readFileSync(path, "utf-8");
+    const [frontmatterLines] = splitFrontmatter(content);
+    return frontmatterLines ? parseFrontmatterMap(frontmatterLines) : { version: 1 };
+  };
+
+  const writePrefs = async (prefs: Record<string, unknown>): Promise<void> => {
+    prefs.version = prefs.version || 1;
+    const frontmatter = serializePreferencesToFrontmatter(prefs);
+    let body = "\n# GSD Skill Preferences\n\nSee `~/.gsd/agent/extensions/gsd/docs/preferences-reference.md` for full field documentation and examples.\n";
+    if (existsSync(path)) {
+      const existingContent = readFileSync(path, "utf-8");
+      const closingIdx = existingContent.indexOf("\n---", existingContent.indexOf("---"));
+      if (closingIdx !== -1) {
+        const afterFrontmatter = existingContent.slice(closingIdx + 4);
+        if (afterFrontmatter.trim()) body = afterFrontmatter;
+      }
+    }
+    await saveFile(path, `---\n${frontmatter}---${body}`);
+  };
+
+  await runClaudeImportFlow(ctx, scope, readPrefs, writePrefs);
 }
 
 async function handleDoctor(args: string, ctx: ExtensionCommandContext, pi: ExtensionAPI): Promise<void> {

--- a/src/resources/extensions/universal-config/discovery.ts
+++ b/src/resources/extensions/universal-config/discovery.ts
@@ -58,6 +58,8 @@ export async function discoverAllConfigs(
   const rules = allItems.filter((i) => i.type === "rule").length;
   const contextFiles = allItems.filter((i) => i.type === "context-file").length;
   const settings = allItems.filter((i) => i.type === "settings").length;
+  const claudeSkills = allItems.filter((i) => i.type === "claude-skill").length;
+  const claudePlugins = allItems.filter((i) => i.type === "claude-plugin").length;
   const toolsWithConfig = toolResults.filter((r) => r.items.length > 0).length;
 
   return {
@@ -68,6 +70,8 @@ export async function discoverAllConfigs(
       rules,
       contextFiles,
       settings,
+      claudeSkills,
+      claudePlugins,
       totalItems: allItems.length,
       toolsScanned: TOOLS.length,
       toolsWithConfig,

--- a/src/resources/extensions/universal-config/format.ts
+++ b/src/resources/extensions/universal-config/format.ts
@@ -23,7 +23,7 @@ export function formatDiscoveryForTool(result: DiscoveryResult): string {
     return lines.join("\n");
   }
 
-  lines.push(`Found: ${summary.mcpServers} MCP server(s), ${summary.rules} rule(s), ${summary.contextFiles} context file(s), ${summary.settings} settings file(s)`);
+  lines.push(`Found: ${summary.mcpServers} MCP server(s), ${summary.rules} rule(s), ${summary.contextFiles} context file(s), ${summary.settings} settings file(s), ${summary.claudeSkills} Claude skill(s), ${summary.claudePlugins} Claude plugin(s)`);
   lines.push("");
 
   for (const toolResult of result.tools) {
@@ -66,13 +66,20 @@ export function formatDiscoveryForTool(result: DiscoveryResult): string {
       }
     }
 
-    if (byType.settings?.length) {
-      lines.push(`  Settings (${byType.settings.length}):`);
-      for (const item of byType.settings) {
-        if (item.type !== "settings") continue;
-        const keys = Object.keys(item.data).slice(0, 5);
-        const suffix = Object.keys(item.data).length > 5 ? ` +${Object.keys(item.data).length - 5} more` : "";
-        lines.push(`    - ${item.source.path} (${item.source.level}): keys: ${keys.join(", ")}${suffix}`);
+    if (byType["claude-skill"]?.length) {
+      lines.push(`  Claude Skills (${byType["claude-skill"].length}):`);
+      for (const item of byType["claude-skill"]) {
+        if (item.type !== "claude-skill") continue;
+        lines.push(`    - ${item.name} (${item.source.level}) ${item.path}`);
+      }
+    }
+
+    if (byType["claude-plugin"]?.length) {
+      lines.push(`  Claude Plugins (${byType["claude-plugin"].length}):`);
+      for (const item of byType["claude-plugin"]) {
+        if (item.type !== "claude-plugin") continue;
+        const label = item.packageName ? `${item.name} [${item.packageName}]` : item.name;
+        lines.push(`    - ${label} (${item.source.level}) ${item.path}`);
       }
     }
 
@@ -111,6 +118,8 @@ export function formatDiscoveryForCommand(result: DiscoveryResult): string[] {
   lines.push(`  Rules:       ${summary.rules}`);
   lines.push(`  Context:     ${summary.contextFiles}`);
   lines.push(`  Settings:    ${summary.settings}`);
+  lines.push(`  Claude skills: ${summary.claudeSkills}`);
+  lines.push(`  Claude plugins: ${summary.claudePlugins}`);
   lines.push("");
 
   for (const toolResult of result.tools) {
@@ -122,6 +131,8 @@ export function formatDiscoveryForCommand(result: DiscoveryResult): string[] {
     if (counts.rule) parts.push(`${counts.rule} rules`);
     if (counts["context-file"]) parts.push(`${counts["context-file"]} context`);
     if (counts.settings) parts.push(`${counts.settings} settings`);
+    if (counts["claude-skill"]) parts.push(`${counts["claude-skill"]} Claude skills`);
+    if (counts["claude-plugin"]) parts.push(`${counts["claude-plugin"]} Claude plugins`);
 
     lines.push(`  ${toolResult.tool.name}: ${parts.join(", ")}`);
 
@@ -130,6 +141,18 @@ export function formatDiscoveryForCommand(result: DiscoveryResult): string[] {
     for (const server of servers) {
       if (server.type !== "mcp-server") continue;
       lines.push(`    MCP: ${server.name} (${server.source.level})`);
+    }
+
+    const claudeSkills = toolResult.items.filter((i) => i.type === "claude-skill");
+    for (const skill of claudeSkills) {
+      if (skill.type !== "claude-skill") continue;
+      lines.push(`    Skill: ${skill.name} (${skill.source.level})`);
+    }
+
+    const claudePlugins = toolResult.items.filter((i) => i.type === "claude-plugin");
+    for (const plugin of claudePlugins) {
+      if (plugin.type !== "claude-plugin") continue;
+      lines.push(`    Plugin: ${plugin.name} (${plugin.source.level})`);
     }
   }
 

--- a/src/resources/extensions/universal-config/index.ts
+++ b/src/resources/extensions/universal-config/index.ts
@@ -31,13 +31,13 @@ export default function universalConfig(pi: ExtensionAPI) {
     label: "Discover Configs",
     description:
       "Scan for existing AI coding tool configurations in this project and the user's home directory. " +
-      "Discovers MCP servers, rules, context files, and settings from Claude Code, Cursor, Windsurf, " +
+      "Discovers MCP servers, rules, context files, settings, Claude skills, and Claude plugins from Claude Code, Cursor, Windsurf, " +
       "Gemini CLI, Codex, Cline, GitHub Copilot, and VS Code. Read-only — never modifies config files.",
-    promptSnippet: "Discover existing AI tool configs (MCP servers, rules, context files) from 8 coding tools.",
+    promptSnippet: "Discover existing AI tool configs (MCP servers, rules, context files, Claude skills/plugins) from 8 coding tools.",
     promptGuidelines: [
       "Use discover_configs when a user asks about their existing configuration, MCP servers, or when switching from another AI coding tool.",
       "The tool scans both user-level (~/) and project-level (./) config directories.",
-      "Results include MCP servers that could be reused, rules/instructions that could be adapted, and context files from other tools.",
+      "Results include MCP servers that could be reused, rules/instructions that could be adapted, context files from other tools, and Claude skills/plugins that could be imported.",
     ],
     parameters: Type.Object({
       tool: Type.Optional(
@@ -83,6 +83,8 @@ export default function universalConfig(pi: ExtensionAPI) {
             rules: allItems.filter((i) => i.type === "rule").length,
             contextFiles: allItems.filter((i) => i.type === "context-file").length,
             settings: allItems.filter((i) => i.type === "settings").length,
+            claudeSkills: allItems.filter((i) => i.type === "claude-skill").length,
+            claudePlugins: allItems.filter((i) => i.type === "claude-plugin").length,
             totalItems: allItems.length,
             toolsWithConfig: filtered.filter((t) => t.items.length > 0).length,
           },

--- a/src/resources/extensions/universal-config/scanners.ts
+++ b/src/resources/extensions/universal-config/scanners.ts
@@ -8,6 +8,7 @@
  */
 
 import { readFile, readdir, stat } from "node:fs/promises";
+import { existsSync, readdirSync } from "node:fs";
 import { join, basename, resolve } from "node:path";
 import { homedir } from "node:os";
 import type {
@@ -27,6 +28,30 @@ import type {
 
 function source(tool: ToolInfo, path: string, level: ConfigLevel): ConfigSource {
   return { tool: tool.id, toolName: tool.name, path, level };
+}
+
+function walkDirectories(root: string, visit: (dir: string, depth: number) => void, maxDepth = 4): void {
+  const skip = new Set([".git", "node_modules", ".worktrees", "dist", "build", "cache", ".cache"]);
+
+  function walk(dir: string, depth: number) {
+    visit(dir, depth);
+    if (depth >= maxDepth) return;
+
+    let entries: Array<{ name: string; isDirectory: () => boolean }> = [];
+    try {
+      entries = readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      if (skip.has(entry.name)) continue;
+      walk(join(dir, entry.name), depth + 1);
+    }
+  }
+
+  walk(root, 0);
 }
 
 async function readTextFile(path: string): Promise<string | null> {
@@ -206,6 +231,44 @@ async function scanClaude(projectRoot: string, home: string, tool: ToolInfo): Pr
         source: source(tool, fullPath, "project"),
       });
     }
+  }
+
+  // Claude skills: ~/.claude/skills/**/SKILL.md
+  const userSkillsRoot = join(home, ".claude/skills");
+  if (existsSync(userSkillsRoot)) {
+    walkDirectories(userSkillsRoot, (dir) => {
+      const skillFile = join(dir, "SKILL.md");
+      if (!existsSync(skillFile)) return;
+      items.push({
+        type: "claude-skill",
+        name: basename(dir),
+        path: dir,
+        source: source(tool, skillFile, "user"),
+      });
+    }, 5);
+  }
+
+  // Claude plugins: ~/.claude/plugins/**/package.json
+  const userPluginsRoot = join(home, ".claude/plugins");
+  if (existsSync(userPluginsRoot)) {
+    walkDirectories(userPluginsRoot, (dir) => {
+      const packageJsonPath = join(dir, "package.json");
+      if (!existsSync(packageJsonPath)) return;
+      let packageName: string | undefined;
+      try {
+        const pkg = JSON.parse(readFileSync(packageJsonPath, "utf8")) as { name?: string };
+        packageName = pkg.name;
+      } catch {
+        packageName = undefined;
+      }
+      items.push({
+        type: "claude-plugin",
+        name: packageName || basename(dir),
+        packageName,
+        path: dir,
+        source: source(tool, packageJsonPath, "user"),
+      });
+    }, 4);
   }
 
   // User-level settings: ~/.claude/settings.json

--- a/src/resources/extensions/universal-config/tests/discovery.test.ts
+++ b/src/resources/extensions/universal-config/tests/discovery.test.ts
@@ -41,6 +41,8 @@ describe("discoverAllConfigs", () => {
       assert.equal(result.summary.totalItems, 0);
       assert.equal(result.summary.toolsScanned, 8);
       assert.equal(result.summary.toolsWithConfig, 0);
+      assert.equal(result.summary.claudeSkills, 0);
+      assert.equal(result.summary.claudePlugins, 0);
       assert.ok(result.durationMs >= 0);
     } finally {
       cleanup();
@@ -53,6 +55,8 @@ describe("discoverAllConfigs", () => {
       writeJson(join(testHome, ".claude.json"), {
         mcpServers: { "claude-mcp": { command: "node", args: ["server.js"] } },
       });
+      writeText(join(testHome, ".claude/skills/test-skill/SKILL.md"), "# Test skill");
+      writeJson(join(testHome, ".claude/plugins/test-plugin/package.json"), { name: "test-plugin" });
       writeText(join(testRoot, ".cursorrules"), "Use semicolons.");
       writeText(join(testRoot, ".github/copilot-instructions.md"), "Be helpful.");
 
@@ -61,7 +65,9 @@ describe("discoverAllConfigs", () => {
       assert.equal(result.summary.mcpServers, 1);
       assert.equal(result.summary.rules, 1);
       assert.equal(result.summary.contextFiles, 1);
-      assert.equal(result.allItems.length, 3);
+      assert.equal(result.summary.claudeSkills, 1);
+      assert.equal(result.summary.claudePlugins, 1);
+      assert.equal(result.allItems.length, 5);
     } finally {
       cleanup();
     }
@@ -103,6 +109,8 @@ describe("discoverAllConfigs", () => {
       assert.equal(result.summary.rules, 2);
       assert.equal(result.summary.contextFiles, 1);
       assert.equal(result.summary.settings, 1);
+      assert.equal(result.summary.claudeSkills, 0);
+      assert.equal(result.summary.claudePlugins, 0);
       assert.equal(result.summary.totalItems, 5);
     } finally {
       cleanup();

--- a/src/resources/extensions/universal-config/tests/format.test.ts
+++ b/src/resources/extensions/universal-config/tests/format.test.ts
@@ -16,6 +16,8 @@ const emptyResult: DiscoveryResult = {
     rules: 0,
     contextFiles: 0,
     settings: 0,
+    claudeSkills: 0,
+    claudePlugins: 0,
     totalItems: 0,
     toolsScanned: 8,
     toolsWithConfig: 0,
@@ -38,11 +40,17 @@ const populatedResult: DiscoveryResult = {
           source: { tool: "cursor", toolName: "Cursor", path: "/project/.cursor/mcp.json", level: "project" },
         },
         {
-          type: "rule",
-          name: "style",
-          content: "Use semicolons and strict TypeScript.",
-          alwaysApply: true,
-          source: { tool: "cursor", toolName: "Cursor", path: "/project/.cursor/rules/style.mdc", level: "project" },
+          type: "claude-skill",
+          name: "cursor-mdc-editor",
+          path: "/home/user/.claude/skills/cursor-mdc-editor",
+          source: { tool: "claude", toolName: "Claude Code", path: "/home/user/.claude/skills/cursor-mdc-editor/SKILL.md", level: "user" },
+        },
+        {
+          type: "claude-plugin",
+          name: "context-mode",
+          packageName: "context-mode",
+          path: "/home/user/.claude/plugins/marketplaces/context-mode",
+          source: { tool: "claude", toolName: "Claude Code", path: "/home/user/.claude/plugins/marketplaces/context-mode/package.json", level: "user" },
         },
       ],
       warnings: [],
@@ -66,7 +74,9 @@ const populatedResult: DiscoveryResult = {
     rules: 1,
     contextFiles: 1,
     settings: 0,
-    totalItems: 3,
+    claudeSkills: 1,
+    claudePlugins: 1,
+    totalItems: 5,
     toolsScanned: 8,
     toolsWithConfig: 2,
   },
@@ -86,10 +96,14 @@ describe("formatDiscoveryForTool", () => {
     const text = formatDiscoveryForTool(populatedResult);
     assert.ok(text.includes("2/8 tools with config"));
     assert.ok(text.includes("1 MCP server(s)"));
+    assert.ok(text.includes("1 Claude skill(s)"));
+    assert.ok(text.includes("1 Claude plugin(s)"));
     assert.ok(text.includes("Cursor"));
     assert.ok(text.includes("test-mcp"));
     assert.ok(text.includes("GitHub Copilot"));
     assert.ok(text.includes("copilot-instructions.md"));
+    assert.ok(text.includes("cursor-mdc-editor"));
+    assert.ok(text.includes("context-mode"));
   });
 });
 
@@ -107,5 +121,7 @@ describe("formatDiscoveryForCommand", () => {
     assert.ok(text.includes("2 of 8"));
     assert.ok(text.includes("Cursor"));
     assert.ok(text.includes("MCP: test-mcp"));
+    assert.ok(text.includes("Skill: cursor-mdc-editor"));
+    assert.ok(text.includes("Plugin: context-mode"));
   });
 });

--- a/src/resources/extensions/universal-config/tests/scanners.test.ts
+++ b/src/resources/extensions/universal-config/tests/scanners.test.ts
@@ -107,6 +107,24 @@ describe("Claude Code scanner", () => {
     }
   });
 
+  test("discovers Claude Code skills and plugins", async () => {
+    const { testRoot, testHome, cleanup } = makeTempDirs();
+    try {
+      writeText(join(testHome, ".claude/skills/test-skill/SKILL.md"), "# test skill");
+      writeJson(join(testHome, ".claude/plugins/test-plugin/package.json"), { name: "test-plugin" });
+
+      const { items } = await SCANNERS.claude(testRoot, testHome, getTool("claude"));
+      const skills = items.filter((i) => i.type === "claude-skill");
+      const plugins = items.filter((i) => i.type === "claude-plugin");
+      assert.equal(skills.length, 1);
+      assert.equal(plugins.length, 1);
+      if (skills[0]?.type === "claude-skill") assert.equal(skills[0].name, "test-skill");
+      if (plugins[0]?.type === "claude-plugin") assert.equal(plugins[0].name, "test-plugin");
+    } finally {
+      cleanup();
+    }
+  });
+
   test("discovers settings.json", async () => {
     const { testRoot, testHome, cleanup } = makeTempDirs();
     try {

--- a/src/resources/extensions/universal-config/types.ts
+++ b/src/resources/extensions/universal-config/types.ts
@@ -80,11 +80,28 @@ export interface DiscoveredSettings {
   source: ConfigSource;
 }
 
+export interface DiscoveredClaudeSkill {
+  type: "claude-skill";
+  name: string;
+  path: string;
+  source: ConfigSource;
+}
+
+export interface DiscoveredClaudePlugin {
+  type: "claude-plugin";
+  name: string;
+  path: string;
+  packageName?: string;
+  source: ConfigSource;
+}
+
 export type DiscoveredItem =
   | DiscoveredMCPServer
   | DiscoveredRule
   | DiscoveredContextFile
-  | DiscoveredSettings;
+  | DiscoveredSettings
+  | DiscoveredClaudeSkill
+  | DiscoveredClaudePlugin;
 
 // ── Discovery result ──────────────────────────────────────────────────────────
 
@@ -105,6 +122,8 @@ export interface DiscoveryResult {
     rules: number;
     contextFiles: number;
     settings: number;
+    claudeSkills: number;
+    claudePlugins: number;
     totalItems: number;
     toolsScanned: number;
     toolsWithConfig: number;


### PR DESCRIPTION
## Summary

Add an import flow that lets GSD/Pi reuse existing Claude-side skills and plugin/package directories by reference, instead of requiring users to duplicate those assets into GSD-managed directories.

## Problem

Some users already maintain substantial Claude-oriented skill and plugin libraries in places like:
- `~/.claude/skills`
- `~/.claude/plugins`
- adjacent/local repos used as reference libraries

Before this change, GSD could discover some Claude configuration, but it did not provide a clean way to selectively enable those existing assets in GSD/Pi configuration.

That created unnecessary duplication pressure for users who already have curated skill/plugin repos and want GSD to reuse them directly.

## Desired outcome

Users should be able to:
- discover available Claude skills and plugin/package directories
- select the ones they want to use
- enable them in GSD/Pi configuration
- keep the source of truth in the original existing directories
- avoid copying, vendoring, or maintaining parallel directory trees under GSD-managed paths

In short: **reuse existing assets by path/reference, not by duplication**.

## What this PR adds

### New command flow
- `/gsd prefs import-claude`
- `/gsd prefs import-claude global`
- `/gsd prefs import-claude project`

### Discovery improvements
`discover_configs` now surfaces additional Claude-specific assets:
- Claude skills
- Claude plugins

## Behavior

### Skills
Selected Claude skills are:
- added to GSD preferences as durable skill references (`always_use_skills` or `prefer_skills`)
- added to Pi settings skill paths so they are available without being copied into GSD-managed skill directories

### Plugins / packages
Selected Claude plugin/package directories are:
- added to Pi settings as package/path sources
- referenced from their existing locations rather than duplicated

## Scope and non-goals

This PR is intentionally focused on **configuration import and path-based reuse**.

It does **not** attempt to:
- convert every Claude plugin into a native Pi extension model
- change Claude plugin semantics
- copy or sync external directories into `~/.gsd/agent/`
- broaden unrelated GSD workflow documentation in the same PR

## Implementation notes

- keeps the source path as the durable reference
- favors selective enablement over automatic migration
- extends universal-config discovery so relevant Claude assets are visible before import

## Validation

- `npm test`

## Follow-up

A separate documentation PR can address `src/resources/GSD-WORKFLOW.md` artifact naming alignment without mixing doc cleanup into this feature change.

## Contributor etiquette notes

This change is intended to reduce user friction while staying conservative in scope:
- no unrelated behavior changes
- no forced migration of existing user assets
- no assumption that legacy Claude-side assets should be rewritten or relocated
- feature remains opt-in via explicit import flow
