### PR TITLE
fix: remove stale top-level extension files after rename (.js → .ts)

### DIFF
--- a/src/resource-loader.ts
+++ b/src/resource-loader.ts
@@ -170,18 +170,55 @@ function makeTreeWritable(dirPath: string): void {
  * 1. Makes the destination writable (handles Nix store read-only copies).
  * 2. Removes destination subdirs that exist in source to clear stale files,
  *    while preserving user-created directories.
- * 3. Copies source into destination.
- * 4. Makes the result writable for the next upgrade cycle.
+ * 3. Removes stale top-level files in destDir whose base name (without
+ *    extension) matches a file in srcDir but with a different extension —
+ *    e.g. ask-user-questions.js left over after the source switched to .ts.
+ * 4. Copies source into destination.
+ * 5. Makes the result writable for the next upgrade cycle.
  */
 function syncResourceDir(srcDir: string, destDir: string): void {
   makeTreeWritable(destDir)
   if (existsSync(srcDir)) {
+    // Build a set of base names (without extension) for all top-level files in srcDir.
+    const srcFileBases = new Set<string>()
+    for (const entry of readdirSync(srcDir, { withFileTypes: true })) {
+      if (entry.isFile() || entry.isSymbolicLink()) {
+        const dot = entry.name.lastIndexOf('.')
+        srcFileBases.add(dot > 0 ? entry.name.slice(0, dot) : entry.name)
+      }
+    }
+
     for (const entry of readdirSync(srcDir, { withFileTypes: true })) {
       if (entry.isDirectory()) {
+        // Remove matching destination subdirs so stale nested files don't accumulate.
         const target = join(destDir, entry.name)
         if (existsSync(target)) rmSync(target, { recursive: true, force: true })
       }
     }
+
+    // Remove stale top-level files in destDir that share a base name with a
+    // source file but have a different extension (e.g. .js ↔ .ts swaps).
+    if (existsSync(destDir)) {
+      for (const entry of readdirSync(destDir, { withFileTypes: true })) {
+        if (!entry.isFile() && !entry.isSymbolicLink()) continue
+        const dot = entry.name.lastIndexOf('.')
+        const base = dot > 0 ? entry.name.slice(0, dot) : entry.name
+        // If srcDir has a file with this base name but it's been renamed to a
+        // different extension, the destDir copy is now stale — remove it.
+        if (srcFileBases.has(base)) {
+          const destPath = join(destDir, entry.name)
+          const srcPath = join(srcDir, entry.name)
+          if (!existsSync(srcPath)) {
+            try {
+              rmSync(destPath)
+            } catch {
+              // Non-fatal — best-effort stale-file cleanup
+            }
+          }
+        }
+      }
+    }
+
     try {
       cpSync(srcDir, destDir, { recursive: true, force: true })
     } catch {


### PR DESCRIPTION
## Problem

On startup, GSD was emitting:

```
[gsd] Extension load error: Tool "ask_user_questions" conflicts with /Users/.../.gsd/agent/extensions/ask-user-questions.js
[gsd] Extension load error: Tool "secure_env_collect" conflicts with /Users/.../.gsd/agent/extensions/get-secrets-from-user.js
```

## Root Cause

`syncResourceDir` removes stale **subdirectories** from the destination, but never removes stale top-level **files**. When an extension was renamed from a `.js` file to a `.ts` file between GSD versions, the old `.js` copy persisted indefinitely in `~/.gsd/agent/extensions/`. On the next launch, both the stale `.js` and the newly-synced `.ts` were discovered and loaded, causing both to register the same tool name.

Affected extensions:
- `ask-user-questions.js` → `ask-user-questions.ts` → registered `ask_user_questions` twice
- `get-secrets-from-user.js` → `get-secrets-from-user.ts` → registered `secure_env_collect` twice

## Fix

Before copying source into dest, scan the destination for top-level files whose **base name** (sans extension) matches a file in the source but with a **different extension**. Remove those stale files before the `cpSync`. User-created extensions whose base names have no match in the source are left untouched.

```
~/.gsd/agent/extensions/ask-user-questions.js   ← REMOVED (stale)
~/.gsd/agent/extensions/my-custom-extension.js  ← preserved (no src match)
```

Any future extension file rename will be cleaned up automatically on the next launch.

## Testing

- Verified logic with an isolated Node.js test: stale `.js` removed, unrelated user extensions preserved
- `npm run build` passes clean
- Manually removed the stale files from `~/.gsd/agent/extensions/` so the errors are gone immediately; the sync fix prevents recurrence on future upgrades