### PR TITLE
fix: handle EPIPE in LSP sendNotification and wait for process exit on reload (#815)

### DIFF
--- a/packages/pi-coding-agent/src/core/lsp/client.ts
+++ b/packages/pi-coding-agent/src/core/lsp/client.ts
@@ -842,7 +842,17 @@ export async function sendNotification(client: LspClient, method: string, params
 	};
 
 	client.lastActivity = Date.now();
-	await writeMessage(client.proc.stdin, notification);
+	try {
+		await writeMessage(client.proc.stdin, notification);
+	} catch (err: unknown) {
+		// EPIPE means the LSP process died (e.g. after lsp.reload killed it).
+		// Swallow so callers don't crash — the next getOrCreateClient call
+		// will spawn a fresh server (#815).
+		if (err instanceof Error && 'code' in err && (err as NodeJS.ErrnoException).code === 'EPIPE') {
+			return;
+		}
+		throw err;
+	}
 }
 
 /**

--- a/packages/pi-coding-agent/src/core/lsp/index.ts
+++ b/packages/pi-coding-agent/src/core/lsp/index.ts
@@ -211,6 +211,13 @@ async function reloadServer(client: LspClient, serverName: string, signal?: Abor
 	}
 	if (output.startsWith("Restarted")) {
 		client.proc.kill();
+		// Wait for the process to actually exit so the crash recovery handler
+		// removes the client from the cache. Without this, the next
+		// getOrCreateClient call may return the dead client (#815).
+		await Promise.race([
+			client.proc.exited,
+			new Promise(r => setTimeout(r, 3000)),
+		]);
 	}
 	return output;
 }


### PR DESCRIPTION
Fixes #815 — EPIPE crash after lsp.reload. sendNotification catches EPIPE, and reloadServer waits for the killed process to exit before returning.