### PR TITLE
test: add async job manager teardown to await-tool tests

### DIFF
--- a/src/resources/extensions/async-jobs/await-tool.test.ts
+++ b/src/resources/extensions/async-jobs/await-tool.test.ts
@@ -20,6 +20,8 @@ test("await_job returns immediately when no running jobs exist", async () => {
 	const result = await tool.execute("tc1", {}, noopSignal, () => {}, undefined as never);
 	const text = getTextFromResult(result);
 	assert.match(text, /No running background jobs/);
+
+	manager.shutdown();
 });
 
 test("await_job returns immediately when all watched jobs are already completed", async () => {
@@ -36,6 +38,8 @@ test("await_job returns immediately when all watched jobs are already completed"
 	const text = getTextFromResult(result);
 	assert.match(text, /fast-job/);
 	assert.match(text, /completed/);
+
+	manager.shutdown();
 });
 
 test("await_job returns on timeout when jobs are still running", async () => {


### PR DESCRIPTION
## TL;DR

**What:** Add `manager.shutdown()` teardown to two await-tool tests that were leaving worker threads alive.
**Why:** Without cleanup the test process hangs after assertions pass, blocking CI and local integration runs.
**How:** Call `manager.shutdown()` at the end of each test case that creates an `AsyncJobManager`.

## What

Two test cases in `src/resources/extensions/async-jobs/await-tool.test.ts` create an `AsyncJobManager` but never tear it down. The dangling worker threads prevent the test runner from exiting cleanly.

## Why

This fixes the integration test hang tracked as shared blocker TYK-30. The `await-tool.test.ts` suite passes all assertions but the process never exits because the async job manager keeps its internal workers alive.

## How

Added `manager.shutdown()` after the final assertion in:
- `"await_job returns immediately when no running jobs exist"`
- `"await_job returns immediately when all watched jobs are already completed"`

No behavior change — only test teardown hygiene.

## Change type

- [x] `test` — Adding or updating tests

## Scope

- [x] `gsd extension` — GSD workflow

## Breaking changes

- [x] No breaking changes

## Test plan

- [x] CI passes
- [x] Full local gate green against `f22a9030` (v2.57.0): build, typecheck, unit tests, integration tests
- [x] No tests needed — explained above

## AI disclosure

- [x] This PR includes AI-assisted code (Claude Opus 4.6, GPT-5.4)