### PR TITLE
fix(verification): avoid DEP0190 by passing command to shell explicitly

### DIFF
--- a/src/resources/extensions/gsd/tests/verification-gate.test.ts
+++ b/src/resources/extensions/gsd/tests/verification-gate.test.ts
@@ -18,8 +18,10 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { mkdirSync, writeFileSync, rmSync } from "node:fs";
-import { join } from "node:path";
+import { join, dirname } from "node:path";
 import { tmpdir } from "node:os";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
 import { discoverCommands, runVerificationGate, formatFailureContext, captureRuntimeErrors, runDependencyAudit, isLikelyCommand } from "../verification-gate.ts";
 import type { CaptureRuntimeErrorsOptions, DependencyAuditOptions } from "../verification-gate.ts";
 import { validatePreferences } from "../preferences.ts";
@@ -239,6 +241,47 @@ test("verification-gate: command not found → exit code 127", () => {
     assert.equal(result.checks.length, 1);
     assert.ok(result.checks[0].exitCode !== 0, "should have non-zero exit code");
     assert.ok(result.checks[0].durationMs >= 0);
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("verification-gate: no DEP0190 deprecation warning when running commands", () => {
+  const tmp = makeTempDir("vg-dep0190");
+  try {
+    // Run a subprocess with --throw-deprecation so any DeprecationWarning
+    // becomes a thrown error (non-zero exit). The fix passes the command
+    // string to sh -c explicitly instead of using spawnSync(cmd, {shell:true}).
+    const thisDir = dirname(fileURLToPath(import.meta.url));
+    const gatePath = join(thisDir, "..", "verification-gate.ts");
+    const resolverPath = join(thisDir, "resolve-ts.mjs");
+    const script = [
+      `import { runVerificationGate } from ${JSON.stringify("file://" + gatePath)};`,
+      `runVerificationGate({`,
+      `  basePath: ${JSON.stringify(tmp)},`,
+      `  unitId: "T-DEP",`,
+      `  cwd: ${JSON.stringify(tmp)},`,
+      `  preferenceCommands: ["echo dep0190-check"],`,
+      `});`,
+    ].join("\n");
+    const child = spawnSync(
+      process.execPath,
+      [
+        "--throw-deprecation",
+        "--experimental-strip-types",
+        "--import", resolverPath,
+        "--input-type=module",
+        "-e", script,
+      ],
+      { encoding: "utf-8", timeout: 15_000 },
+    );
+    // With --throw-deprecation, any DeprecationWarning becomes a thrown error
+    // causing a non-zero exit. Exit 0 proves no deprecation was emitted.
+    assert.equal(
+      child.status,
+      0,
+      `Expected exit 0 (no deprecation) but got ${child.status}. stderr: ${child.stderr}`,
+    );
   } finally {
     rmSync(tmp, { recursive: true, force: true });
   }

--- a/src/resources/extensions/gsd/verification-gate.ts
+++ b/src/resources/extensions/gsd/verification-gate.ts
@@ -3,7 +3,7 @@
 // Discovery order (D003): preference → task plan verify → package.json scripts.
 // First non-empty source wins.
 
-import { spawnSync } from "node:child_process";
+import { spawnSync, type SpawnSyncReturns } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
 import { join, basename } from "node:path";
 import type { AuditWarning, RuntimeError, VerificationCheck, VerificationResult } from "./types.js";
@@ -259,8 +259,11 @@ export function runVerificationGate(options: RunVerificationGateOptions): Verifi
 
   for (const command of commands) {
     const start = Date.now();
-    const result = spawnSync(command, {
-      shell: true,
+    // Pass the command string as an argument to the shell explicitly
+    // to avoid Node.js DEP0190 (spawnSync with shell: true and no args).
+    const shellBin = process.platform === "win32" ? "cmd" : "sh";
+    const shellArgs = process.platform === "win32" ? ["/c", command] : ["-c", command];
+    const result: SpawnSyncReturns<string> = spawnSync(shellBin, shellArgs, {
       cwd: options.cwd,
       stdio: "pipe",
       encoding: "utf-8",


### PR DESCRIPTION
## TL;DR

**What:** Replace `spawnSync(command, { shell: true })` with explicit shell invocation to avoid DEP0190.
**Why:** Node.js emits DeprecationWarning DEP0190 when `spawnSync` receives a command string with `shell: true` but no args array.
**How:** Changed to `spawnSync('sh', ['-c', command])` (platform-aware: `cmd /c` on Windows).

## What

- `verification-gate.ts`: Replaced `spawnSync(command, { shell: true })` with `spawnSync(process.platform === 'win32' ? 'cmd' : 'sh', [process.platform === 'win32' ? '/c' : '-c', command])`
- New regression test in `verification-gate.test.ts` that spawns with `--throw-deprecation` and verifies clean exit

## Why

Node.js DEP0190 warns when passing a command string to `spawnSync` with `shell: true` because arguments aren't escaped, only concatenated. This produces noisy console output during verification runs that can confuse users and may become an error in future Node.js versions.

Fixes #1751

## How

The fix passes the command to the shell explicitly via `sh -c` (or `cmd /c` on Windows), which is functionally identical to `shell: true` but doesn't trigger the deprecation. This preserves support for piped commands, quoted arguments, and shell features without the naive `command.split(' ')` approach that would break them.

### Change type
- [x] `fix` — Bug fix

## Test plan
- [x] Regression test: subprocess with `--throw-deprecation` runs verification gate without error
- [x] 71 verification-gate tests pass
- [ ] Manual test: run `npm test` and verify no DEP0190 warnings in output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>