### PR TITLE
fix: use unique temp paths in saveFile() to prevent parallel write collisions (#810)

### DIFF
--- a/src/resources/extensions/gsd/files.ts
+++ b/src/resources/extensions/gsd/files.ts
@@ -5,6 +5,7 @@
 
 import { promises as fs } from 'node:fs';
 import { dirname, resolve } from 'node:path';
+import { randomBytes } from 'node:crypto';
 import { resolveMilestoneFile, relMilestoneFile, resolveGsdRootFile } from './paths.js';
 import { milestoneIdSort, findMilestoneIds } from './guided-flow.js';
 
@@ -705,9 +706,19 @@ export async function saveFile(path: string, content: string): Promise<void> {
   const dir = dirname(path);
   await fs.mkdir(dir, { recursive: true });
 
-  const tmpPath = path + '.tmp';
+  // Use a unique temp path per call to avoid collisions when parallel
+  // tool calls target the same file (e.g. concurrent gsd_save_decision).
+  // rename() is atomic on POSIX, so last-writer-wins is correct for
+  // regenerate-from-DB writes.
+  const tmpPath = path + `.tmp.${randomBytes(4).toString("hex")}`;
   await fs.writeFile(tmpPath, content, 'utf-8');
-  await fs.rename(tmpPath, path);
+  try {
+    await fs.rename(tmpPath, path);
+  } catch (err) {
+    // Clean up orphaned temp file on rename failure
+    await fs.unlink(tmpPath).catch(() => {});
+    throw err;
+  }
 }
 
 export function parseRequirementCounts(content: string | null): RequirementCounts {


### PR DESCRIPTION
Fixes #810

## Problem

`saveFile()` uses a static temp path (`path + ".tmp"`) for atomic writes. When parallel tool calls (e.g. concurrent `gsd_save_decision`) target the same file, writers collide on the same `.tmp` path — one caller's `rename()` succeeds and consumes the temp file, then the other gets `ENOENT`.

## Fix

Replace the deterministic `.tmp` suffix with a per-call random suffix (`randomBytes(4).toString('hex')`) so each concurrent writer gets its own temp file. `rename()` is atomic on POSIX, so last-writer-wins is correct for these regenerate-from-DB writes.

Also adds cleanup of orphaned temp files on `rename()` failure.

## Changes
- `src/resources/extensions/gsd/files.ts`: `saveFile()` uses unique temp paths