### PR TITLE
fix(gsd): support Shift+Tab in visualizer

### DIFF
--- a/src/resources/extensions/gsd/tests/visualizer-overlay.test.ts
+++ b/src/resources/extensions/gsd/tests/visualizer-overlay.test.ts
@@ -1,5 +1,5 @@
 // Tests for GSD visualizer overlay.
-// Verifies filter mode, tab switching, and export key handling.
+// Verifies filter mode, tab switching, including reverse tab navigation, and export key handling.
 
 import { readFileSync } from "node:fs";
 import { join, dirname } from "node:path";
@@ -81,6 +81,11 @@ assertTrue(
   "tab key wraps around TAB_COUNT",
 );
 
+assertTrue(
+  overlaySrc.includes('Key.shift("tab")') || overlaySrc.includes("Key.shift('tab')"),
+  "supports Shift+Tab for reverse tab switching",
+);
+
 console.log("\n=== Overlay: Export Key Interception ===");
 
 assertTrue(
@@ -101,8 +106,8 @@ assertTrue(
 console.log("\n=== Overlay: Footer ===");
 
 assertTrue(
-  overlaySrc.includes("Tab/1-7"),
-  "footer hint shows 1-7 tab range",
+  overlaySrc.includes("Tab/Shift+Tab/1-7"),
+  "footer hint shows Tab, Shift+Tab, and 1-7 tab range",
 );
 
 assertTrue(

--- a/src/resources/extensions/gsd/visualizer-overlay.ts
+++ b/src/resources/extensions/gsd/visualizer-overlay.ts
@@ -112,6 +112,13 @@ export class GSDVisualizerOverlay {
       return;
     }
 
+    if (matchesKey(data, Key.shift("tab"))) {
+      this.activeTab = (this.activeTab - 1 + TAB_COUNT) % TAB_COUNT;
+      this.invalidate();
+      this.tui.requestRender();
+      return;
+    }
+
     if (matchesKey(data, Key.tab)) {
       this.activeTab = (this.activeTab + 1) % TAB_COUNT;
       this.invalidate();
@@ -300,7 +307,7 @@ export class GSDVisualizerOverlay {
     const lines = this.wrapInBox(visibleContent, width);
 
     // Footer hint
-    const hint = th.fg("dim", "Tab/1-7 switch · / filter · ↑↓ scroll · g/G top/end · esc close");
+    const hint = th.fg("dim", "Tab/Shift+Tab/1-7 switch · / filter · ↑↓ scroll · g/G top/end · esc close");
     const hintVis = visibleWidth(hint);
     const hintPad = Math.max(0, Math.floor((width - hintVis) / 2));
     lines.push(" ".repeat(hintPad) + hint);


### PR DESCRIPTION
## Summary
- add Shift+Tab support to move to the previous /gsd visualize tab
- keep Tab behavior for forward tab cycling
- update overlay tests and footer hint to document reverse tab navigation

## Testing
- node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/visualizer-overlay.test.ts src/resources/extensions/gsd/tests/visualizer-data.test.ts