### PR TITLE
fix(doctor): chdir out of orphaned worktree before removal

### DIFF
--- a/src/resources/extensions/gsd/doctor-checks.ts
+++ b/src/resources/extensions/gsd/doctor-checks.ts
@@ -70,17 +70,24 @@ export async function checkGitHealth(
         });
 
         if (shouldFix("orphaned_auto_worktree")) {
-          // Never remove a worktree matching current working directory
+          // If cwd is inside the worktree, chdir out first — matching the
+          // pattern in removeWorktree() (#1946). Without this, git cannot
+          // remove the worktree and the doctor enters a deadlock where it
+          // detects the orphan every run but never cleans it up.
           const cwd = process.cwd();
           if (wt.path === cwd || cwd.startsWith(wt.path + sep)) {
-            fixesApplied.push(`skipped removing worktree at ${wt.path} (is cwd)`);
-          } else {
             try {
-              nativeWorktreeRemove(basePath, wt.path, true);
-              fixesApplied.push(`removed orphaned worktree ${wt.path}`);
+              process.chdir(basePath);
             } catch {
-              fixesApplied.push(`failed to remove worktree ${wt.path}`);
+              fixesApplied.push(`skipped removing worktree at ${wt.path} (cannot chdir to basePath)`);
+              continue;
             }
+          }
+          try {
+            nativeWorktreeRemove(basePath, wt.path, true);
+            fixesApplied.push(`removed orphaned worktree ${wt.path}`);
+          } catch {
+            fixesApplied.push(`failed to remove worktree ${wt.path}`);
           }
         }
       }

--- a/src/resources/extensions/gsd/tests/doctor-git.test.ts
+++ b/src/resources/extensions/gsd/tests/doctor-git.test.ts
@@ -149,6 +149,56 @@ async function main(): Promise<void> {
       console.log("\n=== orphaned_auto_worktree (skipped on Windows) ===");
     }
 
+    // ─── Test 1b: Orphaned worktree fix when cwd is inside worktree (#1946) ──
+    // Reproduces the deadlock: if process.cwd() is inside the orphaned worktree,
+    // the doctor must chdir out before removing it — not skip the removal.
+    if (process.platform !== "win32") {
+    console.log("\n=== orphaned_auto_worktree (cwd inside worktree) ===");
+    {
+      const dir = createRepoWithCompletedMilestone();
+      cleanups.push(dir);
+
+      // Create worktree with milestone/M001 branch under .gsd/worktrees/
+      mkdirSync(join(dir, ".gsd", "worktrees"), { recursive: true });
+      run("git worktree add -b milestone/M001 .gsd/worktrees/M001", dir);
+
+      const wtPath = realpathSync(join(dir, ".gsd", "worktrees", "M001"));
+
+      // Simulate the deadlock: set cwd inside the orphaned worktree
+      const previousCwd = process.cwd();
+      process.chdir(wtPath);
+      try {
+        const fixed = await runGSDDoctor(dir, { fix: true, isolationMode: "worktree" });
+
+        // The fix must NOT skip removal — it should chdir out and remove
+        assertTrue(
+          !fixed.fixesApplied.some(f => f.includes("skipped removing worktree")),
+          "does NOT skip removal when cwd is inside worktree",
+        );
+        assertTrue(
+          fixed.fixesApplied.some(f => f.includes("removed orphaned worktree")),
+          "removes orphaned worktree even when cwd was inside it",
+        );
+
+        // Verify worktree is gone
+        const wtList = run("git worktree list", dir);
+        assertTrue(!wtList.includes("milestone/M001"), "worktree removed after fix with cwd inside");
+
+        // Verify cwd was moved out (should be basePath, not still inside worktree)
+        const newCwd = process.cwd();
+        assertTrue(
+          !newCwd.startsWith(wtPath),
+          "cwd moved out of worktree after fix",
+        );
+      } finally {
+        // Restore cwd — the worktree dir may be gone, so chdir to previousCwd
+        try { process.chdir(previousCwd); } catch { process.chdir(dir); }
+      }
+    }
+    } else {
+      console.log("\n=== orphaned_auto_worktree (cwd inside worktree — skipped on Windows) ===");
+    }
+
     // ─── Test 2: Stale milestone branch detection & fix ────────────────
     // Skip on Windows: git branch glob matching and path resolution
     // behave differently in Windows temp dirs.


### PR DESCRIPTION
## TL;DR

**What:** Doctor's `orphaned_auto_worktree` fix now calls `process.chdir(basePath)` before worktree removal when cwd is inside the worktree.
**Why:** Without this, the fix skips removal (deadlock), and the orphan persists across every doctor run.
**How:** Added chdir-out-first logic matching the existing `removeWorktree()` pattern, with a regression test.

## What

Changed the `orphaned_auto_worktree` fix in `doctor-checks.ts` to call `process.chdir(basePath)` before attempting `nativeWorktreeRemove()` when `process.cwd()` is inside the worktree path. If the chdir fails, the removal is skipped with a descriptive message.

Added a regression test in `doctor-git.test.ts` that sets cwd inside an orphaned worktree and verifies the doctor successfully removes it instead of skipping.

## Why

The previous code had a deadlock: it detected the orphaned worktree for a completed milestone but refused to remove it because cwd was inside it. Nothing else changed cwd, so the doctor would report `skipped removing worktree at ... (is cwd)` on every run. This left stale `.gsd/` state that polluted `deriveState()` and caused `/gsd status` to show the wrong active milestone.

The correct pattern already existed in `removeWorktree()` (`worktree-manager.ts:309-313`) — chdir to basePath before removal.

## How

- `doctor-checks.ts`: Replaced the skip-if-cwd-inside guard with a chdir-then-remove sequence. Falls back to skip only if `process.chdir(basePath)` itself throws.
- `doctor-git.test.ts`: Added test "orphaned_auto_worktree (cwd inside worktree)" that sets `process.cwd()` inside the worktree, runs `runGSDDoctor` with `fix: true`, and asserts: (1) removal is not skipped, (2) worktree is removed, (3) cwd is no longer inside the worktree.

Fixes #1946

Generated with [Claude Code](https://claude.com/claude-code)