### PR TITLE
fix: deduplicate formatDuration into shared format-utils

### DIFF
--- a/src/resources/extensions/gsd/commands.ts
+++ b/src/resources/extensions/gsd/commands.ts
@@ -1720,7 +1720,7 @@ async function handleDryRun(ctx: ExtensionCommandContext, basePath: string): Pro
 
   const { getLedger, getProjectTotals, formatCost, formatTokenCount, loadLedgerFromDisk } = await import("./metrics.js");
   const { loadEffectiveGSDPreferences: loadPrefs } = await import("./preferences.js");
-  const { formatDuration } = await import("./history.js");
+  const { formatDuration } = await import("../shared/format-utils.js");
 
   const ledger = getLedger();
   const units = ledger?.units ?? loadLedgerFromDisk(basePath)?.units ?? [];

--- a/src/resources/extensions/gsd/export-html.ts
+++ b/src/resources/extensions/gsd/export-html.ts
@@ -25,7 +25,7 @@ import type {
   VisualizerMilestone,
   VisualizerSlice,
 } from './visualizer-data.js';
-import { formatDuration } from './history.js';
+import { formatDuration } from '../shared/format-utils.js';
 import { formatCost, formatTokenCount } from './metrics.js';
 
 // ─── Public API ────────────────────────────────────────────────────────────────

--- a/src/resources/extensions/gsd/export.ts
+++ b/src/resources/extensions/gsd/export.ts
@@ -10,7 +10,7 @@ import {
 } from "./metrics.js";
 import type { UnitMetrics } from "./metrics.js";
 import { gsdRoot } from "./paths.js";
-import { formatDuration } from "./history.js";
+import { formatDuration } from "../shared/format-utils.js";
 
 /**
  * Write an export file directly, without requiring an ExtensionCommandContext.

--- a/src/resources/extensions/gsd/forensics.ts
+++ b/src/resources/extensions/gsd/forensics.ts
@@ -26,7 +26,7 @@ import { deriveState } from "./state.js";
 import { isAutoActive } from "./auto.js";
 import { loadPrompt } from "./prompt-loader.js";
 import { gsdRoot } from "./paths.js";
-import { formatDuration } from "./history.js";
+import { formatDuration } from "../shared/format-utils.js";
 import { getAutoWorktreePath } from "./auto-worktree.js";
 
 // ─── Types ────────────────────────────────────────────────────────────────────

--- a/src/resources/extensions/gsd/history.ts
+++ b/src/resources/extensions/gsd/history.ts
@@ -2,6 +2,7 @@
 // Human-readable display of past auto-mode unit executions.
 
 import type { ExtensionCommandContext } from "@gsd/pi-coding-agent";
+import { formatDuration } from "../shared/format-utils.js";
 import {
   getLedger, getProjectTotals, formatCost, formatTokenCount,
   aggregateBySlice, aggregateByPhase, aggregateByModel, loadLedgerFromDisk,
@@ -127,18 +128,6 @@ function showModelBreakdown(units: UnitMetrics[], ctx: ExtensionCommandContext):
 }
 
 // ─── Formatting helpers ──────────────────────────────────────────────────────
-
-export function formatDuration(ms: number): string {
-  if (ms < 1000) return `${ms}ms`;
-  const secs = Math.floor(ms / 1000);
-  if (secs < 60) return `${secs}s`;
-  const mins = Math.floor(secs / 60);
-  const remSecs = secs % 60;
-  if (mins < 60) return `${mins}m ${remSecs}s`;
-  const hours = Math.floor(mins / 60);
-  const remMins = mins % 60;
-  return `${hours}h ${remMins}m`;
-}
 
 function formatRelativeTime(timestamp: number): string {
   const diff = Date.now() - timestamp;

--- a/src/resources/extensions/gsd/reports.ts
+++ b/src/resources/extensions/gsd/reports.ts
@@ -18,7 +18,7 @@ import { writeFileSync, readFileSync, mkdirSync, existsSync } from 'node:fs';
 import { join, basename } from 'node:path';
 import { gsdRoot } from './paths.js';
 import { formatCost, formatTokenCount } from './metrics.js';
-import { formatDuration } from './history.js';
+import { formatDuration } from '../shared/format-utils.js';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 

--- a/src/resources/extensions/shared/format-utils.ts
+++ b/src/resources/extensions/shared/format-utils.ts
@@ -11,6 +11,7 @@ import { truncateToWidth, visibleWidth } from "@gsd/pi-tui";
 
 /** Format a millisecond duration as a compact human-readable string. */
 export function formatDuration(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
   const s = Math.floor(ms / 1000);
   if (s < 60) return `${s}s`;
   const m = Math.floor(s / 60);


### PR DESCRIPTION
## Summary
- Two `formatDuration()` implementations with different behavior (one showed ms, one didn't)
- Enhanced shared `format-utils.ts` version with ms support
- Removed duplicate from `history.ts`, updated imports

## Test plan
- [ ] `npx tsc --noEmit` passes
- [ ] Duration formatting shows ms for sub-second values

🤖 Generated with [Claude Code](https://claude.com/claude-code)