### PR TITLE
fix(remote-questions): null coalesce optional threadUrl

### DIFF
--- a/src/resources/extensions/remote-questions/manager.ts
+++ b/src/resources/extensions/remote-questions/manager.ts
@@ -70,7 +70,7 @@ export async function tryRemoteQuestions(
         channel: config.channel,
         timed_out: true,
         promptId: prompt.id,
-        threadUrl: dispatch.ref.threadUrl,
+        threadUrl: dispatch.ref.threadUrl ?? null,
         status: signal?.aborted ? "cancelled" : "timed_out",
       },
     };
@@ -92,7 +92,7 @@ export async function tryRemoteQuestions(
       channel: config.channel,
       timed_out: false,
       promptId: prompt.id,
-      threadUrl: dispatch.ref.threadUrl,
+      threadUrl: dispatch.ref.threadUrl ?? null,
       questions,
       response: answer,
       status: "answered",


### PR DESCRIPTION
## Summary
- `RemotePromptRef.threadUrl` is typed as optional (`string | undefined`), but the "answered" and "timed_out" detail objects accessed it without `?? null`, producing `undefined` instead of `null` in serialized JSON
- Added `?? null` coalesces on lines 73 and 95 to match the existing pattern on line 64

## Test plan
- [x] `npx tsc --noEmit` passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)