### PR TITLE
fix(headless): skip execution_complete for multi-turn commands (auto/next)

### DIFF
--- a/src/headless.ts
+++ b/src/headless.ts
@@ -255,6 +255,7 @@ async function runHeadlessOnce(options: HeadlessOptions, restartCount: number): 
   // per-unit timeout via auto-supervisor. Disable the overall timeout unless the
   // user explicitly set --timeout.
   const isAutoMode = options.command === 'auto'
+  const isMultiTurnCommand = options.command === 'auto' || options.command === 'next'
   if (isAutoMode && options.timeout === 300_000) {
     options.timeout = 0
   }
@@ -571,7 +572,9 @@ async function runHeadlessOnce(options: HeadlessOptions, restartCount: number): 
     }
 
     // Handle execution_complete (v2 structured completion)
-    if (eventObj.type === 'execution_complete' && !completed) {
+    // Skip for multi-turn commands (auto, next) — their completion is detected via
+    // isTerminalNotification("Auto-mode stopped..."/"Step-mode stopped..."), not per-turn events
+    if (eventObj.type === 'execution_complete' && !completed && !isMultiTurnCommand) {
       completed = true
       const status = String(eventObj.status ?? 'success')
       exitCode = mapStatusToExitCode(status)

--- a/src/tests/headless-v2-migration.test.ts
+++ b/src/tests/headless-v2-migration.test.ts
@@ -132,6 +132,7 @@ interface EventHandlerState {
   blocked: boolean
   exitCode: number
   v2Enabled: boolean
+  isMultiTurnCommand?: boolean
 }
 
 function handleEvent(
@@ -140,7 +141,9 @@ function handleEvent(
   client: MockRpcClient,
 ): void {
   // execution_complete (v2 structured completion)
-  if (eventObj.type === 'execution_complete' && !state.completed) {
+  // Skip for multi-turn commands (auto, next) — their completion is detected via
+  // isTerminalNotification, not per-turn events
+  if (eventObj.type === 'execution_complete' && !state.completed && !state.isMultiTurnCommand) {
     state.completed = true
     const status = String(eventObj.status ?? 'success')
     state.exitCode = mapStatusToExitCode(status)
@@ -459,4 +462,73 @@ test('injector adapter handles multi-select values', () => {
   assert.equal(client.sendUICalls.length, 1)
   assert.equal(client.sendUICalls[0].id, 'inj3')
   assert.deepEqual(client.sendUICalls[0].response.values, ['a', 'b'])
+})
+
+// ─── multi-turn command (auto/next) skips execution_complete ───────────────
+
+test('execution_complete is ignored for multi-turn commands (auto)', () => {
+  const client = new MockRpcClient()
+  const state: EventHandlerState = { completed: false, blocked: false, exitCode: -1, v2Enabled: true, isMultiTurnCommand: true }
+
+  handleEvent({ type: 'execution_complete', status: 'success' }, state, client)
+
+  assert.equal(state.completed, false, 'should not mark completed for auto/next commands')
+  assert.equal(state.exitCode, -1, 'exit code should remain unchanged')
+})
+
+test('execution_complete is ignored for multi-turn commands even with error status', () => {
+  const client = new MockRpcClient()
+  const state: EventHandlerState = { completed: false, blocked: false, exitCode: -1, v2Enabled: true, isMultiTurnCommand: true }
+
+  handleEvent({ type: 'execution_complete', status: 'error' }, state, client)
+
+  assert.equal(state.completed, false, 'should not mark completed for auto/next commands')
+  assert.equal(state.exitCode, -1, 'exit code should remain unchanged')
+})
+
+test('multi-turn commands still complete via terminal notification', () => {
+  const client = new MockRpcClient()
+  const state: EventHandlerState = { completed: false, blocked: false, exitCode: -1, v2Enabled: true, isMultiTurnCommand: true }
+
+  // First, execution_complete fires (should be ignored)
+  handleEvent({ type: 'execution_complete', status: 'success' }, state, client)
+  assert.equal(state.completed, false, 'execution_complete should be skipped')
+
+  // Then the real terminal notification fires
+  handleEvent(
+    { type: 'extension_ui_request', method: 'notify', id: 'n1', message: 'Auto-mode stopped — all slices complete' },
+    state,
+    client,
+  )
+  assert.equal(state.completed, true, 'terminal notification should trigger completion')
+  assert.equal(state.exitCode, EXIT_SUCCESS)
+})
+
+test('multi-turn commands detect blocked via terminal notification', () => {
+  const client = new MockRpcClient()
+  const state: EventHandlerState = { completed: false, blocked: false, exitCode: -1, v2Enabled: true, isMultiTurnCommand: true }
+
+  // execution_complete is ignored
+  handleEvent({ type: 'execution_complete', status: 'success' }, state, client)
+  assert.equal(state.completed, false)
+
+  // Blocked terminal notification
+  handleEvent(
+    { type: 'extension_ui_request', method: 'notify', id: 'n2', message: 'Auto-mode stopped (Blocked: plan rejected)' },
+    state,
+    client,
+  )
+  assert.equal(state.completed, true)
+  assert.equal(state.blocked, true)
+  assert.equal(state.exitCode, EXIT_BLOCKED)
+})
+
+test('non-multi-turn commands still complete on execution_complete', () => {
+  const client = new MockRpcClient()
+  const state: EventHandlerState = { completed: false, blocked: false, exitCode: -1, v2Enabled: true, isMultiTurnCommand: false }
+
+  handleEvent({ type: 'execution_complete', status: 'success' }, state, client)
+
+  assert.equal(state.completed, true, 'single-turn commands should complete on execution_complete')
+  assert.equal(state.exitCode, EXIT_SUCCESS)
 })


### PR DESCRIPTION
## What
Skip `execution_complete` event handling for multi-turn commands (`auto` and `next`) in `headless.ts`.

## Why
`gsd headless auto` exits immediately with `Status: complete` and zero work done. The `execution_complete` handler fires on the first `agent_end` (when `/gsd auto` is processed as an extension command), resolving the completion promise before auto-mode executes any units.

Multi-turn commands have their own completion signals via `isTerminalNotification` ("Auto-mode stopped..."/"Step-mode stopped...") and should not exit on the per-turn `execution_complete` event.

Closes #2917

## How
- Added `isMultiTurnCommand` variable (`options.command === 'auto' || options.command === 'next'`) alongside the existing `isAutoMode` variable
- Guarded the `execution_complete` handler with `!isMultiTurnCommand` so multi-turn commands rely solely on terminal notifications for completion detection
- Kept `isAutoMode` separate for timeout handling (auto disables timeout, next keeps it)

## Key changes
- `src/headless.ts` — added `isMultiTurnCommand` flag, guarded `execution_complete` handler
- `src/tests/headless-v2-migration.test.ts` — added 5 tests: execution_complete ignored for multi-turn, error status also ignored, terminal notification still works, blocked detection still works, single-turn commands unaffected

## Testing
- All 96 headless tests pass (headless-v2-migration, headless-events, headless-detection, headless-cli-surface)
- TypeScript type check clean (`tsc --noEmit`)
- New tests verify: multi-turn commands ignore execution_complete, still complete via terminal notification, blocked detection works, and single-turn commands are unaffected

## Risk
Low — the guard only affects `auto` and `next` commands which already had broken behavior (immediate exit). All other commands are unaffected. Terminal notification detection (the existing v1 path) is battle-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)