### PR TITLE
fix(gsd): skip doctor directory checks for pending slices

### DIFF
--- a/src/resources/extensions/gsd/doctor.ts
+++ b/src/resources/extensions/gsd/doctor.ts
@@ -470,7 +470,7 @@ export async function runGSDDoctor(basePath: string, options?: { fix?: boolean; 
     if (!roadmapContent) continue;
 
     // Normalize slices: prefer DB, fall back to parser
-    type NormSlice = RoadmapSliceEntry;
+    type NormSlice = RoadmapSliceEntry & { pending?: boolean };
     let slices: NormSlice[];
     if (isDbAvailable()) {
       const dbSlices = getMilestoneSlices(milestoneId);
@@ -478,6 +478,7 @@ export async function runGSDDoctor(basePath: string, options?: { fix?: boolean; 
         id: s.id,
         title: s.title,
         done: s.status === "complete",
+        pending: s.status === "pending",
         risk: (s.risk || "medium") as RoadmapSliceEntry["risk"],
         depends: s.depends,
         demo: s.demo,
@@ -564,6 +565,9 @@ export async function runGSDDoctor(basePath: string, options?: { fix?: boolean; 
 
       const slicePath = resolveSlicePath(basePath, milestoneId, slice.id);
       if (!slicePath) {
+        // Pending slices haven't been planned yet — directories are created
+        // lazily by ensurePreconditions() at dispatch time. Skip them.
+        if (slice.pending) continue;
         const expectedPath = relSlicePath(basePath, milestoneId, slice.id);
         issues.push({
           severity: slice.done ? "warning" : "error",
@@ -586,6 +590,8 @@ export async function runGSDDoctor(basePath: string, options?: { fix?: boolean; 
 
       const tasksDir = resolveTasksDir(basePath, milestoneId, slice.id);
       if (!tasksDir) {
+        // Pending slices haven't been planned yet — tasks/ is created on demand.
+        if (slice.pending) continue;
         issues.push({
           severity: slice.done ? "warning" : "error",
           code: "missing_tasks_dir",


### PR DESCRIPTION
## Summary

- Preserves DB `status` field in doctor's slice mapping (adds `pending` boolean alongside existing `done`)
- Skips `missing_slice_dir` and `missing_tasks_dir` checks entirely for slices with `status: "pending"`
- Directories for unplanned slices are created lazily by `ensurePreconditions()` at dispatch time — their absence is expected, not broken

Closes #2446

## Root Cause

`plan-milestone` inserts all slices with `status: "pending"`, but doctor mapped status to a binary `done: boolean`, collapsing `pending` into the same bucket as `active`. This caused false ERROR severity for slices that haven't been planned yet.

## Test plan

- [x] TypeScript compiles clean (`tsc --noEmit`)
- [x] Existing doctor tests pass (`doctor-fixlevel.test.ts`)
- [ ] Manual: run `plan-milestone` for a new milestone, verify post-unit doctor produces no `missing_slice_dir`/`missing_tasks_dir` errors for unplanned slices
- [ ] Verify `active` slices (planned but not complete) still get ERROR severity when directories are missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)