### PR TITLE
fix(forensics): filter benign bash exit-code-1 and user skips from error traces

### DIFF
--- a/src/resources/extensions/gsd/session-forensics.ts
+++ b/src/resources/extensions/gsd/session-forensics.ts
@@ -172,7 +172,17 @@ export function extractTrace(entries: unknown[]): ExecutionTrace {
       }
 
       if (isError && resultText) {
-        errors.push(resultText.slice(0, 300));
+        // Filter out benign "errors" that are normal during code exploration:
+        // - grep/rg/find returning exit code 1 (no matches) is expected POSIX behavior
+        // - User interrupts (Escape/skip) are intentional, not failures
+        const trimmed = resultText.trim();
+        const isBenignNoMatch = pending?.name === "bash" &&
+          /^\(no output\)\s*\n\s*Command exited with code 1$/m.test(trimmed);
+        const isUserSkip = /^Skipped due to queued user message/i.test(trimmed);
+
+        if (!isBenignNoMatch && !isUserSkip) {
+          errors.push(resultText.slice(0, 300));
+        }
       }
     }
   }

--- a/src/resources/extensions/gsd/tests/forensics-error-filter.test.ts
+++ b/src/resources/extensions/gsd/tests/forensics-error-filter.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Regression test for #2539: extractTrace should not count benign bash
+ * exit-code-1 (grep no-match) or user skips as errors.
+ */
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+
+import { extractTrace } from "../session-forensics.ts";
+
+/**
+ * Build a minimal JSONL entry pair: assistant tool_use → toolResult.
+ * This is the shape extractTrace() expects from session activity files.
+ */
+function makeToolPair(
+  toolName: string,
+  input: Record<string, unknown>,
+  resultText: string,
+  isError: boolean,
+): unknown[] {
+  const toolCallId = `toolu_${Math.random().toString(36).slice(2, 10)}`;
+  return [
+    {
+      type: "message",
+      message: {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: toolCallId,
+            name: toolName,
+            arguments: input,
+          },
+        ],
+      },
+    },
+    {
+      type: "message",
+      message: {
+        role: "toolResult",
+        toolCallId,
+        toolName,
+        isError,
+        content: [{ type: "text", text: resultText }],
+      },
+    },
+  ];
+}
+
+describe("extractTrace error filtering (#2539)", () => {
+  test("grep exit-code-1 (no matches) is not counted as an error", () => {
+    const entries = makeToolPair(
+      "bash",
+      { command: "grep -rn 'nonexistent' src/" },
+      "(no output)\nCommand exited with code 1",
+      true,
+    );
+    const trace = extractTrace(entries);
+    assert.equal(trace.errors.length, 0, "grep no-match should not be an error");
+  });
+
+  test("user skip is not counted as an error", () => {
+    const entries = makeToolPair(
+      "bash",
+      { command: "npm run test" },
+      "Skipped due to queued user message",
+      true,
+    );
+    const trace = extractTrace(entries);
+    assert.equal(trace.errors.length, 0, "user skip should not be an error");
+  });
+
+  test("real bash error is still counted", () => {
+    const entries = makeToolPair(
+      "bash",
+      { command: "cat /nonexistent" },
+      "cat: /nonexistent: No such file or directory\nCommand exited with code 1",
+      true,
+    );
+    const trace = extractTrace(entries);
+    assert.equal(trace.errors.length, 1, "real error should still be counted");
+    assert.match(trace.errors[0], /No such file or directory/);
+  });
+
+  test("non-bash tool error is still counted", () => {
+    const entries = makeToolPair(
+      "edit",
+      { path: "foo.ts", oldText: "x", newText: "y" },
+      "oldText not found in file",
+      true,
+    );
+    const trace = extractTrace(entries);
+    assert.equal(trace.errors.length, 1, "non-bash tool errors should still be counted");
+  });
+
+  test("mixed entries: only real errors are counted", () => {
+    const entries = [
+      // benign grep no-match
+      ...makeToolPair("bash", { command: "grep -rn 'pattern' src/" }, "(no output)\nCommand exited with code 1", true),
+      // user skip
+      ...makeToolPair("bash", { command: "npm test" }, "Skipped due to queued user message", true),
+      // real error
+      ...makeToolPair("bash", { command: "node broken.js" }, "SyntaxError: Unexpected token\nCommand exited with code 1", true),
+      // successful command (not an error)
+      ...makeToolPair("bash", { command: "echo hello" }, "hello", false),
+    ];
+    const trace = extractTrace(entries);
+    assert.equal(trace.errors.length, 1, "only the real error should be counted");
+    assert.match(trace.errors[0], /SyntaxError/);
+  });
+
+  test("exit code 1 with actual output is still an error", () => {
+    const entries = makeToolPair(
+      "bash",
+      { command: "npm run lint" },
+      "src/foo.ts:10:5 - error TS2304: Cannot find name 'x'\nCommand exited with code 1",
+      true,
+    );
+    const trace = extractTrace(entries);
+    assert.equal(trace.errors.length, 1, "lint error with output should be counted");
+  });
+});


