### PR TITLE
fix: centralize GSD timeout and cache constants

### DIFF
--- a/src/resources/extensions/gsd/constants.ts
+++ b/src/resources/extensions/gsd/constants.ts
@@ -1,0 +1,21 @@
+/**
+ * GSD Extension — Shared Constants
+ *
+ * Centralized timeout and cache-size constants used across the GSD extension.
+ */
+
+// ─── Timeouts ─────────────────────────────────────────────────────────────────
+
+/** Default timeout for verification-gate commands (ms). */
+export const DEFAULT_COMMAND_TIMEOUT_MS = 120_000;
+
+/** Default timeout for the dynamic bash tool (seconds). */
+export const DEFAULT_BASH_TIMEOUT_SECS = 120;
+
+// ─── Cache Sizes ──────────────────────────────────────────────────────────────
+
+/** Max directory-listing cache entries before eviction (#611). */
+export const DIR_CACHE_MAX = 200;
+
+/** Max parse-cache entries before eviction. */
+export const CACHE_MAX = 50;

--- a/src/resources/extensions/gsd/files.ts
+++ b/src/resources/extensions/gsd/files.ts
@@ -23,10 +23,9 @@ import { checkExistingEnvKeys } from '../get-secrets-from-user.js';
 import { parseRoadmapSlices } from './roadmap-slices.js';
 import { nativeParseRoadmap, nativeExtractSection, nativeParsePlanFile, nativeParseSummaryFile, NATIVE_UNAVAILABLE } from './native-parser-bridge.js';
 import { debugTime, debugCount } from './debug-logger.js';
+import { CACHE_MAX } from './constants.js';
 
 // ─── Parse Cache ──────────────────────────────────────────────────────────
-
-const CACHE_MAX = 50;
 
 /** Fast composite key: length + first/mid/last 100 chars. The middle sample
  *  prevents collisions when only a few characters change in the interior of

--- a/src/resources/extensions/gsd/index.ts
+++ b/src/resources/extensions/gsd/index.ts
@@ -62,6 +62,7 @@ import { Text } from "@gsd/pi-tui";
 import { pauseAutoForProviderError, classifyProviderError } from "./provider-error-pause.js";
 import { toPosixPath } from "../shared/path-display.js";
 import { isParallelActive, shutdownParallel } from "./parallel-orchestrator.js";
+import { DEFAULT_BASH_TIMEOUT_SECS } from "./constants.js";
 
 // ── Agent Instructions ────────────────────────────────────────────────────
 // Lightweight "always follow" files injected into every GSD agent session.
@@ -171,7 +172,6 @@ export default function (pi: ExtensionAPI) {
   // the timeout parameter, commands run indefinitely, causing hangs on
   // Windows where process killing is unreliable (see #40). We wrap execute
   // to inject a 120-second default when no timeout is provided.
-  const DEFAULT_BASH_TIMEOUT_SECS = 120;
   const baseBash = createBashTool(process.cwd(), {
     spawnHook: (ctx) => ({ ...ctx, cwd: process.cwd() }),
   });

--- a/src/resources/extensions/gsd/paths.ts
+++ b/src/resources/extensions/gsd/paths.ts
@@ -12,11 +12,9 @@
 import { readdirSync, existsSync, Dirent } from "node:fs";
 import { join } from "node:path";
 import { nativeScanGsdTree, type GsdTreeEntry } from "./native-parser-bridge.js";
+import { DIR_CACHE_MAX } from "./constants.js";
 
 // ─── Directory Listing Cache ──────────────────────────────────────────────────
-
-/** Max entries before eviction. Prevents unbounded growth in long sessions (#611). */
-const DIR_CACHE_MAX = 200;
 
 const dirEntryCache = new Map<string, Dirent[]>();
 const dirListCache = new Map<string, string[]>();

--- a/src/resources/extensions/gsd/verification-gate.ts
+++ b/src/resources/extensions/gsd/verification-gate.ts
@@ -7,6 +7,7 @@ import { spawnSync } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
 import { join, basename } from "node:path";
 import type { AuditWarning, RuntimeError, VerificationCheck, VerificationResult } from "./types.js";
+import { DEFAULT_COMMAND_TIMEOUT_MS } from "./constants.js";
 
 /** Maximum bytes of stdout/stderr to retain per command (10 KB). */
 const MAX_OUTPUT_BYTES = 10 * 1024;
@@ -151,9 +152,6 @@ function sanitizeCommand(cmd: string): string | null {
   if (SHELL_INJECTION_PATTERN.test(cmd)) return null;
   return cmd;
 }
-
-/** Default timeout for verification commands (ms). */
-const DEFAULT_COMMAND_TIMEOUT_MS = 120_000;
 
 export interface RunVerificationGateOptions {
   basePath: string;


### PR DESCRIPTION
## Summary
- Create `src/resources/extensions/gsd/constants.ts` with all GSD-specific timeout and cache-size constants
- Move `DEFAULT_COMMAND_TIMEOUT_MS` from verification-gate.ts, `DEFAULT_BASH_TIMEOUT_SECS` from index.ts, `DIR_CACHE_MAX` from paths.ts, and `CACHE_MAX` from files.ts into the new module
- Update all import sites to use the centralized constants

## Test plan
- [x] `npx tsc --noEmit` passes with zero errors
- [ ] Verify GSD auto-mode still respects bash timeout
- [ ] Verify verification gate still uses correct timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)