### PR TITLE
feat(model-routing): enable dynamic routing by default

### DIFF
--- a/src/resources/extensions/gsd/model-router.ts
+++ b/src/resources/extensions/gsd/model-router.ts
@@ -191,7 +191,7 @@ export function escalateTier(currentTier: ComplexityTier): ComplexityTier | null
  */
 export function defaultRoutingConfig(): DynamicRoutingConfig {
   return {
-    enabled: false,
+    enabled: true,
     escalate_on_failure: true,
     budget_pressure: true,
     cross_provider: true,


### PR DESCRIPTION
## TL;DR

**What:** Enable dynamic model routing by default.
**Why:** Dynamic routing saves cost by using cheaper models for simple tasks, but was disabled by default requiring manual opt-in.
**How:** Single-line change: `defaultRoutingConfig().enabled` from `false` to `true`.

## What

- `defaultRoutingConfig()` now returns `enabled: true` instead of `enabled: false`

## Why

Dynamic routing (tier-based model downgrading) was built and tested but disabled by default. Users had to explicitly enable it in PREFERENCES.md to benefit from cost savings. With the routing infrastructure stable, it should be on by default. Split from #2369 per review feedback — this is isolated as a separate PR due to the significant behavioral impact.

## How

One-line change. Users who don't want automatic downgrading can set `dynamic_routing.enabled: false` in PREFERENCES.md.

### Breaking change

**This is a behavioral change.** Sessions that previously used the configured model for all tasks will now automatically downgrade to cheaper models for light and standard complexity tasks. Users can opt out via `dynamic_routing.enabled: false`.

- [x] `feat` — New feature or capability

AI-assisted contribution.

### Test plan
- [x] All 15 model-router tests pass
- [x] TypeScript type check passes