### PR TITLE
fix: prevent auto-mode from dispatching deferred slices

### DIFF
--- a/src/resources/extensions/gsd/db-writer.ts
+++ b/src/resources/extensions/gsd/db-writer.ts
@@ -316,6 +316,23 @@ export async function saveDecisionToDb(
       adapter?.prepare('DELETE FROM decisions WHERE id = :id').run({ ':id': id });
       throw diskErr;
     }
+    // #2661: When a decision defers a slice, update the slice status in the DB
+    // so the dispatcher skips it. Without this, STATE.md and DECISIONS.md are
+    // in split-brain: the decision says "deferred" but the state still says
+    // "active", causing auto-mode to keep dispatching the deferred work.
+    try {
+      const sliceRef = extractDeferredSliceRef(fields);
+      if (sliceRef) {
+        db.updateSliceStatus(sliceRef.milestoneId, sliceRef.sliceId, 'deferred');
+      }
+    } catch (deferErr) {
+      // Non-fatal — log but don't fail the decision save
+      logError('manifest', 'failed to update deferred slice status', {
+        fn: 'saveDecisionToDb',
+        error: String((deferErr as Error).message),
+      });
+    }
+
     // Invalidate file-read caches so deriveState() sees the updated markdown.
     // Do NOT clear the artifacts table — we just wrote to it intentionally.
     invalidateStateCache();
@@ -327,6 +344,39 @@ export async function saveDecisionToDb(
     logError('manifest', 'saveDecisionToDb failed', { fn: 'saveDecisionToDb', error: String((err as Error).message) });
     throw err;
   }
+}
+
+/**
+ * Extract a milestone/slice reference from a deferral decision.
+ *
+ * Detects deferrals by checking:
+ *   - scope contains "defer" (e.g., "deferral", "defer")
+ *   - choice or decision contains "defer" + an M###/S## pattern
+ *
+ * Returns { milestoneId, sliceId } if found, null otherwise.
+ */
+export function extractDeferredSliceRef(
+  fields: Pick<SaveDecisionFields, 'scope' | 'decision' | 'choice'>,
+): { milestoneId: string; sliceId: string } | null {
+  const isDeferral =
+    /\bdefer(?:ral|red)?\b/i.test(fields.scope) ||
+    /\bdefer(?:ral|red|ring|s)?\b/i.test(fields.choice) ||
+    /\bdefer(?:ral|red|ring|s)?\b/i.test(fields.decision);
+
+  if (!isDeferral) return null;
+
+  // Look for M###/S## pattern in choice first, then decision
+  const slicePattern = /\b(M\d{3,4})\/(S\d{2,3})\b/;
+  const choiceMatch = fields.choice.match(slicePattern);
+  if (choiceMatch) {
+    return { milestoneId: choiceMatch[1], sliceId: choiceMatch[2] };
+  }
+  const decisionMatch = fields.decision.match(slicePattern);
+  if (decisionMatch) {
+    return { milestoneId: decisionMatch[1], sliceId: decisionMatch[2] };
+  }
+
+  return null;
 }
 
 // ─── Update Requirement in DB + Regenerate Markdown ───────────────────────

