### PR TITLE
fix(gsd): sanitize milestone merge commit titles

### DIFF
--- a/src/resources/extensions/gsd/auto-worktree.ts
+++ b/src/resources/extensions/gsd/auto-worktree.ts
@@ -60,6 +60,18 @@ import {
 /** Original project root before chdir into auto-worktree. */
 let originalBase: string | null = null;
 
+function sanitizeMilestoneCommitTitle(rawTitle: string, milestoneId: string): string {
+  const normalized = rawTitle
+    .replace(/[\r\n\t]+/g, " ")
+    .replace(/[\x00-\x1F\x7F]/g, "")
+    .replace(/[\u2014\u2013]/g, "-")
+    .replace(/\//g, "-")
+    .replace(/\s+/g, " ")
+    .trim();
+
+  return normalized || milestoneId;
+}
+
 function clearProjectRootStateFiles(basePath: string, milestoneId: string): void {
   const gsdDir = gsdRoot(basePath);
   const transientFiles = [
@@ -847,8 +859,10 @@ export function mergeMilestoneToMain(
   }
 
   // 6. Build rich commit message
-  const milestoneTitle =
-    roadmap.title.replace(/^M\d+:\s*/, "").trim() || milestoneId;
+  const milestoneTitle = sanitizeMilestoneCommitTitle(
+    roadmap.title.replace(/^M\d+(?:-[a-z0-9]{6})?[^:]*:\s*/, "").trim(),
+    milestoneId,
+  );
   const subject = `feat(${milestoneId}): ${milestoneTitle}`;
   let body = "";
   if (completedSlices.length > 0) {

--- a/src/resources/extensions/gsd/tests/auto-worktree-milestone-merge.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-worktree-milestone-merge.test.ts
@@ -180,7 +180,29 @@ async function main(): Promise<void> {
       assertTrue(gitMsg.includes("- S01: Core API"), "git commit body has S01");
     }
 
-    // ─── Test 3: Nothing to commit — no changes ────────────────────────
+    // ─── Test 3: Unsafe milestone titles are sanitized for commit subject ─────────
+    console.log("\n=== unsafe milestone titles are sanitized for commit subject ===");
+    {
+      const repo = freshRepo();
+      const wtPath = createAutoWorktree(repo, "M025");
+
+      addSliceToMilestone(repo, wtPath, "M025", "S01", "Core plumbing", [
+        { file: "core.ts", content: "export const core = true;\n", message: "add core" },
+      ]);
+
+      const roadmap = makeRoadmap("M025", "Foundation — Build Core/API\n\tPhase\u0007", [
+        { id: "S01", title: "Core plumbing" },
+      ]);
+
+      const result = mergeMilestoneToMain(repo, "M025", roadmap);
+      assertTrue(result.commitMessage.startsWith("feat(M025): Foundation - Build Core-API Phase"), "sanitizes em dash, slash, newline, tab, and control chars in subject");
+
+      const gitMsg = run("git log -1 --format=%B main", repo).trim();
+      assertTrue(gitMsg.startsWith("feat(M025): Foundation - Build Core-API Phase"), "git commit subject is sanitized");
+      assertTrue(!gitMsg.includes("\n\n\n"), "subject sanitation does not inject extra blank lines");
+    }
+
+    // ─── Test 4: Nothing to commit — no changes ────────────────────────
     console.log("\n=== nothing to commit — no changes ===");
     {
       const repo = freshRepo();


### PR DESCRIPTION
## Summary
- sanitize milestone titles before building the final milestone squash-merge commit subject
- align milestone title prefix stripping with the unique milestone ID format (`M001-abc123`) already handled elsewhere
- add a regression test covering unsafe title characters in milestone merge subjects

## Problem
`/gsd doctor` already warns when milestone titles contain delimiter characters like em dashes or `/`, but the milestone merge path still used the raw parsed title when building the final squash-merge commit message.

That left a gap where:
- unsafe title characters could leak into the final commit subject
- unique milestone IDs were not stripped correctly in this path because it only matched `M001:` and not `M001-abc123:`

## What changed
- sanitize milestone merge commit titles by:
  - collapsing newlines/tabs into spaces
  - removing control characters
  - normalizing em/en dash to `-`
  - replacing `/` with `-`
  - collapsing repeated whitespace
  - falling back to `milestoneId` if the sanitized title becomes empty
- use the same broader milestone-title stripping regex already covered in regex-hardening tests
- add a merge regression test for unsafe milestone titles

## Verification
I verified the behavior end-to-end with real temp git repos using `createAutoWorktree()` + `mergeMilestoneToMain()`:
- unsafe title `Foundation — Build Core/API` now produces `feat(M025): Foundation - Build Core-API`
- unique milestone ID `M001-abc123` now produces `feat(M001-abc123): Foundation - Build Core-API`

I did not run the package TS test harness locally because the environment here is on Node 20 and this repo's test path requires Node 22+ for `--experimental-strip-types`.
