### PR TITLE
feat: add aws-auth extension for automatic Bedrock credential refresh + retryLastTurn extension API

### DIFF
--- a/packages/pi-coding-agent/src/core/agent-session.ts
+++ b/packages/pi-coding-agent/src/core/agent-session.ts
@@ -2216,6 +2216,20 @@ export class AgentSession {
 						});
 					});
 				},
+				retryLastTurn: () => {
+					const messages = this.agent.state.messages;
+					const last = messages[messages.length - 1];
+					if (last?.role === "assistant" && (last as AssistantMessage).stopReason === "error") {
+						this.agent.replaceMessages(messages.slice(0, -1));
+						this.agent.continue().catch((err) => {
+							runner.emitError({
+								extensionPath: "<runtime>",
+								event: "retry_last_turn",
+								error: err instanceof Error ? err.message : String(err),
+							});
+						});
+					}
+				},
 				appendEntry: (customType, data) => {
 					this.sessionManager.appendCustomEntry(customType, data);
 				},

--- a/packages/pi-coding-agent/src/core/extensions/loader.ts
+++ b/packages/pi-coding-agent/src/core/extensions/loader.ts
@@ -144,6 +144,7 @@ export function createExtensionRuntime(): ExtensionRuntime {
 	const runtime: ExtensionRuntime = {
 		sendMessage: notInitialized,
 		sendUserMessage: notInitialized,
+		retryLastTurn: notInitialized,
 		appendEntry: notInitialized,
 		setSessionName: notInitialized,
 		getSessionName: notInitialized,
@@ -240,6 +241,10 @@ function createExtensionAPI(
 
 		sendUserMessage(content, options): void {
 			runtime.sendUserMessage(content, options);
+		},
+
+		retryLastTurn(): void {
+			runtime.retryLastTurn();
 		},
 
 		appendEntry(customType: string, data?: unknown): void {

--- a/packages/pi-coding-agent/src/core/extensions/runner.ts
+++ b/packages/pi-coding-agent/src/core/extensions/runner.ts
@@ -249,6 +249,7 @@ export class ExtensionRunner {
 		// Copy actions into the shared runtime (all extension APIs reference this)
 		this.runtime.sendMessage = actions.sendMessage;
 		this.runtime.sendUserMessage = actions.sendUserMessage;
+		this.runtime.retryLastTurn = actions.retryLastTurn;
 		this.runtime.appendEntry = actions.appendEntry;
 		this.runtime.setSessionName = actions.setSessionName;
 		this.runtime.getSessionName = actions.getSessionName;

--- a/packages/pi-coding-agent/src/core/extensions/types.ts
+++ b/packages/pi-coding-agent/src/core/extensions/types.ts
@@ -1058,6 +1058,13 @@ export interface ExtensionAPI {
 		options?: { deliverAs?: "steer" | "followUp" },
 	): void;
 
+	/**
+	 * Retry the last turn by removing the failed assistant response and
+	 * re-running the agent from the last user message. No-op if the last
+	 * message is not an assistant error.
+	 */
+	retryLastTurn(): void;
+
 	/** Append a custom entry to the session for state persistence (not sent to LLM). */
 	appendEntry<T = unknown>(customType: string, data?: T): void;
 
@@ -1329,6 +1336,7 @@ export interface ExtensionRuntimeState {
 export interface ExtensionActions {
 	sendMessage: SendMessageHandler;
 	sendUserMessage: SendUserMessageHandler;
+	retryLastTurn: () => void;
 	appendEntry: AppendEntryHandler;
 	setSessionName: SetSessionNameHandler;
 	getSessionName: GetSessionNameHandler;

--- a/src/resources/extensions/aws-auth/index.ts
+++ b/src/resources/extensions/aws-auth/index.ts
@@ -1,0 +1,144 @@
+/**
+ * AWS Auth Refresh Extension
+ *
+ * Automatically refreshes AWS credentials when Bedrock API requests fail
+ * with authentication/token errors, then retries the user's message.
+ *
+ * ## How it works
+ *
+ * Hooks into `agent_end` to check if the last assistant message failed with
+ * an AWS auth error (expired SSO token, missing credentials, etc.). If so:
+ *
+ *   1. Runs the configured `awsAuthRefresh` command (e.g. `aws sso login`)
+ *   2. Streams the SSO auth URL and verification code to the TUI so users
+ *      can copy/paste if the browser doesn't auto-open
+ *   3. Calls `retryLastTurn()` which removes the failed assistant response
+ *      and re-runs the agent from the user's original message
+ *
+ * ## Activation
+ *
+ * This extension is completely inert unless BOTH conditions are met:
+ *   1. A Bedrock API request fails with a recognized AWS auth error
+ *   2. `awsAuthRefresh` is configured in settings.json
+ *
+ * Non-Bedrock users and Bedrock users without `awsAuthRefresh` configured
+ * are not affected in any way.
+ *
+ * ## Setup
+ *
+ * Add to ~/.gsd/agent/settings.json (or project-level .gsd/settings.json):
+ *
+ *   { "awsAuthRefresh": "aws sso login --profile my-profile" }
+ *
+ * ## Matched error patterns
+ *
+ * The extension recognizes errors from the AWS SDK, Bedrock, and SSO
+ * credential providers including:
+ *   - ExpiredTokenException / ExpiredToken
+ *   - The security token included in the request is expired
+ *   - The SSO session associated with this profile has expired or is invalid
+ *   - Unable to locate credentials / Could not load credentials
+ *   - UnrecognizedClientException
+ *   - Error loading SSO Token / Token does not exist
+ *   - SSOTokenProviderFailure
+ */
+
+import { exec } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+import type { ExtensionAPI } from "@gsd/pi-coding-agent";
+
+/** Matches AWS SDK / Bedrock / SSO credential and token errors. */
+const AWS_AUTH_ERROR_RE =
+	/ExpiredToken|security token.*expired|unable to locate credentials|SSO.*(?:session|token).*(?:expired|not found|invalid)|UnrecognizedClient|Could not load credentials|Invalid identity token|token is expired|credentials.*(?:could not|cannot|failed to).*(?:load|resolve|find)|The.*token.*is.*not.*valid|token has expired|SSOTokenProviderFailure|Error loading SSO Token|Token.*does not exist/i;
+
+/**
+ * Reads the `awsAuthRefresh` command from settings.json.
+ * Checks project-level first, then global (~/.gsd/agent/settings.json).
+ */
+function getAwsAuthRefreshCommand(): string | undefined {
+	const configDir = process.env.PI_CONFIG_DIR || ".gsd";
+	const paths = [
+		join(process.cwd(), configDir, "settings.json"),
+		join(homedir(), configDir, "agent", "settings.json"),
+	];
+	for (const settingsPath of paths) {
+		if (!existsSync(settingsPath)) continue;
+		try {
+			const settings = JSON.parse(readFileSync(settingsPath, "utf-8"));
+			if (settings.awsAuthRefresh) return settings.awsAuthRefresh;
+		} catch {}
+	}
+	return undefined;
+}
+
+/**
+ * Runs the refresh command with a 2-minute timeout (for SSO browser flows).
+ * Streams stdout/stderr to capture and display the SSO auth URL and
+ * verification code in real-time via TUI notifications.
+ */
+async function runRefresh(
+	command: string,
+	notify: (msg: string, level: "info" | "warning" | "error") => void,
+): Promise<boolean> {
+	notify("Refreshing AWS credentials...", "info");
+	try {
+		await new Promise<void>((resolve, reject) => {
+			const child = exec(command, { timeout: 120_000, env: { ...process.env } });
+			const onData = (data: Buffer | string) => {
+				const text = data.toString();
+				const urlMatch = text.match(/https?:\/\/\S+/);
+				if (urlMatch) {
+					notify(`Open this URL if the browser didn't launch: ${urlMatch[0]}`, "warning");
+				}
+				const codeMatch = text.match(/code[:\s]+([A-Z]{4}-[A-Z]{4})/i);
+				if (codeMatch) {
+					notify(`Verification code: ${codeMatch[1]}`, "info");
+				}
+			};
+			child.stdout?.on("data", onData);
+			child.stderr?.on("data", onData);
+			child.on("close", (code) => {
+				if (code === 0) resolve();
+				else reject(new Error(`Refresh command exited with code ${code}`));
+			});
+			child.on("error", reject);
+		});
+		notify("AWS credentials refreshed successfully ✓", "info");
+		return true;
+	} catch (error) {
+		const msg = error instanceof Error ? error.message : String(error);
+		const isTimeout = /timed out|ETIMEDOUT|killed/i.test(msg);
+		if (isTimeout) {
+			notify("AWS credential refresh timed out. The SSO login may have been cancelled or the browser window was closed.", "error");
+		} else {
+			notify(`AWS credential refresh failed: ${msg}`, "error");
+		}
+		return false;
+	}
+}
+
+export default function (pi: ExtensionAPI) {
+	pi.on("agent_end", async (event, ctx) => {
+		const refreshCommand = getAwsAuthRefreshCommand();
+		if (!refreshCommand) return;
+
+		const messages = event.messages;
+		const lastAssistant = messages[messages.length - 1];
+		if (
+			!lastAssistant ||
+			lastAssistant.role !== "assistant" ||
+			!("errorMessage" in lastAssistant) ||
+			!lastAssistant.errorMessage ||
+			!AWS_AUTH_ERROR_RE.test(lastAssistant.errorMessage)
+		) {
+			return;
+		}
+
+		const refreshed = await runRefresh(refreshCommand, (m, level) => ctx.ui.notify(m, level));
+		if (!refreshed) return;
+
+		pi.retryLastTurn();
+	});
+}


### PR DESCRIPTION
## Summary

- Adds a new bundled `aws-auth` extension that automatically refreshes AWS credentials when Bedrock requests fail with auth errors, then retries the user's message
- Adds `retryLastTurn()` to the extension API — removes the failed assistant response and re-runs the agent from the last user message

## Motivation

Users running GSD with Amazon Bedrock via AWS SSO frequently hit expired credential errors, requiring them to manually `aws sso login` in another terminal and retry. This extension automates the entire flow — similar to Claude Code's `awsAuthRefresh` config option.

The `retryLastTurn()` API addition makes this possible cleanly from an extension, and is useful for any extension that needs to retry after resolving a transient error.

## Setup

Add `awsAuthRefresh` to your `settings.json` (global or project-level):

```json
{
  "awsAuthRefresh": "aws sso login --profile my-profile"
}
```

**Global**: `~/.gsd/agent/settings.json`
**Project**: `.gsd/settings.json`

Example with a real profile:

```json
{
  "awsAuthRefresh": "aws sso login --profile AWS-SSO-MyOrg-DevRole-123456789012"
}
```

## Change type

- [x] `feat` — New feature or capability

## Scope

- [x] `pi-coding-agent` — Coding agent (extension API + bundled extension)

## Breaking changes

- [x] No breaking changes

Zero impact on non-Bedrock users. The extension only activates when a Bedrock request fails with an AWS auth error AND `awsAuthRefresh` is configured in `settings.json`. The `retryLastTurn()` API is additive — no existing behavior changes.

## Test plan

- [x] Manual testing — describe steps:

1. Add `"awsAuthRefresh": "aws sso login --profile <profile>"` to `settings.json`
2. Set model to a Bedrock model, clear SSO cache: `rm -rf ~/.aws/sso/cache/*.json`
3. Launch GSD and send a message — Bedrock fails with SSO error
4. Extension detects error, runs `aws sso login`, shows auth URL + verification code in TUI
5. After browser auth completes, shows "AWS credentials refreshed successfully ✓"
6. `retryLastTurn()` removes the error and re-runs — user sees response without retyping
7. Without `awsAuthRefresh` configured — extension is completely inert
8. With a non-Bedrock model — extension is completely inert

## Rollback plan

- [x] Safe to revert (no migrations, no state changes)

## Release context

- **Target**: main
