### PR TITLE
fix(gsd): pass milestoneBranch to removeWorktree in mergeMilestoneToMain

### DIFF
--- a/src/resources/extensions/gsd/auto-worktree.ts
+++ b/src/resources/extensions/gsd/auto-worktree.ts
@@ -1285,7 +1285,7 @@ export function mergeMilestoneToMain(
   // 11. Remove worktree directory first (must happen before branch deletion)
   try {
     removeWorktree(originalBasePath_, milestoneId, {
-      branch: null as unknown as string,
+      branch: milestoneBranch,
       deleteBranch: false,
     });
   } catch {


### PR DESCRIPTION
## TL;DR

**What:** Pass `milestoneBranch` instead of `null` to `removeWorktree()` in `mergeMilestoneToMain()`.
**Why:** Passing `null` caused the worktree lookup to use the wrong branch name pattern, silently failing to remove the worktree and branch after milestone merge.
**How:** One-line change: replace `branch: null as unknown as string` with `branch: milestoneBranch` (already in scope).

## What

One file changed:
- `src/resources/extensions/gsd/auto-worktree.ts` — line 1288: `null` → `milestoneBranch`

## Why

After a successful squash-merge of a milestone branch to main, `mergeMilestoneToMain()` calls `removeWorktree()` with `branch: null`. Inside `removeWorktree()`, `null` triggers the fallback to `worktreeBranchName(milestoneId)` which produces `worktree/<MID>` — but the actual git worktree entry uses `milestone/<MID>` (set by `autoWorktreeBranch()`).

This mismatch means:
1. The branch-based worktree path lookup fails to find the real worktree
2. `git worktree remove` fails silently (wrong path)
3. `git branch -D` fails silently (branch still checked out in the un-removed worktree)
4. Stale worktree directories and milestone branches accumulate after every merge

The correct call site (`teardownAutoWorktree()` at line 772) already passes the branch correctly. This was simply missed in `mergeMilestoneToMain()`.

Closes #2156

## How

`milestoneBranch` is already defined at line 975 (`autoWorktreeBranch(milestoneId)`) and used throughout the function. The fix passes it to `removeWorktree()` at step 11, consistent with the correct pattern at line 772.

## Change type

- [x] `fix` — Bug fix

## Scope

- [x] `gsd extension` — GSD workflow

## Breaking changes

- [x] No breaking changes

## Test plan

- [x] CI passes
- [ ] New/updated tests included
- [x] Manual testing — all 69 auto-worktree-milestone-merge tests pass ✅
- [ ] No tests needed — explained above

Local verification:
- `npm run build` — ✅
- `npm run typecheck:extensions` — ✅
- `npm run test:unit` — 2723 pass / 1 fail (pre-existing, confirmed on `upstream/main`) / 4 skip
- `npm run test:integration` — 59 pass / 3 fail (pre-existing, confirmed on `upstream/main`) / 1 skip

## AI disclosure

- [x] This PR includes AI-assisted code — authored with Claude Code (pi/gsd). All changes verified through full local CI gate and manual code review.
