### PR TITLE
fix(ci): skip git-diff guard in prepublishOnly during CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "pipeline:version-stamp": "node scripts/version-stamp.mjs",
     "docker:build-runtime": "docker build --target runtime -t ghcr.io/gsd-build/gsd-pi .",
     "docker:build-builder": "docker build --target builder -t ghcr.io/gsd-build/gsd-ci-builder .",
-    "prepublishOnly": "npm run sync-pkg-version && npm run sync-platform-versions && git diff --exit-code || (echo 'ERROR: version sync changed files — commit them before publishing' && exit 1) && npm run build && npm run typecheck:extensions && npm run validate-pack"
+    "prepublishOnly": "npm run sync-pkg-version && npm run sync-platform-versions && ([ \"$CI\" = 'true' ] || git diff --exit-code || (echo 'ERROR: version sync changed files — commit them before publishing' && exit 1)) && npm run build && npm run typecheck:extensions && npm run validate-pack"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.73.0",


### PR DESCRIPTION
## Problem

PR #1145 fixed the pipeline's version stamp step but didn't address the root cause: `prepublishOnly`'s `git diff --exit-code` guard fails in CI because the version stamp **intentionally** dirties `package.json` and all 5 platform `package.json` files. The guard catches these expected changes and aborts `npm publish`.

## Fix

Skip the `git diff --exit-code` check when `CI=true` (set automatically by GitHub Actions). Local publishes still run the guard.

```
([ "$CI" = 'true' ] || git diff --exit-code || (echo 'ERROR: ...' && exit 1))
```

## Test plan

- [ ] Pipeline succeeds after merge (CI run triggers dev publish)
- [ ] Local `npm publish` still runs git-diff guard (CI env var not set)

🤖 Generated with [Claude Code](https://claude.com/claude-code)