### PR TITLE
feat: default to Opus 4.6 1M context variant

### DIFF
--- a/packages/pi-coding-agent/src/core/model-resolver.ts
+++ b/packages/pi-coding-agent/src/core/model-resolver.ts
@@ -13,7 +13,7 @@ import type { ModelRegistry } from "./model-registry.js";
 /** Default model IDs for each known provider */
 export const defaultModelPerProvider: Record<KnownProvider, string> = {
 	"amazon-bedrock": "us.anthropic.claude-opus-4-6-v1",
-	anthropic: "claude-opus-4-6",
+	anthropic: "claude-opus-4-6[1m]",
 	openai: "gpt-5.4",
 	"azure-openai-responses": "gpt-5.2",
 	"openai-codex": "gpt-5.4",
@@ -23,7 +23,7 @@ export const defaultModelPerProvider: Record<KnownProvider, string> = {
 	"google-vertex": "gemini-3-pro-preview",
 	"github-copilot": "gpt-4o",
 	openrouter: "openai/gpt-5.1-codex",
-	"vercel-ai-gateway": "anthropic/claude-opus-4-6",
+	"vercel-ai-gateway": "anthropic/claude-opus-4-6[1m]",
 	xai: "grok-4-fast-non-reasoning",
 	groq: "openai/gpt-oss-120b",
 	cerebras: "zai-glm-4.6",


### PR DESCRIPTION
## Summary
- Updates default Anthropic model from `claude-opus-4-6` (200k context) to `claude-opus-4-6[1m]` (1M context)
- Applies to both `anthropic` and `vercel-ai-gateway` provider defaults

## Test plan
- [ ] Verify `gsd --list-models` still shows correct default
- [ ] Confirm new sessions start with the 1M context variant
- [ ] Test `--model claude-opus-4-6` still works for explicit 200k selection

🤖 Generated with [Claude Code](https://claude.com/claude-code)