### PR TITLE
fix(auto-artifact-paths): run-uat expected artifact is ASSESSMENT, not UAT (fixes #2873)

### DIFF
--- a/src/resources/extensions/gsd/auto-artifact-paths.ts
+++ b/src/resources/extensions/gsd/auto-artifact-paths.ts
@@ -52,7 +52,7 @@ export function resolveExpectedArtifactPath(
     }
     case "run-uat": {
       const dir = resolveSlicePath(base, mid, sid!);
-      return dir ? join(dir, buildSliceFileName(sid!, "UAT")) : null;
+      return dir ? join(dir, buildSliceFileName(sid!, "ASSESSMENT")) : null;
     }
     case "execute-task": {
       const dir = resolveSlicePath(base, mid, sid!);
@@ -118,7 +118,7 @@ export function diagnoseExpectedArtifact(
     case "reassess-roadmap":
       return `${relSliceFile(base, mid, sid!, "ASSESSMENT")} (roadmap reassessment)`;
     case "run-uat":
-      return `${relSliceFile(base, mid, sid!, "UAT")} (UAT result)`;
+      return `${relSliceFile(base, mid, sid!, "ASSESSMENT")} (UAT result)`;
     case "validate-milestone":
       return `${relMilestoneFile(base, mid, "VALIDATION")} (milestone validation report)`;
     case "complete-milestone":

--- a/src/resources/extensions/gsd/tests/integration/auto-recovery.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/auto-recovery.test.ts
@@ -111,7 +111,7 @@ test("resolveExpectedArtifactPath returns correct path for all slice-level types
 
   const uatResult = resolveExpectedArtifactPath("run-uat", "M001/S01", base);
   assert.ok(uatResult);
-  assert.ok(uatResult!.includes("UAT"));
+  assert.ok(uatResult!.includes("ASSESSMENT"), "run-uat expected artifact should be ASSESSMENT (not UAT spec)");
 });
 
 // ─── diagnoseExpectedArtifact ─────────────────────────────────────────────


### PR DESCRIPTION
## TL;DR

**What:** Change the expected artifact for `run-uat` from `S##-UAT.md` to `S##-ASSESSMENT.md`.
**Why:** The prompt instructs the agent to write via `gsd_summary_save` with `artifact_type: "ASSESSMENT"`, but artifact verification looked for `S##-UAT.md` — causing a stuck retry loop.
**How:** Update both `resolveExpectedArtifactPath` and `diagnoseExpectedArtifact` in `auto-artifact-paths.ts`.

## What

- `src/resources/extensions/gsd/auto-artifact-paths.ts` — changed `"UAT"` → `"ASSESSMENT"` for the `run-uat` case in both functions
- `src/resources/extensions/gsd/tests/integration/auto-recovery.test.ts` — updated assertion to expect `ASSESSMENT` in the path

## Why

The `run-uat` prompt tells the agent to save results via `gsd_summary_save` with `artifact_type: "ASSESSMENT"`, which writes to `S##-ASSESSMENT.md`. However, `resolveExpectedArtifactPath("run-uat", ...)` returned the path to `S##-UAT.md` — the *input* spec file, not the result file.

This contract mismatch meant the agent could follow the prompt exactly, write a valid result, and still have auto-mode think the expected artifact was never written — causing indefinite re-dispatch of `run-uat`.

Note: the redispatch guard in `checkNeedsRunUat` already had a workaround checking ASSESSMENT files (added in a prior fix). This change aligns the artifact verification path to match, closing the remaining gap.

Closes #2873

---

- [x] `fix` — Bug fix