### PR TITLE
fix(roadmap): anchor prose dependency regex and validate slice IDs

### DIFF
--- a/src/resources/extensions/gsd/roadmap-slices.ts
+++ b/src/resources/extensions/gsd/roadmap-slices.ts
@@ -248,18 +248,23 @@ function parseProseSliceHeaders(content: string): RoadmapSliceEntry[] {
       title = title.replace(/\s*\(Complete\)\s*$/i, "");
     }
 
-    // Try to extract depends from prose: "Depends on: S01" or "**Depends on:** S01, S02"
+    // Extract dependencies — handles multiple LLM-generated variants:
+    //   "**Depends on:** S01"  |  "- **Depends:** S01"  |  "Depends: S01, S02"
+    //   "**Depends on:** none" |  "- **Depends:** none"
+    // The regex is anchored to start-of-line (^) to avoid matching prose like
+    // "depends on LangFuse tag-based query support" inside Risk descriptions.
+    // Extracted tokens are filtered to valid slice ID patterns as defense-in-depth.
     const afterHeader = content.slice(match.index + match[0].length);
     const nextHeader = afterHeader.search(/^#{1,4}\s/m);
     const section = nextHeader !== -1 ? afterHeader.slice(0, nextHeader) : afterHeader.slice(0, 500);
 
-    const depsMatch = section.match(/\*{0,2}Depends\s+on:?\*{0,2}\s*(.+)/i);
+    const depsMatch = section.match(/^[-*\s]*\*{0,2}Depends(?:\s+on)?:?\*{0,2}\s*(.+)/im);
     let depends: string[] = [];
     if (depsMatch) {
       const rawDeps = depsMatch[1]!.replace(/none/i, "").trim();
       if (rawDeps) {
         depends = expandDependencies(
-          rawDeps.split(/[,;]/).map(s => s.trim().replace(/[^A-Za-z0-9]/g, "")).filter(Boolean)
+          rawDeps.split(/[,;\s]+/).map(s => s.trim().replace(/[^A-Za-z0-9]/g, "")).filter(s => /^S\d+$/i.test(s))
         );
       }
     }

--- a/src/resources/extensions/gsd/tests/roadmap-slices.test.ts
+++ b/src/resources/extensions/gsd/tests/roadmap-slices.test.ts
@@ -253,3 +253,22 @@ Do the second thing.
   assert.equal(slices[0]?.id, "S01");
   assert.equal(slices[1]?.id, "S02");
 });
+
+test("parseRoadmapSlices: prose 'depends on' in Risk line is NOT extracted as dependency", () => {
+  // Bug: "depends on" in natural language prose matched the dependency regex,
+  // extracting garbage like "LangFusetagbasedquerysupport" as a slice ID.
+  const content = `# M005: Prose Deps Bug
+
+## S01: LangFuse Integration
+- **Risk:** medium — depends on LangFuse tag-based query support
+- **Depends on:** none
+
+## S02: Dashboard
+- **Risk:** low
+- **Depends on:** S01
+`;
+  const slices = parseRoadmapSlices(content);
+  assert.equal(slices.length, 2);
+  assert.deepEqual(slices[0]?.depends, [], "S01 should have no deps — prose 'depends on' in Risk line ignored");
+  assert.deepEqual(slices[1]?.depends, ["S01"], "S02 depends on S01 from structured field");
+});


### PR DESCRIPTION
## Problem

`parseProseSliceHeaders()` extracts garbage dependency IDs from natural language prose. When a Risk description contains "depends on" — e.g. `- **Risk:** medium — depends on LangFuse tag-based query support` — the dependency regex matches this prose instead of the structured `- **Depends on:** S01` field below it. The extracted sentence fragments become garbage slice IDs like `LangFusetagbasedquerysupport`, corrupting the `depends` array and bypassing positional slice ordering in `dispatch-guard.ts`.

## Root Cause

The regex `/\*{0,2}Depends\s+on:?\*{0,2}\s*(.+)/i` has no start-of-line anchor, so it matches "depends on" anywhere in the section text. `String.match()` returns the first match, which is the prose Risk line — the actual structured Depends field is never reached. The subsequent cleanup step strips non-alphanumeric characters but has no validation that the result is a valid slice ID.

## Fix

Two changes to `parseProseSliceHeaders()` in `roadmap-slices.ts`:

1. **Anchor the regex to start-of-line** — `^[-*\s]*\*{0,2}Depends(?:\s+on)?:?\*{0,2}\s*(.+)` with the `m` flag. This ensures only structured dependency fields at the beginning of a line match, not mid-sentence prose.

2. **Filter extracted tokens to valid slice IDs** — `.filter(s => /^S\d+$/i.test(s))` rejects any extracted value that is not a slice ID pattern (S01, S02, etc.) as defense-in-depth.

Also makes "on" optional (`Depends:` vs `Depends on:`) since LLMs write both variants.

## Changed Files

| File | Change |
|------|--------|
| `src/resources/extensions/gsd/roadmap-slices.ts` | Anchor deps regex to `^`, add `m` flag, add S-ID filter |
| `src/resources/extensions/gsd/tests/roadmap-slices.test.ts` | Regression test: prose "depends on" in Risk line not extracted |

## Test Evidence

- 17/17 roadmap-slices tests pass (16 existing + 1 new regression test)
- All roadmap-parse-regression tests pass (no regressions)
- Verified against a real roadmap where `- **Risk:** medium — depends on LangFuse...` was incorrectly parsed as dependency — now correctly ignored

## Related

Fixes #2055
Related to PR #2068 — addresses the same core issue with a different approach (line anchoring + ID validation vs backtick-first parsing)
See also PR #2074 — fixes a related roadmap parser issue (checkbox completion state not merged into prose slices)