### PR TITLE
feat(gsd-watch): standalone extension for live TUI dashboard

### DIFF
--- a/src/resources/extensions/gsd-watch/extension-manifest.json
+++ b/src/resources/extensions/gsd-watch/extension-manifest.json
@@ -1,0 +1,16 @@
+{
+  "id": "gsd-watch",
+  "name": "GSD Watch",
+  "version": "1.0.0",
+  "description": "Live TUI dashboard — navigable tree of milestones, phases, and plans with status badges",
+  "tier": "bundled",
+  "requires": { "platform": ">=2.29.0" },
+  "provides": {
+    "commands": ["watch"],
+    "hooks": ["session_start"]
+  },
+  "dependencies": {
+    "extensions": ["gsd"],
+    "runtime": ["chokidar"]
+  }
+}

--- a/src/resources/extensions/gsd-watch/extension-manifest.json
+++ b/src/resources/extensions/gsd-watch/extension-manifest.json
@@ -6,8 +6,7 @@
   "tier": "bundled",
   "requires": { "platform": ">=2.29.0" },
   "provides": {
-    "commands": ["watch"],
-    "hooks": ["session_start"]
+    "commands": ["watch"]
   },
   "dependencies": {
     "extensions": ["gsd"],

--- a/src/resources/extensions/gsd-watch/index.ts
+++ b/src/resources/extensions/gsd-watch/index.ts
@@ -1,0 +1,26 @@
+// GSD Watch Extension — Live TUI dashboard for monitoring project progress
+// Copyright (c) 2026 Jeremy McSpadden <jeremy@fluxlabs.net>
+
+import type { ExtensionAPI } from "@gsd/pi-coding-agent";
+
+export default function gsdWatch(pi: ExtensionAPI) {
+  pi.registerCommand("watch", {
+    description: "Live TUI dashboard: /watch [stop]",
+
+    getArgumentCompletions: (prefix: string) => {
+      const subs = ["stop"];
+      const parts = prefix.trim().split(/\s+/);
+      if (parts.length <= 1) {
+        return subs
+          .filter((s) => s.startsWith(parts[0] ?? ""))
+          .map((s) => ({ value: s, label: s }));
+      }
+      return [];
+    },
+
+    handler: async (args, ctx) => {
+      const { handleWatch } = await import("./orchestrator.js");
+      await handleWatch(args.trim(), ctx);
+    },
+  });
+}

--- a/src/resources/extensions/gsd-watch/orchestrator.ts
+++ b/src/resources/extensions/gsd-watch/orchestrator.ts
@@ -1,0 +1,194 @@
+// GSD Watch — Watch orchestrator: tmux guard, singleton lock, pane creation
+// Copyright (c) 2026 Jeremy McSpadden <jeremy@fluxlabs.net>
+
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync, writeFileSync, unlinkSync, mkdirSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { platform } from "node:os";
+import type { ExtensionCommandContext } from "@gsd/pi-coding-agent";
+import { WATCH_LOCK_FILE } from "./types.js";
+import type { WatchLockData } from "./types.js";
+
+/**
+ * Resolve the .gsd directory for a project root.
+ * Checks the root directly, then falls back to creating it.
+ */
+function resolveGsdDir(root: string): string {
+  const gsdDir = join(root, ".gsd");
+  mkdirSync(gsdDir, { recursive: true });
+  return gsdDir;
+}
+
+/**
+ * Returns an OS-appropriate install hint for tmux.
+ * Per D-01: darwin → brew, linux → apt/dnf, other → GitHub wiki.
+ */
+export function buildTmuxInstallHint(): string {
+  switch (platform()) {
+    case "darwin":
+      return "Install with: brew install tmux";
+    case "linux":
+      return "Install with: sudo apt install tmux (Debian/Ubuntu) or sudo dnf install tmux (Fedora/RHEL)";
+    default:
+      return "See https://github.com/tmux/tmux/wiki/Installing";
+  }
+}
+
+/**
+ * Read and parse the watch lock file from the given .gsd/ directory.
+ * Returns null if the file is missing or contains invalid JSON.
+ */
+export function readWatchLock(gsdDir: string): WatchLockData | null {
+  const lockPath = join(gsdDir, WATCH_LOCK_FILE);
+  if (!existsSync(lockPath)) return null;
+  try {
+    const raw = readFileSync(lockPath, "utf-8");
+    return JSON.parse(raw) as WatchLockData;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Write watch lock data as JSON to .gsd/watch.lock.
+ * Creates the .gsd/ directory if it does not exist.
+ */
+export function writeWatchLock(gsdDir: string, data: WatchLockData): void {
+  mkdirSync(gsdDir, { recursive: true });
+  writeFileSync(join(gsdDir, WATCH_LOCK_FILE), JSON.stringify(data, null, 2));
+}
+
+/**
+ * Remove the watch lock file if it exists. Errors are silently swallowed.
+ */
+export function clearWatchLock(gsdDir: string): void {
+  try {
+    const lockPath = join(gsdDir, WATCH_LOCK_FILE);
+    if (existsSync(lockPath)) unlinkSync(lockPath);
+  } catch {
+    // Non-fatal: lock removal failure
+  }
+}
+
+/**
+ * Check whether a process with the given PID is currently alive.
+ * Uses process.kill(pid, 0) — no signal is sent; it merely checks existence.
+ */
+export function isWatchPidAlive(pid: number): boolean {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "EPERM") return true;
+    return false;
+  }
+}
+
+/**
+ * Remove the stale watch lock and attempt to kill the orphaned tmux pane.
+ * The kill-pane call is wrapped in try/catch since the pane may already be gone.
+ */
+export function cleanupStaleLock(gsdDir: string, lock: WatchLockData): void {
+  clearWatchLock(gsdDir);
+  try {
+    execFileSync("tmux", ["kill-pane", "-t", lock.paneId]);
+  } catch {
+    // Pane may already be gone — non-fatal
+  }
+}
+
+/**
+ * Handle the /watch stop subcommand: kill the watch pane and remove the lock.
+ */
+function handleStop(gsdDir: string, ctx: ExtensionCommandContext): void {
+  const lock = readWatchLock(gsdDir);
+  if (lock === null) {
+    ctx.ui.notify("Watch is not running", "info");
+    return;
+  }
+  cleanupStaleLock(gsdDir, lock);
+  ctx.ui.notify("Watch stopped", "info");
+}
+
+/**
+ * Main entry point for the /watch command.
+ *
+ * Flow:
+ *  1. If "stop" subcommand, kill existing pane and return
+ *  2. If not in tmux, show OS-aware install hint and return
+ *  3. Check singleton lock — if alive, notify; if stale, clean up
+ *  4. Spawn a right-side tmux pane at 35% width running the renderer entry
+ *  5. Capture the new pane's ID and PID, write the watch lock
+ */
+export async function handleWatch(args: string, ctx: ExtensionCommandContext): Promise<void> {
+  const root = ctx.cwd;
+  const gsdDir = resolveGsdDir(root);
+
+  // Subcommand: /watch stop
+  if (args === "stop") {
+    handleStop(gsdDir, ctx);
+    return;
+  }
+
+  // Step 1: tmux guard
+  if (!process.env.TMUX) {
+    ctx.ui.notify(
+      `tmux is required to run /watch.\n${buildTmuxInstallHint()}`,
+      "warning",
+    );
+    return;
+  }
+
+  // Step 2: singleton guard
+  const lock = readWatchLock(gsdDir);
+  if (lock !== null) {
+    if (isWatchPidAlive(lock.pid)) {
+      ctx.ui.notify("Watch already running — use /watch stop to close", "info");
+      return;
+    }
+    // Stale lock: PID is dead — clean up before relaunching
+    cleanupStaleLock(gsdDir, lock);
+  }
+
+  // Step 3: spawn renderer pane
+  const rendererEntryPath = join(
+    dirname(fileURLToPath(import.meta.url)),
+    "renderer-entry.js",
+  );
+
+  execFileSync("tmux", [
+    "split-window",
+    "-h",
+    "-l", "35%",
+    "-d",
+    "node",
+    rendererEntryPath,
+    root,
+  ]);
+
+  // Capture the new pane's ID and PID (targets the most recently created pane)
+  const newPaneId = execFileSync(
+    "tmux",
+    ["display-message", "-p", "-t", "{last}", "#{pane_id}"],
+    { encoding: "utf-8" },
+  ).trim();
+
+  const newPanePidStr = execFileSync(
+    "tmux",
+    ["display-message", "-p", "-t", "{last}", "#{pane_pid}"],
+    { encoding: "utf-8" },
+  ).trim();
+
+  const newPanePid = parseInt(newPanePidStr, 10);
+
+  writeWatchLock(gsdDir, {
+    pid: newPanePid,
+    paneId: newPaneId,
+    startedAt: new Date().toISOString(),
+    projectRoot: root,
+  });
+
+  ctx.ui.notify("Watch started — use /watch stop to close", "info");
+}

--- a/src/resources/extensions/gsd-watch/renderer-entry.ts
+++ b/src/resources/extensions/gsd-watch/renderer-entry.ts
@@ -1,0 +1,803 @@
+// GSD Watch — Renderer subprocess entry point: viewport scrolling, signal wiring, quit key detection, tree rendering
+// Copyright (c) 2026 Jeremy McSpadden <jeremy@fluxlabs.net>
+
+import { existsSync, readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { startPlanningWatcher } from "./watcher.js";
+import { clearWatchLock } from "./orchestrator.js";
+import { buildProjectTree } from "./tree-model.js";
+import type { DbQueries } from "./tree-model.js";
+import { renderTreeLines } from "./tree-renderer.js";
+import type { VisibleNode } from "./tree-renderer.js";
+import { visibleWidth, truncateToWidth } from "@gsd/pi-tui";
+import type { FSWatcher } from "chokidar";
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+/** Signals that should trigger cleanup and graceful exit. */
+export const CLEANUP_SIGNALS: NodeJS.Signals[] = ["SIGTERM", "SIGHUP", "SIGINT"];
+
+/** Minimum PTY width to guard against zero-width pane at startup (Pitfall 2). */
+const MIN_WIDTH = 40;
+
+/** Minimum PTY height to guard against zero-height pane and non-TTY contexts. */
+const MIN_HEIGHT = 3;
+
+/** Time window (ms) within which a repeated key press counts as a quit sequence. */
+const QUIT_TIMEOUT_MS = 500;
+
+// ─── PTY Width Guard ──────────────────────────────────────────────────────────
+
+/**
+ * Returns the effective terminal width, enforcing a minimum of MIN_WIDTH (40)
+ * to guard against PTY width=0 at pane creation time.
+ */
+export function getEffectiveWidth(): number {
+  return Math.max(process.stdout.columns || 0, MIN_WIDTH);
+}
+
+// ─── Quit Key State Machine ───────────────────────────────────────────────────
+
+let lastKey = "";
+let lastKeyTime = 0;
+
+/**
+ * Reset the quit-sequence state machine.
+ * Exported for test isolation (call in beforeEach).
+ */
+export function resetQuitState(): void {
+  lastKey = "";
+  lastKeyTime = 0;
+}
+
+/**
+ * Parse a raw keypress chunk from stdin and detect quit sequences:
+ *   - `qq` (two q presses within QUIT_TIMEOUT_MS)
+ *   - `\x1b\x1b` (two Esc presses within QUIT_TIMEOUT_MS)
+ *   - `\x03` (Ctrl+C raw byte in raw mode)
+ *
+ * Returns true if the current keypress completes a quit sequence.
+ */
+export function parseQuitSequence(chunk: string): boolean {
+  // Ctrl+C raw byte in raw mode
+  if (chunk === "\x03") {
+    lastKey = "";
+    lastKeyTime = 0;
+    return true;
+  }
+
+  const now = Date.now();
+
+  if (
+    chunk === "q" &&
+    lastKey === "q" &&
+    now - lastKeyTime < QUIT_TIMEOUT_MS
+  ) {
+    lastKey = "";
+    lastKeyTime = 0;
+    return true;
+  }
+
+  if (
+    chunk === "\x1b" &&
+    lastKey === "\x1b" &&
+    now - lastKeyTime < QUIT_TIMEOUT_MS
+  ) {
+    lastKey = "";
+    lastKeyTime = 0;
+    return true;
+  }
+
+  lastKey = chunk;
+  lastKeyTime = now;
+  return false;
+}
+
+// ─── PTY Height Guard ─────────────────────────────────────────────────────────
+
+/**
+ * Returns the effective terminal height, enforcing a minimum of MIN_HEIGHT (3)
+ * to guard against PTY height=0 at pane creation and undefined in non-TTY contexts.
+ */
+export function getEffectiveHeight(): number {
+  return Math.max(process.stdout.rows || 0, MIN_HEIGHT);
+}
+
+// ─── Viewport State ───────────────────────────────────────────────────────────
+
+/** Current top-of-viewport line index. Module-level state, mirrors lastKey/lastKeyTime pattern. */
+let viewportOffset = 0;
+
+/**
+ * Reset the viewport state.
+ * Exported for test isolation (call in beforeEach).
+ */
+export function resetViewportState(): void {
+  viewportOffset = 0;
+}
+
+/**
+ * Returns the current viewport offset.
+ * Exported for test assertions.
+ */
+export function getViewportOffset(): number {
+  return viewportOffset;
+}
+
+// ─── Navigation State ────────────────────────────────────────────────────────
+
+/** Current cursor position index into the lastRenderedNodes array. */
+let cursorIndex = 0;
+
+/** Set of phase dirName values that are collapsed (hiding child plans). */
+let collapsedPhases: Set<string> = new Set();
+
+/** Set of milestone indices that are collapsed (hiding all phases/plans). */
+let collapsedMilestones: Set<number> = new Set();
+
+/** Whether the help overlay is currently visible (replaces tree content). */
+let helpOverlayVisible = false;
+
+/** Parallel node metadata from the most recent renderTreeLines() call. */
+let lastRenderedNodes: VisibleNode[] = [];
+
+/** Whether auto-collapse has run (only on first render). */
+let autoCollapseApplied = false;
+
+/**
+ * Reset all navigation state.
+ * Exported for test isolation (call in beforeEach).
+ */
+export function resetNavigationState(): void {
+  cursorIndex = 0;
+  collapsedPhases = new Set();
+  collapsedMilestones = new Set();
+  helpOverlayVisible = false;
+  lastRenderedNodes = [];
+  autoCollapseApplied = false;
+}
+
+/** Returns the current cursor index. Exported for test assertions. */
+export function getCursorIndex(): number { return cursorIndex; }
+
+/** Returns a copy of the current collapsed phases set. Exported for test assertions. */
+export function getCollapsedPhases(): Set<string> { return new Set(collapsedPhases); }
+
+/** Returns whether the help overlay is currently visible. Exported for test assertions. */
+export function isHelpOverlayVisible(): boolean { return helpOverlayVisible; }
+
+// ─── Cursor Highlight ────────────────────────────────────────────────────────
+
+/**
+ * Wrap a rendered tree line in ANSI reverse video (D-01), padded to fill
+ * the full terminal width so the highlight bar spans the entire row.
+ */
+export function applyCursorHighlight(line: string, width: number): string {
+  const visLen = visibleWidth(line);
+  const padded = line + " ".repeat(Math.max(0, width - visLen));
+  return `\x1b[7m${padded}\x1b[0m`;
+}
+
+// ─── Cursor Viewport Sync ───────────────────────────────────────────────────
+
+/**
+ * Adjust viewportOffset so that the cursor is visible (D-04).
+ * - If cursor is above viewport: scroll up to cursor.
+ * - If cursor is below viewport: scroll down so cursor is at bottom of viewport.
+ * - If cursor is within viewport: no change.
+ */
+export function ensureCursorInViewport(cursor: number, totalNodes: number, contentHeight: number): void {
+  if (cursor < viewportOffset) {
+    viewportOffset = cursor;
+  } else if (cursor >= viewportOffset + contentHeight) {
+    viewportOffset = cursor - contentHeight + 1;
+  }
+  // Clamp viewportOffset to valid range
+  const maxOffset = Math.max(0, totalNodes - contentHeight);
+  viewportOffset = Math.max(0, Math.min(viewportOffset, maxOffset));
+}
+
+// ─── Help Overlay ───────────────────────────────────────────────────────────
+
+/**
+ * Render the help overlay as an array of terminal-safe strings (D-12, D-13, D-14).
+ * Contains two sections: KEYBINDINGS and BADGE LEGEND.
+ */
+export function renderHelpOverlayLines(width: number): string[] {
+  const KEY_COL_WIDTH = 14;
+  const KEYBINDINGS: [string, string][] = [
+    ["↑ / ↓",        "Move cursor up / down"],
+    ["← / →",        "Collapse / expand node"],
+    ["j / k",        "Move cursor (vim)"],
+    ["h / l",        "Collapse / expand (vim)"],
+    ["g / G",        "Jump to top / bottom"],
+    ["?",            "Toggle this help overlay"],
+    ["qq / EscEsc",  "Quit"],
+    ["Ctrl+C",       "Quit (force)"],
+  ];
+  const BADGE_LEGEND: [string, string][] = [
+    ["Pos 1", "CONTEXT"],
+    ["Pos 2", "RESEARCH"],
+    ["Pos 3", "UI-SPEC"],
+    ["Pos 4", "PLAN"],
+    ["Pos 5", "SUMMARY"],
+    ["Pos 6", "VERIFICATION"],
+    ["Pos 7", "HUMAN-UAT"],
+  ];
+
+  const BOLD = "\x1b[1m";
+  const DIM  = "\x1b[2m";
+  const CYAN = "\x1b[36m";
+  const RST  = "\x1b[0m";
+
+  const lines: string[] = [];
+  lines.push("");
+  lines.push(`${BOLD}KEYBINDINGS${RST}`);
+  lines.push("");
+  for (const [key, desc] of KEYBINDINGS) {
+    const keyPadded = key + " ".repeat(Math.max(0, KEY_COL_WIDTH - visibleWidth(key)));
+    const descTrunc = truncateToWidth(desc, Math.max(1, width - KEY_COL_WIDTH), "…");
+    lines.push(`${CYAN}${keyPadded}${RST}${descTrunc}`);
+  }
+  lines.push("");
+  lines.push(`${BOLD}BADGE LEGEND${RST}`);
+  lines.push("");
+  for (const [pos, name] of BADGE_LEGEND) {
+    const posPadded = pos + " ".repeat(Math.max(0, KEY_COL_WIDTH - visibleWidth(pos)));
+    const nameTrunc = truncateToWidth(name, Math.max(1, width - KEY_COL_WIDTH), "…");
+    lines.push(`${CYAN}${posPadded}${RST}${nameTrunc}`);
+  }
+
+  return lines;
+}
+
+// ─── Arrow Key Parser ─────────────────────────────────────────────────────────
+
+export type ArrowDirection = "up" | "down" | "left" | "right" | null;
+
+/**
+ * Parse a raw keypress chunk and detect ANSI arrow key sequences.
+ * Returns "up", "down", "left", "right", or null for non-arrow input.
+ *
+ * Per Pattern 3: run BEFORE parseQuitSequence in the stdin data handler so that
+ * the \x1b prefix of arrow sequences never reaches the quit state machine.
+ */
+export function parseArrowKey(chunk: string): ArrowDirection {
+  if (chunk === "\x1b[A") return "up";
+  if (chunk === "\x1b[B") return "down";
+  if (chunk === "\x1b[D") return "left";
+  if (chunk === "\x1b[C") return "right";
+  return null;
+}
+
+// ─── Mouse Scroll Parser ──────────────────────────────────────────────────────
+
+export type MouseScrollDirection = "up" | "down" | null;
+
+/**
+ * Parse SGR mouse escape sequences for scroll wheel events.
+ * SGR format: \x1b[<button;col;rowM  or  \x1b[<button;col;rowm
+ * Scroll up: button=64, scroll down: button=65.
+ */
+export function parseMouseScroll(chunk: string): MouseScrollDirection {
+  const match = chunk.match(/^\x1b\[<(\d+);\d+;\d+[mM]$/);
+  if (!match) return null;
+  const button = parseInt(match[1], 10);
+  if (button === 64) return "up";
+  if (button === 65) return "down";
+  return null;
+}
+
+// ─── Navigation Key Parser ──────────────────────────────────────────────────────
+
+export type NavKey = "cursor-up" | "cursor-down" | "collapse" | "expand" |
+                     "jump-top" | "jump-bottom" | "help" | null;
+
+/**
+ * Parse a raw keypress chunk and detect vim-style navigation keys.
+ * Returns the NavKey action or null for non-navigation input.
+ *
+ * Must be called BEFORE parseArrowKey in the stdin data handler (D-15).
+ */
+export function parseNavKey(chunk: string): NavKey {
+  if (chunk === "j") return "cursor-down";
+  if (chunk === "k") return "cursor-up";
+  if (chunk === "h") return "collapse";
+  if (chunk === "l") return "expand";
+  if (chunk === "g") return "jump-top";
+  if (chunk === "G") return "jump-bottom";
+  if (chunk === "?") return "help";
+  return null;
+}
+
+// ─── Viewport Scroll ──────────────────────────────────────────────────────────
+
+/**
+ * Mutate viewportOffset by delta, clamped to [0, totalLines - contentHeight].
+ */
+export function scrollViewport(delta: number, totalLines: number, contentHeight: number): void {
+  const maxOffset = Math.max(0, totalLines - contentHeight);
+  viewportOffset = Math.max(0, Math.min(viewportOffset + delta, maxOffset));
+}
+
+// ─── Viewport Renderer ────────────────────────────────────────────────────────
+
+/**
+ * Build the centered status bar string.
+ * Hides ▲ when at top (offset === 0), hides ▼ when at bottom.
+ */
+function buildStatusBar(
+  offset: number,
+  total: number,
+  contentHeight: number,
+  width: number
+): string {
+  const DIM = "\x1b[2m";
+  const RST = "\x1b[0m";
+  const upArrow = offset > 0 ? "▲" : " ";
+  const downArrow = offset + contentHeight < total ? "▼" : " ";
+  const positionText = `${offset + 1}/${total}`;
+  const rawBar = `${upArrow} ${positionText} ${downArrow}`;
+  const barWidth = visibleWidth(rawBar);
+  if (barWidth <= width) {
+    const padding = Math.floor((width - barWidth) / 2);
+    return `${DIM}${" ".repeat(padding)}${rawBar}${RST}`;
+  }
+  return `${DIM}${truncateToWidth(rawBar, width, "")}${RST}`;
+}
+
+/**
+ * Slice the full line array into a viewport window and append a conditional status bar.
+ *
+ * Per Pitfall 2: status bar row only reserved when scrollable (total > height).
+ * When tree fits, returns all lines joined — no height reduction, no status bar.
+ */
+export function renderViewport(
+  lines: string[],
+  offset: number,
+  height: number,
+  width: number
+): string {
+  const total = lines.length;
+  const scrollable = total > height;
+
+  if (!scrollable) {
+    return lines.join("\n");
+  }
+
+  // Reserve 1 row for status bar when scrollable
+  const contentHeight = height - 1;
+  const clampedOffset = Math.max(0, Math.min(offset, Math.max(0, total - contentHeight)));
+  const visible = lines.slice(clampedOffset, clampedOffset + contentHeight);
+  const statusBar = buildStatusBar(clampedOffset, total, contentHeight, width);
+
+  return visible.join("\n") + "\n" + statusBar;
+}
+
+// ─── Placeholder Renderer ─────────────────────────────────────────────────────
+
+/**
+ * Render a contextual placeholder message to stdout.
+ *
+ * Per D-09, D-10, D-11, D-12:
+ *   - If PROJECT.md found: outputs "[ProjectName]\nLoading project..."
+ *   - If .planning/ doesn't exist: outputs waiting/setup message
+ *   - If .planning/ exists but empty/no phases: outputs "No phases found" message
+ *   - Otherwise: outputs "Loading project..."
+ */
+export function renderPlaceholder(projectRoot: string): void {
+  // Clear screen and move cursor to top-left
+  process.stdout.write("\x1b[2J\x1b[H");
+
+  const planningDir = join(projectRoot, ".planning");
+
+  // .planning/ doesn't exist at all
+  if (!existsSync(planningDir)) {
+    process.stdout.write(
+      "Waiting for project...\n(Run /gsd:new-project to get started)\n"
+    );
+    return;
+  }
+
+  // Try to read PROJECT.md and extract project name from first "# " heading
+  const projectMdPath = join(planningDir, "PROJECT.md");
+  if (existsSync(projectMdPath)) {
+    try {
+      const content = readFileSync(projectMdPath, "utf-8");
+      const match = content.match(/^#\s+(.+)$/m);
+      if (match && match[1]) {
+        const projectName = match[1].trim();
+        process.stdout.write(`${projectName}\nLoading project...\n`);
+        return;
+      }
+    } catch {
+      // Fall through to generic message
+    }
+  }
+
+  // .planning/ exists but no PROJECT.md (or couldn't parse heading)
+  process.stdout.write("Loading project...\n");
+}
+
+// ─── Tree Renderer ────────────────────────────────────────────────────────────
+
+/** Cache of last rendered lines — used by arrow key handler and resize handler. */
+let lastRenderedLines: string[] = [];
+
+/** Injected DB queries — set on startup if DB is available. */
+let dbQueries: DbQueries | null = null;
+
+/** Set the DB queries for tree building. Called once on startup. */
+export function setDbQueries(q: DbQueries | null): void {
+  dbQueries = q;
+}
+
+/**
+ * Render the full project tree to stdout through the viewport.
+ * Uses DB as source of truth when available, falls back to filesystem.
+ * Updates lastRenderedLines and lastRenderedNodes so navigation and resize handlers work.
+ * Applies cursor highlight (reverse video) to the cursor row (D-01).
+ * When help overlay is visible, renders overlay content instead of tree (D-12).
+ * Uses single atomic write to prevent flicker (Pitfall 5 from research).
+ */
+export function renderTree(projectRoot: string): void {
+  const width = getEffectiveWidth();
+  const height = getEffectiveHeight();
+  const milestones = buildProjectTree(projectRoot, dbQueries);
+
+  // Auto-collapse on first render: collapse completed milestones and done phases
+  if (!autoCollapseApplied && milestones.length > 1) {
+    autoCollapseApplied = true;
+    let activeMilestoneIdx = -1;
+    for (let mi = 0; mi < milestones.length; mi++) {
+      const m = milestones[mi];
+      if (m.status === "done") {
+        collapsedMilestones.add(mi);
+      } else {
+        if (activeMilestoneIdx === -1) activeMilestoneIdx = mi;
+        // For active milestones, collapse done phases so focus is on active work
+        for (const phase of m.phases) {
+          if (phase.status === "done") {
+            collapsedPhases.add(phase.dirName);
+          }
+        }
+      }
+    }
+    // Position cursor on the active milestone (last non-done, at bottom in chronological order)
+    if (activeMilestoneIdx >= 0) {
+      // Render once to get node positions, then find the active milestone node
+      const preview = renderTreeLines(milestones, width, collapsedPhases, collapsedMilestones);
+      const targetIdx = preview.nodes.findIndex(
+        n => n.kind === "milestone" && n.milestoneIdx === activeMilestoneIdx
+      );
+      if (targetIdx >= 0) {
+        cursorIndex = targetIdx;
+        const scrollable = preview.lines.length > height;
+        const contentHeight = scrollable ? height - 1 : height;
+        ensureCursorInViewport(cursorIndex, preview.lines.length, contentHeight);
+      }
+    }
+  }
+
+  // Prune stale collapse entries (D-11): remove any dirName that no longer exists
+  const activeDirNames = new Set(milestones.flatMap(m => m.phases.map(p => p.dirName)));
+  for (const d of collapsedPhases) {
+    if (!activeDirNames.has(d)) collapsedPhases.delete(d);
+  }
+
+  const { lines, nodes } = renderTreeLines(milestones, width, collapsedPhases, collapsedMilestones);
+
+  // Clamp cursor to valid range after nodes may have changed
+  cursorIndex = Math.max(0, Math.min(cursorIndex, nodes.length - 1));
+
+  // Store for use by arrow key handler, resize handler, and cursor-sticky logic
+  lastRenderedLines = lines;
+  lastRenderedNodes = nodes;
+
+  let outputLines: string[];
+
+  if (helpOverlayVisible) {
+    // Help overlay replaces tree content (D-12, D-15)
+    outputLines = renderHelpOverlayLines(width);
+  } else {
+    // Apply cursor highlight (reverse video) to the cursor row (D-01)
+    outputLines = lines.map((line, i) =>
+      i === cursorIndex ? applyCursorHighlight(line, width) : line
+    );
+  }
+
+  const output = renderViewport(outputLines, viewportOffset, height, width);
+  // Atomic single write: clear screen + content in one call to prevent flicker
+  process.stdout.write("\x1b[2J\x1b[H" + output + "\n");
+}
+
+// ─── Shutdown ─────────────────────────────────────────────────────────────────
+
+/** Enable mouse reporting: basic tracking + SGR extended mode for scroll wheel events. */
+function enableMouseReporting(): void {
+  process.stdout.write("\x1b[?1000h\x1b[?1006h");
+}
+
+/** Disable mouse reporting — must be called before exit to restore terminal state. */
+function disableMouseReporting(): void {
+  process.stdout.write("\x1b[?1000l\x1b[?1006l");
+}
+
+/**
+ * Perform a clean shutdown:
+ *   1. Disable mouse reporting
+ *   2. Disable raw mode on stdin (if TTY)
+ *   3. Close the file watcher
+ *   4. Remove the watch lock file
+ *   5. Exit with code 0
+ */
+async function shutdown(
+  watcher: FSWatcher,
+  gsdDir: string
+): Promise<void> {
+  disableMouseReporting();
+  if (process.stdin.isTTY) process.stdin.setRawMode(false);
+  await watcher.close();
+  clearWatchLock(gsdDir);
+  process.exit(0);
+}
+
+// ─── Main Execution Block ─────────────────────────────────────────────────────
+
+// Only run when executed directly as a subprocess, not when imported for testing.
+const isMainModule =
+  process.argv[1]?.endsWith("renderer-entry.ts") ||
+  process.argv[1]?.endsWith("renderer-entry.js");
+
+if (isMainModule) {
+  const projectRoot = process.argv[2];
+  if (!projectRoot) {
+    process.stderr.write(
+      "renderer-entry: missing required argument: projectRoot\n"
+    );
+    process.exit(1);
+  }
+
+  const gsdDir = join(projectRoot, ".gsd");
+  const planningDir = join(projectRoot, ".planning");
+
+  // Open GSD database if available (source of truth for progress tracking)
+  const dbPath = join(gsdDir, "gsd.db");
+  if (existsSync(dbPath)) {
+    try {
+      // Dynamic import from sibling GSD extension — soft dependency
+      const gsdExtDir = join(dirname(new URL(import.meta.url).pathname), "..", "gsd");
+      const db = await import(join(gsdExtDir, "gsd-db.js"));
+      if (db.openDatabase(dbPath)) {
+        setDbQueries({
+          getAllMilestones: () => db.getAllMilestones().map((m: { id: string; title: string; status: string }) => ({
+            id: m.id, title: m.title, status: m.status
+          })),
+          getMilestoneSlices: (mid: string) => db.getMilestoneSlices(mid).map((s: { milestone_id: string; id: string; title: string; status: string }) => ({
+            milestone_id: s.milestone_id, id: s.id, title: s.title, status: s.status
+          })),
+          getSliceTasks: (mid: string, sid: string) => db.getSliceTasks(mid, sid).map((t: { milestone_id: string; slice_id: string; id: string; title: string; status: string }) => ({
+            milestone_id: t.milestone_id, slice_id: t.slice_id, id: t.id, title: t.title, status: t.status
+          })),
+        });
+      }
+    } catch {
+      // DB unavailable — fall back to filesystem
+    }
+  }
+
+  // Render initial tree
+  renderTree(projectRoot);
+
+  // Start file watcher — smart auto-follow on file changes (D-02)
+  const watcher = startPlanningWatcher(planningDir, () => {
+    // Smart auto-follow (D-02): only scroll to active phase if it was already visible
+    const height = getEffectiveHeight();
+    const oldLines = lastRenderedLines;
+    const total = oldLines.length;
+    const scrollable = total > height;
+    const contentHeight = scrollable ? height - 1 : height;
+
+    // Find active phase (◆) in current (pre-refresh) lines
+    const activeIndex = oldLines.findIndex((line) => line.includes("◆"));
+    const wasInView =
+      activeIndex >= 0 &&
+      activeIndex >= viewportOffset &&
+      activeIndex < viewportOffset + contentHeight;
+
+    // Cursor-sticky (D-05): record the logical node the cursor is on before re-render
+    const prevNode = lastRenderedNodes[cursorIndex];
+
+    // Re-render (this updates lastRenderedLines and lastRenderedNodes)
+    renderTree(projectRoot);
+
+    // Cursor-sticky (D-05): restore cursor to same logical node after re-render
+    if (prevNode) {
+      const newIdx = lastRenderedNodes.findIndex(n => {
+        if (prevNode.kind === "phase" && n.kind === "phase") return n.dirName === prevNode.dirName;
+        if (prevNode.kind === "plan" && n.kind === "plan") return n.planId === prevNode.planId;
+        return n.kind === "milestone" && prevNode.kind === "milestone";
+      });
+      cursorIndex = newIdx >= 0 ? newIdx : Math.min(cursorIndex, Math.max(0, lastRenderedNodes.length - 1));
+    }
+
+    // After render: if active was in view, ensure it still is
+    if (wasInView && lastRenderedLines.length > 0) {
+      const newActiveIndex = lastRenderedLines.findIndex((line) => line.includes("◆"));
+      if (newActiveIndex >= 0) {
+        const newHeight = getEffectiveHeight();
+        const newTotal = lastRenderedLines.length;
+        const newScrollable = newTotal > newHeight;
+        const newContentHeight = newScrollable ? newHeight - 1 : newHeight;
+        const inViewNow =
+          newActiveIndex >= viewportOffset &&
+          newActiveIndex < viewportOffset + newContentHeight;
+        if (!inViewNow) {
+          // Scroll so active phase is at the top of viewport
+          const maxOffset = Math.max(0, newTotal - newContentHeight);
+          viewportOffset = Math.min(newActiveIndex, maxOffset);
+          // Re-render with corrected offset
+          renderTree(projectRoot);
+        }
+      }
+    }
+  });
+
+  // Register signal handlers for clean exit on all termination paths
+  for (const sig of CLEANUP_SIGNALS) {
+    process.on(sig, () => void shutdown(watcher, gsdDir));
+  }
+
+  // Set up stdin in raw mode for quit key detection (qq, Esc Esc, Ctrl+C)
+  if (process.stdin.isTTY) {
+    process.stdin.setRawMode(true);
+    process.stdin.resume();
+    process.stdin.setEncoding("utf-8");
+    enableMouseReporting();
+    process.stdin.on("data", (chunk: string) => {
+      // 1. Help overlay guard (D-15): when overlay is visible, only ?, Esc, Ctrl+C are active
+      if (helpOverlayVisible) {
+        if (chunk === "?" ) {
+          // Toggle help off
+          helpOverlayVisible = false;
+          renderTree(projectRoot);
+        } else if (chunk === "\x1b") {
+          // Single Esc dismisses help overlay — MUST NOT reach parseQuitSequence (RESEARCH Pitfall 1)
+          helpOverlayVisible = false;
+          renderTree(projectRoot);
+        } else if (chunk === "\x03") {
+          // Ctrl+C — force quit
+          void shutdown(watcher, gsdDir);
+        }
+        // All other keys ignored while overlay is visible
+        return;
+      }
+
+      // 2. Navigation keys (j/k/h/l/g/G/?) — checked before arrow keys and quit (D-15)
+      const navKey = parseNavKey(chunk);
+      if (navKey !== null) {
+        const height = getEffectiveHeight();
+        const total = lastRenderedNodes.length;
+        const scrollable = total > height;
+        const contentHeight = scrollable ? height - 1 : height;
+
+        switch (navKey) {
+          case "cursor-down":
+            cursorIndex = Math.min(cursorIndex + 1, lastRenderedNodes.length - 1);
+            ensureCursorInViewport(cursorIndex, lastRenderedNodes.length, contentHeight);
+            renderTree(projectRoot);
+            break;
+          case "cursor-up":
+            cursorIndex = Math.max(cursorIndex - 1, 0);
+            ensureCursorInViewport(cursorIndex, lastRenderedNodes.length, contentHeight);
+            renderTree(projectRoot);
+            break;
+          case "collapse": {
+            const node = lastRenderedNodes[cursorIndex];
+            if (node?.kind === "milestone" && node.milestoneIdx !== undefined) {
+              collapsedMilestones.add(node.milestoneIdx);
+            } else if (node?.kind === "phase" && node.dirName !== undefined) {
+              collapsedPhases.add(node.dirName);
+            }
+            renderTree(projectRoot);
+            // Clamp cursor after collapse (fewer visible nodes)
+            cursorIndex = Math.max(0, Math.min(cursorIndex, lastRenderedNodes.length - 1));
+            break;
+          }
+          case "expand": {
+            const node = lastRenderedNodes[cursorIndex];
+            if (node?.kind === "milestone" && node.milestoneIdx !== undefined) {
+              collapsedMilestones.delete(node.milestoneIdx);
+            } else if (node?.kind === "phase" && node.dirName !== undefined) {
+              collapsedPhases.delete(node.dirName);
+            }
+            renderTree(projectRoot);
+            break;
+          }
+          case "jump-top":
+            cursorIndex = 0;
+            ensureCursorInViewport(cursorIndex, lastRenderedNodes.length, contentHeight);
+            renderTree(projectRoot);
+            break;
+          case "jump-bottom":
+            cursorIndex = Math.max(0, lastRenderedNodes.length - 1);
+            ensureCursorInViewport(cursorIndex, lastRenderedNodes.length, contentHeight);
+            renderTree(projectRoot);
+            break;
+          case "help":
+            helpOverlayVisible = true;
+            renderTree(projectRoot);
+            break;
+        }
+        return; // consumed — do NOT pass to arrow key or quit handler
+      }
+
+      // 3. Arrow keys — cursor movement (up/down) and collapse/expand (left/right)
+      // MUST be checked before parseQuitSequence — their \x1b prefix must NOT reach quit state machine
+      const arrow = parseArrowKey(chunk);
+      if (arrow !== null) {
+        const height = getEffectiveHeight();
+        const total = lastRenderedNodes.length;
+        const scrollable = total > height;
+        const contentHeight = scrollable ? height - 1 : height;
+
+        if (arrow === "up") {
+          cursorIndex = Math.max(cursorIndex - 1, 0);
+          ensureCursorInViewport(cursorIndex, total, contentHeight);
+        } else if (arrow === "down") {
+          cursorIndex = Math.min(cursorIndex + 1, total - 1);
+          ensureCursorInViewport(cursorIndex, total, contentHeight);
+        } else if (arrow === "left") {
+          const node = lastRenderedNodes[cursorIndex];
+          if (node?.kind === "milestone" && node.milestoneIdx !== undefined) {
+            collapsedMilestones.add(node.milestoneIdx);
+          } else if (node?.kind === "phase" && node.dirName !== undefined) {
+            collapsedPhases.add(node.dirName);
+          }
+        } else if (arrow === "right") {
+          const node = lastRenderedNodes[cursorIndex];
+          if (node?.kind === "milestone" && node.milestoneIdx !== undefined) {
+            collapsedMilestones.delete(node.milestoneIdx);
+          } else if (node?.kind === "phase" && node.dirName !== undefined) {
+            collapsedPhases.delete(node.dirName);
+          }
+        }
+        renderTree(projectRoot);
+        cursorIndex = Math.max(0, Math.min(cursorIndex, lastRenderedNodes.length - 1));
+        return; // consumed — do NOT pass to parseQuitSequence
+      }
+
+      // 4. Mouse scroll wheel — SGR encoded sequences
+      const mouseScroll = parseMouseScroll(chunk);
+      if (mouseScroll !== null) {
+        const height = getEffectiveHeight();
+        const total = lastRenderedLines.length;
+        const scrollable = total > height;
+        const contentHeight = scrollable ? height - 1 : height;
+        scrollViewport(mouseScroll === "up" ? -3 : 3, total, contentHeight);
+        renderTree(projectRoot);
+        return;
+      }
+
+      // 5. Quit sequences (qq, EscEsc, Ctrl+C)
+      if (parseQuitSequence(chunk)) {
+        void shutdown(watcher, gsdDir);
+      }
+    });
+  }
+
+  // Re-render on terminal resize — clamp viewport offset and cursor before re-render (Pitfall 4)
+  process.stdout.on("resize", () => {
+    const height = getEffectiveHeight();
+    const total = lastRenderedLines.length;
+    const scrollable = total > height;
+    const contentHeight = scrollable ? height - 1 : height;
+    const maxOffset = Math.max(0, total - contentHeight);
+    if (viewportOffset > maxOffset) {
+      viewportOffset = maxOffset;
+    }
+    // Clamp cursor index after resize (node count may change at new width)
+    cursorIndex = Math.max(0, Math.min(cursorIndex, Math.max(0, lastRenderedNodes.length - 1)));
+    renderTree(projectRoot);
+  });
+}

--- a/src/resources/extensions/gsd-watch/tests/watch-orchestrator.test.ts
+++ b/src/resources/extensions/gsd-watch/tests/watch-orchestrator.test.ts
@@ -1,0 +1,287 @@
+// GSD Watch — Unit tests for the watch orchestrator (tmux guard, singleton lock, pane creation)
+// Copyright (c) 2026 Jeremy McSpadden <jeremy@fluxlabs.net>
+
+import { describe, test, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import {
+  buildTmuxInstallHint,
+  readWatchLock,
+  writeWatchLock,
+  isWatchPidAlive,
+} from "../orchestrator.js";
+import type { WatchLockData } from "../types.js";
+
+// ─── Test 7: buildTmuxInstallHint ────────────────────────────────────────────
+
+describe("buildTmuxInstallHint", () => {
+  test("Test 7a: returns brew install hint on darwin", () => {
+    // buildTmuxInstallHint reads platform() — on darwin this will return the brew hint
+    // We can only verify the actual platform OR mock process.platform. Since the function
+    // uses os.platform(), test the string directly on the current platform.
+    const hint = buildTmuxInstallHint();
+    assert.ok(typeof hint === "string" && hint.length > 0, "should return a non-empty string");
+  });
+
+  test("Test 7b: returns apt install hint for linux string", () => {
+    // We test the exported function directly.
+    // The function returns platform-specific hints, and the platform is fixed at test time.
+    // Since we cannot easily mock os.platform() in node:test without module mocking,
+    // we verify it contains one of the known hint phrases.
+    const hint = buildTmuxInstallHint();
+    const knownHints = ["brew install tmux", "apt install tmux", "https://github.com/tmux/tmux"];
+    const hasKnownHint = knownHints.some((h) => hint.includes(h));
+    assert.ok(hasKnownHint, `hint "${hint}" should contain one of the known install phrases`);
+  });
+});
+
+// ─── Tests 8-10: readWatchLock, writeWatchLock ───────────────────────────────
+
+describe("readWatchLock and writeWatchLock", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "watch-lock-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test("Test 8: readWatchLock returns null when lock file does not exist", () => {
+    const result = readWatchLock(tmpDir);
+    assert.equal(result, null, "should return null for missing lock file");
+  });
+
+  test("Test 9: readWatchLock returns parsed WatchLockData when lock file exists with valid JSON", () => {
+    const data: WatchLockData = {
+      pid: 12345,
+      paneId: "%7",
+      startedAt: "2026-01-01T00:00:00.000Z",
+      projectRoot: "/project/root",
+    };
+    writeFileSync(join(tmpDir, "watch.lock"), JSON.stringify(data));
+
+    const result = readWatchLock(tmpDir);
+    assert.deepEqual(result, data, "should return parsed lock data");
+  });
+
+  test("Test 10: writeWatchLock creates .gsd/ directory if needed and writes valid JSON", () => {
+    const nestedDir = join(tmpDir, "nested", ".gsd");
+    const data: WatchLockData = {
+      pid: 99999,
+      paneId: "%3",
+      startedAt: "2026-01-01T12:00:00.000Z",
+      projectRoot: "/some/project",
+    };
+
+    writeWatchLock(nestedDir, data);
+
+    const result = readWatchLock(nestedDir);
+    assert.deepEqual(result, data, "should write and read back lock data correctly");
+  });
+});
+
+// ─── isWatchPidAlive ─────────────────────────────────────────────────────────
+
+describe("isWatchPidAlive", () => {
+  test("returns true for current process PID (alive)", () => {
+    assert.equal(isWatchPidAlive(process.pid), true, "current process should be alive");
+  });
+
+  test("returns false for a dead PID (999999)", () => {
+    // PID 999999 is virtually always dead — if it somehow exists, the test may fail on
+    // that specific machine, but this is the standard test-idiom for dead PIDs.
+    assert.equal(isWatchPidAlive(999999), false, "PID 999999 should not be alive");
+  });
+
+  test("returns false for non-integer PID", () => {
+    assert.equal(isWatchPidAlive(NaN), false);
+    assert.equal(isWatchPidAlive(1.5), false);
+    assert.equal(isWatchPidAlive(-1), false);
+    assert.equal(isWatchPidAlive(0), false);
+  });
+});
+
+// ─── Test 1-6: handleWatch behavior via mocking ──────────────────────────────
+// These tests verify handleWatch's behavior by mocking execFileSync and ctx.ui.notify.
+// Since node:test doesn't have built-in module mocking, we test the guard logic
+// through the exported helpers and verify the function signature / integration paths.
+
+describe("handleWatch tmux guard and singleton guard", () => {
+  let tmpDir: string;
+  const originalTmux = process.env.TMUX;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "watch-handle-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+    // Restore TMUX env var
+    if (originalTmux === undefined) {
+      delete process.env.TMUX;
+    } else {
+      process.env.TMUX = originalTmux;
+    }
+  });
+
+  test("Test 1: handleWatch outside tmux calls ctx.ui.notify and returns without execFileSync", async () => {
+    // We import handleWatch dynamically and verify it calls notify when TMUX is unset.
+    // We use a mock ctx that tracks notify calls and a mock execFileSync that throws if called.
+    delete process.env.TMUX;
+
+    const { handleWatch } = await import("../orchestrator.js");
+
+    let notifyCalled = false;
+    let notifyMessage = "";
+    let execCalled = false;
+
+    const mockCtx = {
+      cwd: tmpDir,
+      ui: {
+        notify: (msg: string, _severity?: string) => {
+          notifyCalled = true;
+          notifyMessage = msg;
+        },
+      },
+    };
+
+    // Override execFileSync during this test by patching the module instance.
+    // Since we can't easily mock ESM internals, we verify by checking that the function
+    // does NOT throw (which it would if it tried to run tmux) and that notify IS called.
+    await handleWatch("", mockCtx as any);
+
+    assert.ok(notifyCalled, "ctx.ui.notify should be called when TMUX is not set");
+    assert.ok(
+      notifyMessage.includes("tmux is required"),
+      `notification should mention tmux requirement, got: "${notifyMessage}"`,
+    );
+    void execCalled; // unused in this path
+  });
+
+  test("Test 2: handleWatch outside tmux on darwin includes brew install tmux in message", async () => {
+    delete process.env.TMUX;
+
+    const { handleWatch, buildTmuxInstallHint: hint } = await import("../orchestrator.js");
+
+    let notifyMessage = "";
+    const mockCtx = {
+      cwd: tmpDir,
+      ui: {
+        notify: (msg: string, _severity?: string) => {
+          notifyMessage = msg;
+        },
+      },
+    };
+
+    await handleWatch("", mockCtx as any);
+
+    // The message should include the platform-appropriate hint
+    const expectedHint = hint();
+    assert.ok(
+      notifyMessage.includes(expectedHint),
+      `message should include install hint: "${expectedHint}"`,
+    );
+  });
+
+  test("Test 3: buildTmuxInstallHint returns platform-appropriate string for darwin, linux, and unknown", () => {
+    // Direct test of the exported function — platform-specific behavior
+    const hint = buildTmuxInstallHint();
+    assert.ok(typeof hint === "string" && hint.length > 0, "should return a non-empty string");
+
+    // On any platform, the hint should contain a recognizable instruction
+    const knownPhrases = ["brew install tmux", "apt install tmux", "dnf install tmux", "https://github.com/tmux"];
+    const hasPhrase = knownPhrases.some((p) => hint.includes(p));
+    assert.ok(hasPhrase, `hint should contain a known install phrase: "${hint}"`);
+  });
+
+  test("Test 4: handleWatch with active watch lock (PID alive) calls notify with 'Watch already running'", async () => {
+    // Set TMUX so we get past the tmux guard
+    process.env.TMUX = "/tmp/tmux-test-socket,1234,0";
+
+    const { handleWatch, writeWatchLock: writeLock } = await import("../orchestrator.js");
+
+    // Write a lock with the current process's PID (alive)
+    const lockData: WatchLockData = {
+      pid: process.pid,
+      paneId: "%5",
+      startedAt: new Date().toISOString(),
+      projectRoot: tmpDir,
+    };
+
+    mkdirSync(join(tmpDir, ".gsd"), { recursive: true });
+    writeLock(join(tmpDir, ".gsd"), lockData);
+
+    let notifyMessage = "";
+    const mockCtx = {
+      ui: {
+        notify: (msg: string, _severity?: string) => {
+          notifyMessage = msg;
+        },
+      },
+    };
+
+    // We need to mock projectRoot() and gsdRoot() — since we can't easily mock ESM,
+    // we test the guard logic by verifying isWatchPidAlive and readWatchLock directly
+    // rather than calling handleWatch end-to-end (which would call projectRoot()).
+    // The handleWatch function is integration-level; lock helpers are unit-testable.
+    const { readWatchLock, isWatchPidAlive: checkAlive } = await import("../orchestrator.js");
+    const lock = readWatchLock(join(tmpDir, ".gsd"));
+    assert.ok(lock !== null, "lock should be readable");
+    assert.ok(checkAlive(lock!.pid), "PID should be alive");
+    void handleWatch; void mockCtx; void notifyMessage;
+  });
+
+  test("Test 5: stale watch lock (PID dead) is cleaned up before spawning", async () => {
+    const { readWatchLock: rl, writeWatchLock: wl, clearWatchLock: cl, isWatchPidAlive: ia } = await import("../orchestrator.js");
+
+    const gsdDir = join(tmpDir, ".gsd");
+    mkdirSync(gsdDir, { recursive: true });
+
+    // Write a lock with a dead PID
+    const lockData: WatchLockData = {
+      pid: 999999, // almost certainly dead
+      paneId: "%9",
+      startedAt: new Date().toISOString(),
+      projectRoot: tmpDir,
+    };
+
+    wl(gsdDir, lockData);
+
+    // Verify lock exists
+    const lock = rl(gsdDir);
+    assert.ok(lock !== null, "lock should exist after write");
+
+    // Simulate stale lock detection and cleanup
+    if (lock && !ia(lock.pid)) {
+      cl(gsdDir);
+    }
+
+    // Verify lock is gone
+    const afterCleanup = rl(gsdDir);
+    assert.equal(afterCleanup, null, "lock should be removed after stale cleanup");
+  });
+
+  test("Test 6: buildTmuxInstallHint returns 'brew install tmux' reference for darwin platform logic", () => {
+    // We cannot easily change the platform at runtime, so we test the hint function logic
+    // by verifying the function is exported and returns a non-trivial string
+    const hint = buildTmuxInstallHint();
+    assert.ok(hint.length > 10, "hint should be a meaningful message");
+
+    // On macOS (darwin), the hint will reference brew
+    // On Linux, it references apt/dnf
+    // On other platforms, it references the GitHub wiki
+    const validPatterns = [
+      /brew install tmux/,
+      /apt install tmux/,
+      /dnf install tmux/,
+      /tmux\/wiki/,
+    ];
+    const isValid = validPatterns.some((re) => re.test(hint));
+    assert.ok(isValid, `hint "${hint}" should match one of the known install patterns`);
+  });
+});

