### PR TITLE
fix(worktree): recurse into tasks/ when syncing slice artifacts back to project root

### DIFF
--- a/src/resources/extensions/gsd/auto-worktree.ts
+++ b/src/resources/extensions/gsd/auto-worktree.ts
@@ -300,6 +300,31 @@ export function syncWorktreeStateBack(
             } catch {
               /* non-fatal */
             }
+          } else if (fileEntry.isDirectory() && fileEntry.name === "tasks") {
+            // Recurse into tasks/ to sync task-level summaries (#1678)
+            const wtTasksDir = join(wtSliceDir, "tasks");
+            const mainTasksDir = join(mainSliceDir, "tasks");
+            try {
+              mkdirSync(mainTasksDir, { recursive: true });
+              for (const taskEntry of readdirSync(wtTasksDir, {
+                withFileTypes: true,
+              })) {
+                if (taskEntry.isFile() && taskEntry.name.endsWith(".md")) {
+                  const src = join(wtTasksDir, taskEntry.name);
+                  const dst = join(mainTasksDir, taskEntry.name);
+                  try {
+                    cpSync(src, dst, { force: true });
+                    synced.push(
+                      `milestones/${milestoneId}/slices/${sid}/tasks/${taskEntry.name}`,
+                    );
+                  } catch {
+                    /* non-fatal */
+                  }
+                }
+              }
+            } catch {
+              /* non-fatal */
+            }
           }
         }
       }

--- a/src/resources/extensions/gsd/tests/worktree-sync-milestones.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-sync-milestones.test.ts
@@ -1,9 +1,12 @@
 /**
- * worktree-sync-milestones.test.ts — Regression test for #1311.
+ * worktree-sync-milestones.test.ts — Regression tests for #1311 and #1678.
  *
  * Verifies that syncProjectRootToWorktree copies milestone artifacts
  * from the main repo's .gsd/ into the worktree's .gsd/ for the
  * specified milestone, and deletes gsd.db so it rebuilds from fresh state.
+ *
+ * Also verifies that syncWorktreeStateBack recurses into tasks/ subdirectories
+ * so task-level summaries are not dropped on milestone teardown (#1678).
  *
  * Covers:
  *   - Milestone directory synced from main to worktree
@@ -12,6 +15,7 @@
  *   - No-op when paths are equal
  *   - No-op when milestoneId is null
  *   - Non-existent directories handled gracefully
+ *   - syncWorktreeStateBack recurses into tasks/ subdirectory (#1678)
  */
 
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync } from 'node:fs';
@@ -19,7 +23,7 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
 import { syncProjectRootToWorktree } from '../auto-worktree-sync.ts';
-import { syncGsdStateToWorktree } from '../auto-worktree.ts';
+import { syncGsdStateToWorktree, syncWorktreeStateBack } from '../auto-worktree.ts';
 import { createTestContext } from './test-helpers.ts';
 
 const { assertTrue, report } = createTestContext();
