### PR TITLE
fix: exclude completion-transition errors from health escalation at task level

### DIFF
--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -35,6 +35,7 @@ import {
 import { writeUnitRuntimeRecord, clearUnitRuntimeRecord } from "./unit-runtime.js";
 import { resolveAutoSupervisorConfig, loadEffectiveGSDPreferences } from "./preferences.js";
 import { runGSDDoctor, rebuildState, summarizeDoctorIssues } from "./doctor.js";
+import { COMPLETION_TRANSITION_CODES } from "./doctor-types.js";
 import { recordHealthSnapshot, checkHealEscalation } from "./doctor-proactive.js";
 import { syncStateToProjectRoot } from "./auto-worktree-sync.js";
 import { resetRewriteCircuitBreaker } from "./auto-dispatch.js";
@@ -154,13 +155,17 @@ export async function postUnitPreVerification(pctx: PostUnitContext): Promise<"d
         ctx.ui.notify(`Post-hook: applied ${report.fixesApplied.length} fix(es).`, "info");
       }
 
-      // Proactive health tracking
-      const summary = summarizeDoctorIssues(report.issues);
+      // Proactive health tracking — exclude completion-transition codes at task level
+      // since they are expected after the last task and resolved by complete-slice
+      const issuesForHealth = effectiveFixLevel === "task"
+        ? report.issues.filter(i => !COMPLETION_TRANSITION_CODES.has(i.code))
+        : report.issues;
+      const summary = summarizeDoctorIssues(issuesForHealth);
       recordHealthSnapshot(summary.errors, summary.warnings, report.fixesApplied.length);
 
       // Check if we should escalate to LLM-assisted heal
       if (summary.errors > 0) {
-        const unresolvedErrors = report.issues
+        const unresolvedErrors = issuesForHealth
           .filter(i => i.severity === "error" && !i.fixable)
           .map(i => ({ code: i.code, message: i.message, unitId: i.unitId }));
         const escalation = checkHealEscalation(summary.errors, unresolvedErrors);

--- a/src/resources/extensions/gsd/doctor-types.ts
+++ b/src/resources/extensions/gsd/doctor-types.ts
@@ -32,6 +32,19 @@ export type DoctorIssueCode =
   | "gitignore_missing_patterns"
   | "unresolvable_dependency";
 
+/**
+ * Issue codes that represent expected completion-transition states.
+ * These are detected by the doctor but should NOT be auto-fixed at task level —
+ * they are resolved by the complete-slice/complete-milestone dispatch units.
+ * Consumers (e.g. auto-post-unit health tracking) should exclude these from
+ * error counts when running at task fixLevel to avoid false escalation.
+ */
+export const COMPLETION_TRANSITION_CODES = new Set<DoctorIssueCode>([
+  "all_tasks_done_missing_slice_summary",
+  "all_tasks_done_missing_slice_uat",
+  "all_tasks_done_roadmap_not_checked",
+]);
+
 export interface DoctorIssue {
   severity: DoctorSeverity;
   code: DoctorIssueCode;

--- a/src/resources/extensions/gsd/doctor.ts
+++ b/src/resources/extensions/gsd/doctor.ts
@@ -8,6 +8,7 @@ import { invalidateAllCaches } from "./cache.js";
 import { loadEffectiveGSDPreferences, type GSDPreferences } from "./preferences.js";
 
 import type { DoctorIssue, DoctorIssueCode } from "./doctor-types.js";
+import { COMPLETION_TRANSITION_CODES } from "./doctor-types.js";
 import { checkGitHealth, checkRuntimeHealth } from "./doctor-checks.js";
 
 // ── Re-exports ─────────────────────────────────────────────────────────────
@@ -356,16 +357,11 @@ export async function runGSDDoctor(basePath: string, options?: { fix?: boolean; 
   // dispatch lifecycle (complete-slice, complete-milestone units), not to
   // mechanical post-hook bookkeeping. When fixLevel is "task", these are
   // detected and reported but never auto-fixed.
-  const completionTransitionCodes = new Set<DoctorIssueCode>([
-    "all_tasks_done_missing_slice_summary",
-    "all_tasks_done_missing_slice_uat",
-    "all_tasks_done_roadmap_not_checked",
-  ]);
 
   /** Whether a given issue code should be auto-fixed at the current fixLevel. */
   const shouldFix = (code: DoctorIssueCode): boolean => {
     if (!fix) return false;
-    if (fixLevel === "task" && completionTransitionCodes.has(code)) return false;
+    if (fixLevel === "task" && COMPLETION_TRANSITION_CODES.has(code)) return false;
     return true;
   };
 


### PR DESCRIPTION
## Problem

After the last `execute-task` in a slice completes, the post-hook doctor runs with `fixLevel: "task"` and correctly detects `all_tasks_done_missing_slice_summary`, `all_tasks_done_missing_slice_uat`, and `all_tasks_done_roadmap_not_checked`. These are intentionally not auto-fixed at task level — they're completion-transition codes reserved for `complete-slice`.

However, the health escalation logic in `auto-post-unit.ts` was counting these expected issues as real errors:
- `recordHealthSnapshot()` incremented the error count, inflating `consecutiveErrorUnits`
- `checkHealEscalation()` could trigger a misleading "Dispatching LLM-assisted heal" warning
- Over multiple slices, accumulated phantom errors could trigger the escalation threshold

Reported with full forensic context in #1155.

## Fix

1. **Exported `COMPLETION_TRANSITION_CODES`** from `doctor-types.ts` — previously defined locally inside `runGSDDoctor()`. This makes the set available to consumers that need to distinguish expected transition states from real errors.

2. **`doctor.ts`** now imports and uses the shared constant (no behavioral change).

3. **`auto-post-unit.ts`** filters completion-transition codes from the issue list before computing health metrics when `fixLevel` is `"task"`:
   - `summarizeDoctorIssues()` receives the filtered list → accurate error count
   - `recordHealthSnapshot()` receives accurate counts → no phantom error accumulation
   - `checkHealEscalation()` receives only real unresolved errors

When `fixLevel` is `"all"` (complete-slice, run-uat), all issues are counted as before.

## Verification

- `tsc --noEmit` passes
- All 5 `doctor-fixlevel.test.ts` tests pass (doctor still detects+reports but does not fix at task level)
- All 9 `doctor.test.ts` tests pass (63 assertions)

Fixes #1155