### PR TITLE
fix: prevent parallel worktree path resolution from escaping to home directory

### DIFF
--- a/src/resources/extensions/gsd/auto-worktree-sync.ts
+++ b/src/resources/extensions/gsd/auto-worktree-sync.ts
@@ -170,6 +170,20 @@ export function escapeStaleWorktree(base: string): string {
 
   // base is inside .gsd/worktrees/<something> — extract the project root
   const projectRoot = base.slice(0, idx);
+
+  // Guard: If the candidate project root's .gsd IS the user-level ~/.gsd,
+  // the string-slice heuristic matched the wrong /.gsd/ boundary. This happens
+  // when .gsd is a symlink into ~/.gsd/projects/<hash> and process.cwd()
+  // resolved through the symlink. Returning ~ would be catastrophic (#1676).
+  const candidateGsd = join(projectRoot, ".gsd").replaceAll("\\", "/");
+  const gsdHomePath = gsdHome.replaceAll("\\", "/");
+  if (candidateGsd === gsdHomePath || candidateGsd.startsWith(gsdHomePath + "/")) {
+    // Don't chdir to home — return base unchanged.
+    // resolveProjectRoot() in worktree.ts has the full git-file-based recovery
+    // and will be called by the caller (startAuto → projectRoot()).
+    return base;
+  }
+
   try {
     process.chdir(projectRoot);
   } catch {

--- a/src/resources/extensions/gsd/repo-identity.ts
+++ b/src/resources/extensions/gsd/repo-identity.ts
@@ -243,6 +243,15 @@ export function ensureGsdSymlink(projectPath: string): string {
   const localGsd = join(projectPath, ".gsd");
   const inWorktree = isInsideWorktree(projectPath);
 
+  // Guard: Never create a symlink at ~/.gsd — that's the user-level GSD home,
+  // not a project .gsd. This can happen if resolveProjectRoot() or
+  // escapeStaleWorktree() returned ~ as the project root (#1676).
+  const localGsdNormalized = localGsd.replaceAll("\\", "/");
+  const gsdHomePath = gsdHome.replaceAll("\\", "/");
+  if (localGsdNormalized === gsdHomePath) {
+    return localGsd;
+  }
+
   // Ensure external directory exists
   mkdirSync(externalPath, { recursive: true });
 

--- a/src/resources/extensions/gsd/tests/worktree.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree.test.ts
@@ -204,6 +204,9 @@ async function main(): Promise<void> {
     "/real/project",
     "uses GSD_PROJECT_ROOT when set",
   );
+  delete process.env.GSD_PROJECT_ROOT;
+
+  // Without GSD_PROJECT_ROOT, direct layout still works (no ~/.gsd collision)
   assertEq(
     resolveProjectRoot("/some/repo"),
     "/some/repo",

--- a/src/resources/extensions/gsd/worktree.ts
+++ b/src/resources/extensions/gsd/worktree.ts
@@ -123,15 +123,14 @@ export function detectWorktreeName(basePath: string): string | null {
  * operate against the real project root, not a worktree subdirectory.
  */
 export function resolveProjectRoot(basePath: string): string {
-  const normalizedPath = basePath.replaceAll("\\", "/");
-  const seg = findWorktreeSegment(normalizedPath);
-  if (!seg) return basePath;
-
   // Layer 1: If the coordinator passed the real project root, use it.
-  // Only apply this override when basePath actually looks like a worktree path.
   if (process.env.GSD_PROJECT_ROOT) {
     return process.env.GSD_PROJECT_ROOT;
   }
+
+  const normalizedPath = basePath.replaceAll("\\", "/");
+  const seg = findWorktreeSegment(normalizedPath);
+  if (!seg) return basePath;
 
   // Candidate root via the string-slice heuristic
   const sepChar = basePath.includes("\\") ? "\\" : "/";
@@ -173,7 +172,7 @@ function resolveProjectRootFromGitFile(worktreePath: string): string | null {
   try {
     // Walk up from the worktree path to find the .git file
     let dir = worktreePath;
-    while (true) {
+    for (let i = 0; i < 10; i++) {
       const gitPath = join(dir, ".git");
       if (existsSync(gitPath)) {
         const content = readFileSync(gitPath, "utf8").trim();

--- a/tests/repro-worktree-bug/verify-fix.mjs
+++ b/tests/repro-worktree-bug/verify-fix.mjs
@@ -31,7 +31,7 @@ function findWorktreeSegment(normalizedPath) {
 function resolveProjectRootFromGitFile(worktreePath) {
   try {
     let dir = worktreePath;
-    while (true) {
+    for (let i = 0; i < 10; i++) {
       const gitPath = join(dir, ".git");
       if (existsSync(gitPath)) {
         const content = readFileSync(gitPath, "utf8").trim();
@@ -71,14 +71,14 @@ function normalizePathForCompare(path) {
 }
 
 function resolveProjectRoot(basePath) {
-  const normalizedPath = basePath.replaceAll("\\", "/");
-  const seg = findWorktreeSegment(normalizedPath);
-  if (!seg) return basePath;
-
   // Layer 1: If the coordinator passed the real project root, use it.
   if (process.env.GSD_PROJECT_ROOT) {
     return process.env.GSD_PROJECT_ROOT;
   }
+
+  const normalizedPath = basePath.replaceAll("\\", "/");
+  const seg = findWorktreeSegment(normalizedPath);
+  if (!seg) return basePath;
 
   const sepChar = basePath.includes("\\") ? "\\" : "/";
   const gsdMarker = `${sepChar}.gsd${sepChar}`;

--- a/tests/repro-worktree-bug/verify-integration.mjs
+++ b/tests/repro-worktree-bug/verify-integration.mjs
@@ -41,7 +41,7 @@ function findWorktreeSegment(normalizedPath) {
 function resolveProjectRootFromGitFile(worktreePath) {
   try {
     let dir = worktreePath;
-    while (true) {
+    for (let i = 0; i < 10; i++) {
       const gitPath = join(dir, ".git");
       if (existsSync(gitPath)) {
         const content = readFileSync(gitPath, "utf8").trim();
@@ -81,13 +81,14 @@ function normalizePathForCompare(path) {
 }
 
 function resolveProjectRoot(basePath) {
-  const normalizedPath = basePath.replaceAll("\\", "/");
-  const seg = findWorktreeSegment(normalizedPath);
-  if (!seg) return basePath;
-
+  // Layer 1: If the coordinator passed the real project root, use it.
   if (process.env.GSD_PROJECT_ROOT) {
     return process.env.GSD_PROJECT_ROOT;
   }
+
+  const normalizedPath = basePath.replaceAll("\\", "/");
+  const seg = findWorktreeSegment(normalizedPath);
+  if (!seg) return basePath;
 
   const sepChar = basePath.includes("\\") ? "\\" : "/";
   const gsdMarker = `${sepChar}.gsd${sepChar}`;


### PR DESCRIPTION
## TL;DR

**What:** Fix `resolveProjectRoot()` returning `~` when `.gsd` is a symlink into `~/.gsd/projects/<hash>`.
**Why:** Parallel workers corrupt `~/.gsd`, create `~/.git`, and crash pi.
**How:** 3-layer defense: `GSD_PROJECT_ROOT` env var from coordinator, `.git` file fallback, existing `validateDirectory` guard.

Closes #1676

## What

When `/gsd parallel` spawns workers with worktree isolation, the worker's `process.cwd()` resolves symlinks. If `.gsd` is a symlink to `~/.gsd/projects/<hash>` (the default layout), the resolved path contains `/.gsd/` at the **user-level** `~/.gsd` boundary. `findWorktreeSegment()` matches there instead of at the project `.gsd`, and `resolveProjectRoot()` returns `~` — the home directory.

### Files changed

| File | Change |
|------|--------|
| `src/resources/extensions/gsd/worktree.ts` | Fix `resolveProjectRoot()` with home-dir detection + `.git` file fallback |
| `src/resources/extensions/gsd/parallel-orchestrator.ts` | Pass `GSD_PROJECT_ROOT` env var to spawned workers |
| `src/resources/extensions/gsd/tests/worktree.test.ts` | Fix test that asserted buggy behavior as correct |
| `tests/repro-worktree-bug/` | Docker-based reproduction and verification scripts |

## Why

**Critical bug** — corrupts user-level GSD configuration and requires manual recovery:
- `git init` in `~` (creates `~/.git/`)
- `~/.gsd` overwritten with fresh project init
- `~/.gsd/parallel/` and `orchestrator.json` written to wrong location
- Pi unable to start until manual recovery

Affects every project using the default symlink layout with parallel execution.

The existing test literally asserted the bug as correct:
```typescript
assertEq(
    resolveProjectRoot("/Users/fran/.gsd/projects/89e1c9ad49bf/worktrees/M001"),
    "/Users/fran",  // This IS the bug
    "resolves to user home for symlink-resolved path",
);
```

## How

### 3-layer fix

**Layer 1 — `GSD_PROJECT_ROOT` env var (primary):** The coordinator in `parallel-orchestrator.ts` already knows the real `basePath`. Now passes it as `GSD_PROJECT_ROOT` to spawned workers. `resolveProjectRoot()` checks this first and short-circuits.

**Layer 2 — Home directory detection + `.git` file fallback (defensive):** After computing the candidate root via the string-slice heuristic, `resolveProjectRoot()` checks if `candidate/.gsd` matches the user-level GSD home (`~/.gsd`). If so, falls back to reading the worktree's `.git` file — it contains `gitdir: /real/project/.git/worktrees/<name>`, giving the real project root unambiguously.

**Layer 3 — Existing `validateDirectory` guard:** Already blocks `~` as a project root — but the bug bypassed it. With layers 1-2, this is now the fallback safety net.

### Why not just layer 1?

Layer 1 alone would fix parallel workers but not any other code path that calls `resolveProjectRoot()` with a symlink-resolved path. Layer 2 makes the function itself robust against this class of path confusion.

## Verification

### Docker reproduction (bug confirmed)
```
🐛 BUG CONFIRMED: resolveProjectRoot() returns "/root"
   when it should return "/tmp/myproject"
```

### Docker fix verification (8/8 pass)
- `GSD_PROJECT_ROOT` overrides path resolution ✅
- Direct layout still works ✅  
- Symlink-resolved path resolves to REAL project (not ~) ✅
- `resolveProjectRootFromGitFile` returns real project ✅
- Old code would have returned home directory (regression guard) ✅

### Docker integration verification (19/19 pass)
- `parallel/` dir created in project `.gsd`, not `~/.gsd` ✅
- Session status writes land in correct location ✅
- `orchestrator.json` lands in correct location ✅
- `validateDirectory` blocks `~` as fallback safety net ✅
- Non-worktree paths unaffected ✅

### Unit tests
- All 48 worktree-related tests pass ✅
- Full test suite: 1810 pass, 17 fail (all pre-existing on `main` in `native-search.test.ts` / `provider.test.ts`) ✅

- [x] `fix` — Bug fix
- [x] `test` — Adding or updating tests

AI-assisted: This PR was developed with AI assistance. All code has been tested in Docker isolation and verified against the full test suite.