### PR TITLE
fix(bash): add EINVAL resilience with shell fallback on Windows

### DIFF
--- a/packages/pi-coding-agent/src/core/bash-executor.ts
+++ b/packages/pi-coding-agent/src/core/bash-executor.ts
@@ -10,7 +10,7 @@ import { randomBytes } from "node:crypto";
 import { createWriteStream, unlinkSync, type WriteStream } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { type ChildProcess, spawn } from "child_process";
+import { type ChildProcess } from "child_process";
 
 /** Track temp files created by bash execution for cleanup on exit. */
 const bashTempFiles = new Set<string>();
@@ -30,7 +30,7 @@ function registerTempCleanup(): void {
 	});
 }
 import { processStreamChunk, type StreamState } from "@gsd/native";
-import { getShellConfig, getShellEnv, killProcessTree, sanitizeCommand } from "../utils/shell.js";
+import { getShellConfig, getShellEnv, killProcessTree, sanitizeCommand, spawnWithEinvalRecovery } from "../utils/shell.js";
 import type { BashOperations } from "./tools/bash.js";
 import { DEFAULT_MAX_BYTES, truncateTail } from "./tools/truncate.js";
 
@@ -91,11 +91,21 @@ export function executeBash(command: string, options?: BashExecutorOptions & { l
 		// cause EINVAL in VSCode/ConPTY terminal contexts.  The bg-shell
 		// extension already guards this (process-manager.ts); align here.
 		// Process-tree cleanup uses taskkill /F /T on Windows regardless.
-		const child: ChildProcess = spawn(shell, [...args, sanitizeCommand(command)], {
-			detached: process.platform !== "win32",
-			env: getShellEnv(),
-			stdio: ["ignore", "pipe", "pipe"],
-		});
+		//
+		// spawnWithEinvalRecovery provides additional resilience: if spawn
+		// still fails with EINVAL (Node.js regressions, ConPTY changes),
+		// it retries with cmd.exe/PowerShell fallbacks.
+		let child: ChildProcess;
+		try {
+			child = spawnWithEinvalRecovery(shell, [...args, sanitizeCommand(command)], {
+				detached: process.platform !== "win32",
+				env: getShellEnv(),
+				stdio: ["ignore", "pipe", "pipe"],
+			});
+		} catch (err) {
+			reject(err);
+			return;
+		}
 
 		// Track sanitized output for truncation
 		const outputChunks: string[] = [];

--- a/packages/pi-coding-agent/src/core/tools/bash-spawn-windows.test.ts
+++ b/packages/pi-coding-agent/src/core/tools/bash-spawn-windows.test.ts
@@ -2,7 +2,9 @@
  * bash-spawn-windows.test.ts — Regression test for Windows spawn EINVAL.
  *
  * Verifies that bash tool spawn options disable `detached: true` on Windows
- * to prevent EINVAL errors in ConPTY / VSCode terminal contexts.
+ * to prevent EINVAL errors in ConPTY / VSCode terminal contexts, and that
+ * the EINVAL recovery mechanism (spawnWithEinvalRecovery) provides fallback
+ * shells when the primary bash spawn fails.
  *
  * Background:
  *   On Windows, `spawn()` with `detached: true` sets the
@@ -12,6 +14,11 @@
  *   EINVAL from libuv.  The bg-shell extension already guards against this
  *   with `detached: process.platform !== "win32"` (process-manager.ts);
  *   this test ensures all other spawn sites are aligned.
+ *
+ *   Additionally, EINVAL can occur for other reasons on Windows (Node.js
+ *   version regressions, ConPTY changes in recent Windows builds).  The
+ *   spawnWithEinvalRecovery wrapper catches these and retries with cmd.exe
+ *   or PowerShell as fallback shells.
  *
  * See: gsd-build/gsd-2#XXXX
  */
@@ -23,8 +30,9 @@ import { spawn } from "node:child_process";
 // Verify the spawn option pattern used across the codebase.
 // This is a static/structural test — it reads the source files and asserts
 // they use the platform-guarded detached flag.
-import { readFileSync } from "node:fs";
+import { readFileSync, mkdirSync, rmSync } from "node:fs";
 import { join, dirname } from "node:path";
+import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -45,7 +53,7 @@ test("spawn calls use platform-guarded detached flag (no unconditional detached:
 			// Skip comments
 			if (line.trim().startsWith("//") || line.trim().startsWith("*")) continue;
 			// Check for unconditional `detached: true`
-			if (/detached:\s*true\b/.test(line)) {
+			if (/detache/mnt/d/s*true/b/.test(line)) {
 				assert.fail(
 					`${file}:${i + 1} has unconditional 'detached: true' — ` +
 					`must use 'detached: process.platform !== "win32"' ` +
@@ -64,7 +72,7 @@ test("killProcessTree does not use detached: true for taskkill on Windows", () =
 	const taskkillRegion = content.match(/spawn\("taskkill"[\s\S]*?\}\)/);
 	if (taskkillRegion) {
 		assert.ok(
-			!/detached:\s*true/.test(taskkillRegion[0]),
+			!/detache/mnt/d/s*true/.test(taskkillRegion[0]),
 			"taskkill spawn should not use detached: true — " +
 			"it can cause EINVAL on Windows and is unnecessary for a utility process",
 		);
@@ -98,4 +106,128 @@ test("spawn with detached: process.platform !== 'win32' succeeds", async () => {
 	});
 
 	await promise;
+});
+
+// Smoke test: spawn with the actual resolved bash shell (not just cmd.exe).
+// This catches issues where bash.exe itself can't be spawned — the original
+// smoke test uses cmd.exe which sidesteps bash-specific spawn failures.
+test("spawn with resolved bash shell succeeds", async () => {
+	// Import getShellConfig dynamically to avoid import cycle issues in test
+	let getShellConfig: () => { shell: string; args: string[] };
+	try {
+		const shellMod = await import("../../utils/shell.js");
+		getShellConfig = shellMod.getShellConfig;
+	} catch {
+		// If import fails (e.g., missing dependencies in test env), skip
+		return;
+	}
+
+	let shell: string;
+	let args: string[];
+	try {
+		({ shell, args } = getShellConfig());
+	} catch {
+		// No shell available (e.g., CI without bash) — skip
+		return;
+	}
+
+	const { promise, resolve, reject } = Promise.withResolvers<void>();
+
+	const child = spawn(shell, [...args, "echo bash-ok"], {
+		detached: process.platform !== "win32",
+		stdio: ["ignore", "pipe", "pipe"],
+	});
+
+	let output = "";
+	child.stdout?.on("data", (d: Buffer) => { output += d.toString(); });
+	child.on("error", reject);
+	child.on("close", (code) => {
+		try {
+			assert.equal(code, 0, `spawn ${shell} should succeed`);
+			assert.ok(
+				output.trim().includes("bash-ok"),
+				`Expected 'bash-ok' in output from ${shell}, got: ${output}`,
+			);
+			resolve();
+		} catch (e) {
+			reject(e);
+		}
+	});
+
+	await promise;
+});
+
+// Test that spawn works with spaces in the working directory path.
+// This is a common Windows issue — directory names like "My Project" or
+// "PinkBrain Router git" must be handled correctly by the spawn cwd option.
+test("spawn succeeds with spaces in cwd path", async () => {
+	const tempDir = join(tmpdir(), "gsd test dir with spaces");
+	mkdirSync(tempDir, { recursive: true });
+
+	try {
+		const { promise, resolve, reject } = Promise.withResolvers<void>();
+
+		const child = spawn(
+			process.platform === "win32" ? "cmd" : "sh",
+			process.platform === "win32" ? ["/c", "echo cwd-ok"] : ["-c", "echo cwd-ok"],
+			{
+				cwd: tempDir,
+				detached: process.platform !== "win32",
+				stdio: ["ignore", "pipe", "pipe"],
+			},
+		);
+
+		let output = "";
+		child.stdout?.on("data", (d: Buffer) => { output += d.toString(); });
+		child.on("error", reject);
+		child.on("close", (code) => {
+			try {
+				assert.equal(code, 0, "spawn with spaces in cwd should succeed");
+				assert.ok(
+					output.trim().includes("cwd-ok"),
+					`Expected 'cwd-ok' in output, got: ${output}`,
+				);
+				resolve();
+			} catch (e) {
+				reject(e);
+			}
+		});
+
+		await promise;
+	} finally {
+		try { rmSync(tempDir, { recursive: true, force: true }); } catch { /* cleanup best-effort */ }
+	}
+});
+
+// Structural test: shell.ts exports the EINVAL recovery functions
+test("shell.ts exports spawnWithEinvalRecovery and getFallbackShellConfig", () => {
+	const shellFile = join(__dirname, "..", "..", "utils", "shell.ts");
+	const content = readFileSync(shellFile, "utf-8");
+
+	assert.ok(
+		content.includes("export function spawnWithEinvalRecovery"),
+		"shell.ts should export spawnWithEinvalRecovery for EINVAL resilience",
+	);
+	assert.ok(
+		content.includes("export function getFallbackShellConfig"),
+		"shell.ts should export getFallbackShellConfig for Windows fallback shells",
+	);
+	assert.ok(
+		content.includes("export function formatSpawnDiagnostics"),
+		"shell.ts should export formatSpawnDiagnostics for actionable error messages",
+	);
+});
+
+// Structural test: bash.ts and bash-executor.ts use spawnWithEinvalRecovery
+test("spawn sites use spawnWithEinvalRecovery instead of raw spawn for command execution", () => {
+	const bashFile = join(__dirname, "bash.ts");
+	const executorFile = join(__dirname, "..", "bash-executor.ts");
+
+	for (const file of [bashFile, executorFile]) {
+		const content = readFileSync(file, "utf-8");
+		assert.ok(
+			content.includes("spawnWithEinvalRecovery"),
+			`${file} should use spawnWithEinvalRecovery for Windows EINVAL resilience`,
+		);
+	}
 });

--- a/packages/pi-coding-agent/src/core/tools/bash-spawn-windows.test.ts
+++ b/packages/pi-coding-agent/src/core/tools/bash-spawn-windows.test.ts
@@ -36,11 +36,13 @@ import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
+const packageRoot = join(__dirname, "..", "..", "..");
+const sourceRoot = join(packageRoot, "src");
 
 const SPAWN_FILES = [
-	join(__dirname, "bash.ts"),
-	join(__dirname, "..", "bash-executor.ts"),
-	join(__dirname, "..", "..", "utils", "shell.ts"),
+	join(sourceRoot, "core", "tools", "bash.ts"),
+	join(sourceRoot, "core", "bash-executor.ts"),
+	join(sourceRoot, "utils", "shell.ts"),
 ];
 
 test("spawn calls use platform-guarded detached flag (no unconditional detached: true)", () => {
@@ -53,7 +55,7 @@ test("spawn calls use platform-guarded detached flag (no unconditional detached:
 			// Skip comments
 			if (line.trim().startsWith("//") || line.trim().startsWith("*")) continue;
 			// Check for unconditional `detached: true`
-			if (/detache/mnt/d/s*true/b/.test(line)) {
+			if (/detached:\s*true\b/.test(line)) {
 				assert.fail(
 					`${file}:${i + 1} has unconditional 'detached: true' — ` +
 					`must use 'detached: process.platform !== "win32"' ` +
@@ -65,14 +67,14 @@ test("spawn calls use platform-guarded detached flag (no unconditional detached:
 });
 
 test("killProcessTree does not use detached: true for taskkill on Windows", () => {
-	const shellFile = join(__dirname, "..", "..", "utils", "shell.ts");
+	const shellFile = join(sourceRoot, "utils", "shell.ts");
 	const content = readFileSync(shellFile, "utf-8");
 
 	// Find the taskkill spawn call and ensure it doesn't have detached: true
 	const taskkillRegion = content.match(/spawn\("taskkill"[\s\S]*?\}\)/);
 	if (taskkillRegion) {
 		assert.ok(
-			!/detache/mnt/d/s*true/.test(taskkillRegion[0]),
+			!/detached:\s*true/.test(taskkillRegion[0]),
 			"taskkill spawn should not use detached: true — " +
 			"it can cause EINVAL on Windows and is unnecessary for a utility process",
 		);
@@ -201,7 +203,7 @@ test("spawn succeeds with spaces in cwd path", async () => {
 
 // Structural test: shell.ts exports the EINVAL recovery functions
 test("shell.ts exports spawnWithEinvalRecovery and getFallbackShellConfig", () => {
-	const shellFile = join(__dirname, "..", "..", "utils", "shell.ts");
+	const shellFile = join(sourceRoot, "utils", "shell.ts");
 	const content = readFileSync(shellFile, "utf-8");
 
 	assert.ok(
@@ -220,8 +222,8 @@ test("shell.ts exports spawnWithEinvalRecovery and getFallbackShellConfig", () =
 
 // Structural test: bash.ts and bash-executor.ts use spawnWithEinvalRecovery
 test("spawn sites use spawnWithEinvalRecovery instead of raw spawn for command execution", () => {
-	const bashFile = join(__dirname, "bash.ts");
-	const executorFile = join(__dirname, "..", "bash-executor.ts");
+	const bashFile = join(sourceRoot, "core", "tools", "bash.ts");
+	const executorFile = join(sourceRoot, "core", "bash-executor.ts");
 
 	for (const file of [bashFile, executorFile]) {
 		const content = readFileSync(file, "utf-8");

--- a/packages/pi-coding-agent/src/core/tools/bash.ts
+++ b/packages/pi-coding-agent/src/core/tools/bash.ts
@@ -6,7 +6,7 @@ import { join } from "node:path";
 import type { AgentTool } from "@gsd/pi-agent-core";
 import { type Static, Type } from "@sinclair/typebox";
 import { spawn } from "child_process";
-import { getShellConfig, getShellEnv, killProcessTree, sanitizeCommand } from "../../utils/shell.js";
+import { getShellConfig, getShellEnv, killProcessTree, sanitizeCommand, spawnWithEinvalRecovery, formatSpawnDiagnostics, getFallbackShellConfig } from "../../utils/shell.js";
 import { type BashInterceptorRule, compileInterceptor, DEFAULT_BASH_INTERCEPTOR_RULES } from "./bash-interceptor.js";
 import { DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES, formatSize, type TruncationResult, truncateTail } from "./truncate.js";
 import type { ArtifactManager } from "../artifact-manager.js";
@@ -146,7 +146,9 @@ export interface BashOperations {
 }
 
 /**
- * Default bash operations using local shell
+ * Default bash operations using local shell.
+ * Uses spawnWithEinvalRecovery for Windows resilience — if bash.exe spawn
+ * fails with EINVAL, automatically retries with cmd.exe/PowerShell fallback.
  */
 const defaultBashOperations: BashOperations = {
 	exec: (command, cwd, { onData, signal, timeout, env }) => {
@@ -162,12 +164,22 @@ const defaultBashOperations: BashOperations = {
 			// cause EINVAL in VSCode/ConPTY terminal contexts.  The bg-shell
 			// extension already guards this (process-manager.ts); align here.
 			// Process-tree cleanup uses taskkill /F /T on Windows regardless.
-			const child = spawn(shell, [...args, command], {
-				cwd,
-				detached: process.platform !== "win32",
-				env: env ?? getShellEnv(),
-				stdio: ["ignore", "pipe", "pipe"],
-			});
+			//
+			// spawnWithEinvalRecovery adds a second safety net: if spawn still
+			// fails with EINVAL (Node.js regressions, new ConPTY behaviors),
+			// it retries with cmd.exe or PowerShell as a fallback shell.
+			let child;
+			try {
+				child = spawnWithEinvalRecovery(shell, [...args, command], {
+					cwd,
+					detached: process.platform !== "win32",
+					env: env ?? getShellEnv(),
+					stdio: ["ignore", "pipe", "pipe"],
+				});
+			} catch (spawnErr) {
+				reject(spawnErr);
+				return;
+			}
 
 			let timedOut = false;
 

--- a/packages/pi-coding-agent/src/utils/shell.ts
+++ b/packages/pi-coding-agent/src/utils/shell.ts
@@ -1,6 +1,7 @@
 import { existsSync } from "node:fs";
+import { release } from "node:os";
 import { delimiter } from "node:path";
-import { spawn, spawnSync } from "child_process";
+import { type ChildProcess, type SpawnOptions, spawn, spawnSync } from "child_process";
 import { getBinDir, getSettingsPath } from "../config.js";
 import { SettingsManager } from "../core/settings-manager.js";
 
@@ -94,11 +95,11 @@ export function getShellConfig(): { shell: string; args: string[] } {
 		}
 
 		throw new Error(
-			`No bash shell found. Options:\n` +
+			`No bash shell found. Option/mnt/s/n` +
 				`  1. Install Git for Windows: https://git-scm.com/download/win\n` +
 				`  2. Add your bash to PATH (Cygwin, MSYS2, etc.)\n` +
 				`  3. Set shellPath in ${getSettingsPath()}\n\n` +
-				`Searched Git Bash in:\n${paths.map((p) => `  ${p}`).join("\n")}`,
+				`Searched Git Bash i/mnt/n/n${paths.map((p) => `  ${p}`).join("\n")}`,
 		);
 	}
 
@@ -116,6 +117,108 @@ export function getShellConfig(): { shell: string; args: string[] } {
 
 	cachedShellConfig = { shell: "sh", args: ["-c"] };
 	return cachedShellConfig;
+}
+
+/**
+ * Get a fallback shell configuration for Windows when bash spawning fails.
+ * Tries PowerShell Core, Windows PowerShell, and cmd.exe in order.
+ * Returns null on non-Windows or if no fallback works.
+ */
+export function getFallbackShellConfig(): { shell: string; args: string[] } | null {
+	if (process.platform !== "win32") return null;
+
+	const candidates: Array<{ shell: string; args: string[]; testArgs: string[] }> = [
+		{ shell: "pwsh.exe", args: ["-NoProfile", "-Command"], testArgs: ["-NoProfile", "-Command", "echo ok"] },
+		{ shell: "powershell.exe", args: ["-NoProfile", "-Command"], testArgs: ["-NoProfile", "-Command", "echo ok"] },
+		{ shell: "cmd.exe", args: ["/c"], testArgs: ["/c", "echo ok"] },
+	];
+
+	for (const candidate of candidates) {
+		try {
+			const result = spawnSync(candidate.shell, candidate.testArgs, {
+				encoding: "utf-8",
+				timeout: 5000,
+				stdio: "pipe",
+			});
+			if (result.status === 0) {
+				return { shell: candidate.shell, args: candidate.args };
+			}
+		} catch {
+			continue;
+		}
+	}
+	return null;
+}
+
+/**
+ * Format diagnostic information for spawn errors.
+ * Helps users and maintainers understand what went wrong.
+ */
+export function formatSpawnDiagnostics(shell: string, cwd?: string): string {
+	const shellExists = (() => {
+		try { return existsSync(shell); } catch { return "unknown"; }
+	})();
+
+	return [
+		`Shell: ${shell} (exists: ${shellExists})`,
+		`CWD: ${cwd ?? process.cwd()}`,
+		`Node: ${process.version}`,
+		`Platform: ${process.platform} ${process.arch}`,
+		`OS: ${release()}`,
+		`Hint: Set shellPath in settings (${getSettingsPath()}) to override shell resolution`,
+	].join("\n  ");
+}
+
+/**
+ * Spawn a child process with EINVAL resilience on Windows.
+ *
+ * On Windows, spawn() can fail with EINVAL for multiple reasons beyond the
+ * known detached:true / CREATE_NEW_PROCESS_GROUP cause (which is already
+ * guarded). Additional triggers include Node.js version regressions,
+ * ConPTY changes in recent Windows builds, and specific terminal contexts.
+ *
+ * This wrapper catches synchronous EINVAL errors and retries with fallback
+ * shell configurations (cmd.exe, PowerShell) to keep the session functional.
+ */
+export function spawnWithEinvalRecovery(
+	file: string,
+	args: readonly string[],
+	options: SpawnOptions,
+): ChildProcess {
+	try {
+		return spawn(file, args as string[], options);
+	} catch (err: any) {
+		if (err?.code === "EINVAL" && process.platform === "win32") {
+			// Retry 1: same shell but wrapped via cmd.exe (shell: true)
+			try {
+				return spawn(file, args as string[], { ...options, shell: true });
+			} catch {
+				// Retry 2: use a Windows-native fallback shell entirely
+				const fallback = getFallbackShellConfig();
+				if (fallback) {
+					// The last arg is the command — extract it and rewrap
+					const command = args[args.length - 1];
+					return spawn(fallback.shell, [...fallback.args, command as string], {
+						...options,
+						shell: false,
+					});
+				}
+			}
+
+			// All retries exhausted — throw with diagnostics
+			const cwd = typeof options.cwd === "string" ? options.cwd : undefined;
+			throw new Error(
+				`spawn EINVAL: All shell fallbacks exhausted on Windows.\n` +
+				`  ${formatSpawnDiagnostics(file, cwd)}\n\n` +
+				`Possible cause/mnt/s/n` +
+				`  - Node.js ${process.version} spawn regression on Windows\n` +
+				`  - ConPTY conflict with terminal host (Windows ${release()})\n` +
+				`  - Shell binary inaccessible or corrupted\n\n` +
+				`Workaround: Set shellPath to cmd.exe or powershell.exe in ${getSettingsPath()}`,
+			);
+		}
+		throw err;
+	}
 }
 
 /**


### PR DESCRIPTION
## TL;DR

Add spawn EINVAL resilience for Windows — retry with fallback shells (cmd.exe / PowerShell) + actionable diagnostics when bash spawning fails.

**What:** `spawnWithEinvalRecovery()` wrapper, `getFallbackShellConfig()`, diagnostic error messages, strengthened regression tests.
**Why:** Users on Windows 11 (build 26200+) with Node.js v24 still experience `spawn EINVAL` on every bash command despite the `detached: false` fix in PR #2744. Session becomes completely non-functional.
**How:** Catch EINVAL → retry with `shell: true` → retry with cmd.exe/PowerShell fallback → fail with actionable diagnostics.

## What

### New exports in `shell.ts`:
- **`spawnWithEinvalRecovery(file, args, options)`** — Drop-in wrapper around `child_process.spawn()` that catches synchronous EINVAL errors on Windows and retries with fallback strategies:
  1. Same shell with `shell: true` (uses cmd.exe as wrapper, handles path quoting)
  2. Windows-native fallback shell via `getFallbackShellConfig()` (PowerShell → cmd.exe)
  3. If all retries fail, throws with full diagnostic context instead of raw "spawn EINVAL"

- **`getFallbackShellConfig()`** — Probes available Windows shells in order: `pwsh.exe` (PowerShell Core), `powershell.exe` (Windows PowerShell), `cmd.exe`. Returns the first that responds to a test command. Returns `null` on non-Windows.

- **`formatSpawnDiagnostics(shell, cwd?)`** — Formats actionable error context: shell path + existence check, cwd, Node.js version, platform, OS version, and a hint to set `shellPath` in settings.

### Updated spawn sites:
- **`bash.ts` (`defaultBashOperations.exec`)** — Uses `spawnWithEinvalRecovery` instead of raw `spawn`.
- **`bash-executor.ts` (`executeBash`)** — Uses `spawnWithEinvalRecovery` instead of raw `spawn`.

### Strengthened regression tests (`bash-spawn-windows.test.ts`):
- **`spawn with resolved bash shell succeeds`** — Smoke-tests with the actual resolved bash.exe (not just cmd.exe).
- **`spawn succeeds with spaces in cwd path`** — Tests spawn with spaces in the directory name.
- **Structural assertions** — Verify recovery function exports and usage across spawn sites.

## Why

PR #2744 correctly fixed the `detached: true` / `CREATE_NEW_PROCESS_GROUP` cause. However, users continue to experience `spawn EINVAL` on **every bash command** in specific environments:

### Reproduction
- **GSD version:** v2.58.0 (gsd-pi)
- **OS:** Windows 11 Home, build 26200
- **Node.js:** v24.13.1
- **Terminal:** PowerShell (Windows Terminal / ConPTY)
- **Directory:** Path with spaces: `C:\Users\...\PinkBrain Router git`

### Observed behavior
Every bash command fails — even `echo hello`, `true`, `hostname`. File reads and web fetches still work. Session stalls completely.

### Root cause
The compiled v2.58.0 code **does** have the `detached: false` guard. The EINVAL comes from a **different trigger**:
1. **Node.js v24 libuv regression** — [nodejs/node#52681](https://github.com/nodejs/node/issues/52681)
2. **Windows 11 build 26200 ConPTY changes**
3. **Terminal host interaction** with specific shell + Node.js combination

### The real problem: zero resilience
- No retry — error propagates immediately
- No fallback — only tries bash.exe
- No diagnostics — raw "spawn EINVAL"
- The regression test smoke test uses cmd.exe, not bash.exe

## How

### Recovery flow:
```
spawn(bash.exe, args, opts)
  ├─ Success → return ChildProcess
  └─ catch EINVAL on win32:
       ├─ Retry 1: spawn(bash.exe, args, { ...opts, shell: true })
       ├─ Retry 2: getFallbackShellConfig() → spawn(pwsh/cmd, args)
       └─ All failed → throw with formatSpawnDiagnostics()
```

### Files changed
| File | Change |
|------|--------|
| `packages/pi-coding-agent/src/utils/shell.ts` | +109: recovery wrapper, fallback config, diagnostics |
| `packages/pi-coding-agent/src/core/tools/bash.ts` | Use `spawnWithEinvalRecovery` in `defaultBashOperations` |
| `packages/pi-coding-agent/src/core/bash-executor.ts` | Use `spawnWithEinvalRecovery` in `executeBash` |
| `packages/pi-coding-agent/src/core/tools/bash-spawn-windows.test.ts` | +4 new tests |

## Test plan
- [ ] Existing tests pass (static analysis + smoke test)
- [ ] New: spawn with resolved bash.exe
- [ ] New: spawn with spaces in cwd
- [ ] New: structural assertions for recovery exports
- [ ] Manual: GSD in directory with spaces on Windows 11

## Related
- PR #2744 — Original `detached: true` EINVAL fix
- [nodejs/node#52681](https://github.com/nodejs/node/issues/52681) — Node.js spawn EINVAL on Windows
- [anthropics/claude-code#28348](https://github.com/anthropics/claude-code/issues/28348) — Claude Code Bash tool EINVAL

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)