### PR TITLE
fix(state): treat zero-slice roadmap as pre-planning instead of blocked

### DIFF
--- a/src/resources/extensions/gsd/state.ts
+++ b/src/resources/extensions/gsd/state.ts
@@ -550,6 +550,30 @@ async function _deriveStateImpl(basePath: string): Promise<GSDState> {
     };
   }
 
+  // ── Zero-slice roadmap guard (#1785) ─────────────────────────────────
+  // A stub roadmap (placeholder text, no slice definitions) has a truthy
+  // roadmap object but an empty slices array. Without this check the
+  // slice-finding loop below finds nothing and returns phase: "blocked".
+  // An empty slices array means the roadmap still needs slice definitions,
+  // so the correct phase is pre-planning.
+  if (activeRoadmap.slices.length === 0) {
+    return {
+      activeMilestone,
+      activeSlice: null,
+      activeTask: null,
+      phase: 'pre-planning',
+      recentDecisions: [],
+      blockers: [],
+      nextAction: `Milestone ${activeMilestone.id} has a roadmap but no slices defined. Add slices to the roadmap.`,
+      registry,
+      requirements,
+      progress: {
+        milestones: milestoneProgress,
+        slices: { done: 0, total: 0 },
+      },
+    };
+  }
+
   // Check if active milestone needs validation or completion (all slices done)
   if (isMilestoneComplete(activeRoadmap)) {
     const validationFile = resolveMilestoneFile(basePath, activeMilestone.id, "VALIDATION");

--- a/src/resources/extensions/gsd/tests/derive-state.test.ts
+++ b/src/resources/extensions/gsd/tests/derive-state.test.ts
@@ -957,6 +957,28 @@ slice: S01
     }
   }
 
+  // ─── Test: zero-slice roadmap → pre-planning, not blocked (#1785) ────
+  console.log('\n=== zero-slice roadmap → pre-planning, not blocked (#1785) ===');
+  {
+    const base = createFixtureBase();
+    try {
+      // Write a stub roadmap with zero slices (placeholder text, no slice definitions)
+      writeRoadmap(base, 'M001', `# M001: Stub Milestone\n\n**Vision:** Placeholder.\n\n## Slices\n\n_No slices defined yet._\n`);
+
+      const state = await deriveState(base);
+
+      assertEq(state.phase, 'pre-planning', 'phase is pre-planning when roadmap has zero slices');
+      assertTrue(state.activeMilestone !== null, 'activeMilestone is set');
+      assertEq(state.activeMilestone?.id, 'M001', 'activeMilestone is M001');
+      assertEq(state.activeSlice, null, 'activeSlice is null');
+      assertEq(state.activeTask, null, 'activeTask is null');
+      assertEq(state.blockers.length, 0, 'no blockers reported');
+      assertTrue(state.nextAction.includes('M001'), 'nextAction references M001');
+    } finally {
+      cleanup(base);
+    }
+  }
+
   report();
 }
 


### PR DESCRIPTION
## TL;DR

**What:** Return `pre-planning` instead of `blocked` when a roadmap has zero slice definitions.
**Why:** Stub roadmaps from `/gsd queue` have a valid file but no slices, causing a false "No slice eligible" deadlock that users can't recover from.
**How:** Added zero-slices guard in `deriveState()` that returns `pre-planning` before the slice-finding loop.

## What

- `state.ts`: Added guard after the `!activeRoadmap` check — when `activeRoadmap.slices.length === 0`, returns `phase: 'pre-planning'` immediately
- New regression test in `derive-state.test.ts` verifying zero-slice roadmap returns `pre-planning` with no blockers

## Why

`deriveState()` handles missing roadmaps (`!activeRoadmap`) by returning `pre-planning`. But when a stub roadmap exists (from `/gsd queue` with placeholder text), the roadmap object is truthy with `slices: []`. The code falls through to the slice-finding loop, which iterates over nothing, and returns `phase: "blocked"` with "No slice eligible — check dependency ordering." This conflates two cases: (1) stub needing planning (should be `pre-planning`) and (2) actual dependency deadlock (should be `blocked`).

Fixes #1785

## How

One guard added before the slice loop: `if (activeRoadmap.slices.length === 0) return { phase: 'pre-planning', ... }`. This is the same shape as the `!activeRoadmap` return — minimal change, no new abstractions.

### Change type
- [x] `fix` — Bug fix

## Test plan
- [x] Regression test: milestone with zero-slice stub roadmap returns `pre-planning`
- [x] Full test suite passes
- [ ] Manual test: `/gsd queue` a milestone with stub roadmap, verify auto-mode enters planning

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>