### PR TITLE
fix: /gsd quick respects git isolation: none preference

### DIFF
--- a/src/resources/extensions/gsd/quick.ts
+++ b/src/resources/extensions/gsd/quick.ts
@@ -102,27 +102,30 @@ export async function handleQuick(
   const taskDirRel = `.gsd/quick/${taskNum}-${slug}`;
   const date = new Date().toISOString().split("T")[0];
 
-  // Create git branch for the quick task
+  // Create git branch for the quick task (unless isolation: none)
   const gitPrefs = loadEffectiveGSDPreferences()?.preferences?.git ?? {};
   const git = new GitServiceImpl(basePath, gitPrefs);
   const branchName = `gsd/quick/${taskNum}-${slug}`;
+  const skipBranch = gitPrefs.isolation === "none";
 
   let branchCreated = false;
-  try {
-    const current = git.getCurrentBranch();
-    if (current !== branchName) {
-      // Auto-commit any dirty state before switching
-      try {
-        git.autoCommit("quick-task", `Q${taskNum}`, []);
-      } catch { /* nothing to commit — fine */ }
+  if (!skipBranch) {
+    try {
+      const current = git.getCurrentBranch();
+      if (current !== branchName) {
+        // Auto-commit any dirty state before switching
+        try {
+          git.autoCommit("quick-task", `Q${taskNum}`, []);
+        } catch { /* nothing to commit — fine */ }
 
-      runGit(basePath, ["checkout", "-b", branchName]);
-      branchCreated = true;
+        runGit(basePath, ["checkout", "-b", branchName]);
+        branchCreated = true;
+      }
+    } catch (err) {
+      // Branch creation failed — continue on current branch
+      const message = err instanceof Error ? err.message : String(err);
+      ctx.ui.notify(`Could not create branch ${branchName}: ${message}. Working on current branch.`, "warning");
     }
-  } catch (err) {
-    // Branch creation failed — continue on current branch
-    const message = err instanceof Error ? err.message : String(err);
-    ctx.ui.notify(`Could not create branch ${branchName}: ${message}. Working on current branch.`, "warning");
   }
 
   const actualBranch = branchCreated ? branchName : git.getCurrentBranch();


### PR DESCRIPTION
## Problem

`/gsd quick` always creates a new branch (`gsd/quick/<n>-<slug>`) regardless of the `git.isolation` preference. When `isolation: none` is set, users expect all work to stay on the current branch with no branch creation.

## Fix

Added a check for `gitPrefs.isolation === "none"` before the branch creation block in `quick.ts`. When isolation is `none`, the entire branch creation logic (including the auto-commit and checkout) is skipped, and the task runs on the current branch.

The `branch` and `worktree` isolation modes continue creating branches as before.

## Verification

- TypeScript compiles cleanly (`tsc --noEmit`)
- Logic mirrors the pattern used by `auto.ts` (`shouldUseWorktreeIsolation()`)

Fixes #1153