### PR TITLE
fix(doctor): prevent cleanup from deleting user work files

### DIFF
--- a/src/resources/extensions/gsd/doctor-types.ts
+++ b/src/resources/extensions/gsd/doctor-types.ts
@@ -84,12 +84,19 @@ export const COMPLETION_TRANSITION_CODES = new Set<DoctorIssueCode>([
 ]);
 
 /**
- * Issue codes that represent global (cross-project) state.
+ * Issue codes that represent global or completion-critical state.
  * These must NOT be auto-fixed when fixLevel is "task" — automated
- * post-task health checks must never delete external project state directories.
+ * post-task health checks must never delete external project state directories
+ * or remove completed-unit keys (which causes state reversion / data loss).
+ *
+ * orphaned_completed_units: Removing completed-unit keys causes deriveState to
+ * consider those tasks incomplete, reverting the user to an earlier slice and
+ * effectively discarding all work past that point (#1809). This must only be
+ * fixed by an explicit manual doctor run (fixLevel="all").
  */
 export const GLOBAL_STATE_CODES = new Set<DoctorIssueCode>([
   "orphaned_project_state",
+  "orphaned_completed_units",
 ]);
 
 export interface DoctorIssue {

--- a/src/resources/extensions/gsd/tests/doctor-runtime.test.ts
+++ b/src/resources/extensions/gsd/tests/doctor-runtime.test.ts
@@ -346,6 +346,46 @@ node_modules/
       console.log("\n=== stranded_lock_directory (skipped on Windows) ===");
     }
 
+    // ─── Test: orphaned_completed_units NOT auto-fixed at fixLevel="task" (#1809) ──
+    // Regression: task-level doctor was removing completed-unit keys whose artifacts
+    // were temporarily missing, causing deriveState to revert the user to S01 and
+    // effectively discarding hours of work.
+    console.log("\n=== orphaned_completed_units protected at fixLevel=task (#1809) ===");
+    {
+      const dir = createMinimalProject();
+      cleanups.push(dir);
+
+      // Write completed-units.json with keys that reference non-existent artifacts.
+      // At fixLevel="task" (auto-mode post-unit), these must NOT be removed.
+      const completedKeys = [
+        "execute-task/M001/S01/T99",  // artifact missing
+        "complete-slice/M001/S99",     // artifact missing
+      ];
+      writeFileSync(join(dir, ".gsd", "completed-units.json"), JSON.stringify(completedKeys));
+
+      // fixLevel="task" — the level used by auto-post-unit after every task
+      const taskLevelFix = await runGSDDoctor(dir, { fix: true, fixLevel: "task" });
+      const taskLevelOrphan = taskLevelFix.issues.filter(i => i.code === "orphaned_completed_units");
+      assertTrue(taskLevelOrphan.length > 0, "orphaned_completed_units detected at task fixLevel");
+
+      // Verify keys were NOT removed — the fix must be suppressed at task level
+      const afterTaskFix = JSON.parse(readFileSync(join(dir, ".gsd", "completed-units.json"), "utf-8"));
+      assertEq(afterTaskFix.length, 2, "completed-unit keys preserved at fixLevel=task (data loss prevention)");
+      assertTrue(
+        !taskLevelFix.fixesApplied.some(f => f.includes("orphaned")),
+        "no orphaned-units fix applied at fixLevel=task",
+      );
+
+      // fixLevel="all" (explicit manual doctor) — fix SHOULD apply
+      const allLevelFix = await runGSDDoctor(dir, { fix: true, fixLevel: "all" });
+      assertTrue(
+        allLevelFix.fixesApplied.some(f => f.includes("orphaned")),
+        "orphaned-units fix applied at fixLevel=all (manual doctor)",
+      );
+      const afterAllFix = JSON.parse(readFileSync(join(dir, ".gsd", "completed-units.json"), "utf-8"));
+      assertEq(afterAllFix.length, 0, "orphaned keys removed at fixLevel=all");
+    }
+
   } finally {
     for (const dir of cleanups) {
       try { rmSync(dir, { recursive: true, force: true }); } catch { /* ignore */ }


### PR DESCRIPTION
## TL;DR

**What:** Prevent doctor's `orphaned_completed_units` check from auto-fixing during post-task health checks.
**Why:** The check removes completion keys when artifacts are temporarily unreachable (worktree sync timing), causing `deriveState` to revert the user back to S01 — losing hours of work.
**How:** Added `orphaned_completed_units` to `GLOBAL_STATE_CODES` so it only runs during explicit manual doctor invocations, not automated post-task checks.

## What

- `doctor-types.ts`: Added `orphaned_completed_units` to `GLOBAL_STATE_CODES` set
- New regression test in `tests/doctor-runtime.test.ts` verifying task-level doctor detects but does NOT fix orphaned keys

## Why

After every task, `auto-post-unit.ts` runs the doctor with `fix: true, fixLevel: "task"`. The `orphaned_completed_units` check calls `verifyExpectedArtifact()` for each key in `completed-units.json`. When artifact files are temporarily unreachable (worktree sync timing, path resolution races), it removes those completion keys. `deriveState` then sees tasks as incomplete and reverts to S01, discarding all subsequent work. A user lost 5 hours of work to this bug.

Fixes #1809

## How

One-line addition: `orphaned_completed_units` added to `GLOBAL_STATE_CODES`. The `shouldFix()` guard in `doctor.ts` already skips global-state codes at `fixLevel="task"`. Explicit manual doctor runs (`/gsd doctor fix`) with `fixLevel="all"` can still clean up genuinely orphaned keys. This is the minimal change that prevents the data loss without removing the check entirely.

### Change type
- [x] `fix` — Bug fix

### Breaking changes
None. The check still runs and reports at task level — it just no longer auto-fixes, which matches the intent for destructive state operations.

## Test plan
- [x] Regression test: task-level doctor detects orphaned keys but does not remove them
- [x] Full test suite passes
- [ ] Manual test: complete several tasks, verify completed-units.json is preserved across doctor runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>