### PR TITLE
fix(tools): warn on uncommitted keyFiles in complete-task, complete-slice, complete-milestone

### DIFF
--- a/src/resources/extensions/gsd/tests/complete-tools-git-awareness.test.ts
+++ b/src/resources/extensions/gsd/tests/complete-tools-git-awareness.test.ts
@@ -1,0 +1,58 @@
+/**
+ * complete-tools-git-awareness.test.ts — Regression test for #3194.
+ *
+ * Completion tools must check git status of keyFiles before marking
+ * work complete and include a warning in the result when files are
+ * uncommitted.
+ */
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const toolsDir = join(__dirname, "..", "tools");
+
+const taskSrc = readFileSync(join(toolsDir, "complete-task.ts"), "utf-8");
+const sliceSrc = readFileSync(join(toolsDir, "complete-slice.ts"), "utf-8");
+const milestoneSrc = readFileSync(join(toolsDir, "complete-milestone.ts"), "utf-8");
+
+describe("#3194: completion tools git awareness", () => {
+  test("complete-task.ts calls checkUncommittedKeyFiles", () => {
+    assert.ok(
+      taskSrc.includes("checkUncommittedKeyFiles"),
+      "complete-task.ts must call checkUncommittedKeyFiles()",
+    );
+  });
+
+  test("complete-slice.ts calls checkUncommittedKeyFiles", () => {
+    assert.ok(
+      sliceSrc.includes("checkUncommittedKeyFiles"),
+      "complete-slice.ts must call checkUncommittedKeyFiles()",
+    );
+  });
+
+  test("complete-milestone.ts calls checkUncommittedKeyFiles", () => {
+    assert.ok(
+      milestoneSrc.includes("checkUncommittedKeyFiles"),
+      "complete-milestone.ts must call checkUncommittedKeyFiles()",
+    );
+  });
+
+  test("at least one tool result type includes uncommittedWarning field", () => {
+    const allSrc = taskSrc + sliceSrc + milestoneSrc;
+    assert.ok(
+      allSrc.includes("uncommittedWarning"),
+      "at least one tool result type must include uncommittedWarning field",
+    );
+  });
+
+  test("git status --porcelain or spawnSync present in tool sources", () => {
+    const allSrc = taskSrc + sliceSrc + milestoneSrc;
+    assert.ok(
+      allSrc.includes("--porcelain") || allSrc.includes("spawnSync"),
+      "git status --porcelain or spawnSync must be present in tool sources",
+    );
+  });
+});

--- a/src/resources/extensions/gsd/tools/complete-milestone.ts
+++ b/src/resources/extensions/gsd/tools/complete-milestone.ts
@@ -8,6 +8,7 @@
 
 import { join } from "node:path";
 import { mkdirSync } from "node:fs";
