### PR TITLE
fix(roadmap-slices): strip HTML comments before checkbox parsing

### DIFF
--- a/src/resources/extensions/gsd/roadmap-slices.ts
+++ b/src/resources/extensions/gsd/roadmap-slices.ts
@@ -144,16 +144,20 @@ export function parseRoadmapSlices(content: string): RoadmapSliceEntry[] {
     return parseProseSliceHeaders(content);
   }
 
+  // Strip HTML comments before parsing — they can contain format-rule
+  // examples that match the checkbox regex and corrupt slice state (#2022).
+  const strippedSection = slicesSection.replace(/<!--[\s\S]*?-->/g, "");
+
   // Try table format first — if the section contains pipe-delimited rows with
   // slice IDs, parse them as a table (#1736).
-  const tableSlices = parseTableSlices(slicesSection);
+  const tableSlices = parseTableSlices(strippedSection);
   if (tableSlices.length > 0) {
     return tableSlices;
   }
 
   // Standard checkbox format
   const slices: RoadmapSliceEntry[] = [];
-  const checkboxItems = slicesSection.split("\n");
+  const checkboxItems = strippedSection.split("\n");
   let currentSlice: RoadmapSliceEntry | null = null;
 
   for (const line of checkboxItems) {

--- a/src/resources/extensions/gsd/tests/roadmap-slices.test.ts
+++ b/src/resources/extensions/gsd/tests/roadmap-slices.test.ts
@@ -253,3 +253,82 @@ Do the second thing.
   assert.equal(slices[0]?.id, "S01");
   assert.equal(slices[1]?.id, "S02");
 });
+
+// ── Regression tests for #2022 ─────────────────────────────────────────────
+
+test("parseRoadmapSlices: HTML comments with checkbox examples do not corrupt slice parsing (#2022)", () => {
+  const roadmapWithComment = `# M004: Milestone Four
+
+**Vision:** Ship the feature.
+
+## Slices
+
+- [x] **S01: Dependency Updates** \`risk:low\` \`depends:[]\`
+  > After this: All deps updated.
+- [ ] **S02: Core Implementation** \`risk:medium\` \`depends:[S01]\`
+  > After this: Core works.
+
+<!--
+  Format rules (parsers depend on this exact structure):
+  - Checkbox line: - [ ] **S01: Title** \`risk:high|medium|low\` \`depends:[S01,S02]\`
+  - Demo line:     > After this: what the user can see or do
+-->
+
+## Boundary Map
+### S01 → S02
+Produces: deps.json
+`;
+  const slices = parseRoadmapSlices(roadmapWithComment);
+  assert.equal(slices.length, 2, "should find exactly 2 real slices, ignoring comment content");
+  assert.equal(slices[0]?.id, "S01");
+  assert.equal(slices[0]?.done, true, "S01 should be done (checked [x])");
+  assert.equal(slices[0]?.title, "Dependency Updates");
+  assert.equal(slices[1]?.id, "S02");
+  assert.equal(slices[1]?.done, false);
+});
+
+test("parseRoadmapSlices: HTML comment before real slices does not shadow them (#2022)", () => {
+  const roadmapCommentFirst = `# M005: Comment First
+
+## Slices
+
+<!--
+  - [ ] **S01: Fake Entry** \`risk:high\` \`depends:[]\`
+  - [ ] **S02: Another Fake** \`risk:low\` \`depends:[S01]\`
+-->
+
+- [x] **S01: Real Entry** \`risk:low\` \`depends:[]\`
+- [x] **S02: Also Real** \`risk:medium\` \`depends:[S01]\`
+
+## Boundary Map
+`;
+  const slices = parseRoadmapSlices(roadmapCommentFirst);
+  assert.equal(slices.length, 2, "should parse only real slices outside comment");
+  assert.equal(slices[0]?.id, "S01");
+  assert.equal(slices[0]?.done, true, "real S01 should be done");
+  assert.equal(slices[0]?.title, "Real Entry");
+  assert.equal(slices[1]?.id, "S02");
+  assert.equal(slices[1]?.done, true, "real S02 should be done");
+  assert.equal(slices[1]?.title, "Also Real");
+});
+
+test("parseRoadmapSlices: multiline HTML comment spanning multiple lines stripped (#2022)", () => {
+  const roadmapMultilineComment = `# M006: Multiline
+
+## Slices
+
+- [x] **S01: Done** \`risk:low\` \`depends:[]\`
+<!-- This is a
+multi-line comment
+- [ ] **S01: Ghost** \`risk:high\` \`depends:[]\`
+that should be ignored -->
+- [ ] **S02: Pending** \`risk:medium\` \`depends:[S01]\`
+`;
+  const slices = parseRoadmapSlices(roadmapMultilineComment);
+  assert.equal(slices.length, 2);
+  assert.equal(slices[0]?.id, "S01");
+  assert.equal(slices[0]?.done, true);
+  assert.equal(slices[0]?.title, "Done");
+  assert.equal(slices[1]?.id, "S02");
+  assert.equal(slices[1]?.done, false);
+});


### PR DESCRIPTION
## TL;DR
**What:** Strip HTML comments from the slices section before parsing checkboxes.
**Why:** Comments containing format-rule examples match the checkbox regex, overwriting real slice entries and causing an infinite `complete-slice` dispatch loop.
**How:** One-line regex strip (`<!--[\s\S]*?-->`) applied after `extractSlicesSection()` and before the checkbox/table parser runs.

## What
`parseRoadmapSlices` in `roadmap-slices.ts` now strips HTML comment blocks (`<!-- ... -->`) from the extracted slices section before running the checkbox or table parser.

## Why
LLMs embed format-documentation comments inside the `## Slices` section. These comments contain checkbox examples like `- [ ] **S01: Title**` that match the checkbox regex. When the comment's fake `S01` entry (with `done=false`) overwrites the real `S01` entry (with `done=true`), `verifyExpectedArtifact` always returns false, the slice is never recorded as complete, and `complete-slice` dispatches in an infinite loop.

## How
After `extractSlicesSection()` returns the raw text and before any parsing:
```typescript
const strippedSection = slicesSection.replace(/<!--[\s\S]*?-->/g, "");
```
This is a single non-greedy regex that handles single-line and multi-line comments. The stripped section is then passed to both the table parser and the checkbox parser.

## Test plan
- [x] Reproduction test: HTML comment with checkbox examples after real slices
- [x] Reproduction test: HTML comment with fake entries before real slices (shadowing)
- [x] Reproduction test: Multi-line comment containing a fake slice entry
- [x] All 19 existing roadmap-slices tests pass (no regressions)

Fixes #2022

🤖 Generated with [Claude Code](https://claude.com/claude-code)