### PR TITLE
feat(pi-ai): provider capability registry and tool-compatibility layer (ADR-005)

### DIFF
--- a/.plans/adr-005-provider-capability-registry.md
+++ b/.plans/adr-005-provider-capability-registry.md
@@ -1,0 +1,262 @@
+# ADR-005: Provider Capability Registry — Implementation Plan
+
+**Branch:** `feat/provider-capability-registry`
+**Base:** `origin/main`
+**ADR:** `revised_adr_005.md`
+**Research:** `.planning/research/ARCHITECTURE.md`, `.planning/research/PITFALLS.md`
+
+---
+
+## Overview
+
+Implement a provider capability registry and tool compatibility layer that integrates with the existing ADR-004 capability-aware model router. This enables tool-aware model selection, provider-aware tool filtering, and explicit cross-provider conversation handling.
+
+## Phased Implementation
+
+### Phase 1: Provider Capability Registry (Zero Dependencies)
+
+**Goal:** Create the declarative registry in `packages/pi-ai/src/providers/capabilities.ts`
+
+**Files:**
+- **NEW:** `packages/pi-ai/src/providers/capabilities.ts`
+- **NEW:** `packages/pi-ai/src/providers/capabilities.test.ts`
+
+**Tasks:**
+1. Define `ProviderCapabilities` interface matching ADR-005 spec
+2. Define `PROVIDER_CAPABILITIES` record for all 5 canonical APIs:
+   - `anthropic-messages`
+   - `openai-responses`
+   - `google-generative-ai`
+   - `mistral-conversations`
+   - `bedrock-converse-stream`
+3. Add API variant aliasing for the 6 additional registered APIs:
+   - `anthropic-vertex` → `anthropic-messages`
+   - `google-vertex` → `google-generative-ai`
+   - `google-gemini-cli` → `google-generative-ai`
+   - `azure-openai-responses` → `openai-responses`
+   - `openai-codex-responses` → `openai-responses`
+   - `openai-completions` → `openai-responses`
+4. Export `getProviderCapabilities(api: string): ProviderCapabilities` with permissive default for unknown APIs
+5. Export `PERMISSIVE_CAPABILITIES` constant (fail-open default)
+6. Write tests:
+   - Known API returns correct profile
+   - Variant API returns parent profile (e.g., `anthropic-vertex` → anthropic caps)
+   - Unknown API returns permissive default
+   - Bare provider name (e.g., `"anthropic"`) returns permissive default (NOT the Anthropic profile) — **Pitfall 1 prevention**
+
+**Key pitfall to address:** Registry MUST be keyed on `.api` (e.g., `"anthropic-messages"`), not `.provider` (e.g., `"anthropic"`). The test for bare provider names is the critical safety net.
+
+---
+
+### Phase 2: ToolCompatibility Metadata on ToolDefinition
+
+**Goal:** Extend `ToolDefinition` with optional compatibility metadata
+
+**Files:**
+- **MODIFY:** `packages/pi-coding-agent/src/core/extensions/types.ts`
+
+**Tasks:**
+1. Add `ToolCompatibility` interface:
+   ```typescript
+   interface ToolCompatibility {
+     producesImages?: boolean;
+     schemaFeatures?: string[];
+     minCapabilityTier?: "light" | "standard" | "heavy";
+   }
+   ```
+2. Add to `ToolDefinition`:
+   - `compatibility?: ToolCompatibility`
+   - `priority?: number` (1-10, higher = keep during pruning)
+3. Both fields are optional — no existing tool registrations break
+
+**Note:** Built-in tools (bash, read, write, edit) do NOT need explicit annotations — tools without `compatibility` metadata are universally compatible. No changes to `dynamic-tools.ts` needed in this phase. **Pitfall 6 prevention:** The "no metadata = always compatible" invariant is preserved by NOT annotating universal tools.
+
+---
+
+### Phase 3: Tool-Compatibility Filter in model-router.ts
+
+**Goal:** Add Step 2 hard filter between tier filtering and capability scoring
+
+**Files:**
+- **MODIFY:** `src/resources/extensions/gsd/model-router.ts`
+- **MODIFY:** `src/resources/extensions/gsd/auto-model-selection.ts` (pass required tools)
+- **NEW:** `src/resources/extensions/gsd/tests/tool-compatibility-filter.test.ts`
+
+**Tasks:**
+1. Add `getRequiredTools(unitType: string): string[]` mapping in model-router.ts
+   - Maps unit types to the tool names they require (derived from `UNIT_TYPE_TIERS` in complexity-classifier.ts)
+   - `execute-task` → `["Bash", "Read", "Write", "Edit"]`
+   - `research-milestone`, `research-slice` → `["Read"]`
+   - Other unit types → `[]` (no tool requirements = no filtering)
+
+2. Add `filterModelsByToolCompatibility()` helper:
+   ```typescript
+   function filterModelsByToolCompatibility(
+     eligibleModels: string[],
+     requiredToolNames: string[],
+     registeredTools: ToolInfo[],
+     availableModels: Model[]
+   ): string[]
+   ```
+   - For each eligible model, resolve its API → get provider capabilities
+   - Check each required tool's `compatibility` against provider capabilities
+   - Tools without `compatibility` → always pass (fail-open)
+   - Models whose provider fails any tool check → removed from eligible set
+   - If filter removes ALL models → return original set (fail-open at the set level too)
+
+3. Insert filter call in `resolveModelForComplexity()` AFTER tier eligibility, BEFORE capability scoring (**Pitfall 3 prevention**)
+
+4. Wire: `selectAndApplyModel()` passes `registeredTools` from `pi.getAllTools()` through to `resolveModelForComplexity()`
+
+5. Tests:
+   - Model filtered when provider lacks `imageToolResults` and required tool has `producesImages: true`
+   - Model passes when tool has no `compatibility` metadata (**Pitfall 6 test — write this FIRST**)
+   - Unknown provider passes (permissive default)
+   - All-models-filtered fallback returns original set
+   - Filter runs before scoring (verified via model selection outcome)
+
+**Key pitfall to address:** Filter position is load-bearing — must be BEFORE `findModelForTier()`, not after. The test must verify a tool-incompatible model is never returned even if it scores highest on capabilities.
+
+---
+
+### Phase 4: adjustToolSet + Save/Restore in auto-model-selection.ts
+
+**Goal:** Scope tool set changes to individual dispatch turns
+
+**Files:**
+- **MODIFY:** `src/resources/extensions/gsd/auto-model-selection.ts`
+- **NEW:** `src/resources/extensions/gsd/tests/adjust-tool-set.test.ts`
+
+**Tasks:**
+1. Add `adjustToolSet()` pure function:
+   ```typescript
+   function adjustToolSet(
+     model: { id: string; api: string },
+     registeredTools: ToolInfo[],
+     providerCaps: ProviderCapabilities
+   ): string[]
+   ```
+   - Filter out tools whose `compatibility` conflicts with provider caps
+   - Prune lowest-priority tools if exceeding `maxTools`
+   - Return filtered tool name list
+
+2. Wire into `selectAndApplyModel()`:
+   - After `pi.setModel()`, save current tools: `const priorTools = pi.getActiveTools()`
+   - Compute adjusted set via `adjustToolSet()`
+   - Call `pi.setActiveTools(adjusted)`
+   - Return `priorTools` in `ModelSelectionResult` so caller can restore after dispatch
+
+3. Update `ModelSelectionResult` interface:
+   ```typescript
+   interface ModelSelectionResult {
+     routing: { tier: string; modelDowngraded: boolean } | null;
+     priorTools?: string[];  // Caller must restore after dispatch in a finally block
+   }
+   ```
+
+4. Tests for `adjustToolSet` in isolation (pure function):
+   - Tool without compatibility → included
+   - Tool with `producesImages: true` on provider without `imageToolResults` → excluded
+   - Tool with `schemaFeatures` matching `unsupportedSchemaFeatures` → excluded
+   - `maxTools` pruning by priority
+   - Empty tools → empty result
+
+**Key pitfall to address:** Session drift (**Pitfall 2**). The caller MUST restore tools in a `finally` block. Document this contract clearly in the return type JSDoc.
+
+---
+
+### Phase 5: ProviderSwitchReport in transform-messages.ts
+
+**Goal:** Make cross-provider context loss visible and trackable
+
+**Files:**
+- **MODIFY:** `packages/pi-ai/src/providers/transform-messages.ts`
+- **MODIFY:** `src/resources/extensions/gsd/routing-history.ts`
+- **NEW:** `packages/pi-ai/src/providers/transform-messages.test.ts` (or extend existing)
+
+**Tasks:**
+1. Define `ProviderSwitchReport` interface:
+   ```typescript
+   interface ProviderSwitchReport {
+     fromApi: string;
+     toApi: string;
+     thinkingBlocksDropped: number;
+     thinkingBlocksDowngraded: number;
+     toolCallIdsRemapped: number;
+     syntheticToolResultsInserted: number;
+     thoughtSignaturesDropped: number;
+   }
+   ```
+
+2. Modify `transformMessages()` return type:
+   - Return `{ messages: Message[]; switchReport?: ProviderSwitchReport }`
+   - Only compute report when `fromApi !== toApi` (**Pitfall 7 prevention** — early exit for same-provider)
+   - Count each transformation type during existing passes (no new traversals)
+
+3. Update all callers of `transformMessages()` in pi-ai to handle new return shape
+   - Callers that don't need the report destructure only `messages`
+
+4. Add `switchReport?: ProviderSwitchReport` to routing history entry type
+5. Update `recordOutcome()` to accept and store the report
+
+6. Tests:
+   - Cross-provider transform produces report with correct counts
+   - Same-provider transform produces no report (undefined)
+   - Report stored in routing history when present
+
+---
+
+### Phase 6: models.json Override Parsing (Optional / Deferred)
+
+**Goal:** User-facing escape hatch for provider capability overrides
+
+**Deferred to a follow-up PR.** Core functionality works without it. The registry and filter are the priority.
+
+---
+
+## Build Order & Dependencies
+
+```
+Phase 1 (capabilities.ts)       ← no dependencies, build first
+    ↓
+Phase 2 (ToolCompatibility)     ← no dependencies on Phase 1, can parallel
+    ↓
+Phase 3 (filter in router)      ← depends on Phase 1 + Phase 2
+    ↓
+Phase 4 (adjustToolSet)         ← depends on Phase 1 + Phase 2
+    ↓
+Phase 5 (ProviderSwitchReport)  ← independent of Phase 3-4, can parallel
+```
+
+**Parallel opportunities:**
+- Phase 1 and Phase 2 can be built in parallel (no dependency)
+- Phase 3 and Phase 4 are sequential (Phase 3 first for stability)
+- Phase 5 is independent and can be built alongside Phase 3-4
+
+## Testing Strategy
+
+- All tests use `node:test` and `node:assert/strict` per CONTRIBUTING.md
+- No Jest, Vitest, or `createTestContext()`
+- Cleanup via `beforeEach`/`afterEach` or `t.after()`
+- Fixture data via array join (no template literal indentation issues)
+- Each phase has its own test file
+- Phase 3 tests are the most critical — they verify the filter position invariant
+
+## Risk Mitigation
+
+| Risk | Mitigation |
+|------|------------|
+| API name vs provider ID mismatch | Phase 1 test: bare provider name → permissive default |
+| Tool filter fails-closed on missing metadata | Phase 3 test #1: tool without compatibility → passes filter |
+| Session drift from missing tool restore | Phase 4: return `priorTools` in result; document restore contract |
+| Filter after scoring (wrong position) | Phase 3 test: incompatible model never selected regardless of score |
+| ProviderSwitchReport hot-path overhead | Phase 5: early exit when `fromApi === toApi` |
+| transform-messages.ts return type break | Phase 5: update all callers; destructure pattern is backwards-compatible |
+
+## Copyright
+
+All new files include:
+```
+// GSD-2 — [File Purpose]
+// Copyright (c) 2026 Jeremy McSpadden <jeremy@fluxlabs.net>
+```

