### PR TITLE
fix: inline compareSemver in gsd extension to fix broken relative import

### DIFF
--- a/src/resources/extensions/gsd/commands.ts
+++ b/src/resources/extensions/gsd/commands.ts
@@ -2280,9 +2280,20 @@ Examples:
 
 // ─── Self-update handler ────────────────────────────────────────────────────
 
+function compareSemverLocal(a: string, b: string): number {
+  const pa = a.split('.').map(Number)
+  const pb = b.split('.').map(Number)
+  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+    const va = pa[i] || 0
+    const vb = pb[i] || 0
+    if (va > vb) return 1
+    if (va < vb) return -1
+  }
+  return 0
+}
+
 async function handleUpdate(ctx: ExtensionCommandContext): Promise<void> {
   const { execSync } = await import("node:child_process");
-  const { compareSemver } = await import("../../../update-check.js");
 
   const NPM_PACKAGE = "gsd-pi";
   const current = process.env.GSD_VERSION || "0.0.0";
@@ -2300,7 +2311,7 @@ async function handleUpdate(ctx: ExtensionCommandContext): Promise<void> {
     return;
   }
 
-  if (compareSemver(latest, current) <= 0) {
+  if (compareSemverLocal(latest, current) <= 0) {
     ctx.ui.notify(`Already up to date (v${current}).`, "info");
     return;
   }


### PR DESCRIPTION
## Summary

- The `/gsd update` command's `handleUpdate()` function imported `compareSemver` from `../../../update-check.js` — a relative path that works in the source tree (`src/resources/extensions/gsd/` → `src/update-check.js`) but breaks when extensions are synced to `~/.gsd/agent/extensions/gsd/` at runtime (where `../../../` resolves to `~/.gsd/`, which has no `update-check.js`)
- This caused the startup error: `Extension "command:gsd" error: Cannot find module '../../../update-check.js'`
- Fix: inlined a local `compareSemverLocal()` function (10 lines) directly in `commands.ts`, eliminating the cross-tree import dependency

Closes #1060

## Root cause

Extensions in `src/resources/extensions/` are synced to `~/.gsd/agent/extensions/` by `initResources()` on startup. Any relative imports that escape the extensions directory (e.g., `../../../update-check.js`) will resolve to different paths in the source tree vs the installed location:

| Context | `../../../` resolves to | Has `update-check.js`? |
|---------|------------------------|----------------------|
| Source tree | `src/` | Yes |
| Installed (`~/.gsd/agent/extensions/gsd/`) | `~/.gsd/` | No |

## What changed

**`src/resources/extensions/gsd/commands.ts`**:
- Removed `import("../../../update-check.js")` dynamic import from `handleUpdate()`
- Added self-contained `compareSemverLocal()` function that replicates the same semver comparison logic
- The original function is well-tested via `update-check.test.ts`; the inlined version is identical

## Test plan

- [x] `npm run build` — compiles cleanly
- [x] `npm run test:unit` — all 1306 tests pass, no regressions
- [x] Verified `dist/resources/extensions/gsd/commands.ts` contains the fix and no `update-check.js` reference
- [ ] Launch `gsd` and confirm no `Cannot find module` errors on startup
- [ ] Run `/gsd update` and confirm it correctly checks and reports version status