### PR TITLE
fix(auto): refresh progress widget from disk every 5s during unit execution

### DIFF
--- a/src/resources/extensions/gsd/auto-dashboard.ts
+++ b/src/resources/extensions/gsd/auto-dashboard.ts
@@ -265,6 +265,16 @@ export function updateProgressWidget(
       tui.requestRender();
     }, 800);
 
+    // Refresh progress cache from disk every 5s so the widget reflects
+    // task/slice completion mid-unit. Without this, the progress bar only
+    // updates at dispatch time, appearing frozen during long-running units.
+    const progressRefreshTimer = mid ? setInterval(() => {
+      try {
+        updateSliceProgressCache(accessors.getBasePath(), mid.id, slice?.id);
+        cachedLines = undefined;
+      } catch { /* non-fatal */ }
+    }, 5_000) : null;
+
     return {
       render(width: number): string[] {
         if (cachedLines && cachedWidth === width) return cachedLines;
@@ -416,6 +426,7 @@ export function updateProgressWidget(
       },
       dispose() {
         clearInterval(pulseTimer);
+        if (progressRefreshTimer) clearInterval(progressRefreshTimer);
       },
     };
   });


### PR DESCRIPTION
## Summary

Fixes #549 — progress indicator shows no update during auto-mode execution.

### Root cause

The auto-mode progress widget reads from `cachedSliceProgress` (via `getRoadmapSlicesSync()`), which is only populated by `updateSliceProgressCache()`. That function has always had a single call site — at dispatch time in `dispatchNextUnit()` (line 1681 in `auto.ts`). During a unit's entire execution, the cache is never refreshed, so the progress bar appears frozen.

**This is a design limitation from the initial commit**, not a recent regression. However, it became significantly more noticeable after **PR #506** (`cc501bc8` — branchless worktree architecture, landed in v2.14.0) because:

1. **Longer-running units** — worktree setup adds overhead, units take longer, making stale progress more visible
2. **Root vs worktree state divergence** — users see root `.gsd/STATE.md` (stale) while real work happens in the worktree's `.gsd/`

### Fix

Add a 5-second `setInterval` inside the widget that re-reads the roadmap and plan files from disk via `updateSliceProgressCache()`. The timer is:
- Only created when a milestone is active (`mid` is defined)
- Cleaned up in `dispose()` alongside the existing pulse timer
- Wrapped in try/catch so I/O failures don't crash the widget

## Test plan

- [ ] Verify progress bar updates mid-unit when a task checkbox is marked `[x]` on disk
- [ ] Verify progress bar updates when slice completion changes in the roadmap
- [ ] Verify widget disposes cleanly (no leaked timers) when auto-mode stops
- [ ] Verify no performance impact from 5s disk reads during normal operation

🤖 Generated with [Claude Code](https://claude.com/claude-code)