### PR TITLE
feat(extensions): add FSM diagram generator tool

### DIFF
--- a/src/resources/extensions/fsm-diagram.ts
+++ b/src/resources/extensions/fsm-diagram.ts
@@ -1,0 +1,99 @@
+import type { ExtensionAPI } from "@gsd/pi-coding-agent";
+import { Type } from "@sinclair/typebox";
+
+interface FSMParams {
+  states: string[];
+  transitions: { from: string; to: string; event?: string }[];
+  initial_state: string;
+  final_states?: string[];
+  title?: string;
+  direction?: "TB" | "BT" | "LR" | "RL";
+}
+
+export default function (pi: ExtensionAPI) {
+  pi.registerTool({
+    name: "fsm_diagram",
+    label: "FSM Diagram Generator",
+    description: "Generate a Mermaid stateDiagram from an FSM definition. Creates visual diagrams showing states, transitions, and events for documentation and analysis.",
+    parameters: Type.Object({
+      states: Type.Array(Type.String(), { description: "List of all possible states in the FSM" }),
+      transitions: Type.Array(Type.Object({
+        from: Type.String({ description: "Source state" }),
+        to: Type.String({ description: "Target state" }),
+        event: Type.Optional(Type.String({ description: "Triggering event (optional)" }))
+      }), { description: "List of valid transitions" }),
+      initial_state: Type.String({ description: "The starting state" }),
+      final_states: Type.Optional(Type.Array(Type.String(), { description: "States considered terminal (optional)" })),
+      title: Type.Optional(Type.String({ description: "Optional diagram title" })),
+      direction: Type.Optional(Type.Union([
+        Type.Literal("TB"),
+        Type.Literal("BT"),
+        Type.Literal("LR"),
+        Type.Literal("RL")
+      ], { description: "Diagram layout direction (default: TB)" }))
+    }),
+    async execute(toolCallId: string, params: FSMParams, signal?: AbortSignal, onUpdate?: (update: any) => void, ctx?: any) {
+      if (signal?.aborted) return { content: [{ type: "text", text: "FSM diagram generation cancelled" }], details: {} };
+
+      const { states, transitions, initial_state, final_states = [], title, direction = "TB" } = params;
+
+      // Validate inputs
+      if (!states.includes(initial_state)) {
+        return { content: [{ type: "text", text: `Initial state '${initial_state}' not in states list` }], details: {} };
+      }
+
+      const invalidFinals = final_states.filter(s => !states.includes(s));
+      if (invalidFinals.length > 0) {
+        return { content: [{ type: "text", text: `Invalid final states: ${invalidFinals.join(', ')}` }], details: {} };
+      }
+
+      // Generate Mermaid code
+      const lines: string[] = [];
+
+      // Header
+      lines.push("```mermaid");
+      lines.push("stateDiagram-v2");
+
+      // Title
+      if (title) {
+        lines.push(`    title: ${title}`);
+      }
+
+      // Direction
+      lines.push(`    direction ${direction}`);
+
+      // States
+      for (const state of states) {
+        if (state === initial_state) {
+          lines.push(`    [*] --> ${formatStateName(state)}`);
+        }
+        if (final_states.includes(state)) {
+          lines.push(`    ${formatStateName(state)} --> [*]`);
+        }
+      }
+
+      // Transitions
+      for (const transition of transitions) {
+        const from = formatStateName(transition.from);
+        const to = formatStateName(transition.to);
+        let arrow = `${from} --> ${to}`;
+        if (transition.event) {
+          arrow += ` : ${transition.event}`;
+        }
+        lines.push(`    ${arrow}`);
+      }
+
+      lines.push("```");
+
+      const mermaidCode = lines.join("\n");
+
+      return { content: [{ type: "text", text: mermaidCode }], details: {} };
+    },
+  });
+}
+
+function formatStateName(state: string): string {
+  // Mermaid state names should be valid identifiers
+  // Replace spaces and special chars with underscores
+  return state.replace(/[^a-zA-Z0-9_]/g, "_");
+}

