### PR TITLE
fix: single ENTER submits slash command argument autocomplete (#944)

### DIFF
--- a/packages/pi-tui/src/components/editor.ts
+++ b/packages/pi-tui/src/components/editor.ts
@@ -559,7 +559,9 @@ export class Editor implements Component, Focusable {
 					this.state.cursorLine = result.cursorLine;
 					this.setCursorCol(result.cursorCol);
 
-					if (this.autocompletePrefix.startsWith("/")) {
+					if (this.autocompletePrefix.startsWith("/") || this.isInSlashCommandContext(
+						(this.state.lines[this.state.cursorLine] || "").slice(0, this.state.cursorCol),
+					)) {
 						this.cancelAutocomplete();
 						// Fall through to submit
 					} else {


### PR DESCRIPTION
Fixes #944

When completing a `/gsd` subcommand via autocomplete (e.g. selecting `auto` after typing `/gsd `), ENTER now submits immediately instead of requiring a second press.

**Root cause:** The `selectConfirm` handler in `editor.ts` only fell through to submit when `autocompletePrefix.startsWith("/")` — true for command name completion (`/gsd`) but not for argument completion (`auto`). Arguments hit the `else` branch which returned without submitting.

**Fix:** Also fall through to submit when the cursor is in a slash command context (`isInSlashCommandContext()`), not just when the prefix starts with `/`.

Non-slash completions (`@file` references, paths) still require explicit ENTER — only slash command arguments auto-submit.

**File changed:** `packages/pi-tui/src/components/editor.ts` — 3 lines added, 1 removed