### PR TITLE
fix(gsd): use pauseAuto instead of stopAuto for warning-level dispatch stops

### DIFF
--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -504,7 +504,17 @@ export async function runDispatch(
 
   if (dispatchResult.action === "stop") {
     deps.emitJournalEvent({ ts: new Date().toISOString(), flowId: ic.flowId, seq: ic.nextSeq(), eventType: "dispatch-stop", rule: dispatchResult.matchedRule, data: { reason: dispatchResult.reason } });
-    await closeoutAndStop(ctx, pi, s, deps, dispatchResult.reason);
+    // Warning-level stops are recoverable human checkpoints (e.g. UAT verdict
+    // gate) — pause instead of hard-stopping so the session is resumable with
+    // `/gsd auto`. Error/info-level stops remain hard stops for infrastructure
+    // failures and terminal conditions respectively.
+    // See: https://github.com/gsd-build/gsd-2/issues/2474
+    if (dispatchResult.level === "warning") {
+      ctx.ui.notify(dispatchResult.reason, "warning");
+      await deps.pauseAuto(ctx, pi);
+    } else {
+      await closeoutAndStop(ctx, pi, s, deps, dispatchResult.reason);
+    }
     debugLog("autoLoop", { phase: "exit", reason: "dispatch-stop" });
     return { action: "break", reason: "dispatch-stop" };
   }

--- a/src/resources/extensions/gsd/tests/auto-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-loop.test.ts
@@ -882,6 +882,74 @@ test("autoLoop handles dispatch stop action", async (t) => {
   );
 });
 
