### PR TITLE
fix(auto): prevent stale agent_end from resolving next unit's promise

### DIFF
--- a/src/resources/extensions/gsd/auto/run-unit.ts
+++ b/src/resources/extensions/gsd/auto/run-unit.ts
@@ -30,6 +30,20 @@ export async function runUnit(
 ): Promise<UnitResult> {
   debugLog("runUnit", { phase: "start", unitType, unitId });
 
+  // ── Clear stale follow-up messages from the previous unit (#2060) ──
+  // When the previous unit used async_bash/bg_shell, completed background job
+  // results can arrive as follow-up messages that trigger additional LLM turns.
+  // Clearing the queue BEFORE creating a new session ensures those stale
+  // follow-ups cannot generate agent_end events that race with the new unit.
+  try {
+    const cmdCtxAny = s.cmdCtx as Record<string, unknown> | null;
+    if (typeof cmdCtxAny?.clearQueue === "function") {
+      (cmdCtxAny.clearQueue as () => unknown)();
+    }
+  } catch {
+    // Non-fatal — clearQueue may not be available in all contexts
+  }
+
   // ── Session creation with timeout ──
   debugLog("runUnit", { phase: "session-create", unitType, unitId });
 
@@ -74,6 +88,14 @@ export async function runUnit(
   // This happens after newSession completes so session-switch agent_end events
   // from the previous session cannot resolve the new unit.
   _setSessionSwitchInFlight(false);
+
+  // Yield to the event loop to drain any stale agent_end events that were
+  // queued before the session switch completed (#2060). Without this drain,
+  // a stale agent_end from async follow-up turns in the previous unit can
+  // fire between _setSessionSwitchInFlight(false) and _setCurrentResolve(),
+  // resolving the new unit's promise immediately.
+  await new Promise<void>((r) => setImmediate(r));
+
   const unitPromise = new Promise<UnitResult>((resolve) => {
     _setCurrentResolve(resolve);
   });
@@ -104,20 +126,6 @@ export async function runUnit(
     unitId,
     status: result.status,
   });
-
-  // Discard trailing follow-up messages (e.g. async_job_result notifications)
-  // from the completed unit. Without this, queued follow-ups trigger wasteful
-  // LLM turns before the next session can start (#1642).
-  // clearQueue() lives on AgentSession but isn't part of the typed
-  // ExtensionCommandContext interface — call it via runtime check.
-  try {
-    const cmdCtxAny = s.cmdCtx as Record<string, unknown> | null;
-    if (typeof cmdCtxAny?.clearQueue === "function") {
-      (cmdCtxAny.clearQueue as () => unknown)();
-    }
-  } catch {
-    // Non-fatal — clearQueue may not be available in all contexts
-  }
 
   return result;
 }

--- a/src/resources/extensions/gsd/tests/auto-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-loop.test.ts
@@ -2112,3 +2112,98 @@ test("autoLoop stops when worktree has no project files for execute-task (#1833)
     "should notify about missing project files in worktree",
   );
 });
