### PR TITLE
fix(gsd extension): render missing roadmap planning sections from DB

### DIFF
--- a/src/resources/extensions/gsd/markdown-renderer.ts
+++ b/src/resources/extensions/gsd/markdown-renderer.ts
@@ -171,6 +171,52 @@ function renderRoadmapMarkdown(milestone: MilestoneRow, slices: SliceRow[]): str
     lines.push("");
   }
 
+  if (milestone.key_risks.length > 0) {
+    lines.push("## Key Risks / Unknowns");
+    lines.push("");
+    for (const r of milestone.key_risks) {
+      lines.push(`- ${r.risk} — ${r.whyItMatters}`);
+    }
+    lines.push("");
+  }
+
+  if (milestone.proof_strategy.length > 0) {
+    lines.push("## Proof Strategy");
+    lines.push("");
+    for (const p of milestone.proof_strategy) {
+      lines.push(`- ${p.riskOrUnknown} → retire in ${p.retireIn} by proving ${p.whatWillBeProven}`);
+    }
+    lines.push("");
+  }
+
+  const verClasses: string[] = [];
+  if (milestone.verification_contract) verClasses.push(`- **Contract:** ${milestone.verification_contract}`);
+  if (milestone.verification_integration) verClasses.push(`- **Integration:** ${milestone.verification_integration}`);
+  if (milestone.verification_operational) verClasses.push(`- **Operational:** ${milestone.verification_operational}`);
+  if (milestone.verification_uat) verClasses.push(`- **UAT:** ${milestone.verification_uat}`);
+  if (verClasses.length > 0) {
+    lines.push("## Verification Classes");
+    lines.push("");
+    lines.push(...verClasses);
+    lines.push("");
+  }
+
+  if (milestone.definition_of_done.length > 0) {
+    lines.push("## Milestone Definition of Done");
+    lines.push("");
+    for (const item of milestone.definition_of_done) {
+      lines.push(`- ${item}`);
+    }
+    lines.push("");
+  }
+
+  if (milestone.requirement_coverage.trim()) {
+    lines.push("## Requirement Coverage");
+    lines.push("");
+    lines.push(milestone.requirement_coverage.trim());
+    lines.push("");
+  }
+
   lines.push("## Slices");
   lines.push("");
   for (const slice of slices) {

--- a/src/resources/extensions/gsd/tests/markdown-renderer.test.ts
+++ b/src/resources/extensions/gsd/tests/markdown-renderer.test.ts
@@ -23,6 +23,7 @@ import {
   renderAllFromDb,
   renderPlanFromDb,
   renderTaskPlanFromDb,
+  renderRoadmapFromDb,
   detectStaleRenders,
   repairStaleRenders,
 } from '../markdown-renderer.ts';
@@ -1158,4 +1159,110 @@ test('── markdown-renderer: detectStaleRenders finds missing slice summary a
 });
 
 // ═══════════════════════════════════════════════════════════════════════════
