### PR TITLE
fix(ci): reduce GitHub Actions minutes ~60-70%

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,24 +2,41 @@ name: CI
 
 on:
   push:
-    branches: [main, feat/**]
+    branches: [main]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - '.github/workflows/ai-triage.yml'
+      - '.github/workflows/build-native.yml'
+      - '.github/workflows/cleanup-dev-versions.yml'
+      - '.github/workflows/pipeline.yml'
+      - 'LICENSE'
   pull_request:
     branches: [main]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - '.github/workflows/ai-triage.yml'
+      - '.github/workflows/build-native.yml'
+      - '.github/workflows/cleanup-dev-versions.yml'
+      - '.github/workflows/pipeline.yml'
+      - 'LICENSE'
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  secret-scan:
+  lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+
       - name: Scan for hardcoded secrets
         run: bash scripts/secret-scan.sh --diff origin/main
 
-  no-gsd-dir:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
       - name: Ensure .gsd/ is not checked in
         run: |
           if [ -d ".gsd" ]; then
@@ -27,14 +44,11 @@ jobs:
             exit 1
           fi
 
-  skill-references:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
           node-version: '24'
+
       - name: Validate skill references
         run: node scripts/check-skill-references.mjs
 
@@ -72,6 +86,7 @@ jobs:
         run: npm run test:integration
 
   windows-portability:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: windows-latest
 
     steps:


### PR DESCRIPTION
## Summary

- **Remove `feat/**` push trigger** — PRs already cover feature branches targeting main. This alone eliminates ~40-50% of duplicate runs (every feat branch push was firing CI *in addition to* the PR trigger)
- **Add `concurrency` with `cancel-in-progress`** — rapid pushes to the same ref cancel stale runs instead of running to completion
- **Add `paths-ignore`** — docs/markdown/license/unrelated workflow file changes skip CI entirely
- **Consolidate 3 trivial jobs into 1 `lint` job** — `secret-scan`, `no-gsd-dir`, and `skill-references` shared a single runner instead of spinning up 3 separate runners with their own checkout
- **Restrict Windows runner to `main` push only** — the 2x minute multiplier no longer fires on every PR iteration

### Impact

| Metric | Before | After (est.) |
|---|---|---|
| Monthly minutes | ~10,271 | ~3,000-4,000 |
| Monthly cost (overage) | ~$144 | ~$0-38 |
| CI runs/day | ~69 | ~25-30 |
| Jobs per run | 5 | 2-3 |

## Test plan

- [ ] Verify CI triggers on push to main
- [ ] Verify CI triggers on PR to main
- [ ] Verify CI does NOT trigger on push to feat/* branches (only via PR)
- [ ] Verify docs-only changes skip CI
- [ ] Verify Windows job only runs on main push, not PRs
- [ ] Verify concurrent pushes cancel previous runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)