### PR TITLE
refactor(web): consolidate subprocess boilerplate into shared runner

### DIFF
--- a/src/web/auto-dashboard-service.ts
+++ b/src/web/auto-dashboard-service.ts
@@ -1,12 +1,12 @@
-import { execFile } from "node:child_process";
 import { existsSync } from "node:fs";
 import { join } from "node:path";
-import { pathToFileURL } from "node:url";
 
 import type { AutoDashboardData } from "./bridge-service.ts";
-import { resolveTypeStrippingFlag } from "./ts-subprocess-flags.ts"
+import { resolveSubprocessModule } from "./subprocess-module-resolver.ts";
+import { runSubprocess } from "./subprocess-runner.ts";
 
 const AUTO_DASHBOARD_MAX_BUFFER = 1024 * 1024;
+const AUTO_DASHBOARD_TIMEOUT_MS = 10_000;
 const TEST_AUTO_DASHBOARD_MODULE_ENV = "GSD_WEB_TEST_AUTO_DASHBOARD_MODULE";
 const TEST_AUTO_DASHBOARD_FALLBACK_ENV = "GSD_WEB_TEST_USE_FALLBACK_AUTO_DASHBOARD";
 const AUTO_DASHBOARD_MODULE_ENV = "GSD_AUTO_DASHBOARD_MODULE";
@@ -32,14 +32,6 @@ function fallbackAutoDashboardData(): AutoDashboardData {
   };
 }
 
-function resolveAutoDashboardModulePath(packageRoot: string, env: NodeJS.ProcessEnv): string {
-  return env[TEST_AUTO_DASHBOARD_MODULE_ENV] || join(packageRoot, "src", "resources", "extensions", "gsd", "auto.ts");
-}
-
-function resolveTsLoaderPath(packageRoot: string): string {
-  return join(packageRoot, "src", "resources", "extensions", "gsd", "tests", "resolve-ts.mjs");
-}
-
 export function collectTestOnlyFallbackAutoDashboardData(): AutoDashboardData {
   return fallbackAutoDashboardData();
 }
@@ -54,11 +46,35 @@ export async function collectAuthoritativeAutoDashboardData(
   }
 
   const checkExists = options.existsSync ?? existsSync;
-  const resolveTsLoader = resolveTsLoaderPath(packageRoot);
-  const autoModulePath = resolveAutoDashboardModulePath(packageRoot, env);
 
