### PR TITLE
fix(web): use compiled JS for subprocess calls under node_modules

### DIFF
--- a/src/tests/web-packaged-standalone-subprocess.test.ts
+++ b/src/tests/web-packaged-standalone-subprocess.test.ts
@@ -1,0 +1,120 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+import { join } from "node:path"
+
+import {
+  resolveAutoDashboardSubprocessConfig,
+} from "../web/auto-dashboard-service.ts"
+import {
+  resolveWorkspaceIndexSubprocessConfig,
+} from "../web/bridge-service.ts"
+
+// ---------------------------------------------------------------------------
+// Issue #1959 — packaged-standalone subprocess must use compiled JS, not TS
+// ---------------------------------------------------------------------------
+// When GSD is installed via npm, source files live under node_modules/.
+// Node.js rejects --experimental-strip-types for files under node_modules/
+// (ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING), and
+// --experimental-transform-types requires @swc/wasm-typescript which may
+// not be installed.
+//
+// The fix: when packageRoot is under node_modules/, use the pre-compiled
+// dist/ JS files and skip type-stripping flags entirely.
+
+// ── Auto Dashboard ──────────────────────────────────────────────────────────
+
+test("auto-dashboard subprocess: uses dist/auto.js when packageRoot is under node_modules/", () => {
+  const packageRoot = "/opt/homebrew/lib/node_modules/gsd-pi"
+  const config = resolveAutoDashboardSubprocessConfig(packageRoot, {
+    existsSync: () => true,
+    env: {} as NodeJS.ProcessEnv,
+  })
+
+  const expectedDistPath = join(packageRoot, "dist", "resources", "extensions", "gsd", "auto.js")
+  assert.equal(config.modulePath, expectedDistPath, "must resolve to dist/auto.js")
+  assert.ok(!config.args.includes("--experimental-strip-types"), "must not use --experimental-strip-types")
+  assert.ok(!config.args.includes("--experimental-transform-types"), "must not use --experimental-transform-types")
+  assert.ok(!config.args.some((a: string) => a.includes("resolve-ts.mjs")), "must not use resolve-ts.mjs loader")
+})
+
+test("auto-dashboard subprocess: uses src/auto.ts when packageRoot is NOT under node_modules/", () => {
+  const packageRoot = "/home/user/projects/gsd-2"
+  const config = resolveAutoDashboardSubprocessConfig(packageRoot, {
+    existsSync: () => true,
+    env: {} as NodeJS.ProcessEnv,
+  })
+
+  const expectedSrcPath = join(packageRoot, "src", "resources", "extensions", "gsd", "auto.ts")
+  assert.equal(config.modulePath, expectedSrcPath, "must resolve to src/auto.ts")
+  const hasTypeFlag = config.args.some((a: string) =>
+    a === "--experimental-strip-types" || a === "--experimental-transform-types",
+  )
+  assert.ok(hasTypeFlag, "must include a type-stripping flag for TS source")
+})
+
+test("auto-dashboard subprocess: falls back to src/auto.ts when dist/auto.js does not exist under node_modules/", () => {
+  const packageRoot = "/opt/homebrew/lib/node_modules/gsd-pi"
+  const distPath = join(packageRoot, "dist", "resources", "extensions", "gsd", "auto.js")
+
+  const config = resolveAutoDashboardSubprocessConfig(packageRoot, {
+    existsSync: (p: string) => p !== distPath, // dist file does not exist
+    env: {} as NodeJS.ProcessEnv,
+  })
+
+  const expectedSrcPath = join(packageRoot, "src", "resources", "extensions", "gsd", "auto.ts")
+  assert.equal(config.modulePath, expectedSrcPath, "must fall back to src/auto.ts when dist not available")
+})
+
+// ── Workspace Index ─────────────────────────────────────────────────────────
+
+test("workspace-index subprocess: uses dist/workspace-index.js when packageRoot is under node_modules/", () => {
+  const packageRoot = "/opt/homebrew/lib/node_modules/gsd-pi"
+  const config = resolveWorkspaceIndexSubprocessConfig(packageRoot, {
+    existsSync: () => true,
+  })
+
+  const expectedDistPath = join(packageRoot, "dist", "resources", "extensions", "gsd", "workspace-index.js")
+  assert.equal(config.modulePath, expectedDistPath, "must resolve to dist/workspace-index.js")
+  assert.ok(!config.args.includes("--experimental-strip-types"), "must not use --experimental-strip-types")
+  assert.ok(!config.args.includes("--experimental-transform-types"), "must not use --experimental-transform-types")
+  assert.ok(!config.args.some((a: string) => a.includes("resolve-ts.mjs")), "must not use resolve-ts.mjs loader")
+})
+
+test("workspace-index subprocess: uses src/workspace-index.ts when packageRoot is NOT under node_modules/", () => {
+  const packageRoot = "/home/user/projects/gsd-2"
+  const config = resolveWorkspaceIndexSubprocessConfig(packageRoot, {
+    existsSync: () => true,
+  })
+
+  const expectedSrcPath = join(packageRoot, "src", "resources", "extensions", "gsd", "workspace-index.ts")
+  assert.equal(config.modulePath, expectedSrcPath, "must resolve to src/workspace-index.ts")
+  const hasTypeFlag = config.args.some((a: string) =>
+    a === "--experimental-strip-types" || a === "--experimental-transform-types",
+  )
+  assert.ok(hasTypeFlag, "must include a type-stripping flag for TS source")
+})
+
+test("workspace-index subprocess: falls back to src/workspace-index.ts when dist file missing under node_modules/", () => {
+  const packageRoot = "/opt/homebrew/lib/node_modules/gsd-pi"
+  const distPath = join(packageRoot, "dist", "resources", "extensions", "gsd", "workspace-index.js")
+
+  const config = resolveWorkspaceIndexSubprocessConfig(packageRoot, {
+    existsSync: (p: string) => p !== distPath,
+  })
+
+  const expectedSrcPath = join(packageRoot, "src", "resources", "extensions", "gsd", "workspace-index.ts")
+  assert.equal(config.modulePath, expectedSrcPath, "must fall back to src/workspace-index.ts when dist not available")
+})
+
+// ── Windows path handling ───────────────────────────────────────────────────
+
+test("auto-dashboard subprocess: detects node_modules in Windows-style paths", () => {
+  const packageRoot = "C:\\Users\\dev\\AppData\\node_modules\\gsd-pi"
+  const config = resolveAutoDashboardSubprocessConfig(packageRoot, {
+    existsSync: () => true,
+    env: {} as NodeJS.ProcessEnv,
+  })
+
+  const expectedDistPath = join(packageRoot, "dist", "resources", "extensions", "gsd", "auto.js")
+  assert.equal(config.modulePath, expectedDistPath, "must detect node_modules in Windows paths")
+})

