### PR TITLE
test(forensics-dedup): replace source-regex tests with behavioral unit tests

### DIFF
--- a/src/resources/extensions/gsd/forensics.ts
+++ b/src/resources/extensions/gsd/forensics.ts
@@ -105,7 +105,7 @@ interface ForensicReport {
 
 // ─── Duplicate Detection ──────────────────────────────────────────────────────
 
-const DEDUP_PROMPT_SECTION = `
+export const DEDUP_PROMPT_SECTION = `
 ## Duplicate Detection (REQUIRED before issue creation)
 
 Before offering to create a GitHub issue, you MUST search for existing issues and PRs that may already address this bug. This step uses the user's AI tokens for analysis.
@@ -144,6 +144,11 @@ If you find potential matches, present them to the user:
 
 Only proceed to issue creation if no matches were found OR the user explicitly chooses "Create new issue anyway".
 `;
+
+/** Pure helper: returns the dedup prompt section based on the preference value. */
+export function resolveDedupSection(forensicsDedup: boolean | undefined): string {
+  return forensicsDedup === true ? DEDUP_PROMPT_SECTION : "";
+}
 
 async function writeForensicsDedupPref(ctx: ExtensionCommandContext, enabled: boolean): Promise<void> {
   const prefsPath = getGlobalGSDPreferencesPath();
@@ -220,7 +225,7 @@ export async function handleForensics(
     }
   }
 
-  const dedupSection = dedupEnabled ? DEDUP_PROMPT_SECTION : "";
+  const dedupSection = resolveDedupSection(dedupEnabled);
 
   ctx.ui.notify("Building forensic report...", "info");
 

--- a/src/resources/extensions/gsd/tests/forensics-dedup.test.ts
+++ b/src/resources/extensions/gsd/tests/forensics-dedup.test.ts
@@ -4,45 +4,40 @@ import { readFileSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { KNOWN_PREFERENCE_KEYS } from "../preferences-types.js";
+import { DEDUP_PROMPT_SECTION, resolveDedupSection } from "../forensics.js";
+
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const gsdDir = join(__dirname, "..");
 
 describe("forensics dedup (#2096)", () => {
   it("forensics_dedup is in KNOWN_PREFERENCE_KEYS", () => {
-    const source = readFileSync(join(gsdDir, "preferences-types.ts"), "utf-8");
-    assert.ok(source.includes('"forensics_dedup"'),
-      "KNOWN_PREFERENCE_KEYS must contain forensics_dedup");
-    assert.ok(source.includes("forensics_dedup?: boolean"),
-      "GSDPreferences must declare forensics_dedup as optional boolean");
+    assert.ok(
+      KNOWN_PREFERENCE_KEYS.has("forensics_dedup"),
+      "KNOWN_PREFERENCE_KEYS must contain forensics_dedup",
+    );
   });
 
   it("forensics prompt contains {{dedupSection}} placeholder", () => {
-    const prompt = readFileSync(join(gsdDir, "prompts", "forensics.md"), "utf-8");
-    assert.ok(prompt.includes("{{dedupSection}}"),
-      "forensics.md must contain {{dedupSection}} placeholder");
+    const prompt = readFileSync(join(__dirname, "..", "prompts", "forensics.md"), "utf-8");
+    assert.ok(prompt.includes("{{dedupSection}}"), "forensics.md must contain {{dedupSection}} placeholder");
   });
 
-  it("DEDUP_PROMPT_SECTION contains required search commands", async () => {
-    const source = readFileSync(join(gsdDir, "forensics.ts"), "utf-8");
-    assert.ok(source.includes("DEDUP_PROMPT_SECTION"), "forensics.ts must define DEDUP_PROMPT_SECTION");
-    assert.ok(source.includes("gh issue list --repo gsd-build/gsd-2 --state closed"));
-    assert.ok(source.includes("gh pr list --repo gsd-build/gsd-2 --state open"));
-    assert.ok(source.includes("gh pr list --repo gsd-build/gsd-2 --state merged"));
+  it("DEDUP_PROMPT_SECTION contains required search commands", () => {
+    assert.ok(DEDUP_PROMPT_SECTION.includes("gh issue list --repo gsd-build/gsd-2 --state closed"));
+    assert.ok(DEDUP_PROMPT_SECTION.includes("gh pr list --repo gsd-build/gsd-2 --state open"));
+    assert.ok(DEDUP_PROMPT_SECTION.includes("gh pr list --repo gsd-build/gsd-2 --state merged"));
   });
 
-  it("handleForensics checks forensics_dedup preference", () => {
-    const source = readFileSync(join(gsdDir, "forensics.ts"), "utf-8");
-    assert.ok(source.includes("forensics_dedup"),
-      "handleForensics must reference forensics_dedup preference");
-    assert.ok(source.includes("dedupSection"),
-      "handleForensics must pass dedupSection to loadPrompt");
+  it("resolveDedupSection returns prompt section when enabled", () => {
+    const section = resolveDedupSection(true);
+    assert.strictEqual(section, DEDUP_PROMPT_SECTION);
   });
 
-  it("first-time opt-in shows when preference is undefined", () => {
-    const source = readFileSync(join(gsdDir, "forensics.ts"), "utf-8");
-    assert.ok(source.includes("=== undefined"),
-      "first-time detection must check for undefined (not false)");
-    assert.ok(source.includes("Duplicate detection available") || source.includes("duplicate detection"),
-      "opt-in notice must mention duplicate detection");
+  it("resolveDedupSection returns empty string when disabled", () => {
+    assert.strictEqual(resolveDedupSection(false), "");
+  });
+
+  it("resolveDedupSection returns empty string when preference is undefined (first-time opt-in not yet answered)", () => {
+    assert.strictEqual(resolveDedupSection(undefined), "");
   });
 });


### PR DESCRIPTION
## Summary

- Exports `DEDUP_PROMPT_SECTION` from `forensics.ts`
- Extracts pure `resolveDedupSection(forensicsDedup: boolean | undefined): string` helper (dependency-injectable, no side effects)
- Replaces 4 `readFileSync` + `source.includes(...)` checks with direct imports and behavioral assertions
- `KNOWN_PREFERENCE_KEYS.has("forensics_dedup")` replaces source-grep
- `resolveDedupSection` contract tested across all three states: `true` → full section, `false` → `""`, `undefined` → `""`
- Prompt template check (`forensics.md`) retained — it's a data file assertion, not TypeScript source scanning
- All 6 tests pass

## Test plan

- [x] `npx tsx --test src/resources/extensions/gsd/tests/forensics-dedup.test.ts` — 6/6 pass, 0 fail

Closes #3002

🤖 Generated with [Claude Code](https://claude.com/claude-code)