### PR TITLE
docs: add troubleshooting for oh-my-zsh gsd alias collision (#722)

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -151,3 +151,23 @@ Shows each session's date, message count, and first-message preview so you can c
 - [Auto Mode](./auto-mode.md) — deep dive into autonomous execution
 - [Configuration](./configuration.md) — model selection, timeouts, budgets
 - [Commands Reference](./commands.md) — all commands and shortcuts
+
+## Troubleshooting
+
+### `gsd` command runs `git svn dcommit` instead of GSD
+
+The [oh-my-zsh git plugin](https://github.com/ohmyzsh/ohmyzsh/tree/master/plugins/git) defines `alias gsd='git svn dcommit'`, which shadows the GSD binary.
+
+**Option 1** — Remove the alias in your `~/.zshrc` (add after the `source $ZSH/oh-my-zsh.sh` line):
+
+```bash
+unalias gsd 2>/dev/null
+```
+
+**Option 2** — Use the alternative binary name:
+
+```bash
+gsd-cli
+```
+
+Both `gsd` and `gsd-cli` point to the same binary.


### PR DESCRIPTION
Fixes #722

oh-my-zsh's git plugin defines `alias gsd='git svn dcommit'` which shadows the GSD binary. Multiple users confirmed this issue.

Added a troubleshooting section to `docs/getting-started.md` with two solutions:
1. `unalias gsd 2>/dev/null` in `~/.zshrc`
2. Use the `gsd-cli` alternative binary name (already exists in package.json bin)

## File changed
- `docs/getting-started.md`: new Troubleshooting section