### PR TITLE
refactor: extract createGitService() factory, remove debug logs

### DIFF
--- a/src/resources/extensions/gsd/auto-start.ts
+++ b/src/resources/extensions/gsd/auto-start.ts
@@ -38,7 +38,7 @@ import {
 import { selfHealRuntimeRecords } from "./auto-recovery.js";
 import { ensureGitignore, untrackRuntimeFiles } from "./gitignore.js";
 import { nativeIsRepo, nativeInit } from "./native-git-bridge.js";
-import { GitServiceImpl } from "./git-service.js";
+import { createGitService } from "./git-service.js";
 import {
   captureIntegrationBranch,
   detectWorktreeName,
@@ -129,7 +129,7 @@ export async function bootstrapAutoSession(
   }
 
   // Initialize GitServiceImpl
-  s.gitService = new GitServiceImpl(s.basePath, loadEffectiveGSDPreferences()?.preferences?.git ?? {});
+  s.gitService = createGitService(s.basePath);
 
   // Check for crash from previous session (use both old and new lock data)
   const crashLock = readCrashLock(base);
@@ -330,12 +330,12 @@ export async function bootstrapAutoSession(
       if (existingWtPath) {
         const wtPath = enterAutoWorktree(base, s.currentMilestoneId);
         s.basePath = wtPath;
-        s.gitService = new GitServiceImpl(s.basePath, loadEffectiveGSDPreferences()?.preferences?.git ?? {});
+        s.gitService = createGitService(s.basePath);
         ctx.ui.notify(`Entered auto-worktree at ${wtPath}`, "info");
       } else {
         const wtPath = createAutoWorktree(base, s.currentMilestoneId);
         s.basePath = wtPath;
-        s.gitService = new GitServiceImpl(s.basePath, loadEffectiveGSDPreferences()?.preferences?.git ?? {});
+        s.gitService = createGitService(s.basePath);
         ctx.ui.notify(`Created auto-worktree at ${wtPath}`, "info");
       }
       registerSigtermHandler(s.originalBasePath);

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -118,7 +118,7 @@ import {
   parseSliceBranch,
   setActiveMilestoneId,
 } from "./worktree.js";
-import { GitServiceImpl, type TaskCommitContext } from "./git-service.js";
+import { createGitService, type TaskCommitContext } from "./git-service.js";
 import { getPriorSliceCompletionBlocker } from "./dispatch-guard.js";
 import { formatGitError } from "./git-self-heal.js";
 import {
@@ -462,7 +462,7 @@ export async function stopAuto(ctx?: ExtensionContext, pi?: ExtensionAPI, reason
       try { autoCommitCurrentBranch(s.basePath, "stop", s.currentMilestoneId); } catch (e) { debugLog("stop-auto-commit-failed", { error: e instanceof Error ? e.message : String(e) }); }
       teardownAutoWorktree(s.originalBasePath, s.currentMilestoneId, { preserveBranch: true });
       s.basePath = s.originalBasePath;
-      s.gitService = new GitServiceImpl(s.basePath, loadEffectiveGSDPreferences()?.preferences?.git ?? {});
+      s.gitService = createGitService(s.basePath);
       ctx?.ui.notify("Exited auto-worktree (branch preserved for resume).", "info");
     } catch (err) {
       ctx?.ui.notify(
@@ -626,12 +626,12 @@ export async function startAuto(
         if (existingWtPath) {
           const wtPath = enterAutoWorktree(s.originalBasePath, s.currentMilestoneId);
           s.basePath = wtPath;
-          s.gitService = new GitServiceImpl(s.basePath, loadEffectiveGSDPreferences()?.preferences?.git ?? {});
+          s.gitService = createGitService(s.basePath);
           ctx.ui.notify(`Re-entered auto-worktree at ${wtPath}`, "info");
         } else {
           const wtPath = createAutoWorktree(s.originalBasePath, s.currentMilestoneId);
           s.basePath = wtPath;
-          s.gitService = new GitServiceImpl(s.basePath, loadEffectiveGSDPreferences()?.preferences?.git ?? {});
+          s.gitService = createGitService(s.basePath);
           ctx.ui.notify(`Recreated auto-worktree at ${wtPath}`, "info");
         }
       } catch (err) {
@@ -1124,7 +1124,7 @@ async function dispatchNextUnit(
       }
 
       s.basePath = s.originalBasePath;
-      s.gitService = new GitServiceImpl(s.basePath, loadEffectiveGSDPreferences()?.preferences?.git ?? {});
+      s.gitService = createGitService(s.basePath);
       invalidateAllCaches();
 
       state = await deriveState(s.basePath);
@@ -1136,7 +1136,7 @@ async function dispatchNextUnit(
         try {
           const wtPath = createAutoWorktree(s.basePath, mid);
           s.basePath = wtPath;
-          s.gitService = new GitServiceImpl(s.basePath, loadEffectiveGSDPreferences()?.preferences?.git ?? {});
+          s.gitService = createGitService(s.basePath);
           ctx.ui.notify(`Created auto-worktree for ${mid} at ${wtPath}`, "info");
         } catch (err) {
           ctx.ui.notify(
@@ -1176,7 +1176,7 @@ async function dispatchNextUnit(
             const roadmapContent = readFileSync(roadmapPath, "utf-8");
             const mergeResult = mergeMilestoneToMain(s.originalBasePath, s.currentMilestoneId, roadmapContent);
             s.basePath = s.originalBasePath;
-            s.gitService = new GitServiceImpl(s.basePath, loadEffectiveGSDPreferences()?.preferences?.git ?? {});
+            s.gitService = createGitService(s.basePath);
             ctx.ui.notify(
               `Milestone ${ s.currentMilestoneId } merged to main.${mergeResult.pushed ? " Pushed to remote." : ""}`,
               "info",
@@ -1201,7 +1201,7 @@ async function dispatchNextUnit(
             if (roadmapPath) {
               const roadmapContent = readFileSync(roadmapPath, "utf-8");
               const mergeResult = mergeMilestoneToMain(s.basePath, s.currentMilestoneId, roadmapContent);
-              s.gitService = new GitServiceImpl(s.basePath, loadEffectiveGSDPreferences()?.preferences?.git ?? {});
+              s.gitService = createGitService(s.basePath);
               ctx.ui.notify(
                 `Milestone ${ s.currentMilestoneId } merged (branch mode).${mergeResult.pushed ? " Pushed to remote." : ""}`,
                 "info",
@@ -1279,7 +1279,7 @@ async function dispatchNextUnit(
         const roadmapContent = readFileSync(roadmapPath, "utf-8");
         const mergeResult = mergeMilestoneToMain(s.originalBasePath, s.currentMilestoneId, roadmapContent);
         s.basePath = s.originalBasePath;
-        s.gitService = new GitServiceImpl(s.basePath, loadEffectiveGSDPreferences()?.preferences?.git ?? {});
+        s.gitService = createGitService(s.basePath);
         ctx.ui.notify(
           `Milestone ${ s.currentMilestoneId } merged to main.${mergeResult.pushed ? " Pushed to remote." : ""}`,
           "info",
@@ -1303,7 +1303,7 @@ async function dispatchNextUnit(
           if (roadmapPath) {
             const roadmapContent = readFileSync(roadmapPath, "utf-8");
             const mergeResult = mergeMilestoneToMain(s.basePath, s.currentMilestoneId, roadmapContent);
-            s.gitService = new GitServiceImpl(s.basePath, loadEffectiveGSDPreferences()?.preferences?.git ?? {});
+            s.gitService = createGitService(s.basePath);
             ctx.ui.notify(
               `Milestone ${ s.currentMilestoneId } merged (branch mode).${mergeResult.pushed ? " Pushed to remote." : ""}`,
               "info",
@@ -1874,8 +1874,6 @@ export async function dispatchHookUnit(
   ctx.ui.setStatus("gsd-auto", s.stepMode ? "next" : "auto");
   ctx.ui.notify(`Running post-unit hook: ${hookName}`, "info");
 
-  console.log(`[dispatchHookUnit] Sending prompt of length ${hookPrompt.length}`);
-  console.log(`[dispatchHookUnit] Prompt preview: ${hookPrompt.substring(0, 200)}...`);
   pi.sendMessage(
     { customType: "gsd-auto", content: hookPrompt, display: true },
     { triggerTurn: true },

--- a/src/resources/extensions/gsd/commands-workflow-templates.ts
+++ b/src/resources/extensions/gsd/commands-workflow-templates.ts
@@ -19,8 +19,7 @@ import {
 } from "./workflow-templates.js";
 import { loadPrompt } from "./prompt-loader.js";
 import { gsdRoot } from "./paths.js";
-import { GitServiceImpl, runGit } from "./git-service.js";
-import { loadEffectiveGSDPreferences } from "./preferences.js";
+import { createGitService, runGit } from "./git-service.js";
 import { isAutoActive, isAutoPaused } from "./auto.js";
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
@@ -423,9 +422,8 @@ export async function handleStart(
 
   // ─── Create git branch (unless isolation: none) ─────────────────────────
 
-  const gitPrefs = loadEffectiveGSDPreferences()?.preferences?.git ?? {};
-  const git = new GitServiceImpl(basePath, gitPrefs);
-  const skipBranch = gitPrefs.isolation === "none";
+  const git = createGitService(basePath);
+  const skipBranch = git.prefs.isolation === "none";
   const slug = slugify(description || templateId);
   const branchName = `gsd/${templateId}/${slug}`;
   let branchCreated = false;

--- a/src/resources/extensions/gsd/git-service.ts
+++ b/src/resources/extensions/gsd/git-service.ts
@@ -13,6 +13,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { gsdRoot } from "./paths.js";
 import { GIT_NO_PROMPT_ENV } from "./git-constants.js";
+import { loadEffectiveGSDPreferences } from "./preferences.js";
 
 import {
   detectWorktreeName,
@@ -539,6 +540,14 @@ export class GitServiceImpl {
 
   // ─── Merge ─────────────────────────────────────────────────────────────
 
+}
+
+// ─── Factory ───────────────────────────────────────────────────────────────
+
+/** Create a GitServiceImpl with the current effective git preferences. */
+export function createGitService(basePath: string): GitServiceImpl {
+  const gitPrefs = loadEffectiveGSDPreferences()?.preferences?.git ?? {};
+  return new GitServiceImpl(basePath, gitPrefs);
 }
 
 // ─── Commit Type Inference ─────────────────────────────────────────────────

--- a/src/resources/extensions/gsd/quick.ts
+++ b/src/resources/extensions/gsd/quick.ts
@@ -14,8 +14,7 @@ import { existsSync, mkdirSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 import { loadPrompt } from "./prompt-loader.js";
 import { gsdRoot } from "./paths.js";
-import { GitServiceImpl, runGit } from "./git-service.js";
-import { loadEffectiveGSDPreferences } from "./preferences.js";
+import { createGitService, runGit } from "./git-service.js";
 
 // ─── Quick Task Helpers ───────────────────────────────────────────────────────
 
@@ -103,10 +102,9 @@ export async function handleQuick(
   const date = new Date().toISOString().split("T")[0];
 
   // Create git branch for the quick task (unless isolation: none)
-  const gitPrefs = loadEffectiveGSDPreferences()?.preferences?.git ?? {};
-  const git = new GitServiceImpl(basePath, gitPrefs);
+  const git = createGitService(basePath);
   const branchName = `gsd/quick/${taskNum}-${slug}`;
-  const skipBranch = gitPrefs.isolation === "none";
+  const skipBranch = git.prefs.isolation === "none";
 
   let branchCreated = false;
   if (!skipBranch) {


### PR DESCRIPTION
## What
Extract a `createGitService(basePath)` factory function and remove debug `console.log` statements from `dispatchHookUnit`.

## Why
13 call sites copy-pasted `new GitServiceImpl(basePath, loadEffectiveGSDPreferences()?.preferences?.git ?? {})`. If git preference defaults change, all 13 sites need updating. The two `console.log` statements in `dispatchHookUnit` pollute stderr on every hook dispatch with prompt length and preview noise.

## How
- Added `createGitService(basePath): GitServiceImpl` to `git-service.ts`, encapsulating the preference-loading pattern in one place.
- Replaced all 13 inline instantiations across `auto.ts` (9), `auto-start.ts` (3), `commands-workflow-templates.ts` (1), and `quick.ts` (1).
- Removed unused `loadEffectiveGSDPreferences` imports from files that no longer reference it directly (`commands-workflow-templates.ts`, `quick.ts`).
- For `commands-workflow-templates.ts` and `quick.ts`, the local `gitPrefs` variable was also eliminated by reading `git.prefs.isolation` from the created instance.
- Deleted 2 `console.log` lines in `dispatchHookUnit` (~line 1877-1878).

## Key changes
| File | Change |
|------|--------|
| `git-service.ts` | Added `createGitService()` factory + `loadEffectiveGSDPreferences` import |
| `auto.ts` | 9 sites → `createGitService(s.basePath)`, removed 2 console.log lines |
| `auto-start.ts` | 3 sites → `createGitService(s.basePath)` |
| `commands-workflow-templates.ts` | 1 site → `createGitService(basePath)`, removed unused import |
| `quick.ts` | 1 site → `createGitService(basePath)`, removed unused import |

## Testing
- `npx tsc --noEmit` passes with zero errors (no circular dependency issues)
- `grep -rn "new GitServiceImpl.*loadEffective"` returns zero matches (all sites replaced)
- `grep -n "console.log.*dispatchHookUnit"` returns zero matches (debug logs removed)
- Full test suite via `npx vitest run`

## Risk
Low. Pure mechanical refactor — no behavior change. The factory function calls the same constructor with the same arguments. The only semantic change is removing two debug log statements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)