### PR TITLE
fix: handle pause_turn stop reason for native web search

### DIFF
--- a/packages/pi-agent-core/src/agent-loop.ts
+++ b/packages/pi-agent-core/src/agent-loop.ts
@@ -232,6 +232,13 @@ async function runLoop(
 			const toolCalls = message.content.filter((c) => c.type === "toolCall");
 			hasMoreToolCalls = toolCalls.length > 0;
 
+			// pause_turn: server-side tool (e.g. web_search) paused mid-execution.
+			// Continue the inner loop so the LLM is re-invoked with the partial
+			// assistant message already in context — it will resume where it left off.
+			if (message.stopReason === "pauseTurn") {
+				hasMoreToolCalls = true;
+			}
+
 			const toolResults: ToolResultMessage[] = [];
 			if (hasMoreToolCalls) {
 				const toolExecution = await executeToolCalls(

--- a/packages/pi-ai/src/providers/anthropic-shared.ts
+++ b/packages/pi-ai/src/providers/anthropic-shared.ts
@@ -502,7 +502,7 @@ export function mapStopReason(reason: string): StopReason {
 		case "refusal":
 			return "error";
 		case "pause_turn":
-			return "stop";
+			return "pauseTurn";
 		case "stop_sequence":
 			return "stop";
 		case "sensitive":

--- a/packages/pi-ai/src/types.ts
+++ b/packages/pi-ai/src/types.ts
@@ -192,7 +192,7 @@ export interface Usage {
 	};
 }
 
-export type StopReason = "stop" | "length" | "toolUse" | "error" | "aborted";
+export type StopReason = "stop" | "length" | "toolUse" | "pauseTurn" | "error" | "aborted";
 
 export interface UserMessage {
 	role: "user";
@@ -253,7 +253,7 @@ export type AssistantMessageEvent =
 	| { type: "toolcall_end"; contentIndex: number; toolCall: ToolCall; partial: AssistantMessage }
 	| { type: "server_tool_use"; contentIndex: number; partial: AssistantMessage }
 	| { type: "web_search_result"; contentIndex: number; partial: AssistantMessage }
-	| { type: "done"; reason: Extract<StopReason, "stop" | "length" | "toolUse">; message: AssistantMessage }
+	| { type: "done"; reason: Extract<StopReason, "stop" | "length" | "toolUse" | "pauseTurn">; message: AssistantMessage }
 	| { type: "error"; reason: Extract<StopReason, "aborted" | "error">; error: AssistantMessage };
 
 /**


### PR DESCRIPTION
## Summary

Fixes #2869

`mapStopReason()` mapped Anthropic's `pause_turn` to `"stop"`, causing the agent loop to treat incomplete server tool responses as normal completions. When the API pauses a long-running server-side tool (e.g. `web_search`) mid-execution, the assistant message may contain a `server_tool_use` block without the corresponding `web_search_tool_result`. This incomplete message persists in session history, and the next API request fails with:

```
400: web_search tool use with id ... was found without a
corresponding web_search_tool_result block
```

## Changes

**3 files, +10/-3**

- **`packages/pi-ai/src/types.ts`** — Add `"pauseTurn"` to `StopReason` union and `done` event reason
- **`packages/pi-ai/src/providers/anthropic-shared.ts`** — Map `pause_turn` → `"pauseTurn"` instead of `"stop"`
- **`packages/pi-agent-core/src/agent-loop.ts`** — Treat `pauseTurn` like a pending tool call so the inner loop re-invokes the LLM, allowing Claude to resume where it paused

## How It Works

Per [Anthropic server tools docs](https://docs.anthropic.com/en/docs/build-with-claude/tool-use/server-tools):

> The response may include a `pause_turn` stop reason, which indicates that the API paused a long-running turn. You may provide the response back as-is in a subsequent request to let Claude continue its turn.

The fix re-uses the existing inner loop mechanism: when `stopReason === "pauseTurn"`, set `hasMoreToolCalls = true` so the loop continues. The partial assistant message is already in context, so the next LLM call lets Claude resume exactly where it paused.

## References

- Anthropic docs: [Server tools — pause_turn](https://docs.anthropic.com/en/docs/build-with-claude/tool-use/server-tools)
- Same root cause in pydantic-ai: [pydantic/pydantic-ai#2600](https://github.com/pydantic/pydantic-ai/issues/2600)