### PR TITLE
fix(repo-identity): use native realpath on Windows to resolve 8.3 short paths

### DIFF
--- a/src/resources/extensions/gsd/repo-identity.ts
+++ b/src/resources/extensions/gsd/repo-identity.ts
@@ -164,7 +164,8 @@ function getRemoteUrl(basePath: string): string {
  */
 function canonicalizeExistingPath(path: string): string {
   try {
-    return realpathSync(path);
+    // Use native realpath on Windows to resolve 8.3 short paths (e.g. RUNNER~1)
+    return process.platform === "win32" ? realpathSync.native(path) : realpathSync(path);
   } catch {
     return resolve(path);
   }


### PR DESCRIPTION
## Summary

- Use `realpathSync.native()` instead of `realpathSync()` on Windows in `canonicalizeExistingPath`
- JS `realpathSync` doesn't resolve 8.3 short names (e.g. `RUNNER~1` → `runneradmin`), causing `isInheritedRepo` path comparisons to fail

Last pre-existing `windows-portability` CI failure (the other 3 were fixed in #1956).

## Test plan

- [x] Local tests pass
- [ ] Windows CI — targets this specific failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)