### PR TITLE
fix(lsp): bound message buffer and clean up stale client state

### DIFF
--- a/packages/pi-coding-agent/src/core/lsp/client.ts
+++ b/packages/pi-coding-agent/src/core/lsp/client.ts
@@ -29,6 +29,9 @@ let idleTimeoutMs: number | null = null;
 let idleCheckInterval: ReturnType<typeof setInterval> | null = null;
 const IDLE_CHECK_INTERVAL_MS = 60 * 1000;
 
+/** Maximum allowed size for the message buffer (10 MB). */
+const MAX_MESSAGE_BUFFER_SIZE = 10 * 1024 * 1024;
+
 /**
  * Configure the idle timeout for LSP clients.
  */
@@ -51,6 +54,10 @@ function startIdleChecker(): void {
 			if (now - client.lastActivity > idleTimeoutMs) {
 				shutdownClient(key);
 			}
+		}
+		// Stop the checker if there are no more clients to monitor
+		if (clients.size === 0) {
+			stopIdleChecker();
 		}
 	}, IDLE_CHECK_INTERVAL_MS);
 }
@@ -252,6 +259,17 @@ async function startMessageReader(client: LspClient): Promise<void> {
 	return new Promise<void>((resolve) => {
 		stdout.on("data", async (chunk: Buffer) => {
 			const currentBuffer: Buffer = Buffer.concat([client.messageBuffer, chunk]);
+
+			if (currentBuffer.length > MAX_MESSAGE_BUFFER_SIZE) {
+				if (process.env.DEBUG) {
+					console.error(
+						`[lsp] Message buffer exceeded ${MAX_MESSAGE_BUFFER_SIZE} bytes (${currentBuffer.length}), discarding`,
+					);
+				}
+				client.messageBuffer = Buffer.alloc(0);
+				return;
+			}
+
 			client.messageBuffer = currentBuffer;
 
 			let workingBuffer = currentBuffer;
@@ -778,6 +796,14 @@ export function shutdownClient(key: string): void {
 		client.proc.kill();
 	}
 	clients.delete(key);
+	clientLocks.delete(key);
+
+	// Clean up any file operation locks associated with this client
+	for (const lockKey of Array.from(fileOperationLocks.keys())) {
+		if (lockKey.startsWith(`${key}:`)) {
+			fileOperationLocks.delete(lockKey);
+		}
+	}
 }
 
 // =============================================================================
@@ -892,6 +918,9 @@ export async function sendNotification(client: LspClient, method: string, params
 export function shutdownAll(): void {
 	const clientsToShutdown = Array.from(clients.values());
 	clients.clear();
+	clientLocks.clear();
+	fileOperationLocks.clear();
+	stopIdleChecker();
 
 	const err = new Error("LSP client shutdown");
 	for (const client of clientsToShutdown) {


### PR DESCRIPTION
## What
Fix three sources of unbounded memory growth in the LSP client module.

## Why
Long-running sessions with multiple workspaces accumulate LSP client entries in global `clients`, `clientLocks`, and `fileOperationLocks` Maps that are never evicted after the client exits. Additionally, the `messageBuffer` can grow to 10-50 MB if an LSP server sends malformed or incomplete data, and the idle check interval may keep running even when no clients exist.

## How

### 1. Message buffer size cap
- Added `MAX_MESSAGE_BUFFER_SIZE` constant (10 MB)
- In the `stdout` data handler, check if the concatenated buffer exceeds the limit before processing
- If exceeded, discard the buffer entirely (log in DEBUG mode) and return early
- This prevents runaway memory consumption from misbehaving LSP servers

### 2. Client and lock map cleanup on shutdown
- `shutdownClient()` now also deletes the entry from `clientLocks` and removes associated `fileOperationLocks` entries
- `shutdownAll()` now clears `clientLocks` and `fileOperationLocks` alongside `clients`

### 3. Idle checker lifecycle management
- The idle check interval now stops itself when no clients remain after eviction
- `shutdownAll()` explicitly calls `stopIdleChecker()` to prevent a dangling interval

## Key changes
- `packages/pi-coding-agent/src/core/lsp/client.ts` — all changes in a single file (+29 lines)

## Testing
- [x] `npx tsc --noEmit` passes with no type errors
- [ ] Manual: start multiple LSP workspaces, close them, verify Maps are empty
- [ ] Manual: simulate oversized buffer scenario and verify it resets

## Risk
Low. All changes are defensive additions (bounds checks, cleanup on existing teardown paths). No behavioral changes for well-behaved LSP servers under normal conditions.