### PR TITLE
test: replace shape-only assertions with value checks

### DIFF
--- a/packages/pi-coding-agent/src/core/discovery-cache.test.ts
+++ b/packages/pi-coding-agent/src/core/discovery-cache.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, it } from "node:test";
@@ -59,7 +59,9 @@ describe("ModelDiscoveryCache — basic operations", () => {
 
 		cache.clear("openai");
 		assert.equal(cache.get("openai"), undefined);
-		assert.ok(cache.get("google"));
+		const googleEntry = cache.get("google");
+		assert.ok(googleEntry);
+		assert.equal(googleEntry.models[0].id, "gemini-pro");
 	});
 
 	it("clear without provider removes all entries", () => {

--- a/src/resources/extensions/gsd/tests/skill-lifecycle.test.ts
+++ b/src/resources/extensions/gsd/tests/skill-lifecycle.test.ts
@@ -3,7 +3,7 @@
  * Tests the pure functions — no file I/O, no extension context.
  */
 
-import { describe, it, beforeEach } from "node:test";
+import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import type { UnitMetrics } from "../metrics.js";
 
@@ -72,7 +72,7 @@ describe("skill-health", () => {
 
     // With no metrics file, should return empty
     const result = computeStaleAvoidList("/nonexistent/path", ["some-skill"]);
-    assert.ok(Array.isArray(result));
+    assert.deepEqual(result, []);
   });
 });
 

