### PR TITLE
fix: add anti-pattern rule against bash with & to prevent agent hangs (#733)

### DIFF
--- a/src/resources/extensions/gsd/prompts/system.md
+++ b/src/resources/extensions/gsd/prompts/system.md
@@ -154,7 +154,7 @@ Templates showing the expected format for each artifact type are in:
 
 **External facts:** Use `search-the-web` + `fetch_page`, or `search_and_read` for one-call extraction. Use `freshness` for recency. Never state current facts from training data without verification.
 
-**Background processes:** Use `bg_shell` with `start` + `wait_for_ready` for servers, watchers, and daemons. Never poll with `sleep`/retry loops — `wait_for_ready` exists for this. For status checks, use `digest` (~30 tokens), not `output` (~2000 tokens). Use `highlights` (~100 tokens) when you need significant lines only. Use `output` only when actively debugging.
+**Background processes:** Use `bg_shell` with `start` + `wait_for_ready` for servers, watchers, and daemons. Never use `bash` with `&` or `nohup` to background a process — the `bash` tool waits for stdout to close, so backgrounded children that inherit the file descriptors cause it to hang indefinitely. Never poll with `sleep`/retry loops — `wait_for_ready` exists for this. For status checks, use `digest` (~30 tokens), not `output` (~2000 tokens). Use `highlights` (~100 tokens) when you need significant lines only. Use `output` only when actively debugging.
 
 **One-shot commands:** Use `async_bash` for builds, tests, and installs. The result is pushed to you when the command exits — no polling needed. Use `await_job` to block on a specific job.
 
@@ -169,6 +169,7 @@ Templates showing the expected format for each artifact type are in:
 - Never use `cat` to read a file you might edit — `read` gives you the exact text `edit` needs.
 - Never `grep` for a function definition when `lsp` go-to-definition is available.
 - Never poll a server with `sleep 1 && curl` loops — use `bg_shell` `wait_for_ready`.
+- Never use `bash` with `&` to background a process — it hangs because the child inherits stdout. Use `bg_shell` `start` instead.
 - Never use `bg_shell` `output` for a status check — use `digest`.
 - Never read files one-by-one to understand a subsystem — use `rg` or `scout` first.
 - Never guess at library APIs from training data — use `get_library_docs`.


### PR DESCRIPTION
## Problem

When the LLM runs `python -m http.server 8080 &` via the `bash` tool, the agent hangs indefinitely. The `bash` tool waits for stdout/stderr file descriptors to close before returning. Shell `&` backgrounds the Python process, but the child inherits the parent's stdout — so the bash call never completes.

The `bg_shell` tool exists for exactly this purpose (detached process groups, automatic readiness detection, lifecycle management), but the system prompt didn't explicitly warn against the `&` pattern.

Fixes #733

## Fix

Updated `system.md` (the system prompt injected into every agent session):

1. **Anti-pattern rule added**: "Never use `bash` with `&` to background a process — it hangs because the child inherits stdout. Use `bg_shell` `start` instead."

2. **Background processes section expanded**: Added explanation of *why* `&` hangs (fd inheritance) and explicit mention that `nohup` has the same problem.

## Scope

This is a prompt-level fix — the underlying `bash` tool behavior is in the Pi SDK. The system prompt is the correct layer for tool usage guidance, and is already where anti-patterns are documented.

## File Changed

`src/resources/extensions/gsd/prompts/system.md` — 2 insertions, 1 deletion