### PR TITLE
feat(ADR-006): dependency cleanup, install infrastructure, & loader enhancements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -56,6 +56,7 @@
       "devDependencies": {
         "@types/node": "^24.12.0",
         "@types/picomatch": "^4.0.2",
+        "@types/semver": "^7.7.1",
         "c8": "^11.0.0",
         "esbuild": "^0.25.12",
         "jiti": "^2.6.1",
@@ -4257,6 +4258,13 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
       "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/sql.js": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
         "playwright": "^1.58.2",
         "proper-lockfile": "^4.1.2",
         "proxy-agent": "^6.5.0",
+        "semver": "^7.7.4",
         "sharp": "^0.34.5",
         "sql.js": "^1.14.1",
         "strip-ansi": "^7.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gsd-pi",
-  "version": "2.56.0",
+  "version": "2.58.0-dev.e1342dfc2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gsd-pi",
-      "version": "2.56.0",
+      "version": "2.58.0-dev.e1342dfc2",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [
@@ -22,10 +22,8 @@
         "@mariozechner/jiti": "^2.6.2",
         "@mistralai/mistralai": "^1.14.1",
         "@modelcontextprotocol/sdk": "^1.27.1",
-        "@octokit/rest": "^22.0.1",
         "@silvia-odwyer/photon-node": "^0.3.4",
         "@sinclair/typebox": "^0.34.41",
-        "@types/mime-types": "^2.1.4",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "chalk": "^5.6.2",
@@ -33,12 +31,10 @@
         "diff": "^8.0.2",
         "extract-zip": "^2.0.1",
         "file-type": "^21.1.1",
-        "get-east-asian-width": "^1.3.0",
         "glob": "^13.0.1",
         "hosted-git-info": "^9.0.2",
         "ignore": "^7.0.5",
         "marked": "^15.0.12",
-        "mime-types": "^3.0.1",
         "minimatch": "^10.2.3",
         "openai": "^6.26.0",
         "picocolors": "^1.1.1",
@@ -50,8 +46,7 @@
         "sql.js": "^1.14.1",
         "strip-ansi": "^7.1.0",
         "undici": "^7.24.2",
-        "yaml": "^2.8.2",
-        "zod-to-json-schema": "^3.24.6"
+        "yaml": "^2.8.2"
       },
       "bin": {
         "gsd": "dist/loader.js",
@@ -2601,161 +2596,6 @@
         }
       }
     },
-    "node_modules/@octokit/auth-token": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-6.0.0.tgz",
-      "integrity": "sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@octokit/core": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.6.tgz",
-      "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/auth-token": "^6.0.0",
-        "@octokit/graphql": "^9.0.3",
-        "@octokit/request": "^10.0.6",
-        "@octokit/request-error": "^7.0.2",
-        "@octokit/types": "^16.0.0",
-        "before-after-hook": "^4.0.0",
-        "universal-user-agent": "^7.0.0"
-      },
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@octokit/endpoint": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-11.0.3.tgz",
-      "integrity": "sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag==",
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/types": "^16.0.0",
-        "universal-user-agent": "^7.0.2"
-      },
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@octokit/graphql": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-9.0.3.tgz",
-      "integrity": "sha512-grAEuupr/C1rALFnXTv6ZQhFuL1D8G5y8CN04RgrO4FIPMrtm+mcZzFG7dcBm+nq+1ppNixu+Jd78aeJOYxlGA==",
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/request": "^10.0.6",
-        "@octokit/types": "^16.0.0",
-        "universal-user-agent": "^7.0.0"
-      },
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@octokit/openapi-types": {
-      "version": "27.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-27.0.0.tgz",
-      "integrity": "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==",
-      "license": "MIT"
-    },
-    "node_modules/@octokit/plugin-paginate-rest": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-14.0.0.tgz",
-      "integrity": "sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw==",
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/types": "^16.0.0"
-      },
-      "engines": {
-        "node": ">= 20"
-      },
-      "peerDependencies": {
-        "@octokit/core": ">=6"
-      }
-    },
-    "node_modules/@octokit/plugin-request-log": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-6.0.0.tgz",
-      "integrity": "sha512-UkOzeEN3W91/eBq9sPZNQ7sUBvYCqYbrrD8gTbBuGtHEuycE4/awMXcYvx6sVYo7LypPhmQwwpUe4Yyu4QZN5Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 20"
-      },
-      "peerDependencies": {
-        "@octokit/core": ">=6"
-      }
-    },
-    "node_modules/@octokit/plugin-rest-endpoint-methods": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-17.0.0.tgz",
-      "integrity": "sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw==",
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/types": "^16.0.0"
-      },
-      "engines": {
-        "node": ">= 20"
-      },
-      "peerDependencies": {
-        "@octokit/core": ">=6"
-      }
-    },
-    "node_modules/@octokit/request": {
-      "version": "10.0.8",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.8.tgz",
-      "integrity": "sha512-SJZNwY9pur9Agf7l87ywFi14W+Hd9Jg6Ifivsd33+/bGUQIjNujdFiXII2/qSlN2ybqUHfp5xpekMEjIBTjlSw==",
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/endpoint": "^11.0.3",
-        "@octokit/request-error": "^7.0.2",
-        "@octokit/types": "^16.0.0",
-        "fast-content-type-parse": "^3.0.0",
-        "json-with-bigint": "^3.5.3",
-        "universal-user-agent": "^7.0.2"
-      },
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@octokit/request-error": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-7.1.0.tgz",
-      "integrity": "sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw==",
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/types": "^16.0.0"
-      },
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@octokit/rest": {
-      "version": "22.0.1",
-      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-22.0.1.tgz",
-      "integrity": "sha512-Jzbhzl3CEexhnivb1iQ0KJ7s5vvjMWcmRtq5aUsKmKDrRW6z3r84ngmiFKFvpZjpiU/9/S6ITPFRpn5s/3uQJw==",
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/core": "^7.0.6",
-        "@octokit/plugin-paginate-rest": "^14.0.0",
-        "@octokit/plugin-request-log": "^6.0.0",
-        "@octokit/plugin-rest-endpoint-methods": "^17.0.0"
-      },
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@octokit/types": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-16.0.0.tgz",
-      "integrity": "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==",
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/openapi-types": "^27.0.0"
-      }
-    },
     "node_modules/@phosphor-icons/react": {
       "version": "2.1.10",
       "resolved": "https://registry.npmjs.org/@phosphor-icons/react/-/react-2.1.10.tgz",
@@ -4353,6 +4193,7 @@
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@types/mime-types/-/mime-types-2.1.4.tgz",
       "integrity": "sha512-lfU4b34HOri+kAY5UheuFMWPDOI+OPceBSHZKp69gEyTL/mmJ4cnU6Y/rlme3UL3GyOn6Y42hyIEw0/q8sWx5w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -4623,12 +4464,6 @@
       "engines": {
         "node": ">=10.0.0"
       }
-    },
-    "node_modules/before-after-hook": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-4.0.0.tgz",
-      "integrity": "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==",
-      "license": "Apache-2.0"
     },
     "node_modules/bignumber.js": {
       "version": "9.3.1",
@@ -5664,22 +5499,6 @@
         "@types/yauzl": "^2.9.1"
       }
     },
-    "node_modules/fast-content-type-parse": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-3.0.0.tgz",
-      "integrity": "sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -6573,12 +6392,6 @@
       "dev": true,
       "license": "ISC",
       "optional": true
-    },
-    "node_modules/json-with-bigint": {
-      "version": "3.5.7",
-      "resolved": "https://registry.npmjs.org/json-with-bigint/-/json-with-bigint-3.5.7.tgz",
-      "integrity": "sha512-7ei3MdAI5+fJPVnKlW77TKNKwQ5ppSzWvhPuSuINT/GYW9ZOC1eRKOuhV9yHG5aEsUPj9BBx5JIekkmoLHxZOw==",
-      "license": "MIT"
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -8522,12 +8335,6 @@
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "license": "MIT"
     },
-    "node_modules/universal-user-agent": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
-      "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==",
-      "license": "ISC"
-    },
     "node_modules/universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
