### PR TITLE
fix(verification-gate): sanitize preference commands with isLikelyCommand

### DIFF
--- a/src/resources/extensions/gsd/verification-gate.ts
+++ b/src/resources/extensions/gsd/verification-gate.ts
@@ -45,11 +45,12 @@ const PACKAGE_SCRIPT_KEYS = ["typecheck", "lint", "test"] as const;
  *   4. None found
  */
 export function discoverCommands(options: DiscoverCommandsOptions): DiscoveredCommands {
-  // 1. Preference commands
+  // 1. Preference commands (still sanitize — may contain prose from misconfiguration)
   if (options.preferenceCommands && options.preferenceCommands.length > 0) {
     const filtered = options.preferenceCommands
       .map(c => c.trim())
-      .filter(Boolean);
+      .filter(Boolean)
+      .filter(c => isLikelyCommand(c));
     if (filtered.length > 0) {
       return { commands: filtered, source: "preference" };
     }


### PR DESCRIPTION
## Problem

The verification gate's `discoverCommands()` accepted preference commands without sanitization. Prose-like strings (e.g. `All 10 slice-level verification checks pass (build, lint, grep checks)`) were passed directly to `spawnSync` with `shell: true`, causing:

```
/bin/sh: 1: Syntax error: "(" unexpected
```

This crashed the auto-mode process during verification checks.

## Fix

Filter preference commands through `isLikelyCommand()` (same filter already used for task-plan commands) to reject prose descriptions before they reach `spawnSync`.

## Changes

- `verification-gate.ts`: Added `.filter(c => isLikelyCommand(c))` to preference command discovery

Fixes #1103