### PR TITLE
fix(auto): add EAGAIN to INFRA_ERROR_CODES

### DIFF
--- a/src/resources/extensions/gsd/auto/infra-errors.ts
+++ b/src/resources/extensions/gsd/auto/infra-errors.ts
@@ -18,6 +18,7 @@ export const INFRA_ERROR_CODES: ReadonlySet<string> = new Set([
   "EDQUOT",   // disk quota exceeded
   "EMFILE",   // too many open files (process)
   "ENFILE",   // too many open files (system)
+  "EAGAIN",       // resource temporarily unavailable (resource exhaustion)
   "ECONNREFUSED", // connection refused (offline / local server down)
   "ENOTFOUND",    // DNS lookup failed (offline / no network)
   "ENETUNREACH",  // network unreachable (offline / no route)

--- a/src/resources/extensions/gsd/tests/infra-error.test.ts
+++ b/src/resources/extensions/gsd/tests/infra-error.test.ts
@@ -9,11 +9,11 @@ import { isInfrastructureError, INFRA_ERROR_CODES } from "../auto/infra-errors.j
 test("INFRA_ERROR_CODES contains the expected codes", () => {
   for (const code of [
     "ENOSPC", "ENOMEM", "EROFS", "EDQUOT", "EMFILE", "ENFILE",
-    "ECONNREFUSED", "ENOTFOUND", "ENETUNREACH",
+    "EAGAIN", "ECONNREFUSED", "ENOTFOUND", "ENETUNREACH",
   ]) {
     assert.ok(INFRA_ERROR_CODES.has(code), `missing ${code}`);
   }
-  assert.equal(INFRA_ERROR_CODES.size, 9, "unexpected extra codes");
+  assert.equal(INFRA_ERROR_CODES.size, 10, "unexpected extra codes");
 });
 
 // ── isInfrastructureError: code property detection ───────────────────────────
@@ -46,6 +46,16 @@ test("detects EMFILE via code property", () => {
 test("detects ENFILE via code property", () => {
   const err = Object.assign(new Error("file table overflow"), { code: "ENFILE" });
   assert.equal(isInfrastructureError(err), "ENFILE");
+});
+
+test("detects EAGAIN via code property", () => {
+  const err = Object.assign(new Error("resource temporarily unavailable"), { code: "EAGAIN" });
+  assert.equal(isInfrastructureError(err), "EAGAIN");
+});
+
+test("detects EAGAIN in error message fallback", () => {
+  const err = new Error("spawn failed: EAGAIN resource temporarily unavailable");
+  assert.equal(isInfrastructureError(err), "EAGAIN");
 });
 
 test("detects ECONNREFUSED via code property", () => {


### PR DESCRIPTION
## Summary
- Adds EAGAIN to INFRA_ERROR_CODES to stop budget-burning retries under resource exhaustion
- Cherry-picked from #2374 (trek-e) with conflict resolution to include network error codes added since

Closes #2359
Supersedes #2374

Co-authored-by: Tom Boucher <trekkie@nomorestars.com>