### PR TITLE
fix(roadmap): make 'on' optional in prose depends regex

### DIFF
--- a/src/resources/extensions/gsd/roadmap-slices.ts
+++ b/src/resources/extensions/gsd/roadmap-slices.ts
@@ -253,7 +253,7 @@ function parseProseSliceHeaders(content: string): RoadmapSliceEntry[] {
     const nextHeader = afterHeader.search(/^#{1,4}\s/m);
     const section = nextHeader !== -1 ? afterHeader.slice(0, nextHeader) : afterHeader.slice(0, 500);
 
-    const depsMatch = section.match(/\*{0,2}Depends\s+on:?\*{0,2}\s*(.+)/i);
+    const depsMatch = section.match(/\*{0,2}Depends(?:\s+on)?:?\*{0,2}\s*(.+)/i);
     let depends: string[] = [];
     if (depsMatch) {
       const rawDeps = depsMatch[1]!.replace(/none/i, "").trim();

--- a/src/resources/extensions/gsd/tests/roadmap-slices.test.ts
+++ b/src/resources/extensions/gsd/tests/roadmap-slices.test.ts
@@ -236,6 +236,36 @@ test("parseRoadmapSlices: ## Slices with valid checkboxes does NOT invoke prose 
   assert.equal(slices[0]?.done, true);
 });
 
+// ── Regression test for #1931 ─────────────────────────────────────────────
+
+test("parseRoadmapSlices: prose 'Depends:' without 'on' parses dependencies (#1931)", () => {
+  const proseContent = `# M030: Depends Without On
+
+## Slices
+
+### S01 — Foundation
+Set up the base.
+
+### S02 — Core Logic
+Build the core.
+**Depends:** S01
+
+### S03 — Integration
+Wire it together.
+**Depends:** S01, S02
+
+### S04 — Polish
+Final polish.
+Depends: S02, S03
+`;
+  const slices = parseRoadmapSlices(proseContent);
+  assert.equal(slices.length, 4, "should find 4 slices");
+  assert.deepEqual(slices[0]?.depends, [], "S01 has no depends");
+  assert.deepEqual(slices[1]?.depends, ["S01"], "S02 depends on S01");
+  assert.deepEqual(slices[2]?.depends, ["S01", "S02"], "S03 depends on S01, S02");
+  assert.deepEqual(slices[3]?.depends, ["S02", "S03"], "S04 depends on S02, S03");
+});
+
 test("parseRoadmapSlices: ## Slices with only non-matching lines returns prose fallback results", () => {
   const weirdContent = `# M020: Odd
 


### PR DESCRIPTION
## TL;DR

**What:** Make "on" optional in the prose depends regex so `**Depends:** S01` is parsed the same as `**Depends on:** S01`.
**Why:** LLMs commonly write `Depends:` without "on", silently dropping dependency chains and causing incorrect dispatch ordering.
**How:** Changed regex from `Depends\s+on:?` to `Depends(?:\s+on)?:?` in `parseProseSliceHeaders()`.

## What

- `roadmap-slices.ts` line 256: made `\s+on` an optional non-capturing group in the depends regex
- `roadmap-slices.test.ts`: added regression test with 4 slices using `**Depends:** S01` format (no "on")

## Why

Issue #1931 reported two bugs. Bug 1 (prose fallback unreachable when `## Slices` exists) was already fixed by PR #1744 (closes #1711). Bug 2 (depends regex requiring "on") remained unfixed -- the regex `/Depends\s+on:?/` mandates "on" but LLMs commonly write `**Depends:** S01`, causing dependencies to be silently dropped.

## How

Changed the regex to make "on" optional: `Depends(?:\s+on)?:?`. Both `Depends on: S01` and `Depends: S01` now match. Existing tests for the "Depends on:" form continue to pass.

Fixes #1931

### Change type
- [x] `fix` -- Bug fix

## Test plan
- [x] New regression test: prose `Depends:` without "on" parses dependencies (#1931) -- 4 slices with mixed dependency patterns
- [x] All 17 existing roadmap-slices tests pass (including #1711 "Depends on:" test)

Generated with [Claude Code](https://claude.com/claude-code)