### PR TITLE
fix: reconcile stale task status in filesystem-based state derivation

### DIFF
--- a/src/resources/extensions/gsd/state.ts
+++ b/src/resources/extensions/gsd/state.ts
@@ -1248,6 +1248,24 @@ export async function _deriveStateImpl(basePath: string): Promise<GSDState> {
   }
 
   const slicePlan = parsePlan(slicePlanContent);
+
+  // ── Reconcile stale task status for filesystem-based projects (#2514) ──
+  // Heading-style tasks (### T01:) are always parsed as done=false by
+  // parsePlan because the heading syntax has no checkbox. When the agent
+  // writes a SUMMARY file but the plan's heading isn't converted to a
+  // checkbox, the task appears incomplete forever — causing infinite
+  // re-dispatch. Reconcile by checking SUMMARY files on disk.
+  for (const t of slicePlan.tasks) {
+    if (t.done) continue;
+    const summaryPath = resolveTaskFile(basePath, activeMilestone.id, activeSlice.id, t.id, "SUMMARY");
+    if (summaryPath && existsSync(summaryPath)) {
+      t.done = true;
+      process.stderr.write(
+        `gsd-reconcile: task ${activeMilestone.id}/${activeSlice.id}/${t.id} has SUMMARY on disk but plan shows incomplete — marking done (#2514)\n`,
+      );
+    }
+  }
+
   const taskProgress = {
     done: slicePlan.tasks.filter(t => t.done).length,
     total: slicePlan.tasks.length,


### PR DESCRIPTION
## Summary

Fixes #2619

`_deriveStateImpl` (filesystem-based state derivation, used when no `gsd.db` exists) lacked the SUMMARY-based task reconciliation added to `deriveStateFromDb` in 561d0103.

## Problem

Heading-style tasks (`### T01: Title`) are always parsed as `done=false` by `parsePlan()` because the heading syntax has no checkbox. When the agent writes a SUMMARY file but the plan heading is not converted to a checkbox, the task appears incomplete forever — causing **infinite re-dispatch of the same completed task**.

This was already fixed for the DB-backed path in #2514 (commit 561d0103), but the filesystem path (`_deriveStateImpl`) was missed. Projects without `gsd.db` hit this bug.

### Root cause

`parsePlan()` recognizes two task formats:
1. `- [x] **T01: Title**` → `done` from checkbox state  
2. `### T01: Title` → **always `done=false`** (no checkbox to read)

The DB path reconciles via SUMMARY files. The filesystem path did not.

## Fix

After `parsePlan()` in `_deriveStateImpl`, iterate non-done tasks and check for SUMMARY files on disk. If found, mark `done=true` and log to stderr for observability.

## Related

- Extends #2514 (DB-only fix) to cover the filesystem path
- Closes #2619