### PR TITLE
fix: allDiscussed early-return no longer blocks queued milestone discussion

### DIFF
--- a/src/resources/extensions/gsd/guided-flow.ts
+++ b/src/resources/extensions/gsd/guided-flow.ts
@@ -620,6 +620,12 @@ export async function showDiscuss(
   const pendingSlices = normSlices.filter(s => !s.done);
 
   if (pendingSlices.length === 0) {
+    // All slices complete — but queued milestones may still need discussion (#3150)
+    const pendingMilestones = state.registry.filter(m => m.status === "pending");
+    if (pendingMilestones.length > 0) {
+      await showDiscussQueuedMilestone(ctx, pi, basePath, pendingMilestones);
+      return;
+    }
     ctx.ui.notify("All slices are complete — nothing to discuss.", "info");
     return;
   }
@@ -636,9 +642,14 @@ export async function showDiscuss(
       discussedMap.set(s.id, !!contextFile);
     }
 
-    // If all pending slices are discussed, notify and exit instead of looping
+    // If all pending slices are discussed, check for queued milestones before exiting (#3150)
     const allDiscussed = pendingSlices.every(s => discussedMap.get(s.id));
     if (allDiscussed) {
+      const pendingMilestones = state.registry.filter(m => m.status === "pending");
+      if (pendingMilestones.length > 0) {
+        await showDiscussQueuedMilestone(ctx, pi, basePath, pendingMilestones);
+        return;
+      }
       const lockData = readSessionLockData(basePath);
       const remoteAutoRunning = lockData && lockData.pid !== process.pid && isSessionLockProcessAlive(lockData);
       const nextStep = remoteAutoRunning

--- a/src/resources/extensions/gsd/tests/discuss-queued-milestones.test.ts
+++ b/src/resources/extensions/gsd/tests/discuss-queued-milestones.test.ts
@@ -238,4 +238,44 @@ describe("discuss-queued-milestones (#2307)", () => {
       "queued milestone picker must label entries with [queued] to distinguish from active",
     );
   });
+
+  // ─── #3150: allDiscussed early-return must not block queued milestone discussion ──
+
+  test("12. allDiscussed path checks for pending milestones before returning (#3150)", () => {
+    const source = readGuidedFlowSource();
+
+    // Extract the allDiscussed block — the if (allDiscussed) { ... } body
+    const allDiscussedMatch = source.match(
+      /const allDiscussed = pendingSlices\.every\([\s\S]*?\n    if \(allDiscussed\) \{([\s\S]*?)\n    \}/,
+    );
+    assert.ok(!!allDiscussedMatch, "allDiscussed guard block must exist in showDiscuss()");
+
+    if (allDiscussedMatch) {
+      const body = allDiscussedMatch[1];
+      // The fix must check for pending milestones and route to showDiscussQueuedMilestone
+      assert.ok(
+        body.includes("pending") && body.includes("showDiscussQueuedMilestone"),
+        "allDiscussed block must check for pending milestones and call showDiscussQueuedMilestone before returning (#3150)",
+      );
+    }
+  });
+
+  test("13. pendingSlices.length===0 path checks for pending milestones before returning (#3150)", () => {
+    const source = readGuidedFlowSource();
+
+    // Find the pendingSlices.length === 0 guard block
+    const zeroSlicesMatch = source.match(
+      /if \(pendingSlices\.length === 0\) \{([\s\S]*?)\n  \}/,
+    );
+    assert.ok(!!zeroSlicesMatch, "pendingSlices.length === 0 guard block must exist in showDiscuss()");
+
+    if (zeroSlicesMatch) {
+      const body = zeroSlicesMatch[1];
+      // The fix must check for pending milestones and route to showDiscussQueuedMilestone
+      assert.ok(
+        body.includes("pending") && body.includes("showDiscussQueuedMilestone"),
+        "pendingSlices.length===0 block must check for pending milestones and call showDiscussQueuedMilestone before returning (#3150)",
+      );
+    }
+  });
 });


### PR DESCRIPTION
## Summary

- Fixes the `allDiscussed` early-return in `showDiscuss()` that hard-returned before checking for queued milestones, blocking users from discussing pending milestones when all active slices were discussed
- Fixes the `pendingSlices.length === 0` guard that similarly blocked queued milestone discussion when all slices were complete
- Both paths now check `state.registry` for pending milestones and route to `showDiscussQueuedMilestone()` before falling through to the dead-end notification

Closes #3150

## Test plan

- [x] Added test 12: verifies `allDiscussed` block checks for pending milestones and calls `showDiscussQueuedMilestone`
- [x] Added test 13: verifies `pendingSlices.length===0` block checks for pending milestones and calls `showDiscussQueuedMilestone`
- [x] All 13 tests in `discuss-queued-milestones.test.ts` pass
- [x] TypeScript compiles cleanly with `npx tsc -p tsconfig.test.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)