### PR TITLE
fix: downgrade missing_tasks_dir to warning for completed slices

### DIFF
--- a/src/resources/extensions/gsd/doctor.ts
+++ b/src/resources/extensions/gsd/doctor.ts
@@ -1093,18 +1093,12 @@ export async function runGSDDoctor(basePath: string, options?: { fix?: boolean; 
 
       const tasksDir = resolveTasksDir(basePath, milestoneId, slice.id);
       if (!tasksDir) {
-        // Check if slice is already complete — missing tasks/ is cosmetic, not structural
-        const sliceSumPath = resolveSliceFile(basePath, milestoneId, slice.id, "SUMMARY");
-        const sliceSumContent = sliceSumPath ? await loadFile(sliceSumPath) : null;
-        const sliceSummary = sliceSumContent ? parseSummary(sliceSumContent) : null;
-        const sliceComplete = sliceSummary?.frontmatter?.status === "complete";
-
         issues.push({
-          severity: sliceComplete ? "warning" : "error",
+          severity: slice.done ? "warning" : "error",
           code: "missing_tasks_dir",
           scope: "slice",
           unitId,
-          message: sliceComplete
+          message: slice.done
             ? `Missing tasks directory for ${unitId} (slice is complete — cosmetic only)`
             : `Missing tasks directory for ${unitId}`,
           file: relSlicePath(basePath, milestoneId, slice.id),
@@ -1120,13 +1114,7 @@ export async function runGSDDoctor(basePath: string, options?: { fix?: boolean; 
       const planContent = planPath ? await loadFile(planPath) : null;
       const plan = planContent ? parsePlan(planContent) : null;
       if (!plan) {
-        // Reuse slice completion check from above, or compute if tasksDir existed
-        const planSumPath = resolveSliceFile(basePath, milestoneId, slice.id, "SUMMARY");
-        const planSumContent = planSumPath ? await loadFile(planSumPath) : null;
-        const planSummary = planSumContent ? parseSummary(planSumContent) : null;
-        const planSliceComplete = planSummary?.frontmatter?.status === "complete";
-
-        if (!planSliceComplete) {
+        if (!slice.done) {
           issues.push({
             severity: "warning",
             code: "missing_slice_plan",


### PR DESCRIPTION
## Summary

Fixes #726.

- **`missing_tasks_dir`**: When a slice has a summary with `status: complete`, downgrade severity from `"error"` to `"warning"` and append "(slice is complete — cosmetic only)" to the message. This unblocks `/gsd visualize` for completed milestones whose `tasks/` directories were removed with worktrees.
- **`missing_slice_plan`**: Skip the warning entirely for completed slices, since a plan file has no purpose after completion.

## Context

When a worktree is removed and artifacts are rebuilt, `tasks/` directories aren't recreated. For completed slices these directories are cosmetic scaffolding — the slice is provably done. Reporting this as an error incorrectly blocks visualization of completed milestones.

## Test plan

- [ ] Run `gsd doctor` on a project with completed slices missing `tasks/` dirs — verify warning (not error)
- [ ] Run `gsd doctor` on a project with incomplete slices missing `tasks/` dirs — verify error still fires
- [ ] Run `gsd visualize` on a completed milestone — verify it renders without being blocked
- [ ] Run `gsd doctor --fix` — verify it still creates missing `tasks/` dirs regardless of severity

🤖 Generated with [Claude Code](https://claude.com/claude-code)