### PR TITLE
refactor: extract shared abort signal handler from tool implementations

### DIFF
--- a/packages/pi-coding-agent/src/core/tools/abort-utils.ts
+++ b/packages/pi-coding-agent/src/core/tools/abort-utils.ts
@@ -1,0 +1,93 @@
+/**
+ * Shared abort signal handling for tool implementations.
+ *
+ * Most tools wrap their execute body in a `new Promise` with identical abort
+ * boilerplate: early-abort check, addEventListener, an `aborted` flag for
+ * mid-flight checks, cleanup in both success/error paths, and a guard that
+ * swallows errors after abort.  `withAbortSignal` extracts that pattern into
+ * a single utility so each tool only contains its domain logic.
+ */
+
+/**
+ * Sentinel thrown (and caught internally) when an operation is aborted
+ * mid-flight via `checkAborted()`.  Never leaks to callers — the outer
+ * promise is rejected with the canonical "Operation aborted" error instead.
+ */
+class AbortedSentinel extends Error {
+	constructor() {
+		super("aborted-sentinel");
+	}
+}
+
+/**
+ * Run `fn` inside an abort-aware Promise wrapper.
+ *
+ * @param signal  - The optional `AbortSignal` supplied by the framework.
+ * @param fn      - The async work to perform.  Receives a `checkAborted`
+ *                  helper that throws if the signal has fired — call it at
+ *                  natural yield points (after awaits) to bail out early.
+ * @returns A promise that resolves with the value returned by `fn`, or
+ *          rejects with `Error("Operation aborted")` if the signal fires.
+ *
+ * Behavior contract (identical to the hand-rolled version in each tool):
+ * 1. If `signal` is already aborted on entry, rejects immediately.
+ * 2. An `"abort"` listener is registered (once) to reject on late aborts.
+ * 3. `checkAborted()` throws an internal sentinel when `aborted` is true,
+ *    causing `fn` to unwind without producing a result.
+ * 4. The listener is removed in a `finally` block (success *or* failure).
+ * 5. If `fn` throws after an abort, the error is swallowed — the abort
+ *    rejection has already settled the promise.
+ */
+export function withAbortSignal<T>(
+	signal: AbortSignal | undefined,
+	fn: (checkAborted: () => void) => Promise<T>,
+): Promise<T> {
+	return new Promise<T>((resolve, reject) => {
+		// 1. Early abort check
+		if (signal?.aborted) {
+			reject(new Error("Operation aborted"));
+			return;
+		}
+
+		let aborted = false;
+
+		// 2. Abort listener
+		const onAbort = () => {
+			aborted = true;
+			reject(new Error("Operation aborted"));
+		};
+
+		if (signal) {
+			signal.addEventListener("abort", onAbort, { once: true });
+		}
+
+		// 3. Helper for the caller to check mid-flight
+		const checkAborted = () => {
+			if (aborted) {
+				throw new AbortedSentinel();
+			}
+		};
+
+		// 4. Run the async work
+		(async () => {
+			try {
+				const result = await fn(checkAborted);
+
+				// Don't resolve if aborted in the meantime
+				if (aborted) return;
+
+				resolve(result);
+			} catch (error: unknown) {
+				if (!aborted) {
+					reject(error);
+				}
+				// If aborted, the onAbort handler already rejected — swallow.
+			} finally {
+				// 5. Always clean up the listener
+				if (signal) {
+					signal.removeEventListener("abort", onAbort);
+				}
+			}
+		})();
+	});
+}

--- a/packages/pi-coding-agent/src/core/tools/edit.ts
+++ b/packages/pi-coding-agent/src/core/tools/edit.ts
@@ -12,6 +12,7 @@ import {
 	stripBom,
 } from "./edit-diff.js";
 import { notifyFileChanged } from "../lsp/client.js";
