### PR TITLE
fix: always ensure tasks/ directory exists for slice units (#900)

### DIFF
--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -3309,15 +3309,16 @@ function ensurePreconditions(
       const slicesDir = join(mDirResolved, "slices");
       const sDir = resolveDir(slicesDir, sid);
       if (!sDir) {
-        // Create slice dir with bare ID
-        const newSliceDir = join(slicesDir, sid);
-        mkdirSync(join(newSliceDir, "tasks"), { recursive: true });
-      } else {
-        // Ensure tasks/ subdir exists
-        const tasksDir = join(slicesDir, sDir, "tasks");
-        if (!existsSync(tasksDir)) {
-          mkdirSync(tasksDir, { recursive: true });
-        }
+        // Create slice dir with bare ID (tasks/ included)
+        mkdirSync(join(slicesDir, sid, "tasks"), { recursive: true });
+      }
+      // Always ensure tasks/ subdir exists — even when slice dir was already
+      // present. Handles the case where a slice was created manually or by a
+      // previous run that didn't create tasks/. (#900)
+      const resolvedSliceDir = resolveDir(slicesDir, sid) ?? sid;
+      const tasksDir = join(slicesDir, resolvedSliceDir, "tasks");
+      if (!existsSync(tasksDir)) {
+        mkdirSync(tasksDir, { recursive: true });
       }
     }
   }


### PR DESCRIPTION
Fixes #900

`ensurePreconditions()` had two branches for slice directory handling:
1. Slice doesn't exist → create with `tasks/`
2. Slice exists → conditionally create `tasks/`

The second path could miss cases where a slice dir was created manually or by a previous run that didn't create the `tasks/` subdirectory, causing doctor errors (`missing_tasks_dir`).

## Fix

Simplified to: create slice dir if missing, then **always** check and create `tasks/` unconditionally. Removes the branching that could leave `tasks/` missing.

## File changed
- `src/resources/extensions/gsd/auto.ts`: `ensurePreconditions()` function