### PR TITLE
feat: add communication_language preference for native language support

### DIFF
--- a/src/resources/extensions/gsd/preferences-types.ts
+++ b/src/resources/extensions/gsd/preferences-types.ts
@@ -91,6 +91,7 @@ export const KNOWN_PREFERENCE_KEYS = new Set<string>([
   "service_tier",
   "forensics_dedup",
   "show_token_cost",
+  "communication_language",
 ]);
 
 /** Canonical list of all dispatch unit types. */
@@ -229,6 +230,8 @@ export interface GSDPreferences {
   forensics_dedup?: boolean;
   /** Opt-in: show per-prompt and cumulative session token cost in the footer. Default: false. */
   show_token_cost?: boolean;
+  /** Communication language preference. When set to a non-English language (e.g. "Polish", "French"), GSD communicates in that language. Technical terms, code, and file paths remain in English. */
+  communication_language?: string;
 }
 
 export interface LoadedGSDPreferences {

--- a/src/resources/extensions/gsd/preferences-validation.ts
+++ b/src/resources/extensions/gsd/preferences-validation.ts
@@ -756,5 +756,14 @@ export function validatePreferences(preferences: GSDPreferences): {
     }
   }
 
+  // ─── Communication Language ─────────────────────────────────────────
+  if (preferences.communication_language !== undefined) {
+    if (typeof preferences.communication_language === "string" && preferences.communication_language.trim() !== "") {
+      validated.communication_language = preferences.communication_language.trim();
+    } else {
+      errors.push("communication_language must be a non-empty string (e.g. \"Polish\", \"French\", \"English\")");
+    }
+  }
+
   return { preferences: validated, errors, warnings };
 }

--- a/src/resources/extensions/gsd/preferences.ts
+++ b/src/resources/extensions/gsd/preferences.ts
@@ -343,6 +343,7 @@ function mergePreferences(base: GSDPreferences, override: GSDPreferences): GSDPr
     service_tier: override.service_tier ?? base.service_tier,
     forensics_dedup: override.forensics_dedup ?? base.forensics_dedup,
     show_token_cost: override.show_token_cost ?? base.show_token_cost,
+    communication_language: override.communication_language ?? base.communication_language,
   };
 }
 
@@ -456,6 +457,14 @@ export function renderPreferencesForSystemPrompt(preferences: GSDPreferences, re
     for (const instruction of preferences.custom_instructions) {
       lines.push(`  - ${instruction}`);
     }
+  }
+
+  // ─── Communication Language Directive ──────────────────────────────
+  const lang = preferences.communication_language?.trim();
+  if (lang && lang.toLowerCase() !== "english") {
+    lines.push("");
+    lines.push("## Communication Language");
+    lines.push(`Communicate with the user in ${lang}. Write all explanations, questions, and status messages in ${lang}. Technical terms, code, file paths, and command names should remain in English.`);
   }
 
   return lines.join("\n");

--- a/src/resources/extensions/gsd/tests/preferences.test.ts
+++ b/src/resources/extensions/gsd/tests/preferences.test.ts
@@ -15,6 +15,7 @@ import {
   applyModeDefaults,
   getIsolationMode,
   parsePreferencesMarkdown,
+  renderPreferencesForSystemPrompt,
 } from "../preferences.ts";
 import type { GSDPreferences, GSDModelConfigV2, GSDPhaseModelConfig } from "../preferences.ts";
 
