### PR TITLE
fix: replace web_search with search-the-web in prompts (#2920)

### DIFF
--- a/src/resources/agents/researcher.md
+++ b/src/resources/agents/researcher.md
@@ -1,7 +1,7 @@
 ---
 name: researcher
 description: Web researcher that finds and synthesizes current information using Brave Search
-tools: web_search, bash
+tools: search-the-web, bash
 ---
 
 You are a web researcher. You find current, accurate information using web search and synthesize it into a clear, well-structured report.

--- a/src/resources/extensions/gsd/prompts/discuss-headless.md
+++ b/src/resources/extensions/gsd/prompts/discuss-headless.md
@@ -38,7 +38,7 @@ Do a mandatory investigation pass before making any decisions. This is not optio
 3. **Web search** — `search-the-web` if the domain is unfamiliar, if you need current best practices, or if the spec references external services/APIs you need facts about. Use `fetch_page` for full content when snippets aren't enough.
 
 **Web search budget:** Budget carefully across investigation + focused research:
-- Prefer `resolve_library` / `get_library_docs` over `web_search` for library documentation.
+- Prefer `resolve_library` / `get_library_docs` over `search-the-web` for library documentation.
 - Prefer `search_and_read` for one-shot topic research.
 - Target 2-3 web searches in this investigation pass. Save remaining budget for focused research.
 - Do NOT repeat the same or similar queries.

--- a/src/resources/extensions/gsd/prompts/discuss.md
+++ b/src/resources/extensions/gsd/prompts/discuss.md
@@ -37,7 +37,7 @@ Before asking your first question, do a mandatory investigation pass. This is no
 3. **Web search** — `search-the-web` if the domain is unfamiliar, if you need current best practices, or if the user referenced external services/APIs you need facts about. Use `fetch_page` for full content when snippets aren't enough.
 
 **Web search budget:** You have a limited number of web searches per turn (typically 3-5). The discuss phase spans many turns (investigation, question rounds, focused research, requirements), so budget carefully:
-- Prefer `resolve_library` / `get_library_docs` over `web_search` for library documentation — they don't consume the web search budget.
+- Prefer `resolve_library` / `get_library_docs` over `search-the-web` for library documentation — they don't consume the web search budget.
 - Prefer `search_and_read` for one-shot topic research — it combines search + page fetch in a single call.
 - Target 2-3 web searches in the investigation pass. Save remaining budget for the focused research pass before roadmap creation.
 - Do NOT repeat the same or similar queries. If a search didn't find what you need, rephrase once or move on.

--- a/src/resources/extensions/gsd/prompts/guided-discuss-milestone.md
+++ b/src/resources/extensions/gsd/prompts/guided-discuss-milestone.md
@@ -13,7 +13,7 @@ Discuss milestone {{milestoneId}} ("{{milestoneTitle}}"). Identify gray areas, a
 Do a lightweight targeted investigation so your questions are grounded in reality:
 - Scout the codebase (`rg`, `find`, or `scout`) to understand what already exists that this milestone touches or builds on
 - Check the roadmap context above (if present) to understand what surrounds this milestone
-- Use `resolve_library` / `get_library_docs` for unfamiliar libraries — prefer this over `web_search` for library documentation
+- Use `resolve_library` / `get_library_docs` for unfamiliar libraries — prefer this over `search-the-web` for library documentation
 - Identify the 3–5 biggest behavioural and architectural unknowns: things where the user's answer will materially change what gets built
 
 **Web search budget:** You have a limited number of web searches per turn (typically 3-5). Prefer `resolve_library` / `get_library_docs` for library documentation and `search_and_read` for one-shot topic research — they are more budget-efficient. Target 2-3 web searches in the investigation pass. Distribute remaining searches across subsequent question rounds rather than clustering them.

--- a/src/resources/extensions/gsd/prompts/guided-discuss-slice.md
+++ b/src/resources/extensions/gsd/prompts/guided-discuss-slice.md
@@ -13,7 +13,7 @@ Your goal is **not** to center the discussion on tech stack trivia, naming conve
 Do a lightweight targeted investigation so your questions are grounded in reality:
 - Scout the codebase (`rg`, `find`, or `scout` for broad unfamiliar areas) to understand what already exists that this slice touches or builds on
 - Check the roadmap context above to understand what surrounds this slice — what comes before, what depends on it
-- Use `resolve_library` / `get_library_docs` for unfamiliar libraries — prefer this over `web_search` for library documentation
+- Use `resolve_library` / `get_library_docs` for unfamiliar libraries — prefer this over `search-the-web` for library documentation
 - Identify the 3–5 biggest behavioural unknowns: things where the user's answer will materially change what gets built
 
 **Web search budget:** You have a limited number of web searches per turn (typically 3-5). Prefer `resolve_library` / `get_library_docs` for library documentation and `search_and_read` for one-shot topic research — they are more budget-efficient. Target 2-3 web searches in the investigation pass. Distribute remaining searches across subsequent question rounds rather than clustering them.

--- a/src/resources/extensions/gsd/tests/prompt-tool-names.test.ts
+++ b/src/resources/extensions/gsd/tests/prompt-tool-names.test.ts
@@ -1,0 +1,69 @@
+// prompt-tool-names — Ensures prompt files reference correct tool names.
+//
+// The registered GSD tool is `search-the-web`, not `web_search`.
+// `web_search` is an Anthropic API implementation detail that should
+// never appear in GSD prompts or agent frontmatter.
+// See: https://github.com/gsd-build/gsd-2/issues/2920
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync, readdirSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const promptsDir = join(__dirname, "..", "prompts");
+const agentsDir = join(__dirname, "..", "..", "..", "agents");
+
+/** Collect all .md files in a directory (non-recursive). */
+function mdFiles(dir: string): string[] {
+  return readdirSync(dir)
+    .filter((f) => f.endsWith(".md"))
+    .map((f) => join(dir, f));
+}
+
+const WRONG_TOOL = "web_search";
+const CORRECT_TOOL = "search-the-web";
+
+test("prompt files must not reference `web_search` — use `search-the-web` instead", () => {
+  const files = mdFiles(promptsDir);
+  assert.ok(files.length > 0, "Expected at least one prompt file");
+
+  const violations: string[] = [];
+  for (const file of files) {
+    const content = readFileSync(file, "utf-8");
+    if (content.includes(WRONG_TOOL)) {
+      violations.push(file);
+    }
+  }
+
+  assert.deepStrictEqual(
+    violations,
+    [],
+    `These prompt files reference "${WRONG_TOOL}" instead of "${CORRECT_TOOL}":\n${violations.join("\n")}`,
+  );
+});
+
+test("agent frontmatter must not reference `web_search` — use `search-the-web` instead", () => {
+  const files = mdFiles(agentsDir);
+  assert.ok(files.length > 0, "Expected at least one agent file");
+
+  const violations: string[] = [];
+  for (const file of files) {
+    const content = readFileSync(file, "utf-8");
+    // Check frontmatter tools line specifically
+    const frontmatterMatch = content.match(/^---\n([\s\S]*?)\n---/);
+    if (frontmatterMatch) {
+      const frontmatter = frontmatterMatch[1];
+      if (frontmatter.includes(WRONG_TOOL)) {
+        violations.push(file);
+      }
+    }
+  }
+
+  assert.deepStrictEqual(
+    violations,
+    [],
+    `These agent files reference "${WRONG_TOOL}" in frontmatter instead of "${CORRECT_TOOL}":\n${violations.join("\n")}`,
+  );
+});


### PR DESCRIPTION
## Summary
- Replaced all occurrences of `web_search` with `search-the-web` in four GSD prompt files and the `agents/researcher.md` frontmatter
- `web_search` is an Anthropic API implementation detail; the registered GSD tool name is `search-the-web`
- Added regression test (`prompt-tool-names.test.ts`) that scans prompt and agent files for the wrong tool name

Fixes #2920

## Test plan
- [x] New test `prompt-tool-names.test.ts` written first (TDD) -- confirmed failing before fix, passing after
- [x] TypeScript compilation passes (`npx tsc -p tsconfig.test.json`)
- [x] Test suite passes via `node --test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)