### PR TITLE
fix: support fractional slice IDs (e.g. S03.5) in roadmap parser (#681)

### DIFF
--- a/src/resources/extensions/gsd/files.ts
+++ b/src/resources/extensions/gsd/files.ts
@@ -436,7 +436,7 @@ function _parsePlanImpl(content: string): SlicePlan {
     let currentTask: TaskPlanEntry | null = null;
 
     for (const line of taskLines) {
-      const cbMatch = line.match(/^-\s+\[([ xX])\]\s+\*\*(\w+):\s+(.+?)\*\*\s*(.*)/);
+      const cbMatch = line.match(/^-\s+\[([ xX])\]\s+\*\*([\w.]+):\s+(.+?)\*\*\s*(.*)/);
       if (cbMatch) {
         if (currentTask) tasks.push(currentTask);
 

--- a/src/resources/extensions/gsd/roadmap-slices.ts
+++ b/src/resources/extensions/gsd/roadmap-slices.ts
@@ -19,7 +19,7 @@ export function parseRoadmapSlices(content: string): RoadmapSliceEntry[] {
   let currentSlice: RoadmapSliceEntry | null = null;
 
   for (const line of checkboxItems) {
-    const cbMatch = line.match(/^\s*-\s+\[([ xX])\]\s+\*\*(\w+):\s+(.+?)\*\*\s*(.*)/);
+    const cbMatch = line.match(/^\s*-\s+\[([ xX])\]\s+\*\*([\w.]+):\s+(.+?)\*\*\s*(.*)/);
     if (cbMatch) {
       if (currentSlice) slices.push(currentSlice);
 


### PR DESCRIPTION
## Problem

When `/gsd steer` inserts a slice with a fractional ID like `S03.5`, the roadmap parser silently skips it. The dispatch engine then:
1. Sees S03 (done) → jumps to S04
2. S04 depends on S03.5 which was never parsed → blocked
3. Tries S05 → blocked by S04
4. Stops with `Cannot dispatch: earlier slice is not complete`

## Root Cause

The roadmap parser regex in `roadmap-slices.ts` used `(\w+)` to capture slice IDs. `\w` matches `[a-zA-Z0-9_]` but not dots, so `S03.5` fails to match and the entire line is skipped.

Same pattern exists in `files.ts` for task ID parsing.

## Fix

Update the ID capture group from `(\w+)` to `([\w.]+)` in both files, allowing dots in slice/task IDs while preserving all existing behavior for standard IDs.

## Verification

```js
// Before: S03.5 → NO MATCH
// After:  S03.5 → id=S03.5 title=Performance Testing Gate
```

## Files changed

- `src/resources/extensions/gsd/roadmap-slices.ts` — slice ID regex
- `src/resources/extensions/gsd/files.ts` — task ID regex (consistency)

Closes #681