### PR TITLE
fix(state): check activeMilestoneHasDraft in hasRoadmap zero-slices branch

### DIFF
--- a/src/resources/extensions/gsd/state.ts
+++ b/src/resources/extensions/gsd/state.ts
@@ -659,13 +659,14 @@ export async function deriveStateFromDb(basePath: string): Promise<GSDState> {
       };
     }
 
-    // Has roadmap file but zero slices in DB — pre-planning (zero-slice roadmap guard)
+    // Has roadmap file but zero slices in DB — check for CONTEXT-DRAFT even in this branch (#3191)
+    const phase = activeMilestoneHasDraft ? 'needs-discussion' as const : 'pre-planning' as const;
+    const nextAction = activeMilestoneHasDraft
+      ? `Discuss draft context for milestone ${activeMilestone.id}.`
+      : `Milestone ${activeMilestone.id} has a roadmap but no slices defined. Add slices to the roadmap.`;
     return {
       activeMilestone, activeSlice: null, activeTask: null,
-      phase: 'pre-planning',
-      recentDecisions: [], blockers: [],
-      nextAction: `Milestone ${activeMilestone.id} has a roadmap but no slices defined. Add slices to the roadmap.`,
-      registry, requirements,
+      phase, recentDecisions: [], blockers: [], nextAction, registry, requirements,
       progress: {
         milestones: milestoneProgress,
         slices: { done: 0, total: 0 },
@@ -1236,6 +1237,9 @@ export async function _deriveStateImpl(basePath: string): Promise<GSDState> {
           activeMilestone = { id: mid, title };
           activeRoadmap = roadmap;
           activeMilestoneFound = true;
+          // Check for CONTEXT-DRAFT even when a roadmap exists — a stub roadmap can
+          // coexist with a CONTEXT-DRAFT that still needs discussion (#3191).
+          if (!contextContent && draftFile) activeMilestoneHasDraft = true;
           registry.push({ id: mid, title, status: 'active', ...(deps.length > 0 ? { dependsOn: deps } : {}) });
         }
       } else {
@@ -1368,16 +1372,21 @@ export async function _deriveStateImpl(basePath: string): Promise<GSDState> {
   // roadmap object but an empty slices array. Without this check the
   // slice-finding loop below finds nothing and returns phase: "blocked".
   // An empty slices array means the roadmap still needs slice definitions,
-  // so the correct phase is pre-planning.
+  // so the correct phase is pre-planning — unless a CONTEXT-DRAFT also
+  // exists, in which case the milestone still needs discussion (#3191).
   if (activeRoadmap.slices.length === 0) {
+    const zeroSlicePhase = activeMilestoneHasDraft ? 'needs-discussion' as const : 'pre-planning' as const;
+    const zeroSliceNextAction = activeMilestoneHasDraft
+      ? `Discuss draft context for milestone ${activeMilestone.id}.`
+      : `Milestone ${activeMilestone.id} has a roadmap but no slices defined. Add slices to the roadmap.`;
     return {
       activeMilestone,
       activeSlice: null,
       activeTask: null,
-      phase: 'pre-planning',
+      phase: zeroSlicePhase,
       recentDecisions: [],
       blockers: [],
-      nextAction: `Milestone ${activeMilestone.id} has a roadmap but no slices defined. Add slices to the roadmap.`,
+      nextAction: zeroSliceNextAction,
       registry,
       requirements,
       progress: {

--- a/src/resources/extensions/gsd/tests/state-draft-roadmap-phase.test.ts
+++ b/src/resources/extensions/gsd/tests/state-draft-roadmap-phase.test.ts
@@ -1,0 +1,133 @@
+// Regression test for https://github.com/gsd-build/gsd-2/issues/3191
+// Verifies that a milestone with a stub ROADMAP file and zero DB slices but an
+// existing CONTEXT-DRAFT returns 'needs-discussion', not 'pre-planning'.
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { deriveState } from '../state.js';
+
+let passed = 0;
+let failed = 0;
+
+function assertEq<T>(actual: T, expected: T, message: string): void {
+  if (JSON.stringify(actual) === JSON.stringify(expected)) {
+    passed++;
+  } else {
+    failed++;
+    console.error(`  FAIL: ${message} — expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+  }
+}
+
+// ─── Fixture Helpers ───────────────────────────────────────────────────────
+
+function createFixtureBase(): string {
+  const base = mkdtempSync(join(tmpdir(), 'gsd-draft-roadmap-'));
+  mkdirSync(join(base, '.gsd', 'milestones'), { recursive: true });
+  return base;
+}
+
+function writeContextDraft(base: string, mid: string, content: string): void {
+  const dir = join(base, '.gsd', 'milestones', mid);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, `${mid}-CONTEXT-DRAFT.md`), content);
+}
+
+function writeContext(base: string, mid: string, content: string): void {
+  const dir = join(base, '.gsd', 'milestones', mid);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, `${mid}-CONTEXT.md`), content);
+}
+
+function writeRoadmap(base: string, mid: string, content: string): void {
+  const dir = join(base, '.gsd', 'milestones', mid);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, `${mid}-ROADMAP.md`), content);
+}
+
+function cleanup(base: string): void {
+  rmSync(base, { recursive: true, force: true });
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Test Groups
+// ═══════════════════════════════════════════════════════════════════════════
+
+async function main(): Promise<void> {
+
+  // ─── Test A: ROADMAP + CONTEXT-DRAFT + zero DB slices → needs-discussion ──
+  // (#3191) The hasRoadmap branch was ignoring activeMilestoneHasDraft.
+  console.log('\n=== Test A: ROADMAP + CONTEXT-DRAFT + zero slices → needs-discussion ===');
+  {
+    const base = createFixtureBase();
+    try {
+      // Stub ROADMAP file with no slices listed
+      writeRoadmap(base, 'M001', '# M001: Stub Roadmap\n\n**Vision:** TBD.\n\n## Slices\n\n(none yet)\n');
+      // CONTEXT-DRAFT present — user still needs to discuss context
+      writeContextDraft(base, 'M001', '# Draft Context\n\nSeed discussion material.');
+
+      const state = await deriveState(base);
+
+      assertEq(state.phase, 'needs-discussion', 'Test A: phase should be needs-discussion (#3191)');
+      assertEq(state.activeMilestone?.id, 'M001', 'Test A: activeMilestone id is M001');
+      assertEq(state.activeSlice, null, 'Test A: activeSlice is null');
+      assertEq(state.activeTask, null, 'Test A: activeTask is null');
+    } finally {
+      cleanup(base);
+    }
+  }
+
+  // ─── Test B: ROADMAP + no CONTEXT-DRAFT + zero DB slices → pre-planning ──
+  // The existing behaviour for stub roadmaps without a draft must not regress.
+  console.log('\n=== Test B: ROADMAP + no CONTEXT-DRAFT + zero slices → pre-planning ===');
+  {
+    const base = createFixtureBase();
+    try {
+      writeRoadmap(base, 'M001', '# M001: Stub Roadmap\n\n**Vision:** TBD.\n\n## Slices\n\n(none yet)\n');
+      // No CONTEXT-DRAFT — should remain pre-planning
+
+      const state = await deriveState(base);
+
+      assertEq(state.phase, 'pre-planning', 'Test B: phase should be pre-planning when no draft');
+      assertEq(state.activeMilestone?.id, 'M001', 'Test B: activeMilestone id is M001');
+    } finally {
+      cleanup(base);
+    }
+  }
+
+  // ─── Test C: ROADMAP + CONTEXT (not draft) + zero slices → pre-planning ──
+  // A finalised CONTEXT.md alongside a stub ROADMAP should not trigger needs-discussion.
+  console.log('\n=== Test C: ROADMAP + CONTEXT (not draft) + zero slices → pre-planning ===');
+  {
+    const base = createFixtureBase();
+    try {
+      writeRoadmap(base, 'M001', '# M001: Stub Roadmap\n\n**Vision:** TBD.\n\n## Slices\n\n(none yet)\n');
+      // CONTEXT.md present (finalised) — suppresses draft flag even if CONTEXT-DRAFT also existed
+      writeContext(base, 'M001', '---\ntitle: Full Context\n---\n\n# M001\n\nReady for planning.');
+
+      const state = await deriveState(base);
+
+      assertEq(state.phase, 'pre-planning', 'Test C: phase should be pre-planning when CONTEXT.md exists');
+      assertEq(state.activeMilestone?.id, 'M001', 'Test C: activeMilestone id is M001');
+    } finally {
+      cleanup(base);
+    }
+  }
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // Summary
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  console.log(`\n${'═'.repeat(60)}`);
+  console.log(`stub-roadmap draft-phase routing: ${passed} passed, ${failed} failed`);
+  console.log('═'.repeat(60));
+
+  if (failed > 0) {
+    process.exit(1);
+  }
+}
+
+main().catch(err => {
+  console.error('Test suite error:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## TL;DR
When a milestone has a ROADMAP file but zero slices, the state machine now checks
`activeMilestoneHasDraft` before returning `pre-planning`, matching the behaviour
of the `!hasRoadmap` branch. Previously the flag was ignored, causing milestones
with both a stub ROADMAP and a CONTEXT-DRAFT to report `pre-planning` instead of
`needs-discussion`.

Fixes #3191.

## Changes
- `state.ts` (DB path, `deriveStateFromDb`): Replace unconditional `phase: 'pre-planning'`
  in the `hasRoadmap && zero-slices` branch with a draft-aware conditional.
- `state.ts` (filesystem path, `_deriveStateImpl`): Set `activeMilestoneHasDraft` when
  promoting an active milestone via the roadmap path, and apply the same conditional
  in the zero-slice roadmap guard.
- `tests/state-draft-roadmap-phase.test.ts`: Regression test covering three cases:
  - Test A: ROADMAP + CONTEXT-DRAFT + zero slices → `needs-discussion` (was failing)
  - Test B: ROADMAP + no CONTEXT-DRAFT + zero slices → `pre-planning` (regression guard)
  - Test C: ROADMAP + CONTEXT (not draft) + zero slices → `pre-planning` (regression guard)

## AI Disclosure
Fix authored with AI assistance.