### PR TITLE
fix: clear all untracked .gsd/ files before squash merge

### DIFF
--- a/src/resources/extensions/gsd/auto-worktree.ts
+++ b/src/resources/extensions/gsd/auto-worktree.ts
@@ -83,39 +83,36 @@ function clearProjectRootStateFiles(basePath: string, milestoneId: string): void
     }
   }
 
-  // Clean up entire synced milestone directory and runtime/units.
-  // syncStateToProjectRoot() copies these into the project root during
-  // execution.  If they remain as untracked files when we attempt
-  // `git merge --squash`, git rejects the merge with "local changes would
-  // be overwritten", causing silent data loss (#1738).
-  const syncedDirs = [
-    join(gsdDir, "milestones", milestoneId),
-    join(gsdDir, "runtime", "units"),
-  ];
-
-  for (const dir of syncedDirs) {
-    try {
-      if (existsSync(dir)) {
-        // Only remove files that are untracked by git — tracked files are
-        // managed by the branch checkout and should not be deleted.
-        const untrackedOutput = execFileSync(
-          "git",
-          ["ls-files", "--others", "--exclude-standard", dir],
-          { cwd: basePath, stdio: ["ignore", "pipe", "pipe"], encoding: "utf-8" },
-        ).trim();
-        if (untrackedOutput) {
-          for (const f of untrackedOutput.split("\n").filter(Boolean)) {
-            try {
-              unlinkSync(join(basePath, f));
-            } catch {
-              /* non-fatal */
-            }
-          }
+  // Clean up ALL untracked files under .gsd/.
+  // syncWorktreeStateBack() syncs QUEUE.md, completed-units.json, and ALL
+  // milestone directories (including future milestones created by
+  // complete-milestone) into the project root during execution. If any of
+  // these remain as untracked files when we attempt `git merge --squash`,
+  // git rejects the merge with "local changes would be overwritten",
+  // causing silent data loss (#1738, #1890).
+  //
+  // Rather than maintaining a manual whitelist of dirs to clean, we scan
+  // the entire .gsd/ tree for untracked files and remove them all. This
+  // covers the current milestone dir, runtime/units/, future milestone
+  // dirs (M005-CONTEXT.md, M006-CONTEXT.md, etc.), and root-level files
+  // like QUEUE.md.
+  try {
+    const untrackedOutput = execFileSync(
+      "git",
+      ["ls-files", "--others", "--exclude-standard", gsdDir],
+      { cwd: basePath, stdio: ["ignore", "pipe", "pipe"], encoding: "utf-8" },
+    ).trim();
+    if (untrackedOutput) {
+      for (const f of untrackedOutput.split("\n").filter(Boolean)) {
+        try {
+          unlinkSync(join(basePath, f));
+        } catch {
+          /* non-fatal */
         }
       }
-    } catch {
-      /* non-fatal — git command may fail if not in repo */
     }
+  } catch {
+    /* non-fatal — git command may fail if not in repo */
   }
 }
 // ─── Worktree ↔ Main Repo Sync (#1311) ──────────────────────────────────────

--- a/src/resources/extensions/gsd/tests/auto-worktree-milestone-merge.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-worktree-milestone-merge.test.ts
@@ -771,6 +771,63 @@ async function main(): Promise<void> {
       assertTrue(existsSync(join(repo, "real-code.ts")), "real-code.ts merged to main");
     }
 
+    // ─── Test 20: #1890 — QUEUE.md and future milestone dirs cleaned before merge ──
+    console.log("\n=== #1890: QUEUE.md and future milestone dirs cleaned before merge ===");
+    {
+      const repo = freshRepo();
+      const wtPath = createAutoWorktree(repo, "M200");
+
+      addSliceToMilestone(repo, wtPath, "M200", "S01", "Queue cleanup test", [
+        { file: "queue-test.ts", content: "export const queueTest = true;\n", message: "add queue-test" },
+      ]);
+
+      writeFileSync(join(repo, ".gsd", "QUEUE.md"), "# Queue\n- Next task\n");
+
+      const futureMs1 = join(repo, ".gsd", "milestones", "M201");
+      mkdirSync(futureMs1, { recursive: true });
+      writeFileSync(join(futureMs1, "M201-CONTEXT.md"), "# M201 Context\n");
+      writeFileSync(join(futureMs1, "M201-ROADMAP.md"), "# M201 Roadmap\n");
+
+      const futureMs2 = join(repo, ".gsd", "milestones", "M202");
+      mkdirSync(futureMs2, { recursive: true });
+      writeFileSync(join(futureMs2, "M202-CONTEXT.md"), "# M202 Context\n");
+
+      const untrackedBefore = run(
+        "git ls-files --others --exclude-standard .gsd/",
+        repo,
+      );
+      assertTrue(untrackedBefore.includes("QUEUE.md"), "QUEUE.md is untracked before merge");
+      assertTrue(untrackedBefore.includes("M201"), "M201 dir is untracked before merge");
+      assertTrue(untrackedBefore.includes("M202"), "M202 dir is untracked before merge");
+
+      const roadmap = makeRoadmap("M200", "Queue cleanup milestone", [
+        { id: "S01", title: "Queue cleanup test" },
+      ]);
+
+      let threw = false;
+      let errMsg = "";
+      try {
+        const result = mergeMilestoneToMain(repo, "M200", roadmap);
+        assertTrue(
+          result.commitMessage.includes("feat(M200)"),
+          "#1890 merge succeeds after cleaning QUEUE.md and future milestone dirs",
+        );
+      } catch (err: unknown) {
+        threw = true;
+        errMsg = err instanceof Error ? err.message : String(err);
+      }
+      assertTrue(!threw, `#1890 merge must not fail on QUEUE.md/future milestone dirs (got: ${errMsg})`);
+      assertTrue(existsSync(join(repo, "queue-test.ts")), "queue-test.ts on main after merge");
+
+      const untrackedAfter = run(
+        "git ls-files --others --exclude-standard .gsd/ || true",
+        repo,
+      );
+      assertTrue(!untrackedAfter.includes("QUEUE.md"), "#1890: QUEUE.md cleaned before merge");
+      assertTrue(!untrackedAfter.includes("M201"), "#1890: future milestone M201 cleaned before merge");
+      assertTrue(!untrackedAfter.includes("M202"), "#1890: future milestone M202 cleaned before merge");
+    }
+
   } finally {
     process.chdir(savedCwd);
     for (const d of tempDirs) {


### PR DESCRIPTION
## TL;DR
`clearProjectRootStateFiles` now removes all untracked files under `.gsd/` instead of only the current milestone dir and `runtime/units/`, preventing QUEUE.md and future-milestone directories from blocking squash merges.

## What
- Replaced per-directory cleanup loop with a single `git ls-files --others --exclude-standard .gsd/` scan
- Added regression test (Test 18) that plants QUEUE.md and two future milestone directories as untracked files and verifies they are cleaned before merge

## Why
`syncWorktreeStateBack` syncs QUEUE.md and ALL milestone directories to the project root, but `clearProjectRootStateFiles` only cleaned the current milestone dir and `runtime/units/`. When `complete-milestone` creates next-milestone artifacts (M005-CONTEXT.md, M006-CONTEXT.md) and QUEUE.md, these persisted as untracked files and caused `git merge --squash` to fail.

## How
Instead of maintaining a manual whitelist of directories to clean, scan the entire `.gsd/` tree for untracked files via `git ls-files` and remove them all. This covers current milestone dirs, future milestone dirs, runtime/units/, and root-level files like QUEUE.md -- matching the full scope of what `syncWorktreeStateBack` syncs.

Fixes #1890

🤖 Generated with [Claude Code](https://claude.com/claude-code)