### PR TITLE
fix: align @gsd/native with CJS build output

### DIFF
--- a/packages/native/package.json
+++ b/packages/native/package.json
@@ -2,7 +2,7 @@
   "name": "@gsd/native",
   "version": "0.1.0",
   "description": "Native Rust bindings for GSD \u2014 high-performance native modules via N-API",
-  "type": "module",
+  "type": "commonjs",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "scripts": {
@@ -14,75 +14,75 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "default": "./dist/index.js"
     },
     "./grep": {
       "types": "./dist/grep/index.d.ts",
-      "import": "./dist/grep/index.js"
+      "default": "./dist/grep/index.js"
     },
     "./ps": {
       "types": "./dist/ps/index.d.ts",
-      "import": "./dist/ps/index.js"
+      "default": "./dist/ps/index.js"
     },
     "./glob": {
       "types": "./dist/glob/index.d.ts",
-      "import": "./dist/glob/index.js"
+      "default": "./dist/glob/index.js"
     },
     "./clipboard": {
       "types": "./dist/clipboard/index.d.ts",
-      "import": "./dist/clipboard/index.js"
+      "default": "./dist/clipboard/index.js"
     },
     "./ast": {
       "types": "./dist/ast/index.d.ts",
-      "import": "./dist/ast/index.js"
+      "default": "./dist/ast/index.js"
     },
     "./html": {
       "types": "./dist/html/index.d.ts",
-      "import": "./dist/html/index.js"
+      "default": "./dist/html/index.js"
     },
     "./text": {
       "types": "./dist/text/index.d.ts",
-      "import": "./dist/text/index.js"
+      "default": "./dist/text/index.js"
     },
     "./fd": {
       "types": "./dist/fd/index.d.ts",
-      "import": "./dist/fd/index.js"
+      "default": "./dist/fd/index.js"
     },
     "./image": {
       "types": "./dist/image/index.d.ts",
-      "import": "./dist/image/index.js"
+      "default": "./dist/image/index.js"
     },
     "./xxhash": {
       "types": "./dist/xxhash/index.d.ts",
-      "import": "./dist/xxhash/index.js"
+      "default": "./dist/xxhash/index.js"
     },
     "./diff": {
       "types": "./dist/diff/index.d.ts",
-      "import": "./dist/diff/index.js"
+      "default": "./dist/diff/index.js"
     },
     "./gsd-parser": {
       "types": "./dist/gsd-parser/index.d.ts",
-      "import": "./dist/gsd-parser/index.js"
+      "default": "./dist/gsd-parser/index.js"
     },
     "./highlight": {
       "types": "./dist/highlight/index.d.ts",
-      "import": "./dist/highlight/index.js"
+      "default": "./dist/highlight/index.js"
     },
     "./json-parse": {
       "types": "./dist/json-parse/index.d.ts",
-      "import": "./dist/json-parse/index.js"
+      "default": "./dist/json-parse/index.js"
     },
     "./stream-process": {
       "types": "./dist/stream-process/index.d.ts",
-      "import": "./dist/stream-process/index.js"
+      "default": "./dist/stream-process/index.js"
     },
     "./truncate": {
       "types": "./dist/truncate/index.d.ts",
-      "import": "./dist/truncate/index.js"
+      "default": "./dist/truncate/index.js"
     },
     "./ttsr": {
       "types": "./dist/ttsr/index.d.ts",
-      "import": "./dist/ttsr/index.js"
+      "default": "./dist/ttsr/index.js"
     }
   },
   "files": [

--- a/packages/native/src/native.ts
+++ b/packages/native/src/native.ts
@@ -8,12 +8,7 @@
  *   3. native/addon/gsd_engine.dev.node (local debug build)
  */
 
-import { createRequire } from "node:module";
 import * as path from "node:path";
-import { fileURLToPath } from "node:url";
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const require = createRequire(import.meta.url);
 
 const addonDir = path.resolve(__dirname, "..", "..", "..", "native", "addon");
 const platformTag = `${process.platform}-${process.arch}`;


### PR DESCRIPTION
## Summary

- `@gsd/native` declares `"type": "module"` in package.json but `tsc` compiles the dist/ to CommonJS (`require()`/`Object.defineProperty(exports, ...)`). This CJS/ESM mismatch causes Node.js to fail resolving named exports, crashing GSD at startup with `SyntaxError: The requested module '@gsd/native' does not provide an export named 'parseStreamingJson'`.
- Changes `"type"` from `"module"` to `"commonjs"` to match the actual build output
- Replaces `"import"` export conditions with `"default"` for universal compatibility
- Removes ESM-only `import.meta.url` and `createRequire` from `native.ts` — CJS provides `__dirname` and `require` natively

Fixes #2861

## Root cause

The root tsconfig uses `"module": "NodeNext"`, which determines output format from the closest `package.json` `type` field. With `"type": "module"`, TypeScript should emit ESM — but the published dist contains CJS. This mismatch means Node.js treats the `.js` files as ESM (due to the `type` field) but can't resolve named exports from the CJS-style code.

## Test plan

- [ ] `npm install -g gsd-pi` on Node.js v22 — `gsd` launches without `SyntaxError`
- [ ] `npm install -g gsd-pi` on Node.js v24 — `gsd` launches without `SyntaxError`
- [ ] Native addon loads correctly on supported platforms (darwin-arm64, darwin-x64, linux-x64)
- [ ] JS fallback path still works when native addon is unavailable