### PR TITLE
fix(hooks): process depth verification in queue mode

### DIFF
--- a/src/resources/extensions/gsd/bootstrap/register-hooks.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-hooks.ts
@@ -136,7 +136,8 @@ export function registerHooks(pi: ExtensionAPI): void {
   pi.on("tool_result", async (event) => {
     if (event.toolName !== "ask_user_questions") return;
     const milestoneId = getDiscussionMilestoneId();
-    if (!milestoneId) return;
+    const queueActive = isQueuePhaseActive();
+    if (!milestoneId && !queueActive) return;
 
     const details = event.details as any;
     if (details?.cancelled || !details?.response) return;
@@ -148,6 +149,8 @@ export function registerHooks(pi: ExtensionAPI): void {
         break;
       }
     }
+
+    if (!milestoneId) return;
 
     const basePath = process.cwd();
     const milestoneDir = resolveMilestonePath(basePath, milestoneId);

--- a/src/resources/extensions/gsd/tests/write-gate.test.ts
+++ b/src/resources/extensions/gsd/tests/write-gate.test.ts
@@ -11,7 +11,17 @@
 
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { shouldBlockContextWrite } from '../index.ts';
+import {
+  shouldBlockContextWrite,
+  isDepthVerified,
+  isQueuePhaseActive,
+  setQueuePhaseActive,
+} from '../index.ts';
+import {
+  markDepthVerified,
+  clearDiscussionFlowState,
+  resetWriteGateState,
+} from '../bootstrap/write-gate.ts';
 
 // ─── Scenario 1: Blocks CONTEXT.md write during discussion without depth verification (absolute path) ──
 
@@ -119,4 +129,65 @@ test('write-gate: blocked reason contains depth_verification keyword', () => {
   assert.strictEqual(result.block, true);
   assert.ok(result.reason!.includes('depth_verification'), 'reason should mention depth_verification question id');
   assert.ok(result.reason!.includes('ask_user_questions'), 'reason should mention ask_user_questions tool');
+});
+
+// ─── Scenario 8: Queue mode blocks CONTEXT.md write without depth verification ──
+
+test('write-gate: blocks CONTEXT.md write in queue mode without depth verification', () => {
+  const result = shouldBlockContextWrite(
+    'write',
+    '.gsd/milestones/M001/M001-CONTEXT.md',
+    null,   // no milestoneId in queue mode
+    false,  // not depth-verified
+    true,   // queue phase active
+  );
+  assert.strictEqual(result.block, true, 'should block in queue mode without depth verification');
+  assert.ok(result.reason, 'should provide a reason');
+});
+
+// ─── Scenario 9: Queue mode allows CONTEXT.md write after depth verification ──
+
+test('write-gate: allows CONTEXT.md write in queue mode after depth verification', () => {
+  const result = shouldBlockContextWrite(
+    'write',
+    '.gsd/milestones/M001/M001-CONTEXT.md',
+    null,   // no milestoneId in queue mode
+    true,   // depth-verified
+    true,   // queue phase active
+  );
+  assert.strictEqual(result.block, false, 'should not block in queue mode after depth verification');
+});
+
+// ─── Scenario 10: markDepthVerified works in queue-only mode (no milestoneId) ──
+// This is the core regression for #1812: in queue mode, the tool_result handler
+// must call markDepthVerified() even when getDiscussionMilestoneId() is null.
+
+test('write-gate: markDepthVerified unblocks queue-mode writes when milestoneId is null', () => {
+  clearDiscussionFlowState();
+  setQueuePhaseActive(true);
+
+  // Before marking: should block
+  const blocked = shouldBlockContextWrite(
+    'write',
+    '.gsd/milestones/M001/M001-CONTEXT.md',
+    null,
+    isDepthVerified(),
+    isQueuePhaseActive(),
+  );
+  assert.strictEqual(blocked.block, true, 'should block before markDepthVerified');
+
+  // Simulate what the fixed tool_result handler does
+  markDepthVerified();
+
+  // After marking: should pass
+  const allowed = shouldBlockContextWrite(
+    'write',
+    '.gsd/milestones/M001/M001-CONTEXT.md',
+    null,
+    isDepthVerified(),
+    isQueuePhaseActive(),
+  );
+  assert.strictEqual(allowed.block, false, 'should allow after markDepthVerified in queue mode');
+
+  clearDiscussionFlowState();
 });


### PR DESCRIPTION
## TL;DR

**What:** Allow depth verification handler to process in queue mode, not just discussion mode.
**Why:** `getDiscussionMilestoneId()` returns null in queue mode, causing the handler to exit before calling `markDepthVerified()` — permanently blocking CONTEXT.md writes.
**How:** Changed early return guard to also check `isQueuePhaseActive()`, added secondary guard to prevent discussion log writes in queue mode.

## What

- `register-hooks.ts`: Changed `if (!milestoneId) return` to `if (!milestoneId && !queueActive) return`, allowing depth verification in queue mode. Added second guard before discussion log write.
- 3 new regression tests in `write-gate.test.ts` covering queue-mode blocking, unblocking, and the full state transition.

## Why

State machine mismatch: queue mode sets `queuePhaseActive = true` but never sets `pendingAutoStart`, so `getDiscussionMilestoneId()` returns null. The write gate correctly blocks on `queuePhaseActive`, but the verification handler exits early on null milestone ID. The agent answers the depth question, the answer is received, but `markDepthVerified()` is never called — permanent deadlock.

Fixes #1812

## How

Minimal guard change — one condition expanded from `!milestoneId` to `!milestoneId && !queueActive`. The rest of the handler logic works correctly for both modes. Added a secondary `if (!milestoneId) return` after the verification section to prevent the discussion log append (which needs a real milestone ID) from running in queue-only mode.

### Change type
- [x] `fix` — Bug fix

## Test plan
- [x] Queue-mode write blocked without verification
- [x] Queue-mode write allowed after verification
- [x] Full markDepthVerified state transition in queue-only mode (direct #1812 reproduction)
- [ ] Manual test: `/gsd queue`, answer depth question, verify CONTEXT.md writes proceed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>