### PR TITLE
fix: prevent stale state loop on auto-mode restart with existing worktree (#759)

### DIFF
--- a/src/resources/extensions/gsd/auto-worktree.ts
+++ b/src/resources/extensions/gsd/auto-worktree.ts
@@ -158,7 +158,15 @@ export function createAutoWorktree(basePath: string, milestoneId: string): strin
   // Planning artifacts may be untracked if the project's .gitignore had a
   // blanket .gsd/ rule (pre-v2.14.0). Without this copy, auto-mode loops
   // on plan-slice because the plan file doesn't exist in the worktree.
-  copyPlanningArtifacts(basePath, info.path);
+  //
+  // IMPORTANT: Skip when re-attaching to an existing branch (#759).
+  // The branch checkout already has committed artifacts with correct state
+  // (e.g. [x] for completed slices). Copying from the project root would
+  // overwrite them with stale data ([ ] checkboxes) because the root is
+  // not always fully synced.
+  if (!branchExists) {
+    copyPlanningArtifacts(basePath, info.path);
+  }
 
   // Run user-configured post-create hook (#597) — e.g. copy .env, symlink assets
   const hookError = runWorktreePostCreateHook(basePath, info.path);

--- a/src/resources/extensions/gsd/state.ts
+++ b/src/resources/extensions/gsd/state.ts
@@ -32,7 +32,6 @@ import {
 
 import { milestoneIdSort, findMilestoneIds } from './guided-flow.js';
 import { nativeBatchParseGsdFiles, type BatchParsedFile } from './native-parser-bridge.js';
-import { isDbAvailable, _getAdapter } from './gsd-db.js';
 
 import { join, resolve } from 'path';
 import { debugCount, debugTime } from './debug-logger.js';
@@ -149,37 +148,18 @@ async function _deriveStateImpl(basePath: string): Promise<GSDState> {
   const fileContentCache = new Map<string, string>();
   const gsdDir = gsdRoot(basePath);
 
-  // ── DB-first content loading ──
-  // When the DB is available, load artifact content from the artifacts table
-  // (indexed SELECT instead of O(N) file I/O). Falls back to native Rust batch
-  // parser, which in turn falls back to sequential JS reads via cachedLoadFile.
-  let dbContentLoaded = false;
-  if (isDbAvailable()) {
-    const adapter = _getAdapter();
-    if (adapter) {
-      try {
-        const rows = adapter.prepare('SELECT path, full_content FROM artifacts').all();
-        for (const row of rows) {
-          const relPath = (row as Record<string, unknown>)['path'] as string;
-          const content = (row as Record<string, unknown>)['full_content'] as string;
-          const absPath = resolve(gsdDir, relPath);
-          fileContentCache.set(absPath, content);
-        }
-        dbContentLoaded = rows.length > 0;
-      } catch {
-        // DB query failed — fall through to native batch parse
-      }
-    }
-  }
-
-  if (!dbContentLoaded) {
+  // NOTE: We intentionally do NOT load from the SQLite DB here (#759).
+  // The DB's artifacts table is populated once during migrateFromMarkdown
+  // and is never updated when files change on disk (e.g. roadmap [x] updates,
+  // plan checkbox changes). Using stale DB content causes deriveState to
+  // return incorrect phase/slice state, leading to infinite skip loops.
+  // The native Rust batch parser is fast enough for state derivation.
   const batchFiles = nativeBatchParseGsdFiles(gsdDir);
   if (batchFiles) {
     for (const f of batchFiles) {
       const absPath = resolve(gsdDir, f.path);
       fileContentCache.set(absPath, f.rawContent);
     }
-  }
   }
 
   /**

--- a/src/resources/extensions/gsd/tests/derive-state-db.test.ts
+++ b/src/resources/extensions/gsd/tests/derive-state-db.test.ts
@@ -248,31 +248,24 @@ async function main(): Promise<void> {
     }
   }
 
-  // ─── Test 5: Requirements counting from DB content ────────────────────
-  console.log('\n=== derive-state-db: requirements from DB content ===');
+  // ─── Test 5: Requirements counting from disk (DB no longer used for content) ─
+  console.log('\n=== derive-state-db: requirements from disk content ===');
   {
     const base = createFixtureBase();
     try {
       // Write minimal milestone dir (needed for milestone discovery)
       mkdirSync(join(base, '.gsd', 'milestones', 'M001'), { recursive: true });
-      // Do NOT write REQUIREMENTS.md to disk — only in DB
-
-      openDatabase(':memory:');
-      insertArtifactRow('REQUIREMENTS.md', REQUIREMENTS_CONTENT, {
-        artifact_type: 'requirements',
-      });
+      // Write REQUIREMENTS.md to disk (DB content is no longer used by deriveState)
+      writeFile(base, 'REQUIREMENTS.md', REQUIREMENTS_CONTENT);
 
       invalidateStateCache();
       const state = await deriveState(base);
 
-      // Requirements should come from DB
-      assertEq(state.requirements?.active, 2, 'req-from-db: requirements.active = 2');
-      assertEq(state.requirements?.validated, 1, 'req-from-db: requirements.validated = 1');
-      assertEq(state.requirements?.total, 3, 'req-from-db: requirements.total = 3');
-
-      closeDatabase();
+      // Requirements should come from disk
+      assertEq(state.requirements?.active, 2, 'req-from-disk: requirements.active = 2');
+      assertEq(state.requirements?.validated, 1, 'req-from-disk: requirements.validated = 1');
+      assertEq(state.requirements?.total, 3, 'req-from-disk: requirements.total = 3');
     } finally {
-      closeDatabase();
       cleanup(base);
     }
   }


### PR DESCRIPTION
## Problem

After stopping and restarting `/gsd auto`, auto-mode enters an infinite skip loop — alternating between "Skipped 20+ completed units" and "Skipping complete-slice M001/S04 — already completed". Doctor reports `task_done_missing_summary` errors but heal finds nothing actionable.

Two compounding bugs cause this:

### Bug 1: `copyPlanningArtifacts` overwrites worktree state

When auto-mode restarts and the milestone branch exists (worktree directory was removed but branch preserved):

1. `createAutoWorktree()` detects `branchExists = true`, re-attaches worktree to the existing `milestone/<MID>` branch
2. Git correctly checks out committed state with `[x]` for completed slices
3. **Then `copyPlanningArtifacts()` runs unconditionally** — copies root `.gsd/milestones/` into the worktree
4. The root has stale `[ ]` checkboxes (not fully synced) → overwrites the correct `[x]`

### Bug 2: `deriveState()` reads stale content from SQLite DB

`deriveState()` had a DB-first content loading path:
```typescript
if (isDbAvailable()) {
  const rows = adapter.prepare('SELECT path, full_content FROM artifacts').all();
  // ... loads into fileContentCache
}
```

The `artifacts` table was populated once during `migrateFromMarkdown` and **never updated when files changed on disk**. Even after fixing roadmap files to show `[x]`, `deriveState()` read the DB's stale `[ ]` content and kept returning the same incomplete slice, creating the infinite skip loop.

Fixes #759

## Fix

### Bug 1 fix: `auto-worktree.ts`

Skip `copyPlanningArtifacts` when `branchExists` is true — the branch checkout already has committed artifacts with correct state:

```typescript
if (!branchExists) {
  copyPlanningArtifacts(basePath, info.path);
}
```

### Bug 2 fix: `state.ts`

Remove the DB content loading path from `deriveState()` entirely. The native Rust batch parser (`nativeBatchParseGsdFiles`) reads all `.md` files in one call and is fast enough for state derivation. The DB is still used for structured queries (decisions, requirements tools) but no longer serves as a content cache that can go stale.

## Files Changed

| File | Change |
|------|--------|
| `auto-worktree.ts` | Guard `copyPlanningArtifacts` with `!branchExists` |
| `state.ts` | Remove DB-first content loading, remove unused `gsd-db` import |
| `tests/derive-state-db.test.ts` | Update Test 5 to write requirements to disk instead of testing removed DB-only path |

## Tests

- derive-state.test.ts: 109 passed ✓
- derive-state-db.test.ts: 51 passed ✓ (updated)
- derive-state-deps.test.ts: passed ✓
- derive-state-draft.test.ts: passed ✓
- auto-worktree.test.ts: 24 passed ✓
- auto-recovery.test.ts: 26 passed ✓

## Workaround (until fix is released)

```bash
rm -f .gsd/worktrees/<MID>/.gsd/gsd.db*
# Ensure roadmap has correct [x] checkboxes for completed slices
```