### PR TITLE
fix: normalize Windows paths in LLM-visible text to prevent bash failures (#874)

### DIFF
--- a/packages/pi-coding-agent/src/core/system-prompt.ts
+++ b/packages/pi-coding-agent/src/core/system-prompt.ts
@@ -3,6 +3,7 @@
  */
 
 import { getDocsPath, getExamplesPath, getReadmePath } from "../config.js";
+import { toPosixPath } from "../utils/path-display.js";
 import { formatSkillsForPrompt, type Skill } from "./skills.js";
 
 /** Tool descriptions for system prompt */
@@ -48,7 +49,7 @@ export function buildSystemPrompt(options: BuildSystemPromptOptions = {}): strin
 		contextFiles: providedContextFiles,
 		skills: providedSkills,
 	} = options;
-	const resolvedCwd = cwd ?? process.cwd();
+	const resolvedCwd = toPosixPath(cwd ?? process.cwd());
 
 	const now = new Date();
 	const dateTime = now.toLocaleString("en-US", {

--- a/packages/pi-coding-agent/src/index.ts
+++ b/packages/pi-coding-agent/src/index.ts
@@ -348,3 +348,5 @@ export { copyToClipboard } from "./utils/clipboard.js";
 export { parseFrontmatter, stripFrontmatter } from "./utils/frontmatter.js";
 // Shell utilities
 export { getShellConfig, sanitizeCommand } from "./utils/shell.js";
+// Cross-platform path display
+export { toPosixPath } from "./utils/path-display.js";

--- a/packages/pi-coding-agent/src/tests/path-display.test.ts
+++ b/packages/pi-coding-agent/src/tests/path-display.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Cross-platform path display tests.
+ *
+ * Verifies that toPosixPath correctly normalizes Windows paths and that
+ * the system prompt builder produces forward-slash paths for LLM consumption.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { toPosixPath } from "../utils/path-display.js";
+import { buildSystemPrompt } from "../core/system-prompt.js";
+
+// ─── toPosixPath ────────────────────────────────────────────────────────────
+
+test("toPosixPath: converts Windows backslash paths to forward slashes", () => {
+	assert.equal(toPosixPath("C:\\Users\\name\\project"), "C:/Users/name/project");
+});
+
+test("toPosixPath: handles mixed separators", () => {
+	assert.equal(toPosixPath("C:\\Users/name\\project/src"), "C:/Users/name/project/src");
+});
+
+test("toPosixPath: no-op for Unix paths", () => {
+	assert.equal(toPosixPath("/home/user/project"), "/home/user/project");
+});
+
+test("toPosixPath: handles empty string", () => {
+	assert.equal(toPosixPath(""), "");
+});
+
+test("toPosixPath: handles Windows UNC paths", () => {
+	assert.equal(toPosixPath("\\\\server\\share\\dir"), "//server/share/dir");
+});
+
+test("toPosixPath: handles .gsd/worktrees path on Windows", () => {
+	assert.equal(
+		toPosixPath("C:\\Users\\name\\project\\.gsd\\worktrees\\M001"),
+		"C:/Users/name/project/.gsd/worktrees/M001",
+	);
+});
+
+// ─── System prompt path normalization ───────────────────────────────────────
+
+test("buildSystemPrompt: cwd uses forward slashes even with Windows input", () => {
+	const prompt = buildSystemPrompt({
+		cwd: "C:\\Users\\name\\development\\app-name",
+	});
+	assert.ok(
+		prompt.includes("C:/Users/name/development/app-name"),
+		"System prompt should contain forward-slash path",
+	);
+	assert.ok(
+		!prompt.includes("C:\\Users\\name\\development\\app-name"),
+		"System prompt must NOT contain backslash path",
+	);
+});
+
+test("buildSystemPrompt: Unix paths pass through unchanged", () => {
+	const prompt = buildSystemPrompt({
+		cwd: "/home/user/project",
+	});
+	assert.ok(prompt.includes("/home/user/project"));
+});
+
+// ─── Regression: no backslash paths in LLM-visible text ────────────────────
+
+/**
+ * Pattern that matches Windows-style absolute paths with backslashes.
+ * Catches: C:\Users\..., D:\Projects\..., \\server\share\...
+ * Does not match: escaped chars in regex, JSON strings, etc.
+ */
+const WINDOWS_ABS_PATH_RE = /[A-Z]:\\[A-Za-z]/;
+
+test("buildSystemPrompt: no Windows absolute paths with backslashes in output", () => {
+	// Simulate a Windows-like cwd
+	const prompt = buildSystemPrompt({
+		cwd: "D:\\Projects\\my-app\\.gsd\\worktrees\\M002",
+	});
+	const lines = prompt.split("\n");
+	const violations = lines.filter(line => WINDOWS_ABS_PATH_RE.test(line));
+	assert.equal(
+		violations.length, 0,
+		`System prompt contains Windows backslash paths:\n${violations.join("\n")}`,
+	);
+});

--- a/packages/pi-coding-agent/src/utils/path-display.ts
+++ b/packages/pi-coding-agent/src/utils/path-display.ts
@@ -1,0 +1,36 @@
+/**
+ * Cross-platform path display utilities.
+ *
+ * Paths injected into LLM prompts, tool results, or any text the model
+ * processes must use forward slashes. Windows backslash paths cause bash
+ * failures when the model copies them into shell commands — bash interprets
+ * backslashes as escape characters, silently stripping them.
+ *
+ * Node's `path` module and `fs` module handle native separators correctly
+ * for filesystem operations. This module is ONLY for paths that enter
+ * text consumed by the LLM or interpreted by a shell.
+ *
+ * Usage:
+ *   import { toPosixPath } from "./path-display.js";
+ *   prompt += `Current working directory: ${toPosixPath(cwd)}`;
+ *
+ * NOT for:
+ *   fs.readFile(path)          — use native path as-is
+ *   path.join(a, b)            — use native path module
+ *   spawn(cmd, { cwd: path })  — Node handles this correctly
+ */
+
+/**
+ * Convert a filesystem path to forward-slash (POSIX) form for display.
+ *
+ * On Unix this is a no-op. On Windows it converts `C:\Users\name\project`
+ * to `C:/Users/name/project`, which is valid in:
+ * - Git Bash / MSYS2
+ * - WSL bash
+ * - PowerShell
+ * - Node.js APIs (which accept both separators)
+ * - Most Windows programs
+ */
+export function toPosixPath(fsPath: string): string {
+	return fsPath.replaceAll("\\", "/");
+}

--- a/src/resources/extensions/bg-shell/index.ts
+++ b/src/resources/extensions/bg-shell/index.ts
@@ -66,6 +66,7 @@ import { waitForReady } from "./readiness-detector.js";
 import { queryShellEnv, sendAndWait, runOnSession } from "./interaction.js";
 import { formatUptime, formatTokenCount, resolveBgShellPersistenceCwd } from "./utilities.js";
 import { BgManagerOverlay } from "./overlay.js";
+import { toPosixPath } from "../shared/path-display.js";
 
 // ── Re-exports for consumers ───────────────────────────────────────────────
 
@@ -337,7 +338,7 @@ export default function (pi: ExtensionAPI) {
 					text += `  type: ${bg.processType}\n`;
 					text += `  status: ${bg.status}\n`;
 					text += `  command: ${bg.command}\n`;
-					text += `  cwd: ${bg.cwd}`;
+					text += `  cwd: ${toPosixPath(bg.cwd)}`;
 
 					if (bg.group) text += `\n  group: ${bg.group}`;
 					if (bg.readyPort) text += `\n  ready_port: ${bg.readyPort}`;
@@ -694,7 +695,7 @@ export default function (pi: ExtensionAPI) {
 					}
 
 					let text = `Shell environment for ${bg.id} (${bg.label}):\n`;
-					text += `  cwd: ${envResult.cwd}\n`;
+					text += `  cwd: ${toPosixPath(envResult.cwd)}\n`;
 					text += `  shell: ${envResult.shell}\n`;
 
 					const envEntries = Object.entries(envResult.env);

--- a/src/resources/extensions/gsd/index.ts
+++ b/src/resources/extensions/gsd/index.ts
@@ -59,6 +59,7 @@ import { homedir } from "node:os";
 import { shortcutDesc } from "../shared/terminal.js";
 import { Text } from "@gsd/pi-tui";
 import { pauseAutoForProviderError } from "./provider-error-pause.js";
+import { toPosixPath } from "../shared/path-display.js";
 
 // ── Agent Instructions ────────────────────────────────────────────────────
 // Lightweight "always follow" files injected into every GSD agent session.
@@ -608,12 +609,12 @@ export default function (pi: ExtensionAPI) {
         "",
         "[WORKTREE CONTEXT — OVERRIDES CURRENT WORKING DIRECTORY ABOVE]",
         `IMPORTANT: Ignore the "Current working directory" shown earlier in this prompt.`,
-        `The actual current working directory is: ${process.cwd()}`,
+        `The actual current working directory is: ${toPosixPath(process.cwd())}`,
         "",
         `You are working inside a GSD worktree.`,
         `- Worktree name: ${worktreeName}`,
-        `- Worktree path (this is the real cwd): ${process.cwd()}`,
-        `- Main project: ${worktreeMainCwd}`,
+        `- Worktree path (this is the real cwd): ${toPosixPath(process.cwd())}`,
+        `- Main project: ${toPosixPath(worktreeMainCwd)}`,
         `- Branch: worktree/${worktreeName}`,
         "",
         "All file operations, bash commands, and GSD state resolve against the worktree path above.",
@@ -625,12 +626,12 @@ export default function (pi: ExtensionAPI) {
         "",
         "[WORKTREE CONTEXT — OVERRIDES CURRENT WORKING DIRECTORY ABOVE]",
         `IMPORTANT: Ignore the "Current working directory" shown earlier in this prompt.`,
-        `The actual current working directory is: ${process.cwd()}`,
+        `The actual current working directory is: ${toPosixPath(process.cwd())}`,
         "",
         "You are working inside a GSD auto-worktree.",
         `- Milestone worktree: ${autoWorktree.worktreeName}`,
-        `- Worktree path (this is the real cwd): ${process.cwd()}`,
-        `- Main project: ${autoWorktree.originalBase}`,
+        `- Worktree path (this is the real cwd): ${toPosixPath(process.cwd())}`,
+        `- Main project: ${toPosixPath(autoWorktree.originalBase)}`,
         `- Branch: ${autoWorktree.branch}`,
         "",
         "All file operations, bash commands, and GSD state resolve against the worktree path above.",

--- a/src/resources/extensions/shared/path-display.ts
+++ b/src/resources/extensions/shared/path-display.ts
@@ -1,0 +1,19 @@
+/**
+ * Cross-platform path display for LLM-visible text.
+ *
+ * Paths injected into prompts, tool results, or extension messages must use
+ * forward slashes. Windows backslash paths cause bash failures when the model
+ * copies them into shell commands — bash interprets backslashes as escape chars.
+ *
+ * Use this ONLY for paths entering text the LLM or shell sees.
+ * Filesystem operations (fs.readFile, path.join, spawn cwd) handle native
+ * separators correctly and should NOT be normalized.
+ */
+
+/**
+ * Convert a filesystem path to forward-slash form for display in LLM text.
+ * No-op on Unix. On Windows converts `C:\Users\name` to `C:/Users/name`.
+ */
+export function toPosixPath(fsPath: string): string {
+  return fsPath.replaceAll("\\", "/");
+}


### PR DESCRIPTION
## Problem

On Windows, `process.cwd()` returns backslash paths (`C:\Users\name\...`). When injected into system prompts, worktree context blocks, or tool results, the model copies them into bash commands. Bash interprets backslashes as escape characters, producing invalid paths like `C:Usersnamedevelopmentapp-name`.

This causes state divergence: agents write artifacts to wrong directories, the state machine can't find completed work, and dispatch loops get stuck re-dispatching finished units.

## Approach

This is a **cross-platform boundary fix**, not a regex hack:

| Path context | Handling |
|---|---|
| **Filesystem I/O** (fs.readFile, path.join, spawn cwd) | Native separators — Node handles both correctly. **No change.** |
| **LLM-visible text** (prompts, tool results, messages) | `toPosixPath()` normalizes to forward slashes |

`C:/Users/name/project` is valid in Git Bash, WSL bash, PowerShell, and Node.js APIs.

## Changes

| File | What |
|---|---|
| `utils/path-display.ts` | New `toPosixPath()` utility in pi-coding-agent package |
| `shared/path-display.ts` | Same utility for extensions (avoids compiled package import) |
| `system-prompt.ts` | Normalize `resolvedCwd` before injection |
| `gsd/index.ts` | Normalize worktree context paths (`process.cwd()`, `originalBase`) |
| `bg-shell/index.ts` | Normalize `cwd` in tool result text (start, env actions) |
| `path-display.test.ts` | 9 regression tests |

## Audit Scope

Full codebase audit of `process.cwd()` usage across pi-coding-agent and all bundled extensions:
- **Filesystem-only paths** (join, readFile, spawn, existsSync): correct, left unchanged
- **Worktree detection** (detectWorktreeName, resolveProjectRoot, escapeStaleWorktree): already normalize with `replaceAll('\\\\', '/')` or use `pathSep` — correct
- **LLM-visible text** (system prompt, worktree block, bg-shell results): **fixed**

## Regression Tests

- `toPosixPath` unit tests (backslash, mixed, Unix, UNC, empty, .gsd paths)
- `buildSystemPrompt` integration test: Windows cwd produces forward-slash output
- Backslash path scanner: fails if `buildSystemPrompt()` output contains any `X:\...` patterns

Closes #874.