### PR TITLE
fix(parallel): clean up log files on stop/cleanup to prevent ghost workers in monitor

### DIFF
--- a/src/resources/extensions/gsd/parallel-merge.ts
+++ b/src/resources/extensions/gsd/parallel-merge.ts
@@ -9,7 +9,7 @@ import { loadFile } from "./files.js";
 import { resolveMilestoneFile } from "./paths.js";
 import { mergeMilestoneToMain } from "./auto-worktree.js";
 import { MergeConflictError } from "./git-service.js";
-import { removeSessionStatus } from "./session-status-io.js";
+import { removeSessionArtifacts } from "./session-status-io.js";
 import type { WorkerInfo } from "./parallel-orchestrator.js";
 import { getErrorMessage } from "./error-utils.js";
 
@@ -80,7 +80,7 @@ export async function mergeCompletedMilestone(
     const result = mergeMilestoneToMain(basePath, milestoneId, roadmapContent);
 
     // Clean up parallel session status
-    removeSessionStatus(basePath, milestoneId);
+    removeSessionArtifacts(basePath, milestoneId);
 
     return {
       milestoneId,

--- a/src/resources/extensions/gsd/parallel-orchestrator.ts
+++ b/src/resources/extensions/gsd/parallel-orchestrator.ts
@@ -32,6 +32,7 @@ import {
   readAllSessionStatuses,
   readSessionStatus,
   removeSessionStatus,
+  removeSessionArtifacts,
   sendSignal,
   cleanupStaleSessions,
   type SessionStatus,
@@ -336,8 +337,9 @@ export async function prepareParallelStart(
     const alive = isPidAlive(session.pid);
     orphans.push({ milestoneId: session.milestoneId, pid: session.pid, alive });
     if (!alive) {
-      // Clean up dead session
-      removeSessionStatus(basePath, session.milestoneId);
+      // Clean up dead session — remove all artifacts (status, signal, logs)
+      // to prevent stale log files from showing ghost workers in the monitor.
+      removeSessionArtifacts(basePath, session.milestoneId);
     }
   }
 
@@ -845,8 +847,8 @@ export async function stopParallel(
     worker.state = "stopped";
     worker.process = null;
 
-    // Clean up session status file
-    removeSessionStatus(basePath, mid);
+    // Clean up all session artifacts (status, signal, logs)
+    removeSessionArtifacts(basePath, mid);
   }
 
   // If stopping all workers, deactivate the orchestrator

--- a/src/resources/extensions/gsd/session-status-io.ts
+++ b/src/resources/extensions/gsd/session-status-io.ts
@@ -124,6 +124,27 @@ export function removeSessionStatus(basePath: string, milestoneId: string): void
   } catch { /* non-fatal */ }
 }
 
+/**
+ * Remove ALL parallel artifacts for a milestone: status, signal, and logs.
+ * Called during stop/cleanup to prevent stale log files from causing the
+ * monitor overlay's discoverWorkers() to show ghost workers from prior runs.
+ */
+export function removeSessionArtifacts(basePath: string, milestoneId: string): void {
+  const dir = parallelDir(basePath);
+  const files = [
+    `${milestoneId}${STATUS_SUFFIX}`,
+    `${milestoneId}${SIGNAL_SUFFIX}`,
+    `${milestoneId}.stdout.log`,
+    `${milestoneId}.stderr.log`,
+  ];
+  for (const file of files) {
+    try {
+      const p = join(dir, file);
+      if (existsSync(p)) unlinkSync(p);
+    } catch { /* non-fatal */ }
+  }
+}
+
 // ─── Signal I/O ────────────────────────────────────────────────────────────
 
 /** Write a signal file for a worker to consume. */
@@ -165,12 +186,7 @@ export function cleanupStaleSessions(
 
   for (const status of statuses) {
     if (isSessionStale(status, timeoutMs)) {
-      removeSessionStatus(basePath, status.milestoneId);
-      // Also clean up any lingering signal file
-      try {
-        const sig = signalPath(basePath, status.milestoneId);
-        if (existsSync(sig)) unlinkSync(sig);
-      } catch { /* non-fatal */ }
+      removeSessionArtifacts(basePath, status.milestoneId);
       removed.push(status.milestoneId);
     }
   }

--- a/src/resources/extensions/gsd/tests/session-status-cleanup.test.ts
+++ b/src/resources/extensions/gsd/tests/session-status-cleanup.test.ts
@@ -1,0 +1,118 @@
+/**
+ * session-status-cleanup.test.ts — Tests for removeSessionArtifacts.
+ *
+ * Verifies that all parallel artifacts (status, signal, stdout/stderr logs)
+ * are cleaned up when a worker is stopped or a session goes stale.
+ * Prevents ghost workers in the monitor overlay from stale log files.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  existsSync,
+  rmSync,
+  realpathSync,
+} from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import {
+  removeSessionArtifacts,
+  removeSessionStatus,
+} from "../session-status-io.ts";
+
+function makeTempBase(): string {
+  const dir = realpathSync(mkdtempSync(join(tmpdir(), "session-cleanup-")));
+  mkdirSync(join(dir, ".gsd", "parallel"), { recursive: true });
+  return dir;
+}
+
+function cleanup(dir: string): void {
+  try { rmSync(dir, { recursive: true, force: true }); } catch { /* */ }
+}
+
+test("removeSessionArtifacts removes all four artifact types", () => {
+  const base = makeTempBase();
+  const pDir = join(base, ".gsd", "parallel");
+  const mid = "M001";
+
+  // Create all four artifact types
+  writeFileSync(join(pDir, `${mid}.status.json`), "{}");
+  writeFileSync(join(pDir, `${mid}.signal.json`), "{}");
+  writeFileSync(join(pDir, `${mid}.stdout.log`), "output");
+  writeFileSync(join(pDir, `${mid}.stderr.log`), "errors");
+
+  // All exist before cleanup
+  assert.ok(existsSync(join(pDir, `${mid}.status.json`)));
+  assert.ok(existsSync(join(pDir, `${mid}.signal.json`)));
+  assert.ok(existsSync(join(pDir, `${mid}.stdout.log`)));
+  assert.ok(existsSync(join(pDir, `${mid}.stderr.log`)));
+
+  removeSessionArtifacts(base, mid);
+
+  // All removed after cleanup
+  assert.ok(!existsSync(join(pDir, `${mid}.status.json`)), "status.json should be removed");
+  assert.ok(!existsSync(join(pDir, `${mid}.signal.json`)), "signal.json should be removed");
+  assert.ok(!existsSync(join(pDir, `${mid}.stdout.log`)), "stdout.log should be removed");
+  assert.ok(!existsSync(join(pDir, `${mid}.stderr.log`)), "stderr.log should be removed");
+
+  cleanup(base);
+});
+
+test("removeSessionArtifacts handles missing files gracefully", () => {
+  const base = makeTempBase();
+  const pDir = join(base, ".gsd", "parallel");
+  const mid = "M002";
+
+  // Only create one file — the rest are missing
+  writeFileSync(join(pDir, `${mid}.stderr.log`), "errors");
+
+  // Should not throw
+  removeSessionArtifacts(base, mid);
+
+  assert.ok(!existsSync(join(pDir, `${mid}.stderr.log`)), "stderr.log should be removed");
+
+  cleanup(base);
+});
+
+test("removeSessionArtifacts does not affect other milestones", () => {
+  const base = makeTempBase();
+  const pDir = join(base, ".gsd", "parallel");
+
+  // Create artifacts for M001 and M002
+  writeFileSync(join(pDir, "M001.stdout.log"), "m001 output");
+  writeFileSync(join(pDir, "M001.stderr.log"), "m001 errors");
+  writeFileSync(join(pDir, "M002.stdout.log"), "m002 output");
+  writeFileSync(join(pDir, "M002.stderr.log"), "m002 errors");
+
+  // Remove only M001
+  removeSessionArtifacts(base, "M001");
+
+  assert.ok(!existsSync(join(pDir, "M001.stdout.log")), "M001 stdout should be removed");
+  assert.ok(!existsSync(join(pDir, "M001.stderr.log")), "M001 stderr should be removed");
+  assert.ok(existsSync(join(pDir, "M002.stdout.log")), "M002 stdout should be untouched");
+  assert.ok(existsSync(join(pDir, "M002.stderr.log")), "M002 stderr should be untouched");
+
+  cleanup(base);
+});
+
+test("removeSessionStatus only removes status.json, not logs", () => {
+  const base = makeTempBase();
+  const pDir = join(base, ".gsd", "parallel");
+  const mid = "M003";
+
+  writeFileSync(join(pDir, `${mid}.status.json`), "{}");
+  writeFileSync(join(pDir, `${mid}.stdout.log`), "output");
+  writeFileSync(join(pDir, `${mid}.stderr.log`), "errors");
+
+  removeSessionStatus(base, mid);
+
+  assert.ok(!existsSync(join(pDir, `${mid}.status.json`)), "status.json should be removed");
+  assert.ok(existsSync(join(pDir, `${mid}.stdout.log`)), "stdout.log should remain");
+  assert.ok(existsSync(join(pDir, `${mid}.stderr.log`)), "stderr.log should remain");
+
+  cleanup(base);
+});


