### PR TITLE
fix(prompts): make skill loading an active directive in auto-mode units

### DIFF
--- a/src/resources/extensions/gsd/prompts/execute-task.md
+++ b/src/resources/extensions/gsd/prompts/execute-task.md
@@ -26,7 +26,7 @@ A researcher explored the codebase and a planner decomposed the work — you are
 
 Then:
 0. Narrate step transitions, key implementation decisions, and verification outcomes as you work. Keep it terse — one line between tool-call clusters, not between every call.
-1. If a `GSD Skill Preferences` block is present in system context, use it to decide which skills to load and follow during execution, without relaxing required verification or artifact rules
+1. **Load relevant skills before writing code.** Check the `GSD Skill Preferences` block in system context and the `<available_skills>` catalog in your system prompt. For each skill that matches this task's technology stack (e.g., React, Next.js, accessibility, component design), `read` its SKILL.md file now. Skills contain implementation rules and patterns that should guide your code. If no skills match this task, skip this step.
 2. Execute the steps in the inlined task plan
 3. Build the real thing. If the task plan says "create login endpoint", build an endpoint that actually authenticates against a real store, not one that returns a hardcoded success response. If the task plan says "create dashboard page", build a page that renders real data from the API, not a component with hardcoded props. Stubs and mocks are for tests, not for the shipped feature.
 4. Write or update tests as part of execution — tests are verification, not an afterthought. If the slice plan defines test files in its Verification section and this is the first task, create them (they should initially fail).

--- a/src/resources/extensions/gsd/prompts/plan-slice.md
+++ b/src/resources/extensions/gsd/prompts/plan-slice.md
@@ -33,7 +33,7 @@ Then:
 1. Read the templates:
    - `~/.gsd/agent/extensions/gsd/templates/plan.md`
    - `~/.gsd/agent/extensions/gsd/templates/task-plan.md`
-2. If a `GSD Skill Preferences` block is present in system context, use it to decide which skills to load and follow during planning, without overriding required plan formatting
+2. **Load relevant skills.** Check the `GSD Skill Preferences` block in system context and the `<available_skills>` catalog in your system prompt. `read` any skill files relevant to this slice's technology stack before decomposing. When writing task plans, note which installed skills are relevant in the task description so executors know which to load.
 3. Define slice-level verification — the objective stopping condition for this slice:
    - For non-trivial slices: plan actual test files with real assertions. Name the files.
    - For simple slices: executable commands or script assertions are fine.

--- a/src/resources/extensions/gsd/prompts/research-slice.md
+++ b/src/resources/extensions/gsd/prompts/research-slice.md
@@ -42,7 +42,7 @@ An honest "this is straightforward, here's the pattern to follow" is more valuab
 
 Research what this slice needs. Narrate key findings and surprises as you go — what exists, what's missing, what constrains the approach.
 0. If `REQUIREMENTS.md` was preloaded above, identify which Active requirements this slice owns or supports. Research should target these requirements — surfacing risks, unknowns, and implementation constraints that could affect whether the slice actually delivers them.
-1. If a `GSD Skill Preferences` block is present in system context, use it to decide which skills to load and follow during research, without relaxing required verification or artifact rules
+1. **Load relevant skills.** Check the `GSD Skill Preferences` block in system context and the `<available_skills>` catalog in your system prompt. `read` any skill files relevant to this slice's technology stack before exploring code. Reference specific rules from loaded skills in your findings where they inform the implementation approach.
 2. **Skill Discovery ({{skillDiscoveryMode}}):**{{skillDiscoveryInstructions}}
 3. Explore relevant code for this slice's scope. For targeted exploration, use `rg`, `find`, and reads. For broad or unfamiliar subsystems, use `scout` to map the relevant area first.
 4. Use `resolve_library` / `get_library_docs` for unfamiliar libraries — skip this for libraries already used in the codebase


### PR DESCRIPTION
## Problem

Auto-mode executor agents have access to project skills via `<available_skills>` in the system prompt and `GSD Skill Preferences` in the GSD system context, but they **never actually `read` the skill files**. Across 30+ execute-task, plan-slice, and complete-slice units in a real milestone (M001, 40 units, 7 slices), zero skill files were loaded after S01 research.

The plumbing works — skills are discovered, loaded into the system prompt, and the preferences block renders correctly via `before_agent_start`. The issue is behavioral: the current instruction is passive and gets overridden by the stronger execution directive.

### Evidence

Traced via activity JSONL logs across an entire milestone:

- **S01 research:** Read `next-best-practices/SKILL.md` once (the only skill read in the entire milestone)
- **S01 plan → S06 complete (30+ units):** Zero reads of any skill file
- Research noted "next-best-practices skill already installed locally" but this never propagated to execution
- Confirmed `<available_skills>` XML block is present in system prompt via `buildSystemPrompt` → `formatSkillsForPrompt`
- Confirmed `GSD Skill Preferences` block is present via `before_agent_start` → `renderPreferencesForSystemPrompt`

### Root Cause

The execute-task prompt has a strong directive:

> "Don't re-research or re-plan — build what the plan says"

The skill instruction (step 1) is passive:

> "If a `GSD Skill Preferences` block is present in system context, use it to decide which skills to load"

"Use it to decide" is too weak — the agent interprets this as optional and skips it 100% of the time.

## Solution

Rewrite the skill instruction in all three unit prompts from passive guidance to an explicit action:

### `execute-task.md`

**Before:** `If a GSD Skill Preferences block is present in system context, use it to decide which skills to load...`

**After:** `**Load relevant skills before writing code.** Check the GSD Skill Preferences block in system context and the <available_skills> catalog in your system prompt. For each skill that matches this task's technology stack, read its SKILL.md file now. Skills contain implementation rules and patterns that should guide your code. If no skills match this task, skip this step.`

### `plan-slice.md`

Same passive → active pattern. Also adds: "When writing task plans, note which installed skills are relevant in the task description so executors know which to load."

### `research-slice.md`

Same passive → active pattern. Also adds: "Reference specific rules from loaded skills in your findings where they inform the implementation approach."

## Why This Works

- Prompt-only change — no TypeScript modifications needed
- `read its SKILL.md file now` is a concrete tool-call instruction the agent reliably follows
- Points agents to **both** `GSD Skill Preferences` and `<available_skills>` (old wording only referenced preferences)
- Matches the pattern in the GSD system prompt's own skills table (trigger → "load the relevant skill file with the `read` tool")
- Plan-slice change creates a propagation path: planner notes relevant skills → executor loads them

## Testing

Observed on gsd-pi v2.19.0 with Claude Sonnet 4 auto-mode execution. Skills installed at both user level (`~/.gsd/agent/skills/`) and project level (`.agents/skills/`).

Closes #704