### PR TITLE
fix: use shell: true for LSP spawn on Windows to resolve .cmd executables

### DIFF
--- a/packages/pi-coding-agent/src/core/lsp/client.ts
+++ b/packages/pi-coding-agent/src/core/lsp/client.ts
@@ -455,6 +455,9 @@ async function getOrCreateClientOnce(config: ServerConfig, cwd: string, initTime
 			cwd,
 			stdio: ["pipe", "pipe", "pipe"],
 			env: env ? { ...process.env, ...env } : undefined,
+			// On Windows, executables like npx/tsc are .cmd scripts that need
+			// shell resolution. Without this, spawn fails with ENOENT (#1222).
+			shell: process.platform === "win32",
 		});
 
 		// Handle spawn failure (e.g., ENOENT when the command doesn't exist).


### PR DESCRIPTION
## Problem

On Windows, the LSP client spawns language servers via `spawn(command, args)` without `shell: true`. Executables like `npx`, `tsc`, and `typescript-language-server` are `.cmd` batch scripts on Windows. Without shell resolution, `spawn` can't find them and fails with `ENOENT`, crashing auto-mode.

```
spawn npx ENOENT
spawnargs: [ 'tsc', '--noEmit' ]
```

This is the same class of issue as #901 but through the LSP spawn path rather than the typescript-language-server bootstrap.

## Fix

Added `shell: process.platform === "win32"` to the LSP client's `spawn()` options. This enables `.cmd` resolution on Windows while leaving Unix behavior unchanged.

## Verification

- `tsc --noEmit` passes

Fixes #1222
