### PR TITLE
fix(paths): resolve .gsd/ to main worktree root in git worktrees

### DIFF
--- a/src/resources/extensions/gsd/paths.ts
+++ b/src/resources/extensions/gsd/paths.ts
@@ -9,8 +9,70 @@
  * via prefix matching, so existing projects work without migration.
  */
 
-import { readdirSync, existsSync, Dirent } from "node:fs";
-import { join } from "node:path";
+import { readdirSync, existsSync, realpathSync, Dirent } from "node:fs";
+import { execSync } from "node:child_process";
+import { join, resolve } from "node:path";
+
+// ─── Main Worktree Resolution ─────────────────────────────────────────────────
+
+/**
+ * Cache for resolveMainWorktreeRoot(). Keyed by basePath, stores the resolved
+ * main worktree root (or basePath itself if not in a worktree).
+ */
+const mainWorktreeCache = new Map<string, string>();
+
+/**
+ * Resolve the main worktree root from any git worktree.
+ *
+ * When GSD runs inside a git worktree (e.g. `.gsd/worktrees/M001/`),
+ * `basePath` points to the worktree root. `.gsd/` must resolve relative
+ * to the **main** worktree so all worktrees share a single `.gsd/` state.
+ *
+ * Uses `git rev-parse --show-toplevel` from the git common dir to find
+ * the main worktree root. Falls back to basePath on error.
+ */
+export function resolveMainWorktreeRoot(basePath: string): string {
+  const cached = mainWorktreeCache.get(basePath);
+  if (cached !== undefined) return cached;
+
+  try {
+    // git-common-dir: the shared .git object store (same for all worktrees)
+    const gitCommonDir = execSync("git rev-parse --git-common-dir", {
+      cwd: basePath,
+      stdio: ["ignore", "pipe", "pipe"],
+      encoding: "utf-8",
+    }).trim();
+
+    // git-dir: the per-worktree .git reference
+    const gitDir = execSync("git rev-parse --git-dir", {
+      cwd: basePath,
+      stdio: ["ignore", "pipe", "pipe"],
+      encoding: "utf-8",
+    }).trim();
+
+    // If git-common-dir === git-dir, we're in the main worktree already
+    const resolvedCommon = resolve(basePath, gitCommonDir);
+    const resolvedGitDir = resolve(basePath, gitDir);
+
+    if (resolvedCommon === resolvedGitDir) {
+      mainWorktreeCache.set(basePath, basePath);
+      return basePath;
+    }
+
+    // We're in a linked worktree. The common dir is the main repo's .git/.
+    // The main worktree root is one level up from the common dir
+    // (e.g. /repo/.git → /repo).
+    let mainRoot = resolve(resolvedCommon, "..");
+    // Resolve symlinks to normalize paths (e.g. /var → /private/var on macOS)
+    if (existsSync(mainRoot)) mainRoot = realpathSync(mainRoot);
+    mainWorktreeCache.set(basePath, mainRoot);
+    return mainRoot;
+  } catch {
+    // Not a git repo or git not available — fall back to basePath
+    mainWorktreeCache.set(basePath, basePath);
+    return basePath;
+  }
+}
 
 // ─── Directory Listing Cache ──────────────────────────────────────────────────
 
