### PR TITLE
feat(ask-user-questions): add optional markdown preview panel with side-by-side layout

### DIFF
--- a/src/resources/extensions/ask-user-questions.ts
+++ b/src/resources/extensions/ask-user-questions.ts
@@ -48,6 +48,12 @@ type AskUserQuestionsDetails = LocalResultDetails | RemoteResultDetails;
 const OptionSchema = Type.Object({
 	label: Type.String({ description: "User-facing label (1-5 words)" }),
 	description: Type.String({ description: "One short sentence explaining impact/tradeoff if selected" }),
+	preview: Type.Optional(
+		Type.String({
+			description:
+				"Optional markdown content shown in a side-by-side preview panel when this option is highlighted. Use for showing code samples, config snippets, or detailed explanations. Keep under ~20 lines — longer content is truncated.",
+		}),
+	),
 });
 
 const QuestionSchema = Type.Object({
@@ -56,7 +62,7 @@ const QuestionSchema = Type.Object({
 	question: Type.String({ description: "Single-sentence prompt shown to the user" }),
 	options: Type.Array(OptionSchema, {
 		description:
-			'Provide 2-3 mutually exclusive choices for single-select, or any number for multi-select. Put the recommended option first and suffix its label with "(Recommended)". Do not include an "Other" option for single-select; the client adds a free-form "None of the above" option automatically.',
+			'Provide 2-3 mutually exclusive choices for single-select, or any number for multi-select. Put the recommended option first and suffix its label with "(Recommended)". Each option can include an optional "preview" field with markdown content shown in a side panel. Do not include an "Other" option for single-select; the client adds a free-form "None of the above" option automatically.',
 	}),
 	allowMultiple: Type.Optional(
 		Type.Boolean({
@@ -111,12 +117,14 @@ export default function AskUserQuestions(pi: ExtensionAPI) {
 		name: "ask_user_questions",
 		label: "Request User Input",
 		description:
-			"Request user input for one to three short questions and wait for the response. Single-select questions have 2-3 mutually exclusive options with a free-form 'None of the above' added automatically. Multi-select questions (allowMultiple: true) let the user toggle multiple options with SPACE and confirm with ENTER.",
+			"Request user input for one to three short questions and wait for the response. Single-select questions have 2-3 mutually exclusive options with a free-form 'None of the above' added automatically. Multi-select questions (allowMultiple: true) let the user toggle multiple options with SPACE and confirm with ENTER. Options can include an optional 'preview' field with markdown content shown in a side-by-side panel when highlighted.",
 		promptGuidelines: [
 			"Use ask_user_questions when you need the user to choose between concrete alternatives before proceeding.",
 			"Keep questions to 1 when possible; never exceed 3.",
 			"For single-select: each question must have 2-3 options. Put the recommended option first with '(Recommended)' suffix. Do not include an 'Other' or 'None of the above' option - the client adds one automatically.",
 			"For multi-select: set allowMultiple: true. The user can pick any number of options. No 'None of the above' is added.",
+			"When options involve code patterns, config choices, or architecture decisions, add a 'preview' field with markdown content (code blocks, lists, headers, etc.). The preview renders in a side-by-side panel when the option is highlighted.",
+			"Preview content is rendered in a fixed-height panel (max ~20 lines visible). Keep previews concise — show the most relevant snippet, not exhaustive examples. Longer content is truncated with a '+N lines hidden' indicator.",
 		],
 		parameters: AskUserQuestionsParams,
 
@@ -209,6 +217,13 @@ export default function AskUserQuestions(pi: ExtensionAPI) {
 			if (qs.length > 0) {
 				const headers = qs.map((q) => q.header).join(", ");
 				text += theme.fg("dim", ` (${headers})`);
+			}
+			const previewCount = qs.reduce(
+				(acc, q) => acc + (q.options || []).filter((o: QuestionOption) => o.preview).length,
+				0,
+			);
+			if (previewCount > 0) {
+				text += theme.fg("accent", ` [${previewCount} preview${previewCount !== 1 ? "s" : ""}]`);
 			}
 			for (const q of qs) {
 				const multiSel = !!q.allowMultiple;

--- a/src/resources/extensions/shared/interview-ui.ts
+++ b/src/resources/extensions/shared/interview-ui.ts
@@ -26,14 +26,16 @@
  */
 
 import type { ExtensionCommandContext } from "@gsd/pi-coding-agent";
-import { type Theme } from "@gsd/pi-coding-agent";
+import { getMarkdownTheme, type Theme } from "@gsd/pi-coding-agent";
 import {
 	Editor,
 	Key,
+	Markdown,
 	matchesKey,
 	truncateToWidth,
 	type TUI,
 } from "@gsd/pi-tui";
+import { mergeSideBySide } from "./layout-utils.js";
 import { makeUI, INDENT } from "./ui.js";
 
 // ─── Exported types ───────────────────────────────────────────────────────────
@@ -41,6 +43,8 @@ import { makeUI, INDENT } from "./ui.js";
 export interface QuestionOption {
 	label: string;
 	description: string;
+	/** Optional markdown content shown in a side-by-side preview panel when this option is highlighted. */
+	preview?: string;
 }
 
 export interface Question {
@@ -106,6 +110,14 @@ export interface WrapUpOptions {
 
 const OTHER_OPTION_LABEL = "None of the above";
 const OTHER_OPTION_DESCRIPTION = "Press TAB to add optional notes.";
+
+// Preview layout constants
+const MIN_PREVIEW_WIDTH = 30;
+const MIN_OPTIONS_WIDTH = 30;
+const PREVIEW_RATIO = 0.60;       // preview gets the majority of the width
+const DIVIDER_CHARS = " │ ";
+const DIVIDER_WIDTH = 3;
+const PREVIEW_MAX_LINES = 20;     // hard cap — keeps total ≤ 24 rows for single-question
 
 // ─── Wrap-up screen ───────────────────────────────────────────────────────────
 
@@ -494,6 +506,99 @@ export async function showInterviewRound(
 			return lines;
 		}
 
+		// ── Preview helpers ──────────────────────────────────────────────
+
+		let mdThemeCache: ReturnType<typeof getMarkdownTheme> | null = null;
+		let previewCache: { markdown: string; width: number; lines: string[] } | null = null;
+
+		function questionHasAnyPreview(): boolean {
+			return questions[currentIdx].options.some(
+				(o) => o.preview != null && o.preview.trim().length > 0,
+			);
+		}
+
+		function getCurrentPreview(): string | null {
+			const q = questions[currentIdx];
+			const idx = states[currentIdx].cursorIndex;
+			if (idx < q.options.length) {
+				const preview = q.options[idx].preview;
+				return preview && preview.trim().length > 0 ? preview : null;
+			}
+			return null;
+		}
+
+		function renderOptionsColumn(optWidth: number): string[] {
+			const ui = makeUI(theme, optWidth);
+			const col: string[] = [];
+			const push = (...rows: string[][]) => { for (const r of rows) col.push(...r); };
+
+			const q = questions[currentIdx];
+			const st = states[currentIdx];
+			const multiSel = isMultiSelect(currentIdx);
+
+			push(ui.question(` ${q.question}`));
+			if (multiSel) push(ui.meta("  (Select all that apply)"));
+			push(ui.blank());
+
+			for (let i = 0; i < q.options.length; i++) {
+				const opt = q.options[i];
+				const isCursor = i === st.cursorIndex;
+				if (multiSel) {
+					const isChecked = st.checkedIndices.has(i);
+					if (isCursor && !focusNotes) push(ui.checkboxSelected(opt.label, opt.description, isChecked));
+					else push(ui.checkboxUnselected(opt.label, opt.description, isChecked, focusNotes));
+				} else {
+					const isCommitted = i === st.committedIndex;
+					if (isCursor && !focusNotes) {
+						push(ui.optionSelected(i + 1, opt.label, opt.description, isCommitted));
+					} else {
+						push(ui.optionUnselected(i + 1, opt.label, opt.description, { isCommitted, isFocusDimmed: focusNotes }));
+					}
+				}
+			}
+
+			const ndIdx = noneOrDoneIdx(currentIdx);
+			const ndCursor = ndIdx === st.cursorIndex;
+			if (multiSel) {
+				push(ui.blank());
+				if (ndCursor && !focusNotes) push(ui.doneSelected());
+				else push(ui.doneUnselected());
+			} else {
+				const ndCommitted = ndIdx === st.committedIndex;
+				if (ndCursor && !focusNotes) {
+					push(ui.slotSelected(OTHER_OPTION_LABEL, OTHER_OPTION_DESCRIPTION, ndCommitted));
+				} else {
+					push(ui.slotUnselected(OTHER_OPTION_LABEL, OTHER_OPTION_DESCRIPTION, { isCommitted: ndCommitted, isFocusDimmed: focusNotes }));
+				}
+			}
+
+			if (st.notesVisible || focusNotes) {
+				push(ui.blank(), ui.notesLabel(focusNotes));
+				if (focusNotes) {
+					for (const line of getEditor().render(optWidth - 2)) col.push(truncateToWidth(` ${line}`, optWidth));
+				} else if (st.notes) {
+					push(ui.notesText(st.notes));
+				}
+			}
+
+			return col;
+		}
+
+		function renderPreviewColumn(markdown: string, previewWidth: number): string[] {
+			if (previewCache && previewCache.markdown === markdown && previewCache.width === previewWidth) {
+				return previewCache.lines;
+			}
+			if (!mdThemeCache) mdThemeCache = getMarkdownTheme();
+			const header = [
+				truncateToWidth(theme.fg("accent", theme.bold(" Preview")), previewWidth),
+				truncateToWidth(theme.fg("dim", " " + "─".repeat(Math.max(0, previewWidth - 2))), previewWidth),
+			];
+			const md = new Markdown(markdown, 1, 0, mdThemeCache);
+			const lines = [...header, ...md.render(previewWidth)];
+			previewCache = { markdown, width: previewWidth, lines };
+			return lines;
+		}
+
 		// ── Main render ──────────────────────────────────────────────────
 
 		function render(width: number): string[] {
@@ -501,6 +606,94 @@ export async function showInterviewRound(
 
 			if (showingExitConfirm) { cachedLines = renderExitConfirm(width); return cachedLines; }
 			if (showingReview) { cachedLines = renderReviewScreen(width); return cachedLines; }
+
+			const useSideBySide = questionHasAnyPreview()
+				&& width >= (MIN_OPTIONS_WIDTH + MIN_PREVIEW_WIDTH + DIVIDER_WIDTH);
+
+			if (useSideBySide) {
+				// ── Preview path ──────────────────────────────────────
+				const ui = makeUI(theme, width);
+				const lines: string[] = [];
+				const push = (...rows: string[][]) => { for (const r of rows) lines.push(...r); };
+
+				push(ui.bar());
+
+				if (isMultiQuestion) {
+					const unanswered = questions.filter((_, i) => !isQuestionAnswered(i)).length;
+					const answeredSet = new Set(questions.map((_, i) => i).filter(i => isQuestionAnswered(i)));
+					push(ui.questionTabs(questions.map(q => q.header), currentIdx, answeredSet));
+					push(ui.blank());
+					const progressParts = [
+						opts.progress,
+						`Question ${currentIdx + 1}/${questions.length}`,
+						unanswered > 0 ? `${unanswered} unanswered` : null,
+					].filter(Boolean).join("  •  ");
+					if (progressParts) push(ui.meta(`  ${progressParts}`));
+					push(ui.blank());
+				} else {
+					if (opts.progress) push(ui.meta(`  ${opts.progress}`), ui.blank());
+				}
+
+				// Side-by-side body — fixed height per render, capped to terminal.
+				// TUI_CHROME accounts for the spinner, status bar, and other
+				// elements rendered outside the interview component.
+				const termRows = (typeof process !== "undefined" && process.stdout?.rows) || 24;
+				const footerLines = 3; // blank + hints + bar
+				const tuiChrome = 5;   // spinner, status bar, safety margin
+				const maxBody = Math.min(PREVIEW_MAX_LINES, Math.max(6, termRows - lines.length - footerLines - tuiChrome));
+
+				const previewWidth = Math.max(MIN_PREVIEW_WIDTH, Math.floor(width * PREVIEW_RATIO));
+				const leftWidth = Math.max(MIN_OPTIONS_WIDTH, width - previewWidth - DIVIDER_WIDTH);
+
+				const fullLeft = renderOptionsColumn(leftWidth);
+				const leftLines = fullLeft.slice(0, maxBody);
+				if (fullLeft.length > maxBody) {
+					const n = fullLeft.length - maxBody + 1;
+					const lbl = `+${n} lines hidden`;
+					const d = "─".repeat(Math.max(0, Math.floor((leftWidth - lbl.length - 2) / 2)));
+					leftLines[maxBody - 1] = truncateToWidth(theme.fg("dim", ` ${d} ${lbl} ${d}`), leftWidth);
+				}
+
+				const preview = getCurrentPreview();
+				const fullRight = preview ? renderPreviewColumn(preview, previewWidth) : [];
+				const rightLines = fullRight.slice(0, maxBody);
+				if (fullRight.length > maxBody) {
+					const n = fullRight.length - maxBody + 1;
+					const lbl = `+${n} lines hidden`;
+					const d = "─".repeat(Math.max(0, Math.floor((previewWidth - lbl.length - 2) / 2)));
+					rightLines[maxBody - 1] = truncateToWidth(theme.fg("dim", ` ${d} ${lbl} ${d}`), previewWidth);
+				}
+
+				while (leftLines.length < maxBody) leftLines.push("");
+				while (rightLines.length < maxBody) rightLines.push("");
+				const divider = theme.fg("dim", DIVIDER_CHARS);
+				lines.push(...mergeSideBySide(leftLines, rightLines, leftWidth, divider, width));
+
+				// Footer
+				push(ui.blank());
+				const isLast = !isMultiQuestion || currentIdx === questions.length - 1;
+				const hints: string[] = [];
+				if (focusNotes) {
+					hints.push("enter to confirm");
+					hints.push("tab or esc to close notes");
+				} else if (isMultiSelect(currentIdx)) {
+					hints.push("space to toggle");
+					if (isMultiQuestion) hints.push("←/→ navigate questions");
+					hints.push("tab to add notes");
+					hints.push(isLast && allAnswered() ? "enter to review" : "enter to next");
+				} else {
+					hints.push("tab to add notes");
+					if (isMultiQuestion) hints.push("←/→ navigate");
+					hints.push(isLast && allAnswered() ? "enter to review" : "enter to next");
+				}
+				hints.push("esc to exit");
+				push(ui.hints(hints), ui.bar());
+
+				cachedLines = lines;
+				return lines;
+			}
+
+			// ── Original path — no preview, untouched ────────────────
 
 			const ui = makeUI(theme, width);
 			const lines: string[] = [];

--- a/src/resources/extensions/shared/interview-ui.ts
+++ b/src/resources/extensions/shared/interview-ui.ts
@@ -635,11 +635,12 @@ export async function showInterviewRound(
 				}
 
 				// Side-by-side body — fixed height per render, capped to terminal.
-				// TUI_CHROME accounts for the spinner, status bar, and other
-				// elements rendered outside the interview component.
+				// tuiChrome accounts for elements rendered outside the interview
+				// component: spinner/loader (1-2), status line (1), tool header (1),
+				// plus a safety margin for future additions.
 				const termRows = (typeof process !== "undefined" && process.stdout?.rows) || 24;
 				const footerLines = 3; // blank + hints + bar
-				const tuiChrome = 5;   // spinner, status bar, safety margin
+				const tuiChrome = 5;
 				const maxBody = Math.min(PREVIEW_MAX_LINES, Math.max(6, termRows - lines.length - footerLines - tuiChrome));
 
 				const previewWidth = Math.max(MIN_PREVIEW_WIDTH, Math.floor(width * PREVIEW_RATIO));

--- a/src/resources/extensions/shared/layout-utils.ts
+++ b/src/resources/extensions/shared/layout-utils.ts
@@ -47,3 +47,29 @@ export function fitColumns(parts: string[], width: number, separator = "  "): st
   }
   return truncateToWidth(result, width);
 }
+
+/**
+ * Merge two sets of lines into a side-by-side layout with a vertical divider.
+ *
+ * Each left line is padded to `leftWidth`, then joined with a styled divider
+ * and the corresponding right line. Output lines are truncated to `totalWidth`.
+ */
+export function mergeSideBySide(
+  leftLines: string[],
+  rightLines: string[],
+  leftWidth: number,
+  divider: string,
+  totalWidth: number,
+): string[] {
+  const maxLen = Math.max(leftLines.length, rightLines.length);
+  const merged: string[] = [];
+
+  for (let i = 0; i < maxLen; i++) {
+    const left = i < leftLines.length ? leftLines[i] : "";
+    const right = i < rightLines.length ? rightLines[i] : "";
+    const paddedLeft = padRight(left, leftWidth);
+    merged.push(truncateToWidth(paddedLeft + divider + right, totalWidth));
+  }
+
+  return merged;
+}

--- a/src/resources/extensions/shared/tests/interview-preview.test.ts
+++ b/src/resources/extensions/shared/tests/interview-preview.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, before } from "node:test";
+import assert from "node:assert/strict";
+import { Markdown, visibleWidth } from "@gsd/pi-tui";
+import { getMarkdownTheme, initTheme } from "@gsd/pi-coding-agent";
+import type { QuestionOption, Question } from "../interview-ui.js";
+
+// Theme must be initialized before Markdown rendering
+before(() => { initTheme(); });
+
+// ─── QuestionOption.preview type contract ─────────────────────────────────────
+
+describe("QuestionOption preview field", () => {
+  it("accepts option without preview (backward compat)", () => {
+    const opt: QuestionOption = { label: "A", description: "Desc A" };
+    assert.equal(opt.preview, undefined);
+  });
+
+  it("accepts option with preview string", () => {
+    const opt: QuestionOption = {
+      label: "A",
+      description: "Desc A",
+      preview: "## Code\n```ts\nconst x = 1;\n```",
+    };
+    assert.equal(typeof opt.preview, "string");
+    assert.ok(opt.preview!.length > 0);
+  });
+
+  it("Question with mixed preview/no-preview options is valid", () => {
+    const q: Question = {
+      id: "test",
+      header: "Test",
+      question: "Pick one",
+      options: [
+        { label: "A", description: "Has preview", preview: "# Preview A" },
+        { label: "B", description: "No preview" },
+        { label: "C", description: "Has preview", preview: "# Preview C" },
+      ],
+    };
+    const withPreview = q.options.filter((o) => o.preview);
+    const withoutPreview = q.options.filter((o) => !o.preview);
+    assert.equal(withPreview.length, 2);
+    assert.equal(withoutPreview.length, 1);
+  });
+});
+
+// ─── Markdown preview rendering ───────────────────────────────────────────────
+
+describe("preview column rendering", () => {
+  it("Markdown component renders non-empty output for a markdown string", () => {
+    const mdTheme = getMarkdownTheme();
+    const md = new Markdown("## Hello\n\nSome **bold** text.", 1, 0, mdTheme);
+    const lines = md.render(40);
+    assert.ok(lines.length > 0, "Markdown should produce at least one line");
+    // At least one line should have visible content
+    const hasContent = lines.some((l) => visibleWidth(l) > 0);
+    assert.ok(hasContent, "At least one rendered line should have visible content");
+  });
+
+  it("Markdown component renders code blocks", () => {
+    const mdTheme = getMarkdownTheme();
+    const md = new Markdown("```ts\nconst x = 1;\n```", 1, 0, mdTheme);
+    const lines = md.render(40);
+    assert.ok(lines.length > 0);
+    const joined = lines.join("\n");
+    // The rendered output should contain the code content somewhere
+    assert.ok(joined.includes("const") || joined.includes("x"), "Code block content should be present");
+  });
+
+  it("Markdown component respects width constraint", () => {
+    const mdTheme = getMarkdownTheme();
+    const longContent = "This is a very long paragraph that should wrap when rendered at a narrow width constraint.";
+    const md = new Markdown(longContent, 1, 0, mdTheme);
+    const lines = md.render(30);
+    // All lines should respect the width
+    for (const line of lines) {
+      assert.ok(
+        visibleWidth(line) <= 30,
+        `Line exceeds width: "${line}" (visible: ${visibleWidth(line)})`,
+      );
+    }
+  });
+});
+
+// ─── Layout stability ─────────────────────────────────────────────────────────
+
+describe("layout stability", () => {
+  const MIN_PREVIEW_WIDTH = 30;
+  const MIN_OPTIONS_WIDTH = 30;
+  const DIVIDER_WIDTH = 3;
+
+  /** Mirrors questionHasAnyPreview() logic from interview-ui.ts */
+  function questionHasAnyPreview(options: QuestionOption[]): boolean {
+    return options.some((o) => o.preview != null && o.preview.trim().length > 0);
+  }
+
+  it("useSideBySide is true when ANY option has a preview (not just current)", () => {
+    const options: QuestionOption[] = [
+      { label: "A", description: "Has preview", preview: "# Hello" },
+      { label: "B", description: "No preview" },
+      { label: "C", description: "Also no preview" },
+    ];
+    const width = 100;
+    const useSideBySide = questionHasAnyPreview(options) && width >= (MIN_OPTIONS_WIDTH + MIN_PREVIEW_WIDTH + DIVIDER_WIDTH);
+    assert.equal(useSideBySide, true, "side-by-side should activate when any option has preview");
+  });
+
+  it("useSideBySide is false when no options have a preview", () => {
+    const options: QuestionOption[] = [
+      { label: "A", description: "No preview" },
+      { label: "B", description: "No preview" },
+    ];
+    const useSideBySide = questionHasAnyPreview(options) && 100 >= 63;
+    assert.equal(useSideBySide, false);
+  });
+
+  it("PREVIEW_MAX_LINES produces constant side-by-side height", () => {
+    const PREVIEW_MAX_LINES = 20;
+    // Short and long content both produce exactly PREVIEW_MAX_LINES after cap+pad
+    for (const contentLen of [3, 10, 15, 30]) {
+      const capped = Math.min(contentLen, PREVIEW_MAX_LINES);
+      const padded = Math.max(capped, PREVIEW_MAX_LINES);
+      assert.equal(padded, PREVIEW_MAX_LINES, `content ${contentLen} should pad to ${PREVIEW_MAX_LINES}`);
+    }
+  });
+
+  it("total with PREVIEW_MAX_LINES fits in standard terminal (single-question)", () => {
+    const PREVIEW_MAX_LINES = 20;
+    const singleHeader = 1;  // bar only
+    const footer = 3;        // blank + hints + bar
+    const total = singleHeader + PREVIEW_MAX_LINES + footer;
+    assert.ok(total <= 24, `single-question total ${total} exceeds 24-row terminal`);
+  });
+});
+
+// ─── Preview layout constants ─────────────────────────────────────────────────
+
+describe("preview layout constraints", () => {
+  const MIN_PREVIEW_WIDTH = 30;
+  const MIN_OPTIONS_WIDTH = 30;
+  const DIVIDER_WIDTH = 3;
+  const PREVIEW_RATIO = 0.60;
+
+  it("minimum terminal width for preview = MIN_OPTIONS + MIN_PREVIEW + DIVIDER", () => {
+    const minWidth = MIN_OPTIONS_WIDTH + MIN_PREVIEW_WIDTH + DIVIDER_WIDTH;
+    assert.equal(minWidth, 63);
+  });
+
+  it("at minimum width, both columns get their floor", () => {
+    const width = 63;
+    const previewWidth = Math.max(MIN_PREVIEW_WIDTH, Math.floor(width * PREVIEW_RATIO));
+    const leftWidth = Math.max(MIN_OPTIONS_WIDTH, width - previewWidth - DIVIDER_WIDTH);
+    assert.ok(previewWidth >= MIN_PREVIEW_WIDTH, `preview ${previewWidth} < min ${MIN_PREVIEW_WIDTH}`);
+    assert.ok(leftWidth >= MIN_OPTIONS_WIDTH, `options ${leftWidth} < min ${MIN_OPTIONS_WIDTH}`);
+  });
+
+  it("at wide terminal, preview ratio is approximately 60%", () => {
+    const width = 120;
+    const previewWidth = Math.max(MIN_PREVIEW_WIDTH, Math.floor(width * PREVIEW_RATIO));
+    const leftWidth = Math.max(MIN_OPTIONS_WIDTH, width - previewWidth - DIVIDER_WIDTH);
+    // Preview should be close to 60% of total
+    const actualRatio = previewWidth / width;
+    assert.ok(actualRatio >= 0.55 && actualRatio <= 0.65, `Ratio ${actualRatio} not near 0.60`);
+    assert.ok(leftWidth >= MIN_OPTIONS_WIDTH);
+  });
+
+  it("preview disabled when terminal is too narrow", () => {
+    const width = 62; // just under threshold
+    const canShow = width >= (MIN_OPTIONS_WIDTH + MIN_PREVIEW_WIDTH + DIVIDER_WIDTH);
+    assert.equal(canShow, false);
+  });
+
+  it("preview enabled when terminal is exactly at threshold", () => {
+    const width = 63;
+    const canShow = width >= (MIN_OPTIONS_WIDTH + MIN_PREVIEW_WIDTH + DIVIDER_WIDTH);
+    assert.equal(canShow, true);
+  });
+});

--- a/src/resources/extensions/shared/tests/preview-layout.test.ts
+++ b/src/resources/extensions/shared/tests/preview-layout.test.ts
@@ -1,0 +1,120 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { visibleWidth } from "@gsd/pi-tui";
+import { mergeSideBySide, padRight } from "../layout-utils.js";
+
+// ─── mergeSideBySide ──────────────────────────────────────────────────────────
+
+describe("mergeSideBySide", () => {
+  const plainDivider = " | ";
+
+  it("merges equal-length line arrays", () => {
+    const left = ["aaa", "bbb"];
+    const right = ["111", "222"];
+    const merged = mergeSideBySide(left, right, 6, plainDivider, 80);
+    assert.equal(merged.length, 2);
+    // left padded to 6, then divider, then right
+    assert.ok(merged[0].includes("aaa"));
+    assert.ok(merged[0].includes("111"));
+    assert.ok(merged[1].includes("bbb"));
+    assert.ok(merged[1].includes("222"));
+  });
+
+  it("pads short left lines to leftWidth", () => {
+    const left = ["ab"];
+    const right = ["xy"];
+    const merged = mergeSideBySide(left, right, 6, plainDivider, 80);
+    // "ab" padded to 6 = "ab    ", then " | ", then "xy"
+    assert.ok(merged[0].startsWith("ab    "));
+  });
+
+  it("handles empty left array", () => {
+    const merged = mergeSideBySide([], ["aaa", "bbb"], 6, plainDivider, 80);
+    assert.equal(merged.length, 2);
+    // Left side should be blank (just padding)
+    assert.ok(merged[0].startsWith("      "));
+  });
+
+  it("handles empty right array", () => {
+    const merged = mergeSideBySide(["aaa", "bbb"], [], 6, plainDivider, 80);
+    assert.equal(merged.length, 2);
+    assert.ok(merged[0].includes("aaa"));
+  });
+
+  it("handles both arrays empty", () => {
+    const merged = mergeSideBySide([], [], 6, plainDivider, 80);
+    assert.equal(merged.length, 0);
+  });
+
+  it("handles mismatched lengths — left longer", () => {
+    const left = ["a", "b", "c"];
+    const right = ["1"];
+    const merged = mergeSideBySide(left, right, 6, plainDivider, 80);
+    assert.equal(merged.length, 3);
+    assert.ok(merged[0].includes("1"));
+    // Lines 2 and 3 have empty right side
+    assert.ok(merged[2].includes("c"));
+  });
+
+  it("handles mismatched lengths — right longer", () => {
+    const left = ["a"];
+    const right = ["1", "2", "3"];
+    const merged = mergeSideBySide(left, right, 6, plainDivider, 80);
+    assert.equal(merged.length, 3);
+    assert.ok(merged[2].includes("3"));
+  });
+
+  it("truncates merged output to totalWidth", () => {
+    const left = ["aaaaaaaaaa"];  // 10 chars
+    const right = ["bbbbbbbbbb"]; // 10 chars
+    const merged = mergeSideBySide(left, right, 10, plainDivider, 15);
+    // Should be truncated to 15 visible chars
+    assert.ok(visibleWidth(merged[0]) <= 15);
+  });
+
+  it("handles ANSI-colored left content correctly", () => {
+    const red = "\x1b[31m";
+    const reset = "\x1b[0m";
+    const left = [`${red}hello${reset}`]; // visible: "hello" (5 chars)
+    const right = ["world"];
+    const merged = mergeSideBySide(left, right, 8, plainDivider, 80);
+    // "hello" is 5 visible chars, padded to 8 = 3 spaces of padding
+    // The ANSI codes don't count toward visible width
+    assert.ok(merged[0].includes(red));
+    assert.ok(merged[0].includes("world"));
+    // Verify padding is correct (8 visible chars on left side)
+    const beforeDivider = merged[0].split(" | ")[0];
+    assert.equal(visibleWidth(beforeDivider), 8);
+  });
+
+  it("handles ANSI-colored divider", () => {
+    const dim = "\x1b[2m";
+    const reset = "\x1b[0m";
+    const styledDivider = `${dim} │ ${reset}`;
+    const left = ["abc"];
+    const right = ["xyz"];
+    const merged = mergeSideBySide(left, right, 6, styledDivider, 80);
+    assert.equal(merged.length, 1);
+    assert.ok(merged[0].includes("abc"));
+    assert.ok(merged[0].includes("xyz"));
+  });
+});
+
+// ─── padRight with ANSI ───────────────────────────────────────────────────────
+
+describe("padRight with ANSI content", () => {
+  it("pads based on visible width, not string length", () => {
+    const red = "\x1b[31m";
+    const reset = "\x1b[0m";
+    const colored = `${red}hi${reset}`;
+    // colored.length >> 2, but visible width is 2
+    const padded = padRight(colored, 6);
+    assert.equal(visibleWidth(padded), 6);
+  });
+
+  it("does not over-pad plain text", () => {
+    const padded = padRight("hello", 5);
+    assert.equal(padded, "hello");
+    assert.equal(visibleWidth(padded), 5);
+  });
+});


### PR DESCRIPTION
## TL;DR

**What:** Adds an optional `preview` field to `ask_user_questions` options that renders markdown in a side-by-side terminal panel.
**Why:** When choosing between code patterns or config options, a label and one-line description aren't enough context. Inspired by Claude Code's `AskUserQuestion` tool.
**How:** Optional `QuestionOption.preview` field triggers a fixed-height side-by-side layout with `renderOptionsColumn()` + `renderPreviewColumn()` + reusable `mergeSideBySide()` utility. Preview is capped at 20 lines (adaptive to terminal height) with a truncation indicator; the LLM prompt enforces this limit.

> AI-assisted contribution (GSD + Claude). Tested locally and reviewed by contributor.

## What

Adds an optional `preview` field to `QuestionOption` that renders markdown content in a side-by-side panel when an option is highlighted — code samples, config snippets, architecture diagrams, etc.

**`ask-user-questions.ts`** — Schema + rendering
- `OptionSchema` gains optional `preview: string` field with ~20-line guidance
- `promptGuidelines` updated to tell the LLM to keep previews concise (max ~20 lines visible, longer content truncated with "+N lines hidden" indicator)
- `renderCall` shows `[N previews]` badge when options include previews

**`interview-ui.ts`** — Core UI
- `QuestionOption.preview?: string` added to the shared type
- Side-by-side layout activates when: any option in the question has preview AND terminal width >= 63 chars
- Preview gets 60% of width, options get the rest (both have 30-col minimum floors)
- Fixed-height body: `min(PREVIEW_MAX_LINES, termRows - header - footer - tuiChrome)` — constant between renders, eliminates scroll creep
- When content is truncated, a dim `── +N lines hidden ──` indicator replaces the last line
- Non-preview path is the **verbatim original render code** — zero behavioral change for questions without previews
- Preview column has a render cache keyed by (markdown content, width) to avoid re-parsing on cursor moves
- Graceful fallback to single-column when no previews or terminal too narrow

**`layout-utils.ts`** — Reusable utility
- `mergeSideBySide()` — ANSI-aware column merge with vertical divider
- `padRight()` uses `visibleWidth()` for ANSI-safe width calculation

## Why

When the LLM asks the user to choose between code patterns, config options, or architectural approaches, a text label and one-line description aren't enough context. Claude Code's `AskUserQuestion` tool solves this with a preview pane. This brings the same UX to GSD.

## How

The implementation extends the existing interview UI with a clean `if/else` branch. When any option in a question has a `preview` field and the terminal is wide enough (>= 63 chars), the render function takes the side-by-side path. Otherwise it executes the original render code verbatim — zero refactoring of the non-preview path.

The side-by-side body height is `min(20, termRows - header - footer - 5)`. The 5-line buffer accounts for TUI chrome (spinner, status bar) that exists outside the interview component. Both columns are sliced to fit and then padded to fill. This constant height prevents the TUI's `maxLinesRendered` from ratcheting up between renders, which eliminates scroll creep entirely.

### Review concern responses

- **Tests**: 27 new tests across two files (see below)
- **ANSI-aware padding**: `padRight()` uses `visibleWidth()` from `@gsd/pi-tui`. Verified with explicit ANSI test cases (colored content, styled dividers).
- **Minimum options width**: `MIN_OPTIONS_WIDTH = 30` floor. Both columns have explicit minimums. Threshold: `width >= 63`.
- **Cross-package coupling**: `Markdown` and `getMarkdownTheme` are already used by deployed extensions (`subagent/index.ts`). No new dependency edges.

## Tests

27 new tests across two files:

**`preview-layout.test.ts`** (12 tests) — `mergeSideBySide` unit tests:
- Equal-length, mismatched-length, and empty line arrays
- ANSI-colored left content with correct visual-width padding
- ANSI-colored divider passthrough
- `totalWidth` truncation
- `padRight` with ANSI content (visual width vs string length)

**`interview-preview.test.ts`** (15 tests) — Integration tests:
- `QuestionOption.preview` type contract (backward compat, with preview, mixed)
- `Markdown` component rendering (non-empty output, code blocks, width constraint)
- Layout stability (side-by-side activates on any-preview, constant height, terminal budget)
- Layout constraint arithmetic (minimum threshold, column floors, 60% ratio, fallback)

### Change type

- [x] feat — New feature (optional preview field)
- [x] test — New test coverage

### Backward compatibility

Zero breaking changes. `preview` is optional — existing callers and LLM tool calls without it work identically. The non-preview render path is the original code, untouched.