### PR TITLE
feat: interactive update prompt on startup (#770)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -211,12 +211,16 @@ if (!isPrintMode && shouldRunOnboarding(authStorage, settingsManager.getDefaultP
   process.stdin.pause()
 }
 
-// Interactive update check — runs at most once per 24h, asks user to update or skip
+// Update check — interactive prompt when stdin is a TTY, passive banner otherwise
 if (!isPrintMode) {
-  const updated = await checkAndPromptForUpdates().catch(() => false)
-  if (updated) {
-    // User chose to update — exit so they relaunch with the new version
-    process.exit(0)
+  if (process.stdin.isTTY) {
+    const updated = await checkAndPromptForUpdates().catch(() => false)
+    if (updated) {
+      // User chose to update — exit so they relaunch with the new version
+      process.exit(0)
+    }
+  } else {
+    checkForUpdates().catch(() => {})
   }
 }
 

--- a/src/update-check.ts
+++ b/src/update-check.ts
@@ -158,18 +158,17 @@ export async function checkAndPromptForUpdates(options: UpdateCheckOptions = {})
   }
 
   // Update available — show interactive prompt
-  // Build the inner content line without ANSI codes to measure visible width,
-  // then pad to fit a dynamic box.
-  const innerText = `  Update available! v${currentVersion} → v${latestVersion}  `
-  const innerWidth = innerText.length
+  // Measure visible (ANSI-free) width to size the box, then render with chalk.
+  const midContent = `  ${chalk.bold('Update available!')} ${chalk.dim(`v${currentVersion}`)} → ${chalk.bold.green(`v${latestVersion}`)}  `
+  const midVisible = `  Update available! v${currentVersion} → v${latestVersion}  `
+  const innerWidth = midVisible.length
   const top = '╔' + '═'.repeat(innerWidth) + '╗'
-  const mid = '║' + `  ${chalk.bold('Update available!')} ${chalk.dim(`v${currentVersion}`)} → ${chalk.bold.green(`v${latestVersion}`)}  ` + '║'
   const bot = '╚' + '═'.repeat(innerWidth) + '╝'
 
   process.stderr.write('\n')
   process.stderr.write(
     `  ${chalk.yellow(top)}\n` +
-    `  ${chalk.yellow('║')}${mid.slice(1, -1)}${chalk.yellow('║')}\n` +
+    `  ${chalk.yellow('║')}${midContent}${chalk.yellow('║')}\n` +
     `  ${chalk.yellow(bot)}\n\n`,
   )
 


### PR DESCRIPTION
Closes #770

## Summary

When a newer version of `gsd-pi` is available, show an interactive prompt at startup so users can update immediately without having to remember to run `npm install -g gsd-pi@latest` manually.

## What changed

### `src/update-check.ts`
- **`checkAndPromptForUpdates()`** — new exported function that:
  - Reuses the existing 24h cache (`readUpdateCache` / `writeUpdateCache`) so the npm registry is hit at most once per day
  - Displays a dynamically-sized banner box showing `v{current} → v{latest}` (box width is computed from the visible text length, so it stays aligned for any version string)
  - Prompts with two options: **[1] Update now** (`npm install -g gsd-pi@latest`) or **[2] Skip**
  - Auto-skips after **30 seconds** if no input is received (guards against non-TTY / piped-stdin edge cases)
  - Runs `npm install -g gsd-pi@latest` via `execSync` on choice `[1]`; returns `true` on success so the caller can `process.exit(0)` and let the user relaunch with the new build
  - Cleans up stdin listeners and raw mode after the prompt so the TUI starts with a clean slate

### `src/cli.ts`
- Replaces the old fire-and-forget `checkForUpdates()` call with `await checkAndPromptForUpdates()`
- If the update succeeds, calls `process.exit(0)` so the user relaunches with the new version
- Still guarded by `!isPrintMode` — skipped in print / RPC / MCP / headless modes

## Fixes included (review feedback)
- **Removed duplicate `NPM_PACKAGE` constant** that shadowed the existing `NPM_PACKAGE_NAME`
- **Dynamic box width** — measured from plain-text content rather than hardcoded, works with any version string
- **30s prompt timeout** — auto-resolves to skip so a non-responsive stdin never hangs startup

## Testing
- Manually verified prompt renders correctly and both choices work as expected
- Update failure path correctly falls through and returns `false` (does not exit)
- No TypeScript errors