### PR TITLE
fix: extension resource management — prune stale dirs, fix isBuiltIn, gate skills on Skill tool, suppress search warnings

### DIFF
--- a/packages/pi-coding-agent/src/core/resource-loader.ts
+++ b/packages/pi-coding-agent/src/core/resource-loader.ts
@@ -1,6 +1,6 @@
 import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { homedir } from "node:os";
-import { join, resolve, sep } from "node:path";
+import { basename, dirname, join, resolve, sep } from "node:path";
 import chalk from "chalk";
 import { CONFIG_DIR_NAME, getAgentDir } from "../config.js";
 import { loadThemeFromPath, type Theme } from "../modes/interactive/theme/theme.js";
@@ -127,6 +127,8 @@ export interface DefaultResourceLoaderOptions {
 	noThemes?: boolean;
 	systemPrompt?: string;
 	appendSystemPrompt?: string;
+	/** Names of bundled extensions (used to identify built-in extensions in conflict detection). */
+	bundledExtensionNames?: Set<string>;
 	extensionsOverride?: (base: LoadExtensionsResult) => LoadExtensionsResult;
 	skillsOverride?: (base: { skills: Skill[]; diagnostics: ResourceDiagnostic[] }) => {
 		skills: Skill[];
@@ -164,6 +166,7 @@ export class DefaultResourceLoader implements ResourceLoader {
 	private noThemes: boolean;
 	private systemPromptSource?: string;
 	private appendSystemPromptSource?: string;
+	private bundledExtensionNames: Set<string>;
 	private extensionsOverride?: (base: LoadExtensionsResult) => LoadExtensionsResult;
 	private skillsOverride?: (base: { skills: Skill[]; diagnostics: ResourceDiagnostic[] }) => {
 		skills: Skill[];
@@ -219,6 +222,7 @@ export class DefaultResourceLoader implements ResourceLoader {
 		this.noThemes = options.noThemes ?? false;
 		this.systemPromptSource = options.systemPrompt;
 		this.appendSystemPromptSource = options.appendSystemPrompt;
+		this.bundledExtensionNames = options.bundledExtensionNames ?? new Set();
 		this.extensionsOverride = options.extensionsOverride;
 		this.skillsOverride = options.skillsOverride;
 		this.promptsOverride = options.promptsOverride;
@@ -790,6 +794,19 @@ export class DefaultResourceLoader implements ResourceLoader {
 		return target.startsWith(prefix);
 	}
 
+	/**
+	 * Extract the extension name from its path.
+	 * For root-level files: basename without extension (e.g. "search-the-web.ts" → "search-the-web")
+	 * For subdirectory extensions: the directory name (e.g. "/path/to/gsd/index.ts" → "gsd")
+	 */
+	private getExtensionNameFromPath(extPath: string): string {
+		const base = basename(extPath);
+		if (base === "index.js" || base === "index.ts") {
+			return basename(dirname(extPath));
+		}
+		return base.replace(/\.(?:ts|js)$/, "");
+	}
+
 	private detectExtensionConflicts(extensions: Extension[]): Array<{ path: string; message: string }> {
 		const conflicts: Array<{ path: string; message: string }> = [];
 
@@ -803,9 +820,10 @@ export class DefaultResourceLoader implements ResourceLoader {
 			for (const toolName of ext.tools.keys()) {
 				const existingOwner = toolOwners.get(toolName);
 				if (existingOwner && existingOwner !== ext.path) {
-					// Determine if the existing owner is a built-in (not a user extension)
-					const isBuiltIn = !existingOwner.includes("/.gsd/agent/extensions/") &&
-						!existingOwner.includes("/.gsd/extensions/");
+					// Determine if the existing owner is a bundled extension by checking
+					// its name against the canonical bundled extensions list
+					const ownerName = this.getExtensionNameFromPath(existingOwner);
+					const isBuiltIn = this.bundledExtensionNames.has(ownerName);
 					const hint = isBuiltIn
 						? ` (built-in tool supersedes — consider removing ${ext.path})`
 						: "";
@@ -822,8 +840,8 @@ export class DefaultResourceLoader implements ResourceLoader {
 			for (const commandName of ext.commands.keys()) {
 				const existingOwner = commandOwners.get(commandName);
 				if (existingOwner && existingOwner !== ext.path) {
-					const isBuiltIn = !existingOwner.includes("/.gsd/agent/extensions/") &&
-						!existingOwner.includes("/.gsd/extensions/");
+					const ownerName = this.getExtensionNameFromPath(existingOwner);
+					const isBuiltIn = this.bundledExtensionNames.has(ownerName);
 					const hint = isBuiltIn
 						? ` (built-in command supersedes — consider removing ${ext.path})`
 						: "";

--- a/packages/pi-coding-agent/src/core/system-prompt.ts
+++ b/packages/pi-coding-agent/src/core/system-prompt.ts
@@ -84,9 +84,9 @@ export function buildSystemPrompt(options: BuildSystemPromptOptions = {}): strin
 			}
 		}
 
-		// Append skills section (only if read tool is available)
-		const customPromptHasRead = !selectedTools || selectedTools.includes("read");
-		if (customPromptHasRead && skills.length > 0) {
+		// Append skills section (if read or Skill tool is available)
+		const customPromptHasSkillAccess = !selectedTools || selectedTools.includes("read") || selectedTools.includes("Skill");
+		if (customPromptHasSkillAccess && skills.length > 0) {
 			prompt += formatSkillsForPrompt(skills);
 		}
 
@@ -232,8 +232,9 @@ Pi documentation (read only when the user asks about pi itself, its SDK, extensi
 		}
 	}
 
-	// Append skills section (only if read tool is available)
-	if (hasRead && skills.length > 0) {
+	// Append skills section (if read or Skill tool is available)
+	const hasSkill = tools.includes("Skill");
+	if ((hasRead || hasSkill) && skills.length > 0) {
 		prompt += formatSkillsForPrompt(skills);
 	}
 

--- a/src/resource-loader.ts
+++ b/src/resource-loader.ts
@@ -40,6 +40,12 @@ interface ManagedResourceManifest {
    * causing extension load errors.
    */
   installedExtensionRootFiles?: string[]
+  /**
+   * Subdirectory extension names installed in extensions/ by this GSD version.
+   * Used on the next upgrade to detect and prune subdirectory extensions that
+   * were removed from the bundle.
+   */
+  installedExtensionDirs?: string[]
 }
 
 export { discoverExtensionEntryPaths } from './extension-discovery.js'
@@ -67,13 +73,24 @@ function getBundledGsdVersion(): string {
 }
 
 function writeManagedResourceManifest(agentDir: string): void {
-  // Record root-level files currently in the bundled extensions source so that
-  // future upgrades can detect and prune any that get removed or moved.
+  // Record root-level files and subdirectory extension names currently in the
+  // bundled extensions source so that future upgrades can detect and prune any
+  // that get removed or moved.
   let installedExtensionRootFiles: string[] = []
+  let installedExtensionDirs: string[] = []
   try {
     if (existsSync(bundledExtensionsDir)) {
-      installedExtensionRootFiles = readdirSync(bundledExtensionsDir, { withFileTypes: true })
+      const entries = readdirSync(bundledExtensionsDir, { withFileTypes: true })
+      installedExtensionRootFiles = entries
         .filter(e => e.isFile())
+        .map(e => e.name)
+      installedExtensionDirs = entries
+        .filter(e => e.isDirectory())
+        .filter(e => {
+          // Only track directories that are actual extensions (contain index.js or index.ts)
+          const dirPath = join(bundledExtensionsDir, e.name)
+          return existsSync(join(dirPath, 'index.js')) || existsSync(join(dirPath, 'index.ts'))
+        })
         .map(e => e.name)
     }
   } catch { /* non-fatal */ }
@@ -83,6 +100,7 @@ function writeManagedResourceManifest(agentDir: string): void {
     syncedAt: Date.now(),
     contentHash: computeResourceFingerprint(),
     installedExtensionRootFiles,
+    installedExtensionDirs,
   }
   writeFileSync(getManagedResourceManifestPath(agentDir), JSON.stringify(manifest))
 }
@@ -314,24 +332,40 @@ function pruneRemovedBundledExtensions(
 
   // Current bundled root-level files (what the new version provides)
   const currentSourceFiles = new Set<string>()
+  // Current bundled subdirectory extensions
+  const currentSourceDirs = new Set<string>()
   try {
     if (existsSync(bundledExtensionsDir)) {
       for (const e of readdirSync(bundledExtensionsDir, { withFileTypes: true })) {
         if (e.isFile()) currentSourceFiles.add(e.name)
+        if (e.isDirectory()) currentSourceDirs.add(e.name)
       }
     }
   } catch { /* non-fatal */ }
 
-  const removeIfStale = (fileName: string) => {
+  const removeFileIfStale = (fileName: string) => {
     if (currentSourceFiles.has(fileName)) return  // still in bundle, not stale
     const stale = join(extensionsDir, fileName)
     try { if (existsSync(stale)) rmSync(stale, { force: true }) } catch { /* non-fatal */ }
   }
 
+  const removeDirIfStale = (dirName: string) => {
+    if (currentSourceDirs.has(dirName)) return  // still in bundle, not stale
+    const stale = join(extensionsDir, dirName)
+    try { if (existsSync(stale)) rmSync(stale, { recursive: true, force: true }) } catch { /* non-fatal */ }
+  }
+
   if (manifest?.installedExtensionRootFiles) {
     // Manifest-based: remove previously-installed root files that are no longer bundled
     for (const prevFile of manifest.installedExtensionRootFiles) {
-      removeIfStale(prevFile)
+      removeFileIfStale(prevFile)
+    }
+  }
+
+  if (manifest?.installedExtensionDirs) {
+    // Manifest-based: remove previously-installed subdirectory extensions that are no longer bundled
+    for (const prevDir of manifest.installedExtensionDirs) {
+      removeDirIfStale(prevDir)
     }
   }
 
@@ -339,7 +373,7 @@ function pruneRemovedBundledExtensions(
   // These were installed by pre-manifest versions so they may not appear in
   // installedExtensionRootFiles even when a manifest exists.
   // env-utils.js was moved from extensions/ root → gsd/ in v2.39.x (#1634)
-  removeIfStale('env-utils.js')
+  removeFileIfStale('env-utils.js')
 }
 
 /**
@@ -452,5 +486,6 @@ export function buildResourceLoader(agentDir: string): DefaultResourceLoader {
   return new DefaultResourceLoader({
     agentDir,
     additionalExtensionPaths: piExtensionPaths,
-  })
+    bundledExtensionNames: bundledKeys,
+  } as ConstructorParameters<typeof DefaultResourceLoader>[0])
 }

--- a/src/resources/extensions/gsd/doctor-providers.ts
+++ b/src/resources/extensions/gsd/doctor-providers.ts
@@ -305,11 +305,24 @@ function checkOptionalProviders(): ProviderCheckResult[] {
   const optional = ["brave", "tavily", "jina", "context7"] as const;
   const results: ProviderCheckResult[] = [];
 
+  // Determine which search providers are configured so we can suppress
+  // "not configured" noise for alternative search providers when at least
+  // one is already active (e.g. don't warn about missing BRAVE_API_KEY
+  // when Tavily is configured).
+  const searchProviderIds = ["brave", "tavily"] as const;
+  const hasAnySearchProvider = searchProviderIds.some(id => resolveKey(id).found);
+
   for (const providerId of optional) {
     const info = PROVIDER_REGISTRY.find(p => p.id === providerId);
     if (!info) continue;
 
     const lookup = resolveKey(providerId);
+
+    // Skip unconfigured search providers when another search provider is active
+    if (!lookup.found && hasAnySearchProvider && info.category === "search") {
+      continue;
+    }
+
     results.push({
       name: providerId,
       label: info.label,


### PR DESCRIPTION
## What
Four related fixes in the extension/resource management subsystem addressing stale directory pruning, conflict detection, skill catalog gating, and noisy provider warnings.

## Why
- **#1955**: Removed bundled subdirectory extensions (e.g. `mcporter/`) persist forever in `~/.gsd/agent/extensions/`, causing tool name conflicts
- **#2075**: `isBuiltIn` heuristic in `detectExtensionConflicts` uses a path check that can never match because all extensions (bundled and user) live in `~/.gsd/agent/extensions/`
- **#1949**: Skill catalog only appears in system prompt when `read` tool is active, but `Skill` is now a real built-in tool
- **#2027**: "not configured" warnings for Brave/Gemini search providers appear even when Tavily is the active search provider

## How

### 1. Subdirectory extension pruning (`src/resource-loader.ts`)
- `writeManagedResourceManifest()` now records `installedExtensionDirs` — directories containing `index.js` or `index.ts`
- `pruneRemovedBundledExtensions()` handles directory entries with `rmSync({ recursive: true })`

### 2. Fix isBuiltIn heuristic (`packages/pi-coding-agent/src/core/resource-loader.ts`)
- Added `bundledExtensionNames` option to `DefaultResourceLoaderOptions`
- `detectExtensionConflicts()` extracts the extension name from the owner path and checks against the canonical bundled names set
- `buildResourceLoader()` passes the already-computed `bundledKeys` to the resource loader

### 3. Gate skills on Skill tool (`packages/pi-coding-agent/src/core/system-prompt.ts`)
- Both custom prompt and default prompt paths now check for `Skill` tool in addition to `read` tool when deciding whether to include the skills catalog

### 4. Suppress search provider noise (`src/resources/extensions/gsd/doctor-providers.ts`)
- `checkOptionalProviders()` skips unconfigured search providers when at least one search provider is already configured

## Key changes
- `src/resource-loader.ts` — manifest writer and pruner handle subdirectory extensions
- `packages/pi-coding-agent/src/core/resource-loader.ts` — `isBuiltIn` uses bundled extension names set
- `packages/pi-coding-agent/src/core/system-prompt.ts` — skill catalog gated on `Skill` OR `read`
- `src/resources/extensions/gsd/doctor-providers.ts` — suppress redundant search provider warnings

## Testing
- `npx tsc --noEmit` passes clean (root tsconfig)
- `packages/pi-coding-agent` source type-checks clean (pre-existing `activeInferenceModel` error is unrelated)
- `src/tests/resource-sync-staleness.test.ts` — all 4 tests pass
- Existing `doctor-providers.test.ts` logic verified compatible (unconfigured search providers still show when NO search provider is configured)

## Risk
Low. All changes are additive or narrow conditional refinements:
- Manifest gains a new optional field (`installedExtensionDirs`) — old manifests without it are handled gracefully
- `bundledExtensionNames` defaults to empty set — no behavioral change when not provided
- Skill gating is strictly more permissive (OR condition)
- Search provider suppression only triggers when at least one provider IS configured

Closes #1955, closes #2075, closes #1949, closes #2027

🤖 Generated with [Claude Code](https://claude.com/claude-code)