### PR TITLE
fix: add exports fields to pi-tui and pi-agent-core

### DIFF
--- a/packages/pi-agent-core/package.json
+++ b/packages/pi-agent-core/package.json
@@ -5,6 +5,12 @@
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
   "scripts": {
     "build": "tsc -p tsconfig.json"
   },

--- a/packages/pi-tui/package.json
+++ b/packages/pi-tui/package.json
@@ -3,8 +3,14 @@
   "version": "0.57.1",
   "description": "Terminal User Interface library (vendored from pi-mono)",
   "type": "module",
-  "main": "dist/index.js",
+  "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
   "scripts": {
     "build": "tsc -p tsconfig.json"
   },


### PR DESCRIPTION
## Summary
- `pi-tui` and `pi-agent-core` lacked `exports` fields, unlike peer packages
- Added explicit `exports` matching the pattern used by `pi-ai` and `pi-coding-agent`
- Enforces module boundaries and prevents internal imports

## Test plan
- [x] `npx tsc --noEmit` passes
- [ ] Existing imports from these packages still resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)