### PR TITLE
fix(gsd): remove over-broad skill activation heuristic

### DIFF
--- a/src/resources/extensions/gsd/auto-prompts.ts
+++ b/src/resources/extensions/gsd/auto-prompts.ts
@@ -420,8 +420,6 @@ export function buildSkillActivationBlock(params: {
     params.sliceTitle,
     params.taskId,
     params.taskTitle,
-    ...(params.extraContext ?? []),
-    params.taskPlanContent ?? undefined,
   );
 
   const visibleSkills = (typeof getLoadedSkills === 'function' ? getLoadedSkills() : []).filter(skill => !skill.disableModelInvocation);
@@ -449,12 +447,6 @@ export function buildSkillActivationBlock(params: {
       }
     } catch {
       // Non-fatal — malformed task plan should not break prompt construction
-    }
-  }
-
-  for (const skill of visibleSkills) {
-    if (skillMatchesContext(skill, contextTokens)) {
-      matched.add(normalizeSkillReference(skill.name));
     }
   }
 

--- a/src/resources/extensions/gsd/tests/skill-activation.test.ts
+++ b/src/resources/extensions/gsd/tests/skill-activation.test.ts
@@ -39,7 +39,7 @@ function buildBlock(
   });
 }
 
-test("buildSkillActivationBlock matches installed skills from task context", () => {
+test("buildSkillActivationBlock does not auto-activate skills via broad context heuristic", () => {
   const base = makeTempBase();
   try {
     writeSkill(base, "react", "Use for React components, hooks, JSX, and frontend UI work.");
@@ -52,7 +52,29 @@ test("buildSkillActivationBlock matches installed skills from task context", () 
       taskTitle: "Implement React settings panel",
     });
 
-    assert.match(result, /<skill_activation>/);
+    // Skills should not be activated just because their name appears in task context.
+    // Activation requires explicit preference sources (always_use, skill_rules, prefer_skills, skills_used).
+    assert.equal(result, "");
+  } finally {
+    cleanup(base);
+  }
+});
+
+test("buildSkillActivationBlock activates skills via prefer_skills when context matches", () => {
+  const base = makeTempBase();
+  try {
+    writeSkill(base, "react", "Use for React components, hooks, JSX, and frontend UI work.");
+    writeSkill(base, "swiftui", "Use for SwiftUI views, iOS layout, and Apple platform UI work.");
+    loadOnlyTestSkills(base);
+
+    const result = buildBlock(base, {
+      sliceTitle: "Build React dashboard",
+      taskId: "T01",
+      taskTitle: "Implement React settings panel",
+    }, {
+      prefer_skills: ["react"],
+    });
+
     assert.match(result, /Call Skill\('react'\)/);
     assert.doesNotMatch(result, /swiftui/);
   } finally {
@@ -105,7 +127,7 @@ test("buildSkillActivationBlock includes skill_rules matches and task-plan skill
   }
 });
 
-test("buildSkillActivationBlock honors avoid_skills", () => {
+test("buildSkillActivationBlock honors avoid_skills against always_use_skills", () => {
   const base = makeTempBase();
   try {
     writeSkill(base, "react", "Use for React components and frontend UI work.");
@@ -114,6 +136,7 @@ test("buildSkillActivationBlock honors avoid_skills", () => {
     const result = buildBlock(base, {
       taskTitle: "Implement React settings panel",
     }, {
+      always_use_skills: ["react"],
       avoid_skills: ["react"],
     });
 
@@ -133,6 +156,36 @@ test("buildSkillActivationBlock falls back cleanly when nothing matches", () => 
       taskTitle: "Plain text docs task",
     });
 
+    assert.equal(result, "");
+  } finally {
+    cleanup(base);
+  }
+});
+
+test("buildSkillActivationBlock does not activate skills from extraContext or taskPlanContent body", () => {
+  const base = makeTempBase();
+  try {
+    writeSkill(base, "xcode-build", "Use for Xcode build workflows and iOS compilation.");
+    writeSkill(base, "ableton-lom", "Use for Ableton Live Object Model scripting.");
+    writeSkill(base, "frontend-design", "Use for frontend design systems and UI components.");
+    loadOnlyTestSkills(base);
+
+    const taskPlan = [
+      "---",
+      "skills_used: []",
+      "---",
+      "# T01: Build the API endpoint",
+      "Use xcode-build patterns and frontend-design tokens.",
+    ].join("\n");
+
+    const result = buildBlock(base, {
+      taskTitle: "Build REST API",
+      extraContext: ["Build workflow for iOS and Ableton integration testing"],
+      taskPlanContent: taskPlan,
+    });
+
+    // None of these skills should activate — extraContext and taskPlanContent body
+    // must not be used for heuristic matching.
     assert.equal(result, "");
   } finally {
     cleanup(base);


### PR DESCRIPTION
## Summary
- Removes the blanket heuristic loop in `buildSkillActivationBlock()` that auto-activated every visible skill matching substring tokens from broad prompt context (`extraContext`, `taskPlanContent` body)
- Restricts `contextTokens` to narrow metadata only (milestone/slice/task IDs and titles)
- Skill activation now uses only explicit preference sources: `always_use_skills`, `skill_rules`, `prefer_skills`, and `skills_used` from task plan frontmatter

Closes #2239

## Test plan
- [x] Updated existing tests to verify heuristic no longer activates skills from task context
- [x] Added test for `prefer_skills` as the correct explicit opt-in path
- [x] Added test for `avoid_skills` against `always_use_skills`
- [x] Added regression test verifying `extraContext` and `taskPlanContent` body don't trigger activation
- [x] All 7 skill-activation tests pass
- [x] Pre-existing failure in GSD test suite confirmed on main (unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)