### PR TITLE
fix: sync root-level living docs (DECISIONS/REQUIREMENTS/PROJECT/KNOWLEDGE) from worktree to project root (#1168)

### DIFF
--- a/src/resources/extensions/gsd/auto-worktree-sync.ts
+++ b/src/resources/extensions/gsd/auto-worktree-sync.ts
@@ -51,7 +51,9 @@ export function syncProjectRootToWorktree(projectRoot: string, worktreePath: str
 /**
  * Sync dispatch-critical .gsd/ state files from worktree to project root.
  * Only runs when inside an auto-worktree (worktreePath differs from projectRoot).
- * Copies: STATE.md + active milestone directory (roadmap, slice plans, task summaries).
+ * Copies: STATE.md, root-level living docs (DECISIONS/REQUIREMENTS/PROJECT/KNOWLEDGE),
+ * active milestone directory (roadmap, slice plans, task summaries), completed-units,
+ * and runtime unit records.
  * Non-fatal — sync failure should never block dispatch.
  */
 export function syncStateToProjectRoot(worktreePath: string, projectRoot: string, milestoneId: string | null): void {
@@ -63,6 +65,16 @@ export function syncStateToProjectRoot(worktreePath: string, projectRoot: string
 
   // 1. STATE.md — the quick-glance status used by initial deriveState()
   safeCopy(join(wtGsd, "STATE.md"), join(prGsd, "STATE.md"), { force: true })
+
+  // 1b. Root-level living documents — DECISIONS.md, REQUIREMENTS.md, PROJECT.md, KNOWLEDGE.md
+  // Agents update these during slice execution in the worktree. Without syncing,
+  // the project root retains stale versions: missing decisions, unvalidated
+  // requirements, outdated project description, and no accumulated knowledge.
+  // On session restart, deriveState and context inlining read these from the
+  // project root — stale copies cause the next agent to work with wrong context.
+  for (const doc of ["DECISIONS.md", "REQUIREMENTS.md", "PROJECT.md", "KNOWLEDGE.md"]) {
+    safeCopy(join(wtGsd, doc), join(prGsd, doc), { force: true })
+  }
 
   // 2. Milestone directory — ROADMAP, slice PLANs, task summaries
   // Copy the entire milestone .gsd subtree so deriveState reads current checkboxes

--- a/src/resources/extensions/gsd/tests/auto-recovery.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-recovery.test.ts
@@ -638,3 +638,90 @@ test("#793: invalidateAllCaches clears all caches so deriveState sees fresh disk
     cleanup(base);
   }
 });
+
+test("syncStateToProjectRoot copies root-level living docs to project root", () => {
+  // Verifies fix for: DECISIONS.md, REQUIREMENTS.md, PROJECT.md, KNOWLEDGE.md
+  // are updated by agents during worktree execution but never synced back to
+  // the project root. On session restart, stale root copies cause the next
+  // agent to work with wrong context (missing decisions, unvalidated reqs, etc.).
+  const { syncStateToProjectRoot } = require("../auto-worktree-sync.js");
+
+  const projectRoot = makeTmpBase();
+  const worktree = makeTmpBase();
+  try {
+    const prGsd = join(projectRoot, ".gsd");
+    const wtGsd = join(worktree, ".gsd");
+
+    // Write stale docs in project root
+    writeFileSync(join(prGsd, "DECISIONS.md"), "# Decisions\n\n| ID |\n| D001 |\n");
+    writeFileSync(join(prGsd, "REQUIREMENTS.md"), "# Requirements\n\nR001 active\n");
+    writeFileSync(join(prGsd, "PROJECT.md"), "# Project\n\nInitialized.\n");
+    // KNOWLEDGE.md intentionally missing in root — common case
+
+    // Write updated docs in worktree (as agent would during slice execution)
+    writeFileSync(join(wtGsd, "DECISIONS.md"), "# Decisions\n\n| ID |\n| D001 |\n| D002 |\n| D003 |\n");
+    writeFileSync(join(wtGsd, "REQUIREMENTS.md"), "# Requirements\n\nR001 validated\nR002 active\n");
+    writeFileSync(join(wtGsd, "PROJECT.md"), "# Project\n\nS01-S04 complete.\n");
+    writeFileSync(join(wtGsd, "KNOWLEDGE.md"), "# Knowledge\n\n## SQLite bool gotcha\n");
+
+    // Sync worktree → project root
+    syncStateToProjectRoot(worktree, projectRoot, "M001");
+
+    // Verify all four docs were synced
+    assert.equal(
+      readFileSync(join(prGsd, "DECISIONS.md"), "utf8"),
+      "# Decisions\n\n| ID |\n| D001 |\n| D002 |\n| D003 |\n",
+      "DECISIONS.md should be overwritten with worktree version"
+    );
+    assert.equal(
+      readFileSync(join(prGsd, "REQUIREMENTS.md"), "utf8"),
+      "# Requirements\n\nR001 validated\nR002 active\n",
+      "REQUIREMENTS.md should be overwritten with worktree version"
+    );
+    assert.equal(
+      readFileSync(join(prGsd, "PROJECT.md"), "utf8"),
+      "# Project\n\nS01-S04 complete.\n",
+      "PROJECT.md should be overwritten with worktree version"
+    );
+    assert.ok(
+      existsSync(join(prGsd, "KNOWLEDGE.md")),
+      "KNOWLEDGE.md should be created in project root even if it didn't exist before"
+    );
+    assert.equal(
+      readFileSync(join(prGsd, "KNOWLEDGE.md"), "utf8"),
+      "# Knowledge\n\n## SQLite bool gotcha\n",
+      "KNOWLEDGE.md content should match worktree"
+    );
+  } finally {
+    cleanup(projectRoot);
+    cleanup(worktree);
+  }
+});
+
+test("syncStateToProjectRoot skips missing living docs without error", () => {
+  // If the worktree has no KNOWLEDGE.md (e.g. no knowledge entries yet),
+  // sync should not crash or create an empty file in the project root.
+  const { syncStateToProjectRoot } = require("../auto-worktree-sync.js");
+
+  const projectRoot = makeTmpBase();
+  const worktree = makeTmpBase();
+  try {
+    // Only STATE.md exists in worktree — no living docs
+    writeFileSync(join(worktree, ".gsd", "STATE.md"), "# State\n");
+
+    syncStateToProjectRoot(worktree, projectRoot, "M001");
+
+    // Should not create docs that don't exist in worktree
+    assert.ok(
+      !existsSync(join(projectRoot, ".gsd", "KNOWLEDGE.md")),
+      "KNOWLEDGE.md should not be created if it doesn't exist in worktree"
+    );
+    assert.ok(
+      !existsSync(join(projectRoot, ".gsd", "DECISIONS.md")),
+      "DECISIONS.md should not be created if it doesn't exist in worktree"
+    );
+  } finally {
+    cleanup(projectRoot);
+    cleanup(worktree);
+  }
+});


### PR DESCRIPTION
## Problem

`syncStateToProjectRoot()` copies STATE.md, milestone dirs, completed-units, and runtime records — but not the four root-level living documents that agents update during slice execution:

- `DECISIONS.md` (append-only decision register)
- `REQUIREMENTS.md` (requirement status/validation updates)
- `PROJECT.md` (current project state description)
- `KNOWLEDGE.md` (accumulated rules and lessons)

When auto-mode restarts and reads the project root, it gets stale copies: missing decisions, unvalidated requirements, outdated project description, and no accumulated knowledge. The next agent session works with wrong context.

## Observed Impact

In a real project after 4 completed slices (131 tests, full frontend+backend):
- Root DECISIONS.md was missing 8 decisions (D012–D019)
- Root REQUIREMENTS.md showed 0 validated requirements (should be 4)
- Root PROJECT.md still said "Project initialized. No source code yet."
- Root KNOWLEDGE.md did not exist at all (worktree had 8 entries)

## Fix

Added a loop in `syncStateToProjectRoot()` after the STATE.md copy that syncs each document via `safeCopy` (gracefully skips missing files):

```typescript
for (const doc of ["DECISIONS.md", "REQUIREMENTS.md", "PROJECT.md", "KNOWLEDGE.md"]) {
  safeCopy(join(wtGsd, doc), join(prGsd, doc), { force: true })
}
```

## Testing

Two new tests in `auto-recovery.test.ts`:
1. **Copies updated docs** — verifies all 4 docs are overwritten with worktree versions, including KNOWLEDGE.md that did not exist in root
2. **Skips missing docs** — verifies sync does not crash or create empty files when docs are absent from worktree

## Related

- #769 / #774 — Same class of bug (worktree→root sync gap), fixed for runtime unit records
- Closes #1168