+import { spawnSync } from "node:child_process";
 
 import {
   transaction,
@@ -56,6 +57,30 @@ export interface CompleteMilestoneParams {
 export interface CompleteMilestoneResult {
   milestoneId: string;
   summaryPath: string;
+  uncommittedWarning?: string;
+}
+
+/**
+ * Check whether any of the given keyFiles have uncommitted changes in git.
+ * Returns a warning string if uncommitted files are found, null otherwise.
+ * Returns null (silently) if git is unavailable or the path is not a git repo.
+ */
+function checkUncommittedKeyFiles(keyFiles: string[], basePath: string): string | null {
+  if (!keyFiles || keyFiles.length === 0) return null;
+  try {
+    const result = spawnSync(
+      "git",
+      ["status", "--porcelain", "--", ...keyFiles],
+      { cwd: basePath, encoding: "utf-8", timeout: 5000 },
+    );
+    if (result.status !== 0 || result.error) return null; // git unavailable — skip
+    const dirtyLines = (result.stdout ?? "").trim().split("\n").filter(Boolean);
+    if (dirtyLines.length === 0) return null;
+    const fileList = dirtyLines.map(l => l.slice(3)).join(", ");
+    return `Warning: the following keyFiles have uncommitted changes: ${fileList}. Consider committing before marking complete.`;
+  } catch {
+    return null; // never block completion due to git check failure
+  }
 }
 
 function renderMilestoneSummaryMarkdown(params: CompleteMilestoneParams): string {
@@ -138,6 +163,9 @@ export async function handleCompleteMilestone(
   if (params.verificationPassed !== true) {
     return { error: "verification did not pass — milestone completion blocked. verificationPassed must be explicitly set to true after all verification steps succeed" };
   }
+
+  // ── Git awareness check (warning-only, never blocks completion) ─────────
+  const uncommittedWarning = checkUncommittedKeyFiles(params.keyFiles, basePath);
 
   // ── Guards + DB writes inside a single transaction (prevents TOCTOU) ───
   const completedAt = new Date().toISOString();
@@ -246,5 +274,6 @@ export async function handleCompleteMilestone(
   return {
     milestoneId: params.milestoneId,
     summaryPath,
+    ...(uncommittedWarning ? { uncommittedWarning } : {}),
   };
 }

--- a/src/resources/extensions/gsd/tools/complete-slice.ts
+++ b/src/resources/extensions/gsd/tools/complete-slice.ts
@@ -9,6 +9,7 @@
 
 import { join } from "node:path";
 import { mkdirSync } from "node:fs";
+import { spawnSync } from "node:child_process";
 
 import type { CompleteSliceParams } from "../types.js";
 import { isClosedStatus } from "../status-guards.js";
@@ -37,6 +38,30 @@ export interface CompleteSliceResult {
   milestoneId: string;
   summaryPath: string;
   uatPath: string;
+  uncommittedWarning?: string;
+}
+
+/**
+ * Check whether any of the given keyFiles have uncommitted changes in git.
+ * Returns a warning string if uncommitted files are found, null otherwise.
+ * Returns null (silently) if git is unavailable or the path is not a git repo.
+ */
+function checkUncommittedKeyFiles(keyFiles: string[], basePath: string): string | null {
+  if (!keyFiles || keyFiles.length === 0) return null;
+  try {
+    const result = spawnSync(
+      "git",
+      ["status", "--porcelain", "--", ...keyFiles],
+      { cwd: basePath, encoding: "utf-8", timeout: 5000 },
+    );
+    if (result.status !== 0 || result.error) return null; // git unavailable — skip
+    const dirtyLines = (result.stdout ?? "").trim().split("\n").filter(Boolean);
+    if (dirtyLines.length === 0) return null;
+    const fileList = dirtyLines.map(l => l.slice(3)).join(", ");
+    return `Warning: the following keyFiles have uncommitted changes: ${fileList}. Consider committing before marking complete.`;
+  } catch {
+    return null; // never block completion due to git check failure
+  }
 }
 
 /**
@@ -242,6 +267,9 @@ export async function handleCompleteSlice(
     return { error: `slice verification indicates blocked/failed state — do not complete a slice that has not passed verification. Address the blockers and re-verify first.` };
   }
 
+  // ── Git awareness check (warning-only, never blocks completion) ─────────
+  const uncommittedWarning = checkUncommittedKeyFiles(params.keyFiles, basePath);
+
   // ── Guards + DB writes inside a single transaction (prevents TOCTOU) ───
   const completedAt = new Date().toISOString();
   const originalSliceStatus = getSlice(params.milestoneId, params.sliceId)?.status ?? "pending";
@@ -366,5 +394,6 @@ export async function handleCompleteSlice(
     milestoneId: params.milestoneId,
     summaryPath,
     uatPath,
+    ...(uncommittedWarning ? { uncommittedWarning } : {}),
   };
 }

--- a/src/resources/extensions/gsd/tools/complete-task.ts
+++ b/src/resources/extensions/gsd/tools/complete-task.ts
@@ -9,6 +9,7 @@
 
 import { join } from "node:path";
 import { mkdirSync, existsSync } from "node:fs";
+import { spawnSync } from "node:child_process";
 
 import type { CompleteTaskParams } from "../types.js";
 import { isClosedStatus } from "../status-guards.js";
@@ -40,6 +41,30 @@ export interface CompleteTaskResult {
   sliceId: string;
   milestoneId: string;
   summaryPath: string;
+  uncommittedWarning?: string;
+}
+
+/**
+ * Check whether any of the given keyFiles have uncommitted changes in git.
+ * Returns a warning string if uncommitted files are found, null otherwise.
+ * Returns null (silently) if git is unavailable or the path is not a git repo.
+ */
+function checkUncommittedKeyFiles(keyFiles: string[], basePath: string): string | null {
+  if (!keyFiles || keyFiles.length === 0) return null;
+  try {
+    const result = spawnSync(
+      "git",
+      ["status", "--porcelain", "--", ...keyFiles],
+      { cwd: basePath, encoding: "utf-8", timeout: 5000 },
+    );
+    if (result.status !== 0 || result.error) return null; // git unavailable — skip
+    const dirtyLines = (result.stdout ?? "").trim().split("\n").filter(Boolean);
+    if (dirtyLines.length === 0) return null;
+    const fileList = dirtyLines.map(l => l.slice(3)).join(", ");
+    return `Warning: the following keyFiles have uncommitted changes: ${fileList}. Consider committing before marking complete.`;
+  } catch {
+    return null; // never block completion due to git check failure
+  }
 }
 
 import type { TaskRow } from "../gsd-db.js";
@@ -124,6 +149,9 @@ export async function handleCompleteTask(
   if (ownershipErr) {
     return { error: ownershipErr };
   }
+
+  // ── Git awareness check (warning-only, never blocks completion) ─────────
+  const uncommittedWarning = checkUncommittedKeyFiles(params.keyFiles, basePath);
 
   // ── Guards + DB writes inside a single transaction (prevents TOCTOU) ───
   const completedAt = new Date().toISOString();
@@ -272,5 +300,6 @@ export async function handleCompleteTask(
     sliceId: params.sliceId,
     milestoneId: params.milestoneId,
     summaryPath,
+    ...(uncommittedWarning ? { uncommittedWarning } : {}),
   };
 }


### PR DESCRIPTION
## TL;DR

**What:** Add git awareness to all three completion tools so they warn when keyFiles have uncommitted changes.
**Why:** Agents could mark work complete in the DB while file changes were never committed, silently hiding unfinished work from history.
**How:** Add a `checkUncommittedKeyFiles()` helper in each tool that runs `git status --porcelain`; embed the warning in the tool response (warning-only, never a hard block).

## What

Adds a `checkUncommittedKeyFiles(keyFiles, basePath)` helper to `complete-task.ts`, `complete-slice.ts`, and `complete-milestone.ts`. When any of the caller-supplied `keyFiles` have uncommitted changes at the time of completion, the handler includes an `uncommittedWarning` field in its response. The DB write still proceeds.

Affected files:
- `src/resources/extensions/gsd/tools/complete-task.ts`
- `src/resources/extensions/gsd/tools/complete-slice.ts`
- `src/resources/extensions/gsd/tools/complete-milestone.ts`
- `src/resources/extensions/gsd/tests/complete-tools-git-awareness.test.ts` (new regression test)

## Why

Closes #3194

All three handlers wrote directly to the DB without consulting `git status`. An agent calling `gsd_complete_task` with a dirty worktree produced a SUMMARY.md claiming the task was done while the actual file content never landed in git history. This silently hid unfinished work from code review.

## How

- `checkUncommittedKeyFiles(keyFiles, basePath)` runs `git status --porcelain -- <keyFiles>` via `spawnSync` with a 5-second timeout.
- If any files are dirty, the handler includes `uncommittedWarning?: string` in the tool response.
- The DB write is **not** blocked — warning-only by design. Hard-blocking would break projects where git is not used or file path conventions differ. The agent sees the warning and decides whether to commit first.
- Helper defined inline in each tool file (no new cross-file dependency).
- Graceful degradation: silently returns `null` (no warning) if git is unavailable, exits non-zero, or the directory is not a git repo.

## Change type

- [x] `fix` — Bug fix

## Scope

- [x] `gsd extension` — GSD workflow

## Breaking changes

- [x] No breaking changes — `uncommittedWarning` is optional on all three result types; existing callers are unaffected.

## Test plan

- [x] New regression test `tests/complete-tools-git-awareness.test.ts` (5 assertions using `node:test`/`node:assert/strict`) — fails before fix, passes after.
- [x] All existing `complete-task.test.ts`, `complete-slice.test.ts`, `complete-milestone.test.ts` tests pass.
- [x] `npm run build` passes (TypeScript strict mode).

## AI disclosure

- [x] This PR includes AI-assisted code