### PR TITLE
fix: apply capture triage resolutions before next dispatch cycle (#701)

### DIFF
--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -144,7 +144,8 @@ import {
   detectWorkingTreeActivity,
 } from "./auto-supervisor.js";
 import { isDbAvailable } from "./gsd-db.js";
-import { hasPendingCaptures, loadPendingCaptures, countPendingCaptures } from "./captures.js";
+import { hasPendingCaptures, loadPendingCaptures, countPendingCaptures, loadAllCaptures, markCaptureApplied } from "./captures.js";
+import { executeInject, executeReplan } from "./triage-resolution.js";
 
 // ─── Worktree → Project Root State Sync ───────────────────────────────────────
 // When running in an auto-worktree, dispatch state (.gsd/ metadata) diverges
@@ -1548,6 +1549,60 @@ export async function handleAgentEnd(
       }
     } catch {
       // Triage check failure is non-fatal — proceed to normal dispatch
+    }
+  }
+
+  // ── Post-triage resolution: apply inject/replan classifications (#701) ───
+  // After a triage-captures unit completes, the LLM has classified captures in
+  // CAPTURES.md but has NOT applied resolutions (the prompt forbids it).
+  // We programmatically execute inject/replan resolutions here so that newly
+  // added tasks are visible to deriveState before the next dispatch cycle.
+  // Without this, the dispatch pipeline sees "all tasks done" and proceeds to
+  // complete-slice, skipping the captured work entirely.
+  if (currentUnit?.type === "triage-captures") {
+    try {
+      const allCaptures = loadAllCaptures(basePath);
+      const state = await deriveState(basePath);
+      const mid = state.activeMilestone?.id;
+      const sid = state.activeSlice?.id;
+
+      if (mid && sid) {
+        let injectedCount = 0;
+        let replanTriggered = false;
+
+        for (const cap of allCaptures) {
+          if (cap.status !== "resolved") continue;
+          if (cap.appliedAt) continue; // Already applied in a prior cycle
+
+          if (cap.classification === "inject") {
+            const newTaskId = executeInject(basePath, mid, sid, cap);
+            if (newTaskId) {
+              injectedCount++;
+              markCaptureApplied(basePath, cap.id, `Injected as ${newTaskId}`);
+              debugLog(`[triage-resolution] Injected task ${newTaskId} from capture ${cap.id}`);
+            }
+          } else if (cap.classification === "replan" && !replanTriggered) {
+            const triggered = executeReplan(basePath, mid, sid, cap);
+            if (triggered) {
+              replanTriggered = true;
+              markCaptureApplied(basePath, cap.id, "Replan triggered");
+              debugLog(`[triage-resolution] Triggered replan from capture ${cap.id}`);
+            }
+          }
+        }
+
+        if (injectedCount > 0 || replanTriggered) {
+          // Invalidate state cache so the next deriveState() picks up new tasks
+          invalidateStateCache();
+          ctx.ui.notify(
+            `Applied triage resolutions: ${injectedCount} task${injectedCount !== 1 ? "s" : ""} injected${replanTriggered ? ", replan triggered" : ""}`,
+            "info",
+          );
+        }
+      }
+    } catch {
+      // Resolution application failure is non-fatal — captures are still
+      // classified in CAPTURES.md for manual inspection.
     }
   }
 

