### PR TITLE
fix: resolve symlinks in doctor orphaned-worktree check

### DIFF
--- a/src/resources/extensions/gsd/doctor-checks.ts
+++ b/src/resources/extensions/gsd/doctor-checks.ts
@@ -267,15 +267,23 @@ export async function checkGitHealth(
   try {
     const wtDir = worktreesDir(basePath);
     if (existsSync(wtDir)) {
+      // Resolve symlinks and normalize separators so that symlinked .gsd
+      // paths (e.g. ~/.gsd/projects/<hash>/worktrees/…) match the paths
+      // returned by `git worktree list`.
+      const normalizePath = (p: string): string => {
+        try { p = realpathSync(p); } catch { /* path may not exist */ }
+        return p.replaceAll("\\", "/");
+      };
       const registeredPaths = new Set(
-        nativeWorktreeList(basePath).map(entry => entry.path),
+        nativeWorktreeList(basePath).map(entry => normalizePath(entry.path)),
       );
       for (const entry of readdirSync(wtDir)) {
         const fullPath = join(wtDir, entry);
         try {
           if (!statSync(fullPath).isDirectory()) continue;
         } catch { continue; }
-        if (!registeredPaths.has(fullPath)) {
+        const normalizedFullPath = normalizePath(fullPath);
+        if (!registeredPaths.has(normalizedFullPath)) {
           issues.push({
             severity: "warning",
             code: "worktree_directory_orphaned",

--- a/src/resources/extensions/gsd/tests/doctor-git.test.ts
+++ b/src/resources/extensions/gsd/tests/doctor-git.test.ts
@@ -8,7 +8,7 @@
  *   integration_branch_missing, worktree_directory_orphaned
  */
 
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync, realpathSync, readFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync, realpathSync, readFileSync, symlinkSync, renameSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { execSync } from "node:child_process";
@@ -493,6 +493,32 @@ async function main(): Promise<void> {
       const result = await runGSDDoctor(dir, { isolationMode: "none" });
       const trackedIssues = result.issues.filter(i => i.code === "tracked_runtime_files");
       assertTrue(trackedIssues.length > 0, "none-mode: tracked runtime files IS detected");
+    }
+
+    // ─── Test: Symlinked .gsd does not cause false orphan detection ────
+    if (process.platform !== "win32") {
+    console.log("\n=== worktree_directory_orphaned (symlinked .gsd not false-positive) ===");
+    {
+      const dir = createRepoWithActiveMilestone();
+      cleanups.push(dir);
+
+      // Move .gsd to an external location and replace with a symlink.
+      // This simulates the ~/.gsd/projects/<hash> layout where .gsd is a symlink.
+      const externalGsd = join(realpathSync(mkdtempSync(join(tmpdir(), "doc-git-symlink-"))), "gsd-data");
+      cleanups.push(externalGsd);
+      renameSync(join(dir, ".gsd"), externalGsd);
+      symlinkSync(externalGsd, join(dir, ".gsd"));
+
+      // Create a real registered worktree under the (now symlinked) .gsd/worktrees/
+      mkdirSync(join(dir, ".gsd", "worktrees"), { recursive: true });
+      run("git worktree add -b worktree/symlink-test .gsd/worktrees/symlink-test", dir);
+
+      const detect = await runGSDDoctor(dir);
+      const orphanDirIssues = detect.issues.filter(i => i.code === "worktree_directory_orphaned");
+      assertEq(orphanDirIssues.length, 0, "registered worktree via symlinked .gsd NOT flagged as orphaned");
+    }
+    } else {
+      console.log("\n=== worktree_directory_orphaned (symlinked .gsd — skipped on Windows) ===");
     }
 
   } finally {


### PR DESCRIPTION
## What
Resolve symlinks and normalize path separators before comparing worktree paths in the doctor orphaned-worktree check.

## Why
Closes #1715

When `.gsd` is a symlink (e.g. pointing to `~/.gsd/projects/<hash>/`), the orphaned worktree check compares two different representations of the same path:
- `fullPath` from `worktreesDir()` + directory listing: uses the symlink path
- `registeredPaths` from `nativeWorktreeList()`: uses the resolved real path

The `Set.has()` check on the raw strings always fails, so every registered worktree is flagged as orphaned and deleted. Confirmed on macOS and Windows.

## How
- Added a `normalizePath()` helper inside the check that applies `realpathSync` (with try/catch for missing paths) and normalizes backslashes to forward slashes
- Applied it to both `registeredPaths` entries and `fullPath` before comparison

## Key changes
- `src/resources/extensions/gsd/doctor-checks.ts` — symlink resolution + separator normalization in the orphaned worktree detection loop
- `src/resources/extensions/gsd/tests/doctor-git.test.ts` — new test that creates a symlinked `.gsd` directory with a registered worktree and verifies it is not falsely flagged as orphaned

## Testing
- Existing `worktree_directory_orphaned` tests continue to pass (orphan detection still works, registered worktrees still not flagged)
- New symlink test: moves `.gsd` to a temp dir, replaces with symlink, creates a real worktree, confirms doctor reports zero orphan issues
- Ran full `doctor-git.test.ts` suite: 43 passed, 2 pre-existing failures (unrelated `integration_branch_missing` tests)

## Risk
Low — the change is scoped to a single comparison block. `realpathSync` is wrapped in try/catch so non-existent paths fall through gracefully. Backslash normalization is a no-op on Unix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)