+// renderRoadmapMarkdown — regression: all DB-backed sections appear (#3216)
+// ═══════════════════════════════════════════════════════════════════════════
+
+test('── markdown-renderer: renderRoadmapFromDb includes all planning sections ──', async () => {
+  const tmpDir = makeTmpDir();
+  const dbPath = path.join(tmpDir, '.gsd', 'gsd.db');
+  openDatabase(dbPath);
+  clearAllCaches();
+
+  try {
+    scaffoldDirs(tmpDir, 'M019', ['S01']);
+
+    insertMilestone({
+      id: 'M019',
+      title: 'Full Planning Milestone',
+      status: 'active',
+      planning: {
+        vision: 'A fully rendered roadmap',
+        successCriteria: ['All sections present', 'No data lost'],
+        keyRisks: [
+          { risk: 'Parser fragility', whyItMatters: 'Breaks downstream consumers' },
+        ],
+        proofStrategy: [
+          { riskOrUnknown: 'Parser fragility', retireIn: 'S01', whatWillBeProven: 'All sections round-trip' },
+        ],
+        verificationContract: 'Unit tests pass',
+        verificationIntegration: 'Integration tests pass',
+        verificationOperational: 'Daemon restart recovers',
+        verificationUat: 'Human reads full roadmap',
+        definitionOfDone: ['All slices complete', 'All verification classes met'],
+        requirementCoverage: 'Covers: R001, R002\nPartially covers: R003',
+        boundaryMapMarkdown: '',
+      },
+    });
+
+    insertSlice({ id: 'S01', milestoneId: 'M019', title: 'Core', status: 'pending' });
+
+    const { content } = await renderRoadmapFromDb(tmpDir, 'M019');
+
+    assert.ok(content.includes('## Success Criteria'), 'success_criteria section present');
+    assert.ok(content.includes('- All sections present'), 'success_criteria content present');
+    assert.ok(content.includes('## Key Risks / Unknowns'), 'key_risks section present');
+    assert.ok(content.includes('- Parser fragility — Breaks downstream consumers'), 'key_risks content present');
+    assert.ok(content.includes('## Proof Strategy'), 'proof_strategy section present');
+    assert.ok(content.includes('- Parser fragility → retire in S01 by proving All sections round-trip'), 'proof_strategy content present');
+    assert.ok(content.includes('## Verification Classes'), 'verification classes section present');
+    assert.ok(content.includes('- **Contract:** Unit tests pass'), 'verification_contract present');
+    assert.ok(content.includes('- **Integration:** Integration tests pass'), 'verification_integration present');
+    assert.ok(content.includes('- **Operational:** Daemon restart recovers'), 'verification_operational present');
+    assert.ok(content.includes('- **UAT:** Human reads full roadmap'), 'verification_uat present');
+    assert.ok(content.includes('## Milestone Definition of Done'), 'definition_of_done section present');
+    assert.ok(content.includes('- All slices complete'), 'definition_of_done content present');
+    assert.ok(content.includes('## Requirement Coverage'), 'requirement_coverage section present');
+    assert.ok(content.includes('Covers: R001, R002'), 'requirement_coverage content present');
+    assert.ok(content.includes('## Slices'), 'slices section present');
+  } finally {
+    closeDatabase();
+    cleanupDir(tmpDir);
+  }
+});
+
+test('── markdown-renderer: renderRoadmapFromDb omits empty planning sections ──', async () => {
+  const tmpDir = makeTmpDir();
+  const dbPath = path.join(tmpDir, '.gsd', 'gsd.db');
+  openDatabase(dbPath);
+  clearAllCaches();
+
+  try {
+    scaffoldDirs(tmpDir, 'M100', ['S01']);
+
+    insertMilestone({
+      id: 'M100',
+      title: 'Minimal Milestone',
+      status: 'active',
+      planning: {
+        vision: 'Only vision and slices',
+        successCriteria: [],
+        keyRisks: [],
+        proofStrategy: [],
+        verificationContract: '',
+        verificationIntegration: '',
+        verificationOperational: '',
+        verificationUat: '',
+        definitionOfDone: [],
+        requirementCoverage: '',
+        boundaryMapMarkdown: '',
+      },
+    });
+
+    insertSlice({ id: 'S01', milestoneId: 'M100', title: 'Core', status: 'pending' });
+
+    const { content } = await renderRoadmapFromDb(tmpDir, 'M100');
+
+    assert.ok(!content.includes('## Success Criteria'), 'empty success_criteria omitted');
+    assert.ok(!content.includes('## Key Risks'), 'empty key_risks omitted');
+    assert.ok(!content.includes('## Proof Strategy'), 'empty proof_strategy omitted');
+    assert.ok(!content.includes('## Verification Classes'), 'empty verification classes omitted');
+    assert.ok(!content.includes('## Milestone Definition of Done'), 'empty definition_of_done omitted');
+    assert.ok(!content.includes('## Requirement Coverage'), 'empty requirement_coverage omitted');
+    assert.ok(content.includes('## Slices'), 'slices section always present');
+    assert.ok(content.includes('**Vision:** Only vision and slices'), 'vision present');
+  } finally {
+    closeDatabase();
+    cleanupDir(tmpDir);
+  }
+});
 


### PR DESCRIPTION
## TL;DR

**What:** Restore the missing DB-backed roadmap planning sections in milestone rendering and add regression coverage for populated and empty planning data.
**Why:** `renderRoadmapMarkdown()` was dropping key risks, proof strategy, verification classes, definition of done, and requirement coverage, which truncated roadmap files and hid planning context needed by humans and downstream consumers.
**How:** Render the missing non-empty planning sections in template order, keep empty sections omitted, and verify the behavior with focused regression tests plus a manual DB-backed smoke run.

## What

- Update `src/resources/extensions/gsd/markdown-renderer.ts` so roadmap rendering includes `key_risks`, `proof_strategy`, all four verification class fields, `definition_of_done`, and `requirement_coverage` between `Success Criteria` and `Slices`, matching the roadmap template order.
- Add two regression tests in `src/resources/extensions/gsd/tests/markdown-renderer.test.ts` covering both fully populated planning data and empty planning fields.

## Why

Issue `#3216` reported that `renderRoadmapMarkdown()` could emit a 12-line roadmap even when the DB contained the full milestone planning payload. That dropped the planning context reviewers and downstream consumers need to understand risks, proof, verification, and done criteria.

Closes #3216

## How

- Render each missing planning section only when it has content, preserving the existing omit-empty behavior for minimal milestones.
- Keep the section order aligned with `templates/roadmap.md` so DB-backed rendering matches the expected roadmap structure.
- Add targeted regression coverage for both populated and empty planning states.

**Bug reproduction:**

1. Create a scratch `.gsd` project with a milestone whose DB row includes `key_risks`, `proof_strategy`, all four verification fields, `definition_of_done`, and `requirement_coverage`.
2. Call `renderRoadmapFromDb(base, 'M019')`.
3. Inspect the rendered roadmap markdown for the planning sections between `Success Criteria` and `Slices`.

Before fix: the roadmap omitted the planning sections and jumped from `Success Criteria` straight to `Slices`.
After fix: the roadmap includes `Key Risks / Unknowns`, `Proof Strategy`, `Verification Classes`, `Milestone Definition of Done`, and `Requirement Coverage` before `Slices`.

Repro script (run from repo root):
  node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --input-type=module

## Change type

- [x] `fix` — Bug fix
- [x] `test` — Adding or updating tests
- [ ] `feat` — New feature or capability
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [x] `gsd extension` — GSD workflow
- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [ ] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

## AI disclosure

- [x] This PR includes AI-assisted code. Verified locally with `npm run test:compile`, the focused `markdown-renderer` test suite, and a manual DB-backed smoke run.
