### PR TITLE
docs: clarify scout vs researcher delegation in system.md

### DIFF
--- a/src/resources/extensions/gsd/prompts/research-milestone.md
+++ b/src/resources/extensions/gsd/prompts/research-milestone.md
@@ -23,7 +23,7 @@ A milestone adding a small feature to an established codebase needs targeted res
 Then research the codebase and relevant technologies. Narrate key findings and surprises as you go — what exists, what's missing, what constrains the approach.
 1. If a `GSD Skill Preferences` block is present in system context, use it to decide which skills to load and follow during research, without relaxing required verification or artifact rules
 2. **Skill Discovery ({{skillDiscoveryMode}}):**{{skillDiscoveryInstructions}}
-3. Explore relevant code. For small/familiar codebases, use `rg`, `find`, and targeted reads. For large or unfamiliar codebases, use `scout` to build a broad map efficiently before diving in.
+3. Explore relevant code. For small/familiar codebases, use `rg`, `find`, and targeted reads. For large or unfamiliar codebases, use a `scout` subagent to build a broad map efficiently before diving in.
 4. Use `resolve_library` / `get_library_docs` for unfamiliar libraries — skip this for libraries already used in the codebase
 5. Use the **Research** output template from the inlined context above — include only sections that have real content
 6. If `.gsd/REQUIREMENTS.md` exists, research against it. Identify which Active requirements are table stakes, likely omissions, overbuilt risks, or domain-standard behaviors the user may or may not want.

--- a/src/resources/extensions/gsd/prompts/research-slice.md
+++ b/src/resources/extensions/gsd/prompts/research-slice.md
@@ -18,7 +18,7 @@ Pay particular attention to **Forward Intelligence** sections — they contain h
 
 ## Your Role in the Pipeline
 
-You are the scout. After you finish, a **planner agent** reads your output in a fresh context with no memory of your exploration. It uses your findings to decompose this slice into executable tasks — deciding what files change, what order to build things, how to verify the work. Then **executor agents** build each task in isolated context windows.
+You are the research stage for this slice. After you finish, a **planner agent** reads your output in a fresh context with no memory of your exploration. It uses your findings to decompose this slice into executable tasks — deciding what files change, what order to build things, how to verify the work. Then **executor agents** build each task in isolated context windows.
 
 Write for the planner, not for a human. The planner needs:
 - **What files exist and what they do** — so it can scope tasks to specific files
@@ -44,7 +44,7 @@ Research what this slice needs. Narrate key findings and surprises as you go —
 0. If `REQUIREMENTS.md` was preloaded above, identify which Active requirements this slice owns or supports. Research should target these requirements — surfacing risks, unknowns, and implementation constraints that could affect whether the slice actually delivers them.
 1. **Load relevant skills.** Check the `GSD Skill Preferences` block in system context and the `<available_skills>` catalog in your system prompt. `read` any skill files relevant to this slice's technology stack before exploring code. Reference specific rules from loaded skills in your findings where they inform the implementation approach.
 2. **Skill Discovery ({{skillDiscoveryMode}}):**{{skillDiscoveryInstructions}}
-3. Explore relevant code for this slice's scope. For targeted exploration, use `rg`, `find`, and reads. For broad or unfamiliar subsystems, use `scout` to map the relevant area first.
+3. Explore relevant code for this slice's scope. For targeted exploration, use `rg`, `find`, and reads. For broad or unfamiliar subsystems, use a `scout` subagent to map the relevant area first.
 4. Use `resolve_library` / `get_library_docs` for unfamiliar libraries — skip this for libraries already used in the codebase
 5. Use the **Research** output template from the inlined context above — include only sections that have real content. The template is already inlined above; do NOT attempt to read any template file from disk (there is no `templates/SLICE-RESEARCH.md` — the correct template is already present in this prompt).
 6. Write `{{outputPath}}`

