### PR TITLE
feat: add /btw skill — ephemeral side questions from conversation context

### DIFF
--- a/src/resources/skills/btw/SKILL.md
+++ b/src/resources/skills/btw/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: btw
+description: Ask a quick side question about your current work without derailing the main task. Claude answers from existing conversation context only — no tool calls, no file reads, single concise response. Use when you need a fast answer from what Claude already knows in this session.
+---
+
+<objective>
+Answer a quick side question using only what is already present in the current conversation context. Do not read files, run commands, search, or use any tools. Give a single, concise response and return focus to the main work.
+</objective>
+
+<behavior>
+**This is a side question, not a task.**
+
+- Answer only from information already in the conversation (files read, decisions made, code seen, context established)
+- Do NOT use any tools — no Read, no Bash, no Grep, no Search
+- If the answer requires reading something new, say so briefly and suggest the user ask as a normal prompt instead
+- Keep the response short and direct — one to a few sentences unless the question genuinely needs more
+- Do not summarize the main work, ask follow-up questions, or offer to do anything else
+- After answering, stop — do not prompt for next steps
+</behavior>
+
+<quick_start>
+Parse the argument after `/btw` as the question. Answer it directly from context.
+
+If no argument is provided, ask: "What did you want to know?"
+
+If the question cannot be answered from current context (requires reading a file, running a command, or information not yet in the session), respond with:
+"I'd need to [read X / run Y / look up Z] to answer that — ask it as a normal prompt when you're ready."
+</quick_start>
+
+<examples>
+**Good uses of /btw:**
+- `/btw what was the name of that config file again?` → answers from files already read in session
+- `/btw which branch are we on?` → answers from git context already established
+- `/btw did we already handle the null case in that function?` → answers from code already reviewed
+- `/btw what model does this use?` → answers from code or config already in context
+
+**Not a good fit for /btw (suggest normal prompt):**
+- Questions requiring reading a file not yet seen
+- Questions requiring running a command
+- Questions needing a multi-step answer or follow-up
+- Starting a new task or changing direction
+</examples>


### PR DESCRIPTION
Closes #1828

## Summary

- Adds a new bundled skill `/btw` inspired by Claude Code's built-in `/btw` command
- Lets users ask a quick side question from within the current session **without derailing the main task or adding to conversation history**
- Answers from context only — no tool use, single response, graceful fallback when tools would be needed

## Motivation

Claude Code ships a `/btw` feature that creates an ephemeral overlay for fast side questions. GSD2 users working in long sessions often need the same thing: a lightweight way to recall something Claude already knows ("what was that config key?", "which branch are we on?", "did we handle the null case?") without interrupting flow or bloating context.

This skill mirrors that behavior within GSD2's skill system.

## Behavior

```
/btw what was the name of that config file again?
/btw which branch are we on?
/btw did we already handle the null case in that function?
```

**Rules enforced by the skill:**
- Answers **only from information already in the session** (files read, decisions made, code seen)
- **No tool calls** — no Read, no Bash, no Grep, no Search
- **Single response only** — no follow-up turns, no offering next steps
- If the question requires reading something new, responds: *"I'd need to [read X / run Y] to answer that — ask it as a normal prompt when you're ready."*

## Implementation

Single new file: `src/resources/skills/btw/SKILL.md`

No wiring changes needed. The existing pipeline handles everything:

1. `scripts/copy-resources.cjs` copies all non-TS files from `src/resources/` → `dist/resources/` at build time
2. `initResources()` in `src/resource-loader.ts:274` syncs `dist/resources/skills/` → `~/.gsd/agent/skills/` at startup
3. `getSkillSearchDirs()` in `preferences-skills.ts` picks it up by bare name (`btw`)

This is identical to how all other bundled skills ship (`lint`, `review`, `create-skill`, etc.).

### How it differs from Claude Code's native `/btw`

Claude Code's `/btw` is a platform-level feature with a dismissible overlay UI that never enters conversation history, and can run in parallel while Claude is processing. GSD2's implementation is a skill — it runs within the conversation — so the overlay and true history isolation aren't possible. What is preserved:

| Behavior | Claude Code | GSD2 `/btw` |
|----------|-------------|-------------|
| Answers from current context only | ✅ | ✅ |
| No tool calls | ✅ | ✅ (enforced by skill) |
| Single response, no follow-ups | ✅ | ✅ (enforced by skill) |
| Graceful fallback when tools needed | ✅ | ✅ |
| Dismissible overlay / out of history | ✅ | ❌ (skill limitation) |
| Runs in parallel during active turn | ✅ | ❌ (skill limitation) |

The core user value — fast, focused side questions without derailing the main task — is fully delivered.

## Test plan

- [ ] After build, verify `~/.gsd/agent/skills/btw/SKILL.md` exists
- [ ] Run `/btw what was the last file we read?` mid-session — should answer from context with no tool calls
- [ ] Run `/btw` with a question requiring a file read — should decline gracefully and suggest a normal prompt
- [ ] Run `/btw` with no argument — should ask "What did you want to know?"
- [ ] Confirm the response does not prompt for follow-ups or next steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)