### PR TITLE
fix: accept 'partial' UAT verdict + enforce valid verdict values (#1393)

### DIFF
--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -144,7 +144,10 @@ const DISPATCH_RULES: DispatchRule[] = [
         if (!content) continue;
         const verdictMatch = content.match(/verdict:\s*([\w-]+)/i);
         const verdict = verdictMatch?.[1]?.toLowerCase();
-        if (verdict && verdict !== "pass" && verdict !== "passed") {
+        // Valid passing verdicts: pass, passed, partial (partial = issues noted but not blocking)
+        // Invalid/blocking: fail, failed, needs-remediation, or any unrecognized value
+        const passingVerdicts = new Set(["pass", "passed", "partial"]);
+        if (verdict && !passingVerdicts.has(verdict)) {
           return {
             action: "stop" as const,
             reason: `UAT verdict for ${slice.id} is "${verdict}" — blocking progression until resolved.\nReview the UAT result and update the verdict to PASS, or re-run /gsd auto after fixing.`,

--- a/src/resources/extensions/gsd/prompts/run-uat.md
+++ b/src/resources/extensions/gsd/prompts/run-uat.md
@@ -38,6 +38,8 @@ After running all checks, compute the **overall verdict**:
 - `FAIL` — one or more checks failed
 - `PARTIAL` — some checks passed, some failed or were skipped
 
+**The verdict field MUST be exactly one of: PASS, FAIL, or PARTIAL.** Do not invent other values (e.g., "surfaced-for-human-review", "needs-attention"). If unsure, use PARTIAL.
+
 Write `{{uatResultPath}}` with:
 
 ```markdown


### PR DESCRIPTION
## Problem

The UAT verdict gate in `auto-dispatch.ts` only accepted 'pass'/'passed' and blocked on any other value — including the valid 'partial' verdict that the run-uat prompt template defines as an option. When a doctor-reconstructed placeholder UAT led the LLM to write a non-standard verdict like 'surfaced-for-human-review', auto-mode hard-stopped.

## Fix

- `auto-dispatch.ts`: Verdict gate uses a `passingVerdicts` set (`pass`, `passed`, `partial`) instead of two hardcoded string comparisons
- `run-uat.md`: Added explicit enforcement that verdict MUST be exactly PASS, FAIL, or PARTIAL — no invented values

Fixes #1393