### PR TITLE
fix: skip false crash recovery when auto.lock is from current process

### DIFF
--- a/src/resources/extensions/gsd/auto-start.ts
+++ b/src/resources/extensions/gsd/auto-start.ts
@@ -131,9 +131,11 @@ export async function bootstrapAutoSession(
   // Initialize GitServiceImpl
   s.gitService = createGitService(s.basePath);
 
-  // Check for crash from previous session (use both old and new lock data)
+  // Check for crash from previous session (use both old and new lock data).
+  // Skip if the lock PID matches this process — acquireSessionLock() writes
+  // to the same auto.lock file before this check, so we'd always false-positive.
   const crashLock = readCrashLock(base);
-  if (crashLock) {
+  if (crashLock && crashLock.pid !== process.pid) {
     // We already hold the session lock, so no concurrent session is running.
     // The crash lock is from a dead process — recover context from it.
     const recoveredMid = crashLock.unitId.split("/")[0];


### PR DESCRIPTION
## Summary

- `acquireSessionLock()` and `readCrashLock()` both use the same `auto.lock` file
- Since `acquireSessionLock()` runs first in `bootstrapAutoSession()`, `readCrashLock()` always finds a lock written by **this process** and falsely triggers crash recovery on every startup
- The recovery falls back to the activity log, finds tool calls from a previous session, and shows a spurious "Recovered N tool calls from crashed session" warning **every time GSD launches**
- Fix: compare `crashLock.pid` with `process.pid` — skip recovery when they match

## Reproduction

1. Run `gsd` in any project with prior activity logs
2. Every startup shows:
```
Warning: Previous auto-mode session was interrupted.
  Was executing: starting (bootstrap)
  ...
  Units completed before crash: 0
Recovered 60 tool calls from crashed session.
```
3. This happens even after clean shutdowns

## Test plan

- [ ] Start GSD on a project with existing activity logs — no false crash recovery warning
- [ ] Kill GSD mid-session (`kill -9`), restart — real crash recovery still triggers correctly (PID differs)
- [ ] Existing crash-recovery tests pass