### PR TITLE
ci(test): wire packages/pi-coding-agent tests into CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,6 +139,9 @@ jobs:
       - name: Run unit tests
         run: npm run test:unit
 
+      - name: Run package tests
+        run: npm run test:packages
+
       - name: Run integration tests
         run: npm run test:integration
 
@@ -171,3 +174,6 @@ jobs:
 
       - name: Run unit tests
         run: npm run test:unit
+
+      - name: Run package tests
+        run: npm run test:packages

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "copy-themes": "node scripts/copy-themes.cjs",
     "copy-export-html": "node scripts/copy-export-html.cjs",
     "test:unit": "node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --experimental-test-isolation=process --test src/resources/extensions/gsd/tests/*.test.ts src/resources/extensions/gsd/tests/*.test.mjs src/tests/*.test.ts",
+    "test:packages": "node --test packages/pi-coding-agent/dist/core/*.test.js",
     "test:marketplace": "GSD_TEST_CLONE_MARKETPLACES=1 node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/claude-import-tui.test.ts src/resources/extensions/gsd/tests/plugin-importer-live.test.ts src/tests/marketplace-discovery.test.ts",
     "test:coverage": "c8 --reporter=text --reporter=lcov --exclude='src/resources/extensions/gsd/tests/**' --exclude='src/tests/**' --exclude='scripts/**' --exclude='native/**' --exclude='node_modules/**' --check-coverage --statements=50 --lines=50 --branches=20 --functions=20 node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --experimental-test-isolation=process --test src/resources/extensions/gsd/tests/*.test.ts src/resources/extensions/gsd/tests/*.test.mjs src/tests/*.test.ts",
     "test:integration": "node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --experimental-test-isolation=process --test src/resources/extensions/gsd/tests/*integration*.test.ts src/tests/integration/*.test.ts",

--- a/packages/pi-coding-agent/src/core/auth-storage.test.ts
+++ b/packages/pi-coding-agent/src/core/auth-storage.test.ts
@@ -266,7 +266,7 @@ describe("AuthStorage — areAllCredentialsBackedOff", () => {
 // ─── mismatched oauth credential for non-OAuth provider (#2083) ───────────────
 
 describe("AuthStorage — oauth credential for non-OAuth provider (#2083)", () => {
-	it("returns undefined when openrouter has type:oauth (no registered OAuth provider)", async () => {
+	it("returns undefined when openrouter has type:oauth (no registered OAuth provider)", async (t) => {
 		// Simulates the bug: OpenRouter credential stored as type:"oauth"
 		// but OpenRouter is not a registered OAuth provider.
 		const storage = inMemory({
@@ -278,12 +278,25 @@ describe("AuthStorage — oauth credential for non-OAuth provider (#2083)", () =
 			},
 		});
 
+		// Isolate from any real OPENROUTER_API_KEY in the environment so the
+		// fall-through to env / fallback finds nothing and returns undefined.
+		const origEnv = process.env.OPENROUTER_API_KEY;
+		delete process.env.OPENROUTER_API_KEY;
+		t.after(() => {
+			if (origEnv === undefined) {
+				delete process.env.OPENROUTER_API_KEY;
+			} else {
+				process.env.OPENROUTER_API_KEY = origEnv;
+			}
+		});
+
 		// Before the fix, getApiKey returns undefined because
 		// resolveCredentialApiKey calls getOAuthProvider("openrouter") → null → undefined.
 		// The key in the oauth credential is never extracted.
 		const key = await storage.getApiKey("openrouter");
 		// After the fix, the oauth credential with an unrecognised provider
 		// should be skipped, and getApiKey should fall through to env / fallback.
+		// With no env var and no fallback resolver configured, the result is undefined.
 		assert.equal(key, undefined);
 	});
 
@@ -312,7 +325,7 @@ describe("AuthStorage — oauth credential for non-OAuth provider (#2083)", () =
 		assert.equal(key, "sk-or-v1-env-key");
 	});
 
-	it("falls through to fallback resolver when openrouter has type:oauth credential", async () => {
+	it("falls through to fallback resolver when openrouter has type:oauth credential", async (t) => {
 		const storage = inMemory({
 			openrouter: {
 				type: "oauth",
@@ -320,6 +333,18 @@ describe("AuthStorage — oauth credential for non-OAuth provider (#2083)", () =
 				refresh_token: "rt-fake",
 				expires: Date.now() + 3_600_000,
 			},
+		});
+
+		// Isolate from any real OPENROUTER_API_KEY so env fallback is skipped
+		// and the fallback resolver is reached.
+		const origEnv = process.env.OPENROUTER_API_KEY;
+		delete process.env.OPENROUTER_API_KEY;
+		t.after(() => {
+			if (origEnv === undefined) {
+				delete process.env.OPENROUTER_API_KEY;
+			} else {
+				process.env.OPENROUTER_API_KEY = origEnv;
+			}
 		});
 
 		storage.setFallbackResolver((provider) =>


### PR DESCRIPTION
## TL;DR

13 test files in `packages/pi-coding-agent/src/core/` were never executed — by CI or by `npm test`. This adds a `test:packages` script and wires it into both CI jobs. Also fixes two env-isolation bugs found when running those tests for the first time.

## What

- Add `test:packages` script in `package.json` that runs the compiled dist tests: `node --test packages/pi-coding-agent/dist/core/*.test.js`
- Add "Run package tests" step to the `build` CI job (after unit tests, before integration tests)
- Add "Run package tests" step to the `windows-portability` CI job
- Fix `auth-storage.test.ts`: two tests in the `#2083` oauth suite did not clear `OPENROUTER_API_KEY` before calling `getApiKey`, causing failures in environments where that env var is set

## Why

The `test:unit` glob only covers `src/resources/extensions/gsd/tests/` and `src/tests/`. The package tests in `packages/pi-coding-agent/src/core/*.test.ts` use TypeScript parameter property syntax (`private readonly x: T`) that Node's strip-only transpiler can't handle, so they must run against the compiled `dist/` output. The `build` step already produces `dist/` before tests run in CI, making this a natural insertion point.

The `auth-storage.test.ts` env-isolation bug was latent since PR #2452 — tests 1 and 3 of the `#2083` suite assumed `OPENROUTER_API_KEY` was unset, but didn't enforce it. Test 2 already used the correct save/restore pattern; tests 1 and 3 now follow the same pattern.

## How

- `test:packages` runs `node --test packages/pi-coding-agent/dist/core/*.test.js` — no special loader needed since these are compiled JS
- CI inserts the new step after `npm run test:unit` in both jobs; `npm run build` earlier in the job ensures `dist/` is fresh
- Env isolation fix: `delete process.env.OPENROUTER_API_KEY` before the assertion + `t.after()` restore, matching the pattern in the passing test

## Change type checklist

- [ ] `feat`
- [x] `fix` — env isolation bug in auth-storage tests
- [ ] `refactor`
- [ ] `test`
- [ ] `docs`
- [x] `chore` — CI and test script wiring

## Testing

```
npm run test:packages   # 185 tests, 185 pass, 0 fail
npm run test:unit       # 3812 tests, 3807 pass, 5 intentional skips, 0 fail
```

> AI assistance used in authoring this PR.