### PR TITLE
fix: allow suffix text after '## Slices' heading in roadmap parser (#924)

### DIFF
--- a/src/resources/extensions/gsd/roadmap-slices.ts
+++ b/src/resources/extensions/gsd/roadmap-slices.ts
@@ -41,7 +41,7 @@ export function expandDependencies(deps: string[]): string[] {
 }
 
 function extractSlicesSection(content: string): string {
-  const headingMatch = /^## Slices\s*$/m.exec(content);
+  const headingMatch = /^## Slices\b.*$/m.exec(content);
   if (!headingMatch || headingMatch.index == null) return "";
 
   const start = headingMatch.index + headingMatch[0].length;


### PR DESCRIPTION
Regex required exact `## Slices` with nothing after. Changed to `/^## Slices\b.*$/m` — allows trailing text while ensuring 'Slices' is a complete word. Closes #924.