### PR TITLE
docs(create-gsd-extension): fix community extension install path — use ~/.pi not ~/.gsd

### DIFF
--- a/src/resources/skills/create-gsd-extension/SKILL.md
+++ b/src/resources/skills/create-gsd-extension/SKILL.md
@@ -8,8 +8,10 @@ description: Create, debug, and iterate on GSD extensions (TypeScript modules th
 **Extensions are TypeScript modules** that hook into GSD's runtime (built on pi). They export a default function receiving `ExtensionAPI` and use it to subscribe to events, register tools/commands/shortcuts, and interact with the session.
 
 **GSD extension paths:**
-- Global extensions: `~/.gsd/agent/extensions/*.ts` or `~/.gsd/agent/extensions/*/index.ts`
+- Global extensions: `~/.pi/agent/extensions/*.ts` or `~/.pi/agent/extensions/*/index.ts`
 - Project-local extensions: `.gsd/extensions/*.ts` or `.gsd/extensions/*/index.ts`
+
+**Note:** `~/.gsd/agent/extensions/` is for bundled extensions only (auto-synced from gsd-pi). Community extensions placed there are silently ignored — use `~/.pi/agent/extensions/` instead.
 
 **The three primitives:**
 1. **Events** — Listen and react (`pi.on("event", handler)`). Can block tool calls, modify messages, inject context.

--- a/src/resources/skills/create-gsd-extension/references/key-rules-gotchas.md
+++ b/src/resources/skills/create-gsd-extension/references/key-rules-gotchas.md
@@ -26,11 +26,14 @@ Non-negotiable rules and common gotchas when building GSD extensions.
 </common_patterns>
 
 <gsd_paths>
-**GSD extension paths:**
-- Global: `~/.gsd/agent/extensions/*.ts`
-- Global (subdir): `~/.gsd/agent/extensions/*/index.ts`
+**GSD extension paths (community / user-installed extensions):**
+- Global: `~/.pi/agent/extensions/*.ts`
+- Global (subdir): `~/.pi/agent/extensions/*/index.ts`
 - Project-local: `.gsd/extensions/*.ts`
 - Project-local (subdir): `.gsd/extensions/*/index.ts`
 
-The upstream pi docs reference `~/.pi` paths — GSD uses `~/.gsd` everywhere instead.
+**Important:** `~/.gsd/agent/extensions/` is reserved for **bundled** extensions that GSD
+auto-syncs from the `gsd-pi` npm package on startup. Community extensions placed there are
+**silently ignored** by the loader. Always use `~/.pi/agent/extensions/` for anything you
+build or install yourself.
 </gsd_paths>

--- a/src/resources/skills/create-gsd-extension/workflows/add-capability.md
+++ b/src/resources/skills/create-gsd-extension/workflows/add-capability.md
@@ -14,8 +14,10 @@ Read the reference file for the specific capability being added:
 ## Step 1: Identify the Extension
 
 Locate the existing extension file. Check:
-- `~/.gsd/agent/extensions/` (global)
+- `~/.pi/agent/extensions/` (global community extensions)
 - `.gsd/extensions/` (project-local)
+
+> **Note:** `~/.gsd/agent/extensions/` contains bundled extensions — do not edit files there directly.
 
 Read the current extension code to understand its structure.
 
@@ -28,7 +30,7 @@ If the extension needs new imports, add them at the top of the file.
 ## Step 3: Handle Structural Changes
 
 **Single file → Directory**: If the extension is outgrowing a single file:
-1. Create `~/.gsd/agent/extensions/my-extension/`
+1. Create `~/.pi/agent/extensions/my-extension/`
 2. Move the file to `index.ts`
 3. Extract helpers to separate files
 

--- a/src/resources/skills/create-gsd-extension/workflows/create-extension.md
+++ b/src/resources/skills/create-gsd-extension/workflows/create-extension.md
@@ -12,8 +12,10 @@
 ## Step 1: Determine Scope and Placement
 
 Ask the user:
-- **Global** (`~/.gsd/agent/extensions/`) — Available in all GSD sessions
+- **Global** (`~/.pi/agent/extensions/`) — Available in all GSD sessions
 - **Project-local** (`.gsd/extensions/`) — Available only in this project
+
+> **Note:** `~/.gsd/agent/extensions/` is reserved for bundled extensions synced from gsd-pi. Do not install community extensions there — they will be silently ignored.
 
 ## Step 2: Determine Extension Capabilities
 
@@ -36,12 +38,12 @@ Identify what the extension needs from the user's description:
 
 **Single file** — for small extensions (1-2 tools/commands, simple hooks):
 ```
-~/.gsd/agent/extensions/my-extension.ts
+~/.pi/agent/extensions/my-extension.ts
 ```
 
 **Directory with index.ts** — for multi-file extensions:
 ```
-~/.gsd/agent/extensions/my-extension/
+~/.pi/agent/extensions/my-extension/
 ├── index.ts
 ├── tools.ts
 └── utils.ts
@@ -49,7 +51,7 @@ Identify what the extension needs from the user's description:
 
 **Package with dependencies** — when npm packages are needed:
 ```
-~/.gsd/agent/extensions/my-extension/
+~/.pi/agent/extensions/my-extension/
 ├── package.json
 ├── src/index.ts
 └── node_modules/

--- a/src/resources/skills/create-gsd-extension/workflows/debug-extension.md
+++ b/src/resources/skills/create-gsd-extension/workflows/debug-extension.md
@@ -32,11 +32,13 @@ gsd -e ./path/to/extension.ts
 
 ## Step 3: Verify File Location
 
-Extensions must be in auto-discovery paths:
-- `~/.gsd/agent/extensions/*.ts`
-- `~/.gsd/agent/extensions/*/index.ts`
+Community extensions must be in one of these auto-discovery paths:
+- `~/.pi/agent/extensions/*.ts`
+- `~/.pi/agent/extensions/*/index.ts`
 - `.gsd/extensions/*.ts`
 - `.gsd/extensions/*/index.ts`
+
+> **Common mistake:** `~/.gsd/agent/extensions/` is for bundled extensions only — community extensions placed there are silently ignored.
 
 The file must `export default function(pi: ExtensionAPI) { ... }`.
 


### PR DESCRIPTION
## TL;DR

**What:** Correct the community extension install directory in all `create-gsd-extension` skill docs.
**Why:** The documented path (`~/.gsd/agent/extensions/`) is wrong — extensions placed there are silently ignored.
**How:** Update five files to use `~/.pi/agent/extensions/` and add clarifying notes.

## What

Updates five `create-gsd-extension` skill files to document the correct install path for community/user-installed extensions.

## Why

Closes #3131

`~/.gsd/agent/extensions/` is reserved for **bundled** extensions synced from the gsd-pi npm package on startup (`resource-loader.js` only scans `~/.pi/agent/extensions/` for non-bundled extensions). Any community extension placed in the gsd path is silently invisible to the loader.

Discovered while debugging why `gsd-telegram-remote` wasn't activating despite being installed per the docs.

## How

- All install-path examples changed from `~/.gsd/agent/extensions/` → `~/.pi/agent/extensions/`
- Added warning notes explaining the bundled vs community distinction
- Removed the incorrect note `"The upstream pi docs reference ~/.pi paths — GSD uses ~/.gsd everywhere instead"` which was only true for bundled extensions

## Files changed

| File | Change |
|---|---|
| `SKILL.md` | Corrected global extension path + added warning note |
| `references/key-rules-gotchas.md` | Rewrote `<gsd_paths>` block with correct path and distinction note |
| `workflows/create-extension.md` | Corrected Step 1 and Step 3 examples |
| `workflows/add-capability.md` | Corrected Step 1 directory locations |
| `workflows/debug-extension.md` | Corrected Step 3 discovery paths, added common-mistake callout |

## Change type

- [ ] `fix` — Bug fix
- [ ] `feat` — New feature or capability
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [x] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [x] `gsd extension` — GSD workflow
- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] No tests needed — documentation only change
- [x] Manually verified: extension placed in `~/.pi/agent/extensions/` loads correctly; same extension in `~/.gsd/agent/extensions/` is silently ignored

## AI disclosure

- [x] This PR includes AI-assisted code — prepared with GSD and verified as described above.
