### PR TITLE
fix: add actionable recovery guidance to crash info messages

### DIFF
--- a/src/resources/extensions/gsd/crash-recovery.ts
+++ b/src/resources/extensions/gsd/crash-recovery.ts
@@ -98,11 +98,24 @@ export function isLockProcessAlive(lock: LockData): boolean {
 
 /** Format crash info for display or injection into a prompt. */
 export function formatCrashInfo(lock: LockData): string {
-  return [
+  const lines = [
     `Previous auto-mode session was interrupted.`,
     `  Was executing: ${lock.unitType} (${lock.unitId})`,
     `  Started at: ${lock.unitStartedAt}`,
     `  Units completed before crash: ${lock.completedUnits}`,
     `  PID: ${lock.pid}`,
-  ].join("\n");
+  ];
+
+  // Add recovery guidance based on what was happening when it crashed
+  if (lock.unitType === "starting" && lock.unitId === "bootstrap" && lock.completedUnits === 0) {
+    lines.push(`No work was lost. Run /gsd auto to restart.`);
+  } else if (lock.unitType.includes("research") || lock.unitType.includes("plan")) {
+    lines.push(`The ${lock.unitType} unit may be incomplete. Run /gsd auto to re-run it.`);
+  } else if (lock.unitType.includes("execute")) {
+    lines.push(`Task execution was interrupted. Run /gsd auto to resume — completed work is preserved.`);
+  } else if (lock.unitType.includes("complete")) {
+    lines.push(`Slice/milestone completion was interrupted. Run /gsd auto to finish.`);
+  }
+
+  return lines.join("\n");
 }


### PR DESCRIPTION
Crash recovery messages were diagnostic-only. Added context-aware guidance based on unit type so users know what to do next.

Fixes #1290, #1274