### PR TITLE
fix(gsd): discover project subagents in .gsd

### DIFF
--- a/src/resources/extensions/gsd/tests/subagent-agent-discovery.test.ts
+++ b/src/resources/extensions/gsd/tests/subagent-agent-discovery.test.ts
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import { discoverAgents } from "../../subagent/agents.ts";
+
+function makeProjectRoot(t: test.TestContext): string {
+	const root = mkdtempSync(join(tmpdir(), "gsd-subagent-agents-"));
+	t.after(() => rmSync(root, { recursive: true, force: true }));
+	return root;
+}
+
+function writeAgent(root: string, configDirName: ".gsd" | ".pi", name = "ping"): string {
+	const agentsDir = join(root, configDirName, "agents");
+	mkdirSync(agentsDir, { recursive: true });
+	writeFileSync(
+		join(agentsDir, `${name}.md`),
+		`---\nname: ${name}\ndescription: ${name} agent\n---\nSay hello\n`,
+	);
+	return agentsDir;
+}
+
+test("discoverAgents finds project agents in .gsd/agents", (t) => {
+	const root = makeProjectRoot(t);
+	const agentsDir = writeAgent(root, ".gsd");
+
+	const discovery = discoverAgents(root, "project");
+
+	assert.equal(discovery.projectAgentsDir, agentsDir);
+	assert.deepEqual(discovery.agents.map((agent) => agent.name), ["ping"]);
+	assert.equal(discovery.agents[0]?.source, "project");
+});
+
+test("discoverAgents falls back to legacy .pi/agents when needed", (t) => {
+	const root = makeProjectRoot(t);
+	const agentsDir = writeAgent(root, ".pi");
+
+	const discovery = discoverAgents(root, "project");
+
+	assert.equal(discovery.projectAgentsDir, agentsDir);
+	assert.deepEqual(discovery.agents.map((agent) => agent.name), ["ping"]);
+});

--- a/src/resources/extensions/subagent/agents.ts
+++ b/src/resources/extensions/subagent/agents.ts
@@ -6,6 +6,8 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { getAgentDir, parseFrontmatter } from "@gsd/pi-coding-agent";
 
+const PROJECT_AGENT_DIR_CANDIDATES = [".gsd", ".pi"] as const;
+
 export type AgentScope = "user" | "project" | "both";
 
 export interface AgentConfig {
@@ -85,8 +87,12 @@ function isDirectory(p: string): boolean {
 function findNearestProjectAgentsDir(cwd: string): string | null {
 	let currentDir = cwd;
 	while (true) {
-		const candidate = path.join(currentDir, ".pi", "agents");
-		if (isDirectory(candidate)) return candidate;
+		// Prefer the documented project-local location while preserving support
+		// for older workarounds that placed agents under .pi/agents.
+		for (const configDir of PROJECT_AGENT_DIR_CANDIDATES) {
+			const candidate = path.join(currentDir, configDir, "agents");
+			if (isDirectory(candidate)) return candidate;
+		}
 
 		const parentDir = path.dirname(currentDir);
 		if (parentDir === currentDir) return null;


### PR DESCRIPTION
## TL;DR

**What:** Fix project-local subagent discovery so `.gsd/agents/` is actually scanned.
**Why:** The tool description and user guidance point to `.gsd/agents/`, but discovery was still hardcoded to `.pi/agents/`.
**How:** Switch project-level discovery to `.gsd/agents/` and lock the behavior with a regression test.

## What

This change updates project-local subagent discovery to look in `.gsd/agents/` instead of `.pi/agents/` and adds a regression test that proves project-local agent definitions are found from the documented path.

## Why

Closes #2864.

The current behavior silently ignores project-local agents created in `.gsd/agents/`, even though that is the path described in the tool prompt and command guidance. That makes project-local subagents fail to appear despite following the documented workflow.

## How

- update the project-level discovery helper in `src/resources/extensions/subagent/agents.ts`
- add `subagent-agent-discovery.test.ts` to lock the documented `.gsd/agents/` behavior
- refresh the branch on current `upstream/main` and re-run the full local gate

## Change type

- [x] `fix` — Bug fix
- [ ] `feat` — New feature or capability
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [x] `gsd extension` — GSD workflow
- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

Manual verification:
- reproduced the project-local subagent discovery mismatch against the documented `.gsd/agents/` path
- verified project-local discovery now resolves agents from `.gsd/agents/`
- ran `npm run build`, `npm run typecheck:extensions`, `npm run test:unit`, and `npm run test:integration`
- manually reviewed the diff for leaked secrets or local machine details

## AI disclosure

- [x] This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.
