### PR TITLE
fix: classify stream-truncation JSON parse errors as transient

### DIFF
--- a/src/resources/extensions/gsd/provider-error-pause.ts
+++ b/src/resources/extensions/gsd/provider-error-pause.ts
@@ -46,6 +46,15 @@ export function classifyProviderError(errorMsg: string): {
     return { isTransient: true, isRateLimit: false, suggestedDelayMs: 15_000 }; // 15s for connection errors
   }
 
+  // Stream-truncation JSON parse errors — transient (#2572).
+  // When the API stream is cut mid-chunk, pi tries to reassemble the partial
+  // tool-call JSON and gets a SyntaxError. This is the downstream symptom of
+  // a connection drop — same root cause as ECONNRESET, one layer up.
+  const isMalformedStream = /Unexpected end of JSON|Unexpected token.*JSON|Expected double-quoted property name|SyntaxError.*JSON/i.test(errorMsg);
+  if (isMalformedStream) {
+    return { isTransient: true, isRateLimit: false, suggestedDelayMs: 15_000 }; // 15s, same as connection errors
+  }
+
   // Unknown error — treat as permanent (user reviews)
   return { isTransient: false, isRateLimit: false, suggestedDelayMs: 0 };
 }

--- a/src/resources/extensions/gsd/tests/terminated-transient.test.ts
+++ b/src/resources/extensions/gsd/tests/terminated-transient.test.ts
@@ -47,3 +47,27 @@ test("#2309: rate limits are still transient", () => {
   assert.equal(rlResult.isTransient, true, "rate limits are still transient");
   assert.equal(rlResult.isRateLimit, true, "rate limits are flagged as rate limits");
 });
+
+// --- #2572: stream-truncation JSON parse errors should be transient ---
+
+test("#2572: 'Expected double-quoted property name' (truncated stream) is transient", () => {
+  const result = classifyProviderError("Expected double-quoted property name in JSON at position 23 (line 1 column 24)");
+  assert.equal(result.isTransient, true, "truncated-stream JSON parse error should be transient");
+  assert.equal(result.isRateLimit, false, "not a rate limit");
+  assert.equal(result.suggestedDelayMs, 15_000, "should use 15s backoff like connection errors");
+});
+
+test("#2572: 'Unexpected end of JSON input' (truncated stream) is transient", () => {
+  const result = classifyProviderError("Unexpected end of JSON input");
+  assert.equal(result.isTransient, true, "'Unexpected end of JSON input' should be transient");
+});
+
+test("#2572: 'Unexpected token' in JSON (truncated stream) is transient", () => {
+  const result = classifyProviderError("Unexpected token < in JSON at position 0");
+  assert.equal(result.isTransient, true, "'Unexpected token in JSON' should be transient");
+});
+
+test("#2572: 'SyntaxError' with JSON context (truncated stream) is transient", () => {
+  const result = classifyProviderError("SyntaxError: JSON.parse: unexpected character at line 1 column 1");
+  assert.equal(result.isTransient, true, "'SyntaxError...JSON' should be transient");
+});


### PR DESCRIPTION
## TL;DR

**What:** Classify JSON `SyntaxError` messages from truncated API streams as transient in `classifyProviderError()`, so auto-mode retries instead of stopping permanently.
**Why:** When the Anthropic API stream is cut mid-chunk, the resulting JSON parse error falls through to the "unknown = permanent" default, pausing auto-mode indefinitely — even though the failure is fully recoverable.
**How:** Add an `isMalformedStream` regex guard before the permanent-error fallback, matching common JSON parse error patterns. Uses the same 15s backoff as connection errors.

## What

Two files changed:

- **`src/resources/extensions/gsd/provider-error-pause.ts`** — Added `isMalformedStream` guard that matches JSON SyntaxError patterns (`Expected double-quoted property name`, `Unexpected end of JSON`, `Unexpected token...JSON`, `SyntaxError...JSON`) and classifies them as transient with 15s backoff.
- **`src/resources/extensions/gsd/tests/terminated-transient.test.ts`** — Added 4 regression tests covering the new patterns, following the established test structure from #2309.

## Why

When the API stream is truncated mid-chunk, pi tries to reassemble the partial tool-call JSON and gets a `SyntaxError`. `classifyProviderError()` checks four pattern groups (rate limit, server error, connection error, permanent/auth) but has no match for JSON parse errors. These fall through to the default:

```typescript
// Unknown error — treat as permanent (user reviews)
return { isTransient: false, isRateLimit: false, suggestedDelayMs: 0 };
```

This stops auto-mode permanently for a failure that is fully recoverable — the same class of transient failure as `ECONNRESET`, just one layer up in the stack.

Closes #2572

## How

The fix adds a single regex check between the `isConnectionError` guard and the permanent-error fallback:

```typescript
const isMalformedStream = /Unexpected end of JSON|Unexpected token.*JSON|Expected double-quoted property name|SyntaxError.*JSON/i.test(errorMsg);
if (isMalformedStream) {
  return { isTransient: true, isRateLimit: false, suggestedDelayMs: 15_000 };
}
```

This follows the same pattern established by PR #2432 for connection-layer strings. The JSON parse errors are the downstream artifact of the same connection drops — they belong in the same transient bucket.

**Alternatives considered:**
- Merging the pattern into the existing `isConnectionError` regex — rejected because the error source is conceptually different (JSON layer vs connection layer) and deserves its own comment block for maintainability.
- Changing the default fallback to transient — rejected because truly unknown errors should still pause for user review.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

### Automated tests

4 new regression tests added to `terminated-transient.test.ts`:

1. `"Expected double-quoted property name in JSON at position 23"` → transient, 15s delay
2. `"Unexpected end of JSON input"` → transient
3. `"Unexpected token < in JSON at position 0"` → transient
4. `"SyntaxError: JSON.parse: unexpected character at line 1 column 1"` → transient

All 7 existing tests continue to pass (connection errors transient, auth errors permanent, rate limits transient).

### Local CI gate

| Step | Result |
|------|--------|
| `npm run build` | ✅ pass |
| `npm run typecheck:extensions` | ✅ pass |
| `npm run test:unit` | ✅ 3985 pass, 1 pre-existing failure (`session-lock-transient-read.test.ts` — fails on `main` too) |
| `npm run test:integration` | ✅ 71 pass, 3 pre-existing failures (`web-mode-assembled`, `web-mode-onboarding` — fail on `main` too) |

### Manual smoke test

Imported `classifyProviderError` directly and tested with the exact error message from the issue:

```
Input:  "Expected double-quoted property name in JSON at position 23 (line 1 column 24)"
Result: { isTransient: true, isRateLimit: false, suggestedDelayMs: 15000 }
```

Also verified all 4 JSON parse patterns return transient, and confirmed non-regression: auth errors remain permanent, unknown errors remain permanent.

## AI disclosure

- [x] This PR includes AI-assisted code — Claude (Anthropic) assisted with implementation and test writing. All code was reviewed, tested locally with the full CI gate, and verified with a manual smoke test.
