### PR TITLE
refactor: extract generic lazy SDK loader utility

### DIFF
--- a/packages/pi-ai/src/providers/anthropic.ts
+++ b/packages/pi-ai/src/providers/anthropic.ts
@@ -31,19 +31,13 @@ import type {
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
 import { parseStreamingJson } from "../utils/json-parse.js";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
+import { lazyImport } from "../utils/lazy-import.js";
 
 import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "./github-copilot-headers.js";
 import { adjustMaxTokensForThinking, buildBaseOptions } from "./simple-options.js";
 import { transformMessages } from "./transform-messages.js";
 
-let _AnthropicClass: typeof Anthropic | undefined;
-async function getAnthropicClass(): Promise<typeof Anthropic> {
-	if (!_AnthropicClass) {
-		const mod = await import("@anthropic-ai/sdk");
-		_AnthropicClass = mod.default;
-	}
-	return _AnthropicClass;
-}
+const getAnthropicClass = lazyImport<typeof Anthropic>("@anthropic-ai/sdk");
 
 /**
  * Resolve cache retention preference.
@@ -512,7 +506,7 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
 			if (model.provider === "alibaba-coding-plan") {
 				output.errorMessage = `[alibaba-coding-plan] ${output.errorMessage}`;
 			}
-			const AnthropicSdk = _AnthropicClass;
+			const AnthropicSdk = await getAnthropicClass().catch(() => undefined);
 			if (AnthropicSdk && error instanceof AnthropicSdk.APIError && error.headers) {
 				const retryAfterMs = extractRetryAfterMs(error.headers, error.message);
 				if (retryAfterMs !== undefined) {

--- a/packages/pi-ai/src/providers/azure-openai-responses.ts
+++ b/packages/pi-ai/src/providers/azure-openai-responses.ts
@@ -14,17 +14,11 @@ import type {
 	StreamOptions,
 } from "../types.js";
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
+import { lazyImport } from "../utils/lazy-import.js";
 import { convertResponsesMessages, convertResponsesTools, processResponsesStream } from "./openai-responses-shared.js";
 import { buildBaseOptions, clampReasoning } from "./simple-options.js";
 
-let _AzureOpenAIClass: typeof AzureOpenAI | undefined;
-async function getAzureOpenAIClass(): Promise<typeof AzureOpenAI> {
-	if (!_AzureOpenAIClass) {
-		const mod = await import("openai");
-		_AzureOpenAIClass = mod.AzureOpenAI;
-	}
-	return _AzureOpenAIClass;
-}
+const getAzureOpenAIClass = lazyImport<typeof AzureOpenAI>("openai", (mod) => mod.AzureOpenAI);
 
 /**
  * Clamp reasoning effort for models that don't support all levels.

--- a/packages/pi-ai/src/providers/google-vertex.ts
+++ b/packages/pi-ai/src/providers/google-vertex.ts
@@ -32,16 +32,13 @@ import {
 	mapToolChoice,
 	retainThoughtSignature,
 } from "./google-shared.js";
+import { lazyImport } from "../utils/lazy-import.js";
 import { buildBaseOptions, clampReasoning } from "./simple-options.js";
 
-let _GoogleVertexClass: typeof GoogleGenAI | undefined;
-async function getGoogleVertexClass(): Promise<typeof GoogleGenAI> {
-	if (!_GoogleVertexClass) {
-		const mod = await import("@google/genai");
-		_GoogleVertexClass = mod.GoogleGenAI;
-	}
-	return _GoogleVertexClass;
-}
+const getGoogleVertexClass = lazyImport<typeof GoogleGenAI>(
+	"@google/genai",
+	(mod) => mod.GoogleGenAI,
+);
 
 export interface GoogleVertexOptions extends StreamOptions {
 	toolChoice?: "auto" | "none" | "any";

--- a/packages/pi-ai/src/providers/google.ts
+++ b/packages/pi-ai/src/providers/google.ts
@@ -7,14 +7,12 @@ import type {
 	ThinkingConfig,
 } from "@google/genai";
 
-let _GoogleGenAIClass: typeof GoogleGenAI | undefined;
-async function getGoogleGenAIClass(): Promise<typeof GoogleGenAI> {
-	if (!_GoogleGenAIClass) {
-		const mod = await import("@google/genai");
-		_GoogleGenAIClass = mod.GoogleGenAI;
-	}
-	return _GoogleGenAIClass;
-}
+import { lazyImport } from "../utils/lazy-import.js";
+
+const getGoogleGenAIClass = lazyImport<typeof GoogleGenAI>(
+	"@google/genai",
+	(mod) => mod.GoogleGenAI,
+);
 import { getEnvApiKey } from "../env-api-keys.js";
 import { calculateCost } from "../models.js";
 import type {

--- a/packages/pi-ai/src/providers/mistral.ts
+++ b/packages/pi-ai/src/providers/mistral.ts
@@ -10,14 +10,12 @@ import type {
 	FunctionTool,
 } from "@mistralai/mistralai/models/components/index.js";
 
-let _MistralClass: typeof Mistral | undefined;
-async function getMistralClass(): Promise<typeof Mistral> {
-	if (!_MistralClass) {
-		const mod = await import("@mistralai/mistralai");
-		_MistralClass = mod.Mistral;
-	}
-	return _MistralClass;
-}
+import { lazyImport } from "../utils/lazy-import.js";
+
+const getMistralClass = lazyImport<typeof Mistral>(
+	"@mistralai/mistralai",
+	(mod) => mod.Mistral,
+);
 import { getEnvApiKey } from "../env-api-keys.js";
 import { calculateCost } from "../models.js";
 import type {

--- a/packages/pi-ai/src/providers/openai-completions.ts
+++ b/packages/pi-ai/src/providers/openai-completions.ts
@@ -31,18 +31,12 @@ import type {
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
 import { parseStreamingJson } from "../utils/json-parse.js";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
+import { lazyImport } from "../utils/lazy-import.js";
 import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "./github-copilot-headers.js";
 import { buildBaseOptions, clampReasoning } from "./simple-options.js";
 import { transformMessages } from "./transform-messages.js";
 
-let _OpenAICompletionsClass: typeof OpenAI | undefined;
-async function getOpenAICompletionsClass(): Promise<typeof OpenAI> {
-	if (!_OpenAICompletionsClass) {
-		const mod = await import("openai");
-		_OpenAICompletionsClass = mod.default;
-	}
-	return _OpenAICompletionsClass;
-}
+const getOpenAICompletionsClass = lazyImport<typeof OpenAI>("openai");
 
 /**
  * Check if conversation messages contain tool calls or tool results.

--- a/packages/pi-ai/src/providers/openai-responses.ts
+++ b/packages/pi-ai/src/providers/openai-responses.ts
@@ -16,18 +16,12 @@ import type {
 	Usage,
 } from "../types.js";
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
+import { lazyImport } from "../utils/lazy-import.js";
 import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "./github-copilot-headers.js";
 import { convertResponsesMessages, convertResponsesTools, processResponsesStream } from "./openai-responses-shared.js";
 import { buildBaseOptions, clampReasoning } from "./simple-options.js";
 
-let _OpenAIResponsesClass: typeof OpenAI | undefined;
-async function getOpenAIResponsesClass(): Promise<typeof OpenAI> {
-	if (!_OpenAIResponsesClass) {
-		const mod = await import("openai");
-		_OpenAIResponsesClass = mod.default;
-	}
-	return _OpenAIResponsesClass;
-}
+const getOpenAIResponsesClass = lazyImport<typeof OpenAI>("openai");
 
 /**
  * Clamp reasoning effort for models that don't support all levels.

--- a/packages/pi-ai/src/utils/lazy-import.ts
+++ b/packages/pi-ai/src/utils/lazy-import.ts
@@ -1,0 +1,40 @@
+/**
+ * Creates a lazy, cached async loader for a dynamically-imported module export.
+ *
+ * Many provider files need to defer heavy SDK imports until first use to keep
+ * startup fast.  This helper eliminates the repeated boilerplate of
+ * "cached-variable + async getter that does `await import(…)` and stores the
+ * result."
+ *
+ * @param moduleSpecifier - The module to import (e.g. `"openai"`).
+ * @param extract - Optional function that pulls the desired export out of the
+ *   module namespace.  Defaults to `(mod) => mod.default` (the default
+ *   export).
+ * @returns An async function that resolves to the extracted value, caching it
+ *   after the first call.
+ *
+ * @example
+ * ```ts
+ * import type Anthropic from "@anthropic-ai/sdk";
+ * const getAnthropic = lazyImport<typeof Anthropic>("@anthropic-ai/sdk");
+ *
+ * import type { GoogleGenAI } from "@google/genai";
+ * const getGoogleGenAI = lazyImport<typeof GoogleGenAI>(
+ *   "@google/genai",
+ *   (mod) => mod.GoogleGenAI,
+ * );
+ * ```
+ */
+export function lazyImport<T>(
+	moduleSpecifier: string,
+	extract: (mod: any) => T = (mod) => mod.default,
+): () => Promise<T> {
+	let cached: T | undefined;
+	return async () => {
+		if (!cached) {
+			const mod = await import(moduleSpecifier);
+			cached = extract(mod);
+		}
+		return cached;
+	};
+}


### PR DESCRIPTION
## Summary
- Extracts the duplicated lazy SDK loading pattern (cached variable + async getter + `await import(…)`) from 7 provider files into a single `lazyImport<T>()` utility in `packages/pi-ai/src/utils/lazy-import.ts`.
- Supports both default exports (`lazyImport<typeof X>("pkg")`) and named exports (`lazyImport<typeof X>("pkg", m => m.X)`).
- Net reduction of ~28 lines of boilerplate across providers: `anthropic`, `openai-responses`, `openai-completions`, `azure-openai-responses`, `google`, `google-vertex`, and `mistral`.

## Test plan
- [x] `npx tsc --noEmit` passes with no errors in `packages/pi-ai`
- [ ] Verify SDK lazy-loading still works at runtime (each provider loads its SDK on first call, not at import time)
- [ ] Verify Anthropic error handler still extracts `retry-after` headers from `APIError` instances