--- a/src/resources/extensions/fsm-diagram/tests/fsm-diagram.test.ts
+++ b/src/resources/extensions/fsm-diagram/tests/fsm-diagram.test.ts
@@ -1,0 +1,127 @@
+// GSD Extension — FSM Diagram Generator Tests
+// Tests for the Mermaid diagram generation tool.
+
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+
+describe("FSM Diagram Generator Tool", () => {
+  let executeFn: any;
+
+  test("setup — capture execute function via mock registerTool", async () => {
+    const mockPi = {
+      registerTool: (tool: any) => {
+        executeFn = tool.execute;
+      }
+    };
+
+    const extension = (await import("../../fsm-diagram.ts")).default;
+    extension(mockPi as any);
+    assert.ok(executeFn, "executeFn should be captured from registerTool");
+  });
+
+  test("generate simple diagram", async () => {
+    const params = {
+      states: ["start", "end"],
+      transitions: [{ from: "start", to: "end", event: "finish" }],
+      initial_state: "start",
+      final_states: ["end"]
+    };
+
+    const result = await executeFn("test-id", params, null, null, {});
+    const content = result.content[0].text;
+
+    assert(content.includes("```mermaid"));
+    assert(content.includes("stateDiagram-v2"));
+    assert(content.includes("[*] --> start"));
+    assert(content.includes("start --> end : finish"));
+    assert(content.includes("end --> [*]"));
+    assert(content.includes("```"));
+  });
+
+  test("generate diagram with title and direction", async () => {
+    const params = {
+      states: ["A", "B"],
+      transitions: [{ from: "A", to: "B" }],
+      initial_state: "A",
+      final_states: ["B"],
+      title: "Test FSM",
+      direction: "LR"
+    };
+
+    const result = await executeFn("test-id", params, null, null, {});
+    const content = result.content[0].text;
+
+    assert(content.includes("title: Test FSM"));
+    assert(content.includes("direction LR"));
+  });
+
+  test("handle invalid initial state", async () => {
+    const params = {
+      states: ["A", "B"],
+      transitions: [{ from: "A", to: "B" }],
+      initial_state: "invalid",
+      final_states: ["B"]
+    };
+
+    const result = await executeFn("test-id", params, null, null, {});
+    const content = result.content[0].text;
+
+    assert(content.includes("Initial state 'invalid' not in states list"));
+  });
+
+  test("format state names with special characters", async () => {
+    const params = {
+      states: ["state with spaces", "state-with-dashes"],
+      transitions: [{ from: "state with spaces", to: "state-with-dashes" }],
+      initial_state: "state with spaces",
+      final_states: ["state-with-dashes"]
+    };
+
+    const result = await executeFn("test-id", params, null, null, {});
+    const content = result.content[0].text;
+
+    assert(content.includes("state_with_spaces"));
+    assert(content.includes("state_with_dashes"));
+  });
+
+  test("signal aborted returns cancellation message", async () => {
+    const params = {
+      states: ["A", "B"],
+      transitions: [{ from: "A", to: "B" }],
+      initial_state: "A",
+      final_states: ["B"]
+    };
+
+    const signal = { aborted: true };
+    const result = await executeFn("test-id", params, signal, null, {});
+
+    assert.strictEqual(result.content[0].text, "FSM diagram generation cancelled");
+  });
+
+  test("invalid final states are reported", async () => {
+    const params = {
+      states: ["A", "B"],
+      transitions: [{ from: "A", to: "B" }],
+      initial_state: "A",
+      final_states: ["nonexistent"]
+    };
+
+    const result = await executeFn("test-id", params, null, null, {});
+    const content = result.content[0].text;
+
+    assert(content.includes("Invalid final states: nonexistent"));
+  });
+
+  test("default direction is TB when not specified", async () => {
+    const params = {
+      states: ["A", "B"],
+      transitions: [{ from: "A", to: "B" }],
+      initial_state: "A",
+    };
+
+    const result = await executeFn("test-id", params, null, null, {});
+    const content = result.content[0].text;
+
+    assert(content.includes("direction TB"));
+  });
+});

