### PR TITLE
fix(pi-coding-agent): unref async job eviction timers

### DIFF
--- a/src/resources/extensions/async-jobs/await-tool.test.ts
+++ b/src/resources/extensions/async-jobs/await-tool.test.ts
@@ -36,6 +36,11 @@ test("await_job returns immediately when all watched jobs are already completed"
 	const text = getTextFromResult(result);
 	assert.match(text, /fast-job/);
 	assert.match(text, /completed/);
+
+	const evictionTimer = (manager as any).evictionTimers.get(jobId) as { hasRef?: () => boolean } | undefined;
+	assert.equal(evictionTimer?.hasRef?.(), false, "completed-job eviction timer should be unrefed");
+
+	manager.shutdown();
 });
 
 test("await_job returns on timeout when jobs are still running", async () => {

--- a/src/resources/extensions/async-jobs/job-manager.ts
+++ b/src/resources/extensions/async-jobs/job-manager.ts
@@ -186,6 +186,9 @@ export class AsyncJobManager {
 			this.evictionTimers.delete(id);
 			this.jobs.delete(id);
 		}, this.evictionMs);
+		// Completed jobs should not pin the host process until their eviction TTL
+		// expires; the timer is only best-effort background cleanup.
+		if (typeof timer === "object" && "unref" in timer) timer.unref();
 
 		this.evictionTimers.set(id, timer);
 	}


### PR DESCRIPTION
## TL;DR

**What:** Unref async job eviction timers and lock the behavior with a regression test.
**Why:** Completed async jobs can keep the process alive until TTL cleanup runs, which makes the await-tool path and full integration verification unreliable.
**How:** Call `timer.unref()` when scheduling completed-job eviction and assert the timer is unrefed in await-tool coverage.

## What

Update `AsyncJobManager` so completed-job eviction timers do not keep the process alive, and add regression coverage for the await-tool path.

## Why

The completed-job eviction timer was still ref'ed after a job finished. That leaves the process artificially alive until the TTL expires, which is the wrong runtime behavior and can interfere with integration verification.

## How

- call `timer.unref()` in the eviction scheduling path
- add a focused regression test that asserts the completed-job eviction timer is unrefed
- verify the full local gate after the fix

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [x] `pi-coding-agent` — Coding agent
- [ ] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

Manual verification:
- verified the completed-job eviction timer is unrefed in await-tool regression coverage
- ran `npm run build`, `npm run typecheck:extensions`, `npm run test:unit`, and `npm run test:integration`
- manually reviewed the diff for leaked secrets or local machine details

## AI disclosure

- [x] This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.
