### PR TITLE
test: add regression test for #1317 (worktree inside $HOME)

### DIFF
--- a/src/resources/extensions/gsd/tests/validate-directory.test.ts
+++ b/src/resources/extensions/gsd/tests/validate-directory.test.ts
@@ -101,6 +101,21 @@ test("validateDirectory: subdirectory of home is NOT blocked", () => {
   }
 });
 
+// Regression test for #1317: GSD worktree inside $HOME must not be blocked even
+// when the resolved project root equals $HOME (e.g. home dir is a git repo).
+test("validateDirectory: GSD worktree path nested under home is NOT blocked (#1317)", () => {
+  const worktreePath = join(homedir(), ".gsd", "worktrees", "M001");
+  mkdirSync(worktreePath, { recursive: true });
+  try {
+    // The worktree CWD itself is a valid location — it must pass.
+    const result = validateDirectory(worktreePath);
+    assert.equal(result.safe, true, "GSD worktree path should be safe to run in");
+    assert.equal(result.severity, "ok");
+  } finally {
+    rmSync(join(homedir(), ".gsd", "worktrees", "M001"), { recursive: true, force: true });
+  }
+});
+
 // ─── Temp directory root ─────────────────────────────────────────────────────────
 
 test("validateDirectory: temp directory root is blocked", () => {


### PR DESCRIPTION
## Summary
- Adds regression test for #1317: GSD worktree path nested under $HOME must not be blocked even when resolved project root equals $HOME
- Core fix already on main — this PR adds test coverage only

Extracted from closed PR #1324.

🤖 Generated with [Claude Code](https://claude.com/claude-code)