### PR TITLE
fix(notifications): prefer terminal-notifier over osascript on macOS

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -494,6 +494,14 @@ notifications:
   on_attention: true          # notify when manual attention needed
 ```
 
+**macOS delivery:** GSD uses [`terminal-notifier`](https://github.com/julienXX/terminal-notifier) when available, falling back to `osascript`. We recommend installing `terminal-notifier` for reliable notification delivery:
+
+```bash
+brew install terminal-notifier
+```
+
+Why: `osascript display notification` is attributed to your terminal app (Ghostty, iTerm2, etc.), which may not have notification permissions in System Settings → Notifications. `terminal-notifier` registers as its own app and prompts for permission on first use. See [Troubleshooting: Notifications not appearing on macOS](troubleshooting.md#notifications-not-appearing-on-macos) if notifications aren't working.
+
 ### `remote_questions`
 
 Route interactive questions to Slack or Discord for headless auto mode:

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -339,3 +339,33 @@ This shows which servers are active and, if none are found, diagnoses why — in
 | Go | `go install golang.org/x/tools/gopls@latest` |
 
 After installing, run `lsp reload` to restart detection without restarting GSD.
+
+## Notifications
+
+### Notifications not appearing on macOS
+
+**Symptoms:** `notifications.enabled: true` in preferences, but no desktop notifications appear during auto-mode (no milestone complete alerts, no budget warnings, no error notifications). No error messages logged.
+
+**Cause:** GSD uses `osascript display notification` as a fallback on macOS. This command is attributed to your terminal app (Ghostty, iTerm2, Alacritty, Kitty, Warp, etc.). If that app doesn't have notification permissions in System Settings → Notifications, macOS silently drops the notification — `osascript` exits 0 with no error.
+
+Most terminal apps don't appear in the Notifications settings panel until they've successfully delivered at least one notification, creating a chicken-and-egg problem.
+
+**Fix (recommended):** Install `terminal-notifier`, which registers as its own Notification Center app:
+
+```bash
+brew install terminal-notifier
+```
+
+GSD automatically prefers `terminal-notifier` when available. On first use, macOS will prompt you to allow notifications — this is the expected behavior.
+
+**Fix (alternative):** Go to **System Settings → Notifications** and enable notifications for your terminal app. If your terminal doesn't appear in the list, try sending a test notification from Terminal.app first to register "Script Editor":
+
+```bash
+osascript -e 'display notification "test" with title "GSD"'
+```
+
+**Verify:** After applying either fix, test with:
+
+```bash
+terminal-notifier -title "GSD" -message "working!" -sound Glass
+```

--- a/src/resources/extensions/gsd/notifications.ts
+++ b/src/resources/extensions/gsd/notifications.ts
@@ -74,6 +74,17 @@ export function buildDesktopNotificationCommand(
   const normalizedMessage = normalizeNotificationText(message);
 
   if (platform === "darwin") {
+    // Prefer terminal-notifier: registers as its own Notification Center app,
+    // so it gets a proper permission entry in System Settings → Notifications.
+    // osascript notifications are silently swallowed when the calling terminal
+    // (Ghostty, iTerm2, etc.) lacks notification permissions — exits 0, no error.
+    // See: https://github.com/gsd-build/gsd-2/issues/2632
+    const tnPath = findExecutable("terminal-notifier");
+    if (tnPath) {
+      const sound = level === "error" ? "Basso" : "Glass";
+      return { file: tnPath, args: ["-title", normalizedTitle, "-message", normalizedMessage, "-sound", sound] };
+    }
+    // Fallback: osascript (works if terminal app has notification permissions)
     const sound = level === "error" ? 'sound name "Basso"' : 'sound name "Glass"';
     const script = `display notification "${escapeAppleScript(normalizedMessage)}" with title "${escapeAppleScript(normalizedTitle)}" ${sound}`;
     return { file: "osascript", args: ["-e", script] };
@@ -93,4 +104,16 @@ function normalizeNotificationText(s: string): string {
 
 function escapeAppleScript(s: string): string {
   return s.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
+/**
+ * Locate an executable on PATH. Returns absolute path or null.
+ * Non-fatal — returns null on any error.
+ */
+function findExecutable(name: string): string | null {
+  try {
+    return execFileSync("which", [name], { timeout: 2000, stdio: ["ignore", "pipe", "ignore"] }).toString().trim() || null;
+  } catch {
+    return null;
+  }
 }

--- a/src/resources/extensions/gsd/tests/notifications.test.ts
+++ b/src/resources/extensions/gsd/tests/notifications.test.ts
@@ -31,7 +31,10 @@ test("shouldSendDesktopNotification disables all categories when notifications a
   assert.equal(shouldSendDesktopNotification("milestone", prefs), false);
 });
 
-test("buildDesktopNotificationCommand uses argument arrays for macOS notifications", () => {
+test("buildDesktopNotificationCommand falls back to osascript on macOS when terminal-notifier is absent", () => {
+  // When terminal-notifier is not on PATH, falls back to osascript.
+  // This test runs in CI where terminal-notifier is typically not installed.
+  // If terminal-notifier IS installed, we verify it returns that instead.
   const command = buildDesktopNotificationCommand(
     "darwin",
     `Bob's "Milestone"`,
