### PR TITLE
fix: wire require_slice_discussion into auto-mode dispatch

### DIFF
--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -317,6 +317,22 @@ export const DISPATCH_RULES: DispatchRule[] = [
     },
   },
   {
+    name: "planning (require_slice_discussion gate) → pause",
+    match: async ({ state, mid, basePath, prefs }) => {
+      if (state.phase !== "planning") return null;
+      if (!prefs?.phases?.require_slice_discussion) return null;
+      if (!state.activeSlice) return null; // fall through to missing-slice stop
+      const sid = state.activeSlice.id;
+      const sliceContextFile = resolveSliceFile(basePath, mid, sid, "CONTEXT");
+      if (sliceContextFile) return null; // has context, discussion already happened
+      return {
+        action: "stop",
+        reason: `Slice ${sid} requires discussion before planning. Run /gsd discuss to discuss this slice, then /gsd auto to resume.`,
+        level: "info",
+      };
+    },
+  },
+  {
     name: "planning (no research, not S01) → research-slice",
     match: async ({ state, mid, midTitle, basePath, prefs }) => {
       if (state.phase !== "planning") return null;

--- a/src/resources/extensions/gsd/tests/require-slice-discussion.test.ts
+++ b/src/resources/extensions/gsd/tests/require-slice-discussion.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Tests for the require_slice_discussion dispatch gate.
+ *
+ * When `phases.require_slice_discussion` is enabled and the active slice
+ * has no CONTEXT.md, auto-mode should stop (pause) instead of dispatching
+ * research-slice or plan-slice.
+ *
+ * When the slice has a CONTEXT.md (discussion already happened), dispatch
+ * should proceed normally.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { resolveDispatch } from "../auto-dispatch.ts";
+import type { DispatchContext } from "../auto-dispatch.ts";
+import type { GSDState } from "../types.ts";
+
+function makeState(overrides: Partial<GSDState> = {}): GSDState {
+  return {
+    activeMilestone: { id: "M001", title: "Test Milestone" },
+    activeSlice: { id: "S02", title: "Second Slice" },
+    activeTask: null,
+    phase: "planning",
+    recentDecisions: [],
+    blockers: [],
+    nextAction: "",
+    registry: [],
+    ...overrides,
+  };
+}
+
+function scaffoldMilestone(basePath: string, mid: string): void {
+  const dir = join(basePath, ".gsd", "milestones", mid);
+  mkdirSync(dir, { recursive: true });
+  // Minimal context so milestone-level rules don't interfere
+  writeFileSync(join(dir, `${mid}-CONTEXT.md`), `# ${mid} Context\n`);
+  writeFileSync(join(dir, `${mid}-ROADMAP.md`), `# ${mid} Roadmap\n`);
+}
+
+function scaffoldSliceDir(basePath: string, mid: string, sid: string): void {
+  const dir = join(basePath, ".gsd", "milestones", mid, "slices", sid);
+  mkdirSync(dir, { recursive: true });
+}
+
+function scaffoldSliceContext(basePath: string, mid: string, sid: string): void {
+  const dir = join(basePath, ".gsd", "milestones", mid, "slices", sid);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, `${sid}-CONTEXT.md`), `# ${sid} Context\n\nDiscussion notes.\n`);
+}
+
+// ─── Tests ─────────────────────────────────────────────────────────────────
+
+test("dispatch: require_slice_discussion stops when slice has no CONTEXT", async (t) => {
+  const tmp = mkdtempSync(join(tmpdir(), "gsd-slice-discuss-"));
+  t.after(() => rmSync(tmp, { recursive: true, force: true }));
+
+  scaffoldMilestone(tmp, "M001");
+  scaffoldSliceDir(tmp, "M001", "S02");
+
+  const ctx: DispatchContext = {
+    basePath: tmp,
+    mid: "M001",
+    midTitle: "Test Milestone",
+    state: makeState(),
+    prefs: {
+      phases: { require_slice_discussion: true },
+    } as any,
+  };
+
+  const result = await resolveDispatch(ctx);
+  assert.equal(result.action, "stop", "should stop to require discussion");
+  assert.match(result.reason!, /S02.*discussion/i, "reason should mention the slice and discussion");
+});
+
+test("dispatch: require_slice_discussion allows dispatch when slice has CONTEXT", async (t) => {
+  const tmp = mkdtempSync(join(tmpdir(), "gsd-slice-discuss-"));
+  t.after(() => rmSync(tmp, { recursive: true, force: true }));
+
+  scaffoldMilestone(tmp, "M001");
+  scaffoldSliceContext(tmp, "M001", "S02");
+
+  const ctx: DispatchContext = {
+    basePath: tmp,
+    mid: "M001",
+    midTitle: "Test Milestone",
+    state: makeState(),
+    prefs: {
+      phases: { require_slice_discussion: true },
+    } as any,
+  };
+
+  const result = await resolveDispatch(ctx);
+  // Should fall through to research-slice or plan-slice, not stop
+  assert.notEqual(result.action, "stop", "should not stop when CONTEXT exists");
+  if (result.action === "dispatch") {
+    assert.match(result.unitType, /slice/, "should dispatch a slice-level unit");
+  }
+});
+
+test("dispatch: planning proceeds normally when require_slice_discussion is off", async (t) => {
+  const tmp = mkdtempSync(join(tmpdir(), "gsd-slice-discuss-"));
+  t.after(() => rmSync(tmp, { recursive: true, force: true }));
+
+  scaffoldMilestone(tmp, "M001");
+  scaffoldSliceDir(tmp, "M001", "S02");
+
+  const ctx: DispatchContext = {
+    basePath: tmp,
+    mid: "M001",
+    midTitle: "Test Milestone",
+    state: makeState(),
+    prefs: undefined, // no prefs = no discussion gate
+  };
+
+  const result = await resolveDispatch(ctx);
+  assert.notEqual(result.action, "stop", "should not stop when preference is off");
+});


