### PR TITLE
fix(gsd): persist rewrite-docs circuit breaker counter to disk

### DIFF
--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -17,6 +17,7 @@ import { isDbAvailable, getMilestoneSlices, getPendingGates, markAllGatesOmitted
 import { extractVerdict, isAcceptableUatVerdict } from "./verdict-parser.js";
 
 import {
+  gsdRoot,
   resolveMilestoneFile,
   resolveMilestonePath,
   resolveSliceFile,
@@ -26,7 +27,7 @@ import {
   buildMilestoneFileName,
   buildSliceFileName,
 } from "./paths.js";
-import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { hasImplementationArtifacts } from "./auto-recovery.js";
 import {
@@ -92,6 +93,29 @@ function missingSliceStop(mid: string, phase: string): DispatchAction {
 
 const MAX_REWRITE_ATTEMPTS = 3;
 
+// ─── Disk-persisted rewrite attempt counter ──────────────────────────────────
+// The counter must survive session restarts (crash recovery, pause/resume,
+// step-mode). Storing it on the in-memory session object caused the circuit
+// breaker to never trip — see https://github.com/gsd-build/gsd-2/issues/2203
+function rewriteCountPath(basePath: string): string {
+  return join(gsdRoot(basePath), "runtime", "rewrite-count.json");
+}
+
+export function getRewriteCount(basePath: string): number {
+  try {
+    const data = JSON.parse(readFileSync(rewriteCountPath(basePath), "utf-8"));
+    return typeof data.count === "number" ? data.count : 0;
+  } catch {
+    return 0;
+  }
+}
+
+export function setRewriteCount(basePath: string, count: number): void {
+  const filePath = rewriteCountPath(basePath);
+  mkdirSync(join(gsdRoot(basePath), "runtime"), { recursive: true });
+  writeFileSync(filePath, JSON.stringify({ count, updatedAt: new Date().toISOString() }) + "\n");
+}
+
 // ─── Rules ────────────────────────────────────────────────────────────────
 
 export const DISPATCH_RULES: DispatchRule[] = [
@@ -100,14 +124,14 @@ export const DISPATCH_RULES: DispatchRule[] = [
     match: async ({ mid, midTitle, state, basePath, session }) => {
       const pendingOverrides = await loadActiveOverrides(basePath);
       if (pendingOverrides.length === 0) return null;
-      const count = session?.rewriteAttemptCount ?? 0;
+      const count = getRewriteCount(basePath);
       if (count >= MAX_REWRITE_ATTEMPTS) {
         const { resolveAllOverrides } = await import("./files.js");
         await resolveAllOverrides(basePath);
-        if (session) session.rewriteAttemptCount = 0;
+        setRewriteCount(basePath, 0);
         return null;
       }
-      if (session) session.rewriteAttemptCount++;
+      setRewriteCount(basePath, count + 1);
       const unitId = state.activeSlice ? `${mid}/${state.activeSlice.id}` : mid;
       return {
         action: "dispatch",

--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -331,6 +331,10 @@ export async function postUnitPreVerification(pctx: PostUnitContext, opts?: PreV
     if (s.currentUnit.type === "rewrite-docs") {
       await runSafely("postUnit", "rewrite-docs-resolve", async () => {
         await resolveAllOverrides(s.basePath);
+        // Reset both disk and in-memory counters. Disk counter is authoritative
+        // (survives restarts); in-memory is kept in sync for the current session.
+        const { setRewriteCount } = await import("./auto-dispatch.js");
+        setRewriteCount(s.basePath, 0);
         s.rewriteAttemptCount = 0;
         ctx.ui.notify("Override(s) resolved — rewrite-docs completed.", "info");
       });

--- a/src/resources/extensions/gsd/tests/rewrite-count-persist.test.ts
+++ b/src/resources/extensions/gsd/tests/rewrite-count-persist.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Regression tests for #2203: rewrite-docs circuit breaker must persist
+ * across session restarts.
+ *
+ * The rewrite attempt counter was stored in-memory on the session object,
+ * resetting to 0 on every session restart. This allowed the rewrite-docs
+ * dispatch rule to fire indefinitely, never tripping the MAX_REWRITE_ATTEMPTS
+ * circuit breaker.
+ *
+ * The fix persists the counter to `.gsd/runtime/rewrite-count.json`.
+ */
+import { describe, test, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, existsSync, readFileSync, writeFileSync, rmSync, mkdtempSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { getRewriteCount, setRewriteCount } from "../auto-dispatch.ts";
+
+describe("rewrite-docs circuit breaker persistence (#2203)", () => {
+  let tempBase: string;
+
+  beforeEach(() => {
+    tempBase = mkdtempSync(join(tmpdir(), "gsd-rewrite-test-"));
+    // Create .gsd/ directory so gsdRoot resolves to it
+    mkdirSync(join(tempBase, ".gsd", "runtime"), { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tempBase, { recursive: true, force: true });
+  });
+
+  test("getRewriteCount returns 0 when no file exists", () => {
+    const count = getRewriteCount(tempBase);
+    assert.equal(count, 0);
+  });
+
+  test("setRewriteCount writes and getRewriteCount reads back", () => {
+    setRewriteCount(tempBase, 2);
+    const count = getRewriteCount(tempBase);
+    assert.equal(count, 2);
+  });
+
+  test("counter persists across simulated session restarts", () => {
+    // Session 1: increment to 1
+    setRewriteCount(tempBase, 1);
+
+    // "Session restart" — only the disk file survives, session object is gone
+    const countAfterRestart = getRewriteCount(tempBase);
+    assert.equal(countAfterRestart, 1, "counter should survive session restart");
+
+    // Session 2: increment to 2
+    setRewriteCount(tempBase, countAfterRestart + 1);
+    assert.equal(getRewriteCount(tempBase), 2);
+  });
+
+  test("setRewriteCount(0) resets the counter", () => {
+    setRewriteCount(tempBase, 3);
+    assert.equal(getRewriteCount(tempBase), 3);
+
+    setRewriteCount(tempBase, 0);
+    assert.equal(getRewriteCount(tempBase), 0);
+  });
+
+  test("getRewriteCount handles corrupt JSON gracefully", () => {
+    const filePath = join(tempBase, ".gsd", "runtime", "rewrite-count.json");
+    // writeFileSync is imported at the top of this file
+    writeFileSync(filePath, "not json{{{");
+    const count = getRewriteCount(tempBase);
+    assert.equal(count, 0, "corrupt file should return 0");
+  });
+
+  test("rewrite-count.json is written to .gsd/runtime/", () => {
+    setRewriteCount(tempBase, 1);
+    const filePath = join(tempBase, ".gsd", "runtime", "rewrite-count.json");
+    assert.ok(existsSync(filePath), "rewrite-count.json should exist");
+
+    const content = JSON.parse(readFileSync(filePath, "utf-8"));
+    assert.equal(content.count, 1);
+    assert.ok(content.updatedAt, "should include timestamp");
+  });
+});


### PR DESCRIPTION
## TL;DR

**What:** The rewrite-docs circuit breaker counter is now persisted to `.gsd/runtime/rewrite-count.json` instead of the in-memory session object.
**Why:** The in-memory counter reset to 0 on every session restart (crash, pause/resume, step-mode), allowing the rewrite-docs dispatch rule to fire indefinitely without tripping the MAX_REWRITE_ATTEMPTS breaker.
**How:** Added `getRewriteCount(basePath)` / `setRewriteCount(basePath, count)` helpers that read/write a JSON file in the established `.gsd/runtime/` directory.

## What

- **`auto-dispatch.ts`**: Replaced `session?.rewriteAttemptCount` reads/writes with `getRewriteCount(basePath)` / `setRewriteCount(basePath, count)` calls. Added `gsdRoot` import from `./paths.js` and `readFileSync` to `node:fs` import. Added helper functions with corruption-safe JSON parsing.
- **`auto-post-unit.ts`**: Updated the post-unit rewrite-docs completion handler to reset the disk counter via `setRewriteCount(basePath, 0)` alongside the existing in-memory reset.
- **`tests/rewrite-count-persist.test.ts`**: Six new regression tests covering round-trip persistence, session restart survival, reset, corrupt file recovery, and file location.

## Why

The rewrite-docs dispatch rule has a circuit breaker that trips after `MAX_REWRITE_ATTEMPTS` (3) dispatches and auto-resolves all overrides. The counter was stored on `session.rewriteAttemptCount` — an in-memory field that resets to 0 whenever the session object is recreated:

- Crash recovery: session destroyed, new session created
- Pause/resume: `stopAuto()` / `startAuto()` creates new session
- Step-mode: each `/gsd next` creates a new session
- Provider errors: budget gate pauses, session recycled

Because `OVERRIDES.md` persists on disk after a rewrite-docs unit completes (it's only removed by `resolveAllOverrides()` when the breaker trips), the gate re-matches on every restart. With the counter always at 0, the breaker never trips, and `rewrite-docs` dispatches indefinitely.

Closes #2203

## How

The fix follows the established `.gsd/runtime/` directory pattern used by `paused-session.json`, `units/*.json`, and `quick-return.json`:

```typescript
function rewriteCountPath(basePath: string): string {
  return join(gsdRoot(basePath), "runtime", "rewrite-count.json");
}

export function getRewriteCount(basePath: string): number {
  try {
    const data = JSON.parse(readFileSync(rewriteCountPath(basePath), "utf-8"));
    return typeof data.count === "number" ? data.count : 0;
  } catch { return 0; }
}

export function setRewriteCount(basePath: string, count: number): void {
  mkdirSync(join(gsdRoot(basePath), "runtime"), { recursive: true });
  writeFileSync(filePath, JSON.stringify({ count, updatedAt: ... }) + "\n");
}
```

**Key decisions:**
- **Disk file rather than DB** — the counter is lightweight and needs no schema migration. The `runtime/` directory is already gitignored and understood as ephemeral runtime state.
- **Exported helpers** — `getRewriteCount` / `setRewriteCount` are exported so the post-unit handler in `auto-post-unit.ts` can reset the counter without re-implementing the file logic.
- **In-memory counter preserved** — `session.rewriteAttemptCount` is still reset in `auto-post-unit.ts` for backward compatibility within a running session. The disk file is authoritative across restarts.

**Bug reproduction:**

1. Create a temp `.gsd/runtime/` directory (simulating a GSD project)
2. Call `setRewriteCount(tempBase, 1)` then `setRewriteCount(tempBase, 2)` — simulating two dispatch cycles in session 1
3. Read back with `getRewriteCount(tempBase)` — simulating session restart (only disk state survives)
4. Increment to 3 and check if `count >= MAX_REWRITE_ATTEMPTS` (3) — the circuit breaker condition

Before fix: After "restart", `session.rewriteAttemptCount` is 0 — counter lost, breaker never trips, rewrite-docs dispatches forever
After fix: After "restart", `getRewriteCount()` returns 2 — counter survives, breaker trips at 3

Repro command (run from repo root):
```
node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs \
     --experimental-strip-types -e '<inline script calling setRewriteCount/getRewriteCount>'
```

## Change type

- [x] `fix` — Bug fix

## Scope

- [x] `gsd extension` — GSD workflow

## Breaking changes

- [x] No breaking changes

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above

**Local CI gate:**
| Step | Result |
|---|---|
| `npm run build` | ✅ pass |
| `npm run typecheck:extensions` | ✅ pass |
| `npm run test:unit` | ✅ 3995 pass, 1 pre-existing fail (`session-lock-transient-read`) |
| `npm run test:integration` | ✅ 71 pass, 3 pre-existing fail (web-mode tests) |

**New tests** (6 in `rewrite-count-persist.test.ts`):
1. `getRewriteCount returns 0 when no file exists` — clean start
2. `setRewriteCount writes and getRewriteCount reads back` — round-trip
3. `counter persists across simulated session restarts` — core regression test
4. `setRewriteCount(0) resets the counter` — post-unit completion path
5. `getRewriteCount handles corrupt JSON gracefully` — defensive parsing
6. `rewrite-count.json is written to .gsd/runtime/` — file location contract

## AI disclosure

- [x] This PR includes AI-assisted code — authored with Claude, verified via standalone reproduction script, targeted module tests, and full CI gate.
