### PR TITLE
fix: worktree created from integration branch, not main (#606)

### DIFF
--- a/src/resources/extensions/gsd/auto-worktree.ts
+++ b/src/resources/extensions/gsd/auto-worktree.ts
@@ -16,6 +16,7 @@ import {
 } from "./worktree-manager.js";
 import {
   MergeConflictError,
+  readIntegrationBranch,
 } from "./git-service.js";
 import { parseRoadmap } from "./files.js";
 import { loadEffectiveGSDPreferences } from "./preferences.js";
@@ -90,7 +91,12 @@ export function autoWorktreeBranch(milestoneId: string): string {
  */
 export function createAutoWorktree(basePath: string, milestoneId: string): string {
   const branch = autoWorktreeBranch(milestoneId);
-  const info = createWorktree(basePath, milestoneId, { branch });
+
+  // Use the integration branch recorded in META.json as the start point.
+  // This ensures the worktree branch is created from the branch the user
+  // was on when they started the milestone (e.g. f-setup-gsd-2), not main.
+  const integrationBranch = readIntegrationBranch(basePath, milestoneId) ?? undefined;
+  const info = createWorktree(basePath, milestoneId, { branch, startPoint: integrationBranch });
 
   // Copy .gsd/ planning artifacts from the source repo into the new worktree.
   // Worktrees are fresh git checkouts — untracked files don't carry over.
@@ -279,11 +285,12 @@ export function mergeMilestoneToMain(
   const previousCwd = process.cwd();
   process.chdir(originalBasePath_);
 
-  // 4. Resolve main branch from preferences
+  // 4. Resolve integration branch — prefer milestone metadata, fall back to preferences / "main"
   const prefs = loadEffectiveGSDPreferences()?.preferences?.git ?? {};
-  const mainBranch = prefs.main_branch || "main";
+  const integrationBranch = readIntegrationBranch(originalBasePath_, milestoneId);
+  const mainBranch = integrationBranch ?? prefs.main_branch ?? "main";
 
-  // 5. Checkout main
+  // 5. Checkout integration branch
   nativeCheckoutBranch(originalBasePath_, mainBranch);
 
   // 6. Build rich commit message

--- a/src/resources/extensions/gsd/worktree-manager.ts
+++ b/src/resources/extensions/gsd/worktree-manager.ts
@@ -94,7 +94,7 @@ export function worktreeBranchName(name: string): string {
  *
  * @param opts.branch — override the default `worktree/<name>` branch name
  */
-export function createWorktree(basePath: string, name: string, opts: { branch?: string } = {}): WorktreeInfo {
+export function createWorktree(basePath: string, name: string, opts: { branch?: string; startPoint?: string } = {}): WorktreeInfo {
   // Validate name: alphanumeric, hyphens, underscores only
   if (!/^[a-zA-Z0-9_-]+$/.test(name)) {
     throw new Error(`Invalid worktree name "${name}". Use only letters, numbers, hyphens, and underscores.`);
@@ -114,9 +114,12 @@ export function createWorktree(basePath: string, name: string, opts: { branch?: 
   // Prune any stale worktree entries from a previous removal
   nativeWorktreePrune(basePath);
 
+  // Use the explicit start point (e.g. integration branch) if provided,
+  // otherwise fall back to the repo's detected main branch.
+  const startPoint = opts.startPoint ?? nativeDetectMainBranch(basePath);
+
   // Check if the branch already exists (leftover from a previous worktree)
   const branchAlreadyExists = nativeBranchExists(basePath, branch);
-  const mainBranch = nativeDetectMainBranch(basePath);
 
   if (branchAlreadyExists) {
     // Check if the branch is actively used by an existing worktree.
@@ -130,11 +133,11 @@ export function createWorktree(basePath: string, name: string, opts: { branch?: 
       );
     }
 
-    // Reset the stale branch to current main, then attach worktree to it
-    nativeBranchForceReset(basePath, branch, mainBranch);
+    // Reset the stale branch to the start point, then attach worktree to it
+    nativeBranchForceReset(basePath, branch, startPoint);
     nativeWorktreeAdd(basePath, wtPath, branch);
   } else {
-    nativeWorktreeAdd(basePath, wtPath, branch, true, mainBranch);
+    nativeWorktreeAdd(basePath, wtPath, branch, true, startPoint);
   }
 
   return {


### PR DESCRIPTION
## Summary

Fixes #606 — worktrees were always created from `main` instead of the branch the user was on when they started the milestone.

### Root Cause

Three places in the worktree lifecycle hardcoded `main` (or `nativeDetectMainBranch()`) instead of reading the integration branch from `META.json`:

1. **`createWorktree()`** in `worktree-manager.ts` — always branched from `nativeDetectMainBranch()`
2. **`createAutoWorktree()`** in `auto-worktree.ts` — didn't pass the integration branch to `createWorktree()`
3. **`mergeMilestoneToMain()`** in `auto-worktree.ts` — always merged back to `prefs.main_branch || "main"`

This despite `captureIntegrationBranch()` correctly recording the user's branch in `META.json` at milestone start.

### Changes

**`worktree-manager.ts`**
- `createWorktree()` now accepts an optional `startPoint` parameter
- Falls back to `nativeDetectMainBranch()` when not provided (preserves behavior for manual `/worktree`)

**`auto-worktree.ts`**
- `createAutoWorktree()` reads the integration branch from `META.json` via `readIntegrationBranch()` and passes it as `startPoint`
- `mergeMilestoneToMain()` resolves the integration branch from `META.json` before falling back to preferences or `"main"`

### Bugs addressed from #606

| Bug | Status |
|-----|--------|
| Bug 1: milestone branch created from main instead of feature branch | **Fixed** — uses integration branch from META.json |
| Bug 2: work done in shadow copy (.gsd/worktrees/) | By design for auto-mode (worktree isolation), but now correctly based on the right branch |
| Bug 3: locally checked out branch didn't change | By design — worktree is a separate working copy. Changes are visible after merge. |
| Bug 4: code not merged back to integration branch | **Fixed** — merge now targets the recorded integration branch |