### PR TITLE
test(budget-prediction): replace source-regex tests with direct imports

### DIFF
--- a/src/resources/extensions/gsd/tests/budget-prediction.test.ts
+++ b/src/resources/extensions/gsd/tests/budget-prediction.test.ts
@@ -1,90 +1,46 @@
 /**
  * Budget Prediction — unit tests for M004/S04.
  *
- * Tests prediction math, auto-downgrade logic, and dashboard integration.
- * Uses extracted pure functions (avoiding module import chain) and
- * source-level structural checks for dashboard/auto.ts integration.
+ * Tests prediction math and auto-downgrade logic.
  */
 
 import test from "node:test";
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
-import { join, dirname } from "node:path";
-import { fileURLToPath } from "node:url";
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const metricsSrc = readFileSync(join(__dirname, "..", "metrics.ts"), "utf-8");
-const dashboardSrc = readFileSync(join(__dirname, "..", "auto-dashboard.ts"), "utf-8");
+import {
+  getAverageCostPerUnitType,
+  predictRemainingCost,
+  type UnitMetrics,
+} from "../metrics.js";
 
-// ─── Extract pure functions from metrics.ts source ────────────────────────
-// Can't import directly due to paths.js → @gsd/pi-coding-agent import chain.
-// Extract and evaluate the pure math functions.
+// ─── Test helpers ─────────────────────────────────────────────────────────────
 
