### PR TITLE
fix: correct GSD-WORKFLOW.md fallback path and sync to agentDir

### DIFF
--- a/src/resource-loader.ts
+++ b/src/resource-loader.ts
@@ -216,7 +216,7 @@ function copyDirRecursive(src: string, dest: string): void {
  * - extensions/ → ~/.gsd/agent/extensions/   (overwrite when version changes)
  * - agents/     → ~/.gsd/agent/agents/        (overwrite when version changes)
  * - skills/     → ~/.gsd/agent/skills/        (overwrite when version changes)
- * - GSD-WORKFLOW.md is read directly from bundled path via GSD_WORKFLOW_PATH env var
+ * - GSD-WORKFLOW.md → ~/.gsd/agent/GSD-WORKFLOW.md (fallback for env var miss)
  *
  * Skips the copy when the managed-resources.json version matches the current
  * GSD version, avoiding ~128ms of synchronous cpSync on every startup.
@@ -244,6 +244,13 @@ export function initResources(agentDir: string): void {
   syncResourceDir(bundledExtensionsDir, join(agentDir, 'extensions'))
   syncResourceDir(join(resourcesDir, 'agents'), join(agentDir, 'agents'))
   syncResourceDir(join(resourcesDir, 'skills'), join(agentDir, 'skills'))
+
+  // Sync GSD-WORKFLOW.md to agentDir as a fallback for when GSD_WORKFLOW_PATH
+  // env var is not set (e.g. fork/dev builds, alternative entry points).
+  const workflowSrc = join(resourcesDir, 'GSD-WORKFLOW.md')
+  if (existsSync(workflowSrc)) {
+    try { copyFileSync(workflowSrc, join(agentDir, 'GSD-WORKFLOW.md')) } catch { /* non-fatal */ }
+  }
 
   // Ensure all newly copied files are owner-writable so the next run can
   // overwrite them (covers extensions, agents, and skills in one walk).

--- a/src/resources/extensions/gsd/commands-handlers.ts
+++ b/src/resources/extensions/gsd/commands-handlers.ts
@@ -24,7 +24,7 @@ import { projectRoot } from "./commands.js";
 import { loadPrompt } from "./prompt-loader.js";
 
 export function dispatchDoctorHeal(pi: ExtensionAPI, scope: string | undefined, reportText: string, structuredIssues: string): void {
-  const workflowPath = process.env.GSD_WORKFLOW_PATH ?? join(process.env.HOME ?? "~", ".pi", "GSD-WORKFLOW.md");
+  const workflowPath = process.env.GSD_WORKFLOW_PATH ?? join(process.env.HOME ?? "~", ".gsd", "agent", "GSD-WORKFLOW.md");
   const workflow = readFileSync(workflowPath, "utf-8");
   const prompt = loadPrompt("doctor-heal", {
     doctorSummary: reportText,
@@ -187,7 +187,7 @@ export async function handleTriage(ctx: ExtensionCommandContext, pi: ExtensionAP
     roadmapContext: roadmapContext || "(no active roadmap)",
   });
 
-  const workflowPath = process.env.GSD_WORKFLOW_PATH ?? join(process.env.HOME ?? "~", ".pi", "GSD-WORKFLOW.md");
+  const workflowPath = process.env.GSD_WORKFLOW_PATH ?? join(process.env.HOME ?? "~", ".gsd", "agent", "GSD-WORKFLOW.md");
   const workflow = readFileSync(workflowPath, "utf-8");
 
   pi.sendMessage(

--- a/src/resources/extensions/gsd/guided-flow.ts
+++ b/src/resources/extensions/gsd/guided-flow.ts
@@ -191,7 +191,7 @@ type UIContext = ExtensionContext;
  * This is the only way the wizard triggers work — everything else is the LLM's job.
  */
 function dispatchWorkflow(pi: ExtensionAPI, note: string, customType = "gsd-run"): void {
-  const workflowPath = process.env.GSD_WORKFLOW_PATH ?? join(process.env.HOME ?? "~", ".pi", "GSD-WORKFLOW.md");
+  const workflowPath = process.env.GSD_WORKFLOW_PATH ?? join(process.env.HOME ?? "~", ".gsd", "agent", "GSD-WORKFLOW.md");
   const workflow = readFileSync(workflowPath, "utf-8");
 
   pi.sendMessage(


### PR DESCRIPTION
## Summary
- The fallback path for GSD-WORKFLOW.md still referenced the legacy `.pi` directory (`~/.pi/GSD-WORKFLOW.md`) instead of the correct `.gsd/agent` location
- This broke workflow dispatch (`dispatchWorkflow`, `dispatchDoctorHeal`, `handleTriage`) when `GSD_WORKFLOW_PATH` env var was not set
- Additionally, `initResources()` now syncs GSD-WORKFLOW.md to agentDir as a fallback for alternative entry points

## Changes
- Update fallback path from `~/.pi/` to `~/.gsd/agent/` in 3 call sites
- Sync `GSD-WORKFLOW.md` to `agentDir` during `initResources()`

## Test plan
- [ ] Remove `GSD_WORKFLOW_PATH` env var and run `/gsd auto` — workflow should load correctly from `~/.gsd/agent/GSD-WORKFLOW.md`
- [ ] Run `/gsd` with the env var set — behavior unchanged (env var takes precedence)
- [ ] Run `npm run test:unit` — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)