+// #2474: warning-level dispatch stop should pause (resumable), not hard-stop
+test("autoLoop pauses instead of stopping for warning-level dispatch stop", async (t) => {
+  _resetPendingResolve();
+
+  const ctx = makeMockCtx();
+  ctx.ui.setStatus = () => {};
+  const pi = makeMockPi();
+  const s = makeLoopSession();
+
+  const deps = makeMockDeps({
+    resolveDispatch: async () => {
+      deps.callLog.push("resolveDispatch");
+      return {
+        action: "stop" as const,
+        reason: 'UAT verdict for S01 is "partial" — blocking progression.',
+        level: "warning" as const,
+      };
+    },
+  });
+
+  await autoLoop(ctx, pi, s, deps);
+
+  assert.ok(
+    deps.callLog.includes("resolveDispatch"),
+    "should have called resolveDispatch",
+  );
+  assert.ok(
+    deps.callLog.includes("pauseAuto"),
+    "warning-level stop should call pauseAuto (resumable)",
+  );
+  assert.ok(
+    !deps.callLog.includes("stopAuto"),
+    "warning-level stop should NOT call stopAuto (hard stop)",
+  );
+});
+
+// #2474: error-level dispatch stop should still hard-stop
+test("autoLoop hard-stops for error-level dispatch stop", async (t) => {
+  _resetPendingResolve();
+
+  const ctx = makeMockCtx();
+  ctx.ui.setStatus = () => {};
+  const pi = makeMockPi();
+  const s = makeLoopSession();
+
+  const deps = makeMockDeps({
+    resolveDispatch: async () => {
+      deps.callLog.push("resolveDispatch");
+      return {
+        action: "stop" as const,
+        reason: "Cannot complete milestone: missing SUMMARY files.",
+        level: "error" as const,
+      };
+    },
+  });
+
+  await autoLoop(ctx, pi, s, deps);
+
+  assert.ok(
+    deps.callLog.includes("stopAuto"),
+    "error-level stop should call stopAuto (hard stop)",
+  );
+  assert.ok(
+    !deps.callLog.includes("pauseAuto"),
+    "error-level stop should NOT call pauseAuto",
+  );
+});
+
 test("autoLoop handles dispatch skip action by continuing", async (t) => {
   _resetPendingResolve();
 


### PR DESCRIPTION
## TL;DR

**What:** Warning-level dispatch stops now call `pauseAuto()` (resumable) instead of `closeoutAndStop()` → `stopAuto()` (session destroyed).
**Why:** The UAT verdict gate returns `level: "warning"` for non-PASS verdicts — a recoverable human checkpoint, not an infrastructure failure. Hard-stopping forces a cold restart.
**How:** Added a `level === "warning"` guard in `runDispatch()` that routes to `pauseAuto()`. Error and info-level stops remain unchanged.

## What

- **`auto/phases.ts`**: In `runDispatch()`, when `dispatchResult.action === "stop"` and `dispatchResult.level === "warning"`, call `ctx.ui.notify()` + `deps.pauseAuto()` instead of `closeoutAndStop()`. Added a comment explaining the semantic distinction.
- **`tests/auto-loop.test.ts`**: Two new regression tests — one verifying warning-level stop calls `pauseAuto` (not `stopAuto`), one verifying error-level stop still calls `stopAuto` (not `pauseAuto`).

## Why

When `run-uat` writes a UAT result with `verdict: PARTIAL` or `FAIL`, the `uat-verdict-gate` dispatch rule fires and returns:

```typescript
{ action: "stop", reason: "UAT verdict for S01 is \"partial\"...", level: "warning" }
```

In `runDispatch()`, all `action: "stop"` results were routed identically to `closeoutAndStop()`:

```typescript
if (dispatchResult.action === "stop") {
    await closeoutAndStop(ctx, pi, s, deps, dispatchResult.reason);
    // → stopAuto() → s.active = false, lock cleared, session dead
}
```

`stopAuto()` is designed for unrecoverable conditions (infrastructure errors, budget ceiling). Using it for a `PARTIAL` UAT verdict — which is an expected, recoverable human checkpoint — forces the user to:
1. Manually locate and edit the UAT result file
2. Cold-restart `/gsd auto` from scratch
3. Lose any in-progress session state

After the fix, the session pauses instead of stopping. The user can review the UAT result, decide whether to accept it, and resume with `/gsd auto` — no cold restart needed.

Closes #2474

## How

The fix adds a level-based branch before the existing `closeoutAndStop()` call:

```typescript
if (dispatchResult.level === "warning") {
    ctx.ui.notify(dispatchResult.reason, "warning");
    await deps.pauseAuto(ctx, pi);
} else {
    await closeoutAndStop(ctx, pi, s, deps, dispatchResult.reason);
}
```

**Key decisions:**
- **Branch on `level` rather than adding a new `"pause"` action** — the issue's suggested fix (Option B) was to add a first-class `"pause"` action to the dispatch type. However, `level: "warning"` already exists and is semantically correct — only the UAT verdict gate uses it. Adding a new action type would require changes to the `DispatchAction` type, all rule implementations, and all consumers. The `level` guard is minimal and correct.
- **Only `"warning"` triggers pause** — auditing all dispatch rules shows: `"error"` (4 rules: missing slices, no implementation files, etc.), `"info"` (2 rules: all-complete, unhandled phase), `"warning"` (1 rule: UAT verdict gate). Error and info levels remain hard stops.

**Bug reproduction:**

1. Create a minimal `IterationContext` with mock deps where `resolveDispatch` returns `{ action: "stop", reason: "UAT verdict for S01 is partial", level: "warning" }`
2. Call `runDispatch(ic, preData, loopState)` — the same code path as the auto-mode dispatch loop
3. Check which function was called: `stopAuto` (session destroyed) or `pauseAuto` (session resumable)

Before fix: `stopAuto` called — session destroyed, user must cold-restart `/gsd auto`
After fix: `pauseAuto` called — session paused, resumable with `/gsd auto`

Repro command (run from repo root):
```
node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs \
     --experimental-strip-types -e '<inline script calling runDispatch with warning-level stop>'
```

## Change type

- [x] `fix` — Bug fix

## Scope

- [x] `gsd extension` — GSD workflow

## Breaking changes

- [x] No breaking changes

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above

**Local CI gate:**
| Step | Result |
|---|---|
| `npm run build` | ✅ pass |
| `npm run typecheck:extensions` | ✅ pass |
| `npm run test:unit` | ✅ 3991 pass, 1 pre-existing fail (`session-lock-transient-read`) |
| `npm run test:integration` | ✅ 71 pass, 3 pre-existing fail (web-mode tests) |

**New tests** (2 in `auto-loop.test.ts`):
1. `autoLoop pauses instead of stopping for warning-level dispatch stop` — verifies `pauseAuto` is called and `stopAuto` is NOT called
2. `autoLoop hard-stops for error-level dispatch stop` — guard test verifying error-level still routes to `stopAuto`

## AI disclosure

- [x] This PR includes AI-assisted code — authored with Claude, verified via standalone reproduction script, targeted module tests, and full CI gate.