-interface MockUnitMetrics {
-  type: string;
-  cost: number;
+function makeUnit(type: string, cost: number): UnitMetrics {
+  return {
+    type,
+    id: `test/${type}`,
+    model: "test-model",
+    startedAt: 0,
+    finishedAt: 1,
+    tokens: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    cost,
+    toolCalls: 0,
+    assistantMessages: 1,
+    userMessages: 1,
+  };
 }
-
-// Re-implement the functions under test (verified against source below)
-function getAverageCostPerUnitType(units: MockUnitMetrics[]): Map<string, number> {
-  const sums = new Map<string, { total: number; count: number }>();
-  for (const u of units) {
-    const entry = sums.get(u.type) ?? { total: 0, count: 0 };
-    entry.total += u.cost;
-    entry.count += 1;
-    sums.set(u.type, entry);
-  }
-  const avgs = new Map<string, number>();
-  for (const [type, { total, count }] of sums) {
-    avgs.set(type, total / count);
-  }
-  return avgs;
-}
-
-function predictRemainingCost(
-  avgCosts: Map<string, number>,
-  remainingUnits: string[],
-  fallbackAvg?: number,
-): number {
-  const allAvgs = [...avgCosts.values()];
-  const overallAvg = fallbackAvg ?? (allAvgs.length > 0 ? allAvgs.reduce((a, b) => a + b, 0) / allAvgs.length : 0);
-  let total = 0;
-  for (const unitType of remainingUnits) {
-    total += avgCosts.get(unitType) ?? overallAvg;
-  }
-  return total;
-}
-
-// ═══════════════════════════════════════════════════════════════════════════
-// Source Verification — confirm our re-implementation matches
-// ═══════════════════════════════════════════════════════════════════════════
-
-test("source: metrics.ts exports getAverageCostPerUnitType", () => {
-  assert.ok(metricsSrc.includes("export function getAverageCostPerUnitType"), "should be exported");
-});
-
-test("source: metrics.ts exports predictRemainingCost", () => {
-  assert.ok(metricsSrc.includes("export function predictRemainingCost"), "should be exported");
-});
-
-test("source: getAverageCostPerUnitType uses Map<string, number>", () => {
-  assert.ok(
-    metricsSrc.includes("Map<string, number>") && metricsSrc.includes("getAverageCostPerUnitType"),
-    "should return Map<string, number>",
-  );
-});
 
 // ═══════════════════════════════════════════════════════════════════════════
 // Average Cost Per Unit Type
 // ═══════════════════════════════════════════════════════════════════════════
 
 test("avgCost: returns correct averages per unit type", () => {
-  const units: MockUnitMetrics[] = [
-    { type: "execute-task", cost: 0.10 },
-    { type: "execute-task", cost: 0.20 },
-    { type: "plan-slice", cost: 0.05 },
-    { type: "plan-slice", cost: 0.15 },
-    { type: "complete-slice", cost: 0.08 },
+  const units: UnitMetrics[] = [
+    makeUnit("execute-task", 0.10),
+    makeUnit("execute-task", 0.20),
+    makeUnit("plan-slice", 0.05),
+    makeUnit("plan-slice", 0.15),
+    makeUnit("complete-slice", 0.08),
   ];
   const avgs = getAverageCostPerUnitType(units);
   assert.ok(Math.abs(avgs.get("execute-task")! - 0.15) < 0.001, "execute-task avg should be 0.15");
@@ -98,7 +54,7 @@ test("avgCost: returns empty map for empty input", () => {
 });
 
 test("avgCost: single unit per type returns exact cost", () => {
-  const avgs = getAverageCostPerUnitType([{ type: "execute-task", cost: 0.42 }]);
+  const avgs = getAverageCostPerUnitType([makeUnit("execute-task", 0.42)]);
   assert.ok(Math.abs(avgs.get("execute-task")! - 0.42) < 0.001);
 });
 
@@ -146,33 +102,15 @@ test("predict: handles no averages and no fallback", () => {
 });
 
 // ═══════════════════════════════════════════════════════════════════════════
-// Dashboard Integration
-// ═══════════════════════════════════════════════════════════════════════════
-
-test("dashboard: AutoDashboardData includes projectedRemainingCost field", () => {
-  assert.ok(
-    dashboardSrc.includes("projectedRemainingCost"),
-    "AutoDashboardData should have projectedRemainingCost field",
-  );
-});
-
-test("dashboard: AutoDashboardData includes profileDowngraded field", () => {
-  assert.ok(
-    dashboardSrc.includes("profileDowngraded"),
-    "AutoDashboardData should have profileDowngraded field",
-  );
-});
-
-// ═══════════════════════════════════════════════════════════════════════════
 // Budget Prediction — End-to-End Math
 // ═══════════════════════════════════════════════════════════════════════════
 
 test("e2e: budget ceiling exceeded triggers downgrade prediction", () => {
-  const units: MockUnitMetrics[] = [
-    { type: "execute-task", cost: 0.50 },
-    { type: "execute-task", cost: 0.60 },
-    { type: "plan-slice", cost: 0.30 },
-    { type: "complete-slice", cost: 0.20 },
+  const units: UnitMetrics[] = [
+    makeUnit("execute-task", 0.50),
+    makeUnit("execute-task", 0.60),
+    makeUnit("plan-slice", 0.30),
+    makeUnit("complete-slice", 0.20),
   ];
   const totalSpent = units.reduce((sum, u) => sum + u.cost, 0); // 1.60
   const avgs = getAverageCostPerUnitType(units);
@@ -184,9 +122,9 @@ test("e2e: budget ceiling exceeded triggers downgrade prediction", () => {
 });
 
 test("e2e: budget ceiling not exceeded does not trigger", () => {
-  const units: MockUnitMetrics[] = [
-    { type: "execute-task", cost: 0.10 },
-    { type: "plan-slice", cost: 0.05 },
+  const units: UnitMetrics[] = [
+    makeUnit("execute-task", 0.10),
+    makeUnit("plan-slice", 0.05),
   ];
   const totalSpent = units.reduce((sum, u) => sum + u.cost, 0); // 0.15
   const avgs = getAverageCostPerUnitType(units);
@@ -202,7 +140,6 @@ test("e2e: budget ceiling not exceeded does not trigger", () => {
 // ═══════════════════════════════════════════════════════════════════════════
 
 test("downgrade: one-way per D048 — downgrade should not be reversible", () => {
-  // Simulate: first prediction triggers downgrade, second doesn't reverse it
   let downgraded = false;
 
   function checkDowngrade(predictedTotal: number, ceiling: number) {


### PR DESCRIPTION
Closes part of #3002.

## What

`budget-prediction.test.ts` was re-implementing `getAverageCostPerUnitType` and `predictRemainingCost` locally, then using `readFileSync` + string matching to verify the copy "matched" the source. This is exactly the grep-theater described in #3002.

## Why it was wrong

- The "can't import directly" comment was stale — `metrics.ts` only uses `import type` for `@gsd/pi-coding-agent`, which strips at runtime. The `dist-redirect.mjs` resolver already handles `@gsd/*` specifiers.
- Source-regex tests break on any rename/refactor while catching zero behavioral regressions.
- The dashboard field tests (`projectedRemainingCost`, `profileDowngraded`) were checking that string literals exist in source — TypeScript already enforces those at compile time.

## Changes

- Import `getAverageCostPerUnitType`, `predictRemainingCost`, `UnitMetrics` directly from `metrics.ts`
- Add `makeUnit()` helper to construct minimal valid `UnitMetrics` fixtures
- Delete 5 source-regex tests + the local function re-implementations (98 lines → 35)
- Delete 2 dashboard field source-checks (compile-time concern, not runtime)
- All 11 behavioral tests pass against the real implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)