### PR TITLE
fix(auto): dispatch discussion instead of hard-stopping on needs-discussion phase

### DIFF
--- a/src/resources/extensions/gsd/auto-dashboard.ts
+++ b/src/resources/extensions/gsd/auto-dashboard.ts
@@ -67,6 +67,7 @@ export interface AutoDashboardData {
 export function unitVerb(unitType: string): string {
   if (unitType.startsWith("hook/")) return `hook: ${unitType.slice(5)}`;
   switch (unitType) {
+    case "discuss-milestone": return "discussing";
     case "research-milestone":
     case "research-slice": return "researching";
     case "plan-milestone":
@@ -84,6 +85,7 @@ export function unitVerb(unitType: string): string {
 export function unitPhaseLabel(unitType: string): string {
   if (unitType.startsWith("hook/")) return "HOOK";
   switch (unitType) {
+    case "discuss-milestone": return "DISCUSS";
     case "research-milestone": return "RESEARCH";
     case "research-slice": return "RESEARCH";
     case "plan-milestone": return "PLAN";
@@ -108,6 +110,7 @@ function peekNext(unitType: string, state: GSDState): string {
   const sid = state.activeSlice?.id ?? "";
   if (unitType.startsWith("hook/")) return `continue ${sid}`;
   switch (unitType) {
+    case "discuss-milestone": return "research or plan milestone";
     case "research-milestone": return "plan milestone roadmap";
     case "plan-milestone": return "plan or execute first slice";
     case "research-slice": return `plan ${sid}`;

--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -27,6 +27,7 @@ import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { hasImplementationArtifacts } from "./auto-recovery.js";
 import {
+  buildDiscussMilestonePrompt,
   buildResearchMilestonePrompt,
   buildPlanMilestonePrompt,
   buildResearchSlicePrompt,
@@ -181,27 +182,29 @@ const DISPATCH_RULES: DispatchRule[] = [
     },
   },
   {
-    name: "needs-discussion → stop",
-    match: async ({ state, mid, midTitle }) => {
+    name: "needs-discussion → discuss-milestone",
+    match: async ({ state, mid, midTitle, basePath }) => {
       if (state.phase !== "needs-discussion") return null;
       return {
-        action: "stop",
-        reason: `${mid}: ${midTitle} has draft context from a prior discussion — needs its own discussion before planning.\nRun /gsd to discuss.`,
-        level: "warning",
+        action: "dispatch",
+        unitType: "discuss-milestone",
+        unitId: mid,
+        prompt: await buildDiscussMilestonePrompt(mid, midTitle, basePath),
       };
     },
   },
   {
-    name: "pre-planning (no context) → stop",
-    match: async ({ state, mid, basePath }) => {
+    name: "pre-planning (no context) → discuss-milestone",
+    match: async ({ state, mid, midTitle, basePath }) => {
       if (state.phase !== "pre-planning") return null;
       const contextFile = resolveMilestoneFile(basePath, mid, "CONTEXT");
       const hasContext = !!(contextFile && (await loadFile(contextFile)));
       if (hasContext) return null; // fall through to next rule
       return {
-        action: "stop",
-        reason: "No context or roadmap yet. Run /gsd to discuss first.",
-        level: "warning",
+        action: "dispatch",
+        unitType: "discuss-milestone",
+        unitId: mid,
+        prompt: await buildDiscussMilestonePrompt(mid, midTitle, basePath),
       };
     },
   },

--- a/src/resources/extensions/gsd/auto-prompts.ts
+++ b/src/resources/extensions/gsd/auto-prompts.ts
@@ -767,6 +767,34 @@ export async function checkNeedsRunUat(
 
 // ─── Prompt Builders ──────────────────────────────────────────────────────
 
+/**
+ * Build a prompt for the discuss-milestone unit type.
+ * Loads the guided-discuss-milestone template and inlines the CONTEXT-DRAFT
+ * as a seed when present. The discussion agent interviews the user, writes
+ * a full CONTEXT.md, and the phase transitions to pre-planning automatically.
+ */
+export async function buildDiscussMilestonePrompt(mid: string, midTitle: string, base: string): Promise<string> {
+  const discussTemplates = inlineTemplate("context", "Context");
+
+  const basePrompt = loadPrompt("guided-discuss-milestone", {
+    milestoneId: mid,
+    milestoneTitle: midTitle,
+    inlinedTemplates: discussTemplates,
+    structuredQuestionsAvailable: "true",
+    commitInstruction: "Do not commit planning artifacts — .gsd/ is managed externally.",
+  });
+
+  // If a CONTEXT-DRAFT.md exists, append it as seed material
+  const draftPath = resolveMilestoneFile(base, mid, "CONTEXT-DRAFT");
+  const draftContent = draftPath ? await loadFile(draftPath) : null;
+
+  if (draftContent) {
+    return `${basePrompt}\n\n## Prior Discussion (Draft Seed)\n\nThe following draft was captured from a prior multi-milestone discussion. Use it as seed material — the user has already provided this context. Start with a brief reflection on what the draft covers, then probe for any gaps or open questions before writing the full CONTEXT.md.\n\n${draftContent}`;
+  }
+
+  return basePrompt;
+}
+
 export async function buildResearchMilestonePrompt(mid: string, midTitle: string, base: string): Promise<string> {
   const contextPath = resolveMilestoneFile(base, mid, "CONTEXT");
   const contextRel = relMilestoneFile(base, mid, "CONTEXT");

--- a/src/resources/extensions/gsd/auto-recovery.ts
+++ b/src/resources/extensions/gsd/auto-recovery.ts
@@ -63,6 +63,10 @@ export function resolveExpectedArtifactPath(
   const mid = parts[0]!;
   const sid = parts[1];
   switch (unitType) {
+    case "discuss-milestone": {
+      const dir = resolveMilestonePath(base, mid);
+      return dir ? join(dir, buildMilestoneFileName(mid, "CONTEXT")) : null;
+    }
     case "research-milestone": {
       const dir = resolveMilestonePath(base, mid);
       return dir ? join(dir, buildMilestoneFileName(mid, "RESEARCH")) : null;
@@ -441,6 +445,8 @@ export function diagnoseExpectedArtifact(
   const mid = parts[0];
   const sid = parts[1];
   switch (unitType) {
+    case "discuss-milestone":
+      return `${relMilestoneFile(base, mid!, "CONTEXT")} (milestone context from discussion)`;
     case "research-milestone":
       return `${relMilestoneFile(base, mid!, "RESEARCH")} (milestone research)`;
     case "plan-milestone":

--- a/src/resources/extensions/gsd/complexity-classifier.ts
+++ b/src/resources/extensions/gsd/complexity-classifier.ts
@@ -35,7 +35,8 @@ const UNIT_TYPE_TIERS: Record<string, ComplexityTier> = {
   "complete-slice": "light",
   "run-uat": "light",
 
-  // Tier 2 — Standard: research, routine planning
+  // Tier 2 — Standard: research, routine planning, discussion
+  "discuss-milestone": "standard",
   "research-milestone": "standard",
   "research-slice": "standard",
   "plan-milestone": "standard",


### PR DESCRIPTION
## TL;DR

**What:** Replace two hard-stop rules in auto-dispatch with `discuss-milestone` unit dispatch.
**Why:** Auto-mode dead-ends when a milestone has CONTEXT-DRAFT.md or no CONTEXT.md — the stop message says "Run /gsd" but `/gsd` hits the same stop rule.
**How:** New `discuss-milestone` unit type that interviews the user via `guided-discuss-milestone` prompt, writes CONTEXT.md, then auto-mode continues normally.

## What

Two dispatch rules in `auto-dispatch.ts` changed from `action: "stop"` to `action: "dispatch"`:
- `needs-discussion → stop` → `needs-discussion → discuss-milestone`
- `pre-planning (no context) → stop` → `pre-planning (no context) → discuss-milestone`

Supporting changes across 4 additional files:
- `auto-prompts.ts`: new `buildDiscussMilestonePrompt()` — loads `guided-discuss-milestone` template, inlines CONTEXT-DRAFT.md as seed when present
- `auto-dashboard.ts`: "discussing" / "DISCUSS" labels for the new unit type
- `complexity-classifier.ts`: `discuss-milestone` classified as "standard" tier
- `auto-recovery.ts`: expected artifact = CONTEXT.md for `discuss-milestone` in both `verifyExpectedArtifact` and `diagnoseExpectedArtifact`

## Why

When a multi-milestone discussion writes CONTEXT-DRAFT.md files (via the "Write draft for later" gate option), the subsequent milestone enters the `needs-discussion` phase. Auto-mode has a hard-stop rule for this phase:

```
reason: "${mid} has draft context from a prior discussion — needs its own discussion before planning.\nRun /gsd to discuss."
```

This creates a dead-end loop:
1. `/gsd auto` → `resolveDispatch` → `needs-discussion → stop` → "Run /gsd to discuss"
2. `/gsd` (bare) → `handleAutoCommand` catches `""` → `startAuto(step: true)` → same stop
3. `/gsd next` → same stop
4. Only `/gsd discuss` works — but the stop message doesn't mention it

The same problem exists for `pre-planning (no context)` — a blank milestone with no CONTEXT.md also hard-stops instead of initiating discussion.

## How It Works After This Fix

```
Milestone has CONTEXT-DRAFT.md, no CONTEXT.md
→ deriveState(): phase = "needs-discussion"
→ resolveDispatch(): discuss-milestone unit dispatched
→ Agent uses guided-discuss-milestone prompt (with draft as seed)
→ Agent interviews user, writes CONTEXT.md
→ deriveState(): phase = "pre-planning" (CONTEXT.md now exists)
→ Normal pipeline: research → plan → execute
```

For blank milestones (no CONTEXT.md, no draft):
```
→ deriveState(): phase = "pre-planning"
→ resolveDispatch(): discuss-milestone unit dispatched (no draft seed)
→ Agent conducts full discussion from scratch
→ Continues as above
```

### Related

- #1743 — fixes draft `depends_on` being silently discarded (complementary, not overlapping)

### Change type
- [x] `fix` — Bug fix

## Test plan
- [x] Build passes (zero type errors)
- [x] Verified dispatch rule replacement: no remaining `needs-discussion → stop` or `pre-planning → stop` in codebase
- [x] Verified phase transition: after CONTEXT.md written, `deriveState()` returns `pre-planning` (not `needs-discussion`), so discussion doesn't loop
- [x] Verified expected artifact registration: `auto-recovery.ts` correctly maps `discuss-milestone` → CONTEXT.md
