### PR TITLE
feat(remote-questions): add project_label to remote notifications and questions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gsd-pi",
-  "version": "2.56.0",
+  "version": "2.58.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gsd-pi",
-      "version": "2.56.0",
+      "version": "2.58.0",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [
@@ -9534,7 +9534,7 @@
     },
     "packages/pi-coding-agent": {
       "name": "@gsd/pi-coding-agent",
-      "version": "2.56.0",
+      "version": "2.58.0",
       "dependencies": {
         "@mariozechner/jiti": "^2.6.2",
         "@silvia-odwyer/photon-node": "^0.3.4",

--- a/src/resources/extensions/gsd/preferences-types.ts
+++ b/src/resources/extensions/gsd/preferences-types.ts
@@ -177,6 +177,8 @@ export interface RemoteQuestionsConfig {
   channel_id: string | number;
   timeout_minutes?: number;        // clamped to 1-30
   poll_interval_seconds?: number;  // clamped to 2-30
+  /** Optional label to identify this project in remote messages. Falls back to working directory name. */
+  project_label?: string;
 }
 
 export interface CmuxPreferences {

--- a/src/resources/extensions/gsd/tests/remote-questions.test.ts
+++ b/src/resources/extensions/gsd/tests/remote-questions.test.ts
@@ -753,3 +753,131 @@ test("config source-level: removeProviderToken uses auth.remove not auth.set wit
   assert.ok(fnBody.includes("auth.remove("), "removeProviderToken should call auth.remove()");
   assert.ok(!fnBody.includes('key: ""'), "removeProviderToken should not set an empty key");
 });
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Project Label Tests
+// ═══════════════════════════════════════════════════════════════════════════
+
+test("formatForTelegram includes project label in header when present", () => {
+  const prompt = {
+    id: "tg-label-1",
+    channel: "telegram" as const,
+    createdAt: Date.now(),
+    timeoutAt: Date.now() + 60000,
+    pollIntervalMs: 5000,
+    context: { source: "ask_user_questions", projectLabel: "my-app" },
+    questions: [{
+      id: "q1",
+      header: "Confirm",
+      question: "Proceed?",
+      options: [
+        { label: "Yes", description: "Continue" },
+        { label: "No", description: "Stop" },
+      ],
+      allowMultiple: false,
+    }],
+  };
+
+  const msg = formatForTelegram(prompt);
+  assert.ok(msg.text.includes("[my-app]"), "Telegram header should include project label");
+  assert.ok(msg.text.includes("<b>GSD needs your input [my-app]</b>"), "project label should be inside the bold header");
+});
+
+test("formatForTelegram omits project label bracket when not present", () => {
+  const prompt = {
+    id: "tg-label-2",
+    channel: "telegram" as const,
+    createdAt: Date.now(),
+    timeoutAt: Date.now() + 60000,
+    pollIntervalMs: 5000,
+    questions: [{
+      id: "q1",
+      header: "Confirm",
+      question: "Proceed?",
+      options: [{ label: "Yes", description: "Continue" }],
+      allowMultiple: false,
+    }],
+  };
+
+  const msg = formatForTelegram(prompt);
+  assert.ok(msg.text.includes("<b>GSD needs your input</b>"), "header should not have brackets when no label");
+  assert.ok(!msg.text.includes("["), "should not contain stray brackets");
+});
+
+test("formatForSlack includes project label in header when present", () => {
+  const blocks = formatForSlack({
+    id: "slack-label-1",
+    channel: "slack",
+    createdAt: Date.now(),
+    timeoutAt: Date.now() + 60000,
+    pollIntervalMs: 5000,
+    context: { source: "ask_user_questions", projectLabel: "my-app" },
+    questions: [{
+      id: "q1",
+      header: "Confirm",
+      question: "Proceed?",
+      options: [{ label: "Yes", description: "Continue" }],
+      allowMultiple: false,
+    }],
+  });
+
+  const headerBlock = blocks.find((b) => b.type === "header");
+  assert.ok(headerBlock, "should have a header block");
+  assert.ok(headerBlock!.text!.text.includes("[my-app]"), "Slack header should include project label");
+});
+
+test("formatForDiscord includes project label in embed title and footer when present", () => {
+  const prompt = {
+    id: "discord-label-1",
+    channel: "discord" as const,
+    createdAt: Date.now(),
+    timeoutAt: Date.now() + 60000,
+    pollIntervalMs: 5000,
+    context: { source: "ask_user_questions", projectLabel: "my-app" },
+    questions: [{
+      id: "q1",
+      header: "Confirm",
+      question: "Proceed?",
+      options: [
+        { label: "Yes", description: "Continue" },
+        { label: "No", description: "Stop" },
+      ],
+      allowMultiple: false,
+    }],
+  };
+
+  const { embeds } = formatForDiscord(prompt);
+  assert.ok(embeds[0].title.includes("[my-app]"), "Discord embed title should include project label");
+  assert.ok(embeds[0].footer?.text.includes("Project: my-app"), "Discord embed footer should include project label");
+});
+
+test("formatForTelegram escapes HTML in project label", () => {
+  const prompt = {
+    id: "tg-label-3",
+    channel: "telegram" as const,
+    createdAt: Date.now(),
+    timeoutAt: Date.now() + 60000,
+    pollIntervalMs: 5000,
+    context: { source: "ask_user_questions", projectLabel: "<script>alert(1)</script>" },
+    questions: [{
+      id: "q1",
+      header: "Confirm",
+      question: "Proceed?",
+      options: [{ label: "Yes", description: "Continue" }],
+      allowMultiple: false,
+    }],
+  };
+
+  const msg = formatForTelegram(prompt);
+  assert.ok(!msg.text.includes("<script>"), "project label should be HTML-escaped");
+  assert.ok(msg.text.includes("&lt;script&gt;"), "should contain escaped version");
+});
+
+test("config source-level: resolveProjectLabel falls back to cwd basename", () => {
+  const configSrc = readFileSync(
+    join(__dirname, "..", "..", "remote-questions", "config.ts"),
+    "utf-8",
+  );
+  assert.ok(configSrc.includes("basename(process.cwd())"), "resolveProjectLabel should fall back to cwd basename");
+  assert.ok(configSrc.includes("project_label"), "resolveRemoteConfig should read project_label from preferences");
+});

--- a/src/resources/extensions/remote-questions/config.ts
+++ b/src/resources/extensions/remote-questions/config.ts
@@ -2,6 +2,7 @@
  * Remote Questions — configuration resolution and validation
  */
 
+import { basename } from "node:path";
 import { AuthStorage } from "@gsd/pi-coding-agent";
 import { loadEffectiveGSDPreferences, type RemoteQuestionsConfig } from "../gsd/preferences.js";
 import type { RemoteChannel } from "./types.js";
@@ -12,6 +13,8 @@ export interface ResolvedConfig {
   timeoutMs: number;
   pollIntervalMs: number;
   token: string;
+  /** Human-readable project label for message prefixes. Never empty. */
+  projectLabel: string;
 }
 
 const ENV_KEYS: Record<RemoteChannel, string> = {
@@ -74,6 +77,15 @@ function hydrateRemoteTokensFromAuth(): void {
   }
 }
 
+/**
+ * Resolve a human-readable project label for remote message prefixes.
+ * Priority: explicit preference > cwd basename.
+ */
+function resolveProjectLabel(explicit?: string): string {
+  if (explicit && explicit.trim()) return explicit.trim();
+  return basename(process.cwd());
+}
+
 export function resolveRemoteConfig(): ResolvedConfig | null {
   hydrateRemoteTokensFromAuth();
   const prefs = loadEffectiveGSDPreferences();
@@ -96,6 +108,7 @@ export function resolveRemoteConfig(): ResolvedConfig | null {
     timeoutMs: timeoutMinutes * 60 * 1000,
     pollIntervalMs: pollIntervalSeconds * 1000,
     token,
+    projectLabel: resolveProjectLabel(rq.project_label),
   };
 }
 

--- a/src/resources/extensions/remote-questions/format.ts
+++ b/src/resources/extensions/remote-questions/format.ts
@@ -23,10 +23,11 @@ export const SLACK_NUMBER_REACTION_NAMES = ["one", "two", "three", "four", "five
 const MAX_USER_NOTE_LENGTH = 500;
 
 export function formatForSlack(prompt: RemotePrompt): SlackBlock[] {
+  const projectTag = prompt.context?.projectLabel ? ` [${prompt.context.projectLabel}]` : "";
   const blocks: SlackBlock[] = [
     {
       type: "header",
-      text: { type: "plain_text", text: "GSD needs your input" },
+      text: { type: "plain_text", text: `GSD needs your input${projectTag}` },
     },
   ];
 
@@ -90,6 +91,7 @@ export function formatForSlack(prompt: RemotePrompt): SlackBlock[] {
 }
 
 export function formatForDiscord(prompt: RemotePrompt): { embeds: DiscordEmbed[]; reactionEmojis: string[] } {
+  const projectTag = prompt.context?.projectLabel ? ` [${prompt.context.projectLabel}]` : "";
   const reactionEmojis: string[] = [];
   const embeds: DiscordEmbed[] = prompt.questions.map((q, questionIndex) => {
     const supportsReactions = prompt.questions.length === 1;
@@ -110,9 +112,12 @@ export function formatForDiscord(prompt: RemotePrompt): { embeds: DiscordEmbed[]
     if (prompt.context?.source) {
       footerParts.push(`Source: ${prompt.context.source}`);
     }
+    if (projectTag) {
+      footerParts.push(`Project: ${prompt.context?.projectLabel}`);
+    }
 
     return {
-      title: q.header,
+      title: `${q.header}${projectTag}`,
       description: q.question,
       color: 0x7c3aed,
       fields: [{ name: "Options", value: optionLines.join("\n") }],
@@ -216,7 +221,8 @@ function escapeHtml(s: string): string {
 }
 
 export function formatForTelegram(prompt: RemotePrompt): TelegramMessage {
-  const lines: string[] = ["<b>GSD needs your input</b>", ""];
+  const projectTag = prompt.context?.projectLabel ? ` [${escapeHtml(prompt.context.projectLabel)}]` : "";
+  const lines: string[] = [`<b>GSD needs your input${projectTag}</b>`, ""];
 
   for (let qi = 0; qi < prompt.questions.length; qi++) {
     const q = prompt.questions[qi];

--- a/src/resources/extensions/remote-questions/manager.ts
+++ b/src/resources/extensions/remote-questions/manager.ts
@@ -107,7 +107,7 @@ function createPrompt(questions: QuestionInput[], config: ResolvedConfig): Remot
     createdAt,
     timeoutAt: createdAt + config.timeoutMs,
     pollIntervalMs: config.pollIntervalMs,
-    context: { source: "ask_user_questions" },
+    context: { source: "ask_user_questions", projectLabel: config.projectLabel },
     questions: questions.map((q): RemoteQuestion => ({
       id: q.id,
       header: q.header,

--- a/src/resources/extensions/remote-questions/notify.ts
+++ b/src/resources/extensions/remote-questions/notify.ts
@@ -27,16 +27,18 @@ export async function sendRemoteNotification(title: string, message: string): Pr
   }
   if (!config) return;
 
+  const projectTag = config.projectLabel ? ` [${config.projectLabel}]` : "";
+
   try {
     switch (config.channel) {
       case "slack":
-        await sendSlackNotification(config, title, message);
+        await sendSlackNotification(config, title, message, projectTag);
         break;
       case "discord":
-        await sendDiscordNotification(config, title, message);
+        await sendDiscordNotification(config, title, message, projectTag);
         break;
       case "telegram":
-        await sendTelegramNotification(config, title, message);
+        await sendTelegramNotification(config, title, message, projectTag);
         break;
     }
   } catch {
@@ -44,7 +46,7 @@ export async function sendRemoteNotification(title: string, message: string): Pr
   }
 }
 
-async function sendSlackNotification(config: ResolvedConfig, title: string, message: string): Promise<void> {
+async function sendSlackNotification(config: ResolvedConfig, title: string, message: string, projectTag: string): Promise<void> {
   const response = await fetch(`https://slack.com/api/chat.postMessage`, {
     method: "POST",
     headers: {
@@ -53,14 +55,14 @@ async function sendSlackNotification(config: ResolvedConfig, title: string, mess
     },
     body: JSON.stringify({
       channel: config.channelId,
-      text: `⚠️ *${title}*\n${message}`,
+      text: `⚠️ *${title}${projectTag}*\n${message}`,
     }),
     signal: AbortSignal.timeout(PER_REQUEST_TIMEOUT_MS),
   });
   if (!response.ok) throw new Error(`Slack HTTP ${response.status}`);
 }
 
-async function sendDiscordNotification(config: ResolvedConfig, title: string, message: string): Promise<void> {
+async function sendDiscordNotification(config: ResolvedConfig, title: string, message: string, projectTag: string): Promise<void> {
   const response = await fetch(`https://discord.com/api/v10/channels/${config.channelId}/messages`, {
     method: "POST",
     headers: {
@@ -68,20 +70,20 @@ async function sendDiscordNotification(config: ResolvedConfig, title: string, me
       "Content-Type": "application/json",
     },
     body: JSON.stringify({
-      content: `⚠️ **${title}**\n${message}`,
+      content: `⚠️ **${title}${projectTag}**\n${message}`,
     }),
     signal: AbortSignal.timeout(PER_REQUEST_TIMEOUT_MS),
   });
   if (!response.ok) throw new Error(`Discord HTTP ${response.status}`);
 }
 
-async function sendTelegramNotification(config: ResolvedConfig, title: string, message: string): Promise<void> {
+async function sendTelegramNotification(config: ResolvedConfig, title: string, message: string, projectTag: string): Promise<void> {
   const response = await fetch(`https://api.telegram.org/bot${config.token}/sendMessage`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({
       chat_id: config.channelId,
-      text: `⚠️ *${title}*\n${message}`,
+      text: `⚠️ *${title}${projectTag}*\n${message}`,
       parse_mode: "Markdown",
     }),
     signal: AbortSignal.timeout(PER_REQUEST_TIMEOUT_MS),

--- a/src/resources/extensions/remote-questions/types.ts
+++ b/src/resources/extensions/remote-questions/types.ts
@@ -29,6 +29,8 @@ export interface RemotePrompt {
   questions: RemoteQuestion[];
   context?: {
     source: string;
+    /** Human-readable project label for message prefixes. */
+    projectLabel?: string;
   };
 }
 
@@ -62,6 +64,7 @@ interface RemotePromptRecordBase {
   lastError?: string;
   context?: {
     source: string;
+    projectLabel?: string;
   };
 }
 


### PR DESCRIPTION
## TL;DR

**What:** Adds project identification to all remote channel messages (Telegram, Slack, Discord).
**Why:** Users running multiple projects in parallel can't tell which project sent a notification or question.
**How:** Optional `project_label` in preferences, falling back to `basename(cwd)` so it works with zero config.

## What

Adds `project_label?: string` to `RemoteQuestionsConfig`. All three formatters (`formatForTelegram`, `formatForSlack`, `formatForDiscord`) and `sendRemoteNotification` now prefix messages with `[project-name]`.

Affected files: `preferences-types.ts`, `config.ts`, `types.ts`, `manager.ts`, `format.ts`, `notify.ts`, plus 6 new tests in `remote-questions.test.ts`.

## Why

Closes #3127

## How

Resolution order: explicit `project_label` preference → `basename(process.cwd())`.

The fallback means zero-config behaviour is already useful — projects are identified by their directory name without any setup. HTML-escaped in Telegram (HTML parse mode), plain text in Slack/Discord headers.

### Change type
- [x] `feat` — New feature or capability
- [x] `test` — Adding or updating tests

---

> **AI-assisted:** This PR was implemented with Claude (Anthropic). The implementation was manually reviewed and verified working against a live Telegram bot.