### PR TITLE
fix: clean up stranded .gsd.lock/ directory to prevent false lock conflicts

### DIFF
--- a/src/resources/extensions/gsd/session-lock.ts
+++ b/src/resources/extensions/gsd/session-lock.ts
@@ -92,11 +92,12 @@ export function acquireSessionLock(basePath: string): SessionLockResult {
     return acquireFallbackLock(basePath, lp, lockData);
   }
 
+  const gsdDir = gsdRoot(basePath);
+
   try {
     // Try to acquire an exclusive OS-level lock on the lock file.
     // We lock the directory (gsdRoot) since proper-lockfile works best
     // on directories, and the lock file itself may not exist yet.
-    const gsdDir = gsdRoot(basePath);
     mkdirSync(gsdDir, { recursive: true });
 
     const release = lockfile.lockSync(gsdDir, {


### PR DESCRIPTION
## Problem

After clean milestone completion, `.gsd.lock/` (proper-lockfile's OS-level lock directory) is left on disk even though `auto.lock` is correctly cleaned up. The next `/gsd auto` finds the stale directory and refuses to start: "Another auto-mode session is already running" — but no process exists.

## Fix

Three layers of defense:

1. **`releaseSessionLock`**: Now explicitly removes `.gsd.lock/` after releasing the OS lock
2. **`acquireSessionLock`**: When lock fails but no `auto.lock` exists or the owning PID is dead, auto-removes the stale `.gsd.lock/` and retries
3. **`process.on('exit')`**: Safety net registered at lock acquisition — cleans up on normal exit if `releaseSessionLock` wasn't called

## Verification

- `tsc --noEmit` passes

Fixes #1245
