### PR TITLE
fix: validate auto-worktree is a real git worktree before use (#695)

### DIFF
--- a/src/resources/extensions/gsd/auto-worktree.ts
+++ b/src/resources/extensions/gsd/auto-worktree.ts
@@ -264,11 +264,29 @@ export function isInAutoWorktree(basePath: string): boolean {
 }
 
 /**
- * Get the filesystem path for an auto-worktree, or null if it doesn't exist.
+ * Get the filesystem path for an auto-worktree, or null if it doesn't exist
+ * or is not a valid git worktree.
+ *
+ * Validates that the path is a real git worktree (has a .git file with a
+ * gitdir: pointer) rather than just a stray directory. This prevents
+ * mis-detection of leftover directories as active worktrees (#695).
  */
 export function getAutoWorktreePath(basePath: string, milestoneId: string): string | null {
   const p = worktreePath(basePath, milestoneId);
-  return existsSync(p) ? p : null;
+  if (!existsSync(p)) return null;
+
+  // Validate this is a real git worktree, not a stray directory.
+  // A git worktree has a .git *file* (not directory) containing "gitdir: <path>".
+  const gitPath = join(p, ".git");
+  if (!existsSync(gitPath)) return null;
+  try {
+    const content = readFileSync(gitPath, "utf8").trim();
+    if (!content.startsWith("gitdir: ")) return null;
+  } catch {
+    return null;
+  }
+
+  return p;
 }
 
 /**
@@ -281,6 +299,21 @@ export function enterAutoWorktree(basePath: string, milestoneId: string): string
   const p = worktreePath(basePath, milestoneId);
   if (!existsSync(p)) {
     throw new Error(`Auto-worktree for ${milestoneId} does not exist at ${p}`);
+  }
+
+  // Validate this is a real git worktree, not a stray directory (#695)
+  const gitPath = join(p, ".git");
+  if (!existsSync(gitPath)) {
+    throw new Error(`Auto-worktree path ${p} exists but is not a git worktree (no .git)`);
+  }
+  try {
+    const content = readFileSync(gitPath, "utf8").trim();
+    if (!content.startsWith("gitdir: ")) {
+      throw new Error(`Auto-worktree path ${p} has a .git but it is not a worktree gitdir pointer`);
+    }
+  } catch (err) {
+    if (err instanceof Error && err.message.includes("worktree")) throw err;
+    throw new Error(`Auto-worktree path ${p} exists but .git is unreadable`);
   }
 
   const previousCwd = process.cwd();


### PR DESCRIPTION
## Problem

A stray (non-git) directory under `.gsd/worktrees/<MID>/` is treated as a valid auto-worktree. Auto-mode enters it, derives state from an empty/invalid path, and concludes no milestones exist — silently skipping all work.

## Root Cause

`getAutoWorktreePath()` only checked `existsSync()` on the directory. Any directory that exists — even one left behind by a failed cleanup or manual creation — was accepted as a valid worktree.

`enterAutoWorktree()` had the same issue.

## Fix

Add git worktree validation to both functions: check that the directory contains a `.git` **file** (not directory) with a `gitdir:` pointer. This is the hallmark of a real git worktree checkout — the main repo has a `.git` directory, but worktrees have a `.git` file pointing back to the main repo's git objects.

- `getAutoWorktreePath()`: returns `null` if validation fails (stray dir ignored)
- `enterAutoWorktree()`: throws with a descriptive error if validation fails

Auto-mode then falls through to normal worktree creation or root-state derivation.

## Files changed

- `src/resources/extensions/gsd/auto-worktree.ts`

Closes #695