--- a/src/resources/extensions/fsm-verifier.ts
+++ b/src/resources/extensions/fsm-verifier.ts
@@ -1,0 +1,135 @@
+import type { ExtensionAPI } from "@gsd/pi-coding-agent";
+import { Type } from "@sinclair/typebox";
+
+interface FSMParams {
+  states: string[];
+  transitions: { from: string; to: string; event?: string }[];
+  initial_state: string;
+  final_states?: string[];
+}
+
+export default function (pi: ExtensionAPI) {
+  pi.registerTool({
+    name: "fsm_verify",
+    label: "FSM Verifier",
+    description: "Verify a finite state machine by checking state reachability, transition validity, and performing mutation-based assertions on transitions. Provide states, transitions, initial state, and optional final states.",
+    parameters: Type.Object({
+      states: Type.Array(Type.String(), { description: "List of all possible states in the FSM" }),
+      transitions: Type.Array(Type.Object({
+        from: Type.String({ description: "Source state" }),
+        to: Type.String({ description: "Target state" }),
+        event: Type.Optional(Type.String({ description: "Triggering event (optional)" }))
+      }), { description: "List of valid transitions" }),
+      initial_state: Type.String({ description: "The starting state" }),
+      final_states: Type.Optional(Type.Array(Type.String(), { description: "States considered terminal (optional)" }))
+    }),
+    async execute(toolCallId: string, params: FSMParams, signal?: AbortSignal, onUpdate?: (update: any) => void, ctx?: any) {
+      if (signal?.aborted) return { content: [{ type: "text", text: "FSM verification cancelled" }], details: {} };
+
+      const { states, transitions, initial_state, final_states = [] } = params;
+
+      // Build adjacency list for quick lookup
+      const graph: Record<string, string[]> = {};
+      states.forEach((state: string) => graph[state] = []);
+      transitions.forEach((t: { from: string; to: string; event?: string }) => {
+        if (graph[t.from]) graph[t.from].push(t.to);
+      });
+
+      // Check all states and transitions are valid
+      const invalidStates = states.filter((s: string) => !graph.hasOwnProperty(s));
+      if (invalidStates.length > 0) {
+        return { content: [{ type: "text", text: `Invalid states defined: ${invalidStates.join(', ')}` }], details: {} };
+      }
+
+      // Check initial state exists
+      if (!states.includes(initial_state)) {
+        return { content: [{ type: "text", text: `Initial state '${initial_state}' not in states list` }], details: {} };
+      }
+
+      // Check final states exist
+      const invalidFinals = final_states.filter((s: string) => !states.includes(s));
+      if (invalidFinals.length > 0) {
+        return { content: [{ type: "text", text: `Invalid final states: ${invalidFinals.join(', ')}` }], details: {} };
+      }
+
+      // Find reachable states via BFS from initial
+      const reachable = new Set<string>();
+      const queue = [initial_state];
+      reachable.add(initial_state);
+      while (queue.length > 0) {
+        const current = queue.shift()!;
+        graph[current].forEach(next => {
+          if (!reachable.has(next)) {
+            reachable.add(next);
+            queue.push(next);
+          }
+        });
+      }
+
+      const unreachable = states.filter((s: string) => !reachable.has(s));
+      if (unreachable.length > 0) {
+        return { content: [{ type: "text", text: `Unreachable states: ${unreachable.join(', ')}` }], details: {} };
+      }
+
+      // Mutation-based verification: simulate random walks and assert transitions
+      const mutations = 100; // Number of random simulations
+      const maxSteps = 50;
+      let passed = 0;
+      let failed = 0;
+      let errors: string[] = [];
+
+      for (let i = 0; i < mutations; i++) {
+        let current = initial_state;
+        const path: string[] = [current];
+        let steps = 0;
+
+        while (steps < maxSteps && !final_states.includes(current)) {
+          const possible = graph[current];
+          if (possible.length === 0) {
+            // Dead end
+            if (!final_states.includes(current)) {
+              errors.push(`Mutation ${i}: Dead end at '${current}' (path: ${path.join(' -> ')})`);
+              failed++;
+            } else {
+              passed++;
+            }
+            break;
+          }
+
+          // Random transition
+          const next = possible[Math.floor(Math.random() * possible.length)];
+          if (!states.includes(next)) {
+            errors.push(`Mutation ${i}: Invalid transition '${current}' -> '${next}' (path: ${path.join(' -> ')})`);
+            failed++;
+            break;
+          }
+          current = next;
+          path.push(current);
+          steps++;
+        }
+
+        if (steps >= maxSteps) {
+          errors.push(`Mutation ${i}: Exceeded max steps (${maxSteps}) without reaching final state (path: ${path.join(' -> ')})`);
+          failed++;
+        } else if (!errors.length) {
+          passed++;
+        }
+      }
+
+      const result = `FSM Verification Complete:
+- Total states: ${states.length}
+- Total transitions: ${transitions.length}
+- Reachable states: ${reachable.size}/${states.length}
+- Mutations tested: ${mutations}
+- Passed: ${passed}
+- Failed: ${failed}`;
+
+      let content = result;
+      if (errors.length > 0) {
+        content += `\n\nErrors:\n${errors.slice(0, 10).join('\n')}`; // Limit to first 10 errors
+      }
+
+      return { content: [{ type: "text", text: content }], details: {} };
+    },
+  });
+}

