### PR TITLE
ci(issues): prompt upgrade when bug report GSD version is outdated

### DIFF
--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -1,0 +1,113 @@
+name: Version Check
+
+on:
+  issues:
+    types: [opened, edited]
+
+permissions:
+  issues: write
+
+jobs:
+  check-version:
+    # Only run on bug reports (they have the "GSD version" field)
+    if: contains(github.event.issue.body, 'GSD version')
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+      - name: Check GSD version and comment if outdated
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = context.payload.issue.body || '';
+            const issueNumber = context.payload.issue.number;
+
+            // Parse the version from the issue body.
+            // GitHub issue forms render field labels as "### GSD version\n\n<value>"
+            const match = body.match(/###\s+GSD version\s*\n+\s*([^\s\n]+)/i);
+            if (!match) {
+              core.info('Could not find a GSD version value in the issue body — skipping.');
+              return;
+            }
+
+            const reportedVersion = match[1].trim().replace(/^v/, '');
+            core.info(`Reported version: ${reportedVersion}`);
+
+            // Fetch the latest published version from npm
+            const npmResponse = await fetch('https://registry.npmjs.org/gsd-pi/latest');
+            if (!npmResponse.ok) {
+              core.setFailed(`npm registry request failed: ${npmResponse.status}`);
+              return;
+            }
+            const npmData = await npmResponse.json();
+            const latestVersion = npmData.version;
+            core.info(`Latest version: ${latestVersion}`);
+
+            // Semver comparison (major.minor.patch — no pre-release handling needed)
+            function parseVersion(v) {
+              const parts = v.replace(/^v/, '').split('.').map(Number);
+              return [parts[0] || 0, parts[1] || 0, parts[2] || 0];
+            }
+
+            function isOutdated(reported, latest) {
+              const [rMaj, rMin, rPat] = parseVersion(reported);
+              const [lMaj, lMin, lPat] = parseVersion(latest);
+              if (rMaj !== lMaj) return rMaj < lMaj;
+              if (rMin !== lMin) return rMin < lMin;
+              return rPat < lPat;
+            }
+
+            if (!isOutdated(reportedVersion, latestVersion)) {
+              core.info(`Version ${reportedVersion} is current — no comment needed.`);
+              return;
+            }
+
+            // Check if we've already posted this comment to avoid duplicates on edits
+            const comments = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+            });
+
+            const botMarker = '<!-- gsd-version-check -->';
+            const alreadyCommented = comments.data.some(c =>
+              c.user.type === 'Bot' && c.body.includes(botMarker)
+            );
+
+            if (alreadyCommented) {
+              core.info('Version check comment already posted — skipping duplicate.');
+              return;
+            }
+
+            const comment = `${botMarker}
+👋 Thanks for filing this bug report!
+
+It looks like you're running **GSD v${reportedVersion}**, but the latest release is **v${latestVersion}**.
+
+Before we investigate further, please upgrade and check whether the issue still occurs:
+
+\`\`\`bash
+npm install -g gsd-pi@latest
+gsd --version   # should print ${latestVersion}
+\`\`\`
+
+Then re-run your reproduction steps. If the problem persists on **v${latestVersion}**, please update the **GSD version** field in this issue and let us know.
+
+> **Why?** Many bugs are fixed in subsequent releases. Confirming on the latest version keeps the team focused on real, current issues.
+
+---
+*This is an automated check. If you're intentionally pinned to an older version, feel free to explain why and we'll continue from there.*`;
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              body: comment,
+            });
+
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              labels: ['needs-upgrade'],
+            });
+
+            core.info(`Posted upgrade prompt for v${reportedVersion} → v${latestVersion}`);


### PR DESCRIPTION
## TL;DR

Adds a GitHub Actions workflow that auto-comments on bug reports filed against an outdated GSD version, giving the reporter the exact upgrade command and asking them to re-test before the team investigates.

---

## What

New workflow: `.github/workflows/version-check.yml`

- Triggers on `issues: [opened, edited]`
- Skips any issue that doesn't contain a "GSD version" field (non-bug-report issues)
- Parses the version from the `### GSD version` block rendered by the bug report form
- Fetches the latest published version from `registry.npmjs.org/gsd-pi/latest` (no auth required)
- Inline semver comparison (major.minor.patch)
- If outdated: posts a friendly comment with `npm install -g gsd-pi@latest` and applies a `needs-upgrade` label
- Deduplicates: a hidden `<!-- gsd-version-check -->` marker prevents re-posting the same comment on subsequent edits

## Why

Bug reports filed against old versions waste maintainer time. Many issues are already fixed by the time they're reported. This surfaces the problem immediately at triage time and moves the "have you tried the latest?" conversation to automation.

## How

No new secrets or external actions — follows the same `actions/github-script@v7` pattern as `ai-triage.yml`. Reads from the public npm registry via `fetch`. The `needs-upgrade` label will need to be created once in the repo's Labels page.

---

## Change type

- [ ] feat
- [x] ci
- [ ] fix
- [ ] refactor
- [ ] docs
- [ ] chore

## Breaking changes

None.

## Checklist

- [x] Branch based on `upstream/main`
- [x] Commit follows Conventional Commits format
- [x] No unrelated file changes
- [x] AI assistance disclosed (Claude Code)