### PR TITLE
fix(git): LC_ALL=C on all git call sites

### DIFF
--- a/src/resources/extensions/gsd/auto-dashboard.ts
+++ b/src/resources/extensions/gsd/auto-dashboard.ts
@@ -18,6 +18,7 @@ import {
 import { parseRoadmap, parsePlan } from "./files.js";
 import { readFileSync, writeFileSync, existsSync } from "node:fs";
 import { execFileSync } from "node:child_process";
+import { GIT_NO_PROMPT_ENV } from "./git-constants.js";
 import { truncateToWidth, visibleWidth } from "@gsd/pi-tui";
 import { makeUI } from "../shared/tui.js";
 import { GLYPH, INDENT } from "../shared/mod.js";
@@ -305,6 +306,7 @@ function refreshLastCommit(basePath: string): void {
       encoding: "utf-8",
       stdio: ["pipe", "pipe", "pipe"],
       timeout: 3000,
+      env: GIT_NO_PROMPT_ENV,
     }).trim();
     const sep = raw.indexOf("|");
     if (sep > 0) {

--- a/src/resources/extensions/gsd/auto-worktree.ts
+++ b/src/resources/extensions/gsd/auto-worktree.ts
@@ -25,6 +25,7 @@ import {
 } from "./gsd-db.js";
 import { atomicWriteSync } from "./atomic-write.js";
 import { execFileSync } from "node:child_process";
+import { GIT_NO_PROMPT_ENV } from "./git-constants.js";
 import { safeCopy, safeCopyRecursive } from "./safe-fs.js";
 import { gsdRoot } from "./paths.js";
 import {
@@ -1055,11 +1056,13 @@ export function mergeMilestoneToMain(
         cwd: worktreeCwd,
         stdio: ["ignore", "pipe", "pipe"],
         encoding: "utf-8",
+        env: GIT_NO_PROMPT_ENV,
       }).trim();
       const branchHead = execFileSync("git", ["rev-parse", milestoneBranch], {
         cwd: originalBasePath_,
         stdio: ["ignore", "pipe", "pipe"],
         encoding: "utf-8",
+        env: GIT_NO_PROMPT_ENV,
       }).trim();
 
       if (worktreeHead && branchHead && worktreeHead !== branchHead) {
@@ -1227,6 +1230,7 @@ export function mergeMilestoneToMain(
         cwd: originalBasePath_,
         stdio: ["ignore", "pipe", "pipe"],
         encoding: "utf-8",
+        env: GIT_NO_PROMPT_ENV,
       });
       pushed = true;
     } catch {
@@ -1245,6 +1249,7 @@ export function mergeMilestoneToMain(
         cwd: originalBasePath_,
         stdio: ["ignore", "pipe", "pipe"],
         encoding: "utf-8",
+        env: GIT_NO_PROMPT_ENV,
       });
       // Create PR via gh CLI
       execFileSync("gh", [

--- a/src/resources/extensions/gsd/diff-context.ts
+++ b/src/resources/extensions/gsd/diff-context.ts
@@ -9,6 +9,7 @@
 import { execFileSync, execFile } from "node:child_process";
 import { resolve } from "node:path";
 import { GSDError, GSD_PARSE_ERROR } from "./errors.js";
+import { GIT_NO_PROMPT_ENV } from "./git-constants.js";
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -31,6 +32,7 @@ const EXEC_OPTS = {
   encoding: "utf-8" as const,
   timeout: 5000,
   stdio: ["pipe", "pipe", "pipe"] as ["pipe", "pipe", "pipe"],
+  env: GIT_NO_PROMPT_ENV,
 };
 
 /** Synchronous git — used where sequential control flow is required (fallback paths). */
@@ -44,7 +46,7 @@ function gitAsync(args: string[], cwd: string): Promise<string> {
     execFile(
       "git",
       args,
-      { encoding: "utf-8", timeout: 5000, cwd },
+      { encoding: "utf-8", timeout: 5000, cwd, env: GIT_NO_PROMPT_ENV },
       (err, stdout) => resolve(err ? "" : stdout.trim()),
     );
   });

--- a/src/resources/extensions/gsd/native-git-bridge.ts
+++ b/src/resources/extensions/gsd/native-git-bridge.ts
@@ -812,6 +812,7 @@ export function nativeCheckoutBranch(basePath: string, branch: string): void {
     cwd: basePath,
     stdio: ["ignore", "pipe", "pipe"],
     encoding: "utf-8",
+    env: GIT_NO_PROMPT_ENV,
   });
 }
 

--- a/src/resources/extensions/gsd/paths.ts
+++ b/src/resources/extensions/gsd/paths.ts
@@ -12,6 +12,7 @@
 import { readdirSync, existsSync, realpathSync, Dirent } from "node:fs";
 import { join, dirname, normalize } from "node:path";
 import { spawnSync } from "node:child_process";
