### PR TITLE
fix: route needs-discussion phase to interactive flow instead of stopping

### DIFF
--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -1439,6 +1439,23 @@ async function dispatchNextUnit(
 
   await runSecretsGate();
 
+  // ── Interactive discussion gate ──
+  // If the active milestone needs discussion (has CONTEXT-DRAFT.md but no roadmap),
+  // stop auto-mode and route to the interactive discussion flow. The guided-flow
+  // handles needs-discussion correctly — it just needs to be called instead of
+  // letting the dispatch table fire "needs-discussion → stop" (#1170).
+  if (state.phase === "needs-discussion") {
+    if (s.currentUnit) {
+      await closeoutUnit(ctx, s.basePath, s.currentUnit.type, s.currentUnit.id, s.currentUnit.startedAt, buildSnapshotOpts(s.currentUnit.type, s.currentUnit.id));
+    }
+    const cmdCtx = s.cmdCtx!;
+    const basePath = s.basePath;
+    await stopAuto(ctx, pi, `${mid}: ${midTitle} needs discussion before planning.`);
+    const { showSmartEntry } = await import("./guided-flow.js");
+    await showSmartEntry(cmdCtx, pi, basePath);
+    return;
+  }
+
   // ── Dispatch table ──
   const dispatchResult = await resolveDispatch({ basePath: s.basePath, mid, midTitle: midTitle!, state, prefs,
   });


### PR DESCRIPTION
## Problem

When a milestone has `CONTEXT-DRAFT.md` but no roadmap yet, `deriveState` returns phase `needs-discussion`. The dispatch table in `auto-dispatch.ts` matches this with `needs-discussion → stop`, which calls `stopAuto()`.

Running `/gsd` again re-enters `startAuto` → `dispatchNextUnit` → `resolveDispatch` → stop → loop. The user is stuck in an unbreakable cycle.

Meanwhile, `guided-flow.ts` has a complete interactive handler for `needs-discussion` (lines 920+): discuss from draft, start fresh, or skip. It just was never reachable from the auto-mode entry path.

## Fix

Added an early check in `dispatchNextUnit` (before the dispatch table): if phase is `needs-discussion`, stop auto-mode gracefully and call `showSmartEntry()` which routes to the existing interactive discussion flow.

Key detail: `stopAuto()` clears `s.cmdCtx`, so both `cmdCtx` and `basePath` are captured before the stop call.

## Verification

- `tsc --noEmit` passes
- 1729 unit tests pass

Fixes #1170
