### PR TITLE
fix: add error handlers to visualizer overlay promise chains

### DIFF
--- a/src/resources/extensions/gsd/visualizer-overlay.ts
+++ b/src/resources/extensions/gsd/visualizer-overlay.ts
@@ -86,6 +86,9 @@ export class GSDVisualizerOverlay {
       this.data = d;
       this.loading = false;
       this.tui.requestRender();
+    }).catch(() => {
+      this.loading = false;
+      this.tui.requestRender();
     });
 
     this.refreshTimer = setInterval(() => {
@@ -94,7 +97,7 @@ export class GSDVisualizerOverlay {
         this.data = d;
         this.invalidate();
         this.tui.requestRender();
-      });
+      }).catch(() => {}); // retry on next interval
     }, 5000);
   }
 


### PR DESCRIPTION
## Summary
- Adds `.catch()` to the initial `loadVisualizerData()` call so `loading` is set to `false` on failure (previously it would stay `true` forever)
- Adds `.catch()` to the refresh timer's `loadVisualizerData()` call to prevent unhandled promise rejections (retries automatically in 5s)

## Test plan
- [ ] Verify `npx tsc --noEmit` passes (confirmed locally)
- [ ] Confirm overlay recovers gracefully when visualizer data fails to load

🤖 Generated with [Claude Code](https://claude.com/claude-code)