### PR TITLE
fix(parallel): prevent workers from committing files outside their milestone

### DIFF
--- a/src/resources/extensions/gsd/git-service.ts
+++ b/src/resources/extensions/gsd/git-service.ts
@@ -9,7 +9,7 @@
  */
 
 import { execFileSync, execSync } from "node:child_process";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { gsdRoot } from "./paths.js";
 import { GIT_NO_PROMPT_ENV } from "./git-constants.js";
@@ -527,7 +527,33 @@ export class GitServiceImpl {
     // Native path uses libgit2 (single syscall), fallback spawns git.
     if (!nativeHasChanges(this.basePath)) return null;
 
-    this.smartStage(extraExclusions);
+    // Parallel worker isolation (#1991): when GSD_MILESTONE_LOCK is set,
+    // this process is scoped to a single milestone. Exclude all other
+    // milestone directories from staging so a worker cannot accidentally
+    // commit artifacts (SUMMARY, VALIDATION, etc.) for milestones it
+    // doesn't own. Without this guard, a parallel worker can fabricate
+    // the entire artifact tree of a sibling milestone in a single commit.
+    const allExclusions = [...extraExclusions];
+    const milestoneLock = process.env.GSD_MILESTONE_LOCK;
+    if (milestoneLock) {
+      try {
+        const msDir = join(gsdRoot(this.basePath), "milestones");
+        if (existsSync(msDir)) {
+          const entries = readdirSync(msDir, { withFileTypes: true });
+          for (const entry of entries) {
+            if (entry.isDirectory() && entry.name !== milestoneLock) {
+              allExclusions.push(`.gsd/milestones/${entry.name}/`);
+            }
+          }
+        }
+      } catch {
+        // Non-fatal: if we can't read the milestones dir, proceed without
+        // extra exclusions. The commit will include all milestone artifacts
+        // (same as before this fix).
+      }
+    }
+
+    this.smartStage(allExclusions);
 
     // After smart staging, check if anything was actually staged
     // (all changes might have been runtime files that got excluded)

--- a/src/resources/extensions/gsd/tests/git-service.test.ts
+++ b/src/resources/extensions/gsd/tests/git-service.test.ts
@@ -1411,6 +1411,106 @@ async function main(): Promise<void> {
     rmSync(repo, { recursive: true, force: true });
   }
 
+  // ─── autoCommit excludes other milestone dirs when GSD_MILESTONE_LOCK set (#1991) ──
+
+  console.log("\n=== autoCommit: GSD_MILESTONE_LOCK excludes other milestones ===");
+
+  {
+    const repo = mkdtempSync(join(tmpdir(), "gsd-milestone-lock-"));
+    run("git init -b main", repo);
+    run("git config user.email test@test.com", repo);
+    run("git config user.name Test", repo);
+    writeFileSync(join(repo, "README.md"), "init");
+    run("git add -A && git commit -m init", repo);
+
+    // Set up: two milestones M032 and M033 with artifacts
+    mkdirSync(join(repo, ".gsd", "milestones", "M032", "slices", "S01"), { recursive: true });
+    mkdirSync(join(repo, ".gsd", "milestones", "M033", "slices", "S01"), { recursive: true });
+    writeFileSync(join(repo, ".gsd", "milestones", "M032", "M032-SUMMARY.md"), "# M032 Summary (fabricated)");
+    writeFileSync(join(repo, ".gsd", "milestones", "M032", "slices", "S01", "S01-SUMMARY.md"), "# S01 Summary");
+    writeFileSync(join(repo, ".gsd", "milestones", "M033", "ROADMAP.md"), "# M033 Roadmap");
+    mkdirSync(join(repo, "src"), { recursive: true });
+    writeFileSync(join(repo, "src", "app.ts"), "const x = 1;");
+
+    // Simulate parallel worker locked to M033
+    const originalLock = process.env.GSD_MILESTONE_LOCK;
+    process.env.GSD_MILESTONE_LOCK = "M033";
+
+    try {
+      const svc = new GitServiceImpl(repo);
+      const msg = svc.autoCommit("execute-task", "M033/S01/T01");
+      assertTrue(msg !== null, "milestone-lock: commit succeeds");
+
+      const committed = run("git show --name-only HEAD", repo);
+
+      // M033 artifacts SHOULD be committed (own milestone)
+      assertTrue(committed.includes(".gsd/milestones/M033/"),
+        "milestone-lock: M033 artifacts ARE in commit (own milestone)");
+
+      // M032 artifacts should NOT be committed (other milestone)
+      assertTrue(!committed.includes(".gsd/milestones/M032/"),
+        "milestone-lock: M032 artifacts are NOT in commit (other milestone)");
+
+      // Source files SHOULD be committed
+      assertTrue(committed.includes("src/app.ts"),
+        "milestone-lock: source files ARE in commit");
+    } finally {
+      // Restore env
+      if (originalLock === undefined) {
+        delete process.env.GSD_MILESTONE_LOCK;
+      } else {
+        process.env.GSD_MILESTONE_LOCK = originalLock;
+      }
+    }
+
+    rmSync(repo, { recursive: true, force: true });
+  }
+
+  // ─── autoCommit without GSD_MILESTONE_LOCK commits all milestones ──
+
+  console.log("\n=== autoCommit: no GSD_MILESTONE_LOCK commits all milestones ===");
+
+  {
+    const repo = mkdtempSync(join(tmpdir(), "gsd-no-milestone-lock-"));
+    run("git init -b main", repo);
+    run("git config user.email test@test.com", repo);
+    run("git config user.name Test", repo);
+    writeFileSync(join(repo, "README.md"), "init");
+    run("git add -A && git commit -m init", repo);
+
+    // Set up: two milestones
+    mkdirSync(join(repo, ".gsd", "milestones", "M032"), { recursive: true });
+    mkdirSync(join(repo, ".gsd", "milestones", "M033"), { recursive: true });
+    writeFileSync(join(repo, ".gsd", "milestones", "M032", "ROADMAP.md"), "# M032");
+    writeFileSync(join(repo, ".gsd", "milestones", "M033", "ROADMAP.md"), "# M033");
+
+    // Ensure GSD_MILESTONE_LOCK is NOT set
+    const originalLock = process.env.GSD_MILESTONE_LOCK;
+    delete process.env.GSD_MILESTONE_LOCK;
+
+    try {
+      const svc = new GitServiceImpl(repo);
+      const msg = svc.autoCommit("execute-task", "M033/S01/T01");
+      assertTrue(msg !== null, "no-lock: commit succeeds");
+
+      const committed = run("git show --name-only HEAD", repo);
+
+      // Both milestones SHOULD be committed when no lock is set
+      assertTrue(committed.includes(".gsd/milestones/M032/"),
+        "no-lock: M032 artifacts ARE in commit");
+      assertTrue(committed.includes(".gsd/milestones/M033/"),
+        "no-lock: M033 artifacts ARE in commit");
+    } finally {
+      if (originalLock === undefined) {
+        delete process.env.GSD_MILESTONE_LOCK;
+      } else {
+        process.env.GSD_MILESTONE_LOCK = originalLock;
+      }
+    }
+
+    rmSync(repo, { recursive: true, force: true });
+  }
+
   report();
 }
 


