### PR TITLE
fix: add windowsHide to all web-mode subprocess spawns

### DIFF
--- a/src/tests/integration/web-mode-cli.test.ts
+++ b/src/tests/integration/web-mode-cli.test.ts
@@ -164,6 +164,7 @@ test('launchWebMode prefers the packaged standalone host and opens the resolved 
       cwd: standaloneRoot,
       detached: true,
       stdio: 'ignore',
+      windowsHide: true,
       env: {
         TEST_ENV: '1',
         HOSTNAME: '127.0.0.1',

--- a/src/tests/integration/web-mode-windows-hide.test.ts
+++ b/src/tests/integration/web-mode-windows-hide.test.ts
@@ -1,0 +1,120 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+const webMode = await import("../../web-mode.ts");
+
+// ---------------------------------------------------------------------------
+// #2628 — On Windows, child processes spawned by web-mode must set
+// `windowsHide: true` to prevent console windows from flashing on screen.
+// ---------------------------------------------------------------------------
+
+test("launchWebMode passes windowsHide: true in spawn options", async (t) => {
+  const tmp = mkdtempSync(join(tmpdir(), "gsd-web-winhide-"));
+  const standaloneRoot = join(tmp, "dist", "web", "standalone");
+  const serverPath = join(standaloneRoot, "server.js");
+  mkdirSync(standaloneRoot, { recursive: true });
+  writeFileSync(serverPath, 'console.log("stub")\n');
+
+  const pidFilePath = join(tmp, "web-server.pid");
+  const registryPath = join(tmp, "web-instances.json");
+
+  let capturedOptions: Record<string, unknown> | undefined;
+
+  t.after(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  const status = await webMode.launchWebMode(
+    {
+      cwd: "/tmp/winhide-project",
+      projectSessionsDir: "/tmp/.gsd/sessions/winhide",
+      agentDir: "/tmp/.gsd/agent",
+      packageRoot: tmp,
+    },
+    {
+      initResources: () => {},
+      resolvePort: async () => 46000,
+      execPath: "/custom/node",
+      env: { TEST_ENV: "1" },
+      spawn: (_command, _args, options) => {
+        capturedOptions = options as Record<string, unknown>;
+        return {
+          pid: 70001,
+          once: () => undefined,
+          unref: () => {},
+        } as any;
+      },
+      waitForBootReady: async () => undefined,
+      openBrowser: () => {},
+      pidFilePath,
+      writePidFile: webMode.writePidFile,
+      registryPath,
+      stderr: { write: () => true },
+    },
+  );
+
+  assert.equal(status.ok, true, "launch should succeed");
+  assert.ok(capturedOptions, "spawn must have been called");
+  assert.equal(
+    capturedOptions!.windowsHide,
+    true,
+    "spawn options must include windowsHide: true to prevent console window flashing on Windows (#2628)",
+  );
+});
+
+test("launchWebMode source-dev host also passes windowsHide: true", async (t) => {
+  const tmp = mkdtempSync(join(tmpdir(), "gsd-web-winhide-src-"));
+  const webRoot = join(tmp, "web");
+  mkdirSync(webRoot, { recursive: true });
+  writeFileSync(join(webRoot, "package.json"), '{"name":"web"}\n');
+
+  const pidFilePath = join(tmp, "web-server.pid");
+  const registryPath = join(tmp, "web-instances.json");
+
+  let capturedOptions: Record<string, unknown> | undefined;
+
+  t.after(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  const status = await webMode.launchWebMode(
+    {
+      cwd: "/tmp/winhide-src-project",
+      projectSessionsDir: "/tmp/.gsd/sessions/winhide-src",
+      agentDir: "/tmp/.gsd/agent",
+      packageRoot: tmp,
+    },
+    {
+      initResources: () => {},
+      resolvePort: async () => 46001,
+      execPath: "/custom/node",
+      env: { TEST_ENV: "1" },
+      platform: "win32",
+      spawn: (_command, _args, options) => {
+        capturedOptions = options as Record<string, unknown>;
+        return {
+          pid: 70002,
+          once: () => undefined,
+          unref: () => {},
+        } as any;
+      },
+      waitForBootReady: async () => undefined,
+      openBrowser: () => {},
+      pidFilePath,
+      writePidFile: webMode.writePidFile,
+      registryPath,
+      stderr: { write: () => true },
+    },
+  );
+
+  assert.equal(status.ok, true, "launch should succeed");
+  assert.ok(capturedOptions, "spawn must have been called");
+  assert.equal(
+    capturedOptions!.windowsHide,
+    true,
+    "source-dev spawn must also include windowsHide: true (#2628)",
+  );
+});

--- a/src/web-mode.ts
+++ b/src/web-mode.ts
@@ -14,7 +14,7 @@ const DEFAULT_PACKAGE_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '.
 function openBrowser(url: string): void {
   if (process.platform === 'win32') {
     // PowerShell's Start-Process handles URLs with '&' safely; cmd /c start does not.
-    execFile('powershell', ['-c', `Start-Process '${url.replace(/'/g, "''")}'`], () => {})
+    execFile('powershell', ['-c', `Start-Process '${url.replace(/'/g, "''")}'`], { windowsHide: true }, () => {})
   } else {
     const cmd = process.platform === 'darwin' ? 'open' : 'xdg-open'
     execFile(cmd, [url], () => {})
@@ -635,6 +635,7 @@ export async function launchWebMode(
       cwd: spawnSpec.cwd,
       detached: true,
       stdio: 'ignore',
+      windowsHide: true,
       env,
     },
   )

--- a/src/web/auto-dashboard-service.ts
+++ b/src/web/auto-dashboard-service.ts
@@ -95,6 +95,7 @@ export async function collectAuthoritativeAutoDashboardData(
           [AUTO_DASHBOARD_MODULE_ENV]: autoModulePath,
         },
         maxBuffer: AUTO_DASHBOARD_MAX_BUFFER,
+        windowsHide: true,
       },
       (error, stdout, stderr) => {
         if (error) {

--- a/src/web/bridge-service.ts
+++ b/src/web/bridge-service.ts
@@ -771,6 +771,7 @@ async function loadSessionBrowserSessionsViaChildProcess(config: BridgeRuntimeCo
           GSD_SESSION_BROWSER_DIR: config.projectSessionsDir,
         },
         maxBuffer: 1024 * 1024,
+        windowsHide: true,
       },
       (error, stdout, stderr) => {
         if (error) {
@@ -832,6 +833,7 @@ async function appendSessionInfoViaChildProcess(
           GSD_TARGET_SESSION_NAME: name,
         },
         maxBuffer: 1024 * 1024,
+        windowsHide: true,
       },
       (error, _stdout, stderr) => {
         if (error) {
@@ -1030,6 +1032,7 @@ async function loadWorkspaceIndexViaChildProcess(basePath: string, packageRoot: 
           GSD_WORKSPACE_BASE: basePath,
         },
         maxBuffer: 1024 * 1024,
+        windowsHide: true,
       },
       (error, stdout, stderr) => {
         if (error) {
@@ -1616,6 +1619,7 @@ export class BridgeService {
       cwd: cliEntry.cwd,
       env: childEnv,
       stdio: ["pipe", "pipe", "pipe"],
+      windowsHide: true,
     }) as SpawnedRpcChild;
 
     this.process = child;

--- a/src/web/captures-service.ts
+++ b/src/web/captures-service.ts
@@ -64,6 +64,7 @@ export async function collectCapturesData(projectCwdOverride?: string): Promise<
           GSD_CAPTURES_BASE: projectCwd,
         },
         maxBuffer: CAPTURES_MAX_BUFFER,
+        windowsHide: true,
       },
       (error, stdout, stderr) => {
         if (error) {
@@ -136,6 +137,7 @@ export async function resolveCaptureAction(request: CaptureResolveRequest, proje
           GSD_CAPTURES_BASE: projectCwd,
         },
         maxBuffer: CAPTURES_MAX_BUFFER,
+        windowsHide: true,
       },
       (error, stdout, stderr) => {
         if (error) {

--- a/src/web/cleanup-service.ts
+++ b/src/web/cleanup-service.ts
@@ -78,6 +78,7 @@ export async function collectCleanupData(projectCwdOverride?: string): Promise<C
           GSD_CLEANUP_BASE: projectCwd,
         },
         maxBuffer: CLEANUP_MAX_BUFFER,
+        windowsHide: true,
       },
       (error, stdout, stderr) => {
         if (error) {
@@ -170,6 +171,7 @@ export async function executeCleanup(
           GSD_CLEANUP_SNAPSHOTS: JSON.stringify(pruneSnapshots),
         },
         maxBuffer: CLEANUP_MAX_BUFFER,
+        windowsHide: true,
       },
       (error, stdout, stderr) => {
         if (error) {

--- a/src/web/doctor-service.ts
+++ b/src/web/doctor-service.ts
@@ -41,6 +41,7 @@ function runDoctorChild(
           GSD_DOCTOR_SCOPE: scope ?? "",
         },
         maxBuffer: DOCTOR_MAX_BUFFER,
+        windowsHide: true,
       },
       (error, stdout, stderr) => {
         if (error) {

--- a/src/web/export-service.ts
+++ b/src/web/export-service.ts
@@ -74,6 +74,7 @@ export async function collectExportData(
           GSD_EXPORT_FORMAT: format,
         },
         maxBuffer: EXPORT_MAX_BUFFER,
+        windowsHide: true,
       },
       (error, stdout, stderr) => {
         if (error) {

--- a/src/web/forensics-service.ts
+++ b/src/web/forensics-service.ts
@@ -94,6 +94,7 @@ export async function collectForensicsData(projectCwdOverride?: string): Promise
           GSD_FORENSICS_BASE: projectCwd,
         },
         maxBuffer: FORENSICS_MAX_BUFFER,
+        windowsHide: true,
       },
       (error, stdout, stderr) => {
         if (error) {

--- a/src/web/history-service.ts
+++ b/src/web/history-service.ts
@@ -66,6 +66,7 @@ export async function collectHistoryData(projectCwdOverride?: string): Promise<H
           GSD_HISTORY_BASE: projectCwd,
         },
         maxBuffer: HISTORY_MAX_BUFFER,
+        windowsHide: true,
       },
       (error, stdout, stderr) => {
         if (error) {

--- a/src/web/hooks-service.ts
+++ b/src/web/hooks-service.ts
@@ -66,6 +66,7 @@ export async function collectHooksData(projectCwdOverride?: string): Promise<Hoo
           [HOOKS_MODULE_ENV]: hooksModulePath,
         },
         maxBuffer: HOOKS_MAX_BUFFER,
+        windowsHide: true,
       },
       (error, stdout, stderr) => {
         if (error) {

--- a/src/web/recovery-diagnostics-service.ts
+++ b/src/web/recovery-diagnostics-service.ts
@@ -491,6 +491,7 @@ async function collectRecoveryDiagnosticsChildPayload(
           GSD_RECOVERY_FORENSICS_MODULE: sessionForensicsModulePath,
         },
         maxBuffer: RECOVERY_DIAGNOSTICS_MAX_BUFFER,
+        windowsHide: true,
       },
       (error, stdout, stderr) => {
         if (error) {

--- a/src/web/settings-service.ts
+++ b/src/web/settings-service.ts
@@ -142,6 +142,7 @@ export async function collectSettingsData(projectCwdOverride?: string): Promise<
           GSD_SETTINGS_BASE: projectCwd,
         },
         maxBuffer: SETTINGS_MAX_BUFFER,
+        windowsHide: true,
       },
       (error, stdout, stderr) => {
         if (error) {

--- a/src/web/skill-health-service.ts
+++ b/src/web/skill-health-service.ts
@@ -61,6 +61,7 @@ export async function collectSkillHealthData(projectCwdOverride?: string): Promi
           GSD_SKILL_HEALTH_BASE: projectCwd,
         },
         maxBuffer: SKILL_HEALTH_MAX_BUFFER,
+        windowsHide: true,
       },
       (error, stdout, stderr) => {
         if (error) {

--- a/src/web/undo-service.ts
+++ b/src/web/undo-service.ts
@@ -195,6 +195,7 @@ export async function executeUndo(projectCwdOverride?: string): Promise<UndoResu
           GSD_UNDO_BASE: projectCwd,
         },
         maxBuffer: UNDO_MAX_BUFFER,
+        windowsHide: true,
       },
       (error, stdout, stderr) => {
         if (error) {

--- a/src/web/update-service.ts
+++ b/src/web/update-service.ts
@@ -73,6 +73,7 @@ export function triggerUpdate(targetVersion?: string): boolean {
     stdio: ["ignore", "ignore", "pipe"],
     // Detach so the child process is not killed if the parent exits
     detached: false,
+    windowsHide: true,
   })
 
   let stderr = ""

--- a/src/web/visualizer-service.ts
+++ b/src/web/visualizer-service.ts
@@ -98,6 +98,7 @@ export async function collectVisualizerData(projectCwdOverride?: string): Promis
           GSD_VISUALIZER_BASE: projectCwd,
         },
         maxBuffer: VISUALIZER_MAX_BUFFER,
+        windowsHide: true,
       },
       (error, stdout, stderr) => {
         if (error) {


### PR DESCRIPTION
## Summary

- Add `windowsHide: true` to every `spawn()` and `execFile()` call in the web mode stack (web-mode.ts, bridge-service, update-service, and all 13 web service files) to prevent console windows from flashing on Windows
- Add `windowsHide: true` to the PowerShell `execFile` call in `openBrowser()` for Windows
- Add regression tests asserting `windowsHide: true` is present in spawn options for both packaged-standalone and source-dev host modes

Closes #2628

## Test plan

- [x] New tests in `web-mode-windows-hide.test.ts` verify `windowsHide: true` is passed in spawn options for both host kinds
- [x] Updated existing `web-mode-cli.test.ts` spawn assertion to include `windowsHide: true`
- [ ] Manual verification on Windows: run `gsd --web` and confirm no console windows flash

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>