### PR TITLE
fix(gsd): record phase-selected model in metrics

### DIFF
--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -628,7 +628,14 @@ export async function postUnitPostVerification(pctx: PostUnitContext): Promise<"
             });
 
             if (s.currentUnit) {
-              await closeoutUnit(ctx, s.basePath, s.currentUnit.type, s.currentUnit.id, s.currentUnit.startedAt);
+              await closeoutUnit(
+                ctx,
+                s.basePath,
+                s.currentUnit.type,
+                s.currentUnit.id,
+                s.currentUnit.startedAt,
+                buildSnapshotOpts(s.currentUnit.type, s.currentUnit.id),
+              );
             }
 
             const triageUnitId = `${mid}/${sid}/triage`;
@@ -660,7 +667,14 @@ export async function postUnitPostVerification(pctx: PostUnitContext): Promise<"
       const prompt = buildQuickTaskPrompt(capture);
 
       if (s.currentUnit) {
-        await closeoutUnit(ctx, s.basePath, s.currentUnit.type, s.currentUnit.id, s.currentUnit.startedAt);
+        await closeoutUnit(
+          ctx,
+          s.basePath,
+          s.currentUnit.type,
+          s.currentUnit.id,
+          s.currentUnit.startedAt,
+          buildSnapshotOpts(s.currentUnit.type, s.currentUnit.id),
+        );
       }
 
       markCaptureExecuted(s.basePath, capture.id);

--- a/src/resources/extensions/gsd/auto-unit-closeout.ts
+++ b/src/resources/extensions/gsd/auto-unit-closeout.ts
@@ -14,6 +14,7 @@ export interface CloseoutOptions {
   tier?: string;
   modelDowngraded?: boolean;
   continueHereFired?: boolean;
+  model?: string;
 }
 
 /**
@@ -28,7 +29,8 @@ export async function closeoutUnit(
   startedAt: number,
   opts?: CloseoutOptions,
 ): Promise<string | undefined> {
-  const modelId = ctx.model?.id ?? "unknown";
+  const modelId = opts?.model
+    ?? (ctx.model ? `${ctx.model.provider}/${ctx.model.id}` : "unknown");
   snapshotUnitMetrics(ctx, unitType, unitId, startedAt, modelId, opts);
   const activityFile = saveActivityLog(ctx, basePath, unitType, unitId);
 

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -502,11 +502,15 @@ function buildSnapshotOpts(
   continueHereFired?: boolean;
   promptCharCount?: number;
   baselineCharCount?: number;
+  model?: string;
 } & Record<string, unknown> {
   return {
     promptCharCount: s.lastPromptCharCount,
     baselineCharCount: s.lastBaselineCharCount,
     ...(s.currentUnitRouting ?? {}),
+    ...(s.currentUnitModel
+      ? { model: `${s.currentUnitModel.provider}/${s.currentUnitModel.id}` }
+      : {}),
   };
 }
 
@@ -859,7 +863,14 @@ export async function pauseAuto(
   // Close out the current unit so its runtime record doesn't stay at "dispatched"
   if (s.currentUnit && ctx) {
     try {
-      await closeoutUnit(ctx, s.basePath, s.currentUnit.type, s.currentUnit.id, s.currentUnit.startedAt);
+      await closeoutUnit(
+        ctx,
+        s.basePath,
+        s.currentUnit.type,
+        s.currentUnit.id,
+        s.currentUnit.startedAt,
+        buildSnapshotOpts(s.currentUnit.type, s.currentUnit.id),
+      );
     } catch {
       // Non-fatal — best-effort closeout on pause
     }

--- a/src/resources/extensions/gsd/tests/metrics.test.ts
+++ b/src/resources/extensions/gsd/tests/metrics.test.ts
@@ -22,8 +22,10 @@ import {
   initMetrics,
   resetMetrics,
   getLedger,
+  loadLedgerFromDisk,
   snapshotUnitMetrics,
 } from "../metrics.js";
+import { closeoutUnit } from "../auto-unit-closeout.js";
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -246,6 +248,39 @@ test("initMetrics creates ledger, snapshotUnitMetrics persists across resets", (
     const emptyUnit = snapshotUnitMetrics(mockCtx([]), "plan-slice", "M001/S01", Date.now(), "test-model");
     assert.equal(emptyUnit, null);
     assert.equal(getLedger()!.units.length, 1);
+  } finally {
+    resetMetrics();
+    rmSync(tmpBase, { recursive: true, force: true });
+  }
+});
+
+test("closeoutUnit prefers explicit per-unit model over ctx.model when snapshotting metrics", async () => {
+  const tmpBase = mkdtempSync(join(tmpdir(), "gsd-closeout-model-"));
+  mkdirSync(join(tmpBase, ".gsd"), { recursive: true });
+
+  try {
+    resetMetrics();
+    initMetrics(tmpBase);
+
+    const ctx = mockCtx([
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", name: "Read", input: { file: "foo.ts" } }],
+        usage: {
+          input: 1000, output: 500, cacheRead: 0, cacheWrite: 0, totalTokens: 1500,
+          cost: 0.01,
+        },
+      },
+    ]);
+
+    await closeoutUnit(ctx, tmpBase, "execute-task", "M001/S01/T01", Date.now() - 3000, {
+      model: "openai-codex/gpt-5.3-codex",
+    });
+
+    const ledger = loadLedgerFromDisk(tmpBase);
+    assert.ok(ledger);
+    assert.equal(ledger!.units.length, 1);
+    assert.equal(ledger!.units[0].model, "openai-codex/gpt-5.3-codex");
   } finally {
     resetMetrics();
     rmSync(tmpBase, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- record the phase-selected unit model in GSD metrics instead of reading `ctx.model` at closeout time
- propagate snapshot model metadata through auto pause and post-unit sidecar closeout paths
- add a regression test covering `closeoutUnit()` with an explicit per-unit model override

Closes #3288.

## Root cause
Auto-mode stored the selected model for a unit in `s.currentUnitModel`, but `closeoutUnit()` snapshotted `ctx.model?.id` into the metrics ledger. `history` and `forensics` both read that ledger, so they reported the session/default model instead of the actual phase-selected model.

## Testing
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/metrics.test.ts`

## Notes
- This intentionally fixes metrics/history/forensics only.
- Widget model display still reads `cmdCtx.model` and should be handled separately.