### PR TITLE
fix: claude-code provider statelessness and invisible tool results

### DIFF
--- a/packages/pi-agent-core/src/agent-loop.ts
+++ b/packages/pi-agent-core/src/agent-loop.ts
@@ -239,7 +239,11 @@ async function runLoop(
 			if (hasMoreToolCalls && config.externalToolExecution) {
 				// External execution mode: tools were handled by the provider
 				// (e.g., Claude Code SDK). Emit tool_execution events for each
-				// tool call. The TUI adds these as components after the message.
+				// tool call with actual results when available.
+				const externalResults = (message as any)._externalToolResults as
+					| Record<string, { content: Array<{ type: string; text?: string }>; isError: boolean }>
+					| undefined;
+
 				for (const tc of toolCalls as AgentToolCall[]) {
 					stream.push({
 						type: "tool_execution_start",
@@ -247,15 +251,16 @@ async function runLoop(
 						toolName: tc.name,
 						args: tc.arguments,
 					});
+
+					const paired = externalResults?.[tc.id];
 					stream.push({
 						type: "tool_execution_end",
 						toolCallId: tc.id,
 						toolName: tc.name,
-						result: {
-							content: [{ type: "text", text: "(executed by Claude Code)" }],
-							details: {},
-						},
-						isError: false,
+						result: paired
+							? { content: paired.content, details: {} }
+							: { content: [{ type: "text", text: "(executed by Claude Code)" }], details: {} },
+						isError: paired?.isError ?? false,
 					});
 				}
 				// Don't add tool results to context or loop back — the streamSimple

--- a/src/resources/extensions/claude-code-cli/sdk-types.ts
+++ b/src/resources/extensions/claude-code-cli/sdk-types.ts
@@ -27,6 +27,19 @@ export type BetaContentBlock =
 	| { type: "server_tool_use"; id: string; name: string; input: unknown }
 	| { type: "web_search_tool_result"; tool_use_id: string; content: unknown };
 
+/** Tool result block from a user message (Anthropic API MessageParam format). */
+export interface ToolResultBlock {
+	type: "tool_result";
+	tool_use_id: string;
+	content?: string | Array<{ type: "text"; text: string } | { type: "image"; source: unknown }>;
+	is_error?: boolean;
+}
+
+/** Content block in a user message (MessageParam format). */
+export type UserContentBlock =
+	| { type: "text"; text: string }
+	| ToolResultBlock;
+
 /** Streaming event emitted when includePartialMessages is true. */
 export interface BetaRawMessageStreamEvent {
 	type: string;
@@ -48,7 +61,7 @@ export interface SDKUserMessage {
 	type: "user";
 	uuid?: UUID;
 	session_id: string;
-	message: unknown;
+	message: { role: "user"; content: string | UserContentBlock[] };
 	parent_tool_use_id: string | null;
 	isSynthetic?: boolean;
 	tool_use_result?: unknown;

--- a/src/resources/extensions/claude-code-cli/stream-adapter.ts
+++ b/src/resources/extensions/claude-code-cli/stream-adapter.ts
@@ -3,8 +3,15 @@
  *
  * The SDK runs the full agentic loop (multi-turn, tool execution, compaction)
  * in one call. This adapter translates the SDK's streaming output into
- * AssistantMessageEvents for TUI rendering, then strips tool-call blocks from
- * the final AssistantMessage so GSD's agent loop doesn't try to dispatch them.
+ * AssistantMessageEvents for TUI rendering.
+ *
+ * Key behaviors:
+ * - Session persistence enabled by default — subsequent calls resume the
+ *   previous session so Claude Code maintains conversational continuity.
+ * - Tool results are captured from SDK user messages and paired with their
+ *   corresponding tool calls for accurate TUI rendering.
+ * - Tool execution events are emitted in real-time as intermediate turns
+ *   complete, preserving chronological order (tools above final text).
  */
 
 import type {
@@ -14,6 +21,7 @@ import type {
 	Context,
 	Model,
 	SimpleStreamOptions,
+	ToolCall,
 } from "@gsd/pi-ai";
 import { EventStream } from "@gsd/pi-ai";
 import { execSync } from "node:child_process";
@@ -26,6 +34,8 @@ import type {
 	SDKSystemMessage,
 	SDKStatusMessage,
 	SDKUserMessage,
+	ToolResultBlock,
+	UserContentBlock,
 } from "./sdk-types.js";
 
 // ---------------------------------------------------------------------------
@@ -71,13 +81,20 @@ function getClaudePath(): string {
 }
 
 // ---------------------------------------------------------------------------
+// Session tracking
+// ---------------------------------------------------------------------------
+
+/** Per-model session IDs for cross-turn continuity. */
+const sessionMap = new Map<string, string>();
+
+// ---------------------------------------------------------------------------
 // Prompt extraction
 // ---------------------------------------------------------------------------
 
 /**
  * Extract the last user prompt text from GSD's context messages.
- * The SDK manages its own conversation history — we only send
- * the latest user message as the prompt.
+ * When resuming a session, the SDK already has conversation history —
+ * we only need to send the new user message.
  */
 function extractLastUserPrompt(context: Context): string {
 	for (let i = context.messages.length - 1; i >= 0; i--) {
@@ -93,6 +110,46 @@ function extractLastUserPrompt(context: Context): string {
 		}
 	}
 	return "";
+}
+
+// ---------------------------------------------------------------------------
+// Tool result extraction
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract tool results from an SDK user message. The user message contains
+ * `tool_result` content blocks with actual tool output (bash stdout, file
+ * contents, edit diffs, etc.) paired by `tool_use_id`.
+ */
+export function extractToolResults(
+	userMsg: SDKUserMessage,
+): Map<string, { content: Array<{ type: string; text?: string }>; isError: boolean }> {
+	const results = new Map<string, { content: Array<{ type: string; text?: string }>; isError: boolean }>();
+	const msgContent = userMsg.message?.content;
+	if (!msgContent || typeof msgContent === "string") return results;
+
+	for (const block of msgContent as UserContentBlock[]) {
+		if (block.type !== "tool_result") continue;
+		const toolResult = block as ToolResultBlock;
+
+		let content: Array<{ type: string; text?: string }>;
+		if (typeof toolResult.content === "string") {
+			content = [{ type: "text", text: toolResult.content }];
+		} else if (Array.isArray(toolResult.content)) {
+			content = toolResult.content.map((c) => {
+				if (c.type === "text") return { type: "text", text: c.text };
+				return { type: c.type };
+			});
+		} else {
+			content = [{ type: "text", text: "(no output)" }];
+		}
+
+		results.set(toolResult.tool_use_id, {
+			content,
+			isError: toolResult.is_error ?? false,
+		});
+	}
+	return results;
 }
 
 // ---------------------------------------------------------------------------
@@ -128,6 +185,15 @@ export function makeStreamExhaustedErrorMessage(model: string, lastTextContent: 
 }
 
 // ---------------------------------------------------------------------------
+// Intermediate tool call with paired result
+// ---------------------------------------------------------------------------
+
+interface ToolCallWithResult {
+	toolCall: ToolCall;
+	result: { content: Array<{ type: string; text?: string }>; isError: boolean } | null;
+}
+
+// ---------------------------------------------------------------------------
 // streamSimple implementation
 // ---------------------------------------------------------------------------
 
@@ -135,8 +201,9 @@ export function makeStreamExhaustedErrorMessage(model: string, lastTextContent: 
  * GSD streamSimple function that delegates to the Claude Agent SDK.
  *
  * Emits AssistantMessageEvent deltas for real-time TUI rendering
- * (thinking, text, tool calls). The final AssistantMessage has tool-call
- * blocks stripped so the agent loop ends the turn without local dispatch.
+ * (thinking, text, tool calls). Tool execution events are emitted
+ * as intermediate turns complete, with actual tool results from
+ * the SDK's user messages.
  */
 export function streamViaClaudeCode(
 	model: Model<any>,
@@ -161,8 +228,10 @@ async function pumpSdkMessages(
 	/** Track the last text content seen across all assistant turns for the final message. */
 	let lastTextContent = "";
 	let lastThinkingContent = "";
-	/** Collect tool calls from intermediate SDK turns for tool_execution events. */
-	const intermediateToolCalls: AssistantMessage["content"] = [];
+	/** Tool calls from the current intermediate assistant turn (reset on user message). */
+	let pendingToolCalls: ToolCall[] = [];
+	/** All intermediate tool calls with their paired results, for the final message. */
+	const intermediateToolCallsWithResults: ToolCallWithResult[] = [];
 
 	try {
 		// Dynamic import — the SDK is an optional dependency.
@@ -181,23 +250,28 @@ async function pumpSdkMessages(
 		}
 
 		const prompt = extractLastUserPrompt(context);
+		const existingSessionId = sessionMap.get(modelId);
 
-		const queryResult = sdk.query({
-			prompt,
-			options: {
-				pathToClaudeCodeExecutable: getClaudePath(),
-				model: modelId,
-				includePartialMessages: true,
-				persistSession: false,
-				abortController: controller,
-				cwd: process.cwd(),
-				permissionMode: "bypassPermissions",
-				allowDangerouslySkipPermissions: true,
-				settingSources: ["project"],
-				systemPrompt: { type: "preset", preset: "claude_code" },
-				betas: modelId.includes("sonnet") ? ["context-1m-2025-08-07"] : [],
-			},
-		});
+		const queryOptions: Record<string, unknown> = {
+			pathToClaudeCodeExecutable: getClaudePath(),
+			model: modelId,
+			includePartialMessages: true,
+			persistSession: true,
+			abortController: controller,
+			cwd: process.cwd(),
+			permissionMode: "bypassPermissions",
+			allowDangerouslySkipPermissions: true,
+			settingSources: ["project"],
+			systemPrompt: { type: "preset", preset: "claude_code" },
+			betas: modelId.includes("sonnet") ? ["context-1m-2025-08-07"] : [],
+		};
+
+		// Resume previous session for conversational continuity
+		if (existingSessionId) {
+			queryOptions.resume = existingSessionId;
+		}
+
+		const queryResult = sdk.query({ prompt, options: queryOptions });
 
 		// Emit start with an empty partial
 		const initialPartial: AssistantMessage = {
@@ -218,7 +292,11 @@ async function pumpSdkMessages(
 			switch (msg.type) {
 				// -- Init --
 				case "system": {
-					// Nothing to emit — the stream is already started.
+					// Track session ID for future resumption
+					const sysMsg = msg as SDKSystemMessage;
+					if (sysMsg.session_id) {
+						sessionMap.set(modelId, sysMsg.session_id as string);
+					}
 					break;
 				}
 
@@ -226,6 +304,11 @@ async function pumpSdkMessages(
 				case "stream_event": {
 					const partial = msg as SDKPartialAssistantMessage;
 					if (partial.parent_tool_use_id !== null) break; // skip subagent
+
+					// Track session ID from any message
+					if (partial.session_id) {
+						sessionMap.set(modelId, partial.session_id);
+					}
 
 					const event = partial.event;
 
@@ -241,14 +324,11 @@ async function pumpSdkMessages(
 
 					const assistantEvent = builder.handleEvent(event);
 					if (assistantEvent) {
-						// Skip toolcall events — the agent loop's externalToolExecution
-						// path emits tool_execution_start/end events after streamSimple
-						// returns. Streaming toolcall events would render tool calls
-						// out of order in the TUI's accumulated message content.
-						const t = assistantEvent.type;
-						if (t !== "toolcall_start" && t !== "toolcall_delta" && t !== "toolcall_end") {
-							stream.push(assistantEvent);
-						}
+						// Stream text and thinking events for real-time TUI rendering.
+						// Tool call events are also streamed — they render in the
+						// correct chronological position (during the turn, before
+						// final text from a later turn).
+						stream.push(assistantEvent);
 					}
 					break;
 				}
@@ -258,12 +338,23 @@ async function pumpSdkMessages(
 					const sdkAssistant = msg as SDKAssistantMessage;
 					if (sdkAssistant.parent_tool_use_id !== null) break;
 
-					// Capture text content from complete messages
+					if (sdkAssistant.session_id) {
+						sessionMap.set(modelId, sdkAssistant.session_id);
+					}
+
+					// Capture text content and tool calls from complete messages
 					for (const block of sdkAssistant.message.content) {
 						if (block.type === "text") {
 							lastTextContent = block.text;
 						} else if (block.type === "thinking") {
 							lastThinkingContent = block.thinking;
+						} else if (block.type === "tool_use") {
+							pendingToolCalls.push({
+								type: "toolCall",
+								id: block.id,
+								name: block.name,
+								arguments: block.input,
+							});
 						}
 					}
 					break;
@@ -274,7 +365,14 @@ async function pumpSdkMessages(
 					const userMsg = msg as SDKUserMessage;
 					if (userMsg.parent_tool_use_id !== null) break;
 
-					// Capture content from the completed turn before resetting
+					if (userMsg.session_id) {
+						sessionMap.set(modelId, userMsg.session_id);
+					}
+
+					// Extract tool results from the user message
+					const toolResults = extractToolResults(userMsg);
+
+					// Capture content from the completed assistant turn
 					if (builder) {
 						for (const block of builder.message.content) {
 							if (block.type === "text" && block.text) {
@@ -282,11 +380,18 @@ async function pumpSdkMessages(
 							} else if (block.type === "thinking" && block.thinking) {
 								lastThinkingContent = block.thinking;
 							} else if (block.type === "toolCall") {
-								// Collect tool calls for externalToolExecution rendering
-								intermediateToolCalls.push(block);
+								pendingToolCalls.push(block);
 							}
 						}
 					}
+
+					// Pair tool calls with their results and store for final message
+					for (const tc of pendingToolCalls) {
+						const result = toolResults.get(tc.id) ?? null;
+						intermediateToolCallsWithResults.push({ toolCall: tc, result });
+					}
+
+					pendingToolCalls = [];
 					builder = null;
 					break;
 				}
@@ -295,13 +400,19 @@ async function pumpSdkMessages(
 				case "result": {
 					const result = msg as SDKResultMessage;
 
+					if (result.session_id) {
+						sessionMap.set(modelId, result.session_id);
+					}
+
 					// Build final message. Include intermediate tool calls so the
 					// agent loop's externalToolExecution path emits tool_execution
-					// events for proper TUI rendering, followed by the text response.
+					// events with actual results for proper TUI rendering.
 					const finalContent: AssistantMessage["content"] = [];
 
 					// Add tool calls from intermediate turns first (renders above text)
-					finalContent.push(...intermediateToolCalls);
+					for (const { toolCall } of intermediateToolCallsWithResults) {
+						finalContent.push(toolCall);
+					}
 
 					// Add text/thinking from the last turn
 					if (builder && builder.message.content.length > 0) {
@@ -333,7 +444,15 @@ async function pumpSdkMessages(
 						usage: mapUsage(result.usage, result.total_cost_usd),
 						stopReason: result.is_error ? "error" : "stop",
 						timestamp: Date.now(),
-					};
+						// Attach tool results for the agent loop's externalToolExecution path
+						_externalToolResults: intermediateToolCallsWithResults.length > 0
+							? Object.fromEntries(
+								intermediateToolCallsWithResults
+									.filter((t) => t.result !== null)
+									.map((t) => [t.toolCall.id, t.result]),
+							)
+							: undefined,
+					} as AssistantMessage & { _externalToolResults?: Record<string, unknown> };
 
 					if (result.is_error) {
 						const errText =

--- a/src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts
+++ b/src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts
@@ -1,6 +1,7 @@
 import { describe, test } from "node:test";
 import assert from "node:assert/strict";
-import { makeStreamExhaustedErrorMessage } from "../stream-adapter.ts";
+import { makeStreamExhaustedErrorMessage, extractToolResults } from "../stream-adapter.ts";
+import type { SDKUserMessage } from "../sdk-types.ts";
 
 describe("stream-adapter — exhausted stream fallback (#2575)", () => {
 	test("generator exhaustion becomes an error message instead of clean completion", () => {
@@ -17,5 +18,129 @@ describe("stream-adapter — exhausted stream fallback (#2575)", () => {
 		assert.equal(message.stopReason, "error");
 		assert.equal(message.errorMessage, "stream_exhausted_without_result");
 		assert.match(String((message.content[0] as any)?.text ?? ""), /Claude Code error: stream_exhausted_without_result/);
+	});
+});
+
+describe("stream-adapter — tool result extraction (#2860)", () => {
+	test("extracts tool_result blocks from user message content", () => {
+		const userMsg: SDKUserMessage = {
+			type: "user",
+			session_id: "test-session",
+			parent_tool_use_id: null,
+			message: {
+				role: "user",
+				content: [
+					{
+						type: "tool_result",
+						tool_use_id: "tool_abc",
+						content: [{ type: "text", text: "file contents here" }],
+					},
+					{
+						type: "tool_result",
+						tool_use_id: "tool_def",
+						content: "bash output line 1\nbash output line 2",
+						is_error: false,
+					},
+				],
+			},
+		};
+
+		const results = extractToolResults(userMsg);
+		assert.equal(results.size, 2);
+
+		const resultAbc = results.get("tool_abc");
+		assert.ok(resultAbc);
+		assert.deepEqual(resultAbc.content, [{ type: "text", text: "file contents here" }]);
+		assert.equal(resultAbc.isError, false);
+
+		const resultDef = results.get("tool_def");
+		assert.ok(resultDef);
+		assert.deepEqual(resultDef.content, [{ type: "text", text: "bash output line 1\nbash output line 2" }]);
+		assert.equal(resultDef.isError, false);
+	});
+
+	test("handles error tool results", () => {
+		const userMsg: SDKUserMessage = {
+			type: "user",
+			session_id: "test-session",
+			parent_tool_use_id: null,
+			message: {
+				role: "user",
+				content: [
+					{
+						type: "tool_result",
+						tool_use_id: "tool_err",
+						content: "command not found: foobar",
+						is_error: true,
+					},
+				],
+			},
+		};
+
+		const results = extractToolResults(userMsg);
+		const result = results.get("tool_err");
+		assert.ok(result);
+		assert.equal(result.isError, true);
+		assert.deepEqual(result.content, [{ type: "text", text: "command not found: foobar" }]);
+	});
+
+	test("returns empty map for string content messages", () => {
+		const userMsg: SDKUserMessage = {
+			type: "user",
+			session_id: "test-session",
+			parent_tool_use_id: null,
+			message: {
+				role: "user",
+				content: "plain text message",
+			},
+		};
+
+		const results = extractToolResults(userMsg);
+		assert.equal(results.size, 0);
+	});
+
+	test("handles tool_result with no content", () => {
+		const userMsg: SDKUserMessage = {
+			type: "user",
+			session_id: "test-session",
+			parent_tool_use_id: null,
+			message: {
+				role: "user",
+				content: [
+					{
+						type: "tool_result",
+						tool_use_id: "tool_empty",
+					},
+				],
+			},
+		};
+
+		const results = extractToolResults(userMsg);
+		const result = results.get("tool_empty");
+		assert.ok(result);
+		assert.deepEqual(result.content, [{ type: "text", text: "(no output)" }]);
+	});
+
+	test("skips non-tool-result blocks", () => {
+		const userMsg: SDKUserMessage = {
+			type: "user",
+			session_id: "test-session",
+			parent_tool_use_id: null,
+			message: {
+				role: "user",
+				content: [
+					{ type: "text", text: "some text" },
+					{
+						type: "tool_result",
+						tool_use_id: "tool_only",
+						content: "actual result",
+					},
+				],
+			},
+		};
+
+		const results = extractToolResults(userMsg);
+		assert.equal(results.size, 1);
+		assert.ok(results.has("tool_only"));
 	});
 });


### PR DESCRIPTION
## Summary

- **Session persistence enabled** — `persistSession: true` (was `false`), with automatic session resumption via `resume: sessionId` for cross-turn conversational continuity. Fixes the stateless-by-design behavior where every SDK call was isolated. (#2859)
- **Tool results captured from SDK user messages** — Parses `tool_result` content blocks from the SDK's synthetic user messages and pairs them with tool calls by `tool_use_id`. The agent-loop's `externalToolExecution` path now emits actual tool output instead of the hardcoded `"(executed by Claude Code)"` placeholder. (#2860)
- **Tool call events streamed in chronological order** — Removed the filter that suppressed `toolcall_start/delta/end` events during intermediate turns. Tool calls now render in their correct temporal position (during the turn, before the final text response). (#2860)

## Files changed

- `src/resources/extensions/claude-code-cli/stream-adapter.ts` — Session tracking, tool result extraction, chronological event streaming
- `src/resources/extensions/claude-code-cli/sdk-types.ts` — Added `ToolResultBlock`, `UserContentBlock` types; typed `SDKUserMessage.message`
- `packages/pi-agent-core/src/agent-loop.ts` — `externalToolExecution` path reads paired results from `_externalToolResults`
- `src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts` — 5 new tests for tool result extraction

## Test plan

- [x] Existing `stream-adapter.test.ts` tests pass (exhausted stream fallback)
- [x] 5 new tests for `extractToolResults`: array content, string content, error results, empty content, mixed blocks
- [x] Type checks pass (`tsconfig.extensions.json`, `pi-agent-core/tsconfig.json`)
- [x] Full build succeeds
- [ ] Manual: verify multi-turn continuity with Claude Code provider
- [ ] Manual: verify tool call components show actual output (bash stdout, file contents)
- [ ] Manual: verify tool calls render above final text response

Closes #2859, closes #2860

🤖 Generated with [Claude Code](https://claude.com/claude-code)