### PR TITLE
fix: handle symlinked .gsd in git add pathspec exclusions

### DIFF
--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -151,6 +151,7 @@ export async function postUnitPreVerification(pctx: PostUnitContext, opts?: PreV
       }
     } catch (e) {
       debugLog("postUnit", { phase: "auto-commit", error: String(e) });
+      ctx.ui.notify(`Auto-commit failed: ${String(e).split("\n")[0]}`, "warning");
     }
 
     // GitHub sync (non-blocking, opt-in)

--- a/src/resources/extensions/gsd/auto-worktree.ts
+++ b/src/resources/extensions/gsd/auto-worktree.ts
@@ -38,6 +38,7 @@ import {
   nudgeGitBranchCache,
 } from "./worktree.js";
 import { MergeConflictError, readIntegrationBranch, RUNTIME_EXCLUSION_PATHS } from "./git-service.js";
+import { debugLog } from "./debug-logger.js";
 import { parseRoadmap } from "./files.js";
 import { loadEffectiveGSDPreferences } from "./preferences.js";
 import {
@@ -800,7 +801,8 @@ function autoCommitDirtyState(cwd: string): boolean {
       "chore: auto-commit before milestone merge",
     );
     return result !== null;
-  } catch {
+  } catch (e) {
+    debugLog("autoCommitDirtyState", { error: String(e) });
     return false;
   }
 }

--- a/src/resources/extensions/gsd/native-git-bridge.ts
+++ b/src/resources/extensions/gsd/native-git-bridge.ts
@@ -698,10 +698,17 @@ export function nativeAddAllWithExclusions(basePath: string, exclusions: readonl
       env: GIT_NO_PROMPT_ENV,
     });
   } catch (err: unknown) {
+    const stderr = (err as { stderr?: string })?.stderr ?? "";
     // git exits 1 when pathspec exclusions reference paths already covered
     // by .gitignore. The staging itself succeeds — only suppress that case.
-    const stderr = (err as { stderr?: string })?.stderr ?? "";
     if (stderr.includes("ignored by one of your .gitignore files")) {
+      return;
+    }
+    // When .gsd is a symlink, git rejects `:!.gsd/...` pathspecs with
+    // "beyond a symbolic link". Fall back to plain `git add -A` which
+    // respects .gitignore (where .gsd/ is listed by default).
+    if (stderr.includes("beyond a symbolic link")) {
+      nativeAddAll(basePath);
       return;
     }
     throw new GSDError(GSD_GIT_ERROR, `git add -A with exclusions failed in ${basePath}: ${getErrorMessage(err)}`);

--- a/src/resources/extensions/gsd/tests/git-service.test.ts
+++ b/src/resources/extensions/gsd/tests/git-service.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync } from "node:fs";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync, symlinkSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { tmpdir } from "node:os";
 import { execSync } from "node:child_process";
@@ -18,6 +18,7 @@ import {
   type PreMergeCheckResult,
   type TaskCommitContext,
 } from "../git-service.ts";
+import { nativeAddAllWithExclusions } from "../native-git-bridge.ts";
 import { createTestContext } from './test-helpers.ts';
 
 const { assertEq, assertTrue, report } = createTestContext();
