### PR TITLE
fix: separate pi-tui layout utils to fix report generation

### DIFF
--- a/src/resources/extensions/gsd/history.ts
+++ b/src/resources/extensions/gsd/history.ts
@@ -2,7 +2,8 @@
 // Human-readable display of past auto-mode unit executions.
 
 import type { ExtensionCommandContext } from "@gsd/pi-coding-agent";
-import { formatDuration, padRight, truncateWithEllipsis } from "../shared/format-utils.js";
+import { formatDuration, truncateWithEllipsis } from "../shared/format-utils.js";
+import { padRight } from "../shared/layout-utils.js";
 import {
   getLedger, getProjectTotals, formatCost, formatTokenCount,
   aggregateBySlice, aggregateByPhase, aggregateByModel, loadLedgerFromDisk,

--- a/src/resources/extensions/gsd/metrics.ts
+++ b/src/resources/extensions/gsd/metrics.ts
@@ -20,8 +20,10 @@ import { getAndClearSkills } from "./skill-telemetry.js";
 import { loadJsonFile, loadJsonFileOrNull, saveJsonFile } from "./json-persistence.js";
 import { parseUnitId } from "./unit-id.js";
 
-// Re-export from shared — canonical implementation lives in format-utils.
-export { formatTokenCount } from "../shared/mod.js";
+// Re-export from shared — import directly from format-utils to avoid pulling
+// in the full barrel (mod.js → ui.js → @gsd/pi-tui) which breaks when loaded
+// outside jiti's alias resolution (e.g. dynamic import in auto-loop reports).
+export { formatTokenCount } from "../shared/format-utils.js";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 

--- a/src/resources/extensions/shared/format-utils.ts
+++ b/src/resources/extensions/shared/format-utils.ts
@@ -1,11 +1,11 @@
 /**
- * Shared formatting and layout utilities for TUI dashboard components.
+ * Shared pure formatting utilities — no @gsd/pi-tui dependency.
  *
- * Consolidates helpers that were previously duplicated across
- * auto-dashboard.ts, dashboard-overlay.ts, and visualizer-views.ts.
+ * ANSI-aware layout helpers (padRight, joinColumns, centerLine, fitColumns)
+ * live in layout-utils.ts to avoid pulling @gsd/pi-tui into modules that
+ * run outside jiti's alias resolution (e.g. HTML report generation via
+ * dynamic import in auto-loop).
  */
-
-import { truncateToWidth, visibleWidth } from "@gsd/pi-tui";
 
 // ─── Duration Formatting ──────────────────────────────────────────────────────
 
@@ -29,45 +29,6 @@ export function formatTokenCount(count: number): string {
   if (count < 1000) return `${count}`;
   if (count < 1_000_000) return `${(count / 1000).toFixed(1)}k`;
   return `${(count / 1_000_000).toFixed(2)}M`;
-}
-
-// ─── Layout Helpers ───────────────────────────────────────────────────────────
-
-/** Pad a string with trailing spaces to fill `width` (ANSI-aware). */
-export function padRight(content: string, width: number): string {
-  const vis = visibleWidth(content);
-  return content + " ".repeat(Math.max(0, width - vis));
-}
-
-/** Build a line with left-aligned and right-aligned content. */
-export function joinColumns(left: string, right: string, width: number): string {
-  const leftW = visibleWidth(left);
-  const rightW = visibleWidth(right);
-  if (leftW + rightW + 2 > width) {
-    return truncateToWidth(`${left}  ${right}`, width);
-  }
-  return left + " ".repeat(width - leftW - rightW) + right;
-}
-
-/** Center content within `width` (ANSI-aware). */
-export function centerLine(content: string, width: number): string {
-  const vis = visibleWidth(content);
-  if (vis >= width) return truncateToWidth(content, width);
-  const leftPad = Math.floor((width - vis) / 2);
-  return " ".repeat(leftPad) + content;
-}
-
-/** Join as many parts as fit within `width`, separated by `separator`. */
-export function fitColumns(parts: string[], width: number, separator = "  "): string {
-  const filtered = parts.filter(Boolean);
-  if (filtered.length === 0) return "";
-  let result = filtered[0];
-  for (let i = 1; i < filtered.length; i++) {
-    const candidate = `${result}${separator}${filtered[i]}`;
-    if (visibleWidth(candidate) > width) break;
-    result = candidate;
-  }
-  return truncateToWidth(result, width);
 }
 
 // ─── Text Truncation ─────────────────────────────────────────────────────────

--- a/src/resources/extensions/shared/layout-utils.ts
+++ b/src/resources/extensions/shared/layout-utils.ts
@@ -1,0 +1,49 @@
+/**
+ * ANSI-aware TUI layout utilities that depend on @gsd/pi-tui.
+ *
+ * Separated from format-utils.ts so that modules needing only pure
+ * formatting (e.g. HTML report generation) can import format-utils
+ * without pulling in the @gsd/pi-tui dependency — which fails when
+ * loaded outside jiti's alias resolution context.
+ */
+
+import { truncateToWidth, visibleWidth } from "@gsd/pi-tui";
+
+// ─── Layout Helpers ───────────────────────────────────────────────────────────
+
+/** Pad a string with trailing spaces to fill `width` (ANSI-aware). */
+export function padRight(content: string, width: number): string {
+  const vis = visibleWidth(content);
+  return content + " ".repeat(Math.max(0, width - vis));
+}
+
+/** Build a line with left-aligned and right-aligned content. */
+export function joinColumns(left: string, right: string, width: number): string {
+  const leftW = visibleWidth(left);
+  const rightW = visibleWidth(right);
+  if (leftW + rightW + 2 > width) {
+    return truncateToWidth(`${left}  ${right}`, width);
+  }
+  return left + " ".repeat(width - leftW - rightW) + right;
+}
+
+/** Center content within `width` (ANSI-aware). */
+export function centerLine(content: string, width: number): string {
+  const vis = visibleWidth(content);
+  if (vis >= width) return truncateToWidth(content, width);
+  const leftPad = Math.floor((width - vis) / 2);
+  return " ".repeat(leftPad) + content;
+}
+
+/** Join as many parts as fit within `width`, separated by `separator`. */
+export function fitColumns(parts: string[], width: number, separator = "  "): string {
+  const filtered = parts.filter(Boolean);
+  if (filtered.length === 0) return "";
+  let result = filtered[0];
+  for (let i = 1; i < filtered.length; i++) {
+    const candidate = `${result}${separator}${filtered[i]}`;
+    if (visibleWidth(candidate) > width) break;
+    result = candidate;
+  }
+  return truncateToWidth(result, width);
+}

--- a/src/resources/extensions/shared/mod.ts
+++ b/src/resources/extensions/shared/mod.ts
@@ -13,14 +13,17 @@ export {
 	stripAnsi,
 	formatTokenCount,
 	formatDuration,
-	padRight,
-	joinColumns,
-	centerLine,
-	fitColumns,
 	sparkline,
 	normalizeStringArray,
 	fileLink,
 } from "./format-utils.js";
+
+export {
+	padRight,
+	joinColumns,
+	centerLine,
+	fitColumns,
+} from "./layout-utils.js";
 
 export { shortcutDesc } from "./terminal.js";
 export { toPosixPath } from "./path-display.js";

--- a/src/resources/extensions/shared/tests/format-utils.test.ts
+++ b/src/resources/extensions/shared/tests/format-utils.test.ts
@@ -2,13 +2,15 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import {
   formatDuration,
+  sparkline,
+  stripAnsi,
+} from "../format-utils.js";
+import {
   padRight,
   joinColumns,
   centerLine,
   fitColumns,
-  sparkline,
-  stripAnsi,
-} from "../format-utils.js";
+} from "../layout-utils.js";
 
 describe("formatDuration", () => {
   it("formats seconds", () => {


### PR DESCRIPTION
## TL;DR

**What:** Separates ANSI-aware TUI layout functions from pure formatting utilities into a dedicated `layout-utils.ts` module.
**Why:** Report generation fails with `Cannot find package '@gsd/pi-tui'` because dynamic imports in auto-loop bypass jiti's alias resolution.
**How:** Moved pi-tui-dependent functions to `layout-utils.ts`, keeping `format-utils.ts` dependency-free so report modules can import formatting functions without triggering pi-tui resolution.

## What

- Created `src/resources/extensions/shared/layout-utils.ts` containing the 4 ANSI-aware layout functions that depend on `@gsd/pi-tui`: `padRight`, `joinColumns`, `centerLine`, `fitColumns`
- Cleaned `src/resources/extensions/shared/format-utils.ts` — removed `@gsd/pi-tui` import, now contains only pure formatting functions
- Updated `src/resources/extensions/shared/mod.ts` — barrel re-exports layout functions from `layout-utils.js` instead of `format-utils.js`
- Fixed `src/resources/extensions/gsd/metrics.ts` — imports `formatTokenCount` directly from `format-utils.js` instead of the barrel `mod.js` (which pulls in `ui.js` → `@gsd/pi-tui`)
- Updated `src/resources/extensions/gsd/history.ts` — imports `padRight` from `layout-utils.js`
- Updated test file to match new import structure

## Why

Report generation in `auto-loop.ts` uses native `await import("./export-html.js")` which bypasses jiti's module alias resolution. The transitive import chain was:

1. `auto-loop.ts` → `await import("./export-html.js")` (native ESM, not jiti)
2. `export-html.js` → `import from './metrics.js'`
3. `metrics.js` → `export { formatTokenCount } from "../shared/mod.js"` (barrel)
4. `mod.js` → `export { makeUI, ... } from "./ui.js"`
5. `ui.js` → `import { ... } from "@gsd/pi-tui"` — **fails** because Node resolves from `~/.gsd/agent/extensions/` where `@gsd/pi-tui` is not available

Additionally, `format-utils.ts` itself imported `@gsd/pi-tui` at the top level for layout helpers, meaning any module importing even pure formatting functions (like `formatDuration` or `formatDateShort`) would also trigger the failing resolution.

## How

The fix separates concerns at the module boundary:

- **`format-utils.ts`** — pure functions only (no external deps): `formatDuration`, `formatTokenCount`, `formatDateShort`, `sparkline`, `stripAnsi`, `fileLink`, `truncateWithEllipsis`, `normalizeStringArray`
- **`layout-utils.ts`** — ANSI-aware TUI layout helpers that require `@gsd/pi-tui`: `padRight`, `joinColumns`, `centerLine`, `fitColumns`

This ensures that report modules (`export-html.ts`, `reports.ts`) can safely import pure formatting functions via native dynamic `import()` without pulling in the `@gsd/pi-tui` dependency. TUI modules continue to get layout functions through the `mod.js` barrel or direct `layout-utils.js` import — both loaded through jiti where aliases work correctly.

The `metrics.ts` fix (importing from `format-utils.js` directly instead of `mod.js`) breaks the second transitive path through the barrel → `ui.js` → `@gsd/pi-tui`.

- [ ] `fix` — Bug fix

AI-assisted contribution (Claude Code). Tested locally — build passes, type check passes, all relevant tests pass (22/23; the 1 failure is pre-existing in `formatDuration(0)` test).