### PR TITLE
fix(gsd): treat prompt substitutions as literal strings

### DIFF
--- a/src/resources/extensions/gsd/prompt-loader.ts
+++ b/src/resources/extensions/gsd/prompt-loader.ts
@@ -134,7 +134,9 @@ export function loadPrompt(name: string, vars: Record<string, string> = {}): str
   }
 
   for (const [key, value] of Object.entries(effectiveVars)) {
-    content = content.replaceAll(`{{${key}}}`, value);
+    // Use literal split/join substitution so replacement strings like `$'`
+    // from shell snippets are not interpreted as replace-pattern metacharacters.
+    content = content.split(`{{${key}}}`).join(value);
   }
 
   return content.trim();

--- a/src/resources/extensions/gsd/tests/prompt-loader.test.ts
+++ b/src/resources/extensions/gsd/tests/prompt-loader.test.ts
@@ -1,0 +1,61 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { loadPrompt } from "../prompt-loader.ts";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const promptsDir = join(__dirname, "..", "prompts");
+
+function safeRender(name: string, vars: Record<string, string>): string {
+  let content = readFileSync(join(promptsDir, `${name}.md`), "utf-8");
+  const effectiveVars = {
+    skillActivation: "If a `GSD Skill Preferences` block is present in system context, use it and the `<available_skills>` catalog in your system prompt to decide which skills to load and follow for this unit, without relaxing required verification or artifact rules.",
+    ...vars,
+  };
+
+  for (const [key, value] of Object.entries(effectiveVars)) {
+    content = content.split(`{{${key}}}`).join(value);
+  }
+
+  return content.trim();
+}
+
+test("loadPrompt treats replacement values literally", () => {
+  const slicePlanExcerpt = [
+    "## Verification",
+    "- grep -q '^0$' file.txt",
+    "- printf '$&'",
+    "- printf '$`'",
+  ].join("\n");
+
+  const vars = {
+    workingDirectory: "/tmp/test-project",
+    milestoneId: "M001",
+    sliceId: "S01",
+    sliceTitle: "Prompt loader regression",
+    taskId: "T01",
+    taskTitle: "Render prompt safely",
+    planPath: ".gsd/milestones/M001/slices/S01/S01-PLAN.md",
+    taskPlanPath: ".gsd/milestones/M001/slices/S01/tasks/T01-PLAN.md",
+    taskPlanInline: "## Task Plan\n- implement the fix",
+    slicePlanExcerpt,
+    carryForwardSection: "Carry forward context",
+    resumeSection: "Resume context",
+    runtimeContext: "",
+    priorTaskLines: "- (no prior tasks)",
+    taskSummaryPath: ".gsd/milestones/M001/slices/S01/tasks/T01-SUMMARY.md",
+    inlinedTemplates: "Template",
+    verificationBudget: "~10K chars",
+    overridesSection: "",
+  };
+
+  const rendered = loadPrompt("execute-task", vars);
+  const expected = safeRender("execute-task", vars);
+
+  assert.equal(rendered, expected);
+  assert.ok(rendered.includes("grep -q '^0$' file.txt"));
+  assert.ok(rendered.includes("printf '$&'"));
+  assert.ok(rendered.includes("printf '$`'"));
+});


### PR DESCRIPTION
## TL;DR

**What:** Makes prompt template substitution treat replacement values literally instead of as JavaScript replacement patterns.
**Why:** Shell snippets like `grep -q '^0$'` could expand `$'`, `$&`, or ``$` `` into prompt text and blow a single prompt far past the model context window.
**How:** Replaces `replaceAll(..., value)` with literal split/join substitution in the production loader and adds a regression test that renders `execute-task` with those exact literals.

## What

This PR updates `src/resources/extensions/gsd/prompt-loader.ts` so template variables are substituted with literal split/join semantics instead of `String.replaceAll(..., replacement)` semantics. It also adds `src/resources/extensions/gsd/tests/prompt-loader.test.ts` to lock in the regression case using the real `execute-task` prompt path.

## Why

Closes #2968.

Prompt rendering was treating replacement values as replacement patterns rather than plain text. That meant ordinary shell verification snippets like `grep -q '^0$'` could trigger `$'` expansion and inject a chunk of the template tail into the rendered prompt. In the worst case that can balloon a single prompt enough to trip provider context-window limits and stall auto-mode.

## How

The fix is deliberately small:

- switch prompt substitution to literal split/join replacement
- keep the existing placeholder validation logic unchanged
- add a regression test that renders `execute-task` with `$'`, `$&`, and ``$` `` in `slicePlanExcerpt`
- assert the rendered prompt preserves those literals exactly

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

Verified locally with the full CI mirror gate in a clean local verification clone:
- `npm run build`
- `npm run typecheck:extensions`
- `npm run test:unit`
- `npm run test:integration`

**Bug reproduction:**

1. From repo root, run an inline Node script that imports `loadPrompt(...)` from `src/resources/extensions/gsd/prompt-loader.ts` and renders `execute-task` with `slicePlanExcerpt` containing `grep -q '^0$' file.txt`, `printf '$&'`, and ``printf '$`'``.
2. Inspect the rendered prompt text.
3. Confirm the rendered output still contains those exact literals instead of expanding them into surrounding template text.

Before fix: replacement-pattern metacharacters in prompt variables could expand into template text and inflate the rendered prompt unexpectedly.
After fix: the rendered prompt preserves `^0$`, `$&`, and ``$` `` literally.

## AI disclosure

- [x] This PR includes AI-assisted code

This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.
