### PR TITLE
fix(gsd): use split/join for prompt template substitution to avoid $-expansion

### DIFF
--- a/src/resources/extensions/gsd/prompt-loader.ts
+++ b/src/resources/extensions/gsd/prompt-loader.ts
@@ -134,7 +134,10 @@ export function loadPrompt(name: string, vars: Record<string, string> = {}): str
   }
 
   for (const [key, value] of Object.entries(effectiveVars)) {
-    content = content.replaceAll(`{{${key}}}`, value);
+    // Use split/join instead of replaceAll to avoid JavaScript's special
+    // replacement patterns ($', $`, $&, $$) being interpreted in values.
+    // See: https://github.com/gsd-build/gsd-2/issues/2968
+    content = content.split(`{{${key}}}`).join(value);
   }
 
   return content.trim();

--- a/src/resources/extensions/gsd/tests/prompt-loader-dollar-expansion.test.ts
+++ b/src/resources/extensions/gsd/tests/prompt-loader-dollar-expansion.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Regression test for prompt template variable expansion with special
+ * replacement patterns ($', $`, $&) in values.
+ *
+ * Bug: String.replaceAll() interprets $' as "insert text after match",
+ * causing exponential expansion when user content (e.g. bash commands
+ * like `grep -q '^0$'`) flows through template variables.
+ *
+ * See: https://github.com/gsd-build/gsd-2/issues/2968
+ */
+import { describe, test, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+/**
+ * Minimal reproduction of the loadPrompt substitution logic.
+ * We test the core algorithm in isolation since loadPrompt is tightly
+ * coupled to its module-level cache and directory resolution.
+ */
+
+/** Buggy version — uses replaceAll directly */
+function substituteVarsBuggy(content: string, vars: Record<string, string>): string {
+  for (const [key, value] of Object.entries(vars)) {
+    content = content.replaceAll(`{{${key}}}`, value);
+  }
+  return content;
+}
+
+/** Fixed version — uses split/join to avoid special replacement patterns */
+function substituteVarsFixed(content: string, vars: Record<string, string>): string {
+  for (const [key, value] of Object.entries(vars)) {
+    content = content.split(`{{${key}}}`).join(value);
+  }
+  return content;
+}
+
+describe("prompt template variable substitution", () => {
+  test("buggy replaceAll expands $' in values (demonstrates the bug)", () => {
+    // $' in replaceAll inserts the portion of the string AFTER the match.
+    // With a single variable, the expansion is modest. With multiple variables
+    // processed sequentially, the expansion cascades. This test demonstrates
+    // the basic mechanism: $' injects trailing content.
+    const template = "Run: {{command}}\nMore content here.\nAnd more.";
+    const vars = { command: "grep -q '^0$'" };
+
+    const buggyResult = substituteVarsBuggy(template, vars);
+    const fixedResult = substituteVarsFixed(template, vars);
+
+    // The buggy result should differ from the fixed result because $' injects
+    // the text after the match ("\nMore content here.\nAnd more.")
+    assert.notEqual(buggyResult, fixedResult,
+      "Buggy replaceAll should produce different output due to $' expansion");
+
+    // The fixed result should be exactly what we expect
+    assert.equal(fixedResult, "Run: grep -q '^0$'\nMore content here.\nAnd more.");
+  });
+
+  test("split/join substitution handles $' without expansion", () => {
+    const template = "Run: {{command}}\nDone.";
+    const vars = { command: "grep -q '^0$'" };
+
+    const result = substituteVarsFixed(template, vars);
+
+    const expected = "Run: grep -q '^0$'\nDone.";
+    assert.equal(result, expected);
+  });
+
+  test("split/join substitution handles $` without expansion", () => {
+    const template = "Check: {{verify}}";
+    const vars = { verify: "echo $`hostname`" };
+
+    const result = substituteVarsFixed(template, vars);
+
+    assert.equal(result, "Check: echo $`hostname`");
+  });
+
+  test("split/join substitution handles $& without expansion", () => {
+    const template = "Value: {{val}}";
+    const vars = { val: "price is $&tax" };
+
+    const result = substituteVarsFixed(template, vars);
+
+    assert.equal(result, "Value: price is $&tax");
+  });
+
+  test("split/join substitution handles $$ without consuming it", () => {
+    const template = "Cost: {{amount}}";
+    const vars = { amount: "$$100" };
+
+    const result = substituteVarsFixed(template, vars);
+
+    assert.equal(result, "Cost: $$100");
+  });
+
+  test("multiple variables with dollar signs all substitute correctly", () => {
+    const template = [
+      "## Verification",
+      "```bash",
+      "{{step1}}",
+      "{{step2}}",
+      "```",
+    ].join("\n");
+    const vars = {
+      step1: "grep -c 'foo' file.txt | grep -q '^0$' && echo 'PASS'",
+      step2: "test $(wc -l < out.txt) -eq 5",
+    };
+
+    const result = substituteVarsFixed(template, vars);
+
+    const expected = [
+      "## Verification",
+      "```bash",
+      "grep -c 'foo' file.txt | grep -q '^0$' && echo 'PASS'",
+      "test $(wc -l < out.txt) -eq 5",
+      "```",
+    ].join("\n");
+    assert.equal(result, expected);
+  });
+
+  test("cascading expansion bug with multiple variables (demonstrates severity)", () => {
+    // This simulates a realistic prompt template with slice plan content
+    const template = [
+      "## Task",
+      "{{taskPlan}}",
+      "",
+      "## Slice Context",
+      "{{slicePlanExcerpt}}",
+      "",
+      "## Instructions",
+      "Execute the task above.",
+    ].join("\n");
+
+    const slicePlan = [
+      "### Verification",
+      "```bash",
+      "grep -c 'error' log.txt | grep -q '^0$' && echo PASS",
+      "```",
+    ].join("\n");
+
+    const vars = {
+      taskPlan: "Do something simple.",
+      slicePlanExcerpt: slicePlan,
+    };
+
+    const buggyResult = substituteVarsBuggy(template, vars);
+    const fixedResult = substituteVarsFixed(template, vars);
+
+    // Fixed result should be a reasonable size
+    assert.ok(
+      fixedResult.length < template.length + slicePlan.length + 100,
+      `Fixed result should be reasonably sized, got ${fixedResult.length}`,
+    );
+
+    // Buggy result expands due to $' injecting the template remainder
+    assert.ok(
+      buggyResult.length > fixedResult.length,
+      `Buggy result (${buggyResult.length}) should be larger than fixed (${fixedResult.length})`,
+    );
+  });
+});


### PR DESCRIPTION
## TL;DR

**What:** Replace `String.replaceAll()` with `split().join()` in `loadPrompt()` template variable substitution.
**Why:** `replaceAll` interprets `$'`, `$\``, `$&`, and `$$` as special replacement patterns, causing exponential prompt expansion when user content contains dollar signs (e.g. bash commands like `grep -q '^0$'`).
**How:** One-line fix in `prompt-loader.ts` + regression test covering all special `$` patterns.

## What

`prompt-loader.ts` line ~130 substitutes `{{variableName}}` placeholders using `String.replaceAll()`. This change replaces that with `split().join()`, which has no special pattern interpretation.

Files changed:
- `src/resources/extensions/gsd/prompt-loader.ts` — the fix (1 line changed)
- `src/resources/extensions/gsd/tests/prompt-loader-dollar-expansion.test.ts` — regression test (7 test cases)

## Why

JavaScript's `String.replaceAll()` interprets [special replacement patterns](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#specifying_a_string_as_the_replacement) in the replacement string:
- `$'` → insert text **after** the match
- `$\`` → insert text **before** the match  
- `$&` → insert the matched text itself
- `$$` → consumed as a single literal `$`

When any template variable's value contains `$'` — which happens naturally in bash verification commands like `grep -q '^0$'` — the replacement injects the entire remainder of the template into itself. Each subsequent `replaceAll` call compounds the expansion, turning a ~10K prompt into 1.4M+ tokens.

This blocks auto-mode entirely: the API returns 400 (prompt too long), auto-mode pauses, resumes, hits the same error in a loop, and `/compact` cannot help because the bloat is in a single message.

Closes #2968

## How

`split(pattern).join(value)` is semantically equivalent to `replaceAll(pattern, value)` for literal string patterns, but treats the replacement value as a plain string with no special interpretation. This is a well-known JavaScript idiom for avoiding replacement pattern issues.

The regression test covers:
1. `$'` expansion (demonstrates the bug with `replaceAll`, confirms `split/join` is immune)
2. `$\`` handling
3. `$&` handling
4. `$$` handling (preserved literally)
5. Multiple variables with dollar signs
6. Cascading multi-variable expansion (simulates realistic prompt with slice plan content)

---

- [x] `fix` — Bug fix

> AI-assisted: This PR was authored with AI assistance. The fix and test have been manually verified.