### PR TITLE
fix(web): resolve compiled .js modules when under node_modules

### DIFF
--- a/src/tests/web-node-modules-resolution.test.ts
+++ b/src/tests/web-node-modules-resolution.test.ts
@@ -1,0 +1,57 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+import { join } from "node:path"
+
+import { resolveSubprocessModule } from "../web/ts-subprocess-flags.ts"
+
+// ---------------------------------------------------------------------------
+// Reproduction test for #2081 — Web mode fails to start when installed
+// under node_modules (global npm install) on Node v24+.
+//
+// Node v24 refuses to handle .ts files under node_modules/ regardless of
+// --experimental-transform-types. The subprocess module resolver must
+// prefer compiled .js in dist/ when the package lives under node_modules/.
+// ---------------------------------------------------------------------------
+
+test("resolveSubprocessModule returns .ts source path when not under node_modules", () => {
+  const packageRoot = "/home/user/projects/gsd"
+  const result = resolveSubprocessModule(packageRoot, "resources/extensions/gsd/auto.ts", {
+    existsSync: () => true,
+  })
+  assert.equal(result, join(packageRoot, "src", "resources", "extensions", "gsd", "auto.ts"))
+})
+
+test("resolveSubprocessModule returns compiled .js path when under node_modules and dist exists", () => {
+  const packageRoot = "/usr/local/lib/node_modules/gsd-pi"
+  const distPath = join(packageRoot, "dist", "resources", "extensions", "gsd", "auto.js")
+  const result = resolveSubprocessModule(packageRoot, "resources/extensions/gsd/auto.ts", {
+    existsSync: (p: string) => p === distPath,
+  })
+  assert.equal(result, distPath)
+})
+
+test("resolveSubprocessModule falls back to .ts source when under node_modules but dist does not exist", () => {
+  const packageRoot = "/usr/local/lib/node_modules/gsd-pi"
+  const result = resolveSubprocessModule(packageRoot, "resources/extensions/gsd/auto.ts", {
+    existsSync: () => false,
+  })
+  assert.equal(result, join(packageRoot, "src", "resources", "extensions", "gsd", "auto.ts"))
+})
+
+test("resolveSubprocessModule handles Windows-style paths under node_modules", () => {
+  const packageRoot = "C:\\Users\\dev\\AppData\\node_modules\\gsd-pi"
+  const distPath = join(packageRoot, "dist", "resources", "extensions", "gsd", "auto.js")
+  const result = resolveSubprocessModule(packageRoot, "resources/extensions/gsd/auto.ts", {
+    existsSync: (p: string) => p === distPath,
+  })
+  assert.equal(result, distPath)
+})
+
+test("resolveSubprocessModule strips .ts extension and adds .js for dist path", () => {
+  const packageRoot = "/usr/lib/node_modules/gsd-pi"
+  const distPath = join(packageRoot, "dist", "resources", "extensions", "gsd", "visualizer-data.js")
+  const result = resolveSubprocessModule(packageRoot, "resources/extensions/gsd/visualizer-data.ts", {
+    existsSync: (p: string) => p === distPath,
+  })
+  assert.equal(result, distPath)
+})

--- a/src/web/auto-dashboard-service.ts
+++ b/src/web/auto-dashboard-service.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 
 import type { AutoDashboardData } from "./bridge-service.ts";
-import { resolveTypeStrippingFlag } from "./ts-subprocess-flags.ts"
+import { resolveTypeStrippingFlag, resolveSubprocessModule } from "./ts-subprocess-flags.ts"
 
 const AUTO_DASHBOARD_MAX_BUFFER = 1024 * 1024;
 const TEST_AUTO_DASHBOARD_MODULE_ENV = "GSD_WEB_TEST_AUTO_DASHBOARD_MODULE";
