### PR TITLE
refactor(auto-loop): initial cleanup — hoist constant, cache prefs per iteration

### DIFF
--- a/src/resources/extensions/gsd/auto-loop.ts
+++ b/src/resources/extensions/gsd/auto-loop.ts
@@ -630,6 +630,7 @@ export async function autoLoop(
 
     try {
       // ── Blanket try/catch: one bad iteration must not kill the session
+      const prefs = deps.loadEffectiveGSDPreferences()?.preferences;
 
       const sessionLockBase = deps.lockBase();
       if (sessionLockBase) {
@@ -702,7 +703,7 @@ export async function autoLoop(
 
       // Derive state
       let state = await deps.deriveState(s.basePath);
-      deps.syncCmuxSidebar(deps.loadEffectiveGSDPreferences()?.preferences, state);
+      deps.syncCmuxSidebar(prefs, state);
       let mid = state.activeMilestone?.id;
       let midTitle = state.activeMilestone?.title;
       debugLog("autoLoop", {
@@ -725,12 +726,12 @@ export async function autoLoop(
           "milestone",
         );
         deps.logCmuxEvent(
-          deps.loadEffectiveGSDPreferences()?.preferences,
+          prefs,
           `Milestone ${s.currentMilestoneId} complete. Advancing to ${mid}.`,
           "success",
         );
 
-        const vizPrefs = deps.loadEffectiveGSDPreferences()?.preferences;
+        const vizPrefs = prefs;
         if (vizPrefs?.auto_visualize) {
           ctx.ui.notify("Run /gsd visualize to see progress overview.", "info");
         }
@@ -763,9 +764,7 @@ export async function autoLoop(
         if (mid) {
           if (deps.getIsolationMode() !== "none") {
             deps.captureIntegrationBranch(s.basePath, mid, {
-              commitDocs:
-                deps.loadEffectiveGSDPreferences()?.preferences?.git
-                  ?.commit_docs,
+              commitDocs: prefs?.git?.commit_docs,
             });
           }
           deps.resolver.enterMilestone(mid, ctx.ui);
@@ -817,7 +816,7 @@ export async function autoLoop(
             "milestone",
           );
           deps.logCmuxEvent(
-            deps.loadEffectiveGSDPreferences()?.preferences,
+            prefs,
             "All milestones complete.",
             "success",
           );
@@ -839,7 +838,7 @@ export async function autoLoop(
           await deps.stopAuto(ctx, pi, blockerMsg);
           ctx.ui.notify(`${blockerMsg}. Fix and run /gsd auto.`, "warning");
           deps.sendDesktopNotification("GSD", blockerMsg, "error", "attention");
-          deps.logCmuxEvent(deps.loadEffectiveGSDPreferences()?.preferences, blockerMsg, "error");
+          deps.logCmuxEvent(prefs, blockerMsg, "error");
         } else {
           const ids = incomplete.map((m: { id: string }) => m.id).join(", ");
           const diag = `basePath=${s.basePath}, milestones=[${state.registry.map((m: { id: string; status: string }) => `${m.id}:${m.status}`).join(", ")}], phase=${state.phase}`;
@@ -898,7 +897,7 @@ export async function autoLoop(
           "milestone",
         );
         deps.logCmuxEvent(
-          deps.loadEffectiveGSDPreferences()?.preferences,
+          prefs,
           `Milestone ${mid} complete.`,
           "success",
         );
@@ -913,14 +912,12 @@ export async function autoLoop(
         await closeoutAndStop(ctx, pi, s, deps, blockerMsg);
         ctx.ui.notify(`${blockerMsg}. Fix and run /gsd auto.`, "warning");
         deps.sendDesktopNotification("GSD", blockerMsg, "error", "attention");
-        deps.logCmuxEvent(deps.loadEffectiveGSDPreferences()?.preferences, blockerMsg, "error");
+        deps.logCmuxEvent(prefs, blockerMsg, "error");
         debugLog("autoLoop", { phase: "exit", reason: "blocked" });
         break;
       }
 
       // ── Phase 2: Guards ─────────────────────────────────────────────────
-
-      const prefs = deps.loadEffectiveGSDPreferences()?.preferences;
 
       // Budget ceiling guard
       const budgetCeiling = prefs?.budget_ceiling;


### PR DESCRIPTION
Part of #1615 — decomposing `autoLoop` god function.

## Changes

Two mechanical, no-behavior-change commits:

**1. Hoist `MAX_RECOVERY_CHARS` to module level**
The constant `50_000` was being re-declared inside the `while` loop body on every iteration. Moved to module level next to `MAX_LOOP_ITERATIONS`.

**2. Cache `loadEffectiveGSDPreferences()` once per iteration**
`deps.loadEffectiveGSDPreferences()?.preferences` was called 9 times per loop iteration with no intermediate caching. Now called once at the top of the `try` block and stored in `prefs`, used throughout. The existing `const prefs` in Phase 2 (budget guard) is the same assignment — moved earlier and shared.

## Test plan
- [ ] TypeScript compiles clean
- [ ] Run auto-mode for at least 2 unit completions — behaviour unchanged
- [ ] `prefs` variable accessible at all former call sites within the iteration

🤖 Generated with [Claude Code](https://claude.com/claude-code)