### PR TITLE
fix(ci): standardize GitHub Actions and Node.js versions

### DIFF
--- a/.github/workflows/ai-triage.yml
+++ b/.github/workflows/ai-triage.yml
@@ -14,7 +14,7 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           sparse-checkout: |
             VISION.md

--- a/.github/workflows/pr-risk.yml
+++ b/.github/workflows/pr-risk.yml
@@ -19,14 +19,14 @@ jobs:
     steps:
       # Checkout the BASE branch — our trusted script and map, not fork code.
       - name: Checkout base
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.base_ref }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
 
       # Use the GitHub API to get changed files — no fork code is executed.
       - name: Get changed files
@@ -44,14 +44,14 @@ jobs:
         id: risk
         run: |
           REPORT=$(cat /tmp/changed-files.txt | node scripts/pr-risk-check.mjs --github || true)
-          echo "report<<EOF" >> $GITHUB_OUTPUT
-          echo "$REPORT" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          echo "report<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$REPORT" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
 
           RISK_LEVEL=$(cat /tmp/changed-files.txt | node scripts/pr-risk-check.mjs --json 2>/dev/null \
             | node -e "let d=''; process.stdin.on('data',c=>d+=c); process.stdin.on('end',()=>{ try { console.log(JSON.parse(d).risk) } catch { console.log('low') } })" \
             || echo "low")
-          echo "level=$RISK_LEVEL" >> $GITHUB_OUTPUT
+          echo "level=$RISK_LEVEL" >> "$GITHUB_OUTPUT"
 
       - name: Write step summary
         run: echo "${{ steps.risk.outputs.report }}" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## What

Standardize GitHub Actions versions across all CI workflows. `pr-risk.yml` and `ai-triage.yml` were using outdated `actions/checkout@v4` and `actions/setup-node@v4` with Node 20, while all other workflows (`ci.yml`, `pipeline.yml`, `build-native.yml`, `cleanup-dev-versions.yml`) use `@v6` with Node 24.

## Why

- **Consistency**: Version inconsistency causes different behavior across CI jobs.
- **Security**: Older action versions may miss security patches available in newer releases.
- **Maintenance**: A single standard version across all workflows reduces cognitive overhead.
- **Shell correctness**: Unquoted `$GITHUB_OUTPUT` in `pr-risk.yml` is a word-splitting bug waiting to happen.

## How

Version bumps only — no logic changes.

## Key changes

### `pr-risk.yml`
- `actions/checkout@v4` → `@v6`
- `actions/setup-node@v4` → `@v6`
- `node-version: '20'` → `'24'`
- Quote all `$GITHUB_OUTPUT` references (`>> $GITHUB_OUTPUT` → `>> "$GITHUB_OUTPUT"`) on 4 lines

### `ai-triage.yml`
- `actions/checkout@v4` → `@v6`

## Testing

- [x] YAML syntax validated with `python3 yaml.safe_load()` for both files
- [x] Diff reviewed — only version strings and quoting changed, no logic modifications
- [ ] CI workflows will validate on this PR itself

## Risk

**Low** — Pure version bumps and shell quoting fix. No behavioral logic changes.