### PR TITLE
fix(headless-query): use jiti to load extension .ts modules

### DIFF
--- a/src/headless-query.ts
+++ b/src/headless-query.ts
@@ -8,13 +8,32 @@
  *   state — deriveState() output (phase, milestones, progress, blockers)
  *   next  — dry-run dispatch preview (what auto-mode would do next)
  *   cost  — aggregated parallel worker costs
+ *
+ * Note: Extension modules are .ts files loaded via jiti (not compiled to .js).
+ * We use createJiti() here because this module is imported directly from cli.ts,
+ * bypassing the extension loader's jiti setup (#1137).
  */
 
-import { deriveState } from './resources/extensions/gsd/state.js'
-import { resolveDispatch } from './resources/extensions/gsd/auto-dispatch.js'
-import { readAllSessionStatuses } from './resources/extensions/gsd/session-status-io.js'
-import { loadEffectiveGSDPreferences } from './resources/extensions/gsd/preferences.js'
+import { createJiti } from '@mariozechner/jiti'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
 import type { GSDState } from './resources/extensions/gsd/types.js'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const jiti = createJiti(fileURLToPath(import.meta.url), { interopDefault: true, debug: false })
+
+async function loadExtensionModules() {
+  const stateModule = await jiti.import(join(__dirname, 'resources/extensions/gsd/state.ts'), {}) as any
+  const dispatchModule = await jiti.import(join(__dirname, 'resources/extensions/gsd/auto-dispatch.ts'), {}) as any
+  const sessionModule = await jiti.import(join(__dirname, 'resources/extensions/gsd/session-status-io.ts'), {}) as any
+  const prefsModule = await jiti.import(join(__dirname, 'resources/extensions/gsd/preferences.ts'), {}) as any
+  return {
+    deriveState: stateModule.deriveState as (basePath: string) => Promise<GSDState>,
+    resolveDispatch: dispatchModule.resolveDispatch as (opts: any) => Promise<any>,
+    readAllSessionStatuses: sessionModule.readAllSessionStatuses as (basePath: string) => any[],
+    loadEffectiveGSDPreferences: prefsModule.loadEffectiveGSDPreferences as () => any,
+  }
+}
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -46,6 +65,7 @@ export interface QueryResult {
 // ─── Implementation ─────────────────────────────────────────────────────────
 
 export async function handleQuery(basePath: string): Promise<QueryResult> {
+  const { deriveState, resolveDispatch, readAllSessionStatuses, loadEffectiveGSDPreferences } = await loadExtensionModules()
   const state = await deriveState(basePath)
 
   // Derive next dispatch action


### PR DESCRIPTION
## Problem

`gsd headless query` crashes with `ERR_MODULE_NOT_FOUND` because `headless-query.ts` imports 4 extension modules with `.js` extensions, but those files only exist as `.ts` (never compiled to `.js`).

Other code paths work because they go through the extension loader's jiti setup. The `query` command bypasses this as a performance optimization (no LLM session needed), but loses jiti transpilation.

## Fix

Use `createJiti()` from `@mariozechner/jiti` to dynamically import the 4 extension modules:
- `state.ts` → `deriveState()`
- `auto-dispatch.ts` → `resolveDispatch()`
- `session-status-io.ts` → `readAllSessionStatuses()`
- `preferences.ts` → `loadEffectiveGSDPreferences()`

Modules are loaded lazily inside `handleQuery()` so the jiti overhead (~100ms) only applies when the query command is actually used.

## Changes

- `src/headless-query.ts`: Replaced direct ESM imports with jiti-based dynamic imports

Fixes #1137