### PR TITLE
fix: add missing package.json subpath exports and oauth stubs

### DIFF
--- a/packages/native/package.json
+++ b/packages/native/package.json
@@ -55,6 +55,34 @@
     "./xxhash": {
       "types": "./dist/xxhash/index.d.ts",
       "import": "./dist/xxhash/index.js"
+    },
+    "./diff": {
+      "types": "./dist/diff/index.d.ts",
+      "import": "./dist/diff/index.js"
+    },
+    "./gsd-parser": {
+      "types": "./dist/gsd-parser/index.d.ts",
+      "import": "./dist/gsd-parser/index.js"
+    },
+    "./highlight": {
+      "types": "./dist/highlight/index.d.ts",
+      "import": "./dist/highlight/index.js"
+    },
+    "./json-parse": {
+      "types": "./dist/json-parse/index.d.ts",
+      "import": "./dist/json-parse/index.js"
+    },
+    "./stream-process": {
+      "types": "./dist/stream-process/index.d.ts",
+      "import": "./dist/stream-process/index.js"
+    },
+    "./truncate": {
+      "types": "./dist/truncate/index.d.ts",
+      "import": "./dist/truncate/index.js"
+    },
+    "./ttsr": {
+      "types": "./dist/ttsr/index.d.ts",
+      "import": "./dist/ttsr/index.js"
     }
   },
   "files": [

--- a/packages/pi-ai/oauth.d.ts
+++ b/packages/pi-ai/oauth.d.ts
@@ -1,0 +1,1 @@
+export * from "./dist/oauth.js";

--- a/packages/pi-ai/oauth.js
+++ b/packages/pi-ai/oauth.js
@@ -1,0 +1,1 @@
+export * from "./dist/oauth.js";


### PR DESCRIPTION
## Summary
- Add 7 missing subpath exports to `@gsd/native` package.json: `diff`, `gsd-parser`, `highlight`, `json-parse`, `stream-process`, `truncate`, `ttsr` — all exported from `src/index.ts` but missing from the `exports` field
- Create root-level `oauth.js` and `oauth.d.ts` stub files for `@gsd/pi-ai` to match the existing `bedrock-provider` pattern

## Test plan
- [x] `npx tsc --noEmit` passes cleanly
- [ ] Verify `import { highlightCode } from "@gsd/native/highlight"` resolves correctly in consuming packages
- [ ] Verify `import { ... } from "@gsd/pi-ai/oauth"` resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)