### PR TITLE
fix: prevent false-positive session lock loss during sleep/stalls (#1512)

### DIFF
--- a/src/resources/extensions/gsd/session-lock.ts
+++ b/src/resources/extensions/gsd/session-lock.ts
@@ -260,6 +260,16 @@ export function acquireSessionLock(basePath: string): SessionLockResult {
           stale: 1_800_000, // 30 minutes — match primary lock settings
           update: 10_000,
           onCompromised: () => {
+            // Same false-positive suppression as the primary lock (#1512).
+            // Without this, the retry path fires _lockCompromised unconditionally
+            // on benign mtime drift (laptop sleep, heavy LLM event loop stalls).
+            const elapsed = Date.now() - _lockAcquiredAt;
+            if (elapsed < 1_800_000) {
+              process.stderr.write(
+                `[gsd] Lock heartbeat mismatch after ${Math.round(elapsed / 1000)}s — event loop stall, continuing.\n`,
+              );
+              return;
+            }
             _lockCompromised = true;
             _releaseFunction = null;
           },
@@ -361,6 +371,26 @@ export function updateSessionLock(
 export function validateSessionLock(basePath: string): boolean {
   // Lock was compromised by proper-lockfile (mtime drift from sleep, stall, etc.)
   if (_lockCompromised) {
+    // Recovery gate (#1512): Before declaring the lock lost, check if the lock
+    // file still contains our PID. If it does, no other process took over — the
+    // onCompromised fired from benign mtime drift (laptop sleep, event loop stall
+    // beyond the stale window). Attempt re-acquisition instead of giving up.
+    const lp = lockPath(basePath);
+    const existing = readExistingLockData(lp);
+    if (existing && existing.pid === process.pid) {
+      // Lock file still ours — try to re-acquire the OS lock
+      try {
+        const result = acquireSessionLock(basePath);
+        if (result.acquired) {
+          process.stderr.write(
+            `[gsd] Lock recovered after onCompromised — lock file PID matched, re-acquired.\n`,
+          );
+          return true;
+        }
+      } catch {
+        // Re-acquisition failed — fall through to return false
+      }
+    }
     return false;
   }
 


### PR DESCRIPTION
## What
Prevents `onCompromised` from falsely terminating auto-mode sessions during laptop sleep or heavy event loop stalls when no other GSD process has actually taken over.

## Why
Fixes #1512
Long-running auto-mode sessions (20h+, 271 units) were being killed with "another GSD process appears to have taken over" when no other session existed. The `onCompromised` callback from `proper-lockfile` fires on benign mtime drift caused by laptop sleep or event loop stalls during heavy LLM operations.

## How
Two targeted changes in `session-lock.ts`:

### Key changes
- `src/resources/extensions/gsd/session-lock.ts` — **Retry path onCompromised handler**: Added the same elapsed-time false-positive suppression that the primary acquisition path already had. The retry path (used when re-acquiring after stale lock cleanup) was missing this check, unconditionally setting `_lockCompromised = true` on any mtime drift.
- `src/resources/extensions/gsd/session-lock.ts` — **validateSessionLock recovery gate**: Before returning `false` when `_lockCompromised` is set, the function now reads the lock file to check if the PID still matches the current process. If it does (no actual takeover), it attempts re-acquisition via `acquireSessionLock()`. This gives sessions a chance to recover from transient mtime drift that slips past the stale window.

## Testing
- [x] All 31 session-lock regression tests pass
- [x] All 33 auto-loop tests pass
- [x] All 12 auto-lock-creation tests pass
- [x] No new TypeScript errors introduced (pre-existing config-level errors only)
- [x] Edge cases considered: actual takeover (different PID in lock file) still correctly returns false; re-acquisition failure still correctly returns false

## Risk & rollback
Low risk. The retry `onCompromised` fix is a strict addition of existing logic. The `validateSessionLock` recovery gate has safe fallback behavior — if PID doesn't match or re-acquisition fails, it returns `false` as before. Worst case: a session that should have stopped gets one extra re-acquisition attempt before stopping.