### PR TITLE
fix: exclude completion-transition errors from health escalation at task level

### DIFF
--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -34,7 +34,7 @@ import {
 } from "./auto-recovery.js";
 import { writeUnitRuntimeRecord, clearUnitRuntimeRecord } from "./unit-runtime.js";
 import { resolveAutoSupervisorConfig, loadEffectiveGSDPreferences } from "./preferences.js";
-import { runGSDDoctor, rebuildState, summarizeDoctorIssues } from "./doctor.js";
+import { runGSDDoctor, rebuildState, summarizeDoctorIssues, COMPLETION_TRANSITION_CODES } from "./doctor.js";
 import { recordHealthSnapshot, checkHealEscalation } from "./doctor-proactive.js";
 import { syncStateToProjectRoot } from "./auto-worktree-sync.js";
 import { resetRewriteCircuitBreaker } from "./auto-dispatch.js";
@@ -154,13 +154,21 @@ export async function postUnitPreVerification(pctx: PostUnitContext): Promise<"d
         ctx.ui.notify(`Post-hook: applied ${report.fixesApplied.length} fix(es).`, "info");
       }
 
-      // Proactive health tracking
-      const summary = summarizeDoctorIssues(report.issues);
+      // Proactive health tracking — exclude completion-transition codes from
+      // error counts when running at task fixLevel. These codes are expected
+      // after the last task in a slice and will be resolved by the subsequent
+      // complete-slice dispatch. Counting them as errors causes false health
+      // escalations and misleading verification retries (#1155).
+      const isTaskLevel = effectiveFixLevel === "task";
+      const filteredIssues = isTaskLevel
+        ? report.issues.filter(i => !COMPLETION_TRANSITION_CODES.has(i.code))
+        : report.issues;
+      const summary = summarizeDoctorIssues(filteredIssues);
       recordHealthSnapshot(summary.errors, summary.warnings, report.fixesApplied.length);
 
       // Check if we should escalate to LLM-assisted heal
       if (summary.errors > 0) {
-        const unresolvedErrors = report.issues
+        const unresolvedErrors = filteredIssues
           .filter(i => i.severity === "error" && !i.fixable)
           .map(i => ({ code: i.code, message: i.message, unitId: i.unitId }));
         const escalation = checkHealEscalation(summary.errors, unresolvedErrors);

--- a/src/resources/extensions/gsd/doctor.ts
+++ b/src/resources/extensions/gsd/doctor.ts
@@ -17,6 +17,22 @@ export type { DoctorSeverity, DoctorIssueCode, DoctorIssue, DoctorReport, Doctor
 export { summarizeDoctorIssues, filterDoctorIssues, formatDoctorReport, formatDoctorIssuesForPrompt } from "./doctor-format.js";
 
 /**
+ * Issue codes that represent completion state transitions — creating summary
+ * stubs, marking slices/milestones done in the roadmap. These belong to the
+ * dispatch lifecycle (complete-slice, complete-milestone units), not to
+ * mechanical post-hook bookkeeping. When fixLevel is "task", these are
+ * detected and reported but never auto-fixed.
+ *
+ * Exported so that callers (e.g. auto-post-unit.ts health escalation) can
+ * exclude these from error counts when running at task fixLevel.
+ */
+export const COMPLETION_TRANSITION_CODES: ReadonlySet<DoctorIssueCode> = new Set([
+  "all_tasks_done_missing_slice_summary",
+  "all_tasks_done_missing_slice_uat",
+  "all_tasks_done_roadmap_not_checked",
+]);
+
+/**
  * Characters that are used as delimiters in GSD state management documents
  * and should not appear in milestone or slice titles.
  *
@@ -351,21 +367,10 @@ export async function runGSDDoctor(basePath: string, options?: { fix?: boolean; 
   const fix = options?.fix === true;
   const fixLevel = options?.fixLevel ?? "all";
 
-  // Issue codes that represent completion state transitions — creating summary
-  // stubs, marking slices/milestones done in the roadmap. These belong to the
-  // dispatch lifecycle (complete-slice, complete-milestone units), not to
-  // mechanical post-hook bookkeeping. When fixLevel is "task", these are
-  // detected and reported but never auto-fixed.
-  const completionTransitionCodes = new Set<DoctorIssueCode>([
-    "all_tasks_done_missing_slice_summary",
-    "all_tasks_done_missing_slice_uat",
-    "all_tasks_done_roadmap_not_checked",
-  ]);
-
   /** Whether a given issue code should be auto-fixed at the current fixLevel. */
   const shouldFix = (code: DoctorIssueCode): boolean => {
     if (!fix) return false;
-    if (fixLevel === "task" && completionTransitionCodes.has(code)) return false;
+    if (fixLevel === "task" && COMPLETION_TRANSITION_CODES.has(code)) return false;
     return true;
   };
 

--- a/src/resources/extensions/gsd/tests/doctor-proactive.test.ts
+++ b/src/resources/extensions/gsd/tests/doctor-proactive.test.ts
@@ -265,6 +265,52 @@ async function main(): Promise<void> {
       assertTrue(result.issues.length === 0, "no blocking issues after heal");
     }
 
+    // ─── Completion Transition Code Filtering (#1155) ──────────────────
+    console.log("\n=== completion transition codes: excluded from health snapshot at task level ===");
+    {
+      resetProactiveHealing();
+      // Import the constant and summarize helper
+      const { COMPLETION_TRANSITION_CODES, summarizeDoctorIssues } = await import("../doctor.ts");
+
+      // Simulate doctor report with only completion transition errors
+      const fakeIssues = [
+        { severity: "error" as const, code: "all_tasks_done_missing_slice_summary" as const, scope: "slice", unitId: "M001/S01", message: "missing summary", fixable: true },
+        { severity: "error" as const, code: "all_tasks_done_roadmap_not_checked" as const, scope: "slice", unitId: "M001/S01", message: "roadmap not checked", fixable: true },
+      ];
+
+      // Without filtering (old behavior) — would count 2 errors
+      const rawSummary = summarizeDoctorIssues(fakeIssues as any);
+      assertEq(rawSummary.errors, 2, "raw count includes completion transition errors");
+
+      // With filtering (new behavior) — should count 0 errors
+      const filteredIssues = fakeIssues.filter(i => !COMPLETION_TRANSITION_CODES.has(i.code));
+      const filteredSummary = summarizeDoctorIssues(filteredIssues as any);
+      assertEq(filteredSummary.errors, 0, "filtered count excludes completion transition errors");
+
+      // Verify that recording filtered snapshot does NOT increment consecutive error counter
+      recordHealthSnapshot(filteredSummary.errors, filteredSummary.warnings, 0);
+      assertEq(getConsecutiveErrorUnits(), 0, "completion transition errors should not increment consecutive error streak");
+    }
+
+    console.log("\n=== completion transition codes: real errors still counted at task level ===");
+    {
+      resetProactiveHealing();
+      const { COMPLETION_TRANSITION_CODES, summarizeDoctorIssues } = await import("../doctor.ts");
+
+      // Mix of completion transition errors and a real error
+      const fakeIssues = [
+        { severity: "error" as const, code: "all_tasks_done_missing_slice_summary" as const, scope: "slice", unitId: "M001/S01", message: "missing summary", fixable: true },
+        { severity: "error" as const, code: "task_plan_missing" as const, scope: "task", unitId: "M001/S01/T01", message: "plan missing", fixable: false },
+      ];
+
+      const filteredIssues = fakeIssues.filter(i => !COMPLETION_TRANSITION_CODES.has(i.code));
+      const filteredSummary = summarizeDoctorIssues(filteredIssues as any);
+      assertEq(filteredSummary.errors, 1, "real errors still counted after filtering");
+
+      recordHealthSnapshot(filteredSummary.errors, 0, 0);
+      assertEq(getConsecutiveErrorUnits(), 1, "real errors still increment consecutive error streak");
+    }
+
   } finally {
     resetProactiveHealing();
     for (const dir of cleanups) {


### PR DESCRIPTION
Fixes #1155

## Summary

- Completion-transition error codes (`all_tasks_done_missing_slice_summary`, `all_tasks_done_roadmap_not_checked`) are now excluded from health snapshot tracking when the doctor runs at `task` fixLevel
- These errors are **expected** after the final task in a slice — they signal that `complete-slice` should dispatch next, not that something is wrong
- Previously they were counted as unresolved errors, inflating `consecutiveErrorUnits` and triggering false "Verification failed — auto-fix attempt" warnings

## Problem

After the final `execute-task` in a slice completes:

1. Post-hook doctor runs with `fixLevel: "task"` and detects `all_tasks_done_missing_slice_summary` + `all_tasks_done_roadmap_not_checked`
2. Doctor correctly skips fixing them (they're `completionTransitionCodes`, reserved for `complete-slice`)
3. **But** `summarizeDoctorIssues` counted them as errors → `recordHealthSnapshot` recorded `errors > 0` → `consecutiveErrorUnits` incremented
4. Over multiple last-task completions, this triggered health escalation and verification retry loops
5. The retry loop removed the completion key and re-dispatched `execute-task` instead of advancing to `complete-slice`

## Fix

In `auto-post-unit.ts`, when `effectiveFixLevel === "task"`, filter out `COMPLETION_TRANSITION_CODES` from the issue list **before** passing to `summarizeDoctorIssues` and `recordHealthSnapshot`. This way:

- Completion-transition errors are still detected and reported by the doctor (for diagnostics)
- But they don't pollute health tracking or trigger false escalations
- Real errors at task level are still counted and escalated normally

## Files Changed

| File | Change |
|------|--------|
| `doctor.ts` | Extracted `COMPLETION_TRANSITION_CODES` to module-level exported constant |
| `auto-post-unit.ts` | Filter completion-transition issues from health snapshot at task fixLevel |
| `tests/doctor-proactive.test.ts` | 2 new tests: filtered exclusion + real errors still counted |

## Test plan

- [x] 2 new tests: completion-transition codes excluded from health snapshot; real errors still counted
- [x] All 43 doctor-proactive tests pass
- [x] All 63 doctor tests pass
- [x] TypeScript compilation clean
- [x] Full build passes