### PR TITLE
fix(extensions): update provides.hooks in 7 extension manifests

### DIFF
--- a/src/resources/extensions/async-jobs/extension-manifest.json
+++ b/src/resources/extensions/async-jobs/extension-manifest.json
@@ -8,6 +8,6 @@
   "provides": {
     "tools": ["async_bash", "await_job", "cancel_job"],
     "commands": ["jobs"],
-    "hooks": ["session_start"]
+    "hooks": ["session_start", "session_before_switch", "session_shutdown"]
   }
 }

--- a/src/resources/extensions/bg-shell/extension-manifest.json
+++ b/src/resources/extensions/bg-shell/extension-manifest.json
@@ -8,7 +8,7 @@
   "provides": {
     "tools": ["bg_shell"],
     "commands": ["bg"],
-    "hooks": ["session_shutdown"],
+    "hooks": ["session_shutdown", "session_compact", "session_tree", "session_switch", "before_agent_start", "session_start", "turn_end", "agent_end", "tool_execution_end"],
     "shortcuts": ["Ctrl+Alt+B"]
   }
 }

--- a/src/resources/extensions/browser-tools/extension-manifest.json
+++ b/src/resources/extensions/browser-tools/extension-manifest.json
@@ -29,7 +29,7 @@
       "browser_visual_diff", "browser_zoom_region",
       "browser_generate_test", "browser_action_cache", "browser_check_injection"
     ],
-    "hooks": ["session_shutdown"]
+    "hooks": ["session_start", "session_shutdown"]
   },
   "dependencies": {
     "runtime": ["playwright"]

--- a/src/resources/extensions/context7/extension-manifest.json
+++ b/src/resources/extensions/context7/extension-manifest.json
@@ -7,6 +7,6 @@
   "requires": { "platform": ">=2.29.0" },
   "provides": {
     "tools": ["resolve_library", "get_library_docs"],
-    "hooks": ["session_start"]
+    "hooks": ["session_start", "session_shutdown"]
   }
 }

--- a/src/resources/extensions/google-search/extension-manifest.json
+++ b/src/resources/extensions/google-search/extension-manifest.json
@@ -7,6 +7,6 @@
   "requires": { "platform": ">=2.29.0" },
   "provides": {
     "tools": ["google_search"],
-    "hooks": ["session_start"]
+    "hooks": ["session_start", "session_shutdown"]
   }
 }

--- a/src/resources/extensions/gsd/extension-manifest.json
+++ b/src/resources/extensions/gsd/extension-manifest.json
@@ -12,7 +12,22 @@
       "gsd_requirement_update", "gsd_milestone_generate_id"
     ],
     "commands": ["gsd", "kill", "worktree", "exit"],
-    "hooks": ["session_start", "session_switch"],
+    "hooks": [
+      "session_start",
+      "session_switch",
+      "bash_transform",
+      "session_fork",
+      "before_agent_start",
+      "agent_end",
+      "session_before_compact",
+      "session_shutdown",
+      "tool_call",
+      "tool_result",
+      "tool_execution_start",
+      "tool_execution_end",
+      "model_select",
+      "before_provider_request"
+    ],
     "shortcuts": ["Ctrl+Alt+G"]
   }
 }

--- a/src/resources/extensions/search-the-web/extension-manifest.json
+++ b/src/resources/extensions/search-the-web/extension-manifest.json
@@ -8,6 +8,6 @@
   "provides": {
     "tools": ["search-the-web", "fetch_page", "search_and_read", "web_search"],
     "commands": ["search-provider"],
-    "hooks": ["model_select", "before_provider_request"]
+    "hooks": ["session_start", "model_select", "before_provider_request"]
   }
 }


### PR DESCRIPTION
## TL;DR

**What:** Update `provides.hooks` arrays in 7 bundled extension manifests to match actual `pi.on()` registrations.
**Why:** Regression test (#3149) found manifests were incomplete — blocks accurate extension capability discovery.
**How:** Audited every `pi.on()` call in each extension and updated manifests.

Closes #3156

## What

| Extension | Before | After |
|-----------|--------|-------|
| async-jobs | `session_start` | +`session_before_switch`, `session_shutdown` |
| bg-shell | `session_shutdown` | +`session_compact`, `session_tree`, `session_switch`, `before_agent_start`, `session_start`, `turn_end`, `agent_end`, `tool_execution_end` |
| browser-tools | `session_shutdown` | +`session_start` |
| context7 | `session_start` | +`session_shutdown` |
| google-search | `session_start` | +`session_shutdown` |
| gsd | `session_start`, `session_switch` | +`bash_transform`, `session_fork`, `before_agent_start`, `agent_end`, `session_before_compact`, `session_shutdown`, `tool_call`, `tool_result`, `tool_execution_start`, `tool_execution_end`, `model_select`, `before_provider_request` |
| search-the-web | `model_select`, `before_provider_request` | +`session_start` |

## Why

Found during full extension regression test for #3149 (Extension SDK). Manifests are currently informational but should be accurate for:
- Extension capability discovery
- Dependency validation
- SDK documentation generation

## How

For each extension: grep all `pi.on()` calls in source, cross-reference with manifest, update.

## Test plan

- [x] `npx tsc --noEmit` passes (JSON-only changes)
- [x] No runtime behavior change — manifests are read-only metadata
- [x] Each hook verified against source `pi.on()` calls