### PR TITLE
feat(gsd): add renderCall/renderResult previews to DB tools

### DIFF
--- a/src/resources/extensions/gsd/bootstrap/db-tools.ts
+++ b/src/resources/extensions/gsd/bootstrap/db-tools.ts
@@ -1,5 +1,6 @@
 import { Type } from "@sinclair/typebox";
 import type { ExtensionAPI } from "@gsd/pi-coding-agent";
+import { Text } from "@gsd/pi-tui";
 
 import { findMilestoneIds, nextMilestoneId, claimReservedId, getReservedMilestoneIds } from "../guided-flow.js";
 import { loadEffectiveGSDPreferences } from "../preferences.js";
@@ -85,6 +86,22 @@ export function registerDbTools(pi: ExtensionAPI): void {
       ], { description: "Who made this decision: 'human' (user directed), 'agent' (LLM decided autonomously), or 'collaborative' (discussed and agreed). Default: 'agent'" })),
     }),
     execute: decisionSaveExecute,
+    renderCall(args: any, theme: any) {
+      let text = theme.fg("toolTitle", theme.bold("decision_save "));
+      if (args.scope) text += theme.fg("accent", `[${args.scope}] `);
+      if (args.decision) text += theme.fg("muted", args.decision);
+      if (args.choice) text += theme.fg("dim", ` — ${args.choice}`);
+      return new Text(text, 0, 0);
+    },
+    renderResult(result: any, _options: any, theme: any) {
+      const d = result.details;
+      if (result.isError || d?.error) {
+        return new Text(theme.fg("error", `Error: ${d?.error ?? "unknown"}`), 0, 0);
+      }
+      let text = theme.fg("success", `Decision ${d?.id ?? ""} saved`);
+      if (d?.id) text += theme.fg("dim", ` → DECISIONS.md`);
+      return new Text(text, 0, 0);
+    },
   };
 
   pi.registerTool(decisionSaveTool);
@@ -155,6 +172,22 @@ export function registerDbTools(pi: ExtensionAPI): void {
       supporting_slices: Type.Optional(Type.String({ description: "Supporting slices" })),
     }),
     execute: requirementUpdateExecute,
+    renderCall(args: any, theme: any) {
+      let text = theme.fg("toolTitle", theme.bold("requirement_update "));
+      if (args.id) text += theme.fg("accent", args.id);
+      const fields = ["status", "validation", "notes", "description"].filter((f) => args[f]);
+      if (fields.length > 0) text += theme.fg("dim", ` (${fields.join(", ")})`);
+      return new Text(text, 0, 0);
+    },
+    renderResult(result: any, _options: any, theme: any) {
+      const d = result.details;
+      if (result.isError || d?.error) {
+        return new Text(theme.fg("error", `Error: ${d?.error ?? "unknown"}`), 0, 0);
+      }
+      let text = theme.fg("success", `Requirement ${d?.id ?? ""} updated`);
+      text += theme.fg("dim", ` → REQUIREMENTS.md`);
+      return new Text(text, 0, 0);
+    },
   };
 
   pi.registerTool(requirementUpdateTool);
@@ -233,6 +266,22 @@ export function registerDbTools(pi: ExtensionAPI): void {
       content: Type.String({ description: "The full markdown content of the artifact" }),
     }),
     execute: summarySaveExecute,
+    renderCall(args: any, theme: any) {
+      let text = theme.fg("toolTitle", theme.bold("summary_save "));
+      if (args.artifact_type) text += theme.fg("accent", args.artifact_type);
+      const path = [args.milestone_id, args.slice_id, args.task_id].filter(Boolean).join("/");
+      if (path) text += theme.fg("dim", ` ${path}`);
+      return new Text(text, 0, 0);
+    },
+    renderResult(result: any, _options: any, theme: any) {
+      const d = result.details;
+      if (result.isError || d?.error) {
+        return new Text(theme.fg("error", `Error: ${d?.error ?? "unknown"}`), 0, 0);
+      }
+      let text = theme.fg("success", `${d?.artifact_type ?? "Artifact"} saved`);
+      if (d?.path) text += theme.fg("dim", ` → ${d.path}`);
+      return new Text(text, 0, 0);
+    },
   };
 
   pi.registerTool(summarySaveTool);
