### PR TITLE
Respect CARGO_TARGET_DIR in native build script

### DIFF
--- a/native/scripts/build.js
+++ b/native/scripts/build.js
@@ -44,7 +44,11 @@ try {
 }
 
 // Locate the built library
-const targetDir = path.join(nativeRoot, "target", profile);
+const cargoTargetRoot = process.env.CARGO_TARGET_DIR
+  ? path.resolve(process.env.CARGO_TARGET_DIR)
+  : path.join(nativeRoot, "target");
+
+const targetDir = path.join(cargoTargetRoot, profile);
 const platformTag = `${process.platform}-${process.arch}`;
 
 const libraryNames = {


### PR DESCRIPTION
This updates `native/scripts/build.js` to respect `CARGO_TARGET_DIR` when locating the compiled native library.

Without this change, a build can succeed at the Rust/Cargo level but the JS helper script still fails when copying the built artifact into `native/addon/`, because it always assumes Cargo output lives under `native/target/<profile>`.

With this change, the script:
- uses `CARGO_TARGET_DIR` when it is set
- falls back to the existing `native/target/<profile>` behavior otherwise

This is useful for environments where Cargo target output is redirected, such as systems with small home directories or custom build-cache locations.