### PR TITLE
feat(remote-questions): add Signal adapter via signal-cli-rest-api

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Full documentation is available in the [`docs/`](./docs/) directory:
 - **[CI/CD Pipeline](./docs/ci-cd-pipeline.md)** — three-stage promotion pipeline (Dev → Test → Prod)
 - **[VS Code Extension](./vscode-extension/README.md)** — chat participant, sidebar dashboard, RPC integration
 - **[Visualizer](./docs/visualizer.md)** — workflow visualizer with stats and discussion status
-- **[Remote Questions](./docs/remote-questions.md)** — route decisions to Slack or Discord when human input is needed
+- **[Remote Questions](./docs/remote-questions.md)** — route decisions to Slack, Discord, Telegram, or Signal when human input is needed
 - **[Dynamic Model Routing](./docs/dynamic-model-routing.md)** — complexity-based model selection and budget pressure
 - **[Pipeline Simplification (ADR-003)](./docs/ADR-003-pipeline-simplification.md)** — merged research into planning, mechanical completion
 - **[Migration from v1](./docs/migration.md)** — `.planning` → `.gsd` migration
@@ -335,7 +335,7 @@ gsd headless query
 gsd headless dispatch plan
 ```
 
-Headless auto-responds to interactive prompts, detects completion, and exits with structured codes: `0` complete, `1` error/timeout, `2` blocked. Auto-restarts on crash with exponential backoff. Use `gsd headless query` for instant, machine-readable state inspection — returns phase, next dispatch preview, and parallel worker costs as a single JSON object without spawning an LLM session. Pair with [remote questions](./docs/remote-questions.md) to route decisions to Slack or Discord when human input is needed.
+Headless auto-responds to interactive prompts, detects completion, and exits with structured codes: `0` complete, `1` error/timeout, `2` blocked. Auto-restarts on crash with exponential backoff. Use `gsd headless query` for instant, machine-readable state inspection — returns phase, next dispatch preview, and parallel worker costs as a single JSON object without spawning an LLM session. Pair with [remote questions](./docs/remote-questions.md) to route decisions to Slack, Discord, Telegram, or Signal when human input is needed.
 
 **Multi-session orchestration** — headless mode supports file-based IPC in `.gsd/parallel/` for coordinating multiple GSD workers across milestones. Build orchestrators that spawn, monitor, and budget-cap a fleet of GSD workers.
 
@@ -561,7 +561,7 @@ GSD ships with 19 extensions, all loaded automatically:
 | **Slash Commands**     | Custom command creation                                                                                                |
 | **Ask User Questions** | Structured user input with single/multi-select                                                                         |
 | **Secure Env Collect** | Masked secret collection without manual .env editing                                                                   |
-| **Remote Questions**   | Route decisions to Slack/Discord when human input is needed in headless/CI mode                                         |
+| **Remote Questions**   | Route decisions to Slack, Discord, Telegram, or Signal when human input is needed in headless/CI mode                   |
 | **Universal Config**   | Discover and import MCP servers and rules from other AI coding tools                                                    |
 | **AWS Auth**           | Automatic Bedrock credential refresh for AWS-hosted models                                                              |
 | **TTSR**               | Tool-use type-safe runtime validation                                                                                   |

--- a/docs/remote-questions.md
+++ b/docs/remote-questions.md
@@ -1,6 +1,6 @@
 # Remote Questions
 
-Remote questions allow GSD to ask for user input via Slack, Discord, or Telegram when running in headless auto-mode. When GSD encounters a decision point that needs human input, it posts the question to your configured channel and polls for a response.
+Remote questions allow GSD to ask for user input via Slack, Discord, Telegram, or Signal when running in headless auto-mode. When GSD encounters a decision point that needs human input, it posts the question to your configured channel and polls for a response.
 
 ## Setup
 
@@ -63,13 +63,47 @@ The setup wizard:
 - Bot must be added to the target group chat (or use private chat with the bot)
 - The `TELEGRAM_BOT_TOKEN` environment variable must be set
 
+### Signal
+
+```
+/gsd remote signal
+```
+
+The setup wizard:
+1. Prompts for your signal-cli-rest-api URL (e.g. `http://localhost:8080`)
+2. Prompts for the bot's phone number (registered with signal-cli)
+3. Validates connectivity against the `/v1/about` endpoint
+4. Prompts for the recipient's phone number (where questions will be sent)
+5. Sends a test message to confirm the pipeline works
+6. Saves the configuration
+
+**Requirements:**
+- A running [signal-cli-rest-api](https://github.com/bbernhard/signal-cli-rest-api) instance
+- A phone number registered with signal-cli (the bot's number)
+- The recipient's phone number (your personal number)
+- Environment variables:
+  - `SIGNAL_SERVICE_URL` — base URL of signal-cli-rest-api
+  - `SIGNAL_PHONE_NUMBER` — the bot's phone number
+
+**Signal configuration example:**
+
+```yaml
+remote_questions:
+  channel: signal
+  channel_id: "+15559876543"    # recipient phone number
+  timeout_minutes: 5
+  poll_interval_seconds: 5
+```
+
+**Note:** Signal uses plain text messages (no rich formatting, no inline buttons). Questions are formatted with numbered options and emoji bullets for readability on mobile. Reply with a number (`1`), comma-separated numbers (`1,3`), or free text.
+
 ## Configuration
 
 Remote questions are configured in `~/.gsd/preferences.md`:
 
 ```yaml
 remote_questions:
-  channel: discord          # or slack or telegram
+  channel: discord          # or slack, telegram, signal
   channel_id: "1234567890123456789"
   timeout_minutes: 5        # 1-30, default 5
   poll_interval_seconds: 5  # 2-30, default 5
@@ -108,6 +142,8 @@ If no response is received within `timeout_minutes`, the prompt times out and GS
 | `/gsd remote` | Show remote questions menu and current status |
 | `/gsd remote slack` | Set up Slack integration |
 | `/gsd remote discord` | Set up Discord integration |
+| `/gsd remote telegram` | Set up Telegram integration |
+| `/gsd remote signal` | Set up Signal integration |
 | `/gsd remote status` | Show current configuration and last prompt status |
 | `/gsd remote disconnect` | Remove remote questions configuration |
 
@@ -146,4 +182,6 @@ If no response is received within `timeout_minutes`, the prompt times out and GS
 ### Channel ID format
 - **Slack:** 9-12 uppercase alphanumeric characters (e.g., `C0123456789`)
 - **Discord:** 17-20 digit numeric snowflake ID (e.g., `1234567890123456789`)
+- **Telegram:** Numeric chat ID, can be negative for groups (e.g., `-1001234567890`)
+- **Signal:** International phone number format (e.g., `+15551234567`)
 - Enable Developer Mode in Discord (Settings → Advanced) to copy channel IDs

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gsd-pi",
-  "version": "2.40.0",
+  "version": "2.42.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gsd-pi",
-      "version": "2.40.0",
+      "version": "2.42.0",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [
@@ -9166,7 +9166,7 @@
     },
     "packages/pi-coding-agent": {
       "name": "@gsd/pi-coding-agent",
-      "version": "2.40.0",
+      "version": "2.42.0",
       "dependencies": {
         "@mariozechner/jiti": "^2.6.2",
         "@silvia-odwyer/photon-node": "^0.3.4",

--- a/src/onboarding.ts
+++ b/src/onboarding.ts
@@ -686,6 +686,7 @@ async function runRemoteQuestionsStep(
     { value: 'discord', label: 'Discord', hint: 'receive questions in a Discord channel' },
     { value: 'slack', label: 'Slack', hint: 'receive questions in a Slack channel' },
     { value: 'telegram', label: 'Telegram', hint: 'receive questions via Telegram bot' },
+    { value: 'signal', label: 'Signal', hint: 'receive questions via Signal (signal-cli-rest-api)' },
     { value: 'skip', label: 'Skip for now', hint: 'use /gsd remote inside GSD later' },
   )
 
@@ -827,6 +828,87 @@ async function runRemoteQuestionsStep(
     saveRemoteQuestionsConfig('telegram', trimmedChatId)
     p.log.success(`Telegram chat: ${pc.green(trimmedChatId)}`)
     return 'Telegram'
+  }
+
+  if (choice === 'signal') {
+    const serviceUrl = await p.text({
+      message: `Signal service URL ${pc.dim('(signal-cli-rest-api, e.g. http://localhost:8080)')}:`,
+      validate: (val) => {
+        if (!val?.trim()) return 'URL is required'
+        try { new URL(val.trim()) } catch { return 'Invalid URL' }
+      },
+    })
+    if (p.isCancel(serviceUrl) || !serviceUrl) return null
+    const trimmedUrl = (serviceUrl as string).trim().replace(/\/+$/, '')
+
+    const phoneNumber = await p.text({
+      message: `Bot phone number ${pc.dim('(registered with signal-cli, e.g. +15551234567)')}:`,
+      validate: (val) => {
+        if (!val || !/^\+\d{7,15}$/.test(val.trim())) return 'Expected international format: +15551234567'
+      },
+    })
+    if (p.isCancel(phoneNumber) || !phoneNumber) return null
+    const trimmedPhone = (phoneNumber as string).trim()
+
+    // Validate connectivity
+    const s = p.spinner()
+    s.start('Connecting to signal-cli-rest-api...')
+    try {
+      const res = await fetch(`${trimmedUrl}/v1/about`, { signal: AbortSignal.timeout(10_000) })
+      if (!res.ok) {
+        s.stop(`Signal service returned HTTP ${res.status}`)
+        return null
+      }
+      const data = await res.json() as any
+      s.stop(`Signal service: ${pc.green(data?.versions?.['signal-cli'] ? `signal-cli ${data.versions['signal-cli']}` : 'connected')}`)
+    } catch {
+      s.stop('Could not reach signal-cli-rest-api')
+      return null
+    }
+
+    const recipientNumber = await p.text({
+      message: `Your phone number ${pc.dim('(where questions will be sent, e.g. +15559876543)')}:`,
+      validate: (val) => {
+        if (!val || !/^\+\d{7,15}$/.test(val.trim())) return 'Expected international format: +15559876543'
+      },
+    })
+    if (p.isCancel(recipientNumber) || !recipientNumber) return null
+    const trimmedRecipient = (recipientNumber as string).trim()
+
+    // Test send
+    const ts = p.spinner()
+    ts.start('Sending test message...')
+    try {
+      const res = await fetch(`${trimmedUrl}/v2/send`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          message: '✅ GSD remote questions connected via Signal.',
+          number: trimmedPhone,
+          recipients: [trimmedRecipient],
+        }),
+        signal: AbortSignal.timeout(15_000),
+      })
+      if (!res.ok) {
+        const body = await res.text().catch(() => '')
+        ts.stop(`Could not send test message: HTTP ${res.status} ${body.slice(0, 100)}`)
+        return null
+      }
+      ts.stop('Test message sent')
+    } catch (err) {
+      ts.stop(`Could not send test message: ${(err as Error).message}`)
+      return null
+    }
+
+    // Store the service URL as the "token" and phone as env vars
+    authStorage.set('signal_service', { type: 'api_key', key: trimmedUrl })
+    process.env.SIGNAL_SERVICE_URL = trimmedUrl
+    process.env.SIGNAL_PHONE_NUMBER = trimmedPhone
+
+    const { saveRemoteQuestionsConfig } = await import('./remote-questions-config.js')
+    saveRemoteQuestionsConfig('signal', trimmedRecipient)
+    p.log.success(`Signal: ${pc.green(trimmedRecipient)} via ${pc.green(trimmedUrl)}`)
+    return 'Signal'
   }
 
   return null

--- a/src/remote-questions-config.ts
+++ b/src/remote-questions-config.ts
@@ -18,7 +18,7 @@ import { appRoot } from "./app-paths.js";
 // in dist/. See #592, #1110.
 const GLOBAL_PREFERENCES_PATH = join(appRoot, "preferences.md");
 
-export function saveRemoteQuestionsConfig(channel: "slack" | "discord" | "telegram", channelId: string): void {
+export function saveRemoteQuestionsConfig(channel: "slack" | "discord" | "telegram" | "signal", channelId: string): void {
   const prefsPath = GLOBAL_PREFERENCES_PATH;
   const block = [
     "remote_questions:",

--- a/src/resources/extensions/gsd/preferences-types.ts
+++ b/src/resources/extensions/gsd/preferences-types.ts
@@ -164,7 +164,7 @@ export interface AutoSupervisorConfig {
 }
 
 export interface RemoteQuestionsConfig {
-  channel: "slack" | "discord" | "telegram";
+  channel: "slack" | "discord" | "telegram" | "signal";
   channel_id: string | number;
   timeout_minutes?: number;        // clamped to 1-30
   poll_interval_seconds?: number;  // clamped to 2-30

--- a/src/resources/extensions/gsd/tests/signal-integration.test.ts
+++ b/src/resources/extensions/gsd/tests/signal-integration.test.ts
@@ -1,0 +1,353 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createServer, type Server, type IncomingMessage, type ServerResponse } from "node:http";
+import { WebSocketServer, WebSocket } from "ws";
+
+/**
+ * Integration tests for SignalAdapter using mock HTTP + WebSocket servers.
+ * Tests the full sendPrompt → pollAnswer → acknowledgeAnswer flow
+ * without a real signal-cli-rest-api instance.
+ */
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+interface MockSignalServer {
+  httpServer: Server;
+  wss: WebSocketServer;
+  port: number;
+  url: string;
+  /** Messages received via POST /v2/send */
+  sentMessages: Array<{ message: string; number: string; recipients: string[] }>;
+  /** Contacts to return from GET /v1/contacts/{number} */
+  contacts: any[];
+  /** Inject a message into the WebSocket stream (simulates incoming Signal message) */
+  injectMessage: (envelope: any) => void;
+  close: () => Promise<void>;
+}
+
+async function startMockSignalServer(): Promise<MockSignalServer> {
+  const sentMessages: MockSignalServer["sentMessages"] = [];
+  let contacts: any[] = [];
+  const wsClients: Set<WebSocket> = new Set();
+
+  const httpServer = createServer(async (req: IncomingMessage, res: ServerResponse) => {
+    const url = new URL(req.url ?? "/", `http://localhost`);
+
+    // GET /v1/about
+    if (req.method === "GET" && url.pathname === "/v1/about") {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ versions: ["v1", "v2"], build: 2, mode: "json-rpc", version: "0.98" }));
+      return;
+    }
+
+    // GET /v1/accounts
+    if (req.method === "GET" && url.pathname === "/v1/accounts") {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(["+15550001111"]));
+      return;
+    }
+
+    // GET /v1/contacts/{number}
+    if (req.method === "GET" && url.pathname.startsWith("/v1/contacts/")) {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(contacts));
+      return;
+    }
+
+    // POST /v2/send
+    if (req.method === "POST" && url.pathname === "/v2/send") {
+      const chunks: Buffer[] = [];
+      for await (const chunk of req) chunks.push(chunk as Buffer);
+      const body = JSON.parse(Buffer.concat(chunks).toString());
+      sentMessages.push(body);
+      res.writeHead(201, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ timestamp: String(Date.now()) }));
+      return;
+    }
+
+    res.writeHead(404);
+    res.end("Not found");
+  });
+
+  const wss = new WebSocketServer({ server: httpServer });
+  wss.on("connection", (ws) => {
+    wsClients.add(ws);
+    ws.on("close", () => wsClients.delete(ws));
+  });
+
+  return new Promise((resolve) => {
+    httpServer.listen(0, "127.0.0.1", () => {
+      const addr = httpServer.address() as { port: number };
+      resolve({
+        httpServer,
+        wss,
+        port: addr.port,
+        url: `http://127.0.0.1:${addr.port}`,
+        sentMessages,
+        contacts,
+        injectMessage: (envelope: any) => {
+          const data = JSON.stringify(envelope);
+          for (const ws of wsClients) ws.send(data);
+        },
+        close: () => new Promise((r) => {
+          wss.close(() => httpServer.close(() => r()));
+        }),
+      });
+    });
+  });
+}
+
+function makePrompt(id = "test-prompt-1") {
+  return {
+    id,
+    channel: "signal" as const,
+    createdAt: Date.now(),
+    timeoutAt: Date.now() + 300_000,
+    pollIntervalMs: 5000,
+    questions: [{
+      id: "choice",
+      header: "Approach",
+      question: "Which approach?",
+      options: [
+        { label: "Option A", description: "First" },
+        { label: "Option B", description: "Second" },
+      ],
+      allowMultiple: false,
+    }],
+  };
+}
+
+function makeEnvelope(sender: string, message: string, senderUuid?: string) {
+  return {
+    envelope: {
+      source: sender,
+      sourceUuid: senderUuid ?? "uuid-" + sender.replace(/\+/g, ""),
+      dataMessage: {
+        message,
+        timestamp: Date.now(),
+      },
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Integration tests
+// ---------------------------------------------------------------------------
+
+test("SignalAdapter.validate succeeds against mock server", async () => {
+  const server = await startMockSignalServer();
+  try {
+    const original = process.env.SIGNAL_PHONE_NUMBER;
+    process.env.SIGNAL_PHONE_NUMBER = "+15550001111";
+
+    const { SignalAdapter } = await import("../../remote-questions/signal-adapter.ts");
+    const adapter = new SignalAdapter(server.url, "+15552223333");
+    await adapter.validate();  // should not throw
+
+    if (original !== undefined) process.env.SIGNAL_PHONE_NUMBER = original;
+    else delete process.env.SIGNAL_PHONE_NUMBER;
+  } finally {
+    await server.close();
+  }
+});
+
+test("SignalAdapter.sendPrompt sends formatted message to mock server", async () => {
+  const server = await startMockSignalServer();
+  try {
+    process.env.SIGNAL_PHONE_NUMBER = "+15550001111";
+
+    const { SignalAdapter } = await import("../../remote-questions/signal-adapter.ts");
+    const adapter = new SignalAdapter(server.url, "+15552223333");
+    await adapter.validate();
+
+    const prompt = makePrompt();
+    const result = await adapter.sendPrompt(prompt);
+
+    // Check the message was sent
+    assert.equal(server.sentMessages.length, 1);
+    assert.equal(server.sentMessages[0].number, "+15550001111");
+    assert.deepEqual(server.sentMessages[0].recipients, ["+15552223333"]);
+    assert.ok(server.sentMessages[0].message.includes("GSD needs your input"));
+    assert.ok(server.sentMessages[0].message.includes("Option A"));
+
+    // Check the returned ref
+    assert.equal(result.ref.channel, "signal");
+    assert.equal(result.ref.channelId, "+15552223333");
+    assert.ok(result.ref.messageId);
+
+    delete process.env.SIGNAL_PHONE_NUMBER;
+  } finally {
+    await server.close();
+  }
+});
+
+test("SignalAdapter.pollAnswer receives reply via WebSocket", async () => {
+  const server = await startMockSignalServer();
+  try {
+    process.env.SIGNAL_PHONE_NUMBER = "+15550001111";
+
+    const { SignalAdapter } = await import("../../remote-questions/signal-adapter.ts");
+    const adapter = new SignalAdapter(server.url, "+15552223333");
+    await adapter.validate();
+
+    const prompt = makePrompt();
+    const sendResult = await adapter.sendPrompt(prompt);
+
+    // Start polling, then inject a reply after a short delay
+    const pollPromise = adapter.pollAnswer(prompt, sendResult.ref);
+
+    // Wait for WebSocket to connect, then inject reply
+    await new Promise((r) => setTimeout(r, 500));
+    server.injectMessage(makeEnvelope("+15552223333", "2"));
+
+    const answer = await pollPromise;
+
+    assert.ok(answer, "Expected an answer from pollAnswer");
+    assert.deepEqual(answer!.answers.choice.answers, ["Option B"]);
+
+    delete process.env.SIGNAL_PHONE_NUMBER;
+  } finally {
+    await server.close();
+  }
+});
+
+test("SignalAdapter.pollAnswer ignores messages from wrong sender", async () => {
+  const server = await startMockSignalServer();
+  try {
+    process.env.SIGNAL_PHONE_NUMBER = "+15550001111";
+
+    const { SignalAdapter } = await import("../../remote-questions/signal-adapter.ts");
+    const adapter = new SignalAdapter(server.url, "+15552223333");
+    await adapter.validate();
+
+    const prompt = makePrompt();
+    const sendResult = await adapter.sendPrompt(prompt);
+
+    const pollPromise = adapter.pollAnswer(prompt, sendResult.ref);
+
+    await new Promise((r) => setTimeout(r, 500));
+    // Inject message from wrong sender — should be ignored
+    server.injectMessage(makeEnvelope("+15559999999", "1"));
+
+    const answer = await pollPromise;
+    assert.equal(answer, null, "Should return null when no matching reply");
+
+    delete process.env.SIGNAL_PHONE_NUMBER;
+  } finally {
+    await server.close();
+  }
+}, { timeout: 15_000 });
+
+test("SignalAdapter.acknowledgeAnswer sends confirmation", async () => {
+  const server = await startMockSignalServer();
+  try {
+    process.env.SIGNAL_PHONE_NUMBER = "+15550001111";
+
+    const { SignalAdapter } = await import("../../remote-questions/signal-adapter.ts");
+    const adapter = new SignalAdapter(server.url, "+15552223333");
+    await adapter.validate();
+
+    const ref = {
+      id: "test-ack",
+      channel: "signal" as const,
+      messageId: "123",
+      channelId: "+15552223333",
+    };
+
+    await adapter.acknowledgeAnswer(ref);
+
+    // Find the ack message (sendPrompt may have also sent one)
+    const ackMsg = server.sentMessages.find((m) => m.message.includes("Got it"));
+    assert.ok(ackMsg, "Expected acknowledgement message");
+    assert.ok(ackMsg!.message.includes("✅"));
+
+    delete process.env.SIGNAL_PHONE_NUMBER;
+  } finally {
+    await server.close();
+  }
+});
+
+test("SignalAdapter resolves UUID from contacts list", async () => {
+  const server = await startMockSignalServer();
+  // Set up contacts with UUID mapping
+  server.contacts.push(
+    { number: "+15552223333", uuid: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", profile: {} },
+  );
+  // Need to reassign since contacts is a separate array
+  const origHandler = server.httpServer.listeners("request")[0] as any;
+
+  try {
+    process.env.SIGNAL_PHONE_NUMBER = "+15550001111";
+
+    const { SignalAdapter } = await import("../../remote-questions/signal-adapter.ts");
+    const adapter = new SignalAdapter(server.url, "+15552223333");
+    await adapter.validate();
+
+    const prompt = makePrompt();
+    await adapter.sendPrompt(prompt);
+
+    // The send should use the UUID, not the phone number
+    const sent = server.sentMessages[0];
+    assert.ok(sent, "Expected a sent message");
+    // UUID resolution: recipient should be the UUID
+    assert.deepEqual(sent.recipients, ["aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"]);
+
+    delete process.env.SIGNAL_PHONE_NUMBER;
+  } finally {
+    await server.close();
+  }
+});
+
+test("SignalAdapter falls back to phone number when contacts lookup fails", async () => {
+  const server = await startMockSignalServer();
+  // Empty contacts — no UUID match
+  try {
+    process.env.SIGNAL_PHONE_NUMBER = "+15550001111";
+
+    const { SignalAdapter } = await import("../../remote-questions/signal-adapter.ts");
+    const adapter = new SignalAdapter(server.url, "+15554445555");
+    await adapter.validate();
+
+    const prompt = makePrompt();
+    await adapter.sendPrompt(prompt);
+
+    const sent = server.sentMessages[0];
+    assert.ok(sent);
+    assert.deepEqual(sent.recipients, ["+15554445555"]);
+
+    delete process.env.SIGNAL_PHONE_NUMBER;
+  } finally {
+    await server.close();
+  }
+});
+
+test("SignalAdapter handles free text reply as user_note", async () => {
+  const server = await startMockSignalServer();
+  try {
+    process.env.SIGNAL_PHONE_NUMBER = "+15550001111";
+
+    const { SignalAdapter } = await import("../../remote-questions/signal-adapter.ts");
+    const adapter = new SignalAdapter(server.url, "+15552223333");
+    await adapter.validate();
+
+    const prompt = makePrompt();
+    const sendResult = await adapter.sendPrompt(prompt);
+
+    const pollPromise = adapter.pollAnswer(prompt, sendResult.ref);
+
+    await new Promise((r) => setTimeout(r, 500));
+    server.injectMessage(makeEnvelope("+15552223333", "I want something custom"));
+
+    const answer = await pollPromise;
+
+    assert.ok(answer);
+    assert.deepEqual(answer!.answers.choice.answers, []);
+    assert.equal(answer!.answers.choice.user_note, "I want something custom");
+
+    delete process.env.SIGNAL_PHONE_NUMBER;
+  } finally {
+    await server.close();
+  }
+});

--- a/src/resources/extensions/gsd/tests/signal-remote-questions.test.ts
+++ b/src/resources/extensions/gsd/tests/signal-remote-questions.test.ts
@@ -1,0 +1,225 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { formatForSignal, parseSignalResponse, parseSlackReply } from "../../remote-questions/format.ts";
+import { isValidChannelId } from "../../remote-questions/config.ts";
+
+// ---------------------------------------------------------------------------
+// Signal channel ID validation
+// ---------------------------------------------------------------------------
+
+test("isValidChannelId accepts valid Signal phone numbers", () => {
+  assert.ok(isValidChannelId("signal", "+15551234567"));
+  assert.ok(isValidChannelId("signal", "+442071234567"));
+  assert.ok(isValidChannelId("signal", "+8613800138000"));
+});
+
+test("isValidChannelId rejects invalid Signal phone numbers", () => {
+  assert.ok(!isValidChannelId("signal", "5551234567"));    // missing +
+  assert.ok(!isValidChannelId("signal", "+123"));           // too short
+  assert.ok(!isValidChannelId("signal", "not-a-number"));   // letters
+  assert.ok(!isValidChannelId("signal", ""));               // empty
+});
+
+// ---------------------------------------------------------------------------
+// Signal message formatting
+// ---------------------------------------------------------------------------
+
+test("formatForSignal produces readable plain text for single question", () => {
+  const prompt = {
+    id: "test-123",
+    channel: "signal" as const,
+    createdAt: Date.now(),
+    timeoutAt: Date.now() + 300_000,
+    pollIntervalMs: 5000,
+    questions: [{
+      id: "choice",
+      header: "Approach",
+      question: "Which approach do you prefer?",
+      options: [
+        { label: "Option A", description: "First approach" },
+        { label: "Option B", description: "Second approach" },
+      ],
+      allowMultiple: false,
+    }],
+  };
+
+  const text = formatForSignal(prompt);
+
+  assert.ok(text.includes("GSD needs your input"));
+  assert.ok(text.includes("📋 Approach"));
+  assert.ok(text.includes("Which approach do you prefer?"));
+  assert.ok(text.includes("1. Option A — First approach"));
+  assert.ok(text.includes("2. Option B — Second approach"));
+  assert.ok(text.includes("Reply with a number"));
+});
+
+test("formatForSignal handles multi-select prompt", () => {
+  const prompt = {
+    id: "test-456",
+    channel: "signal" as const,
+    createdAt: Date.now(),
+    timeoutAt: Date.now() + 300_000,
+    pollIntervalMs: 5000,
+    questions: [{
+      id: "multi",
+      header: "Features",
+      question: "Which features do you want?",
+      options: [
+        { label: "Auth", description: "Authentication" },
+        { label: "API", description: "REST API" },
+        { label: "UI", description: "Web dashboard" },
+      ],
+      allowMultiple: true,
+    }],
+  };
+
+  const text = formatForSignal(prompt);
+  assert.ok(text.includes("comma-separated numbers"));
+});
+
+test("formatForSignal handles multi-question prompt", () => {
+  const prompt = {
+    id: "test-789",
+    channel: "signal" as const,
+    createdAt: Date.now(),
+    timeoutAt: Date.now() + 300_000,
+    pollIntervalMs: 5000,
+    questions: [
+      {
+        id: "q1",
+        header: "First",
+        question: "Pick one",
+        options: [{ label: "A", description: "a" }, { label: "B", description: "b" }],
+        allowMultiple: false,
+      },
+      {
+        id: "q2",
+        header: "Second",
+        question: "Pick another",
+        options: [{ label: "C", description: "c" }, { label: "D", description: "d" }],
+        allowMultiple: false,
+      },
+    ],
+  };
+
+  const text = formatForSignal(prompt);
+  assert.ok(text.includes("Question 1/2"));
+  assert.ok(text.includes("Question 2/2"));
+  assert.ok(text.includes("semicolons"));
+});
+
+// ---------------------------------------------------------------------------
+// Signal response parsing
+// ---------------------------------------------------------------------------
+
+test("parseSignalResponse handles single-number answer", () => {
+  const result = parseSignalResponse("2", [{
+    id: "choice",
+    header: "Choice",
+    question: "Pick one",
+    allowMultiple: false,
+    options: [
+      { label: "Alpha", description: "A" },
+      { label: "Beta", description: "B" },
+    ],
+  }], "prompt-1");
+
+  assert.deepEqual(result, { answers: { choice: { answers: ["Beta"] } } });
+});
+
+test("parseSignalResponse handles comma-separated multi-select", () => {
+  const result = parseSignalResponse("1,3", [{
+    id: "multi",
+    header: "Multi",
+    question: "Pick several",
+    allowMultiple: true,
+    options: [
+      { label: "A", description: "a" },
+      { label: "B", description: "b" },
+      { label: "C", description: "c" },
+    ],
+  }], "prompt-2");
+
+  assert.deepEqual(result, { answers: { multi: { answers: ["A", "C"] } } });
+});
+
+test("parseSignalResponse handles free text as user_note", () => {
+  const result = parseSignalResponse("I want something custom", [{
+    id: "choice",
+    header: "Choice",
+    question: "Pick one",
+    allowMultiple: false,
+    options: [
+      { label: "Alpha", description: "A" },
+      { label: "Beta", description: "B" },
+    ],
+  }], "prompt-3");
+
+  assert.deepEqual(result, {
+    answers: { choice: { answers: [], user_note: "I want something custom" } },
+  });
+});
+
+test("parseSignalResponse handles multi-question semicolon answers", () => {
+  const result = parseSignalResponse("1; custom note", [
+    {
+      id: "first",
+      header: "First",
+      question: "Pick one",
+      allowMultiple: false,
+      options: [
+        { label: "Alpha", description: "A" },
+        { label: "Beta", description: "B" },
+      ],
+    },
+    {
+      id: "second",
+      header: "Second",
+      question: "Explain",
+      allowMultiple: false,
+      options: [
+        { label: "Gamma", description: "G" },
+        { label: "Delta", description: "D" },
+      ],
+    },
+  ], "prompt-4");
+
+  assert.deepEqual(result, {
+    answers: {
+      first: { answers: ["Alpha"] },
+      second: { answers: [], user_note: "custom note" },
+    },
+  });
+});
+
+test("parseSignalResponse handles empty text", () => {
+  const result = parseSignalResponse("", [{
+    id: "choice",
+    header: "Choice",
+    question: "Pick one",
+    allowMultiple: false,
+    options: [{ label: "A", description: "a" }],
+  }], "prompt-5");
+
+  assert.deepEqual(result, {
+    answers: { choice: { answers: [], user_note: "No response provided" } },
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Signal adapter — constructor / validation (unit-level, no network)
+// ---------------------------------------------------------------------------
+
+test("SignalAdapter requires SIGNAL_PHONE_NUMBER", async () => {
+  const { SignalAdapter } = await import("../../remote-questions/signal-adapter.ts");
+  const original = process.env.SIGNAL_PHONE_NUMBER;
+  delete process.env.SIGNAL_PHONE_NUMBER;
+
+  const adapter = new SignalAdapter("http://localhost:8080", "+15551234567");
+  await assert.rejects(
+    () => adapter.validate(),
+    { message: /SIGNAL_PHONE_NUMBER not set/ },
+  );
+
+  if (original !== undefined) process.env.SIGNAL_PHONE_NUMBER = original;
+});

--- a/src/resources/extensions/remote-questions/config.ts
+++ b/src/resources/extensions/remote-questions/config.ts
@@ -17,6 +17,7 @@ const ENV_KEYS: Record<RemoteChannel, string> = {
   slack: "SLACK_BOT_TOKEN",
   discord: "DISCORD_BOT_TOKEN",
   telegram: "TELEGRAM_BOT_TOKEN",
+  signal: "SIGNAL_SERVICE_URL",
 };
 
 // Channel ID format validation — prevents SSRF if preferences are attacker-controlled
@@ -24,6 +25,7 @@ const CHANNEL_ID_PATTERNS: Record<RemoteChannel, RegExp> = {
   slack: /^[A-Z0-9]{9,12}$/,
   discord: /^\d{17,20}$/,
   telegram: /^-?\d{5,20}$/,
+  signal: /^\+\d{7,15}$/,
 };
 
 const DEFAULT_TIMEOUT_MINUTES = 5;
@@ -37,7 +39,7 @@ export function resolveRemoteConfig(): ResolvedConfig | null {
   const prefs = loadEffectiveGSDPreferences();
   const rq: RemoteQuestionsConfig | undefined = prefs?.preferences.remote_questions;
   if (!rq || !rq.channel || !rq.channel_id) return null;
-  if (rq.channel !== "slack" && rq.channel !== "discord" && rq.channel !== "telegram") return null;
+  if (rq.channel !== "slack" && rq.channel !== "discord" && rq.channel !== "telegram" && rq.channel !== "signal") return null;
 
   const channelId = String(rq.channel_id);
   if (!CHANNEL_ID_PATTERNS[rq.channel].test(channelId)) return null;
@@ -61,7 +63,7 @@ export function getRemoteConfigStatus(): string {
   const prefs = loadEffectiveGSDPreferences();
   const rq: RemoteQuestionsConfig | undefined = prefs?.preferences.remote_questions;
   if (!rq || !rq.channel || !rq.channel_id) return "Remote questions: not configured";
-  if (rq.channel !== "slack" && rq.channel !== "discord" && rq.channel !== "telegram") return `Remote questions: unknown channel type \"${rq.channel}\"`;
+  if (rq.channel !== "slack" && rq.channel !== "discord" && rq.channel !== "telegram" && rq.channel !== "signal") return `Remote questions: unknown channel type \"${rq.channel}\"`;
   const channelId = String(rq.channel_id);
   if (!CHANNEL_ID_PATTERNS[rq.channel].test(channelId)) return `Remote questions: invalid ${rq.channel} channel ID format`;
   const envVar = ENV_KEYS[rq.channel];

--- a/src/resources/extensions/remote-questions/extension-manifest.json
+++ b/src/resources/extensions/remote-questions/extension-manifest.json
@@ -2,7 +2,7 @@
   "id": "remote-questions",
   "name": "Remote Questions",
   "version": "1.0.0",
-  "description": "Remote user question routing via Slack, Discord, and Telegram adapters",
+  "description": "Remote user question routing via Slack, Discord, Telegram, and Signal adapters",
   "tier": "bundled",
   "requires": { "platform": ">=2.29.0" },
   "provides": {

--- a/src/resources/extensions/remote-questions/format.ts
+++ b/src/resources/extensions/remote-questions/format.ts
@@ -313,3 +313,53 @@ function parseAnswerForQuestion(text: string, q: RemoteQuestion): { answers: str
 function truncateNote(text: string): string {
   return text.length > MAX_USER_NOTE_LENGTH ? text.slice(0, MAX_USER_NOTE_LENGTH) + "…" : text;
 }
+
+// ---------------------------------------------------------------------------
+// Signal formatting
+// ---------------------------------------------------------------------------
+
+/**
+ * Format a prompt as a plain-text Signal message.
+ * Signal has no rich formatting (no HTML, no inline keyboards) — use
+ * numbered options with emoji bullets for clarity on mobile.
+ */
+export function formatForSignal(prompt: RemotePrompt): string {
+  const lines: string[] = ["🤖 GSD needs your input", ""];
+
+  for (let qi = 0; qi < prompt.questions.length; qi++) {
+    const q = prompt.questions[qi];
+    lines.push(`📋 ${q.header}`);
+    lines.push(q.question);
+    lines.push("");
+
+    for (let i = 0; i < q.options.length; i++) {
+      lines.push(`  ${i + 1}. ${q.options[i].label} — ${q.options[i].description}`);
+    }
+
+    lines.push("");
+    if (prompt.questions.length === 1) {
+      lines.push(q.allowMultiple
+        ? "Reply with comma-separated numbers (1,3) or free text."
+        : "Reply with a number (1) or free text.");
+    } else {
+      lines.push(`Question ${qi + 1}/${prompt.questions.length} — reply with one line per question or use semicolons.`);
+    }
+
+    if (qi < prompt.questions.length - 1) lines.push("");
+  }
+
+  return lines.join("\n");
+}
+
+/**
+ * Parse a Signal text reply into a RemoteAnswer.
+ * Reuses the same number/text parsing logic as Slack (format-agnostic).
+ */
+export function parseSignalResponse(
+  text: string,
+  questions: RemoteQuestion[],
+  _promptId: string,
+): RemoteAnswer {
+  return parseSlackReply(text, questions);
+}
+

--- a/src/resources/extensions/remote-questions/manager.ts
+++ b/src/resources/extensions/remote-questions/manager.ts
@@ -8,6 +8,7 @@ import { resolveRemoteConfig, type ResolvedConfig } from "./config.js";
 import { DiscordAdapter } from "./discord-adapter.js";
 import { SlackAdapter } from "./slack-adapter.js";
 import { TelegramAdapter } from "./telegram-adapter.js";
+import { SignalAdapter } from "./signal-adapter.js";
 import { createPromptRecord, writePromptRecord, markPromptAnswered, markPromptDispatched, markPromptStatus, updatePromptRecord } from "./store.js";
 import { sanitizeError } from "../shared/sanitize.js";
 
@@ -121,6 +122,7 @@ function createPrompt(questions: QuestionInput[], config: ResolvedConfig): Remot
 function createAdapter(config: ResolvedConfig): ChannelAdapter {
   if (config.channel === "slack") return new SlackAdapter(config.token, config.channelId);
   if (config.channel === "telegram") return new TelegramAdapter(config.token, config.channelId);
+  if (config.channel === "signal") return new SignalAdapter(config.token, config.channelId);
   return new DiscordAdapter(config.token, config.channelId);
 }
 

--- a/src/resources/extensions/remote-questions/remote-command.ts
+++ b/src/resources/extensions/remote-questions/remote-command.ts
@@ -22,6 +22,7 @@ export async function handleRemote(
   if (trimmed === "slack") return handleSetupSlack(ctx);
   if (trimmed === "discord") return handleSetupDiscord(ctx);
   if (trimmed === "telegram") return handleSetupTelegram(ctx);
+  if (trimmed === "signal") return handleSetupSignal(ctx);
   if (trimmed === "status") return handleRemoteStatus(ctx);
   if (trimmed === "disconnect") return handleDisconnect(ctx);
 
@@ -182,6 +183,52 @@ async function handleSetupTelegram(ctx: ExtensionCommandContext): Promise<void> 
   ctx.ui.notify(`Telegram connected — remote questions enabled for chat ${chatId}.`, "info");
 }
 
+async function handleSetupSignal(ctx: ExtensionCommandContext): Promise<void> {
+  const serviceUrl = await promptInput(ctx, "Signal Service URL", "signal-cli-rest-api URL (e.g. http://localhost:8080)");
+  if (!serviceUrl) return void ctx.ui.notify("Signal setup cancelled.", "info");
+  try { new URL(serviceUrl); } catch { return void ctx.ui.notify("Invalid URL format.", "error"); }
+  const trimmedUrl = serviceUrl.replace(/\/+$/, "");
+
+  const phoneNumber = await promptInput(ctx, "Bot Phone Number", "Registered with signal-cli (e.g. +15551234567)");
+  if (!phoneNumber) return void ctx.ui.notify("Signal setup cancelled.", "info");
+  if (!/^\+\d{7,15}$/.test(phoneNumber)) return void ctx.ui.notify("Invalid phone number — expected international format: +15551234567", "error");
+
+  ctx.ui.notify("Connecting to signal-cli-rest-api...", "info");
+  const about = await fetchJson(`${trimmedUrl}/v1/about`);
+  if (!about) return void ctx.ui.notify("Could not reach signal-cli-rest-api — check the URL.", "error");
+
+  const recipientNumber = await promptInput(ctx, "Your Phone Number", "Where questions will be sent (e.g. +15559876543)");
+  if (!recipientNumber) return void ctx.ui.notify("Signal setup cancelled.", "info");
+  if (!isValidChannelId("signal", recipientNumber)) return void ctx.ui.notify("Invalid phone number — expected international format: +15559876543", "error");
+
+  // Test send
+  ctx.ui.notify("Sending test message...", "info");
+  try {
+    const res = await fetch(`${trimmedUrl}/v2/send`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        message: "✅ GSD remote questions connected via Signal.",
+        number: phoneNumber,
+        recipients: [recipientNumber],
+      }),
+      signal: AbortSignal.timeout(15_000),
+    });
+    if (!res.ok) {
+      const body = await res.text().catch(() => "");
+      return void ctx.ui.notify(`Could not send test message: HTTP ${res.status} ${body.slice(0, 100)}`, "error");
+    }
+  } catch (err) {
+    return void ctx.ui.notify(`Could not send test message: ${(err as Error).message}`, "error");
+  }
+
+  saveProviderToken("signal_service", trimmedUrl);
+  process.env.SIGNAL_SERVICE_URL = trimmedUrl;
+  process.env.SIGNAL_PHONE_NUMBER = phoneNumber;
+  saveRemoteQuestionsConfig("signal", recipientNumber);
+  ctx.ui.notify(`Signal connected — remote questions enabled for ${recipientNumber}.`, "info");
+}
+
 async function handleRemoteStatus(ctx: ExtensionCommandContext): Promise<void> {
   const status = getRemoteConfigStatus();
   const config = resolveRemoteConfig();
@@ -207,11 +254,12 @@ async function handleDisconnect(ctx: ExtensionCommandContext): Promise<void> {
   if (!channel) return void ctx.ui.notify("No remote channel configured — nothing to disconnect.", "info");
 
   removeRemoteQuestionsConfig();
-  const providerMap: Record<string, string> = { slack: "slack_bot", discord: "discord_bot", telegram: "telegram_bot" };
+  const providerMap: Record<string, string> = { slack: "slack_bot", discord: "discord_bot", telegram: "telegram_bot", signal: "signal_service" };
   removeProviderToken(providerMap[channel] ?? channel);
   if (channel === "slack") delete process.env.SLACK_BOT_TOKEN;
   if (channel === "discord") delete process.env.DISCORD_BOT_TOKEN;
   if (channel === "telegram") delete process.env.TELEGRAM_BOT_TOKEN;
+  if (channel === "signal") { delete process.env.SIGNAL_SERVICE_URL; delete process.env.SIGNAL_PHONE_NUMBER; }
   ctx.ui.notify(`Remote questions disconnected (${channel}).`, "info");
 }
 
@@ -230,6 +278,7 @@ async function handleRemoteMenu(ctx: ExtensionCommandContext): Promise<void> {
         "  /gsd remote slack",
         "  /gsd remote discord",
         "  /gsd remote telegram",
+        "  /gsd remote signal",
       ]
     : [
         "No remote question channel configured.",
@@ -238,6 +287,7 @@ async function handleRemoteMenu(ctx: ExtensionCommandContext): Promise<void> {
         "  /gsd remote slack",
         "  /gsd remote discord",
         "  /gsd remote telegram",
+        "  /gsd remote signal",
         "  /gsd remote status",
       ];
 
@@ -315,7 +365,7 @@ function removeProviderToken(provider: string): void {
   auth.set(provider, { type: "api_key", key: "" });
 }
 
-export function saveRemoteQuestionsConfig(channel: "slack" | "discord" | "telegram", channelId: string): void {
+export function saveRemoteQuestionsConfig(channel: "slack" | "discord" | "telegram" | "signal", channelId: string): void {
   const prefsPath = getGlobalGSDPreferencesPath();
   const block = [
     "remote_questions:",

--- a/src/resources/extensions/remote-questions/signal-adapter.ts
+++ b/src/resources/extensions/remote-questions/signal-adapter.ts
@@ -1,0 +1,236 @@
+/**
+ * Remote Questions — Signal adapter
+ *
+ * Uses signal-cli-rest-api (https://github.com/bbernhard/signal-cli-rest-api)
+ * to send questions and poll for replies.
+ *
+ * Configuration:
+ *   - SIGNAL_SERVICE_URL: base URL of signal-cli-rest-api (e.g. http://localhost:8080)
+ *   - SIGNAL_PHONE_NUMBER: the bot's registered phone number
+ *   - channel_id: recipient phone number or UUID
+ *
+ * Sending uses the /v2/send REST endpoint.
+ * Receiving uses a WebSocket connection to /v1/receive/{number} — this is
+ * required when signal-cli-rest-api runs in json-rpc mode (the default for
+ * Docker deployments). The REST /v1/receive endpoint only works in normal mode.
+ *
+ * The adapter resolves the recipient's UUID from the contacts list on first
+ * use, since signal-cli may index contacts by UUID rather than phone number.
+ */
+
+import type {
+  ChannelAdapter,
+  RemotePrompt,
+  RemoteDispatchResult,
+  RemoteAnswer,
+  RemotePromptRef,
+} from "./types.js";
+import { formatForSignal, parseSignalResponse } from "./format.js";
+import { sanitizeError } from "../shared/sanitize.js";
+
+export class SignalAdapter implements ChannelAdapter {
+  readonly name = "signal" as const;
+  private readonly serviceUrl: string;
+  private readonly phoneNumber: string;
+  private readonly recipientNumber: string;
+  private resolvedRecipient: string | null = null;
+  private lastSentTimestamp = 0;
+
+  constructor(serviceUrl: string, recipientNumber: string) {
+    // serviceUrl is user-configured (SIGNAL_SERVICE_URL env var), unlike other adapters
+    // which hit fixed public APIs. This is intentional — signal-cli-rest-api is always
+    // a local/trusted service managed by the user. The value is set during onboarding
+    // or via env var, never from untrusted preferences.
+    this.serviceUrl = serviceUrl.replace(/\/+$/, "");
+    this.recipientNumber = recipientNumber;
+    this.phoneNumber = process.env.SIGNAL_PHONE_NUMBER ?? "";
+  }
+
+  async validate(): Promise<void> {
+    if (!this.phoneNumber) {
+      throw new Error("Signal auth failed: SIGNAL_PHONE_NUMBER not set");
+    }
+    if (!this.serviceUrl) {
+      throw new Error("Signal auth failed: SIGNAL_SERVICE_URL not set");
+    }
+
+    const resp = await fetch(`${this.serviceUrl}/v1/about`, {
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!resp.ok) {
+      throw new Error(`Signal service unreachable: HTTP ${resp.status}`);
+    }
+
+    // Pre-resolve the recipient to UUID if needed
+    await this.resolveRecipient();
+  }
+
+  async sendPrompt(prompt: RemotePrompt): Promise<RemoteDispatchResult> {
+    const text = formatForSignal(prompt);
+    const recipient = await this.resolveRecipient();
+
+    const resp = await fetch(`${this.serviceUrl}/v2/send`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        message: text,
+        number: this.phoneNumber,
+        recipients: [recipient],
+      }),
+      signal: AbortSignal.timeout(15_000),
+    });
+
+    if (!resp.ok) {
+      const body = await resp.text().catch(() => "");
+      throw new Error(`Signal send failed: HTTP ${resp.status}: ${sanitizeError(body.slice(0, 200))}`);
+    }
+
+    const result = await resp.json().catch(() => ({})) as Record<string, unknown>;
+    this.lastSentTimestamp = typeof result.timestamp === "string"
+      ? parseInt(result.timestamp, 10)
+      : Date.now();
+
+    return {
+      ref: {
+        id: prompt.id,
+        channel: "signal",
+        messageId: String(this.lastSentTimestamp),
+        channelId: this.recipientNumber,
+      },
+    };
+  }
+
+  async pollAnswer(
+    prompt: RemotePrompt,
+    ref: RemotePromptRef,
+  ): Promise<RemoteAnswer | null> {
+    // Use WebSocket for a single poll cycle. signal-cli-rest-api in json-rpc
+    // mode (the Docker default) only delivers messages via WebSocket.
+    const wsUrl = `${this.serviceUrl.replace(/^http/, "ws")}/v1/receive/${encodeURIComponent(this.phoneNumber)}`;
+    const recipient = this.resolvedRecipient ?? this.recipientNumber;
+
+    // Resolve WebSocket implementation before opening the connection
+    let WebSocketImpl: any;
+    try {
+      // Prefer global WebSocket (Bun, Deno), fall back to 'ws' package (Node).
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      WebSocketImpl = globalThis.WebSocket ?? ((await import("ws" as string)) as any).default;
+    } catch {
+      return null;
+    }
+
+    return new Promise<RemoteAnswer | null>((resolve) => {
+      let settled = false;
+      const finish = (result: RemoteAnswer | null) => {
+        if (settled) return;
+        settled = true;
+        try { ws.close(); } catch { /* ignore */ }
+        resolve(result);
+      };
+
+      // Timeout: don't hold the WebSocket open longer than one poll interval
+      const timer = setTimeout(() => finish(null), 8_000);
+
+      let ws: any;
+      try {
+        ws = new WebSocketImpl(wsUrl);
+      } catch {
+        clearTimeout(timer);
+        resolve(null);
+        return;
+      }
+
+      ws.onmessage = (event: any) => {
+        try {
+          const data = typeof event.data === "string" ? event.data : event.data.toString();
+          const envelope = JSON.parse(data);
+          const msg = envelope.envelope?.dataMessage;
+          if (!msg?.message) return;
+
+          const sender = envelope.envelope?.source;
+          const senderUuid = envelope.envelope?.sourceUuid;
+
+          // Match by phone number or UUID
+          const isRecipient =
+            sender === this.recipientNumber ||
+            senderUuid === recipient ||
+            sender === recipient;
+          if (!isRecipient) return;
+
+          const msgTimestamp = msg.timestamp ?? 0;
+          if (msgTimestamp < this.lastSentTimestamp) return;
+
+          clearTimeout(timer);
+          finish(parseSignalResponse(msg.message.trim(), prompt.questions, prompt.id));
+        } catch { /* ignore parse errors */ }
+      };
+
+      ws.onerror = () => {
+        clearTimeout(timer);
+        finish(null);
+      };
+
+      ws.onclose = () => {
+        clearTimeout(timer);
+        finish(null);
+      };
+    });
+  }
+
+  async acknowledgeAnswer(ref: RemotePromptRef): Promise<void> {
+    const recipient = this.resolvedRecipient ?? this.recipientNumber;
+    try {
+      await fetch(`${this.serviceUrl}/v2/send`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          message: "✅ Got it — continuing.",
+          number: this.phoneNumber,
+          recipients: [recipient],
+        }),
+        signal: AbortSignal.timeout(10_000),
+      });
+    } catch {
+      // Best-effort
+    }
+  }
+
+  /**
+   * Resolve the recipient to a UUID if signal-cli has them indexed by UUID
+   * rather than phone number. Falls back to the phone number if no match.
+   */
+  private async resolveRecipient(): Promise<string> {
+    if (this.resolvedRecipient) return this.resolvedRecipient;
+
+    // If it already looks like a UUID, use it directly
+    if (/^[0-9a-f]{8}-/.test(this.recipientNumber)) {
+      this.resolvedRecipient = this.recipientNumber;
+      return this.resolvedRecipient;
+    }
+
+    // Try the contacts list to find the UUID for this phone number
+    try {
+      const resp = await fetch(
+        `${this.serviceUrl}/v1/contacts/${encodeURIComponent(this.phoneNumber)}`,
+        { signal: AbortSignal.timeout(10_000) },
+      );
+      if (resp.ok) {
+        const contacts: any[] = await resp.json();
+        if (Array.isArray(contacts)) {
+          // Match by phone number
+          const match = contacts.find((c: any) => c.number === this.recipientNumber);
+          if (match?.uuid) {
+            this.resolvedRecipient = match.uuid as string;
+            return this.resolvedRecipient;
+          }
+        }
+      }
+    } catch {
+      // Best-effort — fall through to phone number
+    }
+
+    // Fall back to phone number (works if signal-cli has the mapping)
+    this.resolvedRecipient = this.recipientNumber;
+    return this.resolvedRecipient;
+  }
+}

--- a/src/resources/extensions/remote-questions/types.ts
+++ b/src/resources/extensions/remote-questions/types.ts
@@ -5,7 +5,7 @@
 /** Timeout applied to every outbound HTTP request across all channel adapters. */
 export const PER_REQUEST_TIMEOUT_MS = 15_000;
 
-export type RemoteChannel = "slack" | "discord" | "telegram";
+export type RemoteChannel = "slack" | "discord" | "telegram" | "signal";
 
 export interface RemoteQuestionOption {
   label: string;


### PR DESCRIPTION
## TL;DR

**What:** Add Signal as a fourth remote questions channel (alongside Slack, Discord, Telegram) via signal-cli-rest-api.
**Why:** Signal provides end-to-end encrypted question routing for privacy-conscious users running GSD in headless/CI mode.
**How:** New `SignalAdapter` implementing the existing `ChannelAdapter` interface, with WebSocket-based message polling (required for signal-cli's default json-rpc Docker mode) and automatic UUID resolution from the contacts list.

## What

Adds Signal support to the remote-questions extension. When GSD hits a decision point during auto/headless mode, it can now route the question to a Signal conversation via a self-hosted [signal-cli-rest-api](https://github.com/bbernhard/signal-cli-rest-api) instance.

**Files changed (15):**

| File | Change |
|------|--------|
| `signal-adapter.ts` | New `ChannelAdapter` implementation (220 lines) |
| `format.ts` | `formatForSignal()` (plain text + emoji) and `parseSignalResponse()` |
| `types.ts` | Extend `RemoteChannel` union with `"signal"` |
| `config.ts` | Add `SIGNAL_SERVICE_URL` env key and `^\+\d{7,15}$` phone validation |
| `manager.ts` | Wire `SignalAdapter` into `createAdapter()` |
| `remote-command.ts` | `/gsd remote signal` interactive setup flow |
| `onboarding.ts` | Signal option in channel selection during first-run wizard |
| `preferences-types.ts` | Extend channel union type |
| `remote-questions-config.ts` | Extend `saveRemoteQuestionsConfig` signature |
| `extension-manifest.json` | Update description |
| `README.md` | Update 3 references to include Signal |
| `docs/remote-questions.md` | Full Signal setup section, config, commands, troubleshooting |
| `signal-remote-questions.test.ts` | 11 unit tests (format, parse, validation) |
| `signal-integration.test.ts` | 8 integration tests (mock HTTP + WebSocket server) |

## Why

The existing remote-questions extension supports Slack, Discord, and Telegram — all centralized platforms. Signal is the standard for privacy-focused encrypted messaging and is commonly self-hosted via signal-cli-rest-api in security-conscious environments.

The adapter pattern was already clean and extensible. Adding Signal required no architectural changes — just a new adapter file plus type/config extensions.

## How

**Sending:** Uses the `/v2/send` REST endpoint to post formatted questions. Messages are plain text with numbered options and emoji bullets (Signal has no rich formatting, inline keyboards, or reactions).

**Receiving:** Uses a WebSocket connection to `/v1/receive/{number}`. This was a key discovery during live testing — the REST `/v1/receive` endpoint only works when signal-cli runs in `normal` mode, but the default Docker mode is `json-rpc`, which requires WebSocket. The adapter opens a short-lived WebSocket per poll cycle (8s timeout), matching the poll interval pattern used by other adapters.

**UUID resolution:** signal-cli sometimes indexes contacts by UUID rather than phone number, causing `/v2/send` with a phone number to return 400. The adapter resolves the recipient's UUID from the `/v1/contacts` endpoint on first use and falls back to the phone number if no UUID match is found.

**Security considerations:**
- Error messages are wrapped with `sanitizeError()` to prevent leaking service URLs or tokens
- Phone number validation uses E.164 regex (`^\+\d{7,15}$`) consistent with the other adapters' channel ID validation
- The `SIGNAL_SERVICE_URL` is user-configured (unlike other adapters which hit fixed public APIs) — this is intentional since signal-cli-rest-api is always a local/trusted service. Documented in code.
- All `fetch()` calls use `AbortSignal.timeout()` to prevent hanging
- No phone numbers, UUIDs, or PII in any committed code — only example numbers (`+15551234567`)

**Configuration:**
```yaml
# ~/.gsd/preferences.md frontmatter
remote_questions:
  channel: signal
  channel_id: "+15559876543"    # recipient phone number
  timeout_minutes: 5
  poll_interval_seconds: 5
```
```bash
SIGNAL_SERVICE_URL=http://localhost:8080
SIGNAL_PHONE_NUMBER=+15551234567
```

## Testing

**52 tests total, all passing:**
- 11 unit tests: channel ID validation, message formatting (single/multi-select/multi-question), response parsing (number, comma-separated, free text, semicolons, empty), adapter constructor validation
- 8 integration tests using mock HTTP + WebSocket servers: validate, sendPrompt, pollAnswer (correct sender + wrong sender filtering), acknowledgeAnswer, UUID resolution from contacts, phone number fallback, free text user_note handling
- 33 existing remote-questions tests: all still passing (no regressions)

**Build:** `npm run build` compiles cleanly (tsc + full web build).

**Live tested:** Full send → WebSocket receive → acknowledge round-trip verified against signal-cli-rest-api v0.98 (Docker, json-rpc mode). Functional testing confirmed message delivery and reply capture.

**AI-assisted:** This PR was developed with AI assistance (Claude/CIPHER). All code was tested, reviewed, security audited, and the approach is fully understood by the contributor.

## Change type

- [x] `feat` — New feature or capability
- [x] `test` — Adding tests
- [x] `docs` — Documentation updates
