### PR TITLE
fix: open existing GSD database on /gsd inspect

### DIFF
--- a/src/resources/extensions/gsd/commands-inspect.ts
+++ b/src/resources/extensions/gsd/commands-inspect.ts
@@ -5,6 +5,9 @@
  */
 
 import type { ExtensionCommandContext } from "@gsd/pi-coding-agent";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { gsdRoot } from "./paths.js";
 import { getErrorMessage } from "./error-utils.js";
 
 export interface InspectData {
@@ -44,11 +47,15 @@ export function formatInspectOutput(data: InspectData): string {
 
 export async function handleInspect(ctx: ExtensionCommandContext): Promise<void> {
   try {
-    const { isDbAvailable, _getAdapter } = await import("./gsd-db.js");
+    const { isDbAvailable, _getAdapter, openDatabase } = await import("./gsd-db.js");
 
     if (!isDbAvailable()) {
-      ctx.ui.notify("No GSD database available. Run /gsd auto to create one.", "info");
-      return;
+      const gsdDir = gsdRoot(process.cwd());
+      const dbPath = join(gsdDir, "gsd.db");
+      if (!existsSync(gsdDir) || !existsSync(dbPath) || !openDatabase(dbPath)) {
+        ctx.ui.notify("No GSD database available. Run /gsd auto to create one.", "info");
+        return;
+      }
     }
 
     const adapter = _getAdapter();

--- a/src/resources/extensions/gsd/tests/commands-inspect-open-db.test.ts
+++ b/src/resources/extensions/gsd/tests/commands-inspect-open-db.test.ts
@@ -1,0 +1,46 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import fs from "node:fs";
+
+import { handleInspect } from "../commands-inspect.ts";
+import { closeDatabase, openDatabase } from "../gsd-db.ts";
+
+test("/gsd inspect opens existing database when it was not yet opened in session", async () => {
+  closeDatabase();
+
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "gsd-inspect-db-"));
+  const prevCwd = process.cwd();
+
+  try {
+    const gsdDir = path.join(tmp, ".gsd");
+    fs.mkdirSync(gsdDir, { recursive: true });
+    const dbPath = path.join(gsdDir, "gsd.db");
+
+    assert.equal(openDatabase(dbPath), true);
+    closeDatabase();
+
+    process.chdir(tmp);
+
+    const notifications: Array<{ message: string; level: string }> = [];
+    const ctx = {
+      ui: {
+        notify(message: string, level: string) {
+          notifications.push({ message, level });
+        },
+      },
+    } as any;
+
+    await handleInspect(ctx);
+
+    assert.equal(notifications.length, 1);
+    assert.equal(notifications[0].level, "info");
+    assert.match(notifications[0].message, /=== GSD Database Inspect ===/);
+    assert.doesNotMatch(notifications[0].message, /No GSD database available/);
+  } finally {
+    process.chdir(prevCwd);
+    closeDatabase();
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

Fixes `/gsd inspect` reporting "No GSD database available" when `.gsd/gsd.db` already exists on disk but has not yet been opened in the current session.

## Root cause

`handleInspect()` only checked whether a DB connection was already open in-process (`isDbAvailable()` / `_getAdapter()`). It did not attempt to open the existing on-disk database on demand.

That meant these two states were treated as equivalent:

- no GSD database exists
- GSD database exists on disk, but this session hasn't opened it yet

## Changes

- update `src/resources/extensions/gsd/commands-inspect.ts` to open `.gsd/gsd.db` on demand when present
- add a focused regression test covering the case where the DB exists on disk but is not yet opened in-session

## Verification

- added targeted test: `/gsd inspect opens existing database when it was not yet opened in session`
- built successfully with `npm run build`

