### PR TITLE
fix(gsd): add GIT_NO_PROMPT_ENV to gitFileExec and deduplicate constant

### DIFF
--- a/src/resources/extensions/gsd/git-constants.ts
+++ b/src/resources/extensions/gsd/git-constants.ts
@@ -1,0 +1,11 @@
+/**
+ * Shared git constants used across git-service and native-git-bridge.
+ */
+
+/** Env overlay that suppresses interactive git credential prompts and git-svn noise. */
+export const GIT_NO_PROMPT_ENV = {
+  ...process.env,
+  GIT_TERMINAL_PROMPT: "0",
+  GIT_ASKPASS: "",
+  GIT_SVN_ID: "",
+};

--- a/src/resources/extensions/gsd/git-service.ts
+++ b/src/resources/extensions/gsd/git-service.ts
@@ -11,6 +11,7 @@
 import { execFileSync, execSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { GIT_NO_PROMPT_ENV } from "./git-constants.js";
 
 import {
   detectWorktreeName,
@@ -254,13 +255,6 @@ export function writeIntegrationBranch(basePath: string, milestoneId: string, br
 
 // ─── Git Helper ────────────────────────────────────────────────────────────
 
-/** Env overlay that suppresses interactive git credential prompts and git-svn noise. */
-const GIT_NO_PROMPT_ENV = {
-  ...process.env,
-  GIT_TERMINAL_PROMPT: "0",
-  GIT_ASKPASS: "",
-  GIT_SVN_ID: "",
-};
 
 /**
  * Strip git-svn noise from error messages.

--- a/src/resources/extensions/gsd/native-git-bridge.ts
+++ b/src/resources/extensions/gsd/native-git-bridge.ts
@@ -9,14 +9,7 @@ import { execSync, execFileSync } from "node:child_process";
 import { existsSync, readFileSync, unlinkSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { GSDError, GSD_GIT_ERROR } from "./errors.js";
-
-/** Env overlay that suppresses interactive git credential prompts and git-svn noise. */
-const GIT_NO_PROMPT_ENV = {
-  ...process.env,
-  GIT_TERMINAL_PROMPT: "0",
-  GIT_ASKPASS: "",
-  GIT_SVN_ID: "",
-};
+import { GIT_NO_PROMPT_ENV } from "./git-constants.js";
 
 // Issue #453: keep auto-mode bookkeeping on the stable git CLI path unless a
 // caller explicitly opts into the native helper.
@@ -160,6 +153,7 @@ function gitFileExec(basePath: string, args: string[], allowFailure = false): st
       cwd: basePath,
       stdio: ["ignore", "pipe", "pipe"],
       encoding: "utf-8",
+      env: GIT_NO_PROMPT_ENV,
     }).trim();
   } catch {
     if (allowFailure) return "";


### PR DESCRIPTION
## Summary
- **Critical fix**: `gitFileExec()` in `native-git-bridge.ts` was missing the `GIT_NO_PROMPT_ENV` env overlay. Without it, git can prompt for credentials and hang the process on write operations (add, commit, revert, checkout) called from 12+ locations.
- **Dedup**: Extracted the shared `GIT_NO_PROMPT_ENV` constant into a new `git-constants.ts` file, imported by both `git-service.ts` and `native-git-bridge.ts`. This avoids a circular dependency (git-service already imports from native-git-bridge).

## Test plan
- [ ] `npx tsc --noEmit` passes (verified locally)
- [ ] Run GSD auto-mode end-to-end — git write operations (commit, stage, revert) should not hang
- [ ] Verify no credential prompts appear when pushing to a repo with expired/missing credentials (should fail fast instead of hanging)

🤖 Generated with [Claude Code](https://claude.com/claude-code)