### PR TITLE
fix: avoid resolving slice branches as main

### DIFF
--- a/native/crates/engine/src/git.rs
+++ b/native/crates/engine/src/git.rs
@@ -10,6 +10,30 @@ use git2::{Repository, StatusOptions};
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
 
+fn is_gsd_slice_branch(branch: &str) -> bool {
+    let mut parts = branch.split('/');
+    if parts.next() != Some("gsd") {
+        return false;
+    }
+
+    let second = match parts.next() {
+        Some(value) => value,
+        None => return false,
+    };
+
+    let (milestone, slice) = if second.starts_with('M') {
+        (second, parts.next())
+    } else {
+        let milestone = match parts.next() {
+            Some(value) => value,
+            None => return false,
+        };
+        (milestone, parts.next())
+    };
+
+    milestone.starts_with('M') && slice.map(|value| value.starts_with('S')).unwrap_or(false)
+}
+
 /// Open a git repository at the given path.
 fn open_repo(repo_path: &str) -> Result<Repository> {
     Repository::open(repo_path).map_err(|e| {
@@ -59,7 +83,9 @@ pub fn git_main_branch(repo_path: String) -> Result<String> {
         if let Ok(resolved) = reference.resolve() {
             if let Some(name) = resolved.name() {
                 if let Some(branch) = name.strip_prefix("refs/remotes/origin/") {
-                    return Ok(branch.to_string());
+                    if !is_gsd_slice_branch(branch) {
+                        return Ok(branch.to_string());
+                    }
                 }
             }
         }

--- a/src/resources/extensions/gsd/git-service.ts
+++ b/src/resources/extensions/gsd/git-service.ts
@@ -716,6 +716,13 @@ export class GitServiceImpl {
     const wtName = detectWorktreeName(this.basePath);
     const branch = getSliceBranchName(milestoneId, sliceId, wtName);
 
+    if (branch === mainBranch) {
+      throw new Error(
+        `Refusing to merge "${branch}" into itself — getMainBranch() resolved to a slice branch. ` +
+        `Fix the remote HEAD with: git remote set-head origin main`,
+      );
+    }
+
     if (!this.branchExists(branch)) {
       throw new Error(
         `Slice branch "${branch}" does not exist. Nothing to merge.`,

--- a/src/resources/extensions/gsd/native-git-bridge.ts
+++ b/src/resources/extensions/gsd/native-git-bridge.ts
@@ -27,6 +27,9 @@ let nativeModule: {
 
 let loadAttempted = false;
 
+// Keep native main-branch detection independent from worktree.ts to avoid a circular import.
+const GSD_SLICE_BRANCH_RE = /^gsd\/(?:[a-zA-Z0-9_-]+\/)?M\d+(?:-[a-z0-9]{6})?\/S\d+$/;
+
 function loadNative(): typeof nativeModule {
   if (loadAttempted) return nativeModule;
   loadAttempted = true;
@@ -85,14 +88,18 @@ export function nativeGetCurrentBranch(basePath: string): string {
 export function nativeDetectMainBranch(basePath: string): string {
   const native = loadNative();
   if (native) {
-    return native.gitMainBranch(basePath);
+    const nativeBranch = native.gitMainBranch(basePath);
+    if (!GSD_SLICE_BRANCH_RE.test(nativeBranch)) {
+      return nativeBranch;
+    }
   }
 
   // Fallback: same logic as GitServiceImpl.getMainBranch() repo-level detection
   const symbolic = gitExec(basePath, ["symbolic-ref", "refs/remotes/origin/HEAD"], true);
   if (symbolic) {
     const match = symbolic.match(/refs\/remotes\/origin\/(.+)$/);
-    if (match) return match[1]!;
+    const branch = match?.[1];
+    if (branch && !GSD_SLICE_BRANCH_RE.test(branch)) return branch;
   }
 
   const mainExists = gitExec(basePath, ["show-ref", "--verify", "refs/heads/main"], true);

--- a/src/resources/extensions/gsd/tests/git-service.test.ts
+++ b/src/resources/extensions/gsd/tests/git-service.test.ts
@@ -1033,6 +1033,30 @@ async function main(): Promise<void> {
     rmSync(repo, { recursive: true, force: true });
   }
 
+  // ─── mergeSliceToMain: error — refuses self-merge ─────────────────────
+
+  {
+    const repo = initBranchTestRepo();
+    const svc = new GitServiceImpl(repo, { main_branch: "gsd/M001/S01" });
+
+    svc.ensureSliceBranch("M001", "S01");
+    createFile(repo, "src/work.ts", "work");
+    svc.commit({ message: "slice work" });
+
+    let threw = false;
+    try {
+      svc.mergeSliceToMain("M001", "S01", "Some feature");
+    } catch (e) {
+      threw = true;
+      const msg = (e as Error).message;
+      assertTrue(msg.includes('Refusing to merge "gsd/M001/S01" into itself'), "error mentions self-merge refusal");
+      assertTrue(msg.includes("git remote set-head origin main"), "error includes remediation command");
+    }
+    assertTrue(threw, "mergeSliceToMain throws when main branch resolves to the slice branch");
+
+    rmSync(repo, { recursive: true, force: true });
+  }
+
   // ─── mergeSliceToMain: auto-resolve .gsd/ planning artifact conflicts ──
 
   console.log("\n=== mergeSliceToMain: auto-resolve .gsd/ planning conflicts ===");
@@ -1464,6 +1488,37 @@ async function main(): Promise<void> {
     assertEq(svc.getMainBranch(), "main", "getMainBranch falls back to auto-detection when main_branch not set");
 
     rmSync(repo, { recursive: true, force: true });
+  }
+
+  // ─── getMainBranch: ignores slice branch from origin/HEAD ─────────────
+
+  console.log("\n=== getMainBranch: ignores slice branch from origin/HEAD ===");
+
+  {
+    const bareDir = mkdtempSync(join(tmpdir(), "gsd-git-bare-"));
+    run("git init --bare -b main", bareDir);
+
+    const repo = initBranchTestRepo();
+    run(`git remote add origin ${bareDir}`, repo);
+    run("git push -u origin main", repo);
+
+    const svc = new GitServiceImpl(repo);
+    svc.ensureSliceBranch("M001", "S01");
+    createFile(repo, "src/slice.ts", "export const slice = true;");
+    svc.commit({ message: "slice work" });
+    run("git push -u origin gsd/M001/S01", repo);
+    svc.switchToMain();
+
+    run("git symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/gsd/M001/S01", repo);
+
+    assertEq(
+      svc.getMainBranch(),
+      "main",
+      "getMainBranch ignores origin/HEAD when it points at a slice branch",
+    );
+
+    rmSync(repo, { recursive: true, force: true });
+    rmSync(bareDir, { recursive: true, force: true });
   }
 
   // ─── getMainBranch: ignores invalid branch names ───────────────────────

--- a/src/resources/extensions/gsd/worktree-manager.ts
+++ b/src/resources/extensions/gsd/worktree-manager.ts
@@ -19,6 +19,8 @@ import { existsSync, mkdirSync, realpathSync } from "node:fs";
 import { execSync } from "node:child_process";
 import { join, resolve, sep } from "node:path";
 
+const GSD_SLICE_BRANCH_RE = /^gsd\/(?:[a-zA-Z0-9_-]+\/)?M\d+(?:-[a-z0-9]{6})?\/S\d+$/;
+
 // ─── Types ─────────────────────────────────────────────────────────────────
 
 export interface WorktreeInfo {
@@ -94,7 +96,8 @@ export function getMainBranch(basePath: string): string {
   const symbolic = runGit(basePath, ["symbolic-ref", "refs/remotes/origin/HEAD"], { allowFailure: true });
   if (symbolic) {
     const match = symbolic.match(/refs\/remotes\/origin\/(.+)$/);
-    if (match) return match[1]!;
+    const branch = match?.[1];
+    if (branch && !GSD_SLICE_BRANCH_RE.test(branch)) return branch;
   }
   if (runGit(basePath, ["show-ref", "--verify", "refs/heads/main"], { allowFailure: true })) return "main";
   if (runGit(basePath, ["show-ref", "--verify", "refs/heads/master"], { allowFailure: true })) return "master";


### PR DESCRIPTION
## Summary
- ignore GSD slice branches when deriving the repo main branch from origin/HEAD in both the TypeScript and native Rust paths
- refuse self-merges in mergeSliceToMain when main branch resolution is corrupted to a slice branch
- add regression coverage for origin/HEAD slice-branch fallback and self-merge refusal

## Testing
- node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/git-service.test.ts src/resources/extensions/gsd/tests/worktree.test.ts src/resources/extensions/gsd/tests/worktree-manager.test.ts src/resources/extensions/gsd/tests/worktree-integration.test.ts
- CARGO_TARGET_DIR=/tmp/gsd-issue-486-cargo-target cargo check -p gsd-engine --manifest-path native/Cargo.toml

Closes #486