### PR TITLE
fix(gsd): widen test search window for CRLF portability on Windows

### DIFF
--- a/src/resources/extensions/gsd/tests/completed-units-metrics-sync.test.ts
+++ b/src/resources/extensions/gsd/tests/completed-units-metrics-sync.test.ts
@@ -26,16 +26,17 @@ test("#2313: completed-units.json should not be blindly wiped to [] on milestone
   const completedUnitsIdx = phasesSrc.indexOf("completed-units", transitionIdx);
   assert.ok(completedUnitsIdx !== -1, "completed-units handling exists in transition");
 
-  // Get a window around the completed-units handling
-  const windowStart = Math.max(0, completedUnitsIdx - 200);
-  const windowEnd = Math.min(phasesSrc.length, completedUnitsIdx + 500);
-  const window = phasesSrc.slice(windowStart, windowEnd);
+  // Get a window around the completed-units handling (1200 chars to
+  // accommodate CRLF line endings on Windows which inflate byte offsets).
+  const windowStart = Math.max(0, completedUnitsIdx - 300);
+  const windowEnd = Math.min(phasesSrc.length, completedUnitsIdx + 900);
+  const window = phasesSrc.slice(windowStart, windowEnd).toLowerCase();
 
   // Should archive/rename the old file before resetting
   const hasArchive = window.includes("archive") ||
     window.includes("rename") ||
-    window.includes("cpSync") ||
-    window.includes("safeCopy") ||
+    window.includes("cpsync") ||
+    window.includes("safecopy") ||
     window.includes("completed-units-");
 
   assert.ok(


### PR DESCRIPTION
## Summary
- The `completed-units-metrics-sync` test scans `phases.ts` source code in a character window to verify archive keywords exist near the milestone transition block
- On Windows, CRLF line endings inflate byte offsets, causing the 700-char window to cut off 2 characters before the `archivePath` variable — missing the lowercase "archive" match
- Widens the window from 700 to 1200 chars and lowercases both the window and search terms for case-insensitive matching

## Test plan
- [x] Local test passes with LF
- [x] Simulated CRLF scenario passes (verified with Node script)
- [ ] CI windows-portability job goes green

🤖 Generated with [Claude Code](https://claude.com/claude-code)