### PR TITLE
fix(gsd): reconcile disk-only milestones into DB in deriveStateFromDb

### DIFF
--- a/src/resources/extensions/gsd/state.ts
+++ b/src/resources/extensions/gsd/state.ts
@@ -48,6 +48,7 @@ import {
   getSliceTasks,
   getReplanHistory,
   getSlice,
+  insertMilestone,
   type MilestoneRow,
   type SliceRow,
   type TaskRow,
@@ -257,7 +258,24 @@ function isStatusDone(status: string): boolean {
 export async function deriveStateFromDb(basePath: string): Promise<GSDState> {
   const requirements = parseRequirementCounts(await loadFile(resolveGsdRootFile(basePath, "REQUIREMENTS")));
 
-  const allMilestones = getAllMilestones();
+  let allMilestones = getAllMilestones();
+
+  // Incremental disk→DB sync: milestone directories created outside the DB
+  // write path (via /gsd queue, manual mkdir, or complete-milestone writing the
+  // next CONTEXT.md) are never inserted by the initial migration guard in
+  // auto-start.ts because that guard only runs when gsd.db doesn't exist yet.
+  // Reconcile here so deriveStateFromDb never silently misses queued milestones.
+  // insertMilestone uses INSERT OR IGNORE, so this is safe to call every time.
+  const dbIdSet = new Set(allMilestones.map(m => m.id));
+  const diskIds = findMilestoneIds(basePath);
+  let synced = false;
+  for (const diskId of diskIds) {
+    if (!dbIdSet.has(diskId) && !isGhostMilestone(basePath, diskId)) {
+      insertMilestone({ id: diskId, status: 'active' });
+      synced = true;
+    }
+  }
+  if (synced) allMilestones = getAllMilestones();
 
   // Parallel worker isolation: when locked, filter to just the locked milestone
   const milestoneLock = process.env.GSD_MILESTONE_LOCK;

--- a/src/resources/extensions/gsd/tests/derive-state-db.test.ts
+++ b/src/resources/extensions/gsd/tests/derive-state-db.test.ts
@@ -987,6 +987,43 @@ async function main(): Promise<void> {
     }
   }
 
+  // ─── Regression: disk-only milestones synced into DB (#2416) ─────────
+  // deriveStateFromDb() must reconcile milestone directories that exist on disk
+  // but have no DB row — created by /gsd queue or complete-milestone writing a
+  // next CONTEXT.md after the initial migration guard ran.
+  console.log('\n=== derive-state-db: disk-only milestone auto-synced into DB (#2416) ===');
+  {
+    const base = createFixtureBase();
+    try {
+      // M001 is complete and exists in DB. M002 was queued on disk only — no DB row.
+      writeFile(base, 'milestones/M001/M001-SUMMARY.md', '# M001 Summary\n\nDone.');
+      writeFile(base, 'milestones/M002/M002-CONTEXT.md', '# M002: Queued\n\nQueued milestone.');
+
+      openDatabase(':memory:');
+      // Only insert M001 — simulates the state after migration guard ran then /gsd queue added M002
+      insertMilestone({ id: 'M001', title: 'First', status: 'complete' });
+
+      invalidateStateCache();
+      const state = await deriveStateFromDb(base);
+
+      // Before the fix, M002 was invisible: getAllMilestones() returned only M001
+      // (complete) → phase='complete' → auto-mode stopped.
+      // After the fix, deriveStateFromDb reconciles disk dirs and inserts M002.
+      assertEq(state.phase, 'pre-planning', 'disk-sync-2416: phase is pre-planning, not complete');
+      assertEq(state.registry.length, 2, 'disk-sync-2416: both milestones visible in registry');
+      assertEq(state.registry[0]?.id, 'M001', 'disk-sync-2416: registry[0] is M001');
+      assertEq(state.registry[0]?.status, 'complete', 'disk-sync-2416: M001 is complete');
+      assertEq(state.registry[1]?.id, 'M002', 'disk-sync-2416: registry[1] is M002');
+      assertEq(state.registry[1]?.status, 'active', 'disk-sync-2416: M002 is active');
+      assertEq(state.activeMilestone?.id, 'M002', 'disk-sync-2416: activeMilestone is M002');
+
+      closeDatabase();
+    } finally {
+      closeDatabase();
+      cleanup(base);
+    }
+  }
+
   report();
 }
 


### PR DESCRIPTION
## TL;DR

**What:** `deriveStateFromDb()` now reconciles milestone directories that exist on disk but have no DB row before iterating.
**Why:** Milestones created via `/gsd queue` are never inserted into the DB, making them invisible to the state machine and causing premature `phase='complete'`.
**How:** Incremental disk→DB sync using existing `findMilestoneIds()` + `insertMilestone()` (INSERT OR IGNORE) at the top of `deriveStateFromDb()`.

## What

Two files changed:
- `src/resources/extensions/gsd/state.ts` — adds disk→DB reconciliation in `deriveStateFromDb()` and imports `insertMilestone`
- `src/resources/extensions/gsd/tests/derive-state-db.test.ts` — regression test reproducing the exact scenario from #2416

## Why

The migration guard in `auto-start.ts` only runs `migrateFromMarkdown()` when `gsd.db` does not yet exist (`!existsSync(gsdDbPath)`). Milestones created after that point — via `/gsd queue`, manual directory creation, or `complete-milestone` writing a next CONTEXT.md — are never inserted into the DB.

`deriveStateFromDb()` called `getAllMilestones()` (DB-only query) with no disk fallback. When all DB-tracked milestones completed, `phase='complete'` fired and auto-mode stopped, even though queued milestones existed on disk with CONTEXT.md files.

Closes #2416

## How

Inside `deriveStateFromDb()`, immediately after `getAllMilestones()`:

1. Call `findMilestoneIds(basePath)` to get all milestone directories on disk
2. Build a `Set` of known DB IDs
3. For each disk ID not in the set: skip ghost directories (no substantive files), otherwise call `insertMilestone({ id, status: 'active' })` — `INSERT OR IGNORE` makes this idempotent
4. Re-query `getAllMilestones()` only if rows were inserted (happy path has zero overhead)

Both `findMilestoneIds` and `isGhostMilestone` were already in scope. Only `insertMilestone` needed to be added to the import.

The regression test confirms: M001 complete in DB, M002 queued on disk only → before fix `phase='complete'`, after fix `phase='pre-planning'` with both milestones visible in the registry.

## Change type

- [x] `fix` — Bug fix

## Notes

This is a safety-net fix at the state derivation layer. The deeper root cause — that `/gsd queue` writes CONTEXT.md without calling `insertMilestone()` — is a separate concern requiring a prompt/tool change and will be tracked separately. Additional DB sync gaps identified during analysis (worktree reconciliation missing milestone/slice/task tables, `"complete → stop"` dispatch rule lacking disk cross-check) are also out of scope for this PR per the one-concern rule.

> AI-assisted: this PR was researched and implemented with AI assistance. The fix, test, and root cause analysis were verified against the codebase.