### PR TITLE
feat: add communication_language preference for native language support

### DIFF
--- a/src/resources/extensions/gsd/auto-recovery.ts
+++ b/src/resources/extensions/gsd/auto-recovery.ts
@@ -12,7 +12,7 @@ import { parseUnitId } from "./unit-id.js";
 import { atomicWriteSync } from "./atomic-write.js";
 import { clearParseCache } from "./files.js";
 import { parseRoadmap as parseLegacyRoadmap, parsePlan as parseLegacyPlan } from "./parsers-legacy.js";
-import { isDbAvailable, getTask, getSlice, getSliceTasks, updateTaskStatus } from "./gsd-db.js";
+import { isDbAvailable, getTask, getSlice, getSliceTasks, updateTaskStatus, updateSliceStatus } from "./gsd-db.js";
 import { isValidationTerminal } from "./state.js";
 import { getErrorMessage } from "./error-utils.js";
 import {
@@ -412,13 +412,16 @@ export function writeBlockerPlaceholder(
   ].join("\n");
   writeFileSync(absPath, content, "utf-8");
 
-  // Mark the task as complete in the DB so verifyExpectedArtifact passes.
+  // Mark the task/slice as complete in the DB so verifyExpectedArtifact passes.
   // Without this, the DB status stays "pending" and the dispatch loop
-  // re-derives the same task indefinitely (#2531).
-  if (unitType === "execute-task" && isDbAvailable()) {
+  // re-derives the same unit indefinitely (#2531, #2653).
+  if (isDbAvailable()) {
     const { milestone: mid, slice: sid, task: tid } = parseUnitId(unitId);
-    if (mid && sid && tid) {
+    if (unitType === "execute-task" && mid && sid && tid) {
       try { updateTaskStatus(mid, sid, tid, "complete", new Date().toISOString()); } catch { /* non-fatal */ }
+    }
+    if (unitType === "complete-slice" && mid && sid) {
+      try { updateSliceStatus(mid, sid, "complete", new Date().toISOString()); } catch { /* non-fatal */ }
     }
   }
 

--- a/src/resources/extensions/gsd/tests/auto-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-loop.test.ts
@@ -2107,11 +2107,11 @@ test("autoLoop rejects execute-task with 0 tool calls as hallucinated (#1833)", 
   // The task should NOT have been added to completedUnits on the first iteration
   // (0 tool calls), but SHOULD be added on the second iteration (5 tool calls)
   const warningNotification = notifications.find(
-    (n) => n.includes("0 tool calls") && n.includes("hallucinated"),
+    (n) => n.includes("0 tool calls") && n.includes("context exhaustion"),
   );
   assert.ok(
     warningNotification,
-    "should notify about 0 tool calls hallucination",
+    "should notify about 0 tool calls context exhaustion",
   );
 
   // Verify deriveState was called at least twice (two iterations)
@@ -2122,7 +2122,7 @@ test("autoLoop rejects execute-task with 0 tool calls as hallucinated (#1833)", 
   );
 });
 
-test("autoLoop does NOT reject non-execute-task units with 0 tool calls (#1833)", async () => {
+test("autoLoop rejects complete-slice with 0 tool calls as context-exhausted (#2653)", async () => {
   _resetPendingResolve();
 
   const ctx = makeMockCtx();
@@ -2130,6 +2130,7 @@ test("autoLoop does NOT reject non-execute-task units with 0 tool calls (#1833)"
   ctx.sessionManager = { getSessionFile: () => "/tmp/session.json" };
   const pi = makeMockPi();
 
+  let iterationCount = 0;
   const notifications: string[] = [];
   ctx.ui.notify = (msg: string) => { notifications.push(msg); };
 
@@ -2163,7 +2164,7 @@ test("autoLoop does NOT reject non-execute-task units with 0 tool calls (#1833)"
       };
     },
     closeoutUnit: async () => {
-      // complete-slice with 0 tool calls is fine (e.g. it may just update status)
+      // complete-slice with 0 tool calls — context exhausted, no progress
       mockLedger.units.push({
         type: "complete-slice",
         id: "M001/S01",
@@ -2177,31 +2178,51 @@ test("autoLoop does NOT reject non-execute-task units with 0 tool calls (#1833)"
     getLedger: () => mockLedger,
     postUnitPostVerification: async () => {
       deps.callLog.push("postUnitPostVerification");
-      s.active = false;
+      iterationCount++;
+      // Deactivate after 2nd iteration
+      s.active = iterationCount < 2;
       return "continue" as const;
     },
   });
 
   const loopPromise = autoLoop(ctx, pi, s, deps);
 
+  // First iteration: complete-slice with 0 tool calls → rejected
   await new Promise((r) => setTimeout(r, 50));
+  resolveAgentEnd(makeEvent());
+
+  // Second iteration: re-dispatched, this time with tool calls
+  await new Promise((r) => setTimeout(r, 50));
+  mockLedger.units.length = 0;
+  (deps as any).closeoutUnit = async () => {
+    mockLedger.units.push({
+      type: "complete-slice",
+      id: "M001/S01",
+      startedAt: s.currentUnit?.startedAt ?? Date.now(),
+      toolCalls: 3,
+      assistantMessages: 2,
+      tokens: { input: 200, output: 400, total: 600, cacheRead: 0, cacheWrite: 0 },
+      cost: 0.30,
+    });
+  };
   resolveAgentEnd(makeEvent());
 
   await loopPromise;
 
-  // Should NOT have a hallucination warning for non-execute-task units
+  // Should have a warning about 0 tool calls for complete-slice
   const warningNotification = notifications.find(
-    (n) => n.includes("0 tool calls") && n.includes("hallucinated"),
+    (n) => n.includes("0 tool calls"),
   );
   assert.ok(
-    !warningNotification,
-    "should NOT flag non-execute-task units with 0 tool calls",
+    warningNotification,
+    "should flag complete-slice with 0 tool calls as failed (#2653)",
   );
 
-  // Verify the loop ran to completion (postUnitPostVerification was called)
+  // Verify deriveState was called at least twice (two iterations: rejected + retry)
+  const deriveCount = deps.callLog.filter((c) => c === "deriveState").length;
   assert.ok(
-    deps.callLog.includes("postUnitPostVerification"),
-    "complete-slice with 0 tool calls should still complete the post-unit pipeline",
+    deriveCount >= 2,
+    `deriveState should be called at least 2 times for retry (got ${deriveCount})`,
   );
 });
 

--- a/src/resources/extensions/gsd/tests/integration/idle-recovery.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/idle-recovery.test.ts
@@ -357,3 +357,37 @@ test('writeBlockerPlaceholder: does NOT update DB for non-execute-task types', a
     cleanup(base);
   }
 });
+
+test('writeBlockerPlaceholder: updates DB slice status for complete-slice (#2653)', async () => {
+  const base = createFixtureBase();
+  try {
+    const { openDatabase, closeDatabase, insertMilestone, insertSlice, getSlice, isDbAvailable } =
+      await import("../../gsd-db.ts");
+
+    const dbPath = join(base, ".gsd", "gsd.db");
+    mkdirSync(join(base, ".gsd", "milestones", "M001", "slices", "S01"), { recursive: true });
+
+    openDatabase(dbPath);
+    try {
+      insertMilestone({ id: "M001", title: "Test", status: "active" });
+      insertSlice({ id: "S01", milestoneId: "M001", title: "Slice", status: "active" });
+
+      // complete-slice blocker should update slice DB status to "complete"
+      writeBlockerPlaceholder("complete-slice", "M001/S01", base, "context exhaustion recovery");
+
+      const slice = getSlice("M001", "S01");
+      assert.equal(slice?.status, "complete",
+        "writeBlockerPlaceholder must update DB slice status to 'complete' for complete-slice so dispatch guard unblocks downstream (#2653)");
+
+      // Verify the full chain works: verifyExpectedArtifact should return true
+      // (requires both UAT file and DB status = complete)
+      // Note: the placeholder writes a SUMMARY file, but complete-slice also needs UAT.
+      // The placeholder itself doesn't write UAT, so artifact verification may still fail
+      // for complete-slice — but the DB status is now correct, breaking the circular dep.
+    } finally {
+      if (isDbAvailable()) closeDatabase();
+    }
+  } finally {
+    cleanup(base);
+  }
+});


### PR DESCRIPTION
## TL;DR

**What:** Handle complete-slice context exhaustion in auto-recovery to prevent stuck dispatch loops.
**Why:** Complete-slice units with 0 tool calls were not being detected as context-exhausted, causing infinite re-dispatch.
**How:** Extend the auto-recovery logic to mark slices as complete in the DB and detect 0-tool-call complete-slice units as context-exhausted.

## What

Extend auto-recovery to handle complete-slice units that produce 0 tool calls, treating them as context-exhausted rather than silently passing. Also update DB status for slices (not just tasks) during recovery.

## Why

When a complete-slice unit exhausted its context and produced 0 tool calls, the dispatch loop would re-derive the same unit indefinitely because the slice status was never updated in the DB. This created a stuck-loop scenario.

## How

- Updated `auto-recovery.ts` to call `updateSliceStatus` for complete-slice units during recovery, not just `updateTaskStatus` for execute-task units
- Changed 0-tool-call detection for complete-slice from "allowed" to "context-exhausted" rejection
- Updated tests in `auto-loop.test.ts` and `idle-recovery.test.ts` to cover the new behavior

## Change type

- [x] `fix` — Bug fix

---
*AI-assisted: This PR was generated with Claude Code.*