### PR TITLE
fix(auto): broaden worktree health check with SOURCE_DIRS fallback

### DIFF
--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -26,7 +26,7 @@ import { runUnit } from "./run-unit.js";
 import { debugLog } from "../debug-logger.js";
 import { gsdRoot } from "../paths.js";
 import { atomicWriteSync } from "../atomic-write.js";
-import { PROJECT_FILES } from "../detection.js";
+import { PROJECT_FILES, SOURCE_DIRS } from "../detection.js";
 import { join } from "node:path";
 
 // ─── generateMilestoneReport ──────────────────────────────────────────────────
@@ -835,7 +835,7 @@ export async function runUnitPhase(
       return { action: "break", reason: "worktree-invalid" };
     }
     const hasProjectFile = PROJECT_FILES.some((f) => deps.existsSync(join(s.basePath, f)));
-    const hasSrcDir = deps.existsSync(join(s.basePath, "src"));
+    const hasSrcDir = SOURCE_DIRS.some((d) => deps.existsSync(join(s.basePath, d)));
     if (!hasProjectFile && !hasSrcDir) {
       const msg = `Worktree health check failed: ${s.basePath} has no recognized project files — refusing to dispatch ${unitType} ${unitId}`;
       debugLog("runUnitPhase", { phase: "worktree-health-fail", basePath: s.basePath, hasProjectFile, hasSrcDir });

--- a/src/resources/extensions/gsd/detection.ts
+++ b/src/resources/extensions/gsd/detection.ts
@@ -87,6 +87,27 @@ export const PROJECT_FILES = [
   "mix.exs",
   "deno.json",
   "deno.jsonc",
+  "Justfile",
+  "Taskfile.yml",
+  "Dockerfile",
+  "requirements.txt",
+  "setup.cfg",
+  "build.sh",
+] as const;
+
+/**
+ * Common source directory names used as a fallback signal for project detection.
+ * If a directory has .git but no PROJECT_FILES match, the presence of any of
+ * these directories indicates it is a real project (not an empty worktree).
+ */
+export const SOURCE_DIRS = [
+  "src",
+  "app",
+  "lib",
+  "Sources",     // Swift convention
+  "pkg",         // Go convention
+  "cmd",         // Go convention
+  "internal",    // Go convention
 ] as const;
 
 const LANGUAGE_MAP: Record<string, string> = {
@@ -95,6 +116,8 @@ const LANGUAGE_MAP: Record<string, string> = {
   "go.mod": "go",
   "pyproject.toml": "python",
   "setup.py": "python",
+  "requirements.txt": "python",
+  "setup.cfg": "python",
   "Gemfile": "ruby",
   "pom.xml": "java",
   "build.gradle": "java/kotlin",

--- a/src/resources/extensions/gsd/tests/worktree-health-dispatch.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-health-dispatch.test.ts
@@ -14,7 +14,7 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { execSync } from "node:child_process";
 
-import { PROJECT_FILES } from "../detection.js";
+import { PROJECT_FILES, SOURCE_DIRS } from "../detection.js";
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -37,7 +37,7 @@ function createGitRepo(): string {
  * proceeds), false when it would FAIL (dispatch blocked).
  *
  * This mirrors the fixed logic: .git must exist, AND at least one
- * PROJECT_FILES entry or a src/ directory must exist.
+ * PROJECT_FILES entry or a SOURCE_DIRS directory must exist.
  */
 function wouldPassHealthCheck(basePath: string, existsSyncFn: (p: string) => boolean): boolean {
   const hasGit = existsSyncFn(join(basePath, ".git"));
@@ -46,7 +46,9 @@ function wouldPassHealthCheck(basePath: string, existsSyncFn: (p: string) => boo
   for (const file of PROJECT_FILES) {
     if (existsSyncFn(join(basePath, file))) return true;
   }
-  if (existsSyncFn(join(basePath, "src"))) return true;
+  for (const dir of SOURCE_DIRS) {
+    if (existsSyncFn(join(basePath, dir))) return true;
+  }
 
   return false;
 }
@@ -57,7 +59,7 @@ import { existsSync } from "node:fs";
 
 test("PROJECT_FILES is exported and contains expected multi-ecosystem entries", () => {
   assert.ok(Array.isArray(PROJECT_FILES), "PROJECT_FILES is an array");
-  assert.ok(PROJECT_FILES.length >= 17, `expected >= 17 entries, got ${PROJECT_FILES.length}`);
+  assert.ok(PROJECT_FILES.length >= 23, `expected >= 23 entries, got ${PROJECT_FILES.length}`);
   // Spot-check key ecosystems
   assert.ok(PROJECT_FILES.includes("Cargo.toml"), "includes Rust marker");
   assert.ok(PROJECT_FILES.includes("go.mod"), "includes Go marker");
@@ -65,6 +67,17 @@ test("PROJECT_FILES is exported and contains expected multi-ecosystem entries", 
   assert.ok(PROJECT_FILES.includes("package.json"), "includes JS marker");
   assert.ok(PROJECT_FILES.includes("pom.xml"), "includes Java marker");
   assert.ok(PROJECT_FILES.includes("Package.swift"), "includes Swift marker");
+  assert.ok(PROJECT_FILES.includes("Justfile"), "includes Justfile marker");
+  assert.ok(PROJECT_FILES.includes("Dockerfile"), "includes Dockerfile marker");
+  assert.ok(PROJECT_FILES.includes("build.sh"), "includes build.sh marker");
+});
+
+test("SOURCE_DIRS is exported and contains expected directory names", () => {
+  assert.ok(Array.isArray(SOURCE_DIRS), "SOURCE_DIRS is an array");
+  assert.ok(SOURCE_DIRS.includes("src"), "includes src");
+  assert.ok(SOURCE_DIRS.includes("app"), "includes app");
+  assert.ok(SOURCE_DIRS.includes("lib"), "includes lib");
+  assert.ok(SOURCE_DIRS.includes("Sources"), "includes Sources (Swift)");
 });
 
 test("health check passes for Rust project (Cargo.toml, no package.json)", () => {
@@ -153,6 +166,36 @@ test("health check passes for src/-only project (backward compat)", () => {
   try {
     mkdirSync(join(dir, "src"), { recursive: true });
     assert.ok(wouldPassHealthCheck(dir, existsSync), "src/-only project should pass health check");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("health check passes for app/-only project (e.g. Swift without SPM)", () => {
+  const dir = createGitRepo();
+  try {
+    mkdirSync(join(dir, "app"), { recursive: true });
+    assert.ok(wouldPassHealthCheck(dir, existsSync), "app/-only project should pass health check");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("health check passes for lib/-only project", () => {
+  const dir = createGitRepo();
+  try {
+    mkdirSync(join(dir, "lib"), { recursive: true });
+    assert.ok(wouldPassHealthCheck(dir, existsSync), "lib/-only project should pass health check");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("health check passes for Sources/-only project (Swift convention)", () => {
+  const dir = createGitRepo();
+  try {
+    mkdirSync(join(dir, "Sources"), { recursive: true });
+    assert.ok(wouldPassHealthCheck(dir, existsSync), "Sources/-only project should pass health check");
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Problem

The worktree health check rejects valid projects that use source directories other than `src/` (e.g. `app/`, `lib/`, `Sources/`) and lack standard package manager files. This blocks auto-mode dispatch for Swift projects without SPM, custom-build projects, and any project that organizes source under a non-`src` directory.

## Root Cause

The health check in `phases.ts` has a hardcoded `src/` fallback:

```typescript
const hasSrcDir = deps.existsSync(join(s.basePath, "src"));
```

When no `PROJECT_FILES` match is found, only `src/` is checked. Projects with source in `app/`, `lib/`, `Sources/`, `pkg/`, `cmd/`, or `internal/` are incorrectly rejected as empty worktrees.

Additionally, `PROJECT_FILES` in `detection.ts` is missing common build markers for custom-build projects (`build.sh`, `Justfile`, `Taskfile.yml`, `Dockerfile`, `requirements.txt`, `setup.cfg`).

## Fix

1. **Add `SOURCE_DIRS` constant** to `detection.ts`: `["src", "app", "lib", "Sources", "pkg", "cmd", "internal"]` — common source directory conventions across ecosystems (Swift, Go, Rails, custom builds).

2. **Replace hardcoded `src/` check** in `phases.ts` with `SOURCE_DIRS.some(...)`.

3. **Extend `PROJECT_FILES`** with 6 additional markers: `Justfile`, `Taskfile.yml`, `Dockerfile`, `requirements.txt`, `setup.cfg`, `build.sh`.

## Changed Files

| File | Change |
|------|--------|
| `src/resources/extensions/gsd/detection.ts` | Add `SOURCE_DIRS` export, add 6 entries to `PROJECT_FILES`, add `requirements.txt`/`setup.cfg` to `LANGUAGE_MAP` |
| `src/resources/extensions/gsd/auto/phases.ts` | Import `SOURCE_DIRS`, replace `existsSync("src")` with `SOURCE_DIRS.some(...)` |
| `src/resources/extensions/gsd/tests/worktree-health-dispatch.test.ts` | Add `SOURCE_DIRS` export test, add tests for `app/`, `lib/`, `Sources/` directory detection, update `PROJECT_FILES` count assertion |

## Test Evidence

- All 16 worktree health dispatch tests pass (including 3 new tests for `app/`, `lib/`, `Sources/`)
- All 54 auto-loop tests pass (zero regressions)
- `npm run build` succeeds

## Related

- Extends the work in #1860 (broaden worktree health check to all ecosystems)
- Complements #1882 (adds Xcode-specific markers) — this PR covers the broader source-directory gap
- Related to #1879 (Xcode project detection)