### PR TITLE
fix: prevent summarizing phase stall by retrying dropped agent_end events

### DIFF
--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -1163,7 +1163,15 @@ export async function handleAgentEnd(
   pi: ExtensionAPI,
 ): Promise<void> {
   if (!s.active || !s.cmdCtx) return;
-  if (s.handlingAgentEnd) return;
+  if (s.handlingAgentEnd) {
+    // Another agent_end arrived while we're still processing the previous one.
+    // This happens when a unit dispatched inside handleAgentEnd (e.g. via hooks,
+    // triage, or quick-task early-dispatch paths) completes before the outer
+    // handleAgentEnd returns. Queue a retry so the completed unit's agent_end
+    // is not silently dropped (#1072).
+    s.pendingAgentEndRetry = true;
+    return;
+  }
   s.handlingAgentEnd = true;
 
   try {
@@ -1888,6 +1896,23 @@ export async function handleAgentEnd(
 
   } finally {
     s.handlingAgentEnd = false;
+
+    // If an agent_end event was dropped by the reentrancy guard while we were
+    // processing, re-enter handleAgentEnd on the next microtask. This prevents
+    // the summarizing phase stall (#1072) where a unit dispatched inside
+    // handleAgentEnd (hooks, triage, quick-task) completes before we return,
+    // and its agent_end is silently dropped — leaving auto-mode active but
+    // permanently stalled with no unit running and no watchdog set.
+    if (s.pendingAgentEndRetry) {
+      s.pendingAgentEndRetry = false;
+      setImmediate(() => {
+        handleAgentEnd(ctx, pi).catch((err) => {
+          const msg = err instanceof Error ? err.message : String(err);
+          ctx.ui.notify(`Deferred agent_end retry failed: ${msg}`, "error");
+          pauseAuto(ctx, pi).catch(() => {});
+        });
+      });
+    }
   }
 }
 

--- a/src/resources/extensions/gsd/auto/session.ts
+++ b/src/resources/extensions/gsd/auto/session.ts
@@ -112,6 +112,7 @@ export class AutoSession {
 
   // ── Guards ───────────────────────────────────────────────────────────────
   handlingAgentEnd = false;
+  pendingAgentEndRetry = false;
   dispatching = false;
   skipDepth = 0;
   readonly recentlyEvictedKeys = new Set<string>();
@@ -198,6 +199,7 @@ export class AutoSession {
 
     // Guards
     this.handlingAgentEnd = false;
+    this.pendingAgentEndRetry = false;
     this.dispatching = false;
     this.skipDepth = 0;
     this.recentlyEvictedKeys.clear();

--- a/src/resources/extensions/gsd/tests/agent-end-retry.test.ts
+++ b/src/resources/extensions/gsd/tests/agent-end-retry.test.ts
@@ -1,0 +1,107 @@
+/**
+ * agent-end-retry.test.ts — Verifies the deferred agent_end retry mechanism (#1072).
+ *
+ * When handleAgentEnd is already running and a second agent_end event fires
+ * (e.g. a hook/triage/quick-task unit dispatched inside handleAgentEnd completes
+ * before it returns), the reentrancy guard must not silently drop the event.
+ * Instead, it should queue a retry via pendingAgentEndRetry so the completed
+ * unit's agent_end is processed after the current handler finishes.
+ *
+ * Without this, auto-mode can stall permanently in the "summarizing" phase
+ * with no unit running and no watchdog set.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const AUTO_TS_PATH = join(__dirname, "..", "auto.ts");
+const SESSION_TS_PATH = join(__dirname, "..", "auto", "session.ts");
+
+function getAutoTsSource(): string {
+  return readFileSync(AUTO_TS_PATH, "utf-8");
+}
+
+function getSessionTsSource(): string {
+  return readFileSync(SESSION_TS_PATH, "utf-8");
+}
+
+// ── AutoSession must declare pendingAgentEndRetry ────────────────────────────
+
+test("AutoSession declares pendingAgentEndRetry field", () => {
+  const source = getSessionTsSource();
+  assert.ok(
+    source.includes("pendingAgentEndRetry"),
+    "AutoSession (auto/session.ts) must declare pendingAgentEndRetry field for deferred retry",
+  );
+});
+
+test("AutoSession resets pendingAgentEndRetry in reset()", () => {
+  const source = getSessionTsSource();
+  // Find the reset() method — it's declared as "reset(): void {"
+  const resetIdx = source.indexOf("reset(): void");
+  assert.ok(resetIdx > -1, "AutoSession must have a reset() method");
+  const resetBlock = source.slice(resetIdx, resetIdx + 3000);
+  assert.ok(
+    resetBlock.includes("pendingAgentEndRetry"),
+    "reset() must clear pendingAgentEndRetry",
+  );
+});
+
+// ── handleAgentEnd reentrancy guard must queue retry ─────────────────────────
+
+test("handleAgentEnd sets pendingAgentEndRetry when reentrant", () => {
+  const source = getAutoTsSource();
+  // Find the handleAgentEnd function
+  const fnIdx = source.indexOf("export async function handleAgentEnd");
+  assert.ok(fnIdx > -1, "handleAgentEnd must exist in auto.ts");
+
+  // The reentrancy guard section (within ~500 chars of the function start)
+  const guardBlock = source.slice(fnIdx, fnIdx + 800);
+  assert.ok(
+    guardBlock.includes("s.handlingAgentEnd"),
+    "handleAgentEnd must check s.handlingAgentEnd",
+  );
+  assert.ok(
+    guardBlock.includes("pendingAgentEndRetry = true"),
+    "reentrancy guard must set pendingAgentEndRetry = true instead of silently dropping (#1072)",
+  );
+});
+
+// ── finally block must process pendingAgentEndRetry ──────────────────────────
+
+test("handleAgentEnd finally block retries if pendingAgentEndRetry is set", () => {
+  const source = getAutoTsSource();
+  const fnIdx = source.indexOf("export async function handleAgentEnd");
+  assert.ok(fnIdx > -1, "handleAgentEnd must exist");
+
+  // Find the finally block within handleAgentEnd (search for the closing pattern)
+  const fnBlock = source.slice(fnIdx, source.indexOf("\n// ─── ", fnIdx + 100));
+  assert.ok(
+    fnBlock.includes("pendingAgentEndRetry"),
+    "handleAgentEnd finally block must check pendingAgentEndRetry",
+  );
+  assert.ok(
+    fnBlock.includes("setImmediate"),
+    "deferred retry must use setImmediate to avoid stack overflow (#1072)",
+  );
+  assert.ok(
+    fnBlock.includes("handleAgentEnd(ctx, pi)"),
+    "deferred retry must call handleAgentEnd recursively (#1072)",
+  );
+});
+
+// ── Regression: reentrancy guard must NOT silently return ─────────────────────
+
+test("reentrancy guard references issue #1072", () => {
+  const source = getAutoTsSource();
+  const fnIdx = source.indexOf("export async function handleAgentEnd");
+  const guardBlock = source.slice(fnIdx, fnIdx + 800);
+  assert.ok(
+    guardBlock.includes("1072"),
+    "reentrancy guard comment must reference #1072 for traceability",
+  );
+});


### PR DESCRIPTION
## Summary

Fixes #1072 — Slice completion phase hangs after all tasks finish; summary never written.

### Root Cause

When `handleAgentEnd` dispatches a sub-unit via one of its early-dispatch paths (post-unit hooks at line 1583, triage at line 1768, or quick-task at line 1848), the dispatched unit may complete before the outer `handleAgentEnd` call returns. When this happens:

1. The completed unit's `agent_end` event fires
2. `handleAgentEnd` is called again for the new event
3. The reentrancy guard (`if (s.handlingAgentEnd) return`) **silently drops the event**
4. The outer `handleAgentEnd` finishes — but the dropped unit's completion is never processed
5. Auto-mode remains active with no unit running and no watchdog set
6. The process sits at high CPU (idle intervals firing) but never advances

This manifests as a stall in the "summarizing" phase because:
- The last `execute-task` completes normally
- `handleAgentEnd` fires and dispatches `complete-slice` via the normal dispatch path
- If a post-unit hook fires for the execute-task and completes quickly, the hook's `agent_end` is dropped
- The `complete-slice` dispatch in `dispatchNextUnit` never reaches `sendMessage`
- STATE.md shows `phase: summarizing` but no new session is created

### Fix

Instead of silently dropping the reentrant `agent_end`, set a `pendingAgentEndRetry` flag on `AutoSession`. In the `finally` block of `handleAgentEnd`, if the flag is set, schedule a deferred retry via `setImmediate()` so the completed unit's `agent_end` is processed on the next event loop tick.

This is a defense-in-depth fix — it ensures no `agent_end` event is ever permanently lost, regardless of which early-dispatch path triggered it.

### Changes

- **`auto/session.ts`**: Add `pendingAgentEndRetry` field to `AutoSession`, cleared in `reset()`
- **`auto.ts`**: 
  - Reentrancy guard now sets `s.pendingAgentEndRetry = true` instead of silently returning
  - `finally` block checks the flag and schedules deferred retry via `setImmediate`
  - Error handling wraps the deferred retry to prevent unhandled rejections
- **`tests/agent-end-retry.test.ts`**: 5 structural tests verifying:
  - `AutoSession` declares and resets `pendingAgentEndRetry`
  - Reentrancy guard sets the flag (not silent drop)
  - `finally` block processes the flag with `setImmediate`
  - Issue #1072 is referenced for traceability

## Test Plan

- [x] `npm run build` passes
- [x] `npm run test:unit` — 1311/1311 pass (0 failures)
- [x] `npm run test:integration` — 30/31 pass (1 skipped: no API key)
- [x] New `agent-end-retry.test.ts` — 5/5 pass
- [ ] Manual: run `/gsd auto` through a full slice completion cycle — verify `complete-slice` dispatches after all tasks finish without stalling
- [ ] Manual: reproduce on large project (22+ milestones) with `isolation: none` — verify no 15-minute stall