### PR TITLE
fix: load resolved quick-task captures on auto-mode startup

### DIFF
--- a/src/resources/extensions/gsd/auto-start.ts
+++ b/src/resources/extensions/gsd/auto-start.ts
@@ -475,7 +475,11 @@ export async function bootstrapAutoSession(
     s.autoStartTime = Date.now();
     s.resourceVersionOnStart = readResourceVersion();
     s.completedUnits = [];
-    s.pendingQuickTasks = [];
+    // Seed pendingQuickTasks from CAPTURES.md — resolved quick-tasks triaged
+    // in a prior session would otherwise be stranded (#1904).
+    const { loadActionableCaptures } = await import("./captures.js");
+    s.pendingQuickTasks = loadActionableCaptures(base)
+      .filter(c => c.classification === "quick-task");
     s.currentUnit = null;
     s.currentMilestoneId = state.activeMilestone?.id ?? null;
     s.originalModelId = ctx.model?.id ?? null;

--- a/src/resources/extensions/gsd/tests/triage-dispatch.test.ts
+++ b/src/resources/extensions/gsd/tests/triage-dispatch.test.ts
@@ -331,10 +331,36 @@ test("dispatch: quick-task excluded from post-unit hook triggering", () => {
 
 // ─── pendingQuickTasks queue lifecycle ────────────────────────────────────────
 
-test("dispatch: pendingQuickTasks queue is reset on auto-mode start/stop", () => {
-  const resetMatches = autoSrc.match(/s\.pendingQuickTasks = \[\]/g);
+test("dispatch: pendingQuickTasks queue is reset on auto-mode stop", () => {
+  // Stop path should still hard-reset to []
+  const autoStopSrc = [
+    readFileSync(join(__dirname, "..", "auto.ts"), "utf-8"),
+    readFileSync(join(__dirname, "..", "auto-post-unit.ts"), "utf-8"),
+  ].join("\n");
   assert.ok(
-    resetMatches && resetMatches.length >= 2,
-    "s.pendingQuickTasks should be reset in start and stop paths",
+    autoStopSrc.includes("s.pendingQuickTasks = []"),
+    "s.pendingQuickTasks should be reset in stop path",
+  );
+});
+
+// ─── Startup: load resolved quick-tasks from CAPTURES.md (#1904) ────────────
+
+test("startup: auto-start loads resolved quick-task captures into pendingQuickTasks", () => {
+  const startSrc = readFileSync(join(__dirname, "..", "auto-start.ts"), "utf-8");
+  assert.ok(
+    startSrc.includes("loadActionableCaptures"),
+    "auto-start.ts should call loadActionableCaptures to seed pendingQuickTasks",
+  );
+  assert.ok(
+    startSrc.includes('c.classification === "quick-task"'),
+    "auto-start.ts should filter actionable captures to quick-task classification",
+  );
+});
+
+test("startup: auto-start imports loadActionableCaptures from captures module", () => {
+  const startSrc = readFileSync(join(__dirname, "..", "auto-start.ts"), "utf-8");
+  assert.ok(
+    startSrc.includes("loadActionableCaptures") && startSrc.includes("captures"),
+    "auto-start.ts should import loadActionableCaptures from captures",
   );
 });


### PR DESCRIPTION
## TL;DR

Resolved quick-task captures triaged in a prior session are now loaded into
`pendingQuickTasks` when auto-mode starts, instead of being silently dropped.

## What

`auto-start.ts` unconditionally set `s.pendingQuickTasks = []` on every
auto-mode boot. Quick-tasks triaged outside auto-mode (e.g., via `/gsd triage`)
were stranded in `CAPTURES.md` -- resolved but never executed.

## Why

When `/gsd auto` starts in a new session after triage ran in a previous session,
the `complete -> stop` dispatch rule fires before any quick-task check, causing
auto-mode to exit with "All milestones complete" while actionable quick-tasks
sit unexecuted in CAPTURES.md.

## How

Replace the unconditional `s.pendingQuickTasks = []` with a dynamic import of
`loadActionableCaptures(base)` filtered to `quick-task` classification. This
function already filters for `status === "resolved" && !executed`, returning
exactly the captures that need dispatching.

## Test plan

- Added regression tests in `triage-dispatch.test.ts` verifying auto-start.ts
  imports and calls `loadActionableCaptures` with quick-task filter
- Updated existing lifecycle test to check stop-path reset independently
- Full test suite passes (29/29 triage-dispatch tests)

Fixes #1904