### PR TITLE
feat(sse): add cursor-based event replay for browser reconnection [1/4]

### DIFF
--- a/src/web/__tests__/event-log.test.ts
+++ b/src/web/__tests__/event-log.test.ts
@@ -1,0 +1,384 @@
+import { describe, test, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync, chmodSync, statSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { EventLog, getEventLogDir } from "../event-log.ts";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeTmpDir(): string {
+  return mkdtempSync(join(tmpdir(), "event-log-test-"));
+}
+
+async function collectEntries(gen: AsyncIterable<{ seq: number; event: unknown; ts: string }>) {
+  const entries: { seq: number; event: unknown; ts: string }[] = [];
+  for await (const entry of gen) {
+    entries.push(entry);
+  }
+  return entries;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("EventLog", () => {
+  let tmpDir: string;
+  let log: EventLog;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+    log = new EventLog(tmpDir);
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  // --- init ---
+
+  test("init() on a non-existent file starts seq at 0", async () => {
+    await log.init();
+    assert.equal(log.currentSeq, 0);
+  });
+
+  test("init() restores seq from last valid line of existing log file", async () => {
+    // Write a stub log with some entries
+    const lines = [
+      JSON.stringify({ seq: 10, event: { type: "a" }, ts: "2024-01-01T00:00:00.000Z" }),
+      JSON.stringify({ seq: 20, event: { type: "b" }, ts: "2024-01-01T00:00:01.000Z" }),
+      JSON.stringify({ seq: 42, event: { type: "c" }, ts: "2024-01-01T00:00:02.000Z" }),
+    ].join("\n") + "\n";
+    writeFileSync(join(tmpDir, "events.jsonl"), lines);
+
+    await log.init();
+    assert.equal(log.currentSeq, 42);
+  });
+
+  test("init() with a truncated/malformed last line restores seq from last valid line", async () => {
+    const lines = [
+      JSON.stringify({ seq: 5, event: { type: "a" }, ts: "2024-01-01T00:00:00.000Z" }),
+      JSON.stringify({ seq: 7, event: { type: "b" }, ts: "2024-01-01T00:00:01.000Z" }),
+      '{"seq":99,"event":{"type":"c"},"ts":"TRUNCATED', // malformed — no closing
+    ].join("\n") + "\n";
+    writeFileSync(join(tmpDir, "events.jsonl"), lines);
+
+    await log.init();
+    assert.equal(log.currentSeq, 7);
+  });
+
+  // --- append ---
+
+  test("append() writes a JSON line with seq and event fields", async () => {
+    await log.init();
+    log.append({ type: "test_event", data: "hello" });
+
+    const content = readFileSync(join(tmpDir, "events.jsonl"), "utf-8");
+    const lines = content.trim().split("\n");
+    assert.equal(lines.length, 1);
+    const parsed = JSON.parse(lines[0]);
+    assert.equal(parsed.seq, 1);
+    assert.deepEqual(parsed.event, { type: "test_event", data: "hello" });
+    assert.ok(typeof parsed.ts === "string");
+  });
+
+  test("append() increments seq monotonically", async () => {
+    await log.init();
+    log.append({ type: "e1" });
+    log.append({ type: "e2" });
+    log.append({ type: "e3" });
+
+    const content = readFileSync(join(tmpDir, "events.jsonl"), "utf-8");
+    const lines = content.trim().split("\n");
+    assert.equal(lines.length, 3);
+    assert.equal(JSON.parse(lines[0]).seq, 1);
+    assert.equal(JSON.parse(lines[1]).seq, 2);
+    assert.equal(JSON.parse(lines[2]).seq, 3);
+  });
+
+  test("append() continues seq from restored value after init", async () => {
+    const existingLines = [
+      JSON.stringify({ seq: 42, event: { type: "x" }, ts: "2024-01-01T00:00:00.000Z" }),
+    ].join("\n") + "\n";
+    writeFileSync(join(tmpDir, "events.jsonl"), existingLines);
+
+    await log.init();
+    log.append({ type: "new" });
+
+    const content = readFileSync(join(tmpDir, "events.jsonl"), "utf-8");
+    const lines = content.trim().split("\n");
+    assert.equal(lines.length, 2);
+    assert.equal(JSON.parse(lines[1]).seq, 43);
+  });
+
+  test("append() catches write errors gracefully (does not throw)", async () => {
+    await log.init();
+
+    // Make log file read-only to simulate write error — skip if root
+    const logPath = join(tmpDir, "events.jsonl");
+    // Write a valid entry first so the file exists
+    log.append({ type: "first" });
+    chmodSync(logPath, 0o444);
+
+    // Should not throw even though file is read-only
+    try {
+      assert.doesNotThrow(() => log.append({ type: "second" }));
+    } finally {
+      chmodSync(logPath, 0o644);
+    }
+  });
+
+  // --- currentSeq ---
+
+  test("currentSeq getter returns the current sequence number", async () => {
+    await log.init();
+    assert.equal(log.currentSeq, 0);
+    log.append({ type: "a" });
+    assert.equal(log.currentSeq, 1);
+    log.append({ type: "b" });
+    assert.equal(log.currentSeq, 2);
+  });
+
+  // --- filePath ---
+
+  test("filePath getter returns path to events.jsonl inside logDir", async () => {
+    assert.equal(log.filePath, join(tmpDir, "events.jsonl"));
+  });
+
+  // --- readSince ---
+
+  test("readSince(5) returns only entries with seq > 5", async () => {
+    await log.init();
+    for (let i = 0; i < 10; i++) {
+      log.append({ type: `event_${i}` });
+    }
+
+    const entries = await collectEntries(log.readSince(5));
+    assert.equal(entries.length, 5);
+    assert.equal(entries[0].seq, 6);
+    assert.equal(entries[4].seq, 10);
+  });
+
+  test("readSince(0) returns all entries", async () => {
+    await log.init();
+    log.append({ type: "a" });
+    log.append({ type: "b" });
+
+    const entries = await collectEntries(log.readSince(0));
+    assert.equal(entries.length, 2);
+  });
+
+  test("readSince(-1) returns no entries (skip replay)", async () => {
+    await log.init();
+    log.append({ type: "a" });
+    log.append({ type: "b" });
+
+    const entries = await collectEntries(log.readSince(-1));
+    assert.equal(entries.length, 0);
+  });
+
+  test("readSince() on empty/missing file returns empty", async () => {
+    await log.init();
+    const entries = await collectEntries(log.readSince(0));
+    assert.equal(entries.length, 0);
+  });
+
+  test("readSince() skips malformed lines silently", async () => {
+    await log.init();
+    log.append({ type: "a" });
+    // Inject a malformed line
+    const logPath = join(tmpDir, "events.jsonl");
+    const current = readFileSync(logPath, "utf-8");
+    writeFileSync(logPath, current + "NOT_JSON\n");
+    log.append({ type: "b" });
+
+    const entries = await collectEntries(log.readSince(0));
+    // Should get 2 valid entries, malformed line skipped
+    assert.equal(entries.length, 2);
+  });
+
+  // --- oldestSeq ---
+
+  test("oldestSeq() returns seq of first line", async () => {
+    await log.init();
+    for (let i = 0; i < 5; i++) {
+      log.append({ type: `e_${i}` });
+    }
+    const oldest = await log.oldestSeq();
+    assert.equal(oldest, 1);
+  });
+
+  test("oldestSeq() returns null for missing/empty file", async () => {
+    await log.init();
+    const oldest = await log.oldestSeq();
+    assert.equal(oldest, null);
+  });
+
+  // --- rotateIfNeeded ---
+
+  test("rotateIfNeeded() with file < 50MB does nothing", async () => {
+    await log.init();
+    log.append({ type: "small" });
+    const sizeBefore = statSync(join(tmpDir, "events.jsonl")).size;
+    await log.rotateIfNeeded();
+    const sizeAfter = statSync(join(tmpDir, "events.jsonl")).size;
+    assert.equal(sizeBefore, sizeAfter);
+  });
+
+  test("rotateIfNeeded() with file > 50MB truncates to ~10MB keeping newest entries", async () => {
+    await log.init();
+
+    // Write a large synthetic file (>50MB) directly to bypass append counter
+    const logPath = join(tmpDir, "events.jsonl");
+
+    // Build entries: 60MB worth of data
+    const lines: string[] = [];
+    let totalBytes = 0;
+    let seq = 1;
+    while (totalBytes < 52 * 1024 * 1024) {
+      const line = JSON.stringify({ seq, event: { type: "bulk", data: "x".repeat(500) }, ts: new Date().toISOString() });
+      lines.push(line);
+      totalBytes += Buffer.byteLength(line + "\n");
+      seq++;
+    }
+    writeFileSync(logPath, lines.join("\n") + "\n");
+
+    // Patch internal seq to match
+    // We can't access private fields, so just test on the file directly
+    await log.rotateIfNeeded();
+
+    const sizeAfter = statSync(logPath).size;
+    // Should be less than 50MB now
+    assert.ok(sizeAfter < 50 * 1024 * 1024, `Expected size < 50MB, got ${sizeAfter}`);
+    // Should still have some content (around 10MB)
+    assert.ok(sizeAfter > 0, "File should not be empty after rotation");
+  });
+
+  test("after rotation, all remaining lines are valid JSON (no truncated lines)", async () => {
+    await log.init();
+    const logPath = join(tmpDir, "events.jsonl");
+
+    // Create a >50MB file
+    const lines: string[] = [];
+    let totalBytes = 0;
+    let seq = 1;
+    while (totalBytes < 52 * 1024 * 1024) {
+      const line = JSON.stringify({ seq, event: { type: "bulk", data: "x".repeat(200) }, ts: new Date().toISOString() });
+      lines.push(line);
+      totalBytes += Buffer.byteLength(line + "\n");
+      seq++;
+    }
+    writeFileSync(logPath, lines.join("\n") + "\n");
+
+    await log.rotateIfNeeded();
+
+    const content = readFileSync(logPath, "utf-8");
+    const remaining = content.trim().split("\n").filter(l => l.length > 0);
+    assert.ok(remaining.length > 0, "Should have remaining entries after rotation");
+    for (const line of remaining) {
+      assert.doesNotThrow(() => JSON.parse(line), `Line should be valid JSON: ${line.slice(0, 80)}`);
+    }
+  });
+
+  test("rotation uses atomic rename — .tmp file does not persist after rotation", async () => {
+    await log.init();
+    const logPath = join(tmpDir, "events.jsonl");
+    const tmpPath = logPath + ".tmp";
+
+    // Create >50MB file
+    const lines: string[] = [];
+    let totalBytes = 0;
+    let seq = 1;
+    while (totalBytes < 52 * 1024 * 1024) {
+      const line = JSON.stringify({ seq, event: { type: "bulk", data: "x".repeat(200) }, ts: new Date().toISOString() });
+      lines.push(line);
+      totalBytes += Buffer.byteLength(line + "\n");
+      seq++;
+    }
+    writeFileSync(logPath, lines.join("\n") + "\n");
+
+    await log.rotateIfNeeded();
+
+    // .tmp file should not exist after rotation completes
+    let tmpExists = false;
+    try {
+      statSync(tmpPath);
+      tmpExists = true;
+    } catch {
+      tmpExists = false;
+    }
+    assert.equal(tmpExists, false, ".tmp file should not persist after rotation");
+  });
+
+  test("append() triggers inline rotation check after 100 appends when file exceeds threshold", async () => {
+    await log.init();
+    const logPath = join(tmpDir, "events.jsonl");
+
+    // Pre-write a >50MB file so that when the 100th append triggers the check, rotation occurs
+    const lines: string[] = [];
+    let totalBytes = 0;
+    let seq = 1;
+    while (totalBytes < 52 * 1024 * 1024) {
+      const line = JSON.stringify({ seq, event: { type: "bulk", data: "x".repeat(200) }, ts: new Date().toISOString() });
+      lines.push(line);
+      totalBytes += Buffer.byteLength(line + "\n");
+      seq++;
+    }
+    writeFileSync(logPath, lines.join("\n") + "\n");
+
+    // Do 99 appends — no rotation yet (counter resets at 100)
+    for (let i = 0; i < 99; i++) {
+      log.append({ type: "pre" });
+    }
+
+    const sizeBefore = statSync(logPath).size;
+
+    // 100th append triggers the inline check
+    log.append({ type: "trigger" });
+
+    // Wait briefly for async rotation to fire (fire-and-forget)
+    await new Promise(resolve => setTimeout(resolve, 200));
+
+    const sizeAfter = statSync(logPath).size;
+    // File should have been rotated (size decreased significantly)
+    assert.ok(sizeAfter < sizeBefore, `Expected rotation to reduce file size (before: ${sizeBefore}, after: ${sizeAfter})`);
+  });
+
+  // --- dispose ---
+
+  test("dispose() does not throw", async () => {
+    await log.init();
+    assert.doesNotThrow(() => log.dispose());
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getEventLogDir
+// ---------------------------------------------------------------------------
+
+describe("getEventLogDir", () => {
+  test("returns a path under appRoot/web-events/<hash>", () => {
+    const dir = getEventLogDir("/some/project/path");
+    assert.ok(dir.includes("web-events"), `Expected 'web-events' in path: ${dir}`);
+    // Should have a 16-char hex segment
+    const parts = dir.split("/");
+    const lastPart = parts[parts.length - 1];
+    assert.match(lastPart, /^[0-9a-f]{16}$/);
+  });
+
+  test("returns consistent path for same projectCwd", () => {
+    const dir1 = getEventLogDir("/my/project");
+    const dir2 = getEventLogDir("/my/project");
+    assert.equal(dir1, dir2);
+  });
+
+  test("returns different path for different projectCwd", () => {
+    const dir1 = getEventLogDir("/project/a");
+    const dir2 = getEventLogDir("/project/b");
+    assert.notEqual(dir1, dir2);
+  });
+});

--- a/src/web/bridge-service.ts
+++ b/src/web/bridge-service.ts
@@ -39,6 +39,7 @@ import {
   collectTestOnlyFallbackAutoDashboardData,
 } from "./auto-dashboard-service.ts";
 import { resolveGsdCliEntry } from "./cli-entry.ts";
+import { EventLog, getEventLogDir } from "./event-log.ts";
 
 // The standalone Next.js bundle bakes import.meta.url at build time with the
 // CI runner's absolute path.  On Windows, fileURLToPath() rejects a Linux
@@ -1396,6 +1397,9 @@ export class BridgeService {
   private authRefreshPromise: Promise<void> | null = null;
   private requestCounter = 0;
   private stderrBuffer = "";
+  private seq = 0;
+  private eventLog: EventLog | null = null;
+  private rotationInterval: ReturnType<typeof setInterval> | null = null;
   private snapshot: BridgeRuntimeSnapshot;
 
   constructor(config: BridgeRuntimeConfig, deps: BridgeServiceDeps) {
@@ -1421,6 +1425,21 @@ export class BridgeService {
     return structuredClone(this.snapshot);
   }
 
+  async initEventLog(): Promise<void> {
+    const logDir = getEventLogDir(this.config.projectCwd);
+    this.eventLog = new EventLog(logDir);
+    await this.eventLog.init();
+    this.seq = this.eventLog.currentSeq;
+    // Hourly rotation is a fallback sweep — primary rotation triggered inline in EventLog.append()
+    this.rotationInterval = setInterval(() => {
+      void this.eventLog?.rotateIfNeeded();
+    }, 60 * 60 * 1000);
+  }
+
+  getEventLog(): EventLog | null {
+    return this.eventLog;
+  }
+
   publishLiveStateInvalidation(
     descriptor: BridgeLiveStateInvalidationDescriptor,
   ): BridgeLiveStateInvalidationEvent {
@@ -1433,6 +1452,9 @@ export class BridgeService {
   }
 
   async ensureStarted(): Promise<void> {
+    if (!this.eventLog) {
+      await this.initEventLog();
+    }
     if (this.process && this.snapshot.phase === "ready") return;
     if (this.startPromise) return await this.startPromise;
 
@@ -1590,6 +1612,12 @@ export class BridgeService {
       this.process.kill("SIGTERM");
       this.process = null;
     }
+    if (this.rotationInterval) {
+      clearInterval(this.rotationInterval);
+      this.rotationInterval = null;
+    }
+    this.eventLog?.dispose();
+    this.eventLog = null;
     this.snapshot.phase = "idle";
     this.snapshot.connectionCount = 0;
     this.snapshot.updatedAt = nowIso();
@@ -1817,9 +1845,12 @@ export class BridgeService {
   }
 
   private emit(event: BridgeEvent): void {
+    this.seq++;
+    const seqEvent = { ...event, _seq: this.seq };
+    this.eventLog?.append(seqEvent);
     for (const subscriber of this.subscribers) {
       try {
-        subscriber(event);
+        subscriber(seqEvent as BridgeEvent);
       } catch {
         // Subscriber failures should not break delivery.
       }

--- a/src/web/event-log.ts
+++ b/src/web/event-log.ts
@@ -1,0 +1,262 @@
+import {
+  appendFileSync,
+  createReadStream,
+  mkdirSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { rename, stat } from "node:fs/promises";
+import { createInterface } from "node:readline";
+import { createHash } from "node:crypto";
+import { join } from "node:path";
+
+import { appRoot } from "../app-paths.ts";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface LogEntry {
+  seq: number;
+  event: unknown;
+  ts: string;
+}
+
+// ---------------------------------------------------------------------------
+// Directory helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns the event log directory for a given project working directory.
+ * Uses a SHA-256 hash of the path to avoid filesystem-unsafe characters.
+ */
+export function getEventLogDir(projectCwd: string): string {
+  const hash = createHash("sha256").update(projectCwd).digest("hex").slice(0, 16);
+  return join(appRoot, "web-events", hash);
+}
+
+// ---------------------------------------------------------------------------
+// EventLog class
+// ---------------------------------------------------------------------------
+
+export class EventLog {
+  private seq: number = 0;
+  private readonly logPath: string;
+  private appendCount: number = 0;
+
+  constructor(private readonly logDir: string) {
+    this.logPath = join(logDir, "events.jsonl");
+  }
+
+  /** Path to the events.jsonl file — used by the SSE route for replay reads. */
+  get filePath(): string {
+    return this.logPath;
+  }
+
+  /** Current sequence number (last assigned seq). */
+  get currentSeq(): number {
+    return this.seq;
+  }
+
+  /**
+   * Initialize the event log. Creates the log directory if needed and restores
+   * the sequence counter from the last valid JSON line in the existing log file.
+   *
+   * Resilient to truncated/malformed last lines — scans all lines and keeps
+   * the last valid seq found. Safe to call on a fresh (non-existent) log.
+   */
+  async init(): Promise<void> {
+    mkdirSync(this.logDir, { recursive: true });
+
+    let lastValidSeq = 0;
+    try {
+      const rl = createInterface({
+        input: createReadStream(this.logPath, { encoding: "utf-8" }),
+        crlfDelay: Infinity,
+      });
+
+      for await (const line of rl) {
+        if (!line.trim()) continue;
+        try {
+          const entry = JSON.parse(line) as LogEntry;
+          if (typeof entry.seq === "number") {
+            lastValidSeq = entry.seq;
+          }
+        } catch {
+          // Malformed line — keep the last valid seq found so far.
+        }
+      }
+    } catch (err: unknown) {
+      // ENOENT = fresh log, seq stays 0. Other errors are surfaced.
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code !== "ENOENT") {
+        process.stderr.write(`[EventLog] init error reading log: ${String(err)}\n`);
+      }
+    }
+
+    this.seq = lastValidSeq;
+  }
+
+  /**
+   * Append a new event to the log with the next sequence number.
+   *
+   * Sync write intentional: guarantees seq ordering under concurrent emits. ~0.1ms on SSD.
+   *
+   * Write errors (ENOSPC, permission denied, etc.) are logged to stderr and
+   * swallowed — logging failures must not interrupt event delivery.
+   *
+   * Every 100 appends, triggers an inline rotation check as burst protection
+   * beyond the hourly fallback timer.
+   */
+  append(event: unknown): void {
+    this.seq++;
+    const entry: LogEntry = {
+      seq: this.seq,
+      event,
+      ts: new Date().toISOString(),
+    };
+
+    try {
+      // Sync write intentional: guarantees seq ordering under concurrent emits. ~0.1ms on SSD.
+      appendFileSync(this.logPath, JSON.stringify(entry) + "\n");
+    } catch (err: unknown) {
+      process.stderr.write(`[EventLog] append error (seq=${this.seq}): ${String(err)}\n`);
+      return;
+    }
+
+    this.appendCount++;
+    if (this.appendCount >= 100) {
+      this.appendCount = 0;
+      // Fire-and-forget: provides burst protection beyond the hourly timer.
+      void this.rotateIfNeeded();
+    }
+  }
+
+  /**
+   * Async iterator that yields log entries with seq > sinceSeq.
+   *
+   * Pass sinceSeq = -1 to skip replay entirely (returns immediately).
+   * Handles missing log file gracefully (empty iterator).
+   * Malformed/non-JSON lines are skipped silently.
+   */
+  async *readSince(sinceSeq: number): AsyncGenerator<LogEntry> {
+    if (sinceSeq < 0) return;
+
+    try {
+      const rl = createInterface({
+        input: createReadStream(this.logPath, { encoding: "utf-8" }),
+        crlfDelay: Infinity,
+      });
+
+      for await (const line of rl) {
+        if (!line.trim()) continue;
+        try {
+          const entry = JSON.parse(line) as LogEntry;
+          if (typeof entry.seq === "number" && entry.seq > sinceSeq) {
+            yield entry;
+          }
+        } catch {
+          // Skip malformed lines silently.
+        }
+      }
+    } catch (err: unknown) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code !== "ENOENT") {
+        process.stderr.write(`[EventLog] readSince error: ${String(err)}\n`);
+      }
+      // ENOENT = no log yet = no entries to replay.
+    }
+  }
+
+  /**
+   * Returns the seq of the first valid JSON line in the log file, or null if
+   * the file is missing or empty.
+   */
+  async oldestSeq(): Promise<number | null> {
+    try {
+      const rl = createInterface({
+        input: createReadStream(this.logPath, { encoding: "utf-8" }),
+        crlfDelay: Infinity,
+      });
+
+      for await (const line of rl) {
+        if (!line.trim()) continue;
+        try {
+          const entry = JSON.parse(line) as LogEntry;
+          if (typeof entry.seq === "number") {
+            rl.close();
+            return entry.seq;
+          }
+        } catch {
+          // Malformed line — skip and try next.
+        }
+      }
+    } catch (err: unknown) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code !== "ENOENT") {
+        process.stderr.write(`[EventLog] oldestSeq error: ${String(err)}\n`);
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Rotates the log file if it exceeds 50MB.
+   *
+   * Keeps the newest ~10MB of data (whole-line boundaries preserved — no line
+   * is ever split). Uses atomic POSIX rename so active readline streams on the
+   * old inode continue reading safely.
+   */
+  async rotateIfNeeded(): Promise<void> {
+    let fileSize: number;
+    try {
+      const info = await stat(this.logPath);
+      fileSize = info.size;
+    } catch (err: unknown) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code !== "ENOENT") {
+        process.stderr.write(`[EventLog] rotateIfNeeded stat error: ${String(err)}\n`);
+      }
+      return; // Nothing to rotate.
+    }
+
+    if (fileSize <= 50 * 1024 * 1024) return;
+
+    try {
+      // Read entire file content synchronously.
+      const content = readFileSync(this.logPath, "utf-8");
+
+      // Split into lines, filter empty.
+      const allLines = content.split("\n").filter(l => l.length > 0);
+
+      // Accumulate lines from the END until total byte length reaches ~10MB.
+      const keepTarget = 10 * 1024 * 1024;
+      const kept: string[] = [];
+      let keptBytes = 0;
+      for (let i = allLines.length - 1; i >= 0; i--) {
+        const lineBytes = Buffer.byteLength(allLines[i] + "\n");
+        if (keptBytes + lineBytes > keepTarget && kept.length > 0) break;
+        kept.unshift(allLines[i]);
+        keptBytes += lineBytes;
+      }
+
+      const rotatedContent = kept.join("\n") + "\n";
+      const tmpPath = this.logPath + ".tmp";
+
+      // Write to .tmp then atomically rename over the original.
+      writeFileSync(tmpPath, rotatedContent, "utf-8");
+      // Atomic rename: active readline streams on old inode continue safely (POSIX)
+      await rename(tmpPath, this.logPath);
+    } catch (err: unknown) {
+      process.stderr.write(`[EventLog] rotation error: ${String(err)}\n`);
+    }
+  }
+
+  /**
+   * Placeholder for future cleanup. Currently a no-op.
+   */
+  dispose(): void {
+    // No-op placeholder for future cleanup.
+  }
+}

--- a/web/app/api/session/events/route.ts
+++ b/web/app/api/session/events/route.ts
@@ -10,8 +10,17 @@ export const dynamic = "force-dynamic";
 
 const encoder = new TextEncoder();
 
+const LIVE_BUFFER_CAP = 10_000;
+const PING_INTERVAL_MS = 30_000;
+
+/** Unnamed SSE event — backward-compatible for existing clients (onmessage handler). */
 function encodeSseData(payload: unknown): Uint8Array {
   return encoder.encode(`data: ${JSON.stringify(payload)}\n\n`);
+}
+
+/** Named SSE event — used for replay/live/snapshot typed events. */
+function encodeSseEvent(type: "replay" | "live" | "snapshot", payload: unknown): Uint8Array {
+  return encoder.encode(`event: ${type}\ndata: ${JSON.stringify(payload)}\n\n`);
 }
 
 export async function GET(request: Request): Promise<Response> {
@@ -37,23 +46,133 @@ export async function GET(request: Request): Promise<Response> {
     // Keep the stream open and let the initial bridge_status event surface the failure state.
   }
 
+  // Parse and strictly validate the ?since=N cursor parameter.
+  const url = new URL(request.url);
+  const sinceParam = url.searchParams.get("since");
+  let sinceSeq = -1; // Default: no cursor, skip replay
+  if (sinceParam !== null) {
+    const parsed = parseInt(sinceParam, 10);
+    // Only accept non-negative integers; reject NaN, negative, decimal
+    if (!isNaN(parsed) && parsed >= 0 && String(parsed) === sinceParam) {
+      sinceSeq = parsed;
+    }
+  }
+  const hasReplayCursor = sinceSeq >= 0;
+
+  // Get the EventLog reference from the bridge (may be null if not yet started).
+  const eventLog = bridge.getEventLog();
+
   let unsubscribe: (() => void) | null = null;
   let closed = false;
+  let pingInterval: ReturnType<typeof setInterval> | null = null;
 
   const closeWith = (controller: ReadableStreamDefaultController<Uint8Array>) => {
     if (closed) return;
     closed = true;
     unsubscribe?.();
     unsubscribe = null;
+    if (pingInterval !== null) {
+      clearInterval(pingInterval);
+      pingInterval = null;
+    }
     controller.close();
   };
 
   const stream = new ReadableStream<Uint8Array>({
     start(controller) {
+      const liveBuffer: unknown[] = [];
+      let isReplaying = hasReplayCursor && eventLog !== null;
+      let bufferOverflow = false;
+
+      // Subscribe to live events first — captures events arriving during replay.
       unsubscribe = bridge.subscribe((event) => {
         if (closed) return;
-        controller.enqueue(encodeSseData(event));
+        if (isReplaying) {
+          if (liveBuffer.length >= LIVE_BUFFER_CAP) {
+            bufferOverflow = true;
+          } else {
+            liveBuffer.push(event);
+          }
+        } else {
+          controller.enqueue(encodeSseEvent("live", event));
+        }
       });
+
+      // Start ping heartbeat to detect zombie connections.
+      pingInterval = setInterval(() => {
+        if (closed) {
+          if (pingInterval !== null) {
+            clearInterval(pingInterval);
+            pingInterval = null;
+          }
+          return;
+        }
+        try {
+          controller.enqueue(encoder.encode(": ping\n\n"));
+        } catch {
+          if (pingInterval !== null) {
+            clearInterval(pingInterval);
+            pingInterval = null;
+          }
+        }
+      }, PING_INTERVAL_MS);
+
+      // Replay missed events if cursor provided and EventLog is available.
+      if (hasReplayCursor && eventLog !== null) {
+        void (async () => {
+          try {
+            // Check for stale cursor — sinceSeq is before the oldest log entry.
+            const oldest = await eventLog.oldestSeq();
+            if (oldest !== null && sinceSeq < oldest) {
+              // Stale cursor — send snapshot signal; client should refresh.
+              controller.enqueue(encodeSseEvent("snapshot", { reason: "cursor_expired" }));
+            } else {
+              // Capture replay ceiling BEFORE reading the file to prevent duplicate delivery.
+              // Only replay file entries with seq <= ceiling; live buffer entries > ceiling.
+              const replayCeilingSeq = eventLog.currentSeq;
+
+              // Stream missed events from the log up to the ceiling seq.
+              for await (const entry of eventLog.readSince(sinceSeq)) {
+                if (closed) return;
+                if (entry.seq > replayCeilingSeq) break; // Don't read past the ceiling.
+                controller.enqueue(encodeSseEvent("replay", entry.event));
+              }
+
+              if (bufferOverflow) {
+                // Too many live events arrived during replay — fall back to snapshot.
+                controller.enqueue(encodeSseEvent("snapshot", { reason: "buffer_overflow" }));
+              } else {
+                // Flush buffered live events that arrived during replay (seq > ceiling).
+                for (const buffered of liveBuffer) {
+                  if (closed) return;
+                  controller.enqueue(encodeSseEvent("replay", buffered));
+                }
+              }
+            }
+          } catch {
+            // Log rotation or read error during replay — switch to live gracefully.
+            if (!closed) {
+              controller.enqueue(encodeSseEvent("snapshot", { reason: "replay_error" }));
+            }
+          } finally {
+            isReplaying = false;
+            liveBuffer.length = 0;
+            // Send live transition sentinel — client dismisses "Catching up..." banner.
+            if (!closed) {
+              controller.enqueue(encodeSseEvent("live", { type: "stream_live" }));
+            }
+          }
+        })();
+      } else if (!hasReplayCursor) {
+        // No cursor — legacy path: existing behavior via unnamed events.
+        // Re-wire subscribe to use unnamed encodeSseData for backward compatibility
+        // with clients that use onmessage rather than addEventListener.
+        unsubscribe?.();
+        unsubscribe = bridge.subscribe((event) => {
+          if (closed) return;
+          controller.enqueue(encodeSseData(event));
+        });
+      }
 
       request.signal.addEventListener("abort", () => closeWith(controller), { once: true });
     },
@@ -62,6 +181,10 @@ export async function GET(request: Request): Promise<Response> {
       closed = true;
       unsubscribe?.();
       unsubscribe = null;
+      if (pingInterval !== null) {
+        clearInterval(pingInterval);
+        pingInterval = null;
+      }
     },
   });
 

--- a/web/components/gsd/app-shell.tsx
+++ b/web/components/gsd/app-shell.tsx
@@ -34,6 +34,7 @@ import { ScopeBadge } from "@/components/gsd/scope-badge"
 import { Badge } from "@/components/ui/badge"
 import { ProjectsPanel, ProjectSelectionGate } from "@/components/gsd/projects-view"
 import { UpdateBanner } from "@/components/gsd/update-banner"
+import { CatchingUpBanner } from "@/lib/components/catching-up-banner"
 import { getAuthToken } from "@/lib/auth"
 
 const KNOWN_VIEWS = new Set(["dashboard", "power", "chat", "roadmap", "files", "activity", "visualize"])
@@ -282,6 +283,7 @@ function WorkspaceChrome() {
 
   return (
     <div className="relative flex h-screen flex-col overflow-hidden bg-background text-foreground">
+      <CatchingUpBanner visible={workspace.isCatchingUp} />
       <header className="flex h-12 flex-shrink-0 items-center justify-between border-b border-border bg-card px-2 md:px-4">
         <div className="flex items-center gap-2 md:gap-3 min-w-0">
           {/* Mobile hamburger menu */}

--- a/web/lib/components/catching-up-banner.tsx
+++ b/web/lib/components/catching-up-banner.tsx
@@ -1,0 +1,28 @@
+"use client"
+
+interface CatchingUpBannerProps {
+  visible: boolean
+}
+
+export function CatchingUpBanner({ visible }: CatchingUpBannerProps) {
+  if (!visible) return null
+
+  return (
+    <div
+      className="fixed top-0 left-0 right-0 z-50 flex items-center justify-center gap-2 bg-blue-600 px-4 py-1.5 text-xs font-medium text-white shadow-sm"
+      role="status"
+      aria-live="polite"
+    >
+      <svg
+        className="h-3.5 w-3.5 animate-spin"
+        xmlns="http://www.w3.org/2000/svg"
+        fill="none"
+        viewBox="0 0 24 24"
+      >
+        <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+        <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+      </svg>
+      Catching up — replaying missed events...
+    </div>
+  )
+}

--- a/web/lib/gsd-workspace-store.tsx
+++ b/web/lib/gsd-workspace-store.tsx
@@ -543,6 +543,8 @@ export interface WidgetContent {
 export interface WorkspaceStoreState {
   bootStatus: WorkspaceStatus
   connectionState: WorkspaceConnectionState
+  /** True while the stream is replaying missed events from the event log on reconnect */
+  isCatchingUp: boolean
   boot: WorkspaceBootPayload | null
   live: WorkspaceLiveState
   terminalLines: WorkspaceTerminalLine[]
@@ -1810,6 +1812,7 @@ function createInitialState(): WorkspaceStoreState {
   return {
     bootStatus: "idle",
     connectionState: "idle",
+    isCatchingUp: false,
     boot: null,
     live: createInitialWorkspaceLiveState(),
     terminalLines: [createTerminalLine("system", "Preparing the live GSD workspace…")],
@@ -1840,6 +1843,51 @@ function createInitialState(): WorkspaceStoreState {
   }
 }
 
+// ---------------------------------------------------------------------------
+// SSE cursor tracking — project-scoped localStorage helpers
+// ---------------------------------------------------------------------------
+
+function seqStorageKey(projectCwd: string): string {
+  return `gsd-last-seq:${projectCwd}`
+}
+
+function getStoredSeq(projectCwd: string): number {
+  if (typeof window === "undefined") return -1
+  const stored = localStorage.getItem(seqStorageKey(projectCwd))
+  if (stored === null) return -1
+  const parsed = parseInt(stored, 10)
+  return isNaN(parsed) ? -1 : parsed
+}
+
+function storeSeq(projectCwd: string, seq: number): void {
+  if (typeof window === "undefined") return
+  localStorage.setItem(seqStorageKey(projectCwd), String(seq))
+}
+
+function clearStoredSeq(projectCwd: string): void {
+  if (typeof window === "undefined") return
+  localStorage.removeItem(seqStorageKey(projectCwd))
+}
+
+// ---------------------------------------------------------------------------
+// Replay-safe event filtering
+// Control events that must NOT be replayed — they trigger live side effects
+// (state reloads, blocking UI prompts, extension auth refreshes, etc.)
+// ---------------------------------------------------------------------------
+
+const REPLAY_UNSAFE_EVENT_TYPES = new Set([
+  "live_state_invalidation", // calls reloadLiveState() — would re-fetch stale data
+  "extension_ui_request",    // queues blocking UI prompts in pendingUiRequests
+])
+
+function isReplayableEvent(event: WorkspaceEvent): boolean {
+  const eventType = (event as { type?: string }).type
+  if (eventType && REPLAY_UNSAFE_EVENT_TYPES.has(eventType)) return false
+  return true
+}
+
+// ---------------------------------------------------------------------------
+
 export function buildProjectUrl(path: string, projectCwd?: string): string {
   if (!projectCwd) return path
   const url = new URL(path, "http://localhost")
@@ -1867,6 +1915,8 @@ export class GSDWorkspaceStore {
   private commandTimeoutTimer: ReturnType<typeof setTimeout> | null = null
   private lastBootRefreshAt = 0
   private visibilityHandler: (() => void) | null = null
+  /** Per-tab monotonic dedupe — prevents duplicate event application even when localStorage is shared across tabs */
+  private lastAppliedSeq = -1
 
   subscribe = (listener: () => void): (() => void) => {
     this.listeners.add(listener)
@@ -4868,7 +4918,23 @@ export class GSDWorkspaceStore {
   private ensureEventStream(): void {
     if (this.eventSource || this.disposed || this.state.boot?.onboarding.locked) return
 
-    const stream = new EventSource(appendAuthParam(this.buildUrl("/api/session/events")))
+    // Get project identifier for cursor scoping
+    const projectCwd = this.projectCwd ?? ""
+
+    // Read stored cursor and set catching-up state IMMEDIATELY before EventSource creation (D-01)
+    const storedSeq = getStoredSeq(projectCwd)
+    if (storedSeq >= 0) {
+      this.patchState({ isCatchingUp: true })
+    }
+
+    // Build EventSource URL — append ?since= when a stored cursor exists
+    let eventUrl = appendAuthParam(this.buildUrl("/api/session/events"))
+    if (storedSeq >= 0) {
+      const separator = eventUrl.includes("?") ? "&" : "?"
+      eventUrl = `${eventUrl}${separator}since=${storedSeq}`
+    }
+
+    const stream = new EventSource(eventUrl)
     this.eventSource = stream
 
     stream.onopen = () => {
@@ -4881,11 +4947,99 @@ export class GSDWorkspaceStore {
       }
       this.lastStreamState = "connected"
       this.patchState({ connectionState: "connected", lastClientError: null })
-      if (wasDisconnected) {
+      if (wasDisconnected && storedSeq < 0) {
+        // Only soft-refresh on reconnect when NOT doing a replay (replay provides the missed state)
         void this.refreshBoot({ soft: true })
       }
     }
 
+    // Handle replay events (missed events from log) — filter unsafe control events
+    stream.addEventListener("replay", (msg: MessageEvent) => {
+      try {
+        const parsed: unknown = JSON.parse(msg.data)
+        if (!isWorkspaceEvent(parsed)) return
+
+        // Monotonic dedupe: skip events at or below last applied seq
+        const seq = (parsed as { _seq?: number })._seq
+        if (typeof seq === "number") {
+          if (seq <= this.lastAppliedSeq) return // dedupe
+          this.lastAppliedSeq = seq
+          storeSeq(projectCwd, seq)
+        }
+
+        // Only replay safe events — skip control events that would trigger side effects
+        if (!isReplayableEvent(parsed)) return
+
+        // D-02: Replay events go through handleEvent() which triggers the same
+        // scroll-to-bottom behavior as live events — no special handling needed.
+        this.handleEvent(parsed)
+      } catch {
+        // Skip malformed replay events
+      }
+    })
+
+    // Handle live events (real-time + stream_live sentinel)
+    stream.addEventListener("live", (msg: MessageEvent) => {
+      try {
+        const parsed: unknown = JSON.parse(msg.data)
+        // Check for stream_live sentinel — marks end of replay, dismiss catching-up banner
+        if (parsed && typeof parsed === "object" && (parsed as { type?: string }).type === "stream_live") {
+          this.patchState({ isCatchingUp: false })
+          return
+        }
+        if (!isWorkspaceEvent(parsed)) return
+
+        // Monotonic dedupe for live events too
+        const seq = (parsed as { _seq?: number })._seq
+        if (typeof seq === "number") {
+          if (seq <= this.lastAppliedSeq) return // dedupe
+          this.lastAppliedSeq = seq
+          storeSeq(projectCwd, seq)
+        }
+
+        this.handleEvent(parsed)
+      } catch (error) {
+        const text = normalizeClientError(error)
+        this.patchState({
+          lastClientError: text,
+          terminalLines: withTerminalLine(this.state.terminalLines, createTerminalLine("error", `Failed to parse stream event — ${text}`)),
+        })
+      }
+    })
+
+    // Handle snapshot events (stale cursor or buffer overflow)
+    stream.addEventListener("snapshot", (msg: MessageEvent) => {
+      try {
+        const parsed: unknown = JSON.parse(msg.data)
+        const reason = (parsed as { reason?: string })?.reason
+        if (reason === "cursor_expired" || reason === "buffer_overflow" || reason === "replay_error") {
+          // Close the current stream before refreshing state
+          this.closeEventStream()
+          this.patchState({ isCatchingUp: false })
+
+          // D-04: Show appropriate message to user
+          const message =
+            reason === "cursor_expired"
+              ? "Session too old — showing current state."
+              : "Replay interrupted — showing current state."
+          this.patchState({
+            terminalLines: withTerminalLine(this.state.terminalLines, createTerminalLine("system", message)),
+          })
+
+          // Clear stored cursor — next stream will be pure live (no replay)
+          clearStoredSeq(projectCwd)
+
+          // Refresh full state via refreshBoot(), then reopen stream with no cursor
+          void this.refreshBoot().then(() => {
+            if (!this.disposed) this.ensureEventStream()
+          })
+        }
+      } catch {
+        // Skip malformed snapshot events
+      }
+    })
+
+    // Backward-compat fallback: handle unnamed events from servers without named-event support
     stream.onmessage = (message) => {
       try {
         const parsed: unknown = JSON.parse(message.data)
@@ -4895,6 +5049,12 @@ export class GSDWorkspaceStore {
             terminalLines: withTerminalLine(this.state.terminalLines, createTerminalLine("error", "Malformed event received from stream")),
           })
           return
+        }
+        const seq = (parsed as { _seq?: number })._seq
+        if (typeof seq === "number") {
+          if (seq <= this.lastAppliedSeq) return // dedupe
+          this.lastAppliedSeq = seq
+          storeSeq(projectCwd, seq)
         }
         this.handleEvent(parsed)
       } catch (error) {
@@ -4925,12 +5085,20 @@ export class GSDWorkspaceStore {
         this.patchState({ connectionState: nextConnectionState })
       }
       this.lastStreamState = nextConnectionState
+
+      // Pitfall 5: Close the stale EventSource and recreate it with the LATEST cursor
+      // (browser auto-reconnect would reuse the original URL with the original ?since= value)
+      this.closeEventStream()
+      setTimeout(() => {
+        if (!this.disposed) this.ensureEventStream()
+      }, 2000)
     }
   }
 
   private closeEventStream(): void {
     this.eventSource?.close()
     this.eventSource = null
+    this.patchState({ isCatchingUp: false })
   }
 
   private handleEvent(event: WorkspaceEvent): void {


### PR DESCRIPTION
## Remote Access — PR 1 of 4: SSE Event Replay

> **Remote Access Series** — 4 independent PRs, merge in order: 1→2→3→4. Each PR contains only its own files. Split per review feedback on #3024.

### Summary

Reconnecting browsers recover all agent output that occurred while disconnected.

- **EventLog** (`src/web/event-log.ts`): JSONL log with monotonic seq numbers, atomic rotation, `readSince()`
- **bridge-service**: wraps every event with `_seq`, logs independent of browser connections
- **SSE endpoint**: `?since=N` replay with ceiling protocol, live buffer, stale cursor → snapshot
- **Client**: localStorage cursor, named SSE listeners, monotonic dedupe, "Catching up..." banner

**7 files** | 25 tests

### Test plan
- [x] `gsd --web` starts normally (no regression)
- [x] Events persist to JSONL, reconnect replays missed events
- [x] "Catching up..." banner shows during replay, hides when live