### PR TITLE
fix(gsd): call ensureDbOpen() before slice queries in /gsd discuss

### DIFF
--- a/src/resources/extensions/gsd/guided-flow.ts
+++ b/src/resources/extensions/gsd/guided-flow.ts
@@ -450,7 +450,10 @@ async function buildDiscussSlicePrompt(
   }
 
   // Completed slice summaries — what was already built that this slice builds on
+  // Ensure DB is open so getMilestoneSlices returns real data (#2560).
   {
+    const { ensureDbOpen } = await import("./bootstrap/dynamic-tools.js");
+    await ensureDbOpen();
     type NormSlice = { id: string; done: boolean };
     let normSlices: NormSlice[] = [];
     if (isDbAvailable()) {
@@ -587,6 +590,14 @@ export async function showDiscuss(
     }
     return;
   }
+
+  // Ensure DB is open before querying slices (#2560).
+  // showDiscuss() is a command handler — unlike tool handlers, it has no
+  // automatic ensureDbOpen() call. Without this, isDbAvailable() returns
+  // false on cold-start sessions and normSlices falls to [] → false
+  // "All slices complete" exit.
+  const { ensureDbOpen } = await import("./bootstrap/dynamic-tools.js");
+  await ensureDbOpen();
 
   // Guard: no roadmap yet (unless DB has slices)
   const roadmapFile = resolveMilestoneFile(basePath, mid, "ROADMAP");


### PR DESCRIPTION
## TL;DR

**What:** Add `ensureDbOpen()` calls before `isDbAvailable()` checks in `/gsd discuss` command handler and its context builder.
**Why:** On cold-start sessions (no prior GSD tool call), the DB singleton is uninitialized, so `isDbAvailable()` returns false — causing a false "All slices are complete" exit even when all slices are pending.
**How:** Insert `await ensureDbOpen()` via dynamic import before both `isDbAvailable()` call sites in `guided-flow.ts`, matching the pattern used by all GSD tool handlers.

## What

One file changed: `src/resources/extensions/gsd/guided-flow.ts`

Two insertion points:

1. **`showDiscuss()`** (line ~597) — the primary bug. Without `ensureDbOpen()`, `isDbAvailable()` returns false on cold-start, `normSlices` falls to `[]`, `pendingSlices` is empty, and the function exits with the misleading "All slices are complete — nothing to discuss." notification.

2. **`buildDiscussSlicePrompt()`** (line ~455) — secondary. The same missing initialization causes `getMilestoneSlices()` to return no data, so completed-slice summaries are not inlined into the discussion context prompt.

## Why

`showDiscuss()` is a **command handler**, not a tool handler. GSD tool handlers get automatic `ensureDbOpen()` calls via `db-tools.ts` before every invocation. Command handlers do not — they need to open the DB themselves.

When `/gsd discuss` is invoked in a fresh session (before any GSD tool has been called), `ensureDbOpen()` has never run, so `currentDb` is null and `isDbAvailable()` returns false. The fallback is `normSlices = []`, which filters to zero pending slices, triggering the false-positive "All slices complete" exit.

**Workaround (before this fix):** Any GSD tool call in the session before `/gsd discuss` opens the DB as a side effect.

Closes #2560

## How

Both fixes use the same dynamic import pattern already established in GSD's codebase:

```typescript
const { ensureDbOpen } = await import("./bootstrap/dynamic-tools.js");
await ensureDbOpen();
```

The dynamic import avoids circular dependency issues (guided-flow → dynamic-tools → guided-flow). `ensureDbOpen()` is idempotent — if the DB is already open, it returns `true` immediately.

**Alternatives considered:**
- Adding `ensureDbOpen()` to all command handlers globally — rejected as too broad; most command handlers don't need DB access.
- Calling `openDatabase()` directly — rejected; `ensureDbOpen()` handles migration, path resolution for worktrees, and error recovery.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [ ] New/updated tests included
- [x] Manual testing — steps described above
- [x] No tests needed — explained above

### Why no new automated tests

The bug is a missing initialization call in a command handler — a one-line fix at two call sites. The existing test suite covers `ensureDbOpen()`, `isDbAvailable()`, and `getMilestoneSlices()` extensively. A meaningful regression test would require mocking the full command handler lifecycle (ExtensionCommandContext, ExtensionAPI, session state, DB singleton), which is disproportionate to the fix.

### Local CI gate

| Step | Result |
|------|--------|
| `npm run build` | ✅ pass |
| `npm run typecheck:extensions` | ✅ pass |
| `npm run test:unit` | ✅ 3981 pass, 1 pre-existing failure (`session-lock-transient-read.test.ts`) |
| `npm run test:integration` | ✅ 71 pass, 3 pre-existing failures (`web-mode-assembled`, `web-mode-onboarding`) |

### Manual verification

1. Verified both `ensureDbOpen()` calls appear in the compiled build output (`dist/resources/extensions/gsd/guided-flow.js`)
2. Verified `bootstrap/dynamic-tools.js` exists in dist and exports `ensureDbOpen`
3. Verified both `isDbAvailable()` calls in `guided-flow.ts` are now preceded by `ensureDbOpen()`
4. Confirmed the fix follows the same dynamic import pattern used in all GSD tool handlers

## AI disclosure

- [x] This PR includes AI-assisted code — Claude (Anthropic) assisted with implementation. All code was reviewed, tested locally with the full CI gate, and verified with manual inspection.
