### PR TITLE
fix(shell): validate custom shellPath before accepting it

### DIFF
--- a/packages/pi-coding-agent/src/core/settings-manager.ts
+++ b/packages/pi-coding-agent/src/core/settings-manager.ts
@@ -122,7 +122,7 @@ export interface Settings {
 	branchSummary?: BranchSummarySettings;
 	retry?: RetrySettings;
 	hideThinkingBlock?: boolean;
-	shellPath?: string; // Custom shell path (e.g., for Cygwin users on Windows)
+	shellPath?: string; // Custom shell path (must accept "-c <command>", e.g., bash/sh/pwsh)
 	quietStartup?: boolean;
 	shellCommandPrefix?: string; // Prefix prepended to every bash command (e.g., "shopt -s expand_aliases" for alias support)
 	collapseChangelog?: boolean; // Show condensed changelog after update (use /changelog for full)

--- a/packages/pi-coding-agent/src/utils/shell.test.ts
+++ b/packages/pi-coding-agent/src/utils/shell.test.ts
@@ -1,0 +1,62 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { resolveCustomShellConfig } from "./shell.js";
+
+describe("resolveCustomShellConfig", () => {
+	it("returns a shell config when the custom shell probe succeeds", () => {
+		const result = resolveCustomShellConfig("/custom/bash", {
+			existsSyncImpl: () => true,
+			spawnSyncImpl: () =>
+				({
+					status: 0,
+					signal: null,
+					stdout: "",
+					stderr: "",
+				}) as any,
+			settingsPath: "/tmp/settings.json",
+		});
+
+		assert.deepEqual(result, { shell: "/custom/bash", args: ["-c"] });
+	});
+
+	it("throws a not found error when the custom shell path does not exist", () => {
+		assert.throws(
+			() =>
+				resolveCustomShellConfig("/missing/bash", {
+					existsSyncImpl: () => false,
+					settingsPath: "/tmp/settings.json",
+				}),
+			(error: unknown) => {
+				assert.ok(error instanceof Error);
+				assert.match(error.message, /Custom shell path not found: \/missing\/bash/);
+				assert.match(error.message, /Please update shellPath in \/tmp\/settings\.json/);
+				return true;
+			},
+		);
+	});
+
+	it("throws a compatibility error when the executable exists but does not support '-c'", () => {
+		assert.throws(
+			() =>
+				resolveCustomShellConfig("/custom/not-a-shell", {
+					existsSyncImpl: () => true,
+					spawnSyncImpl: () =>
+						({
+							status: 1,
+							signal: null,
+							stdout: "",
+							stderr: "Node.js v24.13.1",
+						}) as any,
+					settingsPath: "/tmp/settings.json",
+				}),
+			(error: unknown) => {
+				assert.ok(error instanceof Error);
+				assert.match(error.message, /not a compatible shell/);
+				assert.match(error.message, /accepts '-c <command>'/);
+				assert.match(error.message, /Node\.js v24\.13\.1/);
+				assert.match(error.message, /update or remove shellPath in \/tmp\/settings\.json/);
+				return true;
+			},
+		);
+	});
+});

--- a/packages/pi-coding-agent/src/utils/shell.ts
+++ b/packages/pi-coding-agent/src/utils/shell.ts
@@ -6,6 +6,93 @@ import { SettingsManager } from "../core/settings-manager.js";
 
 let cachedShellConfig: { shell: string; args: string[] } | null = null;
 
+interface ResolveCustomShellConfigOptions {
+	existsSyncImpl?: typeof existsSync;
+	spawnSyncImpl?: typeof spawnSync;
+	settingsPath?: string;
+}
+
+function formatShellCompatibilityError(
+	customShellPath: string,
+	settingsPath: string,
+	probeResult?: {
+		status?: number | null;
+		signal?: NodeJS.Signals | null;
+		stderr?: string | Buffer | null;
+		error?: unknown;
+	},
+): Error {
+	const details: string[] = [
+		`Custom shell path is not a compatible shell: ${customShellPath}`,
+		`The shellPath setting must point to a shell that accepts '-c <command>' (for example: bash, sh, zsh, pwsh).`,
+	];
+
+	if (probeResult?.status !== undefined && probeResult.status !== null) {
+		details.push(`Probe exit status: ${probeResult.status}`);
+	}
+
+	if (probeResult?.signal) {
+		details.push(`Probe signal: ${probeResult.signal}`);
+	}
+
+	const stderr =
+		typeof probeResult?.stderr === "string"
+			? probeResult.stderr.trim()
+			: Buffer.isBuffer(probeResult?.stderr)
+				? probeResult.stderr.toString("utf-8").trim()
+				: "";
+	if (stderr) {
+		details.push(`Probe stderr: ${stderr.slice(0, 300)}`);
+	}
+
+	if (probeResult?.error instanceof Error && probeResult.error.message) {
+		details.push(`Probe error: ${probeResult.error.message}`);
+	}
+
+	details.push(
+		`This usually means shellPath points at a non-shell executable (for example node.exe or python.exe).`,
+		`Please update or remove shellPath in ${settingsPath}`,
+	);
+
+	return new Error(details.join("\n"));
+}
+
+export function resolveCustomShellConfig(
+	customShellPath: string,
+	options: ResolveCustomShellConfigOptions = {},
+): { shell: string; args: string[] } {
+	const existsSyncImpl = options.existsSyncImpl ?? existsSync;
+	const spawnSyncImpl = options.spawnSyncImpl ?? spawnSync;
+	const settingsPath = options.settingsPath ?? getSettingsPath();
+
+	if (!existsSyncImpl(customShellPath)) {
+		throw new Error(
+			`Custom shell path not found: ${customShellPath}\nPlease update shellPath in ${settingsPath}`,
+		);
+	}
+
+	try {
+		const probe = spawnSyncImpl(customShellPath, ["-c", "exit 0"], {
+			encoding: "utf-8",
+			timeout: 5000,
+			stdio: "pipe",
+			windowsHide: true,
+		});
+
+		if (probe.status === 0 && !probe.error) {
+			return { shell: customShellPath, args: ["-c"] };
+		}
+
+		throw formatShellCompatibilityError(customShellPath, settingsPath, probe);
+	} catch (error) {
+		if (error instanceof Error && error.message.includes("not a compatible shell")) {
+			throw error;
+		}
+
+		throw formatShellCompatibilityError(customShellPath, settingsPath, { error });
+	}
+}
+
 /**
  * Find bash executable on PATH (cross-platform)
  */
@@ -58,13 +145,8 @@ export function getShellConfig(): { shell: string; args: string[] } {
 
 	// 1. Check user-specified shell path
 	if (customShellPath) {
-		if (existsSync(customShellPath)) {
-			cachedShellConfig = { shell: customShellPath, args: ["-c"] };
-			return cachedShellConfig;
-		}
-		throw new Error(
-			`Custom shell path not found: ${customShellPath}\nPlease update shellPath in ${getSettingsPath()}`,
-		);
+		cachedShellConfig = resolveCustomShellConfig(customShellPath);
+		return cachedShellConfig;
 	}
 
 	if (process.platform === "win32") {


### PR DESCRIPTION
## Summary

Add an explicit compatibility guard for `shellPath` so GSD refuses existing executables that are not actually usable shells.

Today `getShellConfig()` only checks whether `shellPath` exists. If the path points to a real executable that is **not** a shell (for example a renamed `node.exe`, `python.exe`, or another binary that does not support `-c <command>`), GSD accepts it and caches it as the active shell. The real failure only shows up later when commands run, which produces confusing downstream behavior instead of a clear configuration error.

This PR makes custom shell resolution prove that the configured executable can actually run a shell-style probe before GSD accepts it.

## Why this deserves its own PR

This is intentionally separate from [#3027](https://github.com/gsd-build/gsd-2/pull/3027).

- `#3027` hardens runtime process spawning on Windows when a valid shell exists but `spawn()` fails with `EINVAL`.
- This PR hardens configuration loading when the configured shell path is wrong in the first place.

They are adjacent issues, but they fail at different layers:

1. `shellPath` is loaded from settings.
2. GSD decides whether to trust that configured executable.
3. Later, command execution uses that executable.

Right now step 2 is too weak. This PR fixes that.

## Root cause

Current behavior in `packages/pi-coding-agent/src/utils/shell.ts`:

```ts
if (customShellPath) {
  if (existsSync(customShellPath)) {
    cachedShellConfig = { shell: customShellPath, args: ["-c"] };
    return cachedShellConfig;
  }
  throw new Error(...)
}
```

That means any existing executable is treated as a shell, even if it does not understand `-c <command>`.

In real-world debugging, this kind of misconfiguration is easy to create:

- a copied or renamed executable called `bash.exe`
- a stale wrapper binary
- a user pointing `shellPath` at an interpreter instead of a shell
- a toolchain migration that leaves behind a file at the old path

When that happens, GSD fails later and opaquely. The user sees command/runtime breakage instead of a direct settings error.

## What changed

### 1. Added `resolveCustomShellConfig()` in `packages/pi-coding-agent/src/utils/shell.ts`

This new helper centralizes custom shell validation.

Behavior:

- If the configured path does not exist, it preserves the current not-found error.
- If the path exists, it runs a probe:
  - `shellPath -c "exit 0"`
- Only a successful probe is accepted.
- Failures now throw an actionable compatibility error that explains:
  - the path exists
  - it is not a compatible shell
  - `shellPath` must accept `-c <command>`
  - common examples of what went wrong
  - where to update/remove the setting

### 2. `getShellConfig()` now uses the validator instead of trusting existence alone

This keeps the existing resolution order, but strengthens the custom override path.

### 3. Added a dedicated regression test file

New file:

- `packages/pi-coding-agent/src/utils/shell.test.ts`

Coverage added:

- valid custom shell path is accepted
- missing custom shell path still throws the expected not-found error
- existing but incompatible executable throws a compatibility-focused error with stderr surfaced to the user

### 4. Clarified the settings contract

Updated the `shellPath` comment in `packages/pi-coding-agent/src/core/settings-manager.ts` to document that the configured executable must accept `-c <command>`.

## User impact

Before this PR:

- settings load succeeds
- invalid `shellPath` is cached as if it were fine
- later bash/tool execution fails in a confusing way

After this PR:

- startup/config resolution fails early
- the error points directly at `shellPath`
- the message explains what kind of executable is required
- the user gets a concrete fix instead of debugging unrelated shell symptoms

## Example of the new failure mode

Instead of silently accepting a non-shell binary and failing later, GSD now fails with a direct error shaped like:

```text
Custom shell path is not a compatible shell: C:\...\bash.exe
The shellPath setting must point to a shell that accepts '-c <command>' (for example: bash, sh, zsh, pwsh).
Probe exit status: 1
Probe stderr: Node.js v24.13.1
This usually means shellPath points at a non-shell executable (for example node.exe or python.exe).
Please update or remove shellPath in ...\settings.json
```

That is much closer to the actual problem.

## Verification

Ran locally in a fresh clone:

```bash
npm run build -w @gsd/pi-coding-agent
node --test packages/pi-coding-agent/dist/utils/shell.test.js
npm run build
```

Observed results:

- package build passed
- new shell validation test passed (`3/3`)
- repo build passed

## Scope notes

This PR only hardens the repo's `shellPath` setting path.

It does **not** attempt to validate every possible external env-based shell override in other host applications. That broader area is worth thinking about, but this PR keeps the change small, testable, and directly aligned with GSD's own settings model.
