### PR TITLE
fix: add JS fallbacks for native TUI functions (#1418)

### DIFF
--- a/packages/pi-tui/src/utils.ts
+++ b/packages/pi-tui/src/utils.ts
@@ -85,7 +85,12 @@ export function extractAnsiCode(str: string, pos: number): { code: string; lengt
  * Delegates to the native Rust implementation.
  */
 export function visibleWidth(str: string): number {
-	return nativeVisibleWidth(str);
+	try {
+		return nativeVisibleWidth(str);
+	} catch {
+		// JS fallback — strip ANSI codes and return length (#1418)
+		return str.replace(/\x1b\[[0-9;]*m/g, "").length;
+	}
 }
 
 /**
@@ -97,7 +102,28 @@ export function visibleWidth(str: string): number {
  * @returns Array of wrapped lines (NOT padded to width)
  */
 export function wrapTextWithAnsi(text: string, width: number): string[] {
-	return nativeWrapTextWithAnsi(text, width);
+	try {
+		return nativeWrapTextWithAnsi(text, width);
+	} catch {
+		// JS fallback when native addon is unavailable (e.g., glibc mismatch on older Linux) (#1418)
+		const lines: string[] = [];
+		for (const line of text.split("\n")) {
+			if (line.length <= width) {
+				lines.push(line);
+			} else {
+				// Simple word-wrap without ANSI awareness
+				let remaining = line;
+				while (remaining.length > width) {
+					const breakAt = remaining.lastIndexOf(" ", width);
+					const splitPoint = breakAt > 0 ? breakAt : width;
+					lines.push(remaining.slice(0, splitPoint));
+					remaining = remaining.slice(splitPoint).trimStart();
+				}
+				if (remaining) lines.push(remaining);
+			}
+		}
+		return lines;
+	}
 }
 
 /**

--- a/src/resource-loader.ts
+++ b/src/resource-loader.ts
@@ -19,7 +19,9 @@ import { loadRegistry, readManifestFromEntryPath, isExtensionEnabled, ensureRegi
 const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
 const distResources = join(packageRoot, 'dist', 'resources')
 const srcResources = join(packageRoot, 'src', 'resources')
-const resourcesDir = existsSync(distResources) ? distResources : srcResources
+const resourcesDir = (existsSync(distResources) && existsSync(join(distResources, 'agents')))
+  ? distResources
+  : srcResources
 const bundledExtensionsDir = join(resourcesDir, 'extensions')
 const resourceVersionManifestName = 'managed-resources.json'
 

--- a/src/resources/extensions/gsd/tests/repo-identity-worktree.test.ts
+++ b/src/resources/extensions/gsd/tests/repo-identity-worktree.test.ts
@@ -13,8 +13,8 @@ function run(command: string, cwd: string): string {
 }
 
 async function main(): Promise<void> {
-  const base = mkdtempSync(join(tmpdir(), "gsd-repo-identity-"));
-  const stateDir = mkdtempSync(join(tmpdir(), "gsd-state-"));
+  const base = realpathSync(mkdtempSync(join(tmpdir(), "gsd-repo-identity-")));
+  const stateDir = realpathSync(mkdtempSync(join(tmpdir(), "gsd-state-")));
 
   try {
     process.env.GSD_STATE_DIR = stateDir;
@@ -38,7 +38,7 @@ async function main(): Promise<void> {
     assertEq(worktreeState, expectedExternalState, "worktree symlink target matches main repo external state dir");
     assertTrue(existsSync(join(worktreePath, ".gsd")), "worktree .gsd exists");
     assertTrue(lstatSync(join(worktreePath, ".gsd")).isSymbolicLink(), "worktree .gsd is a symlink");
-    assertEq(realpathSync(join(worktreePath, ".gsd")), expectedExternalState, "worktree .gsd symlink resolves to main repo external state dir");
+    assertEq(realpathSync(join(worktreePath, ".gsd")), realpathSync(expectedExternalState), "worktree .gsd symlink resolves to main repo external state dir");
 
     console.log("\n=== ensureGsdSymlink heals stale worktree symlinks ===");
     const staleState = join(stateDir, "projects", "stale-worktree-state");
@@ -47,7 +47,7 @@ async function main(): Promise<void> {
     symlinkSync(staleState, join(worktreePath, ".gsd"), "junction");
     const healedState = ensureGsdSymlink(worktreePath);
     assertEq(healedState, expectedExternalState, "stale worktree symlink is repaired to canonical external state dir");
-    assertEq(realpathSync(join(worktreePath, ".gsd")), expectedExternalState, "healed worktree symlink resolves to canonical external state dir");
+    assertEq(realpathSync(join(worktreePath, ".gsd")), realpathSync(expectedExternalState), "healed worktree symlink resolves to canonical external state dir");
 
     console.log("\n=== ensureGsdSymlink preserves worktree .gsd directories ===");
     rmSync(join(worktreePath, ".gsd"), { recursive: true, force: true });

--- a/src/tests/file-watcher.test.ts
+++ b/src/tests/file-watcher.test.ts
@@ -54,10 +54,11 @@ test("settings.json change emits settings-changed event", async () => {
 	const bus = createMockEventBus();
 
 	await startFileWatcher(dir, bus);
+	await delay(200);
 
 	writeFileSync(join(dir, "settings.json"), JSON.stringify({ updated: true }));
 	// Wait for debounce (300ms) + filesystem propagation
-	await delay(600);
+	await delay(800);
 
 	const matched = bus.events.filter((e) => e.channel === "settings-changed");
 	assert.ok(matched.length > 0, "should emit settings-changed event");
@@ -68,9 +69,10 @@ test("auth.json change emits auth-changed event", async () => {
 	const bus = createMockEventBus();
 
 	await startFileWatcher(dir, bus);
+	await delay(200);
 
 	writeFileSync(join(dir, "auth.json"), JSON.stringify({ token: "new" }));
-	await delay(600);
+	await delay(800);
 
 	const matched = bus.events.filter((e) => e.channel === "auth-changed");
 	assert.ok(matched.length > 0, "should emit auth-changed event");
@@ -81,9 +83,10 @@ test("models.json change emits models-changed event", async () => {
 	const bus = createMockEventBus();
 
 	await startFileWatcher(dir, bus);
+	await delay(200);
 
 	writeFileSync(join(dir, "models.json"), JSON.stringify({ model: "new" }));
-	await delay(600);
+	await delay(800);
 
 	const matched = bus.events.filter((e) => e.channel === "models-changed");
 	assert.ok(matched.length > 0, "should emit models-changed event");
@@ -133,7 +136,7 @@ test("debouncing coalesces rapid changes into one event", async () => {
 	for (let i = 0; i < 5; i++) {
 		writeFileSync(join(dir, "settings.json"), JSON.stringify({ i }));
 	}
-	await delay(600);
+	await delay(800);
 
 	const matched = bus.events.filter((e) => e.channel === "settings-changed");
 	assert.strictEqual(


### PR DESCRIPTION
## Problem

On older Linux (RHEL 8, older glibc), the native Rust addon fails to load. `wrapTextWithAnsi` and `visibleWidth` in pi-tui called the native functions directly with no fallback, causing an uncaught crash during TUI rendering.

## Fix

Both functions now catch native throws and fall back to JS:
- `wrapTextWithAnsi`: simple word-wrap by spaces
- `visibleWidth`: strip ANSI codes and return string length

Fixes #1418