### PR TITLE
fix: rebuild stale workspace packages after git pull

### DIFF
--- a/src/resources/extensions/shared/tests/rtk.test.ts
+++ b/src/resources/extensions/shared/tests/rtk.test.ts
@@ -18,25 +18,22 @@ const makeSpawn = (status: number, stdout: string): SpawnSyncImpl =>
 
 describe("rewriteCommandWithRtk (shared extension)", () => {
   it("rewrites command when spawn returns exit 0", () => {
-    const spawnSyncImpl = makeSpawn(0, "rtk git status");
     assert.equal(
-      rewriteCommandWithRtk("git status", { binaryPath: "/fake/rtk", spawnSyncImpl }),
+      rewriteCommandWithRtk("git status", { binaryPath: "/fake/rtk", spawnSyncImpl: makeSpawn(0, "rtk git status") }),
       "rtk git status",
     );
   });
 
   it("rewrites command when spawn returns exit 3 (ask mode)", () => {
-    const spawnSyncImpl = makeSpawn(3, "rtk npm run test");
     assert.equal(
-      rewriteCommandWithRtk("npm run test", { binaryPath: "/fake/rtk", spawnSyncImpl }),
+      rewriteCommandWithRtk("npm run test", { binaryPath: "/fake/rtk", spawnSyncImpl: makeSpawn(3, "rtk npm run test") }),
       "rtk npm run test",
     );
   });
 
   it("passes command through when spawn returns non-zero non-3 status", () => {
-    const spawnSyncImpl = makeSpawn(1, "");
     assert.equal(
-      rewriteCommandWithRtk("echo hello", { binaryPath: "/fake/rtk", spawnSyncImpl }),
+      rewriteCommandWithRtk("echo hello", { binaryPath: "/fake/rtk", spawnSyncImpl: makeSpawn(1, "") }),
       "echo hello",
     );
   });
@@ -58,31 +55,36 @@ describe("rewriteCommandWithRtk (shared extension)", () => {
   });
 
   it("passes command through when RTK is disabled via env", () => {
-    const spawnSyncImpl = (() => {
-      throw new Error("should not be called");
-    }) as unknown as SpawnSyncImpl;
+    const shouldNotRun = (() => { throw new Error("should not be called"); }) as unknown as SpawnSyncImpl;
     assert.equal(
-      rewriteCommandWithRtk("git status", {
-        binaryPath: "/fake/rtk",
-        spawnSyncImpl,
-        env: { GSD_RTK_DISABLED: "1" },
-      }),
+      rewriteCommandWithRtk("git status", { binaryPath: "/fake/rtk", spawnSyncImpl: shouldNotRun, env: { GSD_RTK_DISABLED: "1" } }),
       "git status",
     );
   });
 
-  it("returns empty command unchanged", () => {
-    const spawnSyncImpl = makeSpawn(0, "rtk  ");
-    assert.equal(rewriteCommandWithRtk("  ", { binaryPath: "/fake/rtk", spawnSyncImpl }), "  ");
-  });
-
-  it("passes command through when no binary path resolves", () => {
+  it("passes command through when no binary resolves", () => {
     assert.equal(
-      rewriteCommandWithRtk("git status", {
-        env: {},
-        spawnSyncImpl: makeSpawn(0, "rtk git status"),
-      }),
+      rewriteCommandWithRtk("git status", { env: { GSD_HOME: "/nonexistent" }, spawnSyncImpl: makeSpawn(0, "rtk git status") }),
       "git status",
     );
+  });
+
+  it("trims trailing whitespace from rewritten command", () => {
+    assert.equal(
+      rewriteCommandWithRtk("git status", { binaryPath: "/fake/rtk", spawnSyncImpl: makeSpawn(0, "rtk git status  \n") }),
+      "rtk git status",
+    );
+  });
+
+  it("falls back to original when spawn returns empty stdout", () => {
+    assert.equal(
+      rewriteCommandWithRtk("git status", { binaryPath: "/fake/rtk", spawnSyncImpl: makeSpawn(0, "") }),
+      "git status",
+    );
+  });
+
+  it("returns whitespace-only command unchanged without spawning", () => {
+    const shouldNotRun = (() => { throw new Error("should not be called"); }) as unknown as SpawnSyncImpl;
+    assert.equal(rewriteCommandWithRtk("  ", { binaryPath: "/fake/rtk", spawnSyncImpl: shouldNotRun }), "  ");
   });
 });

--- a/src/tests/rtk.test.ts
+++ b/src/tests/rtk.test.ts
@@ -48,6 +48,14 @@ test("resolveRtkBinaryPath returns explicit binaryPath without existsSync check"
   assert.equal(resolveRtkBinaryPath({ binaryPath: fakePath }), fakePath);
 });
 
+test("resolveRtkBinaryPath with empty string binaryPath falls through to normal resolution", () => {
+  // Empty string is falsy — should NOT bypass existsSync, should use normal lookup
+  // With empty env and no files present, resolves to null
+  // Use a non-existent GSD_HOME to prevent fallback to the managed dir on this machine
+  const result = resolveRtkBinaryPath({ binaryPath: "", env: { GSD_HOME: "/this/does/not/exist/gsd-home" }, platform: "linux" });
+  assert.equal(result, null);
+});
+
 test("rewriteCommandWithRtk rewrites when RTK returns exit 0 or 3", () => {
   const spawnSyncImpl = ((_binary: string, _args: string[]) => ({ status: 0, stdout: "rtk git status", error: undefined })) as typeof import("node:child_process").spawnSync;
   assert.equal(rewriteCommandWithRtk("git status", { binaryPath: "/tmp/rtk", spawnSyncImpl }), "rtk git status");


### PR DESCRIPTION
## Summary

- Adds regression tests locking down `resolveRtkBinaryPath` explicit `binaryPath` bypass (trusts it without `existsSync`)
- Adds full test coverage for the options-object API on `rewriteCommandWithRtk` in `shared/rtk.ts` (exit 0, exit 3, passthrough, error, disabled, no binary, empty stdout, whitespace-only)

The underlying fixes (explicit binaryPath bypass, options-object API, stale workspace rebuild) landed in main separately — this PR contributes the regression tests that lock down that behaviour.

## Test plan

- [ ] `npm test` — rtk.test.ts and shared/tests/rtk.test.ts pass
- [ ] No regressions in existing RTK tests