### PR TITLE
fix: don't trigger LLM turns on async_bash job completion (#875)

### DIFF
--- a/src/resources/extensions/async-jobs/index.ts
+++ b/src/resources/extensions/async-jobs/index.ts
@@ -54,6 +54,14 @@ export default function AsyncJobs(pi: ExtensionAPI) {
 					? output.slice(0, maxLen) + "\n\n[... truncated, use await_job for full output]"
 					: output;
 
+				// Deliver as follow-up without triggering a new LLM turn (#875).
+				// When the agent is streaming: the message is queued and picked up
+				// by the agent loop's getFollowUpMessages() after the current turn.
+				// When the agent is idle: the message is appended to context so it's
+				// visible on the next user-initiated prompt. Previously triggerTurn:true
+				// caused spurious autonomous turns — the model would interpret completed
+				// job output as requiring action and cascade into unbounded self-reinforcing
+				// loops (running more commands, spawning more jobs, burning context).
 				pi.sendMessage(
 					{
 						customType: "async_job_result",
@@ -64,7 +72,7 @@ export default function AsyncJobs(pi: ExtensionAPI) {
 						].join("\n"),
 						display: true,
 					},
-					{ deliverAs: "followUp", triggerTurn: true },
+					{ deliverAs: "followUp" },
 				);
 			},
 		});


### PR DESCRIPTION
## Problem

When a background job (`async_bash`) completes after the agent has finished its work, the job result is delivered with `triggerTurn: true`. This unconditionally starts a new LLM turn when the agent is idle. The model interprets the job output as requiring action and can cascade into unbounded self-reinforcing loops — running more commands, spawning more jobs, and burning tokens with no user input.

**Mild case:** Agent says "Ready for your testing" — one wasted turn.
**Severe case:** Agent interprets build warnings/errors as actionable, runs more commands, spawns more async jobs, enters an unbounded cascade.

## Root Cause

In `src/resources/extensions/async-jobs/index.ts`, the `onJobComplete` callback calls:

```ts
pi.sendMessage(message, { deliverAs: "followUp", triggerTurn: true });
```

When the agent is streaming, `deliverAs: "followUp"` correctly queues the message for the agent loop. But when the agent is idle, `triggerTurn: true` calls `agent.prompt()` — starting a brand new autonomous LLM turn.

## Fix

Remove `triggerTurn: true`. Results are still delivered via `deliverAs: 'followUp'`:

| Agent state | Before (broken) | After (fixed) |
|-------------|-----------------|---------------|
| **Streaming** | Queued as follow-up ✅ | Queued as follow-up ✅ (no change) |
| **Idle** | `agent.prompt()` — spurious turn ❌ | `agent.appendMessage()` — appended to context ✅ |

The agent still sees job results — they're in the conversation context and visible on the next user-initiated prompt. It just doesn't get forced into an autonomous turn to process them.

Closes #875.