### PR TITLE
refactor: remove commands.ts re-exports

### DIFF
--- a/src/resources/extensions/gsd/commands.ts
+++ b/src/resources/extensions/gsd/commands.ts
@@ -45,12 +45,6 @@ import { handleCleanupBranches, handleCleanupSnapshots, handleSkip, handleDryRun
 import { handleDoctor, handleSteer, handleCapture, handleTriage, handleKnowledge, handleRunHook, handleUpdate, handleSkillHealth } from "./commands-handlers.js";
 import { handleLogs } from "./commands-logs.js";
 
-// ─── Re-exports (preserve public API surface) ───────────────────────────────
-export { handlePrefs, handlePrefsMode, handlePrefsWizard, ensurePreferencesFile, handleImportClaude, buildCategorySummaries, serializePreferencesToFrontmatter, yamlSafeString, configureMode } from "./commands-prefs-wizard.js";
-export { TOOL_KEYS, loadToolApiKeys, getConfigAuthStorage, handleConfig } from "./commands-config.js";
-export { type InspectData, formatInspectOutput, handleInspect } from "./commands-inspect.js";
-export { handleCleanupBranches, handleCleanupSnapshots, handleSkip, handleDryRun } from "./commands-maintenance.js";
-export { handleDoctor, handleSteer, handleCapture, handleTriage, handleKnowledge, handleRunHook, handleUpdate, handleSkillHealth } from "./commands-handlers.js";
 
 export function dispatchDoctorHeal(pi: ExtensionAPI, scope: string | undefined, reportText: string, structuredIssues: string): void {
   const workflowPath = process.env.GSD_WORKFLOW_PATH ?? join(process.env.HOME ?? "~", ".pi", "GSD-WORKFLOW.md");

--- a/src/resources/extensions/gsd/index.ts
+++ b/src/resources/extensions/gsd/index.ts
@@ -27,7 +27,8 @@ import { createBashTool, createWriteTool, createReadTool, createEditTool, isTool
 import { Type } from "@sinclair/typebox";
 
 import { debugLog, debugTime } from "./debug-logger.js";
-import { registerGSDCommand, loadToolApiKeys } from "./commands.js";
+import { registerGSDCommand } from "./commands.js";
+import { loadToolApiKeys } from "./commands-config.js";
 import { registerExitCommand } from "./exit-command.js";
 import { registerWorktreeCommand, getWorktreeOriginalCwd, getActiveWorktreeName } from "./worktree-command.js";
 import { getActiveAutoWorktreeContext } from "./auto-worktree.js";

--- a/src/resources/extensions/gsd/tests/gsd-inspect.test.ts
+++ b/src/resources/extensions/gsd/tests/gsd-inspect.test.ts
@@ -3,7 +3,7 @@
 // Tests the pure formatInspectOutput function with known data.
 
 import { createTestContext } from './test-helpers.ts';
-import { formatInspectOutput, type InspectData } from '../commands.ts';
+import { formatInspectOutput, type InspectData } from '../commands-inspect.ts';
 
 const { assertEq, assertTrue, assertMatch, report } = createTestContext();
 


### PR DESCRIPTION
## Summary
- Remove the 5 re-export lines from `commands.ts` that forwarded symbols from submodules (`commands-config`, `commands-inspect`, `commands-maintenance`, `commands-handlers`, `commands-prefs-wizard`)
- Update `index.ts` to import `loadToolApiKeys` directly from `commands-config.js`
- Update `gsd-inspect.test.ts` to import `InspectData`/`formatInspectOutput` directly from `commands-inspect.ts`

## Test plan
- [x] `npx tsc --noEmit` passes with zero errors
- [x] `gsd-inspect.test.ts` — 32/32 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)