### PR TITLE
docs: update docs/ for v2.32 — remove commit_docs, update Node version, reflect ADR-003

### DIFF
--- a/docs/auto-mode.md
+++ b/docs/auto-mode.md
@@ -157,11 +157,11 @@ After a milestone completes, GSD auto-generates a self-contained HTML report in 
 auto_report: true    # enabled by default
 ```
 
-Generate manually anytime with `/gsd export --html`, or generate reports for all milestones at once with `/gsd export --html --all` (v2.28).
+Generate manually anytime with `/gsd export --html`, or generate reports for all milestones at once with `/gsd export --html --all`.
 
-### Failure Recovery (v2.28)
+### Failure Recovery
 
-v2.28 hardens auto-mode reliability with multiple safeguards: atomic file writes prevent corruption on crash, OAuth fetch timeouts (30s) prevent indefinite hangs, RPC subprocess exit is detected and reported, and blob garbage collection prevents unbounded disk growth. Combined with the existing crash recovery and headless auto-restart, auto-mode is designed for true "fire and forget" overnight execution.
+Auto-mode reliability is hardened with multiple safeguards: atomic file writes prevent corruption on crash, OAuth fetch timeouts (30s) prevent indefinite hangs, RPC subprocess exit is detected and reported, and blob garbage collection prevents unbounded disk growth. Combined with the existing crash recovery and headless auto-restart, auto-mode is designed for true "fire and forget" overnight execution.
 
 ## Controlling Auto Mode
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -214,9 +214,9 @@ The server registers all tools from the agent session and maps MCP `tools/list` 
 
 ```bash
 /gsd update
-# Current version: v2.28.0
+# Current version: v2.32.0
 # Checking npm registry...
-# Updated to v2.29.0. Restart GSD to use the new version.
+# Updated to v2.32.0. Restart GSD to use the new version.
 ```
 
 If already up to date, it reports so and takes no action.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -155,7 +155,7 @@ Fine-grained control over which phases run in auto mode:
 phases:
   skip_research: false        # skip milestone-level research
   skip_reassess: false        # skip roadmap reassessment after each slice
-  skip_slice_research: true   # skip per-slice research
+  # (research is now integrated into plan-slice per ADR-003)
   require_slice_discussion: false  # pause auto-mode before each slice for discussion
 ```
 
@@ -271,7 +271,6 @@ git:
   main_branch: main           # primary branch name
   merge_strategy: squash      # how worktree branches merge: "squash" or "merge"
   isolation: worktree         # git isolation: "worktree", "branch", or "none"
-  commit_docs: true           # commit .gsd/ artifacts to git (set false to keep local)
   manage_gitignore: true      # set false to prevent GSD from modifying .gitignore
   worktree_post_create: .gsd/hooks/post-worktree-create  # script to run after worktree creation
   auto_pr: false              # create a PR on milestone completion (requires push_branches)
@@ -289,7 +288,6 @@ git:
 | `main_branch` | string | `"main"` | Primary branch name |
 | `merge_strategy` | string | `"squash"` | How worktree branches merge: `"squash"` (combine all commits) or `"merge"` (preserve individual commits) |
 | `isolation` | string | `"worktree"` | Auto-mode isolation: `"worktree"` (separate directory), `"branch"` (work in project root — useful for submodule-heavy repos), or `"none"` (no isolation — commits on current branch, no worktree or milestone branch) |
-| `commit_docs` | boolean | `true` | Commit `.gsd/` planning artifacts to git. Set `false` to keep local-only |
 | `manage_gitignore` | boolean | `true` | When `false`, GSD will not modify `.gitignore` at all — no baseline patterns, no self-healing. Use if you manage your own `.gitignore` |
 | `worktree_post_create` | string | (none) | Script to run after worktree creation. Receives `SOURCE_DIR` and `WORKTREE_DIR` env vars |
 | `auto_pr` | boolean | `false` | Automatically create a pull request when a milestone completes. Requires `auto_push: true` and `gh` CLI installed and authenticated |
