### PR TITLE
fix(auto): guard against auto-mode dispatch on quick-task branches

### DIFF
--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -26,6 +26,8 @@ import {
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { hasImplementationArtifacts } from "./auto-recovery.js";
+import { getCurrentBranch } from "./worktree.js";
+import { QUICK_BRANCH_RE } from "./git-service.js";
 import {
   buildDiscussMilestonePrompt,
   buildResearchMilestonePrompt,
@@ -91,6 +93,26 @@ const MAX_REWRITE_ATTEMPTS = 3;
 // ─── Rules ────────────────────────────────────────────────────────────────
 
 export const DISPATCH_RULES: DispatchRule[] = [
+  {
+    name: "quick-branch-guard",
+    match: async ({ basePath }) => {
+      let branch: string;
+      try {
+        branch = getCurrentBranch(basePath);
+      } catch {
+        return null; // Cannot determine branch — let other rules decide
+      }
+      if (!QUICK_BRANCH_RE.test(branch)) return null;
+      return {
+        action: "stop",
+        reason:
+          `Auto-mode is on quick-task branch "${branch}". ` +
+          "Refusing to dispatch milestone work on a quick branch to prevent silent work loss. " +
+          "Return to the original branch first (run cleanupQuickBranch or checkout manually).",
+        level: "error",
+      };
+    },
+  },
   {
     name: "rewrite-docs (override gate)",
     match: async ({ mid, midTitle, state, basePath, session }) => {

--- a/src/resources/extensions/gsd/auto-start.ts
+++ b/src/resources/extensions/gsd/auto-start.ts
@@ -186,6 +186,23 @@ export async function bootstrapAutoSession(
       }
     }
 
+    // Recover from stale quick-task branch (#2086): if auto-mode is starting
+    // while the checkout is still on a gsd/quick/* branch (because
+    // cleanupQuickBranch was never called — #1935), merge the quick work back
+    // and return to the original branch before proceeding.
+    try {
+      const { cleanupQuickBranch } = await import("./quick.js");
+      const quickCleaned = cleanupQuickBranch(base);
+      if (quickCleaned) {
+        ctx.ui.notify(
+          "Recovered from stale quick-task branch. Quick work merged back to original branch.",
+          "info",
+        );
+      }
+    } catch {
+      // Non-fatal — quick module may fail; the dispatch guard will catch it
+    }
+
     // Initialize GitServiceImpl
     s.gitService = new GitServiceImpl(
       s.basePath,

--- a/src/resources/extensions/gsd/tests/auto-dispatch-quick-branch-guard.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-dispatch-quick-branch-guard.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Test: auto-mode dispatch refuses to dispatch on gsd/quick/* branches.
+ *
+ * Reproduces #2086 — auto-mode commits milestone work onto a quick-task
+ * branch because resolveDispatch has no branch awareness.
+ *
+ * The fix adds a "quick-branch-guard" dispatch rule that fires first and
+ * returns a "stop" action when the current branch matches gsd/quick/*.
+ */
+
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { execSync } from "node:child_process";
+
+import { createTestContext } from "./test-helpers.ts";
+import { resolveDispatch, DISPATCH_RULES } from "../auto-dispatch.ts";
+import type { DispatchContext } from "../auto-dispatch.ts";
+import type { GSDState } from "../types.ts";
+
+const { assertEq, assertTrue, report } = createTestContext();
+
+function run(command: string, cwd: string): string {
+  return execSync(command, {
+    cwd,
+    stdio: ["ignore", "pipe", "pipe"],
+    encoding: "utf-8",
+  }).trim();
+}
+
+function createTestRepo(): string {
+  const repo = mkdtempSync(join(tmpdir(), "gsd-quick-dispatch-guard-"));
+  run("git init -b main", repo);
+  run(`git config user.name "GSD Test"`, repo);
+  run(`git config user.email "test@gsd.dev"`, repo);
+  mkdirSync(join(repo, ".gsd", "milestones", "M001"), { recursive: true });
+  writeFileSync(join(repo, "README.md"), "init\n");
+  run("git add -A", repo);
+  run(`git commit -m "init"`, repo);
+  return repo;
+}
+
+function makeState(phase: string): GSDState {
+  return {
+    phase,
+    activeMilestone: { id: "M001", title: "Test milestone", status: "active" },
+    activeSlice: { id: "S01", title: "Test slice", status: "active" },
+    activeTask: { id: "T01", title: "Test task", status: "active" },
+    registry: [],
+  } as unknown as GSDState;
+}
+
+async function main(): Promise<void> {
+  // ═══════════════════════════════════════════════════════════════════════
+  // quick-branch-guard rule exists in DISPATCH_RULES
+  // ═══════════════════════════════════════════════════════════════════════
+
+  console.log("\n=== DISPATCH_RULES includes quick-branch-guard ===");
+
+  const guardRule = DISPATCH_RULES.find((r) => r.name === "quick-branch-guard");
+  assertTrue(!!guardRule, "quick-branch-guard rule exists");
+  assertEq(DISPATCH_RULES[0].name, "quick-branch-guard", "quick-branch-guard is the first rule");
+
+  // ═══════════════════════════════════════════════════════════════════════
+  // resolveDispatch stops on gsd/quick/* branch
+  // ═══════════════════════════════════════════════════════════════════════
+
+  console.log("\n=== resolveDispatch: stops on quick branch ===");
+
+  {
+    const repo = createTestRepo();
+
+    // Switch to a quick-task branch
+    run("git checkout -b gsd/quick/1-fix-typo", repo);
+
+    const ctx: DispatchContext = {
+      basePath: repo,
+      mid: "M001",
+      midTitle: "Test milestone",
+      state: makeState("executing"),
+      prefs: undefined,
+    };
+
+    const result = await resolveDispatch(ctx);
+
+    assertEq(result.action, "stop", "dispatch returns stop on quick branch");
+    assertTrue(
+      (result as any).reason?.includes("quick"),
+      "stop reason mentions quick branch",
+    );
+
+    rmSync(repo, { recursive: true, force: true });
+  }
+
+  // ═══════════════════════════════════════════════════════════════════════
+  // resolveDispatch proceeds normally on non-quick branch
+  // ═══════════════════════════════════════════════════════════════════════
+
+  console.log("\n=== resolveDispatch: proceeds on main branch ===");
+
+  {
+    const repo = createTestRepo();
+
+    // Stay on main — dispatch should NOT stop
+    const ctx: DispatchContext = {
+      basePath: repo,
+      mid: "M001",
+      midTitle: "Test milestone",
+      state: makeState("complete"),
+      prefs: undefined,
+    };
+
+    const result = await resolveDispatch(ctx);
+
+    // "complete" phase dispatches a stop, but it's the "All milestones complete"
+    // stop, NOT the quick-branch guard stop.
+    assertEq(result.action, "stop", "complete phase stops");
+    assertTrue(
+      !(result as any).reason?.includes("quick"),
+      "stop reason is NOT about quick branch",
+    );
+
+    rmSync(repo, { recursive: true, force: true });
+  }
+
+  // ═══════════════════════════════════════════════════════════════════════
+  // Guard fires for any gsd/quick/ prefix
+  // ═══════════════════════════════════════════════════════════════════════
+
+  console.log("\n=== resolveDispatch: guards various quick branch patterns ===");
+
+  {
+    const repo = createTestRepo();
+
+    for (const branch of [
+      "gsd/quick/1-fix-typo",
+      "gsd/quick/42-some-long-slug-name",
+      "gsd/quick/99-a",
+    ]) {
+      // Create branch if it doesn't exist
+      try {
+        run(`git checkout -b ${branch}`, repo);
+      } catch {
+        run(`git checkout ${branch}`, repo);
+      }
+
+      const ctx: DispatchContext = {
+        basePath: repo,
+        mid: "M001",
+        midTitle: "Test milestone",
+        state: makeState("executing"),
+        prefs: undefined,
+      };
+
+      const result = await resolveDispatch(ctx);
+      assertEq(result.action, "stop", `stop on ${branch}`);
+
+      // Return to main for next iteration
+      run("git checkout main", repo);
+    }
+
+    rmSync(repo, { recursive: true, force: true });
+  }
+
+  report();
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## TL;DR

**What**: Add a branch guard so auto-mode refuses to dispatch milestone work when on a `gsd/quick/*` branch.
**Why**: Auto-mode silently committed milestone work onto quick-task branches, stranding commits and polluting git history (#2086).
**How**: First dispatch rule checks `QUICK_BRANCH_RE`; bootstrap calls `cleanupQuickBranch()` proactively.

## What

- Added `quick-branch-guard` as the **first** dispatch rule in `DISPATCH_RULES` (`auto-dispatch.ts`). When the current branch matches `gsd/quick/*`, `resolveDispatch` returns a `stop` action with a clear error message.
- Added a `cleanupQuickBranch()` call during `bootstrapAutoSession` (`auto-start.ts`) so auto-mode proactively merges quick work back and returns to the original branch before proceeding.

## Why

When `/gsd quick` created a branch and auto-mode resumed, milestone commits silently landed on the quick-task branch. This caused:
1. Milestone work stranded on a throwaway branch
2. Required manual `git cherry-pick` recovery via reflog
3. Squash-merge would attribute unrelated milestone commits to a quick task

Root cause: `auto-dispatch.ts`, `auto-start.ts`, and `auto.ts` had zero awareness of `gsd/quick/*` branches, and `cleanupQuickBranch()` was dead code (#1935).

## How

Two-layer defense:
1. **Dispatch guard** (`auto-dispatch.ts`): `quick-branch-guard` rule fires first, using the existing `QUICK_BRANCH_RE` regex and `getCurrentBranch()` to detect quick branches. Returns `stop` with level `error`.
2. **Bootstrap recovery** (`auto-start.ts`): Calls `cleanupQuickBranch(base)` early in `bootstrapAutoSession`. If a stale quick-return state exists on disk, the quick work is merged back and the checkout returns to the original branch — all before state derivation.

## Test plan

- [x] New test: `auto-dispatch-quick-branch-guard.test.ts` — 9 assertions covering rule existence, stop on quick branch, passthrough on main, and multiple branch patterns
- [x] Existing `quick-branch-lifecycle.test.ts` — all 26 assertions still pass
- [x] Full unit suite — 2696 pass, 0 fail
- [x] Type check passes


🤖 Generated with [Claude Code](https://claude.com/claude-code)