### PR TITLE
fix(google-search): add 30s timeout to Gemini API call to prevent hangs

### DIFF
--- a/src/resources/extensions/google-search/index.ts
+++ b/src/resources/extensions/google-search/index.ts
@@ -265,14 +265,27 @@ export default function (pi: ExtensionAPI) {
 			try {
 				if (process.env.GEMINI_API_KEY) {
 					const ai = await getClient();
-					const response = await ai.models.generateContent({
-						model: process.env.GEMINI_SEARCH_MODEL || "gemini-2.5-flash",
-						contents: params.query,
-						config: {
-							tools: [{ googleSearch: {} }],
-							abortSignal: signal,
-						},
-					});
+
+					// Add a 30-second timeout to prevent hanging (#1100)
+					const timeoutController = new AbortController();
+					const timeoutId = setTimeout(() => timeoutController.abort(), 30_000);
+					const combinedSignal = signal
+						? AbortSignal.any([signal, timeoutController.signal])
+						: timeoutController.signal;
+
+					let response;
+					try {
+						response = await ai.models.generateContent({
+							model: process.env.GEMINI_SEARCH_MODEL || "gemini-2.5-flash",
+							contents: params.query,
+							config: {
+								tools: [{ googleSearch: {} }],
+								abortSignal: combinedSignal,
+							},
+						});
+					} finally {
+						clearTimeout(timeoutId);
+					}
 
 					// Extract answer text
 					const answer = response.text ?? "";


### PR DESCRIPTION
## Problem

The `google_search` tool hung indefinitely during a session. The Gemini API call only used the caller's abort signal, which may not fire if the hang is at the network level.

## Fix

Added a 30-second `AbortController` timeout to the `generateContent()` call, combined with the caller's signal via `AbortSignal.any()`. This ensures the tool always returns or errors within 30 seconds, matching the timeout pattern used by the search-the-web extension's HTTP layer.

## Changes

- `google-search/index.ts`: Added timeout wrapper around Gemini API call

Fixes #1100