### PR TITLE
fix: replace empty catch blocks with debug logging across codebase

### DIFF
--- a/src/headless.ts
+++ b/src/headless.ts
@@ -719,7 +719,7 @@ async function runHeadlessOnce(options: HeadlessOptions, restartCount: number): 
     // Kill child process — don't await, just fire and exit.
     // The main flow may be awaiting a promise that resolves when the child dies,
     // which would race with this handler. Exit synchronously to ensure correct exit code.
-    try { client.stop().catch(() => {}) } catch {}
+    try { client.stop().catch((err: unknown) => { if (process.env.GSD_DEBUG) console.error("[gsd:headless]", err); }); } catch (err) { if (process.env.GSD_DEBUG) console.error("[gsd:headless] stop threw", err); }
     if (timeoutTimer) clearTimeout(timeoutTimer)
     if (idleTimer) clearTimeout(idleTimer)
     // Emit batch JSON result if in json mode before exiting

--- a/src/resources/extensions/aws-auth/index.ts
+++ b/src/resources/extensions/aws-auth/index.ts
@@ -68,7 +68,9 @@ function getAwsAuthRefreshCommand(): string | undefined {
 		try {
 			const settings = JSON.parse(readFileSync(settingsPath, "utf-8"));
 			if (settings.awsAuthRefresh) return settings.awsAuthRefresh;
-		} catch {}
+		} catch (err) {
+			if (process.env.GSD_DEBUG) console.error("[gsd:aws-auth]", err);
+		}
 	}
 	return undefined;
 }

--- a/src/resources/extensions/gsd/gsd-db.ts
+++ b/src/resources/extensions/gsd/gsd-db.ts
@@ -11,6 +11,7 @@ import { dirname } from "node:path";
 import type { Decision, Requirement, GateRow, GateId, GateScope, GateStatus, GateVerdict } from "./types.js";
 import { GSDError, GSD_STALE_STATE } from "./errors.js";
 import { logError, logWarning } from "./workflow-logger.js";
+import { debugLog } from "./debug-logger.js";
 
 const _require = createRequire(import.meta.url);
 

--- a/src/resources/extensions/gsd/tests/empty-catch-regression.test.ts
+++ b/src/resources/extensions/gsd/tests/empty-catch-regression.test.ts
@@ -1,0 +1,79 @@
+/**
+ * empty-catch-regression.test.ts — Regression test for #3169
+ *
+ * Verifies that no production source files contain empty catch blocks
+ * that silently discard errors. Empty catches make production debugging
+ * difficult because failures leave no trace even with GSD_DEBUG=1.
+ *
+ * Pattern: grep the patched files and assert zero matches.
+ * Test fails before the fix (when empty catches exist) and passes after.
+ */
+
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = join(fileURLToPath(import.meta.url), "../../../../../..");
+
+function readFile(relPath: string): string {
+  return readFileSync(join(REPO_ROOT, relPath), "utf-8");
+}
+
+/** Returns true if the source text contains a bare `} catch {}` or `catch {}` block. */
+function hasEmptyCatch(source: string): boolean {
+  // Match: catch {} or catch (e) {} or catch(err){} — empty body with optional whitespace
+  return /catch\s*(\([^)]*\))?\s*\{\s*\}/.test(source);
+}
+
+const PATCHED_FILES = [
+  "src/resources/extensions/mac-tools/index.ts",
+  "src/resources/extensions/aws-auth/index.ts",
+  "src/resources/extensions/gsd/auto.ts",
+  "src/resources/extensions/gsd/gsd-db.ts",
+  "src/headless.ts",
+];
+
+describe("empty catch regression (#3169)", () => {
+  for (const filePath of PATCHED_FILES) {
+    test(`${filePath} has no empty catch blocks`, () => {
+      const source = readFile(filePath);
+      assert.ok(
+        !hasEmptyCatch(source),
+        `Found empty catch {} in ${filePath} — errors are silently swallowed. ` +
+        `Use debugLog() (GSD files) or if (process.env.GSD_DEBUG) console.error() (non-GSD files).`
+      );
+    });
+  }
+
+  test("GSD extension files use debugLog for catch logging", () => {
+    const gsdFiles = [
+      "src/resources/extensions/gsd/auto.ts",
+      "src/resources/extensions/gsd/gsd-db.ts",
+    ];
+    for (const filePath of gsdFiles) {
+      const source = readFile(filePath);
+      // Verify debugLog is present (used for error surfacing)
+      assert.ok(
+        source.includes("debugLog"),
+        `${filePath} should use debugLog() for error surfacing in catch blocks`
+      );
+    }
+  });
+
+  test("non-GSD files use GSD_DEBUG guard for catch logging", () => {
+    const nonGsdFiles = [
+      "src/resources/extensions/mac-tools/index.ts",
+      "src/resources/extensions/aws-auth/index.ts",
+      "src/headless.ts",
+    ];
+    for (const filePath of nonGsdFiles) {
+      const source = readFile(filePath);
+      assert.ok(
+        source.includes("GSD_DEBUG"),
+        `${filePath} should use if (process.env.GSD_DEBUG) for error surfacing in catch blocks`
+      );
+    }
+  });
+});

