### PR TITLE
fix: release stranded bootstrap locks and handle re-entrant reacquire (#1351)

### DIFF
--- a/src/resources/extensions/gsd/auto-start.ts
+++ b/src/resources/extensions/gsd/auto-start.ts
@@ -103,13 +103,20 @@ export async function bootstrapAutoSession(
     return false;
   }
 
-  // Ensure git repo exists
-  if (!nativeIsRepo(base)) {
-    const mainBranch = loadEffectiveGSDPreferences()?.preferences?.git?.main_branch || "main";
-    nativeInit(base, mainBranch);
+  function releaseLockAndReturn(): false {
+    releaseSessionLock(base);
+    clearLock(base);
+    return false;
   }
 
-  // Ensure .gitignore has baseline patterns
+  try {
+    // Ensure git repo exists
+    if (!nativeIsRepo(base)) {
+      const mainBranch = loadEffectiveGSDPreferences()?.preferences?.git?.main_branch || "main";
+      nativeInit(base, mainBranch);
+    }
+
+    // Ensure .gitignore has baseline patterns
   const gitPrefs = loadEffectiveGSDPreferences()?.preferences?.git;
   const manageGitignore = gitPrefs?.manage_gitignore;
   ensureGitignore(base, { manageGitignore });
@@ -251,10 +258,10 @@ export async function bootstrapAutoSession(
             "Discussion completed but no milestone context was written. Run /gsd to try the discussion again, or /gsd auto after creating the milestone manually.",
             "warning",
           );
-          return false;
+          return releaseLockAndReturn();
         }
       } else {
-        return false;
+        return releaseLockAndReturn();
       }
     }
 
@@ -276,7 +283,7 @@ export async function bootstrapAutoSession(
             "Discussion completed but milestone context is still missing. Run /gsd to try again.",
             "warning",
           );
-          return false;
+          return releaseLockAndReturn();
         }
       }
     }
@@ -286,7 +293,7 @@ export async function bootstrapAutoSession(
   if (!state.activeMilestone) {
     const { showSmartEntry } = await import("./guided-flow.js");
     await showSmartEntry(ctx, pi, base, { step: requestedStepMode });
-    return false;
+    return releaseLockAndReturn();
   }
 
   // ── Initialize session state ──
@@ -479,5 +486,10 @@ export async function bootstrapAutoSession(
     }
   } catch { /* non-fatal */ }
 
-  return true;
+    return true;
+  } catch (err) {
+    releaseSessionLock(base);
+    clearLock(base);
+    throw err;
+  }
 }

