### PR TITLE
fix(gsd): clear stale milestone ID reservations at session start

### DIFF
--- a/src/resources/extensions/gsd/guided-flow.ts
+++ b/src/resources/extensions/gsd/guided-flow.ts
@@ -35,7 +35,7 @@ import { showProjectInit, offerMigration } from "./init-wizard.js";
 import { validateDirectory } from "./validate-directory.js";
 import { showConfirm } from "../shared/tui.js";
 import { debugLog } from "./debug-logger.js";
-import { findMilestoneIds, nextMilestoneId, reserveMilestoneId, getReservedMilestoneIds } from "./milestone-ids.js";
+import { findMilestoneIds, nextMilestoneId, reserveMilestoneId, getReservedMilestoneIds, clearReservedMilestoneIds } from "./milestone-ids.js";
 import { parkMilestone, discardMilestone } from "./milestone-actions.js";
 import { resolveModelWithFallbacksForUnit } from "./preferences-models.js";
 
@@ -373,6 +373,9 @@ export async function showHeadlessMilestoneCreation(
   basePath: string,
   seedContext: string,
 ): Promise<void> {
+  // Clear stale reservations from previous cancelled sessions (#2488)
+  clearReservedMilestoneIds();
+
   // Ensure .gsd/ is bootstrapped
   bootstrapGsdProject(basePath);
 
@@ -841,6 +844,11 @@ export async function showSmartEntry(
   options?: { step?: boolean },
 ): Promise<void> {
   const stepMode = options?.step;
+
+  // ── Clear stale milestone ID reservations from previous cancelled sessions ──
+  // Reservations only need to survive within a single /gsd interaction.
+  // Without this, each cancelled session permanently bumps the next ID. (#2488)
+  clearReservedMilestoneIds();
 
   // ── Directory safety check — refuse to operate in system/home dirs ───
   const dirCheck = validateDirectory(basePath);

--- a/src/resources/extensions/gsd/tests/stale-milestone-id-reservation.test.ts
+++ b/src/resources/extensions/gsd/tests/stale-milestone-id-reservation.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Regression test for #2488: Stale milestone ID reservations inflate next ID
+ * after cancelled /gsd sessions.
+ *
+ * The module-level `reservedMilestoneIds` Set persists across /gsd invocations
+ * within the same Node process. Without clearReservedMilestoneIds() at session
+ * start, each cancelled session permanently bumps the counter by 1.
+ */
+import { describe, test, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  nextMilestoneId,
+  reserveMilestoneId,
+  getReservedMilestoneIds,
+  clearReservedMilestoneIds,
+} from "../milestone-ids.ts";
+
+describe("stale milestone ID reservation cleanup (#2488)", () => {
+  beforeEach(() => {
+    clearReservedMilestoneIds();
+  });
+
+  test("without cleanup, cancelled sessions inflate the next ID", () => {
+    const diskIds = ["M001", "M002", "M003"];
+
+    // Session 1: user starts /gsd, ID is previewed and reserved, then cancelled
+    const allIds1 = [...new Set([...diskIds, ...getReservedMilestoneIds()])];
+    const preview1 = nextMilestoneId(allIds1);
+    reserveMilestoneId(preview1);
+    assert.equal(preview1, "M004");
+
+    // Session 2: user starts /gsd again — stale reservation still in Set
+    // WITHOUT clearing, the next ID skips M004 (reserved) and goes to M005
+    const allIds2 = [...new Set([...diskIds, ...getReservedMilestoneIds()])];
+    const preview2 = nextMilestoneId(allIds2);
+    assert.equal(preview2, "M005", "without cleanup, ID inflates to M005");
+  });
+
+  test("with cleanup at session start, next ID is correct", () => {
+    const diskIds = ["M001", "M002", "M003"];
+
+    // Session 1: user starts /gsd, ID is previewed and reserved, then cancelled
+    const allIds1 = [...new Set([...diskIds, ...getReservedMilestoneIds()])];
+    const preview1 = nextMilestoneId(allIds1);
+    reserveMilestoneId(preview1);
+    assert.equal(preview1, "M004");
+
+    // Session 2: clear stale reservations first (the fix)
+    clearReservedMilestoneIds();
+
+    // Now the next ID correctly returns M004 again
+    const allIds2 = [...new Set([...diskIds, ...getReservedMilestoneIds()])];
+    const preview2 = nextMilestoneId(allIds2);
+    assert.equal(preview2, "M004", "after cleanup, ID is correctly M004");
+  });
+
+  test("multiple cancelled sessions compound the inflation without cleanup", () => {
+    const diskIds = ["M001", "M002", "M003"];
+
+    // 3 cancelled sessions without cleanup
+    for (let i = 0; i < 3; i++) {
+      const allIds = [...new Set([...diskIds, ...getReservedMilestoneIds()])];
+      const preview = nextMilestoneId(allIds);
+      reserveMilestoneId(preview);
+    }
+
+    // Without cleanup, we're now at M007 instead of M004
+    const allIds = [...new Set([...diskIds, ...getReservedMilestoneIds()])];
+    const next = nextMilestoneId(allIds);
+    assert.equal(next, "M007", "3 cancelled sessions inflate ID by 3");
+
+    // With cleanup, we're back to M004
+    clearReservedMilestoneIds();
+    const allIdsClean = [...new Set([...diskIds, ...getReservedMilestoneIds()])];
+    const nextClean = nextMilestoneId(allIdsClean);
+    assert.equal(nextClean, "M004", "cleanup restores correct next ID");
+  });
+});


### PR DESCRIPTION
## TL;DR

**What:** Call `clearReservedMilestoneIds()` at the start of `showSmartEntry()` and `showHeadlessMilestoneCreation()` to discard stale ID reservations from previous cancelled sessions.
**Why:** Each cancelled `/gsd` session permanently inflates the next milestone ID — starting `/gsd` 3 times without completing produces M011 instead of M009.
**How:** The cleanup function already existed but was never called outside tests. Add one call at each session entry point.

## What

- `guided-flow.ts`: Added `clearReservedMilestoneIds` to the direct import from `milestone-ids.js` and call it at the top of both `showSmartEntry()` and `showHeadlessMilestoneCreation()`.
- New test file `stale-milestone-id-reservation.test.ts`: 3 test cases demonstrating the inflation bug and verifying the fix.

## Why

The module-level `reservedMilestoneIds` Set in `milestone-ids.ts` persists for the Node.js process lifetime. `nextMilestoneIdReserved()` reserves an ID on every `/gsd` invocation. If the session ends before `claimReservedId()` claims the reservation (e.g. user cancels), the stale ID stays in the Set.

On the next `/gsd`, `nextMilestoneIdReserved` merges disk IDs with stale reservations, computing `maxMilestoneNum` from the union — so each cancelled session permanently bumps the counter by 1.

`clearReservedMilestoneIds()` was introduced in PR #1802 alongside the reservation mechanism but was **never called** in production code — only in tests.

Closes #2488

## How

Add `clearReservedMilestoneIds()` at the top of the two guided-flow entry points:

1. **`showSmartEntry()`** — the main `/gsd` interactive entry point
2. **`showHeadlessMilestoneCreation()`** — the `gsd headless new-milestone` entry point

Both are called at the start of a new user interaction, before any ID generation. Clearing stale reservations here ensures the counter is accurate without affecting the within-session reservation→claim flow.

The alternative of clearing on session end was considered but rejected — session teardown paths are numerous and some (crash, SIGKILL) skip cleanup entirely. Clearing at session start is more robust.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

**Local verification (all four CI-gate steps):**

| Step | Result |
|------|--------|
| `npm run build` | ✅ pass |
| `npm run typecheck:extensions` | ✅ pass |
| `npm run test:unit` | ✅ 3815 pass, 0 fail |
| `npm run test:integration` | ✅ 70 pass, 3 pre-existing failures (web-mode-onboarding, reproduced on `upstream/main`) |

**New test:** `stale-milestone-id-reservation.test.ts` — 3 cases:
1. Without cleanup, cancelled sessions inflate the next ID
2. With cleanup at session start, next ID is correct
3. Multiple cancelled sessions compound the inflation without cleanup

**Manual smoke test:**
1. Simulated 3 cancelled `/gsd` sessions by reserving IDs without claiming them (M004, M005, M006)
2. Without cleanup: next ID inflated to M007 (expected M004) — bug confirmed
3. Called `clearReservedMilestoneIds()` — next ID correctly returned M004
4. Verified the fix eliminates ID inflation from any number of cancelled sessions

## AI disclosure

- [x] This PR includes AI-assisted code — Claude (Anthropic). All code reviewed, tested locally with full CI gate, and verified against upstream.