+import { GIT_NO_PROMPT_ENV } from "./git-constants.js";
 import { nativeScanGsdTree, type GsdTreeEntry } from "./native-parser-bridge.js";
 import { DIR_CACHE_MAX } from "./constants.js";
 
@@ -325,6 +326,7 @@ function probeGsdRoot(rawBasePath: string): string {
     const out = spawnSync("git", ["rev-parse", "--show-toplevel"], {
       cwd: basePath,
       encoding: "utf-8",
+      env: GIT_NO_PROMPT_ENV,
     });
     if (out.status === 0) {
       const r = out.stdout.trim();

--- a/src/resources/extensions/gsd/repo-identity.ts
+++ b/src/resources/extensions/gsd/repo-identity.ts
@@ -8,6 +8,7 @@
 
 import { createHash } from "node:crypto";
 import { execFileSync } from "node:child_process";
+import { GIT_NO_PROMPT_ENV } from "./git-constants.js";
 import { existsSync, lstatSync, mkdirSync, readdirSync, readFileSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { basename, dirname, join, resolve } from "node:path";
@@ -152,6 +153,7 @@ function getRemoteUrl(basePath: string): string {
       encoding: "utf-8",
       stdio: ["ignore", "pipe", "ignore"],
       timeout: 5_000,
+      env: GIT_NO_PROMPT_ENV,
     }).trim();
   } catch {
     return "";
@@ -178,6 +180,7 @@ function resolveGitCommonDir(basePath: string): string {
       encoding: "utf-8",
       stdio: ["ignore", "pipe", "ignore"],
       timeout: 5_000,
+      env: GIT_NO_PROMPT_ENV,
     }).trim();
   } catch {
     const raw = execFileSync("git", ["rev-parse", "--git-common-dir"], {
@@ -185,6 +188,7 @@ function resolveGitCommonDir(basePath: string): string {
       encoding: "utf-8",
       stdio: ["ignore", "pipe", "ignore"],
       timeout: 5_000,
+      env: GIT_NO_PROMPT_ENV,
     }).trim();
     return resolve(basePath, raw);
   }
@@ -212,6 +216,7 @@ function resolveGitRoot(basePath: string): string {
       encoding: "utf-8",
       stdio: ["ignore", "pipe", "ignore"],
       timeout: 5_000,
+      env: GIT_NO_PROMPT_ENV,
     }).trim());
   } catch {
     return resolve(basePath);

--- a/src/resources/extensions/gsd/tests/git-locale.test.ts
+++ b/src/resources/extensions/gsd/tests/git-locale.test.ts
@@ -124,6 +124,112 @@ async function main(): Promise<void> {
     );
   }
 
