### PR TITLE
fix: isLockProcessAlive should return true for own PID

### DIFF
--- a/src/resources/extensions/gsd/crash-recovery.ts
+++ b/src/resources/extensions/gsd/crash-recovery.ts
@@ -76,12 +76,16 @@ export function readCrashLock(basePath: string): LockData | null {
 /**
  * Check whether the process that wrote the lock is still running.
  * Uses `process.kill(pid, 0)` which sends no signal but checks liveness.
- * Returns false if the PID matches our own (recycled PID from a prior run).
+ * Returns true if the PID matches our own — we are the lock holder (#2470).
  */
 export function isLockProcessAlive(lock: LockData): boolean {
   const pid = lock.pid;
   if (!Number.isInteger(pid) || pid <= 0) return false;
-  if (pid === process.pid) return false;
+  // Our own PID means WE hold this lock — we are alive. (#2470)
+  // Callers that need to distinguish "our lock" from "someone else's lock"
+  // (e.g. startAuto checking for a prior crashed session with a recycled PID)
+  // already guard with `crashLock.pid !== process.pid` before calling us.
+  if (pid === process.pid) return true;
   try {
     process.kill(pid, 0);
     return true;

--- a/src/resources/extensions/gsd/tests/auto-lock-creation.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-lock-creation.test.ts
@@ -140,7 +140,7 @@ test("isLockProcessAlive returns false for dead PID", () => {
   assert.equal(isLockProcessAlive(lock), false, "dead PID should return false");
 });
 
-test("isLockProcessAlive returns false for own PID (recycled)", () => {
+test("#2470: isLockProcessAlive returns true for own PID (we hold the lock)", () => {
   const lock = {
     pid: process.pid,
     startedAt: new Date().toISOString(),
@@ -148,7 +148,7 @@ test("isLockProcessAlive returns false for own PID (recycled)", () => {
     unitId: "M001/S01/T01",
     unitStartedAt: new Date().toISOString(),
   };
-  assert.equal(isLockProcessAlive(lock), false, "own PID should return false (recycled)");
+  assert.equal(isLockProcessAlive(lock), true, "own PID means we are alive — not stale (#2470)");
 });
 
 test("isLockProcessAlive returns false for invalid PID", () => {

--- a/src/resources/extensions/gsd/tests/crash-recovery.test.ts
+++ b/src/resources/extensions/gsd/tests/crash-recovery.test.ts
@@ -68,8 +68,10 @@ test("clearLock is safe when no lock exists", (t) => {
 
 // ─── isLockProcessAlive ──────────────────────────────────────────────────
 
-test("isLockProcessAlive returns true for current process (different pid)", () => {
-  // Our own PID is explicitly excluded (recycled PID guard)
+test("#2470: isLockProcessAlive returns true for own PID (we hold the lock)", () => {
+  // Own PID means we ARE the lock holder — alive, not stale. (#2470)
+  // Callers that need recycled-PID detection (e.g. startAuto) already
+  // guard with `crashLock.pid !== process.pid` before calling us.
   const lock: LockData = {
     pid: process.pid,
     startedAt: new Date().toISOString(),
@@ -77,7 +79,7 @@ test("isLockProcessAlive returns true for current process (different pid)", () =
     unitId: "M001/S01/T01",
     unitStartedAt: new Date().toISOString(),
   };
-  assert.equal(isLockProcessAlive(lock), false, "own PID should return false");
+  assert.equal(isLockProcessAlive(lock), true, "own PID should return true — we are alive");
 });
 
 test("isLockProcessAlive returns false for dead PID", () => {


### PR DESCRIPTION
## TL;DR

**What:** Change `isLockProcessAlive()` to return `true` (alive) when the lock PID matches the current process, instead of `false` (dead).
**Why:** The old `false` return caused the doctor to delete `auto.lock` and `.gsd.lock/` during live auto-mode sessions, silently destroying the session lock and stopping auto-mode.
**How:** Flip `pid === process.pid` from `return false` to `return true`. All callers that need recycled-PID detection already have their own pre-check.

## What

Three files changed:

- **`crash-recovery.ts`** — Changed self-PID guard from `return false` to `return true` with updated comment explaining why.
- **`tests/crash-recovery.test.ts`** — Updated test to assert `true` instead of `false` for own-PID case.
- **`tests/auto-lock-creation.test.ts`** — Updated duplicate test to assert `true` instead of `false`.

## Why

When the GSD doctor runs during auto-mode (via `postUnitPreVerification` with `fix: true`), it calls `isLockProcessAlive()` to check if `auto.lock` is stale. The function returned `false` for `pid === process.pid`, causing the doctor to conclude its own session's lock was stale and delete it — along with the `.gsd.lock/` OS-level lock directory.

This triggered `proper-lockfile`'s `onCompromised` handler, and the next auto-mode iteration either failed `newSession()` (30s timeout → `stopAuto`) or encountered other lock-related issues. Auto-mode stopped silently.

**The `pid === process.pid` guard was added in PR #362 for `startAuto()`**, where a matching PID could mean a recycled PID from a prior crashed process. But `startAuto()` already has its own explicit check:

```typescript
if (crashLock && crashLock.pid !== process.pid) {
    if (isLockProcessAlive(crashLock)) { ... }
}
```

So `isLockProcessAlive` is never called with self-PID from `startAuto()`. The function-level guard was redundant there and actively harmful in all other callers (doctor, forensics, `stopAutoRemote`, `checkRemoteAutoSession`).

Closes #2470

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

### Updated tests

Two existing tests updated to assert the corrected behavior:
- `crash-recovery.test.ts` — `isLockProcessAlive` returns `true` for own PID
- `auto-lock-creation.test.ts` — `isLockProcessAlive` returns `true` for own PID

All 20 lock-related tests pass (8 in crash-recovery, 12 in auto-lock-creation).

### Caller analysis (manual verification)

Verified all 11 call sites of `isLockProcessAlive` to confirm no caller is broken by this change:

| Caller | Context | Safe? |
|--------|---------|-------|
| `startAuto` (auto-start.ts:197) | Already guards with `crashLock.pid !== process.pid` | ✅ Never reaches `isLockProcessAlive` for self-PID |
| `stopAutoRemote` (auto.ts:406) | Only called when `!isAutoActive()` | ✅ Self-PID = alive = correct |
| `checkRemoteAutoSession` (auto.ts:437) | Checks remote sessions | ✅ Self-PID = alive = correct |
| `doctor-runtime-checks.ts` (3 sites) | The bug site — doctor during auto-mode | ✅ Self-PID = alive = won't delete our lock |
| `doctor-proactive.ts:223` | Proactive doctor check | ✅ Self-PID = alive = correct |
| `forensics.ts` (2 sites) | Forensic analysis | ✅ Self-PID = alive = correct |

### Local CI gate

| Step | Result |
|------|--------|
| `npm run build` | ✅ pass |
| `npm run typecheck:extensions` | ✅ pass |
| `npm run test:unit` | ✅ 3981 pass, 1 pre-existing failure (`session-lock-transient-read.test.ts`) |
| `npm run test:integration` | ✅ 71 pass, 3 pre-existing failures (`web-mode-assembled`, `web-mode-onboarding`) |

## AI disclosure

- [x] This PR includes AI-assisted code — Claude (Anthropic) assisted with implementation and caller analysis. All code was reviewed, tested locally with the full CI gate, and each call site was manually verified.
