### PR TITLE
feat: OSC 8 clickable file path hyperlinks in notifications

### DIFF
--- a/src/resources/extensions/gsd/export.ts
+++ b/src/resources/extensions/gsd/export.ts
@@ -10,7 +10,7 @@ import {
 } from "./metrics.js";
 import type { UnitMetrics } from "./metrics.js";
 import { gsdRoot } from "./paths.js";
-import { formatDuration } from "../shared/mod.js";
+import { formatDuration, fileLink } from "../shared/mod.js";
 
 /**
  * Write an export file directly, without requiring an ExtensionCommandContext.
@@ -241,7 +241,7 @@ export async function handleExport(args: string, ctx: ExtensionCommandContext, b
     };
     const outPath = join(exportDir, `export-${timestamp}.json`);
     writeFileSync(outPath, JSON.stringify(report, null, 2) + "\n", "utf-8");
-    ctx.ui.notify(`Exported to ${outPath}`, "success");
+    ctx.ui.notify(`Exported to ${fileLink(outPath)}`, "success");
   } else {
     const totals = getProjectTotals(units);
     const phases = aggregateByPhase(units);
@@ -285,6 +285,6 @@ export async function handleExport(args: string, ctx: ExtensionCommandContext, b
 
     const outPath = join(exportDir, `export-${timestamp}.md`);
     writeFileSync(outPath, md, "utf-8");
-    ctx.ui.notify(`Exported to ${outPath}`, "success");
+    ctx.ui.notify(`Exported to ${fileLink(outPath)}`, "success");
   }
 }

--- a/src/resources/extensions/shared/format-utils.ts
+++ b/src/resources/extensions/shared/format-utils.ts
@@ -105,6 +105,15 @@ export function formatDateShort(iso: string): string {
   } catch { return iso; }
 }
 
+// ─── Hyperlinks ──────────────────────────────────────────────────────────────
+
+/** Wrap text in an OSC 8 hyperlink for terminals that support clickable links. */
+export function fileLink(filePath: string, displayText?: string): string {
+  const uri = `file://${filePath}`;
+  const label = displayText ?? filePath;
+  return `\x1b]8;;${uri}\x07${label}\x1b]8;;\x07`;
+}
+
 // ─── ANSI Stripping ───────────────────────────────────────────────────────────
 
 /** Strip ANSI escape sequences from a string. */

--- a/src/resources/extensions/shared/mod.ts
+++ b/src/resources/extensions/shared/mod.ts
@@ -19,6 +19,7 @@ export {
 	fitColumns,
 	sparkline,
 	normalizeStringArray,
+	fileLink,
 } from "./format-utils.js";
 
 export { shortcutDesc } from "./terminal.js";


### PR DESCRIPTION
## Problem

File paths in GSD notifications (e.g. export paths) are plain text. Terminals that support OSC 8 hyperlinks (Ghostty, iTerm2, Kitty, WezTerm, etc.) can't make them clickable with Cmd+click.

The same file paths in Claude Code and Pi are clickable because they use OSC 8 escape sequences.

## Fix

Adds a `fileLink()` helper to `shared/format-utils.ts` that wraps a file path in the OSC 8 hyperlink escape sequence:

```
ESC]8;;<file-url>BEL<display-text>ESC]8;;BEL
```

Used in `export.ts` for the "Exported to ..." notifications. The helper is available via the shared barrel export for use in other extensions.

Terminals that don't support OSC 8 will simply ignore the escape sequences and show the plain path, so this is backward compatible.

## Test plan

- [ ] Run `/gsd export` in a terminal that supports OSC 8 (Ghostty, iTerm2, Kitty)
- [ ] Verify the exported file path is clickable with Cmd+click
- [ ] Verify non-OSC 8 terminals show the path without artifacts