### PR TITLE
fix(gsd): resume auto-mode after transient provider pause

### DIFF
--- a/src/resources/extensions/gsd/bootstrap/agent-end-recovery.ts
+++ b/src/resources/extensions/gsd/bootstrap/agent-end-recovery.ts
@@ -7,6 +7,7 @@ import { pauseAutoForProviderError } from "../provider-error-pause.js";
 import { isSessionSwitchInFlight, resolveAgentEnd } from "../auto-loop.js";
 import { resolveModelId } from "../auto-model-selection.js";
 import { clearDiscussionFlowState } from "./write-gate.js";
+import { resumeAutoAfterProviderDelay } from "./provider-error-resume.js";
 import {
   classifyError,
   createRetryState,
@@ -44,10 +45,10 @@ async function pauseTransientWithBackoff(
     retryAfterMs,
     resume: allowAutoResume
       ? () => {
-        pi.sendMessage(
-          { customType: "gsd-auto-timeout-recovery", content: "Continue execution — provider error recovery delay elapsed.", display: false },
-          { triggerTurn: true },
-        );
+        void resumeAutoAfterProviderDelay(pi, ctx).catch((err) => {
+          const message = err instanceof Error ? err.message : String(err);
+          ctx.ui.notify(`Provider error recovery delay elapsed, but auto-mode failed to resume: ${message}`, "error");
+        });
       }
       : undefined,
   });

--- a/src/resources/extensions/gsd/bootstrap/provider-error-resume.ts
+++ b/src/resources/extensions/gsd/bootstrap/provider-error-resume.ts
@@ -1,0 +1,53 @@
+import type {
+  ExtensionAPI,
+  ExtensionCommandContext,
+  ExtensionContext,
+} from "@gsd/pi-coding-agent";
+
+import { getAutoDashboardData, startAuto, type AutoDashboardData } from "../auto.js";
+
+type AutoResumeSnapshot = Pick<AutoDashboardData, "active" | "paused" | "stepMode" | "basePath">;
+
+export interface ProviderErrorResumeDeps {
+  getSnapshot(): AutoResumeSnapshot;
+  startAuto(
+    ctx: ExtensionCommandContext,
+    pi: ExtensionAPI,
+    base: string,
+    verboseMode: boolean,
+    options?: { step?: boolean },
+  ): Promise<void>;
+}
+
+const defaultDeps: ProviderErrorResumeDeps = {
+  getSnapshot: () => getAutoDashboardData(),
+  startAuto,
+};
+
+export async function resumeAutoAfterProviderDelay(
+  pi: ExtensionAPI,
+  ctx: ExtensionContext,
+  deps: ProviderErrorResumeDeps = defaultDeps,
+): Promise<"resumed" | "already-active" | "not-paused" | "missing-base"> {
+  const snapshot = deps.getSnapshot();
+
+  if (snapshot.active) return "already-active";
+  if (!snapshot.paused) return "not-paused";
+
+  if (!snapshot.basePath) {
+    ctx.ui.notify(
+      "Provider error recovery delay elapsed, but no paused auto-mode base path was available. Leaving auto-mode paused.",
+      "warning",
+    );
+    return "missing-base";
+  }
+
+  await deps.startAuto(
+    ctx as ExtensionCommandContext,
+    pi,
+    snapshot.basePath,
+    false,
+    { step: snapshot.stepMode },
+  );
+  return "resumed";
+}

--- a/src/resources/extensions/gsd/tests/provider-errors.test.ts
+++ b/src/resources/extensions/gsd/tests/provider-errors.test.ts
@@ -12,6 +12,7 @@ import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { classifyError, isTransient, isTransientNetworkError } from "../error-classifier.ts";
 import { pauseAutoForProviderError } from "../provider-error-pause.ts";
+import { resumeAutoAfterProviderDelay } from "../bootstrap/provider-error-resume.ts";
 import { getNextFallbackModel } from "../preferences.ts";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -268,6 +269,90 @@ test("pauseAutoForProviderError falls back to indefinite pause when not rate lim
   ]);
 });
 
