### PR TITLE
docs: document guided prompt selection logic

### DIFF
--- a/src/resources/extensions/gsd/prompts/README.md
+++ b/src/resources/extensions/gsd/prompts/README.md
@@ -1,0 +1,40 @@
+# GSD Prompts
+
+Prompt templates that drive GSD agent behavior. Loaded by `prompt-loader.ts`, which reads all `.md` files at module init and substitutes `{{variable}}` placeholders at dispatch time.
+
+## Two Prompt Variants: Guided vs Full
+
+Each workflow step (execute-task, plan-slice, etc.) has up to two prompt variants:
+
+### Full prompts (`<name>.md`)
+
+Used by **auto-mode** (`auto-prompts.ts`). Auto-mode agents launch in a fresh context with no prior conversation, so full prompts inline all backing artifacts: task plans, slice plans, prior summaries, overrides, decisions, and context files. These prompts are long (50-150+ lines) because they must be entirely self-contained.
+
+### Guided prompts (`guided-<name>.md`)
+
+Used by the **interactive `/gsd` wizard** (`guided-flow.ts`). The guided flow runs inside an active conversation where `showSmartEntry()` has already resolved project state, presented an action menu, and gathered user intent. Guided prompts are concise (1-10 lines) because the surrounding conversation provides context that auto-mode agents lack.
+
+### Selection logic
+
+`guided-flow.ts` determines which guided prompt to load based on the current project phase and the user's menu selection:
+
+| Phase | User action | Prompt loaded |
+|---|---|---|
+| No roadmap, no context | "Discuss first" | `guided-discuss-milestone` |
+| No roadmap | "Create roadmap" | `guided-plan-milestone` |
+| Planning (slice) | "Discuss first" | `guided-discuss-slice` |
+| Planning (slice) | "Research first" | `guided-research-slice` |
+| Planning (slice) | "Plan" | `guided-plan-slice` |
+| Executing (task, no continue file) | "Execute \<taskId\>" | `guided-execute-task` |
+| Executing (task, continue file exists) | "Resume \<taskId\>" | `guided-resume-task` |
+| Summarizing (all tasks done) | "Complete \<sliceId\>" | `guided-complete-slice` |
+
+`auto-prompts.ts` loads the corresponding full prompt (e.g., `execute-task`, `plan-slice`) when auto-mode dispatches a unit.
+
+### Discussion prompts are guided-only
+
+`guided-discuss-milestone` and `guided-discuss-slice` have no full auto-mode counterpart. Discussion is inherently interactive (interviewing the user), so it only runs through the guided flow. These "guided" files contain the complete interview protocol despite the `guided-` prefix.
+
+## Templates
+
+Output templates (defining artifact structure) live in `../templates/` and are inlined into prompts via `inlineTemplate()`. They are not prompt variants -- they define the expected format for artifacts like roadmaps, plans, summaries, and UAT files.

--- a/src/resources/extensions/gsd/prompts/guided-complete-slice.md
+++ b/src/resources/extensions/gsd/prompts/guided-complete-slice.md
@@ -1,3 +1,15 @@
+<!--
+  Guided variant of complete-slice.md.
+  Full version: prompts/complete-slice.md (used by auto-mode via auto-prompts.ts).
+
+  Selected by guided-flow.ts → showSmartEntry() when:
+    - The user runs /gsd, the active slice's phase is "summarizing" (all tasks done),
+      and the user picks "Complete <sliceId>".
+
+  This prompt is concise because guided-flow has already confirmed all tasks are done
+  and the user is ready to write the slice summary. The full auto-mode prompt inlines
+  task summaries, the slice plan, and other backing context.
+-->
 Complete slice {{sliceId}} ("{{sliceTitle}}") of milestone {{milestoneId}}. Your working directory is `{{workingDirectory}}` — all file operations must use this path. All tasks are done. Your slice summary is the primary record of what was built — downstream agents (reassess-roadmap, future slice researchers) read it to understand what this slice delivered and what to watch out for. Use the **Slice Summary** and **UAT** output templates below. If a `GSD Skill Preferences` block is present in system context, use it to decide which skills to load and follow during completion, without relaxing required verification or artifact rules. Write `{{sliceId}}-SUMMARY.md` (compress task summaries), write `{{sliceId}}-UAT.md`, and fill the `UAT Type` plus `Not Proven By This UAT` sections explicitly so the artifact states what class of acceptance it covers and what still remains unproven. Review task summaries for `key_decisions` and ensure any significant ones are in `.gsd/DECISIONS.md`. Mark the slice checkbox done in the roadmap, update STATE.md, update milestone summary, Do not commit or merge manually — the system handles this after the unit completes.
 
 {{inlinedTemplates}}

