### PR TITLE
fix: /gsd inspect calls ensureDbAvailable() before querying DB

### DIFF
--- a/src/resources/extensions/gsd/commands-inspect.ts
+++ b/src/resources/extensions/gsd/commands-inspect.ts
@@ -45,6 +45,13 @@ export function formatInspectOutput(data: InspectData): string {
 export async function handleInspect(ctx: ExtensionCommandContext): Promise<void> {
   try {
     const { isDbAvailable, _getAdapter } = await import("./gsd-db.js");
+    const { ensureDbAvailable } = await import("./index.js");
+
+    // Ensure the DB is open, initializing from disk if needed
+    if (!await ensureDbAvailable()) {
+      ctx.ui.notify("No GSD database available. Run /gsd auto to create one.", "info");
+      return;
+    }
 
     if (!isDbAvailable()) {
       ctx.ui.notify("No GSD database available. Run /gsd auto to create one.", "info");


### PR DESCRIPTION
## Summary
- `/gsd inspect` crashes when the DB has not been opened yet (e.g. fresh session or cold start)
- Added `ensureDbAvailable()` call in `handleInspect()` to open the existing `.gsd/gsd.db` from disk before querying
- Returns a graceful error message if the DB is truly unavailable

## Test plan
- [ ] Run `/gsd inspect` in a project with an existing `.gsd/gsd.db` without running any other command first — should work without error
- [ ] Run `/gsd inspect` in a project without `.gsd/gsd.db` — should show a clear error message instead of crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)