### PR TITLE
fix: consolidate duplicate VerificationCheck/Result type definitions

### DIFF
--- a/src/resources/extensions/browser-tools/state.ts
+++ b/src/resources/extensions/browser-tools/state.ts
@@ -139,16 +139,16 @@ export interface ClickTargetStateSnapshot {
 	open: boolean | null;
 }
 
-export interface VerificationCheck {
+export interface BrowserVerificationCheck {
 	name: string;
 	passed: boolean;
 	value?: unknown;
 	expected?: unknown;
 }
 
-export interface VerificationResult {
+export interface BrowserVerificationResult {
 	verified: boolean;
-	checks: VerificationCheck[];
+	checks: BrowserVerificationCheck[];
 	verificationSummary: string;
 	retryHint?: string;
 }
@@ -379,8 +379,8 @@ export interface ToolDeps {
 
 	// Utilities (forwarded from utils.ts)
 	truncateText: (text: string) => string;
-	verificationFromChecks: (checks: VerificationCheck[], retryHint?: string) => VerificationResult;
-	verificationLine: (verification: VerificationResult) => string;
+	verificationFromChecks: (checks: BrowserVerificationCheck[], retryHint?: string) => BrowserVerificationResult;
+	verificationLine: (verification: BrowserVerificationResult) => string;
 	collectAssertionState: (
 		p: Page,
 		checks: BrowserAssertionCheckInput[],

--- a/src/resources/extensions/browser-tools/utils.ts
+++ b/src/resources/extensions/browser-tools/utils.ts
@@ -44,8 +44,8 @@ import {
 	type CompactPageState,
 	type CompactSelectorState,
 	type ClickTargetStateSnapshot,
-	type VerificationCheck,
-	type VerificationResult,
+	type BrowserVerificationCheck,
+	type BrowserVerificationResult,
 	type BrowserAssertionCheckInput,
 	type AdaptiveSettleOptions,
 	type AdaptiveSettleDetails,
@@ -265,9 +265,9 @@ export function getPendingCriticalRequests(p: Page): number {
 // ---------------------------------------------------------------------------
 
 export function verificationFromChecks(
-	checks: VerificationCheck[],
+	checks: BrowserVerificationCheck[],
 	retryHint?: string,
-): VerificationResult {
+): BrowserVerificationResult {
 	const passedChecks = checks
 		.filter((check) => check.passed)
 		.map((check) => check.name);
@@ -282,7 +282,7 @@ export function verificationFromChecks(
 	};
 }
 
-export function verificationLine(verification: VerificationResult): string {
+export function verificationLine(verification: BrowserVerificationResult): string {
 	return `Verification: ${verification.verificationSummary}`;
 }
 


### PR DESCRIPTION
## Summary
- Renamed `VerificationCheck` and `VerificationResult` in `browser-tools/state.ts` to `BrowserVerificationCheck` and `BrowserVerificationResult` to eliminate name collisions with the semantically different types in `gsd/types.ts`
- The browser-tools types track UI element state verification (name/passed/value/expected), while gsd/types.ts types track command execution verification (command/exitCode/stdout/stderr) — genuinely different types that happened to share a name
- Updated all references in `browser-tools/utils.ts` and the forwarded type signatures in `browser-tools/state.ts`

## Test plan
- [x] `npx tsc --noEmit` passes with zero errors
- [ ] Verify browser-tools verification functions work correctly at runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)