### PR TITLE
feat(gsd): harden discussion phase with incremental alignment and output discipline

### DIFF
--- a/src/resources/extensions/gsd/prompts/discuss.md
+++ b/src/resources/extensions/gsd/prompts/discuss.md
@@ -15,6 +15,17 @@ After the user describes their idea, **do not ask questions yet**. First, prove 
 
 This prevents runaway questioning by forcing comprehension proof before anything else. Do not skip this step. Do not combine it with the first question round.
 
+## Dense Input Abstraction
+
+When the user provides substantial input (long voice transcripts, multi-paragraph descriptions, stream-of-consciousness thoughts), every sub-thought may carry its own requirement. Do not summarize loosely — systematically extract:
+
+1. **Parse each distinct point** — number them. A five-minute thought may contain 8+ discrete ideas, constraints, or requirements. Between-the-lines nuance counts as a point.
+2. **Present via `ask_user_questions`** — show the extracted points as a numbered list and ask: "I found N points in your input. Missing anything?" Use the question format, not a text wall.
+3. **Preserve exact terminology** — if the user said "craft feel", write "craft feel". If they said "enforced alignment", write "enforced alignment". Their precision is signal.
+4. **Flag ambiguity explicitly** — if a sub-thought is unclear, don't silently interpret it. Mark it: "Point 4 — I'm not sure if you mean X or Y. Which one?"
+
+This step replaces the tendency to produce a large summary paragraph. The numbered-points-via-AskUserQuestion pattern lets the user scan and confirm quickly instead of reading prose.
+
 ## Vision Mapping
 
 After reflection is confirmed, decide the approach based on the actual scope — not a label:
@@ -46,6 +57,27 @@ Before asking your first question, do a mandatory investigation pass. This is no
 This happens ONCE, before the first round. The goal: your first questions should reflect what's actually true, not what you assume.
 
 For subsequent rounds, continue investigating between rounds — check docs, search, or scout as needed to make each round's questions smarter. But the first-round investigation is mandatory and explicit. Distribute searches across turns rather than clustering them in one turn.
+
+## Output Discipline
+
+The user reads your output in a terminal. Large text blocks get skimmed and nuance is lost — the opposite of what this phase needs. Follow this pattern:
+
+**Show → Confirm → Next.** Every substantial output should end with an `ask_user_questions` confirmation, not a text dump the user has to parse and mentally evaluate. If you have 3 things to confirm, use 3 questions in one `ask_user_questions` call — not a paragraph with 3 embedded points.
+
+- Prefer `ask_user_questions` with focused questions over prose paragraphs
+- When you must output text (reflection, research findings), keep it under 10 lines, then confirm via `ask_user_questions`
+- Multiple `ask_user_questions` fields in one call are better than one long text block — the user can address each point independently
+- Never produce a text wall and then ask "what do you think?" — that forces the user to do the structuring work
+
+## Incremental Alignment
+
+After each questioning round, consolidate understanding via `ask_user_questions` before proceeding to the next round:
+
+1. State what you now understand in 2-3 short sentences (in the question header, not as separate text)
+2. Ask: "Is this accurate, or should I adjust?" with options like "Accurate — continue", "Not quite — let me clarify"
+3. Only proceed to the next round after confirmation
+
+This prevents drift where 3 rounds of questions produce progressively divergent understanding without the user noticing until the roadmap comes out wrong.
 
 ## Questioning Philosophy
 
@@ -81,7 +113,7 @@ You are a thinking partner, not an interviewer.
 
 ## Depth Enforcement
 
-Do NOT offer to proceed until ALL of the following are satisfied. Track these internally as a background checklist:
+Do NOT offer to proceed until ALL of the following are satisfied. **Surface these explicitly** — the user must see which items are resolved and which remain open:
 
 - [ ] **What they're building** — concrete enough that you could explain it to a stranger
 - [ ] **Why it needs to exist** — the problem it solves or the desire it fulfills
@@ -89,6 +121,8 @@ Do NOT offer to proceed until ALL of the following are satisfied. Track these in
 - [ ] **What "done" looks like** — observable outcomes, not abstract goals
 - [ ] **The biggest technical unknowns / risks** — what could fail, what hasn't been proven
 - [ ] **What external systems/services this touches** — APIs, databases, third-party services, hardware
+
+**Explicit gap surfacing:** At the end of each questioning round, state which checklist items are satisfied and which remain open. Use `ask_user_questions` to present gaps: "I still need clarity on: [gaps]. Want to address these now, or should I investigate first?" Do not track gaps silently — if you don't understand something, say so immediately rather than hoping a later round will resolve it.
 
 Before offering to proceed, demonstrate absorption: reference specific things the user emphasized, specific terminology they used, specific nuance they sharpened — and show how those shaped your understanding. Synthesize, don't recite. "Your emphasis on X led me to prioritize Y over Z" is good. "You said X, you said Y, you said Z" is not. The user should feel heard in the specifics, not just acknowledged in the abstract.
 
