### PR TITLE
fix(web): pass --webpack flag to next dev for Next.js 16 compatibility

### DIFF
--- a/src/web-mode.ts
+++ b/src/web-mode.ts
@@ -386,7 +386,7 @@ function buildSpawnSpec(
 
   return {
     command: getSpawnCommandForSourceHost(platform),
-    args: ['run', 'dev', '--', '--hostname', host, '--port', String(port)],
+    args: ['run', 'dev', '--', '--webpack', '--hostname', host, '--port', String(port)],
     cwd: resolution.hostRoot,
   }
 }


### PR DESCRIPTION
## TL;DR

**What:** Add `--webpack` flag to the `next dev` spawn args in `web-mode.ts`.
**Why:** Next.js 16 defaults to Turbopack, which doesn't support `extensionAlias` — breaking `gsd --web`.
**How:** One-line change in `buildSpawnSpec()`.

## What

`gsd --web` fails to start on Next.js 16.1.6. The dev server exits with:

```
⨯ ERROR: This build is using Turbopack, with a `webpack` config and no `turbopack` config.
```

## Why

`web/next.config.mjs` uses a webpack callback for `extensionAlias` (`.js` → `.ts` resolution). The config itself notes this on line 19:

```js
// Turbopack doesn't support extensionAlias, so builds use --webpack flag.
```

But the flag was never actually passed in the dev spawn command. This worked on Next.js 15 (webpack was the default), but Next.js 16 changed the default to Turbopack.

## How

Add `--webpack` to the spawn args in `buildSpawnSpec()`:

```diff
- args: ['run', 'dev', '--', '--hostname', host, '--port', String(port)],
+ args: ['run', 'dev', '--', '--webpack', '--hostname', host, '--port', String(port)],
```

Closes #3192

- [x] `fix` — Bug fix

This PR is AI-assisted.