### PR TITLE
fix(web): read live auto-mode state in chat-mode header and CTA

### DIFF
--- a/web/components/gsd/chat-mode.tsx
+++ b/web/components/gsd/chat-mode.tsx
@@ -13,6 +13,7 @@ import {
   useGSDWorkspaceState,
   useGSDWorkspaceActions,
   buildPromptCommand,
+  getLiveAutoDashboard,
   type CompletedToolExecution,
   type ActiveToolExecution,
   type PendingUiRequest,
@@ -169,7 +170,7 @@ function ChatModeHeader({ onPrimaryAction, onSecondaryAction }: ChatModeHeaderPr
 
   const boot = state.boot
   const workspace = boot?.workspace ?? null
-  const auto = boot?.auto ?? null
+  const auto = getLiveAutoDashboard(state)
 
   const workflowAction = deriveWorkflowAction({
     phase: workspace?.active.phase ?? "pre-planning",
@@ -1168,7 +1169,8 @@ function ChatInputBar({
   connected: boolean
   onOpenAction?: (action: GSDActionDef) => void
 }) {
-  const autoActive = useGSDWorkspaceState().boot?.auto?.active ?? false
+  const state = useGSDWorkspaceState()
+  const autoActive = getLiveAutoDashboard(state)?.active ?? false
   const [value, setValue] = useState("")
   const [overflowOpen, setOverflowOpen] = useState(false)
   const [pendingImages, setPendingImages] = useState<PendingImage[]>([])
@@ -2019,10 +2021,11 @@ export function ChatPane({ className, onOpenAction }: ChatPaneProps) {
   const bridge = state.boot?.bridge ?? null
 
   // ── Derive smart CTA for the placeholder state ──
+  const auto = getLiveAutoDashboard(state)
   const workflowAction = deriveWorkflowAction({
     phase: state.boot?.workspace?.active.phase ?? "pre-planning",
-    autoActive: state.boot?.auto?.active ?? false,
-    autoPaused: state.boot?.auto?.paused ?? false,
+    autoActive: auto?.active ?? false,
+    autoPaused: auto?.paused ?? false,
     onboardingLocked: state.boot?.onboarding.locked ?? false,
     commandInFlight: state.commandInFlight,
     bootStatus: state.bootStatus,
@@ -2033,8 +2036,8 @@ export function ChatPane({ className, onOpenAction }: ChatPaneProps) {
   const placeholderCTA = useMemo((): { label: string; icon: LucideIcon } | null => {
     if (!workflowAction.primary || workflowAction.disabled) return null
     const phase = state.boot?.workspace?.active.phase ?? "pre-planning"
-    const autoActive = state.boot?.auto?.active ?? false
-    const autoPaused = state.boot?.auto?.paused ?? false
+    const autoActive = auto?.active ?? false
+    const autoPaused = auto?.paused ?? false
 
     if (autoActive && !autoPaused) {
       return { label: "Stop Auto", icon: Square }
@@ -2055,7 +2058,7 @@ export function ChatPane({ className, onOpenAction }: ChatPaneProps) {
       return { label: "Initialize Project", icon: Play }
     }
     return { label: "Continue", icon: Play }
-  }, [workflowAction, state.boot?.workspace?.active.phase, state.boot?.auto?.active, state.boot?.auto?.paused])
+  }, [workflowAction, state.boot?.workspace?.active.phase, auto?.active, auto?.paused])
 
   const handlePlaceholderCTA = useCallback(() => {
     if (!workflowAction.primary) return

--- a/web/lib/__tests__/workflow-actions.test.ts
+++ b/web/lib/__tests__/workflow-actions.test.ts
@@ -1,0 +1,89 @@
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+
+import { deriveWorkflowAction, type WorkflowActionInput } from "../workflow-actions.ts";
+
+/**
+ * Regression tests for deriveWorkflowAction — specifically covering
+ * the auto-mode state transitions that were broken when chat-mode.tsx
+ * read stale boot state instead of live state.
+ *
+ * See: https://github.com/gsd-build/gsd-2/issues/2705
+ */
+
+function makeInput(overrides: Partial<WorkflowActionInput> = {}): WorkflowActionInput {
+  return {
+    phase: "executing",
+    autoActive: false,
+    autoPaused: false,
+    onboardingLocked: false,
+    commandInFlight: null,
+    bootStatus: "ready",
+    hasMilestones: true,
+    projectDetectionKind: null,
+    ...overrides,
+  };
+}
+
+describe("deriveWorkflowAction", () => {
+  describe("auto-mode active state (#2705 regression)", () => {
+    test("shows 'Stop Auto' when autoActive is true", () => {
+      const result = deriveWorkflowAction(makeInput({ autoActive: true }));
+      assert.equal(result.primary?.label, "Stop Auto");
+      assert.equal(result.primary?.command, "/gsd stop");
+      assert.equal(result.primary?.variant, "destructive");
+    });
+
+    test("shows 'Start Auto' when autoActive is false and phase is executing", () => {
+      const result = deriveWorkflowAction(makeInput({ autoActive: false, phase: "executing" }));
+      assert.equal(result.primary?.label, "Start Auto");
+      assert.equal(result.primary?.command, "/gsd auto");
+    });
+
+    test("shows 'Resume Auto' when auto is paused", () => {
+      const result = deriveWorkflowAction(makeInput({ autoActive: true, autoPaused: true }));
+      assert.equal(result.primary?.label, "Resume Auto");
+      assert.equal(result.primary?.command, "/gsd auto");
+    });
+
+    test("does not show 'Start Auto' when autoActive is true", () => {
+      const result = deriveWorkflowAction(makeInput({ autoActive: true, phase: "executing" }));
+      assert.notEqual(
+        result.primary?.label,
+        "Start Auto",
+        "must not show 'Start Auto' when auto-mode is already active",
+      );
+    });
+  });
+
+  describe("other phases", () => {
+    test("shows 'Plan' during planning phase", () => {
+      const result = deriveWorkflowAction(makeInput({ phase: "planning" }));
+      assert.equal(result.primary?.label, "Plan");
+    });
+
+    test("shows 'New Milestone' when phase is complete", () => {
+      const result = deriveWorkflowAction(makeInput({ phase: "complete" }));
+      assert.equal(result.primary?.label, "New Milestone");
+      assert.equal(result.isNewMilestone, true);
+    });
+
+    test("shows 'Initialize Project' for pre-planning without milestones", () => {
+      const result = deriveWorkflowAction(makeInput({ phase: "pre-planning", hasMilestones: false }));
+      assert.equal(result.primary?.label, "Initialize Project");
+    });
+  });
+
+  describe("disabled states", () => {
+    test("disabled when command is in flight", () => {
+      const result = deriveWorkflowAction(makeInput({ commandInFlight: "/gsd auto" }));
+      assert.equal(result.disabled, true);
+      assert.equal(result.disabledReason, "Command in progress");
+    });
+
+    test("disabled when boot status is not ready", () => {
+      const result = deriveWorkflowAction(makeInput({ bootStatus: "loading" }));
+      assert.equal(result.disabled, true);
+    });
+  });
+});


### PR DESCRIPTION
## TL;DR

**What:** Switch chat-mode auto-state reads from stale `boot?.auto` to live `getLiveAutoDashboard(state)`.
**Why:** The "Start Auto" button stays visible even while auto-mode is running because the header reads the boot snapshot, not the live SSE updates (#2705).
**How:** Replace `state.boot?.auto` with `getLiveAutoDashboard(state)` at all three call sites in `chat-mode.tsx`.

## What

Three call sites in `web/components/gsd/chat-mode.tsx` read auto-mode state from `state.boot?.auto` — the initial boot payload that never updates:

1. **`ChatModeHeader`** — derives the primary action button (line ~172)
2. **`ChatInputBar`** — `autoActive` flag for disabling actions during auto (line ~1171)
3. **`ChatPane` placeholder CTA** — derives the empty-state workflow action (line ~2024)

All three now use `getLiveAutoDashboard(state)`, which correctly falls through: `state.live.auto ?? state.boot?.auto`.

New test file `web/lib/__tests__/workflow-actions.test.ts` with 9 tests covering auto-mode state transitions and button labels.

## Why

When auto-mode starts *after* boot, the live SSE updates land in `state.live.auto`, but `state.boot?.auto` remains stale. The `deriveWorkflowAction()` function receives `autoActive: false` and returns `{ label: "Start Auto" }` — even though auto is actively running.

Every other component that consumes auto-mode state (`dashboard.tsx`, `status-bar.tsx`, `sidebar.tsx`, `projects-view.tsx`) already uses `getLiveAutoDashboard()`. The chat-mode header was the only consumer that skipped the live layer.

Closes #2705

## How

This is a data-source fix, not a logic change. `deriveWorkflowAction()` was already correct — it just received the wrong input.

1. Added `getLiveAutoDashboard` to the import from `gsd-workspace-store`
2. Replaced `boot?.auto ?? null` with `getLiveAutoDashboard(state)` in `ChatModeHeader`
3. Replaced `useGSDWorkspaceState().boot?.auto?.active` with `getLiveAutoDashboard(state)?.active` in `ChatInputBar`
4. Replaced `state.boot?.auto` reads with a shared `auto` variable from `getLiveAutoDashboard(state)` in `ChatPane`
5. Updated `useMemo` dependency array to use `auto?.active` / `auto?.paused` instead of `state.boot?.auto?.active` / `state.boot?.auto?.paused`

### Change type

- [x] `fix` — Bug fix

### Checklist

- [x] Regression test included (`workflow-actions.test.ts`)
- [x] Test uses `node:test` and `node:assert/strict`
- [x] One concern — only the state-source fix
- [x] No drive-by formatting
- [x] TypeScript typecheck passes (`tsc --noEmit`)

---

_This contribution is AI-assisted._