### PR TITLE
fix: export RPC utilities from pi-coding-agent public API

### DIFF
--- a/packages/pi-coding-agent/src/index.ts
+++ b/packages/pi-coding-agent/src/index.ts
@@ -302,7 +302,16 @@ export {
 	type PrintModeOptions,
 	runPrintMode,
 	runRpcMode,
+	type ModelInfo,
+	RpcClient,
+	type RpcClientOptions,
+	type RpcEventListener,
+	type RpcCommand,
+	type RpcResponse,
+	type RpcSessionState,
 } from "./modes/index.js";
+// RPC JSONL utilities
+export { attachJsonlLineReader, serializeJsonLine } from "./modes/rpc/jsonl.js";
 // UI components for extensions
 export {
 	ArminComponent,

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -15,10 +15,7 @@ import { existsSync, readFileSync, mkdirSync, writeFileSync } from 'node:fs'
 import { join, resolve } from 'node:path'
 import { ChildProcess } from 'node:child_process'
 
-// RpcClient is not in @gsd/pi-coding-agent's public exports — import from dist directly.
-// This relative path resolves correctly from both src/ (via tsx) and dist/ (compiled).
-import { RpcClient } from '../packages/pi-coding-agent/dist/modes/rpc/rpc-client.js'
-import { attachJsonlLineReader, serializeJsonLine } from '../packages/pi-coding-agent/dist/modes/rpc/jsonl.js'
+import { RpcClient, attachJsonlLineReader, serializeJsonLine } from '@gsd/pi-coding-agent'
 
 // ---------------------------------------------------------------------------
 // Types


### PR DESCRIPTION
## Summary
- Exports `RpcClient`, `attachJsonlLineReader`, and `serializeJsonLine` from `@gsd/pi-coding-agent` public API
- Updates `src/headless.ts` to import from public API instead of reaching into `dist/`
- Removes fragile cross-package dist/ imports

Resolves coherence audit item 01-7: import path fragility via dist/ imports.

## Test plan
- [ ] Build passes (`npm run build`)
- [ ] Headless mode works (`gsd headless` starts without import errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)