### PR TITLE
feat: show release notes on build and TUI startup

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "build:pi-coding-agent": "npm run build -w @gsd/pi-coding-agent",
     "build:native-pkg": "npm run build -w @gsd/native",
     "build:pi": "npm run build:native-pkg && npm run build:pi-tui && npm run build:pi-ai && npm run build:pi-agent-core && npm run build:pi-coding-agent",
-    "build": "npm run build:pi && tsc && npm run copy-resources && npm run copy-themes && npm run copy-export-html",
+    "build": "npm run build:pi && tsc && npm run copy-resources && npm run copy-themes && npm run copy-export-html && node scripts/show-release-notes.cjs",
     "copy-resources": "node scripts/copy-resources.cjs",
     "copy-themes": "node scripts/copy-themes.cjs",
     "copy-export-html": "node scripts/copy-export-html.cjs",

--- a/scripts/show-release-notes.cjs
+++ b/scripts/show-release-notes.cjs
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+"use strict";
+
+const { execSync } = require("child_process");
+const { readFileSync } = require("fs");
+const { join } = require("path");
+
+const root = join(__dirname, "..");
+const pkg = JSON.parse(readFileSync(join(root, "package.json"), "utf8"));
+const version = pkg.version;
+
+// Find the last release tag or release commit
+let lastRelease = "";
+try {
+  // Try tag first (e.g. v2.33.1)
+  execSync(`git rev-parse "v${version}" 2>/dev/null`, { cwd: root });
+  lastRelease = `v${version}`;
+} catch {
+  try {
+    // Fallback: find "release: vX.Y.Z" commit
+    lastRelease = execSync(
+      `git log --all --format=%H --grep="release: v${version}" -1`,
+      { cwd: root, encoding: "utf8" }
+    ).trim();
+  } catch {
+    // ignore
+  }
+}
+
+const range = lastRelease ? `${lastRelease}..HEAD` : "-20";
+let log = "";
+try {
+  log = execSync(`git log ${range} --oneline --no-merges`, {
+    cwd: root,
+    encoding: "utf8",
+  }).trim();
+} catch {
+  log = "";
+}
+
+// Colors
+const RESET = "\x1b[0m";
+const BOLD = "\x1b[1m";
+const CYAN = "\x1b[36m";
+const GREEN = "\x1b[32m";
+const YELLOW = "\x1b[33m";
+const DIM = "\x1b[2m";
+
+const line = "─".repeat(50);
+
+console.log("");
+console.log(`${CYAN}${line}${RESET}`);
+console.log(`${BOLD}${GREEN} ✔ Build complete${RESET}  ${DIM}v${version}${RESET}`);
+console.log(`${CYAN}${line}${RESET}`);
+
+if (!log) {
+  console.log(`${DIM}  No changes since last release.${RESET}`);
+} else {
+  const commits = log.split("\n");
+  console.log(`${BOLD} 📋 Changes since v${version}:${RESET}`);
+  console.log("");
+  for (const c of commits) {
+    const match = c.match(/^([a-f0-9]+)\s+(.*)$/);
+    if (!match) continue;
+    const [, hash, msg] = match;
+
+    // Color by type
+    let icon = "•";
+    let color = RESET;
+    if (msg.startsWith("feat")) { icon = "✦"; color = GREEN; }
+    else if (msg.startsWith("fix")) { icon = "✧"; color = YELLOW; }
+    else if (msg.startsWith("refactor")) { icon = "↻"; color = CYAN; }
+
+    console.log(`  ${color}${icon} ${DIM}${hash}${RESET} ${msg}`);
+  }
+  console.log("");
+  console.log(`${DIM}  ${commits.length} commit(s) since last release${RESET}`);
+}
+console.log(`${CYAN}${line}${RESET}`);
+console.log("");

