### PR TITLE
fix: resolve ${VAR} env references in MCP client .mcp.json configs

### DIFF
--- a/src/resources/extensions/mcp-client/index.ts
+++ b/src/resources/extensions/mcp-client/index.ts
@@ -114,6 +114,22 @@ function getServerConfig(name: string): McpServerConfig | undefined {
 	return readConfigs().find((s) => s.name === name);
 }
 
+/** Resolve ${VAR} references in env values against process.env. */
+function resolveEnv(env: Record<string, string>): Record<string, string> {
+	const resolved: Record<string, string> = {};
+	for (const [key, value] of Object.entries(env)) {
+		if (typeof value === "string") {
+			resolved[key] = value.replace(
+				/\$\{([^}]+)\}/g,
+				(_match, varName) => process.env[varName] ?? "",
+			);
+		} else {
+			resolved[key] = value;
+		}
+	}
+	return resolved;
+}
+
 async function getOrConnect(name: string, signal?: AbortSignal): Promise<Client> {
 	const existing = connections.get(name);
 	if (existing) return existing.client;
@@ -128,7 +144,7 @@ async function getOrConnect(name: string, signal?: AbortSignal): Promise<Client>
 		transport = new StdioClientTransport({
 			command: config.command,
 			args: config.args,
-			env: config.env ? { ...process.env, ...config.env } as Record<string, string> : undefined,
+			env: config.env ? { ...process.env, ...resolveEnv(config.env) } as Record<string, string> : undefined,
 			cwd: config.cwd,
 			stderr: "pipe",
 		});


### PR DESCRIPTION
## What
Adds environment variable interpolation for `${VAR}` patterns in MCP client `.mcp.json` env configurations.

## Why
The MCP client was passing raw `"${VAR}"` strings to child processes instead of resolving them against `process.env`. This broke MCP servers that rely on environment variable references in their config — a standard convention used by Claude Code, Cursor, and VS Code.

## How
- Added a `resolveEnv()` helper function that replaces `${VAR_NAME}` patterns in env config values with their corresponding `process.env` values (falling back to empty string for undefined vars)
- Updated the `StdioClientTransport` env construction in `getOrConnect()` to pipe config env through `resolveEnv()` before merging with `process.env`

## Key changes
- `src/resources/extensions/mcp-client/index.ts`: Added `resolveEnv()` function and updated env resolution in transport creation (line 147)

## Testing
- Regex correctly handles: `${VAR}`, `${VAR_WITH_UNDERSCORES}`, `${MULTI_SEGMENT_VAR_123}`
- Missing/undefined env vars resolve to empty string (no crashes)
- Plain string values without `${...}` patterns pass through unchanged
- Non-string values in env config are preserved as-is
- TypeScript compilation passes (no new errors introduced)

## Risk
Low — isolated change to env value resolution. Only affects stdio transport env setup. No behavioral change for configs that don't use `${VAR}` patterns.

Closes #1599

🤖 Generated with [Claude Code](https://claude.com/claude-code)