### PR TITLE
fix: remove broken ./hooks export from pi-coding-agent

### DIFF
--- a/packages/pi-coding-agent/package.json
+++ b/packages/pi-coding-agent/package.json
@@ -13,10 +13,6 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
-    },
-    "./hooks": {
-      "types": "./dist/core/hooks/index.d.ts",
-      "import": "./dist/core/hooks/index.js"
     }
   },
   "scripts": {


### PR DESCRIPTION
## Summary
- The `./hooks` export in `packages/pi-coding-agent/package.json` referenced non-existent dist paths
- Importing `@gsd/pi-coding-agent/hooks` would fail with MODULE_NOT_FOUND at runtime
- Removed the broken export entry (no corresponding source exists)

## Test plan
- [ ] `npm run build` succeeds
- [ ] No existing code imports from `@gsd/pi-coding-agent/hooks`

🤖 Generated with [Claude Code](https://claude.com/claude-code)