### PR TITLE
fix(auto): reverse-sync root-level .gsd files on worktree teardown

### DIFF
--- a/src/resources/extensions/gsd/auto-worktree.ts
+++ b/src/resources/extensions/gsd/auto-worktree.ts
@@ -113,13 +113,15 @@ export function syncGsdStateToWorktree(
 
   if (!existsSync(mainGsd) || !existsSync(wtGsd)) return { synced };
 
-  // Sync root-level .gsd/ files (DECISIONS, REQUIREMENTS, PROJECT, KNOWLEDGE)
+  // Sync root-level .gsd/ files (DECISIONS, REQUIREMENTS, PROJECT, KNOWLEDGE, etc.)
   const rootFiles = [
     "DECISIONS.md",
     "REQUIREMENTS.md",
     "PROJECT.md",
     "KNOWLEDGE.md",
     "OVERRIDES.md",
+    "QUEUE.md",
+    "completed-units.json",
   ];
   for (const f of rootFiles) {
     const src = join(mainGsd, f);
@@ -267,12 +269,16 @@ export function syncWorktreeStateBack(
   // ── 1. Sync root-level .gsd/ files back ──────────────────────────────
   // The worktree is authoritative — complete-milestone updates REQUIREMENTS,
   // PROJECT, etc. These must overwrite main's copies so they survive teardown.
+  // Also includes QUEUE.md and completed-units.json which are written during
+  // milestone closeout and lost on teardown without explicit sync (#1787).
   const rootFiles = [
     "DECISIONS.md",
     "REQUIREMENTS.md",
     "PROJECT.md",
     "KNOWLEDGE.md",
     "OVERRIDES.md",
+    "QUEUE.md",
+    "completed-units.json",
   ];
   for (const f of rootFiles) {
     const src = join(wtGsd, f);

--- a/src/resources/extensions/gsd/tests/worktree-sync-milestones.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-sync-milestones.test.ts
@@ -453,6 +453,70 @@ async function main(): Promise<void> {
     }
   }
 
+  // ─── 13. syncWorktreeStateBack syncs QUEUE.md and completed-units.json (#1787) ──
+  console.log('\n=== 13. QUEUE.md and completed-units.json synced from worktree (#1787) ===');
+  {
+    const mainBase = mkdtempSync(join(tmpdir(), 'gsd-wt-back-queue-main-'));
+    const wtBase = mkdtempSync(join(tmpdir(), 'gsd-wt-back-queue-wt-'));
+
+    try {
+      mkdirSync(join(mainBase, '.gsd', 'milestones', 'M001'), { recursive: true });
+      mkdirSync(join(wtBase, '.gsd', 'milestones', 'M001'), { recursive: true });
+
+      // Worktree has QUEUE.md and completed-units.json written during milestone closeout
+      writeFileSync(join(wtBase, '.gsd', 'QUEUE.md'), '# Queue\n- M002 next');
+      writeFileSync(
+        join(wtBase, '.gsd', 'completed-units.json'),
+        JSON.stringify({ units: [{ id: 'M001-S01-T01', completed: true }] }),
+      );
+
+      // Main has neither
+      assertTrue(
+        !existsSync(join(mainBase, '.gsd', 'QUEUE.md')),
+        'QUEUE.md missing in main before sync',
+      );
+      assertTrue(
+        !existsSync(join(mainBase, '.gsd', 'completed-units.json')),
+        'completed-units.json missing in main before sync',
+      );
+
+      const { synced } = syncWorktreeStateBack(mainBase, wtBase, 'M001');
+
+      // QUEUE.md should be synced
+      assertTrue(
+        existsSync(join(mainBase, '.gsd', 'QUEUE.md')),
+        '#1787: QUEUE.md synced from worktree to main',
+      );
+      const queueContent = readFileSync(join(mainBase, '.gsd', 'QUEUE.md'), 'utf-8');
+      assertTrue(
+        queueContent.includes('M002 next'),
+        '#1787: QUEUE.md has correct content',
+      );
+      assertTrue(
+        synced.includes('QUEUE.md'),
+        '#1787: QUEUE.md appears in synced list',
+      );
+
+      // completed-units.json should be synced
+      assertTrue(
+        existsSync(join(mainBase, '.gsd', 'completed-units.json')),
+        '#1787: completed-units.json synced from worktree to main',
+      );
+      const cuContent = readFileSync(join(mainBase, '.gsd', 'completed-units.json'), 'utf-8');
+      assertTrue(
+        cuContent.includes('M001-S01-T01'),
+        '#1787: completed-units.json has correct content',
+      );
+      assertTrue(
+        synced.includes('completed-units.json'),
+        '#1787: completed-units.json appears in synced list',
+      );
+    } finally {
+      rmSync(mainBase, { recursive: true, force: true });
+      rmSync(wtBase, { recursive: true, force: true });
+    }
+  }
+
   report();
 }
 


### PR DESCRIPTION
## TL;DR
Add `QUEUE.md` and `completed-units.json` to the durable file whitelist so they survive worktree teardown.

## What
- Added `QUEUE.md` and `completed-units.json` to the `rootFiles` whitelist in both `syncGsdStateToWorktree` (forward sync, main-to-worktree) and `syncWorktreeStateBack` (reverse sync, worktree-to-main).
- Added regression test (test 13) verifying both files are correctly synced back from worktree to project root.

## Why
`syncWorktreeStateBack()` only copied 5 root-level `.gsd/` files (`DECISIONS.md`, `REQUIREMENTS.md`, `PROJECT.md`, `KNOWLEDGE.md`, `OVERRIDES.md`). `QUEUE.md` and `completed-units.json` — both written during milestone closeout — were silently dropped on worktree teardown because they were not in the whitelist.

## How
Whitelist addition only — two entries added to each of the two existing `rootFiles` arrays in `auto-worktree.ts`. No logic changes, no new code paths.

Fixes #1787