### PR TITLE
fix: enable node:sqlite on Node 22-23 via --experimental-sqlite flag

### DIFF
--- a/scripts/dev-cli.js
+++ b/scripts/dev-cli.js
@@ -11,7 +11,7 @@ const resolveTsPath = resolve(root, 'src', 'resources', 'extensions', 'gsd', 'te
 
 const child = spawn(
   process.execPath,
-  ['--import', resolveTsPath, '--experimental-strip-types', srcLoaderPath, ...process.argv.slice(2)],
+  ['--import', resolveTsPath, '--experimental-strip-types', '--experimental-sqlite', srcLoaderPath, ...process.argv.slice(2)],
   {
     cwd: process.cwd(),
     stdio: 'inherit',

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -5,6 +5,33 @@ import { fileURLToPath } from 'url'
 import { dirname, resolve, join, relative, delimiter } from 'path'
 import { existsSync, readFileSync, mkdirSync, symlinkSync, cpSync } from 'fs'
 
+// ─── node:sqlite flag injection ────────────────────────────────────────────
+// node:sqlite is experimental on Node 22-23 and requires --experimental-sqlite.
+// Without it, the GSD database layer silently falls back to "no provider available"
+// and all DB tools (gsd_decision_save, gsd_requirement_update, etc.) fail.
+// On Node >=24 the flag is no longer needed (node:sqlite is stable).
+// Re-exec once with the flag if we're on Node <24 and it's not already present.
+const nodeMajor = parseInt(process.version.slice(1), 10)
+if (
+  nodeMajor < 24 &&
+  !process.execArgv.includes('--experimental-sqlite') &&
+  !(process.env.NODE_OPTIONS || '').includes('--experimental-sqlite') &&
+  !process.env.__GSD_SQLITE_REEXEC
+) {
+  const { execFileSync } = await import('child_process')
+  try {
+    execFileSync(
+      process.execPath,
+      ['--experimental-sqlite', ...process.execArgv, ...process.argv.slice(1)],
+      { stdio: 'inherit', env: { ...process.env, __GSD_SQLITE_REEXEC: '1' } },
+    )
+    process.exit(0)
+  } catch (err: any) {
+    // Propagate the child's exit code
+    process.exit(err.status ?? 1)
+  }
+}
+
 // Fast-path: handle --version/-v and --help/-h before importing any heavy
 // dependencies. This avoids loading the entire pi-coding-agent barrel import
 // (~1s) just to print a version string.


### PR DESCRIPTION
## Problem

All GSD database tools (`gsd_decision_save`, `gsd_requirement_update`, `gsd_summary_save`) silently fail with `"GSD database is not available"` on Node 22-23. This affects every user on the supported Node version range (`engines: >=22.0.0`). The DB layer appears to work but no data is ever persisted; 16 unit tests also fail for the same reason.

## Root Cause

`node:sqlite` is the primary SQLite provider in `gsd-db.ts` `loadProvider()`. On Node <24, it requires the `--experimental-sqlite` flag — without it, `require('node:sqlite')` throws `ERR_UNKNOWN_BUILTIN_MODULE`. The fallback provider `better-sqlite3` is not in the dependency tree (intentionally removed in #356). Both fail → `providerModule` stays `null` → `openDatabase()` returns `false` → all DB tools return the "not available" error.

The flag is not passed anywhere: not in the loader shebang, not in `scripts/dev-cli.js`, and not in the `package.json` test scripts.

## Fix

**Loader (`src/loader.ts`):** Detect Node <24 without `--experimental-sqlite` in `execArgv` or `NODE_OPTIONS`. Re-exec the process once with the flag injected. On Node >=24 (where `node:sqlite` is stable), no re-exec occurs — zero overhead.

**Dev CLI (`scripts/dev-cli.js`):** Add `--experimental-sqlite` to the spawn args alongside `--experimental-strip-types`.

**Test scripts (`package.json`):** Add `--experimental-sqlite` to all test runner commands that use `--experimental-strip-types`.

## Changed Files

| File | Change |
|------|--------|
| `src/loader.ts` | Add re-exec block that detects Node <24 and injects `--experimental-sqlite` |
| `scripts/dev-cli.js` | Add `--experimental-sqlite` to spawn args |
| `package.json` | Add `--experimental-sqlite` to 10 test scripts |

## Test Evidence

**Before fix:** 20 test failures, including `ensure-db-open.test.ts`, `gsd-db.test.ts`, `db-writer.test.ts`, `md-importer.test.ts`, `worktree-db.test.ts`, `memory-extractor.test.ts`, etc.

**After fix:** 4 test failures (pre-existing, unrelated to SQLite — `search-loop-guard.test.ts` and `computeStaleAvoidList`).

Verified on Node v23.3.0:
```
# Before: node:sqlite unavailable
node -e "require('node:sqlite')"  # ERR_UNKNOWN_BUILTIN_MODULE

# After: loader re-execs with flag
node dist/loader.js --version  # 2.42.0 (exits cleanly)

# DB tests pass
node --experimental-sqlite ... --test gsd-db.test.ts  # 41/41 pass
node --experimental-sqlite ... --test ensure-db-open.test.ts  # 13/13 pass
```

## Idempotency

The re-exec is guarded by three conditions (all must be true):
1. `nodeMajor < 24` — skipped entirely on Node 24+ where the flag is unnecessary
2. `!process.execArgv.includes('--experimental-sqlite')` — skipped if already present
3. `!NODE_OPTIONS.includes('--experimental-sqlite')` — skipped if user set it globally

## Related

- #356 — removed `better-sqlite3` in favor of `sql.js` for the memory pipeline, but did not address `gsd-db.ts` which still relies on `node:sqlite` as primary provider
- #2041 — ADR for DB architecture (related context)