### PR TITLE
fix(gsd): add filesystem safety guard to complete-slice prompt

### DIFF
--- a/src/resources/extensions/gsd/prompts/complete-slice.md
+++ b/src/resources/extensions/gsd/prompts/complete-slice.md
@@ -33,6 +33,8 @@ Then:
 12. Do not run git commands — the system commits your changes and handles any merge after this unit succeeds.
 13. Update `.gsd/PROJECT.md` if it exists — refresh current state if needed.
 
+**File system safety:** Task summaries are preloaded in the inlined context above. If you need to re-read any of them, use `find .gsd/milestones/{{milestoneId}}/slices/{{sliceId}}/tasks -name "*-SUMMARY.md"` to list file paths first — never pass `{{slicePath}}` or any other directory path directly to the `read` tool. The `read` tool only accepts file paths, not directories.
+
 **You MUST call `gsd_complete_slice` with the slice summary and UAT content before finishing. The tool persists to both DB and disk and renders `{{sliceSummaryPath}}` and `{{sliceUatPath}}` automatically.**
 
 When done, say: "Slice {{sliceId}} complete."

--- a/src/resources/extensions/gsd/tests/prompt-contracts.test.ts
+++ b/src/resources/extensions/gsd/tests/prompt-contracts.test.ts
@@ -131,6 +131,13 @@ test("complete-slice prompt still contains template variables for context", () =
   assert.match(prompt, /\{\{sliceUatPath\}\}/);
 });
 
+// Regression: #2935 — complete-slice was missing filesystem safety guard (gap from #1343)
+test("complete-slice prompt includes filesystem safety guard against EISDIR", () => {
+  const prompt = readPrompt("complete-slice");
+  assert.match(prompt, /File system safety/);
+  assert.match(prompt, /never pass.*directory path.*directly to the `read` tool/i);
+});
+
 test("plan-milestone prompt references DB-backed planning tool and explicitly forbids manual roadmap writes", () => {
   const prompt = readPrompt("plan-milestone");
   assert.match(prompt, /gsd_plan_milestone/);


### PR DESCRIPTION
## TL;DR

**What:** Add filesystem safety instruction to `complete-slice.md` prompt — same guard that `complete-milestone.md` already has.
**Why:** The LLM passes slice directory paths to `read`, triggering `EISDIR` errors when inlined context is truncated.
**How:** One paragraph added to the prompt + regression test.

## What

`prompts/complete-slice.md` now includes a filesystem safety instruction before the `gsd_complete_slice` reminder, telling the LLM to use `find` to enumerate files instead of passing directory paths to `read`.

`tests/prompt-contracts.test.ts` gets a regression test verifying the guard is present.

Files changed:
- `src/resources/extensions/gsd/prompts/complete-slice.md` — added safety guard
- `src/resources/extensions/gsd/tests/prompt-contracts.test.ts` — regression test

## Why

PR #1367 (fixing #1343) added this exact guard to `complete-milestone.md` but missed `complete-slice.md`. When the 30,000-char inlined context cap truncates task summaries, the LLM tries to re-read them by navigating from `{{slicePath}}` — a directory — causing `EISDIR: illegal operation on a directory, read`. Forensic evidence shows this occurring across M005–M008 in multiple `complete-slice` units.

Closes #2935

## How

The same filesystem safety paragraph from `complete-milestone.md` (line 66), adapted with slice-specific template variables (`{{milestoneId}}`, `{{sliceId}}`, `{{slicePath}}`).

---

- [x] `fix` — Bug fix

> AI-assisted: This PR was authored with AI assistance. The fix and test have been manually verified.