### PR TITLE
fix: skip symlinks in makeTreeWritable to prevent EPERM on NixOS/nix-darwin

### DIFF
--- a/src/resource-loader.ts
+++ b/src/resource-loader.ts
@@ -1,7 +1,7 @@
 import { DefaultResourceLoader } from '@gsd/pi-coding-agent'
 import { createHash } from 'node:crypto'
 import { homedir } from 'node:os'
-import { chmodSync, copyFileSync, cpSync, existsSync, mkdirSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from 'node:fs'
+import { chmodSync, copyFileSync, cpSync, existsSync, lstatSync, mkdirSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from 'node:fs'
 import { dirname, join, relative, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { compareSemver } from './update-check.js'
@@ -133,7 +133,12 @@ export function getNewerManagedResourceVersion(agentDir: string, currentVersion:
 function makeTreeWritable(dirPath: string): void {
   if (!existsSync(dirPath)) return
 
-  const stats = statSync(dirPath)
+  // Use lstatSync to avoid following symlinks into immutable filesystems
+  // (e.g., Nix store on NixOS/nix-darwin). Symlinks don't carry their own
+  // permissions and their targets may be read-only by design (#1298).
+  const stats = lstatSync(dirPath)
+  if (stats.isSymbolicLink()) return
+
   const isDir = stats.isDirectory()
   const currentMode = stats.mode & 0o777
 
@@ -144,7 +149,11 @@ function makeTreeWritable(dirPath: string): void {
   }
 
   if (newMode !== currentMode) {
-    chmodSync(dirPath, newMode)
+    try {
+      chmodSync(dirPath, newMode)
+    } catch {
+      // Non-fatal — may fail on read-only filesystems or insufficient permissions
+    }
   }
 
   if (isDir) {


### PR DESCRIPTION
## Problem

GSD crashes on startup with `EPERM: operation not permitted, chmod` on NixOS and nix-darwin systems. `makeTreeWritable()` uses `statSync` which follows symlinks into the immutable Nix store (`/run/current-system/sw/bin/`), then tries to `chmod` the read-only target.

## Root Cause Analysis

1. `ensureManagedTools()` symlinks `fd`/`rg` from PATH into `~/.gsd/agent/bin/`
2. On Nix, those PATH entries resolve to the Nix store (immutable filesystem)
3. `makeTreeWritable()` walks `~/.gsd/agent/` recursively with `statSync` → follows symlinks → `chmod` on Nix store → EPERM

## Fix

- **`lstatSync` instead of `statSync`** — detects symlinks without following them
- **Skip symlinks entirely** — they don't carry own permissions, targets may be immutable
- **`try/catch` around `chmodSync`** — safety net for any remaining permission errors

## Secondary Analysis

Checked for cascading issues after the fix:
- `rmSync(target, { recursive: true, force: true })` — correctly removes symlinks (the link, not target) ✅
- `cpSync(src, dst, { force: true })` — replaces symlinks with regular files (desired for resource sync) ✅
- `statSync` at line 107 (file fingerprinting) — follows symlinks intentionally to get real file size ✅ (not in the chmod path)

## Verification

- `tsc --noEmit` passes
- 1780 unit tests pass

Fixes #1298
