### PR TITLE
fix(forensics): use GSD_VERSION env var instead of package.json path traversal

### DIFF
--- a/src/resources/extensions/gsd/forensics.ts
+++ b/src/resources/extensions/gsd/forensics.ts
@@ -178,14 +178,10 @@ async function buildForensicReport(basePath: string): Promise<ForensicReport> {
     }
   }
 
-  // 8. GSD version
-  let gsdVersion = "unknown";
-  try {
-    const pkgPath = join(dirname(fileURLToPath(import.meta.url)), "../../../../package.json");
-    if (existsSync(pkgPath)) {
-      gsdVersion = JSON.parse(readFileSync(pkgPath, "utf-8")).version ?? "unknown";
-    }
-  } catch { /* non-fatal */ }
+  // 8. GSD version — use GSD_VERSION env var set by the loader at startup.
+  // Extensions run from ~/.gsd/agent/extensions/gsd/ at runtime, so path-traversal
+  // from import.meta.url would resolve to ~/package.json (wrong on every system).
+  const gsdVersion = process.env.GSD_VERSION || "unknown";
 
   // 9. Run anomaly detectors
   if (metrics?.units) detectStuckLoops(metrics.units, anomalies);


### PR DESCRIPTION
## Problem

`/gsd forensics` was reading the GSD version by traversing 4 directories up from `import.meta.url` to find `package.json`:

```typescript
const pkgPath = join(dirname(fileURLToPath(import.meta.url)), "../../../../package.json");
gsdVersion = JSON.parse(readFileSync(pkgPath, "utf-8")).version ?? "unknown";
```

This worked in development (`dist/resources/extensions/gsd/` → project root), but **fails in every production environment** because extensions are synced to `~/.gsd/agent/extensions/gsd/` at runtime. From there, `../../../../package.json` resolves to `~/package.json` — the user's home directory, which either doesn't exist (returning `"unknown"`) or is a completely unrelated file.

Verified:
```
Extension dir: ~/.gsd/agent/extensions/gsd
Resolved pkg path: ~/package.json   ← wrong
```

## Fix

Use `process.env.GSD_VERSION`, which the loader sets at startup before any extension loads. This is exactly how every other part of the codebase reads the version:

- `src/resources/extensions/gsd/index.ts` — `process.env.GSD_VERSION || "0.0.0"`
- `src/resource-loader.ts` — `process.env.GSD_VERSION || '0.0.0'`
- `src/cli.ts` — `process.env.GSD_VERSION || '0.0.0'`

## Test plan

- [ ] Run `/gsd forensics` and verify the saved report shows the correct version (e.g. `2.22.0`) instead of `"unknown"`
- [ ] All 952 unit tests pass (`npm run test:unit`)