### PR TITLE
fix(roadmap): merge checkbox completion state into prose-parsed slices

### DIFF
--- a/src/resources/extensions/gsd/files.ts
+++ b/src/resources/extensions/gsd/files.ts
@@ -125,9 +125,12 @@ export function parseRoadmap(content: string): Roadmap {
 
 function _parseRoadmapImpl(content: string): Roadmap {
   const stopTimer = debugTime("parse-roadmap");
-  // Try native parser first for better performance
+  // Try native parser first for better performance.
+  // Fall through to TS parser when native returns 0 slices but the content
+  // likely contains slice structure — the Rust parser only handles checkbox
+  // format, not prose headers or tables (#1931).
   const nativeResult = nativeParseRoadmap(content);
-  if (nativeResult) {
+  if (nativeResult && nativeResult.slices.length > 0) {
     stopTimer({ native: true, slices: nativeResult.slices.length, boundaryEntries: nativeResult.boundaryMap.length });
     debugCount("parseRoadmapCalls");
     return nativeResult;

--- a/src/resources/extensions/gsd/roadmap-slices.ts
+++ b/src/resources/extensions/gsd/roadmap-slices.ts
@@ -135,13 +135,65 @@ function parseTableSlices(section: string): RoadmapSliceEntry[] {
   return slices;
 }
 
+/**
+ * Merge completion state from checkbox-format lines found anywhere in the
+ * document into prose-parsed slices.
+ *
+ * Handles hybrid roadmaps where checkboxes (- [x] **S01: ...**) live in
+ * a different section (e.g. "### Slice Ordering Rationale") than the H3
+ * prose headers (### S01 — Title) under "## Slices". The prose parser
+ * finds the structural slices but cannot detect [x] completion state.
+ *
+ * Scans the full content for checkbox lines matching slice IDs. When a
+ * checkbox `[x]` is found for a slice ID that exists in the parsed list,
+ * sets `done: true`. When `[ ]` is found, sets `done: false`. If multiple
+ * checkboxes reference the same ID, the last one wins.
+ *
+ * Only modifies `done` — does not add slices that don't exist in the
+ * parsed list (no phantom slices).
+ */
+function mergeCheckboxCompletionState(
+  slices: RoadmapSliceEntry[],
+  fullContent: string,
+): RoadmapSliceEntry[] {
+  if (slices.length === 0) return slices;
+
+  // Build a set of known slice IDs for fast lookup
+  const knownIds = new Set(slices.map(s => s.id));
+
+  // Scan full document for checkbox lines with slice IDs
+  const checkboxPattern = /^\s*-\s+\[([ xX])\]\s+\*\*(S\d+)[:\s\u2014\u2013-]/gm;
+  const completionState = new Map<string, boolean>();
+  let match: RegExpExecArray | null;
+
+  while ((match = checkboxPattern.exec(fullContent)) !== null) {
+    const done = match[1]!.toLowerCase() === "x";
+    const id = match[2]!;
+    if (knownIds.has(id)) {
+      completionState.set(id, done);
+    }
+  }
+
+  // Merge into slices
+  if (completionState.size > 0) {
+    for (const slice of slices) {
+      const cbDone = completionState.get(slice.id);
+      if (cbDone !== undefined) {
+        slice.done = cbDone;
+      }
+    }
+  }
+
+  return slices;
+}
+
 export function parseRoadmapSlices(content: string): RoadmapSliceEntry[] {
   const slicesSection = extractSlicesSection(content);
   if (!slicesSection) {
     // Fallback: detect prose-style slice headers (## Slice S01: Title)
     // when the LLM writes freeform prose instead of the ## Slices checklist.
     // This prevents a permanent "No slice eligible" block (#807).
-    return parseProseSliceHeaders(content);
+    return mergeCheckboxCompletionState(parseProseSliceHeaders(content), content);
   }
 
   // Try table format first — if the section contains pipe-delimited rows with
@@ -189,7 +241,7 @@ export function parseRoadmapSlices(content: string): RoadmapSliceEntry[] {
   // (e.g. the LLM used H3 prose headers instead of checkboxes), fall through
   // to the prose-header parser as a second-chance fallback.
   if (slices.length === 0) {
-    return parseProseSliceHeaders(content);
+    return mergeCheckboxCompletionState(parseProseSliceHeaders(content), content);
   }
 
   return slices;

--- a/src/resources/extensions/gsd/tests/roadmap-slices.test.ts
+++ b/src/resources/extensions/gsd/tests/roadmap-slices.test.ts
@@ -253,3 +253,54 @@ Do the second thing.
   assert.equal(slices[0]?.id, "S01");
   assert.equal(slices[1]?.id, "S02");
 });
+
+test("parseRoadmapSlices: hybrid roadmap — checkbox completion merged into prose H3 headers", () => {
+  // Bug scenario: checkboxes with [x] in one section, prose ### headers in ## Slices.
+  // The checkbox parser finds nothing in ## Slices, prose parser returns done:false.
+  // mergeCheckboxCompletionState should set done:true from the [x] checkbox.
+  const content = `# M003: Hybrid Roadmap
+
+## Strategic Reasoning
+
+### Slice Ordering Rationale
+
+- [x] **S01: RBAC** \`risk:low\` \`depends:[]\` — Role enforcement.
+- [ ] **S02: App Filter** \`risk:medium\` \`depends:[S01]\` — Per-app filtering.
+
+## Slices
+
+### S01 — Role-Based Access Control
+- **Risk:** low
+- **Depends:** none
+
+### S02 — App Filter & Per-App Costs
+- **Risk:** medium
+- **Depends:** S01
+
+## Milestone Definition of Done
+`;
+  const slices = parseRoadmapSlices(content);
+  assert.equal(slices.length, 2, "should find both slices from prose headers");
+  assert.equal(slices[0]?.id, "S01");
+  assert.equal(slices[0]?.done, true, "S01 should be done from checkbox [x] in different section");
+  assert.equal(slices[1]?.id, "S02");
+  assert.equal(slices[1]?.done, false, "S02 should be not done from checkbox [ ]");
+});
+
+test("parseRoadmapSlices: checkbox completion merge is additive — no effect when checkboxes absent", () => {
+  // When no checkbox lines exist, prose parser alone determines done state.
+  const content = `# M004: Pure Prose
+
+## Slices
+
+### S01 — First Slice
+Some description.
+
+### S02 — Second Slice
+Another description.
+`;
+  const slices = parseRoadmapSlices(content);
+  assert.equal(slices.length, 2);
+  assert.equal(slices[0]?.done, false, "S01 default done=false without checkboxes");
+  assert.equal(slices[1]?.done, false, "S02 default done=false without checkboxes");
+});


### PR DESCRIPTION
## Problem

When a roadmap has checkbox items (`- [x] **S01: RBAC**`) in one section (e.g. "Slice Ordering Rationale") and H3 prose headers (`### S01 — Title`) under `## Slices`, the parser returns `done: false` for all slices — ignoring the actual checkbox completion state.

This causes `verifyExpectedArtifact("complete-slice", ...)` to fail indefinitely: the summary and UAT files exist, the roadmap checkbox is `[x]`, but `parseRoadmapSlices()` returns `done: false`, so the verification gate keeps retrying the `complete-slice` unit forever.

## Root Cause

`parseRoadmapSlices()` extracts the `## Slices` section and tries the checkbox parser first. When the section contains only H3 prose headers (no checkboxes), it falls through to `parseProseSliceHeaders()`, which scans the full document for `### S01 — Title` patterns. The prose parser detects completion via `✓` markers or `(Complete)` suffixes, but cannot see checkbox `[x]` state from a different section.

Hybrid roadmaps — where the LLM writes both a compact checkbox summary (for structure) and detailed H3 sections (for documentation) — hit this gap.

Additionally, when the native Rust parser is enabled, it returns an empty `Roadmap` (0 slices) for prose-format roadmaps since it only handles checkbox format. The bridge returns a non-null result, so the TS fallback never runs.

## Fix

1. **`roadmap-slices.ts`**: Add `mergeCheckboxCompletionState()` — after prose parsing, scan the full document for checkbox lines (`- [x] **S01: ...`) and merge `done` state into the prose-parsed slices. Applied at both prose-fallback return points.

2. **`files.ts`**: Guard the native parser path — fall through to TS when `nativeResult.slices.length === 0`, allowing the TS parser (with prose fallback + checkbox merge) to handle formats the Rust parser cannot.

## Changed Files

| File | Change |
|------|--------|
| `src/resources/extensions/gsd/roadmap-slices.ts` | Add `mergeCheckboxCompletionState()` helper; apply at both prose-fallback paths |
| `src/resources/extensions/gsd/files.ts` | Guard native parser: fall through to TS when 0 slices returned |
| `src/resources/extensions/gsd/tests/roadmap-slices.test.ts` | 2 new tests: hybrid checkbox+prose, and no-checkbox baseline |

## Test Evidence

- All 18 roadmap-slices tests pass (16 existing + 2 new)
- Verified against a real hybrid roadmap that exhibited the bug: parser now correctly returns `done: true` for `S01` (was `false`)
- Existing checkbox, table, and prose-only tests unaffected (no regressions)

## Related

- Related to #1931 — same parser area, different symptom (0 slices vs wrong done state)
- Related to #2053 — prose parser misses different checkbox-in-header patterns
- See also #1884 — prose completion marker variants