### PR TITLE
fix: add shell flag for Windows spawn in VSCode extension

### DIFF
--- a/vscode-extension/src/gsd-client.ts
+++ b/vscode-extension/src/gsd-client.ts
@@ -127,6 +127,7 @@ export class GsdClient implements vscode.Disposable {
 			cwd: this.cwd,
 			stdio: ["pipe", "pipe", "pipe"],
 			env: { ...process.env },
+			shell: process.platform === "win32",
 		});
 		this.process = proc;
 


### PR DESCRIPTION
## What
Add `shell: process.platform === "win32"` to the `spawn()` call in the VSCode extension's GSD client.

## Why
On Windows, npm global installs create `.cmd` wrapper scripts (e.g., `gsd.cmd`). Node's `child_process.spawn` cannot execute `.cmd` files directly — it requires `shell: true` to resolve them through the Windows command interpreter. Without this flag, Windows users get ENOENT or EINVAL errors when the VSCode extension tries to start the GSD agent process.

## How
Added `shell: process.platform === "win32"` to the spawn options in `gsd-client.ts`. This conditionally enables shell mode only on Windows, leaving Unix behavior unchanged.

## Key changes
- `vscode-extension/src/gsd-client.ts` — Added `shell` option to spawn call at line 130

## Testing
- TypeScript compilation passes (pre-existing vscode module errors unrelated to this change)
- The flag is conditional on `process.platform === "win32"`, so macOS/Linux behavior is unaffected
- Windows users with npm-global-installed GSD should no longer see ENOENT/EINVAL on extension startup

## Risk
Low. Single-line, platform-conditional change. No effect on non-Windows platforms.

Closes #2721

🤖 Generated with [Claude Code](https://claude.com/claude-code)