--- a/src/resources/extensions/gsd/captures.ts
+++ b/src/resources/extensions/gsd/captures.ts
@@ -26,6 +26,7 @@ export interface CaptureEntry {
   resolution?: string;
   rationale?: string;
   resolvedAt?: string;
+  appliedAt?: string;
 }
 
 export interface TriageResult {
@@ -211,6 +212,44 @@ export function markCaptureResolved(
   writeFileSync(filePath, updated, "utf-8");
 }
 
+/**
+ * Mark a resolved capture as applied (resolution has been executed).
+ * Appends an `**Applied:** <timestamp>` field to prevent re-application
+ * on subsequent dispatch cycles.
+ */
+export function markCaptureApplied(
+  basePath: string,
+  captureId: string,
+  detail?: string,
+): void {
+  const filePath = resolveCapturesPath(basePath);
+  if (!existsSync(filePath)) return;
+
+  const content = readFileSync(filePath, "utf-8");
+  const appliedAt = new Date().toISOString();
+
+  const sectionRegex = new RegExp(
+    `(### ${escapeRegex(captureId)}\\n(?:(?!### ).)*?)(?=### |$)`,
+    "s",
+  );
+  const match = sectionRegex.exec(content);
+  if (!match) return;
+
+  let section = match[1];
+
+  // Remove any existing Applied field (in case of re-application)
+  section = section.replace(/\*\*Applied:\*\*\s*.+\n?/g, "");
+
+  const appliedLine = detail
+    ? `**Applied:** ${appliedAt} — ${detail}`
+    : `**Applied:** ${appliedAt}`;
+
+  section = section.trimEnd() + "\n" + appliedLine + "\n";
+
+  const updated = content.replace(sectionRegex, section);
+  writeFileSync(filePath, updated, "utf-8");
+}
+
 // ─── Parser ───────────────────────────────────────────────────────────────────
 
 /**
@@ -235,6 +274,7 @@ function parseCapturesContent(content: string): CaptureEntry[] {
     const resolution = extractBoldField(body, "Resolution");
     const rationale = extractBoldField(body, "Rationale");
     const resolvedAt = extractBoldField(body, "Resolved");
+    const appliedAt = extractBoldField(body, "Applied");
 
     if (!text || !timestamp) continue;
 
@@ -251,6 +291,7 @@ function parseCapturesContent(content: string): CaptureEntry[] {
       ...(resolution ? { resolution } : {}),
       ...(rationale ? { rationale } : {}),
       ...(resolvedAt ? { resolvedAt } : {}),
+      ...(appliedAt ? { appliedAt } : {}),
     });
   }
 

--- a/src/resources/extensions/gsd/tests/captures.test.ts
+++ b/src/resources/extensions/gsd/tests/captures.test.ts
@@ -436,3 +436,62 @@ test("triage: parseTriageOutput preserves affectedFiles and targetSlice", () => 
   assert.strictEqual(results[1].targetSlice, "S04");
   assert.strictEqual(results[1].affectedFiles, undefined);
 });
+
+// ─── markCaptureApplied ───────────────────────────────────────────────────
+
+import { markCaptureApplied } from "../captures.ts";
+
+test("markCaptureApplied adds Applied field to resolved capture", () => {
+  const dir = makeTempDir("mark-applied");
+  try {
+    const id = appendCapture(dir, "Deploy to production");
+    markCaptureResolved(dir, id, "inject", "Add task T05", "Needs real deployment");
+    markCaptureApplied(dir, id, "Injected as T05");
+
+    const captures = loadAllCaptures(dir);
+    const cap = captures.find(c => c.id === id);
+    assert.ok(cap);
+    assert.ok(cap!.appliedAt);
+    assert.ok(cap!.appliedAt!.includes("Injected as T05"));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("markCaptureApplied is idempotent — replaces existing Applied field", () => {
+  const dir = makeTempDir("mark-applied-idem");
+  try {
+    const id = appendCapture(dir, "Setup CI pipeline");
+    markCaptureResolved(dir, id, "inject", "Add task T06", "CI needed");
+    markCaptureApplied(dir, id, "Injected as T06");
+    markCaptureApplied(dir, id, "Re-injected as T07");
+
+    const captures = loadAllCaptures(dir);
+    const cap = captures.find(c => c.id === id);
+    assert.ok(cap);
+    assert.ok(cap!.appliedAt!.includes("Re-injected as T07"));
+    // Should only have one Applied field
+    const content = readFileSync(resolveCapturesPath(dir), "utf-8");
+    const appliedMatches = content.match(/\*\*Applied:\*\*/g);
+    assert.strictEqual(appliedMatches?.length, 1);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("appliedAt field is parsed correctly by loadAllCaptures", () => {
+  const dir = makeTempDir("applied-parse");
+  try {
+    const id = appendCapture(dir, "Test applied parsing");
+    markCaptureResolved(dir, id, "note", "Just a note", "For testing");
+    // Not applied — should have no appliedAt
+    let captures = loadAllCaptures(dir);
+    assert.strictEqual(captures[0].appliedAt, undefined);
+
+    markCaptureApplied(dir, id);
+    captures = loadAllCaptures(dir);
+    assert.ok(captures[0].appliedAt);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/src/resources/extensions/gsd/tests/triage-resolution.test.ts
+++ b/src/resources/extensions/gsd/tests/triage-resolution.test.ts
@@ -213,3 +213,49 @@ test("resolution: buildQuickTaskPrompt includes capture text and ID", () => {
   assert.ok(prompt.includes("Quick Task"), "should have Quick Task header");
   assert.ok(prompt.includes("Do NOT modify"), "should warn about plan files");
 });
+
+// ─── executeInject + markCaptureApplied integration (#701) ───────────────────
+
+import { markCaptureApplied } from "../captures.ts";
+
+test("resolution: inject creates task and markCaptureApplied prevents re-injection", () => {
+  const tmp = makeTempDir("inject-applied");
+  try {
+    // Create a plan with existing tasks
+    const planDir = join(tmp, ".gsd", "milestones", "M001", "slices", "S01");
+    mkdirSync(planDir, { recursive: true });
+    const planPath = join(planDir, "S01-PLAN.md");
+    writeFileSync(planPath, [
+      "# S01: Auth Flow",
+      "",
+      "## Tasks",
+      "",
+      "- [x] **T01: Basic login** `est:2h`",
+      "- [x] **T02: Token refresh** `est:1h`",
+    ].join("\n"));
+
+    // Create and resolve a capture as inject
+    const capId = appendCapture(tmp, "Add rate limiting");
+    markCaptureResolved(tmp, capId, "inject", "Add task for rate limiting", "API needs protection");
+
+    // First injection should succeed
+    const taskId = executeInject(tmp, "M001", "S01", loadAllCaptures(tmp).find(c => c.id === capId)!);
+    assert.ok(taskId, "should create a new task");
+    assert.strictEqual(taskId, "T03");
+
+    // Mark as applied
+    markCaptureApplied(tmp, capId, `Injected as ${taskId}`);
+
+    // Verify the applied field prevents re-processing
+    const caps = loadAllCaptures(tmp);
+    const cap = caps.find(c => c.id === capId)!;
+    assert.ok(cap.appliedAt, "should have appliedAt field");
+
+    // Verify the plan now has T03
+    const plan = readFileSync(planPath, "utf-8");
+    assert.ok(plan.includes("**T03:"), "plan should contain T03");
+    assert.ok(plan.includes("Add rate limiting"), "plan should contain capture text");
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Problem

When a user fires a `/gsd capture` during auto-mode, the capture is triaged at the next natural seam. The triage LLM classifies captures (inject, replan, defer, note, quick-task) and updates `CAPTURES.md` — but the triage prompt explicitly says **"Do NOT execute any resolutions."**

The `executeInject()` and `executeReplan()` functions existed in `triage-resolution.ts` but were **never called from the auto-mode dispatch pipeline**. After triage completes, normal dispatch resumes. If all original tasks in the slice were done, `deriveState()` returns `phase: "summarizing"` → `complete-slice` → milestone closes — skipping the captured work entirely.

The user's captures were classified and marked resolved, but the tasks they requested were never created or executed.

Fixes #701

## Fix

### 1. Post-triage resolution execution (`auto.ts`)

After a `triage-captures` unit completes, a new block scans `CAPTURES.md` for resolved captures classified as `inject` or `replan`:

- **inject**: Calls `executeInject()` to append a new task to the active slice plan. The task appears as `- [ ] **T##: <capture text>**` — making it visible to `deriveState()` as incomplete work.
- **replan**: Calls `executeReplan()` to write `REPLAN-TRIGGER.md`, which the state machine detects and enters the replanning phase.

After applying resolutions, `invalidateStateCache()` ensures the next `deriveState()` sees the new tasks. A notification reports how many tasks were injected and whether a replan was triggered.

### 2. Applied tracking (`captures.ts`)

New `markCaptureApplied()` function adds an `**Applied:** <timestamp> — <detail>` field to resolved captures in `CAPTURES.md`. This prevents re-injection on subsequent dispatch cycles (the resolution block skips captures with `appliedAt` set).

The `appliedAt` field is parsed by `loadAllCaptures()` and exposed on `CaptureEntry`.

### 3. Idempotency

- Captures already applied (have `appliedAt` field) are skipped
- `markCaptureApplied` replaces any existing Applied field (safe on re-run)
- Only `resolved` captures with `inject` or `replan` classification are processed
- Resolution failures are non-fatal — captures remain classified in CAPTURES.md for manual inspection

## Files Changed

| File | Change |
|------|--------|
| `auto.ts` | Post-triage resolution block + imports |
| `captures.ts` | `markCaptureApplied()`, `appliedAt` field on `CaptureEntry`, parser update |
| `tests/captures.test.ts` | 3 tests: write/parse/idempotency of Applied field |
| `tests/triage-resolution.test.ts` | 1 integration test: inject + markCaptureApplied flow |

## Tests

All 39 tests pass across both test files (27 captures + 12 triage-resolution).