### PR TITLE
fix: showNextAction falls back to select() in RPC mode (#447)

### DIFF
--- a/src/resources/extensions/shared/next-action-ui.ts
+++ b/src/resources/extensions/shared/next-action-ui.ts
@@ -118,7 +118,7 @@ export async function showNextAction(
 		}
 	});
 
-	return ctx.ui.custom<string>((_tui: TUI, theme: Theme, _kb, done) => {
+	const result = await ctx.ui.custom<string>((_tui: TUI, theme: Theme, _kb, done) => {
 		let cursorIdx = defaultIdx;
 		let cachedLines: string[] | undefined;
 
@@ -194,4 +194,19 @@ export async function showNextAction(
 
 		return { render, invalidate: () => { cachedLines = undefined; }, handleInput };
 	});
+
+	// Fallback for RPC mode where ctx.ui.custom() returns undefined (#447).
+	// Fall back to ctx.ui.select() which IS implemented in RPC mode.
+	if (result === undefined || result === null) {
+		const labels = allActions.map(a => {
+			const tag = a.recommended ? " (recommended)" : "";
+			return `${a.label}${tag}: ${a.description}`;
+		});
+		const selected = await ctx.ui.select(opts.title, labels);
+		if (selected === undefined || selected === null) return "not_yet";
+		const idx = labels.indexOf(selected as string);
+		return idx >= 0 ? allActions[idx].id : "not_yet";
+	}
+
+	return result;
 }


### PR DESCRIPTION
## Summary

Fixes #447 — `ctx.ui.custom()` returns `undefined` in RPC mode, silently breaking all `showNextAction()` flows (13+ call sites in guided-flow.ts).

### Root Cause

In RPC mode, `ctx.ui.custom()` returns `undefined` immediately without emitting any RPC event. `showNextAction()` passes the return value through without checking, so every flow that uses it (no active milestone, phase complete, pre-planning, crash recovery, step-mode confirmations) silently completes with no action taken.

### Fix

After `ctx.ui.custom()` returns, check for `undefined`/`null` and fall back to `ctx.ui.select()` which IS implemented in RPC mode. The action list is mapped to select labels with descriptions and the chosen option is resolved back to the action id.

This preserves the rich TUI experience in interactive mode while making RPC mode functional.