### PR TITLE
fix(doctor): skip directory checks for unmaterialized future slices

### DIFF
--- a/src/resources/extensions/gsd/doctor.ts
+++ b/src/resources/extensions/gsd/doctor.ts
@@ -707,21 +707,27 @@ export async function runGSDDoctor(basePath: string, options?: { fix?: boolean; 
 
       const slicePath = resolveSlicePath(basePath, milestoneId, slice.id);
       if (!slicePath) {
+        // Unmaterialized future slices: if the slice directory doesn't exist
+        // and the slice isn't done, it's a planned-but-not-yet-started slice.
+        // Auto-mode lazily materializes directories only for the active slice
+        // (via ensurePreconditions), so flagging these is a false positive.
+        // Only report missing dirs for completed slices (cosmetic warning).
+        if (!slice.done) {
+          continue;
+        }
         const expectedPath = relSlicePath(basePath, milestoneId, slice.id);
         issues.push({
-          severity: slice.done ? "warning" : "error",
+          severity: "warning",
           code: "missing_slice_dir",
           scope: "slice",
           unitId,
-          message: slice.done
-            ? `Missing slice directory for ${unitId} (slice is complete — cosmetic only)`
-            : `Missing slice directory for ${unitId}`,
+          message: `Missing slice directory for ${unitId} (slice is complete — cosmetic only)`,
           file: expectedPath,
           fixable: true,
         });
         if (fix) {
           const absoluteSliceDir = join(milestonePath, "slices", slice.id);
-          mkdirSync(absoluteSliceDir, { recursive: true });
+          mkdirSync(join(absoluteSliceDir, "tasks"), { recursive: true });
           fixesApplied.push(`created ${absoluteSliceDir}`);
         }
         continue;

--- a/src/resources/extensions/gsd/tests/doctor.test.ts
+++ b/src/resources/extensions/gsd/tests/doctor.test.ts
@@ -643,6 +643,101 @@ Discovered an issue.
     rmSync(base, { recursive: true, force: true });
   }
 
+  // ─── Future slices should not be flagged as missing dirs (#2017) ──────
+  console.log("\n=== doctor skips unmaterialized future slices (#2017) ===");
+  {
+    const fsBase = mkdtempSync(join(tmpdir(), "gsd-doctor-future-slice-"));
+    const fsGsd = join(fsBase, ".gsd");
+    const fsMDir = join(fsGsd, "milestones", "M003");
+    // Only create the milestone dir + roadmap — no slice dirs at all,
+    // simulating the state immediately after plan-milestone.
+    mkdirSync(fsMDir, { recursive: true });
+
+    writeFileSync(join(fsMDir, "M003-ROADMAP.md"), `# M003: Future Milestone
+
+## Slices
+- [ ] **S01: First Slice** \`risk:low\` \`depends:[]\`
+  > After this: first slice done
+- [ ] **S02: Second Slice** \`risk:low\` \`depends:[S01]\`
+  > After this: second slice done
+- [ ] **S03: Third Slice** \`risk:medium\` \`depends:[S02]\`
+  > After this: third slice done
+- [ ] **S04: Fourth Slice** \`risk:low\` \`depends:[S03]\`
+  > After this: fourth slice done
+`);
+
+    const r = await runGSDDoctor(fsBase, { fix: false, scope: "M003" });
+    const sliceDirIssues = r.issues.filter(i => i.code === "missing_slice_dir");
+    const tasksDirIssues = r.issues.filter(i => i.code === "missing_tasks_dir");
+    const slicePlanIssues = r.issues.filter(i => i.code === "missing_slice_plan");
+    assertEq(sliceDirIssues.length, 0,
+      "no missing_slice_dir for unmaterialized future slices");
+    assertEq(tasksDirIssues.length, 0,
+      "no missing_tasks_dir for unmaterialized future slices");
+    assertEq(slicePlanIssues.length, 0,
+      "no missing_slice_plan for unmaterialized future slices");
+
+    // A slice that IS materialized (has a dir) should still be checked
+    const fsS01Dir = join(fsMDir, "slices", "S01");
+    mkdirSync(fsS01Dir, { recursive: true });
+    // S01 has a dir but no tasks/ — should flag missing_tasks_dir
+    const r2 = await runGSDDoctor(fsBase, { fix: false, scope: "M003" });
+    const s01TasksDirIssues = r2.issues.filter(
+      i => i.code === "missing_tasks_dir" && i.unitId === "M003/S01"
+    );
+    assertEq(s01TasksDirIssues.length, 1,
+      "missing_tasks_dir reported for materialized slice without tasks/");
+    // S02-S04 still have no dirs — should NOT be flagged
+    const futureSliceDirIssues = r2.issues.filter(
+      i => i.code === "missing_slice_dir" && i.unitId !== "M003/S01"
+    );
+    assertEq(futureSliceDirIssues.length, 0,
+      "no missing_slice_dir for S02-S04 (still unmaterialized)");
+
+    // Completed slices without dirs SHOULD still be flagged (as warnings)
+    const fsDoneBase = mkdtempSync(join(tmpdir(), "gsd-doctor-done-slice-"));
+    const fsDoneGsd = join(fsDoneBase, ".gsd");
+    const fsDoneMDir = join(fsDoneGsd, "milestones", "M001");
+    mkdirSync(fsDoneMDir, { recursive: true });
+    writeFileSync(join(fsDoneMDir, "M001-ROADMAP.md"), `# M001: Done Milestone
+
+## Slices
+- [x] **S01: Completed Slice** \`risk:low\` \`depends:[]\`
+  > After this: done
+`);
+    const r3 = await runGSDDoctor(fsDoneBase, { fix: false, scope: "M001" });
+    const doneSliceDirIssues = r3.issues.filter(i => i.code === "missing_slice_dir");
+    assertEq(doneSliceDirIssues.length, 1,
+      "missing_slice_dir reported as warning for completed slice without dir");
+
+    rmSync(fsBase, { recursive: true, force: true });
+    rmSync(fsDoneBase, { recursive: true, force: true });
+  }
+
+  // ─── Doctor fix creates tasks/ alongside slice dir (#2017) ──────────
+  console.log("\n=== doctor fix creates tasks/ alongside slice dir (#2017) ===");
+  {
+    const fxBase = mkdtempSync(join(tmpdir(), "gsd-doctor-fix-tasks-"));
+    const fxGsd = join(fxBase, ".gsd");
+    const fxMDir = join(fxGsd, "milestones", "M001");
+    const fxS01Dir = join(fxMDir, "slices", "S01");
+    // Create S01 dir but NOT tasks/ — simulating partial auto-fix
+    mkdirSync(fxS01Dir, { recursive: true });
+
+    writeFileSync(join(fxMDir, "M001-ROADMAP.md"), `# M001: Test Milestone
+
+## Slices
+- [x] **S01: Done Slice** \`risk:low\` \`depends:[]\`
+  > After this: done
+`);
+
+    const r = await runGSDDoctor(fxBase, { fix: true, scope: "M001" });
+    assertTrue(existsSync(join(fxS01Dir, "tasks")),
+      "fix creates tasks/ dir when slice dir exists but tasks/ is missing");
+
+    rmSync(fxBase, { recursive: true, force: true });
+  }
+
   report();
 }
 


### PR DESCRIPTION
## TL;DR

**What:** Stop doctor from flagging `missing_slice_dir` / `missing_tasks_dir` for future slices that haven't been materialized on disk yet.
**Why:** After `plan-milestone`, doctor eagerly validates every roadmap slice, causing false errors that degrade health.
**How:** Gate directory checks behind a materialization condition; also fix the auto-fix path to create `tasks/` alongside the slice dir.

## What

- In the slice validation loop in `doctor.ts`, skip `missing_slice_dir` / `missing_tasks_dir` / `missing_slice_plan` checks for incomplete slices whose directories don't exist on disk yet.
- Completed slices without directories are still flagged (as warnings, matching existing behavior).
- When auto-fixing a missing slice dir for a completed slice, create `slices/<SID>/tasks/` in the same pass instead of only creating the parent dir and `continue`-ing, which previously caused a cascading `missing_tasks_dir` on the next doctor pass.

## Why

Auto-mode lazily materializes directories only for the currently dispatched slice (via `ensurePreconditions`). After `plan-milestone` writes the roadmap with S01-S04, post-unit cleanup runs doctor on the milestone scope, which incorrectly treats every listed slice as already materialized. This flips health from green to yellow/error with `missing_slice_dir`, then degrades further into `missing_tasks_dir` after doctor's partial auto-fix only creates parent dirs.

## How

In the `for (const slice of roadmap.slices)` loop (~line 708 of `doctor.ts`):

1. When `resolveSlicePath()` returns null and `slice.done` is false, `continue` immediately — the slice is an unmaterialized future slice and should not be flagged.
2. When `resolveSlicePath()` returns null and `slice.done` is true, report the existing `missing_slice_dir` warning but fix with `mkdirSync(join(absoluteSliceDir, "tasks"), { recursive: true })` to create both the slice dir and tasks/ in one pass.

## Test plan

- [x] Reproduction test: roadmap with S01-S04, no materialized dirs — no `missing_slice_dir` or `missing_tasks_dir` reported
- [x] Materialized slice (dir exists, no tasks/) still gets `missing_tasks_dir`
- [x] Completed slice without dir still gets `missing_slice_dir` warning
- [x] Auto-fix creates `tasks/` alongside slice dir
- [x] All 1788 existing tests pass

Fixes #2017

🤖 Generated with [Claude Code](https://claude.com/claude-code)