### PR TITLE
fix: validate worktree .git file and fix metrics toolCall casing

### DIFF
--- a/src/resources/extensions/gsd/metrics.ts
+++ b/src/resources/extensions/gsd/metrics.ts
@@ -164,7 +164,7 @@ export function snapshotUnitMetrics(
       // Count tool calls in this message
       if (msg.content && Array.isArray(msg.content)) {
         for (const block of msg.content) {
-          if (block.type === "tool_call") toolCalls++;
+          if (block.type === "toolCall") toolCalls++;
         }
       }
     } else if (msg.role === "user") {

--- a/src/resources/extensions/gsd/tests/auto-worktree.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-worktree.test.ts
@@ -172,6 +172,29 @@ async function main(): Promise<void> {
       teardownAutoWorktree(tempDir, "M005");
     }
 
+    // ─── #1713: stale worktree directory recovery ─────────────────────
+    console.log("\n=== #1713: stale worktree directory without .git file ===");
+    {
+      // Simulate a crash leaving a stale directory with no .git file.
+      // createAutoWorktree should detect and remove the stale directory,
+      // then successfully create a fresh worktree.
+      const { worktreePath } = await import("../worktree-manager.ts");
+      const staleDir = worktreePath(tempDir, "M010");
+      mkdirSync(staleDir, { recursive: true });
+      // Write a dummy file to prove it's not an empty directory
+      writeFileSync(join(staleDir, "orphan.txt"), "stale leftover\n");
+      assertTrue(existsSync(staleDir), "stale directory exists before recovery");
+      assertTrue(!existsSync(join(staleDir, ".git")), "stale directory has no .git file");
+
+      // createAutoWorktree should remove the stale dir and create a real worktree
+      const recoveredPath = createAutoWorktree(tempDir, "M010");
+      assertTrue(existsSync(recoveredPath), "worktree created after stale dir recovery");
+      assertTrue(existsSync(join(recoveredPath, ".git")), "recovered worktree has .git file");
+      assertTrue(!existsSync(join(recoveredPath, "orphan.txt")), "stale file removed by recovery");
+
+      teardownAutoWorktree(tempDir, "M010");
+    }
+
     // ─── #778: reconcile plan checkboxes on re-attach ─────────────────
     console.log("\n=== #778: reconcile plan checkboxes on re-attach ===");
     {

--- a/src/resources/extensions/gsd/tests/metrics.test.ts
+++ b/src/resources/extensions/gsd/tests/metrics.test.ts
@@ -334,3 +334,51 @@ test("snapshotUnitMetrics handles simulated idle-watchdog duplicate pattern", ()
     rmSync(tmpBase, { recursive: true, force: true });
   }
 });
+
+// ── toolCall block counting ─────────────────────────────────────────────────
+
+test("snapshotUnitMetrics counts toolCall blocks correctly (#1713)", () => {
+  const tmpBase = mkdtempSync(join(tmpdir(), "gsd-metrics-toolcall-"));
+  mkdirSync(join(tmpBase, ".gsd"), { recursive: true });
+
+  try {
+    resetMetrics();
+    initMetrics(tmpBase);
+
+    const ctx = mockCtx([
+      { role: "user", content: "Do something" },
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "Let me help." },
+          { type: "toolCall", name: "Read", input: { file: "foo.ts" } },
+          { type: "toolCall", name: "Edit", input: { file: "bar.ts" } },
+        ],
+        usage: {
+          input: 1000, output: 500, cacheRead: 0, cacheWrite: 0, totalTokens: 1500,
+          cost: 0.01,
+        },
+      },
+      {
+        role: "assistant",
+        content: [
+          { type: "toolCall", name: "Bash", input: { command: "ls" } },
+          { type: "text", text: "All done." },
+        ],
+        usage: {
+          input: 800, output: 300, cacheRead: 0, cacheWrite: 0, totalTokens: 1100,
+          cost: 0.008,
+        },
+      },
+    ]);
+
+    const unit = snapshotUnitMetrics(ctx, "execute-task", "M001/S01/T01", Date.now() - 3000, "test-model");
+    assert.ok(unit);
+    assert.equal(unit!.toolCalls, 3, "should count 3 toolCall blocks across 2 assistant messages");
+    assert.equal(unit!.assistantMessages, 2);
+    assert.equal(unit!.userMessages, 1);
+  } finally {
+    resetMetrics();
+    rmSync(tmpBase, { recursive: true, force: true });
+  }
+});

