### PR TITLE
fix: add missing worktree-merge case to model resolution switch

### DIFF
--- a/src/resources/extensions/gsd/preferences-models.ts
+++ b/src/resources/extensions/gsd/preferences-models.ts
@@ -69,6 +69,7 @@ export function resolveModelWithFallbacksForUnit(unitType: string): ResolvedMode
       break;
     case "complete-slice":
     case "complete-milestone":
+    case "worktree-merge":
     case "run-uat":
       phaseConfig = m.completion;
       break;

--- a/src/resources/extensions/gsd/preferences-types.ts
+++ b/src/resources/extensions/gsd/preferences-types.ts
@@ -100,7 +100,8 @@ export const KNOWN_PREFERENCE_KEYS = new Set<string>([
 export const KNOWN_UNIT_TYPES = [
   "research-milestone", "plan-milestone", "research-slice", "plan-slice",
   "execute-task", "reactive-execute", "gate-evaluate", "complete-slice", "replan-slice", "reassess-roadmap",
-  "run-uat", "complete-milestone",
+  "run-uat", "complete-milestone", "validate-milestone", "rewrite-docs",
+  "discuss-milestone", "discuss-slice", "worktree-merge",
 ] as const;
 export type UnitType = (typeof KNOWN_UNIT_TYPES)[number];
 

--- a/src/resources/extensions/gsd/tests/model-unittype-mapping.test.ts
+++ b/src/resources/extensions/gsd/tests/model-unittype-mapping.test.ts
@@ -155,6 +155,34 @@ test("all auto-dispatch unitTypes have preference mapping or subagent handling",
 });
 
 // ═══════════════════════════════════════════════════════════════════════════
+// #2900: worktree-merge must map to completion phase
+// ═══════════════════════════════════════════════════════════════════════════
+
+test("#2900: resolveModelWithFallbacksForUnit handles worktree-merge", () => {
+  assert.ok(preferencesSrc.includes('"worktree-merge"'), "missing worktree-merge case in switch");
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// #2900: KNOWN_UNIT_TYPES must include all dispatched unit types
+// ═══════════════════════════════════════════════════════════════════════════
+
+const preferenceTypesSrc = readSrc("preferences-types.ts");
+
+test("#2900: KNOWN_UNIT_TYPES includes all auto-dispatch unit types", () => {
+  const missing: string[] = [];
+  for (const ut of ALL_KNOWN_UNIT_TYPES) {
+    if (!preferenceTypesSrc.includes(`"${ut}"`)) {
+      missing.push(ut);
+    }
+  }
+  assert.deepEqual(missing, [], `Missing from KNOWN_UNIT_TYPES: ${missing.join(", ")}`);
+});
+
+test("#2900: KNOWN_UNIT_TYPES includes worktree-merge", () => {
+  assert.ok(preferenceTypesSrc.includes('"worktree-merge"'), "worktree-merge missing from KNOWN_UNIT_TYPES");
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
 // metrics.ts: classifyUnitPhase coverage
 // ═══════════════════════════════════════════════════════════════════════════
 


### PR DESCRIPTION
## Summary

- Add `worktree-merge` to the `resolveModelWithFallbacksForUnit` switch, mapping it to `m.completion` so it respects `models.completion` preference instead of silently falling through to the session start model
- Update `KNOWN_UNIT_TYPES` in `preferences-types.ts` to include all dispatched unit types that were missing: `validate-milestone`, `rewrite-docs`, `discuss-milestone`, `discuss-slice`, `worktree-merge`
- Add regression tests for #2900 verifying `worktree-merge` is in the switch and all dispatched unit types are in `KNOWN_UNIT_TYPES`

Closes #2900

## Test plan

- [x] New test `#2900: resolveModelWithFallbacksForUnit handles worktree-merge` passes
- [x] New test `#2900: KNOWN_UNIT_TYPES includes all auto-dispatch unit types` passes
- [x] New test `#2900: KNOWN_UNIT_TYPES includes worktree-merge` passes
- [x] All 18 model-unittype-mapping tests pass
- [x] Token-profile tests (24 tests) pass with no regressions

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>