### PR TITLE
fix: resolve race conditions in blob-store, discovery-cache, and agent-loop

### DIFF
--- a/packages/pi-agent-core/src/agent-loop.ts
+++ b/packages/pi-agent-core/src/agent-loop.ts
@@ -118,7 +118,10 @@ export function agentLoopContinue(
 
 	(async () => {
 		const newMessages: AgentMessage[] = [];
-		const currentContext: AgentContext = { ...context };
+		const currentContext: AgentContext = {
+			...context,
+			messages: [...context.messages],
+		};
 
 		stream.push({ type: "agent_start" });
 		stream.push({ type: "turn_start" });

--- a/packages/pi-coding-agent/src/core/blob-store.ts
+++ b/packages/pi-coding-agent/src/core/blob-store.ts
@@ -6,7 +6,7 @@
  * provides automatic deduplication across sessions.
  */
 import { createHash } from "node:crypto";
-import { mkdirSync, readdirSync, readFileSync, writeFileSync, existsSync, accessSync, unlinkSync, statSync } from "node:fs";
+import { mkdirSync, readdirSync, readFileSync, writeFileSync, accessSync, unlinkSync, statSync } from "node:fs";
 import { join } from "node:path";
 
 const BLOB_PREFIX = "blob:sha256:";
@@ -37,8 +37,11 @@ export class BlobStore {
 			},
 		};
 
-		if (!existsSync(blobPath)) {
-			writeFileSync(blobPath, data);
+		try {
+			writeFileSync(blobPath, data, { flag: "wx" }); // Atomic: fails if file exists
+		} catch (err: any) {
+			if (err.code !== "EEXIST") throw err;
+			// File already exists — expected for content-addressed storage
 		}
 		return result;
 	}

--- a/packages/pi-coding-agent/src/core/discovery-cache.ts
+++ b/packages/pi-coding-agent/src/core/discovery-cache.ts
@@ -3,7 +3,7 @@
  * Stores results at {agentDir}/discovery-cache.json with per-provider TTLs.
  */
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "fs";
 import { dirname, join } from "path";
 import { getAgentDir } from "../config.js";
 import { type DiscoveredModel, getDefaultTTL } from "./model-discovery.js";
@@ -35,6 +35,8 @@ export class ModelDiscoveryCache {
 	}
 
 	set(provider: string, models: DiscoveredModel[], ttlMs?: number): void {
+		// Re-read from disk to get the latest state before modifying
+		this.load();
 		this.data.entries[provider] = {
 			models,
 			fetchedAt: Date.now(),
@@ -50,6 +52,8 @@ export class ModelDiscoveryCache {
 	}
 
 	clear(provider?: string): void {
+		// Re-read from disk to get the latest state before modifying
+		this.load();
 		if (provider) {
 			delete this.data.entries[provider];
 		} else {
@@ -89,7 +93,10 @@ export class ModelDiscoveryCache {
 			if (!existsSync(dir)) {
 				mkdirSync(dir, { recursive: true });
 			}
-			writeFileSync(this.cachePath, JSON.stringify(this.data, null, 2), "utf-8");
+			// Atomic write: write to temp file then rename to avoid partial reads
+			const tmpPath = this.cachePath + ".tmp";
+			writeFileSync(tmpPath, JSON.stringify(this.data, null, 2), "utf-8");
+			renameSync(tmpPath, this.cachePath);
 		} catch {
 			// Silently ignore write failures (read-only FS, permissions, etc.)
 		}


### PR DESCRIPTION
## What
Fix three race conditions across the codebase:
1. **blob-store.ts**: Non-atomic check-then-act pattern (`existsSync` + `writeFileSync`)
2. **discovery-cache.ts**: Concurrent cache writes without protection can corrupt JSON
3. **agent-loop.ts**: Shallow context copy in `agentLoopContinue` shares `messages` array reference

## Why
- The blob-store race can corrupt blobs when multiple processes write the same content-addressed blob simultaneously — one process checks existence, another writes, then the first overwrites mid-write.
- The discovery-cache race can lose model definitions when concurrent processes read stale in-memory state and overwrite each other's disk changes.
- The agent-loop shallow copy causes unexpected side effects: mutations to `currentContext.messages` (e.g., pushing new messages during streaming) propagate back to the caller's original `context.messages` array.

## How

### blob-store.ts
Replaced the `existsSync` + `writeFileSync` check-then-act with a single `writeFileSync` using the `wx` flag (exclusive creation). This is atomic at the OS level — the file is created exclusively or the call fails with `EEXIST`, which we silently ignore since the content is identical (content-addressed storage).

### discovery-cache.ts
Two changes:
- **Read-before-write**: `set()` and `clear()` now call `this.load()` before modifying in-memory state, ensuring they operate on the latest disk state rather than a potentially stale in-memory snapshot.
- **Atomic save**: `save()` now writes to a `.tmp` file first, then uses `renameSync` to atomically replace the cache file. This prevents other processes from reading partially-written JSON.

### agent-loop.ts
Changed `agentLoopContinue` to deep copy the messages array (`messages: [...context.messages]`) instead of relying on the shallow spread which shares the same array reference.

## Key changes
- `packages/pi-coding-agent/src/core/blob-store.ts` — `put()` method uses `{ flag: "wx" }` instead of `existsSync` guard
- `packages/pi-coding-agent/src/core/discovery-cache.ts` — `set()`/`clear()` reload from disk; `save()` uses temp+rename
- `packages/pi-agent-core/src/agent-loop.ts` — `agentLoopContinue` copies messages array

## Testing
- `npx tsc --noEmit` passes with zero errors
- `writeFileSync` with `wx` flag is standard Node.js API (O_CREAT | O_EXCL)
- `renameSync` is atomic on POSIX filesystems (same-device rename)
- The messages spread (`[...array]`) is the same pattern already used in `agentLoop`

## Risk
**Low.** All three changes are minimal, targeted, and use well-established patterns. The blob-store and discovery-cache changes only affect error handling paths (existing content / concurrent writes). The agent-loop change aligns `agentLoopContinue` with the pattern already used in `agentLoop`.