### PR TITLE
docs: update documentation for v2.22 release features

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Full documentation is available in the [`docs/`](./docs/) directory:
 - **[Skills](./docs/skills.md)** — bundled skills, discovery, custom authoring
 - **[Commands Reference](./docs/commands.md)** — all commands and keyboard shortcuts
 - **[Architecture](./docs/architecture.md)** — system design and dispatch pipeline
-- **[Troubleshooting](./docs/troubleshooting.md)** — common issues, doctor, recovery
+- **[Troubleshooting](./docs/troubleshooting.md)** — common issues, doctor, forensics, recovery
 - **[Migration from v1](./docs/migration.md)** — `.planning` → `.gsd` migration
 
 ---

--- a/docs/auto-mode.md
+++ b/docs/auto-mode.md
@@ -63,6 +63,10 @@ A lock file tracks the current unit. If the session dies, the next `/gsd auto` r
 
 If the same unit dispatches twice (the LLM didn't produce the expected artifact), GSD retries once with a deep diagnostic prompt. If it fails again, auto mode stops with the exact file it expected, so you can intervene.
 
+### Post-Mortem Investigation
+
+When auto mode fails or produces unexpected results, `/gsd forensics` provides structured post-mortem analysis. It inspects activity logs, crash locks, and session state to identify root causes — whether the failure was a model error, missing context, a stuck loop, or a broken tool call. See [Troubleshooting](./troubleshooting.md) for more on diagnosing issues.
+
 ### Timeout Supervision
 
 Three timeout tiers prevent runaway sessions:

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -15,6 +15,8 @@
 | `/gsd queue` | Queue and reorder future milestones (safe during auto mode) |
 | `/gsd capture` | Fire-and-forget thought capture (works during auto mode) |
 | `/gsd triage` | Manually trigger triage of pending captures |
+| `/gsd forensics` | Post-mortem investigation of auto-mode failures — structured root-cause analysis with log inspection |
+| `/gsd cleanup` | Clean up GSD state files and stale worktrees |
 | `/gsd visualize` | Open workflow visualizer (progress, deps, metrics, timeline) |
 | `/gsd knowledge` | Add persistent project knowledge (rule, pattern, or lesson) |
 | `/gsd help` | Categorized command reference with descriptions for all GSD subcommands |
@@ -121,3 +123,14 @@ gsd headless dispatch plan
 **Exit codes:** `0` = complete, `1` = error or timeout, `2` = blocked.
 
 Any `/gsd` subcommand works as a positional argument — `gsd headless status`, `gsd headless doctor`, `gsd headless dispatch execute`, etc.
+
+## MCP Server Mode
+
+`gsd --mode mcp` runs GSD as a [Model Context Protocol](https://modelcontextprotocol.io) server over stdin/stdout. This exposes all GSD tools (read, write, edit, bash, etc.) to external AI clients — Claude Desktop, VS Code Copilot, and any MCP-compatible host.
+
+```bash
+# Start GSD as an MCP server
+gsd --mode mcp
+```
+
+The server registers all tools from the agent session and maps MCP `tools/list` and `tools/call` requests to GSD tool definitions. It runs until the transport closes.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -12,6 +12,9 @@ GSD preferences live in `~/.gsd/preferences.md` (global) or `.gsd/preferences.md
 | `/gsd prefs status` | Show current preference files, merged values, and skill resolution status |
 | `/gsd prefs wizard` | Alias for `/gsd prefs global` |
 | `/gsd prefs setup` | Alias for `/gsd prefs wizard` — creates preferences file if missing |
+| `/gsd prefs import-claude` | Import Claude marketplace plugins and skills as namespaced GSD components |
+| `/gsd prefs import-claude global` | Import to global scope |
+| `/gsd prefs import-claude project` | Import to project scope |
 
 ## Preferences File Format
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -21,6 +21,9 @@ GSD ships with these skills, installed to `~/.gsd/agent/skills/`:
 | `security-audit` | Security auditing — dependency scanning, OWASP | Comprehensive security assessment |
 | `security-review` | Code security review — injection, XSS, auth flaws | Vulnerability-focused code review |
 | `security-docker` | Docker security — Dockerfile, runtime hardening | Container security best practices |
+| `review` | Code review — staged changes, PRs, security, performance | Diff-aware code review with quality analysis |
+| `test` | Test generation and execution — auto-detects frameworks | Generate tests or run existing suites with failure analysis |
+| `lint` | Linting and formatting — ESLint, Biome, Prettier | Auto-detect linter, fix issues, report remaining problems |
 
 ## Skill Discovery
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -111,5 +111,5 @@ Doctor rebuilds `STATE.md` from plan and roadmap files on disk and fixes detecte
 
 - **GitHub Issues:** [github.com/gsd-build/GSD-2/issues](https://github.com/gsd-build/GSD-2/issues)
 - **Dashboard:** `Ctrl+Alt+G` or `/gsd status` for real-time diagnostics
+- **Forensics:** `/gsd forensics` for structured post-mortem analysis of auto-mode failures
 - **Session logs:** `.gsd/activity/` contains JSONL session dumps for crash forensics
-ctivity/` contains JSONL session dumps for crash forensics


### PR DESCRIPTION
## Documentation Updates for v2.22

Updates documentation to cover features introduced in the v2.22.0 release.

### Changes

| File | Update |
|------|--------|
| `docs/commands.md` | Added `/gsd forensics` and `/gsd cleanup` commands |
| `docs/commands.md` | Added MCP Server Mode section (`--mode mcp`) |
| `docs/configuration.md` | Added `/gsd prefs import-claude` commands for Claude marketplace import |
| `docs/skills.md` | Added `review`, `test`, and `lint` to bundled skills table |
| `docs/auto-mode.md` | Added Post-Mortem Investigation section |
| `docs/troubleshooting.md` | Added forensics to Getting Help, fixed corrupted duplicate line |
| `README.md` | Updated troubleshooting link description |

### v2.22 Features Covered

- `/gsd forensics` — post-mortem investigation of auto-mode failures
- Claude marketplace import (`/gsd prefs import-claude`)
- MCP server mode (`--mode mcp`)
- `/review`, `/test`, `/lint` bundled skills
- `/gsd cleanup` command