### PR TITLE
fix: cancel trailing async jobs on session switch to prevent wasted LLM turns

### DIFF
--- a/src/resources/extensions/async-jobs/index.ts
+++ b/src/resources/extensions/async-jobs/index.ts
@@ -78,6 +78,17 @@ export default function AsyncJobs(pi: ExtensionAPI) {
 		});
 	});
 
+	pi.on("session_before_switch", async () => {
+		if (manager) {
+			// Cancel all running background jobs — their results are no longer
+			// relevant to the new session and would produce wasteful follow-up
+			// notifications that trigger empty LLM turns (#1642).
+			for (const job of manager.getRunningJobs()) {
+				manager.cancel(job.id);
+			}
+		}
+	});
+
 	pi.on("session_shutdown", async () => {
 		if (manager) {
 			manager.shutdown();

--- a/src/resources/extensions/gsd/auto-loop.ts
+++ b/src/resources/extensions/gsd/auto-loop.ts
@@ -287,6 +287,20 @@ export async function runUnit(
     status: result.status,
   });
 
+  // Discard trailing follow-up messages (e.g. async_job_result notifications)
+  // from the completed unit. Without this, queued follow-ups trigger wasteful
+  // LLM turns before the next session can start (#1642).
+  // clearQueue() lives on AgentSession but isn't part of the typed
+  // ExtensionCommandContext interface — call it via runtime check.
+  try {
+    const cmdCtxAny = s.cmdCtx as Record<string, unknown> | null;
+    if (typeof cmdCtxAny?.clearQueue === "function") {
+      (cmdCtxAny.clearQueue as () => unknown)();
+    }
+  } catch {
+    // Non-fatal — clearQueue may not be available in all contexts
+  }
+
   return result;
 }
 


### PR DESCRIPTION
## What

Prevents trailing `async_job_result` follow-up notifications from firing after a unit completes, eliminating wasted LLM turns and token spend in auto-mode.

## Why

When a unit spawns parallel background jobs via `async_bash`, job completion callbacks fire `pi.sendMessage()` with `deliverAs: "followUp"`. These follow-up messages trigger additional LLM turns after `agent_end` has resolved the unit promise. The auto-loop has moved on but the previous session's LLM is still processing follow-ups — adding 12-45+ seconds of wasted time and ~14 unnecessary LLM turns per unit.

## How

Two complementary fixes at different layers:

1. **Source prevention** (`async-jobs/index.ts`): Register a `session_before_switch` handler that cancels all running background jobs. Cancelled jobs skip the `deliverResult` callback, so no follow-up messages are generated for the old session.

2. **Defense-in-depth** (`auto-loop.ts`): After `runUnit()` returns (unit promise resolved), clear the follow-up queue via a runtime check for `clearQueue()` on the command context. This catches any follow-ups that were already queued before the jobs were cancelled.

## Key changes

- `src/resources/extensions/async-jobs/index.ts` — Added `session_before_switch` handler that iterates running jobs and cancels each one
- `src/resources/extensions/gsd/auto-loop.ts` — Added queue-clearing call after `await unitPromise` resolves in `runUnit()`

## Testing

- TypeScript compilation passes (`npx tsc --noEmit`)
- Verified `session_before_switch` is a supported event in the extension API types
- Verified `AsyncJobManager.cancel()` sets status to `"cancelled"` which causes the `.catch()` handler to skip `deliverResult` — no follow-up message is generated
- Verified `newSession()` in `agent-session.ts` emits `session_before_switch` before resetting the agent, confirming the handler fires at the right time
- No existing unit tests for these files; manual auto-mode testing recommended

## Risk

Low. Both fixes are additive and non-breaking:
- Fix 1 uses an existing event (`session_before_switch`) and existing cancel mechanics — cancelled jobs already skip result delivery
- Fix 2 is wrapped in try/catch and uses a runtime type check — silently no-ops if `clearQueue` isn't available

Closes #1642

🤖 Generated with [Claude Code](https://claude.com/claude-code)