### PR TITLE
fix: resolve TypeScript errors in GSD extension

### DIFF
--- a/packages/pi-coding-agent/src/core/extensions/types.ts
+++ b/packages/pi-coding-agent/src/core/extensions/types.ts
@@ -117,7 +117,7 @@ export interface ExtensionUIContext {
 	input(title: string, placeholder?: string, opts?: ExtensionUIDialogOptions): Promise<string | undefined>;
 
 	/** Show a notification to the user. */
-	notify(message: string, type?: "info" | "warning" | "error"): void;
+	notify(message: string, type?: "info" | "warning" | "error" | "success"): void;
 
 	/** Listen to raw terminal input (interactive mode only). Returns an unsubscribe function. */
 	onTerminalInput(handler: TerminalInputHandler): () => void;

--- a/packages/pi-coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/interactive-mode.ts
@@ -1728,7 +1728,7 @@ export class InteractiveMode {
 	/**
 	 * Show a notification for extensions.
 	 */
-	private showExtensionNotify(message: string, type?: "info" | "warning" | "error"): void {
+	private showExtensionNotify(message: string, type?: "info" | "warning" | "error" | "success"): void {
 		if (type === "error") {
 			this.showError(message);
 		} else if (type === "warning") {

--- a/packages/pi-coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/pi-coding-agent/src/modes/rpc/rpc-mode.ts
@@ -133,7 +133,7 @@ export async function runRpcMode(session: AgentSession): Promise<never> {
 				"cancelled" in r && r.cancelled ? undefined : "value" in r ? r.value : undefined,
 			),
 
-		notify(message: string, type?: "info" | "warning" | "error"): void {
+		notify(message: string, type?: "info" | "warning" | "error" | "success"): void {
 			// Fire and forget - no response needed
 			output({
 				type: "extension_ui_request",

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -1270,6 +1270,7 @@ async function dispatchNextUnit(
     if (currentMilestoneId && isInAutoWorktree(basePath) && originalBasePath) {
       try {
         const roadmapPath = resolveMilestoneFile(originalBasePath, currentMilestoneId, "ROADMAP");
+        if (!roadmapPath) throw new Error(`Cannot resolve ROADMAP file for milestone ${currentMilestoneId}`);
         const roadmapContent = readFileSync(roadmapPath, "utf-8");
         const mergeResult = mergeMilestoneToMain(originalBasePath, currentMilestoneId, roadmapContent);
         basePath = originalBasePath;
@@ -1355,7 +1356,7 @@ async function dispatchNextUnit(
   const contextThreshold = prefs?.context_pause_threshold ?? 0; // 0 = disabled by default
   if (contextThreshold > 0 && cmdCtx) {
     const contextUsage = cmdCtx.getContextUsage();
-    if (contextUsage && contextUsage.percent >= contextThreshold) {
+    if (contextUsage && contextUsage.percent !== null && contextUsage.percent >= contextThreshold) {
       const msg = `Context window at ${contextUsage.percent}% (threshold: ${contextThreshold}%). Pausing to prevent truncated output.`;
       ctx.ui.notify(`${msg} Run /gsd auto to continue (will start fresh session).`, "warning");
       sendDesktopNotification("GSD", `Context ${contextUsage.percent}% — paused`, "warning", "attention");
@@ -1406,6 +1407,13 @@ async function dispatchNextUnit(
     }
     await stopAuto(ctx, pi);
     ctx.ui.notify(dispatchResult.reason, dispatchResult.level);
+    return;
+  }
+
+  if (dispatchResult.action !== "dispatch") {
+    // skip action — yield and re-dispatch
+    await new Promise(r => setImmediate(r));
+    await dispatchNextUnit(ctx, pi);
     return;
   }
 

--- a/src/resources/extensions/gsd/commands.ts
+++ b/src/resources/extensions/gsd/commands.ts
@@ -417,7 +417,7 @@ async function handlePrefsWizard(
       const title = `Model for ${phase} phase${current ? ` (current: ${current})` : ""}:`;
       const choice = await ctx.ui.select(title, modelOptions);
 
-      if (choice && choice !== "(keep current)") {
+      if (choice && typeof choice === "string" && choice !== "(keep current)") {
         if (choice === "(clear)") {
           delete models[phase];
         } else {
@@ -662,7 +662,7 @@ export function loadToolApiKeys(): void {
   }
 }
 
-function getConfigAuthStorage(): InstanceType<typeof AuthStorage> {
+function getConfigAuthStorage(): AuthStorage {
   const authPath = join(process.env.HOME ?? "", ".gsd", "agent", "auth.json");
   mkdirSync(dirname(authPath), { recursive: true });
   return AuthStorage.create(authPath);
@@ -689,7 +689,7 @@ async function handleConfig(ctx: ExtensionCommandContext): Promise<void> {
   let changed = false;
   while (true) {
     const choice = await ctx.ui.select("Configure which tool? Press Escape when done.", options);
-    if (!choice || choice === "(done)") break;
+    if (!choice || typeof choice !== "string" || choice === "(done)") break;
 
     const toolIdx = TOOL_KEYS.findIndex(t => choice.startsWith(t.label));
     if (toolIdx === -1) break;

--- a/src/resources/extensions/gsd/provider-error-pause.ts
+++ b/src/resources/extensions/gsd/provider-error-pause.ts
@@ -1,5 +1,5 @@
 export type ProviderErrorPauseUI = {
-  notify(message: string, level: string): void;
+  notify(message: string, level?: "info" | "warning" | "error" | "success"): void;
 };
 
 export async function pauseAutoForProviderError(


### PR DESCRIPTION
## Summary
- Add `"success"` to notify type union in extension types, interactive mode, and RPC mode
- Fix null safety issues in auto.ts (readFileSync path, contextUsage.percent)
- Add discriminated union narrowing in auto.ts dispatch logic
- Add `typeof` guards for `select()` return values (`string | string[]`) in commands.ts
- Align ProviderErrorPauseUI notify signature with ExtensionUIContext
- Simplify AuthStorage return type (`AuthStorage` instead of `InstanceType<typeof AuthStorage>`)

Part of enabling `tsc --project tsconfig.extensions.json` in CI to catch type errors in extensions before they ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)