### PR TITLE
fix(auto): move selectAndApplyModel before updateProgressWidget

### DIFF
--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -929,6 +929,23 @@ export async function runUnitPhase(
     },
   );
 
+  // Select and apply model (with tier escalation on retry — normal units only)
+  const modelResult = await deps.selectAndApplyModel(
+    ctx,
+    pi,
+    unitType,
+    unitId,
+    s.basePath,
+    prefs,
+    s.verbose,
+    s.autoModeStartModel,
+    sidecarItem ? undefined : { isRetry, previousTier },
+  );
+  s.currentUnitRouting =
+    modelResult.routing as AutoSession["currentUnitRouting"];
+  s.currentUnitModel =
+    modelResult.appliedModel as AutoSession["currentUnitModel"];
+
   // Status bar + progress widget
   ctx.ui.setStatus("gsd-auto", "auto");
   if (mid)
@@ -1000,23 +1017,6 @@ export async function runUnitPhase(
       reorderErr instanceof Error ? reorderErr.message : String(reorderErr);
     logWarning("engine", "Prompt reorder failed", { error: msg });
   }
-
-  // Select and apply model (with tier escalation on retry — normal units only)
-  const modelResult = await deps.selectAndApplyModel(
-    ctx,
-    pi,
-    unitType,
-    unitId,
-    s.basePath,
-    prefs,
-    s.verbose,
-    s.autoModeStartModel,
-    sidecarItem ? undefined : { isRetry, previousTier },
-  );
-  s.currentUnitRouting =
-    modelResult.routing as AutoSession["currentUnitRouting"];
-  s.currentUnitModel =
-    modelResult.appliedModel as AutoSession["currentUnitModel"];
 
   // Apply sidecar/pre-dispatch hook model override (takes priority over standard model selection)
   const hookModelOverride = sidecarItem?.model ?? iterData.hookModelOverride;

--- a/src/resources/extensions/gsd/tests/auto-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-loop.test.ts
@@ -317,6 +317,35 @@ test("auto/resolve.ts one-shot pattern: _currentResolve is nulled before calling
   );
 });
 
+test("auto/phases.ts: selectAndApplyModel called exactly once and before updateProgressWidget (#2907)", () => {
+  const src = readFileSync(
+    resolve(import.meta.dirname, "..", "auto", "phases.ts"),
+    "utf-8",
+  );
+  // Extract the runUnitPhase function body
+  const fnStart = src.indexOf("export async function runUnitPhase");
+  assert.ok(fnStart > 0, "runUnitPhase should exist in phases.ts");
+  const fnBody = src.slice(fnStart, fnStart + 8000);
+
+  // selectAndApplyModel must appear exactly once
+  const allOccurrences = [...fnBody.matchAll(/selectAndApplyModel\(/g)];
+  assert.equal(
+    allOccurrences.length,
+    1,
+    `selectAndApplyModel should be called exactly once in runUnitPhase, found ${allOccurrences.length} calls`,
+  );
+
+  // selectAndApplyModel must appear BEFORE updateProgressWidget
+  const modelIdx = fnBody.indexOf("selectAndApplyModel(");
+  const widgetIdx = fnBody.indexOf("updateProgressWidget(");
+  assert.ok(modelIdx > 0, "selectAndApplyModel should exist in runUnitPhase");
+  assert.ok(widgetIdx > 0, "updateProgressWidget should exist in runUnitPhase");
+  assert.ok(
+    modelIdx < widgetIdx,
+    "selectAndApplyModel must be called BEFORE updateProgressWidget (#2899/#2907)",
+  );
+});
+
 // ─── autoLoop tests (T02) ─────────────────────────────────────────────────
 
 /**


### PR DESCRIPTION
## TL;DR

Moves `selectAndApplyModel` to before `updateProgressWidget` in `runUnitPhase` so the model is resolved before the dashboard widget renders, and ensures exactly one call per unit dispatch.

## What changed

- **`src/resources/extensions/gsd/auto/phases.ts`**: Moved the `selectAndApplyModel` block from after the prompt injection section to before `updateProgressWidget`. No logic changes — same arguments, same result assignments.
- **`src/resources/extensions/gsd/tests/auto-loop.test.ts`**: Added a structural regression test that reads the source of `phases.ts` and asserts `selectAndApplyModel` appears exactly once in `runUnitPhase` and before `updateProgressWidget`.

## Why

`selectAndApplyModel` was positioned after `updateProgressWidget` and the prompt injection block. This caused the dashboard to show the previous unit's model label (stale `ctx.model`). It also created the precondition for the regression described in #2907: if a second call were added before the widget (to fix #2899) without removing the original, every unit would call `selectAndApplyModel` twice, risking model bleed from `claude-code` providers via bare-ID disambiguation.

## How to verify

```bash
node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs \
  --experimental-strip-types --test \
  --test-name-pattern "selectAndApplyModel called exactly once" \
  src/resources/extensions/gsd/tests/auto-loop.test.ts
```

Closes #2907

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>