### PR TITLE
feat(browser-tools): configurable screenshot resolution, format, and quality

### DIFF
--- a/src/resources/extensions/browser-tools/capture.ts
+++ b/src/resources/extensions/browser-tools/capture.ts
@@ -13,8 +13,40 @@ import { formatCompactStateSummary } from "./utils.js";
 // Anthropic vision: 1568px is the recommended optimal width. Height is capped
 // generously at 8000px so tall full-page screenshots remain readable rather
 // than being squished into a square constraint.
-const MAX_SCREENSHOT_WIDTH = 1568;
-const MAX_SCREENSHOT_HEIGHT = 8000;
+//
+// Override via environment variables:
+//   SCREENSHOT_MAX_WIDTH=0   → uncap width (use raw resolution)
+//   SCREENSHOT_MAX_HEIGHT=0  → uncap height
+//   SCREENSHOT_FORMAT=png    → lossless PNG for all viewport/fullpage screenshots
+//   SCREENSHOT_QUALITY=100   → max JPEG quality (1-100, default 80)
+const MAX_SCREENSHOT_WIDTH = parseScreenshotDimension(process.env.SCREENSHOT_MAX_WIDTH, 1568);
+const MAX_SCREENSHOT_HEIGHT = parseScreenshotDimension(process.env.SCREENSHOT_MAX_HEIGHT, 8000);
+
+/** Parse a dimension env var: positive int = that value, 0 = Infinity (uncapped), absent/invalid = default. */
+function parseScreenshotDimension(value: string | undefined, fallback: number): number {
+	if (value === undefined || value === "") return fallback;
+	const n = parseInt(value, 10);
+	if (isNaN(n) || n < 0) return fallback;
+	if (n === 0) return Infinity;
+	return n;
+}
+
+/** Return the user-configured screenshot format override, or null for default behavior. */
+export function getScreenshotFormatOverride(): "png" | "jpeg" | null {
+	const fmt = process.env.SCREENSHOT_FORMAT?.toLowerCase();
+	if (fmt === "png") return "png";
+	if (fmt === "jpeg" || fmt === "jpg") return "jpeg";
+	return null;
+}
+
+/** Return the user-configured default JPEG quality, or the provided fallback. */
+export function getScreenshotQualityDefault(fallback: number): number {
+	const q = process.env.SCREENSHOT_QUALITY;
+	if (q === undefined || q === "") return fallback;
+	const n = parseInt(q, 10);
+	if (isNaN(n) || n < 1 || n > 100) return fallback;
+	return n;
+}
 
 // ---------------------------------------------------------------------------
 // Compact page state capture

--- a/src/resources/extensions/browser-tools/tests/browser-tools-integration.test.mjs
+++ b/src/resources/extensions/browser-tools/tests/browser-tools-integration.test.mjs
@@ -92,7 +92,7 @@ let page;
 
 before(async () => {
   browser = await chromium.launch({ headless: true });
-  const context = await browser.newContext({ viewport: { width: 1280, height: 720 } });
+  const context = await browser.newContext({ viewport: { width: 1280, height: 800 }, deviceScaleFactor: 2 });
   page = await context.newPage();
 });
 

--- a/src/resources/extensions/browser-tools/tests/browser-tools-unit.test.cjs
+++ b/src/resources/extensions/browser-tools/tests/browser-tools-unit.test.cjs
@@ -602,14 +602,14 @@ describe("constrainScreenshot", () => {
 	});
 
 	it("handles an image where only height exceeds the limit", async () => {
-		const buf = await createTestJpeg(1000, 2000);
+		const buf = await createTestJpeg(1000, 9000);
 		const result = await constrainScreenshot(null, buf, "image/jpeg", 80);
 		const sharp = require("sharp");
 		const meta = await sharp(result).metadata();
 		assert.ok(meta.width <= 1568);
-		assert.ok(meta.height <= 1568);
+		assert.ok(meta.height <= 8000);
 		// Height was the constraining dimension
-		assert.equal(meta.height, 1568);
+		assert.equal(meta.height, 8000);
 	});
 });
 

--- a/src/resources/extensions/browser-tools/tools/screenshot.ts
+++ b/src/resources/extensions/browser-tools/tools/screenshot.ts
@@ -1,6 +1,7 @@
 import type { ExtensionAPI } from "@gsd/pi-coding-agent";
 import { Type } from "@sinclair/typebox";
 import type { ToolDeps } from "../state.js";
