### PR TITLE
fix: discover MCP servers from project-root .mcp.json (#692)

### DIFF
--- a/src/resources/extensions/mcporter/index.ts
+++ b/src/resources/extensions/mcporter/index.ts
@@ -26,6 +26,8 @@ import { Text } from "@gsd/pi-tui";
 import { Type } from "@sinclair/typebox";
 import { execFile, exec } from "node:child_process";
 import { promisify } from "node:util";
+import { readFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
 
 const execFileAsync = promisify(execFile);
 const execAsync = promisify(exec);
@@ -99,6 +101,37 @@ async function runMcporter(
 	return stdout;
 }
 
+/**
+ * Read .mcp.json from the project root (cwd) and return servers not already
+ * discovered by mcporter. This bridges the gap where mcporter doesn't scan
+ * the standard .mcp.json config used by Claude Code, Cursor, etc.
+ */
+function readProjectMcpJson(knownNames: Set<string>): McpServer[] {
+	const servers: McpServer[] = [];
+	try {
+		const mcpJsonPath = join(process.cwd(), ".mcp.json");
+		if (!existsSync(mcpJsonPath)) return servers;
+		const raw = readFileSync(mcpJsonPath, "utf-8");
+		const data = JSON.parse(raw) as Record<string, unknown>;
+		const mcpServers = (data.mcpServers ?? data.servers) as Record<string, Record<string, unknown>> | undefined;
+		if (!mcpServers || typeof mcpServers !== "object") return servers;
+
+		for (const [name, config] of Object.entries(mcpServers)) {
+			if (knownNames.has(name)) continue; // Already discovered by mcporter
+			const transport = (config.type as string) ?? (config.command ? "stdio" : config.url ? "http" : "unknown");
+			servers.push({
+				name,
+				status: "ok",
+				transport,
+				tools: [], // Tools unknown until mcp_discover is called
+			});
+		}
+	} catch {
+		// Non-fatal — .mcp.json may not exist or be malformed
+	}
+	return servers;
+}
+
 async function getServerList(signal?: AbortSignal): Promise<McpServer[]> {
 	if (serverListCache) return serverListCache;
 
@@ -112,6 +145,14 @@ async function getServerList(signal?: AbortSignal): Promise<McpServer[]> {
 	if (!Array.isArray(data.servers)) {
 		throw new Error(`Unexpected mcporter response shape: ${JSON.stringify(Object.keys(data))}`);
 	}
+
+	// Merge servers from project-root .mcp.json that mcporter didn't discover
+	const knownNames = new Set(data.servers.map((s) => s.name));
+	const projectServers = readProjectMcpJson(knownNames);
+	if (projectServers.length > 0) {
+		data.servers.push(...projectServers);
+	}
+
 	serverListCache = data.servers;
 	return serverListCache;
 }
@@ -122,10 +163,37 @@ async function getServerDetail(
 ): Promise<McpServerDetail> {
 	if (serverDetailCache.has(serverName)) return serverDetailCache.get(serverName)!;
 
-	const raw = await runMcporter(["list", serverName, "--schema", "--json"], signal);
+	// Check if this server came from .mcp.json (not known to mcporter natively)
+	const mcpJsonUrl = getMcpJsonServerUrl(serverName);
+	const args = mcpJsonUrl
+		? ["list", mcpJsonUrl, "--schema", "--json"]
+		: ["list", serverName, "--schema", "--json"];
+
+	const raw = await runMcporter(args, signal);
 	const data = JSON.parse(raw) as McpServerDetail;
+	// Preserve the user-facing name from .mcp.json
+	if (mcpJsonUrl) data.name = serverName;
 	serverDetailCache.set(serverName, data);
 	return data;
+}
+
+/**
+ * Look up a server's URL from .mcp.json if it's an HTTP server not known to mcporter.
+ */
+function getMcpJsonServerUrl(serverName: string): string | null {
+	try {
+		const mcpJsonPath = join(process.cwd(), ".mcp.json");
+		if (!existsSync(mcpJsonPath)) return null;
+		const raw = readFileSync(mcpJsonPath, "utf-8");
+		const data = JSON.parse(raw) as Record<string, unknown>;
+		const mcpServers = (data.mcpServers ?? data.servers) as Record<string, Record<string, unknown>> | undefined;
+		if (!mcpServers?.[serverName]) return null;
+		const config = mcpServers[serverName];
+		if (config.type === "http" && typeof config.url === "string") return config.url;
+		return null;
+	} catch {
+		return null;
+	}
 }
 
 function formatServerList(servers: McpServer[]): string {
@@ -328,7 +396,10 @@ export default function (pi: ExtensionAPI) {
 
 		async execute(_id, params, signal) {
 			// Build mcporter call command: mcporter call server.tool key:value ...
-			const callTarget = `${params.server}.${params.tool}`;
+			// For HTTP servers from .mcp.json, use the URL directly as the server identifier
+			const mcpJsonUrl = getMcpJsonServerUrl(params.server);
+			const serverRef = mcpJsonUrl ?? params.server;
+			const callTarget = `${serverRef}.${params.tool}`;
 			const cliArgs = ["call", callTarget, "--output", "raw"];
 
 			if (params.args && Object.keys(params.args).length > 0) {

--- a/src/resources/extensions/universal-config/scanners.ts
+++ b/src/resources/extensions/universal-config/scanners.ts
@@ -166,8 +166,8 @@ async function scanClaude(projectRoot: string, home: string, tool: ToolInfo): Pr
     }
   }
 
-  // Project-level MCP: .claude/.mcp.json or .claude/mcp.json
-  for (const relPath of [".claude/.mcp.json", ".claude/mcp.json"]) {
+  // Project-level MCP: .mcp.json (standard), .claude/.mcp.json, or .claude/mcp.json
+  for (const relPath of [".mcp.json", ".claude/.mcp.json", ".claude/mcp.json"]) {
     const fullPath = join(projectRoot, relPath);
     const content = await readTextFile(fullPath);
     if (content) {


### PR DESCRIPTION
## Problem

MCP servers configured in `.mcp.json` at the project root are not discovered by `mcp_servers` / `mcp_discover` / `mcp_call`. The mcporter CLI only scans `.vscode/mcp.json` and VS Code user-level config, ignoring the standard `.mcp.json` format used by Claude Code, Cursor, and other AI coding tools.

HTTP-based MCP servers (Linear, Figma, Sentry, etc.) configured in `.mcp.json` are invisible to the agent.

## Fix

**mcporter extension (`index.ts`):**
- Add `readProjectMcpJson()` that reads `.mcp.json` from the project root and returns servers not already found by mcporter
- Merge those servers into `getServerList()` results
- Add `getMcpJsonServerUrl()` to resolve HTTP URLs for `.mcp.json`-only servers
- Update `getServerDetail()` to pass HTTP URLs directly to mcporter for discovery
- Update `mcp_call` to use the HTTP URL as the server reference when calling tools on `.mcp.json`-only servers

**discover_configs scanner (`scanners.ts`):**
- Add `.mcp.json` to the project-level MCP config scan alongside `.claude/.mcp.json` and `.claude/mcp.json`

## Files changed

- `src/resources/extensions/mcporter/index.ts`
- `src/resources/extensions/universal-config/scanners.ts`

Closes #692