### PR TITLE
fix(tui,gsd): prevent stack overflow on large renders + detect intra-unit tool loops

### DIFF
--- a/packages/pi-tui/src/components/markdown.ts
+++ b/packages/pi-tui/src/components/markdown.ts
@@ -121,7 +121,7 @@ export class Markdown implements Component {
 			const token = tokens[i];
 			const nextToken = tokens[i + 1];
 			const tokenLines = this.renderToken(token, contentWidth, nextToken?.type);
-			renderedLines.push(...tokenLines);
+			for (let i = 0; i < tokenLines.length; i++) renderedLines.push(tokenLines[i]);
 		}
 
 		// Wrap lines (NO padding, NO background yet)
@@ -308,7 +308,8 @@ export class Markdown implements Component {
 			}
 
 			case "code": {
-				lines.push(...this.renderCodeBlock(token.text, token.lang));
+				{ const codeBlockLines = this.renderCodeBlock(token.text, token.lang);
+				for (let i = 0; i < codeBlockLines.length; i++) lines.push(codeBlockLines[i]); }
 				if (nextTokenType !== "space") {
 					lines.push(""); // Add spacing after code blocks (unless space token follows)
 				}
@@ -317,7 +318,7 @@ export class Markdown implements Component {
 
 			case "list": {
 				const listLines = this.renderList(token as any, 0, styleContext);
-				lines.push(...listLines);
+				for (let i = 0; i < listLines.length; i++) lines.push(listLines[i]);
 				// Don't add spacing after lists if a space token follows
 				// (the space token will handle it)
 				break;
@@ -325,7 +326,7 @@ export class Markdown implements Component {
 
 			case "table": {
 				const tableLines = this.renderTable(token as any, width, styleContext);
-				lines.push(...tableLines);
+				for (let i = 0; i < tableLines.length; i++) lines.push(tableLines[i]);
 				break;
 			}
 
@@ -561,7 +562,7 @@ export class Markdown implements Component {
 				// Nested list - render with one additional indent level
 				// These lines will have their own indent, so we just add them as-is
 				const nestedLines = this.renderList(token as any, parentDepth + 1, styleContext);
-				lines.push(...nestedLines);
+				for (let i = 0; i < nestedLines.length; i++) lines.push(nestedLines[i]);
 			} else if (token.type === "text") {
 				// Text content (may have inline tokens)
 				const text =
@@ -575,7 +576,8 @@ export class Markdown implements Component {
 				lines.push(text);
 			} else if (token.type === "code") {
 				// Code block in list item
-				lines.push(...this.renderCodeBlock(token.text, token.lang));
+				{ const codeLines = this.renderCodeBlock(token.text, token.lang);
+			for (let i = 0; i < codeLines.length; i++) lines.push(codeLines[i]); }
 			} else {
 				// Other token types - try to render as inline
 				const text = this.renderInlineTokens([token], styleContext);

--- a/packages/pi-tui/src/components/settings-list.ts
+++ b/packages/pi-tui/src/components/settings-list.ts
@@ -91,7 +91,8 @@ export class SettingsList implements Component {
 		const lines: string[] = [];
 
 		if (this.searchEnabled && this.searchInput) {
-			lines.push(...this.searchInput.render(width));
+			const rendered = this.searchInput.render(width);
+			for (let i = 0; i < rendered.length; i++) lines.push(rendered[i]);
 			lines.push("");
 		}
 

--- a/packages/pi-tui/src/tui.ts
+++ b/packages/pi-tui/src/tui.ts
@@ -191,7 +191,8 @@ export class Container implements Component {
 	render(width: number): string[] {
 		const lines: string[] = [];
 		for (const child of this.children) {
-			lines.push(...child.render(width));
+			const rendered = child.render(width);
+			for (let i = 0; i < rendered.length; i++) lines.push(rendered[i]);
 		}
 		return lines;
 	}

--- a/src/resources/extensions/gsd/auto-loop.ts
+++ b/src/resources/extensions/gsd/auto-loop.ts
@@ -26,6 +26,7 @@ import type {
 import type { DispatchAction } from "./auto-dispatch.js";
 import type { WorktreeResolver } from "./worktree-resolver.js";
 import { debugLog } from "./debug-logger.js";
+import { resetToolLoopGuard, disableToolLoopGuard } from "./auto-tool-loop-guard.js";
 import type { CmuxLogLevel } from "../cmux/index.js";
 
 /**
@@ -231,6 +232,9 @@ export async function runUnit(
       process.chdir(s.basePath);
     }
   } catch { /* non-fatal — chdir may fail if dir was removed */ }
+
+  // ── Reset intra-unit tool loop guard ──
+  resetToolLoopGuard();
 
   // ── Send the prompt ──
   debugLog("runUnit", { phase: "send-message", unitType, unitId });

--- a/src/resources/extensions/gsd/auto-tool-loop-guard.ts
+++ b/src/resources/extensions/gsd/auto-tool-loop-guard.ts
@@ -1,0 +1,65 @@
+/**
+ * Intra-unit tool-call loop guard.
+ * Detects when a model is stuck calling the same tool with the same arguments
+ * repeatedly within a single unit execution.
+ */
+
+import { createHash } from "crypto";
+
+const MAX_CONSECUTIVE_IDENTICAL_CALLS = 5;
+
+let consecutiveCount = 0;
+let lastSignature = "";
+let unitActive = false;
+
+/** Hash a tool call into a compact signature. */
+function hashToolCall(toolName: string, args: Record<string, unknown>): string {
+  const h = createHash("sha256");
+  h.update(toolName);
+  h.update(JSON.stringify(args));
+  return h.digest("hex").slice(0, 16);
+}
+
+/** Call at the start of each unit dispatch to reset tracking. */
+export function resetToolLoopGuard(): void {
+  consecutiveCount = 0;
+  lastSignature = "";
+  unitActive = true;
+}
+
+/** Call when auto-mode stops or pauses. */
+export function disableToolLoopGuard(): void {
+  unitActive = false;
+  consecutiveCount = 0;
+  lastSignature = "";
+}
+
+/**
+ * Record a tool call. Returns true if the call is allowed,
+ * false if the loop threshold has been exceeded (caller should abort).
+ */
+export function recordToolCall(
+  toolName: string,
+  args: Record<string, unknown>,
+): { allowed: boolean; count: number } {
+  if (!unitActive) return { allowed: true, count: 0 };
+
+  const sig = hashToolCall(toolName, args);
+
+  if (sig === lastSignature) {
+    consecutiveCount++;
+  } else {
+    consecutiveCount = 1;
+    lastSignature = sig;
+  }
+
+  return {
+    allowed: consecutiveCount < MAX_CONSECUTIVE_IDENTICAL_CALLS,
+    count: consecutiveCount,
+  };
+}
+
+/** Get current consecutive count (for diagnostics). */
+export function getConsecutiveToolCallCount(): number {
+  return consecutiveCount;
+}

--- a/src/resources/extensions/gsd/auto-tool-tracking.ts
+++ b/src/resources/extensions/gsd/auto-tool-tracking.ts
@@ -27,7 +27,10 @@ export function markToolEnd(toolCallId: string): void {
  */
 export function getOldestInFlightToolAgeMs(): number {
   if (inFlightTools.size === 0) return 0;
-  const oldestStart = Math.min(...inFlightTools.values());
+  let oldestStart = Infinity;
+  for (const t of inFlightTools.values()) {
+    if (t < oldestStart) oldestStart = t;
+  }
   return Date.now() - oldestStart;
 }
 
@@ -43,7 +46,11 @@ export function getInFlightToolCount(): number {
  */
 export function getOldestInFlightToolStart(): number | undefined {
   if (inFlightTools.size === 0) return undefined;
-  return Math.min(...inFlightTools.values());
+  let oldest = Infinity;
+  for (const t of inFlightTools.values()) {
+    if (t < oldest) oldest = t;
+  }
+  return oldest;
 }
 
 /**

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -156,6 +156,7 @@ import {
 import { pruneQueueOrder } from "./queue-order.js";
 
 import { debugLog, isDebugEnabled, writeDebugSummary } from "./debug-logger.js";
+import { disableToolLoopGuard } from "./auto-tool-loop-guard.js";
 import {
   resolveExpectedArtifactPath,
   verifyExpectedArtifact,
@@ -534,6 +535,7 @@ export async function stopAuto(
   reason?: string,
 ): Promise<void> {
   if (!s.active && !s.paused) return;
+  disableToolLoopGuard();
   const loadedPreferences = loadEffectiveGSDPreferences()?.preferences;
   const reasonSuffix = reason ? ` — ${reason}` : "";
   clearUnitTimeout();
@@ -671,6 +673,7 @@ export async function pauseAuto(
   _pi?: ExtensionAPI,
 ): Promise<void> {
   if (!s.active) return;
+  disableToolLoopGuard();
   clearUnitTimeout();
 
   s.pausedSessionFile = ctx?.sessionManager?.getSessionFile() ?? null;

--- a/src/resources/extensions/gsd/index.ts
+++ b/src/resources/extensions/gsd/index.ts
@@ -66,6 +66,7 @@ import { toPosixPath } from "../shared/mod.js";
 import { isParallelActive, shutdownParallel } from "./parallel-orchestrator.js";
 import { DEFAULT_BASH_TIMEOUT_SECS } from "./constants.js";
 import { markCmuxPromptShown, shouldPromptToEnableCmux } from "../cmux/index.js";
+import { recordToolCall, resetToolLoopGuard, disableToolLoopGuard } from "./auto-tool-loop-guard.js";
 
 // ── Agent Instructions (DEPRECATED) ──────────────────────────────────────
 // agent-instructions.md is deprecated. Use AGENTS.md or CLAUDE.md instead.
@@ -1103,6 +1104,17 @@ export default function (pi: ExtensionAPI) {
   pi.on("tool_execution_start", async (event) => {
     if (!isAutoActive()) return;
     markToolStart(event.toolCallId);
+
+    // Intra-unit tool-call loop detection
+    const loopCheck = recordToolCall(event.toolName, event.args ?? {});
+    if (!loopCheck.allowed) {
+      ctx.ui.notify(
+        `Tool loop detected: ${event.toolName} called ${loopCheck.count} times with identical arguments. Aborting unit.`,
+        "error",
+      );
+      disableToolLoopGuard();
+      await pauseAuto(ctx, pi);
+    }
   });
 
   pi.on("tool_execution_end", async (event) => {


### PR DESCRIPTION
## Summary

- **Bug 1 — TUI Stack Overflow**: Replaced `Array.push(...spread)` with loop-based push in `Container.render()`, `Markdown` component (6 instances), `SettingsList` component, and `auto-tool-tracking.ts` `Math.min(...spread)`. Prevents V8 call stack exhaustion when child components return thousands of lines.
- **Bug 2 — Intra-unit tool loop detection**: Added `auto-tool-loop-guard.ts` that tracks consecutive identical tool calls (same name + same args hash) within a single unit execution. When a tool is called 5+ times with identical arguments, auto-mode pauses with a notification. Guard resets on each `runUnit` dispatch and disables on `stopAuto`/`pauseAuto`.

Closes #1551

## Test plan

- [ ] Verify TUI renders correctly with large markdown content (no RangeError)
- [ ] Verify auto-mode pauses with notification when a model enters a tool call loop
- [ ] Verify the loop guard resets between unit dispatches (no false positives across units)
- [ ] Verify `npx tsc --noEmit` passes for both `packages/pi-tui` and root `tsconfig.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)