### PR TITLE
fix: syncProjectRootToWorktree no longer clobbers existing worktree files

### DIFF
--- a/src/resources/extensions/gsd/auto-worktree-sync.ts
+++ b/src/resources/extensions/gsd/auto-worktree-sync.ts
@@ -44,11 +44,14 @@ export function syncProjectRootToWorktree(
   const prGsd = join(projectRoot, ".gsd");
   const wtGsd = join(worktreePath, ".gsd");
 
-  // Copy milestone directory from project root to worktree if the project root
-  // has newer artifacts (e.g. slices that don't exist in the worktree yet)
+  // Copy milestone directory from project root to worktree, but only files
+  // that don't already exist in the worktree. Without force:false, cpSync
+  // overwrites worktree files (e.g. roadmap with completed [x] checkboxes)
+  // with stale project root copies that still show [ ]. (#2144)
   safeCopyRecursive(
     join(prGsd, "milestones", milestoneId),
     join(wtGsd, "milestones", milestoneId),
+    { force: false },
   );
 
   // Delete worktree gsd.db so it rebuilds from the freshly synced files.

--- a/src/resources/extensions/gsd/tests/worktree-sync-milestones.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-sync-milestones.test.ts
@@ -591,6 +591,57 @@ async function main(): Promise<void> {
     }
   }
 
+
+  // --- 16. syncProjectRootToWorktree does not clobber existing worktree files (#2144)
+  console.log('\n=== 16. root->worktree sync preserves existing worktree files (#2144) ===');
+  {
+    const mainBase = createBase('main');
+    const wtBase = createBase('wt');
+
+    try {
+      // Main (project root) has a stale roadmap with [ ] checkboxes
+      const mainM001 = join(mainBase, '.gsd', 'milestones', 'M001');
+      mkdirSync(join(mainM001, 'slices', 'S01'), { recursive: true });
+      writeFileSync(join(mainM001, 'M001-ROADMAP.md'), '- [ ] **S01: Do thing** `risk:high`');
+      writeFileSync(join(mainM001, 'slices', 'S01', 'S01-PLAN.md'), '# S01 Plan');
+
+      // Worktree has an updated roadmap with [x] (slice completed) and a new S02 research
+      const wtM001 = join(wtBase, '.gsd', 'milestones', 'M001');
+      mkdirSync(join(wtM001, 'slices', 'S01'), { recursive: true });
+      mkdirSync(join(wtM001, 'slices', 'S02'), { recursive: true });
+      writeFileSync(join(wtM001, 'M001-ROADMAP.md'), '- [x] **S01: Do thing** `risk:high`');
+      writeFileSync(join(wtM001, 'slices', 'S01', 'S01-PLAN.md'), '# S01 Plan');
+      writeFileSync(join(wtM001, 'slices', 'S01', 'S01-SUMMARY.md'), '# S01 Summary -- done');
+      writeFileSync(join(wtM001, 'slices', 'S02', 'S02-RESEARCH.md'), '# S02 Research');
+
+      syncProjectRootToWorktree(mainBase, wtBase, 'M001');
+
+      // The worktree roadmap must NOT be overwritten -- [x] must survive
+      const roadmap = readFileSync(join(wtBase, '.gsd', 'milestones', 'M001', 'M001-ROADMAP.md'), 'utf-8');
+      assertTrue(
+        roadmap.includes('[x]'),
+        '#2144: worktree roadmap [x] preserved after root->worktree sync',
+      );
+      assertTrue(
+        !roadmap.includes('[ ]'),
+        '#2144: stale [ ] from project root did not overwrite worktree',
+      );
+
+      // Existing worktree files must survive
+      assertTrue(
+        existsSync(join(wtBase, '.gsd', 'milestones', 'M001', 'slices', 'S01', 'S01-SUMMARY.md')),
+        '#2144: S01-SUMMARY.md preserved in worktree',
+      );
+      assertTrue(
+        existsSync(join(wtBase, '.gsd', 'milestones', 'M001', 'slices', 'S02', 'S02-RESEARCH.md')),
+        '#2144: S02-RESEARCH.md preserved in worktree',
+      );
+    } finally {
+      cleanup(mainBase);
+      cleanup(wtBase);
+    }
+  }
+
   report();
 }
 


### PR DESCRIPTION
Fixes #2144

## Problem

`syncProjectRootToWorktree` calls `safeCopyRecursive` without `{ force: false }`, so `cpSync` defaults to overwriting existing worktree files with project root copies. After a slice completes in the worktree (roadmap checkboxes updated to `[x]`), the next session's root→worktree sync reverts them to `[ ]`. Dispatch then sees the slice as incomplete and blocks the next slice.

Also affects projects migrated from GSD v1 where the project root `.gsd/` was never updated by v2's slice-completion hooks.

## Fix

Pass `{ force: false }` to `safeCopyRecursive` in `syncProjectRootToWorktree`. This preserves existing worktree files while still syncing new files (missing slices, new artifacts) from the project root.

Verified behavior:
- `force: false` → existing files preserved, new files copied (correct)
- Default (no option) → existing files overwritten with stale copies (the bug)

## Test

Added test 16 to `worktree-sync-milestones.test.ts`:
- Creates a project root with stale `[ ]` roadmap
- Creates a worktree with updated `[x]` roadmap + additional artifacts
- Runs `syncProjectRootToWorktree`
- Asserts worktree roadmap still has `[x]`, not the stale `[ ]`

All 60 assertions across 16 test groups pass.