### PR TITLE
fix: pass verificationBudget to execute-task prompt template

### DIFF
--- a/src/resources/extensions/gsd/auto-prompts.ts
+++ b/src/resources/extensions/gsd/auto-prompts.ts
@@ -716,6 +716,12 @@ export async function buildExecuteTaskPrompt(
   const activeOverrides = await loadActiveOverrides(base);
   const overridesSection = formatOverridesSection(activeOverrides);
 
+  // Compute verification budget for the executor's context window (issue #707)
+  const prefs = loadEffectiveGSDPreferences();
+  const contextWindow = resolveExecutorContextWindow(undefined, prefs?.preferences);
+  const budgets = computeBudgets(contextWindow);
+  const verificationBudget = `~${Math.round(budgets.verificationBudgetChars / 1000)}K chars`;
+
   return loadPrompt("execute-task", {
     overridesSection,
     workingDirectory: base,
@@ -730,6 +736,7 @@ export async function buildExecuteTaskPrompt(
     priorTaskLines: priorLines,
     taskSummaryPath,
     inlinedTemplates,
+    verificationBudget,
   });
 }
 

--- a/src/resources/extensions/gsd/tests/context-compression.test.ts
+++ b/src/resources/extensions/gsd/tests/context-compression.test.ts
@@ -74,6 +74,19 @@ test("compression: buildExecuteTaskPrompt minimal truncates prior summaries", ()
   );
 });
 
+test("compression: buildExecuteTaskPrompt passes verificationBudget to loadPrompt (#707)", () => {
+  // The execute-task template declares {{verificationBudget}} — the builder must supply it
+  assert.ok(
+    promptsSrc.includes("verificationBudget"),
+    "buildExecuteTaskPrompt should pass verificationBudget in the loadPrompt vars object",
+  );
+  // Verify it computes the budget from computeBudgets
+  assert.ok(
+    promptsSrc.includes("computeBudgets(contextWindow)"),
+    "buildExecuteTaskPrompt should compute budgets from the executor context window",
+  );
+});
+
 test("compression: buildPlanMilestonePrompt minimal drops project/requirements/decisions files", () => {
   // The plan-milestone builder should gate root file inlining on inlineLevel
   assert.ok(


### PR DESCRIPTION
## Summary

- `buildExecuteTaskPrompt()` in `auto-prompts.ts` was missing the `verificationBudget` template variable that `execute-task.md` declares on line 46
- The strict placeholder validator in `prompt-loader.ts` throws when any `{{...}}` placeholder has no matching value, causing **every auto-mode task dispatch to fail** immediately
- Fix computes the verification budget from the executor's context window using the existing `computeBudgets()` engine and passes it as a `~NNK chars` format string
- Added regression test in `context-compression.test.ts` verifying the variable is present in the builder

## Root Cause

The `execute-task.md` template was updated to include `{{verificationBudget}}` for context budget guidance, but `buildExecuteTaskPrompt()` was never updated to compute and supply that variable. The prompt loader's strict validation correctly rejects the incomplete substitution.

## Changes

| File | Change |
|------|--------|
| `src/resources/extensions/gsd/auto-prompts.ts` | Compute `verificationBudget` from `computeBudgets()` and pass to `loadPrompt("execute-task", {...})` |
| `src/resources/extensions/gsd/tests/context-compression.test.ts` | Add regression test asserting `verificationBudget` is passed and computed from budget engine |

## Test plan

- [x] All 917 unit tests pass (0 failures)
- [x] `prompt-budget-enforcement.test.ts` — 17/17 pass
- [x] `context-compression.test.ts` — 18/18 pass (includes new #707 regression test)
- [x] Build succeeds with no TypeScript errors
- [ ] Manual: run `/gsd auto` with queued tasks — verify task dispatch no longer throws `loadPrompt("execute-task"): template declares {{verificationBudget}} but no value was provided`

Fixes #707
Also related to #705 (same class of bug — already fixed by #677)