### PR TITLE
fix: remove leaked abort signal listeners in find, ls, and sleep

### DIFF
--- a/packages/pi-coding-agent/src/core/tools/find.ts
+++ b/packages/pi-coding-agent/src/core/tools/find.ts
@@ -79,6 +79,7 @@ export function createFindTool(cwd: string, options?: FindToolOptions): AgentToo
 						// If custom operations provided with glob, use that
 						if (customOps?.glob) {
 							if (!(await ops.exists(searchPath))) {
+								signal?.removeEventListener("abort", onAbort);
 								reject(new Error(`Path not found: ${searchPath}`));
 								return;
 							}

--- a/packages/pi-coding-agent/src/core/tools/ls.ts
+++ b/packages/pi-coding-agent/src/core/tools/ls.ts
@@ -72,6 +72,7 @@ export function createLsTool(cwd: string, options?: LsToolOptions): AgentTool<ty
 
 						// Check if path exists
 						if (!(await ops.exists(dirPath))) {
+							signal?.removeEventListener("abort", onAbort);
 							reject(new Error(`Path not found: ${dirPath}`));
 							return;
 						}
@@ -79,6 +80,7 @@ export function createLsTool(cwd: string, options?: LsToolOptions): AgentTool<ty
 						// Check if path is a directory
 						const stat = await ops.stat(dirPath);
 						if (!stat.isDirectory()) {
+							signal?.removeEventListener("abort", onAbort);
 							reject(new Error(`Not a directory: ${dirPath}`));
 							return;
 						}
@@ -88,6 +90,7 @@ export function createLsTool(cwd: string, options?: LsToolOptions): AgentTool<ty
 						try {
 							entries = await ops.readdir(dirPath);
 						} catch (e: any) {
+							signal?.removeEventListener("abort", onAbort);
 							reject(new Error(`Cannot read directory: ${e.message}`));
 							return;
 						}

--- a/packages/pi-coding-agent/src/utils/sleep.ts
+++ b/packages/pi-coding-agent/src/utils/sleep.ts
@@ -8,11 +8,16 @@ export function sleep(ms: number, signal?: AbortSignal): Promise<void> {
 			return;
 		}
 
-		const timeout = setTimeout(resolve, ms);
-
-		signal?.addEventListener("abort", () => {
+		const onAbort = () => {
 			clearTimeout(timeout);
 			reject(new Error("Aborted"));
-		});
+		};
+
+		const timeout = setTimeout(() => {
+			signal?.removeEventListener("abort", onAbort);
+			resolve();
+		}, ms);
+
+		signal?.addEventListener("abort", onAbort, { once: true });
 	});
 }


### PR DESCRIPTION
## What

Fix event listener leaks on `AbortSignal` in three files where `removeEventListener` is missing on early return/reject paths.

## Why

When promises reject early (e.g., path not found, not a directory, readdir failure), the abort listener stays attached to the signal. Over many tool calls, listeners accumulate on shared `AbortController` signals, causing memory growth proportional to the number of failed/early-exit tool invocations.

## How

Add `signal?.removeEventListener("abort", onAbort)` before every early `reject()` call, and restructure `sleep.ts` for proper bidirectional cleanup.

## Key changes

### `packages/pi-coding-agent/src/core/tools/find.ts`
- Added listener cleanup before `reject()` when custom-ops path doesn't exist (line 82)

### `packages/pi-coding-agent/src/core/tools/ls.ts`
- Added listener cleanup before `reject()` on three early-exit paths:
  - Path not found
  - Not a directory
  - Cannot read directory (readdir throws)

### `packages/pi-coding-agent/src/utils/sleep.ts`
- Extracted anonymous abort handler into named `onAbort` function so it can be removed
- Added `{ once: true }` option to `addEventListener` for defense-in-depth
- Added `signal?.removeEventListener("abort", onAbort)` in the normal timeout-resolve path so the listener is cleaned up when sleep completes normally

## Testing

- `npx tsc --noEmit` passes with zero errors
- Manual review confirms every early-exit path in all three files now cleans up its listener
- The happy paths already had cleanup; this PR closes the gaps on error paths

## Risk

Low. All changes are additive cleanup calls (`removeEventListener`) on rejection paths. No behavioral change to success paths. The `{ once: true }` option on sleep's listener is an extra safety net but doesn't change semantics since we also explicitly remove.