### PR TITLE
fix(pi-ai): signal malformed tool arguments in toolcall_end event

### DIFF
--- a/packages/pi-ai/src/types.ts
+++ b/packages/pi-ai/src/types.ts
@@ -250,7 +250,7 @@ export type AssistantMessageEvent =
 	| { type: "thinking_end"; contentIndex: number; content: string; partial: AssistantMessage }
 	| { type: "toolcall_start"; contentIndex: number; partial: AssistantMessage }
 	| { type: "toolcall_delta"; contentIndex: number; delta: string; partial: AssistantMessage }
-	| { type: "toolcall_end"; contentIndex: number; toolCall: ToolCall; partial: AssistantMessage }
+	| { type: "toolcall_end"; contentIndex: number; toolCall: ToolCall; partial: AssistantMessage; malformedArguments?: boolean }
 	| { type: "server_tool_use"; contentIndex: number; partial: AssistantMessage }
 	| { type: "web_search_result"; contentIndex: number; partial: AssistantMessage }
 	| { type: "done"; reason: Extract<StopReason, "stop" | "length" | "toolUse">; message: AssistantMessage }

--- a/src/resources/extensions/claude-code-cli/partial-builder.ts
+++ b/src/resources/extensions/claude-code-cli/partial-builder.ts
@@ -244,7 +244,12 @@ export class PartialMessageBuilder {
 					try {
 						block.arguments = JSON.parse(jsonStr);
 					} catch {
+						// Stream was truncated mid-tool-call — JSON is garbage.
+						// Preserve the raw string for diagnostics but signal the
+						// malformation explicitly so downstream consumers can
+						// distinguish this from a healthy tool completion (#2574).
 						block.arguments = { _raw: jsonStr };
+						return { type: "toolcall_end", contentIndex, toolCall: block, partial: this.partial, malformedArguments: true };
 					}
 					return { type: "toolcall_end", contentIndex, toolCall: block, partial: this.partial };
 				}

--- a/src/resources/extensions/claude-code-cli/tests/partial-builder.test.ts
+++ b/src/resources/extensions/claude-code-cli/tests/partial-builder.test.ts
@@ -1,0 +1,105 @@
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import { PartialMessageBuilder } from "../partial-builder.ts";
+import type { BetaRawMessageStreamEvent } from "../sdk-types.ts";
+
+describe("PartialMessageBuilder — malformed tool arguments (#2574)", () => {
+	/**
+	 * Helper: feed a tool_use block through the builder lifecycle and return
+	 * the toolcall_end event. Simulates: content_block_start → N deltas → content_block_stop.
+	 */
+	function feedToolCall(
+		builder: PartialMessageBuilder,
+		jsonFragments: string[],
+	) {
+		// Start the tool_use block at stream index 0
+		builder.handleEvent({
+			type: "content_block_start",
+			index: 0,
+			content_block: { type: "tool_use", id: "tool_1", name: "gsd_plan_slice", input: {} },
+		} as BetaRawMessageStreamEvent);
+
+		// Feed JSON fragments as input_json_delta
+		for (const fragment of jsonFragments) {
+			builder.handleEvent({
+				type: "content_block_delta",
+				index: 0,
+				delta: { type: "input_json_delta", partial_json: fragment },
+			} as BetaRawMessageStreamEvent);
+		}
+
+		// Stop the block — this is where JSON parse happens
+		return builder.handleEvent({
+			type: "content_block_stop",
+			index: 0,
+		} as BetaRawMessageStreamEvent);
+	}
+
+	test("valid JSON → toolcall_end without malformedArguments", () => {
+		const builder = new PartialMessageBuilder("claude-sonnet-4-20250514");
+		const event = feedToolCall(builder, ['{"milestone', 'Id": "M001"}']);
+
+		assert.ok(event, "event should not be null");
+		assert.equal(event!.type, "toolcall_end");
+		// Valid JSON should NOT have the malformedArguments flag
+		assert.equal(
+			(event as any).malformedArguments,
+			undefined,
+			"valid JSON should not set malformedArguments",
+		);
+		// Arguments should be parsed correctly
+		if (event!.type === "toolcall_end") {
+			assert.deepEqual(event!.toolCall.arguments, { milestoneId: "M001" });
+		}
+	});
+
+	test("truncated JSON → toolcall_end WITH malformedArguments: true", () => {
+		const builder = new PartialMessageBuilder("claude-sonnet-4-20250514");
+		// Simulate a stream truncation: JSON is cut off mid-value
+		const event = feedToolCall(builder, ['{"milestone', 'Id": "M00']);
+
+		assert.ok(event, "event should not be null");
+		assert.equal(event!.type, "toolcall_end");
+		assert.equal(
+			(event as any).malformedArguments,
+			true,
+			"truncated JSON should set malformedArguments: true",
+		);
+		// The _raw field should contain the original broken JSON
+		if (event!.type === "toolcall_end") {
+			assert.equal(
+				event!.toolCall.arguments._raw,
+				'{"milestoneId": "M00',
+				"_raw should contain the truncated JSON string",
+			);
+		}
+	});
+
+	test("no JSON deltas → malformedArguments: true (empty accumulator is not valid JSON)", () => {
+		const builder = new PartialMessageBuilder("claude-sonnet-4-20250514");
+		// No deltas — the accumulator is initialized to "" by content_block_start,
+		// and "" is not valid JSON, so this correctly signals malformed.
+		const event = feedToolCall(builder, []);
+
+		assert.ok(event, "event should not be null");
+		assert.equal(event!.type, "toolcall_end");
+		assert.equal(
+			(event as any).malformedArguments,
+			true,
+			"empty accumulator (no JSON deltas) is not valid JSON → malformed",
+		);
+	});
+
+	test("garbage input (non-JSON) → malformedArguments: true", () => {
+		const builder = new PartialMessageBuilder("claude-sonnet-4-20250514");
+		const event = feedToolCall(builder, ["not json at all <html>"]);
+
+		assert.ok(event, "event should not be null");
+		assert.equal(event!.type, "toolcall_end");
+		assert.equal(
+			(event as any).malformedArguments,
+			true,
+			"non-JSON content should set malformedArguments: true",
+		);
+	});
+});


