### PR TITLE
fix(test): Windows CI failure — single quotes in git commit message

### DIFF
--- a/src/resources/extensions/gsd/tests/git-service.test.ts
+++ b/src/resources/extensions/gsd/tests/git-service.test.ts
@@ -1433,7 +1433,8 @@ async function main(): Promise<void> {
 
     // .gitignore blocks .gsd (as ensureGitignore would do for symlink projects)
     writeFileSync(join(repo, ".gitignore"), ".gsd\n");
-    run("git add .gitignore && git commit -m 'add gitignore'", repo);
+    run('git add .gitignore', repo);
+    run('git commit -m "add gitignore"', repo);
 
     // Simulate new milestone artifacts created during execution
     writeFileSync(join(externalGsd, "milestones", "M009", "M009-SUMMARY.md"), "# M009 Summary");


### PR DESCRIPTION
## Summary

- Fixes the Windows portability CI failure that's been red on main since #2104
- The symlink test at `git-service.test.ts:1436` used `run("git add .gitignore && git commit -m 'add gitignore'", repo)` — single quotes inside a `&&`-chained command
- On Windows, `cmd.exe` doesn't treat single quotes as string delimiters, so git received the pathspec `gitignore'` (with trailing quote) → `error: pathspec 'gitignore'' did not match any file(s) known to git`
- Split into two separate `run()` calls with double-quoted commit message, matching the pattern of every other test in the file

## Test plan

- [x] `git-service.test.ts` — 188/188 pass locally
- [ ] Windows CI should go green (this was the only failure: 2699/2700 pass → 2700/2700)

🤖 Generated with [Claude Code](https://claude.com/claude-code)