### PR TITLE
fix(gsd): block complete-milestone dispatch when VALIDATION is needs-remediation

### DIFF
--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -626,6 +626,25 @@ export const DISPATCH_RULES: DispatchRule[] = [
     match: async ({ state, mid, midTitle, basePath }) => {
       if (state.phase !== "completing-milestone") return null;
 
+      // Safety guard (#2675): block completion when VALIDATION verdict is
+      // needs-remediation. The state machine treats needs-remediation as
+      // terminal (to prevent validate-milestone loops per #832), but
+      // completing-milestone should NOT proceed — remediation work is needed.
+      const validationFile = resolveMilestoneFile(basePath, mid, "VALIDATION");
+      if (validationFile) {
+        const validationContent = await loadFile(validationFile);
+        if (validationContent) {
+          const verdict = extractVerdict(validationContent);
+          if (verdict === "needs-remediation") {
+            return {
+              action: "stop",
+              reason: `Cannot complete milestone ${mid}: VALIDATION verdict is "needs-remediation". Address the remediation findings and re-run validation, or update the verdict manually.`,
+              level: "warning",
+            };
+          }
+        }
+      }
+
       // Safety guard (#1368): verify all roadmap slices have SUMMARY files.
       const missingSlices = findMissingSummaries(basePath, mid);
       if (missingSlices.length > 0) {

--- a/src/resources/extensions/gsd/tests/remediation-completion-guard.test.ts
+++ b/src/resources/extensions/gsd/tests/remediation-completion-guard.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Regression test for #2675: completing-milestone dispatch rule must
+ * block completion when VALIDATION verdict is "needs-remediation".
+ *
+ * Without this guard, needs-remediation + allSlicesDone causes a loop:
+ * complete-milestone dispatched → agent refuses (correct) → no SUMMARY
+ * → re-dispatch → repeat until stuck detection fires.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { DISPATCH_RULES } from "../auto-dispatch.ts";
+
+/** Find the completing-milestone dispatch rule */
+const completingRule = DISPATCH_RULES.find(r => r.name === "completing-milestone → complete-milestone");
+
+test("completing-milestone dispatch rule exists", () => {
+  assert.ok(completingRule, "rule should exist in DISPATCH_RULES");
+});
+
+test("completing-milestone blocks when VALIDATION verdict is needs-remediation (#2675)", async () => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-remediation-"));
+  mkdirSync(join(base, ".gsd", "milestones", "M001"), { recursive: true });
+
+  try {
+    // Write a VALIDATION file with needs-remediation verdict
+    writeFileSync(
+      join(base, ".gsd", "milestones", "M001", "M001-VALIDATION.md"),
+      [
+        "---",
+        "verdict: needs-remediation",
+        "remediation_round: 0",
+        "---",
+        "",
+        "# Validation Report",
+        "",
+        "3 success criteria failed. Remediation required.",
+      ].join("\n"),
+    );
+
+    const ctx = {
+      mid: "M001",
+      midTitle: "Test Milestone",
+      basePath: base,
+      state: { phase: "completing-milestone" } as any,
+      prefs: {} as any,
+      session: undefined,
+    };
+
+    const result = await completingRule!.match(ctx);
+
+    assert.ok(result !== null, "rule should match");
+    assert.equal(result!.action, "stop", "should return stop action");
+    if (result!.action === "stop") {
+      assert.equal(result!.level, "warning", "should be warning level (pausable)");
+      assert.ok(
+        result!.reason.includes("needs-remediation"),
+        "reason should mention needs-remediation",
+      );
+    }
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("completing-milestone proceeds normally when VALIDATION verdict is pass (#2675 guard)", async () => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-remediation-"));
+  mkdirSync(join(base, ".gsd", "milestones", "M001"), { recursive: true });
+
+  try {
+    // Write a VALIDATION file with pass verdict
+    writeFileSync(
+      join(base, ".gsd", "milestones", "M001", "M001-VALIDATION.md"),
+      [
+        "---",
+        "verdict: pass",
+        "---",
+        "",
+        "# Validation Report",
+        "",
+        "All criteria met.",
+      ].join("\n"),
+    );
+
+    const ctx = {
+      mid: "M001",
+      midTitle: "Test Milestone",
+      basePath: base,
+      state: { phase: "completing-milestone" } as any,
+      prefs: {} as any,
+      session: undefined,
+    };
+
+    const result = await completingRule!.match(ctx);
+
+    // Should NOT return a stop — should either dispatch or return stop for
+    // a different reason (e.g. missing SUMMARY files, no implementation)
+    if (result && result.action === "stop") {
+      assert.ok(
+        !result.reason.includes("needs-remediation"),
+        "pass verdict should NOT trigger the remediation guard",
+      );
+    }
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## TL;DR

**What:** The `completing-milestone → complete-milestone` dispatch rule now blocks dispatch when VALIDATION verdict is `needs-remediation`.
**Why:** Without this guard, `needs-remediation` + `allSlicesDone` causes a loop: the agent correctly refuses to complete (validation failed), no SUMMARY is written, and the unit is re-dispatched up to MAX_LIFETIME_DISPATCHES times.
**How:** Added a verdict check before the existing safety guards that returns `action: "stop", level: "warning"` for `needs-remediation`, pausing the session so the user can address findings and resume.

## What

- **`auto-dispatch.ts`**: Added a VALIDATION verdict check in the `completing-milestone → complete-milestone` dispatch rule. When `extractVerdict(validationContent) === "needs-remediation"`, the rule returns `action: "stop"` with `level: "warning"`. The check is placed before the existing SUMMARY and implementation-artifacts guards.
- **`tests/remediation-completion-guard.test.ts`**: Three new tests — rule existence, `needs-remediation` blocking, and `pass` verdict proceeding normally.

## Why

When VALIDATION.md has verdict `needs-remediation` and all roadmap slices appear done in the DB, the state machine enters `completing-milestone` (because `isValidationTerminal()` treats `needs-remediation` as terminal per #832). The auto-dispatch rule then fires `complete-milestone`, but:

1. The agent correctly refuses to call `gsd_complete_milestone` (validation failed)
2. No MILESTONE-SUMMARY is written (correct refusal)
3. `verifyExpectedArtifact("complete-milestone", mid)` returns `false`
4. The unit is re-dispatched → back to step 1
5. Loop runs until stuck detection fires (6+ dispatches at ~$0.20 each)

The fix intercepts this loop at the dispatch level, before the unit is ever dispatched.

Using `level: "warning"` ensures the session pauses (resumable with `/gsd auto`) rather than hard-stopping, thanks to the guard from #2474.

Closes #2675

## How

```typescript
const validationFile = resolveMilestoneFile(basePath, mid, "VALIDATION");
if (validationFile) {
    const validationContent = await loadFile(validationFile);
    if (validationContent) {
        const verdict = extractVerdict(validationContent);
        if (verdict === "needs-remediation") {
            return { action: "stop", reason: "...", level: "warning" };
        }
    }
}
```

**Key decisions:**
- **Guard in dispatch rule (Option A) rather than changing `isValidationTerminal`** — changing `isValidationTerminal` to exclude `needs-remediation` would fix this bug but re-introduce the validate-milestone loop that #832 fixed. The dispatch guard is additive and preserves both fixes.
- **`level: "warning"` for pausable stop** — `needs-remediation` is a recoverable human checkpoint (review findings, fix, re-validate), not an infrastructure failure. Warning level triggers `pauseAuto()` per #2474.

**Bug reproduction:**

1. Create a temp `.gsd/milestones/M001/` directory with a `M001-VALIDATION.md` file containing `verdict: needs-remediation`
2. Call the `completing-milestone → complete-milestone` dispatch rule's `match()` function with `state.phase === "completing-milestone"`
3. Check the return value

Before fix: Rule returns `{ action: "dispatch", unitType: "complete-milestone", ... }` — agent dispatched, refuses, loop starts
After fix: Rule returns `{ action: "stop", level: "warning", reason: "...needs-remediation..." }` — session pauses, user can address findings

## Change type

- [x] `fix` — Bug fix

## Scope

- [x] `gsd extension` — GSD workflow

## Breaking changes

- [x] No breaking changes

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above

**Local CI gate:**
| Step | Result |
|---|---|
| `npm run build` | ✅ pass |
| `npm run typecheck:extensions` | ✅ pass |
| `npm run test:unit` | ✅ 3992 pass, 1 pre-existing fail (`session-lock-transient-read`) |
| `npm run test:integration` | ✅ 71 pass, 3 pre-existing fail (web-mode tests) |

**New tests** (3 in `remediation-completion-guard.test.ts`):
1. `completing-milestone dispatch rule exists` — rule discovery sanity check
2. `completing-milestone blocks when VALIDATION verdict is needs-remediation` — core regression test
3. `completing-milestone proceeds normally when VALIDATION verdict is pass` — positive guard

## AI disclosure

- [x] This PR includes AI-assisted code — authored with Claude, verified via targeted rule tests and full CI gate.
