### PR TITLE
fix(auto-worktree): detect worktree structurally when originalBase is null

### DIFF
--- a/src/resources/extensions/gsd/auto-worktree.ts
+++ b/src/resources/extensions/gsd/auto-worktree.ts
@@ -6,8 +6,8 @@
  * manages create, enter, detect, and teardown for auto-mode worktrees.
  */
 
-import { existsSync, cpSync, readFileSync, readdirSync, mkdirSync, realpathSync, unlinkSync } from "node:fs";
-import { isAbsolute, join } from "node:path";
+import { existsSync, cpSync, readFileSync, readdirSync, mkdirSync, realpathSync, unlinkSync, statSync } from "node:fs";
+import { isAbsolute, join, sep } from "node:path";
 import { GSDError, GSD_IO_ERROR, GSD_GIT_ERROR } from "./errors.js";
 import { copyWorktreeDb, reconcileWorktreeDb, isDbAvailable } from "./gsd-db.js";
 import { atomicWriteSync } from "./atomic-write.js";
@@ -341,13 +341,36 @@ export function teardownAutoWorktree(
  * Checks both module state and git branch prefix.
  */
 export function isInAutoWorktree(basePath: string): boolean {
-  if (!originalBase) return false;
   const cwd = process.cwd();
-  const resolvedBase = existsSync(basePath) ? realpathSync(basePath) : basePath;
-  const wtDir = join(resolvedBase, ".gsd", "worktrees");
-  if (!cwd.startsWith(wtDir)) return false;
-  const branch = nativeGetCurrentBranch(cwd);
-  return branch.startsWith("milestone/");
+
+  // Primary check: use originalBase if available (fast path)
+  if (originalBase) {
+    const resolvedBase = existsSync(basePath) ? realpathSync(basePath) : basePath;
+    const wtDir = join(resolvedBase, ".gsd", "worktrees");
+    if (!cwd.startsWith(wtDir)) return false;
+    const branch = nativeGetCurrentBranch(cwd);
+    return branch.startsWith("milestone/");
+  }
+
+  // Fallback: infer worktree status structurally when originalBase is null
+  // (happens after session restart where module-level state is lost, #1120).
+  // Check if cwd is inside a .gsd/worktrees/ directory and has a .git file
+  // (worktree marker) pointing to the main repo.
+  const worktreeMarker = join(cwd, ".git");
+  if (!existsSync(worktreeMarker)) return false;
+  try {
+    const stat = statSync(worktreeMarker);
+    if (stat.isDirectory()) return false; // Main repo has .git dir, not file
+    // Worktrees have a .git file with "gitdir: ..." pointing to the main repo
+    const gitContent = readFileSync(worktreeMarker, "utf-8").trim();
+    if (!gitContent.startsWith("gitdir:")) return false;
+    // Verify cwd path contains .gsd/worktrees/
+    if (!cwd.includes(`${sep}.gsd${sep}worktrees${sep}`) && !cwd.includes("/.gsd/worktrees/")) return false;
+    const branch = nativeGetCurrentBranch(cwd);
+    return branch.startsWith("milestone/");
+  } catch {
+    return false;
+  }
 }
 
 /**


### PR DESCRIPTION
## Problem

`isInAutoWorktree()` returns `false` when the module-level `originalBase` variable is `null` (not persisted across session restarts). This causes the branch-mode merge path to execute instead of the worktree path, which fails with `fatal: 'develop' is already checked out`.

**Root cause chain:**
1. `originalBase` is module-level state, lost on session restart
2. `isInAutoWorktree(basePath)` returns false → wrong merge path
3. Branch-mode attempts `git checkout develop` while develop is already checked out by the main worktree

## Fix

Added a structural fallback to `isInAutoWorktree()` that activates when `originalBase` is null:
1. Checks if cwd has a `.git` *file* (not directory) — worktree marker
2. Verifies the `.git` file contains `gitdir:` pointer
3. Confirms cwd path contains `.gsd/worktrees/`
4. Checks the current branch starts with `milestone/`

This approach is robust because it relies on git's own worktree structure rather than ephemeral module state.

## Changes

- `auto-worktree.ts`: Added structural worktree detection fallback in `isInAutoWorktree()`

Fixes #1120