### PR TITLE
fix: self-heal orphaned runtime records on auto-loop startup

### DIFF
--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -115,6 +115,7 @@ import {
   formatHealthSummary,
   getConsecutiveErrorUnits,
 } from "./doctor-proactive.js";
+import { selfHealRuntimeRecords } from "./auto-recovery.js";
 import { clearSkillSnapshot } from "./skill-discovery.js";
 import {
   captureAvailableSkills,
@@ -1052,6 +1053,9 @@ export async function startAuto(
     );
     logCmuxEvent(loadEffectiveGSDPreferences()?.preferences, s.stepMode ? "Step-mode resumed." : "Auto-mode resumed.", "progress");
 
+    // Clear orphaned runtime records from prior process deaths before entering the loop
+    await selfHealRuntimeRecords(s.basePath, ctx);
+
     await autoLoop(ctx, pi, s, buildLoopDeps());
     return;
   }
@@ -1081,6 +1085,9 @@ export async function startAuto(
     // Best-effort only — sidebar sync must never block auto-mode startup
   }
   logCmuxEvent(loadEffectiveGSDPreferences()?.preferences, requestedStepMode ? "Step-mode started." : "Auto-mode started.", "progress");
+
+  // Clear orphaned runtime records from prior process deaths before entering the loop
+  await selfHealRuntimeRecords(s.basePath, ctx);
 
   // Dispatch the first unit
   await autoLoop(ctx, pi, s, buildLoopDeps());

--- a/src/resources/extensions/gsd/tests/auto-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-loop.test.ts
@@ -1098,6 +1098,32 @@ test("auto.ts startAuto calls autoLoop (not dispatchNextUnit as first dispatch)"
   );
 });
 
+test("startAuto calls selfHealRuntimeRecords before autoLoop (#1727)", () => {
+  const src = readFileSync(
+    resolve(import.meta.dirname, "..", "auto.ts"),
+    "utf-8",
+  );
+  const fnIdx = src.indexOf("export async function startAuto");
+  assert.ok(fnIdx > -1, "startAuto must exist in auto.ts");
+  const fnEnd = src.indexOf("\n// ─── ", fnIdx + 100);
+  const fnBlock =
+    fnEnd > -1 ? src.slice(fnIdx, fnEnd) : src.slice(fnIdx, fnIdx + 5000);
+
+  // Both autoLoop call sites must be preceded by selfHealRuntimeRecords
+  const healIdx = fnBlock.indexOf("selfHealRuntimeRecords");
+  const loopIdx = fnBlock.indexOf("autoLoop(");
+  assert.ok(healIdx > -1, "startAuto must call selfHealRuntimeRecords");
+  assert.ok(healIdx < loopIdx, "selfHealRuntimeRecords must be called before autoLoop");
+
+  // Verify the second autoLoop call site also has selfHeal before it
+  const secondLoopIdx = fnBlock.indexOf("autoLoop(", loopIdx + 1);
+  if (secondLoopIdx > -1) {
+    const secondHealIdx = fnBlock.indexOf("selfHealRuntimeRecords", healIdx + 1);
+    assert.ok(secondHealIdx > -1, "second autoLoop call must also have selfHealRuntimeRecords");
+    assert.ok(secondHealIdx < secondLoopIdx, "second selfHealRuntimeRecords must precede second autoLoop");
+  }
+});
+
 test("agent_end handler calls resolveAgentEnd (not handleAgentEnd)", () => {
   const hooksSrc = readFileSync(
     resolve(import.meta.dirname, "..", "bootstrap", "register-hooks.ts"),


### PR DESCRIPTION
## What
Call `selfHealRuntimeRecords(basePath, ctx)` before both `autoLoop()` call sites in `startAuto()` to clear orphaned dispatched runtime records on every auto-mode entry.

## Why
When the auto-mode process dies after a subagent completes but before `agent_end` is processed, the runtime record stays permanently at `"phase": "dispatched"`. No crash lock is written (that happens earlier in the lifecycle), and `selfHealRuntimeRecords()` was only called from `guided-flow.ts` (the manual wizard), never from auto-loop startup. The orphaned record blocks the dispatch loop forever with no recovery.

## How
- Import `selfHealRuntimeRecords` from `auto-recovery.ts` into `auto.ts`
- Add `await selfHealRuntimeRecords(s.basePath, ctx)` before the `autoLoop()` call on the **resume path** (~line 1057)
- Add the same call before the `autoLoop()` call on the **fresh-start path** (~line 1091)
- The function already handles its own error boundaries and only clears records older than 1 hour, so it is safe to call unconditionally

## Key changes
- `src/resources/extensions/gsd/auto.ts` — import + two `selfHealRuntimeRecords()` calls
- `src/resources/extensions/gsd/tests/auto-loop.test.ts` — source-inspection test verifying selfHeal precedes autoLoop at both call sites

## Testing
- All 45 `auto-loop.test.ts` tests pass (including the new structural assertion)
- All 27 `auto-recovery.test.ts` tests pass
- TypeScript compiles clean (no new errors)

## Risk
Low. `selfHealRuntimeRecords` is an existing, well-tested function with its own try/catch. It only clears records older than 1 hour, so it cannot interfere with an actively running dispatch.

Closes #1727

🤖 Generated with [Claude Code](https://claude.com/claude-code)