### PR TITLE
feat: custom workflow engine for auto-mode

### DIFF
--- a/src/resources/extensions/gsd/auto-dashboard.ts
+++ b/src/resources/extensions/gsd/auto-dashboard.ts
@@ -50,6 +50,10 @@ export interface AutoDashboardData {
 
 export function unitVerb(unitType: string): string {
   if (unitType.startsWith("hook/")) return `hook: ${unitType.slice(5)}`;
+  if (unitType.startsWith("wf/")) {
+    const parts = unitType.split("/");
+    return parts[2] ?? parts[1] ?? unitType;
+  }
   switch (unitType) {
     case "research-milestone":
     case "research-slice": return "researching";
@@ -67,6 +71,10 @@ export function unitVerb(unitType: string): string {
 
 export function unitPhaseLabel(unitType: string): string {
   if (unitType.startsWith("hook/")) return "HOOK";
+  if (unitType.startsWith("wf/")) {
+    const parts = unitType.split("/");
+    return (parts[2] ?? parts[1] ?? unitType).toUpperCase();
+  }
   switch (unitType) {
     case "research-milestone": return "RESEARCH";
     case "research-slice": return "RESEARCH";

--- a/src/resources/extensions/gsd/auto-model-selection.ts
+++ b/src/resources/extensions/gsd/auto-model-selection.ts
@@ -33,8 +33,9 @@ export async function selectAndApplyModel(
   prefs: GSDPreferences | undefined,
   verbose: boolean,
   autoModeStartModel: { provider: string; id: string } | null,
+  overrideUnitType?: string,
 ): Promise<ModelSelectionResult> {
-  const modelConfig = resolveModelWithFallbacksForUnit(unitType);
+  const modelConfig = resolveModelWithFallbacksForUnit(overrideUnitType ?? unitType);
   let routing: { tier: string; modelDowngraded: boolean } | null = null;
 
   if (modelConfig) {

--- a/src/resources/extensions/gsd/auto-start.ts
+++ b/src/resources/extensions/gsd/auto-start.ts
@@ -202,6 +202,58 @@ export async function bootstrapAutoSession(
     }
   } catch (e) { debugLog("stale-unit-dir-cleanup-failed", { error: e instanceof Error ? e.message : String(e) }); }
 
+  // ── Custom workflow bootstrap: skip milestone state derivation ──
+  if (s.workflow) {
+    // Ensure artifact directory exists
+    const artDir = join(base, s.workflow.artifactDir);
+    if (!existsSync(artDir)) mkdirSync(artDir, { recursive: true });
+
+    // Initialize session state (subset of the full milestone bootstrap)
+    s.active = true;
+    s.stepMode = requestedStepMode;
+    s.verbose = verboseMode;
+    s.cmdCtx = ctx;
+    s.basePath = base;
+    s.originalBasePath = base;
+    s.unitDispatchCount.clear();
+    s.unitRecoveryCount.clear();
+    s.unitConsecutiveSkips.clear();
+    s.lastBudgetAlertLevel = 0;
+    s.unitLifetimeDispatches.clear();
+    s.completedKeySet.clear();
+    loadPersistedKeys(base, s.completedKeySet);
+    resetHookState();
+    resetProactiveHealing();
+    s.autoStartTime = Date.now();
+    s.resourceVersionOnStart = readResourceVersion();
+    s.completedUnits = [];
+    s.pendingQuickTasks = [];
+    s.currentUnit = null;
+    s.originalModelId = ctx.model?.id ?? null;
+    s.originalModelProvider = ctx.model?.provider ?? null;
+
+    registerSigtermHandler(base);
+    initMetrics(s.basePath);
+    initRoutingHistory(s.basePath);
+
+    const currentModel = ctx.model;
+    if (currentModel) {
+      s.autoModeStartModel = { provider: currentModel.provider, id: currentModel.id };
+    }
+
+    ctx.ui.setStatus("gsd-auto", s.stepMode ? "next" : "auto");
+    ctx.ui.setFooter(hideFooter);
+    ctx.ui.notify(
+      `${s.stepMode ? "Step-mode" : "Auto-mode"} started with workflow "${s.workflow.name}" (${s.workflow.steps.length} steps).`,
+      "info",
+    );
+
+    updateSessionLock(lockBase(), "starting", s.workflow.name, 0);
+    writeLock(lockBase(), "starting", s.workflow.name, 0);
+
+    return true;
+  }
+
   let state = await deriveState(base);
 
   // Stale worktree state recovery (#654)

--- a/src/resources/extensions/gsd/auto-verification.ts
+++ b/src/resources/extensions/gsd/auto-verification.ts
@@ -48,7 +48,15 @@ export async function runPostUnitVerification(
 ): Promise<VerificationResult> {
   const { s, ctx, pi } = vctx;
 
-  if (!s.currentUnit || s.currentUnit.type !== "execute-task") {
+  if (!s.currentUnit) return "continue";
+
+  // Custom workflows: check workflow-level verification mode
+  if (s.workflow && s.currentUnit.type.startsWith("wf/")) {
+    const { resolveWorkflowVerification } = await import("./workflow-dispatch.js");
+    const verifyMode = resolveWorkflowVerification(s.workflow, s.currentUnit.type);
+    if (verifyMode === "none") return "continue";
+    // "inherit" falls through to the standard verification logic below
+  } else if (s.currentUnit.type !== "execute-task") {
     return "continue";
   }
 

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -179,6 +179,8 @@ import { checkStuckAndRecover, type StuckContext } from "./auto-stuck-detection.
 import { runPostUnitVerification, type VerificationContext } from "./auto-verification.js";
 import { postUnitPreVerification, postUnitPostVerification, type PostUnitContext } from "./auto-post-unit.js";
 import { bootstrapAutoSession, type BootstrapDeps } from "./auto-start.js";
+import { resolveWorkflowDispatch, resolveWorkflowModelCategory, workflowCategoryToUnitType } from "./workflow-dispatch.js";
+import { resolveWorkflow } from "./workflow-loader.js";
 
 // Worktree sync, resource staleness, stale worktree escape → auto-worktree-sync.ts
 
@@ -590,9 +592,19 @@ export async function startAuto(
   pi: ExtensionAPI,
   base: string,
   verboseMode: boolean,
-  options?: { step?: boolean },
+  options?: { step?: boolean; workflow?: string },
 ): Promise<void> {
   const requestedStepMode = options?.step ?? false;
+
+  // ── Custom workflow resolution ──
+  if (options?.workflow) {
+    const workflow = resolveWorkflow(options.workflow, base);
+    if (!workflow) {
+      ctx.ui.notify(`Workflow "${options.workflow}" not found. Check .gsd/workflows/ or ~/.gsd/workflows/.`, "error");
+      return;
+    }
+    s.workflow = workflow;
+  }
 
   // Escape stale worktree cwd from a previous milestone (#608).
   base = escapeStaleWorktree(base);
@@ -1021,6 +1033,22 @@ async function dispatchNextUnit(
   // ── Sync project root artifacts into worktree ──
   if (s.originalBasePath && s.basePath !== s.originalBasePath && s.currentMilestoneId) {
     syncProjectRootToWorktree(s.originalBasePath, s.basePath, s.currentMilestoneId);
+  }
+
+  // ── Custom workflow path: skip deriveState, use workflow dispatch ──
+  if (s.workflow) {
+    const wfDispatch = await resolveWorkflowDispatch(s.workflow, s.basePath);
+    if (wfDispatch.action === "stop") {
+      if (s.currentUnit) {
+        await closeoutUnit(ctx, s.basePath, s.currentUnit.type, s.currentUnit.id, s.currentUnit.startedAt, buildSnapshotOpts(s.currentUnit.type, s.currentUnit.id));
+      }
+      await stopAuto(ctx, pi, wfDispatch.reason);
+      return;
+    }
+    if (wfDispatch.action === "dispatch") {
+      await dispatchWorkflowUnit(ctx, pi, wfDispatch.unitType, wfDispatch.unitId, wfDispatch.prompt);
+    }
+    return;
   }
 
   const stopDeriveTimer = debugTime("derive-state");
@@ -1729,6 +1757,140 @@ async function dispatchNextUnit(
   } finally {
     s.dispatching = false;
   }
+}
+
+// ─── Workflow Dispatch Helper ──────────────────────────────────────────────────
+
+/**
+ * Dispatch a single unit for a custom workflow.
+ * Handles session creation, model selection, prompt injection, and supervision —
+ * the same pipeline as the standard dispatch, but without milestone/state logic.
+ */
+async function dispatchWorkflowUnit(
+  ctx: ExtensionContext,
+  pi: ExtensionAPI,
+  unitType: string,
+  unitId: string,
+  prompt: string,
+): Promise<void> {
+  const prefs = loadEffectiveGSDPreferences()?.preferences;
+
+  // Idempotency check
+  const idempotencyResult = checkIdempotency({
+    s,
+    unitType,
+    unitId,
+    basePath: s.basePath,
+    notify: (msg, level) => ctx.ui.notify(msg, level),
+  });
+
+  if (idempotencyResult.action === "skip") {
+    if (idempotencyResult.reason === "completed" || idempotencyResult.reason === "fallback-persisted" || idempotencyResult.reason === "phantom-loop-cleared" || idempotencyResult.reason === "evicted") {
+      if (!s.active) return;
+      s.skipDepth++;
+      await new Promise(r => setTimeout(r, 150));
+      await dispatchNextUnit(ctx, pi);
+      s.skipDepth = Math.max(0, s.skipDepth - 1);
+      return;
+    }
+  } else if (idempotencyResult.action === "stop") {
+    await stopAuto(ctx, pi, idempotencyResult.reason);
+    return;
+  }
+
+  // Closeout previous unit
+  if (s.currentUnit) {
+    await closeoutUnit(ctx, s.basePath, s.currentUnit.type, s.currentUnit.id, s.currentUnit.startedAt, buildSnapshotOpts(s.currentUnit.type, s.currentUnit.id));
+
+    const closeoutKey = `${s.currentUnit.type}/${s.currentUnit.id}`;
+    const incomingKey = `${unitType}/${unitId}`;
+    if (closeoutKey !== incomingKey) {
+      persistCompletedKey(s.basePath, closeoutKey);
+      s.completedKeySet.add(closeoutKey);
+      s.completedUnits.push({
+        type: s.currentUnit.type,
+        id: s.currentUnit.id,
+        startedAt: s.currentUnit.startedAt,
+        finishedAt: Date.now(),
+      });
+      clearUnitRuntimeRecord(s.basePath, s.currentUnit.type, s.currentUnit.id);
+      s.unitDispatchCount.delete(closeoutKey);
+    }
+  }
+
+  s.currentUnit = { type: unitType, id: unitId, startedAt: Date.now() };
+  writeUnitRuntimeRecord(s.basePath, unitType, unitId, s.currentUnit.startedAt, {
+    phase: "dispatched",
+    wrapupWarningSent: false,
+    timeoutAt: null,
+    lastProgressAt: s.currentUnit.startedAt,
+    progressCount: 0,
+    lastProgressKind: "dispatch",
+  });
+
+  // Ensure artifact directory exists
+  if (s.workflow) {
+    const { mkdirSync: mkdirSyncFs } = await import("node:fs");
+    const { join: joinPath } = await import("node:path");
+    const artDir = joinPath(s.basePath, s.workflow.artifactDir);
+    mkdirSyncFs(artDir, { recursive: true });
+  }
+
+  // Status bar (no GSDState for custom workflows, use a minimal stub)
+  ctx.ui.setStatus("gsd-auto", "auto");
+
+  // Fresh session
+  let result: { cancelled: boolean };
+  try {
+    const sessionPromise = s.cmdCtx!.newSession();
+    const timeoutPromise = new Promise<{ cancelled: true }>((resolve) =>
+      setTimeout(() => resolve({ cancelled: true }), NEW_SESSION_TIMEOUT_MS),
+    );
+    result = await Promise.race([sessionPromise, timeoutPromise]);
+  } catch (sessionErr) {
+    const msg = sessionErr instanceof Error ? sessionErr.message : String(sessionErr);
+    ctx.ui.notify(`Session creation failed: ${msg}. Retrying via watchdog.`, "error");
+    throw new Error(`newSession() failed: ${msg}`);
+  }
+  if (result.cancelled) {
+    ctx.ui.notify(`Session creation timed out for ${unitType} ${unitId}.`, "warning");
+    await stopAuto(ctx, pi, "Session creation failed");
+    return;
+  }
+
+  const sessionFile = ctx.sessionManager.getSessionFile();
+  updateSessionLock(lockBase(), unitType, unitId, s.completedUnits.length, sessionFile);
+  writeLock(lockBase(), unitType, unitId, s.completedUnits.length, sessionFile);
+
+  // Model selection: map workflow model_category to a known unit type for resolution
+  let overrideUnitType: string | undefined;
+  if (s.workflow) {
+    const category = resolveWorkflowModelCategory(s.workflow, unitType);
+    if (category) overrideUnitType = workflowCategoryToUnitType(category);
+  }
+  const modelResult = await selectAndApplyModel(ctx, pi, unitType, unitId, s.basePath, prefs, s.verbose, s.autoModeStartModel, overrideUnitType);
+  s.currentUnitRouting = modelResult.routing;
+
+  // Supervision
+  clearUnitTimeout();
+  startUnitSupervision({
+    s,
+    ctx,
+    pi,
+    unitType,
+    unitId,
+    prefs,
+    buildSnapshotOpts: () => buildSnapshotOpts(unitType, unitId),
+    buildRecoveryContext: () => buildRecoveryContext(),
+    pauseAuto,
+  });
+
+  // Inject prompt
+  if (!s.active) return;
+  pi.sendMessage(
+    { customType: "gsd-auto", content: prompt, display: s.verbose },
+    { triggerTurn: true },
+  );
 }
 
 // ─── Preconditions ────────────────────────────────────────────────────────────

--- a/src/resources/extensions/gsd/auto/session.ts
+++ b/src/resources/extensions/gsd/auto/session.ts
@@ -20,6 +20,7 @@ import type { ExtensionCommandContext } from "@gsd/pi-coding-agent";
 import type { GitServiceImpl } from "../git-service.js";
 import type { CaptureEntry } from "../captures.js";
 import type { BudgetAlertLevel } from "../auto-budget.js";
+import type { WorkflowDefinition } from "../workflow-definition.js";
 
 // ─── Exported Types ──────────────────────────────────────────────────────────
 
@@ -126,6 +127,9 @@ export class AutoSession {
   lastBaselineCharCount: number | undefined;
   pendingQuickTasks: CaptureEntry[] = [];
 
+  // ── Custom workflow ─────────────────────────────────────────────────────
+  workflow: WorkflowDefinition | null = null;
+
   // ── Signal handler ───────────────────────────────────────────────────────
   sigtermHandler: (() => void) | null = null;
 
@@ -214,6 +218,9 @@ export class AutoSession {
     this.lastBaselineCharCount = undefined;
     this.pendingQuickTasks = [];
 
+    // Custom workflow
+    this.workflow = null;
+
     // Signal handler
     this.sigtermHandler = null;
   }
@@ -231,6 +238,7 @@ export class AutoSession {
       unitDispatchCount: Object.fromEntries(this.unitDispatchCount),
       dispatching: this.dispatching,
       skipDepth: this.skipDepth,
+      workflow: this.workflow?.name ?? null,
     };
   }
 }

--- a/src/resources/extensions/gsd/commands.ts
+++ b/src/resources/extensions/gsd/commands.ts
@@ -100,6 +100,8 @@ export function registerGSDCommand(pi: ExtensionAPI): void {
         { cmd: "update", desc: "Update GSD to the latest version" },
         { cmd: "start", desc: "Start a workflow template (bugfix, spike, feature, etc.)" },
         { cmd: "templates", desc: "List available workflow templates" },
+        { cmd: "workflows", desc: "List available custom workflows" },
+        { cmd: "workflow install", desc: "Install a workflow file globally" },
       ];
       const parts = prefix.trim().split(/\s+/);
 
@@ -447,7 +449,34 @@ export function registerGSDCommand(pi: ExtensionAPI): void {
         const verboseMode = trimmed.includes("--verbose");
         const debugMode = trimmed.includes("--debug");
         if (debugMode) enableDebug(projectRoot());
-        await startAuto(ctx, pi, projectRoot(), verboseMode);
+        // Parse --workflow flag
+        const workflowMatch = trimmed.match(/--workflow\s+(\S+)/);
+        const workflowName = workflowMatch?.[1];
+        await startAuto(ctx, pi, projectRoot(), verboseMode, workflowName ? { workflow: workflowName } : undefined);
+        return;
+      }
+
+      if (trimmed === "workflows" || trimmed === "workflow list") {
+        const { listWorkflows } = await import("./workflow-loader.js");
+        const entries = listWorkflows(projectRoot());
+        if (entries.length === 0) {
+          ctx.ui.notify("No workflows found. Place .md files in .gsd/workflows/ or ~/.gsd/workflows/.", "info");
+        } else {
+          const lines = entries.map(e => `  ${e.name} (${e.source}) — ${e.description}`);
+          ctx.ui.notify(`Available workflows:\n${lines.join("\n")}`, "info");
+        }
+        return;
+      }
+
+      if (trimmed.startsWith("workflow install ")) {
+        const sourcePath = trimmed.replace(/^workflow install\s+/, "").trim();
+        const { installWorkflow } = await import("./workflow-loader.js");
+        const result = installWorkflow(sourcePath);
+        if (result.installed) {
+          ctx.ui.notify(`Workflow installed to ${result.destPath}`, "info");
+        } else {
+          ctx.ui.notify(`Install failed: ${result.error}`, "error");
+        }
         return;
       }
 

--- a/src/resources/extensions/gsd/tests/workflow-definition.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-definition.test.ts
@@ -1,0 +1,329 @@
+/**
+ * workflow-definition.test.ts — Unit tests for workflow definition parsing and validation.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { parseWorkflowDefinition, validateWorkflowDefinition } from "../workflow-definition.js";
+
+// ─── Valid Workflow ───────────────────────────────────────────────────────────
+
+const VALID_WORKFLOW = `---
+name: Write Ebook
+description: Research, outline, draft, and edit an ebook
+version: 1
+author: someone
+artifact_dir: .gsd/workflows/ebook
+
+steps:
+  - id: research
+    name: Research Topic
+    model_category: research
+    produces: RESEARCH.md
+    prompt: |
+      Research the topic thoroughly. Write findings to {{artifact_dir}}/RESEARCH.md.
+
+  - id: outline
+    name: Create Outline
+    model_category: planning
+    produces: OUTLINE.md
+    requires: [research]
+    prompt: |
+      Read {{artifact_dir}}/RESEARCH.md. Create a chapter outline.
+
+  - id: draft
+    name: Draft Chapters
+    model_category: execution
+    produces: chapters/
+    requires: [outline]
+    iterate:
+      source: OUTLINE.md
+      pattern: "^## "
+      id_format: "CH{:02d}"
+    prompt: |
+      Write chapter {{iter_index}}: "{{iter_title}}".
+
+  - id: edit
+    name: Edit & Polish
+    model_category: completion
+    produces: FINAL.md
+    requires: [draft]
+    prompt: |
+      Read all chapter files. Compile into {{artifact_dir}}/FINAL.md.
+
+isolation: none
+verification: none
+---
+
+# Write Ebook
+
+A workflow for writing an ebook.
+`;
+
+test("parseWorkflowDefinition parses a valid workflow", () => {
+  const def = parseWorkflowDefinition(VALID_WORKFLOW);
+  assert.ok(def);
+  assert.equal(def.name, "Write Ebook");
+  assert.equal(def.description, "Research, outline, draft, and edit an ebook");
+  assert.equal(def.version, 1);
+  assert.equal(def.author, "someone");
+  assert.equal(def.artifactDir, ".gsd/workflows/ebook");
+  assert.equal(def.isolation, "none");
+  assert.equal(def.verification, "none");
+  assert.equal(def.steps.length, 4);
+});
+
+test("step properties are parsed correctly", () => {
+  const def = parseWorkflowDefinition(VALID_WORKFLOW)!;
+  const research = def.steps[0]!;
+  assert.equal(research.id, "research");
+  assert.equal(research.name, "Research Topic");
+  assert.equal(research.modelCategory, "research");
+  assert.equal(research.produces, "RESEARCH.md");
+  assert.deepEqual(research.requires, []);
+  assert.equal(research.verification, "none");
+  assert.ok(research.promptTemplate.includes("Research the topic"));
+});
+
+test("step requires are parsed correctly", () => {
+  const def = parseWorkflowDefinition(VALID_WORKFLOW)!;
+  const outline = def.steps[1]!;
+  assert.deepEqual(outline.requires, ["research"]);
+});
+
+test("step iterate config is parsed correctly", () => {
+  const def = parseWorkflowDefinition(VALID_WORKFLOW)!;
+  const draft = def.steps[2]!;
+  assert.ok(draft.iterate);
+  assert.equal(draft.iterate!.source, "OUTLINE.md");
+  assert.equal(draft.iterate!.pattern, "^## ");
+  assert.equal(draft.iterate!.idFormat, "CH{:02d}");
+});
+
+test("model_category defaults to execution when missing", () => {
+  const content = `---
+name: Test
+description: Test workflow
+artifact_dir: .gsd/test
+steps:
+  - id: step1
+    name: Step 1
+    produces: OUT.md
+    prompt: Do something
+---
+`;
+  const def = parseWorkflowDefinition(content)!;
+  assert.equal(def.steps[0]!.modelCategory, "execution");
+});
+
+// ─── Invalid Workflows ───────────────────────────────────────────────────────
+
+test("parseWorkflowDefinition returns null for missing frontmatter", () => {
+  assert.equal(parseWorkflowDefinition("No frontmatter here"), null);
+});
+
+test("parseWorkflowDefinition returns null for missing name", () => {
+  const content = `---
+description: No name
+artifact_dir: .gsd/test
+steps:
+  - id: step1
+    name: Step 1
+    produces: OUT.md
+    prompt: Do it
+---
+`;
+  assert.equal(parseWorkflowDefinition(content), null);
+});
+
+test("parseWorkflowDefinition returns null for empty steps", () => {
+  const content = `---
+name: Test
+description: Empty steps
+artifact_dir: .gsd/test
+steps: []
+---
+`;
+  assert.equal(parseWorkflowDefinition(content), null);
+});
+
+test("parseWorkflowDefinition returns null for duplicate step IDs", () => {
+  const content = `---
+name: Test
+description: Dupe IDs
+artifact_dir: .gsd/test
+steps:
+  - id: step1
+    name: Step 1
+    produces: A.md
+    prompt: Do A
+  - id: step1
+    name: Step 2
+    produces: B.md
+    prompt: Do B
+---
+`;
+  assert.equal(parseWorkflowDefinition(content), null);
+});
+
+test("parseWorkflowDefinition returns null for invalid requires reference", () => {
+  const content = `---
+name: Test
+description: Bad requires
+artifact_dir: .gsd/test
+steps:
+  - id: step1
+    name: Step 1
+    produces: A.md
+    requires: [nonexistent]
+    prompt: Do A
+---
+`;
+  assert.equal(parseWorkflowDefinition(content), null);
+});
+
+test("parseWorkflowDefinition returns null for self-referencing requires", () => {
+  const content = `---
+name: Test
+description: Self ref
+artifact_dir: .gsd/test
+steps:
+  - id: step1
+    name: Step 1
+    produces: A.md
+    requires: [step1]
+    prompt: Do A
+---
+`;
+  assert.equal(parseWorkflowDefinition(content), null);
+});
+
+test("parseWorkflowDefinition detects dependency cycles", () => {
+  const content = `---
+name: Test
+description: Cycle
+artifact_dir: .gsd/test
+steps:
+  - id: a
+    name: A
+    produces: A.md
+    requires: [b]
+    prompt: Do A
+  - id: b
+    name: B
+    produces: B.md
+    requires: [a]
+    prompt: Do B
+---
+`;
+  assert.equal(parseWorkflowDefinition(content), null);
+});
+
+// ─── Validation ──────────────────────────────────────────────────────────────
+
+test("validateWorkflowDefinition returns valid for good workflow", () => {
+  const result = validateWorkflowDefinition(VALID_WORKFLOW);
+  assert.equal(result.valid, true);
+  assert.equal(result.errors.length, 0);
+});
+
+test("validateWorkflowDefinition reports missing frontmatter", () => {
+  const result = validateWorkflowDefinition("No frontmatter");
+  assert.equal(result.valid, false);
+  assert.ok(result.errors.some(e => e.includes("frontmatter")));
+});
+
+test("validateWorkflowDefinition reports missing fields", () => {
+  const content = `---
+description: No name field
+steps: []
+---
+`;
+  const result = validateWorkflowDefinition(content);
+  assert.equal(result.valid, false);
+  assert.ok(result.errors.some(e => e.includes("name")));
+});
+
+// ─── Verification Mode Parsing ───────────────────────────────────────────────
+
+test("workflow-level verification: inherit", () => {
+  const content = `---
+name: Test
+description: Test
+artifact_dir: .gsd/test
+verification: inherit
+steps:
+  - id: step1
+    name: Step 1
+    produces: OUT.md
+    prompt: Do it
+---
+`;
+  const def = parseWorkflowDefinition(content)!;
+  assert.equal(def.verification, "inherit");
+});
+
+test("step-level verification with commands", () => {
+  const content = `---
+name: Test
+description: Test
+artifact_dir: .gsd/test
+steps:
+  - id: step1
+    name: Step 1
+    produces: OUT.md
+    verification:
+      commands:
+        - command: npm test
+          blocking: true
+        - command: npm run lint
+          blocking: false
+    prompt: Do it
+---
+`;
+  const def = parseWorkflowDefinition(content)!;
+  const v = def.steps[0]!.verification;
+  assert.notEqual(v, "none");
+  assert.notEqual(v, "inherit");
+  assert.ok(typeof v === "object");
+  assert.equal(v.commands.length, 2);
+  assert.equal(v.commands[0]!.command, "npm test");
+  assert.equal(v.commands[0]!.blocking, true);
+  assert.equal(v.commands[1]!.command, "npm run lint");
+  assert.equal(v.commands[1]!.blocking, false);
+});
+
+// ─── Isolation Mode ──────────────────────────────────────────────────────────
+
+test("isolation defaults to none", () => {
+  const content = `---
+name: Test
+description: Test
+artifact_dir: .gsd/test
+steps:
+  - id: step1
+    name: Step 1
+    produces: OUT.md
+    prompt: Do it
+---
+`;
+  const def = parseWorkflowDefinition(content)!;
+  assert.equal(def.isolation, "none");
+});
+
+test("isolation: worktree is parsed", () => {
+  const content = `---
+name: Test
+description: Test
+artifact_dir: .gsd/test
+isolation: worktree
+steps:
+  - id: step1
+    name: Step 1
+    produces: OUT.md
+    prompt: Do it
+---
+`;
+  const def = parseWorkflowDefinition(content)!;
+  assert.equal(def.isolation, "worktree");
+});

--- a/src/resources/extensions/gsd/tests/workflow-dispatch.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-dispatch.test.ts
@@ -1,0 +1,303 @@
+/**
+ * workflow-dispatch.test.ts — Unit tests for custom workflow dispatch resolution.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, writeFileSync, rmSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  resolveWorkflowDispatch,
+  resolveIterationItems,
+  renderWorkflowPrompt,
+  resolveWorkflowVerification,
+  resolveWorkflowModelCategory,
+  workflowCategoryToUnitType,
+} from "../workflow-dispatch.js";
+import { parseWorkflowDefinition } from "../workflow-definition.js";
+
+// ─── Test Helpers ─────────────────────────────────────────────────────────────
+
+function makeTempDir(): string {
+  const dir = join(tmpdir(), `gsd-wf-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function makeWorkflow(steps: string): ReturnType<typeof parseWorkflowDefinition> {
+  return parseWorkflowDefinition(`---
+name: Test Workflow
+description: A test workflow
+artifact_dir: .artifacts
+steps:
+${steps}
+---
+`);
+}
+
+// ─── renderWorkflowPrompt ─────────────────────────────────────────────────────
+
+test("renderWorkflowPrompt substitutes variables", () => {
+  const result = renderWorkflowPrompt(
+    "Write to {{artifact_dir}}/{{step_name}}.md about {{iter_title}}",
+    { artifact_dir: "/tmp/art", step_name: "research", iter_title: "AI" },
+  );
+  assert.equal(result, "Write to /tmp/art/research.md about AI");
+});
+
+test("renderWorkflowPrompt handles missing variables gracefully", () => {
+  const result = renderWorkflowPrompt("Hello {{name}} and {{unknown}}", { name: "world" });
+  assert.equal(result, "Hello world and {{unknown}}");
+});
+
+// ─── resolveIterationItems ────────────────────────────────────────────────────
+
+test("resolveIterationItems with count produces fixed items", () => {
+  const dir = makeTempDir();
+  try {
+    const items = resolveIterationItems(dir, {
+      source: "any.md",
+      pattern: ".*",
+      idFormat: "ITEM{:02d}",
+      count: 3,
+    });
+    assert.equal(items.length, 3);
+    assert.equal(items[0]!.id, "ITEM01");
+    assert.equal(items[1]!.id, "ITEM02");
+    assert.equal(items[2]!.id, "ITEM03");
+    assert.equal(items[0]!.index, 1);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("resolveIterationItems with pattern parses source file", () => {
+  const dir = makeTempDir();
+  try {
+    writeFileSync(join(dir, "OUTLINE.md"), [
+      "# My Book",
+      "",
+      "## Introduction",
+      "Some intro text",
+      "",
+      "## Chapter One",
+      "Content here",
+      "",
+      "## Conclusion",
+    ].join("\n"));
+
+    const items = resolveIterationItems(dir, {
+      source: "OUTLINE.md",
+      pattern: "^## ",
+      idFormat: "CH{:02d}",
+    });
+    assert.equal(items.length, 3);
+    assert.equal(items[0]!.id, "CH01");
+    assert.equal(items[0]!.title, "Introduction");
+    assert.equal(items[1]!.id, "CH02");
+    assert.equal(items[1]!.title, "Chapter One");
+    assert.equal(items[2]!.id, "CH03");
+    assert.equal(items[2]!.title, "Conclusion");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("resolveIterationItems returns empty for missing source", () => {
+  const dir = makeTempDir();
+  try {
+    const items = resolveIterationItems(dir, {
+      source: "MISSING.md",
+      pattern: "^## ",
+      idFormat: "X{:02d}",
+    });
+    assert.equal(items.length, 0);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// ─── resolveWorkflowDispatch ──────────────────────────────────────────────────
+
+test("dispatches first incomplete step", async () => {
+  const dir = makeTempDir();
+  try {
+    const workflow = makeWorkflow(`
+  - id: research
+    name: Research
+    produces: RESEARCH.md
+    prompt: Research the topic.
+  - id: outline
+    name: Outline
+    produces: OUTLINE.md
+    requires: [research]
+    prompt: Create outline.
+`)!;
+
+    const result = await resolveWorkflowDispatch(workflow, dir);
+    assert.equal(result.action, "dispatch");
+    if (result.action === "dispatch") {
+      assert.equal(result.unitType, "wf/Test Workflow/research");
+      assert.equal(result.unitId, "research");
+      assert.ok(result.prompt.includes("Research the topic"));
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("skips completed steps and dispatches next", async () => {
+  const dir = makeTempDir();
+  try {
+    const artDir = join(dir, ".artifacts");
+    mkdirSync(artDir, { recursive: true });
+    writeFileSync(join(artDir, "RESEARCH.md"), "Done");
+
+    const workflow = makeWorkflow(`
+  - id: research
+    name: Research
+    produces: RESEARCH.md
+    prompt: Research the topic.
+  - id: outline
+    name: Outline
+    produces: OUTLINE.md
+    requires: [research]
+    prompt: Create outline.
+`)!;
+
+    const result = await resolveWorkflowDispatch(workflow, dir);
+    assert.equal(result.action, "dispatch");
+    if (result.action === "dispatch") {
+      assert.equal(result.unitType, "wf/Test Workflow/outline");
+      assert.equal(result.unitId, "outline");
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("returns stop when all steps complete", async () => {
+  const dir = makeTempDir();
+  try {
+    const artDir = join(dir, ".artifacts");
+    mkdirSync(artDir, { recursive: true });
+    writeFileSync(join(artDir, "RESEARCH.md"), "Done");
+    writeFileSync(join(artDir, "OUTLINE.md"), "Done");
+
+    const workflow = makeWorkflow(`
+  - id: research
+    name: Research
+    produces: RESEARCH.md
+    prompt: Research.
+  - id: outline
+    name: Outline
+    produces: OUTLINE.md
+    requires: [research]
+    prompt: Outline.
+`)!;
+
+    const result = await resolveWorkflowDispatch(workflow, dir);
+    assert.equal(result.action, "stop");
+    if (result.action === "stop") {
+      assert.ok(result.reason.includes("complete"));
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("skips step when dependencies not met", async () => {
+  const dir = makeTempDir();
+  try {
+    const workflow = makeWorkflow(`
+  - id: step1
+    name: Step 1
+    produces: A.md
+    prompt: Do A.
+  - id: step2
+    name: Step 2
+    produces: B.md
+    requires: [step1]
+    prompt: Do B.
+`)!;
+
+    // step2 depends on step1, which isn't done. Only step1 should dispatch.
+    const result = await resolveWorkflowDispatch(workflow, dir);
+    assert.equal(result.action, "dispatch");
+    if (result.action === "dispatch") {
+      assert.ok(result.unitType.includes("step1"));
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// ─── Verification Resolution ──────────────────────────────────────────────────
+
+test("resolveWorkflowVerification returns step verification", () => {
+  const workflow = makeWorkflow(`
+  - id: step1
+    name: Step 1
+    produces: OUT.md
+    verification: inherit
+    prompt: Do it.
+`)!;
+
+  const result = resolveWorkflowVerification(workflow, "wf/Test Workflow/step1");
+  assert.equal(result, "inherit");
+});
+
+test("resolveWorkflowVerification falls back to workflow default", () => {
+  const content = `---
+name: Test
+description: Test
+artifact_dir: .art
+verification: inherit
+steps:
+  - id: step1
+    name: Step 1
+    produces: OUT.md
+    prompt: Do it
+---
+`;
+  const workflow = parseWorkflowDefinition(content)!;
+  // step1 has verification: none, so it falls through to workflow default
+  const result = resolveWorkflowVerification(workflow, "wf/Test/step1");
+  assert.equal(result, "inherit");
+});
+
+// ─── Model Category Resolution ────────────────────────────────────────────────
+
+test("resolveWorkflowModelCategory returns step category", () => {
+  const workflow = makeWorkflow(`
+  - id: step1
+    name: Step 1
+    model_category: research
+    produces: OUT.md
+    prompt: Do it.
+`)!;
+
+  assert.equal(resolveWorkflowModelCategory(workflow, "wf/Test Workflow/step1"), "research");
+});
+
+test("resolveWorkflowModelCategory returns undefined for unknown step", () => {
+  const workflow = makeWorkflow(`
+  - id: step1
+    name: Step 1
+    produces: OUT.md
+    prompt: Do it.
+`)!;
+
+  assert.equal(resolveWorkflowModelCategory(workflow, "wf/Test Workflow/unknown"), undefined);
+});
+
+// ─── workflowCategoryToUnitType ───────────────────────────────────────────────
+
+test("workflowCategoryToUnitType maps categories correctly", () => {
+  assert.equal(workflowCategoryToUnitType("research"), "research-milestone");
+  assert.equal(workflowCategoryToUnitType("planning"), "plan-milestone");
+  assert.equal(workflowCategoryToUnitType("execution"), "execute-task");
+  assert.equal(workflowCategoryToUnitType("completion"), "complete-slice");
+  assert.equal(workflowCategoryToUnitType("unknown"), "execute-task");
+});

--- a/src/resources/extensions/gsd/workflow-definition.ts
+++ b/src/resources/extensions/gsd/workflow-definition.ts
@@ -1,0 +1,266 @@
+/**
+ * Custom Workflow Definition — types, parsing, and validation.
+ *
+ * A workflow is a `.md` file with YAML frontmatter describing a sequence of
+ * steps the auto-mode engine should execute. Each step produces an artifact
+ * (file or directory) that serves as its completion signal.
+ */
+
+import { parse as parseYaml } from "yaml";
+
+// ─── Types ────────────────────────────────────────────────────────────────
+
+export interface WorkflowDefinition {
+  name: string;
+  description: string;
+  version: number;
+  author?: string;
+  artifactDir: string;
+  steps: WorkflowStep[];
+  isolation: "none" | "worktree";
+  verification: VerificationMode;
+}
+
+export interface WorkflowStep {
+  id: string;
+  name: string;
+  modelCategory: "research" | "planning" | "execution" | "completion";
+  produces: string;
+  requires: string[];
+  verification: VerificationMode;
+  promptTemplate: string;
+  iterate?: IterationConfig;
+}
+
+export interface IterationConfig {
+  source: string;
+  pattern: string;
+  idFormat: string;
+  count?: number;
+}
+
+export type VerificationMode = "none" | "inherit" | { commands: VerificationCommand[] };
+
+export interface VerificationCommand {
+  command: string;
+  blocking?: boolean;
+}
+
+// ─── Parsing ──────────────────────────────────────────────────────────────
+
+/**
+ * Parse a workflow definition from a `.md` file's contents.
+ * Uses the same frontmatter parsing pattern as `parsePreferencesMarkdown`.
+ */
+export function parseWorkflowDefinition(content: string): WorkflowDefinition | null {
+  const startMarker = content.startsWith("---\r\n") ? "---\r\n" : "---\n";
+  if (!content.startsWith(startMarker)) return null;
+  const searchStart = startMarker.length;
+  const endIdx = content.indexOf("\n---", searchStart);
+  if (endIdx === -1) return null;
+  const block = content.slice(searchStart, endIdx).replace(/\r/g, "");
+
+  let raw: Record<string, unknown>;
+  try {
+    const parsed = parseYaml(block);
+    if (typeof parsed !== "object" || parsed === null) return null;
+    raw = parsed as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+
+  // Required fields
+  if (typeof raw.name !== "string" || !raw.name) return null;
+  if (typeof raw.description !== "string" || !raw.description) return null;
+  if (!Array.isArray(raw.steps) || raw.steps.length === 0) return null;
+  if (typeof raw.artifact_dir !== "string" || !raw.artifact_dir) return null;
+
+  const steps = parseSteps(raw.steps);
+  if (!steps) return null;
+
+  const validation = validateSteps(steps);
+  if (!validation.valid) return null;
+
+  return {
+    name: raw.name,
+    description: raw.description,
+    version: typeof raw.version === "number" ? raw.version : 1,
+    author: typeof raw.author === "string" ? raw.author : undefined,
+    artifactDir: raw.artifact_dir,
+    steps,
+    isolation: raw.isolation === "worktree" ? "worktree" : "none",
+    verification: parseVerificationMode(raw.verification) ?? "none",
+  };
+}
+
+// ─── Step Parsing ─────────────────────────────────────────────────────────
+
+const VALID_MODEL_CATEGORIES = new Set(["research", "planning", "execution", "completion"]);
+
+function parseSteps(rawSteps: unknown[]): WorkflowStep[] | null {
+  const steps: WorkflowStep[] = [];
+
+  for (const rawStep of rawSteps) {
+    if (typeof rawStep !== "object" || rawStep === null) return null;
+    const s = rawStep as Record<string, unknown>;
+
+    if (typeof s.id !== "string" || !s.id) return null;
+    if (typeof s.name !== "string" || !s.name) return null;
+    if (typeof s.produces !== "string" || !s.produces) return null;
+    if (typeof s.prompt !== "string" || !s.prompt) return null;
+
+    const modelCategory = typeof s.model_category === "string" && VALID_MODEL_CATEGORIES.has(s.model_category)
+      ? s.model_category as WorkflowStep["modelCategory"]
+      : "execution";
+
+    const requires = Array.isArray(s.requires)
+      ? s.requires.filter((r): r is string => typeof r === "string")
+      : [];
+
+    const iterate = parseIterationConfig(s.iterate);
+
+    steps.push({
+      id: s.id,
+      name: s.name,
+      modelCategory,
+      produces: s.produces,
+      requires,
+      verification: parseVerificationMode(s.verification) ?? "none",
+      promptTemplate: s.prompt,
+      iterate: iterate ?? undefined,
+    });
+  }
+
+  return steps;
+}
+
+function parseIterationConfig(raw: unknown): IterationConfig | null {
+  if (typeof raw !== "object" || raw === null) return null;
+  const c = raw as Record<string, unknown>;
+
+  if (typeof c.source !== "string" || !c.source) return null;
+  if (typeof c.pattern !== "string" || !c.pattern) return null;
+
+  return {
+    source: c.source,
+    pattern: c.pattern,
+    idFormat: typeof c.id_format === "string" ? c.id_format : "ITEM{:02d}",
+    count: typeof c.count === "number" ? c.count : undefined,
+  };
+}
+
+function parseVerificationMode(raw: unknown): VerificationMode | null {
+  if (raw === "none" || raw === undefined || raw === null) return "none";
+  if (raw === "inherit") return "inherit";
+  if (typeof raw === "object" && raw !== null) {
+    const obj = raw as Record<string, unknown>;
+    if (Array.isArray(obj.commands)) {
+      const commands: VerificationCommand[] = obj.commands
+        .filter((c): c is Record<string, unknown> => typeof c === "object" && c !== null)
+        .map(c => ({
+          command: String(c.command ?? ""),
+          blocking: c.blocking !== false,
+        }))
+        .filter(c => c.command.length > 0);
+      if (commands.length > 0) return { commands };
+    }
+  }
+  return null;
+}
+
+// ─── Validation ───────────────────────────────────────────────────────────
+
+interface ValidationResult {
+  valid: boolean;
+  errors: string[];
+}
+
+function validateSteps(steps: WorkflowStep[]): ValidationResult {
+  const errors: string[] = [];
+  const ids = new Set<string>();
+
+  for (const step of steps) {
+    // Unique IDs
+    if (ids.has(step.id)) {
+      errors.push(`Duplicate step ID: ${step.id}`);
+    }
+    ids.add(step.id);
+  }
+
+  // Validate requires references
+  for (const step of steps) {
+    for (const req of step.requires) {
+      if (!ids.has(req)) {
+        errors.push(`Step "${step.id}" requires unknown step "${req}"`);
+      }
+      if (req === step.id) {
+        errors.push(`Step "${step.id}" cannot require itself`);
+      }
+    }
+  }
+
+  // Check for cycles (simple DFS)
+  const visited = new Set<string>();
+  const visiting = new Set<string>();
+  const stepMap = new Map(steps.map(s => [s.id, s]));
+
+  function hasCycle(id: string): boolean {
+    if (visiting.has(id)) return true;
+    if (visited.has(id)) return false;
+    visiting.add(id);
+    const step = stepMap.get(id);
+    if (step) {
+      for (const req of step.requires) {
+        if (hasCycle(req)) return true;
+      }
+    }
+    visiting.delete(id);
+    visited.add(id);
+    return false;
+  }
+
+  for (const step of steps) {
+    if (hasCycle(step.id)) {
+      errors.push(`Dependency cycle detected involving step "${step.id}"`);
+      break;
+    }
+  }
+
+  return { valid: errors.length === 0, errors };
+}
+
+/**
+ * Validate a workflow definition and return detailed errors.
+ * Useful for user-facing error messages.
+ */
+export function validateWorkflowDefinition(content: string): { valid: boolean; errors: string[] } {
+  const startMarker = content.startsWith("---\r\n") ? "---\r\n" : "---\n";
+  if (!content.startsWith(startMarker)) return { valid: false, errors: ["Missing YAML frontmatter"] };
+  const searchStart = startMarker.length;
+  const endIdx = content.indexOf("\n---", searchStart);
+  if (endIdx === -1) return { valid: false, errors: ["Unclosed YAML frontmatter"] };
+  const block = content.slice(searchStart, endIdx).replace(/\r/g, "");
+
+  let raw: Record<string, unknown>;
+  try {
+    const parsed = parseYaml(block);
+    if (typeof parsed !== "object" || parsed === null) return { valid: false, errors: ["Frontmatter is not an object"] };
+    raw = parsed as Record<string, unknown>;
+  } catch (e) {
+    return { valid: false, errors: [`YAML parse error: ${e instanceof Error ? e.message : String(e)}`] };
+  }
+
+  const errors: string[] = [];
+  if (typeof raw.name !== "string" || !raw.name) errors.push("Missing required field: name");
+  if (typeof raw.description !== "string" || !raw.description) errors.push("Missing required field: description");
+  if (typeof raw.artifact_dir !== "string" || !raw.artifact_dir) errors.push("Missing required field: artifact_dir");
+  if (!Array.isArray(raw.steps) || raw.steps.length === 0) errors.push("Missing or empty steps array");
+
+  if (errors.length > 0) return { valid: false, errors };
+
+  const steps = parseSteps(raw.steps as unknown[]);
+  if (!steps) return { valid: false, errors: ["Invalid step definitions"] };
+
+  const validation = validateSteps(steps);
+  return validation;
+}

--- a/src/resources/extensions/gsd/workflow-dispatch.ts
+++ b/src/resources/extensions/gsd/workflow-dispatch.ts
@@ -1,0 +1,237 @@
+/**
+ * Custom Workflow Dispatch — resolves the next unit to dispatch for a
+ * custom workflow definition.
+ *
+ * The custom workflow equivalent of `auto-dispatch.ts`. Uses file existence
+ * as the completion signal (same pattern as `deriveState()`), but operates
+ * on a flat step list instead of the milestone/slice/task hierarchy.
+ */
+
+import type { DispatchAction } from "./auto-dispatch.js";
+import type { WorkflowDefinition, WorkflowStep, IterationConfig, VerificationMode } from "./workflow-definition.js";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
+// ─── Iteration Items ──────────────────────────────────────────────────────
+
+export interface IterationItem {
+  id: string;
+  index: number;
+  title: string;
+}
+
+/**
+ * Resolve iteration items from a source artifact using the configured pattern.
+ */
+export function resolveIterationItems(artDir: string, config: IterationConfig): IterationItem[] {
+  if (config.count !== undefined && config.count > 0) {
+    return Array.from({ length: config.count }, (_, i) => ({
+      id: formatIterationId(config.idFormat, i + 1),
+      index: i + 1,
+      title: `Item ${i + 1}`,
+    }));
+  }
+
+  const sourcePath = join(artDir, config.source);
+  if (!existsSync(sourcePath)) return [];
+
+  const content = readFileSync(sourcePath, "utf-8");
+  const regex = new RegExp(config.pattern, "gm");
+  const items: IterationItem[] = [];
+  let match: RegExpExecArray | null;
+  let index = 1;
+
+  while ((match = regex.exec(content)) !== null) {
+    const line = content.slice(match.index).split("\n")[0];
+    // Strip the matched pattern prefix to get the title
+    const title = line.replace(match[0], "").trim() || `Item ${index}`;
+    items.push({
+      id: formatIterationId(config.idFormat, index),
+      index,
+      title,
+    });
+    index++;
+  }
+
+  return items;
+}
+
+function formatIterationId(format: string, index: number): string {
+  // Simple format: replace {:02d} or {:03d} with zero-padded number
+  return format.replace(/\{:0?(\d+)d\}/, (_match, width) => {
+    const w = parseInt(width, 10);
+    return String(index).padStart(w, "0");
+  });
+}
+
+// ─── Template Rendering ───────────────────────────────────────────────────
+
+/**
+ * Render a workflow prompt template with variable substitution.
+ */
+export function renderWorkflowPrompt(
+  template: string,
+  vars: Record<string, string>,
+): string {
+  let result = template;
+  for (const [key, value] of Object.entries(vars)) {
+    result = result.replaceAll(`{{${key}}}`, value);
+  }
+  return result;
+}
+
+// ─── Artifact Existence ───────────────────────────────────────────────────
+
+function artifactExists(artDir: string, produces: string): boolean {
+  const path = join(artDir, produces);
+
+  // Directory-based produces (ends with /)
+  if (produces.endsWith("/")) {
+    return existsSync(path) && isNonEmptyDir(path);
+  }
+
+  return existsSync(path);
+}
+
+function isNonEmptyDir(path: string): boolean {
+  try {
+    const entries = readdirSync(path);
+    return entries.length > 0;
+  } catch {
+    return false;
+  }
+}
+
+// ─── Dispatch Resolution ──────────────────────────────────────────────────
+
+/**
+ * Resolve the next dispatch action for a custom workflow.
+ * Walks steps in dependency order, finds the first incomplete step
+ * whose dependencies are satisfied.
+ */
+export async function resolveWorkflowDispatch(
+  workflow: WorkflowDefinition,
+  basePath: string,
+): Promise<DispatchAction> {
+  const artDir = join(basePath, workflow.artifactDir);
+
+  for (const step of workflow.steps) {
+    // Check requires: all required steps' artifacts must exist
+    const depsReady = step.requires.every(depId => {
+      const dep = workflow.steps.find(s => s.id === depId);
+      return dep && artifactExists(artDir, dep.produces);
+    });
+    if (!depsReady) continue;
+
+    if (step.iterate) {
+      // Find first incomplete iteration
+      const items = resolveIterationItems(artDir, step.iterate);
+      for (const item of items) {
+        const itemProduces = step.produces.includes("{{iter_id}}")
+          ? step.produces.replaceAll("{{iter_id}}", item.id)
+          : step.produces;
+
+        // For directory-based produces, check individual iteration artifact
+        if (step.produces.endsWith("/")) {
+          const itemPath = join(artDir, step.produces, `${item.id}.md`);
+          if (existsSync(itemPath)) continue;
+        } else if (artifactExists(artDir, itemProduces)) {
+          continue;
+        }
+
+        return {
+          action: "dispatch",
+          unitType: `wf/${workflow.name}/${step.id}`,
+          unitId: item.id,
+          prompt: renderWorkflowPrompt(step.promptTemplate, {
+            artifact_dir: artDir,
+            iter_id: item.id,
+            iter_index: String(item.index),
+            iter_title: item.title,
+            step_name: step.name,
+          }),
+        };
+      }
+
+      // All iterations complete — check if directory-based produces is satisfied
+      if (step.produces.endsWith("/")) {
+        const dirPath = join(artDir, step.produces);
+        if (!existsSync(dirPath) || !isNonEmptyDir(dirPath)) {
+          // Edge case: source exists but yielded 0 items. Skip step.
+          continue;
+        }
+      }
+    } else {
+      if (!artifactExists(artDir, step.produces)) {
+        return {
+          action: "dispatch",
+          unitType: `wf/${workflow.name}/${step.id}`,
+          unitId: step.id,
+          prompt: renderWorkflowPrompt(step.promptTemplate, {
+            artifact_dir: artDir,
+            step_name: step.name,
+          }),
+        };
+      }
+    }
+  }
+
+  return {
+    action: "stop",
+    reason: `Workflow "${workflow.name}" complete.`,
+    level: "info",
+  };
+}
+
+// ─── Verification Resolution ──────────────────────────────────────────────
+
+/**
+ * Resolve the verification mode for a given workflow unit type.
+ * Falls back to the workflow-level default if the step has no override.
+ */
+export function resolveWorkflowVerification(
+  workflow: WorkflowDefinition,
+  unitType: string,
+): VerificationMode {
+  // Parse step ID from unitType: "wf/<name>/<stepId>"
+  const parts = unitType.split("/");
+  if (parts.length < 3) return workflow.verification;
+
+  const stepId = parts[2];
+  const step = workflow.steps.find(s => s.id === stepId);
+  if (!step) return workflow.verification;
+
+  return step.verification !== "none" ? step.verification : workflow.verification;
+}
+
+// ─── Model Category Resolution ────────────────────────────────────────────
+
+/**
+ * Resolve the model category for a workflow unit type.
+ * Maps to the same categories used in preferences (research, planning, etc.).
+ */
+export function resolveWorkflowModelCategory(
+  workflow: WorkflowDefinition,
+  unitType: string,
+): string | undefined {
+  const parts = unitType.split("/");
+  if (parts.length < 3) return undefined;
+
+  const stepId = parts[2];
+  const step = workflow.steps.find(s => s.id === stepId);
+  return step?.modelCategory;
+}
+
+/**
+ * Map a workflow model category to the corresponding auto-mode unit type
+ * for model resolution purposes.
+ */
+export function workflowCategoryToUnitType(category: string): string {
+  switch (category) {
+    case "research": return "research-milestone";
+    case "planning": return "plan-milestone";
+    case "execution": return "execute-task";
+    case "completion": return "complete-slice";
+    default: return "execute-task";
+  }
+}

--- a/src/resources/extensions/gsd/workflow-loader.ts
+++ b/src/resources/extensions/gsd/workflow-loader.ts
@@ -1,0 +1,171 @@
+/**
+ * Custom Workflow Loader — discovery, resolution, listing, and install.
+ *
+ * Discovers workflow definition files from multiple locations:
+ * 1. `.gsd/workflows/*.md` (project-local)
+ * 2. `~/.gsd/workflows/*.md` (user global)
+ *
+ * Provides resolution by name and listing for the `/gsd workflows` command.
+ */
+
+import { existsSync, readdirSync, readFileSync, mkdirSync, copyFileSync } from "node:fs";
+import { join, basename } from "node:path";
+import { homedir } from "node:os";
+import { parseWorkflowDefinition, type WorkflowDefinition } from "./workflow-definition.js";
+
+// ─── Discovery ────────────────────────────────────────────────────────────
+
+export interface WorkflowEntry {
+  name: string;
+  description: string;
+  source: "project" | "global";
+  path: string;
+}
+
+/**
+ * Discover all available workflows from project and global locations.
+ * Project workflows take precedence over global workflows with the same name.
+ */
+export function listWorkflows(basePath: string): WorkflowEntry[] {
+  const entries = new Map<string, WorkflowEntry>();
+
+  // Global workflows (lower priority)
+  const globalDir = join(homedir(), ".gsd", "workflows");
+  for (const entry of scanWorkflowDir(globalDir, "global")) {
+    entries.set(entry.name.toLowerCase(), entry);
+  }
+
+  // Project workflows (higher priority, overwrites global)
+  const projectDir = join(basePath, ".gsd", "workflows");
+  for (const entry of scanWorkflowDir(projectDir, "project")) {
+    entries.set(entry.name.toLowerCase(), entry);
+  }
+
+  return Array.from(entries.values()).sort((a, b) => a.name.localeCompare(b.name));
+}
+
+function scanWorkflowDir(dir: string, source: "project" | "global"): WorkflowEntry[] {
+  if (!existsSync(dir)) return [];
+
+  const entries: WorkflowEntry[] = [];
+  try {
+    for (const file of readdirSync(dir)) {
+      if (!file.endsWith(".md")) continue;
+      const filePath = join(dir, file);
+      try {
+        const content = readFileSync(filePath, "utf-8");
+        const def = parseWorkflowDefinition(content);
+        if (def) {
+          entries.push({
+            name: def.name,
+            description: def.description,
+            source,
+            path: filePath,
+          });
+        }
+      } catch {
+        // Skip invalid files
+      }
+    }
+  } catch {
+    // Directory read error
+  }
+
+  return entries;
+}
+
+// ─── Resolution ───────────────────────────────────────────────────────────
+
+/**
+ * Resolve a workflow by name or file path.
+ *
+ * Lookup order:
+ * 1. If `nameOrPath` is a file path that exists, parse it directly
+ * 2. Search project-local `.gsd/workflows/`
+ * 3. Search global `~/.gsd/workflows/`
+ */
+export function resolveWorkflow(nameOrPath: string, basePath: string): WorkflowDefinition | null {
+  // Direct path
+  if (nameOrPath.endsWith(".md") && existsSync(nameOrPath)) {
+    return loadWorkflowFile(nameOrPath);
+  }
+
+  // Search by name
+  const nameLower = nameOrPath.toLowerCase();
+
+  // Project-local first
+  const projectDir = join(basePath, ".gsd", "workflows");
+  const projectResult = findWorkflowByName(projectDir, nameLower);
+  if (projectResult) return projectResult;
+
+  // Global
+  const globalDir = join(homedir(), ".gsd", "workflows");
+  return findWorkflowByName(globalDir, nameLower);
+}
+
+function findWorkflowByName(dir: string, nameLower: string): WorkflowDefinition | null {
+  if (!existsSync(dir)) return null;
+
+  try {
+    for (const file of readdirSync(dir)) {
+      if (!file.endsWith(".md")) continue;
+      const def = loadWorkflowFile(join(dir, file));
+      if (def && def.name.toLowerCase() === nameLower) return def;
+    }
+  } catch {
+    // Directory read error
+  }
+
+  return null;
+}
+
+function loadWorkflowFile(path: string): WorkflowDefinition | null {
+  try {
+    const content = readFileSync(path, "utf-8");
+    return parseWorkflowDefinition(content);
+  } catch {
+    return null;
+  }
+}
+
+// ─── Install ──────────────────────────────────────────────────────────────
+
+/**
+ * Install a workflow file to the global `~/.gsd/workflows/` directory.
+ * Returns the destination path.
+ */
+export function installWorkflow(sourcePath: string): { installed: boolean; destPath: string; error?: string } {
+  const globalDir = join(homedir(), ".gsd", "workflows");
+
+  // Validate before installing
+  if (!existsSync(sourcePath)) {
+    return { installed: false, destPath: "", error: `File not found: ${sourcePath}` };
+  }
+
+  const def = loadWorkflowFile(sourcePath);
+  if (!def) {
+    return { installed: false, destPath: "", error: "Invalid workflow definition" };
+  }
+
+  mkdirSync(globalDir, { recursive: true });
+  const destPath = join(globalDir, basename(sourcePath));
+  copyFileSync(sourcePath, destPath);
+
+  return { installed: true, destPath };
+}
+
+/**
+ * Discover available workflows for a given base path.
+ * Returns parsed WorkflowDefinition objects (heavier than listWorkflows).
+ */
+export function discoverWorkflows(basePath: string): WorkflowDefinition[] {
+  const entries = listWorkflows(basePath);
+  const defs: WorkflowDefinition[] = [];
+
+  for (const entry of entries) {
+    const def = loadWorkflowFile(entry.path);
+    if (def) defs.push(def);
+  }
+
+  return defs;
+}


### PR DESCRIPTION
## Summary

- **Data-driven auto-mode**: custom workflows (ebook writing, ML research, music production, etc.) get the same orchestration power as the default software dev workflow — crash recovery, session-per-step, budget tracking, model routing, verification gates
- **Zero impact on default path**: `state.ts` and `auto-dispatch.ts` are untouched. When `s.workflow` is set, `dispatchNextUnit()` bypasses `deriveState()` entirely and uses a file-existence-based resolver
- **3 new files** (~560 lines): workflow definition parser with cycle detection, dispatch resolver with iteration engine, loader with project/global discovery chain
- **8 modified files** (~270 lines): session state, bootstrap, dispatch branching, verification gate, model selection, dashboard labels, commands

## New Commands

```
/gsd auto --workflow "Write Ebook"     # start auto with custom workflow
/gsd workflows                          # list available workflows
/gsd workflow install ./my-workflow.md  # install globally
```

## Workflow Definition Format

```yaml
---
name: Write Ebook
artifact_dir: .gsd/workflows/ebook
steps:
  - id: research
    name: Research Topic
    model_category: research
    produces: RESEARCH.md
    prompt: |
      Research the topic. Write to {{artifact_dir}}/RESEARCH.md.
  - id: outline
    requires: [research]
    produces: OUTLINE.md
    ...
  - id: draft
    requires: [outline]
    iterate:
      source: OUTLINE.md
      pattern: "^## "
      id_format: "CH{:02d}"
    ...
---
```

## Test plan

- [x] 19 unit tests for workflow definition parsing and validation
- [x] 14 unit tests for workflow dispatch, iteration, template rendering
- [x] 9/9 session encapsulation tests pass (new `workflow` property)
- [x] 21/21 dashboard tests pass (new `wf/*` unit type handling)
- [x] Clean build — zero type errors
- [x] Full test suite — no regressions (6 pre-existing headless CLI failures)


🤖 Generated with [Claude Code](https://claude.com/claude-code)