--- a/src/web/auto-dashboard-service.ts
+++ b/src/web/auto-dashboard-service.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 
 import type { AutoDashboardData } from "./bridge-service.ts";
-import { resolveTypeStrippingFlag } from "./ts-subprocess-flags.ts"
+import { resolveTypeStrippingFlag, isUnderNodeModules } from "./ts-subprocess-flags.ts"
 
 const AUTO_DASHBOARD_MAX_BUFFER = 1024 * 1024;
 const TEST_AUTO_DASHBOARD_MODULE_ENV = "GSD_WEB_TEST_AUTO_DASHBOARD_MODULE";
@@ -15,6 +15,11 @@ export interface AutoDashboardServiceOptions {
   execPath?: string;
   env?: NodeJS.ProcessEnv;
   existsSync?: (path: string) => boolean;
+}
+
+export interface SubprocessConfig {
+  modulePath: string;
+  args: string[];
 }
 
 function fallbackAutoDashboardData(): AutoDashboardData {
@@ -32,12 +37,63 @@ function fallbackAutoDashboardData(): AutoDashboardData {
   };
 }
 
-function resolveAutoDashboardModulePath(packageRoot: string, env: NodeJS.ProcessEnv): string {
-  return env[TEST_AUTO_DASHBOARD_MODULE_ENV] || join(packageRoot, "src", "resources", "extensions", "gsd", "auto.ts");
-}
-
 function resolveTsLoaderPath(packageRoot: string): string {
   return join(packageRoot, "src", "resources", "extensions", "gsd", "tests", "resolve-ts.mjs");
+}
+
+/**
+ * Resolves the subprocess configuration for the auto-dashboard module.
+ *
+ * When packageRoot is under node_modules/ (packaged-standalone mode) and the
+ * compiled dist/auto.js exists, returns a config that uses the compiled JS
+ * directly — no type-stripping flags, no TS loader. This avoids
+ * ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING on all Node versions.
+ *
+ * Falls back to the TypeScript source with appropriate type-stripping flags
+ * when running from a development checkout or when the compiled file is missing.
+ */
+export function resolveAutoDashboardSubprocessConfig(
+  packageRoot: string,
+  options: { existsSync?: (path: string) => boolean; env?: NodeJS.ProcessEnv },
+): SubprocessConfig {
+  const checkExists = options.existsSync ?? existsSync;
+  const env = options.env ?? process.env;
+
+  // Test override path takes precedence
+  const testModulePath = env[TEST_AUTO_DASHBOARD_MODULE_ENV];
+  if (testModulePath) {
+    const resolveTsLoader = resolveTsLoaderPath(packageRoot);
+    return {
+      modulePath: testModulePath,
+      args: [
+        "--import", pathToFileURL(resolveTsLoader).href,
+        resolveTypeStrippingFlag(packageRoot),
+        "--input-type=module",
+      ],
+    };
+  }
+
+  const distModulePath = join(packageRoot, "dist", "resources", "extensions", "gsd", "auto.js");
+  const srcModulePath = join(packageRoot, "src", "resources", "extensions", "gsd", "auto.ts");
+  const resolveTsLoader = resolveTsLoaderPath(packageRoot);
+
+  // Prefer compiled JS when under node_modules/ to avoid type-stripping errors
+  if (isUnderNodeModules(packageRoot) && checkExists(distModulePath)) {
+    return {
+      modulePath: distModulePath,
+      args: ["--input-type=module"],
+    };
+  }
+
+  // Development mode: use TypeScript source with type-stripping
+  return {
+    modulePath: srcModulePath,
+    args: [
+      "--import", pathToFileURL(resolveTsLoader).href,
+      resolveTypeStrippingFlag(packageRoot),
+      "--input-type=module",
+    ],
+  };
 }
 
 export function collectTestOnlyFallbackAutoDashboardData(): AutoDashboardData {
@@ -54,11 +110,21 @@ export async function collectAuthoritativeAutoDashboardData(
   }
 
   const checkExists = options.existsSync ?? existsSync;
-  const resolveTsLoader = resolveTsLoaderPath(packageRoot);
-  const autoModulePath = resolveAutoDashboardModulePath(packageRoot, env);
+  const subprocessConfig = resolveAutoDashboardSubprocessConfig(packageRoot, {
+    existsSync: checkExists,
+    env,
+  });
 
-  if (!checkExists(resolveTsLoader) || !checkExists(autoModulePath)) {
-    throw new Error(`authoritative auto dashboard provider not found; checked=${resolveTsLoader},${autoModulePath}`);
+  // For TS source paths, verify the TS loader also exists
+  if (subprocessConfig.modulePath.endsWith(".ts")) {
+    const resolveTsLoader = resolveTsLoaderPath(packageRoot);
+    if (!checkExists(resolveTsLoader) || !checkExists(subprocessConfig.modulePath)) {
+      throw new Error(`authoritative auto dashboard provider not found; checked=${resolveTsLoader},${subprocessConfig.modulePath}`);
+    }
+  } else {
+    if (!checkExists(subprocessConfig.modulePath)) {
+      throw new Error(`authoritative auto dashboard provider not found; checked=${subprocessConfig.modulePath}`);
+    }
   }
 
   const script = [
@@ -72,10 +138,7 @@ export async function collectAuthoritativeAutoDashboardData(
     execFile(
       options.execPath ?? process.execPath,
       [
-        "--import",
-        pathToFileURL(resolveTsLoader).href,
-        resolveTypeStrippingFlag(packageRoot),
-        "--input-type=module",
+        ...subprocessConfig.args,
         "--eval",
         script,
       ],
@@ -83,7 +146,7 @@ export async function collectAuthoritativeAutoDashboardData(
         cwd: packageRoot,
         env: {
           ...env,
-          [AUTO_DASHBOARD_MODULE_ENV]: autoModulePath,
+          [AUTO_DASHBOARD_MODULE_ENV]: subprocessConfig.modulePath,
         },
         maxBuffer: AUTO_DASHBOARD_MAX_BUFFER,
       },

--- a/src/web/bridge-service.ts
+++ b/src/web/bridge-service.ts
@@ -4,7 +4,7 @@ import { StringDecoder } from "node:string_decoder";
 import type { Readable } from "node:stream";
 import { join, resolve, dirname } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
-import { resolveTypeStrippingFlag } from "./ts-subprocess-flags.ts";
+import { resolveTypeStrippingFlag, isUnderNodeModules } from "./ts-subprocess-flags.ts";
 
 import type { AgentSessionEvent, SessionStateChangeReason } from "../../packages/pi-coding-agent/src/core/agent-session.ts";
 import type {
@@ -903,13 +903,60 @@ async function loadCachedWorkspaceIndex(
   return cloneWorkspaceIndex(await promise);
 }
 
+/**
+ * Resolves the subprocess configuration for the workspace-index module.
+ *
+ * When packageRoot is under node_modules/ and the compiled dist/workspace-index.js
+ * exists, returns a config that uses the compiled JS directly — no type-stripping
+ * flags, no TS loader. This avoids ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING.
+ *
+ * Falls back to the TypeScript source with appropriate type-stripping flags
+ * when running from a development checkout or when the compiled file is missing.
+ */
+export function resolveWorkspaceIndexSubprocessConfig(
+  packageRoot: string,
+  options: { existsSync?: (path: string) => boolean },
+): { modulePath: string; args: string[] } {
+  const checkExists = options.existsSync ?? existsSync;
+
+  const distModulePath = join(packageRoot, "dist", "resources", "extensions", "gsd", "workspace-index.js");
+  const srcModulePath = join(packageRoot, "src", "resources", "extensions", "gsd", "workspace-index.ts");
+  const resolveTsLoader = join(packageRoot, "src", "resources", "extensions", "gsd", "tests", "resolve-ts.mjs");
+
+  // Prefer compiled JS when under node_modules/ to avoid type-stripping errors
+  if (isUnderNodeModules(packageRoot) && checkExists(distModulePath)) {
+    return {
+      modulePath: distModulePath,
+      args: ["--input-type=module"],
+    };
+  }
+
+  // Development mode: use TypeScript source with type-stripping
+  return {
+    modulePath: srcModulePath,
+    args: [
+      "--import", pathToFileURL(resolveTsLoader).href,
+      resolveTypeStrippingFlag(packageRoot),
+      "--input-type=module",
+    ],
+  };
+}
+
 async function loadWorkspaceIndexViaChildProcess(basePath: string, packageRoot: string): Promise<GSDWorkspaceIndex> {
   const deps = getBridgeDeps();
-  const resolveTsLoader = join(packageRoot, "src", "resources", "extensions", "gsd", "tests", "resolve-ts.mjs");
-  const workspaceModulePath = join(packageRoot, "src", "resources", "extensions", "gsd", "workspace-index.ts");
   const checkExists = deps.existsSync ?? existsSync;
-  if (!checkExists(resolveTsLoader) || !checkExists(workspaceModulePath)) {
-    throw new Error(`workspace index loader not found; checked=${resolveTsLoader},${workspaceModulePath}`);
+  const subprocessConfig = resolveWorkspaceIndexSubprocessConfig(packageRoot, { existsSync: checkExists });
+
+  // For TS source paths, verify the TS loader also exists
+  if (subprocessConfig.modulePath.endsWith(".ts")) {
+    const resolveTsLoader = join(packageRoot, "src", "resources", "extensions", "gsd", "tests", "resolve-ts.mjs");
+    if (!checkExists(resolveTsLoader) || !checkExists(subprocessConfig.modulePath)) {
+      throw new Error(`workspace index loader not found; checked=${resolveTsLoader},${subprocessConfig.modulePath}`);
+    }
+  } else {
+    if (!checkExists(subprocessConfig.modulePath)) {
+      throw new Error(`workspace index loader not found; checked=${subprocessConfig.modulePath}`);
+    }
   }
 
   const script = [
@@ -923,10 +970,7 @@ async function loadWorkspaceIndexViaChildProcess(basePath: string, packageRoot: 
     execFile(
       deps.execPath ?? process.execPath,
       [
-        "--import",
-        pathToFileURL(resolveTsLoader).href,
-        resolveTypeStrippingFlag(packageRoot),
-        "--input-type=module",
+        ...subprocessConfig.args,
         "--eval",
         script,
       ],
@@ -934,7 +978,7 @@ async function loadWorkspaceIndexViaChildProcess(basePath: string, packageRoot: 
         cwd: packageRoot,
         env: {
           ...(deps.env ?? process.env),
-          GSD_WORKSPACE_MODULE: workspaceModulePath,
+          GSD_WORKSPACE_MODULE: subprocessConfig.modulePath,
           GSD_WORKSPACE_BASE: basePath,
         },
         maxBuffer: 1024 * 1024,

--- a/src/web/ts-subprocess-flags.ts
+++ b/src/web/ts-subprocess-flags.ts
@@ -23,7 +23,7 @@ export function resolveTypeStrippingFlag(packageRoot: string): string {
  * Returns true when the given path sits inside a `node_modules/` directory.
  * Handles both Unix and Windows path separators.
  */
-function isUnderNodeModules(filePath: string): boolean {
+export function isUnderNodeModules(filePath: string): boolean {
   const normalized = filePath.replace(/\\/g, "/")
   return normalized.includes("/node_modules/")
 }


### PR DESCRIPTION
## TL;DR

Fix `/api/boot` crash (ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING) when GSD is npm-installed by using pre-compiled dist/ JS files instead of spawning TypeScript subprocesses under node_modules/.

## What

- Extract `resolveAutoDashboardSubprocessConfig` from `auto-dashboard-service.ts` and `resolveWorkspaceIndexSubprocessConfig` from `bridge-service.ts` that detect when packageRoot is under `node_modules/` and prefer the compiled `dist/resources/extensions/gsd/auto.js` and `dist/resources/extensions/gsd/workspace-index.js` files.
- When using compiled JS, skip `--experimental-strip-types`, `--experimental-transform-types`, and the `resolve-ts.mjs` TS loader entirely.
- Fall back to TypeScript source with appropriate type-stripping flags for development checkouts.
- Export `isUnderNodeModules` from `ts-subprocess-flags.ts` for reuse.
- Add 7 regression tests covering both modes, fallback behavior, and Windows path detection.

## Why

PR #1864 addressed this class of bug by switching to `--experimental-transform-types` under `node_modules/`, but that flag requires `@swc/wasm-typescript` to be installed (it is not bundled with GSD). The compiled JS files already ship in the npm package (`dist/` is in the `files` array) and are the correct artifacts to use in packaged-standalone mode, following the pattern already established by `resolveGsdCliEntry` in `cli-entry.ts`.

## How

Both `resolveAutoDashboardSubprocessConfig` and `resolveWorkspaceIndexSubprocessConfig` check `isUnderNodeModules(packageRoot)` and whether the corresponding `dist/*.js` file exists. When both conditions are true, they return a subprocess config that uses the compiled JS directly with only `--input-type=module` (no TS flags, no TS loader). When the dist file is missing or the package root is not under `node_modules/`, they fall back to the existing TypeScript subprocess path.

**Note:** 10+ other service files in `src/web/` (visualizer, forensics, doctor, etc.) have the same subprocess pattern and will need the same treatment. Those are tracked separately to keep this PR focused on the `/api/boot` critical path.

Fixes #1959