### PR TITLE
perf: optimize SSE streaming buffer

### DIFF
--- a/packages/pi-ai/src/providers/openai-codex-responses.ts
+++ b/packages/pi-ai/src/providers/openai-codex-responses.ts
@@ -410,8 +410,14 @@ async function* parseSSE(response: Response): AsyncGenerator<Record<string, unkn
 	while (true) {
 		const { done, value } = await reader.read();
 		if (done) break;
-		buffer += decoder.decode(value, { stream: true });
 
+		const decoded = decoder.decode(value, { stream: true });
+		// Avoid appending to an empty buffer — assign directly to skip the
+		// string concatenation and its intermediate allocation.
+		buffer = buffer ? buffer + decoded : decoded;
+
+		// Consume all complete SSE messages (delimited by \n\n) so the
+		// buffer only ever holds one partial message between reads.
 		let idx = buffer.indexOf("\n\n");
 		while (idx !== -1) {
 			const chunk = buffer.slice(0, idx);


### PR DESCRIPTION
## Summary

- The existing `parseSSE` buffer already slices off processed messages in a `while` loop, so true O(n^2) growth was **not present** — the buffer only ever holds one partial SSE message between reads
- Added a minor optimization: skip string concatenation when the buffer is empty (assign directly instead of `"" + decoded`) to avoid an unnecessary intermediate allocation
- Added clarifying comments documenting why the buffer pattern is safe from quadratic growth

## Analysis

The original concern was that `buffer += decoder.decode(value)` in a loop causes quadratic allocation. In practice, the inner `while (idx !== -1)` loop consumes all complete `\n\n`-delimited messages each iteration, keeping the buffer bounded to at most one partial message. The append-then-consume pattern is O(n) overall.

The only change is avoiding `"" + decoded` on the first append of each read cycle by assigning directly when the buffer is empty.

## Test plan

- [ ] Verify SSE streaming still works end-to-end with OpenAI/Codex responses
- [ ] No behavioral change — purely a micro-optimization and documentation improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)