### PR TITLE
fix(gsd): update DB task status in writeBlockerPlaceholder

### DIFF
--- a/src/resources/extensions/gsd/auto-recovery.ts
+++ b/src/resources/extensions/gsd/auto-recovery.ts
@@ -12,7 +12,7 @@ import { parseUnitId } from "./unit-id.js";
 import { atomicWriteSync } from "./atomic-write.js";
 import { clearParseCache } from "./files.js";
 import { parseRoadmap as parseLegacyRoadmap, parsePlan as parseLegacyPlan } from "./parsers-legacy.js";
-import { isDbAvailable, getTask, getSlice, getSliceTasks } from "./gsd-db.js";
+import { isDbAvailable, getTask, getSlice, getSliceTasks, updateTaskStatus } from "./gsd-db.js";
 import { isValidationTerminal } from "./state.js";
 import {
   nativeConflictFiles,
@@ -425,6 +425,20 @@ export function writeBlockerPlaceholder(
     `Review and replace this file before relying on downstream artifacts.`,
   ].join("\n");
   writeFileSync(absPath, content, "utf-8");
+
+  // Mark the task as complete in the DB so verifyExpectedArtifact passes.
+  // Without this, the DB status stays "pending" and the dispatch loop
+  // re-derives the same task indefinitely (#2531).
+  if (unitType === "execute-task" && isDbAvailable()) {
+    const parts = unitId.split("/");
+    const mid = parts[0];
+    const sid = parts[1];
+    const tid = parts[2];
+    if (mid && sid && tid) {
+      try { updateTaskStatus(mid, sid, tid, "complete", new Date().toISOString()); } catch { /* non-fatal */ }
+    }
+  }
+
   return diagnoseExpectedArtifact(unitType, unitId, base);
 }
 

--- a/src/resources/extensions/gsd/tests/idle-recovery.test.ts
+++ b/src/resources/extensions/gsd/tests/idle-recovery.test.ts
@@ -294,3 +294,66 @@ test('verifyExpectedArtifact: hook types always return true', () => {
   }
 });
 
+
+test('writeBlockerPlaceholder: updates DB task status for execute-task (#2531)', async () => {
+  const base = createFixtureBase();
+  try {
+    const { openDatabase, closeDatabase, insertMilestone, insertSlice, insertTask, getTask, isDbAvailable } =
+      await import("../gsd-db.ts");
+
+    const dbPath = join(base, ".gsd", "gsd.db");
+    // Create the tasks directory (required for artifact path resolution)
+    mkdirSync(join(base, ".gsd", "milestones", "M001", "slices", "S01", "tasks"), { recursive: true });
+
+    openDatabase(dbPath);
+    try {
+      insertMilestone({ id: "M001", title: "Test", status: "active" });
+      insertSlice({ id: "S01", milestoneId: "M001", title: "Slice", status: "active" });
+      insertTask({ id: "T01", sliceId: "S01", milestoneId: "M001", title: "Task", status: "pending" });
+
+      // Before fix: writeBlockerPlaceholder wrote the file but left DB as "pending"
+      writeBlockerPlaceholder("execute-task", "M001/S01/T01", base, "idle recovery exhausted");
+
+      const task = getTask("M001", "S01", "T01");
+      assert.equal(task?.status, "complete",
+        "writeBlockerPlaceholder must update DB task status to 'complete' so verifyExpectedArtifact passes");
+
+      // Verify the full chain works: verifyExpectedArtifact should return true
+      const verified = verifyExpectedArtifact("execute-task", "M001/S01/T01", base);
+      assert.equal(verified, true,
+        "verifyExpectedArtifact should pass after writeBlockerPlaceholder updates DB status");
+    } finally {
+      if (isDbAvailable()) closeDatabase();
+    }
+  } finally {
+    cleanup(base);
+  }
+});
+
+test('writeBlockerPlaceholder: does NOT update DB for non-execute-task types', async () => {
+  const base = createFixtureBase();
+  try {
+    const { openDatabase, closeDatabase, insertMilestone, insertSlice, getSlice, isDbAvailable } =
+      await import("../gsd-db.ts");
+
+    const dbPath = join(base, ".gsd", "gsd.db");
+    mkdirSync(join(base, ".gsd", "milestones", "M001", "slices", "S01"), { recursive: true });
+
+    openDatabase(dbPath);
+    try {
+      insertMilestone({ id: "M001", title: "Test", status: "active" });
+      insertSlice({ id: "S01", milestoneId: "M001", title: "Slice", status: "active" });
+
+      // research-slice is NOT execute-task — DB should NOT be updated
+      writeBlockerPlaceholder("research-slice", "M001/S01", base, "idle recovery exhausted");
+
+      const slice = getSlice("M001", "S01");
+      assert.equal(slice?.status, "active",
+        "writeBlockerPlaceholder should not change DB status for non-execute-task types");
+    } finally {
+      if (isDbAvailable()) closeDatabase();
+    }
+  } finally {
+    cleanup(base);
+  }
+});


