### PR TITLE
fix: Two-column dashboard layout with task checklist

### DIFF
--- a/scripts/preview-dashboard.ts
+++ b/scripts/preview-dashboard.ts
@@ -104,14 +104,13 @@ function render(width: number): string[] {
   const contextLine = contextParts.join(theme.fg("dim", " · "));
   lines.push(rightAlign(`${pad}${contextLine}`, phaseBadge, width));
 
-  // Column sizing: both fixed, adjacent. Empty space on the right.
-  const minTwoColWidth = 80;
-  const leftColFixed = 44;
+  // Column sizing: left flexes, right fixed. Task list sits center-right.
+  const minTwoColWidth = 100;
   const rightColFixed = 44;
-  const colGap = 3;
+  const colGap = 5;
   const useTwoCol = width >= minTwoColWidth;
-  const leftColWidth = useTwoCol ? leftColFixed : width;
   const rightColWidth = useTwoCol ? rightColFixed : 0;
+  const leftColWidth = useTwoCol ? width - rightColWidth - colGap : width;
 
   // Left column: progress, ETA, next, stats
   const leftLines: string[] = [];
@@ -179,8 +178,9 @@ function render(width: number): string[] {
     lines.push("");
     for (let i = 0; i < maxRows; i++) {
       const left = padToWidth(leftLines[i] ?? "", leftColWidth);
+      const gap = " ".repeat(colGap - 2);
       const right = rightLines[i] ?? "";
-      lines.push(truncateToWidth(`${left} ${divider} ${right}`, width));
+      lines.push(truncateToWidth(`${left}${gap}${divider} ${right}`, width));
     }
   } else {
     lines.push("");

--- a/src/resources/extensions/gsd/auto-dashboard.ts
+++ b/src/resources/extensions/gsd/auto-dashboard.ts
@@ -400,13 +400,13 @@ export function updateProgressWidget(
         // Left: progress, ETA, next, stats (fixed)  |  Right: task checklist (fixed, adjacent)
         // Both columns sit left-to-center; empty space is on the right.
         const divider = theme.fg("dim", "│");
-        const minTwoColWidth = 80;
-        const leftColFixed = 44;
+        const minTwoColWidth = 100;
         const rightColFixed = 44;
-        const colGap = 3; // space + │ + space
+        const colGap = 5; // breathing room between columns
+        // Left column takes remaining space — no truncation on wide terminals
         const useTwoCol = width >= minTwoColWidth;
-        const leftColWidth = useTwoCol ? leftColFixed : width;
         const rightColWidth = useTwoCol ? rightColFixed : 0;
+        const leftColWidth = useTwoCol ? width - rightColWidth - colGap : width;
 
         const roadmapSlices = mid ? getRoadmapSlicesSync() : null;
 
@@ -603,8 +603,9 @@ export function updateProgressWidget(
             lines.push(""); // spacer before columns
             for (let i = 0; i < maxRows; i++) {
               const left = padToWidth(leftLines[i] ?? "", leftColWidth);
+              const gap = " ".repeat(colGap - 2); // colGap minus divider and its trailing space
               const right = rightLines[i] ?? "";
-              lines.push(truncateToWidth(`${left} ${divider} ${right}`, width));
+              lines.push(truncateToWidth(`${left}${gap}${divider} ${right}`, width));
             }
           }
         } else {


### PR DESCRIPTION
## Summary

Redesigns the auto-mode progress widget to use a two-column layout that makes better use of the full terminal width:

- **Left column (flex)**: progress bar, ETA, next step, token stats, model info — expands to fill available space
- **Right column (fixed 44 chars)**: task checklist with done/active/pending glyphs
- **Divider**: vertical bar with 5-char gap separating the columns
- **Responsive**: falls back to single-column stacked layout below 100 cols
- **Compact header**: project name, slice, and action merged into one line
- **Compact footer**: pwd and keybinding hints on one line

### Before (single column, ~14 lines)
```
  ○ GSD  AUTO                                    1h 23m

  Core Patching Daemon
  S04: CI gate

  ▸ completing  M001-07dqzj/S04              [COMPLETE]

  █████░░░  3/6 slices  ·  task 2/2  ·  ~1h 47m

  → then reassess roadmap

  ~/Github/git-patcher/...
  ↑22 ↓11k R1.1M W38k $18.668 35.2%/200k
  esc pause  |  ⌃⌥G dashboard
```

### After (two-column, ~12 lines, full width)
```
  ● GSD AUTO                                                                              1h 23m
  Core Patching Daemon · S04: CI gate · ▸ completing M001-07dqzj/S04                    COMPLETE

  █████████░░░░░░░░░ 3/6 slices · task 4/6                    │  ✓ T01: Core type definitions
  ~1h 47m remaining                                           │  ✓ T02: Database schema migration
  → then reassess roadmap                                     │  ✓ T03: API route handlers
  ↑22 ↓11k R1.1M W38k ⚡85% $18.668 35.2%/200k                │  ▸ T04: Authentication middleware
  anthropic/claude-opus-4-6                                   │    T05: Unit & integration tests
                                                              │    T06: Documentation updates

  ~/Github/git-patcher/... (milestone/M001-07dqzj)              esc pause | ⌃⌥G dashboard
```

### Changes

- `auto-dashboard.ts`: Two-column render with task checklist, merged context line, compact footer, flex left column
- `auto-dashboard.ts`: Cache task details (id, title, done) in slice progress cache for checklist rendering
- `scripts/preview-dashboard.ts`: Visual test harness — renders widget with mock data at any terminal width

### Visual test harness

```bash
npx tsx scripts/preview-dashboard.ts        # uses terminal width
npx tsx scripts/preview-dashboard.ts 120    # specific width
```

## Test plan

- [x] Build passes cleanly
- [x] All 21 auto-dashboard unit tests pass
- [x] All 41 dashboard-budget tests pass
- [x] All 92 visualizer-views tests pass
- [x] Preview renders correctly at 60, 90, 100, 120, 150, 215 cols
- [x] Narrow fallback (<100 cols) stacks to single column
- [ ] Live test with auto-mode execution