### PR TITLE
refactor: gate v1 migration code behind dynamic import

### DIFF
--- a/src/resources/extensions/gsd/commands.ts
+++ b/src/resources/extensions/gsd/commands.ts
@@ -31,7 +31,7 @@ import {
   filterDoctorIssues,
 } from "./doctor.js";
 import { loadPrompt } from "./prompt-loader.js";
-import { handleMigrate } from "./migrate/command.js";
+
 import { handleRemote } from "../remote-questions/remote-command.js";
 import { handleHistory } from "./history.js";
 import { handleUndo } from "./undo.js";
@@ -249,6 +249,7 @@ export function registerGSDCommand(pi: ExtensionAPI): void {
       }
 
       if (trimmed === "migrate" || trimmed.startsWith("migrate ")) {
+        const { handleMigrate } = await import("./migrate/command.js");
         await handleMigrate(trimmed.replace(/^migrate\s*/, "").trim(), ctx, pi);
         return;
       }


### PR DESCRIPTION
## Summary
- Replaces the static top-level `import { handleMigrate } from "./migrate/command.js"` in `commands.ts` with a dynamic `await import()` inside the `/gsd migrate` handler
- The migrate/ directory (1,862 lines, 9 files) is one-time v1 `.planning/` → `.gsd/` migration code — no reason to load it on every startup
- Follows the existing pattern already used in this file for `post-unit-hooks.js`, `metrics.js`, and `history.js`

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] All 123 GSD tests pass
- [ ] Manual: `/gsd migrate` still works when a `.planning/` directory exists

Closes #523

🤖 Generated with [Claude Code](https://claude.com/claude-code)