### PR TITLE
fix: clean up extension error listener on session dispose

### DIFF
--- a/packages/pi-coding-agent/src/core/agent-session.ts
+++ b/packages/pi-coding-agent/src/core/agent-session.ts
@@ -685,6 +685,8 @@ export class AgentSession {
 	 * Call this when completely done with the session.
 	 */
 	dispose(): void {
+		this._extensionErrorUnsubscriber?.();
+		this._extensionErrorUnsubscriber = undefined;
 		this._disconnectFromAgent();
 		this._eventListeners = [];
 	}
@@ -2159,7 +2161,11 @@ export class AgentSession {
 		runner.setUIContext(this._extensionUIContext);
 		runner.bindCommandContext(this._extensionCommandContextActions);
 
-		this._extensionErrorUnsubscriber?.();
+		try {
+			this._extensionErrorUnsubscriber?.();
+		} catch {
+			// Ignore errors from previous unsubscriber
+		}
 		this._extensionErrorUnsubscriber = this._extensionErrorListener
 			? runner.onError(this._extensionErrorListener)
 			: undefined;


### PR DESCRIPTION
## What

Fix memory leaks in `agent-session.ts` by properly cleaning up the extension error listener subscription.

## Why

The `dispose()` method was not calling `_extensionErrorUnsubscriber`, so the extension error handler remained subscribed to the extension runner after session disposal. Over multiple session reloads in long-running processes, old error handlers accumulate and leak memory.

Additionally, if the previous unsubscriber threw in `_applyExtensionBindings()`, the new subscription would never be set up, silently breaking extension error handling.

## How

1. **`dispose()` method**: Added `_extensionErrorUnsubscriber?.()` and `= undefined` cleanup before disconnecting from the agent
2. **`_applyExtensionBindings()` method**: Wrapped the existing `_extensionErrorUnsubscriber?.()` call in a try-catch so that a failing previous unsubscriber does not prevent the new subscription from being established

## Key changes

- `packages/pi-coding-agent/src/core/agent-session.ts`
  - `dispose()`: Calls and clears `_extensionErrorUnsubscriber` before `_disconnectFromAgent()`
  - `_applyExtensionBindings()`: try-catch around unsubscriber invocation

## Testing

- `npx tsc --noEmit` passes with no type errors
- Verified all references to `_extensionErrorUnsubscriber` are consistent

## Risk

Low. Both changes are defensive additions:
- The dispose cleanup is a straightforward missing teardown step
- The try-catch is a safety net that only changes behavior if the unsubscriber was already throwing