### PR TITLE
fix(auto): reconcile completed-units on boot, fix doctor severity

### DIFF
--- a/src/resources/extensions/gsd/auto-recovery.ts
+++ b/src/resources/extensions/gsd/auto-recovery.ts
@@ -37,6 +37,7 @@ import {
   resolveMilestoneFile,
   clearPathCache,
   resolveGsdRootFile,
+  gsdRoot,
 } from "./paths.js";
 import { markSliceDoneInRoadmap } from "./roadmap-mutations.js";
 import {
@@ -790,4 +791,105 @@ export function buildLoopRemediationSteps(
       break;
   }
   return null;
+}
+
+// ─── Completed-Units Reconciliation ────────────────────────────────────────────
+
+/**
+ * Unit types that have verifiable artifacts on disk. Used by
+ * reconcileCompletedUnits to scan for crash-gap orphans.
+ */
+const RECONCILABLE_SLICE_UNIT_TYPES = [
+  "research-slice",
+  "plan-slice",
+] as const;
+
+const RECONCILABLE_MILESTONE_UNIT_TYPES = [
+  "discuss-milestone",
+  "research-milestone",
+  "plan-milestone",
+] as const;
+
+/**
+ * Reconcile completed-units.json against on-disk artifacts for a milestone.
+ *
+ * When a session terminates between artifact write and the completed-units
+ * flush, the unit is absent from completed-units.json despite its artifact
+ * existing on disk. On restart, deriveState re-derives the unit as needing
+ * dispatch, causing duplicate work or state mismatches (#2076).
+ *
+ * This function scans known unit types for the given milestone, calls
+ * verifyExpectedArtifact for each, and retroactively adds confirmed units
+ * to completed-units.json.
+ *
+ * Returns the list of newly reconciled unit entries.
+ */
+export function reconcileCompletedUnits(
+  basePath: string,
+  milestoneId: string,
+): Array<{ type: string; id: string }> {
+  // Read existing completed-units from disk
+  const completedKeysPath = join(gsdRoot(basePath), "completed-units.json");
+  let existingKeys: string[] = [];
+  try {
+    if (existsSync(completedKeysPath)) {
+      existingKeys = JSON.parse(readFileSync(completedKeysPath, "utf-8"));
+    }
+  } catch {
+    // Malformed or missing — start fresh
+  }
+  const existingSet = new Set(existingKeys);
+
+  const added: Array<{ type: string; id: string }> = [];
+
+  // Scan milestone-level unit types
+  for (const unitType of RECONCILABLE_MILESTONE_UNIT_TYPES) {
+    const key = `${unitType}/${milestoneId}`;
+    if (existingSet.has(key)) continue;
+    if (verifyExpectedArtifact(unitType, milestoneId, basePath)) {
+      added.push({ type: unitType, id: milestoneId });
+      existingKeys.push(key);
+      existingSet.add(key);
+    }
+  }
+
+  // Scan slice-level unit types
+  const milestonePath = resolveMilestonePath(basePath, milestoneId);
+  if (!milestonePath) return added;
+
+  const roadmapFile = resolveMilestoneFile(basePath, milestoneId, "ROADMAP");
+  if (!roadmapFile) return added;
+
+  let roadmapContent: string;
+  try {
+    roadmapContent = readFileSync(roadmapFile, "utf-8");
+  } catch {
+    return added;
+  }
+
+  const roadmap = parseRoadmap(roadmapContent);
+  if (!roadmap) return added;
+
+  for (const slice of roadmap.slices) {
+    const unitId = `${milestoneId}/${slice.id}`;
+
+    for (const unitType of RECONCILABLE_SLICE_UNIT_TYPES) {
+      const key = `${unitType}/${unitId}`;
+      if (existingSet.has(key)) continue;
+      if (verifyExpectedArtifact(unitType, unitId, basePath)) {
+        added.push({ type: unitType, id: unitId });
+        existingKeys.push(key);
+        existingSet.add(key);
+      }
+    }
+  }
+
+  // Persist reconciled entries to disk
+  if (added.length > 0) {
+    try {
+      atomicWriteSync(completedKeysPath, JSON.stringify(existingKeys, null, 2));
+    } catch { /* non-fatal: disk flush failure */ }
+  }
+
+  return added;
 }

