### PR TITLE
fix: include promptGuidelines in customPrompt path of buildSystemPrompt

### DIFF
--- a/packages/pi-coding-agent/src/core/system-prompt.ts
+++ b/packages/pi-coding-agent/src/core/system-prompt.ts
@@ -94,6 +94,17 @@ export function buildSystemPrompt(options: BuildSystemPromptOptions = {}): strin
 		prompt += `\nCurrent date and time: ${dateTime}`;
 		prompt += `\nCurrent working directory: ${resolvedCwd}`;
 
+		// Append promptGuidelines from extension-registered tools.
+		// Without this, tools registered via pi.registerTool() with promptGuidelines
+		// have their definitions reach the API but the model has no guidance on when
+		// to use them (#1184).
+		if (promptGuidelines && promptGuidelines.length > 0) {
+			prompt += "\n\n";
+			for (const guideline of promptGuidelines) {
+				prompt += guideline + "\n";
+			}
+		}
+
 		return prompt;
 	}
 


### PR DESCRIPTION
## Problem

When `buildSystemPrompt()` receives a `customPrompt` (as GSD's system contract provides), it returns early at line ~100 without appending `promptGuidelines` from extension-registered tools. The non-custom path correctly appends them at line ~180.

This means tools registered via `pi.registerTool()` with `promptGuidelines` have their tool definitions reach the Anthropic API's `tools` parameter, but the model has no system prompt guidance on when to use them. In practice, the `subagent` extension's agents (scout, researcher, worker) are never invoked — the model falls back to `async_bash` / `bg_shell` instead.

## Fix

Added `promptGuidelines` append in the `customPrompt` path, after the date/time section and before the early return. This matches the behavior of the non-custom path.

## Verification

- `tsc --noEmit` passes

Fixes #1184
