### PR TITLE
fix: prevent cross-project state leak in brand-new directories

### DIFF
--- a/src/resources/extensions/gsd/auto-start.ts
+++ b/src/resources/extensions/gsd/auto-start.ts
@@ -20,7 +20,7 @@ import {
   resolveSkillDiscoveryMode,
   getIsolationMode,
 } from "./preferences.js";
-import { ensureGsdSymlink, validateProjectId } from "./repo-identity.js";
+import { ensureGsdSymlink, isInheritedRepo, validateProjectId } from "./repo-identity.js";
 import { migrateToExternalState, recoverFailedMigration } from "./migrate-external.js";
 import { collectSecretsFromManifest } from "../get-secrets-from-user.js";
 import { gsdRoot, resolveMilestoneFile, milestonesDir } from "./paths.js";
@@ -140,8 +140,13 @@ export async function bootstrapAutoSession(
       return releaseLockAndReturn();
     }
 
-    // Ensure git repo exists
-    if (!nativeIsRepo(base)) {
+    // Ensure git repo exists.
+    // Guard against inherited repos: if `base` is a subdirectory of another
+    // git repo that has no .gsd (i.e. the parent project was never initialised
+    // with GSD), create a fresh git repo at `base` so it gets its own identity
+    // hash. Without this, repoIdentity() resolves to the parent repo's hash
+    // and loads milestones from an unrelated project (#1639).
+    if (!nativeIsRepo(base) || isInheritedRepo(base)) {
       const mainBranch =
         loadEffectiveGSDPreferences()?.preferences?.git?.main_branch || "main";
       nativeInit(base, mainBranch);

--- a/src/resources/extensions/gsd/guided-flow.ts
+++ b/src/resources/extensions/gsd/guided-flow.ts
@@ -26,6 +26,7 @@ import { join } from "node:path";
 import { readFileSync, existsSync, mkdirSync, readdirSync, rmSync, unlinkSync } from "node:fs";
 import { readSessionLockData, isSessionLockProcessAlive } from "./session-lock.js";
 import { nativeIsRepo, nativeInit } from "./native-git-bridge.js";
+import { isInheritedRepo } from "./repo-identity.js";
 import { ensureGitignore, ensurePreferences, untrackRuntimeFiles } from "./gitignore.js";
 import { loadEffectiveGSDPreferences } from "./preferences.js";
 import { detectProjectState } from "./detection.js";
@@ -346,7 +347,7 @@ function buildHeadlessDiscussPrompt(nextId: string, seedContext: string, _basePa
  * Ensures git repo, .gsd/ structure, gitignore, and preferences all exist.
  */
 function bootstrapGsdProject(basePath: string): void {
-  if (!nativeIsRepo(basePath)) {
+  if (!nativeIsRepo(basePath) || isInheritedRepo(basePath)) {
     const mainBranch = loadEffectiveGSDPreferences()?.preferences?.git?.main_branch || "main";
     nativeInit(basePath, mainBranch);
   }
@@ -870,7 +871,10 @@ export async function showSmartEntry(
   }
 
   // ── Ensure git repo exists — GSD needs it for worktree isolation ──────
-  if (!nativeIsRepo(basePath)) {
+  // Also handle inherited repos: if basePath is a subdirectory of another
+  // git repo that has no .gsd, create a fresh repo to prevent cross-project
+  // state leaks (#1639).
+  if (!nativeIsRepo(basePath) || isInheritedRepo(basePath)) {
     const mainBranch = loadEffectiveGSDPreferences()?.preferences?.git?.main_branch || "main";
     nativeInit(basePath, mainBranch);
   }

--- a/src/resources/extensions/gsd/repo-identity.ts
+++ b/src/resources/extensions/gsd/repo-identity.ts
@@ -10,7 +10,7 @@ import { createHash } from "node:crypto";
 import { execFileSync } from "node:child_process";
 import { existsSync, lstatSync, mkdirSync, readFileSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { basename, join, resolve } from "node:path";
+import { basename, dirname, join, resolve } from "node:path";
 
 const gsdHome = process.env.GSD_HOME || join(homedir(), ".gsd");
 
@@ -92,6 +92,50 @@ export function readRepoMeta(externalPath: string): RepoMeta | null {
     return isRepoMeta(parsed) ? parsed : null;
   } catch {
     return null;
+  }
+}
+
+// ─── Inherited-Repo Detection ───────────────────────────────────────────────
+
+/**
+ * Check whether `basePath` is inheriting a parent directory's git repo
+ * rather than being the git root itself.
+ *
+ * Returns true when ALL of:
+ *   1. basePath is inside a git repo (git rev-parse succeeds)
+ *   2. The resolved git root is a proper ancestor of basePath
+ *   3. There is no `.gsd` directory at the git root (the parent project
+ *      has not been initialised with GSD)
+ *
+ * When true, the caller should run `git init` at basePath so that
+ * `repoIdentity()` produces a hash unique to this directory, preventing
+ * cross-project state leaks (#1639).
+ *
+ * When the git root already has `.gsd`, the directory is a legitimate
+ * subdirectory of an existing GSD project — `cd src/ && /gsd` should
+ * still load the parent project's milestones.
+ */
+export function isInheritedRepo(basePath: string): boolean {
+  try {
+    const root = resolveGitRoot(basePath);
+    const normalizedBase = canonicalizeExistingPath(basePath);
+    const normalizedRoot = canonicalizeExistingPath(root);
+    if (normalizedBase === normalizedRoot) return false; // basePath IS the root
+
+    // The git root is a proper ancestor. Check whether it already has .gsd
+    // (i.e. the parent project was initialised with GSD).
+    if (existsSync(join(root, ".gsd"))) return false;
+
+    // Also walk up from basePath to the git root checking for .gsd
+    let dir = normalizedBase;
+    while (dir !== normalizedRoot && dir !== dirname(dir)) {
+      if (existsSync(join(dir, ".gsd"))) return false;
+      dir = dirname(dir);
+    }
+
+    return true;
+  } catch {
+    return false;
   }
 }
 

--- a/src/resources/extensions/gsd/tests/repo-identity-worktree.test.ts
+++ b/src/resources/extensions/gsd/tests/repo-identity-worktree.test.ts
@@ -3,7 +3,7 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { execSync } from "node:child_process";
 
-import { repoIdentity, externalGsdRoot, ensureGsdSymlink, validateProjectId, readRepoMeta } from "../repo-identity.ts";
+import { repoIdentity, externalGsdRoot, ensureGsdSymlink, validateProjectId, readRepoMeta, isInheritedRepo } from "../repo-identity.ts";
 import { createTestContext } from "./test-helpers.ts";
 
 const { assertEq, assertTrue, report } = createTestContext();
@@ -116,6 +116,66 @@ async function main(): Promise<void> {
 
       rmSync(movedBase, { recursive: true, force: true });
       delete process.env.GSD_PROJECT_ID;
+    }
+
+    console.log("\n=== isInheritedRepo detects subdirectory of parent repo without .gsd (#1639) ===");
+    {
+      const parentRepo = realpathSync(mkdtempSync(join(tmpdir(), "gsd-inherited-parent-")));
+      run("git init -b main", parentRepo);
+      run('git config user.name "Pi Test"', parentRepo);
+      run('git config user.email "pi@example.com"', parentRepo);
+      writeFileSync(join(parentRepo, "README.md"), "# Parent\n", "utf-8");
+      run("git add README.md", parentRepo);
+      run('git commit -m "init"', parentRepo);
+
+      // Create a subdirectory — no .gsd at parent
+      const subdir = join(parentRepo, "newproject");
+      mkdirSync(subdir, { recursive: true });
+      assertTrue(isInheritedRepo(subdir), "subdirectory of parent repo without .gsd is inherited");
+
+      // After adding .gsd at parent, subdirectory is a legitimate child
+      mkdirSync(join(parentRepo, ".gsd"), { recursive: true });
+      assertTrue(!isInheritedRepo(subdir), "subdirectory of parent repo WITH .gsd is NOT inherited");
+
+      // The git root itself is never inherited
+      assertTrue(!isInheritedRepo(parentRepo), "git root is not inherited");
+
+      // A standalone repo (not a subdir) is not inherited
+      const standaloneRepo = realpathSync(mkdtempSync(join(tmpdir(), "gsd-inherited-standalone-")));
+      run("git init -b main", standaloneRepo);
+      run('git config user.name "Pi Test"', standaloneRepo);
+      run('git config user.email "pi@example.com"', standaloneRepo);
+      assertTrue(!isInheritedRepo(standaloneRepo), "standalone repo is not inherited");
+
+      rmSync(parentRepo, { recursive: true, force: true });
+      rmSync(standaloneRepo, { recursive: true, force: true });
+    }
+
+    console.log("\n=== subdirectory of parent repo gets unique identity after git init (#1639) ===");
+    {
+      const parentRepo = realpathSync(mkdtempSync(join(tmpdir(), "gsd-identity-parent-")));
+      run("git init -b main", parentRepo);
+      run('git config user.name "Pi Test"', parentRepo);
+      run('git config user.email "pi@example.com"', parentRepo);
+      run('git remote add origin git@github.com:example/parent-project.git', parentRepo);
+      writeFileSync(join(parentRepo, "README.md"), "# Parent\n", "utf-8");
+      run("git add README.md", parentRepo);
+      run('git commit -m "init"', parentRepo);
+
+      const subdir = join(parentRepo, "childproject");
+      mkdirSync(subdir, { recursive: true });
+
+      // Before git init, subdirectory shares parent's identity
+      const parentIdentity = repoIdentity(parentRepo);
+      const subdirIdentityBefore = repoIdentity(subdir);
+      assertEq(subdirIdentityBefore, parentIdentity, "subdirectory shares parent identity before its own git init");
+
+      // After git init, subdirectory gets its own identity
+      run("git init -b main", subdir);
+      const subdirIdentityAfter = repoIdentity(subdir);
+      assertTrue(subdirIdentityAfter !== parentIdentity, "subdirectory gets unique identity after git init");
+
+      rmSync(parentRepo, { recursive: true, force: true });
     }
 
     console.log("\n=== validateProjectId rejects invalid values ===");


### PR DESCRIPTION
## Summary
- Fixes a bug where launching GSD in a new empty directory inside an existing git repo loads milestones from the parent project
- Adds `isInheritedRepo()` to `repo-identity.ts` that detects when a directory inherits a parent repo's git root without having its own `.gsd`
- When detected, `git init` creates an independent repo so the directory gets a unique identity hash
- Legitimate subdirectory access (`cd src/` inside an existing GSD project) is preserved -- the guard only triggers when the parent repo has no `.gsd`
- All three bootstrap entry points are patched: `bootstrapAutoSession`, `bootstrapGsdProject`, and `showSmartEntry`

Closes #1639

## Test plan
- [x] `isInheritedRepo` returns true for subdirectory of parent repo without `.gsd`
- [x] `isInheritedRepo` returns false when parent repo has `.gsd` (legitimate subdir)
- [x] `isInheritedRepo` returns false for git root itself
- [x] `isInheritedRepo` returns false for standalone repo
- [x] Subdirectory gets unique identity hash after `git init`
- [x] All 34 repo-identity tests pass
- [x] Typecheck passes (`tsc --noEmit` and `typecheck:extensions`)
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)