### PR TITLE
fix: defense-in-depth for roadmap format enforcement

### DIFF
--- a/src/resources/extensions/gsd/auto-recovery.ts
+++ b/src/resources/extensions/gsd/auto-recovery.ts
@@ -307,6 +307,17 @@ export function verifyExpectedArtifact(
   if (!absPath) return false;
   if (!existsSync(absPath)) return false;
 
+  // plan-milestone must produce a roadmap with parseable slices, not just an
+  // empty scaffold. Without this check, a roadmap file that exists but contains
+  // no machine-readable slices (e.g. the LLM used an unsupported format) passes
+  // artifact verification, the unit is marked complete, and auto-mode blocks with
+  // "No slice eligible" — a confusing error with no actionable guidance.
+  if (unitType === "plan-milestone") {
+    const roadmapContent = readFileSync(absPath, "utf-8");
+    const roadmap = parseRoadmap(roadmapContent);
+    if (roadmap.slices.length === 0) return false;
+  }
+
   if (unitType === "validate-milestone") {
     const validationContent = readFileSync(absPath, "utf-8");
     if (!isValidationTerminal(validationContent)) return false;

--- a/src/resources/extensions/gsd/doctor-checks.ts
+++ b/src/resources/extensions/gsd/doctor-checks.ts
@@ -622,6 +622,39 @@ export async function checkRuntimeHealth(
     // Non-fatal — activity log check failed
   }
 
+  // ── Unparseable roadmaps ───────────────────────────────────────────────
+  // A roadmap file that exists but contains zero parseable slices will block
+  // auto-mode silently. Check every milestone that has a ROADMAP file.
+  try {
+    const msDir = milestonesDir(basePath);
+    if (existsSync(msDir)) {
+      const entries = readdirSync(msDir, { withFileTypes: true });
+      for (const entry of entries) {
+        if (!entry.isDirectory()) continue;
+        const mid = entry.name;
+        const roadmapPath = resolveMilestoneFile(basePath, mid, "ROADMAP");
+        if (!roadmapPath) continue;
+        const roadmapContent = roadmapPath ? await loadFile(roadmapPath) : null;
+        if (!roadmapContent) continue;
+
+        const roadmap = parseRoadmap(roadmapContent);
+        if (roadmap.slices.length === 0) {
+          issues.push({
+            severity: "error",
+            code: "unparseable_roadmap",
+            scope: "milestone",
+            unitId: mid,
+            message: `Roadmap for ${mid} exists but has no parseable slices — auto-mode will block. Ensure slices use checkbox format: - [ ] **S01: Title** \`risk:level\` \`depends:[]\``,
+            file: roadmapPath,
+            fixable: false,
+          });
+        }
+      }
+    }
+  } catch {
+    // Non-fatal — roadmap parse check failed
+  }
+
   // ── STATE.md health ───────────────────────────────────────────────────
   try {
     const stateFilePath = resolveGsdRootFile(basePath, "STATE");

--- a/src/resources/extensions/gsd/doctor-types.ts
+++ b/src/resources/extensions/gsd/doctor-types.ts
@@ -69,6 +69,8 @@ export type DoctorIssueCode =
   | "worktree_unpushed"
   // Snapshot ref bloat
   | "snapshot_ref_bloat"
+  // Roadmap structural checks
+  | "unparseable_roadmap"
   // Runtime data integrity
   | "orphaned_project_state"
   | "metrics_ledger_bloat"

--- a/src/resources/extensions/gsd/roadmap-slices.ts
+++ b/src/resources/extensions/gsd/roadmap-slices.ts
@@ -253,7 +253,10 @@ function parseProseSliceHeaders(content: string): RoadmapSliceEntry[] {
     const nextHeader = afterHeader.search(/^#{1,4}\s/m);
     const section = nextHeader !== -1 ? afterHeader.slice(0, nextHeader) : afterHeader.slice(0, 500);
 
-    const depsMatch = section.match(/\*{0,2}Depends\s+on:?\*{0,2}\s*(.+)/i);
+    // Extract dependencies — handles multiple LLM-generated variants:
+    //   "**Depends on:** S01"  |  "- **Depends:** S01"  |  "Depends: S01, S02"
+    //   "**Depends on:** none" |  "- **Depends:** none"
+    const depsMatch = section.match(/[-*\s]*\*{0,2}Depends(?:\s+on)?:?\*{0,2}\s*(.+)/i);
     let depends: string[] = [];
     if (depsMatch) {
       const rawDeps = depsMatch[1]!.replace(/none/i, "").trim();
@@ -264,7 +267,18 @@ function parseProseSliceHeaders(content: string): RoadmapSliceEntry[] {
       }
     }
 
-    slices.push({ id, title, risk: "medium" as RiskLevel, depends, done, demo: "" });
+    // Extract risk level from prose — handles:
+    //   "- **Risk:** high"  |  "**Risk:** medium"  |  "Risk: low"
+    let risk: RiskLevel = "medium";
+    const riskMatch = section.match(/[-*\s]*\*{0,2}Risk:?\*{0,2}\s*(\w+)/i);
+    if (riskMatch) {
+      const riskVal = riskMatch[1]!.toLowerCase();
+      if (riskVal === "high" || riskVal === "low" || riskVal === "medium") {
+        risk = riskVal;
+      }
+    }
+
+    slices.push({ id, title, risk, depends, done, demo: "" });
   }
 
   return slices;

--- a/src/resources/extensions/gsd/templates/roadmap.md
+++ b/src/resources/extensions/gsd/templates/roadmap.md
@@ -63,6 +63,8 @@ This milestone is complete only when all are true:
 
 ## Slices
 
+**IMPORTANT: Use this exact checkbox format for each slice. The auto-mode parser depends on it.**
+
 - [ ] **S01: {{sliceTitle}}** `risk:high` `depends:[]`
   > After this: {{whatIsDemoableWhenThisSliceIsDone}}
 - [ ] **S02: {{sliceTitle}}** `risk:medium` `depends:[S01]`
@@ -75,6 +77,7 @@ This milestone is complete only when all are true:
   - Checkbox line: - [ ] **S01: Title** `risk:high|medium|low` `depends:[S01,S02]`
   - Demo line:     >  After this: one sentence showing what's demoable
   - Mark done:     change [ ] to [x]
+  - Do NOT use ### headers for slices — use checkbox lines only
   - Order slices by risk (highest first)
   - Each slice must be a vertical, demoable increment — not a layer
   - If all slices are completed exactly as written, the milestone's promised outcome should actually work at the stated proof level

--- a/src/resources/extensions/gsd/tests/roadmap-parse-regression.test.ts
+++ b/src/resources/extensions/gsd/tests/roadmap-parse-regression.test.ts
@@ -457,6 +457,103 @@ async function main(): Promise<void> {
     assertEq(slices[1].done, false, '#1736 checkbox compat: S02 not done');
   }
 
+  // ═══════════════════════════════════════════════════════════════════════
+  // U. Regression: ### headers inside ## Slices section (production bug)
+  //    When ## Slices exists but slices use ### sub-headers instead of
+  //    checkboxes, the primary parser finds nothing but the section is
+  //    non-empty — the prose fallback must still trigger.
+  // ═══════════════════════════════════════════════════════════════════════
+
+  console.log('\n=== U. ### inside ## Slices — prose fallback must trigger ===');
+
+  {
+    const content = [
+      '# M002 Roadmap: Test',
+      '',
+      '## Slices',
+      '',
+      '### S01 — Foundation',
+      '- **Risk:** medium',
+      '- **Depends:** none',
+      '',
+      '### S02 — Features',
+      '- **Risk:** high',
+      '- **Depends:** S01',
+      '',
+      '### S03 — Polish',
+      '- **Risk:** low',
+      '- **Depends:** S01',
+      '',
+      '## Boundary Map',
+    ].join('\n');
+
+    const slices = parseRoadmapSlices(content);
+    assertEq(slices.length, 3, '### inside ## Slices: 3 slices found');
+    assertEq(slices[0].id, 'S01', '### inside ## Slices: S01');
+    assertEq(slices[1].id, 'S02', '### inside ## Slices: S02');
+    assertEq(slices[2].id, 'S03', '### inside ## Slices: S03');
+  }
+
+  // ═══════════════════════════════════════════════════════════════════════
+  // V. Prose fallback: - **Depends:** S01 format (without "on")
+  //    The prose parser originally only matched "Depends on:" — it must
+  //    also handle "Depends:" (no "on") and bullet-prefixed variants.
+  // ═══════════════════════════════════════════════════════════════════════
+
+  console.log('\n=== V. Prose deps: - **Depends:** format ===');
+
+  {
+    const content = [
+      '## Slices',
+      '',
+      '### S01 — Foundation',
+      '- **Risk:** low',
+      '- **Depends:** none',
+      '',
+      '### S02 — Features',
+      '- **Risk:** high',
+      '- **Depends:** S01',
+      '',
+      '### S03 — Integration',
+      '- **Risk:** medium',
+      '- **Depends:** S01, S02',
+    ].join('\n');
+
+    const slices = parseRoadmapSlices(content);
+    assertEq(slices.length, 3, 'bullet depends: 3 slices');
+    assertEq(slices[0].depends.length, 0, 'S01: no deps');
+    assertEq(slices[1].depends.length, 1, 'S02: 1 dep');
+    assertEq(slices[1].depends[0], 'S01', 'S02: depends on S01');
+    assertEq(slices[2].depends.length, 2, 'S03: 2 deps');
+    assertTrue(slices[2].depends.includes('S01'), 'S03: has S01');
+    assertTrue(slices[2].depends.includes('S02'), 'S03: has S02');
+  }
+
+  // ═══════════════════════════════════════════════════════════════════════
+  // W. Prose fallback: risk extraction from bullet lines
+  // ═══════════════════════════════════════════════════════════════════════
+
+  console.log('\n=== W. Prose risk extraction ===');
+
+  {
+    const content = [
+      '## S01: Foundation',
+      '- **Risk:** low',
+      '',
+      '## S02: Features',
+      '- **Risk:** high',
+      '',
+      '## S03: Polish',
+      '- **Risk:** medium',
+    ].join('\n');
+
+    const slices = parseRoadmapSlices(content);
+    assertEq(slices.length, 3, 'prose risk: 3 slices');
+    assertEq(slices[0].risk, 'low', 'S01 risk: low');
+    assertEq(slices[1].risk, 'high', 'S02 risk: high');
+    assertEq(slices[2].risk, 'medium', 'S03 risk: medium');
+  }
+
   report();
 }
 


### PR DESCRIPTION
## Problem

When an LLM writes prose-style slice headers inside a `## Slices` section (e.g. `### S01 — Title` with `- **Depends:** S01` bullets instead of the required checkbox format), auto-mode silently blocks with "No slice eligible". The roadmap file exists so artifact verification passes, but zero slices are parsed.

### Root Cause

The prose fallback parser (`parseProseSliceHeaders`) handles this variant correctly, but the primary code path in `parseRoadmapSlices` returns a non-empty section (because `###` is *inside* the `## Slices` section — it does not terminate it). Since the section is non-empty, the fallback is never triggered. The checkbox regex cannot match `###` headers either. Result: 0 slices, no error.

Additionally, the prose parser's dependency regex only matched `Depends on:` — not `Depends:` (without "on") nor bullet-prefixed variants like `- **Depends:** S01`. So even when the fallback did trigger, dependencies and risk levels were lost.

### Control Flow (before fix)

```
extractSlicesSection("## Slices\n\n### S01 — ...")
  → finds "## Slices" heading ✓
  → scans for next "## " heading (### does NOT match ^##\s+)
  → returns full ### content as the section (non-empty)

parseRoadmapSlices(content)
  → section = extractSlicesSection(content)  // non-empty
  → if (!section) return parseProseSliceHeaders(content)  // SKIPPED
  → scan section lines for checkbox regex  // 0 matches
  → return []  // SILENT ZERO

state.ts → "No slice eligible — check dependency ordering"
auto-mode → blocks permanently
```

## Solution

Five layers of defense, any one of which prevents the failure:

### 1. Parser: prose dependency + risk extraction (`roadmap-slices.ts`)

The zero-slice fallback to `parseProseSliceHeaders` was already added in a prior commit. This PR extends the prose parser to handle:
- `- **Depends:** S01` (without "on", with bullet prefix)
- `- **Risk:** high` (risk extraction from prose bullets)

### 2. Artifact verification (`auto-recovery.ts`)

`verifyExpectedArtifact("plan-milestone")` now checks that the roadmap contains parseable slices, not just that the file exists. A roadmap with zero slices fails verification and gets retried. This mirrors the existing `plan-slice` verification pattern that checks for task entries.

### 3. Doctor check (`doctor-checks.ts` + `doctor-types.ts`)

New `unparseable_roadmap` issue code. Scans every milestone's roadmap file and surfaces an error if zero slices are found. Catches the problem before auto-mode even starts.

### 4. Template reinforcement (`templates/roadmap.md`)

- Adds visible `**IMPORTANT:** Use this exact checkbox format` above the slice examples
- Adds `Do NOT use ### headers for slices` to the format rules comment

### 5. Regression tests (`roadmap-parse-regression.test.ts`)

Three new test cases:
- **U.** `### S01` headers inside `## Slices` section (exact production failure)
- **V.** `- **Depends:** S01` format (without "on", bullet-prefixed)
- **W.** Risk extraction from `- **Risk:** high` prose bullets

All 99 tests pass (83 regression + 16 unit).

## Files Changed

| File | Change |
|------|--------|
| `roadmap-slices.ts` | Prose parser: dependency regex handles `Depends:` without "on" + bullet prefix; risk extraction from prose |
| `auto-recovery.ts` | `plan-milestone` artifact verification checks for parseable slices |
| `doctor-checks.ts` | New `unparseable_roadmap` health check |
| `doctor-types.ts` | New `DoctorIssueCode` union member |
| `templates/roadmap.md` | Visible format instruction + explicit "no ### headers" rule |
| `tests/roadmap-parse-regression.test.ts` | 3 new regression tests (U, V, W) |

## Testing

- `npx tsc --noEmit` — zero errors
- `npx tsx src/resources/extensions/gsd/tests/roadmap-parse-regression.test.ts` — 83/83 pass
- `npx tsx src/resources/extensions/gsd/tests/roadmap-slices.test.ts` — 16/16 pass

---

Closes #1931
Relates to #1933 (duplicate, closed), #1788, #1871, #807, #1785