### PR TITLE
fix(gsd): use milestone worktree for parallel merge reconciliation

### DIFF
--- a/src/resources/extensions/gsd/auto-worktree.ts
+++ b/src/resources/extensions/gsd/auto-worktree.ts
@@ -971,10 +971,13 @@ export function mergeMilestoneToMain(
   milestoneId: string,
   roadmapContent: string,
 ): { commitMessage: string; pushed: boolean; prCreated: boolean; codeFilesChanged: boolean } {
-  const worktreeCwd = process.cwd();
+  const currentCwd = process.cwd();
+  const worktreeCwd = getAutoWorktreePath(originalBasePath_, milestoneId) ?? currentCwd;
   const milestoneBranch = autoWorktreeBranch(milestoneId);
 
-  // 1. Auto-commit dirty state in worktree before leaving
+  // 1. Auto-commit dirty state in the milestone worktree before leaving.
+  // Parallel merge runs from the coordinator in the project root, so
+  // process.cwd() is not necessarily the worktree being merged.
   autoCommitDirtyState(worktreeCwd);
 
   // Reconcile worktree DB into main DB before leaving worktree context
@@ -993,7 +996,7 @@ export function mergeMilestoneToMain(
   const completedSlices = roadmap.slices.filter((s) => s.done);
 
   // 3. chdir to original base
-  const previousCwd = process.cwd();
+  const previousCwd = currentCwd;
   process.chdir(originalBasePath_);
 
   // 4. Resolve integration branch — prefer milestone metadata, then preferences,

--- a/src/resources/extensions/gsd/tests/parallel-merge.test.ts
+++ b/src/resources/extensions/gsd/tests/parallel-merge.test.ts
@@ -33,6 +33,7 @@ import {
   formatMergeResults,
   type MergeResult,
 } from "../parallel-merge.ts";
+import { createAutoWorktree } from "../auto-worktree.ts";
 import type { WorkerInfo } from "../parallel-orchestrator.ts";
 import {
   writeSessionStatus,
@@ -293,6 +294,31 @@ test("mergeCompletedMilestone — clean merge, session status cleaned up", async
     // Verify milestone branch deleted
     const branches = run("git branch", repo);
     assert.ok(!branches.includes("milestone/M010"), "milestone branch should be deleted");
+  } finally {
+    process.chdir(savedCwd);
+    cleanup(repo);
+  }
+});
+
+test("mergeCompletedMilestone — uses milestone worktree when invoked from coordinator root", async () => {
+  const savedCwd = process.cwd();
+  const repo = createTempRepo();
+
+  try {
+    setupRoadmap(repo, "M012", "Worktree Merge", ["S01: Worktree feature"]);
+    const wtPath = createAutoWorktree(repo, "M012");
+
+    writeFileSync(join(wtPath, "worktree-feature.ts"), "export const worktreeFeature = true;\n");
+    run("git add .", wtPath);
+    run('git commit -m "feat(M012): worktree feature"', wtPath);
+
+    process.chdir(repo);
+    const result = await mergeCompletedMilestone(repo, "M012");
+
+    assert.equal(result.success, true, `merge should succeed from coordinator root: ${result.error}`);
+    assert.ok(existsSync(join(repo, "worktree-feature.ts")), "worktree feature should be merged to main");
+    const branches = run("git branch", repo);
+    assert.ok(!branches.includes("milestone/M012"), "milestone branch should be deleted after merge");
   } finally {
     process.chdir(savedCwd);
     cleanup(repo);


### PR DESCRIPTION
## TL;DR

**What:** Fix parallel milestone merge so coordinator-root merges reconcile against the milestone worktree instead of assuming the current working directory is already the worker worktree.
**Why:** Parallel final assembly could fail with false divergence errors because merge reconciliation compared the milestone branch against the wrong HEAD.
**How:** Resolve the milestone worktree path explicitly with `getAutoWorktreePath(...)` inside `mergeMilestoneToMain(...)`, and add a regression test that merges a completed milestone from the coordinator/project root.

## What

This change updates `src/resources/extensions/gsd/auto-worktree.ts` so `mergeMilestoneToMain(...)` no longer relies on `process.cwd()` as the source of truth for the milestone worktree during parallel merge reconciliation.

Instead, it:
- captures the caller cwd separately,
- resolves the actual milestone worktree path via `getAutoWorktreePath(originalBasePath_, milestoneId)`,
- uses that worktree path for pre-merge auto-commit and worktree/branch HEAD reconciliation,
- preserves the original caller cwd for later restoration.

It also adds a regression test in `src/resources/extensions/gsd/tests/parallel-merge.test.ts` covering the real failing shape: `mergeCompletedMilestone(...)` invoked from the coordinator/project root while the completed milestone work exists only in the milestone worktree.

## Why

Parallel final assembly exposed a real end-to-end bug:
- workers completed successfully,
- `/gsd parallel merge` ran from the coordinator/root session,
- `mergeMilestoneToMain(...)` treated the coordinator cwd as the worktree cwd,
- reconciliation compared `milestone/<MID>` against the wrong HEAD,
- merge failed with false divergence errors like:
  - `Worktree HEAD (...) diverged from milestone/M001 (...)`

That broke the happy path even when the milestone worktree and branch state were otherwise healthy.

## How

Implementation details:
- replace direct `process.cwd()` usage for worktree reconciliation with:
  - `const currentCwd = process.cwd();`
  - `const worktreeCwd = getAutoWorktreePath(originalBasePath_, milestoneId) ?? currentCwd;`
- keep `currentCwd` as the value used for `previousCwd` restoration,
- continue to use the resolved milestone worktree for:
  - `autoCommitDirtyState(worktreeCwd)`
  - worktree DB reconciliation
  - worktree HEAD vs branch HEAD reconciliation

Regression coverage:
- create a real auto-worktree for `M012`
- commit feature work only in that worktree
- call `mergeCompletedMilestone(repo, "M012")` from the project root
- assert that:
  - merge succeeds
  - merged file appears on main
  - milestone branch is deleted

## Change type

- [x] `fix` — Bug fix
- [x] `test` — Adding or updating tests

## Scope

- [x] `gsd extension` — GSD workflow

## Breaking changes

- [x] No breaking changes

## Test plan

- [ ] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

Verification run on the clean branch:
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/parallel-merge.test.ts src/resources/extensions/gsd/tests/auto-worktree-milestone-merge.test.ts`
  - rerun result: `19 pass / 0 fail`

Broader supporting verification during investigation:
- parallel targeted suites covering recovery/merge/orchestration
- auto-worktree merge suite
- explicit scratch final-assembly scenarios for:
  - happy path
  - restart-before-merge

## AI disclosure

- [x] This PR includes AI-assisted code
  - Tooling used for implementation and verification inside pi/GSD
  - Verification included focused tests, broader merge/worktree tests, and explicit scratch end-to-end final-assembly scenarios