--- a/src/resources/extensions/gsd/index.ts
+++ b/src/resources/extensions/gsd/index.ts
@@ -26,6 +26,7 @@ import type {
 import { createBashTool, createWriteTool, createReadTool, createEditTool, isToolCallEventType } from "@gsd/pi-coding-agent";
 import { Type } from "@sinclair/typebox";
 
+import { execSync } from "node:child_process";
 import { debugLog, debugTime } from "./debug-logger.js";
 import { registerGSDCommand } from "./commands.js";
 import { loadToolApiKeys } from "./commands-config.js";
@@ -610,7 +611,48 @@ export default function (pi: ExtensionAPI) {
       const logoText = GSD_LOGO_LINES.map((line) => theme.fg("accent", line)).join("\n");
       const titleLine = `  ${theme.bold("Get Shit Done")} ${theme.fg("dim", `v${version}`)}`;
 
-      const headerContent = `${logoText}\n${titleLine}`;
+      // Release notes — show recent commits since last release
+      let releaseLines = "";
+      try {
+        const { resolve, dirname } = require("node:path") as typeof import("node:path");
+        const binPath = process.env.GSD_BIN_PATH || process.argv[1] || "";
+        const root = binPath ? resolve(dirname(binPath), "..") : "";
+        if (root) {
+          let lastRelease = "";
+          try {
+            execSync(`git rev-parse "v${version}" 2>/dev/null`, { cwd: root });
+            lastRelease = `v${version}`;
+          } catch {
+            try {
+              lastRelease = execSync(
+                `git log --all --format=%H --grep="release: v${version}" -1`,
+                { cwd: root, encoding: "utf8" },
+              ).trim();
+            } catch { /* ignore */ }
+          }
+          const range = lastRelease ? `${lastRelease}..HEAD` : "-10";
+          const log = execSync(`git log ${range} --oneline --no-merges`, {
+            cwd: root, encoding: "utf8",
+          }).trim();
+          if (log) {
+            const commits = log.split("\n");
+            releaseLines = `\n  ${theme.bold(`Changes since v${version}:`)}`;
+            for (const c of commits) {
+              const m = c.match(/^([a-f0-9]+)\s+(.*)$/);
+              if (!m) continue;
+              const [, hash, msg] = m;
+              let icon = "•";
+              if (msg.startsWith("feat")) icon = "✦";
+              else if (msg.startsWith("fix")) icon = "✧";
+              else if (msg.startsWith("refactor")) icon = "↻";
+              releaseLines += `\n  ${icon} ${theme.fg("dim", hash)} ${msg}`;
+            }
+            releaseLines += `\n  ${theme.fg("dim", `${commits.length} commit(s) since last release`)}`;
+          }
+        }
+      } catch { /* non-fatal */ }
+
+      const headerContent = `${logoText}\n${titleLine}${releaseLines}`;
       ctx.ui.setHeader((_ui, _theme) => new Text(headerContent, 1, 0));
     } catch {
       // RPC mode — no TUI, skip header rendering


### PR DESCRIPTION
## Summary
- Show recent commits since last release after `npm run build` completes (via `scripts/show-release-notes.cjs`)
- Display release notes in the GSD TUI header below "Get Shit Done vX.X.X" on `session_start`
- Commits are color-coded by conventional commit type: ✦ feat, ✧ fix, ↻ refactor, • other

## Details
The release boundary is detected automatically from git tags (`vX.Y.Z`) or `release: vX.Y.Z` commit messages. If there are no changes since the last release, the build script shows "No changes since last release" and the TUI header displays only the logo and version as before.

Non-fatal — if git is unavailable or any error occurs, the release notes are silently skipped and startup is not blocked.

## Test plan
- [ ] Run `npm run build` — release notes should appear after build output
- [ ] Launch `gsd` interactively — TUI header should show version + recent commits below the ASCII logo
- [ ] Build with no changes since last release — should show "No changes since last release"
- [ ] Run in `--print` / `--mode rpc` — release notes should NOT appear (header is skipped in non-TUI modes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)