### PR TITLE
fix: handle bare /gsd cleanup command

### DIFF
--- a/src/resources/extensions/gsd/commands.ts
+++ b/src/resources/extensions/gsd/commands.ts
@@ -281,6 +281,12 @@ export function registerGSDCommand(pi: ExtensionAPI): void {
         return;
       }
 
+      if (trimmed === "cleanup") {
+        await handleCleanupBranches(ctx, projectRoot());
+        await handleCleanupSnapshots(ctx, projectRoot());
+        return;
+      }
+
       if (trimmed === "cleanup branches") {
         await handleCleanupBranches(ctx, projectRoot());
         return;


### PR DESCRIPTION
## Summary

- **Fixed `/gsd cleanup` producing an unknown command warning.** Previously, running `/gsd cleanup` without a subcommand (`branches` or `snapshots`) fell through to the unknown command handler at line 391 of `commands.ts`, producing: `Warning: Unknown: /gsd cleanup. Run /gsd help for available commands.`
- **Added a bare `cleanup` handler** that runs both `handleCleanupBranches` and `handleCleanupSnapshots` sequentially, matching the user's expectation that `/gsd cleanup` performs all cleanup operations.
- The existing subcommand variants (`/gsd cleanup branches` and `/gsd cleanup snapshots`) continue to work independently as before.

## Changes

- `src/resources/extensions/gsd/commands.ts`: Added a new conditional block before the existing `cleanup branches` and `cleanup snapshots` handlers that matches bare `cleanup` and runs both cleanup operations.

## Test plan

- [x] `npm run build` passes with no errors
- [x] `npm test` passes — 16 pass, 0 fail, 1 skipped (API key dependent)
- [x] Verified `/gsd cleanup` no longer produces unknown command warning
- [x] Verified `/gsd cleanup branches` and `/gsd cleanup snapshots` still route correctly
- [ ] CI passes on PR