### PR TITLE
fix: align retry lock path with primary lock settings to prevent ECOMPROMISED

### DIFF
--- a/src/resources/extensions/gsd/session-lock.ts
+++ b/src/resources/extensions/gsd/session-lock.ts
@@ -154,12 +154,23 @@ export function acquireSessionLock(basePath: string): SessionLockResult {
         // Retry acquisition after cleanup
         const release = lockfile.lockSync(gsdDir, {
           realpath: false,
-          stale: 300_000,
+          stale: 1_800_000, // 30 minutes — match primary lock settings
           update: 10_000,
+          onCompromised: () => {
+            _lockCompromised = true;
+          },
         });
         _releaseFunction = release;
         _lockedPath = basePath;
         _lockPid = process.pid;
+
+        // Safety net for retry path too
+        const retryLockDir = join(gsdDir + ".lock");
+        process.once("exit", () => {
+          try { if (_releaseFunction) { _releaseFunction(); _releaseFunction = null; } } catch {}
+          try { if (existsSync(retryLockDir)) rmSync(retryLockDir, { recursive: true, force: true }); } catch {}
+        });
+
         atomicWriteSync(lp, JSON.stringify(lockData, null, 2));
         return { acquired: true };
       } catch {


### PR DESCRIPTION
## Problem

The retry lock acquisition path (from stale lock recovery in #1251) used a 5-minute stale threshold and no `onCompromised` handler, while the primary path used 30 minutes and a graceful flag-based handler. Locks acquired via the retry path threw `ECOMPROMISED` (uncaught, crashes process) if the event loop stalled for >5 minutes.

## Fix

Aligned retry path settings with primary:
- **stale**: 300_000 → 1_800_000 (30 min)
- **onCompromised**: added flag-based handler (sets `_lockCompromised`)
- **process.on('exit')**: added safety net cleanup

## Note to reporter

You're on Node.js v25.6.1 which is an odd-numbered current release (not LTS). GSD requires Node >=22.0.0 with **24 LTS recommended**. Odd releases like v25 may have behavior differences that cause unexpected issues. Please switch to Node 24 LTS.

Fixes #1304
