### PR TITLE
fix: clear stale unit state and restore CWD on step-wizard exit

### DIFF
--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -535,6 +535,33 @@ function handleLostSessionLock(
   ctx?.ui.setFooter(undefined);
 }
 
+/**
+ * Lightweight cleanup after autoLoop exits via step-wizard break.
+ *
+ * Unlike stopAuto (which tears down the entire session), this only clears
+ * the stale unit state, progress widget, status badge, and restores CWD so
+ * the dashboard does not show an orphaned timer and the shell is usable.
+ */
+function cleanupAfterLoopExit(ctx: ExtensionContext): void {
+  s.currentUnit = null;
+  s.active = false;
+  clearUnitTimeout();
+
+  ctx.ui.setStatus("gsd-auto", undefined);
+  ctx.ui.setWidget("gsd-progress", undefined);
+  ctx.ui.setFooter(undefined);
+
+  // Restore CWD out of worktree back to original project root
+  if (s.originalBasePath) {
+    s.basePath = s.originalBasePath;
+    try {
+      process.chdir(s.basePath);
+    } catch {
+      /* best-effort */
+    }
+  }
+}
+
 export async function stopAuto(
   ctx?: ExtensionContext,
   pi?: ExtensionAPI,
@@ -1121,6 +1148,7 @@ export async function startAuto(
     await selfHealRuntimeRecords(s.basePath, ctx);
 
     await autoLoop(ctx, pi, s, buildLoopDeps());
+    cleanupAfterLoopExit(ctx);
     return;
   }
 
@@ -1155,6 +1183,7 @@ export async function startAuto(
 
   // Dispatch the first unit
   await autoLoop(ctx, pi, s, buildLoopDeps());
+  cleanupAfterLoopExit(ctx);
 }
 
 // ─── Agent End Handler ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- After `/gsd next` completes a unit via step-wizard, `autoLoop` breaks without cleanup — leaving `s.currentUnit` set, `s.active` true, the progress widget ticking with an increasing timer, and CWD stuck in the worktree
- Adds `cleanupAfterLoopExit()` — a lightweight teardown (unlike the full `stopAuto`) that nulls stale unit state, clears the widget/status/footer, stops the unit timeout, and restores CWD to the original project root
- Called after both `autoLoop` call sites in `startAuto` (resume path and fresh-start path)

## Test plan
- [ ] Run `/gsd next`, let a unit complete — verify dashboard no longer shows stale unit with running timer
- [ ] Verify CWD returns to project root (not stuck in worktree)
- [ ] Verify session is interactive after step-wizard exits (no kill required)
- [ ] Run `/gsd auto` — verify normal auto-mode still works end-to-end (no regression from cleanup running on normal exit)

Closes #1698

🤖 Generated with [Claude Code](https://claude.com/claude-code)