### PR TITLE
fix: update Anthropic OAuth endpoints to platform.claude.com

### DIFF
--- a/packages/pi-ai/src/utils/oauth/anthropic.ts
+++ b/packages/pi-ai/src/utils/oauth/anthropic.ts
@@ -8,8 +8,8 @@ import type { OAuthCredentials, OAuthLoginCallbacks, OAuthProviderInterface } fr
 const decode = (s: string) => atob(s);
 const CLIENT_ID = decode("OWQxYzI1MGEtZTYxYi00NGQ5LTg4ZWQtNTk0NGQxOTYyZjVl");
 const AUTHORIZE_URL = "https://claude.ai/oauth/authorize";
-const TOKEN_URL = "https://console.anthropic.com/v1/oauth/token";
-const REDIRECT_URI = "https://console.anthropic.com/oauth/code/callback";
+const TOKEN_URL = "https://platform.claude.com/v1/oauth/token";
+const REDIRECT_URI = "https://platform.claude.com/oauth/code/callback";
 const SCOPES = "org:create_api_key user:profile user:inference";
 
 /**


### PR DESCRIPTION
## What
Updates Anthropic OAuth token and redirect URLs from `console.anthropic.com` to `platform.claude.com`.

## Why
Anthropic migrated their OAuth infrastructure to `platform.claude.com`. The old `console.anthropic.com` OAuth endpoints are decommissioned, breaking all OAuth login flows for Claude Pro/Max users.

## How
Two URL constant changes in `packages/pi-ai/src/utils/oauth/anthropic.ts`:
- `TOKEN_URL`: `console.anthropic.com/v1/oauth/token` → `platform.claude.com/v1/oauth/token`
- `REDIRECT_URI`: `console.anthropic.com/oauth/code/callback` → `platform.claude.com/oauth/code/callback`

## Key changes
- **`packages/pi-ai/src/utils/oauth/anthropic.ts`** (lines 11-12): Updated both OAuth endpoint constants to the new domain.

No other files reference `console.anthropic.com` for OAuth purposes. The one remaining reference in `key-manager.ts` is a `dashboardUrl` for the API key management console, which is a separate concern.

## Testing
- Verified no TypeScript compilation errors introduced (pre-existing unrelated errors in `anthropic-vertex.ts` remain unchanged)
- Grepped entire codebase for `console.anthropic.com` to confirm no other OAuth-related references need updating
- Functional verification requires an actual OAuth login flow against Anthropic's servers

## Risk
**Low.** This is a two-line URL change with no logic modifications. The old endpoints are already broken, so this can only improve the situation.

Closes #1587

🤖 Generated with [Claude Code](https://claude.com/claude-code)