### PR TITLE
fix: avoid EISDIR crash in GSD file loader

### DIFF
--- a/src/resources/extensions/gsd/files.ts
+++ b/src/resources/extensions/gsd/files.ts
@@ -590,7 +590,8 @@ export async function loadFile(path: string): Promise<string | null> {
   try {
     return await fs.readFile(path, 'utf-8');
   } catch (err: unknown) {
-    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return null;
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === 'ENOENT' || code === 'EISDIR') return null;
     throw err;
   }
 }

--- a/src/resources/extensions/gsd/tests/files-loadfile-eisdir.test.ts
+++ b/src/resources/extensions/gsd/tests/files-loadfile-eisdir.test.ts
@@ -1,0 +1,20 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import fs from "node:fs";
+
+import { loadFile } from "../files.ts";
+
+test("loadFile returns null for directory paths instead of throwing EISDIR", async () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "gsd-loadfile-eisdir-"));
+  const dirPath = path.join(tmp, "tasks");
+  fs.mkdirSync(dirPath);
+
+  try {
+    const result = await loadFile(dirPath);
+    assert.equal(result, null);
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- make `loadFile()` return `null` for `EISDIR` the same way it already does for missing files
- add a regression test covering directory paths

## Why
During milestone completion/validation, a directory path can occasionally reach the GSD file-loading path. This should not crash the unit-finalization flow. Treating directory paths as unreadable/missing files makes the completion path defensive without changing normal file reads.

## Testing
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/files-loadfile-eisdir.test.ts`
- `npm run build`
