### PR TITLE
fix(auto-dashboard): show trigger task label for hook units

### DIFF
--- a/src/resources/extensions/gsd/auto-dashboard.ts
+++ b/src/resources/extensions/gsd/auto-dashboard.ts
@@ -366,7 +366,10 @@ export function updateProgressWidget(
 
         lines.push("");
 
-        const target = task ? `${task.id}: ${task.title}` : unitId;
+        const isHook = unitType.startsWith("hook/");
+        const target = isHook
+          ? (unitId.split("/").pop() ?? unitId)
+          : (task ? `${task.id}: ${task.title}` : unitId);
         const actionLeft = `${pad}${theme.fg("accent", "▸")} ${theme.fg("accent", verb)}  ${theme.fg("text", target)}`;
         const tierTag = tierBadge ? theme.fg("dim", `[${tierBadge}] `) : "";
         const phaseBadge = `${tierTag}${theme.fg("dim", phaseLabel)}`;
@@ -386,7 +389,10 @@ export function updateProgressWidget(
             let meta = theme.fg("dim", `${done}/${total} slices`);
 
             if (activeSliceTasks && activeSliceTasks.total > 0) {
-              const taskNum = Math.min(activeSliceTasks.done + 1, activeSliceTasks.total);
+              // For hooks, show the trigger task number (done), not the next task (done + 1)
+              const taskNum = isHook
+                ? Math.max(activeSliceTasks.done, 1)
+                : Math.min(activeSliceTasks.done + 1, activeSliceTasks.total);
               meta += theme.fg("dim", `  ·  task ${taskNum}/${activeSliceTasks.total}`);
             }
 


### PR DESCRIPTION
## Problem

When a post-unit hook fires after a task completes, the progress widget displays the **next undone task** label instead of the **trigger task** the hook is reviewing.

Example: T03 completes → code-review hook fires → widget shows `T04: Drive the live targeted rollout...` instead of `T03`.

## Fix

1. When `unitType.startsWith('hook/')`, derive the target label from `unitId` (the trigger task) instead of `state.activeTask` (the next undone task)
2. Fix the task counter to show `done` (trigger task position) instead of `done + 1` during hooks

## Changes

- `auto-dashboard.ts`: Added `isHook` check for target label and task counter

Fixes #1119