### PR TITLE
refactor: extract error message and truncation helpers in interactive mode

### DIFF
--- a/packages/pi-coding-agent/src/modes/interactive/components/tool-execution.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/components/tool-execution.ts
@@ -55,6 +55,27 @@ function normalizeDisplayText(text: string): string {
 	return text.replace(/\r/g, "");
 }
 
+/**
+ * Build a themed `[Truncated: ...]` warning string from custom warnings and an optional
+ * byte-limit truncation flag. Used by ls, find, and grep tool renderers.
+ *
+ * `prefixWarnings` appear before the byte-limit message, `suffixWarnings` after it.
+ * Returns empty string if there are no warnings.
+ */
+function formatTruncationWarning(
+	prefixWarnings: string[],
+	truncation: { truncated?: boolean; maxBytes?: number } | undefined,
+	suffixWarnings: string[] = [],
+): string {
+	const warnings = [...prefixWarnings];
+	if (truncation?.truncated) {
+		warnings.push(`${formatSize(truncation.maxBytes ?? DEFAULT_MAX_BYTES)} limit`);
+	}
+	warnings.push(...suffixWarnings);
+	if (warnings.length === 0) return "";
+	return theme.fg("warning", `[Truncated: ${warnings.join(", ")}]`);
+}
+
 /** Safely coerce value to string for display. Returns null if invalid type. */
 function str(value: unknown): string | null {
 	if (typeof value === "string") return value;
@@ -799,16 +820,12 @@ export class ToolExecutionComponent extends Container {
 				}
 
 				const entryLimit = this.result.details?.entryLimitReached;
-				const truncation = this.result.details?.truncation;
-				if (entryLimit || truncation?.truncated) {
-					const warnings: string[] = [];
-					if (entryLimit) {
-						warnings.push(`${entryLimit} entries limit`);
-					}
-					if (truncation?.truncated) {
-						warnings.push(`${formatSize(truncation.maxBytes ?? DEFAULT_MAX_BYTES)} limit`);
-					}
-					text += `\n${theme.fg("warning", `[Truncated: ${warnings.join(", ")}]`)}`;
+				const truncationWarning = formatTruncationWarning(
+					entryLimit ? [`${entryLimit} entries limit`] : [],
+					this.result.details?.truncation,
+				);
+				if (truncationWarning) {
+					text += `\n${truncationWarning}`;
 				}
 			}
 		} else if (this.toolName === "find") {
@@ -841,16 +858,12 @@ export class ToolExecutionComponent extends Container {
 				}
 
 				const resultLimit = this.result.details?.resultLimitReached;
-				const truncation = this.result.details?.truncation;
-				if (resultLimit || truncation?.truncated) {
-					const warnings: string[] = [];
-					if (resultLimit) {
-						warnings.push(`${resultLimit} results limit`);
-					}
-					if (truncation?.truncated) {
-						warnings.push(`${formatSize(truncation.maxBytes ?? DEFAULT_MAX_BYTES)} limit`);
-					}
-					text += `\n${theme.fg("warning", `[Truncated: ${warnings.join(", ")}]`)}`;
+				const truncationWarning = formatTruncationWarning(
+					resultLimit ? [`${resultLimit} results limit`] : [],
+					this.result.details?.truncation,
+				);
+				if (truncationWarning) {
+					text += `\n${truncationWarning}`;
 				}
 			}
 		} else if (this.toolName === "grep") {
@@ -886,21 +899,21 @@ export class ToolExecutionComponent extends Container {
 					}
 				}
 
-				const matchLimit = this.result.details?.matchLimitReached;
-				const truncation = this.result.details?.truncation;
-				const linesTruncated = this.result.details?.linesTruncated;
-				if (matchLimit || truncation?.truncated || linesTruncated) {
-					const warnings: string[] = [];
-					if (matchLimit) {
-						warnings.push(`${matchLimit} matches limit`);
-					}
-					if (truncation?.truncated) {
-						warnings.push(`${formatSize(truncation.maxBytes ?? DEFAULT_MAX_BYTES)} limit`);
-					}
-					if (linesTruncated) {
-						warnings.push("some lines truncated");
-					}
-					text += `\n${theme.fg("warning", `[Truncated: ${warnings.join(", ")}]`)}`;
+				const customWarnings: string[] = [];
+				if (this.result.details?.matchLimitReached) {
+					customWarnings.push(`${this.result.details.matchLimitReached} matches limit`);
+				}
+				const suffixWarnings: string[] = [];
+				if (this.result.details?.linesTruncated) {
+					suffixWarnings.push("some lines truncated");
+				}
+				const truncationWarning = formatTruncationWarning(
+					customWarnings,
+					this.result.details?.truncation,
+					suffixWarnings,
+				);
+				if (truncationWarning) {
+					text += `\n${truncationWarning}`;
 				}
 			}
 		} else if (this.toolName === "web_search") {

--- a/packages/pi-coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/interactive-mode.ts
@@ -108,6 +108,11 @@ import {
 	theme,
 } from "./theme/theme.js";
 
+/** Extract error message from an unknown caught value */
+function getErrorMessage(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
+}
+
 /** Interface for components that can be expanded/collapsed */
 interface Expandable {
 	setExpanded(expanded: boolean): void;
@@ -1259,7 +1264,7 @@ export class InteractiveMode {
 				if (matchesKey(data, shortcutStr as KeyId)) {
 					// Run handler async, don't block input
 					Promise.resolve(shortcut.handler(createContext())).catch((err) => {
-						this.showError(`Shortcut handler error: ${err instanceof Error ? err.message : String(err)}`);
+						this.showError(`Shortcut handler error: ${getErrorMessage(err)}`);
 					});
 					return true;
 				}
@@ -2983,7 +2988,7 @@ export class InteractiveMode {
 				this.showStatus(`Switched to ${result.model.name || result.model.id}${thinkingStr}`);
 			}
 		} catch (error) {
-			this.showError(error instanceof Error ? error.message : String(error));
+			this.showError(getErrorMessage(error));
 		}
 	}
 
@@ -3219,9 +3224,7 @@ export class InteractiveMode {
 			this.compactionQueuedMessages = queuedMessages;
 			this.updatePendingMessagesDisplay();
 			this.showError(
-				`Failed to send queued message${queuedMessages.length > 1 ? "s" : ""}: ${
-					error instanceof Error ? error.message : String(error)
-				}`,
+				`Failed to send queued message${queuedMessages.length > 1 ? "s" : ""}: ${getErrorMessage(error)}`,
 			);
 		};
 
@@ -3466,7 +3469,7 @@ export class InteractiveMode {
 				this.showStatus(`Model: ${model.id}`);
 				this.checkDaxnutsEasterEgg(model);
 			} catch (error) {
-				this.showError(error instanceof Error ? error.message : String(error));
+				this.showError(getErrorMessage(error));
 			}
 			return;
 		}
