### PR TITLE
fix: clean tracked .gsd/ root files before squash merge (#1985)

### DIFF
--- a/src/resources/extensions/gsd/auto-worktree.ts
+++ b/src/resources/extensions/gsd/auto-worktree.ts
@@ -83,6 +83,45 @@ function clearProjectRootStateFiles(basePath: string, milestoneId: string): void
     }
   }
 
+  // Clean root-level .gsd/ files that syncWorktreeStateBack() may have
+  // dirtied (#1985).  These are the same files the squash merge will bring
+  // in from the milestone branch, so restoring/removing them pre-merge is
+  // safe and avoids "local changes would be overwritten" rejections.
+  const syncBackFiles = [
+    "DECISIONS.md",
+    "REQUIREMENTS.md",
+    "PROJECT.md",
+    "KNOWLEDGE.md",
+    "OVERRIDES.md",
+    "QUEUE.md",
+    "completed-units.json",
+  ];
+  for (const f of syncBackFiles) {
+    const filePath = join(gsdDir, f);
+    try {
+      // Check if the file is tracked by git
+      const isTracked = execFileSync(
+        "git",
+        ["ls-files", filePath],
+        { cwd: basePath, stdio: ["ignore", "pipe", "pipe"], encoding: "utf-8" },
+      ).trim();
+      if (isTracked) {
+        // Tracked and potentially modified — restore to HEAD so the merge
+        // can cleanly apply the milestone branch version.
+        execFileSync("git", ["checkout", "HEAD", "--", filePath], {
+          cwd: basePath,
+          stdio: "ignore",
+        });
+      } else if (existsSync(filePath)) {
+        // Untracked — safe to delete; the merge will recreate from the
+        // milestone branch if the file exists there.
+        unlinkSync(filePath);
+      }
+    } catch {
+      /* non-fatal — git command may fail, file may not exist */
+    }
+  }
+
   // Clean up entire synced milestone directory and runtime/units.
   // syncStateToProjectRoot() copies these into the project root during
   // execution.  If they remain as untracked files when we attempt

--- a/src/resources/extensions/gsd/tests/auto-worktree-milestone-merge.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-worktree-milestone-merge.test.ts
@@ -771,6 +771,63 @@ async function main(): Promise<void> {
       assertTrue(existsSync(join(repo, "real-code.ts")), "real-code.ts merged to main");
     }
 
+    // ─── Test 20: #1985 — tracked root-level .gsd/ files dirtied by syncWorktreeStateBack ──
+    console.log("\n=== #1985: tracked .gsd/ root files cleaned before merge ===");
+    {
+      const repo = freshRepo();
+
+      // Force-track DECISIONS.md (simulates projects where .gsd/ files are
+      // force-added despite .gsd being in .gitignore)
+      writeFileSync(join(repo, ".gsd", "DECISIONS.md"), "# Decisions\n\n| ID | Decision |\n");
+      run("git add -f .gsd/DECISIONS.md", repo);
+      run("git commit -m 'track DECISIONS.md'", repo);
+
+      const wtPath = createAutoWorktree(repo, "M200");
+
+      addSliceToMilestone(repo, wtPath, "M200", "S01", "Tracked GSD files", [
+        { file: "feature.ts", content: "export const feat = true;\n", message: "add feature" },
+      ]);
+
+      // Also commit an updated DECISIONS.md on the milestone branch (worktree)
+      const wtDecisions = join(wtPath, ".gsd", "DECISIONS.md");
+      mkdirSync(join(wtPath, ".gsd"), { recursive: true });
+      writeFileSync(wtDecisions, "# Decisions\n\n| ID | Decision |\n| D001 | Use widgets |\n");
+      run("git add -f .gsd/DECISIONS.md", wtPath);
+      run("git commit -m 'update DECISIONS.md in milestone'", wtPath);
+
+      // Simulate syncWorktreeStateBack: overwrite the project root's tracked
+      // DECISIONS.md with the worktree version — this is what creates the
+      // dirty working tree that previously blocked the merge.
+      writeFileSync(
+        join(repo, ".gsd", "DECISIONS.md"),
+        "# Decisions\n\n| ID | Decision |\n| D001 | Use widgets |\n",
+      );
+
+      // Verify the file is dirty before merge
+      const dirtyStatus = run("git status --porcelain .gsd/DECISIONS.md", repo);
+      assertTrue(dirtyStatus.length > 0, "#1985: DECISIONS.md is dirty before merge");
+
+      const roadmap = makeRoadmap("M200", "Tracked GSD cleanup", [
+        { id: "S01", title: "Tracked GSD files" },
+      ]);
+
+      let threw = false;
+      let errorMsg = "";
+      try {
+        const result = mergeMilestoneToMain(repo, "M200", roadmap);
+        assertTrue(
+          result.commitMessage.includes("feat(M200)"),
+          "#1985: merge succeeds despite previously-dirty tracked .gsd/ files",
+        );
+      } catch (err: unknown) {
+        threw = true;
+        errorMsg = err instanceof Error ? err.message : String(err);
+        console.error("#1985 regression:", errorMsg);
+      }
+      assertTrue(!threw, `#1985: merge must not fail on tracked .gsd/ files dirtied by syncWorktreeStateBack (got: ${errorMsg})`);
+      assertTrue(existsSync(join(repo, "feature.ts")), "#1985: feature.ts on main after merge");
+    }
+
   } finally {
     process.chdir(savedCwd);
     for (const d of tempDirs) {


### PR DESCRIPTION
## Problem

Fixes #1985

`mergeMilestoneToMain` fails with `__dirty_working_tree__` when root-level `.gsd/` files (DECISIONS.md, REQUIREMENTS.md, PROJECT.md, etc.) are tracked by git and dirtied by `syncWorktreeStateBack()` before the squash merge.

## Root Cause

`syncWorktreeStateBack()` copies 7 root-level `.gsd/` files from the worktree into the project root before the merge. `clearProjectRootStateFiles()` cleans transient files (STATE.md, auto.lock, META.json) and untracked files in milestone/runtime dirs, but **never touches the root-level files**. When any of these are tracked (force-added despite `.gsd` in `.gitignore`), they show as modified and `git merge --squash` rejects with "local changes would be overwritten."

## Fix

Extend `clearProjectRootStateFiles()` to handle the root-level `.gsd/` files that `syncWorktreeStateBack()` may have dirtied:

- **Tracked and modified:** `git checkout HEAD -- <file>` to restore to HEAD state
- **Untracked:** `unlinkSync()` to remove (the merge will recreate from the milestone branch)

This is safe because the squash merge brings in the milestone branch versions of these files — the sync-back copies are redundant at merge time.

## Changes

- `src/resources/extensions/gsd/auto-worktree.ts` — added root-level `.gsd/` file cleanup to `clearProjectRootStateFiles()`
- `src/resources/extensions/gsd/tests/auto-worktree-milestone-merge.test.ts` — added Test 20 covering the exact reproduction: force-tracked DECISIONS.md dirtied by syncWorktreeStateBack, then mergeMilestoneToMain succeeds

## Test Results

```
auto-worktree-milestone-merge.test.ts
  Results: 73 passed, 0 failed
  All tests passed
```