### PR TITLE
fix(roadmap): recognize '## Slice Roadmap' header in slice parser

### DIFF
--- a/src/resources/extensions/gsd/roadmap-slices.ts
+++ b/src/resources/extensions/gsd/roadmap-slices.ts
@@ -41,8 +41,8 @@ export function expandDependencies(deps: string[]): string[] {
 }
 
 function extractSlicesSection(content: string): string {
-  // Match "## Slices", "## Slice Overview", "## Slice Table", etc.
-  const headingMatch = /^## Slice(?:s| Overview| Table| Summary| Status)\b.*$/m.exec(content);
+  // Match "## Slices", "## Slice Overview", "## Slice Table", "## Slice Roadmap", etc.
+  const headingMatch = /^## Slice(?:s| Overview| Table| Summary| Status| Roadmap)\b.*$/m.exec(content);
   if (!headingMatch || headingMatch.index == null) return "";
 
   const start = headingMatch.index + headingMatch[0].length;

--- a/src/resources/extensions/gsd/tests/roadmap-slices.test.ts
+++ b/src/resources/extensions/gsd/tests/roadmap-slices.test.ts
@@ -236,6 +236,32 @@ test("parseRoadmapSlices: ## Slices with valid checkboxes does NOT invoke prose 
   assert.equal(slices[0]?.done, true);
 });
 
+// ── Regression test for #1940 ───────────────────────────────────────────────
+// '## Slice Roadmap' header is not recognized by extractSlicesSection, causing
+// checkbox-format slices to be missed and all slices reported as incomplete.
+
+test("parseRoadmapSlices: ## Slice Roadmap heading recognized (#1940)", () => {
+  const roadmapContent = [
+    "# M002: Current Milestone", "",
+    "**Vision:** Ship it.", "",
+    "## Slice Roadmap", "",
+    "- [x] **S01: Foundation** `risk:low` `depends:[]`",
+    "  > After this: base layer works.",
+    "- [x] **S02: Core Logic** `risk:medium` `depends:[S01]`",
+    "- [ ] **S03: Polish** `risk:low` `depends:[S01,S02]`", "",
+    "## Boundary Map",
+  ].join("\n");
+  const slices = parseRoadmapSlices(roadmapContent);
+  assert.equal(slices.length, 3, "should parse 3 slices under '## Slice Roadmap'");
+  assert.equal(slices[0]?.id, "S01");
+  assert.equal(slices[0]?.done, true, "S01 should be marked done");
+  assert.equal(slices[1]?.id, "S02");
+  assert.equal(slices[1]?.done, true, "S02 should be marked done");
+  assert.equal(slices[2]?.id, "S03");
+  assert.equal(slices[2]?.done, false, "S03 should be pending");
+  assert.deepEqual(slices[2]?.depends, ["S01", "S02"]);
+});
+
 test("parseRoadmapSlices: ## Slices with only non-matching lines returns prose fallback results", () => {
   const weirdContent = `# M020: Odd
 


### PR DESCRIPTION
## TL;DR

**What:** Add `Roadmap` to the `extractSlicesSection` heading regex.
**Why:** `## Slice Roadmap` was not matched, causing all slices to be reported as incomplete and trapping auto-mode in a dispatch loop.
**How:** One-word addition to the alternation group in the regex, plus a regression test.

## What

- `roadmap-slices.ts`: added `| Roadmap` to the `extractSlicesSection` heading regex
- `roadmap-slices.test.ts`: added regression test verifying checkbox slices under `## Slice Roadmap` are parsed with correct completion state

## Why

The `extractSlicesSection` function matched `## Slices`, `## Slice Overview`, `## Slice Table`, `## Slice Summary`, and `## Slice Status` but not `## Slice Roadmap`. When a roadmap used this heading, the section extractor returned empty, causing the parser to fall through to `parseProseSliceHeaders`. The prose parser finds `### S01: Title` headers but cannot read `[x]` checkbox state, so all slices are marked `done: false`. The dispatch guard then blocks every slice because earlier slices appear incomplete, trapping auto-mode in a loop (dispatched 1231 times in the reporter's case).

## How

Added ` Roadmap` to the existing alternation in the regex on line 45 of `roadmap-slices.ts`. The `\b` word boundary anchor already ensures no false matches on longer words.

### Change type
- [x] `fix` -- Bug fix

## Test plan
- [x] New regression test: `## Slice Roadmap heading recognized (#1940)` -- verifies 3 slices parsed with correct `done` state
- [x] All 17 existing roadmap-slices tests pass

Fixes #1940

Generated with [Claude Code](https://claude.com/claude-code)