### PR DESCRIPTION
## TL;DR

**What:** `writeBlockerPlaceholder` now updates the DB task status to `"complete"` for `execute-task` units after writing the placeholder file.
**Why:** Without the DB update, `verifyExpectedArtifact` sees `"pending"` in the DB and returns false — causing the dispatch loop to re-derive and re-dispatch the same timed-out task indefinitely.
**How:** After writing the placeholder SUMMARY file, call `updateTaskStatus(mid, sid, tid, "complete")` when the DB is available and the unit type is `execute-task`.

## What

- **`auto-recovery.ts`**: After the `writeFileSync` call in `writeBlockerPlaceholder`, added a conditional DB update for `execute-task` units. Added `updateTaskStatus` to the import from `gsd-db.js`.
- **`idle-recovery.test.ts`**: Two new regression tests — one verifying DB status is updated for `execute-task`, one verifying non-execute-task types are NOT updated.

## Why

When idle recovery exhausts all retries for an `execute-task` unit, `writeBlockerPlaceholder` writes a placeholder `T{tid}-SUMMARY.md` so the pipeline can advance. However, `verifyExpectedArtifact` for `execute-task` uses the DB as the authoritative source:

```typescript
const dbTask = getTask(mid, sid, tid);
if (dbTask) {
    if (dbTask.status !== "complete" && dbTask.status !== "done")
        return false;  // DB says "pending" → verification fails
}
```

Because `writeBlockerPlaceholder` never called `updateTaskStatus`, the DB stayed at `"pending"`. This caused:
1. `verifyExpectedArtifact` → `false`
2. Task never added to `completedUnits`
3. `deriveState` re-derives the same task as active
4. Dispatch returns the same unit
5. Infinite loop (observed as 8–9 "Advancing pipeline" messages)

This PR addresses **Bug 1** from #2531. Bug 2 (stale `recoveryAttempts`) is tracked separately in #2322.

Closes #2531

## How

The fix is additive — a conditional block after the existing `writeFileSync`:

```typescript
if (unitType === "execute-task" && isDbAvailable()) {
    const parts = unitId.split("/");
    if (mid && sid && tid) {
        try { updateTaskStatus(mid, sid, tid, "complete", ...); } catch { /* non-fatal */ }
    }
}
```

**Key decisions:**
- **Only for `execute-task`** — other unit types (research-slice, plan-slice, etc.) don't have the same DB-status verification path, so they don't need this update.
- **Non-fatal try/catch** — if the DB update fails, the placeholder file still exists and the pipeline can degrade gracefully.
- **`isDbAvailable()` guard** — respects unmigrated projects that don't have a DB.

**Bug reproduction:**

```
BEFORE fix:
DB task status after writeBlockerPlaceholder: pending
❌ BUG: verifyExpectedArtifact returns false — pipeline stuck in loop

AFTER fix:
DB task status after writeBlockerPlaceholder: complete
✅ FIXED: verifyExpectedArtifact returns true — pipeline can advance
```

## Change type

- [x] `fix` — Bug fix

## Scope

- [x] `gsd extension` — GSD workflow

## Breaking changes

- [x] No breaking changes

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above

**Local CI gate:**
| Step | Result |
|---|---|
| `npm run build` | ✅ pass |
| `npm run typecheck:extensions` | ✅ pass |
| `npm run test:unit` | ✅ 3983 pass, 1 pre-existing fail (`session-lock-transient-read`) |
| `npm run test:integration` | ✅ 71 pass, 3 pre-existing fail (web-mode tests) |

**New tests** (2 in `idle-recovery.test.ts`):
1. `writeBlockerPlaceholder` updates DB task status for `execute-task` — verifies both DB status and `verifyExpectedArtifact` return value
2. `writeBlockerPlaceholder` does NOT update DB for non-execute-task types — guard test

**Standalone reproduction:** Script opens in-memory DB, inserts a task with `"pending"` status, calls `writeBlockerPlaceholder`, checks DB status and `verifyExpectedArtifact`. Before fix: status stays `"pending"`, verification fails. After fix: status is `"complete"`, verification passes.

## AI disclosure

- [x] This PR includes AI-assisted code — authored with Claude, verified via standalone reproduction script, targeted module tests, and full CI gate.
