### PR TITLE
fix(gsd): add missing SQLite WAL sidecars and journal to runtime exclusion lists

### DIFF
--- a/src/resources/extensions/gsd/git-service.ts
+++ b/src/resources/extensions/gsd/git-service.ts
@@ -196,6 +196,10 @@ export const RUNTIME_EXCLUSION_PATHS: readonly string[] = [
   ".gsd/completed-units.json",
   ".gsd/STATE.md",
   ".gsd/gsd.db",
+  ".gsd/gsd.db-shm",   // SQLite WAL sidecar — always created alongside gsd.db (#2296)
+  ".gsd/gsd.db-wal",   // SQLite WAL sidecar — always created alongside gsd.db (#2296)
+  ".gsd/journal/",     // daily-rotated JSONL event journal (#2296)
+  ".gsd/doctor-history.jsonl", // doctor run history (#2296)
   ".gsd/DISCUSSION-MANIFEST.json",
 ];
 

--- a/src/resources/extensions/gsd/gitignore.ts
+++ b/src/resources/extensions/gsd/gitignore.ts
@@ -29,6 +29,10 @@ const GSD_RUNTIME_PATTERNS = [
   ".gsd/completed-units.json",
   ".gsd/STATE.md",
   ".gsd/gsd.db",
+  ".gsd/gsd.db-shm",   // SQLite WAL sidecar — always created alongside gsd.db (#2296)
+  ".gsd/gsd.db-wal",   // SQLite WAL sidecar — always created alongside gsd.db (#2296)
+  ".gsd/journal/",     // daily-rotated JSONL event journal (#2296)
+  ".gsd/doctor-history.jsonl", // doctor run history (#2296)
   ".gsd/DISCUSSION-MANIFEST.json",
   ".gsd/milestones/**/*-CONTINUE.md",
   ".gsd/milestones/**/continue.md",

--- a/src/resources/extensions/gsd/tests/git-service.test.ts
+++ b/src/resources/extensions/gsd/tests/git-service.test.ts
@@ -251,8 +251,8 @@ async function main(): Promise<void> {
 
   assertEq(
     RUNTIME_EXCLUSION_PATHS.length,
-    9,
-    "exactly 9 runtime exclusion paths"
+    13,
+    "exactly 13 runtime exclusion paths"
   );
 
   const expectedPaths = [
@@ -264,6 +264,10 @@ async function main(): Promise<void> {
     ".gsd/completed-units.json",
     ".gsd/STATE.md",
     ".gsd/gsd.db",
+    ".gsd/gsd.db-shm",
+    ".gsd/gsd.db-wal",
+    ".gsd/journal/",
+    ".gsd/doctor-history.jsonl",
     ".gsd/DISCUSSION-MANIFEST.json",
   ];
 


### PR DESCRIPTION
## TL;DR

**What:** Add 4 missing runtime file patterns to `RUNTIME_EXCLUSION_PATHS` and `GSD_RUNTIME_PATTERNS`.
**Why:** SQLite WAL sidecars (`gsd.db-shm`, `gsd.db-wal`), the event journal (`journal/`), and doctor history (`doctor-history.jsonl`) were staged, tracked, and left out of `.gitignore` — causing squash merge failures.
**How:** Add the 4 patterns to both exclusion lists; update the existing test assertions to match.

## What

- **`git-service.ts`** — Added `.gsd/gsd.db-shm`, `.gsd/gsd.db-wal`, `.gsd/journal/`, `.gsd/doctor-history.jsonl` to `RUNTIME_EXCLUSION_PATHS`. These files are always created alongside `gsd.db` during normal operation.

- **`gitignore.ts`** — Added the same 4 patterns to `GSD_RUNTIME_PATTERNS` so `ensureGitignore()` includes them in `.gitignore`.

- **`git-service.test.ts`** — Updated the `RUNTIME_EXCLUSION_PATHS` assertion from 9 → 13 entries and added the 4 new paths to the expected array.

## Why

`gsd.db-shm`, `gsd.db-wal`, `journal/`, and `doctor-history.jsonl` are runtime files that GSD creates and modifies during every session. Because they were missing from both exclusion lists:

1. `nativeAddAllWithExclusions()` did not exclude them — they got staged and committed
2. `untrackRuntimeFiles()` did not untrack them — they stayed in the index
3. `ensureGitignore()` did not add them to `.gitignore` — they were tracked on new clones
4. During milestone merge, `reconcileWorktreeDb()` modifies `gsd.db` which updates `gsd.db-shm`/`gsd.db-wal`. These tracked-but-modified files then cause `git merge --squash` to reject with "working tree has dirty or untracked files".

Closes #2296

## How

Added all 4 patterns to both `RUNTIME_EXCLUSION_PATHS` (controls `nativeAddAllWithExclusions` and `untrackRuntimeFiles`) and `GSD_RUNTIME_PATTERNS` (controls `ensureGitignore`). This mirrors the existing `gsd.db` entry — the WAL sidecars are inseparable from the database file.

No behavioral change to the exclusion/gitignore logic itself — just filling gaps in the pattern lists.

## Change type

- [x] `fix` — Bug fix
- [x] `test` — Adding or updating tests

## Scope

- [x] `gsd extension` — GSD workflow

## Breaking changes

- [x] No breaking changes

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [x] Local full CI gate: `build` ✅, `typecheck:extensions` ✅, `test:unit` 2750/2750 ✅, `test:integration` 62/62 ✅

Updated `git-service.test.ts` — count assertion 9→13, expected array includes all 4 new entries. All 186 assertions pass.

Pre-existing failures (identical on `upstream/main`):
- `skill-lifecycle.test.ts` — `computeStaleAvoidList` (module resolution, unrelated)
- `web-mode-assembled/onboarding` — 3 auth tests (environment-dependent, unrelated)

## AI disclosure

- [x] This PR includes AI-assisted code — generated with Claude Code, all changes tested via full local CI gate
