### PR TITLE
fix(gsd): move state machine guards inside transaction in 5 tool handlers

### DIFF
--- a/src/resources/extensions/gsd/tools/plan-milestone.ts
+++ b/src/resources/extensions/gsd/tools/plan-milestone.ts
@@ -189,27 +189,34 @@ export async function handlePlanMilestone(
     return { error: `validation failed: ${(err as Error).message}` };
   }
 
-  // ── State machine preconditions ─────────────────────────────────────────
-  const existingMilestone = getMilestone(params.milestoneId);
-  if (existingMilestone && (existingMilestone.status === "complete" || existingMilestone.status === "done")) {
-    return { error: `cannot re-plan milestone ${params.milestoneId}: it is already complete` };
-  }
-
-  // Validate depends_on: all dependencies must exist and be complete
-  if (params.dependsOn && params.dependsOn.length > 0) {
-    for (const depId of params.dependsOn) {
-      const dep = getMilestone(depId);
-      if (!dep) {
-        return { error: `depends_on references unknown milestone: ${depId}` };
-      }
-      if (dep.status !== "complete" && dep.status !== "done") {
-        return { error: `depends_on milestone ${depId} is not yet complete (status: ${dep.status})` };
-      }
-    }
-  }
+  // ── Guards + DB writes inside a single transaction (prevents TOCTOU) ───
+  // Guards must be inside the transaction so the state they check cannot
+  // change between the read and the write (#2723).
+  let guardError: string | null = null;
 
   try {
     transaction(() => {
+      const existingMilestone = getMilestone(params.milestoneId);
+      if (existingMilestone && (existingMilestone.status === "complete" || existingMilestone.status === "done")) {
+        guardError = `cannot re-plan milestone ${params.milestoneId}: it is already complete`;
+        return;
+      }
+
+      // Validate depends_on: all dependencies must exist and be complete
+      if (params.dependsOn && params.dependsOn.length > 0) {
+        for (const depId of params.dependsOn) {
+          const dep = getMilestone(depId);
+          if (!dep) {
+            guardError = `depends_on references unknown milestone: ${depId}`;
+            return;
+          }
+          if (dep.status !== "complete" && dep.status !== "done") {
+            guardError = `depends_on milestone ${depId} is not yet complete (status: ${dep.status})`;
+            return;
+          }
+        }
+      }
+
       insertMilestone({
         id: params.milestoneId,
         title: params.title,
@@ -252,6 +259,10 @@ export async function handlePlanMilestone(
     });
   } catch (err) {
     return { error: `db write failed: ${(err as Error).message}` };
+  }
+
+  if (guardError) {
+    return { error: guardError };
   }
 
   let roadmapPath: string;

--- a/src/resources/extensions/gsd/tools/plan-slice.ts
+++ b/src/resources/extensions/gsd/tools/plan-slice.ts
@@ -146,24 +146,33 @@ export async function handlePlanSlice(
     return { error: `validation failed: ${(err as Error).message}` };
   }
 
-  const parentMilestone = getMilestone(params.milestoneId);
-  if (!parentMilestone) {
-    return { error: `milestone not found: ${params.milestoneId}` };
-  }
-  if (parentMilestone.status === "complete" || parentMilestone.status === "done") {
-    return { error: `cannot plan slice in a closed milestone: ${params.milestoneId} (status: ${parentMilestone.status})` };
-  }
-
-  const parentSlice = getSlice(params.milestoneId, params.sliceId);
-  if (!parentSlice) {
-    return { error: `missing parent slice: ${params.milestoneId}/${params.sliceId}` };
-  }
-  if (parentSlice.status === "complete" || parentSlice.status === "done") {
-    return { error: `cannot re-plan slice ${params.sliceId}: it is already complete — use gsd_slice_reopen first` };
-  }
+  // ── Guards + DB writes inside a single transaction (prevents TOCTOU) ───
+  // Guards must be inside the transaction so the state they check cannot
+  // change between the read and the write (#2723).
+  let guardError: string | null = null;
 
   try {
     transaction(() => {
+      const parentMilestone = getMilestone(params.milestoneId);
+      if (!parentMilestone) {
+        guardError = `milestone not found: ${params.milestoneId}`;
+        return;
+      }
+      if (parentMilestone.status === "complete" || parentMilestone.status === "done") {
+        guardError = `cannot plan slice in a closed milestone: ${params.milestoneId} (status: ${parentMilestone.status})`;
+        return;
+      }
+
+      const parentSlice = getSlice(params.milestoneId, params.sliceId);
+      if (!parentSlice) {
+        guardError = `missing parent slice: ${params.milestoneId}/${params.sliceId}`;
+        return;
+      }
+      if (parentSlice.status === "complete" || parentSlice.status === "done") {
+        guardError = `cannot re-plan slice ${params.sliceId}: it is already complete — use gsd_slice_reopen first`;
+        return;
+      }
+
       upsertSlicePlanning(params.milestoneId, params.sliceId, {
         goal: params.goal,
         successCriteria: params.successCriteria,
@@ -209,6 +218,10 @@ export async function handlePlanSlice(
     });
   } catch (err) {
     return { error: `db write failed: ${(err as Error).message}` };
+  }
+
+  if (guardError) {
+    return { error: guardError };
   }
 
   try {

--- a/src/resources/extensions/gsd/tools/plan-task.ts
+++ b/src/resources/extensions/gsd/tools/plan-task.ts
@@ -77,21 +77,29 @@ export async function handlePlanTask(
     return { error: `validation failed: ${(err as Error).message}` };
   }
 
-  const parentSlice = getSlice(params.milestoneId, params.sliceId);
-  if (!parentSlice) {
-    return { error: `missing parent slice: ${params.milestoneId}/${params.sliceId}` };
-  }
-  if (parentSlice.status === "complete" || parentSlice.status === "done") {
-    return { error: `cannot plan task in a closed slice: ${params.sliceId} (status: ${parentSlice.status})` };
-  }
-
-  const existingTask = getTask(params.milestoneId, params.sliceId, params.taskId);
-  if (existingTask && (existingTask.status === "complete" || existingTask.status === "done")) {
-    return { error: `cannot re-plan task ${params.taskId}: it is already complete — use gsd_task_reopen first` };
-  }
+  // ── Guards + DB writes inside a single transaction (prevents TOCTOU) ───
+  // Guards must be inside the transaction so the state they check cannot
+  // change between the read and the write (#2723).
+  let guardError: string | null = null;
 
   try {
     transaction(() => {
+      const parentSlice = getSlice(params.milestoneId, params.sliceId);
+      if (!parentSlice) {
+        guardError = `missing parent slice: ${params.milestoneId}/${params.sliceId}`;
+        return;
+      }
+      if (parentSlice.status === "complete" || parentSlice.status === "done") {
+        guardError = `cannot plan task in a closed slice: ${params.sliceId} (status: ${parentSlice.status})`;
+        return;
+      }
+
+      const existingTask = getTask(params.milestoneId, params.sliceId, params.taskId);
+      if (existingTask && (existingTask.status === "complete" || existingTask.status === "done")) {
+        guardError = `cannot re-plan task ${params.taskId}: it is already complete — use gsd_task_reopen first`;
+        return;
+      }
+
       if (!existingTask) {
         insertTask({
           id: params.taskId,
@@ -115,6 +123,10 @@ export async function handlePlanTask(
     });
   } catch (err) {
     return { error: `db write failed: ${(err as Error).message}` };
+  }
+
+  if (guardError) {
+    return { error: guardError };
   }
 
   try {

--- a/src/resources/extensions/gsd/tools/reassess-roadmap.ts
+++ b/src/resources/extensions/gsd/tools/reassess-roadmap.ts
@@ -104,47 +104,6 @@ export async function handleReassessRoadmap(
     return { error: `validation failed: ${(err as Error).message}` };
   }
 
-  // ── Verify milestone exists and is active ────────────────────────
-  const milestone = getMilestone(params.milestoneId);
-  if (!milestone) {
-    return { error: `milestone not found: ${params.milestoneId}` };
-  }
-  if (milestone.status === "complete" || milestone.status === "done") {
-    return { error: `cannot reassess a closed milestone: ${params.milestoneId} (status: ${milestone.status})` };
-  }
-
-  // ── Verify completedSliceId is actually complete ──────────────────
-  const completedSlice = getSlice(params.milestoneId, params.completedSliceId);
-  if (!completedSlice) {
-    return { error: `completedSliceId not found: ${params.milestoneId}/${params.completedSliceId}` };
-  }
-  if (completedSlice.status !== "complete" && completedSlice.status !== "done") {
-    return { error: `completedSliceId ${params.completedSliceId} is not complete (status: ${completedSlice.status}) — reassess can only be called after a slice finishes` };
-  }
-
-  // ── Structural enforcement ────────────────────────────────────────
-  const existingSlices = getMilestoneSlices(params.milestoneId);
-  const completedSliceIds = new Set<string>();
-  for (const slice of existingSlices) {
-    if (slice.status === "complete" || slice.status === "done") {
-      completedSliceIds.add(slice.id);
-    }
-  }
-
-  // Reject modifications to completed slices
-  for (const modifiedSlice of params.sliceChanges.modified) {
-    if (completedSliceIds.has(modifiedSlice.sliceId)) {
-      return { error: `cannot modify completed slice ${modifiedSlice.sliceId}` };
-    }
-  }
-
-  // Reject removal of completed slices
-  for (const removedId of params.sliceChanges.removed) {
-    if (completedSliceIds.has(removedId)) {
-      return { error: `cannot remove completed slice ${removedId}` };
-    }
-  }
-
   // ── Compute assessment artifact path ──────────────────────────────
   // Assessment lives in the completed slice's directory
   const assessmentRelPath = join(
@@ -153,9 +112,58 @@ export async function handleReassessRoadmap(
     `${params.completedSliceId}-ASSESSMENT.md`,
   );
 
-  // ── Transaction: DB mutations ─────────────────────────────────────
+  // ── Guards + DB writes inside a single transaction (prevents TOCTOU) ───
+  // Guards must be inside the transaction so the state they check cannot
+  // change between the read and the write (#2723).
+  let guardError: string | null = null;
+
   try {
     transaction(() => {
+      // Verify milestone exists and is active
+      const milestone = getMilestone(params.milestoneId);
+      if (!milestone) {
+        guardError = `milestone not found: ${params.milestoneId}`;
+        return;
+      }
+      if (milestone.status === "complete" || milestone.status === "done") {
+        guardError = `cannot reassess a closed milestone: ${params.milestoneId} (status: ${milestone.status})`;
+        return;
+      }
+
+      // Verify completedSliceId is actually complete
+      const completedSlice = getSlice(params.milestoneId, params.completedSliceId);
+      if (!completedSlice) {
+        guardError = `completedSliceId not found: ${params.milestoneId}/${params.completedSliceId}`;
+        return;
+      }
+      if (completedSlice.status !== "complete" && completedSlice.status !== "done") {
+        guardError = `completedSliceId ${params.completedSliceId} is not complete (status: ${completedSlice.status}) — reassess can only be called after a slice finishes`;
+        return;
+      }
+
+      // Structural enforcement — reject modifications/removal of completed slices
+      const existingSlices = getMilestoneSlices(params.milestoneId);
+      const completedSliceIds = new Set<string>();
+      for (const slice of existingSlices) {
+        if (slice.status === "complete" || slice.status === "done") {
+          completedSliceIds.add(slice.id);
+        }
+      }
+
+      for (const modifiedSlice of params.sliceChanges.modified) {
+        if (completedSliceIds.has(modifiedSlice.sliceId)) {
+          guardError = `cannot modify completed slice ${modifiedSlice.sliceId}`;
+          return;
+        }
+      }
+
+      for (const removedId of params.sliceChanges.removed) {
+        if (completedSliceIds.has(removedId)) {
+          guardError = `cannot remove completed slice ${removedId}`;
+          return;
+        }
+      }
+
       // Record assessment
       insertAssessment({
         path: assessmentRelPath,
@@ -196,6 +204,10 @@ export async function handleReassessRoadmap(
     });
   } catch (err) {
     return { error: `db write failed: ${(err as Error).message}` };
+  }
+
+  if (guardError) {
+    return { error: guardError };
   }
 
   // ── Render artifacts ──────────────────────────────────────────────

--- a/src/resources/extensions/gsd/tools/replan-slice.ts
+++ b/src/resources/extensions/gsd/tools/replan-slice.ts
@@ -90,52 +90,61 @@ export async function handleReplanSlice(
     return { error: `validation failed: ${(err as Error).message}` };
   }
 
-  // ── Verify parent slice exists and is not closed ─────────────────
-  const parentSlice = getSlice(params.milestoneId, params.sliceId);
-  if (!parentSlice) {
-    return { error: `missing parent slice: ${params.milestoneId}/${params.sliceId}` };
-  }
-  if (parentSlice.status === "complete" || parentSlice.status === "done") {
-    return { error: `cannot replan a closed slice: ${params.sliceId} (status: ${parentSlice.status})` };
-  }
-
-  // ── Verify blocker task exists and is complete ────────────────────
-  const blockerTask = getTask(params.milestoneId, params.sliceId, params.blockerTaskId);
-  if (!blockerTask) {
-    return { error: `blockerTaskId not found: ${params.milestoneId}/${params.sliceId}/${params.blockerTaskId}` };
-  }
-  if (blockerTask.status !== "complete" && blockerTask.status !== "done") {
-    return { error: `blockerTaskId ${params.blockerTaskId} is not complete (status: ${blockerTask.status}) — the blocker task must be finished before a replan is triggered` };
-  }
-
-  // ── Structural enforcement ────────────────────────────────────────
-  const existingTasks = getSliceTasks(params.milestoneId, params.sliceId);
-  const completedTaskIds = new Set<string>();
-  for (const task of existingTasks) {
-    if (task.status === "complete" || task.status === "done") {
-      completedTaskIds.add(task.id);
-    }
-  }
-
-  // Reject updates to completed tasks
-  for (const updatedTask of params.updatedTasks) {
-    if (completedTaskIds.has(updatedTask.taskId)) {
-      return { error: `cannot modify completed task ${updatedTask.taskId}` };
-    }
-  }
-
-  // Reject removal of completed tasks
-  for (const removedId of params.removedTaskIds) {
-    if (completedTaskIds.has(removedId)) {
-      return { error: `cannot remove completed task ${removedId}` };
-    }
-  }
-
-  // ── Transaction: DB mutations ─────────────────────────────────────
-  const existingTaskIds = new Set(existingTasks.map((t) => t.id));
+  // ── Guards + DB writes inside a single transaction (prevents TOCTOU) ───
+  // Guards must be inside the transaction so the state they check cannot
+  // change between the read and the write (#2723).
+  let guardError: string | null = null;
+  let existingTaskIds: Set<string> = new Set();
 
   try {
     transaction(() => {
+      // Verify parent slice exists and is not closed
+      const parentSlice = getSlice(params.milestoneId, params.sliceId);
+      if (!parentSlice) {
+        guardError = `missing parent slice: ${params.milestoneId}/${params.sliceId}`;
+        return;
+      }
+      if (parentSlice.status === "complete" || parentSlice.status === "done") {
+        guardError = `cannot replan a closed slice: ${params.sliceId} (status: ${parentSlice.status})`;
+        return;
+      }
+
+      // Verify blocker task exists and is complete
+      const blockerTask = getTask(params.milestoneId, params.sliceId, params.blockerTaskId);
+      if (!blockerTask) {
+        guardError = `blockerTaskId not found: ${params.milestoneId}/${params.sliceId}/${params.blockerTaskId}`;
+        return;
+      }
+      if (blockerTask.status !== "complete" && blockerTask.status !== "done") {
+        guardError = `blockerTaskId ${params.blockerTaskId} is not complete (status: ${blockerTask.status}) — the blocker task must be finished before a replan is triggered`;
+        return;
+      }
+
+      // Structural enforcement — reject modifications/removal of completed tasks
+      const existingTasks = getSliceTasks(params.milestoneId, params.sliceId);
+      const completedTaskIds = new Set<string>();
+      for (const task of existingTasks) {
+        if (task.status === "complete" || task.status === "done") {
+          completedTaskIds.add(task.id);
+        }
+      }
+
+      for (const updatedTask of params.updatedTasks) {
+        if (completedTaskIds.has(updatedTask.taskId)) {
+          guardError = `cannot modify completed task ${updatedTask.taskId}`;
+          return;
+        }
+      }
+
+      for (const removedId of params.removedTaskIds) {
+        if (completedTaskIds.has(removedId)) {
+          guardError = `cannot remove completed task ${removedId}`;
+          return;
+        }
+      }
+
+      existingTaskIds = new Set(existingTasks.map((t) => t.id));
+
       // Record replan history
       insertReplanHistory({
         milestoneId: params.milestoneId,
@@ -187,6 +196,10 @@ export async function handleReplanSlice(
     });
   } catch (err) {
     return { error: `db write failed: ${(err as Error).message}` };
+  }
+
+  if (guardError) {
+    return { error: guardError };
   }
 
   // ── Render artifacts ──────────────────────────────────────────────


### PR DESCRIPTION
## TL;DR

**What:** Move state machine guards inside `transaction()` in 5 tool handlers to eliminate TOCTOU races.
**Why:** Guards ran outside the transaction, so two concurrent agents could both pass the guard and both write successfully — silently corrupting state.
**How:** Apply the `guardError` pattern already used by `complete-task`, `complete-slice`, `reopen-task`, and `reopen-slice` to the 5 affected handlers.

## What

Five tool handlers moved their state machine guard checks into the `transaction()` callback:

| File | Guards moved inside |
|------|-------------------|
| `plan-task.ts` | `getSlice` status, `getTask` status |
| `plan-slice.ts` | `getMilestone` status, `getSlice` status |
| `plan-milestone.ts` | `getMilestone` status, `depends_on` validation |
| `reassess-roadmap.ts` | `getMilestone` status, `getSlice` status, completed-slice structural enforcement |
| `replan-slice.ts` | `getSlice` status, `getTask` status, completed-task structural enforcement |

## Why

All 5 handlers ran state machine guards **outside** the `transaction()` callback, then performed writes inside a separate transaction. This created a TOCTOU (time-of-check-to-time-of-use) race:

1. Agent A calls `plan-task`, reads slice status = `"in_progress"` — guard passes
2. Agent B calls `complete-slice`, marks slice `"complete"` inside its transaction
3. Agent A enters its transaction, plans a task inside a now-complete slice

The correct pattern (used by `complete-task.ts:155-208`, `complete-slice.ts:223-257`, `reopen-task.ts`, `reopen-slice.ts`) colocates guards and writes inside a single `transaction()`, so SQLite's write lock covers both atomically.

Closes #2723

## How

Each handler now follows the same `guardError` pattern:

```typescript
let guardError: string | null = null;
transaction(() => {
  // Guards inside transaction
  const slice = getSlice(...);
  if (slice?.status === "complete") { guardError = "..."; return; }
  // ... writes ...
});
if (guardError) return { error: guardError };
```

No new dependencies, no schema changes, no behavior change on the happy path. Error messages are identical.

**Bug reproduction:**

This is a concurrency race condition — it cannot be demonstrated in a single-threaded test. The fix is verified by code inspection:
1. Before: `getSlice()` at line 80 (outside txn), `transaction()` at line 94 — separate scopes
2. After: both `getSlice()` and writes inside the same `transaction()` callback — atomic

All 33 existing handler tests pass, confirming the guard behavior and error messages are preserved.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [ ] New/updated tests included
- [x] Manual testing — steps described above
- [x] No tests needed — explained above

Race conditions cannot be unit-tested in a single-threaded test runner. The fix is verified by: (1) code inspection showing guards now live inside `transaction()`, and (2) all 33 existing handler tests passing — confirming guard error messages and write behavior are preserved.

Local CI gate:
- `npm run build` — ✅ pass
- `npm run typecheck:extensions` — ✅ pass
- `npm run test:unit` — ✅ 4054 pass, 7 fail (all pre-existing: RTK + session-lock)
- `npm run test:integration` — ✅ 71 pass, 3 fail (all pre-existing: web-mode)

## AI disclosure

- [x] This PR includes AI-assisted code — Claude was used for implementation. All changes follow the existing `guardError` pattern from `complete-task.ts` and `complete-slice.ts`. All handler tests were run locally.
