### PR TITLE
test(integration): suppress npm pack buffer overflows

### DIFF
--- a/src/tests/integration/pack-install.test.ts
+++ b/src/tests/integration/pack-install.test.ts
@@ -49,6 +49,27 @@ function createNpmSandbox(prefix: string): NpmSandbox {
   };
 }
 
+function buildQuietNpmEnv(sandbox: NpmSandbox): NodeJS.ProcessEnv {
+  return {
+    ...sandbox.env,
+    NPM_CONFIG_LOGLEVEL: "error",
+    npm_config_loglevel: "error",
+    NPM_CONFIG_FUND: "false",
+    npm_config_fund: "false",
+    NPM_CONFIG_AUDIT: "false",
+    npm_config_audit: "false",
+  };
+}
+
+function runNpmQuiet(args: string[], sandbox: NpmSandbox): void {
+  execFileSync("npm", args, {
+    cwd: projectRoot,
+    env: buildQuietNpmEnv(sandbox),
+    stdio: "ignore",
+    maxBuffer: 16 * 1024 * 1024,
+  });
+}
+
 function packTarball(sandbox: NpmSandbox): string {
   const pkg = JSON.parse(readFileSync(join(projectRoot, "package.json"), "utf-8"));
   const safeName = pkg.name.replace(/^@[^/]+\//, "").replace(/\//g, "-");
@@ -56,11 +77,7 @@ function packTarball(sandbox: NpmSandbox): string {
   const packDestination = join(sandbox.rootDir, "pack-output");
 
   mkdirSync(packDestination, { recursive: true });
-  execFileSync("npm", ["pack", "--pack-destination", packDestination], {
-    cwd: projectRoot,
-    env: sandbox.env,
-    stdio: ["ignore", "ignore", "pipe"],
-  });
+  runNpmQuiet(["pack", "--pack-destination", packDestination], sandbox);
   return join(packDestination, tarball);
 }
 
@@ -141,10 +158,7 @@ test("tarball installs and gsd binary resolves", async (t) => {
   });
 
   // Install from tarball into a temp prefix
-  execFileSync("npm", ["install", "--prefix", sandbox.installPrefix, tarballPath, "--no-save"], {
-    env: sandbox.env,
-    stdio: ["ignore", "ignore", "pipe"],
-  });
+  runNpmQuiet(["install", "--prefix", sandbox.installPrefix, tarballPath, "--no-save"], sandbox);
 
   // Verify the gsd bin exists in the installed package
   const binName = process.platform === "win32" ? "gsd.cmd" : "gsd";


### PR DESCRIPTION
## TL;DR

**What:** Quiet the `npm pack` / `npm install` integration helper so large npm notice output no longer overflows the child-process buffer.
**Why:** `pack-install.test.ts` was failing with `spawnSync npm ENOBUFS`, which blocked unrelated issue branches from ever reaching a green full integration gate.
**How:** Route pack/install calls through a quiet npm helper, lower npm log chatter via env, ignore child stdio, and raise the process buffer ceiling.

## What

This change hardens the `pack-install` integration helper against noisy npm subprocess output.

It introduces a shared helper that runs npm commands with quieter logging settings, ignores stdio for these test-only subprocesses, and sets a larger `maxBuffer` limit for safety.

The tests themselves stay semantically the same: they still pack the tarball, install it, and validate the resulting package layout and binary behavior.

## Why

The integration suite was intermittently failing on `npm pack produces tarball with required files` and `tarball installs and gsd binary resolves` with `spawnSync npm ENOBUFS`.

That failure was environmental noise, not product behavior, but it blocked full local CI for unrelated branches that otherwise passed their own fixes.

## How

Add a small `runNpmQuiet()` helper in `pack-install.test.ts` that:
- sets npm log level to `error`
- disables audit/fund chatter
- ignores child stdio
- raises `maxBuffer`

Then use that helper for both the `npm pack` and `npm install` subprocess calls in the integration test.

Manual verification:
- reproduced the previous `spawnSync npm ENOBUFS` failure mode in the integration suite before the fix
- verified `pack-install.test.ts` passes after routing npm subprocesses through the quiet helper
- ran `npm run build`, `npm run typecheck:extensions`, `npm run test:unit`, and `npm run test:integration`
- manually reviewed the diff for leaked secrets or local machine details

## Change type

- [ ] `feat` — New feature or capability
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [ ] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [x] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

## AI disclosure

- [x] This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.
