### PR TITLE
fix: inline preferences path to fix remote questions setup

### DIFF
--- a/src/remote-questions-config.ts
+++ b/src/remote-questions-config.ts
@@ -9,11 +9,17 @@
  */
 
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
-import { dirname } from "node:path";
-import { getGlobalGSDPreferencesPath } from "./resources/extensions/gsd/preferences.js";
+import { dirname, join } from "node:path";
+import { homedir } from "node:os";
+
+// Inlined from preferences.ts to avoid crossing the compiled/uncompiled
+// boundary — this file is compiled by tsc, but preferences.ts is loaded
+// via jiti at runtime. Importing it as .js fails because no .js exists
+// in dist/. See #592, #1110.
+const GLOBAL_PREFERENCES_PATH = join(homedir(), ".gsd", "preferences.md");
 
 export function saveRemoteQuestionsConfig(channel: "slack" | "discord" | "telegram", channelId: string): void {
-  const prefsPath = getGlobalGSDPreferencesPath();
+  const prefsPath = GLOBAL_PREFERENCES_PATH;
   const block = [
     "remote_questions:",
     `  channel: ${channel}`,


### PR DESCRIPTION
## Problem

Fixes #1110

`remote-questions-config.ts` was extracted in #592 to avoid crossing the compiled/uncompiled boundary. However, it still imported `getGlobalGSDPreferencesPath` from `preferences.ts` via a `.js` extension — which fails at runtime because `preferences.ts` is loaded via jiti and never compiled to `.js` in `dist/`.

This causes remote questions setup (Telegram/Slack/Discord) to fail during `gsd config`:

```
▲  Remote questions setup failed: Cannot find module
    '.../dist/resources/extensions/gsd/preferences.js'
    imported from '.../dist/remote-questions-config.js'
```

The Telegram bot token is saved correctly in `auth.json` and messages can be sent, but `saveRemoteQuestionsConfig()` never writes the `remote_questions` block to `~/.gsd/preferences.md`.

## Fix

Inline the `GLOBAL_PREFERENCES_PATH` constant directly in `remote-questions-config.ts`. It's a single `join(homedir(), ".gsd", "preferences.md")` call with no logic, so duplicating it is cleaner than:
- Adding `preferences.ts` to the tsc build (which would pull in many extension-only dependencies)
- Creating a separate compiled module just for this one export

## Testing

1. Fresh install: `npm install -g gsd-pi`
2. Run `gsd config` → select Telegram → enter bot token and chat ID
3. **Before fix:** `▲ Remote questions setup failed: Cannot find module...`
4. **After fix:** Remote questions config saved successfully to `~/.gsd/preferences.md`