### PR TITLE
fix(gsd): rerun init wizard for zombie .gsd state

### DIFF
--- a/src/resources/extensions/gsd/auto-start.ts
+++ b/src/resources/extensions/gsd/auto-start.ts
@@ -198,10 +198,12 @@ export async function bootstrapAutoSession(
     ensureGitignore(base, { manageGitignore });
     if (manageGitignore !== false) untrackRuntimeFiles(base);
 
-    // Bootstrap .gsd/ if it doesn't exist
+    // Bootstrap .gsd/ structure if the milestones directory is missing.
+    // The symlinked .gsd root may already exist before init wizard runs.
     const gsdDir = join(base, ".gsd");
-    if (!existsSync(gsdDir)) {
-      mkdirSync(join(gsdDir, "milestones"), { recursive: true });
+    const milestonesPath = join(gsdDir, "milestones");
+    if (!existsSync(milestonesPath)) {
+      mkdirSync(milestonesPath, { recursive: true });
       try {
         nativeAddAll(base);
         nativeCommit(base, "chore: init gsd");

--- a/src/resources/extensions/gsd/guided-flow.ts
+++ b/src/resources/extensions/gsd/guided-flow.ts
@@ -89,6 +89,19 @@ export function getDiscussionMilestoneId(): string | null {
   return pendingAutoStart?.milestoneId ?? null;
 }
 
+/**
+ * Treat a project as bootstrapped only when it has user-facing init artifacts,
+ * not merely a `.gsd/` directory created by external-state symlink setup.
+ */
+export function hasProjectBootstrapArtifacts(
+  detection: ReturnType<typeof detectProjectState>,
+): boolean {
+  return !!(
+    detection.v2
+    && (detection.v2.hasPreferences || detection.v2.milestoneCount > 0)
+  );
+}
+
 /** Called from agent_end to check if auto-mode should start after discuss */
 export function checkAutoStartAfterDiscuss(): boolean {
   if (!pendingAutoStart) return false;
@@ -974,8 +987,8 @@ export async function showSmartEntry(
   }
 
   // ── Detection preamble — run before any bootstrap ────────────────────
-  if (!existsSync(gsdRoot(basePath))) {
-    const detection = detectProjectState(basePath);
+  const detection = detectProjectState(basePath);
+  if (!hasProjectBootstrapArtifacts(detection)) {
 
     // v1 .planning/ detected — offer migration before anything else
     if (detection.state === "v1-planning" && detection.v1) {
@@ -989,7 +1002,8 @@ export async function showSmartEntry(
       // "fresh" — fall through to init wizard
     }
 
-    // No .gsd/ — run the project init wizard
+    // Missing bootstrap artifacts — run the project init wizard. This also
+    // covers zombie external-state dirs that only contain repo-meta.json.
     const result = await showProjectInit(ctx, pi, basePath, detection);
     if (!result.completed) return; // User cancelled
 

--- a/src/resources/extensions/gsd/tests/guided-flow-bootstrap-artifacts.test.ts
+++ b/src/resources/extensions/gsd/tests/guided-flow-bootstrap-artifacts.test.ts
@@ -1,0 +1,72 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { hasProjectBootstrapArtifacts } from "../guided-flow.ts";
+
+test("bootstrap artifacts require more than a zombie .gsd directory", () => {
+  assert.equal(
+    hasProjectBootstrapArtifacts({
+      state: "v2-gsd-empty",
+      isFirstEverLaunch: false,
+      hasGlobalSetup: false,
+      v2: {
+        milestoneCount: 0,
+        hasPreferences: false,
+        hasContext: false,
+      },
+      projectSignals: {
+        detectedFiles: [],
+        isGitRepo: false,
+        isMonorepo: false,
+        xcodePlatforms: [],
+        hasCI: false,
+        hasTests: false,
+        verificationCommands: [],
+      },
+    }),
+    false,
+  );
+});
+
+test("bootstrap artifacts accept seeded preferences or real milestones", () => {
+  const baseDetection = {
+    isFirstEverLaunch: false,
+    hasGlobalSetup: false,
+    v1: undefined,
+    projectSignals: {
+      detectedFiles: [],
+      isGitRepo: false,
+      isMonorepo: false,
+      xcodePlatforms: [],
+      hasCI: false,
+      hasTests: false,
+      verificationCommands: [],
+    },
+  };
+
+  assert.equal(
+    hasProjectBootstrapArtifacts({
+      ...baseDetection,
+      state: "v2-gsd-empty",
+      v2: {
+        milestoneCount: 0,
+        hasPreferences: true,
+        hasContext: false,
+      },
+    }),
+    true,
+  );
+
+  assert.equal(
+    hasProjectBootstrapArtifacts({
+      ...baseDetection,
+      state: "v2-gsd",
+      v2: {
+        milestoneCount: 1,
+        hasPreferences: false,
+        hasContext: false,
+      },
+    }),
+    true,
+  );
+});

--- a/src/resources/extensions/gsd/tests/init-wizard.test.ts
+++ b/src/resources/extensions/gsd/tests/init-wizard.test.ts
@@ -92,6 +92,22 @@ test("init-wizard: empty .gsd/ (no milestones) returns v2-gsd-empty", (t) => {
   }
 });
 
+test("init-wizard: repo-meta-only .gsd/ still counts as v2-gsd-empty", (t) => {
+  const dir = makeTempDir("repo-meta-only");
+  try {
+    mkdirSync(join(dir, ".gsd"), { recursive: true });
+    writeFileSync(join(dir, ".gsd", "repo-meta.json"), "{\n  \"projectId\": \"abc123\"\n}\n", "utf-8");
+
+    const detection = detectProjectState(dir);
+    assert.equal(detection.state, "v2-gsd-empty");
+    assert.ok(detection.v2);
+    assert.equal(detection.v2!.milestoneCount, 0);
+    assert.equal(detection.v2!.hasPreferences, false);
+  } finally {
+    cleanup(dir);
+  }
+});
+
 test("init-wizard: project signals populate from Node.js project", (t) => {
   const dir = makeTempDir("node-project");
   try {

--- a/src/resources/extensions/gsd/tests/zombie-gsd-bootstrap-guards.test.ts
+++ b/src/resources/extensions/gsd/tests/zombie-gsd-bootstrap-guards.test.ts
@@ -1,0 +1,34 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { createTestContext } from "./test-helpers.ts";
+
+const { assertTrue, report } = createTestContext();
+
+const guidedFlowSource = readFileSync(
+  join(import.meta.dirname, "..", "guided-flow.ts"),
+  "utf-8",
+);
+const autoStartSource = readFileSync(
+  join(import.meta.dirname, "..", "auto-start.ts"),
+  "utf-8",
+);
+
+assertTrue(
+  guidedFlowSource.includes("hasProjectBootstrapArtifacts"),
+  "guided-flow.ts should define a bootstrap-artifact guard for zombie .gsd state (#2942)",
+);
+assertTrue(
+  guidedFlowSource.includes("detection.v2.hasPreferences || detection.v2.milestoneCount > 0"),
+  "bootstrap-artifact guard should require preferences or real milestones (#2942)",
+);
+assertTrue(
+  autoStartSource.includes('const milestonesPath = join(gsdDir, "milestones");'),
+  "auto-start.ts should check milestones/ instead of raw .gsd existence (#2942)",
+);
+assertTrue(
+  autoStartSource.includes("if (!existsSync(milestonesPath))"),
+  "auto-start.ts should bootstrap the milestones/ directory when missing (#2942)",
+);
+
+report();


### PR DESCRIPTION
## TL;DR

**What:** Treat repo-meta-only external-state `.gsd` directories as unbootstrapped and rerun the init wizard until real bootstrap artifacts exist.
**Why:** A zombie `.gsd` state could skip initialization entirely and leave users in an unconfigured project session.
**How:** Add a guided-flow bootstrap-artifact guard, tighten auto-start bootstrap conditions, and cover the behavior with repo-meta and guard regression tests.

## What

This PR changes guided entry and auto-start bootstrap detection so an external-state `.gsd` directory is not considered initialized just because the directory or symlink exists.

Instead, the project must have real bootstrap artifacts such as preferences or milestones before guided flow skips the init wizard. The patch also adds focused regression coverage for repo-meta-only state and the new bootstrap guards.

## Why

External-state setup can create a `.gsd` directory containing only repo metadata before the init wizard has actually completed. When guided flow treated that as fully bootstrapped, users could land in an empty session with no preferences, no milestones, and no real project initialization.

Closes #2942

## How

The implementation stays narrow:
- add a guided-flow helper that distinguishes real bootstrap artifacts from zombie `.gsd` state
- run the init wizard when only repo metadata exists
- update auto-start to bootstrap the `milestones/` directory explicitly instead of keying off raw `.gsd` existence
- add regression tests for repo-meta-only detection and the new bootstrap guards

## Change type

- [x] `fix` — Bug fix
- [x] `test` — Adding or updating tests
- [ ] `feat` — New feature or capability
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [x] `gsd extension` — GSD workflow
- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [ ] Manual testing — steps described above
- [ ] No tests needed — explained above

Verified locally with the full CI mirror gate: `npm run build`, `npm run typecheck:extensions`, `npm run test:unit`, and `npm run test:integration`. One full integration pass initially hit a cleanup-only `ENOTEMPTY` failure in `web-mode-onboarding`; the failing onboarding test passed on immediate targeted rerun, and the subsequent full integration rerun completed green.

## AI disclosure

- [x] This PR includes AI-assisted code

This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.