+// ── resumeAutoAfterProviderDelay ────────────────────────────────────────────
+
+test("resumeAutoAfterProviderDelay restarts paused auto-mode from the recorded base path", async () => {
+  const startCalls: Array<{ base: string; verboseMode: boolean; step?: boolean }> = [];
+  const result = await resumeAutoAfterProviderDelay(
+    {} as any,
+    { ui: { notify() {} } } as any,
+    {
+      getSnapshot: () => ({
+        active: false,
+        paused: true,
+        stepMode: true,
+        basePath: "/tmp/project",
+      }),
+      startAuto: async (_ctx, _pi, base, verboseMode, options) => {
+        startCalls.push({ base, verboseMode, step: options?.step });
+      },
+    },
+  );
+
+  assert.equal(result, "resumed");
+  assert.deepEqual(startCalls, [
+    { base: "/tmp/project", verboseMode: false, step: true },
+  ]);
+});
+
+test("resumeAutoAfterProviderDelay does not double-start when auto-mode is already active", async () => {
+  let startCalls = 0;
+  const result = await resumeAutoAfterProviderDelay(
+    {} as any,
+    { ui: { notify() {} } } as any,
+    {
+      getSnapshot: () => ({
+        active: true,
+        paused: false,
+        stepMode: false,
+        basePath: "/tmp/project",
+      }),
+      startAuto: async () => {
+        startCalls += 1;
+      },
+    },
+  );
+
+  assert.equal(result, "already-active");
+  assert.equal(startCalls, 0);
+});
+
+test("resumeAutoAfterProviderDelay leaves auto paused when no base path is available", async () => {
+  const notifications: Array<{ message: string; level: string }> = [];
+  let startCalls = 0;
+
+  const result = await resumeAutoAfterProviderDelay(
+    {} as any,
+    {
+      ui: {
+        notify(message: string, level?: string) {
+          notifications.push({ message, level: level ?? "info" });
+        },
+      },
+    } as any,
+    {
+      getSnapshot: () => ({
+        active: false,
+        paused: true,
+        stepMode: false,
+        basePath: "",
+      }),
+      startAuto: async () => {
+        startCalls += 1;
+      },
+    },
+  );
+
+  assert.equal(result, "missing-base");
+  assert.equal(startCalls, 0);
+  assert.deepEqual(notifications, [
+    {
+      message: "Provider error recovery delay elapsed, but no paused auto-mode base path was available. Leaving auto-mode paused.",
+      level: "warning",
+    },
+  ]);
+});
+
 // ── Escalating backoff for transient errors (#1166) ─────────────────────────
 
 test("agent-end-recovery.ts tracks consecutive transient errors for escalating backoff", () => {
@@ -300,6 +385,19 @@ test("agent-end-recovery.ts applies escalating delay for repeated transient erro
   assert.ok(
     src.includes("2 ** Math.max(0, retryState.consecutiveTransientCount"),
     "agent-end-recovery.ts must escalate retryAfterMs exponentially for consecutive transient errors (#1166)",
+  );
+});
+
+test("agent-end-recovery.ts resumes transient provider pauses through startAuto instead of a hidden prompt", () => {
+  const src = readFileSync(join(__dirname, "..", "bootstrap", "agent-end-recovery.ts"), "utf-8");
+
+  assert.ok(
+    src.includes("resumeAutoAfterProviderDelay"),
+    "agent-end-recovery.ts must resume paused auto-mode through resumeAutoAfterProviderDelay (#2813)",
+  );
+  assert.ok(
+    !src.includes('Continue execution — provider error recovery delay elapsed.'),
+    "transient provider resume must not rely on a hidden continue prompt (#2813)",
   );
 });
 


### PR DESCRIPTION
## TL;DR

**What:** Make transient provider-error recovery restart paused auto-mode instead of sending a hidden continue prompt.
**Why:** The backoff timer fired after the auto loop had already exited, so transient provider errors left auto-mode paused until the user manually restarted it. Closes #2813.
**How:** Route delayed recovery through the existing paused-session `startAuto(...)` resume path and lock the behavior with regression tests.

## What

- replace the transient provider-error resume callback in `agent-end-recovery.ts`
- add a small `provider-error-resume.ts` helper that resumes paused auto-mode from the recorded snapshot
- cover resumed, already-active, and missing-base-path cases in `provider-errors.test.ts`

## Why

The previous recovery path sent a hidden `gsd-auto-timeout-recovery` message after the backoff timer elapsed. By then, `pauseAuto()` had already ended the loop, so the message did not restart auto-mode and users had to manually run `/gsd auto` after each transient provider failure.

## How

The fix keeps the change bounded to provider-error recovery. The timer callback now calls a small helper that inspects the current auto snapshot and, when auto-mode is still paused, resumes through `startAuto(...)` using the recorded base path and step mode. If the user already resumed manually, the helper exits without double-starting. If no base path is available, it leaves auto-mode paused and emits a warning instead of trying a broken recovery.

## Change type

- [x] `fix` — Bug fix
- [ ] `feat` — New feature or capability
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [x] `gsd extension` — GSD workflow
- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

Manual verification:
- reproduced the delayed provider recovery path in local temp scratch space and verified it now calls `startAuto(...)` with the paused session base path
- verified the recovery helper leaves auto-mode paused when no base path is available and does not double-start when auto-mode is already active
- ran `npm run build`, `npm run typecheck:extensions`, `npm run test:unit`, and `npm run test:integration`
- manually reviewed the diff for leaked secrets or local machine details

## AI disclosure

- [x] This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.