### PR TITLE
fix(dispatch): only check done slices for SUMMARY in milestone guards

### DIFF
--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -498,15 +498,17 @@ export const DISPATCH_RULES: DispatchRule[] = [
     match: async ({ state, mid, midTitle, basePath, prefs }) => {
       if (state.phase !== "validating-milestone") return null;
 
-      // Safety guard (#1368): verify all roadmap slices have SUMMARY files before
-      // allowing milestone validation. If any slice lacks a summary, the milestone
-      // is not genuinely complete — something skipped earlier slices.
+      // Safety guard (#1368): verify all done roadmap slices have SUMMARY files
+      // before allowing milestone validation. If any done slice lacks a summary,
+      // the milestone is not genuinely complete — something skipped earlier slices.
+      // Only check done slices (#2056) — undone slices haven't been completed yet.
       const roadmapFile = resolveMilestoneFile(basePath, mid, "ROADMAP");
       const roadmapContent = roadmapFile ? await loadFile(roadmapFile) : null;
       if (roadmapContent) {
         const roadmap = parseRoadmap(roadmapContent);
         const missingSlices: string[] = [];
         for (const slice of roadmap.slices) {
+          if (!slice.done) continue;
           const summaryPath = resolveSliceFile(basePath, mid, slice.id, "SUMMARY");
           if (!summaryPath || !existsSync(summaryPath)) {
             missingSlices.push(slice.id);
@@ -557,13 +559,15 @@ export const DISPATCH_RULES: DispatchRule[] = [
     match: async ({ state, mid, midTitle, basePath }) => {
       if (state.phase !== "completing-milestone") return null;
 
-      // Safety guard (#1368): verify all roadmap slices have SUMMARY files.
+      // Safety guard (#1368): verify all done roadmap slices have SUMMARY files.
+      // Only check done slices (#2056) — undone slices haven't been completed yet.
       const roadmapFile = resolveMilestoneFile(basePath, mid, "ROADMAP");
       const roadmapContent = roadmapFile ? await loadFile(roadmapFile) : null;
       if (roadmapContent) {
         const roadmap = parseRoadmap(roadmapContent);
         const missingSlices: string[] = [];
         for (const slice of roadmap.slices) {
+          if (!slice.done) continue;
           const summaryPath = resolveSliceFile(basePath, mid, slice.id, "SUMMARY");
           if (!summaryPath || !existsSync(summaryPath)) {
             missingSlices.push(slice.id);

--- a/src/resources/extensions/gsd/tests/validate-milestone.test.ts
+++ b/src/resources/extensions/gsd/tests/validate-milestone.test.ts
@@ -380,3 +380,108 @@ test("buildLoopRemediationSteps returns steps for validate-milestone", () => {
     cleanup(base);
   }
 });
+
+// ─── #2056: dispatch guards must skip undone slices ───────────────────────
+
+const PARTIAL_DONE_ROADMAP = `# M001: Test Milestone
+
+## Vision
+Test
+
+## Success Criteria
+- It works
+
+## Slices
+
+- [x] **S01: First slice** \`risk:low\` \`depends:[]\`
+  > After this: first done
+- [ ] **S02: Second slice** \`risk:low\` \`depends:[S01]\`
+  > After this: second done
+
+## Boundary Map
+
+| From | To | Produces | Consumes |
+|------|-----|----------|----------|
+| S01  | S02  | output | nothing |
+| S02  | terminal | output | nothing |
+`;
+
+test("validating-milestone dispatch guard skips undone slices (#2056)", async () => {
+  const base = makeTmpBase();
+  try {
+    // Roadmap has S01 done but S02 not done
+    writeRoadmap(base, "M001", PARTIAL_DONE_ROADMAP);
+    // Only S01 has a SUMMARY (S02 is not done, so no summary expected)
+    writeSliceSummary(base, "M001", "S01", "# S01 Summary\nDone.");
+
+    const state: GSDState = {
+      activeMilestone: { id: "M001", title: "Test" },
+      activeSlice: null,
+      activeTask: null,
+      phase: "validating-milestone",
+      recentDecisions: [],
+      blockers: [],
+      nextAction: "Validate milestone M001.",
+      registry: [{ id: "M001", title: "Test", status: "active" }],
+      progress: { milestones: { done: 0, total: 1 } },
+    };
+
+    const ctx: DispatchContext = {
+      basePath: base,
+      mid: "M001",
+      midTitle: "Test",
+      state,
+      prefs: undefined,
+    };
+
+    const result = await resolveDispatch(ctx);
+    // Should dispatch validate-milestone, NOT stop with missing SUMMARY error
+    assert.equal(result.action, "dispatch", `Expected dispatch but got ${result.action}: ${"reason" in result ? result.reason : ""}`);
+    if (result.action === "dispatch") {
+      assert.equal(result.unitType, "validate-milestone");
+    }
+  } finally {
+    cleanup(base);
+  }
+});
+
+test("completing-milestone dispatch guard skips undone slices (#2056)", async () => {
+  const base = makeTmpBase();
+  try {
+    // Roadmap has S01 done but S02 not done
+    writeRoadmap(base, "M001", PARTIAL_DONE_ROADMAP);
+    // Only S01 has a SUMMARY
+    writeSliceSummary(base, "M001", "S01", "# S01 Summary\nDone.");
+    // Create a dummy implementation file so the artifacts guard passes
+    writeFileSync(join(base, "index.ts"), "export const x = 1;");
+
+    const state: GSDState = {
+      activeMilestone: { id: "M001", title: "Test" },
+      activeSlice: null,
+      activeTask: null,
+      phase: "completing-milestone",
+      recentDecisions: [],
+      blockers: [],
+      nextAction: "Complete milestone M001.",
+      registry: [{ id: "M001", title: "Test", status: "active" }],
+      progress: { milestones: { done: 0, total: 1 } },
+    };
+
+    const ctx: DispatchContext = {
+      basePath: base,
+      mid: "M001",
+      midTitle: "Test",
+      state,
+      prefs: undefined,
+    };
+
+    const result = await resolveDispatch(ctx);
+    // Should dispatch complete-milestone, NOT stop with missing SUMMARY error
+    assert.equal(result.action, "dispatch", `Expected dispatch but got ${result.action}: ${"reason" in result ? result.reason : ""}`);
+    if (result.action === "dispatch") {
+      assert.equal(result.unitType, "complete-milestone");
+    }
+  } finally {
+    cleanup(base);
+  }
+});


### PR DESCRIPTION
## TL;DR

**What**: Filter dispatch SUMMARY guards by `slice.done` in `auto-dispatch.ts`.
**Why**: Undone slices don't have SUMMARY files, causing false validation errors.
**How**: Add `if (!slice.done) continue;` to both `validating-milestone` and `completing-milestone` guards.

## What

The `validating-milestone` and `completing-milestone` dispatch rules in `auto-dispatch.ts` check all roadmap slices for SUMMARY files. When a milestone has undone slices (which naturally lack summaries), the guard incorrectly blocks progression with "missing SUMMARY files" errors.

## Why

This is a distinct bug from #2042 (which fixed the same pattern in `doctor.ts`). The dispatch guards in `auto-dispatch.ts` were not updated in that PR. When a milestone reaches validation with some slices not yet completed, the guard incorrectly requires summaries for undone slices that haven't been worked on yet.

## How

- Added `if (!slice.done) continue;` to the SUMMARY-checking loops in both:
  - `validating-milestone → validate-milestone` rule (line ~509)
  - `completing-milestone → complete-milestone` rule (line ~566)
- Added two reproduction tests that verify both guards skip undone slices

Related: PR #2042 (same pattern, different code path — `doctor.ts` vs `auto-dispatch.ts`)

Fixes #2056

🤖 Generated with [Claude Code](https://claude.com/claude-code)