### PR TITLE
fix(model-resolver): prefer provider's recommended variant over saved base model

### DIFF
--- a/packages/pi-coding-agent/src/core/model-resolver.ts
+++ b/packages/pi-coding-agent/src/core/model-resolver.ts
@@ -504,6 +504,20 @@ export async function findInitialModel(options: {
 	if (defaultProvider && defaultModelId) {
 		const found = modelRegistry.find(defaultProvider, defaultModelId);
 		if (found) {
+			// Check if the provider's recommended default is a higher-capability variant
+			// of the saved model (e.g. saved "claude-opus-4-6" vs recommended "claude-opus-4-6[1m]").
+			// If so, prefer the recommended variant to avoid using a smaller context window (#1125).
+			const recommendedId = defaultModelPerProvider[defaultProvider as KnownProvider];
+			if (recommendedId && recommendedId !== defaultModelId && recommendedId.startsWith(defaultModelId)) {
+				const recommended = modelRegistry.find(defaultProvider, recommendedId);
+				if (recommended) {
+					model = recommended;
+					if (defaultThinkingLevel) {
+						thinkingLevel = defaultThinkingLevel;
+					}
+					return { model, thinkingLevel, fallbackMessage: undefined };
+				}
+			}
 			model = found;
 			if (defaultThinkingLevel) {
 				thinkingLevel = defaultThinkingLevel;


### PR DESCRIPTION
## Problem

`settings.json` persists `"defaultModel": "claude-opus-4-6"` (200k) instead of `"claude-opus-4-6[1m]"` (1M). When `findInitialModel()` resolves the saved default at step 3, it finds the 200k model and returns it — even though the provider's recommended default is the 1M variant.

**Impact:**
- Context budget calculated against 200k instead of 1M
- Task count limits computed at max 6 instead of 8
- Continue-here threshold fires at ~140k tokens instead of ~700k
- Prompt truncation budgets more aggressive than necessary

## Fix

In `findInitialModel()` step 3, after finding the saved default model, check if the provider's `defaultModelPerProvider` maps to a higher-capability variant of the same base model (i.e., the recommended ID starts with the saved ID + a suffix like `[1m]`). If so, prefer the recommended variant.

## Changes

- `packages/pi-coding-agent/src/core/model-resolver.ts`: Added variant upgrade check in `findInitialModel()` step 3

Fixes #1125