@@ -286,6 +335,18 @@ export function registerDbTools(pi: ExtensionAPI): void {
     ],
     parameters: Type.Object({}),
     execute: milestoneGenerateIdExecute,
+    renderCall(_args: any, theme: any) {
+      return new Text(theme.fg("toolTitle", theme.bold("milestone_generate_id")), 0, 0);
+    },
+    renderResult(result: any, _options: any, theme: any) {
+      const d = result.details;
+      if (result.isError || d?.error) {
+        return new Text(theme.fg("error", `Error: ${d?.error ?? "unknown"}`), 0, 0);
+      }
+      let text = theme.fg("success", `Generated ${d?.id ?? "ID"}`);
+      if (d?.source === "reserved") text += theme.fg("dim", " (reserved)");
+      return new Text(text, 0, 0);
+    },
   };
 
   pi.registerTool(milestoneGenerateIdTool);


### PR DESCRIPTION
## TL;DR

**What:** Add `renderCall` and `renderResult` to all 4 GSD DB tools for inline TUI previews.
**Why:** Tool calls showed generic static labels like "Save Decision" with no context about what was being saved.
**How:** Follow the established pattern from context7/search-the-web: `{toolTitle bold name} {accent primary arg} {dim metadata}`.

## What

One file changed:
- `src/resources/extensions/gsd/bootstrap/db-tools.ts` — added `renderCall` + `renderResult` to `gsd_decision_save`, `gsd_requirement_update`, `gsd_summary_save`, and `gsd_milestone_generate_id`

## Why

The TUI showed `⏳ Save Decision` during execution with no indication of what decision was being saved. Users had to expand the tool call to see content. Same for summary save, requirement update, and milestone ID generation.

After this change:
```
⏳ decision_save [architecture] Use SQLite for local state — better-sqlite3
✓ Decision D042 saved → DECISIONS.md

⏳ requirement_update R005 (status, validation)
✓ Requirement R005 updated → REQUIREMENTS.md

⏳ summary_save SUMMARY M001/S01
✓ SUMMARY saved → milestones/M001/slices/S01/S01-SUMMARY.md

⏳ milestone_generate_id
✓ Generated M003-r5jzab (reserved)
```

Closes #2236

## How

Added `renderCall` and `renderResult` methods to each tool definition, following the same pattern used by context7 and search-the-web extensions. Each renderer uses the theme API (`theme.fg("toolTitle", ...)`, `theme.fg("accent", ...)`, `theme.fg("dim", ...)`) and returns `new Text(text, 0, 0)`.

All renderers handle error cases via `result.isError || details.error` and display the error message using `theme.fg("error", ...)`.

## Change type

- [x] `feat` — New feature or capability

## Scope

- [x] `gsd extension` — GSD workflow

## Breaking changes

- [x] No breaking changes

## Test plan

- [x] CI passes
- [ ] New/updated tests included
- [ ] Manual testing — steps described above
- [x] No tests needed — renderCall/renderResult are pure display functions. The tool execution logic is unchanged and already tested. Visual rendering is verified by manual inspection in a live TUI session.

Local verification:
- `npm run build` — ✅
- `npm run typecheck:extensions` — ✅
- `npm run test:unit` — 2723 pass / 1 fail (pre-existing, confirmed on `upstream/main`) / 4 skip
- `npm run test:integration` — 59 pass / 3 fail (pre-existing, confirmed on `upstream/main`) / 1 skip

## AI disclosure

- [x] This PR includes AI-assisted code — authored with Claude Code (pi/gsd). All changes verified through full local CI gate and manual code review.
