### PR TITLE
fix(roadmap): parse [x]/[ ] checkbox markers in prose slice headers

### DIFF
--- a/src/resources/extensions/gsd/roadmap-mutations.ts
+++ b/src/resources/extensions/gsd/roadmap-mutations.ts
@@ -33,14 +33,15 @@ export function markSliceDoneInRoadmap(basePath: string, mid: string, sid: strin
     `$1[x] **${sid}:`,
   );
 
-  // If checkbox format didn't match, try prose format: "## S01: Title" -> "## S01: \u2713 Title"
+  // If checkbox format didn't match, try prose format with optional [x]/[ ] before slice ID:
+  // "## S01: Title" or "## [ ] S01: Title" -> "## [x] S01: Title"
   if (updated === content) {
     updated = content.replace(
-      new RegExp(`^(#{1,4}\\s+(?:\\*{0,2})(?:Slice\\s+)?${sid}\\*{0,2}[:\\s.\\u2014\\u2013-]+\\s*)(.+)`, "m"),
+      new RegExp(`^(#{1,4}\\s+)(?:\\[[ ]\\]\\s+)?(?:\\*{0,2})(?:Slice\\s+)?${sid}\\*{0,2}[:\\s.\\u2014\\u2013-]+\\s*(.+)`, "m"),
       (match, prefix, title) => {
         // Already marked done — no-op
-        if (/^\u2713/.test(title) || /\(Complete\)\s*$/i.test(title)) return match;
-        return `${prefix}\u2713 ${title}`;
+        if (/\[x\]/i.test(match) || /^\u2713/.test(title) || /\(Complete\)\s*$/i.test(title)) return match;
+        return `${prefix}[x] ${sid}: ${title}`;
       },
     );
   }

