### PR TITLE
fix(gsd): promote milestone status from queued to active in plan-milestone

### DIFF
--- a/src/resources/extensions/gsd/gsd-db.ts
+++ b/src/resources/extensions/gsd/gsd-db.ts
@@ -1124,10 +1124,12 @@ export function insertMilestone(m: {
   });
 }
 
-export function upsertMilestonePlanning(milestoneId: string, planning: Partial<MilestonePlanningRecord>): void {
+export function upsertMilestonePlanning(milestoneId: string, planning: Partial<MilestonePlanningRecord> & { title?: string; status?: string }): void {
   if (!currentDb) throw new GSDError(GSD_STALE_STATE, "gsd-db: No database open");
   currentDb.prepare(
     `UPDATE milestones SET
+      title = COALESCE(NULLIF(:title, ''), title),
+      status = COALESCE(NULLIF(:status, ''), status),
       vision = COALESCE(:vision, vision),
       success_criteria = COALESCE(:success_criteria, success_criteria),
       key_risks = COALESCE(:key_risks, key_risks),
@@ -1142,6 +1144,8 @@ export function upsertMilestonePlanning(milestoneId: string, planning: Partial<M
      WHERE id = :id`,
   ).run({
     ":id": milestoneId,
+    ":title": planning.title ?? "",
+    ":status": planning.status ?? "",
     ":vision": planning.vision ?? null,
     ":success_criteria": planning.successCriteria ? JSON.stringify(planning.successCriteria) : null,
     ":key_risks": planning.keyRisks ? JSON.stringify(planning.keyRisks) : null,

--- a/src/resources/extensions/gsd/tests/plan-milestone.test.ts
+++ b/src/resources/extensions/gsd/tests/plan-milestone.test.ts
@@ -4,7 +4,7 @@ import { mkdtempSync, mkdirSync, rmSync, readFileSync, existsSync, writeFileSync
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
-import { openDatabase, closeDatabase, getMilestone, getMilestoneSlices } from '../gsd-db.ts';
+import { openDatabase, closeDatabase, getMilestone, getMilestoneSlices, insertMilestone } from '../gsd-db.ts';
 import { handlePlanMilestone } from '../tools/plan-milestone.ts';
 import { parseRoadmap } from '../parsers-legacy.ts';
 
@@ -193,6 +193,31 @@ test('handlePlanMilestone reruns idempotently and updates existing planning stat
     assert.equal(slices.length, 2);
     assert.equal(slices[0]?.goal, 'Updated goal');
     assert.equal(slices[0]?.observability_impact, 'Updated observability');
+  } finally {
+    cleanup(base);
+  }
+});
+
+test('handlePlanMilestone promotes pre-existing queued milestone to active (#3022)', async () => {
+  const base = makeTmpBase();
+  const dbPath = join(base, '.gsd', 'gsd.db');
+  openDatabase(dbPath);
+
+  try {
+    // Simulate ensureMilestoneDbRow: pre-create row with status "queued"
+    // (this is what gsd_milestone_generate_id does)
+    insertMilestone({ id: 'M001', status: 'queued' });
+
+    const before = getMilestone('M001');
+    assert.equal(before?.status, 'queued', 'pre-condition: milestone should start as queued');
+
+    // Now plan the milestone — status should be promoted to "active"
+    const result = await handlePlanMilestone(validParams(), base);
+    assert.ok(!('error' in result), `unexpected error: ${'error' in result ? result.error : ''}`);
+
+    const after = getMilestone('M001');
+    assert.equal(after?.status, 'active', 'milestone status should be promoted from queued to active');
+    assert.equal(after?.title, 'DB-backed planning', 'milestone title should be set');
   } finally {
     cleanup(base);
   }

--- a/src/resources/extensions/gsd/tools/plan-milestone.ts
+++ b/src/resources/extensions/gsd/tools/plan-milestone.ts
@@ -212,6 +212,8 @@ export async function handlePlanMilestone(
       });
 
       upsertMilestonePlanning(params.milestoneId, {
+        title: params.title,
+        status: params.status ?? "active",
         vision: params.vision,
         successCriteria: params.successCriteria,
         keyRisks: params.keyRisks,


### PR DESCRIPTION
## Summary
- Add `title` and `status` columns to the `upsertMilestonePlanning()` UPDATE statement in `gsd-db.ts`
- Pass `title` and `status` from `handlePlanMilestone()` so pre-existing "queued" rows get promoted to "active"
- Add regression test reproducing the exact scenario: pre-create row with `status: "queued"`, then verify `plan-milestone` promotes it to `"active"`

Closes #3022

## Test plan
- [x] New test: `handlePlanMilestone promotes pre-existing queued milestone to active (#3022)` -- confirms status transitions from queued to active during planning
- [x] All 6 plan-milestone tests pass
- [x] Full unit test suite passes (3994 passed, 6 pre-existing failures unrelated to this change)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>