### PR TITLE
feat: add respectGitignoreInPicker setting for @ file picker (#979)

### DIFF
--- a/packages/pi-coding-agent/src/core/settings-manager.ts
+++ b/packages/pi-coding-agent/src/core/settings-manager.ts
@@ -134,6 +134,7 @@ export interface Settings {
 	thinkingBudgets?: ThinkingBudgetsSettings; // Custom token budgets for thinking levels
 	editorPaddingX?: number; // Horizontal padding for input editor (default: 0)
 	autocompleteMaxVisible?: number; // Max visible items in autocomplete dropdown (default: 5)
+	respectGitignoreInPicker?: boolean; // When false, @ file picker shows gitignored files (default: true)
 	showHardwareCursor?: boolean; // Show terminal cursor while still positioning it for IME
 	markdown?: MarkdownSettings;
 	memory?: MemorySettings;
@@ -1021,6 +1022,16 @@ export class SettingsManager {
 	setAutocompleteMaxVisible(maxVisible: number): void {
 		this.globalSettings.autocompleteMaxVisible = Math.max(3, Math.min(20, Math.floor(maxVisible)));
 		this.markModified("autocompleteMaxVisible");
+		this.save();
+	}
+
+	getRespectGitignoreInPicker(): boolean {
+		return this.settings.respectGitignoreInPicker ?? true;
+	}
+
+	setRespectGitignoreInPicker(value: boolean): void {
+		this.globalSettings.respectGitignoreInPicker = value;
+		this.markModified("respectGitignoreInPicker");
 		this.save();
 	}
 

--- a/packages/pi-coding-agent/src/modes/interactive/components/settings-selector.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/components/settings-selector.ts
@@ -42,6 +42,7 @@ export interface SettingsConfig {
 	showHardwareCursor: boolean;
 	editorPaddingX: number;
 	autocompleteMaxVisible: number;
+	respectGitignoreInPicker: boolean;
 	quietStartup: boolean;
 	clearOnShrink: boolean;
 }
@@ -65,6 +66,7 @@ export interface SettingsCallbacks {
 	onShowHardwareCursorChange: (enabled: boolean) => void;
 	onEditorPaddingXChange: (padding: number) => void;
 	onAutocompleteMaxVisibleChange: (maxVisible: number) => void;
+	onRespectGitignoreInPickerChange: (enabled: boolean) => void;
 	onQuietStartupChange: (enabled: boolean) => void;
 	onClearOnShrinkChange: (enabled: boolean) => void;
 	onCancel: () => void;
@@ -343,6 +345,16 @@ export class SettingsSelectorComponent extends Container {
 			values: ["true", "false"],
 		});
 
+		// Respect .gitignore in file picker toggle (insert after clear-on-shrink)
+		const clearOnShrinkIndex = items.findIndex((item) => item.id === "clear-on-shrink");
+		items.splice(clearOnShrinkIndex + 1, 0, {
+			id: "respect-gitignore-in-picker",
+			label: "Respect .gitignore in file picker",
+			description: "When false, @ file picker shows gitignored files too",
+			currentValue: config.respectGitignoreInPicker ? "true" : "false",
+			values: ["true", "false"],
+		});
+
 		// Add borders
 		this.addChild(new DynamicBorder());
 
@@ -404,6 +416,9 @@ export class SettingsSelectorComponent extends Container {
 						break;
 					case "clear-on-shrink":
 						callbacks.onClearOnShrinkChange(newValue === "true");
+						break;
+					case "respect-gitignore-in-picker":
+						callbacks.onRespectGitignoreInPickerChange(newValue === "true");
 						break;
 				}
 			},

--- a/packages/pi-coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/interactive-mode.ts
@@ -350,6 +350,7 @@ export class InteractiveMode {
 		this.autocompleteProvider = new CombinedAutocompleteProvider(
 			[...slashCommands, ...templateCommands, ...extensionCommands, ...skillCommandList],
 			process.cwd(),
+			{ respectGitignore: this.settingsManager.getRespectGitignoreInPicker() },
 		);
 		this.defaultEditor.setAutocompleteProvider(this.autocompleteProvider);
 		if (this.editor !== this.defaultEditor) {
@@ -3311,6 +3312,7 @@ export class InteractiveMode {
 					showHardwareCursor: this.settingsManager.getShowHardwareCursor(),
 					editorPaddingX: this.settingsManager.getEditorPaddingX(),
 					autocompleteMaxVisible: this.settingsManager.getAutocompleteMaxVisible(),
+					respectGitignoreInPicker: this.settingsManager.getRespectGitignoreInPicker(),
 					quietStartup: this.settingsManager.getQuietStartup(),
 					clearOnShrink: this.settingsManager.getClearOnShrink(),
 				},
@@ -3411,6 +3413,10 @@ export class InteractiveMode {
 					onClearOnShrinkChange: (enabled) => {
 						this.settingsManager.setClearOnShrink(enabled);
 						this.ui.setClearOnShrink(enabled);
+					},
+					onRespectGitignoreInPickerChange: (enabled) => {
+						this.settingsManager.setRespectGitignoreInPicker(enabled);
+						this.autocompleteProvider?.setRespectGitignore(enabled);
 					},
 					onCancel: () => {
 						done();

--- a/packages/pi-tui/src/autocomplete.ts
+++ b/packages/pi-tui/src/autocomplete.ts
@@ -130,13 +130,20 @@ export interface AutocompleteProvider {
 export class CombinedAutocompleteProvider implements AutocompleteProvider {
 	private commands: (SlashCommand | AutocompleteItem)[];
 	private basePath: string;
+	private respectGitignore: boolean;
 
 	constructor(
 		commands: (SlashCommand | AutocompleteItem)[] = [],
 		basePath: string = process.cwd(),
+		options?: { respectGitignore?: boolean },
 	) {
 		this.commands = commands;
 		this.basePath = basePath;
+		this.respectGitignore = options?.respectGitignore ?? true;
+	}
+
+	setRespectGitignore(value: boolean): void {
+		this.respectGitignore = value;
 	}
 
 	getSuggestions(
@@ -562,7 +569,7 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 				query: searchQuery,
 				path: searchPath,
 				hidden: true,
-				gitignore: true,
+				gitignore: this.respectGitignore,
 				maxResults: FUZZY_FILE_MAX_RESULTS,
 			});
 


### PR DESCRIPTION
Fixes #979

Adds a new setting `respectGitignoreInPicker` (default: `true`) that controls whether the `@` file picker respects `.gitignore` when listing files. When set to `false`, gitignored files appear in fuzzy search results.

Configurable via the settings panel (`/settings`).

## Files changed

| File | Change |
|------|--------|
| `packages/pi-tui/src/autocomplete.ts` | `CombinedAutocompleteProvider`: new `respectGitignore` constructor option + `setRespectGitignore()` setter |
| `packages/pi-coding-agent/src/core/settings-manager.ts` | New `respectGitignoreInPicker` setting with getter/setter |
| `packages/pi-coding-agent/src/modes/interactive/components/settings-selector.ts` | Toggle in settings UI |
| `packages/pi-coding-agent/src/modes/interactive/interactive-mode.ts` | Reads setting at init, updates provider on change |

## Testing
- `tsc --noEmit` passes cleanly