@@ -122,16 +156,28 @@ If you need a final scope reflection, fold it into the depth summary or roadmap 
 
 ## Focused Research
 
-For a new project or any project that does not yet have `.gsd/REQUIREMENTS.md`, do a focused research pass before roadmap creation.
+For a new project or any project that does not yet have `.gsd/REQUIREMENTS.md`, a focused research pass before roadmap creation is **mandatory, not optional**.
 
-Research is advisory, not auto-binding. Use the discussion output to identify:
+### Research Decision Gate
+
+Before starting research, use `ask_user_questions` to establish research scope:
+1. Present what you plan to research and why (2-3 sentences in the header)
+2. Ask: "Should I do a deep research pass on these areas?" with options: "Yes — research thoroughly", "Light research only", "Skip — I know the domain well enough"
+
+If the user chooses deep research: execute the full research pass, present findings via `ask_user_questions` (not a text wall), and confirm which findings should become requirements.
+
+If the user chooses light: do a quick scan (1-2 web searches, library doc checks) and present key findings briefly.
+
+### Research Scope
+
+Use the discussion output to identify:
 - table stakes the product space usually expects
 - domain-standard behaviors the user may or may not want
 - likely omissions that would make the product feel incomplete
 - plausible anti-features or scope traps
 - differentiators worth preserving
 
-If the research suggests requirements the user did not explicitly ask for, present them as candidate requirements to confirm, defer, or reject. Do not silently turn research into scope.
+Present research findings as candidate requirements via `ask_user_questions` — each finding as a separate question the user can confirm, defer, or reject. Do not silently turn research into scope, and do not dump findings as a long paragraph.
 
 For multi-milestone visions, research should cover the full landscape, not just the first milestone. Research findings may affect milestone sequencing, not just slice ordering within M001.
 


### PR DESCRIPTION
## Problem

The discussion phase produces large text blocks that users skim rather than deeply engage with. Depth gaps are tracked internally without surfacing them, making it invisible when understanding is incomplete. Research before roadmap creation is advisory rather than enforced, leading to shallow planning. Dense user input (long voice transcripts, multi-paragraph descriptions) gets loosely summarized, losing between-the-lines nuance.

## Root Cause

The discuss prompt uses `ask_user_questions` only at the final depth verification checkpoint. Everything before that — reflection, questioning rounds, research findings — is output as unstructured prose. Users face walls of text and respond with "looks good" rather than correcting specific points, because the cost of reading and evaluating a large block is too high.

## Fix

Five targeted hardening measures to the discuss prompt, all focused on the same principle: **show → confirm → next** instead of text dumps.

### 1. Dense Input Abstraction
When users provide substantial input (voice transcripts, stream-of-consciousness), systematically extract each sub-thought as a numbered point and present via `ask_user_questions` for confirmation. Flags ambiguous points explicitly instead of silently interpreting them.

### 2. Output Discipline
New section enforcing compact outputs: max ~10 lines of text before an `ask_user_questions` confirmation. Multiple question fields in one call preferred over paragraphs with embedded points.

### 3. Incremental Alignment
After each questioning round, consolidate understanding via `ask_user_questions` before proceeding. Prevents drift where multiple rounds produce progressively divergent understanding without the user noticing.

### 4. Explicit Gap Surfacing
Changed depth enforcement from "track internally as background checklist" to explicit surfacing — at the end of each round, state which checklist items are satisfied and which remain open. Gaps are presented via `ask_user_questions`, not hidden.

### 5. Research Decision Gate
Research before roadmap creation is now mandatory (not advisory). A decision gate via `ask_user_questions` lets the user choose research depth (thorough / light / skip). Findings are presented as individual confirmable items, not prose paragraphs.

## Changed Files

| File | Change |
|------|--------|
| `src/resources/extensions/gsd/prompts/discuss.md` | +50/-4 — five new sections for alignment hardening |

## Test Evidence

- Changes are prompt-only (no code logic changes), so no unit test impact
- Build passes cleanly
- The five measures are additive — they layer on top of existing depth enforcement without removing or modifying existing behavior
- Each measure uses `ask_user_questions` which is already the established pattern in the depth verification section

## Related

Builds on #1116 (per-milestone depth verification), #1702 (web search budget awareness), #1002 (reflection step fix). No open issues or PRs address incremental alignment or output discipline in the discussion phase.