### PR TITLE
fix(auth): fall through to env/fallback for non-OAuth credential type

### DIFF
--- a/packages/pi-coding-agent/src/core/auth-storage.test.ts
+++ b/packages/pi-coding-agent/src/core/auth-storage.test.ts
@@ -263,6 +263,74 @@ describe("AuthStorage — areAllCredentialsBackedOff", () => {
 	});
 });
 
+// ─── mismatched oauth credential for non-OAuth provider (#2083) ───────────────
+
+describe("AuthStorage — oauth credential for non-OAuth provider (#2083)", () => {
+	it("returns undefined when openrouter has type:oauth (no registered OAuth provider)", async () => {
+		// Simulates the bug: OpenRouter credential stored as type:"oauth"
+		// but OpenRouter is not a registered OAuth provider.
+		const storage = inMemory({
+			openrouter: {
+				type: "oauth",
+				access_token: "sk-or-v1-fake",
+				refresh_token: "rt-fake",
+				expires: Date.now() + 3_600_000,
+			},
+		});
+
+		// Before the fix, getApiKey returns undefined because
+		// resolveCredentialApiKey calls getOAuthProvider("openrouter") → null → undefined.
+		// The key in the oauth credential is never extracted.
+		const key = await storage.getApiKey("openrouter");
+		// After the fix, the oauth credential with an unrecognised provider
+		// should be skipped, and getApiKey should fall through to env / fallback.
+		assert.equal(key, undefined);
+	});
+
+	it("falls through to env var when openrouter has type:oauth credential", async () => {
+		const storage = inMemory({
+			openrouter: {
+				type: "oauth",
+				access_token: "sk-or-v1-fake",
+				refresh_token: "rt-fake",
+				expires: Date.now() + 3_600_000,
+			},
+		});
+
+		// Simulate OPENROUTER_API_KEY being set via env
+		const origEnv = process.env.OPENROUTER_API_KEY;
+		try {
+			process.env.OPENROUTER_API_KEY = "sk-or-v1-env-key";
+			const key = await storage.getApiKey("openrouter");
+			assert.equal(key, "sk-or-v1-env-key");
+		} finally {
+			if (origEnv === undefined) {
+				delete process.env.OPENROUTER_API_KEY;
+			} else {
+				process.env.OPENROUTER_API_KEY = origEnv;
+			}
+		}
+	});
+
+	it("falls through to fallback resolver when openrouter has type:oauth credential", async () => {
+		const storage = inMemory({
+			openrouter: {
+				type: "oauth",
+				access_token: "sk-or-v1-fake",
+				refresh_token: "rt-fake",
+				expires: Date.now() + 3_600_000,
+			},
+		});
+
+		storage.setFallbackResolver((provider) =>
+			provider === "openrouter" ? "sk-or-v1-fallback" : undefined,
+		);
+
+		const key = await storage.getApiKey("openrouter");
+		assert.equal(key, "sk-or-v1-fallback");
+	});
+});
+
 // ─── getAll truncation ────────────────────────────────────────────────────────
 
 describe("AuthStorage — getAll()", () => {

--- a/packages/pi-coding-agent/src/core/auth-storage.ts
+++ b/packages/pi-coding-agent/src/core/auth-storage.ts
@@ -731,9 +731,12 @@ export class AuthStorage {
 		if (credentials.length > 0) {
 			const index = this.selectCredentialIndex(providerId, credentials, sessionId);
 			if (index >= 0) {
-				return this.resolveCredentialApiKey(providerId, credentials[index]);
+				const resolved = await this.resolveCredentialApiKey(providerId, credentials[index]);
+				if (resolved) return resolved;
+				// Credential unresolvable (e.g. type:"oauth" for a non-OAuth provider) —
+				// fall through to env / fallback instead of returning undefined (#2083)
 			}
-			// All credentials backed off - fall through to env/fallback
+			// All credentials backed off or unresolvable - fall through to env/fallback
 		}
 
 		// Fall back to environment variable


### PR DESCRIPTION
## TL;DR
**What**: When a credential is stored as `type:"oauth"` for a provider without a registered OAuth handler, `getApiKey()` now falls through to env vars and fallback resolvers instead of silently returning `undefined`.
**Why**: OpenRouter keys stored as `type:"oauth"` in `auth.json` cause "Authentication failed" because `getOAuthProvider("openrouter")` returns `null` and the key resolution stops — never reaching `OPENROUTER_API_KEY` env var.
**How**: Changed `getApiKey()` to check the return value of `resolveCredentialApiKey()` and fall through when it returns `undefined`.

## What
`AuthStorage.getApiKey()` in `packages/pi-coding-agent/src/core/auth-storage.ts` previously did `return this.resolveCredentialApiKey(...)` directly. When the credential was `type:"oauth"` for a non-OAuth provider (like OpenRouter), `resolveCredentialApiKey` called `getOAuthProvider()` which returned `undefined`, and the entire `getApiKey` call returned `undefined` — never checking env vars or fallback resolvers.

## Why
Users who had their OpenRouter API key stored as `type:"oauth"` in `~/.gsd/agent/auth.json` (possibly from a migration or manual edit) got "Authentication failed" errors even when `OPENROUTER_API_KEY` was set in their environment. The credential lookup short-circuited on the unresolvable OAuth credential.

## How
- In `getApiKey()`, changed from `return this.resolveCredentialApiKey(...)` to assigning the result and only returning if truthy, otherwise falling through to env/fallback paths.
- Added 3 tests covering the exact scenario: mismatched `type:"oauth"` credential for OpenRouter with fallthrough to env var and fallback resolver.

Fixes #2083

## Test plan
- [x] New test: `type:"oauth"` credential for non-OAuth provider returns `undefined` (no crash)
- [x] New test: falls through to `OPENROUTER_API_KEY` env var
- [x] New test: falls through to fallback resolver
- [x] All 25 auth-storage tests pass
- [x] All 2699 unit tests pass
- [x] TypeScript type check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)