### PR TITLE
fix(gitignore): self-heal blanket .gsd/ ignore from pre-v2.14.0 projects

### DIFF
--- a/src/resources/extensions/gsd/gitignore.ts
+++ b/src/resources/extensions/gsd/gitignore.ts
@@ -87,6 +87,28 @@ export function ensureGitignore(basePath: string): boolean {
     existing = readFileSync(gitignorePath, "utf-8");
   }
 
+  // Self-heal: remove blanket ".gsd/" lines from pre-v2.14.0 projects.
+  // The blanket ignore prevented planning artifacts (.gsd/milestones/) from
+  // being tracked in git, causing artifacts to vanish in worktrees and
+  // triggering loop detection failures. Replace with explicit runtime-only
+  // ignores so planning files are tracked naturally.
+  let modified = false;
+  const lines = existing.split("\n");
+  const filteredLines = lines.filter(line => {
+    const trimmed = line.trim();
+    // Remove standalone ".gsd/" lines (blanket ignore) but keep specific
+    // .gsd/ subpath patterns like ".gsd/activity/" or ".gsd/auto.lock"
+    if (trimmed === ".gsd/" || trimmed === ".gsd") {
+      modified = true;
+      return false;
+    }
+    return true;
+  });
+  if (modified) {
+    existing = filteredLines.join("\n");
+    writeFileSync(gitignorePath, existing, "utf-8");
+  }
+
   // Parse existing lines (trimmed, ignoring comments and blanks)
   const existingLines = new Set(
     existing
@@ -98,7 +120,7 @@ export function ensureGitignore(basePath: string): boolean {
   // Find patterns not yet present
   const missing = BASELINE_PATTERNS.filter((p) => !existingLines.has(p));
 
-  if (missing.length === 0) return false;
+  if (missing.length === 0) return modified;
 
   // Build the block to append
   const block = [


### PR DESCRIPTION
## Problem

Projects created before v2.14.0 have a blanket `.gsd/` line in `.gitignore`. The branchless architecture PR (#506) fixed the GSD repo's own `.gitignore` and the `ensureGitignore` bootstrap patterns, but existing projects keep the blanket ignore forever because `ensureGitignore` only appends — it never removes stale patterns.

This causes: new auto-worktrees start with zero planning state → auto-mode re-executes completed slices → wasted cost.

## Fix

`ensureGitignore()` now scans for standalone `.gsd/` or `.gsd` lines and removes them before appending the explicit runtime-only patterns. Specific `.gsd/` subpath patterns (like `.gsd/activity/`) are preserved.

Self-heals on next auto-mode start in any project.

## Test plan
- [x] `npx tsc --noEmit` — compiles clean
- [x] `npm run test` — 288/288 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)