### PR TITLE
fix: skip external state migration inside git worktrees (#2970)

### DIFF
--- a/src/resources/extensions/gsd/migrate-external.ts
+++ b/src/resources/extensions/gsd/migrate-external.ts
@@ -9,7 +9,7 @@
 import { execFileSync } from "node:child_process";
 import { existsSync, lstatSync, mkdirSync, readdirSync, realpathSync, renameSync, cpSync, rmSync, symlinkSync } from "node:fs";
 import { join } from "node:path";
-import { externalGsdRoot } from "./repo-identity.js";
+import { externalGsdRoot, isInsideWorktree } from "./repo-identity.js";
 import { getErrorMessage } from "./error-utils.js";
 import { hasGitTrackedGsdFiles } from "./gitignore.js";
 import { GIT_NO_PROMPT_ENV } from "./git-constants.js";
@@ -57,6 +57,15 @@ export function migrateToExternalState(basePath: string): MigrationResult {
   // Skip if .gsd/ contains git-tracked files — the project intentionally
   // keeps .gsd/ in version control and migration would destroy that.
   if (hasGitTrackedGsdFiles(basePath)) {
+    return { migrated: false };
+  }
+
+  // Skip if basePath is a git worktree (not the main repo). Worktrees get
+  // their .gsd/ populated via syncGsdStateToWorktree(), not migration.
+  // externalGsdRoot() returns the same hash for worktrees and the main repo
+  // (both resolve to the same git root), so migrating here would create a
+  // junction to the shared project-root state dir — wrong isolation. (#2970)
+  if (isInsideWorktree(basePath)) {
     return { migrated: false };
   }
 

--- a/src/resources/extensions/gsd/tests/integration/gitignore-tracked-gsd.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/gitignore-tracked-gsd.test.ts
@@ -254,3 +254,35 @@ test("migrateToExternalState cleans git index so tracked files don't show as del
     cleanup(dir);
   }
 });
+
+test("migrateToExternalState skips when basePath is a git worktree (#2970)", (t) => {
+  const dir = makeTempRepo();
+  const wtDir = join(dir, "wt");
+  try {
+    // Create a real git worktree
+    git(dir, "worktree", "add", wtDir, "-b", "test-wt");
+
+    // Create a .gsd directory inside the worktree (simulates syncGsdStateToWorktree)
+    mkdirSync(join(wtDir, ".gsd"), { recursive: true });
+    writeFileSync(join(wtDir, ".gsd", "STATE.md"), "# state\n");
+
+    // Attempt migration — should skip because it's a worktree
+    const result = migrateToExternalState(wtDir);
+
+    assert.equal(result.migrated, false, "Should NOT migrate inside a worktree");
+    assert.equal(result.error, undefined, "Should not report an error — just skip");
+
+    // .gsd/ should still be a real directory, not a symlink or junction
+    assert.ok(existsSync(join(wtDir, ".gsd", "STATE.md")), ".gsd/STATE.md should still exist");
+
+    // No .gsd.migrating should exist
+    assert.ok(
+      !existsSync(join(wtDir, ".gsd.migrating")),
+      ".gsd.migrating should not exist — migration should not have started",
+    );
+  } finally {
+    // Remove worktree before cleanup to avoid git lock issues
+    try { git(dir, "worktree", "remove", wtDir, "--force"); } catch { /* best-effort */ }
+    cleanup(dir);
+  }
+});


### PR DESCRIPTION
## Problem

`migrateToExternalState()` runs inside git worktree directories (`.gsd/worktrees/<MID>/`), renaming `.gsd` → `.gsd.migrating` and attempting to create a junction to the external state dir. Since `externalGsdRoot()` returns the same hash for worktrees and the main repo (both resolve to the same git root + remote URL), the migration either:

1. Creates a junction pointing to the shared project-root state dir (wrong isolation), or
2. Fails and leaves `.gsd.migrating` orphaned with no `.gsd` junction

This breaks post-unit hooks, preferences loading, and state isolation in worktree-based auto-mode.

## Root Cause

`migrate-external.ts:migrateToExternalState()` checks for symlinks, real directories, git-tracked files, and active worktree subdirectories — but never checks whether `basePath` itself is a worktree.

## Fix

Add an `isInsideWorktree(basePath)` guard early in `migrateToExternalState()`. Worktrees get their `.gsd/` populated via `syncGsdStateToWorktree()`, not migration. The function already exists in `repo-identity.ts`.

**2 files changed:**
- `migrate-external.ts` — import `isInsideWorktree`, add early-return guard
- `tests/integration/gitignore-tracked-gsd.test.ts` — new test: creates a real git worktree, verifies migration skips it

## Test

```
npx tsx --test src/resources/extensions/gsd/tests/integration/gitignore-tracked-gsd.test.ts
# 11 pass, 0 fail (including new worktree guard test)
```

Closes #2970
