### PR TITLE
refactor: extract shared stream handler from providers

### DIFF
--- a/packages/pi-ai/src/index.ts
+++ b/packages/pi-ai/src/index.ts
@@ -17,6 +17,7 @@ export * from "./stream.js";
 export * from "./types.js";
 export * from "./utils/event-stream.js";
 export * from "./utils/json-parse.js";
+export * from "./utils/stream-handler.js";
 export type {
 	OAuthAuthInfo,
 	OAuthCredentials,

--- a/packages/pi-ai/src/providers/amazon-bedrock.ts
+++ b/packages/pi-ai/src/providers/amazon-bedrock.ts
@@ -22,7 +22,6 @@ import {
 
 import { calculateCost } from "../models.js";
 import type {
-	Api,
 	AssistantMessage,
 	CacheRetention,
 	Context,
@@ -42,6 +41,7 @@ import type {
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
 import { parseStreamingJson } from "../utils/json-parse.js";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
+import { createProviderStream } from "../utils/stream-handler.js";
 import { adjustMaxTokensForThinking, buildBaseOptions, clampReasoning } from "./simple-options.js";
 import { transformMessages } from "./transform-messages.js";
 
@@ -63,28 +63,8 @@ export const streamBedrock: StreamFunction<"bedrock-converse-stream", BedrockOpt
 	model: Model<"bedrock-converse-stream">,
 	context: Context,
 	options: BedrockOptions = {},
-): AssistantMessageEventStream => {
-	const stream = new AssistantMessageEventStream();
-
-	(async () => {
-		const output: AssistantMessage = {
-			role: "assistant",
-			content: [],
-			api: "bedrock-converse-stream" as Api,
-			provider: model.provider,
-			model: model.id,
-			usage: {
-				input: 0,
-				output: 0,
-				cacheRead: 0,
-				cacheWrite: 0,
-				totalTokens: 0,
-				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-			},
-			stopReason: "stop",
-			timestamp: Date.now(),
-		};
-
+): AssistantMessageEventStream =>
+	createProviderStream(model, options, async (output, stream) => {
 		const blocks = output.content as Block[];
 
 		const config: BedrockRuntimeClientConfig = {
@@ -142,79 +122,54 @@ export const streamBedrock: StreamFunction<"bedrock-converse-stream", BedrockOpt
 			config.region = options.region || "us-east-1";
 		}
 
-		try {
-			const client = new BedrockRuntimeClient(config);
+		const client = new BedrockRuntimeClient(config);
 
-			const cacheRetention = resolveCacheRetention(options.cacheRetention);
-			let commandInput = {
-				modelId: model.id,
-				messages: convertMessages(context, model, cacheRetention),
-				system: buildSystemPrompt(context.systemPrompt, model, cacheRetention),
-				inferenceConfig: { maxTokens: options.maxTokens, temperature: options.temperature },
-				toolConfig: convertToolConfig(context.tools, options.toolChoice),
-				additionalModelRequestFields: buildAdditionalModelRequestFields(model, options),
-			};
-			const nextCommandInput = await options?.onPayload?.(commandInput, model);
-			if (nextCommandInput !== undefined) {
-				commandInput = nextCommandInput as typeof commandInput;
-			}
-			const command = new ConverseStreamCommand(commandInput);
-
-			const response = await client.send(command, { abortSignal: options.signal });
-
-			for await (const item of response.stream!) {
-				if (item.messageStart) {
-					if (item.messageStart.role !== ConversationRole.ASSISTANT) {
-						throw new Error("Unexpected assistant message start but got user message start instead");
-					}
-					stream.push({ type: "start", partial: output });
-				} else if (item.contentBlockStart) {
-					handleContentBlockStart(item.contentBlockStart, blocks, output, stream);
-				} else if (item.contentBlockDelta) {
-					handleContentBlockDelta(item.contentBlockDelta, blocks, output, stream);
-				} else if (item.contentBlockStop) {
-					handleContentBlockStop(item.contentBlockStop, blocks, output, stream);
-				} else if (item.messageStop) {
-					output.stopReason = mapStopReason(item.messageStop.stopReason);
-				} else if (item.metadata) {
-					handleMetadata(item.metadata, model, output);
-				} else if (item.internalServerException) {
-					throw new Error(`Internal server error: ${item.internalServerException.message}`);
-				} else if (item.modelStreamErrorException) {
-					throw new Error(`Model stream error: ${item.modelStreamErrorException.message}`);
-				} else if (item.validationException) {
-					throw new Error(`Validation error: ${item.validationException.message}`);
-				} else if (item.throttlingException) {
-					throw new Error(`Throttling error: ${item.throttlingException.message}`);
-				} else if (item.serviceUnavailableException) {
-					throw new Error(`Service unavailable: ${item.serviceUnavailableException.message}`);
-				}
-			}
-
-			if (options.signal?.aborted) {
-				throw new Error("Request was aborted");
-			}
-
-			if (output.stopReason === "error" || output.stopReason === "aborted") {
-				throw new Error("An unknown error occurred");
-			}
-
-			stream.push({ type: "done", reason: output.stopReason, message: output });
-			stream.end();
-		} catch (error) {
-			for (const block of output.content) {
-				delete (block as Block).index;
-				delete (block as Block).partialJson;
-			}
-			output.stopReason = options.signal?.aborted ? "aborted" : "error";
-			output.errorMessage = error instanceof Error ? error.message : JSON.stringify(error);
-			stream.push({ type: "error", reason: output.stopReason, error: output });
-			stream.end();
+		const cacheRetention = resolveCacheRetention(options.cacheRetention);
+		let commandInput = {
+			modelId: model.id,
+			messages: convertMessages(context, model, cacheRetention),
+			system: buildSystemPrompt(context.systemPrompt, model, cacheRetention),
+			inferenceConfig: { maxTokens: options.maxTokens, temperature: options.temperature },
+			toolConfig: convertToolConfig(context.tools, options.toolChoice),
+			additionalModelRequestFields: buildAdditionalModelRequestFields(model, options),
+		};
+		const nextCommandInput = await options?.onPayload?.(commandInput, model);
+		if (nextCommandInput !== undefined) {
+			commandInput = nextCommandInput as typeof commandInput;
 		}
-	})();
+		const command = new ConverseStreamCommand(commandInput);
 
-	return stream;
-};
+		const response = await client.send(command, { abortSignal: options.signal });
+
+		for await (const item of response.stream!) {
+			if (item.messageStart) {
+				if (item.messageStart.role !== ConversationRole.ASSISTANT) {
+					throw new Error("Unexpected assistant message start but got user message start instead");
+				}
+				stream.push({ type: "start", partial: output });
+			} else if (item.contentBlockStart) {
+				handleContentBlockStart(item.contentBlockStart, blocks, output, stream);
+			} else if (item.contentBlockDelta) {
+				handleContentBlockDelta(item.contentBlockDelta, blocks, output, stream);
+			} else if (item.contentBlockStop) {
+				handleContentBlockStop(item.contentBlockStop, blocks, output, stream);
+			} else if (item.messageStop) {
+				output.stopReason = mapStopReason(item.messageStop.stopReason);
+			} else if (item.metadata) {
+				handleMetadata(item.metadata, model, output);
+			} else if (item.internalServerException) {
+				throw new Error(`Internal server error: ${item.internalServerException.message}`);
+			} else if (item.modelStreamErrorException) {
+				throw new Error(`Model stream error: ${item.modelStreamErrorException.message}`);
+			} else if (item.validationException) {
+				throw new Error(`Validation error: ${item.validationException.message}`);
+			} else if (item.throttlingException) {
+				throw new Error(`Throttling error: ${item.throttlingException.message}`);
+			} else if (item.serviceUnavailableException) {
+				throw new Error(`Service unavailable: ${item.serviceUnavailableException.message}`);
+			}
+		}
+	});
 
 export const streamSimpleBedrock: StreamFunction<"bedrock-converse-stream", SimpleStreamOptions> = (
 	model: Model<"bedrock-converse-stream">,

--- a/packages/pi-ai/src/providers/anthropic.ts
+++ b/packages/pi-ai/src/providers/anthropic.ts
@@ -9,8 +9,6 @@ import type {
 import { getEnvApiKey } from "../env-api-keys.js";
 import { calculateCost } from "../models.js";
 import type {
-	Api,
-	AssistantMessage,
 	CacheRetention,
 	Context,
 	ImageContent,
@@ -31,6 +29,7 @@ import type {
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
 import { parseStreamingJson } from "../utils/json-parse.js";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
+import { createProviderStream } from "../utils/stream-handler.js";
 
 import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "./github-copilot-headers.js";
 import { adjustMaxTokensForThinking, buildBaseOptions } from "./simple-options.js";
@@ -266,29 +265,11 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
 	model: Model<"anthropic-messages">,
 	context: Context,
 	options?: AnthropicOptions,
-): AssistantMessageEventStream => {
-	const stream = new AssistantMessageEventStream();
-
-	(async () => {
-		const output: AssistantMessage = {
-			role: "assistant",
-			content: [],
-			api: model.api as Api,
-			provider: model.provider,
-			model: model.id,
-			usage: {
-				input: 0,
-				output: 0,
-				cacheRead: 0,
-				cacheWrite: 0,
-				totalTokens: 0,
-				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-			},
-			stopReason: "stop",
-			timestamp: Date.now(),
-		};
-
-		try {
+): AssistantMessageEventStream =>
+	createProviderStream(
+		model,
+		options,
+		async (output, stream) => {
 			const apiKey = options?.apiKey ?? getEnvApiKey(model.provider) ?? "";
 
 			let copilotDynamicHeaders: Record<string, string> | undefined;
@@ -494,43 +475,27 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
 					calculateCost(model, output.usage);
 				}
 			}
-
-			if (options?.signal?.aborted) {
-				throw new Error("Request was aborted");
-			}
-
-			if (output.stopReason === "aborted" || output.stopReason === "error") {
-				throw new Error("An unknown error occurred");
-			}
-
-			stream.push({ type: "done", reason: output.stopReason, message: output });
-			stream.end();
-		} catch (error) {
-			for (const block of output.content) delete (block as any).index;
-			output.stopReason = options?.signal?.aborted ? "aborted" : "error";
-			output.errorMessage = error instanceof Error ? error.message : JSON.stringify(error);
-			if (model.provider === "alibaba-coding-plan") {
-				output.errorMessage = `[alibaba-coding-plan] ${output.errorMessage}`;
-			}
-			const AnthropicSdk = _AnthropicClass;
-			if (AnthropicSdk && error instanceof AnthropicSdk.APIError && error.headers) {
-				const retryAfterMs = extractRetryAfterMs(error.headers, error.message);
-				if (retryAfterMs !== undefined) {
-					output.retryAfterMs = retryAfterMs;
+		},
+		{
+			onError: (error, output) => {
+				if (model.provider === "alibaba-coding-plan") {
+					output.errorMessage = `[alibaba-coding-plan] ${output.errorMessage}`;
 				}
-			}
-			// Mark transient network errors as retriable so auto-mode can
-			// detect them and retry instead of stopping (#833).
-			if (isTransientNetworkError(error)) {
-				output.retryAfterMs = output.retryAfterMs ?? 5000;
-			}
-			stream.push({ type: "error", reason: output.stopReason, error: output });
-			stream.end();
-		}
-	})();
-
-	return stream;
-};
+				const AnthropicSdk = _AnthropicClass;
+				if (AnthropicSdk && error instanceof AnthropicSdk.APIError && error.headers) {
+					const retryAfterMs = extractRetryAfterMs(error.headers, error.message);
+					if (retryAfterMs !== undefined) {
+						output.retryAfterMs = retryAfterMs;
+					}
+				}
+				// Mark transient network errors as retriable so auto-mode can
+				// detect them and retry instead of stopping (#833).
+				if (isTransientNetworkError(error)) {
+					output.retryAfterMs = output.retryAfterMs ?? 5000;
+				}
+			},
+		},
+	);
 
 /**
  * Check if a model supports adaptive thinking (Opus 4.6 and Sonnet 4.6)

--- a/packages/pi-ai/src/providers/azure-openai-responses.ts
+++ b/packages/pi-ai/src/providers/azure-openai-responses.ts
@@ -5,8 +5,6 @@ import type { ResponseCreateParamsStreaming } from "openai/resources/responses/r
 import { getEnvApiKey } from "../env-api-keys.js";
 import { supportsXhigh } from "../models.js";
 import type {
-	Api,
-	AssistantMessage,
 	Context,
 	Model,
 	SimpleStreamOptions,
@@ -14,6 +12,7 @@ import type {
 	StreamOptions,
 } from "../types.js";
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
+import { createProviderStream } from "../utils/stream-handler.js";
 import { convertResponsesMessages, convertResponsesTools, processResponsesStream } from "./openai-responses-shared.js";
 import { buildBaseOptions, clampReasoning } from "./simple-options.js";
 
@@ -77,69 +76,26 @@ export const streamAzureOpenAIResponses: StreamFunction<"azure-openai-responses"
 	model: Model<"azure-openai-responses">,
 	context: Context,
 	options?: AzureOpenAIResponsesOptions,
-): AssistantMessageEventStream => {
-	const stream = new AssistantMessageEventStream();
-
-	// Start async processing
-	(async () => {
+): AssistantMessageEventStream =>
+	createProviderStream(model, options, async (output, stream) => {
 		const deploymentName = resolveDeploymentName(model, options);
 
-		const output: AssistantMessage = {
-			role: "assistant",
-			content: [],
-			api: "azure-openai-responses" as Api,
-			provider: model.provider,
-			model: model.id,
-			usage: {
-				input: 0,
-				output: 0,
-				cacheRead: 0,
-				cacheWrite: 0,
-				totalTokens: 0,
-				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-			},
-			stopReason: "stop",
-			timestamp: Date.now(),
-		};
-
-		try {
-			// Create Azure OpenAI client
-			const apiKey = options?.apiKey || getEnvApiKey(model.provider) || "";
-			const client = await createClient(model, apiKey, options);
-			let params = buildParams(model, context, options, deploymentName);
-			const nextParams = await options?.onPayload?.(params, model);
-			if (nextParams !== undefined) {
-				params = nextParams as ResponseCreateParamsStreaming;
-			}
-			const openaiStream = await client.responses.create(
-				params,
-				options?.signal ? { signal: options.signal } : undefined,
-			);
-			stream.push({ type: "start", partial: output });
-
-			await processResponsesStream(openaiStream, output, stream, model);
-
-			if (options?.signal?.aborted) {
-				throw new Error("Request was aborted");
-			}
-
-			if (output.stopReason === "aborted" || output.stopReason === "error") {
-				throw new Error("An unknown error occurred");
-			}
-
-			stream.push({ type: "done", reason: output.stopReason, message: output });
-			stream.end();
-		} catch (error) {
-			for (const block of output.content) delete (block as { index?: number }).index;
-			output.stopReason = options?.signal?.aborted ? "aborted" : "error";
-			output.errorMessage = error instanceof Error ? error.message : JSON.stringify(error);
-			stream.push({ type: "error", reason: output.stopReason, error: output });
-			stream.end();
+		// Create Azure OpenAI client
+		const apiKey = options?.apiKey || getEnvApiKey(model.provider) || "";
+		const client = await createClient(model, apiKey, options);
+		let params = buildParams(model, context, options, deploymentName);
+		const nextParams = await options?.onPayload?.(params, model);
+		if (nextParams !== undefined) {
+			params = nextParams as ResponseCreateParamsStreaming;
 		}
-	})();
+		const openaiStream = await client.responses.create(
+			params,
+			options?.signal ? { signal: options.signal } : undefined,
+		);
+		stream.push({ type: "start", partial: output });
 
-	return stream;
-};
+		await processResponsesStream(openaiStream, output, stream, model);
+	});
 
 export const streamSimpleAzureOpenAIResponses: StreamFunction<"azure-openai-responses", SimpleStreamOptions> = (
 	model: Model<"azure-openai-responses">,

--- a/packages/pi-ai/src/providers/google-gemini-cli.ts
+++ b/packages/pi-ai/src/providers/google-gemini-cli.ts
@@ -7,8 +7,6 @@
 import type { Content, ThinkingConfig } from "@google/genai";
 import { calculateCost } from "../models.js";
 import type {
-	Api,
-	AssistantMessage,
 	Context,
 	Model,
 	SimpleStreamOptions,
@@ -22,6 +20,7 @@ import type {
 } from "../types.js";
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
+import { createProviderStream } from "../utils/stream-handler.js";
 import {
 	convertMessages,
 	convertTools,
@@ -321,320 +320,237 @@ export const streamGoogleGeminiCli: StreamFunction<"google-gemini-cli", GoogleGe
 	model: Model<"google-gemini-cli">,
 	context: Context,
 	options?: GoogleGeminiCliOptions,
-): AssistantMessageEventStream => {
-	const stream = new AssistantMessageEventStream();
+): AssistantMessageEventStream =>
+	createProviderStream(model, options, async (output, stream) => {
+		// apiKey is JSON-encoded: { token, projectId }
+		const apiKeyRaw = options?.apiKey;
+		if (!apiKeyRaw) {
+			throw new Error("Google Cloud Code Assist requires OAuth authentication. Use /login to authenticate.");
+		}
 
-	(async () => {
-		const output: AssistantMessage = {
-			role: "assistant",
-			content: [],
-			api: "google-gemini-cli" as Api,
-			provider: model.provider,
-			model: model.id,
-			usage: {
+		let accessToken: string;
+		let projectId: string;
+
+		try {
+			const parsed = JSON.parse(apiKeyRaw) as { token: string; projectId: string };
+			accessToken = parsed.token;
+			projectId = parsed.projectId;
+		} catch {
+			throw new Error("Invalid Google Cloud Code Assist credentials. Use /login to re-authenticate.");
+		}
+
+		if (!accessToken || !projectId) {
+			throw new Error("Missing token or projectId in Google Cloud credentials. Use /login to re-authenticate.");
+		}
+
+		const isAntigravity = model.provider === "google-antigravity";
+		const baseUrl = model.baseUrl?.trim();
+		const endpoints = baseUrl ? [baseUrl] : isAntigravity ? ANTIGRAVITY_ENDPOINT_FALLBACKS : [DEFAULT_ENDPOINT];
+
+		let requestBody = buildRequest(model, context, projectId, options, isAntigravity);
+		const nextRequestBody = await options?.onPayload?.(requestBody, model);
+		if (nextRequestBody !== undefined) {
+			requestBody = nextRequestBody as CloudCodeAssistRequest;
+		}
+		const headers = isAntigravity ? getAntigravityHeaders() : GEMINI_CLI_HEADERS;
+
+		const requestHeaders = {
+			Authorization: `Bearer ${accessToken}`,
+			"Content-Type": "application/json",
+			Accept: "text/event-stream",
+			...headers,
+			...(needsClaudeThinkingBetaHeader(model) ? { "anthropic-beta": CLAUDE_THINKING_BETA_HEADER } : {}),
+			...options?.headers,
+		};
+		const requestBodyJson = JSON.stringify(requestBody);
+
+		// Fetch with retry logic for rate limits, transient errors, and endpoint fallbacks.
+		// On 403/404, immediately try the next endpoint (no delay).
+		// On 429/5xx, retry with backoff on the same or next endpoint.
+		let response: Response | undefined;
+		let lastError: Error | undefined;
+		let requestUrl: string | undefined;
+		let endpointIndex = 0;
+
+		for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+			if (options?.signal?.aborted) {
+				throw new Error("Request was aborted");
+			}
+
+			try {
+				const endpoint = endpoints[endpointIndex];
+				requestUrl = `${endpoint}/v1internal:streamGenerateContent?alt=sse`;
+				response = await fetch(requestUrl, {
+					method: "POST",
+					headers: requestHeaders,
+					body: requestBodyJson,
+					signal: options?.signal,
+				});
+
+				if (response.ok) {
+					break; // Success, exit retry loop
+				}
+
+				const errorText = await response.text();
+
+				// On 403/404, cascade to the next endpoint immediately (no delay)
+				if ((response.status === 403 || response.status === 404) && endpointIndex < endpoints.length - 1) {
+					endpointIndex++;
+					continue;
+				}
+
+				// Check if retryable (429, 5xx, network patterns)
+				if (attempt < MAX_RETRIES && isRetryableError(response.status, errorText)) {
+					// Advance endpoint if possible
+					if (endpointIndex < endpoints.length - 1) {
+						endpointIndex++;
+					}
+
+					// Use server-provided delay or exponential backoff
+					const serverDelay = extractRetryDelay(errorText, response);
+					const delayMs = serverDelay ?? BASE_DELAY_MS * 2 ** attempt;
+
+					// Check if server delay exceeds max allowed (default: 60s)
+					const maxDelayMs = options?.maxRetryDelayMs ?? 60000;
+					if (maxDelayMs > 0 && serverDelay && serverDelay > maxDelayMs) {
+						const delaySeconds = Math.ceil(serverDelay / 1000);
+						throw new Error(
+							`Server requested ${delaySeconds}s retry delay (max: ${Math.ceil(maxDelayMs / 1000)}s). ${extractErrorMessage(errorText)}`,
+						);
+					}
+
+					await sleep(delayMs, options?.signal);
+					continue;
+				}
+
+				// Not retryable or max retries exceeded
+				if (response.status === 404) {
+					throw new Error(
+						`Cloud Code Assist API error (404): Model "${model.id}" was not found. ` +
+						`This model may not be available via Cloud Code Assist. ` +
+						`Try using the "google" provider with a GOOGLE_API_KEY instead, ` +
+						`or switch to a supported model (e.g., gemini-2.5-pro).`,
+					);
+				}
+				throw new Error(`Cloud Code Assist API error (${response.status}): ${extractErrorMessage(errorText)}`);
+			} catch (error) {
+				// Check for abort - fetch throws AbortError, our code throws "Request was aborted"
+				if (error instanceof Error) {
+					if (error.name === "AbortError" || error.message === "Request was aborted") {
+						throw new Error("Request was aborted");
+					}
+				}
+				// Extract detailed error message from fetch errors (Node includes cause)
+				lastError = error instanceof Error ? error : new Error(String(error));
+				if (lastError.message === "fetch failed" && lastError.cause instanceof Error) {
+					lastError = new Error(`Network error: ${lastError.cause.message}`);
+				}
+				// Network errors are retryable
+				if (attempt < MAX_RETRIES) {
+					const delayMs = BASE_DELAY_MS * 2 ** attempt;
+					await sleep(delayMs, options?.signal);
+					continue;
+				}
+				throw lastError;
+			}
+		}
+
+		if (!response || !response.ok) {
+			throw lastError ?? new Error("Failed to get response after retries");
+		}
+
+		let started = false;
+		const ensureStarted = () => {
+			if (!started) {
+				stream.push({ type: "start", partial: output });
+				started = true;
+			}
+		};
+
+		const resetOutput = () => {
+			output.content = [];
+			output.usage = {
 				input: 0,
 				output: 0,
 				cacheRead: 0,
 				cacheWrite: 0,
 				totalTokens: 0,
 				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-			},
-			stopReason: "stop",
-			timestamp: Date.now(),
+			};
+			output.stopReason = "stop";
+			output.errorMessage = undefined;
+			output.timestamp = Date.now();
+			started = false;
 		};
 
-		try {
-			// apiKey is JSON-encoded: { token, projectId }
-			const apiKeyRaw = options?.apiKey;
-			if (!apiKeyRaw) {
-				throw new Error("Google Cloud Code Assist requires OAuth authentication. Use /login to authenticate.");
+		const streamResponse = async (activeResponse: Response): Promise<boolean> => {
+			if (!activeResponse.body) {
+				throw new Error("No response body");
 			}
 
-			let accessToken: string;
-			let projectId: string;
+			let hasContent = false;
+			let currentBlock: TextContent | ThinkingContent | null = null;
+			const blocks = output.content;
+			const blockIndex = () => blocks.length - 1;
+
+			// Read SSE stream
+			const reader = activeResponse.body.getReader();
+			const decoder = new TextDecoder();
+			let buffer = "";
+
+			// Set up abort handler to cancel reader when signal fires
+			const abortHandler = () => {
+				void reader.cancel().catch(() => {});
+			};
+			options?.signal?.addEventListener("abort", abortHandler);
 
 			try {
-				const parsed = JSON.parse(apiKeyRaw) as { token: string; projectId: string };
-				accessToken = parsed.token;
-				projectId = parsed.projectId;
-			} catch {
-				throw new Error("Invalid Google Cloud Code Assist credentials. Use /login to re-authenticate.");
-			}
-
-			if (!accessToken || !projectId) {
-				throw new Error("Missing token or projectId in Google Cloud credentials. Use /login to re-authenticate.");
-			}
-
-			const isAntigravity = model.provider === "google-antigravity";
-			const baseUrl = model.baseUrl?.trim();
-			const endpoints = baseUrl ? [baseUrl] : isAntigravity ? ANTIGRAVITY_ENDPOINT_FALLBACKS : [DEFAULT_ENDPOINT];
-
-			let requestBody = buildRequest(model, context, projectId, options, isAntigravity);
-			const nextRequestBody = await options?.onPayload?.(requestBody, model);
-			if (nextRequestBody !== undefined) {
-				requestBody = nextRequestBody as CloudCodeAssistRequest;
-			}
-			const headers = isAntigravity ? getAntigravityHeaders() : GEMINI_CLI_HEADERS;
-
-			const requestHeaders = {
-				Authorization: `Bearer ${accessToken}`,
-				"Content-Type": "application/json",
-				Accept: "text/event-stream",
-				...headers,
-				...(needsClaudeThinkingBetaHeader(model) ? { "anthropic-beta": CLAUDE_THINKING_BETA_HEADER } : {}),
-				...options?.headers,
-			};
-			const requestBodyJson = JSON.stringify(requestBody);
-
-			// Fetch with retry logic for rate limits, transient errors, and endpoint fallbacks.
-			// On 403/404, immediately try the next endpoint (no delay).
-			// On 429/5xx, retry with backoff on the same or next endpoint.
-			let response: Response | undefined;
-			let lastError: Error | undefined;
-			let requestUrl: string | undefined;
-			let endpointIndex = 0;
-
-			for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
-				if (options?.signal?.aborted) {
-					throw new Error("Request was aborted");
-				}
-
-				try {
-					const endpoint = endpoints[endpointIndex];
-					requestUrl = `${endpoint}/v1internal:streamGenerateContent?alt=sse`;
-					response = await fetch(requestUrl, {
-						method: "POST",
-						headers: requestHeaders,
-						body: requestBodyJson,
-						signal: options?.signal,
-					});
-
-					if (response.ok) {
-						break; // Success, exit retry loop
+				while (true) {
+					// Check abort signal before each read
+					if (options?.signal?.aborted) {
+						throw new Error("Request was aborted");
 					}
 
-					const errorText = await response.text();
+					const { done, value } = await reader.read();
+					if (done) break;
 
-					// On 403/404, cascade to the next endpoint immediately (no delay)
-					if ((response.status === 403 || response.status === 404) && endpointIndex < endpoints.length - 1) {
-						endpointIndex++;
-						continue;
-					}
+					buffer += decoder.decode(value, { stream: true });
+					const lines = buffer.split("\n");
+					buffer = lines.pop() || "";
 
-					// Check if retryable (429, 5xx, network patterns)
-					if (attempt < MAX_RETRIES && isRetryableError(response.status, errorText)) {
-						// Advance endpoint if possible
-						if (endpointIndex < endpoints.length - 1) {
-							endpointIndex++;
+					for (const line of lines) {
+						if (!line.startsWith("data:")) continue;
+
+						const jsonStr = line.slice(5).trim();
+						if (!jsonStr) continue;
+
+						let chunk: CloudCodeAssistResponseChunk;
+						try {
+							chunk = JSON.parse(jsonStr);
+						} catch {
+							continue;
 						}
 
-						// Use server-provided delay or exponential backoff
-						const serverDelay = extractRetryDelay(errorText, response);
-						const delayMs = serverDelay ?? BASE_DELAY_MS * 2 ** attempt;
+						// Unwrap the response
+						const responseData = chunk.response;
+						if (!responseData) continue;
 
-						// Check if server delay exceeds max allowed (default: 60s)
-						const maxDelayMs = options?.maxRetryDelayMs ?? 60000;
-						if (maxDelayMs > 0 && serverDelay && serverDelay > maxDelayMs) {
-							const delaySeconds = Math.ceil(serverDelay / 1000);
-							throw new Error(
-								`Server requested ${delaySeconds}s retry delay (max: ${Math.ceil(maxDelayMs / 1000)}s). ${extractErrorMessage(errorText)}`,
-							);
-						}
-
-						await sleep(delayMs, options?.signal);
-						continue;
-					}
-
-					// Not retryable or max retries exceeded
-					if (response.status === 404) {
-						throw new Error(
-							`Cloud Code Assist API error (404): Model "${model.id}" was not found. ` +
-							`This model may not be available via Cloud Code Assist. ` +
-							`Try using the "google" provider with a GOOGLE_API_KEY instead, ` +
-							`or switch to a supported model (e.g., gemini-2.5-pro).`,
-						);
-					}
-					throw new Error(`Cloud Code Assist API error (${response.status}): ${extractErrorMessage(errorText)}`);
-				} catch (error) {
-					// Check for abort - fetch throws AbortError, our code throws "Request was aborted"
-					if (error instanceof Error) {
-						if (error.name === "AbortError" || error.message === "Request was aborted") {
-							throw new Error("Request was aborted");
-						}
-					}
-					// Extract detailed error message from fetch errors (Node includes cause)
-					lastError = error instanceof Error ? error : new Error(String(error));
-					if (lastError.message === "fetch failed" && lastError.cause instanceof Error) {
-						lastError = new Error(`Network error: ${lastError.cause.message}`);
-					}
-					// Network errors are retryable
-					if (attempt < MAX_RETRIES) {
-						const delayMs = BASE_DELAY_MS * 2 ** attempt;
-						await sleep(delayMs, options?.signal);
-						continue;
-					}
-					throw lastError;
-				}
-			}
-
-			if (!response || !response.ok) {
-				throw lastError ?? new Error("Failed to get response after retries");
-			}
-
-			let started = false;
-			const ensureStarted = () => {
-				if (!started) {
-					stream.push({ type: "start", partial: output });
-					started = true;
-				}
-			};
-
-			const resetOutput = () => {
-				output.content = [];
-				output.usage = {
-					input: 0,
-					output: 0,
-					cacheRead: 0,
-					cacheWrite: 0,
-					totalTokens: 0,
-					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-				};
-				output.stopReason = "stop";
-				output.errorMessage = undefined;
-				output.timestamp = Date.now();
-				started = false;
-			};
-
-			const streamResponse = async (activeResponse: Response): Promise<boolean> => {
-				if (!activeResponse.body) {
-					throw new Error("No response body");
-				}
-
-				let hasContent = false;
-				let currentBlock: TextContent | ThinkingContent | null = null;
-				const blocks = output.content;
-				const blockIndex = () => blocks.length - 1;
-
-				// Read SSE stream
-				const reader = activeResponse.body.getReader();
-				const decoder = new TextDecoder();
-				let buffer = "";
-
-				// Set up abort handler to cancel reader when signal fires
-				const abortHandler = () => {
-					void reader.cancel().catch(() => {});
-				};
-				options?.signal?.addEventListener("abort", abortHandler);
-
-				try {
-					while (true) {
-						// Check abort signal before each read
-						if (options?.signal?.aborted) {
-							throw new Error("Request was aborted");
-						}
-
-						const { done, value } = await reader.read();
-						if (done) break;
-
-						buffer += decoder.decode(value, { stream: true });
-						const lines = buffer.split("\n");
-						buffer = lines.pop() || "";
-
-						for (const line of lines) {
-							if (!line.startsWith("data:")) continue;
-
-							const jsonStr = line.slice(5).trim();
-							if (!jsonStr) continue;
-
-							let chunk: CloudCodeAssistResponseChunk;
-							try {
-								chunk = JSON.parse(jsonStr);
-							} catch {
-								continue;
-							}
-
-							// Unwrap the response
-							const responseData = chunk.response;
-							if (!responseData) continue;
-
-							const candidate = responseData.candidates?.[0];
-							if (candidate?.content?.parts) {
-								for (const part of candidate.content.parts) {
-									if (part.text !== undefined) {
-										hasContent = true;
-										const isThinking = isThinkingPart(part);
-										if (
-											!currentBlock ||
-											(isThinking && currentBlock.type !== "thinking") ||
-											(!isThinking && currentBlock.type !== "text")
-										) {
-											if (currentBlock) {
-												if (currentBlock.type === "text") {
-													stream.push({
-														type: "text_end",
-														contentIndex: blocks.length - 1,
-														content: currentBlock.text,
-														partial: output,
-													});
-												} else {
-													stream.push({
-														type: "thinking_end",
-														contentIndex: blockIndex(),
-														content: currentBlock.thinking,
-														partial: output,
-													});
-												}
-											}
-											if (isThinking) {
-												currentBlock = { type: "thinking", thinking: "", thinkingSignature: undefined };
-												output.content.push(currentBlock);
-												ensureStarted();
-												stream.push({
-													type: "thinking_start",
-													contentIndex: blockIndex(),
-													partial: output,
-												});
-											} else {
-												currentBlock = { type: "text", text: "" };
-												output.content.push(currentBlock);
-												ensureStarted();
-												stream.push({ type: "text_start", contentIndex: blockIndex(), partial: output });
-											}
-										}
-										if (currentBlock.type === "thinking") {
-											currentBlock.thinking += part.text;
-											currentBlock.thinkingSignature = retainThoughtSignature(
-												currentBlock.thinkingSignature,
-												part.thoughtSignature,
-											);
-											stream.push({
-												type: "thinking_delta",
-												contentIndex: blockIndex(),
-												delta: part.text,
-												partial: output,
-											});
-										} else {
-											currentBlock.text += part.text;
-											currentBlock.textSignature = retainThoughtSignature(
-												currentBlock.textSignature,
-												part.thoughtSignature,
-											);
-											stream.push({
-												type: "text_delta",
-												contentIndex: blockIndex(),
-												delta: part.text,
-												partial: output,
-											});
-										}
-									}
-
-									if (part.functionCall) {
-										hasContent = true;
+						const candidate = responseData.candidates?.[0];
+						if (candidate?.content?.parts) {
+							for (const part of candidate.content.parts) {
+								if (part.text !== undefined) {
+									hasContent = true;
+									const isThinking = isThinkingPart(part);
+									if (
+										!currentBlock ||
+										(isThinking && currentBlock.type !== "thinking") ||
+										(!isThinking && currentBlock.type !== "text")
+									) {
 										if (currentBlock) {
 											if (currentBlock.type === "text") {
 												stream.push({
 													type: "text_end",
-													contentIndex: blockIndex(),
+													contentIndex: blocks.length - 1,
 													content: currentBlock.text,
 													partial: output,
 												});
@@ -646,169 +562,206 @@ export const streamGoogleGeminiCli: StreamFunction<"google-gemini-cli", GoogleGe
 													partial: output,
 												});
 											}
-											currentBlock = null;
 										}
-
-										const providedId = part.functionCall.id;
-										const needsNewId =
-											!providedId ||
-											output.content.some((b) => b.type === "toolCall" && b.id === providedId);
-										const toolCallId = needsNewId
-											? `${part.functionCall.name}_${Date.now()}_${++toolCallCounter}`
-											: providedId;
-
-										const toolCall: ToolCall = {
-											type: "toolCall",
-											id: toolCallId,
-											name: part.functionCall.name || "",
-											arguments: (part.functionCall.args as Record<string, unknown>) ?? {},
-											...(part.thoughtSignature && { thoughtSignature: part.thoughtSignature }),
-										};
-
-										output.content.push(toolCall);
-										ensureStarted();
-										stream.push({ type: "toolcall_start", contentIndex: blockIndex(), partial: output });
+										if (isThinking) {
+											currentBlock = { type: "thinking", thinking: "", thinkingSignature: undefined };
+											output.content.push(currentBlock);
+											ensureStarted();
+											stream.push({
+												type: "thinking_start",
+												contentIndex: blockIndex(),
+												partial: output,
+											});
+										} else {
+											currentBlock = { type: "text", text: "" };
+											output.content.push(currentBlock);
+											ensureStarted();
+											stream.push({ type: "text_start", contentIndex: blockIndex(), partial: output });
+										}
+									}
+									if (currentBlock.type === "thinking") {
+										currentBlock.thinking += part.text;
+										currentBlock.thinkingSignature = retainThoughtSignature(
+											currentBlock.thinkingSignature,
+											part.thoughtSignature,
+										);
 										stream.push({
-											type: "toolcall_delta",
+											type: "thinking_delta",
 											contentIndex: blockIndex(),
-											delta: JSON.stringify(toolCall.arguments),
+											delta: part.text,
 											partial: output,
 										});
+									} else {
+										currentBlock.text += part.text;
+										currentBlock.textSignature = retainThoughtSignature(
+											currentBlock.textSignature,
+											part.thoughtSignature,
+										);
 										stream.push({
-											type: "toolcall_end",
+											type: "text_delta",
 											contentIndex: blockIndex(),
-											toolCall,
+											delta: part.text,
 											partial: output,
 										});
 									}
 								}
-							}
 
-							if (candidate?.finishReason) {
-								output.stopReason = mapStopReasonString(candidate.finishReason);
-								if (output.content.some((b) => b.type === "toolCall")) {
-									output.stopReason = "toolUse";
+								if (part.functionCall) {
+									hasContent = true;
+									if (currentBlock) {
+										if (currentBlock.type === "text") {
+											stream.push({
+												type: "text_end",
+												contentIndex: blockIndex(),
+												content: currentBlock.text,
+												partial: output,
+											});
+										} else {
+											stream.push({
+												type: "thinking_end",
+												contentIndex: blockIndex(),
+												content: currentBlock.thinking,
+												partial: output,
+											});
+										}
+										currentBlock = null;
+									}
+
+									const providedId = part.functionCall.id;
+									const needsNewId =
+										!providedId ||
+										output.content.some((b) => b.type === "toolCall" && b.id === providedId);
+									const toolCallId = needsNewId
+										? `${part.functionCall.name}_${Date.now()}_${++toolCallCounter}`
+										: providedId;
+
+									const toolCall: ToolCall = {
+										type: "toolCall",
+										id: toolCallId,
+										name: part.functionCall.name || "",
+										arguments: (part.functionCall.args as Record<string, unknown>) ?? {},
+										...(part.thoughtSignature && { thoughtSignature: part.thoughtSignature }),
+									};
+
+									output.content.push(toolCall);
+									ensureStarted();
+									stream.push({ type: "toolcall_start", contentIndex: blockIndex(), partial: output });
+									stream.push({
+										type: "toolcall_delta",
+										contentIndex: blockIndex(),
+										delta: JSON.stringify(toolCall.arguments),
+										partial: output,
+									});
+									stream.push({
+										type: "toolcall_end",
+										contentIndex: blockIndex(),
+										toolCall,
+										partial: output,
+									});
 								}
 							}
+						}
 
-							if (responseData.usageMetadata) {
-								// promptTokenCount includes cachedContentTokenCount, so subtract to get fresh input
-								const promptTokens = responseData.usageMetadata.promptTokenCount || 0;
-								const cacheReadTokens = responseData.usageMetadata.cachedContentTokenCount || 0;
-								output.usage = {
-									input: promptTokens - cacheReadTokens,
-									output:
-										(responseData.usageMetadata.candidatesTokenCount || 0) +
-										(responseData.usageMetadata.thoughtsTokenCount || 0),
-									cacheRead: cacheReadTokens,
-									cacheWrite: 0,
-									totalTokens: responseData.usageMetadata.totalTokenCount || 0,
-									cost: {
-										input: 0,
-										output: 0,
-										cacheRead: 0,
-										cacheWrite: 0,
-										total: 0,
-									},
-								};
-								calculateCost(model, output.usage);
+						if (candidate?.finishReason) {
+							output.stopReason = mapStopReasonString(candidate.finishReason);
+							if (output.content.some((b) => b.type === "toolCall")) {
+								output.stopReason = "toolUse";
 							}
 						}
+
+						if (responseData.usageMetadata) {
+							// promptTokenCount includes cachedContentTokenCount, so subtract to get fresh input
+							const promptTokens = responseData.usageMetadata.promptTokenCount || 0;
+							const cacheReadTokens = responseData.usageMetadata.cachedContentTokenCount || 0;
+							output.usage = {
+								input: promptTokens - cacheReadTokens,
+								output:
+									(responseData.usageMetadata.candidatesTokenCount || 0) +
+									(responseData.usageMetadata.thoughtsTokenCount || 0),
+								cacheRead: cacheReadTokens,
+								cacheWrite: 0,
+								totalTokens: responseData.usageMetadata.totalTokenCount || 0,
+								cost: {
+									input: 0,
+									output: 0,
+									cacheRead: 0,
+									cacheWrite: 0,
+									total: 0,
+								},
+							};
+							calculateCost(model, output.usage);
+						}
 					}
-				} finally {
-					options?.signal?.removeEventListener("abort", abortHandler);
 				}
+			} finally {
+				options?.signal?.removeEventListener("abort", abortHandler);
+			}
 
-				if (currentBlock) {
-					if (currentBlock.type === "text") {
-						stream.push({
-							type: "text_end",
-							contentIndex: blockIndex(),
-							content: currentBlock.text,
-							partial: output,
-						});
-					} else {
-						stream.push({
-							type: "thinking_end",
-							contentIndex: blockIndex(),
-							content: currentBlock.thinking,
-							partial: output,
-						});
-					}
-				}
-
-				return hasContent;
-			};
-
-			let receivedContent = false;
-			let currentResponse = response;
-
-			for (let emptyAttempt = 0; emptyAttempt <= MAX_EMPTY_STREAM_RETRIES; emptyAttempt++) {
-				if (options?.signal?.aborted) {
-					throw new Error("Request was aborted");
-				}
-
-				if (emptyAttempt > 0) {
-					const backoffMs = EMPTY_STREAM_BASE_DELAY_MS * 2 ** (emptyAttempt - 1);
-					await sleep(backoffMs, options?.signal);
-
-					if (!requestUrl) {
-						throw new Error("Missing request URL");
-					}
-
-					currentResponse = await fetch(requestUrl, {
-						method: "POST",
-						headers: requestHeaders,
-						body: requestBodyJson,
-						signal: options?.signal,
+			if (currentBlock) {
+				if (currentBlock.type === "text") {
+					stream.push({
+						type: "text_end",
+						contentIndex: blockIndex(),
+						content: currentBlock.text,
+						partial: output,
 					});
-
-					if (!currentResponse.ok) {
-						const retryErrorText = await currentResponse.text();
-						throw new Error(`Cloud Code Assist API error (${currentResponse.status}): ${retryErrorText}`);
-					}
-				}
-
-				const streamed = await streamResponse(currentResponse);
-				if (streamed) {
-					receivedContent = true;
-					break;
-				}
-
-				if (emptyAttempt < MAX_EMPTY_STREAM_RETRIES) {
-					resetOutput();
+				} else {
+					stream.push({
+						type: "thinking_end",
+						contentIndex: blockIndex(),
+						content: currentBlock.thinking,
+						partial: output,
+					});
 				}
 			}
 
-			if (!receivedContent) {
-				throw new Error("Cloud Code Assist API returned an empty response");
-			}
+			return hasContent;
+		};
 
+		let receivedContent = false;
+		let currentResponse = response;
+
+		for (let emptyAttempt = 0; emptyAttempt <= MAX_EMPTY_STREAM_RETRIES; emptyAttempt++) {
 			if (options?.signal?.aborted) {
 				throw new Error("Request was aborted");
 			}
 
-			if (output.stopReason === "aborted" || output.stopReason === "error") {
-				throw new Error("An unknown error occurred");
-			}
+			if (emptyAttempt > 0) {
+				const backoffMs = EMPTY_STREAM_BASE_DELAY_MS * 2 ** (emptyAttempt - 1);
+				await sleep(backoffMs, options?.signal);
 
-			stream.push({ type: "done", reason: output.stopReason, message: output });
-			stream.end();
-		} catch (error) {
-			for (const block of output.content) {
-				if ("index" in block) {
-					delete (block as { index?: number }).index;
+				if (!requestUrl) {
+					throw new Error("Missing request URL");
+				}
+
+				currentResponse = await fetch(requestUrl, {
+					method: "POST",
+					headers: requestHeaders,
+					body: requestBodyJson,
+					signal: options?.signal,
+				});
+
+				if (!currentResponse.ok) {
+					const retryErrorText = await currentResponse.text();
+					throw new Error(`Cloud Code Assist API error (${currentResponse.status}): ${retryErrorText}`);
 				}
 			}
-			output.stopReason = options?.signal?.aborted ? "aborted" : "error";
-			output.errorMessage = error instanceof Error ? error.message : JSON.stringify(error);
-			stream.push({ type: "error", reason: output.stopReason, error: output });
-			stream.end();
-		}
-	})();
 
-	return stream;
-};
+			const streamed = await streamResponse(currentResponse);
+			if (streamed) {
+				receivedContent = true;
+				break;
+			}
+
+			if (emptyAttempt < MAX_EMPTY_STREAM_RETRIES) {
+				resetOutput();
+			}
+		}
+
+		if (!receivedContent) {
+			throw new Error("Cloud Code Assist API returned an empty response");
+		}
+	});
 
 export const streamSimpleGoogleGeminiCli: StreamFunction<"google-gemini-cli", SimpleStreamOptions> = (
 	model: Model<"google-gemini-cli">,

--- a/packages/pi-ai/src/providers/google-vertex.ts
+++ b/packages/pi-ai/src/providers/google-vertex.ts
@@ -8,8 +8,6 @@ import type {
 } from "@google/genai";
 import { calculateCost } from "../models.js";
 import type {
-	Api,
-	AssistantMessage,
 	Context,
 	Model,
 	ThinkingLevel as PiThinkingLevel,
@@ -23,6 +21,7 @@ import type {
 } from "../types.js";
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
+import { createProviderStream } from "../utils/stream-handler.js";
 import type { GoogleThinkingLevel } from "./google-gemini-cli.js";
 import {
 	convertMessages,
@@ -73,114 +72,38 @@ export const streamGoogleVertex: StreamFunction<"google-vertex", GoogleVertexOpt
 	model: Model<"google-vertex">,
 	context: Context,
 	options?: GoogleVertexOptions,
-): AssistantMessageEventStream => {
-	const stream = new AssistantMessageEventStream();
+): AssistantMessageEventStream =>
+	createProviderStream(model, options, async (output, stream) => {
+		const project = resolveProject(options);
+		const location = resolveLocation(options);
+		const client = await createClient(model, project, location, options?.headers);
+		let params = buildParams(model, context, options);
+		const nextParams = await options?.onPayload?.(params, model);
+		if (nextParams !== undefined) {
+			params = nextParams as GenerateContentParameters;
+		}
+		const googleStream = await client.models.generateContentStream(params);
 
-	(async () => {
-		const output: AssistantMessage = {
-			role: "assistant",
-			content: [],
-			api: "google-vertex" as Api,
-			provider: model.provider,
-			model: model.id,
-			usage: {
-				input: 0,
-				output: 0,
-				cacheRead: 0,
-				cacheWrite: 0,
-				totalTokens: 0,
-				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-			},
-			stopReason: "stop",
-			timestamp: Date.now(),
-		};
-
-		try {
-			const project = resolveProject(options);
-			const location = resolveLocation(options);
-			const client = await createClient(model, project, location, options?.headers);
-			let params = buildParams(model, context, options);
-			const nextParams = await options?.onPayload?.(params, model);
-			if (nextParams !== undefined) {
-				params = nextParams as GenerateContentParameters;
-			}
-			const googleStream = await client.models.generateContentStream(params);
-
-			stream.push({ type: "start", partial: output });
-			let currentBlock: TextContent | ThinkingContent | null = null;
-			const blocks = output.content;
-			const blockIndex = () => blocks.length - 1;
-			for await (const chunk of googleStream) {
-				const candidate = chunk.candidates?.[0];
-				if (candidate?.content?.parts) {
-					for (const part of candidate.content.parts) {
-						if (part.text !== undefined) {
-							const isThinking = isThinkingPart(part);
-							if (
-								!currentBlock ||
-								(isThinking && currentBlock.type !== "thinking") ||
-								(!isThinking && currentBlock.type !== "text")
-							) {
-								if (currentBlock) {
-									if (currentBlock.type === "text") {
-										stream.push({
-											type: "text_end",
-											contentIndex: blocks.length - 1,
-											content: currentBlock.text,
-											partial: output,
-										});
-									} else {
-										stream.push({
-											type: "thinking_end",
-											contentIndex: blockIndex(),
-											content: currentBlock.thinking,
-											partial: output,
-										});
-									}
-								}
-								if (isThinking) {
-									currentBlock = { type: "thinking", thinking: "", thinkingSignature: undefined };
-									output.content.push(currentBlock);
-									stream.push({ type: "thinking_start", contentIndex: blockIndex(), partial: output });
-								} else {
-									currentBlock = { type: "text", text: "" };
-									output.content.push(currentBlock);
-									stream.push({ type: "text_start", contentIndex: blockIndex(), partial: output });
-								}
-							}
-							if (currentBlock.type === "thinking") {
-								currentBlock.thinking += part.text;
-								currentBlock.thinkingSignature = retainThoughtSignature(
-									currentBlock.thinkingSignature,
-									part.thoughtSignature,
-								);
-								stream.push({
-									type: "thinking_delta",
-									contentIndex: blockIndex(),
-									delta: part.text,
-									partial: output,
-								});
-							} else {
-								currentBlock.text += part.text;
-								currentBlock.textSignature = retainThoughtSignature(
-									currentBlock.textSignature,
-									part.thoughtSignature,
-								);
-								stream.push({
-									type: "text_delta",
-									contentIndex: blockIndex(),
-									delta: part.text,
-									partial: output,
-								});
-							}
-						}
-
-						if (part.functionCall) {
+		stream.push({ type: "start", partial: output });
+		let currentBlock: TextContent | ThinkingContent | null = null;
+		const blocks = output.content;
+		const blockIndex = () => blocks.length - 1;
+		for await (const chunk of googleStream) {
+			const candidate = chunk.candidates?.[0];
+			if (candidate?.content?.parts) {
+				for (const part of candidate.content.parts) {
+					if (part.text !== undefined) {
+						const isThinking = isThinkingPart(part);
+						if (
+							!currentBlock ||
+							(isThinking && currentBlock.type !== "thinking") ||
+							(!isThinking && currentBlock.type !== "text")
+						) {
 							if (currentBlock) {
 								if (currentBlock.type === "text") {
 									stream.push({
 										type: "text_end",
-										contentIndex: blockIndex(),
+										contentIndex: blocks.length - 1,
 										content: currentBlock.text,
 										partial: output,
 									});
@@ -192,108 +115,137 @@ export const streamGoogleVertex: StreamFunction<"google-vertex", GoogleVertexOpt
 										partial: output,
 									});
 								}
-								currentBlock = null;
 							}
-
-							const providedId = part.functionCall.id;
-							const needsNewId =
-								!providedId || output.content.some((b) => b.type === "toolCall" && b.id === providedId);
-							const toolCallId = needsNewId
-								? `${part.functionCall.name}_${Date.now()}_${++toolCallCounter}`
-								: providedId;
-
-							const toolCall: ToolCall = {
-								type: "toolCall",
-								id: toolCallId,
-								name: part.functionCall.name || "",
-								arguments: (part.functionCall.args as Record<string, any>) ?? {},
-								...(part.thoughtSignature && { thoughtSignature: part.thoughtSignature }),
-							};
-
-							output.content.push(toolCall);
-							stream.push({ type: "toolcall_start", contentIndex: blockIndex(), partial: output });
+							if (isThinking) {
+								currentBlock = { type: "thinking", thinking: "", thinkingSignature: undefined };
+								output.content.push(currentBlock);
+								stream.push({ type: "thinking_start", contentIndex: blockIndex(), partial: output });
+							} else {
+								currentBlock = { type: "text", text: "" };
+								output.content.push(currentBlock);
+								stream.push({ type: "text_start", contentIndex: blockIndex(), partial: output });
+							}
+						}
+						if (currentBlock.type === "thinking") {
+							currentBlock.thinking += part.text;
+							currentBlock.thinkingSignature = retainThoughtSignature(
+								currentBlock.thinkingSignature,
+								part.thoughtSignature,
+							);
 							stream.push({
-								type: "toolcall_delta",
+								type: "thinking_delta",
 								contentIndex: blockIndex(),
-								delta: JSON.stringify(toolCall.arguments),
+								delta: part.text,
 								partial: output,
 							});
-							stream.push({ type: "toolcall_end", contentIndex: blockIndex(), toolCall, partial: output });
+						} else {
+							currentBlock.text += part.text;
+							currentBlock.textSignature = retainThoughtSignature(
+								currentBlock.textSignature,
+								part.thoughtSignature,
+							);
+							stream.push({
+								type: "text_delta",
+								contentIndex: blockIndex(),
+								delta: part.text,
+								partial: output,
+							});
 						}
 					}
-				}
 
-				if (candidate?.finishReason) {
-					output.stopReason = mapStopReason(candidate.finishReason);
-					if (output.content.some((b) => b.type === "toolCall")) {
-						output.stopReason = "toolUse";
+					if (part.functionCall) {
+						if (currentBlock) {
+							if (currentBlock.type === "text") {
+								stream.push({
+									type: "text_end",
+									contentIndex: blockIndex(),
+									content: currentBlock.text,
+									partial: output,
+								});
+							} else {
+								stream.push({
+									type: "thinking_end",
+									contentIndex: blockIndex(),
+									content: currentBlock.thinking,
+									partial: output,
+								});
+							}
+							currentBlock = null;
+						}
+
+						const providedId = part.functionCall.id;
+						const needsNewId =
+							!providedId || output.content.some((b) => b.type === "toolCall" && b.id === providedId);
+						const toolCallId = needsNewId
+							? `${part.functionCall.name}_${Date.now()}_${++toolCallCounter}`
+							: providedId;
+
+						const toolCall: ToolCall = {
+							type: "toolCall",
+							id: toolCallId,
+							name: part.functionCall.name || "",
+							arguments: (part.functionCall.args as Record<string, any>) ?? {},
+							...(part.thoughtSignature && { thoughtSignature: part.thoughtSignature }),
+						};
+
+						output.content.push(toolCall);
+						stream.push({ type: "toolcall_start", contentIndex: blockIndex(), partial: output });
+						stream.push({
+							type: "toolcall_delta",
+							contentIndex: blockIndex(),
+							delta: JSON.stringify(toolCall.arguments),
+							partial: output,
+						});
+						stream.push({ type: "toolcall_end", contentIndex: blockIndex(), toolCall, partial: output });
 					}
 				}
+			}
 
-				if (chunk.usageMetadata) {
-					output.usage = {
-						input: chunk.usageMetadata.promptTokenCount || 0,
-						output:
-							(chunk.usageMetadata.candidatesTokenCount || 0) + (chunk.usageMetadata.thoughtsTokenCount || 0),
-						cacheRead: chunk.usageMetadata.cachedContentTokenCount || 0,
+			if (candidate?.finishReason) {
+				output.stopReason = mapStopReason(candidate.finishReason);
+				if (output.content.some((b) => b.type === "toolCall")) {
+					output.stopReason = "toolUse";
+				}
+			}
+
+			if (chunk.usageMetadata) {
+				output.usage = {
+					input: chunk.usageMetadata.promptTokenCount || 0,
+					output:
+						(chunk.usageMetadata.candidatesTokenCount || 0) + (chunk.usageMetadata.thoughtsTokenCount || 0),
+					cacheRead: chunk.usageMetadata.cachedContentTokenCount || 0,
+					cacheWrite: 0,
+					totalTokens: chunk.usageMetadata.totalTokenCount || 0,
+					cost: {
+						input: 0,
+						output: 0,
+						cacheRead: 0,
 						cacheWrite: 0,
-						totalTokens: chunk.usageMetadata.totalTokenCount || 0,
-						cost: {
-							input: 0,
-							output: 0,
-							cacheRead: 0,
-							cacheWrite: 0,
-							total: 0,
-						},
-					};
-					calculateCost(model, output.usage);
-				}
+						total: 0,
+					},
+				};
+				calculateCost(model, output.usage);
 			}
-
-			if (currentBlock) {
-				if (currentBlock.type === "text") {
-					stream.push({
-						type: "text_end",
-						contentIndex: blockIndex(),
-						content: currentBlock.text,
-						partial: output,
-					});
-				} else {
-					stream.push({
-						type: "thinking_end",
-						contentIndex: blockIndex(),
-						content: currentBlock.thinking,
-						partial: output,
-					});
-				}
-			}
-
-			if (options?.signal?.aborted) {
-				throw new Error("Request was aborted");
-			}
-
-			if (output.stopReason === "aborted" || output.stopReason === "error") {
-				throw new Error("An unknown error occurred");
-			}
-
-			stream.push({ type: "done", reason: output.stopReason, message: output });
-			stream.end();
-		} catch (error) {
-			// Remove internal index property used during streaming
-			for (const block of output.content) {
-				if ("index" in block) {
-					delete (block as { index?: number }).index;
-				}
-			}
-			output.stopReason = options?.signal?.aborted ? "aborted" : "error";
-			output.errorMessage = error instanceof Error ? error.message : JSON.stringify(error);
-			stream.push({ type: "error", reason: output.stopReason, error: output });
-			stream.end();
 		}
-	})();
 
-	return stream;
-};
+		if (currentBlock) {
+			if (currentBlock.type === "text") {
+				stream.push({
+					type: "text_end",
+					contentIndex: blockIndex(),
+					content: currentBlock.text,
+					partial: output,
+				});
+			} else {
+				stream.push({
+					type: "thinking_end",
+					contentIndex: blockIndex(),
+					content: currentBlock.thinking,
+					partial: output,
+				});
+			}
+		}
+	});
 
 export const streamSimpleGoogleVertex: StreamFunction<"google-vertex", SimpleStreamOptions> = (
 	model: Model<"google-vertex">,

--- a/packages/pi-ai/src/providers/google.ts
+++ b/packages/pi-ai/src/providers/google.ts
@@ -18,8 +18,6 @@ async function getGoogleGenAIClass(): Promise<typeof GoogleGenAI> {
 import { getEnvApiKey } from "../env-api-keys.js";
 import { calculateCost } from "../models.js";
 import type {
-	Api,
-	AssistantMessage,
 	Context,
 	Model,
 	SimpleStreamOptions,
@@ -33,6 +31,7 @@ import type {
 } from "../types.js";
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
+import { createProviderStream } from "../utils/stream-handler.js";
 import type { GoogleThinkingLevel } from "./google-gemini-cli.js";
 import {
 	convertMessages,
@@ -60,113 +59,37 @@ export const streamGoogle: StreamFunction<"google-generative-ai", GoogleOptions>
 	model: Model<"google-generative-ai">,
 	context: Context,
 	options?: GoogleOptions,
-): AssistantMessageEventStream => {
-	const stream = new AssistantMessageEventStream();
+): AssistantMessageEventStream =>
+	createProviderStream(model, options, async (output, stream) => {
+		const apiKey = options?.apiKey || getEnvApiKey(model.provider) || "";
+		const client = await createClient(model, apiKey, options?.headers);
+		let params = buildParams(model, context, options);
+		const nextParams = await options?.onPayload?.(params, model);
+		if (nextParams !== undefined) {
+			params = nextParams as GenerateContentParameters;
+		}
+		const googleStream = await client.models.generateContentStream(params);
 
-	(async () => {
-		const output: AssistantMessage = {
-			role: "assistant",
-			content: [],
-			api: "google-generative-ai" as Api,
-			provider: model.provider,
-			model: model.id,
-			usage: {
-				input: 0,
-				output: 0,
-				cacheRead: 0,
-				cacheWrite: 0,
-				totalTokens: 0,
-				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-			},
-			stopReason: "stop",
-			timestamp: Date.now(),
-		};
-
-		try {
-			const apiKey = options?.apiKey || getEnvApiKey(model.provider) || "";
-			const client = await createClient(model, apiKey, options?.headers);
-			let params = buildParams(model, context, options);
-			const nextParams = await options?.onPayload?.(params, model);
-			if (nextParams !== undefined) {
-				params = nextParams as GenerateContentParameters;
-			}
-			const googleStream = await client.models.generateContentStream(params);
-
-			stream.push({ type: "start", partial: output });
-			let currentBlock: TextContent | ThinkingContent | null = null;
-			const blocks = output.content;
-			const blockIndex = () => blocks.length - 1;
-			for await (const chunk of googleStream) {
-				const candidate = chunk.candidates?.[0];
-				if (candidate?.content?.parts) {
-					for (const part of candidate.content.parts) {
-						if (part.text !== undefined) {
-							const isThinking = isThinkingPart(part);
-							if (
-								!currentBlock ||
-								(isThinking && currentBlock.type !== "thinking") ||
-								(!isThinking && currentBlock.type !== "text")
-							) {
-								if (currentBlock) {
-									if (currentBlock.type === "text") {
-										stream.push({
-											type: "text_end",
-											contentIndex: blocks.length - 1,
-											content: currentBlock.text,
-											partial: output,
-										});
-									} else {
-										stream.push({
-											type: "thinking_end",
-											contentIndex: blockIndex(),
-											content: currentBlock.thinking,
-											partial: output,
-										});
-									}
-								}
-								if (isThinking) {
-									currentBlock = { type: "thinking", thinking: "", thinkingSignature: undefined };
-									output.content.push(currentBlock);
-									stream.push({ type: "thinking_start", contentIndex: blockIndex(), partial: output });
-								} else {
-									currentBlock = { type: "text", text: "" };
-									output.content.push(currentBlock);
-									stream.push({ type: "text_start", contentIndex: blockIndex(), partial: output });
-								}
-							}
-							if (currentBlock.type === "thinking") {
-								currentBlock.thinking += part.text;
-								currentBlock.thinkingSignature = retainThoughtSignature(
-									currentBlock.thinkingSignature,
-									part.thoughtSignature,
-								);
-								stream.push({
-									type: "thinking_delta",
-									contentIndex: blockIndex(),
-									delta: part.text,
-									partial: output,
-								});
-							} else {
-								currentBlock.text += part.text;
-								currentBlock.textSignature = retainThoughtSignature(
-									currentBlock.textSignature,
-									part.thoughtSignature,
-								);
-								stream.push({
-									type: "text_delta",
-									contentIndex: blockIndex(),
-									delta: part.text,
-									partial: output,
-								});
-							}
-						}
-
-						if (part.functionCall) {
+		stream.push({ type: "start", partial: output });
+		let currentBlock: TextContent | ThinkingContent | null = null;
+		const blocks = output.content;
+		const blockIndex = () => blocks.length - 1;
+		for await (const chunk of googleStream) {
+			const candidate = chunk.candidates?.[0];
+			if (candidate?.content?.parts) {
+				for (const part of candidate.content.parts) {
+					if (part.text !== undefined) {
+						const isThinking = isThinkingPart(part);
+						if (
+							!currentBlock ||
+							(isThinking && currentBlock.type !== "thinking") ||
+							(!isThinking && currentBlock.type !== "text")
+						) {
 							if (currentBlock) {
 								if (currentBlock.type === "text") {
 									stream.push({
 										type: "text_end",
-										contentIndex: blockIndex(),
+										contentIndex: blocks.length - 1,
 										content: currentBlock.text,
 										partial: output,
 									});
@@ -178,109 +101,138 @@ export const streamGoogle: StreamFunction<"google-generative-ai", GoogleOptions>
 										partial: output,
 									});
 								}
-								currentBlock = null;
 							}
-
-							// Generate unique ID if not provided or if it's a duplicate
-							const providedId = part.functionCall.id;
-							const needsNewId =
-								!providedId || output.content.some((b) => b.type === "toolCall" && b.id === providedId);
-							const toolCallId = needsNewId
-								? `${part.functionCall.name}_${Date.now()}_${++toolCallCounter}`
-								: providedId;
-
-							const toolCall: ToolCall = {
-								type: "toolCall",
-								id: toolCallId,
-								name: part.functionCall.name || "",
-								arguments: (part.functionCall.args as Record<string, any>) ?? {},
-								...(part.thoughtSignature && { thoughtSignature: part.thoughtSignature }),
-							};
-
-							output.content.push(toolCall);
-							stream.push({ type: "toolcall_start", contentIndex: blockIndex(), partial: output });
+							if (isThinking) {
+								currentBlock = { type: "thinking", thinking: "", thinkingSignature: undefined };
+								output.content.push(currentBlock);
+								stream.push({ type: "thinking_start", contentIndex: blockIndex(), partial: output });
+							} else {
+								currentBlock = { type: "text", text: "" };
+								output.content.push(currentBlock);
+								stream.push({ type: "text_start", contentIndex: blockIndex(), partial: output });
+							}
+						}
+						if (currentBlock.type === "thinking") {
+							currentBlock.thinking += part.text;
+							currentBlock.thinkingSignature = retainThoughtSignature(
+								currentBlock.thinkingSignature,
+								part.thoughtSignature,
+							);
 							stream.push({
-								type: "toolcall_delta",
+								type: "thinking_delta",
 								contentIndex: blockIndex(),
-								delta: JSON.stringify(toolCall.arguments),
+								delta: part.text,
 								partial: output,
 							});
-							stream.push({ type: "toolcall_end", contentIndex: blockIndex(), toolCall, partial: output });
+						} else {
+							currentBlock.text += part.text;
+							currentBlock.textSignature = retainThoughtSignature(
+								currentBlock.textSignature,
+								part.thoughtSignature,
+							);
+							stream.push({
+								type: "text_delta",
+								contentIndex: blockIndex(),
+								delta: part.text,
+								partial: output,
+							});
 						}
 					}
-				}
 
-				if (candidate?.finishReason) {
-					output.stopReason = mapStopReason(candidate.finishReason);
-					if (output.content.some((b) => b.type === "toolCall")) {
-						output.stopReason = "toolUse";
+					if (part.functionCall) {
+						if (currentBlock) {
+							if (currentBlock.type === "text") {
+								stream.push({
+									type: "text_end",
+									contentIndex: blockIndex(),
+									content: currentBlock.text,
+									partial: output,
+								});
+							} else {
+								stream.push({
+									type: "thinking_end",
+									contentIndex: blockIndex(),
+									content: currentBlock.thinking,
+									partial: output,
+								});
+							}
+							currentBlock = null;
+						}
+
+						// Generate unique ID if not provided or if it's a duplicate
+						const providedId = part.functionCall.id;
+						const needsNewId =
+							!providedId || output.content.some((b) => b.type === "toolCall" && b.id === providedId);
+						const toolCallId = needsNewId
+							? `${part.functionCall.name}_${Date.now()}_${++toolCallCounter}`
+							: providedId;
+
+						const toolCall: ToolCall = {
+							type: "toolCall",
+							id: toolCallId,
+							name: part.functionCall.name || "",
+							arguments: (part.functionCall.args as Record<string, any>) ?? {},
+							...(part.thoughtSignature && { thoughtSignature: part.thoughtSignature }),
+						};
+
+						output.content.push(toolCall);
+						stream.push({ type: "toolcall_start", contentIndex: blockIndex(), partial: output });
+						stream.push({
+							type: "toolcall_delta",
+							contentIndex: blockIndex(),
+							delta: JSON.stringify(toolCall.arguments),
+							partial: output,
+						});
+						stream.push({ type: "toolcall_end", contentIndex: blockIndex(), toolCall, partial: output });
 					}
 				}
+			}
 
-				if (chunk.usageMetadata) {
-					output.usage = {
-						input: chunk.usageMetadata.promptTokenCount || 0,
-						output:
-							(chunk.usageMetadata.candidatesTokenCount || 0) + (chunk.usageMetadata.thoughtsTokenCount || 0),
-						cacheRead: chunk.usageMetadata.cachedContentTokenCount || 0,
+			if (candidate?.finishReason) {
+				output.stopReason = mapStopReason(candidate.finishReason);
+				if (output.content.some((b) => b.type === "toolCall")) {
+					output.stopReason = "toolUse";
+				}
+			}
+
+			if (chunk.usageMetadata) {
+				output.usage = {
+					input: chunk.usageMetadata.promptTokenCount || 0,
+					output:
+						(chunk.usageMetadata.candidatesTokenCount || 0) + (chunk.usageMetadata.thoughtsTokenCount || 0),
+					cacheRead: chunk.usageMetadata.cachedContentTokenCount || 0,
+					cacheWrite: 0,
+					totalTokens: chunk.usageMetadata.totalTokenCount || 0,
+					cost: {
+						input: 0,
+						output: 0,
+						cacheRead: 0,
 						cacheWrite: 0,
-						totalTokens: chunk.usageMetadata.totalTokenCount || 0,
-						cost: {
-							input: 0,
-							output: 0,
-							cacheRead: 0,
-							cacheWrite: 0,
-							total: 0,
-						},
-					};
-					calculateCost(model, output.usage);
-				}
+						total: 0,
+					},
+				};
+				calculateCost(model, output.usage);
 			}
-
-			if (currentBlock) {
-				if (currentBlock.type === "text") {
-					stream.push({
-						type: "text_end",
-						contentIndex: blockIndex(),
-						content: currentBlock.text,
-						partial: output,
-					});
-				} else {
-					stream.push({
-						type: "thinking_end",
-						contentIndex: blockIndex(),
-						content: currentBlock.thinking,
-						partial: output,
-					});
-				}
-			}
-
-			if (options?.signal?.aborted) {
-				throw new Error("Request was aborted");
-			}
-
-			if (output.stopReason === "aborted" || output.stopReason === "error") {
-				throw new Error("An unknown error occurred");
-			}
-
-			stream.push({ type: "done", reason: output.stopReason, message: output });
-			stream.end();
-		} catch (error) {
-			// Remove internal index property used during streaming
-			for (const block of output.content) {
-				if ("index" in block) {
-					delete (block as { index?: number }).index;
-				}
-			}
-			output.stopReason = options?.signal?.aborted ? "aborted" : "error";
-			output.errorMessage = error instanceof Error ? error.message : JSON.stringify(error);
-			stream.push({ type: "error", reason: output.stopReason, error: output });
-			stream.end();
 		}
-	})();
 
-	return stream;
-};
+		if (currentBlock) {
+			if (currentBlock.type === "text") {
+				stream.push({
+					type: "text_end",
+					contentIndex: blockIndex(),
+					content: currentBlock.text,
+					partial: output,
+				});
+			} else {
+				stream.push({
+					type: "thinking_end",
+					contentIndex: blockIndex(),
+					content: currentBlock.thinking,
+					partial: output,
+				});
+			}
+		}
+	});
 
 export const streamSimpleGoogle: StreamFunction<"google-generative-ai", SimpleStreamOptions> = (
 	model: Model<"google-generative-ai">,

--- a/packages/pi-ai/src/providers/mistral.ts
+++ b/packages/pi-ai/src/providers/mistral.ts
@@ -38,6 +38,7 @@ import { AssistantMessageEventStream } from "../utils/event-stream.js";
 import { shortHash } from "../utils/hash.js";
 import { parseStreamingJson } from "../utils/json-parse.js";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
+import { createProviderStream } from "../utils/stream-handler.js";
 import { buildBaseOptions, clampReasoning } from "./simple-options.js";
 import { transformMessages } from "./transform-messages.js";
 
@@ -59,13 +60,11 @@ export const streamMistral: StreamFunction<"mistral-conversations", MistralOptio
 	model: Model<"mistral-conversations">,
 	context: Context,
 	options?: MistralOptions,
-): AssistantMessageEventStream => {
-	const stream = new AssistantMessageEventStream();
-
-	(async () => {
-		const output = createOutput(model);
-
-		try {
+): AssistantMessageEventStream =>
+	createProviderStream(
+		model,
+		options,
+		async (output, stream) => {
 			const apiKey = options?.apiKey || getEnvApiKey(model.provider);
 			if (!apiKey) {
 				throw new Error(`No API key for provider: ${model.provider}`);
@@ -89,27 +88,9 @@ export const streamMistral: StreamFunction<"mistral-conversations", MistralOptio
 			const mistralStream = await mistral.chat.stream(payload, buildRequestOptions(model, options));
 			stream.push({ type: "start", partial: output });
 			await consumeChatStream(model, output, stream, mistralStream);
-
-			if (options?.signal?.aborted) {
-				throw new Error("Request was aborted");
-			}
-
-			if (output.stopReason === "aborted" || output.stopReason === "error") {
-				throw new Error("An unknown error occurred");
-			}
-
-			stream.push({ type: "done", reason: output.stopReason, message: output });
-			stream.end();
-		} catch (error) {
-			output.stopReason = options?.signal?.aborted ? "aborted" : "error";
-			output.errorMessage = formatMistralError(error);
-			stream.push({ type: "error", reason: output.stopReason, error: output });
-			stream.end();
-		}
-	})();
-
-	return stream;
-};
+		},
+		{ formatError: formatMistralError },
+	);
 
 /**
  * Maps provider-agnostic `SimpleStreamOptions` to Mistral options.
@@ -133,25 +114,6 @@ export const streamSimpleMistral: StreamFunction<"mistral-conversations", Simple
 	} satisfies MistralOptions);
 };
 
-function createOutput(model: Model<"mistral-conversations">): AssistantMessage {
-	return {
-		role: "assistant",
-		content: [],
-		api: model.api,
-		provider: model.provider,
-		model: model.id,
-		usage: {
-			input: 0,
-			output: 0,
-			cacheRead: 0,
-			cacheWrite: 0,
-			totalTokens: 0,
-			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-		},
-		stopReason: "stop",
-		timestamp: Date.now(),
-	};
-}
 
 function createMistralToolCallIdNormalizer(): (id: string) => string {
 	const idMap = new Map<string, string>();

--- a/packages/pi-ai/src/providers/openai-codex-responses.ts
+++ b/packages/pi-ai/src/providers/openai-codex-responses.ts
@@ -18,7 +18,6 @@ if (typeof process !== "undefined" && (process.versions?.node || process.version
 import { getEnvApiKey } from "../env-api-keys.js";
 import { supportsXhigh } from "../models.js";
 import type {
-	Api,
 	AssistantMessage,
 	Context,
 	Model,
@@ -27,6 +26,7 @@ import type {
 	StreamOptions,
 } from "../types.js";
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
+import { createProviderStream } from "../utils/stream-handler.js";
 import { convertResponsesMessages, convertResponsesTools, processResponsesStream } from "./openai-responses-shared.js";
 import { buildBaseOptions, clampReasoning } from "./simple-options.js";
 
@@ -111,29 +111,11 @@ export const streamOpenAICodexResponses: StreamFunction<"openai-codex-responses"
 	model: Model<"openai-codex-responses">,
 	context: Context,
 	options?: OpenAICodexResponsesOptions,
-): AssistantMessageEventStream => {
-	const stream = new AssistantMessageEventStream();
-
-	(async () => {
-		const output: AssistantMessage = {
-			role: "assistant",
-			content: [],
-			api: "openai-codex-responses" as Api,
-			provider: model.provider,
-			model: model.id,
-			usage: {
-				input: 0,
-				output: 0,
-				cacheRead: 0,
-				cacheWrite: 0,
-				totalTokens: 0,
-				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-			},
-			stopReason: "stop",
-			timestamp: Date.now(),
-		};
-
-		try {
+): AssistantMessageEventStream =>
+	createProviderStream(
+		model,
+		options,
+		async (output, stream) => {
 			const apiKey = options?.apiKey || getEnvApiKey(model.provider) || "";
 			if (!apiKey) {
 				throw new Error(`No API key for provider: ${model.provider}`);
@@ -165,15 +147,8 @@ export const streamOpenAICodexResponses: StreamFunction<"openai-codex-responses"
 						options,
 					);
 
-					if (options?.signal?.aborted) {
-						throw new Error("Request was aborted");
-					}
-					stream.push({
-						type: "done",
-						reason: output.stopReason as "stop" | "length" | "toolUse",
-						message: output,
-					});
-					stream.end();
+					// WebSocket path succeeded — return and let createProviderStream
+					// handle the done event and stream.end().
 					return;
 				} catch (error) {
 					if (transport === "websocket" || websocketStarted) {
@@ -244,23 +219,11 @@ export const streamOpenAICodexResponses: StreamFunction<"openai-codex-responses"
 
 			stream.push({ type: "start", partial: output });
 			await processStream(response, output, stream, model);
-
-			if (options?.signal?.aborted) {
-				throw new Error("Request was aborted");
-			}
-
-			stream.push({ type: "done", reason: output.stopReason as "stop" | "length" | "toolUse", message: output });
-			stream.end();
-		} catch (error) {
-			output.stopReason = options?.signal?.aborted ? "aborted" : "error";
-			output.errorMessage = error instanceof Error ? error.message : String(error);
-			stream.push({ type: "error", reason: output.stopReason, error: output });
-			stream.end();
-		}
-	})();
-
-	return stream;
-};
+		},
+		{
+			formatError: (error) => (error instanceof Error ? error.message : String(error)),
+		},
+	);
 
 export const streamSimpleOpenAICodexResponses: StreamFunction<"openai-codex-responses", SimpleStreamOptions> = (
 	model: Model<"openai-codex-responses">,

--- a/packages/pi-ai/src/providers/openai-completions.ts
+++ b/packages/pi-ai/src/providers/openai-completions.ts
@@ -13,7 +13,6 @@ import type {
 import { getEnvApiKey } from "../env-api-keys.js";
 import { calculateCost, supportsXhigh } from "../models.js";
 import type {
-	AssistantMessage,
 	Context,
 	Message,
 	Model,
@@ -31,6 +30,7 @@ import type {
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
 import { parseStreamingJson } from "../utils/json-parse.js";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
+import { createProviderStream } from "../utils/stream-handler.js";
 import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "./github-copilot-headers.js";
 import { buildBaseOptions, clampReasoning } from "./simple-options.js";
 import { transformMessages } from "./transform-messages.js";
@@ -72,29 +72,11 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions", OpenA
 	model: Model<"openai-completions">,
 	context: Context,
 	options?: OpenAICompletionsOptions,
-): AssistantMessageEventStream => {
-	const stream = new AssistantMessageEventStream();
-
-	(async () => {
-		const output: AssistantMessage = {
-			role: "assistant",
-			content: [],
-			api: model.api,
-			provider: model.provider,
-			model: model.id,
-			usage: {
-				input: 0,
-				output: 0,
-				cacheRead: 0,
-				cacheWrite: 0,
-				totalTokens: 0,
-				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-			},
-			stopReason: "stop",
-			timestamp: Date.now(),
-		};
-
-		try {
+): AssistantMessageEventStream =>
+	createProviderStream(
+		model,
+		options,
+		async (output, stream) => {
 			const apiKey = options?.apiKey || getEnvApiKey(model.provider) || "";
 			const client = await createClient(model, context, apiKey, options?.headers);
 			let params = buildParams(model, context, options);
@@ -292,30 +274,15 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions", OpenA
 			}
 
 			finishCurrentBlock(currentBlock);
-			if (options?.signal?.aborted) {
-				throw new Error("Request was aborted");
-			}
-
-			if (output.stopReason === "aborted" || output.stopReason === "error") {
-				throw new Error("An unknown error occurred");
-			}
-
-			stream.push({ type: "done", reason: output.stopReason, message: output });
-			stream.end();
-		} catch (error) {
-			for (const block of output.content) delete (block as any).index;
-			output.stopReason = options?.signal?.aborted ? "aborted" : "error";
-			output.errorMessage = error instanceof Error ? error.message : JSON.stringify(error);
-			// Some providers via OpenRouter give additional information in this field.
-			const rawMetadata = (error as any)?.error?.metadata?.raw;
-			if (rawMetadata) output.errorMessage += `\n${rawMetadata}`;
-			stream.push({ type: "error", reason: output.stopReason, error: output });
-			stream.end();
-		}
-	})();
-
-	return stream;
-};
+		},
+		{
+			onError: (error, output) => {
+				// Some providers via OpenRouter give additional information in this field.
+				const rawMetadata = (error as any)?.error?.metadata?.raw;
+				if (rawMetadata) output.errorMessage += `\n${rawMetadata}`;
+			},
+		},
+	);
 
 export const streamSimpleOpenAICompletions: StreamFunction<"openai-completions", SimpleStreamOptions> = (
 	model: Model<"openai-completions">,

--- a/packages/pi-ai/src/providers/openai-responses.ts
+++ b/packages/pi-ai/src/providers/openai-responses.ts
@@ -5,8 +5,6 @@ import type { ResponseCreateParamsStreaming } from "openai/resources/responses/r
 import { getEnvApiKey } from "../env-api-keys.js";
 import { supportsXhigh } from "../models.js";
 import type {
-	Api,
-	AssistantMessage,
 	CacheRetention,
 	Context,
 	Model,
@@ -16,6 +14,7 @@ import type {
 	Usage,
 } from "../types.js";
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
+import { createProviderStream } from "../utils/stream-handler.js";
 import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "./github-copilot-headers.js";
 import { convertResponsesMessages, convertResponsesTools, processResponsesStream } from "./openai-responses-shared.js";
 import { buildBaseOptions, clampReasoning } from "./simple-options.js";
@@ -83,70 +82,27 @@ export const streamOpenAIResponses: StreamFunction<"openai-responses", OpenAIRes
 	model: Model<"openai-responses">,
 	context: Context,
 	options?: OpenAIResponsesOptions,
-): AssistantMessageEventStream => {
-	const stream = new AssistantMessageEventStream();
-
-	// Start async processing
-	(async () => {
-		const output: AssistantMessage = {
-			role: "assistant",
-			content: [],
-			api: model.api as Api,
-			provider: model.provider,
-			model: model.id,
-			usage: {
-				input: 0,
-				output: 0,
-				cacheRead: 0,
-				cacheWrite: 0,
-				totalTokens: 0,
-				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-			},
-			stopReason: "stop",
-			timestamp: Date.now(),
-		};
-
-		try {
-			// Create OpenAI client
-			const apiKey = options?.apiKey || getEnvApiKey(model.provider) || "";
-			const client = await createClient(model, context, apiKey, options?.headers);
-			let params = buildParams(model, context, options);
-			const nextParams = await options?.onPayload?.(params, model);
-			if (nextParams !== undefined) {
-				params = nextParams as ResponseCreateParamsStreaming;
-			}
-			const openaiStream = await client.responses.create(
-				params,
-				options?.signal ? { signal: options.signal } : undefined,
-			);
-			stream.push({ type: "start", partial: output });
-
-			await processResponsesStream(openaiStream, output, stream, model, {
-				serviceTier: options?.serviceTier,
-				applyServiceTierPricing,
-			});
-
-			if (options?.signal?.aborted) {
-				throw new Error("Request was aborted");
-			}
-
-			if (output.stopReason === "aborted" || output.stopReason === "error") {
-				throw new Error("An unknown error occurred");
-			}
-
-			stream.push({ type: "done", reason: output.stopReason, message: output });
-			stream.end();
-		} catch (error) {
-			for (const block of output.content) delete (block as { index?: number }).index;
-			output.stopReason = options?.signal?.aborted ? "aborted" : "error";
-			output.errorMessage = error instanceof Error ? error.message : JSON.stringify(error);
-			stream.push({ type: "error", reason: output.stopReason, error: output });
-			stream.end();
+): AssistantMessageEventStream =>
+	createProviderStream(model, options, async (output, stream) => {
+		// Create OpenAI client
+		const apiKey = options?.apiKey || getEnvApiKey(model.provider) || "";
+		const client = await createClient(model, context, apiKey, options?.headers);
+		let params = buildParams(model, context, options);
+		const nextParams = await options?.onPayload?.(params, model);
+		if (nextParams !== undefined) {
+			params = nextParams as ResponseCreateParamsStreaming;
 		}
-	})();
+		const openaiStream = await client.responses.create(
+			params,
+			options?.signal ? { signal: options.signal } : undefined,
+		);
+		stream.push({ type: "start", partial: output });
 
-	return stream;
-};
+		await processResponsesStream(openaiStream, output, stream, model, {
+			serviceTier: options?.serviceTier,
+			applyServiceTierPricing,
+		});
+	});
 
 export const streamSimpleOpenAIResponses: StreamFunction<"openai-responses", SimpleStreamOptions> = (
 	model: Model<"openai-responses">,

--- a/packages/pi-ai/src/utils/stream-handler.ts
+++ b/packages/pi-ai/src/utils/stream-handler.ts
@@ -1,0 +1,125 @@
+import type { Api, AssistantMessage, Model, StopReason, StreamOptions } from "../types.js";
+import { AssistantMessageEventStream } from "./event-stream.js";
+
+/**
+ * Options for customizing error handling in {@link createProviderStream}.
+ */
+export interface ProviderStreamErrorHooks {
+	/**
+	 * Format the error message. Return a string to override the default
+	 * `error.message ?? JSON.stringify(error)` formatting.
+	 */
+	formatError?: (error: unknown) => string;
+
+	/**
+	 * Called after the output has been updated with stopReason/errorMessage
+	 * but before the error event is pushed to the stream.
+	 * Use this for provider-specific enrichment (e.g. retry-after headers,
+	 * appending metadata from the error object).
+	 */
+	onError?: (error: unknown, output: AssistantMessage) => void;
+}
+
+/**
+ * Create a new AssistantMessage output object with zero-initialized usage.
+ */
+export function createOutputMessage(model: Model<Api>): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [],
+		api: model.api as Api,
+		provider: model.provider,
+		model: model.id,
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: Date.now(),
+	};
+}
+
+/**
+ * Encapsulates the boilerplate every provider repeats:
+ *
+ * 1. Create an {@link AssistantMessageEventStream}.
+ * 2. Create a zero-initialized {@link AssistantMessage} output.
+ * 3. Kick off an async IIFE that calls {@link streamFn} inside try/catch.
+ * 4. On success: push `done` event and end the stream.
+ * 5. On error: clean up internal block properties, set `stopReason` /
+ *    `errorMessage`, push `error` event and end the stream.
+ * 6. Synchronously return the stream.
+ *
+ * The caller (provider) only needs to supply the streaming logic that
+ * populates `output` and pushes events to `stream`.
+ *
+ * @param model   The resolved model descriptor.
+ * @param options Provider-level stream options (used for `signal`).
+ * @param streamFn  Async function that does the actual streaming work.
+ *                  It receives the pre-built `output` and `stream` objects.
+ *                  It must **not** push `done`/`error` events or call
+ *                  `stream.end()` — that is handled automatically.
+ * @param hooks   Optional hooks for provider-specific error handling.
+ * @returns       An {@link AssistantMessageEventStream} that the caller
+ *                can return directly.
+ */
+export function createProviderStream(
+	model: Model<Api>,
+	options: StreamOptions | undefined,
+	streamFn: (output: AssistantMessage, stream: AssistantMessageEventStream) => Promise<void>,
+	hooks?: ProviderStreamErrorHooks,
+): AssistantMessageEventStream {
+	const stream = new AssistantMessageEventStream();
+
+	(async () => {
+		const output = createOutputMessage(model);
+
+		try {
+			await streamFn(output, stream);
+
+			if (options?.signal?.aborted) {
+				throw new Error("Request was aborted");
+			}
+
+			if (output.stopReason === "aborted" || output.stopReason === "error") {
+				throw new Error("An unknown error occurred");
+			}
+
+			stream.push({
+				type: "done",
+				reason: output.stopReason as Exclude<StopReason, "aborted" | "error">,
+				message: output,
+			});
+			stream.end();
+		} catch (error) {
+			// Clean up internal tracking properties that some providers attach
+			// to content blocks during streaming (e.g. `index`, `partialJson`).
+			for (const block of output.content) {
+				if ("index" in block) {
+					delete (block as { index?: number }).index;
+				}
+				if ("partialJson" in block) {
+					delete (block as { partialJson?: string }).partialJson;
+				}
+			}
+
+			output.stopReason = options?.signal?.aborted ? "aborted" : "error";
+			output.errorMessage = hooks?.formatError
+				? hooks.formatError(error)
+				: error instanceof Error
+					? error.message
+					: JSON.stringify(error);
+
+			hooks?.onError?.(error, output);
+
+			stream.push({ type: "error", reason: output.stopReason, error: output });
+			stream.end();
+		}
+	})();
+
+	return stream;
+}


### PR DESCRIPTION
## Summary

- Introduces `createProviderStream()` in `packages/pi-ai/src/utils/stream-handler.ts` that encapsulates the boilerplate every provider repeated: creating an `AssistantMessageEventStream`, initializing an `AssistantMessage` output, wrapping provider logic in an async IIFE with try/catch, cleaning up internal block properties on error, setting stopReason/errorMessage, pushing the error event, and ending the stream.
- Updates all 9 provider files (anthropic, amazon-bedrock, azure-openai-responses, google, google-vertex, google-gemini-cli, mistral, openai-completions, openai-responses, openai-codex-responses) to use the shared utility.
- Provider-specific error handling is preserved via optional hooks: `formatError` (Mistral custom formatting, Codex `String()` vs `JSON.stringify()`) and `onError` (Anthropic retry-after headers + transient network detection, OpenAI OpenRouter raw metadata).
- Net reduction of ~418 lines (910 added including the new utility, 1203 removed).

## Test plan

- [ ] Verify `npx tsc --noEmit` passes in `packages/pi-ai` (confirmed locally)
- [ ] Verify existing provider behavior is preserved (stream creation, error handling, abort signal)
- [ ] Verify Anthropic-specific error enrichment (retry-after, alibaba prefix, transient network)
- [ ] Verify OpenAI Completions OpenRouter metadata appending on error
- [ ] Verify Mistral custom error formatting
- [ ] Verify Codex websocket + SSE fallback paths still work correctly