### PR TITLE
feat(prefs): add search_provider to preferences.md

### DIFF
--- a/src/resources/extensions/gsd/preferences.ts
+++ b/src/resources/extensions/gsd/preferences.ts
@@ -80,6 +80,7 @@ const KNOWN_PREFERENCE_KEYS = new Set<string>([
   "verification_commands",
   "verification_auto_fix",
   "verification_max_retries",
+  "search_provider",
 ]);
 
 export interface GSDSkillRule {
@@ -182,6 +183,8 @@ export interface GSDPreferences {
   verification_commands?: string[];
   verification_auto_fix?: boolean;
   verification_max_retries?: number;
+  /** Search provider preference. "brave"/"tavily"/"ollama" force that backend and disable native Anthropic search. "native" forces native only. "auto" = current default behavior. */
+  search_provider?: "brave" | "tavily" | "ollama" | "native" | "auto";
 }
 
 export interface LoadedGSDPreferences {
@@ -759,6 +762,15 @@ export function resolveInlineLevel(): InlineLevel {
   }
 }
 
+/**
+ * Resolve the search provider preference from preferences.md.
+ * Returns undefined if not configured (caller falls back to existing behavior).
+ */
+export function resolveSearchProviderFromPreferences(): GSDPreferences["search_provider"] | undefined {
+  const prefs = loadEffectiveGSDPreferences();
+  return prefs?.preferences.search_provider;
+}
+
 function mergePreferences(base: GSDPreferences, override: GSDPreferences): GSDPreferences {
   return {
     version: override.version ?? base.version,
@@ -801,6 +813,7 @@ function mergePreferences(base: GSDPreferences, override: GSDPreferences): GSDPr
     verification_commands: mergeStringLists(base.verification_commands, override.verification_commands),
     verification_auto_fix: override.verification_auto_fix ?? base.verification_auto_fix,
     verification_max_retries: override.verification_max_retries ?? base.verification_max_retries,
+    search_provider: override.search_provider ?? base.search_provider,
   };
 }
 
@@ -932,6 +945,16 @@ export function validatePreferences(preferences: GSDPreferences): {
       validated.token_profile = preferences.token_profile as TokenProfile;
     } else {
       errors.push(`token_profile must be one of: budget, balanced, quality`);
+    }
+  }
+
+  // ─── Search Provider ─────────────────────────────────────────────
+  if (preferences.search_provider !== undefined) {
+    const validSearchProviders = new Set(["brave", "tavily", "ollama", "native", "auto"]);
+    if (typeof preferences.search_provider === "string" && validSearchProviders.has(preferences.search_provider)) {
+      validated.search_provider = preferences.search_provider as GSDPreferences["search_provider"];
+    } else {
+      errors.push(`search_provider must be one of: brave, tavily, ollama, native, auto`);
     }
   }
 

--- a/src/resources/extensions/search-the-web/native-search.ts
+++ b/src/resources/extensions/search-the-web/native-search.ts
@@ -5,6 +5,8 @@
  * the heavy tool-registration modules.
  */
 
+import { resolveSearchProviderFromPreferences } from "../gsd/preferences.js";
+
 /** Tool names for the Brave-backed custom search tools */
 export const BRAVE_TOOL_NAMES = ["search-the-web", "search_and_read"];
 
@@ -16,6 +18,11 @@ const THINKING_TYPES = new Set(["thinking", "redacted_thinking"]);
 
 /** When true, skip native web search injection and keep Brave/custom tools active on Anthropic. */
 export function preferBraveSearch(): boolean {
+  // preferences.md takes priority over env var
+  const prefsPref = resolveSearchProviderFromPreferences();
+  if (prefsPref === "brave" || prefsPref === "tavily" || prefsPref === "ollama") return true;
+  if (prefsPref === "native") return false;
+  // Fall back to env var
   return process.env.PREFER_BRAVE_SEARCH === "1" || process.env.PREFER_BRAVE_SEARCH === "true";
 }
 

--- a/src/resources/extensions/search-the-web/provider.ts
+++ b/src/resources/extensions/search-the-web/provider.ts
@@ -12,6 +12,7 @@
 import { AuthStorage } from '@gsd/pi-coding-agent'
 import { homedir } from 'os'
 import { join } from 'path'
+import { resolveSearchProviderFromPreferences } from '../gsd/preferences.js'
 
 // Compute authFilePath locally instead of importing from app-paths.ts,
 // because extensions are copied to ~/.gsd/agent/extensions/ at runtime
@@ -94,9 +95,11 @@ export function resolveSearchProvider(overridePreference?: string): SearchProvid
   if (overridePreference && VALID_PREFERENCES.has(overridePreference)) {
     pref = overridePreference as SearchProviderPreference
   } else {
-    // Invalid override or no override — read stored preference
-    // If overridePreference is provided but invalid, treat as 'auto'
-    if (overridePreference !== undefined && !VALID_PREFERENCES.has(overridePreference)) {
+    // preferences.md takes priority over auth.json
+    const mdPref = resolveSearchProviderFromPreferences()
+    if (mdPref && mdPref !== 'auto' && mdPref !== 'native') {
+      pref = mdPref as SearchProviderPreference
+    } else if (overridePreference !== undefined && !VALID_PREFERENCES.has(overridePreference)) {
       pref = 'auto'
     } else {
       pref = getSearchProviderPreference()


### PR DESCRIPTION
## Summary
- Adds `search_provider` field to `GSDPreferences` with valid values: `"brave"`, `"tavily"`, `"ollama"`, `"native"`, `"auto"` (default)
- `preferences.md` setting takes priority over `PREFER_BRAVE_SEARCH` env var and `auth.json` search_provider key
- `"brave"` / `"tavily"` / `"ollama"` forces that backend and disables native Anthropic search; `"native"` forces native only; `"auto"` preserves existing behavior

## Changes
- **`src/resources/extensions/gsd/preferences.ts`**: Added `search_provider` to `KNOWN_PREFERENCE_KEYS`, `GSDPreferences` interface, `validatePreferences()`, `mergePreferences()`, and new `resolveSearchProviderFromPreferences()` resolver
- **`src/resources/extensions/search-the-web/native-search.ts`**: `preferBraveSearch()` checks preferences.md before env var
- **`src/resources/extensions/search-the-web/provider.ts`**: `resolveSearchProvider()` checks preferences.md before auth.json

## Test plan
- [x] All 45 existing search-related tests pass (provider.test.ts, native-search.test.ts)
- [ ] Manual: set `search_provider: brave` in `~/.gsd/preferences.md`, verify Brave search is used on Anthropic models
- [ ] Manual: set `search_provider: native` in `~/.gsd/preferences.md`, verify native search is forced

🤖 Generated with [Claude Code](https://claude.com/claude-code)