### PR TITLE
qol: double-escape to clear editor input

### DIFF
--- a/packages/pi-coding-agent/src/modes/interactive/components/footer.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/components/footer.ts
@@ -44,6 +44,8 @@ export function formatPromptCost(cost: number): string {
  */
 export class FooterComponent implements Component {
 	private autoCompactEnabled = true;
+	private temporaryRightText: string | undefined = undefined;
+	private temporaryRightTimer: ReturnType<typeof setTimeout> | undefined = undefined;
 
 	constructor(
 		private session: AgentSession,
@@ -52,6 +54,24 @@ export class FooterComponent implements Component {
 
 	setAutoCompactEnabled(enabled: boolean): void {
 		this.autoCompactEnabled = enabled;
+	}
+
+	/**
+	 * Temporarily replace the right-side model text with a message.
+	 * Auto-clears after the specified duration (default 2s).
+	 */
+	setTemporaryRightText(text: string | undefined, durationMs = 2000): void {
+		if (this.temporaryRightTimer) {
+			clearTimeout(this.temporaryRightTimer);
+			this.temporaryRightTimer = undefined;
+		}
+		this.temporaryRightText = text;
+		if (text !== undefined && durationMs > 0) {
+			this.temporaryRightTimer = setTimeout(() => {
+				this.temporaryRightText = undefined;
+				this.temporaryRightTimer = undefined;
+			}, durationMs);
+		}
 	}
 
 	/**
@@ -172,13 +192,19 @@ export class FooterComponent implements Component {
 				thinkingLevel === "off" ? `${modelName} • thinking off` : `${modelName} • ${thinkingLevel}`;
 		}
 
-		// Prepend the provider in parentheses if there are multiple providers and there's enough room
-		let rightSide = rightSideWithoutProvider;
-		if (this.footerData.getAvailableProviderCount() > 1 && displayModel) {
-			rightSide = `(${displayModel.provider}) ${rightSideWithoutProvider}`;
-			if (statsLeftWidth + minPadding + visibleWidth(rightSide) > width) {
-				// Too wide, fall back
-				rightSide = rightSideWithoutProvider;
+		// Use temporary right text if set (e.g. "Press Escape again to clear input")
+		let rightSide: string;
+		if (this.temporaryRightText !== undefined) {
+			rightSide = this.temporaryRightText;
+		} else {
+			// Prepend the provider in parentheses if there are multiple providers and there's enough room
+			rightSide = rightSideWithoutProvider;
+			if (this.footerData.getAvailableProviderCount() > 1 && displayModel) {
+				rightSide = `(${displayModel.provider}) ${rightSideWithoutProvider}`;
+				if (statsLeftWidth + minPadding + visibleWidth(rightSide) > width) {
+					// Too wide, fall back
+					rightSide = rightSideWithoutProvider;
+				}
 			}
 		}
 

--- a/packages/pi-coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/interactive-mode.ts
@@ -177,6 +177,8 @@ export class InteractiveMode {
 
 	private lastSigintTime = 0;
 	private lastEscapeTime = 0;
+	private escapePendingClear = false;
+	private escapePendingTimer: ReturnType<typeof setTimeout> | undefined = undefined;
 	private changelogMarkdown: string | undefined = undefined;
 
 	// Status line tracking (for mutating immediately-sequential status updates)
@@ -1877,7 +1879,27 @@ export class InteractiveMode {
 				this.editor.setText("");
 				this.isBashMode = false;
 				this.updateEditorBorderColor();
-			} else if (!this.editor.getText().trim()) {
+			} else if (this.editor.getText().trim()) {
+				// Double-escape with text in editor clears the input
+				if (this.escapePendingClear) {
+					if (this.escapePendingTimer) {
+						clearTimeout(this.escapePendingTimer);
+						this.escapePendingTimer = undefined;
+					}
+					this.editor.setText("");
+					this.footer.setTemporaryRightText(undefined);
+					this.escapePendingClear = false;
+				} else {
+					this.escapePendingClear = true;
+					this.footer.setTemporaryRightText("Press Escape again to clear input", 1500);
+					this.escapePendingTimer = setTimeout(() => {
+						this.escapePendingClear = false;
+						this.escapePendingTimer = undefined;
+						this.ui.requestRender();
+					}, 1500);
+				}
+				this.ui.requestRender();
+			} else {
 				// Double-escape with empty editor triggers /tree, /fork, or nothing based on setting
 				const action = this.settingsManager.getDoubleEscapeAction();
 				if (action !== "none") {
@@ -1922,6 +1944,16 @@ export class InteractiveMode {
 			this.isBashMode = text.trimStart().startsWith("!");
 			if (wasBashMode !== this.isBashMode) {
 				this.updateEditorBorderColor();
+			}
+			// Reset escape-to-clear flag when user resumes typing
+			if (this.escapePendingClear) {
+				this.escapePendingClear = false;
+				if (this.escapePendingTimer) {
+					clearTimeout(this.escapePendingTimer);
+					this.escapePendingTimer = undefined;
+				}
+				this.footer.setTemporaryRightText(undefined);
+				this.ui.requestRender();
 			}
 		};
 


### PR DESCRIPTION
## Summary
- Pressing Escape when the editor has text shows a "Press Escape again to clear input" hint in the footer's right-side status (temporarily replacing the model info)
- Pressing Escape a second time clears the editor input
- The hint and pending state auto-expire after 1.5s, and reset immediately if the user resumes typing

## Details
- Adds `setTemporaryRightText()` to `FooterComponent` for transient right-side messages with auto-clear
- Uses a flag (`escapePendingClear`) instead of a timing window to avoid races with autocomplete consuming escape presses
- The flag is reset on: second Escape (clears input), typing (user resumed editing), or 1.5s timeout (expired)

## Test plan
- [ ] Type text in editor, press Escape once → footer shows hint, model info is replaced
- [ ] Press Escape again → input clears, model info restores
- [ ] Type text, press Escape once, then type more → hint disappears, flag resets, next Escape shows hint again
- [ ] Type text, press Escape once, wait 1.5s → hint disappears on its own, next Escape shows hint again
- [ ] Verify existing double-escape behavior with empty editor (tree/fork) still works
- [ ] Verify Escape still cancels autocomplete, aborts loading, and exits bash mode