### PR TITLE
feat: integrate hashline edit mode into active workflow (#870)

### DIFF
--- a/packages/pi-coding-agent/src/core/agent-session.ts
+++ b/packages/pi-coding-agent/src/core/agent-session.ts
@@ -774,6 +774,42 @@ export class AgentSession {
 		);
 	}
 
+	/**
+	 * Switch edit mode between standard (text-match) and hashline (LINE#ID anchors).
+	 * Swaps the active read/edit tools and rebuilds the system prompt.
+	 */
+	setEditMode(mode: "standard" | "hashline"): void {
+		this.settingsManager.setEditMode(mode);
+
+		// Get current active tool registry keys
+		const currentKeys = new Set<string>();
+		for (const [key, tool] of this._toolRegistry.entries()) {
+			if (this.agent.state.tools.includes(tool)) {
+				currentKeys.add(key);
+			}
+		}
+
+		// Swap read tools
+		if (mode === "hashline") {
+			currentKeys.delete("read");
+			currentKeys.add("hashline_read");
+			currentKeys.delete("edit");
+			currentKeys.add("hashline_edit");
+		} else {
+			currentKeys.delete("hashline_read");
+			currentKeys.add("read");
+			currentKeys.delete("hashline_edit");
+			currentKeys.add("edit");
+		}
+
+		this.setActiveToolsByName([...currentKeys]);
+	}
+
+	/** Current edit mode */
+	get editMode(): "standard" | "hashline" {
+		return this.settingsManager.getEditMode();
+	}
+
 	/** All messages including custom types like BashExecutionMessage */
 	get messages(): AgentMessage[] {
 		return this.agent.state.messages;

--- a/packages/pi-coding-agent/src/core/sdk.ts
+++ b/packages/pi-coding-agent/src/core/sdk.ts
@@ -30,6 +30,12 @@ import {
 	editTool,
 	findTool,
 	grepTool,
+	hashlineCodingTools,
+	hashlineEditTool,
+	hashlineReadTool,
+	createHashlineCodingTools,
+	createHashlineEditTool,
+	createHashlineReadTool,
 	lsTool,
 	readOnlyTools,
 	readTool,
@@ -119,6 +125,13 @@ export {
 	createGrepTool,
 	createFindTool,
 	createLsTool,
+	// Hashline edit mode
+	hashlineCodingTools,
+	hashlineEditTool,
+	hashlineReadTool,
+	createHashlineCodingTools,
+	createHashlineEditTool,
+	createHashlineReadTool,
 };
 
 // Helper Functions
@@ -238,7 +251,10 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		thinkingLevel = "off";
 	}
 
-	const defaultActiveToolNames: ToolName[] = ["read", "bash", "edit", "write", "lsp"];
+	const editMode = settingsManager.getEditMode();
+	const defaultActiveToolNames: ToolName[] = editMode === "hashline"
+		? ["hashline_read", "bash", "hashline_edit", "write", "lsp"]
+		: ["read", "bash", "edit", "write", "lsp"];
 	const initialActiveToolNames: ToolName[] = options.tools
 		? options.tools.map((t) => t.name).filter((n): n is ToolName => n in allTools)
 		: defaultActiveToolNames;

--- a/packages/pi-coding-agent/src/core/settings-manager.ts
+++ b/packages/pi-coding-agent/src/core/settings-manager.ts
@@ -142,6 +142,7 @@ export interface Settings {
 	taskIsolation?: TaskIsolationSettings;
 	fallback?: FallbackSettings;
 	modelDiscovery?: ModelDiscoverySettings;
+	editMode?: "standard" | "hashline"; // Edit tool mode: "standard" (text match) or "hashline" (LINE#ID anchors). Default: "standard"
 }
 
 /** Deep merge settings: project/overrides take precedence, nested objects merge recursively */
@@ -1125,6 +1126,16 @@ export class SettingsManager {
 		}
 		this.globalSettings.modelDiscovery.enabled = enabled;
 		this.markModified("modelDiscovery", "enabled");
+		this.save();
+	}
+
+	getEditMode(): "standard" | "hashline" {
+		return this.settings.editMode ?? "standard";
+	}
+
+	setEditMode(mode: "standard" | "hashline"): void {
+		this.globalSettings.editMode = mode;
+		this.markModified("editMode");
 		this.save();
 	}
 }

--- a/packages/pi-coding-agent/src/core/slash-commands.ts
+++ b/packages/pi-coding-agent/src/core/slash-commands.ts
@@ -36,5 +36,6 @@ export const BUILTIN_SLASH_COMMANDS: ReadonlyArray<BuiltinSlashCommand> = [
 	{ name: "resume", description: "Resume a different session" },
 	{ name: "reload", description: "Reload extensions, skills, prompts, and themes" },
 	{ name: "thinking", description: "Set thinking level (off/minimal/low/medium/high/xhigh)" },
+	{ name: "edit-mode", description: "Toggle edit mode (standard/hashline)" },
 	{ name: "quit", description: "Quit pi" },
 ];

