### PR TITLE
fix: invalidate caches in runGSDDoctor — repeated fix runs re-detect same issues

### DIFF
--- a/src/resources/extensions/gsd/doctor.ts
+++ b/src/resources/extensions/gsd/doctor.ts
@@ -135,6 +135,9 @@ function buildStateMarkdown(state: Awaited<ReturnType<typeof deriveState>>): str
 }
 
 async function updateStateFile(basePath: string, fixesApplied: string[]): Promise<void> {
+  // Invalidate caches so deriveState reads the post-fix disk state, not stale
+  // pre-fix parsed ROADMAP/PLAN data (#1885).
+  invalidateAllCaches();
   const state = await deriveState(basePath);
   const path = resolveGsdRootFile(basePath, "STATE");
   await saveFile(path, buildStateMarkdown(state));
@@ -475,6 +478,12 @@ export async function readDoctorHistory(basePath: string, lastN = 50): Promise<D
 }
 
 export async function runGSDDoctor(basePath: string, options?: { fix?: boolean; dryRun?: boolean; scope?: string; fixLevel?: "task" | "all"; isolationMode?: "none" | "worktree" | "branch"; includeBuild?: boolean; includeTests?: boolean }): Promise<DoctorReport> {
+  // Invalidate module-level caches at the start so this run always reads current
+  // disk state. Without this, a second doctor invocation in the same process sees
+  // pre-fix cached ROADMAP/PLAN/state data and re-reports already-fixed issues
+  // (#1885).
+  invalidateAllCaches();
+
   const issues: DoctorIssue[] = [];
   const fixesApplied: string[] = [];
   const fix = options?.fix === true;

--- a/src/resources/extensions/gsd/tests/doctor.test.ts
+++ b/src/resources/extensions/gsd/tests/doctor.test.ts
@@ -643,6 +643,44 @@ Discovered an issue.
     rmSync(base, { recursive: true, force: true });
   }
 
+  // ─── Idempotency regression (#1885): second run reads post-fix state ──────
+  // Without invalidateAllCaches() at the start of runGSDDoctor, a second call in
+  // the same process sees stale cached ROADMAP/PLAN data and re-reports issues
+  // that were already fixed by the first call.
+  console.log("\n=== doctor idempotency: second run produces no new fixes (#1885) ===");
+  {
+    const idBase = mkdtempSync(join(tmpdir(), "gsd-doctor-idempotency-"));
+    const idGsd = join(idBase, ".gsd");
+    const idMDir = join(idGsd, "milestones", "M001");
+    const idSDir = join(idMDir, "slices", "S01");
+    const idTDir = join(idSDir, "tasks");
+    mkdirSync(idTDir, { recursive: true });
+
+    // Task marked done in plan with no summary on disk — doctor will:
+    //   run 1: uncheck task, then (since slice was done) uncheck slice, then
+    //          create UAT stub, then update STATE.md
+    //   run 2: should see unchecked task, no summary → nothing to fix
+    writeFileSync(join(idMDir, "M001-ROADMAP.md"), `# M001: Test Milestone\n\n## Slices\n- [x] **S01: Demo Slice** \`risk:low\` \`depends:[]\`\n  > After this: demo works\n`);
+    writeFileSync(join(idSDir, "S01-PLAN.md"), `# S01: Demo Slice\n\n**Goal:** Demo\n**Demo:** Demo\n\n## Tasks\n- [x] **T01: Implement thing** \`est:10m\`\n  Task is complete.\n`);
+    writeFileSync(join(idSDir, "S01-SUMMARY.md"), `---\nid: S01\nparent: M001\n---\n# S01: Demo Slice\nDone.\n`);
+    writeFileSync(join(idSDir, "S01-UAT.md"), `# S01 UAT\nVerified.\n`);
+    // No T01-SUMMARY.md — triggers task_done_missing_summary on first run
+
+    // First run: should apply fixes
+    const run1 = await runGSDDoctor(idBase, { fix: true });
+    assertTrue(run1.fixesApplied.length > 0, "first run applies fixes");
+
+    // Second run: must not re-detect or re-fix the same issues (#1885)
+    const run2 = await runGSDDoctor(idBase, { fix: true });
+    const run2TaskIssues = run2.issues.filter(i => i.code === "task_done_missing_summary");
+    assertEq(run2TaskIssues.length, 0, "second run does NOT re-detect task_done_missing_summary (no stale cache)");
+    // fixesApplied on run 2 should be empty — nothing to fix
+    const run2Mechanical = run2.fixesApplied.filter(f => !f.startsWith("updated ") || !f.includes("STATE"));
+    assertEq(run2Mechanical.length, 0, "second run applies no mechanical fixes (idempotent)");
+
+    rmSync(idBase, { recursive: true, force: true });
+  }
+
   report();
 }
 


### PR DESCRIPTION
## TL;DR

**What:** Add `invalidateAllCaches()` at the start of `runGSDDoctor()` and inside `updateStateFile()` before `deriveState()`.
**Why:** Without it, a second doctor run in the same process reads stale cached ROADMAP/PLAN data and re-reports issues already fixed by the first run.
**How:** Mirror the pattern already used in `rebuildState()` — invalidate caches before every `deriveState()` call that follows file writes.

## What

Two cache invalidation gaps in `src/resources/extensions/gsd/doctor.ts`:

1. **`runGSDDoctor()` entry** — no `invalidateAllCaches()` before the first `deriveState()` call. Module-level `_parseCache`, `_stateCache`, and `dirEntryCache` persist across calls in the extension process, so a second invocation reads pre-fix cached file data.

2. **`updateStateFile()`** — no `invalidateAllCaches()` before `deriveState()`. After the main fix loop writes to ROADMAP/PLAN files, the STATE.md rebuild was deriving from stale parsed data instead of actual disk state. `rebuildState()` (the exported public API) already had the correct `invalidate → derive → save` sequence; `updateStateFile()` was missing the same guard.

Also adds an idempotency regression test to `doctor.test.ts`: verifies that running `runGSDDoctor` twice with `fix:true` in sequence produces zero new `task_done_missing_summary` detections on the second run.

## Why

Auto-mode runs `runGSDDoctor` after every task unit completes. In practice this means two+ calls within a single session. The second run was re-detecting and re-logging issues that the first run had already fixed on disk, because the module-level parse/state caches were still warm with pre-fix data.

The STATE.md rebuild gap meant phase transitions could be wrong: a task unchecked by the doctor would still show the slice/milestone as complete in STATE.md because `updateStateFile` read the old cached roadmap.

Closes #1885 (supersedes).

## How

- `runGSDDoctor`: call `invalidateAllCaches()` as the first statement in the function body.
- `updateStateFile`: call `invalidateAllCaches()` immediately before `deriveState()`, matching the `rebuildState()` pattern exactly.

## Change type

- [x] `fix` — Bug fix

## AI disclosure

This PR is AI-assisted (Claude Code). The root cause analysis, implementation, and test were generated and verified by the author.