@@ -9534,7 +9341,7 @@
     },
     "packages/pi-coding-agent": {
       "name": "@gsd/pi-coding-agent",
-      "version": "2.56.0",
+      "version": "2.58.0",
       "dependencies": {
         "@mariozechner/jiti": "^2.6.2",
         "@silvia-odwyer/photon-node": "^0.3.4",

--- a/package.json
+++ b/package.json
@@ -132,6 +132,7 @@
   "devDependencies": {
     "@types/node": "^24.12.0",
     "@types/picomatch": "^4.0.2",
+    "@types/semver": "^7.7.1",
     "c8": "^11.0.0",
     "esbuild": "^0.25.12",
     "jiti": "^2.6.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gsd-pi",
-  "version": "2.58.0",
+  "version": "2.58.0-dev.e1342dfc2",
   "description": "GSD — Get Shit Done coding agent",
   "license": "MIT",
   "repository": {
@@ -102,10 +102,8 @@
     "@mariozechner/jiti": "^2.6.2",
     "@mistralai/mistralai": "^1.14.1",
     "@modelcontextprotocol/sdk": "^1.27.1",
-    "@octokit/rest": "^22.0.1",
     "@silvia-odwyer/photon-node": "^0.3.4",
     "@sinclair/typebox": "^0.34.41",
-    "@types/mime-types": "^2.1.4",
     "ajv": "^8.17.1",
     "ajv-formats": "^3.0.1",
     "chalk": "^5.6.2",
@@ -113,12 +111,10 @@
     "diff": "^8.0.2",
     "extract-zip": "^2.0.1",
     "file-type": "^21.1.1",
-    "get-east-asian-width": "^1.3.0",
     "glob": "^13.0.1",
     "hosted-git-info": "^9.0.2",
     "ignore": "^7.0.5",
     "marked": "^15.0.12",
-    "mime-types": "^3.0.1",
     "minimatch": "^10.2.3",
     "openai": "^6.26.0",
     "picocolors": "^1.1.1",
@@ -130,8 +126,7 @@
     "sql.js": "^1.14.1",
     "strip-ansi": "^7.1.0",
     "undici": "^7.24.2",
-    "yaml": "^2.8.2",
-    "zod-to-json-schema": "^3.24.6"
+    "yaml": "^2.8.2"
   },
   "devDependencies": {
     "@types/node": "^24.12.0",

--- a/package.json
+++ b/package.json
@@ -122,6 +122,7 @@
     "playwright": "^1.58.2",
     "proper-lockfile": "^4.1.2",
     "proxy-agent": "^6.5.0",
+    "semver": "^7.7.4",
     "sharp": "^0.34.5",
     "sql.js": "^1.14.1",
     "strip-ansi": "^7.1.0",

--- a/packages/pi-coding-agent/src/core/extensions/extension-discovery.ts
+++ b/packages/pi-coding-agent/src/core/extensions/extension-discovery.ts
@@ -1,0 +1,119 @@
+import { existsSync, readFileSync, readdirSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+import { readManifest, readManifestFromEntryPath } from './extension-registry.js'
+
+function isExtensionFile(name: string): boolean {
+  return name.endsWith('.ts') || name.endsWith('.js')
+}
+
+/**
+ * Resolves the entry-point file(s) for a single extension directory.
+ *
+ * 1. If the directory contains a package.json with a `pi` manifest object,
+ *    the manifest is authoritative:
+ *    - `pi.extensions` array → resolve each entry relative to the directory.
+ *    - `pi: {}` (no extensions) → return empty (library opt-out, e.g. cmux).
+ * 2. Only when no `pi` manifest exists does it fall back to `index.ts` → `index.js`.
+ */
+export function resolveExtensionEntries(dir: string): string[] {
+  const packageJsonPath = join(dir, 'package.json')
+  if (existsSync(packageJsonPath)) {
+    try {
+      const pkg = JSON.parse(readFileSync(packageJsonPath, 'utf-8'))
+      if (pkg?.pi && typeof pkg.pi === 'object') {
+        // When a pi manifest exists, it is authoritative — don't fall through
+        // to index.ts/index.js auto-detection. This allows library directories
+        // (like cmux) to opt out by declaring "pi": {} with no extensions.
+        const declared = pkg.pi.extensions
+        if (!Array.isArray(declared) || declared.length === 0) {
+          return []
+        }
+        return declared
+          .filter((entry: unknown): entry is string => typeof entry === 'string')
+          .map((entry: string) => resolve(dir, entry))
+          .filter((entry: string) => existsSync(entry))
+      }
+    } catch {
+      // Ignore malformed manifests and fall back to index.ts/index.js discovery.
+    }
+  }
+
+  const indexTs = join(dir, 'index.ts')
+  if (existsSync(indexTs)) {
+    return [indexTs]
+  }
+
+  const indexJs = join(dir, 'index.js')
+  if (existsSync(indexJs)) {
+    return [indexJs]
+  }
+
+  return []
+}
+
+/**
+ * Discovers all extension entry-point paths under an extensions directory.
+ *
+ * - Top-level .ts/.js files are treated as standalone extension entry points.
+ * - Subdirectories are resolved via `resolveExtensionEntries()` (package.json →
+ *   pi.extensions, then index.ts/index.js fallback).
+ */
+export function discoverExtensionEntryPaths(extensionsDir: string): string[] {
+  if (!existsSync(extensionsDir)) {
+    return []
+  }
+
+  const discovered: string[] = []
+  for (const entry of readdirSync(extensionsDir, { withFileTypes: true })) {
+    const entryPath = join(extensionsDir, entry.name)
+
+    if ((entry.isFile() || entry.isSymbolicLink()) && isExtensionFile(entry.name)) {
+      discovered.push(entryPath)
+      continue
+    }
+
+    if (entry.isDirectory() || entry.isSymbolicLink()) {
+      discovered.push(...resolveExtensionEntries(entryPath))
+    }
+  }
+
+  return discovered
+}
+
+/**
+ * Merge bundled and installed extension entry paths.
+ * Installed extensions with the same manifest ID as a bundled extension take precedence (D-14).
+ * Loader stays dumb — receives a pre-merged path list (D-15).
+ */
+export function mergeExtensionEntryPaths(bundledPaths: string[], installedExtDir: string): string[] {
+  if (!existsSync(installedExtDir)) return bundledPaths
+
+  // Build map: manifest ID → entry paths for installed extensions
+  const installedById = new Map<string, string[]>()
+  for (const entry of readdirSync(installedExtDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue
+    const dir = join(installedExtDir, entry.name)
+    const manifest = readManifest(dir)
+    const entries = resolveExtensionEntries(dir)
+    if (manifest && entries.length > 0) {
+      installedById.set(manifest.id, entries)
+    }
+  }
+
+  if (installedById.size === 0) return bundledPaths
+
+  // Filter bundled paths: skip any whose manifest id is shadowed by installed
+  const merged: string[] = []
+  for (const entryPath of bundledPaths) {
+    const manifest = readManifestFromEntryPath(entryPath)
+    if (manifest && installedById.has(manifest.id)) continue // shadowed by installed
+    merged.push(entryPath)
+  }
+
+  // Append all installed entries
+  for (const entries of installedById.values()) {
+    merged.push(...entries)
+  }
+
+  return merged
+}

--- a/packages/pi-coding-agent/src/core/extensions/extension-registry.ts
+++ b/packages/pi-coding-agent/src/core/extensions/extension-registry.ts
@@ -1,0 +1,222 @@
+/**
+ * Extension Registry — manages manifest reading, registry persistence, and enable/disable state.
+ *
+ * Extensions without manifests always load (backwards compatible).
+ * A fresh install has an empty registry — all extensions enabled by default.
+ * The only way an extension stops loading is an explicit `gsd extensions disable <id>`.
+ */
+
+import { existsSync, mkdirSync, readFileSync, readdirSync, renameSync, writeFileSync } from "node:fs";
+import { getAgentDir } from "../../config.js";
+import { dirname, join } from "node:path";
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+export interface ExtensionManifest {
+  id: string;
+  name: string;
+  version: string;
+  description: string;
+  tier: "core" | "bundled" | "community";
+  requires: { platform: string };
+  provides?: {
+    tools?: string[];
+    commands?: string[];
+    hooks?: string[];
+    shortcuts?: string[];
+  };
+  dependencies?: {
+    extensions?: string[];
+    runtime?: string[];
+  };
+}
+
+export interface ExtensionRegistryEntry {
+  id: string;
+  enabled: boolean;
+  source: "bundled" | "user" | "project";
+  disabledAt?: string;
+  disabledReason?: string;
+  version?: string;           // From manifest, used for semver comparison
+  installedFrom?: string;     // Original specifier: npm package name, git URL, or local path
+  installType?: "npm" | "git" | "local";  // Explicit source type
+}
+
+export interface ExtensionRegistry {
+  version: 1;
+  entries: Record<string, ExtensionRegistryEntry>;
+}
+
+// ─── Validation ─────────────────────────────────────────────────────────────
+
+function isRegistry(data: unknown): data is ExtensionRegistry {
+  if (typeof data !== "object" || data === null) return false;
+  const obj = data as Record<string, unknown>;
+  return obj.version === 1 && typeof obj.entries === "object" && obj.entries !== null;
+}
+
+function isManifest(data: unknown): data is ExtensionManifest {
+  if (typeof data !== "object" || data === null) return false;
+  const obj = data as Record<string, unknown>;
+  return (
+    typeof obj.id === "string" &&
+    typeof obj.name === "string" &&
+    typeof obj.version === "string" &&
+    typeof obj.tier === "string"
+  );
+}
+
+// ─── Registry Path ──────────────────────────────────────────────────────────
+
+export function getRegistryPath(): string {
+  return join(dirname(getAgentDir()), "extensions", "registry.json");
+}
+
+// ─── Registry I/O ───────────────────────────────────────────────────────────
+
+function defaultRegistry(): ExtensionRegistry {
+  return { version: 1, entries: {} };
+}
+
+export function loadRegistry(): ExtensionRegistry {
+  const filePath = getRegistryPath();
+  try {
+    if (!existsSync(filePath)) return defaultRegistry();
+    const raw = readFileSync(filePath, "utf-8");
+    const parsed = JSON.parse(raw);
+    return isRegistry(parsed) ? parsed : defaultRegistry();
+  } catch {
+    return defaultRegistry();
+  }
+}
+
+export function saveRegistry(registry: ExtensionRegistry): void {
+  const filePath = getRegistryPath();
+  try {
+    mkdirSync(dirname(filePath), { recursive: true });
+    const tmp = filePath + ".tmp";
+    writeFileSync(tmp, JSON.stringify(registry, null, 2), "utf-8");
+    renameSync(tmp, filePath);
+  } catch {
+    // Non-fatal — don't let persistence failures break operation
+  }
+}
+
+// ─── Query ──────────────────────────────────────────────────────────────────
+
+/** Returns true if the extension is enabled (missing entries default to enabled). */
+export function isExtensionEnabled(registry: ExtensionRegistry, id: string): boolean {
+  const entry = registry.entries[id];
+  if (!entry) return true;
+  return entry.enabled;
+}
+
+// ─── Mutations ──────────────────────────────────────────────────────────────
+
+export function enableExtension(registry: ExtensionRegistry, id: string): void {
+  const entry = registry.entries[id];
+  if (entry) {
+    entry.enabled = true;
+    delete entry.disabledAt;
+    delete entry.disabledReason;
+  } else {
+    registry.entries[id] = { id, enabled: true, source: "bundled" };
+  }
+}
+
+/**
+ * Disable an extension. Returns an error string if the extension is core (cannot disable),
+ * or null on success.
+ */
+export function disableExtension(
+  registry: ExtensionRegistry,
+  id: string,
+  manifest: ExtensionManifest | null,
+  reason?: string,
+): string | null {
+  if (manifest?.tier === "core") {
+    return `Cannot disable "${id}" — it is a core extension.`;
+  }
+  const entry = registry.entries[id];
+  if (entry) {
+    entry.enabled = false;
+    entry.disabledAt = new Date().toISOString();
+    entry.disabledReason = reason;
+  } else {
+    registry.entries[id] = {
+      id,
+      enabled: false,
+      source: "bundled",
+      disabledAt: new Date().toISOString(),
+      disabledReason: reason,
+    };
+  }
+  return null;
+}
+
+// ─── Manifest Reading ───────────────────────────────────────────────────────
+
+/** Read extension-manifest.json from a directory. Returns null if missing or invalid. */
+export function readManifest(extensionDir: string): ExtensionManifest | null {
+  const manifestPath = join(extensionDir, "extension-manifest.json");
+  if (!existsSync(manifestPath)) return null;
+  try {
+    const raw = JSON.parse(readFileSync(manifestPath, "utf-8"));
+    return isManifest(raw) ? raw : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Given an entry path (e.g. `.../extensions/browser-tools/index.ts`),
+ * resolve the parent directory and read its manifest.
+ */
+export function readManifestFromEntryPath(entryPath: string): ExtensionManifest | null {
+  const dir = dirname(entryPath);
+  return readManifest(dir);
+}
+
+// ─── Discovery ──────────────────────────────────────────────────────────────
+
+/** Scan all subdirectories of extensionsDir for manifests. Returns a Map<id, manifest>. */
+export function discoverAllManifests(extensionsDir: string): Map<string, ExtensionManifest> {
+  const manifests = new Map<string, ExtensionManifest>();
+  if (!existsSync(extensionsDir)) return manifests;
+
+  for (const entry of readdirSync(extensionsDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const manifest = readManifest(join(extensionsDir, entry.name));
+    if (manifest) {
+      manifests.set(manifest.id, manifest);
+    }
+  }
+  return manifests;
+}
+
+/**
+ * Auto-populate registry entries for newly discovered extensions.
+ * Extensions already in the registry are left untouched.
+ */
+export function ensureRegistryEntries(extensionsDir: string): void {
+  const manifests = discoverAllManifests(extensionsDir);
+  if (manifests.size === 0) return;
+
+  const registry = loadRegistry();
+  let changed = false;
+
+  for (const [id, manifest] of manifests) {
+    if (!registry.entries[id]) {
+      registry.entries[id] = {
+        id,
+        enabled: true,
+        source: "bundled",
+      };
+      changed = true;
+    }
+  }
+
+  if (changed) {
+    saveRegistry(registry);
+  }
+}

--- a/packages/pi-coding-agent/src/core/extensions/extension-sort.ts
+++ b/packages/pi-coding-agent/src/core/extensions/extension-sort.ts
@@ -1,0 +1,135 @@
+// GSD-2 — Extension Sort: Topological dependency ordering
+// Copyright (c) 2026 Jeremy McSpadden <jeremy@fluxlabs.net>
+
+import { readManifestFromEntryPath } from './extension-registry.js'
+
+export interface SortWarning {
+  declaringId: string
+  missingId: string
+  message: string
+}
+
+export interface SortResult {
+  sortedPaths: string[]
+  warnings: SortWarning[]
+}
+
+/**
+ * Sort extension entry paths in topological dependency-first order using Kahn's BFS algorithm.
+ *
+ * - Extensions without manifests are prepended in input order.
+ * - Missing dependencies produce a structured warning but do not block loading.
+ * - Cycles produce warnings; cycle participants are appended alphabetically.
+ * - Self-dependencies are silently ignored.
+ */
+export function sortExtensionPaths(paths: string[]): SortResult {
+  const warnings: SortWarning[] = []
+  const pathsWithoutId: string[] = []
+  const idToPath = new Map<string, string>()
+
+  // Step 1: Build ID map
+  for (const path of paths) {
+    const manifest = readManifestFromEntryPath(path)
+    if (!manifest) {
+      pathsWithoutId.push(path)
+    } else {
+      idToPath.set(manifest.id, path)
+    }
+  }
+
+  // Step 2: Build graph — inDegree and dependents adjacency
+  const inDegree = new Map<string, number>()
+  const dependents = new Map<string, string[]>() // dep → [ids that depend on dep]
+
+  for (const id of idToPath.keys()) {
+    if (!inDegree.has(id)) inDegree.set(id, 0)
+    if (!dependents.has(id)) dependents.set(id, [])
+  }
+
+  for (const [id, path] of idToPath) {
+    const manifest = readManifestFromEntryPath(path)
+    const deps = manifest?.dependencies?.extensions ?? []
+
+    for (const depId of deps) {
+      // Silently ignore self-deps
+      if (depId === id) continue
+
+      if (!idToPath.has(depId)) {
+        // Missing dependency — warn and skip edge
+        warnings.push({
+          declaringId: id,
+          missingId: depId,
+          message: `Extension '${id}' declares dependency '${depId}' which is not installed — loading anyway`,
+        })
+        continue
+      }
+
+      // Valid edge: id depends on depId → increment inDegree[id], add id to dependents[depId]
+      inDegree.set(id, (inDegree.get(id) ?? 0) + 1)
+      const depDependents = dependents.get(depId) ?? []
+      depDependents.push(id)
+      dependents.set(depId, depDependents)
+    }
+  }
+
+  // Step 3: Kahn's algorithm — start with nodes that have inDegree 0
+  const sorted: string[] = []
+  // Ready queue: IDs with inDegree 0, maintained in alphabetical order
+  const ready: string[] = [...idToPath.keys()]
+    .filter(id => inDegree.get(id) === 0)
+    .sort()
+
+  while (ready.length > 0) {
+    const id = ready.shift()!
+    sorted.push(idToPath.get(id)!)
+
+    const deps = dependents.get(id) ?? []
+    for (const depId of deps) {
+      const newDegree = (inDegree.get(depId) ?? 0) - 1
+      inDegree.set(depId, newDegree)
+      if (newDegree === 0) {
+        // Insert into ready queue maintaining alphabetical order
+        const insertIdx = ready.findIndex(r => r > depId)
+        if (insertIdx === -1) {
+          ready.push(depId)
+        } else {
+          ready.splice(insertIdx, 0, depId)
+        }
+      }
+    }
+  }
+
+  // Step 4: Cycle handling — any remaining IDs with inDegree > 0
+  const cycleIds = [...idToPath.keys()]
+    .filter(id => (inDegree.get(id) ?? 0) > 0)
+    .sort()
+
+  if (cycleIds.length > 0) {
+    const cycleSet = new Set(cycleIds)
+
+    for (const id of cycleIds) {
+      const path = idToPath.get(id)!
+      const manifest = readManifestFromEntryPath(path)
+      const deps = manifest?.dependencies?.extensions ?? []
+
+      for (const depId of deps) {
+        if (depId === id) continue
+        if (!cycleSet.has(depId)) continue
+
+        // Both id and depId are in cycle — emit warning
+        warnings.push({
+          declaringId: id,
+          missingId: depId,
+          message: `Extension '${id}' and '${depId}' form a dependency cycle — loading both anyway (alphabetical order)`,
+        })
+      }
+
+      sorted.push(path)
+    }
+  }
+
+  return {
+    sortedPaths: [...pathsWithoutId, ...sorted],
+    warnings,
+  }
+}

--- a/packages/pi-coding-agent/src/core/extensions/extension-sort.ts
+++ b/packages/pi-coding-agent/src/core/extensions/extension-sort.ts
@@ -1,5 +1,4 @@
 // GSD-2 — Extension Sort: Topological dependency ordering
-// Copyright (c) 2026 Jeremy McSpadden <jeremy@fluxlabs.net>
 
 import { readManifestFromEntryPath } from './extension-registry.js'
 

--- a/packages/pi-coding-agent/src/core/extensions/loader.ts
+++ b/packages/pi-coding-agent/src/core/extensions/loader.ts
@@ -39,6 +39,7 @@ import { execCommand } from "../exec.js";
 import { getUntrustedExtensionPaths } from "./project-trust.js";
 export { isProjectTrusted, trustProject, getUntrustedExtensionPaths } from "./project-trust.js";
 import { mergeExtensionEntryPaths } from "../../../../../src/extension-discovery.js";
+import { sortExtensionPaths } from "../../../../../src/extension-sort.js";
 import type {
 	Extension,
 	ExtensionAPI,
@@ -823,6 +824,7 @@ export async function loadExtensions(paths: string[], cwd: string, eventBus?: Ev
 	return {
 		extensions,
 		errors,
+		warnings: [],
 		runtime,
 	};
 }
@@ -1004,5 +1006,13 @@ export async function discoverAndLoadExtensions(
 		addPaths([resolved]);
 	}
 
-	return loadExtensions(allPaths, cwd, eventBus);
+	// Topological sort: ensure declared dependencies load first (D-06, D-07)
+	const { sortedPaths, warnings: sortWarnings } = sortExtensionPaths(allPaths)
+	// Emit warnings to stderr immediately — loader runs before ctx.ui is ready (D-08)
+	for (const w of sortWarnings) {
+		process.stderr.write(`[gsd] ${w.message}\n`)
+	}
+	const result = await loadExtensions(sortedPaths, cwd, eventBus)
+	result.warnings.push(...sortWarnings)
+	return result
 }

--- a/packages/pi-coding-agent/src/core/extensions/loader.ts
+++ b/packages/pi-coding-agent/src/core/extensions/loader.ts
@@ -38,6 +38,7 @@ import type { ExecOptions } from "../exec.js";
 import { execCommand } from "../exec.js";
 import { getUntrustedExtensionPaths } from "./project-trust.js";
 export { isProjectTrusted, trustProject, getUntrustedExtensionPaths } from "./project-trust.js";
+import { mergeExtensionEntryPaths } from "../../../../../src/extension-discovery.js";
 import type {
 	Extension,
 	ExtensionAPI,
@@ -978,7 +979,12 @@ export async function discoverAndLoadExtensions(
 
 	// 2. Global extensions: agentDir/extensions/
 	const globalExtDir = path.join(agentDir, "extensions");
-	addPaths(discoverExtensionsInDir(globalExtDir));
+	// 2b. Installed extensions: ~/.gsd/extensions/ merged with bundled (D-14, D-15)
+	// Discovery handles ID-based merge — loader stays dumb.
+	const installedExtDir = path.join(path.dirname(agentDir), "extensions");
+	const globalPaths = discoverExtensionsInDir(globalExtDir);
+	const mergedPaths = mergeExtensionEntryPaths(globalPaths, installedExtDir);
+	addPaths(mergedPaths);
 
 	// 3. Explicitly configured paths
 	for (const p of configuredPaths) {

--- a/packages/pi-coding-agent/src/core/extensions/loader.ts
+++ b/packages/pi-coding-agent/src/core/extensions/loader.ts
@@ -38,8 +38,8 @@ import type { ExecOptions } from "../exec.js";
 import { execCommand } from "../exec.js";
 import { getUntrustedExtensionPaths } from "./project-trust.js";
 export { isProjectTrusted, trustProject, getUntrustedExtensionPaths } from "./project-trust.js";
-import { mergeExtensionEntryPaths } from "../../../../../dist/extension-discovery.js";
-import { sortExtensionPaths } from "../../../../../dist/extension-sort.js";
+import { mergeExtensionEntryPaths } from "./extension-discovery.js";
+import { sortExtensionPaths } from "./extension-sort.js";
 import type {
 	Extension,
 	ExtensionAPI,

--- a/packages/pi-coding-agent/src/core/extensions/loader.ts
+++ b/packages/pi-coding-agent/src/core/extensions/loader.ts
@@ -38,8 +38,8 @@ import type { ExecOptions } from "../exec.js";
 import { execCommand } from "../exec.js";
 import { getUntrustedExtensionPaths } from "./project-trust.js";
 export { isProjectTrusted, trustProject, getUntrustedExtensionPaths } from "./project-trust.js";
-import { mergeExtensionEntryPaths } from "../../../../../src/extension-discovery.js";
-import { sortExtensionPaths } from "../../../../../src/extension-sort.js";
+import { mergeExtensionEntryPaths } from "../../../../../dist/extension-discovery.js";
+import { sortExtensionPaths } from "../../../../../dist/extension-sort.js";
 import type {
 	Extension,
 	ExtensionAPI,

--- a/packages/pi-coding-agent/src/core/extensions/types.ts
+++ b/packages/pi-coding-agent/src/core/extensions/types.ts
@@ -1450,10 +1450,18 @@ export interface Extension {
 	lifecycleHooks: LifecycleHookMap;
 }
 
+/** Warning from extension dependency sort (missing deps, cycles). */
+export interface ExtensionLoadWarning {
+	declaringId: string;
+	missingId: string;
+	message: string;
+}
+
 /** Result of loading extensions. */
 export interface LoadExtensionsResult {
 	extensions: Extension[];
 	errors: Array<{ path: string; error: string }>;
+	warnings: ExtensionLoadWarning[];
 	/** Shared runtime - actions are throwing stubs until runner.initialize() */
 	runtime: ExtensionRuntime;
 }

--- a/packages/pi-coding-agent/src/core/resource-loader.ts
+++ b/packages/pi-coding-agent/src/core/resource-loader.ts
@@ -231,7 +231,7 @@ export class DefaultResourceLoader implements ResourceLoader {
 		this.systemPromptOverride = options.systemPromptOverride;
 		this.appendSystemPromptOverride = options.appendSystemPromptOverride;
 
-		this.extensionsResult = { extensions: [], errors: [], runtime: createExtensionRuntime() };
+		this.extensionsResult = { extensions: [], errors: [], warnings: [], runtime: createExtensionRuntime() };
 		this.skills = [];
 		this.skillDiagnostics = [];
 		this.prompts = [];

--- a/src/extension-discovery.ts
+++ b/src/extension-discovery.ts
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync, readdirSync } from 'node:fs'
 import { join, resolve } from 'node:path'
+import { readManifest, readManifestFromEntryPath } from './extension-registry.js'
 
 function isExtensionFile(name: string): boolean {
   return name.endsWith('.ts') || name.endsWith('.js')
@@ -77,4 +78,42 @@ export function discoverExtensionEntryPaths(extensionsDir: string): string[] {
   }
 
   return discovered
+}
+
+/**
+ * Merge bundled and installed extension entry paths.
+ * Installed extensions with the same manifest ID as a bundled extension take precedence (D-14).
+ * Loader stays dumb — receives a pre-merged path list (D-15).
+ */
+export function mergeExtensionEntryPaths(bundledPaths: string[], installedExtDir: string): string[] {
+  if (!existsSync(installedExtDir)) return bundledPaths
+
+  // Build map: manifest ID → entry paths for installed extensions
+  const installedById = new Map<string, string[]>()
+  for (const entry of readdirSync(installedExtDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue
+    const dir = join(installedExtDir, entry.name)
+    const manifest = readManifest(dir)
+    const entries = resolveExtensionEntries(dir)
+    if (manifest && entries.length > 0) {
+      installedById.set(manifest.id, entries)
+    }
+  }
+
+  if (installedById.size === 0) return bundledPaths
+
+  // Filter bundled paths: skip any whose manifest id is shadowed by installed
+  const merged: string[] = []
+  for (const entryPath of bundledPaths) {
+    const manifest = readManifestFromEntryPath(entryPath)
+    if (manifest && installedById.has(manifest.id)) continue // shadowed by installed
+    merged.push(entryPath)
+  }
+
+  // Append all installed entries
+  for (const entries of installedById.values()) {
+    merged.push(...entries)
+  }
+
+  return merged
 }

--- a/src/extension-registry.ts
+++ b/src/extension-registry.ts
@@ -37,6 +37,9 @@ export interface ExtensionRegistryEntry {
   source: "bundled" | "user" | "project";
   disabledAt?: string;
   disabledReason?: string;
+  version?: string;           // From manifest, used for semver comparison
+  installedFrom?: string;     // Original specifier: npm package name, git URL, or local path
+  installType?: "npm" | "git" | "local";  // Explicit source type
 }
 
 export interface ExtensionRegistry {

--- a/src/extension-sort.ts
+++ b/src/extension-sort.ts
@@ -1,0 +1,135 @@
+// GSD-2 — Extension Sort: Topological dependency ordering
+// Copyright (c) 2026 Jeremy McSpadden <jeremy@fluxlabs.net>
+
+import { readManifestFromEntryPath } from './extension-registry.js'
+
+export interface SortWarning {
+  declaringId: string
+  missingId: string
+  message: string
+}
+
+export interface SortResult {
+  sortedPaths: string[]
+  warnings: SortWarning[]
+}
+
+/**
+ * Sort extension entry paths in topological dependency-first order using Kahn's BFS algorithm.
+ *
+ * - Extensions without manifests are prepended in input order.
+ * - Missing dependencies produce a structured warning but do not block loading.
+ * - Cycles produce warnings; cycle participants are appended alphabetically.
+ * - Self-dependencies are silently ignored.
+ */
+export function sortExtensionPaths(paths: string[]): SortResult {
+  const warnings: SortWarning[] = []
+  const pathsWithoutId: string[] = []
+  const idToPath = new Map<string, string>()
+
+  // Step 1: Build ID map
+  for (const path of paths) {
+    const manifest = readManifestFromEntryPath(path)
+    if (!manifest) {
+      pathsWithoutId.push(path)
+    } else {
+      idToPath.set(manifest.id, path)
+    }
+  }
+
+  // Step 2: Build graph — inDegree and dependents adjacency
+  const inDegree = new Map<string, number>()
+  const dependents = new Map<string, string[]>() // dep → [ids that depend on dep]
+
+  for (const id of idToPath.keys()) {
+    if (!inDegree.has(id)) inDegree.set(id, 0)
+    if (!dependents.has(id)) dependents.set(id, [])
+  }
+
+  for (const [id, path] of idToPath) {
+    const manifest = readManifestFromEntryPath(path)
+    const deps = manifest?.dependencies?.extensions ?? []
+
+    for (const depId of deps) {
+      // Silently ignore self-deps
+      if (depId === id) continue
+
+      if (!idToPath.has(depId)) {
+        // Missing dependency — warn and skip edge
+        warnings.push({
+          declaringId: id,
+          missingId: depId,
+          message: `Extension '${id}' declares dependency '${depId}' which is not installed — loading anyway`,
+        })
+        continue
+      }
+
+      // Valid edge: id depends on depId → increment inDegree[id], add id to dependents[depId]
+      inDegree.set(id, (inDegree.get(id) ?? 0) + 1)
+      const depDependents = dependents.get(depId) ?? []
+      depDependents.push(id)
+      dependents.set(depId, depDependents)
+    }
+  }
+
+  // Step 3: Kahn's algorithm — start with nodes that have inDegree 0
+  const sorted: string[] = []
+  // Ready queue: IDs with inDegree 0, maintained in alphabetical order
+  const ready: string[] = [...idToPath.keys()]
+    .filter(id => inDegree.get(id) === 0)
+    .sort()
+
+  while (ready.length > 0) {
+    const id = ready.shift()!
+    sorted.push(idToPath.get(id)!)
+
+    const deps = dependents.get(id) ?? []
+    for (const depId of deps) {
+      const newDegree = (inDegree.get(depId) ?? 0) - 1
+      inDegree.set(depId, newDegree)
+      if (newDegree === 0) {
+        // Insert into ready queue maintaining alphabetical order
+        const insertIdx = ready.findIndex(r => r > depId)
+        if (insertIdx === -1) {
+          ready.push(depId)
+        } else {
+          ready.splice(insertIdx, 0, depId)
+        }
+      }
+    }
+  }
+
+  // Step 4: Cycle handling — any remaining IDs with inDegree > 0
+  const cycleIds = [...idToPath.keys()]
+    .filter(id => (inDegree.get(id) ?? 0) > 0)
+    .sort()
+
+  if (cycleIds.length > 0) {
+    const cycleSet = new Set(cycleIds)
+
+    for (const id of cycleIds) {
+      const path = idToPath.get(id)!
+      const manifest = readManifestFromEntryPath(path)
+      const deps = manifest?.dependencies?.extensions ?? []
+
+      for (const depId of deps) {
+        if (depId === id) continue
+        if (!cycleSet.has(depId)) continue
+
+        // Both id and depId are in cycle — emit warning
+        warnings.push({
+          declaringId: id,
+          missingId: depId,
+          message: `Extension '${id}' and '${depId}' form a dependency cycle — loading both anyway (alphabetical order)`,
+        })
+      }
+
+      sorted.push(path)
+    }
+  }
+
+  return {
+    sortedPaths: [...pathsWithoutId, ...sorted],
+    warnings,
+  }
+}

--- a/src/extension-sort.ts
+++ b/src/extension-sort.ts
@@ -1,5 +1,4 @@
 // GSD-2 — Extension Sort: Topological dependency ordering
-// Copyright (c) 2026 Jeremy McSpadden <jeremy@fluxlabs.net>
 
 import { readManifestFromEntryPath } from './extension-registry.js'
 

--- a/src/extension-sort.ts
+++ b/src/extension-sort.ts
@@ -48,7 +48,8 @@ export function sortExtensionPaths(paths: string[]): SortResult {
 
   for (const [id, path] of idToPath) {
     const manifest = readManifestFromEntryPath(path)
-    const deps = manifest?.dependencies?.extensions ?? []
+    const rawDeps = manifest?.dependencies?.extensions ?? []
+    const deps = Array.isArray(rawDeps) ? rawDeps : []
 
     for (const depId of deps) {
       // Silently ignore self-deps
@@ -110,7 +111,8 @@ export function sortExtensionPaths(paths: string[]): SortResult {
     for (const id of cycleIds) {
       const path = idToPath.get(id)!
       const manifest = readManifestFromEntryPath(path)
-      const deps = manifest?.dependencies?.extensions ?? []
+      const rawDeps = manifest?.dependencies?.extensions ?? []
+      const deps = Array.isArray(rawDeps) ? rawDeps : []
 
       for (const depId of deps) {
         if (depId === id) continue

--- a/src/extension-validator.ts
+++ b/src/extension-validator.ts
@@ -1,0 +1,177 @@
+// GSD-2 — Extension Package Format Validator
+// Copyright (c) 2026 Jeremy McSpadden <jeremy@fluxlabs.net>
+
+/**
+ * Install-time validator for GSD extension packages. Called by the install command
+ * (Phase 8) before writing files. Not called on bundled extensions — they are
+ * discovered at load time, not installed.
+ */
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export interface ValidationError {
+  code: string;    // "MISSING_GSD_MARKER" | "RESERVED_NAMESPACE" | "WRONG_DEP_FIELD"
+  message: string; // Human-readable, actionable
+  field?: string;  // e.g. "dependencies", "gsd.extension"
+}
+
+export interface ValidationWarning {
+  code: string;
+  message: string;
+}
+
+export interface ValidationResult {
+  valid: boolean;      // ALWAYS derived as errors.length === 0
+  errors: ValidationError[];
+  warnings: ValidationWarning[];
+}
+
+export interface ValidationOptions {
+  allowGsdNamespace?: boolean;  // Per D-05: --allow-gsd-namespace flag pass-through
+  extensionId?: string;         // The manifest ID to check against gsd.* namespace (per D-04)
+}
+
+// ─── Individual Check Functions ───────────────────────────────────────────────
+
+/**
+ * Per D-03: Check that pkg.gsd.extension === true with STRICT equality (not truthiness).
+ * Packages without this marker are not recognized as GSD extensions.
+ */
+export function checkInstallDiscriminator(pkg: unknown): ValidationError | null {
+  if (typeof pkg !== 'object' || pkg === null) {
+    return {
+      code: 'MISSING_GSD_MARKER',
+      message: 'package.json must declare "gsd": { "extension": true } to be recognized as a GSD extension.',
+      field: 'gsd.extension',
+    }
+  }
+
+  const obj = pkg as Record<string, unknown>
+  const gsd = obj.gsd
+
+  if (typeof gsd !== 'object' || gsd === null) {
+    return {
+      code: 'MISSING_GSD_MARKER',
+      message: 'package.json must declare "gsd": { "extension": true } to be recognized as a GSD extension.',
+      field: 'gsd.extension',
+    }
+  }
+
+  const gsdObj = gsd as Record<string, unknown>
+  if (gsdObj.extension !== true) {
+    return {
+      code: 'MISSING_GSD_MARKER',
+      message: 'package.json must declare "gsd": { "extension": true } to be recognized as a GSD extension.',
+      field: 'gsd.extension',
+    }
+  }
+
+  return null
+}
+
+/**
+ * Per D-04/D-05: Check that the extension ID does not use the reserved gsd.* namespace,
+ * unless allowGsdNamespace is explicitly set to true.
+ * Per D-06: Only checks extension manifest ID — not pkg.name.
+ */
+export function checkNamespaceReservation(extensionId: string, opts: ValidationOptions): ValidationError | null {
+  if (opts.allowGsdNamespace === true) {
+    return null
+  }
+
+  if (extensionId.startsWith('gsd.')) {
+    return {
+      code: 'RESERVED_NAMESPACE',
+      message: `Extension ID "${extensionId}" is reserved for GSD core extensions. Use a different namespace for community extensions (e.g., "my-tool" or "acme.my-tool"). To override: pass --allow-gsd-namespace (maintainers only).`,
+      field: 'extensionId',
+    }
+  }
+
+  return null
+}
+
+/**
+ * Per D-07/D-08/D-09/D-10: Scan both `dependencies` and `devDependencies` for @gsd/* packages.
+ * peerDependencies is the correct placement and is NOT flagged.
+ * Returns an error per violation naming the exact field and package.
+ */
+export function checkDependencyPlacement(pkg: unknown): ValidationError[] {
+  const errors: ValidationError[] = []
+
+  if (typeof pkg !== 'object' || pkg === null) {
+    return errors
+  }
+
+  const obj = pkg as Record<string, unknown>
+
+  const fieldsToCheck: Array<{ field: string; reason: string }> = [
+    {
+      field: 'dependencies',
+      reason: 'Extensions must not bundle GSD host packages — the host provides them at runtime.',
+    },
+    {
+      field: 'devDependencies',
+      reason: 'GSD host packages are provided by the host at runtime; listing them in devDependencies misrepresents the runtime contract.',
+    },
+  ]
+
+  for (const { field, reason } of fieldsToCheck) {
+    const deps = obj[field]
+    if (typeof deps !== 'object' || deps === null) continue
+
+    const depsObj = deps as Record<string, unknown>
+    for (const pkgName of Object.keys(depsObj)) {
+      if (pkgName.startsWith('@gsd/')) {
+        errors.push({
+          code: 'WRONG_DEP_FIELD',
+          message: `"${pkgName}" must not appear in "${field}". Move it to "peerDependencies". ${reason}`,
+          field,
+        })
+      }
+    }
+  }
+
+  return errors
+}
+
+// ─── Composite Validation ─────────────────────────────────────────────────────
+
+/**
+ * Run all validation checks for a GSD extension package.json.
+ * - If opts.extensionId is provided, runs namespace reservation check.
+ * - If opts.extensionId is not provided, skips namespace check and adds a warning.
+ * - valid is ALWAYS derived as errors.length === 0.
+ */
+export function validateExtensionPackage(pkg: unknown, opts: ValidationOptions = {}): ValidationResult {
+  const errors: ValidationError[] = []
+  const warnings: ValidationWarning[] = []
+
+  // Check 1: Install discriminator
+  const discriminatorError = checkInstallDiscriminator(pkg)
+  if (discriminatorError) {
+    errors.push(discriminatorError)
+  }
+
+  // Check 2: Namespace reservation (only if extensionId provided)
+  if (opts.extensionId !== undefined) {
+    const namespaceError = checkNamespaceReservation(opts.extensionId, opts)
+    if (namespaceError) {
+      errors.push(namespaceError)
+    }
+  } else {
+    warnings.push({
+      code: 'NAMESPACE_CHECK_SKIPPED',
+      message: 'No extensionId provided — namespace reservation check was skipped.',
+    })
+  }
+
+  // Check 3: Dependency placement
+  const depErrors = checkDependencyPlacement(pkg)
+  errors.push(...depErrors)
+
+  return {
+    valid: errors.length === 0,
+    errors,
+    warnings,
+  }
+}

--- a/src/extension-validator.ts
+++ b/src/extension-validator.ts
@@ -1,5 +1,4 @@
 // GSD-2 — Extension Package Format Validator
-// Copyright (c) 2026 Jeremy McSpadden <jeremy@fluxlabs.net>
 
 /**
  * Install-time validator for GSD extension packages. Called by the install command

--- a/src/resources/extensions/cmux/index.ts
+++ b/src/resources/extensions/cmux/index.ts
@@ -3,8 +3,17 @@ import { existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
-import type { GSDPreferences } from "../gsd/preferences.js";
-import type { GSDState, Phase } from "../gsd/types.js";
+import { CMUX_CHANNELS, type CmuxSidebarEvent, type CmuxLogEvent, type CmuxPreferencesInput, type CmuxStateInput } from "../shared/cmux-events.js";
+import type { EventBus } from "@gsd/pi-coding-agent";
+
+/** Local structural type — only the preferences fields cmux reads. */
+type CmuxPreferences = CmuxPreferencesInput;
+
+/** Local structural type — only the state fields cmux reads. */
+type CmuxState = CmuxStateInput;
+
+/** Local structural type — cmux treats phase as an opaque string. */
+type Phase = string;
 
 const execFileAsync = promisify(execFile);
 const DEFAULT_SOCKET_PATH = "/tmp/cmux.sock";
@@ -55,7 +64,7 @@ export function detectCmuxEnvironment(
 }
 
 export function resolveCmuxConfig(
-  preferences: GSDPreferences | undefined,
+  preferences: CmuxPreferences | undefined,
   env: NodeJS.ProcessEnv = process.env,
   socketExists: (path: string) => boolean = existsSync,
   cliAvailable: () => boolean = isCmuxCliAvailable,
@@ -74,7 +83,7 @@ export function resolveCmuxConfig(
 }
 
 export function shouldPromptToEnableCmux(
-  preferences: GSDPreferences | undefined,
+  preferences: CmuxPreferences | undefined,
   env: NodeJS.ProcessEnv = process.env,
   socketExists: (path: string) => boolean = existsSync,
   cliAvailable: () => boolean = isCmuxCliAvailable,
@@ -116,7 +125,7 @@ export function emitOsc777Notification(title: string, body: string): void {
   process.stdout.write(`\x1b]777;notify;${safeTitle};${safeBody}\x07`);
 }
 
-export function buildCmuxStatusLabel(state: GSDState): string {
+export function buildCmuxStatusLabel(state: CmuxState): string {
   const parts: string[] = [];
   if (state.activeMilestone) parts.push(state.activeMilestone.id);
   if (state.activeSlice) parts.push(state.activeSlice.id);
@@ -128,7 +137,7 @@ export function buildCmuxStatusLabel(state: GSDState): string {
   return `${parts.join(" ")} · ${state.phase}`;
 }
 
-export function buildCmuxProgress(state: GSDState): CmuxSidebarProgress | null {
+export function buildCmuxProgress(state: CmuxState): CmuxSidebarProgress | null {
   const progress = state.progress;
   if (!progress) return null;
 
@@ -174,7 +183,7 @@ export class CmuxClient {
     this.config = config;
   }
 
-  static fromPreferences(preferences: GSDPreferences | undefined): CmuxClient {
+  static fromPreferences(preferences: CmuxPreferences | undefined): CmuxClient {
     return new CmuxClient(resolveCmuxConfig(preferences));
   }
 
@@ -366,7 +375,7 @@ export class CmuxClient {
   }
 }
 
-export function syncCmuxSidebar(preferences: GSDPreferences | undefined, state: GSDState): void {
+export function syncCmuxSidebar(preferences: CmuxPreferences | undefined, state: CmuxState): void {
   const client = CmuxClient.fromPreferences(preferences);
   const config = client.getConfig();
   if (!config.sidebar) return;
@@ -382,7 +391,7 @@ export function syncCmuxSidebar(preferences: GSDPreferences | undefined, state: 
   lastSidebarSnapshots.set(key, snapshot);
 }
 
-export function clearCmuxSidebar(preferences: GSDPreferences | undefined): void {
+export function clearCmuxSidebar(preferences: CmuxPreferences | undefined): void {
   const config = resolveCmuxConfig(preferences);
   if (!config.available || !config.cliAvailable) return;
   const client = new CmuxClient({ ...config, enabled: true, sidebar: true });
@@ -393,7 +402,7 @@ export function clearCmuxSidebar(preferences: GSDPreferences | undefined): void 
 }
 
 export function logCmuxEvent(
-  preferences: GSDPreferences | undefined,
+  preferences: CmuxPreferences | undefined,
   message: string,
   level: CmuxLogLevel = "info",
 ): void {
@@ -439,4 +448,25 @@ function extractSurfaceIds(value: unknown): string[] {
 
   visit(value);
   return Array.from(found);
+}
+
+/**
+ * Wire event subscriptions so cmux reacts to gsd events.
+ * Called by the gsd extension during registration, passing pi.events.
+ */
+export function initCmuxEventListeners(events: EventBus): void {
+  events.on(CMUX_CHANNELS.SIDEBAR, (data) => {
+    const event = data as CmuxSidebarEvent;
+    if (event.action === "sync" && event.preferences && event.state) {
+      syncCmuxSidebar(event.preferences as CmuxPreferences, event.state as CmuxState);
+    }
+    if (event.action === "clear") {
+      clearCmuxSidebar(event.preferences as CmuxPreferences | undefined);
+    }
+  });
+
+  events.on(CMUX_CHANNELS.LOG, (data) => {
+    const event = data as CmuxLogEvent;
+    logCmuxEvent(event.preferences as CmuxPreferences | undefined, event.message, event.level);
+  });
 }

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -176,7 +176,18 @@ import {
 } from "./auto-supervisor.js";
 import { isDbAvailable } from "./gsd-db.js";
 import { countPendingCaptures } from "./captures.js";
-import { clearCmuxSidebar, logCmuxEvent, syncCmuxSidebar } from "../cmux/index.js";
+import { CMUX_CHANNELS, type CmuxLogLevel } from "../shared/cmux-events.js";
+
+function makeCmuxEmitters(pi: ExtensionAPI) {
+  return {
+    syncCmuxSidebar: (preferences: GSDPreferences | undefined, state: GSDState) =>
+      pi.events.emit(CMUX_CHANNELS.SIDEBAR, { action: "sync" as const, preferences, state }),
+    logCmuxEvent: (preferences: GSDPreferences | undefined, message: string, level?: CmuxLogLevel) =>
+      pi.events.emit(CMUX_CHANNELS.LOG, { preferences, message, level: level ?? "info" }),
+    clearCmuxSidebar: (preferences: GSDPreferences | undefined) =>
+      pi.events.emit(CMUX_CHANNELS.SIDEBAR, { action: "clear" as const, preferences }),
+  };
+}
 
 // ── Extracted modules ──────────────────────────────────────────────────────
 import { startUnitSupervision } from "./auto-timers.js";
@@ -524,7 +535,6 @@ function handleLostSessionLock(
   s.paused = false;
   clearUnitTimeout();
   deregisterSigtermHandler();
-  clearCmuxSidebar(loadEffectiveGSDPreferences()?.preferences);
   const base = lockBase();
   const lockFilePath = base ? join(gsdRoot(base), "auto.lock") : "unknown";
   const recoverySuggestion = "\nTo recover, run: gsd doctor --fix";
@@ -724,12 +734,12 @@ export async function stopAuto(
 
     // ── Step 9: Cmux sidebar / event log ──
     try {
-      clearCmuxSidebar(loadedPreferences);
-      logCmuxEvent(
-        loadedPreferences,
-        `Auto-mode stopped${reasonSuffix || ""}.`,
-        reason?.startsWith("Blocked:") ? "warning" : "info",
-      );
+      pi?.events.emit(CMUX_CHANNELS.SIDEBAR, { action: "clear" as const, preferences: loadedPreferences });
+      pi?.events.emit(CMUX_CHANNELS.LOG, {
+        preferences: loadedPreferences,
+        message: `Auto-mode stopped${reasonSuffix || ""}.`,
+        level: reason?.startsWith("Blocked:") ? "warning" : "info",
+      });
     } catch (e) {
       debugLog("stop-cleanup-cmux", { error: e instanceof Error ? e.message : String(e) });
     }
@@ -934,11 +944,13 @@ function buildResolver(): WorktreeResolver {
  * Build the LoopDeps object from auto.ts private scope.
  * This bundles all private functions that autoLoop needs without exporting them.
  */
-function buildLoopDeps(): LoopDeps {
+function buildLoopDeps(pi: ExtensionAPI): LoopDeps {
   // Initialize the unified rule registry with converted dispatch rules.
   // Must happen before LoopDeps is assembled so facade functions
   // (resolveDispatch, runPreDispatchHooks, etc.) delegate to the registry.
   initRegistry(convertDispatchRules(DISPATCH_RULES));
+
+  const cmux = makeCmuxEmitters(pi);
 
   return {
     lockBase,
@@ -947,8 +959,11 @@ function buildLoopDeps(): LoopDeps {
     pauseAuto,
     clearUnitTimeout,
     updateProgressWidget,
-    syncCmuxSidebar,
-    logCmuxEvent,
+    ...cmux,
+    handleLostSessionLock: (ctx, lockStatus) => {
+      cmux.clearCmuxSidebar(loadEffectiveGSDPreferences()?.preferences);
+      handleLostSessionLock(ctx, lockStatus);
+    },
 
     // State and cache
     invalidateAllCaches,
@@ -968,7 +983,6 @@ function buildLoopDeps(): LoopDeps {
     // Session lock
     validateSessionLock: getSessionLockStatus,
     updateSessionLock,
-    handleLostSessionLock,
 
     // Milestone transition
     sendDesktopNotification,
@@ -1164,7 +1178,7 @@ export async function startAuto(
     restoreHookState(s.basePath);
     try {
       await rebuildState(s.basePath);
-      syncCmuxSidebar(loadEffectiveGSDPreferences()?.preferences, await deriveState(s.basePath));
+      pi.events.emit(CMUX_CHANNELS.SIDEBAR, { action: "sync" as const, preferences: loadEffectiveGSDPreferences()?.preferences, state: await deriveState(s.basePath) });
     } catch (e) {
       debugLog("resume-rebuild-state-failed", {
         error: e instanceof Error ? e.message : String(e),
@@ -1214,9 +1228,9 @@ export async function startAuto(
       "resuming",
       s.currentMilestoneId ?? "unknown",
     );
-    logCmuxEvent(loadEffectiveGSDPreferences()?.preferences, s.stepMode ? "Step-mode resumed." : "Auto-mode resumed.", "progress");
+    pi.events.emit(CMUX_CHANNELS.LOG, { preferences: loadEffectiveGSDPreferences()?.preferences, message: s.stepMode ? "Step-mode resumed." : "Auto-mode resumed.", level: "progress" });
 
-    await autoLoop(ctx, pi, s, buildLoopDeps());
+    await autoLoop(ctx, pi, s, buildLoopDeps(pi));
     cleanupAfterLoopExit(ctx);
     return;
   }
@@ -1241,14 +1255,14 @@ export async function startAuto(
   if (!ready) return;
 
   try {
-    syncCmuxSidebar(loadEffectiveGSDPreferences()?.preferences, await deriveState(s.basePath));
+    pi.events.emit(CMUX_CHANNELS.SIDEBAR, { action: "sync" as const, preferences: loadEffectiveGSDPreferences()?.preferences, state: await deriveState(s.basePath) });
   } catch {
     // Best-effort only — sidebar sync must never block auto-mode startup
   }
-  logCmuxEvent(loadEffectiveGSDPreferences()?.preferences, requestedStepMode ? "Step-mode started." : "Auto-mode started.", "progress");
+  pi.events.emit(CMUX_CHANNELS.LOG, { preferences: loadEffectiveGSDPreferences()?.preferences, message: requestedStepMode ? "Step-mode started." : "Auto-mode started.", level: "progress" });
 
   // Dispatch the first unit
-  await autoLoop(ctx, pi, s, buildLoopDeps());
+  await autoLoop(ctx, pi, s, buildLoopDeps(pi));
   cleanupAfterLoopExit(ctx);
 }
 

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -960,7 +960,7 @@ function buildLoopDeps(pi: ExtensionAPI): LoopDeps {
     clearUnitTimeout,
     updateProgressWidget,
     ...cmux,
-    handleLostSessionLock: (ctx, lockStatus) => {
+    handleLostSessionLock: (ctx: ExtensionContext | undefined, lockStatus: SessionLockStatus | undefined) => {
       cmux.clearCmuxSidebar(loadEffectiveGSDPreferences()?.preferences);
       handleLostSessionLock(ctx, lockStatus);
     },

--- a/src/resources/extensions/gsd/auto/loop-deps.ts
+++ b/src/resources/extensions/gsd/auto/loop-deps.ts
@@ -18,7 +18,7 @@ import type {
 } from "../auto-verification.js";
 import type { DispatchAction } from "../auto-dispatch.js";
 import type { WorktreeResolver } from "../worktree-resolver.js";
-import type { CmuxLogLevel } from "../../cmux/index.js";
+import type { CmuxLogLevel } from "../../shared/cmux-events.js";
 import type { JournalEntry } from "../journal.js";
 
 /**

--- a/src/resources/extensions/gsd/auto/types.ts
+++ b/src/resources/extensions/gsd/auto/types.ts
@@ -9,7 +9,7 @@ import type { ExtensionAPI, ExtensionContext } from "@gsd/pi-coding-agent";
 import type { AutoSession } from "./session.js";
 import type { GSDPreferences } from "../preferences.js";
 import type { GSDState } from "../types.js";
-import type { CmuxLogLevel } from "../../cmux/index.js";
+import type { CmuxLogLevel } from "../../shared/cmux-events.js";
 import type { LoopDeps } from "./loop-deps.js";
 
 /**

--- a/src/resources/extensions/gsd/bootstrap/register-extension.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-extension.ts
@@ -61,7 +61,9 @@ export function registerGsdExtension(pi: ExtensionAPI): void {
 
   // Wire cmux event subscriptions — cmux is a library (no pi), so gsd sets up
   // the event listeners on its behalf using the shared event channel contract.
-  void import("../../cmux/index.js").then(({ initCmuxEventListeners }) => {
-    initCmuxEventListeners(pi.events);
-  });
+  if (pi.events) {
+    void import("../../cmux/index.js").then(({ initCmuxEventListeners }) => {
+      initCmuxEventListeners(pi.events);
+    });
+  }
 }

--- a/src/resources/extensions/gsd/bootstrap/register-extension.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-extension.ts
@@ -58,4 +58,10 @@ export function registerGsdExtension(pi: ExtensionAPI): void {
   registerJournalTools(pi);
   registerShortcuts(pi);
   registerHooks(pi);
+
+  // Wire cmux event subscriptions — cmux is a library (no pi), so gsd sets up
+  // the event listeners on its behalf using the shared event channel contract.
+  void import("../../cmux/index.js").then(({ initCmuxEventListeners }) => {
+    initCmuxEventListeners(pi.events);
+  });
 }

--- a/src/resources/extensions/gsd/bootstrap/system-context.ts
+++ b/src/resources/extensions/gsd/bootstrap/system-context.ts
@@ -14,7 +14,6 @@ import { getActiveWorktreeName, getWorktreeOriginalCwd } from "../worktree-comma
 import { deriveState } from "../state.js";
 import { formatOverridesSection, loadActiveOverrides, loadFile, parseContinue, parseSummary } from "../files.js";
 import { toPosixPath } from "../../shared/mod.js";
-import { markCmuxPromptShown, shouldPromptToEnableCmux } from "../../cmux/index.js";
 
 const gsdHome = process.env.GSD_HOME || join(homedir(), ".gsd");
 
@@ -43,6 +42,7 @@ export async function buildBeforeAgentStartResult(
   const stopContextTimer = debugTime("context-inject");
   const systemContent = loadPrompt("system");
   const loadedPreferences = loadEffectiveGSDPreferences();
+  const { markCmuxPromptShown, shouldPromptToEnableCmux } = await import("../../cmux/index.js");
   if (shouldPromptToEnableCmux(loadedPreferences?.preferences)) {
     markCmuxPromptShown();
     ctx.ui.notify(

--- a/src/resources/extensions/gsd/commands-cmux.ts
+++ b/src/resources/extensions/gsd/commands-cmux.ts
@@ -1,6 +1,5 @@
 import type { ExtensionCommandContext } from "@gsd/pi-coding-agent";
 import { existsSync, readFileSync } from "node:fs";
-import { clearCmuxSidebar, CmuxClient, detectCmuxEnvironment, resolveCmuxConfig } from "../cmux/index.js";
 import { saveFile } from "./files.js";
 import {
   getProjectGSDPreferencesPath,
@@ -42,7 +41,9 @@ async function writeProjectCmuxPreferences(
   await ctx.reload();
 }
 
-function formatCmuxStatus(): string {
+async function formatCmuxStatus(): Promise<string> {
+  const { CmuxClient, detectCmuxEnvironment, resolveCmuxConfig } =
+    await import("../cmux/index.js");
   const loaded = loadEffectiveGSDPreferences();
   const detected = detectCmuxEnvironment();
   const resolved = resolveCmuxConfig(loaded?.preferences);
@@ -68,7 +69,8 @@ function formatCmuxStatus(): string {
   ].join("\n");
 }
 
-function ensureCmuxAvailableForEnable(ctx: ExtensionCommandContext): boolean {
+async function ensureCmuxAvailableForEnable(ctx: ExtensionCommandContext): Promise<boolean> {
+  const { detectCmuxEnvironment } = await import("../cmux/index.js");
   const detected = detectCmuxEnvironment();
   if (detected.available) return true;
   ctx.ui.notify(
@@ -81,12 +83,12 @@ function ensureCmuxAvailableForEnable(ctx: ExtensionCommandContext): boolean {
 export async function handleCmux(args: string, ctx: ExtensionCommandContext): Promise<void> {
   const trimmed = args.trim();
   if (!trimmed || trimmed === "status") {
-    ctx.ui.notify(formatCmuxStatus(), "info");
+    ctx.ui.notify(await formatCmuxStatus(), "info");
     return;
   }
 
   if (trimmed === "on") {
-    if (!ensureCmuxAvailableForEnable(ctx)) return;
+    if (!await ensureCmuxAvailableForEnable(ctx)) return;
     await writeProjectCmuxPreferences(ctx, (prefs) => {
       prefs.cmux = {
         enabled: true,
@@ -107,6 +109,7 @@ export async function handleCmux(args: string, ctx: ExtensionCommandContext): Pr
     await writeProjectCmuxPreferences(ctx, (prefs) => {
       prefs.cmux = { ...((prefs.cmux as Record<string, unknown> | undefined) ?? {}), enabled: false };
     });
+    const { clearCmuxSidebar } = await import("../cmux/index.js");
     clearCmuxSidebar(effective);
     ctx.ui.notify("cmux integration disabled in project preferences.", "info");
     return;
@@ -116,7 +119,7 @@ export async function handleCmux(args: string, ctx: ExtensionCommandContext): Pr
   if (parts.length === 2 && ["notifications", "sidebar", "splits", "browser"].includes(parts[0]) && ["on", "off"].includes(parts[1])) {
     const feature = parts[0] as "notifications" | "sidebar" | "splits" | "browser";
     const enabled = parts[1] === "on";
-    if (enabled && !ensureCmuxAvailableForEnable(ctx)) return;
+    if (enabled && !await ensureCmuxAvailableForEnable(ctx)) return;
 
     await writeProjectCmuxPreferences(ctx, (prefs) => {
       const next = { ...((prefs.cmux as Record<string, unknown> | undefined) ?? {}) };
@@ -126,6 +129,7 @@ export async function handleCmux(args: string, ctx: ExtensionCommandContext): Pr
     });
 
     if (!enabled && feature === "sidebar") {
+      const { clearCmuxSidebar } = await import("../cmux/index.js");
       clearCmuxSidebar(loadEffectiveGSDPreferences()?.preferences);
     }
 

--- a/src/resources/extensions/gsd/commands-extensions.ts
+++ b/src/resources/extensions/gsd/commands-extensions.ts
@@ -11,6 +11,7 @@ import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, 
 import { dirname, join, resolve } from "node:path";
 import { homedir, tmpdir } from "node:os";
 import { execFileSync } from "node:child_process";
+import semver from "semver";
 
 const gsdHome = process.env.GSD_HOME || join(homedir(), ".gsd");
 
@@ -318,6 +319,134 @@ function handleUninstall(id: string | undefined, ctx: ExtensionCommandContext): 
   ctx.ui.notify(`Uninstalled "${id}". Restart GSD to deactivate.`, "info");
 }
 
+// ─── Update subcommand ───────────────────────────────────────────────────────
+
+async function getLatestNpmVersion(packageName: string): Promise<string | null> {
+  try {
+    const res = await fetch(`https://registry.npmjs.org/${packageName}/latest`, {
+      signal: AbortSignal.timeout(5000),
+    });
+    if (!res.ok) return null;
+    const data = await res.json() as { version?: string };
+    return data.version ?? null;
+  } catch {
+    return null;
+  }
+}
+
+async function handleUpdate(id: string | undefined, ctx: ExtensionCommandContext): Promise<void> {
+  const registry = loadRegistry();
+
+  if (id) {
+    // Update single extension (D-12)
+    await updateSingleExtension(id, registry, ctx);
+  } else {
+    // Update all installed extensions (D-11)
+    await updateAllExtensions(registry, ctx);
+  }
+}
+
+async function updateSingleExtension(
+  id: string,
+  registry: ExtensionRegistry,
+  ctx: ExtensionCommandContext,
+): Promise<void> {
+  const entry = registry.entries[id];
+
+  if (!entry || entry.source !== "user") {
+    ctx.ui.notify(
+      `Extension "${id}" not found in registry. Run /gsd extensions list to see installed extensions.`,
+      "warning",
+    );
+    return;
+  }
+
+  // Git and local installs: "reinstall to update" hint (D-10, D-12)
+  if (entry.installType !== "npm") {
+    const source = entry.installType ?? "unknown";
+    const hint = entry.installedFrom ? `gsd extensions install ${entry.installedFrom}` : `gsd extensions install <specifier>`;
+    ctx.ui.notify(
+      `"${id}" was installed from ${source}. Reinstall to update: ${hint}`,
+      "warning",
+    );
+    return;
+  }
+
+  // npm extension: check for newer version (D-09)
+  const current = entry.version ?? "0.0.0";
+  const packageName = entry.installedFrom;
+  if (!packageName) {
+    ctx.ui.notify(`"${id}" has no recorded install source. Reinstall manually.`, "warning");
+    return;
+  }
+
+  const latest = await getLatestNpmVersion(packageName);
+  if (!latest) {
+    ctx.ui.notify(`Could not fetch latest version for "${id}".`, "warning");
+    return;
+  }
+
+  if (semver.gt(latest, current)) {
+    ctx.ui.notify(`Updating "${id}": v${current} → v${latest}...`, "info");
+    await handleInstall(packageName, ctx);
+  } else {
+    ctx.ui.notify(`"${id}" is already at the latest version (v${current}).`, "info");
+  }
+}
+
+async function updateAllExtensions(
+  registry: ExtensionRegistry,
+  ctx: ExtensionCommandContext,
+): Promise<void> {
+  // Find all user-installed extensions
+  const userEntries = Object.values(registry.entries).filter(e => e.source === "user");
+
+  if (userEntries.length === 0) {
+    ctx.ui.notify("No user-installed extensions found. Use: gsd extensions install <package> to add one.", "warning");
+    return;
+  }
+
+  ctx.ui.notify(`Checking ${userEntries.length} installed extension(s) for updates...`, "info");
+
+  let updated = 0;
+  let skipped = 0;
+
+  for (const entry of userEntries) {
+    // Skip non-npm installs (D-11)
+    if (entry.installType !== "npm") {
+      const source = entry.installType ?? "unknown";
+      ctx.ui.notify(`  ${entry.id}: installed from ${source} — reinstall to update`, "info");
+      skipped++;
+      continue;
+    }
+
+    const current = entry.version ?? "0.0.0";
+    const packageName = entry.installedFrom;
+    if (!packageName) {
+      ctx.ui.notify(`  ${entry.id}: no recorded install source — skip`, "info");
+      skipped++;
+      continue;
+    }
+
+    const latest = await getLatestNpmVersion(packageName);
+    if (!latest) {
+      ctx.ui.notify(`  ${entry.id}: could not fetch latest version — skip`, "info");
+      skipped++;
+      continue;
+    }
+
+    if (semver.gt(latest, current)) {
+      ctx.ui.notify(`  ${entry.id}: v${current} → v${latest} (updating)`, "info");
+      await handleInstall(packageName, ctx);
+      updated++;
+    } else {
+      ctx.ui.notify(`  ${entry.id}: v${current} (already up to date)`, "info");
+    }
+  }
+
+  ctx.ui.notify(`Updated ${updated} extension(s). ${skipped} skipped (git/local — reinstall to update).`, "info");
+}
+
 // ─── Install subcommand ──────────────────────────────────────────────────────
 
 async function handleInstall(specifier: string | undefined, ctx: ExtensionCommandContext): Promise<void> {
@@ -490,6 +619,11 @@ export async function handleExtensions(args: string, ctx: ExtensionCommandContex
     return;
   }
 
+  if (subCmd === "update") {
+    await handleUpdate(parts[1], ctx);
+    return;
+  }
+
   ctx.ui.notify(
     `Unknown: /gsd extensions ${subCmd}. Usage: /gsd extensions [list|enable|disable|info|install|uninstall|update]`,
     "warning",
@@ -531,6 +665,19 @@ function handleList(ctx: ExtensionCommandContext): void {
       padRight(String(toolCount), 7) +
       String(cmdCount),
     );
+
+    // Show source indicator and install info for user-installed extensions
+    const regEntry = registry.entries[m.id];
+    if (regEntry?.source === "user") {
+      // Append [user] tag to the last line
+      const lastLine = lines[lines.length - 1];
+      lines[lines.length - 1] = lastLine + "      [user]";
+      if (regEntry.installedFrom) {
+        const typePrefix = regEntry.installType ? `${regEntry.installType}:` : "";
+        const versionSuffix = regEntry.version ? `@${regEntry.version}` : "";
+        lines.push(`  installed from: ${typePrefix}${regEntry.installedFrom}${versionSuffix}`);
+      }
+    }
 
     if (!enabled) {
       lines.push(`  ↳ gsd extensions enable ${m.id}`);
@@ -644,6 +791,16 @@ function handleInfo(id: string | undefined, ctx: ExtensionCommandContext): void 
   }
   if (entry?.disabledReason) {
     lines.push(`  Reason:      ${entry.disabledReason}`);
+  }
+
+  // Phase 8 fields for user-installed extensions (per UI-SPEC)
+  if (entry?.source === "user") {
+    if (entry.installedFrom) {
+      lines.push(`  Installed from: ${entry.installedFrom}`);
+    }
+    if (entry.installType) {
+      lines.push(`  Install type:   ${entry.installType}`);
+    }
   }
 
   if (manifest.provides) {

--- a/src/resources/extensions/gsd/commands-extensions.ts
+++ b/src/resources/extensions/gsd/commands-extensions.ts
@@ -249,6 +249,75 @@ function postInstallValidate(
   return extensionId;
 }
 
+// ─── Uninstall helpers ───────────────────────────────────────────────────────
+
+/**
+ * Scan installed extensions to find which ones depend on the target ID.
+ * Used for dependency warning on uninstall (D-06).
+ */
+function findDependents(targetId: string, installedExtDir: string): string[] {
+  const dependents: string[] = [];
+  if (!existsSync(installedExtDir)) return dependents;
+  for (const entry of readdirSync(installedExtDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const manifest = readManifest(join(installedExtDir, entry.name));
+    if (!manifest) continue;
+    if (manifest.dependencies?.extensions?.includes(targetId)) {
+      dependents.push(manifest.id);
+    }
+  }
+  return dependents;
+}
+
+function handleUninstall(id: string | undefined, ctx: ExtensionCommandContext): void {
+  if (!id) {
+    ctx.ui.notify("Usage: /gsd extensions uninstall <id>", "warning");
+    return;
+  }
+
+  const registry = loadRegistry();
+  const entry = registry.entries[id];
+
+  // Check if extension exists and is user-installed
+  if (!entry || entry.source !== "user") {
+    ctx.ui.notify(
+      `Extension "${id}" not found in registry. Run /gsd extensions list to see installed extensions.`,
+      "warning",
+    );
+    return;
+  }
+
+  const installedExtDir = getInstalledExtDir();
+  const extDir = join(installedExtDir, id);
+
+  // Check for dependents and warn (D-06: warn-then-proceed)
+  const dependents = findDependents(id, installedExtDir);
+  if (dependents.length > 0) {
+    ctx.ui.notify(
+      `Warning: the following installed extensions depend on "${id}": ${dependents.join(", ")}. Removing anyway.`,
+      "warning",
+    );
+  }
+
+  // Remove directory first, then registry entry (Pitfall 4 from RESEARCH.md)
+  // If rm fails, do NOT remove registry entry — leaves a recoverable state
+  try {
+    if (existsSync(extDir)) {
+      rmSync(extDir, { recursive: true, force: true });
+    }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    ctx.ui.notify(`Failed to remove extension directory for "${id}": ${msg}`, "error");
+    return; // Do NOT remove registry entry — directory still exists
+  }
+
+  // Remove registry entry (D-07)
+  delete registry.entries[id];
+  saveRegistry(registry);
+
+  ctx.ui.notify(`Uninstalled "${id}". Restart GSD to deactivate.`, "info");
+}
+
 // ─── Install subcommand ──────────────────────────────────────────────────────
 
 async function handleInstall(specifier: string | undefined, ctx: ExtensionCommandContext): Promise<void> {
@@ -413,6 +482,11 @@ export async function handleExtensions(args: string, ctx: ExtensionCommandContex
 
   if (subCmd === "install") {
     await handleInstall(parts[1], ctx);
+    return;
+  }
+
+  if (subCmd === "uninstall") {
+    handleUninstall(parts[1], ctx);
     return;
   }
 

--- a/src/resources/extensions/gsd/commands-extensions.ts
+++ b/src/resources/extensions/gsd/commands-extensions.ts
@@ -1,15 +1,16 @@
 /**
  * GSD Extensions Command — /gsd extensions
  *
- * Manage the extension registry: list, enable, disable, info.
+ * Manage the extension registry: list, enable, disable, info, install.
  * Self-contained — no imports outside the extensions tree (extensions are loaded
  * via jiti at runtime from ~/.gsd/agent/, not compiled by tsc).
  */
 
 import type { ExtensionCommandContext } from "@gsd/pi-coding-agent";
-import { existsSync, mkdirSync, readFileSync, readdirSync, renameSync, writeFileSync } from "node:fs";
-import { dirname, join } from "node:path";
-import { homedir } from "node:os";
+import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { homedir, tmpdir } from "node:os";
+import { execFileSync } from "node:child_process";
 
 const gsdHome = process.env.GSD_HOME || join(homedir(), ".gsd");
 
@@ -40,6 +41,9 @@ interface ExtensionRegistryEntry {
   source: "bundled" | "user" | "project";
   disabledAt?: string;
   disabledReason?: string;
+  version?: string;
+  installedFrom?: string;
+  installType?: "npm" | "git" | "local";
 }
 
 interface ExtensionRegistry {
@@ -112,6 +116,275 @@ function discoverManifests(): Map<string, ExtensionManifest> {
   return manifests;
 }
 
+function getInstalledExtDir(): string {
+  return join(gsdHome, "extensions");
+}
+
+// Source: derived from npm/git URL conventions (from RESEARCH.md)
+function detectInstallType(specifier: string): "npm" | "git" | "local" {
+  if (
+    specifier.startsWith("/") ||
+    specifier.startsWith("./") ||
+    specifier.startsWith("../") ||
+    specifier.startsWith("~/")
+  ) return "local";
+  if (
+    specifier.startsWith("git+") ||
+    specifier.startsWith("git://") ||
+    specifier.startsWith("github:") ||
+    specifier.startsWith("gitlab:") ||
+    specifier.startsWith("bitbucket:") ||
+    (specifier.startsWith("https://") && specifier.endsWith(".git")) ||
+    (specifier.startsWith("http://") && specifier.endsWith(".git"))
+  ) return "git";
+  return "npm";
+}
+
+// ─── Validation (mirrored from extension-validator.ts) ──────────────────────
+
+interface ValidationError {
+  code: string;
+  message: string;
+  field?: string;
+}
+
+interface ValidationResult {
+  valid: boolean;
+  errors: ValidationError[];
+}
+
+function validateExtensionPackage(pkg: unknown, opts: { extensionId?: string; allowGsdNamespace?: boolean } = {}): ValidationResult {
+  const errors: ValidationError[] = [];
+
+  // Check gsd.extension === true (strict)
+  if (typeof pkg !== "object" || pkg === null) {
+    errors.push({ code: "MISSING_GSD_MARKER", message: 'package.json must declare "gsd": { "extension": true } to be recognized as a GSD extension.', field: "gsd.extension" });
+  } else {
+    const obj = pkg as Record<string, unknown>;
+    const gsd = obj.gsd;
+    if (typeof gsd !== "object" || gsd === null || (gsd as Record<string, unknown>).extension !== true) {
+      errors.push({ code: "MISSING_GSD_MARKER", message: 'package.json must declare "gsd": { "extension": true } to be recognized as a GSD extension.', field: "gsd.extension" });
+    }
+  }
+
+  // Check namespace reservation
+  if (opts.extensionId && opts.extensionId.startsWith("gsd.") && opts.allowGsdNamespace !== true) {
+    errors.push({ code: "RESERVED_NAMESPACE", message: `Extension ID "${opts.extensionId}" is reserved for GSD core extensions. Use a different namespace for community extensions.`, field: "extensionId" });
+  }
+
+  // Check dependency placement
+  if (typeof pkg === "object" && pkg !== null) {
+    const obj = pkg as Record<string, unknown>;
+    for (const field of ["dependencies", "devDependencies"] as const) {
+      const deps = obj[field];
+      if (typeof deps === "object" && deps !== null) {
+        for (const pkgName of Object.keys(deps as Record<string, unknown>)) {
+          if (pkgName.startsWith("@gsd/")) {
+            errors.push({ code: "WRONG_DEP_FIELD", message: `"${pkgName}" must not appear in "${field}". Move it to "peerDependencies".`, field });
+          }
+        }
+      }
+    }
+  }
+
+  return { valid: errors.length === 0, errors };
+}
+
+// ─── Post-install convergence ────────────────────────────────────────────────
+
+/**
+ * Post-install convergence: validate package, read manifest, write registry entry.
+ * All three install types (npm, git, local) call this after files are in place.
+ * Returns the extension ID on success, or null on failure (with error notified).
+ */
+function postInstallValidate(
+  destPath: string,
+  specifier: string,
+  installType: "npm" | "git" | "local",
+  ctx: ExtensionCommandContext,
+): string | null {
+  // Read package.json
+  const pkgJsonPath = join(destPath, "package.json");
+  if (!existsSync(pkgJsonPath)) {
+    ctx.ui.notify(`Cannot install "${specifier}": no package.json found.`, "error");
+    return null;
+  }
+  let pkgJson: Record<string, unknown>;
+  try {
+    pkgJson = JSON.parse(readFileSync(pkgJsonPath, "utf-8"));
+  } catch {
+    ctx.ui.notify(`Cannot install "${specifier}": malformed package.json.`, "error");
+    return null;
+  }
+
+  // Read extension-manifest.json for the ID
+  const manifest = readManifest(destPath);
+  const extensionId = manifest?.id;
+
+  // Validate
+  const validation = validateExtensionPackage(pkgJson, { extensionId });
+  if (!validation.valid) {
+    const msgs = validation.errors.map(e => e.message).join("\n");
+    ctx.ui.notify(`Cannot install "${specifier}": ${msgs}`, "error");
+    return null;
+  }
+
+  if (!manifest || !extensionId) {
+    ctx.ui.notify(`Cannot install "${specifier}": no extension-manifest.json with valid id found.`, "error");
+    return null;
+  }
+
+  // Write registry entry with source: "user" and Phase 8 fields
+  const registry = loadRegistry();
+  registry.entries[extensionId] = {
+    id: extensionId,
+    enabled: true,
+    source: "user",
+    version: manifest.version,
+    installedFrom: specifier,
+    installType,
+  };
+  saveRegistry(registry);
+
+  return extensionId;
+}
+
+// ─── Install subcommand ──────────────────────────────────────────────────────
+
+async function handleInstall(specifier: string | undefined, ctx: ExtensionCommandContext): Promise<void> {
+  if (!specifier) {
+    ctx.ui.notify("Usage: /gsd extensions install <npm-package|git-url|local-path>", "warning");
+    return;
+  }
+
+  const installType = detectInstallType(specifier);
+  const installedExtDir = getInstalledExtDir();
+  mkdirSync(installedExtDir, { recursive: true });
+
+  process.stderr.write(`Installing ${specifier}...\n`);
+
+  if (installType === "npm") {
+    installFromNpm(specifier, installedExtDir, ctx);
+  } else if (installType === "git") {
+    installFromGit(specifier, installedExtDir, ctx);
+  } else {
+    installFromLocal(specifier, installedExtDir, ctx);
+  }
+}
+
+function installFromNpm(specifier: string, installedExtDir: string, ctx: ExtensionCommandContext): void {
+  const packDir = mkdtempSync(join(tmpdir(), "gsd-install-"));
+  try {
+    // Step 1: npm pack to tmpdir (D-01, D-05)
+    execFileSync("npm", ["pack", specifier, "--pack-destination", packDir, "--ignore-scripts"], {
+      stdio: "pipe",
+      encoding: "utf-8",
+    });
+
+    // Step 2: Find the tarball
+    const tgzFile = readdirSync(packDir).find(f => f.endsWith(".tgz"));
+    if (!tgzFile) throw new Error("npm pack produced no tarball");
+
+    // Step 3: Extract via tar with --strip-components=1 (flat dir, no package/ wrapper)
+    const extractDir = join(packDir, "extracted");
+    mkdirSync(extractDir, { recursive: true });
+    execFileSync("tar", ["xzf", join(packDir, tgzFile), "-C", extractDir, "--strip-components=1"], { stdio: "pipe" });
+
+    // Step 4: Validate and get extension ID
+    const extensionId = postInstallValidate(extractDir, specifier, "npm", ctx);
+    if (!extensionId) {
+      return; // Error already notified
+    }
+
+    // Step 5: Move to final destination
+    const destPath = join(installedExtDir, extensionId);
+    if (existsSync(destPath)) {
+      rmSync(destPath, { recursive: true, force: true });
+    }
+    renameSync(extractDir, destPath);
+
+    // Step 6: Re-read manifest for version display
+    const manifest = readManifest(destPath);
+    const version = manifest?.version ?? "unknown";
+    ctx.ui.notify(`Installed "${extensionId}" v${version}. Restart GSD to activate.`, "info");
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    ctx.ui.notify(`Failed to install "${specifier}": ${msg}`, "error");
+  } finally {
+    rmSync(packDir, { recursive: true, force: true });
+  }
+}
+
+function installFromGit(gitUrl: string, installedExtDir: string, ctx: ExtensionCommandContext): void {
+  // Clone into temp dir, validate, then rename to real ID (D-02)
+  const tmpDir = join(installedExtDir, `__installing-${Date.now()}`);
+  try {
+    execFileSync("git", ["clone", "--depth=1", gitUrl, tmpDir], { stdio: "pipe" });
+
+    // Remove .git directory — not needed after clone
+    const dotGit = join(tmpDir, ".git");
+    if (existsSync(dotGit)) {
+      rmSync(dotGit, { recursive: true, force: true });
+    }
+
+    const extensionId = postInstallValidate(tmpDir, gitUrl, "git", ctx);
+    if (!extensionId) {
+      rmSync(tmpDir, { recursive: true, force: true });
+      return;
+    }
+
+    const destPath = join(installedExtDir, extensionId);
+    if (existsSync(destPath)) {
+      rmSync(destPath, { recursive: true, force: true });
+    }
+    renameSync(tmpDir, destPath);
+
+    const manifest = readManifest(destPath);
+    const version = manifest?.version ?? "unknown";
+    ctx.ui.notify(`Installed "${extensionId}" v${version}. Restart GSD to activate.`, "info");
+  } catch (err) {
+    if (existsSync(tmpDir)) rmSync(tmpDir, { recursive: true, force: true });
+    const msg = err instanceof Error ? err.message : String(err);
+    ctx.ui.notify(`Failed to install "${gitUrl}": ${msg}`, "error");
+  }
+}
+
+function installFromLocal(localPath: string, installedExtDir: string, ctx: ExtensionCommandContext): void {
+  // Resolve path and copy (not symlink) per D-03
+  const sourcePath = resolve(localPath.startsWith("~/") ? join(homedir(), localPath.slice(2)) : localPath);
+
+  if (!existsSync(sourcePath)) {
+    ctx.ui.notify(`Cannot install "${localPath}": path does not exist.`, "error");
+    return;
+  }
+
+  // Copy to temp dir first, validate, then rename
+  const tmpDir = join(installedExtDir, `__installing-${Date.now()}`);
+  try {
+    cpSync(sourcePath, tmpDir, { recursive: true });
+
+    const extensionId = postInstallValidate(tmpDir, localPath, "local", ctx);
+    if (!extensionId) {
+      rmSync(tmpDir, { recursive: true, force: true });
+      return;
+    }
+
+    const destPath = join(installedExtDir, extensionId);
+    if (existsSync(destPath)) {
+      rmSync(destPath, { recursive: true, force: true });
+    }
+    renameSync(tmpDir, destPath);
+
+    const manifest = readManifest(destPath);
+    const version = manifest?.version ?? "unknown";
+    ctx.ui.notify(`Installed "${extensionId}" v${version}. Restart GSD to activate.`, "info");
+  } catch (err) {
+    if (existsSync(tmpDir)) rmSync(tmpDir, { recursive: true, force: true });
+    const msg = err instanceof Error ? err.message : String(err);
+    ctx.ui.notify(`Failed to install "${localPath}": ${msg}`, "error");
+  }
+}
+
 // ─── Command Handler ────────────────────────────────────────────────────────
 
 export async function handleExtensions(args: string, ctx: ExtensionCommandContext): Promise<void> {
@@ -138,8 +411,13 @@ export async function handleExtensions(args: string, ctx: ExtensionCommandContex
     return;
   }
 
+  if (subCmd === "install") {
+    await handleInstall(parts[1], ctx);
+    return;
+  }
+
   ctx.ui.notify(
-    `Unknown: /gsd extensions ${subCmd}. Usage: /gsd extensions [list|enable|disable|info]`,
+    `Unknown: /gsd extensions ${subCmd}. Usage: /gsd extensions [list|enable|disable|info|install|uninstall|update]`,
     "warning",
   );
 }

--- a/src/resources/extensions/gsd/notifications.ts
+++ b/src/resources/extensions/gsd/notifications.ts
@@ -4,7 +4,6 @@
 import { execFileSync } from "node:child_process";
 import type { NotificationPreferences } from "./types.js";
 import { loadEffectiveGSDPreferences } from "./preferences.js";
-import { CmuxClient, emitOsc777Notification, resolveCmuxConfig } from "../cmux/index.js";
 
 export type NotifyLevel = "info" | "success" | "warning" | "error";
 export type NotificationKind = "complete" | "error" | "budget" | "milestone" | "attention";
@@ -27,20 +26,22 @@ export function sendDesktopNotification(
   const loaded = loadEffectiveGSDPreferences()?.preferences;
   if (!shouldSendDesktopNotification(kind, loaded?.notifications)) return;
 
-  const cmux = resolveCmuxConfig(loaded);
-  if (cmux.notifications) {
-    const delivered = CmuxClient.fromPreferences(loaded).notify(title, message);
-    if (delivered) return;
-    emitOsc777Notification(title, message);
-  }
+  void import("../cmux/index.js").then(({ CmuxClient, emitOsc777Notification, resolveCmuxConfig }) => {
+    const cmux = resolveCmuxConfig(loaded);
+    if (cmux.notifications) {
+      const delivered = CmuxClient.fromPreferences(loaded).notify(title, message);
+      if (delivered) return;
+      emitOsc777Notification(title, message);
+    }
 
-  try {
-    const command = buildDesktopNotificationCommand(process.platform, title, message, level);
-    if (!command) return;
-    execFileSync(command.file, command.args, { timeout: 3000, stdio: "ignore" });
-  } catch {
-    // Non-fatal — desktop notifications are best-effort
-  }
+    try {
+      const command = buildDesktopNotificationCommand(process.platform, title, message, level);
+      if (!command) return;
+      execFileSync(command.file, command.args, { timeout: 3000, stdio: "ignore" });
+    } catch {
+      // Non-fatal — desktop notifications are best-effort
+    }
+  });
 }
 
 export function shouldSendDesktopNotification(

--- a/src/resources/extensions/gsd/tests/cmux.test.ts
+++ b/src/resources/extensions/gsd/tests/cmux.test.ts
@@ -12,7 +12,7 @@ import {
   resolveCmuxConfig,
   shouldPromptToEnableCmux,
 } from "../../cmux/index.ts";
-import type { GSDState } from "../types.ts";
+import type { CmuxStateInput } from "../../shared/cmux-events.ts";
 
 test("detectCmuxEnvironment requires workspace, surface, and socket", () => {
   const detected = detectCmuxEnvironment(
@@ -80,15 +80,11 @@ test("shouldPromptToEnableCmux only prompts once per session", () => {
 });
 
 test("buildCmuxStatusLabel and progress prefer deepest active unit", () => {
-  const state: GSDState = {
-    activeMilestone: { id: "M001", title: "Milestone" },
-    activeSlice: { id: "S02", title: "Slice" },
-    activeTask: { id: "T03", title: "Task" },
+  const state: CmuxStateInput = {
+    activeMilestone: { id: "M001" },
+    activeSlice: { id: "S02" },
+    activeTask: { id: "T03" },
     phase: "executing",
-    recentDecisions: [],
-    blockers: [],
-    nextAction: "Keep going",
-    registry: [],
     progress: {
       milestones: { done: 0, total: 1 },
       slices: { done: 1, total: 3 },

--- a/src/resources/extensions/gsd/tests/milestone-transition-state-rebuild.test.ts
+++ b/src/resources/extensions/gsd/tests/milestone-transition-state-rebuild.test.ts
@@ -86,7 +86,7 @@ test("auto.ts buildLoopDeps wires rebuildState", () => {
   );
 
   // rebuildState should be in the LoopDeps object literal
-  const buildLoopDepsIdx = autoSrc.indexOf("function buildLoopDeps()");
+  const buildLoopDepsIdx = autoSrc.indexOf("function buildLoopDeps(");
   assert.ok(buildLoopDepsIdx > 0, "buildLoopDeps function should exist");
 
   const afterBuild = autoSrc.slice(buildLoopDepsIdx);

--- a/src/resources/extensions/shared/cmux-events.ts
+++ b/src/resources/extensions/shared/cmux-events.ts
@@ -1,0 +1,59 @@
+// GSD-2 — Shared cmux event channel contracts
+// Copyright (c) 2026 Jeremy McSpadden <jeremy@fluxlabs.net>
+
+/**
+ * Neutral event channel module for gsd<->cmux IPC.
+ * Both gsd and cmux import from here — neither imports the other directly.
+ * Per ADR-006 Phase 0: event-based decoupling.
+ */
+
+export const CMUX_CHANNELS = {
+  SIDEBAR: "cmux:sidebar",
+  LOG: "cmux:log",
+  LIFECYCLE: "cmux:lifecycle",
+} as const;
+
+/** Migrated from cmux/index.ts (D-07) — shared by both gsd and cmux. */
+export type CmuxLogLevel = "info" | "progress" | "success" | "warning" | "error";
+
+// ── Structural types (D-05): cmux defines only what it needs ──
+
+export interface CmuxPreferencesInput {
+  cmux?: {
+    enabled?: boolean;
+    notifications?: boolean;
+    sidebar?: boolean;
+    splits?: boolean;
+    browser?: boolean;
+  };
+}
+
+export interface CmuxStateInput {
+  phase: string;
+  activeMilestone?: { id: string };
+  activeSlice?: { id: string };
+  activeTask?: { id: string };
+  progress?: {
+    milestones: { done: number; total: number };
+    slices?: { done: number; total: number };
+    tasks?: { done: number; total: number };
+  };
+}
+
+// ── Event payloads ──
+
+export interface CmuxSidebarEvent {
+  action: "sync" | "clear";
+  preferences?: CmuxPreferencesInput;
+  state?: CmuxStateInput;
+}
+
+export interface CmuxLogEvent {
+  preferences?: CmuxPreferencesInput;
+  message: string;
+  level: CmuxLogLevel;
+}
+
+export interface CmuxLifecycleEvent {
+  action: "markPromptShown";
+}

--- a/src/resources/extensions/shared/cmux-events.ts
+++ b/src/resources/extensions/shared/cmux-events.ts
@@ -1,5 +1,4 @@
 // GSD-2 — Shared cmux event channel contracts
-// Copyright (c) 2026 Jeremy McSpadden <jeremy@fluxlabs.net>
 
 /**
  * Neutral event channel module for gsd<->cmux IPC.

--- a/src/resources/extensions/shared/rtk-session-stats.ts
+++ b/src/resources/extensions/shared/rtk-session-stats.ts
@@ -2,7 +2,6 @@ import { spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
-import { gsdRoot } from "../gsd/paths.js";
 import { formatTokenCount } from "./format-utils.js";
 import { buildRtkEnv, isRtkEnabled, resolveRtkBinaryPath } from "./rtk.js";
 
@@ -46,7 +45,7 @@ interface BaselineStore {
 let cachedSummary: { at: number; binaryPath: string; summary: RtkGainSummary | null } | null = null;
 
 function getRuntimeDir(basePath: string): string {
-  return join(gsdRoot(basePath), "runtime");
+  return join(basePath, ".gsd", "runtime");
 }
 
 function getBaselinesPath(basePath: string): string {

--- a/src/tests/extension-discovery.test.ts
+++ b/src/tests/extension-discovery.test.ts
@@ -1,9 +1,12 @@
+// GSD-2 — Extension Discovery Tests
+// Copyright (c) 2026 Jeremy McSpadden <jeremy@fluxlabs.net>
+
 import test, { describe } from 'node:test'
 import assert from 'node:assert/strict'
 import { mkdirSync, writeFileSync, rmSync } from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
-import { resolveExtensionEntries, discoverExtensionEntryPaths } from '../extension-discovery.ts'
+import { resolveExtensionEntries, discoverExtensionEntryPaths, mergeExtensionEntryPaths } from '../extension-discovery.ts'
 
 function makeTempDir(): string {
   const dir = join(tmpdir(), `ext-discovery-test-${Date.now()}-${Math.random().toString(36).slice(2)}`)
@@ -96,5 +99,109 @@ describe('discoverExtensionEntryPaths', () => {
     assert.equal(paths.length, 1, 'should discover my-ext but skip cmux')
     assert.ok(paths[0].includes('my-ext'))
     assert.ok(!paths.some(p => p.includes('cmux')), 'cmux should not be discovered')
+  })
+})
+
+describe('mergeExtensionEntryPaths', () => {
+  function makeManifest(id: string): string {
+    return JSON.stringify({ id, name: id, version: '1.0.0', description: 'test', tier: 'bundled', requires: { platform: 'node' } })
+  }
+
+  test('returns bundledPaths unchanged when installedExtDir does not exist', (t) => {
+    const nonExistent = join(tmpdir(), `nonexistent-${Date.now()}`)
+    const bundled = ['/fake/path/ext-a/index.ts']
+    const result = mergeExtensionEntryPaths(bundled, nonExistent)
+    assert.deepEqual(result, bundled)
+  })
+
+  test('returns bundledPaths unchanged when installedExtDir is empty', (t) => {
+    const installedDir = join(tmpdir(), `installed-empty-${Date.now()}`)
+    t.after(() => rmSync(installedDir, { recursive: true, force: true }))
+    mkdirSync(installedDir, { recursive: true })
+    const bundled = ['/fake/path/ext-a/index.ts']
+    const result = mergeExtensionEntryPaths(bundled, installedDir)
+    assert.deepEqual(result, bundled)
+  })
+
+  test('appends installed extension entries to bundled paths when IDs differ', (t) => {
+    const root = join(tmpdir(), `installed-additive-${Date.now()}`)
+    t.after(() => rmSync(root, { recursive: true, force: true }))
+
+    // Create installed extension with different ID
+    const installedDir = join(root, 'installed')
+    const newExtDir = join(installedDir, 'new-extension')
+    mkdirSync(newExtDir, { recursive: true })
+    writeFileSync(join(newExtDir, 'extension-manifest.json'), makeManifest('new-extension'))
+    writeFileSync(join(newExtDir, 'index.ts'), 'export default function() {}')
+
+    const bundled = ['/fake/bundled/ext-a/index.ts']
+    const result = mergeExtensionEntryPaths(bundled, installedDir)
+
+    assert.equal(result.length, 2, 'should have 1 bundled + 1 installed')
+    assert.ok(result.includes('/fake/bundled/ext-a/index.ts'), 'bundled entry should be preserved')
+    assert.ok(result.some(p => p.includes('new-extension')), 'installed extension should be appended')
+  })
+
+  test('removes bundled entry when installed extension has same manifest ID (LOADER-02 precedence)', (t) => {
+    const root = join(tmpdir(), `installed-shadow-${Date.now()}`)
+    t.after(() => rmSync(root, { recursive: true, force: true }))
+
+    // Create bundled extension (just a fake entry path pointing to a real location with manifest)
+    const bundledDir = join(root, 'bundled')
+    const bundledExtDir = join(bundledDir, 'my-ext')
+    mkdirSync(bundledExtDir, { recursive: true })
+    writeFileSync(join(bundledExtDir, 'extension-manifest.json'), makeManifest('my-ext'))
+    writeFileSync(join(bundledExtDir, 'index.ts'), 'export default function() {}')
+    const bundledEntryPath = join(bundledExtDir, 'index.ts')
+
+    // Create installed extension with same ID
+    const installedDir = join(root, 'installed')
+    const installedExtDir = join(installedDir, 'my-ext-installed')
+    mkdirSync(installedExtDir, { recursive: true })
+    writeFileSync(join(installedExtDir, 'extension-manifest.json'), makeManifest('my-ext'))
+    writeFileSync(join(installedExtDir, 'index.ts'), 'export default function() {}')
+
+    const result = mergeExtensionEntryPaths([bundledEntryPath], installedDir)
+
+    assert.equal(result.length, 1, 'only one entry: installed takes precedence over bundled')
+    assert.ok(!result.includes(bundledEntryPath), 'bundled entry should be excluded')
+    assert.ok(result.some(p => p.includes('my-ext-installed')), 'installed entry should be present')
+  })
+
+  test('handles multiple installed extensions, some shadowing, some additive', (t) => {
+    const root = join(tmpdir(), `installed-mixed-${Date.now()}`)
+    t.after(() => rmSync(root, { recursive: true, force: true }))
+
+    // Create two bundled extensions
+    const bundledDir = join(root, 'bundled')
+    const bundledExtA = join(bundledDir, 'ext-a')
+    const bundledExtB = join(bundledDir, 'ext-b')
+    mkdirSync(bundledExtA, { recursive: true })
+    mkdirSync(bundledExtB, { recursive: true })
+    writeFileSync(join(bundledExtA, 'extension-manifest.json'), makeManifest('ext-a'))
+    writeFileSync(join(bundledExtA, 'index.ts'), 'export default function() {}')
+    writeFileSync(join(bundledExtB, 'extension-manifest.json'), makeManifest('ext-b'))
+    writeFileSync(join(bundledExtB, 'index.ts'), 'export default function() {}')
+    const bundledPathA = join(bundledExtA, 'index.ts')
+    const bundledPathB = join(bundledExtB, 'index.ts')
+
+    // Create installed extensions: one shadows ext-a, one is new
+    const installedDir = join(root, 'installed')
+    const installedExtA = join(installedDir, 'ext-a-installed')
+    const installedExtNew = join(installedDir, 'ext-new')
+    mkdirSync(installedExtA, { recursive: true })
+    mkdirSync(installedExtNew, { recursive: true })
+    writeFileSync(join(installedExtA, 'extension-manifest.json'), makeManifest('ext-a'))
+    writeFileSync(join(installedExtA, 'index.ts'), 'export default function() {}')
+    writeFileSync(join(installedExtNew, 'extension-manifest.json'), makeManifest('ext-new'))
+    writeFileSync(join(installedExtNew, 'index.ts'), 'export default function() {}')
+
+    const result = mergeExtensionEntryPaths([bundledPathA, bundledPathB], installedDir)
+
+    assert.equal(result.length, 3, 'ext-b preserved, ext-a-installed and ext-new added')
+    assert.ok(!result.includes(bundledPathA), 'bundled ext-a should be shadowed')
+    assert.ok(result.includes(bundledPathB), 'bundled ext-b should be preserved')
+    assert.ok(result.some(p => p.includes('ext-a-installed')), 'installed ext-a should replace bundled')
+    assert.ok(result.some(p => p.includes('ext-new')), 'new installed ext should be added')
   })
 })

--- a/src/tests/extension-discovery.test.ts
+++ b/src/tests/extension-discovery.test.ts
@@ -81,6 +81,22 @@ describe('resolveExtensionEntries', () => {
 })
 
 describe('discoverExtensionEntryPaths', () => {
+  test('falls back to index.ts detection when extension directory has malformed package.json', (t) => {
+    const root = makeTempDir()
+    t.after(() => rmSync(root, { recursive: true, force: true }))
+
+    const extDir = join(root, 'malformed-ext')
+    mkdirSync(extDir)
+    // Write deliberately invalid JSON — resolveExtensionEntries catches the parse error and falls through
+    writeFileSync(join(extDir, 'package.json'), '{ "pi": { INVALID')
+    writeFileSync(join(extDir, 'index.ts'), 'export default function() {}')
+
+    const paths = discoverExtensionEntryPaths(root)
+    assert.equal(paths.length, 1, 'should discover the extension via index.ts fallback')
+    assert.ok(paths[0].includes('malformed-ext'), 'discovered path should be from malformed-ext')
+    assert.ok(paths[0].endsWith('index.ts'), 'should have fallen back to index.ts')
+  })
+
   test('skips library directories with pi: {} opt-out', (t) => {
     const root = makeTempDir()
     t.after(() => rmSync(root, { recursive: true, force: true }));
@@ -166,6 +182,39 @@ describe('mergeExtensionEntryPaths', () => {
     assert.equal(result.length, 1, 'only one entry: installed takes precedence over bundled')
     assert.ok(!result.includes(bundledEntryPath), 'bundled entry should be excluded')
     assert.ok(result.some(p => p.includes('my-ext-installed')), 'installed entry should be present')
+  })
+
+  test('silently skips installed extension with corrupt/unreadable manifest (invalid JSON)', (t) => {
+    const root = join(tmpdir(), `installed-corrupt-manifest-${Date.now()}`)
+    t.after(() => rmSync(root, { recursive: true, force: true }))
+
+    const installedDir = join(root, 'installed')
+    const corruptExtDir = join(installedDir, 'corrupt-ext')
+    mkdirSync(corruptExtDir, { recursive: true })
+    // Write deliberately invalid JSON to extension-manifest.json
+    writeFileSync(join(corruptExtDir, 'extension-manifest.json'), '{ "id": "corrupt-ext" INVALID JSON')
+    writeFileSync(join(corruptExtDir, 'index.ts'), 'export default function() {}')
+
+    const bundled = ['/fake/bundled/ext-a/index.ts']
+    const result = mergeExtensionEntryPaths(bundled, installedDir)
+
+    assert.deepEqual(result, bundled, 'corrupt manifest should be silently skipped, bundled paths unchanged')
+  })
+
+  test('skips installed extension directory with no index.ts/index.js even if manifest is valid', (t) => {
+    const root = join(tmpdir(), `installed-no-entries-${Date.now()}`)
+    t.after(() => rmSync(root, { recursive: true, force: true }))
+
+    const installedDir = join(root, 'installed')
+    const emptyExtDir = join(installedDir, 'empty-ext')
+    mkdirSync(emptyExtDir, { recursive: true })
+    // Valid manifest but no index.ts/index.js
+    writeFileSync(join(emptyExtDir, 'extension-manifest.json'), makeManifest('empty-ext'))
+
+    const bundled = ['/fake/bundled/ext-a/index.ts']
+    const result = mergeExtensionEntryPaths(bundled, installedDir)
+
+    assert.deepEqual(result, bundled, 'extension with no entry files should be skipped even if manifest is valid')
   })
 
   test('handles multiple installed extensions, some shadowing, some additive', (t) => {

--- a/src/tests/extension-discovery.test.ts
+++ b/src/tests/extension-discovery.test.ts
@@ -1,5 +1,4 @@
 // GSD-2 — Extension Discovery Tests
-// Copyright (c) 2026 Jeremy McSpadden <jeremy@fluxlabs.net>
 
 import test, { describe } from 'node:test'
 import assert from 'node:assert/strict'

--- a/src/tests/extension-sort.test.ts
+++ b/src/tests/extension-sort.test.ts
@@ -1,5 +1,4 @@
 // GSD-2 — Extension Sort Tests
-// Copyright (c) 2026 Jeremy McSpadden <jeremy@fluxlabs.net>
 
 import test, { describe } from 'node:test'
 import assert from 'node:assert/strict'

--- a/src/tests/extension-sort.test.ts
+++ b/src/tests/extension-sort.test.ts
@@ -193,4 +193,123 @@ describe('sortExtensionPaths', () => {
     const bIdx = result.sortedPaths.indexOf(pathB)
     assert.ok(aIdx < bIdx, 'A must be before B (dependency order)')
   })
+
+  test('Test 9: string deps instead of array — treated as empty, no crash, extension in output', (t) => {
+    const dir = makeTempDir()
+    t.after(() => rmSync(dir, { recursive: true, force: true }))
+
+    const extDir = join(dir, 'bad.deps')
+    mkdirSync(extDir, { recursive: true })
+    writeFileSync(join(extDir, 'extension-manifest.json'), JSON.stringify({
+      id: 'bad.deps', name: 'bad.deps', version: '1.0.0',
+      description: 'test', tier: 'bundled', requires: { platform: 'node' },
+      dependencies: { extensions: 'not-an-array' }
+    }))
+    writeFileSync(join(extDir, 'index.ts'), 'export default function() {}')
+    const pathBadDeps = join(extDir, 'index.ts')
+
+    const result = sortExtensionPaths([pathBadDeps])
+
+    assert.equal(result.warnings.length, 0, 'no warnings expected for string deps')
+    assert.equal(result.sortedPaths.length, 1, 'extension still in output')
+    assert.ok(result.sortedPaths.includes(pathBadDeps), 'pathBadDeps in output')
+  })
+
+  test('Test 10: null deps — treated as empty, no crash, extension in output', (t) => {
+    const dir = makeTempDir()
+    t.after(() => rmSync(dir, { recursive: true, force: true }))
+
+    const extDir = join(dir, 'null.deps')
+    mkdirSync(extDir, { recursive: true })
+    writeFileSync(join(extDir, 'extension-manifest.json'), JSON.stringify({
+      id: 'null.deps', name: 'null.deps', version: '1.0.0',
+      description: 'test', tier: 'bundled', requires: { platform: 'node' },
+      dependencies: { extensions: null }
+    }))
+    writeFileSync(join(extDir, 'index.ts'), 'export default function() {}')
+    const pathNullDeps = join(extDir, 'index.ts')
+
+    const result = sortExtensionPaths([pathNullDeps])
+
+    assert.equal(result.warnings.length, 0, 'no warnings expected for null deps')
+    assert.equal(result.sortedPaths.length, 1, 'extension still in output')
+    assert.ok(result.sortedPaths.includes(pathNullDeps), 'pathNullDeps in output')
+  })
+
+  test('Test 11: numeric deps — treated as empty, no crash, extension in output', (t) => {
+    const dir = makeTempDir()
+    t.after(() => rmSync(dir, { recursive: true, force: true }))
+
+    const extDir = join(dir, 'num.deps')
+    mkdirSync(extDir, { recursive: true })
+    writeFileSync(join(extDir, 'extension-manifest.json'), JSON.stringify({
+      id: 'num.deps', name: 'num.deps', version: '1.0.0',
+      description: 'test', tier: 'bundled', requires: { platform: 'node' },
+      dependencies: { extensions: 42 }
+    }))
+    writeFileSync(join(extDir, 'index.ts'), 'export default function() {}')
+    const pathNumDeps = join(extDir, 'index.ts')
+
+    const result = sortExtensionPaths([pathNumDeps])
+
+    assert.equal(result.warnings.length, 0, 'no warnings expected for numeric deps')
+    assert.equal(result.sortedPaths.length, 1, 'extension still in output')
+    assert.ok(result.sortedPaths.includes(pathNumDeps), 'pathNumDeps in output')
+  })
+
+  test('Test 12: chain with missing middle — A depends on B, B depends on missing C', (t) => {
+    const dir = makeTempDir()
+    t.after(() => rmSync(dir, { recursive: true, force: true }))
+
+    const pathA = makeExtension(dir, 'chain.mid.a', ['chain.mid.b'])
+    const pathB = makeExtension(dir, 'chain.mid.b', ['chain.mid.c']) // C is not installed
+
+    const result = sortExtensionPaths([pathA, pathB])
+
+    // Missing dep warning for B→C
+    assert.equal(result.warnings.length, 1, 'one missing dep warning for B→C')
+    assert.equal(result.warnings[0].declaringId, 'chain.mid.b')
+    assert.equal(result.warnings[0].missingId, 'chain.mid.c')
+
+    // No cycle warning
+    const hasCycleWarning = result.warnings.some(w => w.message.includes('form a dependency cycle'))
+    assert.ok(!hasCycleWarning, 'no cycle warning expected')
+
+    // Both A and B in output
+    assert.equal(result.sortedPaths.length, 2)
+    assert.ok(result.sortedPaths.includes(pathA), 'pathA in output')
+    assert.ok(result.sortedPaths.includes(pathB), 'pathB in output')
+
+    // B before A (B is a dependency of A)
+    const aIdx = result.sortedPaths.indexOf(pathA)
+    const bIdx = result.sortedPaths.indexOf(pathB)
+    assert.ok(bIdx < aIdx, 'B must appear before A')
+  })
+
+  test('Test 13: duplicate dependency declarations — A declares B twice, no double-counting', (t) => {
+    const dir = makeTempDir()
+    t.after(() => rmSync(dir, { recursive: true, force: true }))
+
+    const pathB = makeExtension(dir, 'dup.b')
+    const pathA = makeExtension(dir, 'dup.a', ['dup.b', 'dup.b'])
+
+    const result = sortExtensionPaths([pathA, pathB])
+
+    // B before A
+    assert.equal(result.sortedPaths.length, 2)
+    const aIdx = result.sortedPaths.indexOf(pathA)
+    const bIdx = result.sortedPaths.indexOf(pathB)
+    assert.ok(bIdx < aIdx, 'B must appear before A')
+
+    // No cycle warning
+    const hasCycleWarning = result.warnings.some(w => w.message.includes('form a dependency cycle'))
+    assert.ok(!hasCycleWarning, 'no cycle warning expected for duplicate deps')
+  })
+
+  test('Test 14: empty paths array — returns empty result with no warnings', (_t) => {
+    const result = sortExtensionPaths([])
+
+    assert.equal(result.warnings.length, 0, 'no warnings for empty input')
+    assert.equal(result.sortedPaths.length, 0, 'no paths in output')
+  })
 })

--- a/src/tests/extension-sort.test.ts
+++ b/src/tests/extension-sort.test.ts
@@ -1,0 +1,196 @@
+// GSD-2 — Extension Sort Tests
+// Copyright (c) 2026 Jeremy McSpadden <jeremy@fluxlabs.net>
+
+import test, { describe } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdirSync, writeFileSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { sortExtensionPaths } from '../extension-sort.ts'
+
+function makeTempDir(): string {
+  const dir = join(tmpdir(), `ext-sort-test-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+  mkdirSync(dir, { recursive: true })
+  return dir
+}
+
+function makeExtension(baseDir: string, id: string, deps?: string[]): string {
+  const extDir = join(baseDir, id)
+  mkdirSync(extDir, { recursive: true })
+  const manifest = {
+    id,
+    name: id,
+    version: '1.0.0',
+    description: 'test extension',
+    tier: 'bundled',
+    requires: { platform: 'node' },
+    ...(deps && deps.length > 0 ? { dependencies: { extensions: deps } } : {}),
+  }
+  writeFileSync(join(extDir, 'extension-manifest.json'), JSON.stringify(manifest))
+  writeFileSync(join(extDir, 'index.ts'), `export default function() {}`)
+  return join(extDir, 'index.ts')
+}
+
+describe('sortExtensionPaths', () => {
+  test('Test 1: no deps — returns alphabetically sorted by ID, zero warnings', (t) => {
+    const dir = makeTempDir()
+    t.after(() => rmSync(dir, { recursive: true, force: true }))
+
+    const pathC = makeExtension(dir, 'test.c')
+    const pathA = makeExtension(dir, 'test.a')
+    const pathB = makeExtension(dir, 'test.b')
+
+    const result = sortExtensionPaths([pathC, pathA, pathB])
+
+    assert.equal(result.warnings.length, 0, 'no warnings expected')
+    assert.equal(result.sortedPaths.length, 3)
+    // A before B before C
+    const ids = result.sortedPaths.map(p => {
+      const parts = p.split('/')
+      return parts[parts.length - 2]
+    })
+    assert.deepEqual(ids, ['test.a', 'test.b', 'test.c'])
+  })
+
+  test('Test 2: linear chain — B depends on A, A appears before B', (t) => {
+    const dir = makeTempDir()
+    t.after(() => rmSync(dir, { recursive: true, force: true }))
+
+    const pathA = makeExtension(dir, 'chain.a')
+    const pathB = makeExtension(dir, 'chain.b', ['chain.a'])
+
+    const result = sortExtensionPaths([pathB, pathA])
+
+    assert.equal(result.warnings.length, 0, 'no warnings expected')
+    assert.equal(result.sortedPaths.length, 2)
+    const aIdx = result.sortedPaths.indexOf(pathA)
+    const bIdx = result.sortedPaths.indexOf(pathB)
+    assert.ok(aIdx < bIdx, 'A must appear before B')
+  })
+
+  test('Test 3: diamond — D depends on B and C; B and C depend on A → A first, B/C alphabetically, then D', (t) => {
+    const dir = makeTempDir()
+    t.after(() => rmSync(dir, { recursive: true, force: true }))
+
+    const pathA = makeExtension(dir, 'diamond.a')
+    const pathB = makeExtension(dir, 'diamond.b', ['diamond.a'])
+    const pathC = makeExtension(dir, 'diamond.c', ['diamond.a'])
+    const pathD = makeExtension(dir, 'diamond.d', ['diamond.b', 'diamond.c'])
+
+    const result = sortExtensionPaths([pathD, pathC, pathB, pathA])
+
+    assert.equal(result.warnings.length, 0, 'no warnings expected')
+    assert.equal(result.sortedPaths.length, 4)
+    const sorted = result.sortedPaths
+    const aIdx = sorted.indexOf(pathA)
+    const bIdx = sorted.indexOf(pathB)
+    const cIdx = sorted.indexOf(pathC)
+    const dIdx = sorted.indexOf(pathD)
+
+    assert.ok(aIdx < bIdx, 'A must be before B')
+    assert.ok(aIdx < cIdx, 'A must be before C')
+    assert.ok(bIdx < dIdx, 'B must be before D')
+    assert.ok(cIdx < dIdx, 'C must be before D')
+    assert.ok(bIdx < cIdx, 'B before C alphabetically')
+  })
+
+  test('Test 4: missing dep — warns with correct format, extension still in output', (t) => {
+    const dir = makeTempDir()
+    t.after(() => rmSync(dir, { recursive: true, force: true }))
+
+    const pathA = makeExtension(dir, 'test.a', ['gsd.nonexistent'])
+
+    const result = sortExtensionPaths([pathA])
+
+    assert.equal(result.sortedPaths.length, 1, 'A still in output')
+    assert.ok(result.sortedPaths.includes(pathA), 'pathA in sorted output')
+    assert.equal(result.warnings.length, 1, 'one warning for missing dep')
+    const w = result.warnings[0]
+    assert.equal(w.declaringId, 'test.a')
+    assert.equal(w.missingId, 'gsd.nonexistent')
+    assert.equal(w.message, "Extension 'test.a' declares dependency 'gsd.nonexistent' which is not installed — loading anyway")
+  })
+
+  test('Test 5: cycle — A depends on B, B depends on A → both loaded, cycle warnings emitted, appended alphabetically', (t) => {
+    const dir = makeTempDir()
+    t.after(() => rmSync(dir, { recursive: true, force: true }))
+
+    const pathA = makeExtension(dir, 'cycle.a', ['cycle.b'])
+    const pathB = makeExtension(dir, 'cycle.b', ['cycle.a'])
+
+    const result = sortExtensionPaths([pathA, pathB])
+
+    assert.equal(result.sortedPaths.length, 2, 'both extensions in output')
+    assert.ok(result.sortedPaths.includes(pathA), 'pathA in output')
+    assert.ok(result.sortedPaths.includes(pathB), 'pathB in output')
+    assert.ok(result.warnings.length > 0, 'cycle warnings emitted')
+    const hasCycleWarning = result.warnings.some(w => w.message.includes('form a dependency cycle'))
+    assert.ok(hasCycleWarning, 'cycle warning with correct format')
+    // Appended alphabetically: cycle.a before cycle.b
+    const aIdx = result.sortedPaths.indexOf(pathA)
+    const bIdx = result.sortedPaths.indexOf(pathB)
+    assert.ok(aIdx < bIdx, 'cycle participants appended alphabetically')
+  })
+
+  test('Test 6: self-dep — A declares dependency on itself → no warning, A still in output', (t) => {
+    const dir = makeTempDir()
+    t.after(() => rmSync(dir, { recursive: true, force: true }))
+
+    const pathA = makeExtension(dir, 'self.a', ['self.a'])
+
+    const result = sortExtensionPaths([pathA])
+
+    assert.equal(result.sortedPaths.length, 1, 'A still in output')
+    assert.ok(result.sortedPaths.includes(pathA), 'pathA in output')
+    assert.equal(result.warnings.length, 0, 'no warnings for self-dep')
+  })
+
+  test('Test 7: no manifest — paths without extension-manifest.json prepended in input order, zero warnings', (t) => {
+    const dir = makeTempDir()
+    t.after(() => rmSync(dir, { recursive: true, force: true }))
+
+    // Create two paths without manifests
+    const noManifestA = join(dir, 'no-manifest-a', 'index.ts')
+    const noManifestB = join(dir, 'no-manifest-b', 'index.ts')
+    mkdirSync(join(dir, 'no-manifest-a'), { recursive: true })
+    mkdirSync(join(dir, 'no-manifest-b'), { recursive: true })
+    writeFileSync(noManifestA, 'export default function() {}')
+    writeFileSync(noManifestB, 'export default function() {}')
+
+    const result = sortExtensionPaths([noManifestA, noManifestB])
+
+    assert.equal(result.warnings.length, 0, 'no warnings expected')
+    assert.equal(result.sortedPaths.length, 2)
+    // Input order preserved
+    assert.equal(result.sortedPaths[0], noManifestA)
+    assert.equal(result.sortedPaths[1], noManifestB)
+  })
+
+  test('Test 8: mixed — no-manifest paths first (input order), then topologically sorted manifest paths', (t) => {
+    const dir = makeTempDir()
+    t.after(() => rmSync(dir, { recursive: true, force: true }))
+
+    // No-manifest paths
+    const noManifestX = join(dir, 'no-manifest-x', 'index.ts')
+    mkdirSync(join(dir, 'no-manifest-x'), { recursive: true })
+    writeFileSync(noManifestX, 'export default function() {}')
+
+    // Manifest paths: B depends on A
+    const pathA = makeExtension(dir, 'mixed.a')
+    const pathB = makeExtension(dir, 'mixed.b', ['mixed.a'])
+
+    // Input order: noManifestX, pathB (dependent), pathA (dependency)
+    const result = sortExtensionPaths([noManifestX, pathB, pathA])
+
+    assert.equal(result.warnings.length, 0, 'no warnings expected')
+    assert.equal(result.sortedPaths.length, 3)
+
+    // no-manifest first
+    assert.equal(result.sortedPaths[0], noManifestX, 'no-manifest path must be first')
+
+    // then dependency-ordered manifests: A before B
+    const aIdx = result.sortedPaths.indexOf(pathA)
+    const bIdx = result.sortedPaths.indexOf(pathB)
+    assert.ok(aIdx < bIdx, 'A must be before B (dependency order)')
+  })
+})

--- a/src/tests/extension-validator.test.ts
+++ b/src/tests/extension-validator.test.ts
@@ -1,5 +1,4 @@
 // GSD-2 — Extension Validator Tests
-// Copyright (c) 2026 Jeremy McSpadden <jeremy@fluxlabs.net>
 
 import test, { describe } from 'node:test'
 import assert from 'node:assert/strict'

--- a/src/tests/extension-validator.test.ts
+++ b/src/tests/extension-validator.test.ts
@@ -1,0 +1,159 @@
+// GSD-2 — Extension Validator Tests
+// Copyright (c) 2026 Jeremy McSpadden <jeremy@fluxlabs.net>
+
+import test, { describe } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  checkInstallDiscriminator,
+  checkNamespaceReservation,
+  checkDependencyPlacement,
+  validateExtensionPackage,
+} from '../extension-validator.ts'
+
+describe('checkInstallDiscriminator', () => {
+  test('returns null for valid gsd.extension === true', () => {
+    const result = checkInstallDiscriminator({ gsd: { extension: true }, pi: { extensions: ['./index.ts'] } })
+    assert.equal(result, null)
+  })
+
+  test('returns error when gsd section is missing', () => {
+    const result = checkInstallDiscriminator({ pi: { extensions: ['./index.ts'] } })
+    assert.ok(result !== null)
+    assert.equal(result.code, 'MISSING_GSD_MARKER')
+    assert.equal(result.field, 'gsd.extension')
+  })
+
+  test('returns error when gsd.extension is number 1 (not boolean true)', () => {
+    const result = checkInstallDiscriminator({ gsd: { extension: 1 } })
+    assert.ok(result !== null)
+    assert.equal(result.code, 'MISSING_GSD_MARKER', 'strict === true check must reject numeric 1')
+  })
+
+  test("returns error when gsd.extension is string 'true'", () => {
+    const result = checkInstallDiscriminator({ gsd: { extension: 'true' } })
+    assert.ok(result !== null)
+    assert.equal(result.code, 'MISSING_GSD_MARKER', "strict === true check must reject string 'true'")
+  })
+
+  test('returns error for null input', () => {
+    const result = checkInstallDiscriminator(null)
+    assert.ok(result !== null)
+    assert.equal(result.code, 'MISSING_GSD_MARKER')
+  })
+})
+
+describe('checkNamespaceReservation', () => {
+  test('returns error for gsd. prefixed extension ID', () => {
+    const result = checkNamespaceReservation('gsd.my-tool', {})
+    assert.ok(result !== null)
+    assert.equal(result.code, 'RESERVED_NAMESPACE')
+    assert.ok(result.message.includes('gsd.my-tool'), 'error message should name the conflicting ID')
+  })
+
+  test('returns null when allowGsdNamespace is true', () => {
+    const result = checkNamespaceReservation('gsd.my-tool', { allowGsdNamespace: true })
+    assert.equal(result, null)
+  })
+
+  test('returns null for non-gsd namespace', () => {
+    const result = checkNamespaceReservation('acme.my-tool', {})
+    assert.equal(result, null)
+  })
+
+  test('returns null for bare extension ID', () => {
+    const result = checkNamespaceReservation('my-tool', {})
+    assert.equal(result, null)
+  })
+})
+
+describe('checkDependencyPlacement', () => {
+  test('returns error for @gsd/ package in dependencies', () => {
+    const errors = checkDependencyPlacement({ dependencies: { '@gsd/pi-coding-agent': '^2.0.0' } })
+    assert.equal(errors.length, 1)
+    assert.equal(errors[0].code, 'WRONG_DEP_FIELD')
+    assert.ok(errors[0].message.includes('@gsd/pi-coding-agent'), 'message must name exact package')
+    assert.ok(errors[0].message.includes('dependencies'), 'message must name exact field')
+    assert.ok(errors[0].message.includes('peerDependencies'), 'message must suggest the fix')
+    assert.equal(errors[0].field, 'dependencies')
+  })
+
+  test('returns error for @gsd/ package in devDependencies', () => {
+    const errors = checkDependencyPlacement({ devDependencies: { '@gsd/pi-ai': '^1.0.0' } })
+    assert.equal(errors.length, 1)
+    assert.equal(errors[0].code, 'WRONG_DEP_FIELD')
+    assert.ok(errors[0].message.includes('@gsd/pi-ai'), 'message must name exact package')
+    assert.ok(errors[0].message.includes('devDependencies'), 'message must name exact field')
+    assert.equal(errors[0].field, 'devDependencies')
+  })
+
+  test('does not flag @gsd/ in peerDependencies', () => {
+    const errors = checkDependencyPlacement({ peerDependencies: { '@gsd/pi-coding-agent': '>=2.50.0' } })
+    assert.equal(errors.length, 0, 'peerDependencies is the correct placement — must not be flagged')
+  })
+
+  test('returns multiple errors for violations in both dependencies and devDependencies', () => {
+    const errors = checkDependencyPlacement({
+      dependencies: { '@gsd/pi-coding-agent': '^2.0.0' },
+      devDependencies: { '@gsd/pi-ai': '^1.0.0' },
+    })
+    assert.equal(errors.length, 2)
+    const fields = errors.map(e => e.field)
+    assert.ok(fields.includes('dependencies'))
+    assert.ok(fields.includes('devDependencies'))
+  })
+
+  test('does not flag non-gsd packages', () => {
+    const errors = checkDependencyPlacement({ dependencies: { 'lodash': '^4.0.0' } })
+    assert.equal(errors.length, 0)
+  })
+
+  test('handles missing dependency fields', () => {
+    const errors = checkDependencyPlacement({})
+    assert.equal(errors.length, 0)
+  })
+})
+
+describe('validateExtensionPackage', () => {
+  test('returns valid for conforming package', () => {
+    const result = validateExtensionPackage(
+      { gsd: { extension: true }, peerDependencies: { '@gsd/pi-coding-agent': '>=2.50.0' } },
+      { extensionId: 'acme.browser' }
+    )
+    assert.equal(result.valid, true)
+    assert.deepEqual(result.errors, [])
+    assert.deepEqual(result.warnings, [])
+  })
+
+  test('aggregates errors from multiple checks', () => {
+    const result = validateExtensionPackage(
+      { dependencies: { '@gsd/pi-ai': '^1.0.0' } },
+      { extensionId: 'gsd.bad' }
+    )
+    assert.equal(result.valid, false)
+    // Expects at least: MISSING_GSD_MARKER + RESERVED_NAMESPACE + WRONG_DEP_FIELD
+    assert.ok(result.errors.length >= 3, `expected >= 3 errors, got ${result.errors.length}: ${JSON.stringify(result.errors.map(e => e.code))}`)
+    const codes = result.errors.map(e => e.code)
+    assert.ok(codes.includes('MISSING_GSD_MARKER'))
+    assert.ok(codes.includes('RESERVED_NAMESPACE'))
+    assert.ok(codes.includes('WRONG_DEP_FIELD'))
+  })
+
+  test('valid is always errors.length === 0', () => {
+    const validPkg = { gsd: { extension: true } }
+    const validResult = validateExtensionPackage(validPkg, { extensionId: 'acme.tool' })
+    assert.equal(validResult.valid, true)
+    assert.equal(validResult.errors.length, 0)
+
+    const invalidPkg = { gsd: { extension: 1 } }
+    const invalidResult = validateExtensionPackage(invalidPkg, { extensionId: 'acme.tool' })
+    assert.equal(invalidResult.valid, false)
+    assert.ok(invalidResult.errors.length > 0)
+  })
+
+  test('adds warning when extensionId is not provided', () => {
+    const result = validateExtensionPackage({ gsd: { extension: true } }, {})
+    assert.equal(result.valid, true)
+    assert.equal(result.warnings.length, 1)
+    assert.equal(result.warnings[0].code, 'NAMESPACE_CHECK_SKIPPED')
+  })
+})

--- a/src/tests/extension-validator.test.ts
+++ b/src/tests/extension-validator.test.ts
@@ -40,6 +40,25 @@ describe('checkInstallDiscriminator', () => {
     assert.ok(result !== null)
     assert.equal(result.code, 'MISSING_GSD_MARKER')
   })
+
+  test('returns error when gsd.extension is undefined', () => {
+    const result = checkInstallDiscriminator({ gsd: {} })
+    assert.ok(result !== null)
+    assert.equal(result.code, 'MISSING_GSD_MARKER')
+    assert.equal(result.field, 'gsd.extension')
+  })
+
+  test('returns error when gsd is an array (not object)', () => {
+    const result = checkInstallDiscriminator({ gsd: ['extension'] })
+    assert.ok(result !== null)
+    assert.equal(result.code, 'MISSING_GSD_MARKER')
+  })
+
+  test('returns error when input is a string (not object)', () => {
+    const result = checkInstallDiscriminator('{"gsd":{"extension":true}}')
+    assert.ok(result !== null)
+    assert.equal(result.code, 'MISSING_GSD_MARKER')
+  })
 })
 
 describe('checkNamespaceReservation', () => {
@@ -111,6 +130,21 @@ describe('checkDependencyPlacement', () => {
     const errors = checkDependencyPlacement({})
     assert.equal(errors.length, 0)
   })
+
+  test('returns empty errors when dependencies is a string instead of object', () => {
+    const errors = checkDependencyPlacement({ dependencies: '@gsd/pi-coding-agent' })
+    assert.equal(errors.length, 0, 'string in dependencies field should be gracefully skipped')
+  })
+
+  test('returns empty errors when dependencies is null', () => {
+    const errors = checkDependencyPlacement({ dependencies: null })
+    assert.equal(errors.length, 0, 'null dependencies should be gracefully skipped')
+  })
+
+  test('returns empty errors when dependencies is an array', () => {
+    const errors = checkDependencyPlacement({ dependencies: ['@gsd/pi-coding-agent'] })
+    assert.equal(errors.length, 0, 'array in dependencies field should be gracefully skipped')
+  })
 })
 
 describe('validateExtensionPackage', () => {
@@ -155,5 +189,15 @@ describe('validateExtensionPackage', () => {
     assert.equal(result.valid, true)
     assert.equal(result.warnings.length, 1)
     assert.equal(result.warnings[0].code, 'NAMESPACE_CHECK_SKIPPED')
+  })
+})
+
+describe('edge cases — field types', () => {
+  test('does not flag @gsd/ package nested in sub-object of dependencies (only top-level keys matter)', () => {
+    // The checker iterates Object.keys(deps) — a sub-object value is a value, not a key name
+    const errors = checkDependencyPlacement({
+      dependencies: { nested: { '@gsd/foo': '1.0' } },
+    })
+    assert.equal(errors.length, 0, 'nested @gsd/ in a sub-object value should not be flagged')
   })
 })


### PR DESCRIPTION
## TL;DR

**What:** Implements the foundation for ADR-006 — dependency cleanup, extension package format, install/uninstall/update commands, and dependency-aware loading.
**Why:** GSD2 ships as a monolith (842 MB, 177K LOC core). This lays the groundwork for modularization.
**How:** 4 workstreams delivering clean dependency graph, package format validator, CLI install infrastructure, and topological extension loading.

Ref #2995

## What

This PR implements the **Foundation & Install Infrastructure** work from [ADR-006](https://github.com/gsd-build/gsd-2/issues/2995). It delivers 19 requirements across dependency cleanup, extension packaging, install commands, and loader enhancements.

### Dependency Coupling Cleanup (DECOUPLE-01 through DECOUPLE-06)

**Problem:** The dependency graph had three categories of coupling issues:
1. **Reverse dependency** — `packages/shared/src/rtk-session-stats.ts` imported `gsd/paths.js`, creating shared→gsd coupling
2. **Bidirectional coupling** — `gsd/auto.ts` directly imported `cmux/` functions, while `cmux/index.ts` imported `gsd/preferences.js` and `gsd/types.js`
3. **Misplaced root dependencies** — `@octokit/rest`, `@types/mime-types`, `get-east-asian-width`, and `zod-to-json-schema` in root `package.json` instead of workspace packages

**Solution:**
- Inlined `gsdRoot()` fast-path as `join(basePath, '.gsd', 'runtime')` in rtk-session-stats.ts — the git-probe fallback is never needed at RTK call sites
- Created `src/resources/extensions/shared/cmux-events.ts` — typed event contracts (`CmuxEventMap`) that both gsd and cmux reference without importing each other
- gsd emits events via `pi.events.emit()` instead of calling cmux functions directly
- cmux subscribes to events via `initCmuxEventListeners(pi.events)` wired by gsd in register-extension.ts (cmux is a library with `pi: {}` opt-out)
- Removed 4 misplaced root dependencies, relocated to correct workspace packages

**Files changed:**
- `packages/shared/src/rtk-session-stats.ts` — removed gsd/paths.js import
- `src/resources/extensions/shared/cmux-events.ts` — new event contract module
- `src/resources/extensions/gsd/register-extension.ts` — wires cmux event listeners
- `src/resources/extensions/gsd/auto.ts` — emits events instead of importing cmux
- `src/resources/extensions/cmux/index.ts` — subscribes to events, uses local structural types
- `package.json` — removed @octokit/rest, @types/mime-types, get-east-asian-width, zod-to-json-schema

### Extension Package Format (FORMAT-01 through FORMAT-03)

**Problem:** No validation existed for what constitutes a valid GSD extension package. Anyone could install an npm package that would fail at load time.

**Solution:** Created `src/extension-validator.ts` with three install-time validation checks:
1. **Install discriminator** — `gsd.extension === true` with strict equality (rejects numeric 1, string 'true', undefined)
2. **Namespace reservation** — Extension IDs matching `gsd.*` are reserved for core; install rejects with clear error unless `--allow-gsd-namespace` is passed
3. **Dependency placement** — `@gsd/*` packages in `dependencies` or `devDependencies` are flagged; must be in `peerDependencies`

**Testing:** 26 unit tests covering all validator functions, edge cases (null input, numeric truthy values, nested deps), and composite validation.

**Files changed:**
- `src/extension-validator.ts` — new validation module
- `src/tests/extension-validator.test.ts` — 26 test cases

### Extension Install Infrastructure (INSTALL-01 through INSTALL-05, LOADER-01 through LOADER-03)

**Problem:** No mechanism existed to install, update, or uninstall extensions after initial setup. Everything shipped bundled.

**Solution:** Implemented the full extension lifecycle in `src/resources/extensions/gsd/commands-extensions.ts`:

**Install (`gsd extensions install <specifier>`):**
- **npm** — `npm pack --ignore-scripts` + tar extraction (security: blocks postinstall scripts)
- **git** — `git clone --depth=1` + `.git/` removal
- **local path** — recursive `cpSync`
- All three paths converge through `postInstallValidate()` which reads package.json, validates via the validator, reads extension-manifest.json for the ID, and writes a registry entry with `source: "user"`

**Uninstall (`gsd extensions uninstall <id>`):**
- Checks registry for user-installed extension
- Scans dependents via `findDependents()` — warns if other installed extensions depend on this one
- Removes directory first, then registry entry (failed rmSync leaves recoverable state)

**Update (`gsd extensions update [id]`):**
- npm-sourced: fetches `registry.npmjs.org` with 5s timeout, compares versions via `semver.gt()`
- git/local-sourced: reports "reinstall to update" (no false "up to date")
- No-arg form updates all npm-sourced extensions, skips git/local with count

**Discovery enhancement:**
- `src/extension-discovery.ts` gains `mergeExtensionEntryPaths()` — merges bundled and installed paths, with installed overriding bundled by manifest ID
- Loader in `packages/pi-coding-agent/src/core/extensions/loader.ts` calls `mergeExtensionEntryPaths()` to get a pre-merged path list (loader stays dumb)
- `src/extension-registry.ts` gains `version`, `installedFrom`, and `installType` optional fields on `ExtensionRegistryEntry`

**Key design decisions:**
- `validateExtensionPackage` is mirrored inline in commands-extensions.ts because jiti runtime cannot resolve src/ imports
- `semver` uses default import (not named) to avoid jiti CJS interop failure
- `installedExtDir` is computed as `path.dirname(agentDir)/extensions` — parallel to `agentDir/extensions`

**Testing:** 15 unit tests for mergeExtensionEntryPaths (including edge cases for corrupt manifests, empty dirs).

**Files changed:**
- `src/extension-discovery.ts` — added `mergeExtensionEntryPaths()`
- `src/extension-registry.ts` — added version/installedFrom/installType fields
- `src/resources/extensions/gsd/commands-extensions.ts` — install/uninstall/update handlers
- `packages/pi-coding-agent/src/core/extensions/loader.ts` — calls mergeExtensionEntryPaths
- `src/tests/extension-discovery.test.ts` — 15 tests
- `package.json` — added `semver` ^7.6.3 dependency

### Extension Dependency Enforcement (LOADER-04, LOADER-05)

**Problem:** Extensions loaded in filesystem discovery order. An extension declaring a dependency on another extension had no guarantee its dependency would be loaded first.

**Solution:** Created `src/extension-sort.ts` implementing Kahn's BFS topological sort:
- Extensions without manifests are prepended in input order (backward compatible)
- Valid dependencies create directed edges; Kahn's algorithm processes zero-inDegree nodes first
- Missing dependencies produce structured warnings but don't block loading
- Cycles are detected (remaining nodes after Kahn's completes); participants are appended alphabetically with cycle warnings
- Self-dependencies silently ignored
- Alphabetical tie-breaking in the ready queue ensures deterministic sort across runs
- `Array.isArray` guard protects against malformed `dependencies.extensions` (string/null/number)

**Integration:** `discoverAndLoadExtensions()` in loader.ts calls `sortExtensionPaths()` after `mergeExtensionEntryPaths()` and before `loadExtensions()`. Sort warnings are emitted to stderr before the loader runs (ctx.ui not ready yet).

**Testing:** 14 unit tests covering no-deps, linear chains, diamond dependencies, missing deps, cycles, self-deps, no-manifest, mixed, and type coercion edge cases.

**Files changed:**
- `src/extension-sort.ts` — new topological sort module
- `packages/pi-coding-agent/src/core/extensions/loader.ts` — wires sortExtensionPaths + ExtensionLoadWarning type
- `src/tests/extension-sort.test.ts` — 14 tests

## Why

[ADR-006](https://github.com/gsd-build/gsd-2/issues/2995) defines a multi-milestone modularization roadmap to address GSD2's monolithic architecture:
- 842 MB node_modules
- 177K LOC core extension
- 20 bundled extensions loaded eagerly
- Bidirectional coupling between core modules

This is the foundation — it cleans the dependency graph and builds the install infrastructure that all future modularization work depends on. Without this, no extensions can be extracted, no skill packs can be distributed, and core decomposition is impossible.

## How

The implementation follows the ADR's architectural decisions:
- **Extensions as npm packages** with `gsd.extension: true` marker — leverages existing npm ecosystem
- **Installed to `~/.gsd/extensions/`** separate from bundled — clean separation with installed overriding bundled by ID
- **Event-based decoupling** — `pi.on()`/`pi.emit()` replaces direct imports between gsd↔cmux
- **`--ignore-scripts`** on all npm subprocesses — security requirement blocking arbitrary postinstall execution
- **Topological sort via Kahn's algorithm** — deterministic load ordering with cycle detection and graceful degradation

## Test plan

- [x] TypeScript compilation: `npx tsc --noEmit` — zero errors
- [x] Extension sort tests: 14/14 pass (topological ordering, cycles, missing deps, type coercion)
- [x] Extension validator tests: 26/26 pass (discriminator, namespace, dependency placement, edge cases)
- [x] Extension discovery tests: 15/15 pass (merge precedence, corrupt manifests, empty dirs)
- [x] Total: 55/55 unit tests pass
- [ ] Full regression suite: `npm run test:unit` — pending
- [ ] E2E: Manual testing of install/uninstall/update commands with test extension
- [ ] E2E: Verify installed extension overrides bundled at load time
- [ ] E2E: Verify all 20+ bundled extensions still load correctly

## Requirements Traceability

| ID | Description | Status |
|----|-------------|--------|
| DECOUPLE-01 | shared/rtk-session-stats.ts accepts gsdRoot as parameter | Done |
| DECOUPLE-02 | gsd/auto.ts emits typed events instead of importing cmux | Done |
| DECOUPLE-03 | cmux/index.ts subscribes to events instead of importing gsd | Done |
| DECOUPLE-04 | @octokit/rest removed from root package.json | Done |
| DECOUPLE-05 | mime-types moved to pi-tui package.json | Done |
| DECOUPLE-06 | zod-to-json-schema moved to pi-ai package.json | Done |
| FORMAT-01 | gsd.extension === true install discriminator | Done |
| FORMAT-02 | gsd.* namespace reservation with override flag | Done |
| FORMAT-03 | @gsd/* dependency placement enforcement | Done |
| INSTALL-01 | npm install with --ignore-scripts | Done |
| INSTALL-02 | git URL install | Done |
| INSTALL-03 | local path install | Done |
| INSTALL-04 | uninstall with dependency warnings | Done |
| INSTALL-05 | update with semver comparison | Done |
| LOADER-01 | Discovery scans ~/.gsd/extensions/ | Done |
| LOADER-02 | Installed overrides bundled by ID | Done |
| LOADER-03 | Registry gains version/installedFrom/installType | Done |
| LOADER-04 | Topological sort before loading | Done |
| LOADER-05 | Missing dep warnings at load time | Done |

🚧 WIP — Full regression suite and E2E testing pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)