### PR TITLE
fix(lsp): use where.exe on Windows to resolve command paths in lspmux

### DIFF
--- a/packages/pi-coding-agent/src/core/lsp/lspmux.ts
+++ b/packages/pi-coding-agent/src/core/lsp/lspmux.ts
@@ -49,7 +49,16 @@ const DEFAULT_SUPPORTED_SERVERS = new Set([
 
 function which(command: string): string | null {
 	try {
-		return execSync(`which ${command}`, { encoding: "utf-8" }).trim() || null;
+		// On Windows, prefer `where.exe` over `which` — MSYS/Git Bash's `which`
+		// returns POSIX paths (/c/Users/...) that Node's spawn() can't execute (#1121).
+		const isWindows = process.platform === "win32";
+		const cmd = isWindows ? "where.exe" : "which";
+		const result = isWindows
+			? execSync(`${cmd} ${command}`, { encoding: "utf-8" })
+			: execSync(`which ${command}`, { encoding: "utf-8" });
+		// `where.exe` may return multiple lines — take the first
+		const resolved = result.trim().split(/\r?\n/)[0]?.trim();
+		return resolved || null;
 	} catch {
 		return null;
 	}


### PR DESCRIPTION
## Problem

`lspmux.ts`'s `which()` function uses `which` unconditionally, which returns MSYS2 POSIX paths (`/c/Users/...`) on Windows. Node's `spawn()` can't resolve these paths, causing `ENOENT` errors when launching LSP servers.

`config.ts` already had the correct fix (using `where.exe` on Windows), but `lspmux.ts` had a duplicate `which()` that wasn't updated.

## Fix

Updated `lspmux.ts`'s `which()` to use `where.exe` on Windows, matching the pattern in `config.ts`.

## EBUSY issue (out of scope)

The EBUSY file lock issue described in #1121 (WXT build directory locked by browser) is a WXT-specific problem. The recommended workaround is to use `outDirTemplate` to target a different output path, or close the browser extension before building.

## Changes

- `packages/pi-coding-agent/src/core/lsp/lspmux.ts`: Updated `which()` to use `where.exe` on Windows

Partially fixes #1121