### PR TITLE
fix(gsd extension): preserve pending semantics in doctor legacy fallback

### DIFF
--- a/src/resources/extensions/gsd/doctor.ts
+++ b/src/resources/extensions/gsd/doctor.ts
@@ -487,7 +487,15 @@ export async function runGSDDoctor(basePath: string, options?: { fix?: boolean; 
         demo: s.demo,
       }));
     } else {
-      slices = parseLegacyRoadmap(roadmapContent).slices;
+      const activeMilestoneId = state.activeMilestone?.id;
+      const activeSliceId = state.activeSlice?.id;
+      slices = parseLegacyRoadmap(roadmapContent).slices.map(s => ({
+        ...s,
+        // Legacy roadmaps only encode done vs not-done. For doctor's
+        // missing-directory checks, treat every undone slice except the
+        // current active slice as effectively pending/unstarted.
+        pending: !s.done && (milestoneId !== activeMilestoneId || s.id !== activeSliceId),
+      }));
     }
     // Wrap in Roadmap-compatible shape for detectCircularDependencies
     const roadmap = { slices };

--- a/src/resources/extensions/gsd/tests/doctor-fixlevel.test.ts
+++ b/src/resources/extensions/gsd/tests/doctor-fixlevel.test.ts
@@ -15,6 +15,7 @@ import { tmpdir } from "node:os";
 import test from "node:test";
 import assert from "node:assert/strict";
 import { runGSDDoctor } from "../doctor.ts";
+import { closeDatabase } from "../gsd-db.ts";
 
 function makeTmp(name: string): string {
   const dir = join(tmpdir(), `doctor-fixlevel-${name}-${Date.now()}-${Math.random().toString(36).slice(2)}`);
@@ -112,6 +113,70 @@ test("fixLevel:all — no reconciliation issue codes are reported", async (t) =>
   assert.ok(roadmapContent.includes("- [ ] **S01"), "roadmap should remain unchecked");
 });
 
