### PR TITLE
refactor: extract shared normalizePath and deduplicate sleep utilities

### DIFF
--- a/packages/pi-ai/src/utils/oauth/google-antigravity.ts
+++ b/packages/pi-ai/src/utils/oauth/google-antigravity.ts
@@ -115,9 +115,8 @@ async function startCallbackServer(): Promise<CallbackServerInfo> {
 					cancelled = true;
 				},
 				waitForCode: async () => {
-					const sleep = () => new Promise((r) => setTimeout(r, 100));
 					while (!result && !cancelled) {
-						await sleep();
+						await new Promise((r) => setTimeout(r, 100));
 					}
 					return result;
 				},

--- a/packages/pi-ai/src/utils/oauth/google-gemini-cli.ts
+++ b/packages/pi-ai/src/utils/oauth/google-gemini-cli.ts
@@ -107,9 +107,8 @@ async function startCallbackServer(): Promise<CallbackServerInfo> {
 					cancelled = true;
 				},
 				waitForCode: async () => {
-					const sleep = () => new Promise((r) => setTimeout(r, 100));
 					while (!result && !cancelled) {
-						await sleep();
+						await new Promise((r) => setTimeout(r, 100));
 					}
 					return result;
 				},
@@ -166,13 +165,6 @@ interface GoogleRpcErrorResponse {
 }
 
 /**
- * Wait helper for onboarding retries
- */
-function wait(ms: number): Promise<void> {
-	return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-/**
  * Get default tier from allowed tiers
  */
 function getDefaultTier(allowedTiers?: Array<{ id?: string; isDefault?: boolean }>): { id?: string } {
@@ -201,7 +193,7 @@ async function pollOperation(
 	while (true) {
 		if (attempt > 0) {
 			onProgress?.(`Waiting for project provisioning (attempt ${attempt + 1})...`);
-			await wait(5000);
+			await new Promise((r) => setTimeout(r, 5000));
 		}
 
 		const response = await fetch(`${CODE_ASSIST_ENDPOINT}/v1internal/${operationName}`, {

--- a/packages/pi-ai/src/utils/oauth/openai-codex.ts
+++ b/packages/pi-ai/src/utils/oauth/openai-codex.ts
@@ -255,11 +255,10 @@ function startLocalOAuthServer(state: string): Promise<OAuthServerInfo> {
 						cancelled = true;
 					},
 					waitForCode: async () => {
-						const sleep = () => new Promise((r) => setTimeout(r, 100));
 						for (let i = 0; i < 600; i += 1) {
 							if (lastCode) return { code: lastCode };
 							if (cancelled) return null;
-							await sleep();
+							await new Promise((r) => setTimeout(r, 100));
 						}
 						return null;
 					},

--- a/packages/pi-coding-agent/src/core/prompt-templates.ts
+++ b/packages/pi-coding-agent/src/core/prompt-templates.ts
@@ -1,8 +1,8 @@
 import { existsSync, readdirSync, readFileSync, statSync } from "fs";
-import { homedir } from "os";
 import { basename, isAbsolute, join, resolve, sep } from "path";
 import { CONFIG_DIR_NAME, getPromptsDir } from "../config.js";
 import { parseFrontmatter } from "../utils/frontmatter.js";
+import { normalizePath } from "../utils/normalize-path.js";
 
 /**
  * Represents a prompt template loaded from a markdown file
@@ -183,14 +183,6 @@ export interface LoadPromptTemplatesOptions {
 	promptPaths?: string[];
 	/** Include default prompt directories. Default: true */
 	includeDefaults?: boolean;
-}
-
-function normalizePath(input: string): string {
-	const trimmed = input.trim();
-	if (trimmed === "~") return homedir();
-	if (trimmed.startsWith("~/")) return join(homedir(), trimmed.slice(2));
-	if (trimmed.startsWith("~")) return join(homedir(), trimmed.slice(1));
-	return trimmed;
 }
 
 function resolvePromptPath(p: string, cwd: string): string {

--- a/packages/pi-coding-agent/src/core/skills.ts
+++ b/packages/pi-coding-agent/src/core/skills.ts
@@ -1,9 +1,9 @@
 import { existsSync, readdirSync, readFileSync, realpathSync, statSync } from "fs";
 import ignore from "ignore";
-import { homedir } from "os";
 import { basename, dirname, isAbsolute, join, relative, resolve, sep } from "path";
 import { CONFIG_DIR_NAME, getAgentDir } from "../config.js";
 import { parseFrontmatter } from "../utils/frontmatter.js";
+import { normalizePath } from "../utils/normalize-path.js";
 import type { ResourceDiagnostic } from "./diagnostics.js";
 
 /** Max name length per spec */
@@ -333,14 +333,6 @@ export interface LoadSkillsOptions {
 	skillPaths?: string[];
 	/** Include default skills directories. Default: true */
 	includeDefaults?: boolean;
-}
-
-function normalizePath(input: string): string {
-	const trimmed = input.trim();
-	if (trimmed === "~") return homedir();
-	if (trimmed.startsWith("~/")) return join(homedir(), trimmed.slice(2));
-	if (trimmed.startsWith("~")) return join(homedir(), trimmed.slice(1));
-	return trimmed;
 }
 
 function resolveSkillPath(p: string, cwd: string): string {

--- a/packages/pi-coding-agent/src/utils/normalize-path.ts
+++ b/packages/pi-coding-agent/src/utils/normalize-path.ts
@@ -1,0 +1,13 @@
+import { homedir } from "os";
+import { join } from "path";
+
+/**
+ * Normalize a file-system path, expanding `~` to the user's home directory.
+ */
+export function normalizePath(input: string): string {
+	const trimmed = input.trim();
+	if (trimmed === "~") return homedir();
+	if (trimmed.startsWith("~/")) return join(homedir(), trimmed.slice(2));
+	if (trimmed.startsWith("~")) return join(homedir(), trimmed.slice(1));
+	return trimmed;
+}


### PR DESCRIPTION
## What

Reduce code duplication across three areas:

1. **normalizePath extraction** -- `normalizePath()` was identically implemented in both `skills.ts` and `prompt-templates.ts`. Extracted to a shared `normalize-path.ts` utility.
2. **sleep/wait deduplication** -- Local `sleep()` / `wait()` helpers were reimplemented in 3 OAuth files (`google-gemini-cli.ts`, `google-antigravity.ts`, `openai-codex.ts`). Replaced with inline `await new Promise(r => setTimeout(r, ms))`.

## Why

Duplicate code leads to maintenance burden and divergent bug fixes. The `normalizePath` duplication was an exact copy-paste. The sleep helpers were trivial one-liners that don't warrant dedicated local functions.

## How

### normalizePath
- Created `packages/pi-coding-agent/src/utils/normalize-path.ts` with the shared implementation
- Updated `skills.ts` and `prompt-templates.ts` to import from the new utility
- Removed unused `homedir` import from both files

### sleep/wait
- Replaced `const sleep = () => new Promise(...)` with inline `await new Promise(r => setTimeout(r, 100))` in all three OAuth files
- Removed the standalone `wait(ms)` function from `google-gemini-cli.ts` and inlined its single call site
- Used inline pattern (not cross-package import) since `pi-ai` cannot depend on `pi-coding-agent`

## Key changes

| File | Change |
|------|--------|
| `packages/pi-coding-agent/src/utils/normalize-path.ts` | New shared utility |
| `packages/pi-coding-agent/src/core/skills.ts` | Import shared `normalizePath`, remove local copy |
| `packages/pi-coding-agent/src/core/prompt-templates.ts` | Import shared `normalizePath`, remove local copy |
| `packages/pi-ai/src/utils/oauth/google-gemini-cli.ts` | Remove local `sleep` and `wait`, use inline Promise |
| `packages/pi-ai/src/utils/oauth/google-antigravity.ts` | Remove local `sleep`, use inline Promise |
| `packages/pi-ai/src/utils/oauth/openai-codex.ts` | Remove local `sleep`, use inline Promise |

## Testing

- `npx tsc --noEmit` passes for both `pi-coding-agent` and `pi-ai` packages
- Pure refactor with no behavioral changes -- function signatures and logic are preserved

## Risk

Low. This is a mechanical extraction and inline replacement with no logic changes.