### PR TITLE
docs: update documentation for v2.42.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,29 @@ One command. Walk away. Come back to a built project with clean git history.
 
 ---
 
+## What's New in v2.42.0
+
+### New Features
+
+- **Declarative workflow engine** — define YAML workflows that execute through auto-loop, enabling repeatable multi-step automations without code. (#2024)
+- **Unified rule registry & event journal** — centralized rule registry, event journal with query tool, and standardized tool naming convention. (#1928)
+- **PR risk checker** — CI classifies changed files by system area and surfaces risk level on pull requests. (#1930)
+- **`/gsd fast`** — toggle service tier for supported models, enabling prioritized API routing for faster responses. (#1862)
+- **Web mode CLI flags** — `--host`, `--port`, and `--allowed-origins` flags give full control over the web server bind address and CORS policy. (#1873)
+- **ADR attribution** — architecture decision records now distinguish human, agent, and collaborative authorship. (#1830)
+
+### Key Fixes
+
+- **Node v24 web boot** — resolved `ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING` that prevented `gsd --web` from starting on Node v24. (#1864)
+- **Worktree health check for all ecosystems** — broadened from JS-only to 17+ ecosystems (Rust, Go, Python, Java, etc.). (#1860)
+- **Doctor roadmap atomicity** — roadmap checkbox gating now checks summary on disk, not issue detection, preventing false unchecks. (#1915)
+- **Windows path handling** — 8.3 short path resolution, backslash normalization in bash commands, PowerShell browser launch, and parenthesis escaping. (#1960, #1863, #1870, #1872)
+- **Auth token persistence** — web UI auth token survives page refreshes via sessionStorage. (#1877)
+- **German/non-English locale git errors** — git commands now force `LC_ALL=C` to prevent locale-dependent parse failures.
+- **Orphan web server process** — stale web server processes on port 3000 are now cleaned up automatically.
+
+---
+
 ## What's New in v2.41.0
 
 ### New Features

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -22,6 +22,7 @@
 | `/gsd export --html --all` | Generate retrospective reports for all milestones at once |
 | `/gsd update` | Update GSD to the latest version in-session |
 | `/gsd knowledge` | Add persistent project knowledge (rule, pattern, or lesson) |
+| `/gsd fast` | Toggle service tier for supported models (prioritized API routing) |
 | `/gsd help` | Categorized command reference with descriptions for all GSD subcommands |
 
 ## Configuration & Diagnostics

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -151,6 +151,38 @@ rm -rf "$(dirname .gsd)/.gsd.lock"
 - If the error persists, close tools that may be holding the file open and then retry.
 - If repeated failures continue, run `/gsd doctor` to confirm the repo state is still healthy and report the exact path + error code.
 
+### Node v24 web boot failure
+
+**Symptoms:** `gsd --web` fails with `ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING` on Node v24.
+
+**Cause:** Node v24 changed type-stripping behavior for `node_modules`, breaking the Next.js web build.
+
+**Fix:** Fixed in v2.42.0+ (#1864). Upgrade to the latest version.
+
+### Orphan web server process
+
+**Symptoms:** `gsd --web` fails because port 3000 is already in use, even though no GSD session is running.
+
+**Cause:** A previous web server process was not cleaned up on exit.
+
+**Fix:** Fixed in v2.42.0+. GSD now cleans up stale web server processes automatically. If you're on an older version, kill the orphan process manually: `lsof -ti:3000 | xargs kill`.
+
+### Non-JS project blocked by worktree health check
+
+**Symptoms:** Worktree health check fails or blocks auto-mode in projects that don't use Node.js (e.g., Rust, Go, Python).
+
+**Cause:** The worktree health check only recognized JavaScript ecosystems prior to v2.42.0.
+
+**Fix:** Fixed in v2.42.0+ (#1860). The health check now supports 17+ ecosystems. Upgrade to the latest version.
+
+### German/non-English locale git errors
+
+**Symptoms:** Git commands fail or produce unexpected results when the system locale is non-English (e.g., German).
+
+**Cause:** GSD parsed git output assuming English locale strings.
+
+**Fix:** Fixed in v2.42.0+. All git commands now force `LC_ALL=C` to ensure consistent English output regardless of system locale.
+
 ## MCP Client Issues
 
 ### `mcp_servers` shows no configured servers

--- a/docs/web-interface.md
+++ b/docs/web-interface.md
@@ -7,10 +7,22 @@ GSD includes a browser-based web interface for project management, real-time pro
 ## Quick Start
 
 ```bash
-pi --web
+gsd --web
 ```
 
 This starts a local web server and opens the GSD dashboard in your default browser.
+
+### CLI Flags (v2.42.0)
+
+```bash
+gsd --web --host 0.0.0.0 --port 8080 --allowed-origins "https://example.com"
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--host` | `localhost` | Bind address for the web server |
+| `--port` | `3000` | Port for the web server |
+| `--allowed-origins` | (none) | Comma-separated list of allowed CORS origins |
 
 ## Features
 
@@ -31,13 +43,21 @@ Key components:
 
 ## Configuration
 
-The web server binds to `localhost` by default. No additional configuration is required.
+The web server binds to `localhost:3000` by default. Use `--host`, `--port`, and `--allowed-origins` to override (see CLI Flags above).
 
 ### Environment Variables
 
 | Variable | Description |
 |----------|-------------|
 | `GSD_WEB_PROJECT_CWD` | Default project path when `?project=` is not specified |
+
+## Node v24 Compatibility
+
+Node v24 introduced breaking changes to type stripping that caused `ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING` on web boot. This is fixed in v2.42.0+ (#1864). If you encounter this error, upgrade GSD.
+
+## Auth Token Persistence
+
+As of v2.42.0, the web UI persists the auth token in `sessionStorage` so it survives page refreshes (#1877). Previously, refreshing the page required re-authentication.
 
 ## Platform Notes
 


### PR DESCRIPTION
## TL;DR

**What:** Update README, web-interface, commands, and troubleshooting docs to reflect v2.42.0.
**Why:** v2.42.0 shipped but docs still reference v2.41.0 as latest.
**How:** Added v2.42.0 What's New section, new CLI flags, `/gsd fast` command, and four new troubleshooting entries.

## What

- **README.md** — Added "What's New in v2.42.0" section above v2.41.0 covering declarative workflow engine, unified rule registry, PR risk checker, `/gsd fast`, web mode CLI flags, ADR attribution, and key fixes.
- **docs/web-interface.md** — Fixed `pi --web` → `gsd --web`, added `--host`/`--port`/`--allowed-origins` flags table, Node v24 compatibility note, and auth token persistence note.
- **docs/commands.md** — Added `/gsd fast` to the Session Commands table.
- **docs/troubleshooting.md** — Added four new sections: Node v24 web boot failure, orphan web server process, non-JS worktree health check, and non-English locale git errors.

## Why

The v2.42.0 release introduced significant new features and fixes that users need documented. The web interface docs also had a stale `pi --web` command reference.

## How

Direct edits to existing doc files. No new files created. All additions follow existing formatting conventions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)