### PR TITLE
test(ci): copy web component sources into dist-test

### DIFF
--- a/scripts/compile-tests.mjs
+++ b/scripts/compile-tests.mjs
@@ -130,6 +130,9 @@ async function main() {
   // Copy web/lib/ assets (tests import from ../../web/lib/ relative to dist-test/src/tests/)
   await copyAssets(join(ROOT, 'web', 'lib'), join(ROOT, 'dist-test', 'web', 'lib'));
 
+  // Copy web/components/ source files for tests that inspect component code directly.
+  await copyAssets(join(ROOT, 'web', 'components'), join(ROOT, 'dist-test', 'web', 'components'));
+
   // Copy scripts/ non-TS files (.cjs etc) — some tests require() scripts directly
   await copyAssets(join(ROOT, 'scripts'), join(ROOT, 'dist-test', 'scripts'));
 


### PR DESCRIPTION
## TL;DR

**What:** Copy `web/components` into `dist-test` during test compilation.
**Why:** Source-based tests can currently fail on missing component files even when the product code is fine.
**How:** Extend the dist-test asset copy step to mirror `web/components` alongside the existing web test assets.

## What

Copy `web/components` into `dist-test/web/components` during `scripts/compile-tests.mjs`.

## Why

Current upstream can fail source-reading tests because `dist-test` mirrors `web/lib` but not `web/components`. That leaves tests like `xterm-theme.test.ts` reading paths that do not exist after compilation.

## How

Add one more asset copy step in `scripts/compile-tests.mjs` so the dist-test harness mirrors the web component sources it already expects to read.

## Change type

- [ ] `feat` — New feature or capability
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [ ] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [x] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [ ] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

Manual verification:
- reproduced the missing `dist-test/web/components` failure locally before the fix
- verified `scripts/compile-tests.mjs` now mirrors `web/components` into the compiled test tree
- ran `npm run build`, `npm run typecheck:extensions`, `npm run test:unit`, and `npm run test:integration`
- manually reviewed the diff for leaked secrets or local machine details

## AI disclosure

- [x] This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.
