### PR TITLE
feat(M004): Supervisor Upgrade — Diagnostic Recovery

### DIFF
--- a/src/resources/extensions/gsd/auto-supervisor.ts
+++ b/src/resources/extensions/gsd/auto-supervisor.ts
@@ -1,11 +1,538 @@
 /**
- * Auto-mode Supervisor — SIGTERM handling and working-tree activity detection.
+ * Auto-mode Supervisor — SIGTERM handling, working-tree activity detection,
+ * and diagnostic signal collection for stuck-vs-active classification.
  *
  * Pure functions — no module-level globals or AutoContext dependency.
  */
 
 import { clearLock } from "./crash-recovery.js";
-import { nativeHasChanges } from "./native-git-bridge.js";
+import { nativeHasChanges, nativeWorkingTreeStatus } from "./native-git-bridge.js";
+import { getDeepDiagnostic } from "./session-forensics.js";
+import type { AutoUnitRuntimeRecord } from "./unit-runtime.js";
+
+// ─── Diagnostic Types ─────────────────────────────────────────────────────────
+
+/** Severity levels for individual diagnostic findings. */
+export type DiagnosticSeverity = "info" | "warning" | "error" | "crash";
+
+/** A category tag for what kind of signal a finding relates to. */
+export type DiagnosticCategory =
+  | "bg-shell"
+  | "trace"
+  | "git"
+  | "temporal"
+  | "tool-activity";
+
+/** A single observation from signal collection or classification. */
+export interface DiagnosticFinding {
+  category: DiagnosticCategory;
+  message: string;
+  severity: DiagnosticSeverity;
+}
+
+/** Health entry for a single bg-shell process. */
+export interface BgShellHealthEntry {
+  id: string;
+  name: string;
+  status: "crashed" | "errored" | "healthy";
+  exitCode?: number | null;
+  signal?: string | null;
+  recentErrors?: string[];
+}
+
+/** Raw signals gathered from all available sources. */
+export interface DiagnosticSignals {
+  /** Formatted activity trace summary from session-forensics, or null if unavailable. */
+  traceSummary: string | null;
+  /** bg-shell process health entries (crashed/errored only), or null if unavailable. */
+  bgShellHealth: BgShellHealthEntry[] | null;
+  /** Git working-tree porcelain status, or null if unavailable. */
+  gitStatus: string | null;
+  /** Milliseconds since last progress signal, or null if runtime unavailable. */
+  msSinceLastProgress: number | null;
+  /** Total progress signals recorded, or null if runtime unavailable. */
+  progressCount: number | null;
+  /** Kind of the last progress signal (e.g. "tool-call", "dispatch"), or null. */
+  lastProgressKind: string | null;
+  /** Number of recovery attempts so far, or null if runtime unavailable. */
+  recoveryAttempts: number | null;
+  /** Number of in-flight (pending) tool calls. */
+  inFlightToolCount: number;
+  /** Age in ms of the oldest in-flight tool call, or null if none pending. */
+  oldestInFlightToolAgeMs: number | null;
+}
+
+/** Classification of whether the unit is stuck and why. */
+export type StuckClassificationLabel =
+  | "active"
+  | "stuck/crash"
+  | "stuck/read-loop"
+  | "stuck/error-loop"
+  | "stuck/no-progress"
+  | "ambiguous";
+
+/** Result of classifying signals into a stuck-vs-active verdict. */
+export interface StuckClassification {
+  classification: StuckClassificationLabel;
+  findings: DiagnosticFinding[];
+  confidence: number;
+}
+
+/** Full diagnostic report produced on escalation to pause. */
+export interface DiagnosticReport {
+  signals: DiagnosticSignals;
+  classification: StuckClassification;
+  unitType: string;
+  unitId: string;
+  timestamp: number;
+}
+
+// ─── Fatal Signals (mirrors verification-gate.ts) ─────────────────────────────
+
+const FATAL_SIGNALS = new Set(["SIGABRT", "SIGSEGV", "SIGBUS"]);
+
+// ─── Signal Collection Options (injectable for testing) ───────────────────────
+
+export interface CollectDiagnosticSignalsOptions {
+  /** Override bg-shell process source for testing. */
+  getProcesses?: () => Map<string, unknown>;
+  /** Override deep diagnostic source for testing. */
+  getDeepDiagnosticFn?: (basePath: string) => string | null;
+  /** Override git status source for testing. */
+  getGitStatusFn?: (basePath: string) => string;
+}
+
+// ─── Signal Collection ────────────────────────────────────────────────────────
+
+/**
+ * Gather diagnostic signals from all available sources.
+ *
+ * Pure function — all external state is provided via parameters or read
+ * through existing exported functions. Each signal source is individually
+ * wrapped in try/catch so a failure in one does not affect others.
+ */
+export async function collectDiagnosticSignals(
+  basePath: string,
+  _unitType: string,
+  _unitId: string,
+  runtime: AutoUnitRuntimeRecord | null,
+  inFlightToolCount: number,
+  oldestInFlightToolAgeMs: number | null,
+  options?: CollectDiagnosticSignalsOptions,
+): Promise<DiagnosticSignals> {
+  // ── Activity trace ──────────────────────────────────────────────────
+  let traceSummary: string | null = null;
+  try {
+    const fn = options?.getDeepDiagnosticFn ?? getDeepDiagnostic;
+    traceSummary = fn(basePath);
+  } catch {
+    // source unavailable — leave null
+  }
+
+  // ── bg-shell process health ─────────────────────────────────────────
+  let bgShellHealth: BgShellHealthEntry[] | null = null;
+  try {
+    let processes: Map<string, unknown>;
+    if (options?.getProcesses) {
+      processes = options.getProcesses();
+    } else {
+      const mod = await import("../bg-shell/process-manager.js");
+      processes = mod.processes;
+    }
+
+    const entries: BgShellHealthEntry[] = [];
+    for (const [id, raw] of processes) {
+      const proc = raw as {
+        id: string;
+        label?: string;
+        status?: string;
+        alive?: boolean;
+        exitCode?: number | null;
+        signal?: string | null;
+        recentErrors?: string[];
+      };
+
+      const name = proc.label || proc.id || id;
+
+      // Fatal signal → crashed
+      if (proc.signal && FATAL_SIGNALS.has(proc.signal)) {
+        entries.push({
+          id, name, status: "crashed",
+          exitCode: proc.exitCode, signal: proc.signal,
+          recentErrors: proc.recentErrors?.slice(0, 3),
+        });
+        continue;
+      }
+
+      // Crashed status
+      if (proc.status === "crashed") {
+        entries.push({
+          id, name, status: "crashed",
+          exitCode: proc.exitCode, signal: proc.signal,
+          recentErrors: proc.recentErrors?.slice(0, 3),
+        });
+        continue;
+      }
+
+      // Non-zero exit on dead process
+      if (
+        !proc.alive &&
+        proc.exitCode !== 0 &&
+        proc.exitCode !== null &&
+        proc.exitCode !== undefined
+      ) {
+        entries.push({
+          id, name, status: "crashed",
+          exitCode: proc.exitCode, signal: proc.signal,
+          recentErrors: proc.recentErrors?.slice(0, 3),
+        });
+        continue;
+      }
+
+      // Alive process with recent errors — non-blocking
+      if (proc.alive && proc.recentErrors && proc.recentErrors.length > 0) {
+        entries.push({
+          id, name, status: "errored",
+          recentErrors: proc.recentErrors.slice(0, 3),
+        });
+      }
+    }
+
+    bgShellHealth = entries;
+  } catch {
+    // bg-shell not available — leave null
+  }
+
+  // ── Git working-tree status ─────────────────────────────────────────
+  let gitStatus: string | null = null;
+  try {
+    const fn = options?.getGitStatusFn ?? nativeWorkingTreeStatus;
+    const status = fn(basePath);
+    gitStatus = status || null;
+  } catch {
+    // git unavailable — leave null
+  }
+
+  // ── Temporal context from runtime record ────────────────────────────
+  let msSinceLastProgress: number | null = null;
+  let progressCount: number | null = null;
+  let lastProgressKind: string | null = null;
+  let recoveryAttempts: number | null = null;
+
+  if (runtime) {
+    msSinceLastProgress = runtime.lastProgressAt
+      ? Date.now() - runtime.lastProgressAt
+      : null;
+    progressCount = runtime.progressCount ?? null;
+    lastProgressKind = runtime.lastProgressKind ?? null;
+    recoveryAttempts = runtime.recoveryAttempts ?? null;
+  }
+
+  return {
+    traceSummary,
+    bgShellHealth,
+    gitStatus,
+    msSinceLastProgress,
+    progressCount,
+    lastProgressKind,
+    recoveryAttempts,
+    inFlightToolCount,
+    oldestInFlightToolAgeMs,
+  };
+}
+
+// ─── Stuck vs Active Classification ───────────────────────────────────────────
+
+/** Threshold in ms for considering lastProgressAt "recent". */
+const PROGRESS_RECENCY_THRESHOLD_MS = 60_000;
+
+/** Pattern for detecting repeated reads in trace summaries (e.g. "read ×3", "read ×5"). */
+const READ_LOOP_PATTERN = /read\s*[×x]\s*(\d+)/i;
+
+/** Pattern for detecting repeated errors/failures in trace summaries. */
+const ERROR_LOOP_PATTERN =
+  /(?:(?:bash|shell|exec)[^\n]*(?:fail|error|exit\s*code\s*[1-9])[^\n]*\n?){2,}|(?:failed|error)\s*[×x]\s*(\d+)/i;
+
+/**
+ * Classify diagnostic signals into a stuck-vs-active verdict.
+ *
+ * Priority ordering (highest-severity first):
+ *   1. Crash detection (stuck/crash)
+ *   2. Error loop (stuck/error-loop)
+ *   3. Read loop (stuck/read-loop)
+ *   4. No progress (stuck/no-progress)
+ *   5. Active check
+ *   6. Ambiguous fallback
+ *
+ * Multiple findings can be present. Classification is determined by the
+ * highest-severity finding.
+ */
+export function classifyStuckVsActive(
+  signals: DiagnosticSignals,
+): StuckClassification {
+  const findings: DiagnosticFinding[] = [];
+  let topClassification: StuckClassificationLabel = "ambiguous";
+  let topConfidence = 0;
+
+  // ── 1. Crash detection (highest priority) ───────────────────────────
+  if (signals.bgShellHealth && signals.bgShellHealth.length > 0) {
+    for (const entry of signals.bgShellHealth) {
+      if (entry.status === "crashed") {
+        const detail = entry.signal
+          ? `Process '${entry.name}' received signal ${entry.signal}`
+          : `Process '${entry.name}' crashed with exit code ${entry.exitCode ?? "unknown"}`;
+        findings.push({
+          category: "bg-shell",
+          message: detail,
+          severity: "crash",
+        });
+      }
+    }
+    if (findings.some((f) => f.severity === "crash")) {
+      topClassification = "stuck/crash";
+      topConfidence = 0.95;
+    }
+  }
+
+  // ── 2. Error loop detection ─────────────────────────────────────────
+  if (signals.traceSummary && ERROR_LOOP_PATTERN.test(signals.traceSummary)) {
+    findings.push({
+      category: "trace",
+      message: "Last commands failed repeatedly with similar errors",
+      severity: "error",
+    });
+    if (topConfidence < 0.85) {
+      topClassification = "stuck/error-loop";
+      topConfidence = 0.85;
+    }
+  }
+
+  // ── 3. Read loop detection ──────────────────────────────────────────
+  if (signals.traceSummary) {
+    const readMatch = READ_LOOP_PATTERN.exec(signals.traceSummary);
+    if (readMatch) {
+      const count = parseInt(readMatch[1]!, 10);
+      if (count >= 3) {
+        findings.push({
+          category: "trace",
+          message: "Agent appears to be reading the same file(s) repeatedly",
+          severity: "warning",
+        });
+        if (topConfidence < 0.8) {
+          topClassification = "stuck/read-loop";
+          topConfidence = 0.8;
+        }
+      }
+    }
+  }
+
+  // ── 4. No progress detection ────────────────────────────────────────
+  const isProgressStale =
+    signals.msSinceLastProgress === null ||
+    signals.msSinceLastProgress > PROGRESS_RECENCY_THRESHOLD_MS;
+  const hasGitChanges = signals.gitStatus !== null && signals.gitStatus.trim().length > 0;
+  const hasTrace = signals.traceSummary !== null && signals.traceSummary.trim().length > 0;
+  const hasInFlightTools = signals.inFlightToolCount > 0;
+
+  // We need at least one signal source to actually be available (non-null) to
+  // confidently declare "no progress". If ALL sources are null, we don't know
+  // enough — that's "ambiguous", not "no progress".
+  const hasAnySourceAvailable =
+    signals.bgShellHealth !== null ||
+    signals.traceSummary !== null ||
+    signals.gitStatus !== null ||
+    signals.msSinceLastProgress !== null;
+
+  if (
+    isProgressStale &&
+    !hasGitChanges &&
+    !hasTrace &&
+    !hasInFlightTools &&
+    hasAnySourceAvailable &&
+    topConfidence < 0.9
+  ) {
+    findings.push({
+      category: "temporal",
+      message: "No tool activity or file changes detected",
+      severity: "warning",
+    });
+    topClassification = "stuck/no-progress";
+    topConfidence = 0.9;
+  }
+
+  // ── 5. Active check ─────────────────────────────────────────────────
+  // Active requires RECENT progress (within threshold). Stale progress
+  // with git changes is NOT enough — temporal weighting matters.
+  if (
+    topConfidence < 0.7 &&
+    signals.msSinceLastProgress !== null &&
+    signals.msSinceLastProgress <= PROGRESS_RECENCY_THRESHOLD_MS &&
+    (hasTrace || hasGitChanges)
+  ) {
+    findings.push({
+      category: "tool-activity",
+      message: "Agent is actively working (recent progress detected)",
+      severity: "info",
+    });
+    topClassification = "active";
+    topConfidence = 0.8;
+  }
+
+  // ── 6. Ambiguous fallback ───────────────────────────────────────────
+  if (topConfidence < 0.5 || findings.length === 0) {
+    // Only add the ambiguous finding if we haven't already classified
+    if (findings.length === 0) {
+      findings.push({
+        category: "temporal",
+        message: "Insufficient signals for definitive classification",
+        severity: "info",
+      });
+    }
+    topClassification = "ambiguous";
+    topConfidence = 0.3;
+  }
+
+  return {
+    classification: topClassification,
+    findings,
+    confidence: topConfidence,
+  };
+}
+
+// ─── Diagnostic Steering Content ──────────────────────────────────────────────
+
+/** Maximum characters for steering content. */
+const STEERING_MAX_CHARS = 500;
+
+/**
+ * Translate a StuckClassification into actionable steering text for the agent.
+ * The text is capped to ~500 characters to avoid bloating the context window.
+ */
+export function buildDiagnosticSteeringContent(
+  classification: StuckClassification,
+  unitType: string,
+  unitId: string,
+): string {
+  const lines: string[] = [];
+  lines.push(`[Diagnostic: ${unitType}/${unitId} classified as ${classification.classification}]`);
+
+  for (const finding of classification.findings) {
+    switch (finding.category) {
+      case "bg-shell":
+        if (finding.severity === "crash") {
+          // Extract process name from the message
+          const nameMatch = /Process '([^']+)'/.exec(finding.message);
+          const name = nameMatch ? nameMatch[1] : "unknown";
+          lines.push(
+            `Your process '${name}' crashed. Check the error output and restart or fix the underlying issue.`,
+          );
+        }
+        break;
+      case "trace":
+        if (finding.message.includes("reading the same file")) {
+          lines.push(
+            "You've been reading the same files repeatedly without making changes. Identify the specific change needed and make it.",
+          );
+        } else if (finding.message.includes("failed repeatedly")) {
+          lines.push(
+            "Your recent commands are failing repeatedly. Read the error output carefully and try a different approach.",
+          );
+        }
+        break;
+      case "temporal":
+        if (finding.message.includes("No tool activity")) {
+          lines.push(
+            "No tool activity detected. If you're blocked, explain the blocker explicitly.",
+          );
+        }
+        break;
+      case "tool-activity":
+        // Active — no corrective steering needed
+        break;
+    }
+  }
+
+  let result = lines.join("\n");
+  if (result.length > STEERING_MAX_CHARS) {
+    result = result.slice(0, STEERING_MAX_CHARS - 3) + "...";
+  }
+  return result;
+}
+
+// ─── Diagnostic Report Formatting ─────────────────────────────────────────────
+
+/**
+ * Format a full diagnostic report as markdown for disk persistence.
+ * Written to .gsd/runtime/diagnostic-{unitType}-{unitId}.md on escalation to pause.
+ */
+export function formatDiagnosticReport(
+  signals: DiagnosticSignals,
+  classification: StuckClassification,
+  unitType: string,
+  unitId: string,
+): string {
+  const lines: string[] = [];
+
+  // ── Header ──────────────────────────────────────────────────────────
+  lines.push(`# Diagnostic Report: ${unitType}/${unitId}`);
+  lines.push("");
+  lines.push(`**Generated:** ${new Date().toISOString()}`);
+  lines.push(`**Unit:** ${unitType} ${unitId}`);
+  lines.push("");
+
+  // ── Classification ──────────────────────────────────────────────────
+  lines.push("## Classification");
+  lines.push("");
+  lines.push(`- **Result:** ${classification.classification}`);
+  lines.push(`- **Confidence:** ${classification.confidence}`);
+  lines.push("");
+
+  // ── Findings ────────────────────────────────────────────────────────
+  lines.push("## Findings");
+  lines.push("");
+  if (classification.findings.length === 0) {
+    lines.push("_No findings._");
+  } else {
+    lines.push("| Category | Severity | Message |");
+    lines.push("|----------|----------|---------|");
+    for (const f of classification.findings) {
+      lines.push(`| ${f.category} | ${f.severity} | ${f.message} |`);
+    }
+  }
+  lines.push("");
+
+  // ── Signal Summary ──────────────────────────────────────────────────
+  lines.push("## Signal Summary");
+  lines.push("");
+  lines.push(`- **Trace available:** ${signals.traceSummary !== null ? "yes" : "no"}`);
+  if (signals.traceSummary) {
+    // Extract brief info from trace (first 200 chars)
+    const brief = signals.traceSummary.length > 200
+      ? signals.traceSummary.slice(0, 200) + "..."
+      : signals.traceSummary;
+    lines.push(`- **Trace excerpt:** ${brief}`);
+  }
+  lines.push(`- **bg-shell processes:** ${signals.bgShellHealth !== null ? `${signals.bgShellHealth.length} unhealthy` : "unavailable"}`);
+  if (signals.bgShellHealth && signals.bgShellHealth.length > 0) {
+    for (const entry of signals.bgShellHealth) {
+      const detail = entry.signal
+        ? `signal=${entry.signal}`
+        : entry.exitCode !== undefined && entry.exitCode !== null
+          ? `exit=${entry.exitCode}`
+          : "";
+      lines.push(`  - ${entry.name}: ${entry.status}${detail ? ` (${detail})` : ""}`);
+    }
+  }
+  lines.push(`- **Git status:** ${signals.gitStatus !== null ? "changes detected" : "no changes or unavailable"}`);
+  lines.push(`- **In-flight tools:** ${signals.inFlightToolCount}${signals.oldestInFlightToolAgeMs !== null ? ` (oldest: ${Math.round(signals.oldestInFlightToolAgeMs / 1000)}s)` : ""}`);
+  lines.push(`- **Time since last progress:** ${signals.msSinceLastProgress !== null ? `${Math.round(signals.msSinceLastProgress / 1000)}s` : "unknown"}`);
+  lines.push(`- **Progress count:** ${signals.progressCount ?? "unknown"}`);
+  lines.push(`- **Last progress kind:** ${signals.lastProgressKind ?? "unknown"}`);
+  lines.push(`- **Recovery attempts:** ${signals.recoveryAttempts ?? "unknown"}`);
+  lines.push("");
+
+  return lines.join("\n");
+}
 
 // ─── SIGTERM Handling ─────────────────────────────────────────────────────────
 

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -163,6 +163,10 @@ import {
   registerSigtermHandler as _registerSigtermHandler,
   deregisterSigtermHandler as _deregisterSigtermHandler,
   detectWorkingTreeActivity,
+  collectDiagnosticSignals,
+  classifyStuckVsActive,
+  buildDiagnosticSteeringContent,
+  formatDiagnosticReport,
 } from "./auto-supervisor.js";
 import { isDbAvailable } from "./gsd-db.js";
 import { hasPendingCaptures, loadPendingCaptures, countPendingCaptures } from "./captures.js";
