### PR TITLE
fix: dispatch guard skips parked milestones — they no longer block later milestone dispatch

### DIFF
--- a/src/resources/extensions/gsd/dispatch-guard.ts
+++ b/src/resources/extensions/gsd/dispatch-guard.ts
@@ -50,6 +50,10 @@ export function getPriorSliceCompletionBlocker(base: string, _mainBranch: string
   const milestoneIds = allIds.slice(0, targetIdx + 1);
 
   for (const mid of milestoneIds) {
+    // Skip parked milestones — they don't block dispatch of later milestones
+    const parkedFile = resolveMilestoneFile(base, mid, "PARKED");
+    if (parkedFile) continue;
+
     // Read from disk (working tree) — always has the latest state
     const roadmapContent = readRoadmapFromDisk(base, mid);
     if (!roadmapContent) continue;

--- a/src/resources/extensions/gsd/tests/dispatch-guard.test.ts
+++ b/src/resources/extensions/gsd/tests/dispatch-guard.test.ts
@@ -71,3 +71,58 @@ test("dispatch guard works without git repo", () => {
     rmSync(repo, { recursive: true, force: true });
   }
 });
+
+test("dispatch guard skips parked milestones — they do not block later milestones", () => {
+  const repo = mkdtempSync(join(tmpdir(), "gsd-dispatch-guard-parked-"));
+  try {
+    // M004 is parked with incomplete slices
+    mkdirSync(join(repo, ".gsd", "milestones", "M004"), { recursive: true });
+    writeFileSync(join(repo, ".gsd", "milestones", "M004", "M004-ROADMAP.md"),
+      "# M004: Parked Milestone\n\n## Slices\n- [ ] **S01: Unfinished** `risk:high` `depends:[]`\n");
+    writeFileSync(join(repo, ".gsd", "milestones", "M004", "M004-PARKED.md"),
+      "---\nparked_at: 2026-03-18T09:00:00.000Z\nreason: \"Parked via /gsd park\"\n---\n\n# M004 — Parked\n");
+
+    // M010 is the target milestone
+    mkdirSync(join(repo, ".gsd", "milestones", "M010"), { recursive: true });
+    writeFileSync(join(repo, ".gsd", "milestones", "M010", "M010-ROADMAP.md"),
+      "# M010: Active Milestone\n\n## Slices\n- [ ] **S01: First** `risk:high` `depends:[]`\n");
+
+    // M004's incomplete S01 should NOT block M010/S01 because M004 is parked
+    assert.equal(
+      getPriorSliceCompletionBlocker(repo, "main", "plan-slice", "M010/S01"),
+      null,
+    );
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("dispatch guard still blocks on non-parked incomplete milestones", () => {
+  const repo = mkdtempSync(join(tmpdir(), "gsd-dispatch-guard-mixed-"));
+  try {
+    // M003 is parked — should be skipped
+    mkdirSync(join(repo, ".gsd", "milestones", "M003"), { recursive: true });
+    writeFileSync(join(repo, ".gsd", "milestones", "M003", "M003-ROADMAP.md"),
+      "# M003: Parked\n\n## Slices\n- [ ] **S01: Unfinished** `risk:high` `depends:[]`\n");
+    writeFileSync(join(repo, ".gsd", "milestones", "M003", "M003-PARKED.md"),
+      "---\nparked_at: 2026-03-18T09:00:00.000Z\nreason: \"Parked\"\n---\n");
+
+    // M005 is NOT parked and has incomplete slices — should block
+    mkdirSync(join(repo, ".gsd", "milestones", "M005"), { recursive: true });
+    writeFileSync(join(repo, ".gsd", "milestones", "M005", "M005-ROADMAP.md"),
+      "# M005: Active Incomplete\n\n## Slices\n- [ ] **S01: Pending** `risk:low` `depends:[]`\n");
+
+    // M010 is the target
+    mkdirSync(join(repo, ".gsd", "milestones", "M010"), { recursive: true });
+    writeFileSync(join(repo, ".gsd", "milestones", "M010", "M010-ROADMAP.md"),
+      "# M010: Target\n\n## Slices\n- [ ] **S01: First** `risk:low` `depends:[]`\n");
+
+    // M005/S01 should block M010/S01 (M003 is parked, so skipped)
+    assert.equal(
+      getPriorSliceCompletionBlocker(repo, "main", "plan-slice", "M010/S01"),
+      "Cannot dispatch plan-slice M010/S01: earlier slice M005/S01 is not complete.",
+    );
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Bug

`/gsd park` creates a `PARKED.md` marker file and the milestone appears as "parked" in state derivation and auto-mode completion checks. However, the **dispatch guard** (`dispatch-guard.ts`) doesn't know about parked milestones — it iterates over all milestones in queue order and blocks dispatch if any earlier milestone has incomplete slices.

**Concrete failure:** User parks M004 (incomplete), then tries to auto-dispatch M010/S01. The guard sees M004's incomplete S01 and returns:
```
Cannot dispatch plan-slice M010/S01: earlier slice M004/S01 is not complete.
```
Auto-mode stops. The parked milestone — which the user explicitly set aside — blocks all later work.

## Root Cause

Three code paths correctly handle parked milestones:
- `state.ts:114` — `resolveMilestoneFile(basePath, mid, "PARKED")` → `continue`
- `auto.ts:825` — `m.status !== "parked"` filter
- `auto.ts:1116` — same filter for completion check

But `dispatch-guard.ts` was missing this check entirely. It reads roadmaps from disk and checks slice completion without ever checking whether the milestone is parked.

## Fix

Add the same `resolveMilestoneFile(base, mid, "PARKED")` check in the guard's milestone loop, consistent with the existing pattern in `state.ts`:

```typescript
for (const mid of milestoneIds) {
  // Skip parked milestones — they don't block dispatch of later milestones
  const parkedFile = resolveMilestoneFile(base, mid, "PARKED");
  if (parkedFile) continue;
  // ... existing roadmap check ...
}
```

4 lines added to `dispatch-guard.ts`, 55 lines added to tests (2 new test cases).

## Tests

| Test | Status |
|------|--------|
| Existing: blocks on prior incomplete milestone | ✅ |
| Existing: blocks on earlier slice in same milestone | ✅ |
| Existing: allows when all earlier slices complete | ✅ |
| Existing: works without git repo | ✅ |
| **New: skips parked milestone with incomplete slices** | ✅ |
| **New: still blocks on non-parked incomplete milestone** | ✅ |

All 6/6 pass via `node --test src/resources/extensions/gsd/tests/dispatch-guard.test.ts`.
