### PR TITLE
fix(retry-handler): stop treating 5xx as credential-level errors

### DIFF
--- a/packages/pi-coding-agent/src/core/retry-handler.ts
+++ b/packages/pi-coding-agent/src/core/retry-handler.ts
@@ -136,7 +136,7 @@ export class RetryHandler {
 		// Try credential fallback before counting against retry budget.
 		if (this._deps.getModel() && message.errorMessage) {
 			const errorType = this._classifyErrorType(message.errorMessage);
-			const isCredentialError = errorType !== "unknown";
+			const isCredentialError = errorType === "rate_limit" || errorType === "quota_exhausted";
 			const hasAlternate =
 				isCredentialError &&
 				this._deps.modelRegistry.authStorage.markUsageLimitReached(


### PR DESCRIPTION
## Summary

- **One-line fix**: `server_error` (5xx) no longer triggers credential backoff via `markUsageLimitReached()`
- Only `rate_limit` and `quota_exhausted` are treated as credential-scoped errors
- Prevents cascading failure where a transient 500 backs off the sole API key for 20s, causing all retry attempts to fail with "All credentials temporarily backed off"

## Root cause

`_classifyErrorType()` correctly classifies 5xx as `"server_error"`, but `handleRetryableError()` treated **any** non-`"unknown"` type as credential-level (`errorType !== "unknown"`). This caused server errors to call `markUsageLimitReached()`, making the only API key unavailable for 20s. The subsequent "temporarily backed off" error message then re-entered the retry path matching `/rate.?limit/`, extending the backoff and burning all 3 retry attempts on a self-inflicted error cascade.

## Change

```diff
- const isCredentialError = errorType !== "unknown";
+ const isCredentialError = errorType === "rate_limit" || errorType === "quota_exhausted";
```

Server errors now fall through to exponential backoff retry without touching credential state.

## Test plan

- [ ] Build passes (`npm run build --workspace=packages/pi-coding-agent`)
- [ ] Simulate a 500 response with a single API key — retries should use exponential backoff without "All credentials temporarily backed off"
- [ ] Rate limit (429) and quota errors still trigger credential rotation as before

Closes #2588

🤖 Generated with [Claude Code](https://claude.com/claude-code)