### PR TITLE
refactor: extract PER_REQUEST_TIMEOUT_MS to shared types

### DIFF
--- a/src/resources/extensions/remote-questions/discord-adapter.ts
+++ b/src/resources/extensions/remote-questions/discord-adapter.ts
@@ -2,11 +2,11 @@
  * Remote Questions — Discord adapter
  */
 
-import type { ChannelAdapter, RemotePrompt, RemoteDispatchResult, RemoteAnswer, RemotePromptRef } from "./types.js";
+import { PER_REQUEST_TIMEOUT_MS, type ChannelAdapter, type RemotePrompt, type RemoteDispatchResult, type RemoteAnswer, type RemotePromptRef } from "./types.js";
 import { formatForDiscord, parseDiscordResponse, DISCORD_NUMBER_EMOJIS } from "./format.js";
 
 const DISCORD_API = "https://discord.com/api/v10";
-const PER_REQUEST_TIMEOUT_MS = 15_000;
+
 export class DiscordAdapter implements ChannelAdapter {
   readonly name = "discord" as const;
   private botUserId: string | null = null;

--- a/src/resources/extensions/remote-questions/notify.ts
+++ b/src/resources/extensions/remote-questions/notify.ts
@@ -9,8 +9,7 @@
 
 import { resolveRemoteConfig } from "./config.js";
 import type { ResolvedConfig } from "./config.js";
-
-const PER_REQUEST_TIMEOUT_MS = 15_000;
+import { PER_REQUEST_TIMEOUT_MS } from "./types.js";
 
 /**
  * Send a one-way notification to the configured remote channel.

--- a/src/resources/extensions/remote-questions/slack-adapter.ts
+++ b/src/resources/extensions/remote-questions/slack-adapter.ts
@@ -2,11 +2,10 @@
  * Remote Questions — Slack adapter
  */
 
-import type { ChannelAdapter, RemotePrompt, RemoteDispatchResult, RemoteAnswer, RemotePromptRef } from "./types.js";
+import { PER_REQUEST_TIMEOUT_MS, type ChannelAdapter, type RemotePrompt, type RemoteDispatchResult, type RemoteAnswer, type RemotePromptRef } from "./types.js";
 import { formatForSlack, parseSlackReply, parseSlackReactionResponse, SLACK_NUMBER_REACTION_NAMES } from "./format.js";
 
 const SLACK_API = "https://slack.com/api";
-const PER_REQUEST_TIMEOUT_MS = 15_000;
 const SLACK_ACK_REACTION = "white_check_mark";
 
 export class SlackAdapter implements ChannelAdapter {

--- a/src/resources/extensions/remote-questions/telegram-adapter.ts
+++ b/src/resources/extensions/remote-questions/telegram-adapter.ts
@@ -2,11 +2,10 @@
  * Remote Questions — Telegram adapter
  */
 
-import type { ChannelAdapter, RemotePrompt, RemoteDispatchResult, RemoteAnswer, RemotePromptRef } from "./types.js";
+import { PER_REQUEST_TIMEOUT_MS, type ChannelAdapter, type RemotePrompt, type RemoteDispatchResult, type RemoteAnswer, type RemotePromptRef } from "./types.js";
 import { formatForTelegram, parseTelegramResponse } from "./format.js";
 
 const TELEGRAM_API = "https://api.telegram.org";
-const PER_REQUEST_TIMEOUT_MS = 15_000;
 
 export class TelegramAdapter implements ChannelAdapter {
   readonly name = "telegram" as const;

--- a/src/resources/extensions/remote-questions/types.ts
+++ b/src/resources/extensions/remote-questions/types.ts
@@ -2,6 +2,9 @@
  * Remote Questions — shared types
  */
 
+/** Timeout applied to every outbound HTTP request across all channel adapters. */
+export const PER_REQUEST_TIMEOUT_MS = 15_000;
+
 export type RemoteChannel = "slack" | "discord" | "telegram";
 
 export interface RemoteQuestionOption {


### PR DESCRIPTION
## Summary
- Extracted the duplicated `PER_REQUEST_TIMEOUT_MS = 15_000` constant from 4 files into `types.ts` (the shared types/constants file for the remote-questions module)
- Updated `slack-adapter.ts`, `discord-adapter.ts`, `telegram-adapter.ts`, and `notify.ts` to import from the single source of truth
- Zero behavioral change; `npx tsc --noEmit` passes clean

## Test plan
- [x] `npx tsc --noEmit` passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)