### PR TITLE
fix(gsd): delete orphaned verification_evidence rows on complete-task rollback

### DIFF
--- a/src/resources/extensions/gsd/tests/complete-task-rollback-evidence.test.ts
+++ b/src/resources/extensions/gsd/tests/complete-task-rollback-evidence.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomUUID } from "node:crypto";
+
+import { handleCompleteTask } from "../tools/complete-task.js";
+import {
+  openDatabase,
+  closeDatabase,
+  _getAdapter,
+  insertMilestone,
+  insertSlice,
+} from "../gsd-db.js";
+import { clearPathCache } from "../paths.js";
+import { clearParseCache } from "../files.js";
+
+function makeTmpBase(): string {
+  const base = join(tmpdir(), `gsd-ct-rollback-${randomUUID()}`);
+  // Create the full tasks directory so the success path works
+  mkdirSync(join(base, ".gsd", "milestones", "M001", "slices", "S01", "tasks"), { recursive: true });
+  return base;
+}
+
+const VALID_PARAMS = {
+  milestoneId: "M001",
+  sliceId: "S01",
+  taskId: "T01",
+  oneLiner: "Test task",
+  narrative: "Did the thing",
+  verification: "Checked it",
+  deviations: "None.",
+  knownIssues: "None.",
+  keyFiles: ["src/foo.ts"],
+  keyDecisions: ["Used approach A"],
+  blockerDiscovered: false,
+  verificationEvidence: [
+    { command: "npm test", exitCode: 0, verdict: "✅ pass", durationMs: 1000 },
+    { command: "npm run lint", exitCode: 0, verdict: "✅ pass", durationMs: 500 },
+  ],
+};
+
+describe("complete-task rollback cleans up verification_evidence (#2724)", () => {
+  let base: string;
+
+  afterEach(() => {
+    clearPathCache();
+    clearParseCache();
+    try { closeDatabase(); } catch { /* */ }
+    if (base) {
+      try { rmSync(base, { recursive: true, force: true }); } catch { /* */ }
+    }
+  });
+
+  it("inserts verification_evidence rows on success", async () => {
+    base = makeTmpBase();
+    openDatabase(join(base, ".gsd", "gsd.db"));
+    insertMilestone({ id: "M001" });
+    insertSlice({ id: "S01", milestoneId: "M001" });
+
+    // Write a minimal slice plan so renderPlanCheckboxes doesn't error
+    writeFileSync(
+      join(base, ".gsd", "milestones", "M001", "slices", "S01", "S01-PLAN.md"),
+      "# S01 Plan\n\n## Tasks\n\n- [ ] **T01: Test task**\n",
+    );
+
+    const result = await handleCompleteTask(VALID_PARAMS, base);
+    assert.ok(!("error" in result), `unexpected error: ${"error" in result ? result.error : ""}`);
+
+    const adapter = _getAdapter()!;
+    const rows = adapter.prepare(
+      `SELECT * FROM verification_evidence WHERE task_id = 'T01' AND slice_id = 'S01' AND milestone_id = 'M001'`,
+    ).all();
+    assert.equal(rows.length, 2, "should have 2 evidence rows after success");
+  });
+
+  it("deletes verification_evidence rows on disk-render rollback", async () => {
+    base = makeTmpBase();
+    openDatabase(join(base, ".gsd", "gsd.db"));
+    insertMilestone({ id: "M001" });
+    insertSlice({ id: "S01", milestoneId: "M001" });
+
+    // Replace the tasks directory with a file so disk write fails (cross-platform)
+    const tasksDir = join(base, ".gsd", "milestones", "M001", "slices", "S01", "tasks");
+    rmSync(tasksDir, { recursive: true, force: true });
+    writeFileSync(tasksDir, "not-a-directory");
+
+    const result = await handleCompleteTask(VALID_PARAMS, base);
+    assert.ok("error" in result, "should return error when disk write fails");
+
+    // Task should be rolled back to pending
+    const adapter = _getAdapter()!;
+    const task = adapter.prepare(
+      `SELECT status FROM tasks WHERE milestone_id = 'M001' AND slice_id = 'S01' AND id = 'T01'`,
+    ).get() as { status: string } | undefined;
+    assert.ok(task, "task row should still exist");
+    assert.equal(task!.status, "pending", "task status should be rolled back to pending");
+
+    // Verification evidence should be cleaned up — no orphaned rows
+    const evidenceRows = adapter.prepare(
+      `SELECT * FROM verification_evidence WHERE task_id = 'T01' AND slice_id = 'S01' AND milestone_id = 'M001'`,
+    ).all();
+    assert.equal(evidenceRows.length, 0, "verification_evidence should be empty after rollback");
+  });
+});

