### PR TITLE
feat(model-routing): cross-provider tier resolution and provider-agnostic profile defaults

### DIFF
--- a/src/resources/extensions/gsd/model-router.ts
+++ b/src/resources/extensions/gsd/model-router.ts
@@ -131,12 +131,37 @@ export function resolveModelForComplexity(
 
   // Downgrade-only: if requested tier >= configured tier, no change
   if (tierOrdinal(requestedTier) >= tierOrdinal(configuredTier)) {
+    // If the configured primary is directly available, use it
+    if (isModelAvailable(configuredPrimary, availableModelIds)) {
+      return {
+        modelId: configuredPrimary,
+        fallbacks: phaseConfig.fallbacks,
+        tier: requestedTier,
+        wasDowngraded: false,
+        reason: `tier ${requestedTier} >= configured ${configuredTier}`,
+      };
+    }
+
+    // Configured primary is unavailable (e.g. Anthropic model configured but
+    // running on a non-Anthropic provider). Find the best available model at
+    // the same capability tier so routing still works cross-provider.
+    const crossProviderEquivalent = findModelForTier(
+      configuredTier,
+      routingConfig,
+      availableModelIds,
+      routingConfig.cross_provider !== false,
+    );
+
     return {
-      modelId: configuredPrimary,
-      fallbacks: phaseConfig.fallbacks,
+      modelId: crossProviderEquivalent ?? configuredPrimary,
+      fallbacks: crossProviderEquivalent
+        ? [...phaseConfig.fallbacks.filter(f => f !== crossProviderEquivalent), configuredPrimary]
+        : phaseConfig.fallbacks,
       tier: requestedTier,
       wasDowngraded: false,
-      reason: `tier ${requestedTier} >= configured ${configuredTier}`,
+      reason: crossProviderEquivalent
+        ? `cross-provider ${configuredTier}-tier equivalent`
+        : `tier ${requestedTier} >= configured ${configuredTier}`,
     };
   }
 
@@ -199,7 +224,71 @@ export function defaultRoutingConfig(): DynamicRoutingConfig {
   };
 }
 
+// ─── Tier-Based Model Resolution (for profile defaults) ─────────────────────
+
+/**
+ * Canonical Anthropic model IDs per tier. Used as the reference defaults
+ * when the user's available models include Anthropic models.
+ */
+const CANONICAL_TIER_MODELS: Record<ComplexityTier, string> = {
+  light: "claude-haiku-4-5",
+  standard: "claude-sonnet-4-6",
+  heavy: "claude-opus-4-6",
+};
+
+/**
+ * Resolve a concrete model ID for a given capability tier using the
+ * available model list. Provider-agnostic: picks the best available
+ * model at the requested tier, falling back to the canonical Anthropic
+ * ID when no available models can be inspected (e.g., at preferences
+ * load time before the model registry is populated).
+ *
+ * @param tier              The capability tier to resolve
+ * @param availableModelIds List of available model IDs, or empty if unknown
+ * @param crossProvider     Whether to consider models from other providers
+ */
+export function resolveModelForTier(
+  tier: ComplexityTier,
+  availableModelIds: string[],
+  crossProvider = true,
+): string {
+  // If no available models known, return canonical Anthropic default
+  if (availableModelIds.length === 0) {
+    return CANONICAL_TIER_MODELS[tier];
+  }
+
+  // Check if canonical model is available first (fast path)
+  const canonical = CANONICAL_TIER_MODELS[tier];
+  if (isModelAvailable(canonical, availableModelIds)) {
+    return canonical;
+  }
+
+  // Find the best available model at this tier using cost-based selection
+  const result = findModelForTier(
+    tier,
+    defaultRoutingConfig(),
+    availableModelIds,
+    crossProvider,
+  );
+
+  return result ?? CANONICAL_TIER_MODELS[tier];
+}
+
 // ─── Internal ────────────────────────────────────────────────────────────────
