### PR TITLE
fix(parallel): four bugs from headless migration — DB truncation, idle timer, monitor paths, provider-error resume (#2815)

### DIFF
--- a/scripts/parallel-monitor.mjs
+++ b/scripts/parallel-monitor.mjs
@@ -6,38 +6,28 @@
  * Zero dependencies — uses raw ANSI escape codes, Node.js builtins only.
  * 
  * Usage:
- *   node scripts/parallel-monitor.mjs                    # live dashboard, 5s refresh
- *   node scripts/parallel-monitor.mjs --interval 3       # faster refresh
- *   node scripts/parallel-monitor.mjs --once              # single snapshot, then exit
- *   node scripts/parallel-monitor.mjs --heal              # auto-respawn dead workers
- *   node scripts/parallel-monitor.mjs --heal --heal-retries 5 --heal-cooldown 60
+ *   node scripts/parallel-monitor.mjs                          # live dashboard, 5s refresh
+ *   node scripts/parallel-monitor.mjs --interval 3             # faster refresh
+ *   node scripts/parallel-monitor.mjs --once                   # single snapshot, then exit
+ *   node scripts/parallel-monitor.mjs --heal                   # auto-respawn dead workers
+ *   node scripts/parallel-monitor.mjs --heal --auto-pause      # + pause/resume on rate limit
  * 
  * Options:
- *   --interval <sec>      Refresh interval in seconds (default: 5)
- *   --once                Render once and exit (useful for scripting/piping)
- *   --heal                Auto-respawn dead workers (opt-in, off by default)
- *   --heal-retries <n>    Max respawn attempts per worker (default: 3)
- *   --heal-cooldown <sec> Seconds between respawn attempts (default: 30)
- *   --dir <path>          Status file directory (default: .gsd/parallel)
- *   --root <path>         Project root (default: cwd)
+ *   --interval <sec>         Refresh interval in seconds (default: 5)
+ *   --once                   Render once and exit (useful for scripting/piping)
+ *   --heal                   Auto-respawn dead workers (opt-in, off by default)
+ *   --heal-retries <n>       Max respawn attempts per worker (default: 3)
+ *   --heal-cooldown <sec>    Seconds between respawn attempts (default: 30)
+ *   --auto-pause             Detect rate limit exhaustion, pause all workers, probe
+ *                            for session reset, and auto-respawn when available
+ *   --probe-interval <sec>   Seconds between session probes while paused (default: 60)
  * 
  * Data sources:
- *   .gsd/parallel/M0xx.status.json  — heartbeat, cost, state (written by orchestrator)
- *   .gsd/worktrees/M0xx/.gsd/auto.lock — current unit type + ID (written by worker)
- *   .gsd/worktrees/M0xx/.gsd/gsd.db — task/slice completion (SQLite, queried via cli)
- *   .gsd/parallel/M0xx.stdout.log — NDJSON events (cost extraction, notify messages)
- *   .gsd/parallel/M0xx.stderr.log — error surfacing
- * 
- * Health indicators:
- *   ● green  — PID alive, fresh heartbeat (<30s)
- *   ● green  — PID alive, heartbeat stale (respawned worker, file mtime used as proxy)
- *   ○ red    — PID dead
- * 
- * Self-healing (--heal):
- *   When a dead worker is detected, the monitor writes a temp shell script and launches
- *   a new headless auto-mode process in the worker's worktree with the correct env vars.
- *   Cooldown prevents rapid respawn loops. Gives up after --heal-retries consecutive 
- *   failures. Resets retry count when a worker comes back alive.
+ *   .gsd/auto-M0xx.lock              — current unit type + ID (written by worker)
+ *   .gsd/gsd.db                      — task/slice completion (project root, shared-WAL)
+ *   .gsd/parallel/M0xx.status.json   — heartbeat, cost, state (written by orchestrator)
+ *   .gsd/parallel/M0xx.stdout.log    — NDJSON events (notify messages)
+ *   .gsd/parallel/M0xx.stderr.log    — headless progress lines
  */
 
 import fs from 'node:fs';
@@ -52,11 +42,26 @@ const PARALLEL_DIR = getArg('--dir', '.gsd/parallel');
 const PROJECT_ROOT = getArg('--root', process.cwd());
 const ONE_SHOT = args.includes('--once');
 const HEAL_MODE = args.includes('--heal');
+const AUTO_PAUSE = args.includes('--auto-pause');
 const HEAL_MAX_RETRIES = parseInt(getArg('--heal-retries', '3'), 10);
 const HEAL_COOLDOWN_SEC = parseInt(getArg('--heal-cooldown', '30'), 10);
+const PAUSE_PROBE_SEC = parseInt(getArg('--probe-interval', '60'), 10);
 
 // Per-worker heal state: { lastAttempt: number, retries: number }
 const healState = {};
+
+// ─── Auto-pause/resume state (--auto-pause) ─────────────────────────────────
+// Detects when ALL workers die from rate limits (session budget exhausted),
+// pauses, probes `claude --print "pong"` until the window resets, then respawns.
+let autoPauseState = {
+  paused: false,          // true when we've paused due to rate limit
+  pausedAt: 0,            // timestamp when pause began  
+  lastProbeAt: 0,         // timestamp of last probe attempt
+  probeCount: 0,          // number of probes sent
+  savedWorkers: [],       // worker mids to respawn on resume
+  consecutiveDeaths: 0,   // track rapid worker deaths (all dying = rate limit)
+  lastDeathAt: 0,         // timestamp of most recent death
+};
 
 function getArg(flag, defaultVal) {
   const idx = args.indexOf(flag);
@@ -141,9 +146,13 @@ function discoverWorkers() {
   }
   
   // From worktree directories that have auto.lock (actively running)
+  // Check both per-milestone locks at project root and worktree locks
   if (fs.existsSync(worktreeDir)) {
     for (const d of fs.readdirSync(worktreeDir)) {
-      if (d.startsWith('M') && fs.existsSync(path.join(worktreeDir, d, '.gsd', 'auto.lock'))) {
+      if (d.startsWith('M') && (
+        fs.existsSync(path.join(PROJECT_ROOT, '.gsd', `auto-${d}.lock`)) ||
+        fs.existsSync(path.join(worktreeDir, d, '.gsd', 'auto.lock'))
+      )) {
         mids.add(d);
       }
     }
@@ -157,13 +166,46 @@ function readWorkerStatus(mid) {
   return readJsonSafe(statusPath);
 }
 
+/**
+ * Read the last error message from a worker's NDJSON stdout log.
+ * Looks for notify events containing error keywords in the tail of the file.
+ */
+function getLastWorkerError(mid) {
+  const stdoutPath = path.resolve(PROJECT_ROOT, PARALLEL_DIR, `${mid}.stdout.log`);
+  if (!fs.existsSync(stdoutPath)) return null;
+  try {
+    const stat = fs.statSync(stdoutPath);
+    const readSize = Math.min(stat.size, 16384);
+    const fd = fs.openSync(stdoutPath, 'r');
+    const buf = Buffer.alloc(readSize);
+    fs.readSync(fd, buf, 0, readSize, Math.max(0, stat.size - readSize));
+    fs.closeSync(fd);
+    const lines = buf.toString('utf-8').trim().split('\n').reverse();
+    for (const line of lines) {
+      try {
+        const obj = JSON.parse(line);
+        if (obj.method === 'notify' && obj.message && /error|rate.?limit|429|500|502|503|overloaded/i.test(obj.message)) {
+          return obj.message;
+        }
+      } catch {}
+    }
+  } catch {}
+  return null;
+}
+
 function readAutoLock(mid) {
-  const lockPath = path.resolve(PROJECT_ROOT, `.gsd/worktrees/${mid}/.gsd/auto.lock`);
-  return readJsonSafe(lockPath);
+  // Parallel workers write per-milestone lock files (auto-<MID>.lock) in
+  // the project root .gsd/, not auto.lock inside the worktree.
+  const perMilestoneLock = path.resolve(PROJECT_ROOT, `.gsd/auto-${mid}.lock`);
+  const worktreeLock = path.resolve(PROJECT_ROOT, `.gsd/worktrees/${mid}/.gsd/auto.lock`);
+  return readJsonSafe(perMilestoneLock) || readJsonSafe(worktreeLock);
 }
 
 function querySliceProgress(mid) {
-  const dbPath = path.resolve(PROJECT_ROOT, `.gsd/worktrees/${mid}/.gsd/gsd.db`);
+  // Shared-WAL: use project root DB (worktree DB may be empty or missing)
+  const rootDbPath = path.resolve(PROJECT_ROOT, '.gsd/gsd.db');
+  const worktreeDbPath = path.resolve(PROJECT_ROOT, `.gsd/worktrees/${mid}/.gsd/gsd.db`);
+  const dbPath = fs.existsSync(rootDbPath) ? rootDbPath : worktreeDbPath;
   if (!fs.existsSync(dbPath)) return [];
   
   try {
@@ -274,38 +316,7 @@ function extractCostFromNdjson(mid) {
 
 // ─── Self-Healing ────────────────────────────────────────────────────────────
 
-// Auto-detect the GSD loader path — works across npm global, homebrew, and local installs
-function findGsdLoader() {
-  // 1. Check if we're running from inside the gsd-2 repo itself
-  const repoLoader = path.resolve(import.meta.dirname, '..', 'dist', 'loader.js');
-  if (fs.existsSync(repoLoader)) return repoLoader;
-  
-  // 2. Check common global install locations
-  try {
-    const globalRoot = execSync('npm root -g', { encoding: 'utf-8', timeout: 3000 }).trim();
-    const candidates = [
-      path.join(globalRoot, 'gsd-pi', 'dist', 'loader.js'),
-      path.join(globalRoot, '@gsd', 'pi', 'dist', 'loader.js'),
-    ];
-    for (const c of candidates) {
-      if (fs.existsSync(c)) return c;
-    }
-  } catch { /* skip */ }
-  
-  // 3. Try `which gsd` and resolve symlink
-  try {
-    const bin = execSync('which gsd', { encoding: 'utf-8', timeout: 3000 }).trim();
-    if (bin) {
-      const realBin = fs.realpathSync(bin);
-      const loader = path.resolve(path.dirname(realBin), '..', 'dist', 'loader.js');
-      if (fs.existsSync(loader)) return loader;
-    }
-  } catch { /* skip */ }
-  
-  return null;
-}
-
-const GSD_LOADER = findGsdLoader();
+const GSD_LOADER = '/opt/homebrew/lib/node_modules/gsd-pi/dist/loader.js';
 
 /**
  * Respawn a dead worker. Returns the new PID or null on failure.
@@ -401,6 +412,30 @@ function healWorkers(workers) {
       const remaining = Math.ceil((HEAL_COOLDOWN_SEC * 1000 - elapsed) / 1000);
       // Don't spam the feed — only note on first cooldown tick
       continue;
+    }
+    
+    // Check if the worker died from a transient API error — if so, back off longer
+    // to avoid a respawn-crash-respawn loop that burns retries on a temporary outage
+    const lastError = getLastWorkerError(wk.mid);
+    if (lastError && /rate.?limit|429|too many requests/i.test(lastError)) {
+      // Rate limit — don't respawn at all, let auto-pause handle it
+      if (!hs.rateLimited) {
+        events.push({ ts: now, mid: wk.mid, msg: `⏸️  ${wk.mid}: rate-limited, waiting for session reset` });
+        hs.rateLimited = true;
+      }
+      continue;
+    }
+    if (lastError && /server.error|500|502|503|overloaded|internal.server/i.test(lastError)) {
+      // Transient server error — wait 60s instead of the normal cooldown
+      const serverCooldown = 60 * 1000;
+      if (elapsed < serverCooldown) {
+        if (!hs.serverErrorLogged) {
+          events.push({ ts: now, mid: wk.mid, msg: `⏳ ${wk.mid}: server error, waiting 60s before respawn` });
+          hs.serverErrorLogged = true;
+        }
+        continue;
+      }
+      hs.serverErrorLogged = false;
     }
     
     // Check the milestone isn't already complete
@@ -515,7 +550,10 @@ function truncate(str, maxLen) {
  * Get recently completed tasks/slices from the worktree DB for the event feed.
  */
 function queryRecentCompletions(mid) {
-  const dbPath = path.resolve(PROJECT_ROOT, `.gsd/worktrees/${mid}/.gsd/gsd.db`);
+  // Shared-WAL: use project root DB (worktree DB may be empty or missing)
+  const rootDbPath = path.resolve(PROJECT_ROOT, '.gsd/gsd.db');
+  const wtDbPath = path.resolve(PROJECT_ROOT, `.gsd/worktrees/${mid}/.gsd/gsd.db`);
+  const dbPath = fs.existsSync(rootDbPath) ? rootDbPath : wtDbPath;
   if (!fs.existsSync(dbPath)) return [];
   
   try {
@@ -785,13 +823,154 @@ function render(workers) {
   const healInfo = HEAL_MODE 
     ? ` │ heal: ${HEAL_COOLDOWN_SEC}s cooldown, ${HEAL_MAX_RETRIES} max retries`
     : '';
-  buf.push(`  ${DIM}Ctrl+C to exit${allDone ? ' (monitoring stopped)' : ''}${healInfo}${RESET}`);
+  const pauseInfo = AUTO_PAUSE
+    ? autoPauseState.paused
+      ? ` │ ${FG.yellow}⏸ PAUSED${RESET}${DIM} — probing every ${PAUSE_PROBE_SEC}s (${autoPauseState.probeCount} probes sent)`
+      : ` │ ${FG.green}⚡ auto-pause${RESET}${DIM}`
+    : '';
+  buf.push(`  ${DIM}Ctrl+C to exit${allDone ? ' (monitoring stopped)' : ''}${healInfo}${pauseInfo}${RESET}`);
   
   // Write to screen
   process.stdout.write(CLEAR_SCREEN);
   process.stdout.write(buf.join('\n') + '\n');
   
   return allDone;
+}
+
+// ─── Auto-pause: rate limit detection & probing ─────────────────────────────
+
+/**
+ * Detect if all workers died from rate limiting.
+ * Heuristic: if ALL workers are dead and total cost > $1, assume rate limit.
+ * A single dead worker is normal (task crash) — all dead at once is rate limit.
+ */
+function detectRateLimitExhaustion(workers) {
+  if (!AUTO_PAUSE || autoPauseState.paused) return false;
+  if (workers.length === 0) return false;
+  
+  const alive = workers.filter(w => w.alive);
+  const dead = workers.filter(w => !w.alive);
+  const totalCost = workers.reduce((s, w) => s + (w.cost || 0), 0);
+  
+  // All workers dead and meaningful work was done (not just startup failures)
+  if (alive.length === 0 && dead.length >= 2 && totalCost > 1.0) {
+    return true;
+  }
+  
+  return false;
+}
+
+/**
+ * Kill all surviving workers, save their milestone IDs, enter paused state.
+ */
+function pauseAllWorkers(workers) {
+  const events = [];
+  autoPauseState.paused = true;
+  autoPauseState.pausedAt = Date.now();
+  autoPauseState.probeCount = 0;
+  autoPauseState.savedWorkers = workers.map(w => w.mid);
+  
+  // Kill any that are somehow still alive
+  for (const wk of workers) {
+    if (wk.alive && wk.pid) {
+      try { process.kill(wk.pid, 'SIGTERM'); } catch {}
+    }
+  }
+  
+  // Reset heal state so heal doesn't fight us
+  for (const mid of autoPauseState.savedWorkers) {
+    healState[mid] = { lastAttempt: 0, retries: HEAL_MAX_RETRIES + 1 };
+  }
+  
+  events.push({
+    ts: Date.now(),
+    mid: 'ALL',
+    msg: `⏸️  Rate limit detected — paused all workers. Probing every ${PAUSE_PROBE_SEC}s for session reset...`
+  });
+  
+  return events;
+}
+
+/**
+ * Probe Claude API to check if the session window has reset.
+ * Returns true if the API is available (session has budget).
+ */
+function probeSessionAvailable() {
+  try {
+    const result = execSync(
+      `perl -e 'alarm 15; exec @ARGV' -- claude --print "reply pong"`,
+      { encoding: 'utf-8', timeout: 20000, stdio: ['pipe', 'pipe', 'pipe'] }
+    ).trim();
+    return result.toLowerCase().includes('pong');
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Check probe status and respawn workers when session resets.
+ * Called every tick while in paused state.
+ */
+function tickAutoPause() {
+  if (!autoPauseState.paused) return [];
+  
+  const events = [];
+  const now = Date.now();
+  const elapsed = now - autoPauseState.pausedAt;
+  
+  // Only probe every PAUSE_PROBE_SEC
+  if (now - autoPauseState.lastProbeAt < PAUSE_PROBE_SEC * 1000) return events;
+  
+  autoPauseState.lastProbeAt = now;
+  autoPauseState.probeCount++;
+  
+  const elapsedMin = Math.floor(elapsed / 60000);
+  events.push({
+    ts: now,
+    mid: 'SYS',
+    msg: `🔍 Probe #${autoPauseState.probeCount} (paused ${elapsedMin}m) — checking if session reset...`
+  });
+  
+  const available = probeSessionAvailable();
+  
+  if (available) {
+    events.push({
+      ts: now,
+      mid: 'SYS',
+      msg: `✅ Session available! Respawning ${autoPauseState.savedWorkers.length} workers...`
+    });
+    
+    // Respawn all saved workers
+    let respawned = 0;
+    for (const mid of autoPauseState.savedWorkers) {
+      // Reset heal state for fresh start
+      healState[mid] = { lastAttempt: 0, retries: 0 };
+      
+      const newPid = respawnWorker(mid);
+      if (newPid) {
+        respawned++;
+        events.push({ ts: now, mid, msg: `🟢 ${mid}: respawned as PID ${newPid}` });
+      } else {
+        events.push({ ts: now, mid, msg: `❌ ${mid}: respawn failed` });
+      }
+    }
+    
+    autoPauseState.paused = false;
+    autoPauseState.savedWorkers = [];
+    events.push({
+      ts: now,
+      mid: 'SYS',
+      msg: `🚀 Resumed: ${respawned}/${autoPauseState.savedWorkers.length || respawned} workers respawned`
+    });
+  } else {
+    events.push({
+      ts: now,
+      mid: 'SYS',
+      msg: `⏳ Session still rate-limited. Next probe in ${PAUSE_PROBE_SEC}s...`
+    });
+  }
+  
+  return events;
 }
 
 // ─── Main Loop ───────────────────────────────────────────────────────────────
@@ -829,7 +1008,25 @@ function main() {
   // Refresh loop
   const timer = setInterval(() => {
     try {
+      // ── Auto-pause: probe while paused ──
+      if (autoPauseState.paused) {
+        const probeEvents = tickAutoPause();
+        for (const evt of probeEvents) lastEventFeed.push(evt);
+        const workers = collectWorkerData();
+        render(workers);
+        return;
+      }
+      
       const workers = collectWorkerData();
+      
+      // ── Auto-pause: detect rate limit exhaustion ──
+      if (AUTO_PAUSE && detectRateLimitExhaustion(workers)) {
+        const pauseEvents = pauseAllWorkers(workers);
+        for (const evt of pauseEvents) lastEventFeed.push(evt);
+        render(workers);
+        return;
+      }
+      
       const healEvents = healWorkers(workers);
       for (const evt of healEvents) lastEventFeed.push(evt);
       done = render(workers);

--- a/src/headless-events.ts
+++ b/src/headless-events.ts
@@ -65,6 +65,8 @@ export function mapStatusToExitCode(status: string): number {
  * Blocked detection is separate — checked via isBlockedNotification.
  */
 export const TERMINAL_PREFIXES = ['auto-mode stopped', 'step-mode stopped']
+export const PAUSE_PREFIXES = ['auto-mode paused', 'step-mode paused']
+export const AUTO_RESUME_RE = /auto-resuming in (\d+)s/i
 export const IDLE_TIMEOUT_MS = 15_000
 // new-milestone is a long-running creative task where the LLM may pause
 // between tool calls (e.g. after mkdir, before writing files). Use a
@@ -75,6 +77,28 @@ export function isTerminalNotification(event: Record<string, unknown>): boolean 
   if (event.type !== 'extension_ui_request' || event.method !== 'notify') return false
   const message = String(event.message ?? '').toLowerCase()
   return TERMINAL_PREFIXES.some((prefix) => message.startsWith(prefix))
+}
+
+/**
+ * Detect auto-mode pause notification.
+ * These are emitted by pauseAuto() and indicate the auto-loop exited but
+ * the session may be resumable (e.g. after a provider error recovery delay).
+ */
+export function isPauseNotification(event: Record<string, unknown>): boolean {
+  if (event.type !== 'extension_ui_request' || event.method !== 'notify') return false
+  const message = String(event.message ?? '').toLowerCase()
+  return PAUSE_PREFIXES.some((prefix) => message.startsWith(prefix))
+}
+
+/**
+ * Extract auto-resume delay from a notification like "Auto-resuming in 30s...".
+ * Returns the delay in milliseconds, or null if not an auto-resume notification.
+ */
+export function extractAutoResumeDelay(event: Record<string, unknown>): number | null {
+  if (event.type !== 'extension_ui_request' || event.method !== 'notify') return null
+  const message = String(event.message ?? '')
+  const match = AUTO_RESUME_RE.exec(message)
+  return match ? parseInt(match[1], 10) * 1000 : null
 }
 
 export function isBlockedNotification(event: Record<string, unknown>): boolean {

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -458,6 +458,13 @@ async function runHeadlessOnce(options: HeadlessOptions, restartCount: number): 
 
   function resetIdleTimer(): void {
     if (idleTimer) clearTimeout(idleTimer)
+    // Auto-mode has its own supervision via auto-timers.ts (idle + hard
+    // timeout with graduated recovery). The headless idle timer must NOT
+    // run for auto/next sessions — a single slow tool call (e.g. reading
+    // from cloud storage, large builds) can exceed 15s without emitting
+    // events, causing the headless wrapper to kill the session mid-task.
+    // Auto-mode exits via terminal notification ("Auto-mode stopped...").
+    if (isMultiTurnCommand) return
     if (toolCallCount > 0) {
       idleTimer = setTimeout(() => {
         completed = true

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -26,6 +26,8 @@ import {
   isTerminalNotification,
   isBlockedNotification,
   isMilestoneReadyNotification,
+  isPauseNotification,
+  extractAutoResumeDelay,
   isQuickCommand,
   FIRE_AND_FORGET_METHODS,
   IDLE_TIMEOUT_MS,
@@ -364,6 +366,7 @@ async function runHeadlessOnce(options: HeadlessOptions, restartCount: number): 
   let completed = false
   let exitCode = 0
   let milestoneReady = false  // tracks "Milestone X ready." for auto-chaining
+  let pendingAutoResumeMs = 0 // delay (ms) from "Auto-resuming in Xs..." notification
   const recentEvents: TrackedEvent[] = []
 
   // JSON batch mode: cost aggregation (cumulative-max pattern per K004)
@@ -665,6 +668,17 @@ async function runHeadlessOnce(options: HeadlessOptions, restartCount: number): 
         milestoneReady = true
       }
 
+      // Capture "Auto-resuming in Xs..." delay for provider-error recovery.
+      // When auto-mode pauses due to a transient error and schedules a resume,
+      // we need to keep the headless process alive and re-send /gsd auto after
+      // the delay — otherwise the process exits and the resume timer dies (#2815).
+      if (isMultiTurnCommand) {
+        const resumeDelay = extractAutoResumeDelay(eventObj)
+        if (resumeDelay != null) {
+          pendingAutoResumeMs = resumeDelay
+        }
+      }
+
       if (isTerminalNotification(eventObj)) {
         completed = true
       }
@@ -809,6 +823,16 @@ async function runHeadlessOnce(options: HeadlessOptions, restartCount: number): 
   if (internalProcess) {
     internalProcess.on('exit', (code) => {
       if (!completed) {
+        // When auto-mode pauses for a transient provider error, the RPC child
+        // exits (command handler returned). If we captured a pending auto-resume
+        // delay, don't treat this as a fatal exit — we'll wait and re-send
+        // /gsd auto after the delay. Without this, the headless process exits
+        // and the scheduled resume timer dies with it (#2815).
+        if (isMultiTurnCommand && pendingAutoResumeMs > 0) {
+          process.stderr.write(`[headless] Child exited after provider-error pause. Waiting ${pendingAutoResumeMs / 1000}s for auto-resume...\n`)
+          // Don't set exitCode to error — we're going to retry
+          return
+        }
         const msg = `[headless] Child process exited unexpectedly with code ${code ?? 'null'}\n`
         process.stderr.write(msg)
         exitCode = EXIT_ERROR
@@ -833,6 +857,86 @@ async function runHeadlessOnce(options: HeadlessOptions, restartCount: number): 
   // Wait for completion
   if (exitCode === EXIT_SUCCESS || exitCode === EXIT_BLOCKED) {
     await completionPromise
+  }
+
+  // ── Provider-error auto-resume ─────────────────────────────────────────────
+  // When auto-mode paused due to a transient provider error (rate limit, 500,
+  // overloaded) and we captured a "Auto-resuming in Xs..." delay, wait for the
+  // delay then re-send /gsd auto. The RPC child exited (pauseAuto returns to
+  // command handler which exits), so we need to start a new RPC session.
+  // This loop retries until we get a terminal notification or a clean exit.
+  while (isMultiTurnCommand && pendingAutoResumeMs > 0 && !completed && exitCode !== EXIT_CANCELLED) {
+    const delaySec = Math.ceil(pendingAutoResumeMs / 1000)
+    process.stderr.write(`[headless] Provider error — waiting ${delaySec}s before auto-resume...\n`)
+    await new Promise(r => setTimeout(r, pendingAutoResumeMs + 2000)) // +2s buffer
+
+    pendingAutoResumeMs = 0  // Reset — will be set again if another error occurs
+    completed = false
+    blocked = false
+    exitCode = EXIT_SUCCESS
+
+    // Start a fresh RPC session for the retry
+    const retryClient = new RpcClient(clientOptions)
+    retryClient.onEvent((event) => {
+      const eventObj = event as Record<string, unknown>
+      trackEvent(eventObj)
+      resetIdleTimer()
+
+      if (options.json && options.outputFormat === 'stream-json') {
+        const eventType = String(eventObj.type ?? '')
+        if (!options.eventFilter || options.eventFilter.has(eventType)) {
+          process.stdout.write(JSON.stringify(eventObj) + '\n')
+        }
+      }
+
+      // Terminal and pause detection
+      if (eventObj.type === 'extension_ui_request') {
+        if (isTerminalNotification(eventObj)) {
+          completed = true
+        }
+        const resumeDelay = extractAutoResumeDelay(eventObj)
+        if (resumeDelay != null) {
+          pendingAutoResumeMs = resumeDelay
+        }
+        handleExtensionUIRequest(eventObj as unknown as ExtensionUIRequest, retryClient)
+        if (completed) {
+          exitCode = blocked ? EXIT_BLOCKED : EXIT_SUCCESS
+          resolveCompletion()
+          return
+        }
+      }
+    })
+
+    const retryCompletion = new Promise<void>((resolve) => {
+      resolveCompletion = resolve
+    })
+
+    try {
+      await retryClient.start()
+      process.stderr.write('[headless] Auto-resume: sending /gsd auto...\n')
+      await retryClient.prompt('/gsd auto')
+    } catch (err) {
+      process.stderr.write(`[headless] Auto-resume failed: ${err instanceof Error ? err.message : String(err)}\n`)
+      exitCode = EXIT_ERROR
+      break
+    }
+
+    const retryProcess = (retryClient as any).process as ChildProcess
+    if (retryProcess) {
+      retryProcess.on('exit', (code) => {
+        if (!completed) {
+          if (pendingAutoResumeMs > 0) {
+            process.stderr.write(`[headless] Child exited after pause. Will retry in ${pendingAutoResumeMs / 1000}s...\n`)
+            return
+          }
+          exitCode = code === 0 ? EXIT_SUCCESS : EXIT_ERROR
+          resolveCompletion()
+        }
+      })
+    }
+
+    await retryCompletion
+    await retryClient.stop().catch(() => {})
   }
 
   // Auto-mode chaining: if --auto and milestone creation succeeded, send /gsd auto

--- a/src/resources/extensions/gsd/auto-worktree.ts
+++ b/src/resources/extensions/gsd/auto-worktree.ts
@@ -223,16 +223,26 @@ export function syncProjectRootToWorktree(
     { force: true },
   );
 
-  // Delete worktree gsd.db so it rebuilds from the freshly synced files.
-  // Stale DB rows are the root cause of the infinite skip loop (#853).
-  try {
-    const wtDb = join(wtGsd, "gsd.db");
-    if (existsSync(wtDb)) {
-      unlinkSync(wtDb);
-    }
-  } catch {
-    /* non-fatal */
-  }
+  // NOTE: Do NOT delete the worktree gsd.db here.
+  //
+  // The shared-WAL design (R012) means workers resolve to the project root
+  // DB via resolveProjectRootDbPath(). Deleting the worktree DB was a fix
+  // for #853 (stale DB rows causing infinite skip loops), but that fix
+  // predates the shared-WAL architecture. Under shared-WAL, workers never
+  // read from the worktree DB — resolveProjectRootDbPath() always returns
+  // the project root path.
+  //
+  // Deleting the worktree DB here causes #2815: the deletion races with
+  // session startup paths that call openDatabase() or openRawDb(), which
+  // create a new 0-byte file at the worktree path. This empty DB has no
+  // tables, so getPendingSliceGateCount() falls through to the markdown
+  // parser, which re-inserts 'pending' gate rows, trapping the worker in
+  // an infinite evaluating-gates → skip → re-derive loop.
+  //
+  // A stale worktree DB is harmless — the DB path resolver directs all
+  // reads/writes to the project root DB. If a worktree DB somehow gets
+  // opened instead, reconcileWorktreeDb() handles merging on milestone
+  // completion.
 }
 
 /**

--- a/src/resources/extensions/gsd/parallel-monitor-overlay.ts
+++ b/src/resources/extensions/gsd/parallel-monitor-overlay.ts
@@ -113,7 +113,10 @@ function discoverWorkers(basePath: string): string[] {
   if (existsSync(worktreeDir)) {
     try {
       for (const d of readdirSync(worktreeDir)) {
-        if (d.startsWith("M") && existsSync(join(worktreeDir, d, ".gsd", "auto.lock"))) {
+        if (d.startsWith("M") && (
+          existsSync(join(basePath, ".gsd", `auto-${d}.lock`)) ||
+          existsSync(join(worktreeDir, d, ".gsd", "auto.lock"))
+        )) {
           mids.add(d);
         }
       }
@@ -124,7 +127,10 @@ function discoverWorkers(basePath: string): string[] {
 }
 
 function querySliceProgress(basePath: string, mid: string): SliceProgress[] {
-  const dbPath = join(basePath, ".gsd", "worktrees", mid, ".gsd", "gsd.db");
+  // Shared-WAL: prefer project root DB (worktree DB may be empty or missing)
+  const rootDbPath = join(basePath, ".gsd", "gsd.db");
+  const wtDbPath = join(basePath, ".gsd", "worktrees", mid, ".gsd", "gsd.db");
+  const dbPath = existsSync(rootDbPath) ? rootDbPath : wtDbPath;
   if (!existsSync(dbPath)) return [];
 
   try {
@@ -164,7 +170,9 @@ function extractCostFromNdjson(basePath: string, mid: string): number {
 }
 
 function queryRecentCompletions(basePath: string, mid: string): string[] {
-  const dbPath = join(basePath, ".gsd", "worktrees", mid, ".gsd", "gsd.db");
+  const rootDbPath = join(basePath, ".gsd", "gsd.db");
+  const wtDbPath = join(basePath, ".gsd", "worktrees", mid, ".gsd", "gsd.db");
+  const dbPath = existsSync(rootDbPath) ? rootDbPath : wtDbPath;
   if (!existsSync(dbPath)) return [];
   try {
     const sql = `SELECT id, slice_id, one_liner FROM tasks WHERE milestone_id='${mid}' AND status='complete' AND completed_at IS NOT NULL ORDER BY completed_at DESC LIMIT 5`;
@@ -187,7 +195,10 @@ function collectWorkerData(basePath: string): WorkerView[] {
 
   for (const mid of mids) {
     const status = readJsonSafe<StatusJson>(join(parallelDir, `${mid}.status.json`));
-    const lock = readJsonSafe<AutoLock>(join(basePath, ".gsd", "worktrees", mid, ".gsd", "auto.lock"));
+    // Parallel workers write per-milestone lock files (auto-<MID>.lock) at the
+    // project root .gsd/, not auto.lock inside the worktree .gsd/ (#2815).
+    const lock = readJsonSafe<AutoLock>(join(basePath, ".gsd", `auto-${mid}.lock`))
+      || readJsonSafe<AutoLock>(join(basePath, ".gsd", "worktrees", mid, ".gsd", "auto.lock"));
     const slices = querySliceProgress(basePath, mid);
 
     const pid = lock?.pid || status?.pid || 0;

--- a/src/resources/extensions/gsd/tests/worktree-db-no-truncation.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-db-no-truncation.test.ts
@@ -1,0 +1,116 @@
+/**
+ * worktree-db-no-truncation.test.ts — Regression test for #2815.
+ *
+ * Verifies that syncProjectRootToWorktree does NOT delete or truncate
+ * the worktree's gsd.db file. Under the shared-WAL design (R012),
+ * workers resolve to the project root DB via resolveProjectRootDbPath().
+ * Deleting the worktree DB races with session startup, creating a 0-byte
+ * file that traps workers in an infinite evaluating-gates skip loop.
+ */
+
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  rmSync,
+  existsSync,
+  readFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { syncProjectRootToWorktree } from "../auto-worktree.ts";
+import { createTestContext } from "./test-helpers.ts";
+
+const { assertTrue, assertEq, report } = createTestContext();
+
+function createBase(name: string): string {
+  const base = mkdtempSync(join(tmpdir(), `gsd-wt-2815-${name}-`));
+  mkdirSync(join(base, ".gsd", "milestones"), { recursive: true });
+  return base;
+}
+
+function cleanup(base: string): void {
+  rmSync(base, { recursive: true, force: true });
+}
+
+async function main(): Promise<void> {
+  // ─── 1. Worktree gsd.db must NOT be deleted by sync ─────────────────────
+  console.log(
+    "\n=== 1. #2815: worktree gsd.db preserved after syncProjectRootToWorktree ===",
+  );
+  {
+    const mainBase = createBase("main");
+    const wtBase = createBase("wt");
+
+    try {
+      // Both have milestone dirs (required for sync to run)
+      const prM013 = join(mainBase, ".gsd", "milestones", "M013");
+      mkdirSync(prM013, { recursive: true });
+      writeFileSync(join(prM013, "M013-ROADMAP.md"), "# roadmap");
+
+      const wtM013 = join(wtBase, ".gsd", "milestones", "M013");
+      mkdirSync(wtM013, { recursive: true });
+
+      // Simulate a worktree DB (stale or otherwise)
+      const wtDbPath = join(wtBase, ".gsd", "gsd.db");
+      writeFileSync(wtDbPath, "FAKE_SQLITE_DATA_FOR_TEST");
+
+      syncProjectRootToWorktree(mainBase, wtBase, "M013");
+
+      // gsd.db must still exist and retain its content
+      assertTrue(
+        existsSync(wtDbPath),
+        "#2815: worktree gsd.db still exists after sync",
+      );
+      assertEq(
+        readFileSync(wtDbPath, "utf-8"),
+        "FAKE_SQLITE_DATA_FOR_TEST",
+        "#2815: worktree gsd.db content not truncated",
+      );
+    } finally {
+      cleanup(mainBase);
+      cleanup(wtBase);
+    }
+  }
+
+  // ─── 2. Sync still works when worktree has no gsd.db ───────────────────
+  console.log(
+    "\n=== 2. #2815: sync succeeds when worktree has no gsd.db ===",
+  );
+  {
+    const mainBase = createBase("main");
+    const wtBase = createBase("wt");
+
+    try {
+      const prM013 = join(mainBase, ".gsd", "milestones", "M013");
+      mkdirSync(prM013, { recursive: true });
+      writeFileSync(join(prM013, "M013-ROADMAP.md"), "# roadmap");
+
+      // No gsd.db in worktree — should not be created by sync
+      syncProjectRootToWorktree(mainBase, wtBase, "M013");
+
+      // gsd.db should NOT be created by sync
+      assertTrue(
+        !existsSync(join(wtBase, ".gsd", "gsd.db")),
+        "#2815: sync does not create gsd.db in worktree",
+      );
+
+      // But the milestone files should still be synced
+      assertTrue(
+        existsSync(join(wtBase, ".gsd", "milestones", "M013", "M013-ROADMAP.md")),
+        "#2815: milestone files still synced correctly",
+      );
+    } finally {
+      cleanup(mainBase);
+      cleanup(wtBase);
+    }
+  }
+
+  report();
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Problem

Parallel workers fail in four ways when running in worktree isolation mode, all caused by the v2.58 migration from `--print` to `headless --json auto` (#2801):

1. **DB truncation** — worktree `gsd.db` truncated to 0 bytes, infinite `evaluating-gates` loop
2. **Idle timer kills auto-mode** — headless 15s idle timer fires during slow tool calls, killing workers mid-task
3. **Monitor shows "idle / between units"** — monitor reads wrong lock file path / wrong DB path
4. **Provider-error pause kills the process** — transient API errors (500, rate limit) trigger `pauseAuto` which exits the process, killing the scheduled auto-resume timer

All four worked on v2.56 because parallel used `--print "/gsd auto"` (PI process loop, no headless wrapper). The v2.58 `headless` migration changed the execution context, exposing these latent issues.

Fixes #2815.

## Root Causes & Fixes

### 1. DB Truncation (`auto-worktree.ts`)

`syncProjectRootToWorktree()` deletes the worktree `gsd.db` every loop iteration (#853 fix). Under shared-WAL (R012), workers use the project root DB — deletion races with `openDatabase()` creating a 0-byte file.

**Fix:** Remove `unlinkSync(wtDb)` — stale worktree DBs are harmless under shared-WAL.

### 2. Headless Idle Timer (`headless.ts`)

The 15s `resetIdleTimer()` fires for ALL sessions including auto-mode. Any slow tool call (cloud storage reads, builds) emits no events for >15s → headless kills the session.

**Fix:** Skip idle timer for `isMultiTurnCommand` (auto/next) — auto-mode has its own supervision via `auto-timers.ts`.

### 3. Monitor Lock/DB Path (`parallel-monitor-overlay.ts`)

Parallel workers write `auto-<MID>.lock` in the project root `.gsd/`. The monitor reads `worktrees/<MID>/.gsd/auto.lock`. Similarly, DB queries targeted the worktree's empty `gsd.db` instead of the project root's shared DB.

**Fix:** Check `auto-<MID>.lock` from project root first; prefer project root DB for slice/task progress queries.

### 4. Provider-Error Pause Exits Process (`headless.ts`, `headless-events.ts`)

When auto-mode pauses for a transient error (500, rate limit), `pauseAuto()` sets `s.active = false` → auto-loop exits → RPC child exits → headless treats this as a fatal exit → process dies → the `setTimeout` for auto-resume dies with it. In parallel mode, heal mode sees the dead worker and respawns immediately into the same transient error, burning all retries.

**Fix:** Add `isPauseNotification()` and `extractAutoResumeDelay()` to detect "Auto-resuming in Xs..." notifications. When the RPC child exits after a provider-error pause, the headless process waits for the retry delay, starts a fresh RPC session, and re-sends `/gsd auto`. Loops until a terminal notification or clean exit. Mirrors the existing milestone-chaining pattern.

## Evidence

3-worker parallel run (M013, M014, M015) on GSD 2.58.0:

| Phase | Symptom | Fix |
|-------|---------|-----|
| All workers stuck in `evaluating-gates` loop | 0-byte worktree DBs | Commit 1 |
| M013 killed at 31s during PDF read | 15s idle timer | Commit 2 |
| M014 killed at 19min, M015 at 11min | 15s idle timer on slow tool call | Commit 2 |
| Monitor shows "idle / between units" for all | Wrong lock path + wrong DB | Commit 3 |
| M013 respawn-crash loop on API 500 | pauseAuto kills process + resume timer | Commit 4 |

## Tests

Added `worktree-db-no-truncation.test.ts`:
1. Worktree `gsd.db` preserved after `syncProjectRootToWorktree`
2. Sync succeeds when worktree has no `gsd.db`

Existing `worktree-sync-overwrite-loop.test.ts` passes unchanged.
TypeScript compilation passes with project tsconfig.