@@ -1228,6 +1229,76 @@ async function main(): Promise<void> {
     // Idempotent — calling again doesn't add duplicates
     const modified2 = ensureGitignore(repo);
     assertTrue(!modified2, "ensureGitignore: second call is idempotent");
+
+    rmSync(repo, { recursive: true, force: true });
+  }
+
+  // ─── nativeAddAllWithExclusions: symlinked .gsd fallback ───────────────
+
+  console.log("\n=== nativeAddAllWithExclusions: symlinked .gsd fallback ===");
+
+  {
+    // When .gsd is a symlink, git rejects `:!.gsd/...` pathspecs with
+    // "fatal: pathspec '...' is beyond a symbolic link". The fix falls
+    // back to plain `git add -A`, which respects .gitignore.
+    const repo = initTempRepo();
+
+    // Create the real .gsd directory outside the repo, then symlink it
+    const externalGsd = mkdtempSync(join(tmpdir(), "gsd-external-"));
+    mkdirSync(join(externalGsd, "activity"), { recursive: true });
+    writeFileSync(join(externalGsd, "activity", "log.jsonl"), "log data");
+    writeFileSync(join(externalGsd, "STATE.md"), "# State");
+
+    // Symlink .gsd -> external directory
+    symlinkSync(externalGsd, join(repo, ".gsd"));
+
+    // Add .gitignore so git add -A fallback skips .gsd/
+    writeFileSync(join(repo, ".gitignore"), ".gsd\n");
+
+    // Create a real file that should be staged
+    createFile(repo, "src/app.ts", "export const x = 1;");
+
+    // nativeAddAllWithExclusions should NOT throw despite .gsd being a symlink
+    let threw = false;
+    try {
+      nativeAddAllWithExclusions(repo, RUNTIME_EXCLUSION_PATHS);
+    } catch (e) {
+      threw = true;
+      console.error("  unexpected error:", e);
+    }
+    assertTrue(!threw, "nativeAddAllWithExclusions does not throw with symlinked .gsd");
+
+    // Verify the real file was staged
+    const staged = run("git diff --cached --name-only", repo);
+    assertTrue(staged.includes("src/app.ts"), "real file staged despite symlinked .gsd");
+    assertTrue(!staged.includes(".gsd"), ".gsd content not staged");
+
+    rmSync(repo, { recursive: true, force: true });
+    rmSync(externalGsd, { recursive: true, force: true });
+  }
+
+  // ─── nativeAddAllWithExclusions: non-symlinked .gsd still works ───────
+
+  console.log("\n=== nativeAddAllWithExclusions: non-symlinked .gsd still works ===");
+
+  {
+    // Verify the normal (non-symlink) case still works with pathspec exclusions
+    const repo = initTempRepo();
+
+    createFile(repo, ".gsd/activity/log.jsonl", "log data");
+    createFile(repo, ".gsd/STATE.md", "# State");
+    createFile(repo, "src/code.ts", "export const y = 2;");
+
+    let threw = false;
+    try {
+      nativeAddAllWithExclusions(repo, RUNTIME_EXCLUSION_PATHS);
+    } catch {
+      threw = true;
+    }
+    assertTrue(!threw, "nativeAddAllWithExclusions works with normal .gsd directory");
+
+    const staged = run("git diff --cached --name-only", repo);
+    assertTrue(staged.includes("src/code.ts"), "real file staged with normal .gsd");
 
     rmSync(repo, { recursive: true, force: true });
   }


### PR DESCRIPTION
## What
Handle `git add` "beyond a symbolic link" errors when `.gsd` is a symlink, and surface auto-commit failures to the user.

## Why
Closes #1712

When `.gsd` is a symlink (e.g. pointing to an external state directory), `git add -A -- :!.gsd/activity/ :!.gsd/runtime/ ...` fails with `fatal: pathspec '...' is beyond a symbolic link`. The pathspec exclusions in `nativeAddAllWithExclusions()` trigger this git limitation. Post-unit auto-commit failures were only debug-logged, silently losing committed work.

## How
- In `nativeAddAllWithExclusions`, catch the "beyond a symbolic link" stderr message and fall back to plain `git add -A`, which respects `.gitignore` (where `.gsd/` is listed by default)
- Elevate auto-commit failure in `postUnitPreVerification` from `debugLog` to `ctx.ui.notify(..., "warning")` so users see when commits fail
- Add `debugLog` to `autoCommitDirtyState` in `auto-worktree.ts` which previously had a bare `catch {}`

## Key changes
- `native-git-bridge.ts`: symlink-aware fallback in `nativeAddAllWithExclusions`
- `auto-post-unit.ts`: warning notification on auto-commit failure
- `auto-worktree.ts`: debug logging for `autoCommitDirtyState` errors
- `tests/git-service.test.ts`: two new tests (symlinked and non-symlinked `.gsd` scenarios)

## Testing
- Added test that creates a repo with a symlinked `.gsd` directory and verifies `nativeAddAllWithExclusions` succeeds via fallback
- Added test that verifies normal (non-symlink) `.gsd` still works with pathspec exclusions
- All 160 tests pass (including 2 new)

## Risk
Low. The symlink fallback only activates on the specific "beyond a symbolic link" error. Normal non-symlink repos are unaffected. The fallback to `git add -A` is safe because `.gsd/` is already in `.gitignore` by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)