### PR TITLE
fix(undo): use invalidateAllCaches to prevent stale state after undo

### DIFF
--- a/src/resources/extensions/gsd/undo.ts
+++ b/src/resources/extensions/gsd/undo.ts
@@ -6,7 +6,8 @@ import type { ExtensionCommandContext, ExtensionAPI } from "@gsd/pi-coding-agent
 import { existsSync, readFileSync, writeFileSync, unlinkSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 import { execFileSync } from "node:child_process";
-import { deriveState, invalidateStateCache } from "./state.js";
+import { deriveState } from "./state.js";
+import { invalidateAllCaches } from "./cache.js";
 import { gsdRoot, resolveTasksDir, resolveSlicePath, buildTaskFileName } from "./paths.js";
 import { sendDesktopNotification } from "./notifications.js";
 
@@ -118,7 +119,7 @@ export async function handleUndo(args: string, ctx: ExtensionCommandContext, _pi
   }
 
   // 6. Re-derive state
-  invalidateStateCache();
+  invalidateAllCaches();
   await deriveState(basePath);
 
   // Build result message


### PR DESCRIPTION
## Summary
- `/gsd undo` was only calling `invalidateStateCache()` after deleting summary files and modifying PLAN files
- Path and parse caches remained stale, causing `deriveState()` to return incorrect results — showing undone tasks as still complete
- Replaced with `invalidateAllCaches()` to clear all three cache layers (state, path, parse) atomically

## Test plan
- [x] Build passes with zero errors
- [x] All 357 unit tests pass
- [x] All 7 integration tests pass
- [ ] Manual: run `/gsd undo --force` on a completed task and verify state correctly reflects the undo