--- a/src/resources/extensions/mac-tools/index.ts
+++ b/src/resources/extensions/mac-tools/index.ts
@@ -39,7 +39,9 @@ function getSourceMtime(): number {
 	// Check Package.swift
 	try {
 		latest = Math.max(latest, statSync(PACKAGE_SWIFT).mtimeMs);
-	} catch {}
+	} catch (err) {
+		if (process.env.GSD_DEBUG) console.error("[gsd:mac-tools]", err);
+	}
 	// Check all files in Sources/
 	try {
 		const files = readdirSync(SOURCES_DIR);
@@ -47,9 +49,13 @@ function getSourceMtime(): number {
 			try {
 				const mt = statSync(path.join(SOURCES_DIR, f)).mtimeMs;
 				if (mt > latest) latest = mt;
-			} catch {}
+			} catch (err) {
+				if (process.env.GSD_DEBUG) console.error("[gsd:mac-tools]", err);
+			}
 		}
-	} catch {}
+	} catch (err) {
+		if (process.env.GSD_DEBUG) console.error("[gsd:mac-tools]", err);
+	}
 	return latest;
 }
 


### PR DESCRIPTION
## TL;DR

**What:** Replace empty `catch {}` blocks in 5 production source files with `debugLog()` or `GSD_DEBUG` console.error so swallowed errors surface in debug mode.
**Why:** Closes #3169. Silent error swallowing hides bugs; failures leave no trace even with `GSD_DEBUG=1`, making production debugging difficult.
**How:** GSD extension files use the existing `debugLog()` utility; non-GSD files use `if (process.env.GSD_DEBUG) console.error()` for zero new dependencies.

## What

Updates 5 production source files to replace empty catch blocks with conditional debug logging:

- `src/resources/extensions/mac-tools/index.ts` — 3 empty catches in `getSourceMtime()` (Package.swift stat, Sources/ readdirSync, inner file stat) now log to `[gsd:mac-tools]` under `GSD_DEBUG`
- `src/resources/extensions/aws-auth/index.ts` — settings.json parse failure now logs to `[gsd:aws-auth]` under `GSD_DEBUG`
- `src/resources/extensions/gsd/auto.ts` — `process.chdir()` failure in hook dispatch now logs via `debugLog("chdir failed", ...)`
- `src/resources/extensions/gsd/gsd-db.ts` — `closeDatabase()` failure in the process exit handler now logs via `debugLog("closeDatabase on exit failed", ...)`; adds `debugLog` import from `debug-logger.js`
- `src/headless.ts` — `client.stop()` rejection and synchronous throw in SIGINT/SIGTERM handler now log to `[gsd:headless]` under `GSD_DEBUG`

Test files and code-as-string templates are excluded — their empty catches are intentional:
- `src/web/cleanup-service.ts` and `src/web/undo-service.ts` contain string literals (code templates), not actual catch blocks
- Integration test cleanup catches (`rmSync`) are intentional no-ops per project convention

## Why

Closes #3169.

Empty catch blocks silently discard errors, making production debugging difficult. When something goes wrong in `getSourceMtime()`, `getAwsAuthRefreshCommand()`, the `chdir` call, `closeDatabase()` on exit, or `client.stop()` during signal handling, there is currently zero trace — even with `GSD_DEBUG=1` active.

The graceful-fallback intent is preserved: each catch still prevents crashes. The change only adds conditional logging that is a no-op unless `GSD_DEBUG` is set.

## How

Two patterns by file location:

1. **GSD extension files** (`gsd/auto.ts`, `gsd/gsd-db.ts`) use the existing `debugLog()` utility from `debug-logger.js`. This integrates with the structured JSONL debug log and is consistent with how other error catches in these files already report.

2. **Non-GSD files** (`mac-tools/index.ts`, `aws-auth/index.ts`, `headless.ts`) use `if (process.env.GSD_DEBUG) console.error("[gsd:scope]", err)` — zero new dependencies, consistent with the project's approach for modules outside the GSD extension.

Regression test (`src/resources/extensions/gsd/tests/empty-catch-regression.test.ts`) reads the patched files at test time and asserts:
- No empty catch blocks remain in any of the 5 files
- GSD files contain `debugLog`
- Non-GSD files contain `GSD_DEBUG`

The test failed before the fix and passes after, satisfying the test-first requirement.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included — `src/resources/extensions/gsd/tests/empty-catch-regression.test.ts` (7 assertions, written test-first)
- [ ] Manual testing — steps described above
- [ ] No tests needed — explained above

`npm run build` passes. `grep -rn "catch {}" src --include="*.ts" | grep -v "test\|cleanup-service\|undo-service"` returns 0 lines.

## AI disclosure

- [x] This PR includes AI-assisted code