### PR TITLE
fix(async-jobs): suppress duplicate follow-up for awaited jobs

### DIFF
--- a/src/resources/extensions/async-jobs/await-tool.test.ts
+++ b/src/resources/extensions/async-jobs/await-tool.test.ts
@@ -118,3 +118,50 @@ test("await_job returns not-found message for invalid job IDs", async () => {
 
 	manager.shutdown();
 });
+
+test("await_job marks jobs as awaited to suppress follow-up delivery (#2248)", async () => {
+	const followUps: string[] = [];
+	const manager = new AsyncJobManager({
+		onJobComplete: (job) => {
+			if (!job.awaited) followUps.push(job.id);
+		},
+	});
+	const tool = createAwaitTool(() => manager);
+
+	// Register a job that completes in 50ms
+	const jobId = manager.register("bash", "awaited-job", async () => {
+		return new Promise<string>((resolve) => setTimeout(() => resolve("result"), 50));
+	});
+
+	// await_job consumes the result — should mark as awaited before promise resolves
+	await tool.execute("tc7", { jobs: [jobId] }, noopSignal, () => {}, undefined as never);
+
+	// Give the onJobComplete callback a tick to fire
+	await new Promise((r) => setTimeout(r, 50));
+
+	assert.equal(followUps.length, 0, "onJobComplete should not deliver follow-up for awaited jobs");
+
+	manager.shutdown();
+});
+
+test("unawaited jobs still get follow-up delivery (#2248)", async () => {
+	const followUps: string[] = [];
+	const manager = new AsyncJobManager({
+		onJobComplete: (job) => {
+			if (!job.awaited) followUps.push(job.id);
+		},
+	});
+
+	// Register a fire-and-forget job
+	const jobId = manager.register("bash", "fire-and-forget", async () => "done");
+	const job = manager.getJob(jobId)!;
+	await job.promise;
+
+	// Give the callback a tick
+	await new Promise((r) => setTimeout(r, 50));
+
+	assert.equal(followUps.length, 1, "onJobComplete should deliver follow-up for unawaited jobs");
+	assert.equal(followUps[0], jobId);
+
+	manager.shutdown();
+});

--- a/src/resources/extensions/async-jobs/await-tool.ts
+++ b/src/resources/extensions/async-jobs/await-tool.ts
@@ -66,6 +66,11 @@ export function createAwaitTool(getManager: () => AsyncJobManager): ToolDefiniti
 				}
 			}
 
+			// Mark all watched jobs as awaited upfront so the onJobComplete
+			// callback (which fires synchronously in the promise .then()) knows
+			// to suppress the follow-up message.
+			for (const j of watched) j.awaited = true;
+
 			// If all watched jobs are already done, return immediately
 			const running = watched.filter((j) => j.status === "running");
 			if (running.length === 0) {

--- a/src/resources/extensions/async-jobs/index.ts
+++ b/src/resources/extensions/async-jobs/index.ts
@@ -42,6 +42,7 @@ export default function AsyncJobs(pi: ExtensionAPI) {
 
 		manager = new AsyncJobManager({
 			onJobComplete: (job) => {
+				if (job.awaited) return;
 				const statusEmoji = job.status === "completed" ? "done" : "error";
 				const elapsed = ((Date.now() - job.startTime) / 1000).toFixed(1);
 				const output = job.status === "completed"

--- a/src/resources/extensions/async-jobs/job-manager.ts
+++ b/src/resources/extensions/async-jobs/job-manager.ts
@@ -22,6 +22,8 @@ export interface Job {
 	promise: Promise<void>;
 	resultText?: string;
 	errorText?: string;
+	/** Set by await_job when results are consumed. Suppresses follow-up delivery. */
+	awaited?: boolean;
 }
 
 export interface JobManagerOptions {


### PR DESCRIPTION
## Summary

- Adds `awaited` flag to `Job` interface in `job-manager.ts`
- `await_job` marks all watched jobs as awaited **before** waiting (avoids race with promise `.then()` callback)
- `onJobComplete` in `index.ts` skips follow-up delivery for awaited jobs
- Fire-and-forget jobs (never passed to `await_job`) still get follow-up messages

This eliminates the dual-delivery pattern where `await_job` consumed results and `onJobComplete` also fired follow-ups — each triggering a wasteful LLM turn (~84K tokens) saying "Already captured". Observed 6 wasted turns costing $0.27 (21.4% of task cost) in a single execution.

## Test plan

- [x] `tsc --noEmit` passes
- [x] Existing `await-tool.test.ts` — 6/6 pass (no regressions)
- [x] New test: awaited jobs suppress follow-up delivery
- [x] New test: unawaited jobs still get follow-up delivery
- [x] `async-bash-timeout.test.ts` — 2/2 pass

Closes #2248

🤖 Generated with [Claude Code](https://claude.com/claude-code)