### PR TITLE
fix: validate-milestone blocks on carried-forward slices without SUMMARY

### DIFF
--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -501,12 +501,16 @@ export const DISPATCH_RULES: DispatchRule[] = [
       // Safety guard (#1368): verify all roadmap slices have SUMMARY files before
       // allowing milestone validation. If any slice lacks a summary, the milestone
       // is not genuinely complete — something skipped earlier slices.
+      // Exception: slices marked [x] at plan time with no slice directory are
+      // "carried-forward" from prior milestones and don't need a SUMMARY.
       const roadmapFile = resolveMilestoneFile(basePath, mid, "ROADMAP");
       const roadmapContent = roadmapFile ? await loadFile(roadmapFile) : null;
       if (roadmapContent) {
         const roadmap = parseRoadmap(roadmapContent);
         const missingSlices: string[] = [];
         for (const slice of roadmap.slices) {
+          const sliceDir = resolveSlicePath(basePath, mid, slice.id);
+          if (!sliceDir) continue; // no directory = carried-forward, not missing
           const summaryPath = resolveSliceFile(basePath, mid, slice.id, "SUMMARY");
           if (!summaryPath || !existsSync(summaryPath)) {
             missingSlices.push(slice.id);
@@ -558,12 +562,15 @@ export const DISPATCH_RULES: DispatchRule[] = [
       if (state.phase !== "completing-milestone") return null;
 
       // Safety guard (#1368): verify all roadmap slices have SUMMARY files.
+      // Exception: carried-forward slices (no slice directory) are skipped.
       const roadmapFile = resolveMilestoneFile(basePath, mid, "ROADMAP");
       const roadmapContent = roadmapFile ? await loadFile(roadmapFile) : null;
       if (roadmapContent) {
         const roadmap = parseRoadmap(roadmapContent);
         const missingSlices: string[] = [];
         for (const slice of roadmap.slices) {
+          const sliceDir = resolveSlicePath(basePath, mid, slice.id);
+          if (!sliceDir) continue; // no directory = carried-forward, not missing
           const summaryPath = resolveSliceFile(basePath, mid, slice.id, "SUMMARY");
           if (!summaryPath || !existsSync(summaryPath)) {
             missingSlices.push(slice.id);


### PR DESCRIPTION
## Problem

**Auto-mode stops with an unrecoverable error** when a milestone has slices that were marked `[x]` at plan time (carried forward from a prior milestone) but have no SUMMARY file. The error message suggests slices "may have been skipped" — but they were intentionally recognized as already complete by the planner.

```
Auto-mode stopped — Cannot validate milestone M014: slices S01 are
missing SUMMARY files. These slices may have been skipped.
```

There is no recovery path: restarting auto-mode hits the same guard, and there is no command to create a stub SUMMARY. The only workaround is manually creating the file.

## Root Cause

The `#1368` safety guard in `auto-dispatch.ts` iterates all roadmap slices and requires a SUMMARY file for each. It does not distinguish between:

1. **Skipped slices** (a real problem — something went wrong during execution)
2. **Carried-forward slices** (intentional — the planner recognized prior work and marked `[x]` at plan time, never creating a slice directory)

Both cases produce the same symptom: `resolveSliceFile(basePath, mid, slice.id, "SUMMARY")` returns null. But only case 1 is an error.

## Fix

Before checking for SUMMARY, check if the slice directory exists via `resolveSlicePath`. A slice with `[x]` in the roadmap but **no slice directory on disk** was never planned or executed in this milestone — it is carried-forward work and should be skipped.

Applied to both guard locations:
- `validating-milestone → validate-milestone` (line ~501)
- `completing-milestone → complete-milestone` (line ~563)

## Changed File

| File | Change |
|------|--------|
| `auto-dispatch.ts` | +3 lines per guard (resolveSlicePath check + continue) |

Related: #1368 (original safety guard), #1988 (worktree source-loss — same milestone lifecycle area)