### PR TITLE
fix(tests): Windows portability for M003 worktree tests

### DIFF
--- a/src/resources/extensions/gsd/tests/auto-worktree.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-worktree.test.ts
@@ -53,7 +53,7 @@ async function main(): Promise<void> {
     mkdirSync(msDir, { recursive: true });
     writeFileSync(join(msDir, "CONTEXT.md"), "# M003 Context\n");
     run("git add .", tempDir);
-    run("git commit -m 'add milestone'", tempDir);
+    run("git commit -m \"add milestone\"", tempDir);
 
     console.log("\n=== auto-worktree lifecycle ===");
 

--- a/src/resources/extensions/gsd/tests/doctor-git.test.ts
+++ b/src/resources/extensions/gsd/tests/doctor-git.test.ts
@@ -60,7 +60,7 @@ _None_
 
   // Commit .gsd files
   run("git add -A", dir);
-  run("git commit -m 'add milestone'", dir);
+  run("git commit -m \"add milestone\"", dir);
 
   return dir;
 }
@@ -101,7 +101,7 @@ _None_
 `);
 
   run("git add -A", dir);
-  run("git commit -m 'add milestone'", dir);
+  run("git commit -m \"add milestone\"", dir);
 
   return dir;
 }
@@ -187,7 +187,7 @@ async function main(): Promise<void> {
       mkdirSync(activityDir, { recursive: true });
       writeFileSync(join(activityDir, "test.log"), "log data\n");
       run("git add -f .gsd/activity/test.log", dir);
-      run("git commit -m 'track runtime file'", dir);
+      run("git commit -m \"track runtime file\"", dir);
 
       const detect = await runGSDDoctor(dir);
       const trackedIssues = detect.issues.filter(i => i.code === "tracked_runtime_files");

--- a/src/resources/extensions/gsd/tests/git-self-heal.test.ts
+++ b/src/resources/extensions/gsd/tests/git-self-heal.test.ts
@@ -24,10 +24,11 @@ import {
 function makeTempRepo(): string {
   const dir = mkdtempSync(join(tmpdir(), "gsd-self-heal-"));
   execSync("git init", { cwd: dir, stdio: "pipe" });
-  execSync("git config user.email 'test@test.com'", { cwd: dir, stdio: "pipe" });
-  execSync("git config user.name 'Test'", { cwd: dir, stdio: "pipe" });
+  execSync("git config user.email \"test@test.com\"", { cwd: dir, stdio: "pipe" });
+  execSync("git config user.name \"Test\"", { cwd: dir, stdio: "pipe" });
   writeFileSync(join(dir, "README.md"), "# init\n");
-  execSync("git add -A && git commit -m 'init'", { cwd: dir, stdio: "pipe" });
+  execSync("git add -A && git commit -m \"init\"", { cwd: dir, stdio: "pipe" });
+  execSync("git branch -M main", { cwd: dir, stdio: "pipe" });
   return dir;
 }
 
@@ -50,10 +51,10 @@ console.log("── abortAndReset ──");
     // Create a conflicting branch
     execSync("git checkout -b feature", { cwd: dir, stdio: "pipe" });
     writeFileSync(join(dir, "file.txt"), "feature content\n");
-    execSync("git add -A && git commit -m 'feature'", { cwd: dir, stdio: "pipe" });
-    execSync("git checkout master 2>/dev/null || git checkout main", { cwd: dir, stdio: "pipe" });
+    execSync("git add -A && git commit -m \"feature\"", { cwd: dir, stdio: "pipe" });
+    execSync("git checkout main", { cwd: dir, stdio: "pipe" });
     writeFileSync(join(dir, "file.txt"), "main content\n");
-    execSync("git add -A && git commit -m 'main change'", { cwd: dir, stdio: "pipe" });
+    execSync("git add -A && git commit -m \"main change\"", { cwd: dir, stdio: "pipe" });
 
     // Create a merge conflict → MERGE_HEAD will exist
     try {
@@ -135,10 +136,10 @@ console.log("── withMergeHeal ──");
     // Set up a real merge conflict
     execSync("git checkout -b conflict-branch", { cwd: dir, stdio: "pipe" });
     writeFileSync(join(dir, "conflict.txt"), "branch A\n");
-    execSync("git add -A && git commit -m 'branch A'", { cwd: dir, stdio: "pipe" });
-    execSync("git checkout master 2>/dev/null || git checkout main", { cwd: dir, stdio: "pipe" });
+    execSync("git add -A && git commit -m \"branch A\"", { cwd: dir, stdio: "pipe" });
+    execSync("git checkout main", { cwd: dir, stdio: "pipe" });
     writeFileSync(join(dir, "conflict.txt"), "branch B\n");
-    execSync("git add -A && git commit -m 'branch B'", { cwd: dir, stdio: "pipe" });
+    execSync("git add -A && git commit -m \"branch B\"", { cwd: dir, stdio: "pipe" });
 
     let callCount = 0;
     try {
@@ -169,7 +170,7 @@ console.log("── recoverCheckout ──");
   try {
     // Create a branch to checkout to
     execSync("git checkout -b target-branch", { cwd: dir, stdio: "pipe" });
-    execSync("git checkout master 2>/dev/null || git checkout main", { cwd: dir, stdio: "pipe" });
+    execSync("git checkout main", { cwd: dir, stdio: "pipe" });
 
     // Dirty the index
     writeFileSync(join(dir, "README.md"), "dirty changes\n");

--- a/src/resources/extensions/gsd/tests/isolation-resolver.test.ts
+++ b/src/resources/extensions/gsd/tests/isolation-resolver.test.ts
@@ -58,7 +58,7 @@ async function main(): Promise<void> {
       run("git checkout -b gsd/M001/S01", dir);
       writeFileSync(join(dir, "slice.md"), "# S01\n");
       run("git add .", dir);
-      run("git commit -m 'slice work'", dir);
+      run("git commit -m \"slice work\"", dir);
       run("git checkout main", dir);
 
       const result = shouldUseWorktreeIsolation(dir);
@@ -77,7 +77,7 @@ async function main(): Promise<void> {
       run("git checkout -b gsd/M001/S01", dir);
       writeFileSync(join(dir, "slice.md"), "# S01\n");
       run("git add .", dir);
-      run("git commit -m 'slice work'", dir);
+      run("git commit -m \"slice work\"", dir);
       run("git checkout main", dir);
 
       const result = shouldUseWorktreeIsolation(dir, { isolation: "worktree" });

--- a/src/resources/extensions/gsd/tests/worktree-e2e.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-e2e.test.ts
@@ -279,7 +279,7 @@ Test
 _None_
 `);
       run("git add -A", repo);
-      run("git commit -m 'add milestone'", repo);
+      run("git commit -m \"add milestone\"", repo);
 
       // Create orphaned worktree
       mkdirSync(join(repo, ".gsd", "worktrees"), { recursive: true });


### PR DESCRIPTION
## Summary
- Replace single-quoted git commit messages with double quotes (PowerShell treats single quotes literally)
- Replace `git checkout master 2>/dev/null || git checkout main` bash redirect syntax with `git checkout main` (cross-platform)
- Add `git branch -M main` to `git-self-heal.test.ts` setup so `git checkout main` works on systems defaulting to `master`

## Test plan
- [ ] Run M003 test suite on Windows (PowerShell)
- [ ] Run M003 test suite on macOS/Linux to verify no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)