### PR TITLE
fix: skip redundant checkout in worktree merge when main already current

### DIFF
--- a/src/resources/extensions/gsd/auto-worktree.ts
+++ b/src/resources/extensions/gsd/auto-worktree.ts
@@ -429,8 +429,12 @@ export function mergeMilestoneToMain(
   const integrationBranch = readIntegrationBranch(originalBasePath_, milestoneId);
   const mainBranch = integrationBranch ?? prefs.main_branch ?? "main";
 
-  // 5. Checkout integration branch
-  nativeCheckoutBranch(originalBasePath_, mainBranch);
+  // 5. Checkout integration branch (skip if already current — avoids git error
+  //    when main is already checked out in the project-root worktree, #757)
+  const currentBranchAtBase = nativeGetCurrentBranch(originalBasePath_);
+  if (currentBranchAtBase !== mainBranch) {
+    nativeCheckoutBranch(originalBasePath_, mainBranch);
+  }
 
   // 6. Build rich commit message
   const milestoneTitle = roadmap.title.replace(/^M\d+:\s*/, "").trim() || milestoneId;

--- a/src/resources/extensions/gsd/tests/auto-worktree-milestone-merge.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-worktree-milestone-merge.test.ts
@@ -290,6 +290,40 @@ async function main(): Promise<void> {
       assertTrue(existsSync(join(repo, "feature.ts")), "feature.ts merged to main");
     }
 
+    // ─── Test 6: Skip checkout when main already current (#757) ───────
+    console.log("\n=== skip checkout when main already current (#757) ===");
+    {
+      const repo = freshRepo();
+      const wtPath = createAutoWorktree(repo, "M060");
+
+      addSliceToMilestone(repo, wtPath, "M060", "S01", "Skip checkout test", [
+        { file: "skip-checkout.ts", content: "export const skip = true;\n", message: "add skip-checkout" },
+      ]);
+
+      const roadmap = makeRoadmap("M060", "Skip checkout verification", [
+        { id: "S01", title: "Skip checkout test" },
+      ]);
+
+      // Verify main is already checked out at repo root (worktree default)
+      const branchAtRoot = run("git rev-parse --abbrev-ref HEAD", repo);
+      assertEq(branchAtRoot, "main", "main is already checked out at project root");
+
+      // mergeMilestoneToMain should succeed without attempting to checkout main
+      // (which would fail with "already used by worktree" error)
+      let threw = false;
+      try {
+        const result = mergeMilestoneToMain(repo, "M060", roadmap);
+        assertTrue(result.commitMessage.includes("feat(M060)"), "merge commit created");
+      } catch (err) {
+        threw = true;
+        console.error("Unexpected error:", err);
+      }
+      assertTrue(!threw, "does not fail when main is already checked out at project root");
+
+      // Verify the merge actually happened
+      assertTrue(existsSync(join(repo, "skip-checkout.ts")), "skip-checkout.ts merged to main");
+    }
+
   } finally {
     process.chdir(savedCwd);
     for (const d of tempDirs) {


### PR DESCRIPTION
## Summary

Fixes #757 — worktree milestone merge fails with `fatal: 'main' is already used by worktree` error.

**Root cause:** `mergeMilestoneToMain` in `auto-worktree.ts` unconditionally runs `git checkout main` at the project root. In worktree mode, `main` is already checked out there — git refuses to checkout a branch that's active in another worktree (even the same one), causing the merge to fail.

**Fix:** Check `nativeGetCurrentBranch()` before attempting checkout. If the integration branch is already current at the project root, skip the checkout entirely. This is always the case in worktree-mode merges, since the worktree uses `milestone/<MID>` while `main` stays checked out at the project root.

## Changes

- `auto-worktree.ts`: Guard the checkout call with a branch comparison — only checkout if the current branch differs from the target integration branch
- `auto-worktree-milestone-merge.test.ts`: Added Test 6 that verifies the merge succeeds when `main` is already checked out at the project root (the exact scenario from the bug report)

## Test plan

- [x] New test "skip checkout when main already current (#757)" passes
- [x] All 30 assertions in `auto-worktree-milestone-merge.test.ts` pass
- [x] Full unit test suite: 972/975 pass (3 pre-existing failures in `mcp-server.test.ts` due to missing build artifact, unrelated)