### PR TITLE
fix: document silent catch handlers in browser-tools

### DIFF
--- a/src/resources/extensions/browser-tools/lifecycle.ts
+++ b/src/resources/extensions/browser-tools/lifecycle.ts
@@ -103,10 +103,10 @@ export function attachPageListeners(p: Page, pageId: number): void {
 				try {
 					const body = await response.text();
 					entry.responseBody = body.slice(0, 2000);
-				} catch {}
+				} catch { /* non-fatal — response body may be unavailable or already consumed */ }
 			}
 			logPusher(networkLogs, entry);
-		} catch {}
+		} catch { /* non-fatal — request may have been aborted or page closed */ }
 	});
 
 	p.on("requestfailed", (request) => {

--- a/src/resources/extensions/browser-tools/tools/navigation.ts
+++ b/src/resources/extensions/browser-tools/tools/navigation.ts
@@ -60,7 +60,7 @@ export function registerNavigationTools(pi: ExtensionAPI, deps: ToolDeps): void 
 						let buf = await p.screenshot({ type: "jpeg", quality: 80, scale: "css" });
 						buf = await deps.constrainScreenshot(p, buf, "image/jpeg", 80);
 						screenshotContent = [{ type: "image", data: buf.toString("base64"), mimeType: "image/jpeg" }];
-					} catch {}
+					} catch { /* non-fatal — screenshot is optional, navigation result is still valid */ }
 				}
 
 				return {
@@ -207,7 +207,7 @@ export function registerNavigationTools(pi: ExtensionAPI, deps: ToolDeps): void 
 						data: buf.toString("base64"),
 						mimeType: "image/jpeg",
 					}];
-				} catch {}
+				} catch { /* non-fatal — screenshot is optional, reload result is still valid */ }
 
 				return {
 					content: [

--- a/src/resources/extensions/browser-tools/tools/network-mock.ts
+++ b/src/resources/extensions/browser-tools/tools/network-mock.ts
@@ -161,7 +161,7 @@ export function registerNetworkMockTools(pi: ExtensionAPI, deps: ToolDeps): void
 					const cleanup = async () => {
 						try {
 							await p.unroute(pattern, handler);
-						} catch {}
+						} catch { /* cleanup — route may already be removed or page closed */ }
 					};
 
 					const routeInfo: ActiveRoute = {

--- a/src/resources/extensions/browser-tools/tools/pages.ts
+++ b/src/resources/extensions/browser-tools/tools/pages.ts
@@ -137,7 +137,7 @@ export function registerPageTools(pi: ExtensionAPI, deps: ToolDeps): void {
 					try {
 						remaining.title = await remaining.page.title();
 						remaining.url = remaining.page.url();
-					} catch {}
+					} catch { /* non-fatal — page may have been closed or navigated away */ }
 				}
 				const pages = registryListPages(pageRegistry);
 				const lines = pages.map((p: any) => {

--- a/src/resources/extensions/browser-tools/tools/state-persistence.ts
+++ b/src/resources/extensions/browser-tools/tools/state-persistence.ts
@@ -69,7 +69,7 @@ export function registerStatePersistenceTools(pi: ExtensionAPI, deps: ToolDeps):
 
 				// Ensure .gitignore covers the state dir
 				const gitignorePath = path.resolve(process.cwd(), STATE_DIR, ".gitignore");
-				await writeFile(gitignorePath, "*\n!.gitignore\n").catch(() => {});
+				await writeFile(gitignorePath, "*\n!.gitignore\n").catch(() => { /* best-effort — .gitignore may already exist or dir may be read-only */ });
 
 				const cookieCount = storageState.cookies?.length ?? 0;
 				const localStorageOrigins = storageState.origins?.length ?? 0;

--- a/src/resources/extensions/browser-tools/tools/visual-diff.ts
+++ b/src/resources/extensions/browser-tools/tools/visual-diff.ts
@@ -55,7 +55,7 @@ export function registerVisualDiffTools(pi: ExtensionAPI, deps: ToolDeps): void 
 
 				// Ensure .gitignore
 				const gitignorePath = pathMod.join(baselineDir, ".gitignore");
-				await writeFile(gitignorePath, "*\n!.gitignore\n").catch(() => {});
+				await writeFile(gitignorePath, "*\n!.gitignore\n").catch(() => { /* best-effort — .gitignore may already exist or dir may be read-only */ });
 
 				// Generate baseline name
 				const url = p.url();


### PR DESCRIPTION
## Summary
- Added descriptive inline comments to all 8 empty `catch` blocks across 6 files in browser-tools
- Each comment explains why the error is intentionally swallowed (networkidle timeouts, optional screenshots, best-effort file writes, response body reads, route cleanup, page metadata refreshes)
- Zero empty catch blocks remain in the browser-tools extension

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] Grep confirms zero empty catch blocks remain in browser-tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)