### PR TITLE
fix: re-entrant transactions + missing slice_dependencies table in initSchema

### DIFF
--- a/src/resources/extensions/gsd/gsd-db.ts
+++ b/src/resources/extensions/gsd/gsd-db.ts
@@ -387,8 +387,30 @@ function initSchema(db: DbAdapter, fileBacked: boolean): void {
       )
     `);
 
+    // Slice dependency junction table (v14)
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS slice_dependencies (
+        milestone_id TEXT NOT NULL,
+        slice_id TEXT NOT NULL,
+        depends_on_slice_id TEXT NOT NULL,
+        PRIMARY KEY (milestone_id, slice_id, depends_on_slice_id),
+        FOREIGN KEY (milestone_id, slice_id) REFERENCES slices(milestone_id, id),
+        FOREIGN KEY (milestone_id, depends_on_slice_id) REFERENCES slices(milestone_id, id)
+      )
+    `);
+
     db.exec("CREATE INDEX IF NOT EXISTS idx_memories_active ON memories(superseded_by)");
     db.exec("CREATE INDEX IF NOT EXISTS idx_replan_history_milestone ON replan_history(milestone_id, created_at)");
+
+    // v13 indexes — hot-path dispatch queries
+    db.exec("CREATE INDEX IF NOT EXISTS idx_tasks_active ON tasks(milestone_id, slice_id, status)");
+    db.exec("CREATE INDEX IF NOT EXISTS idx_slices_active ON slices(milestone_id, status)");
+    db.exec("CREATE INDEX IF NOT EXISTS idx_milestones_status ON milestones(status)");
+    db.exec("CREATE INDEX IF NOT EXISTS idx_quality_gates_pending ON quality_gates(milestone_id, slice_id, status)");
+    db.exec("CREATE INDEX IF NOT EXISTS idx_verification_evidence_task ON verification_evidence(milestone_id, slice_id, task_id)");
+
+    // v14 index — slice dependency lookups
+    db.exec("CREATE INDEX IF NOT EXISTS idx_slice_deps_target ON slice_dependencies(milestone_id, depends_on_slice_id)");
 
     db.exec(`CREATE VIEW IF NOT EXISTS active_decisions AS SELECT * FROM decisions WHERE superseded_by IS NULL`);
     db.exec(`CREATE VIEW IF NOT EXISTS active_requirements AS SELECT * FROM requirements WHERE superseded_by IS NULL`);
@@ -800,8 +822,23 @@ export function vacuumDatabase(): void {
   } catch { /* non-fatal */ }
 }
 
+let _txDepth = 0;
+
 export function transaction<T>(fn: () => T): T {
   if (!currentDb) throw new GSDError(GSD_STALE_STATE, "gsd-db: No database open");
+
+  // Re-entrant: if already inside a transaction, just run fn() without
+  // starting a new one. SQLite does not support nested BEGIN/COMMIT.
+  if (_txDepth > 0) {
+    _txDepth++;
+    try {
+      return fn();
+    } finally {
+      _txDepth--;
+    }
+  }
+
+  _txDepth++;
   currentDb.exec("BEGIN");
   try {
     const result = fn();
@@ -810,6 +847,8 @@ export function transaction<T>(fn: () => T): T {
   } catch (err) {
     currentDb.exec("ROLLBACK");
     throw err;
+  } finally {
+    _txDepth--;
   }
 }
 


### PR DESCRIPTION
Fixes the CI failures in #2756.

## What broke

1. **Nested transaction crash**: `deleteTask()` and `deleteSlice()` were wrapped in `transaction()` but get called from within an outer `transaction()` block in `reassess-roadmap.ts` and `replan-slice.ts`. SQLite doesn't support nested `BEGIN` → crash: `cannot start a transaction within a transaction`.

2. **Missing table for fresh DBs**: `slice_dependencies` table and v13/v14 indexes were only created in `migrateSchema()` (for upgrades from older versions) but missing from `initSchema()` (for fresh databases). New databases started at schema version 14 but never created the table → `no such table: slice_dependencies`.

## Fix

1. `transaction()` now tracks nesting depth. Inner calls skip `BEGIN/COMMIT` and just run the callback directly — the outer transaction handles atomicity.

2. Added `CREATE TABLE IF NOT EXISTS slice_dependencies` and all v13/v14 indexes to `initSchema()`.

## Tests

All 18 previously-failing tests now pass:
- `reassess-handler.test.ts`: 9/9 ✅
- `replan-handler.test.ts`: 9/9 ✅
- `gsd-db.test.ts`: 10/10 ✅
- `complete-slice.test.ts`: 67/67 ✅
- `complete-task.test.ts`: 79/79 ✅
- `memory-store.test.ts` + `md-importer.test.ts`: 24/24 ✅