@@ -33,7 +33,7 @@ function fallbackAutoDashboardData(): AutoDashboardData {
 }
 
 function resolveAutoDashboardModulePath(packageRoot: string, env: NodeJS.ProcessEnv): string {
-  return env[TEST_AUTO_DASHBOARD_MODULE_ENV] || join(packageRoot, "src", "resources", "extensions", "gsd", "auto.ts");
+  return env[TEST_AUTO_DASHBOARD_MODULE_ENV] || resolveSubprocessModule(packageRoot, "resources/extensions/gsd/auto.ts");
 }
 
 function resolveTsLoaderPath(packageRoot: string): string {

--- a/src/web/bridge-service.ts
+++ b/src/web/bridge-service.ts
@@ -4,7 +4,7 @@ import { StringDecoder } from "node:string_decoder";
 import type { Readable } from "node:stream";
 import { join, resolve, dirname } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
-import { resolveTypeStrippingFlag } from "./ts-subprocess-flags.ts";
+import { resolveTypeStrippingFlag, resolveSubprocessModule } from "./ts-subprocess-flags.ts";
 
 import type { AgentSessionEvent, SessionStateChangeReason } from "../../packages/pi-coding-agent/src/core/agent-session.ts";
 import type {
@@ -906,7 +906,7 @@ async function loadCachedWorkspaceIndex(
 async function loadWorkspaceIndexViaChildProcess(basePath: string, packageRoot: string): Promise<GSDWorkspaceIndex> {
   const deps = getBridgeDeps();
   const resolveTsLoader = join(packageRoot, "src", "resources", "extensions", "gsd", "tests", "resolve-ts.mjs");
-  const workspaceModulePath = join(packageRoot, "src", "resources", "extensions", "gsd", "workspace-index.ts");
+  const workspaceModulePath = resolveSubprocessModule(packageRoot, "resources/extensions/gsd/workspace-index.ts");
   const checkExists = deps.existsSync ?? existsSync;
   if (!checkExists(resolveTsLoader) || !checkExists(workspaceModulePath)) {
     throw new Error(`workspace index loader not found; checked=${resolveTsLoader},${workspaceModulePath}`);

--- a/src/web/captures-service.ts
+++ b/src/web/captures-service.ts
@@ -4,14 +4,14 @@ import { join } from "node:path"
 import { pathToFileURL } from "node:url"
 
 import { resolveBridgeRuntimeConfig } from "./bridge-service.ts"
-import { resolveTypeStrippingFlag } from "./ts-subprocess-flags.ts"
+import { resolveTypeStrippingFlag, resolveSubprocessModule } from "./ts-subprocess-flags.ts"
 import type { CapturesData, CaptureResolveRequest, CaptureResolveResult } from "../../web/lib/knowledge-captures-types.ts"
 
 const CAPTURES_MAX_BUFFER = 2 * 1024 * 1024
 const CAPTURES_MODULE_ENV = "GSD_CAPTURES_MODULE"
 
 function resolveCapturesModulePath(packageRoot: string): string {
-  return join(packageRoot, "src", "resources", "extensions", "gsd", "captures.ts")
+  return resolveSubprocessModule(packageRoot, "resources/extensions/gsd/captures.ts")
 }
 
 function resolveTsLoaderPath(packageRoot: string): string {

--- a/src/web/cleanup-service.ts
+++ b/src/web/cleanup-service.ts
@@ -4,14 +4,14 @@ import { join } from "node:path"
 import { pathToFileURL } from "node:url"
 
 import { resolveBridgeRuntimeConfig } from "./bridge-service.ts"
-import { resolveTypeStrippingFlag } from "./ts-subprocess-flags.ts"
+import { resolveTypeStrippingFlag, resolveSubprocessModule } from "./ts-subprocess-flags.ts"
 import type { CleanupData, CleanupResult } from "../../web/lib/remaining-command-types.ts"
 
 const CLEANUP_MAX_BUFFER = 2 * 1024 * 1024
 const CLEANUP_MODULE_ENV = "GSD_CLEANUP_MODULE"
 
 function resolveCleanupModulePath(packageRoot: string): string {
-  return join(packageRoot, "src", "resources", "extensions", "gsd", "native-git-bridge.ts")
+  return resolveSubprocessModule(packageRoot, "resources/extensions/gsd/native-git-bridge.ts")
 }
 
 function resolveTsLoaderPath(packageRoot: string): string {

--- a/src/web/doctor-service.ts
+++ b/src/web/doctor-service.ts
@@ -4,14 +4,14 @@ import { join } from "node:path"
 import { pathToFileURL } from "node:url"
 
 import { resolveBridgeRuntimeConfig } from "./bridge-service.ts"
-import { resolveTypeStrippingFlag } from "./ts-subprocess-flags.ts"
+import { resolveTypeStrippingFlag, resolveSubprocessModule } from "./ts-subprocess-flags.ts"
 import type { DoctorReport, DoctorFixResult } from "../../web/lib/diagnostics-types.ts"
 
 const DOCTOR_MAX_BUFFER = 2 * 1024 * 1024
 const DOCTOR_MODULE_ENV = "GSD_DOCTOR_MODULE"
 
 function resolveDoctorModulePath(packageRoot: string): string {
-  return join(packageRoot, "src", "resources", "extensions", "gsd", "doctor.ts")
+  return resolveSubprocessModule(packageRoot, "resources/extensions/gsd/doctor.ts")
 }
 
 function resolveTsLoaderPath(packageRoot: string): string {

--- a/src/web/export-service.ts
+++ b/src/web/export-service.ts
@@ -4,14 +4,14 @@ import { join } from "node:path"
 import { pathToFileURL } from "node:url"
 
 import { resolveBridgeRuntimeConfig } from "./bridge-service.ts"
-import { resolveTypeStrippingFlag } from "./ts-subprocess-flags.ts"
+import { resolveTypeStrippingFlag, resolveSubprocessModule } from "./ts-subprocess-flags.ts"
 import type { ExportResult } from "../../web/lib/remaining-command-types.ts"
 
 const EXPORT_MAX_BUFFER = 4 * 1024 * 1024
 const EXPORT_MODULE_ENV = "GSD_EXPORT_MODULE"
 
 function resolveExportModulePath(packageRoot: string): string {
-  return join(packageRoot, "src", "resources", "extensions", "gsd", "export.ts")
+  return resolveSubprocessModule(packageRoot, "resources/extensions/gsd/export.ts")
 }
 
 function resolveTsLoaderPath(packageRoot: string): string {

--- a/src/web/forensics-service.ts
+++ b/src/web/forensics-service.ts
@@ -4,14 +4,14 @@ import { join } from "node:path"
 import { pathToFileURL } from "node:url"
 
 import { resolveBridgeRuntimeConfig } from "./bridge-service.ts"
-import { resolveTypeStrippingFlag } from "./ts-subprocess-flags.ts"
+import { resolveTypeStrippingFlag, resolveSubprocessModule } from "./ts-subprocess-flags.ts"
 import type { ForensicReport } from "../../web/lib/diagnostics-types.ts"
 
 const FORENSICS_MAX_BUFFER = 2 * 1024 * 1024
 const FORENSICS_MODULE_ENV = "GSD_FORENSICS_MODULE"
 
 function resolveForensicsModulePath(packageRoot: string): string {
-  return join(packageRoot, "src", "resources", "extensions", "gsd", "forensics.ts")
+  return resolveSubprocessModule(packageRoot, "resources/extensions/gsd/forensics.ts")
 }
 
 function resolveTsLoaderPath(packageRoot: string): string {

--- a/src/web/history-service.ts
+++ b/src/web/history-service.ts
@@ -4,14 +4,14 @@ import { join } from "node:path"
 import { pathToFileURL } from "node:url"
 
 import { resolveBridgeRuntimeConfig } from "./bridge-service.ts"
-import { resolveTypeStrippingFlag } from "./ts-subprocess-flags.ts"
+import { resolveTypeStrippingFlag, resolveSubprocessModule } from "./ts-subprocess-flags.ts"
 import type { HistoryData } from "../../web/lib/remaining-command-types.ts"
 
 const HISTORY_MAX_BUFFER = 2 * 1024 * 1024
 const HISTORY_MODULE_ENV = "GSD_HISTORY_MODULE"
 
 function resolveHistoryModulePath(packageRoot: string): string {
-  return join(packageRoot, "src", "resources", "extensions", "gsd", "metrics.ts")
+  return resolveSubprocessModule(packageRoot, "resources/extensions/gsd/metrics.ts")
 }
 
 function resolveTsLoaderPath(packageRoot: string): string {

--- a/src/web/hooks-service.ts
+++ b/src/web/hooks-service.ts
@@ -4,14 +4,14 @@ import { join } from "node:path"
 import { pathToFileURL } from "node:url"
 
 import { resolveBridgeRuntimeConfig } from "./bridge-service.ts"
-import { resolveTypeStrippingFlag } from "./ts-subprocess-flags.ts"
+import { resolveTypeStrippingFlag, resolveSubprocessModule } from "./ts-subprocess-flags.ts"
 import type { HooksData } from "../../web/lib/remaining-command-types.ts"
 
 const HOOKS_MAX_BUFFER = 512 * 1024
 const HOOKS_MODULE_ENV = "GSD_HOOKS_MODULE"
 
 function resolveHooksModulePath(packageRoot: string): string {
-  return join(packageRoot, "src", "resources", "extensions", "gsd", "post-unit-hooks.ts")
+  return resolveSubprocessModule(packageRoot, "resources/extensions/gsd/post-unit-hooks.ts")
 }
 
 function resolveTsLoaderPath(packageRoot: string): string {

--- a/src/web/recovery-diagnostics-service.ts
+++ b/src/web/recovery-diagnostics-service.ts
@@ -8,7 +8,7 @@ import {
   collectSelectiveLiveStatePayload,
   resolveBridgeRuntimeConfig,
 } from "./bridge-service.ts"
-import { resolveTypeStrippingFlag } from "./ts-subprocess-flags.ts"
+import { resolveTypeStrippingFlag, resolveSubprocessModule } from "./ts-subprocess-flags.ts"
 import type {
   WorkspaceRecoveryBrowserAction,
   WorkspaceRecoveryCodeSummary,
@@ -361,11 +361,11 @@ function resolveTsLoaderPath(packageRoot: string): string {
 }
 
 function resolveDoctorModulePath(packageRoot: string): string {
-  return join(packageRoot, "src", "resources", "extensions", "gsd", "doctor.ts")
+  return resolveSubprocessModule(packageRoot, "resources/extensions/gsd/doctor.ts")
 }
 
 function resolveSessionForensicsModulePath(packageRoot: string): string {
-  return join(packageRoot, "src", "resources", "extensions", "gsd", "session-forensics.ts")
+  return resolveSubprocessModule(packageRoot, "resources/extensions/gsd/session-forensics.ts")
 }
 
 async function collectRecoveryDiagnosticsChildPayload(

--- a/src/web/settings-service.ts
+++ b/src/web/settings-service.ts
@@ -4,13 +4,13 @@ import { join } from "node:path"
 import { pathToFileURL } from "node:url"
 
 import { resolveBridgeRuntimeConfig } from "./bridge-service.ts"
-import { resolveTypeStrippingFlag } from "./ts-subprocess-flags.ts"
+import { resolveTypeStrippingFlag, resolveSubprocessModule } from "./ts-subprocess-flags.ts"
 import type { SettingsData } from "../../web/lib/settings-types.ts"
 
 const SETTINGS_MAX_BUFFER = 2 * 1024 * 1024
 
 function resolveModulePath(packageRoot: string, moduleName: string): string {
-  return join(packageRoot, "src", "resources", "extensions", "gsd", moduleName)
+  return resolveSubprocessModule(packageRoot, `resources/extensions/gsd/${moduleName}`)
 }
 
 function resolveTsLoaderPath(packageRoot: string): string {

--- a/src/web/skill-health-service.ts
+++ b/src/web/skill-health-service.ts
@@ -4,14 +4,14 @@ import { join } from "node:path"
 import { pathToFileURL } from "node:url"
 
 import { resolveBridgeRuntimeConfig } from "./bridge-service.ts"
-import { resolveTypeStrippingFlag } from "./ts-subprocess-flags.ts"
+import { resolveTypeStrippingFlag, resolveSubprocessModule } from "./ts-subprocess-flags.ts"
 import type { SkillHealthReport } from "../../web/lib/diagnostics-types.ts"
 
 const SKILL_HEALTH_MAX_BUFFER = 2 * 1024 * 1024
 const SKILL_HEALTH_MODULE_ENV = "GSD_SKILL_HEALTH_MODULE"
 
 function resolveSkillHealthModulePath(packageRoot: string): string {
-  return join(packageRoot, "src", "resources", "extensions", "gsd", "skill-health.ts")
+  return resolveSubprocessModule(packageRoot, "resources/extensions/gsd/skill-health.ts")
 }
 
 function resolveTsLoaderPath(packageRoot: string): string {

--- a/src/web/ts-subprocess-flags.ts
+++ b/src/web/ts-subprocess-flags.ts
@@ -1,3 +1,6 @@
+import { existsSync as fsExistsSync } from "node:fs"
+import { join } from "node:path"
+
 /**
  * Returns the correct Node.js type-stripping flag for subprocess spawning.
  *
@@ -7,9 +10,9 @@
  * `--experimental-strip-types` fails deterministically.
  *
  * `--experimental-transform-types` applies a full TypeScript transform that
- * works regardless of whether the file is under `node_modules/`. On older
- * Node versions (< 22.7) that lack both flags, this falls back to
- * `--experimental-strip-types` (the caller's loader handles the rest).
+ * bypasses the restriction on older Node versions (22.7–23.x). On Node v24+
+ * where type stripping is stable, the restriction is absolute — use
+ * {@link resolveSubprocessModule} to resolve to compiled .js instead.
  */
 export function resolveTypeStrippingFlag(packageRoot: string): string {
   const needsTransform =
@@ -17,6 +20,44 @@ export function resolveTypeStrippingFlag(packageRoot: string): string {
   return needsTransform
     ? "--experimental-transform-types"
     : "--experimental-strip-types"
+}
+
+export interface ResolveSubprocessModuleOptions {
+  existsSync?: (path: string) => boolean
+}
+
+/**
+ * Resolves a subprocess module path, preferring the compiled .js equivalent
+ * under `dist/` when the package is installed inside `node_modules/`.
+ *
+ * Node v24 unconditionally refuses to handle .ts files under `node_modules/`
+ * (ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING), even with
+ * `--experimental-transform-types`. When GSD is installed globally via npm
+ * the source .ts files live under `node_modules/gsd-pi/src/...`, so
+ * subprocess invocations must use the compiled output in `dist/` instead.
+ *
+ * @param packageRoot - Absolute path to the package root directory.
+ * @param relPath     - Path relative to `src/` (e.g. "resources/extensions/gsd/auto.ts").
+ * @param options     - Optional overrides (primarily for testing).
+ * @returns Absolute path to either `dist/<relPath>.js` or `src/<relPath>`.
+ */
+export function resolveSubprocessModule(
+  packageRoot: string,
+  relPath: string,
+  options: ResolveSubprocessModuleOptions = {},
+): string {
+  const checkExists = options.existsSync ?? fsExistsSync
+  const srcPath = join(packageRoot, "src", relPath)
+
+  if (isUnderNodeModules(packageRoot)) {
+    const jsRelPath = relPath.replace(/\.ts$/, ".js")
+    const distPath = join(packageRoot, "dist", jsRelPath)
+    if (checkExists(distPath)) {
+      return distPath
+    }
+  }
+
+  return srcPath
 }
 
 /**

--- a/src/web/undo-service.ts
+++ b/src/web/undo-service.ts
@@ -4,7 +4,7 @@ import { join } from "node:path"
 import { pathToFileURL } from "node:url"
 
 import { resolveBridgeRuntimeConfig } from "./bridge-service.ts"
-import { resolveTypeStrippingFlag } from "./ts-subprocess-flags.ts"
+import { resolveTypeStrippingFlag, resolveSubprocessModule } from "./ts-subprocess-flags.ts"
 import type { UndoInfo, UndoResult } from "../../web/lib/remaining-command-types.ts"
 
 const UNDO_MAX_BUFFER = 2 * 1024 * 1024
@@ -12,11 +12,11 @@ const UNDO_MODULE_ENV = "GSD_UNDO_MODULE"
 const PATHS_MODULE_ENV = "GSD_PATHS_MODULE"
 
 function resolveUndoModulePath(packageRoot: string): string {
-  return join(packageRoot, "src", "resources", "extensions", "gsd", "undo.ts")
+  return resolveSubprocessModule(packageRoot, "resources/extensions/gsd/undo.ts")
 }
 
 function resolvePathsModulePath(packageRoot: string): string {
-  return join(packageRoot, "src", "resources", "extensions", "gsd", "paths.ts")
+  return resolveSubprocessModule(packageRoot, "resources/extensions/gsd/paths.ts")
 }
 
 function resolveTsLoaderPath(packageRoot: string): string {

--- a/src/web/visualizer-service.ts
+++ b/src/web/visualizer-service.ts
@@ -4,7 +4,7 @@ import { join } from "node:path"
 import { pathToFileURL } from "node:url"
 
 import { resolveBridgeRuntimeConfig } from "./bridge-service.ts"
-import { resolveTypeStrippingFlag } from "./ts-subprocess-flags.ts"
+import { resolveTypeStrippingFlag, resolveSubprocessModule } from "./ts-subprocess-flags.ts"
 
 const VISUALIZER_MAX_BUFFER = 2 * 1024 * 1024
 const VISUALIZER_MODULE_ENV = "GSD_VISUALIZER_MODULE"
@@ -36,7 +36,7 @@ export interface SerializedVisualizerData {
 }
 
 function resolveVisualizerModulePath(packageRoot: string): string {
-  return join(packageRoot, "src", "resources", "extensions", "gsd", "visualizer-data.ts")
+  return resolveSubprocessModule(packageRoot, "resources/extensions/gsd/visualizer-data.ts")
 }
 
 function resolveTsLoaderPath(packageRoot: string): string {


### PR DESCRIPTION
## TL;DR

**What**: Web services now resolve to compiled `dist/*.js` modules instead of `src/*.ts` sources when the package lives under `node_modules/`.
**Why**: Node v24 unconditionally refuses `.ts` files under `node_modules/`, breaking `gsd --web` for global npm installs.
**How**: New `resolveSubprocessModule()` utility in `ts-subprocess-flags.ts` + updated all 14 web service module resolvers.

## What

- Added `resolveSubprocessModule(packageRoot, relPath)` to `src/web/ts-subprocess-flags.ts`
- When `packageRoot` contains `/node_modules/`, it checks for `dist/<relPath>.js` and returns that if it exists
- Falls back to `src/<relPath>` when not under `node_modules/` or when the compiled file is absent
- Updated module path resolution in: `auto-dashboard-service`, `bridge-service`, `captures-service`, `cleanup-service`, `doctor-service`, `export-service`, `forensics-service`, `history-service`, `hooks-service`, `recovery-diagnostics-service`, `settings-service`, `skill-health-service`, `undo-service`, `visualizer-service`

## Why

Node v24 made type stripping stable and simultaneously enforces `ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING` for **all** `.ts` files under `node_modules/` — even with `--experimental-transform-types`. When GSD is installed globally via `npm install -g`, every subprocess that loads a `.ts` extension module crashes, preventing web mode from starting (100% repro on Node v24+).

## How

The existing `resolveTypeStrippingFlag()` correctly selects `--experimental-transform-types` for Node 22.7–23.x under `node_modules/`, but that flag no longer bypasses the restriction in v24. Rather than adding yet another flag-based workaround, the fix uses the compiled `.js` output that `npm run build` already produces in `dist/`. This is the same strategy `cli-entry.ts` uses for `packaged-standalone` host kinds.

## Test plan

- [x] New `web-node-modules-resolution.test.ts` with 5 cases covering: non-node_modules path, node_modules with dist, node_modules without dist, Windows paths, different module names
- [x] Existing `web-boot-node24.test.ts` still passes
- [x] Existing `web-cli-entry.test.ts` still passes
- [x] `tsc --noEmit` passes

Fixes #2081

🤖 Generated with [Claude Code](https://claude.com/claude-code)