### PR TITLE
fix: handle unhandled promise rejections in critical paths

### DIFF
--- a/src/resources/extensions/bg-shell/overlay.ts
+++ b/src/resources/extensions/bg-shell/overlay.ts
@@ -125,6 +125,10 @@ export class BgManagerOverlay {
 				restartProcess(proc.id).then(() => {
 					this.invalidate();
 					this.tui.requestRender();
+				}).catch((err) => {
+					if (process.env.GSD_DEBUG) console.error('[bg-shell] restart failed:', err);
+					this.invalidate();
+					this.tui.requestRender();
 				});
 			}
 			return;

--- a/src/resources/extensions/gsd/auto-unit-closeout.ts
+++ b/src/resources/extensions/gsd/auto-unit-closeout.ts
@@ -37,7 +37,9 @@ export async function closeoutUnit(
       const { buildMemoryLLMCall, extractMemoriesFromUnit } = await import('./memory-extractor.js');
       const llmCallFn = buildMemoryLLMCall(ctx);
       if (llmCallFn) {
-        extractMemoriesFromUnit(activityFile, unitType, unitId, llmCallFn).catch(() => {});
+        extractMemoriesFromUnit(activityFile, unitType, unitId, llmCallFn).catch((err) => {
+          if (process.env.GSD_DEBUG) console.error(`[gsd] memory extraction failed for ${unitType}/${unitId}:`, err);
+        });
       }
     } catch { /* non-fatal */ }
   }

--- a/src/resources/extensions/gsd/files.ts
+++ b/src/resources/extensions/gsd/files.ts
@@ -716,7 +716,9 @@ export async function saveFile(path: string, content: string): Promise<void> {
     await fs.rename(tmpPath, path);
   } catch (err) {
     // Clean up orphaned temp file on rename failure
-    await fs.unlink(tmpPath).catch(() => {});
+    await fs.unlink(tmpPath).catch((unlinkErr) => {
+      if (process.env.GSD_DEBUG) console.error(`[gsd] temp file cleanup failed for ${tmpPath}:`, unlinkErr);
+    });
     throw err;
   }
 }

--- a/src/resources/extensions/gsd/guided-flow.ts
+++ b/src/resources/extensions/gsd/guided-flow.ts
@@ -28,6 +28,7 @@ import { ensureGitignore, ensurePreferences, untrackRuntimeFiles } from "./gitig
 import { loadEffectiveGSDPreferences } from "./preferences.js";
 import { showConfirm } from "../shared/confirm-ui.js";
 import { loadQueueOrder, sortByQueueOrder, saveQueueOrder } from "./queue-order.js";
+import { debugLog } from "./debug-logger.js";
 
 // ─── Commit Instruction Helpers ──────────────────────────────────────────────
 
@@ -146,8 +147,9 @@ export function checkAutoStartAfterDiscuss(): boolean {
 
   pendingAutoStart = null;
   startAuto(ctx, pi, basePath, false, { step }).catch((err) => {
-    ctx.ui.notify(`Auto-start failed: ${err instanceof Error ? err.message : String(err)}`, "warning");
+    ctx.ui.notify(`Auto-start failed: ${err instanceof Error ? err.message : String(err)}`, "error");
     if (process.env.GSD_DEBUG) console.error('[gsd] auto start error:', err);
+    debugLog("auto-start-failed", { error: err instanceof Error ? err.message : String(err) });
   });
   return true;
 }


### PR DESCRIPTION
## Summary
- `bg-shell/overlay.ts`: Added `.catch()` to `restartProcess()` — prevents overlay crash on restart failure
- `guided-flow.ts`: Upgraded `startAuto()` error notification from "warning" to "error" severity, added `debugLog` for traceability
- `auto-unit-closeout.ts`: Added debug logging for memory extraction failures (was silently swallowed)
- `files.ts`: Added debug logging for temp file cleanup failures in atomic `saveFile()`

## Test plan
- [x] `npx tsc --noEmit` passes
- [ ] Overlay doesn't crash when process restart fails
- [ ] Auto-start failures are properly reported

🤖 Generated with [Claude Code](https://claude.com/claude-code)