### PR TITLE
fix: improve RemotePromptRecord.ref type safety

### DIFF
--- a/src/resources/extensions/remote-questions/manager.ts
+++ b/src/resources/extensions/remote-questions/manager.ts
@@ -79,11 +79,9 @@ export async function tryRemoteQuestions(
   markPromptAnswered(prompt.id, answer);
 
   // Best-effort acknowledgement gives remote users a visible receipt signal.
-  if (dispatch.ref) {
-    try {
-      await adapter.acknowledgeAnswer?.(dispatch.ref);
-    } catch { /* best-effort */ }
-  }
+  try {
+    await adapter.acknowledgeAnswer?.(dispatch.ref);
+  } catch { /* best-effort */ }
 
   return {
     content: [{ type: "text", text: JSON.stringify({ answers: formatForTool(answer) }) }],

--- a/src/resources/extensions/remote-questions/store.ts
+++ b/src/resources/extensions/remote-questions/store.ts
@@ -51,11 +51,15 @@ export function updatePromptRecord(
 ): RemotePromptRecord | null {
   const current = readPromptRecord(id);
   if (!current) return null;
-  const next: RemotePromptRecord = {
+  const merged = {
     ...current,
     ...updates,
     updatedAt: Date.now(),
   };
+  // After spreading, the merged object satisfies one of the union members
+  // but TypeScript can't prove it statically. The invariant is maintained
+  // by callers: once `ref` is set via markPromptDispatched it is never removed.
+  const next = merged as RemotePromptRecord;
   writePromptRecord(next);
   return next;
 }

--- a/src/resources/extensions/remote-questions/types.ts
+++ b/src/resources/extensions/remote-questions/types.ts
@@ -44,17 +44,16 @@ export interface RemoteAnswer {
 
 export type RemotePromptStatus = "pending" | "answered" | "timed_out" | "failed" | "cancelled";
 
-export interface RemotePromptRecord {
+/** Shared fields present on every prompt record regardless of dispatch state. */
+interface RemotePromptRecordBase {
   version: 1;
   id: string;
   createdAt: number;
   updatedAt: number;
-  status: RemotePromptStatus;
   channel: RemoteChannel;
   timeoutAt: number;
   pollIntervalMs: number;
   questions: RemoteQuestion[];
-  ref?: RemotePromptRef;
   response?: RemoteAnswer;
   lastPollAt?: number;
   lastError?: string;
@@ -62,6 +61,30 @@ export interface RemotePromptRecord {
     source: string;
   };
 }
+
+/** Record before the prompt has been dispatched to a channel. */
+export interface PendingPromptRecord extends RemotePromptRecordBase {
+  status: "pending";
+  ref?: undefined;
+}
+
+/** Record after the prompt has been dispatched (ref is always present). */
+export interface DispatchedPromptRecord extends RemotePromptRecordBase {
+  status: RemotePromptStatus;
+  ref: RemotePromptRef;
+}
+
+/**
+ * A prompt record is either pre-dispatch (no ref) or post-dispatch (ref required).
+ *
+ * Narrow via `record.ref`:
+ * ```ts
+ * if (record.ref) {
+ *   // DispatchedPromptRecord — ref is RemotePromptRef
+ * }
+ * ```
+ */
+export type RemotePromptRecord = PendingPromptRecord | DispatchedPromptRecord;
 
 export interface RemoteDispatchResult {
   ref: RemotePromptRef;


### PR DESCRIPTION
## Summary
- Split `RemotePromptRecord` into a discriminated union: `PendingPromptRecord` (ref undefined) and `DispatchedPromptRecord` (ref required), enforcing at the type level that `ref` is always present after dispatch
- Added a single `as RemotePromptRecord` assertion in `updatePromptRecord` where TypeScript can't statically prove the spread maintains the union invariant
- Removed redundant `if (dispatch.ref)` guard in `manager.ts` since `RemoteDispatchResult.ref` is already non-optional

## Test plan
- [x] `npx tsc --noEmit` passes with zero errors
- [ ] Existing remote-questions functionality works as before (no runtime changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)