### PR TITLE
fix: restore bidirectional root-level .gsd/ file sync between worktree and project root

### DIFF
--- a/src/resources/extensions/gsd/auto-worktree-sync.ts
+++ b/src/resources/extensions/gsd/auto-worktree-sync.ts
@@ -51,6 +51,13 @@ export function syncProjectRootToWorktree(
     join(wtGsd, "milestones", milestoneId),
   );
 
+  // Copy root-level living documents so agents in the worktree see current
+  // decisions, requirements, project state, knowledge, and queue.
+  // Originally added in #1173, accidentally dropped during the #1419 refactor.
+  for (const doc of ["DECISIONS.md", "REQUIREMENTS.md", "PROJECT.md", "KNOWLEDGE.md", "OVERRIDES.md", "QUEUE.md"]) {
+    safeCopy(join(prGsd, doc), join(wtGsd, doc), { force: true });
+  }
+
   // Delete worktree gsd.db so it rebuilds from the freshly synced files.
   // Stale DB rows are the root cause of the infinite skip loop (#853).
   try {
@@ -102,6 +109,15 @@ export function syncStateToProjectRoot(
     join(prGsd, "runtime", "units"),
     { force: true },
   );
+
+  // 5. Root-level living documents — decisions, requirements, project description,
+  // knowledge, overrides, queue. Agents update these during slice execution.
+  // Without syncing back, a new session reads stale copies from the project root,
+  // losing architectural decisions, requirement status updates, and accumulated
+  // knowledge. Originally added in #1173, accidentally dropped during #1419.
+  for (const doc of ["DECISIONS.md", "REQUIREMENTS.md", "PROJECT.md", "KNOWLEDGE.md", "OVERRIDES.md", "QUEUE.md"]) {
+    safeCopy(join(wtGsd, doc), join(prGsd, doc), { force: true });
+  }
 }
 
 // ─── Resource Staleness ───────────────────────────────────────────────────

--- a/src/resources/extensions/gsd/tests/worktree-sync-milestones.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-sync-milestones.test.ts
@@ -158,6 +158,47 @@ async function main(): Promise<void> {
     assertTrue(true, 'no crash on missing directories');
   }
 
+  // ─── 6b. syncProjectRootToWorktree copies root-level living docs ──────
+  console.log('\n=== 6b. syncProjectRootToWorktree copies root-level living docs (#1168 regression) ===');
+  {
+    const mainBase = createBase('main');
+    const wtBase = createBase('wt');
+
+    try {
+      // Main repo has root-level living docs
+      const m001Dir = join(mainBase, '.gsd', 'milestones', 'M001');
+      mkdirSync(m001Dir, { recursive: true });
+      writeFileSync(join(m001Dir, 'M001-ROADMAP.md'), '# Roadmap');
+      writeFileSync(join(mainBase, '.gsd', 'DECISIONS.md'), '# Decisions\n## D001');
+      writeFileSync(join(mainBase, '.gsd', 'REQUIREMENTS.md'), '# Requirements\n## R001');
+      writeFileSync(join(mainBase, '.gsd', 'PROJECT.md'), '# Project\nActive milestone: M001');
+      writeFileSync(join(mainBase, '.gsd', 'KNOWLEDGE.md'), '# Knowledge\nSome learning.');
+      writeFileSync(join(mainBase, '.gsd', 'OVERRIDES.md'), '# Overrides');
+      writeFileSync(join(mainBase, '.gsd', 'QUEUE.md'), '# Queue\n- M002 next');
+
+      // Worktree has stale copies
+      writeFileSync(join(wtBase, '.gsd', 'DECISIONS.md'), '# Decisions (stale)');
+      writeFileSync(join(wtBase, '.gsd', 'REQUIREMENTS.md'), '# Requirements (stale)');
+
+      syncProjectRootToWorktree(mainBase, wtBase, 'M001');
+
+      // Root-level files should be overwritten with project root versions
+      const decContent = readFileSync(join(wtBase, '.gsd', 'DECISIONS.md'), 'utf-8');
+      assertTrue(decContent.includes('D001'), '#1168: DECISIONS.md synced to worktree');
+
+      const reqContent = readFileSync(join(wtBase, '.gsd', 'REQUIREMENTS.md'), 'utf-8');
+      assertTrue(reqContent.includes('R001'), '#1168: REQUIREMENTS.md synced to worktree');
+
+      assertTrue(existsSync(join(wtBase, '.gsd', 'PROJECT.md')), '#1168: PROJECT.md synced to worktree');
+      assertTrue(existsSync(join(wtBase, '.gsd', 'KNOWLEDGE.md')), '#1168: KNOWLEDGE.md synced to worktree');
+      assertTrue(existsSync(join(wtBase, '.gsd', 'OVERRIDES.md')), '#1168: OVERRIDES.md synced to worktree');
+      assertTrue(existsSync(join(wtBase, '.gsd', 'QUEUE.md')), '#1168: QUEUE.md synced to worktree');
+    } finally {
+      cleanup(mainBase);
+      cleanup(wtBase);
+    }
+  }
+
   // ─── 7. milestones/ directory created in worktree when missing ────────
   console.log('\n=== 7. milestones/ directory created in worktree when missing ===');
   {


### PR DESCRIPTION
## Problem

When auto-mode runs inside a worktree, root-level `.gsd/` files (DECISIONS.md, REQUIREMENTS.md, PROJECT.md, KNOWLEDGE.md, OVERRIDES.md, QUEUE.md) are not synced between the worktree and the project root. Agents in worktrees see stale or missing root-level files, and sessions that restart after worktree execution read stale copies from the project root.

This is a regression from #1419 which rewrote `auto-worktree-sync.ts` but dropped the bidirectional root-level file sync that was added in #1173 to fix #1168.

## Root Cause

`syncProjectRootToWorktree()` (called before `deriveState` each loop iteration) only copies the active milestone directory via `safeCopyRecursive()`. It does not copy root-level `.gsd/` files.

`syncStateToProjectRoot()` (called after each unit completion) copies STATE.md, the milestone directory, and runtime records — but not the root-level living documents.

A more comprehensive sync function (`syncGsdStateToWorktree` in `auto-worktree.ts`) handles root-level files correctly but is only called during initial worktree creation, not in the per-iteration sync path.

## Fix

Restore the bidirectional sync for 6 root-level living documents in both functions:

- `syncProjectRootToWorktree`: copies DECISIONS.md, REQUIREMENTS.md, PROJECT.md, KNOWLEDGE.md, OVERRIDES.md, QUEUE.md from project root → worktree (with `force: true`) before milestone directory sync
- `syncStateToProjectRoot`: copies the same files from worktree → project root after runtime record sync

Uses the existing `safeCopy` helper with `{ force: true }` — identical pattern to the original #1173 fix.

## Changed Files

| File | Change |
|------|--------|
| `src/resources/extensions/gsd/auto-worktree-sync.ts` | Add root-level file sync to both `syncProjectRootToWorktree` and `syncStateToProjectRoot` |
| `src/resources/extensions/gsd/tests/worktree-sync-milestones.test.ts` | Add test verifying root-level files are synced by `syncProjectRootToWorktree` |

## Test Evidence

- Existing 15 worktree sync tests continue to pass (62/62 assertions)
- New test 6b verifies all 6 root-level files are synced from project root to worktree, including overwriting stale copies
- Build passes cleanly (`npm run build` exits 0)

## Related

Regression from #1419 (M001 refactor)
Restores fix from #1173 which closed #1168
Related to #1886 (worktree sync overwrite issues)
Related to #2153 (worktree artifact sync-back failures)