### PR TITLE
fix: use Array.from instead of Buffer.from for native processStreamChunk state

### DIFF
--- a/packages/native/src/__tests__/stream-process.test.mjs
+++ b/packages/native/src/__tests__/stream-process.test.mjs
@@ -1,0 +1,34 @@
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { processStreamChunk } from "../stream-process/index.ts";
+
+describe("processStreamChunk", () => {
+  test("processes a single chunk without state", () => {
+    const result = processStreamChunk(Buffer.from("hello world\n"));
+    assert.equal(result.text, "hello world\n");
+    assert.ok(Array.isArray(result.state.utf8Pending));
+    assert.ok(Array.isArray(result.state.ansiPending));
+  });
+
+  test("processes multiple chunks passing state between calls", () => {
+    const result1 = processStreamChunk(Buffer.from("first\n"));
+    assert.equal(result1.text, "first\n");
+
+    // This was the crash: passing state back caused
+    // "Given napi value is not an array on StreamState.utf8Pending"
+    // when state arrays were wrapped in Buffer.from() instead of Array.from()
+    const result2 = processStreamChunk(Buffer.from("second\n"), result1.state);
+    assert.equal(result2.text, "second\n");
+
+    const result3 = processStreamChunk(Buffer.from("third\n"), result2.state);
+    assert.equal(result3.text, "third\n");
+  });
+
+  test("state fields are plain arrays, not Buffers", () => {
+    const result = processStreamChunk(Buffer.from("test\n"));
+    assert.ok(Array.isArray(result.state.utf8Pending), "utf8Pending should be a plain array");
+    assert.ok(Array.isArray(result.state.ansiPending), "ansiPending should be a plain array");
+    assert.ok(!(result.state.utf8Pending instanceof Buffer), "utf8Pending should not be a Buffer");
+    assert.ok(!(result.state.ansiPending instanceof Buffer), "ansiPending should not be a Buffer");
+  });
+});

--- a/packages/native/src/stream-process/index.ts
+++ b/packages/native/src/stream-process/index.ts
@@ -33,8 +33,8 @@ export function processStreamChunk(
   // Convert StreamState arrays to the format napi expects (Vec<u8>)
   const napiState = state
     ? {
-        utf8Pending: Buffer.from(state.utf8Pending),
-        ansiPending: Buffer.from(state.ansiPending),
+        utf8Pending: Array.from(state.utf8Pending),
+        ansiPending: Array.from(state.ansiPending),
       }
     : undefined;
 


### PR DESCRIPTION
## TL;DR

**What:** Fix crash in native stream processor when processing multi-chunk bash output.
**Why:** `processStreamChunk` crashes with `Given napi value is not an array on StreamState.utf8Pending` on any bash command that produces more than one output chunk.
**How:** Change `Buffer.from()` to `Array.from()` when passing state back to the napi layer, matching the expected `Vec<u8>` type.

## What

One-line fix in `packages/native/src/stream-process/index.ts`. The JS wrapper converts the returned state arrays to `Buffer` before passing them back on the next call, but the Rust napi binding expects plain JS arrays (`Vec<u8>`).

## Why

Any bash command producing multi-chunk output (e.g. `ping`, `curl`, long-running commands) crashes the app:

```
Error: Given napi value is not an array on StreamState.utf8Pending
    at processStreamChunk
    at Socket.handleData (bash-executor.js)
```

This affects both `!` bash commands and LLM-invoked bash tool calls.

## How

Changed the state conversion from `Buffer.from(state.utf8Pending)` to `Array.from(state.utf8Pending)` (and same for `ansiPending`). The napi layer already returns arrays, so `Array.from()` is a no-op passthrough on the common path.

- [x] `fix` — Bug fix

**AI-assisted:** This change was authored with Claude (AI pair programming).