### PR TITLE
fix(gsd): use registered search-the-web tool names in prompts

### DIFF
--- a/src/resources/agents/researcher.md
+++ b/src/resources/agents/researcher.md
@@ -1,7 +1,7 @@
 ---
 name: researcher
 description: Web researcher that finds and synthesizes current information using Brave Search
-tools: web_search, bash
+tools: search-the-web, bash
 ---
 
 You are a web researcher. You find current, accurate information using web search and synthesize it into a clear, well-structured report.

--- a/src/resources/extensions/gsd/prompts/discuss-headless.md
+++ b/src/resources/extensions/gsd/prompts/discuss-headless.md
@@ -38,7 +38,7 @@ Do a mandatory investigation pass before making any decisions. This is not optio
 3. **Web search** — `search-the-web` if the domain is unfamiliar, if you need current best practices, or if the spec references external services/APIs you need facts about. Use `fetch_page` for full content when snippets aren't enough.
 
 **Web search budget:** Budget carefully across investigation + focused research:
-- Prefer `resolve_library` / `get_library_docs` over `web_search` for library documentation.
+- Prefer `resolve_library` / `get_library_docs` over `search-the-web` for library documentation.
 - Prefer `search_and_read` for one-shot topic research.
 - Target 2-3 web searches in this investigation pass. Save remaining budget for focused research.
 - Do NOT repeat the same or similar queries.

--- a/src/resources/extensions/gsd/prompts/discuss.md
+++ b/src/resources/extensions/gsd/prompts/discuss.md
@@ -37,7 +37,7 @@ Before asking your first question, do a mandatory investigation pass. This is no
 3. **Web search** — `search-the-web` if the domain is unfamiliar, if you need current best practices, or if the user referenced external services/APIs you need facts about. Use `fetch_page` for full content when snippets aren't enough.
 
 **Web search budget:** You have a limited number of web searches per turn (typically 3-5). The discuss phase spans many turns (investigation, question rounds, focused research, requirements), so budget carefully:
-- Prefer `resolve_library` / `get_library_docs` over `web_search` for library documentation — they don't consume the web search budget.
+- Prefer `resolve_library` / `get_library_docs` over `search-the-web` for library documentation — they don't consume the web search budget.
 - Prefer `search_and_read` for one-shot topic research — it combines search + page fetch in a single call.
 - Target 2-3 web searches in the investigation pass. Save remaining budget for the focused research pass before roadmap creation.
 - Do NOT repeat the same or similar queries. If a search didn't find what you need, rephrase once or move on.

--- a/src/resources/extensions/gsd/prompts/guided-discuss-milestone.md
+++ b/src/resources/extensions/gsd/prompts/guided-discuss-milestone.md
@@ -13,7 +13,7 @@ Discuss milestone {{milestoneId}} ("{{milestoneTitle}}"). Identify gray areas, a
 Do a lightweight targeted investigation so your questions are grounded in reality:
 - Scout the codebase (`rg`, `find`, or `scout`) to understand what already exists that this milestone touches or builds on
 - Check the roadmap context above (if present) to understand what surrounds this milestone
-- Use `resolve_library` / `get_library_docs` for unfamiliar libraries — prefer this over `web_search` for library documentation
+- Use `resolve_library` / `get_library_docs` for unfamiliar libraries — prefer this over `search-the-web` for library documentation
 - Identify the 3–5 biggest behavioural and architectural unknowns: things where the user's answer will materially change what gets built
 
 **Web search budget:** You have a limited number of web searches per turn (typically 3-5). Prefer `resolve_library` / `get_library_docs` for library documentation and `search_and_read` for one-shot topic research — they are more budget-efficient. Target 2-3 web searches in the investigation pass. Distribute remaining searches across subsequent question rounds rather than clustering them.

--- a/src/resources/extensions/gsd/prompts/guided-discuss-slice.md
+++ b/src/resources/extensions/gsd/prompts/guided-discuss-slice.md
@@ -13,7 +13,7 @@ Your goal is **not** to center the discussion on tech stack trivia, naming conve
 Do a lightweight targeted investigation so your questions are grounded in reality:
 - Scout the codebase (`rg`, `find`, or `scout` for broad unfamiliar areas) to understand what already exists that this slice touches or builds on
 - Check the roadmap context above to understand what surrounds this slice — what comes before, what depends on it