--- a/.plans/capability-validation-gaps.md
+++ b/.plans/capability-validation-gaps.md
@@ -1,0 +1,84 @@
+# Plan: Close Capability Validation Gaps (ADR-004/005)
+
+**Status:** In Progress
+**Date:** 2026-03-27
+**Branch:** feat/provider-capability-registry
+**Related:** ADR-004, ADR-005, capabilities.ts, model-router.ts
+
+## Problem
+
+Only 4 of 16+ unit types have capability validation. Three dispatch paths (direct, guided-flow, hooks) completely bypass capability checks. The planning phase has no forward-looking validation — it can create tasks that the configured model pool can't execute.
+
+## Priority Order
+
+### Layer 1 — Expand `getRequiredToolNames()` (HIGH)
+**Files:** `model-router.ts`
+
+Expand tool requirements for all unit types that actually use tools:
+
+| Unit Type | Current Required Tools | Should Be |
+|---|---|---|
+| execute-task | Bash, Read, Write, Edit | ✓ (correct) |
+| execute-plan | Bash, Read, Write, Edit | ✓ (correct) |
+| research-milestone | Read | Read, WebSearch, WebFetch |
+| research-slice | Read | Read, WebSearch, WebFetch |
+| plan-milestone | (none) | Read, Write |
+| plan-slice | (none) | Read, Write |
+| run-uat | (none) | Read, Bash (+ imageToolResults flag) |
+| replan-slice | (none) | Read, Write |
+| complete-slice | (none) | Read, Write |
+| complete-milestone | (none) | Read, Write |
+| rewrite-docs | (none) | Read, Write |
+| reactive-execute | (none) | Bash, Read, Write, Edit |
+
+### Layer 2 — Unify Dispatch Paths (CRITICAL)
+**Files:** `auto-direct-dispatch.ts`, `guided-flow.ts`, `auto.ts`
+
+All dispatch paths must flow through capability validation:
+
+- **auto-direct-dispatch.ts** — Add `adjustToolSet()` call before `pi.sendMessage()`
+- **guided-flow.ts:dispatchWorkflow()** — Add `adjustToolSet()` after `pi.setModel()`, apply capability overrides
+- **auto.ts:dispatchHookUnit()** — Add `adjustToolSet()` after hook model is applied
+
+### Layer 3 — Plan-Time Capability Validation (HIGH)
+**Files:** `auto-model-selection.ts` (new export), `auto-prompts.ts`, plan-slice prompt
+
+Add a `validatePlanCapabilities()` function that:
+1. Takes the available model pool + their APIs
+2. For each task in the plan, infers capability requirements from:
+   - Task description keywords (screenshot, image, diagram → imageToolResults)
+   - File extensions in task files (.png, .svg → imageToolResults)
+   - Tool references in task descriptions
+3. Checks if ANY model in the pool can satisfy each requirement
+4. Returns warnings for unresolvable gaps
+5. Inject warnings into plan output / notify user
+
+### Layer 4 — Replan Context Enrichment (MEDIUM)
+**Files:** `auto-prompts.ts` (buildReplanSlicePrompt), `auto-post-unit.ts`
+
+When a task fails:
+- Check if failure correlates with a capability mismatch (tool was filtered, model couldn't handle image)
+- Include this in the replan context: "Task T3 failed — the execution model does not support imageToolResults. Consider restructuring to avoid image-dependent tools."
+
+## Execution Order
+
+1. Layer 1 — getRequiredToolNames expansion + tests
+2. Layer 2 — Unify dispatch paths + tests
+3. Layer 3 — Plan-time validation function + integration
+4. Layer 4 — Replan enrichment
+
+## Testing Strategy
+
+- Unit tests for expanded getRequiredToolNames() (all unit types)
+- Unit tests for adjustToolSet() in each dispatch path
+- Integration test: plan-slice → capability warning when model pool can't handle images
+- Integration test: direct-dispatch applies tool filtering
+- Integration test: hook dispatch applies tool filtering
+
+## Success Criteria
+
+- All 16+ unit types have accurate tool requirements
+- All 3 dispatch paths (direct, guided-flow, hooks) apply capability validation
+- Planning phase emits warnings when tasks exceed model pool capabilities
+- Replan context includes capability mismatch information
+- All existing tests pass, no regressions

--- a/.plans/gsd-complete-slice-json-error-debug.md
+++ b/.plans/gsd-complete-slice-json-error-debug.md
@@ -1,0 +1,72 @@
+# Debug Finding: JSON Parsing Error in gsd_complete_slice (#2882)
+
+**Date:** 2026-03-27
+**Issue:** https://github.com/gsd-build/gsd-2/issues/2882
+**Status:** Root cause identified, fix not yet applied
+
+## Error
+
+```
+gsd_complete_slice
+No number after minus sign in JSON at position 2559 (line 1 column 2560)
+
+Warning: Auto-mode paused due to provider error: No number after minus sign in JSON at position 2559
+```
+
+## Root Cause (HIGH confidence — 85%)
+
+**Incomplete error classification** causes a recoverable stream corruption error to be treated as a permanent failure.
+
+### Causal Chain
+
+1. The Anthropic SDK's `streaming.ts:70` calls raw `JSON.parse()` on each SSE event data line
+2. Stream corruption (network glitch, truncation) produces a malformed SSE line containing a bare minus sign without following digits
+3. `JSON.parse` throws "No number after minus sign in JSON at position 2559"
+4. The SDK re-throws (no recovery) and it propagates up through the agent loop
+5. `error-classifier.ts:51` — the `STREAM_RE` regex **does NOT match** this error pattern:
+   ```
+   /Unexpected end of JSON|Unexpected token.*JSON|Expected double-quoted property name|SyntaxError.*JSON/i
+   ```
+6. Classification returns `{ kind: "unknown" }` instead of `{ kind: "stream" }`
+7. `agent-end-recovery.ts:162` calls `pauseAutoForProviderError` with `isTransient: false` — **permanent pause**
+
+### Contributing Factor
+
+The `gsd_complete_slice` tool has the most complex schema in the system (23 params, 5 nested object arrays at db-tools.ts:748-802), producing the longest JSON payloads (~2000-3000+ bytes). Longer payloads = higher probability of hitting stream corruption mid-generation.
+
+## Key Files
+
+- `src/resources/extensions/gsd/error-classifier.ts:51` — STREAM_RE regex (the gap)
+- `src/resources/extensions/gsd/bootstrap/agent-end-recovery.ts:162` — unknown errors cause permanent pause
+- `src/resources/extensions/gsd/bootstrap/db-tools.ts:748-802` — gsd_complete_slice schema (25 params)
+- `packages/pi-ai/src/providers/anthropic-shared.ts:555-706` — streaming loop consuming SDK events
+- `packages/pi-agent-core/src/agent-loop.ts:203-224` — error catch converting to error message
+- `node_modules/@anthropic-ai/sdk/src/core/streaming.ts:70-74` — SDK SSE JSON.parse with re-throw
+
+## Recommended Fixes
+
+### Fix 1 — Error classifier regex (minimal, directly resolves issue)
+
+```typescript
+// error-classifier.ts:51
+// Before:
+const STREAM_RE = /Unexpected end of JSON|Unexpected token.*JSON|Expected double-quoted property name|SyntaxError.*JSON/i;
+
+// After — catch ALL JSON parse errors with the universal suffix:
+const STREAM_RE = /Unexpected end of JSON|Unexpected token.*JSON|Expected double-quoted property name|SyntaxError.*JSON|in JSON at position/i;
+```
+
+The phrase `"in JSON at position"` appears in ALL Node.js JSON parse error messages — this future-proofs against other variants.
+
+### Fix 2 — Schema simplification (defense in depth, optional)
+
+Collapse the 5 nested object arrays in `gsd_complete_slice` into a single JSON string parameter. Parse internally in the tool execute function with error logging. Reduces payload size and LLM generation complexity.
+
+### Fix 3 — SSE stream defense (defense in depth, optional)
+
+Wrap the SSE streaming loop in `anthropic-shared.ts` with a try-catch that converts JSON parse errors into graceful error responses.
+
+## Falsified Hypotheses
+
+- **Model-router modifications**: Does not touch tool arguments or JSON at all
+- **Schema complexity as sole cause**: Other tools with deep nesting (gsd_reassess_roadmap) don't exhibit this issue — complexity is a contributing factor, not root cause

--- a/packages/pi-ai/src/index.ts
+++ b/packages/pi-ai/src/index.ts
@@ -12,6 +12,8 @@ export * from "./providers/google-vertex.js";
 export * from "./providers/mistral.js";
 export * from "./providers/openai-completions.js";
 export * from "./providers/openai-responses.js";
+export * from "./providers/capabilities.js";
+export type { ProviderSwitchReport, TransformResult } from "./providers/transform-messages.js";
 export * from "./providers/register-builtins.js";
 export * from "./stream.js";
 export * from "./types.js";

--- a/packages/pi-ai/src/providers/amazon-bedrock.ts
+++ b/packages/pi-ai/src/providers/amazon-bedrock.ts
@@ -487,7 +487,7 @@ function convertMessages(
 	cacheRetention: CacheRetention,
 ): Message[] {
 	const result: Message[] = [];
-	const transformedMessages = transformMessages(context.messages, model, normalizeToolCallId);
+	const { messages: transformedMessages } = transformMessages(context.messages, model, normalizeToolCallId);
 
 	for (let i = 0; i < transformedMessages.length; i++) {
 		const m = transformedMessages[i];

--- a/packages/pi-ai/src/providers/anthropic-shared.ts
+++ b/packages/pi-ai/src/providers/anthropic-shared.ts
@@ -235,7 +235,7 @@ export function convertMessages(
 ): MessageParam[] {
 	const params: MessageParam[] = [];
 
-	const transformedMessages = transformMessages(messages, model, normalizeToolCallId);
+	const { messages: transformedMessages } = transformMessages(messages, model, normalizeToolCallId);
 
 	for (let i = 0; i < transformedMessages.length; i++) {
 		const msg = transformedMessages[i];

--- a/packages/pi-ai/src/providers/azure-openai-responses.ts
+++ b/packages/pi-ai/src/providers/azure-openai-responses.ts
@@ -21,6 +21,7 @@ import {
 	handleStreamError,
 } from "./openai-shared.js";
 import { buildBaseOptions, clampReasoning } from "./simple-options.js";
+import { clampThinkingLevel } from "./capabilities.js";
 
 let _AzureOpenAIClass: typeof AzureOpenAI | undefined;
 async function getAzureOpenAIClass(): Promise<typeof AzureOpenAI> {
@@ -222,7 +223,7 @@ function buildParams(
 
 	if (model.reasoning) {
 		if (options?.reasoningEffort || options?.reasoningSummary) {
-			const effort = clampReasoningForModel(model.name, options?.reasoningEffort || "medium") as typeof options.reasoningEffort;
+			const effort = clampThinkingLevel(model.api, clampReasoningForModel(model.name, options?.reasoningEffort || "medium")) as typeof options.reasoningEffort;
 			params.reasoning = {
 				effort: effort || "medium",
 				summary: options?.reasoningSummary || "auto",

--- a/packages/pi-ai/src/providers/capabilities.test.ts
+++ b/packages/pi-ai/src/providers/capabilities.test.ts
@@ -1,0 +1,171 @@
+// GSD-2 — Tests for provider capability registry (ADR-005)
+// Copyright (c) 2026 Jeremy McSpadden <jeremy@fluxlabs.net>
+
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import {
+	getProviderCapabilities,
+	getRegisteredApis,
+	getApiVariantAliases,
+	PERMISSIVE_CAPABILITIES,
+} from "./capabilities.js";
+
+describe("Provider Capability Registry", () => {
+	describe("getProviderCapabilities", () => {
+		test("returns Anthropic profile for anthropic-messages", () => {
+			const caps = getProviderCapabilities("anthropic-messages");
+			assert.equal(caps.toolCalling, true);
+			assert.equal(caps.imageToolResults, true);
+			assert.equal(caps.thinkingPersistence, "full");
+			assert.deepEqual(caps.unsupportedSchemaFeatures, []);
+			assert.equal(caps.toolCallIdFormat.maxLength, 64);
+		});
+
+		test("returns OpenAI profile for openai-responses", () => {
+			const caps = getProviderCapabilities("openai-responses");
+			assert.equal(caps.imageToolResults, false);
+			assert.equal(caps.thinkingPersistence, "text-only");
+			assert.equal(caps.toolCallIdFormat.maxLength, 512);
+		});
+
+		test("returns Google profile with patternProperties restriction", () => {
+			const caps = getProviderCapabilities("google-generative-ai");
+			assert.equal(caps.imageToolResults, true);
+			assert.equal(caps.thinkingPersistence, "text-only");
+			assert.deepEqual(caps.unsupportedSchemaFeatures, ["patternProperties"]);
+		});
+
+		test("returns Mistral profile with short tool call IDs", () => {
+			const caps = getProviderCapabilities("mistral-conversations");
+			assert.equal(caps.imageToolResults, false);
+			assert.equal(caps.thinkingPersistence, "none");
+			assert.equal(caps.toolCallIdFormat.maxLength, 9);
+		});
+
+		test("returns Bedrock profile", () => {
+			const caps = getProviderCapabilities("bedrock-converse-stream");
+			assert.equal(caps.toolCalling, true);
+			assert.equal(caps.imageToolResults, false);
+			assert.equal(caps.thinkingPersistence, "text-only");
+		});
+	});
+
+	describe("API variant aliases", () => {
+		test("anthropic-vertex inherits anthropic-messages capabilities", () => {
+			const variant = getProviderCapabilities("anthropic-vertex");
+			const canonical = getProviderCapabilities("anthropic-messages");
+			assert.deepEqual(variant.unsupportedSchemaFeatures, canonical.unsupportedSchemaFeatures);
+			assert.equal(variant.imageToolResults, canonical.imageToolResults);
+			assert.equal(variant.thinkingPersistence, canonical.thinkingPersistence);
+		});
+
+		test("google-vertex inherits google-generative-ai capabilities", () => {
+			const variant = getProviderCapabilities("google-vertex");
+			const canonical = getProviderCapabilities("google-generative-ai");
+			assert.deepEqual(variant.unsupportedSchemaFeatures, canonical.unsupportedSchemaFeatures);
+			assert.equal(variant.imageToolResults, canonical.imageToolResults);
+		});
+
+		test("google-gemini-cli inherits google-generative-ai capabilities", () => {
+			const variant = getProviderCapabilities("google-gemini-cli");
+			const canonical = getProviderCapabilities("google-generative-ai");
+			assert.deepEqual(variant.unsupportedSchemaFeatures, canonical.unsupportedSchemaFeatures);
+		});
+
+		test("azure-openai-responses inherits openai-responses capabilities", () => {
+			const variant = getProviderCapabilities("azure-openai-responses");
+			const canonical = getProviderCapabilities("openai-responses");
+			assert.equal(variant.imageToolResults, canonical.imageToolResults);
+			assert.equal(variant.thinkingPersistence, canonical.thinkingPersistence);
+		});
+
+		test("openai-codex-responses inherits openai-responses capabilities", () => {
+			const variant = getProviderCapabilities("openai-codex-responses");
+			const canonical = getProviderCapabilities("openai-responses");
+			assert.equal(variant.imageToolResults, canonical.imageToolResults);
+		});
+
+		test("openai-completions inherits openai-responses capabilities", () => {
+			const variant = getProviderCapabilities("openai-completions");
+			const canonical = getProviderCapabilities("openai-responses");
+			assert.equal(variant.imageToolResults, canonical.imageToolResults);
+		});
+	});
+
+	describe("fail-open for unknown APIs", () => {
+		test("unknown API returns permissive default", () => {
+			const caps = getProviderCapabilities("some-unknown-api");
+			assert.equal(caps, PERMISSIVE_CAPABILITIES);
+			assert.equal(caps.toolCalling, true);
+			assert.equal(caps.maxTools, 0);
+			assert.equal(caps.imageToolResults, true);
+			assert.equal(caps.structuredOutput, true);
+			assert.equal(caps.thinkingPersistence, "full");
+			assert.deepEqual(caps.unsupportedSchemaFeatures, []);
+		});
+
+		test("bare provider name returns permissive default, NOT the provider profile (Pitfall 1)", () => {
+			// "anthropic" is a provider short name, not an API name.
+			// It must NOT match the "anthropic-messages" entry.
+			const caps = getProviderCapabilities("anthropic");
+			assert.equal(caps, PERMISSIVE_CAPABILITIES);
+		});
+
+		test("bare google provider name returns permissive default", () => {
+			const caps = getProviderCapabilities("google");
+			assert.equal(caps, PERMISSIVE_CAPABILITIES);
+		});
+
+		test("bare openai provider name returns permissive default", () => {
+			const caps = getProviderCapabilities("openai");
+			assert.equal(caps, PERMISSIVE_CAPABILITIES);
+		});
+
+		test("empty string returns permissive default", () => {
+			const caps = getProviderCapabilities("");
+			assert.equal(caps, PERMISSIVE_CAPABILITIES);
+		});
+	});
+
+	describe("registry completeness", () => {
+		test("all 5 canonical APIs have entries", () => {
+			const apis = getRegisteredApis();
+			assert.ok(apis.includes("anthropic-messages"));
+			assert.ok(apis.includes("openai-responses"));
+			assert.ok(apis.includes("google-generative-ai"));
+			assert.ok(apis.includes("mistral-conversations"));
+			assert.ok(apis.includes("bedrock-converse-stream"));
+			assert.equal(apis.length, 5);
+		});
+
+		test("all variant aliases point to registered canonical APIs", () => {
+			const aliases = getApiVariantAliases();
+			const canonicals = getRegisteredApis();
+			for (const [variant, canonical] of Object.entries(aliases)) {
+				assert.ok(
+					canonicals.includes(canonical),
+					`Variant "${variant}" points to unregistered canonical "${canonical}"`,
+				);
+			}
+		});
+
+		test("variant aliases cover all non-canonical APIs from register-builtins", () => {
+			// These are the APIs registered in register-builtins.ts that are NOT canonical
+			const expectedVariants = [
+				"anthropic-vertex",
+				"google-vertex",
+				"google-gemini-cli",
+				"azure-openai-responses",
+				"openai-codex-responses",
+				"openai-completions",
+			];
+			const aliases = getApiVariantAliases();
+			for (const variant of expectedVariants) {
+				assert.ok(
+					variant in aliases,
+					`Expected variant alias for "${variant}" (registered in register-builtins.ts)`,
+				);
+			}
+		});
+	});
+});

--- a/packages/pi-ai/src/providers/capabilities.test.ts
+++ b/packages/pi-ai/src/providers/capabilities.test.ts
@@ -12,6 +12,7 @@ import {
 	getApiVariantAliases,
 	setProviderCapabilityOverrides,
 	clearProviderCapabilityOverrides,
+	clampThinkingLevel,
 	PERMISSIVE_CAPABILITIES,
 } from "./capabilities.js";
 
@@ -310,6 +311,46 @@ describe("Provider Capability Registry", () => {
 			// Call again with same reference — should be a no-op (cached)
 			setProviderCapabilityOverrides(overrides);
 			assert.equal(getProviderCapabilities("openai-responses").imageToolResults, true);
+		});
+	});
+
+	describe("clampThinkingLevel", () => {
+		afterEach(() => {
+			clearProviderCapabilityOverrides();
+		});
+
+		test("minimal is clamped to low for OpenAI (gpt-5.3-codex fix)", () => {
+			const result = clampThinkingLevel("openai-responses", "minimal");
+			assert.equal(result, "low");
+		});
+
+		test("minimal is clamped to low for OpenAI codex variant", () => {
+			const result = clampThinkingLevel("openai-codex-responses", "minimal");
+			assert.equal(result, "low");
+		});
+
+		test("minimal is supported for Anthropic (no clamping)", () => {
+			const result = clampThinkingLevel("anthropic-messages", "minimal");
+			assert.equal(result, "minimal");
+		});
+
+		test("xhigh is clamped to high for Google (not supported)", () => {
+			const result = clampThinkingLevel("google-generative-ai", "xhigh");
+			assert.equal(result, "high");
+		});
+
+		test("supported level passes through unchanged", () => {
+			assert.equal(clampThinkingLevel("openai-responses", "medium"), "medium");
+			assert.equal(clampThinkingLevel("anthropic-messages", "high"), "high");
+			assert.equal(clampThinkingLevel("google-generative-ai", "low"), "low");
+		});
+
+		test("unknown provider returns level unchanged (fail-open)", () => {
+			assert.equal(clampThinkingLevel("some-unknown-api", "minimal"), "minimal");
+		});
+
+		test("unknown level passes through unchanged", () => {
+			assert.equal(clampThinkingLevel("openai-responses", "turbo"), "turbo");
 		});
 	});
 });

--- a/packages/pi-ai/src/providers/capabilities.test.ts
+++ b/packages/pi-ai/src/providers/capabilities.test.ts
@@ -276,5 +276,40 @@ describe("Provider Capability Registry", () => {
 			const google = getProviderCapabilities("google-generative-ai");
 			assert.equal(google.imageToolResults, true);
 		});
+
+		test("partial toolCallIdFormat override preserves other nested fields (deep merge)", () => {
+			setProviderCapabilityOverrides({
+				"anthropic-messages": {
+					toolCallIdFormat: { maxLength: 128 },
+				} as any,
+			});
+			const caps = getProviderCapabilities("anthropic-messages");
+			assert.equal(caps.toolCallIdFormat.maxLength, 128);
+			// allowedChars should be preserved from built-in, not lost
+			assert.ok(caps.toolCallIdFormat.allowedChars instanceof RegExp);
+			assert.ok(caps.toolCallIdFormat.allowedChars.test("abc123"));
+		});
+
+		test("string allowedChars in override is converted to RegExp", () => {
+			setProviderCapabilityOverrides({
+				"anthropic-messages": {
+					toolCallIdFormat: { maxLength: 256, allowedChars: "^[a-z]+$" },
+				} as any,
+			});
+			const caps = getProviderCapabilities("anthropic-messages");
+			assert.equal(caps.toolCallIdFormat.maxLength, 256);
+			assert.ok(caps.toolCallIdFormat.allowedChars instanceof RegExp);
+			assert.ok(caps.toolCallIdFormat.allowedChars.test("abc"));
+			assert.ok(!caps.toolCallIdFormat.allowedChars.test("ABC123"));
+		});
+
+		test("same reference skips reparse (caching)", () => {
+			const overrides = { "openai-responses": { imageToolResults: true } };
+			setProviderCapabilityOverrides(overrides);
+			assert.equal(getProviderCapabilities("openai-responses").imageToolResults, true);
+			// Call again with same reference — should be a no-op (cached)
+			setProviderCapabilityOverrides(overrides);
+			assert.equal(getProviderCapabilities("openai-responses").imageToolResults, true);
+		});
 	});
 });

--- a/packages/pi-ai/src/providers/capabilities.test.ts
+++ b/packages/pi-ai/src/providers/capabilities.test.ts
@@ -1,12 +1,17 @@
 // GSD-2 — Tests for provider capability registry (ADR-005)
 // Copyright (c) 2026 Jeremy McSpadden <jeremy@fluxlabs.net>
 
-import { describe, test } from "node:test";
+import { describe, test, afterEach } from "node:test";
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
 import {
 	getProviderCapabilities,
 	getRegisteredApis,
 	getApiVariantAliases,
+	setProviderCapabilityOverrides,
+	clearProviderCapabilityOverrides,
 	PERMISSIVE_CAPABILITIES,
 } from "./capabilities.js";
 
@@ -166,6 +171,110 @@ describe("Provider Capability Registry", () => {
 					`Expected variant alias for "${variant}" (registered in register-builtins.ts)`,
 				);
 			}
+		});
+
+		test("every API in register-builtins.ts is covered by registry or aliases (dynamic CI check)", () => {
+			// Dynamically read register-builtins.ts source to extract all registered API strings.
+			// This test fails CI if a new provider is added without a registry/alias entry.
+			const __filename = fileURLToPath(import.meta.url);
+			const __dirname = dirname(__filename);
+			const source = readFileSync(
+				join(__dirname, "register-builtins.ts"),
+				"utf-8",
+			);
+			// Extract all `api: "..."` values from registerApiProvider calls
+			const apiRegex = /api:\s*"([^"]+)"/g;
+			const registeredApis: string[] = [];
+			let match;
+			while ((match = apiRegex.exec(source)) !== null) {
+				registeredApis.push(match[1]);
+			}
+
+			assert.ok(registeredApis.length > 0, "Failed to parse any APIs from register-builtins.ts");
+
+			const canonicals = getRegisteredApis();
+			const aliases = getApiVariantAliases();
+
+			for (const api of registeredApis) {
+				const inRegistry = canonicals.includes(api);
+				const inAliases = api in aliases;
+				assert.ok(
+					inRegistry || inAliases,
+					`API "${api}" is registered in register-builtins.ts but has no entry in ` +
+					`PROVIDER_CAPABILITIES (canonical) or API_VARIANT_ALIASES. ` +
+					`Add it to capabilities.ts to ensure tool compatibility filtering works for this provider.`,
+				);
+			}
+		});
+	});
+
+	describe("provider capability overrides (Phase 6)", () => {
+		afterEach(() => {
+			clearProviderCapabilityOverrides();
+		});
+
+		test("override changes a specific field while preserving others", () => {
+			setProviderCapabilityOverrides({
+				"openai-responses": { imageToolResults: true },
+			});
+			const caps = getProviderCapabilities("openai-responses");
+			// Override applied
+			assert.equal(caps.imageToolResults, true);
+			// Other fields preserved from built-in
+			assert.equal(caps.toolCalling, true);
+			assert.equal(caps.thinkingPersistence, "text-only");
+		});
+
+		test("override for unknown API creates new entry with merged permissive defaults", () => {
+			setProviderCapabilityOverrides({
+				"my-custom-api": { toolCalling: false },
+			});
+			const caps = getProviderCapabilities("my-custom-api");
+			assert.equal(caps.toolCalling, false);
+			// Other fields come from permissive default
+			assert.equal(caps.imageToolResults, true);
+		});
+
+		test("clearing overrides restores built-in values", () => {
+			setProviderCapabilityOverrides({
+				"openai-responses": { imageToolResults: true },
+			});
+			assert.equal(getProviderCapabilities("openai-responses").imageToolResults, true);
+
+			clearProviderCapabilityOverrides();
+			assert.equal(getProviderCapabilities("openai-responses").imageToolResults, false);
+		});
+
+		test("setProviderCapabilityOverrides with undefined clears overrides", () => {
+			setProviderCapabilityOverrides({
+				"anthropic-messages": { maxTools: 10 },
+			});
+			assert.equal(getProviderCapabilities("anthropic-messages").maxTools, 10);
+
+			setProviderCapabilityOverrides(undefined);
+			assert.equal(getProviderCapabilities("anthropic-messages").maxTools, 0);
+		});
+
+		test("override does not affect other APIs", () => {
+			setProviderCapabilityOverrides({
+				"openai-responses": { imageToolResults: true },
+			});
+			// Anthropic should be unchanged
+			const anthropic = getProviderCapabilities("anthropic-messages");
+			assert.equal(anthropic.imageToolResults, true); // built-in value
+		});
+
+		test("override for variant API applies only to variant, not canonical", () => {
+			setProviderCapabilityOverrides({
+				"google-vertex": { imageToolResults: false },
+			});
+			// google-vertex override applied
+			const vertex = getProviderCapabilities("google-vertex");
+			assert.equal(vertex.imageToolResults, false);
+
+			// canonical google-generative-ai unchanged
+			const google = getProviderCapabilities("google-generative-ai");
+			assert.equal(google.imageToolResults, true);
 		});
 	});
 });

