### PR TITLE
fix: prevent false-positive "Session lock lost" during auto-mode

### DIFF
--- a/src/resources/extensions/gsd/auto-supervisor.ts
+++ b/src/resources/extensions/gsd/auto-supervisor.ts
@@ -5,6 +5,7 @@
  */
 
 import { clearLock } from "./crash-recovery.js";
+import { releaseSessionLock } from "./session-lock.js";
 import { nativeHasChanges } from "./native-git-bridge.js";
 
 // ─── SIGTERM Handling ─────────────────────────────────────────────────────────
@@ -23,6 +24,7 @@ export function registerSigtermHandler(
 ): () => void {
   if (previousHandler) process.off("SIGTERM", previousHandler);
   const handler = () => {
+    releaseSessionLock(currentBasePath);
     clearLock(currentBasePath);
     process.exit(0);
   };

--- a/src/resources/extensions/gsd/session-lock.ts
+++ b/src/resources/extensions/gsd/session-lock.ts
@@ -51,6 +51,9 @@ let _lockedPath: string | null = null;
 /** Our PID at lock acquisition time. */
 let _lockPid: number = 0;
 
+/** Set to true when proper-lockfile fires onCompromised (mtime drift, sleep, etc.). */
+let _lockCompromised: boolean = false;
+
 const LOCK_FILE = "auto.lock";
 
 function lockPath(basePath: string): string {
@@ -101,13 +104,22 @@ export function acquireSessionLock(basePath: string): SessionLockResult {
 
     const release = lockfile.lockSync(gsdDir, {
       realpath: false,
-      stale: 300_000, // 5 minutes — consider lock stale if holder hasn't updated
+      stale: 1_800_000, // 30 minutes — safe for laptop sleep / long event loop stalls
       update: 10_000, // Update lock mtime every 10s to prove liveness
+      onCompromised: () => {
+        // proper-lockfile detected mtime drift (system sleep, event loop stall, etc.).
+        // Default handler throws inside setTimeout — an uncaught exception that crashes
+        // or corrupts process state. Instead, set a flag so validateSessionLock() can
+        // detect the compromise gracefully on the next dispatch cycle.
+        _lockCompromised = true;
+        _releaseFunction = null;
+      },
     });
 
     _releaseFunction = release;
     _lockedPath = basePath;
     _lockPid = process.pid;
+    _lockCompromised = false;
 
     // Write the informational lock data
     atomicWriteSync(lp, JSON.stringify(lockData, null, 2));
@@ -195,6 +207,11 @@ export function updateSessionLock(
  * This is called periodically during the dispatch loop.
  */
 export function validateSessionLock(basePath: string): boolean {
+  // Lock was compromised by proper-lockfile (mtime drift from sleep, stall, etc.)
+  if (_lockCompromised) {
+    return false;
+  }
+
   // If we have an OS-level lock, we're still the owner
   if (_releaseFunction && _lockedPath === basePath) {
     return true;
@@ -235,6 +252,7 @@ export function releaseSessionLock(basePath: string): void {
 
   _lockedPath = null;
   _lockPid = 0;
+  _lockCompromised = false;
 }
 
 /**


### PR DESCRIPTION
## What happened

While running `/gsd auto` on a laptop, auto-mode would intermittently stop with:

```
Error: Session lock lost — another GSD process appears to have taken over. Stopping gracefully.
```

No second GSD process was running. The error is a false positive caused by three issues in the session lock implementation that compound under normal laptop usage (sleep/wake cycles, long-running sessions).

## Root causes

### 1. No `onCompromised` handler — uncaught throw crashes the process

`proper-lockfile` keeps the OS lock alive by updating a directory's mtime every 10 seconds. When it detects mtime drift (laptop sleep, event loop stall), it calls `onCompromised`. GSD doesn't pass a custom handler, so the default fires: `(err) => { throw err }` — an uncaught exception inside a `setTimeout` callback. This corrupts process state or crashes silently, causing the next `validateSessionLock()` call to fail.

**Fix:** Pass an `onCompromised` handler that sets a flag and nulls the release function. `validateSessionLock()` checks the flag and returns `false` gracefully — auto-mode stops cleanly instead of crashing unpredictably.

### 2. Stale threshold too short for laptop sleep

The `stale` timeout was 5 minutes. Closing a laptop lid for longer than that expires the lock. On wake, `proper-lockfile` detects the drift and fires `onCompromised`, or a second terminal could steal the lock.

**Fix:** Increased `stale` from 300,000ms (5 min) to 1,800,000ms (30 min). The 10-second `update` interval still proves liveness for detecting dead processes — the stale threshold just needs to survive realistic sleep durations.

### 3. SIGTERM handler doesn't release the OS lock

The SIGTERM handler in `auto-supervisor.ts` calls `clearLock()` (deletes the `.gsd/auto.lock` JSON file) but not `releaseSessionLock()` (releases the OS-level `.gsd.lock/` directory). Cleanup relied on `proper-lockfile`'s `signal-exit` hook during `process.exit()`. If that hook doesn't fire, the lock directory survives on disk, blocking new sessions until the stale threshold expires.

**Fix:** Call `releaseSessionLock()` explicitly before `clearLock()` in the SIGTERM handler.

## Changes

- **`session-lock.ts`** — Add `_lockCompromised` flag + `onCompromised` handler; increase `stale` to 30 min; check flag in `validateSessionLock()`; reset flag in `acquireSessionLock()` and `releaseSessionLock()`
- **`auto-supervisor.ts`** — Import `releaseSessionLock`; call it in the SIGTERM handler before `clearLock()`

## Testing

- All 16 existing `session-lock.test.ts` tests pass
- Both modified modules load cleanly
- No API changes, no new dependencies