--- a/packages/pi-coding-agent/src/index.ts
+++ b/packages/pi-coding-agent/src/index.ts
@@ -279,6 +279,19 @@ export {
 	type WriteToolInput,
 	type WriteToolOptions,
 	writeTool,
+	// Hashline edit mode tools
+	hashlineEditTool,
+	hashlineReadTool,
+	hashlineCodingTools,
+	createHashlineEditTool,
+	createHashlineReadTool,
+	createHashlineCodingTools,
+	type HashlineEditInput,
+	type HashlineEditToolDetails,
+	type HashlineEditToolOptions,
+	type HashlineReadToolDetails,
+	type HashlineReadToolInput,
+	type HashlineReadToolOptions,
 } from "./core/tools/index.js";
 // Main entry point
 export { main } from "./main.js";

--- a/packages/pi-coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/interactive-mode.ts
@@ -2063,6 +2063,12 @@ export class InteractiveMode {
 				this.handleThinkingCommand(arg);
 				return;
 			}
+			if (text === "/edit-mode" || text.startsWith("/edit-mode ")) {
+				const arg = text.startsWith("/edit-mode ") ? text.slice(11).trim() : undefined;
+				this.editor.setText("");
+				this.handleEditModeCommand(arg);
+				return;
+			}
 			if (text === "/debug") {
 				this.handleDebugCommand();
 				this.editor.setText("");
@@ -2889,6 +2895,27 @@ export class InteractiveMode {
 		}
 
 		this.showThinkingSelector();
+	}
+
+	private handleEditModeCommand(arg?: string): void {
+		const modes = ["standard", "hashline"] as const;
+
+		if (arg) {
+			const mode = arg.toLowerCase();
+			if (!modes.includes(mode as typeof modes[number])) {
+				this.showStatus(`Invalid edit mode "${arg}". Available: standard, hashline`);
+				return;
+			}
+			this.session.setEditMode(mode as "standard" | "hashline");
+			this.showStatus(`Edit mode: ${mode}${mode === "hashline" ? " (LINE#ID anchored edits)" : " (text-match edits)"}`);
+			return;
+		}
+
+		// Toggle
+		const current = this.session.editMode;
+		const next = current === "standard" ? "hashline" : "standard";
+		this.session.setEditMode(next);
+		this.showStatus(`Edit mode: ${next}${next === "hashline" ? " (LINE#ID anchored edits)" : " (text-match edits)"}`);
 	}
 
 	private showThinkingSelector(): void {


### PR DESCRIPTION
## Problem

Hashline edit tools (`hashline_edit`, `hashline_read`) are fully implemented in the codebase but never wired into the active workflow. They can't be accessed by users or used by the agent without manual tool override configuration.

## Solution

Integrate hashline as a selectable edit mode alongside the standard text-match edit mode.

### Changes

| File | Change |
|------|--------|
| `settings-manager.ts` | Add `editMode` setting (`'standard'` \| `'hashline'`, default `'standard'`) |
| `sdk.ts` | Select initial active tools based on `editMode`; export hashline tools from SDK |
| `agent-session.ts` | Add `setEditMode()` for runtime tool swapping + `editMode` getter |
| `slash-commands.ts` | Register `/edit-mode` command |
| `interactive-mode.ts` | Handle `/edit-mode` — toggle or set explicitly |
| `index.ts` | Export hashline tools, factories, and types from public API |

### How it works

- **Setting**: `editMode: 'hashline'` in settings activates hashline mode on startup
- **Runtime toggle**: `/edit-mode` in interactive mode toggles between standard and hashline
- **Tool swapping**: When switching modes, `read` ↔ `hashline_read` and `edit` ↔ `hashline_edit` are swapped in the active tool set. System prompt is rebuilt automatically.
- **SDK API**: Hashline tools are now exported for programmatic use

### What hashline mode provides

The `read` tool outputs `LINE#ID:content` format where each line gets a content-hash anchor. The `hashline_edit` tool references these anchors for edits, providing:
- **Integrity checking**: hash mismatches caught before mutation (stale file detection)
- **Precise line addressing**: edits target exact lines via hash anchors, not text matching
- **Batch operations**: multiple edits in one call with replace/append/prepend ops
- **Auto-correction**: handles escaped tabs, duplicate boundary lines, diff markers

### Not in scope (future work)

- Making hashline the default mode (needs broader testing first)
- Streaming hashline formatting for large files
- @file mention auto-formatting with hashline tags
- Hashline prompt documentation (oh-my-pi has extensive examples)

Closes #870.