### PR TITLE
fix: guard TUI render during session transitions to prevent freeze

### DIFF
--- a/src/resources/extensions/gsd/auto-dashboard.ts
+++ b/src/resources/extensions/gsd/auto-dashboard.ts
@@ -390,6 +390,8 @@ export interface WidgetStateAccessors {
   getCmdCtx(): ExtensionCommandContext | null;
   getBasePath(): string;
   isVerbose(): boolean;
+  /** True while newSession() is in-flight — render must not access session state. */
+  isSessionSwitching(): boolean;
 }
 
 export function updateProgressWidget(
@@ -459,6 +461,14 @@ export function updateProgressWidget(
     return {
       render(width: number): string[] {
         if (cachedLines && cachedWidth === width) return cachedLines;
+
+        // While newSession() is in-flight, session state is mid-mutation.
+        // Accessing cmdCtx.sessionManager or cmdCtx.getContextUsage() can
+        // block the render loop and freeze the TUI. Return the last cached
+        // frame (or an empty frame on first render) until the switch settles.
+        if (accessors.isSessionSwitching()) {
+          return cachedLines ?? [];
+        }
 
         const ui = makeUI(theme, width);
         const lines: string[] = [];

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -195,7 +195,7 @@ import {
   postUnitPostVerification,
 } from "./auto-post-unit.js";
 import { bootstrapAutoSession, type BootstrapDeps } from "./auto-start.js";
-import { autoLoop, resolveAgentEnd, type LoopDeps } from "./auto-loop.js";
+import { autoLoop, resolveAgentEnd, isSessionSwitchInFlight, type LoopDeps } from "./auto-loop.js";
 import {
   WorktreeResolver,
   type WorktreeResolverDeps,
@@ -1129,6 +1129,7 @@ const widgetStateAccessors: WidgetStateAccessors = {
   getCmdCtx: () => s.cmdCtx,
   getBasePath: () => s.basePath,
   isVerbose: () => s.verbose,
+  isSessionSwitching: isSessionSwitchInFlight,
 };
 
 // ─── Preconditions ────────────────────────────────────────────────────────────


### PR DESCRIPTION
## What
Guard the auto-mode progress widget `render()` against accessing session state while `newSession()` is in-flight.

## Why
During auto-mode session transitions, `newSession()` mutates `sessionManager` state. The progress widget's `render()` function calls `cmdCtx.sessionManager.getEntries()` and `cmdCtx.getContextUsage()` synchronously on each frame. When these overlap, the render blocks on stale/mid-mutation state, starving the TUI input loop:

```
autoLoop
  └─ runUnit()
       ├─ _sessionSwitchInFlight = true
       ├─ cmdCtx.newSession()          ← mutating session state
       │    └─ sessionManager.reset()  ← entries mid-mutation
       │
       │   [concurrent]
       │
       └─ TUI render tick
            └─ render(width)
                 └─ cmdCtx.sessionManager.getEntries()  ← blocks on stale state
                      └─ TUI input loop starved → terminal frozen
```

The agent continues running in the background but the user sees a frozen terminal requiring force-kill. This causes lost work: uncommitted partial edits, no crash lock written, no graceful shutdown.

## How
- Add `isSessionSwitching()` accessor to `WidgetStateAccessors` interface, wired to the existing `isSessionSwitchInFlight()` export from `auto-loop.ts`
- Guard `render()` at the top: when a session switch is in-flight, return the last cached frame (or empty array on first render), skipping all `cmdCtx.sessionManager` and `cmdCtx.getContextUsage()` calls
- The guard sits after the width-based cache check but before any session state access

## Key changes
- `src/resources/extensions/gsd/auto-dashboard.ts` — added `isSessionSwitching` to `WidgetStateAccessors` interface; added early-return guard in `render()`
- `src/resources/extensions/gsd/auto.ts` — imported `isSessionSwitchInFlight` from `auto-loop.ts`; wired it into `widgetStateAccessors`

## Testing
- `npx tsc --noEmit` passes cleanly
- The guard covers all session-accessing code paths in `render()`: `cmdCtx.sessionManager.getEntries()`, `cmdCtx.getContextUsage()`, and `cmdCtx.model` access
- The existing `_sessionSwitchInFlight` flag is already tested in `agent-end-retry.test.ts`
- Defense-in-depth: returns cached frame during transition so the widget shows the previous state rather than going blank

## Risk
Low. The change only affects render behavior during the brief `newSession()` window (~50-200ms). Outside that window, `isSessionSwitching()` returns `false` and render proceeds normally. Worst case if the flag gets stuck `true`: widget stops updating (but TUI remains responsive and agent continues working).

Closes #1653

🤖 Generated with [Claude Code](https://claude.com/claude-code)