### PR TITLE
fix(roadmap): detect done:true/done:false metadata in prose slice headers

### DIFF
--- a/src/resources/extensions/gsd/roadmap-slices.ts
+++ b/src/resources/extensions/gsd/roadmap-slices.ts
@@ -264,6 +264,16 @@ function parseProseSliceHeaders(content: string): RoadmapSliceEntry[] {
       }
     }
 
+    // Extract done state from structured metadata lines — handles:
+    //   "- [x] done:true"  |  "- [ ] done:false"  |  "- done: true"  |  "done:true"
+    // This is authoritative when present — overrides header-level ✓ and (Complete) heuristics.
+    // Intentionally does NOT match bare "- [x]" (high false-positive risk from verification
+    // checklists and task lists in prose body). Only the explicit "done:" keyword is safe.
+    const doneMetaMatch = section.match(/^[-*\s]*(?:\[[ xX]\]\s*)?done:\s*(true|false)/im);
+    if (doneMetaMatch) {
+      done = doneMetaMatch[1]!.toLowerCase() === "true";
+    }
+
     slices.push({ id, title, risk: "medium" as RiskLevel, depends, done, demo: "" });
   }
 

--- a/src/resources/extensions/gsd/tests/roadmap-slices.test.ts
+++ b/src/resources/extensions/gsd/tests/roadmap-slices.test.ts
@@ -253,3 +253,83 @@ Do the second thing.
   assert.equal(slices[0]?.id, "S01");
   assert.equal(slices[1]?.id, "S02");
 });
+
+// ── Regression: done:true/done:false metadata lines in prose headers ────────
+
+test("parseRoadmapSlices: prose headers with '- [x] done:true' metadata detected as done", () => {
+  const proseContent = `# M030: Metadata Done
+
+## Slices
+
+### S01: First Feature
+- [x] done:true
+- depends: []
+
+Some description of what was built.
+
+### S02: Second Feature
+- [ ] done:false
+- depends: [S01]
+
+Not started yet.
+`;
+  const slices = parseRoadmapSlices(proseContent);
+  assert.equal(slices.length, 2);
+  assert.equal(slices[0]?.id, "S01");
+  assert.equal(slices[0]?.done, true, "S01 should be done via '- [x] done:true'");
+  assert.equal(slices[1]?.id, "S02");
+  assert.equal(slices[1]?.done, false, "S02 should not be done");
+});
+
+test("parseRoadmapSlices: 'done:true' metadata overrides missing header marker", () => {
+  const proseContent = `# M031: Override Test
+
+## Slices
+
+### S01: Plain Header
+- done: true
+
+### S02: Also Plain
+- done: false
+`;
+  const slices = parseRoadmapSlices(proseContent);
+  assert.equal(slices.length, 2);
+  assert.equal(slices[0]?.done, true, "done:true in body should set done");
+  assert.equal(slices[1]?.done, false, "done:false in body should keep not-done");
+});
+
+test("parseRoadmapSlices: 'done:false' metadata overrides (Complete) header marker", () => {
+  const proseContent = `# M032: Conflict Test
+
+## Slices
+
+### S01: Feature (Complete)
+- done: false
+
+Description says complete but metadata says not.
+`;
+  const slices = parseRoadmapSlices(proseContent);
+  assert.equal(slices.length, 1);
+  assert.equal(slices[0]?.done, false, "explicit done:false should override (Complete) marker");
+});
+
+test("parseRoadmapSlices: bare [x] in verification checklist does NOT false-positive done", () => {
+  const proseContent = `# M033: False Positive Guard
+
+## Slices
+
+### S01: Build Feature
+
+**Verification:**
+- [x] Tests pass
+- [ ] Browser renders correctly
+- [x] API returns 200
+
+### S02: Polish
+Not started.
+`;
+  const slices = parseRoadmapSlices(proseContent);
+  assert.equal(slices.length, 2);
+  assert.equal(slices[0]?.done, false, "bare [x] in verification list must NOT set done");
+  assert.equal(slices[1]?.done, false);
+});


### PR DESCRIPTION
## Problem

When LLMs write prose-format roadmaps with H3 headers and structured metadata lines below them, completed slices are parsed as `done: false`. This causes `verifyExpectedArtifact()` to reject genuinely complete slices, triggering artifact-verification retry loops that can run indefinitely (see #2007).

Example format that fails:

```markdown
### S01: Feature Title
- [x] done:true
- risk: high
- depends: []
```

## Root Cause

`parseProseSliceHeaders()` in `roadmap-slices.ts` checks for completion only on the header line itself — via `✓` (U+2713) prefix/suffix and `(Complete)` suffix. It already extracts `depends` from the section body between headers but never checks for `done:` metadata in that same section. The `done` field defaults to `false` for any slice without a header-level marker.

## Fix

Adds a targeted regex match for `done:true` / `done:false` metadata lines in the section body, after the existing header-level checks. When present, this metadata is authoritative — it overrides header-level `✓` and `(Complete)` heuristics.

**Key design choice:** The fix intentionally does NOT match bare `- [x]` checkboxes. Prose slice sections often contain verification checklists (`- [x] Tests pass`) that would false-positive as completion markers. Only the explicit `done:` keyword is matched — no LLM writes `done:true` in organic prose.

## Changed Files

| File | Change |
|------|--------|
| `src/resources/extensions/gsd/roadmap-slices.ts` | Add `done:true`/`done:false` metadata detection in `parseProseSliceHeaders()` section body |
| `src/resources/extensions/gsd/tests/roadmap-slices.test.ts` | 4 new test cases: metadata done detection, override of header markers, `done:false` override, and false-positive guard |

## Test Evidence

4 new tests covering the fix:

1. **`- [x] done:true` detected as done** — prose headers with structured metadata lines parse correctly
2. **`done:true` overrides missing header marker** — works without `✓` or `(Complete)` on the header
3. **`done:false` overrides `(Complete)` header marker** — explicit metadata wins over heuristic
4. **Bare `[x]` in verification checklist does NOT false-positive** — ensures `- [x] Tests pass` inside a slice description does not set `done: true`

All 20 tests pass (16 existing + 4 new). No existing test behavior changed.

## Related

- Related to #1884 — same function, different variant (U+2705 emoji vs metadata lines)
- Related to #2007 — this parser bug is one root cause of unbounded artifact-verification retry loops
- See also #1816 — prior fix that added `✓` detection to the same function