### PR TITLE
fix(gsd): sync worktree state before parallel worker bootstrap

### DIFF
--- a/src/resources/extensions/gsd/parallel-orchestrator.ts
+++ b/src/resources/extensions/gsd/parallel-orchestrator.ts
@@ -21,7 +21,7 @@ import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { gsdRoot } from "./paths.js";
 import { createWorktree, worktreePath } from "./worktree-manager.js";
-import { autoWorktreeBranch, runWorktreePostCreateHook } from "./auto-worktree.js";
+import { autoWorktreeBranch, runWorktreePostCreateHook, syncGsdStateToWorktree } from "./auto-worktree.js";
 import { nativeBranchExists } from "./native-git-bridge.js";
 import { readIntegrationBranch } from "./git-service.js";
 import { resolveParallelConfig } from "./preferences.js";
@@ -489,6 +489,13 @@ function createMilestoneWorktree(basePath: string, milestoneId: string): string 
     const integrationBranch = readIntegrationBranch(basePath, milestoneId) ?? undefined;
     info = createWorktree(basePath, milestoneId, { branch, startPoint: integrationBranch });
   }
+
+  // Parallel workers bootstrap from the worktree path. If the next milestone
+  // only exists as untracked .gsd state in the project root, a raw git
+  // worktree checkout won't contain it yet. Sync planning artifacts into the
+  // worktree before the worker process starts so bootstrap deriveState() sees
+  // the locked milestone immediately.
+  syncGsdStateToWorktree(basePath, info.path);
 
   // Run post-create hook if configured
   runWorktreePostCreateHook(basePath, info.path);