+import { getScreenshotFormatOverride, getScreenshotQualityDefault } from "../capture.js";
 
 export function registerScreenshotTools(pi: ExtensionAPI, deps: ToolDeps): void {
 	pi.registerTool({
@@ -32,20 +33,37 @@ export function registerScreenshotTools(pi: ExtensionAPI, deps: ToolDeps): void 
 
 				let screenshotBuffer: Buffer;
 				let mimeType: string;
-				const quality = params.quality ?? 80;
+				const formatOverride = getScreenshotFormatOverride();
+				const quality = params.quality ?? getScreenshotQualityDefault(80);
 
 				if (params.selector) {
+					const fmt = formatOverride ?? "png";
 					const locator = p.locator(params.selector).first();
-					screenshotBuffer = await locator.screenshot({ type: "png", scale: "css" });
-					mimeType = "image/png";
+					if (fmt === "jpeg") {
+						screenshotBuffer = await locator.screenshot({ type: "jpeg", quality, scale: "css" });
+						mimeType = "image/jpeg";
+					} else {
+						screenshotBuffer = await locator.screenshot({ type: "png", scale: "css" });
+						mimeType = "image/png";
+					}
 				} else {
-					screenshotBuffer = await p.screenshot({
-						fullPage: params.fullPage ?? false,
-						type: "jpeg",
-						quality,
-						scale: "css",
-					});
-					mimeType = "image/jpeg";
+					const fmt = formatOverride ?? "jpeg";
+					if (fmt === "png") {
+						screenshotBuffer = await p.screenshot({
+							fullPage: params.fullPage ?? false,
+							type: "png",
+							scale: "css",
+						});
+						mimeType = "image/png";
+					} else {
+						screenshotBuffer = await p.screenshot({
+							fullPage: params.fullPage ?? false,
+							type: "jpeg",
+							quality,
+							scale: "css",
+						});
+						mimeType = "image/jpeg";
+					}
 				}
 
 				screenshotBuffer = await deps.constrainScreenshot(p, screenshotBuffer, mimeType, quality);


### PR DESCRIPTION
## Summary

- **Configurable screenshot capture** via environment variables so users can opt into full-resolution output for human review while keeping Anthropic vision-optimized defaults:
  - `SCREENSHOT_MAX_WIDTH` — default `1568` (Anthropic vision optimal), set to `0` to uncap
  - `SCREENSHOT_MAX_HEIGHT` — default `8000`, set to `0` to uncap  
  - `SCREENSHOT_FORMAT` — default `jpeg` for viewport/fullpage, `png` for element crops. Override to `png` for lossless everywhere
  - `SCREENSHOT_QUALITY` — default `80`, range 1-100 for JPEG quality
- **Fixed integration test viewport/scale mismatch** — test context was `1280×720, deviceScaleFactor: 1` but production uses `1280×800, deviceScaleFactor: 2`. Tests now match production settings.
- **Fixed pre-existing unit test bug** — `constrainScreenshot` height-limit test asserted `height <= 1568` but `MAX_SCREENSHOT_HEIGHT` has always been `8000`. Updated test image from 2000px to 9000px tall and corrected assertions to match the actual cap.

## Changes

| File | Change |
|------|--------|
| `capture.ts` | Added `parseScreenshotDimension()`, `getScreenshotFormatOverride()`, `getScreenshotQualityDefault()` helpers; dimension constants now read from env vars |
| `tools/screenshot.ts` | Screenshot tool respects format/quality env var overrides for both viewport and element screenshots |
| `tests/browser-tools-integration.test.mjs` | Fixed viewport to `1280×800` and added `deviceScaleFactor: 2` to match production |
| `tests/browser-tools-unit.test.cjs` | Fixed height-limit test: image 1000×9000, assertions use 8000 cap |

## Usage

Default behavior is unchanged. For full-resolution screenshots:

```bash
SCREENSHOT_MAX_WIDTH=0 SCREENSHOT_MAX_HEIGHT=0 SCREENSHOT_FORMAT=png SCREENSHOT_QUALITY=100
```

## Test plan

- [x] `npm run build` — clean compilation
- [x] `npm run test:browser-tools` — all 110 tests pass (including the previously-failing height test)
- [ ] Verify default behavior unchanged (no env vars set → same output as before)
- [ ] Verify `SCREENSHOT_FORMAT=png` produces PNG for viewport screenshots
- [ ] Verify `SCREENSHOT_MAX_WIDTH=0` skips dimension capping