### PR TITLE
fix: prevent banner from printing twice on first run

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -630,8 +630,9 @@ if (!process.stdin.isTTY) {
   process.exit(1)
 }
 
-// Welcome screen — shown on every fresh interactive session before TUI takes over
-{
+// Welcome screen — shown on every fresh interactive session before TUI takes over.
+// Skip when the first-run banner was already printed in loader.ts (prevents double banner).
+if (!process.env.GSD_FIRST_RUN_BANNER) {
   const { printWelcomeScreen } = await import('./welcome-screen.js')
   printWelcomeScreen({
     version: process.env.GSD_VERSION || '0.0.0',

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -49,7 +49,8 @@ process.env.PI_PACKAGE_DIR = pkgDir
 process.env.PI_SKIP_VERSION_CHECK = '1'  // GSD runs its own update check in cli.ts — suppress pi's
 process.title = 'gsd'
 
-// Print branded banner on first launch (before ~/.gsd/ exists)
+// Print branded banner on first launch (before ~/.gsd/ exists).
+// Set GSD_FIRST_RUN_BANNER so cli.ts skips the duplicate welcome screen.
 if (!existsSync(appRoot)) {
   const cyan  = '\x1b[36m'
   const green = '\x1b[32m'
@@ -62,6 +63,7 @@ if (!existsSync(appRoot)) {
     `  Get Shit Done ${dim}v${gsdVersion}${reset}\n` +
     `  ${green}Welcome.${reset} Setting up your environment...\n\n`
   )
+  process.env.GSD_FIRST_RUN_BANNER = '1'
 }
 
 // GSD_CODING_AGENT_DIR — tells pi's getAgentDir() to return ~/.gsd/agent/ instead of ~/.gsd/agent/


### PR DESCRIPTION
## TL;DR

**What:** Prevent the GSD ASCII banner from printing twice on first launch.
**Why:** Both `loader.ts` and `cli.ts` independently print a banner, resulting in duplicate output on first run.
**How:** Set `GSD_FIRST_RUN_BANNER` env flag in `loader.ts`; check it in `cli.ts` before printing.

## What

Two files changed:
- `src/loader.ts` — sets `process.env.GSD_FIRST_RUN_BANNER = '1'` after printing the first-run banner
- `src/cli.ts` — checks `if (!process.env.GSD_FIRST_RUN_BANNER)` before calling `printWelcomeScreen()`

## Why

On first launch (before `~/.gsd/` exists), two independent code paths both print a branded banner:

1. `loader.ts:53` checks `!existsSync(appRoot)` and prints a raw ASCII logo + "Welcome. Setting up your environment..."
2. Between these two prints, onboarding runs and creates `~/.gsd/`
3. `cli.ts:635` unconditionally calls `printWelcomeScreen()`, printing a second full welcome panel

The user sees two banners on every first launch.

Closes #2245

## How

A lightweight env flag (`GSD_FIRST_RUN_BANNER`) coordinates the two code paths:
- `loader.ts` sets the flag after printing
- `cli.ts` skips `printWelcomeScreen()` when the flag is set

The session-restart banner in `register-hooks.ts` is unaffected — it only fires on non-first sessions via its existing `isFirstSession` guard.

Alternatives considered:
- Removing the loader banner entirely — rejected because it provides immediate feedback before the slower onboarding starts
- Using a module-level variable — rejected because `loader.ts` and `cli.ts` are separate module scopes; env var is the simplest cross-module coordination

## Change type

- [x] `fix` — Bug fix

## Scope

- [x] `gsd extension` — GSD workflow

## Breaking changes

- [x] No breaking changes

## Test plan

- [x] CI passes
- [ ] New/updated tests included
- [x] Manual testing — the banner code path requires a clean `~/.gsd/` directory which is impractical to unit-test without mocking `existsSync` on the loader entry point. Verified by code inspection: the env flag is set exactly once, checked exactly once, and the session-restart path (`register-hooks.ts`) is confirmed unaffected.
- [ ] No tests needed — explained above

Local verification:
- `npm run build` — ✅
- `npm run typecheck:extensions` — ✅
- `npm run test:unit` — 2780 pass / 0 fail / 4 skip
- `npm run test:integration` — 59 pass / 3 fail (pre-existing web-mode onboarding failures, confirmed identical on `upstream/main`)

## AI disclosure

- [x] This PR includes AI-assisted code — authored with Claude Code (pi/gsd). All changes were verified through full local CI gate and manual code review.
