### PR TITLE
fix: add Warp to unsupported Ctrl+Alt shortcut list

### DIFF
--- a/src/resources/extensions/shared/terminal.ts
+++ b/src/resources/extensions/shared/terminal.ts
@@ -5,7 +5,7 @@
  * Terminals that lack this support silently swallow the key combos.
  */
 
-const UNSUPPORTED_TERMS = ["apple_terminal"];
+const UNSUPPORTED_TERMS = ["apple_terminal", "warpterm"];
 
 export function supportsCtrlAltShortcuts(): boolean {
   const term = (process.env.TERM_PROGRAM || "").toLowerCase();


### PR DESCRIPTION
## Summary
- Adds `"warpterm"` to the `UNSUPPORTED_TERMS` array in `terminal.ts`
- Warp terminal (`TERM_PROGRAM=WarpTerminal`) does not emit recognized escape sequences for Ctrl+Alt key combos, so shortcuts like Ctrl+Alt+G (dashboard) silently fail
- With this change, users in Warp see the fallback hint (e.g. "use `/gsd status`") instead of broken shortcuts

Closes #643

## Test plan
- [ ] Verify `supportsCtrlAltShortcuts()` returns `false` when `TERM_PROGRAM=WarpTerminal`
- [ ] Verify shortcut descriptions show fallback hint in Warp
- [ ] Verify no regression in supported terminals (iTerm2, Kitty, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)