### PR TITLE
fix: flush extension provider registrations before model resolution

### DIFF
--- a/packages/pi-coding-agent/src/core/sdk.ts
+++ b/packages/pi-coding-agent/src/core/sdk.ts
@@ -195,6 +195,16 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		time("resourceLoader.reload");
 	}
 
+	// Flush provider registrations queued during extension loading so that
+	// extension models (e.g. pi-claude-cli) are visible in the registry before
+	// findInitialModel() runs. bindCore() repeats this flush as a safety net
+	// for any late-arriving registrations.
+	const { runtime: extensionRuntime } = resourceLoader.getExtensions();
+	for (const { name, config } of extensionRuntime.pendingProviderRegistrations) {
+		modelRegistry.registerProvider(name, config);
+	}
+	extensionRuntime.pendingProviderRegistrations = [];
+
 	// Check if session has existing data to restore
 	const existingSession = sessionManager.buildSessionContext();
 	const hasExistingSession = existingSession.messages.length > 0;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -116,6 +116,48 @@ function parseCliArgs(argv: string[]): CliFlags {
   return flags
 }
 
+/**
+ * Validate the configured default model against the registry and reset it if
+ * it no longer exists.  Must run AFTER extensions have registered their
+ * providers so that extension models (e.g. pi-claude-cli) are visible.
+ */
+function validateConfiguredModel(
+  modelRegistry: ModelRegistry,
+  settingsManager: SettingsManager,
+): void {
+  const configuredProvider = settingsManager.getDefaultProvider()
+  const configuredModel = settingsManager.getDefaultModel()
+  const allModels = modelRegistry.getAll()
+  const availableModels = modelRegistry.getAvailable()
+  const configuredExists = configuredProvider && configuredModel &&
+    allModels.some((m) => m.provider === configuredProvider && m.id === configuredModel)
+  const configuredAvailable = configuredProvider && configuredModel &&
+    availableModels.some((m) => m.provider === configuredProvider && m.id === configuredModel)
+
+  if (!configuredModel || !configuredExists) {
+    // Model not configured at all, or removed from registry — pick a fallback.
+    // Only fires when the model is genuinely unknown (not just temporarily unavailable).
+    const piDefault = getPiDefaultModelAndProvider()
+    const preferred =
+      (piDefault
+        ? availableModels.find((m) => m.provider === piDefault.provider && m.id === piDefault.model)
+        : undefined) ||
+      availableModels.find((m) => m.provider === 'openai' && m.id === 'gpt-5.4') ||
+      availableModels.find((m) => m.provider === 'openai') ||
+      availableModels.find((m) => m.provider === 'anthropic' && m.id === 'claude-opus-4-6') ||
+      availableModels.find((m) => m.provider === 'anthropic' && m.id.includes('opus')) ||
+      availableModels.find((m) => m.provider === 'anthropic') ||
+      availableModels[0]
+    if (preferred) {
+      settingsManager.setDefaultModelAndProvider(preferred.provider, preferred.id)
+    }
+  }
+
+  if (settingsManager.getDefaultThinkingLevel() !== 'off' && !configuredExists) {
+    settingsManager.setDefaultThinkingLevel('off')
+  }
+}
+
 const cliFlags = parseCliArgs(process.argv)
 const isPrintMode = cliFlags.print || cliFlags.mode !== undefined
 
@@ -299,8 +341,23 @@ if (!isPrintMode && process.stdout.columns && process.stdout.columns < 40) {
   )
 }
 
-// --list-models: print available models and exit (no TTY needed)
+// --list-models: load extensions so that extension-registered providers (e.g.
+// pi-claude-cli) appear in the listing, then flush their pending registrations
+// into the model registry before printing.
 if (cliFlags.listModels !== undefined) {
+  exitIfManagedResourcesAreNewer(agentDir)
+  initResources(agentDir)
+  const listModelsLoader = new DefaultResourceLoader({
+    agentDir,
+    additionalExtensionPaths: cliFlags.extensions.length > 0 ? cliFlags.extensions : undefined,
+  })
+  await listModelsLoader.reload()
+  const listModelsExtensions = listModelsLoader.getExtensions()
+  for (const { name, config } of listModelsExtensions.runtime.pendingProviderRegistrations) {
+    modelRegistry.registerProvider(name, config)
+  }
+  listModelsExtensions.runtime.pendingProviderRegistrations = []
+
   const models = modelRegistry.getAvailable()
   if (models.length === 0) {
     console.log('No models available. Set API keys in environment variables.')
@@ -340,42 +397,6 @@ if (cliFlags.listModels !== undefined) {
     console.log(row.map((c, i) => pad(c, widths[i])).join('  '))
   }
   process.exit(0)
-}
-
-// Validate configured model on startup — catches stale settings from prior installs
-// (e.g. grok-2 which no longer exists) and fresh installs with no settings.
-// Only resets the default when the configured model no longer exists in the registry;
-// never overwrites a valid user choice.
-const configuredProvider = settingsManager.getDefaultProvider()
-const configuredModel = settingsManager.getDefaultModel()
-const allModels = modelRegistry.getAll()
-const availableModels = modelRegistry.getAvailable()
-const configuredExists = configuredProvider && configuredModel &&
-  allModels.some((m) => m.provider === configuredProvider && m.id === configuredModel)
-const configuredAvailable = configuredProvider && configuredModel &&
-  availableModels.some((m) => m.provider === configuredProvider && m.id === configuredModel)
-
-if (!configuredModel || !configuredExists) {
-  // Model not configured at all, or removed from registry — pick a fallback.
-  // Only fires when the model is genuinely unknown (not just temporarily unavailable).
-  const piDefault = getPiDefaultModelAndProvider()
-  const preferred =
-    (piDefault
-      ? availableModels.find((m) => m.provider === piDefault.provider && m.id === piDefault.model)
-      : undefined) ||
-    availableModels.find((m) => m.provider === 'openai' && m.id === 'gpt-5.4') ||
-    availableModels.find((m) => m.provider === 'openai') ||
-    availableModels.find((m) => m.provider === 'anthropic' && m.id === 'claude-opus-4-6') ||
-    availableModels.find((m) => m.provider === 'anthropic' && m.id.includes('opus')) ||
-    availableModels.find((m) => m.provider === 'anthropic') ||
-    availableModels[0]
-  if (preferred) {
-    settingsManager.setDefaultModelAndProvider(preferred.provider, preferred.id)
-  }
-}
-
-if (settingsManager.getDefaultThinkingLevel() !== 'off' && !configuredExists) {
-  settingsManager.setDefaultThinkingLevel('off')
 }
 
 // GSD always uses quiet startup — the gsd extension renders its own branded header
@@ -435,6 +456,11 @@ if (isPrintMode) {
       process.stderr.write(`[gsd] ${prefix}: ${err.error}\n`)
     }
   }
