### PR TITLE
feat: show discussion status indicators in /gsd discuss slice picker (#782)

### DIFF
--- a/src/resources/extensions/gsd/guided-flow.ts
+++ b/src/resources/extensions/gsd/guided-flow.ts
@@ -959,12 +959,22 @@ export async function showDiscuss(
 
   // Loop: show picker, dispatch discuss, repeat until "not_yet"
   while (true) {
-    const actions = pendingSlices.map((s, i) => ({
-      id: s.id,
-      label: `${s.id}: ${s.title}`,
-      description: state.activeSlice?.id === s.id ? "active slice" : "upcoming",
-      recommended: i === 0,
-    }));
+    const actions = pendingSlices.map((s, i) => {
+      // Check if this slice has already been discussed (CONTEXT file exists)
+      const contextFile = resolveSliceFile(basePath, mid, s.id, "CONTEXT");
+      const discussed = !!contextFile;
+      const statusParts: string[] = [];
+      if (state.activeSlice?.id === s.id) statusParts.push("active");
+      else statusParts.push("upcoming");
+      statusParts.push(discussed ? "discussed ✓" : "not discussed");
+
+      return {
+        id: s.id,
+        label: `${s.id}: ${s.title}`,
+        description: statusParts.join(" · "),
+        recommended: i === 0,
+      };
+    });
 
     const choice = await showNextAction(ctx, {
       title: "GSD — Discuss a slice",


### PR DESCRIPTION
Fixes #782 — the discuss slice picker now shows `discussed ✓` or `not discussed` next to each slice based on whether a CONTEXT file exists.