### PR DESCRIPTION
## TL;DR

**What:** Add a `malformedArguments` flag to `toolcall_end` events when JSON argument parsing fails in `PartialMessageBuilder`.
**Why:** Truncated streams produce `toolcall_end` events indistinguishable from healthy completions — downstream has no signal that the tool call is garbage.
**How:** Set `malformedArguments: true` on the event in the JSON parse catch path; extend the `AssistantMessageEvent` union type with the optional flag.

## What

- **`partial-builder.ts`**: In the `content_block_stop` handler for tool_use blocks, the catch path now returns `{ ...event, malformedArguments: true }` instead of the identical event shape as the success path.
- **`types.ts`** (`@gsd/pi-ai`): The `toolcall_end` variant of `AssistantMessageEvent` gains an optional `malformedArguments?: boolean` field.
- **New test file**: `partial-builder.test.ts` with 4 tests covering valid JSON, truncated JSON, empty accumulator, and garbage input.

## Why

When the API stream is truncated mid-tool-call, `PartialMessageBuilder` silently emits a `toolcall_end` event with `{ _raw: "<broken json>" }` in the arguments. The event type and shape are identical to a healthy tool completion. Downstream consumers — error classifiers, tool handlers, activity log — have no way to distinguish a truncated call from a completed one.

This causes:
1. `classifyProviderError()` receives the JSON syntax error, matches no transient pattern, and pauses auto-mode permanently
2. Tool handlers receive `{ _raw: "..." }` and either crash with confusing validation errors or silently no-op
3. Activity log records misleading tool call data

Closes #2574

## How

The fix is additive — the catch path now includes `malformedArguments: true` on the returned event object. The `_raw` sentinel in arguments is preserved for backward compatibility.

**Key decisions:**
- **Flag on existing event type (Option B from issue)** rather than a new `toolcall_error` event type. This is less disruptive — existing `switch` statements on `event.type` continue to work unchanged. The flag is opt-in for consumers that care.
- **Optional field on the type union** rather than a separate property on `ToolCall`. The malformation is a property of the *event* (the stream was interrupted), not the tool call definition itself.
- **Existing consumers unaffected.** `agent-loop.ts`, `proxy.ts`, and `stream-adapter.ts` all handle `toolcall_end` without checking `malformedArguments` — they continue to work identically.

**Bug reproduction:**

```
BEFORE fix (stashed):
Event type: toolcall_end
Has malformedArguments? false
❌ BUG: No way to distinguish malformed from healthy toolcall_end
   arguments: {"_raw":"{\"milestoneId\": \"M00"}

AFTER fix:
Event type: toolcall_end
Has malformedArguments? true
malformedArguments value: true
✅ FIXED: malformedArguments flag present on event
```

## Change type

- [x] `fix` — Bug fix

## Scope

- [x] `pi-ai` — AI/LLM layer
- [x] `pi-coding-agent` — Coding agent

## Breaking changes

- [x] No breaking changes

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above

**Local CI gate:**
| Step | Result |
|---|---|
| `npm run build` | ✅ pass |
| `npm run typecheck:extensions` | ✅ pass |
| `npm run test:unit` | ✅ 3981 pass, 1 pre-existing fail (`session-lock-transient-read`) |
| `npm run test:integration` | ✅ 71 pass, 3 pre-existing fail (web-mode tests) |

**New tests:** 4 tests in `partial-builder.test.ts`:
1. Valid JSON → no `malformedArguments` flag
2. Truncated JSON → `malformedArguments: true`
3. No JSON deltas (empty accumulator) → `malformedArguments: true`
4. Garbage non-JSON input → `malformedArguments: true`

**Manual reproduction:** Standalone script instantiating `PartialMessageBuilder`, feeding a truncated tool_use event sequence. Before fix: no `malformedArguments` on event. After fix: `malformedArguments: true`.

## AI disclosure

- [x] This PR includes AI-assisted code — authored with Claude, verified via standalone reproduction script, targeted module tests, and full CI gate.

