### PR TITLE
fix: respect pi:{} manifest opt-out in package-manager resolveExtensionEntries

### DIFF
--- a/packages/pi-coding-agent/src/core/package-manager.ts
+++ b/packages/pi-coding-agent/src/core/package-manager.ts
@@ -414,7 +414,13 @@ function resolveExtensionEntries(dir: string): string[] | null {
 	const packageJsonPath = join(dir, "package.json");
 	if (existsSync(packageJsonPath)) {
 		const manifest = readPiManifestFile(packageJsonPath);
-		if (manifest?.extensions?.length) {
+		if (manifest) {
+			// When a pi manifest exists, it is authoritative — don't fall through
+			// to index.ts/index.js auto-detection. This allows library directories
+			// (like cmux) to opt out by declaring "pi": {} with no extensions.
+			if (!manifest.extensions?.length) {
+				return null;
+			}
 			const entries: string[] = [];
 			for (const extPath of manifest.extensions) {
 				const resolvedExtPath = resolve(dir, extPath);
@@ -422,9 +428,7 @@ function resolveExtensionEntries(dir: string): string[] | null {
 					entries.push(resolvedExtPath);
 				}
 			}
-			if (entries.length > 0) {
-				return entries;
-			}
+			return entries.length > 0 ? entries : null;
 		}
 	}
 


### PR DESCRIPTION
## Problem

`resolveExtensionEntries()` in `package-manager.ts` does not treat an existing `pi` manifest as authoritative. When a directory has a `package.json` with `"pi": {}` (no `extensions` array), the function falls through to the `index.ts`/`index.js` auto-detection fallback, causing library directories like `cmux` to be incorrectly loaded as extensions.

This produces the error on startup:
```
[gsd] Extension load error: Extension does not export a valid factory function: .../cmux/index.js
```

## Root cause

There are two copies of `resolveExtensionEntries`:

1. **`extensions/loader.ts`** (correct) — checks if manifest exists, returns `null` when `pi: {}` has no extensions, with a comment explaining the opt-out pattern:
   ```ts
   if (manifest) {
       // When a pi manifest exists, it is authoritative
       if (!manifest.extensions?.length) {
           return null;
       }
       // ...
   }
   ```

2. **`package-manager.ts`** (buggy) — only checks `manifest?.extensions?.length`, which is falsy for `pi: {}`, so it falls through to `index.js` auto-detection:
   ```ts
   if (manifest?.extensions?.length) {
       // ... never enters for pi: {}
   }
   // falls through to index.js detection
   ```

The `loader.ts` version is used by `discoverExtensionsInDir()` (direct extension discovery), while the `package-manager.ts` version is used by the `DefaultPackageManager.resolve()` path — which is the one actually called during startup via `ResourceLoader.reload()`.

## Fix

Align `package-manager.ts` with `loader.ts`: when a `pi` manifest exists, treat it as authoritative and return `null` if no extensions are declared.