--- a/src/resources/extensions/gsd/state.ts
+++ b/src/resources/extensions/gsd/state.ts
@@ -36,7 +36,7 @@ import {
 
 import { findMilestoneIds } from './milestone-ids.js';
 import { loadQueueOrder, sortByQueueOrder } from './queue-order.js';
-import { isClosedStatus } from './status-guards.js';
+import { isClosedStatus, isDeferredStatus } from './status-guards.js';
 import { nativeBatchParseGsdFiles, type BatchParsedFile } from './native-parser-bridge.js';
 
 import { join, resolve } from 'path';
@@ -617,6 +617,10 @@ export async function deriveStateFromDb(basePath: string): Promise<GSDState> {
 
   for (const s of activeMilestoneSlices) {
     if (isClosedStatus(s.status)) continue;
+    // #2661: Skip deferred slices — a decision explicitly deferred this work.
+    // Without this guard the dispatcher would keep dispatching deferred slices
+    // because DECISIONS.md is only contextual, not authoritative for dispatch.
+    if (isDeferredStatus(s.status)) continue;
     if (s.depends.every(dep => doneSliceIds.has(dep))) {
       activeSlice = { id: s.id, title: s.title };
       activeSliceRow = s;

--- a/src/resources/extensions/gsd/status-guards.ts
+++ b/src/resources/extensions/gsd/status-guards.ts
@@ -11,3 +11,16 @@
 export function isClosedStatus(status: string): boolean {
   return status === "complete" || status === "done";
 }
+
+/** Returns true when a slice status indicates it was deferred by a decision. */
+export function isDeferredStatus(status: string): boolean {
+  return status === "deferred";
+}
+
+/**
+ * Returns true when a slice should be skipped during active-slice selection.
+ * This includes both closed (complete/done) and deferred slices.
+ */
+export function isInactiveStatus(status: string): boolean {
+  return isClosedStatus(status) || isDeferredStatus(status);
+}

--- a/src/resources/extensions/gsd/tests/deferred-slice-dispatch.test.ts
+++ b/src/resources/extensions/gsd/tests/deferred-slice-dispatch.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Regression test for #2661: Auto-mode dispatches deferred slices.
+ *
+ * When a decision defers a slice, the dispatcher must skip it and advance
+ * to the next eligible slice. This tests both:
+ *   1. deriveStateFromDb skips slices with status "deferred"
+ *   2. saveDecisionToDb updates the slice status when the decision is a deferral
+ */
+
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { deriveStateFromDb, invalidateStateCache } from "../state.ts";
+import {
+  openDatabase,
+  closeDatabase,
+  isDbAvailable,
+  insertMilestone,
+  insertSlice,
+  insertTask,
+  insertArtifact,
+  updateSliceStatus,
+} from "../gsd-db.ts";
+import { isDeferredStatus } from "../status-guards.ts";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────
+
+function createFixtureBase(): string {
+  const base = mkdtempSync(join(tmpdir(), "gsd-deferred-dispatch-"));
+  mkdirSync(join(base, ".gsd", "milestones"), { recursive: true });
+  return base;
+}
+
+function writeFile(base: string, relativePath: string, content: string): void {
+  const full = join(base, ".gsd", relativePath);
+  mkdirSync(join(full, ".."), { recursive: true });
+  writeFileSync(full, content);
+}
+
+function cleanup(base: string): void {
+  rmSync(base, { recursive: true, force: true });
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────
+
+describe("deferred-slice-dispatch (#2661)", () => {
+  test("isDeferredStatus returns true for 'deferred'", () => {
+    assert.ok(isDeferredStatus("deferred"), "should recognize 'deferred'");
+    assert.ok(!isDeferredStatus("active"), "should not match 'active'");
+    assert.ok(!isDeferredStatus("complete"), "should not match 'complete'");
+    assert.ok(!isDeferredStatus("pending"), "should not match 'pending'");
+  });
+
+  test("deriveStateFromDb skips deferred slice and picks next eligible", async () => {
+    const base = createFixtureBase();
+    try {
+      openDatabase(":memory:");
+      assert.ok(isDbAvailable());
+
+      // M001 with three slices: S01 complete, S02 deferred, S03 pending
+      insertMilestone({ id: "M001", title: "Test Milestone", status: "active" });
+
+      insertSlice({ id: "S01", milestoneId: "M001", title: "Done Slice", status: "complete", risk: "low", depends: [] });
+      insertSlice({ id: "S02", milestoneId: "M001", title: "Deferred Slice", status: "deferred", risk: "low", depends: [] });
+      insertSlice({ id: "S03", milestoneId: "M001", title: "Next Slice", status: "pending", risk: "low", depends: [] });
+
+      // S01 needs a SUMMARY file to count as complete for milestone-level checks
+      writeFile(base, "milestones/M001/M001-ROADMAP.md", `# M001: Test Milestone
+
+**Vision:** Test deferred slices.
+
+## Slices
+
+- [x] **S01: Done Slice** \`risk:low\` \`depends:[]\`
+  > Done.
+
+- [ ] **S02: Deferred Slice** \`risk:low\` \`depends:[]\`
+  > Deferred.
+
+- [ ] **S03: Next Slice** \`risk:low\` \`depends:[]\`
+  > Next.
+`);
+      writeFile(base, "milestones/M001/slices/S01/S01-SUMMARY.md", "# S01 Summary\nDone.");
+
+      invalidateStateCache();
+      const state = await deriveStateFromDb(base);
+
+      // The active slice must be S03, NOT S02 (which is deferred)
+      assert.equal(state.activeMilestone?.id, "M001", "active milestone is M001");
+      assert.equal(state.activeSlice?.id, "S03", "active slice should skip deferred S02 and land on S03");
+      assert.notEqual(state.activeSlice?.id, "S02", "active slice must NOT be the deferred S02");
+
+      closeDatabase();
+    } finally {
+      closeDatabase();
+      cleanup(base);
+    }
+  });
+
+  test("deriveStateFromDb does not count deferred slices as done for progress", async () => {
+    const base = createFixtureBase();
+    try {
+      openDatabase(":memory:");
+
+      insertMilestone({ id: "M001", title: "Test", status: "active" });
+      insertSlice({ id: "S01", milestoneId: "M001", title: "Complete", status: "complete", risk: "low", depends: [] });
+      insertSlice({ id: "S02", milestoneId: "M001", title: "Deferred", status: "deferred", risk: "low", depends: [] });
+      insertSlice({ id: "S03", milestoneId: "M001", title: "Pending", status: "pending", risk: "low", depends: [] });
+
+      writeFile(base, "milestones/M001/M001-ROADMAP.md", `# M001
+## Slices
+- [x] **S01: Complete** \`risk:low\` \`depends:[]\`
+- [ ] **S02: Deferred** \`risk:low\` \`depends:[]\`
+- [ ] **S03: Pending** \`risk:low\` \`depends:[]\`
+`);
+      writeFile(base, "milestones/M001/slices/S01/S01-SUMMARY.md", "# Done");
+
+      invalidateStateCache();
+      const state = await deriveStateFromDb(base);
+
+      // Deferred slices should not count as "done" in progress
+      // Only S01 (complete) counts as done
+      assert.equal(state.progress?.slices?.done, 1, "only 1 slice (S01) should be done");
+      // Total should still be 3 (deferred slices are still part of the milestone)
+      assert.equal(state.progress?.slices?.total, 3, "all 3 slices counted in total");
+
+      closeDatabase();
+    } finally {
+      closeDatabase();
+      cleanup(base);
+    }
+  });
+
+  test("all slices deferred results in blocked state", async () => {
+    const base = createFixtureBase();
+    try {
+      openDatabase(":memory:");
+
+      insertMilestone({ id: "M001", title: "Test", status: "active" });
+      insertSlice({ id: "S01", milestoneId: "M001", title: "Deferred A", status: "deferred", risk: "low", depends: [] });
+      insertSlice({ id: "S02", milestoneId: "M001", title: "Deferred B", status: "deferred", risk: "low", depends: [] });
+
+      writeFile(base, "milestones/M001/M001-ROADMAP.md", `# M001
+## Slices
+- [ ] **S01: Deferred A** \`risk:low\` \`depends:[]\`
+- [ ] **S02: Deferred B** \`risk:low\` \`depends:[]\`
+`);
+
+      invalidateStateCache();
+      const state = await deriveStateFromDb(base);
+
+      // No eligible slice — should be blocked
+      assert.equal(state.activeSlice, null, "no active slice when all deferred");
+      assert.equal(state.phase, "blocked", "phase should be blocked when all slices deferred");
+
+      closeDatabase();
+    } finally {
+      closeDatabase();
+      cleanup(base);
+    }
+  });
+
+  test("saveDecisionToDb marks slice as deferred when decision is a deferral", async () => {
+    const base = createFixtureBase();
+    try {
+      openDatabase(":memory:");
+
+      insertMilestone({ id: "M001", title: "Test", status: "active" });
+      insertSlice({ id: "S03", milestoneId: "M001", title: "Target Slice", status: "active", risk: "low", depends: [] });
+
+      writeFile(base, "milestones/M001/M001-ROADMAP.md", `# M001
+## Slices
+- [ ] **S03: Target Slice** \`risk:low\` \`depends:[]\`
+`);
+
+      const { saveDecisionToDb } = await import("../db-writer.ts");
+      const { getSlice } = await import("../gsd-db.ts");
+
+      // Save a deferral decision that references M001/S03
+      await saveDecisionToDb(
+        {
+          scope: "deferral",
+          decision: "Defer S03 to focus on higher priority work",
+          choice: "defer M001/S03",
+          rationale: "Not ready yet",
+        },
+        base,
+      );
+
+      // The slice status should now be "deferred"
+      const slice = getSlice("M001", "S03");
+      assert.equal(slice?.status, "deferred", "slice status should be updated to 'deferred' after deferral decision");
+
+      closeDatabase();
+    } finally {
+      closeDatabase();
+      cleanup(base);
+    }
+  });
+});


### PR DESCRIPTION
## TL;DR

Auto-mode dispatched deferred slices because `gsd_decision_save` wrote the deferral to DECISIONS.md but never updated the slice status in the DB. The dispatcher reads DB state, not DECISIONS.md, causing a split-brain that burned $31+ in tokens on wrong work.

## What changed

1. **`status-guards.ts`** — Added `isDeferredStatus()` and `isInactiveStatus()` predicates so the state machine can distinguish deferred slices from active ones.

2. **`state.ts`** — The active-slice selection loop (`deriveStateFromDb`) now skips slices with `"deferred"` status, just as it already skips `"complete"`/`"done"` slices. When all remaining slices are deferred, the state correctly reports `"blocked"`.

3. **`db-writer.ts`** — `saveDecisionToDb` now detects deferral decisions (by matching `defer`/`deferral`/`deferred` in scope/choice/decision fields) and extracts the `M###/S##` slice reference. When found, it calls `updateSliceStatus()` to set the slice to `"deferred"` in the DB — closing the split-brain at the source.

## Why

The root cause was a missing write path: decisions were saved to DECISIONS.md (contextual) but never propagated to the DB (authoritative for dispatch). The dispatcher instruction "Execute T01" overrode the contextual deferral in DECISIONS.md, so agents followed the instruction, not the decision.

## How

- Detection uses regex matching on the decision fields for deferral intent + M###/S## pattern extraction
- The status update is non-fatal (logged but does not fail the decision save) for robustness
- Defense in depth: even if `saveDecisionToDb` misses a deferral, manually setting a slice to "deferred" status in the DB will now be respected by the state machine

## Test plan

- [x] `isDeferredStatus` returns true for "deferred", false for other statuses
- [x] `deriveStateFromDb` skips deferred slices and picks the next eligible one
- [x] Deferred slices do not count as "done" in progress tracking
- [x] All-deferred milestone correctly enters "blocked" phase
- [x] `saveDecisionToDb` updates slice status to "deferred" when decision is a deferral
- [x] Full unit test suite: 3342 passed, 0 failed

Closes #2661

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>