--- a/src/resources/extensions/gsd/tools/complete-task.ts
+++ b/src/resources/extensions/gsd/tools/complete-task.ts
@@ -250,6 +250,16 @@ export async function handleCompleteTask(
     );
     const rollbackAdapter = _getAdapter();
     if (rollbackAdapter) {
+      // Delete orphaned verification_evidence rows first (FK constraint
+      // references tasks, so evidence must go before status change).
+      // Without this, retries accumulate duplicate evidence rows (#2724).
+      rollbackAdapter.prepare(
+        `DELETE FROM verification_evidence WHERE milestone_id = :mid AND slice_id = :sid AND task_id = :tid`,
+      ).run({
+        ":mid": params.milestoneId,
+        ":sid": params.sliceId,
+        ":tid": params.taskId,
+      });
       rollbackAdapter.prepare(
         `UPDATE tasks SET status = 'pending' WHERE milestone_id = :mid AND slice_id = :sid AND id = :tid`,
       ).run({


### PR DESCRIPTION
## TL;DR

**What:** Delete orphaned `verification_evidence` rows when `complete-task` rolls back after a disk-render failure.
**Why:** The rollback path reset the task to `pending` but left evidence rows behind, causing duplicate accumulation on retries.
**How:** Add a `DELETE FROM verification_evidence` before the status rollback `UPDATE`, matching the cleanup order already used by `undoTask()` and `resetSlice()`.

## What

**`src/resources/extensions/gsd/tools/complete-task.ts`** — the rollback path (lines ~246-270):
- Added `DELETE FROM verification_evidence WHERE milestone_id = :mid AND slice_id = :sid AND task_id = :tid` before the existing `UPDATE tasks SET status = 'pending'`
- The DELETE must come first due to the FK constraint (evidence → tasks)

**`src/resources/extensions/gsd/tests/complete-task-rollback-evidence.test.ts`** — 2 new handler-level tests:
- Success path: 2 evidence rows exist after successful completion
- Rollback path: evidence rows are deleted when disk write fails

## Why

When `complete-task` fails during disk render (e.g. filesystem full, permission error), the rollback path correctly resets the task status to `pending`. However, it did not clean up `verification_evidence` rows that were inserted in the same transaction.

Since `insertVerificationEvidence` uses plain `INSERT` (no `ON CONFLICT` dedup) and there is no unique constraint on the evidence table, each retry accumulated additional rows. After 3 failed retries:
- Task status: `pending` (correct — rolled back each time)
- Evidence rows: 6 instead of 2 (3 sets accumulated, never cleaned up)

The `undoTask()` and `resetSlice()` functions in `gsd-db.ts` (lines 1699-1712) already follow the correct pattern: delete evidence first, then modify the task.

Closes #2724

## How

Single surgical addition — a `DELETE` statement before the existing `UPDATE` in the catch block. No schema changes, no new dependencies, no behavior change on the happy path.

**Bug reproduction:**

1. Setup: Create a temp project with milestone M001, slice S01, and a tasks directory. Open DB, register milestone and slice.
2. Action: Call `handleCompleteTask` with 2 verification evidence entries — succeeds, DB shows 2 evidence rows.
3. Action: Replace the tasks directory with a regular file (cross-platform way to force disk write failure), then call `handleCompleteTask` again.
4. Observation: Returns `{ error: "disk render failed: ..." }`. Task status rolled back to `pending`.
5. Before fix: Evidence rows from the failed attempt remain in DB — 2 orphaned rows pointing to a `pending` task.
6. After fix: Evidence rows are deleted during rollback — 0 evidence rows for the `pending` task.

Repro test (run from repo root):
```bash
node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs \
     --experimental-strip-types \
     --test src/resources/extensions/gsd/tests/complete-task-rollback-evidence.test.ts
```

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

Local CI gate (all four steps):
- `npm run build` — ✅ pass
- `npm run typecheck:extensions` — ✅ pass
- `npm run test:unit` — ✅ 4056 pass, 7 fail (all pre-existing: RTK + session-lock)
- `npm run test:integration` — ✅ 71 pass, 3 fail (all pre-existing: web-mode)

All 79 existing `complete-task.test.ts` internal assertions pass. Both new rollback tests pass.

## AI disclosure

- [x] This PR includes AI-assisted code — Claude was used for implementation and testing. All code was reviewed, all tests were run locally, and the fix was verified against the existing `undoTask`/`resetSlice` cleanup patterns.
