### PR TITLE
fix(auto): add timeout guard for postUnitPostVerification in runFinalize

### DIFF
--- a/src/resources/extensions/gsd/auto/finalize-timeout.ts
+++ b/src/resources/extensions/gsd/auto/finalize-timeout.ts
@@ -1,0 +1,46 @@
+/**
+ * auto/finalize-timeout.ts — Timeout guard for post-unit finalization.
+ *
+ * Prevents the auto-loop from hanging indefinitely when
+ * postUnitPostVerification() never resolves (#2344).
+ *
+ * Leaf module — no imports from auto/ to avoid circular dependencies.
+ */
+
+/** Timeout for postUnitPostVerification in runFinalize (ms). */
+export const FINALIZE_POST_TIMEOUT_MS = 60_000;
+
+/**
+ * Race a promise against a timeout. Returns an object indicating whether
+ * the timeout fired and the resolved value (if any).
+ *
+ * Unlike Promise.race with a rejection, this returns a discriminated
+ * result so callers can handle timeouts as a recoverable condition
+ * rather than an exception.
+ *
+ * The timeout timer is always cleaned up, whether the promise resolves
+ * or the timeout fires.
+ */
+export async function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  label: string,
+): Promise<{ value: T; timedOut: false } | { value: undefined; timedOut: true }> {
+  let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+
+  const timeoutPromise = new Promise<{ value: undefined; timedOut: true }>((resolve) => {
+    timeoutHandle = setTimeout(() => {
+      resolve({ value: undefined, timedOut: true });
+    }, timeoutMs);
+  });
+
+  try {
+    const result = await Promise.race([
+      promise.then((value) => ({ value, timedOut: false as const })),
+      timeoutPromise,
+    ]);
+    return result;
+  } finally {
+    if (timeoutHandle) clearTimeout(timeoutHandle);
+  }
+}

