### PR TITLE
fix: health widget shows "No project loaded" after init

### DIFF
--- a/src/resources/extensions/gsd/health-widget.ts
+++ b/src/resources/extensions/gsd/health-widget.ts
@@ -11,9 +11,11 @@
 import type { ExtensionContext } from "@gsd/pi-coding-agent";
 import { runProviderChecks, summariseProviderIssues } from "./doctor-providers.js";
 import { runEnvironmentChecks } from "./doctor-environment.js";
+import { existsSync } from "node:fs";
 import { loadEffectiveGSDPreferences } from "./preferences.js";
 import { loadLedgerFromDisk, getProjectTotals } from "./metrics.js";
 import { projectRoot } from "./commands.js";
+import { gsdRoot } from "./paths.js";
 
 // ── Types ──────────────────────────────────────────────────────────────────────
 
@@ -41,9 +43,10 @@ function loadHealthWidgetData(basePath: string): HealthWidgetData {
     const prefs = loadEffectiveGSDPreferences();
     budgetCeiling = prefs?.preferences?.budget_ceiling;
 
+    hasProject = existsSync(gsdRoot(basePath));
+
     const ledger = loadLedgerFromDisk(basePath);
     if (ledger) {
-      hasProject = true;
       const totals = getProjectTotals(ledger.units ?? []);
       budgetSpent = totals.cost;
     }


### PR DESCRIPTION
## Summary
- Health widget `hasProject` check was tied to `metrics.json` existence, which is only created after auto-mode completes a unit
- Changed to check `.gsd/` directory existence via `existsSync(gsdRoot(basePath))`, matching the actual project initialization state
- Budget info still loads from `metrics.json` when available; widget now shows "System OK" immediately after `/gsd init`

## Test plan
- [ ] Run `/gsd init` in a clean directory → widget should show "System OK", not "No project loaded"
- [ ] Run auto-mode and complete a unit → budget info should display correctly
- [ ] Open a directory without `.gsd/` → widget should show "No project loaded"

🤖 Generated with [Claude Code](https://claude.com/claude-code)