### PR TITLE
fix: parse cache collision causing false loop detection on complete-slice

### DIFF
--- a/src/resources/extensions/gsd/auto-recovery.ts
+++ b/src/resources/extensions/gsd/auto-recovery.ts
@@ -11,6 +11,7 @@ import type { ExtensionContext } from "@gsd/pi-coding-agent";
 import {
   clearUnitRuntimeRecord,
 } from "./unit-runtime.js";
+import { clearParseCache } from "./files.js";
 import {
   nativeConflictFiles,
   nativeCommit,
@@ -107,9 +108,13 @@ export function verifyExpectedArtifact(unitType: string, unitId: string, base: s
   // is managed by the hook engine, not the artifact verification system.
   if (unitType.startsWith("hook/")) return true;
 
-  // Clear stale directory listing cache so artifact checks see fresh disk state (#431).
-  // Moved after hook check to avoid unnecessary cache clears for hook units.
+  // Clear stale directory listing cache AND parse cache so artifact checks see
+  // fresh disk state (#431). The parse cache must also be cleared because
+  // cacheKey() uses length + first/last 100 chars — when a checkbox changes
+  // from [ ] to [x], the key collides with the pre-edit version, returning
+  // stale parsed results (e.g., slice.done = false when it's actually true).
   clearPathCache();
+  clearParseCache();
 
   if (unitType === "rewrite-docs") {
     const overridesPath = resolveGsdRootFile(base, "OVERRIDES");

--- a/src/resources/extensions/gsd/files.ts
+++ b/src/resources/extensions/gsd/files.ts
@@ -26,12 +26,16 @@ import { nativeParseRoadmap, nativeExtractSection, nativeParsePlanFile, nativePa
 
 const CACHE_MAX = 50;
 
-/** Fast composite key: length + first/last 100 chars. Unique enough for distinct markdown files. */
+/** Fast composite key: length + first/mid/last 100 chars. The middle sample
+ *  prevents collisions when only a few characters change in the interior of
+ *  a file (e.g., a checkbox [ ] → [x] that doesn't alter length or endpoints). */
 function cacheKey(content: string): string {
   const len = content.length;
   const head = content.slice(0, 100);
+  const midStart = Math.max(0, Math.floor(len / 2) - 50);
+  const mid = len > 200 ? content.slice(midStart, midStart + 100) : '';
   const tail = len > 100 ? content.slice(-100) : '';
-  return `${len}:${head}:${tail}`;
+  return `${len}:${head}:${mid}:${tail}`;
 }
 
 const _parseCache = new Map<string, unknown>();

--- a/src/resources/extensions/gsd/tests/auto-recovery.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-recovery.test.ts
@@ -7,6 +7,7 @@ import { randomUUID } from "node:crypto";
 
 import {
   resolveExpectedArtifactPath,
+  verifyExpectedArtifact,
   diagnoseExpectedArtifact,
   buildLoopRemediationSteps,
   completedKeysPath,
@@ -14,6 +15,7 @@ import {
   removePersistedKey,
   loadPersistedKeys,
 } from "../auto-recovery.ts";
+import { parseRoadmap, clearParseCache } from "../files.ts";
 
 function makeTmpBase(): string {
   const base = join(tmpdir(), `gsd-test-${randomUUID()}`);
@@ -267,6 +269,54 @@ test("removePersistedKey is safe when file doesn't exist", () => {
   try {
     assert.doesNotThrow(() => removePersistedKey(base, "nonexistent"));
   } finally {
+    cleanup(base);
+  }
+});
+
+// ─── verifyExpectedArtifact: parse cache collision regression ─────────────
+
+test("verifyExpectedArtifact detects roadmap [x] change despite parse cache", () => {
+  // Regression test: cacheKey collision when [ ] → [x] doesn't change
+  // file length or first/last 100 chars. Without the fix, parseRoadmap
+  // returns stale cached data with done=false even though the file has [x].
+  const base = makeTmpBase();
+  try {
+    // Build a roadmap long enough that the [x] change is outside the first/last 100 chars
+    const padding = "A".repeat(200);
+    const roadmapBefore = [
+      `# M001: Test Milestone ${padding}`,
+      "",
+      "## Slices",
+      "",
+      "- [ ] **S01: First slice** `risk:low`",
+      "",
+      `## Footer ${padding}`,
+    ].join("\n");
+    const roadmapAfter = roadmapBefore.replace("- [ ] **S01:", "- [x] **S01:");
+
+    // Verify lengths are identical (the key collision condition)
+    assert.equal(roadmapBefore.length, roadmapAfter.length);
+
+    // Populate parse cache with the pre-edit roadmap
+    const before = parseRoadmap(roadmapBefore);
+    const sliceBefore = before.slices.find(s => s.id === "S01");
+    assert.ok(sliceBefore);
+    assert.equal(sliceBefore!.done, false);
+
+    // Now write the post-edit roadmap to disk and create required artifacts
+    const roadmapPath = join(base, ".gsd", "milestones", "M001", "M001-ROADMAP.md");
+    writeFileSync(roadmapPath, roadmapAfter);
+    const summaryPath = join(base, ".gsd", "milestones", "M001", "slices", "S01", "S01-SUMMARY.md");
+    writeFileSync(summaryPath, "# Summary\nDone.");
+    const uatPath = join(base, ".gsd", "milestones", "M001", "slices", "S01", "S01-UAT.md");
+    writeFileSync(uatPath, "# UAT\nPassed.");
+
+    // verifyExpectedArtifact should see the [x] despite the parse cache
+    // having the [ ] version. The fix clears the parse cache inside verify.
+    const verified = verifyExpectedArtifact("complete-slice", "M001/S01", base);
+    assert.equal(verified, true, "verifyExpectedArtifact should return true when roadmap has [x]");
+  } finally {
+    clearParseCache();
     cleanup(base);
   }
 });


### PR DESCRIPTION
## Summary

- **Root cause**: `cacheKey()` in `files.ts` generated cache keys using only `length + first 100 chars + last 100 chars`. When a roadmap checkbox changes `[ ]` → `[x]`, the file length stays the same and the first/last 100 chars are unchanged (for slices in the middle of the file), causing a hash collision. `parseRoadmap()` returns the stale cached result with `done: false`.
- **Trigger**: `verifyExpectedArtifact()` in `auto-recovery.ts` cleared the path cache (`clearPathCache()`) but not the parse cache before calling `parseRoadmap()`. It reads the roadmap fresh from disk, but the parse cache returns the pre-edit result.
- **Symptom**: `complete-slice` units loop 4 times then trigger "Loop detected" error, even though the LLM successfully writes SUMMARY, UAT, and marks `[x]` in the roadmap.

## Changes

1. **`auto-recovery.ts`**: Added `clearParseCache()` alongside `clearPathCache()` in `verifyExpectedArtifact()` — ensures artifact verification always sees freshly parsed data
2. **`files.ts`**: Improved `cacheKey()` to include a 100-char middle sample in addition to head/tail — prevents collisions for interior-only changes like checkbox toggling
3. **`auto-recovery.test.ts`**: Added regression test that populates the parse cache with a `[ ]` roadmap, then verifies `verifyExpectedArtifact` correctly detects `[x]` on disk

## Test plan

- [x] Build passes (`npm run build`)
- [x] All 20 auto-recovery tests pass (19 existing + 1 new regression test)
- [x] All 377 parser tests pass
- [x] Regression test specifically reproduces the cache collision scenario:
  - Creates a roadmap where `[ ]` → `[x]` produces identical `cacheKey` under the old algorithm
  - Populates parse cache with pre-edit roadmap
  - Writes post-edit roadmap to disk with all required artifacts
  - Verifies `verifyExpectedArtifact` returns `true` (would return `false` without the fix)

## Reproduction

Observed in `~/Github/groundcontrol` running `/gsd auto`:
```
All required artifacts are in place and substantive.
Slice S03 complete.

Error: Loop detected: complete-slice M011/S03 dispatched 4 times total. Expected artifact not found.
    Expected: Slice S03 marked [x] in .gsd/milestones/M011/M011-ROADMAP.md + summary + UAT written
```