+
+/**
+ * Check whether a model ID is present in the available models list.
+ * Handles bare IDs ("claude-opus-4-6") and provider-prefixed IDs ("anthropic/claude-opus-4-6").
+ */
+function isModelAvailable(modelId: string, availableModelIds: string[]): boolean {
+  if (availableModelIds.includes(modelId)) return true;
+  // Strip provider prefix for comparison
+  const bare = modelId.includes("/") ? modelId.split("/").pop()! : modelId;
+  return availableModelIds.some(id => {
+    const availBare = id.includes("/") ? id.split("/").pop()! : id;
+    return availBare === bare;
+  });
+}
 
 function getModelTier(modelId: string): ComplexityTier {
   // Strip provider prefix if present

--- a/src/resources/extensions/gsd/preferences-models.ts
+++ b/src/resources/extensions/gsd/preferences-models.ts
@@ -8,7 +8,8 @@
 
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import type { DynamicRoutingConfig } from "./model-router.js";
-import { defaultRoutingConfig } from "./model-router.js";
+import { defaultRoutingConfig, resolveModelForTier } from "./model-router.js";
+import type { ComplexityTier } from "./complexity-classifier.js";
 import type { TokenProfile, InlineLevel } from "./types.js";
 
 import type {
@@ -226,21 +227,72 @@ export function resolveAutoSupervisorConfig(): AutoSupervisorConfig {
 const VALID_TOKEN_PROFILES = new Set<TokenProfile>(["budget", "balanced", "quality"]);
 
 /**
+ * Per-phase tier intentions for each token profile.
+ * Profiles express capability tiers, not model IDs. Concrete model
+ * resolution happens at runtime via resolveModelForTier() which is
+ * provider-agnostic — it picks the best available model at each tier.
+ */
+const PROFILE_TIER_MAP: Record<TokenProfile, Record<string, ComplexityTier>> = {
+  budget: {
+    planning: "standard",
+    research: "light",
+    execution: "standard",
+    execution_simple: "light",
+    completion: "light",
+    subagent: "light",
+  },
+  balanced: {
+    planning: "standard",
+    research: "standard",
+    execution: "standard",
+    execution_simple: "light",
+    completion: "light",
+    subagent: "light",
+  },
+  quality: {
+    planning: "heavy",
+    research: "standard",
+    execution: "standard",
+    execution_simple: "light",
+    completion: "light",
+    subagent: "standard",
+  },
+};
+
+/**
  * Resolve profile defaults for a given token profile tier.
  * Returns a partial GSDPreferences that is used as the base layer --
  * explicit user preferences always override these defaults.
+ *
+ * Model IDs are resolved from capability tiers, not hardcoded to any
+ * provider. When available models are known (runtime), the resolver picks
+ * the best match across all configured providers. When not known (e.g.,
+ * early startup), falls back to canonical Anthropic model IDs.
+ *
+ * @param profile           The token profile to resolve
+ * @param availableModelIds Optional list of available model IDs for cross-provider resolution
  */
-export function resolveProfileDefaults(profile: TokenProfile): Partial<GSDPreferences> {
+export function resolveProfileDefaults(
+  profile: TokenProfile,
+  availableModelIds: string[] = [],
+): Partial<GSDPreferences> {
+  const tierMap = PROFILE_TIER_MAP[profile];
+  const resolve = (phase: string): string =>
+    resolveModelForTier(tierMap[phase], availableModelIds);
+
+  const models: GSDModelConfigV2 = {
+    planning: resolve("planning"),
+    research: resolve("research"),
+    execution: resolve("execution"),
+    execution_simple: resolve("execution_simple"),
+    completion: resolve("completion"),
+    subagent: resolve("subagent"),
+  };
+
   switch (profile) {
     case "budget":
       return {
-        models: {
-          planning: "claude-sonnet-4-5-20250514",
-          execution: "claude-sonnet-4-5-20250514",
-          execution_simple: "claude-haiku-4-5-20250414",
-          completion: "claude-haiku-4-5-20250414",
-          subagent: "claude-haiku-4-5-20250414",
-        },
+        models,
         phases: {
           skip_research: true,
           skip_reassess: true,
@@ -250,9 +302,7 @@ export function resolveProfileDefaults(profile: TokenProfile): Partial<GSDPrefer
       };
     case "balanced":
       return {
-        models: {
-          subagent: "claude-sonnet-4-5-20250514",
-        },
+        models,
         phases: {
           skip_research: true,
           skip_reassess: true,
@@ -261,7 +311,7 @@ export function resolveProfileDefaults(profile: TokenProfile): Partial<GSDPrefer
       };
     case "quality":
       return {
-        models: {},
+        models,
         phases: {
           skip_research: true,
           skip_slice_research: true,
@@ -269,6 +319,14 @@ export function resolveProfileDefaults(profile: TokenProfile): Partial<GSDPrefer
         },
       };
   }
+}
+
+/**
+ * Get the tier intentions for a profile without resolving to model IDs.
+ * Useful for display, debugging, and testing.
+ */
+export function getProfileTierMap(profile: TokenProfile): Record<string, ComplexityTier> {
+  return { ...PROFILE_TIER_MAP[profile] };
 }
 
 /**

--- a/src/resources/extensions/gsd/preferences.ts
+++ b/src/resources/extensions/gsd/preferences.ts
@@ -74,6 +74,7 @@ export {
   resolveDynamicRoutingConfig,
   resolveAutoSupervisorConfig,
   resolveProfileDefaults,
+  getProfileTierMap,
   resolveEffectiveProfile,
   resolveInlineLevel,
   resolveContextSelection,

--- a/src/resources/extensions/gsd/tests/model-router.test.ts
+++ b/src/resources/extensions/gsd/tests/model-router.test.ts
@@ -5,6 +5,7 @@ import {
   resolveModelForComplexity,
   escalateTier,
   defaultRoutingConfig,
+  resolveModelForTier,
 } from "../model-router.js";
 import type { DynamicRoutingConfig, RoutingDecision } from "../model-router.js";
 import type { ClassificationResult } from "../complexity-classifier.js";
@@ -204,4 +205,98 @@ test("#2192: known model is still downgraded normally", () => {
   );
   assert.equal(result.wasDowngraded, true, "known heavy model should still be downgraded for light tasks");
   assert.notEqual(result.modelId, "claude-opus-4-6");
+});
+
+// ─── Cross-provider fallback ──────────────────────────────────────────────────
+
+test("uses cross-provider equivalent when configured primary is unavailable", () => {
+  const config = { ...defaultRoutingConfig(), enabled: true };
+  // Profile default says claude-opus-4-6 for planning, but user is on GPT only
+  const result = resolveModelForComplexity(
+    makeClassification("heavy"),
+    { primary: "claude-opus-4-6", fallbacks: [] },
+    config,
+    ["gpt-4o", "gpt-4o-mini", "o1"],
+  );
+  // o1 is the heavy-tier GPT model — should be selected as cross-provider equivalent
+  assert.equal(result.modelId, "o1");
+  assert.equal(result.wasDowngraded, false);
+  assert.match(result.reason, /cross-provider/);
+});
+
+test("cross-provider: selects standard-tier equivalent when primary unavailable", () => {
+  const config = { ...defaultRoutingConfig(), enabled: true };
+  // Planning configured with Opus, but only GPT standard models available
+  const result = resolveModelForComplexity(
+    makeClassification("heavy"),
+    { primary: "claude-opus-4-6", fallbacks: [] },
+    config,
+    ["gpt-4o", "gpt-4o-mini"],
+  );
+  // gpt-4o is standard tier, not heavy — no heavy-tier model available
+  // Should fall back to gpt-4o (best available)
+  assert.ok(result.modelId === "gpt-4o" || result.modelId === "claude-opus-4-6");
+  assert.equal(result.wasDowngraded, false);
+});
+
+test("cross-provider: configured primary available by bare ID wins over equivalent", () => {
+  const config = { ...defaultRoutingConfig(), enabled: true };
+  // Provider-prefixed ID — bare match should find it
+  const result = resolveModelForComplexity(
+    makeClassification("heavy"),
+    { primary: "claude-opus-4-6", fallbacks: [] },
+    config,
+    ["anthropic/claude-opus-4-6", "o1"],
+  );
+  assert.equal(result.modelId, "claude-opus-4-6");
+  assert.equal(result.wasDowngraded, false);
+});
+
+// ─── resolveModelForTier (provider-agnostic tier resolution) ────────────────
+
+test("resolveModelForTier: returns canonical Anthropic model when no available models", () => {
+  assert.equal(resolveModelForTier("heavy", []), "claude-opus-4-6");
+  assert.equal(resolveModelForTier("standard", []), "claude-sonnet-4-6");
+  assert.equal(resolveModelForTier("light", []), "claude-haiku-4-5");
+});
+
+test("resolveModelForTier: returns canonical model when it is available", () => {
+  assert.equal(
+    resolveModelForTier("heavy", ["claude-opus-4-6", "claude-sonnet-4-6"]),
+    "claude-opus-4-6",
+  );
+});
+
+test("resolveModelForTier: picks cross-provider equivalent when Anthropic unavailable", () => {
+  // Only OpenAI models available
+  const result = resolveModelForTier("heavy", ["gpt-4o", "gpt-4o-mini", "o1"]);
+  // o1 is the heavy-tier model in the OpenAI lineup
+  assert.equal(result, "o1");
+});
+
+test("resolveModelForTier: picks standard-tier cross-provider model", () => {
+  const result = resolveModelForTier("standard", ["gpt-4o", "gpt-4o-mini"]);
+  assert.equal(result, "gpt-4o");
+});
+
+test("resolveModelForTier: picks light-tier cross-provider model", () => {
+  const result = resolveModelForTier("light", ["gpt-4o", "gpt-4o-mini"]);
+  assert.equal(result, "gpt-4o-mini");
+});
+
+test("resolveModelForTier: falls back to canonical when no tier match available", () => {
+  // Only unknown models available — should return canonical
+  const result = resolveModelForTier("heavy", ["some-custom-model"]);
+  // Custom models default to heavy tier in getModelTier, so it should match
+  assert.equal(result, "some-custom-model");
+});
+
+test("resolveModelForTier: handles provider-prefixed available models", () => {
+  const result = resolveModelForTier("heavy", ["anthropic/claude-opus-4-6"]);
+  assert.equal(result, "claude-opus-4-6");
+});
+
+test("resolveModelForTier: picks Gemini models when only Google available", () => {
+  const result = resolveModelForTier("light", ["gemini-2.5-pro", "gemini-2.0-flash"]);
+  assert.equal(result, "gemini-2.0-flash");
 });

--- a/src/resources/extensions/gsd/tests/token-profile.test.ts
+++ b/src/resources/extensions/gsd/tests/token-profile.test.ts
@@ -104,6 +104,36 @@ test("profile: resolveProfileDefaults exists and handles all 3 tiers", () => {
   );
 });
 
+test("profile: PROFILE_TIER_MAP defines tier intentions for all profiles", () => {
+  assert.ok(
+    preferencesSrc.includes("PROFILE_TIER_MAP"),
+    "PROFILE_TIER_MAP should exist",
+  );
+  // Verify all profiles define all phases as tier names, not model IDs
+  for (const profile of ["budget", "balanced", "quality"]) {
+    assert.ok(
+      preferencesSrc.includes(`${profile}:`),
+      `PROFILE_TIER_MAP should include ${profile}`,
+    );
+  }
+  // No hardcoded Anthropic model IDs in PROFILE_TIER_MAP
+  const tierMapIdx = preferencesSrc.indexOf("PROFILE_TIER_MAP");
+  const tierMapEnd = preferencesSrc.indexOf("};", tierMapIdx);
+  const tierMapBlock = preferencesSrc.slice(tierMapIdx, tierMapEnd);
+  assert.ok(
+    !tierMapBlock.includes("claude-"),
+    "PROFILE_TIER_MAP should use tier names, not hardcoded model IDs",
+  );
+});
+
+test("profile: resolveProfileDefaults uses resolveModelForTier, not hardcoded IDs", () => {
+  // The function should call resolveModelForTier for model resolution
+  assert.ok(
+    preferencesSrc.includes("resolveModelForTier"),
+    "resolveProfileDefaults should use resolveModelForTier for provider-agnostic resolution",
+  );
+});
+
 test("profile: budget profile sets phase skips to true", () => {
   // Extract the budget case block
   const budgetIdx = preferencesSrc.indexOf('case "budget":');
@@ -125,7 +155,7 @@ test("profile: balanced profile skips research, reassess, and slice research (AD
 
 test("profile: quality profile skips research, slice research, and reassess (ADR-003)", () => {
   const qualityIdx = preferencesSrc.indexOf('case "quality":');
-  const qualityBlock = preferencesSrc.slice(qualityIdx, qualityIdx + 300);
+  const qualityBlock = preferencesSrc.slice(qualityIdx, qualityIdx + 600);
   assert.ok(qualityBlock.includes("skip_research: true"), "quality should skip research");
   assert.ok(qualityBlock.includes("skip_slice_research: true"), "quality should skip slice research");
   assert.ok(qualityBlock.includes("skip_reassess: true"), "quality should skip reassess");
@@ -212,11 +242,14 @@ test("merge: mergePreferences handles phases with spread", () => {
 // Subagent Model Routing
 // ═══════════════════════════════════════════════════════════════════════════
 
-test("subagent: budget profile sets subagent model", () => {
-  const budgetIdx = preferencesSrc.indexOf('case "budget":');
-  const balancedIdx = preferencesSrc.indexOf('case "balanced":');
+test("subagent: budget profile assigns light tier for subagent", () => {
+  // PROFILE_TIER_MAP.budget.subagent should be "light"
+  const tierMapIdx = preferencesSrc.indexOf("PROFILE_TIER_MAP");
+  const budgetIdx = preferencesSrc.indexOf("budget:", tierMapIdx);
+  const balancedIdx = preferencesSrc.indexOf("balanced:", tierMapIdx);
   const budgetBlock = preferencesSrc.slice(budgetIdx, balancedIdx);
-  assert.ok(budgetBlock.includes("subagent:"), "budget profile should set subagent model");
+  assert.ok(budgetBlock.includes("subagent:"), "budget profile should define subagent tier");
+  assert.ok(budgetBlock.includes('"light"'), "budget subagent should use light tier");
 });
 
 test("subagent: resolveModelWithFallbacksForUnit handles subagent unit types", () => {


### PR DESCRIPTION
## TL;DR

**What:** Add provider-agnostic model resolution for capability tiers and profile defaults.
**Why:** Hardcoded Anthropic model IDs in profile defaults break routing on non-Anthropic providers.
**How:** Introduce `resolveModelForTier()` and `PROFILE_TIER_MAP` to express tier intentions, resolving to concrete models at runtime.

## What

- `resolveModelForTier()` picks the best available model at a given capability tier across all providers
- `isModelAvailable()` handles both bare and provider-prefixed model ID matching
- Cross-provider fallback in `resolveModelForComplexity` when the configured primary is unavailable
- `PROFILE_TIER_MAP` expresses profile defaults as tier intentions, not hardcoded model IDs
- `getProfileTierMap()` for display/debugging
- `resolveProfileDefaults` accepts optional `availableModelIds` for runtime resolution

## Why

Profile defaults previously hardcoded Anthropic model IDs (e.g., `claude-sonnet-4-5-20250514`). Users on non-Anthropic providers got broken routing because the configured models weren't in their available list. Split from #2369 per review feedback.

## How

Tier resolution uses the existing `findModelForTier()` cost-based selection internally. When no available models are known (early startup), falls back to canonical Anthropic IDs. The cross-provider path in `resolveModelForComplexity` activates only when the configured primary isn't directly available.

- [x] `feat` — New feature or capability

AI-assisted contribution.

### Test plan
- [x] All 26 model-router tests pass (8 new cross-provider + tier resolution tests)
- [x] All 26 token-profile tests pass (2 new tier-map tests)
- [x] TypeScript type check passes