### PR TITLE
fix: parsePlan recognizes heading-style task entries

### DIFF
--- a/src/resources/extensions/gsd/auto-recovery.ts
+++ b/src/resources/extensions/gsd/auto-recovery.ts
@@ -319,10 +319,15 @@ export function verifyExpectedArtifact(
   // plan has no tasks, creating an infinite skip loop (#699).
   if (unitType === "plan-slice") {
     const planContent = readFileSync(absPath, "utf-8");
-    if (!/^- \[[xX ]\] \*\*T\d+:/m.test(planContent)) return false;
+    // Accept checkbox-style (- [x] **T01: ...) or heading-style (### T01 -- / ### T01: / ### T01 —)
+    const hasCheckboxTask = /^- \[[xX ]\] \*\*T\d+:/m.test(planContent);
+    const hasHeadingTask = /^#{2,4}\s+T\d+\s*(?:--|—|:)/m.test(planContent);
+    if (!hasCheckboxTask && !hasHeadingTask) return false;
   }
 
-  // execute-task must also have its checkbox marked [x] in the slice plan
+  // execute-task must also have its checkbox marked [x] in the slice plan.
+  // Heading-style plans (### T01 -- Title) have no checkbox — the task summary
+  // file existence (checked above via resolveExpectedArtifactPath) is sufficient.
   if (unitType === "execute-task") {
     const parts = unitId.split("/");
     const mid = parts[0];
@@ -333,8 +338,11 @@ export function verifyExpectedArtifact(
       if (planAbs && existsSync(planAbs)) {
         const planContent = readFileSync(planAbs, "utf-8");
         const escapedTid = tid.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-        const re = new RegExp(`^- \\[[xX]\\] \\*\\*${escapedTid}:`, "m");
-        if (!re.test(planContent)) return false;
+        const cbRe = new RegExp(`^- \\[[xX]\\] \\*\\*${escapedTid}:`, "m");
+        const hdRe = new RegExp(`^#{2,4}\\s+${escapedTid}\\s*(?:--|—|:)`, "m");
+        // Heading-style entries count as verified (no checkbox to toggle);
+        // checkbox-style entries require [x].
+        if (!cbRe.test(planContent) && !hdRe.test(planContent)) return false;
       }
     }
   }

--- a/src/resources/extensions/gsd/files.ts
+++ b/src/resources/extensions/gsd/files.ts
@@ -374,20 +374,37 @@ function _parsePlanImpl(content: string): SlicePlan {
 
     for (const line of taskLines) {
       const cbMatch = line.match(/^-\s+\[([ xX])\]\s+\*\*([\w.]+):\s+(.+?)\*\*\s*(.*)/);
-      if (cbMatch) {
+      // Heading-style: ### T01 -- Title, ### T01: Title, ### T01 — Title
+      const hdMatch = !cbMatch ? line.match(/^#{2,4}\s+([\w.]+)\s*(?:--|—|:)\s*(.+)/) : null;
+      if (cbMatch || hdMatch) {
         if (currentTask) tasks.push(currentTask);
 
-        const rest = cbMatch[4] || '';
-        const estMatch = rest.match(/`est:([^`]+)`/);
-        const estimate = estMatch ? estMatch[1] : '';
+        if (cbMatch) {
+          const rest = cbMatch[4] || '';
+          const estMatch = rest.match(/`est:([^`]+)`/);
+          const estimate = estMatch ? estMatch[1] : '';
 
-        currentTask = {
-          id: cbMatch[2],
-          title: cbMatch[3],
-          description: '',
-          done: cbMatch[1].toLowerCase() === 'x',
-          estimate,
-        };
+          currentTask = {
+            id: cbMatch[2],
+            title: cbMatch[3],
+            description: '',
+            done: cbMatch[1].toLowerCase() === 'x',
+            estimate,
+          };
+        } else {
+          const rest = hdMatch![2] || '';
+          const titleEstMatch = rest.match(/^(.+?)\s*`est:([^`]+)`\s*$/);
+          const title = titleEstMatch ? titleEstMatch[1].trim() : rest.trim();
+          const estimate = titleEstMatch ? titleEstMatch[2] : '';
+
+          currentTask = {
+            id: hdMatch![1],
+            title,
+            description: '',
+            done: false,
+            estimate,
+          };
+        }
       } else if (currentTask && line.match(/^\s*-\s+Files:\s*(.*)/)) {
         const filesMatch = line.match(/^\s*-\s+Files:\s*(.*)/);
         if (filesMatch) {

--- a/src/resources/extensions/gsd/tests/auto-recovery.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-recovery.test.ts
@@ -386,6 +386,91 @@ test("verifyExpectedArtifact plan-slice fails for plan with no tasks (#699)", ()
   }
 });
 
+// ─── verifyExpectedArtifact: heading-style plan tasks (#1691) ─────────────
+
+test("verifyExpectedArtifact accepts plan-slice with heading-style tasks (### T01 --)", () => {
+  const base = makeTmpBase();
+  try {
+    const sliceDir = join(base, ".gsd", "milestones", "M001", "slices", "S01");
+    const tasksDir = join(sliceDir, "tasks");
+    mkdirSync(tasksDir, { recursive: true });
+    writeFileSync(join(sliceDir, "S01-PLAN.md"), [
+      "# S01: Test Slice",
+      "",
+      "## Tasks",
+      "",
+      "### T01 -- Implement feature",
+      "",
+      "Feature description.",
+      "",
+      "### T02 -- Write tests",
+      "",
+      "Test description.",
+    ].join("\n"));
+    writeFileSync(join(tasksDir, "T01-PLAN.md"), "# T01 Plan");
+    writeFileSync(join(tasksDir, "T02-PLAN.md"), "# T02 Plan");
+    assert.strictEqual(
+      verifyExpectedArtifact("plan-slice", "M001/S01", base),
+      true,
+      "Heading-style plan with task entries should be treated as completed artifact",
+    );
+  } finally {
+    cleanup(base);
+  }
+});
+
+test("verifyExpectedArtifact accepts plan-slice with colon-style heading tasks (### T01:)", () => {
+  const base = makeTmpBase();
+  try {
+    const sliceDir = join(base, ".gsd", "milestones", "M001", "slices", "S01");
+    const tasksDir = join(sliceDir, "tasks");
+    mkdirSync(tasksDir, { recursive: true });
+    writeFileSync(join(sliceDir, "S01-PLAN.md"), [
+      "# S01: Test Slice",
+      "",
+      "## Tasks",
+      "",
+      "### T01: Implement feature",
+      "",
+      "Feature description.",
+    ].join("\n"));
+    writeFileSync(join(tasksDir, "T01-PLAN.md"), "# T01 Plan");
+    assert.strictEqual(
+      verifyExpectedArtifact("plan-slice", "M001/S01", base),
+      true,
+      "Colon heading-style plan should be treated as completed artifact",
+    );
+  } finally {
+    cleanup(base);
+  }
+});
+
+test("verifyExpectedArtifact execute-task passes for heading-style plan entry (#1691)", () => {
+  const base = makeTmpBase();
+  try {
+    const sliceDir = join(base, ".gsd", "milestones", "M001", "slices", "S01");
+    const tasksDir = join(sliceDir, "tasks");
+    mkdirSync(tasksDir, { recursive: true });
+    writeFileSync(join(sliceDir, "S01-PLAN.md"), [
+      "# S01: Test Slice",
+      "",
+      "## Tasks",
+      "",
+      "### T01 -- Implement feature",
+      "",
+      "Feature description.",
+    ].join("\n"));
+    writeFileSync(join(tasksDir, "T01-SUMMARY.md"), "# T01 Summary\n\nDone.");
+    assert.strictEqual(
+      verifyExpectedArtifact("execute-task", "M001/S01/T01", base),
+      true,
+      "execute-task should pass for heading-style plan entry when summary exists",
+    );
+  } finally {
+    cleanup(base);
+  }
+});
+
 // ─── selfHealRuntimeRecords — worktree base path (#769) ──────────────────
 
 test("selfHealRuntimeRecords clears stale dispatched records (#769)", async () => {

--- a/src/resources/extensions/gsd/tests/parsers.test.ts
+++ b/src/resources/extensions/gsd/tests/parsers.test.ts
@@ -652,6 +652,116 @@ console.log('\n=== parsePlan: new-format task entries with Files and Verify subl
   assertTrue(p.tasks[0].description.includes('Why: because we need typed plan entries'), 'Why line accumulates into description');
 }
 
+console.log('\n=== parsePlan: heading-style task entries (### T01 -- Title) ===');
+{
+  const content = `# S11: Heading Style
+
+**Goal:** Test heading-style task parsing.
+**Demo:** Parser handles heading-style task entries.
+
+## Tasks
+
+### T01 -- Implement feature
+
+- Why: the feature is needed
+- Files: \`src/feature.ts\`
+- Verify: npm test
+
+### T02 -- Write tests \`est:1h\`
+
+Some description for the second task.
+`;
+
+  const p = parsePlan(content);
+  assertEq(p.tasks.length, 2, 'heading-style task count');
+  assertEq(p.tasks[0].id, 'T01', 'heading T01 id');
+  assertEq(p.tasks[0].title, 'Implement feature', 'heading T01 title');
+  assertEq(p.tasks[0].done, false, 'heading T01 not done (headings have no checkbox)');
+  assertEq(p.tasks[0].files![0], 'src/feature.ts', 'heading T01 files extracted');
+  assertEq(p.tasks[0].verify, 'npm test', 'heading T01 verify extracted');
+  assertEq(p.tasks[1].id, 'T02', 'heading T02 id');
+  assertEq(p.tasks[1].title, 'Write tests', 'heading T02 title');
+  assertEq(p.tasks[1].estimate, '1h', 'heading T02 estimate');
+  assertTrue(p.tasks[1].description.includes('Some description'), 'heading T02 description');
+}
+
+console.log('\n=== parsePlan: heading-style with colon separator (### T01: Title) ===');
+{
+  const content = `# S12: Heading Colon Style
+
+**Goal:** Test colon-separated heading tasks.
+**Demo:** Parser handles colon separator.
+
+## Tasks
+
+### T01: Setup project
+  Basic project setup steps.
+
+### T02: Add CI pipeline \`est:30m\`
+  Configure CI.
+`;
+
+  const p = parsePlan(content);
+  assertEq(p.tasks.length, 2, 'colon heading task count');
+  assertEq(p.tasks[0].id, 'T01', 'colon heading T01 id');
+  assertEq(p.tasks[0].title, 'Setup project', 'colon heading T01 title');
+  assertEq(p.tasks[1].id, 'T02', 'colon heading T02 id');
+  assertEq(p.tasks[1].title, 'Add CI pipeline', 'colon heading T02 title');
+  assertEq(p.tasks[1].estimate, '30m', 'colon heading T02 estimate');
+}
+
+console.log('\n=== parsePlan: heading-style with em-dash separator (### T01 — Title) ===');
+{
+  const content = `# S13: Em-Dash Style
+
+**Goal:** Test em-dash separated heading tasks.
+**Demo:** Parser handles em-dash separator.
+
+## Tasks
+
+### T01 — Build the widget
+
+Widget description.
+`;
+
+  const p = parsePlan(content);
+  assertEq(p.tasks.length, 1, 'em-dash heading task count');
+  assertEq(p.tasks[0].id, 'T01', 'em-dash heading T01 id');
+  assertEq(p.tasks[0].title, 'Build the widget', 'em-dash heading T01 title');
+}
+
+console.log('\n=== parsePlan: mixed checkbox and heading-style tasks ===');
+{
+  const content = `# S14: Mixed Format
+
+**Goal:** Test mixed formats.
+**Demo:** Parser handles both styles in one plan.
+
+## Tasks
+
+- [ ] **T01: Checkbox task** \`est:20m\`
+  A checkbox-style task.
+
+### T02 -- Heading task \`est:15m\`
+
+A heading-style task.
+
+- [x] **T03: Done checkbox task** \`est:10m\`
+  Already completed.
+`;
+
+  const p = parsePlan(content);
+  assertEq(p.tasks.length, 3, 'mixed format task count');
+  assertEq(p.tasks[0].id, 'T01', 'mixed T01 id');
+  assertEq(p.tasks[0].done, false, 'mixed T01 not done');
+  assertEq(p.tasks[1].id, 'T02', 'mixed T02 id');
+  assertEq(p.tasks[1].title, 'Heading task', 'mixed T02 title');
+  assertEq(p.tasks[1].estimate, '15m', 'mixed T02 estimate');
+  assertEq(p.tasks[1].done, false, 'mixed T02 not done (heading style)');
+  assertEq(p.tasks[2].id, 'T03', 'mixed T03 id');
+  assertEq(p.tasks[2].done, true, 'mixed T03 done');
+}
+
 // ═══════════════════════════════════════════════════════════════════════════
 // parseSummary tests
 // ═══════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary
- `parsePlan()` in `files.ts` now recognizes heading-style task entries (`### T01 -- Title`, `### T01: Title`, `### T01 — Title`) as a fallback alongside checkbox format (`- [x] **T01: Title**`)
- `verifyExpectedArtifact()` in `auto-recovery.ts` updated for both `plan-slice` (task presence check) and `execute-task` (done check) to accept heading-style entries
- Heading-style tasks default to `done: false` since they have no checkbox to toggle

Closes #1691

## Test plan
- [x] 4 new `parsePlan` tests: double-dash, colon, em-dash, and mixed checkbox+heading formats
- [x] 3 new `verifyExpectedArtifact` tests: heading-style plan-slice acceptance (double-dash and colon), execute-task with heading-style entry
- [x] All existing parser tests pass (429/429)
- [x] All auto-recovery tests pass (31/31)
- [x] `npm run build` succeeds
- [x] `npm run typecheck:extensions` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)