### PR TITLE
fix: verify artifacts on disk before bailing on dispatch loop limit

### DIFF
--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -1921,6 +1921,30 @@ async function dispatchNextUnit(
       }
     }
 
+    // General reconciliation: if the last attempt DID produce the expected
+    // artifact on disk, clear the counter and advance instead of stopping.
+    // The execute-task path above handles its special case (writing placeholder
+    // summaries). This catch-all covers complete-slice, plan-slice,
+    // research-slice, and all other unit types where the Nth attempt at the
+    // dispatch limit succeeded but the counter check fires before anyone
+    // verifies disk state. Without this, a successful final attempt is
+    // indistinguishable from a failed one.
+    if (verifyExpectedArtifact(unitType, unitId, basePath)) {
+      ctx.ui.notify(
+        `Loop recovery: ${unitType} ${unitId} — artifact verified after ${prevCount + 1} dispatches. Advancing.`,
+        "info",
+      );
+      // Persist completion so the idempotency check prevents re-dispatch
+      // if deriveState keeps returning this unit (see #462).
+      persistCompletedKey(basePath, dispatchKey);
+      completedKeySet.add(dispatchKey);
+      unitDispatchCount.delete(dispatchKey);
+      invalidateStateCache();
+      await new Promise(r => setImmediate(r));
+      await dispatchNextUnit(ctx, pi);
+      return;
+    }
+
     const expected = diagnoseExpectedArtifact(unitType, unitId, basePath);
     const remediation = buildLoopRemediationSteps(unitType, unitId, basePath);
     await stopAuto(ctx, pi);


### PR DESCRIPTION
## Problem

The loop detection in `dispatchNextUnit` stops auto-mode when a unit has been dispatched `MAX_UNIT_DISPATCHES` (3) times. For `execute-task`, there is reconciliation logic that checks whether the expected artifact actually exists on disk before bailing — allowing the pipeline to advance if the last attempt succeeded. **All other unit types** (`complete-slice`, `plan-slice`, `research-slice`, etc.) lack this check and immediately stop, even when the artifact was successfully written on the final attempt.

This is a timing issue between the dispatch counter and artifact verification:

1. The dispatch counter increments at dispatch time
2. Artifact verification only runs during closeout of the *next* unit (line ~1900)
3. If the last allowed attempt (Nth) succeeds, the counter is already at the limit when dispatch N+1 fires
4. Nobody checks disk state → pipeline stops with "Expected artifact not found" despite artifacts existing

## Reproduction

Observed in production with `complete-slice`:

1. `complete-slice M009/S02` dispatched 3 times (LLM missed writing the UAT file on attempts 1-2, succeeded on attempt 3)
2. Attempt 3 produces both `S02-SUMMARY.md` and `S02-UAT.md` — auto-committed to disk
3. Dispatch 4 fires: `prevCount` (3) >= `MAX_UNIT_DISPATCHES` (3)
4. No `verifyExpectedArtifact` check for `complete-slice` → auto-mode stops with loop error
5. All required artifacts are on disk, verified by manual inspection

The same scenario can occur with `plan-slice` (LLM writes plan on final attempt), `research-slice`, or any non-`execute-task` unit type.

## Fix

Add a general `verifyExpectedArtifact()` check after the `execute-task`-specific reconciliation and before the final bail-out. If the artifact exists on disk, clear the dispatch counter and advance. If not, the same error fires as before.

The fix is structurally identical to the existing `execute-task` recovery pattern — it uses the same `verifyExpectedArtifact` function, same counter cleanup, same `dispatchNextUnit` re-entry. The only difference: no placeholder writing (the artifact must actually exist from the LLM's work, unlike `execute-task` which can write stub summaries).

```
// Before (only execute-task had recovery):
if (unitType === "execute-task") { /* reconciliation */ }
// → all other types fall through to bail-out

// After (general catch-all before bail-out):
if (unitType === "execute-task") { /* reconciliation */ }
if (verifyExpectedArtifact(unitType, unitId, basePath)) { /* advance */ }
// → only bail if artifact is genuinely missing
```

## Scope

- **1 file changed:** `src/resources/extensions/gsd/auto.ts`
- **19 lines added**, 0 removed
- **No new dependencies**, no API changes, no config changes
- **Backward compatible:** units that genuinely fail to produce artifacts still get the same error. The only behavioral change is: successful-but-late artifacts are now recognized instead of ignored.

## Testing

- `npm run build` — clean ✓
- `npm run test:unit -- --grep "idle-recovery"` — all existing loop recovery + `verifyExpectedArtifact` tests pass ✓
- Production validation: the exact scenario (complete-slice at dispatch limit with artifacts on disk) was the trigger for this fix and verified working