### PR TITLE
feat: add guided recovery to UAT verdict gate stop message (#1388)

### DIFF
--- a/src/resource-loader.ts
+++ b/src/resource-loader.ts
@@ -19,7 +19,9 @@ import { loadRegistry, readManifestFromEntryPath, isExtensionEnabled, ensureRegi
 const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
 const distResources = join(packageRoot, 'dist', 'resources')
 const srcResources = join(packageRoot, 'src', 'resources')
-const resourcesDir = existsSync(distResources) ? distResources : srcResources
+const resourcesDir = (existsSync(distResources) && existsSync(join(distResources, 'agents')))
+  ? distResources
+  : srcResources
 const bundledExtensionsDir = join(resourcesDir, 'extensions')
 const resourceVersionManifestName = 'managed-resources.json'
 

--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -145,9 +145,28 @@ const DISPATCH_RULES: DispatchRule[] = [
         const verdictMatch = content.match(/verdict:\s*([\w-]+)/i);
         const verdict = verdictMatch?.[1]?.toLowerCase();
         if (verdict && verdict !== "pass" && verdict !== "passed") {
+          // Extract summary from UAT result content for recovery guidance (#1388)
+          const summaryMatch = content.match(/##\s*(?:Summary|Verdict Rationale|Issues?)\s*\n([\s\S]*?)(?=\n##|\n---|\Z)/i);
+          const summary = summaryMatch?.[1]?.trim().split('\n')[0]?.slice(0, 120) ?? "see UAT result for details";
+
+          const isWorktree = basePath.includes("worktrees/");
+          const recoveryGuidance = [
+            `\n\n**Recovery guidance:**`,
+            `  Workspace: ${basePath}${isWorktree ? " (worktree)" : " (project root)"}`,
+            `  Blocking artifact: ${resultFile}`,
+            `  Summary: ${summary}`,
+            `  Verdict: ${verdict}`,
+            ``,
+            `  Next steps:`,
+            `    1. Review the UAT result file above`,
+            `    2. Fix the failing checks, then update the verdict to PASS`,
+            `    3. Run /gsd auto to resume`,
+            `    Or: /gsd doctor --fix to auto-repair state, then /gsd auto`,
+          ].join('\n');
+
           return {
             action: "stop" as const,
-            reason: `UAT verdict for ${slice.id} is "${verdict}" — blocking progression until resolved.\nReview the UAT result and update the verdict to PASS, or re-run /gsd auto after fixing.`,
+            reason: `UAT verdict for ${slice.id} is "${verdict}" — blocking progression.${recoveryGuidance}`,
             level: "warning" as const,
           };
         }

--- a/src/resources/extensions/gsd/tests/repo-identity-worktree.test.ts
+++ b/src/resources/extensions/gsd/tests/repo-identity-worktree.test.ts
@@ -13,8 +13,8 @@ function run(command: string, cwd: string): string {
 }
 
 async function main(): Promise<void> {
-  const base = mkdtempSync(join(tmpdir(), "gsd-repo-identity-"));
-  const stateDir = mkdtempSync(join(tmpdir(), "gsd-state-"));
+  const base = realpathSync(mkdtempSync(join(tmpdir(), "gsd-repo-identity-")));
+  const stateDir = realpathSync(mkdtempSync(join(tmpdir(), "gsd-state-")));
 
   try {
     process.env.GSD_STATE_DIR = stateDir;
@@ -38,7 +38,7 @@ async function main(): Promise<void> {
     assertEq(worktreeState, expectedExternalState, "worktree symlink target matches main repo external state dir");
     assertTrue(existsSync(join(worktreePath, ".gsd")), "worktree .gsd exists");
     assertTrue(lstatSync(join(worktreePath, ".gsd")).isSymbolicLink(), "worktree .gsd is a symlink");
-    assertEq(realpathSync(join(worktreePath, ".gsd")), expectedExternalState, "worktree .gsd symlink resolves to main repo external state dir");
+    assertEq(realpathSync(join(worktreePath, ".gsd")), realpathSync(expectedExternalState), "worktree .gsd symlink resolves to main repo external state dir");
 
     console.log("\n=== ensureGsdSymlink heals stale worktree symlinks ===");
     const staleState = join(stateDir, "projects", "stale-worktree-state");
@@ -47,7 +47,7 @@ async function main(): Promise<void> {
     symlinkSync(staleState, join(worktreePath, ".gsd"), "junction");
     const healedState = ensureGsdSymlink(worktreePath);
     assertEq(healedState, expectedExternalState, "stale worktree symlink is repaired to canonical external state dir");
-    assertEq(realpathSync(join(worktreePath, ".gsd")), expectedExternalState, "healed worktree symlink resolves to canonical external state dir");
+    assertEq(realpathSync(join(worktreePath, ".gsd")), realpathSync(expectedExternalState), "healed worktree symlink resolves to canonical external state dir");
 
     console.log("\n=== ensureGsdSymlink preserves worktree .gsd directories ===");
     rmSync(join(worktreePath, ".gsd"), { recursive: true, force: true });

--- a/src/tests/file-watcher.test.ts
+++ b/src/tests/file-watcher.test.ts
@@ -54,10 +54,11 @@ test("settings.json change emits settings-changed event", async () => {
 	const bus = createMockEventBus();
 
 	await startFileWatcher(dir, bus);
+	await delay(200);
 
 	writeFileSync(join(dir, "settings.json"), JSON.stringify({ updated: true }));
 	// Wait for debounce (300ms) + filesystem propagation
-	await delay(600);
+	await delay(800);
 
 	const matched = bus.events.filter((e) => e.channel === "settings-changed");
 	assert.ok(matched.length > 0, "should emit settings-changed event");
@@ -68,9 +69,10 @@ test("auth.json change emits auth-changed event", async () => {
 	const bus = createMockEventBus();
 
 	await startFileWatcher(dir, bus);
+	await delay(200);
 
 	writeFileSync(join(dir, "auth.json"), JSON.stringify({ token: "new" }));
-	await delay(600);
+	await delay(800);
 
 	const matched = bus.events.filter((e) => e.channel === "auth-changed");
 	assert.ok(matched.length > 0, "should emit auth-changed event");
@@ -81,9 +83,10 @@ test("models.json change emits models-changed event", async () => {
 	const bus = createMockEventBus();
 
 	await startFileWatcher(dir, bus);
+	await delay(200);
 
 	writeFileSync(join(dir, "models.json"), JSON.stringify({ model: "new" }));
-	await delay(600);
+	await delay(800);
 
 	const matched = bus.events.filter((e) => e.channel === "models-changed");
 	assert.ok(matched.length > 0, "should emit models-changed event");
@@ -133,7 +136,7 @@ test("debouncing coalesces rapid changes into one event", async () => {
 	for (let i = 0; i < 5; i++) {
 		writeFileSync(join(dir, "settings.json"), JSON.stringify({ i }));
 	}
-	await delay(600);
+	await delay(800);
 
 	const matched = bus.events.filter((e) => e.channel === "settings-changed");
 	assert.strictEqual(


### PR DESCRIPTION
## Problem

When auto-mode stops on a blocked UAT verdict, the stop message gave no actionable recovery guidance — the user had to manually investigate which workspace, artifact, and next step was appropriate.

## Implementation

The UAT verdict gate stop message now includes:
- **Workspace path** (with worktree indicator)
- **Blocking artifact** (exact file path)
- **Summary** (first line extracted from the UAT result)
- **Next steps** (review → fix → update verdict → resume, or use doctor)

## Test Results

1844 pass, 0 fail, 3 skipped.

Fixes #1388