### PR TITLE
fix: complete shared barrel exports and add import-claude to help text

### DIFF
--- a/src/resources/extensions/gsd/commands.ts
+++ b/src/resources/extensions/gsd/commands.ts
@@ -846,7 +846,7 @@ function showHelp(ctx: ExtensionCommandContext): void {
     "  /gsd init           Project init wizard — detect, configure, bootstrap .gsd/",
     "  /gsd setup          Global setup status  [llm|search|remote|keys|prefs]",
     "  /gsd mode           Set workflow mode (solo/team)  [global|project]",
-    "  /gsd prefs          Manage preferences  [global|project|status|wizard|setup]",
+    "  /gsd prefs          Manage preferences  [global|project|status|wizard|setup|import-claude]",
     "  /gsd config         Set API keys for external tools",
     "  /gsd keys           API key manager  [list|add|remove|test|rotate|doctor]",
     "  /gsd hooks          Show post-unit hook configuration",

--- a/src/resources/extensions/shared/mod.ts
+++ b/src/resources/extensions/shared/mod.ts
@@ -28,3 +28,6 @@ export { showInterviewRound } from "./interview-ui.js";
 export type { Question, QuestionOption, RoundResult } from "./interview-ui.js";
 export { showNextAction } from "./next-action-ui.js";
 export { showConfirm } from "./confirm-ui.js";
+export { sanitizeError } from "./sanitize.js";
+export { formatDateShort, truncateWithEllipsis } from "./format-utils.js";
+export { splitFrontmatter, parseFrontmatterMap } from "./frontmatter.js";


### PR DESCRIPTION
## Summary
- Adds missing re-exports to `shared/mod.ts`: `sanitizeError`, `formatDateShort`, `truncateWithEllipsis`, `splitFrontmatter`, `parseFrontmatterMap`
- Adds `import-claude` to the `/gsd prefs` help text bracketed options so the subcommand is discoverable

## Test plan
- [x] `npx tsc --noEmit` passes with no errors
- [ ] Verify `/gsd help` shows `import-claude` in the prefs line
- [ ] Verify consumers importing from `shared/mod.js` can access the newly exported symbols

🤖 Generated with [Claude Code](https://claude.com/claude-code)