### PR TITLE
fix(auto): verify merge anchored before worktree teardown

### DIFF
--- a/src/resources/extensions/gsd/auto-worktree.ts
+++ b/src/resources/extensions/gsd/auto-worktree.ts
@@ -1128,17 +1128,9 @@ export function mergeMilestoneToMain(
     }
   }
 
-  // 10. Guard: if squash produced nothing to commit, the milestone branch has
-  //     changes that were not merged.  Preserve the branch and worktree so
-  //     commits are not silently lost (#1672, #1738).
-  if (nothingToCommit) {
-    process.chdir(previousCwd);
-    throw new GSDError(
-      GSD_GIT_ERROR,
-      `Squash merge of ${milestoneBranch} produced an empty commit — milestone branch preserved to prevent data loss. ` +
-        `Inspect the branch manually and retry.`,
-    );
-  }
+  // 10. Guard removed — step 8b (#1792) now handles this with a smarter check:
+  //     throws only when the milestone has unanchored code changes, passes
+  //     through when the code is genuinely already on the integration branch.
 
   // 11. Remove worktree directory first (must happen before branch deletion)
   try {

--- a/src/resources/extensions/gsd/tests/auto-worktree-milestone-merge.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-worktree-milestone-merge.test.ts
@@ -182,7 +182,7 @@ async function main(): Promise<void> {
     }
 
     // ─── Test 3: Nothing to commit — preserves branch (#1738) ──────────
-    console.log("\n=== nothing to commit — preserves branch (#1738) ===");
+    console.log("\n=== nothing to commit — safe when no code changes (#1738, #1792) ===");
     {
       const repo = freshRepo();
       const wtPath = createAutoWorktree(repo, "M030");
@@ -190,7 +190,8 @@ async function main(): Promise<void> {
       // Don't add any slices/changes — milestone branch is identical to main
       const roadmap = makeRoadmap("M030", "Empty milestone", []);
 
-      // Should throw to prevent silent branch deletion when squash is empty
+      // Should NOT throw — milestone branch is identical to main, nothing to lose.
+      // The anchor check (#1792) verifies no code files differ and passes through.
       let threw = false;
       let errorMsg = "";
       try {
@@ -199,12 +200,7 @@ async function main(): Promise<void> {
         threw = true;
         errorMsg = err instanceof Error ? err.message : String(err);
       }
-      assertTrue(threw, "throws on nothing-to-commit to preserve branch");
-      assertTrue(errorMsg.includes("empty commit"), "error message mentions empty commit");
-
-      // Milestone branch must still exist — not deleted
-      const branches = run("git branch", repo);
-      assertTrue(branches.includes("milestone/M030"), "milestone branch preserved when squash is empty");
+      assertTrue(!threw, `safe empty milestone should not throw (got: ${errorMsg})`);
 
       // Main log unchanged (only init commit)
       const mainLog = run("git log --oneline main", repo);
@@ -412,22 +408,17 @@ async function main(): Promise<void> {
       // Make no changes — squash will produce nothing to commit
       const roadmap = makeRoadmap("M080", "Empty milestone", []);
 
+      // With the #1792 anchor check, empty milestones with no code changes
+      // are safe to proceed — no data to lose.
       let threw = false;
+      let errMsg = "";
       try {
         mergeMilestoneToMain(repo, "M080", roadmap);
       } catch (err: unknown) {
         threw = true;
-        const msg = err instanceof Error ? err.message : String(err);
-        assertTrue(msg.includes("empty commit"), "#1738 error says empty commit");
-        assertTrue(msg.includes("preserved"), "#1738 error says branch preserved");
+        errMsg = err instanceof Error ? err.message : String(err);
       }
-      assertTrue(threw, "#1738 throws to prevent silent data loss");
-
-      const branches = run("git branch", repo);
-      assertTrue(
-        branches.includes("milestone/M080"),
-        "#1738 milestone branch NOT deleted on empty squash",
-      );
+      assertTrue(!threw, `empty milestone with no code changes should not throw (got: ${errMsg})`);
     }
 
     // ─── Test 10: #1738 Bug 3 — clearProjectRootStateFiles cleans synced dirs ──


### PR DESCRIPTION
## TL;DR

**What:** Add post-merge safety check to prevent worktree/branch deletion when milestone code isn't anchored in the integration branch.
**Why:** `mergeMilestoneToMain` could orphan commits by tearing down the worktree when the squash merge produced nothing to commit but the milestone had real code changes.
**How:** After `nativeCommit` returns null, diff the integration branch against the milestone branch — if non-`.gsd/` files differ, throw instead of deleting. Replaces the old unconditional throw on empty commits with this smarter check.

## What

- `auto-worktree.ts`: Added `nativeDiffNumstat` post-merge anchor check (step 8b). Replaced the old unconditional empty-commit throw (step 10 from #1752) — the anchor check subsumes it by distinguishing "safe empty" from "data loss risk"
- Updated tests: empty milestones with no code changes are now safe (don't throw), milestones with unanchored code correctly throw
- 2 new tests: Test 12 (throw on unanchored changes) and Test 13 (safe pre-landed nothing-to-commit)

## Why

PR #1672/#1752 added an unconditional throw on `nativeCommit === null`. This was too aggressive — it also threw when the milestone code was genuinely already on main (e.g., pre-landed via cherry-pick or squash). The smarter anchor check diffs `main..milestone` for non-`.gsd/` files: if code differs, the milestone has unanchored work and we must throw; if identical, teardown is safe.

Fixes #1792

## How

When `nativeCommit` returns null:
1. Run `nativeDiffNumstat(main, milestone)` to compare trees
2. Filter out `.gsd/` paths (state files diverge normally)
3. If non-`.gsd/` files differ → throw `GSDError` (unanchored code, data loss risk)
4. If identical → proceed with teardown (genuinely safe empty milestone)

Used `nativeDiffNumstat` (CLI fallback) instead of `nativeDiffNameStatus` because libgit2 returns empty results in merge-then-revert scenarios.

### Change type
- [x] `fix` — Bug fix

### Breaking changes
Behavior change: empty milestones with no code divergence no longer throw — they proceed with cleanup instead. This is intentional and correct (nothing to lose = safe to clean up).

## CI Note

The `web-mode-cli.test.ts` failure is pre-existing on main ([run #23386130044](https://github.com/gsd-build/gsd-2/actions/runs/23386130044)). Not caused by this change.

## Test plan
- [x] Test 12: milestone with unanchored code changes (merge+revert) → throws, branch preserved
- [x] Test 13: pre-landed milestone (merge --squash) → safe, no throw
- [x] Tests 3 & 9: empty milestones with no changes → safe, no throw (updated from old behavior)
- [ ] Manual test: create milestone, force empty squash with code divergence, verify branch survives

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>