### PR TITLE
fix(ci): update FILE-SYSTEM-MAP.md path in pr-risk-check

### DIFF
--- a/scripts/pr-risk-check.mjs
+++ b/scripts/pr-risk-check.mjs
@@ -20,7 +20,7 @@ import { createInterface } from 'readline';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(__dirname, '..');
-const MAP_PATH = resolve(REPO_ROOT, 'docs/FILE-SYSTEM-MAP.md');
+const MAP_PATH = resolve(REPO_ROOT, 'docs-internal/FILE-SYSTEM-MAP.md');
 
 // ---------------------------------------------------------------------------
 // Risk tier definitions


### PR DESCRIPTION
## Summary
- The Mintlify docs migration moved `docs/` → `docs-internal/` but `scripts/pr-risk-check.mjs` still referenced `docs/FILE-SYSTEM-MAP.md`
- Every PR Risk Report workflow has been failing with `Missing comment 'body'` because the script errors out and produces an empty report
- One-line path fix

## Test plan
- [ ] PR Risk Report workflow passes on this PR itself (self-validating)

🤖 Generated with [Claude Code](https://claude.com/claude-code)