### PR TITLE
fix(web): reconcile auto-mode state with on-disk lock (#2705)

### DIFF
--- a/src/tests/integration/web-auto-dashboard-lock-reconciliation.test.ts
+++ b/src/tests/integration/web-auto-dashboard-lock-reconciliation.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Regression test for #2705: Web UI shows "Start auto" even while auto mode is
+ * already running.
+ *
+ * Root cause: collectAuthoritativeAutoDashboardData spawns a subprocess that
+ * imports auto.ts fresh. The module-level AutoSession state (s.active) is
+ * always false in a new process, so the subprocess always reports
+ * { active: false } even when auto IS running in the parent process.
+ *
+ * Fix: after obtaining the subprocess result, reconcile active/paused state
+ * with on-disk session lock and paused-session metadata.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import {
+  collectAuthoritativeAutoDashboardData,
+} from "../../web/auto-dashboard-service.ts";
+
+// ─── Helpers ──────────────────────────────────────────────────────────
+
+const repoRoot = join(import.meta.dirname, "..", "..", "..");
+
+function makeTempFixture(): { projectCwd: string; cleanup: () => void } {
+  const root = mkdtempSync(join(tmpdir(), "gsd-auto-lock-test-"));
+  const projectCwd = join(root, "project");
+  mkdirSync(projectCwd, { recursive: true });
+  return {
+    projectCwd,
+    cleanup: () => {
+      try { rmSync(root, { recursive: true, force: true }); } catch { /* best-effort */ }
+    },
+  };
+}
+
+function writeAutoModule(dir: string, payload: Record<string, unknown>): string {
+  const modulePath = join(dir, "fake-auto-dashboard.mjs");
+  writeFileSync(
+    modulePath,
+    `export function getAutoDashboardData() { return ${JSON.stringify(payload)}; }\n`,
+  );
+  return modulePath;
+}
+
+function writeSessionLock(projectCwd: string, data: Record<string, unknown>): void {
+  const gsdDir = join(projectCwd, ".gsd");
+  mkdirSync(gsdDir, { recursive: true });
+  writeFileSync(join(gsdDir, "auto.lock"), JSON.stringify(data));
+}
+
+function writePausedSession(projectCwd: string, data: Record<string, unknown>): void {
+  const runtimeDir = join(projectCwd, ".gsd", "runtime");
+  mkdirSync(runtimeDir, { recursive: true });
+  writeFileSync(join(runtimeDir, "paused-session.json"), JSON.stringify(data));
+}
+
+const INACTIVE_PAYLOAD = {
+  active: false,
+  paused: false,
+  stepMode: false,
+  startTime: 0,
+  elapsed: 0,
+  currentUnit: null,
+  completedUnits: [],
+  basePath: "",
+  totalCost: 0,
+  totalTokens: 0,
+};
+
+// ─── Tests ──────────────────────────────────────────────────────────
+
+test("#2705 regression: subprocess reports active=false but session lock exists with live PID → reconcile to active=true", async (t) => {
+  const fixture = makeTempFixture();
+  t.after(() => fixture.cleanup());
+
+  const modulePath = writeAutoModule(fixture.projectCwd, INACTIVE_PAYLOAD);
+
+  // On disk: session lock exists with current PID (simulates auto running in parent process).
+  writeSessionLock(fixture.projectCwd, {
+    pid: process.pid,
+    startedAt: new Date().toISOString(),
+    unitType: "execute-task",
+    unitId: "M001/S01/T01",
+    unitStartedAt: new Date().toISOString(),
+  });
+
+  const result = await collectAuthoritativeAutoDashboardData(repoRoot, {
+    env: {
+      ...process.env,
+      GSD_WEB_TEST_AUTO_DASHBOARD_MODULE: modulePath,
+      GSD_WEB_PROJECT_CWD: fixture.projectCwd,
+    },
+  });
+
+  // After reconciliation, active MUST be true because the lock PID is alive.
+  assert.equal(result.active, true, "active must be reconciled to true when session lock PID is alive");
+  assert.equal(result.paused, false, "paused must remain false when no paused-session exists");
+});
+
+test("#2705: subprocess reports active=false and no session lock → remains inactive", async (t) => {
+  const fixture = makeTempFixture();
+  t.after(() => fixture.cleanup());
+
+  const modulePath = writeAutoModule(fixture.projectCwd, INACTIVE_PAYLOAD);
+
+  const result = await collectAuthoritativeAutoDashboardData(repoRoot, {
+    env: {
+      ...process.env,
+      GSD_WEB_TEST_AUTO_DASHBOARD_MODULE: modulePath,
+      GSD_WEB_PROJECT_CWD: fixture.projectCwd,
+    },
+  });
+
+  assert.equal(result.active, false, "active must remain false when no session lock exists");
+  assert.equal(result.paused, false);
+});
+
+test("#2705: subprocess reports active=false but paused-session.json exists → reconcile to paused=true", async (t) => {
+  const fixture = makeTempFixture();
+  t.after(() => fixture.cleanup());
+
+  const modulePath = writeAutoModule(fixture.projectCwd, INACTIVE_PAYLOAD);
+
+  writePausedSession(fixture.projectCwd, {
+    milestoneId: "M001",
+    pausedAt: new Date().toISOString(),
+    stepMode: false,
+  });
+
+  const result = await collectAuthoritativeAutoDashboardData(repoRoot, {
+    env: {
+      ...process.env,
+      GSD_WEB_TEST_AUTO_DASHBOARD_MODULE: modulePath,
+      GSD_WEB_PROJECT_CWD: fixture.projectCwd,
+    },
+  });
+
+  assert.equal(result.paused, true, "paused must be reconciled to true when paused-session.json exists");
+  assert.equal(result.active, false, "active must remain false when paused (paused overrides active)");
+});
+
+test("#2705: subprocess reports active=true → no reconciliation needed", async (t) => {
+  const fixture = makeTempFixture();
+  t.after(() => fixture.cleanup());
+
+  const activePayload = {
+    active: true,
+    paused: false,
+    stepMode: true,
+    startTime: 1000,
+    elapsed: 500,
+    currentUnit: { type: "execute-task", id: "M001/S01/T01", startedAt: 1000 },
+    completedUnits: [],
+    basePath: fixture.projectCwd,
+    totalCost: 1.5,
+    totalTokens: 1000,
+  };
+  const modulePath = writeAutoModule(fixture.projectCwd, activePayload);
+
+  const result = await collectAuthoritativeAutoDashboardData(repoRoot, {
+    env: {
+      ...process.env,
+      GSD_WEB_TEST_AUTO_DASHBOARD_MODULE: modulePath,
+      GSD_WEB_PROJECT_CWD: fixture.projectCwd,
+    },
+  });
+
+  assert.equal(result.active, true, "active should remain true when subprocess already reports it");
+});
+
+test("#2705: session lock exists but PID is dead → remains inactive (stale lock)", async (t) => {
+  const fixture = makeTempFixture();
+  t.after(() => fixture.cleanup());
+
+  const modulePath = writeAutoModule(fixture.projectCwd, INACTIVE_PAYLOAD);
+
+  // Use a PID that is almost certainly dead.
+  writeSessionLock(fixture.projectCwd, {
+    pid: 999999999,
+    startedAt: new Date().toISOString(),
+    unitType: "execute-task",
+    unitId: "M001/S01/T01",
+    unitStartedAt: new Date().toISOString(),
+  });
+
+  const result = await collectAuthoritativeAutoDashboardData(repoRoot, {
+    env: {
+      ...process.env,
+      GSD_WEB_TEST_AUTO_DASHBOARD_MODULE: modulePath,
+      GSD_WEB_PROJECT_CWD: fixture.projectCwd,
+    },
+  });
+
+  assert.equal(result.active, false, "active must remain false when session lock PID is dead (stale lock)");
+});

--- a/src/web/auto-dashboard-service.ts
+++ b/src/web/auto-dashboard-service.ts
@@ -1,5 +1,5 @@
 import { execFile } from "node:child_process";
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 
@@ -40,6 +40,64 @@ function resolveTsLoaderPath(packageRoot: string): string {
 
 export function collectTestOnlyFallbackAutoDashboardData(): AutoDashboardData {
   return fallbackAutoDashboardData();
+}
+
+/**
+ * Check if a PID is alive by sending signal 0.
+ */
+function isPidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Reconcile subprocess auto dashboard data with on-disk session state.
+ *
+ * The subprocess always starts with fresh module state (s.active === false),
+ * so it can never report active/paused correctly. We check:
+ *   1. .gsd/auto.lock — if present and its PID is alive, auto IS running.
+ *   2. .gsd/runtime/paused-session.json — if present, auto IS paused.
+ *
+ * See #2705.
+ */
+function reconcileWithDiskState(
+  data: AutoDashboardData,
+  projectCwd: string,
+  checkExists: (path: string) => boolean,
+): AutoDashboardData {
+  // If the subprocess already reports active or paused, trust it.
+  if (data.active || data.paused) return data;
+
+  // Check for paused-session.json first (paused takes precedence).
+  const pausedPath = join(projectCwd, ".gsd", "runtime", "paused-session.json");
+  if (checkExists(pausedPath)) {
+    try {
+      // Validate the file is readable JSON (not corrupt).
+      JSON.parse(readFileSync(pausedPath, "utf-8"));
+      return { ...data, paused: true };
+    } catch {
+      // Corrupt or unreadable — ignore.
+    }
+  }
+
+  // Check for session lock with a live PID.
+  const lockPath = join(projectCwd, ".gsd", "auto.lock");
+  if (checkExists(lockPath)) {
+    try {
+      const lockData = JSON.parse(readFileSync(lockPath, "utf-8")) as { pid?: number };
+      if (typeof lockData.pid === "number" && isPidAlive(lockData.pid)) {
+        return { ...data, active: true };
+      }
+    } catch {
+      // Corrupt or unreadable — ignore.
+    }
+  }
+
+  return data;
 }
 
 export async function collectAuthoritativeAutoDashboardData(
@@ -103,7 +161,12 @@ export async function collectAuthoritativeAutoDashboardData(
         }
 
         try {
-          resolveResult(JSON.parse(stdout) as AutoDashboardData);
+          const parsed = JSON.parse(stdout) as AutoDashboardData;
+          const projectCwd = env.GSD_WEB_PROJECT_CWD || "";
+          const reconciled = projectCwd
+            ? reconcileWithDiskState(parsed, projectCwd, checkExists)
+            : parsed;
+          resolveResult(reconciled);
         } catch (parseError) {
           reject(
             new Error(


### PR DESCRIPTION
## Summary
- Fix web UI showing "Start auto" even while auto mode is already running
- The subprocess spawned by `collectAuthoritativeAutoDashboardData` always starts with fresh module state (`s.active === false`), so it could never report the running state
- After obtaining the subprocess result, reconcile `active`/`paused` state with on-disk session lock (`.gsd/auto.lock` PID liveness check) and paused-session metadata (`.gsd/runtime/paused-session.json`)

Closes #2705

## Test plan
- [x] Added 5 regression tests in `web-auto-dashboard-lock-reconciliation.test.ts`
- [x] Verified subprocess returns `active=false` + live lock PID → reconciled to `active=true`
- [x] Verified no lock file → remains `active=false`
- [x] Verified paused-session.json present → reconciled to `paused=true`
- [x] Verified subprocess already returns `active=true` → no change
- [x] Verified dead PID in lock file → remains `active=false` (stale lock)
- [x] All existing web-bridge-contract, workflow-controls, and auto-dashboard tests pass
- [x] TypeScript compilation passes (`tsc -p tsconfig.test.json`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)