@@ -386,7 +384,7 @@ post_unit_hooks:
     enabled: true                   # optional: disable without removing
 ```
 
-**Known unit types for `after`:** `research-milestone`, `plan-milestone`, `research-slice`, `plan-slice`, `execute-task`, `complete-slice`, `replan-slice`, `reassess-roadmap`, `run-uat`
+**Known unit types for `after`:** `research-milestone`, `plan-milestone`, `plan-slice`, `execute-task`, `complete-slice`, `replan-slice`, `reassess-roadmap`, `run-uat`
 
 **Prompt substitutions:** `{milestoneId}`, `{sliceId}`, `{taskId}` are replaced with current context values.
 
@@ -410,7 +408,7 @@ pre_dispatch_hooks:
 ```yaml
 pre_dispatch_hooks:
   - name: skip-research
-    before: [research-slice]
+    before: [plan-slice]
     action: skip
     skip_if: RESEARCH.md            # optional: only skip if this file exists
 ```
@@ -551,7 +549,6 @@ git:
   auto_push: true
   merge_strategy: squash
   isolation: worktree         # "worktree", "branch", or "none"
-  commit_docs: true
 
 # Skills
 skill_discovery: suggest

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -6,7 +6,7 @@
 npm install -g gsd-pi
 ```
 
-Requires Node.js ≥ 20.6.0 (22+ recommended) and Git.
+Requires Node.js ≥ 22.0.0 (24 LTS recommended) and Git.
 
 GSD checks for updates once every 24 hours. When a new version is available, you'll see an interactive prompt at startup with the option to update immediately or skip. You can also update from within a session with `/gsd update`.
 
@@ -77,7 +77,7 @@ Step mode is the on-ramp. You stay in the loop, reviewing output between each st
 
 ### Auto Mode — `/gsd auto`
 
-Type `/gsd auto` and walk away. GSD autonomously researches, plans, executes, verifies, commits, and advances through every slice until the milestone is complete.
+Type `/gsd auto` and walk away. GSD autonomously plans (with integrated research), executes, verifies, commits, and advances through every slice until the milestone is complete.
 
 ```
 /gsd auto

--- a/docs/git-strategy.md
+++ b/docs/git-strategy.md
@@ -125,7 +125,6 @@ mode: team    # shared repos — unique IDs, push branches, pre-merge checks
 | `git.pre_merge_check` | `false` | `true` |
 | `git.merge_strategy` | `"squash"` | `"squash"` |
 | `git.isolation` | `"worktree"` | `"worktree"` |
-| `git.commit_docs` | `true` | `true` |
 | `unique_milestone_ids` | `false` | `true` |
 
 Mode defaults are the lowest priority — any explicit preference overrides them. For example, `mode: solo` with `git.auto_push: false` gives you everything from solo except auto-push.
@@ -145,7 +144,6 @@ git:
   pre_merge_check: false      # pre-merge validation
   commit_type: feat           # override commit type prefix
   main_branch: main           # primary branch name
-  commit_docs: true           # commit .gsd/ to git
   isolation: worktree         # "worktree", "branch", or "none"
   auto_pr: false              # create PR on milestone completion
   pr_target_branch: develop   # PR target branch (default: main)
@@ -165,9 +163,9 @@ git:
 This pushes the milestone branch and creates a PR targeting `develop` (or whichever branch you specify). Requires `gh` CLI installed and authenticated. See [git.auto_pr](./configuration.md#gitauto_pr) for details.
 ```
 
-### `commit_docs: false`
+### External State Directory
 
-When set to `false`, GSD adds `.gsd/` to `.gitignore` and keeps all planning artifacts local-only. Useful for teams where only some members use GSD, or when company policy requires a clean repository.
+As of v2.30, GSD stores `.gsd/` state in an external directory (`~/.gsd/projects/`) with a symlink in the project root. This keeps the repository clean while preserving all planning artifacts. The `.gsd` symlink should be added to `.gitignore`.
 
 ## Self-Healing
 

--- a/docs/token-optimization.md
+++ b/docs/token-optimization.md
@@ -267,7 +267,7 @@ The profile is resolved once and flows through the entire dispatch pipeline. Exp
 
 ## Prompt Compression
 
-*Introduced in v2.29.0*
+
 
 GSD can apply deterministic prompt compression before falling back to section-boundary truncation. This preserves more information when context exceeds the budget.
 
@@ -286,7 +286,7 @@ Two strategies are available:
 
 | Strategy | Behavior | Default For |
 |----------|----------|------------|
