### PR TITLE
fix(session): rebuild tools when cwd changes in newSession (#633)

### DIFF
--- a/packages/pi-coding-agent/src/core/agent-session.ts
+++ b/packages/pi-coding-agent/src/core/agent-session.ts
@@ -1356,6 +1356,7 @@ export class AgentSession {
 		this.agent.reset();
 		// Update cwd to current process directory — auto-mode may have chdir'd
 		// into a worktree since the original session was created.
+		const previousCwd = this._cwd;
 		this._cwd = process.cwd();
 		this.sessionManager.newSession({ parentSession: options?.parentSession });
 		this.agent.sessionId = this.sessionManager.getSessionId();
@@ -1364,6 +1365,17 @@ export class AgentSession {
 		this._pendingNextTurnMessages = [];
 
 		this.sessionManager.appendThinkingLevelChange(this.thinkingLevel);
+
+		// Rebuild tools when cwd changed (e.g., auto-mode entered a worktree).
+		// Tools capture cwd at creation time for path resolution — without
+		// rebuilding, write/read/edit/bash resolve relative paths against
+		// the original project root instead of the worktree (#633).
+		if (this._cwd !== previousCwd) {
+			this._buildRuntime({
+				activeToolNames: this.getActiveToolNames(),
+				includeAllExtensionTools: true,
+			});
+		}
 
 		// Run setup callback if provided (e.g., to append initial messages)
 		if (options?.setup) {


### PR DESCRIPTION
## Problem

When auto-mode enters a worktree, the agent writes artifacts to the main project's `.gsd/` directory instead of the worktree's `.gsd/`. The dispatcher can't find the artifact at the expected worktree path and retries indefinitely.

## Root Cause

Tools (write, read, edit, bash) are created via `createWriteTool(cwd)`, `createReadTool(cwd)`, etc. — they capture `cwd` at creation time in a closure. The tools are created once in `_buildRuntime()` during session construction.

When auto-mode enters a worktree:
1. `createAutoWorktree()` calls `process.chdir(worktreePath)`
2. `newSession()` updates `this._cwd = process.cwd()` ✓
3. But `_buildRuntime()` is NOT called — tools still use the original project root cwd ✗

So `resolveToCwd('.gsd/milestones/M025/...', originalProjectRoot)` resolves to the main project's `.gsd/`, not the worktree's.

## Fix

Detect cwd change in `newSession()` and call `_buildRuntime()` to recreate tools with the updated cwd. This is a targeted rebuild that only fires when cwd actually changed — typically once per auto-mode session when entering a worktree.

## Testing

- Build passes
- 594/594 unit tests pass

Fixes #633