### PR TITLE
refactor: extract planning-state validation helpers in detectRogueFileWrites

### DIFF
--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -84,6 +84,14 @@ export interface RogueFileWrite {
  * in postUnitPostVerification() eventually ingests rogue files, but explicit
  * detection provides immediate diagnostics so operators know the prompt failed.
  */
+function hasNonEmptyFields(row: Record<string, unknown> | null, fields: string[]): boolean {
+  if (!row) return false;
+  return fields.some(f => String(row[f] || "").trim().length > 0);
+}
+
+const MILESTONE_PLANNING_FIELDS = ["title", "vision", "requirement_coverage", "boundary_map_markdown"];
+const SLICE_PLANNING_FIELDS = ["title", "demo", "risk", "depends"];
+
 export function detectRogueFileWrites(
   unitType: string,
   unitId: string,
@@ -124,12 +132,7 @@ export function detectRogueFileWrites(
     if (!roadmapPath || !existsSync(roadmapPath)) return [];
 
     const dbRow = getMilestone(mid);
-    const hasPlanningState = !!dbRow && (
-      String(dbRow.title || "").trim().length > 0 ||
-      String(dbRow.vision || "").trim().length > 0 ||
-      String(dbRow.requirement_coverage || "").trim().length > 0 ||
-      String(dbRow.boundary_map_markdown || "").trim().length > 0
-    );
+    const hasPlanningState = hasNonEmptyFields(dbRow, MILESTONE_PLANNING_FIELDS);
 
     if (!hasPlanningState) {
       rogues.push({ path: roadmapPath, unitType, unitId });
@@ -142,12 +145,7 @@ export function detectRogueFileWrites(
     if (!planPath || !existsSync(planPath)) return [];
 
     const dbRow = getSlice(mid, sid);
-    const hasPlanningState = !!dbRow && (
-      String(dbRow.title || "").trim().length > 0 ||
-      String(dbRow.demo || "").trim().length > 0 ||
-      String(dbRow.risk || "").trim().length > 0 ||
-      String(dbRow.depends || "").trim().length > 0
-    );
+    const hasPlanningState = hasNonEmptyFields(dbRow, SLICE_PLANNING_FIELDS);
 
     if (!hasPlanningState) {
       rogues.push({ path: planPath, unitType, unitId });

--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -84,7 +84,8 @@ export interface RogueFileWrite {
  * in postUnitPostVerification() eventually ingests rogue files, but explicit
  * detection provides immediate diagnostics so operators know the prompt failed.
  */
-function hasNonEmptyFields(row: Record<string, unknown> | null, fields: string[]): boolean {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function hasNonEmptyFields(row: Record<string, any> | null, fields: string[]): boolean {
   if (!row) return false;
   return fields.some(f => String(row[f] || "").trim().length > 0);
 }


### PR DESCRIPTION
## What
Extract duplicate planning-state validation logic in `detectRogueFileWrites()` into a shared `hasNonEmptyFields()` helper function with declarative field-name arrays.

## Why
Two near-identical "has any non-empty field" checks existed for milestone (lines 127-132) and slice (lines 145-150), each repeating the `String(dbRow.field || "").trim().length > 0` pattern 4 times. This duplication makes it easy to introduce inconsistencies when adding new fields or changing the validation logic.

## How
- Added a generic `hasNonEmptyFields(row, fields)` helper that takes a DB row and an array of field names, returning `true` if any field has a non-empty trimmed string value
- Defined `MILESTONE_PLANNING_FIELDS` and `SLICE_PLANNING_FIELDS` constant arrays listing the relevant DB columns
- Replaced both inline validation blocks with single-line calls to the helper

## Key changes
- `src/resources/extensions/gsd/auto-post-unit.ts`: +10 lines, -12 lines — net reduction of 2 lines while improving readability

## Testing
- `npx tsc --noEmit` passes clean
- `npx vitest run src/resources/extensions/gsd/tests/` — all tests pass, 0 failures
- Behavioral equivalence: the helper checks the exact same fields with the exact same `String(val || "").trim().length > 0` logic

## Risk
Low. Pure refactor with no behavioral change. The same fields are checked in the same order with the same coercion logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)