### PR TITLE
fix: add defensive guards against undefined .filter() in auto-mode dispatch/recovery

### DIFF
--- a/src/resources/extensions/gsd/auto-recovery.ts
+++ b/src/resources/extensions/gsd/auto-recovery.ts
@@ -211,7 +211,7 @@ export function verifyExpectedArtifact(unitType: string, unitId: string, base: s
         try {
           const roadmapContent = readFileSync(roadmapFile, "utf-8");
           const roadmap = parseRoadmap(roadmapContent);
-          const slice = roadmap.slices.find(s => s.id === sid);
+          const slice = (roadmap.slices ?? []).find(s => s.id === sid);
           if (slice && !slice.done) return false;
         } catch {
           // Corrupt/unparseable roadmap — fail verification so the unit

--- a/src/resources/extensions/gsd/auto-start.ts
+++ b/src/resources/extensions/gsd/auto-start.ts
@@ -415,7 +415,7 @@ export async function bootstrapAutoSession(
   ctx.ui.setStatus("gsd-auto", s.stepMode ? "next" : "auto");
   ctx.ui.setFooter(hideFooter);
   const modeLabel = s.stepMode ? "Step-mode" : "Auto-mode";
-  const pendingCount = state.registry.filter(m => m.status !== 'complete' && m.status !== 'parked').length;
+  const pendingCount = (state.registry ?? []).filter(m => m.status !== 'complete' && m.status !== 'parked').length;
   const scopeMsg = pendingCount > 1
     ? `Will loop through ${pendingCount} milestones.`
     : "Will loop until milestone complete.";

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -877,7 +877,7 @@ async function showStepWizard(
     : "previous unit";
 
   if (!mid || state.phase === "complete") {
-    const incomplete = state.registry.filter(m => m.status !== "complete" && m.status !== "parked");
+    const incomplete = (state.registry ?? []).filter(m => m.status !== "complete" && m.status !== "parked");
     if (incomplete.length > 0 && state.phase !== "complete" && state.phase !== "blocked" && state.phase !== "pre-planning") {
       const ids = incomplete.map(m => m.id).join(", ");
       const diag = `basePath=${s.basePath}, milestones=[${state.registry.map(m => `${m.id}:${m.status}`).join(", ")}], phase=${state.phase}`;
@@ -1171,7 +1171,7 @@ async function dispatchNextUnit(
       }
     }
 
-    const pendingIds = state.registry
+    const pendingIds = (state.registry ?? [])
       .filter(m => m.status !== "complete")
       .map(m => m.id);
     pruneQueueOrder(s.basePath, pendingIds);
@@ -1186,7 +1186,7 @@ async function dispatchNextUnit(
       await closeoutUnit(ctx, s.basePath, s.currentUnit.type, s.currentUnit.id, s.currentUnit.startedAt, buildSnapshotOpts(s.currentUnit.type, s.currentUnit.id));
     }
 
-    const incomplete = state.registry.filter(m => m.status !== "complete" && m.status !== "parked");
+    const incomplete = (state.registry ?? []).filter(m => m.status !== "complete" && m.status !== "parked");
     if (incomplete.length === 0) {
       // Genuinely all complete (parked milestones excluded) — merge milestone branch to main before stopping (#962)
       if (s.currentMilestoneId && isInAutoWorktree(s.basePath) && s.originalBasePath) {


### PR DESCRIPTION
## Problem

Auto-mode crashed with `Cannot read properties of undefined (reading 'filter')` during partial execute-task recovery. The crash occurred when derived state was structurally incomplete or undefined — likely from a corrupt/partially-written state file during crash recovery.

Reported via `/gsd forensics` in #1176.

## Fix

Added `?? []` fallback guards on all `.filter()` / `.find()` / `.map()` calls in the dispatch and recovery hot paths that access derived arrays:

| File | Line | Property |
|------|------|----------|
| `auto.ts` | ~880 | `state.registry.filter()` |
| `auto.ts` | ~1189 | `state.registry.filter()` |
| `auto.ts` | ~1175 | `state.registry.filter().map()` |
| `auto-recovery.ts` | ~214 | `roadmap.slices.find()` |
| `auto-start.ts` | ~418 | `state.registry.filter()` |

The parsers (`deriveState`, `parseRoadmap`, `parsePlan`) always return properly initialized arrays, so these guards are belt-and-suspenders for the rare case where crash recovery encounters a partially written file that produces an unexpected parse result.

## Verification

- `tsc --noEmit` passes
- 1729 unit tests pass

Fixes #1176
