### PR TITLE
fix: add git.manage_gitignore preference to opt out of .gitignore changes (#950)

### DIFF
--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -734,9 +734,11 @@ export async function startAuto(
   }
 
   // Ensure .gitignore has baseline patterns
-  const commitDocs = loadEffectiveGSDPreferences()?.preferences?.git?.commit_docs;
-  ensureGitignore(base, { commitDocs });
-  untrackRuntimeFiles(base);
+  const gitPrefs = loadEffectiveGSDPreferences()?.preferences?.git;
+  const commitDocs = gitPrefs?.commit_docs;
+  const manageGitignore = gitPrefs?.manage_gitignore;
+  ensureGitignore(base, { commitDocs, manageGitignore });
+  if (manageGitignore !== false) untrackRuntimeFiles(base);
 
   // Bootstrap .gsd/ if it doesn't exist
   const gsdDir = join(base, ".gsd");

--- a/src/resources/extensions/gsd/git-service.ts
+++ b/src/resources/extensions/gsd/git-service.ts
@@ -53,6 +53,12 @@ export interface GitPreferences {
    *  Default: true (planning docs are tracked in git).
    */
   commit_docs?: boolean;
+  /** When false, GSD will not modify .gitignore at all — no baseline patterns
+   *  are added and no self-healing occurs. Use this if you manage your own
+   *  .gitignore and don't want GSD touching it.
+   *  Default: true (GSD ensures baseline patterns are present).
+   */
+  manage_gitignore?: boolean;
   /** Script to run after a worktree is created (#597).
    *  Receives SOURCE_DIR and WORKTREE_DIR as environment variables.
    *  Can be an absolute path or relative to the project root.

--- a/src/resources/extensions/gsd/gitignore.ts
+++ b/src/resources/extensions/gsd/gitignore.ts
@@ -85,7 +85,10 @@ const BASELINE_PATTERNS = [
  * .gitignore instead of individual runtime patterns, keeping all GSD
  * artifacts local-only.
  */
-export function ensureGitignore(basePath: string, options?: { commitDocs?: boolean }): boolean {
+export function ensureGitignore(basePath: string, options?: { commitDocs?: boolean; manageGitignore?: boolean }): boolean {
+  // If manage_gitignore is explicitly false, do not touch .gitignore at all
+  if (options?.manageGitignore === false) return false;
+
   const gitignorePath = join(basePath, ".gitignore");
   const commitDocs = options?.commitDocs !== false; // default true
 

--- a/src/resources/extensions/gsd/preferences.ts
+++ b/src/resources/extensions/gsd/preferences.ts
@@ -1317,6 +1317,10 @@ export function validatePreferences(preferences: GSDPreferences): {
       if (typeof g.commit_docs === "boolean") git.commit_docs = g.commit_docs;
       else errors.push("git.commit_docs must be a boolean");
     }
+    if (g.manage_gitignore !== undefined) {
+      if (typeof g.manage_gitignore === "boolean") git.manage_gitignore = g.manage_gitignore;
+      else errors.push("git.manage_gitignore must be a boolean");
+    }
     if (g.worktree_post_create !== undefined) {
       if (typeof g.worktree_post_create === "string" && g.worktree_post_create.trim()) {
         git.worktree_post_create = g.worktree_post_create.trim();


### PR DESCRIPTION
Fixes #950

Adds a `manage_gitignore` boolean to the `git` preferences block. When set to `false`, GSD will not modify `.gitignore` at all — no baseline patterns added, no self-healing, no untracking.

**Usage in `.gsd/preferences.md`:**
```yaml
git:
  manage_gitignore: false
```

**Files changed:**
- `git-service.ts`: Add `manage_gitignore` to `GitPreferences` interface with documentation
- `gitignore.ts`: Early return in `ensureGitignore()` when `manageGitignore` is `false`
- `auto.ts`: Pass `manage_gitignore` preference to `ensureGitignore` and gate `untrackRuntimeFiles`
- `preferences.ts`: Parse and validate `manage_gitignore` in git config section