### PR TITLE
feat: add require_slice_discussion option to pause auto-mode before each slice (#789)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -120,6 +120,7 @@ phases:
   skip_research: false        # skip milestone-level research
   skip_reassess: false        # skip roadmap reassessment after each slice
   skip_slice_research: true   # skip per-slice research
+  require_slice_discussion: false  # pause auto-mode before each slice for discussion
 ```
 
 These are usually set automatically by `token_profile`, but can be overridden explicitly.

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -3751,6 +3751,20 @@ export async function dispatchDirectPhase(
           ctx.ui.notify("Cannot dispatch research-slice: no active slice.", "warning");
           return;
         }
+
+        // When require_slice_discussion is enabled, pause auto-mode before
+        // each new slice so the user can discuss requirements first (#789).
+        const sliceContextFile = resolveSliceFile(base, mid, sid, "CONTEXT");
+        const requireDiscussion = loadEffectiveGSDPreferences()?.preferences?.phases?.require_slice_discussion;
+        if (requireDiscussion && !sliceContextFile) {
+          ctx.ui.notify(
+            `Slice ${sid} requires discussion before planning. Run /gsd discuss to discuss this slice, then /gsd auto to resume.`,
+            "info",
+          );
+          await pauseAuto(ctx, pi);
+          return;
+        }
+
         unitType = "research-slice";
         unitId = `${mid}/${sid}`;
         prompt = await buildResearchSlicePrompt(mid, midTitle, sid, sTitle, base);

--- a/src/resources/extensions/gsd/preferences.ts
+++ b/src/resources/extensions/gsd/preferences.ts
@@ -916,8 +916,9 @@ export function validatePreferences(preferences: GSDPreferences): {
       if (p.skip_reassess !== undefined) validatedPhases.skip_reassess = !!p.skip_reassess;
       if (p.skip_slice_research !== undefined) validatedPhases.skip_slice_research = !!p.skip_slice_research;
       if (p.skip_milestone_validation !== undefined) validatedPhases.skip_milestone_validation = !!p.skip_milestone_validation;
+      if ((p as any).require_slice_discussion !== undefined) (validatedPhases as any).require_slice_discussion = !!(p as any).require_slice_discussion;
       // Warn on unknown phase keys
-      const knownPhaseKeys = new Set(["skip_research", "skip_reassess", "skip_slice_research", "skip_milestone_validation"]);
+      const knownPhaseKeys = new Set(["skip_research", "skip_reassess", "skip_slice_research", "skip_milestone_validation", "require_slice_discussion"]);
       for (const key of Object.keys(p)) {
         if (!knownPhaseKeys.has(key)) {
           warnings.push(`unknown phases key "${key}" — ignored`);

--- a/src/resources/extensions/gsd/types.ts
+++ b/src/resources/extensions/gsd/types.ts
@@ -265,6 +265,8 @@ export interface PhaseSkipPreferences {
   skip_reassess?: boolean;
   skip_slice_research?: boolean;
   skip_milestone_validation?: boolean;
+  /** When true, auto-mode pauses before each slice for discussion (#789). */
+  require_slice_discussion?: boolean;
 }
 
 export interface NotificationPreferences {


### PR DESCRIPTION
Fixes #789 — new `phases.require_slice_discussion: true` preference pauses auto-mode before each slice for discussion. Resumes after /gsd discuss creates a slice CONTEXT file.