### PR TITLE
fix: break web search loop with consecutive duplicate guard (#949)

### DIFF
--- a/src/resources/extensions/search-the-web/tool-search.ts
+++ b/src/resources/extensions/search-the-web/tool-search.ts
@@ -104,6 +104,12 @@ interface SearchDetails {
 const searchCache = new LRUTTLCache<CachedSearchResult>({ max: 100, ttlMs: 600_000 });
 searchCache.startPurgeInterval(60_000);
 
+// Consecutive duplicate search guard (#949)
+// Tracks recent query keys to detect and break search loops.
+const MAX_CONSECUTIVE_DUPES = 3;
+let lastSearchKey = "";
+let consecutiveDupeCount = 0;
+
 // Summarizer responses: max 50 entries, 15-minute TTL
 const summarizerCache = new LRUTTLCache<string>({ max: 50, ttlMs: 900_000 });
 
@@ -388,6 +394,26 @@ export function registerSearchTool(pi: ExtensionAPI) {
       // Cache lookup (provider-prefixed key)
       // ------------------------------------------------------------------
       const cacheKey = normalizeQuery(effectiveQuery) + `|f:${freshness || ""}|s:${wantSummary}|p:${provider}`;
+
+      // ── Consecutive duplicate search guard (#949) ──────────────────────
+      // If the LLM keeps calling the same search query, break the loop
+      // with an explicit warning instead of returning the same results.
+      if (cacheKey === lastSearchKey) {
+        consecutiveDupeCount++;
+        if (consecutiveDupeCount >= MAX_CONSECUTIVE_DUPES) {
+          consecutiveDupeCount = 0;
+          lastSearchKey = "";
+          return {
+            content: [{ type: "text" as const, text: `⚠️ Search loop detected: the query "${params.query}" has been searched ${MAX_CONSECUTIVE_DUPES + 1} times consecutively with identical results. The information you need is already in the previous search results above. Stop searching and use those results to proceed with your task.` }],
+            isError: true,
+            details: { errorKind: "search_loop", error: "Consecutive duplicate search detected" } satisfies Partial<SearchDetails>,
+          };
+        }
+      } else {
+        lastSearchKey = cacheKey;
+        consecutiveDupeCount = 0;
+      }
+
       const cached = searchCache.get(cacheKey);
 
       if (cached) {


### PR DESCRIPTION
Fixes #949

When the LLM calls the same web search query 4+ times consecutively, the tool now returns an error message telling it to stop searching and use the existing results.

**Problem:** During planning, the LLM can enter a loop where it repeatedly calls web search with the same query (e.g. "MUI v6 to v7 migration"), gets cached results each time, doesn't use them, and searches again. The cache returns instantly but the LLM never breaks out.

**Fix:** Track consecutive duplicate searches via a counter keyed on the normalized query + parameters. After 3 consecutive duplicates (4th search), return an `isError: true` result with an explicit "search loop detected" message instead of returning the same cached results.

The counter resets whenever a different query is searched, so legitimate re-searches after other queries are unaffected.

**File changed:** `src/resources/extensions/search-the-web/tool-search.ts` — 26 lines added