### PR TITLE
fix: wire escalateTier into auto-loop retry path (#1505)

### DIFF
--- a/src/resources/extensions/gsd/auto-loop.ts
+++ b/src/resources/extensions/gsd/auto-loop.ts
@@ -456,6 +456,7 @@ export interface LoopDeps {
     prefs: GSDPreferences | undefined,
     verbose: boolean,
     startModel: { provider: string; id: string } | null,
+    retryContext?: { isRetry: boolean; previousTier?: string },
   ) => Promise<{ routing: { tier: string; modelDowngraded: boolean } | null }>;
   startUnitSupervision: (sctx: {
     s: AutoSession;
@@ -1182,6 +1183,14 @@ export async function autoLoop(
         unitId,
       });
 
+      // Detect retry and capture previous tier for escalation
+      const isRetry = !!(
+        s.currentUnit &&
+        s.currentUnit.type === unitType &&
+        s.currentUnit.id === unitId
+      );
+      const previousTier = s.currentUnitRouting?.tier;
+
       // Closeout previous unit
       if (s.currentUnit) {
         await deps.closeoutUnit(
@@ -1335,7 +1344,7 @@ export async function autoLoop(
         );
       }
 
-      // Select and apply model
+      // Select and apply model (with tier escalation on retry)
       const modelResult = await deps.selectAndApplyModel(
         ctx,
         pi,
@@ -1345,6 +1354,7 @@ export async function autoLoop(
         prefs,
         s.verbose,
         s.autoModeStartModel,
+        { isRetry, previousTier },
       );
       s.currentUnitRouting =
         modelResult.routing as AutoSession["currentUnitRouting"];

--- a/src/resources/extensions/gsd/auto-model-selection.ts
+++ b/src/resources/extensions/gsd/auto-model-selection.ts
@@ -7,8 +7,9 @@
 import type { ExtensionAPI, ExtensionContext } from "@gsd/pi-coding-agent";
 import type { GSDPreferences } from "./preferences.js";
 import { resolveModelWithFallbacksForUnit, resolveDynamicRoutingConfig } from "./preferences.js";
+import type { ComplexityTier } from "./complexity-classifier.js";
 import { classifyUnitComplexity, tierLabel } from "./complexity-classifier.js";
-import { resolveModelForComplexity } from "./model-router.js";
+import { resolveModelForComplexity, escalateTier } from "./model-router.js";
 import { getLedger, getProjectTotals } from "./metrics.js";
 import { unitPhaseLabel } from "./auto-dashboard.js";
 
@@ -33,6 +34,7 @@ export async function selectAndApplyModel(
   prefs: GSDPreferences | undefined,
   verbose: boolean,
   autoModeStartModel: { provider: string; id: string } | null,
+  retryContext?: { isRetry: boolean; previousTier?: string },
 ): Promise<ModelSelectionResult> {
   const modelConfig = resolveModelWithFallbacksForUnit(unitType);
   let routing: { tier: string; modelDowngraded: boolean } | null = null;
@@ -60,8 +62,27 @@ export async function selectAndApplyModel(
       const shouldClassify = !isHook || routingConfig.hooks !== false;
 
       if (shouldClassify) {
-        const classification = classifyUnitComplexity(unitType, unitId, basePath, budgetPct);
+        let classification = classifyUnitComplexity(unitType, unitId, basePath, budgetPct);
         const availableModelIds = availableModels.map(m => m.id);
+
+        // Escalate tier on retry when escalate_on_failure is enabled (default: true)
+        if (
+          retryContext?.isRetry &&
+          retryContext.previousTier &&
+          routingConfig.escalate_on_failure !== false
+        ) {
+          const escalated = escalateTier(retryContext.previousTier as ComplexityTier);
+          if (escalated) {
+            classification = { ...classification, tier: escalated, reason: "escalated after failure" };
+            if (verbose) {
+              ctx.ui.notify(
+                `Tier escalation: ${retryContext.previousTier} → ${escalated} (retry after failure)`,
+                "info",
+              );
+            }
+          }
+        }
+
         const routingResult = resolveModelForComplexity(classification, modelConfig, routingConfig, availableModelIds);
 
         if (routingResult.wasDowngraded) {


### PR DESCRIPTION
## What
Wire the existing `escalateTier()` function from `model-router.ts` into the auto-loop retry path, so that when a unit fails and is retried, the model tier is escalated (e.g., light → standard → heavy).

## Why
`escalateTier()` was fully implemented and tested but never called at runtime. The `escalate_on_failure` config option was parsed and validated but never read. Users expect failure escalation to work when `dynamic_routing` is enabled.

Fixes #1505 (partial — addresses the `escalateTier` dead code path)

## How
- **`auto-model-selection.ts`**: Added optional `retryContext` parameter to `selectAndApplyModel()`. After complexity classification, if this is a retry and `escalate_on_failure !== false`, the classified tier is overridden with the escalated tier from `escalateTier()`.
- **`auto-loop.ts`**: Computed `isRetry` and `previousTier` before unit closeout (where `currentUnitRouting` is still available), then passed them as `retryContext` to `selectAndApplyModel()`.

## Key changes
- `selectAndApplyModel` accepts optional `retryContext?: { isRetry: boolean; previousTier?: string }` (backward-compatible — all existing callers continue to work without changes)
- Escalation respects `escalate_on_failure` config (default: `true` per `defaultRoutingConfig()`)
- Escalation only fires when dynamic routing is enabled, this is a retry, and the previous tier is known
- Verbose mode logs the escalation for observability
- No new state added to `AutoSession` — retry context is computed inline and passed as a parameter

## Testing
- `npx tsc --noEmit` passes cleanly
- All 12 existing `model-router.test.ts` tests pass (including `escalateTier` unit tests)
- No behavioral change when `dynamic_routing` is disabled or `escalate_on_failure: false`
- The second call site (sidecar dispatch at ~line 1524) intentionally does not pass retry context — sidecar units are not retries

## Risk
Low. The new parameter is optional with no default behavior change. Escalation only activates when three conditions are met simultaneously: dynamic routing enabled, `escalate_on_failure` not explicitly disabled, and the dispatch is a retry of the same unit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)