### PR TITLE
fix: add runtime paths to forensics prompt to prevent path hallucination

### DIFF
--- a/src/resources/extensions/gsd/prompts/forensics.md
+++ b/src/resources/extensions/gsd/prompts/forensics.md
@@ -20,6 +20,20 @@ Key files for understanding failures:
 
 You may read these files to identify the specific code path that caused the failure.
 
+## Key Runtime Paths
+
+All paths are relative to the project root. `.gsd/` is the GSD state directory.
+
+- Activity logs (raw JSONL): `.gsd/activity/`
+- Worktree activity logs: `.gsd/worktrees/<MID>/.gsd/activity/`
+- Debug logs: `.gsd/debug/`
+- Runtime state: `.gsd/runtime/`
+- Crash lock: `.gsd/auto.lock`
+- Completed units: `.gsd/completed-units.json`
+- Forensics reports: `.gsd/forensics/`
+
+Use these exact paths when inspecting raw log files. The `{{forensicData}}` above contains pre-parsed data from these locations, but you can read the files directly for additional detail.
+
 ## Your Task
 
 1. **Analyze** the forensic report. Identify the root cause of the user's problem.


### PR DESCRIPTION
## What

Adds a "Key Runtime Paths" section to the forensics prompt (`prompts/forensics.md`) that provides concrete `.gsd/` filesystem paths for activity logs, debug logs, runtime state, crash lock, completed units, and forensics reports.

## Why

The forensics prompt mentions "activity logs" in natural language but never provides the actual `.gsd/activity/` filesystem path. When the forensics agent needs to inspect raw JSONL logs beyond the pre-parsed `{{forensicData}}`, it hallucinates the path `activity-logs/` — which doesn't exist anywhere in the codebase. The string `activity-logs` appears in zero GSD source files; it's a pure hallucination derived from the phrase "activity logs."

Closes #1652

## How

Added a new "Key Runtime Paths" section between the "GSD Source Location" section and the "Your Task" section. The paths were verified against the actual source code:

- `.gsd/activity/` — from `forensics.ts:279` (`join(gsdRoot(basePath), "activity")`)
- `.gsd/worktrees/<MID>/.gsd/activity/` — from `forensics.ts:271`
- `.gsd/debug/` — from `debug-logger.ts:40` and `commands-logs.ts:43`
- `.gsd/runtime/` — from `unit-runtime.ts:50` and `auto.ts:727`
- `.gsd/auto.lock` — from `crash-recovery.ts:18,32`
- `.gsd/completed-units.json` — from `forensics.ts:288`
- `.gsd/forensics/` — from `forensics.ts:432`

## Key changes

- `src/resources/extensions/gsd/prompts/forensics.md` — added 14 lines (new section with 7 path entries and contextual guidance)

## Testing

- Verified all paths against source code references
- `npx tsc --noEmit` passes clean
- Confirmed `activity-logs` appears in zero source files (validating the hallucination claim)

## Risk

**Very low.** This is an additive-only change to a markdown prompt template. No code logic is modified. The only behavioral change is that the forensics agent now has correct paths to reference instead of guessing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)