### PR TITLE
fix: eager template cache warming prevents version-skew crash

### DIFF
--- a/src/resources/extensions/gsd/prompt-loader.ts
+++ b/src/resources/extensions/gsd/prompt-loader.ts
@@ -7,15 +7,17 @@
  * Templates live at prompts/ relative to this module's directory.
  * They use {{variableName}} syntax for substitution.
  *
- * Templates are cached on first read per session. This prevents a running
- * session from being invalidated when another `gsd` launch overwrites
- * ~/.gsd/agent/ with newer templates via initResources(). Without caching,
- * the in-memory extension code (which knows variable set A) can read a
- * newer template from disk (which expects variable set B), causing a
- * "template declares {{X}} but no value was provided" crash mid-session.
+ * All templates are eagerly loaded into cache at module init via warmCache().
+ * This prevents a running session from being invalidated when another `gsd`
+ * launch overwrites ~/.gsd/agent/ with newer templates via initResources().
+ * Without eager caching, the in-memory extension code (which knows variable
+ * set A) can read a newer template from disk (which expects variable set B),
+ * causing a "template declares {{X}} but no value was provided" crash
+ * mid-session — especially for late-loading templates like complete-milestone
+ * that aren't read until the end of a long auto-mode run.
  */
 
-import { readFileSync } from "node:fs";
+import { readFileSync, readdirSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -23,9 +25,43 @@ const __extensionDir = dirname(fileURLToPath(import.meta.url));
 const promptsDir = join(__extensionDir, "prompts");
 const templatesDir = join(__extensionDir, "templates");
 
-// Cache templates on first read — a running session uses the template versions
-// that were on disk when it first loaded them, immune to later overwrites.
+// Cache all templates eagerly at module load — a running session uses the
+// template versions that were on disk at startup, immune to later overwrites.
 const templateCache = new Map<string, string>();
+
+/**
+ * Eagerly read all .md files from prompts/ and templates/ into cache.
+ * Called once at module init so that every template is snapshot before
+ * a concurrent initResources() can overwrite files on disk.
+ */
+function warmCache(): void {
+  try {
+    for (const file of readdirSync(promptsDir)) {
+      if (!file.endsWith(".md")) continue;
+      const name = file.slice(0, -3);
+      if (!templateCache.has(name)) {
+        templateCache.set(name, readFileSync(join(promptsDir, file), "utf-8"));
+      }
+    }
+  } catch {
+    // prompts/ may not exist in test environments — lazy loading still works
+  }
+
+  try {
+    for (const file of readdirSync(templatesDir)) {
+      if (!file.endsWith(".md")) continue;
+      const cacheKey = `tpl:${file.slice(0, -3)}`;
+      if (!templateCache.has(cacheKey)) {
+        templateCache.set(cacheKey, readFileSync(join(templatesDir, file), "utf-8"));
+      }
+    }
+  } catch {
+    // templates/ may not exist in test environments — lazy loading still works
+  }
+}
+
+// Snapshot all templates at module load time
+warmCache();
 
 /**
  * Load a prompt template and substitute variables.


### PR DESCRIPTION
## Summary

- **Eagerly loads all prompt and output templates into cache at module init** (`warmCache()` in `prompt-loader.ts`), eliminating the race window where a concurrent `initResources()` could overwrite templates on disk before a running session reads them for the first time.
- Late-loading templates like `complete-milestone` (only needed at the end of a long auto-mode run) were especially vulnerable — by the time they were first loaded, another `gsd` launch may have already overwritten them with a newer version expecting different variables.
- Gracefully handles missing directories (test environments) with try/catch fallback to the existing lazy-loading path.

## Root Cause

The existing lazy cache only protected templates that had already been loaded during the session. The race condition:

1. Session starts, extension code version N loaded into memory
2. Template `complete-milestone` is **not yet cached** (first use is at milestone end)
3. Another `gsd` launch runs `initResources()` → overwrites templates on disk (version N+1)
4. Session finally dispatches `complete-milestone` → reads new template from disk → variable set mismatch → crash: `"template declares {{workingDirectory}} but no value was provided"`

## Test plan

- [x] `complete-milestone.test.ts` — 24 passed
- [x] `replan-slice.test.ts` — 40 passed
- [x] `run-uat.test.ts` — 29 passed
- [x] `reassess-prompt.test.ts` — 18 passed
- [x] `derive-state.test.ts` — 109 passed