### PR TITLE
fix: handle ECOMPROMISED in uncaughtException guard to stop crash loop on resume

### DIFF
--- a/src/resources/extensions/gsd/index.ts
+++ b/src/resources/extensions/gsd/index.ts
@@ -223,11 +223,22 @@ export default function (pi: ExtensionAPI) {
   // chance to persist state and pause instead of crashing (see issue #739).
   if (!process.listeners("uncaughtException").some(l => l.name === "_gsdEpipeGuard")) {
     const _gsdEpipeGuard = (err: Error): void => {
-      if ((err as NodeJS.ErrnoException).code === "EPIPE") {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code === "EPIPE") {
         // Pipe closed — nothing we can write; just exit cleanly
         process.exit(0);
       }
-      // Re-throw anything that isn't EPIPE so real crashes still surface
+      // ECOMPROMISED: proper-lockfile's update timer detected mtime drift (system
+      // sleep, heavy event loop stall, or filesystem precision mismatch on Node.js
+      // v25+). The onCompromised callback already set _lockCompromised = true, but
+      // due to a subtle interaction between the synchronous fs adapter and the
+      // setTimeout boundary, the error can still propagate here as an uncaught
+      // exception. Exit cleanly so the process.once("exit") handler removes the
+      // lock directory — allowing the next session to acquire cleanly (#1322).
+      if (code === "ECOMPROMISED") {
+        process.exit(1);
+      }
+      // Re-throw anything that isn't EPIPE or ECOMPROMISED so real crashes still surface
       throw err;
     };
     process.on("uncaughtException", _gsdEpipeGuard);

--- a/src/resources/extensions/gsd/session-lock.ts
+++ b/src/resources/extensions/gsd/session-lock.ts
@@ -158,6 +158,7 @@ export function acquireSessionLock(basePath: string): SessionLockResult {
           update: 10_000,
           onCompromised: () => {
             _lockCompromised = true;
+            _releaseFunction = null;
           },
         });
         _releaseFunction = release;


### PR DESCRIPTION
## Problem

When a GSD session crashes hard (SIGKILL, OOM, or crash during bootstrap), the proper-lockfile OS lock directory (`.gsd.lock/`) is left stranded because the `process.once("exit")` handler never ran.

On the next `/gsd auto` resume:
1. `acquireSessionLock` detects the dead PID, cleans up the stale lock dir, and re-acquires via the **retry path**
2. 10 seconds later, proper-lockfile's update timer fires
3. Due to a subtle interaction between the **synchronous fs adapter** (`lockSync` / `toSyncOptions`) and the `setTimeout` boundary in Node.js v25+, the `ECOMPROMISED` error propagates up through the synchronous callback chain and becomes an **uncaught exception** — even though `onCompromised` sets `_lockCompromised = true` without throwing
4. `_gsdEpipeGuard` only handled `EPIPE`, so it **re-threw** `ECOMPROMISED` → crash
5. Each crash wrote a new "interrupted session" record → **infinite crash loop on resume**

## Root Cause

The `_gsdEpipeGuard` uncaughtException handler in `index.ts` re-throws anything that isn't `EPIPE`. `ECOMPROMISED` is not `EPIPE`, so it crashed the process, leaving another interrupted session state, causing the loop.

Additionally, the retry path's `onCompromised` callback was missing `_releaseFunction = null` (unlike the primary path), meaning `validateSessionLock()` would return `true` even after the lock was compromised.

## Fix

**`index.ts`** — Add `ECOMPROMISED` to the graceful-exit cases in `_gsdEpipeGuard`:
- Exit with code 1 (non-zero) so `process.once("exit")` fires and removes the lock directory
- Allows the next session to start clean without the loop

**`session-lock.ts`** — Align retry path `onCompromised` with primary path:
- Add `_releaseFunction = null` so `validateSessionLock()` correctly detects compromise and stops the dispatch loop

## Testing

- All 1823 unit tests pass, 0 failures
- `crash-recovery.test.ts` and `stop-auto-remote.test.ts` pass clean

## What the loop looked like

```
crash (PID 5327, bootstrap) → .gsd.lock/ stranded
  → resume → ECOMPROMISED (10s) → re-thrown → crash
  → resume → ECOMPROMISED (10s) → re-thrown → crash
  → ...
```

Fixes the crash loop reported in `~/Github/git-patcher` with Node.js v25.6.1.