@@ -176,6 +180,51 @@ async function main(): Promise<void> {
       assertTrue(result.synced.length > 0, 'sync reported files');
     } finally {
       cleanup(mainBase);
+      rmSync(wtBase, { recursive: true, force: true });
+    }
+  }
+
+  // ─── 8. syncWorktreeStateBack recurses into tasks/ (#1678) ───────────
+  console.log('\n=== 8. syncWorktreeStateBack copies tasks/ subdirectory (#1678) ===');
+  {
+    const mainBase = mkdtempSync(join(tmpdir(), 'gsd-wt-back-main-'));
+    const wtBase = mkdtempSync(join(tmpdir(), 'gsd-wt-back-wt-'));
+
+    try {
+      // Build worktree milestone structure with slice-level and task-level files
+      const wtSliceDir = join(wtBase, '.gsd', 'milestones', 'M001', 'slices', 'S01');
+      const wtTasksDir = join(wtSliceDir, 'tasks');
+      mkdirSync(wtTasksDir, { recursive: true });
+      writeFileSync(join(wtSliceDir, 'S01-SUMMARY.md'), '# S01 Summary');
+      writeFileSync(join(wtTasksDir, 'T01-SUMMARY.md'), '# T01 Summary');
+      writeFileSync(join(wtTasksDir, 'T02-SUMMARY.md'), '# T02 Summary');
+
+      // Main project root starts with only the milestone directory (no slices yet)
+      mkdirSync(join(mainBase, '.gsd', 'milestones', 'M001'), { recursive: true });
+
+      const { synced } = syncWorktreeStateBack(mainBase, wtBase, 'M001');
+
+      const mainSliceDir = join(mainBase, '.gsd', 'milestones', 'M001', 'slices', 'S01');
+      const mainTasksDir = join(mainSliceDir, 'tasks');
+
+      assertTrue(
+        existsSync(join(mainSliceDir, 'S01-SUMMARY.md')),
+        '#1678: slice SUMMARY synced to project root',
+      );
+      assertTrue(
+        existsSync(join(mainTasksDir, 'T01-SUMMARY.md')),
+        '#1678: task T01-SUMMARY synced to project root',
+      );
+      assertTrue(
+        existsSync(join(mainTasksDir, 'T02-SUMMARY.md')),
+        '#1678: task T02-SUMMARY synced to project root',
+      );
+      assertTrue(
+        synced.some((p) => p.includes('tasks/T01-SUMMARY.md')),
+        '#1678: task summary appears in synced list',
+      );
+    } finally {
+      rmSync(mainBase, { recursive: true, force: true });
       rmSync(wtBase, { recursive: true, force: true });
     }
   }


### PR DESCRIPTION
## TL;DR

**What:** `syncWorktreeStateBack()` silently skipped the `tasks/` subdirectory inside each slice directory — task-level summaries were never copied back to the project root before worktree teardown.
**Why:** The inner loop checked `fileEntry.isFile()`, so directory entries like `tasks/` fell through without being processed.
**How:** Added an `else if` branch that detects `tasks/` and recurses into it, copying all `.md` files and appending them to the `synced` list.

Closes #1678

## Root Cause

In `auto-worktree.ts`, `syncWorktreeStateBack()` iterates each slice directory but only handles files:

```typescript
// Before: tasks/ directory silently skipped
for (const fileEntry of readdirSync(wtSliceDir, { withFileTypes: true })) {
  if (fileEntry.isFile() && fileEntry.name.endsWith(".md")) {
    cpSync(src, dst, { force: true }); // S01-SUMMARY.md ✓
  }
  // tasks/ is a directory → falls through, never copied
}
```

The result: 42 completion artifacts (23 task summaries, 9 slice summaries, 9 UAT files) were lost in the reporter's project after a milestone completed and the worktree was torn down.

## Fix

```typescript
} else if (fileEntry.isDirectory() && fileEntry.name === "tasks") {
  // Recurse into tasks/ to sync task-level summaries (#1678)
  const wtTasksDir = join(wtSliceDir, "tasks");
  const mainTasksDir = join(mainSliceDir, "tasks");
  mkdirSync(mainTasksDir, { recursive: true });
  for (const taskEntry of readdirSync(wtTasksDir, { withFileTypes: true })) {
    if (taskEntry.isFile() && taskEntry.name.endsWith(".md")) {
      cpSync(src, dst, { force: true });
      synced.push(`milestones/${milestoneId}/slices/${sid}/tasks/${taskEntry.name}`);
    }
  }
}
```

This is consistent with how `syncStateToProjectRoot()` already handles recursive copy via `safeCopyRecursive()`.

## Test

Added case 8 to `worktree-sync-milestones.test.ts`: builds a worktree with `S01/tasks/T01-SUMMARY.md` and `T02-SUMMARY.md`, calls `syncWorktreeStateBack()`, and asserts all task summaries land in the project root and appear in the `synced` list.

```
Results: 21 passed, 0 failed
```