### PR DESCRIPTION
## TL;DR

**What:** `stopParallel()`, `cleanupStaleSessions()`, and `mergeCompletedMilestone()` now remove `.stdout.log` and `.stderr.log` alongside `.status.json` and `.signal.json`.

**Why:** The monitor overlay's `discoverWorkers()` scans log filenames via regex (`M\d+.stderr.log` → add milestone ID). Stale logs from previous parallel runs cause ghost workers to appear in `/gsd parallel watch` with DEAD/PID 0 status, cluttering the dashboard.

**How:** Added `removeSessionArtifacts()` to `session-status-io.ts` that removes all four artifact types. Replaced `removeSessionStatus()` calls in stop, cleanup, and merge paths.

## What

### 1. `session-status-io.ts` — New `removeSessionArtifacts()`

Removes all four parallel artifact files for a milestone:
- `{mid}.status.json`
- `{mid}.signal.json`
- `{mid}.stdout.log`
- `{mid}.stderr.log`

`removeSessionStatus()` is preserved for callers that only need to clear the status file.

`cleanupStaleSessions()` now calls `removeSessionArtifacts()` instead of `removeSessionStatus()` + manual signal cleanup.

### 2. `parallel-orchestrator.ts` — Stop and dead-session cleanup

Two call sites updated:
- `stopParallel()` → `removeSessionArtifacts()` (was `removeSessionStatus()`)
- Dead-session cleanup in orchestrator init → `removeSessionArtifacts()` (was `removeSessionStatus()`)

### 3. `parallel-merge.ts` — Post-merge cleanup

`mergeCompletedMilestone()` → `removeSessionArtifacts()` (was `removeSessionStatus()`)

### 4. Tests

4 new tests in `session-status-cleanup.test.ts`:
- Removes all four artifact types
- Handles missing files gracefully (no crash)
- Does not affect other milestones' artifacts
- `removeSessionStatus()` backward compatibility (only removes `.status.json`, leaves logs)

## Why

The root cause: `discoverWorkers()` in `parallel-monitor-overlay.ts` discovers milestone IDs from three sources:
1. `*.status.json` files
2. `*.stderr.log` / `*.stdout.log` files (regex match)
3. Worktree directories with `auto.lock`

When `stopParallel()` runs, it removes `.status.json` and writes `.signal.json`, but leaves `.stdout.log` and `.stderr.log` behind. On the next parallel run, the monitor picks up the old milestone IDs from stale log files and shows them as DEAD workers.

## Change type

- [x] `fix` — Bug fix