### PR TITLE
fix: create .gsd/ in parallel worktrees before state sync

### DIFF
--- a/src/resources/extensions/gsd/auto-worktree.ts
+++ b/src/resources/extensions/gsd/auto-worktree.ts
@@ -435,7 +435,14 @@ export function syncGsdStateToWorktree(
   // If both resolve to the same directory (symlink), no sync needed
   if (isSamePath(mainGsd, wtGsd)) return { synced };
 
-  if (!existsSync(mainGsd) || !existsSync(wtGsd)) return { synced };
+  if (!existsSync(mainGsd)) return { synced };
+
+  // Ensure the .gsd/ directory exists in the worktree — git won't create it
+  // because .gsd is gitignored. Without this, parallel workers fail with
+  // "No .gsd/ directory found in current directory".
+  if (!existsSync(wtGsd)) {
+    mkdirSync(wtGsd, { recursive: true });
+  }
 
   // Sync root-level .gsd/ files (DECISIONS, REQUIREMENTS, PROJECT, KNOWLEDGE, etc.)
   for (const f of ROOT_STATE_FILES) {

--- a/src/resources/extensions/gsd/parallel-orchestrator.ts
+++ b/src/resources/extensions/gsd/parallel-orchestrator.ts
@@ -431,9 +431,12 @@ export async function startParallel(
       try {
         wtPath = createMilestoneWorktree(basePath, mid);
       } catch {
-        // Worktree creation may fail in test environments or when git
-        // is not available. Fall back to a placeholder path.
+        // Worktree already exists (e.g. restart after error) or git is
+        // unavailable. Fall back to the existing path and ensure .gsd/
+        // state is synced — createMilestoneWorktree handles sync
+        // internally, but the fallback path skips it.
         wtPath = worktreePath(basePath, mid);
+        syncGsdStateToWorktree(basePath, wtPath);
       }
 
       const worker: WorkerInfo = {


### PR DESCRIPTION
## TL;DR

**What:** Ensure `.gsd/` directory exists in parallel worktrees before syncing state files.
**Why:** When `.gsd/` is gitignored (common in team repos), `git worktree add` does not create it — headless workers crash immediately.
**How:** `syncGsdStateToWorktree` now `mkdirSync`s the target `.gsd/` instead of bailing, and the orchestrator's fallback path calls the sync on restart.

## What

Two changes in `auto-worktree.ts` and `parallel-orchestrator.ts`:

1. `syncGsdStateToWorktree` — replaced `if (!existsSync(wtGsd)) return` with `if (!existsSync(wtGsd)) mkdirSync(wtGsd, { recursive: true })`.
2. `parallel-orchestrator.ts` — the catch block in the worker startup loop (when `createWorktree` throws because the worktree already exists) now calls `syncGsdStateToWorktree` on the fallback path.

## Why

When `.gsd/` is gitignored (common in team repos), `git worktree add` does not include it. `syncGsdStateToWorktree` has a guard that returns early if the target `.gsd/` does not exist. This means parallel workers start without a `.gsd/` directory. The headless process then fails with "No .gsd/ directory found in current directory" and exits code 1.

Additionally, on restart after a crash, `createWorktree` throws `GSD_STALE_STATE` because the worktree already exists. The orchestrator catches this and falls back to `worktreePath()` — but never calls `syncGsdStateToWorktree`, so the worktree remains without state even on retry.

## How

The natural fix point is `syncGsdStateToWorktree` itself — it is the function responsible for ensuring the worktree has the state it needs. Creating the directory when it is missing (rather than bailing) is safe because the function already handles missing individual files gracefully. The orchestrator fix ensures the sync runs on the restart/fallback path too.

## Change type
- [x] `fix` — Bug fix

## Scope
- [x] `gsd extension` — GSD workflow

## Breaking changes
- [x] No breaking changes

## Test plan
- [x] Manual testing — enabled `parallel.enabled: true`, ran `/gsd parallel start`, confirmed both workers start successfully. Previously the second worker crashed immediately with "No .gsd/ directory found in current directory".

## AI disclosure
- [x] This PR includes AI-assisted code — Claude Code identified and implemented the fix. Both changes were manually verified by reproducing the bug and confirming the fix.