### PR TITLE
fix(gsd): recognize heading-checkbox format in roadmap prose parser

### DIFF
--- a/src/resources/extensions/gsd/roadmap-slices.ts
+++ b/src/resources/extensions/gsd/roadmap-slices.ts
@@ -218,13 +218,15 @@ export function parseRoadmapSlices(content: string): RoadmapSliceEntry[] {
 function parseProseSliceHeaders(content: string): RoadmapSliceEntry[] {
   const slices: RoadmapSliceEntry[] = [];
   // Match H1-H4 headers containing S<digits> with optional "Slice" prefix, bold markers,
-  // and optional checkmark completion marker before the slice ID.
+  // optional [x]/[ ] checkbox, and optional checkmark completion marker before the slice ID.
   // Separator after the ID is flexible: colon, dash, em/en dash, dot, or just whitespace.
-  const headerPattern = /^#{1,4}\s+\*{0,2}(?:\u2713\s+)?(?:Slice\s+)?(S\d+)\*{0,2}[:\s.\u2014\u2013-]*\s*(.+)/gm;
+  const headerPattern = /^#{1,4}\s+\*{0,2}(?:\[[ xX]\]\s+)?(?:\u2713\s+)?(?:Slice\s+)?(S\d+)\*{0,2}[:\s.\u2014\u2013-]*\s*(.+)/gm;
   let match: RegExpExecArray | null;
 
-  // Check for checkmark before the slice ID (e.g., "## checkmark S01: Title")
+  // Check for checkmark before the slice ID (e.g., "## ✓ S01: Title")
   const prefixCheckPattern = /^#{1,4}\s+\*{0,2}\u2713\s+/;
+  // Check for [x] checkbox before the slice ID (e.g., "### [x] S01 — Title") — see #2263
+  const checkboxDonePattern = /^#{1,4}\s+\*{0,2}\[[xX]\]/;
 
   while ((match = headerPattern.exec(content)) !== null) {
     const id = match[1]!;
@@ -232,11 +234,12 @@ function parseProseSliceHeaders(content: string): RoadmapSliceEntry[] {
     if (!title) continue; // skip if we only matched the ID with no title
 
     // Detect completion markers:
-    // 1. Checkmark before the slice ID: "## checkmark S01: Title"
-    // 2. Checkmark after separator: "## S01: checkmark Title"
-    // 3. (Complete) suffix: "## S01: Title (Complete)"
+    // 1. [x] checkbox before the slice ID: "### [x] S01 — Title" (#2263)
+    // 2. Checkmark before the slice ID: "## ✓ S01: Title"
+    // 3. Checkmark after separator: "## S01: ✓ Title"
+    // 4. (Complete) suffix: "## S01: Title (Complete)"
     const line = match[0];
-    let done = prefixCheckPattern.test(line);
+    let done = checkboxDonePattern.test(line) || prefixCheckPattern.test(line);
 
     if (!done && title.startsWith("\u2713")) {
       done = true;

--- a/src/resources/extensions/gsd/tests/roadmap-parse-regression.test.ts
+++ b/src/resources/extensions/gsd/tests/roadmap-parse-regression.test.ts
@@ -457,6 +457,50 @@ async function main(): Promise<void> {
     assertEq(slices[1].done, false, '#1736 checkbox compat: S02 not done');
   }
 
+  // ═══════════════════════════════════════════════════════════════════════
+
+  console.log('\n=== U. #2263: Heading-checkbox format (### [x] S01 — Title) ===');
+
+  {
+    const content = [
+      '# M003: IaC Automation',
+      '',
+      '## Slices',
+      '',
+      '### [x] S01 — Pipeline Configuration',
+      '',
+      'Set up CI/CD pipelines.',
+      '',
+      '### [x] S02 — Infrastructure Templates',
+      '',
+      'Create CloudFormation templates.',
+      '',
+      '### [ ] S03 — Monitoring Setup',
+      '',
+      'Configure alerting and dashboards.',
+      '',
+    ].join('\n');
+
+    const slices = parseRoadmapSlices(content);
+    assertEq(slices.length, 3, '#2263 heading-checkbox: 3 slices parsed');
+    assertEq(slices[0].id, 'S01', '#2263: S01 id');
+    assertEq(slices[0].title, 'Pipeline Configuration', '#2263: S01 title');
+    assertEq(slices[0].done, true, '#2263: S01 done (checked)');
+    assertEq(slices[1].id, 'S02', '#2263: S02 id');
+    assertEq(slices[1].done, true, '#2263: S02 done (checked)');
+    assertEq(slices[2].id, 'S03', '#2263: S03 id');
+    assertEq(slices[2].done, false, '#2263: S03 not done (unchecked)');
+  }
+
+  {
+    // Verify the exact pattern from the issue report
+    const content = '### [x] S01 — Title\n\nSome content.\n\n### [ ] S02 — Other\n\nMore content.\n';
+    const slices = parseRoadmapSlices(content);
+    assertEq(slices.length, 2, '#2263 exact repro: 2 slices');
+    assertEq(slices[0].done, true, '#2263 exact repro: S01 done');
+    assertEq(slices[1].done, false, '#2263 exact repro: S02 not done');
+  }
+
   report();
 }
 


### PR DESCRIPTION
## TL;DR

**What:** Add `[x]`/`[ ]` checkbox support to the roadmap prose heading parser.
**Why:** Headings like `### [x] S01 — Title` were not recognized, causing `parseRoadmapSlices()` to return 0 slices and triggering an infinite `plan-milestone` dispatch loop.
**How:** Extend the header regex with an optional checkbox group and add checkbox-based done detection.

## What

Two files changed:
- `src/resources/extensions/gsd/roadmap-slices.ts` — extended `headerPattern` regex and added `checkboxDonePattern` for completion detection
- `src/resources/extensions/gsd/tests/roadmap-parse-regression.test.ts` — added section U with 2 test blocks (heading-checkbox format + exact reproduction scenario)

## Why

When a plan-milestone agent writes roadmap slices using heading-checkbox format (`### [x] S01 — Title`), none of the three parsers (table, checkbox, prose heading) could match it:
1. Table parser — no pipe characters
2. Checkbox parser — expects `- [x]`, not `### [x]`
3. Prose header parser — regex didn't include `[x]` prefix

With 0 slices returned, `deriveState()` hit the zero-slice guard and returned `phase: pre-planning`, even for a fully-completed milestone. This triggered an infinite plan-milestone loop that hard-stopped after 3 consecutive attempts.

Closes #2263

## How

Two surgical changes in `parseProseSliceHeaders()`:

1. **Regex**: Added `(?:\[[ xX]\]\s+)?` optional group before the existing checkmark group
2. **Done detection**: Added `checkboxDonePattern` (`/^#{1,4}\s+\*{0,2}\[[xX]\]/`) checked alongside the existing checkmark and `(Complete)` patterns

No other parsers or functions were modified.

## Change type

- [x] `fix` — Bug fix

## Scope

- [x] `gsd extension` — GSD workflow

## Breaking changes

- [x] No breaking changes

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [ ] Manual testing — steps described above
- [ ] No tests needed — explained above

Test additions (section U in roadmap-parse-regression):
- 3-slice heading-checkbox roadmap: verifies ID extraction, title extraction, and done/not-done detection
- Exact reproduction scenario from the issue: `### [x] S01 — Title` parsed correctly

Local verification:
- `npm run build` — ✅
- `npm run typecheck:extensions` — ✅
- `npm run test:unit` — 2723 pass / 1 fail (pre-existing env-dependent, confirmed on `upstream/main`) / 4 skip
- `npm run test:integration` — 59 pass / 3 fail (pre-existing web-mode, confirmed on `upstream/main`) / 1 skip
- All 79 roadmap-parse-regression tests pass ✅
- All 17 roadmap-slices tests pass ✅

## AI disclosure

- [x] This PR includes AI-assisted code — authored with Claude Code (pi/gsd). All changes verified through full local CI gate and manual code review.