### PR DESCRIPTION
## TL;DR

**What:** Filter benign bash exit-code-1 (grep no-match) and user-interrupt skips from forensic error traces.
**Why:** `extractTrace()` counts all `isError` tool results as errors, producing false-positive `error-trace` anomalies — in a healthy 10-unit run, 3 units were flagged with 8 spurious "errors".
**How:** Add two regex guards in `extractTrace()` before pushing to the `errors` array: one for POSIX grep no-match output, one for user-skip messages.

## What

- `session-forensics.ts`: Added two filters in the `isError && resultText` block (~line 174). Grep/rg/find returning `(no output)\nCommand exited with code 1` from bash is now recognized as normal exploration behavior. `Skipped due to queued user message` is recognized as an intentional user interrupt.
- New test file `forensics-error-filter.test.ts`: 6 test cases covering grep no-match, user skip, real bash error, non-bash tool error, mixed entries, and exit-code-1 with actual output.

## Why

Pi's bash tool sets `isError: true` for any non-zero exit code. `grep` exits 1 when it finds no matches — this is correct POSIX behavior and completely normal during research/planning phases. Similarly, `Skipped due to queued user message` fires when the user hits Escape — intentional, not a failure.

The downstream `detectErrorTraces()` in `forensics.ts` flags any unit with `errors.length > 0` as a WARNING anomaly. Without filtering, every auto-mode unit that ran exploratory grep commands gets a false-positive anomaly.

Closes #2539

## How

Two regex filters in `extractTrace()`, applied before pushing to the `errors` array:

```ts
const isBenignNoMatch = pending?.name === "bash" &&
  /^\(no output\)\s*\n\s*Command exited with code 1$/m.test(trimmed);
const isUserSkip = /^Skipped due to queued user message/i.test(trimmed);

if (!isBenignNoMatch && !isUserSkip) {
  errors.push(resultText.slice(0, 300));
}
```

The `pending?.name === "bash"` guard ensures only bash tool results are filtered — non-bash tool errors (e.g. `edit` tool failures) are always counted. The `isBenignNoMatch` check is scoped to the exact format Pi uses for no-output + exit-code-1, avoiding false negatives on real errors that happen to mention "exit code 1" in their output.

Alternative considered: filtering in `detectErrorTraces()` instead. Rejected because the root cause is in `extractTrace()` — better to avoid polluting the `errors` array in the first place.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

**Local verification (all four CI-gate steps):**

| Step | Result |
|------|--------|
| `npm run build` | ✅ pass |
| `npm run typecheck:extensions` | ✅ pass |
| `npm run test:unit` | ✅ 3818 pass, 0 fail |
| `npm run test:integration` | ✅ 70 pass, 3 pre-existing failures (web-mode-onboarding, reproduced on `upstream/main`) |

**New test:** `forensics-error-filter.test.ts` — 6 cases:
1. Grep exit-code-1 (no matches) is not counted as an error
2. User skip is not counted as an error
3. Real bash error is still counted
4. Non-bash tool error is still counted
5. Mixed entries: only real errors are counted
6. Exit code 1 with actual output is still an error

**Manual smoke test:**
1. Built the project and loaded `extractTrace` from the compiled dist
2. Simulated a session with 6 tool results: 2× grep no-match, 1× user skip, 1× SyntaxError, 1× permission denied, 1× success
3. Before fix: all 4 `isError` results would be counted (4 errors)
4. After fix: only 2 real errors counted (SyntaxError, permission denied) — 2 grep no-match and 1 user skip correctly filtered
5. Verified real errors with actual output are never filtered

## AI disclosure

- [x] This PR includes AI-assisted code — Claude (Anthropic). All code reviewed, tested locally with full CI gate, and verified against upstream.