### PR DESCRIPTION
## TL;DR

**What:** Wire `require_slice_discussion` into the auto-mode dispatch table so it actually pauses between slices.
**Why:** The preference was only checked in the manual `/gsd dispatch` path, making it a no-op during `/gsd auto`.
**How:** Add a new dispatch rule before the research-slice and plan-slice rules that stops auto-mode when the slice has no CONTEXT.md.

> **AI-assisted:** This PR was developed with AI assistance (Claude). The contributor has reviewed and tested all changes.

## What

Adds a new dispatch rule `planning (require_slice_discussion gate) → pause` to `auto-dispatch.ts`. The rule fires when:
- The state phase is `planning`
- `phases.require_slice_discussion` is `true` in preferences
- The active slice has no `CONTEXT.md` file (meaning discussion hasn't happened)

When triggered, auto-mode stops with a message directing the user to run `/gsd discuss`.

Also adds three regression tests covering: gate fires when no CONTEXT exists, gate allows dispatch when CONTEXT exists, and normal dispatch when the preference is off.

## Why

`require_slice_discussion: true` was only checked in `auto-direct-dispatch.ts` (the handler for manual `/gsd dispatch` commands). The auto-mode dispatch table in `auto-dispatch.ts` — which is the code path `/gsd auto` actually uses — never checked this preference. Auto-mode would blow straight through slice transitions without pausing for discussion.

## How

A single new rule is inserted into the `DISPATCH_RULES` array before the existing `planning (no research, not S01) → research-slice` rule. Since dispatch rules evaluate in order and first match wins, the discussion gate fires before any slice-level dispatch can occur. Once the user runs `/gsd discuss` and a CONTEXT.md is written, the gate returns null and falls through to research/plan as normal.

This mirrors the existing check in `auto-direct-dispatch.ts` (line 69) but placed in the correct code path.

## Change type

- [x] `fix` — Bug fix
- [x] `test` — Adding tests