### PR TITLE
fix: treat auto-discovered verification failures as advisory, not blocking

### DIFF
--- a/src/resources/extensions/gsd/auto-verification.ts
+++ b/src/resources/extensions/gsd/auto-verification.ts
@@ -155,6 +155,20 @@ export async function runPostUnitVerification(
       s.verificationRetryCount.delete(s.currentUnit.id);
       s.pendingVerificationRetry = null;
       return "continue";
+    } else if (result.discoverySource === "package-json") {
+      // Auto-discovered checks from package.json may fail on pre-existing errors
+      // that the current task didn't introduce. Don't trigger the retry loop —
+      // log a warning and let the task proceed (#1186).
+      process.stderr.write(
+        `verification-gate: auto-discovered checks failed (source: package-json) — treating as advisory, not blocking\n`,
+      );
+      ctx.ui.notify(
+        `Verification: auto-discovered checks failed (pre-existing errors likely). Continuing without retry.`,
+        "warning",
+      );
+      s.verificationRetryCount.delete(s.currentUnit.id);
+      s.pendingVerificationRetry = null;
+      return "continue";
     } else if (autoFixEnabled && attempt + 1 <= maxRetries) {
       const nextAttempt = attempt + 1;
       s.verificationRetryCount.set(s.currentUnit.id, nextAttempt);


### PR DESCRIPTION
## Problem

The verification gate auto-discovers `typecheck`, `lint`, and `test` commands from `package.json`. When a project has pre-existing errors (e.g., 205 lint errors across files the current task never touched), the gate fails after every `execute-task`, triggers the auto-fix retry loop, and the agent can't fix errors it didn't introduce. This creates a doom loop: execute → lint fail → auto-fix → lint still fails → retry exhausted → pause → stale lock.

Reported in #1186, also the root cause behind #1182.

## Fix

In `auto-verification.ts`, when `result.discoverySource === "package-json"` and the gate fails, treat it as **advisory** rather than **blocking**:
- Log a warning to stderr and the UI
- Do NOT trigger the auto-fix retry loop
- Return `"continue"` so the task proceeds

Explicitly configured checks still trigger the full retry cycle:
- `verification_commands` in preferences → source: `"preference"` → blocking
- `verify:` field in task plan → source: `"task-plan"` → blocking
- Auto-discovered from `package.json` → source: `"package-json"` → **advisory** (new)

This preserves the safety of user-configured verification while preventing auto-discovered checks from blocking on inherited tech debt.

## Verification

- `tsc --noEmit` passes
- 1729 unit tests pass

Fixes #1186
