### PR TITLE
fix(auto): clean session state on step-wizard exit

### DIFF
--- a/src/resources/extensions/gsd/auto-worktree-sync.ts
+++ b/src/resources/extensions/gsd/auto-worktree-sync.ts
@@ -102,6 +102,16 @@ export function syncStateToProjectRoot(
     join(prGsd, "runtime", "units"),
     { force: true },
   );
+
+  // 5. completed-units.json — unit completion tracking for crash recovery
+  // and forensics. Without this, the project root has no record of completed
+  // units, so crash recovery and forensics report completedUnits: 0 even
+  // when units finished successfully in the worktree (#1944).
+  safeCopy(
+    join(wtGsd, "completed-units.json"),
+    join(prGsd, "completed-units.json"),
+    { force: true },
+  );
 }
 
 // ─── Resource Staleness ───────────────────────────────────────────────────

--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -1260,7 +1260,11 @@ export async function runFinalize(
   }
 
   if (postResult === "step-wizard") {
-    // Step mode — exit the loop (caller handles wizard)
+    // Step mode — persist session state so the next /gsd auto takes the
+    // resume path instead of fresh-bootstrap (which resets completedUnits).
+    // Without this, s.active stays true, the crash lock is stale, and the
+    // session lock is unreleased (#1944).
+    await deps.pauseAuto(ctx, pi);
     debugLog("autoLoop", { phase: "exit", reason: "step-wizard" });
     return { action: "break", reason: "step-wizard" };
   }

--- a/src/resources/extensions/gsd/tests/auto-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-loop.test.ts
@@ -2129,3 +2129,88 @@ test("autoLoop stops when worktree has no project files for execute-task (#1833)
     "should notify about missing project files in worktree",
   );
 });
+
+// ─── #1944: Step-mode exit must call pauseAuto ────────────────────────────
+
+test("step-wizard break calls pauseAuto before exiting (#1944)", async (t) => {
+  _resetPendingResolve();
+
+  const ctx = makeMockCtx();
+  ctx.ui.setStatus = () => {};
+  ctx.sessionManager = { getSessionFile: () => "/tmp/session.json" };
+  const pi = makeMockPi();
+
+  let loopCount = 0;
+  const s = makeLoopSession({ stepMode: true });
+
+  const deps = makeMockDeps({
+    deriveState: async () => {
+      deps.callLog.push("deriveState");
+      return {
+        phase: "executing",
+        activeMilestone: { id: "M001", title: "Test", status: "active" },
+        activeSlice: { id: "S01", title: "Slice 1" },
+        activeTask: { id: "T01" },
+        registry: [{ id: "M001", status: "active" }],
+        blockers: [],
+      } as any;
+    },
+    resolveDispatch: async () => {
+      deps.callLog.push("resolveDispatch");
+      return {
+        action: "dispatch" as const,
+        unitType: "execute-task",
+        unitId: "M001/S01/T01",
+        prompt: "do the thing",
+      };
+    },
+    postUnitPostVerification: async () => {
+      deps.callLog.push("postUnitPostVerification");
+      loopCount++;
+      return "step-wizard" as const;
+    },
+  });
+
+  const loopPromise = autoLoop(ctx, pi, s, deps);
+
+  // Give the loop time to reach runUnit's await
+  await new Promise((r) => setTimeout(r, 50));
+
+  // Resolve the unit's agent_end
+  resolveAgentEnd(makeEvent());
+
+  await loopPromise;
+
+  // pauseAuto MUST be called before the loop exits on step-wizard
+  assert.ok(
+    deps.callLog.includes("pauseAuto"),
+    `step-wizard exit must call pauseAuto to persist session state for clean resume. Call log: ${deps.callLog.join(", ")}`,
+  );
+
+  // stopAuto should NOT be called — step-wizard is a pause, not a stop
+  assert.ok(
+    !deps.callLog.includes("stopAuto"),
+    "step-wizard exit should not call stopAuto",
+  );
+});
+
+// ─── #1944: syncStateToProjectRoot must sync completed-units.json ─────────
+
+test("syncStateToProjectRoot copies completed-units.json (#1944)", () => {
+  const source = readFileSync(
+    resolve(import.meta.dirname, "..", "auto-worktree-sync.ts"),
+    "utf-8",
+  );
+
+  const fnIdx = source.indexOf("export function syncStateToProjectRoot");
+  assert.ok(fnIdx > -1, "syncStateToProjectRoot must exist in auto-worktree-sync.ts");
+
+  // Extract the function body (up to the next export or top-level comment block)
+  const nextExportIdx = source.indexOf("\n// ─── ", fnIdx + 50);
+  const fnBlock = source.slice(fnIdx, nextExportIdx > -1 ? nextExportIdx : undefined);
+
+  assert.ok(
+    fnBlock.includes("completed-units.json"),
+    "syncStateToProjectRoot must sync completed-units.json from worktree to project root",
+  );
+});


### PR DESCRIPTION
## TL;DR

**What:** Call `pauseAuto` before the step-wizard break in `runFinalize`, and sync `completed-units.json` from worktree to project root.
**Why:** Step-mode loop exit left `s.active = true`, the crash lock stale, and the session lock unreleased, causing subsequent `/gsd auto` to take the fresh-bootstrap path (resetting `completedUnits`). Separately, `completed-units.json` was never synced to the project root, so crash recovery and forensics lost unit completion tracking.
**How:** Two targeted changes plus regression tests.

## What

1. **`auto/phases.ts` (`runFinalize`):** When `postUnitPostVerification` returns `"step-wizard"`, call `await deps.pauseAuto(ctx, pi)` before returning the break action. This mirrors how every other non-error exit path (UAT pause, budget pause, context-window pause, health-gate) already calls `pauseAuto` or `stopAuto` before breaking.

2. **`auto-worktree-sync.ts` (`syncStateToProjectRoot`):** Add `safeCopy` for `completed-units.json` from worktree `.gsd/` to project root `.gsd/`, so crash recovery and forensics can read completed-unit data regardless of which directory they resolve.

## Why

- The step-wizard break path was the only `autoLoop` exit that performed no session cleanup. The comment "caller handles wizard" was aspirational -- `startAuto` does not contain wizard logic after `await autoLoop()`.
- Without `pauseAuto`, `s.active` remains `true`, the crash lock retains stale unit info, and the session lock (`proper-lockfile`) is never released. The next `/gsd auto` call enters `bootstrapAutoSession` (fresh start) and resets `s.completedUnits = []`.
- `completed-units.json` was tracked in `.gitignore` and `git-service.ts` exclusions, and was written by `auto-post-unit.ts`, but `syncStateToProjectRoot` never copied it. Forensics reading from the project root reported `Completed Keys: 0`.

## How

- `phases.ts`: Added `await deps.pauseAuto(ctx, pi)` on the line before the `debugLog` and `return` in the `step-wizard` branch of `runFinalize`.
- `auto-worktree-sync.ts`: Added a `safeCopy` call for `completed-units.json` after the existing runtime records sync block.
- `auto-loop.test.ts`: Two new regression tests:
  - Behavioral test: runs `autoLoop` with `postUnitPostVerification` returning `"step-wizard"` and asserts `pauseAuto` was called (and `stopAuto` was not).
  - Structural test: reads `auto-worktree-sync.ts` source and asserts `syncStateToProjectRoot` references `completed-units.json`.

Fixes #1944