### PR TITLE
fix: make skip-loop interruptible and count toward lifetime cap (#792)

### DIFF
--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -2426,18 +2426,31 @@ async function dispatchNextUnit(
           `Skip loop detected: ${unitType} ${unitId} skipped ${skipCount} times without advancing. Evicting completion record and forcing reconciliation.`,
           "warning",
         );
+        if (!active) return;
         _skipDepth++;
-        await new Promise(r => setTimeout(r, 50));
+        await new Promise(r => setTimeout(r, 150));
         await dispatchNextUnit(ctx, pi);
         _skipDepth = Math.max(0, _skipDepth - 1);
+        return;
+      }
+      // Count toward lifetime cap so hard-stop fires during skip loops (#792)
+      const lifeSkip = (unitLifetimeDispatches.get(idempotencyKey) ?? 0) + 1;
+      unitLifetimeDispatches.set(idempotencyKey, lifeSkip);
+      if (lifeSkip > MAX_LIFETIME_DISPATCHES) {
+        await stopAuto(ctx, pi, `Hard loop: ${unitType} ${unitId} (skip cycle)`);
+        ctx.ui.notify(
+          `Hard loop detected: ${unitType} ${unitId} hit lifetime cap during skip cycle (${lifeSkip} iterations).`,
+          "error",
+        );
         return;
       }
       ctx.ui.notify(
         `Skipping ${unitType} ${unitId} — already completed in a prior session. Advancing.`,
         "info",
       );
+      if (!active) return;
       _skipDepth++;
-      await new Promise(r => setTimeout(r, 50));
+      await new Promise(r => setTimeout(r, 150));
       await dispatchNextUnit(ctx, pi);
       _skipDepth = Math.max(0, _skipDepth - 1);
       return;
@@ -2473,18 +2486,31 @@ async function dispatchNextUnit(
         `Skip loop detected: ${unitType} ${unitId} skipped ${skipCount2} times without advancing. Evicting completion record and forcing reconciliation.`,
         "warning",
       );
+      if (!active) return;
       _skipDepth++;
-      await new Promise(r => setTimeout(r, 50));
+      await new Promise(r => setTimeout(r, 150));
       await dispatchNextUnit(ctx, pi);
       _skipDepth = Math.max(0, _skipDepth - 1);
+      return;
+    }
+    // Count toward lifetime cap so hard-stop fires during skip loops (#792)
+    const lifeSkip2 = (unitLifetimeDispatches.get(idempotencyKey) ?? 0) + 1;
+    unitLifetimeDispatches.set(idempotencyKey, lifeSkip2);
+    if (lifeSkip2 > MAX_LIFETIME_DISPATCHES) {
+      await stopAuto(ctx, pi, `Hard loop: ${unitType} ${unitId} (skip cycle)`);
+      ctx.ui.notify(
+        `Hard loop detected: ${unitType} ${unitId} hit lifetime cap during skip cycle (${lifeSkip2} iterations).`,
+        "error",
+      );
       return;
     }
     ctx.ui.notify(
       `Skipping ${unitType} ${unitId} — artifact exists but completion key was missing. Repaired and advancing.`,
       "info",
     );
+    if (!active) return;
     _skipDepth++;
-    await new Promise(r => setTimeout(r, 50));
+    await new Promise(r => setTimeout(r, 150));
     await dispatchNextUnit(ctx, pi);
     _skipDepth = Math.max(0, _skipDepth - 1);
     return;


### PR DESCRIPTION
## Summary
- Add `if (!active) return` guards before all 4 recursive `dispatchNextUnit()` calls in skip paths, so `stopAuto()` can interrupt skip loops
- Increment `unitLifetimeDispatches` during skip cycles so the `MAX_LIFETIME_DISPATCHES` hard cap fires as a safety net against infinite loops
- Increase skip-path `setTimeout` yield from 50ms to 150ms to give the event loop more time for stop commands to execute (Windows reliability)

## Test plan
- [x] Existing `auto-skip-loop.test.ts` passes (all 10 assertions)
- [x] No new type errors introduced (`tsc --noEmit` — pre-existing `headless.ts` errors only)
- [ ] Manual: trigger a skip loop and verify stop command interrupts it promptly
- [ ] Manual: verify lifetime cap fires with "Hard loop detected" notification after 6 skip iterations

Fixes #792

🤖 Generated with [Claude Code](https://claude.com/claude-code)