### PR TITLE
fix: check project root .env when secrets gate runs in worktree (#1387)

### DIFF
--- a/src/resources/extensions/gsd/auto-loop.ts
+++ b/src/resources/extensions/gsd/auto-loop.ts
@@ -344,6 +344,7 @@ export interface LoopDeps {
   getManifestStatus: (
     basePath: string,
     mid: string | undefined,
+    projectRoot?: string,
   ) => Promise<{ pending: unknown[] } | null>;
   collectSecretsFromManifest: (
     basePath: string,
@@ -983,7 +984,7 @@ export async function autoLoop(
 
       // Secrets re-check gate
       try {
-        const manifestStatus = await deps.getManifestStatus(s.basePath, mid);
+        const manifestStatus = await deps.getManifestStatus(s.basePath, mid, s.originalBasePath);
         if (manifestStatus && manifestStatus.pending.length > 0) {
           const result = await deps.collectSecretsFromManifest(
             s.basePath,

--- a/src/resources/extensions/gsd/auto-start.ts
+++ b/src/resources/extensions/gsd/auto-start.ts
@@ -484,7 +484,7 @@ export async function bootstrapAutoSession(
     // Secrets collection gate
     const mid = state.activeMilestone!.id;
     try {
-      const manifestStatus = await getManifestStatus(base, mid);
+      const manifestStatus = await getManifestStatus(base, mid, s.originalBasePath || base);
       if (manifestStatus && manifestStatus.pending.length > 0) {
         const result = await collectSecretsFromManifest(base, mid, ctx);
         if (

--- a/src/resources/extensions/gsd/files.ts
+++ b/src/resources/extensions/gsd/files.ts
@@ -805,7 +805,7 @@ export async function inlinePriorMilestoneSummary(mid: string, base: string): Pr
  * file not on disk) - callers can distinguish "no manifest" from "empty manifest".
  */
 export async function getManifestStatus(
-  base: string, milestoneId: string,
+  base: string, milestoneId: string, projectRoot?: string,
 ): Promise<ManifestStatus | null> {
   const resolvedPath = resolveMilestoneFile(base, milestoneId, 'SECRETS');
   if (!resolvedPath) return null;
@@ -815,8 +815,17 @@ export async function getManifestStatus(
 
   const manifest = parseSecretsManifest(content);
   const keys = manifest.entries.map(e => e.key);
+
+  // Check both the base path .env AND the project root .env (#1387).
+  // In worktree mode, base is the worktree path which may not have .env.
+  // The project root's .env is where the user actually defined their keys.
   const existingKeys = await checkExistingEnvKeys(keys, resolve(base, '.env'));
   const existingSet = new Set(existingKeys);
+
+  if (projectRoot && projectRoot !== base) {
+    const rootKeys = await checkExistingEnvKeys(keys, resolve(projectRoot, '.env'));
+    for (const k of rootKeys) existingSet.add(k);
+  }
 
   const result: ManifestStatus = {
     pending: [],


### PR DESCRIPTION
## Problem

In worktree isolation mode, the secrets gate checked for `.env` at the worktree path only. The user's `.env` lives at the project root. Keys that existed were reported as missing, causing repeated blocking key collection prompts overnight.

Root cause confirmed by @AriaShishegaran: no secrets manifest existed, keys were in the project root `.env`, but the worktree checkout had its own filesystem tree where `.env` wasn't present.

## Fix

`getManifestStatus()` now accepts an optional `projectRoot` parameter. When in worktree mode, it checks both the worktree `.env` AND the project root `.env`. All callers pass `s.originalBasePath`.

## Test Results

1844 pass, 0 fail, 3 skipped.

Fixes #1387