--- a/src/resources/extensions/gsd/prompts/system.md
+++ b/src/resources/extensions/gsd/prompts/system.md
@@ -148,7 +148,17 @@ Templates showing the expected format for each artifact type are in:
 
 **Code navigation:** Use `lsp` for definition, type_definition, implementation, references, incoming_calls, outgoing_calls, hover, signature, symbols, rename, code_actions, format, and diagnostics. Falls back gracefully if no server is available. Never `grep` for a symbol definition when `lsp` can resolve it semantically. Never shell out to prettier/rustfmt/gofmt when `lsp format` is available. After editing code, use `lsp diagnostics` to verify no type errors were introduced.
 
-**Codebase exploration:** Use `subagent` with `scout` for broad unfamiliar subsystem mapping. Use `rg` for text search across files. Use `lsp` for structural navigation. Never read files one-by-one to "explore" — search first, then read what's relevant.
+**Codebase exploration:** Use `rg` for text search across files. Use `lsp` for structural navigation. Never read files one-by-one to "explore" — search first, then read what's relevant.
+
+**Investigation delegation — choose the lightest sufficient approach:**
+
+| Approach | When to use | What it does |
+|---|---|---|
+| **Self-investigation** | Scope is narrow (1-3 files) and you already know where to look | Direct `rg`, `lsp`, `read` calls in your own context window |
+| **Scout subagent** | You need to map an unfamiliar subsystem or locate relevant code across a broad area | Fast codebase recon via `subagent` with `scout`. Returns compressed context (file locations, key types, architecture notes). Minutes, not hours. Use when you need to *find* things. |
+| **Research pipeline stage** | Auto-mode research-milestone or research-slice units | A dedicated context window explores the codebase (or web) and writes a structured research doc (`*-RESEARCH.md`). Used before planning to understand how something works, evaluate approaches, and surface risks. The pipeline invokes this automatically — you do not call it manually. |
+
+The `scout` agent (defined in `agents/scout.md`) is a subagent you invoke on demand via the `subagent` tool. The research pipeline stages (`research-milestone`, `research-slice`) are auto-mode units dispatched by the orchestrator — they are not subagents you invoke directly. When auto-mode prompts refer to "a researcher agent already explored..." they mean the research pipeline stage that ran before the current unit, not the `researcher` subagent (which is a web researcher for external information).
 
 **Documentation lookup:** Use `resolve_library` → `get_library_docs` for library/framework questions. Start with `tokens=5000`. Never guess at API signatures from memory when docs are available.
 
@@ -171,7 +181,7 @@ Templates showing the expected format for each artifact type are in:
 - Never poll a server with `sleep 1 && curl` loops — use `bg_shell` `wait_for_ready`.
 - Never use `bash` with `&` to background a process — it hangs because the child inherits stdout. Use `bg_shell` `start` instead.
 - Never use `bg_shell` `output` for a status check — use `digest`.
-- Never read files one-by-one to understand a subsystem — use `rg` or `scout` first.
+- Never read files one-by-one to understand a subsystem — use `rg` first, or delegate to a `scout` subagent for broad mapping.
 - Never guess at library APIs from training data — use `get_library_docs`.
 - Never ask the user to run a command, set a variable, or check something you can check yourself.
 - Never await stale async jobs after editing source — `cancel_job` them first, then re-run.


### PR DESCRIPTION
## Summary
- Adds investigation delegation decision tree to system.md (self-investigation vs scout subagent vs research pipeline stage)
- Clarifies that "researcher agent" in auto-mode prompts refers to the research pipeline stage, not the `researcher` subagent (which is a web researcher)
- Fixes research-slice.md calling itself "the scout" — now says "the research stage"
- Aligns all references to `scout` to consistently say "scout subagent" to distinguish from pipeline stages

Resolves coherence audit item 03-4.

## Test plan
- [ ] Decision tree in system.md is clear and actionable
- [ ] Terminology consistent across system.md, research-slice.md, and research-milestone.md
- [ ] No functional code changes — prompt text only

🤖 Generated with [Claude Code](https://claude.com/claude-code)