### PR TITLE
fix: add missing resolveSkillDiscoveryMode import in auto.ts

### DIFF
--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -39,7 +39,7 @@ import {
   readUnitRuntimeRecord,
   writeUnitRuntimeRecord,
 } from "./unit-runtime.js";
-import { resolveAutoSupervisorConfig, resolveModelWithFallbacksForUnit, loadEffectiveGSDPreferences } from "./preferences.js";
+import { resolveAutoSupervisorConfig, resolveModelWithFallbacksForUnit, resolveSkillDiscoveryMode, loadEffectiveGSDPreferences } from "./preferences.js";
 import { sendDesktopNotification } from "./notifications.js";
 import type { GSDPreferences } from "./preferences.js";
 import {


### PR DESCRIPTION
## Summary

Fixes runtime error: `Extension "command:gsd" error: resolveSkillDiscoveryMode is not defined`

The `resolveSkillDiscoveryMode()` function is called at line 687 in `auto.ts` but was not included in the import statement from `./preferences.js`.

### Environment

- **GSD version**: 2.15.0
- **Node**: v25.6.1
- **OS**: macOS Darwin 25.2.0 (Apple Silicon)

### Regression trace

1. **PR #441** (`f4479d3a`): Added `resolveSkillDiscoveryMode` import and usage — working correctly
2. **PR #534** (`58f7c5e5`): Decompose refactor removed both the import and usage (moved skill snapshot logic to `auto-prompts.ts`)
3. **PR #530/#531** (`92555955`): Merge conflict resolution re-introduced the `resolveSkillDiscoveryMode()` call at line 687 but did **not** re-add the import

**Regressed by: PR #530/#531** — conflict resolution during merge of the decompose refactor (#534) and the merge loop fix.

One-line fix: add `resolveSkillDiscoveryMode` to the existing import from `./preferences.js`.

## Test plan

- [ ] Verify `/gsd auto` starts without the "resolveSkillDiscoveryMode is not defined" error
- [ ] Verify skill discovery mode preference is respected (off/suggest/auto)

🤖 Generated with [Claude Code](https://claude.com/claude-code)