### PR TITLE
fix: prevent web_search injection for Copilot/proxy providers (#444)

### DIFF
--- a/packages/pi-coding-agent/src/core/extensions/runner.ts
+++ b/packages/pi-coding-agent/src/core/extensions/runner.ts
@@ -712,7 +712,7 @@ export class ExtensionRunner {
 		return currentMessages;
 	}
 
-	async emitBeforeProviderRequest(payload: unknown): Promise<unknown> {
+	async emitBeforeProviderRequest(payload: unknown, model?: { provider: string; id: string }): Promise<unknown> {
 		const ctx = this.createContext();
 		let currentPayload = payload;
 
@@ -725,6 +725,7 @@ export class ExtensionRunner {
 					const event: BeforeProviderRequestEvent = {
 						type: "before_provider_request",
 						payload: currentPayload,
+						model,
 					};
 					const handlerResult = await handler(event, ctx);
 					if (handlerResult !== undefined) {

--- a/packages/pi-coding-agent/src/core/extensions/types.ts
+++ b/packages/pi-coding-agent/src/core/extensions/types.ts
@@ -506,6 +506,8 @@ export interface ContextEvent {
 export interface BeforeProviderRequestEvent {
 	type: "before_provider_request";
 	payload: unknown;
+	/** The resolved model for this request (provider, id, etc.) */
+	model?: { provider: string; id: string };
 }
 
 /** Fired after user submits prompt but before agent loop. */

--- a/packages/pi-coding-agent/src/core/sdk.ts
+++ b/packages/pi-coding-agent/src/core/sdk.ts
@@ -292,12 +292,12 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			tools: [],
 		},
 		convertToLlm: convertToLlmWithBlockImages,
-		onPayload: async (payload, _model) => {
+		onPayload: async (payload, currentModel) => {
 			const runner = extensionRunnerRef.current;
 			if (!runner?.hasHandlers("before_provider_request")) {
 				return payload;
 			}
-			return runner.emitBeforeProviderRequest(payload);
+			return runner.emitBeforeProviderRequest(payload, currentModel);
 		},
 		sessionId: sessionManager.getSessionId(),
 		transformContext: async (messages) => {

--- a/src/resources/extensions/search-the-web/native-search.ts
+++ b/src/resources/extensions/search-the-web/native-search.ts
@@ -105,16 +105,21 @@ export function registerNativeSearchHooks(pi: NativeSearchPI): { getIsAnthropic:
     const payload = event.payload as Record<string, unknown>;
     if (!payload) return;
 
-    // Detect Anthropic provider. Prefer the model_select flag when available,
-    // but fall back to checking the model name in the payload. model_select
-    // may not fire when the session restores with the same model already set
-    // (modelsAreEqual guard in the SDK suppresses the event). When model_select
-    // HAS fired and said "not Anthropic" (e.g. Copilot serving claude-*),
-    // respect that — don't override with model name heuristic.
-    const modelName = typeof payload.model === "string" ? payload.model : "";
-    const isAnthropic = modelSelectFired
-      ? isAnthropicProvider
-      : modelName.startsWith("claude-");
+    // Detect Anthropic provider. Use the model object from the event (most
+    // reliable — comes directly from the resolved Model), then fall back to
+    // the model_select flag, then to the model name heuristic (last resort).
+    // The model name heuristic is needed for session restores where
+    // modelsAreEqual suppresses model_select AND the SDK doesn't pass model.
+    const eventModel = event.model as { provider: string } | undefined;
+    let isAnthropic: boolean;
+    if (eventModel?.provider) {
+      isAnthropic = eventModel.provider === "anthropic";
+    } else if (modelSelectFired) {
+      isAnthropic = isAnthropicProvider;
+    } else {
+      const modelName = typeof payload.model === "string" ? payload.model : "";
+      isAnthropic = modelName.startsWith("claude-");
+    }
     if (!isAnthropic) return;
 
     // Strip thinking blocks from history to avoid signature validation errors

--- a/src/tests/native-search.test.ts
+++ b/src/tests/native-search.test.ts
@@ -177,6 +177,57 @@ test("before_provider_request does NOT inject for claude model on non-Anthropic 
   );
 });
 
+// ─── Issue #444 regression: Copilot claude-* model without model_select ──────
+
+test("before_provider_request does NOT inject when event.model indicates non-Anthropic provider (no model_select)", async () => {
+  const pi = createMockPI();
+  registerNativeSearchHooks(pi);
+
+  // NO model_select fired — simulates a new session where model was set before
+  // extensions were bound. The event.model field from the SDK reveals the true provider.
+  const payload: Record<string, unknown> = {
+    model: "claude-sonnet-4-6-20250514",
+    tools: [{ name: "bash", type: "custom" }],
+  };
+
+  const result = await pi.fire("before_provider_request", {
+    type: "before_provider_request",
+    payload,
+    model: { provider: "github-copilot", id: "claude-sonnet-4-6" },
+  });
+
+  assert.equal(result, undefined, "Should not modify payload when event.model says non-Anthropic");
+  const tools = payload.tools as any[];
+  assert.equal(tools.length, 1, "Should not inject web_search for Copilot provider");
+  assert.ok(
+    !tools.some((t: any) => t.type === "web_search_20250305"),
+    "web_search_20250305 must NOT be present for Copilot"
+  );
+});
+
+test("before_provider_request DOES inject when event.model indicates Anthropic provider (no model_select)", async () => {
+  const pi = createMockPI();
+  registerNativeSearchHooks(pi);
+
+  // NO model_select fired, but event.model confirms Anthropic provider
+  const payload: Record<string, unknown> = {
+    model: "claude-sonnet-4-6-20250514",
+    tools: [{ name: "bash", type: "custom" }],
+  };
+
+  const result = await pi.fire("before_provider_request", {
+    type: "before_provider_request",
+    payload,
+    model: { provider: "anthropic", id: "claude-sonnet-4-6" },
+  });
+
+  const tools = ((result as any)?.tools ?? payload.tools) as any[];
+  assert.ok(
+    tools.some((t: any) => t.type === "web_search_20250305"),
+    "Should inject web_search when event.model confirms Anthropic"
+  );
+});
+
 test("before_provider_request does not double-inject", async () => {
   const pi = createMockPI();
   registerNativeSearchHooks(pi);


### PR DESCRIPTION
## Summary
- Fixes #444 — GitHub Copilot users with Claude models get `400 {"error":{"message":"The use of the web search tool is not supported."}}` errors
- Root cause: `model_select` event never fires before the first API request on new sessions, so the fallback heuristic (`modelName.startsWith("claude-")`) can't distinguish direct Anthropic API from Copilot/Bedrock proxied Claude models
- Fix: pass the resolved `Model` object (with `provider` field) through to `BeforeProviderRequestEvent`, so the native-search extension can reliably check `model.provider === "anthropic"` instead of guessing from the model name

## Changes
- **`types.ts`** — Added optional `model` field to `BeforeProviderRequestEvent`
- **`runner.ts`** — Forward `model` parameter in `emitBeforeProviderRequest()`
- **`sdk.ts`** — Pass the `Model` from `onPayload` callback through to the extension runner
- **`native-search.ts`** — 3-tier provider detection: `event.model.provider` → `model_select` flag → model name heuristic (last resort)
- **`native-search.test.ts`** — 2 new regression tests for the exact issue #444 scenario

## Test plan
- [x] All 30 native-search tests pass (including 2 new ones)
- [x] Build succeeds with no type errors
- [ ] Manual test with GitHub Copilot OAuth + Claude model — no 400 error on startup
- [ ] Manual test with direct Anthropic API key — web search still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)