### PR TITLE
fix(ci): retry npm install in pipeline for registry propagation

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -81,8 +81,15 @@ jobs:
           registry-url: https://registry.npmjs.org
           cache: 'npm'
 
-      - name: Install gsd-pi@dev globally
-        run: npm install -g gsd-pi@dev
+      - name: Install gsd-pi@dev globally (with registry propagation retry)
+        run: |
+          for i in 1 2 3 4 5 6; do
+            npm install -g gsd-pi@dev && exit 0
+            echo "Attempt $i failed — waiting 10s for npm registry propagation..."
+            sleep 10
+          done
+          echo "Failed to install gsd-pi@dev after 6 attempts"
+          exit 1
 
       - name: Run smoke tests (against installed binary)
         run: |


### PR DESCRIPTION
## Summary
- Dev Publish succeeded but Test & Verify failed because npm's CDN hadn't propagated `2.45.0-dev.6b9da3e` yet
- Adds a retry loop (6 attempts, 10s apart = up to 60s tolerance) on `npm install -g gsd-pi@dev`

## Test plan
- [x] Re-ran the failed pipeline run — passes now that the package is available
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)