+  // ─── ALL production git call sites must use GIT_NO_PROMPT_ENV (#2294) ──
+
+  console.log("\n=== ALL production git call sites use GIT_NO_PROMPT_ENV (#2294) ===");
+
+  {
+    // Static analysis: every production source file that calls
+    // execFileSync("git" / execFile("git" / spawnSync("git" must either:
+    //   a) pass env: GIT_NO_PROMPT_ENV in the options, OR
+    //   b) spread EXEC_OPTS which itself includes env: GIT_NO_PROMPT_ENV
+    //
+    // This prevents regressions where new git call sites forget LC_ALL=C,
+    // causing stderr checks to fail on non-English locales.
+
+    const { readdirSync } = await import("node:fs");
+    const { resolve: resolvePath } = await import("node:path");
+
+    const srcDir = resolvePath(import.meta.dirname, "..");
+    const sourceFiles = [
+      "native-git-bridge.ts",
+      "git-service.ts",
+      "diff-context.ts",
+      "auto-dashboard.ts",
+      "auto-worktree.ts",
+      "verification-gate.ts",
+      "paths.ts",
+      "repo-identity.ts",
+      "gitignore.ts",
+      "migrate-external.ts",
+    ];
+
+    const gitCallPattern = /(?:execFileSync|execFile|spawnSync)\(\s*"git"/g;
+
+    for (const file of sourceFiles) {
+      const filePath = join(srcDir, file);
+      let content: string;
+      try {
+        content = readFileSync(filePath, "utf-8");
+      } catch {
+        continue; // File may not exist in all configurations
+      }
+
+      const lines = content.split("\n");
+
+      // For each git call, verify the options object includes GIT_NO_PROMPT_ENV or LC_ALL
+      for (let i = 0; i < lines.length; i++) {
+        const line = lines[i];
+        if (!gitCallPattern.test(line)) {
+          gitCallPattern.lastIndex = 0;
+          continue;
+        }
+        gitCallPattern.lastIndex = 0;
+
+        // Grab surrounding context (the options object may span multiple lines)
+        const context = lines.slice(i, Math.min(i + 8, lines.length)).join("\n");
+
+        const hasLocaleEnv =
+          context.includes("GIT_NO_PROMPT_ENV") ||
+          context.includes("LC_ALL") ||
+          context.includes("...EXEC_OPTS");
+
+        assertTrue(
+          hasLocaleEnv,
+          `${file}:${i + 1} — git call must use GIT_NO_PROMPT_ENV (or LC_ALL) to ensure English output (#2294)`
+        );
+      }
+    }
+  }
+
+  // ─── nativeCheckoutBranch fallback uses GIT_NO_PROMPT_ENV (#2294) ──
+
+  console.log("\n=== nativeCheckoutBranch fallback uses GIT_NO_PROMPT_ENV (#2294) ===");
+
+  {
+    const src = readFileSync(
+      join(import.meta.dirname, "..", "native-git-bridge.ts"),
+      "utf-8"
+    );
+    const fnStart = src.indexOf("export function nativeCheckoutBranch");
+    assertTrue(fnStart !== -1, "nativeCheckoutBranch function exists in source");
+
+    const nextFnStart = src.indexOf("\nexport function", fnStart + 1);
+    const fnBody = src.slice(fnStart, nextFnStart !== -1 ? nextFnStart : undefined);
+    const hasEnv = fnBody.includes("env: GIT_NO_PROMPT_ENV");
+    assertTrue(
+      hasEnv,
+      "nativeCheckoutBranch fallback must pass env: GIT_NO_PROMPT_ENV (#2294)"
+    );
+  }
+
+  // ─── diff-context.ts uses GIT_NO_PROMPT_ENV (#2294) ───────────────────
+
+  console.log("\n=== diff-context.ts uses GIT_NO_PROMPT_ENV (#2294) ===");
+
+  {
+    const src = readFileSync(
+      join(import.meta.dirname, "..", "diff-context.ts"),
+      "utf-8"
+    );
+
+    // EXEC_OPTS must include env: GIT_NO_PROMPT_ENV
+    assertTrue(
+      src.includes("GIT_NO_PROMPT_ENV"),
+      "diff-context.ts must reference GIT_NO_PROMPT_ENV for locale-safe git calls (#2294)"
+    );
+  }
+
   report();
 }
 

--- a/src/resources/extensions/gsd/verification-gate.ts
+++ b/src/resources/extensions/gsd/verification-gate.ts
@@ -4,6 +4,7 @@
 // First non-empty source wins.
 
 import { spawnSync, type SpawnSyncReturns } from "node:child_process";
+import { GIT_NO_PROMPT_ENV } from "./git-constants.js";
 import { existsSync, readFileSync } from "node:fs";
 import { join, basename } from "node:path";
 import type { AuditWarning, RuntimeError, VerificationCheck, VerificationResult } from "./types.js";
@@ -518,6 +519,7 @@ function defaultGitDiff(cwd: string): string[] {
       cwd,
       encoding: "utf-8",
       timeout: 10_000,
+      env: GIT_NO_PROMPT_ENV,
     });
     if (result.status !== 0 || !result.stdout) return [];
     return result.stdout.trim().split("\n").filter(Boolean);


### PR DESCRIPTION
## Summary

- Adds `env: GIT_NO_PROMPT_ENV` (which includes `LC_ALL: "C"`) to **all** remaining git `execFileSync`/`execFile`/`spawnSync` call sites that PR #2035 missed
- Fixes auto-commit failures on non-English locales when pathspec exclusions hit ignored `.gsd` runtime files — stderr string checks like `"ignored by one of your .gitignore files"` now always match English output
- Extends `git-locale.test.ts` with a static analysis guard that scans all production source files for git exec calls missing `GIT_NO_PROMPT_ENV`, preventing future regressions

## Affected files

| File | Call sites fixed |
|------|-----------------|
| `native-git-bridge.ts` | `nativeCheckoutBranch` fallback |
| `diff-context.ts` | `gitSync`, `gitAsync`, `EXEC_OPTS` |
| `auto-dashboard.ts` | `refreshLastCommit` |
| `auto-worktree.ts` | `rev-parse HEAD`, `rev-parse <branch>`, 2x `git push` |
| `verification-gate.ts` | `defaultGitDiff` |
| `paths.ts` | `rev-parse --show-toplevel` |
| `repo-identity.ts` | `config --get`, `rev-parse --git-common-dir` (2x), `rev-parse --show-toplevel` |

## Test plan

- [x] Reproduction test written first — 14 failures confirmed before fix
- [x] All 32 assertions in `git-locale.test.ts` pass after fix
- [x] Full unit suite passes (2751/2751, 1 pre-existing unrelated failure in `derive-state-db.test.ts`)
- [x] Build succeeds

Fixes #2294

🤖 Generated with [Claude Code](https://claude.com/claude-code)