### PR TITLE
test(web): guard readdirSync import in boot payload path

### DIFF
--- a/src/tests/web-boot-node24.test.ts
+++ b/src/tests/web-boot-node24.test.ts
@@ -151,3 +151,26 @@ test("boot route returns { error } JSON on handler failure", async () => {
     "boot route must return status 500 on error",
   )
 })
+
+// ---------------------------------------------------------------------------
+// Bug 4 — bridge-service must import readdirSync for session listing (#1936)
+// ---------------------------------------------------------------------------
+
+test("bridge-service imports readdirSync from node:fs (#1936)", async () => {
+  // The boot payload calls listProjectSessions which uses readdirSync.
+  // A missing import causes ReferenceError → HTTP 500 on /api/boot.
+  const { readFileSync } = await import("node:fs")
+  const { join } = await import("node:path")
+
+  const bridgeSource = readFileSync(
+    join(process.cwd(), "src", "web", "bridge-service.ts"),
+    "utf-8",
+  )
+
+  assert.match(
+    bridgeSource,
+    /import\s*\{[^}]*readdirSync[^}]*\}\s*from\s*["']node:fs["']/,
+    "bridge-service.ts must import readdirSync from node:fs — " +
+      "removing it breaks /api/boot with ReferenceError (see #1936)",
+  )
+})

--- a/src/tests/web-bridge-contract.test.ts
+++ b/src/tests/web-bridge-contract.test.ts
@@ -659,3 +659,77 @@ test("bridge command/runtime failures are inspectable and redact secret material
     fixture.cleanup();
   }
 });
+
+// ---------------------------------------------------------------------------
+// Bug — readdirSync must be available in bridge-service for session listing
+// (Fixes #1936: /api/boot returns 500 when readdirSync is missing)
+// ---------------------------------------------------------------------------
+
+test("/api/boot lists sessions from the real filesystem via readdirSync (#1936)", async () => {
+  const fixture = makeWorkspaceFixture();
+  const sessionPath = createSessionFile(fixture.projectCwd, fixture.sessionsDir, "sess-fs", "FS Session");
+  const harness = createHarness((command, current) => {
+    if (command.type === "get_state") {
+      current.emit({
+        id: command.id,
+        type: "response",
+        command: "get_state",
+        success: true,
+        data: {
+          sessionId: "sess-fs",
+          sessionFile: sessionPath,
+          thinkingLevel: "off",
+          isStreaming: false,
+          isCompacting: false,
+          steeringMode: "all",
+          followUpMode: "all",
+          autoCompactionEnabled: false,
+          autoRetryEnabled: false,
+          retryInProgress: false,
+          retryAttempt: 0,
+          messageCount: 0,
+          pendingMessageCount: 0,
+        },
+      });
+      return;
+    }
+    assert.fail(`unexpected command during boot: ${command.type}`);
+  });
+
+  // Deliberately omit listSessions so the real listProjectSessions (which
+  // calls readdirSync) is exercised. If readdirSync is missing from the
+  // bridge-service node:fs import, this test will throw ReferenceError.
+  bridge.configureBridgeServiceForTests({
+    env: {
+      ...process.env,
+      GSD_WEB_PROJECT_CWD: fixture.projectCwd,
+      GSD_WEB_PROJECT_SESSIONS_DIR: fixture.sessionsDir,
+      GSD_WEB_PACKAGE_ROOT: repoRoot,
+    },
+    spawn: harness.spawn,
+    indexWorkspace: async () => fakeWorkspaceIndex(),
+    getAutoDashboardData: () => fakeAutoDashboardData(),
+    getOnboardingNeeded: () => false,
+  });
+
+  try {
+    const response = await bootRoute.GET();
+    assert.equal(response.status, 200, "/api/boot must not return 500 — readdirSync must be available");
+    const payload = await response.json() as any;
+
+    // The real listProjectSessions should have found the session file via readdirSync
+    assert.ok(
+      Array.isArray(payload.resumableSessions),
+      "boot payload must include resumableSessions array",
+    );
+    assert.equal(
+      payload.resumableSessions.length,
+      1,
+      "readdirSync-based session listing must find the test session file",
+    );
+    assert.equal(payload.resumableSessions[0].id, "sess-fs");
+  } finally {
+    await bridge.resetBridgeServiceForTests();
+    fixture.cleanup();
+  }
+});


### PR DESCRIPTION
## TL;DR

**What:** Add regression tests ensuring `readdirSync` stays imported in `bridge-service.ts`.
**Why:** A missing `readdirSync` import causes `/api/boot` to return HTTP 500 on every request, breaking `gsd --web` completely.
**How:** Two guard tests — one source-level import check, one integration test exercising the real filesystem session listing path.

Fixes #1936

## What

Added two regression tests:

1. **Source-level guard** (`web-boot-node24.test.ts`): Reads `bridge-service.ts` source and asserts that `readdirSync` is in the `node:fs` import. This catches the import being accidentally removed during refactoring.

2. **Integration test** (`web-bridge-contract.test.ts`): Exercises the `/api/boot` endpoint **without** mocking `listSessions`, so the real `listProjectSessions` function (which calls `readdirSync`) runs against the filesystem. Verifies the response is 200 and session files are correctly discovered.

## Why

The boot payload flow calls `listProjectSessions()` which uses `readdirSync` to scan session `.jsonl` files. All existing contract tests mock `listSessions`, so a missing `readdirSync` import would not be caught by existing tests — the endpoint would still return 200 in test but fail with `ReferenceError` in production.

## How

- The source-level test uses regex matching against the import statement
- The integration test creates a temp workspace with a session file, configures the bridge service **without** a `listSessions` override, and asserts the boot endpoint returns 200 with the session in `resumableSessions`
- Verified the integration test correctly fails (HTTP 500) when `readdirSync` is removed from the import

🤖 Generated with [Claude Code](https://claude.com/claude-code)