### PR TITLE
refactor: consolidate retry/sleep/error utilities from providers

### DIFF
--- a/packages/pi-ai/src/providers/anthropic.ts
+++ b/packages/pi-ai/src/providers/anthropic.ts
@@ -30,6 +30,7 @@ import type {
 } from "../types.js";
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
 import { parseStreamingJson } from "../utils/json-parse.js";
+import { extractRetryDelayMs, isTransientNetworkError } from "../utils/retry-utils.js";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
 
 import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "./github-copilot-headers.js";
@@ -201,65 +202,6 @@ function mergeHeaders(...headerSources: (Record<string, string> | undefined)[]):
 		}
 	}
 	return merged;
-}
-
-/**
- * Detect transient network errors that are likely to succeed on retry.
- * Covers WebSocket disconnects (Tailscale, VPN), TCP resets, and DNS failures.
- */
-function isTransientNetworkError(error: unknown): boolean {
-  if (!(error instanceof Error)) return false;
-  const msg = error.message.toLowerCase();
-  const code = (error as NodeJS.ErrnoException).code;
-  return (
-    code === 'ECONNRESET' ||
-    code === 'EPIPE' ||
-    code === 'ETIMEDOUT' ||
-    code === 'ENOTFOUND' ||
-    code === 'EAI_AGAIN' ||
-    msg.includes('connector_closed') ||
-    msg.includes('socket hang up') ||
-    msg.includes('network') ||
-    msg.includes('connection') && msg.includes('closed') ||
-    msg.includes('fetch failed')
-  );
-}
-
-/**
- * Extract retry delay from Anthropic error response headers (in milliseconds).
- * Checks: retry-after (seconds or RFC date), x-ratelimit-reset-requests, x-ratelimit-reset-tokens.
- * Returns undefined if no valid delay is found or if the delay is in the past.
- */
-export function extractRetryAfterMs(headers: Headers | { get(name: string): string | null }, errorText = ""): number | undefined {
-	const normalizeDelay = (ms: number): number | undefined => (ms > 0 ? Math.ceil(ms + 1000) : undefined);
-
-	const retryAfter = headers.get("retry-after");
-	if (retryAfter) {
-		const seconds = Number(retryAfter);
-		if (Number.isFinite(seconds)) {
-			const delay = normalizeDelay(seconds * 1000);
-			if (delay !== undefined) return delay;
-		}
-		const asDate = new Date(retryAfter).getTime();
-		if (!Number.isNaN(asDate)) {
-			const delay = normalizeDelay(asDate - Date.now());
-			if (delay !== undefined) return delay;
-		}
-	}
-
-	// x-ratelimit-reset-requests / x-ratelimit-reset-tokens are Unix timestamps (seconds)
-	for (const header of ["x-ratelimit-reset-requests", "x-ratelimit-reset-tokens"]) {
-		const value = headers.get(header);
-		if (value) {
-			const resetSeconds = Number(value);
-			if (Number.isFinite(resetSeconds)) {
-				const delay = normalizeDelay(resetSeconds * 1000 - Date.now());
-				if (delay !== undefined) return delay;
-			}
-		}
-	}
-
-	return undefined;
 }
 
 export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOptions> = (
@@ -514,7 +456,7 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
 			}
 			const AnthropicSdk = _AnthropicClass;
 			if (AnthropicSdk && error instanceof AnthropicSdk.APIError && error.headers) {
-				const retryAfterMs = extractRetryAfterMs(error.headers, error.message);
+				const retryAfterMs = extractRetryDelayMs(error.headers, error.message);
 				if (retryAfterMs !== undefined) {
 					output.retryAfterMs = retryAfterMs;
 				}

--- a/packages/pi-ai/src/providers/google-gemini-cli.ts
+++ b/packages/pi-ai/src/providers/google-gemini-cli.ts
@@ -21,6 +21,7 @@ import type {
 	ToolCall,
 } from "../types.js";
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
+import { extractRetryDelayMs, isRetryableError, sleep } from "../utils/retry-utils.js";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
 import {
 	convertMessages,
@@ -103,106 +104,6 @@ const MAX_EMPTY_STREAM_RETRIES = 2;
 const EMPTY_STREAM_BASE_DELAY_MS = 500;
 const CLAUDE_THINKING_BETA_HEADER = "interleaved-thinking-2025-05-14";
 
-/**
- * Extract retry delay from Gemini error response (in milliseconds).
- * Checks headers first (Retry-After, x-ratelimit-reset, x-ratelimit-reset-after),
- * then parses body patterns like:
- * - "Your quota will reset after 39s"
- * - "Your quota will reset after 18h31m10s"
- * - "Please retry in Xs" or "Please retry in Xms"
- * - "retryDelay": "34.074824224s" (JSON field)
- */
-export function extractRetryDelay(errorText: string, response?: Response | Headers): number | undefined {
-	const normalizeDelay = (ms: number): number | undefined => (ms > 0 ? Math.ceil(ms + 1000) : undefined);
-
-	const headers = response instanceof Headers ? response : response?.headers;
-	if (headers) {
-		const retryAfter = headers.get("retry-after");
-		if (retryAfter) {
-			const retryAfterSeconds = Number(retryAfter);
-			if (Number.isFinite(retryAfterSeconds)) {
-				const delay = normalizeDelay(retryAfterSeconds * 1000);
-				if (delay !== undefined) {
-					return delay;
-				}
-			}
-			const retryAfterDate = new Date(retryAfter);
-			const retryAfterMs = retryAfterDate.getTime();
-			if (!Number.isNaN(retryAfterMs)) {
-				const delay = normalizeDelay(retryAfterMs - Date.now());
-				if (delay !== undefined) {
-					return delay;
-				}
-			}
-		}
-
-		const rateLimitReset = headers.get("x-ratelimit-reset");
-		if (rateLimitReset) {
-			const resetSeconds = Number.parseInt(rateLimitReset, 10);
-			if (!Number.isNaN(resetSeconds)) {
-				const delay = normalizeDelay(resetSeconds * 1000 - Date.now());
-				if (delay !== undefined) {
-					return delay;
-				}
-			}
-		}
-
-		const rateLimitResetAfter = headers.get("x-ratelimit-reset-after");
-		if (rateLimitResetAfter) {
-			const resetAfterSeconds = Number(rateLimitResetAfter);
-			if (Number.isFinite(resetAfterSeconds)) {
-				const delay = normalizeDelay(resetAfterSeconds * 1000);
-				if (delay !== undefined) {
-					return delay;
-				}
-			}
-		}
-	}
-
-	// Pattern 1: "Your quota will reset after ..." (formats: "18h31m10s", "10m15s", "6s", "39s")
-	const durationMatch = errorText.match(/reset after (?:(\d+)h)?(?:(\d+)m)?(\d+(?:\.\d+)?)s/i);
-	if (durationMatch) {
-		const hours = durationMatch[1] ? parseInt(durationMatch[1], 10) : 0;
-		const minutes = durationMatch[2] ? parseInt(durationMatch[2], 10) : 0;
-		const seconds = parseFloat(durationMatch[3]);
-		if (!Number.isNaN(seconds)) {
-			const totalMs = ((hours * 60 + minutes) * 60 + seconds) * 1000;
-			const delay = normalizeDelay(totalMs);
-			if (delay !== undefined) {
-				return delay;
-			}
-		}
-	}
-
-	// Pattern 2: "Please retry in X[ms|s]"
-	const retryInMatch = errorText.match(/Please retry in ([0-9.]+)(ms|s)/i);
-	if (retryInMatch?.[1]) {
-		const value = parseFloat(retryInMatch[1]);
-		if (!Number.isNaN(value) && value > 0) {
-			const ms = retryInMatch[2].toLowerCase() === "ms" ? value : value * 1000;
-			const delay = normalizeDelay(ms);
-			if (delay !== undefined) {
-				return delay;
-			}
-		}
-	}
-
-	// Pattern 3: "retryDelay": "34.074824224s" (JSON field in error details)
-	const retryDelayMatch = errorText.match(/"retryDelay":\s*"([0-9.]+)(ms|s)"/i);
-	if (retryDelayMatch?.[1]) {
-		const value = parseFloat(retryDelayMatch[1]);
-		if (!Number.isNaN(value) && value > 0) {
-			const ms = retryDelayMatch[2].toLowerCase() === "ms" ? value : value * 1000;
-			const delay = normalizeDelay(ms);
-			if (delay !== undefined) {
-				return delay;
-			}
-		}
-	}
-
-	return undefined;
-}
-
 function needsClaudeThinkingBetaHeader(model: Model<"google-gemini-cli">): boolean {
 	return model.provider === "google-antigravity" && model.id.startsWith("claude-") && model.reasoning;
 }
@@ -220,16 +121,6 @@ function isGemini3Model(modelId: string): boolean {
 }
 
 /**
- * Check if an error is retryable (rate limit, server error, network error, etc.)
- */
-function isRetryableError(status: number, errorText: string): boolean {
-	if (status === 429 || status === 500 || status === 502 || status === 503 || status === 504) {
-		return true;
-	}
-	return /resource.?exhausted|rate.?limit|overloaded|service.?unavailable|other.?side.?closed/i.test(errorText);
-}
-
-/**
  * Extract a clean, user-friendly error message from Google API error response.
  * Parses JSON error responses and returns just the message field.
  */
@@ -243,23 +134,6 @@ function extractErrorMessage(errorText: string): string {
 		// Not JSON, return as-is
 	}
 	return errorText;
-}
-
-/**
- * Sleep for a given number of milliseconds, respecting abort signal.
- */
-function sleep(ms: number, signal?: AbortSignal): Promise<void> {
-	return new Promise((resolve, reject) => {
-		if (signal?.aborted) {
-			reject(new Error("Request was aborted"));
-			return;
-		}
-		const timeout = setTimeout(resolve, ms);
-		signal?.addEventListener("abort", () => {
-			clearTimeout(timeout);
-			reject(new Error("Request was aborted"));
-		});
-	});
 }
 
 interface CloudCodeAssistRequest {
@@ -429,7 +303,7 @@ export const streamGoogleGeminiCli: StreamFunction<"google-gemini-cli", GoogleGe
 						}
 
 						// Use server-provided delay or exponential backoff
-						const serverDelay = extractRetryDelay(errorText, response);
+						const serverDelay = extractRetryDelayMs(response.headers, errorText);
 						const delayMs = serverDelay ?? BASE_DELAY_MS * 2 ** attempt;
 
 						// Check if server delay exceeds max allowed (default: 60s)

--- a/packages/pi-ai/src/providers/openai-codex-responses.ts
+++ b/packages/pi-ai/src/providers/openai-codex-responses.ts
@@ -27,6 +27,7 @@ import type {
 	StreamOptions,
 } from "../types.js";
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
+import { isRetryableError, sleep } from "../utils/retry-utils.js";
 import { convertResponsesMessages, convertResponsesTools, processResponsesStream } from "./openai-responses-shared.js";
 import { buildBaseOptions, clampReasoning } from "./simple-options.js";
 
@@ -76,31 +77,6 @@ interface RequestBody {
 	include?: string[];
 	prompt_cache_key?: string;
 	[key: string]: unknown;
-}
-
-// ============================================================================
-// Retry Helpers
-// ============================================================================
-
-function isRetryableError(status: number, errorText: string): boolean {
-	if (status === 429 || status === 500 || status === 502 || status === 503 || status === 504) {
-		return true;
-	}
-	return /rate.?limit|overloaded|service.?unavailable|upstream.?connect|connection.?refused/i.test(errorText);
-}
-
-function sleep(ms: number, signal?: AbortSignal): Promise<void> {
-	return new Promise((resolve, reject) => {
-		if (signal?.aborted) {
-			reject(new Error("Request was aborted"));
-			return;
-		}
-		const timeout = setTimeout(resolve, ms);
-		signal?.addEventListener("abort", () => {
-			clearTimeout(timeout);
-			reject(new Error("Request was aborted"));
-		});
-	});
 }
 
 // ============================================================================

--- a/packages/pi-ai/src/utils/retry-utils.ts
+++ b/packages/pi-ai/src/utils/retry-utils.ts
@@ -1,0 +1,177 @@
+/**
+ * Shared retry, sleep, and error detection utilities for AI providers.
+ *
+ * Consolidates duplicated helpers from anthropic.ts, google-gemini-cli.ts,
+ * and openai-codex-responses.ts into a single module.
+ */
+
+/**
+ * Sleep for a given number of milliseconds, respecting abort signal.
+ * Rejects immediately if the signal is already aborted, and cleans up
+ * the timer if the signal fires while sleeping.
+ */
+export function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+	return new Promise((resolve, reject) => {
+		if (signal?.aborted) {
+			reject(new Error("Request was aborted"));
+			return;
+		}
+		const timeout = setTimeout(resolve, ms);
+		signal?.addEventListener("abort", () => {
+			clearTimeout(timeout);
+			reject(new Error("Request was aborted"));
+		});
+	});
+}
+
+/**
+ * Check if an HTTP error is retryable (rate limit, server error, or known
+ * transient error patterns in the response text).
+ *
+ * Covers patterns from Google Gemini CLI (resource exhausted, other side closed)
+ * and OpenAI Codex (upstream connect, connection refused).
+ */
+export function isRetryableError(status: number, errorText = ""): boolean {
+	if (status === 429 || status === 500 || status === 502 || status === 503 || status === 504) {
+		return true;
+	}
+	return /resource.?exhausted|rate.?limit|overloaded|service.?unavailable|other.?side.?closed|upstream.?connect|connection.?refused/i.test(
+		errorText,
+	);
+}
+
+/**
+ * Detect transient network errors that are likely to succeed on retry.
+ * Covers WebSocket disconnects (Tailscale, VPN), TCP resets, and DNS failures.
+ */
+export function isTransientNetworkError(error: unknown): boolean {
+	if (!(error instanceof Error)) return false;
+	const msg = error.message.toLowerCase();
+	const code = (error as NodeJS.ErrnoException).code;
+	return (
+		code === "ECONNRESET" ||
+		code === "EPIPE" ||
+		code === "ETIMEDOUT" ||
+		code === "ENOTFOUND" ||
+		code === "EAI_AGAIN" ||
+		msg.includes("connector_closed") ||
+		msg.includes("socket hang up") ||
+		msg.includes("network") ||
+		(msg.includes("connection") && msg.includes("closed")) ||
+		msg.includes("fetch failed")
+	);
+}
+
+/**
+ * Extract retry delay from HTTP error response headers and/or body text (in milliseconds).
+ *
+ * Checks headers (in order):
+ * - `retry-after` (seconds or RFC 7231 date)
+ * - `x-ratelimit-reset` (Unix timestamp in seconds)
+ * - `x-ratelimit-reset-after` (relative seconds)
+ * - `x-ratelimit-reset-requests` (Unix timestamp in seconds)
+ * - `x-ratelimit-reset-tokens` (Unix timestamp in seconds)
+ *
+ * Then parses body text patterns:
+ * - "Your quota will reset after 18h31m10s"
+ * - "Please retry in Xs" or "Please retry in Xms"
+ * - "retryDelay": "34.074824224s" (JSON field in error details)
+ *
+ * Returns `undefined` if no valid delay is found or if the computed delay is not positive.
+ * Adds a 1-second buffer to all returned delays.
+ */
+export function extractRetryDelayMs(
+	headers?: Headers | { get(name: string): string | null } | null,
+	errorText = "",
+): number | undefined {
+	const normalizeDelay = (ms: number): number | undefined => (ms > 0 ? Math.ceil(ms + 1000) : undefined);
+
+	if (headers) {
+		// retry-after: seconds or RFC 7231 date
+		const retryAfter = headers.get("retry-after");
+		if (retryAfter) {
+			const retryAfterSeconds = Number(retryAfter);
+			if (Number.isFinite(retryAfterSeconds)) {
+				const delay = normalizeDelay(retryAfterSeconds * 1000);
+				if (delay !== undefined) return delay;
+			}
+			const retryAfterDate = new Date(retryAfter);
+			const retryAfterMs = retryAfterDate.getTime();
+			if (!Number.isNaN(retryAfterMs)) {
+				const delay = normalizeDelay(retryAfterMs - Date.now());
+				if (delay !== undefined) return delay;
+			}
+		}
+
+		// x-ratelimit-reset: Unix timestamp in seconds
+		const rateLimitReset = headers.get("x-ratelimit-reset");
+		if (rateLimitReset) {
+			const resetSeconds = Number.parseInt(rateLimitReset, 10);
+			if (!Number.isNaN(resetSeconds)) {
+				const delay = normalizeDelay(resetSeconds * 1000 - Date.now());
+				if (delay !== undefined) return delay;
+			}
+		}
+
+		// x-ratelimit-reset-after: relative seconds
+		const rateLimitResetAfter = headers.get("x-ratelimit-reset-after");
+		if (rateLimitResetAfter) {
+			const resetAfterSeconds = Number(rateLimitResetAfter);
+			if (Number.isFinite(resetAfterSeconds)) {
+				const delay = normalizeDelay(resetAfterSeconds * 1000);
+				if (delay !== undefined) return delay;
+			}
+		}
+
+		// x-ratelimit-reset-requests / x-ratelimit-reset-tokens: Unix timestamps (Anthropic)
+		for (const header of ["x-ratelimit-reset-requests", "x-ratelimit-reset-tokens"]) {
+			const value = headers.get(header);
+			if (value) {
+				const resetSeconds = Number(value);
+				if (Number.isFinite(resetSeconds)) {
+					const delay = normalizeDelay(resetSeconds * 1000 - Date.now());
+					if (delay !== undefined) return delay;
+				}
+			}
+		}
+	}
+
+	// Body text patterns (Google Gemini specific, but useful generally)
+
+	// Pattern 1: "Your quota will reset after ..." (formats: "18h31m10s", "10m15s", "6s", "39s")
+	const durationMatch = errorText.match(/reset after (?:(\d+)h)?(?:(\d+)m)?(\d+(?:\.\d+)?)s/i);
+	if (durationMatch) {
+		const hours = durationMatch[1] ? parseInt(durationMatch[1], 10) : 0;
+		const minutes = durationMatch[2] ? parseInt(durationMatch[2], 10) : 0;
+		const seconds = parseFloat(durationMatch[3]);
+		if (!Number.isNaN(seconds)) {
+			const totalMs = ((hours * 60 + minutes) * 60 + seconds) * 1000;
+			const delay = normalizeDelay(totalMs);
+			if (delay !== undefined) return delay;
+		}
+	}
+
+	// Pattern 2: "Please retry in X[ms|s]"
+	const retryInMatch = errorText.match(/Please retry in ([0-9.]+)(ms|s)/i);
+	if (retryInMatch?.[1]) {
+		const value = parseFloat(retryInMatch[1]);
+		if (!Number.isNaN(value) && value > 0) {
+			const ms = retryInMatch[2].toLowerCase() === "ms" ? value : value * 1000;
+			const delay = normalizeDelay(ms);
+			if (delay !== undefined) return delay;
+		}
+	}
+
+	// Pattern 3: "retryDelay": "34.074824224s" (JSON field in error details)
+	const retryDelayMatch = errorText.match(/"retryDelay":\s*"([0-9.]+)(ms|s)"/i);
+	if (retryDelayMatch?.[1]) {
+		const value = parseFloat(retryDelayMatch[1]);
+		if (!Number.isNaN(value) && value > 0) {
+			const ms = retryDelayMatch[2].toLowerCase() === "ms" ? value : value * 1000;
+			const delay = normalizeDelay(ms);
+			if (delay !== undefined) return delay;
+		}
+	}
+
+	return undefined;
+}


### PR DESCRIPTION
## Summary
- Extracts duplicated `sleep()`, `isRetryableError()`, `isTransientNetworkError()`, and retry-delay extraction logic from 3 provider files into a single shared module at `packages/pi-ai/src/utils/retry-utils.ts`.
- The unified `extractRetryDelayMs()` handles all header formats from Google (x-ratelimit-reset, x-ratelimit-reset-after) and Anthropic (x-ratelimit-reset-requests, x-ratelimit-reset-tokens), plus body text patterns from the Gemini provider.
- The unified `isRetryableError()` merges regex patterns from both Google (resource exhausted, other side closed) and OpenAI (upstream connect, connection refused) providers.
- Removes ~213 lines of duplication across `anthropic.ts`, `google-gemini-cli.ts`, and `openai-codex-responses.ts`.

## Test plan
- [x] `npx tsc --noEmit` passes with no errors
- [ ] Verify Anthropic provider retry behavior is preserved (transient network error detection, retry-after header parsing)
- [ ] Verify Google Gemini CLI retry behavior is preserved (rate limit detection, body text retry delay parsing)
- [ ] Verify OpenAI Codex retry behavior is preserved (retryable error detection, abort-aware sleep)