--- a/src/resources/extensions/gsd/prompts/guided-discuss-milestone.md
+++ b/src/resources/extensions/gsd/prompts/guided-discuss-milestone.md
@@ -1,3 +1,17 @@
+<!--
+  Guided variant of the milestone discussion prompt.
+  No full auto-mode equivalent — milestone discussion is inherently interactive.
+
+  Selected by guided-flow.ts → showSmartEntry() when:
+    - The user runs /gsd, the active milestone has no roadmap and no context file,
+      and the user picks "Discuss first".
+  Also selected by showDiscuss() when:
+    - The milestone is in "needs-discussion" phase (has CONTEXT-DRAFT.md but no roadmap),
+      and the user picks "Discuss from draft" or "Start fresh discussion".
+
+  This prompt contains the full interview protocol because discussion is always
+  interactive — there is no separate auto-mode path for milestone discussion.
+-->
 Discuss milestone {{milestoneId}} ("{{milestoneTitle}}"). Identify gray areas, ask the user about them, and write `{{milestoneId}}-CONTEXT.md` in the milestone directory with the decisions. Use the **Context** output template below. If a `GSD Skill Preferences` block is present in system context, use it to decide which skills to load and follow; do not override required artifact rules.
 
 **Structured questions available: {{structuredQuestionsAvailable}}**

--- a/src/resources/extensions/gsd/prompts/guided-discuss-slice.md
+++ b/src/resources/extensions/gsd/prompts/guided-discuss-slice.md
@@ -1,3 +1,15 @@
+<!--
+  Guided variant of the slice discussion prompt.
+  No full auto-mode equivalent — slice discussion is inherently interactive.
+
+  Selected by guided-flow.ts → showSmartEntry() when:
+    - The user runs /gsd, the active slice's phase is "planning", and the user
+      picks "Discuss first" (available when no context file exists for the slice).
+  Also selected by showDiscuss() for per-slice discussion.
+
+  This prompt contains the full interview protocol because discussion is always
+  interactive — there is no separate auto-mode path for slice discussion.
+-->
 You are interviewing the user to surface behavioural, UX, and usage grey areas for slice **{{sliceId}}: {{sliceTitle}}** of milestone **{{milestoneId}}**.
 
 Your goal is **not** to settle tech stack, naming conventions, or architecture — that happens during research and planning. Your goal is to produce a context file that captures the human decisions: what this slice should feel like, how it should behave, what edge cases matter, where scope begins and ends, and what the user cares about that won't be obvious from the roadmap entry alone.

--- a/src/resources/extensions/gsd/prompts/guided-execute-task.md
+++ b/src/resources/extensions/gsd/prompts/guided-execute-task.md
@@ -1,3 +1,16 @@
+<!--
+  Guided variant of execute-task.md.
+  Full version: prompts/execute-task.md (used by auto-mode via auto-prompts.ts).
+
+  Selected by guided-flow.ts → showSmartEntry() when:
+    - The user runs /gsd, the active slice has an active task with no continue file,
+      and the user picks "Execute <taskId>".
+
+  This prompt is concise because guided-flow has already resolved state, gathered
+  context, and presented the action menu. The full auto-mode prompt inlines all
+  backing artifacts (plans, summaries, overrides) because auto-mode agents launch
+  in a fresh context with no prior conversation.
+-->
 Execute the next task: {{taskId}} ("{{taskTitle}}") in slice {{sliceId}} of milestone {{milestoneId}}. Read the task plan (`{{taskId}}-PLAN.md`), load relevant summaries from prior tasks, and execute each step. Verify must-haves when done. If the task touches UI, browser flows, DOM behavior, or user-visible web state, exercise the real flow in the browser, prefer `browser_batch` for obvious sequences, prefer `browser_assert` for explicit pass/fail verification, use `browser_diff` when an action's effect is ambiguous, and use browser diagnostics when validating async or failure-prone UI. If you made an architectural, pattern, or library decision, append it to `.gsd/DECISIONS.md`. Use the **Task Summary** output template below. Write `{{taskId}}-SUMMARY.md`, mark it done, commit, and advance. If a `GSD Skill Preferences` block is present in system context, use it to decide which skills to load and follow during execution, without relaxing required verification or artifact rules. If running long and not all steps are finished, stop implementing and prioritize writing a clean partial summary over attempting one more step — a recoverable handoff is more valuable than a half-finished step with no documentation. If verification fails, debug methodically: form a hypothesis and test that specific theory before changing anything, change one variable at a time, read entire functions not just the suspect line, distinguish observable facts from assumptions, and if 3+ fixes fail without progress stop and reassess your mental model — list what you know for certain, what you've ruled out, and form fresh hypotheses. Don't fix symptoms — understand why something fails before changing code.
 
 {{inlinedTemplates}}

