### PR TITLE
fix(ci): copy web/components to dist-test for xterm-theme test

### DIFF
--- a/scripts/compile-tests.mjs
+++ b/scripts/compile-tests.mjs
@@ -130,6 +130,9 @@ async function main() {
   // Copy web/lib/ assets (tests import from ../../web/lib/ relative to dist-test/src/tests/)
   await copyAssets(join(ROOT, 'web', 'lib'), join(ROOT, 'dist-test', 'web', 'lib'));
 
+  // Copy web/components/ assets (xterm-theme test reads shell-terminal.tsx via import.meta.dirname)
+  await copyAssets(join(ROOT, 'web', 'components'), join(ROOT, 'dist-test', 'web', 'components'));
+
   // Copy scripts/ non-TS files (.cjs etc) — some tests require() scripts directly
   await copyAssets(join(ROOT, 'scripts'), join(ROOT, 'dist-test', 'scripts'));
 


### PR DESCRIPTION
## Summary
- The `xterm-theme.test.ts` test reads `shell-terminal.tsx` and `main-session-terminal.tsx` via `readFileSync` relative to `import.meta.dirname`
- When compiled tests run from `dist-test/src/tests/`, this resolves to `dist-test/web/components/gsd/` — but `compile-tests.mjs` only copied `web/lib/`, not `web/components/`
- Added `copyAssets` call for `web/components/` alongside the existing `web/lib/` copy

## Test plan
- [x] `npm run test:compile` succeeds and copies `web/components/` to `dist-test/`
- [x] `xterm-theme.test.js` passes both subtests including "terminal components share the central xterm theme helper"

🤖 Generated with [Claude Code](https://claude.com/claude-code)