### PR TITLE
fix(native): add JS fallback for wrapTextWithAnsi on linux-arm64

### DIFF
--- a/packages/native/src/__tests__/text-fallback.test.mjs
+++ b/packages/native/src/__tests__/text-fallback.test.mjs
@@ -1,0 +1,54 @@
+/**
+ * Regression tests for wrapTextWithAnsi JS fallback (#3212).
+ *
+ * These tests import from the TypeScript wrapper (packages/native/src/text/index.ts)
+ * rather than the raw native addon, so the try/catch fallback path is exercised
+ * even on platforms where the native addon is unavailable (e.g., linux-arm64
+ * devcontainers).
+ *
+ * Run with:
+ *   node --import tsx/esm --test packages/native/src/__tests__/text-fallback.test.mjs
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+
+// Import the TS wrapper — tsx resolves the .ts source at test time.
+// On platforms with native available, the native path runs.
+// On platforms without native (linux-arm64 devcontainers), the JS fallback runs.
+// Either way, the function must return string[] without throwing.
+import { wrapTextWithAnsi } from "../text/index.ts";
+
+// ── wrapTextWithAnsi JS fallback ────────────────────────────────────────────
+
+describe("wrapTextWithAnsi — JS fallback", () => {
+  test("returns an array of strings without throwing", () => {
+    const result = wrapTextWithAnsi("hello world", 5);
+    assert.ok(Array.isArray(result), "must return array");
+    assert.ok(result.length > 0, "must have at least one line");
+    assert.ok(
+      result.every((l) => typeof l === "string"),
+      "all lines must be strings",
+    );
+  });
+
+  test("each returned line fits within the specified width", () => {
+    const result = wrapTextWithAnsi(
+      "the quick brown fox jumps over the lazy dog",
+      10,
+    );
+    for (const line of result) {
+      assert.ok(line.length <= 10, `line "${line}" exceeds width 10`);
+    }
+  });
+
+  test("empty string does not throw", () => {
+    assert.doesNotThrow(() => wrapTextWithAnsi("", 80));
+  });
+
+  test("width=1 does not throw and returns single-char lines", () => {
+    const result = wrapTextWithAnsi("hi", 1);
+    assert.ok(Array.isArray(result));
+    assert.ok(result.length >= 2);
+  });
+});

--- a/packages/native/src/text/index.ts
+++ b/packages/native/src/text/index.ts
@@ -12,23 +12,59 @@ export type { ExtractSegmentsResult, SliceResult };
 export { EllipsisKind } from "./types.js";
 
 /**
+ * Pure-JS fallback for wrapTextWithAnsi.
+ * Does not handle ANSI codes — plain character-count wrap.
+ * Used only when the native addon is unavailable (e.g., linux-arm64
+ * devcontainers — #3212).
+ */
+function wrapTextWithAnsiJs(text: string, width: number): string[] {
+  if (width <= 0) return [text];
+  const lines: string[] = [];
+  for (const rawLine of text.split("\n")) {
+    if (rawLine.length <= width) {
+      lines.push(rawLine);
+      continue;
+    }
+    let remaining = rawLine;
+    while (remaining.length > width) {
+      // Prefer breaking at a space boundary within the width
+      let breakAt = width;
+      const lastSpace = remaining.lastIndexOf(" ", width - 1);
+      if (lastSpace > 0) breakAt = lastSpace;
+      lines.push(remaining.slice(0, breakAt));
+      remaining = remaining.slice(breakAt).replace(/^ /, "");
+    }
+    if (remaining.length > 0) lines.push(remaining);
+  }
+  return lines.length > 0 ? lines : [""];
+}
+
+/**
  * Word-wrap text to a visible width, preserving ANSI escape codes across
  * line breaks.
  *
  * Active SGR codes (colors, bold, etc.) are carried to continuation lines.
  * Underline and strikethrough are reset at line ends and restored on the
  * next line.
+ *
+ * Delegates to the native Rust implementation when available.
+ * Falls back to a plain JS implementation on platforms where the native
+ * addon is not built (e.g., linux-arm64 devcontainers — #3212).
  */
 export function wrapTextWithAnsi(
   text: string,
   width: number,
   tabWidth?: number,
 ): string[] {
-  return (native as Record<string, Function>).wrapTextWithAnsi(
-    text,
-    width,
-    tabWidth,
-  ) as string[];
+  try {
+    return (native as Record<string, Function>).wrapTextWithAnsi(
+      text,
+      width,
+      tabWidth,
+    ) as string[];
+  } catch {
+    return wrapTextWithAnsiJs(text, width);
+  }
 }
 
 /**


### PR DESCRIPTION
## TL;DR

**What:** Add a pure-JS fallback to `wrapTextWithAnsi` for platforms where the native addon is unavailable.
**Why:** linux-arm64 devcontainers crash at startup because the native Proxy throws on any call, breaking TUI rendering and markdown display.
**How:** Wrap the native call in try/catch; fall back to a simple character-count word-wrap when native throws.

## What

Updates `packages/native/src/text/index.ts` — wraps the `wrapTextWithAnsi` native call in a try/catch and falls back to a pure-JS word-wrap (`wrapTextWithAnsiJs`) when the native addon is not available. Adds regression tests in a new file `packages/native/src/__tests__/text-fallback.test.mjs` that import from the TypeScript wrapper (not the raw native addon) so the fallback path is exercised even when native is unavailable.

## Why

Closes #3212. The `native.ts` Proxy throws `Native function 'wrapTextWithAnsi' is not available on linux-arm64-gnu` when called on linux-arm64 devcontainers. This crashes TUI rendering and markdown display at startup. The comment in `native.ts` already states "Consumers with JS fallbacks catch these and degrade gracefully" — this PR implements that contract for `wrapTextWithAnsi`.

Only `wrapTextWithAnsi` receives a fallback in this PR. The other text functions (`truncateToWidth`, `visibleWidth`, etc.) are not on the crash path for this issue and are left unchanged.

## How

- `try/catch` around the native call in `wrapTextWithAnsi`
- Helper `wrapTextWithAnsiJs` does a plain character-count word-wrap with space-boundary preference (splits on newlines, breaks long lines at word boundaries)
- The JS fallback does not preserve ANSI codes (that requires the native implementation), but it keeps the devcontainer usable for plain text

Regression tests (`text-fallback.test.mjs`) run via:
```
node --import tsx/esm --test packages/native/src/__tests__/text-fallback.test.mjs
```
These import the TypeScript wrapper (not the raw `.node` addon), exercising the fallback path on any platform where native is unavailable.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [ ] `gsd extension` — GSD workflow
- [x] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [ ] Manual testing — steps described above
- [ ] No tests needed — explained above

Run locally:
```bash
node --import tsx/esm --test packages/native/src/__tests__/text-fallback.test.mjs
```

## AI disclosure

- [x] This PR includes AI-assisted code