### PR TITLE
fix(commands): friendly message when /gsd runs from $HOME

### DIFF
--- a/src/resources/extensions/gsd/commands/context.ts
+++ b/src/resources/extensions/gsd/commands/context.ts
@@ -1,7 +1,7 @@
 import type { ExtensionAPI, ExtensionCommandContext } from "@gsd/pi-coding-agent";
 
 import { checkRemoteAutoSession, isAutoActive, isAutoPaused, stopAutoRemote } from "../auto.js";
-import { assertSafeDirectory } from "../validate-directory.js";
+import { validateDirectory } from "../validate-directory.js";
 import { resolveProjectRoot } from "../worktree.js";
 import { showNextAction } from "../../shared/tui.js";
 import { handleStatus } from "./handlers/core.js";
@@ -12,13 +12,24 @@ export interface GsdDispatchContext {
   trimmed: string;
 }
 
+/**
+ * Typed error for when GSD is run outside a valid project directory.
+ * Command handlers catch this to show a friendly message instead of a raw exception.
+ */
+export class GSDNoProjectError extends Error {
+  constructor(reason: string) {
+    super(reason);
+    this.name = "GSDNoProjectError";
+  }
+}
+
 export function projectRoot(): string {
   const cwd = process.cwd();
   const root = resolveProjectRoot(cwd);
-  if (root !== cwd) {
-    assertSafeDirectory(cwd);
-  } else {
-    assertSafeDirectory(root);
+  const pathToCheck = root !== cwd ? cwd : root;
+  const result = validateDirectory(pathToCheck);
+  if (result.severity === "blocked") {
+    throw new GSDNoProjectError(result.reason ?? "GSD must be run inside a project directory.");
   }
   return root;
 }

--- a/src/resources/extensions/gsd/commands/dispatcher.ts
+++ b/src/resources/extensions/gsd/commands/dispatcher.ts
@@ -1,5 +1,6 @@
 import type { ExtensionAPI, ExtensionCommandContext } from "@gsd/pi-coding-agent";
 
+import { GSDNoProjectError } from "./context.js";
 import { handleAutoCommand } from "./handlers/auto.js";
 import { handleCoreCommand } from "./handlers/core.js";
 import { handleOpsCommand } from "./handlers/ops.js";
@@ -21,10 +22,21 @@ export async function handleGSDCommand(
     () => handleOpsCommand(trimmed, ctx, pi),
   ];
 
-  for (const handler of handlers) {
-    if (await handler()) {
+  try {
+    for (const handler of handlers) {
+      if (await handler()) {
+        return;
+      }
+    }
+  } catch (err) {
+    if (err instanceof GSDNoProjectError) {
+      ctx.ui.notify(
+        "No project found in this directory. `cd` into a project directory or run `/gsd new-project` to initialize one.",
+        "warning",
+      );
       return;
     }
+    throw err;
   }
 
   ctx.ui.notify(`Unknown: /gsd ${trimmed}. Run /gsd help for available commands.`, "warning");

--- a/src/resources/extensions/gsd/commands/dispatcher.ts
+++ b/src/resources/extensions/gsd/commands/dispatcher.ts
@@ -31,7 +31,7 @@ export async function handleGSDCommand(
   } catch (err) {
     if (err instanceof GSDNoProjectError) {
       ctx.ui.notify(
-        "No project found in this directory. `cd` into a project directory or run `/gsd new-project` to initialize one.",
+        `${err.message} \`cd\` into a project directory first.`,
         "warning",
       );
       return;

--- a/src/resources/extensions/gsd/tests/gsd-no-project-error.test.ts
+++ b/src/resources/extensions/gsd/tests/gsd-no-project-error.test.ts
@@ -1,0 +1,73 @@
+/**
+ * GSDNoProjectError — tests for friendly home-directory error handling.
+ *
+ * Verifies that GSDNoProjectError is thrown for blocked directories and
+ * that the dispatcher catches it with a user-friendly message.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const contextSrc = readFileSync(join(__dirname, "..", "commands", "context.ts"), "utf-8");
+const dispatcherSrc = readFileSync(join(__dirname, "..", "commands", "dispatcher.ts"), "utf-8");
+
+// ─── GSDNoProjectError class ──────────────────────────────────────────────
+
+test("GSDNoProjectError class is exported from context.ts", () => {
+  assert.ok(
+    contextSrc.includes("export class GSDNoProjectError extends Error"),
+    "GSDNoProjectError should be an exported Error subclass",
+  );
+});
+
+test("GSDNoProjectError sets name property", () => {
+  assert.ok(
+    contextSrc.includes('this.name = "GSDNoProjectError"'),
+    "GSDNoProjectError should set its name for instanceof checks",
+  );
+});
+
+// ─── projectRoot blocked directory handling ───────────────────────────────
+
+test("projectRoot uses validateDirectory and checks for blocked severity", () => {
+  assert.ok(
+    contextSrc.includes("validateDirectory(pathToCheck)"),
+    "projectRoot should call validateDirectory",
+  );
+  assert.ok(
+    contextSrc.includes('result.severity === "blocked"'),
+    "projectRoot should check for blocked severity",
+  );
+});
+
+test("projectRoot throws GSDNoProjectError on blocked directory", () => {
+  assert.ok(
+    contextSrc.includes("throw new GSDNoProjectError"),
+    "projectRoot should throw GSDNoProjectError when directory is blocked",
+  );
+});
+
+// ─── Dispatcher catch ─────────────────────────────────────────────────────
+
+test("dispatcher catches GSDNoProjectError with user-friendly message", () => {
+  assert.ok(
+    dispatcherSrc.includes("err instanceof GSDNoProjectError"),
+    "dispatcher should catch GSDNoProjectError specifically",
+  );
+  assert.ok(
+    dispatcherSrc.includes("cd"),
+    "error message should suggest cd-ing into a project directory",
+  );
+});
+
+test("dispatcher re-throws non-GSDNoProjectError exceptions", () => {
+  assert.ok(
+    dispatcherSrc.includes("throw err"),
+    "dispatcher should re-throw unexpected errors",
+  );
+});


### PR DESCRIPTION
## Summary
- Replace `assertSafeDirectory` with `validateDirectory` in `projectRoot()` and throw a typed `GSDNoProjectError` instead of a raw `Error`
- Catch `GSDNoProjectError` in the dispatcher and show a user-friendly warning: "No project found in this directory. `cd` into a project directory or run `/gsd new-project` to initialize one."
- Fixes the regression where `/gsd` from `$HOME` threw an unhandled `Extension "command:gsd" error`

Fixes #3023

## Test plan
- [ ] Run `/gsd` from `$HOME` — should show friendly warning, not an exception
- [ ] Run `/gsd` from a valid project directory — should work as before
- [ ] Run `/gsd` from a blocked system path (e.g. `/usr`) — should show friendly warning
- [ ] Run existing `validate-directory.test.ts` — all pass
- [ ] Full build passes