### PR TITLE
feat(gsd): workflow-logger — structured error/warning accumulation (standalone)

### DIFF
--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -24,6 +24,7 @@ import {
 import { detectStuck } from "./detect-stuck.js";
 import { runUnit } from "./run-unit.js";
 import { debugLog } from "../debug-logger.js";
+import { drainLogs, summarizeLogs, formatForNotification } from "../workflow-logger.js";
 import { gsdRoot } from "../paths.js";
 import { atomicWriteSync } from "../atomic-write.js";
 import { PROJECT_FILES } from "../detection.js";
@@ -564,19 +565,26 @@ export async function runDispatch(
         deps.invalidateAllCaches();
       } else {
         // Level 2: hard stop — genuinely stuck
+        // Drain logger for root cause context
+        const logSummary = summarizeLogs();
+        const stuckReason = logSummary
+          ? `${stuckSignal.reason}. Root cause: ${logSummary}`
+          : stuckSignal.reason;
+        drainLogs(); // clear buffer
+
         debugLog("autoLoop", {
           phase: "stuck-detected",
           unitType,
           unitId,
-          reason: stuckSignal.reason,
+          reason: stuckReason,
         });
         await deps.stopAuto(
           ctx,
           pi,
-          `Stuck: ${stuckSignal.reason}`,
+          `Stuck: ${stuckReason}`,
         );
         ctx.ui.notify(
-          `Stuck on ${unitType} ${unitId} — ${stuckSignal.reason}. The expected artifact was not written.`,
+          `Stuck on ${unitType} ${unitId} — ${stuckReason}`,
           "error",
         );
         return { action: "break", reason: "stuck-detected" };
@@ -1071,6 +1079,23 @@ export async function runUnitPhase(
         lastEntry.error = msgStr.slice(0, 200);
       }
     }
+  }
+
+  // ── Workflow logger drain ──────────────────────────────────────────
+  // Surface any warnings/errors accumulated during this unit (blocked
+  // writes, tool failures, loop guard triggers, etc.)
+  const logEntries = drainLogs();
+  if (logEntries.length > 0) {
+    const hasLogErrors = logEntries.some(e => e.severity === "error");
+    const lastEntry = loopState.recentUnits[loopState.recentUnits.length - 1];
+    if (lastEntry && !lastEntry.error && hasLogErrors) {
+      // Tag the window entry so stuck detection catches it via Rule 1
+      lastEntry.error = formatForNotification(logEntries.filter(e => e.severity === "error")).slice(0, 200);
+    }
+    ctx.ui.notify(
+      `Engine: ${formatForNotification(logEntries)}`,
+      hasLogErrors ? "error" : "warning",
+    );
   }
 
   if (unitResult.status === "cancelled") {

--- a/src/resources/extensions/gsd/bootstrap/register-hooks.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-hooks.ts
@@ -15,6 +15,7 @@ import { getAutoDashboardData, isAutoActive, isAutoPaused, markToolEnd, markTool
 import { isParallelActive, shutdownParallel } from "../parallel-orchestrator.js";
 import { checkToolCallLoop, resetToolCallLoopGuard } from "./tool-call-loop-guard.js";
 import { saveActivityLog } from "../activity-log.js";
+import { logWarning } from "../workflow-logger.js";
 
 // Skip the welcome screen on the very first session_start — cli.ts already
 // printed it before the TUI launched. Only re-print on /clear (subsequent sessions).
@@ -125,6 +126,7 @@ export function registerHooks(pi: ExtensionAPI): void {
     // ── Loop guard: block repeated identical tool calls ──
     const loopCheck = checkToolCallLoop(event.toolName, event.input as Record<string, unknown>);
     if (loopCheck.block) {
+      logWarning("intercept", `tool-call loop guard blocked ${event.toolName}`, { tool: event.toolName });
       return { block: true, reason: loopCheck.reason };
     }
 

--- a/src/resources/extensions/gsd/docs/workflow-logger-limitations.md
+++ b/src/resources/extensions/gsd/docs/workflow-logger-limitations.md
@@ -1,0 +1,75 @@
+# workflow-logger — Standalone PR Limitations
+
+This document describes what the standalone workflow-logger PR covers and what
+requires the single-writer PRs (01–04) to be merged before it becomes available.
+
+## What this PR delivers (standalone, no dependencies)
+
+| Integration point | File | Benefit |
+|---|---|---|
+| Core logger module | `workflow-logger.ts` | Structured accumulator with severity, component, message, context. Buffers up to 100 entries. Forwards to stderr. |
+| Stuck detection enrichment | `auto/phases.ts` | Hard-stop message includes accumulated root causes: `Stuck: artifact not written. Root cause: 2 error(s): tool-call loop guard blocked Write` |
+| Post-unit log drain | `auto/phases.ts` | After each unit completes, any warnings/errors surface as a UI notification instead of silently going to stderr |
+| Tool-call loop guard logging | `bootstrap/register-hooks.ts` | When `checkToolCallLoop` blocks a repeated tool call, the tool name is now logged and buffered |
+
+## What requires single-writer PRs 01–04
+
+The following call sites exist in the stacked PR (`single-writer/05-workflow-logger`)
+but **cannot be applied to upstream/main** because the files they modify were
+introduced or substantially rewritten in PRs 01–04.
+
+### `bootstrap/workflow-tools.ts` — tool handler errors
+**Requires:** PR 02 (write-side state transitions) introduces this file.
+**Missing:** 7 tool handler `catch` blocks that replace `process.stderr.write` with
+`logError("tool", ...)` for `gsd_complete_task`, `gsd_complete_slice`,
+`gsd_plan_slice`, `gsd_start_task`, `gsd_record_verification`,
+`gsd_report_blocker`, `gsd_engine_save_decision`.
+**Impact:** Tool handler failures still go to stderr only. Not buffered. Not
+surfaced in stuck messages.
+
+### `bootstrap/register-hooks.ts` — blocked state file writes
+**Requires:** PR 01 (engine foundation) introduces `write-intercept.ts` with
+`isBlockedStateFile` / `BLOCKED_WRITE_ERROR`.
+**Missing:** `logError("intercept", ...)` for blocked Write and Edit tool calls
+to authoritative `.gsd/` state files.
+**Impact:** When the agent tries to directly edit `.gsd/STATE.md` or similar
+protected files, the block is enforced but not logged. The stuck message will
+not mention "blocked write to .gsd/STATE.md" as a root cause.
+
+### `workflow-engine.ts` — afterCommand side effects
+**Requires:** PRs 01–03 replace the `workflow-engine.ts` interface with a
+concrete `WorkflowEngine` class that wraps SQLite and calls `renderAllProjections`,
+`writeManifest`, and `appendEvent` after every command.
+**Missing:** `logWarning("projection", ...)`, `logWarning("manifest", ...)`,
+`logWarning("event-log", ...)` in the `afterCommand` method; `logWarning` for
+replay unknown cmd and replay skip errors.
+**Impact:** Projection render failures, manifest write failures, and event append
+failures are not buffered. These are among the most useful root causes when the
+auto-loop gets stuck after a command succeeds structurally but side effects fail.
+
+### `state.ts` — migration and engine fallback
+**Requires:** PRs 01–04 add `validateMigration`, `auto-migration`, and the
+`deriveState → engine → markdown fallback` chain in `state.ts`.
+**Missing:** `logWarning("migration", ...)` for post-migration discrepancies;
+`logError("migration", ...)` for failed auto-migration; `logWarning("state", ...)`
+for engine-unavailable fallback to markdown parsing.
+**Impact:** Migration and engine-initialization failures are invisible until
+they cascade into a stuck loop.
+
+## Summary table
+
+| Component | Standalone PR | With PRs 01–04 |
+|---|---|---|
+| Logger module + tests | ✅ | ✅ |
+| Stuck message enrichment | ✅ | ✅ |
+| Post-unit drain + notify | ✅ | ✅ |
+| Loop guard logging | ✅ | ✅ |
+| Tool handler error logging | ❌ | ✅ |
+| Blocked state-file write logging | ❌ | ✅ |
+| Projection / manifest / event-log failures | ❌ | ✅ |
+| Migration discrepancy logging | ❌ | ✅ |
+| Engine fallback logging | ❌ | ✅ |
+
+The standalone PR captures ~40% of the total logging surface — the parts the
+auto-loop itself can see. The remaining 60% requires the single-writer
+infrastructure that owns the write path.

--- a/src/resources/extensions/gsd/tests/workflow-logger.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-logger.test.ts
@@ -1,0 +1,144 @@
+// GSD Extension — Workflow Logger Tests
+// Tests for the centralized warning/error accumulator.
+
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import {
+  logWarning,
+  logError,
+  drainLogs,
+  peekLogs,
+  hasErrors,
+  hasWarnings,
+  summarizeLogs,
+  formatForNotification,
+  _resetLogs,
+} from "../workflow-logger.ts";
+
+describe("workflow-logger", () => {
+  beforeEach(() => {
+    _resetLogs();
+  });
+
+  describe("accumulation", () => {
+    it("logWarning adds an entry with severity warn", () => {
+      logWarning("engine", "test warning");
+      const entries = peekLogs();
+      assert.equal(entries.length, 1);
+      assert.equal(entries[0].severity, "warn");
+      assert.equal(entries[0].component, "engine");
+      assert.equal(entries[0].message, "test warning");
+      assert.ok(entries[0].ts);
+    });
+
+    it("logError adds an entry with severity error", () => {
+      logError("intercept", "blocked write", { path: "/foo/STATE.md" });
+      const entries = peekLogs();
+      assert.equal(entries.length, 1);
+      assert.equal(entries[0].severity, "error");
+      assert.equal(entries[0].component, "intercept");
+      assert.deepEqual(entries[0].context, { path: "/foo/STATE.md" });
+    });
+
+    it("accumulates multiple entries in order", () => {
+      logWarning("projection", "render failed");
+      logError("intercept", "blocked write");
+      logWarning("manifest", "write failed");
+      assert.equal(peekLogs().length, 3);
+      assert.equal(peekLogs()[0].component, "projection");
+      assert.equal(peekLogs()[1].component, "intercept");
+      assert.equal(peekLogs()[2].component, "manifest");
+    });
+  });
+
+  describe("drain", () => {
+    it("returns all entries and clears buffer", () => {
+      logWarning("engine", "w1");
+      logError("engine", "e1");
+      const drained = drainLogs();
+      assert.equal(drained.length, 2);
+      assert.equal(peekLogs().length, 0);
+    });
+
+    it("returns empty array when no entries", () => {
+      assert.deepEqual(drainLogs(), []);
+    });
+  });
+
+  describe("hasErrors / hasWarnings", () => {
+    it("hasErrors returns false when only warnings", () => {
+      logWarning("engine", "just a warning");
+      assert.equal(hasErrors(), false);
+      assert.equal(hasWarnings(), true);
+    });
+
+    it("hasErrors returns true when errors present", () => {
+      logWarning("engine", "warning");
+      logError("intercept", "error");
+      assert.equal(hasErrors(), true);
+    });
+
+    it("hasWarnings returns false when buffer empty", () => {
+      assert.equal(hasWarnings(), false);
+    });
+  });
+
+  describe("summarizeLogs", () => {
+    it("returns null when empty", () => {
+      assert.equal(summarizeLogs(), null);
+    });
+
+    it("summarizes errors and warnings separately", () => {
+      logError("intercept", "blocked STATE.md");
+      logWarning("projection", "render failed");
+      logWarning("manifest", "write failed");
+      const summary = summarizeLogs()!;
+      assert.ok(summary.includes("1 error(s)"));
+      assert.ok(summary.includes("blocked STATE.md"));
+      assert.ok(summary.includes("2 warning(s)"));
+    });
+
+    it("only shows errors section when no warnings", () => {
+      logError("intercept", "blocked");
+      const summary = summarizeLogs()!;
+      assert.ok(summary.includes("1 error(s)"));
+      assert.ok(!summary.includes("warning"));
+    });
+  });
+
+  describe("formatForNotification", () => {
+    it("returns empty string for empty array", () => {
+      assert.equal(formatForNotification([]), "");
+    });
+
+    it("formats single entry without line breaks", () => {
+      logError("intercept", "blocked write");
+      const entries = drainLogs();
+      const formatted = formatForNotification(entries);
+      assert.equal(formatted, "[intercept] blocked write");
+    });
+
+    it("formats multiple entries with line breaks", () => {
+      logWarning("projection", "render failed");
+      logError("intercept", "blocked write");
+      const entries = drainLogs();
+      const formatted = formatForNotification(entries);
+      assert.ok(formatted.includes("[projection] render failed"));
+      assert.ok(formatted.includes("[intercept] blocked write"));
+      assert.ok(formatted.includes("\n"));
+    });
+  });
+
+  describe("buffer limit", () => {
+    it("caps at 100 entries, dropping oldest", () => {
+      for (let i = 0; i < 110; i++) {
+        logWarning("engine", `msg-${i}`);
+      }
+      const entries = peekLogs();
+      assert.equal(entries.length, 100);
+      // Oldest should be msg-10 (first 10 dropped)
+      assert.equal(entries[0].message, "msg-10");
+      assert.equal(entries[99].message, "msg-109");
+    });
+  });
+});

--- a/src/resources/extensions/gsd/workflow-logger.ts
+++ b/src/resources/extensions/gsd/workflow-logger.ts
@@ -1,0 +1,151 @@
+// GSD Extension — Workflow Logger
+// Centralized warning/error accumulator for the workflow engine pipeline.
+// Captures structured entries that the auto-loop can drain after each unit
+// to surface root causes for stuck loops, silent degradation, and blocked writes.
+
+// ─── Types ──────────────────────────────────────────────────────────────
+
+export type LogSeverity = "warn" | "error";
+
+export type LogComponent =
+  | "engine"        // WorkflowEngine afterCommand side effects
+  | "projection"    // Projection rendering
+  | "manifest"      // Manifest write
+  | "event-log"     // Event append
+  | "intercept"     // Write intercept / tool-call blocks
+  | "migration"     // Auto-migration from markdown
+  | "state"         // deriveState fallback/degradation
+  | "tool"          // Tool handler errors
+  | "compaction"    // Event compaction
+  | "reconcile";    // Worktree reconciliation
+
+export interface LogEntry {
+  ts: string;
+  severity: LogSeverity;
+  component: LogComponent;
+  message: string;
+  /** Optional structured context (file path, command name, etc.) */
+  context?: Record<string, string>;
+}
+
+// ─── Buffer ─────────────────────────────────────────────────────────────
+
+const MAX_BUFFER = 100;
+let _buffer: LogEntry[] = [];
+
+// ─── Public API ─────────────────────────────────────────────────────────
+
+/**
+ * Record a warning or error. Also writes to stderr for terminal visibility.
+ */
+export function logWarning(
+  component: LogComponent,
+  message: string,
+  context?: Record<string, string>,
+): void {
+  _push("warn", component, message, context);
+}
+
+export function logError(
+  component: LogComponent,
+  message: string,
+  context?: Record<string, string>,
+): void {
+  _push("error", component, message, context);
+}
+
+/**
+ * Drain all accumulated entries and clear the buffer.
+ * Returns entries oldest-first.
+ */
+export function drainLogs(): LogEntry[] {
+  const entries = _buffer;
+  _buffer = [];
+  return entries;
+}
+
+/**
+ * Peek at current entries without clearing.
+ */
+export function peekLogs(): readonly LogEntry[] {
+  return _buffer;
+}
+
+/**
+ * Check if there are any entries at a given severity or higher.
+ */
+export function hasErrors(): boolean {
+  return _buffer.some((e) => e.severity === "error");
+}
+
+export function hasWarnings(): boolean {
+  return _buffer.length > 0;
+}
+
+/**
+ * Get a one-line summary of accumulated issues for stuck detection messages.
+ * Returns null if no entries.
+ */
+export function summarizeLogs(): string | null {
+  if (_buffer.length === 0) return null;
+  const errors = _buffer.filter((e) => e.severity === "error");
+  const warns = _buffer.filter((e) => e.severity === "warn");
+
+  const parts: string[] = [];
+  if (errors.length > 0) {
+    parts.push(`${errors.length} error(s): ${errors.map((e) => e.message).join("; ")}`);
+  }
+  if (warns.length > 0) {
+    parts.push(`${warns.length} warning(s): ${warns.map((e) => e.message).join("; ")}`);
+  }
+  return parts.join(" | ");
+}
+
+/**
+ * Format entries for stderr output (used by auto-loop post-unit notification).
+ */
+export function formatForNotification(entries: readonly LogEntry[]): string {
+  if (entries.length === 0) return "";
+  if (entries.length === 1) {
+    const e = entries[0];
+    return `[${e.component}] ${e.message}`;
+  }
+  return entries
+    .map((e) => `[${e.component}] ${e.message}`)
+    .join("\n");
+}
+
+/**
+ * Reset buffer (testing only).
+ */
+export function _resetLogs(): void {
+  _buffer = [];
+}
+
+// ─── Internal ───────────────────────────────────────────────────────────
+
+function _push(
+  severity: LogSeverity,
+  component: LogComponent,
+  message: string,
+  context?: Record<string, string>,
+): void {
+  const entry: LogEntry = {
+    ts: new Date().toISOString(),
+    severity,
+    component,
+    message,
+    ...(context ? { context } : {}),
+  };
+
+  // Always forward to stderr so terminal watchers see it
+  const prefix = severity === "error" ? "ERROR" : "WARN";
+  const ctxStr = context ? ` ${JSON.stringify(context)}` : "";
+  process.stderr.write(`[gsd:${component}] ${prefix}: ${message}${ctxStr}\n`);
+
+  // Buffer for auto-loop to drain
+  _buffer.push(entry);
+  if (_buffer.length > MAX_BUFFER) {
+    _buffer.shift();
+  }
+}


### PR DESCRIPTION
## Summary

Adds a centralized `workflow-logger` module to the auto-loop pipeline. This is a **standalone version** that applies directly to `main` with no dependencies on the single-writer PR stack.

- **`workflow-logger.ts`** — structured accumulator (severity, component, message, context). Buffers up to 100 entries, forwards to stderr.
- **`auto/phases.ts`** — stuck-stop messages now include accumulated root causes. Post-unit drain surfaces engine warnings as UI notifications.
- **`bootstrap/register-hooks.ts`** — tool-call loop guard blocks are now logged and buffered.
- **15 tests** — full coverage of accumulation, drain, summarize, format, buffer cap.

## Relationship to the single-writer stack

This PR is a subset of #2292 (`single-writer/05-workflow-logger`), extracted to land independently while the single-writer PRs are under review.

**What this PR covers vs the stacked version:**

| Integration point | This PR | With single-writer 01–04 (#2292) |
|---|---|---|
| Logger module + 15 tests | ✅ | ✅ |
| Stuck message root-cause enrichment | ✅ | ✅ |
| Post-unit drain + UI notify | ✅ | ✅ |
| Tool-call loop guard logging | ✅ | ✅ |
| Tool handler error logging (7 tools) | ❌ | ✅ |
| Blocked state-file write logging | ❌ | ✅ |
| Projection / manifest / event-log failures | ❌ | ✅ |
| Migration + engine fallback logging | ❌ | ✅ |

The missing ~60% of logging surface requires infrastructure (`write-intercept.ts`, the `WorkflowEngine` class, migration tooling) that lives in the single-writer stack. Full details in `docs/workflow-logger-limitations.md`.

If the single-writer PRs land first, this PR should be closed in favour of #2292.

## Test plan

- [ ] `npm run test:unit` — 15/15 workflow-logger tests pass, no regressions
- [ ] `npm run build` — clean build
- [ ] Manual: trigger a stuck loop, verify the stuck message includes `Root cause: ...`
- [ ] Manual: trigger tool-call loop guard, verify warning appears in UI notification

🤖 Generated with [Claude Code](https://claude.com/claude-code)