### PR TITLE
Defer default model validation until after extensions register

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -367,38 +367,37 @@ if (cliFlags.listModels !== undefined) {
 
 // Validate configured model on startup — catches stale settings from prior installs
 // (e.g. grok-2 which no longer exists) and fresh installs with no settings.
-// Only resets the default when the configured model no longer exists in the registry;
-// never overwrites a valid user choice.
-const configuredProvider = settingsManager.getDefaultProvider()
-const configuredModel = settingsManager.getDefaultModel()
-const allModels = modelRegistry.getAll()
-const availableModels = modelRegistry.getAvailable()
-const configuredExists = configuredProvider && configuredModel &&
-  allModels.some((m) => m.provider === configuredProvider && m.id === configuredModel)
-const configuredAvailable = configuredProvider && configuredModel &&
-  availableModels.some((m) => m.provider === configuredProvider && m.id === configuredModel)
+// Deferred to after createAgentSession so extension-provided models (e.g. claude-code)
+// are registered in the model registry before validation runs.
+function validateDefaultModel(): void {
+  const cfgProvider = settingsManager.getDefaultProvider()
+  const cfgModel = settingsManager.getDefaultModel()
+  const all = modelRegistry.getAll()
+  const available = modelRegistry.getAvailable()
+  const exists = cfgProvider && cfgModel &&
+    all.some((m) => m.provider === cfgProvider && m.id === cfgModel)
 
-if (!configuredModel || !configuredExists) {
-  // Model not configured at all, or removed from registry — pick a fallback.
-  // Only fires when the model is genuinely unknown (not just temporarily unavailable).
-  const piDefault = getPiDefaultModelAndProvider()
-  const preferred =
-    (piDefault
-      ? availableModels.find((m) => m.provider === piDefault.provider && m.id === piDefault.model)
-      : undefined) ||
-    availableModels.find((m) => m.provider === 'openai' && m.id === 'gpt-5.4') ||
-    availableModels.find((m) => m.provider === 'openai') ||
-    availableModels.find((m) => m.provider === 'anthropic' && m.id === 'claude-opus-4-6') ||
-    availableModels.find((m) => m.provider === 'anthropic' && m.id.includes('opus')) ||
-    availableModels.find((m) => m.provider === 'anthropic') ||
-    availableModels[0]
-  if (preferred) {
-    settingsManager.setDefaultModelAndProvider(preferred.provider, preferred.id)
+  if (!cfgModel || !exists) {
+    // Model not configured at all, or removed from registry — pick a fallback.
+    const piDefault = getPiDefaultModelAndProvider()
+    const preferred =
+      (piDefault
+        ? available.find((m) => m.provider === piDefault.provider && m.id === piDefault.model)
+        : undefined) ||
+      available.find((m) => m.provider === 'openai' && m.id === 'gpt-5.4') ||
+      available.find((m) => m.provider === 'openai') ||
+      available.find((m) => m.provider === 'anthropic' && m.id === 'claude-opus-4-6') ||
+      available.find((m) => m.provider === 'anthropic' && m.id.includes('opus')) ||
+      available.find((m) => m.provider === 'anthropic') ||
+      available[0]
+    if (preferred) {
+      settingsManager.setDefaultModelAndProvider(preferred.provider, preferred.id)
+    }
   }
-}
 
-if (settingsManager.getDefaultThinkingLevel() !== 'off' && !configuredExists) {
-  settingsManager.setDefaultThinkingLevel('off')
+  if (settingsManager.getDefaultThinkingLevel() !== 'off' && !exists) {
+    settingsManager.setDefaultThinkingLevel('off')
+  }
 }
 
 // GSD always uses quiet startup — the gsd extension renders its own branded header
@@ -458,6 +457,9 @@ if (isPrintMode) {
       process.stderr.write(`[gsd] ${prefix}: ${err.error}\n`)
     }
   }
+
+  // Validate default model now that extensions have registered their models
+  validateDefaultModel()
 
   // Apply --model override if specified
   if (cliFlags.model) {
@@ -589,6 +591,9 @@ if (extensionsResult.errors.length > 0) {
     process.stderr.write(`[gsd] ${prefix}: ${err.error}\n`)
   }
 }
+
+// Validate default model now that extensions have registered their models
+validateDefaultModel()
 
 // Restore scoped models from settings on startup.
 // The upstream InteractiveMode reads enabledModels from settings when /scoped-models is opened,


### PR DESCRIPTION
## Summary

- Fixes #2626 — extension-provided models (e.g. `claude-code`) silently overwritten on every startup
- Extracts startup model validation into `validateDefaultModel()` function
- Calls it after `createAgentSession()` in both print and interactive mode paths, so extension models are registered before validation runs

## Root Cause

The startup model validation at `src/cli.ts:368-398` ran before `createAgentSession()`, which is where extensions call `registerProvider()` to add their models to the `ModelRegistry`. Any extension model set as default (e.g. `claude-code/claude-sonnet-4-6`) would fail the `configuredExists` check and get overwritten by the fallback logic.

## Changes

**`src/cli.ts`** — single file, minimal diff:
1. Replaced inline validation block with `validateDefaultModel()` function (same logic, no behavior change)
2. Added call after `createAgentSession()` in print-mode path (line ~460)
3. Added call after `createAgentSession()` in interactive-mode path (line ~595)

## Test plan

- [ ] Set `defaultProvider: "claude-code"` and `defaultModel: "claude-sonnet-4-6"` in `~/.gsd/agent/settings.json`
- [ ] Start `gsd` — verify status bar shows `(claude-code) claude-sonnet-4-6`
- [ ] Restart `gsd` — verify the setting persists (not overwritten)
- [ ] Remove the `defaultModel` field entirely — verify fallback logic still picks a valid model
- [ ] Set a non-existent model (e.g. `fake-provider/fake-model`) — verify fallback still works
- [ ] Test `gsd --print "hello"` — verify print mode also validates correctly