### PR TITLE
fix: break repeated google_search loops

### DIFF
--- a/src/resources/extensions/google-search/index.ts
+++ b/src/resources/extensions/google-search/index.ts
@@ -167,8 +167,21 @@ async function searchWithOAuth(
 
 const resultCache = new Map<string, SearchResult>();
 
+// Consecutive duplicate search guard
+// Breaks repeated identical google_search calls in the same session so the
+// model doesn't burn turns re-running the same query instead of using results.
+const MAX_CONSECUTIVE_DUPES = 3;
+let lastSearchKey = "";
+let consecutiveDupeCount = 0;
+
 function cacheKey(query: string): string {
 	return query.toLowerCase().trim();
+}
+
+export function __resetGoogleSearchStateForTests(): void {
+	resultCache.clear();
+	lastSearchKey = "";
+	consecutiveDupeCount = 0;
 }
 
 // ── Extension ────────────────────────────────────────────────────────────────
@@ -207,6 +220,35 @@ export default function (pi: ExtensionAPI) {
 		async execute(_toolCallId, params, signal, _onUpdate, ctx) {
 			const startTime = Date.now();
 			const maxSources = Math.min(Math.max(params.maxSources ?? 5, 1), 10);
+			const key = cacheKey(params.query);
+
+			// Break repeated identical google_search calls before the model gets
+			// stuck in a search-only loop. Mirrors the duplicate-query guard used
+			// by search-the-web, including cached-result replays.
+			if (key === lastSearchKey) {
+				consecutiveDupeCount++;
+				if (consecutiveDupeCount >= MAX_CONSECUTIVE_DUPES) {
+					consecutiveDupeCount = 0;
+					lastSearchKey = "";
+					return {
+						content: [{
+							type: "text",
+							text: `⚠️ Search loop detected: the query "${params.query}" has been searched ${MAX_CONSECUTIVE_DUPES + 1} times consecutively. The information you need is already in the previous search results above. Stop searching and use those results to proceed with your task.`,
+						}],
+						isError: true,
+						details: {
+							query: params.query,
+							sourceCount: 0,
+							cached: false,
+							durationMs: Date.now() - startTime,
+							error: "search_loop: Consecutive duplicate search detected",
+						} as SearchDetails,
+					};
+				}
+			} else {
+				lastSearchKey = key;
+				consecutiveDupeCount = 0;
+			}
 
 			// Check for credentials
 			let oauthToken: string | undefined;
@@ -245,7 +287,6 @@ export default function (pi: ExtensionAPI) {
 			}
 
 			// Check cache
-			const key = cacheKey(params.query);
 			if (resultCache.has(key)) {
 				const cached = resultCache.get(key)!;
 				const output = formatOutput(cached, maxSources);

--- a/src/tests/google-search-auth.repro.test.ts
+++ b/src/tests/google-search-auth.repro.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import googleSearchExtension from "../resources/extensions/google-search/index.ts";
+import googleSearchExtension, { __resetGoogleSearchStateForTests } from "../resources/extensions/google-search/index.ts";
 
 function createMockPI() {
   const handlers: any[] = [];
@@ -39,6 +39,7 @@ function mockModelRegistry(oauthJson?: string) {
 }
 
 test("fix: google-search uses OAuth if GEMINI_API_KEY is missing", async () => {
+  __resetGoogleSearchStateForTests();
   const originalKey = process.env.GEMINI_API_KEY;
   delete process.env.GEMINI_API_KEY;
 
@@ -84,6 +85,7 @@ test("fix: google-search uses OAuth if GEMINI_API_KEY is missing", async () => {
 });
 
 test("google-search warns if NO authentication is present", async () => {
+  __resetGoogleSearchStateForTests();
   const originalKey = process.env.GEMINI_API_KEY;
   delete process.env.GEMINI_API_KEY;
 
@@ -111,6 +113,7 @@ test("google-search warns if NO authentication is present", async () => {
 });
 
 test("google-search uses GEMINI_API_KEY if present (precedence)", async () => {
+  __resetGoogleSearchStateForTests();
   process.env.GEMINI_API_KEY = "mock-api-key";
 
   try {
@@ -127,5 +130,60 @@ test("google-search uses GEMINI_API_KEY if present (precedence)", async () => {
     assert.equal(notifications.length, 0, "Should NOT notify if API Key is present");
   } finally {
     delete process.env.GEMINI_API_KEY;
+  }
+});
+
+test("google-search breaks repeated identical queries instead of looping forever", async () => {
+  __resetGoogleSearchStateForTests();
+  const originalKey = process.env.GEMINI_API_KEY;
+  delete process.env.GEMINI_API_KEY;
+
+  const originalFetch = global.fetch;
+  let fetchCalls = 0;
+  (global as any).fetch = async () => {
+    fetchCalls++;
+    return {
+      ok: true,
+      json: async () => ({
+        response: {
+          candidates: [{ content: { parts: [{ text: "Mocked AI Answer" }] } }]
+        }
+      }),
+      text: async () => JSON.stringify({
+        response: {
+          candidates: [{ content: { parts: [{ text: "Mocked AI Answer" }] } }]
+        }
+      }),
+    };
+  };
+
+  try {
+    const pi = createMockPI();
+    googleSearchExtension(pi as any);
+
+    const oauthJson = JSON.stringify({ token: "mock-token", projectId: "mock-project" });
+    const mockCtx = {
+      ui: { notify() {} },
+      modelRegistry: mockModelRegistry(oauthJson),
+    };
+
+    const registeredTool = (pi as any).registeredTool;
+    const query = "latest node lts version";
+
+    const first = await registeredTool.execute("call-1", { query }, new AbortController().signal, () => {}, mockCtx);
+    const second = await registeredTool.execute("call-2", { query }, new AbortController().signal, () => {}, mockCtx);
+    const third = await registeredTool.execute("call-3", { query }, new AbortController().signal, () => {}, mockCtx);
+    const fourth = await registeredTool.execute("call-4", { query }, new AbortController().signal, () => {}, mockCtx);
+
+    assert.equal(first.isError, undefined);
+    assert.equal(second.isError, undefined);
+    assert.equal(third.isError, undefined);
+    assert.equal(fourth.isError, true);
+    assert.match(fourth.content[0].text, /Search loop detected/i);
+    assert.equal(fetchCalls, 1, "only the first identical query should hit the network");
+  } finally {
+    global.fetch = originalFetch;
+    process.env.GEMINI_API_KEY = originalKey;
+    __resetGoogleSearchStateForTests();
   }
 });


### PR DESCRIPTION
## Summary
- add a consecutive duplicate-query guard to `google_search`
- add a regression test covering repeated identical searches in the same session

## Why
The repo already had loop protection for `search-the-web`, but `google_search` could still repeat the same query indefinitely. This applies the same class of guard to the Google-backed search path so the model gets a clear stop signal instead of burning turns on identical searches.

## Testing
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/tests/google-search-auth.repro.test.ts src/tests/native-search.test.ts`
- `npm run build`
