### PR TITLE
feat: add searchExcludeDirs setting for @ file autocomplete blacklist

### DIFF
--- a/packages/pi-coding-agent/src/core/settings-manager.ts
+++ b/packages/pi-coding-agent/src/core/settings-manager.ts
@@ -141,6 +141,7 @@ export interface Settings {
 	editorPaddingX?: number; // Horizontal padding for input editor (default: 0)
 	autocompleteMaxVisible?: number; // Max visible items in autocomplete dropdown (default: 5)
 	respectGitignoreInPicker?: boolean; // When false, @ file picker shows gitignored files (default: true)
+	searchExcludeDirs?: string[]; // Directories to exclude from @ file search (e.g., ["node_modules", ".git", "dist"])
 	showHardwareCursor?: boolean; // Show terminal cursor while still positioning it for IME
 	markdown?: MarkdownSettings;
 	memory?: MemorySettings;
@@ -1038,6 +1039,16 @@ export class SettingsManager {
 	setRespectGitignoreInPicker(value: boolean): void {
 		this.globalSettings.respectGitignoreInPicker = value;
 		this.markModified("respectGitignoreInPicker");
+		this.save();
+	}
+
+	getSearchExcludeDirs(): string[] {
+		return this.settings.searchExcludeDirs ?? [];
+	}
+
+	setSearchExcludeDirs(dirs: string[]): void {
+		this.globalSettings.searchExcludeDirs = dirs.filter(Boolean);
+		this.markModified("searchExcludeDirs");
 		this.save();
 	}
 

--- a/packages/pi-coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/interactive-mode.ts
@@ -367,7 +367,10 @@ export class InteractiveMode {
 		this.autocompleteProvider = new CombinedAutocompleteProvider(
 			[...slashCommands, ...templateCommands, ...extensionCommands, ...skillCommandList],
 			process.cwd(),
-			{ respectGitignore: this.settingsManager.getRespectGitignoreInPicker() },
+			{
+				respectGitignore: this.settingsManager.getRespectGitignoreInPicker(),
+				excludeDirs: this.settingsManager.getSearchExcludeDirs(),
+			},
 		);
 		this.defaultEditor.setAutocompleteProvider(this.autocompleteProvider);
 		if (this.editor !== this.defaultEditor) {

--- a/packages/pi-tui/src/autocomplete.ts
+++ b/packages/pi-tui/src/autocomplete.ts
@@ -131,19 +131,25 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 	private commands: (SlashCommand | AutocompleteItem)[];
 	private basePath: string;
 	private respectGitignore: boolean;
+	private excludeDirs: Set<string>;
 
 	constructor(
 		commands: (SlashCommand | AutocompleteItem)[] = [],
 		basePath: string = process.cwd(),
-		options?: { respectGitignore?: boolean },
+		options?: { respectGitignore?: boolean; excludeDirs?: string[] },
 	) {
 		this.commands = commands;
 		this.basePath = basePath;
 		this.respectGitignore = options?.respectGitignore ?? true;
+		this.excludeDirs = new Set(options?.excludeDirs ?? []);
 	}
 
 	setRespectGitignore(value: boolean): void {
 		this.respectGitignore = value;
+	}
+
+	setExcludeDirs(dirs: string[]): void {
+		this.excludeDirs = new Set(dirs.filter(Boolean));
 	}
 
 	getSuggestions(
@@ -485,6 +491,11 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 					continue;
 				}
 
+				// Skip excluded directories
+				if (this.excludeDirs.has(entry.name)) {
+					continue;
+				}
+
 				// Check if entry is a directory (or a symlink pointing to a directory)
 				let isDirectory = entry.isDirectory();
 				if (!isDirectory && entry.isSymbolicLink()) {
@@ -578,6 +589,13 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 			for (const { path: entryPath, isDirectory } of result.matches) {
 				// Native module includes trailing / for directories
 				const pathWithoutSlash = isDirectory ? entryPath.slice(0, -1) : entryPath;
+
+				// Skip paths that start with or contain an excluded directory
+				if (this.excludeDirs.size > 0) {
+					const segments = pathWithoutSlash.split("/");
+					if (segments.some(seg => this.excludeDirs.has(seg))) continue;
+				}
+
 				const displayPath = scopedQuery
 					? this.scopedPathForDisplay(scopedQuery.displayBase, pathWithoutSlash)
 					: pathWithoutSlash;


### PR DESCRIPTION
## Background

Issue #660 implemented the `@` file autocomplete investigation (items 1-2) but left items 3-5 incomplete — the configurable directory blacklist was never wired up. #1190 asked about this.

## Feature

Users can now exclude directories from the `@` file picker via `~/.gsd/agent/settings.json`:

```json
{
  "searchExcludeDirs": ["node_modules", ".git", "dist", "build", "vendor"]
}
```

Excluded directories are filtered from both:
- **readdir-based autocomplete** (Tab completion, path prefix matching) — skipped during entry enumeration
- **Native fuzzy search** (`@query`) — filtered from results by checking path segments

The native `fd` fuzzy search already respects `.gitignore`. This setting covers directories that aren't gitignored but shouldn't clutter autocomplete (e.g., large vendor dirs, build outputs, data directories).

## Changes

| File | Change |
|------|--------|
| `packages/pi-coding-agent/src/core/settings-manager.ts` | Added `searchExcludeDirs` setting with `get`/`set` methods |
| `packages/pi-tui/src/autocomplete.ts` | `CombinedAutocompleteProvider` accepts `excludeDirs`, filters in both search paths |
| `packages/pi-coding-agent/src/modes/interactive/interactive-mode.ts` | Passes `searchExcludeDirs` to provider constructor |

## Verification

- `tsc --noEmit` passes
- 1729 unit tests pass

Closes #1190
Completes #660 (items 3-4)