-- Use `resolve_library` / `get_library_docs` for unfamiliar libraries — prefer this over `web_search` for library documentation
+- Use `resolve_library` / `get_library_docs` for unfamiliar libraries — prefer this over `search-the-web` for library documentation
 - Identify the 3–5 biggest behavioural unknowns: things where the user's answer will materially change what gets built
 
 **Web search budget:** You have a limited number of web searches per turn (typically 3-5). Prefer `resolve_library` / `get_library_docs` for library documentation and `search_and_read` for one-shot topic research — they are more budget-efficient. Target 2-3 web searches in the investigation pass. Distribute remaining searches across subsequent question rounds rather than clustering them.

--- a/src/resources/extensions/gsd/tests/prompt-contracts.test.ts
+++ b/src/resources/extensions/gsd/tests/prompt-contracts.test.ts
@@ -51,6 +51,28 @@ test("guided discussion prompts avoid wrap-up prompts after every round", () => 
   assert.doesNotMatch(slicePrompt, /I think I have a solid picture of this slice\. Ready to wrap up/i);
 });
 
+test("discussion prompts reference the registered search-the-web tool name", () => {
+  const discussPrompt = readPrompt("discuss");
+  const discussHeadlessPrompt = readPrompt("discuss-headless");
+  const milestonePrompt = readPrompt("guided-discuss-milestone");
+  const slicePrompt = readPrompt("guided-discuss-slice");
+
+  for (const prompt of [discussPrompt, discussHeadlessPrompt, milestonePrompt, slicePrompt]) {
+    assert.match(prompt, /search-the-web/);
+    assert.doesNotMatch(prompt, /`web_search`/);
+  }
+});
+
+test("researcher agent frontmatter uses the registered search-the-web tool name", () => {
+  const researcherAgent = readFileSync(
+    join(process.cwd(), "src/resources/agents/researcher.md"),
+    "utf-8",
+  );
+
+  assert.match(researcherAgent, /^tools:\s*search-the-web,\s*bash$/m);
+  assert.doesNotMatch(researcherAgent, /^tools:\s*web_search,\s*bash$/m);
+});
+
 test("guided-resume-task prompt preserves recovery state until work is superseded", () => {
   const prompt = readPrompt("guided-resume-task");
   assert.match(prompt, /Do \*\*not\*\* delete the continue file immediately/i);


### PR DESCRIPTION
## TL;DR

**What:** Replace GSD prompt and agent references to the internal `web_search` identifier with the registered `search-the-web` tool name.
**Why:** Prompted agents were learning the wrong callable tool name and could fail with invalid tool input or tool-not-found errors.
**How:** Update the affected prompt text and researcher frontmatter, then lock the behavior in with prompt contract regression tests.

## What

This change updates the discussion prompts and the bundled `researcher` agent so they consistently refer to `search-the-web`, which is the tool name exposed to GSD users and agents.

It also adds prompt contract coverage to catch regressions if future prompt edits reintroduce the internal `web_search` name.

## Why

The prompts were teaching the model to call `web_search`, which is an internal/native implementation detail rather than the registered tool interface. That led to avoidable tool-call failures during discussion and research flows.

Closes #2920

## How

The fix is intentionally small:
- replace the incorrect tool name in the affected prompt files
- update the `researcher` agent frontmatter to the registered tool name
- add prompt contract assertions for both the prompt text and the agent frontmatter

## Change type

- [x] `fix` — Bug fix
- [x] `test` — Adding or updating tests
- [ ] `feat` — New feature or capability
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [x] `gsd extension` — GSD workflow
- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [ ] Manual testing — steps described above
- [ ] No tests needed — explained above

Verified locally with the full CI mirror gate: `npm run build`, `npm run typecheck:extensions`, `npm run test:unit`, and `npm run test:integration`. The final integration truth phase was run in a plain verification clone after worktree-based integration verification produced unstable `npm pack`/install signal.

## AI disclosure

- [x] This PR includes AI-assisted code

This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.
