### PR TITLE
fix: skip mtime staleness check for npm-installed packages

### DIFF
--- a/scripts/ensure-workspace-builds.cjs
+++ b/scripts/ensure-workspace-builds.cjs
@@ -13,6 +13,13 @@
  *
  * Skipped in CI (where the full build pipeline handles this) and when
  * installing as an end-user dependency (no packages/ directory).
+ *
+ * Note: packages/ IS included in the npm tarball (via the "files" field), so
+ * the packages/ existence check does not distinguish npm installs from git
+ * clones. Staleness checking is gated on .git presence instead — npm-installed
+ * packages have pre-built dist/ that is always current; mtime comparisons are
+ * unreliable after tarball extraction (extraction order can leave src/ files
+ * with a newer timestamp than dist/).
  */
 const { existsSync, statSync, readdirSync } = require('fs')
 const { resolve, join } = require('path')
@@ -21,7 +28,7 @@ const { execSync } = require('child_process')
 const root = resolve(__dirname, '..')
 const packagesDir = join(root, 'packages')
 
-// Skip if packages/ doesn't exist (published tarball / end-user install)
+// Skip if packages/ doesn't exist
 if (!existsSync(packagesDir)) process.exit(0)
 
 // Skip in CI — the pipeline runs `npm run build` explicitly
@@ -56,6 +63,11 @@ function newestSrcMtime(dir) {
   return newest
 }
 
+// Staleness detection is only reliable in a git checkout.
+// After npm tarball extraction, file mtimes are set by extraction order and may
+// make src/ appear newer than dist/ even though dist/ was correctly pre-built.
+const isGitRepo = existsSync(join(root, '.git'))
+
 const stale = []
 for (const pkg of WORKSPACE_PACKAGES) {
   const distIndex = join(packagesDir, pkg, 'dist', 'index.js')
@@ -63,10 +75,12 @@ for (const pkg of WORKSPACE_PACKAGES) {
     stale.push(pkg)
     continue
   }
-  const distMtime = statSync(distIndex).mtimeMs
-  const srcMtime = newestSrcMtime(join(packagesDir, pkg, 'src'))
-  if (srcMtime > distMtime) {
-    stale.push(pkg)
+  if (isGitRepo) {
+    const distMtime = statSync(distIndex).mtimeMs
+    const srcMtime = newestSrcMtime(join(packagesDir, pkg, 'src'))
+    if (srcMtime > distMtime) {
+      stale.push(pkg)
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

- Fixes #2877: `DefaultResourceLoader` not found after upgrading to v2.53.0 or v2.54.0
- The staleness check added in v2.53.0 fires incorrectly during npm global installs, triggering a spurious rebuild that can drop the `DefaultResourceLoader` export from `@gsd/pi-coding-agent`

## Root cause

In v2.53.0, `scripts/ensure-workspace-builds.cjs` added an mtime-based staleness check (`srcMtime > distMtime`). When npm installs the package from a tarball, extraction order can leave `src/*.ts` files with a newer timestamp than `dist/index.js` — even though `dist/` was correctly pre-built at publish time. This triggers a rebuild that may corrupt or replace the pre-built dist.

The script's early-exit comment says "Skip if packages/ doesn't exist (published tarball / end-user install)" — but `packages/` **is** included in the npm tarball (via the `files` field in `package.json`), so that guard never fires for end-user installs.

## Fix

Gate the mtime comparison behind a `.git` presence check. The staleness check is only meaningful in a developer git checkout (to catch stale `dist/` after `git pull`). End-user npm installs always have a correctly pre-built `dist/` and should never trigger a rebuild based on unreliable extracted mtimes.

```js
const isGitRepo = existsSync(join(root, '.git'))

// only runs mtime check in git checkouts:
if (isGitRepo) { ... srcMtime > distMtime check ... }
```

## Test plan

- [ ] Fresh `npm install -g gsd-pi@next` → `gsd --version` works without `DefaultResourceLoader` error
- [ ] Developer workflow preserved: deleting `packages/pi-coding-agent/dist/` then running `node scripts/ensure-workspace-builds.cjs` from repo root rebuilds it
- [ ] After `git pull` with updated sources, stale dist is still detected and rebuilt (`.git` exists in dev clone)