### PR TITLE
feat: session-internal /gsd config + fix key hydration in gsd config

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -113,6 +113,7 @@ const isPrintMode = cliFlags.print || cliFlags.mode !== undefined
 // `gsd config` — replay the setup wizard and exit
 if (cliFlags.messages[0] === 'config') {
   const authStorage = AuthStorage.create(authFilePath)
+  loadStoredEnvKeys(authStorage)
   await runOnboarding(authStorage)
   process.exit(0)
 }

--- a/src/resources/extensions/gsd/commands.ts
+++ b/src/resources/extensions/gsd/commands.ts
@@ -5,7 +5,8 @@
  */
 
 import type { ExtensionAPI, ExtensionCommandContext } from "@gsd/pi-coding-agent";
-import { existsSync, readFileSync } from "node:fs";
+import { AuthStorage } from "@gsd/pi-coding-agent";
+import { existsSync, readFileSync, mkdirSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { deriveState } from "./state.js";
@@ -53,10 +54,10 @@ function dispatchDoctorHeal(pi: ExtensionAPI, scope: string | undefined, reportT
 
 export function registerGSDCommand(pi: ExtensionAPI): void {
   pi.registerCommand("gsd", {
-    description: "GSD — Get Shit Done: /gsd next|auto|stop|status|queue|prefs|hooks|doctor|migrate|remote",
+    description: "GSD — Get Shit Done: /gsd next|auto|stop|status|queue|prefs|config|hooks|doctor|migrate|remote",
 
     getArgumentCompletions: (prefix: string) => {
-      const subcommands = ["next", "auto", "stop", "status", "queue", "discuss", "prefs", "hooks", "doctor", "migrate", "remote"];
+      const subcommands = ["next", "auto", "stop", "status", "queue", "discuss", "prefs", "config", "hooks", "doctor", "migrate", "remote"];
       const parts = prefix.trim().split(/\s+/);
 
       if (parts.length <= 1) {
@@ -151,6 +152,11 @@ export function registerGSDCommand(pi: ExtensionAPI): void {
         return;
       }
 
+      if (trimmed === "config") {
+        await handleConfig(ctx);
+        return;
+      }
+
       if (trimmed === "hooks") {
         const { formatHookStatus } = await import("./post-unit-hooks.js");
         ctx.ui.notify(formatHookStatus(), "info");
@@ -174,7 +180,7 @@ export function registerGSDCommand(pi: ExtensionAPI): void {
       }
 
       ctx.ui.notify(
-        `Unknown: /gsd ${trimmed}. Use /gsd, /gsd next, /gsd auto, /gsd stop, /gsd status, /gsd queue, /gsd discuss, /gsd prefs [global|project|status|wizard|setup], /gsd hooks, /gsd doctor [audit|fix|heal] [M###/S##], /gsd migrate <path>, or /gsd remote [slack|discord|status|disconnect].`,
+        `Unknown: /gsd ${trimmed}. Use /gsd, /gsd next, /gsd auto, /gsd stop, /gsd status, /gsd queue, /gsd discuss, /gsd prefs, /gsd config, /gsd hooks, /gsd doctor [audit|fix|heal] [M###/S##], /gsd migrate <path>, or /gsd remote [slack|discord|status|disconnect].`,
         "warning",
       );
     },
@@ -519,6 +525,74 @@ function serializePreferencesToFrontmatter(prefs: Record<string, unknown>): stri
   }
 
   return lines.join("\n") + "\n";
+}
+
+// ─── Tool Config Wizard ───────────────────────────────────────────────────────
+
+const TOOL_KEYS = [
+  { id: "tavily",   env: "TAVILY_API_KEY",   label: "Tavily Search",     hint: "tavily.com/app/api-keys" },
+  { id: "brave",    env: "BRAVE_API_KEY",     label: "Brave Search",      hint: "brave.com/search/api" },
+  { id: "context7", env: "CONTEXT7_API_KEY",  label: "Context7 Docs",     hint: "context7.com/dashboard" },
+  { id: "jina",     env: "JINA_API_KEY",      label: "Jina Page Extract", hint: "jina.ai/api" },
+  { id: "groq",     env: "GROQ_API_KEY",      label: "Groq Voice",        hint: "console.groq.com" },
+] as const;
+
+function getConfigAuthStorage(): InstanceType<typeof AuthStorage> {
+  const authPath = join(process.env.HOME ?? "", ".gsd", "agent", "auth.json");
+  mkdirSync(dirname(authPath), { recursive: true });
+  return AuthStorage.create(authPath);
+}
+
+async function handleConfig(ctx: ExtensionCommandContext): Promise<void> {
+  const auth = getConfigAuthStorage();
+
+  // Show current status
+  const statusLines = ["GSD Tool Configuration\n"];
+  for (const tool of TOOL_KEYS) {
+    const hasKey = !!process.env[tool.env] || !!(auth.get(tool.id) as { key?: string })?.key;
+    statusLines.push(`  ${hasKey ? "✓" : "✗"} ${tool.label}${hasKey ? "" : ` — get key at ${tool.hint}`}`);
+  }
+  ctx.ui.notify(statusLines.join("\n"), "info");
+
+  // Ask which tools to configure
+  const options = TOOL_KEYS.map(t => {
+    const hasKey = !!process.env[t.env] || !!(auth.get(t.id) as { key?: string })?.key;
+    return `${t.label} ${hasKey ? "(configured ✓)" : "(not set)"}`;
+  });
+  options.push("(done)");
+
+  let changed = false;
+  while (true) {
+    const choice = await ctx.ui.select("Configure which tool? Press Escape when done.", options);
+    if (!choice || choice === "(done)") break;
+
+    const toolIdx = TOOL_KEYS.findIndex(t => choice.startsWith(t.label));
+    if (toolIdx === -1) break;
+
+    const tool = TOOL_KEYS[toolIdx];
+    const input = await ctx.ui.input(
+      `API key for ${tool.label} (${tool.hint}):`,
+      "paste your key here",
+    );
+
+    if (input !== null && input !== undefined) {
+      const key = input.trim();
+      if (key) {
+        auth.set(tool.id, { type: "api_key", key });
+        process.env[tool.env] = key;
+        ctx.ui.notify(`${tool.label} key saved and activated.`, "info");
+        // Update option label
+        options[toolIdx] = `${tool.label} (configured ✓)`;
+        changed = true;
+      }
+    }
+  }
+
+  if (changed) {
+    await ctx.waitForIdle();
+    await ctx.reload();
+    ctx.ui.notify("Configuration saved. Extensions reloaded with new keys.", "info");
+  }
 }
 
 async function ensurePreferencesFile(

--- a/src/resources/extensions/search-the-web/command-search-provider.ts
+++ b/src/resources/extensions/search-the-web/command-search-provider.ts
@@ -90,8 +90,10 @@ export function registerSearchProviderCommand(pi: ExtensionAPI): void {
 
       setSearchProviderPreference(chosen)
       const effective = resolveSearchProvider()
+      const isAnthropic = ctx.model?.provider === 'anthropic'
+      const nativeNote = isAnthropic ? '\nNote: Native Anthropic web search is also active (automatic, no API key needed).' : ''
       ctx.ui.notify(
-        `Search provider set to ${chosen}. Effective provider: ${effective ?? 'none (no API keys)'}`,
+        `Search provider set to ${chosen}. Effective provider: ${effective ?? 'none (no API keys)'}${nativeNote}`,
         'info',
       )
     },


### PR DESCRIPTION
## Problem

### 1. gsd config doesn't hydrate existing keys
Running `gsd config` from the terminal shows API keys as "not configured" even when they exist in `~/.gsd/agent/auth.json`. The `config` subcommand in `cli.ts` creates an `AuthStorage` and calls `runOnboarding()` but skips `loadStoredEnvKeys()` — so environment variables aren't populated from stored credentials.

### 2. No way to configure API keys from within a running session
Tool API keys (Tavily, Brave, Context7, Jina, Groq) can only be set via `gsd config` in the terminal — which requires exiting the current session. There's no slash command equivalent.

### 3. Native Anthropic search not visible in /search-provider
When using a Claude model, native web search is automatically active but `/search-provider` doesn't mention this.

## Architecture: How Config Flows

```
┌─────────────────────────────────────────────────────────────────┐
│                    KEY STORAGE & HYDRATION                       │
│                                                                 │
│  ~/.gsd/agent/auth.json                                         │
│  ┌─────────────────────────────────────────────┐                │
│  │ tavily:   { type: "api_key", key: "tvly-…" }│                │
│  │ brave:    { type: "api_key", key: "BSA…"  } │                │
│  │ context7: { type: "api_key", key: "c7-…"  } │                │
│  │ jina:     { type: "api_key", key: "…"     } │                │
│  │ groq:     { type: "api_key", key: "…"     } │                │
│  └──────────────────┬──────────────────────────┘                │
│                     │                                           │
│          loadStoredEnvKeys()                                    │
│                     │                                           │
│                     ▼                                           │
│  process.env                                                    │
│  ┌─────────────────────────────────────────────┐                │
│  │ TAVILY_API_KEY   = "tvly-…"                 │                │
│  │ BRAVE_API_KEY    = "BSA…"                   │                │
│  │ CONTEXT7_API_KEY = "c7-…"                   │                │
│  │ JINA_API_KEY     = "…"                      │                │
│  │ GROQ_API_KEY     = "…"                      │                │
│  └──────────────────┬──────────────────────────┘                │
│                     │                                           │
│         Extensions read at runtime                              │
│                     │                                           │
│     ┌───────────────┼───────────────┐                           │
│     ▼               ▼               ▼                           │
│  Context7       Search-the-Web    Voice                         │
│  Extension      Extension         Extension                     │
└─────────────────────────────────────────────────────────────────┘
```

## Entry Points for Configuration

```
BEFORE (only terminal):                 AFTER (both):

  Terminal                                Terminal
  $ gsd config ─────┐                    $ gsd config ─────┐
                     │                                      │
                     ▼                                      ▼
              ┌─────────────┐                        ┌─────────────┐
              │ Onboarding  │                        │ Onboarding  │
              │ Wizard      │                        │ Wizard      │
              │ (@clack)    │                        │ (@clack)    │
              └──────┬──────┘                        └──────┬──────┘
                     │                                      │
                     ▼                                      ▼
              auth.json                               auth.json
                                                           ▲
                                                           │
  Session                                 Session          │
  /gsd config ──── ✗ not available        /gsd config ─────┘
                                          │ ctx.ui.select()
                                          │ ctx.ui.input()
                                          │ AuthStorage.set()
                                          │ process.env = key
                                          └─► ctx.reload()
```

## Search Provider Architecture

```
┌──────────────────────────────────────────────────────────┐
│                  SEARCH TOOL ROUTING                      │
│                                                          │
│  Model selected                                          │
│       │                                                  │
│       ├── Anthropic (Claude)?                            │
│       │        │                                         │
│       │        ▼                                         │
│       │   ┌──────────────────────────────┐               │
│       │   │ Native web_search_20250305   │  automatic    │
│       │   │ $0.01/search via API key     │  no setup     │
│       │   │ Custom tools DISABLED        │  needed       │
│       │   └──────────────────────────────┘               │
│       │                                                  │
│       └── Non-Anthropic?                                 │
│                │                                         │
│                ▼                                         │
│   ┌────────────────────────────────┐                     │
│   │ /search-provider preference    │                     │
│   │                                │                     │
│   │  auto ──► tavily ► brave ► ollama (fallback chain)   │
│   │  tavily ─► TAVILY_API_KEY                            │
│   │  brave ──► BRAVE_API_KEY                             │
│   │  ollama ─► OLLAMA_API_KEY                            │
│   └────────────────────────────────┘                     │
│                                                          │
│  NEW: /search-provider now shows native search status    │
│       when Anthropic model is active                     │
└──────────────────────────────────────────────────────────┘
```

## Changes

### cli.ts
Add `loadStoredEnvKeys(authStorage)` before `runOnboarding()` in the `config` subcommand path, matching the normal startup flow.

### commands.ts (GSD extension)
New `/gsd config` subcommand with session-internal tool key wizard:
- Shows current key status (configured/not set) for each provider
- Interactive loop: select provider, enter key, save to auth.json
- Keys immediately activated in `process.env` + extensions reloaded
- Pattern follows existing `remote-command.ts` AuthStorage usage

### command-search-provider.ts
Append native Anthropic web search status note when Claude model is active.

## Verification

**TypeScript:** `npx tsc --noEmit` — passed, zero errors across all packages.

**Test suite:** `npx vitest run --passWithNoTests` — **87/87 test files passed** (13 skipped = empty test stubs with no suites, pre-existing). No regressions introduced.

**Manual testing performed:**
- `/gsd config` in running session: key status display correct, Tavily key entered and saved
- Verified key persisted to `~/.gsd/agent/auth.json` (`tavily: tvly-dev-3TA...`)
- Verified `process.env.TAVILY_API_KEY` activated immediately after save
- `/search-provider` with Anthropic model: native search note displayed correctly
- `gsd config` terminal flow: `loadStoredEnvKeys` now called, existing keys shown as configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)