### PR TITLE
fix(gsd): respect queue-order.json in DB-backed state derivation

### DIFF
--- a/src/resources/extensions/gsd/state.ts
+++ b/src/resources/extensions/gsd/state.ts
@@ -34,7 +34,8 @@ import {
   gsdRoot,
 } from './paths.js';
 
-import { milestoneIdSort, findMilestoneIds } from './milestone-ids.js';
+import { findMilestoneIds } from './milestone-ids.js';
+import { loadQueueOrder, sortByQueueOrder } from './queue-order.js';
 import { nativeBatchParseGsdFiles, type BatchParsedFile } from './native-parser-bridge.js';
 
 import { join, resolve } from 'path';
@@ -149,8 +150,14 @@ export async function getActiveMilestoneId(basePath: string): Promise<string | n
   if (isDbAvailable()) {
     const allMilestones = getAllMilestones();
     if (allMilestones.length > 0) {
-      const sorted = [...allMilestones].sort((a, b) => a.id.localeCompare(b.id));
-      for (const m of sorted) {
+      // Respect queue-order.json so /gsd queue reordering is honored (#2556).
+      // Without this, the DB path uses lexicographic sort while the dispatch
+      // guard uses queue order — causing a deadlock.
+      const customOrder = loadQueueOrder(basePath);
+      const sortedIds = sortByQueueOrder(allMilestones.map(m => m.id), customOrder);
+      const byId = new Map(allMilestones.map(m => [m.id, m]));
+      for (const id of sortedIds) {
+        const m = byId.get(id)!;
         if (m.status === "complete" || m.status === "done" || m.status === "parked") continue;
         return m.id;
       }
@@ -304,8 +311,12 @@ export async function deriveStateFromDb(basePath: string): Promise<GSDState> {
       } as MilestoneRow);
     }
   }
-  // Re-sort so milestones are in canonical order after injection
-  allMilestones.sort((a, b) => milestoneIdSort(a.id, b.id));
+  // Re-sort so milestones follow queue order (same as dispatch guard) (#2556)
+  const customOrder = loadQueueOrder(basePath);
+  const sortedIds = sortByQueueOrder(allMilestones.map(m => m.id), customOrder);
+  const byId = new Map(allMilestones.map(m => [m.id, m]));
+  allMilestones.length = 0;
+  for (const id of sortedIds) allMilestones.push(byId.get(id)!);
 
   // Parallel worker isolation: when locked, filter to just the locked milestone
   const milestoneLock = process.env.GSD_MILESTONE_LOCK;

--- a/src/resources/extensions/gsd/tests/queue-reorder-e2e.test.ts
+++ b/src/resources/extensions/gsd/tests/queue-reorder-e2e.test.ts
@@ -292,4 +292,44 @@ test('E2E: depends_on inline format preserved after partial removal', () => {
   }
 });
 
+test('E2E: DB-backed path respects queue order (#2556)', async () => {
+    // Regression test for #2556: getActiveMilestoneId and deriveStateFromDb
+    // used lexicographic sort instead of queue order, causing a deadlock when
+    // the dispatch guard (which respects queue order) blocked completion.
+    const base = createFixtureBase();
+    try {
+      const { openDatabase, closeDatabase, insertMilestone, isDbAvailable } = await import('../gsd-db.ts');
+      const dbPath = join(base, '.gsd', 'gsd.db');
+
+      // Create milestone directories (required for findMilestoneIds)
+      writeMilestoneDir(base, 'M006');
+      writeContext(base, 'M006', '', 'Earlier milestone');
+      writeMilestoneDir(base, 'M008');
+      writeContext(base, 'M008', '', 'Later milestone');
+
+      // Open DB and insert milestones
+      openDatabase(dbPath);
+      try {
+        insertMilestone({ id: 'M006', title: 'Earlier', status: 'active' });
+        insertMilestone({ id: 'M008', title: 'Later', status: 'active' });
+
+        // Set queue order: M008 should come FIRST (user reordered via /gsd queue)
+        saveQueueOrder(base, ['M008', 'M006']);
+
+        // deriveState should pick M008 (queue-first), not M006 (ID-first)
+        invalidateStateCache();
+        const state = await deriveState(base);
+        assert.equal(
+          state.activeMilestone?.id,
+          'M008',
+          'DB-backed deriveState must respect queue order — M008 is queued first',
+        );
+      } finally {
+        if (isDbAvailable()) closeDatabase();
+      }
+    } finally {
+      cleanup(base);
+    }
+});
+
 });


