### PR TITLE
refactor(complexity): reclassify planning phases from standard to heavy tier

### DIFF
--- a/src/resources/extensions/gsd/complexity-classifier.ts
+++ b/src/resources/extensions/gsd/complexity-classifier.ts
@@ -35,15 +35,17 @@ const UNIT_TYPE_TIERS: Record<string, ComplexityTier> = {
   "complete-slice": "light",
   "run-uat": "light",
 
-  // Tier 2 — Standard: research, routine planning, discussion
+  // Tier 2 — Standard: research, routine discussion
   "discuss-milestone": "standard",
   "discuss-slice": "standard",
   "research-milestone": "standard",
   "research-slice": "standard",
-  "plan-milestone": "standard",
-  "plan-slice": "standard",
 
-  // Tier 3 — Heavy: execution, replanning (requires deep reasoning)
+  // Tier 3 — Heavy: planning, execution, replanning (requires deep reasoning)
+  // Planning is heavy so it uses the best configured model (e.g. Opus) and is
+  // not downgraded by dynamic routing when a capable model is configured.
+  "plan-milestone": "heavy",
+  "plan-slice": "heavy",
   "execute-task": "standard",   // default standard, upgraded by metadata
   "replan-slice": "heavy",
   "reassess-roadmap": "heavy",
@@ -185,8 +187,8 @@ function analyzePlanComplexity(
   // Check if this is a milestone-level plan (more complex) vs single slice
   const { milestone: mid, slice: sid } = parseUnitId(unitId);
   if (!sid) {
-    // Milestone-level planning is always at least standard
-    return { tier: "standard", reason: "milestone-level planning" };
+    // Milestone-level planning is always heavy — requires full context and best model
+    return { tier: "heavy", reason: "milestone-level planning" };
   }
 
   // For slice planning, try to read the context/research to gauge complexity

--- a/src/resources/extensions/gsd/tests/complexity-classifier.test.ts
+++ b/src/resources/extensions/gsd/tests/complexity-classifier.test.ts
@@ -41,14 +41,14 @@ test("research-slice classifies as standard", () => {
   assert.equal(result.tier, "standard");
 });
 
-test("plan-milestone classifies as standard", () => {
+test("plan-milestone classifies as heavy", () => {
   const result = classifyUnitComplexity("plan-milestone", "M001", "/tmp/fake");
-  assert.equal(result.tier, "standard");
+  assert.equal(result.tier, "heavy");
 });
 
-test("plan-slice classifies as standard", () => {
+test("plan-slice classifies as heavy", () => {
   const result = classifyUnitComplexity("plan-slice", "M001/S01", "/tmp/fake");
-  assert.equal(result.tier, "standard");
+  assert.equal(result.tier, "heavy");
 });
 
 test("replan-slice classifies as heavy", () => {


### PR DESCRIPTION
## TL;DR

**What:** Reclassify planning phases from standard to heavy tier.
**Why:** Planning requires the best configured model and should not be downgraded by dynamic routing.
**How:** Move `plan-milestone` and `plan-slice` from standard to heavy in the tier map and update milestone-level analysis.

## What

- `plan-milestone` and `plan-slice` moved from `"standard"` to `"heavy"` in `UNIT_TYPE_TIERS`
- `analyzePlanComplexity` returns `"heavy"` for milestone-level planning instead of `"standard"`

## Why

Planning phases were classified as standard tier, which caused dynamic routing to downgrade them to cheaper models (e.g., Sonnet instead of Opus). Planning requires deep reasoning and full context — it should always use the best configured model. Split from #2369 per review feedback.

## How

Two-line change in the tier map plus one-line change in the analysis function. Updated test assertions to match.

- [x] `refactor` — Code restructuring (no behavior change)

Note: While this is technically a behavior change for dynamic routing, it's a correctness fix — planning was incorrectly classified.

AI-assisted contribution.

### Test plan
- [x] All 28 complexity-classifier tests pass (2 updated assertions)
- [x] TypeScript type check passes