### PR TITLE
fix(auto): dispatch retry after verification gate failure

### DIFF
--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -1525,6 +1525,15 @@ export async function handleAgentEnd(
         // Remove completion key so dispatchNextUnit re-dispatches this unit
         s.completedKeySet.delete(completionKey);
         removePersistedKey(s.basePath, completionKey);
+        // Dispatch retry immediately — without this, handleAgentEnd returns
+        // without calling dispatchNextUnit, leaving auto-mode stalled (#978).
+        try {
+          await dispatchNextUnit(ctx, pi);
+        } catch (retryDispatchErr) {
+          const msg = retryDispatchErr instanceof Error ? retryDispatchErr.message : String(retryDispatchErr);
+          ctx.ui.notify(`Verification retry dispatch error: ${msg}`, "error");
+          startDispatchGapWatchdog(ctx, pi);
+        }
         return; // ← Critical: exit before DB dual-write and post-unit hooks
       } else {
         // Gate failed, retries exhausted (or auto-fix disabled) — pause for human review


### PR DESCRIPTION
## Problem

When the verification gate fails during auto-mode execution with retries remaining (auto-fix attempt 1/2), `handleAgentEnd` stalls permanently. The execution shows "Verification failed — auto-fix attempt 1/2" but never re-dispatches the unit.

### Root Cause

In `handleAgentEnd` (auto.ts ~line 1528), when the verification gate fails with retries remaining, the code:

1. Sets `pendingVerificationRetry` with the failure context
2. Deletes the completion key so the unit can be re-dispatched
3. **Returns early** — exiting `handleAgentEnd` entirely

The problem is that `dispatchNextUnit` (line 1842) is only called **after** the verification block, so the early return skips it. No other mechanism triggers a re-dispatch:
- The dispatch gap watchdog (line 1862) is only started after `dispatchNextUnit` completes — it's never reached
- No timer or event re-enters the dispatch chain

The `pendingVerificationRetry` state is correctly set up (it would inject failure context into the next prompt at line 2951), but `dispatchNextUnit` is never called to consume it.

### Symptoms

- Auto-mode shows "Verification failed — auto-fix attempt 1/2" 
- Progress bar freezes (e.g., "1/5 slices · task 3/3")
- Status shows "executing" but no new agent session is started
- The only recovery is manual intervention (pause/resume or restart)

## Fix

Call `dispatchNextUnit` immediately after setting up the retry state, before the early return. If dispatch throws, fall back to the dispatch gap watchdog as a safety net (matching the existing pattern at line 1855).

```diff
+        // Dispatch retry immediately — without this, handleAgentEnd returns
+        // without calling dispatchNextUnit, leaving auto-mode stalled (#978).
+        try {
+          await dispatchNextUnit(ctx, pi);
+        } catch (retryDispatchErr) {
+          const msg = retryDispatchErr instanceof Error ? retryDispatchErr.message : String(retryDispatchErr);
+          ctx.ui.notify(`Verification retry dispatch error: ${msg}`, "error");
+          startDispatchGapWatchdog(ctx, pi);
+        }
         return; // ← Critical: exit before DB dual-write and post-unit hooks
```

## Test Plan

- [x] `npm run typecheck:extensions` passes
- [x] `npm run build` passes  
- [x] `npm run test:unit` — 1279/1280 pass (1 pre-existing flaky test in `stop-auto-remote.test.ts` unrelated to this change)
- [x] `npm run test:integration` — 30/31 pass (1 skipped: no API key)
- [ ] Manual verification: run auto-mode on a project where verification gate fails — confirm the unit is re-dispatched with failure context instead of stalling