### PR TITLE
fix(web): auth token gate — synthetic 401 on missing token, unauthenticated boot state, and recovery screen

### DIFF
--- a/web/components/gsd/app-shell.tsx
+++ b/web/components/gsd/app-shell.tsx
@@ -235,6 +235,41 @@ function WorkspaceChrome() {
     detection.kind !== "active-gsd" &&
     detection.kind !== "empty-gsd"
 
+  // --- Unauthenticated gate ---
+  // Render a clear recovery screen before any workspace chrome is mounted so
+  // users who open a manually-typed URL (no #token= fragment) get actionable
+  // guidance instead of a cascade of 401 errors.
+  if (workspace.bootStatus === "unauthenticated") {
+    return (
+      <div className="flex h-dvh flex-col items-center justify-center gap-6 bg-background p-8 text-center">
+        <Image
+          src="/logo-black.svg"
+          alt="GSD"
+          width={57}
+          height={16}
+          className="shrink-0 h-4 w-auto dark:hidden"
+        />
+        <Image
+          src="/logo-white.svg"
+          alt="GSD"
+          width={57}
+          height={16}
+          className="shrink-0 h-4 w-auto hidden dark:block"
+        />
+        <div className="flex flex-col items-center gap-2">
+          <h1 className="text-lg font-semibold text-foreground">Authentication Required</h1>
+          <p className="max-w-sm text-sm text-muted-foreground">
+            This workspace requires an auth token. Copy the full URL from your terminal
+            (including the{" "}
+            <code className="rounded bg-muted px-1 py-0.5 font-mono text-xs">#token=…</code>{" "}
+            part) or restart with{" "}
+            <code className="rounded bg-muted px-1 py-0.5 font-mono text-xs">gsd --web</code>.
+          </p>
+        </div>
+      </div>
+    )
+  }
+
   return (
     <div className="relative flex h-screen flex-col overflow-hidden bg-background text-foreground">
       <header className="flex h-12 flex-shrink-0 items-center justify-between border-b border-border bg-card px-2 md:px-4">

--- a/web/lib/auth.ts
+++ b/web/lib/auth.ts
@@ -81,10 +81,20 @@ export function authHeaders(extra?: Record<string, string>): Record<string, stri
 
 /**
  * Wrapper around `fetch()` that automatically injects the auth token.
+ *
+ * When no token is available (missing `#token=` fragment and no sessionStorage
+ * entry), returns a synthetic 401 Response instead of making an unauthenticated
+ * request that will fail server-side anyway. This lets callers handle the
+ * missing-token case uniformly rather than silently cascading 401s.
  */
 export async function authFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
   const token = getAuthToken()
-  if (!token) return fetch(input, init)
+  if (!token) {
+    return new Response(JSON.stringify({ error: "No auth token available" }), {
+      status: 401,
+      headers: { "Content-Type": "application/json" },
+    })
+  }
 
   const headers = new Headers(init?.headers)
   if (!headers.has("Authorization")) {

--- a/web/lib/gsd-workspace-store.tsx
+++ b/web/lib/gsd-workspace-store.tsx
@@ -66,7 +66,7 @@ import type {
 } from "./session-browser-contract"
 import { authFetch, appendAuthParam } from "./auth"
 
-export type WorkspaceStatus = "idle" | "loading" | "ready" | "error"
+export type WorkspaceStatus = "idle" | "loading" | "ready" | "error" | "unauthenticated"
 export type WorkspaceConnectionState =
   | "idle"
   | "connecting"
@@ -4135,6 +4135,13 @@ export class GSDWorkspaceStore {
         })
 
         if (!response.ok) {
+          if (response.status === 401) {
+            this.patchState({
+              bootStatus: "unauthenticated",
+              connectionState: "error",
+            })
+            return
+          }
           throw new Error(`Boot request failed with ${response.status}`)
         }
 


### PR DESCRIPTION
## TL;DR

**What:** Add a client-side auth token gate that prevents cascading 401s when the `#token=` fragment is missing.
**Why:** Without the gate, opening a manually-typed URL fills the console with silent 401 errors and leaves the UI broken with no recovery path.
**How:** `authFetch()` returns a synthetic 401 when no token is available; `refreshBoot()` maps that 401 to a new `"unauthenticated"` status; `app-shell` renders a clear recovery screen for that state.

## What

Three files changed:

- `web/lib/auth.ts` — `authFetch()` short-circuits with a synthetic `401 Response` when `getAuthToken()` returns `null`, instead of delegating to a naked `fetch()` that will always fail server-side.
- `web/lib/gsd-workspace-store.tsx` — Added `"unauthenticated"` to `WorkspaceStatus`. `refreshBoot()` detects a 401 response from `/api/boot` and patches `bootStatus` to `"unauthenticated"` rather than throwing a generic error.
- `web/components/gsd/app-shell.tsx` — Early-return guard renders a minimal "Authentication Required" screen when `bootStatus === "unauthenticated"`, explaining the problem and how to fix it.

## Why

Closes #2731

When a user opens `gsd --web` without the `#token=` fragment (manual URL entry, bookmark, new tab), the previous code path had two gaps:

1. `authFetch()` silently fell back to bare `fetch()` — all requests returned 401 and no error was catchable.
2. `refreshBoot()` threw a generic error for any non-OK response — the UI showed "Boot request failed with 401" with a Retry button that could never succeed.

## How

**Option A** from the issue — client-side token gate.

The synthetic-Response approach means all callers of `authFetch()` handle missing-token the same way they handle a real 401, with zero extra plumbing. Adding `"unauthenticated"` as a distinct `WorkspaceStatus` keeps it separate from transient errors (which are retryable) — the recovery screen intentionally has no Retry button since the problem is configuration, not connectivity.

## Change type

- [x] `fix` — Bug fix

## Scope

- [x] `gsd extension` — GSD workflow

## Breaking changes

- [x] No breaking changes

## Test plan

- [x] CI passes
- [ ] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

**Manual repro:**
1. `gsd --web` — copy only the base URL (omit `#token=…`)
2. Open that URL in a new tab
3. **Before:** console fills with 401 errors, UI is broken
4. **After:** "Authentication Required" screen with actionable instructions

## AI disclosure

- [x] This PR includes AI-assisted code <!-- Claude Code + manual review -->