### PR TITLE
fix: preserve milestone branch on merge-back during transitions

### DIFF
--- a/src/resources/extensions/gsd/tests/milestone-transition-worktree.test.ts
+++ b/src/resources/extensions/gsd/tests/milestone-transition-worktree.test.ts
@@ -142,3 +142,25 @@ test("auto/phases.ts milestone transition block contains worktree lifecycle", ()
     "auto/phases.ts should call resolver.enterMilestone for incoming milestone",
   );
 });
+
+// ─── Verify worktree-resolver mergeAndExit preserves branch on missing roadmap (#1573) ──
+
+test("worktree-resolver mergeAndExit preserves branch when roadmap is missing (#1573)", () => {
+  const resolverSrc = readFileSync(
+    join(__dirname, "..", "worktree-resolver.ts"),
+    "utf-8",
+  );
+
+  // The fallback teardown must pass preserveBranch: true to prevent orphaning commits
+  assert.ok(
+    resolverSrc.includes("preserveBranch: true"),
+    "worktree-resolver.ts should pass preserveBranch: true in the no-roadmap fallback",
+  );
+
+  // The worktree path should be tried as a fallback for roadmap resolution
+  assert.ok(
+    resolverSrc.includes("this.s.basePath !== originalBase") ||
+      resolverSrc.includes("roadmap-fallback"),
+    "worktree-resolver.ts should try resolving roadmap from worktree path as fallback",
+  );
+});

--- a/src/resources/extensions/gsd/tests/worktree-resolver.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-resolver.test.ts
@@ -434,7 +434,7 @@ test("mergeAndExit in worktree mode shows pushed status", () => {
   assert.ok(ctx.messages.some((m) => m.msg.includes("Pushed to remote")));
 });
 
