### PR TITLE
fix(claude-code-cli): treat exhausted SDK streams as errors

### DIFF
--- a/src/resources/extensions/claude-code-cli/stream-adapter.ts
+++ b/src/resources/extensions/claude-code-cli/stream-adapter.ts
@@ -113,6 +113,20 @@ function makeErrorMessage(model: string, errorMsg: string): AssistantMessage {
 	};
 }
 
+/**
+ * Generator exhaustion without a terminal result means the SDK stream was
+ * interrupted mid-turn. Surface it as an error so downstream recovery logic
+ * can classify and retry it instead of treating it as a clean completion.
+ */
+export function makeStreamExhaustedErrorMessage(model: string, lastTextContent: string): AssistantMessage {
+	const errorMsg = "stream_exhausted_without_result";
+	const message = makeErrorMessage(model, errorMsg);
+	if (lastTextContent) {
+		message.content = [{ type: "text", text: lastTextContent }];
+	}
+	return message;
+}
+
 // ---------------------------------------------------------------------------
 // streamSimple implementation
 // ---------------------------------------------------------------------------
@@ -339,26 +353,11 @@ async function pumpSdkMessages(
 			}
 		}
 
-		// Generator exhausted without a result message (unexpected)
-		const fallbackContent: AssistantMessage["content"] = [];
-		if (lastTextContent) {
-			fallbackContent.push({ type: "text", text: lastTextContent });
-		}
-		if (fallbackContent.length === 0) {
-			fallbackContent.push({ type: "text", text: "(Claude Code session ended without a response)" });
-		}
-
-		const fallback: AssistantMessage = {
-			role: "assistant",
-			content: fallbackContent,
-			api: "anthropic-messages",
-			provider: "claude-code",
-			model: modelId,
-			usage: { ...ZERO_USAGE },
-			stopReason: "stop",
-			timestamp: Date.now(),
-		};
-		stream.push({ type: "done", reason: "stop", message: fallback });
+		// Generator exhaustion without a terminal result is a stream interruption,
+		// not a successful completion. Emitting an error lets GSD classify it as a
+		// transient provider failure instead of advancing auto-mode state.
+		const fallback = makeStreamExhaustedErrorMessage(modelId, lastTextContent);
+		stream.push({ type: "error", reason: "error", error: fallback });
 	} catch (err) {
 		const errorMsg = err instanceof Error ? err.message : String(err);
 		stream.push({

--- a/src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts
+++ b/src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts
@@ -1,0 +1,21 @@
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import { makeStreamExhaustedErrorMessage } from "../stream-adapter.ts";
+
+describe("stream-adapter — exhausted stream fallback (#2575)", () => {
+	test("generator exhaustion becomes an error message instead of clean completion", () => {
+		const message = makeStreamExhaustedErrorMessage("claude-sonnet-4-20250514", "partial answer");
+
+		assert.equal(message.stopReason, "error");
+		assert.equal(message.errorMessage, "stream_exhausted_without_result");
+		assert.deepEqual(message.content, [{ type: "text", text: "partial answer" }]);
+	});
+
+	test("generator exhaustion without prior text still exposes a classifiable error", () => {
+		const message = makeStreamExhaustedErrorMessage("claude-sonnet-4-20250514", "");
+
+		assert.equal(message.stopReason, "error");
+		assert.equal(message.errorMessage, "stream_exhausted_without_result");
+		assert.match(String((message.content[0] as any)?.text ?? ""), /Claude Code error: stream_exhausted_without_result/);
+	});
+});

--- a/src/resources/extensions/gsd/provider-error-pause.ts
+++ b/src/resources/extensions/gsd/provider-error-pause.ts
@@ -22,7 +22,7 @@ export function classifyProviderError(errorMsg: string): {
   // Connection/process errors — transient, auto-resume after brief backoff (#2309).
   // These indicate the process was killed, the connection was reset, or a network
   // blip occurred. They are NOT permanent failures.
-  const isConnectionError = /terminated|connection.?reset|connection.?refused|other side closed|fetch failed|network.?(?:is\s+)?unavailable|ECONNREFUSED|ECONNRESET|EPIPE/i.test(errorMsg);
+  const isConnectionError = /terminated|connection.?reset|connection.?refused|other side closed|fetch failed|network.?(?:is\s+)?unavailable|ECONNREFUSED|ECONNRESET|EPIPE|stream_exhausted(?:_without_result)?/i.test(errorMsg);
 
   // Permanent errors — never auto-resume
   const isPermanent = /auth|unauthorized|forbidden|invalid.*key|invalid.*api|billing|quota exceeded|account/i.test(errorMsg);

--- a/src/resources/extensions/gsd/tests/provider-errors.test.ts
+++ b/src/resources/extensions/gsd/tests/provider-errors.test.ts
@@ -42,6 +42,15 @@ test("classifyProviderError defaults to 60s for rate limit without reset", () =>
   assert.equal(result.suggestedDelayMs, 60_000);
 });
 
+test("classifyProviderError treats stream_exhausted_without_result as transient connection failure", () => {
+  const result = classifyProviderError("stream_exhausted_without_result");
+  assert.deepStrictEqual(result, {
+    isTransient: true,
+    isRateLimit: false,
+    suggestedDelayMs: 15_000,
+  });
+});
+
 test("classifyProviderError detects Anthropic internal server error", () => {
   const msg = '{"type":"error","error":{"details":null,"type":"api_error","message":"Internal server error"}}';
   const result = classifyProviderError(msg);


### PR DESCRIPTION
## TL;DR

**What:** Treat exhausted Claude Agent SDK streams without a terminal `result` message as errors instead of successful completions.
**Why:** The old fallback surfaced an interrupted stream as `stop`, which could advance GSD auto-mode with a phantom success.
**How:** Convert the fallback path in `stream-adapter.ts` into a classifiable error and teach GSD's provider recovery logic to treat it as transient.

## What

This PR changes the Claude Code stream adapter and the GSD provider error classifier so interrupted SDK streams are surfaced as errors rather than successful completions.

Files changed:
- `src/resources/extensions/claude-code-cli/stream-adapter.ts`
- `src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts`
- `src/resources/extensions/gsd/provider-error-pause.ts`
- `src/resources/extensions/gsd/tests/provider-errors.test.ts`

Behavioral change:
- If the Claude Agent SDK generator exhausts without ever emitting a terminal `result` message, GSD now emits `stopReason: "error"` with `errorMessage: "stream_exhausted_without_result"`.
- GSD then classifies that error as transient provider recovery instead of treating it as a clean completion.

## Why

Issue #2575 describes a failure mode where the Claude SDK stream ends unexpectedly between the last user turn and the terminal result message.

Before this change, the adapter synthesized a successful `done` event with `stopReason: "stop"`. That made the interruption look like a normal completion. In auto-mode, that could advance unit state or trigger downstream retries from the wrong failure surface instead of routing through provider error recovery.

Closes #2575.

## How

The change is intentionally small and surgical:

1. In `stream-adapter.ts`, the generator-exhausted fallback now builds an error message instead of a synthetic success.
2. The fallback error uses a stable classifiable string: `stream_exhausted_without_result`.
3. In `provider-error-pause.ts`, that error string is treated like the existing transient connection-style failures so recovery behavior stays consistent.
4. Regression tests cover both the fallback message shape and the provider classification.

### Bug reproduction

1. Add a small mocked Claude SDK module that emits:
   - a `system` message,
   - an `assistant` message with partial text,
   - and then ends **without** a terminal `result` message.
2. Run `streamViaClaudeCode(...)` against that mocked SDK stream from a small local repro script.
3. Read the final message from `stream.result()`.

Before fix:
- Final message had `stopReason: "stop"`
- `errorMessage` was `null`
- The interrupted stream looked like a normal completion

After fix:
- Final message has `stopReason: "error"`
- `errorMessage` is `stream_exhausted_without_result`
- The interruption is classifiable and routes through provider recovery

Equivalent repro shape from repo root:

```bash
node --loader ./path/to/mock-sdk-loader.mjs \
  --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs \
  --experimental-strip-types \
  ./path/to/repro-script.mjs
```

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [x] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [ ] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

Local verification run on this branch:

```bash
npm run build
npm run typecheck:extensions
node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts
node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/provider-errors.test.ts src/resources/extensions/gsd/tests/terminated-transient.test.ts
npm run test:unit
npm run test:integration
```

Observed results:
- `npm run build` ✅
- `npm run typecheck:extensions` ✅
- targeted regression tests ✅
- `npm run test:unit` ⚠️ unrelated RTK-related failures reproduced on `upstream/main`
- `npm run test:integration` ⚠️ unrelated web onboarding failures reproduced on `upstream/main`

## AI disclosure

- [x] This PR includes AI-assisted code. The change was manually reviewed, reproduced before/after with a mocked interrupted SDK stream, and verified with targeted regression tests plus local build/typecheck runs.
