### PR TITLE
fix: broaden unit-runtime path sanitization

### DIFF
--- a/src/resources/extensions/gsd/unit-runtime.ts
+++ b/src/resources/extensions/gsd/unit-runtime.ts
@@ -51,8 +51,8 @@ function runtimeDir(basePath: string): string {
 }
 
 function runtimePath(basePath: string, unitType: string, unitId: string): string {
-  const sanitizedUnitType = unitType.replace(/[\/]/g, "-");
-  const sanitizedUnitId = unitId.replace(/[\/]/g, "-");
+  const sanitizedUnitType = unitType.replace(/[^a-zA-Z0-9._-]+/g, "-");
+  const sanitizedUnitId = unitId.replace(/[^a-zA-Z0-9._-]+/g, "-");
   return join(runtimeDir(basePath), `${sanitizedUnitType}-${sanitizedUnitId}.json`);
 }
 


### PR DESCRIPTION
## Summary
- Replace narrow `/`-only regex in `unit-runtime.ts` `runtimePath()` with `[^a-zA-Z0-9._-]+`, matching the `sanitizeArtifactName()` pattern used elsewhere in the codebase
- Prevents filesystem path breakage from characters like `:`, `|`, `*`, `?`, `<`, `>`, `"`, `\`

## Test plan
- [x] `npx tsc --noEmit` passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)