### PR TITLE
refactor: remove facade re-exports from auto.ts

### DIFF
--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -22,7 +22,6 @@ import { loadFile, getManifestStatus, resolveAllOverrides, parsePlan, parseSumma
 import { loadPrompt } from "./prompt-loader.js";
 import { runVerificationGate, formatFailureContext, captureRuntimeErrors, runDependencyAudit } from "./verification-gate.js";
 import { writeVerificationJSON } from "./verification-evidence.js";
-export { inlinePriorMilestoneSummary } from "./files.js";
 import { collectSecretsFromManifest } from "../get-secrets-from-user.js";
 import {
   gsdRoot, resolveMilestoneFile, resolveSliceFile, resolveSlicePath,
@@ -192,12 +191,6 @@ import {
   NEW_SESSION_TIMEOUT_MS, DISPATCH_HANG_TIMEOUT_MS,
 } from "./auto/session.js";
 import type { CompletedUnit, CurrentUnit, UnitRouting, StartModel, PendingVerificationRetry } from "./auto/session.js";
-export {
-  MAX_UNIT_DISPATCHES, STUB_RECOVERY_THRESHOLD, MAX_LIFETIME_DISPATCHES,
-  MAX_CONSECUTIVE_SKIPS, DISPATCH_GAP_TIMEOUT_MS, MAX_SKIP_DEPTH,
-  NEW_SESSION_TIMEOUT_MS, DISPATCH_HANG_TIMEOUT_MS,
-} from "./auto/session.js";
-export type { CompletedUnit, CurrentUnit, UnitRouting, StartModel } from "./auto/session.js";
 
 // ── ENCAPSULATION INVARIANT ─────────────────────────────────────────────────
 // ALL mutable auto-mode state lives in the AutoSession class (auto/session.ts).
@@ -268,8 +261,6 @@ export function shouldUseWorktreeIsolation(): boolean {
  * Maps toolCallId → start timestamp (ms) so the idle watchdog can detect tools that have been
  * running suspiciously long (e.g., a Bash command hung because `&` kept stdout open).
  */
-// Re-export budget utilities for external consumers
-export { getBudgetAlertLevel, getNewBudgetAlertLevel, getBudgetEnforcementAction } from "./auto-budget.js";
 
 /** Wrapper: register SIGTERM handler and store reference. */
 function registerSigtermHandler(currentBasePath: string): void {
@@ -281,8 +272,6 @@ function deregisterSigtermHandler(): void {
   _deregisterSigtermHandler(s.sigtermHandler);
   s.sigtermHandler = null;
 }
-
-export { type AutoDashboardData } from "./auto-dashboard.js";
 
 export function getAutoDashboardData(): AutoDashboardData {
   const ledger = getLedger();
@@ -934,8 +923,6 @@ async function showStepWizard(
   }
 }
 
-// describeNextUnit is imported from auto-dashboard.ts and re-exported
-export { describeNextUnit } from "./auto-dashboard.js";
 
 /** Thin wrapper: delegates to auto-dashboard.ts, passing state accessors. */
 function updateProgressWidget(
@@ -1905,5 +1892,3 @@ export async function dispatchHookUnit(
 }
 
 
-// Direct phase dispatch → auto-direct-dispatch.ts
-export { dispatchDirectPhase } from "./auto-direct-dispatch.js";

--- a/src/resources/extensions/gsd/commands.ts
+++ b/src/resources/extensions/gsd/commands.ts
@@ -13,7 +13,8 @@ import { deriveState } from "./state.js";
 import { GSDDashboardOverlay } from "./dashboard-overlay.js";
 import { GSDVisualizerOverlay } from "./visualizer-overlay.js";
 import { showQueue, showDiscuss, showHeadlessMilestoneCreation } from "./guided-flow.js";
-import { startAuto, stopAuto, pauseAuto, isAutoActive, isAutoPaused, isStepMode, stopAutoRemote, dispatchDirectPhase } from "./auto.js";
+import { startAuto, stopAuto, pauseAuto, isAutoActive, isAutoPaused, isStepMode, stopAutoRemote } from "./auto.js";
+import { dispatchDirectPhase } from "./auto-direct-dispatch.js";
 import { resolveProjectRoot } from "./worktree.js";
 import { assertSafeDirectory } from "./validate-directory.js";
 import {

--- a/src/resources/extensions/gsd/dashboard-overlay.ts
+++ b/src/resources/extensions/gsd/dashboard-overlay.ts
@@ -11,7 +11,8 @@ import { truncateToWidth, visibleWidth, matchesKey, Key } from "@gsd/pi-tui";
 import { deriveState } from "./state.js";
 import { loadFile, parseRoadmap, parsePlan } from "./files.js";
 import { resolveMilestoneFile, resolveSliceFile } from "./paths.js";
-import { getAutoDashboardData, type AutoDashboardData } from "./auto.js";
+import { getAutoDashboardData } from "./auto.js";
+import type { AutoDashboardData } from "./auto-dashboard.js";
 import {
   getLedger, getProjectTotals, aggregateByPhase, aggregateBySlice,
   aggregateByModel, aggregateCacheHitRate, formatCost, formatTokenCount, formatCostProjection,

--- a/src/resources/extensions/gsd/tests/auto-budget-alerts.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-budget-alerts.test.ts
@@ -5,7 +5,7 @@ import {
   getBudgetAlertLevel,
   getBudgetEnforcementAction,
   getNewBudgetAlertLevel,
-} from "../auto.js";
+} from "../auto-budget.js";
 
 test("getBudgetAlertLevel returns the expected threshold bucket", () => {
   assert.equal(getBudgetAlertLevel(0.10), 0);

--- a/src/resources/extensions/gsd/tests/auto-skip-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-skip-loop.test.ts
@@ -17,8 +17,8 @@ import { tmpdir } from "node:os";
 import {
   _getUnitConsecutiveSkips,
   _resetUnitConsecutiveSkips,
-  MAX_CONSECUTIVE_SKIPS,
 } from "../auto.ts";
+import { MAX_CONSECUTIVE_SKIPS } from "../auto/session.ts";
 import { persistCompletedKey, removePersistedKey, loadPersistedKeys } from "../auto-recovery.ts";
 import { createTestContext } from "./test-helpers.ts";
 

--- a/src/resources/extensions/gsd/tests/parallel-workers-multi-milestone-e2e.test.ts
+++ b/src/resources/extensions/gsd/tests/parallel-workers-multi-milestone-e2e.test.ts
@@ -30,7 +30,7 @@ import {
   getBudgetAlertLevel,
   getNewBudgetAlertLevel,
   getBudgetEnforcementAction,
-} from '../auto.ts';
+} from '../auto-budget.ts';
 import {
   type UnitMetrics,
   type MetricsLedger,


### PR DESCRIPTION
## Summary
- Removed 6 re-export lines from `auto.ts` that forwarded symbols from `files.js`, `auto/session.js`, `auto-budget.js`, `auto-dashboard.js`, and `auto-direct-dispatch.js`
- Updated 5 import sites (`commands.ts`, `dashboard-overlay.ts`, and 3 test files) to import directly from source modules
- `auto.ts` no longer acts as a facade for unrelated modules — callers import from where symbols are defined

## Test plan
- [x] `npx tsc --noEmit` passes with zero errors
- [x] Verified no remaining `export { ... } from "..."` re-export lines in `auto.ts`
- [x] All redirected imports point to the correct source modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)