### PR TITLE
fix: resolve TypeScript errors in GSD test files

### DIFF
--- a/src/resources/extensions/gsd/tests/auto-worktree.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-worktree.test.ts
@@ -141,7 +141,7 @@ async function main(): Promise<void> {
     }
   }
 
-  report("auto-worktree");
+  report();
 }
 
 main();

--- a/src/resources/extensions/gsd/tests/integration-mixed-milestones.test.ts
+++ b/src/resources/extensions/gsd/tests/integration-mixed-milestones.test.ts
@@ -502,7 +502,7 @@ Built the legacy feature successfully.
 // When run via vitest, wrap in test(); when run via tsx, call directly.
 const isVitest = typeof globalThis !== 'undefined' && (globalThis as any).__vitest_worker__?.config?.defines != null && 'vitest' in (globalThis as any).__vitest_worker__.config.defines || process.env.VITEST;
 if (isVitest) {
-  const { test } = await import('vitest');
+  const { test } = await import('node:test');
   test('integration-mixed-milestones: all groups pass', async () => {
     await main();
   });

--- a/src/resources/extensions/gsd/tests/preferences-git.test.ts
+++ b/src/resources/extensions/gsd/tests/preferences-git.test.ts
@@ -25,7 +25,7 @@ async function main(): Promise<void> {
 
   // Invalid values produce errors
   {
-    const { errors } = validatePreferences({ git: { isolation: "invalid" } });
+    const { errors } = validatePreferences({ git: { isolation: "invalid" as any } });
     assertTrue(errors.length > 0, "isolation: invalid — produces error");
     assertTrue(errors[0].includes("worktree, branch"), "isolation: invalid — error mentions valid values");
   }
@@ -41,12 +41,12 @@ async function main(): Promise<void> {
 
   // Any value produces a deprecation warning
   {
-    const { warnings } = validatePreferences({ git: { merge_to_main: "milestone" } });
+    const { warnings } = validatePreferences({ git: { merge_to_main: "milestone" } as any });
     assertTrue(warnings.length > 0, "merge_to_main: milestone — produces deprecation warning");
     assertTrue(warnings[0].includes("deprecated"), "merge_to_main: milestone — warning mentions deprecated");
   }
   {
-    const { warnings } = validatePreferences({ git: { merge_to_main: "slice" } });
+    const { warnings } = validatePreferences({ git: { merge_to_main: "slice" } as any });
     assertTrue(warnings.length > 0, "merge_to_main: slice — produces deprecation warning");
     assertTrue(warnings[0].includes("deprecated"), "merge_to_main: slice — warning mentions deprecated");
   }
@@ -55,13 +55,13 @@ async function main(): Promise<void> {
   {
     const { preferences, warnings } = validatePreferences({ git: { auto_push: true } });
     assertEq(warnings.length, 0, "merge_to_main: undefined — no warnings");
-    assertEq(preferences.git?.merge_to_main, undefined, "merge_to_main: undefined — not set");
+    assertEq((preferences.git as any)?.merge_to_main, undefined, "merge_to_main: undefined — not set");
   }
 
   console.log("\n=== isolation + deprecated merge_to_main together ===");
   {
     const { warnings, errors } = validatePreferences({
-      git: { isolation: "branch", merge_to_main: "slice" },
+      git: { isolation: "branch", merge_to_main: "slice" } as any,
     });
     assertEq(errors.length, 0, "branch isolation + deprecated merge_to_main — no errors");
     assertEq(warnings.length, 1, "branch isolation + deprecated merge_to_main — 1 warning (merge_to_main only)");

--- a/src/resources/extensions/gsd/tests/preferences-hooks.test.ts
+++ b/src/resources/extensions/gsd/tests/preferences-hooks.test.ts
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 Jeremy McSpadden <jeremy@fluxlabs.net>
 
 import { createTestContext } from "./test-helpers.ts";
+import type { PreDispatchHookConfig } from "../types.ts";
 
 const { assertEq, assertTrue, report } = createTestContext();
 
@@ -141,16 +142,16 @@ console.log("\n=== Pre-dispatch action validation ===");
 console.log("\n=== Pre-dispatch hook merging ===");
 
 {
-  const baseHooks = [
-    { name: "inject", before: ["execute-task"], action: "modify" as const, prepend: "base" },
+  const baseHooks: PreDispatchHookConfig[] = [
+    { name: "inject", before: ["execute-task"], action: "modify", prepend: "base" },
   ];
 
-  const overrideHooks = [
-    { name: "inject", before: ["execute-task"], action: "modify" as const, prepend: "override" },
-    { name: "gate", before: ["plan-slice"], action: "skip" as const },
+  const overrideHooks: PreDispatchHookConfig[] = [
+    { name: "inject", before: ["execute-task"], action: "modify", prepend: "override" },
+    { name: "gate", before: ["plan-slice"], action: "skip" },
   ];
 
-  const merged = [...baseHooks];
+  const merged: PreDispatchHookConfig[] = [...baseHooks];
   for (const hook of overrideHooks) {
     const idx = merged.findIndex(h => h.name === hook.name);
     if (idx >= 0) {

--- a/src/resources/extensions/gsd/tests/unique-milestone-ids.test.ts
+++ b/src/resources/extensions/gsd/tests/unique-milestone-ids.test.ts
@@ -207,7 +207,7 @@ async function main(): Promise<void> {
 // When run via vitest, wrap in test(); when run via tsx, call directly.
 const isVitest = typeof globalThis !== 'undefined' && (globalThis as any).__vitest_worker__?.config?.defines != null && 'vitest' in (globalThis as any).__vitest_worker__.config.defines || process.env.VITEST;
 if (isVitest) {
-  const { test } = await import('vitest');
+  const { test } = await import('node:test');
   test('unique-milestone-ids: all ID primitives handle both formats', async () => {
     await main();
   });


### PR DESCRIPTION
## Summary
- Fix function call argument mismatch in auto-worktree test
- Fix vitest module resolution in integration tests
- Update preferences-git tests for current GitPreferences type
- Fix discriminated union narrowing in preferences-hooks test

Part of enabling `tsc --project tsconfig.extensions.json` in CI to catch type errors in extensions before they ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)