### PR TITLE
fix(ci): add npm publish to prod-release and prevent mid-deploy cancellation

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -8,7 +8,7 @@ on:
 
 concurrency:
   group: pipeline-${{ github.sha }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 permissions:
   contents: write
@@ -167,6 +167,23 @@ jobs:
           git tag "v${{ steps.release.outputs.version }}"
           git push origin main
           git push origin "v${{ steps.release.outputs.version }}"
+
+      - name: Build release
+        run: npm run build
+
+      - name: Publish release to npm @latest
+        run: |
+          OUTPUT=$(npm publish 2>&1) && echo "$OUTPUT" || {
+            if echo "$OUTPUT" | grep -q "cannot publish over the previously published"; then
+              echo "Version already published — promoting to latest"
+              npm dist-tag add gsd-pi@${{ steps.release.outputs.version }} latest
+            else
+              echo "$OUTPUT"
+              exit 1
+            fi
+          }
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Create GitHub Release
         env:


### PR DESCRIPTION
## Problems

### 1. No npm publish in prod-release

The recent pipeline refactor (changelog/versioning automation) removed the `npm dist-tag add ... latest` step from prod-release and replaced it with version bumping + git tagging. But it never publishes the bumped version to npm.

Current flow:
- dev-publish: `npm publish --tag dev` → `2.28.0-dev.abc123` on npm
- test-verify: promotes to `@next`
- prod-release: bumps to `2.29.0` in git, tags, pushes — **but never publishes `2.29.0` to npm**

Users running `npm install -g gsd-pi` get the old `@latest` version indefinitely.

### 2. cancel-in-progress: true on deployment pipeline

The concurrency group was set to `cancel-in-progress: true`. If a new push to main arrives while prod-release is mid-deploy (publishing to npm, pushing Docker images), the running job gets cancelled. This can leave npm in a partially-published state.

## Fix

1. Added `Build release` and `Publish release to npm @latest` steps after `Commit, tag, and push` and before `Create GitHub Release`. Includes idempotent guard for already-published versions.

2. Changed `cancel-in-progress` back to `false`.

## Pipeline Flow (after fix)

```
dev-publish → test-verify → prod-release
                              ├─ Generate changelog
                              ├─ Bump version
                              ├─ Commit + tag + push
                              ├─ Build release        ← NEW
                              ├─ Publish to npm @latest ← NEW
                              ├─ Create GitHub Release
                              ├─ Post to Discord
                              └─ Tag Docker image
```
