### PR TITLE
fix(gsd): fall back to roadmap when discuss DB is empty

### DIFF
--- a/src/resources/extensions/gsd/guided-flow.ts
+++ b/src/resources/extensions/gsd/guided-flow.ts
@@ -13,6 +13,7 @@ import { isDbAvailable, getMilestoneSlices } from "./gsd-db.js";
 import { loadPrompt, inlineTemplate } from "./prompt-loader.js";
 import { buildSkillActivationBlock } from "./auto-prompts.js";
 import { deriveState } from "./state.js";
+import { parseRoadmap } from "./parsers-legacy.js";
 import { invalidateAllCaches } from "./cache.js";
 import { startAuto } from "./auto.js";
 import { readCrashLock, clearLock, formatCrashInfo } from "./crash-recovery.js";
@@ -204,6 +205,21 @@ function parseMilestoneSequenceFromProject(content: string): string[] {
 // ─── Types ────────────────────────────────────────────────────────────────────
 
 type UIContext = ExtensionContext;
+
+type DiscussSlice = { id: string; done: boolean; title: string };
+
+export function normalizeDiscussSlices(
+  dbSlices: Array<{ id: string; status: string; title: string }>,
+  roadmapContent: string | null,
+): DiscussSlice[] {
+  if (dbSlices.length > 0) {
+    return dbSlices.map(s => ({ id: s.id, done: s.status === "complete", title: s.title }));
+  }
+
+  if (!roadmapContent) return [];
+
+  return parseRoadmap(roadmapContent).slices.map(s => ({ id: s.id, done: s.done, title: s.title }));
+}
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -604,19 +620,14 @@ export async function showDiscuss(
   // Guard: no roadmap yet (unless DB has slices)
   const roadmapFile = resolveMilestoneFile(basePath, mid, "ROADMAP");
   const roadmapContent = roadmapFile ? await loadFile(roadmapFile) : null;
-  if (!roadmapContent && !isDbAvailable()) {
+  const dbSlices = isDbAvailable() ? getMilestoneSlices(mid) : [];
+  if (!roadmapContent && dbSlices.length === 0) {
     ctx.ui.notify("No roadmap yet for this milestone. Run /gsd to plan first.", "warning");
     return;
   }
 
-  // Normalize slices: prefer DB, fall back to parser
-  type NormSlice = { id: string; done: boolean; title: string };
-  let normSlices: NormSlice[];
-  if (isDbAvailable()) {
-    normSlices = getMilestoneSlices(mid).map(s => ({ id: s.id, done: s.status === "complete", title: s.title }));
-  } else {
-    normSlices = [];
-  }
+  // Normalize slices: prefer DB rows when present, otherwise fall back to the roadmap parser.
+  const normSlices = normalizeDiscussSlices(dbSlices, roadmapContent);
   const pendingSlices = normSlices.filter(s => !s.done);
 
   if (pendingSlices.length === 0) {

--- a/src/resources/extensions/gsd/tests/discuss-roadmap-fallback.test.ts
+++ b/src/resources/extensions/gsd/tests/discuss-roadmap-fallback.test.ts
@@ -1,0 +1,41 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { openDatabase, closeDatabase, getMilestoneSlices } from "../gsd-db.ts";
+import { normalizeDiscussSlices } from "../guided-flow.ts";
+
+function createFixtureBase(): string {
+  const base = mkdtempSync(join(tmpdir(), "gsd-discuss-fallback-"));
+  mkdirSync(join(base, ".gsd", "milestones", "M001"), { recursive: true });
+  return base;
+}
+
+test("showDiscuss slice normalization falls back to roadmap when DB is open but empty", () => {
+  const base = createFixtureBase();
+  try {
+    const roadmapPath = join(base, ".gsd", "milestones", "M001", "M001-ROADMAP.md");
+    writeFileSync(
+      roadmapPath,
+      `# M001: Discuss fallback\n\n## Slices\n\n- [ ] **S01: One Slice** \`risk:low\` \`depends:[]\`\n  > After this: still needs discussion.\n`,
+    );
+
+    const dbPath = join(base, ".gsd", "gsd.db");
+    assert.equal(openDatabase(dbPath), true, "should open an empty DB");
+    const dbSlices = getMilestoneSlices("M001");
+    assert.deepStrictEqual(dbSlices, [], "fixture DB should be open but empty for the milestone");
+
+    const roadmapContent = readFileSync(roadmapPath, "utf-8");
+    const slices = normalizeDiscussSlices(dbSlices, roadmapContent);
+
+    assert.equal(slices.length, 1, "roadmap slice should be used when DB is empty");
+    assert.equal(slices[0]?.id, "S01");
+    assert.equal(slices[0]?.done, false);
+    assert.equal(slices[0]?.title, "One Slice");
+  } finally {
+    closeDatabase();
+    rmSync(base, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## TL;DR

**What:** Makes `/gsd discuss` fall back to roadmap slices when the DB is open but empty.
**Why:** A crash-truncated DB could look “available” while returning zero slice rows, causing a false `All slices are complete` exit.
**How:** Adds a small normalization helper that prefers DB rows when present and otherwise parses the roadmap, plus regression coverage for the empty-DB case.

## What

This PR updates `src/resources/extensions/gsd/guided-flow.ts` so the discuss slice picker no longer equates “DB available” with “DB has authoritative slice rows.” It also adds `src/resources/extensions/gsd/tests/discuss-roadmap-fallback.test.ts` to cover the open-but-empty DB scenario.

## Why

Closes #2892.

After a crash, GSD can reopen a valid-but-empty database file and report the DB as available even though the milestone has no slice rows. The discuss flow previously treated that as authoritative, producing an empty pending-slice set and falsely telling the user that all slices were complete. The roadmap is still the right fallback source in that situation.

## How

The implementation stays focused:

- add `normalizeDiscussSlices(...)` to centralize discuss-slice normalization
- use DB slice rows when they exist
- fall back to parsing `ROADMAP.md` when the DB is open but empty
- keep the existing “no roadmap yet” guard, but only when both DB rows and roadmap content are absent
- add a regression test that opens an empty DB, seeds a roadmap, and proves the fallback returns the roadmap slice

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

Verified locally with the full CI mirror gate in a clean local verification clone:
- `npm run build`
- `npm run typecheck:extensions`
- `npm run test:unit`
- `npm run test:integration`

**Bug reproduction:**

1. From repo root, run an inline Node script that imports `normalizeDiscussSlices(...)` from `src/resources/extensions/gsd/guided-flow.ts`.
2. Pass it an empty DB slice list (`[]`) together with a roadmap string containing an incomplete slice such as `S01`.
3. Confirm the returned slice list contains `S01` with `done: false` instead of returning an empty set.

Before fix: an open-but-empty DB path in discuss could collapse to zero pending slices and falsely report that everything was complete.
After fix: discuss falls back to the roadmap when the DB is empty, so incomplete slices still appear.

## AI disclosure

- [x] This PR includes AI-assisted code

This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.
