### PR TITLE
refactor: group GSD commands into /run, /plan, and /gsd namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,12 +119,12 @@ Research → Plan → Execute (per task) → Complete → Reassess Roadmap → N
 
 **Research** scouts the codebase and relevant docs. **Plan** decomposes the slice into tasks with must-haves (mechanically verifiable outcomes). **Execute** runs each task in a fresh context window with only the relevant files pre-loaded. **Complete** writes the summary, UAT script, marks the roadmap, and commits. **Reassess** checks if the roadmap still makes sense given what was learned. **Validate Milestone** runs a reconciliation gate after all slices complete — comparing roadmap success criteria against actual results before sealing the milestone.
 
-### `/gsd auto` — The Main Event
+### `/run` — The Main Event
 
 This is what makes GSD different. Run it, walk away, come back to built software.
 
 ```
-/gsd auto
+/run
 ```
 
 Auto mode is a state machine driven by files on disk. It reads `.gsd/STATE.md`, determines the next unit of work, creates a fresh agent session, injects a focused prompt with all relevant context pre-inlined, and lets the LLM execute. When the LLM finishes, auto mode reads disk state again and dispatches the next unit.
@@ -137,7 +137,7 @@ Auto mode is a state machine driven by files on disk. It reads `.gsd/STATE.md`, 
 
 3. **Git worktree isolation** — Each milestone runs in its own git worktree with a `milestone/<MID>` branch. All slice work commits sequentially — no branch switching, no merge conflicts. When the milestone completes, it's squash-merged to main as one clean commit.
 
