### PR TITLE
fix: lazy-load @gsd/pi-tui in shared/ui.ts to prevent /exit crash

### DIFF
--- a/src/resources/extensions/gsd/tests/lazy-pi-tui-import.test.ts
+++ b/src/resources/extensions/gsd/tests/lazy-pi-tui-import.test.ts
@@ -1,0 +1,46 @@
+// Verifies that shared/ui.ts does NOT eagerly import @gsd/pi-tui at the
+// module level.  An eager top-level import causes /exit (and any other
+// command that transitively loads shared/mod → shared/ui) to blow up when
+// @gsd/pi-tui cannot be resolved — e.g. extensions copied to
+// ~/.gsd/agent/extensions/ where no node_modules tree exists.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const uiSrc = readFileSync(join(__dirname, "../../shared/ui.ts"), "utf-8");
+
+test("shared/ui.ts has no top-level import from @gsd/pi-tui", () => {
+  // Match lines like: import { ... } from "@gsd/pi-tui";
+  // But ignore type-only imports (import type / import("@gsd/pi-tui").X)
+  // and comments.
+  const lines = uiSrc.split("\n");
+  for (const line of lines) {
+    const trimmed = line.trim();
+    // Skip comments and type-only references
+    if (trimmed.startsWith("//") || trimmed.startsWith("*") || trimmed.startsWith("/*")) continue;
+    // Skip type-only import statements
+    if (trimmed.startsWith("import type ")) continue;
+    // Skip inline import() type annotations (erased at runtime)
+    if (/import\(["']@gsd\/pi-tui["']\)/.test(trimmed) && !trimmed.startsWith("import ")) continue;
+
+    // Flag any eager import statement pulling runtime values from @gsd/pi-tui
+    if (/^\s*import\s+\{/.test(line) && line.includes("@gsd/pi-tui")) {
+      assert.fail(
+        `Found eager top-level import from @gsd/pi-tui — this must be lazy.\n` +
+          `Line: ${trimmed}`,
+      );
+    }
+  }
+});
+
+test("shared/ui.ts lazily resolves @gsd/pi-tui inside makeUI", () => {
+  // The lazy accessor pattern: require("@gsd/pi-tui") inside a function body
+  assert.ok(
+    uiSrc.includes('require("@gsd/pi-tui")'),
+    "Expected a lazy require(\"@gsd/pi-tui\") call inside a function body",
+  );
+});

--- a/src/resources/extensions/shared/ui.ts
+++ b/src/resources/extensions/shared/ui.ts
@@ -29,7 +29,21 @@
  */
 
 import { type Theme } from "@gsd/pi-coding-agent";
-import { truncateToWidth, visibleWidth, wrapTextWithAnsi } from "@gsd/pi-tui";
+
+// ─── Lazy @gsd/pi-tui resolution ─────────────────────────────────────────────
+// Deferred to first makeUI() call so that importing this module (via the
+// shared/mod barrel) does not blow up when @gsd/pi-tui cannot be resolved —
+// e.g. for commands like /exit that never render TUI components.
+
+type PiTuiFns = typeof import("@gsd/pi-tui");
+let _piTui: PiTuiFns | undefined;
+function piTui(): PiTuiFns {
+	if (!_piTui) {
+		// eslint-disable-next-line @typescript-eslint/no-require-imports
+		_piTui = require("@gsd/pi-tui") as PiTuiFns;
+	}
+	return _piTui;
+}
 
 // ─── Glyphs ───────────────────────────────────────────────────────────────────
 // Change these to restyle every cursor, checkbox, and indicator at once.
@@ -200,6 +214,8 @@ export interface UI {
  */
 export function makeUI(theme: Theme, width: number): UI {
 	// ── Internal helpers ───────────────────────────────────────────────────────
+
+	const { truncateToWidth, visibleWidth, wrapTextWithAnsi } = piTui();
 
 	const add = (s: string): string => truncateToWidth(s, width);
 	const wrap = (s: string): string[] => wrapTextWithAnsi(s, width);


### PR DESCRIPTION
## What
Replace the eager top-level `import { truncateToWidth, visibleWidth, wrapTextWithAnsi } from "@gsd/pi-tui"` in `shared/ui.ts` with a lazy `require()` accessor that defers resolution to the first `makeUI()` call.

## Why
Closes #1640

Extensions copied to `~/.gsd/agent/extensions/` have no `node_modules` resolution path for `@gsd/pi-tui`. The `/exit` command (and any other command that transitively loads the `shared/mod` barrel) would crash at module load time because `shared/ui.ts` eagerly imported `@gsd/pi-tui` at the module level. This broke `/exit` even though it never uses TUI rendering.

## How
- Removed the static top-level import of runtime values from `@gsd/pi-tui`
- Added a lazy `piTui()` accessor that calls `require("@gsd/pi-tui")` on first invocation and caches the result
- Destructured the needed functions (`truncateToWidth`, `visibleWidth`, `wrapTextWithAnsi`) at the top of `makeUI()` instead of at module scope
- Type-only references (`import("@gsd/pi-tui").EditorTheme`) are unaffected since they're erased at compile time

## Key changes
- `src/resources/extensions/shared/ui.ts` — lazy `require()` pattern replaces eager import
- `src/resources/extensions/gsd/tests/lazy-pi-tui-import.test.ts` — source-level regression tests

## Testing
- Two new tests verify: (1) no eager top-level import of `@gsd/pi-tui` exists, (2) the lazy `require()` pattern is present
- Existing exit-command test continues to pass (when build artifacts are available)

## Risk
Low. The only behavioral change is *when* `@gsd/pi-tui` is resolved — deferred from module load to first `makeUI()` call. All consumers of `makeUI()` run in TUI contexts where `@gsd/pi-tui` is guaranteed to be resolvable via jiti's virtualModules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)