### PR TITLE
fix(model-registry): scope custom provider stream handlers to prevent clobbering built-ins

### DIFF
--- a/packages/pi-coding-agent/src/core/model-registry-auth-mode.test.ts
+++ b/packages/pi-coding-agent/src/core/model-registry-auth-mode.test.ts
@@ -572,3 +572,73 @@ describe("ModelRegistry authMode — streamSimple apiKey boundary", () => {
 		assert.equal((captured as Record<string, unknown>).reasoning, "high", "reasoning must pass through");
 	});
 });
+
+// ─── Provider-scoped stream routing (#2533) ───────────────────────────────────
+
+describe("ModelRegistry authMode — provider-scoped stream routing", () => {
+	it("does not clobber built-in stream handler when custom provider uses same api", () => {
+		const registry = createRegistry(() => true);
+		const customSpy = createStreamSpy();
+
+		// Register a custom provider with the same API type as a built-in (anthropic-messages).
+		// This simulates the claude-code-cli extension registering with api: "anthropic-messages".
+		registry.registerProvider("custom-cli", {
+			authMode: "externalCli",
+			baseUrl: "local://custom",
+			api: "anthropic-messages",
+			streamSimple: customSpy.streamSimple,
+			models: [createProviderModel("custom-model", "anthropic-messages")],
+		});
+
+		// The built-in anthropic-messages provider should still be accessible
+		// when calling streamSimple with a model from the built-in provider.
+		const provider = getApiProvider("anthropic-messages" as Api);
+		assert.ok(provider, "anthropic-messages provider must still be registered");
+
+		// Call with a built-in anthropic model — should NOT hit the custom spy.
+		// The built-in handler will throw (no API key), which proves the routing
+		// correctly delegates to the built-in instead of the custom handler.
+		assert.throws(
+			() => provider.streamSimple(
+				makeModel("anthropic", "claude-sonnet-4-6", "anthropic-messages"),
+				makeContext(),
+				{ maxTokens: 4096 } as SimpleStreamOptions,
+			),
+			(err: Error) => err.message.includes("API key"),
+			"built-in Anthropic handler must be invoked (throws because no API key in tests)",
+		);
+
+		assert.equal(
+			customSpy.getCapturedOptions(),
+			undefined,
+			"custom provider's streamSimple must NOT be called for anthropic provider models",
+		);
+	});
+
+	it("routes to custom provider when model.provider matches", () => {
+		const registry = createRegistry(() => true);
+		const customSpy = createStreamSpy();
+
+		registry.registerProvider("custom-cli", {
+			authMode: "externalCli",
+			baseUrl: "local://custom",
+			api: "anthropic-messages",
+			streamSimple: customSpy.streamSimple,
+			models: [createProviderModel("custom-model", "anthropic-messages")],
+		});
+
+		const provider = getApiProvider("anthropic-messages" as Api);
+		assert.ok(provider);
+
+		// Call with the custom provider's model — should hit the custom spy
+		provider.streamSimple(
+			makeModel("custom-cli", "custom-model", "anthropic-messages"),
+			makeContext(),
+			{ maxTokens: 2048 } as SimpleStreamOptions,
+		);
+
+		const captured = customSpy.getCapturedOptions();
+		assert.ok(captured, "custom provider's streamSimple must be called for its own models");
+		assert.equal(captured.maxTokens, 2048);
+	});
+});

--- a/packages/pi-coding-agent/src/core/model-registry.ts
+++ b/packages/pi-coding-agent/src/core/model-registry.ts
@@ -6,6 +6,7 @@ import {
 	type Api,
 	type AssistantMessageEventStream,
 	type Context,
+	getApiProvider,
 	getModels,
 	getProviders,
 	type KnownProvider,
@@ -635,11 +636,37 @@ export class ModelRegistry {
 					})
 				: rawStreamSimple;
 
+			// Guard: if there's already a handler registered for this API, wrap
+			// the new one so it only fires for models from this provider and
+			// delegates to the previous handler for all other providers. Without
+			// this, a custom provider using api:"anthropic-messages" would clobber
+			// the built-in Anthropic stream handler (#2536).
+			const existingProvider = getApiProvider(config.api as Api);
+			const scopedStream = existingProvider
+				? (model: Model<Api>, context: Context, options?: SimpleStreamOptions): AssistantMessageEventStream => {
+						if (model.provider === providerName) {
+							return streamSimple(model, context, options);
+						}
+						return existingProvider.streamSimple(model, context, options);
+					}
+				: streamSimple;
+
+			const newFullStream = (model: Model<Api>, context: Context, options?: SimpleStreamOptions) =>
+				scopedStream(model, context, options as SimpleStreamOptions);
+			const scopedFullStream = existingProvider
+				? (model: Model<Api>, context: Context, options?: Record<string, unknown>) => {
+						if (model.provider === providerName) {
+							return newFullStream(model, context, options as SimpleStreamOptions);
+						}
+						return existingProvider.stream(model, context, options);
+					}
+				: newFullStream;
+
 			registerApiProvider(
 				{
 					api: config.api,
-					stream: (model, context, options) => streamSimple(model, context, options as SimpleStreamOptions),
-					streamSimple,
+					stream: scopedFullStream as any,
+					streamSimple: scopedStream,
 				},
 				`provider:${providerName}`,
 			);


### PR DESCRIPTION
## Problem

The `claude-code-cli` extension (PR #2532, shipped in v2.47.0) registers a `streamSimple` handler with `api: "anthropic-messages"`. The API provider registry (`apiProviderRegistry`) is a `Map<string, handler>` keyed by the `api` string, so this **overwrites** the built-in Anthropic stream handler.

All models with `api: "anthropic-messages"` — including `anthropic/claude-opus-4-6` — then route through `streamViaClaudeCode` (Claude Code SDK subprocess) instead of the Anthropic API. The SDK subprocess has its own tools (`Glob`, `Read`, `Edit`, `Bash`), which do not exist in pi's tool registry, causing every tool call to fail with "Tool not found".

This affects any user running v2.47.0 with the standard `anthropic` provider when the `claude-code-cli` extension is loaded (which is automatic).

## Root Cause

```
registerApiProvider({ api: "anthropic-messages", streamSimple: streamViaClaudeCode }, "provider:claude-code")
```

This `Map.set("anthropic-messages", ...)` clobbers the previously-registered built-in `streamSimpleAnthropic`.

## Fix

In `model-registry.ts` `applyProviderConfig`: before registering the new handler, save the existing handler via `getApiProvider()`. Register a wrapper that checks `model.provider === providerName` — dispatches to the custom handler for matching models, delegates to the previous handler for all others.

## Test Coverage

Two new tests in `model-registry-auth-mode.test.ts`:
1. **Does not clobber** — registering a custom provider with `api: "anthropic-messages"` preserves the built-in handler for `anthropic` models
2. **Routes correctly** — the custom handler IS invoked when `model.provider` matches

All 33 tests pass. No new type errors (3 pre-existing on main).

Closes https://github.com/gsd-build/gsd-2/issues/2536