+
+// ─── Stale agent_end race condition (issue #2060) ──────────────────────────
+
+test("stale agent_end from previous unit must not resolve next unit's promise (#2060)", async () => {
+  _resetPendingResolve();
+
+  const ctx = makeMockCtx();
+  const pi = makeMockPi();
+  const staleEvent = makeEvent([{ id: "stale-from-unit-A" }]);
+  const freshEvent = makeEvent([{ id: "fresh-from-unit-B" }]);
+
+  // Unit A: normal execution
+  const sessionA = makeMockSession();
+  const unitAPromise = runUnit(ctx, pi, sessionA, "execute-task", "T03", "task A prompt");
+  await new Promise((r) => setTimeout(r, 10));
+  resolveAgentEnd(staleEvent); // Primary agent_end resolves unit A
+  const resultA = await unitAPromise;
+  assert.equal(resultA.status, "completed");
+
+  // Simulate stale follow-up: after unit A resolved, a delayed agent_end fires
+  // (from async job results arriving late). This must NOT resolve unit B.
+  // Schedule the stale event to fire on the next microtask — simulating the
+  // race window between _setSessionSwitchInFlight(false) and _setCurrentResolve.
+  const staleFollowUp = makeEvent([{ id: "stale-followup-from-unit-A" }]);
+
+  const sessionB = makeMockSession({
+    onNewSessionSettle: () => {
+      // When newSession resolves, the session switch flag clears.
+      // In the buggy code, a stale agent_end arriving right after this
+      // but before the new resolver is set would resolve the new promise.
+      // Schedule a stale event to fire during the drain window.
+      setImmediate(() => {
+        resolveAgentEnd(staleFollowUp);
+      });
+    },
+  });
+
+  const unitBPromise = runUnit(ctx, pi, sessionB, "complete-slice", "S01", "slice B prompt");
+
+  // Give unit B time to set up its promise and send the message
+  await new Promise((r) => setTimeout(r, 50));
+
+  // The fresh event should be needed to resolve unit B — if the stale one
+  // already resolved it, this test will detect the mismatch.
+  resolveAgentEnd(freshEvent);
+
+  const resultB = await unitBPromise;
+  assert.equal(resultB.status, "completed");
+  assert.deepEqual(
+    resultB.event,
+    freshEvent,
+    "Unit B must resolve with its own agent_end, not a stale event from unit A",
+  );
+});
+
+test("clearQueue runs before new session creation to cancel in-flight follow-ups (#2060)", async () => {
+  _resetPendingResolve();
+
+  const ctx = makeMockCtx();
+  const pi = makeMockPi();
+  let clearQueueCalledBeforeNewSession = false;
+  let clearQueueCallOrder = -1;
+  let newSessionCallOrder = -1;
+  let callCounter = 0;
+
+  const session = {
+    active: true,
+    verbose: false,
+    basePath: process.cwd(),
+    cmdCtx: {
+      clearQueue: () => {
+        clearQueueCallOrder = ++callCounter;
+      },
+      newSession: () => {
+        newSessionCallOrder = ++callCounter;
+        return Promise.resolve({ cancelled: false });
+      },
+    },
+    clearTimers: () => {},
+  } as any;
+
+  const resultPromise = runUnit(ctx, pi, session, "complete-slice", "S01", "prompt");
+  await new Promise((r) => setTimeout(r, 10));
+  resolveAgentEnd(makeEvent());
+  await resultPromise;
+
+  assert.ok(
+    clearQueueCallOrder > 0,
+    "clearQueue should have been called",
+  );
+  assert.ok(
+    clearQueueCallOrder < newSessionCallOrder,
+    "clearQueue must run before newSession to discard stale follow-up messages",
+  );
+});


### PR DESCRIPTION
## TL;DR

**What:** Fix race condition where stale `agent_end` events from async follow-up turns resolve the next unit's promise, freezing auto-mode.

**Why:** When a task uses `async_bash`/`bg_shell` extensively, background job results arrive as follow-up messages after the primary `agent_end` resolves. These stale events can resolve the next unit's promise before it even sends its prompt.

**How:** Move `clearQueue()` to run before session creation (not after), and add a `setImmediate` drain between the session switch flag clearing and the new resolver being armed.

## What

Two changes in `auto/run-unit.ts`:

1. **Moved `clearQueue()` from after `await unitPromise` to before `newSession()`** — discards stale follow-up messages from the previous unit before creating a new session, preventing them from generating agent_end events that race with the new unit.

2. **Added `await new Promise(r => setImmediate(r))` after session switch completes** — yields to the event loop so any already-queued stale `agent_end` callbacks fire and get dropped (no resolver armed yet) before the new resolver is set.

## Why

Race condition sequence in the bug:
1. Unit A (execute-task T03) completes with 20+ `async_bash` calls
2. Background job results arrive as follow-up messages, triggering additional LLM turns
3. `runUnit()` returns for Unit A, but follow-up turns are still in-flight
4. `clearQueue()` runs too late — after the promise resolved — so stale follow-ups are not cancelled
5. Unit B (complete-slice) starts: `newSession()` completes, `_setSessionSwitchInFlight(false)` runs
6. `_setCurrentResolve(resolve)` arms the new promise
7. Stale `agent_end` from Unit A's follow-up turn fires and immediately resolves Unit B
8. Unit B returns with wrong artifacts, stuck detection fires after 6 retries, auto-mode stops

## How

The fix closes the race window from both directions:
- **clearQueue() early**: prevents new stale events from being generated
- **setImmediate drain**: flushes any already-queued stale events before the resolver is vulnerable

## Test plan

- [x] New test: stale `agent_end` from previous unit must not resolve next unit's promise
- [x] New test: `clearQueue` runs before `newSession` to discard stale follow-up messages
- [x] All 56 existing `auto-loop.test.ts` tests pass
- [x] TypeScript compilation passes (`npx tsc --noEmit`)

Fixes #2060

🤖 Generated with [Claude Code](https://claude.com/claude-code)