### PR TITLE
fix: inject network_idle warning into hook prompts (#1345)

### DIFF
--- a/src/resources/extensions/gsd/post-unit-hooks.ts
+++ b/src/resources/extensions/gsd/post-unit-hooks.ts
@@ -149,10 +149,14 @@ function dequeueNextHook(basePath: string): HookDispatchResult | null {
 
     // Build the prompt with variable substitution
     const [mid, sid, tid] = triggerUnitId.split("/");
-    const prompt = config.prompt
+    let prompt = config.prompt
       .replace(/\{milestoneId\}/g, mid ?? "")
       .replace(/\{sliceId\}/g, sid ?? "")
       .replace(/\{taskId\}/g, tid ?? "");
+
+    // Inject browser safety instruction for hooks that may use browser tools (#1345).
+    // Vite HMR and other persistent connections prevent networkidle from resolving.
+    prompt += "\n\n**Browser tool safety:** Do NOT use `browser_wait_for` with `condition: \"network_idle\"` — it hangs indefinitely when dev servers keep persistent connections (Vite HMR, WebSocket). Use `selector_visible`, `text_visible`, or `delay` instead.";
 
     return {
       hookName: config.name,


### PR DESCRIPTION
## Problem

Post-unit hooks using browser tools hang indefinitely when the LLM calls `browser_wait_for` with `condition: "network_idle"` against a dev server with persistent connections (Vite HMR WebSocket). The `networkidle` event never fires.

## Fix

Inject a browser safety instruction into every hook prompt warning against `network_idle` and recommending `selector_visible`, `text_visible`, or `delay` as alternatives.

Fixes #1345