### PR TITLE
fix(session): update cwd on newSession to reflect worktree chdir

### DIFF
--- a/packages/pi-coding-agent/src/core/agent-session.ts
+++ b/packages/pi-coding-agent/src/core/agent-session.ts
@@ -1354,6 +1354,9 @@ export class AgentSession {
 		this._disconnectFromAgent();
 		await this.abort();
 		this.agent.reset();
+		// Update cwd to current process directory — auto-mode may have chdir'd
+		// into a worktree since the original session was created.
+		this._cwd = process.cwd();
 		this.sessionManager.newSession({ parentSession: options?.parentSession });
 		this.agent.sessionId = this.sessionManager.getSessionId();
 		this._steeringMessages = [];


### PR DESCRIPTION
## Problem

`AgentSession._cwd` is set once at session creation and never updated. When auto-mode creates a worktree and calls `process.chdir(worktreePath)`, every subsequent `newSession()` still tells the LLM "Current working directory: /original/project/root" in the system prompt. The LLM then uses `cd /original/project/root` in bash commands, writing files to the main repo instead of the worktree.

This is the root cause of:
- complete-slice loop (artifacts written to main repo, invisible in worktree)
- plan-slice loop (same mechanism)
- $22+ burned on the crossword-game project re-running S01 four times

## Fix

One line: `this._cwd = process.cwd()` at the start of `newSession()`.

The system prompt now reflects the actual working directory after any `process.chdir()` that occurred since the last session.

## Test plan
- [x] `npx tsc --noEmit` — compiles clean
- [x] `npm run test` — 288/288 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)