### PR TITLE
fix: prevent branch-mode merge fallback from firing in worktree isolation

### DIFF
--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -1212,7 +1212,7 @@ async function dispatchNextUnit(
             try { process.chdir(s.basePath); } catch { /* best-effort */ }
           }
         }
-      } else if (s.currentMilestoneId && !isInAutoWorktree(s.basePath) && getIsolationMode() !== "none") {
+      } else if (s.currentMilestoneId && !isInAutoWorktree(s.basePath) && getIsolationMode() === "branch") {
         try {
           const currentBranch = getCurrentBranch(s.basePath);
           const milestoneBranch = autoWorktreeBranch(s.currentMilestoneId);
@@ -1314,7 +1314,7 @@ async function dispatchNextUnit(
           try { process.chdir(s.basePath); } catch { /* best-effort */ }
         }
       }
-    } else if (s.currentMilestoneId && !isInAutoWorktree(s.basePath) && getIsolationMode() !== "none") {
+    } else if (s.currentMilestoneId && !isInAutoWorktree(s.basePath) && getIsolationMode() === "branch") {
       try {
         const currentBranch = getCurrentBranch(s.basePath);
         const milestoneBranch = autoWorktreeBranch(s.currentMilestoneId);


### PR DESCRIPTION
## Problem

When auto-mode completes a milestone in worktree isolation, the merge dispatcher falls through to the branch-mode path instead of the worktree-mode path. This causes `git checkout main` inside the worktree, which Git rejects:

```
fatal: 'main' is already used by worktree at '/Users/.../project'
```

The condition `!isInAutoWorktree(s.basePath) && getIsolationMode() !== "none"` was meant to match branch-mode only, but it also matches worktree-mode when `isInAutoWorktree()` returns false — which happens after `process.chdir()` moves cwd back to the project root during cleanup.

## Fix

Changed the condition from `getIsolationMode() !== "none"` to `getIsolationMode() === "branch"` at both merge sites (all-complete and milestone-transition paths). The branch-mode merge now only fires when the user explicitly configured `git.isolation: branch`.

| Location | Before | After |
|----------|--------|-------|
| Line ~1215 (all-complete) | `!== "none"` | `=== "branch"` |
| Line ~1317 (milestone-transition) | `!== "none"` | `=== "branch"` |

## Verification

- `tsc --noEmit` passes

Fixes #1179
