### PR TITLE
refactor: replace serial prefs wizard with categorized menu

### DIFF
--- a/src/resources/extensions/gsd/commands.ts
+++ b/src/resources/extensions/gsd/commands.ts
@@ -837,7 +837,8 @@ async function handlePrefsWizard(
       `── Save & Exit ──`,
     ];
 
-    const choice = await ctx.ui.select("GSD Preferences", options);
+    const raw = await ctx.ui.select("GSD Preferences", options);
+    const choice = typeof raw === "string" ? raw : "";
     if (!choice || choice.includes("Save & Exit")) break;
 
     if (choice.startsWith("Models"))             await configureModels(ctx, prefs);


### PR DESCRIPTION
## Summary

The `/gsd prefs` wizard previously dumped 20+ prompts in a serial flow — model selection for 4 phases, then timeouts, then git settings, etc. This was overwhelming, especially on first use. Users had to wade through every single prompt even if they only wanted to change one setting.

This refactors `handlePrefsWizard` into a **category picker loop**:

- A `ctx.ui.select()` menu lists 7 categories with current-value summaries at a glance
- User picks a category → runs only that category's prompts
- Returns to the category menu after each category with updated summaries
- "Save & Exit" (or Escape) serializes and writes the file

### Categories

| Category | Settings |
|---|---|
| **Models** | research/planning/execution/completion phase models |
| **Timeouts** | soft/idle/hard timeout minutes |
| **Git** | main_branch, auto_push, push_branches, snapshots, remote, pre_merge_check, commit_type, merge_strategy, isolation, commit_docs |
| **Skills** | skill_discovery, uat_dispatch |
| **Budget** | budget_ceiling, budget_enforcement, context_pause_threshold |
| **Notifications** | enabled, on_complete, on_error, on_budget, on_milestone, on_attention |
| **Advanced** | unique_milestone_ids |

### What changed

- **`buildCategorySummaries(prefs)`** — Returns short summary strings for each category (e.g., `"research: sonnet-4, planning: sonnet-4"`, `"$50 / pause"`, `"5/6 enabled"`) displayed next to category names in the menu
- **7 extracted category functions** — `configureModels`, `configureTimeouts`, `configureGit`, `configureSkills`, `configureBudget`, `configureNotifications`, `configureAdvanced` — each is a pure extraction of existing prompt logic with zero behavior changes
- **Category loop in `handlePrefsWizard`** — replaces the serial flow with a menu-driven loop; save/serialization logic is unchanged

### What did NOT change

- Individual prompt logic within each category (validation, defaults, keep-current handling)
- Serialization and file writing (frontmatter format, body preservation)
- All existing UI primitives (`ctx.ui.select`, `ctx.ui.input`) used as before

## Test plan

- [x] `npm run build` compiles without errors
- [x] All 32 existing preference validation tests pass (`preferences-wizard-fields.test.ts`)
- [ ] Manual test: `/gsd prefs` shows category menu
- [ ] Picking a category shows only that category's prompts
- [ ] Returning to menu shows updated summaries reflecting changes
- [ ] "Save & Exit" writes the file correctly
- [ ] Escape from category menu saves and exits
- [ ] Output `preferences.md` format is identical to before