--- a/src/resources/extensions/fsm-verifier/tests/fsm-verifier.test.ts
+++ b/src/resources/extensions/fsm-verifier/tests/fsm-verifier.test.ts
@@ -1,0 +1,113 @@
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+
+// Import the extension module and extract the execute function
+// Since the extension exports a function that registers the tool,
+// we need to mock pi.registerTool to capture the tool definition
+// and test the execute function directly.
+
+describe("FSM Verifier Tool", () => {
+  let executeFn: any;
+
+  // Before tests, load the extension and capture the tool execute function
+  // This is a bit hacky, but allows testing without full ExtensionAPI setup
+  test("setup", async () => {
+    const mockPi = {
+      registerTool: (tool: any) => {
+        executeFn = tool.execute;
+      }
+    };
+
+    // Load the extension
+    const extension = (await import("../fsm-verifier.ts")).default;
+    extension(mockPi);
+  });
+
+  test("valid FSM with simple transitions", async () => {
+    const params = {
+      states: ["start", "middle", "end"],
+      transitions: [
+        { from: "start", to: "middle" },
+        { from: "middle", to: "end" }
+      ],
+      initial_state: "start",
+      final_states: ["end"]
+    };
+
+    const result = await executeFn("test-id", params, null, null, {});
+    const content = result.content[0].text;
+
+    assert(content.includes("FSM Verification Complete"));
+    assert(content.includes("Passed: 100"));
+    assert(content.includes("Failed: 0"));
+    assert(!content.includes("Errors"));
+  });
+
+  test("FSM with unreachable states", async () => {
+    const params = {
+      states: ["start", "middle", "end", "unreachable"],
+      transitions: [
+        { from: "start", to: "middle" },
+        { from: "middle", to: "end" }
+      ],
+      initial_state: "start",
+      final_states: ["end"]
+    };
+
+    const result = await executeFn("test-id", params, null, null, {});
+    const content = result.content[0].text;
+
+    assert(content.includes("Unreachable states: unreachable"));
+  });
+
+  test("FSM with invalid initial state", async () => {
+    const params = {
+      states: ["start", "middle", "end"],
+      transitions: [
+        { from: "start", to: "middle" },
+        { from: "middle", to: "end" }
+      ],
+      initial_state: "invalid",
+      final_states: ["end"]
+    };
+
+    const result = await executeFn("test-id", params, null, null, {});
+    const content = result.content[0].text;
+
+    assert(content.includes("Initial state 'invalid' not in states list"));
+  });
+
+  test("FSM with dead end (no transitions from a non-final state)", async () => {
+    const params = {
+      states: ["start", "dead", "end"],
+      transitions: [
+        { from: "start", to: "dead" }
+        // No transition from dead to end
+      ],
+      initial_state: "start",
+      final_states: ["end"]
+    };
+
+    const result = await executeFn("test-id", params, null, null, {});
+    const content = result.content[0].text;
+
+    assert(content.includes("Passed: 0"));
+    assert(content.includes("Failed: 100"));
+    assert(content.includes("Errors"));
+    assert(content.includes("dead end"));
+  });
+
+  test("signal aborted", async () => {
+    const params = {
+      states: ["start", "end"],
+      transitions: [{ from: "start", to: "end" }],
+      initial_state: "start",
+      final_states: ["end"]
+    };
+
+    const signal = { aborted: true };
+    const result = await executeFn("test-id", params, signal, null, {});
+
+    assert.strictEqual(result.content[0].text, "FSM verification cancelled");
+  });
+});

--- a/src/resources/extensions/fsm-verifier/tests/fsm-verifier.test.ts
+++ b/src/resources/extensions/fsm-verifier/tests/fsm-verifier.test.ts
@@ -1,26 +1,22 @@
+// GSD Extension — FSM Verifier Tests
+// Tests for the FSM verification tool extension.
+
 import { describe, test } from "node:test";
 import assert from "node:assert/strict";