@@ -41,6 +103,7 @@ function cachedReaddir(dirPath: string): string[] {
 export function clearPathCache(): void {
   dirEntryCache.clear();
   dirListCache.clear();
+  mainWorktreeCache.clear();
 }
 
 // ─── Name Builders ─────────────────────────────────────────────────────────
@@ -173,7 +236,7 @@ const LEGACY_GSD_ROOT_FILES: Record<GSDRootFileKey, string> = {
 };
 
 export function gsdRoot(basePath: string): string {
-  return join(basePath, ".gsd");
+  return join(resolveMainWorktreeRoot(basePath), ".gsd");
 }
 
 export function milestonesDir(basePath: string): string {

--- a/src/resources/extensions/gsd/tests/worktree-gsd-root.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-gsd-root.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Test: gsdRoot resolves to the main worktree's .gsd/ when running inside a git worktree.
+ *
+ * Verifies that all worktrees share a single .gsd/ directory (the main repo's)
+ * instead of each worktree getting its own isolated .gsd/.
+ */
+
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, realpathSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { execSync } from "node:child_process";
+
+import { gsdRoot, resolveMainWorktreeRoot, clearPathCache } from "../paths.ts";
+import { createTestContext } from "./test-helpers.ts";
+
+const { assertEq, assertTrue, report } = createTestContext();
+
+function run(command: string, cwd: string): string {
+  return execSync(command, { cwd, stdio: ["ignore", "pipe", "pipe"], encoding: "utf-8" }).trim();
+}
+
+// Create a temporary git repo (realpathSync to normalize macOS /var → /private/var)
+const mainRepo = realpathSync(mkdtempSync(join(tmpdir(), "gsd-worktree-root-test-")));
+run("git init -b main", mainRepo);
+run('git config user.name "GSD Test"', mainRepo);
+run('git config user.email "test@example.com"', mainRepo);
+mkdirSync(join(mainRepo, ".gsd", "milestones"), { recursive: true });
+writeFileSync(join(mainRepo, "README.md"), "test\n", "utf-8");
+run("git add .", mainRepo);
+run('git commit -m "init"', mainRepo);
+
+// Create a worktree
+const wtName = "test-wt";
+const wtPath = join(mainRepo, ".gsd", "worktrees", wtName);
+mkdirSync(join(mainRepo, ".gsd", "worktrees"), { recursive: true });
+run(`git worktree add -b worktree/${wtName} "${wtPath}" main`, mainRepo);
+
+async function main(): Promise<void> {
+  // Clear cache to ensure fresh resolution
+  clearPathCache();
+
+  console.log("\n=== resolveMainWorktreeRoot from main repo ===");
+  const mainRoot = resolveMainWorktreeRoot(mainRepo);
+  assertEq(mainRoot, mainRepo, "main repo resolves to itself");
+
+  console.log("\n=== resolveMainWorktreeRoot from worktree ===");
+  clearPathCache();
+  const wtRoot = resolveMainWorktreeRoot(wtPath);
+  assertEq(wtRoot, mainRepo, "worktree resolves to main repo root");
+
+  console.log("\n=== gsdRoot from main repo ===");
+  clearPathCache();
+  const mainGsd = gsdRoot(mainRepo);
+  assertEq(mainGsd, join(mainRepo, ".gsd"), "main repo .gsd/ path is correct");
+
+  console.log("\n=== gsdRoot from worktree ===");
+  clearPathCache();
+  const wtGsd = gsdRoot(wtPath);
+  assertEq(wtGsd, join(mainRepo, ".gsd"), "worktree .gsd/ resolves to main repo's .gsd/");
+
+  console.log("\n=== gsdRoot is same from both locations ===");
+  clearPathCache();
+  assertTrue(gsdRoot(mainRepo) === gsdRoot(wtPath), "gsdRoot identical from main and worktree");
+
+  console.log("\n=== non-git directory falls back to basePath ===");
+  clearPathCache();
+  const nonGitDir = mkdtempSync(join(tmpdir(), "gsd-no-git-"));
+  const nonGitRoot = resolveMainWorktreeRoot(nonGitDir);
+  assertEq(nonGitRoot, nonGitDir, "non-git dir falls back to itself");
+  rmSync(nonGitDir, { recursive: true, force: true });
+
+  // Cleanup
+  run(`git worktree remove --force "${wtPath}"`, mainRepo);
+  rmSync(mainRepo, { recursive: true, force: true });
+
+  report();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- When GSD runs inside a git worktree, `gsdRoot()` resolves `.gsd/` relative to the worktree root, creating an isolated `.gsd/` that doesn't share state with the main repo. This causes auto-mode loop detection failures (artifacts written to main `.gsd/` are invisible from the worktree's empty `.gsd/`).
- Adds `resolveMainWorktreeRoot()` to `paths.ts` that uses `git rev-parse --git-common-dir` vs `--git-dir` to detect linked worktrees and resolve back to the main repo root. `gsdRoot()` now routes through this resolver so all worktrees share one `.gsd/` state.
- Results are cached per basePath and cleared with `clearPathCache()`. Falls back to basePath for non-git directories.

## Test plan
- [x] New test `worktree-gsd-root.test.ts` verifies: main repo resolves to itself, worktree resolves to main repo, gsdRoot identical from both, non-git fallback works
- [x] All 292 existing unit tests pass with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)