--- a/src/tests/blob-store.test.ts
+++ b/src/tests/blob-store.test.ts
@@ -71,7 +71,6 @@ test('get retrieves stored data', () => {
 		const { hash } = store.put(data)
 		const retrieved = store.get(hash)
 
-		assert.ok(retrieved)
 		assert.deepEqual(retrieved, data)
 	} finally {
 		cleanup()

--- a/src/tests/web-diagnostics-contract.test.ts
+++ b/src/tests/web-diagnostics-contract.test.ts
@@ -72,9 +72,9 @@ describe("diagnostics type exports", () => {
     }
     assert.equal(typeof report.gsdVersion, "string")
     assert.equal(typeof report.timestamp, "string")
-    assert.ok(Array.isArray(report.anomalies))
-    assert.ok(Array.isArray(report.recentUnits))
-    assert.ok(Array.isArray(report.unitTraces))
+    assert.deepEqual(report.anomalies, [])
+    assert.deepEqual(report.recentUnits, [])
+    assert.deepEqual(report.unitTraces, [])
     assert.equal(report.crashLock, null)
     assert.equal(typeof report.doctorIssueCount, "number")
     assert.equal(typeof report.unitTraceCount, "number")
@@ -142,18 +142,17 @@ describe("diagnostics type exports", () => {
       summary: { total: 0, errors: 0, warnings: 0, infos: 0, fixable: 0, byCode: [] },
     }
     assert.equal(typeof report.ok, "boolean")
-    assert.ok(Array.isArray(report.issues))
-    assert.ok(Array.isArray(report.fixesApplied))
+    assert.deepEqual(report.issues, [])
+    assert.deepEqual(report.fixesApplied, [])
     assert.equal(typeof report.summary.total, "number")
     assert.equal(typeof report.summary.fixable, "number")
-    assert.ok(Array.isArray(report.summary.byCode))
+    assert.deepEqual(report.summary.byCode, [])
   })
 
   it("DoctorFixResult has required fields", () => {
     const fix: DoctorFixResult = { ok: true, fixesApplied: ["fix1"] }
     assert.equal(typeof fix.ok, "boolean")
-    assert.ok(Array.isArray(fix.fixesApplied))
-    assert.equal(fix.fixesApplied.length, 1)
+    assert.deepEqual(fix.fixesApplied, ["fix1"])
   })
 
   it("SkillHealthEntry has required fields", () => {
@@ -200,10 +199,10 @@ describe("diagnostics type exports", () => {
     }
     assert.equal(typeof report.generatedAt, "string")
     assert.equal(typeof report.totalUnitsWithSkills, "number")
-    assert.ok(Array.isArray(report.skills))
-    assert.ok(Array.isArray(report.staleSkills))
-    assert.ok(Array.isArray(report.decliningSkills))
-    assert.ok(Array.isArray(report.suggestions))
+    assert.deepEqual(report.skills, [])
+    assert.deepEqual(report.staleSkills, [])
+    assert.deepEqual(report.decliningSkills, [])
+    assert.deepEqual(report.suggestions, [])
   })
 })
 
@@ -311,10 +310,10 @@ describe("diagnostics surface→section mapping", () => {
 
 // Compile-time assertion: if any of these method names were removed from the
 // class, TypeScript would error on these type aliases.
-type _AssertLoadForensics = GSDWorkspaceStore["loadForensicsDiagnostics"]
-type _AssertLoadDoctor = GSDWorkspaceStore["loadDoctorDiagnostics"]
-type _AssertApplyFixes = GSDWorkspaceStore["applyDoctorFixes"]
-type _AssertLoadSkillHealth = GSDWorkspaceStore["loadSkillHealthDiagnostics"]
+type _AssertLoadForensics = InstanceType<typeof GSDWorkspaceStore>["loadForensicsDiagnostics"]
+type _AssertLoadDoctor = InstanceType<typeof GSDWorkspaceStore>["loadDoctorDiagnostics"]
+type _AssertApplyFixes = InstanceType<typeof GSDWorkspaceStore>["applyDoctorFixes"]
+type _AssertLoadSkillHealth = InstanceType<typeof GSDWorkspaceStore>["loadSkillHealthDiagnostics"]
 
 describe("diagnostics store methods", () => {
   it("GSDWorkspaceStore is a constructable class export", () => {
@@ -326,22 +325,22 @@ describe("diagnostics store methods", () => {
     // field exists. At runtime, arrow-field methods are on instances, not
     // prototype. We verify the field name appears in the actions Pick type by
     // checking the useGSDWorkspaceActions hook references it in the exports.
-    const methodName: keyof Pick<GSDWorkspaceStore, "loadForensicsDiagnostics"> = "loadForensicsDiagnostics"
+    const methodName: keyof Pick<InstanceType<typeof GSDWorkspaceStore>, "loadForensicsDiagnostics"> = "loadForensicsDiagnostics"
     assert.equal(methodName, "loadForensicsDiagnostics")
   })
 
   it("loadDoctorDiagnostics is a recognized method name on the store type", () => {
-    const methodName: keyof Pick<GSDWorkspaceStore, "loadDoctorDiagnostics"> = "loadDoctorDiagnostics"
+    const methodName: keyof Pick<InstanceType<typeof GSDWorkspaceStore>, "loadDoctorDiagnostics"> = "loadDoctorDiagnostics"
     assert.equal(methodName, "loadDoctorDiagnostics")
   })
 
   it("applyDoctorFixes is a recognized method name on the store type", () => {
-    const methodName: keyof Pick<GSDWorkspaceStore, "applyDoctorFixes"> = "applyDoctorFixes"
+    const methodName: keyof Pick<InstanceType<typeof GSDWorkspaceStore>, "applyDoctorFixes"> = "applyDoctorFixes"
     assert.equal(methodName, "applyDoctorFixes")
   })
 
   it("loadSkillHealthDiagnostics is a recognized method name on the store type", () => {
-    const methodName: keyof Pick<GSDWorkspaceStore, "loadSkillHealthDiagnostics"> = "loadSkillHealthDiagnostics"
+    const methodName: keyof Pick<InstanceType<typeof GSDWorkspaceStore>, "loadSkillHealthDiagnostics"> = "loadSkillHealthDiagnostics"
     assert.equal(methodName, "loadSkillHealthDiagnostics")
   })
 })


### PR DESCRIPTION
## TL;DR

**What:** Replace `assert.ok(Array.isArray(x))` and `assert.ok(result)` patterns with actual value assertions.
**Why:** Shape-only assertions pass even when code returns wrong data — false coverage.
**How:** Swap `Array.isArray` checks for `deepEqual`, remove redundant null guards, expand existence checks to verify content.

## What

Changes across 4 test files:

- `src/tests/web-diagnostics-contract.test.ts` — 11× `Array.isArray()` → `deepEqual(x, [])` for fields constructed as empty arrays; `DoctorFixResult` uses `deepEqual(["fix1"])` instead of `Array.isArray + length`; fix `InstanceType<typeof GSDWorkspaceStore>` for type assertions from dynamic import
- `src/resources/extensions/gsd/tests/skill-lifecycle.test.ts` — `Array.isArray(result)` → `deepEqual(result, [])` since nonexistent path must return empty
- `src/tests/blob-store.test.ts` — remove redundant `assert.ok(retrieved)` immediately before `deepEqual(retrieved, data)`
- `packages/pi-coding-agent/src/core/discovery-cache.test.ts` — `assert.ok(entry)` existence check → verify `models[0].id`

## Why

Tests that only check `typeof x === 'array'` or that something isn't null pass even when the underlying code returns incorrect values. This is false coverage: the test runs, the test passes, the bug ships.

Closes #1874

## How

Mechanical substitution — wherever the constructed value is known (e.g. `anomalies: []`), replace `Array.isArray` with `deepEqual(x, [])`. For the null guards, `deepEqual` already throws on null so the `assert.ok` is redundant noise.

---

- [x] `test` — Adding or updating tests

> AI-assisted: PR generated with Claude Code.