@@ -3677,6 +3681,30 @@ async function recoverTimedOutUnit(
     await new Promise(r => setTimeout(r, backoffMs));
   }
 
+  // ── Diagnostic signal collection & classification ───────────────────
+  const diagnosticSignals = await collectDiagnosticSignals(
+    basePath, unitType, unitId, runtime,
+    inFlightTools.size, getOldestInFlightToolAgeMs(),
+  );
+  const diagnosticClassification = classifyStuckVsActive(diagnosticSignals);
+
+  // ── Active suppression (idle path only) ─────────────────────────────
+  // If diagnostics say the agent is actively working, suppress the false
+  // positive idle recovery. Hard timeout always proceeds regardless.
+  if (reason === "idle" && diagnosticClassification.classification === "active") {
+    writeUnitRuntimeRecord(basePath, unitType, unitId, currentUnit.startedAt, {
+      lastProgressAt: Date.now(),
+      lastProgressKind: "diagnostic-active",
+    });
+    ctx.ui.notify(
+      `Diagnostic: ${unitType} ${unitId} classified as active (confidence ${diagnosticClassification.confidence}). Resetting idle clock.`,
+      "info",
+    );
+    // Undo the recovery count bump since we're not actually recovering
+    unitRecoveryCount.set(recoveryKey, attemptNumber - 1);
+    return "recovered";
+  }
+
   if (unitType === "execute-task") {
     const status = await inspectExecuteTaskDurability(basePath, unitId);
     if (!status) return "paused";
@@ -3713,25 +3741,50 @@ async function recoverTimedOutUnit(
       });
 
       const steeringLines = isEscalation