-test("mergeAndExit falls back to teardown when roadmap is missing", () => {
+test("mergeAndExit falls back to teardown with preserveBranch when roadmap is missing (#1573)", () => {
   const s = makeSession({
     basePath: "/project/.gsd/worktrees/M001",
     originalBasePath: "/project",
@@ -449,10 +449,42 @@ test("mergeAndExit falls back to teardown when roadmap is missing", () => {
 
   resolver.mergeAndExit("M001", ctx);
 
-  assert.equal(findCalls(deps.calls, "teardownAutoWorktree").length, 1);
+  const teardownCalls = findCalls(deps.calls, "teardownAutoWorktree");
+  assert.equal(teardownCalls.length, 1);
+  // Branch must be preserved so commits are not orphaned (#1573)
+  assert.deepEqual(teardownCalls[0].args[2], { preserveBranch: true });
   assert.equal(findCalls(deps.calls, "mergeMilestoneToMain").length, 0);
   assert.equal(s.basePath, "/project"); // restored
-  assert.ok(ctx.messages.some((m) => m.msg.includes("no roadmap for merge")));
+  assert.ok(ctx.messages.some((m) => m.msg.includes("branch preserved")));
+});
+
+test("mergeAndExit resolves roadmap from worktree when missing at project root (#1573)", () => {
+  const s = makeSession({
+    basePath: "/project/.gsd/worktrees/M001",
+    originalBasePath: "/project",
+  });
+  // resolveMilestoneFile returns null for project root, returns path for worktree
+  const deps = makeDeps({
+    isInAutoWorktree: () => true,
+    getIsolationMode: () => "worktree",
+    resolveMilestoneFile: (basePath: string) => {
+      if (basePath === "/project") return null; // missing at project root
+      if (basePath === "/project/.gsd/worktrees/M001") {
+        return "/project/.gsd/worktrees/M001/.gsd/milestones/M001/M001-ROADMAP.md";
+      }
+      return null;
+    },
+  });
+  const ctx = makeNotifyCtx();
+  const resolver = new WorktreeResolver(s, deps);
+
+  resolver.mergeAndExit("M001", ctx);
+
+  // Should have called mergeMilestoneToMain, not bare teardown
+  assert.equal(findCalls(deps.calls, "mergeMilestoneToMain").length, 1);
+  assert.equal(findCalls(deps.calls, "teardownAutoWorktree").length, 0);
+  assert.equal(s.basePath, "/project"); // restored
+  assert.ok(ctx.messages.some((m) => m.msg.includes("merged to main")));
 });
 
 test("mergeAndExit in worktree mode restores to project root on merge failure", () => {

--- a/src/resources/extensions/gsd/worktree-resolver.ts
+++ b/src/resources/extensions/gsd/worktree-resolver.ts
@@ -338,11 +338,31 @@ export class WorktreeResolver {
         });
       }
 
-      const roadmapPath = this.deps.resolveMilestoneFile(
+      // Resolve roadmap — try project root first, then worktree path as fallback.
+      // The worktree may hold the only copy when syncWorktreeStateBack fails
+      // silently or .gsd/ is not symlinked. Without the fallback, a missing
+      // roadmap triggers bare teardown which deletes the branch and orphans all
+      // milestone commits (#1573).
+      let roadmapPath = this.deps.resolveMilestoneFile(
         originalBase,
         milestoneId,
         "ROADMAP",
       );
+      if (!roadmapPath && this.s.basePath !== originalBase) {
+        roadmapPath = this.deps.resolveMilestoneFile(
+          this.s.basePath,
+          milestoneId,
+          "ROADMAP",
+        );
+        if (roadmapPath) {
+          debugLog("WorktreeResolver", {
+            action: "mergeAndExit",
+            milestoneId,
+            phase: "roadmap-fallback",
+            note: "resolved from worktree path",
+          });
+        }
+      }
 
       if (roadmapPath) {
         const roadmapContent = this.deps.readFileSync(roadmapPath, "utf-8");
@@ -356,11 +376,14 @@ export class WorktreeResolver {
           "info",
         );
       } else {
-        // No roadmap — fall back to bare teardown
-        this.deps.teardownAutoWorktree(originalBase, milestoneId);
+        // No roadmap at either location — teardown but PRESERVE the branch so
+        // commits are not orphaned. The user can merge manually later (#1573).
+        this.deps.teardownAutoWorktree(originalBase, milestoneId, {
+          preserveBranch: true,
+        });
         ctx.notify(
-          `Exited worktree for ${milestoneId} (no roadmap for merge).`,
-          "info",
+          `Exited worktree for ${milestoneId} (no roadmap found — branch preserved for manual merge).`,
+          "warning",
         );
       }
     } catch (err) {


### PR DESCRIPTION
## What
Fixes the merge-back-to-main step in `WorktreeResolver._mergeWorktreeMode` to try the worktree path as a fallback when the roadmap is missing at the project root, and to preserve the milestone branch when no roadmap is found at either location.

## Why
Closes #1573

When auto-mode completes a milestone in worktree isolation mode, `mergeAndExit` resolves the roadmap only from the project root. If `syncWorktreeStateBack` fails silently or `.gsd/` is not symlinked, the roadmap is missing at the project root, triggering a bare `teardownAutoWorktree` call without `preserveBranch`. This deletes the milestone branch and orphans all commits — they become recoverable only via `git fsck --unreachable`.

## How
Two changes in `WorktreeResolver._mergeWorktreeMode` (`worktree-resolver.ts`):

1. **Roadmap fallback to worktree path**: When `resolveMilestoneFile` returns null for the project root, try resolving from `this.s.basePath` (the worktree) before giving up. This handles the case where the roadmap only exists in the worktree.

2. **Preserve branch on teardown**: When no roadmap is found at either location, pass `{ preserveBranch: true }` to `teardownAutoWorktree` and emit a warning notification. The branch survives worktree pruning, allowing manual merge recovery.

## Key changes
- `src/resources/extensions/gsd/worktree-resolver.ts` — Added worktree-path fallback for roadmap resolution; changed bare teardown to preserve the branch
- `src/resources/extensions/gsd/tests/worktree-resolver.test.ts` — Updated existing no-roadmap test to verify `preserveBranch: true`; added new test for worktree-path roadmap fallback
- `src/resources/extensions/gsd/tests/milestone-transition-worktree.test.ts` — Added source-level verification that the resolver uses `preserveBranch` and worktree fallback

## Testing
- `npx vitest run src/resources/extensions/gsd/tests/worktree-resolver.test.ts` — 30/30 pass (includes 2 new tests for #1573)
- `npx vitest run src/resources/extensions/gsd/tests/milestone-transition-worktree.test.ts` — 3/3 pass (includes 1 new test for #1573)
- `npx vitest run src/resources/extensions/gsd/tests/all-milestones-complete-merge.test.ts` — 3/3 pass (unchanged, regression check)

## Risk
Low. The change is additive — the happy path (roadmap found at project root) is unchanged. The two new behaviors only activate when the roadmap is missing, which previously led to data loss. No changes to `phases.ts` or the auto-loop flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)