### PR TITLE
fix(search): suppress Brave/Google warnings when alternative provider configured

### DIFF
--- a/src/resources/extensions/google-search/index.ts
+++ b/src/resources/extensions/google-search/index.ts
@@ -423,6 +423,9 @@ export default function (pi: ExtensionAPI) {
 	pi.on("session_start", async (_event, ctx) => {
 		if (process.env.GEMINI_API_KEY) return;
 
+		// Don't warn about Google auth when the user has another search provider configured (#2027)
+		if (process.env.BRAVE_API_KEY || process.env.TAVILY_API_KEY) return;
+
 		const hasOAuth = await ctx.modelRegistry.authStorage.hasAuth("google-gemini-cli");
 		if (!hasOAuth) {
 			ctx.ui.notify(

--- a/src/resources/extensions/search-the-web/native-search.ts
+++ b/src/resources/extensions/search-the-web/native-search.ts
@@ -97,6 +97,7 @@ export function registerNativeSearchHooks(pi: NativeSearchPI): { getIsAnthropic:
     isAnthropicProvider = event.model.provider === "anthropic";
 
     const hasBrave = !!process.env.BRAVE_API_KEY;
+    const hasAlternativeSearch = !!process.env.TAVILY_API_KEY || !!process.env.GEMINI_API_KEY;
 
     // When Anthropic (and not preferring Brave): disable custom search tools —
     // native web_search is server-side and more reliable.
@@ -121,7 +122,7 @@ export function registerNativeSearchHooks(pi: NativeSearchPI): { getIsAnthropic:
       ctx.ui.notify("Native Anthropic web search active", "info");
     } else if (isAnthropicProvider && preferBraveSearch() && !wasAnthropic && event.source !== "restore") {
       ctx.ui.notify("Brave search active (PREFER_BRAVE_SEARCH)", "info");
-    } else if (!isAnthropicProvider && !hasBrave) {
+    } else if (!isAnthropicProvider && !hasBrave && !hasAlternativeSearch) {
       ctx.ui.notify(
         "Web search: Set BRAVE_API_KEY or use an Anthropic model for built-in search",
         "warning"

--- a/src/tests/google-search-auth.repro.test.ts
+++ b/src/tests/google-search-auth.repro.test.ts
@@ -85,7 +85,11 @@ test("fix: google-search uses OAuth if GEMINI_API_KEY is missing", async () => {
 
 test("google-search warns if NO authentication is present", async () => {
   const originalKey = process.env.GEMINI_API_KEY;
+  const origBrave = process.env.BRAVE_API_KEY;
+  const origTavily = process.env.TAVILY_API_KEY;
   delete process.env.GEMINI_API_KEY;
+  delete process.env.BRAVE_API_KEY;
+  delete process.env.TAVILY_API_KEY;
 
   try {
     const pi = createMockPI();
@@ -106,7 +110,64 @@ test("google-search warns if NO authentication is present", async () => {
     assert.equal(result.isError, true);
     assert.ok(result.content[0].text.includes("No authentication found"));
   } finally {
-    process.env.GEMINI_API_KEY = originalKey;
+    if (originalKey) process.env.GEMINI_API_KEY = originalKey;
+    else delete process.env.GEMINI_API_KEY;
+    if (origBrave) process.env.BRAVE_API_KEY = origBrave;
+    else delete process.env.BRAVE_API_KEY;
+    if (origTavily) process.env.TAVILY_API_KEY = origTavily;
+    else delete process.env.TAVILY_API_KEY;
+  }
+});
+
+test("#2027: google-search does NOT warn when TAVILY_API_KEY is set", async () => {
+  const originalKey = process.env.GEMINI_API_KEY;
+  const origTavily = process.env.TAVILY_API_KEY;
+  delete process.env.GEMINI_API_KEY;
+  process.env.TAVILY_API_KEY = "tvly-test-key";
+
+  try {
+    const pi = createMockPI();
+    googleSearchExtension(pi as any);
+
+    const notifications: any[] = [];
+    const mockCtx = {
+      ui: { notify(msg: string, level: string) { notifications.push({ msg, level }); } },
+      modelRegistry: mockModelRegistry(undefined),
+    };
+
+    await pi.fire("session_start", {}, mockCtx);
+    assert.equal(notifications.length, 0, "Should NOT warn about Google auth when Tavily is configured");
+  } finally {
+    if (originalKey) process.env.GEMINI_API_KEY = originalKey;
+    else delete process.env.GEMINI_API_KEY;
+    if (origTavily) process.env.TAVILY_API_KEY = origTavily;
+    else delete process.env.TAVILY_API_KEY;
+  }
+});
+
+test("#2027: google-search does NOT warn when BRAVE_API_KEY is set", async () => {
+  const originalKey = process.env.GEMINI_API_KEY;
+  const origBrave = process.env.BRAVE_API_KEY;
+  delete process.env.GEMINI_API_KEY;
+  process.env.BRAVE_API_KEY = "test-brave-key";
+
+  try {
+    const pi = createMockPI();
+    googleSearchExtension(pi as any);
+
+    const notifications: any[] = [];
+    const mockCtx = {
+      ui: { notify(msg: string, level: string) { notifications.push({ msg, level }); } },
+      modelRegistry: mockModelRegistry(undefined),
+    };
+
+    await pi.fire("session_start", {}, mockCtx);
+    assert.equal(notifications.length, 0, "Should NOT warn about Google auth when Brave is configured");
+  } finally {
+    if (originalKey) process.env.GEMINI_API_KEY = originalKey;
+    else delete process.env.GEMINI_API_KEY;
+    if (origBrave) process.env.BRAVE_API_KEY = origBrave;
+    else delete process.env.BRAVE_API_KEY;
   }
 });
 

--- a/src/tests/native-search.test.ts
+++ b/src/tests/native-search.test.ts
@@ -406,9 +406,13 @@ test("model_select shows 'Native Anthropic web search active' for Anthropic prov
   );
 });
 
-test("model_select shows warning for non-Anthropic without Brave key", async () => {
-  const originalKey = process.env.BRAVE_API_KEY;
+test("model_select shows warning for non-Anthropic without any search key", async () => {
+  const origBrave = process.env.BRAVE_API_KEY;
+  const origTavily = process.env.TAVILY_API_KEY;
+  const origGemini = process.env.GEMINI_API_KEY;
   delete process.env.BRAVE_API_KEY;
+  delete process.env.TAVILY_API_KEY;
+  delete process.env.GEMINI_API_KEY;
 
   try {
     const pi = createMockPI();
@@ -422,14 +426,18 @@ test("model_select shows warning for non-Anthropic without Brave key", async () 
     });
 
     const warning = pi.notifications.find((n) => n.level === "warning");
-    assert.ok(warning, "Should show warning for non-Anthropic without Brave key");
+    assert.ok(warning, "Should show warning for non-Anthropic without any search key");
     assert.ok(
       warning!.message.includes("Anthropic"),
       `Warning should mention Anthropic — got: ${warning!.message}`
     );
   } finally {
-    if (originalKey) process.env.BRAVE_API_KEY = originalKey;
+    if (origBrave) process.env.BRAVE_API_KEY = origBrave;
     else delete process.env.BRAVE_API_KEY;
+    if (origTavily) process.env.TAVILY_API_KEY = origTavily;
+    else delete process.env.TAVILY_API_KEY;
+    if (origGemini) process.env.GEMINI_API_KEY = origGemini;
+    else delete process.env.GEMINI_API_KEY;
   }
 });
 

--- a/src/tests/search-warning-spam.test.ts
+++ b/src/tests/search-warning-spam.test.ts
@@ -1,0 +1,211 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  registerNativeSearchHooks,
+  type NativeSearchPI,
+} from "../resources/extensions/search-the-web/native-search.ts";
+
+/**
+ * Regression tests for #2027: BRAVE_API_KEY & GEMINI warnings spam
+ * despite ONLY Tavily configured.
+ *
+ * When the user has Tavily (or another alternative) configured as their
+ * search provider, they should NOT see warnings about missing BRAVE_API_KEY
+ * or GEMINI_API_KEY on model switch or session start.
+ */
+
+// ─── Mock ExtensionAPI (copied from native-search.test.ts) ──────────────────
+
+interface MockHandler {
+  event: string;
+  handler: (...args: any[]) => any;
+}
+
+function createMockPI() {
+  const handlers: MockHandler[] = [];
+  let activeTools = ["search-the-web", "search_and_read", "google_search", "fetch_page", "bash", "read"];
+  const notifications: Array<{ message: string; level: string }> = [];
+
+  const mockCtx = {
+    ui: {
+      notify(message: string, level: string) {
+        notifications.push({ message, level });
+      },
+    },
+  };
+
+  const pi: NativeSearchPI & {
+    handlers: MockHandler[];
+    notifications: typeof notifications;
+    mockCtx: typeof mockCtx;
+    fire(event: string, eventData: any, ctx?: any): Promise<any>;
+  } = {
+    handlers,
+    notifications,
+    mockCtx,
+    on(event: string, handler: (...args: any[]) => any) {
+      handlers.push({ event, handler });
+    },
+    getActiveTools() {
+      return [...activeTools];
+    },
+    setActiveTools(tools: string[]) {
+      activeTools = tools;
+    },
+    async fire(event: string, eventData: any, ctx?: any) {
+      let lastResult: any;
+      for (const h of handlers) {
+        if (h.event === event) {
+          const result = await h.handler(eventData, ctx ?? mockCtx);
+          if (result !== undefined) lastResult = result;
+        }
+      }
+      return lastResult;
+    },
+  };
+
+  return pi;
+}
+
+// ─── Bug #2027: Brave warning suppressed when Tavily configured ─────────────
+
+test("#2027: no BRAVE_API_KEY warning on non-Anthropic model when TAVILY_API_KEY is set", async () => {
+  const origBrave = process.env.BRAVE_API_KEY;
+  const origTavily = process.env.TAVILY_API_KEY;
+  delete process.env.BRAVE_API_KEY;
+  process.env.TAVILY_API_KEY = "tvly-test-key";
+
+  try {
+    const pi = createMockPI();
+    registerNativeSearchHooks(pi);
+
+    await pi.fire("model_select", {
+      type: "model_select",
+      model: { provider: "openai", name: "gpt-4o" },
+      previousModel: undefined,
+      source: "set",
+    });
+
+    const warning = pi.notifications.find(
+      (n) => n.level === "warning" && n.message.includes("BRAVE_API_KEY")
+    );
+    assert.equal(
+      warning, undefined,
+      "Should NOT warn about BRAVE_API_KEY when TAVILY_API_KEY is set"
+    );
+  } finally {
+    if (origBrave) process.env.BRAVE_API_KEY = origBrave;
+    else delete process.env.BRAVE_API_KEY;
+    if (origTavily) process.env.TAVILY_API_KEY = origTavily;
+    else delete process.env.TAVILY_API_KEY;
+  }
+});
+
+test("#2027: no BRAVE_API_KEY warning on model switch (Ctrl+P) when TAVILY_API_KEY is set", async () => {
+  const origBrave = process.env.BRAVE_API_KEY;
+  const origTavily = process.env.TAVILY_API_KEY;
+  delete process.env.BRAVE_API_KEY;
+  process.env.TAVILY_API_KEY = "tvly-test-key";
+
+  try {
+    const pi = createMockPI();
+    registerNativeSearchHooks(pi);
+
+    // Start on Anthropic
+    await pi.fire("model_select", {
+      type: "model_select",
+      model: { provider: "anthropic", name: "claude-sonnet-4-6" },
+      previousModel: undefined,
+      source: "set",
+    });
+
+    pi.notifications.length = 0; // clear
+
+    // Switch to non-Anthropic (Ctrl+P model switch)
+    await pi.fire("model_select", {
+      type: "model_select",
+      model: { provider: "openai", name: "gpt-4o" },
+      previousModel: { provider: "anthropic", name: "claude-sonnet-4-6" },
+      source: "set",
+    });
+
+    const warning = pi.notifications.find(
+      (n) => n.level === "warning" && n.message.includes("BRAVE_API_KEY")
+    );
+    assert.equal(
+      warning, undefined,
+      "Should NOT warn about BRAVE_API_KEY when switching models with Tavily configured"
+    );
+  } finally {
+    if (origBrave) process.env.BRAVE_API_KEY = origBrave;
+    else delete process.env.BRAVE_API_KEY;
+    if (origTavily) process.env.TAVILY_API_KEY = origTavily;
+    else delete process.env.TAVILY_API_KEY;
+  }
+});
+
+test("#2027: no BRAVE_API_KEY warning when GEMINI_API_KEY is set", async () => {
+  const origBrave = process.env.BRAVE_API_KEY;
+  const origGemini = process.env.GEMINI_API_KEY;
+  delete process.env.BRAVE_API_KEY;
+  process.env.GEMINI_API_KEY = "test-gemini-key";
+
+  try {
+    const pi = createMockPI();
+    registerNativeSearchHooks(pi);
+
+    await pi.fire("model_select", {
+      type: "model_select",
+      model: { provider: "openai", name: "gpt-4o" },
+      previousModel: undefined,
+      source: "set",
+    });
+
+    const warning = pi.notifications.find(
+      (n) => n.level === "warning" && n.message.includes("BRAVE_API_KEY")
+    );
+    assert.equal(
+      warning, undefined,
+      "Should NOT warn about BRAVE_API_KEY when GEMINI_API_KEY is set"
+    );
+  } finally {
+    if (origBrave) process.env.BRAVE_API_KEY = origBrave;
+    else delete process.env.BRAVE_API_KEY;
+    if (origGemini) process.env.GEMINI_API_KEY = origGemini;
+    else delete process.env.GEMINI_API_KEY;
+  }
+});
+
+test("#2027: BRAVE_API_KEY warning still shown when NO search provider is configured", async () => {
+  const origBrave = process.env.BRAVE_API_KEY;
+  const origTavily = process.env.TAVILY_API_KEY;
+  const origGemini = process.env.GEMINI_API_KEY;
+  delete process.env.BRAVE_API_KEY;
+  delete process.env.TAVILY_API_KEY;
+  delete process.env.GEMINI_API_KEY;
+
+  try {
+    const pi = createMockPI();
+    registerNativeSearchHooks(pi);
+
+    await pi.fire("model_select", {
+      type: "model_select",
+      model: { provider: "openai", name: "gpt-4o" },
+      previousModel: undefined,
+      source: "set",
+    });
+
+    const warning = pi.notifications.find((n) => n.level === "warning");
+    assert.ok(
+      warning,
+      "Should still warn when no search provider is configured at all"
+    );
+  } finally {
+    if (origBrave) process.env.BRAVE_API_KEY = origBrave;
+    else delete process.env.BRAVE_API_KEY;
+    if (origTavily) process.env.TAVILY_API_KEY = origTavily;
+    else delete process.env.TAVILY_API_KEY;
+    if (origGemini) process.env.GEMINI_API_KEY = origGemini;
+    else delete process.env.GEMINI_API_KEY;
+  }
+});


### PR DESCRIPTION
## TL;DR

Suppress BRAVE_API_KEY and GEMINI_API_KEY warnings when the user has an alternative search provider (e.g. Tavily) configured. Fixes #2027.

## What

- **native-search.ts**: The `model_select` handler now checks for `TAVILY_API_KEY` and `GEMINI_API_KEY` before emitting the "Set BRAVE_API_KEY or use an Anthropic model" warning on non-Anthropic provider selection.
- **google-search/index.ts**: The `session_start` handler now skips the "No authentication set" warning when `BRAVE_API_KEY` or `TAVILY_API_KEY` is present, since the user has a working search provider.
- **Tests**: Added `search-warning-spam.test.ts` with 4 targeted regression tests for #2027. Updated existing tests in `native-search.test.ts` and `google-search-auth.repro.test.ts` to properly isolate env vars and cover the new behavior.

## Why

Users who configured only Tavily as their search provider were spammed with irrelevant warnings about Brave and Google credentials on every model switch (Ctrl+P) and session start. These warnings are noise when the user already has a working search provider.

## How

Both warning paths now check for the presence of alternative search API keys (`TAVILY_API_KEY`, `GEMINI_API_KEY`, `BRAVE_API_KEY`) before deciding to emit a warning. The warning only fires when **no** search provider is configured at all.

Fixes #2027

🤖 Generated with [Claude Code](https://claude.com/claude-code)