### PR TITLE
fix(gsd): check ASSESSMENT file for UAT verdict in checkNeedsRunUat

### DIFF
--- a/src/resources/extensions/gsd/auto-prompts.ts
+++ b/src/resources/extensions/gsd/auto-prompts.ts
@@ -784,6 +784,14 @@ export async function checkNeedsRunUat(
         if (!uatContent) return null;
         // If the UAT file already contains a verdict, UAT has been run — skip
         if (hasVerdict(uatContent)) return null;
+        // Also check the ASSESSMENT file — the run-uat prompt writes the verdict
+        // there (via gsd_summary_save artifact_type:"ASSESSMENT"), not into the
+        // UAT spec file. Without this check the unit re-dispatches indefinitely.
+        const assessmentFile = resolveSliceFile(base, mid, sid, "ASSESSMENT");
+        if (assessmentFile) {
+          const assessmentContent = await loadFile(assessmentFile);
+          if (assessmentContent && hasVerdict(assessmentContent)) return null;
+        }
         const uatType = getUatType(uatContent);
         return { sliceId: sid, uatType };
       }
@@ -808,6 +816,13 @@ export async function checkNeedsRunUat(
   if (!uatContentFb) return null;
   // If the UAT file already contains a verdict, UAT has been run — skip
   if (hasVerdict(uatContentFb)) return null;
+  // Also check the ASSESSMENT file for the file-based fallback path (same
+  // reason as the DB path above — verdict lives in ASSESSMENT, not UAT).
+  const assessmentFileFb = resolveSliceFile(base, mid, uatSid, "ASSESSMENT");
+  if (assessmentFileFb) {
+    const assessmentContentFb = await loadFile(assessmentFileFb);
+    if (assessmentContentFb && hasVerdict(assessmentContentFb)) return null;
+  }
   const uatTypeFb = getUatType(uatContentFb);
   return { sliceId: uatSid, uatType: uatTypeFb };
 }

--- a/src/resources/extensions/gsd/tests/run-uat.test.ts
+++ b/src/resources/extensions/gsd/tests/run-uat.test.ts
@@ -460,4 +460,150 @@ test('(n) stale replay guard', async () => {
     }
 });
 
