### PR TITLE
fix(roadmap): accept em-dash, en-dash, and hyphen separators in checkbox format

### DIFF
--- a/src/resources/extensions/gsd/roadmap-slices.ts
+++ b/src/resources/extensions/gsd/roadmap-slices.ts
@@ -157,7 +157,7 @@ export function parseRoadmapSlices(content: string): RoadmapSliceEntry[] {
   let currentSlice: RoadmapSliceEntry | null = null;
 
   for (const line of checkboxItems) {
-    const cbMatch = line.match(/^\s*-\s+\[([ xX])\]\s+\*\*([\w.]+):\s+(.+?)\*\*\s*(.*)/);
+    const cbMatch = line.match(/^\s*-\s+\[([ xX])\]\s+\*\*([\w.]+)[:\s\u2014\u2013-]+\s*(.+?)\*\*\s*(.*)/);
     if (cbMatch) {
       if (currentSlice) slices.push(currentSlice);
 

--- a/src/resources/extensions/gsd/tests/roadmap-slices.test.ts
+++ b/src/resources/extensions/gsd/tests/roadmap-slices.test.ts
@@ -253,3 +253,44 @@ Do the second thing.
   assert.equal(slices[0]?.id, "S01");
   assert.equal(slices[1]?.id, "S02");
 });
+
+// ── Regression tests: checkbox separator variants ───────────────────────────
+
+test("parseRoadmapSlices: checkbox with em-dash separator", () => {
+  const content = `# M021: Em Dash
+
+## Slices
+
+- [x] **S01 — Model Swap Control Plane** \`risk:medium\` \`depends:[]\`
+  > After this: founder can swap models.
+
+- [ ] **S02 — Pipeline Config** \`risk:high\` \`depends:[S01]\`
+  > After this: pipeline uses new models.
+`;
+  const slices = parseRoadmapSlices(content);
+  assert.equal(slices.length, 2, "should parse em-dash checkbox slices");
+  assert.equal(slices[0]?.id, "S01");
+  assert.equal(slices[0]?.done, true, "S01 should be done");
+  assert.equal(slices[0]?.title, "Model Swap Control Plane");
+  assert.equal(slices[0]?.risk, "medium");
+  assert.equal(slices[1]?.id, "S02");
+  assert.equal(slices[1]?.done, false);
+  assert.deepEqual(slices[1]?.depends, ["S01"]);
+});
+
+test("parseRoadmapSlices: checkbox with en-dash and hyphen separators", () => {
+  const content = `# M022: Mixed Separators
+
+## Slices
+
+- [ ] **S01 – En Dash Slice** \`risk:low\` \`depends:[]\`
+- [x] **S02 - Hyphen Slice** \`risk:high\` \`depends:[S01]\`
+`;
+  const slices = parseRoadmapSlices(content);
+  assert.equal(slices.length, 2, "should parse en-dash and hyphen separators");
+  assert.equal(slices[0]?.id, "S01");
+  assert.equal(slices[0]?.title, "En Dash Slice");
+  assert.equal(slices[1]?.id, "S02");
+  assert.equal(slices[1]?.done, true);
+  assert.equal(slices[1]?.title, "Hyphen Slice");
+});


### PR DESCRIPTION
## Problem

The checkbox parser regex in `parseRoadmapSlices` requires a **colon** separator between the slice ID and title: `**S01: Title**`. LLMs frequently write em-dash (`**S01 — Title**`), en-dash (`**S01 – Title**`), or hyphen (`**S01 - Title**`) instead. These slices silently fail to parse, returning 0 matches from the checkbox path. When the `## Slices` section exists, the fallback to `parseProseSliceHeaders` only triggers if the section is empty — but `###` headers *inside* `## Slices` make the section non-empty, so the fallback doesn't activate.

**User impact:** Auto-mode permanently blocks with "No slice eligible". Doctor reports `all_tasks_done_roadmap_not_checked` in a loop because the fix function also requires the colon format. The complete-slice agent burns retry attempts trying to mark slices done.

## Root Cause

Line 160 in `roadmap-slices.ts`:

```js
// Before — requires literal colon + space after ID
line.match(/^\s*-\s+\[([ xX])\]\s+\*\*([\w.]+):\s+(.+?)\*\*\s*(.*)/)
```

The `:\s+` character class only matches a colon followed by whitespace. Em-dash (U+2014), en-dash (U+2013), and hyphen are not accepted. The prose parser already handles all these separators — the checkbox parser was inconsistent.

## Fix

Widens the separator character class to accept colon, space, em-dash, en-dash, and hyphen — matching what the prose parser already handles:

```js
// After — flexible separator
line.match(/^\s*-\s+\[([ xX])\]\s+\*\*([\w.]+)[:\s\u2014\u2013-]+\s*(.+?)\*\*\s*(.*)/)
```

Dot (`.`) is intentionally excluded from the separator class to avoid ambiguity with dot-containing IDs like `S01.1`.

## Changed Files

| File | Change |
|------|--------|
| `roadmap-slices.ts` | Checkbox regex: separator class widened from `:\s+` to `[:\s\u2014\u2013-]+\s*` |
| `tests/roadmap-slices.test.ts` | 2 new tests: em-dash checkbox, en-dash/hyphen checkbox |

## Test Evidence

- `npx tsx .../tests/roadmap-slices.test.ts` — 18/18 pass (2 new + 16 existing)
- `npx tsx .../tests/roadmap-parse-regression.test.ts` — 68/68 pass (no regressions)
- Manual: `parseRoadmapSlices` with `- [x] **S01 — Title**` now returns `done: true` (was: 0 slices)

## Related

- Fixes #1884 (partially — addresses the checkbox-format variant; #1897 addresses U+2705 in prose format)
- Complements #1897 (U+2705 recognition in prose parser — different code path, same family of parser inflexibility)
- Related to #1987 (defense-in-depth for roadmap format enforcement — different failure mode)
