### PR TITLE
fix: false "Interrupted Session Detected" on every /gsd startup

### DIFF
--- a/src/resources/extensions/gsd/guided-flow.ts
+++ b/src/resources/extensions/gsd/guided-flow.ts
@@ -792,17 +792,28 @@ export async function showSmartEntry(
   const crashLock = readCrashLock(basePath);
   if (crashLock) {
     clearLock(basePath);
-    const resume = await showNextAction(ctx, {
-      title: "GSD — Interrupted Session Detected",
-      summary: [formatCrashInfo(crashLock)],
-      actions: [
-        { id: "resume", label: "Resume with /gsd auto", description: "Pick up where it left off", recommended: true },
-        { id: "continue", label: "Continue manually", description: "Open the wizard as normal" },
-      ],
-    });
-    if (resume === "resume") {
-      await startAuto(ctx, pi, basePath, false);
-      return;
+
+    // Bootstrap crash with zero completed units = no work was lost.
+    // Auto-discard instead of prompting the user — this commonly happens
+    // when the user exits during init wizard or discuss phase before any
+    // real auto-mode work begins.
+    const isBootstrapCrash = crashLock.unitType === "starting"
+      && crashLock.unitId === "bootstrap"
+      && crashLock.completedUnits === 0;
+
+    if (!isBootstrapCrash) {
+      const resume = await showNextAction(ctx, {
+        title: "GSD — Interrupted Session Detected",
+        summary: [formatCrashInfo(crashLock)],
+        actions: [
+          { id: "resume", label: "Resume with /gsd auto", description: "Pick up where it left off", recommended: true },
+          { id: "continue", label: "Continue manually", description: "Open the wizard as normal" },
+        ],
+      });
+      if (resume === "resume") {
+        await startAuto(ctx, pi, basePath, false);
+        return;
+      }
     }
   }
 

--- a/src/resources/extensions/gsd/session-lock.ts
+++ b/src/resources/extensions/gsd/session-lock.ts
@@ -122,6 +122,12 @@ function ensureExitHandler(gsdDir: string): void {
     try {
       if (_releaseFunction) { _releaseFunction(); _releaseFunction = null; }
     } catch { /* best-effort */ }
+    // Remove the auto.lock metadata file so crash-recovery doesn't
+    // falsely detect an interrupted session on the next startup.
+    try {
+      const lockFile = join(gsdDir, LOCK_FILE);
+      if (existsSync(lockFile)) unlinkSync(lockFile);
+    } catch { /* best-effort */ }
     try {
       const lockDir = join(gsdDir + ".lock");
       if (existsSync(lockDir)) rmSync(lockDir, { recursive: true, force: true });


### PR DESCRIPTION
## Problem

Every time a user runs `/gsd`, exits normally (Ctrl+C, close tab, or choosing "Not yet"), and then runs `/gsd` again, they get a spurious "Interrupted Session Detected" prompt:

```
✓  GSD — Interrupted Session Detected

   Previous auto-mode session was interrupted.
   Was executing: starting (bootstrap)
   Started at: 2026-03-19T14:10:39.264Z
   Units completed before crash: 0
   PID: 23476
   No work was lost. Run /gsd auto to restart.
```

This happens on **every single startup** after any non-clean exit, even though no work was lost. The user has to manually dismiss it each time, which is frustrating and confusing.

## Root Cause

There are two independent bugs that compound into this behavior:

### Bug 1: `session-lock.ts` exit handler doesn't clean `auto.lock`

When `acquireSessionLock()` runs during bootstrap, it writes `auto.lock` with `unitType: "starting"`, `unitId: "bootstrap"`, `completedUnits: 0`. The `process.once("exit")` handler in `ensureExitHandler()` cleans up the OS-level lock directory (`.gsd.lock/`) but **does not remove the `auto.lock` metadata file**:

```typescript
// session-lock.ts:121-129 (before fix)
process.once("exit", () => {
  try {
    if (_releaseFunction) { _releaseFunction(); _releaseFunction = null; }
  } catch { /* best-effort */ }
  try {
    const lockDir = join(gsdDir + ".lock");
    if (existsSync(lockDir)) rmSync(lockDir, { recursive: true, force: true });
  } catch { /* best-effort */ }
});
```

So after any process exit (normal or abnormal), `auto.lock` persists on disk with stale bootstrap data.

### Bug 2: `guided-flow.ts` doesn't distinguish bootstrap crashes from real crashes

On next startup, `showSmartEntry()` calls `readCrashLock()` which finds the stale `auto.lock`. Even though `formatCrashInfo()` already recognizes this as a harmless bootstrap crash (it outputs "No work was lost"), the code **still shows the interactive menu** asking the user to choose between resuming, continuing manually, or waiting:

```typescript
// guided-flow.ts:791-807 (before fix)
const crashLock = readCrashLock(basePath);
if (crashLock) {
  clearLock(basePath);
  // Always shows the menu, even for bootstrap crashes with 0 units
  const resume = await showNextAction(ctx, { ... });
}
```

### The cycle

1. User runs `/gsd` → `acquireSessionLock()` writes `auto.lock` with `bootstrap/0`
2. User exits (Ctrl+C, close tab, "Not yet") → exit handler cleans `.gsd.lock/` dir but leaves `auto.lock`
3. User runs `/gsd` again → `readCrashLock()` finds `auto.lock` → shows "Interrupted Session" menu
4. User dismisses menu → `acquireSessionLock()` overwrites `auto.lock` with new `bootstrap/0`
5. User exits → repeat from step 2

This affects every user who doesn't complete a full auto-mode session on their first `/gsd` run.

## Fix

Two changes that address both root causes:

### 1. `session-lock.ts`: Clean `auto.lock` on process exit

The exit handler now removes the `auto.lock` metadata file alongside the OS lock directory. This prevents stale locks from persisting after normal exits (Ctrl+C, SIGTERM, clean shutdown):

```typescript
process.once("exit", () => {
  // ... release OS lock ...
  try {
    const lockFile = join(gsdDir, LOCK_FILE);
    if (existsSync(lockFile)) unlinkSync(lockFile);
  } catch { /* best-effort */ }
  // ... remove .gsd.lock/ dir ...
});
```

### 2. `guided-flow.ts`: Auto-discard bootstrap crash locks

Even if `auto.lock` survives (SIGKILL, power loss, kernel panic), bootstrap crashes with zero completed units are now silently discarded instead of prompting the user. The crash recovery menu only appears when real work was interrupted:

```typescript
const isBootstrapCrash = crashLock.unitType === "starting"
  && crashLock.unitId === "bootstrap"
  && crashLock.completedUnits === 0;

if (!isBootstrapCrash) {
  // Show crash recovery menu only for real interrupted work
}
```

This is safe because `formatCrashInfo()` already identifies this case and says "No work was lost" — the fix just acts on that knowledge automatically instead of asking the user.

## Why both fixes?

- Fix 1 alone doesn't cover SIGKILL / power loss / kernel panic (exit handler doesn't run)
- Fix 2 alone doesn't cover non-bootstrap stale locks from the same exit handler gap
- Together they provide defense in depth: normal exits clean up properly, and even if cleanup fails, harmless bootstrap locks are silently discarded

## Test plan

- [ ] Run `/gsd` on a project with no `.gsd/`, go through init wizard, exit with Ctrl+C → next `/gsd` should NOT show "Interrupted Session"
- [ ] Run `/gsd auto`, let it start a real unit, exit with Ctrl+C → next `/gsd` SHOULD show "Interrupted Session" (real work was interrupted)
- [ ] Run `/gsd`, choose "Not yet" at any menu → next `/gsd` should NOT show "Interrupted Session"
- [ ] Existing `crash-recovery.test.ts` and `loop-regression.test.ts` tests still pass