-  if (!checkExists(resolveTsLoader) || !checkExists(autoModulePath)) {
-    throw new Error(`authoritative auto dashboard provider not found; checked=${resolveTsLoader},${autoModulePath}`);
+  // When a test override module is set, it is a .ts file that must go through
+  // the ts-loader path. Build the module path manually and bypass the
+  // resolver's compiled-first logic.
+  const testOverridePath = env[TEST_AUTO_DASHBOARD_MODULE_ENV];
+  let resolved;
+  if (testOverridePath) {
+    const tsLoaderPath = join(
+      packageRoot,
+      "src",
+      "resources",
+      "extensions",
+      "gsd",
+      "tests",
+      "resolve-ts.mjs",
+    );
+    const { pathToFileURL } = await import("node:url");
+    resolved = {
+      modulePath: testOverridePath,
+      nodeArgs: [
+        "--import",
+        pathToFileURL(tsLoaderPath).href,
+        "--experimental-strip-types",
+        "--input-type=module",
+        "--eval",
+      ],
+    };
+  } else {
+    resolved = resolveSubprocessModule(packageRoot, "auto.ts", checkExists);
   }
 
   const script = [
@@ -68,41 +84,18 @@ export async function collectAuthoritativeAutoDashboardData(
     'process.stdout.write(JSON.stringify(result));',
   ].join(" ");
 
-  return await new Promise<AutoDashboardData>((resolveResult, reject) => {
-    execFile(
-      options.execPath ?? process.execPath,
-      [
-        "--import",
-        pathToFileURL(resolveTsLoader).href,
-        resolveTypeStrippingFlag(packageRoot),
-        "--input-type=module",
-        "--eval",
-        script,
-      ],
-      {
-        cwd: packageRoot,
-        env: {
-          ...env,
-          [AUTO_DASHBOARD_MODULE_ENV]: autoModulePath,
-        },
-        maxBuffer: AUTO_DASHBOARD_MAX_BUFFER,
+  return runSubprocess<AutoDashboardData>(
+    options.execPath ?? process.execPath,
+    [...resolved.nodeArgs, script],
+    {
+      cwd: packageRoot,
+      env: {
+        ...env,
+        [AUTO_DASHBOARD_MODULE_ENV]: resolved.modulePath,
       },
-      (error, stdout, stderr) => {
-        if (error) {
-          reject(new Error(`authoritative auto dashboard subprocess failed: ${stderr || error.message}`));
-          return;
-        }
-
-        try {
-          resolveResult(JSON.parse(stdout) as AutoDashboardData);
-        } catch (parseError) {
-          reject(
-            new Error(
-              `authoritative auto dashboard subprocess returned invalid JSON: ${parseError instanceof Error ? parseError.message : String(parseError)}`,
-            ),
-          );
-        }
-      },
-    );
-  });
+      maxBuffer: AUTO_DASHBOARD_MAX_BUFFER,
+      timeout: AUTO_DASHBOARD_TIMEOUT_MS,
+    },
+    "authoritative auto dashboard",
+  );
 }

--- a/src/web/bridge-service.ts
+++ b/src/web/bridge-service.ts
@@ -4,7 +4,6 @@ import { StringDecoder } from "node:string_decoder";
 import type { Readable } from "node:stream";
 import { join, resolve, dirname } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
-import { resolveTypeStrippingFlag } from "./ts-subprocess-flags.ts";
 
 import type { AgentSessionEvent, SessionStateChangeReason } from "../../packages/pi-coding-agent/src/core/agent-session.ts";
 import type {
@@ -38,6 +37,7 @@ import {
   collectTestOnlyFallbackAutoDashboardData,
 } from "./auto-dashboard-service.ts";
 import { resolveGsdCliEntry } from "./cli-entry.ts";
+import { resolveSubprocessModule } from "./subprocess-module-resolver.ts";
 
 const DEFAULT_PACKAGE_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
 const RESPONSE_TIMEOUT_MS = 30_000;
@@ -905,12 +905,8 @@ async function loadCachedWorkspaceIndex(
 
 async function loadWorkspaceIndexViaChildProcess(basePath: string, packageRoot: string): Promise<GSDWorkspaceIndex> {
   const deps = getBridgeDeps();
-  const resolveTsLoader = join(packageRoot, "src", "resources", "extensions", "gsd", "tests", "resolve-ts.mjs");
-  const workspaceModulePath = join(packageRoot, "src", "resources", "extensions", "gsd", "workspace-index.ts");
   const checkExists = deps.existsSync ?? existsSync;
-  if (!checkExists(resolveTsLoader) || !checkExists(workspaceModulePath)) {
-    throw new Error(`workspace index loader not found; checked=${resolveTsLoader},${workspaceModulePath}`);
-  }
+  const resolved = resolveSubprocessModule(packageRoot, "workspace-index.ts", checkExists);
 
   const script = [
     'const { pathToFileURL } = await import("node:url");',
@@ -922,19 +918,12 @@ async function loadWorkspaceIndexViaChildProcess(basePath: string, packageRoot: 
   return await new Promise<GSDWorkspaceIndex>((resolveResult, reject) => {
     execFile(
       deps.execPath ?? process.execPath,
-      [
-        "--import",
-        pathToFileURL(resolveTsLoader).href,
-        resolveTypeStrippingFlag(packageRoot),
-        "--input-type=module",
-        "--eval",
-        script,
-      ],
+      [...resolved.nodeArgs, script],
       {
         cwd: packageRoot,
         env: {
           ...(deps.env ?? process.env),
-          GSD_WORKSPACE_MODULE: workspaceModulePath,
+          GSD_WORKSPACE_MODULE: resolved.modulePath,
           GSD_WORKSPACE_BASE: basePath,
         },
         maxBuffer: 1024 * 1024,

--- a/src/web/captures-service.ts
+++ b/src/web/captures-service.ts
@@ -1,22 +1,13 @@
-import { execFile } from "node:child_process"
-import { existsSync } from "node:fs"
-import { join } from "node:path"
-import { pathToFileURL } from "node:url"
-
 import { resolveBridgeRuntimeConfig } from "./bridge-service.ts"
-import { resolveTypeStrippingFlag } from "./ts-subprocess-flags.ts"
+import { resolveSubprocessModule } from "./subprocess-module-resolver.ts"
+import { runSubprocess } from "./subprocess-runner.ts"
 import type { CapturesData, CaptureResolveRequest, CaptureResolveResult } from "../../web/lib/knowledge-captures-types.ts"
 
 const CAPTURES_MAX_BUFFER = 2 * 1024 * 1024
+const CAPTURES_TIMEOUT_MS = 15_000
 const CAPTURES_MODULE_ENV = "GSD_CAPTURES_MODULE"
 
-function resolveCapturesModulePath(packageRoot: string): string {
-  return join(packageRoot, "src", "resources", "extensions", "gsd", "captures.ts")
-}
 
-function resolveTsLoaderPath(packageRoot: string): string {
-  return join(packageRoot, "src", "resources", "extensions", "gsd", "tests", "resolve-ts.mjs")
-}
 
 /**
  * Loads all capture entries via a child process. The child imports the upstream
@@ -26,15 +17,7 @@ function resolveTsLoaderPath(packageRoot: string): string {
 export async function collectCapturesData(projectCwdOverride?: string): Promise<CapturesData> {
   const config = resolveBridgeRuntimeConfig(undefined, projectCwdOverride)
   const { packageRoot, projectCwd } = config
-
-  const resolveTsLoader = resolveTsLoaderPath(packageRoot)
-  const capturesModulePath = resolveCapturesModulePath(packageRoot)
-
-  if (!existsSync(resolveTsLoader) || !existsSync(capturesModulePath)) {
-    throw new Error(
-      `captures data provider not found; checked=${resolveTsLoader},${capturesModulePath}`,
-    )
-  }
+  const resolved = resolveSubprocessModule(packageRoot, "captures.ts")
 
   const script = [
     'const { pathToFileURL } = await import("node:url");',
@@ -46,44 +29,21 @@ export async function collectCapturesData(projectCwdOverride?: string): Promise<
     'process.stdout.write(JSON.stringify(result));',
   ].join(" ")
 
-  return await new Promise<CapturesData>((resolveResult, reject) => {
-    execFile(
-      process.execPath,
-      [
-        "--import",
-        pathToFileURL(resolveTsLoader).href,
-        resolveTypeStrippingFlag(packageRoot),
-        "--input-type=module",
-        "--eval",
-        script,
-      ],
-      {
-        cwd: packageRoot,
-        env: {
-          ...process.env,
-          [CAPTURES_MODULE_ENV]: capturesModulePath,
-          GSD_CAPTURES_BASE: projectCwd,
-        },
-        maxBuffer: CAPTURES_MAX_BUFFER,
+  return runSubprocess<CapturesData>(
+    process.execPath,
+    [...resolved.nodeArgs, script],
+    {
+      cwd: packageRoot,
+      env: {
+        ...process.env,
+        [CAPTURES_MODULE_ENV]: resolved.modulePath,
+        GSD_CAPTURES_BASE: projectCwd,
       },
-      (error, stdout, stderr) => {
-        if (error) {
-          reject(new Error(`captures data subprocess failed: ${stderr || error.message}`))
-          return
-        }
-
-        try {
-          resolveResult(JSON.parse(stdout) as CapturesData)
-        } catch (parseError) {
-          reject(
-            new Error(
-              `captures data subprocess returned invalid JSON: ${parseError instanceof Error ? parseError.message : String(parseError)}`,
-            ),
-          )
-        }
-      },
-    )
-  })
+      maxBuffer: CAPTURES_MAX_BUFFER,
+      timeout: CAPTURES_TIMEOUT_MS,
+    },
+    "captures data",
+  )
 }
 
 /**
@@ -93,15 +53,7 @@ export async function collectCapturesData(projectCwdOverride?: string): Promise<
 export async function resolveCaptureAction(request: CaptureResolveRequest, projectCwdOverride?: string): Promise<CaptureResolveResult> {
   const config = resolveBridgeRuntimeConfig(undefined, projectCwdOverride)
   const { packageRoot, projectCwd } = config
-
-  const resolveTsLoader = resolveTsLoaderPath(packageRoot)
-  const capturesModulePath = resolveCapturesModulePath(packageRoot)
-
-  if (!existsSync(resolveTsLoader) || !existsSync(capturesModulePath)) {
-    throw new Error(
-      `captures data provider not found; checked=${resolveTsLoader},${capturesModulePath}`,
-    )
-  }
+  const resolved = resolveSubprocessModule(packageRoot, "captures.ts")
 
   const safeId = JSON.stringify(request.captureId)
   const safeClassification = JSON.stringify(request.classification)
@@ -115,42 +67,19 @@ export async function resolveCaptureAction(request: CaptureResolveRequest, proje
     `process.stdout.write(JSON.stringify({ ok: true, captureId: ${safeId} }));`,
   ].join(" ")
 
-  return await new Promise<CaptureResolveResult>((resolveResult, reject) => {
-    execFile(
-      process.execPath,
-      [
-        "--import",
-        pathToFileURL(resolveTsLoader).href,
-        resolveTypeStrippingFlag(packageRoot),
-        "--input-type=module",
-        "--eval",
-        script,
-      ],
-      {
-        cwd: packageRoot,
-        env: {
-          ...process.env,
-          [CAPTURES_MODULE_ENV]: capturesModulePath,
-          GSD_CAPTURES_BASE: projectCwd,
-        },
-        maxBuffer: CAPTURES_MAX_BUFFER,
+  return runSubprocess<CaptureResolveResult>(
+    process.execPath,
+    [...resolved.nodeArgs, script],
+    {
+      cwd: packageRoot,
+      env: {
+        ...process.env,
+        [CAPTURES_MODULE_ENV]: resolved.modulePath,
+        GSD_CAPTURES_BASE: projectCwd,
       },
-      (error, stdout, stderr) => {
-        if (error) {
-          reject(new Error(`capture resolve subprocess failed: ${stderr || error.message}`))
-          return
-        }
-
-        try {
-          resolveResult(JSON.parse(stdout) as CaptureResolveResult)
-        } catch (parseError) {
-          reject(
-            new Error(
-              `capture resolve subprocess returned invalid JSON: ${parseError instanceof Error ? parseError.message : String(parseError)}`,
-            ),
-          )
-        }
-      },
-    )
-  })
+      maxBuffer: CAPTURES_MAX_BUFFER,
+      timeout: CAPTURES_TIMEOUT_MS,
+    },
+    "capture resolve",
+  )
 }

--- a/src/web/cleanup-service.ts
+++ b/src/web/cleanup-service.ts
@@ -1,22 +1,13 @@
-import { execFile } from "node:child_process"
-import { existsSync } from "node:fs"
-import { join } from "node:path"
-import { pathToFileURL } from "node:url"
-
 import { resolveBridgeRuntimeConfig } from "./bridge-service.ts"
-import { resolveTypeStrippingFlag } from "./ts-subprocess-flags.ts"
+import { resolveSubprocessModule } from "./subprocess-module-resolver.ts"
+import { runSubprocess } from "./subprocess-runner.ts"
 import type { CleanupData, CleanupResult } from "../../web/lib/remaining-command-types.ts"
 
 const CLEANUP_MAX_BUFFER = 2 * 1024 * 1024
+const CLEANUP_TIMEOUT_MS = 20_000
 const CLEANUP_MODULE_ENV = "GSD_CLEANUP_MODULE"
 
-function resolveCleanupModulePath(packageRoot: string): string {
-  return join(packageRoot, "src", "resources", "extensions", "gsd", "native-git-bridge.ts")
-}
 
-function resolveTsLoaderPath(packageRoot: string): string {
-  return join(packageRoot, "src", "resources", "extensions", "gsd", "tests", "resolve-ts.mjs")
-}
 
 /**
  * Collects cleanup data (GSD branches and snapshot refs) via a child process.
@@ -26,15 +17,7 @@ function resolveTsLoaderPath(packageRoot: string): string {
 export async function collectCleanupData(projectCwdOverride?: string): Promise<CleanupData> {
   const config = resolveBridgeRuntimeConfig(undefined, projectCwdOverride)
   const { packageRoot, projectCwd } = config
-
-  const resolveTsLoader = resolveTsLoaderPath(packageRoot)
-  const cleanupModulePath = resolveCleanupModulePath(packageRoot)
-
-  if (!existsSync(resolveTsLoader) || !existsSync(cleanupModulePath)) {
-    throw new Error(
-      `cleanup data provider not found; checked=${resolveTsLoader},${cleanupModulePath}`,
-    )
-  }
+  const resolved = resolveSubprocessModule(packageRoot, "native-git-bridge.ts")
 
   const script = [
     'const { pathToFileURL } = await import("node:url");',
@@ -60,44 +43,21 @@ export async function collectCleanupData(projectCwdOverride?: string): Promise<C
     'process.stdout.write(JSON.stringify({ branches: branchList, snapshots: snapshotList }));',
   ].join(" ")
 
-  return await new Promise<CleanupData>((resolveResult, reject) => {
-    execFile(
-      process.execPath,
-      [
-        "--import",
-        pathToFileURL(resolveTsLoader).href,
-        resolveTypeStrippingFlag(packageRoot),
-        "--input-type=module",
-        "--eval",
-        script,
-      ],
-      {
-        cwd: packageRoot,
-        env: {
-          ...process.env,
-          [CLEANUP_MODULE_ENV]: cleanupModulePath,
-          GSD_CLEANUP_BASE: projectCwd,
-        },
-        maxBuffer: CLEANUP_MAX_BUFFER,
+  return runSubprocess<CleanupData>(
+    process.execPath,
+    [...resolved.nodeArgs, script],
+    {
+      cwd: packageRoot,
+      env: {
+        ...process.env,
+        [CLEANUP_MODULE_ENV]: resolved.modulePath,
+        GSD_CLEANUP_BASE: projectCwd,
       },
-      (error, stdout, stderr) => {
-        if (error) {
-          reject(new Error(`cleanup data subprocess failed: ${stderr || error.message}`))
-          return
-        }
-
-        try {
-          resolveResult(JSON.parse(stdout) as CleanupData)
-        } catch (parseError) {
-          reject(
-            new Error(
-              `cleanup data subprocess returned invalid JSON: ${parseError instanceof Error ? parseError.message : String(parseError)}`,
-            ),
-          )
-        }
-      },
-    )
-  })
+      maxBuffer: CLEANUP_MAX_BUFFER,
+      timeout: CLEANUP_TIMEOUT_MS,
+    },
+    "cleanup data",
+  )
 }
 
 /**
@@ -112,15 +72,7 @@ export async function executeCleanup(
 ): Promise<CleanupResult> {
   const config = resolveBridgeRuntimeConfig(undefined, projectCwdOverride)
   const { packageRoot, projectCwd } = config
-
-  const resolveTsLoader = resolveTsLoaderPath(packageRoot)
-  const cleanupModulePath = resolveCleanupModulePath(packageRoot)
-
-  if (!existsSync(resolveTsLoader) || !existsSync(cleanupModulePath)) {
-    throw new Error(
-      `cleanup service modules not found; checked=${resolveTsLoader},${cleanupModulePath}`,
-    )
-  }
+  const resolved = resolveSubprocessModule(packageRoot, "native-git-bridge.ts")
 
   const script = [
     'const { pathToFileURL } = await import("node:url");',
@@ -147,44 +99,21 @@ export async function executeCleanup(
     'process.stdout.write(JSON.stringify({ deletedBranches, prunedSnapshots, message }));',
   ].join(" ")
 
-  return await new Promise<CleanupResult>((resolveResult, reject) => {
-    execFile(
-      process.execPath,
-      [
-        "--import",
-        pathToFileURL(resolveTsLoader).href,
-        resolveTypeStrippingFlag(packageRoot),
-        "--input-type=module",
-        "--eval",
-        script,
-      ],
-      {
-        cwd: packageRoot,
-        env: {
-          ...process.env,
-          [CLEANUP_MODULE_ENV]: cleanupModulePath,
-          GSD_CLEANUP_BASE: projectCwd,
-          GSD_CLEANUP_BRANCHES: JSON.stringify(deleteBranches),
-          GSD_CLEANUP_SNAPSHOTS: JSON.stringify(pruneSnapshots),
-        },
-        maxBuffer: CLEANUP_MAX_BUFFER,
+  return runSubprocess<CleanupResult>(
+    process.execPath,
+    [...resolved.nodeArgs, script],
+    {
+      cwd: packageRoot,
+      env: {
+        ...process.env,
+        [CLEANUP_MODULE_ENV]: resolved.modulePath,
+        GSD_CLEANUP_BASE: projectCwd,
+        GSD_CLEANUP_BRANCHES: JSON.stringify(deleteBranches),
+        GSD_CLEANUP_SNAPSHOTS: JSON.stringify(pruneSnapshots),
       },
-      (error, stdout, stderr) => {
-        if (error) {
-          reject(new Error(`cleanup subprocess failed: ${stderr || error.message}`))
-          return
-        }
-
-        try {
-          resolveResult(JSON.parse(stdout) as CleanupResult)
-        } catch (parseError) {
-          reject(
-            new Error(
-              `cleanup subprocess returned invalid JSON: ${parseError instanceof Error ? parseError.message : String(parseError)}`,
-            ),
-          )
-        }
-      },
-    )
-  })
+      maxBuffer: CLEANUP_MAX_BUFFER,
+      timeout: CLEANUP_TIMEOUT_MS,
+    },
+    "cleanup",
+  )
 }

--- a/src/web/doctor-service.ts
+++ b/src/web/doctor-service.ts
@@ -1,73 +1,11 @@
-import { execFile } from "node:child_process"
-import { existsSync } from "node:fs"
-import { join } from "node:path"
-import { pathToFileURL } from "node:url"
-
 import { resolveBridgeRuntimeConfig } from "./bridge-service.ts"
-import { resolveTypeStrippingFlag } from "./ts-subprocess-flags.ts"
+import { resolveSubprocessModule } from "./subprocess-module-resolver.ts"
+import { runSubprocess } from "./subprocess-runner.ts"
 import type { DoctorReport, DoctorFixResult } from "../../web/lib/diagnostics-types.ts"
 
 const DOCTOR_MAX_BUFFER = 2 * 1024 * 1024
+const DOCTOR_TIMEOUT_MS = 45_000
 const DOCTOR_MODULE_ENV = "GSD_DOCTOR_MODULE"
-
-function resolveDoctorModulePath(packageRoot: string): string {
-  return join(packageRoot, "src", "resources", "extensions", "gsd", "doctor.ts")
-}
-
-function resolveTsLoaderPath(packageRoot: string): string {
-  return join(packageRoot, "src", "resources", "extensions", "gsd", "tests", "resolve-ts.mjs")
-}
-
-function validateModulePaths(
-  resolveTsLoader: string,
-  doctorModulePath: string,
-): void {
-  if (!existsSync(resolveTsLoader) || !existsSync(doctorModulePath)) {
-    throw new Error(
-      `doctor data provider not found; checked=${resolveTsLoader},${doctorModulePath}`,
-    )
-  }
-}
-
-function runDoctorChild(
-  packageRoot: string,
-  projectCwd: string,
-  script: string,
-  resolveTsLoader: string,
-  doctorModulePath: string,
-  scope?: string,
-): Promise<string> {
-  return new Promise<string>((resolveResult, reject) => {
-    execFile(
-      process.execPath,
-      [
-        "--import",
-        pathToFileURL(resolveTsLoader).href,
-        resolveTypeStrippingFlag(packageRoot),
-        "--input-type=module",
-        "--eval",
-        script,
-      ],
-      {
-        cwd: packageRoot,
-        env: {
-          ...process.env,
-          [DOCTOR_MODULE_ENV]: doctorModulePath,
-          GSD_DOCTOR_BASE: projectCwd,
-          GSD_DOCTOR_SCOPE: scope ?? "",
-        },
-        maxBuffer: DOCTOR_MAX_BUFFER,
-      },
-      (error, stdout, stderr) => {
-        if (error) {
-          reject(new Error(`doctor subprocess failed: ${stderr || error.message}`))
-          return
-        }
-        resolveResult(stdout)
-      },
-    )
-  })
-}
 
 /**
  * Loads doctor diagnostic data (GET — read-only, no fixes applied).
@@ -76,10 +14,7 @@ function runDoctorChild(
 export async function collectDoctorData(scope?: string, projectCwdOverride?: string): Promise<DoctorReport> {
   const config = resolveBridgeRuntimeConfig(undefined, projectCwdOverride)
   const { packageRoot, projectCwd } = config
-
-  const resolveTsLoader = resolveTsLoaderPath(packageRoot)
-  const doctorModulePath = resolveDoctorModulePath(packageRoot)
-  validateModulePaths(resolveTsLoader, doctorModulePath)
+  const resolved = resolveSubprocessModule(packageRoot, "doctor.ts")
 
   const script = [
     'const { pathToFileURL } = await import("node:url");',
@@ -97,17 +32,22 @@ export async function collectDoctorData(scope?: string, projectCwdOverride?: str
     'process.stdout.write(JSON.stringify(result));',
   ].join(" ")
 
-  const stdout = await runDoctorChild(
-    packageRoot, projectCwd, script, resolveTsLoader, doctorModulePath, scope,
+  return runSubprocess<DoctorReport>(
+    process.execPath,
+    [...resolved.nodeArgs, script],
+    {
+      cwd: packageRoot,
+      env: {
+        ...process.env,
+        [DOCTOR_MODULE_ENV]: resolved.modulePath,
+        GSD_DOCTOR_BASE: projectCwd,
+        GSD_DOCTOR_SCOPE: scope ?? "",
+      },
+      maxBuffer: DOCTOR_MAX_BUFFER,
+      timeout: DOCTOR_TIMEOUT_MS,
+    },
+    "doctor",
   )
-
-  try {
-    return JSON.parse(stdout) as DoctorReport
-  } catch (parseError) {
-    throw new Error(
-      `doctor subprocess returned invalid JSON: ${parseError instanceof Error ? parseError.message : String(parseError)}`,
-    )
-  }
 }
 
 /**
@@ -117,10 +57,7 @@ export async function collectDoctorData(scope?: string, projectCwdOverride?: str
 export async function applyDoctorFixes(scope?: string, projectCwdOverride?: string): Promise<DoctorFixResult> {
   const config = resolveBridgeRuntimeConfig(undefined, projectCwdOverride)
   const { packageRoot, projectCwd } = config
-
-  const resolveTsLoader = resolveTsLoaderPath(packageRoot)
-  const doctorModulePath = resolveDoctorModulePath(packageRoot)
-  validateModulePaths(resolveTsLoader, doctorModulePath)
+  const resolved = resolveSubprocessModule(packageRoot, "doctor.ts")
 
   const script = [
     'const { pathToFileURL } = await import("node:url");',
@@ -135,15 +72,20 @@ export async function applyDoctorFixes(scope?: string, projectCwdOverride?: stri
     'process.stdout.write(JSON.stringify(result));',
   ].join(" ")
 
-  const stdout = await runDoctorChild(
-    packageRoot, projectCwd, script, resolveTsLoader, doctorModulePath, scope,
+  return runSubprocess<DoctorFixResult>(
+    process.execPath,
+    [...resolved.nodeArgs, script],
+    {
+      cwd: packageRoot,
+      env: {
+        ...process.env,
+        [DOCTOR_MODULE_ENV]: resolved.modulePath,
+        GSD_DOCTOR_BASE: projectCwd,
+        GSD_DOCTOR_SCOPE: scope ?? "",
+      },
+      maxBuffer: DOCTOR_MAX_BUFFER,
+      timeout: DOCTOR_TIMEOUT_MS,
+    },
+    "doctor fix",
   )
-
-  try {
-    return JSON.parse(stdout) as DoctorFixResult
-  } catch (parseError) {
-    throw new Error(
-      `doctor fix subprocess returned invalid JSON: ${parseError instanceof Error ? parseError.message : String(parseError)}`,
-    )
-  }
 }

--- a/src/web/export-service.ts
+++ b/src/web/export-service.ts
@@ -1,22 +1,13 @@
-import { execFile } from "node:child_process"
-import { existsSync } from "node:fs"
-import { join } from "node:path"
-import { pathToFileURL } from "node:url"
-
 import { resolveBridgeRuntimeConfig } from "./bridge-service.ts"
-import { resolveTypeStrippingFlag } from "./ts-subprocess-flags.ts"
+import { resolveSubprocessModule } from "./subprocess-module-resolver.ts"
+import { runSubprocess } from "./subprocess-runner.ts"
 import type { ExportResult } from "../../web/lib/remaining-command-types.ts"
 
 const EXPORT_MAX_BUFFER = 4 * 1024 * 1024
+const EXPORT_TIMEOUT_MS = 20_000
 const EXPORT_MODULE_ENV = "GSD_EXPORT_MODULE"
 
-function resolveExportModulePath(packageRoot: string): string {
-  return join(packageRoot, "src", "resources", "extensions", "gsd", "export.ts")
-}
 
-function resolveTsLoaderPath(packageRoot: string): string {
-  return join(packageRoot, "src", "resources", "extensions", "gsd", "tests", "resolve-ts.mjs")
-}
 
 /**
  * Generates an export file via a child process and returns its content.
@@ -29,15 +20,7 @@ export async function collectExportData(
 ): Promise<ExportResult> {
   const config = resolveBridgeRuntimeConfig(undefined, projectCwdOverride)
   const { packageRoot, projectCwd } = config
-
-  const resolveTsLoader = resolveTsLoaderPath(packageRoot)
-  const exportModulePath = resolveExportModulePath(packageRoot)
-
-  if (!existsSync(resolveTsLoader) || !existsSync(exportModulePath)) {
-    throw new Error(
-      `export data provider not found; checked=${resolveTsLoader},${exportModulePath}`,
-    )
-  }
+  const resolved = resolveSubprocessModule(packageRoot, "export.ts")
 
   const script = [
     'const { pathToFileURL } = await import("node:url");',
@@ -55,43 +38,20 @@ export async function collectExportData(
     '}',
   ].join(" ")
 
-  return await new Promise<ExportResult>((resolveResult, reject) => {
-    execFile(
-      process.execPath,
-      [
-        "--import",
-        pathToFileURL(resolveTsLoader).href,
-        resolveTypeStrippingFlag(packageRoot),
-        "--input-type=module",
-        "--eval",
-        script,
-      ],
-      {
-        cwd: packageRoot,
-        env: {
-          ...process.env,
-          [EXPORT_MODULE_ENV]: exportModulePath,
-          GSD_EXPORT_BASE: projectCwd,
-          GSD_EXPORT_FORMAT: format,
-        },
-        maxBuffer: EXPORT_MAX_BUFFER,
+  return runSubprocess<ExportResult>(
+    process.execPath,
+    [...resolved.nodeArgs, script],
+    {
+      cwd: packageRoot,
+      env: {
+        ...process.env,
+        [EXPORT_MODULE_ENV]: resolved.modulePath,
+        GSD_EXPORT_BASE: projectCwd,
+        GSD_EXPORT_FORMAT: format,
       },
-      (error, stdout, stderr) => {
-        if (error) {
-          reject(new Error(`export data subprocess failed: ${stderr || error.message}`))
-          return
-        }
-
-        try {
-          resolveResult(JSON.parse(stdout) as ExportResult)
-        } catch (parseError) {
-          reject(
-            new Error(
-              `export data subprocess returned invalid JSON: ${parseError instanceof Error ? parseError.message : String(parseError)}`,
-            ),
-          )
-        }
-      },
-    )
-  })
+      maxBuffer: EXPORT_MAX_BUFFER,
+      timeout: EXPORT_TIMEOUT_MS,
+    },
+    "export data",
+  )
 }

--- a/src/web/forensics-service.ts
+++ b/src/web/forensics-service.ts
@@ -1,22 +1,11 @@
-import { execFile } from "node:child_process"
-import { existsSync } from "node:fs"
-import { join } from "node:path"
-import { pathToFileURL } from "node:url"
-
 import { resolveBridgeRuntimeConfig } from "./bridge-service.ts"
-import { resolveTypeStrippingFlag } from "./ts-subprocess-flags.ts"
+import { resolveSubprocessModule } from "./subprocess-module-resolver.ts"
+import { runSubprocess } from "./subprocess-runner.ts"
 import type { ForensicReport } from "../../web/lib/diagnostics-types.ts"
 
 const FORENSICS_MAX_BUFFER = 2 * 1024 * 1024
+const FORENSICS_TIMEOUT_MS = 20_000
 const FORENSICS_MODULE_ENV = "GSD_FORENSICS_MODULE"
-
-function resolveForensicsModulePath(packageRoot: string): string {
-  return join(packageRoot, "src", "resources", "extensions", "gsd", "forensics.ts")
-}
-
-function resolveTsLoaderPath(packageRoot: string): string {
-  return join(packageRoot, "src", "resources", "extensions", "gsd", "tests", "resolve-ts.mjs")
-}
 
 /**
  * Loads forensic report data via a child process. Converts the full upstream
@@ -29,14 +18,7 @@ export async function collectForensicsData(projectCwdOverride?: string): Promise
   const config = resolveBridgeRuntimeConfig(undefined, projectCwdOverride)
   const { packageRoot, projectCwd } = config
 
-  const resolveTsLoader = resolveTsLoaderPath(packageRoot)
-  const forensicsModulePath = resolveForensicsModulePath(packageRoot)
-
-  if (!existsSync(resolveTsLoader) || !existsSync(forensicsModulePath)) {
-    throw new Error(
-      `forensics data provider not found; checked=${resolveTsLoader},${forensicsModulePath}`,
-    )
-  }
+  const resolved = resolveSubprocessModule(packageRoot, "forensics.ts")
 
   // The child script loads the upstream module, calls buildForensicReport(),
   // simplifies the output for browser consumption, and writes JSON to stdout.
@@ -74,42 +56,19 @@ export async function collectForensicsData(projectCwdOverride?: string): Promise
     'process.stdout.write(JSON.stringify(result));',
   ].join(" ")
 
-  return await new Promise<ForensicReport>((resolveResult, reject) => {
-    execFile(
-      process.execPath,
-      [
-        "--import",
-        pathToFileURL(resolveTsLoader).href,
-        resolveTypeStrippingFlag(packageRoot),
-        "--input-type=module",
-        "--eval",
-        script,
-      ],
-      {
-        cwd: packageRoot,
-        env: {
-          ...process.env,
-          [FORENSICS_MODULE_ENV]: forensicsModulePath,
-          GSD_FORENSICS_BASE: projectCwd,
-        },
-        maxBuffer: FORENSICS_MAX_BUFFER,
+  return runSubprocess<ForensicReport>(
+    process.execPath,
+    [...resolved.nodeArgs, script],
+    {
+      cwd: packageRoot,
+      env: {
+        ...process.env,
+        [FORENSICS_MODULE_ENV]: resolved.modulePath,
+        GSD_FORENSICS_BASE: projectCwd,
       },
-      (error, stdout, stderr) => {
-        if (error) {
-          reject(new Error(`forensics data subprocess failed: ${stderr || error.message}`))
-          return
-        }
-
-        try {
-          resolveResult(JSON.parse(stdout) as ForensicReport)
-        } catch (parseError) {
-          reject(
-            new Error(
-              `forensics data subprocess returned invalid JSON: ${parseError instanceof Error ? parseError.message : String(parseError)}`,
-            ),
-          )
-        }
-      },
-    )
-  })
+      maxBuffer: FORENSICS_MAX_BUFFER,
+      timeout: FORENSICS_TIMEOUT_MS,
+    },
+    "forensics data",
+  )
 }

--- a/src/web/history-service.ts
+++ b/src/web/history-service.ts
@@ -1,22 +1,13 @@
-import { execFile } from "node:child_process"
-import { existsSync } from "node:fs"
-import { join } from "node:path"
-import { pathToFileURL } from "node:url"
-
 import { resolveBridgeRuntimeConfig } from "./bridge-service.ts"
-import { resolveTypeStrippingFlag } from "./ts-subprocess-flags.ts"
+import { resolveSubprocessModule } from "./subprocess-module-resolver.ts"
+import { runSubprocess } from "./subprocess-runner.ts"
 import type { HistoryData } from "../../web/lib/remaining-command-types.ts"
 
 const HISTORY_MAX_BUFFER = 2 * 1024 * 1024
+const HISTORY_TIMEOUT_MS = 15_000
 const HISTORY_MODULE_ENV = "GSD_HISTORY_MODULE"
 
-function resolveHistoryModulePath(packageRoot: string): string {
-  return join(packageRoot, "src", "resources", "extensions", "gsd", "metrics.ts")
-}
 
-function resolveTsLoaderPath(packageRoot: string): string {
-  return join(packageRoot, "src", "resources", "extensions", "gsd", "tests", "resolve-ts.mjs")
-}
 
 /**
  * Loads history/metrics data via a child process.
@@ -26,15 +17,7 @@ function resolveTsLoaderPath(packageRoot: string): string {
 export async function collectHistoryData(projectCwdOverride?: string): Promise<HistoryData> {
   const config = resolveBridgeRuntimeConfig(undefined, projectCwdOverride)
   const { packageRoot, projectCwd } = config
-
-  const resolveTsLoader = resolveTsLoaderPath(packageRoot)
-  const historyModulePath = resolveHistoryModulePath(packageRoot)
-
-  if (!existsSync(resolveTsLoader) || !existsSync(historyModulePath)) {
-    throw new Error(
-      `history data provider not found; checked=${resolveTsLoader},${historyModulePath}`,
-    )
-  }
+  const resolved = resolveSubprocessModule(packageRoot, "metrics.ts")
 
   const script = [
     'const { pathToFileURL } = await import("node:url");',
@@ -48,42 +31,19 @@ export async function collectHistoryData(projectCwdOverride?: string): Promise<H
     'process.stdout.write(JSON.stringify({ units, totals, byPhase, bySlice, byModel }));',
   ].join(" ")
 
-  return await new Promise<HistoryData>((resolveResult, reject) => {
-    execFile(
-      process.execPath,
-      [
-        "--import",
-        pathToFileURL(resolveTsLoader).href,
-        resolveTypeStrippingFlag(packageRoot),
-        "--input-type=module",
-        "--eval",
-        script,
-      ],
-      {
-        cwd: packageRoot,
-        env: {
-          ...process.env,
-          [HISTORY_MODULE_ENV]: historyModulePath,
-          GSD_HISTORY_BASE: projectCwd,
-        },
-        maxBuffer: HISTORY_MAX_BUFFER,
+  return runSubprocess<HistoryData>(
+    process.execPath,
+    [...resolved.nodeArgs, script],
+    {
+      cwd: packageRoot,
+      env: {
+        ...process.env,
+        [HISTORY_MODULE_ENV]: resolved.modulePath,
+        GSD_HISTORY_BASE: projectCwd,
       },
-      (error, stdout, stderr) => {
-        if (error) {
-          reject(new Error(`history data subprocess failed: ${stderr || error.message}`))
-          return
-        }
-
-        try {
-          resolveResult(JSON.parse(stdout) as HistoryData)
-        } catch (parseError) {
-          reject(
-            new Error(
-              `history data subprocess returned invalid JSON: ${parseError instanceof Error ? parseError.message : String(parseError)}`,
-            ),
-          )
-        }
-      },
-    )
-  })
+      maxBuffer: HISTORY_MAX_BUFFER,
+      timeout: HISTORY_TIMEOUT_MS,
+    },
+    "history data",
+  )
 }

--- a/src/web/hooks-service.ts
+++ b/src/web/hooks-service.ts
@@ -1,22 +1,13 @@
-import { execFile } from "node:child_process"
-import { existsSync } from "node:fs"
-import { join } from "node:path"
-import { pathToFileURL } from "node:url"
-
 import { resolveBridgeRuntimeConfig } from "./bridge-service.ts"
-import { resolveTypeStrippingFlag } from "./ts-subprocess-flags.ts"
+import { resolveSubprocessModule } from "./subprocess-module-resolver.ts"
+import { runSubprocess } from "./subprocess-runner.ts"
 import type { HooksData } from "../../web/lib/remaining-command-types.ts"
 
 const HOOKS_MAX_BUFFER = 512 * 1024
+const HOOKS_TIMEOUT_MS = 10_000
 const HOOKS_MODULE_ENV = "GSD_HOOKS_MODULE"
 
-function resolveHooksModulePath(packageRoot: string): string {
-  return join(packageRoot, "src", "resources", "extensions", "gsd", "post-unit-hooks.ts")
-}
 
-function resolveTsLoaderPath(packageRoot: string): string {
-  return join(packageRoot, "src", "resources", "extensions", "gsd", "tests", "resolve-ts.mjs")
-}
 
 /**
  * Collects hook configuration and status via a child process.
@@ -27,15 +18,7 @@ function resolveTsLoaderPath(packageRoot: string): string {
 export async function collectHooksData(projectCwdOverride?: string): Promise<HooksData> {
   const config = resolveBridgeRuntimeConfig(undefined, projectCwdOverride)
   const { packageRoot, projectCwd } = config
-
-  const resolveTsLoader = resolveTsLoaderPath(packageRoot)
-  const hooksModulePath = resolveHooksModulePath(packageRoot)
-
-  if (!existsSync(resolveTsLoader) || !existsSync(hooksModulePath)) {
-    throw new Error(
-      `hooks data provider not found; checked=${resolveTsLoader},${hooksModulePath}`,
-    )
-  }
+  const resolved = resolveSubprocessModule(packageRoot, "post-unit-hooks.ts")
 
   // getHookStatus() internally calls resolvePostUnitHooks() and resolvePreDispatchHooks()
   // from preferences.ts, which read from process.cwd()/.gsd/preferences.md.
@@ -49,41 +32,18 @@ export async function collectHooksData(projectCwdOverride?: string): Promise<Hoo
     'process.stdout.write(JSON.stringify({ entries, formattedStatus }));',
   ].join(" ")
 
-  return await new Promise<HooksData>((resolveResult, reject) => {
-    execFile(
-      process.execPath,
-      [
-        "--import",
-        pathToFileURL(resolveTsLoader).href,
-        resolveTypeStrippingFlag(packageRoot),
-        "--input-type=module",
-        "--eval",
-        script,
-      ],
-      {
-        cwd: projectCwd,
-        env: {
-          ...process.env,
-          [HOOKS_MODULE_ENV]: hooksModulePath,
-        },
-        maxBuffer: HOOKS_MAX_BUFFER,
+  return runSubprocess<HooksData>(
+    process.execPath,
+    [...resolved.nodeArgs, script],
+    {
+      cwd: projectCwd,
+      env: {
+        ...process.env,
+        [HOOKS_MODULE_ENV]: resolved.modulePath,
       },
-      (error, stdout, stderr) => {
-        if (error) {
-          reject(new Error(`hooks data subprocess failed: ${stderr || error.message}`))
-          return
-        }
-
-        try {
-          resolveResult(JSON.parse(stdout) as HooksData)
-        } catch (parseError) {
-          reject(
-            new Error(
-              `hooks data subprocess returned invalid JSON: ${parseError instanceof Error ? parseError.message : String(parseError)}`,
-            ),
-          )
-        }
-      },
-    )
-  })
+      maxBuffer: HOOKS_MAX_BUFFER,
+      timeout: HOOKS_TIMEOUT_MS,
+    },
+    "hooks data",
+  )
 }

--- a/src/web/recovery-diagnostics-service.ts
+++ b/src/web/recovery-diagnostics-service.ts
@@ -1,14 +1,13 @@
-import { execFile } from "node:child_process"
 import { existsSync } from "node:fs"
 import { join, resolve } from "node:path"
-import { pathToFileURL } from "node:url"
 
 import {
   collectCurrentProjectOnboardingState,
   collectSelectiveLiveStatePayload,
   resolveBridgeRuntimeConfig,
 } from "./bridge-service.ts"
-import { resolveTypeStrippingFlag } from "./ts-subprocess-flags.ts"
+import { resolveSubprocessModule } from "./subprocess-module-resolver.ts"
+import { runSubprocess } from "./subprocess-runner.ts"
 import type {
   WorkspaceRecoveryBrowserAction,
   WorkspaceRecoveryCodeSummary,
@@ -19,6 +18,7 @@ import type {
 } from "../../web/lib/command-surface-contract.ts"
 
 const RECOVERY_DIAGNOSTICS_MAX_BUFFER = 1024 * 1024
+const RECOVERY_DIAGNOSTICS_TIMEOUT_MS = 45_000
 
 type RecoveryDiagnosticsSeverity = "info" | "warning" | "error"
 
@@ -356,18 +356,6 @@ function resolveSummary(options: {
   }
 }
 
-function resolveTsLoaderPath(packageRoot: string): string {
-  return join(packageRoot, "src", "resources", "extensions", "gsd", "tests", "resolve-ts.mjs")
-}
-
-function resolveDoctorModulePath(packageRoot: string): string {
-  return join(packageRoot, "src", "resources", "extensions", "gsd", "doctor.ts")
-}
-
-function resolveSessionForensicsModulePath(packageRoot: string): string {
-  return join(packageRoot, "src", "resources", "extensions", "gsd", "session-forensics.ts")
-}
-
 async function collectRecoveryDiagnosticsChildPayload(
   packageRoot: string,
   basePath: string,
@@ -378,15 +366,8 @@ async function collectRecoveryDiagnosticsChildPayload(
 ): Promise<RecoveryDiagnosticsChildPayload> {
   const env = options.env ?? process.env
   const checkExists = options.existsSync ?? existsSync
-  const resolveTsLoader = resolveTsLoaderPath(packageRoot)
-  const doctorModulePath = resolveDoctorModulePath(packageRoot)
-  const sessionForensicsModulePath = resolveSessionForensicsModulePath(packageRoot)
-
-  if (!checkExists(resolveTsLoader) || !checkExists(doctorModulePath) || !checkExists(sessionForensicsModulePath)) {
-    throw new Error(
-      `recovery diagnostics providers not found; checked=${resolveTsLoader},${doctorModulePath},${sessionForensicsModulePath}`,
-    )
-  }
+  const resolvedDoctor = resolveSubprocessModule(packageRoot, "doctor.ts", checkExists)
+  const resolvedForensics = resolveSubprocessModule(packageRoot, "session-forensics.ts", checkExists)
 
   const script = [
     'const { pathToFileURL } = await import("node:url");',
@@ -468,50 +449,27 @@ async function collectRecoveryDiagnosticsChildPayload(
     '}));',
   ].join(" ")
 
-  return await new Promise<RecoveryDiagnosticsChildPayload>((resolveResult, reject) => {
-    execFile(
-      options.execPath ?? process.execPath,
-      [
-        "--import",
-        pathToFileURL(resolveTsLoader).href,
-        resolveTypeStrippingFlag(packageRoot),
-        "--input-type=module",
-        "--eval",
-        script,
-      ],
-      {
-        cwd: packageRoot,
-        env: {
-          ...env,
-          GSD_RECOVERY_BASE: basePath,
-          GSD_RECOVERY_SCOPE: scope ?? "",
-          GSD_RECOVERY_UNIT_TYPE: unit?.type ?? "execute-project",
-          GSD_RECOVERY_UNIT_ID: unit?.id ?? "project",
-          GSD_RECOVERY_SESSION_FILE: sessionFile ?? "",
-          GSD_RECOVERY_ACTIVITY_DIR: join(basePath, ".gsd", "activity"),
-          GSD_RECOVERY_DOCTOR_MODULE: doctorModulePath,
-          GSD_RECOVERY_FORENSICS_MODULE: sessionForensicsModulePath,
-        },
-        maxBuffer: RECOVERY_DIAGNOSTICS_MAX_BUFFER,
+  return runSubprocess<RecoveryDiagnosticsChildPayload>(
+    options.execPath ?? process.execPath,
+    [...resolvedDoctor.nodeArgs, script],
+    {
+      cwd: packageRoot,
+      env: {
+        ...env,
+        GSD_RECOVERY_BASE: basePath,
+        GSD_RECOVERY_SCOPE: scope ?? "",
+        GSD_RECOVERY_UNIT_TYPE: unit?.type ?? "execute-project",
+        GSD_RECOVERY_UNIT_ID: unit?.id ?? "project",
+        GSD_RECOVERY_SESSION_FILE: sessionFile ?? "",
+        GSD_RECOVERY_ACTIVITY_DIR: join(basePath, ".gsd", "activity"),
+        GSD_RECOVERY_DOCTOR_MODULE: resolvedDoctor.modulePath,
+        GSD_RECOVERY_FORENSICS_MODULE: resolvedForensics.modulePath,
       },
-      (error, stdout, stderr) => {
-        if (error) {
-          reject(new Error(`recovery diagnostics subprocess failed: ${stderr || error.message}`))
-          return
-        }
-
-        try {
-          resolveResult(JSON.parse(stdout) as RecoveryDiagnosticsChildPayload)
-        } catch (parseError) {
-          reject(
-            new Error(
-              `recovery diagnostics subprocess returned invalid JSON: ${parseError instanceof Error ? parseError.message : String(parseError)}`,
-            ),
-          )
-        }
-      },
-    )
-  })
+      maxBuffer: RECOVERY_DIAGNOSTICS_MAX_BUFFER,
+      timeout: RECOVERY_DIAGNOSTICS_TIMEOUT_MS,
+    },
+    "recovery diagnostics",
+  )
 }
 
 export async function collectCurrentProjectRecoveryDiagnostics(

--- a/src/web/settings-service.ts
+++ b/src/web/settings-service.ts
@@ -1,51 +1,36 @@
-import { execFile } from "node:child_process"
-import { existsSync } from "node:fs"
-import { join } from "node:path"
-import { pathToFileURL } from "node:url"
-
 import { resolveBridgeRuntimeConfig } from "./bridge-service.ts"
-import { resolveTypeStrippingFlag } from "./ts-subprocess-flags.ts"
+import { resolveSubprocessModule } from "./subprocess-module-resolver.ts"
+import { runSubprocess } from "./subprocess-runner.ts"
 import type { SettingsData } from "../../web/lib/settings-types.ts"
 
 const SETTINGS_MAX_BUFFER = 2 * 1024 * 1024
-
-function resolveModulePath(packageRoot: string, moduleName: string): string {
-  return join(packageRoot, "src", "resources", "extensions", "gsd", moduleName)
-}
-
-function resolveTsLoaderPath(packageRoot: string): string {
-  return join(packageRoot, "src", "resources", "extensions", "gsd", "tests", "resolve-ts.mjs")
-}
+const SETTINGS_TIMEOUT_MS = 15_000
 
 /**
  * Loads settings data via a child process. Calls upstream extension modules
  * for preferences, routing config, budget allocation, routing history, and
  * project totals, then combines results into a single SettingsData payload.
- *
- * Uses the same child-process pattern as forensics-service.ts — Turbopack
- * cannot resolve the .js extension imports these upstream modules use, so
- * execFile + resolve-ts.mjs is required.
  */
 export async function collectSettingsData(projectCwdOverride?: string): Promise<SettingsData> {
   const config = resolveBridgeRuntimeConfig(undefined, projectCwdOverride)
   const { packageRoot, projectCwd } = config
 
-  const resolveTsLoader = resolveTsLoaderPath(packageRoot)
-  const prefsPath = resolveModulePath(packageRoot, "preferences.ts")
-  const routerPath = resolveModulePath(packageRoot, "model-router.ts")
-  const budgetPath = resolveModulePath(packageRoot, "context-budget.ts")
-  const historyPath = resolveModulePath(packageRoot, "routing-history.ts")
-  const metricsPath = resolveModulePath(packageRoot, "metrics.ts")
+  // All five modules use the same resolution strategy — pick the first for nodeArgs.
+  const resolvedPrefs = resolveSubprocessModule(packageRoot, "preferences.ts")
+  const resolvedRouter = resolveSubprocessModule(packageRoot, "model-router.ts")
+  const resolvedBudget = resolveSubprocessModule(packageRoot, "context-budget.ts")
+  const resolvedHistory = resolveSubprocessModule(packageRoot, "routing-history.ts")
+  const resolvedMetrics = resolveSubprocessModule(packageRoot, "metrics.ts")
 
-  const requiredPaths = [resolveTsLoader, prefsPath, routerPath, budgetPath, historyPath, metricsPath]
-  for (const p of requiredPaths) {
-    if (!existsSync(p)) {
-      throw new Error(`settings data provider not found; missing=${p}`)
-    }
+  const allModules = [resolvedPrefs, resolvedRouter, resolvedBudget, resolvedHistory, resolvedMetrics]
+  const nodeArgsSignature = JSON.stringify(resolvedPrefs.nodeArgs)
+  if (!allModules.every(r => JSON.stringify(r.nodeArgs) === nodeArgsSignature)) {
+    throw new Error(
+      "settings-service: mixed compiled/source resolution — all five modules must resolve the same way. " +
+      "Check that dist/ is either complete or absent.",
+    )
   }
 
-  // The child script loads all upstream modules, calls the 5 data functions,
-  // and writes a combined JSON payload to stdout.
   const script = [
     'const { pathToFileURL } = await import("node:url");',
     'const prefsMod = await import(pathToFileURL(process.env.GSD_SETTINGS_PREFS_MODULE).href);',
@@ -54,7 +39,6 @@ export async function collectSettingsData(projectCwdOverride?: string): Promise<
     'const historyMod = await import(pathToFileURL(process.env.GSD_SETTINGS_HISTORY_MODULE).href);',
     'const metricsMod = await import(pathToFileURL(process.env.GSD_SETTINGS_METRICS_MODULE).href);',
 
-    // 1. Effective preferences (may be null if no preferences files exist)
     'const loaded = prefsMod.loadEffectiveGSDPreferences();',
     'let preferences = null;',
     'if (loaded) {',
@@ -86,65 +70,32 @@ export async function collectSettingsData(projectCwdOverride?: string): Promise<
     '    warnings: loaded.warnings,',
     '  };',
     '}',
-
-    // 2. Resolved dynamic routing config (always returns a config with defaults)
     'const routingConfig = prefsMod.resolveDynamicRoutingConfig();',
-
-    // 3. Budget allocation (use 200K as default context window)
     'const budgetAllocation = budgetMod.computeBudgets(200000);',
-
-    // 4. Routing history (must init before reading)
     'historyMod.initRoutingHistory(process.env.GSD_SETTINGS_BASE);',
     'const routingHistory = historyMod.getRoutingHistory();',
-
-    // 5. Project totals (null if no metrics ledger exists)
     'const ledger = metricsMod.loadLedgerFromDisk(process.env.GSD_SETTINGS_BASE);',
     'const projectTotals = ledger ? metricsMod.getProjectTotals(ledger.units) : null;',
-
-    // Write combined payload
     'process.stdout.write(JSON.stringify({ preferences, routingConfig, budgetAllocation, routingHistory, projectTotals }));',
   ].join(" ")
 
-  return await new Promise<SettingsData>((resolveResult, reject) => {
-    execFile(
-      process.execPath,
-      [
-        "--import",
-        pathToFileURL(resolveTsLoader).href,
-        resolveTypeStrippingFlag(packageRoot),
-        "--input-type=module",
-        "--eval",
-        script,
-      ],
-      {
-        cwd: packageRoot,
-        env: {
-          ...process.env,
-          GSD_SETTINGS_PREFS_MODULE: prefsPath,
-          GSD_SETTINGS_ROUTER_MODULE: routerPath,
-          GSD_SETTINGS_BUDGET_MODULE: budgetPath,
-          GSD_SETTINGS_HISTORY_MODULE: historyPath,
-          GSD_SETTINGS_METRICS_MODULE: metricsPath,
-          GSD_SETTINGS_BASE: projectCwd,
-        },
-        maxBuffer: SETTINGS_MAX_BUFFER,
+  return runSubprocess<SettingsData>(
+    process.execPath,
+    [...resolvedPrefs.nodeArgs, script],
+    {
+      cwd: packageRoot,
+      env: {
+        ...process.env,
+        GSD_SETTINGS_PREFS_MODULE: resolvedPrefs.modulePath,
+        GSD_SETTINGS_ROUTER_MODULE: resolvedRouter.modulePath,
+        GSD_SETTINGS_BUDGET_MODULE: resolvedBudget.modulePath,
+        GSD_SETTINGS_HISTORY_MODULE: resolvedHistory.modulePath,
+        GSD_SETTINGS_METRICS_MODULE: resolvedMetrics.modulePath,
+        GSD_SETTINGS_BASE: projectCwd,
       },
-      (error, stdout, stderr) => {
-        if (error) {
-          reject(new Error(`settings data subprocess failed: ${stderr || error.message}`))
-          return
-        }
-
-        try {
-          resolveResult(JSON.parse(stdout) as SettingsData)
-        } catch (parseError) {
-          reject(
-            new Error(
-              `settings data subprocess returned invalid JSON: ${parseError instanceof Error ? parseError.message : String(parseError)}`,
-            ),
-          )
-        }
-      },
-    )
-  })
+      maxBuffer: SETTINGS_MAX_BUFFER,
+      timeout: SETTINGS_TIMEOUT_MS,
+    },
+    "settings data",
+  )
 }

--- a/src/web/skill-health-service.ts
+++ b/src/web/skill-health-service.ts
@@ -1,22 +1,13 @@
-import { execFile } from "node:child_process"
-import { existsSync } from "node:fs"
-import { join } from "node:path"
-import { pathToFileURL } from "node:url"
-
 import { resolveBridgeRuntimeConfig } from "./bridge-service.ts"
-import { resolveTypeStrippingFlag } from "./ts-subprocess-flags.ts"
+import { resolveSubprocessModule } from "./subprocess-module-resolver.ts"
+import { runSubprocess } from "./subprocess-runner.ts"
 import type { SkillHealthReport } from "../../web/lib/diagnostics-types.ts"
 
 const SKILL_HEALTH_MAX_BUFFER = 2 * 1024 * 1024
+const SKILL_HEALTH_TIMEOUT_MS = 15_000
 const SKILL_HEALTH_MODULE_ENV = "GSD_SKILL_HEALTH_MODULE"
 
-function resolveSkillHealthModulePath(packageRoot: string): string {
-  return join(packageRoot, "src", "resources", "extensions", "gsd", "skill-health.ts")
-}
 
-function resolveTsLoaderPath(packageRoot: string): string {
-  return join(packageRoot, "src", "resources", "extensions", "gsd", "tests", "resolve-ts.mjs")
-}
 
 /**
  * Loads skill health report via a child process.
@@ -25,15 +16,7 @@ function resolveTsLoaderPath(packageRoot: string): string {
 export async function collectSkillHealthData(projectCwdOverride?: string): Promise<SkillHealthReport> {
   const config = resolveBridgeRuntimeConfig(undefined, projectCwdOverride)
   const { packageRoot, projectCwd } = config
-
-  const resolveTsLoader = resolveTsLoaderPath(packageRoot)
-  const skillHealthModulePath = resolveSkillHealthModulePath(packageRoot)
-
-  if (!existsSync(resolveTsLoader) || !existsSync(skillHealthModulePath)) {
-    throw new Error(
-      `skill-health data provider not found; checked=${resolveTsLoader},${skillHealthModulePath}`,
-    )
-  }
+  const resolved = resolveSubprocessModule(packageRoot, "skill-health.ts")
 
   const script = [
     'const { pathToFileURL } = await import("node:url");',
@@ -43,42 +26,19 @@ export async function collectSkillHealthData(projectCwdOverride?: string): Promi
     'process.stdout.write(JSON.stringify(report));',
   ].join(" ")
 
-  return await new Promise<SkillHealthReport>((resolveResult, reject) => {
-    execFile(
-      process.execPath,
-      [
-        "--import",
-        pathToFileURL(resolveTsLoader).href,
-        resolveTypeStrippingFlag(packageRoot),
-        "--input-type=module",
-        "--eval",
-        script,
-      ],
-      {
-        cwd: packageRoot,
-        env: {
-          ...process.env,
-          [SKILL_HEALTH_MODULE_ENV]: skillHealthModulePath,
-          GSD_SKILL_HEALTH_BASE: projectCwd,
-        },
-        maxBuffer: SKILL_HEALTH_MAX_BUFFER,
+  return runSubprocess<SkillHealthReport>(
+    process.execPath,
+    [...resolved.nodeArgs, script],
+    {
+      cwd: packageRoot,
+      env: {
+        ...process.env,
+        [SKILL_HEALTH_MODULE_ENV]: resolved.modulePath,
+        GSD_SKILL_HEALTH_BASE: projectCwd,
       },
-      (error, stdout, stderr) => {
-        if (error) {
-          reject(new Error(`skill-health subprocess failed: ${stderr || error.message}`))
-          return
-        }
-
-        try {
-          resolveResult(JSON.parse(stdout) as SkillHealthReport)
-        } catch (parseError) {
-          reject(
-            new Error(
-              `skill-health subprocess returned invalid JSON: ${parseError instanceof Error ? parseError.message : String(parseError)}`,
-            ),
-          )
-        }
-      },
-    )
-  })
+      maxBuffer: SKILL_HEALTH_MAX_BUFFER,
+      timeout: SKILL_HEALTH_TIMEOUT_MS,
+    },
+    "skill-health",
+  )
 }

--- a/src/web/subprocess-module-resolver.ts
+++ b/src/web/subprocess-module-resolver.ts
@@ -1,0 +1,86 @@
+/**
+ * Resolve the correct module path and Node.js arguments for web-service
+ * subprocesses that execute GSD extension modules.
+ *
+ * Node ≥ 22.12 refuses --experimental-strip-types for files under
+ * node_modules/, which breaks the packaged standalone where all source lives
+ * inside the installed npm package. The compiled dist/ output must be used
+ * instead.
+ *
+ * Resolution priority:
+ *   1. Compiled dist/resources/extensions/gsd/<name>.js  — preferred when it exists
+ *   2. Source  src/resources/extensions/gsd/<name>.ts    — fallback (dev / source builds)
+ */
+
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+export interface ResolvedSubprocessModule {
+  /** Absolute path to the module file to execute. */
+  modulePath: string;
+  /** Node.js argv to prepend before "--eval <script>". */
+  nodeArgs: string[];
+}
+
+/**
+ * Resolve the module path and node args for a given GSD extension module.
+ *
+ * @param packageRoot  Absolute path to the gsd-pi package root.
+ * @param relSrcPath   Path relative to src/resources/extensions/gsd/, e.g. "auto.ts"
+ * @param checkExistsFn  Optional existsSync override for testing.
+ */
+export function resolveSubprocessModule(
+  packageRoot: string,
+  relSrcPath: string,
+  checkExistsFn: (p: string) => boolean = existsSync,
+): ResolvedSubprocessModule {
+  // Strip leading slash if provided accidentally
+  const rel = relSrcPath.replace(/^\//, "");
+
+  // Compiled path: dist/resources/extensions/gsd/<name>.js
+  const compiledPath = join(
+    packageRoot,
+    "dist",
+    "resources",
+    "extensions",
+    "gsd",
+    rel.replace(/\.ts$/, ".js"),
+  );
+
+  if (checkExistsFn(compiledPath)) {
+    return {
+      modulePath: compiledPath,
+      nodeArgs: ["--input-type=module", "--eval"],
+    };
+  }
+
+  // Source path: src/resources/extensions/gsd/<name>.ts
+  const sourcePath = join(packageRoot, "src", "resources", "extensions", "gsd", rel);
+  const tsLoaderPath = join(
+    packageRoot,
+    "src",
+    "resources",
+    "extensions",
+    "gsd",
+    "tests",
+    "resolve-ts.mjs",
+  );
+
+  if (!checkExistsFn(tsLoaderPath) || !checkExistsFn(sourcePath)) {
+    throw new Error(
+      `GSD extension module not found; checked compiled=${compiledPath}, source=${sourcePath}`,
+    );
+  }
+
+  return {
+    modulePath: sourcePath,
+    nodeArgs: [
+      "--import",
+      pathToFileURL(tsLoaderPath).href,
+      "--experimental-strip-types",
+      "--input-type=module",
+      "--eval",
+    ],
+  };
+}

--- a/src/web/subprocess-runner.ts
+++ b/src/web/subprocess-runner.ts
@@ -1,0 +1,42 @@
+import { execFile as execFileCb } from "node:child_process"
+import { promisify } from "node:util"
+
+const execFile = promisify(execFileCb)
+
+/**
+ * Run a Node.js subprocess with an --eval script and return parsed JSON output.
+ *
+ * @param execPath   Path to node executable (usually process.execPath)
+ * @param args       Node argv — typically [...resolved.nodeArgs, script]
+ * @param options    cwd, env, maxBuffer, timeout
+ * @param label      Service name for error messages, e.g. "captures data"
+ */
+export async function runSubprocess<T>(
+  execPath: string,
+  args: string[],
+  options: {
+    cwd: string
+    env: NodeJS.ProcessEnv
+    maxBuffer: number
+    timeout: number
+  },
+  label: string,
+): Promise<T> {
+  let stdout: string
+  try {
+    ;({ stdout } = await execFile(execPath, args, options))
+  } catch (error: unknown) {
+    const msg =
+      error instanceof Error
+        ? ((error as NodeJS.ErrnoException & { stderr?: string }).stderr || error.message)
+        : String(error)
+    throw new Error(`${label} subprocess failed: ${msg}`)
+  }
+  try {
+    return JSON.parse(stdout) as T
+  } catch (parseError) {
+    throw new Error(
+      `${label} subprocess returned invalid JSON: ${parseError instanceof Error ? parseError.message : String(parseError)}`,
+    )
+  }
+}

--- a/src/web/undo-service.ts
+++ b/src/web/undo-service.ts
@@ -1,27 +1,15 @@
-import { execFile } from "node:child_process"
 import { existsSync, readFileSync } from "node:fs"
 import { join } from "node:path"
-import { pathToFileURL } from "node:url"
 
 import { resolveBridgeRuntimeConfig } from "./bridge-service.ts"
-import { resolveTypeStrippingFlag } from "./ts-subprocess-flags.ts"
+import { resolveSubprocessModule } from "./subprocess-module-resolver.ts"
+import { runSubprocess } from "./subprocess-runner.ts"
 import type { UndoInfo, UndoResult } from "../../web/lib/remaining-command-types.ts"
 
 const UNDO_MAX_BUFFER = 2 * 1024 * 1024
+const UNDO_TIMEOUT_MS = 20_000
 const UNDO_MODULE_ENV = "GSD_UNDO_MODULE"
 const PATHS_MODULE_ENV = "GSD_PATHS_MODULE"
-
-function resolveUndoModulePath(packageRoot: string): string {
-  return join(packageRoot, "src", "resources", "extensions", "gsd", "undo.ts")
-}
-
-function resolvePathsModulePath(packageRoot: string): string {
-  return join(packageRoot, "src", "resources", "extensions", "gsd", "paths.ts")
-}
-
-function resolveTsLoaderPath(packageRoot: string): string {
-  return join(packageRoot, "src", "resources", "extensions", "gsd", "tests", "resolve-ts.mjs")
-}
 
 /**
  * Collects information about the last completed unit for display in the undo panel.
@@ -124,15 +112,8 @@ export async function executeUndo(projectCwdOverride?: string): Promise<UndoResu
   const config = resolveBridgeRuntimeConfig(undefined, projectCwdOverride)
   const { packageRoot, projectCwd } = config
 
-  const resolveTsLoader = resolveTsLoaderPath(packageRoot)
-  const undoModulePath = resolveUndoModulePath(packageRoot)
-  const pathsModulePath = resolvePathsModulePath(packageRoot)
-
-  if (!existsSync(resolveTsLoader) || !existsSync(undoModulePath) || !existsSync(pathsModulePath)) {
-    throw new Error(
-      `undo service modules not found; checked=${resolveTsLoader},${undoModulePath},${pathsModulePath}`,
-    )
-  }
+  const resolvedUndo = resolveSubprocessModule(packageRoot, "undo.ts")
+  const resolvedPaths = resolveSubprocessModule(packageRoot, "paths.ts")
 
   const script = [
     'const { pathToFileURL } = await import("node:url");',
@@ -177,43 +158,20 @@ export async function executeUndo(projectCwdOverride?: string): Promise<UndoResu
     'process.stdout.write(JSON.stringify({ success: true, message: results.join("\\n") }));',
   ].join(" ")
 
-  return await new Promise<UndoResult>((resolveResult, reject) => {
-    execFile(
-      process.execPath,
-      [
-        "--import",
-        pathToFileURL(resolveTsLoader).href,
-        resolveTypeStrippingFlag(packageRoot),
-        "--input-type=module",
-        "--eval",
-        script,
-      ],
-      {
-        cwd: packageRoot,
-        env: {
-          ...process.env,
-          [UNDO_MODULE_ENV]: undoModulePath,
-          [PATHS_MODULE_ENV]: pathsModulePath,
-          GSD_UNDO_BASE: projectCwd,
-        },
-        maxBuffer: UNDO_MAX_BUFFER,
+  return runSubprocess<UndoResult>(
+    process.execPath,
+    [...resolvedUndo.nodeArgs, script],
+    {
+      cwd: packageRoot,
+      env: {
+        ...process.env,
+        [UNDO_MODULE_ENV]: resolvedUndo.modulePath,
+        [PATHS_MODULE_ENV]: resolvedPaths.modulePath,
+        GSD_UNDO_BASE: projectCwd,
       },
-      (error, stdout, stderr) => {
-        if (error) {
-          reject(new Error(`undo subprocess failed: ${stderr || error.message}`))
-          return
-        }
-
-        try {
-          resolveResult(JSON.parse(stdout) as UndoResult)
-        } catch (parseError) {
-          reject(
-            new Error(
-              `undo subprocess returned invalid JSON: ${parseError instanceof Error ? parseError.message : String(parseError)}`,
-            ),
-          )
-        }
-      },
-    )
-  })
+      maxBuffer: UNDO_MAX_BUFFER,
+      timeout: UNDO_TIMEOUT_MS,
+    },
+    "undo",
+  )
 }

--- a/src/web/visualizer-service.ts
+++ b/src/web/visualizer-service.ts
@@ -1,12 +1,9 @@
-import { execFile } from "node:child_process"
-import { existsSync } from "node:fs"
-import { join } from "node:path"
-import { pathToFileURL } from "node:url"
-
 import { resolveBridgeRuntimeConfig } from "./bridge-service.ts"
-import { resolveTypeStrippingFlag } from "./ts-subprocess-flags.ts"
+import { resolveSubprocessModule } from "./subprocess-module-resolver.ts"
+import { runSubprocess } from "./subprocess-runner.ts"
 
 const VISUALIZER_MAX_BUFFER = 2 * 1024 * 1024
+const VISUALIZER_TIMEOUT_MS = 15_000
 const VISUALIZER_MODULE_ENV = "GSD_VISUALIZER_MODULE"
 
 /**
@@ -35,14 +32,6 @@ export interface SerializedVisualizerData {
   changelog: unknown
 }
 
-function resolveVisualizerModulePath(packageRoot: string): string {
-  return join(packageRoot, "src", "resources", "extensions", "gsd", "visualizer-data.ts")
-}
-
-function resolveTsLoaderPath(packageRoot: string): string {
-  return join(packageRoot, "src", "resources", "extensions", "gsd", "tests", "resolve-ts.mjs")
-}
-
 /**
  * Loads visualizer data from the current project's filesystem via a child
  * process (required because upstream .ts files use Node ESM .js import
@@ -53,14 +42,7 @@ export async function collectVisualizerData(projectCwdOverride?: string): Promis
   const config = resolveBridgeRuntimeConfig(undefined, projectCwdOverride)
   const { packageRoot, projectCwd } = config
 
-  const resolveTsLoader = resolveTsLoaderPath(packageRoot)
-  const visualizerModulePath = resolveVisualizerModulePath(packageRoot)
-
-  if (!existsSync(resolveTsLoader) || !existsSync(visualizerModulePath)) {
-    throw new Error(
-      `visualizer data provider not found; checked=${resolveTsLoader},${visualizerModulePath}`,
-    )
-  }
+  const resolved = resolveSubprocessModule(packageRoot, "visualizer-data.ts")
 
   // The child script loads the upstream module, calls loadVisualizerData(),
   // converts Map fields to Records, and writes JSON to stdout.
@@ -80,42 +62,19 @@ export async function collectVisualizerData(projectCwdOverride?: string): Promis
     'process.stdout.write(JSON.stringify(result));',
   ].join(" ")
 
-  return await new Promise<SerializedVisualizerData>((resolveResult, reject) => {
-    execFile(
-      process.execPath,
-      [
-        "--import",
-        pathToFileURL(resolveTsLoader).href,
-        resolveTypeStrippingFlag(packageRoot),
-        "--input-type=module",
-        "--eval",
-        script,
-      ],
-      {
-        cwd: packageRoot,
-        env: {
-          ...process.env,
-          [VISUALIZER_MODULE_ENV]: visualizerModulePath,
-          GSD_VISUALIZER_BASE: projectCwd,
-        },
-        maxBuffer: VISUALIZER_MAX_BUFFER,
+  return runSubprocess<SerializedVisualizerData>(
+    process.execPath,
+    [...resolved.nodeArgs, script],
+    {
+      cwd: packageRoot,
+      env: {
+        ...process.env,
+        [VISUALIZER_MODULE_ENV]: resolved.modulePath,
+        GSD_VISUALIZER_BASE: projectCwd,
       },
-      (error, stdout, stderr) => {
-        if (error) {
-          reject(new Error(`visualizer data subprocess failed: ${stderr || error.message}`))
-          return
-        }
-
-        try {
-          resolveResult(JSON.parse(stdout) as SerializedVisualizerData)
-        } catch (parseError) {
-          reject(
-            new Error(
-              `visualizer data subprocess returned invalid JSON: ${parseError instanceof Error ? parseError.message : String(parseError)}`,
-            ),
-          )
-        }
-      },
-    )
-  })
+      maxBuffer: VISUALIZER_MAX_BUFFER,
+      timeout: VISUALIZER_TIMEOUT_MS,
+    },
+    "visualizer data",
+  )
 }


### PR DESCRIPTION
Closes #1888

## TL;DR

**What:** Extract two shared modules to eliminate duplicated subprocess boilerplate across 14 web service files, add missing timeouts, and fix a latent bug in `settings-service`.
**Why:** ~930 lines of identical copy-paste code, zero subprocess timeouts, and a silent failure mode when compiled and source modules resolve inconsistently.
**How:** `subprocess-module-resolver.ts` handles compiled-vs-source path resolution; `subprocess-runner.ts` wraps `util.promisify(execFile)` with uniform error handling. All 14 services migrated.

## What

Two new modules extracted from `src/web/`:

- **`subprocess-module-resolver.ts`** — resolves the correct module path and `nodeArgs` for GSD extension subprocesses. Prefers compiled `dist/` output (required by Node ≥22.12 which refuses `--experimental-strip-types` for files under `node_modules/`), falls back to source with ts-loader. Centralises logic that was previously copy-pasted into every service.

- **`subprocess-runner.ts`** — `runSubprocess<T>()` helper using `util.promisify(execFile)`. Replaces the identical 15-line `new Promise((resolve, reject) => execFile(...callback...))` block in each service with a single `return runSubprocess(...)` call.

All 14 services in `src/web/` migrated. Per-service timeouts added (10s–45s). The `settings-service` nodeArgs consistency assertion added.

Also fixed pre-existing issues uncovered during the refactor:
- Stale `existsSync(resolveTsLoader)` guards referencing deleted variables — these throw `ReferenceError` at runtime on every call path
- Missing `resolved` declarations in second functions of `captures-service` and `cleanup-service` — would throw `ReferenceError`
- Unused imports (`existsSync`, `join`, `pathToFileURL`) in `visualizer-service`, `forensics-service`, `doctor-service`, `settings-service`

## Why

The 14 web services all spawn Node subprocesses using an identical pattern. The duplication meant:
- Any change to error handling, timeout policy, or the subprocess invocation API required touching all 14 files
- No timeouts → a hung subprocess blocks the web UI indefinitely
- The `settings-service` bug was invisible in normal installs (all modules always resolve the same way) but would silently break if `dist/` was partially built

## How

`subprocess-runner.ts` uses `util.promisify(execFile)` — the correct Node.js idiom (`node:child_process/promises` does not exist). Error handling extracts `error.stderr` when available (the promisified `execFile` throws with `.stderr` on non-zero exit), otherwise falls back to `error.message`.

The resolver's compiled-first logic matches what `subprocess-module-resolver.ts` already implements. The `settings-service` fix asserts all five module resolutions produce identical `nodeArgs` before spawning, and throws a clear diagnostic if not.

## Change type

- [x] `refactor` — Code restructuring (no behaviour change)
- [x] `fix` — Bug fix (stale guards, missing `resolved` declarations, mixed nodeArgs)

> AI-assisted: this PR was developed with Claude Code. All changes have been reviewed and verified manually.

## Test plan

- [x] `npm run test:unit` passes (5 pre-existing failures on `main`, none introduced by this PR)
- [x] `cd web && npx tsc --noEmit` — zero errors
- [x] No conflict markers in any changed file