### PR TITLE
fix(gsd): use project root for prior-slice dispatch guard

### DIFF
--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -46,6 +46,17 @@ export function _resolveReportBasePath(s: Pick<AutoSession, "originalBasePath" |
 }
 
 /**
+ * Resolve the authoritative project base for dispatch guards.
+ * Prior-milestone completion lives at the project root, even when the active
+ * unit is running inside an auto worktree.
+ */
+export function _resolveDispatchGuardBasePath(
+  s: Pick<AutoSession, "originalBasePath" | "basePath">,
+): string {
+  return s.originalBasePath || s.basePath;
+}
+
+/**
  * Generate and write an HTML milestone report snapshot.
  * Extracted from the milestone-transition block in autoLoop.
  */
@@ -667,9 +678,10 @@ export async function runDispatch(
     prompt = preDispatchResult.prompt;
   }
 
+  const guardBasePath = _resolveDispatchGuardBasePath(s);
   const priorSliceBlocker = deps.getPriorSliceCompletionBlocker(
-    s.basePath,
-    deps.getMainBranch(s.basePath),
+    guardBasePath,
+    deps.getMainBranch(guardBasePath),
     unitType,
     unitId,
   );

--- a/src/resources/extensions/gsd/tests/journal-integration.test.ts
+++ b/src/resources/extensions/gsd/tests/journal-integration.test.ts
@@ -260,6 +260,61 @@ test("runDispatch emits dispatch-stop when dispatch returns stop action", async 
   assert.equal(stopEvents[0].flowId, ic.flowId);
 });
 
+test("runDispatch checks prior-slice completion against the project root in worktree mode", async () => {
+  const capture = createEventCapture();
+  const guardCalls: Array<{ fn: string; args: unknown[] }> = [];
+  const deps = makeMockDeps(capture, {
+    getMainBranch: (basePath: string) => {
+      guardCalls.push({ fn: "getMainBranch", args: [basePath] });
+      return "main";
+    },
+    getPriorSliceCompletionBlocker: (
+      basePath: string,
+      mainBranch: string,
+      unitType: string,
+      unitId: string,
+    ) => {
+      guardCalls.push({
+        fn: "getPriorSliceCompletionBlocker",
+        args: [basePath, mainBranch, unitType, unitId],
+      });
+      return null;
+    },
+  });
+  const ic = makeIC(deps, {
+    s: {
+      ...makeSession(),
+      basePath: "/tmp/project/.gsd/worktrees/M029-xoklo9",
+      originalBasePath: "/tmp/project",
+    } as any,
+  });
+  const preData: PreDispatchData = {
+    state: {
+      phase: "executing",
+      activeMilestone: { id: "M029-xoklo9", title: "Test", status: "active" },
+      activeSlice: { id: "S01", title: "Slice 1" },
+      registry: [{ id: "M029-xoklo9", status: "active" }],
+      blockers: [],
+    } as any,
+    mid: "M029-xoklo9",
+    midTitle: "Test Milestone",
+  };
+
+  const result = await runDispatch(ic, preData, {
+    recentUnits: [],
+    stuckRecoveryAttempts: 0,
+  });
+
+  assert.equal(result.action, "next");
+  assert.deepEqual(guardCalls, [
+    { fn: "getMainBranch", args: ["/tmp/project"] },
+    {
+      fn: "getPriorSliceCompletionBlocker",
+      args: ["/tmp/project", "main", "execute-task", "M001/S01/T01"],
+    },
+  ]);
+});
+
 test("runUnitPhase emits unit-start and unit-end with causedBy reference", async () => {
   const capture = createEventCapture();
 


### PR DESCRIPTION
## TL;DR

**What:** Route the prior-slice dispatch guard through the project root when auto-mode is running inside a worktree.
**Why:** Completed earlier milestones can look incomplete when the guard reads a stale worktree snapshot instead of the authoritative project root.
**How:** Resolve a dedicated dispatch-guard base path from `originalBasePath` and add a regression test that exercises the real `runDispatch` call path.

## What

- updates [`src/resources/extensions/gsd/auto/phases.ts`](src/resources/extensions/gsd/auto/phases.ts) so prior-slice completion checks use the project root when a worktree session has `originalBasePath`
- adds a regression test in [`src/resources/extensions/gsd/tests/journal-integration.test.ts`](src/resources/extensions/gsd/tests/journal-integration.test.ts) that verifies `runDispatch` calls both `getMainBranch` and `getPriorSliceCompletionBlocker` with the authoritative project root in worktree mode

## Why

Closes #2838.

In worktree mode, prior milestone completion artifacts live at the project root. Before this change, the dispatch guard evaluated prior-slice completion against the active worktree path, so a stale worktree snapshot could block dispatch even after the earlier milestone had already completed.

## How

This keeps the fix at the dispatch call site instead of broadening worktree sync behavior:

- compute a dedicated guard base path with `originalBasePath || basePath`
- use that same base for both the main-branch lookup and the prior-slice completion guard
- cover the regression by running the real `runDispatch` path with a worktree-style session shape

## Change type

- [x] `fix` — Bug fix
- [ ] `feat` — New feature or capability
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

Local verification:

- `npm run build`
- `npm run typecheck:extensions`
- `npm run test:unit`
- `npm run test:integration`

Manual testing:

1. Run a small `runDispatch` smoke harness against `upstream/main` with a session shaped like a worktree (`basePath` = worktree path, `originalBasePath` = project root).
2. Confirm the upstream code passes the worktree path into both `getMainBranch` and `getPriorSliceCompletionBlocker`.
3. Run the same harness on this branch.
4. Confirm both calls now use the project root instead of the worktree path.

Before fix: the guard resolved prior-slice completion from the worktree path.
After fix: the guard resolves prior-slice completion from the project root.

## AI disclosure

- [x] This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.