--- a/packages/pi-ai/src/providers/capabilities.ts
+++ b/packages/pi-ai/src/providers/capabilities.ts
@@ -120,12 +120,17 @@ const API_VARIANT_ALIASES: Record<string, string> = {
 // Loaded from preferences `provider_capabilities` key and deep-merged with
 // built-in defaults. Call setProviderCapabilityOverrides() at preferences load.
 
+// Module-level singleton — safe because auto-loop dispatches are sequential.
+// If parallel dispatch is added, this must become per-dispatch or use a lock.
 let capabilityOverrides: Record<string, Partial<ProviderCapabilities>> = {};
+let lastOverrideInput: Record<string, Record<string, unknown>> | undefined | null = null;
 
 /**
  * Apply provider capability overrides from user preferences.
  * Call this when preferences are loaded/reloaded.
  * Overrides are deep-merged: only specified fields are changed, others keep built-in defaults.
+ *
+ * Skips re-parsing when the same reference is passed (common in sequential dispatches).
  *
  * Keys should be API protocol strings (e.g., "openai-responses").
  * Unknown keys that don't match any canonical or alias API will still be stored —
@@ -134,6 +139,10 @@ let capabilityOverrides: Record<string, Partial<ProviderCapabilities>> = {};
 export function setProviderCapabilityOverrides(
 	overrides: Record<string, Record<string, unknown>> | undefined,
 ): void {
+	// Skip reparse if same reference as last call
+	if (overrides === lastOverrideInput) return;
+	lastOverrideInput = overrides;
+
 	if (!overrides) {
 		capabilityOverrides = {};
 		return;
@@ -152,6 +161,7 @@ export function setProviderCapabilityOverrides(
  */
 export function clearProviderCapabilityOverrides(): void {
 	capabilityOverrides = {};
+	lastOverrideInput = null;
 }
 
 /**
@@ -182,8 +192,21 @@ export function getProviderCapabilities(api: Api): ProviderCapabilities {
 	const override = capabilityOverrides[api];
 	if (!override) return base;
 
-	// Deep-merge: override fields replace base fields
-	return { ...base, ...override } as ProviderCapabilities;
+	// Deep-merge: nested objects (toolCallIdFormat) are merged, not replaced.
+	// RegExp fields from YAML arrive as strings — convert them.
+	const merged = { ...base, ...override };
+	if (override.toolCallIdFormat) {
+		merged.toolCallIdFormat = {
+			...base.toolCallIdFormat,
+			...(override.toolCallIdFormat as Record<string, unknown>),
+		};
+		// Convert string allowedChars to RegExp (YAML/JSON can't represent RegExp)
+		const chars = merged.toolCallIdFormat.allowedChars;
+		if (typeof chars === "string") {
+			merged.toolCallIdFormat.allowedChars = new RegExp(chars);
+		}
+	}
+	return merged as ProviderCapabilities;
 }
 
 /**

--- a/packages/pi-ai/src/providers/capabilities.ts
+++ b/packages/pi-ai/src/providers/capabilities.ts
@@ -1,0 +1,150 @@
+// GSD-2 — Provider capability registry for tool-aware model routing (ADR-005)
+// Copyright (c) 2026 Jeremy McSpadden <jeremy@fluxlabs.net>
+
+import type { Api } from "../types.js";
+
+/**
+ * Declarative description of what a provider API supports.
+ * Used by the tool-compatibility filter (Step 2) and adjustToolSet().
+ */
+export interface ProviderCapabilities {
+	/** Whether models from this provider support tool calling */
+	toolCalling: boolean;
+	/** Maximum number of tools the provider handles well (0 = unlimited) */
+	maxTools: number;
+	/** Whether tool results can contain images */
+	imageToolResults: boolean;
+	/** Whether the provider supports structured JSON output */
+	structuredOutput: boolean;
+	/** Tool call ID format constraints */
+	toolCallIdFormat: {
+		maxLength: number;
+		allowedChars: RegExp;
+	};
+	/** Whether thinking/reasoning blocks are preserved cross-turn */
+	thinkingPersistence: "full" | "text-only" | "none";
+	/** Schema features NOT supported (tools using these get filtered) */
+	unsupportedSchemaFeatures: string[];
+}
+
+/**
+ * Maximally permissive profile for unknown providers.
+ * All features enabled, no restrictions — preserves current behavior exactly.
+ */
+export const PERMISSIVE_CAPABILITIES: ProviderCapabilities = {
+	toolCalling: true,
+	maxTools: 0,
+	imageToolResults: true,
+	structuredOutput: true,
+	toolCallIdFormat: { maxLength: 512, allowedChars: /^.+$/ },
+	thinkingPersistence: "full",
+	unsupportedSchemaFeatures: [],
+};
+
+/**
+ * Provider capabilities keyed by canonical API name.
+ *
+ * IMPORTANT: Keys are API protocol strings (e.g., "anthropic-messages"),
+ * NOT provider short names (e.g., "anthropic"). See ADR-005 Pitfall 1.
+ */
+const PROVIDER_CAPABILITIES: Record<string, ProviderCapabilities> = {
+	"anthropic-messages": {
+		toolCalling: true,
+		maxTools: 0,
+		imageToolResults: true,
+		structuredOutput: true,
+		toolCallIdFormat: { maxLength: 64, allowedChars: /^[a-zA-Z0-9_-]+$/ },
+		thinkingPersistence: "full",
+		unsupportedSchemaFeatures: [],
+	},
+	"openai-responses": {
+		toolCalling: true,
+		maxTools: 0,
+		imageToolResults: false,
+		structuredOutput: true,
+		toolCallIdFormat: { maxLength: 512, allowedChars: /^.+$/ },
+		thinkingPersistence: "text-only",
+		unsupportedSchemaFeatures: [],
+	},
+	"google-generative-ai": {
+		toolCalling: true,
+		maxTools: 0,
+		imageToolResults: true,
+		structuredOutput: true,
+		toolCallIdFormat: { maxLength: 64, allowedChars: /^[a-zA-Z0-9_-]+$/ },
+		thinkingPersistence: "text-only",
+		unsupportedSchemaFeatures: ["patternProperties"],
+	},
+	"mistral-conversations": {
+		toolCalling: true,
+		maxTools: 0,
+		imageToolResults: false,
+		structuredOutput: true,
+		toolCallIdFormat: { maxLength: 9, allowedChars: /^[a-zA-Z0-9]+$/ },
+		thinkingPersistence: "none",
+		unsupportedSchemaFeatures: [],
+	},
+	"bedrock-converse-stream": {
+		toolCalling: true,
+		maxTools: 0,
+		imageToolResults: false,
+		structuredOutput: true,
+		toolCallIdFormat: { maxLength: 64, allowedChars: /^[a-zA-Z0-9_-]+$/ },
+		thinkingPersistence: "text-only",
+		unsupportedSchemaFeatures: [],
+	},
+};
+
+/**
+ * Maps API variant names to their canonical parent API.
+ * Variants inherit the parent's capabilities because they use the same
+ * underlying protocol (e.g., anthropic-vertex uses anthropic-messages protocol).
+ */
+const API_VARIANT_ALIASES: Record<string, string> = {
+	"anthropic-vertex": "anthropic-messages",
+	"google-vertex": "google-generative-ai",
+	"google-gemini-cli": "google-generative-ai",
+	"azure-openai-responses": "openai-responses",
+	"openai-codex-responses": "openai-responses",
+	"openai-completions": "openai-responses",
+};
+
+/**
+ * Returns provider capabilities for the given API string.
+ *
+ * Looks up the canonical API name first, then checks variant aliases.
+ * Returns PERMISSIVE_CAPABILITIES for unknown APIs (fail-open).
+ *
+ * @param api - The API protocol string (e.g., "anthropic-messages", NOT "anthropic")
+ */
+export function getProviderCapabilities(api: Api): ProviderCapabilities {
+	// Direct match on canonical API
+	const direct = PROVIDER_CAPABILITIES[api];
+	if (direct) return direct;
+
+	// Check variant aliases
+	const canonical = API_VARIANT_ALIASES[api];
+	if (canonical) {
+		const aliased = PROVIDER_CAPABILITIES[canonical];
+		if (aliased) return aliased;
+	}
+
+	// Unknown API — return permissive default (fail-open)
+	return PERMISSIVE_CAPABILITIES;
+}
+
+/**
+ * Returns all canonical API names that have explicit capability entries.
+ * Used by the registry completeness test.
+ */
+export function getRegisteredApis(): string[] {
+	return Object.keys(PROVIDER_CAPABILITIES);
+}
+
+/**
+ * Returns all known API variant aliases.
+ * Used by the registry completeness test.
+ */
+export function getApiVariantAliases(): Record<string, string> {
+	return { ...API_VARIANT_ALIASES };
+}

--- a/packages/pi-ai/src/providers/capabilities.ts
+++ b/packages/pi-ai/src/providers/capabilities.ts
@@ -1,5 +1,12 @@
 // GSD-2 — Provider capability registry for tool-aware model routing (ADR-005)
 // Copyright (c) 2026 Jeremy McSpadden <jeremy@fluxlabs.net>
+//
+// Pipeline contract (ADR-005):
+//   The tool-compatibility filter (Step 2) runs BEFORE capability scoring (Step 3).
+//   If a `before_model_select` hook is added in the future, it receives the
+//   POST-tool-filter candidate set — not the full tier-eligible set. This means
+//   the hook cannot override to a model that was filtered for tool incompatibility
+//   unless it explicitly opts out via a `force: true` return value.
 
 import type { Api } from "../types.js";
 
@@ -109,28 +116,74 @@ const API_VARIANT_ALIASES: Record<string, string> = {
 	"openai-completions": "openai-responses",
 };
 
+// ─── Runtime Overrides (ADR-005 Phase 6) ───────────────────────────────────
+// Loaded from preferences `provider_capabilities` key and deep-merged with
+// built-in defaults. Call setProviderCapabilityOverrides() at preferences load.
+
+let capabilityOverrides: Record<string, Partial<ProviderCapabilities>> = {};
+
+/**
+ * Apply provider capability overrides from user preferences.
+ * Call this when preferences are loaded/reloaded.
+ * Overrides are deep-merged: only specified fields are changed, others keep built-in defaults.
+ *
+ * Keys should be API protocol strings (e.g., "openai-responses").
+ * Unknown keys that don't match any canonical or alias API will still be stored —
+ * they create new entries that override the permissive default for custom APIs.
+ */
+export function setProviderCapabilityOverrides(
+	overrides: Record<string, Record<string, unknown>> | undefined,
+): void {
+	if (!overrides) {
+		capabilityOverrides = {};
+		return;
+	}
+	const parsed: Record<string, Partial<ProviderCapabilities>> = {};
+	for (const [api, values] of Object.entries(overrides)) {
+		if (typeof values === "object" && values !== null) {
+			parsed[api] = values as Partial<ProviderCapabilities>;
+		}
+	}
+	capabilityOverrides = parsed;
+}
+
+/**
+ * Clear all provider capability overrides. Used for testing.
+ */
+export function clearProviderCapabilityOverrides(): void {
+	capabilityOverrides = {};
+}
+
 /**
  * Returns provider capabilities for the given API string.
  *
  * Looks up the canonical API name first, then checks variant aliases.
  * Returns PERMISSIVE_CAPABILITIES for unknown APIs (fail-open).
+ * User overrides from preferences are deep-merged on top of built-in values.
  *
  * @param api - The API protocol string (e.g., "anthropic-messages", NOT "anthropic")
  */
 export function getProviderCapabilities(api: Api): ProviderCapabilities {
-	// Direct match on canonical API
+	// Resolve base capabilities: canonical → alias → permissive default
+	let base: ProviderCapabilities;
 	const direct = PROVIDER_CAPABILITIES[api];
-	if (direct) return direct;
-
-	// Check variant aliases
-	const canonical = API_VARIANT_ALIASES[api];
-	if (canonical) {
-		const aliased = PROVIDER_CAPABILITIES[canonical];
-		if (aliased) return aliased;
+	if (direct) {
+		base = direct;
+	} else {
+		const canonical = API_VARIANT_ALIASES[api];
+		if (canonical) {
+			base = PROVIDER_CAPABILITIES[canonical] ?? PERMISSIVE_CAPABILITIES;
+		} else {
+			base = PERMISSIVE_CAPABILITIES;
+		}
 	}
 
-	// Unknown API — return permissive default (fail-open)
-	return PERMISSIVE_CAPABILITIES;
+	// Apply user overrides if present for this API
+	const override = capabilityOverrides[api];
+	if (!override) return base;
+
+	// Deep-merge: override fields replace base fields
+	return { ...base, ...override } as ProviderCapabilities;
 }
 
 /**

--- a/packages/pi-ai/src/providers/capabilities.ts
+++ b/packages/pi-ai/src/providers/capabilities.ts
@@ -32,6 +32,12 @@ export interface ProviderCapabilities {
 	thinkingPersistence: "full" | "text-only" | "none";
 	/** Schema features NOT supported (tools using these get filtered) */
 	unsupportedSchemaFeatures: string[];
+	/**
+	 * Supported thinking/reasoning effort levels for this provider.
+	 * Used to clamp unsupported levels to the nearest valid level.
+	 * Empty array means no thinking support. Null/undefined means all levels supported.
+	 */
+	supportedThinkingLevels?: string[];
 }
 
 /**
@@ -63,6 +69,7 @@ const PROVIDER_CAPABILITIES: Record<string, ProviderCapabilities> = {
 		toolCallIdFormat: { maxLength: 64, allowedChars: /^[a-zA-Z0-9_-]+$/ },
 		thinkingPersistence: "full",
 		unsupportedSchemaFeatures: [],
+		supportedThinkingLevels: ["minimal", "low", "medium", "high", "xhigh"],
 	},
 	"openai-responses": {
 		toolCalling: true,
@@ -72,6 +79,8 @@ const PROVIDER_CAPABILITIES: Record<string, ProviderCapabilities> = {
 		toolCallIdFormat: { maxLength: 512, allowedChars: /^.+$/ },
 		thinkingPersistence: "text-only",
 		unsupportedSchemaFeatures: [],
+		// OpenAI gpt-5.x doesn't support "minimal" — use "low" as minimum
+		supportedThinkingLevels: ["none", "low", "medium", "high", "xhigh"],
 	},
 	"google-generative-ai": {
 		toolCalling: true,
@@ -81,6 +90,7 @@ const PROVIDER_CAPABILITIES: Record<string, ProviderCapabilities> = {
 		toolCallIdFormat: { maxLength: 64, allowedChars: /^[a-zA-Z0-9_-]+$/ },
 		thinkingPersistence: "text-only",
 		unsupportedSchemaFeatures: ["patternProperties"],
+		supportedThinkingLevels: ["minimal", "low", "medium", "high"],
 	},
 	"mistral-conversations": {
 		toolCalling: true,
@@ -90,6 +100,7 @@ const PROVIDER_CAPABILITIES: Record<string, ProviderCapabilities> = {
 		toolCallIdFormat: { maxLength: 9, allowedChars: /^[a-zA-Z0-9]+$/ },
 		thinkingPersistence: "none",
 		unsupportedSchemaFeatures: [],
+		supportedThinkingLevels: [],
 	},
 	"bedrock-converse-stream": {
 		toolCalling: true,
@@ -99,6 +110,7 @@ const PROVIDER_CAPABILITIES: Record<string, ProviderCapabilities> = {
 		toolCallIdFormat: { maxLength: 64, allowedChars: /^[a-zA-Z0-9_-]+$/ },
 		thinkingPersistence: "text-only",
 		unsupportedSchemaFeatures: [],
+		supportedThinkingLevels: ["minimal", "low", "medium", "high"],
 	},
 };
 
@@ -220,6 +232,65 @@ export function getProviderCapabilities(api: Api): ProviderCapabilities {
 		}
 	}
 	return merged as ProviderCapabilities;
+}
+
+/**
+ * Ordered thinking levels from lowest to highest effort.
+ * Used by clampThinkingLevel to find the nearest supported level.
+ */
+const THINKING_LEVEL_ORDER = ["none", "minimal", "low", "medium", "high", "xhigh"];
+
+/**
+ * Clamp a thinking/reasoning level to the nearest supported level for a provider.
+ *
+ * If the requested level is not in the provider's supportedThinkingLevels,
+ * returns the nearest higher supported level, or the highest supported level
+ * if no higher level exists.
+ *
+ * Returns the original level unchanged if:
+ * - supportedThinkingLevels is undefined/null (all levels supported)
+ * - The requested level is already supported
+ *
+ * @param api - The provider API string (e.g., "openai-responses")
+ * @param level - The requested thinking level (e.g., "minimal")
+ * @returns The clamped thinking level safe for this provider
+ */
+export function clampThinkingLevel(api: Api, level: string): string {
+	const caps = getProviderCapabilities(api);
+	const supported = caps.supportedThinkingLevels;
+
+	// No restriction declared — all levels assumed supported
+	if (!supported || supported.length === 0) {
+		// Empty array means no thinking support — return "none" if available, otherwise original
+		if (supported && supported.length === 0 && caps.thinkingPersistence === "none") {
+			return "none";
+		}
+		if (!supported) return level; // undefined = all supported
+		return level;
+	}
+
+	// Already supported
+	if (supported.includes(level)) return level;
+
+	// Find the nearest higher supported level
+	const requestedIdx = THINKING_LEVEL_ORDER.indexOf(level);
+	if (requestedIdx === -1) return level; // Unknown level — pass through
+
+	// Look upward first (prefer slightly more thinking over less)
+	for (let i = requestedIdx + 1; i < THINKING_LEVEL_ORDER.length; i++) {
+		if (supported.includes(THINKING_LEVEL_ORDER[i])) {
+			return THINKING_LEVEL_ORDER[i];
+		}
+	}
+
+	// No higher level available — fall back to highest supported
+	for (let i = requestedIdx - 1; i >= 0; i--) {
+		if (supported.includes(THINKING_LEVEL_ORDER[i])) {
+			return THINKING_LEVEL_ORDER[i];
+		}
+	}
+
+	return level; // No match at all — pass through (fail-open)
 }
 
 /**

--- a/packages/pi-ai/src/providers/capabilities.ts
+++ b/packages/pi-ai/src/providers/capabilities.ts
@@ -138,22 +138,35 @@ let lastOverrideInput: Record<string, Record<string, unknown>> | undefined | nul
  */
 export function setProviderCapabilityOverrides(
 	overrides: Record<string, Record<string, unknown>> | undefined,
-): void {
+): string[] {
 	// Skip reparse if same reference as last call
-	if (overrides === lastOverrideInput) return;
+	if (overrides === lastOverrideInput) return [];
 	lastOverrideInput = overrides;
 
 	if (!overrides) {
 		capabilityOverrides = {};
-		return;
+		return [];
 	}
 	const parsed: Record<string, Partial<ProviderCapabilities>> = {};
+	const warnings: string[] = [];
 	for (const [api, values] of Object.entries(overrides)) {
 		if (typeof values === "object" && values !== null) {
 			parsed[api] = values as Partial<ProviderCapabilities>;
+			// Warn if key doesn't match any known canonical or alias API
+			if (!PROVIDER_CAPABILITIES[api] && !API_VARIANT_ALIASES[api]) {
+				const knownApis = [
+					...Object.keys(PROVIDER_CAPABILITIES),
+					...Object.keys(API_VARIANT_ALIASES),
+				].join(", ");
+				warnings.push(
+					`provider_capabilities key "${api}" does not match any known provider API. ` +
+					`Known APIs: ${knownApis}. The override will apply only if a model uses this exact API string.`,
+				);
+			}
 		}
 	}
 	capabilityOverrides = parsed;
+	return warnings;
 }
 
 /**

--- a/packages/pi-ai/src/providers/google-shared.ts
+++ b/packages/pi-ai/src/providers/google-shared.ts
@@ -80,7 +80,7 @@ export function convertMessages<T extends GoogleApiType>(model: Model<T>, contex
 		return id.replace(/[^a-zA-Z0-9_-]/g, "_").slice(0, 64);
 	};
 
-	const transformedMessages = transformMessages(context.messages, model, normalizeToolCallId);
+	const { messages: transformedMessages } = transformMessages(context.messages, model, normalizeToolCallId);
 
 	for (const msg of transformedMessages) {
 		if (msg.role === "user") {

--- a/packages/pi-ai/src/providers/mistral.ts
+++ b/packages/pi-ai/src/providers/mistral.ts
@@ -79,7 +79,7 @@ export const streamMistral: StreamFunction<"mistral-conversations", MistralOptio
 			});
 
 			const normalizeMistralToolCallId = createMistralToolCallIdNormalizer();
-			const transformedMessages = transformMessages(context.messages, model, (id) => normalizeMistralToolCallId(id));
+			const { messages: transformedMessages } = transformMessages(context.messages, model, (id) => normalizeMistralToolCallId(id));
 
 			let payload = buildChatPayload(model, context, transformedMessages, options);
 			const nextPayload = await options?.onPayload?.(payload, model);

--- a/packages/pi-ai/src/providers/openai-codex-responses.ts
+++ b/packages/pi-ai/src/providers/openai-codex-responses.ts
@@ -29,6 +29,7 @@ import type {
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
 import { convertResponsesMessages, convertResponsesTools, processResponsesStream } from "./openai-responses-shared.js";
 import { buildBaseOptions, clampReasoning } from "./simple-options.js";
+import { clampThinkingLevel } from "./capabilities.js";
 
 // ============================================================================
 // Configuration
@@ -326,9 +327,13 @@ function buildRequestBody(
 }
 
 function clampReasoningEffort(modelId: string, effort: string): string {
+	// ADR-005: Use centralized capability registry for thinking level clamping.
+	// Falls back to per-model overrides for model-specific quirks.
+	const clamped = clampThinkingLevel("openai-codex-responses", effort);
+	if (clamped !== effort) return clamped;
+
+	// Per-model overrides for quirks not captured at the provider level
 	const id = modelId.includes("/") ? modelId.split("/").pop()! : modelId;
-	if ((id.startsWith("gpt-5.2") || id.startsWith("gpt-5.3") || id.startsWith("gpt-5.4")) && effort === "minimal")
-		return "low";
 	if (id === "gpt-5.1" && effort === "xhigh") return "high";
 	if (id === "gpt-5.1-codex-mini") return effort === "high" || effort === "xhigh" ? "high" : "medium";
 	return effort;

--- a/packages/pi-ai/src/providers/openai-completions.ts
+++ b/packages/pi-ai/src/providers/openai-completions.ts
@@ -441,7 +441,7 @@ export function convertMessages(
 		return id;
 	};
 
-	const transformedMessages = transformMessages(context.messages, model, (id) => normalizeToolCallId(id));
+	const { messages: transformedMessages } = transformMessages(context.messages, model, (id) => normalizeToolCallId(id));
 
 	if (context.systemPrompt) {
 		const useDeveloperRole = model.reasoning && compat.supportsDeveloperRole;

--- a/packages/pi-ai/src/providers/openai-responses-shared.ts
+++ b/packages/pi-ai/src/providers/openai-responses-shared.ts
@@ -108,7 +108,7 @@ export function convertResponsesMessages<TApi extends Api>(
 		return `${normalizedCallId}|${normalizedItemId}`;
 	};
 
-	const transformedMessages = transformMessages(context.messages, model, normalizeToolCallId);
+	const { messages: transformedMessages } = transformMessages(context.messages, model, normalizeToolCallId);
 
 	const includeSystemPrompt = options?.includeSystemPrompt ?? true;
 	if (includeSystemPrompt && context.systemPrompt) {

--- a/packages/pi-ai/src/providers/openai-responses.ts
+++ b/packages/pi-ai/src/providers/openai-responses.ts
@@ -23,6 +23,7 @@ import {
 	handleStreamError,
 } from "./openai-shared.js";
 import { buildBaseOptions, clampReasoning } from "./simple-options.js";
+import { clampThinkingLevel } from "./capabilities.js";
 
 const OPENAI_TOOL_CALL_PROVIDERS = new Set(["openai", "openai-codex", "opencode"]);
 
@@ -158,7 +159,7 @@ function buildParams(model: Model<"openai-responses">, context: Context, options
 	if (model.reasoning) {
 		params.include = ["reasoning.encrypted_content"];
 		if (options?.reasoningEffort || options?.reasoningSummary) {
-			const effort = clampReasoningForModel(model.name, options?.reasoningEffort || "medium") as typeof options.reasoningEffort;
+			const effort = clampThinkingLevel(model.api, clampReasoningForModel(model.name, options?.reasoningEffort || "medium")) as typeof options.reasoningEffort;
 			params.reasoning = {
 				effort: effort || "medium",
 				summary: options?.reasoningSummary || "auto",

--- a/packages/pi-ai/src/providers/transform-messages.test.ts
+++ b/packages/pi-ai/src/providers/transform-messages.test.ts
@@ -1,0 +1,260 @@
+// GSD-2 — Tests for transformMessages ProviderSwitchReport (ADR-005 Phase 5)
+// Copyright (c) 2026 Jeremy McSpadden <jeremy@fluxlabs.net>
+
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import { transformMessages, type ProviderSwitchReport } from "./transform-messages.js";
+import type { AssistantMessage, Message, Model, UserMessage, ToolResultMessage } from "../types.js";
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function makeModel(overrides?: Partial<Model<any>>): Model<any> {
+	return {
+		id: "claude-sonnet-4-6",
+		provider: "anthropic",
+		api: "anthropic-messages",
+		name: "Claude Sonnet",
+		contextWindow: 200000,
+		...overrides,
+	} as Model<any>;
+}
+
+function makeUserMessage(text: string): UserMessage {
+	return { role: "user", content: text, timestamp: Date.now() };
+}
+
+function makeAssistantMessage(
+	text: string,
+	overrides?: Partial<AssistantMessage>,
+): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "text", text }],
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "claude-sonnet-4-6",
+		usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } },
+		stopReason: "stop",
+		timestamp: Date.now(),
+		...overrides,
+	};
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe("transformMessages — ProviderSwitchReport (ADR-005)", () => {
+
+	test("same-provider messages produce no switchReport (Pitfall 7 — early exit)", () => {
+		const model = makeModel();
+		const messages: Message[] = [
+			makeUserMessage("Hello"),
+			makeAssistantMessage("Hi there"),
+			makeUserMessage("How are you?"),
+			makeAssistantMessage("Doing well"),
+		];
+
+		const result = transformMessages(messages, model);
+		assert.equal(result.switchReport, undefined, "same-provider should produce no report");
+		assert.equal(result.messages.length, 4);
+	});
+
+	test("cross-provider messages produce a switchReport", () => {
+		// Target model is Anthropic, but conversation has messages from OpenAI
+		const model = makeModel({ api: "anthropic-messages", provider: "anthropic", id: "claude-sonnet-4-6" });
+		const messages: Message[] = [
+			makeUserMessage("Hello"),
+			makeAssistantMessage("Hi from OpenAI", {
+				api: "openai-responses",
+				provider: "openai",
+				model: "gpt-4o",
+				content: [{ type: "text", text: "Hi from OpenAI" }],
+			}),
+			makeUserMessage("Follow up"),
+		];
+
+		const result = transformMessages(messages, model);
+		assert.ok(result.switchReport, "cross-provider should produce a report");
+		assert.equal(result.switchReport!.fromApi, "openai-responses");
+		assert.equal(result.switchReport!.toApi, "anthropic-messages");
+	});
+
+	test("cross-provider report counts thinking blocks downgraded to text", () => {
+		const model = makeModel({ api: "openai-responses", provider: "openai", id: "gpt-4o" });
+		const messages: Message[] = [
+			makeUserMessage("Think about this"),
+			makeAssistantMessage("thought result", {
+				api: "anthropic-messages",
+				provider: "anthropic",
+				model: "claude-sonnet-4-6",
+				content: [
+					{ type: "thinking", thinking: "Deep analysis here", redacted: false },
+					{ type: "text", text: "My conclusion" },
+				],
+			}),
+		];
+
+		const result = transformMessages(messages, model);
+		assert.ok(result.switchReport, "should produce report");
+		assert.equal(result.switchReport!.thinkingBlocksDowngraded, 1, "one thinking block should be downgraded");
+		assert.equal(result.switchReport!.thinkingBlocksDropped, 0, "no blocks should be dropped");
+	});
+
+	test("cross-provider report counts redacted thinking blocks dropped", () => {
+		const model = makeModel({ api: "openai-responses", provider: "openai", id: "gpt-4o" });
+		const messages: Message[] = [
+			makeUserMessage("Think about this"),
+			makeAssistantMessage("result", {
+				api: "anthropic-messages",
+				provider: "anthropic",
+				model: "claude-sonnet-4-6",
+				content: [
+					{ type: "thinking", thinking: "", redacted: true },
+					{ type: "text", text: "My conclusion" },
+				],
+			}),
+		];
+
+		const result = transformMessages(messages, model);
+		assert.ok(result.switchReport, "should produce report");
+		assert.equal(result.switchReport!.thinkingBlocksDropped, 1, "one redacted block should be dropped");
+	});
+
+	test("cross-provider report counts tool call ID remapping", () => {
+		const model = makeModel({ api: "anthropic-messages", provider: "anthropic", id: "claude-sonnet-4-6" });
+		let remapCalled = 0;
+		const normalizer = (id: string) => {
+			remapCalled++;
+			return `remapped-${id.substring(0, 8)}`;
+		};
+
+		const messages: Message[] = [
+			makeUserMessage("Run a tool"),
+			makeAssistantMessage("running", {
+				api: "openai-responses",
+				provider: "openai",
+				model: "gpt-4o",
+				content: [
+					{ type: "toolCall", id: "call_abc123456789", name: "Bash", arguments: { command: "echo hi" } },
+				],
+			}),
+			{
+				role: "toolResult",
+				toolCallId: "call_abc123456789",
+				toolName: "Bash",
+				content: [{ type: "text", text: "hi" }],
+				isError: false,
+				timestamp: Date.now(),
+			} as ToolResultMessage,
+		];
+
+		const result = transformMessages(messages, model, normalizer);
+		assert.ok(result.switchReport, "should produce report");
+		assert.equal(result.switchReport!.toolCallIdsRemapped, 1, "one tool call ID should be remapped");
+	});
+
+	test("cross-provider report counts thought signatures dropped", () => {
+		const model = makeModel({ api: "anthropic-messages", provider: "anthropic", id: "claude-sonnet-4-6" });
+		const messages: Message[] = [
+			makeUserMessage("Run a tool"),
+			makeAssistantMessage("running", {
+				api: "google-generative-ai",
+				provider: "google",
+				model: "gemini-2.5-pro",
+				content: [
+					{
+						type: "toolCall",
+						id: "tc-1",
+						name: "Read",
+						arguments: { path: "/tmp/test" },
+						thoughtSignature: "opaque-google-signature-abc123",
+					},
+				],
+			}),
+			{
+				role: "toolResult",
+				toolCallId: "tc-1",
+				toolName: "Read",
+				content: [{ type: "text", text: "file contents" }],
+				isError: false,
+				timestamp: Date.now(),
+			} as ToolResultMessage,
+		];
+
+		const result = transformMessages(messages, model);
+		assert.ok(result.switchReport, "should produce report");
+		assert.equal(result.switchReport!.thoughtSignaturesDropped, 1, "one thought signature should be dropped");
+	});
+
+	test("report aggregates counts across multiple cross-provider messages", () => {
+		const model = makeModel({ api: "anthropic-messages", provider: "anthropic", id: "claude-sonnet-4-6" });
+		const messages: Message[] = [
+			makeUserMessage("multi-turn"),
+			makeAssistantMessage("turn 1", {
+				api: "openai-responses",
+				provider: "openai",
+				model: "gpt-4o",
+				content: [
+					{ type: "thinking", thinking: "thought 1", redacted: false },
+					{ type: "text", text: "response 1" },
+				],
+			}),
+			makeUserMessage("continue"),
+			makeAssistantMessage("turn 2", {
+				api: "openai-responses",
+				provider: "openai",
+				model: "gpt-4o",
+				content: [
+					{ type: "thinking", thinking: "thought 2", redacted: false },
+					{ type: "thinking", thinking: "", redacted: true },
+					{ type: "text", text: "response 2" },
+				],
+			}),
+		];
+
+		const result = transformMessages(messages, model);
+		assert.ok(result.switchReport, "should produce report");
+		assert.equal(result.switchReport!.thinkingBlocksDowngraded, 2, "two thinking blocks downgraded");
+		assert.equal(result.switchReport!.thinkingBlocksDropped, 1, "one redacted block dropped");
+		assert.equal(result.switchReport!.fromApi, "openai-responses");
+		assert.equal(result.switchReport!.toApi, "anthropic-messages");
+	});
+
+	test("errored/aborted assistant messages are dropped entirely", () => {
+		const model = makeModel();
+		const messages: Message[] = [
+			makeUserMessage("Hello"),
+			makeAssistantMessage("partial", {
+				stopReason: "error",
+				content: [{ type: "text", text: "partial response" }],
+			}),
+			makeUserMessage("retry"),
+			makeAssistantMessage("success"),
+		];
+
+		const result = transformMessages(messages, model);
+		// Errored message should be skipped
+		assert.equal(result.messages.length, 3, "errored message should be dropped");
+		assert.equal(result.switchReport, undefined, "same-provider, no report");
+	});
+
+	test("zero-count report still produced for cross-provider with only text", () => {
+		// Cross-provider but no thinking, no tool calls — report should still be produced
+		const model = makeModel({ api: "anthropic-messages", provider: "anthropic", id: "claude-sonnet-4-6" });
+		const messages: Message[] = [
+			makeUserMessage("Hello"),
+			makeAssistantMessage("Hi from GPT", {
+				api: "openai-responses",
+				provider: "openai",
+				model: "gpt-4o",
+			}),
+		];
+
+		const result = transformMessages(messages, model);
+		assert.ok(result.switchReport, "cross-provider should still produce report even with no transformations");
+		assert.equal(result.switchReport!.thinkingBlocksDropped, 0);
+		assert.equal(result.switchReport!.thinkingBlocksDowngraded, 0);
+		assert.equal(result.switchReport!.toolCallIdsRemapped, 0);
+		assert.equal(result.switchReport!.syntheticToolResultsInserted, 0);
+		assert.equal(result.switchReport!.thoughtSignaturesDropped, 0);
+	});
+});

--- a/packages/pi-ai/src/providers/transform-messages.ts
+++ b/packages/pi-ai/src/providers/transform-messages.ts
@@ -1,17 +1,49 @@
 import type { Api, AssistantMessage, Message, Model, ToolCall, ToolResultMessage } from "../types.js";
 
 /**
+ * Report of transformations applied during a cross-provider message conversion.
+ * Only emitted when fromApi !== toApi. See ADR-005.
+ */
+export interface ProviderSwitchReport {
+	fromApi: string;
+	toApi: string;
+	thinkingBlocksDropped: number;
+	thinkingBlocksDowngraded: number;
+	toolCallIdsRemapped: number;
+	syntheticToolResultsInserted: number;
+	thoughtSignaturesDropped: number;
+}
+
+export interface TransformResult {
+	messages: Message[];
+	switchReport?: ProviderSwitchReport;
+}
+
+/**
  * Normalize tool call ID for cross-provider compatibility.
  * OpenAI Responses API generates IDs that are 450+ chars with special characters like `|`.
  * Anthropic APIs require IDs matching ^[a-zA-Z0-9_-]+$ (max 64 chars).
+ *
+ * Returns transformed messages and an optional ProviderSwitchReport when
+ * cross-provider transformations are detected.
  */
 export function transformMessages<TApi extends Api>(
 	messages: Message[],
 	model: Model<TApi>,
 	normalizeToolCallId?: (id: string, model: Model<TApi>, source: AssistantMessage) => string,
-): Message[] {
+): TransformResult {
 	// Build a map of original tool call IDs to normalized IDs
 	const toolCallIdMap = new Map<string, string>();
+
+	// ADR-005: Track cross-provider transformation counts for ProviderSwitchReport.
+	// Detect if ANY message comes from a different provider/api — if so, we're in a switch scenario.
+	let hasCrossProviderMessages = false;
+	let thinkingBlocksDropped = 0;
+	let thinkingBlocksDowngraded = 0;
+	let toolCallIdsRemapped = 0;
+	let thoughtSignaturesDropped = 0;
+	let syntheticToolResultsInserted = 0;
+	let crossProviderFromApi: string | undefined;
 
 	// First pass: transform messages (thinking blocks, tool call ID normalization)
 	const transformed = messages.map((msg) => {
@@ -37,11 +69,18 @@ export function transformMessages<TApi extends Api>(
 				assistantMsg.api === model.api &&
 				assistantMsg.model === model.id;
 
+			// Track cross-provider source for the report
+			if (!isSameModel && assistantMsg.api && assistantMsg.api !== model.api) {
+				hasCrossProviderMessages = true;
+				if (!crossProviderFromApi) crossProviderFromApi = assistantMsg.api;
+			}
+
 			const transformedContent = assistantMsg.content.flatMap((block) => {
 				if (block.type === "thinking") {
 					// Redacted thinking is opaque encrypted content, only valid for the same model.
 					// Drop it for cross-model to avoid API errors.
 					if (block.redacted) {
+						if (!isSameModel) thinkingBlocksDropped++;
 						return isSameModel ? block : [];
 					}
 					// For same model: keep thinking blocks with signatures (needed for replay)
@@ -50,6 +89,7 @@ export function transformMessages<TApi extends Api>(
 					// Skip empty thinking blocks, convert others to plain text
 					if (!block.thinking || block.thinking.trim() === "") return [];
 					if (isSameModel) return block;
+					thinkingBlocksDowngraded++;
 					return {
 						type: "text" as const,
 						text: block.thinking,
@@ -69,6 +109,7 @@ export function transformMessages<TApi extends Api>(
 					let normalizedToolCall: ToolCall = toolCall;
 
 					if (!isSameModel && toolCall.thoughtSignature) {
+						thoughtSignaturesDropped++;
 						normalizedToolCall = { ...toolCall };
 						delete (normalizedToolCall as { thoughtSignature?: string }).thoughtSignature;
 					}
@@ -76,6 +117,7 @@ export function transformMessages<TApi extends Api>(
 					if (!isSameModel && normalizeToolCallId) {
 						const normalizedId = normalizeToolCallId(toolCall.id, model, assistantMsg);
 						if (normalizedId !== toolCall.id) {
+							toolCallIdsRemapped++;
 							toolCallIdMap.set(toolCall.id, normalizedId);
 							normalizedToolCall = { ...normalizedToolCall, id: normalizedId };
 						}
@@ -109,6 +151,7 @@ export function transformMessages<TApi extends Api>(
 			if (pendingToolCalls.length > 0) {
 				for (const tc of pendingToolCalls) {
 					if (!existingToolResultIds.has(tc.id)) {
+						syntheticToolResultsInserted++;
 						result.push({
 							role: "toolResult",
 							toolCallId: tc.id,
@@ -149,6 +192,7 @@ export function transformMessages<TApi extends Api>(
 			if (pendingToolCalls.length > 0) {
 				for (const tc of pendingToolCalls) {
 					if (!existingToolResultIds.has(tc.id)) {
+						syntheticToolResultsInserted++;
 						result.push({
 							role: "toolResult",
 							toolCallId: tc.id,
@@ -168,5 +212,19 @@ export function transformMessages<TApi extends Api>(
 		}
 	}
 
-	return result;
+	// Build the switch report only when cross-provider transformations occurred (ADR-005 Pitfall 7)
+	let switchReport: ProviderSwitchReport | undefined;
+	if (hasCrossProviderMessages && crossProviderFromApi) {
+		switchReport = {
+			fromApi: crossProviderFromApi,
+			toApi: model.api,
+			thinkingBlocksDropped,
+			thinkingBlocksDowngraded,
+			toolCallIdsRemapped,
+			syntheticToolResultsInserted,
+			thoughtSignaturesDropped,
+		};
+	}
+
+	return { messages: result, switchReport };
 }

--- a/packages/pi-coding-agent/src/core/agent-session.ts
+++ b/packages/pi-coding-agent/src/core/agent-session.ts
@@ -780,6 +780,10 @@ export class AgentSession {
 			name: t.name,
 			description: t.description,
 			parameters: t.parameters,
+			// ADR-005: compatibility and priority exist on the underlying ToolDefinition
+			// objects but are not typed on AgentTool. Access via runtime property check.
+			compatibility: (t as any).compatibility,
+			priority: (t as any).priority,
 		}));
 	}
 

--- a/packages/pi-coding-agent/src/core/extensions/index.ts
+++ b/packages/pi-coding-agent/src/core/extensions/index.ts
@@ -135,6 +135,7 @@ export type {
 	ToolCallEvent,
 	ToolCallEventResult,
 	// Tools
+	ToolCompatibility,
 	ToolDefinition,
 	// Events - Tool Execution
 	ToolExecutionEndEvent,

--- a/packages/pi-coding-agent/src/core/extensions/types.ts
+++ b/packages/pi-coding-agent/src/core/extensions/types.ts
@@ -332,6 +332,19 @@ export interface ToolRenderResultOptions {
 }
 
 /**
+ * Optional compatibility metadata for tool definitions.
+ * Tools without this metadata are assumed universally compatible (no filtering).
+ */
+export interface ToolCompatibility {
+	/** Tool requires image content in results */
+	producesImages?: boolean;
+	/** Tool requires schema features that some providers don't support */
+	schemaFeatures?: string[];
+	/** Tool is effective only with models above a minimum capability threshold */
+	minCapabilityTier?: "light" | "standard" | "heavy";
+}
+
+/**
  * Tool definition for registerTool().
  */
 export interface ToolDefinition<TParams extends TSchema = TSchema, TDetails = unknown> {
@@ -356,6 +369,11 @@ export interface ToolDefinition<TParams extends TSchema = TSchema, TDetails = un
 		onUpdate: AgentToolUpdateCallback<TDetails> | undefined,
 		ctx: ExtensionContext,
 	): Promise<AgentToolResult<TDetails>>;
+
+	/** Optional provider compatibility metadata. Tools without this are universally compatible. */
+	compatibility?: ToolCompatibility;
+	/** Priority for tool pruning when exceeding maxTools (1-10, higher = keep). Defaults to 1. */
+	priority?: number;
 
 	/** Custom rendering for tool call display */
 	renderCall?: (args: Static<TParams>, theme: Theme) => Component | undefined;
@@ -1348,8 +1366,8 @@ export interface ExtensionShortcut {
 
 type HandlerFn = (...args: unknown[]) => Promise<unknown>;
 
-/** Tool info with name, description, and parameter schema */
-export type ToolInfo = Pick<ToolDefinition, "name" | "description" | "parameters">;
+/** Tool info with name, description, parameter schema, and optional compatibility metadata */
+export type ToolInfo = Pick<ToolDefinition, "name" | "description" | "parameters" | "compatibility" | "priority">;
 
 /**
  * Shared state created by loader, used during registration and runtime.

--- a/packages/pi-coding-agent/src/index.ts
+++ b/packages/pi-coding-agent/src/index.ts
@@ -118,6 +118,7 @@ export type {
 	SlashCommandSource,
 	TerminalInputHandler,
 	ToolCallEvent,
+	ToolCompatibility,
 	ToolDefinition,
 	ToolInfo,
 	SortResult,

--- a/src/resources/extensions/gsd/auto-direct-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-direct-dispatch.ts
@@ -29,6 +29,8 @@ import {
 } from "./auto-prompts.js";
 import { loadEffectiveGSDPreferences } from "./preferences.js";
 import { pauseAuto } from "./auto.js";
+import { applyToolCompatibilityAdjustment } from "./auto-model-selection.js";
+import { setProviderCapabilityOverrides } from "@gsd/pi-ai";
 
 export async function dispatchDirectPhase(
   ctx: ExtensionCommandContext,
@@ -244,8 +246,22 @@ export async function dispatchDirectPhase(
   }
 
   ctx.ui.notify(`Dispatching ${unitType} for ${unitId}...`, "info");
+
+  // ADR-005: Apply provider capability overrides and tool filtering.
+  // Direct dispatch previously bypassed all capability validation.
+  const prefs = loadEffectiveGSDPreferences()?.preferences;
+  if (prefs) {
+    setProviderCapabilityOverrides(prefs.provider_capabilities);
+  }
+  const modelApi = ctx.model && "api" in ctx.model ? (ctx.model as { api: string }).api : undefined;
+  const toolAdjustment = applyToolCompatibilityAdjustment(pi, modelApi, ctx.ui.notify.bind(ctx.ui));
+
   const result = await ctx.newSession();
   if (result.cancelled) {
+    // Restore tools if session cancelled to prevent drift
+    if (toolAdjustment.priorTools) {
+      pi.setActiveTools(toolAdjustment.priorTools);
+    }
     ctx.ui.notify("Session creation cancelled.", "warning");
     return;
   }
@@ -253,4 +269,8 @@ export async function dispatchDirectPhase(
     { customType: "gsd-dispatch", content: prompt, display: false },
     { triggerTurn: true },
   );
+
+  // Note: tool restoration after dispatch completion is handled by the
+  // session lifecycle — direct dispatches create a new session, so the
+  // prior session's tool set is not affected.
 }

--- a/src/resources/extensions/gsd/auto-model-selection.ts
+++ b/src/resources/extensions/gsd/auto-model-selection.ts
@@ -74,8 +74,10 @@ export async function selectAndApplyModel(
   retryContext?: { isRetry: boolean; previousTier?: string },
 ): Promise<ModelSelectionResult> {
   // ADR-005 Phase 6: Apply provider capability overrides from preferences.
-  // This ensures user-specified capability overrides take effect before any routing decisions.
-  setProviderCapabilityOverrides(prefs?.provider_capabilities);
+  // Only update when prefs are available — preserve prior overrides when prefs are transiently undefined.
+  if (prefs) {
+    setProviderCapabilityOverrides(prefs.provider_capabilities);
+  }
 
   const modelConfig = resolvePreferredModelConfig(unitType, autoModeStartModel);
   let routing: { tier: string; modelDowngraded: boolean } | null = null;
@@ -143,7 +145,7 @@ export async function selectAndApplyModel(
         const requiredTools: ToolCompatibilityInfo[] = requiredToolNames
           .map(name => {
             const toolInfo = allToolInfos.find(t => t.name === name);
-            return toolInfo ? { name: toolInfo.name, compatibility: (toolInfo as any).compatibility } : { name };
+            return toolInfo ? { name: toolInfo.name, compatibility: toolInfo.compatibility } : { name };
           });
 
         const compatibleModelIds = filterModelsByToolCompatibility(
@@ -216,7 +218,9 @@ export async function selectAndApplyModel(
 
         // ADR-005: Adjust tool set for selected model's provider capabilities.
         // Save prior tools so caller can restore after dispatch (prevents session drift).
-        const modelApi = (model as any).api as string | undefined;
+        // Note: model objects from getAvailable() are Model<Api> with .api field,
+        // but resolveModelId's generic constraint only requires { id, provider }.
+        const modelApi = "api" in model ? (model as { api: string }).api : undefined;
         if (modelApi) {
           const priorToolNames = pi.getActiveTools();
           const providerCaps = getProviderCapabilities(modelApi);

--- a/src/resources/extensions/gsd/auto-model-selection.ts
+++ b/src/resources/extensions/gsd/auto-model-selection.ts
@@ -76,7 +76,12 @@ export async function selectAndApplyModel(
   // ADR-005 Phase 6: Apply provider capability overrides from preferences.
   // Only update when prefs are available — preserve prior overrides when prefs are transiently undefined.
   if (prefs) {
-    setProviderCapabilityOverrides(prefs.provider_capabilities);
+    const overrideWarnings = setProviderCapabilityOverrides(prefs.provider_capabilities);
+    if (verbose && overrideWarnings.length > 0) {
+      for (const warn of overrideWarnings) {
+        ctx.ui.notify(warn, "warning");
+      }
+    }
   }
 
   const modelConfig = resolvePreferredModelConfig(unitType, autoModeStartModel);

--- a/src/resources/extensions/gsd/auto-model-selection.ts
+++ b/src/resources/extensions/gsd/auto-model-selection.ts
@@ -305,6 +305,142 @@ export function adjustToolSet(
 }
 
 /**
+ * Apply tool compatibility adjustment for a provider and return prior tool state.
+ *
+ * Checks the current active tools against the provider's capabilities and
+ * removes incompatible tools. Returns the prior tool names so the caller
+ * can restore them after dispatch (prevents session drift).
+ *
+ * Used by all dispatch paths: auto-loop, direct dispatch, guided-flow, hooks.
+ */
+export function applyToolCompatibilityAdjustment(
+  pi: {
+    getActiveTools(): string[];
+    getAllTools(): Array<{ name: string; compatibility?: { producesImages?: boolean; schemaFeatures?: string[] }; priority?: number }>;
+    setActiveTools(toolNames: string[]): void;
+  },
+  modelApi: string | undefined,
+  notify?: (message: string, level: "info" | "warning") => void,
+): { priorTools?: string[] } {
+  if (!modelApi) return {};
+
+  const priorToolNames = pi.getActiveTools();
+  if (priorToolNames.length === 0) return {};
+
+  const activeToolNames = new Set(priorToolNames);
+  const activeTools = pi.getAllTools().filter((tool: { name: string }) => activeToolNames.has(tool.name));
+  const providerCaps = getProviderCapabilities(modelApi);
+  const adjusted = adjustToolSet(activeTools, providerCaps);
+  if (adjusted.length >= activeTools.length) return {};
+
+  pi.setActiveTools(adjusted.map((t: { name: string }) => t.name));
+  notify?.(`Tool adjustment: ${activeTools.length - adjusted.length} tool(s) filtered for ${modelApi}`, "info");
+  return { priorTools: priorToolNames };
+}
+
+// ─── Plan-Time Capability Validation (ADR-004/005) ──────────────────────────
+
+/** A capability gap detected during plan-time validation. */
+export interface CapabilityWarning {
+  taskId: string;
+  taskTitle: string;
+  capability: string;
+  detail: string;
+}
+
+// Keywords that signal a task needs image support
+const IMAGE_KEYWORDS = /\bscreenshot|image|diagram|visual|render|preview|capture|photo|png|jpg|svg\b/i;
+// File extensions that signal image involvement
+const IMAGE_EXTENSIONS = /\.(png|jpg|jpeg|gif|svg|webp|bmp|ico|avif)$/i;
+
+/**
+ * Validate that planned tasks can be executed by the available model pool.
+ *
+ * Checks each task's description and file list against provider capabilities
+ * to detect tasks that require capabilities no available model supports.
+ *
+ * Pure function — does not modify state. Returns warnings for unresolvable gaps.
+ *
+ * @param tasks     Task descriptions from the plan
+ * @param models    Available models with their API strings
+ * @returns Array of capability warnings (empty = no gaps detected)
+ */
+export function validatePlanCapabilities(
+  tasks: Array<{ taskId: string; title: string; description: string; files: string[] }>,
+  models: Array<{ id: string; api: string }>,
+): CapabilityWarning[] {
+  if (tasks.length === 0 || models.length === 0) return [];
+
+  // Build a set of capabilities ANY model in the pool supports
+  const poolCaps = {
+    imageToolResults: false,
+    structuredOutput: false,
+    toolCalling: false,
+  };
+  for (const model of models) {
+    const caps = getProviderCapabilities(model.api);
+    if (caps.imageToolResults) poolCaps.imageToolResults = true;
+    if (caps.structuredOutput) poolCaps.structuredOutput = true;
+    if (caps.toolCalling) poolCaps.toolCalling = true;
+  }
+
+  // If the pool supports everything, no warnings needed
+  if (poolCaps.imageToolResults && poolCaps.structuredOutput && poolCaps.toolCalling) {
+    return [];
+  }
+
+  const warnings: CapabilityWarning[] = [];
+
+  for (const task of tasks) {
+    const text = `${task.title} ${task.description}`;
+    const hasImageFiles = task.files.some(f => IMAGE_EXTENSIONS.test(f));
+
+    // Check: task needs image support but no model provides it
+    if (!poolCaps.imageToolResults && (IMAGE_KEYWORDS.test(text) || hasImageFiles)) {
+      warnings.push({
+        taskId: task.taskId,
+        taskTitle: task.title,
+        capability: "imageToolResults",
+        detail: hasImageFiles
+          ? `Task references image files (${task.files.filter(f => IMAGE_EXTENSIONS.test(f)).join(", ")}) but no available model supports image tool results.`
+          : "Task description suggests image/screenshot work but no available model supports image tool results.",
+      });
+    }
+
+    // Check: no model supports tool calling at all (rare but possible with local models)
+    if (!poolCaps.toolCalling) {
+      warnings.push({
+        taskId: task.taskId,
+        taskTitle: task.title,
+        capability: "toolCalling",
+        detail: "No available model supports tool calling. Task execution requires tool use.",
+      });
+    }
+  }
+
+  return warnings;
+}
+
+/**
+ * Format capability warnings for display in plan output or notifications.
+ */
+export function formatCapabilityWarnings(warnings: CapabilityWarning[]): string {
+  if (warnings.length === 0) return "";
+  const lines = warnings.map(w =>
+    `- **${w.taskId}** (${w.taskTitle}): ${w.capability} — ${w.detail}`,
+  );
+  return [
+    "## Capability Warnings",
+    "",
+    "The following tasks may not execute correctly with the current model pool:",
+    "",
+    ...lines,
+    "",
+    "Consider configuring a model that supports these capabilities, or restructure tasks to avoid the dependency.",
+  ].join("\n");
+}
+
+/**
  * Resolve a model ID string to a model object from the available models list.
  * Handles formats: "provider/model", "bare-id", "org/model-name" (OpenRouter).
  */

--- a/src/resources/extensions/gsd/auto-model-selection.ts
+++ b/src/resources/extensions/gsd/auto-model-selection.ts
@@ -237,7 +237,7 @@ export async function selectAndApplyModel(
               const removed = allTools.length - adjusted.length;
               ctx.ui.notify(`Tool adjustment: ${removed} tool(s) filtered for ${modelApi}`, "info");
             }
-            return { routing, priorTools: priorToolNames };
+            return { routing, appliedModel: model as unknown as Model<Api>, priorTools: priorToolNames };
           }
         }
 

--- a/src/resources/extensions/gsd/auto-model-selection.ts
+++ b/src/resources/extensions/gsd/auto-model-selection.ts
@@ -19,7 +19,7 @@ import {
 } from "./model-router.js";
 import { getLedger, getProjectTotals } from "./metrics.js";
 import { unitPhaseLabel } from "./auto-dashboard.js";
-import { getProviderCapabilities, type ProviderCapabilities } from "@gsd/pi-ai";
+import { getProviderCapabilities, setProviderCapabilityOverrides, type ProviderCapabilities } from "@gsd/pi-ai";
 import { isToolCompatibleWithProvider } from "./model-router.js";
 
 export interface ModelSelectionResult {
@@ -73,6 +73,10 @@ export async function selectAndApplyModel(
   autoModeStartModel: { provider: string; id: string } | null,
   retryContext?: { isRetry: boolean; previousTier?: string },
 ): Promise<ModelSelectionResult> {
+  // ADR-005 Phase 6: Apply provider capability overrides from preferences.
+  // This ensures user-specified capability overrides take effect before any routing decisions.
+  setProviderCapabilityOverrides(prefs?.provider_capabilities);
+
   const modelConfig = resolvePreferredModelConfig(unitType, autoModeStartModel);
   let routing: { tier: string; modelDowngraded: boolean } | null = null;
   let appliedModel: Model<Api> | null = null;

--- a/src/resources/extensions/gsd/auto-model-selection.ts
+++ b/src/resources/extensions/gsd/auto-model-selection.ts
@@ -10,15 +10,29 @@ import type { GSDPreferences } from "./preferences.js";
 import { resolveModelWithFallbacksForUnit, resolveDynamicRoutingConfig } from "./preferences.js";
 import type { ComplexityTier } from "./complexity-classifier.js";
 import { classifyUnitComplexity, tierLabel, extractTaskMetadata } from "./complexity-classifier.js";
-import { resolveModelForComplexity, escalateTier } from "./model-router.js";
+import {
+  resolveModelForComplexity,
+  escalateTier,
+  getRequiredToolNames,
+  filterModelsByToolCompatibility,
+  type ToolCompatibilityInfo,
+} from "./model-router.js";
 import { getLedger, getProjectTotals } from "./metrics.js";
 import { unitPhaseLabel } from "./auto-dashboard.js";
+import { getProviderCapabilities, type ProviderCapabilities } from "@gsd/pi-ai";
+import { isToolCompatibleWithProvider } from "./model-router.js";
 
 export interface ModelSelectionResult {
   /** Routing metadata for metrics recording */
   routing: { tier: string; modelDowngraded: boolean } | null;
   /** Concrete model applied before dispatch so it can be restored after a fresh session. */
   appliedModel: Model<Api> | null;
+  /**
+   * Prior active tools saved before adjustToolSet filtering.
+   * Caller MUST restore these in a finally block after dispatch to prevent session drift.
+   * Undefined when no tool adjustment was applied.
+   */
+  priorTools?: string[];
 }
 
 export function resolvePreferredModelConfig(
@@ -112,8 +126,38 @@ export async function selectAndApplyModel(
           ? extractTaskMetadata(unitId, basePath)
           : undefined;
 
+        // ADR-005 Step 2: Filter models by tool compatibility BEFORE scoring.
+        // Build a lookup from model ID → API string for the compatibility filter.
+        const modelApiLookup: Record<string, string> = {};
+        for (const m of availableModels) {
+          modelApiLookup[m.id] = m.api;
+        }
+
+        // Get required tools for this unit type, enriched with compatibility metadata
+        const requiredToolNames = getRequiredToolNames(unitType);
+        const allToolInfos = pi.getAllTools();
+        const requiredTools: ToolCompatibilityInfo[] = requiredToolNames
+          .map(name => {
+            const toolInfo = allToolInfos.find(t => t.name === name);
+            return toolInfo ? { name: toolInfo.name, compatibility: (toolInfo as any).compatibility } : { name };
+          });
+
+        const compatibleModelIds = filterModelsByToolCompatibility(
+          availableModelIds,
+          requiredTools,
+          modelApiLookup,
+        );
+
+        if (verbose && compatibleModelIds.length < availableModelIds.length) {
+          const filtered = availableModelIds.length - compatibleModelIds.length;
+          ctx.ui.notify(
+            `Tool compatibility: filtered ${filtered} model(s) incompatible with ${unitType} tools`,
+            "info",
+          );
+        }
+
         const routingResult = resolveModelForComplexity(
-          classification, modelConfig, routingConfig, availableModelIds,
+          classification, modelConfig, routingConfig, compatibleModelIds,
           unitType, taskMeta,
         );
 
@@ -165,6 +209,25 @@ export async function selectAndApplyModel(
           : ` (fallback from ${effectiveModelConfig.primary})`;
         const phase = unitPhaseLabel(unitType);
         ctx.ui.notify(`Model [${phase}]${routingTierLabel}: ${model.provider}/${model.id}${fallbackNote}`, "info");
+
+        // ADR-005: Adjust tool set for selected model's provider capabilities.
+        // Save prior tools so caller can restore after dispatch (prevents session drift).
+        const modelApi = (model as any).api as string | undefined;
+        if (modelApi) {
+          const priorToolNames = pi.getActiveTools();
+          const providerCaps = getProviderCapabilities(modelApi);
+          const allTools = pi.getAllTools();
+          const adjusted = adjustToolSet(allTools, providerCaps);
+          if (adjusted.length < allTools.length) {
+            pi.setActiveTools(adjusted.map(t => t.name));
+            if (verbose) {
+              const removed = allTools.length - adjusted.length;
+              ctx.ui.notify(`Tool adjustment: ${removed} tool(s) filtered for ${modelApi}`, "info");
+            }
+            return { routing, priorTools: priorToolNames };
+          }
+        }
+
         break;
       } else {
         const nextModel = modelsToTry[modelsToTry.indexOf(modelId) + 1];
@@ -197,6 +260,35 @@ export async function selectAndApplyModel(
   }
 
   return { routing, appliedModel };
+}
+
+/**
+ * Filter the active tool set based on provider capabilities.
+ * Pure function — does not call pi API, returns filtered tool list.
+ *
+ * - Tools without compatibility metadata always pass (fail-open)
+ * - Tools with producesImages that the provider can't handle are removed
+ * - Tools with unsupported schema features are removed
+ * - If maxTools exceeded, lowest-priority tools are pruned
+ */
+export function adjustToolSet(
+  registeredTools: Array<{ name: string; compatibility?: { producesImages?: boolean; schemaFeatures?: string[] }; priority?: number }>,
+  providerCaps: ProviderCapabilities,
+): Array<{ name: string; compatibility?: { producesImages?: boolean; schemaFeatures?: string[] }; priority?: number }> {
+  let filtered = registeredTools.filter(tool => {
+    return isToolCompatibleWithProvider(
+      { name: tool.name, compatibility: tool.compatibility as any },
+      providerCaps,
+    );
+  });
+
+  // Prune if exceeding maxTools (0 = unlimited)
+  if (providerCaps.maxTools > 0 && filtered.length > providerCaps.maxTools) {
+    filtered.sort((a, b) => (b.priority ?? 1) - (a.priority ?? 1));
+    filtered = filtered.slice(0, providerCaps.maxTools);
+  }
+
+  return filtered;
 }
 
 /**

--- a/src/resources/extensions/gsd/auto-prompts.ts
+++ b/src/resources/extensions/gsd/auto-prompts.ts
@@ -66,6 +66,55 @@ function formatExecutorConstraints(): string {
   ].join("\n");
 }
 
+// ─── Capability Constraints (ADR-004/005) ───────────────────────────────────
+
+/**
+ * Format model pool capability constraints for injection into plan prompts.
+ * Informs the planner about what the execution model pool can/can't do,
+ * so it avoids creating tasks that require unsupported capabilities.
+ */
+function formatCapabilityConstraints(): string {
+  try {
+    const prefs = loadEffectiveGSDPreferences()?.preferences;
+    const gaps: string[] = [];
+
+    // Check if override preferences explicitly set limitations
+    if (prefs?.provider_capabilities) {
+      for (const [api, overrides] of Object.entries(prefs.provider_capabilities)) {
+        const castOverrides = overrides as Record<string, unknown>;
+        if (castOverrides.imageToolResults === false) {
+          gaps.push(`Provider \`${api}\` does not support image tool results — avoid tasks requiring screenshots or image processing.`);
+        }
+      }
+    }
+
+    // Always inform about known cross-provider limitations
+    const constraints = [
+      "## Model Capability Constraints",
+      "",
+      "When planning tasks, be aware of these execution model limitations:",
+      "- **Image tool results:** OpenAI, Mistral, and Bedrock providers do NOT support image content in tool results. Do not plan tasks that depend on screenshot capture or image analysis unless the execution model is Anthropic or Google.",
+      "- **Schema features:** Google/Gemini providers do not support `patternProperties` in tool schemas.",
+      "- **Thinking persistence:** OpenAI preserves thinking as text-only; Mistral has no thinking support.",
+    ];
+
+    if (gaps.length > 0) {
+      constraints.push("");
+      constraints.push("**Active capability restrictions for this project:**");
+      for (const gap of gaps) {
+        constraints.push(`- ${gap}`);
+      }
+    }
+
+    constraints.push("");
+    constraints.push("Design tasks to work within these constraints. If a task requires capabilities that may not be available, note the requirement explicitly in the task description.");
+
+    return constraints.join("\n");
+  } catch {
+    return ""; // Fail-open: if capability detection fails, don't block planning
+  }
+}
+
 function buildSourceFilePaths(
   base: string,
   mid: string,
@@ -1070,6 +1119,13 @@ export async function buildPlanSlicePrompt(
   // Build executor context constraints from the budget engine
   const executorContextConstraints = formatExecutorConstraints();
 
+  // ADR-004/005: Inject capability constraints so the planner avoids
+  // creating tasks that the model pool cannot execute.
+  const capabilityConstraints = formatCapabilityConstraints();
+  const combinedConstraints = capabilityConstraints
+    ? `${executorContextConstraints}\n\n${capabilityConstraints}`
+    : executorContextConstraints;
+
   const outputRelPath = relSliceFile(base, mid, sid, "PLAN");
   const commitInstruction = "Do not commit — .gsd/ planning docs are managed externally and not tracked in git.";
   return loadPrompt("plan-slice", {
@@ -1082,7 +1138,7 @@ export async function buildPlanSlicePrompt(
     inlinedContext,
     dependencySummaries: depContent,
     sourceFilePaths: buildSourceFilePaths(base, mid, sid),
-    executorContextConstraints,
+    executorContextConstraints: combinedConstraints,
     commitInstruction,
     skillActivation: buildSkillActivationBlock({
       base,

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -78,7 +78,8 @@ import {
 } from "./auto-tool-tracking.js";
 import { closeoutUnit } from "./auto-unit-closeout.js";
 import { recoverTimedOutUnit } from "./auto-timeout-recovery.js";
-import { selectAndApplyModel, resolveModelId } from "./auto-model-selection.js";
+import { selectAndApplyModel, resolveModelId, applyToolCompatibilityAdjustment } from "./auto-model-selection.js";
+import { setProviderCapabilityOverrides } from "@gsd/pi-ai";
 import { resetRoutingHistory, recordOutcome } from "./routing-history.js";
 import {
   checkPostUnitHooks,
@@ -1426,6 +1427,17 @@ export async function dispatchHookUnit(
       );
     }
   }
+
+  // ADR-005: Apply capability overrides and tool filtering for hook dispatch.
+  // Previously hooks ran with zero capability validation.
+  const hookPrefs = loadEffectiveGSDPreferences()?.preferences;
+  if (hookPrefs) {
+    setProviderCapabilityOverrides(hookPrefs.provider_capabilities);
+  }
+  const hookModelApi = ctx.model && "api" in ctx.model ? (ctx.model as { api: string }).api : undefined;
+  const hookToolAdjustment = applyToolCompatibilityAdjustment(
+    pi, hookModelApi, ctx.ui.notify.bind(ctx.ui),
+  );
 
   const sessionFile = ctx.sessionManager.getSessionFile();
   writeLock(

--- a/src/resources/extensions/gsd/auto/loop-deps.ts
+++ b/src/resources/extensions/gsd/auto/loop-deps.ts
@@ -5,6 +5,7 @@
  */
 
 import type { ExtensionAPI, ExtensionContext } from "@gsd/pi-coding-agent";
+import type { ProviderSwitchReport } from "@gsd/pi-ai";
 
 import type { AutoSession } from "./session.js";
 import type { GSDPreferences } from "../preferences.js";
@@ -179,7 +180,7 @@ export interface LoopDeps {
     startedAt: number,
     opts?: CloseoutOptions & Record<string, unknown>,
   ) => Promise<void>;
-  recordOutcome: (unitType: string, tier: string, success: boolean) => void;
+  recordOutcome: (unitType: string, tier: string, success: boolean, tags?: string[], switchReport?: ProviderSwitchReport) => void;
   writeLock: (
     lockBase: string,
     unitType: string,

--- a/src/resources/extensions/gsd/auto/loop-deps.ts
+++ b/src/resources/extensions/gsd/auto/loop-deps.ts
@@ -213,6 +213,7 @@ export interface LoopDeps {
   ) => Promise<{
     routing: { tier: string; modelDowngraded: boolean } | null;
     appliedModel: { provider: string; id: string } | null;
+    priorTools?: string[];
   }>;
   resolveModelId: <T extends { id: string; provider: string }>(
     modelId: string,

--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -993,6 +993,9 @@ export async function runUnitPhase(
   s.currentUnitModel =
     modelResult.appliedModel as AutoSession["currentUnitModel"];
 
+  // ADR-005: Capture prior tools for restore after dispatch (prevents session drift).
+  const priorTools = modelResult.priorTools;
+
   // Status bar + progress widget
   ctx.ui.setStatus("gsd-auto", "auto");
   if (mid)
@@ -1123,14 +1126,23 @@ export async function runUnitPhase(
     unitType,
     unitId,
   });
-  const unitResult = await runUnit(
-    ctx,
-    pi,
-    s,
-    unitType,
-    unitId,
-    finalPrompt,
-  );
+  let unitResult;
+  try {
+    unitResult = await runUnit(
+      ctx,
+      pi,
+      s,
+      unitType,
+      unitId,
+      finalPrompt,
+    );
+  } finally {
+    // ADR-005: Restore prior tool set after dispatch to prevent session drift.
+    // Must be in finally to handle both success and error paths.
+    if (priorTools) {
+      pi.setActiveTools(priorTools);
+    }
+  }
   debugLog("autoLoop", {
     phase: "runUnit-end",
     iteration: ic.iteration,

--- a/src/resources/extensions/gsd/docs/preferences-reference.md
+++ b/src/resources/extensions/gsd/docs/preferences-reference.md
@@ -197,6 +197,14 @@ Setting `prefer_skills: []` does **not** disable skill discovery — it just mea
   - `compaction_threshold_percent`: number — trigger compaction at this % of context window (0.5-0.95). Lower values fire compaction earlier, reducing drift. Default: `0.70`.
   - `tool_result_max_chars`: number — max chars per tool result in GSD sessions (200-10000). Default: `800`.
 
+- `provider_capabilities`: object — override built-in provider capability profiles (ADR-005). Keys are API protocol strings (e.g., `"openai-responses"`), NOT provider short names (e.g., `"openai"`). Values are partial `ProviderCapabilities` objects — only specified fields are overridden, others keep built-in defaults.
+  - `toolCalling`: boolean — whether the provider supports tool calling.
+  - `maxTools`: number — max tools the provider handles well (0 = unlimited).
+  - `imageToolResults`: boolean — whether tool results can contain images.
+  - `structuredOutput`: boolean — whether the provider supports structured JSON output.
+  - `thinkingPersistence`: `"full"`, `"text-only"`, or `"none"` — thinking block preservation.
+  - `unsupportedSchemaFeatures`: string[] — schema features NOT supported (e.g., `["patternProperties"]`).
+
 - `auto_visualize`: boolean — show a visualizer hint after each milestone completion in auto-mode. Default: `false`.
 
 - `auto_report`: boolean — generate an HTML report snapshot after each milestone completion. Default: `true`.

--- a/src/resources/extensions/gsd/guided-flow.ts
+++ b/src/resources/extensions/gsd/guided-flow.ts
@@ -38,7 +38,9 @@ import { showConfirm } from "../shared/tui.js";
 import { debugLog } from "./debug-logger.js";
 import { findMilestoneIds, nextMilestoneId, reserveMilestoneId, getReservedMilestoneIds, clearReservedMilestoneIds } from "./milestone-ids.js";
 import { parkMilestone, discardMilestone } from "./milestone-actions.js";
-import { selectAndApplyModel } from "./auto-model-selection.js";
+import { selectAndApplyModel, applyToolCompatibilityAdjustment } from "./auto-model-selection.js";
+import { resolveModelWithFallbacksForUnit } from "./preferences-models.js";
+import { setProviderCapabilityOverrides } from "@gsd/pi-ai";
 
 // ─── Re-exports (preserve public API for existing importers) ────────────────
 export {
@@ -286,6 +288,15 @@ async function dispatchWorkflow(
         routing: result.routing,
       });
     }
+
+    // ADR-005: Apply capability overrides and tool filtering for guided-flow dispatch.
+    // Previously this path set the model but never filtered incompatible tools.
+    const prefs = loadEffectiveGSDPreferences()?.preferences;
+    if (prefs) {
+      setProviderCapabilityOverrides(prefs.provider_capabilities);
+    }
+    const modelApi = ctx.model && "api" in ctx.model ? (ctx.model as { api: string }).api : undefined;
+    applyToolCompatibilityAdjustment(pi, modelApi, ctx.ui.notify.bind(ctx.ui));
   }
 
   const workflowPath = process.env.GSD_WORKFLOW_PATH ?? join(process.env.HOME ?? "~", ".gsd", "agent", "GSD-WORKFLOW.md");

--- a/src/resources/extensions/gsd/guided-flow.ts
+++ b/src/resources/extensions/gsd/guided-flow.ts
@@ -39,7 +39,6 @@ import { debugLog } from "./debug-logger.js";
 import { findMilestoneIds, nextMilestoneId, reserveMilestoneId, getReservedMilestoneIds, clearReservedMilestoneIds } from "./milestone-ids.js";
 import { parkMilestone, discardMilestone } from "./milestone-actions.js";
 import { selectAndApplyModel, applyToolCompatibilityAdjustment } from "./auto-model-selection.js";
-import { resolveModelWithFallbacksForUnit } from "./preferences-models.js";
 import { setProviderCapabilityOverrides } from "@gsd/pi-ai";
 
 // ─── Re-exports (preserve public API for existing importers) ────────────────
@@ -291,7 +290,6 @@ async function dispatchWorkflow(
 
     // ADR-005: Apply capability overrides and tool filtering for guided-flow dispatch.
     // Previously this path set the model but never filtered incompatible tools.
-    const prefs = loadEffectiveGSDPreferences()?.preferences;
     if (prefs) {
       setProviderCapabilityOverrides(prefs.provider_capabilities);
     }

--- a/src/resources/extensions/gsd/model-router.ts
+++ b/src/resources/extensions/gsd/model-router.ts
@@ -490,21 +490,61 @@ export interface ToolCompatibilityInfo {
 
 // Hoisted constants to avoid per-call array allocation
 const EXECUTE_REQUIRED_TOOLS: readonly string[] = ["Bash", "Read", "Write", "Edit"];
-const RESEARCH_REQUIRED_TOOLS: readonly string[] = ["Read"];
+const RESEARCH_REQUIRED_TOOLS: readonly string[] = ["Read", "WebSearch", "WebFetch"];
+const PLAN_REQUIRED_TOOLS: readonly string[] = ["Read", "Write"];
+const UAT_REQUIRED_TOOLS: readonly string[] = ["Read", "Bash"];
+const COMPLETION_REQUIRED_TOOLS: readonly string[] = ["Read", "Write"];
 const NO_REQUIRED_TOOLS: readonly string[] = [];
 
 /**
  * Maps unit types to the tool names they require.
+ * Used by filterModelsByToolCompatibility() (ADR-005 Step 2) to exclude
+ * models whose provider cannot support the tools a unit type needs.
+ *
  * Units with no required tools get an empty array (no filtering applied).
  */
 export function getRequiredToolNames(unitType: string): readonly string[] {
-  if (unitType === "execute-task" || unitType === "execute-plan") {
-    return EXECUTE_REQUIRED_TOOLS;
+  switch (unitType) {
+    // Execution phases — need full code editing capabilities
+    case "execute-task":
+    case "execute-plan":
+    case "reactive-execute":
+    case "rewrite-docs":
+      return EXECUTE_REQUIRED_TOOLS;
+
+    // Research phases — need web search and file reading
+    case "research-milestone":
+    case "research-slice":
+      return RESEARCH_REQUIRED_TOOLS;
+
+    // Planning phases — read context, write plans
+    case "plan-milestone":
+    case "plan-slice":
+    case "replan-slice":
+      return PLAN_REQUIRED_TOOLS;
+
+    // UAT/verification — read artifacts, run commands
+    case "run-uat":
+      return UAT_REQUIRED_TOOLS;
+
+    // Completion phases — read summaries, write closeout docs
+    case "complete-slice":
+    case "complete-milestone":
+    case "validate-milestone":
+      return COMPLETION_REQUIRED_TOOLS;
+
+    // Reassessment — reads roadmap and slices, writes assessment
+    case "reassess-roadmap":
+      return COMPLETION_REQUIRED_TOOLS;
+
+    // Gate evaluation — lightweight judgment, minimal tool use
+    case "gate-evaluate":
+      return NO_REQUIRED_TOOLS;
+
+    default:
+      // Hooks (hook/*), discuss-*, and unknown unit types — no filtering (fail-open)
+      return NO_REQUIRED_TOOLS;
   }
-  if (unitType === "research-milestone" || unitType === "research-slice") {
-    return RESEARCH_REQUIRED_TOOLS;
-  }
-  return NO_REQUIRED_TOOLS;
 }
 
 /**

--- a/src/resources/extensions/gsd/model-router.ts
+++ b/src/resources/extensions/gsd/model-router.ts
@@ -488,21 +488,23 @@ export interface ToolCompatibilityInfo {
   compatibility?: ToolCompatibility;
 }
 
+// Hoisted constants to avoid per-call array allocation
+const EXECUTE_REQUIRED_TOOLS: readonly string[] = ["Bash", "Read", "Write", "Edit"];
+const RESEARCH_REQUIRED_TOOLS: readonly string[] = ["Read"];
+const NO_REQUIRED_TOOLS: readonly string[] = [];
+
 /**
  * Maps unit types to the tool names they require.
  * Units with no required tools get an empty array (no filtering applied).
  */
-export function getRequiredToolNames(unitType: string): string[] {
-  // Execute tasks need full tool access
+export function getRequiredToolNames(unitType: string): readonly string[] {
   if (unitType === "execute-task" || unitType === "execute-plan") {
-    return ["Bash", "Read", "Write", "Edit"];
+    return EXECUTE_REQUIRED_TOOLS;
   }
-  // Research units need read access
   if (unitType === "research-milestone" || unitType === "research-slice") {
-    return ["Read"];
+    return RESEARCH_REQUIRED_TOOLS;
   }
-  // All other unit types have no hard tool requirements
-  return [];
+  return NO_REQUIRED_TOOLS;
 }
 
 /**

--- a/src/resources/extensions/gsd/model-router.ts
+++ b/src/resources/extensions/gsd/model-router.ts
@@ -1,10 +1,13 @@
 // GSD Extension — Dynamic Model Router
 // Maps complexity tiers to models, enforcing downgrade-only semantics.
 // The user's configured model is always the ceiling.
+// Copyright (c) 2026 Jeremy McSpadden <jeremy@fluxlabs.net>
 
 import type { ComplexityTier, ClassificationResult } from "./complexity-classifier.js";
 import { tierOrdinal } from "./complexity-classifier.js";
 import type { ResolvedModelConfig } from "./preferences.js";
+import { getProviderCapabilities, type ProviderCapabilities } from "@gsd/pi-ai";
+import type { ToolCompatibility } from "@gsd/pi-coding-agent";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -475,4 +478,86 @@ function getModelCost(modelId: string): number {
 
   // Unknown cost — assume expensive to avoid routing to unknown cheap models
   return 999;
+}
+
+// ─── Tool-Compatibility Filter (ADR-005 Step 2) ────────────────────────────
+
+/** Lightweight tool info for compatibility filtering (avoids importing full ToolDefinition) */
+export interface ToolCompatibilityInfo {
+  name: string;
+  compatibility?: ToolCompatibility;
+}
+
+/**
+ * Maps unit types to the tool names they require.
+ * Units with no required tools get an empty array (no filtering applied).
+ */
+export function getRequiredToolNames(unitType: string): string[] {
+  // Execute tasks need full tool access
+  if (unitType === "execute-task" || unitType === "execute-plan") {
+    return ["Bash", "Read", "Write", "Edit"];
+  }
+  // Research units need read access
+  if (unitType === "research-milestone" || unitType === "research-slice") {
+    return ["Read"];
+  }
+  // All other unit types have no hard tool requirements
+  return [];
+}
+
+/**
+ * Check if a single tool is compatible with a provider's capabilities.
+ *
+ * Tools without compatibility metadata are ALWAYS compatible (fail-open).
+ * This is a critical invariant — see ADR-005 Pitfall 6.
+ */
+export function isToolCompatibleWithProvider(
+  tool: ToolCompatibilityInfo,
+  providerCaps: ProviderCapabilities,
+): boolean {
+  const compat = tool.compatibility;
+  if (!compat) return true; // No metadata = universally compatible
+
+  // Hard filter: provider doesn't support image tool results
+  if (compat.producesImages && !providerCaps.imageToolResults) return false;
+
+  // Hard filter: tool uses schema features the provider doesn't support
+  if (compat.schemaFeatures?.some(f => providerCaps.unsupportedSchemaFeatures.includes(f))) {
+    return false;
+  }
+
+  return true;
+}
+
+/**
+ * Filter model IDs to only those whose provider can support all required tools.
+ *
+ * @param modelIds       Candidate model IDs (already tier-filtered)
+ * @param requiredTools  Tools the unit type needs (from getRequiredToolNames + tool registry)
+ * @param modelApiLookup Map from model ID to its API string (for registry lookup)
+ * @returns Filtered model IDs, or the original list if filter would remove ALL models (fail-open)
+ */
+export function filterModelsByToolCompatibility(
+  modelIds: string[],
+  requiredTools: ToolCompatibilityInfo[],
+  modelApiLookup: Record<string, string>,
+): string[] {
+  // No required tools with compatibility metadata = no filtering needed
+  if (requiredTools.length === 0) return modelIds;
+
+  // Only filter based on tools that actually have compatibility metadata
+  const toolsWithMetadata = requiredTools.filter(t => t.compatibility);
+  if (toolsWithMetadata.length === 0) return modelIds;
+
+  const filtered = modelIds.filter(modelId => {
+    const api = modelApiLookup[modelId];
+    if (!api) return true; // Unknown model API = pass through (fail-open)
+    const caps = getProviderCapabilities(api);
+    return toolsWithMetadata.every(tool => isToolCompatibleWithProvider(tool, caps));
+  });
+
+  // If filter removed ALL models, return original set (fail-open at set level)
+  if (filtered.length === 0) return modelIds;
+
+  return filtered;
 }

--- a/src/resources/extensions/gsd/preferences-types.ts
+++ b/src/resources/extensions/gsd/preferences-types.ts
@@ -103,6 +103,7 @@ export const KNOWN_PREFERENCE_KEYS = new Set<string>([
   "stale_commit_threshold_minutes",
   "context_management",
   "experimental",
+  "provider_capabilities",
 ]);
 
 /** Canonical list of all dispatch unit types. */
@@ -275,6 +276,20 @@ export interface GSDPreferences {
    * See the preferences reference for details on each feature.
    */
   experimental?: ExperimentalPreferences;
+  /**
+   * Provider capability overrides (ADR-005). Deep-merged with built-in defaults.
+   * Keys are API protocol strings (e.g., "openai-responses"), NOT provider short names.
+   *
+   * Example:
+   * ```yaml
+   * provider_capabilities:
+   *   openai-responses:
+   *     imageToolResults: true
+   *   my-custom-api:
+   *     toolCalling: false
+   * ```
+   */
+  provider_capabilities?: Record<string, Record<string, unknown>>;
 }
 
 export interface LoadedGSDPreferences {

--- a/src/resources/extensions/gsd/provider-error-pause.ts
+++ b/src/resources/extensions/gsd/provider-error-pause.ts
@@ -3,6 +3,63 @@ export type ProviderErrorPauseUI = {
 };
 
 /**
+ * Classify a provider error as transient (auto-resume) or permanent (manual resume).
+ *
+ * Transient: rate limits, server errors (500/502/503), overloaded, internal errors.
+ * These are expected to self-resolve and should auto-resume after a delay.
+ *
+ * Permanent: auth errors, invalid API key, billing issues.
+ * These require user intervention and should pause indefinitely.
+ */
+export function classifyProviderError(errorMsg: string): {
+  isTransient: boolean;
+  isRateLimit: boolean;
+  suggestedDelayMs: number;
+} {
+  const isRateLimit = /rate.?limit|too many requests|429/i.test(errorMsg);
+  const isServerError = /internal server error|500|502|503|overloaded|server_error|api_error|service.?unavailable/i.test(errorMsg);
+
+  // Connection/process errors — transient, auto-resume after brief backoff (#2309).
+  // These indicate the process was killed, the connection was reset, or a network
+  // blip occurred. They are NOT permanent failures.
+  const isConnectionError = /terminated|connection.?reset|connection.?refused|other side closed|fetch failed|network.?(?:is\s+)?unavailable|ECONNREFUSED|ECONNRESET|EPIPE|stream_exhausted(?:_without_result)?/i.test(errorMsg);
+
+  // Permanent errors — never auto-resume
+  const isPermanent = /auth|unauthorized|forbidden|invalid.*key|invalid.*api|billing|quota exceeded|account/i.test(errorMsg);
+
+  if (isPermanent && !isRateLimit) {
+    return { isTransient: false, isRateLimit: false, suggestedDelayMs: 0 };
+  }
+
+  if (isRateLimit) {
+    // Try to extract retry-after from the message
+    const resetMatch = errorMsg.match(/reset in (\d+)s/i);
+    const delayMs = resetMatch ? Number(resetMatch[1]) * 1000 : 60_000; // default 60s for rate limits
+    return { isTransient: true, isRateLimit: true, suggestedDelayMs: delayMs };
+  }
+
+  if (isServerError) {
+    return { isTransient: true, isRateLimit: false, suggestedDelayMs: 30_000 }; // 30s for server errors
+  }
+
+  if (isConnectionError) {
+    return { isTransient: true, isRateLimit: false, suggestedDelayMs: 15_000 }; // 15s for connection errors
+  }
+
+  // Stream-truncation JSON parse errors — transient (#2572).
+  // When the API stream is cut mid-chunk, pi tries to reassemble the partial
+  // tool-call JSON and gets a SyntaxError. This is the downstream symptom of
+  // a connection drop — same root cause as ECONNRESET, one layer up.
+  const isMalformedStream = /Unexpected end of JSON|Unexpected token.*JSON|Expected double-quoted property name|SyntaxError.*JSON/i.test(errorMsg);
+  if (isMalformedStream) {
+    return { isTransient: true, isRateLimit: false, suggestedDelayMs: 15_000 }; // 15s, same as connection errors
+  }
+
+  // Unknown error — treat as permanent (user reviews)
+  return { isTransient: false, isRateLimit: false, suggestedDelayMs: 0 };
+}
+
+/**
  * Pause auto-mode due to a provider error.
  *
  * For transient errors (rate limits, server errors, overloaded), schedules

--- a/src/resources/extensions/gsd/routing-history.ts
+++ b/src/resources/extensions/gsd/routing-history.ts
@@ -1,11 +1,13 @@
 // GSD Extension — Routing History (Adaptive Learning)
 // Tracks success/failure per tier per unit-type pattern to improve
 // classification accuracy over time.
+// Copyright (c) 2026 Jeremy McSpadden <jeremy@fluxlabs.net>
 
 import { join } from "node:path";
 import { gsdRoot } from "./paths.js";
 import type { ComplexityTier } from "./types.js";
 import { loadJsonFile, saveJsonFile } from "./json-persistence.js";
+import type { ProviderSwitchReport } from "@gsd/pi-ai";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -26,8 +28,16 @@ export interface RoutingHistoryData {
   patterns: Record<string, PatternHistory>;
   /** User feedback entries (from /gsd:rate-unit) */
   feedback: FeedbackEntry[];
+  /** Recent provider switch reports (ADR-005) */
+  switchReports?: ProviderSwitchReportEntry[];
   /** Last updated timestamp */
   updatedAt: string;
+}
+
+export interface ProviderSwitchReportEntry {
+  unitType: string;
+  report: ProviderSwitchReport;
+  timestamp: string;
 }
 
 export interface FeedbackEntry {
@@ -81,6 +91,7 @@ export function recordOutcome(
   tier: ComplexityTier,
   success: boolean,
   tags?: string[],
+  switchReport?: ProviderSwitchReport,
 ): void {
   if (!history) return;
 
@@ -112,6 +123,20 @@ export function recordOutcome(
         p[t].success = Math.round(p[t].success * scale);
         p[t].fail = Math.round(p[t].fail * scale);
       }
+    }
+  }
+
+  // Store provider switch report if present (ADR-005)
+  if (switchReport) {
+    if (!history.switchReports) history.switchReports = [];
+    history.switchReports.push({
+      unitType,
+      report: switchReport,
+      timestamp: new Date().toISOString(),
+    });
+    // Cap at 50 entries
+    if (history.switchReports.length > 50) {
+      history.switchReports = history.switchReports.slice(-50);
     }
   }
 

--- a/src/resources/extensions/gsd/routing-history.ts
+++ b/src/resources/extensions/gsd/routing-history.ts
@@ -7,7 +7,6 @@ import { join } from "node:path";
 import { gsdRoot } from "./paths.js";
 import type { ComplexityTier } from "./types.js";
 import { loadJsonFile, saveJsonFile } from "./json-persistence.js";
-import type { ProviderSwitchReport } from "@gsd/pi-ai";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -28,16 +27,8 @@ export interface RoutingHistoryData {
   patterns: Record<string, PatternHistory>;
   /** User feedback entries (from /gsd:rate-unit) */
   feedback: FeedbackEntry[];
-  /** Recent provider switch reports (ADR-005) */
-  switchReports?: ProviderSwitchReportEntry[];
   /** Last updated timestamp */
   updatedAt: string;
-}
-
-export interface ProviderSwitchReportEntry {
-  unitType: string;
-  report: ProviderSwitchReport;
-  timestamp: string;
 }
 
 export interface FeedbackEntry {
@@ -91,7 +82,6 @@ export function recordOutcome(
   tier: ComplexityTier,
   success: boolean,
   tags?: string[],
-  switchReport?: ProviderSwitchReport,
 ): void {
   if (!history) return;
 
@@ -123,20 +113,6 @@ export function recordOutcome(
         p[t].success = Math.round(p[t].success * scale);
         p[t].fail = Math.round(p[t].fail * scale);
       }
-    }
-  }
-
-  // Store provider switch report if present (ADR-005)
-  if (switchReport) {
-    if (!history.switchReports) history.switchReports = [];
-    history.switchReports.push({
-      unitType,
-      report: switchReport,
-      timestamp: new Date().toISOString(),
-    });
-    // Cap at 50 entries
-    if (history.switchReports.length > 50) {
-      history.switchReports = history.switchReports.slice(-50);
     }
   }
 

--- a/src/resources/extensions/gsd/routing-history.ts
+++ b/src/resources/extensions/gsd/routing-history.ts
@@ -6,6 +6,7 @@
 import { join } from "node:path";
 import { gsdRoot } from "./paths.js";
 import type { ComplexityTier } from "./types.js";
+import type { ProviderSwitchReport } from "@gsd/pi-ai";
 import { loadJsonFile, saveJsonFile } from "./json-persistence.js";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
@@ -27,8 +28,16 @@ export interface RoutingHistoryData {
   patterns: Record<string, PatternHistory>;
   /** User feedback entries (from /gsd:rate-unit) */
   feedback: FeedbackEntry[];
+  /** Cross-provider switch reports from recent dispatches (ADR-005) */
+  switchReports: SwitchReportEntry[];
   /** Last updated timestamp */
   updatedAt: string;
+}
+
+export interface SwitchReportEntry {
+  unitType: string;
+  report: ProviderSwitchReport;
+  timestamp: string;
 }
 
 export interface FeedbackEntry {
@@ -82,6 +91,7 @@ export function recordOutcome(
   tier: ComplexityTier,
   success: boolean,
   tags?: string[],
+  switchReport?: ProviderSwitchReport,
 ): void {
   if (!history) return;
 
@@ -100,6 +110,19 @@ export function recordOutcome(
       const tagOutcome = history.patterns[tagPattern][tier];
       if (success) tagOutcome.success++;
       else tagOutcome.fail++;
+    }
+  }
+
+  // Store cross-provider switch report if present (ADR-005)
+  if (switchReport) {
+    history.switchReports.push({
+      unitType,
+      report: switchReport,
+      timestamp: new Date().toISOString(),
+    });
+    // Cap switch reports at 100 entries
+    if (history.switchReports.length > 100) {
+      history.switchReports = history.switchReports.slice(-100);
     }
   }
 
@@ -260,6 +283,7 @@ function createEmptyHistory(): RoutingHistoryData {
     version: 1,
     patterns: {},
     feedback: [],
+    switchReports: [],
     updatedAt: new Date().toISOString(),
   };
 }
@@ -279,7 +303,12 @@ function isRoutingHistoryData(data: unknown): data is RoutingHistoryData {
 }
 
 function loadHistory(base: string): RoutingHistoryData {
-  return loadJsonFile(historyPath(base), isRoutingHistoryData, createEmptyHistory);
+  const data = loadJsonFile(historyPath(base), isRoutingHistoryData, createEmptyHistory);
+  // Backfill switchReports for legacy data files that predate ADR-005
+  if (!Array.isArray(data.switchReports)) {
+    data.switchReports = [];
+  }
+  return data;
 }
 
 function saveHistory(base: string, data: RoutingHistoryData): void {

--- a/src/resources/extensions/gsd/tests/adjust-tool-set.test.ts
+++ b/src/resources/extensions/gsd/tests/adjust-tool-set.test.ts
@@ -1,0 +1,119 @@
+// GSD-2 — Tests for adjustToolSet (ADR-005 Phase 4)
+// Copyright (c) 2026 Jeremy McSpadden <jeremy@fluxlabs.net>
+
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import { adjustToolSet } from "../auto-model-selection.js";
+import { getProviderCapabilities, PERMISSIVE_CAPABILITIES, type ProviderCapabilities } from "@gsd/pi-ai";
+
+describe("adjustToolSet (ADR-005)", () => {
+  const baseTool = (name: string, opts?: { producesImages?: boolean; schemaFeatures?: string[]; priority?: number }) => ({
+    name,
+    compatibility: opts?.producesImages !== undefined || opts?.schemaFeatures !== undefined
+      ? { producesImages: opts.producesImages, schemaFeatures: opts.schemaFeatures }
+      : undefined,
+    priority: opts?.priority,
+  });
+
+  test("tools without compatibility metadata are always included", () => {
+    const tools = [baseTool("Bash"), baseTool("Read"), baseTool("Write")];
+    const caps = getProviderCapabilities("mistral-conversations");
+    const result = adjustToolSet(tools, caps);
+    assert.equal(result.length, 3);
+    assert.deepEqual(result.map(t => t.name), ["Bash", "Read", "Write"]);
+  });
+
+  test("tool with producesImages excluded on provider without imageToolResults", () => {
+    const tools = [
+      baseTool("Bash"),
+      baseTool("screenshot", { producesImages: true }),
+    ];
+    const caps = getProviderCapabilities("openai-responses"); // no image tool results
+    const result = adjustToolSet(tools, caps);
+    assert.equal(result.length, 1);
+    assert.equal(result[0].name, "Bash");
+  });
+
+  test("tool with producesImages passes on provider with imageToolResults", () => {
+    const tools = [
+      baseTool("Bash"),
+      baseTool("screenshot", { producesImages: true }),
+    ];
+    const caps = getProviderCapabilities("anthropic-messages"); // supports images
+    const result = adjustToolSet(tools, caps);
+    assert.equal(result.length, 2);
+  });
+
+  test("tool with unsupported schemaFeatures excluded", () => {
+    const tools = [
+      baseTool("Read"),
+      baseTool("complex-search", { schemaFeatures: ["patternProperties"] }),
+    ];
+    const caps = getProviderCapabilities("google-generative-ai"); // unsupports patternProperties
+    const result = adjustToolSet(tools, caps);
+    assert.equal(result.length, 1);
+    assert.equal(result[0].name, "Read");
+  });
+
+  test("maxTools pruning keeps highest-priority tools", () => {
+    const tools = [
+      baseTool("Bash", { priority: 10 }),
+      baseTool("Read", { priority: 8 }),
+      baseTool("Write", { priority: 5 }),
+      baseTool("Search", { priority: 3 }),
+      baseTool("Extra", { priority: 1 }),
+    ];
+    const caps: ProviderCapabilities = {
+      ...PERMISSIVE_CAPABILITIES,
+      maxTools: 3,
+    };
+    const result = adjustToolSet(tools, caps);
+    assert.equal(result.length, 3);
+    assert.deepEqual(result.map(t => t.name), ["Bash", "Read", "Write"]);
+  });
+
+  test("maxTools=0 means unlimited (no pruning)", () => {
+    const tools = [
+      baseTool("A", { priority: 1 }),
+      baseTool("B", { priority: 2 }),
+      baseTool("C", { priority: 3 }),
+    ];
+    const caps: ProviderCapabilities = {
+      ...PERMISSIVE_CAPABILITIES,
+      maxTools: 0,
+    };
+    const result = adjustToolSet(tools, caps);
+    assert.equal(result.length, 3);
+  });
+
+  test("tools without priority default to 1 during pruning", () => {
+    const tools = [
+      baseTool("Bash", { priority: 10 }),
+      baseTool("Read"), // priority defaults to 1
+      baseTool("Extra"), // priority defaults to 1
+    ];
+    const caps: ProviderCapabilities = {
+      ...PERMISSIVE_CAPABILITIES,
+      maxTools: 1,
+    };
+    const result = adjustToolSet(tools, caps);
+    assert.equal(result.length, 1);
+    assert.equal(result[0].name, "Bash");
+  });
+
+  test("empty tools returns empty result", () => {
+    const caps = getProviderCapabilities("anthropic-messages");
+    const result = adjustToolSet([], caps);
+    assert.equal(result.length, 0);
+  });
+
+  test("permissive capabilities do not filter anything", () => {
+    const tools = [
+      baseTool("Bash"),
+      baseTool("screenshot", { producesImages: true }),
+      baseTool("complex", { schemaFeatures: ["patternProperties", "anyOf"] }),
+    ];
+    const result = adjustToolSet(tools, PERMISSIVE_CAPABILITIES);
+    assert.equal(result.length, 3);
+  });
+});

--- a/src/resources/extensions/gsd/tests/plan-capability-validation.test.ts
+++ b/src/resources/extensions/gsd/tests/plan-capability-validation.test.ts
@@ -1,0 +1,157 @@
+// GSD-2 — Tests for plan-time capability validation (ADR-004/005)
+// Copyright (c) 2026 Jeremy McSpadden <jeremy@fluxlabs.net>
+
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  validatePlanCapabilities,
+  formatCapabilityWarnings,
+  type CapabilityWarning,
+} from "../auto-model-selection.js";
+
+describe("Plan-Time Capability Validation (ADR-004/005)", () => {
+
+  // ─── validatePlanCapabilities ──────────────────────────────────────────────
+
+  describe("validatePlanCapabilities", () => {
+    const anthropicModel = { id: "claude-sonnet-4-6", api: "anthropic-messages" };
+    const openaiModel = { id: "gpt-4o", api: "openai-responses" };
+    const mistralModel = { id: "mistral-large", api: "mistral-conversations" };
+
+    test("returns empty array when all models support all capabilities", () => {
+      const tasks = [{
+        taskId: "T01",
+        title: "Add screenshot tests",
+        description: "Capture screenshots for visual regression testing",
+        files: ["tests/screenshots/home.png"],
+      }];
+      // Anthropic supports images
+      const warnings = validatePlanCapabilities(tasks, [anthropicModel]);
+      assert.deepEqual(warnings, []);
+    });
+
+    test("warns when task needs images but no model supports imageToolResults", () => {
+      const tasks = [{
+        taskId: "T01",
+        title: "Capture login screenshot",
+        description: "Take a screenshot of the login page for UAT evidence",
+        files: ["evidence/login.png"],
+      }];
+      // OpenAI does NOT support image tool results
+      const warnings = validatePlanCapabilities(tasks, [openaiModel]);
+      assert.ok(warnings.length > 0, "should have at least one warning");
+      assert.equal(warnings[0].taskId, "T01");
+      assert.equal(warnings[0].capability, "imageToolResults");
+    });
+
+    test("warns on image file extensions even without keyword in description", () => {
+      const tasks = [{
+        taskId: "T02",
+        title: "Update logo",
+        description: "Replace the old logo with the new one",
+        files: ["public/logo.svg", "public/favicon.png"],
+      }];
+      const warnings = validatePlanCapabilities(tasks, [openaiModel, mistralModel]);
+      assert.ok(warnings.length > 0, "should detect image files");
+      assert.equal(warnings[0].capability, "imageToolResults");
+      assert.ok(warnings[0].detail.includes("logo.svg") || warnings[0].detail.includes("favicon.png"));
+    });
+
+    test("no warning when at least one model supports the capability", () => {
+      const tasks = [{
+        taskId: "T01",
+        title: "Take screenshot",
+        description: "Capture screenshots",
+        files: ["test.png"],
+      }];
+      // Mixed pool: Anthropic supports images, OpenAI doesn't
+      const warnings = validatePlanCapabilities(tasks, [anthropicModel, openaiModel]);
+      assert.deepEqual(warnings, []);
+    });
+
+    test("returns empty array for empty tasks", () => {
+      const warnings = validatePlanCapabilities([], [anthropicModel]);
+      assert.deepEqual(warnings, []);
+    });
+
+    test("returns empty array for empty models", () => {
+      const tasks = [{
+        taskId: "T01", title: "task", description: "desc", files: [],
+      }];
+      const warnings = validatePlanCapabilities(tasks, []);
+      assert.deepEqual(warnings, []);
+    });
+
+    test("does not warn for tasks without capability requirements", () => {
+      const tasks = [{
+        taskId: "T01",
+        title: "Refactor auth module",
+        description: "Extract validation logic into separate function",
+        files: ["src/auth.ts", "src/validation.ts"],
+      }];
+      const warnings = validatePlanCapabilities(tasks, [openaiModel]);
+      assert.deepEqual(warnings, []);
+    });
+
+    test("detects multiple tasks with capability gaps", () => {
+      const tasks = [
+        {
+          taskId: "T01",
+          title: "Add visual regression tests",
+          description: "Capture screenshots for visual comparison",
+          files: ["tests/visual/home.png"],
+        },
+        {
+          taskId: "T02",
+          title: "Render diagram",
+          description: "Generate architecture diagram as SVG",
+          files: ["docs/architecture.svg"],
+        },
+        {
+          taskId: "T03",
+          title: "Fix bug in parser",
+          description: "Handle edge case in CSV parsing",
+          files: ["src/parser.ts"],
+        },
+      ];
+      const warnings = validatePlanCapabilities(tasks, [mistralModel]);
+      // T01 and T02 should have warnings, T03 should not
+      const warningTaskIds = warnings.map(w => w.taskId);
+      assert.ok(warningTaskIds.includes("T01"), "T01 should have a warning");
+      assert.ok(warningTaskIds.includes("T02"), "T02 should have a warning");
+      assert.ok(!warningTaskIds.includes("T03"), "T03 should NOT have a warning");
+    });
+  });
+
+  // ─── formatCapabilityWarnings ────────────────────────────────────────────
+
+  describe("formatCapabilityWarnings", () => {
+    test("returns empty string for no warnings", () => {
+      assert.equal(formatCapabilityWarnings([]), "");
+    });
+
+    test("formats single warning with header and recommendation", () => {
+      const warnings: CapabilityWarning[] = [{
+        taskId: "T01",
+        taskTitle: "Take screenshot",
+        capability: "imageToolResults",
+        detail: "No model supports image tool results.",
+      }];
+      const output = formatCapabilityWarnings(warnings);
+      assert.ok(output.includes("## Capability Warnings"));
+      assert.ok(output.includes("T01"));
+      assert.ok(output.includes("imageToolResults"));
+      assert.ok(output.includes("Consider configuring"));
+    });
+
+    test("formats multiple warnings", () => {
+      const warnings: CapabilityWarning[] = [
+        { taskId: "T01", taskTitle: "Screenshots", capability: "imageToolResults", detail: "No image support." },
+        { taskId: "T02", taskTitle: "Diagrams", capability: "imageToolResults", detail: "No image support." },
+      ];
+      const output = formatCapabilityWarnings(warnings);
+      assert.ok(output.includes("T01"));
+      assert.ok(output.includes("T02"));
+    });
+  });
+});

--- a/src/resources/extensions/gsd/tests/terminated-transient.test.ts
+++ b/src/resources/extensions/gsd/tests/terminated-transient.test.ts
@@ -126,3 +126,11 @@ test("V8 JSON.parse with line/column suffix is transient", () => {
   assert.equal(isTransient(result), true);
   assert.equal(result.kind, "stream");
 });
+
+test("#2882: 'Unterminated string in JSON' (truncated stream) is transient", () => {
+  const result = classifyError("Unterminated string in JSON at position 1024 (line 1 column 1025)");
+  assert.equal(isTransient(result), true, "'Unterminated string in JSON' should be transient");
+  // Note: "Unterminated" matches CONNECTION_RE ("terminated") first due to classification order.
+  // Still transient either way — both connection and stream kinds trigger auto-retry.
+  assert.equal(result.kind, "connection", "'Unterminated' matches CONNECTION_RE before STREAM_RE");
+});

--- a/src/resources/extensions/gsd/tests/terminated-transient.test.ts
+++ b/src/resources/extensions/gsd/tests/terminated-transient.test.ts
@@ -130,7 +130,7 @@ test("V8 JSON.parse with line/column suffix is transient", () => {
 test("#2882: 'Unterminated string in JSON' (truncated stream) is transient", () => {
   const result = classifyError("Unterminated string in JSON at position 1024 (line 1 column 1025)");
   assert.equal(isTransient(result), true, "'Unterminated string in JSON' should be transient");
-  // Note: "Unterminated" matches CONNECTION_RE ("terminated") first due to classification order.
-  // Still transient either way — both connection and stream kinds trigger auto-retry.
-  assert.equal(result.kind, "connection", "'Unterminated' matches CONNECTION_RE before STREAM_RE");
+  // "in JSON at position \d+" matches STREAM_RE before CONNECTION_RE checks "terminated".
+  // Still transient either way — both stream and connection kinds trigger auto-retry.
+  assert.equal(result.kind, "stream", "'Unterminated string in JSON at position' matches STREAM_RE first");
 });

--- a/src/resources/extensions/gsd/tests/tool-compatibility-filter.test.ts
+++ b/src/resources/extensions/gsd/tests/tool-compatibility-filter.test.ts
@@ -1,0 +1,225 @@
+// GSD-2 — Tests for tool-compatibility filter (ADR-005 Step 2)
+// Copyright (c) 2026 Jeremy McSpadden <jeremy@fluxlabs.net>
+
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  isToolCompatibleWithProvider,
+  filterModelsByToolCompatibility,
+  getRequiredToolNames,
+  type ToolCompatibilityInfo,
+} from "../model-router.js";
+import {
+  getProviderCapabilities,
+  PERMISSIVE_CAPABILITIES,
+  type ProviderCapabilities,
+} from "@gsd/pi-ai";
+
+describe("Tool-Compatibility Filter (ADR-005 Step 2)", () => {
+
+  // ─── isToolCompatibleWithProvider ──────────────────────────────────────────
+
+  describe("isToolCompatibleWithProvider", () => {
+    test("tool without compatibility metadata is ALWAYS compatible (Pitfall 6 — write this FIRST)", () => {
+      // This is the most critical invariant. Tools without metadata must pass.
+      const tool: ToolCompatibilityInfo = { name: "custom-tool" };
+      const googleCaps = getProviderCapabilities("google-generative-ai");
+      const mistralCaps = getProviderCapabilities("mistral-conversations");
+
+      assert.equal(isToolCompatibleWithProvider(tool, googleCaps), true);
+      assert.equal(isToolCompatibleWithProvider(tool, mistralCaps), true);
+      assert.equal(isToolCompatibleWithProvider(tool, PERMISSIVE_CAPABILITIES), true);
+    });
+
+    test("tool with empty compatibility object is compatible", () => {
+      const tool: ToolCompatibilityInfo = { name: "tool", compatibility: {} };
+      const caps = getProviderCapabilities("mistral-conversations");
+      assert.equal(isToolCompatibleWithProvider(tool, caps), true);
+    });
+
+    test("tool with producesImages=true excluded on provider without imageToolResults", () => {
+      const tool: ToolCompatibilityInfo = {
+        name: "screenshot",
+        compatibility: { producesImages: true },
+      };
+      // Mistral does NOT support image tool results
+      const mistralCaps = getProviderCapabilities("mistral-conversations");
+      assert.equal(isToolCompatibleWithProvider(tool, mistralCaps), false);
+    });
+
+    test("tool with producesImages=true passes on provider WITH imageToolResults", () => {
+      const tool: ToolCompatibilityInfo = {
+        name: "screenshot",
+        compatibility: { producesImages: true },
+      };
+      // Anthropic supports image tool results
+      const anthropicCaps = getProviderCapabilities("anthropic-messages");
+      assert.equal(isToolCompatibleWithProvider(tool, anthropicCaps), true);
+    });
+
+    test("tool with schemaFeatures excluded when provider has unsupportedSchemaFeatures", () => {
+      const tool: ToolCompatibilityInfo = {
+        name: "complex-search",
+        compatibility: { schemaFeatures: ["patternProperties"] },
+      };
+      // Google does NOT support patternProperties
+      const googleCaps = getProviderCapabilities("google-generative-ai");
+      assert.equal(isToolCompatibleWithProvider(tool, googleCaps), false);
+    });
+
+    test("tool with schemaFeatures passes when provider supports all features", () => {
+      const tool: ToolCompatibilityInfo = {
+        name: "complex-search",
+        compatibility: { schemaFeatures: ["patternProperties"] },
+      };
+      // Anthropic supports all schema features
+      const anthropicCaps = getProviderCapabilities("anthropic-messages");
+      assert.equal(isToolCompatibleWithProvider(tool, anthropicCaps), true);
+    });
+
+    test("tool with producesImages=false is compatible everywhere", () => {
+      const tool: ToolCompatibilityInfo = {
+        name: "text-tool",
+        compatibility: { producesImages: false },
+      };
+      const mistralCaps = getProviderCapabilities("mistral-conversations");
+      assert.equal(isToolCompatibleWithProvider(tool, mistralCaps), true);
+    });
+
+    test("unknown provider (permissive caps) passes all tools", () => {
+      const tool: ToolCompatibilityInfo = {
+        name: "any-tool",
+        compatibility: { producesImages: true, schemaFeatures: ["patternProperties"] },
+      };
+      assert.equal(isToolCompatibleWithProvider(tool, PERMISSIVE_CAPABILITIES), true);
+    });
+  });
+
+  // ─── filterModelsByToolCompatibility ────────────────────────────────────────
+
+  describe("filterModelsByToolCompatibility", () => {
+    const modelApiLookup: Record<string, string> = {
+      "claude-sonnet-4-6": "anthropic-messages",
+      "gemini-2.0-flash": "google-generative-ai",
+      "gpt-4o": "openai-responses",
+      "mistral-large": "mistral-conversations",
+    };
+
+    test("returns all models when required tools have no compatibility metadata", () => {
+      const tools: ToolCompatibilityInfo[] = [
+        { name: "Bash" },
+        { name: "Read" },
+        { name: "Write" },
+      ];
+      const models = ["claude-sonnet-4-6", "gemini-2.0-flash", "gpt-4o"];
+      const result = filterModelsByToolCompatibility(models, tools, modelApiLookup);
+      assert.deepEqual(result, models);
+    });
+
+    test("returns all models when no required tools", () => {
+      const models = ["claude-sonnet-4-6", "gemini-2.0-flash"];
+      const result = filterModelsByToolCompatibility(models, [], modelApiLookup);
+      assert.deepEqual(result, models);
+    });
+
+    test("filters out models whose provider cannot support image tools", () => {
+      const tools: ToolCompatibilityInfo[] = [
+        { name: "screenshot", compatibility: { producesImages: true } },
+      ];
+      const models = ["claude-sonnet-4-6", "gpt-4o", "mistral-large"];
+      const result = filterModelsByToolCompatibility(models, tools, modelApiLookup);
+      // Anthropic supports images; OpenAI and Mistral do not
+      assert.deepEqual(result, ["claude-sonnet-4-6"]);
+    });
+
+    test("filters out models whose provider has unsupported schema features", () => {
+      const tools: ToolCompatibilityInfo[] = [
+        { name: "search", compatibility: { schemaFeatures: ["patternProperties"] } },
+      ];
+      const models = ["claude-sonnet-4-6", "gemini-2.0-flash", "gpt-4o"];
+      const result = filterModelsByToolCompatibility(models, tools, modelApiLookup);
+      // Google doesn't support patternProperties; Anthropic and OpenAI do
+      assert.deepEqual(result, ["claude-sonnet-4-6", "gpt-4o"]);
+    });
+
+    test("returns original list when filter would remove ALL models (fail-open)", () => {
+      const tools: ToolCompatibilityInfo[] = [
+        { name: "impossible", compatibility: { producesImages: true, schemaFeatures: ["patternProperties"] } },
+      ];
+      // Only Mistral — doesn't support images, so this tool fails on Mistral
+      const models = ["mistral-large"];
+      const result = filterModelsByToolCompatibility(models, tools, modelApiLookup);
+      // Would remove all models — returns original (fail-open)
+      assert.deepEqual(result, ["mistral-large"]);
+    });
+
+    test("passes through models with unknown API (fail-open)", () => {
+      const tools: ToolCompatibilityInfo[] = [
+        { name: "screenshot", compatibility: { producesImages: true } },
+      ];
+      const lookupWithUnknown = { ...modelApiLookup, "local-model": "some-unknown-api" };
+      const models = ["local-model", "mistral-large"];
+      const result = filterModelsByToolCompatibility(models, tools, lookupWithUnknown);
+      // local-model: unknown API → permissive default → passes
+      // mistral-large: no image support → filtered out
+      // But since mistral-large is removed and local-model passes, result has local-model
+      assert.deepEqual(result, ["local-model"]);
+    });
+
+    test("passes through models not in API lookup (fail-open)", () => {
+      const tools: ToolCompatibilityInfo[] = [
+        { name: "screenshot", compatibility: { producesImages: true } },
+      ];
+      const models = ["mystery-model"];
+      const result = filterModelsByToolCompatibility(models, tools, modelApiLookup);
+      // mystery-model not in lookup → passes through
+      assert.deepEqual(result, ["mystery-model"]);
+    });
+
+    test("mixed tools — only tools with metadata trigger filtering", () => {
+      const tools: ToolCompatibilityInfo[] = [
+        { name: "Bash" }, // no metadata
+        { name: "Read" }, // no metadata
+        { name: "screenshot", compatibility: { producesImages: true } },
+      ];
+      const models = ["claude-sonnet-4-6", "gpt-4o"];
+      const result = filterModelsByToolCompatibility(models, tools, modelApiLookup);
+      // OpenAI doesn't support images → filtered
+      assert.deepEqual(result, ["claude-sonnet-4-6"]);
+    });
+  });
+
+  // ─── getRequiredToolNames ──────────────────────────────────────────────────
+
+  describe("getRequiredToolNames", () => {
+    test("execute-task requires Bash, Read, Write, Edit", () => {
+      const tools = getRequiredToolNames("execute-task");
+      assert.deepEqual(tools, ["Bash", "Read", "Write", "Edit"]);
+    });
+
+    test("execute-plan requires Bash, Read, Write, Edit", () => {
+      const tools = getRequiredToolNames("execute-plan");
+      assert.deepEqual(tools, ["Bash", "Read", "Write", "Edit"]);
+    });
+
+    test("research-milestone requires Read", () => {
+      const tools = getRequiredToolNames("research-milestone");
+      assert.deepEqual(tools, ["Read"]);
+    });
+
+    test("research-slice requires Read", () => {
+      const tools = getRequiredToolNames("research-slice");
+      assert.deepEqual(tools, ["Read"]);
+    });
+
+    test("unknown unit type returns empty array (no filtering)", () => {
+      const tools = getRequiredToolNames("discuss-phase");
+      assert.deepEqual(tools, []);
+    });
+
+    test("hook unit types return empty array", () => {
+      const tools = getRequiredToolNames("hook/before_model_select");
+      assert.deepEqual(tools, []);
+    });
+  });
+});

--- a/src/resources/extensions/gsd/tests/tool-compatibility-filter.test.ts
+++ b/src/resources/extensions/gsd/tests/tool-compatibility-filter.test.ts
@@ -203,14 +203,59 @@ describe("Tool-Compatibility Filter (ADR-005 Step 2)", () => {
       assert.deepEqual(tools, ["Bash", "Read", "Write", "Edit"]);
     });
 
-    test("research-milestone requires Read", () => {
-      const tools = getRequiredToolNames("research-milestone");
-      assert.deepEqual(tools, ["Read"]);
+    test("reactive-execute requires Bash, Read, Write, Edit", () => {
+      const tools = getRequiredToolNames("reactive-execute");
+      assert.deepEqual(tools, ["Bash", "Read", "Write", "Edit"]);
     });
 
-    test("research-slice requires Read", () => {
+    test("rewrite-docs requires Bash, Read, Write, Edit", () => {
+      const tools = getRequiredToolNames("rewrite-docs");
+      assert.deepEqual(tools, ["Bash", "Read", "Write", "Edit"]);
+    });
+
+    test("research-milestone requires Read, WebSearch, WebFetch", () => {
+      const tools = getRequiredToolNames("research-milestone");
+      assert.deepEqual(tools, ["Read", "WebSearch", "WebFetch"]);
+    });
+
+    test("research-slice requires Read, WebSearch, WebFetch", () => {
       const tools = getRequiredToolNames("research-slice");
-      assert.deepEqual(tools, ["Read"]);
+      assert.deepEqual(tools, ["Read", "WebSearch", "WebFetch"]);
+    });
+
+    test("plan-milestone requires Read, Write", () => {
+      const tools = getRequiredToolNames("plan-milestone");
+      assert.deepEqual(tools, ["Read", "Write"]);
+    });
+
+    test("plan-slice requires Read, Write", () => {
+      const tools = getRequiredToolNames("plan-slice");
+      assert.deepEqual(tools, ["Read", "Write"]);
+    });
+
+    test("replan-slice requires Read, Write", () => {
+      const tools = getRequiredToolNames("replan-slice");
+      assert.deepEqual(tools, ["Read", "Write"]);
+    });
+
+    test("run-uat requires Read, Bash", () => {
+      const tools = getRequiredToolNames("run-uat");
+      assert.deepEqual(tools, ["Read", "Bash"]);
+    });
+
+    test("complete-slice requires Read, Write", () => {
+      const tools = getRequiredToolNames("complete-slice");
+      assert.deepEqual(tools, ["Read", "Write"]);
+    });
+
+    test("complete-milestone requires Read, Write", () => {
+      const tools = getRequiredToolNames("complete-milestone");
+      assert.deepEqual(tools, ["Read", "Write"]);
+    });
+
+    test("validate-milestone requires Read, Write", () => {
+      const tools = getRequiredToolNames("validate-milestone");
+      assert.deepEqual(tools, ["Read", "Write"]);
     });
 
     test("unknown unit type returns empty array (no filtering)", () => {
@@ -233,12 +278,13 @@ describe("Tool-Compatibility Filter (ADR-005 Step 2)", () => {
           Array.isArray(result),
           `getRequiredToolNames("${unitType}") must return an array (got ${typeof result})`,
         );
-        // Verify the return is one of the known constant arrays, not a new allocation
-        // (which would indicate the function fell through to the default without consideration)
       }
       // Verify that execute-type units get tools and non-execute units are explicitly handled
       assert.ok(getRequiredToolNames("execute-task").length > 0, "execute-task should require tools");
       assert.ok(getRequiredToolNames("research-milestone").length > 0, "research-milestone should require tools");
+      assert.ok(getRequiredToolNames("plan-slice").length > 0, "plan-slice should require tools");
+      assert.ok(getRequiredToolNames("run-uat").length > 0, "run-uat should require tools");
+      assert.ok(getRequiredToolNames("complete-slice").length > 0, "complete-slice should require tools");
     });
   });
 });

--- a/src/resources/extensions/gsd/tests/tool-compatibility-filter.test.ts
+++ b/src/resources/extensions/gsd/tests/tool-compatibility-filter.test.ts
@@ -329,7 +329,7 @@ describe("Tool-Compatibility Filter (ADR-005 Step 2)", () => {
 
       // Step 2: Route with the filtered model set
       const routingResult = resolveModelForComplexity(
-        { tier: "light", reason: "simple task", confidence: 0.9 },
+        { tier: "light", reason: "simple task", downgraded: false },
         { primary: "claude-haiku-4-5", fallbacks: [] },
         { enabled: true, cross_provider: true },
         compatibleModelIds, // <-- filtered set, NOT allModelIds
@@ -364,7 +364,7 @@ describe("Tool-Compatibility Filter (ADR-005 Step 2)", () => {
 
       // Routing should still work with the remaining compatible models
       const routingResult = resolveModelForComplexity(
-        { tier: "standard", reason: "moderate task", confidence: 0.8 },
+        { tier: "standard", reason: "moderate task", downgraded: false },
         { primary: "claude-sonnet-4-6", fallbacks: ["gpt-4o"] },
         { enabled: true, cross_provider: true },
         compatibleModelIds,

--- a/src/resources/extensions/gsd/tests/tool-compatibility-filter.test.ts
+++ b/src/resources/extensions/gsd/tests/tool-compatibility-filter.test.ts
@@ -9,6 +9,7 @@ import {
   getRequiredToolNames,
   type ToolCompatibilityInfo,
 } from "../model-router.js";
+import { KNOWN_UNIT_TYPES } from "../preferences-types.js";
 import {
   getProviderCapabilities,
   PERMISSIVE_CAPABILITIES,
@@ -220,6 +221,24 @@ describe("Tool-Compatibility Filter (ADR-005 Step 2)", () => {
     test("hook unit types return empty array", () => {
       const tools = getRequiredToolNames("hook/before_model_select");
       assert.deepEqual(tools, []);
+    });
+
+    test("every KNOWN_UNIT_TYPE has an explicit decision in getRequiredToolNames (exhaustiveness)", () => {
+      // This test ensures new unit types added to KNOWN_UNIT_TYPES are explicitly
+      // considered for tool requirements. If this test fails, add an entry in
+      // getRequiredToolNames() — even if it returns [] (no requirements).
+      for (const unitType of KNOWN_UNIT_TYPES) {
+        const result = getRequiredToolNames(unitType);
+        assert.ok(
+          Array.isArray(result),
+          `getRequiredToolNames("${unitType}") must return an array (got ${typeof result})`,
+        );
+        // Verify the return is one of the known constant arrays, not a new allocation
+        // (which would indicate the function fell through to the default without consideration)
+      }
+      // Verify that execute-type units get tools and non-execute units are explicitly handled
+      assert.ok(getRequiredToolNames("execute-task").length > 0, "execute-task should require tools");
+      assert.ok(getRequiredToolNames("research-milestone").length > 0, "research-milestone should require tools");
     });
   });
 });

--- a/src/resources/extensions/gsd/tests/tool-compatibility-filter.test.ts
+++ b/src/resources/extensions/gsd/tests/tool-compatibility-filter.test.ts
@@ -7,6 +7,7 @@ import {
   isToolCompatibleWithProvider,
   filterModelsByToolCompatibility,
   getRequiredToolNames,
+  resolveModelForComplexity,
   type ToolCompatibilityInfo,
 } from "../model-router.js";
 import { KNOWN_UNIT_TYPES } from "../preferences-types.js";
@@ -285,6 +286,92 @@ describe("Tool-Compatibility Filter (ADR-005 Step 2)", () => {
       assert.ok(getRequiredToolNames("plan-slice").length > 0, "plan-slice should require tools");
       assert.ok(getRequiredToolNames("run-uat").length > 0, "run-uat should require tools");
       assert.ok(getRequiredToolNames("complete-slice").length > 0, "complete-slice should require tools");
+    });
+  });
+
+  // ─── Filter-Position Integration Test ──────────────────────────────────────
+
+  describe("filter runs BEFORE scoring (position invariant)", () => {
+    test("incompatible model is never selected by resolveModelForComplexity even if it would be cheapest", () => {
+      // Setup: Two light-tier models. gpt-4o-mini is cheaper but its provider (OpenAI)
+      // doesn't support imageToolResults. Claude Haiku does (Anthropic supports images).
+      // If the filter runs BEFORE scoring, gpt-4o-mini gets excluded and Haiku is selected.
+      // If the filter ran AFTER scoring (wrong), gpt-4o-mini would be selected as cheapest-in-tier.
+      const modelApiLookup: Record<string, string> = {
+        "claude-haiku-4-5": "anthropic-messages",
+        "gpt-4o-mini": "openai-responses",
+      };
+
+      const imageTools: ToolCompatibilityInfo[] = [
+        { name: "Bash" }, // no metadata — always passes
+        { name: "screenshot", compatibility: { producesImages: true } },
+      ];
+
+      // All models available
+      const allModelIds = ["claude-haiku-4-5", "gpt-4o-mini"];
+
+      // Step 1: Filter by tool compatibility (as auto-model-selection.ts does)
+      const compatibleModelIds = filterModelsByToolCompatibility(
+        allModelIds,
+        imageTools,
+        modelApiLookup,
+      );
+
+      // OpenAI doesn't support imageToolResults — gpt-4o-mini should be filtered out
+      assert.ok(
+        !compatibleModelIds.includes("gpt-4o-mini"),
+        "gpt-4o-mini should be filtered out (OpenAI has no image tool support)",
+      );
+      assert.ok(
+        compatibleModelIds.includes("claude-haiku-4-5"),
+        "claude-haiku-4-5 should remain (Anthropic supports image tools)",
+      );
+
+      // Step 2: Route with the filtered model set
+      const routingResult = resolveModelForComplexity(
+        { tier: "light", reason: "simple task", confidence: 0.9 },
+        { primary: "claude-haiku-4-5", fallbacks: [] },
+        { enabled: true, cross_provider: true },
+        compatibleModelIds, // <-- filtered set, NOT allModelIds
+      );
+
+      // The routing result should NEVER include the filtered-out model
+      assert.notEqual(
+        routingResult.modelId,
+        "gpt-4o-mini",
+        "incompatible model must never be selected — filter must run BEFORE scoring",
+      );
+      assert.ok(
+        !routingResult.fallbacks.includes("gpt-4o-mini"),
+        "incompatible model must not appear in fallback chain",
+      );
+    });
+
+    test("filter removal does not prevent routing when compatible models remain", () => {
+      const modelApiLookup: Record<string, string> = {
+        "claude-sonnet-4-6": "anthropic-messages",
+        "gpt-4o": "openai-responses",
+        "mistral-large": "mistral-conversations",
+      };
+
+      // Tool that requires schema features Mistral may not support
+      const tools: ToolCompatibilityInfo[] = [
+        { name: "search", compatibility: { schemaFeatures: ["patternProperties"] } },
+      ];
+
+      const allModelIds = ["claude-sonnet-4-6", "gpt-4o", "mistral-large"];
+      const compatibleModelIds = filterModelsByToolCompatibility(allModelIds, tools, modelApiLookup);
+
+      // Routing should still work with the remaining compatible models
+      const routingResult = resolveModelForComplexity(
+        { tier: "standard", reason: "moderate task", confidence: 0.8 },
+        { primary: "claude-sonnet-4-6", fallbacks: ["gpt-4o"] },
+        { enabled: true, cross_provider: true },
+        compatibleModelIds,
+      );
+
+      // Should route to a compatible model, not the filtered one
+      assert.notEqual(routingResult.modelId, "mistral-large");
     });
   });
 });


### PR DESCRIPTION
## TL;DR

**What:** Add a provider capability registry, tool compatibility metadata, and tool-aware model routing (ADR-005).
**Why:** The router currently sends all tools to all models regardless of provider support, causing silent failures when providers can't handle certain tool schemas or result formats.
**How:** Declarative registry + hard filter step before ADR-004 scoring + per-dispatch tool set adjustment with save/restore.

## What

Implements Phases 1-5 of ADR-005 across `pi-ai`, `pi-coding-agent`, and the GSD extension:

- **Provider Capability Registry** (`capabilities.ts`) — declarative `ProviderCapabilities` for 5 canonical APIs + 6 variant aliases, with permissive fail-open defaults for unknown providers
- **ToolCompatibility metadata** — optional `compatibility` and `priority` fields on `ToolDefinition` interface
- **Tool-compatibility hard filter** (Step 2) — filters model candidates by tool support BEFORE ADR-004 capability scoring
- **adjustToolSet** — pure function that filters active tools per provider caps, with save/restore wiring to prevent session drift
- **ProviderSwitchReport** — counts cross-provider transformations (thinking blocks dropped/downgraded, tool call IDs remapped, synthetic results, thought signatures) and stores in routing history

### Files changed (19)

| Layer | Files | Change |
|-------|-------|--------|
| pi-ai | `capabilities.ts` (new), `transform-messages.ts`, `index.ts`, 6 provider callers | Registry + ProviderSwitchReport |
| pi-coding-agent | `types.ts`, `index.ts`, `extensions/index.ts` | ToolCompatibility + ToolInfo update |
| GSD extension | `model-router.ts`, `auto-model-selection.ts`, `routing-history.ts` | Filter + adjustToolSet + history |
| Tests | `capabilities.test.ts`, `tool-compatibility-filter.test.ts`, `adjust-tool-set.test.ts` (all new) | 50 new tests |

## Related

Closes #2790 (ADR-005: Multi-Model, Multi-Provider, and Tool Strategy)

## Why

Closes the tool-compatibility gap identified in ADR-005. Without this:
- Models can be selected that can't process required tool schemas (e.g., Google + `patternProperties`)
- Models can receive image tool results they can't handle (e.g., Mistral, OpenAI)
- Cross-provider context loss is invisible to users and extensions
- Tool sets don't adapt when the router switches providers mid-session

## How

The implementation follows the ADR-005 pipeline design:

```
selectAndApplyModel()
  → classifyUnitComplexity()
  → [NEW] filterModelsByToolCompatibility(availableModelIds, requiredTools, modelApiLookup)
  → resolveModelForComplexity() (ADR-004 scoring on filtered set)
  → pi.setModel()
  → [NEW] adjustToolSet(allTools, providerCaps) + save/restore
```

Key design decisions:
- Registry keyed on API protocol strings (`anthropic-messages`), not provider short names (`anthropic`) — prevents silent lookup misses
- Hard filter before soft scoring — binary incompatibility cannot be overridden by high capability scores
- Fail-open at every level: unknown providers get permissive defaults, tools without metadata always pass, empty filter result returns original set
- `transformMessages()` return type changed to `{ messages, switchReport? }` — all 6 provider callers updated

### Remaining work (WIP)

- [ ] Caller-side `try/finally` restore of `priorTools` after dispatch
- [ ] Annotate first tools with actual `compatibility` metadata
- [ ] Dynamic registry completeness CI test (register-builtins vs capabilities)
- [ ] `before_model_select` hook documentation update
- [ ] Phase 6: `models.json` provider capability overrides

## Test plan

- [x] 19 capability registry tests (profiles, aliases, fail-open, Pitfall 1 prevention, completeness)
- [x] 22 tool-compatibility filter tests (fail-open invariant, image/schema filtering, set-level fail-open)
- [x] 9 adjustToolSet tests (filtering, maxTools pruning, priority sorting)
- [x] 18 existing model-router tests pass (zero regressions)
- [x] 12 existing google-shared tests pass (zero regressions)
- [x] Full suite: 3406/3410 pass (1 pre-existing failure in unrelated `watch-tree-model-db.test.ts`)
- [x] Clean build (`npm run build`) with no TypeScript errors