--- a/src/resources/extensions/gsd/auto/loop.ts
+++ b/src/resources/extensions/gsd/auto/loop.ts
@@ -256,6 +256,11 @@ export async function autoLoop(
       // ── Blanket catch: absorb unexpected exceptions, apply graduated recovery ──
       const msg = loopErr instanceof Error ? loopErr.message : String(loopErr);
 
+      // Always emit iteration-end on error so the journal records iteration
+      // completion even on failure (#2344). Without this, errors in
+      // runFinalize leave the journal incomplete, making diagnosis harder.
+      deps.emitJournalEvent({ ts: new Date().toISOString(), flowId, seq: nextSeq(), eventType: "iteration-end", data: { iteration, error: msg } });
+
       // ── Infrastructure errors: immediate stop, no retry ──
       // These are unrecoverable (disk full, OOM, etc.). Retrying just burns
       // LLM budget on guaranteed failures.

--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -27,6 +27,7 @@ import { debugLog } from "../debug-logger.js";
 import { gsdRoot } from "../paths.js";
 import { atomicWriteSync } from "../atomic-write.js";
 import { PROJECT_FILES } from "../detection.js";
+import { withTimeout, FINALIZE_POST_TIMEOUT_MS } from "./finalize-timeout.js";
 import { join } from "node:path";
 
 // ─── generateMilestoneReport ──────────────────────────────────────────────────
@@ -1246,7 +1247,30 @@ export async function runFinalize(
   }
 
   // Post-verification processing (DB dual-write, hooks, triage, quick-tasks)
-  const postResult = await deps.postUnitPostVerification(postUnitCtx);
+  // Timeout guard: if postUnitPostVerification hangs (e.g., module import
+  // deadlock, SQLite transaction hang), force-continue after timeout so the
+  // auto-loop is not permanently frozen (#2344).
+  const postResultGuard = await withTimeout(
+    deps.postUnitPostVerification(postUnitCtx),
+    FINALIZE_POST_TIMEOUT_MS,
+    "postUnitPostVerification",
+  );
+
+  if (postResultGuard.timedOut) {
+    debugLog("autoLoop", {
+      phase: "post-verification-timeout",
+      iteration: ic.iteration,
+      unitType: iterData.unitType,
+      unitId: iterData.unitId,
+    });
+    ctx.ui.notify(
+      `postUnitPostVerification timed out after ${FINALIZE_POST_TIMEOUT_MS / 1000}s for ${iterData.unitType} ${iterData.unitId} — continuing to next iteration`,
+      "warning",
+    );
+    return { action: "next", data: undefined as void };
+  }
+
+  const postResult = postResultGuard.value;
 
   if (postResult === "stopped") {
     debugLog("autoLoop", {

--- a/src/resources/extensions/gsd/tests/finalize-timeout-guard.test.ts
+++ b/src/resources/extensions/gsd/tests/finalize-timeout-guard.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Regression test for #2344: Auto-loop hangs after plan-slice completes
+ * because postUnitPostVerification() never resolves.
+ *
+ * When postUnitPostVerification() hangs (e.g., due to a module import
+ * deadlock or SQLite transaction hang), the auto-loop blocks forever
+ * with no error message, no notification, and no recovery.
+ *
+ * The fix adds a timeout guard around postUnitPostVerification() in
+ * runFinalize(). If it doesn't resolve within the timeout, the function
+ * force-returns "continue" and logs an error, allowing the loop to
+ * proceed to the next iteration.
+ *
+ * This test verifies the timeout utility used by the fix, since the
+ * full runFinalize function has too many transitive dependencies for
+ * isolated unit testing.
+ */
+
+import { createTestContext } from "./test-helpers.ts";
+import {
+  withTimeout,
+  FINALIZE_POST_TIMEOUT_MS,
+} from "../auto/finalize-timeout.ts";
+
+const { assertTrue, assertEq, report } = createTestContext();
+
+// ═══ Test: withTimeout resolves when inner promise resolves promptly ══════════
+
+{
+  console.log("\n=== #2344: withTimeout passes through when promise resolves ===");
+
+  const result = await withTimeout(
+    Promise.resolve("ok"),
+    1000,
+    "test-timeout",
+  );
+  assertEq(result.value, "ok", "should return inner value");
+  assertEq(result.timedOut, false, "should not be timed out");
+}
+
+// ═══ Test: withTimeout returns fallback when inner promise hangs ══════════════
+
+{
+  console.log("\n=== #2344: withTimeout returns fallback on hang ===");
+
+  const startTime = Date.now();
+  const result = await withTimeout(
+    new Promise<string>(() => {
+      // Never resolves
+    }),
+    100, // short timeout for testing
+    "test-timeout",
+  );
+  const elapsed = Date.now() - startTime;
+
+  assertEq(result.timedOut, true, "should report timeout");
+  assertEq(result.value, undefined, "value should be undefined on timeout");
+  assertTrue(elapsed >= 90, `should wait at least 90ms (took ${elapsed}ms)`);
+  assertTrue(elapsed < 500, `should not wait too long (took ${elapsed}ms)`);
+}
+
+// ═══ Test: withTimeout handles rejection gracefully ═══════════════════════════
+
+{
+  console.log("\n=== #2344: withTimeout propagates rejection ===");
+
+  let caught = false;
+  try {
+    await withTimeout(
+      Promise.reject(new Error("boom")),
+      1000,
+      "test-timeout",
+    );
+  } catch (err: any) {
+    caught = true;
+    assertEq(err.message, "boom", "should propagate the error");
+  }
+  assertTrue(caught, "rejection should propagate");
+}
+
+// ═══ Test: FINALIZE_POST_TIMEOUT_MS is defined and reasonable ═════════════════
+
+{
+  console.log("\n=== #2344: timeout constant is defined and reasonable ===");
+
+  assertTrue(
+    typeof FINALIZE_POST_TIMEOUT_MS === "number",
+    "FINALIZE_POST_TIMEOUT_MS should be a number",
+  );
+  assertTrue(
+    FINALIZE_POST_TIMEOUT_MS >= 30_000,
+    `timeout should be >= 30s (got ${FINALIZE_POST_TIMEOUT_MS}ms)`,
+  );
+  assertTrue(
+    FINALIZE_POST_TIMEOUT_MS <= 120_000,
+    `timeout should be <= 120s (got ${FINALIZE_POST_TIMEOUT_MS}ms)`,
+  );
+}
+
+// ═══ Test: withTimeout cleans up timer on success ════════════════════════════
+
+{
+  console.log("\n=== #2344: withTimeout cleans up timer on success ===");
+
+  // If the timer isn't cleaned up, this test would keep the process alive.
+  // Relying on process.exit behavior — if test completes, timers were cleaned.
+  const result = await withTimeout(
+    new Promise<string>((r) => setTimeout(() => r("delayed"), 50)),
+    5000,
+    "cleanup-test",
+  );
+  assertEq(result.value, "delayed", "should resolve with delayed value");
+  assertEq(result.timedOut, false, "should not time out");
+}
+
+report();


### PR DESCRIPTION
## Summary

- Add `withTimeout()` utility that races a promise against a timeout with a discriminated result type (no exception on timeout)
- Wrap `postUnitPostVerification()` in `runFinalize()` with a 60-second timeout guard so a hanging promise cannot freeze the auto-loop
- Emit `iteration-end` journal event in the `autoLoop()` catch block so every iteration is recorded, even on error

## Problem

After a `plan-slice` unit completes successfully, the auto-loop can hang indefinitely if `postUnitPostVerification()` never resolves. The terminal becomes completely unresponsive — no typing, no input — requiring Ctrl+C to recover. The root cause is an `await` on a promise that neither resolves nor rejects (e.g., due to a dynamic `import()` deadlock or SQLite transaction hang). The blanket `catch` in `autoLoop` handles throws but not a promise that simply never settles.

Forensic evidence from the issue showed `iteration-end` was never emitted, confirming the hang occurred inside `runFinalize()` after `postUnitPreVerification()` completed but before `runFinalize()` returned.

## Approach

Rather than auditing every possible hang point in `postUnitPostVerification()` (which has dynamic imports, DB writes, hook checks, triage, and capture resolution), a timeout guard provides a general safety net. If the function doesn't resolve within 60 seconds, the guard force-returns `"next"` with a warning notification, allowing the loop to proceed. The underlying hung promise becomes a detached fire-and-forget — it may eventually resolve or GC will collect it.

The `iteration-end` journal emission in the catch block is a separate observability improvement: previously, errors in the try block left the journal without an `iteration-end` event, making failure diagnosis harder.

## Test plan

- [x] New test `finalize-timeout-guard.test.ts` verifies the `withTimeout()` utility
  - Normal resolution passes through
  - Hanging promise triggers timeout with correct result shape
  - Rejection propagates (not swallowed)
  - Timer is cleaned up on success (no process leak)
  - Timeout constant is within expected range (30-120s)

Fixes #2344