### PR TITLE
fix(web): read live workspace and auto state in chat-mode and app-shell

### DIFF
--- a/web/components/gsd/app-shell.tsx
+++ b/web/components/gsd/app-shell.tsx
@@ -23,6 +23,7 @@ import { toast } from "sonner"
 import {
   GSDWorkspaceProvider,
   getCurrentScopeLabel,
+  getLiveWorkspaceIndex,
   getProjectDisplayName,
   getStatusPresentation,
   getVisibleWorkspaceError,
@@ -67,7 +68,7 @@ function WorkspaceChrome() {
   const projectPath = workspace.boot?.project.cwd
   const projectLabel = getProjectDisplayName(projectPath)
   const titleOverride = workspace.titleOverride?.trim() || null
-  const scopeLabel = getCurrentScopeLabel(workspace.boot?.workspace)
+  const scopeLabel = getCurrentScopeLabel(getLiveWorkspaceIndex(workspace))
   const visibleError = getVisibleWorkspaceError(workspace)
 
   // Restore persisted view once boot provides projectCwd

--- a/web/components/gsd/chat-mode.tsx
+++ b/web/components/gsd/chat-mode.tsx
@@ -13,6 +13,8 @@ import {
   useGSDWorkspaceState,
   useGSDWorkspaceActions,
   buildPromptCommand,
+  getLiveAutoDashboard,
+  getLiveWorkspaceIndex,
   type CompletedToolExecution,
   type ActiveToolExecution,
   type PendingUiRequest,
@@ -168,8 +170,8 @@ function ChatModeHeader({ onPrimaryAction, onSecondaryAction }: ChatModeHeaderPr
   const state = useGSDWorkspaceState()
 
   const boot = state.boot
-  const workspace = boot?.workspace ?? null
-  const auto = boot?.auto ?? null
+  const workspace = getLiveWorkspaceIndex(state)
+  const auto = getLiveAutoDashboard(state)
 
   const workflowAction = deriveWorkflowAction({
     phase: workspace?.active.phase ?? "pre-planning",
@@ -1168,7 +1170,8 @@ function ChatInputBar({
   connected: boolean
   onOpenAction?: (action: GSDActionDef) => void
 }) {
-  const autoActive = useGSDWorkspaceState().boot?.auto?.active ?? false
+  const state = useGSDWorkspaceState()
+  const autoActive = getLiveAutoDashboard(state)?.active ?? false
   const [value, setValue] = useState("")
   const [overflowOpen, setOverflowOpen] = useState(false)
   const [pendingImages, setPendingImages] = useState<PendingImage[]>([])
@@ -2019,22 +2022,24 @@ export function ChatPane({ className, onOpenAction }: ChatPaneProps) {
   const bridge = state.boot?.bridge ?? null
 
   // ── Derive smart CTA for the placeholder state ──
+  const liveWorkspace = getLiveWorkspaceIndex(state)
+  const auto = getLiveAutoDashboard(state)
   const workflowAction = deriveWorkflowAction({
-    phase: state.boot?.workspace?.active.phase ?? "pre-planning",
-    autoActive: state.boot?.auto?.active ?? false,
-    autoPaused: state.boot?.auto?.paused ?? false,
+    phase: liveWorkspace?.active.phase ?? "pre-planning",
+    autoActive: auto?.active ?? false,
+    autoPaused: auto?.paused ?? false,
     onboardingLocked: state.boot?.onboarding.locked ?? false,
     commandInFlight: state.commandInFlight,
     bootStatus: state.bootStatus,
-    hasMilestones: (state.boot?.workspace?.milestones.length ?? 0) > 0,
+    hasMilestones: (liveWorkspace?.milestones.length ?? 0) > 0,
     projectDetectionKind: state.boot?.projectDetection?.kind ?? null,
   })
 
   const placeholderCTA = useMemo((): { label: string; icon: LucideIcon } | null => {
     if (!workflowAction.primary || workflowAction.disabled) return null
-    const phase = state.boot?.workspace?.active.phase ?? "pre-planning"
-    const autoActive = state.boot?.auto?.active ?? false
-    const autoPaused = state.boot?.auto?.paused ?? false
+    const phase = liveWorkspace?.active.phase ?? "pre-planning"
+    const autoActive = auto?.active ?? false
+    const autoPaused = auto?.paused ?? false
 
     if (autoActive && !autoPaused) {
       return { label: "Stop Auto", icon: Square }
@@ -2055,7 +2060,7 @@ export function ChatPane({ className, onOpenAction }: ChatPaneProps) {
       return { label: "Initialize Project", icon: Play }
     }
     return { label: "Continue", icon: Play }
-  }, [workflowAction, state.boot?.workspace?.active.phase, state.boot?.auto?.active, state.boot?.auto?.paused])
+  }, [workflowAction, liveWorkspace?.active.phase, auto?.active, auto?.paused])
 
   const handlePlaceholderCTA = useCallback(() => {
     if (!workflowAction.primary) return


### PR DESCRIPTION
## TL;DR

**What:** Switch all stale `boot?.workspace` and `boot?.auto` reads to live-state accessors in `chat-mode.tsx` and `app-shell.tsx`.
**Why:** Milestone list, action buttons, scope label, and phase badges stay stale after state changes because these components read the boot snapshot instead of live SSE data (#2706, #2705).
**How:** Replace `boot?.workspace` with `getLiveWorkspaceIndex(state)` and `boot?.auto` with `getLiveAutoDashboard(state)` at all affected call sites.

## What

**`web/components/gsd/chat-mode.tsx`** (5 call sites):
- `ChatModeHeader`: `workspace` and `auto` now sourced from live accessors
- `ChatInputBar`: `autoActive` now sourced from `getLiveAutoDashboard(state)`
- `ChatPane` placeholder CTA: `phase`, `autoActive`, `autoPaused`, `hasMilestones` all from live state
- `useMemo` dependency array updated to track live references

**`web/components/gsd/app-shell.tsx`** (1 call site):
- `WorkspaceChrome`: `scopeLabel` now derived from `getLiveWorkspaceIndex(workspace)` instead of `workspace.boot?.workspace`

## Why

When milestone or auto-mode state changes after boot, the server pushes `live_state_invalidation` SSE events. The live layer updates `state.live.workspace` and `state.live.auto`. But `chat-mode.tsx` and `app-shell.tsx` read `state.boot?.workspace` / `state.boot?.auto` — the initial snapshot that never reflects live updates.

Every other component that consumes workspace or auto state (`dashboard.tsx`, `status-bar.tsx`, `sidebar.tsx`, `roadmap.tsx`, `projects-view.tsx`) already uses `getLiveWorkspaceIndex()` / `getLiveAutoDashboard()`.

Closes #2706
Closes #2705

## How

Pure data-source fix — no logic changes. The live accessors fall through correctly: `state.live.X ?? state.boot?.X`. When no live data has arrived yet, the boot snapshot is still used.

### Change type

- [x] `fix` — Bug fix

### Checklist

- [x] One concern — only stale state-source reads
- [x] No drive-by formatting
- [x] TypeScript typecheck passes (`tsc --noEmit`)
- [x] Subsumes #2844 (which fixed only auto reads) — that PR can be closed if this merges first

---

_This contribution is AI-assisted._