### PR TITLE
fix: copy planning artifacts on worktree reattach when .gsd is gitignored

### DIFF
--- a/src/resources/extensions/gsd/auto-worktree.ts
+++ b/src/resources/extensions/gsd/auto-worktree.ts
@@ -664,6 +664,17 @@ export function createAutoWorktree(
   if (!branchExists) {
     copyPlanningArtifacts(basePath, info.path);
   } else {
+    // If .gsd was gitignored (the default since v2.14.0), the milestone branch
+    // has no .gsd/ content for this milestone even though the branch exists.
+    // In that case, copy artifacts from the project root before reconciling
+    // checkboxes (#2199). Check the specific milestone directory, not just
+    // .gsd/milestones/, because other milestones may have been committed
+    // before .gsd was gitignored.
+    const wtMilestoneDir = join(info.path, ".gsd", "milestones", milestoneId);
+    if (!existsSync(wtMilestoneDir)) {
+      copyPlanningArtifacts(basePath, info.path);
+    }
+
     // Re-attaching to an existing branch: forward-merge any plan checkpoint
     // state from the project root into the worktree (#778).
     //

--- a/src/resources/extensions/gsd/tests/auto-worktree.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-worktree.test.ts
@@ -253,6 +253,64 @@ async function main(): Promise<void> {
       }
     }
 
+    // ─── #2199: reattach copies artifacts when .gsd is gitignored ─────
+    console.log("\n=== #2199: reattach copies artifacts when .gsd is gitignored ===");
+    {
+      // Simulate a greenfield repo where .gsd is gitignored (the default).
+      // A prior auto-mode session created the milestone branch, but since .gsd
+      // was gitignored, the branch contains no .gsd/ content. On re-attach,
+      // copyPlanningArtifacts must run so deriveState can find milestones.
+
+      const { mkdirSync: mkdir, writeFileSync: write, readFileSync: read } = await import("node:fs");
+
+      // Set up .gsd/milestones/M005 in project root (untracked, gitignored)
+      const msRelPath = join(".gsd", "milestones", "M005");
+      const msDir = join(tempDir, msRelPath);
+      mkdir(join(msDir, "slices", "S01"), { recursive: true });
+      write(join(msDir, "CONTEXT.md"), "# M005 Context\n");
+      write(
+        join(msDir, "slices", "S01", "S01-PLAN.md"),
+        "# S01 Plan\n- [ ] **T01:** task one\n- [ ] **T02:** task two\n",
+      );
+
+      // Add .gsd to .gitignore so artifacts are never committed
+      write(join(tempDir, ".gitignore"), ".gsd/\n");
+      run("git add .gitignore", tempDir);
+      run('git commit -m "gitignore .gsd"', tempDir);
+
+      // Create milestone branch (simulating a prior auto-mode session that
+      // created the branch but .gsd was gitignored — branch has no .gsd/)
+      const milestoneBranch = "milestone/M005";
+      run(`git checkout -b ${milestoneBranch}`, tempDir);
+      // Branch exists but has no .gsd content (gitignored)
+      run('git commit --allow-empty -m "milestone branch placeholder"', tempDir);
+      run("git checkout main", tempDir);
+
+      // Re-attach to the existing milestone branch
+      const wtPath = createAutoWorktree(tempDir, "M005");
+
+      try {
+        // The worktree must have .gsd/milestones/M005 even though the branch
+        // never had it committed — copyPlanningArtifacts should have run as
+        // a fallback when the worktree .gsd/milestones directory was missing.
+        const wtMsDir = join(wtPath, ".gsd", "milestones", "M005");
+        assertTrue(existsSync(wtMsDir), "#2199: milestones dir exists in worktree after re-attach with gitignored .gsd");
+        assertTrue(
+          existsSync(join(wtMsDir, "CONTEXT.md")),
+          "#2199: CONTEXT.md copied to worktree",
+        );
+        assertTrue(
+          existsSync(join(wtMsDir, "slices", "S01", "S01-PLAN.md")),
+          "#2199: plan file copied to worktree",
+        );
+
+        const plan = read(join(wtMsDir, "slices", "S01", "S01-PLAN.md"), "utf-8");
+        assertTrue(plan.includes("**T01:**"), "#2199: plan content is correct");
+      } finally {
+        teardownAutoWorktree(tempDir, "M005");
+      }
+    }
+
   } finally {
     // Always restore cwd and clean up
     process.chdir(savedCwd);


### PR DESCRIPTION
## Summary
- When re-attaching a worktree to an existing milestone branch where `.gsd` is gitignored, `copyPlanningArtifacts` was skipped because `branchExists` was true — but the branch had no `.gsd/` content, leaving `deriveState` with zero milestones
- Added a fallback check: if the specific milestone directory (`<worktree>/.gsd/milestones/<milestoneId>`) is missing, copy artifacts from the project root before reconciling checkboxes
- Added a reproduction test that creates a gitignored `.gsd`, creates a milestone branch without `.gsd` content, then verifies artifacts are correctly copied on re-attach

Fixes #2199

## Test plan
- [x] New test `#2199: reattach copies artifacts when .gsd is gitignored` passes
- [x] Existing `#778: reconcile plan checkboxes on re-attach` test still passes (behavior unchanged when `.gsd` content exists in worktree)
- [x] Full unit test suite passes (2695 pass, 0 fail)
- [x] Integration test suite: 1 pre-existing flaky failure in `web-mode-onboarding.test.ts` (unrelated timeout, confirmed fails on `main` as well)

🤖 Generated with [Claude Code](https://claude.com/claude-code)