### PR TITLE
fix: add debug logging to silent early-return paths in dispatchNextUnit (#823)

### DIFF
--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -2011,6 +2011,7 @@ async function dispatchNextUnit(
   pi: ExtensionAPI,
 ): Promise<void> {
   if (!active || !cmdCtx) {
+    debugLog(`dispatchNextUnit early return — active=${active}, cmdCtx=${!!cmdCtx}`);
     if (active && !cmdCtx) {
       ctx.ui.notify("Auto-mode session expired. Run /gsd auto to restart.", "info");
     }
@@ -2020,6 +2021,7 @@ async function dispatchNextUnit(
   // Reentrancy guard: allow recursive calls from skip paths (_skipDepth > 0)
   // but block concurrent external calls (watchdog, step wizard, etc.)
   if (_dispatching && _skipDepth === 0) {
+    debugLog("dispatchNextUnit reentrancy guard — another dispatch in progress, bailing");
     return; // Another dispatch is in progress — bail silently
   }
   _dispatching = true;


### PR DESCRIPTION
Fixes #823 — auto-mode silently stops after plan-slice. Adds debugLog calls to the reentrancy guard and cmdCtx early-return paths so the failure mode is visible in debug logs.