### PR TITLE
fix: honor explicit model config when model is not in known tier map

### DIFF
--- a/src/resources/extensions/gsd/model-router.ts
+++ b/src/resources/extensions/gsd/model-router.ts
@@ -114,6 +114,21 @@ export function resolveModelForComplexity(
   const configuredTier = getModelTier(configuredPrimary);
   const requestedTier = classification.tier;
 
+  // If the configured model is unknown (not in MODEL_CAPABILITY_TIER),
+  // honor the user's explicit choice — don't downgrade based on a guess.
+  // Unknown models default to "heavy" in getModelTier, which makes every
+  // standard/light unit get downgraded to tier_models, silently ignoring
+  // the user's configuration. (#2192)
+  if (!isKnownModel(configuredPrimary)) {
+    return {
+      modelId: configuredPrimary,
+      fallbacks: phaseConfig.fallbacks,
+      tier: requestedTier,
+      wasDowngraded: false,
+      reason: `configured model "${configuredPrimary}" is not in the known tier map — honoring explicit config`,
+    };
+  }
+
   // Downgrade-only: if requested tier >= configured tier, no change
   if (tierOrdinal(requestedTier) >= tierOrdinal(configuredTier)) {
     return {
@@ -200,6 +215,16 @@ function getModelTier(modelId: string): ComplexityTier {
 
   // Unknown models are assumed heavy (safest assumption)
   return "heavy";
+}
+
+/** Check if a model ID has a known capability tier mapping. (#2192) */
+function isKnownModel(modelId: string): boolean {
+  const bareId = modelId.includes("/") ? modelId.split("/").pop()! : modelId;
+  if (MODEL_CAPABILITY_TIER[bareId]) return true;
+  for (const knownId of Object.keys(MODEL_CAPABILITY_TIER)) {
+    if (bareId.includes(knownId) || knownId.includes(bareId)) return true;
+  }
+  return false;
 }
 
 function findModelForTier(

--- a/src/resources/extensions/gsd/tests/model-router.test.ts
+++ b/src/resources/extensions/gsd/tests/model-router.test.ts
@@ -165,3 +165,43 @@ test("falls back to configured model when no light-tier model available", () => 
   assert.equal(result.modelId, "claude-opus-4-6");
   assert.equal(result.wasDowngraded, false);
 });
+
+// ─── #2192: Unknown models honor explicit config ─────────────────────────────
+
+test("#2192: unknown model is not downgraded — respects user config", () => {
+  const config = { ...defaultRoutingConfig(), enabled: true };
+  const result = resolveModelForComplexity(
+    makeClassification("light"),
+    { primary: "gpt-5.4", fallbacks: [] },
+    config,
+    ["gpt-5.4", ...AVAILABLE_MODELS],
+  );
+  assert.equal(result.modelId, "gpt-5.4", "unknown model should be used as-is");
+  assert.equal(result.wasDowngraded, false, "should not be downgraded");
+  assert.ok(result.reason.includes("not in the known tier map"), "reason should explain why");
+});
+
+test("#2192: unknown model with provider prefix is not downgraded", () => {
+  const config = { ...defaultRoutingConfig(), enabled: true };
+  const result = resolveModelForComplexity(
+    makeClassification("standard"),
+    { primary: "custom-provider/my-model-v3", fallbacks: [] },
+    config,
+    ["custom-provider/my-model-v3", ...AVAILABLE_MODELS],
+  );
+  assert.equal(result.modelId, "custom-provider/my-model-v3");
+  assert.equal(result.wasDowngraded, false);
+});
+
+test("#2192: known model is still downgraded normally", () => {
+  const config = { ...defaultRoutingConfig(), enabled: true };
+  // claude-opus-4-6 is known as "heavy" — a light request should downgrade
+  const result = resolveModelForComplexity(
+    makeClassification("light"),
+    { primary: "claude-opus-4-6", fallbacks: [] },
+    config,
+    AVAILABLE_MODELS,
+  );
+  assert.equal(result.wasDowngraded, true, "known heavy model should still be downgraded for light tasks");
+  assert.notEqual(result.modelId, "claude-opus-4-6");
+});


### PR DESCRIPTION
## TL;DR

**What:** Skip dynamic routing downgrade when the user's configured model is not in the known model tier map.
**Why:** Unknown models default to "heavy" tier, causing every standard/light unit to be silently downgraded to `tier_models` — ignoring the user's explicit phase configuration.
**How:** Add an `isKnownModel()` check before the downgrade logic in `resolveModelForComplexity()`. Unknown models pass through unchanged.

## What

Two files changed:

- **`model-router.ts`** — Added `isKnownModel()` helper and an early return in `resolveModelForComplexity()` when the configured model is unknown. The return includes a descriptive reason string.
- **`tests/model-router.test.ts`** — Added 3 regression tests covering unknown models (with and without provider prefix) and verifying known models still downgrade normally.

## Why

When a user explicitly configures a model for a phase (e.g. `planning: gpt-5.4`), they expect that model to be used. But `getModelTier()` returns `"heavy"` for any model not in `MODEL_CAPABILITY_TIER`. The downgrade-only logic then sees `tierOrdinal("standard") < tierOrdinal("heavy")` and downgrades to whatever `tier_models.standard` is configured as — completely ignoring the user's choice.

This affects:
- New models not yet in the hardcoded tier map
- Extension-provided models (e.g. `claude-code/claude-sonnet-4-6`)
- Custom/self-hosted models with non-standard names

Closes #2192

## How

Added a check before the downgrade logic:

```typescript
if (!isKnownModel(configuredPrimary)) {
  return {
    modelId: configuredPrimary,
    fallbacks: phaseConfig.fallbacks,
    tier: requestedTier,
    wasDowngraded: false,
    reason: `configured model "${configuredPrimary}" is not in the known tier map — honoring explicit config`,
  };
}
```

`isKnownModel()` mirrors the same lookup logic as `getModelTier()` (exact match + prefix/suffix match) but returns a boolean instead of a default tier.

**Why not add models to the tier map?** The tier map is a snapshot — new models appear constantly. The fix ensures the system degrades gracefully for any model not yet catalogued, while known models continue to route normally.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

### New tests

3 regression tests added to `model-router.test.ts`:

1. **Unknown model not downgraded** — `gpt-5.4` configured for planning, light-tier request → uses `gpt-5.4` (not downgraded)
2. **Unknown model with provider prefix** — `custom-provider/my-model-v3` → uses as-is
3. **Known model still downgraded** — `claude-opus-4-6` (known heavy) for light request → still downgrades to haiku (non-regression)

All 15 model-router tests pass (12 existing + 3 new).

### Local CI gate

| Step | Result |
|------|--------|
| `npm run build` | ✅ pass |
| `npm run typecheck:extensions` | ✅ pass |
| `npm run test:unit` | ✅ 3984 pass, 1 pre-existing failure (`session-lock-transient-read.test.ts`) |
| `npm run test:integration` | ✅ 71 pass, 3 pre-existing failures (verified on prior branch) |

### Manual verification

Verified the model-router test suite passes all 15 tests including 3 new regression tests covering the exact scenario from the issue.

## AI disclosure

- [x] This PR includes AI-assisted code — Claude (Anthropic) assisted with implementation. All code was reviewed, tested locally with the full CI gate, and verified with regression tests.
