### PR TITLE
fix(git): force LC_ALL=C for non-English locale support

### DIFF
--- a/src/resources/extensions/gsd/git-constants.ts
+++ b/src/resources/extensions/gsd/git-constants.ts
@@ -8,4 +8,5 @@ export const GIT_NO_PROMPT_ENV = {
   GIT_TERMINAL_PROMPT: "0",
   GIT_ASKPASS: "",
   GIT_SVN_ID: "",
+  LC_ALL: "C", // force English git output so stderr string checks work on all locales (#1997)
 };

--- a/src/resources/extensions/gsd/native-git-bridge.ts
+++ b/src/resources/extensions/gsd/native-git-bridge.ts
@@ -847,6 +847,7 @@ export function nativeMergeSquash(basePath: string, branch: string): GitMergeRes
       cwd: basePath,
       stdio: ["ignore", "pipe", "pipe"],
       encoding: "utf-8",
+      env: GIT_NO_PROMPT_ENV,
     });
     return { success: true, conflicts: [] };
   } catch (err: unknown) {

--- a/src/resources/extensions/gsd/tests/git-locale.test.ts
+++ b/src/resources/extensions/gsd/tests/git-locale.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Regression tests for #1997: git locale not forced to C.
+ *
+ * Validates that GIT_NO_PROMPT_ENV includes LC_ALL=C so git always produces
+ * English output, and that nativeMergeSquash passes the env to execFileSync.
+ */
+
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { execFileSync } from "node:child_process";
+
+import { GIT_NO_PROMPT_ENV } from "../git-constants.ts";
+import { nativeAddAllWithExclusions } from "../native-git-bridge.ts";
+import { RUNTIME_EXCLUSION_PATHS } from "../git-service.ts";
+import { createTestContext } from "./test-helpers.ts";
+
+const { assertEq, assertTrue, report } = createTestContext();
+
+function git(cwd: string, ...args: string[]): string {
+  return execFileSync("git", args, { cwd, stdio: ["ignore", "pipe", "pipe"], encoding: "utf-8" }).trim();
+}
+
+function initTempRepo(): string {
+  const dir = mkdtempSync(join(tmpdir(), "gsd-locale-"));
+  git(dir, "init");
+  git(dir, "config", "user.email", "test@test.com");
+  git(dir, "config", "user.name", "Test");
+  // Initial commit so HEAD exists
+  writeFileSync(join(dir, "init.txt"), "init");
+  git(dir, "add", "-A");
+  git(dir, "commit", "-m", "init");
+  return dir;
+}
+
+function createFile(base: string, relPath: string, content: string): void {
+  const full = join(base, relPath);
+  mkdirSync(join(full, ".."), { recursive: true });
+  writeFileSync(full, content);
+}
+
+async function main(): Promise<void> {
+  // ─── GIT_NO_PROMPT_ENV includes LC_ALL=C ─────────────────────────────
+
+  console.log("\n=== GIT_NO_PROMPT_ENV includes LC_ALL=C ===");
+
+  assertEq(
+    GIT_NO_PROMPT_ENV.LC_ALL,
+    "C",
+    "GIT_NO_PROMPT_ENV must set LC_ALL to 'C' to force English git output"
+  );
+
+  assertTrue(
+    "GIT_TERMINAL_PROMPT" in GIT_NO_PROMPT_ENV,
+    "GIT_NO_PROMPT_ENV still contains GIT_TERMINAL_PROMPT"
+  );
+
+  // ─── nativeAddAllWithExclusions: non-English locale does not throw ───
+
+  console.log("\n=== nativeAddAllWithExclusions: non-English locale does not throw ===");
+
+  {
+    // Simulate what happens on a German system: .gsd is gitignored,
+    // exclusion pathspecs trigger an advisory warning exit code 1.
+    // With LC_ALL=C the English stderr guard should match and suppress.
+    const repo = initTempRepo();
+
+    writeFileSync(join(repo, ".gitignore"), ".gsd\n");
+    createFile(repo, ".gsd/STATE.md", "# State");
+    createFile(repo, "src/app.ts", "export const x = 1;");
+
+    // Save original LC_ALL / LANG and force German locale env
+    const origLcAll = process.env.LC_ALL;
+    const origLang = process.env.LANG;
+    process.env.LANG = "de_DE.UTF-8";
+    delete process.env.LC_ALL;
+
+    let threw = false;
+    try {
+      nativeAddAllWithExclusions(repo, RUNTIME_EXCLUSION_PATHS);
+    } catch (e) {
+      threw = true;
+      console.error("  unexpected error:", e);
+    }
+
+    // Restore
+    if (origLcAll !== undefined) process.env.LC_ALL = origLcAll;
+    else delete process.env.LC_ALL;
+    if (origLang !== undefined) process.env.LANG = origLang;
+    else delete process.env.LANG;
+
+    assertTrue(
+      !threw,
+      "nativeAddAllWithExclusions must not throw on non-English locale when .gsd is gitignored (#1997)"
+    );
+
+    const staged = git(repo, "diff", "--cached", "--name-only");
+    assertTrue(staged.includes("src/app.ts"), "real file staged despite German locale");
+
+    rmSync(repo, { recursive: true, force: true });
+  }
+
+  // ─── nativeMergeSquash: env is passed (merge-squash stderr is English) ─
+
+  console.log("\n=== nativeMergeSquash fallback uses GIT_NO_PROMPT_ENV ===");
+
+  {
+    // We verify indirectly: the source code must pass env: GIT_NO_PROMPT_ENV.
+    // Read the source and check for the pattern. This is a static check.
+    const src = readFileSync(
+      join(import.meta.dirname, "..", "native-git-bridge.ts"),
+      "utf-8"
+    );
+
+    // Find the nativeMergeSquash function and check it uses GIT_NO_PROMPT_ENV
+    const fnStart = src.indexOf("export function nativeMergeSquash");
+    assertTrue(fnStart !== -1, "nativeMergeSquash function exists in source");
+
+    const fnBody = src.slice(fnStart, src.indexOf("\nexport function", fnStart + 1));
+    const hasEnv = fnBody.includes("env: GIT_NO_PROMPT_ENV");
+    assertTrue(
+      hasEnv,
+      "nativeMergeSquash fallback must pass env: GIT_NO_PROMPT_ENV to execFileSync (#1997)"
+    );
+  }
+
+  report();
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## TL;DR
**What**: Add `LC_ALL: "C"` to `GIT_NO_PROMPT_ENV` and pass the env to the `nativeMergeSquash` fallback.
**Why**: Non-English systems produce localized git stderr, breaking all English `stderr.includes()` guards — auto-mode cannot commit on German/French/etc systems.
**How**: One-line addition to `git-constants.ts`, one-line addition to `native-git-bridge.ts`, regression test.

## What
- Add `LC_ALL: "C"` to `GIT_NO_PROMPT_ENV` in `git-constants.ts`
- Add `env: GIT_NO_PROMPT_ENV` to the `nativeMergeSquash` fallback `execFileSync` call
- Add `git-locale.test.ts` with 6 assertions covering both fixes

## Why
On non-English systems (e.g. `LANG=de_DE.UTF-8` with `LC_ALL` unset), git produces localized stderr output. GSD hardcodes English string checks in two places:

1. `nativeAddAllWithExclusions` (line 711): `stderr.includes("ignored by one of your .gitignore files")` — never matches German output, so every `smartStage()` throws `GSD_GIT_ERROR`
2. `nativeMergeSquash` (line 861): three English stderr checks for dirty-working-tree detection — all fail, misclassifying merge rejections as content conflicts

This is a critical regression on all non-English systems — auto-mode cannot commit any changes.

## How
- `LC_ALL=C` overrides `LANG` and forces git to produce English output regardless of system locale
- The `nativeMergeSquash` fallback was missing `env: GIT_NO_PROMPT_ENV` entirely (the env was only used in other call sites)
- Tests verify `GIT_NO_PROMPT_ENV.LC_ALL === "C"`, that `nativeAddAllWithExclusions` doesn't throw under a non-English `LANG`, and that `nativeMergeSquash` source includes `env: GIT_NO_PROMPT_ENV`

## Test plan
- [x] New `git-locale.test.ts` — 6 assertions, all pass
- [x] Existing `git-service.test.ts` — 183 assertions, all pass
- [x] Tests fail before fix, pass after fix

Fixes #1997

🤖 Generated with [Claude Code](https://claude.com/claude-code)