### PR TITLE
fix(ci): add pretest typecheck gate to prevent silent type drift

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "test:marketplace": "GSD_TEST_CLONE_MARKETPLACES=1 node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/claude-import-tui.test.ts src/resources/extensions/gsd/tests/plugin-importer-live.test.ts src/tests/marketplace-discovery.test.ts",
     "test:coverage": "c8 --reporter=text --reporter=lcov --exclude='src/resources/extensions/gsd/tests/**' --exclude='src/tests/**' --exclude='scripts/**' --exclude='native/**' --exclude='node_modules/**' --check-coverage --statements=50 --lines=50 --branches=20 --functions=20 node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --experimental-test-isolation=process --test src/resources/extensions/gsd/tests/*.test.ts src/resources/extensions/gsd/tests/*.test.mjs src/tests/*.test.ts",
     "test:integration": "node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --experimental-test-isolation=process --test src/resources/extensions/gsd/tests/*integration*.test.ts src/tests/integration/*.test.ts",
+    "pretest": "npm run typecheck:extensions",
     "test": "npm run test:unit && npm run test:integration",
     "test:smoke": "node --experimental-strip-types tests/smoke/run.ts",
     "test:fixtures": "node --experimental-strip-types tests/fixtures/run.ts",


### PR DESCRIPTION
## Summary
- Adds `typecheck:extensions` as a `pretest` script in package.json
- Extension tests use `node --test` with `--experimental-strip-types` which skips type-checking entirely, so type errors accumulate silently until CI runs `tsc --noEmit --project tsconfig.extensions.json`
- This gate catches drift locally before it reaches CI

## Change
One line in `package.json`: `"pretest": "npm run typecheck:extensions"`

## Test plan
- [x] `tsc --noEmit --project tsconfig.extensions.json` passes clean on main
- [ ] CI build + typecheck passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)