### PR TITLE
fix(auto): add EAGAIN to INFRA_ERROR_CODES

### DIFF
--- a/src/resources/extensions/gsd/auto/infra-errors.ts
+++ b/src/resources/extensions/gsd/auto/infra-errors.ts
@@ -18,6 +18,7 @@ export const INFRA_ERROR_CODES: ReadonlySet<string> = new Set([
   "EDQUOT",   // disk quota exceeded
   "EMFILE",   // too many open files (process)
   "ENFILE",   // too many open files (system)
+  "EAGAIN",   // resource temporarily unavailable (resource exhaustion)
 ]);
 
 /**

--- a/src/resources/extensions/gsd/tests/infra-error.test.ts
+++ b/src/resources/extensions/gsd/tests/infra-error.test.ts
@@ -7,10 +7,10 @@ import { isInfrastructureError, INFRA_ERROR_CODES } from "../auto/infra-errors.j
 // ── INFRA_ERROR_CODES constant ───────────────────────────────────────────────
 
 test("INFRA_ERROR_CODES contains the expected codes", () => {
-  for (const code of ["ENOSPC", "ENOMEM", "EROFS", "EDQUOT", "EMFILE", "ENFILE"]) {
+  for (const code of ["ENOSPC", "ENOMEM", "EROFS", "EDQUOT", "EMFILE", "ENFILE", "EAGAIN"]) {
     assert.ok(INFRA_ERROR_CODES.has(code), `missing ${code}`);
   }
-  assert.equal(INFRA_ERROR_CODES.size, 6, "unexpected extra codes");
+  assert.equal(INFRA_ERROR_CODES.size, 7, "unexpected extra codes");
 });
 
 // ── isInfrastructureError: code property detection ───────────────────────────
@@ -43,6 +43,16 @@ test("detects EMFILE via code property", () => {
 test("detects ENFILE via code property", () => {
   const err = Object.assign(new Error("file table overflow"), { code: "ENFILE" });
   assert.equal(isInfrastructureError(err), "ENFILE");
+});
+
+test("detects EAGAIN via code property", () => {
+  const err = Object.assign(new Error("resource temporarily unavailable"), { code: "EAGAIN" });
+  assert.equal(isInfrastructureError(err), "EAGAIN");
+});
+
+test("detects EAGAIN in error message fallback", () => {
+  const err = new Error("spawn failed: EAGAIN resource temporarily unavailable");
+  assert.equal(isInfrastructureError(err), "EAGAIN");
 });
 
 // ── isInfrastructureError: message fallback ──────────────────────────────────


### PR DESCRIPTION
## Summary
- Add `EAGAIN` (resource temporarily unavailable) to `INFRA_ERROR_CODES` so auto-mode bails immediately instead of retrying on resource exhaustion
- Add test coverage for EAGAIN detection via both `code` property and message fallback

## Problem
When a spawned process fails with `EAGAIN`, the error was not recognized as an infrastructure failure. Auto-mode treated it as a transient error and retried, burning LLM budget on guaranteed failures.

## Test plan
- [x] Wrote failing tests first confirming EAGAIN was not detected
- [x] Added EAGAIN to `INFRA_ERROR_CODES`
- [x] All 20 infra-error tests pass
- [x] `npx tsc --noEmit` passes

Fixes #2359

🤖 Generated with [Claude Code](https://claude.com/claude-code)