### PR TITLE
fix: deduplicate formatDateShort into shared/format-utils

### DIFF
--- a/src/resources/extensions/gsd/export-html.ts
+++ b/src/resources/extensions/gsd/export-html.ts
@@ -25,7 +25,7 @@ import type {
   VisualizerMilestone,
   VisualizerSlice,
 } from './visualizer-data.js';
-import { formatDuration } from '../shared/format-utils.js';
+import { formatDateShort, formatDuration } from '../shared/format-utils.js';
 import { formatCost, formatTokenCount } from './metrics.js';
 
 // ─── Public API ────────────────────────────────────────────────────────────────
@@ -767,12 +767,6 @@ function formatDateLong(iso: string): string {
   } catch { return iso; }
 }
 
-function formatDateShort(iso: string): string {
-  try {
-    const d = new Date(iso);
-    return d.toLocaleString('en-US', { month: 'short', day: 'numeric', year: 'numeric', hour: '2-digit', minute: '2-digit' });
-  } catch { return iso; }
-}
 
 function esc(s: string | undefined | null): string {
   if (s == null) return '';

--- a/src/resources/extensions/gsd/reports.ts
+++ b/src/resources/extensions/gsd/reports.ts
@@ -18,7 +18,7 @@ import { writeFileSync, readFileSync, mkdirSync, existsSync } from 'node:fs';
 import { join, basename } from 'node:path';
 import { gsdRoot } from './paths.js';
 import { formatCost, formatTokenCount } from './metrics.js';
-import { formatDuration } from '../shared/format-utils.js';
+import { formatDateShort, formatDuration } from '../shared/format-utils.js';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -382,12 +382,6 @@ function buildCostSparkline(entries: ReportEntry[]): string {
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
-function formatDateShort(iso: string): string {
-  try {
-    const d = new Date(iso);
-    return d.toLocaleString('en-US', { month: 'short', day: 'numeric', year: 'numeric', hour: '2-digit', minute: '2-digit' });
-  } catch { return iso; }
-}
 
 function esc(s: string | number | undefined | null): string {
   if (s == null) return '';

--- a/src/resources/extensions/shared/format-utils.ts
+++ b/src/resources/extensions/shared/format-utils.ts
@@ -87,6 +87,16 @@ export function sparkline(values: number[]): string {
   return values.map(v => chars[Math.min(7, Math.floor((v / max) * 7))]).join("");
 }
 
+// ─── Date Formatting ─────────────────────────────────────────────────────────
+
+/** Format an ISO date string as a compact locale string (e.g. "Mar 17, 2025, 02:30 PM"). */
+export function formatDateShort(iso: string): string {
+  try {
+    const d = new Date(iso);
+    return d.toLocaleString('en-US', { month: 'short', day: 'numeric', year: 'numeric', hour: '2-digit', minute: '2-digit' });
+  } catch { return iso; }
+}
+
 // ─── ANSI Stripping ───────────────────────────────────────────────────────────
 
 /** Strip ANSI escape sequences from a string. */


### PR DESCRIPTION
## Summary
- Moved `formatDateShort()` from local definitions in `export-html.ts` and `reports.ts` into `shared/format-utils.ts`
- Both consumer files now import from the shared module (already had existing imports from `format-utils.js`)
- `npx tsc --noEmit` passes clean

## Test plan
- [ ] Verify HTML export date formatting unchanged
- [ ] Verify reports date formatting unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)