### PR TITLE
refactor: reorder HTML report sections to match visualizer

### DIFF
--- a/src/resources/extensions/gsd/export-html.ts
+++ b/src/resources/extensions/gsd/export-html.ts
@@ -4,15 +4,15 @@
  * Produces a single self-contained HTML file with:
  *   - Branding header (project name, path, GSD version, generated timestamp)
  *   - Project summary & overall progress
- *   - Health & configuration overview
  *   - Progress tree (milestones → slices → tasks, with critical path)
+ *   - Execution timeline (chronological unit history)
  *   - Slice dependency graph (SVG DAG per milestone)
  *   - Cost & token metrics (bar charts, phase/slice/model/tier breakdowns)
- *   - Execution timeline (chronological unit history)
+ *   - Health & configuration overview
  *   - Changelog (completed slice summaries + file modifications)
  *   - Knowledge base (rules, patterns, lessons)
  *   - Captures log
- *   - Milestone planning / discussion state
+ *   - Artifacts & milestone planning / discussion state
  *
  * No external dependencies — all CSS and JS is inlined.
  * Printable to PDF from any browser.
@@ -46,11 +46,11 @@ export function generateHtmlReport(
 
   const sections = [
     buildSummarySection(data, opts, generated),
-    buildHealthSection(data),
     buildProgressSection(data),
+    buildTimelineSection(data),
     buildDepGraphSection(data),
     buildMetricsSection(data),
-    buildTimelineSection(data),
+    buildHealthSection(data),
     buildChangelogSection(data),
     buildKnowledgeSection(data),
     buildCapturesSection(data),
@@ -94,11 +94,11 @@ export function generateHtmlReport(
 <nav class="toc" aria-label="Report sections">
   <ul>
     <li><a href="#summary">Summary</a></li>
-    <li><a href="#health">Health</a></li>
     <li><a href="#progress">Progress</a></li>
+    <li><a href="#timeline">Timeline</a></li>
     <li><a href="#depgraph">Dependencies</a></li>
     <li><a href="#metrics">Metrics</a></li>
-    <li><a href="#timeline">Timeline</a></li>
+    <li><a href="#health">Health</a></li>
     <li><a href="#changelog">Changelog</a></li>
     <li><a href="#knowledge">Knowledge</a></li>
     <li><a href="#captures">Captures</a></li>


### PR DESCRIPTION
## Summary

- Reorders HTML report sections (`export-html.ts`) to mirror the visualizer tab grouping from #934
- Updates section build order, TOC navigation links, and file header comment

### Previous section order
```
Summary → Health → Progress → Dependencies → Metrics → Timeline → Changelog → Knowledge → Captures → Artifacts → Planning
```

### New section order
```
Summary → Progress → Timeline → Dependencies → Metrics → Health → Changelog → Knowledge → Captures → Artifacts → Planning
```

### Grouping rationale
| Group | Sections |
|-------|----------|
| Core project views | Summary, Progress, Timeline, Dependencies |
| Analytics/monitoring | Metrics, Health |
| Content | Changelog, Knowledge, Captures |
| Report-only | Artifacts, Planning |

## Files changed
- `src/resources/extensions/gsd/export-html.ts` — reordered `sections` array, TOC `<nav>` links, and header JSDoc comment

## Test plan
- [x] `npm run build` — compiles cleanly
- [ ] Manual: run `/gsd export html` and verify sections appear in new order
- [ ] Manual: verify TOC navigation links jump to correct sections
- [ ] Manual: print to PDF and verify page order

## Related
- #934 — visualizer tab reorder (this PR mirrors that order)