### PR TITLE
fix(tui): prevent duplicate web_search result blocks during streaming

### DIFF
--- a/packages/pi-coding-agent/src/modes/interactive/controllers/chat-controller.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/controllers/chat-controller.ts
@@ -143,14 +143,19 @@ export async function handleAgentEvent(host: InteractiveModeStateHost & {
 						}
 					} else if (content.type === "webSearchResult") {
 						const component = host.pendingTools.get(content.toolUseId);
-						if (component) {
+						if (component && !component._webSearchRendered) {
 							const searchContent = content.content;
 							const isError = searchContent && typeof searchContent === "object" && "type" in (searchContent as any) && (searchContent as any).type === "web_search_tool_result_error";
 							component.updateResult({
 								content: [{ type: "text", text: host.formatWebSearchResult(searchContent) }],
 								isError: !!isError,
 							});
-							host.pendingTools.delete(content.toolUseId);
+							// Mark as rendered but do NOT delete from pendingTools.
+							// Deleting would remove the duplicate-creation guard on the
+							// serverToolUse branch, causing every subsequent message_update
+							// to re-create the component (#2029).  message_end / agent_end
+							// already clear pendingTools, so no leak occurs.
+							component._webSearchRendered = true;
 						}
 					}
 				}

--- a/src/tests/web-search-dedup.test.ts
+++ b/src/tests/web-search-dedup.test.ts
@@ -1,0 +1,204 @@
+import assert from "node:assert/strict";
+import { describe, it, before } from "node:test";
+
+/**
+ * Regression test for #2029: server-side web_search tool renders 100+
+ * duplicate result blocks because the message_update handler deletes
+ * the pendingTools entry after rendering a webSearchResult, allowing
+ * every subsequent message_update to re-create the ToolExecutionComponent.
+ */
+
+import { handleAgentEvent } from "../../packages/pi-coding-agent/src/modes/interactive/controllers/chat-controller.js";
+import { initTheme } from "../../packages/pi-coding-agent/src/modes/interactive/theme/theme.js";
+
+function makeMockUI() {
+	return {
+		requestRender: () => {},
+		width: 80,
+		height: 24,
+		onResize: () => {},
+		onInput: () => {},
+		render: () => {},
+		destroy: () => {},
+	};
+}
+
+function makeMockHost() {
+	const children: unknown[] = [];
+	const pendingTools = new Map<string, any>();
+
+	return {
+		isInitialized: true,
+		init: async () => {},
+		footer: { invalidate: () => {} },
+		ui: makeMockUI(),
+		streamingComponent: {
+			updateContent: () => {},
+		},
+		streamingMessage: undefined as any,
+		chatContainer: {
+			addChild(c: unknown) { children.push(c); },
+			removeChild() {},
+			clear() { children.length = 0; },
+		},
+		statusContainer: { clear: () => {}, addChild: () => {} },
+		pendingTools,
+		toolOutputExpanded: false,
+		hideThinkingBlock: false,
+		settingsManager: { getShowImages: () => false },
+		getMarkdownThemeWithSettings: () => ({}),
+		addMessageToChat: () => {},
+		formatWebSearchResult: () => "search result text",
+		getRegisteredToolDefinition: () => undefined,
+		checkShutdownRequested: async () => {},
+		rebuildChatFromMessages: () => {},
+		flushCompactionQueue: async () => {},
+		showStatus: () => {},
+		showError: () => {},
+		updatePendingMessagesDisplay: () => {},
+		updateTerminalTitle: () => {},
+		updateEditorBorderColor: () => {},
+		pendingMessagesContainer: { clear: () => {} },
+		defaultWorkingMessage: "",
+		isBashMode: false,
+		compactionQueuedMessages: [],
+		editorContainer: {},
+		defaultEditor: { onEscape: () => {} },
+		session: {},
+		editor: {},
+		keybindings: {},
+
+		// expose for assertions
+		get childCount() { return children.length; },
+		get children() { return children; },
+	};
+}
+
+function makeAssistantMessage(content: unknown[]) {
+	return { role: "assistant" as const, content };
+}
+
+describe("web_search dedup (#2029)", () => {
+	before(() => {
+		initTheme("default", false);
+	});
+
+	it("should not re-create ToolExecutionComponent for a server tool whose result was already rendered", async () => {
+		const host = makeMockHost();
+
+		const serverToolBlock = {
+			type: "serverToolUse",
+			id: "ws_001",
+			name: "web_search",
+			input: { query: "test query" },
+		};
+		const webSearchResultBlock = {
+			type: "webSearchResult",
+			toolUseId: "ws_001",
+			content: { type: "web_search_tool_result", content: [] },
+		};
+		const textBlock = { type: "text", text: "Here are the results..." };
+
+		// Step 1: streaming event with serverToolUse -> component created
+		await handleAgentEvent(host as any, {
+			type: "message_update",
+			message: makeAssistantMessage([serverToolBlock]),
+		} as any);
+
+		assert.equal(host.childCount, 1, "one component after serverToolUse");
+		assert.ok(host.pendingTools.has("ws_001"), "tool in pendingTools");
+
+		// Step 2: streaming event with both blocks -> result rendered
+		await handleAgentEvent(host as any, {
+			type: "message_update",
+			message: makeAssistantMessage([serverToolBlock, webSearchResultBlock]),
+		} as any);
+
+		assert.equal(host.childCount, 1, "still one component after webSearchResult");
+
+		// Step 3: subsequent text_delta streaming events -> must NOT re-create
+		for (let i = 0; i < 50; i++) {
+			await handleAgentEvent(host as any, {
+				type: "message_update",
+				message: makeAssistantMessage([
+					serverToolBlock,
+					webSearchResultBlock,
+					{ ...textBlock, text: textBlock.text + " ".repeat(i) },
+				]),
+			} as any);
+		}
+
+		assert.equal(
+			host.childCount,
+			1,
+			`expected 1 component but got ${host.childCount} -- duplicate re-creation loop detected`,
+		);
+	});
+
+	it("should still render the result for the component when webSearchResult arrives", async () => {
+		const host = makeMockHost();
+
+		const serverToolBlock = {
+			type: "serverToolUse",
+			id: "ws_002",
+			name: "web_search",
+			input: { query: "another query" },
+		};
+		const webSearchResultBlock = {
+			type: "webSearchResult",
+			toolUseId: "ws_002",
+			content: { type: "web_search_tool_result", content: [] },
+		};
+
+		// Step 1: serverToolUse creates the component
+		await handleAgentEvent(host as any, {
+			type: "message_update",
+			message: makeAssistantMessage([serverToolBlock]),
+		} as any);
+
+		const component = host.pendingTools.get("ws_002");
+		assert.ok(component, "component should exist");
+
+		// Track updateResult calls
+		let updateResultCalled = false;
+		const origUpdateResult = component.updateResult.bind(component);
+		component.updateResult = (...args: any[]) => {
+			updateResultCalled = true;
+			return origUpdateResult(...args);
+		};
+
+		// Step 2: webSearchResult arrives
+		await handleAgentEvent(host as any, {
+			type: "message_update",
+			message: makeAssistantMessage([serverToolBlock, webSearchResultBlock]),
+		} as any);
+
+		assert.ok(updateResultCalled, "updateResult should be called on the component");
+	});
+
+	it("agent_end should clear pendingTools so no leak occurs", async () => {
+		const host = makeMockHost();
+
+		const serverToolBlock = {
+			type: "serverToolUse",
+			id: "ws_003",
+			name: "web_search",
+			input: { query: "query" },
+		};
+
+		// Create a pending tool
+		await handleAgentEvent(host as any, {
+			type: "message_update",
+			message: makeAssistantMessage([serverToolBlock]),
+		} as any);
+
+		assert.ok(host.pendingTools.size > 0, "pendingTools should have entries");
+
+		// agent_end should clear pendingTools
+		await handleAgentEvent(host as any, {
+			type: "agent_end",
+		} as any);
+
+		assert.equal(host.pendingTools.size, 0, "pendingTools cleared after agent_end");
+	});
+});


