### PR TITLE
fix: replace ambiguous double-question in discussion reflection step

### DIFF
--- a/src/resources/extensions/gsd/prompts/guided-discuss-milestone.md
+++ b/src/resources/extensions/gsd/prompts/guided-discuss-milestone.md
@@ -91,7 +91,7 @@ Before moving to the wrap-up gate, verify you have covered:
 - options: "Yes, you got it (Recommended)", "Not quite — let me clarify"
 - **The question ID must contain `depth_verification`** (e.g. `depth_verification_confirm`) — this enables the write-gate downstream.
 
-**If `{{structuredQuestionsAvailable}}` is `false`:** ask in plain text: "Did I capture that correctly? Anything I missed?" Wait for confirmation before proceeding.
+**If `{{structuredQuestionsAvailable}}` is `false`:** ask in plain text: "Did I capture that correctly? If not, tell me what I missed." Wait for confirmation before proceeding.
 
 If they clarify, absorb the correction and re-verify.
 


### PR DESCRIPTION
## Problem

Follow-up to #963. The plain-text fallback for depth verification in `guided-discuss-milestone.md` asks:

> "Did I capture that correctly? Anything I missed?"

A "yes" answer is ambiguous — it could mean "yes, you got it" or "yes, you missed something." Same class of double-question that #963 fixed.

## Fix

Changed to:

> "Did I capture that correctly? If not, tell me what I missed."

One question, then an instruction. Matches the pattern established in #963 and used in `discuss.md`.

Fixes #1224
