### PR TITLE
refactor: extract merge-state cleanup helper in reconcileMergeState

### DIFF
--- a/src/resources/extensions/gsd/auto-recovery.ts
+++ b/src/resources/extensions/gsd/auto-recovery.ts
@@ -516,6 +516,35 @@ export function diagnoseExpectedArtifact(
 // ─── Merge State Reconciliation ───────────────────────────────────────────────
 
 /**
+ * Best-effort abort of a pending merge/squash and hard-reset to HEAD.
+ * Handles both real merges (MERGE_HEAD) and squash merges (SQUASH_MSG).
+ */
+function abortAndResetMerge(
+  basePath: string,
+  hasMergeHead: boolean,
+  squashMsgPath: string,
+): void {
+  if (hasMergeHead) {
+    try {
+      nativeMergeAbort(basePath);
+    } catch {
+      /* best-effort */
+    }
+  } else if (squashMsgPath) {
+    try {
+      unlinkSync(squashMsgPath);
+    } catch {
+      /* best-effort */
+    }
+  }
+  try {
+    nativeResetHard(basePath);
+  } catch {
+    /* best-effort */
+  }
+}
+
+/**
  * Detect leftover merge state from a prior session and reconcile it.
  * If MERGE_HEAD or SQUASH_MSG exists, check whether conflicts are resolved.
  * If resolved: finalize the commit. If still conflicted: abort and reset.
@@ -571,24 +600,7 @@ export function reconcileMergeState(
         }
       }
       if (!resolved) {
-        if (hasMergeHead) {
-          try {
-            nativeMergeAbort(basePath);
-          } catch {
-            /* best-effort */
-          }
-        } else if (hasSquashMsg) {
-          try {
-            unlinkSync(squashMsgPath);
-          } catch {
-            /* best-effort */
-          }
-        }
-        try {
-          nativeResetHard(basePath);
-        } catch {
-          /* best-effort */
-        }
+        abortAndResetMerge(basePath, hasMergeHead, squashMsgPath);
         ctx.ui.notify(
           "Detected leftover merge state — auto-resolve failed, cleaned up. Re-deriving state.",
           "warning",
@@ -596,24 +608,7 @@ export function reconcileMergeState(
       }
     } else {
       // Code conflicts present — abort and reset
-      if (hasMergeHead) {
-        try {
-          nativeMergeAbort(basePath);
-        } catch {
-          /* best-effort */
-        }
-      } else if (hasSquashMsg) {
-        try {
-          unlinkSync(squashMsgPath);
-        } catch {
-          /* best-effort */
-        }
-      }
-      try {
-        nativeResetHard(basePath);
-      } catch {
-        /* best-effort */
-      }
+      abortAndResetMerge(basePath, hasMergeHead, squashMsgPath);
       ctx.ui.notify(
         "Detected leftover merge state with unresolved conflicts — cleaned up. Re-deriving state.",
         "warning",


### PR DESCRIPTION
## What
Extract duplicate merge-state cleanup code in `reconcileMergeState()` into a private `abortAndResetMerge()` helper function.

## Why
The same ~20-line cleanup sequence (merge abort / squash msg unlink / hard reset, each wrapped in best-effort try-catch) appeared twice consecutively in `reconcileMergeState()` — pure copy-paste duplication within the same function. This makes the function harder to read and creates a maintenance risk where one copy could diverge from the other.

## How
- Added a private `abortAndResetMerge(basePath, hasMergeHead, squashMsgPath)` function that encapsulates the three-step cleanup: abort merge if MERGE_HEAD exists, unlink SQUASH_MSG if it exists instead, then hard-reset.
- Replaced both inline cleanup blocks (the "auto-resolve failed" path and the "code conflicts present" path) with calls to the new helper.
- Each call site retains its own distinct notification message.

## Key changes
- `src/resources/extensions/gsd/auto-recovery.ts`: New private `abortAndResetMerge()` helper (lines 522-545), two call sites replacing duplicated inline blocks.

## Testing
- `npx tsc --noEmit` passes clean — no type errors introduced.
- Behavior is identical: the helper contains the exact same logic that was previously inlined at both call sites.
- No new code paths or conditional branches introduced.

## Risk
Minimal. Pure mechanical extraction with no logic changes. The function is private (not exported) so there is no API surface change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)