### PR TITLE
fix(test): move NODE_COMPILE_CACHE outside temp root to fix ENOTEMPTY race

### DIFF
--- a/src/tests/integration/web-mode-onboarding.test.ts
+++ b/src/tests/integration/web-mode-onboarding.test.ts
@@ -452,6 +452,9 @@ test("fresh gsd --web browser onboarding stays locked on failed validation and u
       ANTHROPIC_API_KEY: "",
       OPENAI_API_KEY: "",
       GOOGLE_API_KEY: "",
+      // Regression: #3195 — redirect compile cache outside tempRoot to prevent
+      // ENOTEMPTY race between Node's async cache writes and rmSync cleanup.
+      NODE_COMPILE_CACHE: join(tmpdir(), "gsd-test-compile-cache"),
     },
   })
   port = launch.port


### PR DESCRIPTION
## TL;DR

**What:** Add `NODE_COMPILE_CACHE` to the `launchPackagedWebHost` env in the web-mode onboarding runtime test, pointing to a stable path outside the test's temp root.
**Why:** Node.js writes compile cache files into the temp root, racing `rmSync` cleanup and causing intermittent ENOTEMPTY failures on CI (#3195).
**How:** One-line addition — `NODE_COMPILE_CACHE: join(tmpdir(), "gsd-test-compile-cache")` — redirects cache writes to a sibling directory that is never cleaned up by the test.

## What

Modifies `src/tests/integration/web-mode-onboarding.test.ts`. In the third test ("fresh gsd --web browser onboarding stays locked on failed validation and unlocks after a successful retry"), adds `NODE_COMPILE_CACHE` to the env object passed to `launchPackagedWebHost`. The value is `join(tmpdir(), "gsd-test-compile-cache")` — a stable path under the OS temp directory that is never a child of the test's unique `tempRoot`.

## Why

Closes #3195. When Node.js spawns the packaged web host, it writes `.cache` compilation artifacts for the spawned process. Without an explicit `NODE_COMPILE_CACHE`, Node defaults to a location derived from the process's CWD or a platform default — in this test it lands inside `tempRoot`. The `t.after` hook calls `rmSync(tempRoot, { recursive: true, force: true })` while Node is still asynchronously flushing cache writes, causing an intermittent ENOTEMPTY error on CI.

## How

Single-line addition to the `env` object. No structural test changes. `join(tmpdir(), "gsd-test-compile-cache")` is:
- Outside every test run's unique `tempRoot` (which uses `mkdtempSync` with a unique suffix)
- Never cleaned up by `rmSync(tempRoot, ...)`, so there is no race
- Created automatically by Node on first use — no `mkdirSync` needed
- Safe to persist across runs — compile cache is non-sensitive

Both `tmpdir` and `join` are already imported at the top of the test file, so no additional imports are required.

## Change type

- [ ] `feat` — New feature or capability
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [ ] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [x] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [ ] Manual testing — steps described above
- [ ] No tests needed — explained above

The fix is self-contained in the test file. The ENOTEMPTY race disappears because the compile cache no longer writes into the directory being cleaned up.

## AI disclosure

- [x] This PR includes AI-assisted code — generated with Claude, fix verified by build passing and code review of the single-line change