### PR TITLE
feat(web): respect GSD_WEB_AUTH_TOKEN env var for stable auth token

### DIFF
--- a/src/tests/integration/web-mode-cli.test.ts
+++ b/src/tests/integration/web-mode-cli.test.ts
@@ -185,6 +185,49 @@ test('launchWebMode prefers the packaged standalone host and opens the resolved 
   assert.equal(webMode.readPidFile(pidFilePath), 99999)
 })
 
+test('launchWebMode uses GSD_WEB_AUTH_TOKEN from env when set', async (t) => {
+  const tmp = mkdtempSync(join(tmpdir(), 'gsd-web-stable-token-'))
+  const standaloneRoot = join(tmp, 'dist', 'web', 'standalone')
+  const serverPath = join(standaloneRoot, 'server.js')
+  mkdirSync(standaloneRoot, { recursive: true })
+  writeFileSync(serverPath, 'console.log("stub")\n')
+
+  const stableToken = 'a'.repeat(64)
+  let openedUrl = ''
+  let spawnEnv: Record<string, any> | undefined
+  const pidFilePath = join(tmp, 'web-server.pid')
+
+  t.after(() => { rmSync(tmp, { recursive: true, force: true }) })
+
+  await webMode.launchWebMode(
+    {
+      cwd: '/tmp/stable-token-project',
+      projectSessionsDir: '/tmp/.gsd/sessions/--tmp-stable-token-project--',
+      agentDir: '/tmp/.gsd/agent',
+      packageRoot: tmp,
+    },
+    {
+      initResources: () => {},
+      resolvePort: async () => 45124,
+      execPath: '/custom/node',
+      env: { GSD_WEB_AUTH_TOKEN: stableToken },
+      spawn: (_command, _args, options) => {
+        spawnEnv = (options as Record<string, any>).env
+        return { pid: 99998, once: () => undefined, unref: () => {} } as any
+      },
+      waitForBootReady: async () => undefined,
+      openBrowser: (url) => { openedUrl = url },
+      pidFilePath,
+      writePidFile: (path, pid) => { webMode.writePidFile(path, pid) },
+      stderr: { write: () => true },
+    },
+  )
+
+  // The stable token from env should be used in both the browser URL and child env
+  assert.equal(openedUrl, `http://127.0.0.1:45124/#token=${stableToken}`)
+  assert.equal(spawnEnv?.GSD_WEB_AUTH_TOKEN, stableToken)
+})
+
 test('stopWebMode kills process by PID and removes PID file', (t) => {
   const tmp = mkdtempSync(join(tmpdir(), 'gsd-web-stop-'))
   const pidFilePath = join(tmp, 'web-server.pid')

--- a/src/web-mode.ts
+++ b/src/web-mode.ts
@@ -578,7 +578,7 @@ export async function launchWebMode(
   cleanupStaleInstance(options.cwd, stderr, deps.registryPath)
 
   const port = options.port ?? await (deps.resolvePort ?? reserveWebPort)(host)
-  const authToken = randomBytes(32).toString('hex')
+  const authToken = (deps.env ?? process.env).GSD_WEB_AUTH_TOKEN || randomBytes(32).toString('hex')
   const url = `http://${host}:${port}`
   const env = {
     ...(deps.env ?? process.env),


### PR DESCRIPTION
## TL;DR

**What:** `launchWebMode()` now checks for a pre-set `GSD_WEB_AUTH_TOKEN` env var before generating a random token.
**Why:** Persistent web UI deployments (systemd, Docker) need a stable token that survives restarts.
**How:** One-line change: `(deps.env ?? process.env).GSD_WEB_AUTH_TOKEN || randomBytes(32).toString('hex')`.

## What

- `src/web-mode.ts`: reads `GSD_WEB_AUTH_TOKEN` from the environment before falling back to `randomBytes(32)`
- `src/tests/integration/web-mode-cli.test.ts`: new test verifying the env var is used when set

## Why

`launchWebMode()` always generates a fresh random token. Every restart invalidates browser localStorage, forcing users to retrieve and re-enter the token on all connected devices. For setups where the web UI runs as a persistent service (e.g. systemd on a headless server accessed from a phone over Tailscale), this is a friction point on every restart.

The Next.js middleware already reads `GSD_WEB_AUTH_TOKEN` from the child process env — this change lets the parent process respect a user-supplied value instead of always overwriting it.

Closes #3123

## How

Changed line 581 from:
```ts
const authToken = randomBytes(32).toString('hex')
```
to:
```ts
const authToken = (deps.env ?? process.env).GSD_WEB_AUTH_TOKEN || randomBytes(32).toString('hex')
```

This follows the existing `deps.env ?? process.env` pattern used on the next line for the child process environment, making it testable via dependency injection.

## Change type

- [x] `feat` — New feature or capability

## Scope

- [x] `gsd extension` — GSD workflow

## Breaking changes

- [x] No breaking changes

## Test plan

- [x] New/updated tests included — `launchWebMode uses GSD_WEB_AUTH_TOKEN from env when set` added to `web-mode-cli.test.ts`
- [x] CI passes — all 31 tests in `web-mode-cli.test.ts` pass

## AI disclosure

- [x] This PR includes AI-assisted code — Claude Code, tested by running the full `web-mode-cli.test.ts` suite (31/31 pass)
- [x] tested manually  