### PR TITLE
refactor: deduplicate knownUnitTypes and STATE_REBUILD_MIN_INTERVAL_MS constants

### DIFF
--- a/src/resources/extensions/gsd/auto-constants.ts
+++ b/src/resources/extensions/gsd/auto-constants.ts
@@ -1,0 +1,6 @@
+/**
+ * Shared constants for auto-mode modules (auto.ts, auto-post-unit.ts, etc.).
+ */
+
+/** Throttle STATE.md rebuilds — at most once per 30 seconds. */
+export const STATE_REBUILD_MIN_INTERVAL_MS = 30_000;

--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -60,9 +60,7 @@ import {
   hideFooter,
 } from "./auto-dashboard.js";
 import { join } from "node:path";
-
-/** Throttle STATE.md rebuilds — at most once per 30 seconds */
-const STATE_REBUILD_MIN_INTERVAL_MS = 30_000;
+import { STATE_REBUILD_MIN_INTERVAL_MS } from "./auto-constants.js";
 
 export interface PostUnitContext {
   s: AutoSession;

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -204,8 +204,7 @@ import type { CompletedUnit, CurrentUnit, UnitRouting, StartModel, PendingVerifi
 // ─────────────────────────────────────────────────────────────────────────────
 const s = new AutoSession();
 
-/** Throttle STATE.md rebuilds — at most once per 30 seconds */
-const STATE_REBUILD_MIN_INTERVAL_MS = 30_000;
+import { STATE_REBUILD_MIN_INTERVAL_MS } from "./auto-constants.js";
 
 export function shouldUseWorktreeIsolation(): boolean {
   const prefs = loadEffectiveGSDPreferences()?.preferences?.git;

--- a/src/resources/extensions/gsd/preferences-types.ts
+++ b/src/resources/extensions/gsd/preferences-types.ts
@@ -86,6 +86,14 @@ export const KNOWN_PREFERENCE_KEYS = new Set<string>([
   "context_selection",
 ]);
 
+/** Canonical list of all dispatch unit types. */
+export const KNOWN_UNIT_TYPES = [
+  "research-milestone", "plan-milestone", "research-slice", "plan-slice",
+  "execute-task", "complete-slice", "replan-slice", "reassess-roadmap",
+  "run-uat", "complete-milestone",
+] as const;
+export type UnitType = (typeof KNOWN_UNIT_TYPES)[number];
+
 export const SKILL_ACTIONS = new Set(["use", "prefer", "avoid"]);
 
 export interface GSDSkillRule {

--- a/src/resources/extensions/gsd/preferences-validation.ts
+++ b/src/resources/extensions/gsd/preferences-validation.ts
@@ -14,6 +14,7 @@ import { normalizeStringArray } from "../shared/mod.js";
 
 import {
   KNOWN_PREFERENCE_KEYS,
+  KNOWN_UNIT_TYPES,
   SKILL_ACTIONS,
   type WorkflowMode,
   type GSDPreferences,
@@ -239,11 +240,7 @@ export function validatePreferences(preferences: GSDPreferences): {
   if (preferences.post_unit_hooks && Array.isArray(preferences.post_unit_hooks)) {
     const validHooks: PostUnitHookConfig[] = [];
     const seenNames = new Set<string>();
-    const knownUnitTypes = new Set([
-      "research-milestone", "plan-milestone", "research-slice", "plan-slice",
-      "execute-task", "complete-slice", "replan-slice", "reassess-roadmap",
-      "run-uat", "complete-milestone",
-    ]);
+    const knownUnitTypes = new Set<string>(KNOWN_UNIT_TYPES);
     for (const hook of preferences.post_unit_hooks) {
       if (!hook || typeof hook !== "object") {
         errors.push("post_unit_hooks entry must be an object");
@@ -305,11 +302,7 @@ export function validatePreferences(preferences: GSDPreferences): {
   if (preferences.pre_dispatch_hooks && Array.isArray(preferences.pre_dispatch_hooks)) {
     const validPreHooks: PreDispatchHookConfig[] = [];
     const seenPreNames = new Set<string>();
-    const knownUnitTypes = new Set([
-      "research-milestone", "plan-milestone", "research-slice", "plan-slice",
-      "execute-task", "complete-slice", "replan-slice", "reassess-roadmap",
-      "run-uat", "complete-milestone",
-    ]);
+    const knownUnitTypes = new Set<string>(KNOWN_UNIT_TYPES);
     const validActions = new Set(["modify", "skip", "replace"]);
     for (const hook of preferences.pre_dispatch_hooks) {
       if (!hook || typeof hook !== "object") {


### PR DESCRIPTION
## What
Deduplicate two sets of constants that were defined identically in multiple files:
1. `knownUnitTypes` — the Set of 10 unit type strings (defined twice in `preferences-validation.ts`)
2. `STATE_REBUILD_MIN_INTERVAL_MS = 30_000` — defined in both `auto.ts` and `auto-post-unit.ts`

## Why
Source-of-truth violations. Adding a new unit type required updating two identical inline Sets. Changing the rebuild throttle required finding both definitions. These would cause bugs when only one copy is updated.

## How
- Added `KNOWN_UNIT_TYPES` as const array and `UnitType` derived type to `preferences-types.ts`
- Both `knownUnitTypes` Sets in `preferences-validation.ts` now use `new Set<string>(KNOWN_UNIT_TYPES)`
- Created `auto-constants.ts` with the single `STATE_REBUILD_MIN_INTERVAL_MS` definition
- Both `auto.ts` and `auto-post-unit.ts` import from `auto-constants.ts`

## Key changes
- `preferences-types.ts` — new `KNOWN_UNIT_TYPES` array and `UnitType` type export
- `preferences-validation.ts` — import + use shared array instead of inline Sets (lines ~243, ~305)
- `auto-constants.ts` — new file, single definition of `STATE_REBUILD_MIN_INTERVAL_MS`
- `auto.ts` — replaced local const with import
- `auto-post-unit.ts` — replaced local const with import

## Testing
- `npx tsc --noEmit` passes cleanly
- Verified `knownUnitTypes` definitions use `KNOWN_UNIT_TYPES` (not inline arrays)
- Verified `STATE_REBUILD_MIN_INTERVAL_MS` has exactly 1 definition and 2 imports
- Full test suite shows no regressions (all failures are pre-existing empty test file stubs)

## Risk
Low. Pure refactor — no behavioral changes. The constant values and their usage sites are identical before and after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)