### PR TITLE
fix: document iTerm2 Ctrl+Alt+G keybinding conflict and add helpful hint

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -278,6 +278,16 @@ Doctor rebuilds `STATE.md` from plan and roadmap files on disk and fixes detecte
 - **Forensics:** `/gsd forensics` for structured post-mortem analysis of auto-mode failures
 - **Session logs:** `.gsd/activity/` contains JSONL session dumps for crash forensics
 
+## iTerm2-Specific Issues
+
+### Ctrl+Alt shortcuts trigger the wrong action (e.g., Ctrl+Alt+G opens external editor instead of GSD dashboard)
+
+**Symptoms:** Pressing Ctrl+Alt+G opens the external editor prompt (Ctrl+G) instead of the GSD dashboard. Other Ctrl+Alt shortcuts behave as their Ctrl-only counterparts.
+
+**Cause:** iTerm2's default Left Option Key setting is "Normal", which swallows the Alt modifier for Ctrl+Alt key combinations. The terminal receives only the Ctrl key, so Ctrl+Alt+G arrives as Ctrl+G.
+
+**Fix:** In iTerm2, go to **Profiles → Keys → General** and set **Left Option Key** to **Esc+**. This makes Alt/Option send an escape prefix that terminal applications can detect, enabling Ctrl+Alt shortcuts to work correctly.
+
 ## Windows-Specific Issues
 
 ### LSP returns ENOENT on Windows (MSYS2/Git Bash)

--- a/docs/what-is-pi/18-quick-reference-commands-shortcuts.md
+++ b/docs/what-is-pi/18-quick-reference-commands-shortcuts.md
@@ -40,6 +40,8 @@
 | Alt+Enter (during streaming) | Queue follow-up message |
 | Alt+Up | Retrieve queued messages |
 
+> **iTerm2 users:** Ctrl+Alt shortcuts (e.g., Ctrl+Alt+G for the GSD dashboard) require Left Option Key set to "Esc+" in Profiles → Keys → General. The default "Normal" setting swallows the Alt modifier.
+
 ### CLI
 
 ```bash

--- a/packages/pi-coding-agent/src/modes/interactive/components/extension-editor.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/components/extension-editor.ts
@@ -113,6 +113,9 @@ export class ExtensionEditorComponent extends Container implements Focusable {
 	private openExternalEditor(): void {
 		const editorCmd = process.env.VISUAL || process.env.EDITOR;
 		if (!editorCmd) {
+			// No editor configured — nothing to do.
+			// The main interactive-mode handler shows a warning with an iTerm2 hint;
+			// this component is a secondary editor so we silently bail.
 			return;
 		}
 

--- a/packages/pi-coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/interactive-mode.ts
@@ -2460,7 +2460,14 @@ export class InteractiveMode {
 		// Determine editor (respect $VISUAL, then $EDITOR)
 		const editorCmd = process.env.VISUAL || process.env.EDITOR;
 		if (!editorCmd) {
-			this.showWarning("No editor configured. Set $VISUAL or $EDITOR environment variable.");
+			let msg = "No editor configured. Set $VISUAL or $EDITOR environment variable.";
+			if (process.env.TERM_PROGRAM === "iTerm.app") {
+				msg +=
+					"\n\nTip: If you meant to open the GSD dashboard (Ctrl+Alt+G), set Left Option Key to" +
+					" \"Esc+\" in iTerm2 → Profiles → Keys. With the default \"Normal\" setting," +
+					" Ctrl+Alt+G sends Ctrl+G instead.";
+			}
+			this.showWarning(msg);
 			return;
 		}
 


### PR DESCRIPTION
## What
Addresses the Ctrl+Alt+G keybinding conflict in iTerm2 where the GSD dashboard shortcut fires the external editor action instead.

## Why
iTerm2's default Left Option Key setting ("Normal") swallows the Alt modifier for Ctrl+Alt combinations. Ctrl+Alt+G arrives as Ctrl+G, matching the `externalEditor` keybinding instead of the GSD dashboard shortcut. Users hit a confusing "No editor configured" error with no guidance on what went wrong.

## How
Two-pronged fix:

1. **Code hint**: When `externalEditor` fires with no `$VISUAL`/`$EDITOR` set and the terminal is iTerm2 (`TERM_PROGRAM === "iTerm.app"`), the warning now appends a tip explaining the keybinding conflict and how to fix it (set Left Option Key to "Esc+").

2. **Documentation**: Added iTerm2-specific troubleshooting entry in `docs/troubleshooting.md` and a callout note in the keyboard shortcuts quick reference.

## Key changes
- `packages/pi-coding-agent/src/modes/interactive/interactive-mode.ts` — iTerm2-aware hint in `openExternalEditor()` warning
- `packages/pi-coding-agent/src/modes/interactive/components/extension-editor.ts` — clarifying comment on the silent bail path
- `docs/troubleshooting.md` — new "iTerm2-Specific Issues" section
- `docs/what-is-pi/18-quick-reference-commands-shortcuts.md` — iTerm2 note under keyboard shortcuts table

## Testing
- [x] Verified `npx tsc --noEmit` produces no new errors (pre-existing footer.ts error unrelated)
- [x] Verified the iTerm2 detection uses `TERM_PROGRAM === "iTerm.app"` (the value iTerm2 sets)
- [x] Confirmed the hint only appears when both conditions are met: no editor configured AND running in iTerm2

## Risk
Low. The code change only affects the warning message text in a specific terminal + no-editor scenario. Documentation-only otherwise.

Closes #1563

🤖 Generated with [Claude Code](https://claude.com/claude-code)