### PR TITLE
fix(browser-tools): document intentional silent catches, add debug logging

### DIFF
--- a/src/resources/extensions/browser-tools/lifecycle.ts
+++ b/src/resources/extensions/browser-tools/lifecycle.ts
@@ -137,7 +137,7 @@ export function attachPageListeners(p: Page, pageId: number): void {
 			pageId,
 		});
 		// Auto-accept all dialogs to prevent page freezes
-		await dialog.accept().catch(() => {});
+		await dialog.accept().catch(() => { /* cleanup — dialog may already be dismissed */ });
 	});
 
 	// Frame detach handler — clears activeFrame if the selected frame detaches
@@ -236,7 +236,7 @@ export async function ensureBrowser(): Promise<{ browser: Browser; context: Brow
 		newPage.waitForLoadState("domcontentloaded", { timeout: 5000 })
 			.then(() => newPage.title())
 			.then((title) => { entry.title = title; })
-			.catch(() => {});
+			.catch(() => { /* best-effort title fetch — page may have closed or navigated away */ });
 	});
 
 	return { browser, context, page: getActivePage() };
@@ -264,7 +264,7 @@ export function getActivePageOrNull(): Page | null {
 export async function closeBrowser(): Promise<void> {
 	const browser = getBrowser();
 	if (browser) {
-		await browser.close().catch(() => {});
+		await browser.close().catch(() => { /* cleanup — browser may already be closed */ });
 	}
 	resetAllState();
 }

--- a/src/resources/extensions/browser-tools/settle.ts
+++ b/src/resources/extensions/browser-tools/settle.ts
@@ -126,7 +126,7 @@ export async function settleAfterActionAdaptive(
 	// Install mutation counter + read initial state in one evaluate sequence.
 	// ensureMutationCounter must run first (installs the observer), then we
 	// read the baseline via the combined reader.
-	await ensureMutationCounter(p).catch(() => {});
+	await ensureMutationCounter(p).catch((e) => { if (process.env.GSD_DEBUG) console.error("[browser-tools] ensureMutationCounter failed:", e.message); });
 	const initial = await readSettleState(p, checkFocus);
 	let previousMutationCount = initial.mutationCount;
 	let previousFocus = initial.focusDescriptor;

--- a/src/resources/extensions/browser-tools/tools/assertions.ts
+++ b/src/resources/extensions/browser-tools/tools/assertions.ts
@@ -175,7 +175,7 @@ export function registerAssertionTools(pi: ExtensionAPI, deps: ToolDeps): void {
 						switch (step.action) {
 							case "navigate": {
 								await p.goto(step.url, { waitUntil: "domcontentloaded", timeout: 30000 });
-								await p.waitForLoadState("networkidle", { timeout: 5000 }).catch(() => {});
+								await p.waitForLoadState("networkidle", { timeout: 5000 }).catch(() => { /* networkidle timeout — non-fatal, page may still be usable */ });
 								return { ok: true, action: step.action, url: p.url() };
 							}
 							case "click": {

--- a/src/resources/extensions/browser-tools/tools/device.ts
+++ b/src/resources/extensions/browser-tools/tools/device.ts
@@ -134,7 +134,7 @@ export function registerDeviceTools(pi: ExtensionAPI, deps: ToolDeps): void {
 
 				// Navigate back to previous URL if it wasn't about:blank
 				if (currentUrl && currentUrl !== "about:blank") {
-					await page.goto(currentUrl, { waitUntil: "domcontentloaded", timeout: 15000 }).catch(() => {});
+					await page.goto(currentUrl, { waitUntil: "domcontentloaded", timeout: 15000 }).catch((e) => { if (process.env.GSD_DEBUG) console.error("[browser-tools] device goto restore failed:", e.message); });
 				}
 
 				const viewport = deviceDescriptor.viewport;

--- a/src/resources/extensions/browser-tools/tools/extract.ts
+++ b/src/resources/extensions/browser-tools/tools/extract.ts
@@ -39,7 +39,7 @@ export function registerExtractTools(pi: ExtensionAPI, deps: ToolDeps): void {
 				const { page: p } = await deps.ensureBrowser();
 
 				// Wait for network idle before extraction
-				await p.waitForLoadState("networkidle", { timeout: 10000 }).catch(() => {});
+				await p.waitForLoadState("networkidle", { timeout: 10000 }).catch(() => { /* networkidle timeout — non-fatal, page may still be usable */ });
 
 				const schema = params.schema as any;
 				const scopeSelector = params.selector;

--- a/src/resources/extensions/browser-tools/tools/navigation.ts
+++ b/src/resources/extensions/browser-tools/tools/navigation.ts
@@ -31,7 +31,7 @@ export function registerNavigationTools(pi: ExtensionAPI, deps: ToolDeps): void 
 				beforeState = await deps.captureCompactPageState(p, { includeBodyText: true });
 				actionId = deps.beginTrackedAction("browser_navigate", params, beforeState.url).id;
 				await p.goto(params.url, { waitUntil: "domcontentloaded", timeout: 30000 });
-				await p.waitForLoadState("networkidle", { timeout: 5000 }).catch(() => {});
+				await p.waitForLoadState("networkidle", { timeout: 5000 }).catch(() => { /* networkidle timeout — non-fatal, page may still be usable */ });
 				await new Promise(resolve => setTimeout(resolve, 300));
 
 				const title = await p.title();
@@ -110,7 +110,7 @@ export function registerNavigationTools(pi: ExtensionAPI, deps: ToolDeps): void 
 					};
 				}
 
-				await p.waitForLoadState("networkidle", { timeout: 5000 }).catch(() => {});
+				await p.waitForLoadState("networkidle", { timeout: 5000 }).catch(() => { /* networkidle timeout — non-fatal, page may still be usable */ });
 
 				const title = await p.title();
 				const url = p.url();
@@ -154,7 +154,7 @@ export function registerNavigationTools(pi: ExtensionAPI, deps: ToolDeps): void 
 					};
 				}
 
-				await p.waitForLoadState("networkidle", { timeout: 5000 }).catch(() => {});
+				await p.waitForLoadState("networkidle", { timeout: 5000 }).catch(() => { /* networkidle timeout — non-fatal, page may still be usable */ });
 
 				const title = await p.title();
 				const url = p.url();
@@ -189,7 +189,7 @@ export function registerNavigationTools(pi: ExtensionAPI, deps: ToolDeps): void 
 			try {
 				const { page: p } = await deps.ensureBrowser();
 				await p.reload({ waitUntil: "domcontentloaded", timeout: 30000 });
-				await p.waitForLoadState("networkidle", { timeout: 5000 }).catch(() => {});
+				await p.waitForLoadState("networkidle", { timeout: 5000 }).catch(() => { /* networkidle timeout — non-fatal, page may still be usable */ });
 
 				const title = await p.title();
 				const url = p.url();


### PR DESCRIPTION
## Summary
- Replaces 11 silent `.catch(() => {})` patterns across browser-tools with descriptive comments or debug logging
- Best-effort operations (networkidle waits, dialog dismissal, browser close, title fetch) get inline comments explaining why the catch is intentional
- Operations that should be observable (`page.goto` restore in device emulation, `ensureMutationCounter` in settle) get `GSD_DEBUG`-gated `console.error` logging

## Test plan
- [ ] `npx tsc --noEmit` passes (verified locally)
- [ ] Set `GSD_DEBUG=1` and trigger device emulation with a failing goto to confirm debug logging fires
- [ ] Normal browser-tools usage is unaffected (no visible output without GSD_DEBUG)

🤖 Generated with [Claude Code](https://claude.com/claude-code)