--- a/src/resources/extensions/gsd-watch/tests/watch-renderer-entry.test.ts
+++ b/src/resources/extensions/gsd-watch/tests/watch-renderer-entry.test.ts
@@ -1,0 +1,546 @@
+// GSD Watch — Unit tests for renderer-entry signal handling, quit key detection, placeholder rendering, and viewport scrolling
+// Copyright (c) 2026 Jeremy McSpadden <jeremy@fluxlabs.net>
+
+import { describe, test, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import {
+  CLEANUP_SIGNALS,
+  parseQuitSequence,
+  resetQuitState,
+  getEffectiveWidth,
+  renderPlaceholder,
+  renderTree,
+  getEffectiveHeight,
+  parseArrowKey,
+  renderViewport,
+  scrollViewport,
+  resetViewportState,
+  getViewportOffset,
+  parseNavKey,
+  resetNavigationState,
+  getCursorIndex,
+  getCollapsedPhases,
+  isHelpOverlayVisible,
+  applyCursorHighlight,
+  renderHelpOverlayLines,
+  ensureCursorInViewport,
+} from "../renderer-entry.js";
+import { visibleWidth } from "@gsd/pi-tui";
+
+describe("CLEANUP_SIGNALS", () => {
+  test("Test 1: CLEANUP_SIGNALS contains exactly SIGTERM, SIGHUP, SIGINT", () => {
+    assert.deepEqual(CLEANUP_SIGNALS, ["SIGTERM", "SIGHUP", "SIGINT"]);
+  });
+});
+
+describe("parseQuitSequence", () => {
+  beforeEach(() => {
+    resetQuitState();
+  });
+
+  test("Test 2: detects 'qq' as a quit signal (two q presses)", () => {
+    const first = parseQuitSequence("q");
+    assert.equal(first, false, "first q should not quit");
+    const second = parseQuitSequence("q");
+    assert.equal(second, true, "second q should quit");
+  });
+
+  test("Test 3: detects double-Esc (\\x1b\\x1b) as a quit signal", () => {
+    const first = parseQuitSequence("\x1b");
+    assert.equal(first, false, "first Esc should not quit");
+    const second = parseQuitSequence("\x1b");
+    assert.equal(second, true, "second Esc should quit");
+  });
+
+  test("Test 4: single 'q' does NOT quit", () => {
+    const result = parseQuitSequence("q");
+    assert.equal(result, false);
+  });
+
+  test("Test 5: single Esc does NOT quit", () => {
+    const result = parseQuitSequence("\x1b");
+    assert.equal(result, false);
+  });
+
+  test("Test 6: resets q state after 500ms timeout", async () => {
+    const first = parseQuitSequence("q");
+    assert.equal(first, false, "first q should not quit");
+
+    // Wait 600ms to exceed the QUIT_TIMEOUT_MS of 500ms
+    await new Promise((resolve) => setTimeout(resolve, 600));
+
+    const second = parseQuitSequence("q");
+    assert.equal(second, false, "second q after timeout should NOT quit (state was reset)");
+  });
+});
+
+describe("getEffectiveWidth", () => {
+  test("Test 7: returns process.stdout.columns when >= 40", () => {
+    const original = process.stdout.columns;
+    // Temporarily override columns
+    Object.defineProperty(process.stdout, "columns", {
+      value: 80,
+      configurable: true,
+      writable: true,
+    });
+    const width = getEffectiveWidth();
+    assert.ok(width >= 80, `expected width >= 80, got ${width}`);
+    Object.defineProperty(process.stdout, "columns", {
+      value: original,
+      configurable: true,
+      writable: true,
+    });
+  });
+
+  test("Test 8: returns 40 when process.stdout.columns is 0 or undefined", () => {
+    const original = process.stdout.columns;
+    Object.defineProperty(process.stdout, "columns", {
+      value: 0,
+      configurable: true,
+      writable: true,
+    });
+    const width = getEffectiveWidth();
+    assert.equal(width, 40, `expected minimum width 40, got ${width}`);
+    Object.defineProperty(process.stdout, "columns", {
+      value: original,
+      configurable: true,
+      writable: true,
+    });
+  });
+});
+
+describe("renderTree", () => {
+  let tmpDir: string;
+  let originalWrite: typeof process.stdout.write;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "renderer-entry-tree-test-"));
+    // Create a minimal .planning/phases/ directory structure with one phase
+    const planningDir = join(tmpDir, ".planning");
+    mkdirSync(join(planningDir, "phases", "02-foundation"), { recursive: true });
+    writeFileSync(join(planningDir, "phases", "02-foundation", "02-CONTEXT.md"), "# Context\n");
+    writeFileSync(join(planningDir, "phases", "02-foundation", "02-01-PLAN.md"), "# Plan\n");
+    originalWrite = process.stdout.write.bind(process.stdout);
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (process.stdout as any).write = originalWrite;
+  });
+
+  test("Test 11: renderTree output contains screen clear sequence", () => {
+    const chunks: string[] = [];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (process.stdout as any).write = (chunk: string) => {
+      chunks.push(chunk);
+      return true;
+    };
+
+    renderTree(tmpDir);
+
+    const output = chunks.join("");
+    assert.ok(
+      output.includes("\x1b[2J\x1b[H"),
+      `Expected screen clear sequence in output, got: ${JSON.stringify(output.slice(0, 100))}`
+    );
+  });
+
+  test("Test 12: renderTree output contains tree drawing characters (not placeholder)", () => {
+    const chunks: string[] = [];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (process.stdout as any).write = (chunk: string) => {
+      chunks.push(chunk);
+      return true;
+    };
+
+    renderTree(tmpDir);
+
+    const output = chunks.join("");
+    const hasTreeChars = output.includes("├──") || output.includes("└──");
+    assert.ok(
+      hasTreeChars,
+      `Expected tree drawing chars (├── or └──) in output, got: ${JSON.stringify(output.slice(0, 200))}`
+    );
+  });
+
+  test("Test 13: renderTree output is non-empty beyond the clear sequence", () => {
+    const chunks: string[] = [];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (process.stdout as any).write = (chunk: string) => {
+      chunks.push(chunk);
+      return true;
+    };
+
+    renderTree(tmpDir);
+
+    const output = chunks.join("");
+    // Strip the clear sequence — remaining content should be non-empty
+    const withoutClear = output.replace("\x1b[2J\x1b[H", "");
+    assert.ok(
+      withoutClear.trim().length > 0,
+      "Expected non-empty content beyond the clear sequence"
+    );
+  });
+});
+
+describe("renderPlaceholder", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "renderer-entry-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test("Test 9: outputs 'Loading project...' text when .planning/ exists", () => {
+    // Create a minimal .planning/ directory
+    const planningDir = join(tmpDir, ".planning");
+    mkdirSync(planningDir, { recursive: true });
+
+    // Capture stdout
+    const chunks: string[] = [];
+    const originalWrite = process.stdout.write.bind(process.stdout);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (process.stdout as any).write = (chunk: string) => {
+      chunks.push(chunk);
+      return true;
+    };
+
+    try {
+      renderPlaceholder(tmpDir);
+    } finally {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (process.stdout as any).write = originalWrite;
+    }
+
+    const output = chunks.join("");
+    assert.ok(output.includes("Loading project..."), `expected 'Loading project...' in output, got: ${output}`);
+  });
+
+  test("Test 10: outputs project name when PROJECT.md is readable", () => {
+    // Create .planning/ with a PROJECT.md containing a heading
+    const planningDir = join(tmpDir, ".planning");
+    mkdirSync(planningDir, { recursive: true });
+    writeFileSync(
+      join(planningDir, "PROJECT.md"),
+      [
+        "# My Test Project",
+        "",
+        "Some description here.",
+      ].join("\n")
+    );
+
+    const chunks: string[] = [];
+    const originalWrite = process.stdout.write.bind(process.stdout);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (process.stdout as any).write = (chunk: string) => {
+      chunks.push(chunk);
+      return true;
+    };
+
+    try {
+      renderPlaceholder(tmpDir);
+    } finally {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (process.stdout as any).write = originalWrite;
+    }
+
+    const output = chunks.join("");
+    assert.ok(
+      output.includes("My Test Project"),
+      `expected project name 'My Test Project' in output, got: ${output}`
+    );
+    assert.ok(
+      output.includes("Loading project..."),
+      `expected 'Loading project...' in output, got: ${output}`
+    );
+  });
+});
+
+// ─── Viewport Scrolling Tests (Tests 14–28) ───────────────────────────────────
+
+describe("getEffectiveHeight", () => {
+  test("Test 14: returns process.stdout.rows when >= 3", () => {
+    const original = process.stdout.rows;
+    Object.defineProperty(process.stdout, "rows", {
+      value: 24,
+      configurable: true,
+      writable: true,
+    });
+    const height = getEffectiveHeight();
+    assert.ok(height >= 24, `expected height >= 24, got ${height}`);
+    Object.defineProperty(process.stdout, "rows", {
+      value: original,
+      configurable: true,
+      writable: true,
+    });
+  });
+
+  test("Test 15: returns 3 (MIN_HEIGHT) when process.stdout.rows is 0 or undefined", () => {
+    const original = process.stdout.rows;
+    Object.defineProperty(process.stdout, "rows", {
+      value: 0,
+      configurable: true,
+      writable: true,
+    });
+    const height = getEffectiveHeight();
+    assert.equal(height, 3, `expected minimum height 3, got ${height}`);
+    Object.defineProperty(process.stdout, "rows", {
+      value: original,
+      configurable: true,
+      writable: true,
+    });
+  });
+});
+
+describe("parseArrowKey", () => {
+  test("Test 16: parseArrowKey(\"\\x1b[A\") returns \"up\"", () => {
+    const result = parseArrowKey("\x1b[A");
+    assert.equal(result, "up", `expected "up", got ${JSON.stringify(result)}`);
+  });
+
+  test("Test 17: parseArrowKey(\"\\x1b[B\") returns \"down\"", () => {
+    const result = parseArrowKey("\x1b[B");
+    assert.equal(result, "down", `expected "down", got ${JSON.stringify(result)}`);
+  });
+
+  test("Test 18: parseArrowKey(\"q\") returns null (non-arrow input)", () => {
+    const result = parseArrowKey("q");
+    assert.equal(result, null, `expected null, got ${JSON.stringify(result)}`);
+  });
+
+  test("Test 19: parseArrowKey(\"\\x1b\") returns null (lone Esc is not an arrow key)", () => {
+    const result = parseArrowKey("\x1b");
+    assert.equal(result, null, `expected null for lone Esc, got ${JSON.stringify(result)}`);
+  });
+});
+
+describe("renderViewport", () => {
+  const makeLines = (count: number): string[] =>
+    Array.from({ length: count }, (_, i) => `line ${i + 1}`);
+
+  test("Test 20: returns all lines joined when total <= height (no status bar)", () => {
+    const lines = makeLines(5);
+    const output = renderViewport(lines, 0, 10, 80);
+    assert.ok(!output.includes("▲"), `expected no ▲ in non-scrollable output, got: ${JSON.stringify(output)}`);
+    assert.ok(!output.includes("▼"), `expected no ▼ in non-scrollable output, got: ${JSON.stringify(output)}`);
+    assert.ok(output.includes("line 1"), "expected line 1 in output");
+    assert.ok(output.includes("line 5"), "expected line 5 in output");
+  });
+
+  test("Test 21: slices lines to contentHeight when total > height, returns sliced output + status bar", () => {
+    const lines = makeLines(20);
+    const output = renderViewport(lines, 0, 10, 80);
+    // With 20 lines and height=10, contentHeight=9, offset=0 → lines 1-9 visible
+    assert.ok(output.includes("line 1"), "expected line 1 in sliced output");
+    assert.ok(!output.includes("line 20"), "expected line 20 NOT in sliced output (out of viewport)");
+    // Status bar should appear
+    assert.ok(output.includes("▼"), "expected ▼ in status bar for scrollable output");
+  });
+
+  test("Test 22: status bar hides ▲ when offset=0 (replaces with space)", () => {
+    const lines = makeLines(20);
+    const output = renderViewport(lines, 0, 10, 80);
+    // At offset=0, ▲ should NOT appear (replaced with space)
+    assert.ok(!output.includes("▲"), `expected no ▲ at offset=0, got: ${JSON.stringify(output.slice(-40))}`);
+    assert.ok(output.includes("▼"), "expected ▼ at offset=0 (content below)");
+  });
+
+  test("Test 23: status bar hides ▼ when at bottom (offset + contentHeight >= total)", () => {
+    const lines = makeLines(12);
+    // height=10, contentHeight=9, offset=3 → bottom: 3+9=12 >= 12 total
+    const output = renderViewport(lines, 3, 10, 80);
+    assert.ok(!output.includes("▼"), `expected no ▼ at bottom, got: ${JSON.stringify(output.slice(-40))}`);
+    assert.ok(output.includes("▲"), "expected ▲ at bottom (content above)");
+  });
+
+  test("Test 24: status bar shows both ▲ and ▼ when in the middle", () => {
+    const lines = makeLines(20);
+    // height=10, contentHeight=9, offset=5 → not at top, not at bottom (5+9=14 < 20)
+    const output = renderViewport(lines, 5, 10, 80);
+    assert.ok(output.includes("▲"), `expected ▲ in middle, got: ${JSON.stringify(output.slice(-40))}`);
+    assert.ok(output.includes("▼"), `expected ▼ in middle, got: ${JSON.stringify(output.slice(-40))}`);
+  });
+});
+
+describe("scrollViewport", () => {
+  beforeEach(() => {
+    resetViewportState();
+  });
+
+  test("Test 25: clamps offset at 0 when scrolling up past top", () => {
+    // viewportOffset starts at 0, scroll up (-1) → should stay at 0
+    scrollViewport(-1, 20, 9);
+    assert.equal(getViewportOffset(), 0, `expected offset=0 at top, got ${getViewportOffset()}`);
+  });
+
+  test("Test 26: clamps offset at max (totalLines - contentHeight) when scrolling down past bottom", () => {
+    // max = 20 - 9 = 11; scroll down 100 times
+    scrollViewport(100, 20, 9);
+    assert.equal(getViewportOffset(), 11, `expected offset=11 at bottom, got ${getViewportOffset()}`);
+  });
+});
+
+describe("resetViewportState", () => {
+  test("Test 27: resetViewportState() resets viewportOffset to 0 (verified via getViewportOffset)", () => {
+    // Scroll down first
+    scrollViewport(5, 20, 9);
+    assert.ok(getViewportOffset() > 0, "expected offset > 0 after scrolling down");
+    // Now reset
+    resetViewportState();
+    assert.equal(getViewportOffset(), 0, `expected offset=0 after reset, got ${getViewportOffset()}`);
+  });
+});
+
+describe("arrow key and quit sequence isolation", () => {
+  beforeEach(() => {
+    resetQuitState();
+    resetViewportState();
+  });
+
+  test("Test 28: parseArrowKey does NOT interfere with parseQuitSequence — after arrow key, qq still triggers quit", () => {
+    // Parse an arrow key first
+    const arrowResult = parseArrowKey("\x1b[A");
+    assert.equal(arrowResult, "up", "arrow key should return 'up'");
+
+    // Simulate what the data handler does: arrow was handled, parseQuitSequence NOT called for arrow chunk
+    // Now verify quit state machine is clean: two q presses should still quit
+    const firstQ = parseQuitSequence("q");
+    assert.equal(firstQ, false, "first q should not quit");
+    const secondQ = parseQuitSequence("q");
+    assert.equal(secondQ, true, "second q should quit (parseArrowKey did not corrupt quit state)");
+  });
+});
+
+// ─── Navigation Tests (Tests 29–47) ──────────────────────────────────────────
+
+describe("parseNavKey", () => {
+  test("Test 29: parseNavKey(\"j\") returns \"cursor-down\"", () => {
+    assert.equal(parseNavKey("j"), "cursor-down");
+  });
+
+  test("Test 30: parseNavKey(\"k\") returns \"cursor-up\"", () => {
+    assert.equal(parseNavKey("k"), "cursor-up");
+  });
+
+  test("Test 31: parseNavKey(\"h\") returns \"collapse\"", () => {
+    assert.equal(parseNavKey("h"), "collapse");
+  });
+
+  test("Test 32: parseNavKey(\"l\") returns \"expand\"", () => {
+    assert.equal(parseNavKey("l"), "expand");
+  });
+
+  test("Test 33: parseNavKey(\"g\") returns \"jump-top\"", () => {
+    assert.equal(parseNavKey("g"), "jump-top");
+  });
+
+  test("Test 34: parseNavKey(\"G\") returns \"jump-bottom\"", () => {
+    assert.equal(parseNavKey("G"), "jump-bottom");
+  });
+
+  test("Test 35: parseNavKey(\"?\") returns \"help\"", () => {
+    assert.equal(parseNavKey("?"), "help");
+  });
+
+  test("Test 36: parseNavKey(\"x\") returns null (non-nav key)", () => {
+    assert.equal(parseNavKey("x"), null);
+  });
+
+  test("Test 37: parseNavKey(\"\\x1b[A\") returns null (arrow key is not a nav key)", () => {
+    assert.equal(parseNavKey("\x1b[A"), null);
+  });
+});
+
+describe("resetNavigationState", () => {
+  test("Test 38: resetNavigationState() sets cursorIndex to 0, clears collapsedPhases, sets helpOverlayVisible to false", () => {
+    // The state starts clean, but we call reset to ensure deterministic behavior
+    resetNavigationState();
+    assert.equal(getCursorIndex(), 0, "cursorIndex should be 0 after reset");
+    assert.equal(getCollapsedPhases().size, 0, "collapsedPhases should be empty after reset");
+    assert.equal(isHelpOverlayVisible(), false, "helpOverlayVisible should be false after reset");
+  });
+});
+
+describe("applyCursorHighlight", () => {
+  test("Test 39: applyCursorHighlight wraps a line in \\x1b[7m...\\x1b[0m and pads to width", () => {
+    const result = applyCursorHighlight("hello", 10);
+    assert.ok(result.startsWith("\x1b[7m"), "should start with reverse video escape");
+    assert.ok(result.endsWith("\x1b[0m"), "should end with SGR reset escape");
+  });
+
+  test("Test 40: applyCursorHighlight pads short line (10 visible chars) to full width (40) with spaces inside reverse video", () => {
+    const line = "0123456789"; // 10 visible chars
+    const width = 40;
+    const result = applyCursorHighlight(line, width);
+    // Strip ANSI escapes to measure the visible content
+    const inner = result.replace(/\x1b\[\d+m/g, "");
+    const innerWidth = visibleWidth(inner);
+    assert.equal(innerWidth, width, `expected padded width ${width}, got ${innerWidth}`);
+  });
+});
+
+describe("renderHelpOverlayLines", () => {
+  test("Test 41: renderHelpOverlayLines(60) returns array containing \"KEYBINDINGS\" header", () => {
+    const lines = renderHelpOverlayLines(60);
+    assert.ok(lines.some(l => l.includes("KEYBINDINGS")), "expected KEYBINDINGS header in overlay lines");
+  });
+
+  test("Test 42: renderHelpOverlayLines(60) returns array containing \"BADGE LEGEND\" header", () => {
+    const lines = renderHelpOverlayLines(60);
+    assert.ok(lines.some(l => l.includes("BADGE LEGEND")), "expected BADGE LEGEND header in overlay lines");
+  });
+
+  test("Test 43: renderHelpOverlayLines(60) includes \"j / k\" keybinding entry", () => {
+    const lines = renderHelpOverlayLines(60);
+    assert.ok(lines.some(l => l.includes("j / k")), "expected j / k keybinding entry in overlay lines");
+  });
+
+  test("Test 44: renderHelpOverlayLines(60) includes all 7 badge legend entries (CONTEXT through HUMAN-UAT)", () => {
+    const lines = renderHelpOverlayLines(60);
+    const combined = lines.join("\n");
+    const expectedBadges = ["CONTEXT", "RESEARCH", "UI-SPEC", "PLAN", "SUMMARY", "VERIFICATION", "HUMAN-UAT"];
+    for (const badge of expectedBadges) {
+      assert.ok(combined.includes(badge), `expected badge legend entry: ${badge}`);
+    }
+  });
+});
+
+describe("ensureCursorInViewport", () => {
+  beforeEach(() => {
+    resetViewportState();
+  });
+
+  test("Test 45: ensureCursorInViewport adjusts viewportOffset when cursorIndex is below viewport (cursor > offset + contentHeight - 1)", () => {
+    // Set viewport offset to 0, contentHeight=5, cursor=7 → cursor is below viewport (7 >= 0+5)
+    ensureCursorInViewport(7, 20, 5);
+    // Expected: viewportOffset = 7 - 5 + 1 = 3
+    assert.equal(getViewportOffset(), 3, `expected viewportOffset=3, got ${getViewportOffset()}`);
+  });
+
+  test("Test 46: ensureCursorInViewport adjusts viewportOffset when cursorIndex is above viewport (cursor < offset)", () => {
+    // First scroll down to set offset=10
+    scrollViewport(10, 30, 5);
+    assert.equal(getViewportOffset(), 10, "precondition: offset should be 10");
+    // Now cursor=3 is above viewport (3 < 10)
+    ensureCursorInViewport(3, 30, 5);
+    // Expected: viewportOffset = cursor = 3
+    assert.equal(getViewportOffset(), 3, `expected viewportOffset=3 (set to cursor), got ${getViewportOffset()}`);
+  });
+
+  test("Test 47: ensureCursorInViewport does NOT adjust viewportOffset when cursor is within viewport bounds", () => {
+    // Set offset=2 via scrollViewport, contentHeight=5, cursor=4 → in view (2 <= 4 < 2+5=7)
+    scrollViewport(2, 30, 5);
+    assert.equal(getViewportOffset(), 2, "precondition: offset should be 2");
+    ensureCursorInViewport(4, 30, 5);
+    // Viewport offset should remain 2
+    assert.equal(getViewportOffset(), 2, `expected viewportOffset unchanged at 2, got ${getViewportOffset()}`);
+  });
+});

--- a/src/resources/extensions/gsd-watch/tests/watch-tree-model.test.ts
+++ b/src/resources/extensions/gsd-watch/tests/watch-tree-model.test.ts
@@ -1,0 +1,227 @@
+// GSD Watch — Unit tests for tree model: filesystem scan, badge detection, status derivation
+// Copyright (c) 2026 Jeremy McSpadden <jeremy@fluxlabs.net>
+
+import { describe, test, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { buildMilestoneTree } from "../tree-model.js";
+import type { MilestoneNode, PhaseNode, PlanNode } from "../types.js";
+
+// ─── Fixture Setup ────────────────────────────────────────────────────────────
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "watch-tree-model-test-"));
+
+  // Create base structure
+  const phasesDir = join(tmpDir, ".planning", "phases");
+  mkdirSync(phasesDir, { recursive: true });
+
+  // Phase 02-foundation: 3 plans all done, with lifecycle files
+  const p02 = join(phasesDir, "02-foundation");
+  mkdirSync(p02);
+  writeFileSync(join(p02, "02-CONTEXT.md"), "");
+  writeFileSync(join(p02, "02-RESEARCH.md"), "");
+  writeFileSync(join(p02, "02-01-PLAN.md"), "");
+  writeFileSync(join(p02, "02-01-SUMMARY.md"), "");
+  writeFileSync(join(p02, "02-02-PLAN.md"), "");
+  writeFileSync(join(p02, "02-02-SUMMARY.md"), "");
+  writeFileSync(join(p02, "02-03-PLAN.md"), "");
+  writeFileSync(join(p02, "02-03-SUMMARY.md"), "");
+  writeFileSync(join(p02, "02-VERIFICATION.md"), "");
+  writeFileSync(join(p02, "02-HUMAN-UAT.md"), "");
+
+  // Phase 03-core-renderer: 1 plan active (no summary)
+  const p03 = join(phasesDir, "03-core-renderer");
+  mkdirSync(p03);
+  writeFileSync(join(p03, "03-CONTEXT.md"), "");
+  writeFileSync(join(p03, "03-01-PLAN.md"), "");
+
+  // ROADMAP.md at .planning/ root
+  writeFileSync(
+    join(tmpDir, ".planning", "ROADMAP.md"),
+    "# Roadmap — GSD Watch\n\nSome roadmap content here.\n"
+  );
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+// ─── Core tree structure ───────────────────────────────────────────────────────
+
+describe("buildMilestoneTree - core structure", () => {
+  test("Test 1: returns MilestoneNode with 2 PhaseNodes for fixture directory", () => {
+    const tree = buildMilestoneTree(tmpDir);
+    assert.equal(tree.phases.length, 2, `expected 2 phases, got ${tree.phases.length}`);
+  });
+
+  test("Test 2: phases are sorted by numeric prefix [02, 03]", () => {
+    const tree = buildMilestoneTree(tmpDir);
+    assert.equal(tree.phases[0].number, 2, `first phase number should be 2`);
+    assert.equal(tree.phases[1].number, 3, `second phase number should be 3`);
+  });
+
+  test("Test 3: PhaseNode dirNames are correct", () => {
+    const tree = buildMilestoneTree(tmpDir);
+    assert.equal(tree.phases[0].dirName, "02-foundation");
+    assert.equal(tree.phases[1].dirName, "03-core-renderer");
+  });
+
+  test("Test 4: milestone label is extracted from ROADMAP.md heading", () => {
+    const tree = buildMilestoneTree(tmpDir);
+    assert.ok(
+      tree.label.includes("GSD Watch") || tree.label.length > 0,
+      `expected non-empty label, got: "${tree.label}"`
+    );
+  });
+});
+
+// ─── Badge detection ─────────────────────────────────────────────────────────
+
+describe("buildMilestoneTree - badge detection", () => {
+  test("Test 5: phase with CONTEXT.md and PLAN.md produces correct badge array", () => {
+    // 03-core-renderer has: 03-CONTEXT.md, 03-01-PLAN.md
+    // badges = [CONTEXT, RESEARCH, UI-SPEC, PLAN, SUMMARY, VERIFICATION, HUMAN-UAT]
+    // Expected: [true, false, false, true, false, false, false]
+    const tree = buildMilestoneTree(tmpDir);
+    const phase03 = tree.phases[1]; // 03-core-renderer
+    assert.deepEqual(
+      phase03.badges,
+      [true, false, false, true, false, false, false],
+      `badges mismatch for 03-core-renderer: ${JSON.stringify(phase03.badges)}`
+    );
+  });
+
+  test("Test 6: phase with CONTEXT, RESEARCH, VERIFICATION, HUMAN-UAT produces correct badges", () => {
+    // 02-foundation has: 02-CONTEXT.md, 02-RESEARCH.md, 02-VERIFICATION.md, 02-HUMAN-UAT.md
+    // badges = [CONTEXT, RESEARCH, UI-SPEC, PLAN, SUMMARY, VERIFICATION, HUMAN-UAT]
+    // Expected: [true, true, false, true, true, false, true]  (PLAN/SUMMARY from plan files)
+    const tree = buildMilestoneTree(tmpDir);
+    const phase02 = tree.phases[0]; // 02-foundation
+    // CONTEXT=true, RESEARCH=true, UI-SPEC=false, PLAN=true (02-01-PLAN etc), SUMMARY=true (02-01-SUMMARY etc), VERIFICATION=true, HUMAN-UAT=true
+    assert.equal(phase02.badges[0], true, "CONTEXT badge should be true");
+    assert.equal(phase02.badges[1], true, "RESEARCH badge should be true");
+    assert.equal(phase02.badges[2], false, "UI-SPEC badge should be false");
+    assert.equal(phase02.badges[5], true, "VERIFICATION badge should be true");
+    assert.equal(phase02.badges[6], true, "HUMAN-UAT badge should be true");
+  });
+
+  test("Test 7: badges array always has exactly 7 elements", () => {
+    const tree = buildMilestoneTree(tmpDir);
+    for (const phase of tree.phases) {
+      assert.equal(phase.badges.length, 7, `badges should have 7 elements for ${phase.dirName}`);
+    }
+  });
+});
+
+// ─── Plan status derivation ───────────────────────────────────────────────────
+
+describe("buildMilestoneTree - plan status", () => {
+  test("Test 8: plan with matching SUMMARY file returns status=done", () => {
+    const tree = buildMilestoneTree(tmpDir);
+    const phase02 = tree.phases[0]; // 02-foundation
+    const plan01 = phase02.plans.find((p) => p.id === "02-01");
+    assert.ok(plan01, "plan 02-01 should exist");
+    assert.equal(plan01!.status, "done", `02-01 has a SUMMARY so should be done, got ${plan01!.status}`);
+  });
+
+  test("Test 9: plan without SUMMARY file returns status=active", () => {
+    const tree = buildMilestoneTree(tmpDir);
+    const phase03 = tree.phases[1]; // 03-core-renderer
+    const plan01 = phase03.plans.find((p) => p.id === "03-01");
+    assert.ok(plan01, "plan 03-01 should exist");
+    assert.equal(plan01!.status, "active", `03-01 has no SUMMARY so should be active, got ${plan01!.status}`);
+  });
+});
+
+// ─── Phase status roll-up ──────────────────────────────────────────────────────
+
+describe("buildMilestoneTree - phase status", () => {
+  test("Test 10: phase with no plan files returns status=pending", () => {
+    // Create an empty phase dir with no plan files
+    const emptyPhaseDir = join(tmpDir, ".planning", "phases", "01-empty");
+    mkdirSync(emptyPhaseDir);
+    const tree = buildMilestoneTree(tmpDir);
+    const emptyPhase = tree.phases.find((p) => p.dirName === "01-empty");
+    assert.ok(emptyPhase, "01-empty phase should exist");
+    assert.equal(emptyPhase!.status, "pending", `empty phase should be pending, got ${emptyPhase!.status}`);
+  });
+
+  test("Test 11: phase where all plans are done returns status=done", () => {
+    const tree = buildMilestoneTree(tmpDir);
+    const phase02 = tree.phases.find((p) => p.dirName === "02-foundation");
+    assert.ok(phase02, "02-foundation should exist");
+    assert.equal(phase02!.status, "done", `all plans done, phase should be done, got ${phase02!.status}`);
+  });
+
+  test("Test 12: phase with some done and some active returns status=active", () => {
+    // Add another plan without summary to 02-foundation to make it mixed
+    const p02 = join(tmpDir, ".planning", "phases", "02-foundation");
+    writeFileSync(join(p02, "02-04-PLAN.md"), "");
+    // No 02-04-SUMMARY.md — so one plan is active
+    const tree = buildMilestoneTree(tmpDir);
+    const phase02 = tree.phases.find((p) => p.dirName === "02-foundation");
+    assert.ok(phase02, "02-foundation should exist");
+    assert.equal(phase02!.status, "active", `mixed done/active plans should make phase active, got ${phase02!.status}`);
+  });
+});
+
+// ─── Milestone status roll-up ─────────────────────────────────────────────────
+
+describe("buildMilestoneTree - milestone status", () => {
+  test("Test 13: milestone with all-done phases returns status=done", () => {
+    // Create a dir with only 02-foundation (all plans done)
+    const allDoneDir = mkdtempSync(join(tmpdir(), "all-done-"));
+    try {
+      const phasesDir = join(allDoneDir, ".planning", "phases");
+      const p = join(phasesDir, "02-foundation");
+      mkdirSync(p, { recursive: true });
+      writeFileSync(join(p, "02-01-PLAN.md"), "");
+      writeFileSync(join(p, "02-01-SUMMARY.md"), "");
+      const tree = buildMilestoneTree(allDoneDir);
+      assert.equal(tree.status, "done", `all phases done should make milestone done, got ${tree.status}`);
+    } finally {
+      rmSync(allDoneDir, { recursive: true, force: true });
+    }
+  });
+
+  test("Test 14: milestone with one active phase returns status=active", () => {
+    const tree = buildMilestoneTree(tmpDir);
+    // 03-core-renderer is active (plan without summary)
+    assert.equal(tree.status, "active", `milestone with active phase should be active, got ${tree.status}`);
+  });
+});
+
+// ─── Edge cases ───────────────────────────────────────────────────────────────
+
+describe("buildMilestoneTree - edge cases", () => {
+  test("Test 15: missing .planning/phases/ returns MilestoneNode with empty phases array", () => {
+    const emptyDir = mkdtempSync(join(tmpdir(), "no-phases-"));
+    try {
+      const tree = buildMilestoneTree(emptyDir);
+      assert.equal(tree.phases.length, 0, `expected empty phases array`);
+    } finally {
+      rmSync(emptyDir, { recursive: true, force: true });
+    }
+  });
+
+  test("Test 16: non-directory entries in phases/ are ignored", () => {
+    // Add a stray .md file directly in phases/
+    const phasesDir = join(tmpDir, ".planning", "phases");
+    writeFileSync(join(phasesDir, "stray-notes.md"), "some notes");
+    const tree = buildMilestoneTree(tmpDir);
+    // Should still have exactly 2 phases (not 3)
+    assert.equal(tree.phases.length, 2, `stray file should be ignored, got ${tree.phases.length} phases`);
+  });
+
+  test("Test 17: phase label humanization — '03-core-renderer' produces label '3. Core Renderer'", () => {
+    const tree = buildMilestoneTree(tmpDir);
+    const phase03 = tree.phases[1]; // 03-core-renderer
+    assert.equal(phase03.label, "3. Core Renderer", `expected '3. Core Renderer', got '${phase03.label}'`);
+  });
+});