-        ? [
-            `**FINAL ${reason === "idle" ? "IDLE" : "HARD TIMEOUT"} RECOVERY — last chance before this task is skipped.**`,
-            `You are still executing ${unitType} ${unitId}.`,
-            `Recovery attempt ${recoveryAttempts + 1} of ${maxRecoveryAttempts}.`,
-            `Current durability status: ${formatExecuteTaskRecoveryStatus(status)}.`,
-            "You MUST finish the durable output NOW, even if incomplete.",
-            "Write the task summary with whatever you have accomplished so far.",
-            "Mark the task [x] in the plan. Commit your work.",
-            "A partial summary is infinitely better than no summary.",
-          ]
-        : [
-            `**${reason === "idle" ? "IDLE" : "HARD TIMEOUT"} RECOVERY — do not stop.**`,
-            `You are still executing ${unitType} ${unitId}.`,
-            `Recovery attempt ${recoveryAttempts + 1} of ${maxRecoveryAttempts}.`,
-            `Current durability status: ${formatExecuteTaskRecoveryStatus(status)}.`,
-            "Do not keep exploring.",
-            "Immediately finish the required durable output for this unit.",
-            "If full completion is impossible, write the partial artifact/state needed for recovery and make the blocker explicit.",
-          ];
+        ? diagnosticClassification.classification !== "ambiguous"
+          ? [
+              `**FINAL ${reason === "idle" ? "IDLE" : "HARD TIMEOUT"} RECOVERY — last chance before this task is skipped.**`,
+              `You are still executing ${unitType} ${unitId}.`,
+              `Recovery attempt ${recoveryAttempts + 1} of ${maxRecoveryAttempts}.`,
+              `Current durability status: ${formatExecuteTaskRecoveryStatus(status)}.`,
+              "You MUST finish the durable output NOW, even if incomplete.",
+              "Write the task summary with whatever you have accomplished so far.",
+              "Mark the task [x] in the plan. Commit your work.",
+              "A partial summary is infinitely better than no summary.",
+              "",
+              buildDiagnosticSteeringContent(diagnosticClassification, unitType, unitId),
+            ]
+          : [
+              `**FINAL ${reason === "idle" ? "IDLE" : "HARD TIMEOUT"} RECOVERY — last chance before this task is skipped.**`,
+              `You are still executing ${unitType} ${unitId}.`,
+              `Recovery attempt ${recoveryAttempts + 1} of ${maxRecoveryAttempts}.`,
+              `Current durability status: ${formatExecuteTaskRecoveryStatus(status)}.`,
+              "You MUST finish the durable output NOW, even if incomplete.",
+              "Write the task summary with whatever you have accomplished so far.",
+              "Mark the task [x] in the plan. Commit your work.",
+              "A partial summary is infinitely better than no summary.",
+            ]
+        : diagnosticClassification.classification !== "ambiguous"
+          ? [
+              `**${reason === "idle" ? "IDLE" : "HARD TIMEOUT"} RECOVERY — do not stop.**`,
+              `You are still executing ${unitType} ${unitId}.`,
+              `Recovery attempt ${recoveryAttempts + 1} of ${maxRecoveryAttempts}.`,
+              `Current durability status: ${formatExecuteTaskRecoveryStatus(status)}.`,
+              "",
+              buildDiagnosticSteeringContent(diagnosticClassification, unitType, unitId),
+              "",
+              "Immediately finish the required durable output for this unit.",
+              "If full completion is impossible, write the partial artifact/state needed for recovery and make the blocker explicit.",
+            ]
+          : [
+              `**${reason === "idle" ? "IDLE" : "HARD TIMEOUT"} RECOVERY — do not stop.**`,
+              `You are still executing ${unitType} ${unitId}.`,
+              `Recovery attempt ${recoveryAttempts + 1} of ${maxRecoveryAttempts}.`,
+              `Current durability status: ${formatExecuteTaskRecoveryStatus(status)}.`,
+              "Do not keep exploring.",
+              "Immediately finish the required durable output for this unit.",
+              "If full completion is impossible, write the partial artifact/state needed for recovery and make the blocker explicit.",
+            ];
 
       pi.sendMessage(
         {
@@ -3772,6 +3825,8 @@ async function recoverTimedOutUnit(
     }
 
     // Fallback: couldn't write skip artifacts — pause as before.
+    // Write diagnostic report to disk for post-mortem inspection.
+    const reportPath = writeDiagnosticReport(basePath, diagnosticSignals, diagnosticClassification, unitType, unitId);
     writeUnitRuntimeRecord(basePath, unitType, unitId, currentUnit.startedAt, {
       phase: "paused",
       recovery: status,
@@ -3779,7 +3834,7 @@ async function recoverTimedOutUnit(
       lastRecoveryReason: reason,
     });
     ctx.ui.notify(
-      `${reason === "idle" ? "Idle" : "Timeout"} recovery check for ${unitType} ${unitId}: ${diagnostic}`,
+      `${reason === "idle" ? "Idle" : "Timeout"} recovery check for ${unitType} ${unitId}: ${diagnostic}${reportPath ? `. Diagnostic report: ${reportPath}` : ""}`,
       "warning",
     );
     return "paused";
@@ -3817,25 +3872,50 @@ async function recoverTimedOutUnit(
     });
 
     const steeringLines = isEscalation
-      ? [
-          `**FINAL ${reason === "idle" ? "IDLE" : "HARD TIMEOUT"} RECOVERY — last chance before skip.**`,
-          `You are still executing ${unitType} ${unitId}.`,
-          `Recovery attempt ${recoveryAttempts + 1} of ${maxRecoveryAttempts} — next failure skips this unit.`,
-          `Expected durable output: ${expected}.`,
-          "You MUST write the artifact file NOW, even if incomplete.",
-          "Write whatever you have — partial research, preliminary findings, best-effort analysis.",
-          "A partial artifact is infinitely better than no artifact.",
-          "If you are truly blocked, write the file with a BLOCKER section explaining why.",
-        ]
-      : [
-          `**${reason === "idle" ? "IDLE" : "HARD TIMEOUT"} RECOVERY — stay in auto-mode.**`,
-          `You are still executing ${unitType} ${unitId}.`,
-          `Recovery attempt ${recoveryAttempts + 1} of ${maxRecoveryAttempts}.`,
-          `Expected durable output: ${expected}.`,
-          "Stop broad exploration.",
-          "Write the required artifact now.",
-          "If blocked, write the partial artifact and explicitly record the blocker instead of going silent.",
-        ];
+      ? diagnosticClassification.classification !== "ambiguous"
+        ? [
+            `**FINAL ${reason === "idle" ? "IDLE" : "HARD TIMEOUT"} RECOVERY — last chance before skip.**`,
+            `You are still executing ${unitType} ${unitId}.`,
+            `Recovery attempt ${recoveryAttempts + 1} of ${maxRecoveryAttempts} — next failure skips this unit.`,
+            `Expected durable output: ${expected}.`,
+            "You MUST write the artifact file NOW, even if incomplete.",
+            "Write whatever you have — partial research, preliminary findings, best-effort analysis.",
+            "A partial artifact is infinitely better than no artifact.",
+            "If you are truly blocked, write the file with a BLOCKER section explaining why.",
+            "",
+            buildDiagnosticSteeringContent(diagnosticClassification, unitType, unitId),
+          ]
+        : [
+            `**FINAL ${reason === "idle" ? "IDLE" : "HARD TIMEOUT"} RECOVERY — last chance before skip.**`,
+            `You are still executing ${unitType} ${unitId}.`,
+            `Recovery attempt ${recoveryAttempts + 1} of ${maxRecoveryAttempts} — next failure skips this unit.`,
+            `Expected durable output: ${expected}.`,
+            "You MUST write the artifact file NOW, even if incomplete.",
+            "Write whatever you have — partial research, preliminary findings, best-effort analysis.",
+            "A partial artifact is infinitely better than no artifact.",
+            "If you are truly blocked, write the file with a BLOCKER section explaining why.",
+          ]
+      : diagnosticClassification.classification !== "ambiguous"
+        ? [
+            `**${reason === "idle" ? "IDLE" : "HARD TIMEOUT"} RECOVERY — stay in auto-mode.**`,
+            `You are still executing ${unitType} ${unitId}.`,
+            `Recovery attempt ${recoveryAttempts + 1} of ${maxRecoveryAttempts}.`,
+            `Expected durable output: ${expected}.`,
+            "",
+            buildDiagnosticSteeringContent(diagnosticClassification, unitType, unitId),
+            "",
+            "Write the required artifact now.",
+            "If blocked, write the partial artifact and explicitly record the blocker instead of going silent.",
+          ]
+        : [
+            `**${reason === "idle" ? "IDLE" : "HARD TIMEOUT"} RECOVERY — stay in auto-mode.**`,
+            `You are still executing ${unitType} ${unitId}.`,
+            `Recovery attempt ${recoveryAttempts + 1} of ${maxRecoveryAttempts}.`,
+            `Expected durable output: ${expected}.`,
+            "Stop broad exploration.",
+            "Write the required artifact now.",
+            "If blocked, write the partial artifact and explicitly record the blocker instead of going silent.",
+          ];
 
     pi.sendMessage(
       {
@@ -3875,12 +3955,38 @@ async function recoverTimedOutUnit(
   }
 
   // Fallback: couldn't resolve artifact path — pause as before.
+  // Write diagnostic report to disk for post-mortem inspection.
+  writeDiagnosticReport(basePath, diagnosticSignals, diagnosticClassification, unitType, unitId);
   writeUnitRuntimeRecord(basePath, unitType, unitId, currentUnit.startedAt, {
     phase: "paused",
     recoveryAttempts: recoveryAttempts + 1,
     lastRecoveryReason: reason,
   });
   return "paused";
+}
+
+/**
+ * Write a diagnostic report markdown file to .gsd/runtime/ for post-mortem inspection.
+ * Returns the written file path, or null if writing failed.
+ */
+function writeDiagnosticReport(
+  base: string,
+  signals: Awaited<ReturnType<typeof collectDiagnosticSignals>>,
+  classification: ReturnType<typeof classifyStuckVsActive>,
+  unitType: string,
+  unitId: string,
+): string | null {
+  try {
+    const runtimeDir = join(gsdRoot(base), "runtime");
+    mkdirSync(runtimeDir, { recursive: true });
+    const sanitized = `${unitType}-${unitId}`.replace(/[\/]/g, "-");
+    const filePath = join(runtimeDir, `diagnostic-${sanitized}.md`);
+    const report = formatDiagnosticReport(signals, classification, unitType, unitId);
+    writeFileSync(filePath, report, "utf-8");
+    return filePath;
+  } catch {
+    return null;
+  }
 }
 
 // Re-export recovery functions for external consumers

--- a/src/resources/extensions/gsd/tests/diagnostic-supervisor.test.ts
+++ b/src/resources/extensions/gsd/tests/diagnostic-supervisor.test.ts
@@ -1,0 +1,844 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  collectDiagnosticSignals,
+  classifyStuckVsActive,
+  buildDiagnosticSteeringContent,
+  formatDiagnosticReport,
+  type DiagnosticSignals,
+  type BgShellHealthEntry,
+  type CollectDiagnosticSignalsOptions,
+  type StuckClassification,
+} from "../auto-supervisor.js";
+import type { AutoUnitRuntimeRecord } from "../unit-runtime.js";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeRuntime(overrides: Partial<AutoUnitRuntimeRecord> = {}): AutoUnitRuntimeRecord {
+  return {
+    version: 1,
+    unitType: "execute-task",
+    unitId: "T01",
+    startedAt: Date.now() - 60_000,
+    updatedAt: Date.now(),
+    phase: "dispatched",
+    wrapupWarningSent: false,
+    continueHereFired: false,
+    timeoutAt: null,
+    lastProgressAt: Date.now() - 5_000,
+    progressCount: 12,
+    lastProgressKind: "tool-call",
+    recoveryAttempts: 0,
+    ...overrides,
+  };
+}
+
+function makeProcessMap(
+  entries: Array<{
+    id: string;
+    label?: string;
+    status?: string;
+    alive?: boolean;
+    exitCode?: number | null;
+    signal?: string | null;
+    recentErrors?: string[];
+  }>,
+): Map<string, unknown> {
+  const map = new Map<string, unknown>();
+  for (const e of entries) {
+    map.set(e.id, e);
+  }
+  return map;
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+test("collectDiagnosticSignals returns complete structure when all sources provide data", async () => {
+  const runtime = makeRuntime({ progressCount: 15, lastProgressKind: "tool-call", recoveryAttempts: 1 });
+
+  const processMap = makeProcessMap([
+    { id: "p1", label: "dev-server", status: "running", alive: true },
+  ]);
+
+  const options: CollectDiagnosticSignalsOptions = {
+    getProcesses: () => processMap,
+    getDeepDiagnosticFn: () => "Tool calls completed: 42\nFiles written: `foo.ts`",
+    getGitStatusFn: () => " M src/foo.ts\n?? src/bar.ts",
+  };
+
+  const signals = await collectDiagnosticSignals(
+    "/fake/base",
+    "execute-task",
+    "T01",
+    runtime,
+    2,
+    3500,
+    options,
+  );
+
+  // Structure completeness
+  assert.equal(typeof signals.traceSummary, "string");
+  assert.ok(signals.traceSummary!.includes("Tool calls completed: 42"));
+  assert.ok(Array.isArray(signals.bgShellHealth));
+  assert.equal(signals.bgShellHealth!.length, 0); // healthy processes not included
+  assert.equal(typeof signals.gitStatus, "string");
+  assert.ok(signals.gitStatus!.includes("M src/foo.ts"));
+  assert.equal(typeof signals.msSinceLastProgress, "number");
+  assert.equal(signals.progressCount, 15);
+  assert.equal(signals.lastProgressKind, "tool-call");
+  assert.equal(signals.recoveryAttempts, 1);
+  assert.equal(signals.inFlightToolCount, 2);
+  assert.equal(signals.oldestInFlightToolAgeMs, 3500);
+});
+
+test("deep diagnostic source failure → traceSummary is null, rest still populated", async () => {
+  const options: CollectDiagnosticSignalsOptions = {
+    getProcesses: () => new Map(),
+    getDeepDiagnosticFn: () => { throw new Error("session file corrupted"); },
+    getGitStatusFn: () => " M file.ts",
+  };
+
+  const signals = await collectDiagnosticSignals(
+    "/fake/base", "execute-task", "T01", makeRuntime(), 0, null, options,
+  );
+
+  assert.equal(signals.traceSummary, null);
+  assert.equal(typeof signals.gitStatus, "string");
+  assert.ok(Array.isArray(signals.bgShellHealth));
+});
+
+test("bg-shell source failure → bgShellHealth is null, rest still populated", async () => {
+  const options: CollectDiagnosticSignalsOptions = {
+    getProcesses: () => { throw new Error("process-manager not available"); },
+    getDeepDiagnosticFn: () => "trace data",
+    getGitStatusFn: () => "",
+  };
+
+  const signals = await collectDiagnosticSignals(
+    "/fake/base", "execute-task", "T01", makeRuntime(), 0, null, options,
+  );
+
+  assert.equal(signals.bgShellHealth, null);
+  assert.equal(signals.traceSummary, "trace data");
+});
+
+test("git status source failure → gitStatus is null, rest still populated", async () => {
+  const options: CollectDiagnosticSignalsOptions = {
+    getProcesses: () => new Map(),
+    getDeepDiagnosticFn: () => "trace data",
+    getGitStatusFn: () => { throw new Error("not a git repo"); },
+  };
+
+  const signals = await collectDiagnosticSignals(
+    "/fake/base", "execute-task", "T01", makeRuntime(), 0, null, options,
+  );
+
+  assert.equal(signals.gitStatus, null);
+  assert.equal(signals.traceSummary, "trace data");
+});
+
+test("all sources fail → returns valid DiagnosticSignals with null fields", async () => {
+  const options: CollectDiagnosticSignalsOptions = {
+    getProcesses: () => { throw new Error("fail"); },
+    getDeepDiagnosticFn: () => { throw new Error("fail"); },
+    getGitStatusFn: () => { throw new Error("fail"); },
+  };
+
+  const signals = await collectDiagnosticSignals(
+    "/fake/base", "execute-task", "T01", null, 0, null, options,
+  );
+
+  assert.equal(signals.traceSummary, null);
+  assert.equal(signals.bgShellHealth, null);
+  assert.equal(signals.gitStatus, null);
+  assert.equal(signals.msSinceLastProgress, null);
+  assert.equal(signals.progressCount, null);
+  assert.equal(signals.lastProgressKind, null);
+  assert.equal(signals.recoveryAttempts, null);
+  assert.equal(signals.inFlightToolCount, 0);
+  assert.equal(signals.oldestInFlightToolAgeMs, null);
+});
+
+test("null runtime produces valid signals with null temporal fields", async () => {
+  const options: CollectDiagnosticSignalsOptions = {
+    getProcesses: () => new Map(),
+    getDeepDiagnosticFn: () => null,
+    getGitStatusFn: () => "",
+  };
+
+  const signals = await collectDiagnosticSignals(
+    "/fake/base", "execute-task", "T01", null, 1, 500, options,
+  );
+
+  assert.equal(signals.msSinceLastProgress, null);
+  assert.equal(signals.progressCount, null);
+  assert.equal(signals.lastProgressKind, null);
+  assert.equal(signals.recoveryAttempts, null);
+  // In-flight data still passed through
+  assert.equal(signals.inFlightToolCount, 1);
+  assert.equal(signals.oldestInFlightToolAgeMs, 500);
+});
+
+test("bg-shell scanning finds crashed process (fatal signal)", async () => {
+  const processMap = makeProcessMap([
+    { id: "srv", label: "build-server", status: "running", alive: false, signal: "SIGSEGV", exitCode: null },
+  ]);
+
+  const options: CollectDiagnosticSignalsOptions = {
+    getProcesses: () => processMap,
+    getDeepDiagnosticFn: () => null,
+    getGitStatusFn: () => "",
+  };
+
+  const signals = await collectDiagnosticSignals(
+    "/fake/base", "execute-task", "T01", makeRuntime(), 0, null, options,
+  );
+
+  assert.ok(signals.bgShellHealth);
+  assert.equal(signals.bgShellHealth!.length, 1);
+  assert.equal(signals.bgShellHealth![0]!.status, "crashed");
+  assert.equal(signals.bgShellHealth![0]!.name, "build-server");
+  assert.equal(signals.bgShellHealth![0]!.signal, "SIGSEGV");
+});
+
+test("bg-shell scanning finds crashed process (crashed status)", async () => {
+  const processMap = makeProcessMap([
+    { id: "watcher", label: "file-watcher", status: "crashed", alive: false, exitCode: 1 },
+  ]);
+
+  const options: CollectDiagnosticSignalsOptions = {
+    getProcesses: () => processMap,
+    getDeepDiagnosticFn: () => null,
+    getGitStatusFn: () => "",
+  };
+
+  const signals = await collectDiagnosticSignals(
+    "/fake/base", "execute-task", "T01", makeRuntime(), 0, null, options,
+  );
+
+  assert.ok(signals.bgShellHealth);
+  assert.equal(signals.bgShellHealth!.length, 1);
+  assert.equal(signals.bgShellHealth![0]!.status, "crashed");
+  assert.equal(signals.bgShellHealth![0]!.exitCode, 1);
+});
+
+test("bg-shell scanning finds crashed process (non-zero exit, dead)", async () => {
+  const processMap = makeProcessMap([
+    { id: "build", label: "build-cmd", status: "exited", alive: false, exitCode: 127 },
+  ]);
+
+  const options: CollectDiagnosticSignalsOptions = {
+    getProcesses: () => processMap,
+    getDeepDiagnosticFn: () => null,
+    getGitStatusFn: () => "",
+  };
+
+  const signals = await collectDiagnosticSignals(
+    "/fake/base", "execute-task", "T01", makeRuntime(), 0, null, options,
+  );
+
+  assert.ok(signals.bgShellHealth);
+  assert.equal(signals.bgShellHealth!.length, 1);
+  assert.equal(signals.bgShellHealth![0]!.status, "crashed");
+  assert.equal(signals.bgShellHealth![0]!.exitCode, 127);
+});
+
+test("bg-shell scanning finds errored process (alive with recent errors)", async () => {
+  const processMap = makeProcessMap([
+    { id: "dev", label: "dev-server", status: "running", alive: true, recentErrors: ["ECONNREFUSED", "timeout"] },
+  ]);
+
+  const options: CollectDiagnosticSignalsOptions = {
+    getProcesses: () => processMap,
+    getDeepDiagnosticFn: () => null,
+    getGitStatusFn: () => "",
+  };
+
+  const signals = await collectDiagnosticSignals(
+    "/fake/base", "execute-task", "T01", makeRuntime(), 0, null, options,
+  );
+
+  assert.ok(signals.bgShellHealth);
+  assert.equal(signals.bgShellHealth!.length, 1);
+  assert.equal(signals.bgShellHealth![0]!.status, "errored");
+  assert.deepEqual(signals.bgShellHealth![0]!.recentErrors, ["ECONNREFUSED", "timeout"]);
+});
+
+test("bg-shell scanning skips healthy processes", async () => {
+  const processMap = makeProcessMap([
+    { id: "ok1", label: "healthy-server", status: "running", alive: true },
+    { id: "ok2", label: "healthy-watcher", status: "running", alive: true, exitCode: null },
+  ]);
+
+  const options: CollectDiagnosticSignalsOptions = {
+    getProcesses: () => processMap,
+    getDeepDiagnosticFn: () => null,
+    getGitStatusFn: () => "",
+  };
+
+  const signals = await collectDiagnosticSignals(
+    "/fake/base", "execute-task", "T01", makeRuntime(), 0, null, options,
+  );
+
+  assert.ok(signals.bgShellHealth);
+  assert.equal(signals.bgShellHealth!.length, 0);
+});
+
+test("empty git status string → gitStatus is null", async () => {
+  const options: CollectDiagnosticSignalsOptions = {
+    getProcesses: () => new Map(),
+    getDeepDiagnosticFn: () => null,
+    getGitStatusFn: () => "",
+  };
+
+  const signals = await collectDiagnosticSignals(
+    "/fake/base", "execute-task", "T01", makeRuntime(), 0, null, options,
+  );
+
+  assert.equal(signals.gitStatus, null);
+});
+
+test("runtime with lastProgressAt=0 → msSinceLastProgress is null", async () => {
+  const runtime = makeRuntime({ lastProgressAt: 0 });
+  const options: CollectDiagnosticSignalsOptions = {
+    getProcesses: () => new Map(),
+    getDeepDiagnosticFn: () => null,
+    getGitStatusFn: () => "",
+  };
+
+  const signals = await collectDiagnosticSignals(
+    "/fake/base", "execute-task", "T01", runtime, 0, null, options,
+  );
+
+  // lastProgressAt is 0 (falsy), so msSinceLastProgress should be null
+  assert.equal(signals.msSinceLastProgress, null);
+});
+
+test("mixed bg-shell processes: one crashed, one healthy, one errored", async () => {
+  const processMap = makeProcessMap([
+    { id: "crashed", label: "build", status: "crashed", alive: false, exitCode: 1 },
+    { id: "healthy", label: "server", status: "running", alive: true },
+    { id: "errored", label: "watcher", status: "running", alive: true, recentErrors: ["timeout"] },
+  ]);
+
+  const options: CollectDiagnosticSignalsOptions = {
+    getProcesses: () => processMap,
+    getDeepDiagnosticFn: () => null,
+    getGitStatusFn: () => "",
+  };
+
+  const signals = await collectDiagnosticSignals(
+    "/fake/base", "execute-task", "T01", makeRuntime(), 0, null, options,
+  );
+
+  assert.ok(signals.bgShellHealth);
+  assert.equal(signals.bgShellHealth!.length, 2); // crashed + errored, not healthy
+  const statuses = signals.bgShellHealth!.map((e) => e.status).sort();
+  assert.deepEqual(statuses, ["crashed", "errored"]);
+});
+
+// ─── Classification Helpers ───────────────────────────────────────────────────
+
+function makeSignals(overrides: Partial<DiagnosticSignals> = {}): DiagnosticSignals {
+  return {
+    traceSummary: null,
+    bgShellHealth: null,
+    gitStatus: null,
+    msSinceLastProgress: null,
+    progressCount: null,
+    lastProgressKind: null,
+    recoveryAttempts: null,
+    inFlightToolCount: 0,
+    oldestInFlightToolAgeMs: null,
+    ...overrides,
+  };
+}
+
+// ─── classifyStuckVsActive Tests ──────────────────────────────────────────────
+
+test("classify: active — recent progress + trace present", () => {
+  const result = classifyStuckVsActive(makeSignals({
+    msSinceLastProgress: 15_000, // 15s — well within 60s threshold
+    traceSummary: "Tool calls completed: 12\nbash: npm test",
+    gitStatus: " M src/foo.ts",
+  }));
+
+  assert.equal(result.classification, "active");
+  assert.ok(result.confidence >= 0.7);
+  assert.ok(result.findings.some((f) => f.category === "tool-activity"));
+});
+
+test("classify: active — recent progress + git changes, no trace", () => {
+  const result = classifyStuckVsActive(makeSignals({
+    msSinceLastProgress: 30_000,
+    gitStatus: " M src/bar.ts\n?? new-file.ts",
+  }));
+
+  assert.equal(result.classification, "active");
+  assert.ok(result.confidence >= 0.7);
+});
+
+test("classify: stuck/crash — crashed bg-shell process with exit code", () => {
+  const result = classifyStuckVsActive(makeSignals({
+    bgShellHealth: [
+      { id: "srv", name: "dev-server", status: "crashed", exitCode: 1, signal: null },
+    ],
+  }));
+
+  assert.equal(result.classification, "stuck/crash");
+  assert.ok(result.confidence >= 0.9);
+  assert.ok(result.findings.some((f) =>
+    f.severity === "crash" && f.message.includes("exit code 1"),
+  ));
+});
+
+test("classify: stuck/crash — process received fatal signal", () => {
+  const result = classifyStuckVsActive(makeSignals({
+    bgShellHealth: [
+      { id: "srv", name: "build-server", status: "crashed", exitCode: null, signal: "SIGSEGV" },
+    ],
+  }));
+
+  assert.equal(result.classification, "stuck/crash");
+  assert.ok(result.confidence >= 0.9);
+  assert.ok(result.findings.some((f) =>
+    f.severity === "crash" && f.message.includes("SIGSEGV"),
+  ));
+});
+
+test("classify: stuck/read-loop — trace shows repeated reads", () => {
+  const result = classifyStuckVsActive(makeSignals({
+    traceSummary: "read ×5 src/auto-supervisor.ts\nedit ×0\nbash ×1",
+    msSinceLastProgress: 120_000,
+  }));
+
+  assert.equal(result.classification, "stuck/read-loop");
+  assert.ok(result.confidence >= 0.8);
+  assert.ok(result.findings.some((f) => f.message.includes("reading the same file")));
+});
+
+test("classify: stuck/read-loop — low count (×2) is not enough", () => {
+  const result = classifyStuckVsActive(makeSignals({
+    traceSummary: "read ×2 src/foo.ts\nbash ×1 npm test",
+    msSinceLastProgress: 120_000,
+  }));
+
+  // ×2 is below threshold of ×3, so should NOT be read-loop
+  assert.notEqual(result.classification, "stuck/read-loop");
+});
+
+test("classify: stuck/error-loop — trace shows repeated failures", () => {
+  const result = classifyStuckVsActive(makeSignals({
+    traceSummary: "bash: npm test → exit code 1\nbash: npm test → exit code 1\nbash: npm test → exit code 1",
+    msSinceLastProgress: 90_000,
+  }));
+
+  assert.equal(result.classification, "stuck/error-loop");
+  assert.ok(result.confidence >= 0.8);
+  assert.ok(result.findings.some((f) => f.message.includes("failed repeatedly")));
+});
+
+test("classify: stuck/error-loop — alternative pattern with ×N", () => {
+  const result = classifyStuckVsActive(makeSignals({
+    traceSummary: "failed ×4 similar commands",
+    msSinceLastProgress: 90_000,
+  }));
+
+  assert.equal(result.classification, "stuck/error-loop");
+  assert.ok(result.confidence >= 0.8);
+});
+
+test("classify: stuck/no-progress — stale progress, no trace, no git, no tools", () => {
+  const result = classifyStuckVsActive(makeSignals({
+    msSinceLastProgress: 120_000,
+    bgShellHealth: [],
+    gitStatus: null,
+    traceSummary: null,
+    inFlightToolCount: 0,
+  }));
+
+  assert.equal(result.classification, "stuck/no-progress");
+  assert.ok(result.confidence >= 0.9);
+  assert.ok(result.findings.some((f) => f.message.includes("No tool activity")));
+});
+
+test("classify: stuck/no-progress — null msSinceLastProgress counts as stale", () => {
+  const result = classifyStuckVsActive(makeSignals({
+    msSinceLastProgress: null,
+    bgShellHealth: [],
+    gitStatus: null,
+    traceSummary: null,
+    inFlightToolCount: 0,
+  }));
+
+  assert.equal(result.classification, "stuck/no-progress");
+  assert.ok(result.confidence >= 0.9);
+});
+
+test("classify: ambiguous — all-null signals", () => {
+  const result = classifyStuckVsActive(makeSignals());
+
+  assert.equal(result.classification, "ambiguous");
+  assert.ok(result.confidence <= 0.5);
+  assert.ok(result.findings.some((f) => f.message.includes("Insufficient signals")));
+});
+
+test("classify: ambiguous — mixed signals, no clear pattern", () => {
+  // Has some git changes but stale progress and no trace — not enough for "active"
+  const result = classifyStuckVsActive(makeSignals({
+    msSinceLastProgress: 120_000, // stale
+    gitStatus: " M src/foo.ts", // present, but stale progress means not "active"
+    bgShellHealth: [],
+  }));
+
+  // Has git changes but stale progress — ambiguous (git changes alone don't mean active
+  // when there's no recent progress)
+  assert.equal(result.classification, "ambiguous");
+  assert.ok(result.confidence <= 0.5);
+});
+
+test("classify: temporal weighting — stale progress with git changes is NOT active", () => {
+  const result = classifyStuckVsActive(makeSignals({
+    msSinceLastProgress: 300_000, // 5 minutes — very stale
+    gitStatus: " M src/foo.ts\n M src/bar.ts",
+    traceSummary: "Some old trace data",
+    bgShellHealth: [],
+  }));
+
+  // Despite having git changes AND trace, stale progress prevents "active"
+  assert.notEqual(result.classification, "active");
+});
+
+test("classify: crash takes priority over error loop", () => {
+  const result = classifyStuckVsActive(makeSignals({
+    bgShellHealth: [
+      { id: "srv", name: "dev-server", status: "crashed", exitCode: 1, signal: null },
+    ],
+    traceSummary: "bash: npm test → exit code 1\nbash: npm test → exit code 1",
+    msSinceLastProgress: 90_000,
+  }));
+
+  // Both crash AND error-loop findings present, but classification is crash (highest priority)
+  assert.equal(result.classification, "stuck/crash");
+  assert.ok(result.findings.some((f) => f.severity === "crash"));
+  assert.ok(result.findings.some((f) => f.message.includes("failed repeatedly")));
+});
+
+test("classify: in-flight tools prevent no-progress", () => {
+  const result = classifyStuckVsActive(makeSignals({
+    msSinceLastProgress: 120_000,
+    bgShellHealth: [],
+    gitStatus: null,
+    traceSummary: null,
+    inFlightToolCount: 2, // tools in flight
+    oldestInFlightToolAgeMs: 5_000,
+  }));
+
+  // Has in-flight tools, so shouldn't be "no-progress"
+  assert.notEqual(result.classification, "stuck/no-progress");
+});
+
+// ─── buildDiagnosticSteeringContent Tests ─────────────────────────────────────
+
+test("steering: crash finding produces restart guidance", () => {
+  const classification: StuckClassification = {
+    classification: "stuck/crash",
+    confidence: 0.95,
+    findings: [
+      { category: "bg-shell", message: "Process 'dev-server' crashed with exit code 1", severity: "crash" },
+    ],
+  };
+
+  const content = buildDiagnosticSteeringContent(classification, "execute-task", "T01");
+
+  assert.ok(content.includes("dev-server"));
+  assert.ok(content.includes("crashed"));
+  assert.ok(content.includes("restart or fix"));
+  assert.ok(content.length <= 500);
+});
+
+test("steering: read loop finding produces change guidance", () => {
+  const classification: StuckClassification = {
+    classification: "stuck/read-loop",
+    confidence: 0.8,
+    findings: [
+      { category: "trace", message: "Agent appears to be reading the same file(s) repeatedly", severity: "warning" },
+    ],
+  };
+
+  const content = buildDiagnosticSteeringContent(classification, "execute-task", "T02");
+
+  assert.ok(content.includes("reading the same files"));
+  assert.ok(content.includes("Identify the specific change"));
+  assert.ok(content.length <= 500);
+});
+
+test("steering: error loop finding produces different-approach guidance", () => {
+  const classification: StuckClassification = {
+    classification: "stuck/error-loop",
+    confidence: 0.85,
+    findings: [
+      { category: "trace", message: "Last commands failed repeatedly with similar errors", severity: "error" },
+    ],
+  };
+
+  const content = buildDiagnosticSteeringContent(classification, "execute-task", "T03");
+
+  assert.ok(content.includes("failing repeatedly"));
+  assert.ok(content.includes("different approach"));
+  assert.ok(content.length <= 500);
+});
+
+test("steering: no-progress finding produces blocker guidance", () => {
+  const classification: StuckClassification = {
+    classification: "stuck/no-progress",
+    confidence: 0.9,
+    findings: [
+      { category: "temporal", message: "No tool activity or file changes detected", severity: "warning" },
+    ],
+  };
+
+  const content = buildDiagnosticSteeringContent(classification, "execute-task", "T04");
+
+  assert.ok(content.includes("No tool activity detected"));
+  assert.ok(content.includes("explain the blocker"));
+  assert.ok(content.length <= 500);
+});
+
+test("steering: active classification produces no corrective text", () => {
+  const classification: StuckClassification = {
+    classification: "active",
+    confidence: 0.8,
+    findings: [
+      { category: "tool-activity", message: "Agent is actively working (recent progress detected)", severity: "info" },
+    ],
+  };
+
+  const content = buildDiagnosticSteeringContent(classification, "execute-task", "T05");
+
+  assert.ok(content.includes("active"));
+  // No corrective guidance lines
+  assert.ok(!content.includes("crashed"));
+  assert.ok(!content.includes("failing repeatedly"));
+  assert.ok(!content.includes("reading the same files"));
+  assert.ok(content.length <= 500);
+});
+
+test("steering: ambiguous produces only the header", () => {
+  const classification: StuckClassification = {
+    classification: "ambiguous",
+    confidence: 0.3,
+    findings: [
+      { category: "temporal", message: "Insufficient signals for definitive classification", severity: "info" },
+    ],
+  };
+
+  const content = buildDiagnosticSteeringContent(classification, "execute-task", "T06");
+
+  assert.ok(content.includes("ambiguous"));
+  assert.ok(content.length <= 500);
+});
+
+test("steering: content is capped at 500 chars", () => {
+  // Create a classification with many findings to test truncation
+  const classification: StuckClassification = {
+    classification: "stuck/crash",
+    confidence: 0.95,
+    findings: [
+      { category: "bg-shell", message: "Process 'server-one-with-a-very-long-name' crashed with exit code 1", severity: "crash" },
+      { category: "bg-shell", message: "Process 'server-two-with-a-very-long-name' crashed with exit code 2", severity: "crash" },
+      { category: "bg-shell", message: "Process 'server-three-with-a-very-long-name' crashed with exit code 3", severity: "crash" },
+      { category: "trace", message: "Last commands failed repeatedly with similar errors", severity: "error" },
+      { category: "trace", message: "Agent appears to be reading the same file(s) repeatedly", severity: "warning" },
+      { category: "temporal", message: "No tool activity or file changes detected", severity: "warning" },
+    ],
+  };
+
+  const content = buildDiagnosticSteeringContent(classification, "execute-task", "T07");
+  assert.ok(content.length <= 500, `Steering content too long: ${content.length} chars`);
+});
+
+// ─── formatDiagnosticReport Tests ─────────────────────────────────────────────
+
+test("formatDiagnosticReport produces well-formed markdown with all sections", () => {
+  const signals = makeSignals({
+    traceSummary: "Tool calls completed: 12\nFiles written: `foo.ts`",
+    bgShellHealth: [
+      { id: "srv", name: "dev-server", status: "crashed", exitCode: 1, signal: null },
+    ],
+    gitStatus: " M src/foo.ts\n?? src/bar.ts",
+    msSinceLastProgress: 90_000,
+    progressCount: 15,
+    lastProgressKind: "tool-call",
+    recoveryAttempts: 2,
+    inFlightToolCount: 1,
+    oldestInFlightToolAgeMs: 5_000,
+  });
+
+  const classification: StuckClassification = {
+    classification: "stuck/crash",
+    confidence: 0.95,
+    findings: [
+      { category: "bg-shell", message: "Process 'dev-server' crashed with exit code 1", severity: "crash" },
+      { category: "trace", message: "Last commands failed repeatedly with similar errors", severity: "error" },
+    ],
+  };
+
+  const report = formatDiagnosticReport(signals, classification, "execute-task", "M001/S01/T01");
+
+  // Header section
+  assert.ok(report.includes("# Diagnostic Report: execute-task/M001/S01/T01"));
+  assert.ok(report.includes("**Generated:**"));
+  assert.ok(report.includes("**Unit:** execute-task M001/S01/T01"));
+
+  // Classification section
+  assert.ok(report.includes("## Classification"));
+  assert.ok(report.includes("**Result:** stuck/crash"));
+  assert.ok(report.includes("**Confidence:** 0.95"));
+
+  // Findings table
+  assert.ok(report.includes("## Findings"));
+  assert.ok(report.includes("| Category | Severity | Message |"));
+  assert.ok(report.includes("| bg-shell | crash | Process 'dev-server' crashed with exit code 1 |"));
+  assert.ok(report.includes("| trace | error | Last commands failed repeatedly with similar errors |"));
+
+  // Signal summary
+  assert.ok(report.includes("## Signal Summary"));
+  assert.ok(report.includes("**Trace available:** yes"));
+  assert.ok(report.includes("**bg-shell processes:** 1 unhealthy"));
+  assert.ok(report.includes("dev-server: crashed (exit=1)"));
+  assert.ok(report.includes("**Git status:** changes detected"));
+  assert.ok(report.includes("**In-flight tools:** 1 (oldest: 5s)"));
+  assert.ok(report.includes("**Time since last progress:** 90s"));
+  assert.ok(report.includes("**Progress count:** 15"));
+  assert.ok(report.includes("**Last progress kind:** tool-call"));
+  assert.ok(report.includes("**Recovery attempts:** 2"));
+});
+
+test("formatDiagnosticReport handles all-null signals gracefully", () => {
+  const signals = makeSignals();
+
+  const classification: StuckClassification = {
+    classification: "ambiguous",
+    confidence: 0.3,
+    findings: [
+      { category: "temporal", message: "Insufficient signals for definitive classification", severity: "info" },
+    ],
+  };
+
+  const report = formatDiagnosticReport(signals, classification, "research-milestone", "M002");
+
+  assert.ok(report.includes("# Diagnostic Report: research-milestone/M002"));
+  assert.ok(report.includes("**Result:** ambiguous"));
+  assert.ok(report.includes("**Trace available:** no"));
+  assert.ok(report.includes("**bg-shell processes:** unavailable"));
+  assert.ok(report.includes("**Git status:** no changes or unavailable"));
+  assert.ok(report.includes("**In-flight tools:** 0"));
+  assert.ok(report.includes("**Time since last progress:** unknown"));
+  assert.ok(report.includes("**Progress count:** unknown"));
+  assert.ok(report.includes("**Recovery attempts:** unknown"));
+});
+
+test("formatDiagnosticReport shows empty findings as _No findings._", () => {
+  const signals = makeSignals({ msSinceLastProgress: 10_000, traceSummary: "some trace" });
+  const classification: StuckClassification = {
+    classification: "active",
+    confidence: 0.8,
+    findings: [],
+  };
+
+  const report = formatDiagnosticReport(signals, classification, "execute-task", "T01");
+  assert.ok(report.includes("_No findings._"));
+});
+
+test("formatDiagnosticReport truncates long trace summaries", () => {
+  const longTrace = "x".repeat(500);
+  const signals = makeSignals({ traceSummary: longTrace });
+
+  const classification: StuckClassification = {
+    classification: "ambiguous",
+    confidence: 0.3,
+    findings: [],
+  };
+
+  const report = formatDiagnosticReport(signals, classification, "execute-task", "T01");
+  assert.ok(report.includes("**Trace excerpt:**"));
+  // Should be truncated to 200 chars + "..."
+  assert.ok(report.includes("..."));
+  // Full 500-char trace should NOT appear
+  assert.ok(!report.includes(longTrace));
+});
+
+test("formatDiagnosticReport includes bg-shell process details with signal", () => {
+  const signals = makeSignals({
+    bgShellHealth: [
+      { id: "srv", name: "build-server", status: "crashed", exitCode: null, signal: "SIGSEGV" },
+    ],
+  });
+
+  const classification: StuckClassification = {
+    classification: "stuck/crash",
+    confidence: 0.95,
+    findings: [
+      { category: "bg-shell", message: "Process 'build-server' received signal SIGSEGV", severity: "crash" },
+    ],
+  };
+
+  const report = formatDiagnosticReport(signals, classification, "execute-task", "T01");
+  assert.ok(report.includes("build-server: crashed (signal=SIGSEGV)"));
+});
+
+// ─── Diagnostic steering differs from generic text ────────────────────────────
+
+test("steering: stuck classification produces different text than ambiguous", () => {
+  const stuckClassification: StuckClassification = {
+    classification: "stuck/crash",
+    confidence: 0.95,
+    findings: [
+      { category: "bg-shell", message: "Process 'dev-server' crashed with exit code 1", severity: "crash" },
+    ],
+  };
+
+  const ambiguousClassification: StuckClassification = {
+    classification: "ambiguous",
+    confidence: 0.3,
+    findings: [
+      { category: "temporal", message: "Insufficient signals for definitive classification", severity: "info" },
+    ],
+  };
+
+  const stuckContent = buildDiagnosticSteeringContent(stuckClassification, "execute-task", "T01");
+  const ambiguousContent = buildDiagnosticSteeringContent(ambiguousClassification, "execute-task", "T01");
+
+  // Stuck content should have corrective guidance
+  assert.ok(stuckContent.includes("crashed"));
+  assert.ok(stuckContent.includes("restart or fix"));
+
+  // Ambiguous content should only have the header
+  assert.ok(ambiguousContent.includes("ambiguous"));
+  assert.ok(!ambiguousContent.includes("restart or fix"));
+  assert.ok(!ambiguousContent.includes("reading the same files"));
+  assert.ok(!ambiguousContent.includes("failing repeatedly"));
+
+  // They should be meaningfully different
+  assert.notEqual(stuckContent, ambiguousContent);
+});
+
+// ─── Backward compatibility: ambiguous falls through to generic behavior ──────
+
+test("ambiguous classification produces no actionable steering beyond header", () => {
+  const classification: StuckClassification = {
+    classification: "ambiguous",
+    confidence: 0.3,
+    findings: [
+      { category: "temporal", message: "Insufficient signals for definitive classification", severity: "info" },
+    ],
+  };
+
+  const content = buildDiagnosticSteeringContent(classification, "execute-task", "T01");
+
+  // Should only contain the classification header line
+  const lines = content.split("\n").filter((l) => l.trim().length > 0);
+  assert.equal(lines.length, 1, "Ambiguous should produce only the header line");
+  assert.ok(lines[0]!.includes("ambiguous"));
+});


### PR DESCRIPTION
## Summary

- **Diagnostic-aware idle recovery** — when the watchdog fires, it now inspects activity signals and classifies the agent as stuck vs. active instead of always injecting generic recovery text
- `collectDiagnosticSignals` gathers tool call patterns, file write activity, bg-shell status, and error patterns from the runtime record
- `classifyStuckVsActive` heuristic correctly classifies 6 patterns: active, crash, read-loop, error-loop, no-progress, ambiguous
- Active agents get progress clock reset (no false-positive recovery injection)
- Stuck agents get recovery messages with **specific diagnostic findings** instead of generic "Do not keep exploring"
- When retries exhaust and auto-mode pauses, user sees a **structured diagnostic report** with findings, signal summary, and classification
- `ambiguous` classification falls back to existing generic behavior — graceful degradation for projects without activity logs

## Slices

- **S01**: Full diagnostic pipeline — signal collection (T01), stuck-vs-active classification with 6 patterns (T02), wired into `recoverTimedOutUnit` in `auto.ts` with structured escalation reports (T03)

## Stats

19 files changed, 2,742 insertions(+), 70 deletions(-)

## Test plan

- [ ] Unit tests pass for all 6 classification patterns
- [ ] Existing `idle-recovery.test.ts` and `auto-supervisor.test.mjs` still pass
- [ ] `npx tsc --noEmit` clean
- [ ] Active agents classified correctly — no false-positive recovery
- [ ] Diagnostic findings appear in recovery messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)