### PR TITLE
fix: clamp 'minimal' thinking level to 'low' for gpt-5.x models (#688)

### DIFF
--- a/packages/pi-ai/src/providers/azure-openai-responses.ts
+++ b/packages/pi-ai/src/providers/azure-openai-responses.ts
@@ -15,6 +15,16 @@ import { AssistantMessageEventStream } from "../utils/event-stream.js";
 import { convertResponsesMessages, convertResponsesTools, processResponsesStream } from "./openai-responses-shared.js";
 import { buildBaseOptions, clampReasoning } from "./simple-options.js";
 
+/**
+ * Clamp reasoning effort for models that don't support all levels.
+ * gpt-5.x models don't support "minimal" — map to "low".
+ */
+function clampReasoningForModel(modelName: string, effort: string): string {
+	const name = modelName.includes("/") ? modelName.split("/").pop()! : modelName;
+	if (name.startsWith("gpt-5") && effort === "minimal") return "low";
+	return effort;
+}
+
 const DEFAULT_AZURE_API_VERSION = "v1";
 const AZURE_TOOL_CALL_PROVIDERS = new Set(["openai", "openai-codex", "opencode", "azure-openai-responses"]);
 
@@ -234,8 +244,9 @@ function buildParams(
 
 	if (model.reasoning) {
 		if (options?.reasoningEffort || options?.reasoningSummary) {
+			const effort = clampReasoningForModel(model.name, options?.reasoningEffort || "medium") as typeof options.reasoningEffort;
 			params.reasoning = {
-				effort: options?.reasoningEffort || "medium",
+				effort: effort || "medium",
 				summary: options?.reasoningSummary || "auto",
 			};
 			params.include = ["reasoning.encrypted_content"];

--- a/packages/pi-ai/src/providers/openai-responses.ts
+++ b/packages/pi-ai/src/providers/openai-responses.ts
@@ -18,6 +18,16 @@ import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "./github-copi
 import { convertResponsesMessages, convertResponsesTools, processResponsesStream } from "./openai-responses-shared.js";
 import { buildBaseOptions, clampReasoning } from "./simple-options.js";
 
+/**
+ * Clamp reasoning effort for models that don't support all levels.
+ * gpt-5.x models don't support "minimal" — map to "low".
+ */
+function clampReasoningForModel(modelName: string, effort: string): string {
+	const name = modelName.includes("/") ? modelName.split("/").pop()! : modelName;
+	if (name.startsWith("gpt-5") && effort === "minimal") return "low";
+	return effort;
+}
+
 const OPENAI_TOOL_CALL_PROVIDERS = new Set(["openai", "openai-codex", "opencode"]);
 
 /**
@@ -215,8 +225,9 @@ function buildParams(model: Model<"openai-responses">, context: Context, options
 
 	if (model.reasoning) {
 		if (options?.reasoningEffort || options?.reasoningSummary) {
+			const effort = clampReasoningForModel(model.name, options?.reasoningEffort || "medium") as typeof options.reasoningEffort;
 			params.reasoning = {
-				effort: options?.reasoningEffort || "medium",
+				effort: effort || "medium",
 				summary: options?.reasoningSummary || "auto",
 			};
 			params.include = ["reasoning.encrypted_content"];


### PR DESCRIPTION
## Problem

Setting `/thinking minimal` with gpt-5.4 (via GitHub Copilot) causes a 400 error:

```
Error: 400 Unsupported value: 'minimal' is not supported with the 'gpt-5.4' model.
Supported values are: 'none', 'low', 'medium', 'high', and 'xhigh'.
```

## Root Cause

GSD defines `ThinkingLevel` as `"minimal" | "low" | "medium" | "high" | "xhigh"`, but gpt-5.x models don't support `"minimal"`. The `openai-codex-responses` provider already had a `clampReasoningEffort()` function that maps `minimal → low` for gpt-5.x, but the `openai-responses` and `azure-openai-responses` providers passed the value through unclamped.

## Fix

Add `clampReasoningForModel()` to both `openai-responses.ts` and `azure-openai-responses.ts` that maps `"minimal"` to `"low"` for gpt-5.x models, matching the existing behavior in `openai-codex-responses.ts`.

## Files changed

- `packages/pi-ai/src/providers/openai-responses.ts` — add clamping + apply to reasoning params
- `packages/pi-ai/src/providers/azure-openai-responses.ts` — same

Fixes the bug portion of #688 (the `ask_user_questions` part is a feature request)