### PR TITLE
refactor: flatten syncMilestoneDir nesting with shared helper

### DIFF
--- a/src/resources/extensions/gsd/auto-worktree.ts
+++ b/src/resources/extensions/gsd/auto-worktree.ts
@@ -379,6 +379,29 @@ export function syncWorktreeStateBack(
  * Sync a single milestone directory from worktree to main.
  * Copies milestone-level .md files, slice-level files, and task summaries.
  */
+/** Copy matching files from srcDir to dstDir (non-fatal per file). */
+function syncDirFiles(
+  srcDir: string,
+  dstDir: string,
+  filter: (name: string) => boolean,
+  synced: string[],
+  prefix: string,
+): void {
+  try {
+    for (const entry of readdirSync(srcDir, { withFileTypes: true })) {
+      if (!entry.isFile() || !filter(entry.name)) continue;
+      try {
+        cpSync(join(srcDir, entry.name), join(dstDir, entry.name), { force: true });
+        synced.push(`${prefix}${entry.name}`);
+      } catch {
+        /* non-fatal */
+      }
+    }
+  } catch {
+    /* non-fatal — srcDir may not be readable */
+  }
+}
+
 function syncMilestoneDir(
   wtGsd: string,
   mainGsd: string,
@@ -391,83 +414,35 @@ function syncMilestoneDir(
   if (!existsSync(wtMilestoneDir)) return;
   mkdirSync(mainMilestoneDir, { recursive: true });
 
+  const isMd = (name: string): boolean => name.endsWith(".md");
+
   // Sync milestone-level files (SUMMARY, VALIDATION, ROADMAP, CONTEXT)
+  syncDirFiles(wtMilestoneDir, mainMilestoneDir, isMd, synced, `milestones/${mid}/`);
+
+  // Sync slice-level files (summaries, UATs) and task summaries (#1678)
+  const wtSlicesDir = join(wtMilestoneDir, "slices");
+  const mainSlicesDir = join(mainMilestoneDir, "slices");
+  if (!existsSync(wtSlicesDir)) return;
+
   try {
-    for (const entry of readdirSync(wtMilestoneDir, { withFileTypes: true })) {
-      if (entry.isFile() && entry.name.endsWith(".md")) {
-        const src = join(wtMilestoneDir, entry.name);
-        const dst = join(mainMilestoneDir, entry.name);
-        try {
-          cpSync(src, dst, { force: true });
-          synced.push(`milestones/${mid}/${entry.name}`);
-        } catch {
-          /* non-fatal */
-        }
+    for (const sliceEntry of readdirSync(wtSlicesDir, { withFileTypes: true })) {
+      if (!sliceEntry.isDirectory()) continue;
+      const sid = sliceEntry.name;
+      const wtSliceDir = join(wtSlicesDir, sid);
+      const mainSliceDir = join(mainSlicesDir, sid);
+      mkdirSync(mainSliceDir, { recursive: true });
+
+      syncDirFiles(wtSliceDir, mainSliceDir, isMd, synced, `milestones/${mid}/slices/${sid}/`);
+
+      const wtTasksDir = join(wtSliceDir, "tasks");
+      const mainTasksDir = join(mainSliceDir, "tasks");
+      if (existsSync(wtTasksDir)) {
+        mkdirSync(mainTasksDir, { recursive: true });
+        syncDirFiles(wtTasksDir, mainTasksDir, isMd, synced, `milestones/${mid}/slices/${sid}/tasks/`);
       }
     }
   } catch {
     /* non-fatal */
-  }
-
-  // Sync slice-level files (summaries, UATs)
-  const wtSlicesDir = join(wtMilestoneDir, "slices");
-  const mainSlicesDir = join(mainMilestoneDir, "slices");
-  if (existsSync(wtSlicesDir)) {
-    try {
-      for (const sliceEntry of readdirSync(wtSlicesDir, {
-        withFileTypes: true,
-      })) {
-        if (!sliceEntry.isDirectory()) continue;
-        const sid = sliceEntry.name;
-        const wtSliceDir = join(wtSlicesDir, sid);
-        const mainSliceDir = join(mainSlicesDir, sid);
-        mkdirSync(mainSliceDir, { recursive: true });
-
-        for (const fileEntry of readdirSync(wtSliceDir, {
-          withFileTypes: true,
-        })) {
-          if (fileEntry.isFile() && fileEntry.name.endsWith(".md")) {
-            const src = join(wtSliceDir, fileEntry.name);
-            const dst = join(mainSliceDir, fileEntry.name);
-            try {
-              cpSync(src, dst, { force: true });
-              synced.push(
-                `milestones/${mid}/slices/${sid}/${fileEntry.name}`,
-              );
-            } catch {
-              /* non-fatal */
-            }
-          } else if (fileEntry.isDirectory() && fileEntry.name === "tasks") {
-            // Recurse into tasks/ subdirectory to sync task summaries (#1678).
-            // Without this, T01-SUMMARY.md etc. are silently dropped on
-            // worktree teardown because the loop only processes isFile() entries.
-            const wtTasksDir = join(wtSliceDir, "tasks");
-            const mainTasksDir = join(mainSliceDir, "tasks");
-            mkdirSync(mainTasksDir, { recursive: true });
-            try {
-              for (const taskEntry of readdirSync(wtTasksDir, { withFileTypes: true })) {
-                if (taskEntry.isFile() && taskEntry.name.endsWith(".md")) {
-                  const taskSrc = join(wtTasksDir, taskEntry.name);
-                  const taskDst = join(mainTasksDir, taskEntry.name);
-                  try {
-                    cpSync(taskSrc, taskDst, { force: true });
-                    synced.push(
-                      `milestones/${mid}/slices/${sid}/tasks/${taskEntry.name}`,
-                    );
-                  } catch {
-                    /* non-fatal */
-                  }
-                }
-              }
-            } catch {
-              /* non-fatal: tasks dir read failure */
-            }
-          }
-        }
-      }
-    } catch {
-      /* non-fatal */
-    }
   }
 }
 // ─── Worktree Post-Create Hook (#597) ────────────────────────────────────────


### PR DESCRIPTION
## What
Extract a `syncDirFiles()` helper from `syncMilestoneDir()` in `auto-worktree.ts` to eliminate deeply nested, duplicated copy logic.

## Why
The original 90-line function had 4 levels of nesting: try/catch inside loops inside try/catch. Three structurally identical operations (root milestone files, slice files, task files) each re-implemented the same iterate/filter/copy/catch pattern at different directory depths. This made the function hard to read and maintain.

## How
- Extracted a shared `syncDirFiles(srcDir, dstDir, filter, synced, prefix)` helper that encapsulates the non-fatal directory read + file filter + force-copy + tracking pattern.
- Rewrote `syncMilestoneDir()` to call `syncDirFiles()` three times (once per directory level) instead of inlining the logic each time.
- Maximum nesting depth reduced from 4 to 2 (outer loop over slice dirs, inner calls to helper).

## Key changes
- **New function**: `syncDirFiles()` — generic non-fatal file copier with filtering
- **Modified function**: `syncMilestoneDir()` — uses `syncDirFiles()` at each level (milestone root, slice dirs, task dirs)
- Net reduction: 71 lines removed, 46 lines added

## Testing
- `npx tsc --noEmit` passes clean
- All worktree sync tests pass (worktree-sync-milestones, worktree-sync-tasks, worktree-sync-overwrite-loop, auto-worktree, auto-worktree-milestone-merge)
- Behavior preserved: same file filters (.md), same non-fatal semantics, same force overwrite

## Risk
Low — pure refactor with no behavioral changes. All existing tests pass without modification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)