### PR TITLE
fix(git): use git add -u in symlink .gsd fallback to prevent hang

### DIFF
--- a/src/resources/extensions/gsd/native-git-bridge.ts
+++ b/src/resources/extensions/gsd/native-git-bridge.ts
@@ -712,10 +712,12 @@ export function nativeAddAllWithExclusions(basePath: string, exclusions: readonl
       return;
     }
     // When .gsd is a symlink, git rejects `:!.gsd/...` pathspecs with
-    // "beyond a symbolic link". Fall back to plain `git add -A` which
-    // respects .gitignore (where .gsd/ is listed by default).
+    // "beyond a symbolic link". Fall back to `git add -u` which only
+    // stages changes to already-tracked files — O(tracked) not O(filesystem).
+    // Using `git add -A` here would traverse the entire working tree,
+    // hanging indefinitely on repos with large untracked data dirs. (#1977)
     if (stderr.includes("beyond a symbolic link")) {
-      nativeAddAll(basePath);
+      gitFileExec(basePath, ["add", "-u"]);
       return;
     }
     throw new GSDError(GSD_GIT_ERROR, `git add -A with exclusions failed in ${basePath}: ${getErrorMessage(err)}`);

--- a/src/resources/extensions/gsd/tests/git-service.test.ts
+++ b/src/resources/extensions/gsd/tests/git-service.test.ts
@@ -1241,7 +1241,7 @@ async function main(): Promise<void> {
   {
     // When .gsd is a symlink, git rejects `:!.gsd/...` pathspecs with
     // "fatal: pathspec '...' is beyond a symbolic link". The fix falls
-    // back to plain `git add -A`, which respects .gitignore.
+    // back to `git add -u` (tracked files only), NOT `git add -A`.
     const repo = initTempRepo();
 
     // Create the real .gsd directory outside the repo, then symlink it
@@ -1253,11 +1253,18 @@ async function main(): Promise<void> {
     // Symlink .gsd -> external directory
     symlinkSync(externalGsd, join(repo, ".gsd"));
 
-    // Add .gitignore so git add -A fallback skips .gsd/
+    // Add .gitignore so .gsd/ is ignored
     writeFileSync(join(repo, ".gitignore"), ".gsd\n");
 
-    // Create a real file that should be staged
+    // Create a tracked file and commit it, then modify it
     createFile(repo, "src/app.ts", "export const x = 1;");
+    run("git add -A", repo);
+    run('git commit -m "add app"', repo);
+    writeFileSync(join(repo, "src/app.ts"), "export const x = 2;");
+
+    // Create an untracked file simulating large data (NOT in .gitignore)
+    // This is the key scenario: large untracked dirs that git add -A would traverse
+    createFile(repo, "data/large-model.bin", "pretend this is 10GB");
 
     // nativeAddAllWithExclusions should NOT throw despite .gsd being a symlink
     let threw = false;
@@ -1269,9 +1276,15 @@ async function main(): Promise<void> {
     }
     assertTrue(!threw, "nativeAddAllWithExclusions does not throw with symlinked .gsd");
 
-    // Verify the real file was staged
+    // Verify the tracked modified file was staged
     const staged = run("git diff --cached --name-only", repo);
-    assertTrue(staged.includes("src/app.ts"), "real file staged despite symlinked .gsd");
+    assertTrue(staged.includes("src/app.ts"), "modified tracked file staged despite symlinked .gsd");
+
+    // CRITICAL: untracked files must NOT be staged — the symlink fallback
+    // should use `git add -u` (tracked only), not `git add -A` (all files).
+    // Using `git add -A` on a repo with large untracked data dirs hangs. (#1977)
+    assertTrue(!staged.includes("data/large-model.bin"),
+      "symlink fallback must not stage untracked files (would hang on large repos)");
     assertTrue(!staged.includes(".gsd"), ".gsd content not staged");
 
     rmSync(repo, { recursive: true, force: true });


### PR DESCRIPTION
## TL;DR

**What:** Change the symlink `.gsd` fallback in `nativeAddAllWithExclusions` from `git add -A` to `git add -u`.
**Why:** `git add -A` traverses the entire working tree, hanging indefinitely on repos with large untracked data directories (444GB+ observed in #1977).
**How:** Replace `nativeAddAll(basePath)` with `gitFileExec(basePath, ["add", "-u"])` in the "beyond a symbolic link" catch block.

## What

When `.gsd` is a symlink to an external state directory, git rejects pathspec exclusions like `:!.gsd/activity/` with `fatal: pathspec ... is beyond a symbolic link`. The catch block in `nativeAddAllWithExclusions` previously fell back to `nativeAddAll()` which runs unrestricted `git add -A`.

This change replaces that fallback with `git add -u`, which only stages changes to already-tracked files (O(tracked) instead of O(filesystem)).

## Why

The `git add -A` fallback traverses and hashes the entire working tree. On repos with large untracked data directories (proteomics data, training caches, model artifacts), this pegs CPU at 100% and blocks the Node.js process indefinitely via `execFileSync` with no timeout.

This is a regression of #1712 which introduced the symlink fallback. That fix assumed `.gitignore` would cover all large directories, but scientific/ML repos commonly have massive untracked data dirs not in `.gitignore`.

The original pathspec exclusions fix (#1605) is entirely defeated on symlink-`.gsd` projects because the fallback reverts to pre-#1605 behavior.

## How

- Changed `nativeAddAll(basePath)` to `gitFileExec(basePath, ["add", "-u"])` in the symlink fallback path
- Updated the existing symlink fallback test to verify untracked files are NOT staged (the critical invariant)
- Test creates a tracked+modified file AND an untracked file, then asserts only the tracked file is staged

The tradeoff -- new untracked files are not staged in the symlink fallback path -- is acceptable because auto-commit primarily captures changes the agent made to existing tracked files.

Closes #1977