### PR TITLE
fix(gsd): resolve run-uat artifact path to ASSESSMENT instead of UAT

### DIFF
--- a/src/resources/extensions/gsd/auto-artifact-paths.ts
+++ b/src/resources/extensions/gsd/auto-artifact-paths.ts
@@ -52,7 +52,11 @@ export function resolveExpectedArtifactPath(
     }
     case "run-uat": {
       const dir = resolveSlicePath(base, mid, sid!);
-      return dir ? join(dir, buildSliceFileName(sid!, "UAT")) : null;
+      // The run-uat agent writes its verdict to S{sid}-ASSESSMENT.md via
+      // gsd_summary_save(artifact_type="ASSESSMENT"). S{sid}-UAT.md is the
+      // *input* test-case file and always pre-exists — checking it would make
+      // artifact verification a no-op. (#2652)
+      return dir ? join(dir, buildSliceFileName(sid!, "ASSESSMENT")) : null;
     }
     case "execute-task": {
       const dir = resolveSlicePath(base, mid, sid!);
@@ -118,7 +122,8 @@ export function diagnoseExpectedArtifact(
     case "reassess-roadmap":
       return `${relSliceFile(base, mid, sid!, "ASSESSMENT")} (roadmap reassessment)`;
     case "run-uat":
-      return `${relSliceFile(base, mid, sid!, "UAT")} (UAT result)`;
+      // Verdict is written to ASSESSMENT, not UAT (UAT is the input file). (#2652)
+      return `${relSliceFile(base, mid, sid!, "ASSESSMENT")} (UAT verdict)`;
     case "validate-milestone":
       return `${relMilestoneFile(base, mid, "VALIDATION")} (milestone validation report)`;
     case "complete-milestone":

--- a/src/resources/extensions/gsd/tests/auto-recovery.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-recovery.test.ts
@@ -111,7 +111,8 @@ test("resolveExpectedArtifactPath returns correct path for all slice-level types
 
   const uatResult = resolveExpectedArtifactPath("run-uat", "M001/S01", base);
   assert.ok(uatResult);
-  assert.ok(uatResult!.includes("UAT"));
+  // run-uat writes its verdict to ASSESSMENT, not UAT (UAT is the input file). (#2652)
+  assert.ok(uatResult!.includes("ASSESSMENT"));
 });
 
 // ─── diagnoseExpectedArtifact ─────────────────────────────────────────────


### PR DESCRIPTION
## TL;DR

**What:** Fix `resolveExpectedArtifactPath` and `diagnoseExpectedArtifact` for `run-uat` units to reference `ASSESSMENT` (the output file) instead of `UAT` (the input file).
**Why:** The artifact verifier checked the wrong file, making verification a no-op that always passed — contributing to `run-uat` stuck loops.
**How:** Change the `run-uat` case in both functions from `"UAT"` to `"ASSESSMENT"`, and update the test that asserted the old (buggy) path.

## What

Two functions in `auto-artifact-paths.ts` resolve the expected artifact for `run-uat` units:

- `resolveExpectedArtifactPath("run-uat", ...)` → returned `S{sid}-UAT.md`
- `diagnoseExpectedArtifact("run-uat", ...)` → returned `"S{sid}-UAT.md (UAT result)"`

Both now return the `ASSESSMENT` suffix instead.

The test in `auto-recovery.test.ts` that asserted `uatResult!.includes("UAT")` is updated to assert `uatResult!.includes("ASSESSMENT")`.

## Why

The `run-uat` agent writes its verdict to `S{sid}-ASSESSMENT.md` via `gsd_summary_save(artifact_type="ASSESSMENT")`. But `resolveExpectedArtifactPath` pointed at `S{sid}-UAT.md` — the *input* test-case file that always pre-exists before the agent runs.

This made artifact verification a no-op: it passed immediately on every dispatch, before the agent had produced any output. Combined with the dispatch guard bug fixed in #2646, this caused `run-uat` stuck loops where the same UAT was dispatched repeatedly until the loop detector fired.

Closes #2652

## How

Changed the string literal from `"UAT"` to `"ASSESSMENT"` in both the path resolver and the diagnostic message for the `run-uat` case. Added comments explaining why `ASSESSMENT` is correct (the agent writes there) and `UAT` is wrong (it's the input file).

No alternative approaches were considered — this is a straightforward suffix correction.

**Relation to #2652:** The issue describes two bugs. Bug 2 (`checkNeedsRunUat` reading the wrong file for verdict detection) was already fixed by PR #2646. This PR fixes Bug 1 (artifact path resolution).

## Bug reproduction

1. **Setup:** Create a standard GSD directory structure with `.gsd/milestones/M001/slices/S01/`.
2. **Action:** Call `resolveExpectedArtifactPath("run-uat", "M001/S01", base)`.
3. **Before fix:** Returns `.../S01-UAT.md` — the input file, which always pre-exists. Artifact verification passes vacuously.
4. **After fix:** Returns `.../S01-ASSESSMENT.md` — the file the agent actually writes.
5. **Action:** Call `diagnoseExpectedArtifact("run-uat", "M001/S01", base)`.
6. **Before fix:** Returns `"S01-UAT.md (UAT result)"` — misleading.
7. **After fix:** Returns `"S01-ASSESSMENT.md (UAT verdict)"` — accurate.

Repro script (run from repo root):
```bash
node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs \
     --experimental-strip-types \
     -e '
import { resolveExpectedArtifactPath } from "./src/resources/extensions/gsd/auto-artifact-paths.ts";
import { mkdirSync } from "node:fs";
import { join } from "node:path";
import { tmpdir } from "node:os";

const base = join(tmpdir(), "repro-2652");
mkdirSync(join(base, ".gsd", "milestones", "M001", "slices", "S01"), { recursive: true });

const result = resolveExpectedArtifactPath("run-uat", "M001/S01", base);
console.log("Path:", result);
console.log("Points to ASSESSMENT?", result?.includes("-ASSESSMENT.md"));
'
```

## Change type

- [x] `fix` — Bug fix

## Scope

- [x] `gsd extension` — GSD workflow

## Breaking changes

- [x] No breaking changes

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

**Pre-existing failures (verified identical on `main`):**
- `rtk-session-stats.test.ts` / `rtk.test.ts`: 6 failures (RTK binary not installed locally)
- `session-lock-transient-read.test.ts`: 1 flaky failure (passed on isolated re-run)
- `web-mode-assembled.test.ts` / `web-mode-onboarding.test.ts`: 3 failures (onboarding assertion + boot timeout)

## AI disclosure

- [x] This PR includes AI-assisted code — Claude was used for implementation and verification. All changes were reviewed, the fix was verified via standalone reproduction script showing before/after behavior, and the full CI gate was run locally.