-| `truncate` | Drop entire sections at boundaries (pre-v2.29 behavior) | `quality` profile |
+| `truncate` | Drop entire sections at boundaries (legacy behavior) | `quality` profile |
 | `compress` | Apply heuristic text compression first, then truncate if still over budget | `budget` and `balanced` profiles |
 
 Compression removes redundant whitespace, abbreviates verbose phrases, deduplicates repeated content, and removes low-information boilerplate — all deterministically with no LLM calls.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -46,7 +46,7 @@ It checks:
 **Common causes:**
 - Missing workspace packages — fixed in v2.10.4+
 - `postinstall` hangs on Linux (Playwright `--with-deps` triggering sudo) — fixed in v2.3.6+
-- Node.js version too old — requires ≥ 20.6.0
+- Node.js version too old — requires ≥ 22.0.0
 
 ### Provider errors during auto mode
 
@@ -132,7 +132,7 @@ Doctor rebuilds `STATE.md` from plan and roadmap files on disk and fixes detecte
 
 **Cause:** The `which` command in MSYS2/Git Bash returns POSIX paths that Node.js `spawn()` can't resolve.
 
-**Fix:** Updated in v2.29+ to use `where.exe` on Windows. Upgrade to the latest version.
+**Fix:** Updated to use `where.exe` on Windows. Upgrade to the latest version.
 
 ### EBUSY errors during WXT/extension builds
 
@@ -148,9 +148,9 @@ Doctor rebuilds `STATE.md` from plan and roadmap files on disk and fixes detecte
 
 **Symptoms:** `gsd_save_decision`, `gsd_update_requirement`, or `gsd_save_summary` fail with this error.
 
-**Cause:** The SQLite database wasn't initialized. This happens in manual `/gsd` sessions (non-auto mode) on versions before v2.29.
+**Cause:** The SQLite database wasn't initialized. This happens in manual `/gsd` sessions (non-auto mode) on older versions.
 
-**Fix:** Updated in v2.29+ to auto-initialize the database on first tool call. Upgrade to the latest version.
+**Fix:** Updated to auto-initialize the database on first tool call. Upgrade to the latest version.
 
 ## Verification Issues
 
@@ -160,7 +160,7 @@ Doctor rebuilds `STATE.md` from plan and roadmap files on disk and fixes detecte
 
 **Cause:** A description-like string (e.g., `All 10 checks pass (build, lint)`) was treated as a shell command. This can happen when task plans have `verify:` fields with prose instead of actual commands.
 
-**Fix:** Updated in v2.29+ to filter preference commands through `isLikelyCommand()`. Ensure `verification_commands` in preferences contains only valid shell commands, not descriptions.
+**Fix:** Updated to filter preference commands through `isLikelyCommand()`. Ensure `verification_commands` in preferences contains only valid shell commands, not descriptions.
 
 ## LSP (Language Server Protocol)
 

--- a/docs/working-in-teams.md
+++ b/docs/working-in-teams.md
@@ -54,16 +54,11 @@ git add .gsd/preferences.md
 git commit -m "chore: enable GSD team workflow"
 ```
 
-## `commit_docs: false`
+## External State Directory
 
-For teams where only some members use GSD, or when company policy requires a clean repo:
+As of v2.30, GSD stores `.gsd/` state in an external directory (`~/.gsd/projects/`) with a symlink in the project root. This keeps the repository clean by default — the `.gsd` symlink should be added to `.gitignore`.
 
-```yaml
-git:
-  commit_docs: false
-```
-
-This adds `.gsd/` to `.gitignore` entirely and keeps all artifacts local. The developer gets the benefits of structured planning without affecting teammates who don't use GSD.
+For teams where only some members use GSD, this means GSD artifacts don't clutter the shared repository. Each developer's planning state lives in their home directory.
 
 ## Migrating an Existing Project
 


### PR DESCRIPTION
Updates 8 documentation files to reflect v2.30–v2.32 changes.

### Changes

| File | Updates |
|------|---------|
| `auto-mode.md` | Removed v2.28 version tags from section headers |
| `commands.md` | Version examples → v2.32.0 |
| `configuration.md` | Removed `commit_docs` (deleted in v2.31), updated unit types (`research-slice` → `plan-slice` per ADR-003) |
| `getting-started.md` | Node.js ≥20.6.0 → ≥22.0.0 (24 LTS recommended) |
| `git-strategy.md` | Removed `commit_docs`, replaced with external state directory docs |
| `token-optimization.md` | Removed version-specific callouts |
| `troubleshooting.md` | Node requirement updated, version callouts removed |
| `working-in-teams.md` | Replaced `commit_docs: false` section with external state directory documentation |
