### PR TITLE
feat(subagent): parallel IPC, worktree isolation, and concurrency control

### DIFF
--- a/src/resources/extensions/subagent/index.ts
+++ b/src/resources/extensions/subagent/index.ts
@@ -26,6 +26,7 @@ import { Type } from "@sinclair/typebox";
 import { formatTokenCount } from "../shared/mod.js";
 import { type AgentConfig, type AgentScope, discoverAgents } from "./agents.js";
 import {
+	type DeltaPatch,
 	type IsolationEnvironment,
 	type IsolationMode,
 	type MergeResult,
@@ -33,7 +34,8 @@ import {
 	mergeDeltaPatches,
 	readIsolationMode,
 } from "./isolation.js";
-import { registerWorker, updateWorker } from "./worker-registry.js";
+import { registerWorker, updateWorker, getWaveSummary } from "./worker-registry.js";
+import { ParallelIPC } from "./parallel-ipc.js";
 import { loadEffectiveGSDPreferences } from "../gsd/preferences.js";
 import { CmuxClient, shellEscape } from "../cmux/index.js";
 
@@ -609,6 +611,7 @@ const SubagentParams = Type.Object({
 			default: false,
 		}),
 	),
+	concurrency: Type.Optional(Type.Number({ minimum: 1, maximum: 8, description: "Max concurrent tasks. Defaults to 4." })),
 });
 
 export default function (pi: ExtensionAPI) {
@@ -819,17 +822,55 @@ export default function (pi: ExtensionAPI) {
 				const gridSurfaces = cmuxSplitsEnabled
 					? await cmuxClient.createGridLayout(Math.min(batchSize, MAX_CONCURRENCY))
 					: [];
-				const results = await mapWithConcurrencyLimit(params.tasks, MAX_CONCURRENCY, async (t, index) => {
+				const parallelConcurrency = Math.min(params.concurrency ?? MAX_CONCURRENCY, MAX_PARALLEL_TASKS);
+
+				// Load GSD preferences to check for a subagent model override
+				const prefs = loadEffectiveGSDPreferences();
+				const subagentModelOverride = prefs?.preferences?.reactive_execution?.subagent_model;
+
+				// If a subagent_model override is configured, create a shallow copy of
+				// each agent config with the overridden model so that
+				// buildSubagentProcessArgs picks it up automatically.
+				const effectiveAgents: AgentConfig[] = subagentModelOverride
+					? agents.map((a) => ({ ...a, model: subagentModelOverride }))
+					: agents;
+
+				// File-based IPC — write worker state + NDJSON event stream to .gsd/parallel/<batchId>/
+				const ipc = new ParallelIPC(ctx.cwd, batchId);
+				ipc.init(batchSize);
+				process.stderr.write(`gsd-parallel: batch ${batchId} started — monitor: ${ipc.eventsFilePath}\n`);
+
+				// Per-task worktree isolation (only when params.isolated + a mode is configured)
+				const taskIsolations = new Map<number, IsolationEnvironment>();
+				const taskPatches = new Map<number, DeltaPatch[]>();
+				if (useIsolation) {
+					for (let i = 0; i < params.tasks.length; i++) {
+						try {
+							const taskCwd = params.tasks[i].cwd ?? ctx.cwd;
+							const iso = await createIsolation(taskCwd, `${batchId}-${i}`, isolationMode);
+							taskIsolations.set(i, iso);
+						} catch (err) {
+							process.stderr.write(`gsd-parallel: isolation setup failed for task ${i}: ${err}\n`);
+						}
+					}
+				}
+
+				const results = await mapWithConcurrencyLimit(params.tasks, parallelConcurrency, async (t, index) => {
+					const isolation = taskIsolations.get(index);
+					const effectiveCwd = isolation ? isolation.workDir : t.cwd;
+					const workerStartMs = Date.now();
 					const workerId = registerWorker(t.agent, t.task, index, batchSize, batchId);
+					ipc.workerStart(index, t.agent, t.task);
+
 					const runTask = () => cmuxSplitsEnabled
 						? runSingleAgentInCmuxSplit(
 							cmuxClient,
 							gridSurfaces[index] ?? (index % 2 === 0 ? "right" : "down"),
 							ctx.cwd,
-							agents,
+							effectiveAgents,
 							t.agent,
 							t.task,
-							t.cwd,
+							effectiveCwd,
 							undefined,
 							signal,
 							(partial) => {
@@ -842,10 +883,10 @@ export default function (pi: ExtensionAPI) {
 						)
 						: runSingleAgent(
 							ctx.cwd,
-							agents,
+							effectiveAgents,
 							t.agent,
 							t.task,
-							t.cwd,
+							effectiveCwd,
 							undefined,
 							signal,
 							(partial) => {
@@ -864,13 +905,49 @@ export default function (pi: ExtensionAPI) {
 						result = await runTask();
 					}
 
-					updateWorker(workerId, result.exitCode === 0 ? "completed" : "failed");
+					// Capture delta from isolation before marking complete
+					if (isolation) {
+						try {
+							const patches = await isolation.captureDelta();
+							if (patches.length > 0) taskPatches.set(index, patches);
+						} catch (err) {
+							process.stderr.write(`gsd-parallel: delta capture failed for task ${index}: ${err}\n`);
+						}
+					}
+
+					const workerStatus = result.exitCode === 0 ? "completed" : "failed";
+					const workerDurationMs = Date.now() - workerStartMs;
+					updateWorker(workerId, workerStatus);
+					ipc.workerComplete(index, workerStatus, workerDurationMs);
 					allResults[index] = result;
 					emitParallelUpdate();
 					return result;
 				});
 
+				// Merge isolation patches back to the main repo.
+				// Combine all patches into a single set so mergeDeltaPatches can do
+				// one combined dry-run before applying anything — avoids partial merges.
+				if (taskIsolations.size > 0) {
+					const allPatches: DeltaPatch[] = [];
+					for (let i = 0; i < params.tasks.length; i++) {
+						const patches = taskPatches.get(i);
+						if (patches) allPatches.push(...patches);
+					}
+
+					if (allPatches.length > 0 && !signal?.aborted) {
+						const mergeResult = await mergeDeltaPatches(ctx.cwd, allPatches);
+						if (!mergeResult.success) {
+							process.stderr.write(`gsd-parallel: patch merge failed: ${mergeResult.error}\n`);
+						}
+					}
+
+					for (const iso of taskIsolations.values()) {
+						await iso.cleanup().catch(() => { /* best effort */ });
+					}
+				}
+
 				const successCount = results.filter((r) => r.exitCode === 0).length;
+				ipc.batchComplete(successCount, results.length - successCount);
 				const summaries = results.map((r) => {
 					const isError = r.exitCode !== 0 || r.stopReason === "error" || r.stopReason === "aborted";
 					const output = isError

--- a/src/resources/extensions/subagent/parallel-ipc.ts
+++ b/src/resources/extensions/subagent/parallel-ipc.ts
@@ -1,0 +1,202 @@
+/**
+ * File-based IPC for parallel subagent batches.
+ *
+ * Writes worker state and a structured NDJSON event stream to
+ * `.gsd/parallel/<batchId>/` so that external monitors, dashboards,
+ * and other processes can observe batch progress without needing
+ * access to the in-process worker registry.
+ *
+ * Directory layout:
+ *   .gsd/parallel/<batchId>/
+ *     batch.json          — batch metadata (start, counts, status)
+ *     worker-<n>.json     — per-worker state (agent, task excerpt, timing)
+ *     events.ndjson       — append-only NDJSON event stream
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface BatchMeta {
+  batchId: string;
+  startedAt: number;
+  workerCount: number;
+  status: "running" | "completed";
+  successCount?: number;
+  failedCount?: number;
+  durationMs?: number;
+}
+
+export interface WorkerMeta {
+  index: number;
+  agent: string;
+  /** First 120 chars of the task prompt */
+  taskExcerpt: string;
+  startedAt: number;
+  status: "running" | "completed" | "failed";
+  completedAt?: number;
+  durationMs?: number;
+}
+
+export type IpcEvent =
+  | { type: "batch_start"; batchId: string; workerCount: number; ts: number }
+  | { type: "worker_start"; batchId: string; index: number; agent: string; ts: number }
+  | { type: "worker_complete"; batchId: string; index: number; status: "completed" | "failed"; durationMs: number; ts: number }
+  | { type: "batch_complete"; batchId: string; successCount: number; failedCount: number; durationMs: number; ts: number };
+
+// ─── ParallelIPC ──────────────────────────────────────────────────────────────
+
+/**
+ * Manages the file-based IPC directory for a single parallel batch.
+ * All writes are best-effort — failures are silently ignored so that
+ * IPC problems never interrupt actual agent execution.
+ */
+export class ParallelIPC {
+  private readonly batchId: string;
+  private readonly batchDir: string;
+  private readonly eventsPath: string;
+  private readonly batchStartMs: number;
+
+  constructor(repoRoot: string, batchId: string) {
+    this.batchId = batchId;
+    this.batchDir = path.join(repoRoot, ".gsd", "parallel", batchId);
+    this.eventsPath = path.join(this.batchDir, "events.ndjson");
+    this.batchStartMs = Date.now();
+  }
+
+  /**
+   * Create the IPC directory and write initial batch metadata.
+   * Must be called once before any workerStart() calls.
+   */
+  init(workerCount: number): void {
+    try {
+      fs.mkdirSync(this.batchDir, { recursive: true });
+    } catch {
+      return; // If we can't create the dir, all further writes will silently fail
+    }
+
+    const meta: BatchMeta = {
+      batchId: this.batchId,
+      startedAt: this.batchStartMs,
+      workerCount,
+      status: "running",
+    };
+    this.writeJson("batch.json", meta);
+    this.appendEvent({
+      type: "batch_start",
+      batchId: this.batchId,
+      workerCount,
+      ts: this.batchStartMs,
+    });
+  }
+
+  /** Record that a worker has started. */
+  workerStart(index: number, agent: string, task: string): void {
+    const taskExcerpt = task.length > 120 ? `${task.slice(0, 120)}...` : task;
+    const now = Date.now();
+    const meta: WorkerMeta = {
+      index,
+      agent,
+      taskExcerpt,
+      startedAt: now,
+      status: "running",
+    };
+    this.writeJson(`worker-${index}.json`, meta);
+    this.appendEvent({
+      type: "worker_start",
+      batchId: this.batchId,
+      index,
+      agent,
+      ts: now,
+    });
+  }
+
+  /** Record that a worker has finished. */
+  workerComplete(index: number, status: "completed" | "failed", durationMs: number): void {
+    const now = Date.now();
+    try {
+      const filePath = path.join(this.batchDir, `worker-${index}.json`);
+      const existing: WorkerMeta = JSON.parse(fs.readFileSync(filePath, "utf-8"));
+      existing.status = status;
+      existing.completedAt = now;
+      existing.durationMs = durationMs;
+      this.writeJson(`worker-${index}.json`, existing);
+    } catch {
+      // Worker file may not exist if init() failed; write a minimal record
+      const meta: WorkerMeta = {
+        index,
+        agent: "(unknown)",
+        taskExcerpt: "",
+        startedAt: now - durationMs,
+        status,
+        completedAt: now,
+        durationMs,
+      };
+      this.writeJson(`worker-${index}.json`, meta);
+    }
+    this.appendEvent({
+      type: "worker_complete",
+      batchId: this.batchId,
+      index,
+      status,
+      durationMs,
+      ts: now,
+    });
+  }
+
+  /** Record batch completion with final counts. */
+  batchComplete(successCount: number, failedCount: number): void {
+    const durationMs = Date.now() - this.batchStartMs;
+    try {
+      const batchPath = path.join(this.batchDir, "batch.json");
+      const meta: BatchMeta = JSON.parse(fs.readFileSync(batchPath, "utf-8"));
+      meta.status = "completed";
+      meta.successCount = successCount;
+      meta.failedCount = failedCount;
+      meta.durationMs = durationMs;
+      this.writeJson("batch.json", meta);
+    } catch {
+      // Best effort
+    }
+    this.appendEvent({
+      type: "batch_complete",
+      batchId: this.batchId,
+      successCount,
+      failedCount,
+      durationMs,
+      ts: Date.now(),
+    });
+  }
+
+  /** Absolute path to the NDJSON events file (for external monitoring). */
+  get eventsFilePath(): string {
+    return this.eventsPath;
+  }
+
+  /** Absolute path to the batch IPC directory. */
+  get batchDirPath(): string {
+    return this.batchDir;
+  }
+
+  // ─── Private helpers ────────────────────────────────────────────────────────
+
+  private writeJson(filename: string, data: object): void {
+    try {
+      fs.writeFileSync(
+        path.join(this.batchDir, filename),
+        JSON.stringify(data, null, 2),
+      );
+    } catch {
+      // Best effort — IPC failures must not break agent execution
+    }
+  }
+
+  private appendEvent(event: IpcEvent): void {
+    try {
+      fs.appendFileSync(this.eventsPath, JSON.stringify(event) + "\n");
+    } catch {
+      // Best effort
+    }
+  }
+}

--- a/src/resources/extensions/subagent/tests/parallel-ipc.test.ts
+++ b/src/resources/extensions/subagent/tests/parallel-ipc.test.ts
@@ -1,0 +1,219 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { ParallelIPC } from "../parallel-ipc.js";
+
+function makeTmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "parallel-ipc-test-"));
+}
+
+function readJson(filePath: string): any {
+  return JSON.parse(fs.readFileSync(filePath, "utf-8"));
+}
+
+function readNdjson(filePath: string): any[] {
+  return fs.readFileSync(filePath, "utf-8")
+    .split("\n")
+    .filter((l) => l.trim())
+    .map((l) => JSON.parse(l));
+}
+
+// ─── init ────────────────────────────────────────────────────────────────────
+
+test("init: creates .gsd/parallel/<batchId>/ directory", () => {
+  const root = makeTmpDir();
+  const ipc = new ParallelIPC(root, "batch-001");
+  ipc.init(3);
+
+  assert.ok(fs.existsSync(path.join(root, ".gsd", "parallel", "batch-001")));
+});
+
+test("init: writes batch.json with correct metadata", () => {
+  const root = makeTmpDir();
+  const ipc = new ParallelIPC(root, "batch-002");
+  ipc.init(4);
+
+  const meta = readJson(path.join(root, ".gsd", "parallel", "batch-002", "batch.json"));
+  assert.equal(meta.batchId, "batch-002");
+  assert.equal(meta.workerCount, 4);
+  assert.equal(meta.status, "running");
+  assert.ok(typeof meta.startedAt === "number");
+});
+
+test("init: appends batch_start event to events.ndjson", () => {
+  const root = makeTmpDir();
+  const ipc = new ParallelIPC(root, "batch-003");
+  ipc.init(2);
+
+  const events = readNdjson(path.join(root, ".gsd", "parallel", "batch-003", "events.ndjson"));
+  assert.equal(events.length, 1);
+  assert.equal(events[0].type, "batch_start");
+  assert.equal(events[0].batchId, "batch-003");
+  assert.equal(events[0].workerCount, 2);
+  assert.ok(typeof events[0].ts === "number");
+});
+
+test("init: does not throw when root dir does not exist", () => {
+  const nonExistentRoot = path.join(os.tmpdir(), "definitely-does-not-exist-" + Date.now());
+  const ipc = new ParallelIPC(nonExistentRoot, "batch-x");
+  assert.doesNotThrow(() => ipc.init(1));
+});
+
+// ─── workerStart ─────────────────────────────────────────────────────────────
+
+test("workerStart: writes worker-<n>.json with running status", () => {
+  const root = makeTmpDir();
+  const ipc = new ParallelIPC(root, "batch-w1");
+  ipc.init(2);
+  ipc.workerStart(0, "gsd-executor", "Implement the feature");
+
+  const meta = readJson(path.join(root, ".gsd", "parallel", "batch-w1", "worker-0.json"));
+  assert.equal(meta.index, 0);
+  assert.equal(meta.agent, "gsd-executor");
+  assert.equal(meta.status, "running");
+  assert.ok(meta.taskExcerpt.length > 0);
+  assert.ok(typeof meta.startedAt === "number");
+});
+
+test("workerStart: truncates task to 120 chars in excerpt", () => {
+  const root = makeTmpDir();
+  const ipc = new ParallelIPC(root, "batch-w2");
+  ipc.init(1);
+  const longTask = "x".repeat(200);
+  ipc.workerStart(0, "gsd-executor", longTask);
+
+  const meta = readJson(path.join(root, ".gsd", "parallel", "batch-w2", "worker-0.json"));
+  assert.ok(meta.taskExcerpt.length <= 123); // 120 + "..."
+  assert.ok(meta.taskExcerpt.endsWith("..."));
+});
+
+test("workerStart: appends worker_start event to events.ndjson", () => {
+  const root = makeTmpDir();
+  const ipc = new ParallelIPC(root, "batch-w3");
+  ipc.init(1);
+  ipc.workerStart(0, "my-agent", "do something");
+
+  const events = readNdjson(path.join(root, ".gsd", "parallel", "batch-w3", "events.ndjson"));
+  const startEvent = events.find((e: any) => e.type === "worker_start");
+  assert.ok(startEvent);
+  assert.equal(startEvent.index, 0);
+  assert.equal(startEvent.agent, "my-agent");
+});
+
+// ─── workerComplete ───────────────────────────────────────────────────────────
+
+test("workerComplete: updates worker file with completed status and timing", () => {
+  const root = makeTmpDir();
+  const ipc = new ParallelIPC(root, "batch-c1");
+  ipc.init(1);
+  ipc.workerStart(0, "gsd-executor", "task");
+  ipc.workerComplete(0, "completed", 1234);
+
+  const meta = readJson(path.join(root, ".gsd", "parallel", "batch-c1", "worker-0.json"));
+  assert.equal(meta.status, "completed");
+  assert.equal(meta.durationMs, 1234);
+  assert.ok(typeof meta.completedAt === "number");
+});
+
+test("workerComplete: records failed status", () => {
+  const root = makeTmpDir();
+  const ipc = new ParallelIPC(root, "batch-c2");
+  ipc.init(1);
+  ipc.workerStart(0, "gsd-executor", "task");
+  ipc.workerComplete(0, "failed", 500);
+
+  const meta = readJson(path.join(root, ".gsd", "parallel", "batch-c2", "worker-0.json"));
+  assert.equal(meta.status, "failed");
+});
+
+test("workerComplete: appends worker_complete event to events.ndjson", () => {
+  const root = makeTmpDir();
+  const ipc = new ParallelIPC(root, "batch-c3");
+  ipc.init(1);
+  ipc.workerStart(0, "gsd-executor", "task");
+  ipc.workerComplete(0, "completed", 999);
+
+  const events = readNdjson(path.join(root, ".gsd", "parallel", "batch-c3", "events.ndjson"));
+  const completeEvent = events.find((e: any) => e.type === "worker_complete");
+  assert.ok(completeEvent);
+  assert.equal(completeEvent.index, 0);
+  assert.equal(completeEvent.status, "completed");
+  assert.equal(completeEvent.durationMs, 999);
+});
+
+test("workerComplete: does not throw when worker file was never written (init failed)", () => {
+  const root = makeTmpDir();
+  const ipc = new ParallelIPC(root, "batch-c4");
+  ipc.init(1);
+  // Intentionally skip workerStart — simulates init failure scenario
+  assert.doesNotThrow(() => ipc.workerComplete(0, "failed", 100));
+});
+
+// ─── batchComplete ────────────────────────────────────────────────────────────
+
+test("batchComplete: updates batch.json with completed status and counts", () => {
+  const root = makeTmpDir();
+  const ipc = new ParallelIPC(root, "batch-b1");
+  ipc.init(3);
+  ipc.batchComplete(2, 1);
+
+  const meta = readJson(path.join(root, ".gsd", "parallel", "batch-b1", "batch.json"));
+  assert.equal(meta.status, "completed");
+  assert.equal(meta.successCount, 2);
+  assert.equal(meta.failedCount, 1);
+  assert.ok(typeof meta.durationMs === "number");
+});
+
+test("batchComplete: appends batch_complete event to events.ndjson", () => {
+  const root = makeTmpDir();
+  const ipc = new ParallelIPC(root, "batch-b2");
+  ipc.init(2);
+  ipc.batchComplete(2, 0);
+
+  const events = readNdjson(path.join(root, ".gsd", "parallel", "batch-b2", "events.ndjson"));
+  const completeEvent = events.find((e: any) => e.type === "batch_complete");
+  assert.ok(completeEvent);
+  assert.equal(completeEvent.successCount, 2);
+  assert.equal(completeEvent.failedCount, 0);
+  assert.ok(typeof completeEvent.durationMs === "number");
+});
+
+// ─── NDJSON integrity ─────────────────────────────────────────────────────────
+
+test("full lifecycle produces valid NDJSON with events in order", () => {
+  const root = makeTmpDir();
+  const ipc = new ParallelIPC(root, "batch-full");
+  ipc.init(2);
+  ipc.workerStart(0, "agent-a", "task a");
+  ipc.workerStart(1, "agent-b", "task b");
+  ipc.workerComplete(0, "completed", 100);
+  ipc.workerComplete(1, "failed", 200);
+  ipc.batchComplete(1, 1);
+
+  const events = readNdjson(path.join(root, ".gsd", "parallel", "batch-full", "events.ndjson"));
+  const types = events.map((e: any) => e.type);
+  assert.deepEqual(types, [
+    "batch_start",
+    "worker_start",
+    "worker_start",
+    "worker_complete",
+    "worker_complete",
+    "batch_complete",
+  ]);
+});
+
+// ─── accessors ───────────────────────────────────────────────────────────────
+
+test("eventsFilePath points to events.ndjson inside batch dir", () => {
+  const root = makeTmpDir();
+  const ipc = new ParallelIPC(root, "batch-acc");
+  assert.ok(ipc.eventsFilePath.endsWith(path.join("batch-acc", "events.ndjson")));
+});
+
+test("batchDirPath points to the batch directory", () => {
+  const root = makeTmpDir();
+  const ipc = new ParallelIPC(root, "batch-dir");
+  assert.ok(ipc.batchDirPath.endsWith(path.join("parallel", "batch-dir")));
+});


### PR DESCRIPTION
## TL;DR

**What:** Add file-based IPC for parallel subagent batches with worktree isolation and concurrency control.
**Why:** Parallel subagent execution had no monitoring, no per-task isolation, and fixed concurrency.
**How:** `ParallelIPC` writes NDJSON event streams; per-task worktree isolation captures deltas; configurable concurrency param.

## What

- `ParallelIPC` class: init/workerStart/workerComplete/batchComplete with NDJSON event logging
- Per-task worktree isolation via `createIsolation` + `captureDelta` + combined `mergeDeltaPatches`
- `concurrency` parameter on subagent tool (1-8, default 4)
- Subagent model override from `reactive_execution.subagent_model` preference
- 16 tests for ParallelIPC lifecycle

## Why

Parallel subagent batches ran with no visibility (no event log), no isolation (tasks could clobber each other's files), and fixed 4-way concurrency. The IPC layer enables monitoring tools to tail `.gsd/parallel/<batchId>/events.ndjson`. Worktree isolation prevents file conflicts. Configurable concurrency lets users tune for their API rate limits. Split from #2369 per review feedback.

## How

`ParallelIPC` writes to `.gsd/parallel/<batchId>/` — one JSON file per worker plus an append-only NDJSON events file. Isolation creates git worktrees per task, captures delta patches after completion, and merges them back in a single combined operation to avoid partial merges. The `effectiveAgents` array applies model overrides by shallow-copying agent configs.

- [x] `feat` — New feature or capability

AI-assisted contribution.

### Test plan
- [x] All 16 parallel-ipc tests pass
- [x] TypeScript type check passes
- [x] No existing tests broken