### PR TITLE
fix: match both milestoneId and sliceId in blocker card filter

### DIFF
--- a/src/resources/extensions/gsd/export-html.ts
+++ b/src/resources/extensions/gsd/export-html.ts
@@ -241,7 +241,7 @@ function buildBlockersSection(data: VisualizerData): string {
     </div>`).join('');
 
   const riskCards = highRisk
-    .filter(hr => !blockers.some(b => b.sliceId === hr.slId))
+    .filter(hr => !blockers.some(b => b.milestoneId === hr.msId && b.sliceId === hr.slId))
     .map(hr => `
     <div class="blocker-card">
       <div class="blocker-id">${esc(hr.msId)}/${esc(hr.slId)}</div>


### PR DESCRIPTION
## Summary

- Fix blocker card deduplication in HTML export to match on both `milestoneId` and `sliceId` instead of `sliceId` alone
- Prevents false positive filtering when different milestones have slices with the same ID (e.g. M001/S01 and M002/S01)

Split from #1083 per review feedback — this is the standalone bug fix.

## Test plan

- [x] Build passes
- [x] Typecheck passes
- [ ] Export HTML with multiple milestones sharing slice IDs — verify both appear in blockers section