### PR TITLE
fix: realign cwd before dispatch + clean stale merge state on failure (#1389)

### DIFF
--- a/src/resources/extensions/gsd/auto-loop.ts
+++ b/src/resources/extensions/gsd/auto-loop.ts
@@ -221,6 +221,15 @@ export async function runUnit(
     s.pendingResolve = resolve;
   });
 
+  // Ensure cwd matches basePath before dispatch (#1389).
+  // async_bash and background jobs can drift cwd away from the worktree.
+  // Realigning here prevents commits from landing on the wrong branch.
+  try {
+    if (process.cwd() !== s.basePath) {
+      process.chdir(s.basePath);
+    }
+  } catch { /* non-fatal — chdir may fail if dir was removed */ }
+
   // ── Send the prompt ──
   debugLog("runUnit", { phase: "send-message", unitType, unitId });
 

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -1145,6 +1145,9 @@ export async function dispatchHookUnit(
   ctx.ui.setStatus("gsd-auto", s.stepMode ? "next" : "auto");
   ctx.ui.notify(`Running post-unit hook: ${hookName}`, "info");
 
+  // Ensure cwd matches basePath before hook dispatch (#1389)
+  try { if (process.cwd() !== s.basePath) process.chdir(s.basePath); } catch {}
+
   debugLog("dispatchHookUnit", {
     phase: "send-message",
     promptLength: hookPrompt.length,

--- a/src/resources/extensions/gsd/worktree-resolver.ts
+++ b/src/resources/extensions/gsd/worktree-resolver.ts
@@ -13,6 +13,8 @@
  * `process.chdir()` internally — this class MUST NOT double-chdir.
  */
 
+import { existsSync, unlinkSync } from "node:fs";
+import { join } from "node:path";
 import type { AutoSession } from "./auto/session.js";
 import { debugLog } from "./debug-logger.js";
 
@@ -371,6 +373,15 @@ export class WorktreeResolver {
         fallback: "chdir-to-project-root",
       });
       ctx.notify(`Milestone merge failed: ${msg}`, "warning");
+
+      // Clean up stale merge state left by failed squash-merge (#1389)
+      try {
+        const gitDir = join(originalBase || this.s.basePath, ".git");
+        for (const f of ["SQUASH_MSG", "MERGE_HEAD", "MERGE_MSG"]) {
+          const p = join(gitDir, f);
+          if (existsSync(p)) unlinkSync(p);
+        }
+      } catch { /* best-effort */ }
 
       // Error recovery: always restore to project root
       if (originalBase) {


### PR DESCRIPTION
## Problem

During milestone execution in worktree isolation mode, GSD dispatched slices to both the worktree branch and `main` concurrently. The two branches independently modified the same files, accumulating 41 conflicting files that made squash-merge impossible. The merge failure also left stale `.git/SQUASH_MSG` behind, polluting the working tree.

Root cause: `async_bash` and background jobs can drift `process.cwd()` away from the worktree, causing subsequent commits to land on whatever branch is checked out at the project root.

## Fix

1. **cwd realignment:** Before each unit dispatch and hook dispatch, verify `process.cwd()` matches `s.basePath` and realign if drifted. This prevents the dual-branch dispatch pattern.

2. **Merge failure cleanup:** When `tryMergeMilestone` fails, clean up stale git merge state files (`SQUASH_MSG`, `MERGE_HEAD`, `MERGE_MSG`) so subsequent git operations aren't blocked.

## Note

The reporter is on v2.32.0-dev. v2.33.0 included #1314 (tryMergeMilestone consolidation) which improves the merge path, but doesn't prevent the cwd drift that causes dual-branch dispatch. This fix addresses the dispatch-side cause.

Fixes #1389