### PR TITLE
feat: interactive session picker on startup

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -37,6 +37,7 @@ interface CliFlags {
   print?: boolean
   continue?: boolean
   noSession?: boolean
+  noPicker?: boolean
   worktree?: boolean | string
   model?: string
   listModels?: string | true
@@ -80,6 +81,8 @@ function parseCliArgs(argv: string[]): CliFlags {
       flags.continue = true
     } else if (arg === '--no-session') {
       flags.noSession = true
+    } else if (arg === '--no-picker') {
+      flags.noPicker = true
     } else if (arg === '--model' && i + 1 < args.length) {
       flags.model = args[++i]
     } else if (arg === '--extension' && i + 1 < args.length) {
@@ -190,19 +193,15 @@ if (cliFlags.web || (cliFlags.messages[0] === 'web' && cliFlags.messages[1] !== 
 // ---------------------------------------------------------------------------
 // Session picker — shared by `gsd sessions` subcommand and startup-without-args
 // ---------------------------------------------------------------------------
-/**
- * Display an interactive session picker for the current working directory.
- *
- * `exitOnCancel=true`  — used by `gsd sessions`: q/invalid/empty exits the process.
- * `exitOnCancel=false` — used at startup: q/empty/0 means "start a new session".
- *
- * On a valid pick, sets `cliFlags._selectedSessionPath` so the session manager
- * below opens that specific file instead of creating a new one.
- */
+// Session picker — delegates to src/session-picker.ts
+// ---------------------------------------------------------------------------
 async function runSessionPicker(exitOnCancel: boolean): Promise<void> {
+  const { runSessionPicker: _pick } = await import('./session-picker.js')
+  const { SessionManager } = await import('@gsd/pi-coding-agent')
+  const { getProjectSessionsDir } = await import('./project-sessions.js')
+
   const cwd = process.cwd()
   const pickerSessionsDir = getProjectSessionsDir(cwd)
-
   const sessions = await SessionManager.list(cwd, pickerSessionsDir)
 
   if (sessions.length === 0) {
@@ -213,307 +212,26 @@ async function runSessionPicker(exitOnCancel: boolean): Promise<void> {
     return
   }
 
-  const maxShow = exitOnCancel ? 20 : 10
-  const toShow = sessions.slice(0, maxShow)
+  const result = await _pick(exitOnCancel, cwd, sessions)
 
-  // ── Layout helpers ────────────────────────────────────────────────────────
-  // Sample a long date to get the real max width for this locale
-  const _sampleDate = new Date(2026, 11, 31, 23, 59)
-  function formatDate(d: Date): string {
-    return d.toLocaleString(undefined, {
-      month: 'short', day: 'numeric', year: 'numeric',
-      hour: 'numeric', minute: '2-digit',
-    })
-  }
-
-  // Fixed column widths (never change regardless of terminal size)
-  const COL_NUM  = 3   // right-aligned number: " 1" .. "10"
-  const COL_MSGS = 4   // right-aligned: "  30"
-  const COL_DATE = Math.max(formatDate(_sampleDate).length, 20)
-
-  // getLayout() — reads terminal width at call time so resize is instant
-  function getLayout() {
-    const termWidth = process.stderr.columns || 80
-    // Table row structure:
-    //   "  │ " + NUM + " │ " + DATE + " │ " + MSGS + " │ " + TOPIC + " │"
-    const TABLE_OVERHEAD = 2 + 1 + (COL_NUM + 2) + 1 + (COL_DATE + 2) + 1 + (COL_MSGS + 2) + 1 + 2
-    const MIN_TABLE_WIDTH = TABLE_OVERHEAD + COL_NUM + COL_DATE + COL_MSGS + 12
-    const useWide = termWidth >= MIN_TABLE_WIDTH
-    const COL_TOPIC = Math.max(12, termWidth - TABLE_OVERHEAD - COL_NUM - COL_DATE - COL_MSGS)
-    const compactWidth = Math.max(10, termWidth - 8)
-    return { termWidth, useWide, COL_TOPIC, compactWidth }
-  }
-
-  const ESC = '\x1B'
-  const HIDE_CURSOR  = `${ESC}[?25l`
-  const SHOW_CURSOR  = `${ESC}[?25h`
-  const CLEAR_LINE   = `${ESC}[2K\r`
-  const MOVE_UP      = (n: number) => `${ESC}[${n}A`
-  const ALT_SCREEN_ON  = `${ESC}[?1049h`
-  const ALT_SCREEN_OFF = `${ESC}[?1049l`
-  const CLEAR_SCREEN   = `${ESC}[2J${ESC}[H`
-
-  /** Strip ANSI escape codes to get visible length. */
-  function visLen(s: string): number {
-    return s.replace(/\x1B\[[0-9;]*m/g, '').length
-  }
-
-  /** Pad/truncate to exact visible width. */
-  function cell(text: string, len: number, align: 'left' | 'right' = 'left'): string {
-    const vl = visLen(text)
-    const diff = len - vl
-    if (diff < 0) {
-      let result = ''
-      let count = 0
-      for (const ch of text.replace(/\x1B\[[0-9;]*m/g, '')) {
-        if (count >= len - 1) { result += '…'; break }
-        result += ch; count++
-      }
-      return result
-    }
-    if (align === 'right') return ' '.repeat(diff) + text
-    return text + ' '.repeat(diff)
-  }
-
-  // Wide layout: full table with 4 columns — uses live layout values
-  function tableRow(num: string, date: string, msgs: string, topic: string, COL_TOPIC: number): string {
-    return (
-      '  │ ' + cell(num, COL_NUM, 'right') +
-      ' │ ' + cell(date, COL_DATE) +
-      ' │ ' + cell(msgs, COL_MSGS, 'right') +
-      ' │ ' + cell(topic, COL_TOPIC) +
-      ' │'
-    )
-  }
-
-  function divider(l: string, m: string, r: string, COL_TOPIC: number): string {
-    return (
-      '  ' + l +
-      '─'.repeat(COL_NUM + 2) + m +
-      '─'.repeat(COL_DATE + 2) + m +
-      '─'.repeat(COL_MSGS + 2) + m +
-      '─'.repeat(COL_TOPIC + 2) + r
-    )
-  }
-
-  // compactWidth is now derived inside getLayout() — placeholder kept for compactRow
-  // compactWidth is derived from getLayout() on every render
-
-  function compactRow(num: string | null, date: string, msgs: string, topic: string, isSelected: boolean, cw: number): string[] {
-    const selector = isSelected ? chalk.cyan('▶') : ' '
-    const numStr = num !== null ? chalk.bold(num.padStart(2)) : ' 0'
-    const meta = `${date}  ${chalk.dim(`(${msgs} msgs)`)}`
-    const topicLine = cell(topic, cw)
-    const line1 = `  ${selector} ${numStr}  ${meta}`
-    const line2 = `      ${chalk.dim('└─')} ${isSelected ? chalk.white(topicLine) : chalk.dim(topicLine)}`
-    return [line1, line2]
-  }
-
-
-  // ── Build rows list ───────────────────────────────────────────────────────
-  type PickerRow = { label: string; sessionIdx: number | null }
-  const rows: PickerRow[] = []
-
-  if (!exitOnCancel) {
-    rows.push({ label: '[ new conversation ]', sessionIdx: null })
-  }
-  for (let i = 0; i < toShow.length; i++) {
-    const s = toShow[i]
-    const topic = s.name || (s.firstMessage ? s.firstMessage.replace(/\n/g, ' ') : '(empty)')
-    rows.push({ label: topic, sessionIdx: i })
-  }
-
-  // ── Render ────────────────────────────────────────────────────────────────
-  function renderTable(selectedIdx: number): string {
-    // Re-read terminal dimensions on every render — picks up resize events instantly
-    const { termWidth, useWide, COL_TOPIC, compactWidth } = getLayout()
-    const out: string[] = []
-    out.push(chalk.bold(`\n  Sessions for ${chalk.cyan(cwd)}\n`))
-
-    if (useWide) {
-      // ── Wide: full table ──
-      out.push(divider('┌', '┬', '┐', COL_TOPIC))
-      out.push(tableRow(chalk.bold(' # '), chalk.bold('Date'), chalk.bold('Msgs'), chalk.bold('Topic'), COL_TOPIC))
-      out.push(divider('├', '┼', '┤', COL_TOPIC))
-
-      for (let i = 0; i < rows.length; i++) {
-        const r = rows[i]
-        const isSelected = i === selectedIdx
-
-        if (r.sessionIdx === null) {
-          const line = tableRow(' 0 ', '[ new conversation ]', '', '', COL_TOPIC)
-          out.push(isSelected ? chalk.bgBlue(chalk.white(line)) : chalk.dim(line))
-          out.push(divider('├', '┼', '┤', COL_TOPIC))
-        } else {
-          const s = toShow[r.sessionIdx]
-          const numStr   = String(r.sessionIdx + 1)
-          const dateStr  = formatDate(s.modified)
-          const msgsStr  = String(s.messageCount)
-          // Truncate/pad topic BEFORE applying chalk — cell() can't see through ANSI codes
-          const topicRaw = cell(r.label, COL_TOPIC)
-          const topicStr = isSelected ? topicRaw : (s.name ? chalk.cyan(topicRaw) : chalk.white(topicRaw))
-          const dateColored  = isSelected ? dateStr : chalk.green(dateStr)
-          const msgsColored  = isSelected ? msgsStr : chalk.cyan(msgsStr)
-          const line = tableRow(numStr, dateColored, msgsColored, topicStr, COL_TOPIC)
-          out.push(isSelected ? chalk.bgBlue(chalk.white(line)) : line)
-        }
-      }
-
-      out.push(divider('└', '┴', '┘', COL_TOPIC))
-
-    } else {
-      // ── Compact: 2 lines per row ──
-      out.push('  ' + '─'.repeat(Math.max(10, termWidth - 4)))
-
-      for (let i = 0; i < rows.length; i++) {
-        const r = rows[i]
-        const isSelected = i === selectedIdx
-
-        if (r.sessionIdx === null) {
-          const selector = isSelected ? chalk.cyan('▶') : ' '
-          const line = `  ${selector}  0  ${isSelected ? chalk.white('[ new conversation ]') : chalk.dim('[ new conversation ]')}`
-          out.push(line)
-          out.push('  ' + '─'.repeat(Math.max(10, termWidth - 4)))
-        } else {
-          const s = toShow[r.sessionIdx]
-          const lines = compactRow(
-            String(r.sessionIdx + 1),
-            isSelected ? formatDate(s.modified) : chalk.green(formatDate(s.modified)),
-            String(s.messageCount),
-            r.label,
-            isSelected,
-            compactWidth,
-          )
-          out.push(...lines)
-        }
-      }
-
-      out.push('  ' + '─'.repeat(Math.max(10, termWidth - 4)))
-    }
-
-    if (sessions.length > maxShow) {
-      const extra = sessions.length - maxShow
-      const hint = exitOnCancel ? '' : `  · ${chalk.bold('gsd sessions')} to see all`
-      out.push(chalk.dim(`\n  ... and ${extra} more${hint}`))
-    }
-
-    const hint = exitOnCancel
-      ? chalk.dim('  ↑↓ navigate  ·  Enter select  ·  Esc/q quit')
-      : chalk.dim('  ↑↓ navigate  ·  Enter select  ·  Esc = new conversation')
-    out.push('\n' + hint + '\n')
-
-    return out.join('\n')
-  }
-
-  // ── Interactive key loop ──────────────────────────────────────────────────
-  // Returns: { chosen: selected row index or -1 }
-  async function interactiveSelect(): Promise<{ chosen: number }> {
-    return new Promise((resolve) => {
-      let selected = 0
-      // Enter alternate screen: picker lives here, original terminal is untouched
-      process.stderr.write(ALT_SCREEN_ON + HIDE_CURSOR)
-
-      function paint() {
-        // Always clear from top and redraw — no line counting, no wrap math
-        process.stderr.write(CLEAR_SCREEN + renderTable(selected))
-      }
-
-      paint()
-
-      const stdin = process.stdin as NodeJS.ReadStream
-      if (stdin.setRawMode) stdin.setRawMode(true)
-      stdin.resume()
-      stdin.setEncoding('utf8')
-
-      function onKey(key: string) {
-        if (key === '\x1B[A' || key === '\x1B[D') {
-          // Up or Left
-          selected = (selected - 1 + rows.length) % rows.length
-          paint()
-        } else if (key === '\x1B[B' || key === '\x1B[C') {
-          // Down or Right
-          selected = (selected + 1) % rows.length
-          paint()
-        } else if (key === '\r' || key === '\n') {
-          // Enter — select
-          cleanup()
-          resolve({ chosen: selected })
-        } else if (key === '\x1B' || key === 'q' || key === 'Q') {
-          // Esc or q — cancel
-          cleanup()
-          resolve({ chosen: -1 })
-        } else if (key === '\x03') {
-          // Ctrl+C
-          cleanup()
-          process.stderr.write('\n')
-          process.exit(0)
-        }
-      }
-
-      // Polling fallback: Windows Terminal doesn't fire resize on maximize/restore
-      let lastCols = process.stderr.columns || 80
-      const resizePoll = setInterval(() => {
-        const cols = process.stderr.columns || 80
-        if (cols !== lastCols) {
-          lastCols = cols
-          paint()
-        }
-      }, 150)
-
-      function onResize() { paint() }
-
-      // Listen on both — Windows Terminal fires on stderr, others on stdout
-      process.stdout.on('resize', onResize)
-      process.stderr.on('resize', onResize)
-
-      function cleanup() {
-        clearInterval(resizePoll)
-        process.stdout.removeListener('resize', onResize)
-        process.stderr.removeListener('resize', onResize)
-        stdin.removeListener('data', onKey)
-        if (stdin.setRawMode) stdin.setRawMode(false)
-        stdin.pause()
-        process.stderr.write(ALT_SCREEN_OFF + SHOW_CURSOR)
-      }
-
-      stdin.on('data', onKey)
-    })
-  }
-
-  const { chosen } = await interactiveSelect()
-
-  // Alt screen already exited in cleanup() — terminal is restored automatically
-
-  // Restore stdin for TUI
-  process.stdin.removeAllListeners('data')
-  process.stdin.removeAllListeners('keypress')
-  if ((process.stdin as NodeJS.ReadStream).setRawMode) {
-    (process.stdin as NodeJS.ReadStream).setRawMode(false)
-  }
-  process.stdin.pause()
-
-  if (chosen === -1) {
-    // Cancelled
+  if (result.kind === 'cancelled') {
     if (exitOnCancel) {
       process.stderr.write(chalk.dim('  Cancelled.\n\n'))
       process.exit(0)
     }
-    // ESC at startup = start fresh silently
     return
   }
 
-  const row = rows[chosen]
-
-  if (row.sessionIdx === null) {
-    // "New conversation" row selected
+  if (result.kind === 'new') {
     process.stderr.write(chalk.dim('  Starting new conversation...\n\n'))
     return
   }
 
-  const selected = toShow[row.sessionIdx]
-  process.stderr.write(chalk.green(`  Resuming session from ${formatDate(selected.modified)}...\n\n`))
+  // result.kind === 'selected'
+  const { formatDate } = await import('./session-picker.js')
+  process.stderr.write(chalk.green(`  Resuming session from ${formatDate(result.session.modified)}...\n\n`))
   cliFlags.continue = true
-  cliFlags._selectedSessionPath = selected.path
+  cliFlags._selectedSessionPath = result.session.path
 }
 
 // `gsd sessions` — explicit subcommand: show full picker, exit process on cancel
@@ -527,6 +245,7 @@ if (
   cliFlags.messages.length === 0 &&
   !cliFlags.continue &&
   !cliFlags.noSession &&
+  !cliFlags.noPicker &&
   !isPrintMode &&
   process.stdin.isTTY
 ) {

--- a/src/help-text.ts
+++ b/src/help-text.ts
@@ -121,6 +121,7 @@ export function printHelp(version: string): void {
   process.stdout.write('  --worktree, -w [name]    Start in an isolated worktree (auto-named if omitted)\n')
   process.stdout.write('  --model <id>             Override model (e.g. claude-opus-4-6)\n')
   process.stdout.write('  --no-session             Disable session persistence\n')
+  process.stdout.write('  --no-picker              Skip the startup session picker (always start fresh)\n')
   process.stdout.write('  --extension <path>       Load additional extension\n')
   process.stdout.write('  --tools <a,b,c>          Restrict available tools\n')
   process.stdout.write('  --list-models [search]   List available models and exit\n')

--- a/src/session-picker.ts
+++ b/src/session-picker.ts
@@ -1,0 +1,364 @@
+/**
+ * session-picker.ts
+ *
+ * Interactive terminal session picker — alternate screen, arrow-key navigation,
+ * responsive layout (wide table ↔ compact 2-line rows).
+ *
+ * Exported surface:
+ *   runSessionPicker(exitOnCancel, cwd, sessions, onSelect)
+ *
+ * Pure I/O: no direct imports of cliFlags or SessionManager — callers own
+ * those dependencies so this module is independently testable.
+ */
+
+import chalk from 'chalk'
+
+// ── ANSI escape sequences ─────────────────────────────────────────────────
+const ESC            = '\x1B'
+const HIDE_CURSOR    = `${ESC}[?25l`
+const SHOW_CURSOR    = `${ESC}[?25h`
+const ALT_SCREEN_ON  = `${ESC}[?1049h`
+const ALT_SCREEN_OFF = `${ESC}[?1049l`
+const CLEAR_SCREEN   = `${ESC}[2J${ESC}[H`
+
+// ── Public types ──────────────────────────────────────────────────────────
+
+export interface PickerSession {
+  path: string
+  name?: string
+  firstMessage?: string
+  modified: Date
+  messageCount: number
+}
+
+export type PickerResult =
+  | { kind: 'selected'; session: PickerSession }
+  | { kind: 'new' }
+  | { kind: 'cancelled' }
+
+// ── Layout helpers (exported for unit tests) ──────────────────────────────
+
+/** Strip ANSI escape codes to get visible character length. */
+export function visLen(s: string): number {
+  return s.replace(/\x1B\[[0-9;]*m/g, '').length
+}
+
+/**
+ * Pad or truncate `text` to exactly `len` visible characters.
+ * Truncated strings end with '…'. Alignment applies only when padding.
+ * Always operates on plain text — apply chalk *after* calling cell().
+ */
+export function cell(text: string, len: number, align: 'left' | 'right' = 'left'): string {
+  const vl = visLen(text)
+  const diff = len - vl
+  if (diff < 0) {
+    let result = ''
+    let count = 0
+    for (const ch of text.replace(/\x1B\[[0-9;]*m/g, '')) {
+      if (count >= len - 1) { result += '…'; break }
+      result += ch; count++
+    }
+    return result
+  }
+  if (align === 'right') return ' '.repeat(diff) + text
+  return text + ' '.repeat(diff)
+}
+
+/**
+ * Format a date for display in the picker.
+ * Width varies by locale — Spanish ≈ 24 chars, English ≈ 21 chars.
+ */
+export function formatDate(d: Date): string {
+  return d.toLocaleString(undefined, {
+    month: 'short', day: 'numeric', year: 'numeric',
+    hour: 'numeric', minute: '2-digit',
+  })
+}
+
+// Fixed column widths — locale-aware date width measured once at import time
+const COL_NUM  = 3  // right-aligned: " 1" … "10"
+const COL_MSGS = 4  // right-aligned: "  30"
+const SAMPLE_DATE = new Date(2026, 11, 31, 23, 59)
+export const COL_DATE = Math.max(formatDate(SAMPLE_DATE).length, 20)
+
+/**
+ * Compute layout values from the current terminal width.
+ * Called on every render so resize is reflected immediately.
+ */
+export function getLayout(columns?: number) {
+  const termWidth = columns ?? process.stderr.columns ?? 80
+  // Row structure: "  │ NUM │ DATE │ MSGS │ TOPIC │"
+  const TABLE_OVERHEAD = 2 + 1 + (COL_NUM + 2) + 1 + (COL_DATE + 2) + 1 + (COL_MSGS + 2) + 1 + 2
+  const MIN_TABLE_WIDTH = TABLE_OVERHEAD + COL_NUM + COL_DATE + COL_MSGS + 12
+  const useWide = termWidth >= MIN_TABLE_WIDTH
+  const COL_TOPIC = Math.max(12, termWidth - TABLE_OVERHEAD - COL_NUM - COL_DATE - COL_MSGS)
+  const compactWidth = Math.max(10, termWidth - 8)
+  return { termWidth, useWide, COL_TOPIC, compactWidth }
+}
+
+// ── Rendering ─────────────────────────────────────────────────────────────
+
+function tableRow(num: string, date: string, msgs: string, topic: string, colTopic: number): string {
+  return (
+    '  │ ' + cell(num, COL_NUM, 'right') +
+    ' │ ' + cell(date, COL_DATE) +
+    ' │ ' + cell(msgs, COL_MSGS, 'right') +
+    ' │ ' + topic +  // topic already cell()'d by caller before chalk is applied
+    ' │'
+  )
+}
+
+function divider(l: string, m: string, r: string, colTopic: number): string {
+  return (
+    '  ' + l +
+    '─'.repeat(COL_NUM + 2) + m +
+    '─'.repeat(COL_DATE + 2) + m +
+    '─'.repeat(COL_MSGS + 2) + m +
+    '─'.repeat(colTopic + 2) + r
+  )
+}
+
+function compactRow(
+  num: string | null,
+  date: string,
+  msgs: string,
+  topic: string,
+  isSelected: boolean,
+  cw: number,
+): string[] {
+  const selector = isSelected ? chalk.cyan('▶') : ' '
+  const numStr = num !== null ? chalk.bold(num.padStart(2)) : ' 0'
+  const meta = `${date}  ${chalk.dim(`(${msgs} msgs)`)}`
+  const topicLine = cell(topic, cw)
+  const line1 = `  ${selector} ${numStr}  ${meta}`
+  const line2 = `      ${chalk.dim('└─')} ${isSelected ? chalk.white(topicLine) : chalk.dim(topicLine)}`
+  return [line1, line2]
+}
+
+type PickerRow = { label: string; sessionIdx: number | null }
+
+function renderTable(
+  selectedIdx: number,
+  rows: PickerRow[],
+  toShow: PickerSession[],
+  cwd: string,
+  sessionCount: number,
+  maxShow: number,
+  exitOnCancel: boolean,
+): string {
+  const { termWidth, useWide, COL_TOPIC, compactWidth } = getLayout()
+  const out: string[] = []
+  out.push(chalk.bold(`\n  Sessions for ${chalk.cyan(cwd)}\n`))
+
+  if (useWide) {
+    out.push(divider('┌', '┬', '┐', COL_TOPIC))
+    out.push(tableRow(chalk.bold(' # '), chalk.bold('Date'), chalk.bold('Msgs'), chalk.bold('Topic'), COL_TOPIC))
+    out.push(divider('├', '┼', '┤', COL_TOPIC))
+
+    for (let i = 0; i < rows.length; i++) {
+      const r = rows[i]
+      const isSelected = i === selectedIdx
+
+      if (r.sessionIdx === null) {
+        const topicCell = cell('[ new conversation ]', COL_TOPIC)
+        const line = tableRow(' 0 ', topicCell, '', '', COL_TOPIC)
+        out.push(isSelected ? chalk.bgBlue(chalk.white(line)) : chalk.dim(line))
+        out.push(divider('├', '┼', '┤', COL_TOPIC))
+      } else {
+        const s = toShow[r.sessionIdx]
+        const numStr    = String(r.sessionIdx + 1)
+        const dateStr   = formatDate(s.modified)
+        const msgsStr   = String(s.messageCount)
+        // Truncate/pad BEFORE chalk — cell() cannot see through ANSI codes
+        const topicRaw  = cell(r.label, COL_TOPIC)
+        const topicStr  = isSelected ? topicRaw : (s.name ? chalk.cyan(topicRaw) : chalk.white(topicRaw))
+        const dateCol   = isSelected ? dateStr : chalk.green(dateStr)
+        const msgsCol   = isSelected ? msgsStr : chalk.cyan(msgsStr)
+        const line = tableRow(numStr, dateCol, msgsCol, topicStr, COL_TOPIC)
+        out.push(isSelected ? chalk.bgBlue(chalk.white(line)) : line)
+      }
+    }
+
+    out.push(divider('└', '┴', '┘', COL_TOPIC))
+
+  } else {
+    out.push('  ' + '─'.repeat(Math.max(10, termWidth - 4)))
+
+    for (let i = 0; i < rows.length; i++) {
+      const r = rows[i]
+      const isSelected = i === selectedIdx
+
+      if (r.sessionIdx === null) {
+        const selector = isSelected ? chalk.cyan('▶') : ' '
+        const label = isSelected ? chalk.white('[ new conversation ]') : chalk.dim('[ new conversation ]')
+        out.push(`  ${selector}  0  ${label}`)
+        out.push('  ' + '─'.repeat(Math.max(10, termWidth - 4)))
+      } else {
+        const s = toShow[r.sessionIdx]
+        const lines = compactRow(
+          String(r.sessionIdx + 1),
+          isSelected ? formatDate(s.modified) : chalk.green(formatDate(s.modified)),
+          String(s.messageCount),
+          r.label,
+          isSelected,
+          compactWidth,
+        )
+        out.push(...lines)
+      }
+    }
+
+    out.push('  ' + '─'.repeat(Math.max(10, termWidth - 4)))
+  }
+
+  if (sessionCount > maxShow) {
+    const extra = sessionCount - maxShow
+    // `gsd sessions` shows 20 sessions; startup shows 10 to keep the picker compact.
+    // Either way, tell the user how many more exist.
+    const hint = exitOnCancel ? '' : `  · ${chalk.bold('gsd sessions')} to see all`
+    out.push(chalk.dim(`\n  ... and ${extra} more${hint}`))
+  }
+
+  const hint = exitOnCancel
+    ? chalk.dim('  ↑↓ navigate  ·  Enter select  ·  Esc/q quit')
+    : chalk.dim('  ↑↓ navigate  ·  Enter select  ·  Esc = new conversation')
+  out.push('\n' + hint + '\n')
+
+  return out.join('\n')
+}
+
+// ── Interactive key loop ──────────────────────────────────────────────────
+
+async function interactiveSelect(
+  rows: PickerRow[],
+  toShow: PickerSession[],
+  cwd: string,
+  sessionCount: number,
+  maxShow: number,
+  exitOnCancel: boolean,
+): Promise<{ chosen: number }> {
+  return new Promise((resolve) => {
+    let selected = 0
+
+    // Alternate screen: picker lives here; original terminal restored on exit
+    process.stderr.write(ALT_SCREEN_ON + HIDE_CURSOR)
+
+    function paint() {
+      process.stderr.write(
+        CLEAR_SCREEN + renderTable(selected, rows, toShow, cwd, sessionCount, maxShow, exitOnCancel),
+      )
+    }
+
+    paint()
+
+    const stdin = process.stdin as NodeJS.ReadStream
+    if (stdin.setRawMode) stdin.setRawMode(true)
+    stdin.resume()
+    stdin.setEncoding('utf8')
+
+    function onKey(key: string) {
+      if (key === '\x1B[A' || key === '\x1B[D') {
+        selected = (selected - 1 + rows.length) % rows.length
+        paint()
+      } else if (key === '\x1B[B' || key === '\x1B[C') {
+        selected = (selected + 1) % rows.length
+        paint()
+      } else if (key === '\r' || key === '\n') {
+        cleanup()
+        resolve({ chosen: selected })
+      } else if (key === '\x1B' || key === 'q' || key === 'Q') {
+        cleanup()
+        resolve({ chosen: -1 })
+      } else if (key === '\x03') {
+        cleanup()
+        process.stderr.write('\n')
+        process.exit(0)
+      }
+    }
+
+    // Poll for resize every 150ms — Windows Terminal doesn't fire the resize
+    // event on maximize/restore, only on manual border drag.
+    let lastCols = process.stderr.columns ?? 80
+    const resizePoll = setInterval(() => {
+      const cols = process.stderr.columns ?? 80
+      if (cols !== lastCols) { lastCols = cols; paint() }
+    }, 150)
+
+    function onResize() { paint() }
+    // Some terminals fire on stdout, others on stderr — listen to both
+    process.stdout.on('resize', onResize)
+    process.stderr.on('resize', onResize)
+
+    function cleanup() {
+      clearInterval(resizePoll)
+      process.stdout.removeListener('resize', onResize)
+      process.stderr.removeListener('resize', onResize)
+      stdin.removeListener('data', onKey)
+      if (stdin.setRawMode) stdin.setRawMode(false)
+      stdin.pause()
+      process.stderr.write(ALT_SCREEN_OFF + SHOW_CURSOR)
+    }
+
+    stdin.on('data', onKey)
+  })
+}
+
+// ── Public entry point ────────────────────────────────────────────────────
+
+/**
+ * Show the interactive session picker.
+ *
+ * @param exitOnCancel  true  → used by `gsd sessions`: Esc/q exits the process.
+ *                      false → used at startup: Esc means "start new session".
+ * @param cwd           Working directory label shown in the header.
+ * @param sessions      Full session list (sorted, most-recent first).
+ * @returns             PickerResult describing what the user chose.
+ *
+ * maxShow behaviour:
+ *   exitOnCancel=true  (gsd sessions subcommand) → shows up to 20 sessions
+ *   exitOnCancel=false (startup picker)           → shows up to 10 sessions
+ * The startup picker is intentionally compact; `gsd sessions` is the full view.
+ */
+export async function runSessionPicker(
+  exitOnCancel: boolean,
+  cwd: string,
+  sessions: PickerSession[],
+): Promise<PickerResult> {
+  if (sessions.length === 0) {
+    return { kind: 'cancelled' }
+  }
+
+  // exitOnCancel=true (gsd sessions) shows more; startup shows fewer to stay compact
+  const maxShow = exitOnCancel ? 20 : 10
+  const toShow = sessions.slice(0, maxShow)
+
+  const rows: PickerRow[] = []
+  if (!exitOnCancel) {
+    rows.push({ label: '[ new conversation ]', sessionIdx: null })
+  }
+  for (let i = 0; i < toShow.length; i++) {
+    const s = toShow[i]
+    const topic = s.name || (s.firstMessage ? s.firstMessage.replace(/\n/g, ' ') : '(empty)')
+    rows.push({ label: topic, sessionIdx: i })
+  }
+
+  const { chosen } = await interactiveSelect(rows, toShow, cwd, sessions.length, maxShow, exitOnCancel)
+
+  // Restore stdin for the TUI that takes over after the picker
+  process.stdin.removeAllListeners('data')
+  process.stdin.removeAllListeners('keypress')
+  if ((process.stdin as NodeJS.ReadStream).setRawMode) {
+    (process.stdin as NodeJS.ReadStream).setRawMode(false)
+  }
+  process.stdin.pause()
+
+  if (chosen === -1) {
+    return { kind: exitOnCancel ? 'cancelled' : 'new' }
+  }
+
+  const row = rows[chosen]
+  if (row.sessionIdx === null) {
+    return { kind: 'new' }
+  }
+
+  return { kind: 'selected', session: toShow[row.sessionIdx] }
+}

--- a/src/tests/session-picker.test.ts
+++ b/src/tests/session-picker.test.ts
@@ -1,0 +1,128 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { visLen, cell, formatDate, getLayout, COL_DATE } from '../session-picker.js'
+
+// ── visLen ────────────────────────────────────────────────────────────────
+
+test('visLen returns correct length for plain text', () => {
+  assert.equal(visLen('hello'), 5)
+  assert.equal(visLen(''), 0)
+  assert.equal(visLen('abc def'), 7)
+})
+
+test('visLen strips ANSI escape codes before measuring', () => {
+  const colored = '\x1B[32mhello\x1B[0m'   // chalk.green('hello')
+  assert.equal(visLen(colored), 5)
+
+  const bold = '\x1B[1mworld\x1B[0m'
+  assert.equal(visLen(bold), 5)
+
+  const combined = '\x1B[36mfoo\x1B[0m bar'
+  assert.equal(visLen(combined), 7)
+})
+
+// ── cell ──────────────────────────────────────────────────────────────────
+
+test('cell pads short text to exact width (left align)', () => {
+  const result = cell('hi', 6)
+  assert.equal(result, 'hi    ')
+  assert.equal(result.length, 6)
+})
+
+test('cell pads short text to exact width (right align)', () => {
+  const result = cell('42', 6, 'right')
+  assert.equal(result, '    42')
+  assert.equal(result.length, 6)
+})
+
+test('cell returns text unchanged when it exactly fits', () => {
+  assert.equal(cell('hello', 5), 'hello')
+})
+
+test('cell truncates text longer than len with ellipsis', () => {
+  const result = cell('hello world', 7)
+  assert.equal(visLen(result), 7)
+  assert.ok(result.endsWith('…'), `expected ellipsis, got: ${result}`)
+})
+
+test('cell truncates to single ellipsis when len=1', () => {
+  const result = cell('hello', 1)
+  assert.equal(result, '…')
+})
+
+test('cell operates on plain text — ANSI input is not expected', () => {
+  // callers must strip chalk before passing to cell()
+  const plain = 'session topic'
+  const result = cell(plain, 7)
+  assert.equal(visLen(result), 7)
+  assert.ok(result.endsWith('…'))
+})
+
+// ── formatDate ────────────────────────────────────────────────────────────
+
+test('formatDate returns a non-empty string', () => {
+  const d = new Date(2026, 2, 22, 14, 30)
+  const result = formatDate(d)
+  assert.ok(typeof result === 'string')
+  assert.ok(result.length > 0)
+})
+
+test('formatDate includes the year', () => {
+  const d = new Date(2026, 2, 22, 14, 30)
+  assert.ok(formatDate(d).includes('2026'))
+})
+
+// ── COL_DATE ──────────────────────────────────────────────────────────────
+
+test('COL_DATE is at least 20 characters', () => {
+  assert.ok(COL_DATE >= 20, `COL_DATE=${COL_DATE} should be >= 20`)
+})
+
+test('COL_DATE accommodates the longest possible locale date', () => {
+  // Sample the same date used internally and verify COL_DATE >= its length
+  const sample = formatDate(new Date(2026, 11, 31, 23, 59))
+  assert.ok(
+    COL_DATE >= sample.length,
+    `COL_DATE=${COL_DATE} should be >= sample date length ${sample.length} ("${sample}")`,
+  )
+})
+
+// ── getLayout ─────────────────────────────────────────────────────────────
+
+test('getLayout returns useWide=false for a narrow terminal', () => {
+  const { useWide } = getLayout(40)
+  assert.equal(useWide, false)
+})
+
+test('getLayout returns useWide=true for a wide terminal', () => {
+  const { useWide } = getLayout(200)
+  assert.equal(useWide, true)
+})
+
+test('getLayout COL_TOPIC is at least 12', () => {
+  const { COL_TOPIC } = getLayout(40)
+  assert.ok(COL_TOPIC >= 12, `COL_TOPIC=${COL_TOPIC} should be >= 12`)
+})
+
+test('getLayout COL_TOPIC grows with terminal width', () => {
+  const narrow = getLayout(100)
+  const wide   = getLayout(200)
+  assert.ok(
+    wide.COL_TOPIC > narrow.COL_TOPIC,
+    `expected wide COL_TOPIC (${wide.COL_TOPIC}) > narrow (${narrow.COL_TOPIC})`,
+  )
+})
+
+test('getLayout compactWidth is at least 10', () => {
+  const { compactWidth } = getLayout(10)
+  assert.ok(compactWidth >= 10)
+})
+
+// ── Picker skip conditions (non-TTY / noSession) ──────────────────────────
+
+test('runSessionPicker returns cancelled immediately when sessions list is empty', async () => {
+  const { runSessionPicker } = await import('../session-picker.js')
+  const result = await runSessionPicker(false, '/some/cwd', [])
+  assert.equal(result.kind, 'cancelled')
+})


### PR DESCRIPTION
## What

Shows an interactive session picker when `gsd` is launched without arguments in a directory that has existing sessions.

## How it works

- **Arrow-key navigation** — ↑↓ to move, Enter to select, Esc for new conversation
- **Wide layout** — full table with `#`, `Date`, `Msgs`, `Topic` columns when terminal is wide enough
- **Compact layout** — 2-line-per-row format for narrow terminals
- **Alternate screen buffer** — picker runs in `ESC[?1049h` so it doesn't pollute scroll history
- **Fully responsive** — redraws on resize via `stdout`/`stderr` resize events + 150ms poll fallback for Windows Terminal (which doesn't fire resize on maximize/restore)
- **Locale-aware date column** — width measured at runtime so Spanish (24 chars) and English (21 chars) both fit correctly
- **Safe truncation** — topic is truncated before chalk coloring to prevent cell overflow at any width

## Behavior

- If no sessions exist → falls through silently, starts new conversation as before
- `gsd sessions` subcommand → same picker but exits process on cancel (existing behavior preserved)
- Non-interactive / subagent / print modes → picker skipped