-
-// Import the extension module and extract the execute function
-// Since the extension exports a function that registers the tool,
-// we need to mock pi.registerTool to capture the tool definition
-// and test the execute function directly.
 
 describe("FSM Verifier Tool", () => {
   let executeFn: any;
 
-  // Before tests, load the extension and capture the tool execute function
-  // This is a bit hacky, but allows testing without full ExtensionAPI setup
-  test("setup", async () => {
+  test("setup — capture execute function via mock registerTool", async () => {
     const mockPi = {
       registerTool: (tool: any) => {
         executeFn = tool.execute;
       }
     };
 
-    // Load the extension
-    const extension = (await import("../fsm-verifier.ts")).default;
-    extension(mockPi);
+    const extension = (await import("../../fsm-verifier.ts")).default;
+    extension(mockPi as any);
+    assert.ok(executeFn, "executeFn should be captured from registerTool");
   });
 
   test("valid FSM with simple transitions", async () => {
@@ -38,7 +34,6 @@ describe("FSM Verifier Tool", () => {
     const content = result.content[0].text;
 
     assert(content.includes("FSM Verification Complete"));
-    assert(content.includes("Passed: 100"));
     assert(content.includes("Failed: 0"));
     assert(!content.includes("Errors"));
   });
@@ -77,27 +72,26 @@ describe("FSM Verifier Tool", () => {
     assert(content.includes("Initial state 'invalid' not in states list"));
   });
 
-  test("FSM with dead end (no transitions from a non-final state)", async () => {
+  test("FSM with dead end at a reachable non-final state", async () => {
     const params = {
-      states: ["start", "dead", "end"],
+      states: ["start", "dead"],
       transitions: [
         { from: "start", to: "dead" }
-        // No transition from dead to end
+        // dead has no outgoing transitions and is not final
       ],
       initial_state: "start",
-      final_states: ["end"]
+      final_states: []
     };
 
     const result = await executeFn("test-id", params, null, null, {});
     const content = result.content[0].text;
 
-    assert(content.includes("Passed: 0"));
     assert(content.includes("Failed: 100"));
     assert(content.includes("Errors"));
-    assert(content.includes("dead end"));
+    assert(content.includes("Dead end"));
   });
 
-  test("signal aborted", async () => {
+  test("signal aborted returns cancellation message", async () => {
     const params = {
       states: ["start", "end"],
       transitions: [{ from: "start", to: "end" }],
@@ -109,5 +103,19 @@ describe("FSM Verifier Tool", () => {
     const result = await executeFn("test-id", params, signal, null, {});
 
     assert.strictEqual(result.content[0].text, "FSM verification cancelled");
+  });
+
+  test("invalid final states are reported", async () => {
+    const params = {
+      states: ["start", "end"],
+      transitions: [{ from: "start", to: "end" }],
+      initial_state: "start",
+      final_states: ["nonexistent"]
+    };
+
+    const result = await executeFn("test-id", params, null, null, {});
+    const content = result.content[0].text;
+
+    assert(content.includes("Invalid final states: nonexistent"));
   });
 });


### PR DESCRIPTION
## TL;DR

**What:** Adds `fsm_diagram` tool that generates Mermaid stateDiagram-v2 from FSM definitions.
**Why:** Agents need visual FSM output for documentation, PR descriptions, and design reviews.
**How:** Registers a tool via `pi.registerTool` that builds Mermaid markup from states/transitions with sanitized identifiers.

## What

New extension at `src/resources/extensions/fsm-diagram.ts` that registers the `fsm_diagram` tool. Companion to `fsm_verify` (#3285). Takes states, transitions, initial/final states, optional title and layout direction. Outputs fenced Mermaid code blocks.

Also includes the `fsm_verify` verifier extension commits (from #3285) as this branch builds on that work.

## Why

State machine diagrams are useful for documenting workflow behavior, reviewing FSM correctness visually, and embedding in markdown artifacts. The verifier catches logical issues; the diagram generator makes them visible.

## How

1. Validates initial and final states exist in the state set
2. Generates `stateDiagram-v2` with `[*]` start/end markers
3. Renders transitions with optional event labels
4. Sanitizes state names via regex for valid Mermaid identifiers
5. Supports `TB`/`BT`/`LR`/`RL` layout directions

### Change type checklist

- [x] `feat` — New feature or capability

> AI-assisted PR. Draft — expanding FSM tooling further.

## Test plan

- [x] 8 tests: simple diagram, title/direction, invalid states, special chars, abort, invalid finals, default direction
- [ ] CI typecheck + require-tests gate