+test('(q) verdict in ASSESSMENT file skips UAT dispatch (file-based path)', async () => {
+    // Regression test for #2644: run-uat prompt writes the verdict to
+    // S{sid}-ASSESSMENT.md (via gsd_summary_save artifact_type:"ASSESSMENT"),
+    // but checkNeedsRunUat only checked S{sid}-UAT.md — causing a stuck loop.
+    const base = createFixtureBase();
+    try {
+      const roadmapDir = join(base, '.gsd', 'milestones', 'M001');
+      mkdirSync(roadmapDir, { recursive: true });
+      writeFileSync(
+        join(roadmapDir, 'M001-ROADMAP.md'),
+        [
+          '# M001: Test roadmap',
+          '',
+          '## Slices',
+          '',
+          '- [x] **S01: First slice** `risk:low` `depends:[]`',
+          '- [ ] **S02: Next slice** `risk:low` `depends:[S01]`',
+          '',
+          '## Boundary Map',
+          '',
+        ].join('\n'),
+      );
+
+      // UAT spec file WITHOUT a verdict (the spec never gets one)
+      writeSliceFile(base, 'M001', 'S01', 'UAT', makeUatContent('artifact-driven'));
+      // ASSESSMENT file WITH a verdict (where run-uat actually writes it)
+      writeSliceFile(base, 'M001', 'S01', 'ASSESSMENT', '---\nverdict: PASS\n---\n# UAT Assessment\n');
+
+      const state = {
+        activeMilestone: { id: 'M001', title: 'Test roadmap' },
+        activeSlice: { id: 'S02', title: 'Next slice' },
+        activeTask: null,
+        phase: 'planning',
+        recentDecisions: [],
+        blockers: [],
+        nextAction: 'Plan S02',
+        registry: [],
+      } as const;
+
+      const result = await checkNeedsRunUat(base, 'M001', state as any, { uat_dispatch: true } as any);
+      assert.deepStrictEqual(
+        result,
+        null,
+        'verdict in ASSESSMENT file should prevent re-dispatch of run-uat',
+      );
+    } finally {
+      cleanup(base);
+    }
+});
+
+test('(r) no ASSESSMENT file still dispatches UAT (no false skip)', async () => {
+    // Guard: when there is no ASSESSMENT file at all, UAT should still dispatch
+    // normally. The ASSESSMENT check must not cause a false-negative skip.
+    const base = createFixtureBase();
+    try {
+      const roadmapDir = join(base, '.gsd', 'milestones', 'M001');
+      mkdirSync(roadmapDir, { recursive: true });
+      writeFileSync(
+        join(roadmapDir, 'M001-ROADMAP.md'),
+        [
+          '# M001: Test roadmap',
+          '',
+          '## Slices',
+          '',
+          '- [x] **S01: First slice** `risk:low` `depends:[]`',
+          '- [ ] **S02: Next slice** `risk:low` `depends:[S01]`',
+          '',
+          '## Boundary Map',
+          '',
+        ].join('\n'),
+      );
+
+      // UAT spec file WITHOUT a verdict, and NO ASSESSMENT file
+      writeSliceFile(base, 'M001', 'S01', 'UAT', makeUatContent('artifact-driven'));
+
+      const state = {
+        activeMilestone: { id: 'M001', title: 'Test roadmap' },
+        activeSlice: { id: 'S02', title: 'Next slice' },
+        activeTask: null,
+        phase: 'planning',
+        recentDecisions: [],
+        blockers: [],
+        nextAction: 'Plan S02',
+        registry: [],
+      } as const;
+
+      const result = await checkNeedsRunUat(base, 'M001', state as any, { uat_dispatch: true } as any);
+      assert.deepStrictEqual(
+        result,
+        { sliceId: 'S01', uatType: 'artifact-driven' },
+        'without ASSESSMENT file, UAT still dispatches normally',
+      );
+    } finally {
+      cleanup(base);
+    }
+});
+
+test('(s) ASSESSMENT without verdict does not skip UAT dispatch', async () => {
+    // Guard: an ASSESSMENT file that exists but has no verdict line should
+    // NOT suppress UAT dispatch — only a file with an actual verdict should.
+    const base = createFixtureBase();
+    try {
+      const roadmapDir = join(base, '.gsd', 'milestones', 'M001');
+      mkdirSync(roadmapDir, { recursive: true });
+      writeFileSync(
+        join(roadmapDir, 'M001-ROADMAP.md'),
+        [
+          '# M001: Test roadmap',
+          '',
+          '## Slices',
+          '',
+          '- [x] **S01: First slice** `risk:low` `depends:[]`',
+          '- [ ] **S02: Next slice** `risk:low` `depends:[S01]`',
+          '',
+          '## Boundary Map',
+          '',
+        ].join('\n'),
+      );
+
+      // UAT spec WITHOUT verdict
+      writeSliceFile(base, 'M001', 'S01', 'UAT', makeUatContent('artifact-driven'));
+      // ASSESSMENT file WITHOUT verdict (partial/incomplete assessment)
+      writeSliceFile(base, 'M001', 'S01', 'ASSESSMENT', '# UAT Assessment\n\nStill running checks...\n');
+
+      const state = {
+        activeMilestone: { id: 'M001', title: 'Test roadmap' },
+        activeSlice: { id: 'S02', title: 'Next slice' },
+        activeTask: null,
+        phase: 'planning',
+        recentDecisions: [],
+        blockers: [],
+        nextAction: 'Plan S02',
+        registry: [],
+      } as const;
+
+      const result = await checkNeedsRunUat(base, 'M001', state as any, { uat_dispatch: true } as any);
+      assert.deepStrictEqual(
+        result,
+        { sliceId: 'S01', uatType: 'artifact-driven' },
+        'ASSESSMENT without verdict should not suppress UAT dispatch',
+      );
+    } finally {
+      cleanup(base);
+    }
+});
+
 });


