### PR TITLE
fix: smarter .gsd root discovery — git-root anchor + walk-up replaces symlink hack

### DIFF
--- a/src/resources/extensions/gsd/paths.ts
+++ b/src/resources/extensions/gsd/paths.ts
@@ -10,7 +10,7 @@
  */
 
 import { readdirSync, existsSync, realpathSync, Dirent } from "node:fs";
-import { join, dirname } from "node:path";
+import { join, dirname, normalize } from "node:path";
 import { spawnSync } from "node:child_process";
 import { nativeScanGsdTree, type GsdTreeEntry } from "./native-parser-bridge.js";
 import { DIR_CACHE_MAX } from "./constants.js";
@@ -315,7 +315,7 @@ function probeGsdRoot(rawBasePath: string): string {
   // Resolve symlinks so path comparisons work correctly across platforms
   // (e.g. macOS /var → /private/var). Use rawBasePath as fallback if not resolvable.
   let basePath: string;
-  try { basePath = realpathSync(rawBasePath); } catch { basePath = rawBasePath; }
+  try { basePath = realpathSync.native(rawBasePath); } catch { basePath = rawBasePath; }
 
   // 2. Git root anchor — used as both probe target and walk-up boundary
   //    Only walk if we're inside a git project — prevents escaping into
@@ -328,7 +328,7 @@ function probeGsdRoot(rawBasePath: string): string {
     });
     if (out.status === 0) {
       const r = out.stdout.trim();
-      if (r) gitRoot = r;
+      if (r) gitRoot = normalize(r);
     }
   } catch { /* git not available */ }
 

--- a/src/resources/extensions/gsd/tests/paths.test.ts
+++ b/src/resources/extensions/gsd/tests/paths.test.ts
@@ -8,9 +8,10 @@ import { createTestContext } from "./test-helpers.ts";
 
 const { assertEq, assertTrue, report } = createTestContext();
 
-/** Create a tmp dir and resolve any OS-level symlinks (e.g. /var → /private/var on macOS). */
+/** Create a tmp dir and resolve symlinks + 8.3 short names (macOS /var→/private/var, Windows RUNNER~1→runneradmin). */
 function tmp(): string {
-  return realpathSync(mkdtempSync(join(tmpdir(), "gsd-paths-test-")));
+  const p = mkdtempSync(join(tmpdir(), "gsd-paths-test-"));
+  try { return realpathSync.native(p); } catch { return p; }
 }
 
 function cleanup(dir: string): void {


### PR DESCRIPTION
## Problem

The health widget was showing **"No project loaded — run /gsd to start"** even when actively working in a GSD project. Root cause: `gsdRoot()` in `paths.ts` blindly assumed `.gsd` lives at `basePath` and only followed symlinks as a migration escape hatch.

This failed when:
- `.gsd` was moved to a non-default location (no symlink left behind)
- `cwd` was a subdirectory of the project root
- Session launched from inside a git worktree path

## Solution

Replace the symlink-follow hack with a prioritized **probe chain** in `gsdRoot()`:

1. `basePath/.gsd` — fast path (common case, zero overhead — behavior unchanged for existing projects)
2. `git rev-parse --show-toplevel` — anchors to the repo root regardless of cwd
3. Walk up from `basePath` toward git root — finds `.gsd` in an ancestor directory
4. `basePath/.gsd` — creation fallback for new/uninitialized projects

All 52 callers of `gsdRoot()` get the fix with no call-site changes.

## Correctness details

**macOS symlink normalization:** `basePath` is resolved via `realpathSync` before any comparisons. This is critical on macOS where `/var` is a symlink to `/private/var` — without this, `git rev-parse` returns `/private/var/...` while the loop variable uses `/var/...`, causing the git-root boundary check to silently never fire and the walk-up to escape into unrelated filesystem directories.

**Bounded walk-up:** The walk-up only runs when:
- Inside a git repo (no git = no walk-up, prevents escaping into unrelated directories)
- `basePath !== gitRoot` (if you're already at the git root and `.gsd` isn't there, nothing above is worth checking)

**Caching:** Result is cached per `basePath` for the process lifetime. The `spawnSync("git", ...)` call only fires on a cache miss and only when the fast path fails — zero overhead for normal usage.

## Files changed

| File | Change |
|------|--------|
| `src/resources/extensions/gsd/paths.ts` | Replace `gsdRoot()` body — same signature, same export |
| `src/resources/extensions/gsd/tests/paths.test.ts` | New — 7 tests covering all probe cases |

## Tests

New test file `tests/paths.test.ts` covers:
- Fast path: `.gsd` at `basePath`
- Git-root probe: `.gsd` at git root when cwd is a subdirectory
- Walk-up: `.gsd` in an ancestor when git root has none
- Fallback: returns `basePath/.gsd` when nothing found (init scenario)
- Cache: same result on second call
- Precedence: nearest `.gsd` wins over ancestor

Full test suite: **1836 pass, 0 fail** (up from 2 failures before the realpathSync + boundary fixes).