### PR TITLE
fix: skip onboarding wizard when extension provider already configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- Onboarding wizard no longer repeats every launch for extension-based providers (e.g. pi-claude-cli) that may not require credentials in auth.json
+
 ## [2.19.0] - 2026-03-16
 
 ### Added

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -130,8 +130,11 @@ const authStorage = AuthStorage.create(authFilePath)
 loadStoredEnvKeys(authStorage)
 migratePiCredentials(authStorage)
 
+const modelRegistry = new ModelRegistry(authStorage)
+const settingsManager = SettingsManager.create(agentDir)
+
 // Run onboarding wizard on first launch (no LLM provider configured)
-if (!isPrintMode && shouldRunOnboarding(authStorage)) {
+if (!isPrintMode && shouldRunOnboarding(authStorage, settingsManager.getDefaultProvider())) {
   await runOnboarding(authStorage)
 
   // Clean up stdin state left by @clack/prompts.
@@ -155,9 +158,6 @@ if (!isPrintMode && process.stdout.columns && process.stdout.columns < 40) {
     chalk.yellow(`[gsd] Terminal width is ${process.stdout.columns} columns (minimum recommended: 40). Output may be unreadable.\n`),
   )
 }
-
-const modelRegistry = new ModelRegistry(authStorage)
-const settingsManager = SettingsManager.create(agentDir)
 
 // --list-models: print available models and exit (no TTY needed)
 if (cliFlags.listModels !== undefined) {

--- a/src/onboarding.ts
+++ b/src/onboarding.ts
@@ -146,10 +146,13 @@ function isCancelError(p: ClackModule, err: unknown): boolean {
  *
  * Returns false (skip wizard) when:
  * - Any LLM provider is already available via auth.json, env vars, runtime overrides, or fallback auth
+ * - A default provider is already configured in settings (covers extension-based providers
+ *   that may not require credentials in auth.json)
  * - Not a TTY (piped input, subagent, CI)
  */
-export function shouldRunOnboarding(authStorage: AuthStorage): boolean {
+export function shouldRunOnboarding(authStorage: AuthStorage, settingsDefaultProvider?: string): boolean {
   if (!process.stdin.isTTY) return false
+  if (settingsDefaultProvider) return false
   // Check if any LLM provider has credentials
   const hasLlmAuth = LLM_PROVIDER_IDS.some(id => authStorage.hasAuth(id))
   return !hasLlmAuth


### PR DESCRIPTION
## Summary

- `shouldRunOnboarding()` now accepts an optional `settingsDefaultProvider` parameter and returns false when a provider is already configured
- `modelRegistry` and `settingsManager` creation moved before the onboarding check in `cli.ts` so the default provider is available
- Fixes repeated wizard on every launch for extension-based providers (e.g. pi-claude-cli) that may not require credentials in auth.json

## Motivation

Extension-based providers like pi-claude-cli route through a local CLI subprocess and set `apiKey: "unused"` — they never store real credentials in `auth.json`. Since `shouldRunOnboarding()` only checked `auth.json` for known provider IDs, it always returned true for these users, repeating the wizard every launch regardless of whether a provider was already configured.

## Change type
- [x] `fix` — Bug fix

## Scope
- [x] `pi-coding-agent` — Coding agent

## Breaking changes
- [x] No breaking changes

## Test plan
- [x] Manual testing — describe steps:
  1. With `defaultProvider` set in `settings.json` (e.g. `"pi-claude-cli"`): launch gsd — wizard does NOT appear
  2. Remove `defaultProvider` from `settings.json`: launch gsd — wizard appears as expected
  3. TypeScript type check passes (`npx tsc --noEmit`)

## Rollback plan
- [x] Safe to revert (no migrations, no state changes)

## Release context
- **Target**: main