### PR DESCRIPTION
## TL;DR

**What:** `getActiveMilestoneId` and `deriveStateFromDb` now sort milestones by `queue-order.json` instead of lexicographic ID sort.
**Why:** The DB-backed path ignored `/gsd queue` reordering, causing a deadlock when the dispatch guard (which respects queue order) blocked completion of the milestone the state machine selected.
**How:** Replace `localeCompare`/`milestoneIdSort` with `sortByQueueOrder(loadQueueOrder())` in both DB paths — the same ordering `findMilestoneIds` already uses.

## What

- **`state.ts`**: Two sort sites changed:
  1. `getActiveMilestoneId` DB path (~line 152): replaced `localeCompare` sort with `sortByQueueOrder`
  2. `deriveStateFromDb` milestone sort (~line 311): replaced `milestoneIdSort` with `sortByQueueOrder`
- **`queue-reorder-e2e.test.ts`**: New test verifying the DB-backed path respects queue order.
- Removed unused `milestoneIdSort` import from `state.ts`.

## Why

Three subsystems used different milestone ordering:

| Subsystem | Before | After |
|-----------|--------|-------|
| `getActiveMilestoneId` (DB) | `localeCompare` (ID sort) | `sortByQueueOrder` ✅ |
| `deriveStateFromDb` | `milestoneIdSort` (ID sort) | `sortByQueueOrder` ✅ |
| `dispatch-guard` | `findMilestoneIds` (queue order) | unchanged ✅ |

When a user ran `/gsd queue` to prioritize M008 over M006, the state machine still selected M006 (lower ID). The dispatch guard then blocked M006's completion because M008 wasn't done yet (queue-ordered first). Deadlock.

Closes #2556

## How

Both DB paths now call `loadQueueOrder(basePath)` and `sortByQueueOrder(ids, customOrder)` — the same functions that `findMilestoneIds` uses in the filesystem fallback path. When no `QUEUE-ORDER.json` exists, `sortByQueueOrder` falls back to `milestoneIdSort` (numeric/lexicographic), preserving backward compatibility.

**Bug reproduction:**

```
BEFORE fix:
❌ BUG: getActiveMilestoneId returned "M006" (expected M008)
   → DB path sorts by ID (M006 < M008) instead of queue order (M008 first)

AFTER fix:
✅ FIXED: getActiveMilestoneId respects queue order → M008
```

## Change type

- [x] `fix` — Bug fix

## Scope

- [x] `gsd extension` — GSD workflow

## Breaking changes

- [x] No breaking changes

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above

**Local CI gate:**
| Step | Result |
|---|---|
| `npm run build` | ✅ pass |
| `npm run typecheck:extensions` | ✅ pass |
| `npm run test:unit` | ✅ 3982 pass, 1 pre-existing fail (`session-lock-transient-read`) |
| `npm run test:integration` | ✅ 71 pass, 3 pre-existing fail (web-mode tests) |

**New test:** E2E test in `queue-reorder-e2e.test.ts` that opens a real SQLite DB, inserts two milestones, sets queue order with M008 first, and verifies `deriveState` picks M008 (not M006).

**Existing tests:** All 7 existing queue-reorder e2e tests continue to pass (filesystem fallback path).

## AI disclosure

- [x] This PR includes AI-assisted code — authored with Claude, verified via standalone reproduction script, DB-backed e2e test, and full CI gate.

