### PR TITLE
fix: resolve TypeScript errors in async-jobs extension

### DIFF
--- a/src/resources/extensions/async-jobs/async-bash-tool.ts
+++ b/src/resources/extensions/async-jobs/async-bash-tool.ts
@@ -71,7 +71,7 @@ export function createAsyncBashTool(
 			"Check /jobs to see all running and recent background jobs.",
 		],
 		parameters: schema,
-		async execute(_toolCallId, params) {
+		async execute(_toolCallId, params, _signal, _onUpdate, _ctx) {
 			const manager = getManager();
 			const cwd = getCwd();
 			const { command, timeout, label } = params;
@@ -91,6 +91,7 @@ export function createAsyncBashTool(
 						"Use `await_job` to get results when ready, or `cancel_job` to stop.",
 					].join("\n"),
 				}],
+				details: undefined,
 			};
 		},
 	};

--- a/src/resources/extensions/async-jobs/await-tool.ts
+++ b/src/resources/extensions/async-jobs/await-tool.ts
@@ -24,7 +24,7 @@ export function createAwaitTool(getManager: () => AsyncJobManager): ToolDefiniti
 		description:
 			"Wait for background jobs to complete. Provide specific job IDs or omit to wait for the next job that finishes. Returns results of completed jobs.",
 		parameters: schema,
-		async execute(_toolCallId, params) {
+		async execute(_toolCallId, params, _signal, _onUpdate, _ctx) {
 			const manager = getManager();
 			const { jobs: jobIds } = params;
 
@@ -43,6 +43,7 @@ export function createAwaitTool(getManager: () => AsyncJobManager): ToolDefiniti
 				if (notFound.length > 0 && watched.length === 0) {
 					return {
 						content: [{ type: "text", text: `No jobs found: ${notFound.join(", ")}` }],
+						details: undefined,
 					};
 				}
 			} else {
@@ -50,6 +51,7 @@ export function createAwaitTool(getManager: () => AsyncJobManager): ToolDefiniti
 				if (watched.length === 0) {
 					return {
 						content: [{ type: "text", text: "No running background jobs." }],
+						details: undefined,
 					};
 				}
 			}
@@ -59,7 +61,7 @@ export function createAwaitTool(getManager: () => AsyncJobManager): ToolDefiniti
 			if (running.length === 0) {
 				const result = formatResults(watched);
 				manager.acknowledgeDeliveries(watched.map((j) => j.id));
-				return { content: [{ type: "text", text: result }] };
+				return { content: [{ type: "text", text: result }], details: undefined };
 			}
 
 			// Wait for at least one to complete
@@ -75,7 +77,7 @@ export function createAwaitTool(getManager: () => AsyncJobManager): ToolDefiniti
 				result += `\n\n**Still running:** ${stillRunning.map((j) => `${j.id} (${j.label})`).join(", ")}`;
 			}
 
-			return { content: [{ type: "text", text: result }] };
+			return { content: [{ type: "text", text: result }], details: undefined };
 		},
 	};
 }

--- a/src/resources/extensions/async-jobs/cancel-job-tool.ts
+++ b/src/resources/extensions/async-jobs/cancel-job-tool.ts
@@ -16,7 +16,7 @@ export function createCancelJobTool(getManager: () => AsyncJobManager): ToolDefi
 		label: "Cancel Background Job",
 		description: "Cancel a running background job by its ID.",
 		parameters: schema,
-		async execute(_toolCallId, params) {
+		async execute(_toolCallId, params, _signal, _onUpdate, _ctx) {
 			const manager = getManager();
 			const result = manager.cancel(params.job_id);
 
@@ -28,6 +28,7 @@ export function createCancelJobTool(getManager: () => AsyncJobManager): ToolDefi
 
 			return {
 				content: [{ type: "text", text: messages[result] ?? `Unknown result: ${result}` }],
+				details: undefined,
 			};
 		},
 	};

--- a/src/resources/extensions/async-jobs/index.ts
+++ b/src/resources/extensions/async-jobs/index.ts
@@ -62,7 +62,7 @@ export default function AsyncJobs(pi: ExtensionAPI) {
 							"",
 							truncatedOutput,
 						].join("\n"),
-						display: `Background job ${job.id} ${job.status}`,
+						display: true,
 					},
 					{ deliverAs: "followUp", triggerTurn: true },
 				);
@@ -92,7 +92,7 @@ export default function AsyncJobs(pi: ExtensionAPI) {
 				pi.sendMessage({
 					customType: "async_jobs_list",
 					content: "No async job manager active.",
-					display: "No jobs",
+					display: true,
 				});
 				return;
 			}
@@ -126,7 +126,7 @@ export default function AsyncJobs(pi: ExtensionAPI) {
 			pi.sendMessage({
 				customType: "async_jobs_list",
 				content: lines.join("\n"),
-				display: `${running.length} running, ${completed.length} recent`,
+				display: true,
 			});
 		},
 	});


### PR DESCRIPTION
## Summary
- Add missing `signal`, `onUpdate`, and `ctx` parameters to `execute` signatures in `async-bash-tool.ts`, `await-tool.ts`, and `cancel-job-tool.ts`
- Add `details: undefined` to all return objects to satisfy `AgentToolResult<T>` type requirement
- Fix `display` property from string to boolean in `index.ts` `sendMessage` calls (lines 65, 95, 129)

Part of enabling `tsc --project tsconfig.extensions.json` in CI to catch type errors in extensions before they ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)