### PR TITLE
fix(gsd): accept 'passed' as terminal validation verdict

### DIFF
--- a/src/resources/extensions/gsd/state.ts
+++ b/src/resources/extensions/gsd/state.ts
@@ -64,11 +64,12 @@ export function isValidationTerminal(validationContent: string): boolean {
   if (!match) return false;
   const verdict = match[1].match(/verdict:\s*(\S+)/);
   if (!verdict) return false;
+  const v = verdict[1] === 'passed' ? 'pass' : verdict[1];
   // 'pass' and 'needs-attention' are always terminal.
   // 'needs-remediation' is treated as terminal to prevent infinite loops
   // when no remediation slices exist in the roadmap (#832). The validation
   // report is preserved on disk for manual review.
-  return verdict[1] === 'pass' || verdict[1] === 'needs-attention' || verdict[1] === 'needs-remediation';
+  return v === 'pass' || v === 'needs-attention' || v === 'needs-remediation';
 }
 
 // ─── State Derivation ──────────────────────────────────────────────────────

--- a/src/resources/extensions/gsd/tests/validate-milestone.test.ts
+++ b/src/resources/extensions/gsd/tests/validate-milestone.test.ts
@@ -104,6 +104,11 @@ test("isValidationTerminal returns true for verdict: needs-remediation (#832)", 
   assert.equal(isValidationTerminal(content), true);
 });
 
+test("isValidationTerminal returns true for verdict: passed (#1429)", () => {
+  const content = "---\nverdict: passed\nremediation_round: 0\n---\n\n# Validation";
+  assert.equal(isValidationTerminal(content), true);
+});
+
 test("isValidationTerminal returns false for missing frontmatter", () => {
   const content = "# Validation\nNo frontmatter here.";
   assert.equal(isValidationTerminal(content), false);


### PR DESCRIPTION
## Summary

- `isValidationTerminal()` now normalizes `verdict: passed` → `pass` before comparison
- LLM-generated validation files that write "passed" instead of "pass" are accepted as terminal
- Prevents milestones from being treated as incomplete despite having valid summaries and validation files

Closes #1429

**Depends on:** #1511 (missing imports fix — pre-existing CI failure on main)

## Test plan

- [x] New test in `validate-milestone.test.ts` verifies `verdict: passed` is accepted
- [x] All 21 existing validation tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)