### PR TITLE
fix(web): skip shutdown in daemon mode so server survives tab close

### DIFF
--- a/web/lib/__tests__/shutdown-gate.test.ts
+++ b/web/lib/__tests__/shutdown-gate.test.ts
@@ -1,0 +1,83 @@
+import { describe, test, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  scheduleShutdown,
+  cancelShutdown,
+  isShutdownPending,
+  isDaemonMode,
+} from "../shutdown-gate.ts";
+
+describe("shutdown-gate", () => {
+  afterEach(() => {
+    // Always clean up any pending timers between tests
+    cancelShutdown();
+    delete process.env.GSD_WEB_DAEMON_MODE;
+  });
+
+  describe("default mode (no daemon)", () => {
+    test("scheduleShutdown() sets a pending timer", () => {
+      scheduleShutdown();
+      assert.equal(isShutdownPending(), true);
+    });
+
+    test("cancelShutdown() clears the pending timer", () => {
+      scheduleShutdown();
+      cancelShutdown();
+      assert.equal(isShutdownPending(), false);
+    });
+
+    test("isDaemonMode() returns false", () => {
+      assert.equal(isDaemonMode(), false);
+    });
+  });
+
+  describe("daemon mode (GSD_WEB_DAEMON_MODE=1)", () => {
+    beforeEach(() => {
+      process.env.GSD_WEB_DAEMON_MODE = "1";
+    });
+
+    test("isDaemonMode() returns true", () => {
+      assert.equal(isDaemonMode(), true);
+    });
+
+    test("scheduleShutdown() does not schedule a timer", () => {
+      scheduleShutdown();
+      assert.equal(
+        isShutdownPending(),
+        false,
+        "shutdown timer must not be set in daemon mode",
+      );
+    });
+
+    test("scheduleShutdown() is safe to call multiple times", () => {
+      scheduleShutdown();
+      scheduleShutdown();
+      scheduleShutdown();
+      assert.equal(isShutdownPending(), false);
+    });
+  });
+
+  describe("daemon mode is not activated by other values", () => {
+    test("GSD_WEB_DAEMON_MODE=0 does not enable daemon mode", () => {
+      process.env.GSD_WEB_DAEMON_MODE = "0";
+      assert.equal(isDaemonMode(), false);
+      scheduleShutdown();
+      assert.equal(isShutdownPending(), true);
+    });
+
+    test("GSD_WEB_DAEMON_MODE=true does not enable daemon mode", () => {
+      process.env.GSD_WEB_DAEMON_MODE = "true";
+      assert.equal(isDaemonMode(), false);
+      scheduleShutdown();
+      assert.equal(isShutdownPending(), true);
+    });
+
+    test("unset GSD_WEB_DAEMON_MODE does not enable daemon mode", () => {
+      delete process.env.GSD_WEB_DAEMON_MODE;
+      assert.equal(isDaemonMode(), false);
+      scheduleShutdown();
+      assert.equal(isShutdownPending(), true);
+    });
+  });
+});

--- a/web/lib/shutdown-gate.ts
+++ b/web/lib/shutdown-gate.ts
@@ -6,6 +6,12 @@
  *   pagehide → POST /api/shutdown → scheduleShutdown() → timer starts
  *   refresh  → GET  /api/boot     → cancelShutdown()   → timer cleared
  *   tab close → timer fires → process.exit(0)
+ *
+ * When GSD_WEB_DAEMON_MODE=1, the server is running as a persistent daemon
+ * (e.g. behind a reverse proxy for remote access). In this mode,
+ * scheduleShutdown() is a no-op — no client tab should be able to exit the
+ * server. The /api/shutdown endpoint still returns { ok: true } so the
+ * client beacon doesn't produce a network error.
  */
 
 const SHUTDOWN_DELAY_MS = 3_000;
@@ -13,11 +19,26 @@ const SHUTDOWN_DELAY_MS = 3_000;
 let shutdownTimer: ReturnType<typeof setTimeout> | null = null;
 
 /**
+ * Returns true when the server is running in daemon mode.
+ * In daemon mode, shutdown requests from browser tabs are ignored.
+ */
+export function isDaemonMode(): boolean {
+  return process.env.GSD_WEB_DAEMON_MODE === "1";
+}
+
+/**
  * Schedule a graceful process exit after SHUTDOWN_DELAY_MS.
  * If cancelShutdown() is called before the timer fires (e.g. a page refresh
  * triggers a boot request), the exit is aborted.
+ *
+ * No-op when GSD_WEB_DAEMON_MODE=1 — the server should outlive any
+ * individual browser session.
  */
 export function scheduleShutdown(): void {
+  if (isDaemonMode()) {
+    return;
+  }
+
   // Don't stack timers — reset if already scheduled
   if (shutdownTimer !== null) {
     clearTimeout(shutdownTimer);


### PR DESCRIPTION
## TL;DR

**What:** Add `GSD_WEB_DAEMON_MODE=1` env var that makes `scheduleShutdown()` a no-op, preventing the server from exiting when a browser tab closes.
**Why:** When running `gsd --web` behind a reverse proxy for remote access, the `pagehide` beacon kills the server on every tab close/refresh (#2835).
**How:** Early return in `scheduleShutdown()` when daemon mode is active. The `/api/shutdown` endpoint still returns `{ ok: true }` — the server just does not exit.

## What

Single-file change to `web/lib/shutdown-gate.ts`:
- New exported `isDaemonMode()` function that checks `process.env.GSD_WEB_DAEMON_MODE === "1"`
- `scheduleShutdown()` returns immediately when daemon mode is active — no timer is set, `process.exit()` is never called
- No changes needed to the route handlers — `/api/shutdown` already returns `{ ok: true }` before calling `scheduleShutdown()`

New test file `web/lib/__tests__/shutdown-gate.test.ts` with 9 test cases covering default mode, daemon mode, and edge cases (wrong values like `"0"`, `"true"`, unset).

## Why

When `gsd --web` runs as a persistent daemon behind a reverse proxy (Caddy, nginx), every browser tab close fires `navigator.sendBeacon("/api/shutdown")`. The server calls `process.exit(0)`, and because it exits cleanly, process managers with `Restart=on-failure` do not restart it. The next request returns 502.

The existing 3-second deferred shutdown gate handles page refreshes correctly (pagehide → boot cancels timer), but it has no concept of a deployment context where the server should never exit due to a client event.

Closes #2835

## How

The fix is minimal and contained:

1. `isDaemonMode()` reads `process.env.GSD_WEB_DAEMON_MODE` once per call — strict `=== "1"` check, no truthy coercion
2. `scheduleShutdown()` calls `isDaemonMode()` as its first operation and returns early if true
3. All other shutdown-gate functions (`cancelShutdown`, `isShutdownPending`) remain unchanged — they are harmless no-ops when no timer is active

This maps to the pattern already used by `GSD_WEB_HOST_KIND` elsewhere in the codebase for deployment-context-specific behavior.

### Change type

- [x] `fix` — Bug fix

### Checklist

- [x] Regression test included (fails before fix, passes after)
- [x] Test uses `node:test` and `node:assert/strict`
- [x] One concern — only the daemon mode fix
- [x] No drive-by formatting
- [x] TypeScript typecheck passes (`tsc --noEmit`)

---

_This contribution is AI-assisted._