### PR TITLE
fix(gsd): parse raw YAML under preference headings

### DIFF
--- a/src/resources/extensions/gsd/preferences.ts
+++ b/src/resources/extensions/gsd/preferences.ts
@@ -22,6 +22,7 @@ import { normalizeStringArray } from "../shared/format-utils.js";
 import { resolveProfileDefaults as _resolveProfileDefaults } from "./preferences-models.js";
 
 import {
+  KNOWN_PREFERENCE_KEYS,
   MODE_DEFAULTS,
   type WorkflowMode,
   type GSDPreferences,
@@ -250,7 +251,7 @@ function parseFrontmatterBlock(frontmatter: string): GSDPreferences {
  *   - planner: sonnet
  */
 function parseHeadingListFormat(content: string): GSDPreferences {
-  const result: Record<string, Record<string, string>> = {};
+  const result: Record<string, string[]> = {};
   let currentSection: string | null = null;
 
   for (const rawLine of content.split('\n')) {
@@ -258,27 +259,44 @@ function parseHeadingListFormat(content: string): GSDPreferences {
     const headingMatch = line.match(/^##\s+(.+)$/);
     if (headingMatch) {
       currentSection = headingMatch[1].trim().toLowerCase().replace(/\s+/g, '_');
+      if (!result[currentSection]) result[currentSection] = [];
       continue;
     }
-    if (currentSection) {
-      const itemMatch = line.match(/^-\s+([^:]+):\s*(.*)$/);
-      if (itemMatch) {
-        if (!result[currentSection]) result[currentSection] = {};
-        const value = itemMatch[2].trim();
-        // Coerce "true"/"false" strings and numbers
-        result[currentSection][itemMatch[1].trim()] = value;
-      }
+    if (currentSection && line.trim() && !line.trimStart().startsWith('#')) {
+      result[currentSection].push(line);
     }
   }
 
-  // Convert string values to appropriate types via YAML parser for each section
   const typed: Record<string, unknown> = {};
-  for (const [section, entries] of Object.entries(result)) {
-    const yamlLines = Object.entries(entries).map(([k, v]) => `${k}: ${v}`).join('\n');
+  for (const [section, lines] of Object.entries(result)) {
+    if (lines.length === 0) continue;
+
+    const usesLegacyListItems = lines.every((line) => /^\s*-\s+[^:]+:\s*.*$/.test(line));
+    const yamlBlock = usesLegacyListItems
+      ? lines.map((line) => line.replace(/^\s*-\s+/, '')).join('\n')
+      : lines.join('\n');
+
     try {
-      typed[section] = parseYaml(yamlLines);
+      const parsed = parseYaml(yamlBlock);
+      if (typeof parsed !== 'object' || parsed === null) continue;
+
+      let targetSection = section;
+      let value: unknown = parsed;
+
+      if (!Array.isArray(parsed)) {
+        const keys = Object.keys(parsed);
+        if (keys.length === 1) {
+          const [onlyKey] = keys;
+          if (onlyKey === section || (!KNOWN_PREFERENCE_KEYS.has(section) && KNOWN_PREFERENCE_KEYS.has(onlyKey))) {
+            targetSection = onlyKey;
+            value = (parsed as Record<string, unknown>)[onlyKey];
+          }
+        }
+      }
+
+      typed[targetSection] = value;
     } catch {
-      typed[section] = entries;
+      /* malformed section — skip */
     }
   }
 

--- a/src/resources/extensions/gsd/tests/preferences.test.ts
+++ b/src/resources/extensions/gsd/tests/preferences.test.ts
@@ -352,6 +352,40 @@ test("handles empty models config", () => {
   assert.equal(prefs!.models, undefined);
 });
 
+test("parses raw YAML blocks under headings", () => {
+  const content = `## Parallel
+enabled: true
+max_workers: 3
+`;
+  const prefs = parsePreferencesMarkdown(content);
+  assert.notEqual(prefs, null);
+  assert.equal(prefs!.parallel?.enabled, true);
+  assert.equal(prefs!.parallel?.max_workers, 3);
+});
+
+test("unwraps nested top-level preference key under descriptive headings", () => {
+  const content = `## Parallel Orchestration
+parallel:
+  enabled: true
+  max_workers: 3
+`;
+  const prefs = parsePreferencesMarkdown(content);
+  assert.notEqual(prefs, null);
+  assert.equal(prefs!.parallel?.enabled, true);
+  assert.equal(prefs!.parallel?.max_workers, 3);
+});
+
+test("preserves legacy heading list format", () => {
+  const content = `## Git
+- isolation: branch
+- auto_push: true
+`;
+  const prefs = parsePreferencesMarkdown(content);
+  assert.notEqual(prefs, null);
+  assert.equal(prefs!.git?.isolation, "branch");
+  assert.equal(prefs!.git?.auto_push, true);
+});
+
 // ── Warn-once for unrecognized format (#2373) ────────────────────────────────
 
 test("unrecognized format warning is emitted at most once (#2373)", () => {


### PR DESCRIPTION
## TL;DR

**What:** Teach heading-based preference parsing to accept raw YAML blocks as well as legacy `- key: value` lists.
**Why:** Common `PREFERENCES.md` formats were silently parsing to `{}`, causing settings to fall back to defaults.
**How:** Normalize heading content into YAML, preserve legacy list parsing, and add regression coverage for raw-YAML and nested-key heading cases.

## What

Update the heading-based preferences parser in `src/resources/extensions/gsd/preferences.ts` so it collects non-comment lines under each `##` heading as a YAML block instead of only accepting dash-prefixed list items. The change still supports the legacy heading-list format and now also unwraps descriptive headings when the parsed block contains a single known top-level preference key.

Also add regression tests in `src/resources/extensions/gsd/tests/preferences.test.ts` covering:
- raw YAML directly under a heading
- descriptive headings that wrap a nested top-level preference key
- the legacy heading-list format

## Why

Closes #2787

`parseHeadingListFormat()` was silently dropping raw YAML blocks under markdown headings, so valid project preferences parsed to `{}` and GSD fell back to defaults. This made common `PREFERENCES.md` layouts ineffective without any warning.

## How

The parser now buffers heading content as YAML, normalizes simple `- key: value` lists into plain YAML lines for backward compatibility, and parses the result through the existing YAML path. If a descriptive heading does not map to a known top-level preference key but the parsed block contains exactly one known key, that key is unwrapped into the final preferences object.

## Change type

- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes
- [ ] `feat` — New feature or capability

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

Manual verification:
- reproduced the failure with heading-based raw YAML preferences parsing to `{}` before the fix
- verified raw YAML, nested-key headings, and legacy heading lists all parse correctly after the fix
- ran `npm run build`
- ran `npm run typecheck:extensions`
- ran `npm run test:unit`
- ran `npm run test:integration`

## AI disclosure

- [x] This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.

