### PR TITLE
fix(test): increase perf assertion threshold to prevent CI flake

### DIFF
--- a/src/resources/extensions/gsd/tests/derive-state-db.test.ts
+++ b/src/resources/extensions/gsd/tests/derive-state-db.test.ts
@@ -779,7 +779,9 @@ async function main(): Promise<void> {
       const elapsed = performance.now() - start;
 
       console.log(`  deriveStateFromDb() took ${elapsed.toFixed(3)}ms`);
-      assertTrue(elapsed < 1, `perf-db: deriveStateFromDb() <1ms (got ${elapsed.toFixed(3)}ms)`);
+      // Use 10ms threshold — catches real regressions without flaking on
+      // CI runners under load (1ms threshold failed at 1.050ms on GitHub Actions)
+      assertTrue(elapsed < 10, `perf-db: deriveStateFromDb() <10ms (got ${elapsed.toFixed(3)}ms)`);
 
       closeDatabase();
     } finally {


### PR DESCRIPTION
## Summary
- `deriveStateFromDb() <1ms` perf assertion failed at 1.050ms on GitHub Actions runners under load
- Increased threshold from 1ms to 10ms — still catches 10x regressions without CI jitter flakes
- This single test was causing build failures across all 9 open PRs

## Test plan
- [x] The assertion itself is the test — verifies `deriveStateFromDb` completes in <10ms
- [x] No behavioral change — only the threshold moves

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>