### PR TITLE
feat: add git.manage_gitignore preference to opt out of opinionated .gitignore patterns

### DIFF
--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -734,8 +734,8 @@ export async function startAuto(
   }
 
   // Ensure .gitignore has baseline patterns
-  const commitDocs = loadEffectiveGSDPreferences()?.preferences?.git?.commit_docs;
-  ensureGitignore(base, { commitDocs });
+  const gitPrefs = loadEffectiveGSDPreferences()?.preferences?.git;
+  ensureGitignore(base, { commitDocs: gitPrefs?.commit_docs, manageGitignore: gitPrefs?.manage_gitignore });
   untrackRuntimeFiles(base);
 
   // Bootstrap .gsd/ if it doesn't exist

--- a/src/resources/extensions/gsd/doctor.ts
+++ b/src/resources/extensions/gsd/doctor.ts
@@ -960,7 +960,8 @@ async function checkRuntimeHealth(
           });
 
           if (shouldFix("gitignore_missing_patterns")) {
-            ensureGitignore(basePath);
+            const docGitPrefs = loadEffectiveGSDPreferences()?.preferences?.git;
+            ensureGitignore(basePath, { commitDocs: docGitPrefs?.commit_docs, manageGitignore: docGitPrefs?.manage_gitignore });
             fixesApplied.push("added missing GSD runtime patterns to .gitignore");
           }
         }

