### PR TITLE
fix: return "dispatched" after doctor heal to prevent session race

### DIFF
--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -194,6 +194,7 @@ export async function postUnitPreVerification(pctx: PostUnitContext, opts?: PreV
             const reportText = formatDoctorReport(report, { scope: doctorScope, includeWarnings: true });
             const structuredIssues = formatDoctorIssuesForPrompt(actionable);
             dispatchDoctorHeal(pi, doctorScope, reportText, structuredIssues);
+            return "dispatched";
           } catch (e) {
             debugLog("postUnit", { phase: "doctor-heal-dispatch", error: String(e) });
           }


### PR DESCRIPTION
## What
Add `return "dispatched"` after `dispatchDoctorHeal()` in `postUnitPreVerification` so the auto-loop exits cleanly instead of racing into `newSession()`.

## Why
After `dispatchDoctorHeal` calls `pi.sendMessage({ triggerTurn: true })`, the function fell through to `return "continue"`. The auto-loop interpreted "continue" as "proceed to next unit", called `newSession()` while the session manager was still processing the heal turn, and the 30-second timeout killed auto-mode.

## How
One-line addition: `return "dispatched"` immediately after the `dispatchDoctorHeal()` call (line 197 in `auto-post-unit.ts`). The `"dispatched"` return value is already a valid variant of the function's return type (`Promise<"dispatched" | "continue">`) and the auto-loop already handles it by breaking out of the loop (see `auto-loop.ts:1460`). The heal turn completes, triggers its own `handleAgentEnd`, and the loop resumes naturally.

## Key changes
- `src/resources/extensions/gsd/auto-post-unit.ts`: Added `return "dispatched"` after `dispatchDoctorHeal()` inside the escalation block

## Testing
- TypeScript compilation passes with no errors
- The return value `"dispatched"` is already part of the function's declared return type
- The auto-loop's handling of `"dispatched"` (break + debug log) is already tested via the existing sidecar dispatch path

## Risk
Minimal. Single line addition using an existing, well-tested code path. If `dispatchDoctorHeal` throws, the catch block still runs and the function continues to `return "continue"` as before.

Closes #1580

🤖 Generated with [Claude Code](https://claude.com/claude-code)