+import { withAbortSignal } from "./abort-utils.js";
 import { resolveToCwd } from "./path-utils.js";
 
 const editSchema = Type.Object({
@@ -69,158 +70,84 @@ export function createEditTool(cwd: string, options?: EditToolOptions): AgentToo
 		) => {
 			const absolutePath = resolveToCwd(path, cwd);
 
-			return new Promise<{
-				content: Array<{ type: "text"; text: string }>;
-				details: EditToolDetails | undefined;
-			}>((resolve, reject) => {
-				// Check if already aborted
-				if (signal?.aborted) {
-					reject(new Error("Operation aborted"));
-					return;
+			return withAbortSignal(signal, async (checkAborted) => {
+				// Check if file exists
+				try {
+					await ops.access(absolutePath);
+				} catch {
+					throw new Error(`File not found: ${path}`);
 				}
 
-				let aborted = false;
+				checkAborted();
 
-				// Set up abort handler
-				const onAbort = () => {
-					aborted = true;
-					reject(new Error("Operation aborted"));
+				// Read the file
+				const buffer = await ops.readFile(absolutePath);
+				const rawContent = buffer.toString("utf-8");
+
+				checkAborted();
+
+				// Strip BOM before matching (LLM won't include invisible BOM in oldText)
+				const { bom, text: content } = stripBom(rawContent);
+
+				const originalEnding = detectLineEnding(content);
+				const normalizedContent = normalizeToLF(content);
+				const normalizedOldText = normalizeToLF(oldText);
+				const normalizedNewText = normalizeToLF(newText);
+
+				// Find the old text using fuzzy matching (tries exact match first, then fuzzy)
+				const matchResult = fuzzyFindText(normalizedContent, normalizedOldText);
+
+				if (!matchResult.found) {
+					throw new Error(
+						`Could not find the exact text in ${path}. The old text must match exactly including all whitespace and newlines.`,
+					);
+				}
+
+				// Count occurrences using fuzzy-normalized content for consistency
+				const fuzzyContent = normalizeForFuzzyMatch(normalizedContent);
+				const fuzzyOldText = normalizeForFuzzyMatch(normalizedOldText);
+				const occurrences = fuzzyContent.split(fuzzyOldText).length - 1;
+
+				if (occurrences > 1) {
+					throw new Error(
+						`Found ${occurrences} occurrences of the text in ${path}. The text must be unique. Please provide more context to make it unique.`,
+					);
+				}
+
+				checkAborted();
+
+				// Perform replacement using the matched text position
+				// When fuzzy matching was used, contentForReplacement is the normalized version
+				const baseContent = matchResult.contentForReplacement;
+				const newContent =
+					baseContent.substring(0, matchResult.index) +
+					normalizedNewText +
+					baseContent.substring(matchResult.index + matchResult.matchLength);
+
+				// Verify the replacement actually changed something
+				if (baseContent === newContent) {
+					throw new Error(
+						`No changes made to ${path}. The replacement produced identical content. This might indicate an issue with special characters or the text not existing as expected.`,
+					);
+				}
+
+				const finalContent = bom + restoreLineEndings(newContent, originalEnding);
+				await ops.writeFile(absolutePath, finalContent);
+
+				try { notifyFileChanged(absolutePath); } catch { /* best-effort */ }
+
+				checkAborted();
+
+				const diffResult = generateDiffString(baseContent, newContent);
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: `Successfully replaced text in ${path}.`,
+						},
+					],
+					details: { diff: diffResult.diff, firstChangedLine: diffResult.firstChangedLine },
 				};
-
-				if (signal) {
-					signal.addEventListener("abort", onAbort, { once: true });
-				}
-
-				// Perform the edit operation
-				(async () => {
-					try {
-						// Check if file exists
-						try {
-							await ops.access(absolutePath);
-						} catch {
-							if (signal) {
-								signal.removeEventListener("abort", onAbort);
-							}
-							reject(new Error(`File not found: ${path}`));
-							return;
-						}
-
-						// Check if aborted before reading
-						if (aborted) {
-							return;
-						}
-
-						// Read the file
-						const buffer = await ops.readFile(absolutePath);
-						const rawContent = buffer.toString("utf-8");
-
-						// Check if aborted after reading
-						if (aborted) {
-							return;
-						}
-
-						// Strip BOM before matching (LLM won't include invisible BOM in oldText)
-						const { bom, text: content } = stripBom(rawContent);
-
-						const originalEnding = detectLineEnding(content);
-						const normalizedContent = normalizeToLF(content);
-						const normalizedOldText = normalizeToLF(oldText);
-						const normalizedNewText = normalizeToLF(newText);
-
-						// Find the old text using fuzzy matching (tries exact match first, then fuzzy)
-						const matchResult = fuzzyFindText(normalizedContent, normalizedOldText);
-
-						if (!matchResult.found) {
-							if (signal) {
-								signal.removeEventListener("abort", onAbort);
-							}
-							reject(
-								new Error(
-									`Could not find the exact text in ${path}. The old text must match exactly including all whitespace and newlines.`,
-								),
-							);
-							return;
-						}
-
-						// Count occurrences using fuzzy-normalized content for consistency
-						const fuzzyContent = normalizeForFuzzyMatch(normalizedContent);
-						const fuzzyOldText = normalizeForFuzzyMatch(normalizedOldText);
-						const occurrences = fuzzyContent.split(fuzzyOldText).length - 1;
-
-						if (occurrences > 1) {
-							if (signal) {
-								signal.removeEventListener("abort", onAbort);
-							}
-							reject(
-								new Error(
-									`Found ${occurrences} occurrences of the text in ${path}. The text must be unique. Please provide more context to make it unique.`,
-								),
-							);
-							return;
-						}
-
-						// Check if aborted before writing
-						if (aborted) {
-							return;
-						}
-
-						// Perform replacement using the matched text position
-						// When fuzzy matching was used, contentForReplacement is the normalized version
-						const baseContent = matchResult.contentForReplacement;
-						const newContent =
-							baseContent.substring(0, matchResult.index) +
-							normalizedNewText +
-							baseContent.substring(matchResult.index + matchResult.matchLength);
-
-						// Verify the replacement actually changed something
-						if (baseContent === newContent) {
-							if (signal) {
-								signal.removeEventListener("abort", onAbort);
-							}
-							reject(
-								new Error(
-									`No changes made to ${path}. The replacement produced identical content. This might indicate an issue with special characters or the text not existing as expected.`,
-								),
-							);
-							return;
-						}
-
-						const finalContent = bom + restoreLineEndings(newContent, originalEnding);
-						await ops.writeFile(absolutePath, finalContent);
-
-						try { notifyFileChanged(absolutePath); } catch { /* best-effort */ }
-
-						// Check if aborted after writing
-						if (aborted) {
-							return;
-						}
-
-						// Clean up abort handler
-						if (signal) {
-							signal.removeEventListener("abort", onAbort);
-						}
-
-						const diffResult = generateDiffString(baseContent, newContent);
-						resolve({
-							content: [
-								{
-									type: "text",
-									text: `Successfully replaced text in ${path}.`,
-								},
-							],
-							details: { diff: diffResult.diff, firstChangedLine: diffResult.firstChangedLine },
-						});
-					} catch (error: any) {
-						// Clean up abort handler
-						if (signal) {
-							signal.removeEventListener("abort", onAbort);
-						}
-
-						if (!aborted) {
-							reject(error);
-						}
-					}
-				})();
 			});
 		},
 	};

--- a/packages/pi-coding-agent/src/core/tools/find.ts
+++ b/packages/pi-coding-agent/src/core/tools/find.ts
@@ -4,6 +4,7 @@ import { type Static, Type } from "@sinclair/typebox";
 import { existsSync } from "fs";
 import path from "path";
 import { FIND_DEFAULT_LIMIT } from "../constants.js";
+import { withAbortSignal } from "./abort-utils.js";
 import { resolveToCwd } from "./path-utils.js";
 import { DEFAULT_MAX_BYTES, formatSize, type TruncationResult, truncateHead } from "./truncate.js";
 
@@ -61,136 +62,113 @@ export function createFindTool(cwd: string, options?: FindToolOptions): AgentToo
 			{ pattern, path: searchDir, limit }: { pattern: string; path?: string; limit?: number },
 			signal?: AbortSignal,
 		) => {
-			return new Promise((resolve, reject) => {
-				if (signal?.aborted) {
-					reject(new Error("Operation aborted"));
-					return;
+			return withAbortSignal(signal, async () => {
+				const searchPath = resolveToCwd(searchDir || ".", cwd);
+				const effectiveLimit = limit ?? DEFAULT_LIMIT;
+				const ops = customOps ?? defaultFindOperations;
+
+				// If custom operations provided with glob, use that
+				if (customOps?.glob) {
+					if (!(await ops.exists(searchPath))) {
+						throw new Error(`Path not found: ${searchPath}`);
+					}
+
+					const results = await ops.glob(pattern, searchPath, {
+						ignore: ["**/node_modules/**", "**/.git/**"],
+						limit: effectiveLimit,
+					});
+
+					if (results.length === 0) {
+						return {
+							content: [{ type: "text" as const, text: "No files found matching pattern" }],
+							details: undefined,
+						};
+					}
+
+					// Relativize paths
+					const relativized = results.map((p) => {
+						if (p.startsWith(searchPath)) {
+							return p.slice(searchPath.length + 1);
+						}
+						return path.relative(searchPath, p);
+					});
+
+					const resultLimitReached = relativized.length >= effectiveLimit;
+					const rawOutput = relativized.join("\n");
+					const truncation = truncateHead(rawOutput, { maxLines: Number.MAX_SAFE_INTEGER });
+
+					let resultOutput = truncation.content;
+					const details: FindToolDetails = {};
+					const notices: string[] = [];
+
+					if (resultLimitReached) {
+						notices.push(`${effectiveLimit} results limit reached`);
+						details.resultLimitReached = effectiveLimit;
+					}
+
+					if (truncation.truncated) {
+						notices.push(`${formatSize(DEFAULT_MAX_BYTES)} limit reached`);
+						details.truncation = truncation;
+					}
+
+					if (notices.length > 0) {
+						resultOutput += `\n\n[${notices.join(". ")}]`;
+					}
+
+					return {
+						content: [{ type: "text" as const, text: resultOutput }],
+						details: Object.keys(details).length > 0 ? details : undefined,
+					};
 				}
 
-				const onAbort = () => reject(new Error("Operation aborted"));
-				signal?.addEventListener("abort", onAbort, { once: true });
+				// Default: use native Rust glob
+				const globResult = await nativeGlob({
+					pattern,
+					path: searchPath,
+					hidden: true,
+					gitignore: true,
+					cache: true,
+					maxResults: effectiveLimit,
+				});
 
-				(async () => {
-					try {
-						const searchPath = resolveToCwd(searchDir || ".", cwd);
-						const effectiveLimit = limit ?? DEFAULT_LIMIT;
-						const ops = customOps ?? defaultFindOperations;
+				if (globResult.matches.length === 0) {
+					return {
+						content: [{ type: "text" as const, text: "No files found matching pattern" }],
+						details: undefined,
+					};
+				}
 
-						// If custom operations provided with glob, use that
-						if (customOps?.glob) {
-							if (!(await ops.exists(searchPath))) {
-								reject(new Error(`Path not found: ${searchPath}`));
-								return;
-							}
+				// Native glob returns paths relative to the search root
+				const relativized = globResult.matches.map((m: { path: string }) => m.path);
 
-							const results = await ops.glob(pattern, searchPath, {
-								ignore: ["**/node_modules/**", "**/.git/**"],
-								limit: effectiveLimit,
-							});
+				const resultLimitReached = relativized.length >= effectiveLimit;
+				const rawOutput = relativized.join("\n");
+				const truncation = truncateHead(rawOutput, { maxLines: Number.MAX_SAFE_INTEGER });
 
-							signal?.removeEventListener("abort", onAbort);
+				let resultOutput = truncation.content;
+				const details: FindToolDetails = {};
+				const notices: string[] = [];
 
-							if (results.length === 0) {
-								resolve({
-									content: [{ type: "text", text: "No files found matching pattern" }],
-									details: undefined,
-								});
-								return;
-							}
+				if (resultLimitReached) {
+					notices.push(
+						`${effectiveLimit} results limit reached. Use limit=${effectiveLimit * 2} for more, or refine pattern`,
+					);
+					details.resultLimitReached = effectiveLimit;
+				}
 
-							// Relativize paths
-							const relativized = results.map((p) => {
-								if (p.startsWith(searchPath)) {
-									return p.slice(searchPath.length + 1);
-								}
-								return path.relative(searchPath, p);
-							});
+				if (truncation.truncated) {
+					notices.push(`${formatSize(DEFAULT_MAX_BYTES)} limit reached`);
+					details.truncation = truncation;
+				}
 
-							const resultLimitReached = relativized.length >= effectiveLimit;
-							const rawOutput = relativized.join("\n");
-							const truncation = truncateHead(rawOutput, { maxLines: Number.MAX_SAFE_INTEGER });
+				if (notices.length > 0) {
+					resultOutput += `\n\n[${notices.join(". ")}]`;
+				}
 
-							let resultOutput = truncation.content;
-							const details: FindToolDetails = {};
-							const notices: string[] = [];
-
-							if (resultLimitReached) {
-								notices.push(`${effectiveLimit} results limit reached`);
-								details.resultLimitReached = effectiveLimit;
-							}
-
-							if (truncation.truncated) {
-								notices.push(`${formatSize(DEFAULT_MAX_BYTES)} limit reached`);
-								details.truncation = truncation;
-							}
-
-							if (notices.length > 0) {
-								resultOutput += `\n\n[${notices.join(". ")}]`;
-							}
-
-							resolve({
-								content: [{ type: "text", text: resultOutput }],
-								details: Object.keys(details).length > 0 ? details : undefined,
-							});
-							return;
-						}
-
-						// Default: use native Rust glob
-						const globResult = await nativeGlob({
-							pattern,
-							path: searchPath,
-							hidden: true,
-							gitignore: true,
-							cache: true,
-							maxResults: effectiveLimit,
-						});
-
-						signal?.removeEventListener("abort", onAbort);
-
-						if (globResult.matches.length === 0) {
-							resolve({
-								content: [{ type: "text", text: "No files found matching pattern" }],
-								details: undefined,
-							});
-							return;
-						}
-
-						// Native glob returns paths relative to the search root
-						const relativized = globResult.matches.map((m: { path: string }) => m.path);
-
-						const resultLimitReached = relativized.length >= effectiveLimit;
-						const rawOutput = relativized.join("\n");
-						const truncation = truncateHead(rawOutput, { maxLines: Number.MAX_SAFE_INTEGER });
-
-						let resultOutput = truncation.content;
-						const details: FindToolDetails = {};
-						const notices: string[] = [];
-
-						if (resultLimitReached) {
-							notices.push(
-								`${effectiveLimit} results limit reached. Use limit=${effectiveLimit * 2} for more, or refine pattern`,
-							);
-							details.resultLimitReached = effectiveLimit;
-						}
-
-						if (truncation.truncated) {
-							notices.push(`${formatSize(DEFAULT_MAX_BYTES)} limit reached`);
-							details.truncation = truncation;
-						}
-
-						if (notices.length > 0) {
-							resultOutput += `\n\n[${notices.join(". ")}]`;
-						}
-
-						resolve({
-							content: [{ type: "text", text: resultOutput }],
-							details: Object.keys(details).length > 0 ? details : undefined,
-						});
-					} catch (e: any) {
-						signal?.removeEventListener("abort", onAbort);
-						reject(e);
-					}
-				})();
+				return {
+					content: [{ type: "text" as const, text: resultOutput }],
+					details: Object.keys(details).length > 0 ? details : undefined,
+				};
 			});
 		},
 	};

--- a/packages/pi-coding-agent/src/core/tools/grep.ts
+++ b/packages/pi-coding-agent/src/core/tools/grep.ts
@@ -5,6 +5,7 @@ import { spawn } from "child_process";
 import { readFileSync, statSync } from "fs";
 import path from "path";
 import { ensureTool } from "../../utils/tools-manager.js";
+import { withAbortSignal } from "./abort-utils.js";
 import { resolveToCwd } from "./path-utils.js";
 import {
 	DEFAULT_MAX_BYTES,
@@ -89,254 +90,245 @@ export function createGrepTool(cwd: string, options?: GrepToolOptions): AgentToo
 			},
 			signal?: AbortSignal,
 		) => {
-			return new Promise((resolve, reject) => {
-				if (signal?.aborted) {
-					reject(new Error("Operation aborted"));
-					return;
+			return withAbortSignal(signal, async () => {
+				const rgPath = await ensureTool("rg", true);
+				if (!rgPath) {
+					throw new Error("ripgrep (rg) is not available and could not be downloaded");
 				}
 
-				let settled = false;
-				const settle = (fn: () => void) => {
-					if (!settled) {
-						settled = true;
-						fn();
+				const searchPath = resolveToCwd(searchDir || ".", cwd);
+				const ops = customOps ?? defaultGrepOperations;
+
+				let isDirectory: boolean;
+				try {
+					isDirectory = await ops.isDirectory(searchPath);
+				} catch (_err) {
+					throw new Error(`Path not found: ${searchPath}`);
+				}
+				const contextValue = context && context > 0 ? context : 0;
+				const effectiveLimit = Math.max(1, limit ?? DEFAULT_LIMIT);
+
+				const formatPath = (filePath: string): string => {
+					if (isDirectory) {
+						const relative = path.relative(searchPath, filePath);
+						if (relative && !relative.startsWith("..")) {
+							return relative.replace(/\\/g, "/");
+						}
 					}
+					return path.basename(filePath);
 				};
 
-				(async () => {
-					try {
-						const rgPath = await ensureTool("rg", true);
-						if (!rgPath) {
-							settle(() => reject(new Error("ripgrep (rg) is not available and could not be downloaded")));
-							return;
-						}
-
-						const searchPath = resolveToCwd(searchDir || ".", cwd);
-						const ops = customOps ?? defaultGrepOperations;
-
-						let isDirectory: boolean;
+				const fileCache = new Map<string, string[]>();
+				const getFileLines = async (filePath: string): Promise<string[]> => {
+					let lines = fileCache.get(filePath);
+					if (!lines) {
 						try {
-							isDirectory = await ops.isDirectory(searchPath);
-						} catch (_err) {
-							settle(() => reject(new Error(`Path not found: ${searchPath}`)));
+							const content = await ops.readFile(filePath);
+							lines = content.replace(/\r\n/g, "\n").replace(/\r/g, "\n").split("\n");
+						} catch {
+							lines = [];
+						}
+						fileCache.set(filePath, lines);
+					}
+					return lines;
+				};
+
+				const args: string[] = ["--json", "--line-number", "--color=never", "--hidden"];
+
+				if (ignoreCase) {
+					args.push("--ignore-case");
+				}
+
+				if (literal) {
+					args.push("--fixed-strings");
+				}
+
+				if (glob) {
+					args.push("--glob", glob);
+				}
+
+				args.push(pattern, searchPath);
+
+				// Run ripgrep as a child process — manage its lifecycle with an
+				// inner promise so the outer withAbortSignal handles signal cleanup.
+				return new Promise((resolve, reject) => {
+					let settled = false;
+					const settle = (fn: () => void) => {
+						if (!settled) {
+							settled = true;
+							fn();
+						}
+					};
+
+					const child = spawn(rgPath, args, { stdio: ["ignore", "pipe", "pipe"] });
+					const rl = createInterface({ input: child.stdout });
+					let stderr = "";
+					let matchCount = 0;
+					let matchLimitReached = false;
+					let linesTruncated = false;
+					let aborted = false;
+					let killedDueToLimit = false;
+					const outputLines: string[] = [];
+
+					const cleanup = () => {
+						rl.close();
+						signal?.removeEventListener("abort", onAbortChild);
+					};
+
+					const stopChild = (dueToLimit: boolean = false) => {
+						if (!child.killed) {
+							killedDueToLimit = dueToLimit;
+							child.kill();
+						}
+					};
+
+					const onAbortChild = () => {
+						aborted = true;
+						stopChild();
+					};
+
+					signal?.addEventListener("abort", onAbortChild, { once: true });
+
+					child.stderr?.on("data", (chunk) => {
+						stderr += chunk.toString();
+					});
+
+					const formatBlock = async (filePath: string, lineNumber: number): Promise<string[]> => {
+						const relativePath = formatPath(filePath);
+						const lines = await getFileLines(filePath);
+						if (!lines.length) {
+							return [`${relativePath}:${lineNumber}: (unable to read file)`];
+						}
+
+						const block: string[] = [];
+						const start = contextValue > 0 ? Math.max(1, lineNumber - contextValue) : lineNumber;
+						const end = contextValue > 0 ? Math.min(lines.length, lineNumber + contextValue) : lineNumber;
+
+						for (let current = start; current <= end; current++) {
+							const lineText = lines[current - 1] ?? "";
+							const sanitized = lineText.replace(/\r/g, "");
+							const isMatchLine = current === lineNumber;
+
+							// Truncate long lines
+							const { text: truncatedText, wasTruncated } = truncateLine(sanitized);
+							if (wasTruncated) {
+								linesTruncated = true;
+							}
+
+							if (isMatchLine) {
+								block.push(`${relativePath}:${current}: ${truncatedText}`);
+							} else {
+								block.push(`${relativePath}-${current}- ${truncatedText}`);
+							}
+						}
+
+						return block;
+					};
+
+					// Collect matches during streaming, format after
+					const matches: Array<{ filePath: string; lineNumber: number }> = [];
+
+					rl.on("line", (line) => {
+						if (!line.trim() || matchCount >= effectiveLimit) {
 							return;
 						}
-						const contextValue = context && context > 0 ? context : 0;
-						const effectiveLimit = Math.max(1, limit ?? DEFAULT_LIMIT);
 
-						const formatPath = (filePath: string): string => {
-							if (isDirectory) {
-								const relative = path.relative(searchPath, filePath);
-								if (relative && !relative.startsWith("..")) {
-									return relative.replace(/\\/g, "/");
-								}
-							}
-							return path.basename(filePath);
-						};
-
-						const fileCache = new Map<string, string[]>();
-						const getFileLines = async (filePath: string): Promise<string[]> => {
-							let lines = fileCache.get(filePath);
-							if (!lines) {
-								try {
-									const content = await ops.readFile(filePath);
-									lines = content.replace(/\r\n/g, "\n").replace(/\r/g, "\n").split("\n");
-								} catch {
-									lines = [];
-								}
-								fileCache.set(filePath, lines);
-							}
-							return lines;
-						};
-
-						const args: string[] = ["--json", "--line-number", "--color=never", "--hidden"];
-
-						if (ignoreCase) {
-							args.push("--ignore-case");
+						let event: any;
+						try {
+							event = JSON.parse(line);
+						} catch {
+							return;
 						}
 
-						if (literal) {
-							args.push("--fixed-strings");
+						if (event.type === "match") {
+							matchCount++;
+							const filePath = event.data?.path?.text;
+							const lineNumber = event.data?.line_number;
+
+							if (filePath && typeof lineNumber === "number") {
+								matches.push({ filePath, lineNumber });
+							}
+
+							if (matchCount >= effectiveLimit) {
+								matchLimitReached = true;
+								stopChild(true);
+							}
+						}
+					});
+
+					child.on("error", (error) => {
+						cleanup();
+						settle(() => reject(new Error(`Failed to run ripgrep: ${error.message}`)));
+					});
+
+					child.on("close", async (code) => {
+						cleanup();
+
+						if (aborted) {
+							settle(() => reject(new Error("Operation aborted")));
+							return;
 						}
 
-						if (glob) {
-							args.push("--glob", glob);
+						if (!killedDueToLimit && code !== 0 && code !== 1) {
+							const errorMsg = stderr.trim() || `ripgrep exited with code ${code}`;
+							settle(() => reject(new Error(errorMsg)));
+							return;
 						}
 
-						args.push(pattern, searchPath);
-
-						const child = spawn(rgPath, args, { stdio: ["ignore", "pipe", "pipe"] });
-						const rl = createInterface({ input: child.stdout });
-						let stderr = "";
-						let matchCount = 0;
-						let matchLimitReached = false;
-						let linesTruncated = false;
-						let aborted = false;
-						let killedDueToLimit = false;
-						const outputLines: string[] = [];
-
-						const cleanup = () => {
-							rl.close();
-							signal?.removeEventListener("abort", onAbort);
-						};
-
-						const stopChild = (dueToLimit: boolean = false) => {
-							if (!child.killed) {
-								killedDueToLimit = dueToLimit;
-								child.kill();
-							}
-						};
-
-						const onAbort = () => {
-							aborted = true;
-							stopChild();
-						};
-
-						signal?.addEventListener("abort", onAbort, { once: true });
-
-						child.stderr?.on("data", (chunk) => {
-							stderr += chunk.toString();
-						});
-
-						const formatBlock = async (filePath: string, lineNumber: number): Promise<string[]> => {
-							const relativePath = formatPath(filePath);
-							const lines = await getFileLines(filePath);
-							if (!lines.length) {
-								return [`${relativePath}:${lineNumber}: (unable to read file)`];
-							}
-
-							const block: string[] = [];
-							const start = contextValue > 0 ? Math.max(1, lineNumber - contextValue) : lineNumber;
-							const end = contextValue > 0 ? Math.min(lines.length, lineNumber + contextValue) : lineNumber;
-
-							for (let current = start; current <= end; current++) {
-								const lineText = lines[current - 1] ?? "";
-								const sanitized = lineText.replace(/\r/g, "");
-								const isMatchLine = current === lineNumber;
-
-								// Truncate long lines
-								const { text: truncatedText, wasTruncated } = truncateLine(sanitized);
-								if (wasTruncated) {
-									linesTruncated = true;
-								}
-
-								if (isMatchLine) {
-									block.push(`${relativePath}:${current}: ${truncatedText}`);
-								} else {
-									block.push(`${relativePath}-${current}- ${truncatedText}`);
-								}
-							}
-
-							return block;
-						};
-
-						// Collect matches during streaming, format after
-						const matches: Array<{ filePath: string; lineNumber: number }> = [];
-
-						rl.on("line", (line) => {
-							if (!line.trim() || matchCount >= effectiveLimit) {
-								return;
-							}
-
-							let event: any;
-							try {
-								event = JSON.parse(line);
-							} catch {
-								return;
-							}
-
-							if (event.type === "match") {
-								matchCount++;
-								const filePath = event.data?.path?.text;
-								const lineNumber = event.data?.line_number;
-
-								if (filePath && typeof lineNumber === "number") {
-									matches.push({ filePath, lineNumber });
-								}
-
-								if (matchCount >= effectiveLimit) {
-									matchLimitReached = true;
-									stopChild(true);
-								}
-							}
-						});
-
-						child.on("error", (error) => {
-							cleanup();
-							settle(() => reject(new Error(`Failed to run ripgrep: ${error.message}`)));
-						});
-
-						child.on("close", async (code) => {
-							cleanup();
-
-							if (aborted) {
-								settle(() => reject(new Error("Operation aborted")));
-								return;
-							}
-
-							if (!killedDueToLimit && code !== 0 && code !== 1) {
-								const errorMsg = stderr.trim() || `ripgrep exited with code ${code}`;
-								settle(() => reject(new Error(errorMsg)));
-								return;
-							}
-
-							if (matchCount === 0) {
-								settle(() =>
-									resolve({ content: [{ type: "text", text: "No matches found" }], details: undefined }),
-								);
-								return;
-							}
-
-							// Format matches (async to support remote file reading)
-							for (const match of matches) {
-								const block = await formatBlock(match.filePath, match.lineNumber);
-								outputLines.push(...block);
-							}
-
-							// Apply byte truncation (no line limit since we already have match limit)
-							const rawOutput = outputLines.join("\n");
-							const truncation = truncateHead(rawOutput, { maxLines: Number.MAX_SAFE_INTEGER });
-
-							let output = truncation.content;
-							const details: GrepToolDetails = {};
-
-							// Build notices
-							const notices: string[] = [];
-
-							if (matchLimitReached) {
-								notices.push(
-									`${effectiveLimit} matches limit reached. Use limit=${effectiveLimit * 2} for more, or refine pattern`,
-								);
-								details.matchLimitReached = effectiveLimit;
-							}
-
-							if (truncation.truncated) {
-								notices.push(`${formatSize(DEFAULT_MAX_BYTES)} limit reached`);
-								details.truncation = truncation;
-							}
-
-							if (linesTruncated) {
-								notices.push(
-									`Some lines truncated to ${GREP_MAX_LINE_LENGTH} chars. Use read tool to see full lines`,
-								);
-								details.linesTruncated = true;
-							}
-
-							if (notices.length > 0) {
-								output += `\n\n[${notices.join(". ")}]`;
-							}
-
+						if (matchCount === 0) {
 							settle(() =>
-								resolve({
-									content: [{ type: "text", text: output }],
-									details: Object.keys(details).length > 0 ? details : undefined,
-								}),
+								resolve({ content: [{ type: "text", text: "No matches found" }], details: undefined }),
 							);
-						});
-					} catch (err) {
-						settle(() => reject(err as Error));
-					}
-				})();
+							return;
+						}
+
+						// Format matches (async to support remote file reading)
+						for (const match of matches) {
+							const block = await formatBlock(match.filePath, match.lineNumber);
+							outputLines.push(...block);
+						}
+
+						// Apply byte truncation (no line limit since we already have match limit)
+						const rawOutput = outputLines.join("\n");
+						const truncation = truncateHead(rawOutput, { maxLines: Number.MAX_SAFE_INTEGER });
+
+						let output = truncation.content;
+						const details: GrepToolDetails = {};
+
+						// Build notices
+						const notices: string[] = [];
+
+						if (matchLimitReached) {
+							notices.push(
+								`${effectiveLimit} matches limit reached. Use limit=${effectiveLimit * 2} for more, or refine pattern`,
+							);
+							details.matchLimitReached = effectiveLimit;
+						}
+
+						if (truncation.truncated) {
+							notices.push(`${formatSize(DEFAULT_MAX_BYTES)} limit reached`);
+							details.truncation = truncation;
+						}
+
+						if (linesTruncated) {
+							notices.push(
+								`Some lines truncated to ${GREP_MAX_LINE_LENGTH} chars. Use read tool to see full lines`,
+							);
+							details.linesTruncated = true;
+						}
+
+						if (notices.length > 0) {
+							output += `\n\n[${notices.join(". ")}]`;
+						}
+
+						settle(() =>
+							resolve({
+								content: [{ type: "text", text: output }],
+								details: Object.keys(details).length > 0 ? details : undefined,
+							}),
+						);
+					});
+				});
 			});
 		},
 	};

--- a/packages/pi-coding-agent/src/core/tools/hashline-edit.ts
+++ b/packages/pi-coding-agent/src/core/tools/hashline-edit.ts
@@ -23,6 +23,7 @@ import {
 	parseHashlineText,
 	parseTag,
 } from "./hashline.js";
+import { withAbortSignal } from "./abort-utils.js";
 import { resolveToCwd } from "./path-utils.js";
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -155,160 +156,128 @@ export function createHashlineEditTool(cwd: string, options?: HashlineEditToolOp
 			const { path, edits, delete: deleteFile, move } = params;
 			const absolutePath = resolveToCwd(path, cwd);
 
-			return new Promise<{
-				content: Array<{ type: "text"; text: string }>;
-				details: HashlineEditToolDetails | undefined;
-			}>((resolve, reject) => {
-				if (signal?.aborted) {
-					reject(new Error("Operation aborted"));
-					return;
-				}
-
-				let aborted = false;
-				const onAbort = () => {
-					aborted = true;
-					reject(new Error("Operation aborted"));
-				};
-				if (signal) {
-					signal.addEventListener("abort", onAbort, { once: true });
-				}
-
-				(async () => {
+			return withAbortSignal(signal, async (checkAborted) => {
+				// Handle delete
+				if (deleteFile) {
+					let fileExists = true;
 					try {
-						// Handle delete
-						if (deleteFile) {
-							let fileExists = true;
-							try {
-								await ops.access(absolutePath);
-							} catch {
-								fileExists = false;
+						await ops.access(absolutePath);
+					} catch {
+						fileExists = false;
+					}
+					if (fileExists) {
+						await ops.unlink(absolutePath);
+					}
+					return {
+						content: [{ type: "text" as const, text: fileExists ? `Deleted ${path}` : `File not found, nothing to delete: ${path}` }],
+						details: { diff: "" },
+					};
+				}
+
+				// Handle file creation (no existing file, anchorless appends/prepends)
+				let fileExists = true;
+				try {
+					await ops.access(absolutePath);
+				} catch {
+					fileExists = false;
+				}
+
+				if (!fileExists) {
+					const lines: string[] = [];
+					for (const edit of edits) {
+						if ((edit.op === "append" || edit.op === "prepend") && !edit.pos && !edit.end) {
+							if (edit.op === "prepend") {
+								lines.unshift(...parseHashlineText(edit.lines));
+							} else {
+								lines.push(...parseHashlineText(edit.lines));
 							}
-							if (fileExists) {
-								await ops.unlink(absolutePath);
-							}
-							if (signal) signal.removeEventListener("abort", onAbort);
-							resolve({
-								content: [{ type: "text", text: fileExists ? `Deleted ${path}` : `File not found, nothing to delete: ${path}` }],
-								details: { diff: "" },
-							});
-							return;
-						}
-
-						// Handle file creation (no existing file, anchorless appends/prepends)
-						let fileExists = true;
-						try {
-							await ops.access(absolutePath);
-						} catch {
-							fileExists = false;
-						}
-
-						if (!fileExists) {
-							const lines: string[] = [];
-							for (const edit of edits) {
-								if ((edit.op === "append" || edit.op === "prepend") && !edit.pos && !edit.end) {
-									if (edit.op === "prepend") {
-										lines.unshift(...parseHashlineText(edit.lines));
-									} else {
-										lines.push(...parseHashlineText(edit.lines));
-									}
-								} else {
-									throw new Error(`File not found: ${path}`);
-								}
-							}
-							await ops.writeFile(absolutePath, lines.join("\n"));
-							if (signal) signal.removeEventListener("abort", onAbort);
-							resolve({
-								content: [{ type: "text", text: `Created ${path}` }],
-								details: { diff: "" },
-							});
-							return;
-						}
-
-						if (aborted) return;
-
-						// Read file
-						const rawContent = (await ops.readFile(absolutePath)).toString("utf-8");
-						const { bom, text } = stripBom(rawContent);
-						const originalEnding = detectLineEnding(text);
-						const originalNormalized = normalizeToLF(text);
-
-						if (aborted) return;
-
-						// Resolve and apply edits
-						const anchorEdits = resolveEditAnchors(edits);
-						const result = applyHashlineEdits(originalNormalized, anchorEdits);
-
-						if (originalNormalized === result.lines && !move) {
-							let diagnostic = `No changes made to ${path}. The edits produced identical content.`;
-							if (result.noopEdits && result.noopEdits.length > 0) {
-								const details = result.noopEdits
-									.map(
-										e =>
-											`Edit ${e.editIndex}: replacement for ${e.loc} is identical to current content:\n  ${e.loc}| ${e.current}`,
-									)
-									.join("\n");
-								diagnostic += `\n${details}`;
-								diagnostic +=
-									"\nYour content must differ from what the file already contains. Re-read the file to see the current state.";
-							}
-							throw new Error(diagnostic);
-						}
-
-						if (aborted) return;
-
-						// Write result
-						const finalContent = bom + restoreLineEndings(result.lines, originalEnding);
-						const writePath = move ? resolveToCwd(move, cwd) : absolutePath;
-
-						// Prevent silent overwrite when moving to an existing file
-						if (move && writePath !== absolutePath) {
-							try {
-								await ops.access(writePath);
-								// If access succeeds, the file exists — refuse the move
-								throw new Error(`Destination file already exists: ${writePath}. Use a different path or delete the existing file first.`);
-							} catch (err: any) {
-								// Re-throw our own error; swallow only "file not found"
-								if (err.message?.startsWith("Destination file already exists:")) throw err;
-								// File doesn't exist — safe to proceed
-							}
-						}
-
-						await ops.writeFile(writePath, finalContent);
-
-						// If moved, delete original
-						if (move && writePath !== absolutePath) {
-							await ops.unlink(absolutePath);
-						}
-
-						if (aborted) return;
-
-						if (signal) signal.removeEventListener("abort", onAbort);
-
-						const diffResult = generateDiffString(originalNormalized, result.lines);
-						const resultText = move ? `Moved ${path} to ${move}` : `Updated ${path}`;
-						const warningsBlock = result.warnings?.length
-							? `\nWarnings:\n${result.warnings.join("\n")}`
-							: "";
-
-						resolve({
-							content: [
-								{
-									type: "text",
-									text: `${resultText}${warningsBlock}`,
-								},
-							],
-							details: {
-								diff: diffResult.diff,
-								firstChangedLine: result.firstChangedLine ?? diffResult.firstChangedLine,
-							},
-						});
-					} catch (error: any) {
-						if (signal) signal.removeEventListener("abort", onAbort);
-						if (!aborted) {
-							reject(error);
+						} else {
+							throw new Error(`File not found: ${path}`);
 						}
 					}
-				})();
+					await ops.writeFile(absolutePath, lines.join("\n"));
+					return {
+						content: [{ type: "text" as const, text: `Created ${path}` }],
+						details: { diff: "" },
+					};
+				}
+
+				checkAborted();
+
+				// Read file
+				const rawContent = (await ops.readFile(absolutePath)).toString("utf-8");
+				const { bom, text } = stripBom(rawContent);
+				const originalEnding = detectLineEnding(text);
+				const originalNormalized = normalizeToLF(text);
+
+				checkAborted();
+
+				// Resolve and apply edits
+				const anchorEdits = resolveEditAnchors(edits);
+				const result = applyHashlineEdits(originalNormalized, anchorEdits);
+
+				if (originalNormalized === result.lines && !move) {
+					let diagnostic = `No changes made to ${path}. The edits produced identical content.`;
+					if (result.noopEdits && result.noopEdits.length > 0) {
+						const details = result.noopEdits
+							.map(
+								e =>
+									`Edit ${e.editIndex}: replacement for ${e.loc} is identical to current content:\n  ${e.loc}| ${e.current}`,
+							)
+							.join("\n");
+						diagnostic += `\n${details}`;
+						diagnostic +=
+							"\nYour content must differ from what the file already contains. Re-read the file to see the current state.";
+					}
+					throw new Error(diagnostic);
+				}
+
+				checkAborted();
+
+				// Write result
+				const finalContent = bom + restoreLineEndings(result.lines, originalEnding);
+				const writePath = move ? resolveToCwd(move, cwd) : absolutePath;
+
+				// Prevent silent overwrite when moving to an existing file
+				if (move && writePath !== absolutePath) {
+					try {
+						await ops.access(writePath);
+						// If access succeeds, the file exists — refuse the move
+						throw new Error(`Destination file already exists: ${writePath}. Use a different path or delete the existing file first.`);
+					} catch (err: any) {
+						// Re-throw our own error; swallow only "file not found"
+						if (err.message?.startsWith("Destination file already exists:")) throw err;
+						// File doesn't exist — safe to proceed
+					}
+				}
+
+				await ops.writeFile(writePath, finalContent);
+
+				// If moved, delete original
+				if (move && writePath !== absolutePath) {
+					await ops.unlink(absolutePath);
+				}
+
+				checkAborted();
+
+				const diffResult = generateDiffString(originalNormalized, result.lines);
+				const resultText = move ? `Moved ${path} to ${move}` : `Updated ${path}`;
+				const warningsBlock = result.warnings?.length
+					? `\nWarnings:\n${result.warnings.join("\n")}`
+					: "";
+
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: `${resultText}${warningsBlock}`,
+						},
+					],
+					details: {
+						diff: diffResult.diff,
+						firstChangedLine: result.firstChangedLine ?? diffResult.firstChangedLine,
+					},
+				};
 			});
 		},
 	};

--- a/packages/pi-coding-agent/src/core/tools/hashline-read.ts
+++ b/packages/pi-coding-agent/src/core/tools/hashline-read.ts
@@ -15,6 +15,7 @@ import { constants } from "fs";
 import { access as fsAccess, readFile as fsReadFile } from "fs/promises";
 import { formatDimensionNote, resizeImage } from "../../utils/image-resize.js";
 import { detectSupportedImageMimeTypeFromFile } from "../../utils/mime.js";
+import { withAbortSignal } from "./abort-utils.js";
 import { formatHashLines } from "./hashline.js";
 import { resolveReadPath } from "./path-utils.js";
 import { DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES, formatSize, type TruncationResult, truncateHead } from "./truncate.js";
@@ -67,127 +68,101 @@ export function createHashlineReadTool(cwd: string, options?: HashlineReadToolOp
 		) => {
 			const absolutePath = resolveReadPath(path, cwd);
 
-			return new Promise<{ content: (TextContent | ImageContent)[]; details: HashlineReadToolDetails | undefined }>(
-				(resolve, reject) => {
-					if (signal?.aborted) {
-						reject(new Error("Operation aborted"));
-						return;
-					}
+			return withAbortSignal(signal, async (checkAborted) => {
+				await ops.access(absolutePath);
 
-					let aborted = false;
-					const onAbort = () => {
-						aborted = true;
-						reject(new Error("Operation aborted"));
-					};
-					if (signal) {
-						signal.addEventListener("abort", onAbort, { once: true });
-					}
+				checkAborted();
 
-					(async () => {
-						try {
-							await ops.access(absolutePath);
+				const mimeType = ops.detectImageMimeType ? await ops.detectImageMimeType(absolutePath) : undefined;
 
-							if (aborted) return;
+				let content: (TextContent | ImageContent)[];
+				let details: HashlineReadToolDetails | undefined;
 
-							const mimeType = ops.detectImageMimeType ? await ops.detectImageMimeType(absolutePath) : undefined;
+				if (mimeType) {
+					// Image handling (identical to standard read tool)
+					const buffer = await ops.readFile(absolutePath);
+					const base64 = buffer.toString("base64");
 
-							let content: (TextContent | ImageContent)[];
-							let details: HashlineReadToolDetails | undefined;
-
-							if (mimeType) {
-								// Image handling (identical to standard read tool)
-								const buffer = await ops.readFile(absolutePath);
-								const base64 = buffer.toString("base64");
-
-								if (autoResizeImages) {
-									const resized = await resizeImage({ type: "image", data: base64, mimeType });
-									const dimensionNote = formatDimensionNote(resized);
-									let textNote = `Read image file [${resized.mimeType}]`;
-									if (dimensionNote) {
-										textNote += `\n${dimensionNote}`;
-									}
-									content = [
-										{ type: "text", text: textNote },
-										{ type: "image", data: resized.data, mimeType: resized.mimeType },
-									];
-								} else {
-									content = [
-										{ type: "text", text: `Read image file [${mimeType}]` },
-										{ type: "image", data: base64, mimeType },
-									];
-								}
-							} else {
-								// Text file — format with hashline prefixes
-								const buffer = await ops.readFile(absolutePath);
-								const textContent = buffer.toString("utf-8");
-								const allLines = textContent.split("\n");
-								const totalFileLines = allLines.length;
-
-								const startLine = offset ? Math.max(0, offset - 1) : 0;
-								const startLineDisplay = startLine + 1;
-
-								if (startLine >= allLines.length) {
-									throw new Error(`Offset ${offset} is beyond end of file (${allLines.length} lines total)`);
-								}
-
-								let selectedContent: string;
-								let userLimitedLines: number | undefined;
-								if (limit !== undefined) {
-									const endLine = Math.min(startLine + limit, allLines.length);
-									selectedContent = allLines.slice(startLine, endLine).join("\n");
-									userLimitedLines = endLine - startLine;
-								} else {
-									selectedContent = allLines.slice(startLine).join("\n");
-								}
-
-								// Apply truncation
-								const truncation = truncateHead(selectedContent);
-
-								let outputText: string;
-
-								if (truncation.firstLineExceedsLimit) {
-									const firstLineSize = formatSize(Buffer.byteLength(allLines[startLine], "utf-8"));
-									outputText = `[Line ${startLineDisplay} is ${firstLineSize}, exceeds ${formatSize(DEFAULT_MAX_BYTES)} limit. Use bash: sed -n '${startLineDisplay}p' ${path} | head -c ${DEFAULT_MAX_BYTES}]`;
-									details = { truncation };
-								} else if (truncation.truncated) {
-									const endLineDisplay = startLineDisplay + truncation.outputLines - 1;
-									const nextOffset = endLineDisplay + 1;
-
-									// Format with hashline prefixes
-									outputText = formatHashLines(truncation.content, startLineDisplay);
-
-									if (truncation.truncatedBy === "lines") {
-										outputText += `\n\n[Showing lines ${startLineDisplay}-${endLineDisplay} of ${totalFileLines}. Use offset=${nextOffset} to continue.]`;
-									} else {
-										outputText += `\n\n[Showing lines ${startLineDisplay}-${endLineDisplay} of ${totalFileLines} (${formatSize(DEFAULT_MAX_BYTES)} limit). Use offset=${nextOffset} to continue.]`;
-									}
-									details = { truncation };
-								} else if (userLimitedLines !== undefined && startLine + userLimitedLines < allLines.length) {
-									const remaining = allLines.length - (startLine + userLimitedLines);
-									const nextOffset = startLine + userLimitedLines + 1;
-
-									outputText = formatHashLines(truncation.content, startLineDisplay);
-									outputText += `\n\n[${remaining} more lines in file. Use offset=${nextOffset} to continue.]`;
-								} else {
-									outputText = formatHashLines(truncation.content, startLineDisplay);
-								}
-
-								content = [{ type: "text", text: outputText }];
-							}
-
-							if (aborted) return;
-
-							if (signal) signal.removeEventListener("abort", onAbort);
-							resolve({ content, details });
-						} catch (error: any) {
-							if (signal) signal.removeEventListener("abort", onAbort);
-							if (!aborted) {
-								reject(error);
-							}
+					if (autoResizeImages) {
+						const resized = await resizeImage({ type: "image", data: base64, mimeType });
+						const dimensionNote = formatDimensionNote(resized);
+						let textNote = `Read image file [${resized.mimeType}]`;
+						if (dimensionNote) {
+							textNote += `\n${dimensionNote}`;
 						}
-					})();
-				},
-			);
+						content = [
+							{ type: "text", text: textNote },
+							{ type: "image", data: resized.data, mimeType: resized.mimeType },
+						];
+					} else {
+						content = [
+							{ type: "text", text: `Read image file [${mimeType}]` },
+							{ type: "image", data: base64, mimeType },
+						];
+					}
+				} else {
+					// Text file — format with hashline prefixes
+					const buffer = await ops.readFile(absolutePath);
+					const textContent = buffer.toString("utf-8");
+					const allLines = textContent.split("\n");
+					const totalFileLines = allLines.length;
+
+					const startLine = offset ? Math.max(0, offset - 1) : 0;
+					const startLineDisplay = startLine + 1;
+
+					if (startLine >= allLines.length) {
+						throw new Error(`Offset ${offset} is beyond end of file (${allLines.length} lines total)`);
+					}
+
+					let selectedContent: string;
+					let userLimitedLines: number | undefined;
+					if (limit !== undefined) {
+						const endLine = Math.min(startLine + limit, allLines.length);
+						selectedContent = allLines.slice(startLine, endLine).join("\n");
+						userLimitedLines = endLine - startLine;
+					} else {
+						selectedContent = allLines.slice(startLine).join("\n");
+					}
+
+					// Apply truncation
+					const truncation = truncateHead(selectedContent);
+
+					let outputText: string;
+
+					if (truncation.firstLineExceedsLimit) {
+						const firstLineSize = formatSize(Buffer.byteLength(allLines[startLine], "utf-8"));
+						outputText = `[Line ${startLineDisplay} is ${firstLineSize}, exceeds ${formatSize(DEFAULT_MAX_BYTES)} limit. Use bash: sed -n '${startLineDisplay}p' ${path} | head -c ${DEFAULT_MAX_BYTES}]`;
+						details = { truncation };
+					} else if (truncation.truncated) {
+						const endLineDisplay = startLineDisplay + truncation.outputLines - 1;
+						const nextOffset = endLineDisplay + 1;
+
+						// Format with hashline prefixes
+						outputText = formatHashLines(truncation.content, startLineDisplay);
+
+						if (truncation.truncatedBy === "lines") {
+							outputText += `\n\n[Showing lines ${startLineDisplay}-${endLineDisplay} of ${totalFileLines}. Use offset=${nextOffset} to continue.]`;
+						} else {
+							outputText += `\n\n[Showing lines ${startLineDisplay}-${endLineDisplay} of ${totalFileLines} (${formatSize(DEFAULT_MAX_BYTES)} limit). Use offset=${nextOffset} to continue.]`;
+						}
+						details = { truncation };
+					} else if (userLimitedLines !== undefined && startLine + userLimitedLines < allLines.length) {
+						const remaining = allLines.length - (startLine + userLimitedLines);
+						const nextOffset = startLine + userLimitedLines + 1;
+
+						outputText = formatHashLines(truncation.content, startLineDisplay);
+						outputText += `\n\n[${remaining} more lines in file. Use offset=${nextOffset} to continue.]`;
+					} else {
+						outputText = formatHashLines(truncation.content, startLineDisplay);
+					}
+
+					content = [{ type: "text", text: outputText }];
+				}
+
+				checkAborted();
+
+				return { content, details };
+			});
 		},
 	};
 }

--- a/packages/pi-coding-agent/src/core/tools/ls.ts
+++ b/packages/pi-coding-agent/src/core/tools/ls.ts
@@ -2,6 +2,7 @@ import type { AgentTool } from "@gsd/pi-agent-core";
 import { type Static, Type } from "@sinclair/typebox";
 import { existsSync, readdirSync, statSync } from "fs";
 import nodePath from "path";
+import { withAbortSignal } from "./abort-utils.js";
 import { resolveToCwd } from "./path-utils.js";
 import { DEFAULT_MAX_BYTES, formatSize, type TruncationResult, truncateHead } from "./truncate.js";
 
@@ -56,111 +57,90 @@ export function createLsTool(cwd: string, options?: LsToolOptions): AgentTool<ty
 			{ path, limit }: { path?: string; limit?: number },
 			signal?: AbortSignal,
 		) => {
-			return new Promise((resolve, reject) => {
-				if (signal?.aborted) {
-					reject(new Error("Operation aborted"));
-					return;
+			return withAbortSignal(signal, async () => {
+				const dirPath = resolveToCwd(path || ".", cwd);
+				const effectiveLimit = limit ?? DEFAULT_LIMIT;
+
+				// Check if path exists
+				if (!(await ops.exists(dirPath))) {
+					throw new Error(`Path not found: ${dirPath}`);
 				}
 
-				const onAbort = () => reject(new Error("Operation aborted"));
-				signal?.addEventListener("abort", onAbort, { once: true });
+				// Check if path is a directory
+				const stat = await ops.stat(dirPath);
+				if (!stat.isDirectory()) {
+					throw new Error(`Not a directory: ${dirPath}`);
+				}
 
-				(async () => {
-					try {
-						const dirPath = resolveToCwd(path || ".", cwd);
-						const effectiveLimit = limit ?? DEFAULT_LIMIT;
+				// Read directory entries
+				let entries: string[];
+				try {
+					entries = await ops.readdir(dirPath);
+				} catch (e: any) {
+					throw new Error(`Cannot read directory: ${e.message}`);
+				}
 
-						// Check if path exists
-						if (!(await ops.exists(dirPath))) {
-							reject(new Error(`Path not found: ${dirPath}`));
-							return;
-						}
+				// Sort alphabetically (case-insensitive)
+				entries.sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()));
 
-						// Check if path is a directory
-						const stat = await ops.stat(dirPath);
-						if (!stat.isDirectory()) {
-							reject(new Error(`Not a directory: ${dirPath}`));
-							return;
-						}
+				// Format entries with directory indicators
+				const results: string[] = [];
+				let entryLimitReached = false;
 
-						// Read directory entries
-						let entries: string[];
-						try {
-							entries = await ops.readdir(dirPath);
-						} catch (e: any) {
-							reject(new Error(`Cannot read directory: ${e.message}`));
-							return;
-						}
-
-						// Sort alphabetically (case-insensitive)
-						entries.sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()));
-
-						// Format entries with directory indicators
-						const results: string[] = [];
-						let entryLimitReached = false;
-
-						for (const entry of entries) {
-							if (results.length >= effectiveLimit) {
-								entryLimitReached = true;
-								break;
-							}
-
-							const fullPath = nodePath.join(dirPath, entry);
-							let suffix = "";
-
-							try {
-								const entryStat = await ops.stat(fullPath);
-								if (entryStat.isDirectory()) {
-									suffix = "/";
-								}
-							} catch {
-								// Skip entries we can't stat
-								continue;
-							}
-
-							results.push(entry + suffix);
-						}
-
-						signal?.removeEventListener("abort", onAbort);
-
-						if (results.length === 0) {
-							resolve({ content: [{ type: "text", text: "(empty directory)" }], details: undefined });
-							return;
-						}
-
-						// Apply byte truncation (no line limit since we already have entry limit)
-						const rawOutput = results.join("\n");
-						const truncation = truncateHead(rawOutput, { maxLines: Number.MAX_SAFE_INTEGER });
-
-						let output = truncation.content;
-						const details: LsToolDetails = {};
-
-						// Build notices
-						const notices: string[] = [];
-
-						if (entryLimitReached) {
-							notices.push(`${effectiveLimit} entries limit reached. Use limit=${effectiveLimit * 2} for more`);
-							details.entryLimitReached = effectiveLimit;
-						}
-
-						if (truncation.truncated) {
-							notices.push(`${formatSize(DEFAULT_MAX_BYTES)} limit reached`);
-							details.truncation = truncation;
-						}
-
-						if (notices.length > 0) {
-							output += `\n\n[${notices.join(". ")}]`;
-						}
-
-						resolve({
-							content: [{ type: "text", text: output }],
-							details: Object.keys(details).length > 0 ? details : undefined,
-						});
-					} catch (e: any) {
-						signal?.removeEventListener("abort", onAbort);
-						reject(e);
+				for (const entry of entries) {
+					if (results.length >= effectiveLimit) {
+						entryLimitReached = true;
+						break;
 					}
-				})();
+
+					const fullPath = nodePath.join(dirPath, entry);
+					let suffix = "";
+
+					try {
+						const entryStat = await ops.stat(fullPath);
+						if (entryStat.isDirectory()) {
+							suffix = "/";
+						}
+					} catch {
+						// Skip entries we can't stat
+						continue;
+					}
+
+					results.push(entry + suffix);
+				}
+
+				if (results.length === 0) {
+					return { content: [{ type: "text" as const, text: "(empty directory)" }], details: undefined };
+				}
+
+				// Apply byte truncation (no line limit since we already have entry limit)
+				const rawOutput = results.join("\n");
+				const truncation = truncateHead(rawOutput, { maxLines: Number.MAX_SAFE_INTEGER });
+
+				let output = truncation.content;
+				const details: LsToolDetails = {};
+
+				// Build notices
+				const notices: string[] = [];
+
+				if (entryLimitReached) {
+					notices.push(`${effectiveLimit} entries limit reached. Use limit=${effectiveLimit * 2} for more`);
+					details.entryLimitReached = effectiveLimit;
+				}
+
+				if (truncation.truncated) {
+					notices.push(`${formatSize(DEFAULT_MAX_BYTES)} limit reached`);
+					details.truncation = truncation;
+				}
+
+				if (notices.length > 0) {
+					output += `\n\n[${notices.join(". ")}]`;
+				}
+
+				return {
+					content: [{ type: "text" as const, text: output }],
+					details: Object.keys(details).length > 0 ? details : undefined,
+				};
 			});
 		},
 	};

--- a/packages/pi-coding-agent/src/core/tools/read.ts
+++ b/packages/pi-coding-agent/src/core/tools/read.ts
@@ -5,6 +5,7 @@ import { constants } from "fs";
 import { access as fsAccess, readFile as fsReadFile } from "fs/promises";
 import { formatDimensionNote, resizeImage } from "../../utils/image-resize.js";
 import { detectSupportedImageMimeTypeFromFile } from "../../utils/mime.js";
+import { withAbortSignal } from "./abort-utils.js";
 import { resolveReadPath } from "./path-utils.js";
 import { DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES, formatSize, type TruncationResult, truncateHead } from "./truncate.js";
 
@@ -62,158 +63,113 @@ export function createReadTool(cwd: string, options?: ReadToolOptions): AgentToo
 		) => {
 			const absolutePath = resolveReadPath(path, cwd);
 
-			return new Promise<{ content: (TextContent | ImageContent)[]; details: ReadToolDetails | undefined }>(
-				(resolve, reject) => {
-					// Check if already aborted
-					if (signal?.aborted) {
-						reject(new Error("Operation aborted"));
-						return;
-					}
+			return withAbortSignal(signal, async (checkAborted) => {
+				// Check if file exists
+				await ops.access(absolutePath);
 
-					let aborted = false;
+				checkAborted();
 
-					// Set up abort handler
-					const onAbort = () => {
-						aborted = true;
-						reject(new Error("Operation aborted"));
-					};
+				const mimeType = ops.detectImageMimeType ? await ops.detectImageMimeType(absolutePath) : undefined;
 
-					if (signal) {
-						signal.addEventListener("abort", onAbort, { once: true });
-					}
+				// Read the file based on type
+				let content: (TextContent | ImageContent)[];
+				let details: ReadToolDetails | undefined;
 
-					// Perform the read operation
-					(async () => {
-						try {
-							// Check if file exists
-							await ops.access(absolutePath);
+				if (mimeType) {
+					// Read as image (binary)
+					const buffer = await ops.readFile(absolutePath);
+					const base64 = buffer.toString("base64");
 
-							// Check if aborted before reading
-							if (aborted) {
-								return;
-							}
+					if (autoResizeImages) {
+						// Resize image if needed
+						const resized = await resizeImage({ type: "image", data: base64, mimeType });
+						const dimensionNote = formatDimensionNote(resized);
 
-							const mimeType = ops.detectImageMimeType ? await ops.detectImageMimeType(absolutePath) : undefined;
-
-							// Read the file based on type
-							let content: (TextContent | ImageContent)[];
-							let details: ReadToolDetails | undefined;
-
-							if (mimeType) {
-								// Read as image (binary)
-								const buffer = await ops.readFile(absolutePath);
-								const base64 = buffer.toString("base64");
-
-								if (autoResizeImages) {
-									// Resize image if needed
-									const resized = await resizeImage({ type: "image", data: base64, mimeType });
-									const dimensionNote = formatDimensionNote(resized);
-
-									let textNote = `Read image file [${resized.mimeType}]`;
-									if (dimensionNote) {
-										textNote += `\n${dimensionNote}`;
-									}
-
-									content = [
-										{ type: "text", text: textNote },
-										{ type: "image", data: resized.data, mimeType: resized.mimeType },
-									];
-								} else {
-									const textNote = `Read image file [${mimeType}]`;
-									content = [
-										{ type: "text", text: textNote },
-										{ type: "image", data: base64, mimeType },
-									];
-								}
-							} else {
-								// Read as text
-								const buffer = await ops.readFile(absolutePath);
-								const textContent = buffer.toString("utf-8");
-								const allLines = textContent.split("\n");
-								const totalFileLines = allLines.length;
-
-								// Apply offset if specified (1-indexed to 0-indexed)
-								const startLine = offset ? Math.max(0, offset - 1) : 0;
-								const startLineDisplay = startLine + 1; // For display (1-indexed)
-
-								// Check if offset is out of bounds
-								if (startLine >= allLines.length) {
-									throw new Error(`Offset ${offset} is beyond end of file (${allLines.length} lines total)`);
-								}
-
-								// If limit is specified by user, use it; otherwise we'll let truncateHead decide
-								let selectedContent: string;
-								let userLimitedLines: number | undefined;
-								if (limit !== undefined) {
-									const endLine = Math.min(startLine + limit, allLines.length);
-									selectedContent = allLines.slice(startLine, endLine).join("\n");
-									userLimitedLines = endLine - startLine;
-								} else {
-									selectedContent = allLines.slice(startLine).join("\n");
-								}
-
-								// Apply truncation (respects both line and byte limits)
-								const truncation = truncateHead(selectedContent);
-
-								let outputText: string;
-
-								if (truncation.firstLineExceedsLimit) {
-									// First line at offset exceeds 30KB - tell model to use bash
-									const firstLineSize = formatSize(Buffer.byteLength(allLines[startLine], "utf-8"));
-									outputText = `[Line ${startLineDisplay} is ${firstLineSize}, exceeds ${formatSize(DEFAULT_MAX_BYTES)} limit. Use bash: sed -n '${startLineDisplay}p' ${path} | head -c ${DEFAULT_MAX_BYTES}]`;
-									details = { truncation };
-								} else if (truncation.truncated) {
-									// Truncation occurred - build actionable notice
-									const endLineDisplay = startLineDisplay + truncation.outputLines - 1;
-									const nextOffset = endLineDisplay + 1;
-
-									outputText = truncation.content;
-
-									if (truncation.truncatedBy === "lines") {
-										outputText += `\n\n[Showing lines ${startLineDisplay}-${endLineDisplay} of ${totalFileLines}. Use offset=${nextOffset} to continue.]`;
-									} else {
-										outputText += `\n\n[Showing lines ${startLineDisplay}-${endLineDisplay} of ${totalFileLines} (${formatSize(DEFAULT_MAX_BYTES)} limit). Use offset=${nextOffset} to continue.]`;
-									}
-									details = { truncation };
-								} else if (userLimitedLines !== undefined && startLine + userLimitedLines < allLines.length) {
-									// User specified limit, there's more content, but no truncation
-									const remaining = allLines.length - (startLine + userLimitedLines);
-									const nextOffset = startLine + userLimitedLines + 1;
-
-									outputText = truncation.content;
-									outputText += `\n\n[${remaining} more lines in file. Use offset=${nextOffset} to continue.]`;
-								} else {
-									// No truncation, no user limit exceeded
-									outputText = truncation.content;
-								}
-
-								content = [{ type: "text", text: outputText }];
-							}
-
-							// Check if aborted after reading
-							if (aborted) {
-								return;
-							}
-
-							// Clean up abort handler
-							if (signal) {
-								signal.removeEventListener("abort", onAbort);
-							}
-
-							resolve({ content, details });
-						} catch (error: any) {
-							// Clean up abort handler
-							if (signal) {
-								signal.removeEventListener("abort", onAbort);
-							}
-
-							if (!aborted) {
-								reject(error);
-							}
+						let textNote = `Read image file [${resized.mimeType}]`;
+						if (dimensionNote) {
+							textNote += `\n${dimensionNote}`;
 						}
-					})();
-				},
-			);
+
+						content = [
+							{ type: "text", text: textNote },
+							{ type: "image", data: resized.data, mimeType: resized.mimeType },
+						];
+					} else {
+						const textNote = `Read image file [${mimeType}]`;
+						content = [
+							{ type: "text", text: textNote },
+							{ type: "image", data: base64, mimeType },
+						];
+					}
+				} else {
+					// Read as text
+					const buffer = await ops.readFile(absolutePath);
+					const textContent = buffer.toString("utf-8");
+					const allLines = textContent.split("\n");
+					const totalFileLines = allLines.length;
+
+					// Apply offset if specified (1-indexed to 0-indexed)
+					const startLine = offset ? Math.max(0, offset - 1) : 0;
+					const startLineDisplay = startLine + 1; // For display (1-indexed)
+
+					// Check if offset is out of bounds
+					if (startLine >= allLines.length) {
+						throw new Error(`Offset ${offset} is beyond end of file (${allLines.length} lines total)`);
+					}
+
+					// If limit is specified by user, use it; otherwise we'll let truncateHead decide
+					let selectedContent: string;
+					let userLimitedLines: number | undefined;
+					if (limit !== undefined) {
+						const endLine = Math.min(startLine + limit, allLines.length);
+						selectedContent = allLines.slice(startLine, endLine).join("\n");
+						userLimitedLines = endLine - startLine;
+					} else {
+						selectedContent = allLines.slice(startLine).join("\n");
+					}
+
+					// Apply truncation (respects both line and byte limits)
+					const truncation = truncateHead(selectedContent);
+
+					let outputText: string;
+
+					if (truncation.firstLineExceedsLimit) {
+						// First line at offset exceeds 30KB - tell model to use bash
+						const firstLineSize = formatSize(Buffer.byteLength(allLines[startLine], "utf-8"));
+						outputText = `[Line ${startLineDisplay} is ${firstLineSize}, exceeds ${formatSize(DEFAULT_MAX_BYTES)} limit. Use bash: sed -n '${startLineDisplay}p' ${path} | head -c ${DEFAULT_MAX_BYTES}]`;
+						details = { truncation };
+					} else if (truncation.truncated) {
+						// Truncation occurred - build actionable notice
+						const endLineDisplay = startLineDisplay + truncation.outputLines - 1;
+						const nextOffset = endLineDisplay + 1;
+
+						outputText = truncation.content;
+
+						if (truncation.truncatedBy === "lines") {
+							outputText += `\n\n[Showing lines ${startLineDisplay}-${endLineDisplay} of ${totalFileLines}. Use offset=${nextOffset} to continue.]`;
+						} else {
+							outputText += `\n\n[Showing lines ${startLineDisplay}-${endLineDisplay} of ${totalFileLines} (${formatSize(DEFAULT_MAX_BYTES)} limit). Use offset=${nextOffset} to continue.]`;
+						}
+						details = { truncation };
+					} else if (userLimitedLines !== undefined && startLine + userLimitedLines < allLines.length) {
+						// User specified limit, there's more content, but no truncation
+						const remaining = allLines.length - (startLine + userLimitedLines);
+						const nextOffset = startLine + userLimitedLines + 1;
+
+						outputText = truncation.content;
+						outputText += `\n\n[${remaining} more lines in file. Use offset=${nextOffset} to continue.]`;
+					} else {
+						// No truncation, no user limit exceeded
+						outputText = truncation.content;
+					}
+
+					content = [{ type: "text", text: outputText }];
+				}
+
+				checkAborted();
+
+				return { content, details };
+			});
 		},
 	};
 }

--- a/packages/pi-coding-agent/src/core/tools/write.ts
+++ b/packages/pi-coding-agent/src/core/tools/write.ts
@@ -3,6 +3,7 @@ import { type Static, Type } from "@sinclair/typebox";
 import { mkdir as fsMkdir, writeFile as fsWriteFile } from "fs/promises";
 import { dirname } from "path";
 import { notifyFileChanged } from "../lsp/client.js";
+import { withAbortSignal } from "./abort-utils.js";
 import { resolveToCwd } from "./path-utils.js";
 
 const writeSchema = Type.Object({
@@ -50,69 +51,24 @@ export function createWriteTool(cwd: string, options?: WriteToolOptions): AgentT
 			const absolutePath = resolveToCwd(path, cwd);
 			const dir = dirname(absolutePath);
 
-			return new Promise<{ content: Array<{ type: "text"; text: string }>; details: undefined }>(
-				(resolve, reject) => {
-					// Check if already aborted
-					if (signal?.aborted) {
-						reject(new Error("Operation aborted"));
-						return;
-					}
+			return withAbortSignal(signal, async (checkAborted) => {
+				// Create parent directories if needed
+				await ops.mkdir(dir);
 
-					let aborted = false;
+				checkAborted();
 
-					// Set up abort handler
-					const onAbort = () => {
-						aborted = true;
-						reject(new Error("Operation aborted"));
-					};
+				// Write the file
+				await ops.writeFile(absolutePath, content);
 
-					if (signal) {
-						signal.addEventListener("abort", onAbort, { once: true });
-					}
+				try { notifyFileChanged(absolutePath); } catch { /* best-effort */ }
 
-					// Perform the write operation
-					(async () => {
-						try {
-							// Create parent directories if needed
-							await ops.mkdir(dir);
+				checkAborted();
 
-							// Check if aborted before writing
-							if (aborted) {
-								return;
-							}
-
-							// Write the file
-							await ops.writeFile(absolutePath, content);
-
-							try { notifyFileChanged(absolutePath); } catch { /* best-effort */ }
-
-							// Check if aborted after writing
-							if (aborted) {
-								return;
-							}
-
-							// Clean up abort handler
-							if (signal) {
-								signal.removeEventListener("abort", onAbort);
-							}
-
-							resolve({
-								content: [{ type: "text", text: `Successfully wrote ${content.length} bytes to ${path}` }],
-								details: undefined,
-							});
-						} catch (error: any) {
-							// Clean up abort handler
-							if (signal) {
-								signal.removeEventListener("abort", onAbort);
-							}
-
-							if (!aborted) {
-								reject(error);
-							}
-						}
-					})();
-				},
-			);
+				return {
+					content: [{ type: "text", text: `Successfully wrote ${content.length} bytes to ${path}` }],
+					details: undefined,
+				};
+			});
 		},
 	};
 }


### PR DESCRIPTION
## Summary
- Extracted the duplicated abort signal handling boilerplate from 8 tool files into a shared `withAbortSignal()` utility in `packages/pi-coding-agent/src/core/tools/abort-utils.ts`
- Each tool previously had ~40 lines of identical `new Promise((resolve, reject))` abort boilerplate (early check, addEventListener, `aborted` flag, cleanup in success/error paths, error swallowing after abort). This is now a single function call with a `checkAborted()` helper for mid-flight bail-out
- Net reduction of ~267 lines across the codebase with identical runtime behavior preserved

**Tools updated:** read, write, edit, find, grep, ls, hashline-read, hashline-edit  
**Excluded:** bash (its abort handling is delegated to `ops.exec` internally, not the same pattern)

## Test plan
- [ ] Verify `npx tsc --noEmit` passes (confirmed locally)
- [ ] Run existing tool unit tests to confirm no behavioral regressions
- [ ] Manually test abort scenarios (cancel a long-running read/grep) to verify signal cleanup works correctly