### PR TITLE
fix(gsd): preserve auto start model through discuss

### DIFF
--- a/src/resources/extensions/gsd/auto-start.ts
+++ b/src/resources/extensions/gsd/auto-start.ts
@@ -131,6 +131,15 @@ export async function bootstrapAutoSession(
     return false;
   }
 
+  // Capture the user's session model before guided-flow dispatch can apply a
+  // phase-specific planning model for a discuss turn (#2829).
+  const startModelSnapshot = ctx.model
+    ? {
+        provider: ctx.model.provider,
+        id: ctx.model.id,
+      }
+    : null;
+
   try {
     // Validate GSD_PROJECT_ID early so the user gets immediate feedback
     const customProjectId = process.env.GSD_PROJECT_ID;
@@ -576,12 +585,11 @@ export async function bootstrapAutoSession(
     // Initialize routing history
     initRoutingHistory(s.basePath);
 
-    // Capture session's model at auto-mode start (#650)
-    const currentModel = ctx.model;
-    if (currentModel) {
+    // Restore the model that was active when auto bootstrap began (#650, #2829).
+    if (startModelSnapshot) {
       s.autoModeStartModel = {
-        provider: currentModel.provider,
-        id: currentModel.id,
+        provider: startModelSnapshot.provider,
+        id: startModelSnapshot.id,
       };
     }
 

--- a/src/resources/extensions/gsd/tests/auto-start-model-capture.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-start-model-capture.test.ts
@@ -1,0 +1,28 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const sourcePath = join(import.meta.dirname, "..", "auto-start.ts");
+const source = readFileSync(sourcePath, "utf-8");
+
+test("bootstrapAutoSession snapshots ctx.model before guided-flow entry (#2829)", () => {
+  const snapshotIdx = source.indexOf("const startModelSnapshot = ctx.model");
+  assert.ok(snapshotIdx > -1, "auto-start.ts should snapshot ctx.model at bootstrap start");
+
+  const firstDiscussIdx = source.indexOf('await showSmartEntry(ctx, pi, base, { step: requestedStepMode });');
+  assert.ok(firstDiscussIdx > -1, "auto-start.ts should route through showSmartEntry during guided flow");
+
+  assert.ok(
+    snapshotIdx < firstDiscussIdx,
+    "auto-start.ts must capture the start model before guided-flow can mutate ctx.model",
+  );
+});
+
+test("bootstrapAutoSession restores autoModeStartModel from the early snapshot (#2829)", () => {
+  const assignmentIdx = source.indexOf("s.autoModeStartModel = {");
+  assert.ok(assignmentIdx > -1, "auto-start.ts should assign autoModeStartModel");
+
+  const snapshotRefIdx = source.indexOf("provider: startModelSnapshot.provider", assignmentIdx);
+  assert.ok(snapshotRefIdx > -1, "autoModeStartModel should be restored from startModelSnapshot");
+});


### PR DESCRIPTION
## TL;DR

**What:** Preserve the session’s original auto-mode start model when `/gsd discuss` temporarily applies a planning model.
**Why:** Guided-flow model selection could poison `autoModeStartModel`, causing later auto-mode units to restore the wrong baseline model.
**How:** Snapshot `ctx.model` at the top of `bootstrapAutoSession`, restore `autoModeStartModel` from that early snapshot, and lock the ordering with a regression test.

## What

This change makes `bootstrapAutoSession` capture the current session model before guided-flow entry can mutate it for a discuss turn.

It keeps auto-mode’s fallback baseline tied to the user’s session model instead of whichever planning model `dispatchWorkflow()` temporarily applied.

A small regression test also locks the ordering so future refactors do not reintroduce the timing bug.

## Why

Closes #2829.

`/gsd discuss` can legitimately apply a planning model for the discuss turn, but auto-mode should still remember the model that was active when the user started the flow. Without that separation, later units with no explicit phase preference can restore the planning model instead of the user’s original session model.

## How

Capture an immutable `{ provider, id }` snapshot from `ctx.model` at the top of `bootstrapAutoSession`, before any `showSmartEntry()` or guided-flow work can run.

Later in bootstrap, restore `s.autoModeStartModel` from that early snapshot instead of from the potentially mutated `ctx.model`.

Manual verification:
- confirmed the bootstrap path now snapshots the start model before guided-flow entry can mutate `ctx.model`
- confirmed `autoModeStartModel` is restored from the early snapshot rather than the later session state
- ran `npm run build`, `npm run typecheck:extensions`, `npm run test:unit`, and `npm run test:integration`
- manually reviewed the diff for leaked secrets or local machine details

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

## AI disclosure

- [x] This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.
