### PR TITLE
fix(ci): handle already-published versions in dev-publish step

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -51,7 +51,15 @@ jobs:
           echo "version=$(node -e 'process.stdout.write(require("./package.json").version)')" >> "$GITHUB_OUTPUT"
 
       - name: Publish @dev
-        run: npm publish --tag dev
+        run: |
+          OUTPUT=$(npm publish --tag dev 2>&1) && echo "$OUTPUT" || {
+            if echo "$OUTPUT" | grep -q "cannot publish over the previously published"; then
+              echo "Version already published — skipping"
+            else
+              echo "$OUTPUT"
+              exit 1
+            fi
+          }
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 


### PR DESCRIPTION
## Problem

Pipeline run [#23252072780](https://github.com/gsd-build/gsd-2/actions/runs/23252072780) failed at the "Publish @dev" step with:

```
npm error 403 Forbidden - You cannot publish over the previously
published versions: 2.28.0-dev.4009980.
```

When the Pipeline workflow triggers multiple times for the same commit SHA (e.g., `workflow_run` fires twice), `version-stamp` produces the same dev version. The second publish attempt fails because npm doesn't allow re-publishing the same version.

## Fix

Added the same "already published" guard used in `build-native.yml` for platform package publishing. The publish step now catches the E403 "cannot publish over" error and treats it as a skip rather than a failure.

This makes dev-publish idempotent — re-running the pipeline for the same SHA succeeds instead of failing.
