### PR TITLE
fix: use literal union types in RuntimeErrorJSON

### DIFF
--- a/src/resources/extensions/gsd/verification-evidence.ts
+++ b/src/resources/extensions/gsd/verification-evidence.ts
@@ -23,8 +23,8 @@ export interface EvidenceCheckJSON {
 }
 
 export interface RuntimeErrorJSON {
-  source: string;
-  severity: string;
+  source: "bg-shell" | "browser";
+  severity: "crash" | "error" | "warning";
   message: string;
   blocking: boolean;
 }


### PR DESCRIPTION
## Summary
- `RuntimeErrorJSON.source` and `RuntimeErrorJSON.severity` were typed as `string`, losing the literal union type safety that `RuntimeError` in `types.ts` provides
- Updated to use `"bg-shell" | "browser"` and `"crash" | "error" | "warning"` respectively, matching the source interface

## Test plan
- [x] `npx tsc --noEmit` passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)