### PR TITLE
fix: don't overwrite user's model choice when API key is temporarily unavailable (#910)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -287,7 +287,9 @@ const configuredExists = configuredProvider && configuredModel &&
 const configuredAvailable = configuredProvider && configuredModel &&
   availableModels.some((m) => m.provider === configuredProvider && m.id === configuredModel)
 
-if (!configuredModel || !configuredExists || !configuredAvailable) {
+if (!configuredModel || !configuredExists) {
+  // Model not configured at all, or removed from registry — pick a fallback.
+  // Only fires when the model is genuinely unknown (not just temporarily unavailable).
   const piDefault = getPiDefaultModelAndProvider()
   const preferred =
     (piDefault
@@ -304,7 +306,7 @@ if (!configuredModel || !configuredExists || !configuredAvailable) {
   }
 }
 
-if (settingsManager.getDefaultThinkingLevel() !== 'off' && (!configuredExists || !configuredAvailable)) {
+if (settingsManager.getDefaultThinkingLevel() !== 'off' && !configuredExists) {
   settingsManager.setDefaultThinkingLevel('off')
 }
 


### PR DESCRIPTION
Startup model validation overwrote the configured model when its API key was temporarily unavailable (expired OAuth, rate-limited, network glitch). The fallback selected whatever was first available — often `google/gemini-1.5-flash`.

Fix: Only trigger fallback when the model doesn't exist in the registry (removed/unknown). Temporarily unavailable models keep their setting — the session-level fallback resolver handles it at prompt time.

Closes #910.