### PR TITLE
fix: resolve symlinked skill directories in preferences

### DIFF
--- a/src/resources/extensions/gsd/preferences.ts
+++ b/src/resources/extensions/gsd/preferences.ts
@@ -333,7 +333,7 @@ function resolveSkillReference(ref: string, cwd: string): SkillResolution {
     try {
       const entries = readdirSync(dir, { withFileTypes: true });
       for (const entry of entries) {
-        if (!entry.isDirectory()) continue;
+        if (!entry.isDirectory() && !entry.isSymbolicLink()) continue;
         if (entry.name === expanded) {
           const skillFile = join(dir, entry.name, "SKILL.md");
           if (existsSync(skillFile)) {


### PR DESCRIPTION
Fixes #911

## Problem

`resolveSkillReference()` in `preferences.ts` scans skill directories using `readdirSync` with `withFileTypes: true` and filters entries with:

```typescript
if (!entry.isDirectory()) continue;
```

`Dirent.isDirectory()` returns `false` for symlinks — it reports the type of the link itself, not the target. Symlinked skill directories in `~/.gsd/agent/skills/` are silently skipped, marked as `unresolved`, and the system prompt shows `⚠ not found`.

This means `always_use_skills` (and `prefer_skills`) preferences never resolve for symlinked skills, and auto-mode agents never load or apply the skill guidance.

## Fix

One-line change — also accept `isSymbolicLink()`:

```diff
- if (!entry.isDirectory()) continue;
+ if (!entry.isDirectory() && !entry.isSymbolicLink()) continue;
```

This is safe because the code already calls `existsSync(skillFile)` on the resolved path (`join(dir, entry.name, "SKILL.md")`), which follows symlinks. If the symlink target is invalid or missing `SKILL.md`, it still won't resolve.

The absolute-path resolution branch (line ~312) uses `statSync()` which follows symlinks, so it's unaffected.

## Testing

Verified locally:

```
# Before fix:
building-components isDir: false isSymlink: true → NOT FOUND
vercel-react-best-practices isDir: false isSymlink: true → NOT FOUND

# After fix:
building-components → ✓ FOUND
vercel-react-best-practices → ✓ FOUND
web-design-guidelines → ✓ FOUND
vercel-composition-patterns → ✓ FOUND
```