### PR TITLE
fix(pi-coding-agent): prevent crash when login is cancelled

### DIFF
--- a/packages/pi-coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/interactive-mode.ts
@@ -3372,14 +3372,6 @@ export class InteractiveMode {
 		this.ui.setFocus(dialog);
 		this.ui.requestRender();
 
-		// Promise for manual code input (racing with callback server)
-		let manualCodeResolve: ((code: string) => void) | undefined;
-		let manualCodeReject: ((err: Error) => void) | undefined;
-		const manualCodePromise = new Promise<string>((resolve, reject) => {
-			manualCodeResolve = resolve;
-			manualCodeReject = reject;
-		});
-
 		// Restore editor helper — also disposes the dialog to reject any
 		// dangling promises and prevent the UI from getting stuck.
 		const restoreEditor = () => {
@@ -3395,23 +3387,7 @@ export class InteractiveMode {
 				onAuth: (info: { url: string; instructions?: string }) => {
 					dialog.showAuth(info.url, info.instructions);
 
-					if (usesCallbackServer) {
-						// Show input for manual paste, racing with callback
-						dialog
-							.showManualInput("Paste redirect URL below, or complete login in browser:")
-							.then((value) => {
-								if (value && manualCodeResolve) {
-									manualCodeResolve(value);
-									manualCodeResolve = undefined;
-								}
-							})
-							.catch(() => {
-								if (manualCodeReject) {
-									manualCodeReject(new Error("Login cancelled"));
-									manualCodeReject = undefined;
-								}
-							});
-					} else if (providerId === "github-copilot") {
+					if (!usesCallbackServer && providerId === "github-copilot") {
 						// GitHub Copilot polls after onAuth
 						dialog.showWaiting("Waiting for browser authentication...");
 					}
@@ -3426,7 +3402,12 @@ export class InteractiveMode {
 					dialog.showProgress(message);
 				},
 
-				onManualCodeInput: () => manualCodePromise,
+				// Callback-server providers race browser callback with pasted redirect URL.
+				// Keep manual-input promise ownership inside provider flow to avoid
+				// orphaned rejections when the callback is not consumed.
+				onManualCodeInput: usesCallbackServer
+					? () => dialog.showManualInput("Paste redirect URL below, or complete login in browser:")
+					: undefined,
 
 				signal: dialog.signal,
 			});
@@ -3458,12 +3439,6 @@ export class InteractiveMode {
 			this.showStatus(`Logged in to ${providerName}. Credentials saved to ${getAuthPath()}`);
 		} catch (error: unknown) {
 			restoreEditor();
-			// Also reject the manual code promise if it's still pending
-			if (manualCodeReject) {
-				manualCodeReject(new Error("Login cancelled"));
-				manualCodeReject = undefined;
-				manualCodeResolve = undefined;
-			}
 			const errorMsg = error instanceof Error ? error.message : String(error);
 			if (errorMsg !== "Login cancelled" && !errorMsg.includes("Superseded") && !errorMsg.includes("disposed")) {
 				this.showError(`Failed to login to ${providerName}: ${errorMsg}`);


### PR DESCRIPTION
## TL;DR

**What:** Fixes an interactive OAuth login cancel crash in `pi-coding-agent`.
**Why:** Canceling login could trigger an unhandled rejection and terminate the process.
**How:** Removed InteractiveMode-owned deferred manual-code promise/reject flow and made manual input callback-owned only for callback-server providers.

## What

This change updates:

- `packages/pi-coding-agent/src/modes/interactive/interactive-mode.ts`

Inside `showLoginDialog()`:

- Removed `manualCodePromise`, `manualCodeResolve`, and `manualCodeReject`.
- Removed explicit `manualCodeReject(new Error("Login cancelled"))` calls.
- Changed `onManualCodeInput` to be conditional:
  - callback-server providers: `() => dialog.showManualInput(...)`
  - non-callback providers: `undefined`
- Kept existing editor restore and non-fatal cancel/superseded/disposed error handling behavior.

## Why

The previous implementation always created and later rejected a deferred manual-input promise in InteractiveMode, even when a provider did not consume that callback path. On cancel, that often surfaces as an unhandled rejection which hard crashes the GSD process back to terminal.

## How

The login flow now keeps manual input promise ownership in the provider callback path:

- For callback-server providers, provider code requests manual input via `onManualCodeInput`.
- For non-callback providers, `onManualCodeInput` is not provided.
- InteractiveMode no longer owns a detached deferred promise that can be rejected without a consumer.

Key decision:
- Chose ownership correction (promise lifecycle where it is consumed) over adding more local catch/suppression logic, to eliminate the root cause rather than masking it.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [x] `pi-coding-agent` — Coding agent
- [ ] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [ ] CI passes
- [ ] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

Manual checks performed:
1. `/login` → Anthropic → cancel (`Esc`) returns to editor, no crash.
2. `/login` → callback-server provider (OpenAI Codex/Gemini CLI) → cancel (`Esc`) returns to editor, no crash.
3. `/login` → callback-server provider success path still logs in and shows success status.

## AI disclosure

- [x] This PR includes AI-assisted code

AI tool: Codex (GPT-5) + Claude Opus
Human validation: manual UX regression checks for cancel and successful login flows. Actually triggered crash by hand by exiting from token input instead of entering oAuth token. Manually checked code surface (small), identified the issue and designed the fix myself.