### PR TITLE
fix(gsd): exclude lastReasoning from retry diagnostic to prevent hallucination loops

### DIFF
--- a/src/resources/extensions/gsd/session-forensics.ts
+++ b/src/resources/extensions/gsd/session-forensics.ts
@@ -472,9 +472,13 @@ function formatTraceSummary(trace: ExecutionTrace): string {
   if (trace.errors.length > 0) {
     parts.push(`Errors: ${trace.errors.slice(-3).join("; ")}`);
   }
-  if (trace.lastReasoning) {
-    parts.push(`Last reasoning: "${trace.lastReasoning}"`);
-  }
+  // NOTE: lastReasoning is intentionally excluded from the retry diagnostic.
+  // This summary is injected into retry prompts via getDeepDiagnostic() →
+  // phases.ts. Including prior assistant free-text causes hallucination loops
+  // when the previous turn was truncated or malformed. Crash recovery has its
+  // own path (formatCrashRecoveryBriefing) that handles lastReasoning safely
+  // with explicit "Last Agent Reasoning Before Interruption" framing.
+  // See: https://github.com/gsd-build/gsd-2/issues/2195
   return parts.join("\n");
 }
 

--- a/src/resources/extensions/gsd/tests/retry-diagnostic-reasoning.test.ts
+++ b/src/resources/extensions/gsd/tests/retry-diagnostic-reasoning.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Regression tests for #2195: formatTraceSummary (used by getDeepDiagnostic →
+ * retry prompts) must NOT include lastReasoning from prior assistant text.
+ *
+ * Including prior assistant free-text in retry diagnostics causes hallucination
+ * loops when the previous turn was truncated or malformed.
+ *
+ * The crash recovery path (formatCrashRecoveryBriefing) has its own safe handling
+ * of lastReasoning and is NOT affected by this change.
+ */
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, writeFileSync, rmSync, mkdtempSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { extractTrace, getDeepDiagnostic } from "../session-forensics.ts";
+
+/** Build a minimal assistant text reasoning entry. */
+function makeAssistantText(text: string): unknown {
+  return {
+    type: "message",
+    message: {
+      role: "assistant",
+      content: [{ type: "text", text }],
+    },
+  };
+}
+
+/** Build a minimal assistant tool call + tool result pair. */
+function makeToolPair(
+  toolName: string,
+  input: Record<string, unknown>,
+  resultText: string,
+  isError: boolean,
+): unknown[] {
+  const toolCallId = `toolu_${Math.random().toString(36).slice(2, 10)}`;
+  return [
+    {
+      type: "message",
+      message: {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: toolCallId,
+            name: toolName,
+            arguments: input,
+          },
+        ],
+      },
+    },
+    {
+      type: "message",
+      message: {
+        role: "toolResult",
+        toolCallId,
+        toolName,
+        isError,
+        content: [{ type: "text", text: resultText }],
+      },
+    },
+  ];
+}
+
+describe("retry diagnostic excludes lastReasoning (#2195)", () => {
+  test("extractTrace still captures lastReasoning in the trace object", () => {
+    const entries = [
+      makeAssistantText("I am going to write the summary file now"),
+      ...makeToolPair("write", { path: "/tmp/SUMMARY.md" }, "ok", false),
+      makeAssistantText("The task is complete — all files written."),
+    ];
+
+    const trace = extractTrace(entries);
+    // extractTrace should still collect lastReasoning for crash recovery
+    assert.ok(trace.lastReasoning.length > 0,
+      "extractTrace should still populate lastReasoning");
+    assert.ok(trace.lastReasoning.includes("all files written"),
+      "lastReasoning should contain the last assistant text");
+  });
+
+  test("getDeepDiagnostic output does NOT contain lastReasoning", () => {
+    // Create a temporary activity directory with a JSONL file
+    const tempBase = mkdtempSync(join(tmpdir(), "gsd-diag-test-"));
+    const gsdDir = join(tempBase, ".gsd");
+    const activityDir = join(gsdDir, "activity");
+    mkdirSync(activityDir, { recursive: true });
+
+    try {
+      // Build entries with both tool calls and assistant reasoning
+      const entries = [
+        makeAssistantText("Let me analyze the codebase structure first"),
+        ...makeToolPair("bash", { command: "ls src/" }, "index.ts\nutils.ts", false),
+        makeAssistantText("I see the milestone/M001 branch has a significantly different ... 3. "),
+      ];
+
+      // Write JSONL activity file
+      const jsonl = entries.map(e => JSON.stringify(e)).join("\n");
+      writeFileSync(join(activityDir, "2025-01-01T00-00-00.jsonl"), jsonl);
+
+      const diagnostic = getDeepDiagnostic(tempBase);
+
+      // Diagnostic should exist (we have tool calls)
+      assert.ok(diagnostic !== null, "diagnostic should not be null");
+
+      // Diagnostic should contain structured execution evidence
+      assert.ok(diagnostic!.includes("Tool calls completed:"),
+        "should include tool call count");
+      assert.ok(diagnostic!.includes("ls src/"),
+        "should include commands run");
+
+      // Diagnostic must NOT contain the assistant's free-text reasoning
+      assert.ok(!diagnostic!.includes("Last reasoning"),
+        "diagnostic must not include 'Last reasoning' label");
+      assert.ok(!diagnostic!.includes("analyze the codebase"),
+        "diagnostic must not include prior assistant text");
+      assert.ok(!diagnostic!.includes("significantly different"),
+        "diagnostic must not include truncated assistant reasoning");
+    } finally {
+      rmSync(tempBase, { recursive: true, force: true });
+    }
+  });
+
+  test("getDeepDiagnostic still includes errors and file operations", () => {
+    const tempBase = mkdtempSync(join(tmpdir(), "gsd-diag-test-"));
+    const gsdDir = join(tempBase, ".gsd");
+    const activityDir = join(gsdDir, "activity");
+    mkdirSync(activityDir, { recursive: true });
+
+    try {
+      const entries = [
+        makeAssistantText("Writing the plan file"),
+        ...makeToolPair("write", { path: "M001/S01/S01-PLAN.md" }, "ok", false),
+        ...makeToolPair("bash", { command: "npm run build" }, "Error: type mismatch", true),
+        makeAssistantText("The build failed, let me investigate"),
+      ];
+
+      const jsonl = entries.map(e => JSON.stringify(e)).join("\n");
+      writeFileSync(join(activityDir, "2025-01-01T00-00-00.jsonl"), jsonl);
+
+      const diagnostic = getDeepDiagnostic(tempBase);
+      assert.ok(diagnostic !== null);
+
+      // Structured evidence should be present
+      assert.ok(diagnostic!.includes("S01-PLAN.md"),
+        "should include files written");
+      assert.ok(diagnostic!.includes("npm run build"),
+        "should include commands run");
+      assert.ok(diagnostic!.includes("type mismatch"),
+        "should include errors");
+
+      // But NOT the assistant's free-text
+      assert.ok(!diagnostic!.includes("Writing the plan"),
+        "must not include assistant reasoning");
+      assert.ok(!diagnostic!.includes("build failed"),
+        "must not include assistant reasoning about failures");
+    } finally {
+      rmSync(tempBase, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## TL;DR

**What:** `formatTraceSummary()` no longer includes `lastReasoning` (prior assistant free-text) in retry diagnostic output.
**Why:** When a previous turn was truncated mid-thought, the model recycled its own interrupted reasoning as "diagnostic truth", causing hallucination loops on retry.
**How:** Removed the `lastReasoning` block from `formatTraceSummary()`. Crash recovery has its own safe path and is not affected.

## What

- **`session-forensics.ts`**: Removed the `if (trace.lastReasoning)` block from `formatTraceSummary()`, which is the function called by `getDeepDiagnostic()`. Added a comment explaining why `lastReasoning` is intentionally excluded from retry diagnostics and why the crash recovery path is unaffected.
- **`tests/retry-diagnostic-reasoning.test.ts`**: Three new regression tests verifying (1) `extractTrace` still captures `lastReasoning` for crash recovery, (2) `getDeepDiagnostic` output does NOT contain assistant reasoning, and (3) structured evidence (errors, files, commands) is preserved.

## Why

GSD's retry diagnostic path injects prior execution context into the prompt when a unit is re-dispatched:

```
phases.ts:897 → getDeepDiagnostic() → formatTraceSummary() → retry prompt
```

`formatTraceSummary()` included `lastReasoning`, which is the raw text from the last assistant message in the activity log. When a session crashes or is interrupted mid-thought, this text is truncated and often incoherent. Injecting it as "diagnostic truth" into the retry prompt causes the model to:

1. Treat the truncated reasoning as fact ("I see the milestone/M001 branch has a significantly different...")
2. Build on that truncated context instead of analyzing the actual problem
3. Produce increasingly incoherent output across retries
4. Never make real progress — observed as 4+ retries with no artifact produced

The fix preserves `lastReasoning` in the `ExecutionTrace` data structure (it's still collected by `extractTrace()`), and the crash recovery path (`formatCrashRecoveryBriefing()`) still uses it with explicit "Last Agent Reasoning Before Interruption" framing. Only the retry diagnostic path is changed.

Closes #2195

## How

The fix is a simple removal — the `if (trace.lastReasoning)` block in `formatTraceSummary()` is replaced with a comment explaining the decision:

```typescript
// NOTE: lastReasoning is intentionally excluded from the retry diagnostic.
// This summary is injected into retry prompts via getDeepDiagnostic() →
// phases.ts. Including prior assistant free-text causes hallucination loops
// when the previous turn was truncated or malformed. Crash recovery has its
// own path (formatCrashRecoveryBriefing) that handles lastReasoning safely
// with explicit "Last Agent Reasoning Before Interruption" framing.
```

**Key decisions:**
- **Remove rather than gate on stop reason** — the issue suggests conditionally dropping `lastReasoning` when `stopReason === "error"`, but truncated reasoning is harmful regardless of stop reason. A model that ended mid-thought due to context limits (`stopReason: "max_tokens"`) produces equally misleading reasoning text.
- **Preserve for crash recovery** — `formatCrashRecoveryBriefing()` is a separate function with different framing ("Last Agent Reasoning Before Interruption" under a clear section header). The model knows it's resuming and treats the text as historical context, not diagnostic truth. This path is intentionally unchanged.

**Bug reproduction:**

1. Create a temp `.gsd/activity/` directory containing a JSONL file with assistant reasoning entries + tool calls (simulating a session that crashed mid-thought)
2. Call `getDeepDiagnostic(tempBase)` — the same code path that feeds retry prompts in `phases.ts`
3. Check output for `Last reasoning` label and assistant free-text content

Before fix: output includes `Last reasoning: "Based on what I found, the next step would be to rewrite 3."` — this raw assistant text gets injected into the next retry prompt
After fix: output contains only `Tool calls completed: 1` and `Commands run: \`ls src/\`` — structured execution evidence only

Repro command (run from repo root):
```
node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs \
     --experimental-strip-types -e '<inline script that creates temp JSONL and calls getDeepDiagnostic>'
```

## Change type

- [x] `fix` — Bug fix

## Scope

- [x] `gsd extension` — GSD workflow

## Breaking changes

- [x] No breaking changes

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above

**Local CI gate:**
| Step | Result |
|---|---|
| `npm run build` | ✅ pass |
| `npm run typecheck:extensions` | ✅ pass |
| `npm run test:unit` | ✅ 3984 pass, 1 pre-existing fail (`session-lock-transient-read`) |
| `npm run test:integration` | ✅ 71 pass, 3 pre-existing fail (web-mode tests) |

**New tests** (3 in `retry-diagnostic-reasoning.test.ts`):
1. `extractTrace still captures lastReasoning in the trace object` — verifies the data structure still collects reasoning for crash recovery use
2. `getDeepDiagnostic output does NOT contain lastReasoning` — end-to-end test via temp JSONL activity file; asserts absence of both the label and assistant text content
3. `getDeepDiagnostic still includes errors and file operations` — verifies structured execution evidence (files written, commands run, errors) is preserved in output

## AI disclosure

- [x] This PR includes AI-assisted code — authored with Claude, verified via standalone reproduction script, targeted module tests, and full CI gate.
