### PR TITLE
fix(security): use execFile for browser URL opening

### DIFF
--- a/packages/pi-coding-agent/src/modes/interactive/components/login-dialog.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/components/login-dialog.ts
@@ -2,7 +2,7 @@
 // Copyright (c) 2026 Jeremy McSpadden <jeremy@fluxlabs.net>
 import { getOAuthProviders } from "@gsd/pi-ai/oauth";
 import { Container, type Focusable, getEditorKeybindings, Input, Spacer, Text, type TUI } from "@gsd/pi-tui";
-import { exec } from "child_process";
+import { execFile } from "child_process";
 import { theme } from "../theme/theme.js";
 import { DynamicBorder } from "./dynamic-border.js";
 import { keyHint } from "./keybinding-hints.js";
@@ -134,11 +134,11 @@ export class LoginDialogComponent extends Container implements Focusable {
 
 		// Try to open browser — on Windows, `start` needs an empty title arg
 		// so it treats the URL as a target, not a window title
-		const openCmd = process.platform === "darwin" ? "open" : process.platform === "win32" ? "start" : "xdg-open";
 		if (process.platform === "win32") {
-			exec(`start "" "${url}"`);
+			execFile("cmd", ["/c", "start", "", url], () => {});
 		} else {
-			exec(`${openCmd} "${url}"`);
+			const openCmd = process.platform === "darwin" ? "open" : "xdg-open";
+			execFile(openCmd, [url], () => {});
 		}
 
 		this.tui.requestRender();

--- a/src/onboarding.ts
+++ b/src/onboarding.ts
@@ -10,7 +10,7 @@
  * All steps are skippable. All errors are recoverable. Never crashes boot.
  */
 
-import { exec } from 'node:child_process'
+import { execFile } from 'node:child_process'
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import type { AuthStorage } from '@gsd/pi-coding-agent'
@@ -122,12 +122,12 @@ async function loadPico(): Promise<PicoModule> {
 
 /** Open a URL in the system browser (best-effort, non-blocking) */
 function openBrowser(url: string): void {
-  const cmd = process.platform === 'darwin' ? 'open' :
-    process.platform === 'win32' ? 'start' :
-      'xdg-open'
-  exec(`${cmd} "${url}"`, () => {
-    // Ignore errors — user can manually open the URL
-  })
+  if (process.platform === 'win32') {
+    execFile('cmd', ['/c', 'start', '', url], () => {})
+  } else {
+    const cmd = process.platform === 'darwin' ? 'open' : 'xdg-open'
+    execFile(cmd, [url], () => {})
+  }
 }
 
 /** Check if an error is a clack cancel signal */


### PR DESCRIPTION
## Summary
- Replace `exec` with `execFile` in two browser-URL-opening functions to prevent shell metacharacter injection
- Affected files: `src/onboarding.ts` and `packages/pi-coding-agent/src/modes/interactive/components/login-dialog.ts`
- Windows `start` is a cmd.exe built-in, so it uses `execFile('cmd', ['/c', 'start', '', url])`

## Test plan
- [ ] Verify browser opens correctly on macOS (`open` command)
- [ ] Verify browser opens correctly on Linux (`xdg-open` command)
- [ ] Verify browser opens correctly on Windows (`cmd /c start` command)

🤖 Generated with [Claude Code](https://claude.com/claude-code)