### PR TITLE
Fix read-only file permissions after cpSync from Nix store which prevent updates

### DIFF
--- a/src/resource-loader.ts
+++ b/src/resource-loader.ts
@@ -1,6 +1,6 @@
 import { DefaultResourceLoader } from '@gsd/pi-coding-agent'
 import { homedir } from 'node:os'
-import { chmodSync, cpSync, existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from 'node:fs'
+import { chmodSync, cpSync, existsSync, mkdirSync, readFileSync, readdirSync, statSync, writeFileSync } from 'node:fs'
 import { dirname, join, relative, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { compareSemver } from './update-check.js'
@@ -139,16 +139,32 @@ export function getNewerManagedResourceVersion(agentDir: string, currentVersion:
  * Files copied from the Nix store inherit read-only modes (0444/0555).
  * Calling this before cpSync prevents overwrite failures on subsequent upgrades,
  * and calling it after ensures the next run can overwrite the copies too.
+ *
+ * Preserves existing permission bits (including executability) and only adds
+ * owner-write (and for directories, owner-exec) without widening group/other
+ * permissions.
  */
 function makeTreeWritable(dirPath: string): void {
   if (!existsSync(dirPath)) return
-  chmodSync(dirPath, 0o755)
-  for (const entry of readdirSync(dirPath, { withFileTypes: true })) {
-    const entryPath = join(dirPath, entry.name)
-    if (entry.isDirectory()) {
+
+  const stats = statSync(dirPath)
+  const isDir = stats.isDirectory()
+  const currentMode = stats.mode & 0o777
+
+  // Ensure owner-write; for directories also ensure owner-exec so they remain traversable.
+  let newMode = currentMode | 0o200
+  if (isDir) {
+    newMode |= 0o100
+  }
+
+  if (newMode !== currentMode) {
+    chmodSync(dirPath, newMode)
+  }
+
+  if (isDir) {
+    for (const entry of readdirSync(dirPath, { withFileTypes: true })) {
+      const entryPath = join(dirPath, entry.name)
       makeTreeWritable(entryPath)
-    } else {
-      chmodSync(entryPath, 0o644)
     }
   }
 }


### PR DESCRIPTION
## Summary
- Fix resource initialization so upgrades can overwrite files previously copied from the Nix store with read-only permissions
- Add `makeTreeWritable()` in `src/resource-loader.ts` and run it before and after `cpSync(..., { force: true })`
- Apply the permission repair to all managed resource trees: `extensions/`, `agents/`, and `skills/`
## Motivation
If gsd is packged for nix (got this working fine locally), files copied from the Nix store inherit read-only modes (`0444`/`0555`). On later upgrades, `cpSync(..., { force: true })` fails when trying to overwrite those files in `~/.gsd/agent/`.
This change repairs existing broken installs before copying and ensures copied resources remain writable for future upgrades.
Closes #
## Change type
- [x] `fix` — Bug fix
- [ ] `feat` — New feature or capability
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes
## Scope
- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [x] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [ ] `gsd extension` — GSD workflow (`src/resources/extensions/gsd/`)
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config
## Breaking changes
- [x] No breaking changes
- [ ] Yes — describe below:
## Test plan
- [ ] Unit tests added/updated (`npm run test:unit`)
- [ ] Integration tests added/updated (`npm run test:integration`)
- [x] Manual testing — describe steps:
  1. Start with a `~/.gsd` resource tree containing files copied from the Nix store with read-only permissions
  2. Run resource initialization / upgrade flow
  3. Verify existing resource trees are made writable before copy
  4. Verify `cpSync(..., { force: true })` succeeds without permission errors
  5. Verify copied files are writable afterward so a subsequent upgrade also succeeds
- [ ] No tests needed — explain why:
## Rollback plan
- [x] Safe to revert (no migrations, no state changes)
- [ ] Requires steps — describe:
## Release context
- **Target**: main