### PR TITLE
test(web): isolate onboarding contract env from host machine

### DIFF
--- a/src/tests/web-onboarding-contract.test.ts
+++ b/src/tests/web-onboarding-contract.test.ts
@@ -15,6 +15,59 @@ const onboardingRoute = await import("../../web/app/api/onboarding/route.ts");
 const commandRoute = await import("../../web/app/api/session/command/route.ts");
 const { AuthStorage } = await import("@gsd/pi-coding-agent");
 
+const ONBOARDING_ENV_KEYS = [
+  "GITHUB_TOKEN",
+  "GH_TOKEN",
+  "COPILOT_GITHUB_TOKEN",
+  "ANTHROPIC_OAUTH_TOKEN",
+  "ANTHROPIC_API_KEY",
+  "OPENAI_API_KEY",
+  "AZURE_OPENAI_API_KEY",
+  "GEMINI_API_KEY",
+  "GOOGLE_APPLICATION_CREDENTIALS",
+  "GOOGLE_CLOUD_PROJECT",
+  "GCLOUD_PROJECT",
+  "GOOGLE_CLOUD_LOCATION",
+  "GROQ_API_KEY",
+  "CEREBRAS_API_KEY",
+  "XAI_API_KEY",
+  "OPENROUTER_API_KEY",
+  "AI_GATEWAY_API_KEY",
+  "ZAI_API_KEY",
+  "MISTRAL_API_KEY",
+  "MINIMAX_API_KEY",
+  "MINIMAX_CN_API_KEY",
+  "HF_TOKEN",
+  "OPENCODE_API_KEY",
+  "KIMI_API_KEY",
+  "ALIBABA_API_KEY",
+  "AWS_PROFILE",
+  "AWS_ACCESS_KEY_ID",
+  "AWS_SECRET_ACCESS_KEY",
+  "AWS_BEARER_TOKEN_BEDROCK",
+  "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI",
+  "AWS_CONTAINER_CREDENTIALS_FULL_URI",
+  "AWS_WEB_IDENTITY_TOKEN_FILE",
+] as const;
+
+const ORIGINAL_ONBOARDING_ENV = Object.fromEntries(
+  ONBOARDING_ENV_KEYS.map((key) => [key, process.env[key]]),
+) as Record<(typeof ONBOARDING_ENV_KEYS)[number], string | undefined>;
+
+function clearOnboardingEnv(): void {
+  for (const key of ONBOARDING_ENV_KEYS) {
+    delete process.env[key];
+  }
+}
+
+function restoreOnboardingEnv(): void {
+  for (const key of ONBOARDING_ENV_KEYS) {
+    const value = ORIGINAL_ONBOARDING_ENV[key];
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+}
+
 class FakeRpcChild extends EventEmitter {
   stdin = new PassThrough();
   stdout = new PassThrough();
@@ -229,7 +282,6 @@ function configureBridgeFixture(fixture: { projectCwd: string; sessionsDir: stri
 
   bridge.configureBridgeServiceForTests({
     env: {
-      ...process.env,
       GSD_WEB_PROJECT_CWD: fixture.projectCwd,
       GSD_WEB_PROJECT_SESSIONS_DIR: fixture.sessionsDir,
       GSD_WEB_PACKAGE_ROOT: repoRoot,
@@ -244,6 +296,7 @@ function configureBridgeFixture(fixture: { projectCwd: string; sessionsDir: stri
 
 test("boot and onboarding routes expose locked required state plus explicitly skippable optional setup when auth is missing", async () => {
   const fixture = makeWorkspaceFixture();
+  clearOnboardingEnv();
   const authStorage = AuthStorage.inMemory({});
   configureBridgeFixture(fixture, "sess-missing-auth");
   onboarding.configureOnboardingServiceForTests({ authStorage });
@@ -289,12 +342,14 @@ test("boot and onboarding routes expose locked required state plus explicitly sk
   } finally {
     onboarding.resetOnboardingServiceForTests();
     await bridge.resetBridgeServiceForTests();
+    restoreOnboardingEnv();
     fixture.cleanup();
   }
 });
 
 test("runtime env-backed auth unlocks boot onboarding state and reports the environment source", async () => {
   const fixture = makeWorkspaceFixture();
+  clearOnboardingEnv();
   const authStorage = AuthStorage.inMemory({});
   const previousGithubToken = process.env.GITHUB_TOKEN;
   process.env.GITHUB_TOKEN = "ghu_runtime_env_token";
@@ -325,12 +380,14 @@ test("runtime env-backed auth unlocks boot onboarding state and reports the envi
     }
     onboarding.resetOnboardingServiceForTests();
     await bridge.resetBridgeServiceForTests();
+    restoreOnboardingEnv();
     fixture.cleanup();
   }
 });
 
 test("failed API-key validation stays locked, redacts the error, and is reflected in boot state without persisting auth", async () => {
   const fixture = makeWorkspaceFixture();
+  clearOnboardingEnv();
   const authStorage = AuthStorage.inMemory({});
   configureBridgeFixture(fixture, "sess-validation-failure");
   onboarding.configureOnboardingServiceForTests({
@@ -375,12 +432,14 @@ test("failed API-key validation stays locked, redacts the error, and is reflecte
   } finally {
     onboarding.resetOnboardingServiceForTests();
     await bridge.resetBridgeServiceForTests();
+    restoreOnboardingEnv();
     fixture.cleanup();
   }
 });
 
 test("direct prompt commands cannot bypass onboarding while required setup is still locked", async () => {
   const fixture = makeWorkspaceFixture();
+  clearOnboardingEnv();
   const authStorage = AuthStorage.inMemory({});
   const harness = configureBridgeFixture(fixture, "sess-command-locked");
   onboarding.configureOnboardingServiceForTests({ authStorage });
@@ -416,12 +475,14 @@ test("direct prompt commands cannot bypass onboarding while required setup is st
   } finally {
     onboarding.resetOnboardingServiceForTests();
     await bridge.resetBridgeServiceForTests();
+    restoreOnboardingEnv();
     fixture.cleanup();
   }
 });
 
 test("bridge auth refresh failures remain inspectable and keep the workspace locked after credentials validate", async () => {
   const fixture = makeWorkspaceFixture();
+  clearOnboardingEnv();
   const authStorage = AuthStorage.inMemory({});
   configureBridgeFixture(fixture, "sess-refresh-failure");
   onboarding.configureOnboardingServiceForTests({
@@ -463,12 +524,14 @@ test("bridge auth refresh failures remain inspectable and keep the workspace loc
   } finally {
     onboarding.resetOnboardingServiceForTests();
     await bridge.resetBridgeServiceForTests();
+    restoreOnboardingEnv();
     fixture.cleanup();
   }
 });
 
 test("successful API-key validation persists the credential and unlocks onboarding", async () => {
   const fixture = makeWorkspaceFixture();
+  clearOnboardingEnv();
   const authStorage = AuthStorage.inMemory({});
   const harness = configureBridgeFixture(fixture, "sess-validation-success");
   onboarding.configureOnboardingServiceForTests({
@@ -511,12 +574,14 @@ test("successful API-key validation persists the credential and unlocks onboardi
   } finally {
     onboarding.resetOnboardingServiceForTests();
     await bridge.resetBridgeServiceForTests();
+    restoreOnboardingEnv();
     fixture.cleanup();
   }
 });
 
 test("logout_provider removes saved auth, refreshes the bridge, and relocks onboarding when it was the only provider", async () => {
   const fixture = makeWorkspaceFixture();
+  clearOnboardingEnv();
   const authStorage = AuthStorage.inMemory({
     openai: { type: "api_key", key: "sk-saved-logout" },
   } as any);
@@ -558,12 +623,14 @@ test("logout_provider removes saved auth, refreshes the bridge, and relocks onbo
   } finally {
     onboarding.resetOnboardingServiceForTests();
     await bridge.resetBridgeServiceForTests();
+    restoreOnboardingEnv();
     fixture.cleanup();
   }
 });
 
 test("logout_provider fails clearly for environment-backed auth that the browser cannot remove", async () => {
   const fixture = makeWorkspaceFixture();
+  clearOnboardingEnv();
   const authStorage = AuthStorage.inMemory({});
   const previousGithubToken = process.env.GITHUB_TOKEN;
   process.env.GITHUB_TOKEN = "ghu_env_only_token";
@@ -601,6 +668,7 @@ test("logout_provider fails clearly for environment-backed auth that the browser
     }
     onboarding.resetOnboardingServiceForTests();
     await bridge.resetBridgeServiceForTests();
+    restoreOnboardingEnv();
     fixture.cleanup();
   }
 });


### PR DESCRIPTION
## TL;DR

**What:** Isolate the onboarding contract tests from host-machine auth and provider env vars.
**Why:** The current test fixture leaks `process.env` into the bridge/onboarding setup, so machine-local credentials can unlock onboarding and make the locked-state assertions fail.
**How:** Clear a focused onboarding env key set before each test, restore it in teardown, and stop copying the full host env into the bridge fixture.

## What

This PR updates `src/tests/web-onboarding-contract.test.ts` so the onboarding contract tests run against a controlled env instead of inheriting whatever auth/provider credentials happen to exist on the host machine.

Specifically it:
- adds a focused `ONBOARDING_ENV_KEYS` list for auth and provider env vars that affect onboarding state
- clears those env vars before each onboarding-contract scenario
- restores the original env values during teardown
- stops passing `...process.env` into the bridge test fixture

## Why

Related to the non-locale test stabilization split requested from #2013.

On current `upstream/main`, this test file still depends on ambient machine env. If `GITHUB_TOKEN`, `BRAVE_API_KEY`, `TAVILY_API_KEY`, `OLLAMA_API_KEY`, or similar auth/provider vars are present, the supposedly locked onboarding scenarios can become unlocked and the contract assertions fail for the wrong reason.

That makes the test file environment-dependent instead of deterministic.

## How

- Define the onboarding-relevant env keys at the top of the test file.
- Snapshot the original values once.
- Clear the set before each test body that asserts onboarding lock state.
- Restore the original values in each `finally` block.
- Keep the bridge fixture scoped to the explicit test env instead of inheriting all host vars.

## Change type

- [x] `test` — Adding or updating tests
- [ ] `feat` — New feature or capability
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [ ] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

Local verification:
- Reproduced failure on `upstream/main` with dirty host env:
  - `GITHUB_TOKEN=ghu_host_leak BRAVE_API_KEY=brave_host_leak TAVILY_API_KEY=tavily_host_leak OLLAMA_API_KEY=ollama_host_leak node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/tests/web-onboarding-contract.test.ts`
  - result on upstream: 4 failures / 8 tests
- Verified fixed branch with the same dirty env:
  - same command on this branch
  - result: 8 pass / 0 fail
- Verified fixed branch with clean env:
  - `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/tests/web-onboarding-contract.test.ts`
  - result: 8 pass / 0 fail

## AI disclosure

- [x] This PR includes AI-assisted code. I used GSD/pi to isolate the remaining test-env stabilization work from an older closed PR, reproduce the failure on current `upstream/main`, and verify the fix locally under both dirty and clean env conditions.
