### PR TITLE
fix: load tool API keys from auth.json at session startup

### DIFF
--- a/src/resources/extensions/gsd/commands.ts
+++ b/src/resources/extensions/gsd/commands.ts
@@ -628,13 +628,39 @@ function serializePreferencesToFrontmatter(prefs: Record<string, unknown>): stri
 
 // ─── Tool Config Wizard ───────────────────────────────────────────────────────
 
-const TOOL_KEYS = [
+/**
+ * Tool API key configurations.
+ * This is the source of truth for tool credentials - used by both the config wizard
+ * and session startup to load keys from auth.json into environment variables.
+ */
+export const TOOL_KEYS = [
   { id: "tavily",   env: "TAVILY_API_KEY",   label: "Tavily Search",     hint: "tavily.com/app/api-keys" },
   { id: "brave",    env: "BRAVE_API_KEY",     label: "Brave Search",      hint: "brave.com/search/api" },
   { id: "context7", env: "CONTEXT7_API_KEY",  label: "Context7 Docs",     hint: "context7.com/dashboard" },
   { id: "jina",     env: "JINA_API_KEY",      label: "Jina Page Extract", hint: "jina.ai/api" },
   { id: "groq",     env: "GROQ_API_KEY",      label: "Groq Voice",        hint: "console.groq.com" },
 ] as const;
+
+/**
+ * Load tool API keys from auth.json into environment variables.
+ * Called at session startup to ensure tools have access to their credentials.
+ */
+export function loadToolApiKeys(): void {
+  try {
+    const authPath = join(process.env.HOME ?? "", ".gsd", "agent", "auth.json");
+    if (!existsSync(authPath)) return;
+
+    const auth = AuthStorage.create(authPath);
+    for (const tool of TOOL_KEYS) {
+      const cred = auth.get(tool.id);
+      if (cred && "key" in cred && cred.key && !process.env[tool.env]) {
+        process.env[tool.env] = cred.key;
+      }
+    }
+  } catch {
+    // Failed to load tool keys — ignore, they can still be set via env vars
+  }
+}
 
 function getConfigAuthStorage(): InstanceType<typeof AuthStorage> {
   const authPath = join(process.env.HOME ?? "", ".gsd", "agent", "auth.json");

--- a/src/resources/extensions/gsd/index.ts
+++ b/src/resources/extensions/gsd/index.ts
@@ -25,7 +25,7 @@ import type {
 } from "@gsd/pi-coding-agent";
 import { createBashTool, createWriteTool, createReadTool, createEditTool, isToolCallEventType } from "@gsd/pi-coding-agent";
 
-import { registerGSDCommand } from "./commands.js";
+import { registerGSDCommand, loadToolApiKeys } from "./commands.js";
 import { registerExitCommand } from "./exit-command.js";
 import { registerWorktreeCommand, getWorktreeOriginalCwd, getActiveWorktreeName } from "./worktree-command.js";
 import { saveFile, formatContinue, loadFile, parseContinue, parseSummary } from "./files.js";
@@ -188,7 +188,7 @@ export default function (pi: ExtensionAPI) {
   };
   pi.registerTool(dynamicEdit as any);
 
-  // ── session_start: render branded GSD header + remote channel status ──
+  // ── session_start: render branded GSD header + load tool keys + remote status ──
   pi.on("session_start", async (_event, ctx) => {
     // Theme access throws in RPC mode (no TUI) — header is decorative, skip it
     try {
@@ -203,6 +203,9 @@ export default function (pi: ExtensionAPI) {
     } catch {
       // RPC mode — no TUI, skip header rendering
     }
+
+    // Load tool API keys from auth.json into environment
+    loadToolApiKeys();
 
     // Notify remote questions status if configured
     try {


### PR DESCRIPTION
# Fix: Load Tool API Keys from auth.json at Session Startup

## Problem

Tool-based extensions (Context7, Brave Search, Jina Page Extract, Tavily Search, Groq Voice) were not functioning because API keys stored in `~/.gsd/agent/auth.json` were not being loaded into environment variables at session startup.

Users had to manually run `/gsd config` every time they started pi to load their API keys into `process.env`.

## Root Cause

The `session_start` event handler in `src/resources/extensions/gsd/index.ts` did not load API keys from `auth.json`. Keys were only set when the user explicitly ran `/gsd config`.

Extensions read API keys from `process.env` (e.g., `process.env.CONTEXT7_API_KEY`, `process.env.BRAVE_API_KEY`), not directly from `auth.json`. This is by design - it allows extensions to be simple and rely on standard environment variable patterns.

## Solution

### Changes Made

1. **`src/resources/extensions/gsd/commands.ts`**
   - Exported `TOOL_KEYS` constant (previously private)
   - Added `loadToolApiKeys()` function that:
     - Reads `~/.gsd/agent/auth.json`
     - Loads each tool's API key into `process.env` if not already set
     - Gracefully handles missing file or read errors

2. **`src/resources/extensions/gsd/index.ts`**
   - Imported `loadToolApiKeys` from `commands.js`
   - Called `loadToolApiKeys()` in the `session_start` handler

### Code Added

```typescript
/**
 * Tool API key configurations.
 * This is the source of truth for tool credentials - used by both the config wizard
 * and session startup to load keys from auth.json into environment variables.
 */
export const TOOL_KEYS = [
  { id: "tavily",   env: "TAVILY_API_KEY",   label: "Tavily Search",     hint: "tavily.com/app/api-keys" },
  { id: "brave",    env: "BRAVE_API_KEY",     label: "Brave Search",      hint: "brave.com/search/api" },
  { id: "context7", env: "CONTEXT7_API_KEY",  label: "Context7 Docs",     hint: "context7.com/dashboard" },
  { id: "jina",     env: "JINA_API_KEY",      label: "Jina Page Extract", hint: "jina.ai/api" },
  { id: "groq",     env: "GROQ_API_KEY",      label: "Groq Voice",        hint: "console.groq.com" },
] as const;

/**
 * Load tool API keys from auth.json into environment variables.
 * Called at session startup to ensure tools have access to their credentials.
 */
export function loadToolApiKeys(): void {
  try {
    const authPath = join(process.env.HOME ?? "", ".gsd", "agent", "auth.json");
    if (!existsSync(authPath)) return;

    const auth = AuthStorage.create(authPath);
    for (const tool of TOOL_KEYS) {
      const cred = auth.get(tool.id);
      if (cred && "key" in cred && cred.key && !process.env[tool.env]) {
        process.env[tool.env] = cred.key;
      }
    }
  } catch {
    // Failed to load tool keys — ignore, they can still be set via env vars
  }
}
```

## Impact

After this fix:
- All tool-based extensions work immediately when pi starts
- No need to run `/gsd config` unless adding/changing API keys
- API keys set via environment variables take precedence (not overwritten)
- Graceful fallback if `auth.json` is missing or unreadable

## Testing

1. Set API keys via `/gsd config` (or edit `~/.gsd/agent/auth.json` directly)
2. Restart pi
3. Use any tool-based extension (Context7, Brave Search, etc.)
4. Verify it works without running `/gsd config` again

## Related

- Closes #554
- Consistent with existing `AuthStorage` pattern used throughout the codebase