--- a/src/resources/extensions/gsd/git-service.ts
+++ b/src/resources/extensions/gsd/git-service.ts
@@ -53,6 +53,11 @@ export interface GitPreferences {
    *  Default: true (planning docs are tracked in git).
    */
   commit_docs?: boolean;
+  /** When false, GSD only adds its own runtime patterns to .gitignore
+   *  and skips opinionated baseline patterns (IDE, language, OS junk).
+   *  Default: true (full baseline patterns are added).
+   */
+  manage_gitignore?: boolean;
   /** Script to run after a worktree is created (#597).
    *  Receives SOURCE_DIR and WORKTREE_DIR as environment variables.
    *  Can be an absolute path or relative to the project root.

--- a/src/resources/extensions/gsd/gitignore.ts
+++ b/src/resources/extensions/gsd/gitignore.ts
@@ -85,9 +85,10 @@ const BASELINE_PATTERNS = [
  * .gitignore instead of individual runtime patterns, keeping all GSD
  * artifacts local-only.
  */
-export function ensureGitignore(basePath: string, options?: { commitDocs?: boolean }): boolean {
+export function ensureGitignore(basePath: string, options?: { commitDocs?: boolean; manageGitignore?: boolean }): boolean {
   const gitignorePath = join(basePath, ".gitignore");
   const commitDocs = options?.commitDocs !== false; // default true
+  const manageGitignore = options?.manageGitignore !== false; // default true
 
   let existing = "";
   if (existsSync(gitignorePath)) {
@@ -130,15 +131,23 @@ export function ensureGitignore(basePath: string, options?: { commitDocs?: boole
       .filter((l) => l && !l.startsWith("#")),
   );
 
+  // When manage_gitignore is false, only add GSD runtime patterns — skip
+  // opinionated baseline patterns (IDE, language, OS junk) so the user's
+  // .gitignore is left alone.
+  const patterns = manageGitignore ? BASELINE_PATTERNS : GSD_RUNTIME_PATTERNS;
+
   // Find patterns not yet present
-  const missing = BASELINE_PATTERNS.filter((p) => !existingLines.has(p));
+  const missing = patterns.filter((p) => !existingLines.has(p));
 
   if (missing.length === 0) return modified;
 
   // Build the block to append
+  const label = manageGitignore
+    ? "# ── GSD baseline (auto-generated) ──"
+    : "# ── GSD runtime (auto-generated) ──";
   const block = [
     "",
-    "# ── GSD baseline (auto-generated) ──",
+    label,
     ...missing,
     "",
   ].join("\n");
@@ -216,7 +225,7 @@ See \`~/.gsd/agent/extensions/gsd/docs/preferences-reference.md\` for full field
 - \`models\`: Model preferences for specific task types
 - \`skill_discovery\`: Automatic skill detection preferences
 - \`auto_supervisor\`: Supervision and gating rules for autonomous modes
-- \`git\`: Git preferences — \`main_branch\` (default branch name for new repos, e.g., "main", "master", "trunk"), \`auto_push\`, \`snapshots\`, \`commit_docs\` (set to \`false\` to keep .gsd/ local-only), etc.
+- \`git\`: Git preferences — \`main_branch\` (default branch name for new repos, e.g., "main", "master", "trunk"), \`auto_push\`, \`snapshots\`, \`commit_docs\` (set to \`false\` to keep .gsd/ local-only), \`manage_gitignore\` (set to \`false\` to prevent GSD from adding opinionated patterns like IDE/language/OS entries — GSD runtime patterns are still added), etc.
 
 ## Examples
 

--- a/src/resources/extensions/gsd/guided-flow.ts
+++ b/src/resources/extensions/gsd/guided-flow.ts
@@ -252,8 +252,8 @@ function bootstrapGsdProject(basePath: string): void {
   mkdirSync(join(root, "milestones"), { recursive: true });
   mkdirSync(join(root, "runtime"), { recursive: true });
 
-  const commitDocs = loadEffectiveGSDPreferences()?.preferences?.git?.commit_docs;
-  ensureGitignore(basePath, { commitDocs });
+  const gitPrefs = loadEffectiveGSDPreferences()?.preferences?.git;
+  ensureGitignore(basePath, { commitDocs: gitPrefs?.commit_docs, manageGitignore: gitPrefs?.manage_gitignore });
   ensurePreferences(basePath);
   untrackRuntimeFiles(basePath);
 }
@@ -1074,8 +1074,8 @@ export async function showSmartEntry(
   }
 
   // ── Ensure .gitignore has baseline patterns ──────────────────────────
-  const commitDocs = loadEffectiveGSDPreferences()?.preferences?.git?.commit_docs;
-  ensureGitignore(basePath, { commitDocs });
+  const gitPrefs = loadEffectiveGSDPreferences()?.preferences?.git;
+  ensureGitignore(basePath, { commitDocs: gitPrefs?.commit_docs, manageGitignore: gitPrefs?.manage_gitignore });
   untrackRuntimeFiles(basePath);
 
   // ── No GSD project OR no milestone → Create first/next milestone ────

--- a/src/resources/extensions/gsd/preferences.ts
+++ b/src/resources/extensions/gsd/preferences.ts
@@ -1317,6 +1317,10 @@ export function validatePreferences(preferences: GSDPreferences): {
       if (typeof g.commit_docs === "boolean") git.commit_docs = g.commit_docs;
       else errors.push("git.commit_docs must be a boolean");
     }
+    if (g.manage_gitignore !== undefined) {
+      if (typeof g.manage_gitignore === "boolean") git.manage_gitignore = g.manage_gitignore;
+      else errors.push("git.manage_gitignore must be a boolean");
+    }
     if (g.worktree_post_create !== undefined) {
       if (typeof g.worktree_post_create === "string" && g.worktree_post_create.trim()) {
         git.worktree_post_create = g.worktree_post_create.trim();

--- a/src/resources/extensions/gsd/tests/git-service.test.ts
+++ b/src/resources/extensions/gsd/tests/git-service.test.ts
@@ -1218,6 +1218,65 @@ async function main(): Promise<void> {
     rmSync(repo, { recursive: true, force: true });
   }
 
+  // ─── ensureGitignore: manage_gitignore false skips baseline patterns ─
+
+  console.log("\n=== ensureGitignore: manage_gitignore false ===");
+
+  {
+    const { ensureGitignore } = await import("../gitignore.ts");
+    const repo = mkdtempSync(join(tmpdir(), "gsd-gitignore-manage-false-"));
+
+    // When manage_gitignore is false, should only add GSD runtime patterns
+    const modified = ensureGitignore(repo, { manageGitignore: false });
+    assertTrue(modified, "manage_gitignore=false: gitignore was modified");
+
+    const { readFileSync } = await import("node:fs");
+    const content = readFileSync(join(repo, ".gitignore"), "utf-8");
+
+    // Should contain GSD runtime patterns
+    assertTrue(content.includes(".gsd/forensics/"), "manage_gitignore=false: has GSD runtime pattern");
+    assertTrue(content.includes(".gsd/runtime/"), "manage_gitignore=false: has .gsd/runtime/");
+    assertTrue(content.includes("GSD runtime (auto-generated)"), "manage_gitignore=false: has runtime label");
+
+    // Should NOT contain opinionated baseline patterns
+    assertTrue(!content.includes("node_modules/"), "manage_gitignore=false: no node_modules");
+    assertTrue(!content.includes(".idea/"), "manage_gitignore=false: no .idea/");
+    assertTrue(!content.includes("__pycache__/"), "manage_gitignore=false: no __pycache__");
+    assertTrue(!content.includes("Thumbs.db"), "manage_gitignore=false: no Thumbs.db");
+    assertTrue(!content.includes("*.swp"), "manage_gitignore=false: no *.swp");
+    assertTrue(!content.includes("target/"), "manage_gitignore=false: no target/");
+
+    // Idempotent
+    const modified2 = ensureGitignore(repo, { manageGitignore: false });
+    assertTrue(!modified2, "manage_gitignore=false: second call is idempotent");
+
+    rmSync(repo, { recursive: true, force: true });
+  }
+
+  // ─── ensureGitignore: manage_gitignore true (default) adds everything ─
+
+  console.log("\n=== ensureGitignore: manage_gitignore true (default) ===");
+
+  {
+    const { ensureGitignore } = await import("../gitignore.ts");
+    const repo = mkdtempSync(join(tmpdir(), "gsd-gitignore-manage-true-"));
+
+    // Default (manage_gitignore not set) should add full baseline patterns
+    const modified = ensureGitignore(repo);
+    assertTrue(modified, "manage_gitignore=default: gitignore was modified");
+
+    const { readFileSync } = await import("node:fs");
+    const content = readFileSync(join(repo, ".gitignore"), "utf-8");
+
+    // Should contain both GSD runtime and baseline patterns
+    assertTrue(content.includes(".gsd/forensics/"), "manage_gitignore=default: has GSD runtime pattern");
+    assertTrue(content.includes("node_modules/"), "manage_gitignore=default: has node_modules");
+    assertTrue(content.includes(".idea/"), "manage_gitignore=default: has .idea/");
+    assertTrue(content.includes("GSD baseline (auto-generated)"), "manage_gitignore=default: has baseline label");
+
+    rmSync(repo, { recursive: true, force: true });
+  }
+
   report();
 }
 


### PR DESCRIPTION
## Summary

Fixes #950 — Users can now set `git.manage_gitignore: false` in their GSD preferences to prevent GSD from adding opinionated baseline patterns (IDE files, `node_modules/`, language-specific entries, OS junk) to `.gitignore`.

When disabled, GSD still adds its own runtime patterns (`.gsd/forensics/`, `.gsd/runtime/`, `.gsd/auto.lock`, etc.) to ensure GSD internals are never tracked, but leaves the rest of the user's `.gitignore` untouched.

### Usage

Add to `~/.gsd/preferences.md` or `.gsd/preferences.md` YAML frontmatter:

```yaml
git:
  manage_gitignore: false
```

### What changed

- **`git-service.ts`** — Added `manage_gitignore?: boolean` to the `GitPreferences` interface with JSDoc
- **`gitignore.ts`** — `ensureGitignore()` now accepts `manageGitignore` option. When `false`, only `GSD_RUNTIME_PATTERNS` are used (not the full `BASELINE_PATTERNS`), and the auto-generated comment label changes to `# ── GSD runtime (auto-generated) ──` for clarity
- **`preferences.ts`** — Added parser validation for the new boolean field, placed alongside the existing `commit_docs` validation
- **`auto.ts`** — Updated call site to load and pass `manage_gitignore` from effective preferences
- **`guided-flow.ts`** — Updated both call sites (bootstrap and `/gsd` entry) to pass the preference through
- **`doctor.ts`** — Updated the gitignore fix path to respect the preference
- **`git-service.test.ts`** — Added 2 new test cases:
  - `manage_gitignore=false`: verifies only GSD runtime patterns are added, no IDE/language/OS patterns, and idempotency
  - `manage_gitignore=default` (true): verifies full baseline patterns are added as before

### Design decisions

- **Default is `true`** (existing behavior) — no breaking change for existing users
- **GSD runtime patterns are always added** regardless of the setting — these are GSD's own internal files that should never be tracked
- **Separate from `commit_docs`** — `commit_docs` controls whether `.gsd/` planning docs are committed; `manage_gitignore` controls whether GSD adds non-GSD patterns to `.gitignore`. They serve different purposes and can be used independently

## Test plan

- [x] All 165 existing git-service tests pass
- [x] New test: `manage_gitignore=false` only adds GSD runtime patterns, not baseline
- [x] New test: `manage_gitignore=true` (default) adds full baseline patterns
- [x] Idempotency verified for `manage_gitignore=false`
- [ ] Manual: set `git.manage_gitignore: false` in preferences, run `/gsd` new milestone, verify `.gitignore` only gets GSD runtime entries