--- a/src/resources/extensions/gsd/roadmap-slices.ts
+++ b/src/resources/extensions/gsd/roadmap-slices.ts
@@ -217,18 +217,19 @@ export function parseRoadmapSlices(content: string): RoadmapSliceEntry[] {
  */
 function parseProseSliceHeaders(content: string): RoadmapSliceEntry[] {
   const slices: RoadmapSliceEntry[] = [];
-  // Match H1-H4 headers containing S<digits> with optional "Slice" prefix, bold markers,
-  // and optional checkmark completion marker before the slice ID.
+  // Match H1-H4 headers containing S<digits> with optional checkbox [x]/[ ],
+  // "Slice" prefix, bold markers, and optional checkmark completion marker before the slice ID.
   // Separator after the ID is flexible: colon, dash, em/en dash, dot, or just whitespace.
-  const headerPattern = /^#{1,4}\s+\*{0,2}(?:\u2713\s+)?(?:Slice\s+)?(S\d+)\*{0,2}[:\s.\u2014\u2013-]*\s*(.+)/gm;
+  const headerPattern = /^#{1,4}\s+\*{0,2}(?:\[([ xX])\]\s+)?(?:\u2713\s+)?(?:Slice\s+)?(S\d+)\*{0,2}[:\s.\u2014\u2013-]*\s*(.+)/gm;
   let match: RegExpExecArray | null;
 
   // Check for checkmark before the slice ID (e.g., "## checkmark S01: Title")
   const prefixCheckPattern = /^#{1,4}\s+\*{0,2}\u2713\s+/;
 
   while ((match = headerPattern.exec(content)) !== null) {
-    const id = match[1]!;
-    let title = match[2]!.trim().replace(/\*{1,2}$/g, "").trim(); // strip trailing bold markers
+    const checkboxState = match[1]; // undefined when no checkbox, "x"/"X" when done, " " when not done
+    const id = match[2]!;
+    let title = match[3]!.trim().replace(/\*{1,2}$/g, "").trim(); // strip trailing bold markers
     if (!title) continue; // skip if we only matched the ID with no title
 
     // Detect completion markers:
@@ -236,7 +237,7 @@ function parseProseSliceHeaders(content: string): RoadmapSliceEntry[] {
     // 2. Checkmark after separator: "## S01: checkmark Title"
     // 3. (Complete) suffix: "## S01: Title (Complete)"
     const line = match[0];
-    let done = prefixCheckPattern.test(line);
+    let done = checkboxState?.toLowerCase() === "x" || prefixCheckPattern.test(line);
 
     if (!done && title.startsWith("\u2713")) {
       done = true;

--- a/src/resources/extensions/gsd/tests/roadmap-slices.test.ts
+++ b/src/resources/extensions/gsd/tests/roadmap-slices.test.ts
@@ -236,6 +236,100 @@ test("parseRoadmapSlices: ## Slices with valid checkboxes does NOT invoke prose 
   assert.equal(slices[0]?.done, true);
 });
 
+// ── Regression tests for #2053 ─────────────────────────────────────────────
+// parseProseSliceHeaders must handle [x]/[ ] checkbox markers before slice ID
+
+test("parseRoadmapSlices: prose headers with [x] checkbox detected as done (#2053)", () => {
+  const proseContent = `# M020: Auth Milestone
+
+### [x] S01: Per-User Auth
+Completed auth work.
+
+### [ ] S02: Passkey Support
+Not started yet.
+
+### S03: PWA Foundation
+No checkbox at all.
+`;
+  const slices = parseRoadmapSlices(proseContent);
+  assert.equal(slices.length, 3, "should parse all 3 slices including [x] prefixed ones");
+  assert.equal(slices[0]?.id, "S01");
+  assert.equal(slices[0]?.done, true, "S01 with [x] should be done");
+  assert.equal(slices[0]?.title, "Per-User Auth");
+  assert.equal(slices[1]?.id, "S02");
+  assert.equal(slices[1]?.done, false, "S02 with [ ] should not be done");
+  assert.equal(slices[1]?.title, "Passkey Support");
+  assert.equal(slices[2]?.id, "S03");
+  assert.equal(slices[2]?.done, false, "S03 without checkbox should not be done");
+});
+
+test("parseRoadmapSlices: prose headers with [X] uppercase checkbox detected as done (#2053)", () => {
+  const proseContent = `# M021: Test
+
+## [X] S01: Done Slice
+Complete.
+
+## [ ] S02: Pending Slice
+Not done.
+`;
+  const slices = parseRoadmapSlices(proseContent);
+  assert.equal(slices.length, 2);
+  assert.equal(slices[0]?.done, true, "uppercase [X] should be done");
+  assert.equal(slices[1]?.done, false);
+});
+
+test("parseRoadmapSlices: all slices with [x] should not return empty array (#2053)", () => {
+  // This is the exact scenario that causes the stuck plan-milestone loop:
+  // all slices done via [x] → parser returns [] → state machine enters pre-planning
+  const proseContent = `# M003: Feature Build
+
+### [x] S01: Setup Environment
+Done.
+
+### [x] S02: Build Core
+Done.
+
+### [x] S03: Polish UI
+Done.
+
+### [x] S04: Testing
+Done.
+
+### [x] S05: Deploy
+Done.
+`;
+  const slices = parseRoadmapSlices(proseContent);
+  assert.equal(slices.length, 5, "all 5 slices should be parsed even when all have [x]");
+  for (const s of slices) {
+    assert.equal(s.done, true, `${s.id} should be done`);
+  }
+});
+
+test("parseRoadmapSlices: [x] prose headers under ## Slices section triggers prose fallback (#2053)", () => {
+  // When ## Slices section exists but has H3 prose headers with [x], the checkbox
+  // parser finds nothing → falls through to prose fallback which must handle [x]
+  const proseUnderSlices = `# M010: My Milestone
+
+**Vision:** Ship it.
+
+## Slices
+
+### [x] S01: Setup Environment
+Done.
+
+### [ ] S02: Build Core
+In progress.
+
+### [x] S03: Polish UI
+Done.
+`;
+  const slices = parseRoadmapSlices(proseUnderSlices);
+  assert.equal(slices.length, 3, "should find 3 slices from [x] H3 prose headers under ## Slices");
+  assert.equal(slices[0]?.done, true, "S01 with [x] should be done");
+  assert.equal(slices[1]?.done, false, "S02 with [ ] should not be done");
+  assert.equal(slices[2]?.done, true, "S03 with [x] should be done");
+});
+
 test("parseRoadmapSlices: ## Slices with only non-matching lines returns prose fallback results", () => {
   const weirdContent = `# M020: Odd
 


### PR DESCRIPTION
## TL;DR

**What:** Add `[x]`/`[ ]` checkbox support to the prose slice header regex in `parseProseSliceHeaders` and the prose branch of `markSliceDoneInRoadmap`.

**Why:** When the LLM marks prose headers done as `### [x] S01: Title`, the regex fails to match, causing completed slices to vanish from the parsed array. This triggers a cascading failure: progress counter shrinks to 0/0, state machine enters `pre-planning`, and `plan-milestone` loops until the stuck detector fires.

**How:** Insert an optional `(?:\[([ xX])\]\s+)?` capture group before the slice ID in the header regex; shift capture group indices; use the checkbox state for done detection.

## What

- `roadmap-slices.ts` (`parseProseSliceHeaders`): Added optional checkbox capture group `(?:\[([ xX])\]\s+)?` to `headerPattern`. Updated match indices (`match[1]` -> checkbox, `match[2]` -> id, `match[3]` -> title). Added `checkboxState?.toLowerCase() === "x"` to done detection.
- `roadmap-mutations.ts` (`markSliceDoneInRoadmap`): Updated the prose-format regex to optionally match and strip `[ ]` before the slice ID, and write `[x]` when marking done. Added `[x]` detection to the idempotency guard.

## Why

`### [x] S01: Title` is valid markdown that the LLM produces when told to "mark slices done". The prose header regex only allowed optional `**`, `✓`, and `Slice` before the S-ID — not `[x]`/`[ ]`. Every completed slice disappeared from the parsed array, causing:
1. Progress counter shrinks (0/5 -> 0/4 -> 0/0)
2. Zero slices -> `phase: pre-planning`
3. `plan-milestone` dispatched repeatedly until stuck detector fires
4. ~$4.59 wasted per occurrence on redundant dispatches

## How

The fix is minimal and backward-compatible:
- The new capture group is optional (`?`), so all existing formats continue to match
- Existing completion markers (✓, `(Complete)`) still work alongside checkbox detection
- `markSliceDoneInRoadmap` now writes `[x]` format when mutating prose headers that had `[ ]`

## Test plan

- [x] Added 4 regression tests in `roadmap-slices.test.ts` covering:
  - `[x]` and `[ ]` prose headers parsed correctly (done/not-done)
  - Uppercase `[X]` recognized
  - All-`[x]` roadmap returns full array (not empty — the exact trigger for the stuck loop)
  - `[x]` headers under `## Slices` section fall through to prose parser correctly
- [x] All 20 roadmap-slices tests pass
- [x] All 68 roadmap-parse-regression tests pass
- [x] Existing checkbox, table, and prose formats unaffected

Fixes #2053

🤖 Generated with [Claude Code](https://claude.com/claude-code)