### PR TITLE
fix: replace orphaned invalidateStateCache() calls with invalidateAllCaches()

### DIFF
--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -2470,7 +2470,7 @@ async function dispatchNextUnit(
           // Milestone is complete — evicting this key would fight self-heal.
           // Clear skip counter and re-dispatch from fresh state.
           unitConsecutiveSkips.delete(idempotencyKey);
-          invalidateStateCache();
+          invalidateAllCaches();
           ctx.ui.notify(
             `Phantom skip loop cleared: ${unitType} ${unitId} belongs to completed milestone ${skippedMid}. Re-dispatching from fresh state.`,
             "info",
@@ -2548,7 +2548,7 @@ async function dispatchNextUnit(
         : false;
       if (skippedMilestoneComplete2) {
         unitConsecutiveSkips.delete(idempotencyKey);
-        invalidateStateCache();
+        invalidateAllCaches();
         ctx.ui.notify(
           `Phantom skip loop cleared: ${unitType} ${unitId} belongs to completed milestone ${skippedMid2}. Re-dispatching from fresh state.`,
           "info",


### PR DESCRIPTION
Unblocks CI on PR #802 (and any other open PR against `main`).

## What broke

PR #799 (`fix/790-crash-recovery-phantom-loop`) added two new phantom-loop handling paths in `auto.ts` that called `invalidateStateCache()`. But `invalidateStateCache` was removed from the `auto.ts` import in PR #796, which migrated all call sites to `invalidateAllCaches()`. The two new calls in #799 were written against the old API, causing:

```
error TS2552: Cannot find name 'invalidateStateCache'. Did you mean 'invalidateAllCaches'?
  auto.ts(2473)
  auto.ts(2551)
```

This broke the `build` and `windows-portability` CI jobs for every subsequent PR.

## Fix

Replace the two orphaned `invalidateStateCache()` calls with `invalidateAllCaches()` — consistent with every other call site in the file.

Both affected paths are "phantom skip loop cleared" branches where a completed-milestone unit was being re-dispatched. These benefit from full cache invalidation (path + parse + state) just as much as the other eviction paths.

## Verification

`tsc --noEmit --project tsconfig.extensions.json` — `auto.ts` type errors resolved.