### PR TITLE
fix: forensics reads worktree activity logs (#724)

### DIFF
--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -183,6 +183,16 @@ function syncStateToProjectRoot(worktreePath: string, projectRoot: string, miles
       cpSync(srcMilestone, dstMilestone, { recursive: true, force: true });
     }
   } catch { /* non-fatal */ }
+
+  // 3. Activity logs — so forensics reading from root gets current data
+  try {
+    const srcActivity = join(wtGsd, "activity");
+    const dstActivity = join(prGsd, "activity");
+    if (existsSync(srcActivity)) {
+      mkdirSync(dstActivity, { recursive: true });
+      cpSync(srcActivity, dstActivity, { recursive: true, force: true });
+    }
+  } catch { /* non-fatal */ }
 }
 
 // ─── State ────────────────────────────────────────────────────────────────────

--- a/src/resources/extensions/gsd/doctor.ts
+++ b/src/resources/extensions/gsd/doctor.ts
@@ -8,7 +8,7 @@ import { loadEffectiveGSDPreferences, type GSDPreferences } from "./preferences.
 import { listWorktrees, resolveGitDir } from "./worktree-manager.js";
 import { abortAndReset } from "./git-self-heal.js";
 import { RUNTIME_EXCLUSION_PATHS } from "./git-service.js";
-import { nativeIsRepo, nativeWorktreeRemove, nativeBranchList, nativeBranchDelete, nativeLsFiles, nativeRmCached } from "./native-git-bridge.js";
+import { nativeIsRepo, nativeWorktreeRemove, nativeBranchList, nativeBranchDelete, nativeLsFiles, nativeRmCached, nativeCommitCountBetween } from "./native-git-bridge.js";
 import { readCrashLock, isLockProcessAlive, clearLock } from "./crash-recovery.js";
 import { ensureGitignore } from "./gitignore.js";
 
@@ -657,12 +657,24 @@ async function checkGitHealth(
   try {
     const branchList = nativeBranchList(basePath, "gsd/*/*");
     if (branchList.length > 0) {
+      // Check if any legacy branches contain commits not on the current HEAD
+      let branchesWithUniqueCommits = 0;
+      for (const branch of branchList) {
+        try {
+          const uniqueCount = nativeCommitCountBetween(basePath, "HEAD", branch);
+          if (uniqueCount > 0) branchesWithUniqueCommits++;
+        } catch { /* non-fatal — git rev-list may fail for invalid refs */ }
+      }
+
+      const hasUniqueWork = branchesWithUniqueCommits > 0;
       issues.push({
-        severity: "info",
+        severity: hasUniqueWork ? "warning" : "info",
         code: "legacy_slice_branches",
         scope: "project",
         unitId: "project",
-        message: `${branchList.length} legacy slice branch(es) found: ${branchList.slice(0, 3).join(", ")}${branchList.length > 3 ? "..." : ""}. These are no longer used (branchless architecture). Delete with: git branch -D ${branchList.join(" ")}`,
+        message: hasUniqueWork
+          ? `${branchList.length} legacy slice branch(es) found: ${branchList.slice(0, 3).join(", ")}${branchList.length > 3 ? "..." : ""}. ${branchesWithUniqueCommits} branch(es) contain commits not on HEAD — review before deleting. Delete with: git branch -D ${branchList.join(" ")}`
+          : `${branchList.length} legacy slice branch(es) found: ${branchList.slice(0, 3).join(", ")}${branchList.length > 3 ? "..." : ""}. These are no longer used (branchless architecture). Delete with: git branch -D ${branchList.join(" ")}`,
         fixable: false,
       });
     }

--- a/src/resources/extensions/gsd/forensics.ts
+++ b/src/resources/extensions/gsd/forensics.ts
@@ -27,6 +27,8 @@ import { isAutoActive } from "./auto.js";
 import { loadPrompt } from "./prompt-loader.js";
 import { gsdRoot } from "./paths.js";
 import { formatDuration } from "./history.js";
+import { listWorktrees } from "./worktree-manager.js";
+import { getAutoWorktreePath } from "./auto-worktree.js";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -74,6 +76,42 @@ function parseJSONL(raw: string): unknown[] {
   }).filter(Boolean) as unknown[];
 }
 
