### PR TITLE
fix: worktree health check walks parent dirs for monorepo support

### DIFF
--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -27,7 +27,7 @@ import { debugLog } from "../debug-logger.js";
 import { gsdRoot } from "../paths.js";
 import { atomicWriteSync } from "../atomic-write.js";
 import { PROJECT_FILES } from "../detection.js";
-import { join } from "node:path";
+import { join, dirname, parse as parsePath } from "node:path";
 
 // ─── generateMilestoneReport ──────────────────────────────────────────────────
 
@@ -827,7 +827,22 @@ export async function runUnitPhase(
     }
     const hasProjectFile = PROJECT_FILES.some((f) => deps.existsSync(join(s.basePath, f)));
     const hasSrcDir = deps.existsSync(join(s.basePath, "src"));
+    // Monorepo support (#2347): if no project files in the worktree directory,
+    // walk parent directories up to the filesystem root. In monorepos,
+    // package.json / Cargo.toml etc. live in a parent directory.
+    let hasProjectFileInParent = false;
     if (!hasProjectFile && !hasSrcDir) {
+      let checkDir = dirname(s.basePath);
+      const { root } = parsePath(checkDir);
+      while (checkDir !== root) {
+        if (PROJECT_FILES.some((f) => deps.existsSync(join(checkDir, f)))) {
+          hasProjectFileInParent = true;
+          break;
+        }
+        checkDir = dirname(checkDir);
+      }
+    }
+    if (!hasProjectFile && !hasSrcDir && !hasProjectFileInParent) {
       // Greenfield projects won't have project files yet — the first task creates them.
       // Log a warning but allow execution to proceed. The .git check above is sufficient
       // to ensure we're in a valid working directory.

--- a/src/resources/extensions/gsd/tests/worktree-health-monorepo.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-health-monorepo.test.ts
@@ -1,0 +1,60 @@
+/**
+ * worktree-health-monorepo.test.ts — #2347
+ *
+ * The worktree health check in auto/phases.ts falsely rejects monorepos
+ * where package.json (or other project markers) is in a parent directory.
+ * This test verifies that the health check walks parent directories.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { createTestContext } from "./test-helpers.ts";
+
+const { assertTrue, report } = createTestContext();
+
+const srcPath = join(import.meta.dirname, "..", "auto", "phases.ts");
+const src = readFileSync(srcPath, "utf-8");
+
+console.log("\n=== #2347: Worktree health check supports monorepos ===");
+
+// ── Test 1: The health check region exists ──────────────────────────────
+
+const healthCheckIdx = src.indexOf("Worktree health check");
+assertTrue(healthCheckIdx > 0, "auto/phases.ts has worktree health check section");
+
+const healthCheckRegion = src.slice(healthCheckIdx, healthCheckIdx + 2000);
+
+// ── Test 2: The check walks parent directories for project markers ──────
+
+// The fix should check parent directories for project files, not just s.basePath.
+// Look for patterns like: walking up directories, dirname, parent, or a helper
+// function that checks ancestors.
+const checksParentDirs =
+  healthCheckRegion.includes("dirname") ||
+  healthCheckRegion.includes("parent") ||
+  healthCheckRegion.includes("ancestor") ||
+  healthCheckRegion.includes("walk") ||
+  // Or a helper function that's called with the base path
+  /hasProjectFileInAncestor|findProjectRoot|checkParent/i.test(healthCheckRegion);
+
+assertTrue(
+  checksParentDirs,
+  "Health check should walk parent directories for project markers (monorepo support) (#2347)",
+);
+
+// ── Test 3: The greenfield warning should only trigger when no parent has markers ─
+
+// The original code was:
+//   const hasProjectFile = PROJECT_FILES.some((f) => deps.existsSync(join(s.basePath, f)));
+// The fix should check parents too, so the greenfield warning only fires
+// when NO ancestor directory has project markers either.
+const hasParentCheck = healthCheckRegion.includes("parent") ||
+  healthCheckRegion.includes("dirname") ||
+  /ancestor|walk.*up/i.test(healthCheckRegion);
+
+assertTrue(
+  hasParentCheck,
+  "Greenfield check should consider parent directories before warning (#2347)",
+);
+
+report();


### PR DESCRIPTION
## Summary
- The worktree health check in `auto/phases.ts` only checked for project markers (`package.json`, `Cargo.toml`, etc.) directly in `s.basePath`. In monorepos where these files live in a parent directory, the check falsely rejected the worktree as invalid.
- Now walks up parent directories (using `dirname`) until the filesystem root, looking for project markers before falling back to the greenfield warning.
- Added `dirname` and `parse` to the `node:path` import.

Fixes #2347

## Test plan
- [x] Added `worktree-health-monorepo.test.ts` verifying the parent-directory walk pattern exists in source
- [x] Existing `worktree-health.test.ts` still passes (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)