### PR TITLE
fix: align react-best-practices skill name with directory name

### DIFF
--- a/src/resources/skills/react-best-practices/SKILL.md
+++ b/src/resources/skills/react-best-practices/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: vercel-react-best-practices
+name: react-best-practices
 description: React and Next.js performance optimization guidelines from Vercel Engineering. This skill should be used when writing, reviewing, or refactoring React/Next.js code to ensure optimal performance patterns. Triggers on tasks involving React components, Next.js pages, data fetching, bundle optimization, or performance improvements.
 license: MIT
 metadata:


### PR DESCRIPTION
## Summary

The bundled `react-best-practices` skill had a mismatch between its directory name and the `name` field in its `SKILL.md` frontmatter:

- **Directory:** `src/resources/skills/react-best-practices/`
- **`name` field:** `vercel-react-best-practices`

This triggers a validation warning on every startup:
```
[Skill issues]
  auto (user) ~/.gsd/agent/skills/react-best-practices/SKILL.md
    name "vercel-react-best-practices" does not match parent directory "react-best-practices"
```

The validation logic lives in `packages/pi-coding-agent/src/core/skills.ts:95` and requires the `name` field to match the parent directory name.

## Changes

- Updated `name` field in `src/resources/skills/react-best-practices/SKILL.md` from `vercel-react-best-practices` to `react-best-practices` to match the directory name

## Test plan

- [x] Verified this is the only skill with a name/directory mismatch (checked all skills in `src/resources/skills/`)
- [x] Build passes (`npm run build`)
- [ ] Confirm the startup warning no longer appears after reinstalling skills