### PR TITLE
fix(gsd): seed preferences.md into auto-mode worktrees

### DIFF
--- a/src/resources/extensions/gsd/auto-worktree.ts
+++ b/src/resources/extensions/gsd/auto-worktree.ts
@@ -416,6 +416,22 @@ export function syncGsdStateToWorktree(
     }
   }
 
+  // Forward-sync preferences.md from project root to worktree (additive only).
+  // NOT in ROOT_STATE_FILES because syncWorktreeStateBack() must never overwrite
+  // the project root's preferences — the project root is authoritative (#2684).
+  {
+    const src = join(mainGsd, "preferences.md");
+    const dst = join(wtGsd, "preferences.md");
+    if (existsSync(src) && !existsSync(dst)) {
+      try {
+        cpSync(src, dst);
+        synced.push("preferences.md");
+      } catch {
+        /* non-fatal */
+      }
+    }
+  }
+
   // Sync milestones: copy entire milestone directories that are missing
   const mainMilestonesDir = join(mainGsd, "milestones");
   const wtMilestonesDir = join(wtGsd, "milestones");
@@ -946,6 +962,7 @@ function copyPlanningArtifacts(srcBase: string, wtPath: string): void {
     "STATE.md",
     "KNOWLEDGE.md",
     "OVERRIDES.md",
+    "preferences.md",
   ]) {
     safeCopy(join(srcGsd, file), join(dstGsd, file), { force: true });
   }

