### PR TITLE
fix(preferences-models): route all completion/planning unit types to correct phase model (fixes #2894)

### DIFF
--- a/src/resources/extensions/gsd/preferences-models.ts
+++ b/src/resources/extensions/gsd/preferences-models.ts
@@ -63,8 +63,19 @@ export function resolveModelWithFallbacksForUnit(unitType: string): ResolvedMode
       phaseConfig = m.execution_simple ?? m.execution;
       break;
     case "complete-slice":
+    case "complete-milestone":
+    case "validate-milestone":
+    case "gate-evaluate":
+    case "rewrite-docs":
     case "run-uat":
       phaseConfig = m.completion;
+      break;
+    case "reassess-roadmap":
+    case "discuss-milestone":
+      phaseConfig = m.planning;
+      break;
+    case "reactive-execute":
+      phaseConfig = m.execution;
       break;
     default:
       // Subagent unit types (e.g., "subagent", "subagent/scout")

--- a/src/resources/extensions/gsd/tests/preferences-models-unit-routing.test.ts
+++ b/src/resources/extensions/gsd/tests/preferences-models-unit-routing.test.ts
@@ -1,0 +1,103 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { resolveModelWithFallbacksForUnit } from "../preferences-models.js";
+
+function withPrefs(prefsYaml: string, fn: () => void): void {
+  const originalCwd = process.cwd();
+  const originalGsdHome = process.env.GSD_HOME;
+  const tempProject = mkdtempSync(join(tmpdir(), "gsd-unit-routing-"));
+  const tempGsdHome = mkdtempSync(join(tmpdir(), "gsd-unit-routing-home-"));
+
+  try {
+    mkdirSync(join(tempProject, ".gsd"), { recursive: true });
+    writeFileSync(
+      join(tempProject, ".gsd", "PREFERENCES.md"),
+      prefsYaml,
+      "utf-8",
+    );
+    process.env.GSD_HOME = tempGsdHome;
+    process.chdir(tempProject);
+    fn();
+  } finally {
+    process.chdir(originalCwd);
+    if (originalGsdHome === undefined) delete process.env.GSD_HOME;
+    else process.env.GSD_HOME = originalGsdHome;
+    rmSync(tempProject, { recursive: true, force: true });
+    rmSync(tempGsdHome, { recursive: true, force: true });
+  }
+}
+
+const PREFS = [
+  "---",
+  "models:",
+  "  research: research-model",
+  "  planning: planning-model",
+  "  execution: execution-model",
+  "  completion: completion-model",
+  "  subagent: subagent-model",
+  "---",
+].join("\n");
+
+test("all completion-phase unit types resolve to models.completion (issue #2894)", () => {
+  withPrefs(PREFS, () => {
+    const completionTypes = [
+      "complete-slice",
+      "complete-milestone",
+      "validate-milestone",
+      "gate-evaluate",
+      "rewrite-docs",
+      "run-uat",
+    ];
+    for (const unitType of completionTypes) {
+      const result = resolveModelWithFallbacksForUnit(unitType);
+      assert.ok(result, `${unitType} should resolve to a model config`);
+      assert.equal(result.primary, "completion-model", `${unitType} should map to completion model`);
+    }
+  });
+});
+
+test("reassess-roadmap and discuss-milestone resolve to models.planning (issue #2894)", () => {
+  withPrefs(PREFS, () => {
+    const planningTypes = [
+      "plan-milestone",
+      "plan-slice",
+      "replan-slice",
+      "reassess-roadmap",
+      "discuss-milestone",
+    ];
+    for (const unitType of planningTypes) {
+      const result = resolveModelWithFallbacksForUnit(unitType);
+      assert.ok(result, `${unitType} should resolve to a model config`);
+      assert.equal(result.primary, "planning-model", `${unitType} should map to planning model`);
+    }
+  });
+});
+
+test("reactive-execute resolves to models.execution (issue #2894)", () => {
+  withPrefs(PREFS, () => {
+    const result = resolveModelWithFallbacksForUnit("reactive-execute");
+    assert.ok(result, "reactive-execute should resolve to a model config");
+    assert.equal(result.primary, "execution-model", "reactive-execute should map to execution model");
+  });
+});
+
+test("research unit types resolve to models.research", () => {
+  withPrefs(PREFS, () => {
+    for (const unitType of ["research-milestone", "research-slice"]) {
+      const result = resolveModelWithFallbacksForUnit(unitType);
+      assert.ok(result, `${unitType} should resolve`);
+      assert.equal(result.primary, "research-model", `${unitType} should map to research model`);
+    }
+  });
+});
+
+test("unknown unit type returns undefined", () => {
+  withPrefs(PREFS, () => {
+    const result = resolveModelWithFallbacksForUnit("nonexistent-type");
+    assert.equal(result, undefined);
+  });
+});


### PR DESCRIPTION
## TL;DR

**What:** Add missing `case` entries in `resolveModelWithFallbacksForUnit` so all unit types route to the correct phase model.
**Why:** 5 of 7 completion-phase unit types silently fell back to the session start model (often opus) instead of using `models.completion` (typically haiku) — 10-20× cost difference.
**How:** Add the missing case-fall-throughs for completion, planning, and execution phases.

## What

Two files changed:

- `src/resources/extensions/gsd/preferences-models.ts` — added missing `case` entries in the `switch` statement
- `src/resources/extensions/gsd/tests/preferences-models-unit-routing.test.ts` — new regression test covering all unit type → phase mappings

## Why

`resolveModelWithFallbacksForUnit()` only mapped 2 of 7 completion-phase unit types (`complete-slice`, `run-uat`). The remaining types — `complete-milestone`, `validate-milestone`, `gate-evaluate`, `rewrite-docs` — fell through to `default → return undefined`. When this returns undefined, `selectAndApplyModel` skips dynamic routing and re-applies the session start model (often opus).

Similarly, `reassess-roadmap` and `discuss-milestone` were missing from the planning phase mapping, and `reactive-execute` from execution.

Closes #2894

## How

Added the missing cases to the switch statement:

**Completion phase** (→ `models.completion`):
- `complete-milestone`
- `validate-milestone`
- `gate-evaluate`
- `rewrite-docs`

**Planning phase** (→ `models.planning`):
- `reassess-roadmap`
- `discuss-milestone`

**Execution phase** (→ `models.execution`):
- `reactive-execute`

Cross-referenced against `auto-dispatch.ts`, `auto-recovery.ts`, `auto-post-unit.ts`, and `complexity-classifier.ts` to confirm coverage of all dispatched unit types.

The regression test sets up a PREFERENCES.md with distinct model names per phase and verifies every unit type resolves to the expected phase model.

---

- [x] `fix` — Bug fix