--- a/src/resources/extensions/gsd/prompts/guided-plan-milestone.md
+++ b/src/resources/extensions/gsd/prompts/guided-plan-milestone.md
@@ -1,3 +1,15 @@
+<!--
+  Guided variant of plan-milestone.md.
+  Full version: prompts/plan-milestone.md (used by auto-mode via auto-prompts.ts).
+
+  Selected by guided-flow.ts → showSmartEntry() when:
+    - The user runs /gsd, the active milestone has no roadmap yet, and the user
+      picks "Create roadmap".
+
+  This prompt is concise because guided-flow has already confirmed the milestone
+  state and gathered user intent. The full auto-mode prompt inlines context files,
+  research artifacts, and executor constraints.
+-->
 Plan milestone {{milestoneId}} ("{{milestoneTitle}}"). Read `.gsd/DECISIONS.md` if it exists — respect existing decisions. Read `.gsd/REQUIREMENTS.md` if it exists and treat Active requirements as the capability contract. If `REQUIREMENTS.md` is missing, continue in legacy compatibility mode but explicitly note missing requirement coverage. Use the **Roadmap** output template below. Create `{{milestoneId}}-ROADMAP.md` in the milestone directory with slices, risk levels, dependencies, demo sentences, verification classes, milestone definition of done, requirement coverage, and a boundary map. Write success criteria as observable truths, not implementation tasks. If the milestone crosses multiple runtime boundaries, include an explicit final integration slice that proves the assembled system works end-to-end in a real environment. If planning produces structural decisions, append them to `.gsd/DECISIONS.md`. If a `GSD Skill Preferences` block is present in system context, use it to decide which skills to load and follow during planning, without overriding required roadmap formatting.
 
 ## Requirement Rules

--- a/src/resources/extensions/gsd/prompts/guided-plan-slice.md
+++ b/src/resources/extensions/gsd/prompts/guided-plan-slice.md
@@ -1,3 +1,15 @@
+<!--
+  Guided variant of plan-slice.md.
+  Full version: prompts/plan-slice.md (used by auto-mode via auto-prompts.ts).
+
+  Selected by guided-flow.ts → showSmartEntry() when:
+    - The user runs /gsd, the active slice's phase is "planning", and the user
+      picks "Plan".
+
+  This prompt is concise because guided-flow has already confirmed the slice is
+  ready for planning. The full auto-mode prompt inlines context, research, prior
+  summaries, and executor constraints.
+-->
 Plan slice {{sliceId}} ("{{sliceTitle}}") of milestone {{milestoneId}}. Read `.gsd/DECISIONS.md` if it exists — respect existing decisions. Read `.gsd/REQUIREMENTS.md` if it exists — identify which Active requirements the roadmap says this slice owns or supports, and ensure the plan delivers them. Read the roadmap boundary map, any existing context/research files, and dependency summaries. Use the **Slice Plan** and **Task Plan** output templates below. Decompose into tasks with must-haves. Fill the `Proof Level` and `Integration Closure` sections truthfully so the plan says what class of proof this slice really delivers and what end-to-end wiring still remains. Write `{{sliceId}}-PLAN.md` and individual `T##-PLAN.md` files in the `tasks/` subdirectory. If planning produces structural decisions, append them to `.gsd/DECISIONS.md`. If a `GSD Skill Preferences` block is present in system context, use it to decide which skills to load and follow during planning, without overriding required plan formatting. Before committing, self-audit the plan: every must-have maps to at least one task, every task has complete sections (steps, must-haves, verification, observability impact, inputs, and expected output), task ordering is consistent with no circular references, every pair of artifacts that must connect has an explicit wiring step, task scope targets 2–5 steps and 3–8 files (6–8 steps or 8–10 files — consider splitting; 10+ steps or 12+ files — must split), the plan honors locked decisions from context/research/decisions artifacts, the proof-level wording does not overclaim live integration if only fixture/contract proof is planned, every Active requirement this slice owns has at least one task with verification that proves it is met, and every task produces real user-facing progress — if the slice has a UI surface at least one task builds the real UI, if it has an API at least one task connects it to a real data source, and showing the completed result to a non-technical stakeholder would demonstrate real product progress rather than developer artifacts.
 
 {{inlinedTemplates}}

