### PR TITLE
refactor: replace hardcoded /tmp paths with os.tmpdir()/homedir()

### DIFF
--- a/packages/pi-tui/src/tui.ts
+++ b/packages/pi-tui/src/tui.ts
@@ -811,7 +811,7 @@ export class TUI extends Container {
 		buffer += "\x1b[?2026l"; // End synchronized output
 
 		if (process.env.PI_TUI_DEBUG === "1") {
-			const debugDir = "/tmp/tui";
+			const debugDir = path.join(os.tmpdir(), "tui");
 			fs.mkdirSync(debugDir, { recursive: true });
 			const debugPath = path.join(debugDir, `render-${Date.now()}-${Math.random().toString(36).slice(2)}.log`);
 			const debugData = [

--- a/src/resources/extensions/cmux/index.ts
+++ b/src/resources/extensions/cmux/index.ts
@@ -1,5 +1,7 @@
 import { execFile, execFileSync } from "node:child_process";
 import { existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { promisify } from "node:util";
 import type { GSDPreferences } from "../gsd/preferences.js";
 import type { GSDState, Phase } from "../gsd/types.js";

--- a/src/resources/extensions/voice/index.ts
+++ b/src/resources/extensions/voice/index.ts
@@ -4,6 +4,7 @@ import type { AssistantMessage } from "@gsd/pi-ai";
 import { isKeyRelease, Key, matchesKey, truncateToWidth, visibleWidth } from "@gsd/pi-tui";
 import { spawn, execSync, type ChildProcess } from "node:child_process";
 import * as fs from "node:fs";
+import * as os from "node:os";
 import * as path from "node:path";
 import * as readline from "node:readline";
 
@@ -15,7 +16,7 @@ const PYTHON_SCRIPT = path.join(__extensionDir, "speech-recognizer.py");
 const IS_DARWIN = process.platform === "darwin";
 const IS_LINUX = process.platform === "linux";
 const VOICE_VENV_PYTHON = path.join(
-	process.env.HOME || process.env.USERPROFILE || "/tmp",
+	process.env.HOME || process.env.USERPROFILE || os.homedir(),
 	".gsd",
 	"voice-venv",
 	"bin",


### PR DESCRIPTION
Closes #1707

## What

Replaces hardcoded Unix `/tmp` paths with Node's cross-platform `os` module APIs.

## Why

`/tmp` is Unix-only. On macOS it symlinks to `/private/tmp`; on Windows it doesn't exist. Using `os.tmpdir()` and `os.homedir()` is the correct portable approach.

## Changes

| File | Before | After |
|---|---|---|
| `packages/pi-tui/src/tui.ts` | `"/tmp/tui"` | `path.join(os.tmpdir(), "tui")` |
| `src/resources/extensions/cmux/index.ts` | `"/tmp/cmux.sock"` | `join(tmpdir(), "cmux.sock")` |
| `src/resources/extensions/voice/index.ts` | `\|\| "/tmp"` | `\|\| os.homedir()` |

Build passes clean. Test files left untouched — they use `/tmp` as placeholder strings in assertions, not actual filesystem paths.