### PR TITLE
fix: merge worktree to main when final milestone completes (#962)

### DIFF
--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -2227,7 +2227,31 @@ async function dispatchNextUnit(
 
     const incomplete = state.registry.filter(m => m.status !== "complete");
     if (incomplete.length === 0) {
-      // Genuinely all complete
+      // Genuinely all complete — merge worktree to main before stopping (#962)
+      if (s.currentMilestoneId && isInAutoWorktree(s.basePath) && s.originalBasePath) {
+        try {
+          autoCommitCurrentBranch(s.basePath, "complete-milestone", s.currentMilestoneId);
+        } catch { /* non-fatal */ }
+        try {
+          const roadmapPath = resolveMilestoneFile(s.originalBasePath, s.currentMilestoneId, "ROADMAP");
+          if (roadmapPath) {
+            const roadmapContent = readFileSync(roadmapPath, "utf-8");
+            const mergeResult = mergeMilestoneToMain(s.originalBasePath, s.currentMilestoneId, roadmapContent);
+            ctx.ui.notify(
+              `Milestone ${s.currentMilestoneId} merged to main.${mergeResult.pushed ? " Pushed to remote." : ""}`,
+              "info",
+            );
+          } else {
+            teardownAutoWorktree(s.originalBasePath, s.currentMilestoneId);
+            ctx.ui.notify(`Exited worktree for ${s.currentMilestoneId} (no roadmap for merge).`, "info");
+          }
+        } catch (err) {
+          ctx.ui.notify(
+            `Milestone merge failed on completion: ${err instanceof Error ? err.message : String(err)}`,
+            "warning",
+          );
+        }
+      }
       sendDesktopNotification("GSD", "All milestones complete!", "success", "milestone");
       await stopAuto(ctx, pi, "All milestones complete");
     } else if (state.phase === "blocked") {


### PR DESCRIPTION
Fixes #962

When the last milestone completed with no queued follow-up, `stopAuto()` tore down the worktree with `preserveBranch: true` but never called `mergeMilestoneToMain()`. All work stayed on the milestone branch, unmerged to main.

## Fix

The 'all milestones complete' path now mirrors the milestone transition path:
1. Auto-commit any dirty state
2. Read the roadmap and call `mergeMilestoneToMain()`
3. Then call `stopAuto()`

If the roadmap isn't found, falls back to `teardownAutoWorktree()` (same as the transition path).

## File changed
- `src/resources/extensions/gsd/auto.ts`: 'all milestones complete' branch (~line 2229)

## Testing
- `tsc --noEmit` passes cleanly
- Follows the exact same pattern as the working milestone-transition merge (lines 2152-2182)