### PR TITLE
fix: default UAT type to artifact-driven to prevent unnecessary auto-mode pauses

### DIFF
--- a/src/resources/extensions/gsd/auto-prompts.ts
+++ b/src/resources/extensions/gsd/auto-prompts.ts
@@ -759,8 +759,8 @@ export async function checkNeedsRunUat(
     if (hasResult) return null;
   }
 
-  // Classify UAT type; unknown type → treat as human-experience (human review)
-  const uatType = extractUatType(uatContent) ?? "human-experience";
+  // Classify UAT type; default to artifact-driven (LLM-executed UATs are always artifact-driven)
+  const uatType = extractUatType(uatContent) ?? "artifact-driven";
 
   return { sliceId: sid, uatType };
 }
@@ -1403,7 +1403,7 @@ export async function buildRunUatPrompt(
   const inlinedContext = capPreamble(`## Inlined Context (preloaded — do not re-read these files)\n\n${inlined.join("\n\n---\n\n")}`);
 
   const uatResultPath = join(base, relSliceFile(base, mid, sliceId, "UAT-RESULT"));
-  const uatType = extractUatType(uatContent) ?? "human-experience";
+  const uatType = extractUatType(uatContent) ?? "artifact-driven";
 
   return loadPrompt("run-uat", {
     workingDirectory: base,


### PR DESCRIPTION
## What
Change the default UAT type fallback from `"human-experience"` to `"artifact-driven"` when a UAT file has no `## UAT Type` section.

## Why
`extractUatType()` returns `undefined` when no `## UAT Type` section exists. The fallback was `"human-experience"`, which causes `pauseAfterDispatch: true` in the auto-dispatch rule. This means auto-mode pauses after every `run-uat` unit, even when the UAT is fully artifact-driven (CLI test commands only). Doctor-generated UAT placeholders never include a `## UAT Type` section, so this affected all auto-generated UATs.

## How
Two call sites in `auto-prompts.ts` use `extractUatType(content) ?? fallback`:
1. `checkNeedsRunUat()` (line 763) — determines `uatType` returned to dispatch rule
2. `buildRunUatPrompt()` (line 1406) — passes type into the prompt template

Both changed from `?? "human-experience"` to `?? "artifact-driven"`.

## Key changes
- `src/resources/extensions/gsd/auto-prompts.ts`: Changed default UAT type fallback from `"human-experience"` to `"artifact-driven"` in both `checkNeedsRunUat()` and `buildRunUatPrompt()`
- Updated inline comment to reflect the new rationale

## Testing
- TypeScript compilation passes (`npx tsc --noEmit`)
- Existing `run-uat.test.ts` tests are unaffected — the test that uses `checkNeedsRunUat` with `human-experience` explicitly writes a UAT file containing `## UAT Type` with `human-experience`, so `extractUatType()` returns the explicit value rather than falling through to the default
- Logic verification: with `"artifact-driven"` as default, the dispatch rule's `pauseAfterDispatch` expression (`uatType !== "artifact-driven" && ...`) evaluates to `false`, so auto-mode no longer pauses unnecessarily

## Risk
Low. Only affects the fallback path when no `## UAT Type` section exists. Explicit UAT types are unchanged. The behavioral change is that auto-mode will no longer pause for UATs that lack a type section — which is the desired behavior since these are always LLM-executed.

Closes #1649

🤖 Generated with [Claude Code](https://claude.com/claude-code)