### PR TITLE
feat: add GSD_PROJECT_ID env var to override project hash

### DIFF
--- a/src/resources/extensions/gsd/auto-start.ts
+++ b/src/resources/extensions/gsd/auto-start.ts
@@ -20,7 +20,7 @@ import {
   resolveSkillDiscoveryMode,
   getIsolationMode,
 } from "./preferences.js";
-import { ensureGsdSymlink } from "./repo-identity.js";
+import { ensureGsdSymlink, validateProjectId } from "./repo-identity.js";
 import { migrateToExternalState, recoverFailedMigration } from "./migrate-external.js";
 import { collectSecretsFromManifest } from "../get-secrets-from-user.js";
 import { gsdRoot, resolveMilestoneFile, milestonesDir } from "./paths.js";
@@ -130,6 +130,16 @@ export async function bootstrapAutoSession(
   }
 
   try {
+    // Validate GSD_PROJECT_ID early so the user gets immediate feedback
+    const customProjectId = process.env.GSD_PROJECT_ID;
+    if (customProjectId && !validateProjectId(customProjectId)) {
+      ctx.ui.notify(
+        `GSD_PROJECT_ID must contain only alphanumeric characters, hyphens, and underscores. Got: "${customProjectId}"`,
+        "error",
+      );
+      return releaseLockAndReturn();
+    }
+
     // Ensure git repo exists
     if (!nativeIsRepo(base)) {
       const mainBranch =

--- a/src/resources/extensions/gsd/repo-identity.ts
+++ b/src/resources/extensions/gsd/repo-identity.ts
@@ -93,13 +93,30 @@ function resolveGitRoot(basePath: string): string {
 }
 
 /**
+ * Validate a GSD_PROJECT_ID value.
+ *
+ * Must contain only alphanumeric characters, hyphens, and underscores.
+ * Call this once at startup so the user gets immediate feedback on bad values.
+ */
+export function validateProjectId(id: string): boolean {
+  return /^[a-zA-Z0-9_-]+$/.test(id);
+}
+
+/**
  * Compute a stable identity for a repository.
  *
- * SHA-256 of `${remoteUrl}\n${resolvedRoot}`, truncated to 12 hex chars.
- * Deterministic: same repo always produces the same hash regardless of
- * which worktree the caller is inside.
+ * If `GSD_PROJECT_ID` is set, returns it directly (validation is expected
+ * to have already happened at startup via `validateProjectId`).
+ *
+ * Otherwise returns SHA-256 of `${remoteUrl}\n${resolvedRoot}`, truncated
+ * to 12 hex chars. Deterministic: same repo always produces the same hash
+ * regardless of which worktree the caller is inside.
  */
 export function repoIdentity(basePath: string): string {
+  const projectId = process.env.GSD_PROJECT_ID;
+  if (projectId) {
+    return projectId;
+  }
   const remoteUrl = getRemoteUrl(basePath);
   const root = resolveGitRoot(basePath);
   const input = `${remoteUrl}\n${root}`;

--- a/src/resources/extensions/gsd/tests/repo-identity-worktree.test.ts
+++ b/src/resources/extensions/gsd/tests/repo-identity-worktree.test.ts
@@ -3,7 +3,7 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { execSync } from "node:child_process";
 
-import { externalGsdRoot, ensureGsdSymlink } from "../repo-identity.ts";
+import { repoIdentity, externalGsdRoot, ensureGsdSymlink, validateProjectId } from "../repo-identity.ts";
 import { createTestContext } from "./test-helpers.ts";
 
 const { assertEq, assertTrue, report } = createTestContext();
@@ -57,6 +57,26 @@ async function main(): Promise<void> {
     assertEq(preservedDirState, join(worktreePath, ".gsd"), "worktree .gsd directory is left in place for sync-based refresh");
     assertTrue(lstatSync(join(worktreePath, ".gsd")).isDirectory(), "worktree .gsd directory remains a directory");
     assertTrue(existsSync(join(worktreePath, ".gsd", "milestones", "stale.txt")), "existing worktree .gsd directory contents remain available for sync logic");
+
+    console.log("\n=== GSD_PROJECT_ID overrides computed repo hash ===");
+    process.env.GSD_PROJECT_ID = "my-project";
+    assertEq(repoIdentity(base), "my-project", "repoIdentity returns GSD_PROJECT_ID when set");
+    assertEq(externalGsdRoot(base), join(stateDir, "projects", "my-project"), "externalGsdRoot uses GSD_PROJECT_ID");
+    delete process.env.GSD_PROJECT_ID;
+
+    console.log("\n=== GSD_PROJECT_ID falls back to hash when unset ===");
+    const hashIdentity = repoIdentity(base);
+    assertTrue(/^[0-9a-f]{12}$/.test(hashIdentity), "repoIdentity returns 12-char hex hash when GSD_PROJECT_ID is unset");
+
+    console.log("\n=== validateProjectId rejects invalid values ===");
+    for (const invalid of ["has spaces", "path/traversal", "dot..dot", "back\\slash"]) {
+      assertTrue(!validateProjectId(invalid), `validateProjectId rejects invalid value: "${invalid}"`);
+    }
+
+    console.log("\n=== validateProjectId accepts valid values ===");
+    for (const valid of ["my-project", "foo_bar", "abc123", "A-Z_0-9"]) {
+      assertTrue(validateProjectId(valid), `validateProjectId accepts valid value: "${valid}"`);
+    }
   } finally {
     delete process.env.GSD_STATE_DIR;
     rmSync(base, { recursive: true, force: true });


### PR DESCRIPTION
Allow users to set `GSD_PROJECT_ID` to replace the opaque 12-char SHA-256 hash
in `~/.gsd/projects/<repo-hash>/` that was introduced in https://github.com/gsd-build/gsd-2/pull/1242 with a human-readable project identifier.

This allows continued progress on https://github.com/gsd-build/gsd-2/issues/1544

## TL;DR

**What:** New `GSD_PROJECT_ID` env var that overrides the computed repo hash used for the external state directory.
**Why:** The hash is opaque and unpredictable from outside GSD.
**How:** `repoIdentity()` returns the env var when set; `validateProjectId()` checks it at bootstrap startup and bails with a clear error on invalid values.

## What

- **`repo-identity.ts`** — `repoIdentity()` checks `GSD_PROJECT_ID` and returns it directly when set, skipping hash computation. New `validateProjectId(id): boolean` predicate checks values against `/^[a-zA-Z0-9_-]+$/`.
- **`auto-start.ts`** — Validates `GSD_PROJECT_ID` at the top of `bootstrapAutoSession()`, before any filesystem work. Invalid values get `ctx.ui.notify(msg, "error")` and bail via `releaseLockAndReturn()`.
- **`repo-identity-worktree.test.ts`** — Tests for: override returns custom ID, `externalGsdRoot` uses it, fallback to hash when unset, `validateProjectId` rejects invalid values (`/`, `..`, spaces, `\`) and accepts valid ones.

## Why

The repo hash (`SHA-256(remoteUrl + gitRoot)[:12]`) is opaque and unpredictable from outside GSD. `GSD_PROJECT_ID` gives users a stable, human-readable alternative. Validation at startup prevents bad values (path traversal, spaces, special chars) from silently creating broken directory structures.

## How

- `validateProjectId` is a pure boolean predicate — the caller owns the error message and control flow.
- `repoIdentity()` trusts the value when set (already validated at startup).
- The startup check runs before `recoverFailedMigration` / `ensureGsdSymlink` so an invalid ID never touches the filesystem.

## Change type

- [x] `feat` — New feature or capability
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [ ] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included