### PR TITLE
test: add cross-platform filesystem safety static analysis guard

### DIFF
--- a/src/tests/cross-platform-filesystem-safety.test.ts
+++ b/src/tests/cross-platform-filesystem-safety.test.ts
@@ -41,7 +41,7 @@ function collectProductionFiles(dir: string): SourceFile[] {
     const content = readFileSync(full, "utf-8");
     results.push({
       abs: full,
-      rel: relative(SRC_ROOT, full),
+      rel: relative(SRC_ROOT, full).replaceAll("\\", "/"),
       content,
       lines: content.split("\n"),
     });


### PR DESCRIPTION
## TL;DR

**What:** Static analysis guard test that scans production `.ts` files for cross-platform filesystem anti-patterns.
**Why:** Prevent regressions where platform-specific assumptions (hardcoded `/tmp`, missing `force: true`, shell injection) slip into the codebase.
**How:** Regex-based source scanning with allowlists, modelled after the git-locale static check pattern.

## What

New test file: `src/tests/cross-platform-filesystem-safety.test.ts`

Scans all production `.ts` files under `src/` (excluding test files, `node_modules/`, `dist/`) for six patterns:

| # | Pattern | Severity |
|---|---------|----------|
| 1 | Hardcoded `/tmp` paths | **FAIL** |
| 2 | String concatenation path separators (`+ "/" +`) | WARN |
| 3 | `rmSync` without `force: true` | **FAIL** |
| 4 | Shell command interpolation (`execSync(\`..${var}..\`)`) | **FAIL** |
| 5 | `existsSync` + delete TOCTOU races | WARN |
| 6 | Recursive `rmSync` without containment check | WARN |

## Why

Cross-platform bugs are easy to introduce and hard to catch in review. This test catches them at CI time before they reach users. Current findings:

- **0 hard failures** — all FAIL-level patterns pass clean
- **24 TOCTOU warnings** — informational, documents existing `existsSync` + delete patterns
- **22 containment warnings** — flags `rmSync({ recursive: true })` calls without nearby path validation

## How

Follows the established pattern from `src/resources/extensions/gsd/tests/git-locale.test.ts`:
- Reads source files and scans with regex
- Reports violations with file path and line number
- Maintains commented allowlists for known-safe instances (cmux Unix socket path, npm package name constants)
- Uses `node:test` with `describe`/`test`, `node:assert/strict`

## Test plan

- [x] All 7 sub-tests pass locally
- [x] Works with project's `test:unit` runner flags
- [x] No false positives on hard-fail patterns (allowlists cover known-safe code)
- [x] Warn-only patterns log context without blocking CI