--- a/src/resources/extensions/gsd/prompts/guided-research-slice.md
+++ b/src/resources/extensions/gsd/prompts/guided-research-slice.md
@@ -1,3 +1,15 @@
+<!--
+  Guided variant of research-slice.md.
+  Full version: prompts/research-slice.md (used by auto-mode via auto-prompts.ts).
+
+  Selected by guided-flow.ts → showSmartEntry() when:
+    - The user runs /gsd, the active slice's phase is "planning", and the user
+      picks "Research first".
+
+  This prompt is concise because guided-flow has already confirmed the slice is
+  ready for research. The full auto-mode prompt inlines context, decisions, and
+  knowledge artifacts.
+-->
 Research slice {{sliceId}} ("{{sliceTitle}}") of milestone {{milestoneId}}. Read `.gsd/DECISIONS.md` if it exists — respect existing decisions, don't contradict them. Read `.gsd/REQUIREMENTS.md` if it exists — identify which Active requirements this slice owns or supports and target research toward risks, unknowns, and constraints that could affect delivery of those requirements. If a `GSD Skill Preferences` block is present in system context, use it to decide which skills to load and follow during research, without relaxing required verification or artifact rules. Explore the relevant code — use `rg`/`find` for targeted reads, or `scout` if the area is broad or unfamiliar. Check libraries with `resolve_library`/`get_library_docs` — skip this for libraries already used in the codebase. Use the **Research** output template below. Write `{{sliceId}}-RESEARCH.md` in the slice directory.
 
 **You are the scout.** A planner agent reads your output in a fresh context to decompose this slice into tasks. Write for the planner — surface key files, where the work divides naturally, what to build first, and how to verify. If the research doc is vague, the planner re-explores code you already read. If it's precise, the planner decomposes immediately.

--- a/src/resources/extensions/gsd/prompts/guided-resume-task.md
+++ b/src/resources/extensions/gsd/prompts/guided-resume-task.md
@@ -1,1 +1,13 @@
+<!--
+  Guided variant of execute-task.md (resume path).
+  Full version: prompts/execute-task.md (used by auto-mode via auto-prompts.ts).
+
+  Selected by guided-flow.ts → showSmartEntry() when:
+    - The user runs /gsd, the active slice has an active task WITH a continue file
+      (either <sliceId>-CONTINUE.md or continue.md), and the user picks "Resume <taskId>".
+
+  This prompt is concise because guided-flow has already resolved state and confirmed
+  the user wants to resume. The full auto-mode prompt inlines the continue file contents
+  and all backing artifacts directly.
+-->
 Resume interrupted work. Find the continue file (`{{sliceId}}-CONTINUE.md` or `continue.md`) in slice {{sliceId}} of milestone {{milestoneId}}, then pick up from where you left off. Delete the continue file after reading it. If a `GSD Skill Preferences` block is present in system context, use it to decide which skills to load and follow during execution, without relaxing required verification or artifact rules.


### PR DESCRIPTION
## Summary
- Adds HTML comment headers to all 8 `guided-*.md` files explaining their purpose, when they're selected, and where the full version lives
- Creates `prompts/README.md` documenting the guided vs full prompt distinction, the selection logic table, and the discussion-only exception

Resolves coherence audit item 03-1.

## Test plan
- [ ] Each guided file has a clear header explaining when it's used
- [ ] Selection logic in headers matches what `guided-flow.ts` actually does
- [ ] README table covers all 8 guided prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)