### PR TITLE
fix: resolve OAuth API key in memory extraction

### DIFF
--- a/src/resources/extensions/gsd/memory-extractor.ts
+++ b/src/resources/extensions/gsd/memory-extractor.ts
@@ -89,12 +89,19 @@ export function buildMemoryLLMCall(ctx: ExtensionContext): LLMCallFn | null {
 
     return async (system: string, user: string): Promise<string> => {
       const { completeSimple } = await import('@gsd/pi-ai');
+
+      // Resolve API key via modelRegistry so OAuth tokens (auth.json) are used.
+      // Without this, OAuth users (Claude Max / Claude Pro) get no API key —
+      // getEnvApiKey() only checks env vars, which are not set for OAuth.
+      const resolvedApiKey = await ctx.modelRegistry.getApiKey(selectedModel).catch(() => undefined);
+
       const result: AssistantMessage = await completeSimple(selectedModel, {
         systemPrompt: system,
         messages: [{ role: 'user', content: [{ type: 'text', text: user }], timestamp: Date.now() }],
       }, {
         maxTokens: 2048,
         temperature: 0,
+        ...(resolvedApiKey ? { apiKey: resolvedApiKey } : {}),
       });
 
       // Extract text from response

--- a/src/resources/extensions/gsd/tests/memory-extractor.test.ts
+++ b/src/resources/extensions/gsd/tests/memory-extractor.test.ts
@@ -1,4 +1,4 @@
-import { parseMemoryResponse, _resetExtractionState } from '../memory-extractor.ts';
+import { parseMemoryResponse, _resetExtractionState, buildMemoryLLMCall } from '../memory-extractor.ts';
 import {
   openDatabase,
   closeDatabase,
@@ -9,7 +9,7 @@ import {
   getActiveMemoriesRanked,
 } from '../memory-store.ts';
 import type { MemoryAction } from '../memory-store.ts';
-import { describe, test, beforeEach, afterEach } from 'node:test';
+import { describe, test, beforeEach, afterEach, mock } from 'node:test';
 import assert from 'node:assert/strict';
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -167,5 +167,64 @@ test('memory-extractor: reset extraction state', () => {
   // Just verify it doesn't throw
   _resetExtractionState();
   assert.ok(true, '_resetExtractionState should not throw');
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// buildMemoryLLMCall: resolves OAuth API key via modelRegistry.getApiKey
+// ═══════════════════════════════════════════════════════════════════════════
+
+test('buildMemoryLLMCall: calls modelRegistry.getApiKey for OAuth credential resolution', async () => {
+  // For OAuth users, the API key is not in env vars — it must be resolved
+  // from auth.json via modelRegistry.getApiKey(). This test verifies that
+  // buildMemoryLLMCall calls getApiKey on the selected model.
+
+  const oauthToken = 'sk-ant-oat-test-oauth-token-12345';
+  let getApiKeyCalled = false;
+  let getApiKeyCalledWithModel: any = null;
+
+  const fakeModel = {
+    id: 'claude-3-5-haiku-20241022',
+    name: 'Haiku',
+    provider: 'anthropic',
+    api: 'anthropic-messages' as const,
+    cost: { input: 0.25, output: 1.25 },
+    maxTokens: 8192,
+    contextWindow: 200000,
+  };
+
+  const ctx = {
+    modelRegistry: {
+      getAvailable: () => [fakeModel],
+      getApiKey: async (model: any) => {
+        getApiKeyCalled = true;
+        getApiKeyCalledWithModel = model;
+        return oauthToken;
+      },
+    },
+  } as any;
+
+  const llmFn = buildMemoryLLMCall(ctx);
+  assert.ok(llmFn !== null, 'buildMemoryLLMCall should return a function');
+
+  // Invoke the LLM call — the function should resolve the API key from
+  // modelRegistry.getApiKey() before calling completeSimple. Even if
+  // completeSimple fails (no real provider), we need to verify getApiKey
+  // was called.
+  try {
+    await llmFn('test system prompt', 'test user prompt');
+  } catch {
+    // Expected: completeSimple will fail in test env (no real Anthropic provider).
+    // That's fine — we only care whether getApiKey was called.
+  }
+
+  assert.ok(
+    getApiKeyCalled,
+    'buildMemoryLLMCall must call modelRegistry.getApiKey() to resolve OAuth tokens from auth.json',
+  );
+  assert.deepStrictEqual(
+    getApiKeyCalledWithModel?.id,
+    fakeModel.id,
+    'getApiKey must be called with the selected model',
+  );
 });
 


### PR DESCRIPTION
## Summary

- `buildMemoryLLMCall` in `memory-extractor.ts` called `completeSimple` without passing an API key, routing to `streamSimpleAnthropic` which only checks env vars via `getEnvApiKey()`. OAuth users (Claude Max/Pro) have no `ANTHROPIC_API_KEY` env var — their token lives in `auth.json` — so the call threw, the outer catch swallowed it, and memory extraction silently never ran.
- Now resolves the API key through `ctx.modelRegistry.getApiKey(selectedModel)` (which handles both env vars and OAuth `auth.json` credentials) and passes it via `completeSimple`'s `apiKey` option.
- Added a regression test verifying `modelRegistry.getApiKey()` is called with the selected model when the LLM function is invoked.

Closes #2959

## Test plan

- [x] New test: `buildMemoryLLMCall: calls modelRegistry.getApiKey for OAuth credential resolution` — verifies `getApiKey` is called with the correct model
- [x] All existing memory-extractor tests pass (8/8)
- [ ] Manual verification: OAuth user completes a unit, `memory_processed_units` increments, `memories` table populates

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>