-4. **Crash recovery** — A lock file tracks the current unit. If the session dies, the next `/gsd auto` reads the surviving session file, synthesizes a recovery briefing from every tool call that made it to disk, and resumes with full context.
+4. **Crash recovery** — A lock file tracks the current unit. If the session dies, the next `/run` reads the surviving session file, synthesizes a recovery briefing from every tool call that made it to disk, and resumes with full context.
 
 5. **Stuck detection** — If the same unit dispatches twice (the LLM didn't produce the expected artifact), it retries once with a deep diagnostic. If it fails again, auto mode stops with the exact file it expected.
 
@@ -147,9 +147,9 @@ Auto mode is a state machine driven by files on disk. It reads `.gsd/STATE.md`, 
 
 8. **Adaptive replanning** — After each slice completes, the roadmap is reassessed. If the work revealed new information that changes the plan, slices are reordered, added, or removed before continuing.
 
-9. **Escape hatch** — Press Escape to pause. The conversation is preserved. Interact with the agent, inspect what happened, or just `/gsd auto` to resume from disk state.
+9. **Escape hatch** — Press Escape to pause. The conversation is preserved. Interact with the agent, inspect what happened, or just `/run` to resume from disk state.
 
-### `/gsd` and `/gsd next` — Step Mode
+### `/gsd` and `/run next` — Step Mode
 
 By default, `/gsd` runs in **step mode**: the same state machine as auto mode, but it pauses between units with a wizard showing what completed and what's next. You advance one step at a time, review the output, and continue when ready.
 
@@ -158,7 +158,7 @@ By default, `/gsd` runs in **step mode**: the same state machine as auto mode, b
 - **Roadmap exists, slices pending** → Plan the next slice, execute one task, or switch to auto.
 - **Mid-task** → Resume from where you left off.
 
-`/gsd next` is an explicit alias for step mode. You can switch from step → auto mid-session via the wizard.
+`/run next` is an explicit alias for step mode. You can switch from step → auto mid-session via the wizard.
 
 Step mode is the on-ramp. Auto mode is the highway.
 
@@ -201,7 +201,7 @@ GSD opens an interactive agent session. From there, you have two ways to work:
 
 **`/gsd` — step mode.** Type `/gsd` and GSD executes one unit of work at a time, pausing between each with a wizard showing what completed and what's next. Same state machine as auto mode, but you stay in the loop. No project yet? It starts the discussion flow. Roadmap exists? It plans or executes the next step.
 
-**`/gsd auto` — autonomous mode.** Type `/gsd auto` and walk away. GSD researches, plans, executes, verifies, commits, and advances through every slice until the milestone is complete. Fresh context window per task. No babysitting.
+**`/run` — autonomous mode.** Type `/run` and walk away. GSD researches, plans, executes, verifies, commits, and advances through every slice until the milestone is complete. Fresh context window per task. No babysitting.
 
 ### Two terminals, one project
 
@@ -211,16 +211,16 @@ The real workflow: run auto mode in one terminal, steer from another.
 
 ```bash
 gsd
-/gsd auto
+/run
 ```
 
 **Terminal 2 — steer while it works**
 
 ```bash
 gsd
-/gsd discuss    # talk through architecture decisions
+/plan discuss   # talk through architecture decisions
 /gsd status     # check progress
-/gsd queue      # queue the next milestone
+/plan queue     # queue the next milestone
 ```
 
 Both terminals read and write the same `.gsd/` files on disk. Your decisions in terminal 2 are picked up automatically at the next phase boundary — no need to stop auto mode.
@@ -254,14 +254,14 @@ On first run, GSD launches a branded setup wizard that walks you through LLM pro
 | Command                 | What it does                                                    |
 | ----------------------- | --------------------------------------------------------------- |
 | `/gsd`                  | Step mode — executes one unit at a time, pauses between each    |
-| `/gsd next`             | Explicit step mode (same as bare `/gsd`)                        |
-| `/gsd auto`             | Autonomous mode — researches, plans, executes, commits, repeats |
-| `/gsd quick`            | Execute a quick task with GSD guarantees, skip planning overhead |
-| `/gsd stop`             | Stop auto mode gracefully                                       |
-| `/gsd steer`            | Hard-steer plan documents during execution                      |
-| `/gsd discuss`          | Discuss architecture and decisions (works alongside auto mode)  |
+| `/run next`             | Explicit step mode (same as bare `/gsd`)                        |
+| `/run`                  | Autonomous mode — researches, plans, executes, commits, repeats |
+| `/plan quick`           | Execute a quick task with GSD guarantees, skip planning overhead |
+| `/run stop`             | Stop auto mode gracefully                                       |
+| `/plan steer`           | Hard-steer plan documents during execution                      |
+| `/plan discuss`         | Discuss architecture and decisions (works alongside auto mode)  |
 | `/gsd status`           | Progress dashboard                                              |
-| `/gsd queue`            | Queue future milestones (safe during auto mode)                 |
+| `/plan queue`           | Queue future milestones (safe during auto mode)                 |
 | `/gsd prefs`            | Model selection, timeouts, budget ceiling                       |
 | `/gsd migrate`          | Migrate a v1 `.planning` directory to `.gsd` format             |
 | `/gsd help`             | Categorized command reference for all GSD subcommands           |

--- a/docs/ADR-001-branchless-worktree-architecture.md
+++ b/docs/ADR-001-branchless-worktree-architecture.md
@@ -255,7 +255,7 @@ Rebuttal: In the branchless model, there is no integration step to crash between
 
 **Concern 2: "Concurrent edits to shared root docs (PROJECT.md, DECISIONS.md) from two terminals."**
 
-Rebuttal: Valid edge case. If `/gsd queue` edits `DECISIONS.md` on `main` while auto-mode edits it in a worktree, there's a content conflict at squash-merge time. This is a standard git content conflict — no different from two developers editing the same file. Handled by normal merge resolution. Not caused by or solved by slice branches.
+Rebuttal: Valid edge case. If `/plan queue` edits `DECISIONS.md` on `main` while auto-mode edits it in a worktree, there's a content conflict at squash-merge time. This is a standard git content conflict — no different from two developers editing the same file. Handled by normal merge resolution. Not caused by or solved by slice branches.
 
 **Concern 3: "Slice→milestone merges provide continuous integration. Removing them pushes conflict discovery to the end."**
 

--- a/docs/auto-mode.md
+++ b/docs/auto-mode.md
@@ -1,6 +1,6 @@
 # Auto Mode
 
-Auto mode is GSD's autonomous execution engine. Run `/gsd auto`, walk away, come back to built software with clean git history.
+Auto mode is GSD's autonomous execution engine. Run `/run`, walk away, come back to built software with clean git history.
 
 ## How It Works
 
@@ -60,7 +60,7 @@ When your project has independent milestones, you can run them simultaneously. E
 
 ### Crash Recovery
 
-A lock file tracks the current unit. If the session dies, the next `/gsd auto` reads the surviving session file, synthesizes a recovery briefing from every tool call that made it to disk, and resumes with full context.
+A lock file tracks the current unit. If the session dies, the next `/run` reads the surviving session file, synthesizes a recovery briefing from every tool call that made it to disk, and resumes with full context.
 
 ### Rate Limit Recovery
 
@@ -108,7 +108,7 @@ After each slice completes, the roadmap is reassessed. If the work revealed new 
 ### Start
 
 ```
-/gsd auto
+/run
 ```
 
 ### Pause
@@ -118,7 +118,7 @@ Press **Escape**. The conversation is preserved. You can interact with the agent
 ### Resume
 
 ```
-/gsd auto
+/run
 ```
 
 Auto mode reads disk state and picks up where it left off.
@@ -126,7 +126,7 @@ Auto mode reads disk state and picks up where it left off.
 ### Stop
 
 ```
-/gsd stop
+/run stop
 ```
 
 Stops auto mode gracefully. Can be run from a different terminal.
@@ -134,7 +134,7 @@ Stops auto mode gracefully. Can be run from a different terminal.
 ### Steer
 
 ```
-/gsd steer
+/plan steer
 ```
 
 Hard-steer plan documents during execution without stopping the pipeline. Changes are picked up at the next phase boundary.
@@ -142,7 +142,7 @@ Hard-steer plan documents during execution without stopping the pipeline. Change
 ### Capture
 
 ```
-/gsd capture "add rate limiting to API endpoints"
+/plan capture "add rate limiting to API endpoints"
 ```
 
 Fire-and-forget thought capture. Captures are triaged automatically between tasks. See [Captures & Triage](./captures-triage.md).

--- a/docs/captures-triage.md
+++ b/docs/captures-triage.md
@@ -9,8 +9,8 @@ Captures let you fire-and-forget thoughts during auto-mode execution. Instead of
 While auto-mode is running (or any time):
 
 ```
-/gsd capture "add rate limiting to the API endpoints"
-/gsd capture "the auth flow should support OAuth, not just JWT"
+/plan capture "add rate limiting to the API endpoints"
+/plan capture "the auth flow should support OAuth, not just JWT"
 ```
 
 Captures are appended to `.gsd/CAPTURES.md` and triaged automatically between tasks.
@@ -23,7 +23,7 @@ Captures are appended to `.gsd/CAPTURES.md` and triaged automatically between ta
 capture → triage → confirm → resolve → resume
 ```
 
-1. **Capture** — `/gsd capture "thought"` appends to `.gsd/CAPTURES.md` with a timestamp and unique ID
+1. **Capture** — `/plan capture "thought"` appends to `.gsd/CAPTURES.md` with a timestamp and unique ID
 2. **Triage** — at natural seams between tasks (in `handleAgentEnd`), GSD detects pending captures and classifies them
 3. **Confirm** — the user is shown the proposed resolution and confirms or adjusts
 4. **Resolve** — the resolution is applied (task injection, replan trigger, deferral, etc.)
@@ -55,7 +55,7 @@ The LLM classifies each capture and proposes a resolution. Plan-modifying resolu
 Trigger triage manually at any time:
 
 ```
-/gsd triage
+/plan triage
 ```
 
 This is useful when you've accumulated several captures and want to process them before the next natural seam.
@@ -78,5 +78,5 @@ Captures always resolve to the **original project root's** `.gsd/CAPTURES.md`, n
 
 | Command | Description |
 |---------|-------------|
-| `/gsd capture "text"` | Capture a thought (quotes optional for single words) |
-| `/gsd triage` | Manually trigger triage of pending captures |
+| `/plan capture "text"` | Capture a thought (quotes optional for single words) |
+| `/plan triage` | Manually trigger triage of pending captures |

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,24 +1,46 @@
 # Commands Reference
 
-## Session Commands
+## Execution Commands (`/run`)
 
 | Command | Description |
 |---------|-------------|
 | `/gsd` | Step mode — execute one unit at a time, pause between each |
-| `/gsd next` | Explicit step mode (same as `/gsd`) |
-| `/gsd auto` | Autonomous mode — research, plan, execute, commit, repeat |
-| `/gsd quick` | Execute a quick task with GSD guarantees (atomic commits, state tracking) without full planning overhead |
-| `/gsd stop` | Stop auto mode gracefully |
-| `/gsd steer` | Hard-steer plan documents during execution |
-| `/gsd discuss` | Discuss architecture and decisions (works alongside auto mode) |
+| `/run next` | Explicit step mode (same as `/gsd`) |
+| `/run` | Autonomous mode — research, plan, execute, commit, repeat |
+| `/run stop` | Stop auto mode gracefully |
+| `/run pause` | Pause auto mode (same as Escape) |
+| `/run dispatch` | Force dispatch a specific pipeline phase |
+| `/run undo` | Undo the last completed unit |
+| `/run skip` | Skip the current unit and advance |
+| `/run parallel start` | Analyze eligibility, confirm, and start workers |
+| `/run parallel status` | Show all workers with state, progress, and cost |
+| `/run parallel stop [MID]` | Stop all workers or a specific milestone's worker |
+| `/run parallel pause [MID]` | Pause all workers or a specific one |
+| `/run parallel resume [MID]` | Resume paused workers |
+| `/run parallel merge [MID]` | Merge completed milestones back to main |
+
+## Planning Commands (`/plan`)
+
+| Command | Description |
+|---------|-------------|
+| `/plan` | Start or resume a discussion flow |
+| `/plan discuss` | Discuss architecture and decisions (works alongside auto mode) |
+| `/plan queue` | Queue and reorder future milestones (safe during auto mode) |
+| `/plan quick` | Execute a quick task with GSD guarantees (atomic commits, state tracking) without full planning overhead |
+| `/plan capture` | Fire-and-forget thought capture (works during auto mode) |
+| `/plan triage` | Manually trigger triage of pending captures |
+| `/plan steer` | Hard-steer plan documents during execution |
+| `/plan milestone` | Create a new milestone |
+| `/plan knowledge` | Add persistent project knowledge (rule, pattern, or lesson) |
+
+## Project Commands (`/gsd`)
+
+| Command | Description |
+|---------|-------------|
 | `/gsd status` | Progress dashboard |
-| `/gsd queue` | Queue and reorder future milestones (safe during auto mode) |
-| `/gsd capture` | Fire-and-forget thought capture (works during auto mode) |
-| `/gsd triage` | Manually trigger triage of pending captures |
 | `/gsd forensics` | Post-mortem investigation of auto-mode failures — structured root-cause analysis with log inspection |
 | `/gsd cleanup` | Clean up GSD state files and stale worktrees |
 | `/gsd visualize` | Open workflow visualizer (progress, deps, metrics, timeline) |
-| `/gsd knowledge` | Add persistent project knowledge (rule, pattern, or lesson) |
 | `/gsd help` | Categorized command reference with descriptions for all GSD subcommands |
 
 ## Configuration & Diagnostics
@@ -36,18 +58,18 @@
 | `/gsd run-hook` | Manually trigger a specific hook |
 | `/gsd migrate` | Migrate a v1 `.planning` directory to `.gsd` format |
 
-## Parallel Orchestration
+See [Parallel Orchestration](./parallel-orchestration.md) for full documentation.
+
+## Remote Questions
 
 | Command | Description |
 |---------|-------------|
-| `/gsd parallel start` | Analyze eligibility, confirm, and start workers |
-| `/gsd parallel status` | Show all workers with state, progress, and cost |
-| `/gsd parallel stop [MID]` | Stop all workers or a specific milestone's worker |
-| `/gsd parallel pause [MID]` | Pause all workers or a specific one |
-| `/gsd parallel resume [MID]` | Resume paused workers |
-| `/gsd parallel merge [MID]` | Merge completed milestones back to main |
-
-See [Parallel Orchestration](./parallel-orchestration.md) for full documentation.
+| `/gsd remote` | Show remote questions menu and current status |
+| `/gsd remote slack` | Set up Slack integration |
+| `/gsd remote discord` | Set up Discord integration |
+| `/gsd remote telegram` | Set up Telegram integration |
+| `/gsd remote status` | Show current configuration and last prompt status |
+| `/gsd remote disconnect` | Remove remote questions configuration |
 
 ## Git Commands
 
@@ -138,7 +160,7 @@ echo "Build a CLI tool" | gsd headless new-milestone --context -
 
 **Exit codes:** `0` = complete, `1` = error or timeout, `2` = blocked.
 
-Any `/gsd` subcommand works as a positional argument — `gsd headless status`, `gsd headless doctor`, `gsd headless dispatch execute`, etc.
+Any subcommand works as a positional argument — `gsd headless status`, `gsd headless doctor`, `gsd headless dispatch execute`, etc.
 
 ## MCP Server Mode
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -374,7 +374,7 @@ custom_instructions:
   - "Prefer functional patterns over classes"
 ```
 
-For project-specific knowledge (patterns, gotchas, lessons learned), use `.gsd/KNOWLEDGE.md` instead — it's injected into every agent prompt automatically. Add entries with `/gsd knowledge rule|pattern|lesson <description>`.
+For project-specific knowledge (patterns, gotchas, lessons learned), use `.gsd/KNOWLEDGE.md` instead — it's injected into every agent prompt automatically. Add entries with `/plan knowledge rule|pattern|lesson <description>`.
 
 ### `dynamic_routing`
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -64,12 +64,12 @@ Type `/gsd` inside a session. GSD executes one unit of work at a time, pausing b
 
 Step mode is the on-ramp. You stay in the loop, reviewing output between each step.
 
-### Auto Mode — `/gsd auto`
+### Auto Mode — `/run`
 
-Type `/gsd auto` and walk away. GSD autonomously researches, plans, executes, verifies, commits, and advances through every slice until the milestone is complete.
+Type `/run` and walk away. GSD autonomously researches, plans, executes, verifies, commits, and advances through every slice until the milestone is complete.
 
 ```
-/gsd auto
+/run
 ```
 
 See [Auto Mode](./auto-mode.md) for full details.
@@ -82,16 +82,16 @@ The recommended workflow: auto mode in one terminal, steering from another.
 
 ```bash
 gsd
-/gsd auto
+/run
 ```
 
 **Terminal 2 — steer while it works:**
 
 ```bash
 gsd
-/gsd discuss    # talk through architecture decisions
+/plan discuss   # talk through architecture decisions
 /gsd status     # check progress
-/gsd queue      # queue the next milestone
+/plan queue     # queue the next milestone
 ```
 
 Both terminals read and write the same `.gsd/` files. Decisions in terminal 2 are picked up at the next phase boundary automatically.

--- a/docs/parallel-orchestration.md
+++ b/docs/parallel-orchestration.md
@@ -19,7 +19,7 @@ parallel:
 2. Start parallel execution:
 
 ```
-/gsd parallel start
+/run parallel start
 ```
 
 GSD scans your milestones, checks dependencies and file overlap, shows an eligibility report, and spawns workers for eligible milestones.
@@ -27,13 +27,13 @@ GSD scans your milestones, checks dependencies and file overlap, shows an eligib
 3. Monitor progress:
 
 ```
-/gsd parallel status
+/run parallel status
 ```
 
 4. Stop when done:
 
 ```
-/gsd parallel stop
+/run parallel stop
 ```
 
 ## How It Works
@@ -143,26 +143,26 @@ parallel:
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `enabled` | boolean | `false` | Master toggle. Must be `true` for `/gsd parallel` commands to work. |
+| `enabled` | boolean | `false` | Master toggle. Must be `true` for `/run parallel` commands to work. |
 | `max_workers` | number (1-4) | `2` | Maximum concurrent worker processes. Higher values use more memory and API budget. |
 | `budget_ceiling` | number | none | Aggregate cost ceiling in USD across all workers. When reached, no new units are dispatched. |
 | `merge_strategy` | `"per-slice"` or `"per-milestone"` | `"per-milestone"` | When worktree changes merge back to main. Per-milestone waits for the full milestone to complete. |
-| `auto_merge` | `"auto"`, `"confirm"`, `"manual"` | `"confirm"` | How merge-back is handled. `confirm` prompts before merging. `manual` requires explicit `/gsd parallel merge`. |
+| `auto_merge` | `"auto"`, `"confirm"`, `"manual"` | `"confirm"` | How merge-back is handled. `confirm` prompts before merging. `manual` requires explicit `/run parallel merge`. |
 
 ## Commands
 
 | Command | Description |
 |---------|-------------|
-| `/gsd parallel start` | Analyze eligibility, confirm, and start workers |
-| `/gsd parallel status` | Show all workers with state, units completed, and cost |
-| `/gsd parallel stop` | Stop all workers (sends SIGTERM) |
-| `/gsd parallel stop M002` | Stop a specific milestone's worker |
-| `/gsd parallel pause` | Pause all workers (finish current unit, then wait) |
-| `/gsd parallel pause M002` | Pause a specific worker |
-| `/gsd parallel resume` | Resume all paused workers |
-| `/gsd parallel resume M002` | Resume a specific worker |
-| `/gsd parallel merge` | Merge all completed milestones back to main |
-| `/gsd parallel merge M002` | Merge a specific milestone back to main |
+| `/run parallel start` | Analyze eligibility, confirm, and start workers |
+| `/run parallel status` | Show all workers with state, units completed, and cost |
+| `/run parallel stop` | Stop all workers (sends SIGTERM) |
+| `/run parallel stop M002` | Stop a specific milestone's worker |
+| `/run parallel pause` | Pause all workers (finish current unit, then wait) |
+| `/run parallel pause M002` | Pause a specific worker |
+| `/run parallel resume` | Resume all paused workers |
+| `/run parallel resume M002` | Resume a specific worker |
+| `/run parallel merge` | Merge all completed milestones back to main |
+| `/run parallel merge M002` | Merge a specific milestone back to main |
 
 ## Signal Lifecycle
 
@@ -201,12 +201,12 @@ When milestones complete, their worktree changes need to merge back to main.
 ### Conflict Handling
 
 1. `.gsd/` state files (STATE.md, metrics.json, etc.) — **auto-resolved** by accepting the milestone branch version
-2. Code conflicts — **stop and report**. The merge halts, showing which files conflict. Resolve manually and retry with `/gsd parallel merge <MID>`.
+2. Code conflicts — **stop and report**. The merge halts, showing which files conflict. Resolve manually and retry with `/run parallel merge <MID>`.
 
 ### Example
 
 ```
-/gsd parallel merge
+/run parallel merge
 
 # Merge Results
 
@@ -214,7 +214,7 @@ When milestones complete, their worktree changes need to merge back to main.
 - **M003** — CONFLICT (2 file(s)):
   - `src/types.ts`
   - `src/middleware.ts`
-  Resolve conflicts manually and run `/gsd parallel merge M003` to retry.
+  Resolve conflicts manually and run `/run parallel merge M003` to retry.
 ```
 
 ## Budget Management
@@ -288,20 +288,20 @@ Set `parallel.enabled: true` in your preferences file.
 
 ### "No milestones are eligible for parallel execution"
 
-All milestones are either complete or blocked by dependencies. Check `/gsd queue` to see milestone status and dependency chains.
+All milestones are either complete or blocked by dependencies. Check `/plan queue` to see milestone status and dependency chains.
 
 ### Worker crashed — how to recover
 
 1. Run `/gsd doctor --fix` to clean up stale sessions
-2. Run `/gsd parallel status` to see current state
-3. Re-run `/gsd parallel start` to spawn new workers for remaining milestones
+2. Run `/run parallel status` to see current state
+3. Re-run `/run parallel start` to spawn new workers for remaining milestones
 
 ### Merge conflicts after parallel completion
 
-1. Run `/gsd parallel merge` to see which milestones have conflicts
+1. Run `/run parallel merge` to see which milestones have conflicts
 2. Resolve conflicts in the worktree at `.gsd/worktrees/<MID>/`
-3. Retry with `/gsd parallel merge <MID>`
+3. Retry with `/run parallel merge <MID>`
 
 ### Workers seem stuck
 
-Check if budget ceiling was reached: `/gsd parallel status` shows per-worker costs. Increase `parallel.budget_ceiling` or remove it to continue.
+Check if budget ceiling was reached: `/run parallel status` shows per-worker costs. Increase `parallel.budget_ceiling` or remove it to continue.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -25,13 +25,13 @@ It checks:
 - Stale cache after a crash — the in-memory file listing doesn't reflect new artifacts
 - The LLM didn't produce the expected artifact file
 
-**Fix:** Run `/gsd doctor` to repair state, then resume with `/gsd auto`. If the issue persists, check that the expected artifact file exists on disk.
+**Fix:** Run `/gsd doctor` to repair state, then resume with `/run`. If the issue persists, check that the expected artifact file exists on disk.
 
 ### Auto mode stops with "Loop detected"
 
 **Cause:** A unit failed to produce its expected artifact twice in a row.
 
-**Fix:** Check the task plan for clarity. If the plan is ambiguous, refine it manually, then `/gsd auto` to resume.
+**Fix:** Check the task plan for clarity. If the plan is ambiguous, refine it manually, then `/run` to resume.
 
 ### Wrong files in worktree
 
@@ -66,7 +66,7 @@ models:
 
 **Symptoms:** Auto mode pauses with "Budget ceiling reached."
 
-**Fix:** Increase `budget_ceiling` in preferences, or switch to `budget` token profile to reduce per-unit cost, then resume with `/gsd auto`.
+**Fix:** Increase `budget_ceiling` in preferences, or switch to `budget` token profile to reduce per-unit cost, then resume with `/run`.
 
 ### Stale lock file
 
@@ -89,7 +89,7 @@ rm .gsd/auto.lock
 rm .gsd/completed-units.json
 ```
 
-Then `/gsd auto` to restart from current disk state.
+Then `/run` to restart from current disk state.
 
 ### Reset routing history
 

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -1,7 +1,7 @@
 /**
  * Headless Orchestrator — `gsd headless`
  *
- * Runs any /gsd subcommand without a TUI by spawning a child process in
+ * Runs any GSD subcommand without a TUI by spawning a child process in
  * RPC mode, auto-responding to extension UI requests, and streaming
  * progress to stderr.
  *
@@ -631,12 +631,24 @@ async function runHeadlessOnce(options: HeadlessOptions, restartCount: number): 
     }
   })
 
+  // Map headless commands to the grouped top-level command syntax
+  const EXECUTION_COMMANDS = new Set(['auto', 'next', 'stop', 'pause', 'dispatch', 'undo', 'skip', 'parallel'])
+  const PLANNING_COMMANDS = new Set(['discuss', 'queue', 'quick', 'capture', 'triage', 'steer', 'new-milestone', 'knowledge'])
+
+  function mapCommand(cmd: string, args: string[]): string {
+    const argStr = args.length > 0 ? ' ' + args.join(' ') : ''
+    if (EXECUTION_COMMANDS.has(cmd)) return `/run ${cmd}${argStr}`
+    if (PLANNING_COMMANDS.has(cmd)) return `/plan ${cmd}${argStr}`
+    return `/gsd ${cmd}${argStr}`
+  }
+
+  const command = mapCommand(options.command, options.commandArgs)
+
   if (!options.json) {
-    process.stderr.write(`[headless] Running /gsd ${options.command}${options.commandArgs.length > 0 ? ' ' + options.commandArgs.join(' ') : ''}...\n`)
+    process.stderr.write(`[headless] Running ${command}...\n`)
   }
 
   // Send the command
-  const command = `/gsd ${options.command}${options.commandArgs.length > 0 ? ' ' + options.commandArgs.join(' ') : ''}`
   try {
     await client.prompt(command)
   } catch (err) {
@@ -649,7 +661,7 @@ async function runHeadlessOnce(options: HeadlessOptions, restartCount: number): 
     await completionPromise
   }
 
-  // Auto-mode chaining: if --auto and milestone creation succeeded, send /gsd auto
+  // Auto-mode chaining: if --auto and milestone creation succeeded, send /run
   if (isNewMilestone && options.auto && milestoneReady && !blocked && exitCode === 0) {
     if (!options.json) {
       process.stderr.write('[headless] Milestone ready — chaining into auto-mode...\n')
@@ -664,7 +676,7 @@ async function runHeadlessOnce(options: HeadlessOptions, restartCount: number): 
     })
 
     try {
-      await client.prompt('/gsd auto')
+      await client.prompt('/run')
     } catch (err) {
       process.stderr.write(`[headless] Error: Failed to start auto-mode: ${err instanceof Error ? err.message : String(err)}\n`)
       exitCode = 1

--- a/src/help-text.ts
+++ b/src/help-text.ts
@@ -35,7 +35,7 @@ const SUBCOMMAND_HELP: Record<string, string> = {
   headless: [
     'Usage: gsd headless [flags] [command] [args...]',
     '',
-    'Run /gsd commands without the TUI. Default command: auto',
+    'Run GSD commands without the TUI. Default command: auto',
     '',
     'Flags:',
     '  --timeout N          Overall timeout in ms (default: 300000)',
@@ -57,7 +57,7 @@ const SUBCOMMAND_HELP: Record<string, string> = {
     '  --verbose            Show tool calls in progress output',
     '',
     'Examples:',
-    '  gsd headless                                    Run /gsd auto',
+    '  gsd headless                                    Run /run (auto-mode)',
     '  gsd headless next                               Run one unit',
     '  gsd headless --json status                      Machine-readable status',
     '  gsd headless --timeout 60000                    With 1-minute timeout',
@@ -88,7 +88,7 @@ export function printHelp(version: string): void {
   process.stdout.write('  config                   Re-run the setup wizard\n')
   process.stdout.write('  update                   Update GSD to the latest version\n')
   process.stdout.write('  sessions                 List and resume a past session\n')
-  process.stdout.write('  headless [cmd] [args]    Run /gsd commands without TUI (default: auto)\n')
+  process.stdout.write('  headless [cmd] [args]    Run GSD commands without TUI (default: auto)\n')
   process.stdout.write('\nRun gsd <subcommand> --help for subcommand-specific help.\n')
 }
 

--- a/src/resources/GSD-WORKFLOW.md
+++ b/src/resources/GSD-WORKFLOW.md
@@ -661,6 +661,6 @@ This methodology doc is generic. Project-specific guidance belongs in the milest
 
 If you sense context pressure (many files read, long execution, lots of tool output):
 
-1. **If mid-task:** Write `continue.md` with exact resume state. Tell the user: "Context is getting full. I've saved progress to continue.md. Start a new session and run `/gsd` to pick up where you left off, or `/gsd auto` to resume in auto-execution mode."
+1. **If mid-task:** Write `continue.md` with exact resume state. Tell the user: "Context is getting full. I've saved progress to continue.md. Start a new session and run `/gsd` to pick up where you left off, or `/run` to resume in auto-execution mode."
 2. **If between tasks:** Just update `STATE.md` with the next action. No continue file needed — the next session will read STATE.md and pick up the next task cleanly.
 3. **Don't fight it.** The whole system is designed for this. A fresh session with the right files loaded is better than a stale session with degraded reasoning.

--- a/src/resources/extensions/gsd/auto-direct-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-direct-dispatch.ts
@@ -1,5 +1,5 @@
 /**
- * Direct phase dispatch — handles manual /gsd dispatch commands.
+ * Direct phase dispatch — handles manual /run dispatch commands.
  * Resolves phase name → unit type + prompt, creates a session, and sends the message.
  */
 
@@ -67,7 +67,7 @@ export async function dispatchDirectPhase(
         const requireDiscussion = loadEffectiveGSDPreferences()?.preferences?.phases?.require_slice_discussion;
         if (requireDiscussion && !sliceContextFile) {
           ctx.ui.notify(
-            `Slice ${sid} requires discussion before planning. Run /gsd discuss to discuss this slice, then /gsd auto to resume.`,
+            `Slice ${sid} requires discussion before planning. Run /plan discuss to discuss this slice, then /run to resume.`,
             "info",
           );
           await pauseAuto(ctx, pi);

--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -144,7 +144,7 @@ const DISPATCH_RULES: DispatchRule[] = [
       if (state.phase !== "needs-discussion") return null;
       return {
         action: "stop",
-        reason: `${mid}: ${midTitle} has draft context from a prior discussion — needs its own discussion before planning.\nRun /gsd to discuss.`,
+        reason: `${mid}: ${midTitle} has draft context from a prior discussion — needs its own discussion before planning.\nRun /plan discuss to discuss.`,
         level: "warning",
       };
     },
@@ -158,7 +158,7 @@ const DISPATCH_RULES: DispatchRule[] = [
       if (hasContext) return null; // fall through to next rule
       return {
         action: "stop",
-        reason: "No context or roadmap yet. Run /gsd to discuss first.",
+        reason: "No context or roadmap yet. Run /plan discuss to discuss first.",
         level: "warning",
       };
     },

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -477,7 +477,7 @@ export async function stopAuto(ctx?: ExtensionContext, pi?: ExtensionAPI, reason
   deregisterSigtermHandler();
 
   // ── Auto-worktree: exit worktree and reset basePath on stop ──
-  // Preserve the milestone branch so the next /gsd auto can re-enter
+  // Preserve the milestone branch so the next /run can re-enter
   // where it left off. The branch is only deleted during milestone
   // completion (mergeMilestoneToMain) after the work has been squash-merged.
   if (currentMilestoneId && isInAutoWorktree(basePath)) {
@@ -581,7 +581,7 @@ export async function stopAuto(ctx?: ExtensionContext, pi?: ExtensionAPI, reason
 
 /**
  * Pause auto-mode without destroying state. Context is preserved.
- * The user can interact with the agent, then `/gsd auto` resumes
+ * The user can interact with the agent, then `/run` resumes
  * from disk state. Called when the user presses Escape during auto-mode.
  */
 export async function pauseAuto(ctx?: ExtensionContext, _pi?: ExtensionAPI): Promise<void> {
@@ -607,7 +607,7 @@ export async function pauseAuto(ctx?: ExtensionContext, _pi?: ExtensionAPI): Pro
   ctx?.ui.setStatus("gsd-auto", "paused");
   ctx?.ui.setWidget("gsd-progress", undefined);
   ctx?.ui.setFooter(undefined);
-  const resumeCmd = stepMode ? "/gsd next" : "/gsd auto";
+  const resumeCmd = stepMode ? "/run next" : "/run";
   ctx?.ui.notify(
     `${stepMode ? "Step" : "Auto"}-mode paused (Escape). Type to interact, or ${resumeCmd} to resume.`,
     "info",
@@ -907,7 +907,7 @@ export async function startAuto(
           state = postState;
         } else {
           ctx.ui.notify(
-            "Discussion completed but no milestone context was written. Run /gsd to try the discussion again, or /gsd auto after creating the milestone manually.",
+            "Discussion completed but no milestone context was written. Run /gsd to try the discussion again, or /run after creating the milestone manually.",
             "warning",
           );
           return;
@@ -1953,7 +1953,7 @@ async function showStepWizard(
         description: "Open the dashboard.",
       },
     ],
-    notYetMessage: "Run /gsd next when ready to continue.",
+    notYetMessage: "Run /run next when ready to continue.",
   });
 
   if (choice === "continue") {
@@ -2018,7 +2018,7 @@ async function dispatchNextUnit(
   if (!active || !cmdCtx) {
     debugLog(`dispatchNextUnit early return — active=${active}, cmdCtx=${!!cmdCtx}`);
     if (active && !cmdCtx) {
-      ctx.ui.notify("Auto-mode session expired. Run /gsd auto to restart.", "info");
+      ctx.ui.notify("Auto-mode session expired. Run /run to restart.", "info");
     }
     return;
   }
@@ -2104,7 +2104,7 @@ async function dispatchNextUnit(
     // Hint: visualizer available after milestone transition
     const vizPrefs = loadEffectiveGSDPreferences()?.preferences;
     if (vizPrefs?.auto_visualize) {
-      ctx.ui.notify("Run /gsd visualize to see progress overview.", "info");
+      ctx.ui.notify("Run /gsd visualize to see progress overview.", "info");  // visualize stays under /gsd
     }
     // Auto-generate HTML report snapshot on milestone completion (default: on, disable with auto_report: false)
     if (vizPrefs?.auto_report !== false) {
@@ -2259,7 +2259,7 @@ async function dispatchNextUnit(
       // Milestones exist but are dependency-blocked
       const blockerMsg = `Blocked: ${state.blockers.join(", ")}`;
       await stopAuto(ctx, pi, blockerMsg);
-      ctx.ui.notify(`${blockerMsg}. Fix and run /gsd auto.`, "warning");
+      ctx.ui.notify(`${blockerMsg}. Fix and run /run.`, "warning");
       sendDesktopNotification("GSD", blockerMsg, "error", "attention");
     } else {
       // Milestones with remaining work exist but none became active — unexpected
@@ -2378,7 +2378,7 @@ async function dispatchNextUnit(
     }
     const blockerMsg = `Blocked: ${state.blockers.join(", ")}`;
     await stopAuto(ctx, pi, blockerMsg);
-    ctx.ui.notify(`${blockerMsg}. Fix and run /gsd auto.`, "warning");
+    ctx.ui.notify(`${blockerMsg}. Fix and run /run.`, "warning");
     sendDesktopNotification("GSD", blockerMsg, "error", "attention");
     return;
   }
@@ -2408,7 +2408,7 @@ async function dispatchNextUnit(
         return;
       }
       if (budgetEnforcementAction === "pause") {
-        ctx.ui.notify(`${msg} Pausing auto-mode — /gsd auto to override and continue.`, "warning");
+        ctx.ui.notify(`${msg} Pausing auto-mode — /run to override and continue.`, "warning");
         sendDesktopNotification("GSD", msg, "warning", "budget");
         await pauseAuto(ctx, pi);
         return;
@@ -2440,7 +2440,7 @@ async function dispatchNextUnit(
     const contextUsage = cmdCtx.getContextUsage();
     if (contextUsage && contextUsage.percent !== null && contextUsage.percent >= contextThreshold) {
       const msg = `Context window at ${contextUsage.percent}% (threshold: ${contextThreshold}%). Pausing to prevent truncated output.`;
-      ctx.ui.notify(`${msg} Run /gsd auto to continue (will start fresh session).`, "warning");
+      ctx.ui.notify(`${msg} Run /run to continue (will start fresh session).`, "warning");
       sendDesktopNotification("GSD", `Context ${contextUsage.percent}% — paused`, "warning", "attention");
       await pauseAuto(ctx, pi);
       return;

--- a/src/resources/extensions/gsd/commands.ts
+++ b/src/resources/extensions/gsd/commands.ts
@@ -75,29 +75,25 @@ function projectRoot(): string {
   return resolveProjectRoot(process.cwd());
 }
 
-export function registerGSDCommand(pi: ExtensionAPI): void {
+export function registerAllCommands(pi: ExtensionAPI): void {
+  // ─── Subcommands that moved to /run (backward compat with deprecation hint) ──
+  const movedToRun = new Set(["auto", "next", "stop", "pause", "dispatch", "undo", "skip", "parallel"]);
+  // ─── Subcommands that moved to /plan (backward compat with deprecation hint) ──
+  const movedToPlan = new Set(["discuss", "queue", "quick", "capture", "triage", "steer", "knowledge", "new-milestone"]);
+
+  // ═══════════════════════════════════════════════════════════════════════════════
+  // /gsd — visibility, system, config, maintenance
+  // ═══════════════════════════════════════════════════════════════════════════════
   pi.registerCommand("gsd", {
-    description: "GSD — Get Shit Done: /gsd help|next|auto|stop|pause|status|visualize|queue|quick|capture|triage|dispatch|history|undo|skip|export|cleanup|mode|prefs|config|hooks|run-hook|skill-health|doctor|forensics|migrate|remote|steer|knowledge|new-milestone|parallel",
+    description: "GSD — visibility & system: /gsd status|history|visualize|doctor|prefs|config|export|...",
     getArgumentCompletions: (prefix: string) => {
       const subcommands = [
         { cmd: "help", desc: "Categorized command reference with descriptions" },
-        { cmd: "next", desc: "Explicit step mode (same as /gsd)" },
-        { cmd: "auto", desc: "Autonomous mode — research, plan, execute, commit, repeat" },
-        { cmd: "stop", desc: "Stop auto mode gracefully" },
-        { cmd: "pause", desc: "Pause auto-mode (preserves state, /gsd auto to resume)" },
         { cmd: "status", desc: "Progress dashboard" },
         { cmd: "visualize", desc: "Open workflow visualizer (progress, deps, metrics, timeline)" },
-        { cmd: "queue", desc: "Queue and reorder future milestones" },
-        { cmd: "quick", desc: "Execute a quick task without full planning overhead" },
-        { cmd: "discuss", desc: "Discuss architecture and decisions" },
-        { cmd: "capture", desc: "Fire-and-forget thought capture" },
-        { cmd: "triage", desc: "Manually trigger triage of pending captures" },
-        { cmd: "dispatch", desc: "Dispatch a specific phase directly" },
         { cmd: "history", desc: "View execution history" },
-        { cmd: "undo", desc: "Revert last completed unit" },
-        { cmd: "skip", desc: "Prevent a unit from auto-mode dispatch" },
+        { cmd: "forensics", desc: "Examine execution logs" },
         { cmd: "export", desc: "Export milestone/slice results" },
-        { cmd: "cleanup", desc: "Remove merged branches or snapshots" },
         { cmd: "mode", desc: "Switch workflow mode (solo/team)" },
         { cmd: "prefs", desc: "Manage preferences (model selection, timeouts, etc.)" },
         { cmd: "config", desc: "Set API keys for external tools" },
@@ -105,32 +101,21 @@ export function registerGSDCommand(pi: ExtensionAPI): void {
         { cmd: "run-hook", desc: "Manually trigger a specific hook" },
         { cmd: "skill-health", desc: "Skill lifecycle dashboard" },
         { cmd: "doctor", desc: "Runtime health checks with auto-fix" },
-        { cmd: "forensics", desc: "Examine execution logs" },
+        { cmd: "cleanup", desc: "Remove merged branches or snapshots" },
         { cmd: "migrate", desc: "Migrate a v1 .planning directory to .gsd format" },
         { cmd: "remote", desc: "Control remote auto-mode" },
-        { cmd: "steer", desc: "Hard-steer plan documents during execution" },
         { cmd: "inspect", desc: "Show SQLite DB diagnostics" },
-        { cmd: "knowledge", desc: "Add persistent project knowledge (rule, pattern, or lesson)" },
-        { cmd: "new-milestone", desc: "Create a milestone from a specification document (headless)" },
-        { cmd: "parallel", desc: "Parallel milestone orchestration (start, status, stop, merge)" },
       ];
       const parts = prefix.trim().split(/\s+/);
 
       if (parts.length <= 1) {
         return subcommands
           .filter((item) => item.cmd.startsWith(parts[0] ?? ""))
-          .map((item) => ({ 
-            value: item.cmd, 
-            label: item.cmd, 
-            description: item.desc 
+          .map((item) => ({
+            value: item.cmd,
+            label: item.cmd,
+            description: item.desc
           }));
-      }
-
-      if (parts[0] === "auto" && parts.length <= 2) {
-        const flagPrefix = parts[1] ?? "";
-        return ["--verbose", "--debug"]
-          .filter((f) => f.startsWith(flagPrefix))
-          .map((f) => ({ value: `auto ${f}`, label: f }));
       }
 
       if (parts[0] === "mode" && parts.length <= 2) {
@@ -138,13 +123,6 @@ export function registerGSDCommand(pi: ExtensionAPI): void {
         return ["global", "project"]
           .filter((cmd) => cmd.startsWith(subPrefix))
           .map((cmd) => ({ value: `mode ${cmd}`, label: cmd }));
-      }
-
-      if (parts[0] === "parallel" && parts.length <= 2) {
-        const subPrefix = parts[1] ?? "";
-        return ["start", "status", "stop", "pause", "resume", "merge"]
-          .filter((cmd) => cmd.startsWith(subPrefix))
-          .map((cmd) => ({ value: `parallel ${cmd}`, label: cmd }));
       }
 
       if (parts[0] === "prefs" && parts.length <= 2) {
@@ -161,22 +139,11 @@ export function registerGSDCommand(pi: ExtensionAPI): void {
           .map((cmd) => ({ value: `remote ${cmd}`, label: cmd }));
       }
 
-      if (parts[0] === "next" && parts.length <= 2) {
-        const flagPrefix = parts[1] ?? "";
-        return ["--verbose", "--dry-run"]
-          .filter((f) => f.startsWith(flagPrefix))
-          .map((f) => ({ value: `next ${f}`, label: f }));
-      }
-
       if (parts[0] === "history" && parts.length <= 2) {
         const flagPrefix = parts[1] ?? "";
         return ["--cost", "--phase", "--model", "10", "20", "50"]
           .filter((f) => f.startsWith(flagPrefix))
           .map((f) => ({ value: `history ${f}`, label: f }));
-      }
-
-      if (parts[0] === "undo" && parts.length <= 2) {
-        return [{ value: "undo --force", label: "--force" }];
       }
 
       if (parts[0] === "export" && parts.length <= 2) {
@@ -193,13 +160,6 @@ export function registerGSDCommand(pi: ExtensionAPI): void {
           .map((cmd) => ({ value: `cleanup ${cmd}`, label: cmd }));
       }
 
-      if (parts[0] === "knowledge" && parts.length <= 2) {
-        const subPrefix = parts[1] ?? "";
-        return ["rule", "pattern", "lesson"]
-          .filter((cmd) => cmd.startsWith(subPrefix))
-          .map((cmd) => ({ value: `knowledge ${cmd}`, label: cmd }));
-      }
-
       if (parts[0] === "doctor") {
         const modePrefix = parts[1] ?? "";
         const modes = ["fix", "heal", "audit"];
@@ -213,18 +173,30 @@ export function registerGSDCommand(pi: ExtensionAPI): void {
         return [];
       }
 
-      if (parts[0] === "dispatch" && parts.length <= 2) {
-        const phasePrefix = parts[1] ?? "";
-        return ["research", "plan", "execute", "complete", "reassess", "uat", "replan"]
-          .filter((cmd) => cmd.startsWith(phasePrefix))
-          .map((cmd) => ({ value: `dispatch ${cmd}`, label: cmd }));
-      }
-
       return [];
     },
 
     async handler(args: string, ctx: ExtensionCommandContext) {
       const trimmed = (typeof args === "string" ? args : "").trim();
+      const firstWord = trimmed.split(/\s+/)[0] ?? "";
+
+      // ── Deprecation shims: commands that moved to /run ──────────────
+      if (movedToRun.has(firstWord)) {
+        ctx.ui.notify(`Hint: /gsd ${firstWord} is now /run ${firstWord} (or just /run)`, "info");
+        // Fall through — dispatch via the /run handler for backward compat
+        await runHandler(trimmed, ctx, pi);
+        return;
+      }
+
+      // ── Deprecation shims: commands that moved to /plan ─────────────
+      if (movedToPlan.has(firstWord)) {
+        const planCmd = firstWord === "new-milestone" ? "milestone" : firstWord;
+        ctx.ui.notify(`Hint: /gsd ${firstWord} is now /plan ${planCmd}`, "info");
+        // Map new-milestone → milestone for /plan handler
+        const planArgs = firstWord === "new-milestone" ? trimmed.replace(/^new-milestone/, "milestone") : trimmed;
+        await planHandler(planArgs, ctx, pi);
+        return;
+      }
 
       if (trimmed === "help" || trimmed === "h" || trimmed === "?") {
         showHelp(ctx);
@@ -266,175 +238,13 @@ export function registerGSDCommand(pi: ExtensionAPI): void {
         return;
       }
 
-      if (trimmed === "next" || trimmed.startsWith("next ")) {
-        if (trimmed.includes("--dry-run")) {
-          await handleDryRun(ctx, projectRoot());
-          return;
-        }
-        const verboseMode = trimmed.includes("--verbose");
-        const debugMode = trimmed.includes("--debug");
-        if (debugMode) enableDebug(projectRoot());
-        await startAuto(ctx, pi, projectRoot(), verboseMode, { step: true });
-        return;
-      }
-
-      if (trimmed === "auto" || trimmed.startsWith("auto ")) {
-        const verboseMode = trimmed.includes("--verbose");
-        const debugMode = trimmed.includes("--debug");
-        if (debugMode) enableDebug(projectRoot());
-        await startAuto(ctx, pi, projectRoot(), verboseMode);
-        return;
-      }
-
-      if (trimmed === "stop") {
-        if (!isAutoActive() && !isAutoPaused()) {
-          // Not running in this process — check for a remote auto-mode session
-          const result = stopAutoRemote(projectRoot());
-          if (result.found) {
-            ctx.ui.notify(`Sent stop signal to auto-mode session (PID ${result.pid}). It will shut down gracefully.`, "info");
-          } else if (result.error) {
-            ctx.ui.notify(`Failed to stop remote auto-mode: ${result.error}`, "error");
-          } else {
-            ctx.ui.notify("Auto-mode is not running.", "info");
-          }
-          return;
-        }
-        await stopAuto(ctx, pi, "User requested stop");
-        return;
-      }
-
-      if (trimmed === "pause") {
-        if (!isAutoActive()) {
-          if (isAutoPaused()) {
-            ctx.ui.notify("Auto-mode is already paused. /gsd auto to resume.", "info");
-          } else {
-            ctx.ui.notify("Auto-mode is not running.", "info");
-          }
-          return;
-        }
-        await pauseAuto(ctx, pi);
-        return;
-      }
-
       if (trimmed === "history" || trimmed.startsWith("history ")) {
         await handleHistory(trimmed.replace(/^history\s*/, "").trim(), ctx, projectRoot());
         return;
       }
 
-      if (trimmed === "undo" || trimmed.startsWith("undo ")) {
-        await handleUndo(trimmed.replace(/^undo\s*/, "").trim(), ctx, pi, projectRoot());
-        return;
-      }
-
-      if (trimmed.startsWith("skip ")) {
-        await handleSkip(trimmed.replace(/^skip\s*/, "").trim(), ctx, projectRoot());
-        return;
-      }
-
       if (trimmed === "export" || trimmed.startsWith("export ")) {
         await handleExport(trimmed.replace(/^export\s*/, "").trim(), ctx, projectRoot());
-        return;
-      }
-
-      // ─── Parallel Orchestration ────────────────────────────────────────
-      if (trimmed.startsWith("parallel")) {
-        const parallelArgs = trimmed.slice("parallel".length).trim();
-        const [subCmd = "", ...restParts] = parallelArgs.split(/\s+/);
-        const rest = restParts.join(" ");
-
-        if (subCmd === "start" || subCmd === "") {
-          const loaded = loadEffectiveGSDPreferences();
-          const config = resolveParallelConfig(loaded?.preferences);
-          if (!config.enabled) {
-            pi.sendMessage({
-              customType: "gsd-parallel",
-              content: "Parallel mode is not enabled. Set `parallel.enabled: true` in your preferences.",
-              display: false,
-            });
-            return;
-          }
-          const candidates = await prepareParallelStart(projectRoot(), loaded?.preferences);
-          const report = formatEligibilityReport(candidates);
-          if (candidates.eligible.length === 0) {
-            pi.sendMessage({ customType: "gsd-parallel", content: report + "\n\nNo milestones are eligible for parallel execution.", display: false });
-            return;
-          }
-          const result = await startParallel(
-            projectRoot(),
-            candidates.eligible.map(e => e.milestoneId),
-            loaded?.preferences,
-          );
-          const lines = [`Parallel orchestration started.`, `Workers: ${result.started.join(", ")}`];
-          if (result.errors.length > 0) {
-            lines.push(`Errors: ${result.errors.map(e => `${e.mid}: ${e.error}`).join("; ")}`);
-          }
-          pi.sendMessage({ customType: "gsd-parallel", content: report + "\n\n" + lines.join("\n"), display: false });
-          return;
-        }
-
-        if (subCmd === "status") {
-          if (!isParallelActive()) {
-            pi.sendMessage({ customType: "gsd-parallel", content: "No parallel orchestration is currently active.", display: false });
-            return;
-          }
-          const workers = getWorkerStatuses();
-          const lines = ["# Parallel Workers\n"];
-          for (const w of workers) {
-            lines.push(`- **${w.milestoneId}** (${w.title}) — ${w.state} — ${w.completedUnits} units — $${w.cost.toFixed(2)}`);
-          }
-          const orchState = getOrchestratorState();
-          if (orchState) {
-            lines.push(`\nTotal cost: $${orchState.totalCost.toFixed(2)}`);
-          }
-          pi.sendMessage({ customType: "gsd-parallel", content: lines.join("\n"), display: false });
-          return;
-        }
-
-        if (subCmd === "stop") {
-          const mid = rest.trim() || undefined;
-          await stopParallel(projectRoot(), mid);
-          pi.sendMessage({ customType: "gsd-parallel", content: mid ? `Stopped worker for ${mid}.` : "All parallel workers stopped.", display: false });
-          return;
-        }
-
-        if (subCmd === "pause") {
-          const mid = rest.trim() || undefined;
-          pauseWorker(projectRoot(), mid);
-          pi.sendMessage({ customType: "gsd-parallel", content: mid ? `Paused worker for ${mid}.` : "All parallel workers paused.", display: false });
-          return;
-        }
-
-        if (subCmd === "resume") {
-          const mid = rest.trim() || undefined;
-          resumeWorker(projectRoot(), mid);
-          pi.sendMessage({ customType: "gsd-parallel", content: mid ? `Resumed worker for ${mid}.` : "All parallel workers resumed.", display: false });
-          return;
-        }
-
-        if (subCmd === "merge") {
-          const mid = rest.trim() || undefined;
-          if (mid) {
-            // Merge a specific milestone
-            const result = await mergeCompletedMilestone(projectRoot(), mid);
-            pi.sendMessage({ customType: "gsd-parallel", content: formatMergeResults([result]), display: false });
-            return;
-          }
-          // Merge all completed milestones
-          const workers = getWorkerStatuses();
-          if (workers.length === 0) {
-            pi.sendMessage({ customType: "gsd-parallel", content: "No parallel workers to merge.", display: false });
-            return;
-          }
-          const results = await mergeAllCompleted(projectRoot(), workers);
-          pi.sendMessage({ customType: "gsd-parallel", content: formatMergeResults(results), display: false });
-          return;
-        }
-
-        pi.sendMessage({
-          customType: "gsd-parallel",
-          content: `Unknown parallel subcommand "${subCmd}". Usage: /gsd parallel [start|status|stop|pause|resume|merge]`,
-          display: false,
-        });
         return;
       }
 
@@ -451,46 +261,6 @@ export function registerGSDCommand(pi: ExtensionAPI): void {
 
       if (trimmed === "cleanup snapshots") {
         await handleCleanupSnapshots(ctx, projectRoot());
-        return;
-      }
-
-      if (trimmed === "queue") {
-        await showQueue(ctx, pi, projectRoot());
-        return;
-      }
-
-      if (trimmed === "discuss") {
-        await showDiscuss(ctx, pi, projectRoot());
-        return;
-      }
-
-      if (trimmed === "new-milestone") {
-        const basePath = projectRoot();
-        const headlessContextPath = join(basePath, ".gsd", "runtime", "headless-context.md");
-        if (existsSync(headlessContextPath)) {
-          const seedContext = readFileSync(headlessContextPath, "utf-8");
-          try { unlinkSync(headlessContextPath); } catch { /* non-fatal */ }
-          await showHeadlessMilestoneCreation(ctx, pi, basePath, seedContext);
-        } else {
-          // No headless context — fall back to interactive smart entry
-          const { showSmartEntry } = await import("./guided-flow.js");
-          await showSmartEntry(ctx, pi, basePath);
-        }
-        return;
-      }
-
-      if (trimmed.startsWith("capture ") || trimmed === "capture") {
-        await handleCapture(trimmed.replace(/^capture\s*/, "").trim(), ctx);
-        return;
-      }
-
-      if (trimmed === "triage") {
-        await handleTriage(ctx, pi, process.cwd());
-        return;
-      }
-
-      if (trimmed === "quick" || trimmed.startsWith("quick ")) {
-        await handleQuick(trimmed.replace(/^quick\s*/, "").trim(), ctx, pi);
         return;
       }
 
@@ -531,24 +301,6 @@ Examples:
         return;
       }
 
-      if (trimmed.startsWith("steer ")) {
-        await handleSteer(trimmed.replace(/^steer\s+/, "").trim(), ctx, pi);
-        return;
-      }
-      if (trimmed === "steer") {
-        ctx.ui.notify("Usage: /gsd steer <description of change>. Example: /gsd steer Use Postgres instead of SQLite", "warning");
-        return;
-      }
-
-      if (trimmed.startsWith("knowledge ")) {
-        await handleKnowledge(trimmed.replace(/^knowledge\s+/, "").trim(), ctx);
-        return;
-      }
-      if (trimmed === "knowledge") {
-        ctx.ui.notify("Usage: /gsd knowledge <rule|pattern|lesson> <description>. Example: /gsd knowledge rule Use real DB for integration tests", "warning");
-        return;
-      }
-
       if (trimmed === "migrate" || trimmed.startsWith("migrate ")) {
         const { handleMigrate } = await import("./migrate/command.js");
         await handleMigrate(trimmed.replace(/^migrate\s*/, "").trim(), ctx, pi);
@@ -557,16 +309,6 @@ Examples:
 
       if (trimmed === "remote" || trimmed.startsWith("remote ")) {
         await handleRemote(trimmed.replace(/^remote\s*/, "").trim(), ctx, pi);
-        return;
-      }
-
-      if (trimmed === "dispatch" || trimmed.startsWith("dispatch ")) {
-        const phase = trimmed.replace(/^dispatch\s*/, "").trim();
-        if (!phase) {
-          ctx.ui.notify("Usage: /gsd dispatch <phase>  (research|plan|execute|complete|reassess|uat|replan)", "warning");
-          return;
-        }
-        await dispatchDirectPhase(ctx, pi, phase, projectRoot());
         return;
       }
 
@@ -587,49 +329,392 @@ Examples:
       );
     },
   });
+
+  // ═══════════════════════════════════════════════════════════════════════════════
+  // /run — execution hot path
+  // ═══════════════════════════════════════════════════════════════════════════════
+  pi.registerCommand("run", {
+    description: "Execute — /run [auto|next|stop|pause|dispatch|undo|skip|parallel]",
+    getArgumentCompletions: (prefix: string) => {
+      const subcommands = [
+        { cmd: "auto", desc: "Run all queued units continuously [--verbose] [--debug]" },
+        { cmd: "next", desc: "Execute next task, then pause [--verbose] [--dry-run]" },
+        { cmd: "stop", desc: "Stop auto-mode gracefully" },
+        { cmd: "pause", desc: "Pause auto-mode (preserves state)" },
+        { cmd: "dispatch", desc: "Dispatch a specific phase directly" },
+        { cmd: "undo", desc: "Revert last completed unit [--force]" },
+        { cmd: "skip", desc: "Prevent a unit from auto-mode dispatch" },
+        { cmd: "parallel", desc: "Parallel milestone orchestration (start|status|stop|pause|resume|merge)" },
+      ];
+      const parts = prefix.trim().split(/\s+/);
+
+      if (parts.length <= 1) {
+        return subcommands
+          .filter(item => item.cmd.startsWith(parts[0] ?? ""))
+          .map(item => ({ value: item.cmd, label: item.cmd, description: item.desc }));
+      }
+
+      if (parts[0] === "auto" && parts.length <= 2) {
+        return ["--verbose", "--debug"]
+          .filter(f => f.startsWith(parts[1] ?? ""))
+          .map(f => ({ value: `auto ${f}`, label: f }));
+      }
+      if (parts[0] === "next" && parts.length <= 2) {
+        return ["--verbose", "--dry-run"]
+          .filter(f => f.startsWith(parts[1] ?? ""))
+          .map(f => ({ value: `next ${f}`, label: f }));
+      }
+      if (parts[0] === "undo" && parts.length <= 2) {
+        return [{ value: "undo --force", label: "--force" }];
+      }
+      if (parts[0] === "dispatch" && parts.length <= 2) {
+        return ["research", "plan", "execute", "complete", "reassess", "uat", "replan"]
+          .filter(cmd => cmd.startsWith(parts[1] ?? ""))
+          .map(cmd => ({ value: `dispatch ${cmd}`, label: cmd }));
+      }
+      if (parts[0] === "parallel" && parts.length <= 2) {
+        return ["start", "status", "stop", "pause", "resume", "merge"]
+          .filter(cmd => cmd.startsWith(parts[1] ?? ""))
+          .map(cmd => ({ value: `parallel ${cmd}`, label: cmd }));
+      }
+
+      return [];
+    },
+    async handler(args: string, ctx: ExtensionCommandContext) {
+      await runHandler((typeof args === "string" ? args : "").trim(), ctx, pi);
+    },
+  });
+
+  // ═══════════════════════════════════════════════════════════════════════════════
+  // /plan — work structuring and planning
+  // ═══════════════════════════════════════════════════════════════════════════════
+  pi.registerCommand("plan", {
+    description: "Plan — /plan [discuss|queue|quick|capture|triage|steer|milestone|knowledge]",
+    getArgumentCompletions: (prefix: string) => {
+      const subcommands = [
+        { cmd: "discuss", desc: "Start guided milestone/slice discussion" },
+        { cmd: "queue", desc: "Queue and reorder future milestones" },
+        { cmd: "quick", desc: "Execute a quick task without full planning overhead" },
+        { cmd: "capture", desc: "Fire-and-forget thought capture" },
+        { cmd: "triage", desc: "Manually trigger triage of pending captures" },
+        { cmd: "steer", desc: "Hard-steer plan documents during execution" },
+        { cmd: "milestone", desc: "Create a milestone from a specification document" },
+        { cmd: "knowledge", desc: "Add persistent project knowledge (rule, pattern, or lesson)" },
+      ];
+      const parts = prefix.trim().split(/\s+/);
+
+      if (parts.length <= 1) {
+        return subcommands
+          .filter(item => item.cmd.startsWith(parts[0] ?? ""))
+          .map(item => ({ value: item.cmd, label: item.cmd, description: item.desc }));
+      }
+
+      if (parts[0] === "knowledge" && parts.length <= 2) {
+        return ["rule", "pattern", "lesson"]
+          .filter(cmd => cmd.startsWith(parts[1] ?? ""))
+          .map(cmd => ({ value: `knowledge ${cmd}`, label: cmd }));
+      }
+
+      return [];
+    },
+    async handler(args: string, ctx: ExtensionCommandContext) {
+      await planHandler((typeof args === "string" ? args : "").trim(), ctx, pi);
+    },
+  });
+}
+
+// ─── /run handler (shared by /run command and /gsd backward compat) ───────────
+
+async function runHandler(trimmed: string, ctx: ExtensionCommandContext, pi: ExtensionAPI): Promise<void> {
+  // Bare /run → auto mode (the most common action)
+  if (trimmed === "" || trimmed === "auto" || trimmed.startsWith("auto ")) {
+    const verboseMode = trimmed.includes("--verbose");
+    const debugMode = trimmed.includes("--debug");
+    if (debugMode) enableDebug(projectRoot());
+    await startAuto(ctx, pi, projectRoot(), verboseMode);
+    return;
+  }
+
+  if (trimmed === "next" || trimmed.startsWith("next ")) {
+    if (trimmed.includes("--dry-run")) {
+      await handleDryRun(ctx, projectRoot());
+      return;
+    }
+    const verboseMode = trimmed.includes("--verbose");
+    const debugMode = trimmed.includes("--debug");
+    if (debugMode) enableDebug(projectRoot());
+    await startAuto(ctx, pi, projectRoot(), verboseMode, { step: true });
+    return;
+  }
+
+  if (trimmed === "stop") {
+    if (!isAutoActive() && !isAutoPaused()) {
+      const result = stopAutoRemote(projectRoot());
+      if (result.found) {
+        ctx.ui.notify(`Sent stop signal to auto-mode session (PID ${result.pid}). It will shut down gracefully.`, "info");
+      } else if (result.error) {
+        ctx.ui.notify(`Failed to stop remote auto-mode: ${result.error}`, "error");
+      } else {
+        ctx.ui.notify("Auto-mode is not running.", "info");
+      }
+      return;
+    }
+    await stopAuto(ctx, pi, "User requested stop");
+    return;
+  }
+
+  if (trimmed === "pause") {
+    if (!isAutoActive()) {
+      if (isAutoPaused()) {
+        ctx.ui.notify("Auto-mode is already paused. /run to resume.", "info");
+      } else {
+        ctx.ui.notify("Auto-mode is not running.", "info");
+      }
+      return;
+    }
+    await pauseAuto(ctx, pi);
+    return;
+  }
+
+  if (trimmed === "dispatch" || trimmed.startsWith("dispatch ")) {
+    const phase = trimmed.replace(/^dispatch\s*/, "").trim();
+    if (!phase) {
+      ctx.ui.notify("Usage: /run dispatch <phase>  (research|plan|execute|complete|reassess|uat|replan)", "warning");
+      return;
+    }
+    await dispatchDirectPhase(ctx, pi, phase, projectRoot());
+    return;
+  }
+
+  if (trimmed === "undo" || trimmed.startsWith("undo ")) {
+    await handleUndo(trimmed.replace(/^undo\s*/, "").trim(), ctx, pi, projectRoot());
+    return;
+  }
+
+  if (trimmed.startsWith("skip ")) {
+    await handleSkip(trimmed.replace(/^skip\s*/, "").trim(), ctx, projectRoot());
+    return;
+  }
+  if (trimmed === "skip") {
+    ctx.ui.notify("Usage: /run skip <unit-id>  (e.g., /run skip T03)", "info");
+    return;
+  }
+
+  // ─── Parallel Orchestration ────────────────────────────────────────
+  if (trimmed.startsWith("parallel")) {
+    const parallelArgs = trimmed.slice("parallel".length).trim();
+    const [subCmd = "", ...restParts] = parallelArgs.split(/\s+/);
+    const rest = restParts.join(" ");
+
+    if (subCmd === "start" || subCmd === "") {
+      const loaded = loadEffectiveGSDPreferences();
+      const config = resolveParallelConfig(loaded?.preferences);
+      if (!config.enabled) {
+        pi.sendMessage({
+          customType: "gsd-parallel",
+          content: "Parallel mode is not enabled. Set `parallel.enabled: true` in your preferences.",
+          display: false,
+        });
+        return;
+      }
+      const candidates = await prepareParallelStart(projectRoot(), loaded?.preferences);
+      const report = formatEligibilityReport(candidates);
+      if (candidates.eligible.length === 0) {
+        pi.sendMessage({ customType: "gsd-parallel", content: report + "\n\nNo milestones are eligible for parallel execution.", display: false });
+        return;
+      }
+      const result = await startParallel(
+        projectRoot(),
+        candidates.eligible.map(e => e.milestoneId),
+        loaded?.preferences,
+      );
+      const lines = [`Parallel orchestration started.`, `Workers: ${result.started.join(", ")}`];
+      if (result.errors.length > 0) {
+        lines.push(`Errors: ${result.errors.map(e => `${e.mid}: ${e.error}`).join("; ")}`);
+      }
+      pi.sendMessage({ customType: "gsd-parallel", content: report + "\n\n" + lines.join("\n"), display: false });
+      return;
+    }
+
+    if (subCmd === "status") {
+      if (!isParallelActive()) {
+        pi.sendMessage({ customType: "gsd-parallel", content: "No parallel orchestration is currently active.", display: false });
+        return;
+      }
+      const workers = getWorkerStatuses();
+      const lines = ["# Parallel Workers\n"];
+      for (const w of workers) {
+        lines.push(`- **${w.milestoneId}** (${w.title}) — ${w.state} — ${w.completedUnits} units — $${w.cost.toFixed(2)}`);
+      }
+      const orchState = getOrchestratorState();
+      if (orchState) {
+        lines.push(`\nTotal cost: $${orchState.totalCost.toFixed(2)}`);
+      }
+      pi.sendMessage({ customType: "gsd-parallel", content: lines.join("\n"), display: false });
+      return;
+    }
+
+    if (subCmd === "stop") {
+      const mid = rest.trim() || undefined;
+      await stopParallel(projectRoot(), mid);
+      pi.sendMessage({ customType: "gsd-parallel", content: mid ? `Stopped worker for ${mid}.` : "All parallel workers stopped.", display: false });
+      return;
+    }
+
+    if (subCmd === "pause") {
+      const mid = rest.trim() || undefined;
+      pauseWorker(projectRoot(), mid);
+      pi.sendMessage({ customType: "gsd-parallel", content: mid ? `Paused worker for ${mid}.` : "All parallel workers paused.", display: false });
+      return;
+    }
+
+    if (subCmd === "resume") {
+      const mid = rest.trim() || undefined;
+      resumeWorker(projectRoot(), mid);
+      pi.sendMessage({ customType: "gsd-parallel", content: mid ? `Resumed worker for ${mid}.` : "All parallel workers resumed.", display: false });
+      return;
+    }
+
+    if (subCmd === "merge") {
+      const mid = rest.trim() || undefined;
+      if (mid) {
+        const result = await mergeCompletedMilestone(projectRoot(), mid);
+        pi.sendMessage({ customType: "gsd-parallel", content: formatMergeResults([result]), display: false });
+        return;
+      }
+      const workers = getWorkerStatuses();
+      if (workers.length === 0) {
+        pi.sendMessage({ customType: "gsd-parallel", content: "No parallel workers to merge.", display: false });
+        return;
+      }
+      const results = await mergeAllCompleted(projectRoot(), workers);
+      pi.sendMessage({ customType: "gsd-parallel", content: formatMergeResults(results), display: false });
+      return;
+    }
+
+    pi.sendMessage({
+      customType: "gsd-parallel",
+      content: `Unknown parallel subcommand "${subCmd}". Usage: /run parallel [start|status|stop|pause|resume|merge]`,
+      display: false,
+    });
+    return;
+  }
+
+  ctx.ui.notify(
+    `Unknown: /run ${trimmed}. Run /gsd help for available commands.`,
+    "warning",
+  );
+}
+
+// ─── /plan handler (shared by /plan command and /gsd backward compat) ─────────
+
+async function planHandler(trimmed: string, ctx: ExtensionCommandContext, pi: ExtensionAPI): Promise<void> {
+  // Bare /plan → discuss (the most common planning action)
+  if (trimmed === "" || trimmed === "discuss") {
+    await showDiscuss(ctx, pi, projectRoot());
+    return;
+  }
+
+  if (trimmed === "queue") {
+    await showQueue(ctx, pi, projectRoot());
+    return;
+  }
+
+  if (trimmed === "quick" || trimmed.startsWith("quick ")) {
+    await handleQuick(trimmed.replace(/^quick\s*/, "").trim(), ctx, pi);
+    return;
+  }
+
+  if (trimmed.startsWith("capture ") || trimmed === "capture") {
+    await handleCapture(trimmed.replace(/^capture\s*/, "").trim(), ctx);
+    return;
+  }
+
+  if (trimmed === "triage") {
+    await handleTriage(ctx, pi, process.cwd());
+    return;
+  }
+
+  if (trimmed.startsWith("steer ")) {
+    await handleSteer(trimmed.replace(/^steer\s+/, "").trim(), ctx, pi);
+    return;
+  }
+  if (trimmed === "steer") {
+    ctx.ui.notify("Usage: /plan steer <description of change>. Example: /plan steer Use Postgres instead of SQLite", "warning");
+    return;
+  }
+
+  if (trimmed === "milestone") {
+    const basePath = projectRoot();
+    const headlessContextPath = join(basePath, ".gsd", "runtime", "headless-context.md");
+    if (existsSync(headlessContextPath)) {
+      const seedContext = readFileSync(headlessContextPath, "utf-8");
+      try { unlinkSync(headlessContextPath); } catch { /* non-fatal */ }
+      await showHeadlessMilestoneCreation(ctx, pi, basePath, seedContext);
+    } else {
+      const { showSmartEntry } = await import("./guided-flow.js");
+      await showSmartEntry(ctx, pi, basePath);
+    }
+    return;
+  }
+
+  if (trimmed.startsWith("knowledge ")) {
+    await handleKnowledge(trimmed.replace(/^knowledge\s+/, "").trim(), ctx);
+    return;
+  }
+  if (trimmed === "knowledge") {
+    ctx.ui.notify("Usage: /plan knowledge <rule|pattern|lesson> <description>. Example: /plan knowledge rule Use real DB for integration tests", "warning");
+    return;
+  }
+
+  ctx.ui.notify(
+    `Unknown: /plan ${trimmed}. Run /gsd help for available commands.`,
+    "warning",
+  );
 }
 
 function showHelp(ctx: ExtensionCommandContext): void {
   const lines = [
     "GSD — Get Shit Done\n",
-    "WORKFLOW",
-    "  /gsd               Run next unit in step mode (same as /gsd next)",
-    "  /gsd next           Execute next task, then pause  [--dry-run] [--verbose]",
-    "  /gsd auto           Run all queued units continuously  [--verbose]",
-    "  /gsd stop           Stop auto-mode gracefully",
-    "  /gsd pause          Pause auto-mode (preserves state, /gsd auto to resume)",
-    "  /gsd discuss        Start guided milestone/slice discussion",
-    "  /gsd new-milestone  Create milestone from headless context (used by gsd headless)",
+    "EXECUTION (/run)",
+    "  /run               Start auto-mode (same as /run auto)",
+    "  /run auto          Run all queued units continuously  [--verbose]",
+    "  /run next          Execute next task, then pause  [--dry-run] [--verbose]",
+    "  /run stop          Stop auto-mode gracefully",
+    "  /run pause         Pause auto-mode (preserves state, /run to resume)",
+    "  /run dispatch      Dispatch a specific phase directly  [research|plan|execute|complete|reassess|uat|replan]",
+    "  /run undo          Revert last completed unit  [--force]",
+    "  /run skip          Prevent a unit from auto-mode dispatch",
+    "  /run parallel      Parallel milestone orchestration  [start|status|stop|pause|resume|merge]",
     "",
-    "VISIBILITY",
-    "  /gsd status         Show progress dashboard  (Ctrl+Alt+G)",
-    "  /gsd visualize      Interactive 7-tab TUI (progress, deps, metrics, timeline, agent, changes, export)",
-    "  /gsd queue          Show queued/dispatched units and execution order",
-    "  /gsd history        View execution history  [--cost] [--phase] [--model] [N]",
+    "PLANNING (/plan)",
+    "  /plan              Start guided discussion (same as /plan discuss)",
+    "  /plan discuss      Start guided milestone/slice discussion",
+    "  /plan queue        Show queued/dispatched units and execution order",
+    "  /plan quick        Execute a quick task without full planning overhead",
+    "  /plan capture      Fire-and-forget thought capture",
+    "  /plan triage       Classify and route pending captures",
+    "  /plan steer        Apply user override to active work",
+    "  /plan milestone    Create a milestone from headless context",
+    "  /plan knowledge    Add rule, pattern, or lesson to KNOWLEDGE.md",
     "",
-    "COURSE CORRECTION",
-    "  /gsd steer <desc>   Apply user override to active work",
-    "  /gsd capture <text> Quick-capture a thought to CAPTURES.md",
-    "  /gsd triage         Classify and route pending captures",
-    "  /gsd skip <unit>    Prevent a unit from auto-mode dispatch",
-    "  /gsd undo           Revert last completed unit  [--force]",
+    "VISIBILITY (/gsd)",
+    "  /gsd               Run next unit in step mode",
+    "  /gsd status        Show progress dashboard  (Ctrl+Alt+G)",
+    "  /gsd visualize     Interactive TUI (progress, deps, metrics, timeline)",
+    "  /gsd history       View execution history  [--cost] [--phase] [--model] [N]",
+    "  /gsd export        Export milestone/slice results  [--json|--markdown|--html]",
     "",
-    "PROJECT KNOWLEDGE",
-    "  /gsd knowledge <type> <text>   Add rule, pattern, or lesson to KNOWLEDGE.md",
-    "",
-    "CONFIGURATION",
-    "  /gsd mode           Set workflow mode (solo/team)  [global|project]",
-    "  /gsd prefs          Manage preferences  [global|project|status|wizard|setup]",
-    "  /gsd config         Set API keys for external tools",
-    "  /gsd hooks          Show post-unit hook configuration",
-    "",
-    "MAINTENANCE",
-    "  /gsd doctor         Diagnose and repair .gsd/ state  [audit|fix|heal] [scope]",
-    "  /gsd export         Export milestone/slice results  [--json|--markdown|--html]",
-    "  /gsd cleanup        Remove merged branches or snapshots  [branches|snapshots]",
-    "  /gsd migrate        Upgrade .gsd/ structures to new format",
-    "  /gsd remote         Control remote auto-mode  [slack|discord|status|disconnect]",
-    "  /gsd inspect        Show SQLite DB diagnostics (schema, row counts, recent entries)",
+    "SYSTEM (/gsd)",
+    "  /gsd mode          Set workflow mode (solo/team)  [global|project]",
+    "  /gsd prefs         Manage preferences  [global|project|status|wizard|setup]",
+    "  /gsd config        Set API keys for external tools",
+    "  /gsd hooks         Show post-unit hook configuration",
+    "  /gsd doctor        Diagnose and repair .gsd/ state  [audit|fix|heal] [scope]",
+    "  /gsd cleanup       Remove merged branches or snapshots  [branches|snapshots]",
+    "  /gsd migrate       Upgrade .gsd/ structures to new format",
+    "  /gsd remote        Control remote auto-mode  [slack|discord|status|disconnect]",
+    "  /gsd inspect       Show SQLite DB diagnostics",
   ];
   ctx.ui.notify(lines.join("\n"), "info");
 }
@@ -639,7 +724,7 @@ async function handleStatus(ctx: ExtensionCommandContext): Promise<void> {
   const state = await deriveState(basePath);
 
   if (state.registry.length === 0) {
-    ctx.ui.notify("No GSD milestones found. Run /gsd to start.", "info");
+    ctx.ui.notify("No GSD milestones found. Run /plan to start.", "info");
     return;
   }
 
@@ -886,13 +971,13 @@ async function handleInspect(ctx: ExtensionCommandContext): Promise<void> {
     const { isDbAvailable, _getAdapter } = await import("./gsd-db.js");
 
     if (!isDbAvailable()) {
-      ctx.ui.notify("No GSD database available. Run /gsd auto to create one.", "info");
+      ctx.ui.notify("No GSD database available. Run /run to create one.", "info");
       return;
     }
 
     const adapter = _getAdapter();
     if (!adapter) {
-      ctx.ui.notify("No GSD database available. Run /gsd auto to create one.", "info");
+      ctx.ui.notify("No GSD database available. Run /run to create one.", "info");
       return;
     }
 
@@ -1657,7 +1742,7 @@ async function ensurePreferencesFile(
 
 async function handleSkip(unitArg: string, ctx: ExtensionCommandContext, basePath: string): Promise<void> {
   if (!unitArg) {
-    ctx.ui.notify("Usage: /gsd skip <unit-id>  (e.g., /gsd skip execute-task/M001/S01/T03 or /gsd skip T03)", "info");
+    ctx.ui.notify("Usage: /run skip <unit-id>  (e.g., /run skip execute-task/M001/S01/T03 or /run skip T03)", "info");
     return;
   }
 
@@ -1864,7 +1949,7 @@ async function handleKnowledge(args: string, ctx: ExtensionCommandContext): Prom
 
   if (!typeArg || !["rule", "pattern", "lesson"].includes(typeArg)) {
     ctx.ui.notify(
-      "Usage: /gsd knowledge <rule|pattern|lesson> <description>\nExample: /gsd knowledge rule Use real DB for integration tests",
+      "Usage: /plan knowledge <rule|pattern|lesson> <description>\nExample: /plan knowledge rule Use real DB for integration tests",
       "warning",
     );
     return;
@@ -1872,7 +1957,7 @@ async function handleKnowledge(args: string, ctx: ExtensionCommandContext): Prom
 
   const entryText = parts.slice(1).join(" ").trim();
   if (!entryText) {
-    ctx.ui.notify(`Usage: /gsd knowledge ${typeArg} <description>`, "warning");
+    ctx.ui.notify(`Usage: /plan knowledge ${typeArg} <description>`, "warning");
     return;
   }
 
@@ -1890,7 +1975,7 @@ async function handleKnowledge(args: string, ctx: ExtensionCommandContext): Prom
 // ─── Capture Command ──────────────────────────────────────────────────────────
 
 /**
- * Handle `/gsd capture "..."` — fire-and-forget thought capture.
+ * Handle `/plan capture "..."` — fire-and-forget thought capture.
  * Appends to `.gsd/CAPTURES.md` without interrupting auto-mode.
  * Works in all modes: auto running, paused, stopped, no project.
  */
@@ -1898,7 +1983,7 @@ async function handleCapture(args: string, ctx: ExtensionCommandContext): Promis
   // Strip surrounding quotes from the argument
   let text = args.trim();
   if (!text) {
-    ctx.ui.notify('Usage: /gsd capture "your thought here"', "warning");
+    ctx.ui.notify('Usage: /plan capture "your thought here"', "warning");
     return;
   }
   // Remove wrapping quotes (single or double)
@@ -1906,7 +1991,7 @@ async function handleCapture(args: string, ctx: ExtensionCommandContext): Promis
     text = text.slice(1, -1);
   }
   if (!text) {
-    ctx.ui.notify('Usage: /gsd capture "your thought here"', "warning");
+    ctx.ui.notify('Usage: /plan capture "your thought here"', "warning");
     return;
   }
 
@@ -1925,7 +2010,7 @@ async function handleCapture(args: string, ctx: ExtensionCommandContext): Promis
 // ─── Triage Command ───────────────────────────────────────────────────────────
 
 /**
- * Handle `/gsd triage` — manually trigger triage of pending captures.
+ * Handle `/plan triage` — manually trigger triage of pending captures.
  * Dispatches the triage prompt to the LLM for classification.
  * Triage result handling (confirmation UI) is wired in T03.
  */

--- a/src/resources/extensions/gsd/dashboard-overlay.ts
+++ b/src/resources/extensions/gsd/dashboard-overlay.ts
@@ -350,7 +350,7 @@ export class GSDDashboardOverlay {
       )));
       lines.push(blank());
     } else if (this.dashData.paused) {
-      lines.push(row(th.fg("dim", "/gsd auto to resume")));
+      lines.push(row(th.fg("dim", "/run to resume")));
       lines.push(blank());
     } else if (isRemote) {
       const rs = this.dashData.remoteSession!;
@@ -360,7 +360,7 @@ export class GSDDashboardOverlay {
       lines.push(row(th.fg("text", `Remote session: ${unitDisplay}`)));
       lines.push(blank());
     } else {
-      lines.push(row(th.fg("dim", "No unit running · /gsd auto to start")));
+      lines.push(row(th.fg("dim", "No unit running · /run to start")));
       lines.push(blank());
     }
 

--- a/src/resources/extensions/gsd/forensics.ts
+++ b/src/resources/extensions/gsd/forensics.ts
@@ -91,7 +91,7 @@ export async function handleForensics(
   const basePath = process.cwd();
   const root = gsdRoot(basePath);
   if (!existsSync(root)) {
-    ctx.ui.notify("No GSD state found. Run /gsd auto first.", "warning");
+    ctx.ui.notify("No GSD state found. Run /run first.", "warning");
     return;
   }
 

--- a/src/resources/extensions/gsd/guided-flow.ts
+++ b/src/resources/extensions/gsd/guided-flow.ts
@@ -429,7 +429,7 @@ export async function showQueue(
           description: "Queue new milestones via discussion.",
         },
       ],
-      notYetMessage: "Run /gsd queue when ready.",
+      notYetMessage: "Run /plan queue when ready.",
     });
 
     if (choice === "reorder") {
@@ -855,7 +855,7 @@ async function buildDiscussSlicePrompt(
 }
 
 /**
- * /gsd discuss — show a picker of non-done slices and run a slice interview.
+ * /plan discuss — show a picker of non-done slices and run a slice interview.
  * Loops back to the picker after each discussion so the user can chain
  * multiple slice interviews in one session.
  */
@@ -908,7 +908,7 @@ export async function showDiscuss(
           description: "Leave this milestone as-is and start something new.",
         },
       ],
-      notYetMessage: "Run /gsd discuss when ready to discuss this milestone.",
+      notYetMessage: "Run /plan discuss when ready to discuss this milestone.",
     });
 
     if (choice === "discuss_draft") {
@@ -983,7 +983,7 @@ export async function showDiscuss(
         "Pick a slice to interview. Context file will be written when done.",
       ],
       actions,
-      notYetMessage: "Run /gsd discuss when ready.",
+      notYetMessage: "Run /plan discuss when ready.",
     });
 
     if (choice === "not_yet") return;
@@ -1008,7 +1008,7 @@ export async function showDiscuss(
  * Self-heal: scan runtime records and clear stale ones left behind when
  * auto-mode crashed mid-unit. auto.ts has its own selfHealRuntimeRecords()
  * but guided-flow (manual /gsd mode) never called it — meaning stale records
- * persisted until the next /gsd auto run.  This ensures the wizard always
+ * persisted until the next /run auto run.  This ensures the wizard always
  * starts from a clean state regardless of how the previous session ended.
  */
 function selfHealRuntimeRecords(basePath: string, ctx: ExtensionContext): { cleared: number } {
@@ -1089,7 +1089,7 @@ export async function showSmartEntry(
       title: "GSD — Interrupted Session Detected",
       summary: [formatCrashInfo(crashLock)],
       actions: [
-        { id: "resume", label: "Resume with /gsd auto", description: "Pick up where it left off", recommended: true },
+        { id: "resume", label: "Resume with /run", description: "Pick up where it left off", recommended: true },
         { id: "continue", label: "Continue manually", description: "Open the wizard as normal" },
       ],
     });
@@ -1103,7 +1103,7 @@ export async function showSmartEntry(
 
   if (!state.activeMilestone) {
     // Guard: if a discuss session is already in flight, don't re-inject the prompt.
-    // Both /gsd and /gsd auto reach this branch when no milestone exists yet.
+    // Both /gsd and /run reach this branch when no milestone exists yet.
     // Without this guard, every subsequent /gsd call overwrites pendingAutoStart
     // and fires another dispatchWorkflow, resetting the conversation mid-interview.
     if (pendingAutoStart) {

--- a/src/resources/extensions/gsd/index.ts
+++ b/src/resources/extensions/gsd/index.ts
@@ -4,12 +4,12 @@
  * One command, one wizard. Reads state from disk, shows contextual options,
  * dispatches through GSD-WORKFLOW.md. The LLM does the rest.
  *
- * Auto-mode: /gsd auto loops fresh sessions until milestone complete.
+ * Auto-mode: /run loops fresh sessions until milestone complete.
  *
  * Commands:
  *   /gsd        — contextual wizard (smart entry point)
- *   /gsd auto   — start auto-mode (fresh session per unit)
- *   /gsd stop   — stop auto-mode gracefully
+ *   /run        — start auto-mode (fresh session per unit)
+ *   /run stop   — stop auto-mode gracefully
  *   /gsd status — progress dashboard
  *
  * Hooks:
@@ -27,7 +27,7 @@ import { createBashTool, createWriteTool, createReadTool, createEditTool, isTool
 import { Type } from "@sinclair/typebox";
 
 import { debugLog, debugTime } from "./debug-logger.js";
-import { registerGSDCommand, loadToolApiKeys } from "./commands.js";
+import { registerAllCommands, loadToolApiKeys } from "./commands.js";
 import { registerExitCommand } from "./exit-command.js";
 import { registerWorktreeCommand, getWorktreeOriginalCwd, getActiveWorktreeName } from "./worktree-command.js";
 import { getActiveAutoWorktreeContext } from "./auto-worktree.js";
@@ -127,7 +127,7 @@ const GSD_LOGO_LINES = [
 ];
 
 export default function (pi: ExtensionAPI) {
-  registerGSDCommand(pi);
+  registerAllCommands(pi);
   registerWorktreeCommand(pi);
   registerExitCommand(pi);
 
@@ -866,7 +866,7 @@ export default function (pi: ExtensionAPI) {
     if (!isAutoActive() && !isAutoPaused()) return;
 
     // Save the current session — the lock file stays on disk
-    // so the next /gsd auto knows it was interrupted
+    // so the next /run knows it was interrupted
     const dash = getAutoDashboardData();
     if (dash.currentUnit) {
       saveActivityLog(ctx, dash.basePath, dash.currentUnit.type, dash.currentUnit.id);

--- a/src/resources/extensions/gsd/parallel-merge.ts
+++ b/src/resources/extensions/gsd/parallel-merge.ts
@@ -146,7 +146,7 @@ export function formatMergeResults(results: MergeResult[]): string {
       for (const f of r.conflictFiles) {
         lines.push(`  - \`${f}\``);
       }
