### PR TITLE
fix(discuss): fall through to pending milestones when all slices discussed

### DIFF
--- a/src/resources/extensions/gsd/guided-flow.ts
+++ b/src/resources/extensions/gsd/guided-flow.ts
@@ -10,7 +10,7 @@ import type { ExtensionAPI, ExtensionContext, ExtensionCommandContext } from "@g
 import { showNextAction } from "../shared/tui.js";
 import { loadFile, parseRoadmap } from "./files.js";
 import { loadPrompt, inlineTemplate } from "./prompt-loader.js";
-import { buildSkillActivationBlock } from "./auto-prompts.js";
+import { buildSkillActivationBlock, buildDiscussMilestonePrompt } from "./auto-prompts.js";
 import { deriveState } from "./state.js";
 import { invalidateAllCaches } from "./cache.js";
 import { startAuto } from "./auto.js";
@@ -603,9 +603,47 @@ export async function showDiscuss(
       discussedMap.set(s.id, !!contextFile);
     }
 
-    // If all pending slices are discussed, notify and exit instead of looping
+    // If all pending slices are discussed, check for pending milestones before giving up
     const allDiscussed = pendingSlices.every(s => discussedMap.get(s.id));
     if (allDiscussed) {
+      // Before returning, check if any pending milestones need discussion (#2039)
+      const pendingMilestones = state.registry.filter(
+        m => m.status === "pending" && m.id !== mid,
+      );
+      const undiscussedMilestones = pendingMilestones.filter(m => {
+        const rmFile = resolveMilestoneFile(basePath, m.id, "ROADMAP");
+        return !rmFile; // no roadmap = could benefit from discussion
+      });
+
+      if (undiscussedMilestones.length > 0) {
+        const actions = undiscussedMilestones.map((m, i) => ({
+          id: m.id,
+          label: `${m.id}: ${m.title}`,
+          description: "pending \u00b7 no roadmap yet",
+          recommended: i === 0,
+        }));
+
+        const choice = await showNextAction(ctx, {
+          title: "GSD \u2014 Discuss a queued milestone",
+          summary: [
+            `All ${mid} slices are discussed.`,
+            `${undiscussedMilestones.length} queued milestone(s) can be discussed:`,
+          ],
+          actions,
+          notYetMessage: "Run /gsd discuss when ready.",
+        });
+
+        if (choice !== "not_yet") {
+          const chosen = undiscussedMilestones.find(m => m.id === choice);
+          if (chosen) {
+            const prompt = await buildDiscussMilestonePrompt(chosen.id, chosen.title, basePath);
+            await dispatchWorkflow(pi, prompt, "gsd-discuss", ctx, "plan-milestone");
+          }
+        }
+        return;
+      }
+
+      // Truly nothing to discuss anywhere
       const lockData = readSessionLockData(basePath);
       const remoteAutoRunning = lockData && lockData.pid !== process.pid && isSessionLockProcessAlive(lockData);
       const nextStep = remoteAutoRunning

--- a/src/resources/extensions/gsd/tests/discuss-pending-milestones.test.ts
+++ b/src/resources/extensions/gsd/tests/discuss-pending-milestones.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Regression test for #2039: /gsd discuss dead-ends when active milestone
+ * slices are all discussed — never offers pending milestones.
+ *
+ * Validates that:
+ * 1. The allDiscussed block in showDiscuss checks state.registry for pending milestones
+ * 2. deriveState reports pending milestones alongside an active one
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync, mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+const { deriveState } = await import("../state.js");
+
+// ─── Structural: showDiscuss has pending-milestone fallthrough ───────────────
+
+test("showDiscuss: allDiscussed block checks registry for pending milestones (#2039)", () => {
+  const src = readFileSync(join(import.meta.dirname, "..", "guided-flow.ts"), "utf-8");
+
+  // Find the allDiscussed guard
+  const allDiscussedIdx = src.indexOf("const allDiscussed = pendingSlices.every");
+  assert.ok(allDiscussedIdx > -1, "guided-flow.ts should have the allDiscussed guard");
+
+  // Extract the block from allDiscussed to the end of the if-block (generous window)
+  const blockChunk = src.slice(allDiscussedIdx, allDiscussedIdx + 2500);
+
+  // The fix should check state.registry for pending milestones before returning
+  assert.match(
+    blockChunk,
+    /state\.registry\.filter/,
+    "allDiscussed block should filter state.registry for pending milestones",
+  );
+
+  assert.match(
+    blockChunk,
+    /["']pending["']/,
+    "allDiscussed block should filter for pending status",
+  );
+
+  // Should present a picker when undiscussed pending milestones exist
+  assert.match(
+    blockChunk,
+    /showNextAction\(/,
+    "allDiscussed block should show a picker for pending milestones",
+  );
+
+  // Should dispatch discussion for chosen pending milestone
+  assert.match(
+    blockChunk,
+    /dispatchWorkflow\(/,
+    "allDiscussed block should dispatch a discuss workflow for chosen milestone",
+  );
+});
+
+// ─── Functional: deriveState reports pending milestones alongside active ─────
+
+test("deriveState includes pending milestones in registry when active milestone exists", async () => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-discuss-pending-"));
+
+  try {
+    // Active milestone M001 with roadmap and all slices (will be "active")
+    const m001Dir = join(base, ".gsd", "milestones", "M001");
+    mkdirSync(m001Dir, { recursive: true });
+    writeFileSync(
+      join(m001Dir, "M001-CONTEXT.md"),
+      "# M001 Context\n\nActive milestone.",
+    );
+    writeFileSync(
+      join(m001Dir, "M001-ROADMAP.md"),
+      [
+        "# M001: Active Milestone",
+        "",
+        "## Slices",
+        "- [ ] **S01: First slice** `risk:low` `depends:[]`",
+        "  > Do something.",
+      ].join("\n"),
+    );
+
+    // Pending milestone M002 with only CONTEXT (no roadmap)
+    const m002Dir = join(base, ".gsd", "milestones", "M002");
+    mkdirSync(m002Dir, { recursive: true });
+    writeFileSync(
+      join(m002Dir, "M002-CONTEXT.md"),
+      "# M002 Context\n\nQueued milestone needing discussion.",
+    );
+
+    // Pending milestone M003 with only CONTEXT (no roadmap)
+    const m003Dir = join(base, ".gsd", "milestones", "M003");
+    mkdirSync(m003Dir, { recursive: true });
+    writeFileSync(
+      join(m003Dir, "M003-CONTEXT.md"),
+      "# M003 Context\n\nAnother queued milestone.",
+    );
+
+    const state = await deriveState(base);
+
+    // Registry should have all three milestones
+    assert.ok(state.registry.length >= 3, `registry should have at least 3 entries, got ${state.registry.length}`);
+
+    // M001 should be active
+    const m001Entry = state.registry.find(m => m.id === "M001");
+    assert.ok(m001Entry, "M001 should be in the registry");
+    assert.equal(m001Entry.status, "active", "M001 should be active");
+
+    // M002 and M003 should be pending (they have CONTEXT but no ROADMAP)
+    const m002Entry = state.registry.find(m => m.id === "M002");
+    assert.ok(m002Entry, "M002 should be in the registry");
+    assert.equal(m002Entry.status, "pending", "M002 should be pending");
+
+    const m003Entry = state.registry.find(m => m.id === "M003");
+    assert.ok(m003Entry, "M003 should be in the registry");
+    assert.equal(m003Entry.status, "pending", "M003 should be pending");
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## TL;DR

**What**: When all active milestone slices are discussed, `showDiscuss` now checks the milestone registry for pending milestones without roadmaps and offers them for discussion instead of dead-ending.

**Why**: The `allDiscussed` early-exit block (introduced in #935) returned immediately without checking `state.registry`, so users with queued milestones had no way to discuss them via `/gsd discuss`.

**How**: Added a registry check before the terminal return — filters for pending milestones lacking roadmaps, presents a picker via `showNextAction`, and dispatches `buildDiscussMilestonePrompt` for the chosen milestone.

## What

- Modified the `allDiscussed` guard in `showDiscuss()` (guided-flow.ts ~line 607) to check `state.registry` for pending milestones without roadmaps before returning
- When undiscussed pending milestones exist, a picker is shown offering them for discussion
- The original "nothing to discuss" message is preserved as a final fallback when truly no milestones need discussion

## Why

`/gsd discuss` dead-ended when active milestone slices were all discussed — it returned with "All N slices discussed" and never offered pending milestones (e.g. M009, M010) that had no roadmap yet. This regression from #935 blocked users from discussing queued milestones while auto-mode ran on the active milestone.

## How

1. After detecting `allDiscussed`, filter `state.registry` for milestones with `status === "pending"` (excluding the active milestone)
2. Further filter to those without a ROADMAP file (via `resolveMilestoneFile`)
3. If any exist, present them via `showNextAction` picker
4. On selection, dispatch `buildDiscussMilestonePrompt` for the chosen milestone
5. Only fall through to the terminal "nothing to discuss" message when no pending milestones need discussion either

## Test plan

- [x] Structural test verifies the `allDiscussed` block now references `state.registry.filter`, checks for `"pending"` status, calls `showNextAction`, and calls `dispatchWorkflow`
- [x] Functional test confirms `deriveState` correctly reports pending milestones in the registry alongside an active milestone
- [x] Existing `smart-entry-complete`, `discuss-prompt`, and `derive-state` tests still pass
- [x] TypeScript compiles cleanly (`npx tsc --noEmit`)

Fixes #2039

🤖 Generated with [Claude Code](https://claude.com/claude-code)