--- a/src/resources/extensions/gsd-watch/tests/watch-tree-renderer.test.ts
+++ b/src/resources/extensions/gsd-watch/tests/watch-tree-renderer.test.ts
@@ -1,0 +1,403 @@
+// GSD Watch — Unit tests for tree renderer: layout, badges, width-aware truncation
+// Copyright (c) 2026 Jeremy McSpadden <jeremy@fluxlabs.net>
+
+import { describe, test, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { visibleWidth } from "@gsd/pi-tui";
+import { renderTreeLines } from "../tree-renderer.js";
+import type { VisibleNode } from "../tree-renderer.js";
+import type { MilestoneNode, PhaseNode, PlanNode } from "../types.js";
+
+/** Strip ANSI escape sequences for plain-text assertions. */
+function stripAnsi(s: string): string {
+  return s.replace(/\x1b\[[0-9;]*m/g, "");
+}
+
+// ─── Fixture Data ─────────────────────────────────────────────────────────────
+
+const FIXTURE_MILESTONE: MilestoneNode = {
+  label: "GSD Watch",
+  status: "active",
+  phases: [
+    {
+      number: 2,
+      dirName: "02-foundation",
+      label: "2. Foundation",
+      status: "done",
+      badges: [true, true, false, true, true, true, true],
+      plans: [
+        { id: "02-01", label: "Plan 01", status: "done", hasSummary: true },
+        { id: "02-02", label: "Plan 02", status: "done", hasSummary: true },
+        { id: "02-03", label: "Plan 03", status: "done", hasSummary: true },
+      ],
+    },
+    {
+      number: 3,
+      dirName: "03-core-renderer",
+      label: "3. Core Renderer",
+      status: "active",
+      badges: [true, true, false, false, false, false, false],
+      plans: [
+        { id: "03-01", label: "Plan 01", status: "active", hasSummary: false },
+      ],
+    },
+  ],
+};
+
+const EMPTY_MILESTONE: MilestoneNode = {
+  label: "Empty Project",
+  status: "pending",
+  phases: [],
+};
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("renderTreeLines — box-drawing characters", () => {
+  test("Test 1: output contains box-drawing ├── for non-last phase", () => {
+    const { lines } = renderTreeLines(FIXTURE_MILESTONE, 80);
+    const hasMiddleBox = lines.some((l) => l.includes("├──"));
+    assert.ok(hasMiddleBox, `Expected '├──' in output, got:\n${lines.join("\n")}`);
+  });
+
+  test("Test 2: output contains box-drawing └── for last phase", () => {
+    const { lines } = renderTreeLines(FIXTURE_MILESTONE, 80);
+    const hasLastBox = lines.some((l) => l.includes("└──"));
+    assert.ok(hasLastBox, `Expected '└──' in output, got:\n${lines.join("\n")}`);
+  });
+
+  test("Test 3: last phase uses └── prefix, non-last uses ├──", () => {
+    const { lines } = renderTreeLines(FIXTURE_MILESTONE, 80);
+    const stripped = lines.map(stripAnsi);
+    // Find phase lines (they start with ├── or └── directly, not with │)
+    const phaseLines = stripped.filter((l) => l.startsWith("├──") || l.startsWith("└──"));
+    assert.ok(phaseLines.length >= 2, `Expected at least 2 phase lines, got: ${phaseLines.length}`);
+    // Last phase line must use └──
+    assert.ok(
+      phaseLines[phaseLines.length - 1].startsWith("└──"),
+      `Expected last phase line to start with '└──', got: ${phaseLines[phaseLines.length - 1]}`
+    );
+    // Non-last phase lines must use ├──
+    for (let i = 0; i < phaseLines.length - 1; i++) {
+      assert.ok(
+        phaseLines[i].startsWith("├──"),
+        `Expected non-last phase line to start with '├──', got: ${phaseLines[i]}`
+      );
+    }
+  });
+});
+
+describe("renderTreeLines — status icons", () => {
+  test("Test 4: done phase shows ✓ icon", () => {
+    const { lines } = renderTreeLines(FIXTURE_MILESTONE, 80);
+    const hasDone = lines.some((l) => l.includes("✓"));
+    assert.ok(hasDone, `Expected '✓' icon in output, got:\n${lines.join("\n")}`);
+  });
+
+  test("Test 5: active node shows ◆ icon", () => {
+    const { lines } = renderTreeLines(FIXTURE_MILESTONE, 80);
+    const hasActive = lines.some((l) => l.includes("◆"));
+    assert.ok(hasActive, `Expected '◆' icon in output, got:\n${lines.join("\n")}`);
+  });
+
+  test("Test 6: pending milestone shows ○ icon", () => {
+    const { lines } = renderTreeLines(EMPTY_MILESTONE, 80);
+    const hasPending = lines.some((l) => l.includes("○"));
+    assert.ok(hasPending, `Expected '○' icon in output, got:\n${lines.join("\n")}`);
+  });
+
+  test("Test 7: milestone header includes label and status icon", () => {
+    const { lines } = renderTreeLines(FIXTURE_MILESTONE, 80);
+    assert.ok(lines.length > 0, "Expected at least one line");
+    const header = lines[0];
+    assert.ok(
+      header.includes("GSD Watch"),
+      `Expected milestone label in header, got: ${header}`
+    );
+    assert.ok(
+      header.includes("◆"),
+      `Expected active icon '◆' in milestone header, got: ${header}`
+    );
+  });
+});
+
+describe("renderTreeLines — badge formatting", () => {
+  test("Test 8: badge string for [true,true,false,true,false,false,false] renders as ●●○●○○○", () => {
+    // Create a milestone with a single phase with that exact badge pattern
+    const milestone: MilestoneNode = {
+      label: "Test",
+      status: "active",
+      phases: [
+        {
+          number: 1,
+          dirName: "01-test",
+          label: "1. Test",
+          status: "active",
+          badges: [true, true, false, true, false, false, false],
+          plans: [],
+        },
+      ],
+    };
+    const { lines } = renderTreeLines(milestone, 80);
+    const phaseLine = lines.find((l) => l.includes("1. Test"));
+    assert.ok(phaseLine, "Expected phase line to exist");
+    const stripped = stripAnsi(phaseLine!);
+    assert.ok(
+      stripped.includes("●●○●○○○"),
+      `Expected badge string '●●○●○○○' in phase line, got: ${stripped}`
+    );
+  });
+
+  test("Test 9: phase line at width=80 includes badge circles", () => {
+    const { lines } = renderTreeLines(FIXTURE_MILESTONE, 80);
+    // Phase with done badges should show filled circles
+    const foundationLine = lines.find((l) => l.includes("2. Foundation"));
+    assert.ok(foundationLine, "Expected Foundation phase line");
+    const hasBadge = foundationLine!.includes("●") || foundationLine!.includes("○");
+    assert.ok(hasBadge, `Expected badge circles in wide (80) phase line, got: ${foundationLine}`);
+  });
+});
+
+describe("renderTreeLines — width-aware layout", () => {
+  test("Test 10: phase line at width=30 still shows phase name without overflow", () => {
+    const { lines } = renderTreeLines(FIXTURE_MILESTONE, 30);
+    for (const line of lines) {
+      const w = visibleWidth(line);
+      assert.ok(
+        w <= 30,
+        `Line exceeds width 30 (got ${w}): ${line}`
+      );
+    }
+    // Phase name should still appear
+    const hasFoundation = lines.some((l) => l.includes("Foundation") || l.includes("Found"));
+    assert.ok(hasFoundation, `Expected phase name in 30-wide output, got:\n${lines.join("\n")}`);
+  });
+
+  test("Test 11: phase line at width=20 drops badges, shows truncated name", () => {
+    const { lines } = renderTreeLines(FIXTURE_MILESTONE, 20);
+    for (const line of lines) {
+      const w = visibleWidth(line);
+      assert.ok(
+        w <= 20,
+        `Line exceeds width 20 (got ${w}): ${line}`
+      );
+    }
+  });
+
+  test("Test 12: no line in output exceeds the specified width", () => {
+    const widths = [20, 30, 40, 60, 80, 120];
+    for (const width of widths) {
+      const { lines } = renderTreeLines(FIXTURE_MILESTONE, width);
+      for (const line of lines) {
+        const w = visibleWidth(line);
+        assert.ok(
+          w <= width,
+          `Line exceeds width ${width} (got ${w}): ${line}`
+        );
+      }
+    }
+  });
+});
+
+describe("renderTreeLines — plan indentation", () => {
+  test("Test 13: plan lines are indented deeper than phase lines", () => {
+    const { lines } = renderTreeLines(FIXTURE_MILESTONE, 80);
+    const stripped = lines.map(stripAnsi);
+    // Phase lines start with ├── or └── (4 chars)
+    // Plan lines start with │   ├── or │   └── or     ├── etc (8+ chars)
+    const phaseLines = stripped.filter((l) => l.startsWith("├──") || l.startsWith("└──"));
+    const planLines = stripped.filter((l) => l.startsWith("│   ") || l.startsWith("    "));
+    assert.ok(planLines.length > 0, "Expected at least one plan line");
+    assert.ok(phaseLines.length > 0, "Expected at least one phase line");
+    // Plan prefix should be longer than phase prefix
+    const phasePrefix = phaseLines[0].match(/^([├└]──\s)/)?.[1] ?? "";
+    const planPrefix = planLines[0].match(/^(\s*[│ ]\s*[├└]──\s)/)?.[1] ?? "";
+    assert.ok(
+      planPrefix.length > phasePrefix.length,
+      `Expected plan prefix (${JSON.stringify(planPrefix)}) to be longer than phase prefix (${JSON.stringify(phasePrefix)})`
+    );
+  });
+
+  test("Test 14: last plan under last phase uses '    └── ' prefix (spaces, not │)", () => {
+    const { lines } = renderTreeLines(FIXTURE_MILESTONE, 80);
+    const stripped = lines.map(stripAnsi);
+    // 03-core-renderer is the last phase and has one plan
+    // That plan should start with "    └── " (4 spaces + └──)
+    const corePlanLine = stripped.find((l) => l.startsWith("    └──") && l.includes("Plan 01"));
+    assert.ok(
+      corePlanLine,
+      `Expected last plan under last phase to use '    └──' prefix, lines:\n${stripped.join("\n")}`
+    );
+  });
+
+  test("Test 15: last plan under non-last phase uses '│   └── ' prefix", () => {
+    const { lines } = renderTreeLines(FIXTURE_MILESTONE, 80);
+    const stripped = lines.map(stripAnsi);
+    // 02-foundation is a non-last phase; its last plan (Plan 03) should use │   └──
+    const foundationLastPlan = stripped.find((l) => l.startsWith("│   └──") && l.includes("Plan 03"));
+    assert.ok(
+      foundationLastPlan,
+      `Expected last plan under non-last phase to use '│   └──' prefix, lines:\n${stripped.join("\n")}`
+    );
+  });
+});
+
+describe("renderTreeLines — edge cases", () => {
+  test("Test 16: empty phases array produces only the milestone header line", () => {
+    const { lines } = renderTreeLines(EMPTY_MILESTONE, 80);
+    assert.equal(
+      lines.length,
+      1,
+      `Expected exactly 1 line for empty phases, got ${lines.length}: ${lines.join("\n")}`
+    );
+    assert.ok(
+      lines[0].includes("Empty Project"),
+      `Expected milestone label in header, got: ${lines[0]}`
+    );
+  });
+});
+
+// ─── New Tests: VisibleNode and collapse ──────────────────────────────────────
+
+describe("renderTreeLines — VisibleNode and collapse", () => {
+  test("Test 17: renderTreeLines returns object with lines and nodes arrays of equal length", () => {
+    const result = renderTreeLines(FIXTURE_MILESTONE, 80);
+    assert.ok(result !== null && typeof result === "object", "Expected object return value");
+    assert.ok(Array.isArray(result.lines), "Expected lines to be an array");
+    assert.ok(Array.isArray(result.nodes), "Expected nodes to be an array");
+    assert.equal(
+      result.lines.length,
+      result.nodes.length,
+      `Expected lines.length (${result.lines.length}) === nodes.length (${result.nodes.length})`
+    );
+  });
+
+  test("Test 18: first node entry has kind === 'milestone'", () => {
+    const { nodes } = renderTreeLines(FIXTURE_MILESTONE, 80);
+    assert.ok(nodes.length > 0, "Expected at least one node");
+    assert.equal(nodes[0].kind, "milestone", `Expected first node kind to be 'milestone', got '${nodes[0].kind}'`);
+  });
+
+  test("Test 19: phase node entries have kind === 'phase' and dirName matching PhaseNode.dirName", () => {
+    const { nodes } = renderTreeLines(FIXTURE_MILESTONE, 80);
+    const phaseNodes = nodes.filter((n) => n.kind === "phase");
+    assert.ok(phaseNodes.length >= 2, `Expected at least 2 phase nodes, got ${phaseNodes.length}`);
+    const dirNames = phaseNodes.map((n) => n.dirName);
+    assert.ok(dirNames.includes("02-foundation"), `Expected '02-foundation' in phase dirNames: ${JSON.stringify(dirNames)}`);
+    assert.ok(dirNames.includes("03-core-renderer"), `Expected '03-core-renderer' in phase dirNames: ${JSON.stringify(dirNames)}`);
+  });
+
+  test("Test 20: plan node entries have kind === 'plan' and planId matching PlanNode.id", () => {
+    const { nodes } = renderTreeLines(FIXTURE_MILESTONE, 80);
+    const planNodes = nodes.filter((n) => n.kind === "plan");
+    assert.ok(planNodes.length >= 4, `Expected at least 4 plan nodes, got ${planNodes.length}`);
+    const planIds = planNodes.map((n) => n.planId);
+    assert.ok(planIds.includes("02-01"), `Expected '02-01' in plan planIds: ${JSON.stringify(planIds)}`);
+    assert.ok(planIds.includes("02-02"), `Expected '02-02' in plan planIds: ${JSON.stringify(planIds)}`);
+    assert.ok(planIds.includes("02-03"), `Expected '02-03' in plan planIds: ${JSON.stringify(planIds)}`);
+    assert.ok(planIds.includes("03-01"), `Expected '03-01' in plan planIds: ${JSON.stringify(planIds)}`);
+  });
+
+  test("Test 21: when collapsedPhases contains a phase dirName, that phase's plan lines are omitted from output and nodes array", () => {
+    const collapsedPhases = new Set(["02-foundation"]);
+    const { lines, nodes } = renderTreeLines(FIXTURE_MILESTONE, 80, collapsedPhases);
+    // 02-foundation has 3 plans — they should be gone
+    const planNodesFor02 = nodes.filter((n) => n.kind === "plan" && (n.planId === "02-01" || n.planId === "02-02" || n.planId === "02-03"));
+    assert.equal(planNodesFor02.length, 0, `Expected 0 plan nodes for 02-foundation when collapsed, got ${planNodesFor02.length}`);
+    // Lines also should not contain the plan text
+    const hasFoundationPlanLines = lines.some((l) => l.includes("Plan 01") || l.includes("Plan 02") || l.includes("Plan 03"));
+    // Note: 03-core-renderer also has a Plan 01, so we need to check node counts instead
+    const planNodes02 = nodes.filter((n) => n.planId === "02-01" || n.planId === "02-02" || n.planId === "02-03");
+    assert.equal(planNodes02.length, 0, `Expected no plan nodes for collapsed phase 02-foundation`);
+  });
+
+  test("Test 22: collapsed phase line contains ' ▸' after badge string (or after name if badges dropped)", () => {
+    const collapsedPhases = new Set(["02-foundation"]);
+    const { lines, nodes } = renderTreeLines(FIXTURE_MILESTONE, 80, collapsedPhases);
+    const phaseLineIdx = nodes.findIndex((n) => n.kind === "phase" && n.dirName === "02-foundation");
+    assert.ok(phaseLineIdx >= 0, "Expected to find phase node for 02-foundation");
+    const phaseLine = stripAnsi(lines[phaseLineIdx]);
+    assert.ok(
+      phaseLine.includes(" ▸"),
+      `Expected collapsed phase line to contain ' ▸', got: ${phaseLine}`
+    );
+  });
+
+  test("Test 23: expanded phase line does NOT contain ' ▸'", () => {
+    // Default: no collapsedPhases — all phases expanded
+    const { lines, nodes } = renderTreeLines(FIXTURE_MILESTONE, 80);
+    const phaseLineIdx = nodes.findIndex((n) => n.kind === "phase" && n.dirName === "02-foundation");
+    assert.ok(phaseLineIdx >= 0, "Expected to find phase node for 02-foundation");
+    const phaseLine = stripAnsi(lines[phaseLineIdx]);
+    assert.ok(
+      !phaseLine.includes(" ▸"),
+      `Expected expanded phase line to NOT contain ' ▸', got: ${phaseLine}`
+    );
+  });
+
+  test("Test 24: with 2 phases (3 plans each), collapsing one reduces lines.length by that phase's plan count", () => {
+    const twoPhaseFixture: MilestoneNode = {
+      label: "Two Phase Test",
+      status: "active",
+      phases: [
+        {
+          number: 1,
+          dirName: "01-alpha",
+          label: "1. Alpha",
+          status: "active",
+          badges: [true, false, false, false, false, false, false],
+          plans: [
+            { id: "01-01", label: "Plan 01", status: "done", hasSummary: true },
+            { id: "01-02", label: "Plan 02", status: "done", hasSummary: true },
+            { id: "01-03", label: "Plan 03", status: "done", hasSummary: true },
+          ],
+        },
+        {
+          number: 2,
+          dirName: "02-beta",
+          label: "2. Beta",
+          status: "pending",
+          badges: [false, false, false, false, false, false, false],
+          plans: [
+            { id: "02-01", label: "Plan 01", status: "pending", hasSummary: false },
+            { id: "02-02", label: "Plan 02", status: "pending", hasSummary: false },
+            { id: "02-03", label: "Plan 03", status: "pending", hasSummary: false },
+          ],
+        },
+      ],
+    };
+
+    const { lines: linesExpanded } = renderTreeLines(twoPhaseFixture, 80);
+    const collapsedPhases = new Set(["01-alpha"]);
+    const { lines: linesCollapsed } = renderTreeLines(twoPhaseFixture, 80, collapsedPhases);
+
+    // Collapsing 01-alpha (3 plans) should reduce by 3
+    assert.equal(
+      linesCollapsed.length,
+      linesExpanded.length - 3,
+      `Expected ${linesExpanded.length - 3} lines when phase with 3 plans collapsed, got ${linesCollapsed.length}`
+    );
+  });
+
+  test("Test 25: empty collapsedPhases set (default) produces identical lines to pre-change behavior (backward compat)", () => {
+    // Call with empty Set explicitly — should match call with no collapsedPhases arg
+    const { lines: withEmpty } = renderTreeLines(FIXTURE_MILESTONE, 80, new Set());
+    const { lines: withDefault } = renderTreeLines(FIXTURE_MILESTONE, 80);
+    assert.deepEqual(withEmpty, withDefault, "Expected empty Set to produce same output as default (no arg)");
+  });
+
+  test("Test 26: collapsed phase at narrow width (20) still appends ▸ even when badges are dropped", () => {
+    const collapsedPhases = new Set(["02-foundation"]);
+    const { lines, nodes } = renderTreeLines(FIXTURE_MILESTONE, 20, collapsedPhases);
+    const phaseLineIdx = nodes.findIndex((n) => n.kind === "phase" && n.dirName === "02-foundation");
+    assert.ok(phaseLineIdx >= 0, "Expected to find phase node for 02-foundation at narrow width");
+    const phaseLine = stripAnsi(lines[phaseLineIdx]);
+    // At width=20, badges are dropped but ▸ must still appear
+    assert.ok(
+      phaseLine.includes(" ▸"),
+      `Expected collapsed phase line to contain ' ▸' even at narrow width, got: ${phaseLine}`
+    );
+    // And the line must not exceed width
+    const w = visibleWidth(phaseLine);
+    assert.ok(w <= 20, `Expected line width <= 20, got ${w}: ${phaseLine}`);
+  });
+});

--- a/src/resources/extensions/gsd-watch/tests/watch-watcher.test.ts
+++ b/src/resources/extensions/gsd-watch/tests/watch-watcher.test.ts
@@ -1,0 +1,172 @@
+// GSD Watch — Unit tests for watcher debounce, coalescing, and ignored patterns
+// Copyright (c) 2026 Jeremy McSpadden <jeremy@fluxlabs.net>
+
+import { describe, test, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { startPlanningWatcher } from "../watcher.js";
+import { DEBOUNCE_MS } from "../types.js";
+
+// Total wait: DEBOUNCE_MS (300) + stabilityThreshold (200) + buffer (200) = 700ms
+const SETTLE_MS = DEBOUNCE_MS + 200 + 200;
+
+function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+describe("startPlanningWatcher", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "watch-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test("Test 1: single file write triggers onChange within 400ms", async (t) => {
+    let callCount = 0;
+    const watcher = startPlanningWatcher(tmpDir, () => { callCount++; });
+    t.after(() => watcher.close());
+
+    // Wait for watcher to be ready
+    await wait(100);
+
+    writeFileSync(join(tmpDir, "state.md"), "content");
+
+    await wait(SETTLE_MS);
+
+    assert.equal(callCount, 1, `expected 1 call, got ${callCount}`);
+  });
+
+  test("Test 2: 10 rapid writes coalesce into exactly 1 onChange call", async (t) => {
+    let callCount = 0;
+    const watcher = startPlanningWatcher(tmpDir, () => { callCount++; });
+    t.after(() => watcher.close());
+
+    // Wait for watcher to be ready
+    await wait(100);
+
+    // Write 10 files rapidly
+    for (let i = 0; i < 10; i++) {
+      writeFileSync(join(tmpDir, `file-${i}.md`), `content-${i}`);
+    }
+
+    await wait(SETTLE_MS);
+
+    assert.equal(callCount, 1, `expected 1 coalesced call, got ${callCount}`);
+  });
+
+  test("Test 3: .swp files do NOT trigger onChange", async (t) => {
+    let callCount = 0;
+    const watcher = startPlanningWatcher(tmpDir, () => { callCount++; });
+    t.after(() => watcher.close());
+
+    await wait(100);
+
+    writeFileSync(join(tmpDir, "state.md.swp"), "swap content");
+
+    await wait(SETTLE_MS);
+
+    assert.equal(callCount, 0, `expected 0 calls for .swp file, got ${callCount}`);
+  });
+
+  test("Test 4: files ending in ~ do NOT trigger onChange", async (t) => {
+    let callCount = 0;
+    const watcher = startPlanningWatcher(tmpDir, () => { callCount++; });
+    t.after(() => watcher.close());
+
+    await wait(100);
+
+    writeFileSync(join(tmpDir, "state.md~"), "backup content");
+
+    await wait(SETTLE_MS);
+
+    assert.equal(callCount, 0, `expected 0 calls for ~ file, got ${callCount}`);
+  });
+
+  test("Test 5: .tmp files do NOT trigger onChange", async (t) => {
+    let callCount = 0;
+    const watcher = startPlanningWatcher(tmpDir, () => { callCount++; });
+    t.after(() => watcher.close());
+
+    await wait(100);
+
+    writeFileSync(join(tmpDir, "state.tmp"), "temp content");
+
+    await wait(SETTLE_MS);
+
+    assert.equal(callCount, 0, `expected 0 calls for .tmp file, got ${callCount}`);
+  });
+
+  test("Test 6: .DS_Store files do NOT trigger onChange", async (t) => {
+    let callCount = 0;
+    const watcher = startPlanningWatcher(tmpDir, () => { callCount++; });
+    t.after(() => watcher.close());
+
+    await wait(100);
+
+    writeFileSync(join(tmpDir, ".DS_Store"), "ds store content");
+
+    await wait(SETTLE_MS);
+
+    assert.equal(callCount, 0, `expected 0 calls for .DS_Store, got ${callCount}`);
+  });
+
+  test("Test 7: creating a new subdirectory triggers onChange", async (t) => {
+    let callCount = 0;
+    const watcher = startPlanningWatcher(tmpDir, () => { callCount++; });
+    t.after(() => watcher.close());
+
+    await wait(100);
+
+    mkdirSync(join(tmpDir, "new-subdir"));
+
+    await wait(SETTLE_MS);
+
+    assert.equal(callCount, 1, `expected 1 call for directory creation, got ${callCount}`);
+  });
+
+  test("Test 8: removing a subdirectory triggers onChange", async (t) => {
+    // Pre-create subdir before watcher starts
+    const subDir = join(tmpDir, "existing-subdir");
+    mkdirSync(subDir);
+
+    let callCount = 0;
+    const watcher = startPlanningWatcher(tmpDir, () => { callCount++; });
+    t.after(() => watcher.close());
+
+    await wait(100);
+
+    rmSync(subDir, { recursive: true, force: true });
+
+    await wait(SETTLE_MS);
+
+    assert.equal(callCount, 1, `expected 1 call for directory removal, got ${callCount}`);
+  });
+
+  test("Test 9: watcher.close() stops firing events", async (t) => {
+    let callCount = 0;
+    const watcher = startPlanningWatcher(tmpDir, () => { callCount++; });
+
+    await wait(100);
+
+    // Write a file and wait for it to trigger
+    writeFileSync(join(tmpDir, "first.md"), "first");
+    await wait(SETTLE_MS);
+    assert.equal(callCount, 1, "expected 1 call before close");
+
+    // Close the watcher
+    await watcher.close();
+
+    // Write another file — should NOT trigger
+    writeFileSync(join(tmpDir, "second.md"), "second");
+    await wait(SETTLE_MS);
+
+    assert.equal(callCount, 1, `expected still 1 call after close, got ${callCount}`);
+  });
+});

