### PR TITLE
fix: limit native web_search to max_uses:5 per response (#817)

### DIFF
--- a/src/resources/extensions/search-the-web/native-search.ts
+++ b/src/resources/extensions/search-the-web/native-search.ts
@@ -157,6 +157,10 @@ export function registerNativeSearchHooks(pi: NativeSearchPI): { getIsAnthropic:
     tools.push({
       type: "web_search_20250305",
       name: "web_search",
+      // Cap server-side searches per response to prevent the model from
+      // looping on web_search without synthesizing results (#817).
+      // 5 searches is generous — most queries need 1-2.
+      max_uses: 5,
     });
 
     return payload;

--- a/src/tests/native-search.test.ts
+++ b/src/tests/native-search.test.ts
@@ -92,11 +92,12 @@ test("before_provider_request injects web_search for claude models", async () =>
   });
 
   const tools = (result as any)?.tools ?? payload.tools;
-  const hasNative = (tools as any[]).some(
+  const nativeTool = (tools as any[]).find(
     (t: any) => t.type === "web_search_20250305"
   );
-  assert.ok(hasNative, "Should inject web_search_20250305 tool");
+  assert.ok(nativeTool, "Should inject web_search_20250305 tool");
   assert.equal((tools as any[]).length, 2, "Should have original + injected tool");
+  assert.equal(nativeTool.max_uses, 5, "Should set max_uses to 5 to prevent search loops (#817)");
 });
 
 test("before_provider_request injects web_search for claude models even without model_select", async () => {
@@ -278,6 +279,7 @@ test("before_provider_request creates tools array if missing", async () => {
   assert.ok(Array.isArray(tools), "Should create tools array");
   assert.equal((tools as any[]).length, 1, "Should have exactly 1 tool");
   assert.equal((tools as any[])[0].type, "web_search_20250305");
+  assert.equal((tools as any[])[0].max_uses, 5, "Should include max_uses limit");
 });
 
 test("before_provider_request skips when payload is falsy", async () => {


### PR DESCRIPTION
## Problem

The Anthropic native `web_search_20250305` tool has no default limit on how many searches Claude performs within a single API response. Without `max_uses`, the model can perform 30-50+ searches before synthesizing results, producing tens of thousands of lines of output in the TUI.

This manifests as "search looping" in interactive mode but appears fine in print mode because print mode only renders `text` blocks (search results from `serverToolUse`/`webSearchResult` blocks are invisible). The underlying behavior is the same — the API performs many searches in one response — but interactive mode renders each search result pair visually.

## Why the earlier fix (#844) didn't work for the reporter

The user patched `src/resources/extensions/search-the-web/native-search.ts` but didn't rebuild. The resource loader prefers `dist/resources/` over `src/resources/` (when `dist/` exists), so the unpatched `dist/` version was loaded and synced to `~/.gsd/agent/extensions/` on startup.

## Fix

Add `max_uses: 5` to the injected `web_search` tool configuration. This caps server-side searches to 5 per API response — generous for most queries (typically 1-2 searches needed) while preventing runaway search loops.

## Changes

- `src/resources/extensions/search-the-web/native-search.ts`: Add `max_uses: 5` to native search tool injection
- `src/tests/native-search.test.ts`: Verify `max_uses` is present on injected tool (2 test updates)

Supersedes #844. Closes #817.