### PR TITLE
feat(validate): extract followUps and knownLimitations in parseSummary

### DIFF
--- a/src/resources/extensions/gsd/auto-prompts.ts
+++ b/src/resources/extensions/gsd/auto-prompts.ts
@@ -1357,6 +1357,21 @@ export async function buildValidateMilestonePrompt(
     if (uatInline) inlined.push(uatInline);
   }
 
+  // Aggregate unresolved follow-ups and known limitations across slices
+  const outstandingItems: string[] = [];
+  for (const sid of valSliceIds) {
+    const summaryPath = resolveSliceFile(base, mid, sid, "SUMMARY");
+    if (!summaryPath) continue;
+    const content = await loadFile(summaryPath);
+    if (!content) continue;
+    const summary = parseSummary(content);
+    if (summary.followUps) outstandingItems.push(`- **${sid} Follow-ups:** ${summary.followUps.trim()}`);
+    if (summary.knownLimitations) outstandingItems.push(`- **${sid} Known Limitations:** ${summary.knownLimitations.trim()}`);
+  }
+  if (outstandingItems.length > 0) {
+    inlined.push(`### Outstanding Items (aggregated from slice summaries)\n\nThese follow-ups and known limitations were documented during slice completion but have not been resolved.\n\n${outstandingItems.join('\n')}`);
+  }
+
   // Inline existing VALIDATION file if this is a re-validation round
   const validationPath = resolveMilestoneFile(base, mid, "VALIDATION");
   const validationRel = relMilestoneFile(base, mid, "VALIDATION");

--- a/src/resources/extensions/gsd/files.ts
+++ b/src/resources/extensions/gsd/files.ts
@@ -269,6 +269,8 @@ function _parseSummaryImpl(content: string): Summary {
       whatHappened: nativeResult.whatHappened,
       deviations: nativeResult.deviations,
       filesModified: nativeResult.filesModified,
+      followUps: extractSection(content, 'Follow-ups') ?? '',
+      knownLimitations: extractSection(content, 'Known Limitations') ?? '',
     };
   }
 
@@ -330,7 +332,10 @@ function _parseSummaryImpl(content: string): Summary {
     }
   }
 
-  return { frontmatter, title, oneLiner, whatHappened, deviations, filesModified };
+  const followUps = extractSection(body, 'Follow-ups') ?? '';
+  const knownLimitations = extractSection(body, 'Known Limitations') ?? '';
+
+  return { frontmatter, title, oneLiner, whatHappened, deviations, filesModified, followUps, knownLimitations };
 }
 
 // ─── Continue Parser ───────────────────────────────────────────────────────

--- a/src/resources/extensions/gsd/types.ts
+++ b/src/resources/extensions/gsd/types.ts
@@ -156,6 +156,8 @@ export interface Summary {
   whatHappened: string;
   deviations: string;
   filesModified: FileModified[];
+  followUps: string;
+  knownLimitations: string;
 }
 
 // ─── Continue-Here ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## TL;DR

**What:** Add `followUps` and `knownLimitations` fields to the `Summary` type and extract them in `parseSummary()`, then aggregate outstanding items into the validate-milestone prompt.
**Why:** These sections are written during slice completion but never parsed back — making them write-only data invisible to downstream validation.
**How:** Two new `extractSection()` calls in the summary parser, two new fields on the `Summary` interface, and an aggregation step in `buildValidateMilestonePrompt()`.

## What

| File | Change |
|------|--------|
| `src/resources/extensions/gsd/types.ts` | Add `followUps: string` and `knownLimitations: string` to `Summary` interface |
| `src/resources/extensions/gsd/files.ts` | Add two `extractSection()` calls in summary parser for Follow-ups and Known Limitations |
| `src/resources/extensions/gsd/auto-prompts.ts` | Aggregate non-empty followUps/knownLimitations across slices into validate-milestone prompt context |

## Why

During slice completion, `gsd_slice_complete` renders `## Follow-ups` and `## Known Limitations` sections into SUMMARY.md. These capture concrete deferred work and known gaps. However:

1. `parseSummary()` in `files.ts` extracts `whatHappened`, `deviations`, and `filesModified` — but not Follow-ups or Known Limitations
2. The `Summary` interface has no fields for them
3. No downstream prompt or validation logic can programmatically access this data
4. The validate-milestone prompt builder inlines slice summaries as raw text, but the validator has no structured signal about outstanding items

The result: follow-ups and limitations documented during execution are effectively invisible during milestone validation. The validator must manually spot them in raw markdown — unreliable at best.

Part of a series improving verification class consumption during milestone validation (see also #2621).

## How

1. **types.ts:** Add two string fields to `Summary` — defaulting to empty string for backwards compatibility
2. **files.ts:** Add `extractSection(body, 'Follow-ups')` and `extractSection(body, 'Known Limitations')` alongside the existing section extractions. The `extractSection()` helper already handles all the markdown parsing.
3. **auto-prompts.ts:** After inlining slice summaries in `buildValidateMilestonePrompt()`, iterate parsed summaries and collect non-empty followUps/knownLimitations into an "Outstanding Items" section injected into the prompt context.

**Backwards compatible:** Existing summaries without these sections return empty strings — no behavior change for existing milestones.

## Test Evidence

- `npm run build` passes with zero type errors
- `extractSection()` is battle-tested — used for 3 other sections in the same function
- Summary interface change is additive (new optional-defaulting fields)

---

> AI-assisted contribution — reviewed and tested by contributor.

- [x] `feat`