### PR TITLE
fix: closeout unit on pause and heal runtime records on resume

### DIFF
--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -85,6 +85,7 @@ import {
 } from "./auto-observability.js";
 import { closeoutUnit } from "./auto-unit-closeout.js";
 import { recoverTimedOutUnit } from "./auto-timeout-recovery.js";
+import { selfHealRuntimeRecords } from "./auto-recovery.js";
 import { selectAndApplyModel } from "./auto-model-selection.js";
 import {
   syncProjectRootToWorktree,
@@ -742,6 +743,21 @@ export async function pauseAuto(
     // Non-fatal — resume will still work via full bootstrap, just without worktree context
   }
 
+  // Close out the current unit so its runtime record doesn't stay at "dispatched"
+  if (s.currentUnit && ctx) {
+    try {
+      await closeoutUnit(ctx, s.basePath, s.currentUnit.type, s.currentUnit.id, s.currentUnit.startedAt);
+    } catch {
+      // Non-fatal — best-effort closeout on pause
+    }
+    try {
+      clearUnitRuntimeRecord(s.basePath, s.currentUnit.type, s.currentUnit.id);
+    } catch {
+      // Non-fatal
+    }
+    s.currentUnit = null;
+  }
+
   if (lockBase()) {
     releaseSessionLock(lockBase());
     clearLock(lockBase());
@@ -1018,6 +1034,15 @@ export async function startAuto(
       });
     }
     invalidateAllCaches();
+
+    // Clean stale runtime records left from the paused session
+    try {
+      await selfHealRuntimeRecords(s.basePath, ctx);
+    } catch (e) {
+      debugLog("resume-self-heal-runtime-failed", {
+        error: e instanceof Error ? e.message : String(e),
+      });
+    }
 
     if (s.pausedSessionFile) {
       const activityDir = join(gsdRoot(s.basePath), "activity");

--- a/src/resources/extensions/gsd/tests/auto-recovery.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-recovery.test.ts
@@ -434,6 +434,39 @@ test("selfHealRuntimeRecords clears stale dispatched records (#769)", async () =
   }
 });
 
+// ─── #1625: selfHealRuntimeRecords on resume clears paused-session leftovers ──
+
+test("selfHealRuntimeRecords clears recently-paused dispatched records on resume (#1625)", async () => {
+  // When pauseAuto closes out a unit but clearUnitRuntimeRecord silently fails
+  // (e.g. permission error), selfHealRuntimeRecords on resume should still
+  // clean up stale dispatched records that are >1h old.
+  const base = makeTmpBase();
+  try {
+    const { writeUnitRuntimeRecord, readUnitRuntimeRecord } = await import("../unit-runtime.ts");
+
+    // Simulate a record left behind after a pause — aged >1h to be considered stale
+    writeUnitRuntimeRecord(base, "execute-task", "M001/S01/T01", Date.now() - 3700_000, {
+      phase: "dispatched",
+    });
+
+    const before = readUnitRuntimeRecord(base, "execute-task", "M001/S01/T01");
+    assert.ok(before, "dispatched record should exist before resume heal");
+    assert.equal(before!.phase, "dispatched");
+
+    const notifications: string[] = [];
+    const mockCtx = {
+      ui: { notify: (msg: string) => { notifications.push(msg); } },
+    } as any;
+
+    await selfHealRuntimeRecords(base, mockCtx);
+
+    const after = readUnitRuntimeRecord(base, "execute-task", "M001/S01/T01");
+    assert.equal(after, null, "stale dispatched record should be cleared on resume (#1625)");
+  } finally {
+    cleanup(base);
+  }
+});
+
 // ─── #793: invalidateAllCaches unblocks skip-loop ─────────────────────────
 // When the skip-loop breaker fires, it must call invalidateAllCaches() (not
 // just invalidateStateCache()) to clear path/parse caches that deriveState


### PR DESCRIPTION
## What
Ensure `pauseAuto()` properly closes out the current unit and clears its runtime record, and that same-session `/gsd auto` resume works by healing stale runtime records.

## Why
After a plan-slice completes and auto-mode pauses, the unit runtime record stays at `phase: "dispatched"` with no closeout. Typing `/gsd auto` in the same paused TUI session does nothing because stale runtime records confuse the dispatch loop. Users must open a new terminal to continue.

## How
1. **pauseAuto** — if `s.currentUnit` exists, call `closeoutUnit()` to snapshot metrics and save the activity log, then `clearUnitRuntimeRecord()` to remove the on-disk record, before setting `s.active = false`
2. **Resume path in startAuto** — call `selfHealRuntimeRecords()` before entering `autoLoop` to clean any stale dispatched records that survived from prior sessions (e.g. if `clearUnitRuntimeRecord` failed silently during pause)

## Key changes
- `src/resources/extensions/gsd/auto.ts` — `pauseAuto`: added closeoutUnit + clearUnitRuntimeRecord for current unit
- `src/resources/extensions/gsd/auto.ts` — resume path: added selfHealRuntimeRecords call
- `src/resources/extensions/gsd/tests/auto-recovery.test.ts` — added test for resume-path stale record cleanup

## Testing
- All 28 auto-recovery tests pass
- New test verifies selfHealRuntimeRecords clears stale dispatched records on resume

## Risk
Low. Both closeout and self-heal are wrapped in try/catch (non-fatal). Existing closeoutUnit and selfHealRuntimeRecords are battle-tested functions used elsewhere in the codebase.

Closes #1625

🤖 Generated with [Claude Code](https://claude.com/claude-code)