--- a/src/resources/extensions/gsd/worktree-manager.ts
+++ b/src/resources/extensions/gsd/worktree-manager.ts
@@ -15,7 +15,7 @@
  *   4. remove()  — git worktree remove + branch cleanup
  */
 
-import { existsSync, mkdirSync, readFileSync, realpathSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, realpathSync, rmSync } from "node:fs";
 import { join, resolve, sep } from "node:path";
 import { GSDError, GSD_PARSE_ERROR, GSD_STALE_STATE, GSD_LOCK_HELD, GSD_GIT_ERROR, GSD_MERGE_CONFLICT } from "./errors.js";
 import {
@@ -129,7 +129,19 @@ export function createWorktree(basePath: string, name: string, opts: { branch?: 
   const branch = opts.branch ?? worktreeBranchName(name);
 
   if (existsSync(wtPath)) {
-    throw new GSDError(GSD_STALE_STATE, `Worktree "${name}" already exists at ${wtPath}`);
+    // A valid git worktree has a .git file (not directory) containing a
+    // "gitdir:" pointer.  If the directory exists but has no .git file,
+    // it is a stale leftover from a prior crash — remove it so a fresh
+    // worktree can be created in its place.
+    const gitFilePath = join(wtPath, ".git");
+    if (!existsSync(gitFilePath)) {
+      console.error(
+        `[GSD] Removing stale worktree directory (no .git file): ${wtPath}`,
+      );
+      rmSync(wtPath, { recursive: true, force: true });
+    } else {
+      throw new GSDError(GSD_STALE_STATE, `Worktree "${name}" already exists at ${wtPath}`);
+    }
   }
 
   // Ensure the .gsd/worktrees/ directory exists


### PR DESCRIPTION
## What
Two bug fixes that together prevent a critical silent failure mode where agents work in empty stale directories and report false success.

## Why
Closes #1713

When a prior crash leaves a stale `.gsd/worktrees/<MID>/` directory without a `.git` file, the next run's `createWorktree` throws a `GSD_STALE_STATE` error. Agents get directed to the empty stale directory, write code that doesn't exist in the project root, claim BUILD SUCCEEDED, and the milestone appears complete with zero real code.

A secondary bug in `metrics.ts` masks the problem: `block.type === "tool_call"` (snake_case) never matches because the SDK emits `"toolCall"` (camelCase), so `toolCalls` is always 0 in the metrics ledger. This makes it impossible to spot the anomaly (a "successful" unit with 0 tool calls).

## How
1. **worktree-manager.ts**: In `createWorktree`, when the worktree directory already exists, check for a `.git` file. If absent, log a warning and `rmSync` the stale directory before proceeding with fresh worktree creation. If `.git` exists, throw the existing `GSD_STALE_STATE` error as before.

2. **metrics.ts**: Change `block.type === "tool_call"` to `block.type === "toolCall"` to match the SDK's actual content block type.

## Key changes
- `src/resources/extensions/gsd/worktree-manager.ts` — stale directory detection + removal before `git worktree add`
- `src/resources/extensions/gsd/metrics.ts` — fix camelCase block type comparison (line 167)
- `src/resources/extensions/gsd/tests/auto-worktree.test.ts` — test for stale worktree recovery
- `src/resources/extensions/gsd/tests/metrics.test.ts` — test for toolCall block counting

## Testing
- [x] Added test in `auto-worktree.test.ts`: creates stale directory without `.git`, verifies `createAutoWorktree` recovers and creates valid worktree
- [x] Added test in `metrics.test.ts`: verifies `snapshotUnitMetrics` correctly counts `toolCall` blocks across multiple assistant messages
- [x] All existing tests continue to pass
- [x] Grepped for other `"tool_call"` block.type comparisons — none found

## Risk
Low. The worktree fix only triggers when a directory exists without a `.git` file (crash recovery path). The metrics fix is a string literal correction with no behavioral side effects beyond accurate counting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)