### PR TITLE
fix: worktree lifecycle, basepath resolution, branch-mode merge, remote-questions import

### DIFF
--- a/src/onboarding.ts
+++ b/src/onboarding.ts
@@ -747,7 +747,7 @@ async function runRemoteQuestionsStep(
     })
     if (p.isCancel(channelId) || !channelId) return null
 
-    const { saveRemoteQuestionsConfig } = await import('./resources/extensions/remote-questions/remote-command.js')
+    const { saveRemoteQuestionsConfig } = await import('./remote-questions-config.js')
     saveRemoteQuestionsConfig('slack', (channelId as string).trim())
     p.log.success(`Slack channel: ${pc.green((channelId as string).trim())}`)
     return 'Slack'
@@ -852,7 +852,7 @@ async function runDiscordChannelStep(p: ClackModule, pc: PicoModule, token: stri
   }
 
   // Save remote questions config
-  const { saveRemoteQuestionsConfig } = await import('./resources/extensions/remote-questions/remote-command.js')
+  const { saveRemoteQuestionsConfig } = await import('./remote-questions-config.js')
   saveRemoteQuestionsConfig('discord', channelId)
   const channelName = channels.find(ch => ch.id === channelId)?.name
   p.log.success(`Discord channel: ${pc.green(channelName ? `#${channelName}` : channelId)}`)

--- a/src/remote-questions-config.ts
+++ b/src/remote-questions-config.ts
@@ -1,0 +1,40 @@
+/**
+ * Remote Questions Config Helper
+ *
+ * Extracted from remote-questions extension so onboarding.ts can import
+ * it without crossing the compiled/uncompiled boundary. The extension
+ * files in src/resources/ are shipped as raw .ts and loaded via jiti,
+ * but onboarding.ts is compiled by tsc — dynamic imports from compiled
+ * JS to uncompiled .ts fail at runtime (#592).
+ */
+
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+import { getGlobalGSDPreferencesPath } from "./resources/extensions/gsd/preferences.js";
+
+export function saveRemoteQuestionsConfig(channel: "slack" | "discord", channelId: string): void {
+  const prefsPath = getGlobalGSDPreferencesPath();
+  const block = [
+    "remote_questions:",
+    `  channel: ${channel}`,
+    `  channel_id: "${channelId}"`,
+    "  timeout_minutes: 5",
+    "  poll_interval_seconds: 5",
+  ].join("\n");
+
+  const content = existsSync(prefsPath) ? readFileSync(prefsPath, "utf-8") : "";
+  const fmMatch = content.match(/^---\n([\s\S]*?)\n---/);
+  let next = content;
+
+  if (fmMatch) {
+    let frontmatter = fmMatch[1];
+    const regex = /remote_questions:[\s\S]*?(?=\n[a-zA-Z_]|\n---|$)/;
+    frontmatter = regex.test(frontmatter) ? frontmatter.replace(regex, block) : `${frontmatter.trimEnd()}\n${block}`;
+    next = `---\n${frontmatter}\n---${content.slice(fmMatch[0].length)}`;
+  } else {
+    next = `---\n${block}\n---\n\n${content}`;
+  }
+
+  mkdirSync(dirname(prefsPath), { recursive: true });
+  writeFileSync(prefsPath, next, "utf-8");
+}

--- a/src/resources/extensions/gsd/auto-worktree.ts
+++ b/src/resources/extensions/gsd/auto-worktree.ts
@@ -16,6 +16,7 @@ import {
 } from "./worktree-manager.js";
 import {
   MergeConflictError,
+  readIntegrationBranch,
 } from "./git-service.js";
 import { parseRoadmap } from "./files.js";
 import { loadEffectiveGSDPreferences } from "./preferences.js";
@@ -90,7 +91,12 @@ export function autoWorktreeBranch(milestoneId: string): string {
  */
 export function createAutoWorktree(basePath: string, milestoneId: string): string {
   const branch = autoWorktreeBranch(milestoneId);
-  const info = createWorktree(basePath, milestoneId, { branch });
+
+  // Use the integration branch recorded in META.json as the start point.
+  // This ensures the worktree branch is created from the branch the user
+  // was on when they started the milestone (e.g. f-setup-gsd-2), not main.
+  const integrationBranch = readIntegrationBranch(basePath, milestoneId) ?? undefined;
+  const info = createWorktree(basePath, milestoneId, { branch, startPoint: integrationBranch });
 
   // Copy .gsd/ planning artifacts from the source repo into the new worktree.
   // Worktrees are fresh git checkouts — untracked files don't carry over.
@@ -279,11 +285,12 @@ export function mergeMilestoneToMain(
   const previousCwd = process.cwd();
   process.chdir(originalBasePath_);
 
-  // 4. Resolve main branch from preferences
+  // 4. Resolve integration branch — prefer milestone metadata, fall back to preferences / "main"
   const prefs = loadEffectiveGSDPreferences()?.preferences?.git ?? {};
-  const mainBranch = prefs.main_branch || "main";
+  const integrationBranch = readIntegrationBranch(originalBasePath_, milestoneId);
+  const mainBranch = integrationBranch ?? prefs.main_branch ?? "main";
 
-  // 5. Checkout main
+  // 5. Checkout integration branch
   nativeCheckoutBranch(originalBasePath_, mainBranch);
 
   // 6. Build rich commit message

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -92,6 +92,7 @@ import {
   getAutoWorktreePath,
   getAutoWorktreeOriginalBase,
   mergeMilestoneToMain,
+  autoWorktreeBranch,
 } from "./auto-worktree.js";
 import { showNextAction } from "../shared/next-action-ui.js";
 import {
@@ -1329,6 +1330,32 @@ async function dispatchNextUnit(
       } catch (err) {
         ctx.ui.notify(
           `Milestone merge failed: ${err instanceof Error ? err.message : String(err)}`,
+          "warning",
+        );
+      }
+    } else if (currentMilestoneId && !isInAutoWorktree(basePath)) {
+      // Branch isolation mode (#603): no worktree, but we may be on a milestone/* branch.
+      // Squash-merge back to the integration branch (or main) before stopping.
+      try {
+        const currentBranch = getCurrentBranch(basePath);
+        const milestoneBranch = autoWorktreeBranch(currentMilestoneId);
+        if (currentBranch === milestoneBranch) {
+          const roadmapPath = resolveMilestoneFile(basePath, currentMilestoneId, "ROADMAP");
+          if (roadmapPath) {
+            const roadmapContent = readFileSync(roadmapPath, "utf-8");
+            // mergeMilestoneToMain handles: auto-commit, checkout integration branch,
+            // squash merge, commit, optional push, branch deletion.
+            const mergeResult = mergeMilestoneToMain(basePath, currentMilestoneId, roadmapContent);
+            gitService = new GitServiceImpl(basePath, loadEffectiveGSDPreferences()?.preferences?.git ?? {});
+            ctx.ui.notify(
+              `Milestone ${currentMilestoneId} merged (branch mode).${mergeResult.pushed ? " Pushed to remote." : ""}`,
+              "info",
+            );
+          }
+        }
+      } catch (err) {
+        ctx.ui.notify(
+          `Milestone merge failed (branch mode): ${err instanceof Error ? err.message : String(err)}`,
           "warning",
         );
       }

--- a/src/resources/extensions/gsd/commands.ts
+++ b/src/resources/extensions/gsd/commands.ts
@@ -13,6 +13,7 @@ import { deriveState } from "./state.js";
 import { GSDDashboardOverlay } from "./dashboard-overlay.js";
 import { showQueue, showDiscuss } from "./guided-flow.js";
 import { startAuto, stopAuto, pauseAuto, isAutoActive, isAutoPaused, isStepMode, stopAutoRemote } from "./auto.js";
+import { resolveProjectRoot } from "./worktree.js";
 import {
   getGlobalGSDPreferencesPath,
   getLegacyGlobalGSDPreferencesPath,
@@ -54,6 +55,11 @@ function dispatchDoctorHeal(pi: ExtensionAPI, scope: string | undefined, reportT
     { customType: "gsd-doctor-heal", content, display: false },
     { triggerTurn: true },
   );
+}
+
+/** Resolve the effective project root, accounting for worktree paths. */
+function projectRoot(): string {
+  return resolveProjectRoot(process.cwd());
 }
 
 export function registerGSDCommand(pi: ExtensionAPI): void {
@@ -162,24 +168,24 @@ export function registerGSDCommand(pi: ExtensionAPI): void {
 
       if (trimmed === "next" || trimmed.startsWith("next ")) {
         if (trimmed.includes("--dry-run")) {
-          await handleDryRun(ctx, process.cwd());
+          await handleDryRun(ctx, projectRoot());
           return;
         }
         const verboseMode = trimmed.includes("--verbose");
-        await startAuto(ctx, pi, process.cwd(), verboseMode, { step: true });
+        await startAuto(ctx, pi, projectRoot(), verboseMode, { step: true });
         return;
       }
 
       if (trimmed === "auto" || trimmed.startsWith("auto ")) {
         const verboseMode = trimmed.includes("--verbose");
-        await startAuto(ctx, pi, process.cwd(), verboseMode);
+        await startAuto(ctx, pi, projectRoot(), verboseMode);
         return;
       }
 
       if (trimmed === "stop") {
         if (!isAutoActive() && !isAutoPaused()) {
           // Not running in this process — check for a remote auto-mode session
-          const result = stopAutoRemote(process.cwd());
+          const result = stopAutoRemote(projectRoot());
           if (result.found) {
             ctx.ui.notify(`Sent stop signal to auto-mode session (PID ${result.pid}). It will shut down gracefully.`, "info");
           } else if (result.error) {
@@ -207,42 +213,42 @@ export function registerGSDCommand(pi: ExtensionAPI): void {
       }
 
       if (trimmed === "history" || trimmed.startsWith("history ")) {
-        await handleHistory(trimmed.replace(/^history\s*/, "").trim(), ctx, process.cwd());
+        await handleHistory(trimmed.replace(/^history\s*/, "").trim(), ctx, projectRoot());
         return;
       }
 
       if (trimmed === "undo" || trimmed.startsWith("undo ")) {
-        await handleUndo(trimmed.replace(/^undo\s*/, "").trim(), ctx, pi, process.cwd());
+        await handleUndo(trimmed.replace(/^undo\s*/, "").trim(), ctx, pi, projectRoot());
         return;
       }
 
       if (trimmed.startsWith("skip ")) {
-        await handleSkip(trimmed.replace(/^skip\s*/, "").trim(), ctx, process.cwd());
+        await handleSkip(trimmed.replace(/^skip\s*/, "").trim(), ctx, projectRoot());
         return;
       }
 
       if (trimmed === "export" || trimmed.startsWith("export ")) {
-        await handleExport(trimmed.replace(/^export\s*/, "").trim(), ctx, process.cwd());
+        await handleExport(trimmed.replace(/^export\s*/, "").trim(), ctx, projectRoot());
         return;
       }
 
       if (trimmed === "cleanup branches") {
-        await handleCleanupBranches(ctx, process.cwd());
+        await handleCleanupBranches(ctx, projectRoot());
         return;
       }
 
       if (trimmed === "cleanup snapshots") {
-        await handleCleanupSnapshots(ctx, process.cwd());
+        await handleCleanupSnapshots(ctx, projectRoot());
         return;
       }
 
       if (trimmed === "queue") {
-        await showQueue(ctx, pi, process.cwd());
+        await showQueue(ctx, pi, projectRoot());
         return;
       }
 
       if (trimmed === "discuss") {
-        await showDiscuss(ctx, pi, process.cwd());
+        await showDiscuss(ctx, pi, projectRoot());
         return;
       }
 
@@ -279,7 +285,7 @@ export function registerGSDCommand(pi: ExtensionAPI): void {
 
       if (trimmed === "") {
         // Bare /gsd defaults to step mode
-        await startAuto(ctx, pi, process.cwd(), false, { step: true });
+        await startAuto(ctx, pi, projectRoot(), false, { step: true });
         return;
       }
 
@@ -292,7 +298,7 @@ export function registerGSDCommand(pi: ExtensionAPI): void {
 }
 
 async function handleStatus(ctx: ExtensionCommandContext): Promise<void> {
-  const basePath = process.cwd();
+  const basePath = projectRoot();
   const state = await deriveState(basePath);
 
   if (state.registry.length === 0) {
@@ -376,9 +382,9 @@ async function handleDoctor(args: string, ctx: ExtensionCommandContext, pi: Exte
   const parts = trimmed ? trimmed.split(/\s+/) : [];
   const mode = parts[0] === "fix" || parts[0] === "heal" || parts[0] === "audit" ? parts[0] : "doctor";
   const requestedScope = mode === "doctor" ? parts[0] : parts[1];
-  const scope = await selectDoctorScope(process.cwd(), requestedScope);
+  const scope = await selectDoctorScope(projectRoot(), requestedScope);
   const effectiveScope = mode === "audit" ? requestedScope : scope;
-  const report = await runGSDDoctor(process.cwd(), {
+  const report = await runGSDDoctor(projectRoot(), {
     fix: mode === "fix" || mode === "heal",
     scope: effectiveScope,
   });

--- a/src/resources/extensions/gsd/worktree-manager.ts
+++ b/src/resources/extensions/gsd/worktree-manager.ts
@@ -94,7 +94,7 @@ export function worktreeBranchName(name: string): string {
  *
  * @param opts.branch — override the default `worktree/<name>` branch name
  */
-export function createWorktree(basePath: string, name: string, opts: { branch?: string } = {}): WorktreeInfo {
+export function createWorktree(basePath: string, name: string, opts: { branch?: string; startPoint?: string } = {}): WorktreeInfo {
   // Validate name: alphanumeric, hyphens, underscores only
   if (!/^[a-zA-Z0-9_-]+$/.test(name)) {
     throw new Error(`Invalid worktree name "${name}". Use only letters, numbers, hyphens, and underscores.`);
@@ -114,9 +114,12 @@ export function createWorktree(basePath: string, name: string, opts: { branch?: 
   // Prune any stale worktree entries from a previous removal
   nativeWorktreePrune(basePath);
 
+  // Use the explicit start point (e.g. integration branch) if provided,
+  // otherwise fall back to the repo's detected main branch.
+  const startPoint = opts.startPoint ?? nativeDetectMainBranch(basePath);
+
   // Check if the branch already exists (leftover from a previous worktree)
   const branchAlreadyExists = nativeBranchExists(basePath, branch);
-  const mainBranch = nativeDetectMainBranch(basePath);
 
   if (branchAlreadyExists) {
     // Check if the branch is actively used by an existing worktree.
@@ -130,11 +133,11 @@ export function createWorktree(basePath: string, name: string, opts: { branch?: 
       );
     }
 
-    // Reset the stale branch to current main, then attach worktree to it
-    nativeBranchForceReset(basePath, branch, mainBranch);
+    // Reset the stale branch to the start point, then attach worktree to it
+    nativeBranchForceReset(basePath, branch, startPoint);
     nativeWorktreeAdd(basePath, wtPath, branch);
   } else {
-    nativeWorktreeAdd(basePath, wtPath, branch, true, mainBranch);
+    nativeWorktreeAdd(basePath, wtPath, branch, true, startPoint);
   }
 
   return {

--- a/src/resources/extensions/gsd/worktree.ts
+++ b/src/resources/extensions/gsd/worktree.ts
@@ -77,6 +77,28 @@ export function detectWorktreeName(basePath: string): string | null {
 }
 
 /**
+ * Resolve the project root from a path that may be inside a worktree.
+ * If the path contains `/.gsd/worktrees/<name>/`, returns the portion
+ * before `/.gsd/`. Otherwise returns the input unchanged.
+ *
+ * Use this in commands that call `process.cwd()` to ensure they always
+ * operate against the real project root, not a worktree subdirectory.
+ */
+export function resolveProjectRoot(basePath: string): string {
+  const normalizedPath = basePath.replaceAll("\\", "/");
+  const marker = "/.gsd/worktrees/";
+  const idx = normalizedPath.indexOf(marker);
+  if (idx === -1) return basePath;
+  // Return the original path up to the .gsd/ marker (un-normalized)
+  // Account for potential OS-specific separators
+  const sep = basePath.includes("\\") ? "\\" : "/";
+  const markerOs = `${sep}.gsd${sep}worktrees${sep}`;
+  const idxOs = basePath.indexOf(markerOs);
+  if (idxOs !== -1) return basePath.slice(0, idxOs);
+  return basePath.slice(0, idx);
+}
+
+/**
  * Get the slice branch name, namespaced by worktree when inside one.
  *
  * In the main tree:     gsd/<milestoneId>/<sliceId>


### PR DESCRIPTION
## Summary

Fixes five open issues in a single squashed commit:

### 1. Worktree created from integration branch, not main (#606)
`createAutoWorktree()` now reads the integration branch from `META.json` and passes it as `startPoint` to `createWorktree()`. `mergeMilestoneToMain()` merges to the recorded integration branch instead of hardcoded `main`.

### 2. Stale worktree cwd after milestone completion (#608) + basepath disagreement (#602)
Added `resolveProjectRoot()` that detects `.gsd/worktrees/` in the cwd and extracts the actual project root. All GSD commands (`/gsd discuss`, `/gsd status`, `/gsd queue`, `/gsd doctor`, etc.) now use this instead of raw `process.cwd()`.

### 3. Milestone merge skipped in branch isolation mode (#603)
The merge guard required `isInAutoWorktree()` which is always false in branch mode (`git.isolation=branch`). Added a fallback that detects when the current branch is `milestone/*` and performs the squash-merge via the same `mergeMilestoneToMain()` flow.

### 4. Remote questions onboarding missing .js module (#592)
`onboarding.ts` (compiled by tsc) dynamically imported `remote-command.js` from the extensions directory, but extensions are shipped as raw `.ts`. Extracted `saveRemoteQuestionsConfig()` into `src/remote-questions-config.ts` which compiles alongside onboarding.

Fixes #606, #608, #602, #603, #592