+test("legacy roadmap fallback: future slices are treated as pending, active slice is not", async (t) => {
+  const tmp = makeTmp("legacy-pending-fallback");
+  t.after(() => {
+    try { closeDatabase(); } catch { /* noop */ }
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  // Force the legacy parser branch.
+  try { closeDatabase(); } catch { /* noop */ }
+
+  const gsd = join(tmp, ".gsd");
+  const m = join(gsd, "milestones", "M001");
+  const s01 = join(m, "slices", "S01", "tasks");
+  mkdirSync(s01, { recursive: true });
+
+  writeFileSync(join(m, "M001-ROADMAP.md"), `# M001: Test
+
+## Slices
+
+- [x] **S01: Done Slice** \`risk:low\` \`depends:[]\`
+  > Done
+- [ ] **S02: Active Slice** \`risk:medium\` \`depends:[S01]\`
+  > In progress
+- [ ] **S03: Future Slice** \`risk:low\` \`depends:[S02]\`
+  > Later
+- [ ] **S04: Future Slice Two** \`risk:low\` \`depends:[S03]\`
+  > Later
+`);
+
+  writeFileSync(join(m, "slices", "S01", "S01-PLAN.md"), `# S01: Done Slice
+
+**Goal:** done
+
+## Tasks
+
+- [x] **T01: Done task** \`est:5m\`
+`);
+
+  // Active slice exists in state/registry but has no directory yet — this should
+  // still be reported as a real error, while future untouched slices should be skipped.
+  const report = await runGSDDoctor(tmp, { scope: "M001" });
+  const missingSliceDirUnits = report.issues
+    .filter(i => i.code === "missing_slice_dir")
+    .map(i => i.unitId)
+    .sort();
+
+  assert.deepStrictEqual(
+    missingSliceDirUnits,
+    ["M001/S02"],
+    "legacy fallback should only report the active slice, not future unstarted slices",
+  );
+
+  const missingTasksDirUnits = report.issues
+    .filter(i => i.code === "missing_tasks_dir")
+    .map(i => i.unitId)
+    .sort();
+
+  assert.deepStrictEqual(
+    missingTasksDirUnits,
+    [],
+    "future slices without directories should be skipped before missing_tasks_dir checks",
+  );
+});
+
 test("fixLevel:all — delimiter_in_title still fixable", async (t) => {
   const tmp = makeTmp("delimiter-fix");
   t.after(() => rmSync(tmp, { recursive: true, force: true }));
@@ -141,7 +206,6 @@ test("fixLevel:all — delimiter_in_title still fixable", async (t) => {
 
   const report = await runGSDDoctor(tmp, { fix: true });
 
-  const delimiterIssues = report.issues.filter(i => i.code === "delimiter_in_title");
   // The milestone-level delimiter is auto-fixed, but the report may or may not include it
   // depending on whether it was fixed successfully. Just verify it ran without crashing.
   assert.ok(report.issues !== undefined, "doctor produces a report");


### PR DESCRIPTION
## TL;DR

**What:** Fix doctor’s legacy roadmap fallback so future unstarted slices are treated as pending instead of triggering false `missing_slice_dir` errors.
**Why:** The DB-backed path already preserves `pending`, but the legacy fallback collapsed everything to done/not-done and misclassified future slices during milestone-scoped doctor runs.
**How:** Infer a doctor-local `pending` flag for legacy-parsed slices by treating every undone slice except the current active slice as unstarted, and add a regression test for that fallback path.

## What

This PR updates the GSD doctor’s slice normalization logic in `src/resources/extensions/gsd/doctor.ts` and adds a regression test in `src/resources/extensions/gsd/tests/doctor-fixlevel.test.ts`.

Specifically:
- the DB-backed path remains unchanged
- the legacy roadmap fallback now annotates slices with a doctor-local `pending` flag
- future undone slices are skipped by missing-directory checks
- the current active slice still surfaces real `missing_slice_dir` errors
- a regression test covers the legacy fallback behavior directly

## Why

`#2451` fixed the DB-backed doctor path by preserving `pending` slices, but `#2518` remained open because the legacy parser fallback still returned only `done`/not-done state.

That meant milestone-scoped doctor runs could treat future, untouched roadmap slices as active and emit false:
- `missing_slice_dir`
- and potentially `missing_tasks_dir`

Those directories are expected to be absent until dispatch creates them, so the errors were noise. At the same time, the active slice still needs real missing-directory detection.

Closes #2518

## How

The fix stays local to doctor rather than changing legacy roadmap parsing globally.

In the legacy fallback branch, doctor now infers:
- `pending: true` for undone slices that are not the current active slice
- `pending: false` for the active slice, so real missing-dir problems still surface

That keeps the behavior surgical:
- no parser-wide semantics change
- no drive-by refactor
- no effect on the DB-backed path

I also added a regression test that forces the legacy path by closing the DB and verifies:
- the active slice still reports `missing_slice_dir`
- future unstarted slices no longer do

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [ ] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

Commands run locally:
- `npm run build` ✅
- `npm run typecheck:extensions` ✅
- `npm run test:unit` ✅
- `npm run test:integration` ⚠️ hit 3 pre-existing failures

Pre-existing integration failures:
- `src/tests/integration/web-mode-assembled.test.ts`
- `src/tests/integration/web-mode-onboarding.test.ts` (successful browser onboarding restarts the stale bridge child and unlocks the first prompt)
- `src/tests/integration/web-mode-onboarding.test.ts` (fresh `gsd --web` browser onboarding stays locked on failed validation and unlocks after a successful retry)

These same failures were reproduced on a clean built `upstream/main` control run.

Manual smoke test:
1. Created a temporary smoke-test workspace outside the repo
2. Wrote a minimal `.gsd` milestone with:
   - `S01` complete and planned
   - `S02` active but missing directory
   - `S03`/`S04` future and unstarted
3. Forced the legacy doctor path by running with the DB closed
4. Verified doctor reported only `M001/S02` as `missing_slice_dir`
5. Verified future slices were skipped
6. Removed the temporary workspace afterward

## AI disclosure

- [x] This PR includes AI-assisted code