--- a/src/resources/extensions/gsd/auto-start.ts
+++ b/src/resources/extensions/gsd/auto-start.ts
@@ -57,6 +57,7 @@ import { initMetrics } from "./metrics.js";
 import { initRoutingHistory } from "./routing-history.js";
 import { restoreHookState, resetHookState } from "./post-unit-hooks.js";
 import { resetProactiveHealing, setLevelChangeCallback } from "./doctor-proactive.js";
+import { reconcileCompletedUnits } from "./auto-recovery.js";
 import { snapshotSkills } from "./skill-discovery.js";
 import { isDbAvailable } from "./gsd-db.js";
 import { hideFooter } from "./auto-dashboard.js";
@@ -480,6 +481,30 @@ export async function bootstrapAutoSession(
     s.currentMilestoneId = state.activeMilestone?.id ?? null;
     s.originalModelId = ctx.model?.id ?? null;
     s.originalModelProvider = ctx.model?.provider ?? null;
+
+    // Reconcile completed-units: if a prior session crashed between artifact
+    // write and completed-units flush, retroactively add confirmed units (#2076).
+    if (s.currentMilestoneId) {
+      try {
+        const reconciled = reconcileCompletedUnits(base, s.currentMilestoneId);
+        if (reconciled.length > 0) {
+          for (const u of reconciled) {
+            s.completedUnits.push({
+              type: u.type,
+              id: u.id,
+              startedAt: 0,
+              finishedAt: 0,
+            });
+          }
+          ctx.ui.notify(
+            `Reconciled ${reconciled.length} completed unit${reconciled.length === 1 ? "" : "s"} from on-disk artifacts.`,
+            "info",
+          );
+        }
+      } catch {
+        // Non-fatal — reconciliation is best-effort
+      }
+    }
 
     // Register SIGTERM handler
     registerSigtermHandler(base);

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -85,7 +85,7 @@ import {
 } from "./auto-observability.js";
 import { closeoutUnit } from "./auto-unit-closeout.js";
 import { recoverTimedOutUnit } from "./auto-timeout-recovery.js";
-import { selfHealRuntimeRecords } from "./auto-recovery.js";
+import { selfHealRuntimeRecords, reconcileCompletedUnits } from "./auto-recovery.js";
 import { selectAndApplyModel, resolveModelId } from "./auto-model-selection.js";
 import {
   syncProjectRootToWorktree,
@@ -1095,6 +1095,30 @@ export async function startAuto(
     s.unitLifetimeDispatches.clear();
     if (!getLedger()) initMetrics(base);
     if (s.currentMilestoneId) setActiveMilestoneId(base, s.currentMilestoneId);
+
+    // Reconcile completed-units: if a prior session crashed between artifact
+    // write and completed-units flush, retroactively add confirmed units (#2076).
+    if (s.currentMilestoneId) {
+      try {
+        const reconciled = reconcileCompletedUnits(base, s.currentMilestoneId);
+        if (reconciled.length > 0) {
+          for (const u of reconciled) {
+            s.completedUnits.push({
+              type: u.type,
+              id: u.id,
+              startedAt: 0,
+              finishedAt: 0,
+            });
+          }
+          ctx.ui.notify(
+            `Reconciled ${reconciled.length} completed unit${reconciled.length === 1 ? "" : "s"} from on-disk artifacts.`,
+            "info",
+          );
+        }
+      } catch {
+        // Non-fatal — reconciliation is best-effort
+      }
+    }
 
     // ── Auto-worktree: re-enter worktree on resume ──
     if (

--- a/src/resources/extensions/gsd/doctor.ts
+++ b/src/resources/extensions/gsd/doctor.ts
@@ -668,6 +668,11 @@ export async function runGSDDoctor(basePath: string, options?: { fix?: boolean; 
       }
     } catch { /* non-fatal */ }
 
+    // Determine the first non-done slice — this is the "active" slice.
+    // Slices after it in the roadmap ordering are "future" and should not
+    // inflate error counts for missing directories (#2076).
+    const firstNonDoneSliceId = roadmap.slices.find(s => !s.done)?.id ?? null;
+
     for (const slice of roadmap.slices) {
       const unitId = `${milestoneId}/${slice.id}`;
       if (options?.scope && !matchesScope(unitId, options.scope) && options.scope !== milestoneId) continue;
@@ -708,8 +713,20 @@ export async function runGSDDoctor(basePath: string, options?: { fix?: boolean; 
       const slicePath = resolveSlicePath(basePath, milestoneId, slice.id);
       if (!slicePath) {
         const expectedPath = relSlicePath(basePath, milestoneId, slice.id);
+        // Severity logic (#2076): done slices → "warning" (cosmetic).
+        // The first non-done slice (active) → "error" (blocking).
+        // Future non-done slices (not yet started) → "info" (directories
+        // are created by ensurePreconditions on first dispatch).
+        let severity: "error" | "warning" | "info";
+        if (slice.done) {
+          severity = "warning";
+        } else if (firstNonDoneSliceId === slice.id) {
+          severity = "error";
+        } else {
+          severity = "info";
+        }
         issues.push({
-          severity: slice.done ? "warning" : "error",
+          severity,
           code: "missing_slice_dir",
           scope: "slice",
           unitId,

--- a/src/resources/extensions/gsd/tests/doctor-missing-slice-dir-severity.test.ts
+++ b/src/resources/extensions/gsd/tests/doctor-missing-slice-dir-severity.test.ts
@@ -1,0 +1,134 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomUUID } from "node:crypto";
+
+import { runGSDDoctor } from "../doctor.ts";
+import { clearParseCache } from "../files.ts";
+import { clearPathCache } from "../paths.ts";
+import { invalidateAllCaches } from "../cache.ts";
+
+function makeTmpBase(): string {
+  const base = join(tmpdir(), `gsd-doctor-severity-${randomUUID()}`);
+  mkdirSync(join(base, ".gsd", "milestones", "M001"), { recursive: true });
+  return base;
+}
+
+function cleanup(base: string): void {
+  try { rmSync(base, { recursive: true, force: true }); } catch { /* */ }
+}
+
+// ─── Reproduction: missing_slice_dir severity for future (not-yet-started) slices ───
+
+test("missing_slice_dir for slices ahead of active slice should NOT be 'error'", async () => {
+  const base = makeTmpBase();
+  try {
+    clearPathCache();
+    clearParseCache();
+    invalidateAllCaches();
+
+    const mDir = join(base, ".gsd", "milestones", "M001");
+
+    // S01 is done, S02-S05 have no directories yet (normal forward state)
+    writeFileSync(join(mDir, "M001-ROADMAP.md"), `# M001: Test Milestone
+
+## Slices
+- [x] **S01: First Slice** \`risk:low\` \`depends:[]\`
+  > After this: S01 works
+- [ ] **S02: Second Slice** \`risk:low\` \`depends:[S01]\`
+  > After this: S02 works
+- [ ] **S03: Third Slice** \`risk:low\` \`depends:[S01]\`
+  > After this: S03 works
+- [ ] **S04: Fourth Slice** \`risk:low\` \`depends:[S02]\`
+  > After this: S04 works
+- [ ] **S05: Fifth Slice** \`risk:low\` \`depends:[S03]\`
+  > After this: S05 works
+`);
+
+    // Only S01 has a directory (it's the active/done one)
+    mkdirSync(join(mDir, "slices", "S01", "tasks"), { recursive: true });
+
+    const report = await runGSDDoctor(base, { fix: false, scope: "M001" });
+
+    const missingDirIssues = report.issues.filter(i => i.code === "missing_slice_dir");
+    assert.ok(missingDirIssues.length >= 4, `should have missing_slice_dir issues for S02-S05, got ${missingDirIssues.length}`);
+
+    // S02 is the first non-done slice (the "active" one) — it should be "error"
+    const s02 = missingDirIssues.find(i => i.unitId === "M001/S02");
+    assert.ok(s02, "should have missing_slice_dir for S02");
+    assert.equal(s02!.severity, "error", "active slice S02 missing dir should be error");
+
+    // S03-S05 are future slices — they should NOT be "error"
+    for (const sid of ["S03", "S04", "S05"]) {
+      const issue = missingDirIssues.find(i => i.unitId === `M001/${sid}`);
+      assert.ok(issue, `should have missing_slice_dir for ${sid}`);
+      assert.notEqual(
+        issue!.severity,
+        "error",
+        `future slice ${sid} missing dir should not be error severity (got: ${issue!.severity})`,
+      );
+    }
+  } finally {
+    cleanup(base);
+  }
+});
+
+test("missing_slice_dir for the first non-done slice should remain 'error'", async () => {
+  const base = makeTmpBase();
+  try {
+    clearPathCache();
+    clearParseCache();
+    invalidateAllCaches();
+
+    const mDir = join(base, ".gsd", "milestones", "M001");
+
+    writeFileSync(join(mDir, "M001-ROADMAP.md"), `# M001: Test Milestone
+
+## Slices
+- [x] **S01: First Slice** \`risk:low\` \`depends:[]\`
+  > After this: S01 works
+- [ ] **S02: Active Slice** \`risk:low\` \`depends:[S01]\`
+  > After this: S02 works
+`);
+
+    mkdirSync(join(mDir, "slices", "S01", "tasks"), { recursive: true });
+    // S02 directory is missing
+
+    const report = await runGSDDoctor(base, { fix: false, scope: "M001" });
+
+    const s02Issue = report.issues.find(i => i.code === "missing_slice_dir" && i.unitId === "M001/S02");
+    assert.ok(s02Issue, "should detect missing_slice_dir for S02");
+    assert.equal(s02Issue!.severity, "error", "first non-done slice missing dir should be error");
+  } finally {
+    cleanup(base);
+  }
+});
+
+test("missing_slice_dir for done slices should be 'warning' (not 'error')", async () => {
+  const base = makeTmpBase();
+  try {
+    clearPathCache();
+    clearParseCache();
+    invalidateAllCaches();
+
+    const mDir = join(base, ".gsd", "milestones", "M001");
+
+    // S01 is marked done but has no directory (edge case)
+    writeFileSync(join(mDir, "M001-ROADMAP.md"), `# M001: Test Milestone
+
+## Slices
+- [x] **S01: Done Slice** \`risk:low\` \`depends:[]\`
+  > After this: S01 works
+`);
+
+    const report = await runGSDDoctor(base, { fix: false, scope: "M001" });
+
+    const s01Issue = report.issues.find(i => i.code === "missing_slice_dir" && i.unitId === "M001/S01");
+    assert.ok(s01Issue, "should detect missing_slice_dir for done S01");
+    assert.equal(s01Issue!.severity, "warning", "done slice missing dir should be warning");
+  } finally {
+    cleanup(base);
+  }
+});

--- a/src/resources/extensions/gsd/tests/reconcile-completed-units.test.ts
+++ b/src/resources/extensions/gsd/tests/reconcile-completed-units.test.ts
@@ -1,0 +1,169 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, writeFileSync, readFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomUUID } from "node:crypto";
+
+import { reconcileCompletedUnits } from "../auto-recovery.ts";
+import { clearPathCache } from "../paths.ts";
+import { clearParseCache } from "../files.ts";
+import { invalidateAllCaches } from "../cache.ts";
+
+function makeTmpBase(): string {
+  const base = join(tmpdir(), `gsd-reconcile-${randomUUID()}`);
+  mkdirSync(join(base, ".gsd", "milestones", "M001", "slices", "S01", "tasks"), { recursive: true });
+  return base;
+}
+
+function cleanup(base: string): void {
+  try { rmSync(base, { recursive: true, force: true }); } catch { /* */ }
+}
+
+function writeRoadmap(base: string, slices: string): void {
+  const mDir = join(base, ".gsd", "milestones", "M001");
+  writeFileSync(join(mDir, "M001-ROADMAP.md"), `# M001: Test Milestone\n\n## Slices\n${slices}\n`);
+}
+
+function writeCompletedUnits(base: string, keys: string[]): void {
+  writeFileSync(join(base, ".gsd", "completed-units.json"), JSON.stringify(keys, null, 2));
+}
+
+function readCompletedUnits(base: string): string[] {
+  return JSON.parse(readFileSync(join(base, ".gsd", "completed-units.json"), "utf-8"));
+}
+
+// ─── Reproduction: artifact exists but unit missing from completed-units ───
+
+test("reconcileCompletedUnits adds plan-slice when artifact exists but not in completed-units", () => {
+  const base = makeTmpBase();
+  try {
+    clearPathCache();
+    clearParseCache();
+    invalidateAllCaches();
+
+    writeRoadmap(base, `- [ ] **S01: Demo** \`risk:low\` \`depends:[]\`\n  > After this: demo`);
+
+    // Write the plan-slice artifact (S01-PLAN.md) + task plan — simulates crash after write
+    const sDir = join(base, ".gsd", "milestones", "M001", "slices", "S01");
+    writeFileSync(join(sDir, "S01-PLAN.md"), "# S01: Plan\n\n## Tasks\n- [ ] **T01: Do thing** `est:10m`\n");
+    writeFileSync(join(sDir, "tasks", "T01-PLAN.md"), "# T01: Do thing\n\nPlan details.\n");
+
+    // completed-units.json only has research — plan-slice is missing (crash gap)
+    writeCompletedUnits(base, ["research-slice/M001/S01"]);
+
+    const added = reconcileCompletedUnits(base, "M001");
+
+    assert.ok(added.length > 0, "should have reconciled at least one unit");
+    assert.ok(
+      added.some(u => u.type === "plan-slice" && u.id === "M001/S01"),
+      "should reconcile plan-slice/M001/S01",
+    );
+
+    // Verify it was persisted to disk
+    const persisted = readCompletedUnits(base);
+    assert.ok(persisted.includes("plan-slice/M001/S01"), "plan-slice should be in persisted file");
+    assert.ok(persisted.includes("research-slice/M001/S01"), "existing entries should be preserved");
+  } finally {
+    cleanup(base);
+  }
+});
+
+test("reconcileCompletedUnits does not duplicate existing entries", () => {
+  const base = makeTmpBase();
+  try {
+    clearPathCache();
+    clearParseCache();
+    invalidateAllCaches();
+
+    writeRoadmap(base, `- [ ] **S01: Demo** \`risk:low\` \`depends:[]\`\n  > After this: demo`);
+
+    const sDir = join(base, ".gsd", "milestones", "M001", "slices", "S01");
+    writeFileSync(join(sDir, "S01-PLAN.md"), "# S01: Plan\n\n## Tasks\n- [ ] **T01: Do thing** `est:10m`\n");
+    writeFileSync(join(sDir, "tasks", "T01-PLAN.md"), "# T01: Do thing\n\nPlan details.\n");
+
+    // plan-slice and plan-milestone are already in completed-units
+    writeCompletedUnits(base, ["research-slice/M001/S01", "plan-slice/M001/S01", "plan-milestone/M001"]);
+
+    const added = reconcileCompletedUnits(base, "M001");
+
+    assert.equal(added.length, 0, "should not add duplicates");
+    const persisted = readCompletedUnits(base);
+    const planCount = persisted.filter(k => k === "plan-slice/M001/S01").length;
+    assert.equal(planCount, 1, "no duplicate entries in persisted file");
+  } finally {
+    cleanup(base);
+  }
+});
+
+test("reconcileCompletedUnits returns empty when no slice artifacts exist on disk", () => {
+  const base = makeTmpBase();
+  try {
+    clearPathCache();
+    clearParseCache();
+    invalidateAllCaches();
+
+    writeRoadmap(base, `- [ ] **S01: Demo** \`risk:low\` \`depends:[]\`\n  > After this: demo`);
+
+    // The roadmap itself exists (plan-milestone artifact), so mark it already completed.
+    // No slice-level artifacts exist — nothing else to reconcile.
+    writeCompletedUnits(base, ["plan-milestone/M001"]);
+
+    const added = reconcileCompletedUnits(base, "M001");
+
+    // Should not reconcile any slice-level units (no S01-RESEARCH.md, no S01-PLAN.md, etc.)
+    const sliceUnits = added.filter(u => u.id.includes("/"));
+    assert.equal(sliceUnits.length, 0, "no slice artifacts to reconcile");
+  } finally {
+    cleanup(base);
+  }
+});
+
+test("reconcileCompletedUnits reconciles research-slice artifact", () => {
+  const base = makeTmpBase();
+  try {
+    clearPathCache();
+    clearParseCache();
+    invalidateAllCaches();
+
+    writeRoadmap(base, `- [ ] **S01: Demo** \`risk:low\` \`depends:[]\`\n  > After this: demo`);
+
+    const sDir = join(base, ".gsd", "milestones", "M001", "slices", "S01");
+    writeFileSync(join(sDir, "S01-RESEARCH.md"), "# S01: Research\n\nFindings here.\n");
+
+    writeCompletedUnits(base, []);
+
+    const added = reconcileCompletedUnits(base, "M001");
+
+    assert.ok(
+      added.some(u => u.type === "research-slice" && u.id === "M001/S01"),
+      "should reconcile research-slice/M001/S01",
+    );
+  } finally {
+    cleanup(base);
+  }
+});
+
+test("reconcileCompletedUnits handles missing completed-units.json gracefully", () => {
+  const base = makeTmpBase();
+  try {
+    clearPathCache();
+    clearParseCache();
+    invalidateAllCaches();
+
+    writeRoadmap(base, `- [ ] **S01: Demo** \`risk:low\` \`depends:[]\`\n  > After this: demo`);
+
+    const sDir = join(base, ".gsd", "milestones", "M001", "slices", "S01");
+    writeFileSync(join(sDir, "S01-PLAN.md"), "# S01: Plan\n\n## Tasks\n- [ ] **T01: Do thing** `est:10m`\n");
+    writeFileSync(join(sDir, "tasks", "T01-PLAN.md"), "# T01: Do thing\n\nPlan details.\n");
+
+    // No completed-units.json exists at all
+    const added = reconcileCompletedUnits(base, "M001");
+
+    assert.ok(added.length > 0, "should reconcile even without existing file");
+    const persisted = readCompletedUnits(base);
+    assert.ok(persisted.includes("plan-slice/M001/S01"), "should create the file with reconciled entries");
+  } finally {
+    cleanup(base);
+  }
+});


### PR DESCRIPTION
## TL;DR
**What:** Reconcile completed-units.json against on-disk artifacts at session boot; downgrade `missing_slice_dir` severity for future slices.
**Why:** Session crash between artifact write and completed-units flush leaves units permanently absent, blocking auto-mode restart with state mismatches and inflated error counts.
**How:** New `reconcileCompletedUnits()` function called on both fresh-start and resume paths; doctor severity for `missing_slice_dir` now distinguishes active vs. future slices.

## What
1. **Completed-units reconciliation** (`auto-recovery.ts`): New `reconcileCompletedUnits(basePath, milestoneId)` scans milestone-level and slice-level unit types, calls `verifyExpectedArtifact` for each, and retroactively adds confirmed units to `completed-units.json`.
2. **Session boot integration** (`auto-start.ts`, `auto.ts`): Reconciliation runs on both fresh bootstrap and resume paths, notifying the user of any recovered units.
3. **Doctor severity fix** (`doctor.ts`): `missing_slice_dir` severity is now:
   - `"warning"` for done slices (cosmetic)
   - `"error"` for the first non-done slice (the active one)
   - `"info"` for subsequent non-done slices (future, not yet started)

## Why
When a session terminates abnormally between writing an artifact and flushing `completed-units.json`, the unit is lost from the ledger. On restart, `deriveState` re-derives the unit as needing dispatch, but the re-dispatch attempt encounters missing forward-slice directories (S02-S05), which the doctor reports as 4 `severity: "error"` issues. These inflate `consecutiveErrorUnits`, accelerating LLM-heal escalation for a non-broken condition, blocking auto-mode progress.

## How
- `reconcileCompletedUnits` iterates `RECONCILABLE_MILESTONE_UNIT_TYPES` and `RECONCILABLE_SLICE_UNIT_TYPES`, checking each against `verifyExpectedArtifact`. Confirmed units are added to both the in-memory array and persisted to disk via `atomicWriteSync`.
- The doctor now computes `firstNonDoneSliceId` before iterating slices, using it to assign appropriate severity to `missing_slice_dir` issues.

## Test plan
- [x] `reconcile-completed-units.test.ts` -- 5 tests covering crash-gap reconciliation, duplicate prevention, no-artifact baseline, research-slice reconciliation, missing JSON file handling
- [x] `doctor-missing-slice-dir-severity.test.ts` -- 3 tests covering future slice severity downgrade, active slice error retention, done slice warning
- [x] Existing `doctor.test.ts`, `auto-recovery.test.ts`, `doctor-enhancements.test.ts`, `doctor-runtime.test.ts` all pass
- [x] TypeScript compilation clean (`npx tsc --noEmit`)

Fixes #2076

Generated with [Claude Code](https://claude.com/claude-code)