### PR TITLE
fix(contracts): add isWorkspaceEvent guard + close routeLiveInteractionEvent exhaustiveness gap

### DIFF
--- a/web/lib/gsd-workspace-store.tsx
+++ b/web/lib/gsd-workspace-store.tsx
@@ -470,6 +470,10 @@ export type WorkspaceEvent =
   | TurnEndEvent
   | ({ type: Exclude<string, "bridge_status" | "live_state_invalidation" | "extension_ui_request" | "extension_error" | "message_update" | "tool_execution_start" | "tool_execution_end" | "agent_end" | "turn_end">; [key: string]: unknown } & Record<string, unknown>)
 
+export function isWorkspaceEvent(value: unknown): value is WorkspaceEvent {
+  return value !== null && typeof value === "object" && typeof (value as Record<string, unknown>).type === "string"
+}
+
 export interface WorkspaceCommandResponse {
   type: "response"
   command: string
@@ -4866,8 +4870,15 @@ export class GSDWorkspaceStore {
 
     stream.onmessage = (message) => {
       try {
-        const payload = JSON.parse(message.data) as WorkspaceEvent
-        this.handleEvent(payload)
+        const parsed: unknown = JSON.parse(message.data)
+        if (!isWorkspaceEvent(parsed)) {
+          this.patchState({
+            lastClientError: "Malformed event received from stream",
+            terminalLines: withTerminalLine(this.state.terminalLines, createTerminalLine("error", "Malformed event received from stream")),
+          })
+          return
+        }
+        this.handleEvent(parsed)
       } catch (error) {
         const text = normalizeClientError(error)
         this.patchState({
@@ -4944,6 +4955,15 @@ export class GSDWorkspaceStore {
         break
       case "tool_execution_end":
         this.handleToolExecutionEnd(event as ToolExecutionEndEvent)
+        break
+      case "bridge_status":
+        // Handled upstream in handleEvent with early return — never reaches here
+        break
+      case "live_state_invalidation":
+        // Handled upstream in handleEvent via handleLiveStateInvalidation — no live interaction state update needed
+        break
+      case "extension_error":
+        // Terminal line produced by summarizeEvent — no live interaction state update needed
         break
     }
   }


### PR DESCRIPTION
## Summary

Closes #2875

- **Add `isWorkspaceEvent()` type guard** next to the `WorkspaceEvent` type in `gsd-workspace-store.tsx`. Replaces the unsafe `JSON.parse(...) as WorkspaceEvent` cast in `stream.onmessage` with a validated parse — malformed payloads now produce an explicit error terminal line instead of silently bypassing the type system.

- **Close exhaustiveness gap in `routeLiveInteractionEvent()`** — the switch was missing 3 of 9 `WorkspaceEvent` variants. Added explicit `case` entries for `bridge_status`, `live_state_invalidation`, and `extension_error` with comments explaining why each is a no-op at this routing layer (handled upstream in `handleEvent` or via `summarizeEvent`).

## Test plan

- [ ] `npx tsc --noEmit` — no errors introduced in changed file
- [ ] Verify live event stream still connects and routes events correctly in the web UI
- [ ] Verify malformed stream data produces an error terminal line rather than a silent type coercion

🤖 Generated with [Claude Code](https://claude.com/claude-code)