### PR TITLE
fix: kill non-persistent bg processes between auto-mode units

### DIFF
--- a/src/resources/extensions/bg-shell/process-manager.ts
+++ b/src/resources/extensions/bg-shell/process-manager.ts
@@ -375,6 +375,19 @@ export function cleanupAll(): void {
 	processes.clear();
 }
 
+/**
+ * Kill all alive, non-persistent bg processes.
+ * Called between auto-mode units to prevent orphaned servers from
+ * keeping ports bound across task boundaries (#1209).
+ */
+export function killSessionProcesses(): void {
+	for (const [id, bg] of processes) {
+		if (bg.alive && !bg.persistAcrossSessions) {
+			killProcess(id, "SIGTERM");
+		}
+	}
+}
+
 async function waitForProcessExit(bg: BgProcess, timeoutMs: number): Promise<boolean> {
 	if (!bg.alive) return true;
 	await new Promise<void>((resolve) => {

--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -202,10 +202,13 @@ export async function postUnitPreVerification(pctx: PostUnitContext): Promise<"d
       }
     }
 
-    // Prune dead bg-shell processes
+    // Prune dead bg-shell processes and kill non-persistent live ones.
+    // Without killing live processes between units, dev servers spawned during
+    // one task keep ports bound, causing conflicts in subsequent tasks (#1209).
     try {
-      const { pruneDeadProcesses } = await import("../bg-shell/process-manager.js");
+      const { pruneDeadProcesses, killSessionProcesses } = await import("../bg-shell/process-manager.js");
       pruneDeadProcesses();
+      killSessionProcesses();
     } catch {
       // Non-fatal
     }


### PR DESCRIPTION
## Problem

Background processes spawned during auto-mode tasks (e.g., Vite dev servers for browser verification) were not cleaned up between units. `pruneDeadProcesses()` only removes dead process entries from the registry — it doesn't kill live processes.

The orphaned server keeps ports bound, causing the next unit's dev server to fail. This led to:
- 12 stuck-loop anomalies across multiple milestones
- 3.5x-4.8x cost spikes from timeout recovery retries
- Port conflicts on subsequent task launches

## Fix

Added `killSessionProcesses()` to `bg-shell/process-manager.ts`:
- Iterates all processes in the registry
- Sends `SIGTERM` to alive, non-persistent processes
- Preserves processes with `persistAcrossSessions: true`

Called in `auto-post-unit.ts` after `pruneDeadProcesses()`, so both dead cleanup and live termination happen between every unit.

## Verification

- `tsc --noEmit` passes
- 1743 unit tests pass

Fixes #1209
