### PR TITLE
fix(ci): fix dev-publish version stamp and platform sync

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -43,11 +43,12 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Stamp dev version
+      - name: Stamp dev version and sync platform packages
         id: stamp
         run: |
           npm run pipeline:version-stamp
-          echo "version=$(node -p 'require(\"./package.json\").version')" >> "$GITHUB_OUTPUT"
+          npm run sync-platform-versions
+          echo "version=$(node -e 'process.stdout.write(require("./package.json").version)')" >> "$GITHUB_OUTPUT"
 
       - name: Publish @dev
         run: npm publish --tag dev


### PR DESCRIPTION
## Problem

The **Dev Publish** job in pipeline.yml fails with two distinct errors ([run #23233857718](https://github.com/gsd-build/gsd-2/actions/runs/23233857718)):

### 1. `node -p` SyntaxError on Node 22

```
require("./package.json").version
        ^
Expected unicode escape
SyntaxError: Invalid or unexpected token
```

The `echo "version=$(node -p 'require(\"./package.json\").version')" ` expression uses escaped double-quotes that Node 22's eval mode interprets as a unicode escape.

### 2. Platform packages dirty after version stamp

`version-stamp.mjs` updates root `package.json` to `2.28.0-dev.64cf722`, but platform `package.json` files still have `2.28.0`. When `npm publish` triggers `prepublishOnly`, `sync-platform-versions` diffs those 5 files and `git diff --exit-code` fails:

```
ERROR: version sync changed files — commit them before publishing
```

## Fix

1. **Replaced `node -p`** with `node -e 'process.stdout.write(require("./package.json").version)'` — avoids the escaped-quote parsing issue entirely.

2. **Added `npm run sync-platform-versions`** to the stamp step, immediately after the version stamp. By the time `npm publish` fires `prepublishOnly`, all platform packages already match the dev version and `git diff --exit-code` passes.