### PR TITLE
fix(gsd): add requirement save and markdown sync

### DIFF
--- a/src/resources/extensions/gsd/auto-start.ts
+++ b/src/resources/extensions/gsd/auto-start.ts
@@ -575,6 +575,8 @@ export async function bootstrapAutoSession(
     if (existsSync(gsdDbPath) && !isDbAvailable()) {
       try {
         openDatabase(gsdDbPath);
+        const { syncRequirementsFromMarkdown } = await import("./md-importer.js");
+        syncRequirementsFromMarkdown(s.basePath);
       } catch (err) {
         process.stderr.write(
           `gsd-db: failed to open existing database: ${(err as Error).message}\n`,

--- a/src/resources/extensions/gsd/bootstrap/db-tools.ts
+++ b/src/resources/extensions/gsd/bootstrap/db-tools.ts
@@ -110,6 +110,97 @@ export function registerDbTools(pi: ExtensionAPI): void {
   pi.registerTool(decisionSaveTool);
   registerAlias(pi, decisionSaveTool, "gsd_save_decision", "gsd_decision_save");
 
+  // ─── gsd_requirement_save (formerly gsd_save_requirement) ────────────────
+
+  const requirementSaveExecute = async (_toolCallId: string, params: any, _signal: AbortSignal | undefined, _onUpdate: unknown, _ctx: unknown) => {
+    const dbAvailable = await ensureDbOpen();
+    if (!dbAvailable) {
+      return {
+        content: [{ type: "text" as const, text: "Error: GSD database is not available. Cannot save requirement." }],
+        details: { operation: "save_requirement", id: params.id, error: "db_unavailable" } as any,
+      };
+    }
+    try {
+      const { saveRequirementToDb } = await import("../db-writer.js");
+      const { id } = await saveRequirementToDb(
+        {
+          id: params.id,
+          class: params.class,
+          status: params.status,
+          description: params.description,
+          why: params.why,
+          source: params.source,
+          primary_owner: params.primary_owner,
+          supporting_slices: params.supporting_slices,
+          validation: params.validation,
+          notes: params.notes,
+          full_content: params.full_content,
+          superseded_by: params.superseded_by,
+        },
+        process.cwd(),
+      );
+      return {
+        content: [{ type: "text" as const, text: `Saved requirement ${id}` }],
+        details: { operation: "save_requirement", id } as any,
+      };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      logError("tool", `gsd_requirement_save tool failed: ${msg}`, { tool: "gsd_requirement_save", error: String(err) });
+      return {
+        content: [{ type: "text" as const, text: `Error saving requirement: ${msg}` }],
+        details: { operation: "save_requirement", id: params.id, error: msg } as any,
+      };
+    }
+  };
+
+  const requirementSaveTool = {
+    name: "gsd_requirement_save",
+    label: "Save Requirement",
+    description:
+      "Create or upsert a requirement in the GSD database and regenerate REQUIREMENTS.md. " +
+      "Use this when introducing a requirement that is not yet present in the DB.",
+    promptSnippet: "Create or upsert a GSD requirement by ID (regenerates REQUIREMENTS.md)",
+    promptGuidelines: [
+      "Use gsd_requirement_save when creating a requirement or syncing a newly authored requirement into the DB.",
+      "The id parameter is required and should use the canonical RXXX format.",
+      "Provide the full requirement shape you want persisted; omitted optional fields default to empty strings.",
+      "Use gsd_requirement_update for incremental edits to an existing DB-backed requirement.",
+    ],
+    parameters: Type.Object({
+      id: Type.String({ description: "The requirement ID (e.g. R001, R014)" }),
+      class: Type.String({ description: "Requirement class (e.g. functional, non-functional, failure-visibility)" }),
+      description: Type.String({ description: "Short requirement description" }),
+      status: Type.Optional(Type.String({ description: "Status (defaults to active)" })),
+      why: Type.Optional(Type.String({ description: "Why the requirement matters" })),
+      source: Type.Optional(Type.String({ description: "Where the requirement came from" })),
+      primary_owner: Type.Optional(Type.String({ description: "Primary owning slice or milestone" })),
+      supporting_slices: Type.Optional(Type.String({ description: "Supporting slices" })),
+      validation: Type.Optional(Type.String({ description: "Validation or proof plan" })),
+      notes: Type.Optional(Type.String({ description: "Additional notes" })),
+      full_content: Type.Optional(Type.String({ description: "Optional full requirement body" })),
+      superseded_by: Type.Optional(Type.String({ description: "Superseding requirement ID, if any" })),
+    }),
+    execute: requirementSaveExecute,
+    renderCall(args: any, theme: any) {
+      let text = theme.fg("toolTitle", theme.bold("requirement_save "));
+      if (args.id) text += theme.fg("accent", args.id);
+      if (args.description) text += theme.fg("muted", ` — ${args.description}`);
+      return new Text(text, 0, 0);
+    },
+    renderResult(result: any, _options: any, theme: any) {
+      const d = result.details;
+      if (result.isError || d?.error) {
+        return new Text(theme.fg("error", `Error: ${d?.error ?? "unknown"}`), 0, 0);
+      }
+      let text = theme.fg("success", `Requirement ${d?.id ?? ""} saved`);
+      text += theme.fg("dim", " → REQUIREMENTS.md");
+      return new Text(text, 0, 0);
+    },
+  };
+
+  pi.registerTool(requirementSaveTool);
+  registerAlias(pi, requirementSaveTool, "gsd_save_requirement", "gsd_requirement_save");
+
   // ─── gsd_requirement_update (formerly gsd_update_requirement) ───────────
 
   const requirementUpdateExecute = async (_toolCallId: string, params: any, _signal: AbortSignal | undefined, _onUpdate: unknown, _ctx: unknown) => {
@@ -122,7 +213,12 @@ export function registerDbTools(pi: ExtensionAPI): void {
     }
     try {
       const db = await import("../gsd-db.js");
-      const existing = db.getRequirementById(params.id);
+      let existing = db.getRequirementById(params.id);
+      if (!existing) {
+        const { syncRequirementsFromMarkdown } = await import("../md-importer.js");
+        syncRequirementsFromMarkdown(process.cwd());
+        existing = db.getRequirementById(params.id);
+      }
       if (!existing) {
         return {
           content: [{ type: "text" as const, text: `Error: Requirement ${params.id} not found.` }],
@@ -163,7 +259,7 @@ export function registerDbTools(pi: ExtensionAPI): void {
       "Use gsd_requirement_update to change status, validation, notes, or other fields on an existing requirement.",
       "The id parameter is required — it must be an existing RXXX identifier.",
       "All other fields are optional — only provided fields are updated.",
-      "The tool verifies the requirement exists before updating.",
+      "The tool verifies the requirement exists before updating and backfills missing rows from REQUIREMENTS.md when possible.",
     ],
     parameters: Type.Object({
       id: Type.String({ description: "The requirement ID (e.g. R001, R014)" }),

--- a/src/resources/extensions/gsd/bootstrap/dynamic-tools.ts
+++ b/src/resources/extensions/gsd/bootstrap/dynamic-tools.ts
@@ -50,7 +50,17 @@ export async function ensureDbOpen(): Promise<boolean> {
     // Open existing DB file (may be at project root for worktrees)
     if (existsSync(dbPath)) {
       const opened = db.openDatabase(dbPath);
-      if (opened) setLogBasePath(projectRoot);
+      if (opened) {
+        setLogBasePath(projectRoot);
+        try {
+          const { syncRequirementsFromMarkdown } = await import("../md-importer.js");
+          syncRequirementsFromMarkdown(basePath);
+        } catch (err) {
+          process.stderr.write(
+            `gsd-db: ensureDbOpen requirement sync failed: ${(err as Error).message}\n`,
+          );
+        }
+      }
       return opened;
     }
 
@@ -154,4 +164,3 @@ export function registerDynamicTools(pi: ExtensionAPI): void {
     },
   } as any);
 }
-

--- a/src/resources/extensions/gsd/db-writer.ts
+++ b/src/resources/extensions/gsd/db-writer.ts
@@ -329,6 +329,97 @@ export async function saveDecisionToDb(
   }
 }
 
+function loadAllRequirements(adapter: { prepare: (sql: string) => { all: () => Record<string, unknown>[] } } | null): Requirement[] {
+  if (!adapter) return [];
+  const rows = adapter.prepare('SELECT * FROM requirements ORDER BY id').all();
+  return rows.map(row => ({
+    id: row['id'] as string,
+    class: row['class'] as string,
+    status: row['status'] as string,
+    description: row['description'] as string,
+    why: row['why'] as string,
+    source: row['source'] as string,
+    primary_owner: row['primary_owner'] as string,
+    supporting_slices: row['supporting_slices'] as string,
+    validation: row['validation'] as string,
+    notes: row['notes'] as string,
+    full_content: row['full_content'] as string,
+    superseded_by: (row['superseded_by'] as string) ?? null,
+  }));
+}
+
+async function regenerateRequirementsMarkdown(basePath: string, requirements: Requirement[]): Promise<void> {
+  const nonSuperseded = requirements.filter(r => r.superseded_by == null);
+  const md = generateRequirementsMd(nonSuperseded);
+  await saveFile(resolveGsdRootFile(basePath, 'REQUIREMENTS'), md);
+}
+
+export interface SaveRequirementFields {
+  id: string;
+  class: string;
+  status?: string;
+  description: string;
+  why?: string;
+  source?: string;
+  primary_owner?: string;
+  supporting_slices?: string;
+  validation?: string;
+  notes?: string;
+  full_content?: string;
+  superseded_by?: string | null;
+}
+
+/**
+ * Save or upsert a requirement in DB and regenerate REQUIREMENTS.md.
+ * Uses the provided ID because requirements are human-scoped contract entries.
+ */
+export async function saveRequirementToDb(
+  fields: SaveRequirementFields,
+  basePath: string,
+): Promise<{ id: string }> {
+  try {
+    const db = await import('./gsd-db.js');
+    const existing = db.getRequirementById(fields.id);
+    const adapter = db._getAdapter();
+    const requirement: Requirement = {
+      id: fields.id,
+      class: fields.class,
+      status: fields.status ?? existing?.status ?? 'active',
+      description: fields.description,
+      why: fields.why ?? existing?.why ?? '',
+      source: fields.source ?? existing?.source ?? '',
+      primary_owner: fields.primary_owner ?? existing?.primary_owner ?? '',
+      supporting_slices: fields.supporting_slices ?? existing?.supporting_slices ?? '',
+      validation: fields.validation ?? existing?.validation ?? '',
+      notes: fields.notes ?? existing?.notes ?? '',
+      full_content: fields.full_content ?? existing?.full_content ?? '',
+      superseded_by: fields.superseded_by ?? existing?.superseded_by ?? null,
+    };
+
+    db.upsertRequirement(requirement);
+
+    try {
+      await regenerateRequirementsMarkdown(basePath, loadAllRequirements(adapter));
+    } catch (diskErr) {
+      logError('manifest', 'disk write failed, reverting DB row', { fn: 'saveRequirementToDb', error: String((diskErr as Error).message) });
+      if (existing) {
+        db.upsertRequirement(existing);
+      } else {
+        adapter?.prepare('DELETE FROM requirements WHERE id = :id').run({ ':id': fields.id });
+      }
+      throw diskErr;
+    }
+
+    invalidateStateCache();
+    clearPathCache();
+    clearParseCache();
+    return { id: fields.id };
+  } catch (err) {
+    logError('manifest', 'saveRequirementToDb failed', { fn: 'saveRequirementToDb', error: String((err as Error).message) });
+    throw err;
+  }
+}
+
 // ─── Update Requirement in DB + Regenerate Markdown ───────────────────────
 
 /**
@@ -357,35 +448,9 @@ export async function updateRequirementInDb(
 
     db.upsertRequirement(merged);
 
-    // Fetch ALL requirements (including superseded) for full file regeneration
     const adapter = db._getAdapter();
-    let allRequirements: Requirement[] = [];
-    if (adapter) {
-      const rows = adapter.prepare('SELECT * FROM requirements ORDER BY id').all();
-      allRequirements = rows.map(row => ({
-        id: row['id'] as string,
-        class: row['class'] as string,
-        status: row['status'] as string,
-        description: row['description'] as string,
-        why: row['why'] as string,
-        source: row['source'] as string,
-        primary_owner: row['primary_owner'] as string,
-        supporting_slices: row['supporting_slices'] as string,
-        validation: row['validation'] as string,
-        notes: row['notes'] as string,
-        full_content: row['full_content'] as string,
-        superseded_by: (row['superseded_by'] as string) ?? null,
-      }));
-    }
-
-    // Filter to non-superseded for the markdown file
-    // (superseded requirements don't appear in section headings)
-    const nonSuperseded = allRequirements.filter(r => r.superseded_by == null);
-
-    const md = generateRequirementsMd(nonSuperseded);
-    const filePath = resolveGsdRootFile(basePath, 'REQUIREMENTS');
     try {
-      await saveFile(filePath, md);
+      await regenerateRequirementsMarkdown(basePath, loadAllRequirements(adapter));
     } catch (diskErr) {
       logError('manifest', 'disk write failed, reverting DB row', { fn: 'updateRequirementInDb', error: String((diskErr as Error).message) });
       db.upsertRequirement(existing);

--- a/src/resources/extensions/gsd/extension-manifest.json
+++ b/src/resources/extensions/gsd/extension-manifest.json
@@ -9,7 +9,7 @@
     "tools": [
       "bash", "write", "read", "edit",
       "gsd_decision_save", "gsd_summary_save",
-      "gsd_requirement_update", "gsd_milestone_generate_id"
+      "gsd_requirement_save", "gsd_requirement_update", "gsd_milestone_generate_id"
     ],
     "commands": ["gsd", "kill", "worktree", "exit"],
     "hooks": ["session_start", "session_switch"],

--- a/src/resources/extensions/gsd/md-importer.ts
+++ b/src/resources/extensions/gsd/md-importer.ts
@@ -8,6 +8,7 @@ import { readFileSync, readdirSync, existsSync } from 'node:fs';
 import { join, relative } from 'node:path';
 import type { Decision, Requirement } from './types.js';
 import {
+  getRequirementById,
   upsertDecision,
   upsertRequirement,
   insertArtifact,
@@ -299,6 +300,27 @@ function importRequirements(gsdDir: string): number {
   }
 
   return requirements.length;
+}
+
+/**
+ * Backfill requirements that exist in REQUIREMENTS.md but are missing from the DB.
+ * This preserves already-imported rows and avoids re-running the full migration.
+ */
+export function syncRequirementsFromMarkdown(gsdDir: string): number {
+  const filePath = resolveGsdRootFile(gsdDir, 'REQUIREMENTS');
+  if (!existsSync(filePath)) return 0;
+
+  const content = readFileSync(filePath, 'utf-8');
+  const requirements = parseRequirementsSections(content);
+  let imported = 0;
+
+  for (const requirement of requirements) {
+    if (getRequirementById(requirement.id)) continue;
+    upsertRequirement(requirement);
+    imported += 1;
+  }
+
+  return imported;
 }
 
 // ─── Hierarchy Artifact Walker ─────────────────────────────────────────────

--- a/src/resources/extensions/gsd/tests/db-writer.test.ts
+++ b/src/resources/extensions/gsd/tests/db-writer.test.ts
@@ -22,6 +22,7 @@ import {
   generateRequirementsMd,
   nextDecisionId,
   saveDecisionToDb,
+  saveRequirementToDb,
   updateRequirementInDb,
   saveArtifactToDb,
 } from '../db-writer.ts';
@@ -352,6 +353,45 @@ describe('db-writer', () => {
       const mdContent2 = fs.readFileSync(mdPath, 'utf-8');
       const parsed2 = parseDecisionsTable(mdContent2);
       assert.deepStrictEqual(parsed2.length, 2, 'DECISIONS.md now has 2 decisions');
+    } finally {
+      closeDatabase();
+      cleanupDir(tmpDir);
+    }
+  });
+
+  test('saveRequirementToDb', async () => {
+    const tmpDir = makeTmpDir();
+    const dbPath = path.join(tmpDir, '.gsd', 'gsd.db');
+    openDatabase(dbPath);
+
+    try {
+      const result = await saveRequirementToDb({
+        id: 'R001',
+        class: 'functional',
+        description: 'Persist new requirements through the DB tool path',
+        why: 'Requirement updates need a create path first',
+        source: 'issue-2919',
+        primary_owner: 'M005/S07',
+        validation: 'Tool round-trip succeeds',
+      }, tmpDir);
+
+      assert.deepStrictEqual(result.id, 'R001', 'saveRequirementToDb returns the provided requirement ID');
+
+      const saved = getRequirementById('R001');
+      assert.ok(!!saved, 'requirement exists in DB after save');
+      assert.deepStrictEqual(saved?.status, 'active', 'save defaults status to active');
+      assert.deepStrictEqual(saved?.description, 'Persist new requirements through the DB tool path', 'DB requirement has correct description');
+
+      const mdPath = path.join(tmpDir, '.gsd', 'REQUIREMENTS.md');
+      assert.ok(fs.existsSync(mdPath), 'REQUIREMENTS.md file created');
+
+      const mdContent = fs.readFileSync(mdPath, 'utf-8');
+      assert.ok(mdContent.includes('R001'), 'REQUIREMENTS.md contains requirement ID');
+      assert.ok(mdContent.includes('Persist new requirements through the DB tool path'), 'REQUIREMENTS.md contains requirement description');
+
+      const parsed = parseRequirementsSections(mdContent);
+      assert.deepStrictEqual(parsed.length, 1, 'written REQUIREMENTS.md parses to 1 requirement');
+      assert.deepStrictEqual(parsed[0].id, 'R001', 'parsed requirement has correct ID');
     } finally {
       closeDatabase();
       cleanupDir(tmpDir);

--- a/src/resources/extensions/gsd/tests/ensure-db-open.test.ts
+++ b/src/resources/extensions/gsd/tests/ensure-db-open.test.ts
@@ -10,7 +10,7 @@ import assert from 'node:assert/strict';
 import * as path from 'node:path';
 import * as os from 'node:os';
 import * as fs from 'node:fs';
-import { closeDatabase, isDbAvailable, getDecisionById } from '../gsd-db.ts';
+import { closeDatabase, isDbAvailable, getDecisionById, getRequirementById } from '../gsd-db.ts';
 
 function makeTmpDir(): string {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-ensure-db-'));
@@ -101,10 +101,10 @@ describe('ensure-db-open', () => {
   });
 
   // ═══════════════════════════════════════════════════════════════════════════
-  // ensureDbOpen opens existing DB without re-migration
+  // ensureDbOpen opens existing DB and backfills missing requirements from markdown
   // ═══════════════════════════════════════════════════════════════════════════
 
-  test('ensureDbOpen: opens existing DB', async () => {
+  test('ensureDbOpen: opens existing DB and syncs missing requirements', async () => {
     const tmpDir = makeTmpDir();
     const gsdDir = path.join(tmpDir, '.gsd');
     fs.mkdirSync(gsdDir, { recursive: true });
@@ -114,6 +114,20 @@ describe('ensure-db-open', () => {
     const { openDatabase } = await import('../gsd-db.ts');
     openDatabase(dbPath);
     closeDatabase();
+
+    fs.writeFileSync(path.join(gsdDir, 'REQUIREMENTS.md'), `# Requirements
+
+## Active
+
+### R001 — Sync missing requirements from markdown
+- Class: functional
+- Status: active
+- Description: Sync missing requirements from markdown
+- Why it matters: Requirement updates need DB rows to exist
+- Source: issue-2919
+- Primary owning slice: M005/S07
+- Validation: update succeeds
+`);
 
     assert.ok(fs.existsSync(dbPath), 'DB file should exist from manual create');
 
@@ -125,6 +139,9 @@ describe('ensure-db-open', () => {
       const result = await ensureDbOpen();
       assert.ok(result === true, 'ensureDbOpen should open existing DB');
       assert.ok(isDbAvailable(), 'DB should be available');
+      const requirement = getRequirementById('R001');
+      assert.ok(requirement !== null, 'missing requirement should be synced from REQUIREMENTS.md');
+      assert.deepStrictEqual(requirement?.description, 'Sync missing requirements from markdown', 'synced requirement keeps markdown fields');
     } finally {
       process.cwd = origCwd;
       closeDatabase();

--- a/src/resources/extensions/gsd/tests/gsd-tools.test.ts
+++ b/src/resources/extensions/gsd/tests/gsd-tools.test.ts
@@ -2,7 +2,7 @@ import { describe, test } from 'node:test';
 import assert from 'node:assert/strict';
 // gsd-tools — Structured LLM tool tests
 //
-// Tests the three registered tools: gsd_decision_save, gsd_requirement_update, gsd_summary_save.
+// Tests the core registered tools around decisions, requirements, and artifacts.
 // Each tool is tested via direct function invocation against an in-memory DB.
 
 import * as path from 'node:path';
@@ -20,11 +20,13 @@ import {
 } from '../gsd-db.ts';
 import {
   saveDecisionToDb,
+  saveRequirementToDb,
   updateRequirementInDb,
   saveArtifactToDb,
   nextDecisionId,
 } from '../db-writer.ts';
 import type { Requirement } from '../types.ts';
+import { registerDbTools } from '../bootstrap/db-tools.ts';
 
 // ═══════════════════════════════════════════════════════════════════════════
 // Helpers
@@ -40,6 +42,14 @@ function cleanupDir(dir: string): void {
   try {
     fs.rmSync(dir, { recursive: true, force: true });
   } catch { /* swallow */ }
+}
+
+function makeMockPi() {
+  const tools: any[] = [];
+  return {
+    registerTool: (tool: any) => tools.push(tool),
+    tools,
+  } as any;
 }
 
 /**
@@ -175,6 +185,81 @@ describe('gsd-tools', () => {
 
       closeDatabase();
     } finally {
+      cleanupDir(tmpDir);
+    }
+  });
+
+  test('gsd_requirement_save', async () => {
+    const tmpDir = makeTmpDir();
+    try {
+      const dbPath = path.join(tmpDir, '.gsd', 'gsd.db');
+      openDatabase(dbPath);
+
+      const result = await saveRequirementToDb(
+        {
+          id: 'R002',
+          class: 'functional',
+          description: 'Persist requirements through the DB tool path',
+          why: 'Requirement updates need rows to exist first',
+          source: 'issue-2919',
+        },
+        tmpDir,
+      );
+
+      assert.deepStrictEqual(result.id, 'R002', 'saveRequirementToDb should return the provided requirement ID');
+      const saved = getRequirementById('R002');
+      assert.ok(saved !== null, 'R002 should exist after save');
+      assert.deepStrictEqual(saved!.status, 'active', 'saveRequirementToDb defaults status to active');
+    } finally {
+      closeDatabase();
+      cleanupDir(tmpDir);
+    }
+  });
+
+  test('gsd_requirement_update syncs missing markdown requirement before update', async () => {
+    const tmpDir = makeTmpDir();
+    try {
+      const dbPath = path.join(tmpDir, '.gsd', 'gsd.db');
+      openDatabase(dbPath);
+      fs.writeFileSync(path.join(tmpDir, '.gsd', 'REQUIREMENTS.md'), `# Requirements
+
+## Active
+
+### R010 — Sync on update miss
+- Class: functional
+- Status: active
+- Description: Sync on update miss
+- Why it matters: The DB may lag behind markdown
+- Source: issue-2919
+- Primary owning slice: M005/S07
+- Validation: update succeeds after sync
+`);
+
+      const origCwd = process.cwd;
+      process.cwd = () => tmpDir;
+
+      try {
+        const pi = makeMockPi();
+        registerDbTools(pi);
+        const tool = pi.tools.find((entry: any) => entry.name === 'gsd_requirement_update');
+        assert.ok(tool, 'gsd_requirement_update tool should be registered');
+
+        const result = await tool.execute('call-1', {
+          id: 'R010',
+          status: 'validated',
+          validation: 'synced from markdown before update',
+        });
+
+        assert.ok(!result.details?.error, 'tool should succeed after syncing the missing requirement');
+        const saved = getRequirementById('R010');
+        assert.ok(saved !== null, 'R010 should exist after update-triggered sync');
+        assert.deepStrictEqual(saved!.status, 'validated', 'status should be updated after sync');
+        assert.deepStrictEqual(saved!.validation, 'synced from markdown before update', 'validation should reflect update payload');
+      } finally {
+        process.cwd = origCwd;
+      }
+    } finally {
+      closeDatabase();
       cleanupDir(tmpDir);
     }
   });

--- a/src/resources/extensions/gsd/tests/tool-naming.test.ts
+++ b/src/resources/extensions/gsd/tests/tool-naming.test.ts
@@ -23,6 +23,7 @@ function makeMockPi() {
 
 const RENAME_MAP: Array<{ canonical: string; alias: string }> = [
   { canonical: "gsd_decision_save", alias: "gsd_save_decision" },
+  { canonical: "gsd_requirement_save", alias: "gsd_save_requirement" },
   { canonical: "gsd_requirement_update", alias: "gsd_update_requirement" },
   { canonical: "gsd_summary_save", alias: "gsd_save_summary" },
   { canonical: "gsd_milestone_generate_id", alias: "gsd_generate_milestone_id" },
@@ -44,7 +45,7 @@ console.log('\n── Tool naming: registration count ──');
 const pi = makeMockPi();
 registerDbTools(pi);
 
-assert.deepStrictEqual(pi.tools.length, 27, 'Should register exactly 27 tools (13 canonical + 13 aliases + 1 gate tool)');
+assert.deepStrictEqual(pi.tools.length, 29, 'Should register exactly 29 tools (14 canonical + 14 aliases + 1 gate tool)');
 
 // ─── Both names exist for each pair ──────────────────────────────────────────
 


### PR DESCRIPTION
## TL;DR

**What:** Add a canonical requirement-save tool and resync missing requirement rows from `REQUIREMENTS.md` when opening or updating the GSD database.
**Why:** `gsd_requirement_update` returned `not_found` for requirements that still existed in markdown, and there was no canonical create path to insert a missing requirement row first.
**How:** Introduce `gsd_requirement_save`, backfill markdown-only requirements into existing DBs, and retry updates after sync with targeted regression coverage.

## What

This adds a canonical `gsd_requirement_save` tool, wires it into the manifest and alias map, and teaches the existing requirement-update/open paths to backfill missing requirement rows from `REQUIREMENTS.md`. The diff also refactors requirement markdown regeneration into a shared helper and adds tests for the save path, update-after-sync path, tool registration, and existing-DB reopen flow.

## Why

Closes #2919.

The reported failure mode was real: once a repo had an existing `gsd.db` that was missing a requirement row, `gsd_requirement_update` failed with `not_found` even though the requirement still existed in markdown. On top of that, the toolset had no canonical save path for creating the missing requirement row first.

## How

`ensureDbOpen()` and the auto-start reopen path now sync missing requirements from markdown when they open an existing DB. `gsd_requirement_update` retries after that sync when the first lookup misses, and `gsd_requirement_save` gives the workflow an explicit create/upsert path that also regenerates `REQUIREMENTS.md`. The tests cover both the direct DB helpers and the registered tool behavior.

## Change type

- [x] `fix` — Bug fix
- [ ] `feat` — New feature or capability
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

Verified locally with the full CI mirror gate: `npm run build`, `npm run typecheck:extensions`, `npm run test:unit`, and `npm run test:integration`.

**Bug reproduction:**

1. Create a temporary `.gsd/` directory with an existing `gsd.db` and a `REQUIREMENTS.md` file that contains `R041`, but leave the DB without a row for `R041`.
2. Invoke `gsd_requirement_update` for `R041`, then invoke `gsd_requirement_save` for a brand-new `R042`.
3. Confirm the update succeeds after syncing `R041` from markdown, the save path creates `R042`, and regenerated `REQUIREMENTS.md` contains both requirement IDs.

Before fix: `gsd_requirement_update` returned `not_found` for markdown-only requirements, and there was no canonical tool path to create the missing requirement row first.
After fix: update backfills missing markdown rows on demand, and `gsd_requirement_save` provides the explicit create/upsert path.

## AI disclosure

- [x] This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.