@@ -351,4 +352,77 @@ test("handles empty models config", () => {
   const prefs = parsePreferencesMarkdown("---\nversion: 1\n---\n");
   assert.notEqual(prefs, null);
   assert.equal(prefs!.models, undefined);
+});
+
+// ── Communication language preference (#2124) ────────────────────────────────
+
+test("communication_language is recognized as a known preference key", () => {
+  const { warnings } = validatePreferences({ communication_language: "Polish" });
+  const unknownKeyWarning = warnings.find(w => w.includes("communication_language"));
+  assert.equal(unknownKeyWarning, undefined, "should not warn about unknown key");
+});
+
+test("communication_language validates non-empty string", () => {
+  const { errors, preferences } = validatePreferences({ communication_language: "French" });
+  assert.equal(errors.length, 0);
+  assert.equal(preferences.communication_language, "French");
+});
+
+test("communication_language trims whitespace", () => {
+  const { errors, preferences } = validatePreferences({ communication_language: "  Polish  " });
+  assert.equal(errors.length, 0);
+  assert.equal(preferences.communication_language, "Polish");
+});
+
+test("communication_language rejects empty string", () => {
+  const { errors } = validatePreferences({ communication_language: "" });
+  assert.ok(errors.length > 0);
+  assert.ok(errors[0].includes("communication_language"));
+});
+
+test("communication_language rejects non-string values", () => {
+  const { errors } = validatePreferences({ communication_language: 42 as any });
+  assert.ok(errors.length > 0);
+  assert.ok(errors[0].includes("communication_language"));
+});
+
+test("communication_language parses from YAML frontmatter", () => {
+  const content = "---\ncommunication_language: Polish\n---\n";
+  const prefs = parsePreferencesMarkdown(content);
+  assert.notEqual(prefs, null);
+  assert.equal(prefs!.communication_language, "Polish");
+});
+
+test("renderPreferencesForSystemPrompt includes language directive for non-English language", () => {
+  const prefs: GSDPreferences = { communication_language: "Polish" };
+  const rendered = renderPreferencesForSystemPrompt(prefs);
+  assert.ok(rendered.includes("## Communication Language"), "should have Communication Language heading");
+  assert.ok(rendered.includes("Communicate with the user in Polish"), "should include Polish directive");
+  assert.ok(rendered.includes("Technical terms, code, file paths, and command names should remain in English"), "should keep technical terms in English");
+});
+
+test("renderPreferencesForSystemPrompt omits language directive for English", () => {
+  const prefs: GSDPreferences = { communication_language: "English" };
+  const rendered = renderPreferencesForSystemPrompt(prefs);
+  assert.ok(!rendered.includes("## Communication Language"), "should not include language section for English");
+});
+
+test("renderPreferencesForSystemPrompt omits language directive for english (case-insensitive)", () => {
+  const prefs: GSDPreferences = { communication_language: "english" };
+  const rendered = renderPreferencesForSystemPrompt(prefs);
+  assert.ok(!rendered.includes("## Communication Language"), "should not include language section for lowercase english");
+});
+
+test("renderPreferencesForSystemPrompt omits language directive when not set", () => {
+  const prefs: GSDPreferences = {};
+  const rendered = renderPreferencesForSystemPrompt(prefs);
+  assert.ok(!rendered.includes("## Communication Language"), "should not include language section when unset");
+});
+
+test("communication_language merges correctly (project overrides global)", () => {
+  const global: GSDPreferences = { communication_language: "French" };
+  const project: GSDPreferences = { communication_language: "Polish" };
+  const merged = applyModeDefaults("solo", { ...global, ...project });
+  // applyModeDefaults applies mode defaults as base, project prefs override
+  assert.equal(merged.communication_language, "Polish");
 });


### PR DESCRIPTION
## TL;DR

**What:** Add a `communication_language` preference so GSD communicates in the user's native language.
**Why:** Users want GSD to write explanations, questions, and status messages in their own language (e.g. Polish, French) instead of always English.
**How:** New string preference key with validation, merge support, and a system prompt directive injected when the language is not English.

## What

Adds `communication_language` as a new GSD preference key. When set to a non-English language name (e.g. "Polish", "French"), a directive is appended to the system prompt instructing the agent to communicate in that language while keeping technical terms, code, file paths, and command names in English.

Files changed:
- `src/resources/extensions/gsd/preferences-types.ts` — added to `GSDPreferences` interface and `KNOWN_PREFERENCE_KEYS`
- `src/resources/extensions/gsd/preferences-validation.ts` — validates as non-empty string
- `src/resources/extensions/gsd/preferences.ts` — merge logic + language directive in `renderPreferencesForSystemPrompt()`
- `src/resources/extensions/gsd/tests/preferences.test.ts` — 11 new tests

## Why

Fixes #2124. International users want GSD to communicate in their native language. The preference is opt-in and has zero impact when unset or set to "English".

## How

1. Added `communication_language?: string` to the `GSDPreferences` interface
2. Registered the key in `KNOWN_PREFERENCE_KEYS` so it is not flagged as unknown
3. Added validation: must be a non-empty string when provided
4. Added merge support: project-level overrides global-level (standard `??` semantics)
5. In `renderPreferencesForSystemPrompt()`, when language is set and not "English" (case-insensitive), appends a `## Communication Language` section with the directive

Usage in `preferences.md`:
```yaml
---
communication_language: Polish
---
```

- [x] `feat` — New feature or capability

AI-assisted: This PR was authored with Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>