### PR TITLE
fix: auto-resume on transient server errors, not just rate limits (#886)

### DIFF
--- a/src/resources/extensions/gsd/index.ts
+++ b/src/resources/extensions/gsd/index.ts
@@ -59,7 +59,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { shortcutDesc } from "../shared/terminal.js";
 import { Text } from "@gsd/pi-tui";
-import { pauseAutoForProviderError } from "./provider-error-pause.js";
+import { pauseAutoForProviderError, classifyProviderError } from "./provider-error-pause.js";
 import { toPosixPath } from "../shared/path-display.js";
 import { isParallelActive, shutdownParallel } from "./parallel-orchestrator.js";
 
@@ -817,18 +817,22 @@ export default function (pi: ExtensionAPI) {
         }
       }
 
-      // Detect rate-limit errors and extract retry delay for auto-resume
-      const isRateLimit = /rate.?limit|too many requests|429/i.test(errorMsg);
-      const retryAfterMs = ("retryAfterMs" in lastMsg && typeof lastMsg.retryAfterMs === "number")
+      // Classify the error: transient (auto-resume) vs permanent (manual resume)
+      const classification = classifyProviderError(errorMsg);
+
+      // Extract explicit retry-after from the message or response metadata
+      const explicitRetryAfterMs = ("retryAfterMs" in lastMsg && typeof lastMsg.retryAfterMs === "number")
         ? lastMsg.retryAfterMs
