### PR TITLE
fix(ai): resolve WebSocket listener leaks and bound session cache

### DIFF
--- a/packages/pi-ai/src/providers/openai-codex-responses.ts
+++ b/packages/pi-ai/src/providers/openai-codex-responses.ts
@@ -451,6 +451,7 @@ async function* parseSSE(response: Response): AsyncGenerator<Record<string, unkn
 
 const OPENAI_BETA_RESPONSES_WEBSOCKETS = "responses_websockets=2026-02-06";
 const SESSION_WEBSOCKET_CACHE_TTL_MS = 5 * 60 * 1000;
+const MAX_WEBSOCKET_CACHE_SIZE = 10;
 
 type WebSocketEventType = "open" | "message" | "error" | "close";
 type WebSocketListener = (event: unknown) => void;
@@ -635,6 +636,20 @@ async function acquireWebSocket(
 
 	const socket = await connectWebSocket(url, headers, signal);
 	const entry: CachedWebSocketConnection = { socket, busy: true };
+
+	// Evict the oldest entry if the cache is at capacity (LRU eviction).
+	if (websocketSessionCache.size >= MAX_WEBSOCKET_CACHE_SIZE) {
+		const oldestKey = websocketSessionCache.keys().next().value;
+		if (oldestKey) {
+			const oldEntry = websocketSessionCache.get(oldestKey);
+			websocketSessionCache.delete(oldestKey);
+			if (oldEntry) {
+				if (oldEntry.idleTimer) clearTimeout(oldEntry.idleTimer);
+				closeWebSocketSilently(oldEntry.socket);
+			}
+		}
+	}
+
 	websocketSessionCache.set(sessionId, entry);
 	return {
 		socket,
@@ -705,12 +720,19 @@ async function* parseWebSocket(socket: WebSocketLike, signal?: AbortSignal): Asy
 		resolve();
 	};
 
+	const cleanup = () => {
+		socket.removeEventListener("message", onMessage);
+		socket.removeEventListener("error", onError);
+		socket.removeEventListener("close", onClose);
+		signal?.removeEventListener("abort", onAbort);
+	};
+
 	const onMessage: WebSocketListener = (event) => {
 		void (async () => {
-			if (!event || typeof event !== "object" || !("data" in event)) return;
-			const text = await decodeWebSocketData((event as { data?: unknown }).data);
-			if (!text) return;
 			try {
+				if (!event || typeof event !== "object" || !("data" in event)) return;
+				const text = await decodeWebSocketData((event as { data?: unknown }).data);
+				if (!text) return;
 				const parsed = JSON.parse(text) as Record<string, unknown>;
 				const type = typeof parsed.type === "string" ? parsed.type : "";
 				if (type === "response.completed" || type === "response.done") {
@@ -719,7 +741,19 @@ async function* parseWebSocket(socket: WebSocketLike, signal?: AbortSignal): Asy
 				}
 				queue.push(parsed);
 				wake();
-			} catch {}
+			} catch (err) {
+				// Ensure listeners are cleaned up if the async handler errors.
+				// Without this, the fire-and-forget promise would swallow the
+				// error while leaving listeners attached to the socket.
+				if (err instanceof SyntaxError) {
+					// JSON parse failure — skip the malformed message.
+					return;
+				}
+				failed = err instanceof Error ? err : new Error(String(err));
+				done = true;
+				cleanup();
+				wake();
+			}
 		})();
 	};
 
@@ -775,10 +809,7 @@ async function* parseWebSocket(socket: WebSocketLike, signal?: AbortSignal): Asy
 			throw new Error("WebSocket stream closed before response.completed");
 		}
 	} finally {
-		socket.removeEventListener("message", onMessage);
-		socket.removeEventListener("error", onError);
-		socket.removeEventListener("close", onClose);
-		signal?.removeEventListener("abort", onAbort);
+		cleanup();
 	}
 }
 


### PR DESCRIPTION
## What
Fix two memory leaks in the AI provider WebSocket streaming code in `openai-codex-responses.ts`.

## Why
1. **Listener leak**: The `parseWebSocket()` `onMessage` handler is an async fire-and-forget IIFE. If `decodeWebSocketData()` or any subsequent async operation throws a non-SyntaxError, the error is silently swallowed while four event listeners remain attached to the socket — accumulating JS heap references over time.
2. **Unbounded cache**: `websocketSessionCache` is a plain `Map` with no size limit. In long-running processes with many distinct session IDs, it grows indefinitely, retaining stale `WebSocketLike` objects and their idle timers.

## How

### WebSocket listener cleanup (`parseWebSocket`, ~line 709)
- Extracted the four `removeEventListener` calls into a shared `cleanup()` helper, used by both the `onMessage` error path and the generator's `finally` block.
- Wrapped the entire `onMessage` async body in `try/catch`:
  - **SyntaxError** (malformed JSON): treated as non-fatal, message skipped.
  - **All other errors**: set `failed`/`done`, call `cleanup()` to immediately detach listeners, then `wake()` to unblock the generator loop which will re-throw.

### Cache size limit (`acquireWebSocket`, ~line 637)
- Added `MAX_WEBSOCKET_CACHE_SIZE = 10` constant.
- Before inserting a new entry into `websocketSessionCache`, check if the map is at capacity. If so, evict the oldest entry (first key in Map insertion order), clearing its idle timer and closing its socket.

## Key changes
- `packages/pi-ai/src/providers/openai-codex-responses.ts` — 39 insertions, 8 deletions

## Testing
- [x] `npx tsc --noEmit` passes with zero type errors
- [ ] Manual verification: confirm WebSocket streaming still works end-to-end
- [ ] Confirm that under high session churn the cache stays bounded at 10 entries

## Risk
**Low**. Both changes are additive defensive measures:
- The cleanup helper is idempotent (`removeEventListener` on an already-removed listener is a no-op).
- LRU eviction only activates when 10+ distinct sessions accumulate, which is well above normal usage. Eviction properly closes the socket and clears timers.