### PR TITLE
fix(build): prevent version-stamp from accumulating -dev suffixes

### DIFF
--- a/scripts/version-stamp.mjs
+++ b/scripts/version-stamp.mjs
@@ -5,7 +5,8 @@ const pkgPath = new URL("../package.json", import.meta.url);
 const pkg = JSON.parse(readFileSync(pkgPath, "utf8"));
 
 const shortSha = execFileSync("git", ["rev-parse", "--short", "HEAD"], { encoding: "utf8" }).trim();
-const devVersion = `${pkg.version}-dev.${shortSha}`;
+const baseVersion = pkg.version.replace(/-dev\..*$/, "");
+const devVersion = `${baseVersion}-dev.${shortSha}`;
 
 pkg.version = devVersion;
 writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + "\n");


### PR DESCRIPTION
## Summary
- Running `version-stamp.mjs` multiple times (e.g. via `build-gsd-dev`) appends `-dev.<sha>` on top of an already-stamped version, producing strings like `2.58.0-dev.abc-dev.def-dev.ghi`
- Strip any existing `-dev.*` suffix before appending the new one so the result is always `<base>-dev.<sha>`

## Test plan
- [ ] Run `node scripts/version-stamp.mjs` twice in a row — version should be `X.Y.Z-dev.<current-sha>` both times, not accumulate