### PR TITLE
fix: limit native web_search to 5 uses per turn to prevent search loops (#817)

### DIFF
--- a/src/resources/extensions/search-the-web/native-search.ts
+++ b/src/resources/extensions/search-the-web/native-search.ts
@@ -157,6 +157,9 @@ export function registerNativeSearchHooks(pi: NativeSearchPI): { getIsAnthropic:
     tools.push({
       type: "web_search_20250305",
       name: "web_search",
+      // Limit searches per turn to prevent the model from looping on
+      // web_search calls without synthesizing results (#817).
+      max_uses: 5,
     });
 
     return payload;


### PR DESCRIPTION
Fixes #817 — adds max_uses: 5 to the Anthropic native web_search tool configuration to prevent the model from looping 30-50 times without synthesizing results.