--- a/src/resources/extensions/gsd/session-lock.ts
+++ b/src/resources/extensions/gsd/session-lock.ts
@@ -143,6 +143,16 @@ function ensureExitHandler(gsdDir: string): void {
 export function acquireSessionLock(basePath: string): SessionLockResult {
   const lp = lockPath(basePath);
 
+  // Re-entrant acquire on the same path: release our current OS lock first so
+  // proper-lockfile clears its update timer before we acquire a fresh lock.
+  if (_releaseFunction && _lockedPath === basePath) {
+    try { _releaseFunction(); } catch { /* may already be released */ }
+    _releaseFunction = null;
+    _lockedPath = null;
+    _lockPid = 0;
+    _lockCompromised = false;
+  }
+
   // Ensure the directory exists
   mkdirSync(dirname(lp), { recursive: true });
 
@@ -228,6 +238,7 @@ export function acquireSessionLock(basePath: string): SessionLockResult {
         _releaseFunction = release;
         _lockedPath = basePath;
         _lockPid = process.pid;
+        _lockCompromised = false;
 
         // Safety net — uses centralized handler to avoid double-registration
         ensureExitHandler(gsdDir);

--- a/src/resources/extensions/gsd/tests/auto-lock-creation.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-lock-creation.test.ts
@@ -1,10 +1,25 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { mkdirSync, mkdtempSync, writeFileSync, existsSync, readFileSync, rmSync } from "node:fs";
+import { createRequire } from "node:module";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
 import { writeLock, readCrashLock, clearLock, isLockProcessAlive } from "../crash-recovery.ts";
+import { acquireSessionLock, releaseSessionLock } from "../session-lock.ts";
+
+const require = createRequire(import.meta.url);
+
+function hasProperLockfile(): boolean {
+  try {
+    require("proper-lockfile");
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const properLockfileAvailable = hasProperLockfile();
 
 // ─── writeLock creates auto.lock in .gsd/ ────────────────────────────────
 
@@ -93,6 +108,28 @@ test("clearLock is safe when no lock file exists", () => {
   clearLock(dir);
 
   rmSync(dir, { recursive: true, force: true });
+});
+
+test("bootstrap cleanup releases session lock artifacts", () => {
+  const dir = mkdtempSync(join(tmpdir(), "gsd-lock-test-"));
+  mkdirSync(join(dir, ".gsd"), { recursive: true });
+
+  try {
+    const result = acquireSessionLock(dir);
+    assert.equal(result.acquired, true, "session lock should be acquired");
+    assert.ok(existsSync(join(dir, ".gsd", "auto.lock")), "auto.lock should exist while lock is held");
+    if (properLockfileAvailable) {
+      assert.ok(existsSync(join(dir, ".gsd.lock")), ".gsd.lock should exist while lock is held");
+    }
+
+    releaseSessionLock(dir);
+    clearLock(dir);
+
+    assert.ok(!existsSync(join(dir, ".gsd", "auto.lock")), "auto.lock should be removed by bootstrap cleanup");
+    assert.ok(!existsSync(join(dir, ".gsd.lock")), ".gsd.lock should be removed by bootstrap cleanup");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });
 
 // ─── isLockProcessAlive detects live vs dead PIDs ────────────────────────

--- a/src/resources/extensions/gsd/tests/session-lock-regression.test.ts
+++ b/src/resources/extensions/gsd/tests/session-lock-regression.test.ts
@@ -11,6 +11,7 @@
  */
 
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync, readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
@@ -26,6 +27,18 @@ import { gsdRoot } from '../paths.ts';
 import { createTestContext } from './test-helpers.ts';
 
 const { assertEq, assertTrue, report } = createTestContext();
+const require = createRequire(import.meta.url);
+
+function hasProperLockfile(): boolean {
+  try {
+    require("proper-lockfile");
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const properLockfileAvailable = hasProperLockfile();
 
 async function main(): Promise<void> {
 
@@ -202,6 +215,57 @@ async function main(): Promise<void> {
       const r2 = acquireSessionLock(base);
       assertTrue(r2.acquired, 're-acquisition after release');
       releaseSessionLock(base);
+    } finally {
+      rmSync(base, { recursive: true, force: true });
+    }
+  }
+
+  // ─── 9. Re-entrant acquisition without explicit release ───────────────
+  console.log('\n=== 9. re-entrant acquire without explicit release ===');
+  {
+    const base = mkdtempSync(join(tmpdir(), 'gsd-session-lock-'));
+    mkdirSync(join(base, '.gsd'), { recursive: true });
+
+    try {
+      const r1 = acquireSessionLock(base);
+      assertTrue(r1.acquired, 'first acquisition succeeds');
+
+      const r2 = acquireSessionLock(base);
+      assertTrue(r2.acquired, 're-entrant acquisition succeeds');
+
+      const valid = validateSessionLock(base);
+      assertTrue(valid, 're-entrant acquisition does not corrupt validation state');
+
+      releaseSessionLock(base);
+    } finally {
+      rmSync(base, { recursive: true, force: true });
+    }
+  }
+
+  // ─── 10. Re-entrant acquisition refreshes lock artifacts ──────────────
+  console.log('\n=== 10. re-entrant acquire refreshes lock artifacts ===');
+  {
+    const base = mkdtempSync(join(tmpdir(), 'gsd-session-lock-'));
+    mkdirSync(join(base, '.gsd'), { recursive: true });
+
+    try {
+      const r1 = acquireSessionLock(base);
+      assertTrue(r1.acquired, 'first acquisition succeeds');
+
+      const lockDir = gsdRoot(base) + '.lock';
+      if (properLockfileAvailable) {
+        assertTrue(existsSync(lockDir), '.gsd.lock/ exists after first acquisition');
+      }
+
+      const r2 = acquireSessionLock(base);
+      assertTrue(r2.acquired, 'second acquisition succeeds');
+      if (properLockfileAvailable) {
+        assertTrue(existsSync(lockDir), '.gsd.lock/ exists after re-entrant acquisition');
+      }
+      assertTrue(validateSessionLock(base), 'lock remains valid after re-entrant acquisition');
+
+      releaseSessionLock(base);
+      assertTrue(!existsSync(lockDir), '.gsd.lock/ is removed after release');
     } finally {
       rmSync(base, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- Release session lock on bootstrap failure paths so it doesn't strand after guided-flow aborts
- Handle re-entrant `acquireSessionLock()` by releasing the old proper-lockfile handle first, preventing stale `onCompromised` callbacks from poisoning the new lock
- Reset `_lockCompromised` on retry acquire path for belt-and-suspenders safety
- Wrap post-acquire bootstrap body in try/catch to release the lock on unexpected errors

## Test plan
- [x] `session-lock-regression.test.ts` — all 10 tests pass (2 new: re-entrant acquire, re-entrant artifact refresh)
- [x] `auto-lock-creation.test.ts` — all 12 tests pass (1 new: bootstrap cleanup releases artifacts)
- [x] `session-lock.test.ts` — all 23 existing tests pass
- [x] Manual: fresh repo `/gsd` → abort discussion → `/gsd auto` → starts cleanly without "Session lock lost"

Closes #1351