### PR TITLE
feat: upgrade to Node.js 24 LTS

### DIFF
--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -42,7 +42,7 @@ jobs:
     name: Build ${{ matrix.platform }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -101,11 +101,11 @@ jobs:
     name: Publish platform packages
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: "22"
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
 
       - name: Download all artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'npm'
 
       - name: Install dependencies
@@ -72,7 +72,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/cleanup-dev-versions.yml
+++ b/.github/workflows/cleanup-dev-versions.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           registry-url: https://registry.npmjs.org
 
       - name: Unpublish old dev versions

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -34,7 +34,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           registry-url: https://registry.npmjs.org
 
       - name: Install dependencies
@@ -70,7 +70,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           registry-url: https://registry.npmjs.org
 
       - name: Install gsd-pi@dev globally
@@ -120,7 +120,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           registry-url: https://registry.npmjs.org
 
       - name: Run live LLM tests (optional)

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # Image: ghcr.io/gsd-build/gsd-ci-builder
 # Used by: pipeline.yml Dev stage
 # ──────────────────────────────────────────────
-FROM node:22-bookworm AS builder
+FROM node:24-bookworm AS builder
 
 # Rust toolchain (stable, minimal profile)
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --profile minimal
@@ -24,7 +24,7 @@ RUN node --version && rustc --version && cargo --version
 # Image: ghcr.io/gsd-build/gsd-pi
 # Used by: end users via docker run
 # ──────────────────────────────────────────────
-FROM node:22-slim AS runtime
+FROM node:24-slim AS runtime
 
 # Git is required for GSD's git operations
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,14 +57,14 @@
         "gsd-cli": "dist/loader.js"
       },
       "devDependencies": {
-        "@types/node": "^22.0.0",
+        "@types/node": "^24.12.0",
         "@types/picomatch": "^4.0.2",
         "c8": "^11.0.0",
         "jiti": "^2.6.1",
         "typescript": "^5.4.0"
       },
       "engines": {
-        "node": ">=20.6.0"
+        "node": ">=22.0.0"
       },
       "optionalDependencies": {
         "@gsd-build/engine-darwin-arm64": ">=2.10.2",
@@ -4085,12 +4085,12 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.19.15",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
-      "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
+      "version": "24.12.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.0.tgz",
+      "integrity": "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.16.0"
       }
     },
     "node_modules/@types/picomatch": {
@@ -5000,23 +5000,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/electron/node_modules/@types/node": {
-      "version": "24.12.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.0.tgz",
-      "integrity": "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~7.16.0"
-      }
-    },
-    "node_modules/electron/node_modules/undici-types": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -8162,9 +8145,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "license": "MIT"
     },
     "node_modules/universal-user-agent": {
@@ -9181,6 +9164,23 @@
         "tailwindcss": "^4.2.1",
         "typescript": "^5.9.3"
       }
+    },
+    "studio/node_modules/@types/node": {
+      "version": "22.19.15",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
+      "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "studio/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "configDir": ".gsd"
   },
   "engines": {
-    "node": ">=20.6.0"
+    "node": ">=22.0.0"
   },
   "packageManager": "npm@10.9.3",
   "scripts": {
@@ -117,7 +117,7 @@
     "zod-to-json-schema": "^3.24.6"
   },
   "devDependencies": {
-    "@types/node": "^22.0.0",
+    "@types/node": "^24.12.0",
     "@types/picomatch": "^4.0.2",
     "c8": "^11.0.0",
     "jiti": "^2.6.1",


### PR DESCRIPTION
## Summary

Upgrades all CI pipelines, Docker images, and package metadata from Node.js 22 to Node.js 24 LTS (Krypton).

Node.js 24.11.0 entered LTS with support through April 2028. The migration from 22 → 24 is smooth for this codebase — no deprecated APIs are in use, and `--experimental-strip-types` is still accepted (the flag is stable but not yet renamed).

## Changes

### CI Workflows
| File | Change |
|------|--------|
| `ci.yml` | `node-version: 22` → `24` (build + windows-portability) |
| `pipeline.yml` | `node-version: 22` → `24` (dev-publish, test-verify, prod-release) |
| `build-native.yml` | `node-version: 22` → `24`, `actions/checkout@v4` → `v6`, `actions/setup-node@v4` → `v6` |
| `cleanup-dev-versions.yml` | `node-version: 22` → `24` |

### Docker
| File | Change |
|------|--------|
| `Dockerfile` | `node:22-bookworm` → `node:24-bookworm` (builder), `node:22-slim` → `node:24-slim` (runtime) |

### Package
| File | Change |
|------|--------|
| `package.json` | `engines.node`: `>=20.6.0` → `>=22.0.0`, `@types/node`: `^22.0.0` → `^24.0.0` |

## Verification

- `tsc --noEmit` passes with `@types/node@^24`
- 1729 unit tests pass on Node.js 24.14.0 (0 failures)
- No deprecated Node.js APIs are in use (no `dirent.path`, no legacy crypto, no `util.is*` helpers)

## Note on run 23251203632

The pipeline failure in that run was the smoke test (`gsd: not found`) — a separate issue already fixed in #1163 (merged). The Node 24 upgrade in this PR is independent.