### PR TITLE
fix: deduplicate getMainBranch implementations

### DIFF
--- a/src/resources/extensions/gsd/worktree-command.ts
+++ b/src/resources/extensions/gsd/worktree-command.ts
@@ -12,7 +12,7 @@
 
 import type { ExtensionAPI, ExtensionCommandContext } from "@gsd/pi-coding-agent";
 import { loadPrompt } from "./prompt-loader.js";
-import { autoCommitCurrentBranch } from "./worktree.js";
+import { autoCommitCurrentBranch, getMainBranch } from "./worktree.js";
 import { runWorktreePostCreateHook } from "./auto-worktree.js";
 import { showConfirm } from "../shared/confirm-ui.js";
 import { gsdRoot, milestonesDir } from "./paths.js";
@@ -23,7 +23,6 @@ import {
   mergeWorktreeToMain,
   diffWorktreeAll,
   diffWorktreeNumstat,
-  getMainBranch,
   getWorktreeGSDDiff,
   getWorktreeCodeDiff,
   getWorktreeLog,

--- a/src/resources/extensions/gsd/worktree-manager.ts
+++ b/src/resources/extensions/gsd/worktree-manager.ts
@@ -70,10 +70,6 @@ function normalizePathForComparison(path: string): string {
   return process.platform === "win32" ? normalized.toLowerCase() : normalized;
 }
 
-export function getMainBranch(basePath: string): string {
-  return nativeDetectMainBranch(basePath);
-}
-
 // ─── resolveGitDir ─────────────────────────────────────────────────────────
 
 /**


### PR DESCRIPTION
## Summary
- Two `getMainBranch()` exports existed: `worktree-manager.ts` called `nativeDetectMainBranch()` directly, `worktree.ts` went through `GitService` (which adds preference override, milestone integration branch, and worktree detection)
- Removed the bare native version from `worktree-manager.ts`
- Updated `worktree-command.ts` (sole consumer of the native version) to import from `worktree.ts`

## Test plan
- [x] `npx tsc --noEmit` passes
- [ ] Main branch detection still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)