### PR TITLE
test: add feature-branch lifecycle integration test

### DIFF
--- a/src/resources/extensions/gsd/tests/feature-branch-lifecycle-integration.test.ts
+++ b/src/resources/extensions/gsd/tests/feature-branch-lifecycle-integration.test.ts
@@ -40,7 +40,7 @@ function run(cmd: string, cwd: string): string {
 }
 
 function commitCount(cwd: string, branch: string): number {
-  return run(`git rev-list --count ${branch}`, cwd);
+  return parseInt(run(`git rev-list --count ${branch}`, cwd), 10);
 }
 
 function headSha(cwd: string, ref: string): string {


### PR DESCRIPTION
Proves the core invariant: milestone worktrees branch from and merge back to the feature branch, never touching main.

## Summary

- Adds integration test covering the full feature-branch workflow: start on a feature branch → create auto-worktree with unique milestone ID → add slices → squash-merge back to the feature branch → verify main is untouched
- Tests that untracked `.gsd/` planning files are copied into the worktree via `copyPlanningArtifacts`
- Tests multiple successive milestones with unique IDs (`M001-xxxxxx`, `M002-yyyyyy`) on the same feature branch

## Motivation

No existing test covered the end-to-end invariant that milestone worktrees branch from and merge back to the integration (feature) branch rather than `main`. The individual pieces were tested in isolation (captureIntegrationBranch, readIntegrationBranch, getMainBranch, createAutoWorktree, mergeMilestoneToMain) but the composition was not — meaning a regression in any of those codepaths reading the integration branch metadata would go undetected.

This was identified when reviewing the v2.17.0 → v2.18.0 diff, which fixed exactly this bug: both `createAutoWorktree` and `mergeMilestoneToMain` previously hardcoded `main` instead of reading the recorded integration branch.

## Change type

- [x] `test` — Adding or updating tests

## Scope

- [x] `gsd extension` — GSD workflow (`src/resources/extensions/gsd/`)

## Breaking changes

- [x] No breaking changes

## Test plan

- [x] Integration tests added/updated (`npm run test:integration`)

41 assertions across 3 test scenarios:
1. **Full lifecycle** — feature branch → unique milestone → worktree → slices → merge back → main untouched, worktree cleaned up, milestone branch deleted
2. **Untracked planning files** — `.gsd/` files not yet committed are copied into the worktree
3. **Multiple milestones** — two successive unique-ID milestones both land on the feature branch

## Rollback plan

- [x] Safe to revert (no migrations, no state changes)

## Release context

- **Target**: main
