### PR TITLE
fix: prevent heap OOM during long-running auto-mode sessions (#611)

### DIFF
--- a/src/resources/extensions/gsd/activity-log.ts
+++ b/src/resources/extensions/gsd/activity-log.ts
@@ -8,7 +8,7 @@
  * Diagnostic extraction is handled by session-forensics.ts.
  */
 
-import { writeFileSync, mkdirSync, readdirSync, unlinkSync, statSync, openSync, closeSync, constants } from "node:fs";
+import { writeFileSync, writeSync, mkdirSync, readdirSync, unlinkSync, statSync, openSync, closeSync, constants } from "node:fs";
 import { createHash } from "node:crypto";
 import { join } from "node:path";
 
@@ -22,6 +22,15 @@ interface ActivityLogState {
 }
 
 const activityLogState = new Map<string, ActivityLogState>();
+
+/**
+ * Clear accumulated activity log state (#611).
+ * Call when auto-mode stops to prevent unbounded memory growth
+ * from lastSnapshotKeyByUnit maps accumulating across units.
+ */
+export function clearActivityLogState(): void {
+  activityLogState.clear();
+}
 
 function scanNextSequence(activityDir: string): number {
   let maxSeq = 0;
@@ -46,9 +55,21 @@ function getActivityState(activityDir: string): ActivityLogState {
   return state;
 }
 
-function snapshotKey(unitType: string, unitId: string, content: string): string {
-  const digest = createHash("sha1").update(content).digest("hex");
-  return `${unitType}\0${unitId}\0${digest}`;
+/**
+ * Build a lightweight dedup key from session entries without serializing
+ * the entire content to a string (#611). Uses entry count + hash of
+ * the last few entries as a fingerprint instead of hashing megabytes.
+ */
+function snapshotKey(unitType: string, unitId: string, entries: unknown[]): string {
+  const hash = createHash("sha1");
+  hash.update(`${unitType}\0${unitId}\0${entries.length}\0`);
+  // Hash only the last 3 entries as a fingerprint — if the session grew,
+  // the count change alone detects it; if content changed, the tail hash catches it.
+  const tail = entries.slice(-3);
+  for (const entry of tail) {
+    hash.update(JSON.stringify(entry));
+  }
+  return hash.digest("hex");
 }
 
 function nextActivityFilePath(
@@ -91,14 +112,23 @@ export function saveActivityLog(
     mkdirSync(activityDir, { recursive: true });
 
     const safeUnitId = unitId.replace(/\//g, "-");
-    const content = `${entries.map(entry => JSON.stringify(entry)).join("\n")}\n`;
     const state = getActivityState(activityDir);
     const unitKey = `${unitType}\0${safeUnitId}`;
-    const key = snapshotKey(unitType, safeUnitId, content);
+    // Use lightweight fingerprint instead of serializing all entries (#611)
+    const key = snapshotKey(unitType, safeUnitId, entries);
     if (state.lastSnapshotKeyByUnit.get(unitKey) === key) return;
 
     const filePath = nextActivityFilePath(activityDir, state, unitType, safeUnitId);
-    writeFileSync(filePath, content, "utf-8");
+    // Stream entries to disk line-by-line instead of building one massive string (#611).
+    // For large sessions, the single-string approach allocated hundreds of MB.
+    const fd = openSync(filePath, "w");
+    try {
+      for (const entry of entries) {
+        writeSync(fd, JSON.stringify(entry) + "\n");
+      }
+    } finally {
+      closeSync(fd);
+    }
     state.nextSeq += 1;
     state.lastSnapshotKeyByUnit.set(unitKey, key);
   } catch (e) {

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -29,7 +29,7 @@ import {
   buildMilestoneFileName, buildSliceFileName, buildTaskFileName,
 } from "./paths.js";
 import { invalidateAllCaches } from "./cache.js";
-import { saveActivityLog } from "./activity-log.js";
+import { saveActivityLog, clearActivityLogState } from "./activity-log.js";
 import { synthesizeCrashRecovery, getDeepDiagnostic } from "./session-forensics.js";
 import { writeLock, clearLock, readCrashLock, formatCrashInfo, isLockProcessAlive } from "./crash-recovery.js";
 import {
@@ -485,7 +485,9 @@ export async function stopAuto(ctx?: ExtensionContext, pi?: ExtensionAPI): Promi
   currentUnit = null;
   currentMilestoneId = null;
   originalBasePath = "";
+  completedUnits = [];
   clearSliceProgressCache();
+  clearActivityLogState();
   pendingCrashRecovery = null;
   _handlingAgentEnd = false;
   ctx?.ui.setStatus("gsd-auto", undefined);
@@ -1784,6 +1786,10 @@ async function dispatchNextUnit(
         startedAt: currentUnit.startedAt,
         finishedAt: Date.now(),
       });
+      // Cap to last 200 entries to prevent unbounded growth (#611)
+      if (completedUnits.length > 200) {
+        completedUnits = completedUnits.slice(-200);
+      }
       clearUnitRuntimeRecord(basePath, currentUnit.type, currentUnit.id);
       unitDispatchCount.delete(`${currentUnit.type}/${currentUnit.id}`);
       unitRecoveryCount.delete(`${currentUnit.type}/${currentUnit.id}`);

--- a/src/resources/extensions/gsd/paths.ts
+++ b/src/resources/extensions/gsd/paths.ts
@@ -15,6 +15,9 @@ import { nativeScanGsdTree, type GsdTreeEntry } from "./native-parser-bridge.js"
 
 // ─── Directory Listing Cache ──────────────────────────────────────────────────
 
+/** Max entries before eviction. Prevents unbounded growth in long sessions (#611). */
+const DIR_CACHE_MAX = 200;
+
 const dirEntryCache = new Map<string, Dirent[]>();
 const dirListCache = new Map<string, string[]>();
 
@@ -85,6 +88,7 @@ function cachedReaddirWithTypes(dirPath: string): Dirent[] {
           d.isSocket = () => false;
           return d;
         });
+        if (dirEntryCache.size >= DIR_CACHE_MAX) dirEntryCache.clear();
         dirEntryCache.set(dirPath, dirents);
         return dirents;
       }
@@ -92,6 +96,7 @@ function cachedReaddirWithTypes(dirPath: string): Dirent[] {
   }
 
   const entries = readdirSync(dirPath, { withFileTypes: true });
+  if (dirEntryCache.size >= DIR_CACHE_MAX) dirEntryCache.clear();
   dirEntryCache.set(dirPath, entries);
   return entries;
 }
@@ -107,6 +112,7 @@ function cachedReaddir(dirPath: string): string[] {
       const treeEntries = nativeTreeCache.get(key);
       if (treeEntries) {
         const names = treeEntries.map(e => e.name);
+        if (dirListCache.size >= DIR_CACHE_MAX) dirListCache.clear();
         dirListCache.set(dirPath, names);
         return names;
       }
@@ -114,6 +120,7 @@ function cachedReaddir(dirPath: string): string[] {
   }
 
   const entries = readdirSync(dirPath);
+  if (dirListCache.size >= DIR_CACHE_MAX) dirListCache.clear();
   dirListCache.set(dirPath, entries);
   return entries;
 }

--- a/src/resources/extensions/gsd/tests/memory-leak-guards.test.ts
+++ b/src/resources/extensions/gsd/tests/memory-leak-guards.test.ts
@@ -1,0 +1,87 @@
+/**
+ * memory-leak-guards.test.ts — Tests for #611 memory leak fixes.
+ *
+ * Verifies that module-level state accumulators are properly bounded
+ * and cleared to prevent OOM during long-running auto-mode sessions.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, existsSync, readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { saveActivityLog, clearActivityLogState } from "../activity-log.ts";
+import { clearPathCache } from "../paths.ts";
+import type { ExtensionContext } from "@gsd/pi-coding-agent";
+
+function createCtx(entries: unknown[]) {
+  return { sessionManager: { getEntries: () => entries } } as unknown as ExtensionContext;
+}
+
+// ─── activity-log: clearActivityLogState ─────────────────────────────────────
+
+test("clearActivityLogState resets dedup state so identical saves write again", () => {
+  clearActivityLogState();
+  const baseDir = mkdtempSync(join(tmpdir(), "gsd-memleak-test-"));
+  try {
+    const entries = [{ role: "assistant", content: "test entry" }];
+    const ctx = createCtx(entries);
+
+    // First save
+    saveActivityLog(ctx, baseDir, "execute-task", "M001/S01/T01");
+
+    const actDir = join(baseDir, ".gsd", "activity");
+    assert.equal(readdirSync(actDir).length, 1, "first save creates one file");
+
+    // Same content, same unit — deduped
+    saveActivityLog(ctx, baseDir, "execute-task", "M001/S01/T01");
+    assert.equal(readdirSync(actDir).length, 1, "dedup prevents duplicate write");
+
+    // Clear state
+    clearActivityLogState();
+
+    // Same content again — after clear, writes again (fresh state)
+    saveActivityLog(ctx, baseDir, "execute-task", "M001/S01/T01");
+    assert.equal(readdirSync(actDir).length, 2, "after clear, dedup state is reset");
+  } finally {
+    rmSync(baseDir, { recursive: true, force: true });
+  }
+});
+
+// ─── activity-log: streaming JSONL write ────────────────────────────────────
+
+test("saveActivityLog writes valid JSONL via streaming", () => {
+  clearActivityLogState();
+  const baseDir = mkdtempSync(join(tmpdir(), "gsd-memleak-jsonl-"));
+  try {
+    const entries = [
+      { type: "message", message: { role: "user", content: "hello" } },
+      { type: "message", message: { role: "assistant", content: "world" } },
+      { type: "message", message: { role: "user", content: "test" } },
+    ];
+    const ctx = createCtx(entries);
+
+    saveActivityLog(ctx, baseDir, "execute-task", "M002/S01/T01");
+
+    const actDir = join(baseDir, ".gsd", "activity");
+    const files = readdirSync(actDir);
+    assert.equal(files.length, 1, "one file written");
+
+    const content = readFileSync(join(actDir, files[0]), "utf-8");
+    const lines = content.trim().split("\n");
+    assert.equal(lines.length, 3, "three JSONL lines");
+
+    for (const line of lines) {
+      assert.doesNotThrow(() => JSON.parse(line), `line is valid JSON`);
+    }
+  } finally {
+    rmSync(baseDir, { recursive: true, force: true });
+  }
+});
+
+// ─── paths.ts: directory cache bounds ───────────────────────────────────────
+
+test("clearPathCache does not throw", () => {
+  assert.doesNotThrow(() => clearPathCache(), "clearPathCache should not throw");
+});


### PR DESCRIPTION
## Summary

Fixes #611 — GSD crashes with V8 OOM (`FATAL ERROR: JavaScript heap out of memory`) after ~50 minutes of auto-mode, with heap growing to ~3.75 GB.

### Root Causes Identified

Four sources of unbounded memory growth were found and fixed:

#### 1. `activity-log.ts` — Massive string allocations for dedup (PRIMARY)
**Before:** `saveActivityLog()` serialized ALL session entries into a single string (`entries.map(entry => JSON.stringify(entry)).join("\n")`) and then SHA1-hashed it for duplicate detection. In a 50-minute session with large contexts, this created hundreds of MB of temporary strings per unit cycle — the GC couldn't reclaim them fast enough.

**After:** 
- Streaming writes via `writeSync()` per entry — never builds the full content string in memory
- Lightweight fingerprint for dedup: uses entry count + hash of last 3 entries instead of hashing the entire serialized content

#### 2. `activity-log.ts` — `activityLogState` Map never cleared
**Before:** Module-level `activityLogState` Map accumulated `lastSnapshotKeyByUnit` entries for every unit processed across the entire session lifetime. Never cleared.

**After:** Added `clearActivityLogState()` export, called from `stopAuto()` cleanup.

#### 3. `auto.ts` — `completedUnits` array unbounded
**Before:** Dashboard tracking array `completedUnits` grew with every completed unit for the entire session. For milestone-spanning sessions, this accumulated indefinitely.

**After:** Capped at 200 entries (keeps the most recent). Also cleared on `stopAuto()`.

#### 4. `paths.ts` — Directory caches grow without bounds
**Before:** `dirEntryCache` and `dirListCache` Maps grew unbounded between `clearPathCache()` calls, holding Dirent arrays and string arrays for every directory ever read.

**After:** Added `DIR_CACHE_MAX = 200` eviction — when cache exceeds limit, it's cleared before adding new entries.

## Test plan

- [x] New test file `memory-leak-guards.test.ts` with 3 tests:
  - `clearActivityLogState` resets dedup state correctly
  - Streaming JSONL write produces valid output
  - `clearPathCache` export works
- [x] Existing `activity-log-save.test.ts` passes (13/13) — dedup behavior preserved
- [x] Full test suite passes (`npm test` — 7/7)
- [x] Build passes
- [ ] Manual: run auto-mode for extended session, monitor heap with `--inspect` or `process.memoryUsage()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)