### PR TITLE
feat: add model type and provider fields to bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -12,7 +12,7 @@ body:
     attributes:
       label: GSD version
       description: Run `gsd --version` or check `package.json`
-      placeholder: "e.g., 2.15.0"
+      placeholder: "e.g., 2.25.0"
     validations:
       required: true
 
@@ -90,15 +90,56 @@ body:
       placeholder: "e.g., v22.4.0"
 
   - type: dropdown
+    id: model-type
+    attributes:
+      label: Model type
+      description: Is the model a cloud-hosted provider or a locally-running model?
+      options:
+        - Cloud model
+        - Local model (Ollama, llama.cpp, LM Studio, etc.)
+        - N/A
+    validations:
+      required: true
+
+  - type: dropdown
     id: ai-provider
     attributes:
-      label: AI provider (if relevant)
+      label: AI provider
+      description: Which provider are you using? Select "Other" for providers not listed here.
       options:
         - Anthropic (Claude)
+        - OpenAI
+        - GitHub Copilot
+        - Google (Gemini)
+        - Google Vertex AI
+        - Google Gemini CLI
+        - Antigravity (Gemini 3, Claude, GPT-OSS)
+        - Amazon Bedrock
+        - Azure OpenAI
         - OpenRouter
-        - OpenAI-compatible
-        - Other
+        - Groq
+        - xAI (Grok)
+        - Mistral
+        - Ollama Cloud
+        - Vercel AI Gateway
+        - Other (provide details below)
         - N/A
+    validations:
+      required: true
+
+  - type: input
+    id: model-id
+    attributes:
+      label: Model ID
+      description: The specific model used. Run `/model` in GSD or check settings.
+      placeholder: "e.g., claude-sonnet-4-6, gpt-4o, gemini-2.5-pro"
+
+  - type: input
+    id: custom-provider-docs
+    attributes:
+      label: API documentation link
+      description: Required if you selected "Other" provider above. Link to the API docs for the provider/model you're using so we can verify compatibility.
+      placeholder: "e.g., https://docs.example.com/api"
 
   - type: textarea
     id: context


### PR DESCRIPTION
Expands the bug report issue template to capture model-specific context for better triage.

### New fields

| Field | Type | Required | Purpose |
|-------|------|----------|---------|
| **Model type** | Dropdown | Yes | Cloud model / Local model / N/A |
| **AI provider** | Dropdown | Yes | All 15 supported providers + Other + N/A |
| **Model ID** | Input | No | Specific model string (e.g. `claude-sonnet-4-6`) |
| **API documentation link** | Input | No* | Link to API docs for non-standard providers |

*Described as required when "Other" provider is selected (GitHub templates don't support conditional validation).

### Changes to existing fields

- **AI provider**: Expanded from 4 options to 17, covering all providers from the auth/login flow (Anthropic, OpenAI, GitHub Copilot, Google Gemini, Google Vertex AI, Google Gemini CLI, Antigravity, Amazon Bedrock, Azure OpenAI, OpenRouter, Groq, xAI, Mistral, Ollama Cloud, Vercel AI Gateway). Now required.
- **Version placeholder**: Updated from `2.15.0` to `2.25.0`