### PR TITLE
fix: auto-enable hardware cursor in Warp terminal (#658)

### DIFF
--- a/packages/pi-tui/src/tui.ts
+++ b/packages/pi-tui/src/tui.ts
@@ -221,7 +221,7 @@ export class TUI extends Container {
 	private hardwareCursorRow = 0; // Actual terminal cursor row (may differ due to IME positioning)
 	private inputBuffer = ""; // Buffer for parsing terminal responses
 	private cellSizeQueryPending = false;
-	private showHardwareCursor = process.env.PI_HARDWARE_CURSOR === "1";
+	private showHardwareCursor = process.env.PI_HARDWARE_CURSOR === "1" || process.env.TERM_PROGRAM === "WarpTerminal";
 	private clearOnShrink = process.env.PI_CLEAR_ON_SHRINK === "1"; // Clear empty rows when content shrinks (default: off)
 	private maxLinesRendered = 0; // Track terminal's working area (max lines ever rendered)
 	private previousViewportTop = 0; // Track previous viewport top for resize-aware cursor moves


### PR DESCRIPTION
## Problem

Warp terminal does not correctly re-render inverse video (`\x1b[7m`) cursor indicators when the cursor position changes via arrow keys. The cursor appears invisible during navigation.

## Fix

Auto-detect Warp via `TERM_PROGRAM=WarpTerminal` and enable the hardware cursor by default (same effect as `PI_HARDWARE_CURSOR=1`). The TUI shows the real terminal hardware cursor positioned via `CURSOR_MARKER`, providing reliable visual feedback.

## Impact

- **Warp users**: cursor now visible and tracks correctly
- **Other terminals**: no change
- **PI_HARDWARE_CURSOR=1**: still works as explicit override

## Files changed

- `packages/pi-tui/src/tui.ts` — 1 line change to `showHardwareCursor` initialization

Closes #658