### PR TITLE
fix(cmux): sync sidebar on unit dispatch and add missing phase visuals

### DIFF
--- a/src/resources/extensions/cmux/index.ts
+++ b/src/resources/extensions/cmux/index.ts
@@ -142,7 +142,7 @@ export function buildCmuxProgress(state: GSDState): CmuxSidebarProgress | null {
     ?? choose(progress.milestones.done, progress.milestones.total, "milestones");
 }
 
-function phaseVisuals(phase: Phase): { icon: string; color: string } {
+export function phaseVisuals(phase: Phase): { icon: string; color: string } {
   switch (phase) {
     case "blocked":
       return { icon: "triangle-alert", color: "#ef4444" };
@@ -158,6 +158,17 @@ function phaseVisuals(phase: Phase): { icon: string; color: string } {
     case "validating-milestone":
     case "verifying":
       return { icon: "shield-check", color: "#06b6d4" };
+    case "executing":
+      return { icon: "zap", color: "#4ade80" };
+    case "summarizing":
+      return { icon: "file-text", color: "#60a5fa" };
+    case "advancing":
+      return { icon: "arrow-right", color: "#4ade80" };
+    case "discussing":
+    case "needs-discussion":
+      return { icon: "message-circle", color: "#a78bfa" };
+    case "pre-planning":
+      return { icon: "list", color: "#94a3b8" };
     default:
       return { icon: "rocket", color: "#4ade80" };
   }

--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -864,6 +864,7 @@ export async function runUnitPhase(
   if (mid)
     deps.updateSliceProgressCache(s.basePath, mid, state.activeSlice?.id);
   deps.updateProgressWidget(ctx, unitType, unitId, state);
+  deps.syncCmuxSidebar(prefs, state);
 
   deps.ensurePreconditions(unitType, unitId, s.basePath, state);
 

--- a/src/resources/extensions/gsd/tests/cmux.test.ts
+++ b/src/resources/extensions/gsd/tests/cmux.test.ts
@@ -8,6 +8,7 @@ import {
   buildCmuxStatusLabel,
   detectCmuxEnvironment,
   markCmuxPromptShown,
+  phaseVisuals,
   resetCmuxPromptState,
   resolveCmuxConfig,
   shouldPromptToEnableCmux,
@@ -190,6 +191,55 @@ describe("createGridLayout", () => {
     const surfaces = await mock.createGridLayout(0);
     assert.equal(surfaces.length, 0);
     assert.equal(mock.calls.length, 0);
+  });
+});
+
+describe("phaseVisuals", () => {
+  test("returns distinct visuals for all execution phases", () => {
+    // These were previously falling through to the default rocket icon
+    const executing = phaseVisuals("executing");
+    assert.equal(executing.icon, "zap");
+
+    const summarizing = phaseVisuals("summarizing");
+    assert.equal(summarizing.icon, "file-text");
+
+    const advancing = phaseVisuals("advancing");
+    assert.equal(advancing.icon, "arrow-right");
+
+    const discussing = phaseVisuals("discussing");
+    assert.equal(discussing.icon, "message-circle");
+
+    const needsDiscussion = phaseVisuals("needs-discussion");
+    assert.equal(needsDiscussion.icon, "message-circle");
+
+    const prePlanning = phaseVisuals("pre-planning");
+    assert.equal(prePlanning.icon, "list");
+  });
+
+  test("returns correct visuals for terminal and planning phases", () => {
+    assert.equal(phaseVisuals("blocked").icon, "triangle-alert");
+    assert.equal(phaseVisuals("paused").icon, "pause");
+    assert.equal(phaseVisuals("complete").icon, "check");
+    assert.equal(phaseVisuals("completing-milestone").icon, "check");
+    assert.equal(phaseVisuals("planning").icon, "compass");
+    assert.equal(phaseVisuals("researching").icon, "compass");
+    assert.equal(phaseVisuals("replanning-slice").icon, "compass");
+    assert.equal(phaseVisuals("validating-milestone").icon, "shield-check");
+    assert.equal(phaseVisuals("verifying").icon, "shield-check");
+  });
+
+  test("all Phase values produce a non-empty icon and color", () => {
+    const allPhases = [
+      "pre-planning", "needs-discussion", "discussing", "researching",
+      "planning", "executing", "verifying", "summarizing", "advancing",
+      "validating-milestone", "completing-milestone", "replanning-slice",
+      "complete", "paused", "blocked",
+    ] as const;
+    for (const phase of allPhases) {
+      const visuals = phaseVisuals(phase);
+      assert.ok(visuals.icon.length > 0, `icon missing for phase: ${phase}`);
+      assert.ok(visuals.color.length > 0, `color missing for phase: ${phase}`);
+    }
   });
 });
 


### PR DESCRIPTION
## TL;DR

**What:** Fix cmux sidebar not updating when units are dispatched, and add missing phase visuals.
**Why:** Sidebar status was stale — users couldn't see current execution phase.
**How:** Sync sidebar state on dispatch events and add visual indicators for all phases.

## What

- Sidebar state sync on unit dispatch events
- Missing phase visual indicators added

## Why

The cmux sidebar showed stale status during auto-mode execution. Users had no visual feedback about which phase (planning, executing, verifying) was active.

## How

Hook into dispatch events to trigger sidebar re-render with current phase state.

⚠️ **Note:** This branch includes upstream drift in the diff. The actual change is 1 commit focused on the cmux fix.

### Change type
- [x] `fix` — Bug fix

### AI-assisted contribution
This PR was developed with AI assistance (GSD/Claude).