### PR TITLE
fix: coerce completedAt to String in visualizer changelog sort

### DIFF
--- a/src/resources/extensions/gsd/tests/visualizer-data.test.ts
+++ b/src/resources/extensions/gsd/tests/visualizer-data.test.ts
@@ -165,6 +165,17 @@ assertTrue(
   "VisualizerData has changelog field",
 );
 
+// completedAt must be coerced to String() to handle YAML Date objects (issue #644)
+assertTrue(
+  dataSrc.includes("String(summary.frontmatter.completed_at"),
+  "completedAt assignment coerces to String() for YAML Date safety",
+);
+
+assertTrue(
+  dataSrc.includes("String(b.completedAt") && dataSrc.includes("String(a.completedAt"),
+  "changelog sort coerces completedAt to String() for YAML Date safety",
+);
+
 // Verify overlay source exists and imports data module
 const overlayPath = join(__dirname, "..", "visualizer-overlay.ts");
 const overlaySrc = readFileSync(overlayPath, "utf-8");

--- a/src/resources/extensions/gsd/visualizer-data.ts
+++ b/src/resources/extensions/gsd/visualizer-data.ts
@@ -379,7 +379,7 @@ async function loadChangelog(basePath: string, milestones: VisualizerMilestone[]
           path: f.path,
           description: f.description,
         })),
-        completedAt: summary.frontmatter.completed_at ?? '',
+        completedAt: String(summary.frontmatter.completed_at ?? ''),
       };
 
       changelogCache.set(cacheKey, { mtime, entry });
@@ -388,7 +388,7 @@ async function loadChangelog(basePath: string, milestones: VisualizerMilestone[]
   }
 
   // Sort by completedAt descending
-  entries.sort((a, b) => (b.completedAt || '').localeCompare(a.completedAt || ''));
+  entries.sort((a, b) => String(b.completedAt || '').localeCompare(String(a.completedAt || '')));
 
   return { entries };
 }


### PR DESCRIPTION
## Summary

- **Bug**: `/gsd visualize` crashes with `TypeError: (b.completedAt || "").localeCompare is not a function` on Node.js v25.6.1
- **Root cause**: YAML frontmatter parsers (both native and JS) can return `Date` objects for ISO date strings like `completed_at: 2026-03-15T10:30:00Z`. The code assumed `completed_at` was always a `string`, but `Date` objects don't have `.localeCompare()`.
- **Fix**: Wrap `completedAt` with `String()` at both the assignment site (`visualizer-data.ts:382`) and the sort comparator (`visualizer-data.ts:391`) to safely handle both `string` and `Date` values from either parser path.

## Changes

### `src/resources/extensions/gsd/visualizer-data.ts`
- Line 382: `completedAt: String(summary.frontmatter.completed_at ?? '')` — coerce at assignment
- Line 391: `String(b.completedAt || '').localeCompare(String(a.completedAt || ''))` — defensive coercion in sort

### `src/resources/extensions/gsd/tests/visualizer-data.test.ts`
- Added 2 source-contract tests verifying the `String()` coercion is present to prevent regression

## Error reproduced

```
TypeError: (b.completedAt || "").localeCompare is not a function
    at /Users/jeremymcspadden/.gsd/agent/extensions/gsd/visualizer-data.ts:391:48
    at Array.sort (<anonymous>)
    at loadChangelog (/Users/jeremymcspadden/.gsd/agent/extensions/gsd/visualizer-data.ts:391:11)
    at async loadVisualizerData (/Users/jeremymcspadden/.gsd/agent/extensions/gsd/visualizer-data.ts:490:21)
```

## Test plan

- [x] All 146 visualizer tests pass (18 overlay + 53 data + 59 views + 18 critical-path)
- [x] Full build succeeds with no TypeScript errors
- [x] New tests verify `String()` coercion is present in source
- [ ] Manual verification: run `/gsd visualize` with a project that has completed slices with `completed_at` dates in frontmatter