### PR TITLE
refactor: unify unit-type switch statements into lookup map

### DIFF
--- a/src/resources/extensions/gsd/auto-dashboard.ts
+++ b/src/resources/extensions/gsd/auto-dashboard.ts
@@ -48,40 +48,34 @@ export interface AutoDashboardData {
 
 // ─── Unit Description Helpers ─────────────────────────────────────────────────
 
+/** Canonical verb and phase label for each known unit type. */
+const UNIT_TYPE_INFO: Record<string, { verb: string; phaseLabel: string }> = {
+  "research-milestone": { verb: "researching",  phaseLabel: "RESEARCH" },
+  "research-slice":     { verb: "researching",  phaseLabel: "RESEARCH" },
+  "plan-milestone":     { verb: "planning",     phaseLabel: "PLAN" },
+  "plan-slice":         { verb: "planning",     phaseLabel: "PLAN" },
+  "execute-task":       { verb: "executing",    phaseLabel: "EXECUTE" },
+  "complete-slice":     { verb: "completing",   phaseLabel: "COMPLETE" },
+  "replan-slice":       { verb: "replanning",   phaseLabel: "REPLAN" },
+  "rewrite-docs":       { verb: "rewriting",    phaseLabel: "REWRITE" },
+  "reassess-roadmap":   { verb: "reassessing",  phaseLabel: "REASSESS" },
+  "run-uat":            { verb: "running UAT",  phaseLabel: "UAT" },
+};
+
 export function unitVerb(unitType: string): string {
   if (unitType.startsWith("hook/")) return `hook: ${unitType.slice(5)}`;
-  switch (unitType) {
-    case "research-milestone":
-    case "research-slice": return "researching";
-    case "plan-milestone":
-    case "plan-slice": return "planning";
-    case "execute-task": return "executing";
-    case "complete-slice": return "completing";
-    case "replan-slice": return "replanning";
-    case "rewrite-docs": return "rewriting";
-    case "reassess-roadmap": return "reassessing";
-    case "run-uat": return "running UAT";
-    default: return unitType;
-  }
+  return UNIT_TYPE_INFO[unitType]?.verb ?? unitType;
 }
 
 export function unitPhaseLabel(unitType: string): string {
   if (unitType.startsWith("hook/")) return "HOOK";
-  switch (unitType) {
-    case "research-milestone": return "RESEARCH";
-    case "research-slice": return "RESEARCH";
-    case "plan-milestone": return "PLAN";
-    case "plan-slice": return "PLAN";
-    case "execute-task": return "EXECUTE";
-    case "complete-slice": return "COMPLETE";
-    case "replan-slice": return "REPLAN";
-    case "rewrite-docs": return "REWRITE";
-    case "reassess-roadmap": return "REASSESS";
-    case "run-uat": return "UAT";
-    default: return unitType.toUpperCase();
-  }
+  return UNIT_TYPE_INFO[unitType]?.phaseLabel ?? unitType.toUpperCase();
 }
 
+/**
+ * Describe the expected next step after the current unit completes.
+ * Unit types here mirror the keys in UNIT_TYPE_INFO above.
+ */
 function peekNext(unitType: string, state: GSDState): string {
   // Show active hook info in progress display
   const activeHookState = getActiveHook();


### PR DESCRIPTION
## What
Consolidate duplicated unit-type switch statements in `auto-dashboard.ts` into a single `UNIT_TYPE_INFO` lookup map.

## Why
`unitVerb()` and `unitPhaseLabel()` both switched over the same 10 unit-type strings with identical case lists. Adding or renaming a unit type required updating both switches independently — a DRY violation that invites drift.

## How
- Introduce a `UNIT_TYPE_INFO` record mapping each unit type to `{ verb, phaseLabel }`.
- Rewrite `unitVerb()` and `unitPhaseLabel()` as one-liner lookups with the same fallback behavior (hook prefix special case, unknown type passthrough).
- Leave `peekNext()` as a switch because it depends on runtime state (`state.activeSlice.id`, active hook checks), but add a doc comment referencing the map for discoverability.

## Key changes
- `src/resources/extensions/gsd/auto-dashboard.ts`: +20 / -26 lines — net reduction in code while improving maintainability.

## Testing
- `npx tsc --noEmit` passes with zero errors.
- All 21 existing `auto-dashboard.test.ts` tests pass (unitVerb, unitPhaseLabel, hook handling, unknown types, formatAutoElapsed, formatWidgetTokens).
- Grep confirms no call sites changed — `unitVerb` and `unitPhaseLabel` exports are preserved.

## Risk
Low. Pure refactor with no behavioral change. All return values, special cases, and exports are identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)