### PR TITLE
fix: restore LSP single-server selector export

### DIFF
--- a/packages/pi-coding-agent/src/core/lsp/config.ts
+++ b/packages/pi-coding-agent/src/core/lsp/config.ts
@@ -319,3 +319,6 @@ export function getServersForFile(config: LspConfig, filePath: string): Array<[s
 	});
 }
 
+export function getServerForFile(config: LspConfig, filePath: string): [string, ServerConfig] | null {
+	return getServersForFile(config, filePath)[0] ?? null;
+}


### PR DESCRIPTION
Summary:
Restore the missing getServerForFile export in packages/pi-coding-agent/src/core/lsp/config.ts.

Why:
packages/pi-coding-agent/src/core/lsp/index.ts still imports and uses the singular helper after the LSP dedup refactor. Without this export, TypeScript fails during npm run build, which breaks CI and the Pipeline Dev Publish job.

Verification:
- npm run build