--- a/src/resources/extensions/gsd-watch/tree-model.ts
+++ b/src/resources/extensions/gsd-watch/tree-model.ts
@@ -1,0 +1,365 @@
+// GSD Watch — Tree data model: DB-first status, filesystem fallback, badge detection
+// Copyright (c) 2026 Jeremy McSpadden <jeremy@fluxlabs.net>
+
+import { readdirSync, existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import type { MilestoneNode, PhaseNode, PlanNode, NodeStatus } from "./types.js";
+import { mapDbStatus } from "./types.js";
+
+// ─── Plan Label Extraction ──────────────────────────────────────────────────
+
+/**
+ * Extract a human-readable plan label from a PLAN.md file.
+ * Reads the first line of the <objective> block if present.
+ * Falls back to "Plan NN" if no objective found or file unreadable.
+ */
+export function extractPlanLabel(planFilePath: string, fallback: string): string {
+  try {
+    const content = readFileSync(planFilePath, "utf-8");
+    const match = content.match(/<objective>\s*\n(.+)/);
+    if (match && match[1]) {
+      const line = match[1].trim();
+      // Strip leading markdown formatting (e.g. "## " or "### ")
+      const cleaned = line.replace(/^#+\s*/, "");
+      if (cleaned.length > 0) return cleaned;
+    }
+  } catch {
+    // Fall through to fallback
+  }
+  return fallback;
+}
+
+// ─── Badge Suffixes ───────────────────────────────────────────────────────────
+
+/**
+ * The 7 lifecycle badge suffixes in display order:
+ * [CONTEXT, RESEARCH, UI-SPEC, PLAN, SUMMARY, VERIFICATION, HUMAN-UAT]
+ *
+ * A badge is "active" when any file in the phase directory ends with the suffix.
+ */
+export const BADGE_SUFFIXES = [
+  "-CONTEXT.md",
+  "-RESEARCH.md",
+  "-UI-SPEC.md",
+  "-PLAN.md",
+  "-SUMMARY.md",
+  "-VERIFICATION.md",
+  "-HUMAN-UAT.md",
+] as const;
+
+// ─── Badge Detection ──────────────────────────────────────────────────────────
+
+/**
+ * Detect which lifecycle badges are present for a phase.
+ * Returns a 7-element boolean array corresponding to BADGE_SUFFIXES.
+ */
+export function detectBadges(phaseFiles: string[]): boolean[] {
+  return BADGE_SUFFIXES.map((suffix) =>
+    phaseFiles.some((file) => file.endsWith(suffix))
+  );
+}
+
+// ─── Label Humanization ───────────────────────────────────────────────────────
+
+/**
+ * Humanize the text portion of a phase dir name.
+ * E.g. "03-core-renderer" -> "Core Renderer"
+ */
+export function humanizePhaseLabel(dirName: string): string {
+  const withoutPrefix = dirName.replace(/^\d+-/, "");
+  return withoutPrefix
+    .split("-")
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+}
+
+/**
+ * Format a phase dir name as a numbered label.
+ * E.g. "03-core-renderer" -> "3. Core Renderer"
+ */
+export function formatPhaseLabel(dirName: string): string {
+  const num = parseInt(dirName.split("-")[0], 10);
+  return `${num}. ${humanizePhaseLabel(dirName)}`;
+}
+
+// ─── Status Derivation (filesystem fallback) ─────────────────────────────────
+
+/**
+ * Derive plan status from whether a summary file exists.
+ * - If phaseFiles contains a file ending in `${planId}-SUMMARY.md` -> "done"
+ * - Otherwise -> "active" (plan file exists means it's at least active)
+ */
+export function derivePlanStatus(
+  planId: string,
+  phaseFiles: string[]
+): NodeStatus {
+  const summaryFile = `${planId}-SUMMARY.md`;
+  if (phaseFiles.some((file) => file.endsWith(summaryFile))) {
+    return "done";
+  }
+  return "active";
+}
+
+/**
+ * Derive phase status from its plans.
+ * - No plans -> "pending"
+ * - All plans done -> "done"
+ * - Any active -> "active"
+ */
+export function derivePhaseStatus(
+  plans: PlanNode[],
+  badges: boolean[]
+): NodeStatus {
+  if (plans.length === 0) return "pending";
+  if (plans.every((p) => p.status === "done")) return "done";
+  return "active";
+}
+
+/**
+ * Derive milestone status from its phases using worst-case roll-up (per D-11).
+ * - No phases -> "pending"
+ * - Any blocked -> "blocked"
+ * - Any active -> "active"
+ * - All done -> "done"
+ * - Otherwise -> "pending"
+ */
+export function deriveMilestoneStatus(phases: PhaseNode[]): NodeStatus {
+  if (phases.length === 0) return "pending";
+  if (phases.some((p) => p.status === "blocked")) return "blocked";
+  if (phases.some((p) => p.status === "active")) return "active";
+  if (phases.every((p) => p.status === "done")) return "done";
+  return "pending";
+}
+
+// ─── Plan Scanning (filesystem fallback) ─────────────────────────────────────
+
+/**
+ * Scan a phase directory for plan files and return sorted PlanNode array.
+ * Only files matching /^\d{2}-\d{2}-PLAN\.md$/ are included.
+ */
+export function scanPlans(phaseDir: string, phaseFiles: string[]): PlanNode[] {
+  const planFiles = phaseFiles
+    .filter((file) => /^\d{2}-\d{2}-PLAN\.md$/.test(file))
+    .sort();
+
+  return planFiles.map((file) => {
+    // Extract plan ID: "03-01" from "03-01-PLAN.md"
+    const planId = file.replace(/-PLAN\.md$/, "");
+    // Extract zero-padded plan number for label: "01" from "03-01"
+    const planNumber = planId.split("-")[1];
+    const fallback = `Plan ${planNumber}`;
+    const label = extractPlanLabel(join(phaseDir, file), fallback);
+    const status = derivePlanStatus(planId, phaseFiles);
+    const hasSummary = phaseFiles.some((f) => f.endsWith(`${planId}-SUMMARY.md`));
+
+    return { id: planId, label, status, hasSummary };
+  });
+}
+
+// ─── Milestone Label ──────────────────────────────────────────────────────────
+
+/**
+ * Read the milestone label from ROADMAP.md.
+ * Looks for the first heading line and extracts text after "—" or "–" if present.
+ * Falls back to "Project" if file not found or parse fails.
+ */
+export function readMilestoneLabel(projectRoot: string): string {
+  try {
+    const roadmapPath = join(projectRoot, ".planning", "ROADMAP.md");
+    if (!existsSync(roadmapPath)) return "Project";
+    const content = readFileSync(roadmapPath, "utf-8");
+    const match = content.match(/^#\s+(.+)$/m);
+    if (match && match[1]) {
+      const heading = match[1].trim();
+      // Extract text after em-dash or en-dash if present
+      const dashMatch = heading.match(/[—–]\s*(.+)$/);
+      if (dashMatch && dashMatch[1]) {
+        return dashMatch[1].trim();
+      }
+      return heading;
+    }
+  } catch {
+    // Fall through to default
+  }
+  return "Project";
+}
+
+// ─── Filesystem Tree Builder (fallback) ──────────────────────────────────────
+
+/**
+ * Build the milestone tree by scanning the .planning/phases/ directory.
+ * Used when no GSD database is available.
+ */
+export function buildMilestoneTree(projectRoot: string): MilestoneNode {
+  const phasesDir = join(projectRoot, ".planning", "phases");
+  const label = readMilestoneLabel(projectRoot);
+
+  if (!existsSync(phasesDir)) {
+    return { label, status: "pending", phases: [] };
+  }
+
+  const phaseDirents = readdirSync(phasesDir, { withFileTypes: true })
+    .filter(
+      (dirent) =>
+        dirent.isDirectory() && /^\d{2}-/.test(dirent.name)
+    )
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  const phases: PhaseNode[] = phaseDirents.map((dirent) => {
+    const phaseDir = join(phasesDir, dirent.name);
+    const phaseFiles = readdirSync(phaseDir);
+    const badges = detectBadges(phaseFiles);
+    const plans = scanPlans(phaseDir, phaseFiles);
+    const status = derivePhaseStatus(plans, badges);
+    const number = parseInt(dirent.name.split("-")[0], 10);
+    const phaseLabel = formatPhaseLabel(dirent.name);
+
+    return {
+      number,
+      dirName: dirent.name,
+      label: phaseLabel,
+      status,
+      badges,
+      plans,
+    };
+  });
+
+  const milestoneStatus = deriveMilestoneStatus(phases);
+
+  return { label, status: milestoneStatus, phases };
+}
+
+// ─── DB → Phase Dir Matching ─────────────────────────────────────────────────
+
+/**
+ * Normalize a title string to match filesystem phase dir format.
+ * "Test Infrastructure Foundation" → "test-infrastructure-foundation"
+ */
+function normalizeTitle(title: string): string {
+  return title.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/(^-|-$)/g, "");
+}
+
+/**
+ * Build a lookup map from normalized phase dir name → dir entry for badge detection.
+ * Keys are the name portion after the numeric prefix (e.g. "test-infrastructure-foundation").
+ */
+function buildPhaseDirMap(phasesDir: string): Map<string, string> {
+  const map = new Map<string, string>();
+  if (!existsSync(phasesDir)) return map;
+  try {
+    const entries = readdirSync(phasesDir, { withFileTypes: true });
+    for (const entry of entries) {
+      if (entry.isDirectory() && /^\d{2}-/.test(entry.name)) {
+        const normalized = entry.name.replace(/^\d+-/, "");
+        map.set(normalized, entry.name);
+      }
+    }
+  } catch {
+    // Non-fatal — badges will be empty
+  }
+  return map;
+}
+
+/**
+ * Try to find the matching filesystem phase directory for a DB slice title.
+ * Returns the directory name (e.g. "20-test-infrastructure-foundation") or null.
+ */
+function matchSliceToPhaseDir(sliceTitle: string, phaseDirMap: Map<string, string>): string | null {
+  const normalized = normalizeTitle(sliceTitle);
+  return phaseDirMap.get(normalized) ?? null;
+}
+
+/**
+ * Get badges for a slice by finding its matching filesystem phase directory.
+ * Returns 7-element boolean array, all false if no match found.
+ */
+function getBadgesForSlice(sliceTitle: string, phasesDir: string, phaseDirMap: Map<string, string>): boolean[] {
+  const dirName = matchSliceToPhaseDir(sliceTitle, phaseDirMap);
+  if (!dirName) return [false, false, false, false, false, false, false];
+  try {
+    const phaseDir = join(phasesDir, dirName);
+    const phaseFiles = readdirSync(phaseDir);
+    return detectBadges(phaseFiles);
+  } catch {
+    return [false, false, false, false, false, false, false];
+  }
+}
+
+// ─── DB-backed Tree Builder ──────────────────────────────────────────────────
+
+/** Interface for DB query results to avoid importing full gsd-db types. */
+interface DbMilestone { id: string; title: string; status: string; }
+interface DbSlice { milestone_id: string; id: string; title: string; status: string; }
+interface DbTask { milestone_id: string; slice_id: string; id: string; title: string; status: string; }
+
+/** Query callback type — injected by the renderer to avoid circular imports. */
+export interface DbQueries {
+  getAllMilestones(): DbMilestone[];
+  getMilestoneSlices(milestoneId: string): DbSlice[];
+  getSliceTasks(milestoneId: string, sliceId: string): DbTask[];
+}
+
+/**
+ * Build the project tree from the GSD database.
+ * Returns milestones in display order: active first, then completed (newest first).
+ */
+export function buildProjectTreeFromDb(
+  queries: DbQueries,
+  projectRoot: string
+): MilestoneNode[] {
+  const phasesDir = join(projectRoot, ".planning", "phases");
+  const phaseDirMap = buildPhaseDirMap(phasesDir);
+  const allMilestones = queries.getAllMilestones();
+
+  // Chronological order: completed milestones first, active at bottom
+  // Natural reading order — history flows downward, active work is always last
+
+  return allMilestones.map((m) => {
+    const slices = queries.getMilestoneSlices(m.id);
+    const phases: PhaseNode[] = slices.map((s, idx) => {
+      const tasks = queries.getSliceTasks(m.id, s.id);
+      const badges = getBadgesForSlice(s.title, phasesDir, phaseDirMap);
+      const dirName = matchSliceToPhaseDir(s.title, phaseDirMap) ?? `${m.id}-${s.id}`;
+
+      const plans: PlanNode[] = tasks.map((t) => ({
+        id: `${m.id}-${s.id}-${t.id}`,
+        label: t.title,
+        status: mapDbStatus(t.status),
+        hasSummary: t.status === "complete" || t.status === "done",
+      }));
+
+      return {
+        number: idx + 1,
+        dirName,
+        label: `${s.id}: ${s.title}`,
+        status: mapDbStatus(s.status),
+        badges,
+        plans,
+      };
+    });
+
+    return {
+      label: m.title,
+      status: mapDbStatus(m.status),
+      phases,
+    };
+  });
+}
+
+/**
+ * Build the full project tree.
+ * Tries DB first (source of truth), falls back to filesystem scanning.
+ * Returns an array of MilestoneNodes — one per milestone from DB, or a single
+ * filesystem-derived milestone when no DB is available.
+ */
+export function buildProjectTree(
+  projectRoot: string,
+  dbQueries: DbQueries | null
+): MilestoneNode[] {
+  if (dbQueries) {
+    const milestones = buildProjectTreeFromDb(dbQueries, projectRoot);
+    if (milestones.length > 0) return milestones;
+  }
+  // Fallback: filesystem-only project
+  return [buildMilestoneTree(projectRoot)];
+}

--- a/src/resources/extensions/gsd-watch/tree-renderer.ts
+++ b/src/resources/extensions/gsd-watch/tree-renderer.ts
@@ -1,0 +1,256 @@
+// GSD Watch — Tree renderer: layout engine, badge formatting, ANSI-safe line construction
+// Copyright (c) 2026 Jeremy McSpadden <jeremy@fluxlabs.net>
+
+import { visibleWidth, truncateToWidth } from "@gsd/pi-tui";
+import type { MilestoneNode, PhaseNode, PlanNode, NodeStatus } from "./types.js";
+
+// ─── VisibleNode Types ────────────────────────────────────────────────────────
+
+/** Identifies the type of tree node that a rendered line represents. */
+export type VisibleNodeKind = "milestone" | "phase" | "plan";
+
+/**
+ * Metadata for a single rendered line — maps line index to tree node identity.
+ * Used by cursor navigation to identify collapsible phases and track cursor
+ * position across file-change refreshes.
+ */
+export interface VisibleNode {
+  kind: VisibleNodeKind;
+  milestoneIdx?: number; // index into milestones array, for milestone-level identity
+  dirName?: string;   // defined when kind === "phase"
+  planId?: string;    // defined when kind === "plan"
+}
+
+// ─── ANSI Color Codes ─────────────────────────────────────────────────────────
+
+const RESET   = "\x1b[0m";
+const BOLD    = "\x1b[1m";
+const DIM     = "\x1b[2m";
+const GREEN   = "\x1b[32m";
+const YELLOW  = "\x1b[33m";
+const RED     = "\x1b[31m";
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const STATUS_ICON: Record<NodeStatus, string> = {
+  done:    `${GREEN}✓${RESET}`,
+  active:  `${YELLOW}◆${RESET}`,
+  pending: `${DIM}○${RESET}`,
+  blocked: `${RED}✘${RESET}`,
+};
+
+const BADGE_FILLED = `${GREEN}●${RESET}`;
+const BADGE_EMPTY  = `${DIM}○${RESET}`;
+
+/** Minimum pane width to show plan-level detail. Below this, only phases shown. Per D-13. */
+const MIN_WIDTH_FOR_PLANS = 30;
+
+/** Minimum name characters to show when fitting badges. Below this, drop badges. */
+const MIN_NAME_WITH_BADGES = 4;
+
+/** Collapsed indicator appended to collapsed phase lines. Per D-08. */
+const COLLAPSED_INDICATOR = ` ${DIM}▸${RESET}`;
+
+// ─── Safety Clamp ─────────────────────────────────────────────────────────────
+
+/**
+ * Hard-clamp a line to the given width. Ensures no line ever overflows
+ * the terminal pane, even if individual truncation calculations are off.
+ */
+function clampLine(line: string, width: number): string {
+  if (visibleWidth(line) <= width) return line;
+  return truncateToWidth(line, width, "…");
+}
+
+// ─── Badge Formatting ─────────────────────────────────────────────────────────
+
+/**
+ * Format badge boolean array as a string of filled/empty circles.
+ * Always returns " " + 7 badge characters (8 visible chars total).
+ */
+function formatBadgeString(badges: boolean[]): string {
+  return " " + badges.map((b) => (b ? BADGE_FILLED : BADGE_EMPTY)).join("");
+}
+
+// ─── Milestone Line ───────────────────────────────────────────────────────────
+
+/**
+ * Format the root milestone header line.
+ * No tree prefix — this is the root node.
+ */
+function formatMilestoneLine(milestone: MilestoneNode, width: number): string {
+  const icon = STATUS_ICON[milestone.status];
+  const iconWidth = visibleWidth(icon + " ");
+  const available = width - iconWidth;
+  const name = truncateToWidth(milestone.label, available, "…");
+  return clampLine(icon + " " + BOLD + name + RESET, width);
+}
+
+// ─── Phase Line ───────────────────────────────────────────────────────────────
+
+/**
+ * Format a phase line with status icon, name, and lifecycle badges.
+ * Per D-12: name wins over badges on truncation.
+ *
+ * Layout: prefix + STATUS_ICON + " " + name [+ badgeStr]
+ */
+function formatPhaseLine(phase: PhaseNode, prefix: string, width: number): string {
+  const prefixWidth = visibleWidth(prefix);
+  const icon = STATUS_ICON[phase.status];
+  const statusWidth = visibleWidth(icon + " ");
+  const available = width - prefixWidth - statusWidth;
+
+  const badgeStr = formatBadgeString(phase.badges);
+  const badgeWidth = visibleWidth(badgeStr);
+
+  let namePart: string;
+  let badgePart: string;
+
+  if (available >= MIN_NAME_WITH_BADGES + badgeWidth) {
+    // Enough room for name AND badges
+    const nameWidth = available - badgeWidth;
+    namePart = truncateToWidth(phase.label, nameWidth, "…");
+    badgePart = badgeStr;
+  } else {
+    // Drop badges — name gets all available space
+    namePart = truncateToWidth(phase.label, available, "…");
+    badgePart = "";
+  }
+
+  return clampLine(prefix + icon + " " + namePart + badgePart, width);
+}
+
+// ─── Plan Line ────────────────────────────────────────────────────────────────
+
+/**
+ * Format a plan line with status icon and label.
+ * No badges on individual plans.
+ */
+function formatPlanLine(plan: PlanNode, prefix: string, width: number): string {
+  const prefixWidth = visibleWidth(prefix);
+  const icon = STATUS_ICON[plan.status];
+  const statusWidth = visibleWidth(icon + " ");
+  const available = width - prefixWidth - statusWidth;
+  const name = truncateToWidth(plan.label, available, "…");
+  return clampLine(prefix + icon + " " + name, width);
+}
+
+// ─── Single Milestone Renderer ───────────────────────────────────────────────
+
+/**
+ * Render a single milestone's phases and plans into lines/nodes arrays.
+ */
+function renderSingleMilestone(
+  milestone: MilestoneNode,
+  milestoneIdx: number,
+  width: number,
+  collapsedPhases: Set<string>,
+  lines: string[],
+  nodes: VisibleNode[]
+): void {
+  // Milestone header (root node — no tree prefix)
+  lines.push(formatMilestoneLine(milestone, width));
+  nodes.push({ kind: "milestone", milestoneIdx });
+
+  const phases = milestone.phases;
+  for (let pi = 0; pi < phases.length; pi++) {
+    const phase = phases[pi];
+    const isLastPhase = pi === phases.length - 1;
+    const isCollapsed = collapsedPhases.has(phase.dirName);
+
+    // Phase prefix: ├── for non-last, └── for last (dim tree connectors)
+    const phasePrefix = isLastPhase ? `${DIM}└── ${RESET}` : `${DIM}├── ${RESET}`;
+    let phaseLine = formatPhaseLine(phase, phasePrefix, width);
+
+    if (isCollapsed) {
+      // Append ▸ indicator to collapsed phase lines (D-08).
+      const indicatorWidth = visibleWidth(COLLAPSED_INDICATOR);
+      const currentWidth = visibleWidth(phaseLine);
+      if (currentWidth + indicatorWidth > width) {
+        phaseLine = truncateToWidth(phaseLine, width - indicatorWidth, "…") + COLLAPSED_INDICATOR;
+      } else {
+        phaseLine = phaseLine + COLLAPSED_INDICATOR;
+      }
+    }
+
+    lines.push(phaseLine);
+    nodes.push({ kind: "phase", dirName: phase.dirName, milestoneIdx });
+
+    // Skip plan lines for collapsed phases (D-07, D-08)
+    if (isCollapsed) {
+      continue;
+    }
+
+    // Plans are only shown when width is sufficient (D-13)
+    if (width >= MIN_WIDTH_FOR_PLANS) {
+      const plans = phase.plans;
+      for (let pj = 0; pj < plans.length; pj++) {
+        const plan = plans[pj];
+        const isLastPlan = pj === plans.length - 1;
+
+        // Continuation prefix based on whether this is the last phase (dim tree connectors)
+        const continuation = isLastPhase ? "    " : `${DIM}│${RESET}   `;
+        const connector = isLastPlan ? `${DIM}└── ${RESET}` : `${DIM}├── ${RESET}`;
+        const planPrefix = continuation + connector;
+
+        lines.push(formatPlanLine(plan, planPrefix, width));
+        nodes.push({ kind: "plan", planId: plan.id, milestoneIdx });
+      }
+    }
+  }
+}
+
+// ─── Main Export ─────────────────────────────────────────────────────────────
+
+/**
+ * Render the project tree as an array of terminal-safe strings, alongside
+ * a parallel VisibleNode array identifying each line's tree node.
+ *
+ * Accepts a single milestone or an array of milestones (from DB or filesystem).
+ * Each milestone renders as a root header with its phases/plans underneath.
+ * Collapsed milestones show only their header line with a ▸ indicator.
+ *
+ * @param milestones - The milestone node(s) to render.
+ * @param width - Terminal column width for truncation.
+ * @param collapsedPhases - Optional set of phase dirName values that are collapsed.
+ * @param collapsedMilestones - Optional set of milestone indices that are collapsed.
+ * @returns Object with parallel `lines` (string[]) and `nodes` (VisibleNode[]) arrays.
+ */
+export function renderTreeLines(
+  milestones: MilestoneNode | MilestoneNode[],
+  width: number,
+  collapsedPhases: Set<string> = new Set(),
+  collapsedMilestones: Set<number> = new Set()
+): { lines: string[]; nodes: VisibleNode[] } {
+  const lines: string[] = [];
+  const nodes: VisibleNode[] = [];
+
+  // Normalize to array for uniform handling
+  const milestoneArray = Array.isArray(milestones) ? milestones : [milestones];
+
+  for (let mi = 0; mi < milestoneArray.length; mi++) {
+    // Add blank separator between milestones (only for multi-milestone)
+    if (mi > 0 && milestoneArray.length > 1) {
+      lines.push("");
+      nodes.push({ kind: "milestone", milestoneIdx: mi }); // spacer node
+    }
+
+    if (collapsedMilestones.has(mi)) {
+      // Collapsed milestone: show header with ▸ indicator only
+      let headerLine = formatMilestoneLine(milestoneArray[mi], width);
+      const indicatorWidth = visibleWidth(COLLAPSED_INDICATOR);
+      const currentWidth = visibleWidth(headerLine);
+      if (currentWidth + indicatorWidth > width) {
+        headerLine = truncateToWidth(headerLine, width - indicatorWidth, "…") + COLLAPSED_INDICATOR;
+      } else {
+        headerLine = headerLine + COLLAPSED_INDICATOR;
+      }
+      lines.push(headerLine);
+      nodes.push({ kind: "milestone", milestoneIdx: mi });
+    } else {
+      renderSingleMilestone(milestoneArray[mi], mi, width, collapsedPhases, lines, nodes);
+    }
+  }
+
+  return { lines, nodes };
+}

--- a/src/resources/extensions/gsd-watch/types.ts
+++ b/src/resources/extensions/gsd-watch/types.ts
@@ -1,0 +1,63 @@
+// GSD Watch — Shared types and constants for the watch sidebar module
+// Copyright (c) 2026 Jeremy McSpadden <jeremy@fluxlabs.net>
+
+/** Metadata stored in the watch lock file for singleton guard + stale detection. */
+export interface WatchLockData {
+  pid: number;        // renderer process PID
+  paneId: string;     // tmux pane ID (e.g., "%12") for stale pane cleanup
+  startedAt: string;  // ISO timestamp
+  projectRoot: string; // project root path
+}
+
+/** Debounce interval for coalescing file-change events (ms). Per D-16, within 300-400ms range. */
+export const DEBOUNCE_MS = 300;
+
+/** Glob patterns to ignore inside .planning/ — editor temp/swap files per D-15. */
+export const IGNORED_PATTERNS: string[] = [
+  "**/.DS_Store",
+  "**/*.swp",
+  "**/*~",
+  "**/*.tmp",
+  "**/.gsd-watch.lock",
+];
+
+/** Lock file name for watch singleton guard. Placed in .gsd/ to avoid feedback loop. */
+export const WATCH_LOCK_FILE = "watch.lock";
+
+// ─── Tree Model Types (Phase 3: Core Renderer) ─────────────────────────────
+
+/** Status of a tree node: done, active, pending, or blocked. Per D-09. */
+export type NodeStatus = "done" | "active" | "pending" | "blocked";
+
+/** Map DB status strings to NodeStatus. DB uses "complete"/"done"/"active"/"pending"/"blocked"/"parked". */
+export function mapDbStatus(dbStatus: string): NodeStatus {
+  if (dbStatus === "complete" || dbStatus === "done") return "done";
+  if (dbStatus === "active") return "active";
+  if (dbStatus === "blocked") return "blocked";
+  return "pending"; // covers "pending", "parked", unknown
+}
+
+/** A single plan within a phase. */
+export interface PlanNode {
+  id: string;          // e.g. "03-01"
+  label: string;       // derived from filename, e.g. "Plan 01"
+  status: NodeStatus;
+  hasSummary: boolean;
+}
+
+/** A phase containing plans and lifecycle badges. */
+export interface PhaseNode {
+  number: number;       // numeric prefix, e.g. 3
+  dirName: string;      // e.g. "03-core-renderer"
+  label: string;        // humanized, e.g. "3. Core Renderer" (per D-03)
+  status: NodeStatus;
+  badges: boolean[];    // 7 booleans: [CONTEXT, RESEARCH, UI-SPEC, PLAN, SUMMARY, VERIFICATION, HUMAN-UAT] (per D-05)
+  plans: PlanNode[];
+}
+
+/** Root node: a milestone containing phases. */
+export interface MilestoneNode {
+  label: string;        // e.g. "v1.1 — GSD Watch" from PROJECT.md or ROADMAP.md
+  status: NodeStatus;   // worst-case roll-up from phases (per D-11)
+  phases: PhaseNode[];
+}

--- a/src/resources/extensions/gsd-watch/watcher.ts
+++ b/src/resources/extensions/gsd-watch/watcher.ts
@@ -1,0 +1,65 @@
+// GSD Watch — Chokidar wrapper with single coalescing debounce for .planning/ watching
+// Copyright (c) 2026 Jeremy McSpadden <jeremy@fluxlabs.net>
+
+import { watch } from "chokidar";
+import type { FSWatcher } from "chokidar";
+import { basename } from "node:path";
+import { DEBOUNCE_MS } from "./types.js";
+
+/**
+ * Start watching the given directory (typically .planning/) for any file or
+ * directory changes. Uses a single coalescing debounce so that rapid sequential
+ * writes (e.g. during GSD orchestrator execution) produce exactly one callback.
+ *
+ * @param planningDir - Absolute path to the directory to watch.
+ * @param onChanged   - Callback invoked after the debounce period elapses.
+ * @returns The chokidar FSWatcher instance — call .close() to stop watching.
+ */
+export function startPlanningWatcher(
+  planningDir: string,
+  onChanged: () => void,
+): FSWatcher {
+  let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+  function scheduleRefresh(): void {
+    if (debounceTimer !== null) {
+      clearTimeout(debounceTimer);
+    }
+    debounceTimer = setTimeout(() => {
+      debounceTimer = null;
+      onChanged();
+    }, DEBOUNCE_MS);
+  }
+
+  // chokidar v5 changed glob-based `ignored` pattern matching behavior;
+  // a function predicate is the reliable approach for all versions.
+  // Mirrors the IGNORED_PATTERNS constants defined in types.ts.
+  function isIgnored(filePath: string): boolean {
+    const base = basename(filePath);
+    return (
+      base === ".DS_Store" ||
+      base === ".gsd-watch.lock" ||
+      base.endsWith(".swp") ||
+      base.endsWith(".tmp") ||
+      base.endsWith("~")
+    );
+  }
+
+  const watcher = watch(planningDir, {
+    ignoreInitial: true,
+    ignored: isIgnored,
+    depth: 10,
+    awaitWriteFinish: {
+      stabilityThreshold: 200,
+      pollInterval: 50,
+    },
+  });
+
+  watcher.on("add", scheduleRefresh);
+  watcher.on("change", scheduleRefresh);
+  watcher.on("unlink", scheduleRefresh);
+  watcher.on("addDir", scheduleRefresh);
+  watcher.on("unlinkDir", scheduleRefresh);
+
+  return watcher;
+}


### PR DESCRIPTION
## TL;DR

**What:** Move `/gsd watch` from #2981 into a standalone bundled extension.
**Why:** Follows extension-first architecture — watch is a companion tool, not a core workflow step.
**How:** New `src/resources/extensions/gsd-watch/` with manifest, decoupled imports, `/watch` command.

> **WIP** — still iterating on this.

## What

Standalone bundled extension at `src/resources/extensions/gsd-watch/` that provides a live TUI dashboard as a tmux sidebar pane showing a navigable tree of milestones, phases, and plans with status badges.

### Changes from #2981
- Registered as `/watch` (standalone command) instead of `/gsd watch` (subcommand)
- `/watch stop` subcommand via `getArgumentCompletions`
- Uses `ctx.cwd` instead of GSD-internal `projectRoot()`
- Local `resolveGsdDir()` instead of GSD-internal `gsdRoot()`
- Dynamic import for gsd-db (soft dependency on GSD extension)
- Zero imports from parent directory — fully decoupled from GSD core
- `extension-manifest.json` with `tier: "bundled"`, `dependencies.extensions: ["gsd"]`
- 113 tests passing across 5 test files

## Why

- Extension-first: watch is a companion dashboard, not a workflow step
- Can be disabled independently by users without tmux
- Clean extension boundary — no modifications to GSD core's catalog.ts or core.ts
- Follows the new [Extension SDK](docs/extension-sdk/) conventions (#3149)

## Remaining work

- [ ] Add `gsd-watch` to test:unit glob in package.json
- [ ] Integration test with actual tmux session
- [ ] Verify `/watch stop` kills the pane correctly
- [ ] Consider whether `/watch` or `/gsd watch` is the right UX

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] 113 unit tests pass
- [ ] Manual: `/watch` spawns tmux pane
- [ ] Manual: `/watch stop` kills it
- [ ] Manual: tree updates on `.planning/` file changes