### PR TITLE
fix(gsd): guard writeIntegrationBranch against workflow-template branches

### DIFF
--- a/src/resources/extensions/gsd/git-service.ts
+++ b/src/resources/extensions/gsd/git-service.ts
@@ -246,6 +246,15 @@ export function readIntegrationBranch(basePath: string, milestoneId: string): st
 /** Regex matching GSD quick-task branches: gsd/quick/<num>-<slug> */
 export const QUICK_BRANCH_RE = /^gsd\/quick\//;
 
+/**
+ * Matches all GSD workflow-template branches: gsd/<templateId>/<slug>.
+ *
+ * Template IDs are lowercase alphanumeric with hyphens (e.g. hotfix, bugfix,
+ * small-feature, dep-upgrade). The negative lookahead excludes milestone
+ * branches (gsd/M001/... or gsd/M001-abc123/...) which use SLICE_BRANCH_RE.
+ */
+export const WORKFLOW_BRANCH_RE = /^gsd\/(?!M\d)[\w-]+\//;
+
 export function writeIntegrationBranch(
   basePath: string,
   milestoneId: string,
@@ -257,6 +266,10 @@ export function writeIntegrationBranch(
   // to their origin branch on completion. Recording one as the integration
   // target causes milestone merges to land on the wrong branch (#1293).
   if (QUICK_BRANCH_RE.test(branch)) return;
+  // Don't record workflow-template branches (hotfix, bugfix, spike, etc.) —
+  // same root cause as quick-task branches (#2498). All templates create
+  // gsd/<templateId>/<slug> branches that are ephemeral.
+  if (WORKFLOW_BRANCH_RE.test(branch)) return;
   // Validate
   if (!VALID_BRANCH_NAME.test(branch)) return;
   // Skip if already recorded with the same branch (idempotent across restarts).

--- a/src/resources/extensions/gsd/tests/git-service.test.ts
+++ b/src/resources/extensions/gsd/tests/git-service.test.ts
@@ -868,6 +868,55 @@ describe('git-service', async () => {
     rmSync(repo, { recursive: true, force: true });
   });
 
+  // ─── writeIntegrationBranch: rejects workflow-template branches (#2498) ─
+
+  test('Integration branch: rejects workflow-template branches', () => {
+    const repo = initBranchTestRepo();
+
+    // All 8 registered workflow templates should be rejected
+    writeIntegrationBranch(repo, "M001", "gsd/hotfix/fix-login");
+    assert.deepStrictEqual(readIntegrationBranch(repo, "M001"), null, "hotfix branch is not recorded");
+
+    writeIntegrationBranch(repo, "M001", "gsd/bugfix/null-pointer");
+    assert.deepStrictEqual(readIntegrationBranch(repo, "M001"), null, "bugfix branch is not recorded");
+
+    writeIntegrationBranch(repo, "M001", "gsd/small-feature/add-button");
+    assert.deepStrictEqual(readIntegrationBranch(repo, "M001"), null, "small-feature branch is not recorded");
+
+    writeIntegrationBranch(repo, "M001", "gsd/refactor/rename-module");
+    assert.deepStrictEqual(readIntegrationBranch(repo, "M001"), null, "refactor branch is not recorded");
+
+    writeIntegrationBranch(repo, "M001", "gsd/spike/evaluate-lib");
+    assert.deepStrictEqual(readIntegrationBranch(repo, "M001"), null, "spike branch is not recorded");
+
+    writeIntegrationBranch(repo, "M001", "gsd/security-audit/owasp-scan");
+    assert.deepStrictEqual(readIntegrationBranch(repo, "M001"), null, "security-audit branch is not recorded");
+
+    writeIntegrationBranch(repo, "M001", "gsd/dep-upgrade/bump-react");
+    assert.deepStrictEqual(readIntegrationBranch(repo, "M001"), null, "dep-upgrade branch is not recorded");
+
+    writeIntegrationBranch(repo, "M001", "gsd/full-project/new-app");
+    assert.deepStrictEqual(readIntegrationBranch(repo, "M001"), null, "full-project branch is not recorded");
+
+    rmSync(repo, { recursive: true, force: true });
+  });
+
+  // ─── writeIntegrationBranch: still records legitimate branches ────────
+
+  test('Integration branch: records non-ephemeral gsd branches', () => {
+    const repo = initBranchTestRepo();
+
+    // A normal feature branch should still be recorded
+    writeIntegrationBranch(repo, "M001", "feature/new-thing");
+    assert.deepStrictEqual(readIntegrationBranch(repo, "M001"), "feature/new-thing", "normal branches are recorded");
+
+    // The main branch should be recorded
+    writeIntegrationBranch(repo, "M002", "main");
+    assert.deepStrictEqual(readIntegrationBranch(repo, "M002"), "main", "main branch is recorded");
+
+    rmSync(repo, { recursive: true, force: true });
+  });
+
   // ─── writeIntegrationBranch: rejects invalid branch names ─────────────
 
   test('Integration branch: rejects invalid names', () => {


### PR DESCRIPTION
## TL;DR

**What:** Guard `writeIntegrationBranch` against all 8 workflow-template branches (`gsd/hotfix/*`, `gsd/bugfix/*`, `gsd/spike/*`, etc.).
**Why:** Ephemeral workflow-template branches get recorded as the milestone's integration target, causing milestone merges to land on the wrong branch.
**How:** Add `WORKFLOW_BRANCH_RE` regex with a negative lookahead that matches all `gsd/<templateId>/<slug>` patterns while preserving milestone slice branches.

## What

- Added `WORKFLOW_BRANCH_RE` (`/^gsd\/(?!M\d)[\w-]+\//`) to `git-service.ts`
- Added a guard clause in `writeIntegrationBranch()` that silently returns when the branch matches a workflow-template pattern
- Added 2 tests: one verifying all 8 registered templates are rejected, one verifying legitimate branches still record correctly

## Why

`writeIntegrationBranch` already guards against slice branches (`SLICE_BRANCH_RE`) and quick-task branches (`QUICK_BRANCH_RE`, added in PR #1342), but has no guard for workflow-template branches. When `/gsd start hotfix` (or any of the 8 templates) runs during an active milestone, the resulting `gsd/hotfix/<slug>` branch is recorded as the milestone's integration target in `<MID>-META.json`. When the milestone completes, `mergeMilestoneToMain` squash-merges into the hotfix branch instead of `main`.

Same root cause as `gsd/quick/*` (#1293, PR #1342).

Closes #2498

## How

The fix follows the exact same pattern as the existing `QUICK_BRANCH_RE` guard:

1. Define a regex that matches the branch namespace (`/^gsd\/(?!M\d)[\w-]+\//`)
2. The negative lookahead `(?!M\d)` ensures milestone slice branches (`gsd/M001/S01`, `gsd/M001-abc123/S02`) are not affected
3. Add a guard clause in `writeIntegrationBranch()` that returns early when the regex matches

The broader regex also covers `gsd/quick/*` branches, but the existing `QUICK_BRANCH_RE` guard is kept for backwards compatibility and clarity.

**Alternatives considered:**
- A single `GSD_EPHEMERAL_RE` replacing both `QUICK_BRANCH_RE` and `WORKFLOW_BRANCH_RE` — opted against to keep the existing guard explicit and traceable to its original PR (#1342).
- An allowlist approach (only record known-safe patterns) — too restrictive, would break legitimate `gsd/...` branch patterns that may be added in the future.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

### Local CI gate

| Step | Result |
|------|--------|
| `npm run build` | ✅ pass (27s) |
| `npm run typecheck:extensions` | ✅ pass (3.6s) |
| `npm run test:unit` | ✅ 3857/3857 pass, 0 fail (262s) |
| `npm run test:integration` | ✅ 70/73 pass, 3 pre-existing failures (67s) |

The 3 integration failures (`web-mode-assembled`, `web-mode-onboarding` ×2) reproduce identically on `upstream/main` — they are pre-existing and unrelated to this change.

### New tests

- `Integration branch: rejects workflow-template branches` — verifies all 8 registered templates (`hotfix`, `bugfix`, `small-feature`, `refactor`, `spike`, `security-audit`, `dep-upgrade`, `full-project`) are silently rejected
- `Integration branch: records non-ephemeral gsd branches` — verifies `feature/new-thing` and `main` are still recorded correctly

### Manual smoke test

Created an isolated git repo with a `.gsd/milestones/M001/` directory. Imported `writeIntegrationBranch` and verified 5 scenarios:

1. `gsd/hotfix/fix-login` → ✅ rejected (not recorded)
2. `gsd/bugfix/null-ptr` → ✅ rejected (not recorded)
3. `gsd/spike/eval-lib` → ✅ rejected (not recorded)
4. `main` → ✅ recorded correctly
5. `gsd/dep-upgrade/bump-react` after `main` already recorded → ✅ `main` preserved, not overwritten

## AI disclosure

- [x] This PR includes AI-assisted code — Claude (Anthropic) assisted with implementation and testing. All code was reviewed, tested locally against the full CI pipeline, and manually smoke-tested.
