### PR TITLE
fix: include DB artifact cache in invalidateAllCaches (#793)

### DIFF
--- a/src/resources/extensions/gsd/cache.ts
+++ b/src/resources/extensions/gsd/cache.ts
@@ -12,16 +12,18 @@
 import { invalidateStateCache } from './state.js';
 import { clearPathCache } from './paths.js';
 import { clearParseCache } from './files.js';
+import { clearArtifacts } from './gsd-db.js';
 
 /**
  * Invalidate all GSD runtime caches in one call.
  *
  * Call this after file writes, milestone transitions, merge reconciliation,
  * or any operation that changes .gsd/ contents on disk. Forgetting to clear
- * any single cache causes stale reads (see #431).
+ * any single cache causes stale reads (see #431, #793).
  */
 export function invalidateAllCaches(): void {
   invalidateStateCache();
   clearPathCache();
   clearParseCache();
+  clearArtifacts();
 }

--- a/src/resources/extensions/gsd/gsd-db.ts
+++ b/src/resources/extensions/gsd/gsd-db.ts
@@ -790,6 +790,21 @@ export function upsertRequirement(r: Requirement): void {
 /**
  * Insert or replace an artifact. Uses the `path` PK for idempotency.
  */
+/**
+ * Delete all rows from the artifacts table.
+ * The artifacts table is a read cache — clearing it forces the next
+ * deriveState() to fall through to disk reads (native Rust batch parse).
+ * Safe to call when no database is open (no-op).
+ */
+export function clearArtifacts(): void {
+  if (!currentDb) return;
+  try {
+    currentDb.exec('DELETE FROM artifacts');
+  } catch {
+    // Clearing a cache should never be fatal
+  }
+}
+
 export function insertArtifact(a: {
   path: string;
   artifact_type: string;


### PR DESCRIPTION
## Summary
- Cherry-picked `clearArtifacts()` from #797 — the one useful addition that #796 didn't cover
- Adds `clearArtifacts()` to `gsd-db.ts` (deletes all rows from artifacts table, no-op if no DB open)
- Wires it into `invalidateAllCaches()` in `cache.ts` so the DB artifact table is cleared alongside state/path/parse caches

## Context
PRs #796 and #797 both fixed #793. #796 was merged (more thorough fix + regression test). This PR captures the one piece #797 had that #796 didn't: clearing the DB artifact cache as part of `invalidateAllCaches()`.

## Test plan
- [x] `npx tsc --noEmit` — no type errors
- [x] `clearArtifacts()` is a no-op when no DB is open, and silently catches errors — safe in all contexts

🤖 Generated with [Claude Code](https://claude.com/claude-code)