### PR TITLE
fix: dashboard highlights UAT target slice instead of advanced activeSlice

### DIFF
--- a/src/resources/extensions/gsd/auto-dashboard.ts
+++ b/src/resources/extensions/gsd/auto-dashboard.ts
@@ -24,6 +24,18 @@ import { computeProgressScore } from "./progress-score.js";
 import { getActiveWorktreeName } from "./worktree-command.js";
 import { loadEffectiveGSDPreferences, getGlobalGSDPreferencesPath } from "./preferences.js";
 
+// ─── UAT Slice Extraction ─────────────────────────────────────────────────────
+
+/**
+ * Extract the target slice ID from a run-uat unit ID (e.g. "M001/S01" → "S01").
+ * Returns null if the format doesn't match.
+ */
+export function extractUatSliceId(unitId: string): string | null {
+  const parts = unitId.split("/");
+  if (parts.length >= 2 && parts[1]!.startsWith("S")) return parts[1]!;
+  return null;
+}
+
 // ─── Dashboard Data ───────────────────────────────────────────────────────────
 
 /** Dashboard data for the overlay */
@@ -408,9 +420,16 @@ export function updateProgressWidget(
   const verb = unitVerb(unitType);
   const phaseLabel = unitPhaseLabel(unitType);
   const mid = state.activeMilestone;
-  const slice = state.activeSlice;
-  const task = state.activeTask;
   const isHook = unitType.startsWith("hook/");
+
+  // When run-uat is executing for a just-completed slice (e.g. S01),
+  // deriveState() has already advanced activeSlice to the next one (S02).
+  // Override the displayed slice to match the UAT target from the unit ID.
+  const uatTargetSliceId = unitType === "run-uat" ? extractUatSliceId(unitId) : null;
+  const slice = uatTargetSliceId
+    ? { id: uatTargetSliceId, title: state.activeSlice?.title ?? "" }
+    : state.activeSlice;
+  const task = state.activeTask;
 
   // Cache git branch at widget creation time (not per render)
   let cachedBranch: string | null = null;

--- a/src/resources/extensions/gsd/tests/auto-dashboard.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-dashboard.test.ts
@@ -8,6 +8,7 @@ import {
   formatAutoElapsed,
   formatWidgetTokens,
   estimateTimeRemaining,
+  extractUatSliceId,
 } from "../auto-dashboard.ts";
 
 // ─── unitVerb ─────────────────────────────────────────────────────────────
@@ -177,4 +178,18 @@ test("formatAutoElapsed returns empty string for negative autoStartTime", () => 
   // handle it gracefully via its falsy check.
   assert.equal(formatAutoElapsed(-1), "");
   assert.equal(formatAutoElapsed(NaN), "");
+});
+
+// ─── extractUatSliceId ───────────────────────────────────────────────────
+
+test("extractUatSliceId extracts slice ID from M001/S01 format", () => {
+  assert.equal(extractUatSliceId("M001/S01"), "S01");
+  assert.equal(extractUatSliceId("M002/S03"), "S03");
+  assert.equal(extractUatSliceId("M001/S12"), "S12");
+});
+
+test("extractUatSliceId returns null for invalid formats", () => {
+  assert.equal(extractUatSliceId("M001"), null);
+  assert.equal(extractUatSliceId(""), null);
+  assert.equal(extractUatSliceId("M001/T01"), null);
 });


### PR DESCRIPTION
## Summary
- When `run-uat` executes for a just-completed slice (e.g. S01), `deriveState()` has already advanced `activeSlice` to S02. The dashboard now extracts the target slice ID from the unit ID (`M001/S01` → `S01`) and highlights it instead, so the slice context matches the "Now: run-uat S01" label.
- Adds `extractUatSliceId()` helper with unit tests.

Closes #1695

## Test plan
- [x] `extractUatSliceId` unit tests pass for valid (`M001/S01`) and invalid (`M001`, `M001/T01`) formats
- [x] Build passes (`npm run build`)
- [x] Typecheck passes (`npm run typecheck:extensions`)
- [x] All 24 dashboard unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)