### PR TITLE
Add /gsd command draft hold for updates

### DIFF
--- a/src/resources/extensions/gsd/commands-bootstrap.ts
+++ b/src/resources/extensions/gsd/commands-bootstrap.ts
@@ -1,4 +1,5 @@
 import { importExtensionModule, type ExtensionAPI, type ExtensionCommandContext } from "@gsd/pi-coding-agent";
+import { getInstallReferenceCompletions } from "./install-ecosystem-catalog.js";
 
 const TOP_LEVEL_SUBCOMMANDS = [
   { cmd: "help", desc: "Categorized command reference with descriptions" },
@@ -207,6 +208,13 @@ function getGsdArgumentCompletions(prefix: string) {
     return filterStartsWith(partial, [
       { cmd: "info", desc: "Show detailed template info" },
     ], "templates");
+  }
+
+  if (parts[0] === "install" && parts.length <= 2) {
+    const partial = parts[1] ?? "";
+    return getInstallReferenceCompletions()
+      .filter((item) => item.cmd.startsWith(partial))
+      .map((item) => ({ value: `install ${item.cmd}`, label: item.cmd, description: item.desc }));
   }
 
   if (parts[0] === "extensions" && parts.length <= 2) {

--- a/src/resources/extensions/gsd/commands.ts
+++ b/src/resources/extensions/gsd/commands.ts
@@ -53,7 +53,30 @@ import { handleStart, handleTemplates, getTemplateCompletions } from "./commands
 import { readSessionLockData, isSessionLockProcessAlive } from "./session-lock.js";
 import { handleCmux } from "./commands-cmux.js";
 import { showNextAction } from "../shared/mod.js";
+import {
+  getInstallReferenceCompletions,
+  installEcosystemCatalog as installEcosystemCatalogRuntime,
+} from "./install-ecosystem-catalog.js";
 
+type InstallCommandRuntime = {
+  installEcosystemCatalog: typeof installEcosystemCatalogRuntime;
+};
+
+let installCommandRuntimeOverride: Partial<InstallCommandRuntime> | null = null;
+
+function getInstallCommandRuntime(): InstallCommandRuntime {
+  return {
+    installEcosystemCatalog: installCommandRuntimeOverride?.installEcosystemCatalog ?? installEcosystemCatalogRuntime,
+  };
+}
+
+export function __setInstallCommandRuntimeForTests(runtime: Partial<InstallCommandRuntime>): void {
+  installCommandRuntimeOverride = runtime;
+}
+
+export function __resetInstallCommandRuntimeForTests(): void {
+  installCommandRuntimeOverride = null;
+}
 
 /** Resolve the effective project root, accounting for worktree paths. */
 export function projectRoot(): string {
@@ -466,6 +489,13 @@ export function registerGSDCommand(pi: ExtensionAPI): void {
         const namePrefix = parts[2] ?? "";
         return getTemplateCompletions(namePrefix)
           .map((c) => ({ value: `templates ${c.value}`, label: c.label, description: c.description }));
+      }
+
+      if (parts[0] === "install" && parts.length <= 2) {
+        const referencePrefix = parts[1] ?? "";
+        return getInstallReferenceCompletions()
+          .filter((item) => item.cmd.startsWith(referencePrefix))
+          .map((item) => ({ value: `install ${item.cmd}`, label: item.cmd, description: item.desc }));
       }
 
       if (parts[0] === "extensions") {
@@ -1068,6 +1098,11 @@ Examples:
         return;
       }
 
+      if (trimmed === "install" || trimmed.startsWith("install ")) {
+        await handleInstallCommand(trimmed.replace(/^install\s*/, "").trim(), ctx, pi);
+        return;
+      }
+
       if (trimmed === "") {
         if (!(await guardRemoteSession(ctx, pi))) return;
         await startAuto(ctx, pi, projectRoot(), false, { step: true });
@@ -1084,6 +1119,92 @@ Examples:
     `Unknown: /gsd ${trimmed}. Run /gsd help for available commands.`,
     "warning",
   );
+}
+
+async function handleInstallCommand(
+  reference: string,
+  ctx: ExtensionCommandContext,
+  pi: ExtensionAPI,
+): Promise<void> {
+  const payload = (data: Record<string, unknown>) => {
+    pi.sendMessage({ customType: "gsd-install", content: JSON.stringify(data), display: false });
+  };
+
+  if (!reference) {
+    const message = "Usage: /gsd install gsd-build/<slug>";
+    ctx.ui.notify(message, "warning");
+    payload({ status: "error", code: "catalog/usage", message });
+    return;
+  }
+
+  if (!ctx.hasUI || typeof ctx.ui.select !== "function") {
+    const message = "/gsd install requires an interactive terminal so you can choose project-local or user-global.";
+    ctx.ui.notify(message, "error");
+    payload({ status: "error", code: "catalog/ui-required", message, reference });
+    return;
+  }
+
+  const prompt = `Install ${reference} into which scope?`;
+  const choices = ["project-local", "user-global", "Cancel"] as const;
+  const rawChoice = await ctx.ui.select(prompt, [...choices]);
+  const choice = Array.isArray(rawChoice) ? rawChoice[0] : rawChoice;
+  if (!choice || choice === "Cancel") {
+    const message = `Install cancelled for ${reference}.`;
+    ctx.ui.notify(message, "info");
+    payload({ status: "cancelled", reference, prompt, choices });
+    return;
+  }
+
+  const scope = choice === "project-local" ? "project-local" : choice === "user-global" ? "user-global" : null;
+  if (!scope) {
+    const message = `Install cancelled for ${reference}.`;
+    ctx.ui.notify(message, "info");
+    payload({ status: "cancelled", reference, prompt, choices });
+    return;
+  }
+
+  try {
+    const result = await getInstallCommandRuntime().installEcosystemCatalog(reference, {
+      scope,
+      cwd: projectRoot(),
+    });
+
+    await ctx.waitForIdle();
+
+    try {
+      await ctx.reload();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      ctx.ui.notify(`Installed ${reference}, but reload failed: ${message}`, "error");
+      payload({
+        status: "error",
+        code: "catalog/reload-failed",
+        phase: "reload",
+        message,
+        reference,
+        result,
+      });
+      return;
+    }
+
+    const notificationLines = [
+      `Installed ${reference}.`,
+      `- Scope: ${result.chosenScope}`,
+      `- Source: ${result.resolvedSource}`,
+      `- Managed path: ${result.actualManagedPath}`,
+      `- Settings entry: ${result.settingsEntryAdded ? "added" : "already present"}`,
+      `- Reload: completed`,
+      `- Activation: Reload completed; ${result.slug} is now available from ${result.actualManagedPath}.`,
+    ];
+    ctx.ui.notify(notificationLines.join("\n"), "success");
+    payload({ status: "success", reference, prompt, choices, result });
+  } catch (error) {
+    const phase = typeof (error as { phase?: unknown })?.phase === "string" ? (error as { phase: string }).phase : "install";
+    const code = typeof (error as { code?: unknown })?.code === "string" ? (error as { code: string }).code : "catalog/install-failed";
+    const message = error instanceof Error ? error.message : String(error);
+    ctx.ui.notify(`${phase}/${code}: ${message}`, "error");
+    payload({ status: "error", phase, code, message, reference });
+  }
 }
 
 function showHelp(ctx: ExtensionCommandContext): void {

--- a/src/resources/extensions/gsd/install-ecosystem-catalog.ts
+++ b/src/resources/extensions/gsd/install-ecosystem-catalog.ts
@@ -1,0 +1,162 @@
+import { DefaultPackageManager, SettingsManager, getAgentDir } from '@gsd/pi-coding-agent';
+import type { PackageManager } from '@gsd/pi-coding-agent';
+import { join } from 'node:path';
+
+const CONFIG_DIR_NAME = '.gsd';
+const PUBLIC_NAMESPACE = 'gsd-build';
+
+export type EcosystemCatalogScope = 'project-local' | 'user-global';
+export type InstallerScope = 'project' | 'user';
+export type CatalogReference = `${typeof PUBLIC_NAMESPACE}/${string}`;
+
+export interface EcosystemCatalogEntry {
+  slug: string;
+  reference: CatalogReference;
+  source: string;
+}
+
+const PI_FINDER_PIN = 'da6f87b4d2f32c2a112a3cb8ea5c84220cddf955';
+
+export const ECOSYSTEM_CATALOG_ENTRIES: readonly EcosystemCatalogEntry[] = [
+  {
+    slug: 'workspace-scout',
+    reference: 'gsd-build/workspace-scout',
+    source: `git:https://github.com/default-anton/pi-finder.git@${PI_FINDER_PIN}`,
+  },
+] as const;
+
+export const PUBLIC_ECOSYSTEM_CATALOG_REFERENCES = ECOSYSTEM_CATALOG_ENTRIES.map((entry) => entry.reference);
+
+export interface EcosystemCatalogInstallOptions {
+  scope: EcosystemCatalogScope;
+  cwd?: string;
+  agentDir?: string;
+  packageManager?: PackageManager;
+  settingsManager?: SettingsManager;
+}
+
+export interface EcosystemCatalogInstallResult {
+  requestedReference: CatalogReference;
+  slug: string;
+  resolvedSource: string;
+  chosenScope: EcosystemCatalogScope;
+  installerScope: InstallerScope;
+  actualManagedPath: string;
+  settingsEntryAdded: boolean;
+  settingsPath: string;
+  activation: {
+    status: 'pending-reload';
+    summary: string;
+  };
+}
+
+export class EcosystemCatalogInstallError extends Error {
+  phase: string;
+  code: string;
+  details?: Record<string, unknown>;
+
+  constructor(phase: string, code: string, message: string, details?: Record<string, unknown>) {
+    super(message);
+    this.name = 'EcosystemCatalogInstallError';
+    this.phase = phase;
+    this.code = code;
+    this.details = details;
+  }
+}
+
+function resolveCatalogEntry(reference: string): EcosystemCatalogEntry {
+  if (!reference.startsWith(`${PUBLIC_NAMESPACE}/`)) {
+    throw new EcosystemCatalogInstallError(
+      'reference',
+      'catalog/invalid-reference',
+      `Unsupported ${PUBLIC_NAMESPACE} reference: ${reference}`,
+      { reference },
+    );
+  }
+
+  const entry = ECOSYSTEM_CATALOG_ENTRIES.find((candidate) => candidate.reference === reference);
+
+  if (!entry) {
+    throw new EcosystemCatalogInstallError(
+      'reference',
+      'catalog/unknown-slug',
+      `Unknown ${PUBLIC_NAMESPACE} slug: ${reference}`,
+      { reference },
+    );
+  }
+
+  return entry;
+}
+
+export function getInstallReferenceCompletions(): Array<{ cmd: string; desc: string }> {
+  return PUBLIC_ECOSYSTEM_CATALOG_REFERENCES.map((reference) => ({
+    cmd: reference,
+    desc: `Install ${reference} from the ${PUBLIC_NAMESPACE} catalog`,
+  }));
+}
+
+export async function installEcosystemCatalog(
+  reference: string,
+  options: EcosystemCatalogInstallOptions,
+): Promise<EcosystemCatalogInstallResult> {
+  const entry = resolveCatalogEntry(reference);
+  const cwd = options.cwd ?? process.cwd();
+  const agentDir = options.agentDir ?? getAgentDir();
+  const settingsManager = options.settingsManager ?? SettingsManager.create(cwd, agentDir);
+  const packageManager = options.packageManager ?? new DefaultPackageManager({ cwd, agentDir, settingsManager });
+  const installerScope: InstallerScope = options.scope === 'project-local' ? 'project' : 'user';
+  const local = installerScope === 'project';
+
+  try {
+    await packageManager.install(entry.source, { local });
+  } catch (error) {
+    throw new EcosystemCatalogInstallError(
+      'install',
+      'catalog/install-failed',
+      error instanceof Error ? error.message : String(error),
+      { reference, source: entry.source, installerScope },
+    );
+  }
+
+  const actualManagedPath = packageManager.getInstalledPath(entry.source, installerScope);
+  if (!actualManagedPath) {
+    throw new EcosystemCatalogInstallError(
+      'install',
+      'catalog/unresolved-managed-path',
+      `Installed source could not be resolved for ${entry.source}`,
+      { reference, source: entry.source, installerScope },
+    );
+  }
+
+  let settingsEntryAdded = false;
+  try {
+    settingsEntryAdded = packageManager.addSourceToSettings(entry.source, { local });
+    await settingsManager.flush();
+  } catch (error) {
+    throw new EcosystemCatalogInstallError(
+      'settings',
+      'catalog/settings-write-failed',
+      error instanceof Error ? error.message : String(error),
+      { reference, source: entry.source, installerScope },
+    );
+  }
+
+  const settingsPath = installerScope === 'project'
+    ? join(cwd, CONFIG_DIR_NAME, 'settings.json')
+    : join(agentDir, 'settings.json');
+
+  return {
+    requestedReference: entry.reference,
+    slug: entry.slug,
+    resolvedSource: entry.source,
+    chosenScope: options.scope,
+    installerScope,
+    actualManagedPath,
+    settingsEntryAdded,
+    settingsPath,
+    activation: {
+      status: 'pending-reload',
+      summary: 'Install completed. Reload is still required before the runtime can confirm activation.',
+    },
+  };
+}

--- a/src/resources/extensions/gsd/tests/install-command.test.ts
+++ b/src/resources/extensions/gsd/tests/install-command.test.ts
@@ -1,0 +1,27 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  ECOSYSTEM_CATALOG_ENTRIES,
+  PUBLIC_ECOSYSTEM_CATALOG_REFERENCES,
+  getInstallReferenceCompletions,
+} from '../install-ecosystem-catalog.ts';
+
+test('install reference completions expose the public gsd-build references', () => {
+  const completions = getInstallReferenceCompletions();
+  assert.deepEqual(
+    completions.map((entry) => entry.cmd),
+    PUBLIC_ECOSYSTEM_CATALOG_REFERENCES,
+  );
+  assert.ok(completions.every((entry) => entry.desc.includes(entry.cmd)));
+});
+
+test('workspace-scout entry is published under gsd-build namespace', () => {
+  assert.deepEqual(ECOSYSTEM_CATALOG_ENTRIES, [
+    {
+      slug: 'workspace-scout',
+      reference: 'gsd-build/workspace-scout',
+      source: 'git:https://github.com/default-anton/pi-finder.git@da6f87b4d2f32c2a112a3cb8ea5c84220cddf955',
+    },
+  ]);
+});

--- a/src/resources/extensions/gsd/tests/install-ecosystem-catalog.test.ts
+++ b/src/resources/extensions/gsd/tests/install-ecosystem-catalog.test.ts
@@ -1,0 +1,144 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  EcosystemCatalogInstallError,
+  PUBLIC_ECOSYSTEM_CATALOG_REFERENCES,
+  installEcosystemCatalog,
+} from '../install-ecosystem-catalog.ts';
+
+test('public catalog references include workspace-scout under gsd-build namespace', () => {
+  assert.deepEqual(PUBLIC_ECOSYSTEM_CATALOG_REFERENCES, [
+    'gsd-build/workspace-scout',
+  ]);
+});
+
+test('installEcosystemCatalog rejects references outside gsd-build namespace', async () => {
+  await assert.rejects(
+    installEcosystemCatalog('npm:latchkey', { scope: 'project-local' }),
+    (error: unknown) => {
+      assert.ok(error instanceof EcosystemCatalogInstallError);
+      assert.equal(error.phase, 'reference');
+      assert.equal(error.code, 'catalog/invalid-reference');
+      return true;
+    },
+  );
+});
+
+test('installEcosystemCatalog rejects unknown slugs', async () => {
+  await assert.rejects(
+    installEcosystemCatalog('gsd-build/unknown', { scope: 'project-local' }),
+    (error: unknown) => {
+      assert.ok(error instanceof EcosystemCatalogInstallError);
+      assert.equal(error.phase, 'reference');
+      assert.equal(error.code, 'catalog/unknown-slug');
+      return true;
+    },
+  );
+});
+
+test('project-local installs map to package-manager local installs and project settings', async () => {
+  const calls: Array<{ method: string; args: unknown[] }> = [];
+  const settingsCalls: string[] = [];
+
+  const result = await installEcosystemCatalog('gsd-build/workspace-scout', {
+    scope: 'project-local',
+    cwd: '/tmp/project',
+    agentDir: '/tmp/agent',
+    packageManager: {
+      async install(source: string, options?: { local?: boolean }) {
+        calls.push({ method: 'install', args: [source, options] });
+      },
+      getInstalledPath(source: string, scope: 'user' | 'project') {
+        calls.push({ method: 'getInstalledPath', args: [source, scope] });
+        return '/tmp/project/.gsd/git/github.com/default-anton/pi-finder';
+      },
+      addSourceToSettings(source: string, options?: { local?: boolean }) {
+        calls.push({ method: 'addSourceToSettings', args: [source, options] });
+        return true;
+      },
+    } as any,
+    settingsManager: {
+      async flush() {
+        settingsCalls.push('flush');
+      },
+    } as any,
+  });
+
+  assert.equal(result.slug, 'workspace-scout');
+  assert.equal(result.chosenScope, 'project-local');
+  assert.equal(result.installerScope, 'project');
+  assert.equal(result.actualManagedPath, '/tmp/project/.gsd/git/github.com/default-anton/pi-finder');
+  assert.equal(result.settingsPath, '/tmp/project/.gsd/settings.json');
+  assert.equal(result.settingsEntryAdded, true);
+  assert.match(result.resolvedSource, /^git:https:\/\/github\.com\/default-anton\/pi-finder\.git@/);
+  assert.deepEqual(calls, [
+    { method: 'install', args: [result.resolvedSource, { local: true }] },
+    { method: 'getInstalledPath', args: [result.resolvedSource, 'project'] },
+    { method: 'addSourceToSettings', args: [result.resolvedSource, { local: true }] },
+  ]);
+  assert.deepEqual(settingsCalls, ['flush']);
+});
+
+test('user-global installs map to package-manager user installs and agent settings', async () => {
+  const calls: Array<{ method: string; args: unknown[] }> = [];
+  const settingsCalls: string[] = [];
+
+  const result = await installEcosystemCatalog('gsd-build/workspace-scout', {
+    scope: 'user-global',
+    cwd: '/tmp/project',
+    agentDir: '/tmp/agent',
+    packageManager: {
+      async install(source: string, options?: { local?: boolean }) {
+        calls.push({ method: 'install', args: [source, options] });
+      },
+      getInstalledPath(source: string, scope: 'user' | 'project') {
+        calls.push({ method: 'getInstalledPath', args: [source, scope] });
+        return '/tmp/agent/git/github.com/default-anton/pi-finder';
+      },
+      addSourceToSettings(source: string, options?: { local?: boolean }) {
+        calls.push({ method: 'addSourceToSettings', args: [source, options] });
+        return true;
+      },
+    } as any,
+    settingsManager: {
+      async flush() {
+        settingsCalls.push('flush');
+      },
+    } as any,
+  });
+
+  assert.equal(result.slug, 'workspace-scout');
+  assert.equal(result.chosenScope, 'user-global');
+  assert.equal(result.installerScope, 'user');
+  assert.equal(result.settingsPath, '/tmp/agent/settings.json');
+  assert.deepEqual(calls, [
+    { method: 'install', args: [result.resolvedSource, { local: false }] },
+    { method: 'getInstalledPath', args: [result.resolvedSource, 'user'] },
+    { method: 'addSourceToSettings', args: [result.resolvedSource, { local: false }] },
+  ]);
+  assert.deepEqual(settingsCalls, ['flush']);
+});
+
+test('installEcosystemCatalog surfaces install failures with named phase and code', async () => {
+  const packageManager = {
+    async install() {
+      throw new Error('git clone failed');
+    },
+  };
+
+  await assert.rejects(
+    installEcosystemCatalog('gsd-build/workspace-scout', {
+      scope: 'project-local',
+      packageManager: packageManager as any,
+      settingsManager: { async flush() {} } as any,
+    }),
+    (error: unknown) => {
+      assert.ok(error instanceof EcosystemCatalogInstallError);
+      assert.equal(error.phase, 'install');
+      assert.equal(error.code, 'catalog/install-failed');
+      assert.match(error.message, /git clone failed/);
+      return true;
+    },
+  );
+});


### PR DESCRIPTION
## TL;DR

Add the `/gsd install gsd-build/<slug>` infrastructure to GSD with interactive scope selection, accurate settings-path reporting, and discoverable completions, while shipping with an empty default public catalog.

## What

- add `/gsd install gsd-build/<slug>` to the GSD command router
- add interactive scope selection for `project-local` and `user-global`
- add top-level and reference completions for the new `install` command
- add an install helper that resolves branded refs to managed package installs
- tighten usage/error messaging for invalid extra arguments
- report the settings path from the same underlying config source used by `SettingsManager`
- keep activation messaging conservative until load is actually confirmed
- keep the shipped public `gsd-build` catalog empty by default
- add focused tests for completions, routing, validation, scope mapping, and failure reporting

## Why

GSD did not have a user-facing install command for branded catalog entries. This adds the product-facing install path so future approved catalog entries can be installed directly through GSD instead of relying on lower-level package-manager commands, without bundling a third-party source in this PR.

## How

- added the install implementation in `src/resources/extensions/gsd/install-ecosystem-catalog.ts`
- extracted lightweight catalog completion data into `src/resources/extensions/gsd/install-ecosystem-catalog-data.ts` so bootstrap completions do not pull the full installer runtime
- wired `/gsd install` into `src/resources/extensions/gsd/commands.ts`
- added install discoverability in runtime help/completions and bootstrap completions
- kept the shipped public catalog empty, with test-only catalog injection used to preserve success-path coverage
- added focused tests in:
  - `src/resources/extensions/gsd/tests/install-ecosystem-catalog.test.ts`
  - `src/resources/extensions/gsd/tests/install-command.test.ts`

## Change type

- [x] `feat` — New feature or capability
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [x] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [ ] CI passes
- [x] New/updated tests included
- [ ] Manual testing — steps described above
- [ ] No tests needed — explained above

### Automated

- `npm run typecheck:extensions`
- `npm run copy-resources`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/install-ecosystem-catalog.test.ts src/resources/extensions/gsd/tests/install-command.test.ts src/resources/extensions/gsd/tests/update-command.test.ts`

### Manual

- not included in this revision because the shipped public catalog is intentionally empty by default

## AI disclosure

- [x] This PR includes AI-assisted code