### PR DESCRIPTION
## TL;DR

**What**: Exclude other milestone directories from git staging when `GSD_MILESTONE_LOCK` is set.
**Why**: Parallel workers can fabricate another milestone's entire artifact tree in a single commit.
**How**: `autoCommit` now reads `GSD_MILESTONE_LOCK` and adds pathspec exclusions for sibling milestone dirs.

## What

When a parallel worker (with `GSD_MILESTONE_LOCK` set) runs `autoCommit`, it now lists `.gsd/milestones/` and excludes every directory that does not match the locked milestone from `smartStage`. This prevents staging and committing files like `M032-SUMMARY.md`, `M032-VALIDATION.md`, or slice summaries that belong to a different milestone.

## Why

The `GSD_MILESTONE_LOCK` env var filters what `deriveState()` sees, giving each parallel worker the illusion that only its milestone exists. However, the commit path (`autoCommit` -> `smartStage` -> `git add -A`) had no such filtering — it staged everything in the working tree including artifacts from other milestones. This allowed a worker locked to M033 to commit fabricated planning artifacts for M032, marking it as "done" when no real code had been built.

## How

- `git-service.ts`: In `autoCommit()`, when `GSD_MILESTONE_LOCK` is set, read `.gsd/milestones/` entries and add exclusion pathspecs (`:!.gsd/milestones/<other>/`) for every directory that doesn't match the lock. These are passed to `smartStage` alongside existing `extraExclusions`.
- `git-service.test.ts`: Two new tests:
  1. With `GSD_MILESTONE_LOCK=M033`: verifies M032 artifacts are excluded, M033 artifacts and source files are committed.
  2. Without `GSD_MILESTONE_LOCK`: verifies both milestone artifacts are committed (no regression).

Fixes #1991

🤖 Generated with [Claude Code](https://claude.com/claude-code)