### PR TITLE
fix: deduplicate formatTokenCount into shared format-utils

### DIFF
--- a/src/resources/extensions/bg-shell/index.ts
+++ b/src/resources/extensions/bg-shell/index.ts
@@ -65,7 +65,8 @@ import {
 } from "./output-formatter.js";
 import { waitForReady } from "./readiness-detector.js";
 import { queryShellEnv, sendAndWait, runOnSession } from "./interaction.js";
-import { formatUptime, formatTokenCount, resolveBgShellPersistenceCwd } from "./utilities.js";
+import { formatUptime, resolveBgShellPersistenceCwd } from "./utilities.js";
+import { formatTokenCount } from "../shared/format-utils.js";
 import { BgManagerOverlay } from "./overlay.js";
 import { toPosixPath } from "../shared/path-display.js";
 

--- a/src/resources/extensions/bg-shell/utilities.ts
+++ b/src/resources/extensions/bg-shell/utilities.ts
@@ -47,13 +47,6 @@ export function formatTimeAgo(timestamp: number): string {
 	return formatUptime(Date.now() - timestamp) + " ago";
 }
 
-export function formatTokenCount(count: number): string {
-	if (count < 1000) return count.toString();
-	if (count < 10000) return `${(count / 1000).toFixed(1)}k`;
-	if (count < 1000000) return `${Math.round(count / 1000)}k`;
-	if (count < 10000000) return `${(count / 1000000).toFixed(1)}M`;
-	return `${Math.round(count / 1000000)}M`;
-}
 
 export function resolveBgShellPersistenceCwd(
 	cachedCwd: string,

--- a/src/resources/extensions/gsd/metrics.ts
+++ b/src/resources/extensions/gsd/metrics.ts
@@ -19,6 +19,9 @@ import type { ExtensionContext } from "@gsd/pi-coding-agent";
 import { gsdRoot } from "./paths.js";
 import { getAndClearSkills } from "./skill-telemetry.js";
 
+// Re-export from shared — canonical implementation lives in format-utils.
+export { formatTokenCount } from "../shared/format-utils.js";
+
 // ─── Types ────────────────────────────────────────────────────────────────────
 
 export interface TokenCounts {
@@ -463,11 +466,6 @@ export function formatCostProjection(
   return result;
 }
 
-export function formatTokenCount(count: number): string {
-  if (count < 1000) return `${count}`;
-  if (count < 1_000_000) return `${(count / 1000).toFixed(1)}k`;
-  return `${(count / 1_000_000).toFixed(2)}M`;
-}
 
 // ─── Disk I/O ─────────────────────────────────────────────────────────────────
 

--- a/src/resources/extensions/shared/format-utils.ts
+++ b/src/resources/extensions/shared/format-utils.ts
@@ -21,6 +21,15 @@ export function formatDuration(ms: number): string {
   return `${h}h ${rm}m`;
 }
 
+// ─── Token Count Formatting ──────────────────────────────────────────────────
+
+/** Format a token count as a compact human-readable string (e.g. 1.5k, 1.50M). */
+export function formatTokenCount(count: number): string {
+  if (count < 1000) return `${count}`;
+  if (count < 1_000_000) return `${(count / 1000).toFixed(1)}k`;
+  return `${(count / 1_000_000).toFixed(2)}M`;
+}
+
 // ─── Layout Helpers ───────────────────────────────────────────────────────────
 
 /** Pad a string with trailing spaces to fill `width` (ANSI-aware). */


### PR DESCRIPTION
## Summary
- Two `formatTokenCount()` implementations with different rounding (1 vs 2 decimals for millions)
- Consolidated into shared `format-utils.ts` with consistent formatting
- Updated all imports across bg-shell and gsd modules

## Test plan
- [ ] `npx tsc --noEmit` passes
- [ ] Token counts display consistently across the app

🤖 Generated with [Claude Code](https://claude.com/claude-code)