### PR TITLE
fix(worktree): clean stale MERGE_HEAD before squash merge

### DIFF
--- a/src/resources/extensions/gsd/auto-worktree.ts
+++ b/src/resources/extensions/gsd/auto-worktree.ts
@@ -1566,6 +1566,19 @@ export function mergeMilestoneToMain(
     // Non-fatal — proceed with merge; untracked files may block it
   }
 
+  // 7b. Clean up stale merge state before attempting squash merge (#2912).
+  // A leftover MERGE_HEAD (from a previous failed merge, libgit2 native path,
+  // or interrupted operation) causes `git merge --squash` to refuse with
+  // "fatal: You have not concluded your merge (MERGE_HEAD exists)".
+  // Defensively remove merge artifacts before starting.
+  try {
+    const gitDir_ = resolveGitDir(originalBasePath_);
+    for (const f of ["SQUASH_MSG", "MERGE_MSG", "MERGE_HEAD"]) {
+      const p = join(gitDir_, f);
+      if (existsSync(p)) unlinkSync(p);
+    }
+  } catch { /* best-effort */ }
+
   // 8. Squash merge — auto-resolve .gsd/ state file conflicts (#530)
   const mergeResult = nativeMergeSquash(originalBasePath_, milestoneBranch);
 


### PR DESCRIPTION
## TL;DR

**What:** Defensively remove stale merge state files before attempting squash merge.
**Why:** A leftover `MERGE_HEAD` causes `git merge --squash` to fail with "You have not concluded your merge", producing flaky CI failures across all PRs.
**How:** Add pre-merge cleanup of `MERGE_HEAD`, `MERGE_MSG`, and `SQUASH_MSG` — mirroring the existing post-merge cleanup.

Closes #2912

## What

Adds a defensive cleanup step (7b) in `mergeMilestoneToMain()` that removes stale git merge state files (`MERGE_HEAD`, `MERGE_MSG`, `SQUASH_MSG`) immediately before calling `nativeMergeSquash()`.

## Why

The `#2912: planted MERGE_HEAD is cleaned up in success path` integration test was failing intermittently across all PR CI runs. The root cause: the test plants a `MERGE_HEAD` file before calling `mergeMilestoneToMain()` to simulate libgit2 behavior. But `git merge --squash` refuses to run when `MERGE_HEAD` already exists, so the function throws before reaching the post-merge cleanup code at step 9a.

Beyond the test, this is also a real production issue — any interrupted merge operation could leave `MERGE_HEAD` on disk and block all subsequent milestone merges.

## How

The fix adds a pre-merge cleanup block that mirrors the existing post-merge cleanup (step 9a). It uses `resolveGitDir()` to find the correct `.git` directory (handles worktrees), then removes `SQUASH_MSG`, `MERGE_MSG`, and `MERGE_HEAD` if they exist. The cleanup is best-effort (wrapped in try/catch) to avoid blocking the merge on cleanup failures.

The existing post-merge cleanup at step 9a is preserved as defense-in-depth.

## Change type

- [x] `fix` — Bug fix

---
*AI-assisted: This PR was generated with Claude Code.*