### PR TITLE
fix(ci): use local binary for pipeline smoke test

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -56,7 +56,10 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Smoke test (local)
-        run: npm run test:smoke
+        run: |
+          chmod +x dist/loader.js
+          export GSD_SMOKE_BINARY="$(pwd)/dist/loader.js"
+          npm run test:smoke
 
   test-verify:
     name: Test & Verify


### PR DESCRIPTION
## Problem

After #1160 fixed the publish step, the pipeline now fails at the local smoke test. `npx gsd-pi --version` fails with `sh: 1: gsd: not found` because the `gsd` binary isn't on PATH inside the container.

## Fix

Point `GSD_SMOKE_BINARY` at the built `dist/loader.js` directly (absolute path, chmod +x). The smoke tests already support this env var — the test-verify job uses it for the installed binary.

## Test plan

- [ ] Pipeline passes the local smoke test step
- [ ] test-verify job still works with `$(which gsd)` for installed binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)