### PR TITLE
fix: prevent crash when cancelling OAuth provider login dialog (#821)

### DIFF
--- a/packages/pi-coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/interactive-mode.ts
@@ -3883,12 +3883,16 @@ export class InteractiveMode {
 			const selector = new OAuthSelectorComponent(
 				mode,
 				this.session.modelRegistry.authStorage,
-				async (providerId: string) => {
+				(providerId: string) => {
 					done();
 
-					if (mode === "login") {
-						await this.showLoginDialog(providerId);
-					} else {
+					// OAuthSelectorComponent calls this synchronously (no await),
+					// so we must catch async errors here to prevent unhandled rejections
+					// when the user cancels the login dialog (#821).
+					const handleAsync = async () => {
+						if (mode === "login") {
+							await this.showLoginDialog(providerId);
+						} else {
 						// Logout flow
 						const providerInfo = this.session.modelRegistry.authStorage
 							.getOAuthProviders()
@@ -3919,6 +3923,11 @@ export class InteractiveMode {
 							this.showError(`Logout failed: ${error instanceof Error ? error.message : String(error)}`);
 						}
 					}
+					};
+					handleAsync().catch(() => {
+						// Swallow — showLoginDialog already handles its own errors.
+						// This prevents unhandled rejections when login is cancelled.
+					});
 				},
 				() => {
 					done();


### PR DESCRIPTION
Fixes #821

## Problem

Pressing Escape during the OAuth login flow (after selecting a provider like GitHub Copilot) crashes GSD with:
```
Error: Login cancelled
    at InteractiveMode.showLoginDialog (...)
    at async OAuthSelectorComponent.onSelectCallback (...)
```

`OAuthSelectorComponent` calls its `onSelectCallback` synchronously (no `await`), but the callback in `showOAuthSelector` is `async` — it calls `await this.showLoginDialog(providerId)` which throws "Login cancelled" when the user presses Escape. The unhandled promise rejection bubbles up to the `uncaughtException` handler in `gsd/index.ts` and terminates the process.

## Fix

Wrap the async callback body in a named function with `.catch()` so cancellation errors are swallowed gracefully. `showLoginDialog` already handles its own error display — the "Login cancelled" error is expected and intentionally not shown to the user (line 4043: `if (errorMsg !== "Login cancelled")`). The only issue was the unhandled rejection escaping the synchronous callback boundary.

## Changes
- `packages/pi-coding-agent/src/modes/interactive/interactive-mode.ts`: Wrap async OAuth selector callback with `.catch()` error boundary