### PR TITLE
fix(auto): detect ghost completions during execute-task

### DIFF
--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -32,6 +32,7 @@ import {
 import {
   verifyExpectedArtifact,
   resolveExpectedArtifactPath,
+  getLastCommitNonGsdFiles,
 } from "./auto-recovery.js";
 import { writeUnitRuntimeRecord, clearUnitRuntimeRecord } from "./unit-runtime.js";
 import { runGSDDoctor, rebuildState, summarizeDoctorIssues } from "./doctor.js";
@@ -167,6 +168,30 @@ export async function postUnitPreVerification(pctx: PostUnitContext, opts?: PreV
       const commitMsg = autoCommitCurrentBranch(s.basePath, s.currentUnit.type, s.currentUnit.id, taskContext);
       if (commitMsg) {
         ctx.ui.notify(`Committed: ${commitMsg.split("\n")[0]}`, "info");
+      }
+
+      // Ghost completion detection (#1989): after an execute-task commit,
+      // verify that at least one non-.gsd/ source file was included.
+      // A commit with only .gsd/ artifacts means the LLM wrote summaries
+      // claiming work was done but never created actual source code.
+      if (commitMsg && s.currentUnit.type === "execute-task") {
+        const sourceFiles = getLastCommitNonGsdFiles(s.basePath);
+        if (sourceFiles.length === 0) {
+          const retryKey = `ghost:${s.currentUnit.type}:${s.currentUnit.id}`;
+          const attempt = (s.verificationRetryCount.get(retryKey) ?? 0) + 1;
+          s.verificationRetryCount.set(retryKey, attempt);
+          s.pendingVerificationRetry = {
+            unitId: s.currentUnit.id,
+            failureContext: `Ghost completion detected: task ${s.currentUnit.id} committed only .gsd/ files — no source code was created. The agent must write the actual implementation code, not just summaries (attempt ${attempt}).`,
+            attempt,
+          };
+          debugLog("postUnit", { phase: "ghost-completion", unitId: s.currentUnit.id, attempt });
+          ctx.ui.notify(
+            `Ghost completion: ${s.currentUnit.id} has no source code — retrying (attempt ${attempt})`,
+            "warning",
+          );
+          return "retry";
+        }
       }
     } catch (e) {
       debugLog("postUnit", { phase: "auto-commit", error: String(e) });

--- a/src/resources/extensions/gsd/auto-recovery.ts
+++ b/src/resources/extensions/gsd/auto-recovery.ts
@@ -169,6 +169,32 @@ export function hasImplementationArtifacts(basePath: string): boolean {
 }
 
 /**
+ * Return non-`.gsd/` files changed in the most recent commit.
+ *
+ * Used after `autoCommitCurrentBranch()` for `execute-task` units to detect
+ * "ghost completions" — commits that only touch `.gsd/` metadata without
+ * producing any implementation code (#1989).
+ *
+ * Returns an empty array when:
+ * - The last commit contains only `.gsd/` files (ghost completion).
+ * - The directory is not a git repo or git commands fail (fail-safe).
+ */
+export function getLastCommitNonGsdFiles(basePath: string): string[] {
+  try {
+    const raw = execFileSync(
+      "git", ["diff-tree", "--no-commit-id", "-r", "--name-only", "HEAD"],
+      { cwd: basePath, stdio: ["ignore", "pipe", "pipe"], encoding: "utf-8" },
+    ).trim();
+    if (!raw) return [];
+    const allFiles = raw.split("\n").filter(Boolean);
+    return allFiles.filter(f => !f.startsWith(".gsd/") && !f.startsWith(".gsd\\"));
+  } catch {
+    // Non-fatal — fail-safe returns empty so callers can decide policy
+    return [];
+  }
+}
+
+/**
  * Detect the main/master branch name.
  */
 function detectMainBranch(basePath: string): string {

--- a/src/resources/extensions/gsd/tests/ghost-completion.test.ts
+++ b/src/resources/extensions/gsd/tests/ghost-completion.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Ghost completion detection tests (#1989).
+ *
+ * Verifies that execute-task units are flagged when a commit contains only
+ * .gsd/ files (no source code), preventing slices from being marked complete
+ * without actual implementation.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomUUID } from "node:crypto";
+import { execFileSync } from "node:child_process";
+
+import { getLastCommitNonGsdFiles } from "../auto-recovery.ts";
+
+function makeGitBase(): string {
+  const base = join(tmpdir(), `gsd-test-ghost-${randomUUID()}`);
+  mkdirSync(base, { recursive: true });
+  execFileSync("git", ["init", "--initial-branch=main"], { cwd: base, stdio: "ignore" });
+  execFileSync("git", ["config", "user.email", "test@test.com"], { cwd: base, stdio: "ignore" });
+  execFileSync("git", ["config", "user.name", "Test"], { cwd: base, stdio: "ignore" });
+  writeFileSync(join(base, ".gitkeep"), "");
+  execFileSync("git", ["add", "."], { cwd: base, stdio: "ignore" });
+  execFileSync("git", ["commit", "-m", "initial"], { cwd: base, stdio: "ignore" });
+  return base;
+}
+
+function cleanup(base: string): void {
+  try { rmSync(base, { recursive: true, force: true }); } catch { /* */ }
+}
+
+// ─── getLastCommitNonGsdFiles (#1989) ─────────────────────────────────────
+
+test("getLastCommitNonGsdFiles returns empty when commit has only .gsd/ files (#1989)", () => {
+  const base = makeGitBase();
+  try {
+    mkdirSync(join(base, ".gsd", "milestones", "M001", "slices", "S01", "tasks"), { recursive: true });
+    writeFileSync(
+      join(base, ".gsd", "milestones", "M001", "slices", "S01", "tasks", "T01-SUMMARY.md"),
+      "# T01 Summary\nDone.",
+    );
+    execFileSync("git", ["add", "."], { cwd: base, stdio: "ignore" });
+    execFileSync("git", ["commit", "-m", "chore: task summary only"], { cwd: base, stdio: "ignore" });
+
+    const files = getLastCommitNonGsdFiles(base);
+    assert.deepEqual(files, [], "ghost commit: no non-.gsd/ files expected");
+  } finally {
+    cleanup(base);
+  }
+});
+
+test("getLastCommitNonGsdFiles returns source files when commit has implementation code (#1989)", () => {
+  const base = makeGitBase();
+  try {
+    mkdirSync(join(base, ".gsd", "milestones", "M001", "slices", "S01", "tasks"), { recursive: true });
+    writeFileSync(
+      join(base, ".gsd", "milestones", "M001", "slices", "S01", "tasks", "T01-SUMMARY.md"),
+      "# T01 Summary\nDone.",
+    );
+    mkdirSync(join(base, "src"), { recursive: true });
+    writeFileSync(join(base, "src", "feature.ts"), "export function feature() {}");
+    execFileSync("git", ["add", "."], { cwd: base, stdio: "ignore" });
+    execFileSync("git", ["commit", "-m", "feat: add feature + summary"], { cwd: base, stdio: "ignore" });
+
+    const files = getLastCommitNonGsdFiles(base);
+    assert.ok(files.length > 0, "should have non-.gsd/ files");
+    assert.ok(files.includes("src/feature.ts"), "should include the source file");
+  } finally {
+    cleanup(base);
+  }
+});
+
+test("getLastCommitNonGsdFiles returns empty array for non-git directory (fail-safe) (#1989)", () => {
+  const base = join(tmpdir(), `gsd-test-nogit-${randomUUID()}`);
+  mkdirSync(base, { recursive: true });
+  try {
+    const files = getLastCommitNonGsdFiles(base);
+    assert.deepEqual(files, [], "non-git dir should return empty array (fail-safe)");
+  } finally {
+    cleanup(base);
+  }
+});
+
+test("getLastCommitNonGsdFiles excludes .gsd/ but keeps other dotfiles (#1989)", () => {
+  const base = makeGitBase();
+  try {
+    mkdirSync(join(base, ".gsd", "milestones"), { recursive: true });
+    writeFileSync(join(base, ".gsd", "milestones", "M001-ROADMAP.md"), "# Roadmap");
+    writeFileSync(join(base, ".eslintrc.json"), "{}");
+    execFileSync("git", ["add", "."], { cwd: base, stdio: "ignore" });
+    execFileSync("git", ["commit", "-m", "chore: config + gsd"], { cwd: base, stdio: "ignore" });
+
+    const files = getLastCommitNonGsdFiles(base);
+    assert.ok(files.includes(".eslintrc.json"), ".eslintrc.json is not .gsd/ — should be included");
+  } finally {
+    cleanup(base);
+  }
+});


### PR DESCRIPTION
## TL;DR
**What**: Add per-task source code verification after auto-commit in `postUnitPreVerification()`.
**Why**: The state machine marks slices complete based on `.gsd/` artifacts alone — if the LLM writes summaries but never creates source files, entire milestones advance with zero implementation (#1989).
**How**: After `autoCommitCurrentBranch()` for `execute-task` units, check if the commit contains any non-`.gsd/` files. If not, trigger the existing retry mechanism with context telling the agent to write real code.

## What
- Added `getLastCommitNonGsdFiles(basePath)` to `auto-recovery.ts` — uses `git diff-tree` to list non-`.gsd/` files in the last commit.
- Added ghost completion detection in `auto-post-unit.ts` — after a successful `execute-task` commit, checks for source code and returns `"retry"` with descriptive failure context if none found.
- Added 4 tests in `ghost-completion.test.ts` covering: ghost-only commits, mixed commits, non-git dirs, and dotfile handling.

## Why
PR #1917 added `codeFilesChanged` at **milestone merge time**, but that's too late — by then all slices are already marked `[x]`. This fix operates at **execution time**, catching ghost completions immediately after each task commit. The agent gets retried with explicit context about the failure, giving it a chance to write the actual implementation.

## How
The check hooks into the existing `postUnitPreVerification()` flow, right after `autoCommitCurrentBranch()`:
1. If `commitMsg` is truthy AND `unitType === "execute-task"`, call `getLastCommitNonGsdFiles()`.
2. If the result is empty (all files are `.gsd/`), set `s.pendingVerificationRetry` with failure context and return `"retry"`.
3. The existing auto-loop retry mechanism re-dispatches the unit with the ghost completion warning.

The function fails safe — returns `[]` on git errors, letting the caller decide policy. This matches the pattern used by `hasImplementationArtifacts()`.

## Test plan
- [x] `getLastCommitNonGsdFiles` returns `[]` for commits with only `.gsd/` files
- [x] `getLastCommitNonGsdFiles` returns source files for commits with implementation code
- [x] `getLastCommitNonGsdFiles` returns `[]` for non-git directories (fail-safe)
- [x] `.gsd/` files excluded but other dotfiles preserved
- [x] All 35 auto-recovery tests pass
- [x] All 54 auto-loop tests pass
- [x] TypeScript compiles clean (`tsc --noEmit`)

Related: #1917 (merge-time check)
Fixes #1989

🤖 Generated with [Claude Code](https://claude.com/claude-code)