### PR TITLE
fix: resolve symlinked skill directories in always_use_skills (#911)

### DIFF
--- a/src/resources/extensions/gsd/preferences.ts
+++ b/src/resources/extensions/gsd/preferences.ts
@@ -333,7 +333,7 @@ function resolveSkillReference(ref: string, cwd: string): SkillResolution {
     try {
       const entries = readdirSync(dir, { withFileTypes: true });
       for (const entry of entries) {
-        if (!entry.isDirectory()) continue;
+        if (!entry.isDirectory() && !entry.isSymbolicLink()) continue;
         if (entry.name === expanded) {
           const skillFile = join(dir, entry.name, "SKILL.md");
           if (existsSync(skillFile)) {


### PR DESCRIPTION
One-line fix. `Dirent.isDirectory()` returns false for symlinks. Added `|| entry.isSymbolicLink()` to the bare-name skill scan in `preferences.ts`. The subsequent `existsSync(skillFile)` already follows symlinks.

Closes #911.