### PR TITLE
refactor: decouple session-forensics from auto-worktree

### DIFF
--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -38,6 +38,7 @@ import { clearActivityLogState } from "./activity-log.js";
 import {
   synthesizeCrashRecovery,
   getDeepDiagnostic,
+  readActiveMilestoneId,
 } from "./session-forensics.js";
 import {
   writeLock,
@@ -980,7 +981,11 @@ function buildLoopDeps(): LoopDeps {
     startUnitSupervision,
 
     // Prompt helpers
-    getDeepDiagnostic,
+    getDeepDiagnostic: (basePath: string) => {
+      const mid = readActiveMilestoneId(basePath);
+      const wtPath = mid ? getAutoWorktreePath(basePath, mid) : undefined;
+      return getDeepDiagnostic(basePath, wtPath ?? undefined);
+    },
     isDbAvailable,
     reorderForCaching,
 

--- a/src/resources/extensions/gsd/session-forensics.ts
+++ b/src/resources/extensions/gsd/session-forensics.ts
@@ -25,7 +25,6 @@ import { truncateWithEllipsis } from "../shared/format-utils.js";
 import { nativeParseJsonlTail } from "./native-parser-bridge.js";
 import { MAX_JSONL_BYTES, parseJSONL } from "./jsonl-utils.js";
 import { nativeWorkingTreeStatus, nativeDiffStat } from "./native-git-bridge.js";
-import { getAutoWorktreePath } from "./auto-worktree.js";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -295,17 +294,13 @@ export function synthesizeCrashRecovery(
  * Deep diagnostic from any JSONL source (activity log or session file).
  * Replaces the old shallow getLastActivityDiagnostic().
  */
-export function getDeepDiagnostic(basePath: string): string | null {
-  // Try worktree activity logs first if an auto-worktree is active
+export function getDeepDiagnostic(basePath: string, worktreePath?: string): string | null {
+  // Try worktree activity logs first if a worktree path is provided
   let trace: ExecutionTrace | null = null;
   try {
-    const mid = readActiveMilestoneId(basePath);
-    if (mid) {
-      const wtPath = getAutoWorktreePath(basePath, mid);
-      if (wtPath) {
-        const wtActivityDir = join(gsdRoot(wtPath), "activity");
-        trace = readLastActivityLog(wtActivityDir);
-      }
+    if (worktreePath) {
+      const wtActivityDir = join(gsdRoot(worktreePath), "activity");
+      trace = readLastActivityLog(wtActivityDir);
     }
   } catch { /* non-fatal — fall through to root */ }
 
@@ -323,7 +318,7 @@ export function getDeepDiagnostic(basePath: string): string | null {
  * Read the active milestone ID directly from STATE.md without async deriveState().
  * Looks for `**Active Milestone:** M001` pattern.
  */
-function readActiveMilestoneId(basePath: string): string | null {
+export function readActiveMilestoneId(basePath: string): string | null {
   try {
     const statePath = join(gsdRoot(basePath), "STATE.md");
     if (!existsSync(statePath)) return null;


### PR DESCRIPTION
## What
Remove the `getAutoWorktreePath` import from `session-forensics.ts` by having the caller pass the resolved worktree path as a parameter.

## Why
`session-forensics.ts` is a general-purpose JSONL parser that imported `getAutoWorktreePath` from `auto-worktree.ts` solely for worktree path resolution in `getDeepDiagnostic()`. This created tight coupling between a generic parser module and auto-worktree infrastructure, making session-forensics harder to test and reason about in isolation.

## How
- Added an optional `worktreePath?: string` parameter to `getDeepDiagnostic()` in `session-forensics.ts`
- Removed the `import { getAutoWorktreePath } from "./auto-worktree.js"` line
- Exported `readActiveMilestoneId()` (previously private) so the caller can resolve the milestone ID
- In `auto.ts`, wrapped the `getDeepDiagnostic` dep to resolve the worktree path via `readActiveMilestoneId` + `getAutoWorktreePath` before passing it in
- The dep interface in `loop-deps.ts` remains unchanged (`(basePath: string) => string | null`)

## Key changes
- `src/resources/extensions/gsd/session-forensics.ts` — removed auto-worktree import, `getDeepDiagnostic` accepts optional `worktreePath`, exported `readActiveMilestoneId`
- `src/resources/extensions/gsd/auto.ts` — imported `readActiveMilestoneId`, wrapped `getDeepDiagnostic` in `buildLoopDeps` to resolve worktree path at call time

## Testing
- `npx tsc --noEmit` passes clean
- `grep -r "auto-worktree" session-forensics.ts` returns empty
- No behavioral change: worktree activity logs are still checked first when an active milestone exists

## Risk
Low — pure refactor with no behavioral change. The worktree path resolution logic is identical, just moved from session-forensics to auto.ts where it belongs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)