### PR TITLE
fix(roadmap): parse backtick annotations in prose slice headers, validate prose deps

### DIFF
--- a/src/resources/extensions/gsd/roadmap-slices.ts
+++ b/src/resources/extensions/gsd/roadmap-slices.ts
@@ -248,23 +248,36 @@ function parseProseSliceHeaders(content: string): RoadmapSliceEntry[] {
       title = title.replace(/\s*\(Complete\)\s*$/i, "");
     }
 
-    // Try to extract depends from prose: "Depends on: S01" or "**Depends on:** S01, S02"
+    // Extract the section text between this header and the next
     const afterHeader = content.slice(match.index + match[0].length);
     const nextHeader = afterHeader.search(/^#{1,4}\s/m);
     const section = nextHeader !== -1 ? afterHeader.slice(0, nextHeader) : afterHeader.slice(0, 500);
 
-    const depsMatch = section.match(/\*{0,2}Depends\s+on:?\*{0,2}\s*(.+)/i);
+    // 1. Try backtick `depends:[...]` format first (same as checkbox parser)
+    const backtickDepsMatch = section.match(/`depends:\[([^\]]*)\]`/);
+    const backtickRiskMatch = section.match(/`risk:(\w+)`/);
+    const risk = (backtickRiskMatch ? backtickRiskMatch[1] : "medium") as RiskLevel;
+
     let depends: string[] = [];
-    if (depsMatch) {
-      const rawDeps = depsMatch[1]!.replace(/none/i, "").trim();
-      if (rawDeps) {
-        depends = expandDependencies(
-          rawDeps.split(/[,;]/).map(s => s.trim().replace(/[^A-Za-z0-9]/g, "")).filter(Boolean)
-        );
+    if (backtickDepsMatch) {
+      const raw = backtickDepsMatch[1]!.trim();
+      if (raw) {
+        depends = expandDependencies(raw.split(",").map(s => s.trim()));
+      }
+    } else {
+      // 2. Fallback: prose "Depends on:" format, but validate tokens are slice IDs
+      const depsMatch = section.match(/\*{0,2}Depends\s+on:?\*{0,2}\s*(.+)/i);
+      if (depsMatch) {
+        const rawDeps = depsMatch[1]!.replace(/none/i, "").trim();
+        if (rawDeps) {
+          depends = expandDependencies(
+            rawDeps.split(/[,;]/).map(s => s.trim().replace(/[^A-Za-z0-9]/g, "")).filter(s => /^S\d+$/.test(s))
+          );
+        }
       }
     }
 
-    slices.push({ id, title, risk: "medium" as RiskLevel, depends, done, demo: "" });
+    slices.push({ id, title, risk, depends, done, demo: "" });
   }
 
   return slices;

--- a/src/resources/extensions/gsd/tests/roadmap-slices.test.ts
+++ b/src/resources/extensions/gsd/tests/roadmap-slices.test.ts
@@ -236,6 +236,84 @@ test("parseRoadmapSlices: ## Slices with valid checkboxes does NOT invoke prose 
   assert.equal(slices[0]?.done, true);
 });
 
+// ═══════════════════════════════════════════════════════════════════════════
+// Regression #2055: parseProseSliceHeaders garbage deps, missing backtick parsing
+// ═══════════════════════════════════════════════════════════════════════════
+
+test("parseProseSliceHeaders: backtick depends parsed instead of prose false-positive (#2055)", () => {
+  const proseContent = `# M010: Research
+
+### S01 — Auth & RLS Isolation
+\`risk:critical\` \`depends:[]\` \`verification:integration\`
+
+Every other slice **depends on** a client being able to authenticate and see only their own data. If RLS isolation fails, the entire portal is a security breach. This is the highest-risk work in the milestone and must be proven before building any UI.
+
+### S02 — Portal Layout & Dashboard
+\`risk:medium\` \`depends:[S01]\` \`verification:browser,snapshot\`
+
+Basic portal chrome and the first authenticated page.
+
+### S03 — Inbox & Notifications
+\`risk:low\` \`depends:[S01,S02]\` \`verification:browser\`
+
+Show notifications for the user.
+`;
+  const slices = parseRoadmapSlices(proseContent);
+  assert.equal(slices.length, 3);
+
+  // Bug 1: S01 should have NO deps — the prose "depends on" is natural language, not a dep declaration.
+  // The backtick `depends:[]` should win.
+  assert.deepEqual(slices[0]?.depends, [], "S01 backtick depends:[] should yield empty deps, not garbage from prose");
+
+  // Bug 2: S02 should depend on S01 via backtick annotation
+  assert.deepEqual(slices[1]?.depends, ["S01"], "S02 backtick depends:[S01] should be parsed");
+
+  // S03 depends on S01 and S02
+  assert.deepEqual(slices[2]?.depends, ["S01", "S02"], "S03 backtick depends:[S01,S02] should be parsed");
+
+  // Bug 3: risk should come from backtick annotations, not hardcoded "medium"
+  assert.equal(slices[0]?.risk, "critical", "S01 risk should be 'critical' from backtick annotation");
+  assert.equal(slices[1]?.risk, "medium", "S02 risk should be 'medium' from backtick annotation");
+  assert.equal(slices[2]?.risk, "low", "S03 risk should be 'low' from backtick annotation");
+});
+
+test("parseProseSliceHeaders: prose 'Depends on:' fallback validates slice ID pattern (#2055)", () => {
+  const proseContent = `# M011: Test
+
+## S01: Foundation
+**Depends on:** None
+
+## S02: Features
+**Depends on:** S01
+
+## S03: Polish
+**Depends on:** S01, S02
+`;
+  const slices = parseRoadmapSlices(proseContent);
+  assert.equal(slices.length, 3);
+  assert.deepEqual(slices[0]?.depends, [], "None should yield empty deps");
+  assert.deepEqual(slices[1]?.depends, ["S01"]);
+  assert.deepEqual(slices[2]?.depends, ["S01", "S02"]);
+});
+
+test("parseProseSliceHeaders: prose 'depends on' in natural language without backtick annotation is ignored (#2055)", () => {
+  // No backtick annotations at all — prose "depends on" in a sentence should NOT extract garbage
+  const proseContent = `# M012: Test
+
+## S01: Auth
+This feature depends on a working database connection and proper credentials.
+
+## S02: Dashboard
+Builds the main UI.
+`;
+  const slices = parseRoadmapSlices(proseContent);
+  assert.equal(slices.length, 2);
+  // Without backtick annotations, the prose sentence should not produce garbage deps
+  // because the extracted tokens don't match S\d+ pattern
+  assert.deepEqual(slices[0]?.depends, [], "natural language 'depends on' should not produce garbage deps");
+  assert.deepEqual(slices[1]?.depends, []);
+});
+
 test("parseRoadmapSlices: ## Slices with only non-matching lines returns prose fallback results", () => {
   const weirdContent = `# M020: Odd
 


### PR DESCRIPTION
## TL;DR

**What:** Fix `parseProseSliceHeaders` to parse backtick dependency/risk annotations and validate prose-format dependency tokens against the slice ID pattern.

**Why:** The prose parser extracts garbage dependency IDs from natural language sentences containing "depends on", and silently ignores structured backtick annotations (`depends:[S01]`, `risk:critical`). This causes an unrecoverable dispatch deadlock where no slice can ever be dispatched.

**How:** Try backtick format first, fall back to prose format with slice-ID validation, and parse `risk:` from backtick annotations instead of hardcoding "medium".

## What

`parseProseSliceHeaders` in `roadmap-slices.ts` had three bugs:

1. **Garbage deps from prose** — The regex `/Depends\s+on:?\s*(.+)/i` matched natural language like "Every other slice **depends on** a client being able to authenticate...", extracting sentence fragments as dependency IDs.

2. **Backtick annotations ignored** — Structured annotations like `` `depends:[S01]` `` and `` `risk:critical` `` on the line after each header were never parsed by the prose parser (only the checkbox parser handled them).

3. **Risk hardcoded** — `risk` was always set to `"medium"`, ignoring backtick `risk:` annotations.

## Why

When S01's section contains natural language "depends on", the parser produces unsatisfiable garbage deps, permanently blocking S01. Meanwhile S02's real `` `depends:[S01]` `` annotation is lost, so S02 appears unblocked. The dispatch guard then correctly blocks S02 because S01 is incomplete. No slice can ever be dispatched.

## How

Three changes to `parseProseSliceHeaders`:

1. **Try backtick format first** — Parse `` `depends:[...]` `` using the same regex the checkbox parser uses. Only fall through to prose format when backtick deps are absent.

2. **Validate prose dep tokens** — When using the prose "Depends on:" fallback, filter extracted tokens through `/^S\d+$/` so natural language fragments are rejected.

3. **Parse backtick risk** — Extract `` `risk:<level>` `` from the section text instead of hardcoding "medium".

## Test plan

- [x] Added 3 reproduction tests covering all three bugs
- [x] All 19 tests in `roadmap-slices.test.ts` pass
- [x] All 68 tests in `roadmap-parse-regression.test.ts` pass
- [x] Existing prose "Depends on: S01" format still works with validation
- [x] Existing checkbox format unaffected

Fixes #2055

🤖 Generated with [Claude Code](https://claude.com/claude-code)