### PR TITLE
fix: add auto-fix for premature slice completion deadlock in doctor

### DIFF
--- a/src/resources/extensions/gsd/doctor.ts
+++ b/src/resources/extensions/gsd/doctor.ts
@@ -280,6 +280,21 @@ async function markSliceDoneInRoadmap(basePath: string, milestoneId: string, sli
   }
 }
 
+async function markSliceUndoneInRoadmap(basePath: string, milestoneId: string, sliceId: string, fixesApplied: string[]): Promise<void> {
+  const roadmapPath = resolveMilestoneFile(basePath, milestoneId, "ROADMAP");
+  if (!roadmapPath) return;
+  const content = await loadFile(roadmapPath);
+  if (!content) return;
+  const updated = content.replace(
+    new RegExp(`^(\\s*-\\s+)\\[x\\]\\s+\\*\\*${sliceId}:`, "m"),
+    `$1[ ] **${sliceId}:`,
+  );
+  if (updated !== content) {
+    await saveFile(roadmapPath, updated);
+    fixesApplied.push(`unmarked ${sliceId} in ${roadmapPath} (premature completion)`);
+  }
+}
+
 function matchesScope(unitId: string, scope?: string): boolean {
   if (!scope) return true;
   return unitId === scope || unitId.startsWith(`${scope}/`) || unitId.startsWith(`${scope}`);
@@ -863,6 +878,12 @@ export async function runGSDDoctor(basePath: string, options?: { fix?: boolean; 
           file: relSliceFile(basePath, milestoneId, slice.id, "SUMMARY"),
           fixable: true,
         });
+        if (!allTasksDone) {
+          dryRunCanFix("slice_checked_missing_summary", `uncheck ${slice.id} in roadmap (tasks incomplete)`);
+          if (shouldFix("slice_checked_missing_summary")) {
+            await markSliceUndoneInRoadmap(basePath, milestoneId, slice.id, fixesApplied);
+          }
+        }
       }
 
       if (slice.done && !hasSliceUat) {

--- a/src/resources/extensions/gsd/roadmap-mutations.ts
+++ b/src/resources/extensions/gsd/roadmap-mutations.ts
@@ -40,6 +40,35 @@ export function markSliceDoneInRoadmap(basePath: string, mid: string, sid: strin
 }
 
 /**
+ * Mark a slice as not done ([ ]) in the milestone roadmap.
+ * Idempotent — no-op if already unchecked or if the slice isn't found.
+ *
+ * @returns true if the roadmap was modified, false if no change was needed
+ */
+export function markSliceUndoneInRoadmap(basePath: string, mid: string, sid: string): boolean {
+  const roadmapFile = resolveMilestoneFile(basePath, mid, "ROADMAP");
+  if (!roadmapFile) return false;
+
+  let content: string;
+  try {
+    content = readFileSync(roadmapFile, "utf-8");
+  } catch {
+    return false;
+  }
+
+  const updated = content.replace(
+    new RegExp(`^(\\s*-\\s+)\\[x\\]\\s+\\*\\*${sid}:`, "m"),
+    `$1[ ] **${sid}:`,
+  );
+
+  if (updated === content) return false;
+
+  atomicWriteSync(roadmapFile, updated);
+  clearParseCache();
+  return true;
+}
+
+/**
  * Mark a task as done ([x]) in the slice plan.
  * Idempotent — no-op if already checked or if the task isn't found.
  *


### PR DESCRIPTION
## What
Add a `shouldFix` handler for the `slice_checked_missing_summary` doctor issue code, and add a `markSliceUndoneInRoadmap` function to both `doctor.ts` and `roadmap-mutations.ts`.

## Why
When a slice is marked `[x]` in ROADMAP but tasks are incomplete and no summary exists, doctor detects `slice_checked_missing_summary` (declared `fixable: true`) but no `shouldFix` handler existed. This creates an unrecoverable deadlock: doctor reports the error, auto-fix attempts to resolve it, but there's no fix logic to execute.

Closes #1591

## How
- When `!allTasksDone`: the fix unchecks the slice in ROADMAP (reverts premature completion), allowing the normal task completion flow to resume
- When `allTasksDone`: no action needed here — the existing `all_tasks_done_missing_slice_summary` handler already covers creating the summary stub, after which `all_tasks_done_roadmap_not_checked` re-checks the slice

## Key changes
- `src/resources/extensions/gsd/doctor.ts`: Added `markSliceUndoneInRoadmap` helper (async, mirrors the existing `markSliceDoneInRoadmap`), and added `shouldFix` + `dryRunCanFix` calls after the `slice_checked_missing_summary` issue push
- `src/resources/extensions/gsd/roadmap-mutations.ts`: Added `markSliceUndoneInRoadmap` export — inverse of `markSliceDoneInRoadmap`, replaces `[x]` with `[ ]` for the matching slice

## Testing
- TypeScript compilation passes with no errors
- Existing doctor test files confirmed unaffected
- Fix pattern matches established conventions (`dryRunCanFix` + `shouldFix` guard + async mutation)

## Risk
Low. The fix only triggers when `slice.done && !hasSliceSummary && !allTasksDone` — a narrow deadlock state. The mutation is the exact inverse of the existing `markSliceDoneInRoadmap`, using the same regex and write patterns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)