### PR TITLE
fix(auto-dispatch): accept checkmark emoji in operational verification gate (fixes #2862)

### DIFF
--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -683,7 +683,7 @@ export const DISPATCH_RULES: DispatchRule[] = [
                   validationContent.includes("Operational") &&
                   (validationContent.includes("MET") || validationContent.includes("N/A"));
                 const proseMatch =
-                  /[Oo]perational[\s:][^\n]*(?:pass|verified|confirmed|met|complete|true|yes|addressed|covered|n\/a|not\s+applicable)/i.test(validationContent);
+                  /[Oo]perational[\s:][^\n]*(?:✅|pass|verified|confirmed|met|complete|true|yes|addressed|covered|n\/a|not\s+applicable)/i.test(validationContent);
                 const hasOperationalCheck = structuredMatch || proseMatch;
                 if (!hasOperationalCheck) {
                   return {

--- a/src/resources/extensions/gsd/tests/validation-gate-patterns.test.ts
+++ b/src/resources/extensions/gsd/tests/validation-gate-patterns.test.ts
@@ -25,7 +25,7 @@ function hasOperationalEvidence(validationContent: string): boolean {
     validationContent.includes("Operational") &&
     (validationContent.includes("MET") || validationContent.includes("N/A"));
   const proseMatch =
-    /[Oo]perational[\s:][^\n]*(?:pass|verified|confirmed|met|complete|true|yes|addressed|covered|n\/a|not\s+applicable)/i.test(
+    /[Oo]perational[\s:][^\n]*(?:✅|pass|verified|confirmed|met|complete|true|yes|addressed|covered|n\/a|not\s+applicable)/i.test(
       validationContent,
     );
   return structuredMatch || proseMatch;
@@ -101,6 +101,11 @@ test('prose: "Operational: n/a" passes', () => {
 
 test('prose: "Operational: complete" passes', () => {
   const content = `Operational: complete — all health checks green.`;
+  assert.ok(hasOperationalEvidence(content));
+});
+
+test('prose: "Operational: ✅" checkmark emoji passes (issue #2862)', () => {
+  const content = `- **Operational:** ✅ DECISIONS.md documents D009-D013`;
   assert.ok(hasOperationalEvidence(content));
 });
 


### PR DESCRIPTION
## TL;DR

**What:** Add `✅` to the operational verification prose regex so checkmark-based compliance indicators are accepted.
**Why:** The regex rejected `✅` as a valid indicator, triggering a false positive warning that blocked milestone completion.
**How:** One emoji added to the regex alternation in `auto-dispatch.ts` and the mirrored test helper.

## What

- `src/resources/extensions/gsd/auto-dispatch.ts` — added `✅|` to the `proseMatch` regex alternation
- `src/resources/extensions/gsd/tests/validation-gate-patterns.test.ts` — updated mirrored regex + added regression test case

## Why

When validation output uses `✅` to indicate operational compliance (e.g. `- **Operational:** ✅ DECISIONS.md documents D009-D013`), the prose regex did not match — it only accepted text keywords like `pass`, `verified`, `confirmed` etc. This caused a false positive `dispatch-stop` warning that blocked milestone completion, even though `✅` is GSD's own standard status indicator used throughout the codebase.

Closes #2862

## How

Added `✅` as the first alternative in the prose regex:

```js
// Before
/[Oo]perational[\s:][^\n]*(?:pass|verified|confirmed|...)/i

// After  
/[Oo]perational[\s:][^\n]*(?:✅|pass|verified|confirmed|...)/i
```

Fully backward-compatible — all existing patterns continue to match.

---

- [x] `fix` — Bug fix