### PR TITLE
docs: update documentation for all post-2.22.0 changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+- **`gsd sessions`** — interactive session picker: lists all saved sessions for the current directory with date, message count, and first-message preview; lets you pick one to resume. Compare with `--continue` which always resumes the most recent session. (#721)
+- **10 new browser tools** — shipped from the #698 feature additions: `browser_save_pdf`, `browser_save_state`, `browser_restore_state`, `browser_mock_route`, `browser_block_urls`, `browser_clear_routes`, `browser_emulate_device`, `browser_extract`, `browser_visual_diff`, `browser_zoom_region`, `browser_generate_test`, `browser_check_injection`, `browser_action_cache` (#698)
+
+### Fixed
+- Shift-Tab now navigates to previous tab in the workflow visualizer (#717)
+- Capture resolutions are now executed after triage instead of only being classified (#714)
+- Screenshot constraining uses independent width/height caps to prevent squishing (#725)
+- `auto.lock` is written at process startup; remote sessions are now detected in the dashboard (#723)
+- Cross-platform test compatibility: use `process.ppid` instead of PID 1
+
 ## [2.22.0] - 2026-03-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@ On first run, GSD launches a branded setup wizard that walks you through LLM pro
 | `Ctrl+Alt+B`            | Show background shell processes                                 |
 | `gsd config`            | Re-run the setup wizard (LLM provider + tool keys)              |
 | `gsd --continue` (`-c`) | Resume the most recent session for the current directory        |
+| `gsd sessions`          | Interactive session picker — browse and resume any saved session |
 
 ---
 
@@ -396,7 +397,7 @@ GSD ships with 14 extensions, all loaded automatically:
 | Extension              | What it provides                                                                                                       |
 | ---------------------- | ---------------------------------------------------------------------------------------------------------------------- |
 | **GSD**                | Core workflow engine, auto mode, commands, dashboard                                                                   |
-| **Browser Tools**      | Playwright-based browser with form intelligence, intent-ranked element finding, and semantic actions                   |
+| **Browser Tools**      | Playwright-based browser with form intelligence, intent-ranked element finding, semantic actions, PDF export, session state persistence, network mocking, device emulation, structured extraction, visual diffing, region zoom, test code generation, and prompt injection detection |
 | **Search the Web**     | Brave Search, Tavily, or Jina page extraction                                                                          |
 | **Google Search**      | Gemini-powered web search with AI-synthesized answers                                                                  |
 | **Context7**           | Up-to-date library/framework documentation                                                                             |

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -69,5 +69,6 @@
 |------|-------------|
 | `gsd` | Start a new interactive session |
 | `gsd --continue` (`-c`) | Resume the most recent session for the current directory |
+| `gsd sessions` | Interactive session picker — list all saved sessions for the current directory and choose one to resume |
 | `gsd --debug` | Enable structured JSONL diagnostic logging for troubleshooting dispatch and state issues |
 | `gsd config` | Re-run the setup wizard (LLM provider + tool keys) |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -126,6 +126,14 @@ gsd --continue    # or gsd -c
 
 Resumes the most recent session for the current directory.
 
+To browse and pick from all saved sessions:
+
+```bash
+gsd sessions
+```
+
+Shows each session's date, message count, and first-message preview so you can choose which one to resume.
+
 ## Next Steps
 
 - [Auto Mode](./auto-mode.md) — deep dive into autonomous execution

--- a/docs/proposals/698-browser-tools-feature-additions.md
+++ b/docs/proposals/698-browser-tools-feature-additions.md
@@ -1,15 +1,15 @@
 # Browser-Tools Feature Additions — Implementation Requirements
 
 > Ref: [#698](https://github.com/gsd-build/gsd-2/issues/698)
-> Status: Proposal — open for contributor review
+> Status: **Shipped** — all 10 features implemented and merged to main
 
 ## Current State
 
-Browser-tools ships **47 tools** across 10 modules (~8,300 lines). The extension wraps Playwright's Chromium instance with intent resolution, semantic actions, assertions, state diffing, an action timeline, HAR/trace export, and a deterministic ref system. Context is managed via `lifecycle.ts` (browser/context/page lifecycle) and `state.ts` (session tracking).
+Browser-tools shipped **47 tools** across 10 modules (~8,300 lines) at the time this proposal was written. After implementation of these 10 features, the tool count expanded with 13 additional tools (some features map to multiple tools).
 
-Key existing capabilities: `browser_navigate`, `browser_click`, `browser_evaluate`, `browser_assert`, `browser_diff`, `browser_batch`, `browser_find_best`, `browser_act`, `browser_trace_start/stop`, `browser_export_har`, `browser_set_viewport`, `browser_screenshot`, `browser_snapshot_refs`.
+Key existing capabilities at proposal time: `browser_navigate`, `browser_click`, `browser_evaluate`, `browser_assert`, `browser_diff`, `browser_batch`, `browser_find_best`, `browser_act`, `browser_trace_start/stop`, `browser_export_har`, `browser_set_viewport`, `browser_screenshot`, `browser_snapshot_refs`.
 
-No existing support for: storage state persistence, route interception, PDF export, structured data extraction, device emulation profiles, visual diffing, or test code generation.
+**Implemented tools** (shipped in main): `browser_save_pdf`, `browser_save_state`, `browser_restore_state`, `browser_mock_route`, `browser_block_urls`, `browser_clear_routes`, `browser_emulate_device`, `browser_extract`, `browser_visual_diff`, `browser_zoom_region`, `browser_generate_test`, `browser_check_injection`, `browser_action_cache`.
 
 ---
 


### PR DESCRIPTION
## Summary

Catches documentation up with all changes merged to main since the 2.22.0 release.

- **CHANGELOG.md** — fills in the empty `[Unreleased]` section with every change since 2.22.0: `gsd sessions` subcommand, 10 new browser tools (#698), visualizer shift-tab fix (#717), capture resolution execution fix (#714), screenshot independent constraint fix (#725), `auto.lock` startup fix (#723), and cross-platform test fix
- **README.md** — adds `gsd sessions` to the CLI reference table; expands the Browser Tools extension description to list the 13 new tools shipped in #698
- **docs/commands.md** — adds `gsd sessions` to the CLI Flags table with a description
- **docs/getting-started.md** — documents `gsd sessions` in the "Resume a Session" section alongside `--continue`
- **docs/proposals/698-browser-tools-feature-additions.md** — updates status from "Proposal" to "Shipped" and rewrites the Current State section to list all 13 implemented tools instead of describing what was missing

## What changed in the code these docs cover

| Commit | Feature/Fix |
|--------|------------|
| #721 | `gsd sessions` interactive session picker |
| #698 | 10 new browser tools (pdf, state persistence, network mocking, device emulation, extraction, visual diff, zoom, codegen, injection detection, action cache) |
| #717 | Shift-Tab support in workflow visualizer |
| #714 | Execute capture resolutions after triage (not just classify) |
| #725 | Independent width/height caps for screenshot constraining |
| #723 | `auto.lock` written at startup; remote session detection in dashboard |

## Test plan

- [ ] Verify `gsd sessions` help text matches the commands.md description
- [ ] Verify all 13 browser tool names in CHANGELOG and proposal doc match the actual tool names in `src/resources/extensions/browser-tools/tools/`
- [ ] Check that no other docs pages reference the browser tools as lacking these capabilities