### PR TITLE
fix: doctor cache staleness causes repeated identical output on fix runs

### DIFF
--- a/src/resources/extensions/gsd/doctor.ts
+++ b/src/resources/extensions/gsd/doctor.ts
@@ -475,6 +475,12 @@ export async function readDoctorHistory(basePath: string, lastN = 50): Promise<D
 }
 
 export async function runGSDDoctor(basePath: string, options?: { fix?: boolean; dryRun?: boolean; scope?: string; fixLevel?: "task" | "all"; isolationMode?: "none" | "worktree" | "branch"; includeBuild?: boolean; includeTests?: boolean }): Promise<DoctorReport> {
+  // Always start from a clean slate. The extension process persists module-level
+  // caches (dirEntryCache, _parseCache, _stateCache) across calls. Without this,
+  // a second doctor run in the same session reads stale cached directory listings
+  // and detects the same issues that the first run already fixed on disk (#FIXME).
+  invalidateAllCaches();
+
   const issues: DoctorIssue[] = [];
   const fixesApplied: string[] = [];
   const fix = options?.fix === true;
@@ -1013,6 +1019,11 @@ export async function runGSDDoctor(basePath: string, options?: { fix?: boolean; 
   }
 
   if (fix && !dryRun && fixesApplied.length > 0) {
+    // Invalidate before rebuilding STATE.md so deriveState() reads the files
+    // doctor just wrote (stub summaries, checked roadmap boxes, etc.) rather
+    // than the cached pre-fix snapshot. Without this, STATE.md can be written
+    // with data that predates the fixes applied in this same run.
+    invalidateAllCaches();
     await updateStateFile(basePath, fixesApplied);
   }
 

--- a/src/resources/extensions/gsd/tests/doctor.test.ts
+++ b/src/resources/extensions/gsd/tests/doctor.test.ts
@@ -106,6 +106,21 @@ async function main(): Promise<void> {
     assertTrue(state.includes("# GSD State"), "writes state file");
   }
 
+  // Idempotency: a second fix run on the same base must report no errors.
+  // This regresses the cache staleness bug where module-level dirEntryCache /
+  // _parseCache retained pre-fix directory listings across calls, causing the
+  // same issues to be re-detected even though the first run had written the
+  // fix artifacts to disk.
+  console.log("\n=== doctor fix idempotency (second run must be clean) ===");
+  {
+    const report2 = await runGSDDoctor(tmpBase, { fix: true });
+    const errors2 = report2.issues.filter(i => i.severity === "error");
+    if (errors2.length > 0) {
+      console.error("second doctor run still has errors:", errors2.map(i => i.code));
+    }
+    assertTrue(errors2.length === 0, "second fix run finds no errors — caches were properly invalidated between runs");
+  }
+
   rmSync(tmpBase, { recursive: true, force: true });
 
   // ─── Milestone summary detection: missing summary ──────────────────────


### PR DESCRIPTION
## Root Cause

`runGSDDoctor` never invalidated module-level caches before reading. The extension process is long-lived, so `dirEntryCache`, `_parseCache`, and `_stateCache` in `paths.ts` / `files.ts` / `state.ts` persist across command invocations within the same session.

**What happened:**
1. First `/gsd doctor fix` run — reads slice dir, `S02-SUMMARY.md` doesn't exist → **cached as absent**
2. Fix runs → creates `S02-SUMMARY.md` on disk ✓
3. Second run — `resolveSliceFile()` reads from **stale cache** → `S02-SUMMARY.md` still appears absent → same 2 errors re-detected → stub overwritten again → identical output

**Secondary bug:** `updateStateFile()` at the end of `runGSDDoctor` calls `deriveState()` while caches still reflect the pre-fix snapshot. STATE.md was being rebuilt from data that didn't include the files doctor just created.

## Changes

### `doctor.ts`
- **`invalidateAllCaches()` at top of `runGSDDoctor`** — ensures every call reads fresh state from disk regardless of prior cached calls in the session
- **`invalidateAllCaches()` before `updateStateFile`** — ensures `deriveState()` sees stub summaries, checked roadmap boxes, and other artifacts written in this run before STATE.md is rebuilt

### `tests/doctor.test.ts`
- **Idempotency regression test** — calls `runGSDDoctor({ fix: true })` twice on the same fixture; asserts the second run returns zero errors

## Investigation Details

Five callers of `runGSDDoctor` exist. Only `auto-post-unit.ts` (line 113) calls `invalidateAllCaches()` before the doctor, and only in certain branches — never after. Interactive commands (`commands-handlers.ts`) had no invalidation at all.

Doctor writes ~10 files per fix run:
- Slice summary stubs, UAT stubs
- Plan file checkbox updates
- Roadmap checkbox updates  
- STATE.md
- `.gitignore` pattern additions

All of these require cache invalidation to be visible to subsequent reads.

## Test Plan
- [ ] Run `/gsd doctor fix` twice in the same session on a project with `all_tasks_done_missing_slice_summary` — second run should report no errors
- [ ] Run existing doctor test suite: `npm run test:unit`
- [ ] Confirm `S02-SUMMARY.md` (or equivalent) is created once, not overwritten on every run

🤖 Generated with [Claude Code](https://claude.com/claude-code)