### PR TITLE
fix(gsd): preserve completed parallel workers for merge recovery

### DIFF
--- a/src/resources/extensions/gsd/parallel-merge.ts
+++ b/src/resources/extensions/gsd/parallel-merge.ts
@@ -10,7 +10,7 @@ import { resolveMilestoneFile } from "./paths.js";
 import { mergeMilestoneToMain } from "./auto-worktree.js";
 import { MergeConflictError } from "./git-service.js";
 import { removeSessionStatus } from "./session-status-io.js";
-import type { WorkerInfo } from "./parallel-orchestrator.js";
+import { removeWorkerFromOrchestrator, type WorkerInfo } from "./parallel-orchestrator.js";
 import { getErrorMessage } from "./error-utils.js";
 
 // ─── Types ─────────────────────────────────────────────────────────────────
@@ -79,8 +79,9 @@ export async function mergeCompletedMilestone(
     // Attempt the merge
     const result = mergeMilestoneToMain(basePath, milestoneId, roadmapContent);
 
-    // Clean up parallel session status
+    // Clean up parallel session status and persisted coordinator state
     removeSessionStatus(basePath, milestoneId);
+    removeWorkerFromOrchestrator(basePath, milestoneId);
 
     return {
       milestoneId,

--- a/src/resources/extensions/gsd/parallel-orchestrator.ts
+++ b/src/resources/extensions/gsd/parallel-orchestrator.ts
@@ -141,6 +141,13 @@ function removeStateFile(basePath: string): void {
   } catch { /* non-fatal */ }
 }
 
+function writePersistedStateFile(basePath: string, persisted: PersistedState): void {
+  const dest = stateFilePath(basePath);
+  const tmp = dest + TMP_SUFFIX;
+  writeFileSync(tmp, JSON.stringify(persisted, null, 2), "utf-8");
+  renameSync(tmp, dest);
+}
+
 function isPidAlive(pid: number): boolean {
   if (!Number.isInteger(pid) || pid <= 0) return false;
   try {
@@ -149,6 +156,15 @@ function isPidAlive(pid: number): boolean {
   } catch {
     return false;
   }
+}
+
+function isRecoveryRelevantState(
+  stateValue: "running" | "paused" | "stopped" | "error",
+  completedUnits: number,
+): boolean {
+  return stateValue === "running"
+    || stateValue === "paused"
+    || (stateValue === "stopped" && completedUnits > 0);
 }
 
 /**
@@ -197,37 +213,87 @@ function appendWorkerLog(basePath: string, milestoneId: string, chunk: string): 
   }
 }
 
+function readLiveSessionStatusMap(basePath: string): Map<string, SessionStatus> {
+  cleanupStaleSessions(basePath);
+  const statuses = readAllSessionStatuses(basePath);
+  const map = new Map<string, SessionStatus>();
+  for (const status of statuses) {
+    if (status.state === "error") continue;
+    if (status.state === "running" || status.state === "paused") {
+      if (!isPidAlive(status.pid)) continue;
+      map.set(status.milestoneId, status);
+      continue;
+    }
+    if (status.state === "stopped" && status.completedUnits > 0) {
+      map.set(status.milestoneId, status);
+    }
+  }
+  return map;
+}
+
+function restoreWorkersFromPersistedState(
+  basePath: string,
+  milestoneIds?: string[],
+): { workers: WorkerInfo[]; totalCost: number; startedAt: number } | null {
+  const p = stateFilePath(basePath);
+  if (!existsSync(p)) return null;
+
+  let persisted: PersistedState;
+  try {
+    persisted = JSON.parse(readFileSync(p, "utf-8")) as PersistedState;
+  } catch {
+    return null;
+  }
+
+  const allowedMilestones = milestoneIds ? new Set(milestoneIds) : null;
+  const liveStatusMap = readLiveSessionStatusMap(basePath);
+  const workers: WorkerInfo[] = [];
+
+  for (const worker of persisted.workers) {
+    if (allowedMilestones && !allowedMilestones.has(worker.milestoneId)) continue;
+    if (!isRecoveryRelevantState(worker.state, worker.completedUnits)) continue;
+
+    const diskStatus = liveStatusMap.get(worker.milestoneId);
+    if (!diskStatus) continue;
+
+    workers.push({
+      milestoneId: worker.milestoneId,
+      title: worker.title,
+      pid: diskStatus.pid,
+      process: null,
+      worktreePath: diskStatus.worktreePath,
+      startedAt: worker.startedAt,
+      state: diskStatus.state,
+      completedUnits: diskStatus.completedUnits,
+      cost: diskStatus.cost,
+    });
+  }
+
+  if (workers.length === 0) return null;
+
+  return {
+    workers,
+    totalCost: workers.reduce((sum, worker) => sum + worker.cost, 0),
+    startedAt: Math.min(...workers.map((worker) => worker.startedAt)),
+  };
+}
+
 function restoreRuntimeState(basePath: string): boolean {
   if (state?.active) return true;
 
-  const restored = restoreState(basePath);
+  const restored = restoreWorkersFromPersistedState(basePath);
   if (restored && restored.workers.length > 0) {
     const config = resolveParallelConfig(undefined);
     state = {
-      active: restored.active,
+      active: true,
       workers: new Map(),
-      config: {
-        ...config,
-        max_workers: restored.configSnapshot.max_workers,
-        budget_ceiling: restored.configSnapshot.budget_ceiling,
-      },
+      config,
       totalCost: restored.totalCost,
       startedAt: restored.startedAt,
     };
 
-    for (const w of restored.workers) {
-      const diskStatus = readSessionStatus(basePath, w.milestoneId);
-      state.workers.set(w.milestoneId, {
-        milestoneId: w.milestoneId,
-        title: w.title,
-        pid: diskStatus?.pid ?? w.pid,
-        process: null,
-        worktreePath: diskStatus?.worktreePath ?? w.worktreePath,
-        startedAt: w.startedAt,
-        state: diskStatus?.state ?? w.state,
-        completedUnits: diskStatus?.completedUnits ?? w.completedUnits,
-        cost: diskStatus?.cost ?? w.cost,
-      });
+    for (const worker of restored.workers) {
+      state.workers.set(worker.milestoneId, worker);
     }
 
     return true;
@@ -236,8 +302,8 @@ function restoreRuntimeState(basePath: string): boolean {
   // Fallback: rebuild coordinator state from live session status files.
   // This covers cases where orchestrator.json is missing/corrupt but workers are
   // still running and writing heartbeats under .gsd/parallel/.
-  cleanupStaleSessions(basePath);
-  const statuses = readAllSessionStatuses(basePath);
+  const liveStatusMap = readLiveSessionStatusMap(basePath);
+  const statuses = [...liveStatusMap.values()];
   if (statuses.length === 0) {
     return false;
   }
@@ -831,13 +897,28 @@ export function pauseWorker(
     ? [milestoneId]
     : [...state.workers.keys()];
 
+  let changed = false;
   for (const mid of targets) {
     const worker = state.workers.get(mid);
     if (!worker || worker.state !== "running") continue;
 
     sendSignal(basePath, mid, "pause");
     worker.state = "paused";
+    writeSessionStatus(basePath, {
+      milestoneId: mid,
+      pid: worker.pid,
+      state: worker.state,
+      currentUnit: null,
+      completedUnits: worker.completedUnits,
+      cost: worker.cost,
+      lastHeartbeat: Date.now(),
+      startedAt: worker.startedAt,
+      worktreePath: worker.worktreePath,
+    });
+    changed = true;
   }
+
+  if (changed) persistState(basePath);
 }
 
 /** Resume a specific worker or all workers. */
@@ -851,13 +932,28 @@ export function resumeWorker(
     ? [milestoneId]
     : [...state.workers.keys()];
 
+  let changed = false;
   for (const mid of targets) {
     const worker = state.workers.get(mid);
     if (!worker || worker.state !== "paused") continue;
 
     sendSignal(basePath, mid, "resume");
     worker.state = "running";
+    writeSessionStatus(basePath, {
+      milestoneId: mid,
+      pid: worker.pid,
+      state: worker.state,
+      currentUnit: null,
+      completedUnits: worker.completedUnits,
+      cost: worker.cost,
+      lastHeartbeat: Date.now(),
+      startedAt: worker.startedAt,
+      worktreePath: worker.worktreePath,
+    });
+    changed = true;
   }
+
+  if (changed) persistState(basePath);
 }
 
 // ─── Status Refresh ────────────────────────────────────────────────────────
@@ -937,6 +1033,50 @@ export function isBudgetExceeded(): boolean {
 // ─── Reset ─────────────────────────────────────────────────────────────────
 
 /** Reset orchestrator state. Called on clean shutdown. */
+export function removeWorkerFromOrchestrator(basePath: string, milestoneId: string): void {
+  if (state) {
+    state.workers.delete(milestoneId);
+    state.totalCost = 0;
+    for (const worker of state.workers.values()) {
+      state.totalCost += worker.cost;
+    }
+    const hasRecoverableWorkers = [...state.workers.values()].some(
+      (worker) => isRecoveryRelevantState(worker.state, worker.completedUnits),
+    );
+    if (hasRecoverableWorkers) {
+      state.active = true;
+      persistState(basePath);
+    } else {
+      state.active = false;
+      removeStateFile(basePath);
+    }
+    return;
+  }
+
+  try {
+    const p = stateFilePath(basePath);
+    if (!existsSync(p)) return;
+    const persisted = JSON.parse(readFileSync(p, "utf-8")) as PersistedState;
+    const workers = persisted.workers.filter((worker) => worker.milestoneId !== milestoneId);
+    if (workers.length === persisted.workers.length) return;
+    const hasRecoverableWorkers = workers.some(
+      (worker) => isRecoveryRelevantState(worker.state, worker.completedUnits),
+    );
+    if (!hasRecoverableWorkers) {
+      removeStateFile(basePath);
+      return;
+    }
+    writePersistedStateFile(basePath, {
+      ...persisted,
+      active: true,
+      workers,
+      totalCost: workers.reduce((sum, worker) => sum + worker.cost, 0),
+    });
+  } catch {
+    // Non-fatal — merge cleanup should not block success reporting.
+  }
+}
+
 export function resetOrchestrator(): void {
   state = null;
 }

--- a/src/resources/extensions/gsd/session-status-io.ts
+++ b/src/resources/extensions/gsd/session-status-io.ts
@@ -150,6 +150,7 @@ export function isSessionStale(
   status: SessionStatus,
   timeoutMs: number = DEFAULT_STALE_TIMEOUT_MS,
 ): boolean {
+  if (status.state === "stopped" && status.completedUnits > 0) return false;
   if (!isPidAlive(status.pid)) return true;
   const elapsed = Date.now() - status.lastHeartbeat;
   return elapsed > timeoutMs;

--- a/src/resources/extensions/gsd/tests/parallel-crash-recovery.test.ts
+++ b/src/resources/extensions/gsd/tests/parallel-crash-recovery.test.ts
@@ -213,11 +213,11 @@ function makePersistedState(overrides: Partial<PersistedState> = {}): PersistedS
   }
 }
 
-// Test 6: orphan detection finds stale sessions
+// Test 6: orphan detection finds stale running sessions but preserves completed stopped sessions
 {
   const basePath = makeTempDir();
   try {
-    // Write a session status with a dead PID
+    // Write a running session with a dead PID
     mkdirSync(join(basePath, ".gsd", "parallel"), { recursive: true });
     writeSessionStatus(basePath, {
       milestoneId: "M001",
@@ -231,7 +231,20 @@ function makePersistedState(overrides: Partial<PersistedState> = {}): PersistedS
       worktreePath: "/tmp/wt-M001",
     });
 
-    // Write a session status with alive PID
+    // Write a completed stopped session with a dead PID — should be kept for merge recovery
+    writeSessionStatus(basePath, {
+      milestoneId: "M003",
+      pid: 99999998,
+      state: "stopped",
+      currentUnit: null,
+      completedUnits: 2,
+      cost: 0.20,
+      lastHeartbeat: Date.now(),
+      startedAt: Date.now(),
+      worktreePath: "/tmp/wt-M003",
+    });
+
+    // Write a live running session
     writeSessionStatus(basePath, {
       milestoneId: "M002",
       pid: process.pid,
@@ -244,13 +257,11 @@ function makePersistedState(overrides: Partial<PersistedState> = {}): PersistedS
       worktreePath: "/tmp/wt-M002",
     });
 
-    // Read all sessions — both should exist initially
     const before = readAllSessionStatuses(basePath);
-    assertEq(before.length, 2, "orphan: both sessions exist before detection");
+    assertEq(before.length, 3, "orphan: all sessions exist before detection");
 
-    // Now simulate orphan detection logic (same as prepareParallelStart)
     const sessions = readAllSessionStatuses(basePath);
-    const orphans: Array<{ milestoneId: string; pid: number; alive: boolean }> = [];
+    const orphans: Array<{ milestoneId: string; pid: number; alive: boolean; state: string }> = [];
     for (const session of sessions) {
       let alive: boolean;
       try {
@@ -259,22 +270,24 @@ function makePersistedState(overrides: Partial<PersistedState> = {}): PersistedS
       } catch {
         alive = false;
       }
-      orphans.push({ milestoneId: session.milestoneId, pid: session.pid, alive });
-      if (!alive) {
+      orphans.push({ milestoneId: session.milestoneId, pid: session.pid, alive, state: session.state });
+      if (!alive && !(session.state === "stopped" && session.completedUnits > 0)) {
         removeSessionStatus(basePath, session.milestoneId);
       }
     }
 
-    assertTrue(orphans.length === 2, "orphan: detected both sessions");
-    const deadOrphan = orphans.find(o => o.milestoneId === "M001");
-    assertTrue(deadOrphan !== undefined && !deadOrphan.alive, "orphan: M001 detected as dead");
-    const aliveOrphan = orphans.find(o => o.milestoneId === "M002");
-    assertTrue(aliveOrphan !== undefined && aliveOrphan.alive, "orphan: M002 detected as alive");
+    assertTrue(orphans.length === 3, "orphan: detected all sessions");
+    const deadRunning = orphans.find(o => o.milestoneId === "M001");
+    assertTrue(deadRunning !== undefined && !deadRunning.alive, "orphan: dead running session detected");
+    const deadStopped = orphans.find(o => o.milestoneId === "M003");
+    assertTrue(deadStopped !== undefined && !deadStopped.alive, "orphan: dead stopped session detected");
+    const aliveRunning = orphans.find(o => o.milestoneId === "M002");
+    assertTrue(aliveRunning !== undefined && aliveRunning.alive, "orphan: live running session detected");
 
-    // Dead session should be cleaned up
     const after = readAllSessionStatuses(basePath);
-    assertEq(after.length, 1, "orphan: dead session cleaned up");
-    assertEq(after[0].milestoneId, "M002", "orphan: alive session remains");
+    assertEq(after.length, 2, "orphan: dead running session cleaned up, completed stopped session preserved");
+    assertTrue(after.some((s) => s.milestoneId === "M002"), "orphan: alive running session remains");
+    assertTrue(after.some((s) => s.milestoneId === "M003"), "orphan: completed stopped session remains");
   } finally {
     rmSync(basePath, { recursive: true, force: true });
   }

--- a/src/resources/extensions/gsd/tests/parallel-merge.test.ts
+++ b/src/resources/extensions/gsd/tests/parallel-merge.test.ts
@@ -18,6 +18,7 @@ import {
   mkdtempSync,
   mkdirSync,
   writeFileSync,
+  readFileSync,
   rmSync,
   existsSync,
   realpathSync,
@@ -293,6 +294,71 @@ test("mergeCompletedMilestone — clean merge, session status cleaned up", async
     // Verify milestone branch deleted
     const branches = run("git branch", repo);
     assert.ok(!branches.includes("milestone/M010"), "milestone branch should be deleted");
+  } finally {
+    process.chdir(savedCwd);
+    cleanup(repo);
+  }
+});
+
+test("mergeCompletedMilestone — keeps other persisted workers after cleaning up merged worker", async () => {
+  const savedCwd = process.cwd();
+  const repo = createTempRepo();
+
+  try {
+    createMilestoneBranch(repo, "M011", [
+      { name: "feature.ts", content: "export const feature = true;\n" },
+    ]);
+    setupRoadmap(repo, "M011", "Feature", ["S01: Feature module"]);
+
+    writeFileSync(join(repo, ".gsd", "orchestrator.json"), JSON.stringify({
+      active: true,
+      workers: [
+        {
+          milestoneId: "M011",
+          title: "M011",
+          pid: process.pid,
+          worktreePath: join(repo, ".gsd", "worktrees", "M011"),
+          startedAt: Date.now() - 60000,
+          state: "stopped",
+          completedUnits: 2,
+          cost: 0.9,
+        },
+        {
+          milestoneId: "M099",
+          title: "M099",
+          pid: process.pid,
+          worktreePath: "/tmp/wt-M099",
+          startedAt: Date.now() - 30000,
+          state: "stopped",
+          completedUnits: 1,
+          cost: 0.4,
+        },
+      ],
+      totalCost: 1.3,
+      startedAt: Date.now() - 60000,
+      configSnapshot: { max_workers: 2 },
+    }, null, 2));
+    writeSessionStatus(repo, {
+      milestoneId: "M011",
+      pid: process.pid,
+      state: "stopped",
+      currentUnit: null,
+      completedUnits: 2,
+      cost: 0.9,
+      lastHeartbeat: Date.now(),
+      startedAt: Date.now() - 60000,
+      worktreePath: join(repo, ".gsd", "worktrees", "M011"),
+    });
+
+    process.chdir(repo);
+    const result = await mergeCompletedMilestone(repo, "M011");
+
+    assert.equal(result.success, true, `merge should succeed: ${result.error}`);
+    const persisted = JSON.parse(readFileSync(join(repo, ".gsd", "orchestrator.json"), "utf-8"));
+    assert.equal(persisted.workers.length, 1, "only unmerged worker should remain persisted");
+    assert.equal(persisted.workers[0].milestoneId, "M099");
+    assert.equal(persisted.workers[0].state, "stopped");
+    assert.equal(persisted.workers[0].completedUnits, 1);
   } finally {
     process.chdir(savedCwd);
     cleanup(repo);

--- a/src/resources/extensions/gsd/tests/parallel-orchestration.test.ts
+++ b/src/resources/extensions/gsd/tests/parallel-orchestration.test.ts
@@ -284,7 +284,7 @@ describe("parallel-orchestrator: lifecycle", () => {
     assert.equal(isParallelActive(), false);
   });
 
-  it("getWorkerStatuses restores persisted workers from disk", async () => {
+  it("getWorkerStatuses restores persisted workers only when a live session status exists", async () => {
     const base = makeTmpBase();
     try {
       const persisted = {
@@ -306,6 +306,17 @@ describe("parallel-orchestrator: lifecycle", () => {
         configSnapshot: { max_workers: 2 },
       };
       writeFileSync(join(base, ".gsd", "orchestrator.json"), JSON.stringify(persisted, null, 2), "utf-8");
+      writeSessionStatus(base, {
+        milestoneId: "M001",
+        pid: process.pid,
+        state: "running",
+        currentUnit: null,
+        completedUnits: 2,
+        cost: 0.25,
+        lastHeartbeat: Date.now(),
+        startedAt: Date.now(),
+        worktreePath: "/tmp/wt-M001",
+      });
       const workers = getWorkerStatuses(base);
       assert.equal(workers.length, 1);
       assert.equal(workers[0].milestoneId, "M001");
@@ -343,6 +354,64 @@ describe("parallel-orchestrator: lifecycle", () => {
     // State is "running" if spawn succeeds, "error" if binary not found (CI)
     assert.ok(status.state === "running" || status.state === "error",
       `expected running or error, got ${status.state}`);
+  });
+
+  it("pauseWorker persists paused state for recovery", async () => {
+    await startParallel(base, ["M001"], undefined);
+    const orch = getOrchestratorState();
+    const worker = orch?.workers.get("M001");
+    assert.ok(worker, "worker should exist");
+
+    worker.state = "running";
+    worker.pid = process.pid;
+    worker.process = null;
+    writeSessionStatus(base, {
+      milestoneId: "M001",
+      pid: process.pid,
+      state: "running",
+      currentUnit: null,
+      completedUnits: Math.max(worker.completedUnits, 1),
+      cost: worker.cost,
+      lastHeartbeat: Date.now(),
+      startedAt: worker.startedAt,
+      worktreePath: worker.worktreePath,
+    });
+
+    pauseWorker(base, "M001");
+    resetOrchestrator();
+
+    const restored = getWorkerStatuses(base);
+    assert.equal(restored[0]?.state, "paused");
+  });
+
+  it("resumeWorker persists resumed state for recovery", async () => {
+    await startParallel(base, ["M001"], undefined);
+    const orch = getOrchestratorState();
+    const worker = orch?.workers.get("M001");
+    assert.ok(worker, "worker should exist");
+
+    worker.state = "paused";
+    worker.pid = process.pid;
+    worker.process = null;
+    writeSessionStatus(base, {
+      milestoneId: "M001",
+      pid: process.pid,
+      state: "paused",
+      currentUnit: null,
+      completedUnits: Math.max(worker.completedUnits, 1),
+      cost: worker.cost,
+      lastHeartbeat: Date.now(),
+      startedAt: worker.startedAt,
+      worktreePath: worker.worktreePath,
+    });
+    resetOrchestrator();
+    getWorkerStatuses(base);
+
+    resumeWorker(base, "M001");
+    resetOrchestrator();
+
+    const restored = getWorkerStatuses(base);
+    assert.equal(restored[0]?.state, "running");
   });
 
   it("stopParallel stops all workers", async () => {

--- a/src/resources/extensions/gsd/tests/parallel-worker-monitoring.test.ts
+++ b/src/resources/extensions/gsd/tests/parallel-worker-monitoring.test.ts
@@ -144,10 +144,10 @@ describe("parallel-worker-monitoring", () => {
       "--mode comes before json");
   });
 
-  it("refreshWorkerStatuses restores persisted workers from disk", () => {
+  it("refreshWorkerStatuses restores persisted workers only when a live session status exists", () => {
     const base = mkdtempSync(join(tmpdir(), "gsd-parallel-monitoring-"));
     try {
-      mkdirSync(join(base, ".gsd"), { recursive: true });
+      mkdirSync(join(base, ".gsd", "parallel"), { recursive: true });
       writeFileSync(join(base, ".gsd", "orchestrator.json"), JSON.stringify({
         active: true,
         workers: [
@@ -166,10 +166,21 @@ describe("parallel-worker-monitoring", () => {
         startedAt: Date.now(),
         configSnapshot: { max_workers: 2 },
       }, null, 2));
+      writeFileSync(join(base, ".gsd", "parallel", "M001.status.json"), JSON.stringify({
+        milestoneId: "M001",
+        pid: process.pid,
+        state: "running",
+        currentUnit: null,
+        completedUnits: 1,
+        cost: 0.1,
+        lastHeartbeat: Date.now(),
+        startedAt: Date.now(),
+        worktreePath: "/tmp/wt-M001",
+      }, null, 2));
       refreshWorkerStatuses(base, { restoreIfNeeded: true });
       const workers = getWorkerStatuses();
       assertEq(workers.length, 1, "restored one worker");
-      assertEq(workers[0].milestoneId, "M001", "worker restored from persisted state");
+      assertEq(workers[0].milestoneId, "M001", "worker restored from persisted state + status file");
     } finally {
       resetOrchestrator();
       rmSync(base, { recursive: true, force: true });


### PR DESCRIPTION
## TL;DR

**What:** Preserve merge-ready parallel worker state across restart, partial stop, pause/resume, and merge cleanup.
**Why:** Completed parallel milestones could disappear before final assembly, or merged workers could resurrect from stale persisted orchestrator state.
**How:** Tighten recovery to require live status files, treat completed/stopped workers as recovery-relevant for merge, persist pause/resume and partial-stop state transitions immediately, and remove merged workers from orchestrator persistence.

## What

This change hardens the parallel orchestrator's recovery and cleanup behavior around completed workers.

It updates:
- `src/resources/extensions/gsd/session-status-io.ts`
- `src/resources/extensions/gsd/parallel-orchestrator.ts`
- `src/resources/extensions/gsd/parallel-merge.ts`

It also adds/updates regression coverage in:
- `src/resources/extensions/gsd/tests/parallel-crash-recovery.test.ts`
- `src/resources/extensions/gsd/tests/parallel-worker-monitoring.test.ts`
- `src/resources/extensions/gsd/tests/parallel-orchestration.test.ts`
- `src/resources/extensions/gsd/tests/parallel-merge.test.ts`

## Why

During final-assembly investigation, parallel had a cluster of related persistence bugs:
- completed/stopped workers could be deleted as "stale" before merge recovery,
- restart recovery could lose merge-ready workers,
- persisted orchestrator state could restore ghost workers that had no live session file,
- partial stop could discard recovery info for other workers,
- pause/resume transitions were not persisted for restart recovery,
- successful merge cleaned up session files but could leave merged workers in persisted orchestrator state.

In practice that meant final assembly after restart was unreliable even when individual workers had completed successfully.

## How

### Recovery model
- introduce a recovery-relevance rule:
  - `running`
  - `paused`
  - `stopped` with `completedUnits > 0`
- restore workers only when persisted orchestrator state and a corresponding live status file agree
- do not restore ghost workers from bare persisted JSON
- keep completed/stopped workers available for merge after coordinator reset
- only adopt restored workers for the milestone IDs explicitly requested by `startParallel(...)`

### Session staleness
- `isSessionStale(...)` now preserves `stopped` workers with `completedUnits > 0`
- this prevents merge-ready completed workers from being deleted during stale cleanup

### State persistence
- `pauseWorker(...)` and `resumeWorker(...)` now update session status files and persist orchestrator state immediately
- `stopParallel(base, milestoneId)` now preserves orchestrator persistence when other recoverable workers remain

### Merge cleanup
- after a successful merge, `parallel-merge.ts` now removes:
  - the merged worker's session status file
  - the merged worker's persisted orchestrator entry
- remaining unmerged workers stay recoverable

## Change type

- [x] `fix` — Bug fix
- [x] `test` — Adding or updating tests

## Scope

- [x] `gsd extension` — GSD workflow

## Breaking changes

- [x] No breaking changes

## Test plan

- [ ] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

Verification on the isolated branch:
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/parallel-crash-recovery.test.ts src/resources/extensions/gsd/tests/parallel-worker-monitoring.test.ts src/resources/extensions/gsd/tests/parallel-orchestration.test.ts src/resources/extensions/gsd/tests/parallel-merge.test.ts`
  - result: `88 pass / 0 fail`

Supporting investigation context:
- this fix package was isolated from a broader end-to-end parallel audit
- the audit previously reproduced restart-before-merge failures and stale completed-worker loss during final assembly

## AI disclosure

- [x] This PR includes AI-assisted code
  - Implemented and verified in pi/GSD
  - Verification included targeted recovery/cleanup suites and prior end-to-end final-assembly scenario work
