### PR TITLE
refactor: consolidate branch name patterns into single module

### DIFF
--- a/src/resources/extensions/gsd/branch-patterns.ts
+++ b/src/resources/extensions/gsd/branch-patterns.ts
@@ -1,0 +1,16 @@
+/**
+ * GSD branch naming patterns — single source of truth.
+ *
+ * gsd/<worktree>/<milestone>/<slice>  → SLICE_BRANCH_RE
+ * gsd/quick/<id>-<slug>               → QUICK_BRANCH_RE
+ * gsd/<workflow>/<...>                 → WORKFLOW_BRANCH_RE (non-milestone gsd/ branches)
+ */
+
+/** Matches gsd/ slice branches: gsd/[worktree/]M001[-hash]/S01 */
+export const SLICE_BRANCH_RE = /^gsd\/(?:([a-zA-Z0-9_-]+)\/)?(M\d+(?:-[a-z0-9]{6})?)\/(S\d+)$/;
+
+/** Matches gsd/quick/ task branches */
+export const QUICK_BRANCH_RE = /^gsd\/quick\//;
+
+/** Matches gsd/ workflow branches (non-milestone, e.g. gsd/workflow-name/...) */
+export const WORKFLOW_BRANCH_RE = /^gsd\/(?!M\d)[\w-]+\//;

--- a/src/resources/extensions/gsd/git-service.ts
+++ b/src/resources/extensions/gsd/git-service.ts
@@ -18,8 +18,8 @@ import { loadEffectiveGSDPreferences } from "./preferences.js";
 
 import {
   detectWorktreeName,
-  SLICE_BRANCH_RE,
 } from "./worktree.js";
+import { SLICE_BRANCH_RE, QUICK_BRANCH_RE, WORKFLOW_BRANCH_RE } from "./branch-patterns.js";
 import {
   nativeGetCurrentBranch,
   nativeDetectMainBranch,
@@ -243,17 +243,8 @@ export function readIntegrationBranch(basePath: string, milestoneId: string): st
  *
  * The file is committed immediately so the metadata is persisted in git.
  */
-/** Regex matching GSD quick-task branches: gsd/quick/<num>-<slug> */
-export const QUICK_BRANCH_RE = /^gsd\/quick\//;
-
-/**
- * Matches all GSD workflow-template branches: gsd/<templateId>/<slug>.
- *
- * Template IDs are lowercase alphanumeric with hyphens (e.g. hotfix, bugfix,
- * small-feature, dep-upgrade). The negative lookahead excludes milestone
- * branches (gsd/M001/... or gsd/M001-abc123/...) which use SLICE_BRANCH_RE.
- */
-export const WORKFLOW_BRANCH_RE = /^gsd\/(?!M\d)[\w-]+\//;
+/** Re-export for backward compatibility — canonical definitions in branch-patterns.ts */
+export { QUICK_BRANCH_RE, WORKFLOW_BRANCH_RE } from "./branch-patterns.js";
 
 export function writeIntegrationBranch(
   basePath: string,

--- a/src/resources/extensions/gsd/worktree.ts
+++ b/src/resources/extensions/gsd/worktree.ts
@@ -235,8 +235,9 @@ export function getSliceBranchName(milestoneId: string, sliceId: string, worktre
   return `gsd/${milestoneId}/${sliceId}`;
 }
 
-/** Regex that matches both plain and worktree-namespaced slice branches. */
-export const SLICE_BRANCH_RE = /^gsd\/(?:([a-zA-Z0-9_-]+)\/)?(M\d+(?:-[a-z0-9]{6})?)\/(S\d+)$/;
+/** Re-export for backward compatibility — canonical definition in branch-patterns.ts */
+export { SLICE_BRANCH_RE } from "./branch-patterns.js";
+import { SLICE_BRANCH_RE } from "./branch-patterns.js";
 
 /**
  * Parse a slice branch name into its components.


### PR DESCRIPTION
## What
Extract `SLICE_BRANCH_RE`, `QUICK_BRANCH_RE`, and `WORKFLOW_BRANCH_RE` into a new `branch-patterns.ts` module as the single source of truth for GSD branch naming patterns.

## Why
These three regex constants represent a single concern (GSD branch name matching) but were scattered across two files:
- `SLICE_BRANCH_RE` lived in `worktree.ts`
- `QUICK_BRANCH_RE` and `WORKFLOW_BRANCH_RE` lived in `git-service.ts`
- `git-service.ts` imported `SLICE_BRANCH_RE` from `worktree.ts` — a cross-module dependency for a conceptually unified concern

Adding a new branch type required knowing which of two files to edit.

## How
- Created `src/resources/extensions/gsd/branch-patterns.ts` with all three constants and JSDoc describing the branch naming scheme
- Removed definitions from `worktree.ts` and `git-service.ts`
- Both original modules re-export the constants for backward compatibility — no consumer changes needed

## Key changes
- **New file**: `src/resources/extensions/gsd/branch-patterns.ts` — canonical definitions
- **Modified**: `worktree.ts` — imports + re-exports `SLICE_BRANCH_RE`
- **Modified**: `git-service.ts` — imports all three from `branch-patterns.ts`, re-exports `QUICK_BRANCH_RE` and `WORKFLOW_BRANCH_RE`

## Testing
- `npx tsc --noEmit` passes cleanly
- All existing tests pass (`worktree.test.ts`, `worktree-integration.test.ts`, `quick-branch-lifecycle.test.ts`, `regex-hardening.test.ts`)
- No duplicate definitions remain — verified via grep
- Re-exports maintain backward compatibility for all existing imports

## Risk
Low. Pure refactor with no behavioral changes. All existing imports continue to work via re-exports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)