@@ -3539,7 +3542,7 @@ export class InteractiveMode {
 						this.checkDaxnutsEasterEgg(model);
 					} catch (error) {
 						done();
-						this.showError(error instanceof Error ? error.message : String(error));
+						this.showError(getErrorMessage(error));
 					}
 				},
 				() => {
@@ -3809,7 +3812,7 @@ export class InteractiveMode {
 						}
 						this.showStatus("Navigated to selected point");
 					} catch (error) {
-						this.showError(error instanceof Error ? error.message : String(error));
+						this.showError(getErrorMessage(error));
 					} finally {
 						if (summaryLoader) {
 							summaryLoader.stop();
@@ -3918,7 +3921,7 @@ export class InteractiveMode {
 							this.showStatus(`Discovered ${result?.models.length ?? 0} models from ${provider}`);
 						}
 					} catch (error) {
-						this.showError(error instanceof Error ? error.message : String(error));
+						this.showError(getErrorMessage(error));
 					}
 					done();
 					this.ui.requestRender();
@@ -3981,7 +3984,7 @@ export class InteractiveMode {
 
 							this.showStatus(`Logged out of ${providerName}`);
 						} catch (error: unknown) {
-							this.showError(`Logout failed: ${error instanceof Error ? error.message : String(error)}`);
+							this.showError(`Logout failed: ${getErrorMessage(error)}`);
 						}
 					}
 					};
@@ -4109,7 +4112,7 @@ export class InteractiveMode {
 				manualCodeReject = undefined;
 				manualCodeResolve = undefined;
 			}
-			const errorMsg = error instanceof Error ? error.message : String(error);
+			const errorMsg = getErrorMessage(error);
 			if (errorMsg !== "Login cancelled" && !errorMsg.includes("Superseded") && !errorMsg.includes("disposed")) {
 				this.showError(`Failed to login to ${providerName}: ${errorMsg}`);
 			}
@@ -4187,7 +4190,7 @@ export class InteractiveMode {
 			this.showStatus("Reloaded extensions, skills, prompts, themes");
 		} catch (error) {
 			dismissLoader(previousEditor as Component);
-			this.showError(`Reload failed: ${error instanceof Error ? error.message : String(error)}`);
+			this.showError(`Reload failed: ${getErrorMessage(error)}`);
 		}
 	}
 
@@ -4308,7 +4311,7 @@ export class InteractiveMode {
 			copyToClipboard(text);
 			this.showStatus("Copied last agent message to clipboard");
 		} catch (error) {
-			this.showError(error instanceof Error ? error.message : String(error));
+			this.showError(getErrorMessage(error));
 		}
 	}
 
@@ -4749,7 +4752,7 @@ export class InteractiveMode {
 
 			this.footer.invalidate();
 		} catch (error) {
-			const message = error instanceof Error ? error.message : String(error);
+			const message = getErrorMessage(error);
 			if (message === "Compaction cancelled" || (error instanceof Error && error.name === "AbortError")) {
 				this.showError("Compaction cancelled");
 			} else {


### PR DESCRIPTION
## Summary

- Added `getErrorMessage()` helper in `interactive-mode.ts` to replace 11 repetitive `error instanceof Error ? error.message : String(error)` patterns with a single function call
- Added `formatTruncationWarning()` helper in `tool-execution.ts` to consolidate the truncation warning rendering logic shared by `ls`, `find`, and `grep` tool renderers (3 call sites)
- Pure cosmetic refactor — output is character-for-character identical

## Test plan

- [ ] `npx tsc --noEmit` passes (verified)
- [ ] Verify tool truncation warnings render identically for ls, find, grep results
- [ ] Verify error messages in catch blocks display unchanged