+// ─── Worktree-aware base path resolution ──────────────────────────────────────
+
+/**
+ * Resolve the base path for forensic analysis. When an active worktree exists
+ * (from auto-mode or a crashed session), its `.gsd/` contains the real activity
+ * logs and state. Prefer the worktree path over the project root.
+ */
+function resolveForensicBasePath(basePath: string): string {
+  // Check crash lock first — it may reference a worktree session
+  const crashLock = readCrashLock(basePath);
+
+  // Find active worktrees
+  try {
+    const worktrees = listWorktrees(basePath);
+    if (worktrees.length > 0) {
+      // If there's a crash lock, try to find the worktree that matches the crashed milestone
+      if (crashLock) {
+        for (const wt of worktrees) {
+          if (wt.exists && existsSync(join(wt.path, ".gsd", "activity"))) {
+            return wt.path;
+          }
+        }
+      }
+
+      // Otherwise pick the first worktree that has activity logs
+      for (const wt of worktrees) {
+        if (wt.exists && existsSync(join(wt.path, ".gsd", "activity"))) {
+          return wt.path;
+        }
+      }
+    }
+  } catch { /* worktree listing failure is non-fatal */ }
+
+  return basePath;
+}
+
 // ─── Entry Point ──────────────────────────────────────────────────────────────
 
 export async function handleForensics(
@@ -107,7 +145,8 @@ export async function handleForensics(
 
   ctx.ui.notify("Building forensic report...", "info");
 
-  const report = await buildForensicReport(basePath);
+  const forensicBase = resolveForensicBasePath(basePath);
+  const report = await buildForensicReport(basePath, forensicBase);
   const savedPath = saveForensicReport(basePath, report, problemDescription);
 
   // Derive GSD source dir for prompt
@@ -131,26 +170,30 @@ export async function handleForensics(
 
 // ─── Report Builder ───────────────────────────────────────────────────────────
 
-async function buildForensicReport(basePath: string): Promise<ForensicReport> {
+async function buildForensicReport(basePath: string, forensicBase?: string): Promise<ForensicReport> {
   const anomalies: ForensicAnomaly[] = [];
+  // forensicBase is the worktree path (when active), or basePath itself
+  const activityBase = forensicBase ?? basePath;
 
-  // 1. Derive current state
+  // 1. Derive current state (use worktree path for accurate state)
   let activeMilestone: string | null = null;
   let activeSlice: string | null = null;
   try {
-    const state = await deriveState(basePath);
+    const state = await deriveState(activityBase);
     activeMilestone = state.activeMilestone?.id ?? null;
     activeSlice = state.activeSlice?.id ?? null;
   } catch { /* state derivation failure is non-fatal */ }
 
-  // 2. Scan activity logs (last 5)
-  const unitTraces = scanActivityLogs(basePath);
+  // 2. Scan activity logs from the resolved base (worktree-aware)
+  const unitTraces = scanActivityLogs(activityBase);
 
   // 3. Load metrics
   const metrics = loadLedgerFromDisk(basePath);
 
-  // 4. Load completed keys
-  const completedKeys = loadCompletedKeys(basePath);
+  // 4. Load completed keys (check worktree first, fall back to root)
+  const completedKeys = loadCompletedKeys(activityBase).length > 0
+    ? loadCompletedKeys(activityBase)
+    : loadCompletedKeys(basePath);
 
   // 5. Check crash lock
   const crashLock = readCrashLock(basePath);

--- a/src/resources/extensions/gsd/session-forensics.ts
+++ b/src/resources/extensions/gsd/session-forensics.ts
@@ -22,6 +22,7 @@ import { readFileSync, readdirSync, existsSync, statSync } from "node:fs";
 import { basename, join } from "node:path";
 import { nativeParseJsonlTail } from "./native-parser-bridge.js";
 import { nativeWorkingTreeStatus, nativeDiffStat } from "./native-git-bridge.js";
+import { listWorktrees } from "./worktree-manager.js";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -296,7 +297,19 @@ export function synthesizeCrashRecovery(
  * Replaces the old shallow getLastActivityDiagnostic().
  */
 export function getDeepDiagnostic(basePath: string): string | null {
-  const activityDir = join(basePath, ".gsd", "activity");
+  // Prefer worktree activity logs when a worktree is active
+  let activityDir = join(basePath, ".gsd", "activity");
+  try {
+    const worktrees = listWorktrees(basePath);
+    for (const wt of worktrees) {
+      const wtActivityDir = join(wt.path, ".gsd", "activity");
+      if (wt.exists && existsSync(wtActivityDir)) {
+        activityDir = wtActivityDir;
+        break;
+      }
+    }
+  } catch { /* worktree listing failure is non-fatal */ }
+
   const trace = readLastActivityLog(activityDir);
   if (!trace || trace.toolCallCount === 0) return null;
   return formatTraceSummary(trace);


### PR DESCRIPTION
## Summary
- **forensics.ts**: Added `resolveForensicBasePath()` that detects active worktrees via `listWorktrees()` and uses the worktree's `.gsd/activity/` for analysis instead of stale project root data
- **session-forensics.ts**: `getDeepDiagnostic()` now checks worktree activity directories before falling back to the project root
- **auto.ts**: `syncStateToProjectRoot()` now syncs activity logs (third sync step alongside STATE.md and milestone dir)
- **doctor.ts**: Legacy slice branches with commits not on HEAD are escalated from `info` to `warning` severity, with a message noting the unique commits

Fixes #724

## Test plan
- [ ] Run `gsd forensics` while a worktree-based auto-mode session has recent activity — verify it reads worktree logs, not stale root logs
- [ ] Run `gsd auto` in worktree mode, stop, then check that `.gsd/activity/` in project root has the synced logs
- [ ] Run `gsd doctor` with legacy `gsd/*/` branches that have unique commits — verify warning severity
- [ ] Run `gsd doctor` with legacy branches fully merged — verify info severity (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)