### PR TITLE
fix: invalidate caches before roadmap check in /gsd discuss

### DIFF
--- a/src/resources/extensions/gsd/guided-flow.ts
+++ b/src/resources/extensions/gsd/guided-flow.ts
@@ -415,6 +415,9 @@ export async function showDiscuss(
     return;
   }
 
+  // Invalidate caches to pick up artifacts written by a just-completed discuss/plan
+  invalidateAllCaches();
+
   const state = await deriveState(basePath);
 
   // Guard: no active milestone


### PR DESCRIPTION
After milestone creation, file parse caches could hold stale results from before the ROADMAP was written. `/gsd discuss` checks for ROADMAP but hits the cache, gets null, and reports 'No roadmap yet' even though the file exists on disk.

Added `invalidateAllCaches()` at the top of `showDiscuss()`.

Fixes #1236