### PR TITLE
fix: handle Windows non-ASCII paths in cpSync with copyFileSync fallback

### DIFF
--- a/packages/pi-coding-agent/scripts/copy-assets.cjs
+++ b/packages/pi-coding-agent/scripts/copy-assets.cjs
@@ -1,24 +1,55 @@
 #!/usr/bin/env node
-const { mkdirSync, cpSync } = require('fs');
+const { mkdirSync, cpSync, copyFileSync, readdirSync } = require('fs');
+const { join } = require('path');
+
+/**
+ * Recursive directory copy using copyFileSync — workaround for cpSync failures
+ * on Windows paths containing non-ASCII characters (#1178).
+ */
+function safeCpSync(src, dest, options) {
+  try {
+    cpSync(src, dest, options);
+  } catch {
+    if (options && options.recursive) {
+      copyDirRecursive(src, dest, options && options.filter);
+    } else {
+      copyFileSync(src, dest);
+    }
+  }
+}
+
+function copyDirRecursive(src, dest, filter) {
+  mkdirSync(dest, { recursive: true });
+  for (const entry of readdirSync(src, { withFileTypes: true })) {
+    const srcPath = join(src, entry.name);
+    const destPath = join(dest, entry.name);
+    if (filter && !filter(srcPath)) continue;
+    if (entry.isDirectory()) {
+      copyDirRecursive(srcPath, destPath, filter);
+    } else {
+      copyFileSync(srcPath, destPath);
+    }
+  }
+}
 
 // Theme assets
 mkdirSync('dist/modes/interactive/theme', { recursive: true });
-cpSync('src/modes/interactive/theme', 'dist/modes/interactive/theme', {
+safeCpSync('src/modes/interactive/theme', 'dist/modes/interactive/theme', {
   recursive: true,
   filter: (s) => !s.endsWith('.ts'),
 });
 
 // Export HTML templates and vendor files
 mkdirSync('dist/core/export-html/vendor', { recursive: true });
-cpSync('src/core/export-html/template.html', 'dist/core/export-html/template.html');
-cpSync('src/core/export-html/template.css', 'dist/core/export-html/template.css');
-cpSync('src/core/export-html/template.js', 'dist/core/export-html/template.js');
-cpSync('src/core/export-html/vendor', 'dist/core/export-html/vendor', {
+safeCpSync('src/core/export-html/template.html', 'dist/core/export-html/template.html');
+safeCpSync('src/core/export-html/template.css', 'dist/core/export-html/template.css');
+safeCpSync('src/core/export-html/template.js', 'dist/core/export-html/template.js');
+safeCpSync('src/core/export-html/vendor', 'dist/core/export-html/vendor', {
   recursive: true,
   filter: (s) => !s.endsWith('.ts'),
 });
 
 // LSP defaults
 mkdirSync('dist/core/lsp', { recursive: true });
-cpSync('src/core/lsp/defaults.json', 'dist/core/lsp/defaults.json');
-cpSync('src/core/lsp/lsp.md', 'dist/core/lsp/lsp.md');
+safeCpSync('src/core/lsp/defaults.json', 'dist/core/lsp/defaults.json');
+safeCpSync('src/core/lsp/lsp.md', 'dist/core/lsp/lsp.md');

--- a/src/resource-loader.ts
+++ b/src/resource-loader.ts
@@ -1,6 +1,6 @@
 import { DefaultResourceLoader } from '@gsd/pi-coding-agent'
 import { homedir } from 'node:os'
-import { chmodSync, cpSync, existsSync, mkdirSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from 'node:fs'
+import { chmodSync, copyFileSync, cpSync, existsSync, mkdirSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from 'node:fs'
 import { dirname, join, relative, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { compareSemver } from './update-check.js'
@@ -127,8 +127,31 @@ function syncResourceDir(srcDir: string, destDir: string): void {
         if (existsSync(target)) rmSync(target, { recursive: true, force: true })
       }
     }
-    cpSync(srcDir, destDir, { recursive: true, force: true })
+    try {
+      cpSync(srcDir, destDir, { recursive: true, force: true })
+    } catch {
+      // Fallback for Windows paths with non-ASCII characters where cpSync
+      // fails with the \\?\ extended-length prefix (#1178).
+      copyDirRecursive(srcDir, destDir)
+    }
     makeTreeWritable(destDir)
+  }
+}
+
+/**
+ * Recursive directory copy using copyFileSync — workaround for cpSync failures
+ * on Windows paths containing non-ASCII characters (#1178).
+ */
+function copyDirRecursive(src: string, dest: string): void {
+  mkdirSync(dest, { recursive: true })
+  for (const entry of readdirSync(src, { withFileTypes: true })) {
+    const srcPath = join(src, entry.name)
+    const destPath = join(dest, entry.name)
+    if (entry.isDirectory()) {
+      copyDirRecursive(srcPath, destPath)
+    } else {
+      copyFileSync(srcPath, destPath)
+    }
   }
 }
 


### PR DESCRIPTION
## Problem

Windows users with non-ASCII characters in their username (e.g. `ö`, `ä`, `ü`, `é`) cannot build or run GSD. Node.js's `cpSync` fails with the `\\?\` extended-length path prefix not handling Unicode correctly:

```
Error: , The operation completed successfully.
'\\?\C:\Users\<username-containing-ö>\...\defaults.json'
```

This affects:
1. **Build time** — `copy-assets.cjs` fails during `npm run build`
2. **Runtime** — `syncResourceDir()` in `resource-loader.ts` fails when syncing extensions to `~/.gsd/agent/`

## Fix

Added a try/catch fallback around all `cpSync` calls: when `cpSync` throws, fall back to a manual recursive copy using `copyFileSync` which handles non-ASCII paths correctly on Windows.

| File | Change |
|------|--------|
| `src/resource-loader.ts` | `syncResourceDir()` catches `cpSync` failure, falls back to `copyDirRecursive()` |
| `packages/pi-coding-agent/scripts/copy-assets.cjs` | All `cpSync` calls wrapped in `safeCpSync()` with the same fallback |

The fallback preserves the `filter` option used by `copy-assets.cjs` to skip `.ts` files.

## Verification

- `tsc --noEmit` passes
- `npm run build` completes successfully (copy-assets runs)

Fixes #1178
