### PR TITLE
fix(web): remove markdown opacity affecting light theme readability

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -216,7 +216,6 @@
 
 /* ── File viewer: Markdown rendering ── */
 .markdown-body {
-  color: oklch(0.85 0 0);
   font-family: var(--font-sans);
   font-size: 0.9rem;
   line-height: 1.7;
@@ -301,7 +300,6 @@
 
 .markdown-body strong {
   font-weight: 600;
-  color: oklch(0.92 0 0);
 }
 
 .markdown-body em {


### PR DESCRIPTION
## TL;DR

**What:** Remove opacity from the markdown viewer panel.
**Why:** It hurts readability and accessibility in light theme, with no visible benefit in dark theme, as we can see in the demo video.
**How:** Removing the `color: oklch()` property from the `.markdown-body` and `.markdown-body strong` selectors in `globals.css`.

https://github.com/user-attachments/assets/b35b5dfc-6bd0-4eb1-b9b5-4e7bb279f763

## What

Removes the `color: oklch()` property from the `.markdown-body` and `.markdown-body strong` selectors in `globals.css`. These were the only occurrences of these selectors in the entire web interface — they are not referenced or reused anywhere else in the codebase.

## Why

The web UI exists primarily to provide accessibility for users who struggle with terminal-based interfaces. The `color: oklch()` property applied to `.markdown-body` and `.markdown-body strong` introduces an opacity effect that significantly reduces text contrast in the light theme, directly undermining this core goal. Users who rely on the web panel precisely because the terminal is harder for them to read are met with degraded readability in the interface that was supposed to help them. In dark theme, the effect is virtually imperceptible, meaning the property provides no meaningful visual benefit in either context. Removing it restores proper contrast and upholds the accessibility commitment the web UI was built around.

## How

Removing the `color: oklch()` property from the `.markdown-body` and `.markdown-body strong` selectors in `globals.css`. Prior to this change, the codebase was investigated to confirm these selectors are not used anywhere else in the web interface, making the removal safe with no risk of unintended side effects.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [x] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [ ] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

Open the web interface and navigate to the file viewer, then open any markdown file with the dark theme active. Using DevTools, toggle the .markdown-body selector on and off — no visible difference should be observed. Switch to light theme and repeat the toggle; a clear improvement in text readability should be visible with the selector removed.

- [x] CI passes
- [ ] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

## AI disclosure

- [ ] This PR includes AI-assisted code <!-- If so, note the tool and what was tested -->
