### PR TITLE
fix: add missing parseRoadmap and unlinkSync imports

### DIFF
--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -12,7 +12,7 @@
 import type { GSDState } from "./types.js";
 import type { GSDPreferences } from "./preferences.js";
 import type { UatType } from "./files.js";
-import { loadFile, extractUatType, loadActiveOverrides } from "./files.js";
+import { loadFile, extractUatType, loadActiveOverrides, parseRoadmap } from "./files.js";
 import {
   resolveMilestoneFile,
   resolveMilestonePath,

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -127,7 +127,7 @@ import {
   formatTokenCount,
 } from "./metrics.js";
 import { join } from "node:path";
-import { readFileSync, existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { readFileSync, existsSync, mkdirSync, writeFileSync, unlinkSync } from "node:fs";
 import { atomicWriteSync } from "./atomic-write.js";
 import {
   autoCommitCurrentBranch,

--- a/src/resources/extensions/gsd/tests/worktree-sync-milestones.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-sync-milestones.test.ts
@@ -19,6 +19,7 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
 import { syncProjectRootToWorktree } from '../auto-worktree-sync.ts';
+import { syncGsdStateToWorktree } from '../auto-worktree.ts';
 import { createTestContext } from './test-helpers.ts';
 
 const { assertTrue, report } = createTestContext();


### PR DESCRIPTION
## Summary

- Add missing `parseRoadmap` import in `auto-dispatch.ts`
- Add missing `unlinkSync` import in `auto.ts`

These were dropped during the PR #1419 merge, breaking CI on main.

## Test plan

- [x] `npx tsc --noEmit` passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)