### PR TITLE
Update installation command for gsd-pi to latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This version is different. GSD is now a standalone CLI built on the [Pi SDK](htt
 
 One command. Walk away. Come back to a built project with clean git history.
 
-<pre><code>npm install -g gsd-pi</code></pre>
+<pre><code>npm install -g gsd-pi@latest</code></pre>
 
 > **📋 NOTICE: New to Node on Mac?** If you installed Node.js via Homebrew, you may be running a development release instead of LTS. **[Read this guide](./docs/node-lts-macos.md)** to pin Node 24 LTS and avoid compatibility issues.
 


### PR DESCRIPTION
Just a minor edit to make sure the user doesn't have to update after launching

## TL;DR

**What:** <!-- One sentence — what does this change? --> I changed the install command to include @latest
**Why:** <!-- One sentence — why is it needed? --> The one without @latest is installing an older version.
**How:** <!-- One sentence — what's the approach? --> This installs the latest version of the CLI

## What

Updated the install command in the README to include @latest.

## Why

This just installs the latest version and fixes this issue. Solves #1539 

## How

This is just a minor edit in the install command.

## Change type

- [ ] `feat` — New feature or capability
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [- ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [ ] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [- ] No breaking changes
- [ ] Yes — described above

## Test plan

- [ ] CI passes
- [ ] New/updated tests included
- [ ] Manual testing — steps described above
- [- ] No tests needed — explained above

## AI disclosure

- [ ] This PR includes AI-assisted code <!-- If so, note the tool and what was tested -->
