### PR TITLE
fix: reconcile stale task DB status from disk artifacts (#2514)

### DIFF
--- a/src/resources/extensions/gsd/state.ts
+++ b/src/resources/extensions/gsd/state.ts
@@ -49,6 +49,7 @@ import {
   getReplanHistory,
   getSlice,
   insertMilestone,
+  updateTaskStatus,
   type MilestoneRow,
   type SliceRow,
   type TaskRow,
@@ -629,7 +630,38 @@ export async function deriveStateFromDb(basePath: string): Promise<GSDState> {
   }
 
   // ── Get tasks from DB ────────────────────────────────────────────────
-  const tasks = getSliceTasks(activeMilestone.id, activeSlice.id);
+  let tasks = getSliceTasks(activeMilestone.id, activeSlice.id);
+
+  // ── Reconcile stale task status (#2514) ──────────────────────────────
+  // When a session disconnects after the agent writes SUMMARY + VERIFY
+  // artifacts but before postUnitPostVerification updates the DB, tasks
+  // remain "pending" in the DB despite being complete on disk. Without
+  // reconciliation, deriveState keeps returning the stale task as active,
+  // causing the dispatcher to re-dispatch the same completed task forever.
+  let reconciled = false;
+  for (const t of tasks) {
+    if (isStatusDone(t.status)) continue;
+    const summaryPath = resolveTaskFile(basePath, activeMilestone.id, activeSlice.id, t.id, "SUMMARY");
+    if (summaryPath && existsSync(summaryPath)) {
+      try {
+        updateTaskStatus(activeMilestone.id, activeSlice.id, t.id, "complete");
+        process.stderr.write(
+          `gsd-reconcile: task ${activeMilestone.id}/${activeSlice.id}/${t.id} had SUMMARY on disk but DB status was "${t.status}" — updated to "complete" (#2514)\n`,
+        );
+        reconciled = true;
+      } catch (e) {
+        // DB write failed — continue with stale status rather than crash
+        process.stderr.write(
+          `gsd-reconcile: failed to update task ${t.id}: ${(e as Error).message}\n`,
+        );
+      }
+    }
+  }
+  // Re-fetch tasks if any were reconciled so downstream logic sees fresh status
+  if (reconciled) {
+    tasks = getSliceTasks(activeMilestone.id, activeSlice.id);
+  }
+
   const taskProgress = {
     done: tasks.filter(t => isStatusDone(t.status)).length,
     total: tasks.length,


### PR DESCRIPTION
## TL;DR

**What:** Add reconciliation pass in `deriveStateFromDb()` to auto-fix tasks stuck as "pending" in DB when SUMMARY exists on disk.
**Why:** Session disconnect after agent writes artifacts but before DB update causes infinite re-dispatch of completed tasks (#2514).
**How:** Check each non-done task for a SUMMARY file on disk before selecting active task; if found, update DB to "complete" and log to stderr.

## What

One file changed: `src/resources/extensions/gsd/state.ts`
- 1 import added: `updateTaskStatus` from `gsd-db.js`
- 33 lines added: reconciliation loop between `getSliceTasks()` and active task selection
- Zero behavioral change for tasks already in sync

## Why

When a session disconnects after the agent writes `T{N}-SUMMARY.md` + `T{N}-VERIFY.json` but before `postUnitPostVerification` updates the DB, tasks remain `"pending"` in DB despite being complete on disk.

`deriveStateFromDb()` returns the stale task as `activeTask`, causing the dispatcher to re-dispatch the same completed task in an infinite loop. The user must manually edit runtime JSON files to unblock progress.

Fixes #2514

## How

Added a reconciliation pass in `deriveStateFromDb()` (~line 632) that runs **before** selecting the active task:

1. Iterate all non-done tasks from `getSliceTasks()`
2. For each, check if `resolveTaskFile(SUMMARY)` exists on disk
3. If SUMMARY exists → call `updateTaskStatus("complete")` and log to stderr
4. Re-fetch tasks after reconciliation so downstream logic sees fresh status

**Why in `deriveState` and not elsewhere:**
- `auto-start.ts`: Only runs once at session boot — does not catch mid-session disconnects
- `postUnitPreVerification`: This is the code that _fails to run_ when the session disconnects
- `deriveState`: Runs on every dispatch cycle — guaranteed to catch stale state before task selection

**Observability:** Reconciliation events logged to stderr:
```
gsd-reconcile: task M010/S01/T01 had SUMMARY on disk but DB status was "pending" — updated to "complete" (#2514)
```

Reported by @ahwlsqja