### PR TITLE
fix(auto): abort in-flight stream on pauseAuto to unfreeze TUI input

### DIFF
--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -713,6 +713,14 @@ export async function pauseAuto(
   if (!s.active) return;
   clearUnitTimeout();
 
+  // Abort any in-flight agent operation so isStreaming resets to false before
+  // returning control to the interactive loop. Without this, input-controller
+  // routes all user input as "steer" messages (never calling onInputCallback),
+  // leaving getUserInput() pending indefinitely and the TUI appearing frozen.
+  if (ctx && !ctx.isIdle()) {
+    ctx.abort();
+  }
+
   s.pausedSessionFile = ctx?.sessionManager?.getSessionFile() ?? null;
 
   // Persist paused-session metadata so resume survives /exit (#1383).


### PR DESCRIPTION
## Problem

After a long auto-mode run (observed after 14+ hours), when the session paused — triggered by ESC, budget ceiling, context-window threshold, health-gate failure, or `pauseAutoForProviderError` — the TUI would display **\"paused\"** but completely stop accepting keyboard input. The only recovery was killing the process.

### Root cause

`pauseAuto()` correctly sets `s.paused = true` and updates the UI status to `\"paused\"`, but does **not** cancel the in-flight API stream. The underlying agent continues streaming its response, keeping `session.isStreaming === true`.

The interactive loop's `input-controller` (`setupEditorSubmitHandler`) checks `isStreaming` on every editor submit:

```typescript
// input-controller.ts
if (host.session.isStreaming) {
    await host.session.prompt(text, { streamingBehavior: "steer" });
    return; // ← never calls onInputCallback
}
host.onInputCallback?.(text); // ← only path that unblocks getUserInput()
```

`getUserInput()` is a promise that resolves **only** via `onInputCallback`:

```typescript
async getUserInput(): Promise<string> {
    return new Promise((resolve) => {
        this.onInputCallback = (text: string) => {
            this.onInputCallback = undefined;
            resolve(text);
        };
    });
}
```

The main interactive while-loop sits blocked at `await this.getUserInput()`:

```typescript
while (true) {
    const userInput = await this.getUserInput(); // ← stuck here forever
    await this.session.prompt(userInput);
}
```

With `isStreaming === true`, every keystroke + Enter is swallowed as a steer message. `onInputCallback` is never called. `getUserInput()` never resolves. The TUI looks frozen.

This is worst-case during very long runs where the last auto-unit dispatched a prompt and the API stream has not yet completed when `pauseAuto()` fires. The race window grows with stream duration — a multi-minute browser-automation or code-generation turn makes it nearly guaranteed.

### Call chain

`pauseAuto()` is called from:
- `auto-loop.ts` — context-window threshold, budget ceiling, health-gate failure, stuck-unit recovery, post-unit pause gate
- `auto-timers.ts` — unit supervision timeout
- `auto-verification.ts` — verification gate exhausted
- `auto-direct-dispatch.ts` — direct dispatch path
- `bootstrap/agent-end-recovery.ts` — provider error (rate limit, auth, 5xx)
- `commands/handlers/auto.ts` — user ESC (`/gsd pause`)

Every trigger path is affected.

## Fix

Call `ctx.abort()` at the top of `pauseAuto()` when the agent is not idle:

```typescript
// auto.ts — pauseAuto()
if (ctx && !ctx.isIdle()) {
    ctx.abort();
}
```

`ctx.abort()` cancels the in-flight API stream, which triggers `agent_end` and clears `isStreaming`. By the time the user sees \"paused\" and types anything, the session is properly idle and `onInputCallback` fires normally.

`ctx.isIdle()` and `ctx.abort()` already exist on `ExtensionContext` — no new API surface. The `_pi` parameter was already threaded through all `pauseAuto()` call sites and remains unused (the abort goes through `ctx` as designed by the existing interface).

## Testing

- Build: ✅ `npm run build` — no TypeScript errors
- Tests: ✅ 32/32 pass, 1 skipped (requires API key)

## Reproduction (before fix)

1. Start a long auto-mode run (`/gsd auto`)
2. Wait for a unit with a long-running API stream (code gen, browser automation)
3. Press ESC while streaming is active
4. Status shows \"paused\" — attempt to type anything → TUI frozen, no input accepted
5. Must `Ctrl+C` twice or kill the process to exit

## After fix

1-3 same as above  
4. Status shows \"paused\" — stream is aborted, `isStreaming` resets to `false`  
5. Typing and Enter work immediately

## Files changed

- `src/resources/extensions/gsd/auto.ts` — 8 lines added to `pauseAuto()`