### PR TITLE
fix: sync milestone artifacts into worktree on entry/creation in auto-start

### DIFF
--- a/src/resources/extensions/gsd/auto-start.ts
+++ b/src/resources/extensions/gsd/auto-start.ts
@@ -50,6 +50,7 @@ import {
   getAutoWorktreePath,
   isInAutoWorktree,
 } from "./auto-worktree.js";
+import { syncProjectRootToWorktree } from "./auto-worktree-sync.js";
 import { readResourceVersion } from "./resource-version.js";
 import { initMetrics, getLedger } from "./metrics.js";
 import { initRoutingHistory } from "./routing-history.js";
@@ -333,11 +334,16 @@ export async function bootstrapAutoSession(
         const wtPath = enterAutoWorktree(base, s.currentMilestoneId);
         s.basePath = wtPath;
         s.gitService = createGitService(s.basePath);
+        // Sync milestone artifacts from project root into the worktree.
+        // Critical after crash recovery: the worktree may have been created
+        // but the milestone directory was never copied before the crash (#1300).
+        syncProjectRootToWorktree(base, wtPath, s.currentMilestoneId);
         ctx.ui.notify(`Entered auto-worktree at ${wtPath}`, "info");
       } else {
         const wtPath = createAutoWorktree(base, s.currentMilestoneId);
         s.basePath = wtPath;
         s.gitService = createGitService(s.basePath);
+        syncProjectRootToWorktree(base, wtPath, s.currentMilestoneId);
         ctx.ui.notify(`Created auto-worktree at ${wtPath}`, "info");
       }
       registerSigtermHandler(s.originalBasePath);

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -626,11 +626,19 @@ export async function startAuto(
           const wtPath = enterAutoWorktree(s.originalBasePath, s.currentMilestoneId);
           s.basePath = wtPath;
           s.gitService = createGitService(s.basePath);
+          try {
+            const { syncProjectRootToWorktree } = await import("./auto-worktree-sync.js");
+            syncProjectRootToWorktree(s.originalBasePath, wtPath, s.currentMilestoneId);
+          } catch { /* non-fatal */ }
           ctx.ui.notify(`Re-entered auto-worktree at ${wtPath}`, "info");
         } else {
           const wtPath = createAutoWorktree(s.originalBasePath, s.currentMilestoneId);
           s.basePath = wtPath;
           s.gitService = createGitService(s.basePath);
+          try {
+            const { syncProjectRootToWorktree } = await import("./auto-worktree-sync.js");
+            syncProjectRootToWorktree(s.originalBasePath, wtPath, s.currentMilestoneId);
+          } catch { /* non-fatal */ }
           ctx.ui.notify(`Recreated auto-worktree at ${wtPath}`, "info");
         }
       } catch (err) {


### PR DESCRIPTION
## Problem

When auto-mode crashes during bootstrap (after worktree creation but before first dispatch), the worktree's `.gsd/milestones/` lacks the active milestone's artifacts. On resume, `deriveState()` finds no active milestone → `phase: complete` → auto-mode can't proceed.

`syncProjectRootToWorktree` was only called in `dispatchNextUnit` (dispatch loop), never during worktree setup.

## Fix

Added `syncProjectRootToWorktree` at all 3 worktree entry/creation points:
1. **auto-start.ts** — fresh start (`enterAutoWorktree` + `createAutoWorktree`)
2. **auto.ts** — resume path (`enterAutoWorktree` + `createAutoWorktree`)

## Secondary Analysis

| Concern | Status |
|---------|--------|
| gsd.db staleness after sync | ✅ sync already deletes gsd.db to force rebuild |
| Double-sync on dispatch (already synced at startup) | ✅ Idempotent — safeCopy with force:true |
| STATE.md inconsistency | ✅ deriveState reads disk files, self-corrects |
| Living docs (DECISIONS, REQUIREMENTS, etc.) | ✅ Already synced by the living docs fix (#1173) |

Fixes #1300
