### PR TITLE
fix: Node 22+ TypeScript stripping in node_modules & bind web mode to all interfaces

### DIFF
--- a/src/resources/extensions/gsd/tests/dist-redirect.mjs
+++ b/src/resources/extensions/gsd/tests/dist-redirect.mjs
@@ -54,6 +54,24 @@ export function resolve(specifier, context, nextResolve) {
 }
 
 export function load(url, context, nextLoad) {
+  // Node v22+ built-in type stripping handles .ts files — but explicitly refuses
+  // to strip types from .ts files under node_modules/, throwing
+  // ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING.
+  //
+  // This matters for packaged (npm) installs where src/ ships alongside dist/:
+  // the web server's bridge spawns subprocesses that import .ts source files
+  // (auto.ts, workspace-index.ts) via this loader. When those files live under
+  // node_modules/ the automatic stripping fails.
+  //
+  // Fix: call stripTypeScriptTypes() from the module API directly — it performs
+  // the same SWC-based type erasure but without the node_modules guard.
+  if (url.endsWith('.ts') && url.includes('node_modules')) {
+    const { stripTypeScriptTypes } = require('node:module');
+    const source = readFileSync(fileURLToPath(url), 'utf-8');
+    const stripped = stripTypeScriptTypes(source, { mode: 'strip', sourceUrl: url });
+    return { format: 'module', source: stripped, shortCircuit: true };
+  }
+
   // Node's --experimental-strip-types handles .ts but not .tsx (which may contain JSX).
   // Use TypeScript to transpile .tsx → JS with react-jsx transform, then serve as module.
   if (url.endsWith('.tsx')) {

--- a/src/web-mode.ts
+++ b/src/web-mode.ts
@@ -3,11 +3,12 @@ import { exec, execFile, spawn, type ChildProcess, type SpawnOptions } from 'nod
 import { existsSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs'
 import { request as httpRequest } from 'node:http'
 import { createServer } from 'node:net'
+import { networkInterfaces } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { appRoot, webPidFilePath as defaultWebPidFilePath } from './app-paths.js'
 
-const DEFAULT_HOST = '127.0.0.1'
+const DEFAULT_HOST = '0.0.0.0'
 const DEFAULT_PACKAGE_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..')
 
 /** Open a URL in the user's default browser. */
@@ -580,6 +581,27 @@ export async function launchWebMode(
   const port = options.port ?? await (deps.resolvePort ?? reserveWebPort)(host)
   const authToken = randomBytes(32).toString('hex')
   const url = `http://${host}:${port}`
+
+  // When binding to 0.0.0.0, auto-discover all network interface IPs and add
+  // them as allowed CORS origins so the middleware accepts API requests coming
+  // from LAN / Tailscale / other non-loopback addresses.
+  const autoOrigins: string[] = []
+  if (host === '0.0.0.0') {
+    try {
+      const nets = networkInterfaces()
+      for (const name of Object.keys(nets)) {
+        for (const net of (nets[name] ?? [])) {
+          if (net.family === 'IPv4' && !net.internal) {
+            autoOrigins.push(`http://${net.address}:${port}`)
+          }
+        }
+      }
+    } catch { /* os.networkInterfaces may fail in sandboxed envs */ }
+    autoOrigins.push(`http://127.0.0.1:${port}`)
+    autoOrigins.push(`http://localhost:${port}`)
+  }
+  const mergedOrigins = [...(options.allowedOrigins ?? []), ...autoOrigins]
+
   const env = {
     ...(deps.env ?? process.env),
     HOSTNAME: host,
@@ -592,7 +614,7 @@ export async function launchWebMode(
     GSD_WEB_PACKAGE_ROOT: resolution.packageRoot,
     GSD_WEB_HOST_KIND: resolution.kind,
     ...(resolution.kind === 'source-dev' ? { NEXT_PUBLIC_GSD_DEV: '1' } : {}),
-    ...(options.allowedOrigins?.length ? { GSD_WEB_ALLOWED_ORIGINS: options.allowedOrigins.join(',') } : {}),
+    ...(mergedOrigins.length ? { GSD_WEB_ALLOWED_ORIGINS: mergedOrigins.join(',') } : {}),
   }
 
   try {
@@ -687,9 +709,13 @@ export async function launchWebMode(
       // Register in multi-instance registry
       registerInstance(options.cwd, { pid, port, url }, deps.registryPath)
     }
-    const authenticatedUrl = `${url}/#token=${authToken}`
+    // When bound to 0.0.0.0, open the browser with 127.0.0.1 since
+    // 0.0.0.0 is not a routable address in browsers.
+    const browserUrl = host === '0.0.0.0'
+      ? `http://127.0.0.1:${port}/#token=${authToken}`
+      : `${url}/#token=${authToken}`
     try {
-      ;(deps.openBrowser ?? openBrowser)(authenticatedUrl)
+      ;(deps.openBrowser ?? openBrowser)(browserUrl)
     } catch (browserError) {
       stderr.write(`[gsd] Could not open browser: ${browserError instanceof Error ? browserError.message : String(browserError)}\n`)
     }
@@ -711,7 +737,8 @@ export async function launchWebMode(
     return failure
   }
 
-  const authenticatedUrl = `${url}/#token=${authToken}`
+  const localUrl = host === '0.0.0.0' ? `http://127.0.0.1:${port}` : url
+  const localAuthUrl = `${localUrl}/#token=${authToken}`
   const success: WebModeLaunchSuccess = {
     mode: 'web',
     ok: true,
@@ -724,7 +751,18 @@ export async function launchWebMode(
     hostPath: resolution.entryPath,
     hostRoot: resolution.hostRoot,
   }
-  stderr.write(`[gsd] Ready → ${authenticatedUrl}\n`)
+  stderr.write(`[gsd] Ready → ${localAuthUrl}\n`)
+  if (host === '0.0.0.0' && autoOrigins.length > 0) {
+    const networkUrls = autoOrigins
+      .filter(o => !o.includes('127.0.0.1') && !o.includes('localhost'))
+      .map(o => `${o}/#token=${authToken}`)
+    if (networkUrls.length > 0) {
+      stderr.write(`[gsd] Network access:\n`)
+      for (const nu of networkUrls) {
+        stderr.write(`[gsd]   → ${nu}\n`)
+      }
+    }
+  }
   emitLaunchStatus(stderr, success)
   return success
 }


### PR DESCRIPTION
## Problem

`gsd --web` crashes on Node v22+ with:

```
ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING: Stripping types is currently
unsupported for files under node_modules, for
"file:///…/node_modules/gsd-pi/src/resources/extensions/gsd/auto.ts"
```

Additionally, `gsd --web` binds to `127.0.0.1`, making it inaccessible from other devices on the LAN or over Tailscale.

## Root Cause

### TypeScript stripping

The web server's bridge spawns subprocesses that import `.ts` source files (`auto.ts`, `workspace-index.ts`) via the `dist-redirect.mjs` custom loader. When `gsd-pi` is installed as an npm package, these files live under `node_modules/`. Node v22+ has built-in TypeScript type stripping, but **explicitly refuses** to strip types from files under `node_modules/`, throwing `ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING`.

The `dist-redirect.mjs` loader already handles `.tsx` files manually (via the TypeScript compiler) but relies on Node's built-in stripping for `.ts` files — which breaks in packaged installs.

### Network binding

`DEFAULT_HOST` is hardcoded to `127.0.0.1`, and the CORS middleware only allows `http://{GSD_WEB_HOST}:{port}` as an origin — so even if a user passes `--host 0.0.0.0`, API requests from a LAN IP would be rejected with "Forbidden: origin mismatch".

## Fix

### 1. `dist-redirect.mjs` — handle `.ts` files under `node_modules`

Added a `load()` hook that detects `.ts` files under `node_modules/` and calls `stripTypeScriptTypes()` from the `node:module` API directly. This performs the same SWC-based type erasure as Node's built-in stripping but without the `node_modules` guard.

### 2. `web-mode.ts` — bind to `0.0.0.0` with auto-discovered CORS origins

- Changed `DEFAULT_HOST` from `127.0.0.1` to `0.0.0.0`
- When binding to `0.0.0.0`, auto-discover all IPv4 network interface addresses via `os.networkInterfaces()` and merge them into `GSD_WEB_ALLOWED_ORIGINS` (alongside any user-provided `--allowed-origins`)
- Open the browser with `http://127.0.0.1:PORT` (since `0.0.0.0` isn't routable in browsers)
- Print all discovered network URLs to stderr for easy copy-paste:

```
[gsd] Ready → http://127.0.0.1:49854/#token=abc123...
[gsd] Network access:
[gsd]   → http://192.168.0.211:49854/#token=abc123...
[gsd]   → http://100.101.152.19:49854/#token=abc123...
```

Users who want the old localhost-only behavior can pass `--host 127.0.0.1`.

## Testing

Tested locally on macOS with Node v24.14.0:

- ✅ `gsd --web` starts without TypeScript stripping errors
- ✅ Server listens on `0.0.0.0` (verified via `lsof`)
- ✅ HTTP 200 from localhost, LAN IP, and Tailscale IP
- ✅ API endpoints with Bearer token + Origin header pass CORS for all three IPs
- ✅ `--host 127.0.0.1` still works as before (opt-in to localhost-only)
