### PR TITLE
fix: resolve retry handler hang, inverted source detection, and cache leak

### DIFF
--- a/packages/pi-coding-agent/src/core/agent-session.ts
+++ b/packages/pi-coding-agent/src/core/agent-session.ts
@@ -374,6 +374,17 @@ export class AgentSession {
 		this._retryPromise = new Promise((resolve) => {
 			this._retryResolve = resolve;
 		});
+
+		// Safety timeout: if _handleRetryableError is never called (e.g.
+		// _lastAssistantMessage is undefined when _processAgentEvent runs),
+		// the promise would hang forever. Resolve after 2 minutes as a
+		// defensive fallback so waitForRetry() never blocks indefinitely.
+		const safetyTimeout = setTimeout(() => {
+			this._resolveRetry();
+		}, 120_000);
+
+		// Clear the timeout if the promise resolves normally
+		this._retryPromise.then(() => clearTimeout(safetyTimeout));
 	}
 
 	private _findLastAssistantInMessages(messages: AgentMessage[]): AssistantMessage | undefined {
@@ -469,6 +480,13 @@ export class AgentSession {
 			}
 
 			await this._checkCompaction(msg);
+		}
+
+		// Ensure retry promise is resolved even if the retry path above was
+		// skipped (e.g. _lastAssistantMessage was undefined or the error was
+		// no longer classified as retryable by _processAgentEvent).
+		if (event.type === "agent_end" && this._retryPromise) {
+			this._resolveRetry();
 		}
 	}
 

--- a/packages/pi-coding-agent/src/core/extensions/loader.ts
+++ b/packages/pi-coding-agent/src/core/extensions/loader.ts
@@ -129,10 +129,16 @@ function getJitiOptions() {
 }
 
 const _moduleImporters = new Map<string, ReturnType<typeof createJiti>>();
+const MAX_MODULE_IMPORTERS = 50;
 
 function getModuleImporter(parentModuleUrl: string) {
 	let importer = _moduleImporters.get(parentModuleUrl);
 	if (!importer) {
+		// Evict oldest entry if cache is at capacity
+		if (_moduleImporters.size >= MAX_MODULE_IMPORTERS) {
+			const oldestKey = _moduleImporters.keys().next().value;
+			if (oldestKey) _moduleImporters.delete(oldestKey);
+		}
 		importer = createJiti(parentModuleUrl, {
 			moduleCache: true,
 			...getJitiOptions(),

--- a/packages/pi-coding-agent/src/core/prompt-templates.ts
+++ b/packages/pi-coding-agent/src/core/prompt-templates.ts
@@ -241,13 +241,11 @@ export function loadPromptTemplates(options: LoadPromptTemplatesOptions = {}): P
 	};
 
 	const getSourceInfo = (resolvedPath: string): { source: string; label: string } => {
-		if (!includeDefaults) {
-			if (isUnderPath(resolvedPath, userPromptsDir)) {
-				return { source: "user", label: "(user)" };
-			}
-			if (isUnderPath(resolvedPath, projectPromptsDir)) {
-				return { source: "project", label: "(project)" };
-			}
+		if (isUnderPath(resolvedPath, userPromptsDir)) {
+			return { source: "user", label: "(user)" };
+		}
+		if (isUnderPath(resolvedPath, projectPromptsDir)) {
+			return { source: "project", label: "(project)" };
 		}
 		return { source: "path", label: buildPathSourceLabel(resolvedPath) };
 	};

--- a/packages/pi-coding-agent/src/core/skills.ts
+++ b/packages/pi-coding-agent/src/core/skills.ts
@@ -417,10 +417,8 @@ export function loadSkills(options: LoadSkillsOptions = {}): LoadSkillsResult {
 	};
 
 	const getSource = (resolvedPath: string): "user" | "project" | "path" => {
-		if (!includeDefaults) {
-			if (isUnderPath(resolvedPath, userSkillsDir)) return "user";
-			if (isUnderPath(resolvedPath, projectSkillsDir)) return "project";
-		}
+		if (isUnderPath(resolvedPath, userSkillsDir)) return "user";
+		if (isUnderPath(resolvedPath, projectSkillsDir)) return "project";
 		return "path";
 	};
 


### PR DESCRIPTION
## What

Fix four high-severity logic bugs in the pi-coding-agent core:

1. **Retry handler hang** — `waitForRetry()` could block indefinitely
2. **Inverted source detection in skills** — source always reported as "path"
3. **Inverted source detection in prompt templates** — same bug pattern
4. **Unbounded module importer cache** — memory leak in extension loader

## Why

- The retry handler hang can freeze the entire agent loop when `_handleRetryableError()` is never called after the retry promise is created (e.g. `_lastAssistantMessage` is undefined at `agent_end` time).
- The inverted `if (!includeDefaults)` guard in both `getSource()` and `getSourceInfo()` means skills and prompt templates loaded from user/project directories are always misclassified as "path" source instead of "user" or "project".
- The `_moduleImporters` Map grows without bound as new parent module URLs are encountered, leaking jiti instances.

## How

### agent-session.ts (retry handler)
- Added a 120-second safety timeout on the retry promise created in `_createRetryPromiseForAgentEnd()`. The timeout is cleared if the promise resolves normally.
- Added a fallback `_resolveRetry()` call at the end of `_processAgentEvent()` for `agent_end` events, ensuring the promise is resolved even if the retry path is skipped.

### skills.ts
- Removed the `if (!includeDefaults)` guard around `isUnderPath()` checks in `getSource()`. The path-based source detection now runs unconditionally.

### prompt-templates.ts
- Same fix as skills.ts: removed the `if (!includeDefaults)` guard in `getSourceInfo()`.

### extensions/loader.ts
- Added `MAX_MODULE_IMPORTERS = 50` constant and LRU-style eviction (oldest entry removed) when the cache reaches capacity.

## Key changes

| File | Change |
|------|--------|
| `agent-session.ts` | Safety timeout + fallback resolve for retry promise |
| `skills.ts` | Remove inverted `!includeDefaults` guard |
| `prompt-templates.ts` | Remove inverted `!includeDefaults` guard |
| `extensions/loader.ts` | Cap `_moduleImporters` at 50 entries |

## Testing

- `npx tsc --noEmit` passes with no type errors
- No existing test files in this package to run
- Manual verification: reviewed all code paths that create/resolve `_retryPromise` to confirm no new deadlock scenarios
- The `_resolveRetry()` method is idempotent (checks `_retryResolve` before calling), so multiple resolve calls are safe

## Risk

**Low.** All changes are minimal and targeted:
- The safety timeout only fires if the normal resolution path fails (defensive fallback)
- The fallback resolve at end of `_processAgentEvent` is a no-op if already resolved
- Removing the inverted guard restores the intended behavior documented by the function signatures
- The cache limit is generous (50 entries) and uses simple oldest-first eviction