### PR TITLE
fix: raise maxDelayMs default from 60s to 300s (#756)

### DIFF
--- a/packages/pi-coding-agent/src/core/agent-session.ts
+++ b/packages/pi-coding-agent/src/core/agent-session.ts
@@ -2553,7 +2553,7 @@ export class AgentSession {
 		if (message.retryAfterMs !== undefined) {
 			const cap = settings.maxDelayMs > 0 ? settings.maxDelayMs : Infinity;
 			if (message.retryAfterMs > cap) {
-				// Server wants us to wait longer than our max — give up immediately
+				// Server wants us to wait longer than maxDelayMs — give up to let auto-mode handle recovery
 				this._emit({
 					type: "auto_retry_end",
 					success: false,

--- a/packages/pi-coding-agent/src/core/settings-manager.ts
+++ b/packages/pi-coding-agent/src/core/settings-manager.ts
@@ -20,7 +20,7 @@ export interface RetrySettings {
 	enabled?: boolean; // default: true
 	maxRetries?: number; // default: 3
 	baseDelayMs?: number; // default: 2000 (exponential backoff: 2s, 4s, 8s)
-	maxDelayMs?: number; // default: 60000 (max server-requested delay before failing)
+	maxDelayMs?: number; // default: 300000 (max server-requested delay before failing)
 }
 
 export interface TerminalSettings {
@@ -752,7 +752,7 @@ export class SettingsManager {
 			enabled: this.getRetryEnabled(),
 			maxRetries: this.settings.retry?.maxRetries ?? 3,
 			baseDelayMs: this.settings.retry?.baseDelayMs ?? 2000,
-			maxDelayMs: this.settings.retry?.maxDelayMs ?? 60000,
+			maxDelayMs: this.settings.retry?.maxDelayMs ?? 300000,
 		};
 	}
 


### PR DESCRIPTION
## Summary

- Raises the `maxDelayMs` retry default from 60,000ms (60s) to 300,000ms (5 min)
- Fixes #756: Anthropic 429 responses with `retry-after: 60` caused `extractRetryAfterMs()` to compute 61,000ms (60s + 1s buffer), which exceeded the 60,000ms cap — making every rate-limit retry immediately give up
- Updates the give-up comment in `agent-session.ts` to clarify that auto-mode handles recovery after the retry logic bails

## Root cause

`extractRetryAfterMs()` adds a 1-second buffer to server-requested delays. Anthropic rate limit windows are typically 60-120s. With the old 60s default for `maxDelayMs`, a 60s `retry-after` header became 61s, which always exceeded the cap, causing the retry logic to abandon immediately on virtually every rate limit hit.

## Test plan

- [ ] Verify `getRetrySettings()` returns `maxDelayMs: 300000` with no user override
- [ ] Verify a `retry-after: 60` header (61,000ms after buffer) no longer triggers the give-up path
- [ ] Verify a `retry-after: 301` header (302,000ms after buffer) still triggers the give-up path
- [ ] Verify user overrides in `settings.json` still take precedence

🤖 Generated with [Claude Code](https://claude.com/claude-code)