### PR TITLE
fix(gsd): run forensics dedup before investigation

### DIFF
--- a/src/resources/extensions/gsd/forensics.ts
+++ b/src/resources/extensions/gsd/forensics.ts
@@ -106,13 +106,13 @@ interface ForensicReport {
 // ─── Duplicate Detection ──────────────────────────────────────────────────────
 
 const DEDUP_PROMPT_SECTION = `
-## Duplicate Detection (REQUIRED before issue creation)
-
-Before offering to create a GitHub issue, you MUST search for existing issues and PRs that may already address this bug. This step uses the user's AI tokens for analysis.
+Before reading more GSD source code, you MUST search for existing issues and PRs that may already address this bug.
+Use keywords from the user's problem description and the anomaly summaries in the forensic report.
+This step should happen before deep investigation so the user does not spend tokens on already-known fixes.
 
 ### Search Steps
 
-1. **Search closed issues** for similar keywords from your diagnosis:
+1. **Search closed issues** for similar keywords from the symptom, likely subsystem, and anomaly summaries:
    \`\`\`
    gh issue list --repo gsd-build/gsd-2 --state closed --search "<keywords from root cause>" --limit 20
    \`\`\`
@@ -127,22 +127,20 @@ Before offering to create a GitHub issue, you MUST search for existing issues an
    gh pr list --repo gsd-build/gsd-2 --state merged --search "<keywords>" --limit 10
    \`\`\`
 
-### Analysis
+### Decision Gate
 
-For each result, compare it against your root-cause diagnosis:
+- **Merged PR clearly fixes the described symptom** → report "Already fixed by PR #X" with a brief explanation and skip the full investigation.
+- **Open issue clearly matches** → report "Existing issue #Y already covers this." Offer to add forensic evidence instead of repeating the full investigation unless the user asks for deeper analysis.
+- **No good matches** → continue to the full investigation below.
+
+### If You Continue
+
+When you proceed to the full investigation, compare any promising matches against your eventual diagnosis:
 - Does the issue describe the same code path or file?
 - Does the PR modify the same file:line you identified?
 - Is the symptom description semantically similar even if keywords differ?
 
-### Present Findings
-
-If you find potential matches, present them to the user:
-
-1. **"Already fixed by PR #X — skip issue creation"** — when a merged PR or closed issue clearly addresses the same root cause. Explain why you believe it matches.
-2. **"Add my findings to existing issue #Y"** — when an open issue exists for the same bug. Use \`gh issue comment #Y --repo gsd-build/gsd-2\` to add forensic evidence.
-3. **"Create new issue anyway"** — when existing results do not cover this specific failure.
-
-Only proceed to issue creation if no matches were found OR the user explicitly chooses "Create new issue anyway".
+Only continue to the full investigation when you did not find a clearly matching fix or already-open issue.
 `;
 
 async function writeForensicsDedupPref(ctx: ExtensionCommandContext, enabled: boolean): Promise<void> {

--- a/src/resources/extensions/gsd/prompts/forensics.md
+++ b/src/resources/extensions/gsd/prompts/forensics.md
@@ -102,6 +102,10 @@ A stale lock (PID is dead) means the previous auto-mode session crashed mid-unit
 
 A unit dispatched more than once (`type/id` appears multiple times) indicates a stuck loop — the unit completed but artifact verification failed.
 
+## Pre-Investigation: Duplicate Check
+
+{{dedupSection}}
+
 ## Investigation Protocol
 
 1. **Start with the pre-parsed forensic report** above. The anomaly section contains automated findings — treat these as leads, not conclusions.
@@ -132,8 +136,6 @@ Explain your findings:
 - **Why it happened** — root cause traced to specific code in GSD source, with `file:line` references
 - **Code snippet** — the problematic code and what it should do instead
 - **Recovery** — what the user can do right now to get unstuck
-
-{{dedupSection}}
 
 Then **offer GitHub issue creation**: "Would you like me to create a GitHub issue for this on gsd-build/gsd-2?"
 

--- a/src/resources/extensions/gsd/tests/forensics-dedup.test.ts
+++ b/src/resources/extensions/gsd/tests/forensics-dedup.test.ts
@@ -22,12 +22,34 @@ describe("forensics dedup (#2096)", () => {
       "forensics.md must contain {{dedupSection}} placeholder");
   });
 
+  it("forensics prompt runs dedup before the investigation protocol", () => {
+    const prompt = readFileSync(join(gsdDir, "prompts", "forensics.md"), "utf-8");
+    const dedupIndex = prompt.indexOf("## Pre-Investigation: Duplicate Check");
+    const investigationIndex = prompt.indexOf("## Investigation Protocol");
+    assert.ok(dedupIndex >= 0, "forensics.md must define the duplicate-check gate");
+    assert.ok(investigationIndex >= 0, "forensics.md must define the investigation protocol");
+    assert.ok(dedupIndex < investigationIndex,
+      "duplicate detection must appear before the investigation protocol");
+  });
+
   it("DEDUP_PROMPT_SECTION contains required search commands", async () => {
     const source = readFileSync(join(gsdDir, "forensics.ts"), "utf-8");
     assert.ok(source.includes("DEDUP_PROMPT_SECTION"), "forensics.ts must define DEDUP_PROMPT_SECTION");
     assert.ok(source.includes("gh issue list --repo gsd-build/gsd-2 --state closed"));
     assert.ok(source.includes("gh pr list --repo gsd-build/gsd-2 --state open"));
     assert.ok(source.includes("gh pr list --repo gsd-build/gsd-2 --state merged"));
+    assert.ok(
+      source.includes("user's problem description and the anomaly summaries"),
+      "dedup search should start from the problem description and anomaly summaries, not a post-investigation diagnosis",
+    );
+    assert.ok(
+      source.includes("skip the full investigation"),
+      "dedup gate should allow early exit when an existing fix already matches",
+    );
+    assert.ok(
+      !source.includes("similar keywords from your diagnosis"),
+      "dedup gate should not require a diagnosis before the early duplicate check",
+    );
   });
 
   it("handleForensics checks forensics_dedup preference", () => {


### PR DESCRIPTION
## TL;DR

**What:** Move the forensics duplicate-detection gate ahead of the deep investigation prompt and lock the prompt order with regression coverage.
**Why:** `/gsd forensics` was spending a full investigation before checking whether an existing issue or merged PR already covered the bug.
**How:** Render the dedup guidance as a pre-investigation section, tighten the guidance around early exits, and add prompt-order assertions.

## What

This updates the forensics prompt pipeline so duplicate detection renders before the investigation protocol instead of after the output instructions. The diff also tightens the dedup guidance in `forensics.ts` so the search starts from the user's symptoms and anomaly summaries, and it adds regression coverage for the rendered prompt ordering and early-exit behavior.

## Why

Closes #2704.

The old prompt placement meant the agent only learned about duplicate detection after it had already spent tokens on the full root-cause investigation. That defeated the point of the feature for already-fixed bugs and repeated existing issue work.

## How

The `forensics` prompt now renders `{{dedupSection}}` under a new `Pre-Investigation: Duplicate Check` heading, before `## Investigation Protocol`. The dedup instructions were rewritten to explicitly allow an early exit when a merged PR or clearly matching issue already covers the symptom, and the tests now assert both the prompt order and the updated guidance text.

## Change type

- [x] `fix` — Bug fix
- [ ] `feat` — New feature or capability
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

Verified locally with the full CI mirror gate: `npm run build`, `npm run typecheck:extensions`, `npm run test:unit`, and `npm run test:integration`.

**Bug reproduction:**

1. Render the `forensics` prompt with duplicate detection enabled and representative forensic data.
2. Inspect the rendered headings around the duplicate-check section and the investigation protocol.
3. Confirm the duplicate-check gate appears before the investigation protocol and tells the agent to skip the full investigation when an existing issue or merged PR already matches.

Before fix: duplicate-detection guidance rendered after the investigation/output sections, so the agent had already spent tokens before seeing the gate.
After fix: duplicate detection renders before deep investigation, so already-fixed bugs can short-circuit early.

## AI disclosure

- [x] This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.