--- a/src/resources/extensions/gsd/tests/worktree-preferences-sync.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-preferences-sync.test.ts
@@ -1,0 +1,130 @@
+/**
+ * worktree-preferences-sync.test.ts — Regression test for #2684.
+ *
+ * Verifies that preferences.md is seeded into auto-mode worktrees:
+ *
+ *   1. copyPlanningArtifacts() copies preferences.md on initial worktree creation
+ *   2. syncGsdStateToWorktree() forward-syncs preferences.md (additive only)
+ *   3. syncWorktreeStateBack() does NOT overwrite project root preferences.md
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import {
+  syncGsdStateToWorktree,
+  syncWorktreeStateBack,
+} from "../auto-worktree.ts";
+
+// ─── Helpers ─────────────────────────────────────────────────────────
+
+function makeTempDir(prefix: string): string {
+  return mkdtempSync(join(tmpdir(), `gsd-prefs-test-${prefix}-`));
+}
+
+function cleanup(...dirs: string[]): void {
+  for (const dir of dirs) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function writeFile(dir: string, relativePath: string, content: string): void {
+  const fullPath = join(dir, relativePath);
+  mkdirSync(join(fullPath, ".."), { recursive: true });
+  writeFileSync(fullPath, content, "utf-8");
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────
+
+const PREFS_CONTENT = [
+  "# Preferences",
+  "",
+  "post_unit_hooks:",
+  "  - npm run lint",
+  "",
+  "skill_rules:",
+  '  - use: "frontend-design"',
+].join("\n");
+
+test("#2684: syncGsdStateToWorktree forward-syncs preferences.md when missing from worktree", (t) => {
+  const mainBase = makeTempDir("main");
+  const wtBase = makeTempDir("wt");
+  t.after(() => cleanup(mainBase, wtBase));
+
+  // Project root has preferences.md
+  writeFile(mainBase, ".gsd/preferences.md", PREFS_CONTENT);
+
+  // Worktree has .gsd/ but no preferences.md
+  mkdirSync(join(wtBase, ".gsd"), { recursive: true });
+
+  const result = syncGsdStateToWorktree(mainBase, wtBase);
+
+  assert.ok(
+    existsSync(join(wtBase, ".gsd", "preferences.md")),
+    "preferences.md should be copied to worktree",
+  );
+  assert.equal(
+    readFileSync(join(wtBase, ".gsd", "preferences.md"), "utf-8"),
+    PREFS_CONTENT,
+    "preferences.md content should match source",
+  );
+  assert.ok(
+    result.synced.includes("preferences.md"),
+    "preferences.md should appear in synced list",
+  );
+});
+
+test("#2684: syncGsdStateToWorktree does NOT overwrite existing worktree preferences.md", (t) => {
+  const mainBase = makeTempDir("main");
+  const wtBase = makeTempDir("wt");
+  t.after(() => cleanup(mainBase, wtBase));
+
+  const rootPrefs = "# Root preferences\nold: true";
+  const wtPrefs = "# Worktree preferences\nmodified: true";
+
+  writeFile(mainBase, ".gsd/preferences.md", rootPrefs);
+  writeFile(wtBase, ".gsd/preferences.md", wtPrefs);
+
+  syncGsdStateToWorktree(mainBase, wtBase);
+
+  assert.equal(
+    readFileSync(join(wtBase, ".gsd", "preferences.md"), "utf-8"),
+    wtPrefs,
+    "existing worktree preferences.md must not be overwritten",
+  );
+});
+
+test("#2684: syncWorktreeStateBack does NOT overwrite project root preferences.md", (t) => {
+  const mainBase = makeTempDir("main");
+  const wtBase = makeTempDir("wt");
+  const mid = "M001";
+  t.after(() => cleanup(mainBase, wtBase));
+
+  const rootPrefs = "# Root preferences\nauthoritative: true";
+  const wtPrefs = "# Worktree preferences\nstale-copy: true";
+
+  writeFile(mainBase, ".gsd/preferences.md", rootPrefs);
+  writeFile(wtBase, ".gsd/preferences.md", wtPrefs);
+
+  // Worktree needs at least a milestone dir for the function to proceed
+  mkdirSync(join(wtBase, ".gsd", "milestones", mid), { recursive: true });
+  mkdirSync(join(mainBase, ".gsd", "milestones"), { recursive: true });
+
+  syncWorktreeStateBack(mainBase, wtBase, mid);
+
+  assert.equal(
+    readFileSync(join(mainBase, ".gsd", "preferences.md"), "utf-8"),
+    rootPrefs,
+    "project root preferences.md must NOT be overwritten by worktree copy",
+  );
+});


### PR DESCRIPTION
TL;DR

 What: Seed preferences.md into auto-mode worktrees on creation and forward-sync.
 Why: preferences.md was missing from both seed lists, so post_unit_hooks, skill rules, and custom instructions were silently unavailable in worktrees.
 How: Add preferences.md to copyPlanningArtifacts() and a dedicated forward-sync in syncGsdStateToWorktree(), deliberately kept out of ROOT_STATE_FILES to prevent back-sync overwrite.

 What

 Two locations in auto-worktree.ts maintain lists of .gsd/ files to copy into worktrees. preferences.md was absent from both:
 - copyPlanningArtifacts() — initial seed on worktree creation
 - syncGsdStateToWorktree() — ongoing forward-sync

 Why

 Any configuration in preferences.md — including post_unit_hooks, skill rules, and custom instructions — was silently unavailable inside auto-mode worktrees.

 Closes #2684

 How

 - Added "preferences.md" to the copyPlanningArtifacts() file list.
 - Added a dedicated forward-sync block in syncGsdStateToWorktree() with the same additive-only guard (!existsSync(dst)) used by ROOT_STATE_FILES.
 - Not added to ROOT_STATE_FILES because that constant also drives syncWorktreeStateBack(), which copies worktree → project root with force: true. The project root is authoritative for
 preferences — worktree copies must never overwrite it.

 Change type

 - fix — Bug fix
 - test — Adding or updating tests

 Scope

 - gsd extension — GSD workflow

 Breaking changes

 - No breaking changes

 Test plan

 - CI passes
 - New/updated tests included — 3 regression tests in worktree-preferences-sync.test.ts

 AI disclosure

 - This PR includes AI-assisted code — generated with GSD/Claude Code, all tests verified locally