### PR TITLE
fix: clamp task counter to prevent display overflow after loop recovery

### DIFF
--- a/src/resources/extensions/gsd/auto-dashboard.ts
+++ b/src/resources/extensions/gsd/auto-dashboard.ts
@@ -340,7 +340,8 @@ export function updateProgressWidget(
             let meta = theme.fg("dim", `${done}/${total} slices`);
 
             if (activeSliceTasks && activeSliceTasks.total > 0) {
-              meta += theme.fg("dim", `  ·  task ${activeSliceTasks.done + 1}/${activeSliceTasks.total}`);
+              const taskNum = Math.min(activeSliceTasks.done + 1, activeSliceTasks.total);
+              meta += theme.fg("dim", `  ·  task ${taskNum}/${activeSliceTasks.total}`);
             }
 
             lines.push(truncateToWidth(`${pad}${bar}  ${meta}`, width));


### PR DESCRIPTION
## Summary
- Fixes "task 5/4" display in auto-mode dashboard when restarting after loop recovery
- The `done + 1` display assumed we're always working on the next task, but after loop recovery marks tasks as `[x]`, `done` can equal `total`, producing values exceeding the total
- Clamps `done + 1` to `total` with `Math.min()`

## Test plan
- [ ] Start `/gsd auto` on a project, trigger loop detection (or manually mark all tasks `[x]` in a PLAN file)
- [ ] Restart `/gsd auto` — verify dashboard shows `task 4/4` not `task 5/4`

Closes #662

🤖 Generated with [Claude Code](https://claude.com/claude-code)