### PR TITLE
fix: always sync bundled resources and clean stale files

### DIFF
--- a/src/resource-loader.ts
+++ b/src/resource-loader.ts
@@ -1,6 +1,6 @@
 import { DefaultResourceLoader } from '@gsd/pi-coding-agent'
 import { homedir } from 'node:os'
-import { cpSync, existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from 'node:fs'
+import { cpSync, existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
 import { dirname, join, relative, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { compareSemver } from './update-check.js'
@@ -151,28 +151,41 @@ export function getNewerManagedResourceVersion(agentDir: string, currentVersion:
 export function initResources(agentDir: string): void {
   mkdirSync(agentDir, { recursive: true })
 
-  // Skip resource sync when versions match — saves ~128ms of cpSync per launch
-  const currentVersion = getBundledGsdVersion()
-  const managedVersion = readManagedResourceVersion(agentDir)
-  if (managedVersion && managedVersion === currentVersion) {
-    return
-  }
-
-  // Sync extensions — overwrite so updates land on next launch
+  // Sync extensions — clean bundled subdirs first to remove stale leftover files,
+  // then overwrite so updates land on next launch. Only bundled subdirs are removed;
+  // user-created extension directories are preserved.
   const destExtensions = join(agentDir, 'extensions')
+  for (const entry of readdirSync(bundledExtensionsDir, { withFileTypes: true })) {
+    if (entry.isDirectory()) {
+      const target = join(destExtensions, entry.name)
+      if (existsSync(target)) rmSync(target, { recursive: true, force: true })
+    }
+  }
   cpSync(bundledExtensionsDir, destExtensions, { recursive: true, force: true })
 
   // Sync agents
   const destAgents = join(agentDir, 'agents')
   const srcAgents = join(resourcesDir, 'agents')
   if (existsSync(srcAgents)) {
+    for (const entry of readdirSync(srcAgents, { withFileTypes: true })) {
+      if (entry.isDirectory()) {
+        const target = join(destAgents, entry.name)
+        if (existsSync(target)) rmSync(target, { recursive: true, force: true })
+      }
+    }
     cpSync(srcAgents, destAgents, { recursive: true, force: true })
   }
 
-  // Sync skills — overwrite so updates land on next launch
+  // Sync skills
   const destSkills = join(agentDir, 'skills')
   const srcSkills = join(resourcesDir, 'skills')
   if (existsSync(srcSkills)) {
+    for (const entry of readdirSync(srcSkills, { withFileTypes: true })) {
+      if (entry.isDirectory()) {
+        const target = join(destSkills, entry.name)
+        if (existsSync(target)) rmSync(target, { recursive: true, force: true })
+      }
+    }
     cpSync(srcSkills, destSkills, { recursive: true, force: true })
   }
 


### PR DESCRIPTION
## Summary

- Remove version-match early return in `initResources()` — resources always sync on startup (~128ms, negligible)
- Add `rmSync` of bundled subdirectories before each `cpSync` to remove stale leftover files from other versions
- User-created extension directories are preserved (only bundled subdirs are cleaned)

## Motivation

Closes #761

## Change type
- [x] `fix` — Bug fix

## Scope
- [x] `gsd extension` — GSD workflow (`src/resources/extensions/gsd/`)

## Breaking changes
- [x] No breaking changes

## Test plan
- [x] Unit tests added/updated (`npm run test:unit`) — 359/359 pass
- [x] Manual testing — describe steps:
  - `npm run typecheck:extensions` clean
  - `npm run build` clean
  - Verified version-match skip removed: `grep -c "managedVersion === currentVersion" src/resource-loader.ts` → 0
  - Verified cleanup added: `grep -c "rmSync" src/resource-loader.ts` → 4 (import + 3 sync points)

## Rollback plan
- [x] Safe to revert (no migrations, no state changes)

## Release context
- **Target**: main

🤖 Generated with [Claude Code](https://claude.com/claude-code)