### PR TITLE
fix(system-prompt): gate skill catalog on Skill tool, not read

### DIFF
--- a/packages/pi-coding-agent/src/core/system-prompt.test.ts
+++ b/packages/pi-coding-agent/src/core/system-prompt.test.ts
@@ -1,0 +1,100 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { buildSystemPrompt } from "./system-prompt.js";
+
+const dummySkill = {
+	name: "test-skill",
+	description: "A test skill",
+	filePath: "/tmp/test-skill/SKILL.md",
+	baseDir: "/tmp/test-skill",
+	source: "project",
+	body: "# Test Skill\n",
+	disableModelInvocation: false,
+};
+
+describe("buildSystemPrompt skill catalog gating", () => {
+	// ----- default prompt path -----
+
+	it("includes skills when Skill tool is present but read is absent (default prompt)", () => {
+		const prompt = buildSystemPrompt({
+			selectedTools: ["bash", "edit", "Skill"],
+			skills: [dummySkill],
+		});
+		assert.ok(
+			prompt.includes("<available_skills>"),
+			"Expected <available_skills> when Skill tool is in selectedTools",
+		);
+	});
+
+	it("includes skills when both read and Skill tools are present (default prompt)", () => {
+		const prompt = buildSystemPrompt({
+			selectedTools: ["read", "bash", "edit", "Skill"],
+			skills: [dummySkill],
+		});
+		assert.ok(
+			prompt.includes("<available_skills>"),
+			"Expected <available_skills> when both read and Skill are present",
+		);
+	});
+
+	it("omits skills when neither read nor Skill tool is present (default prompt)", () => {
+		const prompt = buildSystemPrompt({
+			selectedTools: ["bash", "edit"],
+			skills: [dummySkill],
+		});
+		assert.ok(
+			!prompt.includes("<available_skills>"),
+			"Should not include skills when Skill tool is absent",
+		);
+	});
+
+	// ----- custom prompt path -----
+
+	it("includes skills when Skill tool is present but read is absent (custom prompt)", () => {
+		const prompt = buildSystemPrompt({
+			customPrompt: "You are a custom agent.",
+			selectedTools: ["bash", "Skill"],
+			skills: [dummySkill],
+		});
+		assert.ok(
+			prompt.includes("<available_skills>"),
+			"Expected <available_skills> in custom prompt when Skill tool is present",
+		);
+	});
+
+	it("includes skills when both read and Skill tools are present (custom prompt)", () => {
+		const prompt = buildSystemPrompt({
+			customPrompt: "You are a custom agent.",
+			selectedTools: ["read", "Skill"],
+			skills: [dummySkill],
+		});
+		assert.ok(
+			prompt.includes("<available_skills>"),
+			"Expected <available_skills> in custom prompt when both read and Skill are present",
+		);
+	});
+
+	it("omits skills when neither read nor Skill tool is present (custom prompt)", () => {
+		const prompt = buildSystemPrompt({
+			customPrompt: "You are a custom agent.",
+			selectedTools: ["bash", "edit"],
+			skills: [dummySkill],
+		});
+		assert.ok(
+			!prompt.includes("<available_skills>"),
+			"Should not include skills in custom prompt when Skill tool is absent",
+		);
+	});
+
+	// ----- backward compat: no selectedTools means all defaults -----
+
+	it("includes skills when selectedTools is undefined (defaults include read)", () => {
+		const prompt = buildSystemPrompt({
+			skills: [dummySkill],
+		});
+		assert.ok(
+			prompt.includes("<available_skills>"),
+			"Expected <available_skills> when selectedTools is undefined (defaults apply)",
+		);
+	});
+});

--- a/packages/pi-coding-agent/src/core/system-prompt.ts
+++ b/packages/pi-coding-agent/src/core/system-prompt.ts
@@ -84,9 +84,12 @@ export function buildSystemPrompt(options: BuildSystemPromptOptions = {}): strin
 			}
 		}
 
-		// Append skills section (only if read tool is available)
-		const customPromptHasRead = !selectedTools || selectedTools.includes("read");
-		if (customPromptHasRead && skills.length > 0) {
+		// Append skills section when the Skill tool is available.
+		// Before PR #1661 skills depended on the read tool; now Skill is a
+		// standalone built-in, so gate on either tool for backward compat.
+		const customPromptHasSkillTool =
+			!selectedTools || selectedTools.includes("read") || selectedTools.includes("Skill");
+		if (customPromptHasSkillTool && skills.length > 0) {
 			prompt += formatSkillsForPrompt(skills);
 		}
 
@@ -232,8 +235,10 @@ Pi documentation (read only when the user asks about pi itself, its SDK, extensi
 		}
 	}
 
-	// Append skills section (only if read tool is available)
-	if (hasRead && skills.length > 0) {
+	// Append skills section when the Skill tool is available.
+	// Gate on either "read" (legacy) or "Skill" (post-#1661 built-in).
+	const hasSkillTool = tools.includes("Skill");
+	if ((hasRead || hasSkillTool) && skills.length > 0) {
 		prompt += formatSkillsForPrompt(skills);
 	}
 


### PR DESCRIPTION
## TL;DR

**What:** Gate `<available_skills>` on the `Skill` tool presence instead of `read`.
**Why:** Since PR #1661 made `Skill` a standalone built-in, the skill catalog should appear whenever `Skill` is in the toolset -- not only when `read` is.
**How:** Check for `"Skill"` in `selectedTools` alongside the existing `"read"` check in both prompt paths.

## What

The system prompt's `<available_skills>` section was gated on the `read` tool being present in `selectedTools`. In configurations where `read` is excluded but `Skill` is available, the model could invoke the Skill tool but was never told which skills exist.

This PR updates both gating conditions in `buildSystemPrompt`:
- **Custom prompt path:** `customPromptHasRead` renamed to `customPromptHasSkillTool`, now checks `selectedTools.includes("Skill")` in addition to `selectedTools.includes("read")`.
- **Default prompt path:** Added `hasSkillTool = tools.includes("Skill")` and changed the condition to `(hasRead || hasSkillTool)`.

## Why

PR #1661 decoupled skill invocation from the `read` tool by making `Skill` a first-class built-in. The prompt generation was not updated to match, creating a mismatch: the model has the tool but no catalog of valid skill names.

## How

Two lines changed in `packages/pi-coding-agent/src/core/system-prompt.ts`:
1. Custom prompt path (line ~90): OR `selectedTools.includes("Skill")` into the gate.
2. Default prompt path (line ~240): OR `tools.includes("Skill")` into the gate.

Both paths preserve backward compatibility -- `read` alone still triggers the catalog.

## Test plan

- Added `system-prompt.test.ts` with 7 test cases covering:
  - [x] Skills included when `Skill` present but `read` absent (default prompt)
  - [x] Skills included when both `read` and `Skill` present (default prompt)
  - [x] Skills omitted when neither `read` nor `Skill` present (default prompt)
  - [x] Same three scenarios for the custom prompt path
  - [x] Backward compat: skills included when `selectedTools` is undefined

Fixes #1949