### PR TITLE
test(web): isolate compile cache from onboarding runtime temp root

### DIFF
--- a/src/tests/integration/web-mode-onboarding.test.ts
+++ b/src/tests/integration/web-mode-onboarding.test.ts
@@ -452,12 +452,14 @@ test("fresh gsd --web browser onboarding stays locked on failed validation and u
   const tempRoot = mkdtempSync(join(tmpdir(), "gsd-web-onboarding-runtime-"))
   const tempHome = join(tempRoot, "home")
   const browserLogPath = join(tempRoot, "browser-open.log")
+  const compileCacheRoot = mkdtempSync(join(tmpdir(), "gsd-node-compile-cache-"))
   let port: number | null = null
 
   t.after(async () => {
     if (port !== null) {
-    await killProcessOnPort(port)
+      await killProcessOnPort(port)
     }
+    await removeTreeWithRetry(compileCacheRoot)
     await removeTreeWithRetry(tempRoot)
   });
 
@@ -471,6 +473,7 @@ test("fresh gsd --web browser onboarding stays locked on failed validation and u
       ANTHROPIC_API_KEY: "",
       OPENAI_API_KEY: "",
       GOOGLE_API_KEY: "",
+      NODE_COMPILE_CACHE: compileCacheRoot,
     },
   })
   port = launch.port


### PR DESCRIPTION
## Linked issue

Closes #3195

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Isolate the Node compile cache from the web onboarding runtime test temp root.
**Why:** Teardown could intermittently fail with `ENOTEMPTY` when Node wrote compile-cache files into the directory being deleted.
**How:** Create a dedicated compile-cache temp dir, pass it via `NODE_COMPILE_CACHE`, and clean both temp roots up explicitly.

## What

This PR updates `src/tests/integration/web-mode-onboarding.test.ts` for the packaged `gsd --web` onboarding runtime test.

The test now:
- creates a dedicated `compileCacheRoot`
- passes `NODE_COMPILE_CACHE` into the launched runtime
- removes both the compile-cache root and the test temp root explicitly during teardown
- keeps the fix scoped to the integration test harness

## Why

The runtime test could fail during teardown with an intermittent `ENOTEMPTY` when it deleted its temp root immediately after stopping the runtime process.

That temp root could also receive Node compile-cache writes, so late cache-file activity could race with cleanup and make the test flaky even when the onboarding flow itself worked correctly.

## How

Instead of letting the launched runtime write compile-cache files under the same temp root that the test deletes, the test routes compile-cache writes to a sibling temp directory and cleans it up separately.

## Change type

- [ ] `feat` — New feature or capability
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [ ] Manual testing — steps described above
- [ ] No tests needed — explained above

Automated verification:
- `npm run build`
- `npm run typecheck:extensions`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/tests/integration/web-mode-onboarding.test.ts`
- `npm run test:unit` (`7857 passed, 0 failed, 9 skipped`)
- `npm run test:integration` (`1115 passed, 0 failed, 3 skipped`)

## AI disclosure

- [x] This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.
