### PR TITLE
fix: add post-unit verification to guided /gsd mode (#1378)

### DIFF
--- a/src/resources/extensions/gsd/guided-flow.ts
+++ b/src/resources/extensions/gsd/guided-flow.ts
@@ -55,6 +55,22 @@ function buildDocsCommitInstruction(_message: string): string {
 
 // ─── Auto-start after discuss ─────────────────────────────────────────────────
 
+// ─── Guided dispatch tracking (#1378) ─────────────────────────────────────────
+/** Tracks the last guided-mode unit type + ID for post-unit verification. */
+let _activeGuidedUnit: { unitType: string; unitId: string } | null = null;
+
+export function setActiveGuidedUnit(unitType: string, unitId: string): void {
+  _activeGuidedUnit = { unitType, unitId };
+}
+
+export function consumeActiveGuidedUnit(): { unitType: string; unitId: string } | null {
+  const unit = _activeGuidedUnit;
+  _activeGuidedUnit = null;
+  return unit;
+}
+
+// ─── Auto-start after discuss ─────────────────────────────────────────────────
+
 /** Stashed context + flag for auto-starting after discuss phase completes */
 let pendingAutoStart: {
   ctx: ExtensionCommandContext;

--- a/src/resources/extensions/gsd/index.ts
+++ b/src/resources/extensions/gsd/index.ts
@@ -865,8 +865,44 @@ export default function (pi: ExtensionAPI) {
       return;
     }
 
+    // Guided-mode post-unit verification (#1378):
+    // When a guided workflow (non-auto, non-discuss) completes, run state
+    // rebuild and doctor checks to ensure artifacts were written correctly.
+    // This enforces the same artifact creation that auto-mode requires.
+    if (!isAutoActive()) {
+      try {
+        const basePath = process.cwd();
+        const { gsdRoot: getGsdRoot } = await importExtensionModule<typeof import("./paths.js")>(import.meta.url, "./paths.js");
+        const gsdDir = getGsdRoot(basePath);
+        const { existsSync: fsExists } = await import("node:fs");
+        if (fsExists(gsdDir)) {
+          const { rebuildState } = await importExtensionModule<typeof import("./doctor.js")>(import.meta.url, "./doctor.js");
+          const { runGSDDoctor } = await importExtensionModule<typeof import("./doctor.js")>(import.meta.url, "./doctor.js");
+          const { createGitService } = await importExtensionModule<typeof import("./git-service.js")>(import.meta.url, "./git-service.js");
+
+          // Rebuild STATE.md from disk
+          await rebuildState(basePath);
+
+          // Run doctor with auto-fix to repair any missing checkboxes, stale state
+          const report = await runGSDDoctor(basePath, { fix: true });
+          if (report.fixesApplied.length > 0) {
+            ctx.ui.notify(`Post-unit: applied ${report.fixesApplied.length} fix(es) to state.`, "info");
+          }
+
+          // Auto-commit any changes the guided agent made
+          try {
+            const gitService = createGitService(basePath);
+            const commitMsg = gitService.commit({ message: "chore: guided-mode auto-commit" });
+            if (commitMsg) {
+              ctx.ui.notify("Changes committed.", "info");
+            }
+          } catch { /* non-fatal — may not be a git repo */ }
+        }
+      } catch { /* non-fatal — guided verification should never block */ }
+      return;
+    }
+
     // If auto-mode is already running, advance to next unit
-    if (!isAutoActive()) return;
 
     // If the agent was aborted (user pressed Escape) or hit a provider
     // error (fetch failure, rate limit, etc.), pause auto-mode instead of

--- a/src/resources/extensions/gsd/tests/repo-identity-worktree.test.ts
+++ b/src/resources/extensions/gsd/tests/repo-identity-worktree.test.ts
@@ -13,8 +13,8 @@ function run(command: string, cwd: string): string {
 }
 
 async function main(): Promise<void> {
-  const base = mkdtempSync(join(tmpdir(), "gsd-repo-identity-"));
-  const stateDir = mkdtempSync(join(tmpdir(), "gsd-state-"));
+  const base = realpathSync(mkdtempSync(join(tmpdir(), "gsd-repo-identity-")));
+  const stateDir = realpathSync(mkdtempSync(join(tmpdir(), "gsd-state-")));
 
   try {
     process.env.GSD_STATE_DIR = stateDir;
@@ -38,7 +38,7 @@ async function main(): Promise<void> {
     assertEq(worktreeState, expectedExternalState, "worktree symlink target matches main repo external state dir");
     assertTrue(existsSync(join(worktreePath, ".gsd")), "worktree .gsd exists");
     assertTrue(lstatSync(join(worktreePath, ".gsd")).isSymbolicLink(), "worktree .gsd is a symlink");
-    assertEq(realpathSync(join(worktreePath, ".gsd")), expectedExternalState, "worktree .gsd symlink resolves to main repo external state dir");
+    assertEq(realpathSync(join(worktreePath, ".gsd")), realpathSync(expectedExternalState), "worktree .gsd symlink resolves to main repo external state dir");
 
     console.log("\n=== ensureGsdSymlink heals stale worktree symlinks ===");
     const staleState = join(stateDir, "projects", "stale-worktree-state");
@@ -47,7 +47,7 @@ async function main(): Promise<void> {
     symlinkSync(staleState, join(worktreePath, ".gsd"), "junction");
     const healedState = ensureGsdSymlink(worktreePath);
     assertEq(healedState, expectedExternalState, "stale worktree symlink is repaired to canonical external state dir");
-    assertEq(realpathSync(join(worktreePath, ".gsd")), expectedExternalState, "healed worktree symlink resolves to canonical external state dir");
+    assertEq(realpathSync(join(worktreePath, ".gsd")), realpathSync(expectedExternalState), "healed worktree symlink resolves to canonical external state dir");
 
     console.log("\n=== ensureGsdSymlink preserves worktree .gsd directories ===");
     rmSync(join(worktreePath, ".gsd"), { recursive: true, force: true });


### PR DESCRIPTION
## Problem

Guided `/gsd` mode was fire-and-forget — the `agent_end` handler returned early for non-auto-mode sessions, so no artifact verification, state rebuild, or doctor checks ran after a guided workflow completed. The agent could skip writing task plans, summaries, UAT files, and checkbox updates with no enforcement.

## Fix

Added a guided-mode path in `agent_end` that runs after non-auto, non-discuss workflows complete:
1. `rebuildState()` — regenerates STATE.md from disk
2. `runGSDDoctor(fix: true)` — repairs missing checkboxes, stale state
3. Auto-commit via `gitService.commit()` — commits any changes the guided agent made

All wrapped in try/catch as non-fatal — guided verification should never block.

## Additional

- Added `setActiveGuidedUnit`/`consumeActiveGuidedUnit` tracking to guided-flow.ts for future per-unit verification
- Fixed macOS `/var` → `/private/var` path canonicalization in repo-identity-worktree.test.ts

## Test Results

- 1843 pass, 1 pre-existing failure (`initResources syncs` — needs full build, fails on clean main too), 3 skipped
- Type check: ✅ clean

Fixes #1378