### PR TITLE
fix(interactive): clean up leaked SIGINT and extension selector listeners

### DIFF
--- a/packages/pi-coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/interactive-mode.ts
@@ -1553,6 +1553,13 @@ export class InteractiveMode {
 		options: string[],
 		opts?: ExtensionUIDialogOptions,
 	): Promise<string | undefined> {
+		// If a previous selector is still active, dispose it before creating a
+		// new one.  This avoids leaking the previous promise and DOM state when
+		// showExtensionSelector is called rapidly.
+		if (this.extensionSelector) {
+			this.hideExtensionSelector();
+		}
+
 		return new Promise((resolve) => {
 			if (opts?.signal?.aborted) {
 				resolve(undefined);
@@ -2822,18 +2829,24 @@ export class InteractiveMode {
 		const ignoreSigint = () => {};
 		process.on("SIGINT", ignoreSigint);
 
-		// Set up handler to restore TUI when resumed
-		process.once("SIGCONT", () => {
+		try {
+			// Set up handler to restore TUI when resumed
+			process.once("SIGCONT", () => {
+				process.removeListener("SIGINT", ignoreSigint);
+				this.ui.start();
+				this.ui.requestRender(true);
+			});
+
+			// Stop the TUI (restore terminal to normal mode)
+			this.ui.stop();
+
+			// Send SIGTSTP to process group (pid=0 means all processes in group)
+			process.kill(0, "SIGTSTP");
+		} catch {
+			// If suspend fails (e.g. SIGTSTP not supported), ensure the
+			// SIGINT listener doesn't leak.
 			process.removeListener("SIGINT", ignoreSigint);
-			this.ui.start();
-			this.ui.requestRender(true);
-		});
-
-		// Stop the TUI (restore terminal to normal mode)
-		this.ui.stop();
-
-		// Send SIGTSTP to process group (pid=0 means all processes in group)
-		process.kill(0, "SIGTSTP");
+		}
 	}
 
 	private async handleFollowUp(): Promise<void> {


### PR DESCRIPTION
## What
Fix two resource leaks in interactive mode:
1. SIGINT listener registered in `handleCtrlZ()` is not cleaned up if suspend fails
2. Extension selector race condition — calling `showExtensionSelector()` rapidly overwrites previous selector without cleanup

## Why
- **SIGINT leak**: If `process.kill(0, "SIGTSTP")` or `this.ui.stop()` throws, the `ignoreSigint` listener stays registered on the process indefinitely. Each failed Ctrl+Z cycle accumulates another listener.
- **Extension selector leak**: Rapidly invoking `showExtensionSelector()` overwrites `this.extensionSelector` without disposing the previous one, leaking the previous promise and its abort handler.

## How

### handleCtrlZ — try-catch cleanup
Wrapped the suspend/resume logic in a `try-catch` block. On any exception, `process.removeListener("SIGINT", ignoreSigint)` is called in the `catch` block, preventing listener accumulation. The happy path (SIGCONT) continues to clean up the listener as before.

### showExtensionSelector — dispose previous selector
Added a guard at the top of `showExtensionSelector()` that checks for an existing `this.extensionSelector` and calls `hideExtensionSelector()` to dispose it before creating a new one. This ensures the previous selector's DOM state is cleaned up and prevents dangling promises.

## Key changes
- `packages/pi-coding-agent/src/modes/interactive/interactive-mode.ts`
  - `handleCtrlZ()`: Added try-catch around suspend logic with SIGINT listener cleanup in catch block
  - `showExtensionSelector()`: Added guard to dispose previous selector before creating a new one

## Testing
- `npx tsc --noEmit` passes with no type errors
- Verified the changes are minimal and self-contained

## Risk
Low — both changes are defensive guards that only activate in edge cases (suspend failure, rapid selector calls). Normal control flow is unchanged.