### PR TITLE
fix: filter cross-milestone errors from health tracker escalation

### DIFF
--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -172,13 +172,20 @@ export async function postUnitPreVerification(pctx: PostUnitContext, opts?: PreV
         ctx.ui.notify(`Post-hook: applied ${report.fixesApplied.length} fix(es).`, "info");
       }
 
-      // Proactive health tracking
-      const summary = summarizeDoctorIssues(report.issues);
+      // Proactive health tracking — filter to current milestone to avoid
+      // cross-milestone stale errors inflating the escalation counter
+      const currentMilestoneId = s.currentUnit.id.split("/")[0];
+      const milestoneIssues = currentMilestoneId
+        ? report.issues.filter(i =>
+            i.unitId === currentMilestoneId ||
+            i.unitId.startsWith(`${currentMilestoneId}/`))
+        : report.issues;
+      const summary = summarizeDoctorIssues(milestoneIssues);
       recordHealthSnapshot(summary.errors, summary.warnings, report.fixesApplied.length);
 
       // Check if we should escalate to LLM-assisted heal
       if (summary.errors > 0) {
-        const unresolvedErrors = report.issues
+        const unresolvedErrors = milestoneIssues
           .filter(i => i.severity === "error" && !i.fixable)
           .map(i => ({ code: i.code, message: i.message, unitId: i.unitId }));
         const escalation = checkHealEscalation(summary.errors, unresolvedErrors);

--- a/src/resources/extensions/gsd/doctor.ts
+++ b/src/resources/extensions/gsd/doctor.ts
@@ -297,7 +297,7 @@ async function markSliceUndoneInRoadmap(basePath: string, milestoneId: string, s
 
 function matchesScope(unitId: string, scope?: string): boolean {
   if (!scope) return true;
-  return unitId === scope || unitId.startsWith(`${scope}/`) || unitId.startsWith(`${scope}`);
+  return unitId === scope || unitId.startsWith(`${scope}/`);
 }
 
 function auditRequirements(content: string | null): DoctorIssue[] {


### PR DESCRIPTION
## What
Fixes two bugs in the doctor health tracking and scope matching systems that caused false escalation triggers.

## Why
1. **Cross-milestone error inflation**: `recordHealthSnapshot` counted ALL doctor issues including stale errors from other milestones (e.g., M003 errors counted while working in M004). This inflated `consecutiveErrorUnits` past the escalation threshold (5) from unfixable errors the current worker cannot resolve, triggering unnecessary LLM-assisted heal dispatches.
2. **Scope delimiter false match**: `matchesScope` used `unitId.startsWith(scope)` without requiring a delimiter, so scope `"M004/S01"` would incorrectly match `"M004/S010"`, causing the doctor to process slices outside its intended scope.

## How
1. **`auto-post-unit.ts`**: Before passing issues to `recordHealthSnapshot`, extract the current milestone ID from the unit context and filter `report.issues` to only include issues whose `unitId` belongs to the current milestone. The filtered list is also used for `checkHealEscalation`'s unresolved errors.
2. **`doctor.ts`**: Removed the redundant `unitId.startsWith(scope)` branch from `matchesScope`. The function now correctly requires either an exact match (`unitId === scope`) or a slash-delimited prefix match (`unitId.startsWith(scope + "/")`).

## Key changes
- `src/resources/extensions/gsd/auto-post-unit.ts` — milestone-scoped filtering of doctor issues before health tracking
- `src/resources/extensions/gsd/doctor.ts` — delimiter-safe `matchesScope` implementation

## Testing
- TypeScript compilation passes cleanly
- All 38 doctor-proactive tests pass
- All 6 plan-milestone tests pass
- Verified `matchesScope` edge cases: exact match works, child paths work, similar prefixes (S01 vs S010) no longer false-match

## Risk
Low. Both changes are narrowly scoped:
- The milestone filter only affects which issues increment the health tracker — the full doctor report is still used for fix application and UI notifications
- The `matchesScope` fix removes a redundant branch that was always a superset of the exact-match branch

Closes #1579

🤖 Generated with [Claude Code](https://claude.com/claude-code)