-        : (() => { const m = errorMsg.match(/reset in (\d+)s/i); return m ? Number(m[1]) * 1000 : undefined; })();
+        : undefined;
+      const retryAfterMs = explicitRetryAfterMs ?? classification.suggestedDelayMs;
 
       await pauseAutoForProviderError(ctx.ui, errorDetail, () => pauseAuto(ctx, pi), {
-        isRateLimit,
+        isRateLimit: classification.isRateLimit,
+        isTransient: classification.isTransient,
         retryAfterMs,
         resume: () => {
           pi.sendMessage(
-            { customType: "gsd-auto-timeout-recovery", content: "Continue execution \u2014 rate limit window elapsed.", display: false },
+            { customType: "gsd-auto-timeout-recovery", content: "Continue execution \u2014 provider error recovery delay elapsed.", display: false },
             { triggerTurn: true },
           );
         },

--- a/src/resources/extensions/gsd/provider-error-pause.ts
+++ b/src/resources/extensions/gsd/provider-error-pause.ts
@@ -3,11 +3,50 @@ export type ProviderErrorPauseUI = {
 };
 
 /**
+ * Classify a provider error as transient (auto-resume) or permanent (manual resume).
+ *
+ * Transient: rate limits, server errors (500/502/503), overloaded, internal errors.
+ * These are expected to self-resolve and should auto-resume after a delay.
+ *
+ * Permanent: auth errors, invalid API key, billing issues.
+ * These require user intervention and should pause indefinitely.
+ */
+export function classifyProviderError(errorMsg: string): {
+  isTransient: boolean;
+  isRateLimit: boolean;
+  suggestedDelayMs: number;
+} {
+  const isRateLimit = /rate.?limit|too many requests|429/i.test(errorMsg);
+  const isServerError = /internal server error|500|502|503|overloaded|server_error|api_error|service.?unavailable/i.test(errorMsg);
+
+  // Permanent errors — never auto-resume
+  const isPermanent = /auth|unauthorized|forbidden|invalid.*key|invalid.*api|billing|quota exceeded|account/i.test(errorMsg);
+
+  if (isPermanent && !isRateLimit) {
+    return { isTransient: false, isRateLimit: false, suggestedDelayMs: 0 };
+  }
+
+  if (isRateLimit) {
+    // Try to extract retry-after from the message
+    const resetMatch = errorMsg.match(/reset in (\d+)s/i);
+    const delayMs = resetMatch ? Number(resetMatch[1]) * 1000 : 60_000; // default 60s for rate limits
+    return { isTransient: true, isRateLimit: true, suggestedDelayMs: delayMs };
+  }
+
+  if (isServerError) {
+    return { isTransient: true, isRateLimit: false, suggestedDelayMs: 30_000 }; // 30s for server errors
+  }
+
+  // Unknown error — treat as permanent (user reviews)
+  return { isTransient: false, isRateLimit: false, suggestedDelayMs: 0 };
+}
+
+/**
  * Pause auto-mode due to a provider error.
  *
- * For rate-limit errors with a known reset delay, schedules an automatic
- * resume after the delay and shows a countdown notification. For all other
- * errors, pauses indefinitely (user must manually resume).
+ * For transient errors (rate limits, server errors, overloaded), schedules
+ * an automatic resume after a delay. For permanent errors (auth, billing),
+ * pauses indefinitely — user must manually resume.
  */
 export async function pauseAutoForProviderError(
   ui: ProviderErrorPauseUI,
@@ -15,23 +54,33 @@ export async function pauseAutoForProviderError(
   pause: () => Promise<void>,
   options?: {
     isRateLimit?: boolean;
+    isTransient?: boolean;
     retryAfterMs?: number;
     resume?: () => void;
   },
 ): Promise<void> {
-  if (options?.isRateLimit && options.retryAfterMs && options.retryAfterMs > 0 && options.resume) {
-    const delaySec = Math.ceil(options.retryAfterMs / 1000);
+  const shouldAutoResume = (options?.isRateLimit || options?.isTransient)
+    && options.retryAfterMs
+    && options.retryAfterMs > 0
+    && options.resume;
+
+  if (shouldAutoResume) {
+    const delaySec = Math.ceil(options!.retryAfterMs! / 1000);
+    const reason = options!.isRateLimit ? "Rate limited" : "Server error (transient)";
     ui.notify(
-      `Rate limited${errorDetail}. Auto-resuming in ${delaySec}s...`,
+      `${reason}${errorDetail}. Auto-resuming in ${delaySec}s...`,
       "warning",
     );
     await pause();
 
-    // Schedule auto-resume after the rate limit window
+    // Schedule auto-resume after the delay
     setTimeout(() => {
-      ui.notify("Rate limit window elapsed. Resuming auto-mode.", "info");
-      options.resume!();
-    }, options.retryAfterMs);
+      const resumeMsg = options!.isRateLimit
+        ? "Rate limit window elapsed. Resuming auto-mode."
+        : "Server error recovery delay elapsed. Resuming auto-mode.";
+      ui.notify(resumeMsg, "info");
+      options!.resume!();
+    }, options!.retryAfterMs!);
   } else {
     ui.notify(`Auto-mode paused due to provider error${errorDetail}`, "warning");
     await pause();

--- a/src/resources/extensions/gsd/tests/provider-error-classify.test.ts
+++ b/src/resources/extensions/gsd/tests/provider-error-classify.test.ts
@@ -1,0 +1,95 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { classifyProviderError } from "../provider-error-pause.ts";
+
+// ── Rate limit detection ─────────────────────────────────────────────────────
+
+test("classifyProviderError detects rate limit from 429", () => {
+  const result = classifyProviderError("HTTP 429 Too Many Requests");
+  assert.ok(result.isTransient);
+  assert.ok(result.isRateLimit);
+  assert.ok(result.suggestedDelayMs > 0);
+});
+
+test("classifyProviderError detects rate limit from message", () => {
+  const result = classifyProviderError("rate limit exceeded");
+  assert.ok(result.isTransient);
+  assert.ok(result.isRateLimit);
+});
+
+test("classifyProviderError extracts reset delay from message", () => {
+  const result = classifyProviderError("rate limit exceeded, reset in 45s");
+  assert.equal(result.suggestedDelayMs, 45000);
+});
+
+test("classifyProviderError defaults to 60s for rate limit without reset", () => {
+  const result = classifyProviderError("too many requests");
+  assert.equal(result.suggestedDelayMs, 60000);
+});
+
+// ── Server error detection ───────────────────────────────────────────────────
+
+test("classifyProviderError detects Anthropic internal server error", () => {
+  const msg = '{"type":"error","error":{"details":null,"type":"api_error","message":"Internal server error"}}';
+  const result = classifyProviderError(msg);
+  assert.ok(result.isTransient, "should be transient");
+  assert.ok(!result.isRateLimit, "should not be rate limit");
+  assert.equal(result.suggestedDelayMs, 30000, "should suggest 30s delay");
+});
+
+test("classifyProviderError detects overloaded error", () => {
+  const result = classifyProviderError("overloaded_error: Overloaded");
+  assert.ok(result.isTransient);
+  assert.equal(result.suggestedDelayMs, 30000);
+});
+
+test("classifyProviderError detects 503 service unavailable", () => {
+  const result = classifyProviderError("503 Service Unavailable");
+  assert.ok(result.isTransient);
+});
+
+test("classifyProviderError detects 502 bad gateway", () => {
+  const result = classifyProviderError("502 Bad Gateway");
+  assert.ok(result.isTransient);
+});
+
+// ── Permanent error detection ────────────────────────────────────────────────
+
+test("classifyProviderError detects auth error as permanent", () => {
+  const result = classifyProviderError("unauthorized: invalid API key");
+  assert.ok(!result.isTransient);
+  assert.ok(!result.isRateLimit);
+  assert.equal(result.suggestedDelayMs, 0);
+});
+
+test("classifyProviderError detects billing error as permanent", () => {
+  const result = classifyProviderError("billing issue: payment required");
+  assert.ok(!result.isTransient);
+});
+
+test("classifyProviderError detects quota exceeded as permanent", () => {
+  const result = classifyProviderError("quota exceeded for this account");
+  assert.ok(!result.isTransient);
+});
+
+// ── Unknown errors ───────────────────────────────────────────────────────────
+
+test("classifyProviderError treats unknown error as permanent", () => {
+  const result = classifyProviderError("something went wrong");
+  assert.ok(!result.isTransient);
+  assert.equal(result.suggestedDelayMs, 0);
+});
+
+test("classifyProviderError treats empty string as permanent", () => {
+  const result = classifyProviderError("");
+  assert.ok(!result.isTransient);
+});
+
+// ── Edge: rate limit + auth (rate limit wins) ────────────────────────────────
+
+test("classifyProviderError: rate limit takes precedence over auth keywords", () => {
+  // Edge case: "rate limit" in message that also mentions auth
+  const result = classifyProviderError("rate limit on auth endpoint");
+  assert.ok(result.isTransient);
+  assert.ok(result.isRateLimit);
+});


### PR DESCRIPTION
## Summary

Fixes the core complaint in #886 — overnight auto-mode runs pause indefinitely on transient Anthropic 500/503 errors, requiring manual resume.

## Problem

The `agent_end` error handler only auto-resumed for rate-limit errors (`429`/`too many requests`). Server errors like Anthropic's `{"type":"api_error","message":"Internal server error"}` were treated as permanent errors, pausing auto-mode indefinitely. Users running overnight jobs would wake up to find GSD paused for hours on a transient blip.

## Fix

New `classifyProviderError()` function provides structured error classification:

| Error type | Examples | Action | Default delay |
|-----------|----------|--------|---------------|
| **Rate limit** | 429, "too many requests", "rate limit" | Auto-resume | retry-after header or 60s |
| **Server error** | 500, 502, 503, "overloaded", "api_error", "Internal server error" | Auto-resume | 30s |
| **Permanent** | "unauthorized", "invalid key", "billing", "quota exceeded" | Pause indefinitely | — |
| **Unknown** | anything else | Pause indefinitely | — |

The `pauseAutoForProviderError()` function now accepts an `isTransient` flag alongside `isRateLimit`, and auto-resumes for both.

## Files changed

| File | Change |
|------|--------|
| `provider-error-pause.ts` | New `classifyProviderError()`, updated `pauseAutoForProviderError()` with `isTransient` support |
| `index.ts` | Use `classifyProviderError()` instead of inline regex for error classification |
| `tests/provider-error-classify.test.ts` | 14 new tests covering all error categories |

## Testing
- Both tsconfigs pass cleanly
- 1238/1238 unit tests pass (14 new)