### PR TITLE
fix: prevent run-uat re-dispatch loop on roadmap checkbox mismatch

### DIFF
--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -1245,12 +1245,16 @@ export async function handleAgentEnd(
     // fixLevel:"task" ensures doctor only fixes task-level issues (e.g. marking
     // checkboxes). Slice/milestone completion transitions (summary stubs,
     // roadmap [x] marking) are left for the complete-slice dispatch unit.
-    // Exception: after complete-slice itself, use fixLevel:"all" so roadmap
-    // checkboxes get fixed even if complete-slice crashed (#839).
+    // Exception: after complete-slice and run-uat, use fixLevel:"all" so roadmap
+    // checkboxes get fixed. run-uat is the terminal unit for a slice — if the
+    // roadmap checkbox wasn't marked done by complete-slice (e.g. edit failure),
+    // fixing it here prevents the state machine from re-dispatching run-uat
+    // indefinitely (#839, #1063).
     try {
       const scopeParts = s.currentUnit.id.split("/").slice(0, 2);
       const doctorScope = scopeParts.join("/");
-      const effectiveFixLevel = s.currentUnit.type === "complete-slice" ? "all" as const : "task" as const;
+      const sliceTerminalUnits = new Set(["complete-slice", "run-uat"]);
+      const effectiveFixLevel = sliceTerminalUnits.has(s.currentUnit.type) ? "all" as const : "task" as const;
       const report = await runGSDDoctor(s.basePath, { fix: true, scope: doctorScope, fixLevel: effectiveFixLevel });
       if (report.fixesApplied.length > 0) {
         ctx.ui.notify(`Post-hook: applied ${report.fixesApplied.length} fix(es).`, "info");

--- a/src/resources/extensions/gsd/doctor.ts
+++ b/src/resources/extensions/gsd/doctor.ts
@@ -308,7 +308,13 @@ async function markTaskDoneInPlan(basePath: string, milestoneId: string, sliceId
   if (!planPath) return;
   const content = await loadFile(planPath);
   if (!content) return;
-  const updated = content.replace(new RegExp(`^-\\s+\\[ \\]\\s+\\*\\*${taskId}:`, "m"), `- [x] **${taskId}:`);
+  // Allow optional leading whitespace to match the same patterns the plan parser
+  // accepts. Capture the leading whitespace + "- " so the replacement preserves
+  // indentation instead of collapsing it (#1063).
+  const updated = content.replace(
+    new RegExp(`^(\\s*-\\s+)\\[ \\]\\s+\\*\\*${taskId}:`, "m"),
+    `$1[x] **${taskId}:`,
+  );
   if (updated !== content) {
     await saveFile(planPath, updated);
     fixesApplied.push(`marked ${taskId} done in ${planPath}`);
@@ -320,7 +326,13 @@ async function markSliceDoneInRoadmap(basePath: string, milestoneId: string, sli
   if (!roadmapPath) return;
   const content = await loadFile(roadmapPath);
   if (!content) return;
-  const updated = content.replace(new RegExp(`^-\\s+\\[ \\]\\s+\\*\\*${sliceId}:`, "m"), `- [x] **${sliceId}:`);
+  // Allow optional leading whitespace to match the same patterns the roadmap
+  // parser accepts (^\s*-\s+ in roadmap-slices.ts). Capture the prefix so the
+  // replacement preserves original indentation (#1063).
+  const updated = content.replace(
+    new RegExp(`^(\\s*-\\s+)\\[ \\]\\s+\\*\\*${sliceId}:`, "m"),
+    `$1[x] **${sliceId}:`,
+  );
   if (updated !== content) {
     await saveFile(roadmapPath, updated);
     fixesApplied.push(`marked ${sliceId} done in ${roadmapPath}`);

--- a/src/resources/extensions/gsd/tests/doctor-fixlevel.test.ts
+++ b/src/resources/extensions/gsd/tests/doctor-fixlevel.test.ts
@@ -115,6 +115,81 @@ test("fixLevel:all (default) — detects AND fixes completion issues", async () 
   }
 });
 
+test("fixLevel:all — marks indented roadmap checkboxes done (#1063)", async () => {
+  const tmp = makeTmp("indented-roadmap");
+  try {
+    buildScaffold(tmp);
+
+    // Overwrite roadmap with indented checkbox (LLM formatting drift)
+    writeFileSync(join(tmp, ".gsd", "milestones", "M001", "M001-ROADMAP.md"), `# M001: Test
+
+## Slices
+
+  - [ ] **S01: Test Slice** \`risk:low\` \`depends:[]\`
+    > Demo text
+`);
+
+    const report = await runGSDDoctor(tmp, { fix: true });
+
+    const roadmapContent = readFileSync(join(tmp, ".gsd", "milestones", "M001", "M001-ROADMAP.md"), "utf8");
+    // Should mark [x] while preserving the leading whitespace
+    assert.ok(roadmapContent.includes("  - [x] **S01"), "indented roadmap checkbox should be marked done");
+    // Verify indentation is preserved: line should start with "  -", not just "-"
+    const checkedLine = roadmapContent.split("\n").find(l => l.includes("[x] **S01"));
+    assert.ok(checkedLine?.startsWith("  -"), `should preserve leading whitespace, got: "${checkedLine}"`);
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("fixLevel:all — marks indented task checkboxes done (#1063)", async () => {
+  const tmp = makeTmp("indented-task");
+  try {
+    const gsd = join(tmp, ".gsd");
+    const m = join(gsd, "milestones", "M001");
+    const s = join(m, "slices", "S01", "tasks");
+    mkdirSync(s, { recursive: true });
+
+    writeFileSync(join(m, "M001-ROADMAP.md"), `# M001: Test
+
+## Slices
+
+- [ ] **S01: Test Slice** \`risk:low\` \`depends:[]\`
+`);
+
+    // Plan with indented checkbox
+    writeFileSync(join(m, "slices", "S01", "S01-PLAN.md"), `# S01: Test Slice
+
+**Goal:** test
+
+## Tasks
+
+  - [ ] **T01: Do stuff** \`est:5m\`
+`);
+
+    writeFileSync(join(s, "T01-SUMMARY.md"), `---
+id: T01
+parent: S01
+milestone: M001
+duration: 5m
+verification_result: passed
+completed_at: 2026-01-01
+---
+
+# T01: Do stuff
+
+Done.
+`);
+
+    const report = await runGSDDoctor(tmp, { fix: true, fixLevel: "task" });
+
+    const planContent = readFileSync(join(m, "slices", "S01", "S01-PLAN.md"), "utf8");
+    assert.ok(planContent.includes("  - [x] **T01"), "indented task checkbox should be marked done");
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
 test("fixLevel:task — still fixes task-level bookkeeping (checkbox marking)", async () => {
   const tmp = makeTmp("task-checkbox");
   try {


### PR DESCRIPTION
## Problem

Auto-mode kept re-dispatching `run-uat/M003-jtsqzu/S02` after S02 UAT completed successfully. The slice was done, but the state machine did not advance to S03 and instead repeated the same unit (#1063).

### Root Cause

Two compounding bugs:

**Bug 1: `markSliceDoneInRoadmap` regex doesn't match indented checkboxes**

The doctor's regex for marking a slice done uses `^-\s+\[ \]`, requiring the dash at the start of the line. But the roadmap parser (`roadmap-slices.ts:67`) accepts `^\s*-\s+` — optional leading whitespace. When LLMs format roadmap checklist items with indentation (e.g., `  - [ ] **S02: ...`), the parser reads the slice as incomplete, but the doctor can never mark it done because the regex doesn't match.

```
Parser:  ^\s*-\s+\[([ xX])\]  ← matches indented lines
Doctor:  ^-\s+\[ \]           ← requires dash at column 0
```

**Bug 2: `run-uat` closeout doesn't fix slice-level completion state**

After `run-uat` completes, `handleAgentEnd` runs doctor with `fixLevel:"task"`, which explicitly excludes `all_tasks_done_roadmap_not_checked` from being auto-fixed (it's classified as a "completion transition" reserved for `complete-slice`). Since `run-uat` is the **terminal unit** for a slice, this creates a dead end: the roadmap checkbox can never be fixed, `deriveState()` keeps returning the same incomplete slice, and the dispatcher loops.

### Symptoms

- `run-uat` dispatched 7 times for the same slice
- Closeout traces show exact-text edit failures against `.gsd/PROJECT.md` and `.gsd/STATE.md`
- Doctor reports `all_tasks_done_roadmap_not_checked` but never fixes it
- UAT-RESULT file exists with PASS — the problem is purely state-machine advancement

## Fix

### Bug 1 fix: `doctor.ts`

Updated `markSliceDoneInRoadmap` and `markTaskDoneInPlan` regexes to accept optional leading whitespace (`^\s*-` instead of `^-`), matching the same patterns the roadmap/plan parsers accept. The leading whitespace is captured and preserved in the replacement to avoid collapsing indentation.

```diff
- new RegExp(`^-\\s+\\[ \\]\\s+\\*\\*${sliceId}:`, "m")
+ new RegExp(`^(\\s*-\\s+)\\[ \\]\\s+\\*\\*${sliceId}:`, "m")
```

### Bug 2 fix: `auto.ts`

Added `run-uat` to the set of unit types that use `fixLevel:"all"` in `handleAgentEnd` closeout. Since `run-uat` is the terminal unit for a slice, allowing slice-level completion fixes here prevents the state machine from stalling when `complete-slice` failed to mark the roadmap.

```diff
- const effectiveFixLevel = s.currentUnit.type === "complete-slice" ? "all" : "task";
+ const sliceTerminalUnits = new Set(["complete-slice", "run-uat"]);
+ const effectiveFixLevel = sliceTerminalUnits.has(s.currentUnit.type) ? "all" : "task";
```

## Files Changed

| File | Change |
|------|--------|
| `doctor.ts` | Fix `markSliceDoneInRoadmap` and `markTaskDoneInPlan` regexes to accept leading whitespace |
| `auto.ts` | Add `run-uat` to slice terminal units that use `fixLevel:"all"` |
| `tests/doctor-fixlevel.test.ts` | Add 2 tests for indented checkbox marking |

## Tests

- `npm run build` — clean ✓
- `npm run test:unit` — 1308/1308 pass ✓
- New tests:
  - `fixLevel:all — marks indented roadmap checkboxes done (#1063)` ✓
  - `fixLevel:all — marks indented task checkboxes done (#1063)` ✓

Closes #1063