### PR TITLE
fix: reload completed keys after worktree switch in auto-start

### DIFF
--- a/src/resources/extensions/gsd/auto-start.ts
+++ b/src/resources/extensions/gsd/auto-start.ts
@@ -350,6 +350,12 @@ export async function bootstrapAutoSession(
         ctx.ui.notify(`Created auto-worktree at ${wtPath}`, "info");
       }
       registerSigtermHandler(s.originalBasePath);
+      // Reload completed keys from worktree — the initial loadPersistedKeys ran
+      // against the project root (base) which may not have completed-units.json.
+      // The worktree has its own copy persisted by prior auto sessions. Without
+      // this reload, the completedKeySet is empty and previously completed units
+      // (e.g. research-milestone) get re-dispatched. (#1333)
+      loadPersistedKeys(s.basePath, s.completedKeySet);
     } catch (err) {
       ctx.ui.notify(
         `Auto-worktree setup failed: ${getErrorMessage(err)}. Continuing in project root.`,


### PR DESCRIPTION
## Problem

`loadPersistedKeys(base, s.completedKeySet)` runs at line 304 of `auto-start.ts` against the **project root** (`base`), but when worktree isolation is active, `completed-units.json` only exists in the **worktree** `.gsd/` directory — not in the project root.

The worktree switch happens ~40 lines later (line 343–348), after which `s.basePath` points to the worktree. But by then, `completedKeySet` is already empty because the project root had no `completed-units.json`.

### Consequence

Previously completed units (e.g. `research-milestone`) get re-dispatched on the next `/gsd auto` start. The dispatch table correctly resolves to `plan-milestone` (because the RESEARCH.md artifact exists), but the idempotency layer has an empty `completedKeySet` — so if `selfHealRuntimeRecords` does not find a stale runtime record to heal (e.g. because the prior session cleaned it up properly), the skip-path is never triggered.

**Observed behavior:** `/gsd auto` dispatches `research-milestone` again despite RESEARCH.md already existing and `completed-units.json` in the worktree containing `["research-milestone/M001"]`.

### Execution order (before fix)

```
s.basePath = base                          // project root
loadPersistedKeys(base, completedKeySet)   // reads from project root — file missing → empty set
...
s.basePath = wtPath                        // worktree switch
// completedKeySet is still empty
```

### Execution order (after fix)

```
s.basePath = base                          // project root
loadPersistedKeys(base, completedKeySet)   // reads from project root (may or may not exist)
...
s.basePath = wtPath                        // worktree switch
loadPersistedKeys(s.basePath, completedKeySet)  // reload from worktree — union into same Set
```

This matches the pattern already validated by the existing test `loadPersistedKeys unions keys from project root and worktree` in `auto-recovery.test.ts`, which demonstrates the intended dual-load behavior — but the production code only performed a single load.

## Fix

6-line addition after the worktree setup block in `bootstrapAutoSession`: call `loadPersistedKeys(s.basePath, s.completedKeySet)` after entering the worktree. Since `loadPersistedKeys` adds to the existing Set (union semantics), keys from both project root and worktree are preserved.

## Testing

- **Build:** `tsc` clean ✓
- **auto-recovery.test.ts:** 30/30 pass ✓ (includes the `unions keys from project root and worktree` test)
- **auto-dispatch-loop.test.ts:** 40/40 pass ✓ (idempotency skip/rerun/evict paths)
- **auto-worktree-milestone-merge.test.ts:** 30/30 pass ✓

## Related Issues

- **#1333** — Direct match: `completed-units.json` not persisted to correct path, causing stuck-loops on completed M001 units. Same root cause (worktree vs project root path mismatch for completed keys).
- **#1338** — Related pattern: milestone creation writes to project root instead of worktree. Same class of bug (operations using `base` before worktree switch).
- **#1339** — Related: auto-mode exits with "All milestones complete" when next milestone only in project root. Worktree state isolation gap.
- **#1363** — Related: session lock path mismatch via `gsdRoot()`. Same pattern of path divergence in worktree mode.

Refs: #1333