### PR TITLE
fix: treat milestones with SUMMARY as complete regardless of roadmap state (#1369)

### DIFF
--- a/src/resources/extensions/gsd/state.ts
+++ b/src/resources/extensions/gsd/state.ts
@@ -325,20 +325,27 @@ async function _deriveStateImpl(basePath: string): Promise<GSDState> {
     }
 
     const title = roadmap.title.replace(/^M\d+(?:-[a-z0-9]{6})?[^:]*:\s*/, '');
+
+    // Check for summary file FIRST — a milestone with a summary is complete
+    // regardless of roadmap checkbox state. This prevents stale/unsynced roadmaps
+    // in worktrees from resurrecting completed milestones (#1369).
+    const summaryFile = resolveMilestoneFile(basePath, mid, "SUMMARY");
+    if (summaryFile) {
+      // Use roadmap title (already parsed), not summary title
+      registry.push({ id: mid, title, status: 'complete' });
+      completeMilestoneIds.add(mid);
+      continue;
+    }
+
     const complete = isMilestoneComplete(roadmap);
 
     if (complete) {
       // All slices done — check validation and summary state
-      const summaryFile = resolveMilestoneFile(basePath, mid, "SUMMARY");
       const validationFile = resolveMilestoneFile(basePath, mid, "VALIDATION");
       const validationContent = validationFile ? await cachedLoadFile(validationFile) : null;
       const validationTerminal = validationContent ? isValidationTerminal(validationContent) : false;
 
-      if (summaryFile) {
-        // Summary exists → milestone is complete regardless of validation state.
-        // The summary is the terminal artifact (#864).
-        registry.push({ id: mid, title, status: 'complete' });
-      } else if (!validationTerminal && !activeMilestoneFound) {
+      if (!validationTerminal && !activeMilestoneFound) {
         // No summary and no terminal validation → validating-milestone
         activeMilestone = { id: mid, title };
         activeRoadmap = roadmap;


### PR DESCRIPTION
## Problem

When a milestone worktree (M002) inherited a stale copy of a completed milestone's (M001) roadmap where some slices were still `[ ]`, `deriveState()` treated M001 as incomplete and active — dispatching stale units in a hard loop until the lifetime cap was reached.

The root cause: `deriveState()` only checked for `SUMMARY` file inside the `if (isMilestoneComplete(roadmap))` branch. A completed milestone with stale unchecked slices never entered that branch, so its SUMMARY was never consulted.

## Fix

Check for SUMMARY file **before** checking roadmap completeness. The SUMMARY is the terminal completion artifact — if it exists, the milestone is complete regardless of roadmap checkbox state. This prevents stale/unsynced roadmaps in worktrees from resurrecting completed milestones.

## Test Results

- 0 new failures introduced
- Pre-existing upstream failures unaffected: `repo-identity-worktree` (macOS /var), `initResources` (needs full build), file-watcher timing

Fixes #1369