-      lines.push(`  Resolve conflicts manually and run \`/gsd parallel merge ${r.milestoneId}\` to retry.`);
+      lines.push(`  Resolve conflicts manually and run \`/run parallel merge ${r.milestoneId}\` to retry.`);
     } else {
       lines.push(`- **${r.milestoneId}** — failed: ${r.error}`);
     }

--- a/src/resources/extensions/gsd/parallel-orchestrator.ts
+++ b/src/resources/extensions/gsd/parallel-orchestrator.ts
@@ -411,7 +411,7 @@ function createMilestoneWorktree(basePath: string, milestoneId: string): string 
 
 /**
  * Spawn a worker process for a milestone.
- * The worker runs `gsd --print "/gsd auto"` in the milestone's worktree
+ * The worker runs `gsd --print "/run"` in the milestone's worktree
  * with GSD_MILESTONE_LOCK set to isolate state derivation.
  */
 export function spawnWorker(
@@ -429,7 +429,7 @@ export function spawnWorker(
 
   let child: ChildProcess;
   try {
-    child = spawn(process.execPath, [binPath, "--mode", "json", "--print", "/gsd auto"], {
+    child = spawn(process.execPath, [binPath, "--mode", "json", "--print", "/run"], {
       cwd: worker.worktreePath,
       env: {
         ...process.env,

--- a/src/resources/extensions/gsd/prompts/run-uat.md
+++ b/src/resources/extensions/gsd/prompts/run-uat.md
@@ -103,7 +103,7 @@ Review `{{uatPath}}`, perform the described UAT steps, then update this file wit
 - Results for each check
 - Date completed
 
-Once updated, run `/gsd auto` to resume auto-mode.
+Once updated, run `/run` to resume auto-mode.
 ```
 
 ---

--- a/src/resources/extensions/gsd/prompts/system.md
+++ b/src/resources/extensions/gsd/prompts/system.md
@@ -66,8 +66,8 @@ Titles live inside file content (headings, frontmatter), not in file or director
   REQUIREMENTS.md       (requirement contract - tracks active/validated/deferred/out-of-scope)
   DECISIONS.md          (append-only register of architectural and pattern decisions)
   KNOWLEDGE.md          (append-only register of project-specific rules, patterns, and lessons learned)
-  OVERRIDES.md          (user-issued overrides that supersede plan content via /gsd steer)
-  QUEUE.md              (append-only log of queued milestones via /gsd queue)
+  OVERRIDES.md          (user-issued overrides that supersede plan content via /plan steer)
+  QUEUE.md              (append-only log of queued milestones via /plan queue)
   STATE.md
   runtime/              (system-managed — dispatch state, do not edit)
   activity/             (system-managed — JSONL execution logs, do not edit)
@@ -129,12 +129,12 @@ Templates showing the expected format for each artifact type are in:
 
 ### Commands
 
-- `/gsd` - contextual wizard
-- `/gsd auto` - auto-execute (fresh context per task)
-- `/gsd stop` - stop auto-mode
+- `/gsd` - contextual wizard (step mode)
+- `/run` - auto-execute (fresh context per task)
+- `/run stop` - stop auto-mode
 - `/gsd status` - progress dashboard overlay
-- `/gsd queue` - queue future milestones (safe while auto-mode is running)
-- `/gsd quick <task>` - quick task with GSD guarantees (atomic commits, state tracking) but no milestone ceremony
+- `/plan queue` - queue future milestones (safe while auto-mode is running)
+- `/plan quick <task>` - quick task with GSD guarantees (atomic commits, state tracking) but no milestone ceremony
 - `Ctrl+Alt+G` - toggle dashboard overlay
 - `Ctrl+Alt+B` - show shell processes
 

--- a/src/resources/extensions/gsd/prompts/triage-captures.md
+++ b/src/resources/extensions/gsd/prompts/triage-captures.md
@@ -2,7 +2,7 @@ You are triaging user-captured thoughts during a GSD session.
 
 ## UNIT: Triage Captures
 
-The user captured thoughts during execution using `/gsd capture`. Your job is to classify each capture, present your proposals, get user confirmation, and update CAPTURES.md with the final classifications.
+The user captured thoughts during execution using `/plan capture`. Your job is to classify each capture, present your proposals, get user confirmation, and update CAPTURES.md with the final classifications.
 
 ## Pending Captures
 

--- a/src/resources/extensions/gsd/quick.ts
+++ b/src/resources/extensions/gsd/quick.ts
@@ -1,5 +1,5 @@
 /**
- * GSD Quick Mode — /gsd quick <task>
+ * GSD Quick Mode — /plan quick <task>
  * Copyright (c) 2026 Jeremy McSpadden <jeremy@fluxlabs.net>
  *
  * Lightweight task execution with GSD guarantees (atomic commits, state
@@ -88,7 +88,7 @@ export async function handleQuick(
   let description = args.trim();
   if (!description) {
     ctx.ui.notify(
-      "Usage: /gsd quick <task description>\n\nExample: /gsd quick fix login button not responding on mobile",
+      "Usage: /plan quick <task description>\n\nExample: /plan quick fix login button not responding on mobile",
       "info",
     );
     return;

--- a/src/resources/extensions/gsd/skills/gsd-headless/references/multi-session.md
+++ b/src/resources/extensions/gsd/skills/gsd-headless/references/multi-session.md
@@ -69,7 +69,7 @@ Coordinator writes to `.gsd/parallel/<milestoneId>.signal.json`. Worker consumes
 GSD_MILESTONE_LOCK=M001 \
 GSD_PARALLEL_WORKER=1 \
 GSD_BIN_PATH=$(which gsd) \
-  gsd --mode json --print "/gsd auto" \
+  gsd --mode json --print "/run" \
   2>logs/M001.log &
 WORKER_PID=$!
 ```
@@ -77,7 +77,7 @@ WORKER_PID=$!
 Workers emit NDJSON on stdout. Parse `message_end` events for cost tracking:
 ```bash
 # Extract cost from worker output
-gsd --mode json --print "/gsd auto" | while read -r line; do
+gsd --mode json --print "/run" | while read -r line; do
   COST=$(echo "$line" | jq -r 'select(.type=="message_end") | .message.usage.cost.total // empty')
   [ -n "$COST" ] && echo "Cost update: $COST"
 done
@@ -177,9 +177,9 @@ Inside an interactive GSD session, these commands manage the parallel orchestrat
 
 | Command | Description |
 |---------|-------------|
-| `/gsd parallel start` | Analyze eligibility, spawn workers |
-| `/gsd parallel status` | Show all workers, costs, progress |
-| `/gsd parallel stop [MID]` | Stop one or all workers |
-| `/gsd parallel pause [MID]` | Pause without killing |
-| `/gsd parallel resume [MID]` | Resume paused worker |
-| `/gsd parallel merge [MID]` | Merge completed milestone branch |
+| `/run parallel start` | Analyze eligibility, spawn workers |
+| `/run parallel status` | Show all workers, costs, progress |
+| `/run parallel stop [MID]` | Stop one or all workers |
+| `/run parallel pause [MID]` | Pause without killing |
+| `/run parallel resume [MID]` | Resume paused worker |
+| `/run parallel merge [MID]` | Merge completed milestone branch |

--- a/src/resources/extensions/gsd/tests/auto-draft-pause.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-draft-pause.test.ts
@@ -103,10 +103,10 @@ assert(
   "needs-discussion dispatch rule should return stop action",
 );
 
-// Check notification includes /gsd guidance
+// Check notification includes command guidance (/plan discuss or /gsd)
 assert(
-  nextChunk.includes("/gsd"),
-  "needs-discussion notification should tell user to run /gsd",
+  nextChunk.includes("/plan") || nextChunk.includes("/gsd"),
+  "needs-discussion notification should tell user to run /plan discuss",
 );
 
 // ─── Results ──────────────────────────────────────────────────────────────

--- a/src/resources/extensions/gsd/tests/parallel-orchestration.test.ts
+++ b/src/resources/extensions/gsd/tests/parallel-orchestration.test.ts
@@ -600,7 +600,7 @@ describe("parallel-merge: formatMergeResults", () => {
     assert.ok(output.includes("CONFLICT (2 file(s))"));
     assert.ok(output.includes("`src/types.ts`"));
     assert.ok(output.includes("`src/utils.ts`"));
-    assert.ok(output.includes("/gsd parallel merge M003"));
+    assert.ok(output.includes("/run parallel merge M003"));
   });
 
   it("formats a generic error (no conflict files) with the error message", () => {

--- a/src/resources/extensions/gsd/tests/parallel-worker-monitoring.test.ts
+++ b/src/resources/extensions/gsd/tests/parallel-worker-monitoring.test.ts
@@ -147,7 +147,7 @@ describe("parallel-worker-monitoring", () => {
   it("worker spawn args include --mode json", () => {
     // Verify the spawn command includes JSON mode for NDJSON output.
     // We can't easily test the actual spawn, but we verify the args pattern.
-    const expectedArgs = ["--mode", "json", "--print", "/gsd auto"];
+    const expectedArgs = ["--mode", "json", "--print", "/run"];
     assertTrue(expectedArgs.includes("--mode"), "args include --mode");
     assertTrue(expectedArgs.includes("json"), "args include json");
     assertTrue(expectedArgs.indexOf("--mode") < expectedArgs.indexOf("json"),

--- a/src/resources/extensions/gsd/tests/undo.test.ts
+++ b/src/resources/extensions/gsd/tests/undo.test.ts
@@ -38,7 +38,7 @@ test("handleUndo without --force only warns and leaves completed units intact", 
 
     assert.equal(notifications.length, 1);
     assert.equal(notifications[0]?.level, "warning");
-    assert.match(notifications[0]?.message ?? "", /Run \/gsd undo --force to confirm\./);
+    assert.match(notifications[0]?.message ?? "", /Run \/run undo --force to confirm\./);
     assert.deepEqual(
       JSON.parse(readFileSync(join(base, ".gsd", "completed-units.json"), "utf-8")),
       ["execute-task/M001/S01/T01"],

--- a/src/resources/extensions/gsd/tests/workspace-index.test.ts
+++ b/src/resources/extensions/gsd/tests/workspace-index.test.ts
@@ -60,7 +60,7 @@ async function main(): Promise<void> {
   console.log("\n=== next command suggestions ===");
   {
     const commands = await getSuggestedNextCommands(base);
-    assertTrue(commands.includes("/gsd auto"), "suggests auto during execution");
+    assertTrue(commands.includes("/run"), "suggests auto during execution");
     assertTrue(commands.includes("/gsd doctor M001/S01"), "suggests scoped doctor");
     assertTrue(commands.includes("/gsd status"), "suggests status");
   }

--- a/src/resources/extensions/gsd/triage-ui.ts
+++ b/src/resources/extensions/gsd/triage-ui.ts
@@ -2,7 +2,7 @@
  * GSD Triage UI — Confirmation flow for programmatic triage results
  *
  * Used by auto-mode dispatch (S02) when triage fires between tasks.
- * For manual `/gsd triage`, the LLM session handles confirmation directly.
+ * For manual `/plan triage`, the LLM session handles confirmation directly.
  *
  * This module provides `showTriageConfirmation` which presents each
  * triage result to the user via `showNextAction` and returns the

--- a/src/resources/extensions/gsd/undo.ts
+++ b/src/resources/extensions/gsd/undo.ts
@@ -51,7 +51,7 @@ export async function handleUndo(args: string, ctx: ExtensionCommandContext, _pi
       `  - Delete summary artifacts\n` +
       `  - Uncheck task in PLAN (if execute-task)\n` +
       `  - Attempt to revert associated git commits\n\n` +
-      `Run /gsd undo --force to confirm.`,
+      `Run /run undo --force to confirm.`,
       "warning",
     );
     return;

--- a/src/resources/extensions/gsd/workspace-index.ts
+++ b/src/resources/extensions/gsd/workspace-index.ts
@@ -208,7 +208,7 @@ export async function getSuggestedNextCommands(basePath: string): Promise<string
 
   const commands = new Set<string>();
   if (index.active.phase === "planning") commands.add("/gsd");
-  if (index.active.phase === "executing" || index.active.phase === "summarizing") commands.add("/gsd auto");
+  if (index.active.phase === "executing" || index.active.phase === "summarizing") commands.add("/run");
   if (scope) commands.add(`/gsd doctor ${scope}`);
   if (scope) commands.add(`/gsd doctor fix ${scope}`);
   if (index.validationIssues.length > 0 && scope) commands.add(`/gsd doctor audit ${scope}`);

--- a/src/resources/extensions/gsd/worktree-command.ts
+++ b/src/resources/extensions/gsd/worktree-command.ts
@@ -385,7 +385,7 @@ async function handleCreate(
           `This worktree inherited existing GSD milestones from the main branch.`,
           ``,
           `  Continue — keep milestones and pick up where main left off`,
-          `  Start fresh — clear milestones so /gsd auto starts a new project`,
+          `  Start fresh — clear milestones so /run starts a new project`,
         ].join("\n"),
         confirmLabel: "Continue",
         declineLabel: "Start fresh",
@@ -400,7 +400,7 @@ async function handleCreate(
       ? `  ${CLR.muted("Auto-committed on previous branch before switching.")}`
       : "";
     const freshNote = clearedPlans
-      ? `  ${CLR.ok("✓")} Cleared milestones — ${CLR.hint("/gsd auto")} will start fresh.`
+      ? `  ${CLR.ok("✓")} Cleared milestones — ${CLR.hint("/run")} will start fresh.`
       : "";
     ctx.ui.notify(
       [

--- a/src/tests/headless-detection.test.ts
+++ b/src/tests/headless-detection.test.ts
@@ -93,7 +93,7 @@ test("detects blocked notification with 'Blocked:' prefix", () => {
 })
 
 test("detects inline 'Blocked:' message", () => {
-  assert.ok(isBlockedNotification(makeNotify("Blocked: no active milestone. Fix and run /gsd auto.")))
+  assert.ok(isBlockedNotification(makeNotify("Blocked: no active milestone. Fix and run /run.")))
 })
 
 test("does NOT match 'blocked' without colon (avoids false positives)", () => {

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -30,7 +30,7 @@ Use `@gsd` in VS Code Chat (`Ctrl+Shift+I`) to send messages to the agent:
 
 ```
 @gsd refactor the auth module to use JWT
-@gsd /gsd auto
+@gsd /run
 @gsd what's the current milestone status?
 ```
 

--- a/vscode-extension/src/chat-participant.ts
+++ b/vscode-extension/src/chat-participant.ts
@@ -169,12 +169,12 @@ export function registerChatParticipant(
 					title: "Check project status",
 				},
 				{
-					prompt: "/gsd auto",
+					prompt: "/run",
 					label: "$(rocket) Run auto mode",
 					title: "Run autonomous mode",
 				},
 				{
-					prompt: "/gsd capture",
+					prompt: "/plan capture",
 					label: "$(note) Capture a thought",
 					title: "Capture a thought mid-session",
 				},


### PR DESCRIPTION
## Summary

Replaces the monolithic `/gsd` command with three grouped namespaces, organized by usage frequency:

| Group | Purpose | Frequency |
|-------|---------|-----------|
| `/run` | Execution hot path | Typed 100x/day |
| `/plan` | Work structuring | Typed 10x/day |
| `/gsd` | Visibility, system, config | Typed occasionally |

### `/run` — execution (8 subcommands)

| Command | Description |
|---------|-------------|
| `/run` | Start auto-mode (same as `/run auto`) |
| `/run auto` | Run all queued units continuously |
| `/run next` | Execute next task, then pause |
| `/run stop` | Stop auto-mode gracefully |
| `/run pause` | Pause auto-mode |
| `/run dispatch` | Dispatch specific phase directly |
| `/run undo` | Revert last completed unit |
| `/run skip` | Prevent unit from dispatch |
| `/run parallel` | Parallel milestone orchestration |

### `/plan` — work structuring (8 subcommands)

| Command | Description |
|---------|-------------|
| `/plan` | Start guided discussion (same as `/plan discuss`) |
| `/plan discuss` | Guided milestone/slice discussion |
| `/plan queue` | Queue and reorder milestones |
| `/plan quick` | Quick task without full planning |
| `/plan capture` | Fire-and-forget thought capture |
| `/plan triage` | Classify pending captures |
| `/plan steer` | Hard-steer plan documents |
| `/plan milestone` | Create milestone from headless context |
| `/plan knowledge` | Add rule, pattern, or lesson |

### `/gsd` — visibility + system (unchanged, 17 subcommands)

Status, visualize, history, forensics, export, doctor, prefs, config, mode, hooks, run-hook, skill-health, cleanup, migrate, remote, inspect, help — all stay as `/gsd <subcmd>`. Bare `/gsd` still launches step-mode wizard.

### Backward compatibility

`/gsd <moved-subcmd>` (e.g., `/gsd auto`, `/gsd discuss`) still works permanently but shows a one-time hint:
```
Hint: /gsd auto is now /run (or /run auto)
```

### Design principle

**Frequency of use drives how short a command is.** `/run` gets typed 100x/day — give it the shortest path. `/gsd forensics` gets typed once a month — fine behind a namespace. The git analogy: `git status` is short because it lives inside a good namespace, not despite it.

### What changed

- **`commands.ts`**: Registers 3 commands (`/gsd`, `/run`, `/plan`), shared handler functions, updated help text showing grouped structure
- **39 files total**: Command registration, user-facing strings, docs, LLM prompts, tests
- **Critical functional code**: headless.ts command mapping, parallel-orchestrator.ts spawn args, auto.ts resume commands
- **CHANGELOG.md**: Intentionally unchanged (historical record)

## Test plan

- [x] `npm run build` — zero errors
- [x] `npm run test:unit` — 1191 pass, 0 fail
- [x] `npm run test:integration` — 30 pass, 0 fail, 1 skipped (baseline)
- [x] Grep audit: no remaining `/gsd <moved-subcmd>` references outside CHANGELOG.md and backward-compat router
- [ ] Manual smoke test: `/run`, `/run stop`, `/plan`, `/plan queue`, `/gsd status`, `/gsd auto` (backward compat hint)