### PR DESCRIPTION
## TL;DR

**What:** `checkNeedsRunUat` now also checks the ASSESSMENT file for a UAT verdict, not just the UAT spec file.
**Why:** The `run-uat` prompt writes the verdict to `S{sid}-ASSESSMENT.md`, but the dispatch guard only read `S{sid}-UAT.md` — causing an infinite re-dispatch loop.
**How:** After the existing UAT-file verdict check, add an ASSESSMENT-file verdict check on both the DB-primary and file-based fallback paths.

## What

Two additive guard blocks in `checkNeedsRunUat()` (`auto-prompts.ts`):

1. **DB-primary path** (~line 787): after checking the UAT spec file, also resolve and check `S{sid}-ASSESSMENT.md` for a verdict.
2. **File-based fallback path** (~line 819): same ASSESSMENT-file check for the roadmap-checkbox-based fallback.

Three regression tests in `run-uat.test.ts`:
- **(q)** Verdict in ASSESSMENT file → `checkNeedsRunUat` returns `null` (skip dispatch)
- **(r)** No ASSESSMENT file → UAT dispatches normally (no false skip)
- **(s)** ASSESSMENT file without verdict → UAT dispatches normally (no false skip)

## Why

The `run-uat` prompt instructs the agent to call `gsd_summary_save` with `artifact_type: "ASSESSMENT"`, which writes the verdict to `S{sid}-ASSESSMENT.md`. However, `checkNeedsRunUat` only checked `S{sid}-UAT.md` (the spec file) for a verdict via `hasVerdict()`. Since the spec file never receives a verdict, `hasVerdict()` always returned `false`, causing `run-uat` to re-dispatch on every loop iteration until the stuck-loop detector fired after 3 identical dispatches.

Closes #2644

## How

The fix is additive — after the existing `hasVerdict(uatContent)` check, we also resolve the ASSESSMENT file for the same slice and check it for a verdict. If either file contains a verdict, the function returns `null` (skip dispatch).

**Key decisions:**
- **Check both files rather than changing where the verdict is written.** The ASSESSMENT file is the correct artifact for UAT results — it's a separate artifact from the UAT spec. Changing the prompt to write back into the spec file would conflate the test definition with the test result.
- **Same pattern on both paths.** The DB-primary and file-based fallback paths both had the same bug, so both get the same fix.
- **Guard against missing/empty ASSESSMENT.** The fix gracefully handles: no ASSESSMENT file (`resolveSliceFile` returns `null`), empty ASSESSMENT file (`loadFile` returns empty), or ASSESSMENT without a verdict line (`hasVerdict` returns `false`).

**Bug reproduction:**

```
BEFORE fix (stashed):
❌ BUG: checkNeedsRunUat returned {"sliceId":"S01","uatType":"artifact-driven"}
   → UAT would re-dispatch despite verdict existing in ASSESSMENT file

AFTER fix:
✅ PASS: checkNeedsRunUat returned null — verdict in ASSESSMENT detected
```

## Change type

- [x] `fix` — Bug fix

## Scope

- [x] `gsd extension` — GSD workflow

## Breaking changes

- [x] No breaking changes

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above

**Local CI gate:**
| Step | Result |
|---|---|
| `npm run build` | ✅ pass |
| `npm run typecheck:extensions` | ✅ pass |
| `npm run test:unit` | ✅ 3984 pass, 1 pre-existing fail (`session-lock-transient-read`) |
| `npm run test:integration` | ✅ 71 pass, 3 pre-existing fail (web-mode tests) |

**Targeted tests:** All 21 tests in `run-uat.test.ts` pass (including 3 new regression tests).

**Manual reproduction:** Standalone repro script importing `checkNeedsRunUat` directly, with a fixture containing a UAT spec (no verdict) and an ASSESSMENT file (with `verdict: PASS`). Before fix: function returns dispatch target. After fix: function returns `null`.

## AI disclosure

- [x] This PR includes AI-assisted code — authored with Claude, verified via standalone reproduction script, targeted module tests, and full CI gate.

