### PR TITLE
refine: extract findMissingSummaries helper in auto-dispatch

### DIFF
--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -88,6 +88,19 @@ function missingSliceStop(mid: string, phase: string): DispatchAction {
   };
 }
 
+/**
+ * Check for milestone slices missing SUMMARY files.
+ * Returns array of missing slice IDs, or empty array if all present or DB unavailable.
+ */
+function findMissingSummaries(basePath: string, mid: string): string[] {
+  if (!isDbAvailable()) return [];
+  const sliceIds = getMilestoneSlices(mid).map(s => s.id);
+  return sliceIds.filter(sid => {
+    const summaryPath = resolveSliceFile(basePath, mid, sid, "SUMMARY");
+    return !summaryPath || !existsSync(summaryPath);
+  });
+}
+
 // ─── Rewrite Circuit Breaker ──────────────────────────────────────────────
 
 const MAX_REWRITE_ATTEMPTS = 3;
@@ -543,30 +556,14 @@ export const DISPATCH_RULES: DispatchRule[] = [
       if (state.phase !== "validating-milestone") return null;
 
       // Safety guard (#1368): verify all roadmap slices have SUMMARY files before
-      // allowing milestone validation. If any slice lacks a summary, the milestone
-      // is not genuinely complete — something skipped earlier slices.
-      let sliceIds: string[];
-      if (isDbAvailable()) {
-        sliceIds = getMilestoneSlices(mid).map(s => s.id);
-      } else {
-        sliceIds = [];
-      }
-
-      if (sliceIds.length > 0) {
-        const missingSlices: string[] = [];
-        for (const sid of sliceIds) {
-          const summaryPath = resolveSliceFile(basePath, mid, sid, "SUMMARY");
-          if (!summaryPath || !existsSync(summaryPath)) {
-            missingSlices.push(sid);
-          }
-        }
-        if (missingSlices.length > 0) {
-          return {
-            action: "stop",
-            reason: `Cannot validate milestone ${mid}: slices ${missingSlices.join(", ")} are missing SUMMARY files. These slices may have been skipped.`,
-            level: "error",
-          };
-        }
+      // allowing milestone validation.
+      const missingSlices = findMissingSummaries(basePath, mid);
+      if (missingSlices.length > 0) {
+        return {
+          action: "stop",
+          reason: `Cannot validate milestone ${mid}: slices ${missingSlices.join(", ")} are missing SUMMARY files. These slices may have been skipped.`,
+          level: "error",
+        };
       }
 
       // Skip preference: write a minimal pass-through VALIDATION file
@@ -606,28 +603,13 @@ export const DISPATCH_RULES: DispatchRule[] = [
       if (state.phase !== "completing-milestone") return null;
 
       // Safety guard (#1368): verify all roadmap slices have SUMMARY files.
-      let sliceIds: string[];
-      if (isDbAvailable()) {
-        sliceIds = getMilestoneSlices(mid).map(s => s.id);
-      } else {
-        sliceIds = [];
-      }
-
-      if (sliceIds.length > 0) {
-        const missingSlices: string[] = [];
-        for (const sid of sliceIds) {
-          const summaryPath = resolveSliceFile(basePath, mid, sid, "SUMMARY");
-          if (!summaryPath || !existsSync(summaryPath)) {
-            missingSlices.push(sid);
-          }
-        }
-        if (missingSlices.length > 0) {
-          return {
-            action: "stop",
-            reason: `Cannot complete milestone ${mid}: slices ${missingSlices.join(", ")} are missing SUMMARY files. Run /gsd doctor to diagnose.`,
-            level: "error",
-          };
-        }
+      const missingSlices = findMissingSummaries(basePath, mid);
+      if (missingSlices.length > 0) {
+        return {
+          action: "stop",
+          reason: `Cannot complete milestone ${mid}: slices ${missingSlices.join(", ")} are missing SUMMARY files. Run /gsd doctor to diagnose.`,
+          level: "error",
+        };
       }
 
       // Safety guard (#1703): verify the milestone produced implementation


### PR DESCRIPTION
## What
Extract a shared `findMissingSummaries()` helper function in `auto-dispatch.ts` to replace two identical missing-slice-summary validation blocks.

## Why
The "validating-milestone" and "completing-milestone" dispatch rules both contained virtually identical 15-line blocks that check whether all milestone slices have SUMMARY files. The only difference was the error message text. Any future change to the validation logic would need to be applied in two places.

## How
Added a local (non-exported) `findMissingSummaries(basePath, mid)` helper that:
- Returns early with `[]` if the DB is unavailable
- Gets all milestone slice IDs from the DB
- Filters to those missing a resolved SUMMARY file path or where the file doesn't exist on disk

Both dispatch rules now call this helper and check the returned array length, keeping only their unique error message text.

## Key changes
- `src/resources/extensions/gsd/auto-dispatch.ts`: +28 lines, -46 lines (net -18 lines)
  - New `findMissingSummaries()` helper function (lines 91-102)
  - Simplified "validating-milestone" rule (lines 558-567)
  - Simplified "completing-milestone" rule (lines 605-613)

## Testing
- `npx tsc --noEmit` passes cleanly
- `npx tsx --test` on `validate-milestone.test.ts` and `complete-milestone.test.ts`: all 29 tests pass
- No behavioral changes — pure refactor with identical logic

## Risk
Low. This is a mechanical extraction with no behavioral change. The helper function produces identical results to the inlined code it replaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)