### PR TITLE
refactor: extract stop reason mapping into shared utility

### DIFF
--- a/packages/pi-ai/src/providers/amazon-bedrock.ts
+++ b/packages/pi-ai/src/providers/amazon-bedrock.ts
@@ -1,7 +1,6 @@
 import {
 	BedrockRuntimeClient,
 	type BedrockRuntimeClientConfig,
-	StopReason as BedrockStopReason,
 	type Tool as BedrockTool,
 	CachePointType,
 	CacheTTL,
@@ -28,7 +27,6 @@ import type {
 	Context,
 	Model,
 	SimpleStreamOptions,
-	StopReason,
 	StreamFunction,
 	StreamOptions,
 	TextContent,
@@ -42,6 +40,7 @@ import type {
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
 import { parseStreamingJson } from "../utils/json-parse.js";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
+import { mapBedrockStopReason } from "../utils/stop-reason.js";
 import { adjustMaxTokensForThinking, buildBaseOptions, clampReasoning } from "./simple-options.js";
 import { transformMessages } from "./transform-messages.js";
 
@@ -175,7 +174,7 @@ export const streamBedrock: StreamFunction<"bedrock-converse-stream", BedrockOpt
 				} else if (item.contentBlockStop) {
 					handleContentBlockStop(item.contentBlockStop, blocks, output, stream);
 				} else if (item.messageStop) {
-					output.stopReason = mapStopReason(item.messageStop.stopReason);
+					output.stopReason = mapBedrockStopReason(item.messageStop.stopReason);
 				} else if (item.metadata) {
 					handleMetadata(item.metadata, model, output);
 				} else if (item.internalServerException) {
@@ -661,20 +660,6 @@ function convertToolConfig(
 	return { tools: bedrockTools, toolChoice: bedrockToolChoice };
 }
 
-function mapStopReason(reason: string | undefined): StopReason {
-	switch (reason) {
-		case BedrockStopReason.END_TURN:
-		case BedrockStopReason.STOP_SEQUENCE:
-			return "stop";
-		case BedrockStopReason.MAX_TOKENS:
-		case BedrockStopReason.MODEL_CONTEXT_WINDOW_EXCEEDED:
-			return "length";
-		case BedrockStopReason.TOOL_USE:
-			return "toolUse";
-		default:
-			return "error";
-	}
-}
 
 function buildAdditionalModelRequestFields(
 	model: Model<"bedrock-converse-stream">,

--- a/packages/pi-ai/src/providers/anthropic.ts
+++ b/packages/pi-ai/src/providers/anthropic.ts
@@ -18,7 +18,6 @@ import type {
 	Model,
 	ServerToolUseContent,
 	SimpleStreamOptions,
-	StopReason,
 	StreamFunction,
 	StreamOptions,
 	TextContent,
@@ -32,6 +31,7 @@ import { AssistantMessageEventStream } from "../utils/event-stream.js";
 import { parseStreamingJson } from "../utils/json-parse.js";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
 
+import { mapAnthropicStopReason } from "../utils/stop-reason.js";
 import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "./github-copilot-headers.js";
 import { adjustMaxTokensForThinking, buildBaseOptions } from "./simple-options.js";
 import { transformMessages } from "./transform-messages.js";
@@ -472,7 +472,7 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
 					}
 				} else if (event.type === "message_delta") {
 					if (event.delta.stop_reason) {
-						output.stopReason = mapStopReason(event.delta.stop_reason);
+						output.stopReason = mapAnthropicStopReason(event.delta.stop_reason);
 					}
 					// Only update usage fields if present (not null).
 					// Preserves input_tokens from message_start when proxies omit it in message_delta.
@@ -993,24 +993,3 @@ function convertTools(tools: Tool[], isOAuthToken: boolean): Anthropic.Messages.
 	});
 }
 
-function mapStopReason(reason: Anthropic.Messages.StopReason | string): StopReason {
-	switch (reason) {
-		case "end_turn":
-			return "stop";
-		case "max_tokens":
-			return "length";
-		case "tool_use":
-			return "toolUse";
-		case "refusal":
-			return "error";
-		case "pause_turn": // Stop is good enough -> resubmit
-			return "stop";
-		case "stop_sequence":
-			return "stop"; // We don't supply stop sequences, so this should never happen
-		case "sensitive": // Content flagged by safety filters (not yet in SDK types)
-			return "error";
-		default:
-			// Handle unknown stop reasons gracefully (API may add new values)
-			throw new Error(`Unhandled stop reason: ${reason}`);
-	}
-}

--- a/packages/pi-ai/src/providers/google-shared.ts
+++ b/packages/pi-ai/src/providers/google-shared.ts
@@ -2,9 +2,10 @@
  * Shared utilities for Google Generative AI and Google Cloud Code Assist providers.
  */
 
-import { type Content, FinishReason, FunctionCallingConfigMode, type Part } from "@google/genai";
+import { type Content, FunctionCallingConfigMode, type Part } from "@google/genai";
 import type { Context, ImageContent, Model, StopReason, TextContent, Tool } from "../types.js";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
+import { mapGoogleFinishReason, mapGoogleFinishReasonString } from "../utils/stop-reason.js";
 import { transformMessages } from "./transform-messages.js";
 
 type GoogleApiType = "google-generative-ai" | "google-gemini-cli" | "google-vertex";
@@ -319,46 +320,16 @@ export function mapToolChoice(choice: string): FunctionCallingConfigMode {
 
 /**
  * Map Gemini FinishReason to our StopReason.
+ * Re-exported from the shared stop-reason utility.
  */
-export function mapStopReason(reason: FinishReason): StopReason {
-	switch (reason) {
-		case FinishReason.STOP:
-			return "stop";
-		case FinishReason.MAX_TOKENS:
-			return "length";
-		case FinishReason.BLOCKLIST:
-		case FinishReason.PROHIBITED_CONTENT:
-		case FinishReason.SPII:
-		case FinishReason.SAFETY:
-		case FinishReason.IMAGE_SAFETY:
-		case FinishReason.IMAGE_PROHIBITED_CONTENT:
-		case FinishReason.IMAGE_RECITATION:
-		case FinishReason.IMAGE_OTHER:
-		case FinishReason.RECITATION:
-		case FinishReason.FINISH_REASON_UNSPECIFIED:
-		case FinishReason.OTHER:
-		case FinishReason.LANGUAGE:
-		case FinishReason.MALFORMED_FUNCTION_CALL:
-		case FinishReason.UNEXPECTED_TOOL_CALL:
-		case FinishReason.NO_IMAGE:
-			return "error";
-		default: {
-			const _exhaustive: never = reason;
-			throw new Error(`Unhandled stop reason: ${_exhaustive}`);
-		}
-	}
+export function mapStopReason(reason: string): StopReason {
+	return mapGoogleFinishReason(reason);
 }
 
 /**
  * Map string finish reason to our StopReason (for raw API responses).
+ * Re-exported from the shared stop-reason utility.
  */
 export function mapStopReasonString(reason: string): StopReason {
-	switch (reason) {
-		case "STOP":
-			return "stop";
-		case "MAX_TOKENS":
-			return "length";
-		default:
-			return "error";
-	}
+	return mapGoogleFinishReasonString(reason);
 }

--- a/packages/pi-ai/src/providers/mistral.ts
+++ b/packages/pi-ai/src/providers/mistral.ts
@@ -26,7 +26,6 @@ import type {
 	Message,
 	Model,
 	SimpleStreamOptions,
-	StopReason,
 	StreamFunction,
 	StreamOptions,
 	TextContent,
@@ -38,6 +37,7 @@ import { AssistantMessageEventStream } from "../utils/event-stream.js";
 import { shortHash } from "../utils/hash.js";
 import { parseStreamingJson } from "../utils/json-parse.js";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
+import { mapMistralStopReason } from "../utils/stop-reason.js";
 import { buildBaseOptions, clampReasoning } from "./simple-options.js";
 import { transformMessages } from "./transform-messages.js";
 
@@ -311,7 +311,7 @@ async function consumeChatStream(
 		if (!choice) continue;
 
 		if (choice.finishReason) {
-			output.stopReason = mapChatStopReason(choice.finishReason);
+			output.stopReason = mapMistralStopReason(choice.finishReason);
 		}
 
 		const delta = choice.delta;
@@ -579,19 +579,3 @@ function mapToolChoice(
 	};
 }
 
-function mapChatStopReason(reason: string | null): StopReason {
-	if (reason === null) return "stop";
-	switch (reason) {
-		case "stop":
-			return "stop";
-		case "length":
-		case "model_length":
-			return "length";
-		case "tool_calls":
-			return "toolUse";
-		case "error":
-			return "error";
-		default:
-			return "stop";
-	}
-}

--- a/packages/pi-ai/src/providers/openai-completions.ts
+++ b/packages/pi-ai/src/providers/openai-completions.ts
@@ -19,7 +19,6 @@ import type {
 	Model,
 	OpenAICompletionsCompat,
 	SimpleStreamOptions,
-	StopReason,
 	StreamFunction,
 	StreamOptions,
 	TextContent,
@@ -31,6 +30,7 @@ import type {
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
 import { parseStreamingJson } from "../utils/json-parse.js";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
+import { mapOpenAICompletionsStopReason } from "../utils/stop-reason.js";
 import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "./github-copilot-headers.js";
 import { buildBaseOptions, clampReasoning } from "./simple-options.js";
 import { transformMessages } from "./transform-messages.js";
@@ -167,7 +167,7 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions", OpenA
 				if (!choice) continue;
 
 				if (choice.finish_reason) {
-					output.stopReason = mapStopReason(choice.finish_reason);
+					output.stopReason = mapOpenAICompletionsStopReason(choice.finish_reason);
 				}
 
 				if (choice.delta) {
@@ -735,27 +735,6 @@ function convertTools(
 	}));
 }
 
-function mapStopReason(reason: ChatCompletionChunk.Choice["finish_reason"]): StopReason {
-	if (reason === null) return "stop";
-	switch (reason) {
-		case "stop":
-			return "stop";
-		case "length":
-			return "length";
-		case "function_call":
-		case "tool_calls":
-			return "toolUse";
-		case "content_filter":
-			return "error";
-		default:
-			// Third-party and community models (e.g. Qwen GGUF quants) may emit
-			// non-standard finish_reason values like "eos_token", "eos", or
-			// "end_of_turn". The OpenAI spec defines finish_reason as a string,
-			// so we treat unrecognized values as a normal stop rather than
-			// throwing — which would abort in-flight tool calls (#863).
-			return "stop";
-	}
-}
 
 /**
  * Detect compatibility settings from provider and baseUrl for known providers.

--- a/packages/pi-ai/src/providers/openai-responses-shared.ts
+++ b/packages/pi-ai/src/providers/openai-responses-shared.ts
@@ -18,7 +18,6 @@ import type {
 	Context,
 	ImageContent,
 	Model,
-	StopReason,
 	TextContent,
 	TextSignatureV1,
 	ThinkingContent,
@@ -30,6 +29,7 @@ import type { AssistantMessageEventStream } from "../utils/event-stream.js";
 import { shortHash } from "../utils/hash.js";
 import { parseStreamingJson } from "../utils/json-parse.js";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
+import { mapOpenAIResponsesStopReason } from "../utils/stop-reason.js";
 import { transformMessages } from "./transform-messages.js";
 
 // =============================================================================
@@ -462,7 +462,7 @@ export async function processResponsesStream<TApi extends Api>(
 				options.applyServiceTierPricing(output.usage, serviceTier);
 			}
 			// Map status to stop reason
-			output.stopReason = mapStopReason(response?.status);
+			output.stopReason = mapOpenAIResponsesStopReason(response?.status);
 			if (output.content.some((b) => b.type === "toolCall") && output.stopReason === "stop") {
 				output.stopReason = "toolUse";
 			}
@@ -474,23 +474,3 @@ export async function processResponsesStream<TApi extends Api>(
 	}
 }
 
-function mapStopReason(status: OpenAI.Responses.ResponseStatus | undefined): StopReason {
-	if (!status) return "stop";
-	switch (status) {
-		case "completed":
-			return "stop";
-		case "incomplete":
-			return "length";
-		case "failed":
-		case "cancelled":
-			return "error";
-		// These two are wonky ...
-		case "in_progress":
-		case "queued":
-			return "stop";
-		default: {
-			const _exhaustive: never = status;
-			throw new Error(`Unhandled stop reason: ${_exhaustive}`);
-		}
-	}
-}

--- a/packages/pi-ai/src/utils/stop-reason.ts
+++ b/packages/pi-ai/src/utils/stop-reason.ts
@@ -1,0 +1,154 @@
+/**
+ * Shared utility for mapping provider-specific stop/finish reasons to the unified StopReason type.
+ *
+ * Each provider maps its own string values (e.g., "end_turn", "STOP", "completed") to the
+ * unified StopReason. This factory eliminates duplicated switch statements across providers.
+ */
+import type { StopReason } from "../types.js";
+
+/**
+ * Create a stop reason mapper from a record of provider-specific reason strings to unified StopReason values.
+ *
+ * @param mapping - Record mapping provider reason strings to StopReason values.
+ * @param options.nullValue - StopReason to return for null/undefined input. Defaults to "stop".
+ * @param options.defaultValue - StopReason for unrecognized reasons. Defaults to "stop".
+ *   Set to "throw" to throw an Error for unrecognized reasons (useful for exhaustive enums).
+ */
+export function createStopReasonMapper(
+	mapping: Readonly<Record<string, StopReason>>,
+	options?: { nullValue?: StopReason; defaultValue?: StopReason | "throw" },
+): (reason: string | null | undefined) => StopReason {
+	const nullValue = options?.nullValue ?? "stop";
+	const defaultValue = options?.defaultValue ?? "stop";
+
+	return (reason: string | null | undefined): StopReason => {
+		if (reason == null) return nullValue;
+		const mapped = mapping[reason];
+		if (mapped !== undefined) return mapped;
+		if (defaultValue === "throw") {
+			throw new Error(`Unhandled stop reason: ${reason}`);
+		}
+		return defaultValue;
+	};
+}
+
+// =============================================================================
+// Pre-built mappers for each provider API
+// =============================================================================
+
+/**
+ * Anthropic Messages API stop reasons.
+ * Throws on unrecognized reasons since the API should only return known values.
+ */
+export const mapAnthropicStopReason = createStopReasonMapper(
+	{
+		end_turn: "stop",
+		max_tokens: "length",
+		tool_use: "toolUse",
+		refusal: "error",
+		pause_turn: "stop", // resubmit
+		stop_sequence: "stop",
+		sensitive: "error", // content flagged by safety filters
+	},
+	{ defaultValue: "throw" },
+);
+
+/**
+ * OpenAI Chat Completions API finish reasons.
+ * Returns "stop" for unrecognized reasons (community models may emit non-standard values like "eos_token").
+ */
+export const mapOpenAICompletionsStopReason = createStopReasonMapper(
+	{
+		stop: "stop",
+		length: "length",
+		function_call: "toolUse",
+		tool_calls: "toolUse",
+		content_filter: "error",
+	},
+	{ nullValue: "stop", defaultValue: "stop" },
+);
+
+/**
+ * OpenAI Responses API status values.
+ * Throws on unrecognized status since the API defines an exhaustive enum.
+ */
+export const mapOpenAIResponsesStopReason = createStopReasonMapper(
+	{
+		completed: "stop",
+		incomplete: "length",
+		failed: "error",
+		cancelled: "error",
+		in_progress: "stop",
+		queued: "stop",
+	},
+	{ nullValue: "stop", defaultValue: "throw" },
+);
+
+/**
+ * Google Gemini / Vertex AI FinishReason enum values.
+ * Throws on unrecognized reasons to catch new enum members.
+ */
+export const mapGoogleFinishReason = createStopReasonMapper(
+	{
+		STOP: "stop",
+		MAX_TOKENS: "length",
+		BLOCKLIST: "error",
+		PROHIBITED_CONTENT: "error",
+		SPII: "error",
+		SAFETY: "error",
+		IMAGE_SAFETY: "error",
+		IMAGE_PROHIBITED_CONTENT: "error",
+		IMAGE_RECITATION: "error",
+		IMAGE_OTHER: "error",
+		RECITATION: "error",
+		FINISH_REASON_UNSPECIFIED: "error",
+		OTHER: "error",
+		LANGUAGE: "error",
+		MALFORMED_FUNCTION_CALL: "error",
+		UNEXPECTED_TOOL_CALL: "error",
+		NO_IMAGE: "error",
+	},
+	{ defaultValue: "throw" },
+);
+
+/**
+ * Google Gemini CLI raw string finish reasons (from REST API responses).
+ * Returns "error" for unrecognized reasons.
+ */
+export const mapGoogleFinishReasonString = createStopReasonMapper(
+	{
+		STOP: "stop",
+		MAX_TOKENS: "length",
+	},
+	{ defaultValue: "error" },
+);
+
+/**
+ * Mistral chat finish reasons.
+ * Returns "stop" for unrecognized reasons.
+ */
+export const mapMistralStopReason = createStopReasonMapper(
+	{
+		stop: "stop",
+		length: "length",
+		model_length: "length",
+		tool_calls: "toolUse",
+		error: "error",
+	},
+	{ nullValue: "stop", defaultValue: "stop" },
+);
+
+/**
+ * Amazon Bedrock Converse API stop reasons.
+ * Returns "error" for unrecognized reasons.
+ */
+export const mapBedrockStopReason = createStopReasonMapper(
+	{
+		end_turn: "stop",
+		stop_sequence: "stop",
+		max_tokens: "length",
+		model_context_window_exceeded: "length",
+		tool_use: "toolUse",
+	},
+	{ nullValue: "error", defaultValue: "error" },
+);


### PR DESCRIPTION
## Summary
- Created `packages/pi-ai/src/utils/stop-reason.ts` with a `createStopReasonMapper` factory function and pre-built mapper instances for all 6 provider API flavors (Anthropic, OpenAI Completions, OpenAI Responses, Google Gemini, Mistral, Amazon Bedrock).
- Replaced duplicated `mapStopReason` / `mapChatStopReason` switch statements in 6 provider files with calls to the shared mappers, eliminating ~80 lines of duplicated mapping logic.
- The factory accepts a record of `{ providerReason: StopReason }` plus configurable null/default handling, making it easy to add new providers or extend existing mappings.

## Files changed
- **New**: `packages/pi-ai/src/utils/stop-reason.ts` -- factory + 7 pre-built mappers
- **Modified**: `anthropic.ts`, `openai-completions.ts`, `openai-responses-shared.ts`, `google-shared.ts`, `mistral.ts`, `amazon-bedrock.ts` -- removed local mapStopReason functions, import shared mappers instead

## Test plan
- [x] `npx tsc --noEmit` passes with no errors
- [ ] Verify existing provider tests still pass (stop reason mapping behavior is identical)