### PR TITLE
feat(ui): add active session indicators to project selector and dashboard [v1.1 2/2]

### DIFF
--- a/web/components/gsd/chat-mode.tsx
+++ b/web/components/gsd/chat-mode.tsx
@@ -13,6 +13,7 @@ import {
   useGSDWorkspaceState,
   useGSDWorkspaceActions,
   buildPromptCommand,
+  getLiveAutoDashboard,
   type CompletedToolExecution,
   type ActiveToolExecution,
   type PendingUiRequest,
@@ -169,7 +170,7 @@ function ChatModeHeader({ onPrimaryAction, onSecondaryAction }: ChatModeHeaderPr
 
   const boot = state.boot
   const workspace = boot?.workspace ?? null
-  const auto = boot?.auto ?? null
+  const auto = getLiveAutoDashboard(state)
 
   const workflowAction = deriveWorkflowAction({
     phase: workspace?.active.phase ?? "pre-planning",
@@ -1168,7 +1169,7 @@ function ChatInputBar({
   connected: boolean
   onOpenAction?: (action: GSDActionDef) => void
 }) {
-  const autoActive = useGSDWorkspaceState().boot?.auto?.active ?? false
+  const autoActive = getLiveAutoDashboard(useGSDWorkspaceState())?.active ?? false
   const [value, setValue] = useState("")
   const [overflowOpen, setOverflowOpen] = useState(false)
   const [pendingImages, setPendingImages] = useState<PendingImage[]>([])
@@ -2031,8 +2032,8 @@ export function ChatPane({ className, onOpenAction }: ChatPaneProps) {
   // ── Derive smart CTA for the placeholder state ──
   const workflowAction = deriveWorkflowAction({
     phase: state.boot?.workspace?.active.phase ?? "pre-planning",
-    autoActive: state.boot?.auto?.active ?? false,
-    autoPaused: state.boot?.auto?.paused ?? false,
+    autoActive: getLiveAutoDashboard(state)?.active ?? false,
+    autoPaused: getLiveAutoDashboard(state)?.paused ?? false,
     onboardingLocked: state.boot?.onboarding.locked ?? false,
     commandInFlight: state.commandInFlight,
     bootStatus: state.bootStatus,
@@ -2043,8 +2044,9 @@ export function ChatPane({ className, onOpenAction }: ChatPaneProps) {
   const placeholderCTA = useMemo((): { label: string; icon: LucideIcon } | null => {
     if (!workflowAction.primary || workflowAction.disabled) return null
     const phase = state.boot?.workspace?.active.phase ?? "pre-planning"
-    const autoActive = state.boot?.auto?.active ?? false
-    const autoPaused = state.boot?.auto?.paused ?? false
+    const liveAuto = getLiveAutoDashboard(state)
+    const autoActive = liveAuto?.active ?? false
+    const autoPaused = liveAuto?.paused ?? false
 
     if (autoActive && !autoPaused) {
       return { label: "Stop Auto", icon: Square }
@@ -2065,7 +2067,7 @@ export function ChatPane({ className, onOpenAction }: ChatPaneProps) {
       return { label: "Initialize Project", icon: Play }
     }
     return { label: "Continue", icon: Play }
-  }, [workflowAction, state.boot?.workspace?.active.phase, state.boot?.auto?.active, state.boot?.auto?.paused])
+  }, [workflowAction, state.boot?.workspace?.active.phase, state.live.auto, state.boot?.auto])
 
   const handlePlaceholderCTA = useCallback(() => {
     if (!workflowAction.primary) return

--- a/web/components/gsd/dashboard.tsx
+++ b/web/components/gsd/dashboard.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect, useState, useCallback } from "react"
+import { useEffect, useState, useCallback, useRef } from "react"
 import {
   Activity,
   Clock,
@@ -11,6 +11,7 @@ import {
   Play,
   GitBranch,
   TrendingDown,
+  Loader2,
 } from "lucide-react"
 import { cn } from "@/lib/utils"
 import {
@@ -32,6 +33,7 @@ import {
 import { getTaskStatus, type ItemStatus } from "@/lib/workspace-status"
 import { deriveWorkflowAction } from "@/lib/workflow-actions"
 import { executeWorkflowActionInPowerMode } from "@/lib/workflow-action-execution"
+import { Button } from "@/components/ui/button"
 import { Skeleton } from "@/components/ui/skeleton"
 import {
   CurrentSliceCardSkeleton,
@@ -163,6 +165,7 @@ export function Dashboard({ onSwitchView, onExpandTerminal }: DashboardProps = {
   const scopeLabel = getCurrentScopeLabel(workspace)
   const branch = getCurrentBranch(workspace)
   const isAutoActive = auto?.active ?? false
+  const autoPaused = auto?.paused ?? false
   const currentUnitLabel = auto?.currentUnit?.id ?? scopeLabel
   const currentUnitFreshness = freshness.auto.stale ? "stale" : freshness.auto.status
 
@@ -183,10 +186,27 @@ export function Dashboard({ onSwitchView, onExpandTerminal }: DashboardProps = {
     })
   }
 
+  const [pendingAction, setPendingAction] = useState<string | null>(null)
+  const pendingTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
   const handlePrimaryAction = () => {
     if (!workflowAction.primary) return
+    setPendingAction(workflowAction.primary.command)
+    if (pendingTimerRef.current) clearTimeout(pendingTimerRef.current)
+    pendingTimerRef.current = setTimeout(() => {
+      setPendingAction(null)
+    }, 3000)
     handleWorkflowAction(workflowAction.primary.command)
   }
+
+  useEffect(() => {
+    if (pendingAction === null) return
+    setPendingAction(null)
+    if (pendingTimerRef.current) {
+      clearTimeout(pendingTimerRef.current)
+      pendingTimerRef.current = null
+    }
+  }, [isAutoActive, autoPaused]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const recentLines: WorkspaceTerminalLine[] = (state.terminalLines ?? []).slice(-6)
   const isConnecting = state.bootStatus === "idle" || state.bootStatus === "loading"
@@ -251,6 +271,21 @@ export function Dashboard({ onSwitchView, onExpandTerminal }: DashboardProps = {
                 {isAutoActive ? "Auto Mode Active" : "Auto Mode Inactive"}
               </span>
             </div>
+          )}
+          {!isConnecting && workflowAction.primary && (
+            <Button
+              size="sm"
+              variant={workflowAction.primary.variant}
+              disabled={workflowAction.disabled || pendingAction !== null}
+              onClick={handlePrimaryAction}
+              data-testid="dashboard-primary-action"
+            >
+              {pendingAction !== null ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                workflowAction.primary.label
+              )}
+            </Button>
           )}
           {!isConnecting && branch && (
             <div className="flex items-center gap-2 text-sm text-muted-foreground">

--- a/web/components/gsd/projects-view.tsx
+++ b/web/components/gsd/projects-view.tsx
@@ -85,6 +85,13 @@ interface ProjectMetadata {
   progress?: ProjectProgressInfo | null
 }
 
+interface ProjectSessionState {
+  bridgePhase: "idle" | "starting" | "ready" | "failed"
+  autoActive: boolean
+  autoPaused: boolean
+  currentUnit: { type: string; id: string; startedAt: number } | null
+}
+
 // ─── Kind style config ─────────────────────────────────────────────────
 
 const KIND_STYLE: Record<ProjectDetectionKind, { label: string; color: string; bgClass: string; icon: typeof Layers }> = {
@@ -153,6 +160,33 @@ function relativeTime(timestamp: number): string {
   return new Date(timestamp).toLocaleDateString(undefined, { month: "short", day: "numeric" })
 }
 
+// ─── Session badge sub-component ──────────────────────────────────────
+
+function SessionBadge({ session }: { session: ProjectSessionState }) {
+  const isRunning = session.autoActive && !session.autoPaused
+  const isPaused = session.autoPaused
+  const hasSession = session.bridgePhase === "ready" || session.autoActive || session.autoPaused
+
+  if (!hasSession) return null
+
+  const dotClass = isRunning
+    ? "h-2 w-2 shrink-0 rounded-full bg-success animate-pulse"
+    : isPaused
+    ? "h-2 w-2 shrink-0 rounded-full bg-amber-500"
+    : "h-2 w-2 shrink-0 rounded-full bg-muted-foreground/50"
+
+  const mode = session.autoActive ? "Auto" : "Interactive"
+  const unitLabel = session.currentUnit?.id ?? null
+  const subtitle = unitLabel ? `${mode} - ${unitLabel}` : mode
+
+  return (
+    <div className="mt-0.5 flex items-center gap-1.5">
+      <span className={dotClass} />
+      <span className="text-[10px] text-muted-foreground">{subtitle}</span>
+    </div>
+  )
+}
+
 // ─── Shared project card component ─────────────────────────────────────
 
 function ProjectCard({
@@ -160,11 +194,13 @@ function ProjectCard({
   isActive = false,
   onClick,
   disabled = false,
+  sessionState = null,
 }: {
   project: ProjectMetadata
   isActive?: boolean
   onClick: () => void
   disabled?: boolean
+  sessionState?: ProjectSessionState | null
 }) {
   const style = KIND_STYLE[project.kind]
   const KindIcon = style.icon
@@ -212,6 +248,9 @@ function ProjectCard({
             {isActive ? "Current" : style.label}
           </span>
         </div>
+
+        {/* Session badge */}
+        {sessionState && <SessionBadge session={sessionState} />}
 
         {/* Row 2: tech stack tags */}
         {stack.length > 0 && (
@@ -272,6 +311,7 @@ export function ProjectsPanel({
   const [devRoot, setDevRoot] = useState<string | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const [activeSessionState, setActiveSessionState] = useState<ProjectSessionState | null>(null)
 
   const loadProjects = useCallback(async (root: string) => {
     const projRes = await authFetch(`/api/projects?root=${encodeURIComponent(root)}&detail=true`)
@@ -302,6 +342,21 @@ export function ProjectsPanel({
         setDevRoot(prefs.devRoot)
         const discovered = await loadProjects(prefs.devRoot)
         if (!cancelled) setProjects(discovered)
+
+        // Fetch session state for the active project (one-shot; only the active project has a bridge)
+        try {
+          const sessionRes = await authFetch("/api/session/state")
+          if (sessionRes.ok) {
+            const sessionData = await sessionRes.json()
+            if (!cancelled) setActiveSessionState(sessionData as ProjectSessionState)
+          } else {
+            // 503 = no bridge; treat as no active session
+            if (!cancelled) setActiveSessionState(null)
+          }
+        } catch {
+          // Network error — no session badge
+          if (!cancelled) setActiveSessionState(null)
+        }
       } catch (err) {
         if (!cancelled) {
           setError(err instanceof Error ? err.message : "Unknown error")
@@ -314,6 +369,7 @@ export function ProjectsPanel({
     load()
     return () => {
       cancelled = true
+      setActiveSessionState(null)
     }
   }, [open, loadProjects])
 
@@ -435,6 +491,7 @@ export function ProjectsPanel({
             project={project}
             isActive={activeProjectCwd === project.path}
             onClick={() => handleSelectProject(project)}
+            sessionState={activeProjectCwd === project.path ? activeSessionState : null}
           />
         ))}
 

--- a/web/components/gsd/sidebar.tsx
+++ b/web/components/gsd/sidebar.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useMemo, useState, useSyncExternalStore } from "react"
+import { useMemo, useState, useRef, useEffect, useSyncExternalStore } from "react"
 import {
   ChevronRight,
   ChevronDown,
@@ -354,10 +354,30 @@ export function MilestoneExplorer({ isConnecting = false, width, onCollapse }: {
     })
   }
 
+  const isAutoActive = auto?.active ?? false
+  const autoPaused = auto?.paused ?? false
+
+  const [pendingAction, setPendingAction] = useState<string | null>(null)
+  const pendingTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
   const handlePrimaryAction = () => {
     if (!workflowAction.primary) return
+    setPendingAction(workflowAction.primary.command)
+    if (pendingTimerRef.current) clearTimeout(pendingTimerRef.current)
+    pendingTimerRef.current = setTimeout(() => {
+      setPendingAction(null)
+    }, 3000)
     handleCommand(workflowAction.primary.command)
   }
+
+  useEffect(() => {
+    if (pendingAction === null) return
+    setPendingAction(null)
+    if (pendingTimerRef.current) {
+      clearTimeout(pendingTimerRef.current)
+      pendingTimerRef.current = null
+    }
+  }, [isAutoActive, autoPaused]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const handleOpenRecovery = () => {
     openCommandSurface("settings", { source: "sidebar" })
@@ -581,17 +601,17 @@ export function MilestoneExplorer({ isConnecting = false, width, onCollapse }: {
           <div className="flex items-center gap-2">
             <button
               onClick={handlePrimaryAction}
-              disabled={workflowAction.disabled}
+              disabled={workflowAction.disabled || pendingAction !== null}
               className={cn(
                 "inline-flex h-9 flex-1 items-center justify-center gap-2 rounded-md px-3 text-sm font-medium transition-colors",
                 workflowAction.primary.variant === "destructive"
                   ? "bg-destructive text-destructive-foreground hover:bg-destructive/90"
                   : "bg-primary text-primary-foreground hover:bg-primary/90",
-                workflowAction.disabled && "cursor-not-allowed opacity-50",
+                (workflowAction.disabled || pendingAction !== null) && "cursor-not-allowed opacity-50",
               )}
               title={workflowAction.disabledReason}
             >
-              {workspace.commandInFlight ? (
+              {pendingAction !== null ? (
                 <Loader2 className="h-3.5 w-3.5 animate-spin" />
               ) : workflowAction.isNewMilestone ? (
                 <Milestone className="h-3.5 w-3.5" />
@@ -649,10 +669,30 @@ export function CollapsedMilestoneSidebar({ onExpand }: { onExpand: () => void }
     })
   }
 
+  const isAutoActive = auto?.active ?? false
+  const autoPaused = auto?.paused ?? false
+
+  const [pendingAction, setPendingAction] = useState<string | null>(null)
+  const pendingTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
   const handlePrimaryAction = () => {
     if (!workflowAction.primary) return
+    setPendingAction(workflowAction.primary.command)
+    if (pendingTimerRef.current) clearTimeout(pendingTimerRef.current)
+    pendingTimerRef.current = setTimeout(() => {
+      setPendingAction(null)
+    }, 3000)
     handleCommand(workflowAction.primary.command)
   }
+
+  useEffect(() => {
+    if (pendingAction === null) return
+    setPendingAction(null)
+    if (pendingTimerRef.current) {
+      clearTimeout(pendingTimerRef.current)
+      pendingTimerRef.current = null
+    }
+  }, [isAutoActive, autoPaused]) // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
     <div className="flex h-full w-10 flex-col items-center border-l border-border bg-sidebar py-3">
@@ -668,17 +708,17 @@ export function CollapsedMilestoneSidebar({ onExpand }: { onExpand: () => void }
         <div className="mt-auto pb-0.5">
           <button
             onClick={handlePrimaryAction}
-            disabled={workflowAction.disabled}
+            disabled={workflowAction.disabled || pendingAction !== null}
             className={cn(
               "flex h-8 w-8 items-center justify-center rounded-md transition-colors",
               workflowAction.primary.variant === "destructive"
                 ? "bg-destructive text-destructive-foreground hover:bg-destructive/90"
                 : "bg-primary text-primary-foreground hover:bg-primary/90",
-              workflowAction.disabled && "cursor-not-allowed opacity-50",
+              (workflowAction.disabled || pendingAction !== null) && "cursor-not-allowed opacity-50",
             )}
             title={workflowAction.disabledReason ?? workflowAction.primary.label}
           >
-            {workspace.commandInFlight ? (
+            {pendingAction !== null ? (
               <Loader2 className="h-4 w-4 animate-spin" />
             ) : workflowAction.isNewMilestone ? (
               <Milestone className="h-4 w-4" />

--- a/web/lib/gsd-workspace-store.tsx
+++ b/web/lib/gsd-workspace-store.tsx
@@ -442,6 +442,19 @@ export interface TurnEndEvent {
   [key: string]: unknown
 }
 
+export interface SessionStatePayload {
+  type: "session_state"
+  bridgePhase: BridgePhase
+  isStreaming: boolean
+  isCompacting: boolean
+  retryInProgress: boolean
+  sessionId: string | null
+  autoActive: boolean
+  autoPaused: boolean
+  currentUnit: { type: string; id: string; startedAt: number } | null
+  updatedAt: string
+}
+
 export type WorkspaceEvent =
   | BridgeStatusEvent
   | LiveStateInvalidationEvent
@@ -453,7 +466,8 @@ export type WorkspaceEvent =
   | ToolExecutionEndEvent
   | AgentEndEvent
   | TurnEndEvent
-  | ({ type: Exclude<string, "bridge_status" | "live_state_invalidation" | "extension_ui_request" | "extension_error" | "message_update" | "tool_execution_start" | "tool_execution_update" | "tool_execution_end" | "agent_end" | "turn_end">; [key: string]: unknown } & Record<string, unknown>)
+  | SessionStatePayload
+  | ({ type: Exclude<string, "bridge_status" | "live_state_invalidation" | "extension_ui_request" | "extension_error" | "message_update" | "tool_execution_start" | "tool_execution_update" | "tool_execution_end" | "agent_end" | "turn_end" | "session_state">; [key: string]: unknown } & Record<string, unknown>)
 
 export function isWorkspaceEvent(value: unknown): value is WorkspaceEvent {
   return value !== null && typeof value === "object" && typeof (value as Record<string, unknown>).type === "string"
@@ -4447,6 +4461,26 @@ export class GSDWorkspaceStore {
     }
   }
 
+  private handleSessionStateEvent(event: SessionStatePayload): void {
+    const existingAuto = this.state.live.auto ?? this.state.boot?.auto
+    if (!existingAuto) return
+    this.patchState({
+      live: {
+        ...this.state.live,
+        auto: {
+          ...existingAuto,
+          active: event.autoActive,
+          paused: event.autoPaused,
+          currentUnit: event.currentUnit,
+        },
+        freshness: {
+          ...this.state.live.freshness,
+          auto: withFreshnessSucceeded(this.state.live.freshness.auto),
+        },
+      },
+    })
+  }
+
   private handleLiveStateInvalidation(event: LiveStateInvalidationEvent): void {
     this.patchState({
       live: this.invalidateLiveFreshness(event.domains, event.reason, event.source),
@@ -4941,6 +4975,11 @@ export class GSDWorkspaceStore {
       return
     }
 
+    if (event.type === "session_state") {
+      this.handleSessionStateEvent(event as SessionStatePayload)
+      return
+    }
+
     if (event.type === "live_state_invalidation") {
       this.handleLiveStateInvalidation(event as LiveStateInvalidationEvent)
     }
@@ -4976,6 +5015,9 @@ export class GSDWorkspaceStore {
         break
       case "tool_execution_end":
         this.handleToolExecutionEnd(event as ToolExecutionEndEvent)
+        break
+      case "session_state":
+        // Handled upstream in handleEvent with early return — never reaches here
         break
       case "bridge_status":
         // Handled upstream in handleEvent with early return — never reaches here


### PR DESCRIPTION
## Active Session Indicators — PR 2 of 2: UI Components

> **Active Session Indicators (v1.1)** — 2 PRs, merge in order. Depends on v1.0 PRs (#3100-#3103) being merged first.
> **Depends on:** #3135 (Session State API)

### Summary

Project selector and dashboard controls accurately reflect live agent state.

- **Store handler**: `handleSessionStateEvent` in workspace store patches `live.auto` from SSE events — all `getLiveAutoDashboard()` consumers get real-time data
- **Three-state button**: Start Auto → Stop Auto (red/destructive) → Resume Auto (amber) in dashboard, sidebar, and chat-mode
- **Loading spinner**: appears on action click, clears on SSE confirmation or 3s timeout
- **SessionBadge**: green pulsing dot (running), amber (paused), gray (idle) on ProjectCard with inline subtitle "Auto - Phase 3"
- **Stale reads fixed**: all `boot?.auto?.active` reads replaced with `getLiveAutoDashboard(state)`

**5 files** | UI decisions from user discussion (12 decisions captured)

### Where to find it

| Feature | File |
|---------|------|
| Store handler | `web/lib/gsd-workspace-store.tsx` — `handleSessionStateEvent` |
| Dashboard button + spinner | `web/components/gsd/dashboard.tsx` |
| Sidebar button + spinner | `web/components/gsd/sidebar.tsx` |
| Chat-mode live reads | `web/components/gsd/chat-mode.tsx` |
| Session badge + ProjectCard | `web/components/gsd/projects-view.tsx` |

### Test plan
- [ ] Project selector shows green pulsing dot for active sessions
- [ ] Subtitle shows "Auto - T01" for running auto-mode
- [ ] "Auto Mode Active/Inactive" label updates on state change
- [ ] Start Auto → Stop Auto button transition works
- [ ] Spinner appears on click, clears within 2s (or 3s timeout)