### PR TITLE
fix(ext): absorb ERR_INVALID_ARG_TYPE in epipe guard to prevent paste crash

### DIFF
--- a/src/resources/extensions/gsd/bootstrap/register-extension.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-extension.ts
@@ -27,6 +27,12 @@ export function handleRecoverableExtensionProcessError(err: Error): boolean {
       return true;
     }
   }
+  // Absorb ERR_INVALID_ARG_TYPE from MCP server stdout writes during paste (#3206).
+  // Re-throwing this non-fatal error crashes the process; log and survive instead.
+  if ((err as NodeJS.ErrnoException).code === "ERR_INVALID_ARG_TYPE") {
+    process.stderr.write(`[gsd] ERR_INVALID_ARG_TYPE (non-fatal, likely MCP/paste): ${err.message}\n`);
+    return true;
+  }
   return false;
 }
 

--- a/src/resources/extensions/gsd/tests/register-extension-guard.test.ts
+++ b/src/resources/extensions/gsd/tests/register-extension-guard.test.ts
@@ -57,3 +57,25 @@ test("handleRecoverableExtensionProcessError leaves unrelated errors unhandled",
   );
   assert.equal(handled, false);
 });
+
+// Regression test for https://github.com/gsd-build/gsd-2/issues/3206
+// ERR_INVALID_ARG_TYPE from MCP server stdout writes during paste must not crash the process.
+test("handleRecoverableExtensionProcessError swallows ERR_INVALID_ARG_TYPE", () => {
+  let stderr = "";
+  const originalWrite = process.stderr.write.bind(process.stderr);
+  process.stderr.write = ((chunk: string | Uint8Array) => {
+    stderr += String(chunk);
+    return true;
+  }) as typeof process.stderr.write;
+  try {
+    const handled = handleRecoverableExtensionProcessError(
+      Object.assign(new Error("The 'chunk' argument must be of type string or an instance of Buffer"), {
+        code: "ERR_INVALID_ARG_TYPE",
+      }),
+    );
+    assert.equal(handled, true);
+    assert.match(stderr, /\[gsd\].*ERR_INVALID_ARG_TYPE/);
+  } finally {
+    process.stderr.write = originalWrite;
+  }
+});


### PR DESCRIPTION
## TL;DR

**What:** Extend `_gsdEpipeGuard` to absorb `ERR_INVALID_ARG_TYPE` errors from MCP server stdout writes
**Why:** Paste operations trigger an unhandled ERR_INVALID_ARG_TYPE that crashes the process (#3206)
**How:** Add a log-and-survive branch in `handleRecoverableExtensionProcessError` mirroring the existing ENOENT handling

## What

Adds an `ERR_INVALID_ARG_TYPE` branch to `handleRecoverableExtensionProcessError` in `src/resources/extensions/gsd/bootstrap/register-extension.ts`. When a third-party MCP server writes to stdout with an invalid chunk type, the uncaught exception guard now logs the error to stderr and returns `true` (handled) instead of re-throwing. A regression test is added alongside the existing guard tests.

## Why

Closes #3206. Pasting text while an MCP server is active can trigger `ERR_INVALID_ARG_TYPE` from an MCP server's internal stdout write. The existing `_gsdEpipeGuard` re-throws unrecognized errors, which crashes the process. The same guard was extended for EPIPE in the original implementation and for other ENOENT variants in #3163.

Only `ERR_INVALID_ARG_TYPE` is targeted. Other unknown errors continue to re-throw so genuine crashes surface. EPIPE handling (`process.exit(0)`) is unchanged.

## How

Single branch in `handleRecoverableExtensionProcessError` after the ENOENT block. Writes a `[gsd]` diagnostic to stderr so the event is visible in logs, then returns `true` to prevent re-throw. The `_gsdEpipeGuard` function body is unchanged — it already returns when `handleRecoverableExtensionProcessError` returns `true`.

Regression test added to `register-extension-guard.test.ts`: creates an error with `code: "ERR_INVALID_ARG_TYPE"`, verifies the function returns `true` and writes a `[gsd]` diagnostic to stderr. Test failed before the fix, passes after.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [ ] Manual testing — steps described above
- [ ] No tests needed — explained above

## AI disclosure

- [x] This PR includes AI-assisted code (Claude Code — regression test and fix verified locally)