### PR DESCRIPTION
## TL;DR

**What**: Stop server-side web_search results from rendering 100+ duplicate blocks during streaming.
**Why**: The `pendingTools.delete()` call in the `webSearchResult` handler removes the duplicate-creation guard, so every subsequent `message_update` re-creates the component.
**How**: Replace `delete` with a `_webSearchRendered` flag; `message_end`/`agent_end` already clear `pendingTools`.

## What

The `message_update` handler in `chat-controller.ts` iterates all content blocks on every streaming event. For `serverToolUse`, it guards against duplicates with `!host.pendingTools.has(content.id)`. For `webSearchResult`, it rendered the result and then **deleted** the entry from `pendingTools` — removing the guard.

Every subsequent `text_delta` event triggered a `message_update` that re-created the `ToolExecutionComponent` and re-rendered the search result. With 500+ tokens of model output after a search, this produced 100+ identical search result blocks.

## Why

Users see the terminal scroll with identical search result blocks for minutes, making the TUI unusable until the model finishes generating text. The bug is pure rendering — the agent logic is correct.

## How

- Replaced `host.pendingTools.delete(content.toolUseId)` with `component._webSearchRendered = true`
- Added `!component._webSearchRendered` to the `webSearchResult` guard so results render exactly once
- The `pendingTools` entry stays in the map, keeping the `serverToolUse` duplicate guard intact
- `message_end` and `agent_end` already call `pendingTools.clear()`, so no memory leak occurs
- Added regression test (`src/tests/web-search-dedup.test.ts`) that simulates 50 streaming events after a web search and asserts only 1 component is created

Fixes #2029

🤖 Generated with [Claude Code](https://claude.com/claude-code)