### PR TITLE
fix: retry transient network errors before model fallback (#941)

### DIFF
--- a/src/resources/extensions/gsd/index.ts
+++ b/src/resources/extensions/gsd/index.ts
@@ -44,6 +44,7 @@ import {
   resolveAllSkillReferences,
   resolveModelWithFallbacksForUnit,
   getNextFallbackModel,
+  isTransientNetworkError,
 } from "./preferences.js";
 import { hasSkillSnapshot, detectNewSkills, formatSkillsXml } from "./skill-discovery.js";
 import {
@@ -91,6 +92,11 @@ function loadAgentInstructions(): string | null {
 
 // ── Depth verification state ──────────────────────────────────────────────
 let depthVerificationDone = false;
+
+// ── Network error retry counters ──────────────────────────────────────────
+// Tracks per-model retry attempts for transient network errors.
+// Cleared when a model switch occurs or retries are exhausted.
+const networkRetryCounters = new Map<string, number>();
 
 export function isDepthVerified(): boolean {
   return depthVerificationDone;
@@ -727,6 +733,43 @@ export default function (pi: ExtensionAPI) {
           ? `: ${lastMsg.errorMessage}`
           : "";
 
+      const errorMsg = ("errorMessage" in lastMsg && lastMsg.errorMessage) ? String(lastMsg.errorMessage) : "";
+
+      // ── Transient network error retry ──────────────────────────────────
+      // Before falling back to a different model, retry the current model
+      // for transient network errors (connection reset, timeout, DNS, etc.).
+      // This prevents providers with occasional network flakiness from being
+      // immediately abandoned in favor of fallback models (#941).
+      if (isTransientNetworkError(errorMsg)) {
+        const currentModelId = ctx.model?.id ?? "unknown";
+        const retryKey = `network-retry:${currentModelId}`;
+        const maxRetries = 2;
+        const currentRetries = networkRetryCounters.get(retryKey) ?? 0;
+
+        if (currentRetries < maxRetries) {
+          networkRetryCounters.set(retryKey, currentRetries + 1);
+          const attempt = currentRetries + 1;
+          const delayMs = attempt * 3000; // 3s, 6s backoff
+          ctx.ui.notify(
+            `Network error on ${currentModelId}${errorDetail}. Retry ${attempt}/${maxRetries} in ${delayMs / 1000}s...`,
+            "warning",
+          );
+          setTimeout(() => {
+            pi.sendMessage(
+              { customType: "gsd-auto-timeout-recovery", content: "Continue execution — retrying after transient network error.", display: false },
+              { triggerTurn: true },
+            );
+          }, delayMs);
+          return;
+        }
+        // Retries exhausted — clear counter and fall through to fallback logic
+        networkRetryCounters.delete(retryKey);
+        ctx.ui.notify(
+          `Network retries exhausted for ${currentModelId}. Attempting model fallback.`,
+          "warning",
+        );
+      }
+
       const dash = getAutoDashboardData();
       if (dash.currentUnit) {
         const modelConfig = resolveModelWithFallbacksForUnit(dash.currentUnit.type);
@@ -737,6 +780,9 @@ export default function (pi: ExtensionAPI) {
           const nextModelId = getNextFallbackModel(currentModelId, modelConfig);
 
           if (nextModelId) {
+            // Clear any network retry counters when switching models
+            networkRetryCounters.clear();
+
             let modelToSet;
             const slashIdx = nextModelId.indexOf("/");
             if (slashIdx !== -1) {
@@ -771,7 +817,6 @@ export default function (pi: ExtensionAPI) {
       }
 
       // Detect rate-limit errors and extract retry delay for auto-resume
-      const errorMsg = ("errorMessage" in lastMsg && lastMsg.errorMessage) ? String(lastMsg.errorMessage) : "";
       const isRateLimit = /rate.?limit|too many requests|429/i.test(errorMsg);
       const retryAfterMs = ("retryAfterMs" in lastMsg && typeof lastMsg.retryAfterMs === "number")
         ? lastMsg.retryAfterMs
@@ -791,6 +836,7 @@ export default function (pi: ExtensionAPI) {
     }
 
     try {
+      networkRetryCounters.clear(); // Clear network retry state on successful unit completion
       await handleAgentEnd(ctx, pi);
     } catch (err) {
       // Safety net: if handleAgentEnd throws despite its internal try-catch,

--- a/src/resources/extensions/gsd/preferences.ts
+++ b/src/resources/extensions/gsd/preferences.ts
@@ -595,6 +595,18 @@ export function getNextFallbackModel(
   }
 }
 
+/**
+ * Detect whether an error message indicates a transient network error
+ * (worth retrying the same model) vs a permanent provider error
+ * (auth failure, quota exceeded, etc. — should fall back immediately).
+ */
+export function isTransientNetworkError(errorMsg: string): boolean {
+  if (!errorMsg) return false;
+  const hasNetworkSignal = /network|ECONNRESET|ETIMEDOUT|ECONNREFUSED|socket hang up|fetch failed|connection.*reset|dns/i.test(errorMsg);
+  const hasPermanentSignal = /auth|unauthorized|forbidden|invalid.*key|quota|billing/i.test(errorMsg);
+  return hasNetworkSignal && !hasPermanentSignal;
+}
+
 export function resolveModelWithFallbacksForUnit(unitType: string): ResolvedModelConfig | undefined {
   const prefs = loadEffectiveGSDPreferences();
   if (!prefs?.preferences.models) return undefined;

--- a/src/resources/extensions/gsd/tests/network-error-fallback.test.ts
+++ b/src/resources/extensions/gsd/tests/network-error-fallback.test.ts
@@ -6,7 +6,7 @@ import assert from "node:assert/strict";
 // just test that `resolveModelWithFallbacksForUnit` returns the correct format since
 // the fallback rotation logic itself was verified manually.
 
-import { getNextFallbackModel } from "../preferences.ts";
+import { getNextFallbackModel, isTransientNetworkError } from "../preferences.ts";
 
 test("getNextFallbackModel selects next fallback if current is a fallback", () => {
     const modelConfig = { primary: "model-a", fallbacks: ["model-b", "model-c"] };
@@ -51,4 +51,54 @@ test("getNextFallbackModel returns primary if current model is undefined", () =>
     const nextModelId = getNextFallbackModel(currentModelId, modelConfig);
 
     assert.equal(nextModelId, "model-a", "should default to primary if current is undefined");
+});
+
+// ── isTransientNetworkError tests ────────────────────────────────────────────
+
+test("isTransientNetworkError detects ECONNRESET", () => {
+    assert.ok(isTransientNetworkError("fetch failed: ECONNRESET"));
+});
+
+test("isTransientNetworkError detects ETIMEDOUT", () => {
+    assert.ok(isTransientNetworkError("ETIMEDOUT: request timed out"));
+});
+
+test("isTransientNetworkError detects generic network error", () => {
+    assert.ok(isTransientNetworkError("network error"));
+});
+
+test("isTransientNetworkError detects socket hang up", () => {
+    assert.ok(isTransientNetworkError("socket hang up"));
+});
+
+test("isTransientNetworkError detects fetch failed", () => {
+    assert.ok(isTransientNetworkError("fetch failed"));
+});
+
+test("isTransientNetworkError detects connection reset", () => {
+    assert.ok(isTransientNetworkError("connection was reset by peer"));
+});
+
+test("isTransientNetworkError detects DNS errors", () => {
+    assert.ok(isTransientNetworkError("dns resolution failed"));
+});
+
+test("isTransientNetworkError rejects auth errors", () => {
+    assert.ok(!isTransientNetworkError("unauthorized: invalid API key"));
+});
+
+test("isTransientNetworkError rejects quota errors", () => {
+    assert.ok(!isTransientNetworkError("quota exceeded"));
+});
+
+test("isTransientNetworkError rejects billing errors", () => {
+    assert.ok(!isTransientNetworkError("billing issue: network payment required"));
+});
+
+test("isTransientNetworkError rejects empty string", () => {
+    assert.ok(!isTransientNetworkError(""));
+});
+
+test("isTransientNetworkError rejects non-network errors", () => {
+    assert.ok(!isTransientNetworkError("model not found"));
 });


### PR DESCRIPTION
## Summary

Fixes #941 — auto-mode now retries transient network errors before falling back to the next model in the chain.

## Problem

When a provider hits a transient network error (ECONNRESET, ETIMEDOUT, socket hang up, etc.) during auto-mode, the `agent_end` error handler immediately triggers `getNextFallbackModel()` and switches to the next model. There is zero retry of the current model. This means providers with occasional network flakiness (e.g. `zai-coding-plan/glm-5`) get abandoned after a single transient error.

## Fix

Three files changed (110 lines added):

### `preferences.ts` — `isTransientNetworkError()` utility
Extracted testable function that distinguishes transient network errors from permanent provider errors:
- **Transient** (retry): `ECONNRESET`, `ETIMEDOUT`, `ECONNREFUSED`, `socket hang up`, `fetch failed`, `connection reset`, `dns`
- **Permanent** (immediate fallback): `auth`, `unauthorized`, `forbidden`, `invalid key`, `quota`, `billing`

### `index.ts` — retry-before-fallback logic
In the `agent_end` error handler, before the existing fallback chain:
1. Check if error is transient via `isTransientNetworkError()`
2. If transient: retry same model up to **2 times** with linear backoff (3s, 6s)
3. If retries exhausted: clear counter, fall through to existing fallback chain
4. If not transient: skip retry, go directly to fallback (existing behavior)

State tracked in `networkRetryCounters` map (per-model), cleared on:
- Successful unit completion
- Model switch (fallback)

### `network-error-fallback.test.ts` — 12 new tests
Coverage for all transient signal patterns and permanent error exclusions.

## Testing
- Build passes cleanly
- All 17 tests pass (5 existing + 12 new)
- No behavioral change for non-network errors (auth, rate limit, etc.)
