### PR TITLE
fix(gsd): detect markdown body verdicts and guard plan-milestone against completed slices

### DIFF
--- a/src/resources/extensions/gsd/tests/plan-milestone.test.ts
+++ b/src/resources/extensions/gsd/tests/plan-milestone.test.ts
@@ -4,7 +4,7 @@ import { mkdtempSync, mkdirSync, rmSync, readFileSync, existsSync, writeFileSync
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
-import { openDatabase, closeDatabase, getMilestone, getMilestoneSlices } from '../gsd-db.ts';
+import { openDatabase, closeDatabase, getMilestone, getMilestoneSlices, updateSliceStatus } from '../gsd-db.ts';
 import { handlePlanMilestone } from '../tools/plan-milestone.ts';
 import { parseRoadmap } from '../parsers-legacy.ts';
 
@@ -193,6 +193,38 @@ test('handlePlanMilestone reruns idempotently and updates existing planning stat
     assert.equal(slices.length, 2);
     assert.equal(slices[0]?.goal, 'Updated goal');
     assert.equal(slices[0]?.observability_impact, 'Updated observability');
+  } finally {
+    cleanup(base);
+  }
+});
+
+// Regression: #2960 — plan-milestone must refuse to overwrite completed slices
+test('handlePlanMilestone refuses to re-plan a milestone with completed slices (#2960)', async () => {
+  const base = makeTmpBase();
+  const dbPath = join(base, '.gsd', 'gsd.db');
+  openDatabase(dbPath);
+
+  try {
+    // First plan succeeds
+    const first = await handlePlanMilestone(validParams(), base);
+    assert.ok(!('error' in first), `initial plan should succeed: ${'error' in first ? first.error : ''}`);
+
+    // Mark S01 as complete
+    updateSliceStatus('M001', 'S01', 'complete');
+
+    // Second plan should fail — S01 is already complete
+    const second = await handlePlanMilestone({
+      ...validParams(),
+      vision: 'Should not overwrite',
+    }, base);
+    assert.ok('error' in second, 'should refuse to re-plan when slices are completed');
+    assert.match(second.error, /cannot re-plan/i);
+    assert.match(second.error, /S01/);
+
+    // Verify the completed slice was not overwritten
+    const slices = getMilestoneSlices('M001');
+    const s01 = slices.find(s => s.id === 'S01');
+    assert.equal(s01?.status, 'complete', 'S01 should still be complete');
   } finally {
     cleanup(base);
   }

--- a/src/resources/extensions/gsd/tests/verdict-parser.test.ts
+++ b/src/resources/extensions/gsd/tests/verdict-parser.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Tests for verdict-parser.ts — extraction, normalization, and schema validation.
+ *
+ * Regression tests for #2960: extractVerdict() must detect verdicts in both
+ * YAML frontmatter and common markdown body patterns (LLM manual writes).
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  extractVerdict,
+  hasVerdict,
+  isAcceptableUatVerdict,
+  isValidMilestoneVerdict,
+} from "../verdict-parser.ts";
+
+// ── extractVerdict ──────────────────────────────────────────────────────────
+
+describe("extractVerdict", () => {
+  it("extracts verdict from YAML frontmatter", () => {
+    const content = "---\nverdict: pass\n---\n\n# Validation";
+    assert.equal(extractVerdict(content), "pass");
+  });
+
+  it("normalizes 'passed' to 'pass' in frontmatter", () => {
+    const content = "---\nverdict: passed\n---\n";
+    assert.equal(extractVerdict(content), "pass");
+  });
+
+  it("extracts case-insensitive verdict from frontmatter", () => {
+    const content = "---\nVerdict: PASS\n---\n";
+    assert.equal(extractVerdict(content), "pass");
+  });
+
+  it("extracts needs-remediation from frontmatter", () => {
+    const content = "---\nverdict: needs-remediation\n---\n";
+    assert.equal(extractVerdict(content), "needs-remediation");
+  });
+
+  it("returns undefined when content has no frontmatter and no markdown verdict", () => {
+    const content = "# Just a heading\n\nSome text without any verdict.";
+    assert.equal(extractVerdict(content), undefined);
+  });
+
+  // ── Regression: #2960 — markdown body verdicts ─────────────────────────
+
+  it("detects **Verdict:** PASS in markdown body (#2960)", () => {
+    const content = [
+      "# M013 — Milestone Validation",
+      "",
+      "**Verdict:** PASS",
+      "",
+      "All slices completed successfully.",
+    ].join("\n");
+    assert.equal(extractVerdict(content), "pass");
+  });
+
+  it("detects **Verdict:** with emoji prefix in markdown body (#2960)", () => {
+    const content = [
+      "# Milestone Validation",
+      "",
+      "**Verdict:** ✅ PASS",
+      "",
+      "Everything looks good.",
+    ].join("\n");
+    assert.equal(extractVerdict(content), "pass");
+  });
+
+  it("detects **Verdict:** needs-remediation in markdown body (#2960)", () => {
+    const content = [
+      "# Milestone Validation",
+      "",
+      "**Verdict:** needs-remediation",
+      "",
+      "Several issues found.",
+    ].join("\n");
+    assert.equal(extractVerdict(content), "needs-remediation");
+  });
+
+  it("normalizes 'passed' to 'pass' in markdown body (#2960)", () => {
+    const content = "# Validation\n\n**Verdict:** Passed\n";
+    assert.equal(extractVerdict(content), "pass");
+  });
+
+  it("detects verdict without colon in bold pattern (#2960)", () => {
+    const content = "# Validation\n\n**Verdict** PASS\n";
+    assert.equal(extractVerdict(content), "pass");
+  });
+
+  it("prefers frontmatter verdict over markdown body", () => {
+    const content = [
+      "---",
+      "verdict: needs-remediation",
+      "---",
+      "",
+      "**Verdict:** PASS",
+    ].join("\n");
+    assert.equal(extractVerdict(content), "needs-remediation");
+  });
+});
+
+// ── hasVerdict ────────────────────────────────────────────────────────────
+
+describe("hasVerdict", () => {
+  it("returns true when verdict field exists", () => {
+    assert.equal(hasVerdict("verdict: pass"), true);
+  });
+
+  it("returns false when no verdict field exists", () => {
+    assert.equal(hasVerdict("# Just a heading"), false);
+  });
+});
+
+// ── isAcceptableUatVerdict ───────────────────────────────────────────────
+
+describe("isAcceptableUatVerdict", () => {
+  it("accepts pass verdict", () => {
+    assert.equal(isAcceptableUatVerdict("pass", undefined), true);
+  });
+
+  it("accepts passed verdict", () => {
+    assert.equal(isAcceptableUatVerdict("passed", undefined), true);
+  });
+
+  it("rejects fail verdict", () => {
+    assert.equal(isAcceptableUatVerdict("fail", undefined), false);
+  });
+
+  it("accepts partial for mixed UAT type", () => {
+    assert.equal(isAcceptableUatVerdict("partial", "mixed"), true);
+  });
+
+  it("rejects partial for artifact-driven UAT type", () => {
+    assert.equal(isAcceptableUatVerdict("partial", "artifact-driven"), false);
+  });
+});
+
+// ── isValidMilestoneVerdict ──────────────────────────────────────────────
+
+describe("isValidMilestoneVerdict", () => {
+  it("accepts pass", () => {
+    assert.equal(isValidMilestoneVerdict("pass"), true);
+  });
+
+  it("accepts needs-attention", () => {
+    assert.equal(isValidMilestoneVerdict("needs-attention"), true);
+  });
+
+  it("accepts needs-remediation", () => {
+    assert.equal(isValidMilestoneVerdict("needs-remediation"), true);
+  });
+
+  it("rejects unknown verdict", () => {
+    assert.equal(isValidMilestoneVerdict("fail"), false);
+  });
+});

--- a/src/resources/extensions/gsd/tools/plan-milestone.ts
+++ b/src/resources/extensions/gsd/tools/plan-milestone.ts
@@ -4,6 +4,7 @@ import { isNonEmptyString, validateStringArray } from "../validation.js";
 import {
   transaction,
   getMilestone,
+  getMilestoneSlices,
   insertMilestone,
   insertSlice,
   upsertMilestonePlanning,
@@ -186,6 +187,17 @@ export async function handlePlanMilestone(
       const existingMilestone = getMilestone(params.milestoneId);
       if (existingMilestone && isClosedStatus(existingMilestone.status)) {
         guardError = `cannot re-plan milestone ${params.milestoneId}: it is already complete`;
+        return;
+      }
+
+      // Guard: refuse to re-plan a milestone that has completed slices (#2960).
+      // INSERT OR IGNORE on slices won't overwrite existing rows, but a full
+      // re-plan after worktree recreation or DB resync can create new slice rows
+      // that shadow completed work. Block early when any slice is already done.
+      const existingSlices = getMilestoneSlices(params.milestoneId);
+      const completedSlices = existingSlices.filter(s => isClosedStatus(s.status));
+      if (completedSlices.length > 0) {
+        guardError = `cannot re-plan milestone ${params.milestoneId}: ${completedSlices.length} slice(s) already completed (${completedSlices.map(s => s.id).join(", ")}). Use gsd_reassess_roadmap to modify the roadmap.`;
         return;
       }
 

--- a/src/resources/extensions/gsd/verdict-parser.ts
+++ b/src/resources/extensions/gsd/verdict-parser.ts
@@ -20,13 +20,28 @@ import type { UatType } from "./files.js";
  * Returns `undefined` when frontmatter is absent or has no `verdict` field.
  */
 export function extractVerdict(content: string): string | undefined {
+  // Primary: YAML frontmatter verdict (canonical format)
   const fmMatch = content.match(/^---\n([\s\S]*?)\n---/);
-  if (!fmMatch) return undefined;
-  const verdictMatch = fmMatch[1].match(/verdict:\s*([\w-]+)/i);
-  if (!verdictMatch) return undefined;
-  let v = verdictMatch[1].toLowerCase();
-  if (v === "passed") v = "pass";
-  return v;
+  if (fmMatch) {
+    const verdictMatch = fmMatch[1].match(/verdict:\s*([\w-]+)/i);
+    if (verdictMatch) {
+      let v = verdictMatch[1].toLowerCase();
+      if (v === "passed") v = "pass";
+      return v;
+    }
+    return undefined;
+  }
+
+  // Fallback: detect verdict in markdown body (LLM manual writes, #2960).
+  // Matches patterns like: **Verdict:** PASS, **Verdict:** ✅ PASS, **Verdict** needs-remediation
+  const bodyMatch = content.match(/\*\*Verdict:?\*\*\s*(?:✅\s*)?(\w[\w-]*)/i);
+  if (bodyMatch) {
+    let v = bodyMatch[1].toLowerCase();
+    if (v === "passed") v = "pass";
+    return v;
+  }
+
+  return undefined;
 }
 
 /**


### PR DESCRIPTION
## TL;DR

**What:** Fix verdict parsing for non-frontmatter formats and add a guard against re-planning milestones with completed slices.
**Why:** LLMs writing VALIDATION.md without YAML frontmatter cause the state machine to loop, and subsequent re-planning can destroy hours of completed work.
**How:** Markdown body fallback regex in `extractVerdict()` + completed-slice guard in `handlePlanMilestone()`.

Closes #2960

## What Changed

### Bug 1: `extractVerdict()` markdown body fallback
- When no YAML frontmatter is present, `extractVerdict()` now falls back to detecting markdown body verdict patterns like `**Verdict:** PASS`, `**Verdict:** ✅ PASS`, `**Verdict** needs-remediation`
- Normalization (`passed` -> `pass`, lowercase) applied consistently to both paths
- Frontmatter is still preferred when present (no behavior change for existing files)

### Bug 2: `handlePlanMilestone()` completed-slice guard
- Before writing slice rows, checks if any existing slices have a closed status (complete/done)
- If completed slices exist, returns an error directing the user to `gsd_reassess_roadmap` instead
- Guard runs inside the transaction (same pattern as the existing closed-milestone guard)

## Tests

- 22 new tests in `verdict-parser.test.ts` covering YAML frontmatter extraction, markdown body fallback, normalization, and all verdict schema validators
- 1 new regression test in `plan-milestone.test.ts` verifying the completed-slice guard
- All 28 tests pass, existing plan-milestone tests unaffected