### PR TITLE
fix(remote-questions): use static ESM import for AuthStorage hydration

### DIFF
--- a/src/resources/extensions/remote-questions/config.ts
+++ b/src/resources/extensions/remote-questions/config.ts
@@ -2,7 +2,7 @@
  * Remote Questions — configuration resolution and validation
  */
 
-import { join } from "node:path";
+import { AuthStorage } from "@gsd/pi-coding-agent";
 import { loadEffectiveGSDPreferences, type RemoteQuestionsConfig } from "../gsd/preferences.js";
 import type { RemoteChannel } from "./types.js";
 
@@ -54,9 +54,7 @@ function hydrateRemoteTokensFromAuth(): void {
   if (needed.length === 0) return;
 
   try {
-    const { AuthStorage } = require("@gsd/pi-coding-agent") as typeof import("@gsd/pi-coding-agent");
-    const authPath = join(process.env.HOME ?? "~", ".gsd", "agent", "auth.json");
-    const auth = AuthStorage.create(authPath);
+    const auth = AuthStorage.create();
 
     for (const [providerId, envVar] of needed) {
       try {
@@ -72,7 +70,7 @@ function hydrateRemoteTokensFromAuth(): void {
       }
     }
   } catch {
-    // AuthStorage unavailable (unit tests, stripped build) — skip silently.
+    // AuthStorage unavailable or auth.json missing/unreadable — skip silently.
   }
 }
 


### PR DESCRIPTION
## TL;DR

**What:** Replace `require("@gsd/pi-coding-agent")` with a static ESM `import` in `hydrateRemoteTokensFromAuth()`.
**Why:** `require()` cannot load ESM-only packages — hydration was silently a no-op, so remote tokens from `auth.json` were never restored.
**How:** Static `import { AuthStorage } from "@gsd/pi-coding-agent"` + `AuthStorage.create()` (uses `getAgentDir()` internally).

## What

Changes `src/resources/extensions/remote-questions/config.ts`:
- Replaces runtime `require("@gsd/pi-coding-agent")` with a top-level static ESM import of `AuthStorage`
- Replaces hardcoded `join(process.env.HOME, ".gsd", "agent", "auth.json")` path with `AuthStorage.create()` which resolves the path internally via `getAgentDir()`
- Removes now-unused `import { join } from "node:path"`

## Why

PR #2439 added `hydrateRemoteTokensFromAuth()` to restore remote channel tokens (Discord, Slack, Telegram) from `auth.json` into `process.env` on startup. It used `require()` with a try/catch for resilience in non-standard environments.

However, `@gsd/pi-coding-agent` is ESM-only (`"type": "module"`, exports only specify `"import"` — no `"require"` condition). Node's `require()` always throws:

```
No "exports" main defined in .../node_modules/@gsd/pi-coding-agent/package.json
```

The outer try/catch silently swallowed this, making the entire function a no-op. Every session start shows `DISCORD_BOT_TOKEN not set — remote questions disabled` even when the token is correctly stored in `auth.json`.

## How

A static ESM `import` is the correct approach here — every other extension in the codebase already imports from `@gsd/pi-coding-agent` this way. The try/catch around `AuthStorage.create()` and credential reading is preserved for resilience against missing/unreadable `auth.json`.

Using `AuthStorage.create()` (no args) instead of the hardcoded path is cleaner — it delegates path resolution to `getAgentDir()` which already handles platform differences.

---

- [x] `fix` — Bug fix

Closes #2565

> This PR is AI-assisted.