### PR TITLE
fix: invalidate caches inside discuss loop to detect newly written slice context

### DIFF
--- a/src/resources/extensions/gsd/guided-flow.ts
+++ b/src/resources/extensions/gsd/guided-flow.ts
@@ -504,6 +504,9 @@ export async function showDiscuss(
 
   // Loop: show picker, dispatch discuss, repeat until "not_yet"
   while (true) {
+    // Invalidate caches so we pick up CONTEXT files written by the just-completed discussion
+    invalidateAllCaches();
+
     // Build discussion-state map: which slices have CONTEXT files already?
     const discussedMap = new Map<string, boolean>();
     for (const s of pendingSlices) {


### PR DESCRIPTION
After discussing a slice, the discuss loop re-evaluates but hits stale caches, showing the slice as 'not discussed'. Added `invalidateAllCaches()` at the top of each loop iteration.

Fixes #1244