### PR TITLE
fix: increase headless new-milestone timeout and limit investigation scope

### DIFF
--- a/src/headless.ts
+++ b/src/headless.ts
@@ -178,6 +178,11 @@ async function runHeadlessOnce(options: HeadlessOptions, restartCount: number): 
   const startTime = Date.now()
   const isNewMilestone = options.command === 'new-milestone'
 
+  // new-milestone involves codebase investigation + artifact writing — needs more time
+  if (isNewMilestone && options.timeout === 300_000) {
+    options.timeout = 600_000 // 10 minutes
+  }
+
   // Supervised mode cannot share stdin with --context -
   if (options.supervised && options.context === '-') {
     process.stderr.write('[headless] Error: --supervised cannot be used with --context - (both require stdin)\n')

--- a/src/resources/extensions/gsd/prompts/discuss-headless.md
+++ b/src/resources/extensions/gsd/prompts/discuss-headless.md
@@ -16,12 +16,14 @@ Summarize your understanding of the specification concretely:
 - Scope estimate (how many milestones × slices)
 - Any ambiguities or gaps you notice
 
-### Step 2: Investigate
+### Step 2: Investigate (brief)
 
-Scout the codebase to understand what already exists:
+Quickly scout the codebase to understand what already exists — spend no more than 5-6 tool calls here:
 - `ls` the project root and key directories
 - Search for relevant existing code, patterns, dependencies
 - Check library docs if needed (`resolve_library` / `get_library_docs`)
+
+Then move on to writing artifacts. Do not explore exhaustively — the research phase will do deeper investigation later.
 
 ### Step 3: Make Decisions
 


### PR DESCRIPTION
## Problem

`gsd headless new-milestone` times out at 300s. The LLM spends too many tool calls on exhaustive codebase investigation before writing artifacts, running out of time.

## Fix

1. **Timeout**: Bumped default from 300s → 600s for `new-milestone` (only when not explicitly overridden via `--timeout`)
2. **Prompt**: Added "brief" qualifier to the Investigate step with a 5-6 tool call budget, plus a note that the research phase handles deeper investigation later

The `commit_docs: false` preference is already correctly handled — the prompt says "Do not commit" and `ensureGitignore` is idempotent.

Fixes #1227