+
+  // Validate configured model now that extension providers are registered.
+  // Must run after createAgentSession() which flushes pendingProviderRegistrations
+  // so extension models (e.g. pi-claude-cli) are visible in the registry.
+  validateConfiguredModel(modelRegistry, settingsManager)
 
   // Apply --model override if specified
   if (cliFlags.model) {
@@ -558,6 +584,11 @@ if (extensionsResult.errors.length > 0) {
     process.stderr.write(`[gsd] ${prefix}: ${err.error}\n`)
   }
 }
+
+// Validate configured model now that extension providers are registered.
+// Must run after createAgentSession() which flushes pendingProviderRegistrations
+// so extension models (e.g. pi-claude-cli) are visible in the registry.
+validateConfiguredModel(modelRegistry, settingsManager)
 
 // Restore scoped models from settings on startup.
 // The upstream InteractiveMode reads enabledModels from settings when /scoped-models is opened,


### PR DESCRIPTION
## TL;DR

**What:** Flush extension provider registrations before model resolution and startup validation.
**Why:** Extension-based providers (e.g. pi-claude-cli) had their models overwritten on every launch because registrations were queued but not flushed until after model selection ran.
**How:** Flush `pendingProviderRegistrations` in `createAgentSession()` before `findInitialModel()`, move validation after `createAgentSession()` in both code paths, and load extensions before `--list-models`.

## What

Three changes across two files:

**`packages/pi-coding-agent/src/core/sdk.ts`** — Flush `pendingProviderRegistrations` into `ModelRegistry` immediately after `resourceLoader` is ready, before `findInitialModel()` runs. `bindCore()` retains its existing flush as a safety net for late-arriving registrations.

**`src/cli.ts`** — Extract model validation into `validateConfiguredModel()` and call it after `createAgentSession()` in both print mode and interactive mode paths. Update `--list-models` to load extensions and flush registrations before listing, so extension-registered models appear in the output.

## Why

Extension-based providers like pi-claude-cli register their models during `resourceLoader.reload()`, but those registrations are queued in `pendingProviderRegistrations` and only flushed when `bindCore()` runs — which happens inside `AgentSession`'s constructor, after `findInitialModel()` has already resolved the model. This means:

1. `findInitialModel()` can't find the extension model → falls back or errors with "No model selected"
2. The startup validation block sees the configured model as nonexistent → permanently overwrites the user's saved selection
3. `--list-models` doesn't show extension-registered models

The user must re-select their model on every launch.

## How

- Flush the pending queue in `createAgentSession()` right after `resourceLoader` is ready (line 198 in sdk.ts), before any model resolution. This is the same 4-line pattern used in `runner.bindCore()`, kept inline.
- The existing flush in `bindCore()` is preserved as a safety net for any registrations that arrive between `createAgentSession()` and interactive mode bind.
- Model validation is extracted into a function to avoid duplicating the ~30-line block, and called after `createAgentSession()` in both code paths where extension models are now visible.
- `--list-models` creates its own `DefaultResourceLoader`, reloads it, and flushes registrations before listing.

AI-assisted: This PR was developed with Claude Code (Opus). All changes were manually reviewed and tested.

## Change type
- [x] `fix` — Bug fix

## Scope
- [x] `pi-coding-agent` — Coding agent

## Breaking changes
- [x] No breaking changes

## Test plan
- [x] Manual testing — describe steps:
  1. Configure pi-claude-cli extension via `settings.json` `extensions` array
  2. Launch GSD, select a model (e.g. `claude-opus-4-6[1m]`)
  3. Close GSD, reopen — model selection persists (previously reset every launch)
  4. Run with `--print "test"` — no "No model selected" error
  5. TypeScript type check passes (`npx tsc --noEmit`)
  6. Full build passes (`npm run build`)

## Rollback plan
- [x] Safe to revert (no migrations, no state changes)