### PR TITLE
fix(auto): break retry loop on tool invocation errors (malformed JSON)

### DIFF
--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -466,6 +466,18 @@ export async function postUnitPreVerification(pctx: PostUnitContext, opts?: PreV
       // artifact, return "retry" so the caller re-dispatches with failure context
       // instead of blindly re-dispatching the same unit (#1571).
       if (!triggerArtifactVerified) {
+        // #2883: If the artifact is missing because the tool invocation itself
+        // failed (malformed/truncated JSON arguments), retrying will produce the
+        // same failure. Pause auto-mode instead of entering a stuck retry loop.
+        if (s.lastToolInvocationError) {
+          const errMsg = `Tool invocation failed for ${s.currentUnit.type}: ${s.lastToolInvocationError}. Structured argument generation failed — pausing auto-mode.`;
+          debugLog("postUnit", { phase: "tool-invocation-error-pause", unitType: s.currentUnit.type, unitId: s.currentUnit.id, error: s.lastToolInvocationError });
+          ctx.ui.notify(errMsg, "error");
+          s.lastToolInvocationError = null;
+          await pauseAuto(ctx, pi);
+          return "dispatched";
+        }
+
         const hasExpectedArtifact = resolveExpectedArtifactPath(s.currentUnit.type, s.currentUnit.id, s.basePath) !== null;
         if (hasExpectedArtifact) {
           const retryKey = `${s.currentUnit.type}:${s.currentUnit.id}`;

--- a/src/resources/extensions/gsd/auto-tool-tracking.ts
+++ b/src/resources/extensions/gsd/auto-tool-tracking.ts
@@ -83,3 +83,22 @@ export function hasInteractiveToolInFlight(): boolean {
 export function clearInFlightTools(): void {
   inFlightTools.clear();
 }
+
+// ─── Tool invocation error classification (#2883) ────────────────────────
+
+/**
+ * Patterns that indicate a tool invocation failed due to malformed or truncated
+ * JSON arguments — as opposed to a normal business-logic error from the tool
+ * handler. When these errors occur, retrying the same unit will produce the same
+ * failure, so the retry loop must be broken.
+ */
+const TOOL_INVOCATION_ERROR_RE = /Validation failed for tool|Expected ',' or '\}' in JSON|Unexpected end of JSON|Unexpected token.*in JSON/i;
+
+/**
+ * Returns true if the error message indicates a tool invocation failure due to
+ * malformed/truncated arguments (as opposed to a normal tool execution error).
+ */
+export function isToolInvocationError(errorMsg: string): boolean {
+  if (!errorMsg) return false;
+  return TOOL_INVOCATION_ERROR_RE.test(errorMsg);
+}

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -75,6 +75,7 @@ import {
   getOldestInFlightToolStart,
   hasInteractiveToolInFlight,
   clearInFlightTools,
+  isToolInvocationError,
 } from "./auto-tool-tracking.js";
 import { closeoutUnit } from "./auto-unit-closeout.js";
 import { recoverTimedOutUnit } from "./auto-timeout-recovery.js";
@@ -382,6 +383,19 @@ export function markToolStart(toolCallId: string, toolName?: string): void {
 
 export function markToolEnd(toolCallId: string): void {
   _markToolEnd(toolCallId);
+}
+
+/**
+ * Record a tool invocation error on the current session (#2883).
+ * Called from tool_execution_end when a GSD tool fails with isError.
+ * Only stores the error if it matches the tool-invocation-error pattern
+ * (malformed/truncated JSON), not normal business-logic errors.
+ */
+export function recordToolInvocationError(toolName: string, errorMsg: string): void {
+  if (!s.active) return;
+  if (isToolInvocationError(errorMsg)) {
+    s.lastToolInvocationError = `${toolName}: ${errorMsg}`;
+  }
 }
 
 export function getOldestInFlightToolAgeMs(): number {

--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -910,6 +910,7 @@ export async function runUnitPhase(
   const previousTier = s.currentUnitRouting?.tier;
 
   s.currentUnit = { type: unitType, id: unitId, startedAt: Date.now() };
+  s.lastToolInvocationError = null; // #2883: clear stale error from previous unit
   const unitStartSeq = ic.nextSeq();
   deps.emitJournalEvent({ ts: new Date().toISOString(), flowId: ic.flowId, seq: unitStartSeq, eventType: "unit-start", data: { unitType, unitId } });
   deps.captureAvailableSkills();

--- a/src/resources/extensions/gsd/auto/session.ts
+++ b/src/resources/extensions/gsd/auto/session.ts
@@ -120,6 +120,11 @@ export class AutoSession {
   // ── Sidecar queue ─────────────────────────────────────────────────────
   sidecarQueue: SidecarItem[] = [];
 
+  // ── Tool invocation errors (#2883) ──────────────────────────────────
+  /** Set when a GSD tool execution ends with isError due to malformed/truncated
+   *  JSON arguments. Checked by postUnitPreVerification to break retry loops. */
+  lastToolInvocationError: string | null = null;
+
   // ── Isolation degradation ────────────────────────────────────────────
   /** Set to true when worktree creation fails; prevents merge of nonexistent branch. */
   isolationDegraded = false;
@@ -212,6 +217,7 @@ export class AutoSession {
     this.pendingQuickTasks = [];
     this.sidecarQueue = [];
     this.rewriteAttemptCount = 0;
+    this.lastToolInvocationError = null;
     this.isolationDegraded = false;
     this.milestoneMergedInPhases = false;
 

--- a/src/resources/extensions/gsd/bootstrap/register-hooks.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-hooks.ts
@@ -12,7 +12,7 @@ import { getDiscussionMilestoneId } from "../guided-flow.js";
 import { loadToolApiKeys } from "../commands-config.js";
 import { loadFile, saveFile, formatContinue } from "../files.js";
 import { deriveState } from "../state.js";
-import { getAutoDashboardData, isAutoActive, isAutoPaused, markToolEnd, markToolStart } from "../auto.js";
+import { getAutoDashboardData, isAutoActive, isAutoPaused, markToolEnd, markToolStart, recordToolInvocationError } from "../auto.js";
 import { isParallelActive, shutdownParallel } from "../parallel-orchestrator.js";
 import { checkToolCallLoop, resetToolCallLoopGuard } from "./tool-call-loop-guard.js";
 import { saveActivityLog } from "../activity-log.js";
@@ -250,6 +250,14 @@ export function registerHooks(pi: ExtensionAPI): void {
 
   pi.on("tool_execution_end", async (event) => {
     markToolEnd(event.toolCallId);
+    // #2883: Capture tool invocation errors (malformed/truncated JSON arguments)
+    // so postUnitPreVerification can break the retry loop instead of re-dispatching.
+    if (event.isError && event.toolName.startsWith("gsd_")) {
+      const errorText = typeof event.result === "string"
+        ? event.result
+        : (typeof event.result?.content?.[0]?.text === "string" ? event.result.content[0].text : String(event.result));
+      recordToolInvocationError(event.toolName, errorText);
+    }
   });
 
   pi.on("model_select", async (_event, ctx) => {

--- a/src/resources/extensions/gsd/tests/tool-invocation-error-loop-break.test.ts
+++ b/src/resources/extensions/gsd/tests/tool-invocation-error-loop-break.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Regression tests for #2883: gsd_complete_slice tool invocation fails with
+ * JSON truncation, causing stuck retry loop.
+ *
+ * When a GSD tool is invoked with malformed/truncated JSON arguments, the tool
+ * execution fails (isError: true). But postUnitPreVerification only checks if
+ * the expected artifact exists on disk — it does not know the tool itself failed.
+ * When the artifact is missing (because the tool never ran), it sets up
+ * pendingVerificationRetry, re-dispatching the same unit with the same truncated
+ * input, creating a stuck loop.
+ *
+ * The fix adds a `lastToolInvocationError` field to AutoSession. When a GSD tool
+ * execution ends with isError, the error is recorded. postUnitPreVerification
+ * checks this field before retrying — if a tool invocation error occurred, it
+ * pauses auto-mode instead of retrying.
+ */
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import { AutoSession } from "../auto/session.ts";
+
+// ─── AutoSession.lastToolInvocationError field ───────────────────────────
+
+describe("#2883: tool invocation error tracking on AutoSession", () => {
+  test("lastToolInvocationError defaults to null", () => {
+    const s = new AutoSession();
+    assert.equal(s.lastToolInvocationError, null);
+  });
+
+  test("lastToolInvocationError is cleared on reset()", () => {
+    const s = new AutoSession();
+    s.lastToolInvocationError = "Validation failed for tool gsd_complete_slice";
+    assert.ok(s.lastToolInvocationError);
+    s.reset();
+    assert.equal(s.lastToolInvocationError, null);
+  });
+
+  test("lastToolInvocationError can store truncated JSON error", () => {
+    const s = new AutoSession();
+    const errorMsg = "Expected ',' or '}' in JSON at position 4096";
+    s.lastToolInvocationError = errorMsg;
+    assert.equal(s.lastToolInvocationError, errorMsg);
+  });
+});
+
+// ─── isToolInvocationError classifier ────────────────────────────────────
+
+import { isToolInvocationError } from "../auto-tool-tracking.ts";
+
+describe("#2883: isToolInvocationError classification", () => {
+  test("detects JSON validation failure pattern", () => {
+    assert.equal(
+      isToolInvocationError("Validation failed for tool gsd_complete_slice: Expected ',' or '}' in JSON"),
+      true,
+    );
+  });
+
+  test("detects truncated JSON parse error", () => {
+    assert.equal(
+      isToolInvocationError("Expected ',' or '}' in JSON at position 4096"),
+      true,
+    );
+  });
+
+  test("detects Unexpected end of JSON input", () => {
+    assert.equal(
+      isToolInvocationError("Unexpected end of JSON input"),
+      true,
+    );
+  });
+
+  test("detects Unexpected token in JSON", () => {
+    assert.equal(
+      isToolInvocationError("Unexpected token < in JSON at position 0"),
+      true,
+    );
+  });
+
+  test("detects 'Validation failed for tool' prefix", () => {
+    assert.equal(
+      isToolInvocationError("Validation failed for tool gsd_slice_complete"),
+      true,
+    );
+  });
+
+  test("returns false for normal tool errors (business logic)", () => {
+    assert.equal(
+      isToolInvocationError("Slice S01 is already complete"),
+      false,
+    );
+  });
+
+  test("returns false for empty string", () => {
+    assert.equal(isToolInvocationError(""), false);
+  });
+
+  test("returns false for generic error", () => {
+    assert.equal(isToolInvocationError("Something went wrong"), false);
+  });
+
+  test("returns false for network errors (handled elsewhere)", () => {
+    assert.equal(isToolInvocationError("ECONNRESET"), false);
+  });
+});


### PR DESCRIPTION
## TL;DR

When a GSD tool is invoked with truncated/malformed JSON arguments, pause auto-mode instead of entering a stuck retry loop.

## What

- Add `isToolInvocationError()` classifier in `auto-tool-tracking.ts` to detect JSON validation/parse errors
- Add `lastToolInvocationError` field to `AutoSession` to track tool invocation failures
- Wire `tool_execution_end` hook to capture GSD tool errors matching the invocation-error pattern
- In `postUnitPreVerification`, check for tool invocation errors before setting up artifact verification retry -- if present, pause auto-mode with a diagnostic message

## Why

When the LLM generates a massive JSON argument for `gsd_complete_slice` that gets truncated mid-serialization, the tool invocation fails with a JSON validation error. However, `postUnitPreVerification` only checks artifact existence -- it cannot distinguish "tool never ran" from "tool ran but forgot to write artifact". This causes `pendingVerificationRetry` to be set, re-dispatching the same unit with the same malformed arguments, creating a stuck retry loop (observed: unit dispatched 2+ times with identical errors).

## How

1. `isToolInvocationError()` matches patterns like `Validation failed for tool`, `Expected ',' or '}'`, `Unexpected end of JSON input`, and `Unexpected token in JSON`
2. `tool_execution_end` hook checks `event.isError` for `gsd_*` tools and calls `recordToolInvocationError()` which only stores the error if it matches the invocation-error pattern (not normal business-logic errors)
3. `postUnitPreVerification` checks `s.lastToolInvocationError` before entering the retry path -- if set, it calls `pauseAuto()` with a diagnostic message instead
4. `lastToolInvocationError` is cleared on unit start and session reset to prevent stale errors from leaking

Closes #2883

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>