### PR TITLE
fix(ci): skip publish when version already exists on npm

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -8,7 +8,7 @@ on:
 
 concurrency:
   group: pipeline-${{ github.sha }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 permissions:
   contents: write
@@ -51,7 +51,13 @@ jobs:
           echo "version=$(node -e 'process.stdout.write(require("./package.json").version)')" >> "$GITHUB_OUTPUT"
 
       - name: Publish @dev
-        run: npm publish --tag dev
+        run: |
+          VERSION=$(node -e 'process.stdout.write(require("./package.json").version)')
+          if npm view "gsd-pi@${VERSION}" version 2>/dev/null; then
+            echo "Version ${VERSION} already published — skipping"
+          else
+            npm publish --tag dev
+          fi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 


### PR DESCRIPTION
## Problem

Multiple CI completions on the same commit trigger duplicate Pipeline runs. The second run fails with:

```
npm error 403 - You cannot publish over the previously published versions: 2.28.0-dev.4009980
```

## Fix

1. Check `npm view` before `npm publish` — skip if version already exists
2. Set `cancel-in-progress: true` on the concurrency group to prevent redundant pipeline runs for the same sha

## Test plan

- [ ] Pipeline handles duplicate triggers gracefully (skips or cancels)
- [ ] Fresh commits still publish normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)