### PR TITLE
fix(state): add completeMilestoneIds in Phase 2 unchecked-slices-with-summary path

### DIFF
--- a/src/resources/extensions/gsd/state.ts
+++ b/src/resources/extensions/gsd/state.ts
@@ -412,6 +412,7 @@ async function _deriveStateImpl(basePath: string): Promise<GSDState> {
       const summaryFile = resolveMilestoneFile(basePath, mid, "SUMMARY");
       if (summaryFile) {
         registry.push({ id: mid, title, status: 'complete' });
+        completeMilestoneIds.add(mid); // defensive: Phase 1 already adds, but keep in sync (#1941)
       } else if (!activeMilestoneFound) {
         // Check milestone-level dependencies before promoting to active.
         // Fall back to CONTEXT-DRAFT.md when CONTEXT.md is absent (#1724).

--- a/src/resources/extensions/gsd/tests/derive-state-deps.test.ts
+++ b/src/resources/extensions/gsd/tests/derive-state-deps.test.ts
@@ -623,6 +623,56 @@ async function main(): Promise<void> {
     }
   }
 
+  // ─── Test Group: unchecked-slices-summary-dep (#1941) ─────────────────
+  // M001 has a roadmap with UNCHECKED slices but a SUMMARY file exists.
+  // The summary is the terminal artifact (#864), so M001 should be complete
+  // AND added to completeMilestoneIds. M002 depends_on M001 → M002 should
+  // become active, not remain dep-blocked.
+  console.log('\n=== unchecked-slices-summary-dep: summary overrides unchecked slices for dep resolution ===');
+  {
+    const base = createFixtureBase();
+    try {
+      // M001: roadmap with UNCHECKED slices + SUMMARY exists → complete
+      writeRoadmap(base, 'M001', `# M001: First Milestone
+
+**Vision:** Milestone with unchecked slices but summary present.
+
+## Slices
+
+- [ ] **S01: Moved to Later** \`risk:low\` \`depends:[]\`
+  > After this: Done.
+- [x] **S02: Completed** \`risk:low\` \`depends:[]\`
+  > After this: Done.
+`);
+      writeMilestoneSummary(base, 'M001', '# M001 Summary\n\nMilestone complete despite unchecked slices.');
+
+      // M002: depends on M001, should be unblocked because M001 has SUMMARY
+      writeRoadmap(base, 'M002', `# M002: Second Milestone
+
+**Vision:** Should activate because M001 is complete (has SUMMARY).
+
+## Slices
+
+- [ ] **S01: Ready** \`risk:low\` \`depends:[]\`
+  > After this: Done.
+`);
+      writeContext(base, 'M002', 'depends_on: [M001]');
+
+      const state = await deriveState(base);
+
+      assertEq(state.registry[0]?.status, 'complete',
+        'unchecked-slices-summary-dep: M001 is complete (summary overrides unchecked slices)');
+      assertEq(state.registry[1]?.status, 'active',
+        'unchecked-slices-summary-dep: M002 is active (dep on M001 met via summary)');
+      assertEq(state.activeMilestone?.id, 'M002',
+        'unchecked-slices-summary-dep: activeMilestone is M002');
+      assertTrue(state.phase !== 'blocked',
+        'unchecked-slices-summary-dep: phase is not blocked');
+    } finally {
+      cleanup(base);
+    }
+  }
+
   // ─── Test Group 13: draft-only-no-deps (#1724) ────────────────────────
   // M002 has only CONTEXT-DRAFT.md with NO depends_on field.
   // Should behave same as no context file — normal sequential behavior.


### PR DESCRIPTION
## TL;DR

**What:** Add defensive `completeMilestoneIds.add(mid)` in Phase 2's unchecked-slices-with-summary branch and regression test.
**Why:** Phase 2 registers milestones as `status: 'complete'` without mirroring the Phase 1 `completeMilestoneIds` add, creating a latent inconsistency that could surface if Phase 1 is ever refactored.
**How:** One-line add in the `else` branch of the roadmap-complete check, plus a new test group in `derive-state-deps.test.ts`.

## What

When a milestone has a roadmap with unchecked slices but a SUMMARY file exists (the #864 terminal artifact rule), Phase 2 of `deriveState` pushes it to the registry as `status: 'complete'` but does not call `completeMilestoneIds.add(mid)`. Phase 1 already handles this correctly, so downstream `depends_on` resolution works today. However, the Phase 2 branch was inconsistent with the other two completion paths that both mirror the add.

This adds the defensive `completeMilestoneIds.add(mid)` call and a regression test that verifies a milestone with unchecked roadmap slices + SUMMARY correctly unblocks downstream `depends_on` milestones.

## Why

The issue (#1941) reports that downstream milestones with `depends_on` referencing a milestone completed via summary-override remain permanently dep-blocked. Investigation shows Phase 1's pre-scan already populates `completeMilestoneIds` for this case, so the bug does not reproduce in practice. However, the Phase 2 omission is a latent inconsistency: all three completion paths in Phase 2 should mirror the Phase 1 behavior for maintainability and to prevent regressions if Phase 1 is ever restructured.

## How

- `state.ts` line ~414: Added `completeMilestoneIds.add(mid)` after `registry.push` in the unchecked-slices-with-summary branch.
- `derive-state-deps.test.ts`: Added test group "unchecked-slices-summary-dep" that creates M001 with unchecked slices + SUMMARY, M002 with `depends_on: [M001]`, and verifies M002 becomes active (not dep-blocked).

Fixes #1941