### PR TITLE
fix: use relative symlinks in workspace linker for Volta compatibility

### DIFF
--- a/scripts/link-workspace-packages.cjs
+++ b/scripts/link-workspace-packages.cjs
@@ -16,7 +16,7 @@
  * cpSync (directory copy) which works universally.
  */
 const { existsSync, mkdirSync, symlinkSync, cpSync, lstatSync, readlinkSync, unlinkSync } = require('fs')
-const { resolve, join } = require('path')
+const { resolve, join, relative, dirname } = require('path')
 
 const root = resolve(__dirname, '..')
 const packagesDir = join(root, 'packages')
@@ -50,7 +50,8 @@ for (const [dir, name] of Object.entries(packageMap)) {
       const stat = lstatSync(target)
       if (stat.isSymbolicLink()) {
         const linkTarget = readlinkSync(target)
-        if (resolve(join(nodeModulesGsd, linkTarget)) === source || linkTarget === source) {
+        const resolvedLink = resolve(dirname(target), linkTarget)
+        if (resolvedLink === source) {
           continue // Already correct
         }
         unlinkSync(target) // Wrong target, relink
@@ -64,7 +65,11 @@ for (const [dir, name] of Object.entries(packageMap)) {
 
   let symlinkOk = false
   try {
-    symlinkSync(source, target, 'junction') // junction works on Windows too
+    // Use relative path so the symlink survives being moved (e.g., Volta
+    // installs into a temp dir then renames to the final location — absolute
+    // symlinks would still point at the deleted temp path).
+    const relSource = relative(dirname(target), source)
+    symlinkSync(relSource, target, 'junction') // junction works on Windows too
     symlinkOk = true
     linked++
   } catch {


### PR DESCRIPTION
# NOTE - someone else should test this on a system not using volta.


## Problem

Volta installs packages in a temp directory then moves (renames) the tree to its final location. The `link-workspace-packages.cjs` script created **absolute** symlinks during postinstall, so after the move they still pointed at the deleted temp path:

```
libc++abi: terminating due to uncaught exception of type std::__1::__fs::filesystem::filesystem_error:
filesystem error: in equivalent: Operation not supported
[".../packages/native"] [".../node_modules/@gsd/native"]
```

All 5 `@gsd/*` symlinks were broken:
```
native -> /Users/dan/.volta/tmp/image/packages/.tmpXDwvMR/.../packages/native  ❌ (deleted)
```

## Fix

- Use **relative** symlinks (`../../packages/native`) instead of absolute paths — they survive the directory move.
- Fix the "already correct" symlink check to resolve relative targets properly via `resolve(dirname(target), linkTarget)` instead of `resolve(join(nodeModulesGsd, linkTarget))`.

## Testing

Manually verified: fixed the broken install in place with relative symlinks, `gsd --version` works.