### PR TITLE
fix: copy mcp.json into auto-mode worktrees

### DIFF
--- a/src/resources/extensions/gsd/auto-worktree.ts
+++ b/src/resources/extensions/gsd/auto-worktree.ts
@@ -84,6 +84,7 @@ const ROOT_STATE_FILES = [
   "QUEUE.md",
   "completed-units.json",
   "metrics.json",
+  "mcp.json",
   // NOTE: project preferences are intentionally NOT in ROOT_STATE_FILES.
   // Forward-sync (main → worktree) is handled explicitly in syncGsdStateToWorktree().
   // Back-sync (worktree → main) must NEVER overwrite the project root's copy
@@ -1004,6 +1005,7 @@ function copyPlanningArtifacts(srcBase: string, wtPath: string): void {
     "STATE.md",
     "KNOWLEDGE.md",
     "OVERRIDES.md",
+    "mcp.json",
   ]) {
     safeCopy(join(srcGsd, file), join(dstGsd, file), { force: true });
   }

--- a/src/resources/extensions/gsd/tests/integration/auto-worktree.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/auto-worktree.test.ts
@@ -20,6 +20,7 @@ import {
   enterAutoWorktree,
   getAutoWorktreeOriginalBase,
   getActiveAutoWorktreeContext,
+  syncGsdStateToWorktree,
 } from "../../auto-worktree.ts";
 
 // Note: execSync is used intentionally in tests for git operations with
@@ -284,6 +285,64 @@ describe("auto-worktree lifecycle", () => {
       assert.ok(wtPlan.includes("- [ ] **T03:"), "T03 stays [ ] (not in root either)");
     } finally {
       teardownAutoWorktree(tempDir, "M004");
+    }
+  });
+
+  test("#2791: mcp.json copied into worktree via copyPlanningArtifacts", () => {
+    tempDir = createTempRepo();
+    const msDir = join(tempDir, ".gsd", "milestones", "M003");
+    mkdirSync(msDir, { recursive: true });
+    writeFileSync(join(msDir, "CONTEXT.md"), "# M003 Context\n");
+    run("git add .", tempDir);
+    run("git commit -m \"add milestone\"", tempDir);
+
+    // Create mcp.json in .gsd/ AFTER the commit (untracked, like real usage).
+    // copyPlanningArtifacts should copy it into the worktree's .gsd/.
+    writeFileSync(
+      join(tempDir, ".gsd", "mcp.json"),
+      JSON.stringify({ servers: { test: { command: "echo" } } }),
+    );
+
+    const wtPath = createAutoWorktree(tempDir, "M003");
+
+    try {
+      assert.ok(
+        existsSync(join(wtPath, ".gsd", "mcp.json")),
+        "mcp.json should be copied into worktree .gsd/ on creation",
+      );
+    } finally {
+      teardownAutoWorktree(tempDir, "M003");
+    }
+  });
+
+  test("#2791: mcp.json synced via syncGsdStateToWorktree (ROOT_STATE_FILES)", () => {
+    tempDir = createTempRepo();
+    const msDir = join(tempDir, ".gsd", "milestones", "M003");
+    mkdirSync(msDir, { recursive: true });
+    writeFileSync(join(msDir, "CONTEXT.md"), "# M003 Context\n");
+    run("git add .", tempDir);
+    run("git commit -m \"add milestone\"", tempDir);
+
+    // Create worktree first (no mcp.json yet)
+    const wtPath = createAutoWorktree(tempDir, "M003");
+
+    try {
+      // Now add mcp.json to the main .gsd/ after worktree was created
+      writeFileSync(
+        join(tempDir, ".gsd", "mcp.json"),
+        JSON.stringify({ servers: { test: { command: "echo" } } }),
+      );
+
+      // Sync should pick up the new mcp.json
+      const { synced } = syncGsdStateToWorktree(tempDir, wtPath);
+
+      assert.ok(synced.includes("mcp.json"), "mcp.json should be in the synced list");
+      assert.ok(
+        existsSync(join(wtPath, ".gsd", "mcp.json")),
+        "mcp.json should exist in worktree after sync",
+      );
+    } finally {
+      teardownAutoWorktree(tempDir, "M003");
     }
   });
 });


### PR DESCRIPTION
## Summary
- Add `mcp.json` to `ROOT_STATE_FILES` so it is synced from project root to worktree during `syncGsdStateToWorktree()`
- Add `mcp.json` to the `copyPlanningArtifacts()` file list so it is copied on initial worktree creation
- Add two integration tests verifying both code paths

Fixes #2791

## Test plan
- [x] New test: `#2791: mcp.json copied into worktree via copyPlanningArtifacts` -- verifies mcp.json is copied when creating a worktree
- [x] New test: `#2791: mcp.json synced via syncGsdStateToWorktree (ROOT_STATE_FILES)` -- verifies mcp.json is synced when added after worktree creation
- [x] All 9 existing auto-worktree integration tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)