### PR TITLE
fix(auto): kill dispatch loop paths A and B

### DIFF
--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -836,6 +836,24 @@ export async function handleAgentEnd(
     } catch {
       // Non-fatal
     }
+
+    // ── Path A fix: verify artifact and persist completion before re-entering dispatch ──
+    // After doctor + rebuildState, check whether the just-completed unit actually
+    // produced its expected artifact. If so, persist the completion key now so the
+    // idempotency check at the top of dispatchNextUnit() skips it — even if
+    // deriveState() still returns this unit as active (e.g. branch mismatch).
+    try {
+      if (verifyExpectedArtifact(currentUnit.type, currentUnit.id, basePath)) {
+        const completionKey = `${currentUnit.type}/${currentUnit.id}`;
+        if (!completedKeySet.has(completionKey)) {
+          persistCompletedKey(basePath, completionKey);
+          completedKeySet.add(completionKey);
+        }
+        invalidateStateCache();
+      }
+    } catch {
+      // Non-fatal — worst case we fall through to normal dispatch which has its own checks
+    }
   }
 
   // ── Post-unit hooks: check if a configured hook should run before normal dispatch ──
@@ -1391,6 +1409,9 @@ async function dispatchNextUnit(
 
   // Clear stale directory listing cache so deriveState sees fresh disk state (#431)
   clearPathCache();
+  // Clear parsed roadmap/plan cache — doctor may have re-populated it with
+  // stale data between handleAgentEnd and this dispatch call (Path B fix).
+  clearParseCache();
 
   let state = await deriveState(basePath);
   let mid = state.activeMilestone?.id;


### PR DESCRIPTION
## Summary

- **Path B fix:** Added `clearParseCache()` to `dispatchNextUnit()` alongside the existing `clearPathCache()`. Doctor runs between `handleAgentEnd` and dispatch could re-populate the parse cache with stale roadmap data (showing `[ ]` instead of `[x]`), causing `deriveState()` to return the same unit as active.

- **Path A fix:** Added artifact verification + completion persistence in `handleAgentEnd()` after doctor/rebuildState completes but before re-entering the dispatch loop. If `verifyExpectedArtifact()` confirms the unit produced its expected output, the completion key is persisted immediately. The idempotency check at the top of `dispatchNextUnit()` then skips the unit — even if `deriveState()` still returns it as active due to branch mismatch (e.g. slice branch merged but main not yet updated).

## Test plan

- [ ] Run auto-mode through a complete-slice unit and verify it advances to the next unit without re-dispatching
- [ ] Verify `completed-units.json` contains the completion key after a unit finishes
- [ ] Confirm no TypeScript compilation errors (verified: `tsc --noEmit` passes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)