### PR TITLE
feat(prefs): two-step provider→model picker

### DIFF
--- a/src/resources/extensions/gsd/commands-prefs-wizard.ts
+++ b/src/resources/extensions/gsd/commands-prefs-wizard.ts
@@ -260,27 +260,57 @@ async function configureModels(ctx: ExtensionCommandContext, prefs: Record<strin
       group.push(m);
     }
     const providers = Array.from(byProvider.keys()).sort((a, b) => a.localeCompare(b));
-
-    const modelOptions: string[] = [];
-    for (const provider of providers) {
-      const group = byProvider.get(provider)!;
-      modelOptions.push(`─── ${provider} (${group.length}) ───`);
-      for (const m of group) {
-        modelOptions.push(`${m.id} · ${m.provider}`);
-      }
+    // Sort models within each provider
+    for (const group of byProvider.values()) {
+      group.sort((a, b) => a.id.localeCompare(b.id));
     }
-    modelOptions.push("(keep current)", "(clear)");
+
+    // Build provider menu with model counts
+    const providerOptions = providers.map(p => {
+      const count = byProvider.get(p)!.length;
+      return `${p} (${count} models)`;
+    });
+    providerOptions.push("(keep current)", "(clear)", "(type manually)");
 
     for (const phase of modelPhases) {
       const current = models[phase] ?? "";
-      const title = `Model for ${phase} phase${current ? ` (current: ${current})` : ""}:`;
-      const choice = await ctx.ui.select(title, modelOptions);
+      const phaseLabel = `Model for ${phase} phase${current ? ` (current: ${current})` : ""}`;
 
-      if (choice && typeof choice === "string" && choice !== "(keep current)") {
-        if (choice === "(clear)") {
+      // Step 1: pick provider
+      const providerChoice = await ctx.ui.select(`${phaseLabel} — choose provider:`, providerOptions);
+      if (!providerChoice || typeof providerChoice !== "string" || providerChoice === "(keep current)") continue;
+
+      if (providerChoice === "(clear)") {
+        delete models[phase];
+        continue;
+      }
+
+      if (providerChoice === "(type manually)") {
+        const input = await ctx.ui.input(
+          `${phaseLabel} — enter model ID:`,
+          current || "e.g. claude-sonnet-4-20250514",
+        );
+        if (input !== null && input !== undefined) {
+          const val = input.trim();
+          if (val) models[phase] = val;
+        }
+        continue;
+      }
+
+      // Step 2: pick model within provider
+      const providerName = providerChoice.replace(/ \(\d+ models?\)$/, "");
+      const group = byProvider.get(providerName);
+      if (!group) continue;
+
+      const modelOptions = group.map(m => m.id);
+      modelOptions.push("(keep current)", "(clear)");
+
+      const modelChoice = await ctx.ui.select(`${phaseLabel} — ${providerName}:`, modelOptions);
+      if (modelChoice && typeof modelChoice === "string" && modelChoice !== "(keep current)") {
+        if (modelChoice === "(clear)") {
           delete models[phase];
         } else {
-          models[phase] = choice.split(" · ")[0];
+          models[phase] = modelChoice;
         }
       }
     }

--- a/src/resources/extensions/gsd/tests/extension-selector-separator.test.ts
+++ b/src/resources/extensions/gsd/tests/extension-selector-separator.test.ts
@@ -1,4 +1,6 @@
-// Tests for the SEPARATOR_PREFIX convention used by ExtensionSelectorComponent.
+// Tests for the SEPARATOR_PREFIX convention used by ExtensionSelectorComponent
+// and the two-step provider→model picker in configureModels.
+//
 // We cannot import the component directly in node:test because its transitive
 // dependency (countdown-timer.ts) uses TypeScript parameter properties which
 // are unsupported under --experimental-strip-types. Instead we duplicate the
@@ -69,16 +71,17 @@ describe("separator detection", () => {
 	});
 });
 
-describe("model grouping", () => {
-	test("groups models by provider with separator headers", () => {
-		// Simulate the grouping logic from configureModels
-		const availableModels = [
-			{ id: "claude-opus-4-6", provider: "anthropic" },
-			{ id: "gpt-4o", provider: "openai" },
-			{ id: "claude-sonnet-4-5", provider: "anthropic" },
-			{ id: "o3-mini", provider: "openai" },
-		];
+describe("two-step provider→model picker", () => {
+	// Simulate the grouping logic from configureModels
+	const availableModels = [
+		{ id: "claude-opus-4-6", provider: "anthropic" },
+		{ id: "gpt-4o", provider: "openai" },
+		{ id: "claude-sonnet-4-5", provider: "anthropic" },
+		{ id: "o3-mini", provider: "openai" },
+		{ id: "claude-haiku-4-5", provider: "anthropic" },
+	];
 
+	function buildProviderGroups() {
 		const byProvider = new Map<string, typeof availableModels>();
 		for (const m of availableModels) {
 			let group = byProvider.get(m.provider);
@@ -89,34 +92,53 @@ describe("model grouping", () => {
 			group.push(m);
 		}
 		const providers = Array.from(byProvider.keys()).sort((a, b) => a.localeCompare(b));
-
-		const modelOptions: string[] = [];
-		for (const provider of providers) {
-			const group = byProvider.get(provider)!;
-			modelOptions.push(`${SEPARATOR_PREFIX} ${provider} (${group.length}) ${SEPARATOR_PREFIX}`);
-			for (const m of group) {
-				modelOptions.push(`${m.id} · ${m.provider}`);
-			}
+		for (const group of byProvider.values()) {
+			group.sort((a, b) => a.id.localeCompare(b.id));
 		}
-		modelOptions.push("(keep current)", "(clear)");
+		return { byProvider, providers };
+	}
 
-		// Verify structure
-		assert.strictEqual(modelOptions[0], `${SEPARATOR_PREFIX} anthropic (2) ${SEPARATOR_PREFIX}`);
-		assert.strictEqual(modelOptions[1], "claude-opus-4-6 · anthropic");
-		assert.strictEqual(modelOptions[2], "claude-sonnet-4-5 · anthropic");
-		assert.strictEqual(modelOptions[3], `${SEPARATOR_PREFIX} openai (2) ${SEPARATOR_PREFIX}`);
-		assert.strictEqual(modelOptions[4], "gpt-4o · openai");
-		assert.strictEqual(modelOptions[5], "o3-mini · openai");
-		assert.strictEqual(modelOptions[6], "(keep current)");
-		assert.strictEqual(modelOptions[7], "(clear)");
+	test("provider menu lists providers with model counts", () => {
+		const { providers, byProvider } = buildProviderGroups();
+		const providerOptions = providers.map(p => {
+			const count = byProvider.get(p)!.length;
+			return `${p} (${count} models)`;
+		});
+		providerOptions.push("(keep current)", "(clear)", "(type manually)");
 
-		// Verify separators are correctly detected
-		assert.ok(isSeparator(modelOptions, 0));
-		assert.ok(!isSeparator(modelOptions, 1));
-		assert.ok(isSeparator(modelOptions, 3));
-		assert.ok(!isSeparator(modelOptions, 6));
+		assert.strictEqual(providerOptions[0], "anthropic (3 models)");
+		assert.strictEqual(providerOptions[1], "openai (2 models)");
+		assert.strictEqual(providerOptions[2], "(keep current)");
+		assert.strictEqual(providerOptions[3], "(clear)");
+		assert.strictEqual(providerOptions[4], "(type manually)");
+	});
 
-		// Verify first selectable is index 1, not the separator at 0
-		assert.strictEqual(nextSelectable(modelOptions, 0, 1), 1);
+	test("model menu for a provider is sorted alphabetically", () => {
+		const { byProvider } = buildProviderGroups();
+		const anthropicModels = byProvider.get("anthropic")!;
+		const modelOptions = anthropicModels.map(m => m.id);
+
+		assert.strictEqual(modelOptions[0], "claude-haiku-4-5");
+		assert.strictEqual(modelOptions[1], "claude-opus-4-6");
+		assert.strictEqual(modelOptions[2], "claude-sonnet-4-5");
+	});
+
+	test("provider name is extracted correctly from choice string", () => {
+		const choice = "anthropic (3 models)";
+		const providerName = choice.replace(/ \(\d+ models?\)$/, "");
+		assert.strictEqual(providerName, "anthropic");
+
+		const singleChoice = "ollama (1 model)";
+		const singleProvider = singleChoice.replace(/ \(\d+ models?\)$/, "");
+		assert.strictEqual(singleProvider, "ollama");
+	});
+
+	test("openai models are sorted within their group", () => {
+		const { byProvider } = buildProviderGroups();
+		const openaiModels = byProvider.get("openai")!;
+		const modelOptions = openaiModels.map(m => m.id);
+
+		assert.strictEqual(modelOptions[0], "gpt-4o");
+		assert.strictEqual(modelOptions[1], "o3-mini");
 	});
 });


### PR DESCRIPTION
## Summary

- Replaces the flat single-list model selector in `/gsd prefs` with a two-step picker: **choose provider first**, then **choose model** within that provider
- Models within each provider group are now **sorted alphabetically** for easier scanning
- Adds a **"(type manually)"** option on the provider step for entering arbitrary model IDs (e.g. custom or discovered models not in the registry)
- Removes the old separator-based grouping approach which had a bug where selecting a separator line (`─── provider ───`) would be saved as the model ID

### Before
One long flat list with separator headers mixed in with selectable items:
```
─── anthropic (8) ───
claude-opus-4-6 · anthropic
claude-sonnet-4-5 · anthropic
─── openai (6) ───
gpt-4o · openai
...
(keep current)
(clear)
```

### After
**Step 1 — Pick provider:**
```
anthropic (8 models)
openai (6 models)
google (4 models)
(keep current)
(clear)
(type manually)
```

**Step 2 — Pick model (sorted alphabetically):**
```
claude-3-5-haiku-20241022
claude-haiku-4-5-20251001
claude-opus-4-6
claude-sonnet-4-20250514
claude-sonnet-4-5-20250929
(keep current)
(clear)
```

## Changes

- `commands-prefs-wizard.ts`: Rewrote `configureModels()` to use a two-step provider→model flow instead of a flat list with separator headers
- `extension-selector-separator.test.ts`: Updated tests to cover the new two-step picker logic (provider menu structure, alphabetical sorting, provider name extraction from choice strings)

## Test plan

- [x] All 1460 existing GSD tests pass (0 failures, 3 skipped)
- [x] 10/10 selector/picker tests pass including new two-step picker tests
- [x] Build passes cleanly
- [ ] Manual: run `/gsd prefs`, select Models, verify two-step flow works
- [ ] Manual: verify "(type manually)" allows entering arbitrary model IDs
- [ ] Manual: verify "(keep current)" and "(clear)" work at both provider and model steps