### PR TITLE
fix: gate mtime staleness check on .git presence to prevent CJS rebuild on npm install

### DIFF
--- a/scripts/ensure-workspace-builds.cjs
+++ b/scripts/ensure-workspace-builds.cjs
@@ -13,6 +13,13 @@
  *
  * Skipped in CI (where the full build pipeline handles this) and when
  * installing as an end-user dependency (no packages/ directory).
+ *
+ * Note: packages/ IS included in the npm tarball (via the "files" field), so
+ * the packages/ existence check does not distinguish npm installs from git
+ * clones. Staleness checking is gated on .git presence instead — npm-installed
+ * packages have pre-built dist/ that is always current; mtime comparisons are
+ * unreliable after tarball extraction (extraction order can leave src/ files
+ * with a newer timestamp than dist/).
  */
 const { existsSync, statSync, readdirSync } = require('fs')
 const { resolve, join } = require('path')
@@ -21,7 +28,7 @@ const { execSync } = require('child_process')
 const root = resolve(__dirname, '..')
 const packagesDir = join(root, 'packages')
 
-// Skip if packages/ doesn't exist (published tarball / end-user install)
+// Skip if packages/ doesn't exist
 if (!existsSync(packagesDir)) process.exit(0)
 
 // Skip in CI — the pipeline runs `npm run build` explicitly
@@ -56,6 +63,11 @@ function newestSrcMtime(dir) {
   return newest
 }
 
+// Staleness detection is only reliable in a git checkout.
+// After npm tarball extraction, file mtimes are set by extraction order and may
+// make src/ appear newer than dist/ even though dist/ was correctly pre-built.
+const isGitRepo = existsSync(join(root, '.git'))
+
 const stale = []
 for (const pkg of WORKSPACE_PACKAGES) {
   const distIndex = join(packagesDir, pkg, 'dist', 'index.js')
@@ -63,10 +75,12 @@ for (const pkg of WORKSPACE_PACKAGES) {
     stale.push(pkg)
     continue
   }
-  const distMtime = statSync(distIndex).mtimeMs
-  const srcMtime = newestSrcMtime(join(packagesDir, pkg, 'src'))
-  if (srcMtime > distMtime) {
-    stale.push(pkg)
+  if (isGitRepo) {
+    const distMtime = statSync(distIndex).mtimeMs
+    const srcMtime = newestSrcMtime(join(packagesDir, pkg, 'src'))
+    if (srcMtime > distMtime) {
+      stale.push(pkg)
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

- Fixes #2877: `DefaultResourceLoader` not found after upgrading to v2.53.0+
- Gates the mtime staleness check in `ensure-workspace-builds.cjs` behind `.git` presence so npm installs never trigger a spurious rebuild

## Confirmed Root Cause

v2.53.0 added a staleness check comparing `srcMtime > distMtime`. On npm installs, tarball extraction ordering can leave `src/*.ts` files with a slightly newer mtime than `dist/index.js` — triggering a rebuild even though dist/ was correctly pre-built.

**Verified on the reporter's machine:**

1. `src/index.ts` mtime = `20:50:45`, `dist/index.js` mtime = `20:50:56` — extraction made src appear stale
2. The rebuild shelled out to `tsc` on PATH → resolved to **global TypeScript 3.8.3** (`/usr/local/bin/tsc`)
3. TS 3.8.3 doesn't support `module: Node16` (requires TS 4.7+), so it compiled everything to **CommonJS** instead of ESM
4. The pre-built ESM `dist/index.js` (`export { DefaultResourceLoader } ...`) was overwritten with CJS (`"use strict"; exports.DefaultResourceLoader = ...`)
5. ESM `import { DefaultResourceLoader }` from the CJS module fails with the reported error

**Evidence:** `head -1 dist/index.js` → `"use strict";` (CJS, should be ESM export)

## Fix

Gate the mtime comparison behind `.git` presence. The staleness check is only meaningful in developer git checkouts (catching stale dist/ after `git pull`). End-user npm installs have correctly pre-built dist/ and should never trigger a rebuild.

```js
const isGitRepo = existsSync(join(root, '.git'))

if (isGitRepo) {
  // only then compare src vs dist mtimes
}
```

## Test plan

- [ ] Fresh `npm install -g gsd-pi` → `gsd --version` works (no DefaultResourceLoader error)
- [ ] Dev workflow: in git clone, delete `packages/pi-coding-agent/dist/`, run `node scripts/ensure-workspace-builds.cjs` → rebuilds correctly
- [ ] After `git pull` with updated sources, stale dist is still detected and rebuilt

## Workaround for affected users

```bash
npm install -g gsd-pi@2.54.0 --ignore-scripts
cd $(npm root -g)/gsd-pi && node scripts/link-workspace-packages.cjs
```