### PR TITLE
fix(gsd): handle retentionDays=0 on Windows + run windows-portability on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,8 +145,7 @@ jobs:
     timeout-minutes: 15
     needs: detect-changes
     if: >-
-      needs.detect-changes.outputs.docs-only != 'true' &&
-      github.event_name == 'push' && github.ref == 'refs/heads/main'
+      needs.detect-changes.outputs.docs-only != 'true'
     runs-on: blacksmith-4vcpu-windows-2025
 
     steps:

--- a/src/resources/extensions/gsd/activity-log.ts
+++ b/src/resources/extensions/gsd/activity-log.ts
@@ -153,6 +153,7 @@ export function pruneActivityLogs(activityDir: string, retentionDays: number): v
     const cutoff = Date.now() - retentionDays * 86_400_000;
     for (const entry of entries) {
       if (entry.seq === maxSeq) continue;  // always preserve highest-seq
+      if (retentionDays === 0) { try { unlinkSync(entry.filePath); } catch { /* skip */ } continue; }
       try {
         const mtime = statSync(entry.filePath).mtimeMs;
         if (Math.floor(mtime) <= cutoff) unlinkSync(entry.filePath);


### PR DESCRIPTION
## Summary
- `pruneActivityLogs` with `retentionDays=0` failed on Windows because NTFS timestamp resolution meant freshly-created files had `mtime >= cutoff`, so the `<=` comparison never triggered. Added a fast path: when `retentionDays` is 0, skip mtime checks entirely and prune all non-highest-seq files unconditionally.
- Removed the `push && refs/heads/main` gate on the `windows-portability` CI job so it runs on PRs too — no more merging blind and discovering failures on main.

## Test plan
- [x] All 11 activity-log tests pass locally
- [ ] CI windows-portability job passes on this PR (first time it'll run on a PR!)

🤖 Generated with [Claude Code](https://claude.com/claude-code)