### PR TITLE
fix(gsd): apply fast service tier outside auto-mode

### DIFF
--- a/src/resources/extensions/gsd/bootstrap/register-hooks.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-hooks.ts
@@ -20,21 +20,27 @@ import { saveActivityLog } from "../activity-log.js";
 // printed it before the TUI launched. Only re-print on /clear (subsequent sessions).
 let isFirstSession = true;
 
+async function syncServiceTierStatus(ctx: ExtensionContext): Promise<void> {
+  const { getEffectiveServiceTier, formatServiceTierFooterStatus } = await import("../service-tier.js");
+  ctx.ui.setStatus("gsd-fast", formatServiceTierFooterStatus(getEffectiveServiceTier(), ctx.model?.id));
+}
+
 export function registerHooks(pi: ExtensionAPI): void {
   pi.on("session_start", async (_event, ctx) => {
     resetWriteGateState();
     resetToolCallLoopGuard();
+    await syncServiceTierStatus(ctx);
     if (isFirstSession) {
       isFirstSession = false;
     } else {
       try {
         const gsdBinPath = process.env.GSD_BIN_PATH;
         if (gsdBinPath) {
-          const { dirname } = await import('node:path');
+          const { dirname } = await import("node:path");
           const { printWelcomeScreen } = await import(
-            join(dirname(gsdBinPath), 'welcome-screen.js')
+            join(dirname(gsdBinPath), "welcome-screen.js")
           ) as { printWelcomeScreen: (opts: { version: string; modelName?: string; provider?: string }) => void };
-          printWelcomeScreen({ version: process.env.GSD_VERSION || '0.0.0' });
+          printWelcomeScreen({ version: process.env.GSD_VERSION || "0.0.0" });
         }
       } catch { /* non-fatal */ }
     }
@@ -192,8 +198,11 @@ export function registerHooks(pi: ExtensionAPI): void {
     markToolEnd(event.toolCallId);
   });
 
+  pi.on("model_select", async (_event, ctx) => {
+    await syncServiceTierStatus(ctx);
+  });
+
   pi.on("before_provider_request", async (event) => {
-    if (!isAutoActive()) return;
     const modelId = event.model?.id;
     if (!modelId) return;
     const { getEffectiveServiceTier, supportsServiceTier } = await import("../service-tier.js");
@@ -205,4 +214,3 @@ export function registerHooks(pi: ExtensionAPI): void {
     return payload;
   });
 }
-

--- a/src/resources/extensions/gsd/service-tier.ts
+++ b/src/resources/extensions/gsd/service-tier.ts
@@ -23,6 +23,8 @@ import { ensurePreferencesFile, serializePreferencesToFrontmatter } from "./comm
 
 export type ServiceTierSetting = "priority" | "flex" | undefined;
 
+const SERVICE_TIER_SCOPE_NOTE = "Only affects gpt-5.4 models, regardless of provider.";
+
 // ─── Gating ──────────────────────────────────────────────────────────────────
 
 /**
@@ -51,7 +53,7 @@ export function formatServiceTierStatus(tier: ServiceTierSetting): string {
       "  /gsd fast flex   Set to flex (0.5x cost, slower)",
       "  /gsd fast off    Disable service tier",
       "",
-      "Only affects gpt-5.4 models.",
+      SERVICE_TIER_SCOPE_NOTE,
     ].join("\n");
   }
 
@@ -64,8 +66,16 @@ export function formatServiceTierStatus(tier: ServiceTierSetting): string {
     "  /gsd fast flex   Set to flex (0.5x cost, slower)",
     "  /gsd fast off    Disable service tier",
     "",
-    "Only affects gpt-5.4 models.",
+    SERVICE_TIER_SCOPE_NOTE,
   ].join("\n");
+}
+
+export function formatServiceTierFooterStatus(
+  tier: ServiceTierSetting,
+  modelId: string | undefined,
+): string | undefined {
+  if (!tier || !modelId || !supportsServiceTier(modelId)) return undefined;
+  return tier === "priority" ? "fast: ⚡ priority" : "fast: 💰 flex";
 }
 
 // ─── Icon Resolution ─────────────────────────────────────────────────────────
@@ -148,19 +158,22 @@ export async function handleFast(args: string, ctx: ExtensionCommandContext): Pr
 
   if (trimmed === "on") {
     await writeGlobalServiceTier(ctx, "priority");
-    ctx.ui.notify("Service tier set to priority (2x cost, faster responses). Only affects gpt-5.4 models.", "info");
+    ctx.ui.setStatus("gsd-fast", formatServiceTierFooterStatus("priority", ctx.model?.id));
+    ctx.ui.notify("Service tier set to priority (2x cost, faster responses). Only affects gpt-5.4 models, regardless of provider.", "info");
     return;
   }
 
   if (trimmed === "off") {
     await writeGlobalServiceTier(ctx, undefined);
+    ctx.ui.setStatus("gsd-fast", undefined);
     ctx.ui.notify("Service tier disabled.", "info");
     return;
   }
 
   if (trimmed === "flex") {
     await writeGlobalServiceTier(ctx, "flex");
-    ctx.ui.notify("Service tier set to flex (0.5x cost, slower responses). Only affects gpt-5.4 models.", "info");
+    ctx.ui.setStatus("gsd-fast", formatServiceTierFooterStatus("flex", ctx.model?.id));
+    ctx.ui.notify("Service tier set to flex (0.5x cost, slower responses). Only affects gpt-5.4 models, regardless of provider.", "info");
     return;
   }
 

--- a/src/resources/extensions/gsd/tests/service-tier.test.ts
+++ b/src/resources/extensions/gsd/tests/service-tier.test.ts
@@ -4,8 +4,8 @@ import assert from "node:assert/strict";
 import {
   supportsServiceTier,
   formatServiceTierStatus,
+  formatServiceTierFooterStatus,
   resolveServiceTierIcon,
-  type ServiceTierSetting,
 } from "../service-tier.ts";
 
 // ─── supportsServiceTier ─────────────────────────────────────────────────────
@@ -25,6 +25,14 @@ describe("supportsServiceTier", () => {
 
   test("returns true for openai/gpt-5.4 (provider-prefixed)", () => {
     assert.equal(supportsServiceTier("openai/gpt-5.4"), true);
+  });
+
+  test("returns true for vibeproxy-openai/gpt-5.4 (proxy provider-prefixed)", () => {
+    assert.equal(supportsServiceTier("vibeproxy-openai/gpt-5.4"), true);
+  });
+
+  test("returns false for provider-only identifier without gpt-5.4 model suffix", () => {
+    assert.equal(supportsServiceTier("vibeproxy-openai"), false);
   });
 
   test("returns false for claude-opus-4-6", () => {
@@ -52,6 +60,11 @@ describe("formatServiceTierStatus", () => {
     assert.ok(output.includes("disabled"), `Expected 'disabled' in: ${output}`);
   });
 
+  test("mentions provider-agnostic model gating", () => {
+    const output = formatServiceTierStatus("priority");
+    assert.ok(output.includes("regardless of provider"), `Expected provider note in: ${output}`);
+  });
+
   test("shows priority when set to priority", () => {
     const output = formatServiceTierStatus("priority");
     assert.ok(output.includes("priority"), `Expected 'priority' in: ${output}`);
@@ -60,6 +73,22 @@ describe("formatServiceTierStatus", () => {
   test("shows flex when set to flex", () => {
     const output = formatServiceTierStatus("flex");
     assert.ok(output.includes("flex"), `Expected 'flex' in: ${output}`);
+  });
+});
+
+// ─── formatServiceTierFooterStatus ───────────────────────────────────────────
+
+describe("formatServiceTierFooterStatus", () => {
+  test("returns priority footer status for supported model", () => {
+    assert.equal(formatServiceTierFooterStatus("priority", "vibeproxy-openai/gpt-5.4"), "fast: ⚡ priority");
+  });
+
+  test("returns undefined for unsupported model", () => {
+    assert.equal(formatServiceTierFooterStatus("priority", "claude-opus-4-6"), undefined);
+  });
+
+  test("returns undefined when tier is disabled", () => {
+    assert.equal(formatServiceTierFooterStatus(undefined, "gpt-5.4"), undefined);
   });
 });
 


### PR DESCRIPTION
## TL;DR

**What:** Apply `/gsd fast` service-tier injection outside auto-mode and keep the footer status in sync with the active model.
**Why:** Today the service tier preference is only injected during auto-mode, so `/gsd fast` can look enabled but do nothing in normal interactive use.
**How:** Remove the auto-mode gate from `before_provider_request`, add a small shared footer-status helper, and update the service-tier tests accordingly.

## What

This PR updates the `/gsd fast` service-tier path so the selected tier is applied whenever the active model supports it, not only while auto-mode is running.

It also keeps the footer/status indicator in sync when a session starts or the model changes.

Files changed:
- `src/resources/extensions/gsd/bootstrap/register-hooks.ts`
- `src/resources/extensions/gsd/service-tier.ts`
- `src/resources/extensions/gsd/tests/service-tier.test.ts`

## Why

Follow-up to the earlier `/gsd fast` work after the old draft PR #2005 was closed.

On current `upstream/main`, the `before_provider_request` hook still returns early unless `isAutoActive()` is true. That means the global `service_tier` preference can be set via `/gsd fast`, but normal non-auto requests still do not receive `payload.service_tier`.

The footer/status behavior also lags behind that reality: if the setting is global, the status indicator should reflect it consistently when the session starts and when the user switches to a supported model.

## How

- Remove the auto-mode-only gate from the `before_provider_request` hook.
- Add `formatServiceTierFooterStatus(...)` to centralize footer text for supported models.
- Sync the `gsd-fast` footer status on `session_start`, on `model_select`, and when `/gsd fast on|off|flex` runs.
- Extend the service-tier tests to cover proxy-prefixed model IDs, provider-agnostic messaging, and footer-status formatting.

## Change type

- [x] `fix` — Bug fix
- [ ] `feat` — New feature or capability
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [ ] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

Local verification:
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/service-tier.test.ts`
- `npm run build`
- `npx tsc --noEmit`
- `npm run secret-scan`

## AI disclosure

- [x] This PR includes AI-assisted code. I used GSD/pi to isolate the remaining `/gsd fast` global service-tier follow-up onto a clean branch from current `upstream/main`, verify that the behavior is still missing there, and run the local verification above.
