### PR TITLE
refactor: deduplicate projectRoot()

### DIFF
--- a/src/resources/extensions/gsd/commands-handlers.ts
+++ b/src/resources/extensions/gsd/commands-handlers.ts
@@ -20,15 +20,7 @@ import {
 } from "./doctor.js";
 import { loadPrompt } from "./prompt-loader.js";
 import { isAutoActive } from "./auto.js";
-import { resolveProjectRoot } from "./worktree.js";
-import { assertSafeDirectory } from "./validate-directory.js";
-
-/** Resolve the effective project root, accounting for worktree paths. */
-function projectRoot(): string {
-  const root = resolveProjectRoot(process.cwd());
-  assertSafeDirectory(root);
-  return root;
-}
+import { projectRoot } from "./commands.js";
 
 function dispatchDoctorHeal(pi: ExtensionAPI, scope: string | undefined, reportText: string, structuredIssues: string): void {
   const workflowPath = process.env.GSD_WORKFLOW_PATH ?? join(process.env.HOME ?? "~", ".pi", "GSD-WORKFLOW.md");


### PR DESCRIPTION
## Summary
- Removes the local `projectRoot()` function from `commands-handlers.ts` (identical duplicate of the exported version in `commands.ts`)
- Replaces it with an import from `./commands.js`
- Drops the now-unused `resolveProjectRoot` and `assertSafeDirectory` imports

## Test plan
- [x] `npx tsc --noEmit` passes with zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)