### PR TITLE
refactor: extract unit dispatch init helper, inline dead abstraction

### DIFF
--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -64,6 +64,30 @@ import { join } from "node:path";
 /** Throttle STATE.md rebuilds — at most once per 30 seconds */
 const STATE_REBUILD_MIN_INTERVAL_MS = 30_000;
 
+/**
+ * Initialize a unit dispatch: stamp the current time, set `s.currentUnit`,
+ * and persist the initial runtime record. Returns `startedAt` for callers
+ * that need the timestamp.
+ */
+function dispatchUnit(
+  s: AutoSession,
+  basePath: string,
+  unitType: string,
+  unitId: string,
+): number {
+  const startedAt = Date.now();
+  s.currentUnit = { type: unitType, id: unitId, startedAt };
+  writeUnitRuntimeRecord(basePath, unitType, unitId, startedAt, {
+    phase: "dispatched",
+    wrapupWarningSent: false,
+    timeoutAt: null,
+    lastProgressAt: startedAt,
+    progressCount: 0,
+    lastProgressKind: "dispatch",
+  });
+  return startedAt;
+}
+
 export interface PostUnitContext {
   s: AutoSession;
   ctx: ExtensionContext;
@@ -364,19 +388,10 @@ export async function postUnitPostVerification(pctx: PostUnitContext): Promise<"
   if (s.currentUnit && !s.stepMode) {
     const hookUnit = checkPostUnitHooks(s.currentUnit.type, s.currentUnit.id, s.basePath);
     if (hookUnit) {
-      const hookStartedAt = Date.now();
       if (s.currentUnit) {
         await closeoutUnit(ctx, s.basePath, s.currentUnit.type, s.currentUnit.id, s.currentUnit.startedAt, buildSnapshotOpts(s.currentUnit.type, s.currentUnit.id));
       }
-      s.currentUnit = { type: hookUnit.unitType, id: hookUnit.unitId, startedAt: hookStartedAt };
-      writeUnitRuntimeRecord(s.basePath, hookUnit.unitType, hookUnit.unitId, hookStartedAt, {
-        phase: "dispatched",
-        wrapupWarningSent: false,
-        timeoutAt: null,
-        lastProgressAt: hookStartedAt,
-        progressCount: 0,
-        lastProgressKind: "dispatch",
-      });
+      dispatchUnit(s, s.basePath, hookUnit.unitType, hookUnit.unitId);
 
       const state = await deriveState(s.basePath);
       updateProgressWidget(ctx, hookUnit.unitType, hookUnit.unitId, state);
@@ -498,16 +513,7 @@ export async function postUnitPostVerification(pctx: PostUnitContext): Promise<"
 
             const triageUnitType = "triage-captures";
             const triageUnitId = `${mid}/${sid}/triage`;
-            const triageStartedAt = Date.now();
-            s.currentUnit = { type: triageUnitType, id: triageUnitId, startedAt: triageStartedAt };
-            writeUnitRuntimeRecord(s.basePath, triageUnitType, triageUnitId, triageStartedAt, {
-              phase: "dispatched",
-              wrapupWarningSent: false,
-              timeoutAt: null,
-              lastProgressAt: triageStartedAt,
-              progressCount: 0,
-              lastProgressKind: "dispatch",
-            });
+            dispatchUnit(s, s.basePath, triageUnitType, triageUnitId);
             updateProgressWidget(ctx, triageUnitType, triageUnitId, state);
 
             const result = await s.cmdCtx!.newSession();
@@ -568,16 +574,7 @@ export async function postUnitPostVerification(pctx: PostUnitContext): Promise<"
 
       const qtUnitType = "quick-task";
       const qtUnitId = `${s.currentMilestoneId}/${capture.id}`;
-      const qtStartedAt = Date.now();
-      s.currentUnit = { type: qtUnitType, id: qtUnitId, startedAt: qtStartedAt };
-      writeUnitRuntimeRecord(s.basePath, qtUnitType, qtUnitId, qtStartedAt, {
-        phase: "dispatched",
-        wrapupWarningSent: false,
-        timeoutAt: null,
-        lastProgressAt: qtStartedAt,
-        progressCount: 0,
-        lastProgressKind: "dispatch",
-      });
+      dispatchUnit(s, s.basePath, qtUnitType, qtUnitId);
       const state = await deriveState(s.basePath);
       updateProgressWidget(ctx, qtUnitType, qtUnitId, state);
 

--- a/src/resources/extensions/gsd/guided-flow-queue.ts
+++ b/src/resources/extensions/gsd/guided-flow-queue.ts
@@ -23,13 +23,6 @@ import { loadEffectiveGSDPreferences } from "./preferences.js";
 import { loadQueueOrder, sortByQueueOrder, saveQueueOrder } from "./queue-order.js";
 import { findMilestoneIds, nextMilestoneId } from "./milestone-ids.js";
 
-// ─── Commit Instruction Helper (local copy — avoids circular dep) ───────────
-
-/** Build commit instruction for queue prompts. .gsd/ is managed externally and always gitignored. */
-function buildDocsCommitInstruction(_message: string): string {
-  return "Do not commit planning artifacts — .gsd/ is managed externally.";
-}
-
 // ─── Queue Entry Point ──────────────────────────────────────────────────────
 
 /**
@@ -207,7 +200,7 @@ export async function showQueueAdd(
     preamble,
     existingMilestonesContext: existingContext,
     inlinedTemplates: queueInlinedTemplates,
-    commitInstruction: buildDocsCommitInstruction("docs: queue <milestone list>"),
+    commitInstruction: "Do not commit planning artifacts — .gsd/ is managed externally.",
   });
 
   pi.sendMessage(


### PR DESCRIPTION
## What
Extract the repeated unit dispatch initialization pattern in `auto-post-unit.ts` into a `dispatchUnit()` helper, and inline the dead `buildDocsCommitInstruction()` abstraction in `guided-flow-queue.ts`.

## Why
Three sites in `auto-post-unit.ts` (hook dispatch, triage dispatch, quick-task dispatch) duplicated identical code: stamping `Date.now()`, setting `s.currentUnit`, and calling `writeUnitRuntimeRecord` with the same "dispatched" struct literal. Adding a new field to the runtime record required three coordinated edits -- easy to miss one and introduce a silent bug.

`buildDocsCommitInstruction()` ignored its parameter and returned a constant string, used at a single call site. The function added indirection with zero value.

## How
- Created a private `dispatchUnit(s, basePath, unitType, unitId)` helper that encapsulates the timestamp creation, `s.currentUnit` assignment, and `writeUnitRuntimeRecord` call with the full "dispatched" struct.
- Replaced all three dispatch sites with a single `dispatchUnit()` call each.
- Inlined the constant string `"Do not commit planning artifacts — .gsd/ is managed externally."` at the call site in `guided-flow-queue.ts` and deleted the function definition + comment block.

## Key changes
- `src/resources/extensions/gsd/auto-post-unit.ts`: +`dispatchUnit()` helper, -3 duplicated struct literals
- `src/resources/extensions/gsd/guided-flow-queue.ts`: -`buildDocsCommitInstruction()`, inlined string at call site

## Testing
- `npx tsc --noEmit` passes cleanly
- Grepped for `writeUnitRuntimeRecord` in `auto-post-unit.ts` -- remaining calls are the helper itself (line 80), hook finalization (phase "finalized"), and hook timeout (phase "timeout"), all structurally different
- Grepped for `buildDocsCommitInstruction` -- only remains in `guided-flow.ts` (separate, unrelated copy)
- Full test suite run initiated

## Risk
Low. Pure mechanical refactor -- no behavioral changes. The helper produces the exact same struct literal and side effects as the inlined code it replaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)