### PR TITLE
feat(dispatch): parallel research slices and parallel milestone validation

### DIFF
--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -27,6 +27,7 @@ import {
   buildMilestoneFileName,
   buildSliceFileName,
 } from "./paths.js";
+import { parseRoadmap } from "./parsers-legacy.js";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { hasImplementationArtifacts } from "./auto-recovery.js";
@@ -46,6 +47,7 @@ import {
   buildRewriteDocsPrompt,
   buildReactiveExecutePrompt,
   buildGateEvaluatePrompt,
+  buildParallelResearchSlicesPrompt,
   checkNeedsReassessment,
   checkNeedsRunUat,
 } from "./auto-prompts.js";
@@ -345,6 +347,53 @@ export const DISPATCH_RULES: DispatchRule[] = [
           midTitle,
           sid,
           sTitle,
+          basePath,
+        ),
+      };
+    },
+  },
+  {
+    name: "planning (multiple slices need research) → parallel-research-slices",
+    match: async ({ state, mid, midTitle, basePath, prefs }) => {
+      if (state.phase !== "planning") return null;
+      if (prefs?.phases?.skip_research || prefs?.phases?.skip_slice_research) return null;
+
+      // Load roadmap to find all slices
+      const roadmapFile = resolveMilestoneFile(basePath, mid, "ROADMAP");
+      const roadmapContent = roadmapFile ? await loadFile(roadmapFile) : null;
+      if (!roadmapContent) return null;
+      const roadmap = parseRoadmap(roadmapContent);
+
+      // Find slices that need research (no RESEARCH file, dependencies done)
+      const milestoneResearchFile = resolveMilestoneFile(basePath, mid, "RESEARCH");
+      const researchReadySlices: Array<{ id: string; title: string }> = [];
+
+      for (const slice of roadmap.slices) {
+        if (slice.done) continue;
+        // Skip S01 when milestone research exists
+        if (milestoneResearchFile && slice.id === "S01") continue;
+        // Skip if already has research
+        if (resolveSliceFile(basePath, mid, slice.id, "RESEARCH")) continue;
+        // Skip if dependencies aren't done (check for SUMMARY files)
+        const depsComplete = (slice.depends ?? []).every((depId) =>
+          !!resolveSliceFile(basePath, mid, depId, "SUMMARY"),
+        );
+        if (!depsComplete) continue;
+
+        researchReadySlices.push({ id: slice.id, title: slice.title });
+      }
+
+      // Only dispatch parallel if 2+ slices are ready
+      if (researchReadySlices.length < 2) return null;
+
+      return {
+        action: "dispatch",
+        unitType: "research-slice",
+        unitId: `${mid}/parallel-research`,
+        prompt: await buildParallelResearchSlicesPrompt(
+          mid,
+          midTitle,
+          researchReadySlices,
           basePath,
         ),
       };

--- a/src/resources/extensions/gsd/auto-prompts.ts
+++ b/src/resources/extensions/gsd/auto-prompts.ts
@@ -1749,6 +1749,36 @@ const GATE_QUESTIONS: Record<string, { question: string; guidance: string }> = {
   },
 };
 
+export async function buildParallelResearchSlicesPrompt(
+  mid: string,
+  midTitle: string,
+  slices: Array<{ id: string; title: string }>,
+  basePath: string,
+): Promise<string> {
+  // Build individual research-slice prompts for each slice
+  const subagentSections: string[] = [];
+  for (const slice of slices) {
+    const slicePrompt = await buildResearchSlicePrompt(mid, midTitle, slice.id, slice.title, basePath);
+    subagentSections.push([
+      `### ${slice.id}: ${slice.title}`,
+      "",
+      "Use this as the prompt for a `subagent` call (agent: `gsd-executor` or the default agent):",
+      "",
+      "```",
+      slicePrompt,
+      "```",
+    ].join("\n"));
+  }
+
+  return loadPrompt("parallel-research-slices", {
+    mid,
+    midTitle,
+    sliceCount: String(slices.length),
+    sliceList: slices.map((s) => `- **${s.id}**: ${s.title}`).join("\n"),
+    subagentPrompts: subagentSections.join("\n\n---\n\n"),
+  });
+}
+
 export async function buildGateEvaluatePrompt(
   mid: string, midTitle: string, sid: string, sTitle: string,
   base: string,

--- a/src/resources/extensions/gsd/prompts/parallel-research-slices.md
+++ b/src/resources/extensions/gsd/prompts/parallel-research-slices.md
@@ -1,0 +1,23 @@
+# Parallel Slice Research
+
+You are dispatching parallel research agents for **{{sliceCount}} slices** in milestone **{{mid}} — {{midTitle}}**.
+
+## Slices to Research
+
+{{sliceList}}
+
+## Mission
+
+Dispatch ALL slices simultaneously using the `subagent` tool in **parallel mode**. Each subagent will independently research its slice and write a RESEARCH file.
+
+## Execution Protocol
+
+1. Call `subagent` with `tasks: [...]` containing one entry per slice below
+2. Wait for ALL subagents to complete
+3. Verify each slice's RESEARCH file was written (check the `.gsd/{{mid}}/` directory)
+4. If any subagent failed to write its RESEARCH file, re-run it individually
+5. Report which slices completed research and which (if any) failed
+
+## Subagent Prompts
+
+{{subagentPrompts}}

--- a/src/resources/extensions/gsd/prompts/validate-milestone.md
+++ b/src/resources/extensions/gsd/prompts/validate-milestone.md
@@ -1,46 +1,79 @@
-You are executing GSD auto-mode.
+# Milestone Validation — Parallel Review
 
-## UNIT: Validate Milestone {{milestoneId}} ("{{milestoneTitle}}")
+You are the validation orchestrator for **{{milestoneId}} — {{milestoneTitle}}**.
 
 ## Working Directory
 
 Your working directory is `{{workingDirectory}}`. All file reads, writes, and shell commands MUST operate relative to this directory. Do NOT `cd` to any other directory.
 
-## Your Role in the Pipeline
+## Mission
 
-All slices are done. Before the milestone can be completed, you must validate that the planned work was delivered as specified. Compare the roadmap's success criteria and slice definitions against the actual slice summaries and UAT results. This is a reconciliation gate — catch gaps, regressions, or missing deliverables before the milestone is sealed.
+Dispatch 3 independent parallel reviewers, then synthesize their findings into the final VALIDATION verdict.
 
 This is remediation round {{remediationRound}}. If this is round 0, this is the first validation pass. If > 0, prior validation found issues and remediation slices were added and executed — verify those remediation slices resolved the issues.
+
+## Context
 
 All relevant context has been preloaded below — the roadmap, all slice summaries, UAT results, requirements, decisions, and project context are inlined. Start working immediately without re-reading these files.
 
 {{inlinedContext}}
 
-{{skillActivation}}
+## Execution Protocol
 
-## Validation Steps
+### Step 1 — Dispatch Parallel Reviewers
 
-1. For each **success criterion** in `{{roadmapPath}}`, check whether slice summaries and UAT results provide evidence that it was met. Record pass/fail per criterion.
-2. For each **slice** in the roadmap, verify its demo/deliverable claim against its summary. Flag any slice whose summary does not substantiate its claimed output.
-3. Check **cross-slice integration points** — do boundary map entries (produces/consumes) align with what was actually built?
-4. Check **requirement coverage** — are all active requirements addressed by at least one slice?
-5. If **Verification Classes** are provided in the inlined context above, check each non-empty class:
-   - For each verification class (Contract, Integration, Operational, UAT), determine whether slice summaries, UAT results, or observable behavior provide evidence that this verification tier was addressed.
-   - Document the compliance status of each class in a dedicated verification classes section.
-   - If `Operational` verification is non-empty and no evidence of operational verification exists, flag this explicitly — it means planned operational checks (migrations, deployments, runtime verification) were not proven.
-   - A milestone with unaddressed verification classes may still pass if the gaps are minor, but the gaps MUST be documented in the Deferred Work Inventory.
-6. Determine a verdict:
-   - `pass` — all criteria met, all slices delivered, no gaps
-   - `needs-attention` — minor gaps that do not block completion (document them)
-   - `needs-remediation` — material gaps found; remediation slices must be added to the roadmap
+Call `subagent` with `tasks: [...]` containing ALL THREE reviewers simultaneously:
 
-## Persist Validation
+**Reviewer A — Requirements Coverage**
+Prompt: "Review milestone {{milestoneId}} requirements coverage. Working directory: {{workingDirectory}}. Read `.gsd/{{milestoneId}}/REQUIREMENTS.md` (or equivalent requirements file). For each requirement, check the slice SUMMARY files in `.gsd/{{milestoneId}}/` to determine if it is: COVERED (clearly demonstrated), PARTIAL (mentioned but not fully demonstrated), or MISSING (no evidence). Output a markdown table with columns: Requirement | Status | Evidence. End with a one-line verdict: PASS if all covered, NEEDS-ATTENTION if partials exist, FAIL if any missing."
 
-**Persist validation results through `gsd_validate_milestone`.** Call it with: `milestoneId`, `verdict`, `remediationRound`, `successCriteriaChecklist`, `sliceDeliveryAudit`, `crossSliceIntegration`, `requirementCoverage`, `verificationClasses` (when non-empty), `verdictRationale`, and `remediationPlan` (if verdict is `needs-remediation`). The tool writes the validation to the DB and renders VALIDATION.md to disk.
+**Reviewer B — Cross-Slice Integration**
+Prompt: "Review milestone {{milestoneId}} cross-slice integration. Working directory: {{workingDirectory}}. Read `{{roadmapPath}}` and find the boundary map (produces/consumes contracts). For each boundary, check that the producing slice's SUMMARY confirms it produced the artifact, and the consuming slice's SUMMARY confirms it consumed it. Output a markdown table: Boundary | Producer Summary | Consumer Summary | Status. End with a one-line verdict: PASS if all boundaries honored, NEEDS-ATTENTION if any gaps."
+
+**Reviewer C — UAT & Acceptance Criteria**
+Prompt: "Review milestone {{milestoneId}} UAT and acceptance criteria. Working directory: {{workingDirectory}}. Read `.gsd/{{milestoneId}}/CONTEXT.md` for acceptance criteria. Check for UAT-RESULT files in each slice directory. Verify each acceptance criterion maps to either a passing UAT result or clear SUMMARY evidence. Output a checklist: [ ] Criterion | Evidence. End with a one-line verdict: PASS if all criteria met, NEEDS-ATTENTION if gaps exist."
+
+### Step 2 — Synthesize Findings
+
+After all reviewers complete, aggregate their verdicts:
+- If ALL reviewers say PASS → overall verdict: `pass`
+- If any reviewer says NEEDS-ATTENTION → overall verdict: `needs-attention`
+- If any reviewer says FAIL → overall verdict: `needs-remediation`
+
+### Step 3 — Write VALIDATION File
+
+Write to `{{validationPath}}`:
+
+```markdown
+---
+verdict: <pass|needs-attention|needs-remediation>
+remediation_round: {{remediationRound}}
+reviewers: 3
+---
+
+# Milestone Validation: {{milestoneId}}
+
+## Reviewer A — Requirements Coverage
+<paste Reviewer A output>
+
+## Reviewer B — Cross-Slice Integration
+<paste Reviewer B output>
+
+## Reviewer C — UAT & Acceptance Criteria
+<paste Reviewer C output>
+
+## Synthesis
+<2-3 sentences summarizing overall findings and verdict rationale>
+
+## Remediation Plan
+<if verdict is not pass: specific actions required>
+```
 
 If verdict is `needs-remediation`:
-- After calling `gsd_validate_milestone`, use `gsd_reassess_roadmap` to add remediation slices. Pass `milestoneId`, a synthetic `completedSliceId` (e.g. "VALIDATION"), `verdict: "roadmap-adjusted"`, `assessment` text, and `sliceChanges` with the new slices in the `added` array. The tool persists the changes to the DB and re-renders ROADMAP.md.
-- These remediation slices will be planned and executed before validation re-runs.
+- Add new slices to `{{roadmapPath}}` with unchecked `[ ]` status
+- These slices will be planned and executed before validation re-runs
+
+**You MUST write `{{validationPath}}` before finishing.**
 
 **File system safety:** When scanning milestone directories for evidence, use `ls` or `find` to list directory contents first — never pass a directory path (e.g. `tasks/`, `slices/`) directly to the `read` tool. The `read` tool only accepts file paths, not directories.
 


### PR DESCRIPTION
## TL;DR

**What:** Add parallel research slices dispatch and rewrite milestone validation for parallel review.
**Why:** Sequential slice research and validation are bottlenecks — dispatching them in parallel saves time.
**How:** New dispatch rule detects 2+ research-ready slices and dispatches subagents; validation uses 3 parallel reviewers.

## What

- New dispatch rule: `planning (multiple slices need research) → parallel-research-slices`
- `buildParallelResearchSlicesPrompt` generates per-slice subagent prompts
- `parallel-research-slices.md` prompt template
- `validate-milestone.md` rewritten to dispatch 3 parallel reviewers (requirements, integration, UAT)

## Why

When multiple slices need research simultaneously, dispatching them one at a time wastes wall-clock time. Similarly, milestone validation does requirements, integration, and UAT checks sequentially — these are independent and can run in parallel. Split from #2369 per review feedback.

## How

The dispatch rule loads the roadmap, filters for slices that need research (no RESEARCH file, dependencies complete, not S01 when milestone research exists), and triggers parallel dispatch when 2+ slices qualify. The validation prompt is restructured as an orchestrator that dispatches 3 independent reviewers and synthesizes their findings.

- [x] `feat` — New feature or capability

AI-assisted contribution.

### Test plan
- [x] TypeScript type check passes
- [x] No existing tests broken