### PR TITLE
fix(memory-extractor): dereference entry.message for activity-log format

### DIFF
--- a/src/resources/extensions/gsd/memory-extractor.ts
+++ b/src/resources/extensions/gsd/memory-extractor.ts
@@ -164,7 +164,7 @@ function buildExtractionUserPrompt(
  * Extract assistant message text from activity JSONL.
  * Returns concatenated text content from assistant role entries.
  */
-function extractTranscriptFromActivity(raw: string, maxChars = 30_000): string {
+export function extractTranscriptFromActivity(raw: string, maxChars = 30_000): string {
   const lines = raw.split('\n');
   const parts: string[] = [];
   let totalChars = 0;

--- a/src/resources/extensions/gsd/memory-extractor.ts
+++ b/src/resources/extensions/gsd/memory-extractor.ts
@@ -173,11 +173,12 @@ export function extractTranscriptFromActivity(raw: string, maxChars = 30_000): s
     if (!line.trim()) continue;
     try {
       const entry = JSON.parse(line);
-      if (entry.role !== 'assistant') continue;
+      const msg = (entry.type === 'message' && entry.message) ? entry.message : entry;
+      if (msg.role !== 'assistant') continue;
 
       // Handle content array or direct text
-      if (Array.isArray(entry.content)) {
-        for (const block of entry.content) {
+      if (Array.isArray(msg.content)) {
+        for (const block of msg.content) {
           if (block.type === 'text' && block.text) {
             const text = block.text;
             if (totalChars + text.length > maxChars) {
@@ -188,8 +189,8 @@ export function extractTranscriptFromActivity(raw: string, maxChars = 30_000): s
             totalChars += text.length;
           }
         }
-      } else if (typeof entry.content === 'string') {
-        const text = entry.content;
+      } else if (typeof msg.content === 'string') {
+        const text = msg.content;
         if (totalChars + text.length > maxChars) {
           parts.push(text.substring(0, maxChars - totalChars));
           return parts.join('\n\n');

--- a/src/resources/extensions/gsd/tests/memory-extractor.test.ts
+++ b/src/resources/extensions/gsd/tests/memory-extractor.test.ts
@@ -1,4 +1,4 @@
-import { parseMemoryResponse, _resetExtractionState, buildMemoryLLMCall } from '../memory-extractor.ts';
+import { parseMemoryResponse, _resetExtractionState, buildMemoryLLMCall, extractTranscriptFromActivity } from '../memory-extractor.ts';
 import {
   openDatabase,
   closeDatabase,
@@ -250,5 +250,59 @@ test('memory-extractor: buildMemoryLLMCall prefers haiku model', async () => {
   await new Promise(resolve => setTimeout(resolve, 50));
   assert.strictEqual(resolvedModelId, 'claude-3-5-haiku-20241022',
     'should resolve API key for haiku model, not sonnet');
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Regression: extractTranscriptFromActivity — issue #3182
+// Activity log wraps messages as { type: "message", message: { role, content } }.
+// The original code read entry.role directly (always undefined on the outer
+// object), silently dropping every assistant turn and producing empty transcripts.
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('extractTranscriptFromActivity (#3182)', () => {
+  test('extracts text from wrapped { type, message } format', () => {
+    // Before fix: entry.role is undefined on the outer object → silently skipped
+    const line = JSON.stringify({
+      type: 'message',
+      message: {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'Hello world' }],
+      },
+    });
+    const result = extractTranscriptFromActivity(line);
+    assert.ok(
+      result.includes('Hello world'),
+      `Expected result to contain "Hello world", got: ${JSON.stringify(result)}`,
+    );
+  });
+
+  test('ignores non-assistant messages in wrapped format', () => {
+    const line = JSON.stringify({
+      type: 'message',
+      message: {
+        role: 'user',
+        content: [{ type: 'text', text: 'User input' }],
+      },
+    });
+    const result = extractTranscriptFromActivity(line);
+    assert.equal(
+      result.trim(),
+      '',
+      `Expected empty result for user message, got: ${JSON.stringify(result)}`,
+    );
+  });
+
+  test('backward-compatible with bare { role, content } format', () => {
+    // Legacy format without outer wrapper — must work before and after fix
+    const line = JSON.stringify({
+      role: 'assistant',
+      content: [{ type: 'text', text: 'Legacy format' }],
+    });
+    const result = extractTranscriptFromActivity(line);
+    assert.ok(
+      result.includes('Legacy format'),
+      `Expected result to contain "Legacy format", got: ${JSON.stringify(result)}`,
+    );
+  });
 });
 


### PR DESCRIPTION
## TL;DR

**What:** In `extractTranscriptFromActivity`, introduce `const msg = (entry.type === 'message' && entry.message) ? entry.message : entry` and read `msg.role` / `msg.content` instead of `entry.role` / `entry.content`
**Why:** Closes #3182 — activity log lines use `{ type: "message", message: { role, content } }` wrapper; reading `entry.role` directly always yields `undefined`, so every assistant turn is silently dropped and memory extraction produces nothing
**How:** Single dereference variable added; backward-compatible with bare `{ role, content }` entries via the ternary fallback

## What

Modified `src/resources/extensions/gsd/memory-extractor.ts`: the `extractTranscriptFromActivity` function now unwraps the activity-log message envelope before reading `role` and `content`.

Added regression tests to `src/resources/extensions/gsd/tests/memory-extractor.test.ts` covering:
1. Wrapped `{ type, message }` format (the failing case)
2. Non-assistant messages in wrapped format are ignored
3. Bare `{ role, content }` legacy format still works

## Why

Closes #3182. The activity log writes entries in the format:

```json
{ "type": "message", "message": { "role": "assistant", "content": [...] } }
```

The original code read `entry.role` directly. Since `role` lives inside `entry.message`, not on the outer object, `entry.role` is always `undefined`. The `if (entry.role !== 'assistant') continue` guard therefore skips every entry — including all assistant messages. The function returns an empty string, so no memories are ever learned from sessions.

## How

```typescript
const msg = (entry.type === 'message' && entry.message) ? entry.message : entry;
if (msg.role !== 'assistant') continue;
```

The ternary unwraps the envelope when present; otherwise falls back to `entry` directly, preserving backward compatibility with any bare `{ role, content }` legacy entries.

---

**Change type:**
- [x] `fix` — Bug fix

**AI disclosure:** This PR was prepared with AI assistance. The fix, tests, and understanding of root cause are my own.