### PR TITLE
feat(validate): surface verification classes during milestone validation

### DIFF
--- a/src/resources/extensions/gsd/auto-prompts.ts
+++ b/src/resources/extensions/gsd/auto-prompts.ts
@@ -1328,6 +1328,24 @@ export async function buildValidateMilestonePrompt(
   const inlined: string[] = [];
   inlined.push(await inlineFile(roadmapPath, roadmapRel, "Milestone Roadmap"));
 
+  // Inline verification classes from planning (if available in DB)
+  try {
+    const { isDbAvailable, getMilestone } = await import("./gsd-db.js");
+    if (isDbAvailable()) {
+      const milestone = getMilestone(mid);
+      if (milestone) {
+        const classes: string[] = [];
+        if (milestone.verification_contract) classes.push(`- **Contract:** ${milestone.verification_contract}`);
+        if (milestone.verification_integration) classes.push(`- **Integration:** ${milestone.verification_integration}`);
+        if (milestone.verification_operational) classes.push(`- **Operational:** ${milestone.verification_operational}`);
+        if (milestone.verification_uat) classes.push(`- **UAT:** ${milestone.verification_uat}`);
+        if (classes.length > 0) {
+          inlined.push(`### Verification Classes (from planning)\n\nThese verification tiers were defined during milestone planning. Each non-empty class must be checked for evidence during validation.\n\n${classes.join("\n")}`);
+        }
+      }
+    }
+  } catch { /* fall through */ }
+
   // Inline all slice summaries and UAT results
   let valSliceIds: string[] = [];
   try {

--- a/src/resources/extensions/gsd/prompts/validate-milestone.md
+++ b/src/resources/extensions/gsd/prompts/validate-milestone.md
@@ -24,7 +24,12 @@ All relevant context has been preloaded below — the roadmap, all slice summari
 2. For each **slice** in the roadmap, verify its demo/deliverable claim against its summary. Flag any slice whose summary does not substantiate its claimed output.
 3. Check **cross-slice integration points** — do boundary map entries (produces/consumes) align with what was actually built?
 4. Check **requirement coverage** — are all active requirements addressed by at least one slice?
-5. Determine a verdict:
+5. If **Verification Classes** are provided in the inlined context above, check each non-empty class:
+   - For each verification class (Contract, Integration, Operational, UAT), determine whether slice summaries, UAT results, or observable behavior provide evidence that this verification tier was addressed.
+   - Document the compliance status of each class in your verdict rationale.
+   - If `Operational` verification is non-empty and no evidence of operational verification exists, flag this explicitly — it means planned operational checks (migrations, deployments, runtime verification) were not proven.
+   - A milestone with unaddressed verification classes may still pass if the gaps are minor, but the gaps MUST be documented in the Deferred Work Inventory.
+6. Determine a verdict:
    - `pass` — all criteria met, all slices delivered, no gaps
    - `needs-attention` — minor gaps that do not block completion (document them)
    - `needs-remediation` — material gaps found; remediation slices must be added to the roadmap

--- a/src/resources/extensions/gsd/templates/milestone-validation.md
+++ b/src/resources/extensions/gsd/templates/milestone-validation.md
@@ -35,6 +35,18 @@ validated_at: {{date}}
 
 - **{{requirementId}}**: {{status}} — {{disposition: covered by remediation slice / acceptable gap / needs attention}}
 
+## Verification Class Compliance
+
+<!-- If verification classes were defined during planning, document whether each
+     was addressed. Use N/A for classes that were empty or "none" in planning. -->
+
+| Class | Planned | Evidence | Status |
+|-------|---------|----------|--------|
+| Contract | {{planned_or_none}} | {{evidence_or_none}} | {{MET / NOT MET / N/A}} |
+| Integration | {{planned_or_none}} | {{evidence_or_none}} | {{MET / NOT MET / N/A}} |
+| Operational | {{planned_or_none}} | {{evidence_or_none}} | {{MET / NOT MET / N/A}} |
+| UAT | {{planned_or_none}} | {{evidence_or_none}} | {{MET / NOT MET / N/A}} |
+
 ## Remediation Slices
 
 <!-- New slices appended to the roadmap to address auto-remediable gaps.


### PR DESCRIPTION
## TL;DR

**What:** Inject verification class data (contract, integration, operational, UAT) from the DB into the validate-milestone prompt so the validator checks whether planned verification tiers were actually addressed.
**Why:** These fields are captured during milestone planning but never read back during validation — milestones can pass even when planned operational verification was never performed.
**How:** Query `getMilestone()` in the prompt builder to retrieve verification_* fields and inject them as structured context; add a compliance check step to the validation prompt and template.

## What

| File | Change |
|------|--------|
| `src/resources/extensions/gsd/auto-prompts.ts` | Query `getMilestone()` in `buildValidateMilestonePrompt()` to inject verification_* fields as a structured "Verification Classes (from planning)" section into the inlined context |
| `src/resources/extensions/gsd/prompts/validate-milestone.md` | Add step 5 (Verification Class Compliance): for each non-empty verification class, check whether evidence exists in slice summaries/UAT results; flag unaddressed operational verification explicitly |
| `src/resources/extensions/gsd/templates/milestone-validation.md` | Add "Verification Class Compliance" table (Class / Planned / Evidence / Status) to the validation output template, placed before Remediation Slices |

## Why

During milestone planning, `gsd_plan_milestone` captures four verification class fields:
- `verification_contract` — what can be proven by tests/fixtures/artifacts
- `verification_integration` — what must work across real subsystems
- `verification_operational` — what must work under real lifecycle conditions (migrations, deployments, runtime)
- `verification_uat` — what needs real human judgment

These fields are stored in the `milestones` DB table and rendered into the roadmap's "Verification Classes" section. However, `buildValidateMilestonePrompt()` never queries the milestone row to retrieve them, and `validate-milestone.md` has no step to check whether these tiers were addressed. The result: a milestone that planned for operational verification (e.g., "database migration must be applied and verified") can pass validation without any evidence that the operational tier was checked.

This is a soft gate — it surfaces the data and instructs the validator to document compliance. It does not add a hard block. The validator can still issue a `pass` verdict if the gaps are minor, but unaddressed verification tiers must be documented in the Deferred Work Inventory.

## How

**Approach:** Follow the existing inlined-context pattern already used for roadmap, summaries, UAT results, requirements, decisions, and project context. Add one more inlined section — verification classes — queried from the DB via `getMilestone()`.

The prompt change adds a new validation step (step 5, renumbering the verdict step to 6) that:
1. Checks each non-empty verification class for evidence
2. Documents compliance in the verdict rationale
3. Explicitly flags unaddressed operational verification

**Backwards compatible:** If all four verification_* fields are empty (the default for existing milestones), the section is omitted entirely from the prompt — no behavior change for existing milestones.

**Alternatives considered:**
- Hard gate in `auto-dispatch.ts` that blocks completion — deferred as a separate follow-up (progressive enforcement: soft gate first, hard gate later)
- New DB table for verification evidence — over-engineered for the first pass; the prompt-driven approach leverages existing architecture

## Test Evidence

- `npm run build` passes with zero type errors
- The change is additive: 36 insertions, 1 deletion (renumbered step)
- Verification class injection follows the same `try { import; if (isDbAvailable()) } catch {}` pattern used 4 times already in the same function
- Template change is purely structural (new section with placeholder comments)

---

> AI-assisted contribution — reviewed and tested by contributor.

- [x] `feat`