--- a/src/resources/extensions/gsd/tests/parallel-orchestration.test.ts
+++ b/src/resources/extensions/gsd/tests/parallel-orchestration.test.ts
@@ -19,6 +19,7 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { execSync } from "node:child_process";
 
 import {
   writeSessionStatus,
@@ -51,6 +52,7 @@ import {
   resetOrchestrator,
   refreshWorkerStatuses,
 } from "../parallel-orchestrator.js";
+import { worktreePath } from "../worktree-manager.js";
 
 import { validatePreferences, resolveParallelConfig } from "../preferences.js";
 
@@ -62,6 +64,38 @@ import type { WorkerInfo } from "../parallel-orchestrator.js";
 function makeTmpBase(): string {
   const base = mkdtempSync(join(tmpdir(), "gsd-parallel-test-"));
   mkdirSync(join(base, ".gsd"), { recursive: true });
+  return base;
+}
+
+function run(command: string, cwd: string): string {
+  return execSync(command, { cwd, stdio: ["ignore", "pipe", "pipe"], encoding: "utf-8" }).trim();
+}
+
+function makeGitBaseRepo(): string {
+  const base = mkdtempSync(join(tmpdir(), "gsd-parallel-git-test-"));
+  run("git init -b main", base);
+  run('git config user.name "Test User"', base);
+  run('git config user.email "test@example.com"', base);
+  mkdirSync(join(base, ".gsd", "milestones", "M001"), { recursive: true });
+  writeFileSync(join(base, ".gitignore"), ".gsd\n", "utf-8");
+  writeFileSync(join(base, ".gsd", "PROJECT.md"), "# Project\n", "utf-8");
+  writeFileSync(join(base, ".gsd", "REQUIREMENTS.md"), "# Requirements\n", "utf-8");
+  writeFileSync(join(base, ".gsd", "DECISIONS.md"), "# Decisions\n", "utf-8");
+  writeFileSync(join(base, ".gsd", "KNOWLEDGE.md"), "# Knowledge\n", "utf-8");
+  writeFileSync(join(base, ".gsd", "milestones", "M001", "M001-CONTEXT.md"), "# M001: Done\n", "utf-8");
+  writeFileSync(
+    join(base, ".gsd", "milestones", "M001", "M001-ROADMAP.md"),
+    "# M001: Done\n\n## Slices\n- [x] **S01: Finished** `risk:low` `depends:[]`\n  > done\n",
+    "utf-8",
+  );
+  writeFileSync(
+    join(base, ".gsd", "milestones", "M001", "M001-SUMMARY.md"),
+    "---\nid: M001\ntitle: Done\nstatus: complete\n---\n\n# M001 Summary\n",
+    "utf-8",
+  );
+  run("git add .gitignore", base);
+  run("git add -f .gsd/PROJECT.md .gsd/REQUIREMENTS.md .gsd/DECISIONS.md .gsd/KNOWLEDGE.md .gsd/milestones/M001", base);
+  run('git commit -m "seed tracked M001"', base);
   return base;
 }
 
@@ -343,6 +377,37 @@ describe("parallel-orchestrator: lifecycle", () => {
     // State is "running" if spawn succeeds, "error" if binary not found (CI)
     assert.ok(status.state === "running" || status.state === "error",
       `expected running or error, got ${status.state}`);
+  });
+
+  it("startParallel syncs untracked next-milestone artifacts into the worker worktree", async () => {
+    const repo = makeGitBaseRepo();
+    try {
+      mkdirSync(join(repo, ".gsd", "milestones", "M002"), { recursive: true });
+      writeFileSync(
+        join(repo, ".gsd", "milestones", "M002", "M002-ROADMAP.md"),
+        "# M002: Next\n\n## Slices\n- [ ] **S01: Work** `risk:low` `depends:[]`\n  > do work\n",
+        "utf-8",
+      );
+      writeFileSync(
+        join(repo, ".gsd", "milestones", "M002", "M002-META.json"),
+        '{"integrationBranch":"main"}\n',
+        "utf-8",
+      );
+
+      const result = await startParallel(repo, ["M002"], {
+        parallel: { enabled: true, max_workers: 1, merge_strategy: "per-milestone", auto_merge: "confirm" },
+      });
+      assert.deepEqual(result.started, ["M002"]);
+
+      const wtRoadmap = join(worktreePath(repo, "M002"), ".gsd", "milestones", "M002", "M002-ROADMAP.md");
+      assert.equal(existsSync(wtRoadmap), true, "worktree should receive untracked M002 roadmap from project root sync");
+      assert.match(readFileSync(wtRoadmap, "utf-8"), /# M002: Next/);
+
+      await stopParallel(repo);
+    } finally {
+      resetOrchestrator();
+      rmSync(repo, { recursive: true, force: true });
+    }
   });
 
   it("stopParallel stops all workers", async () => {


### PR DESCRIPTION
## TL;DR

**What:** Sync untracked `.gsd` milestone planning artifacts into a newly created parallel worker worktree before worker bootstrap.
**Why:** A raw git worktree checkout does not include untracked next-milestone files, so worker bootstrap can derive state from an incomplete `.gsd` snapshot and miss the locked milestone.
**How:** Call `syncGsdStateToWorktree(basePath, info.path)` during `createMilestoneWorktree(...)` and cover it with a git-backed regression test where `M002` exists only as untracked root-state before `startParallel(...)`.

## What

This change hardens parallel worker startup when the next milestone exists only as untracked `.gsd` state in the project root.

Changed files:
- `src/resources/extensions/gsd/parallel-orchestrator.ts`
- `src/resources/extensions/gsd/tests/parallel-orchestration.test.ts`

Behavior change:
- after creating the milestone worktree for a parallel worker,
- the orchestrator now syncs `.gsd` planning artifacts from the project root into the worktree
- before the worker process starts bootstrapping from that worktree path

## Why

During the broader parallel audit, one concrete root cause for `/gsd parallel start` failures was that worker worktrees could be created from git state that did not contain the next milestone's `.gsd` artifacts yet.

That happens when the next milestone exists only as untracked planning state in the project root. In that case:
- the worker worktree starts from a stale/incomplete `.gsd` snapshot,
- bootstrap state derivation can miss the intended milestone,
- and the worker can stop immediately without doing useful work.

## How

Implementation:
- import `syncGsdStateToWorktree` from `auto-worktree.ts`
- call it in `createMilestoneWorktree(...)` immediately after worktree creation and before the post-create hook / worker bootstrap sequence continues

Regression coverage:
- add a git-backed fixture repo helper in `parallel-orchestration.test.ts`
- create tracked `M001`
- create untracked `M002` roadmap/meta in the project root only
- call `startParallel(repo, ["M002"], ...)`
- assert that the worker worktree receives `.gsd/milestones/M002/M002-ROADMAP.md`

## Change type

- [x] `fix` — Bug fix
- [x] `test` — Adding or updating tests

## Scope

- [x] `gsd extension` — GSD workflow

## Breaking changes

- [x] No breaking changes

## Test plan

- [ ] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

Local verification:
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/parallel-orchestration.test.ts`
  - result: `56 pass / 0 fail`

## AI disclosure

- [x] This PR includes AI-assisted code
  - Implemented and verified in pi/GSD
  - Isolated from the parallel audit as a focused worker-bootstrap fix, separate from merge/recovery and loader-path fixes
