### PR TITLE
feat(tailscale): add Tailscale Serve for remote HTTPS access [3/4]

### DIFF
--- a/src/web/__tests__/tailscale.test.ts
+++ b/src/web/__tests__/tailscale.test.ts
@@ -1,0 +1,377 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync, execFile } from 'node:child_process';
+
+import {
+  parseTailscaleStatus,
+  buildServeCommand,
+  buildServeResetCommand,
+  getInstallCommand,
+  isTailscaleInstalled,
+  getTailscaleStatus,
+  startTailscaleServe,
+  stopTailscaleServe,
+  stopTailscaleServeSync,
+  TailscaleServeError,
+  _deps,
+} from '../tailscale.ts';
+
+// ---------------------------------------------------------------------------
+// Test helpers — replace _deps and restore after each test
+// ---------------------------------------------------------------------------
+
+function withDeps<T>(overrides: Partial<typeof _deps>, fn: () => T): T {
+  const original = { spawnSync: _deps.spawnSync, execFile: _deps.execFile };
+  Object.assign(_deps, overrides);
+  try {
+    return fn();
+  } finally {
+    Object.assign(_deps, original);
+  }
+}
+
+async function withDepsAsync<T>(overrides: Partial<typeof _deps>, fn: () => Promise<T>): Promise<T> {
+  const original = { spawnSync: _deps.spawnSync, execFile: _deps.execFile };
+  Object.assign(_deps, overrides);
+  try {
+    return await fn();
+  } finally {
+    Object.assign(_deps, original);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// parseTailscaleStatus — pure function
+// ---------------------------------------------------------------------------
+
+test('parseTailscaleStatus returns correct fields with trailing dot stripped', () => {
+  const result = parseTailscaleStatus({
+    Self: { HostName: 'Mac mini', DNSName: 'mac-mini.tail7e216d.ts.net.' },
+    MagicDNSSuffix: 'tail7e216d.ts.net',
+  });
+  assert.ok(result !== null);
+  assert.equal(result!.hostname, 'Mac mini');
+  assert.equal(result!.tailnet, 'tail7e216d.ts.net');
+  assert.equal(result!.fqdn, 'mac-mini.tail7e216d.ts.net');
+  assert.equal(result!.url, 'https://mac-mini.tail7e216d.ts.net');
+});
+
+test('parseTailscaleStatus works when DNSName has no trailing dot', () => {
+  const result = parseTailscaleStatus({
+    Self: { HostName: 'mybox', DNSName: 'mybox.tail123.ts.net' },
+    MagicDNSSuffix: 'tail123.ts.net',
+  });
+  assert.ok(result !== null);
+  assert.equal(result!.fqdn, 'mybox.tail123.ts.net');
+  assert.equal(result!.url, 'https://mybox.tail123.ts.net');
+});
+
+test('parseTailscaleStatus returns null when Self field is missing', () => {
+  const result = parseTailscaleStatus({ MagicDNSSuffix: 'tail123.ts.net' });
+  assert.equal(result, null);
+});
+
+test('parseTailscaleStatus returns null when DNSName field is missing', () => {
+  const result = parseTailscaleStatus({
+    Self: { HostName: 'mybox' },
+    MagicDNSSuffix: 'tail123.ts.net',
+  });
+  assert.equal(result, null);
+});
+
+test('parseTailscaleStatus returns null when MagicDNSSuffix field is missing', () => {
+  const result = parseTailscaleStatus({
+    Self: { HostName: 'mybox', DNSName: 'mybox.tail123.ts.net.' },
+  });
+  assert.equal(result, null);
+});
+
+test('parseTailscaleStatus returns null when input is null', () => {
+  const result = parseTailscaleStatus(null);
+  assert.equal(result, null);
+});
+
+// ---------------------------------------------------------------------------
+// buildServeCommand — pure function
+// ---------------------------------------------------------------------------
+
+test('buildServeCommand returns correct args array', () => {
+  const result = buildServeCommand(3456);
+  assert.deepEqual(result, [
+    'serve',
+    '--bg',
+    '--https',
+    '443',
+    'http://127.0.0.1:3456',
+  ]);
+});
+
+test('buildServeCommand includes port in URL', () => {
+  const result = buildServeCommand(8080);
+  assert.ok(result[4].includes('8080'));
+});
+
+// ---------------------------------------------------------------------------
+// buildServeResetCommand — pure function
+// ---------------------------------------------------------------------------
+
+test('buildServeResetCommand returns ["serve", "reset"]', () => {
+  assert.deepEqual(buildServeResetCommand(), ['serve', 'reset']);
+});
+
+// ---------------------------------------------------------------------------
+// getInstallCommand — pure function
+// ---------------------------------------------------------------------------
+
+test('getInstallCommand returns brew install for darwin', () => {
+  assert.equal(getInstallCommand('darwin'), 'brew install tailscale');
+});
+
+test('getInstallCommand returns winget install for win32', () => {
+  assert.equal(getInstallCommand('win32'), 'winget install Tailscale.Tailscale');
+});
+
+test('getInstallCommand returns curl script for linux', () => {
+  const cmd = getInstallCommand('linux');
+  assert.ok(cmd.startsWith('curl'));
+  assert.ok(cmd.includes('tailscale.com/install.sh'));
+});
+
+test('getInstallCommand returns curl script for other platforms', () => {
+  const cmd = getInstallCommand('freebsd');
+  assert.ok(cmd.startsWith('curl'));
+});
+
+// ---------------------------------------------------------------------------
+// isTailscaleInstalled — I/O function (via _deps injection)
+// ---------------------------------------------------------------------------
+
+test('isTailscaleInstalled returns true when spawnSync exits 0', () => {
+  const result = withDeps(
+    { spawnSync: (() => ({ status: 0, stdout: Buffer.from('1.94.1'), stderr: Buffer.from('') })) as unknown as typeof spawnSync },
+    () => isTailscaleInstalled(),
+  );
+  assert.equal(result, true);
+});
+
+test('isTailscaleInstalled returns false when spawnSync exits non-zero', () => {
+  const result = withDeps(
+    { spawnSync: (() => ({ status: 1, stdout: Buffer.from(''), stderr: Buffer.from('not found') })) as unknown as typeof spawnSync },
+    () => isTailscaleInstalled(),
+  );
+  assert.equal(result, false);
+});
+
+test('isTailscaleInstalled returns false when spawnSync throws', () => {
+  const result = withDeps(
+    { spawnSync: (() => { throw new Error('ENOENT'); }) as unknown as typeof spawnSync },
+    () => isTailscaleInstalled(),
+  );
+  assert.equal(result, false);
+});
+
+// ---------------------------------------------------------------------------
+// getTailscaleStatus — I/O function (via _deps injection)
+// ---------------------------------------------------------------------------
+
+const validStatusJson = JSON.stringify({
+  Self: { HostName: 'Mac mini', DNSName: 'mac-mini.tail7e216d.ts.net.' },
+  MagicDNSSuffix: 'tail7e216d.ts.net',
+});
+
+test('getTailscaleStatus returns ok result when spawnSync succeeds with valid JSON', () => {
+  const result = withDeps(
+    {
+      spawnSync: (() => ({
+        status: 0,
+        stdout: Buffer.from(validStatusJson),
+        stderr: Buffer.from(''),
+      })) as unknown as typeof spawnSync,
+    },
+    () => getTailscaleStatus(),
+  );
+  assert.equal(result.ok, true);
+  if (result.ok) {
+    assert.equal(result.info.hostname, 'Mac mini');
+    assert.equal(result.info.fqdn, 'mac-mini.tail7e216d.ts.net');
+  }
+});
+
+test('getTailscaleStatus returns not-connected when spawnSync exits non-zero', () => {
+  const result = withDeps(
+    {
+      spawnSync: (() => ({
+        status: 1,
+        stdout: Buffer.from(''),
+        stderr: Buffer.from('not connected'),
+      })) as unknown as typeof spawnSync,
+    },
+    () => getTailscaleStatus(),
+  );
+  assert.equal(result.ok, false);
+  if (!result.ok) {
+    assert.equal(result.reason, 'not-connected');
+  }
+});
+
+test('getTailscaleStatus returns invalid-status when stdout is not valid JSON', () => {
+  const result = withDeps(
+    {
+      spawnSync: (() => ({
+        status: 0,
+        stdout: Buffer.from('not-json'),
+        stderr: Buffer.from(''),
+      })) as unknown as typeof spawnSync,
+    },
+    () => getTailscaleStatus(),
+  );
+  assert.equal(result.ok, false);
+  if (!result.ok) {
+    assert.equal(result.reason, 'invalid-status');
+  }
+});
+
+test('getTailscaleStatus returns cli-error when spawnSync throws', () => {
+  const result = withDeps(
+    { spawnSync: (() => { throw new Error('ENOENT tailscale'); }) as unknown as typeof spawnSync },
+    () => getTailscaleStatus(),
+  );
+  assert.equal(result.ok, false);
+  if (!result.ok) {
+    assert.equal(result.reason, 'cli-error');
+    assert.ok(result.stderr !== undefined);
+  }
+});
+
+test('getTailscaleStatus returns invalid-status when JSON has no Self field', () => {
+  const result = withDeps(
+    {
+      spawnSync: (() => ({
+        status: 0,
+        stdout: Buffer.from(JSON.stringify({ MagicDNSSuffix: 'tail.ts.net' })),
+        stderr: Buffer.from(''),
+      })) as unknown as typeof spawnSync,
+    },
+    () => getTailscaleStatus(),
+  );
+  assert.equal(result.ok, false);
+  if (!result.ok) {
+    assert.equal(result.reason, 'invalid-status');
+  }
+});
+
+// ---------------------------------------------------------------------------
+// startTailscaleServe — async I/O function (via _deps injection)
+// ---------------------------------------------------------------------------
+
+test('startTailscaleServe calls execFile with buildServeCommand args', async () => {
+  let capturedArgs: string[] | undefined;
+  const fakeExecFile = ((_cmd: string, args: string[], cb: (err: Error | null) => void) => {
+    capturedArgs = args;
+    cb(null);
+    return {} as ReturnType<typeof execFile>;
+  }) as unknown as typeof execFile;
+
+  await withDepsAsync({ execFile: fakeExecFile }, () => startTailscaleServe(3456));
+  assert.ok(capturedArgs !== undefined);
+  assert.deepEqual(capturedArgs, ['serve', '--bg', '--https', '443', 'http://127.0.0.1:3456']);
+});
+
+test('startTailscaleServe throws TailscaleServeError on execFile failure', async () => {
+  const fakeExecFile = ((_cmd: string, _args: string[], cb: (err: Error | null) => void) => {
+    const err = Object.assign(new Error('tailscale serve failed'), { code: 1, stderr: 'daemon not running' });
+    cb(err);
+    return {} as ReturnType<typeof execFile>;
+  }) as unknown as typeof execFile;
+
+  await assert.rejects(
+    () => withDepsAsync({ execFile: fakeExecFile }, () => startTailscaleServe(3456)),
+    (err: unknown) => {
+      assert.ok(err instanceof TailscaleServeError);
+      assert.ok(err.stderr !== undefined);
+      assert.equal(err.name, 'TailscaleServeError');
+      return true;
+    },
+  );
+});
+
+// ---------------------------------------------------------------------------
+// stopTailscaleServe — async I/O function (via _deps injection)
+// ---------------------------------------------------------------------------
+
+test('stopTailscaleServe with strict:true throws TailscaleServeError on failure', async () => {
+  const fakeExecFile = ((_cmd: string, _args: string[], cb: (err: Error | null) => void) => {
+    const err = Object.assign(new Error('reset failed'), { code: 1, stderr: 'some error' });
+    cb(err);
+    return {} as ReturnType<typeof execFile>;
+  }) as unknown as typeof execFile;
+
+  await assert.rejects(
+    () => withDepsAsync({ execFile: fakeExecFile }, () => stopTailscaleServe({ strict: true })),
+    (err: unknown) => {
+      assert.ok(err instanceof TailscaleServeError);
+      return true;
+    },
+  );
+});
+
+test('stopTailscaleServe with strict:false swallows errors silently', async () => {
+  const fakeExecFile = ((_cmd: string, _args: string[], cb: (err: Error | null) => void) => {
+    const err = Object.assign(new Error('reset failed'), { code: 1, stderr: 'some error' });
+    cb(err);
+    return {} as ReturnType<typeof execFile>;
+  }) as unknown as typeof execFile;
+
+  // Should not throw
+  await withDepsAsync({ execFile: fakeExecFile }, () => stopTailscaleServe({ strict: false }));
+});
+
+test('stopTailscaleServe with no options swallows errors silently', async () => {
+  const fakeExecFile = ((_cmd: string, _args: string[], cb: (err: Error | null) => void) => {
+    const err = Object.assign(new Error('reset failed'), { code: 1, stderr: 'some error' });
+    cb(err);
+    return {} as ReturnType<typeof execFile>;
+  }) as unknown as typeof execFile;
+
+  // Should not throw
+  await withDepsAsync({ execFile: fakeExecFile }, () => stopTailscaleServe());
+});
+
+// ---------------------------------------------------------------------------
+// stopTailscaleServeSync — sync I/O function (via _deps injection)
+// ---------------------------------------------------------------------------
+
+test('stopTailscaleServeSync never throws even when spawnSync fails', () => {
+  withDeps(
+    { spawnSync: (() => { throw new Error('tailscale not found'); }) as unknown as typeof spawnSync },
+    () => stopTailscaleServeSync(),
+  );
+  // If we get here, no throw occurred
+  assert.ok(true);
+});
+
+test('stopTailscaleServeSync never throws when spawnSync returns non-zero', () => {
+  withDeps(
+    { spawnSync: (() => ({ status: 1, stdout: Buffer.from(''), stderr: Buffer.from('error') })) as unknown as typeof spawnSync },
+    () => stopTailscaleServeSync(),
+  );
+  assert.ok(true);
+});
+
+// ---------------------------------------------------------------------------
+// TailscaleServeError — class
+// ---------------------------------------------------------------------------
+
+test('TailscaleServeError preserves exitCode and stderr', () => {
+  const err = new TailscaleServeError('serve failed', 2, 'daemon not running');
+  assert.equal(err.exitCode, 2);
+  assert.equal(err.stderr, 'daemon not running');
+  assert.equal(err.name, 'TailscaleServeError');
+  assert.ok(err instanceof Error);
+  assert.ok(err instanceof TailscaleServeError);
+});
+
+test('TailscaleServeError allows null exitCode', () => {
+  const err = new TailscaleServeError('serve failed', null, '');
+  assert.equal(err.exitCode, null);
+});

--- a/src/web/__tests__/web-mode-tailscale.test.ts
+++ b/src/web/__tests__/web-mode-tailscale.test.ts
@@ -1,0 +1,246 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { writeFileSync, unlinkSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { parseCliArgs } from '../../cli-web-branch.ts'
+import { launchWebMode } from '../../web-mode.ts'
+import { TailscaleServeError } from '../tailscale.ts'
+
+// ─── Shared test data ─────────────────────────────────────────────────────────
+
+const fakeTailscaleInfo = {
+  hostname: 'testbox',
+  tailnet: 'test.ts.net',
+  fqdn: 'testbox.test.ts.net',
+  url: 'https://testbox.test.ts.net',
+}
+
+// ─── Mock deps factory ────────────────────────────────────────────────────────
+
+function buildMockDeps(overrides?: Record<string, unknown>) {
+  const calls: string[] = []
+  const capturedEnv: Record<string, string> = {}
+  const stderrOutput: string[] = []
+  let spawnOptions: Record<string, unknown> | null = null
+
+  const deps = {
+    existsSync: () => true,
+    initResources: () => {},
+    resolvePort: () => Promise.resolve(9999),
+    spawn: (_cmd: string, _args: string[], opts: Record<string, unknown>) => {
+      spawnOptions = opts
+      Object.assign(capturedEnv, opts.env)
+      const listeners: Record<string, Function[]> = {}
+      const child = {
+        once: (event: string, cb: Function) => { (listeners[event] ??= []).push(cb) },
+        unref: () => {},
+        pid: 12345,
+        _emit: (event: string, ...args: unknown[]) => { listeners[event]?.forEach(cb => cb(...args)) },
+      }
+      // Auto-emit exit after a tick so launchWebMode's await resolves
+      setTimeout(() => child._emit('exit', 0, null), 50)
+      return child
+    },
+    waitForBootReady: () => Promise.resolve(),
+    openBrowser: () => { calls.push('openBrowser') },
+    stderr: { write: (msg: string) => { stderrOutput.push(msg) } },
+    env: {},
+    platform: 'darwin' as const,
+    execPath: '/usr/bin/node',
+    pidFilePath: '/tmp/test-gsd-web.pid',
+    writePidFile: () => {},
+    readPidFile: () => null,
+    deletePidFile: () => { calls.push('deletePidFile') },
+    registryPath: join(tmpdir(), `test-web-instances-${process.pid}.json`),
+    isTailscaleInstalled: () => true,
+    getTailscaleStatus: () => ({ ok: true as const, info: fakeTailscaleInfo }),
+    startTailscaleServe: async (_port: number) => { calls.push('startServe') },
+    stopTailscaleServe: async () => { calls.push('stopServe') },
+    stopTailscaleServeSync: () => { calls.push('stopServeSync') },
+    readPasswordHash: () => 'scrypt-hash-placeholder',
+    ...overrides,
+  }
+
+  return {
+    deps,
+    calls,
+    capturedEnv,
+    stderrOutput,
+    getSpawnOptions: () => spawnOptions,
+  }
+}
+
+const BASE_OPTIONS = {
+  cwd: '/tmp/test-project',
+  projectSessionsDir: '/tmp/test-sessions',
+  agentDir: '/tmp/test-agent',
+  tailscale: true as const,
+}
+
+// ─── Flag parsing tests ───────────────────────────────────────────────────────
+
+test('parseCliArgs sets tailscale=true when --tailscale flag is present', () => {
+  const flags = parseCliArgs(['node', 'gsd', '--web', '--tailscale'])
+  assert.equal(flags.tailscale, true)
+  assert.equal(flags.web, true)
+})
+
+test('parseCliArgs does not set tailscale when --tailscale is absent', () => {
+  const flags = parseCliArgs(['node', 'gsd', '--web'])
+  assert.equal(flags.tailscale, undefined)
+})
+
+// ─── Preflight failure tests ──────────────────────────────────────────────────
+
+test('returns tailscale:cli-not-found when isTailscaleInstalled returns false', async () => {
+  const { deps, stderrOutput } = buildMockDeps({ isTailscaleInstalled: () => false })
+  const result = await launchWebMode(BASE_OPTIONS, deps)
+  assert.equal(result.ok, false)
+  if (!result.ok) {
+    assert.equal(result.failureReason, 'tailscale:cli-not-found')
+  }
+  assert.ok(stderrOutput.some(m => m.includes('Tailscale CLI not found')))
+})
+
+test('returns tailscale:not-connected when getTailscaleStatus returns not-connected', async () => {
+  const { deps, stderrOutput } = buildMockDeps({
+    getTailscaleStatus: () => ({ ok: false as const, reason: 'not-connected' as const }),
+  })
+  const result = await launchWebMode(BASE_OPTIONS, deps)
+  assert.equal(result.ok, false)
+  if (!result.ok) {
+    assert.equal(result.failureReason, 'tailscale:not-connected')
+  }
+  assert.ok(stderrOutput.some(m => m.includes('not connected')))
+})
+
+test('returns tailscale:no-password when readPasswordHash returns null', async () => {
+  const { deps } = buildMockDeps({ readPasswordHash: () => null })
+  const result = await launchWebMode(BASE_OPTIONS, deps)
+  assert.equal(result.ok, false)
+  if (!result.ok) {
+    assert.equal(result.failureReason, 'tailscale:no-password')
+  }
+})
+
+// ─── Singleton guard test ─────────────────────────────────────────────────────
+
+test('returns tailscale:already-running when live tailscale instance exists in registry', async () => {
+  const registryPath = join(tmpdir(), `test-singleton-${process.pid}.json`)
+  // Write a registry with a live entry (use the current process PID — definitely alive)
+  const registry = {
+    '/some/cwd': {
+      pid: process.pid,
+      port: 3000,
+      url: 'http://127.0.0.1:3000',
+      cwd: '/some/cwd',
+      startedAt: new Date().toISOString(),
+      tailscaleUrl: 'https://testbox.test.ts.net',
+    },
+  }
+  writeFileSync(registryPath, JSON.stringify(registry), 'utf8')
+
+  try {
+    const { deps } = buildMockDeps({ registryPath })
+    const result = await launchWebMode(BASE_OPTIONS, deps)
+    assert.equal(result.ok, false)
+    if (!result.ok) {
+      assert.equal(result.failureReason, 'tailscale:already-running')
+    }
+  } finally {
+    try { unlinkSync(registryPath) } catch { /* cleanup */ }
+  }
+})
+
+// ─── Lifecycle tests ──────────────────────────────────────────────────────────
+
+test('stopTailscaleServe called with strict:true during startup reset', async () => {
+  let strictCallArg: { strict?: boolean } | undefined = undefined
+  const stopTailscaleServe = async (opts?: { strict?: boolean }) => {
+    strictCallArg = opts
+  }
+  const { deps } = buildMockDeps({ stopTailscaleServe })
+  await launchWebMode(BASE_OPTIONS, deps)
+  // The startup reset call should use strict: true
+  assert.ok(strictCallArg !== undefined, 'stopTailscaleServe should have been called')
+  assert.equal(strictCallArg?.strict, true)
+})
+
+test('GSD_WEB_DAEMON_MODE=1 and Tailscale URL in GSD_WEB_ALLOWED_ORIGINS when --tailscale', async () => {
+  const { deps, capturedEnv } = buildMockDeps()
+  await launchWebMode(BASE_OPTIONS, deps)
+  assert.equal(capturedEnv.GSD_WEB_DAEMON_MODE, '1')
+  assert.ok(capturedEnv.GSD_WEB_ALLOWED_ORIGINS?.includes('https://testbox.test.ts.net'))
+})
+
+test('spawn called with detached:false in --tailscale mode (foreground supervisor)', async () => {
+  const { deps, getSpawnOptions } = buildMockDeps()
+  await launchWebMode(BASE_OPTIONS, deps)
+  const opts = getSpawnOptions()
+  assert.ok(opts !== null, 'spawn should have been called')
+  assert.equal(opts?.detached, false)
+})
+
+test('startTailscaleServe called and openBrowser NOT called in --tailscale mode', async () => {
+  const { deps, calls } = buildMockDeps()
+  await launchWebMode(BASE_OPTIONS, deps)
+  assert.ok(calls.includes('startServe'), 'startTailscaleServe should have been called')
+  assert.ok(!calls.includes('openBrowser'), 'openBrowser should NOT be called in --tailscale mode')
+})
+
+test('stderr contains "Accessible at: https://testbox.test.ts.net" after successful launch', async () => {
+  const { deps, stderrOutput } = buildMockDeps()
+  await launchWebMode(BASE_OPTIONS, deps)
+  const combined = stderrOutput.join('')
+  assert.ok(combined.includes('Accessible at: https://testbox.test.ts.net'))
+})
+
+// ─── Rollback test ────────────────────────────────────────────────────────────
+
+test('rollback: kills child process and returns tailscale:serve-failed when startTailscaleServe throws', async () => {
+  const killedPids: number[] = []
+  let deletePidFileCalled = false
+
+  const { deps, stderrOutput } = buildMockDeps({
+    startTailscaleServe: async () => {
+      throw new TailscaleServeError('serve failed', 1, 'port conflict error')
+    },
+    deletePidFile: () => { deletePidFileCalled = true },
+  })
+
+  // Patch spawn to return a pid we can track killing
+  const origSpawn = deps.spawn
+  deps.spawn = (cmd: string, args: string[], opts: Record<string, unknown>) => {
+    const child = origSpawn(cmd, args, opts)
+    return child
+  }
+
+  const result = await launchWebMode(BASE_OPTIONS, deps)
+  assert.equal(result.ok, false)
+  if (!result.ok) {
+    assert.equal(result.failureReason, 'tailscale:serve-failed')
+  }
+  // stderr should contain the TailscaleServeError stderr
+  const combined = stderrOutput.join('')
+  assert.ok(combined.includes('port conflict error'), `Expected 'port conflict error' in: ${combined}`)
+  assert.ok(deletePidFileCalled, 'deletePidFile should be called during rollback')
+})
+
+// ─── Cleanup idempotency (source check) ──────────────────────────────────────
+
+test('cleanupFired guard is present in web-mode.ts source (idempotency guard)', async () => {
+  const { readFileSync } = await import('node:fs')
+  const { fileURLToPath } = await import('node:url')
+  const { dirname, resolve } = await import('node:path')
+
+  const dir = dirname(fileURLToPath(import.meta.url))
+  const webModePath = resolve(dir, '../../web-mode.ts')
+  const source = readFileSync(webModePath, 'utf-8')
+  // Variable is named tailscaleCleanupFired (idempotency guard for double-signal protection)
+  assert.ok(
+    source.includes('tailscaleCleanupFired') || source.includes('cleanupFired'),
+    'web-mode.ts must contain a cleanupFired guard for idempotent cleanup',
+  )
+})

--- a/src/web/tailscale.ts
+++ b/src/web/tailscale.ts
@@ -1,0 +1,236 @@
+import { spawnSync, execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface TailscaleInfo {
+  hostname: string;   // Self.HostName
+  tailnet: string;    // MagicDNSSuffix
+  fqdn: string;       // Self.DNSName with trailing dot stripped
+  url: string;        // https://<fqdn>
+}
+
+export type TailscaleStatusResult =
+  | { ok: true; info: TailscaleInfo }
+  | { ok: false; reason: 'not-connected' | 'invalid-status' | 'cli-error'; stderr?: string };
+
+export class TailscaleServeError extends Error {
+  readonly exitCode: number | null;
+  readonly stderr: string;
+
+  constructor(
+    message: string,
+    exitCode: number | null,
+    stderr: string,
+  ) {
+    super(message);
+    this.name = 'TailscaleServeError';
+    this.exitCode = exitCode;
+    this.stderr = stderr;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Internal injectable deps (for testability without real tailscale)
+// ---------------------------------------------------------------------------
+
+type SpawnSyncFn = typeof spawnSync;
+type ExecFileFn = typeof execFile;
+
+interface TailscaleDeps {
+  spawnSync: SpawnSyncFn;
+  execFile: ExecFileFn;
+}
+
+// Mutable so tests can inject fakes
+export const _deps: TailscaleDeps = {
+  spawnSync,
+  execFile,
+};
+
+// ---------------------------------------------------------------------------
+// Pure functions (no I/O)
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse the output of `tailscale status --json` into a TailscaleInfo object.
+ * Returns null if required fields are missing or invalid.
+ */
+export function parseTailscaleStatus(statusJson: unknown): TailscaleInfo | null {
+  if (statusJson === null || typeof statusJson !== 'object') {
+    return null;
+  }
+  const obj = statusJson as Record<string, unknown>;
+
+  // Validate Self field
+  if (!obj['Self'] || typeof obj['Self'] !== 'object') {
+    return null;
+  }
+  const self = obj['Self'] as Record<string, unknown>;
+
+  // Validate required Self subfields
+  if (typeof self['DNSName'] !== 'string') {
+    return null;
+  }
+  if (typeof self['HostName'] !== 'string') {
+    return null;
+  }
+
+  // Validate MagicDNSSuffix
+  if (typeof obj['MagicDNSSuffix'] !== 'string') {
+    return null;
+  }
+
+  const hostname = self['HostName'];
+  const tailnet = obj['MagicDNSSuffix'];
+  const fqdn = self['DNSName'].replace(/\.$/, '');
+  const url = `https://${fqdn}`;
+
+  return { hostname, tailnet, fqdn, url };
+}
+
+/**
+ * Returns the args array for `tailscale serve --bg` for the given local port.
+ * Example: buildServeCommand(3456) → ["serve", "--bg", "--https", "443", "http://127.0.0.1:3456"]
+ */
+export function buildServeCommand(localPort: number): string[] {
+  return ['serve', '--bg', '--https', '443', `http://127.0.0.1:${localPort}`];
+}
+
+/**
+ * Returns the args array for `tailscale serve reset`.
+ */
+export function buildServeResetCommand(): string[] {
+  return ['serve', 'reset'];
+}
+
+/**
+ * Returns the platform-appropriate install command for Tailscale.
+ * This is a display-only hint — not executed by the system.
+ */
+export function getInstallCommand(platform: NodeJS.Platform): string {
+  if (platform === 'darwin') {
+    return 'brew install tailscale';
+  }
+  if (platform === 'win32') {
+    return 'winget install Tailscale.Tailscale';
+  }
+  return 'curl -fsSL https://tailscale.com/install.sh | sh';
+}
+
+// ---------------------------------------------------------------------------
+// I/O functions
+// ---------------------------------------------------------------------------
+
+/**
+ * Check whether the `tailscale` CLI is on PATH by running `tailscale version`.
+ * Synchronous — suitable for preflight checks before server startup.
+ */
+export function isTailscaleInstalled(): boolean {
+  try {
+    const result = _deps.spawnSync('tailscale', ['version'], { stdio: 'pipe' });
+    return result.status === 0;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Query `tailscale status --json` and return a discriminated result.
+ * Synchronous — suitable for preflight checks before server startup.
+ *
+ * Returns:
+ * - { ok: true, info } on success
+ * - { ok: false, reason: 'not-connected' } on non-zero exit (daemon not running or not connected)
+ * - { ok: false, reason: 'invalid-status' } on JSON parse failure or missing fields
+ * - { ok: false, reason: 'cli-error', stderr } on unexpected exception
+ */
+export function getTailscaleStatus(): TailscaleStatusResult {
+  try {
+    const result = _deps.spawnSync('tailscale', ['status', '--json'], { stdio: 'pipe' });
+    if (result.status !== 0) {
+      return { ok: false, reason: 'not-connected' };
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(result.stdout.toString('utf8'));
+    } catch {
+      return { ok: false, reason: 'invalid-status' };
+    }
+
+    const info = parseTailscaleStatus(parsed);
+    if (info === null) {
+      return { ok: false, reason: 'invalid-status' };
+    }
+
+    return { ok: true, info };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { ok: false, reason: 'cli-error', stderr: message };
+  }
+}
+
+/**
+ * Start `tailscale serve --bg` to expose the given local port via Tailscale HTTPS.
+ * Async — runs during server startup after the Next.js server is boot-ready.
+ *
+ * Throws TailscaleServeError on failure, preserving exitCode and stderr.
+ */
+export async function startTailscaleServe(localPort: number): Promise<void> {
+  const execFileAsync = promisify(_deps.execFile);
+  try {
+    await execFileAsync('tailscale', buildServeCommand(localPort));
+  } catch (err) {
+    const e = err as NodeJS.ErrnoException & { code?: number; stderr?: string };
+    const exitCode = typeof e.code === 'number' ? e.code : null;
+    const stderr = e.stderr ?? e.message ?? String(err);
+    throw new TailscaleServeError(
+      `tailscale serve failed: ${e.message}`,
+      exitCode,
+      stderr,
+    );
+  }
+}
+
+/**
+ * Run `tailscale serve reset` to remove all serve configuration.
+ * Async — used during server startup (strict mode) and shutdown (lenient mode).
+ *
+ * Options:
+ * - strict: true  → throws TailscaleServeError on failure (use for startup reset where failure is actionable)
+ * - strict: false (default) → swallows errors silently (use for shutdown cleanup where best-effort is fine)
+ */
+export async function stopTailscaleServe(options?: { strict?: boolean }): Promise<void> {
+  const execFileAsync = promisify(_deps.execFile);
+  try {
+    await execFileAsync('tailscale', buildServeResetCommand());
+  } catch (err) {
+    if (options?.strict) {
+      const e = err as NodeJS.ErrnoException & { code?: number; stderr?: string };
+      const exitCode = typeof e.code === 'number' ? e.code : null;
+      const stderr = e.stderr ?? e.message ?? String(err);
+      throw new TailscaleServeError(
+        `tailscale serve reset failed: ${(err as Error).message}`,
+        exitCode,
+        stderr,
+      );
+    }
+    // Lenient mode — swallow error silently
+  }
+}
+
+/**
+ * Synchronous variant of stopTailscaleServe for use in `process.on('exit')` handlers,
+ * where async code cannot run.
+ * Never throws — any failure is silently ignored.
+ */
+export function stopTailscaleServeSync(): void {
+  try {
+    _deps.spawnSync('tailscale', buildServeResetCommand(), { stdio: 'pipe' });
+  } catch {
+    // Never throws — best-effort cleanup for exit handlers
+  }
+}


### PR DESCRIPTION
## Remote Access — PR 3 of 4: Tailscale Serve

> **Remote Access Series** — 4 independent PRs, merge in order: 1→2→3→4. Each PR contains only its own files. Split per review feedback on #3024.
> **Depends on:** #3101 (Auth)

### Summary

`gsd --web --tailscale` starts the web server behind Tailscale Serve for HTTPS access within the tailnet.

- **CLI wrapper** (`tailscale.ts`): structured errors, status parsing, serve start/stop, install detection
- **`--tailscale` flag**: parsed in CLI, forwarded to `launchWebMode`
- **Lifecycle tests**: preflight checks, singleton guard, cleanup handlers, rollback

Note: `web-mode.ts` Tailscale lifecycle code is in PR 2 (shares file with session secret injection). This PR adds only the Tailscale module and tests.

**4 files** | 43 tests

### Test plan
- [x] `gsd --web --tailscale` prints tailnet HTTPS URL
- [x] Preflight failures show clear error messages
- [x] Ctrl+C runs `tailscale serve reset`
- [x] Singleton guard blocks duplicate instances