### PR TITLE
ci: add timeout-minutes to all CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ concurrency:
 
 jobs:
   detect-changes:
+    timeout-minutes: 2
     runs-on: ubuntu-latest
     outputs:
       docs-only: ${{ steps.check.outputs.docs-only }}
@@ -59,6 +60,7 @@ jobs:
           fi
 
   docs-check:
+    timeout-minutes: 5
     runs-on: ubuntu-latest
     needs: detect-changes
     steps:
@@ -70,6 +72,7 @@ jobs:
         run: bash scripts/docs-prompt-injection-scan.sh --diff origin/main
 
   lint:
+    timeout-minutes: 5
     needs: detect-changes
     runs-on: ubuntu-latest
     steps:
@@ -96,6 +99,7 @@ jobs:
         run: node scripts/check-skill-references.mjs
 
   build:
+    timeout-minutes: 15
     needs: detect-changes
     if: needs.detect-changes.outputs.docs-only != 'true'
     runs-on: ubuntu-latest
@@ -135,6 +139,7 @@ jobs:
         run: npm run test:integration
 
   windows-portability:
+    timeout-minutes: 15
     needs: detect-changes
     if: >-
       needs.detect-changes.outputs.docs-only != 'true' &&


### PR DESCRIPTION
## Summary
- A hung unit test on PR #2120 ran for **3+ hours** before manual cancellation, burning ~185 min of Actions quota (~$1.48)
- Adds `timeout-minutes` to all 5 CI jobs: `detect-changes` (2m), `docs-check`/`lint` (5m), `build`/`windows-portability` (15m)
- Normal CI completes in ~4 min, so 15m gives plenty of headroom without allowing runaway burns

## Test plan
- [ ] CI runs and passes on this PR (meta-validates the workflow syntax)
- [ ] Verify timeouts appear in Actions UI for each job

🤖 Generated with [Claude Code](https://claude.com/claude-code)