### PR TITLE
fix: remove CSI 3J scrollback clear from TUI full redraws (#455)

### DIFF
--- a/packages/pi-tui/src/tui.ts
+++ b/packages/pi-tui/src/tui.ts
@@ -909,7 +909,7 @@ export class TUI extends Container {
 		const fullRender = (clear: boolean): void => {
 			this.fullRedrawCount += 1;
 			let buffer = "\x1b[?2026h"; // Begin synchronized output
-			if (clear) buffer += "\x1b[3J\x1b[2J\x1b[H"; // Clear scrollback, screen, and home
+			if (clear) buffer += "\x1b[2J\x1b[H"; // Clear screen and home (no scrollback clear — preserves view position)
 			for (let i = 0; i < newLines.length; i++) {
 				if (i > 0) buffer += "\r\n";
 				let line = newLines[i];


### PR DESCRIPTION
## Problem

During full redraws, the TUI emitted `\x1b[3J` (CSI 3J — clear scrollback) before `\x1b[2J\x1b[H` (clear screen + home). In terminals that honor CSI 3J (including Ubuntu Terminal/GNOME Terminal), this destroyed the scrollback buffer and caused the scrollbar/view position to jump to the top during phase transitions and dashboard updates.

## Fix

Remove `\x1b[3J` from the full redraw sequence. `\x1b[2J\x1b[H` alone clears the visible screen and homes the cursor without touching scrollback history — sufficient for a clean redraw while preserving view continuity.

## Files changed

- `packages/pi-tui/src/tui.ts` — 1 line change in `fullRender()`

Closes #455