@@ -40,11 +43,30 @@ test("buildDesktopNotificationCommand uses argument arrays for macOS notificatio
   );
 
   assert.ok(command);
-  assert.equal(command.file, "osascript");
-  assert.deepEqual(command.args.slice(0, 1), ["-e"]);
-  assert.match(command.args[1], /Bob's \\"Milestone\\"/);
-  assert.match(command.args[1], /Budget! Path: C:\\\\temp/);
-  assert.doesNotMatch(command.args[1], /\n/);
+  if (command.file.includes("terminal-notifier")) {
+    // terminal-notifier path — verify args structure
+    assert.ok(command.args.includes("-title"));
+    assert.ok(command.args.includes("-message"));
+    assert.ok(command.args.includes("-sound"));
+    assert.ok(command.args.includes("Basso")); // error level
+  } else {
+    // osascript fallback path
+    assert.equal(command.file, "osascript");
+    assert.deepEqual(command.args.slice(0, 1), ["-e"]);
+    assert.match(command.args[1], /Bob's \\"Milestone\\"/);
+    assert.match(command.args[1], /Budget! Path: C:\\\\temp/);
+    assert.doesNotMatch(command.args[1], /\n/);
+  }
+});
+
+test("buildDesktopNotificationCommand uses Glass sound for non-error on macOS", () => {
+  const command = buildDesktopNotificationCommand("darwin", "Title", "Message", "info");
+  assert.ok(command);
+  if (command.file.includes("terminal-notifier")) {
+    assert.ok(command.args.includes("Glass"));
+  } else {
+    assert.match(command.args[1], /sound name "Glass"/);
+  }
 });
 
 test("buildDesktopNotificationCommand preserves literal shell characters on linux", () => {


### PR DESCRIPTION
## TL;DR

**What:** Prefer `terminal-notifier` over `osascript` for macOS desktop notifications, with osascript as fallback.
**Why:** `osascript display notification` is silently swallowed when the terminal app lacks notification permissions — exits 0, no error, no notification.
**How:** `buildDesktopNotificationCommand()` checks for `terminal-notifier` on PATH first; falls back to existing `osascript` behavior if absent.

## What

`notifications.ts` — the GSD desktop notification helper — now tries `terminal-notifier` before `osascript` on macOS. A new `findExecutable()` helper locates the binary on PATH. Tests updated to handle both paths. Documentation added to `configuration.md` and `troubleshooting.md`.

Files changed:
- `src/resources/extensions/gsd/notifications.ts` — core fix
- `src/resources/extensions/gsd/tests/notifications.test.ts` — updated tests
- `docs/configuration.md` — macOS delivery note in notifications section
- `docs/troubleshooting.md` — new "Notifications not appearing on macOS" entry

## Why

`osascript display notification` attributes notifications to the calling terminal app (Ghostty, iTerm2, Alacritty, Kitty, Warp, etc.). If that app doesn't have notification permissions in System Settings → Notifications, macOS silently drops the notification — the command exits 0 with no error. Most terminal apps don't appear in the Notifications settings panel until they've successfully delivered a notification, creating a chicken-and-egg problem.

This means all GSD auto-mode notifications (milestone complete, budget warnings, blockers, errors) silently never appear for users of third-party terminals. The failure is completely invisible.

`terminal-notifier` (`brew install terminal-notifier`) registers as its own Notification Center app, so macOS prompts the user for permission on first use — the expected UX.

Closes #2632

## How

1. Added `findExecutable(name)` — runs `which` to locate a binary on PATH. Returns absolute path or null. Non-fatal (swallows errors).
2. `buildDesktopNotificationCommand()` on darwin: checks `findExecutable("terminal-notifier")` first. If found, returns a command using its `-title`, `-message`, `-sound` args. If not found, falls back to the existing `osascript` approach unchanged.
3. Tests handle both paths — when `terminal-notifier` is installed (typical on macOS dev machines), they verify the args structure. When absent (CI), they verify the osascript fallback.

No alternatives considered beyond these two — `terminal-notifier` is the standard solution for this exact problem in the macOS CLI ecosystem (used by Guard, node-notifier, etc.). `node-notifier` npm package was considered but adds a runtime dependency; `terminal-notifier` is an optional external binary.

## Change type

- [x] `fix` — Bug fix
- [x] `test` — Adding or updating tests
- [x] `docs` — Documentation only

## Scope

- [x] `gsd extension` — GSD workflow

## Breaking changes

- [x] No breaking changes

## Test plan

- [x] New/updated tests included
- [x] Manual testing — verified on macOS Sequoia with Ghostty terminal:
  - `osascript` notifications: silently dropped (exits 0, no notification visible)
  - `terminal-notifier` notifications: delivered successfully, macOS prompted for permission on first use
  - Fallback path confirmed: renamed `terminal-notifier` binary temporarily, verified osascript path still returns correct command structure
  - Edge cases tested: special characters (quotes, backslashes, dollar signs, em dashes), newlines normalized, error vs info sound levels

## AI disclosure

- [x] This PR includes AI-assisted code — authored with Claude Code (GSD auto-mode). Code was manually tested on macOS and verified to produce notifications. All edge cases (special characters, sound levels, fallback path) were tested interactively.
