### PR TITLE
fix(definition-loader): allow whitespace in {{ key }} placeholders

### DIFF
--- a/src/resources/extensions/gsd/definition-loader.ts
+++ b/src/resources/extensions/gsd/definition-loader.ts
@@ -387,7 +387,7 @@ export function loadDefinition(defsDir: string, name: string): WorkflowDefinitio
 // ─── Parameter Substitution ──────────────────────────────────────────────
 
 /** Regex matching `{{key}}` placeholders — captures the key name. */
-const PARAM_PATTERN = /\{\{(\w+)\}\}/g;
+const PARAM_PATTERN = /\{\{\s*(\w+)\s*\}\}/g;
 
 /**
  * Replace `{{key}}` placeholders in a single prompt string.

--- a/src/resources/extensions/gsd/tests/definition-loader.test.ts
+++ b/src/resources/extensions/gsd/tests/definition-loader.test.ts
@@ -760,3 +760,24 @@ steps:
   assert.deepEqual(def.steps[0].requires, []);
   assert.deepEqual(def.steps[0].produces, []);
 });
+
+// ─── Regression #3189: spaced placeholders ────────────────────────────────
+// PARAM_PATTERN must match {{ key }} (with surrounding whitespace) as well as
+// {{key}} (no spaces). Before the fix, spaced placeholders were silently left
+// unreplaced in generated prompts.
+
+test("substitutePromptString: replaces {{ key }} with surrounding spaces (#3189)", () => {
+  const result = substitutePromptString(
+    "Hello {{ name }}, your score is {{ score }}.",
+    { name: "Alice", score: "42" },
+  );
+  assert.equal(result, "Hello Alice, your score is 42.");
+});
+
+test("substitutePromptString: unchanged behaviour for {{key}} without spaces (#3189)", () => {
+  const result = substitutePromptString(
+    "Hello {{name}}.",
+    { name: "Bob" },
+  );
+  assert.equal(result, "Hello Bob.");
+});


### PR DESCRIPTION
## TL;DR

**What:** Change `PARAM_PATTERN` from `/\{\{(\w+)\}\}/g` to `/\{\{\s*(\w+)\s*\}\}/g`
**Why:** Templates written with standard Jinja/Mustache spacing (`{{ key }}`) were silently left unreplaced, producing broken prompts — closes #3189
**How:** One-line regex change; both `substitutePromptString` and the unresolved-placeholder check derive from `PARAM_PATTERN.source` so both are fixed automatically

## What

Changed the `PARAM_PATTERN` constant in `src/resources/extensions/gsd/definition-loader.ts` (line 390) to accept optional whitespace around the captured key name. No other code changes — the fix propagates to all consumers automatically.

Added two regression tests to `src/resources/extensions/gsd/tests/definition-loader.test.ts`:
- `substitutePromptString: replaces {{ key }} with surrounding spaces (#3189)` — failed before the fix, passes after
- `substitutePromptString: unchanged behaviour for {{key}} without spaces (#3189)` — guards against regression

## Why

Authors writing workflow definitions in YAML commonly use `{{ key }}` (with spaces) following standard Jinja/Mustache conventions. The old regex only matched `{{key}}` (no spaces), so spaced placeholders were passed through unchanged into generated prompts. There was no error or warning — the substitution silently failed.

Closes #3189

## How

The fix adds `\s*` on both sides of the `\w+` capture group:

```
- const PARAM_PATTERN = /\{\{(\w+)\}\}/g;
+ const PARAM_PATTERN = /\{\{\s*(\w+)\s*\}\}/g;
```

Because `substituteParams` reconstructs the regex from `PARAM_PATTERN.source` for its unresolved-placeholder detection loop (line 447), both paths receive the fix from this single change.

---

### Change type checklist

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

---

> This PR is AI-assisted. The analysis, code change, and tests were produced with AI tooling. The fix has been manually reviewed, the test was confirmed to fail before the change and pass after, and `npm run build` exits cleanly.