### PR TITLE
feat(gsd): add /gsd test with smart generation, persistence, resume, and opportunistic dispatch

### DIFF
--- a/docs/FILE-SYSTEM-MAP.md
+++ b/docs/FILE-SYSTEM-MAP.md
@@ -36,6 +36,7 @@
 | **Loader / Bootstrap** | Startup initialization, extension sync, tool bootstrap |
 | **LSP** | Language Server Protocol client and multiplexer |
 | **Mac Tools** | macOS-native utilities (Swift CLI) |
+| **Manual Testing** | Interactive manual test runner (`/gsd test`) |
 | **MCP Server/Client** | Model Context Protocol server and client |
 | **Memory Extension** | In-session memory pipeline and storage |
 | **Migration** | Data and config migration tools |
@@ -511,6 +512,7 @@
 | gsd/commands-logs.ts | Commands | Log viewing and filtering |
 | gsd/commands-workflow-templates.ts | Commands, GSD Workflow | Workflow template management |
 | gsd/commands-cmux.ts | Commands, CMux | Tmux/cmux integration commands |
+| gsd/commands-manual-test.ts | Commands, Manual Testing | Interactive manual test session orchestration |
 | gsd/exit-command.ts | Commands | Exit and cleanup commands |
 | gsd/undo.ts | Commands | Undo and rollback functionality |
 | gsd/kill.ts | Commands | Process termination and cleanup |
@@ -526,6 +528,9 @@
 | gsd/notifications.ts | GSD Workflow | User notification and messaging |
 | gsd/triage-ui.ts | GSD Workflow | Triage interface for issue categorization |
 | gsd/guided-flow.ts | GSD Workflow | User-guided workflow orchestration |
+| gsd/manual-test.ts | Manual Testing | UAT parsing, test case extraction, session model, result rendering |
+| gsd/manual-test-ui.ts | Manual Testing, TUI | TUI overlay for interactive pass/fail/skip test runner |
+| gsd/manual-test-db.ts | Manual Testing, State Machine | DB persistence and artifact writing for test sessions |
 | gsd/env-utils.ts | GSD Workflow | Environment variable utilities |
 | gsd/git-constants.ts | GSD Workflow | Git-related constants and paths |
 | gsd/milestone-id-utils.ts | GSD Workflow | Milestone ID generation and parsing |

--- a/docs/auto-mode.md
+++ b/docs/auto-mode.md
@@ -252,6 +252,20 @@ Hard-steer plan documents during execution without stopping the pipeline. Change
 
 Fire-and-forget thought capture. Captures are triaged automatically between tasks. See [Captures & Triage](./captures-triage.md).
 
+### Manual Testing
+
+```
+/gsd test
+```
+
+Pause auto-mode and run interactive manual testing at any point. GSD analyzes actual source code to generate specific, actionable test cases (e.g. "POST `/api/users` with `{...}` → expect 201"), walks you through each one, and persists every verdict instantly so nothing is lost on crash or interrupt.
+
+If you quit mid-session, re-running `/gsd test` resumes from where you left off. If tests fail, choose "Fix now" to have the agent address each failure automatically before resuming the pipeline.
+
+In auto-mode, outstanding test failures are detected automatically at natural stopping points (post-slice-completion, pre-validation, pre-milestone-complete) and fix units are dispatched without explicit user intervention.
+
+See [Commands Reference — Manual Testing](./commands.md#manual-testing) for full details.
+
 ### Visualize
 
 ```

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -17,6 +17,7 @@
 | `/gsd queue` | Queue and reorder future milestones (safe during auto mode) |
 | `/gsd capture` | Fire-and-forget thought capture (works during auto mode) |
 | `/gsd triage` | Manually trigger triage of pending captures |
+| `/gsd test` | Interactive manual testing — walk through checks, record pass/fail/notes |
 | `/gsd dispatch` | Dispatch a specific phase directly (research, plan, execute, complete, reassess, uat, replan) |
 | `/gsd history` | View execution history (supports `--cost`, `--phase`, `--model` filters) |
 | `/gsd forensics` | Full-access GSD debugger — structured anomaly detection, unit traces, and LLM-guided root-cause analysis for auto-mode failures |
@@ -305,3 +306,89 @@ If already up to date, it reports so and takes no action.
 ```
 
 Reports are saved to `.gsd/reports/` with a browseable `index.html` that links to all generated snapshots.
+
+## Manual Testing
+
+`/gsd test` launches an interactive manual test runner. It generates test cases from actual source code analysis (or UAT files if present), walks you through them one by one, and persists each verdict instantly so nothing is lost on crash or interrupt.
+
+### Commands
+
+| Command | Description |
+|---------|-------------|
+| `/gsd test` | Test most recently completed slice (or all if multiple are done) |
+| `/gsd test <sliceId>` | Test a specific completed slice (e.g. `/gsd test S01`) |
+| `/gsd test all` | Test all completed slices in the active milestone |
+| `/gsd test results` | Show results from the last manual test session |
+
+### How It Works
+
+1. **Pauses auto-mode** if running, snapshots current progress
+2. **Generates test cases** using a three-tier fallback:
+   - **UAT file** — if `S01-UAT.md` exists, it's parsed into checks (highest priority)
+   - **Smart code-aware generation** — analyzes actual source files referenced in task summaries/plans, extracts testable signals (API routes, React components, validation schemas, error handlers, CLI commands, exported functions), and synthesizes concrete test checks with specific HTTP methods/paths, component names, and expected behaviors
+   - **Plan-text extraction** — falls back to slice plan text if no source files are available
+3. **Checks for interrupted sessions** — if a previous session was interrupted, merges saved verdicts onto freshly-generated checks and resumes from the first unjudged check
+4. **Opens a TUI overlay** showing one test at a time with steps and expected results
+5. **You record verdicts** using keyboard shortcuts:
+
+| Key | Action |
+|-----|--------|
+| `P` / `Enter` | Mark as **PASS**, advance to next |
+| `F` | Mark as **FAIL** — type failure notes, press Enter |
+| `S` | **Skip** this check |
+| `←` / `→` | Navigate between checks (review previous) |
+| `Q` / `Esc` | Quit early (all recorded verdicts are preserved) |
+| `?` | Show help |
+
+6. **Persists each verdict instantly** — every pass/fail/skip is saved to the DB the moment you record it, not just on session finish. If the process crashes or you quit mid-session, all recorded verdicts survive.
+7. **If failures exist**, presents three options:
+   - **Fix now** — the agent analyzes each failure's notes and fixes the code automatically
+   - **Fix later** — saves results for later; resume pipeline when ready
+   - **Accept as-is** — mark failures as known issues, continue the pipeline
+
+### Smart Test Generation
+
+When no UAT file exists, GSD analyzes source files to produce specific, actionable test cases. For example:
+
+- **API routes** → "POST `/api/users` with `{name: "test"}` → expect 201 with `id` field"
+- **React components** → "Render `UserProfile` with valid props → expect name displayed"
+- **Validation schemas** → "Submit form with empty `email` field → expect validation error"
+- **Error handlers** → "Trigger error condition → expect graceful error response"
+
+Checks are capped at 15 per slice with proportional allocation (60% test-case, 40% edge-case). Signal extraction uses regex-based heuristics prioritized as: routes > validation > error handlers > components > CLI > exports.
+
+### Incremental Persistence & Resume
+
+Every verdict is persisted to the DB the instant you record it. The session row is pre-inserted before the TUI launches, so even a hard kill preserves all work done up to that point.
+
+When you re-run `/gsd test` after an interruption, GSD detects the in-progress session, merges your saved verdicts onto freshly-generated checks (handling cases where checks were added, removed, or reordered between runs), and starts at the first unjudged check. You never re-test something you already passed.
+
+### Opportunistic Fix Dispatch
+
+In auto-mode, GSD automatically checks for outstanding unfixed test failures at three natural stopping points:
+
+- After slice completion
+- Before milestone validation
+- Before milestone completion
+
+If failures are found, a `fix-manual-tests` unit is dispatched automatically — no explicit "fix now" selection required. Anti-refire logic ensures each set of failures is only dispatched once.
+
+### Fix Flow
+
+When you choose "Fix now" (or auto-mode dispatches it), GSD creates a `fix-manual-tests` dispatch unit containing every failure with your exact notes. The agent:
+
+- Reads the relevant source code for each failing feature
+- Diagnoses root causes based on your notes
+- Fixes the code and verifies each fix
+- Reports what was changed
+
+This runs as the next unit in auto-mode, then the pipeline continues normally.
+
+### Artifacts
+
+Results are written to:
+
+- **Per-slice:** `.gsd/milestones/<MID>/slices/<SID>/<SID>-MANUAL-TEST-RESULT.md`
+- **All-slices:** `.gsd/milestones/<MID>/<MID>-MANUAL-TEST-RESULT.md`
+
+The result file includes a summary table, failed check details with your notes, and a state snapshot showing exactly where testing occurred in the pipeline.

--- a/mintlify-docs/guides/auto-mode.mdx
+++ b/mintlify-docs/guides/auto-mode.mdx
@@ -158,6 +158,16 @@ Hard-steer plan documents without stopping the pipeline. Changes are picked up a
 
 Fire-and-forget thought capture. Triaged automatically between tasks. See [captures and triage](/guides/captures-triage).
 
+### Manual testing
+
+```
+/gsd test
+```
+
+Pause auto-mode and run interactive manual testing at any point. GSD analyzes actual source code to generate specific, actionable test cases, walks you through each one, and persists every verdict instantly so nothing is lost on crash or interrupt.
+
+If you quit mid-session, re-running `/gsd test` resumes from where you left off. In auto-mode, outstanding test failures are detected automatically at natural stopping points and fix units are dispatched without user intervention. See [commands reference — manual testing](/guides/commands#manual-testing).
+
 ## Dashboard
 
 `Ctrl+Alt+G` or `/gsd status` shows real-time progress:

--- a/mintlify-docs/guides/commands.mdx
+++ b/mintlify-docs/guides/commands.mdx
@@ -22,6 +22,7 @@ description: "Every GSD command, keyboard shortcut, and CLI flag."
 | `/gsd queue` | Queue and reorder future milestones (safe during auto mode) |
 | `/gsd capture` | Fire-and-forget thought capture (works during auto mode) |
 | `/gsd triage` | Manually trigger triage of pending captures |
+| `/gsd test` | Interactive manual testing — walk through checks, record pass/fail/notes |
 | `/gsd dispatch` | Dispatch a specific phase directly |
 | `/gsd history` | View execution history (supports `--cost`, `--phase`, `--model` filters) |
 | `/gsd forensics` | Full-access debugger for auto-mode failures |
@@ -180,3 +181,46 @@ gsd --mode mcp
 ```
 
 Runs GSD as a Model Context Protocol server over stdin/stdout, exposing all tools to external AI clients (Claude Desktop, VS Code Copilot, etc.).
+
+## Manual testing
+
+`/gsd test` launches an interactive manual test runner. It generates test cases from actual source code analysis (or UAT files if present), walks you through them one at a time, and persists each verdict instantly so nothing is lost on crash or interrupt.
+
+| Command | Description |
+|---------|-------------|
+| `/gsd test` | Test most recently completed slice (or all if multiple) |
+| `/gsd test <sliceId>` | Test a specific completed slice |
+| `/gsd test all` | Test all completed slices |
+| `/gsd test results` | Show last manual test results |
+
+### Test case generation
+
+When no UAT file exists, GSD analyzes source files referenced in task summaries to produce specific test cases — API routes become checks with HTTP methods and expected responses, React components become UI interaction checks, validation schemas become edge-case checks. Checks are capped at 15 per slice. If a UAT file exists, it takes priority.
+
+### TUI controls
+
+The TUI overlay shows one check at a time with steps and expected results:
+
+| Key | Action |
+|-----|--------|
+| `P` / `Enter` | **PASS** — advance to next |
+| `F` | **FAIL** — type notes, press Enter |
+| `S` | **Skip** |
+| `←` / `→` | Navigate between checks |
+| `Q` / `Esc` | Quit (all recorded verdicts are preserved) |
+
+### Persistence and resume
+
+Every verdict is saved to the DB the instant you record it. If the process crashes or you quit mid-session, re-running `/gsd test` detects the interrupted session, merges saved verdicts onto freshly-generated checks, and resumes from the first unjudged check.
+
+### Opportunistic fix dispatch
+
+In auto-mode, GSD checks for outstanding unfixed test failures at three stopping points (post-slice-completion, pre-validation, pre-milestone-complete) and dispatches fix units automatically.
+
+### Post-test actions
+
+After testing, if failures exist you can choose:
+
+- **Fix now** — agent analyzes your failure notes and fixes the code automatically
+- **Fix later** — saves results, resume when ready
+- **Accept as-is** — continue the pipeline with known issues

--- a/src/resources/extensions/gsd/auto-dashboard.ts
+++ b/src/resources/extensions/gsd/auto-dashboard.ts
@@ -89,6 +89,7 @@ export function unitVerb(unitType: string): string {
     case "rewrite-docs": return "rewriting";
     case "reassess-roadmap": return "reassessing";
     case "run-uat": return "running UAT";
+    case "fix-manual-tests": return "fixing test failures";
     case "custom-step": return "executing workflow step";
     default: return unitType;
   }
@@ -109,6 +110,7 @@ export function unitPhaseLabel(unitType: string): string {
     case "rewrite-docs": return "REWRITE";
     case "reassess-roadmap": return "REASSESS";
     case "run-uat": return "UAT";
+    case "fix-manual-tests": return "FIX-TESTS";
     case "custom-step": return "WORKFLOW";
     default: return unitType.toUpperCase();
   }
@@ -136,6 +138,7 @@ function peekNext(unitType: string, state: GSDState): string {
     case "rewrite-docs": return "continue execution";
     case "reassess-roadmap": return "advance to next slice";
     case "run-uat": return "reassess roadmap";
+    case "fix-manual-tests": return "continue execution";
     default: return "";
   }
 }

--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -177,6 +177,50 @@ export const DISPATCH_RULES: DispatchRule[] = [
     },
   },
   {
+    name: "fix-manual-tests (pending manual test failures)",
+    match: async ({ mid, basePath }) => {
+      const { getPendingManualTestFix, clearManualTestFixPrompt } = await import("./manual-test-db.js");
+      const pending = getPendingManualTestFix(mid);
+      if (!pending) return null;
+      // Clear the fix prompt so it doesn't dispatch again after the fix runs
+      clearManualTestFixPrompt(mid);
+      return {
+        action: "dispatch",
+        unitType: "fix-manual-tests",
+        unitId: `${mid}/manual-test-fix`,
+        prompt: pending.fixPrompt,
+      };
+    },
+  },
+  {
+    name: "opportunistic-fix-manual-tests (outstanding failures at stopping point)",
+    match: async ({ mid, basePath, state }) => {
+      // Only activate at natural stopping points
+      const stoppingPhases = ["summarizing", "validating-milestone", "completing-milestone"];
+      if (!stoppingPhases.includes(state.phase)) return null;
+
+      const { getOutstandingFailures, setPendingManualTestFix } = await import("./manual-test-db.js");
+      const session = getOutstandingFailures(mid);
+      if (!session) return null;
+      if (!session.checks || session.checks.filter(c => c.verdict === "fail").length === 0) return null;
+
+      const { buildFixManualTestsPrompt } = await import("./manual-test.js");
+      const prompt = buildFixManualTestsPrompt(session, basePath);
+      if (!prompt) return null;
+
+      // Set fix_prompt to prevent re-dispatch (anti-refire) and integrate
+      // with existing clear flow
+      setPendingManualTestFix(mid, prompt);
+
+      return {
+        action: "dispatch",
+        unitType: "fix-manual-tests",
+        unitId: `${mid}/manual-test-fix-opportunistic`,
+        prompt,
+      };
+    },
+  },
+  {
     name: "summarizing → complete-slice",
     match: async ({ state, mid, midTitle, basePath }) => {
       if (state.phase !== "summarizing") return null;

--- a/src/resources/extensions/gsd/commands-manual-test.ts
+++ b/src/resources/extensions/gsd/commands-manual-test.ts
@@ -1,0 +1,344 @@
+/**
+ * commands-manual-test.ts — Handler for `/gsd test` command.
+ *
+ * Orchestrates the full manual testing flow:
+ * 1. Resolve target slice(s) and gather test checks from UAT files
+ * 2. Pause auto-mode if running
+ * 3. Launch the interactive TUI test runner
+ * 4. Persist results (DB + markdown artifact)
+ * 5. Handle post-test action (fix now / fix later / ignore)
+ */
+
+import type { ExtensionAPI, ExtensionCommandContext } from "@gsd/pi-coding-agent";
+
+import { isAutoActive, stopAuto } from "./auto.js";
+import { deriveState } from "./state.js";
+import {
+  gatherChecksForSlice,
+  gatherChecksForAllSlices,
+  getCompletedSliceIds,
+  sessionCounts,
+  renderManualTestResult,
+  buildFixManualTestsPrompt,
+  type ManualTestSession,
+  type ManualTestCheck,
+} from "./manual-test.js";
+import { showManualTestRunner, showPostTestActionPicker, type PostTestAction } from "./manual-test-ui.js";
+import {
+  saveManualTestSession,
+  getLatestManualTestSession,
+  updateManualTestSessionStatus,
+  updateSessionResults,
+  getInProgressSession,
+} from "./manual-test-db.js";
+
+// ─── Check Merging ────────────────────────────────────────────────────────────
+
+/**
+ * Merge persisted verdicts onto freshly-generated checks.
+ *
+ * Fresh checks are canonical (ordering, additions, removals). For each fresh check,
+ * if a persisted check with the same `id` exists and has a non-null verdict, copy
+ * `verdict`, `notes`, and `timestamp` onto the fresh check. New checks keep null verdicts;
+ * removed checks (present in persisted but not in fresh) are dropped.
+ */
+export function mergeChecks(freshChecks: ManualTestCheck[], persistedChecks: ManualTestCheck[]): ManualTestCheck[] {
+  const persistedMap = new Map<string, ManualTestCheck>();
+  for (const c of persistedChecks) {
+    if (c.verdict !== null) persistedMap.set(c.id, c);
+  }
+
+  return freshChecks.map((fresh) => {
+    const persisted = persistedMap.get(fresh.id);
+    if (persisted) {
+      return { ...fresh, verdict: persisted.verdict, notes: persisted.notes, timestamp: persisted.timestamp };
+    }
+    return fresh;
+  });
+}
+
+// ─── Handler ──────────────────────────────────────────────────────────────────
+
+export async function handleManualTest(
+  args: string,
+  ctx: ExtensionCommandContext,
+  pi: ExtensionAPI,
+  basePath: string,
+): Promise<void> {
+  // ── Parse subcommands ──────────────────────────────────────────────────
+  const trimmed = args.trim();
+
+  if (trimmed === "results") {
+    await showResults(ctx, basePath);
+    return;
+  }
+
+  // ── Derive current state ───────────────────────────────────────────────
+  const state = await deriveState(basePath);
+
+  if (!state.activeMilestone) {
+    ctx.ui.notify("No active milestone. Run /gsd to start a milestone first.", "warning");
+    return;
+  }
+
+  const mid = state.activeMilestone.id;
+  const midTitle = state.activeMilestone.title;
+
+  // ── Determine target slice(s) ──────────────────────────────────────────
+  const completedSliceIds = getCompletedSliceIds(basePath, mid);
+  if (completedSliceIds.length === 0) {
+    ctx.ui.notify(
+      "No completed slices to test. Complete at least one slice first.",
+      "warning",
+    );
+    return;
+  }
+
+  let targetSliceId: string | null = null;
+  let checks;
+
+  if (trimmed === "all" || trimmed === "") {
+    // Default: if multiple completed slices, test all. If one, test that one.
+    if (trimmed === "all" || completedSliceIds.length > 1) {
+      targetSliceId = null; // "all" mode
+      checks = gatherChecksForAllSlices(basePath, mid);
+    } else {
+      targetSliceId = completedSliceIds[completedSliceIds.length - 1];
+      checks = gatherChecksForSlice(basePath, mid, targetSliceId);
+    }
+  } else {
+    // Specific slice requested
+    const requestedSlice = trimmed.toUpperCase();
+    if (!completedSliceIds.includes(requestedSlice)) {
+      const available = completedSliceIds.join(", ");
+      ctx.ui.notify(
+        `Slice ${requestedSlice} is not completed or doesn't exist.\nCompleted slices: ${available}`,
+        "warning",
+      );
+      return;
+    }
+    targetSliceId = requestedSlice;
+    checks = gatherChecksForSlice(basePath, mid, targetSliceId);
+  }
+
+  if (checks.length === 0) {
+    ctx.ui.notify(
+      targetSliceId
+        ? `No test cases found for ${targetSliceId}. The slice has no UAT file, plan, or summary to extract checks from.`
+        : "No test cases found in any completed slice. Slices may be missing UAT files and plan documents.",
+      "warning",
+    );
+    return;
+  }
+
+  // ── Stop auto-mode if running ───────────────────────────────────────────
+  const wasAutoRunning = isAutoActive();
+  if (wasAutoRunning) {
+    ctx.ui.notify("Stopping auto-mode for manual testing...", "info");
+    await stopAuto(ctx, pi, "Manual testing requested via /gsd test");
+    // Create a fresh session to kill the in-flight agent turn.
+    // Without this, the LLM keeps streaming underneath the test overlay.
+    await ctx.newSession();
+  }
+
+  // ── Resume detection ────────────────────────────────────────────────────
+  const existingSession = getInProgressSession(mid, targetSliceId);
+  let startIndex = 0;
+
+  let session: ManualTestSession;
+
+  if (existingSession) {
+    // Resume path: merge persisted verdicts onto fresh checks, reuse DB row
+    const mergedChecks = mergeChecks(checks, existingSession.checks);
+    startIndex = mergedChecks.findIndex((c) => c.verdict === null);
+    if (startIndex < 0) startIndex = 0; // all judged — restart from beginning
+
+    session = {
+      id: existingSession.id,
+      milestoneId: existingSession.milestoneId,
+      sliceId: existingSession.sliceId,
+      status: "in-progress",
+      startedAt: existingSession.startedAt,
+      completedAt: null,
+      checks: mergedChecks,
+      snapshot: existingSession.snapshot,
+    };
+
+    const judged = mergedChecks.filter((c) => c.verdict !== null).length;
+    ctx.ui.notify(
+      `Resuming interrupted session — ${judged}/${mergedChecks.length} checks already judged, starting at #${startIndex + 1}`,
+      "info",
+    );
+  } else {
+    // New session path
+    session = {
+      milestoneId: mid,
+      sliceId: targetSliceId,
+      status: "in-progress",
+      startedAt: new Date().toISOString(),
+      completedAt: null,
+      checks,
+      snapshot: {
+        phase: state.phase,
+        milestoneProgress: state.progress
+          ? `${state.progress.slices?.done ?? 0}/${state.progress.slices?.total ?? 0} slices done`
+          : "unknown",
+        slicesComplete: completedSliceIds,
+      },
+    };
+
+    // Pre-insert session to DB for incremental persistence
+    const sessionId = saveManualTestSession(session);
+    if (sessionId > 0) session.id = sessionId;
+  }
+
+  // Incremental-save callback: persists verdicts after each pass/fail/skip
+  const onVerdictRecorded = (s: ManualTestSession) => {
+    try { updateSessionResults(s); } catch (e) { process.stderr.write(`gsd-manual-test: verdict persistence failed: ${(e as Error).message}\n`); }
+  };
+
+  // ── Show test runner ───────────────────────────────────────────────────
+  ctx.ui.notify(
+    `Starting manual testing: ${checks.length} check(s) for ${targetSliceId ?? "all completed slices"}\n` +
+    `Milestone: ${mid} — ${midTitle}`,
+    "info",
+  );
+
+  const result = await showManualTestRunner(ctx, session, { onVerdictRecorded, startIndex });
+
+  if (!result) {
+    ctx.ui.notify("Manual test runner requires an interactive terminal.", "warning");
+    return;
+  }
+
+  const { completed, session: updatedSession } = result;
+  const counts = sessionCounts(updatedSession);
+
+  // ── Persist results ────────────────────────────────────────────────────
+  const resultMarkdown = renderManualTestResult(updatedSession);
+
+  // Incremental saves already persisted verdicts to DB — write the markdown artifact
+  const { writeArtifactDirect } = await import("./manual-test-db.js");
+  const artifactPath = writeArtifactDirect(updatedSession, resultMarkdown, basePath);
+
+  // ── Show summary ───────────────────────────────────────────────────────
+  const verdictLabel = counts.failed > 0 ? "FAIL" : counts.skipped > 0 ? "PARTIAL" : "PASS";
+  const summary = [
+    `Manual testing ${completed ? "complete" : "ended early"}: ${verdictLabel}`,
+    `  ${counts.passed} passed, ${counts.failed} failed, ${counts.skipped} skipped`,
+    `  Result saved: ${artifactPath}`,
+  ];
+
+  ctx.ui.notify(summary.join("\n"), counts.failed > 0 ? "warning" : "info");
+
+  // ── Post-test action (only if there are failures) ──────────────────────
+  if (counts.failed > 0) {
+    const action = await showPostTestActionPicker(ctx, counts.failed);
+    await handlePostTestAction(action, updatedSession, ctx, pi, basePath, wasAutoRunning);
+  } else if (wasAutoRunning) {
+    ctx.ui.notify("All tests passed. Run /gsd auto to resume.", "info");
+  }
+}
+
+// ─── Post-test Action Handling ────────────────────────────────────────────────
+
+async function handlePostTestAction(
+  action: PostTestAction,
+  session: ManualTestSession,
+  ctx: ExtensionCommandContext,
+  pi: ExtensionAPI,
+  basePath: string,
+  wasAutoRunning: boolean,
+): Promise<void> {
+  switch (action) {
+    case "fix-now": {
+      // Update session status to needs-fix
+      session.status = "needs-fix";
+      try {
+        updateManualTestSessionStatus(session.milestoneId, session.startedAt, "needs-fix");
+      } catch (e) { process.stderr.write(`gsd-manual-test: status update to needs-fix failed: ${(e as Error).message}\n`); }
+      const fixPrompt = buildFixManualTestsPrompt(session, basePath);
+
+      // Store the fix prompt so the dispatch rule can pick it up
+      const { setPendingManualTestFix } = await import("./manual-test-db.js");
+      setPendingManualTestFix(session.milestoneId, fixPrompt);
+
+      ctx.ui.notify(
+        "Fix mode activated. The agent will analyze and fix each failure.\n" +
+        "Run /gsd auto to start fixing, or /gsd next for step mode.",
+        "info",
+      );
+
+      // If auto was running, offer to resume
+      if (wasAutoRunning) {
+        const { startAuto } = await import("./auto.js");
+        await startAuto(ctx, pi, basePath, false);
+      }
+      break;
+    }
+
+    case "fix-later": {
+      ctx.ui.notify(
+        "Results saved. You can:\n" +
+        "  • Run /gsd test results to review\n" +
+        "  • Fix issues manually and run /gsd test again\n" +
+        "  • Run /gsd auto to continue the pipeline",
+        "info",
+      );
+      break;
+    }
+
+    case "ignore": {
+      // Mark the session as complete (accepted with known issues)
+      session.status = "complete";
+      try {
+        updateManualTestSessionStatus(session.milestoneId, session.startedAt, "complete");
+      } catch (e) { process.stderr.write(`gsd-manual-test: status update to complete failed: ${(e as Error).message}\n`); }
+
+      ctx.ui.notify("Failures accepted as known issues. Pipeline can continue.", "info");
+
+      if (wasAutoRunning) {
+        ctx.ui.notify("Run /gsd auto to resume.", "info");
+      }
+      break;
+    }
+  }
+}
+
+// ─── Results Display ──────────────────────────────────────────────────────────
+
+async function showResults(
+  ctx: ExtensionCommandContext,
+  basePath: string,
+): Promise<void> {
+  const state = await deriveState(basePath);
+  if (!state.activeMilestone) {
+    ctx.ui.notify("No active milestone.", "warning");
+    return;
+  }
+
+  const session = getLatestManualTestSession(state.activeMilestone.id);
+  if (!session) {
+    ctx.ui.notify("No manual test results found for this milestone.", "info");
+    return;
+  }
+
+  const counts = sessionCounts(session);
+  const verdict = counts.failed > 0 ? "FAIL" : counts.skipped > 0 ? "PARTIAL" : "PASS";
+
+  const lines = [
+    `Manual Test Results — ${session.milestoneId}${session.sliceId ? `/${session.sliceId}` : ""}`,
+    `Status: ${session.status}  Verdict: ${verdict}`,
+    `Date: ${session.startedAt}`,
+    `${counts.passed} passed, ${counts.failed} failed, ${counts.skipped} skipped`,
+    "",
+  ];
+
+  for (const c of session.checks) {
+    const icon = c.verdict === "pass" ? "✓" : c.verdict === "fail" ? "✗" : c.verdict === "skip" ? "–" : "○";
+    const notes = c.verdict === "fail" && c.notes ? ` — ${c.notes}` : "";
+    lines.push(`  ${icon} ${c.name}${notes}`);
+  }
+
+  ctx.ui.notify(lines.join("\n"), "info");
+}

--- a/src/resources/extensions/gsd/commands/catalog.ts
+++ b/src/resources/extensions/gsd/commands/catalog.ts
@@ -15,7 +15,7 @@ export interface GsdCommandDefinition {
 type CompletionMap = Record<string, readonly GsdCommandDefinition[]>;
 
 export const GSD_COMMAND_DESCRIPTION =
-  "GSD — Get Shit Done: /gsd help|start|templates|next|auto|stop|pause|status|widget|visualize|queue|quick|discuss|capture|triage|dispatch|history|undo|undo-task|reset-slice|rate|skip|export|cleanup|mode|prefs|config|keys|hooks|run-hook|skill-health|doctor|logs|forensics|changelog|migrate|remote|steer|knowledge|new-milestone|parallel|cmux|park|unpark|init|setup|inspect|extensions|update|fast|mcp|rethink|codebase";
+  "GSD — Get Shit Done: /gsd help|start|templates|next|auto|stop|pause|status|widget|visualize|queue|quick|discuss|capture|triage|dispatch|history|undo|undo-task|reset-slice|rate|skip|export|cleanup|mode|prefs|config|keys|hooks|run-hook|skill-health|doctor|logs|forensics|changelog|migrate|remote|steer|knowledge|new-milestone|parallel|cmux|park|unpark|init|setup|inspect|extensions|update|fast|mcp|rethink|codebase|test";
 
 export const TOP_LEVEL_SUBCOMMANDS: readonly GsdCommandDefinition[] = [
   { cmd: "help", desc: "Categorized command reference with descriptions" },
@@ -70,6 +70,7 @@ export const TOP_LEVEL_SUBCOMMANDS: readonly GsdCommandDefinition[] = [
   { cmd: "fast", desc: "Toggle OpenAI service tier (on/off/flex/status)" },
   { cmd: "mcp", desc: "MCP server status and connectivity check (status, check <server>)" },
   { cmd: "rethink", desc: "Conversational project reorganization — reorder, park, discard, add milestones" },
+  { cmd: "test", desc: "Interactive manual testing — walk through checks, record pass/fail/notes" },
   { cmd: "workflow", desc: "Custom workflow lifecycle (new, run, list, validate, pause, resume)" },
   { cmd: "codebase", desc: "Generate and manage codebase map (.gsd/CODEBASE.md)" },
 ];
@@ -203,6 +204,10 @@ const NESTED_COMPLETIONS: CompletionMap = {
     { cmd: "--json", desc: "Output report as JSON (CI/tooling friendly)" },
     { cmd: "--build", desc: "Include slow build health check (npm run build)" },
     { cmd: "--test", desc: "Include slow test health check (npm test)" },
+  ],
+  test: [
+    { cmd: "all", desc: "Test all completed slices" },
+    { cmd: "results", desc: "Show last manual test results" },
   ],
   dispatch: [
     { cmd: "research", desc: "Run research phase" },

--- a/src/resources/extensions/gsd/commands/handlers/core.ts
+++ b/src/resources/extensions/gsd/commands/handlers/core.ts
@@ -36,6 +36,7 @@ export function showHelp(ctx: ExtensionCommandContext): void {
     "  /gsd triage         Classify and route pending captures",
     "  /gsd skip <unit>    Prevent a unit from auto-mode dispatch",
     "  /gsd undo           Revert last completed unit  [--force]",
+    "  /gsd test           Interactive manual testing  [all|<sliceId>|results]",
     "  /gsd rethink        Conversational project reorganization — reorder, park, discard, add milestones",
     "  /gsd park [id]      Park a milestone — skip without deleting  [reason]",
     "  /gsd unpark [id]    Reactivate a parked milestone",

--- a/src/resources/extensions/gsd/commands/handlers/ops.ts
+++ b/src/resources/extensions/gsd/commands/handlers/ops.ts
@@ -211,5 +211,10 @@ Examples:
     await handleCodebase(trimmed.replace(/^codebase\s*/, "").trim(), ctx, pi);
     return true;
   }
+  if (trimmed === "test" || trimmed.startsWith("test ")) {
+    const { handleManualTest } = await import("../../commands-manual-test.js");
+    await handleManualTest(trimmed.replace(/^test\s*/, "").trim(), ctx, pi, projectRoot());
+    return true;
+  }
   return false;
 }

--- a/src/resources/extensions/gsd/complexity-classifier.ts
+++ b/src/resources/extensions/gsd/complexity-classifier.ts
@@ -34,6 +34,7 @@ const UNIT_TYPE_TIERS: Record<string, ComplexityTier> = {
   // Tier 1 — Light: structured summaries, completion, UAT
   "complete-slice": "light",
   "run-uat": "light",
+  "fix-manual-tests": "standard",
 
   // Tier 2 — Standard: research, routine planning, discussion
   "discuss-milestone": "standard",

--- a/src/resources/extensions/gsd/gsd-db.ts
+++ b/src/resources/extensions/gsd/gsd-db.ts
@@ -160,7 +160,7 @@ function openRawDb(path: string): unknown {
   return new Database(path);
 }
 
-const SCHEMA_VERSION = 14;
+const SCHEMA_VERSION = 15;
 
 function initSchema(db: DbAdapter, fileBacked: boolean): void {
   if (fileBacked) db.exec("PRAGMA journal_mode=WAL");
@@ -412,6 +412,27 @@ function initSchema(db: DbAdapter, fileBacked: boolean): void {
 
     // v14 index — slice dependency lookups
     db.exec("CREATE INDEX IF NOT EXISTS idx_slice_deps_target ON slice_dependencies(milestone_id, depends_on_slice_id)");
+
+    // Manual test sessions (v15)
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS manual_test_sessions (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        milestone_id TEXT NOT NULL,
+        slice_id TEXT,
+        status TEXT NOT NULL DEFAULT 'in-progress',
+        started_at TEXT NOT NULL,
+        completed_at TEXT,
+        total_checks INTEGER DEFAULT 0,
+        passed INTEGER DEFAULT 0,
+        failed INTEGER DEFAULT 0,
+        skipped INTEGER DEFAULT 0,
+        results_json TEXT,
+        snapshot_json TEXT,
+        fix_prompt TEXT,
+        created_at TEXT NOT NULL DEFAULT (datetime('now'))
+      )
+    `);
+    db.exec("CREATE INDEX IF NOT EXISTS idx_manual_test_milestone ON manual_test_sessions(milestone_id, status)");
 
     db.exec(`CREATE VIEW IF NOT EXISTS active_decisions AS SELECT * FROM decisions WHERE superseded_by IS NULL`);
     db.exec(`CREATE VIEW IF NOT EXISTS active_requirements AS SELECT * FROM requirements WHERE superseded_by IS NULL`);
@@ -742,6 +763,32 @@ function migrateSchema(db: DbAdapter): void {
       db.exec("CREATE INDEX IF NOT EXISTS idx_slice_deps_target ON slice_dependencies(milestone_id, depends_on_slice_id)");
       db.prepare("INSERT INTO schema_version (version, applied_at) VALUES (:version, :applied_at)").run({
         ":version": 14,
+        ":applied_at": new Date().toISOString(),
+      });
+    }
+
+    if (currentVersion < 15) {
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS manual_test_sessions (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          milestone_id TEXT NOT NULL,
+          slice_id TEXT,
+          status TEXT NOT NULL DEFAULT 'in-progress',
+          started_at TEXT NOT NULL,
+          completed_at TEXT,
+          total_checks INTEGER DEFAULT 0,
+          passed INTEGER DEFAULT 0,
+          failed INTEGER DEFAULT 0,
+          skipped INTEGER DEFAULT 0,
+          results_json TEXT,
+          snapshot_json TEXT,
+          fix_prompt TEXT,
+          created_at TEXT NOT NULL DEFAULT (datetime('now'))
+        )
+      `);
+      db.exec("CREATE INDEX IF NOT EXISTS idx_manual_test_milestone ON manual_test_sessions(milestone_id, status)");
+      db.prepare("INSERT INTO schema_version (version, applied_at) VALUES (:version, :applied_at)").run({
+        ":version": 15,
         ":applied_at": new Date().toISOString(),
       });
     }
@@ -2202,4 +2249,169 @@ export function getPendingSliceGateCount(milestoneId: string, sliceId: string): 
      WHERE milestone_id = :mid AND slice_id = :sid AND scope = 'slice' AND status = 'pending'`,
   ).get({ ":mid": milestoneId, ":sid": sliceId });
   return row ? (row["cnt"] as number) : 0;
+}
+
+// ─── Manual Test Sessions ─────────────────────────────────────────────────────
+
+export interface ManualTestSessionRow {
+  id: number;
+  milestone_id: string;
+  slice_id: string | null;
+  status: string;
+  started_at: string;
+  completed_at: string | null;
+  total_checks: number;
+  passed: number;
+  failed: number;
+  skipped: number;
+  results_json: string | null;
+  snapshot_json: string | null;
+  fix_prompt: string | null;
+  created_at: string;
+}
+
+export function insertManualTestSession(s: {
+  milestoneId: string;
+  sliceId: string | null;
+  status: string;
+  startedAt: string;
+  completedAt: string | null;
+  totalChecks: number;
+  passed: number;
+  failed: number;
+  skipped: number;
+  resultsJson: string;
+  snapshotJson: string;
+}): number {
+  if (!currentDb) return -1;
+  const result = currentDb.prepare(
+    `INSERT INTO manual_test_sessions
+       (milestone_id, slice_id, status, started_at, completed_at, total_checks, passed, failed, skipped, results_json, snapshot_json)
+     VALUES (:mid, :sid, :status, :started, :completed, :total, :passed, :failed, :skipped, :results, :snapshot)`,
+  ).run({
+    ":mid": s.milestoneId,
+    ":sid": s.sliceId,
+    ":status": s.status,
+    ":started": s.startedAt,
+    ":completed": s.completedAt,
+    ":total": s.totalChecks,
+    ":passed": s.passed,
+    ":failed": s.failed,
+    ":skipped": s.skipped,
+    ":results": s.resultsJson,
+    ":snapshot": s.snapshotJson,
+  });
+  // run() returns unknown; try to extract lastInsertRowid if present
+  const res = result as Record<string, unknown> | undefined;
+  if (res && typeof res.lastInsertRowid === "bigint") return Number(res.lastInsertRowid);
+  if (res && typeof res.lastInsertRowid === "number") return res.lastInsertRowid;
+  return -1;
+}
+
+export function getLatestManualTestSessionRow(milestoneId: string): ManualTestSessionRow | null {
+  if (!currentDb) return null;
+  const row = currentDb.prepare(
+    `SELECT * FROM manual_test_sessions
+     WHERE milestone_id = :mid
+     ORDER BY id DESC LIMIT 1`,
+  ).get({ ":mid": milestoneId });
+  return row ? row as unknown as ManualTestSessionRow : null;
+}
+
+export function updateManualTestSessionStatusDb(milestoneId: string, startedAt: string, status: string): void {
+  if (!currentDb) return;
+  currentDb.prepare(
+    `UPDATE manual_test_sessions SET status = :status
+     WHERE milestone_id = :mid AND started_at = :started`,
+  ).run({
+    ":status": status,
+    ":mid": milestoneId,
+    ":started": startedAt,
+  });
+}
+
+export function setManualTestFixPrompt(milestoneId: string, fixPrompt: string): void {
+  if (!currentDb) return;
+  // Update the latest needs-fix session for this milestone
+  const row = currentDb.prepare(
+    `SELECT id FROM manual_test_sessions
+     WHERE milestone_id = :mid AND status = 'needs-fix'
+     ORDER BY id DESC LIMIT 1`,
+  ).get({ ":mid": milestoneId });
+  if (!row) return;
+  currentDb.prepare(
+    `UPDATE manual_test_sessions SET fix_prompt = :prompt WHERE id = :id`,
+  ).run({ ":prompt": fixPrompt, ":id": row["id"] });
+}
+
+export function getPendingManualTestFix(milestoneId: string): { fixPrompt: string; sessionId: number } | null {
+  if (!currentDb) return null;
+  const row = currentDb.prepare(
+    `SELECT id, fix_prompt FROM manual_test_sessions
+     WHERE milestone_id = :mid AND status = 'needs-fix' AND fix_prompt IS NOT NULL
+     ORDER BY id DESC LIMIT 1`,
+  ).get({ ":mid": milestoneId });
+  if (!row || !row["fix_prompt"]) return null;
+  return { fixPrompt: row["fix_prompt"] as string, sessionId: row["id"] as number };
+}
+
+export function clearManualTestFixPrompt(milestoneId: string): void {
+  if (!currentDb) return;
+  currentDb.prepare(
+    `UPDATE manual_test_sessions SET status = 'complete', fix_prompt = NULL
+     WHERE milestone_id = :mid AND status = 'needs-fix'`,
+  ).run({ ":mid": milestoneId });
+}
+
+export function updateManualTestSessionResults(
+  id: number,
+  resultsJson: string,
+  totalChecks: number,
+  passed: number,
+  failed: number,
+  skipped: number,
+): void {
+  if (!currentDb) return;
+  currentDb.prepare(
+    `UPDATE manual_test_sessions
+     SET results_json = :results, total_checks = :total, passed = :passed, failed = :failed, skipped = :skipped
+     WHERE id = :id`,
+  ).run({
+    ":results": resultsJson,
+    ":total": totalChecks,
+    ":passed": passed,
+    ":failed": failed,
+    ":skipped": skipped,
+    ":id": id,
+  });
+}
+
+export function getOutstandingTestFailures(milestoneId: string): ManualTestSessionRow | null {
+  if (!currentDb) return null;
+  const row = currentDb.prepare(
+    `SELECT * FROM manual_test_sessions
+     WHERE milestone_id = :mid AND failed > 0 AND fix_prompt IS NULL
+       AND status IN ('needs-fix', 'in-progress')
+     ORDER BY id DESC LIMIT 1`,
+  ).get({ ":mid": milestoneId });
+  return row ? row as unknown as ManualTestSessionRow : null;
+}
+
+export function getInProgressSessionRow(
+  milestoneId: string,
+  sliceId: string | null,
+): ManualTestSessionRow | null {
+  if (!currentDb) return null;
+  const row = sliceId != null
+    ? currentDb.prepare(
+        `SELECT * FROM manual_test_sessions
+         WHERE milestone_id = :mid AND slice_id = :sid AND status = 'in-progress'
+         ORDER BY id DESC LIMIT 1`,
+      ).get({ ":mid": milestoneId, ":sid": sliceId })
+    : currentDb.prepare(
+        `SELECT * FROM manual_test_sessions
+         WHERE milestone_id = :mid AND slice_id IS NULL AND status = 'in-progress'
+         ORDER BY id DESC LIMIT 1`,
+      ).get({ ":mid": milestoneId });
+  return row ? row as unknown as ManualTestSessionRow : null;
 }

--- a/src/resources/extensions/gsd/manual-test-db.ts
+++ b/src/resources/extensions/gsd/manual-test-db.ts
@@ -1,0 +1,221 @@
+/**
+ * manual-test-db.ts — DB and artifact persistence layer for manual testing.
+ *
+ * Bridges the manual-test session model with gsd-db storage and disk artifacts.
+ * Kept separate from manual-test.ts to avoid circular deps (manual-test.ts
+ * is imported by both the UI and the command handler).
+ */
+
+import { join } from "node:path";
+import { writeFileSync, mkdirSync, existsSync, readdirSync } from "node:fs";
+
+import {
+  isDbAvailable,
+  insertManualTestSession,
+  getLatestManualTestSessionRow,
+  updateManualTestSessionStatusDb,
+  updateManualTestSessionResults,
+  getInProgressSessionRow,
+  setManualTestFixPrompt,
+  getPendingManualTestFix as getPendingFixFromDb,
+  clearManualTestFixPrompt as clearFixFromDb,
+  getOutstandingTestFailures,
+  type ManualTestSessionRow,
+} from "./gsd-db.js";
+import {
+  sessionCounts,
+  type ManualTestSession,
+  type ManualTestCheck,
+} from "./manual-test.js";
+import { gsdRoot } from "./paths.js";
+
+// ─── Save Session ─────────────────────────────────────────────────────────────
+
+/**
+ * Persist a manual test session to the DB.
+ */
+export function saveManualTestSession(session: ManualTestSession): number {
+  if (!isDbAvailable()) return -1;
+
+  const counts = sessionCounts(session);
+  return insertManualTestSession({
+    milestoneId: session.milestoneId,
+    sliceId: session.sliceId,
+    status: session.status,
+    startedAt: session.startedAt,
+    completedAt: session.completedAt,
+    totalChecks: counts.total,
+    passed: counts.passed,
+    failed: counts.failed,
+    skipped: counts.skipped,
+    resultsJson: JSON.stringify(session.checks),
+    snapshotJson: JSON.stringify(session.snapshot),
+  });
+}
+
+// ─── Load Session ─────────────────────────────────────────────────────────────
+
+/**
+ * Load the latest manual test session for a milestone from the DB.
+ */
+export function getLatestManualTestSession(milestoneId: string): ManualTestSession | null {
+  const row = getLatestManualTestSessionRow(milestoneId);
+  if (!row) return null;
+  return rowToSession(row);
+}
+
+function rowToSession(row: ManualTestSessionRow): ManualTestSession {
+  let checks: ManualTestCheck[] = [];
+  try {
+    if (row.results_json) checks = JSON.parse(row.results_json);
+  } catch { /* corrupt JSON — return empty checks */ }
+
+  let snapshot = { phase: "unknown", milestoneProgress: "unknown", slicesComplete: [] as string[] };
+  try {
+    if (row.snapshot_json) snapshot = JSON.parse(row.snapshot_json);
+  } catch { /* corrupt JSON — return defaults */ }
+
+  return {
+    id: row.id,
+    milestoneId: row.milestone_id,
+    sliceId: row.slice_id,
+    status: row.status as ManualTestSession["status"],
+    startedAt: row.started_at,
+    completedAt: row.completed_at,
+    checks,
+    snapshot,
+  };
+}
+
+// ─── Update Status ────────────────────────────────────────────────────────────
+
+export function updateManualTestSessionStatus(
+  milestoneId: string,
+  startedAt: string,
+  status: string,
+): void {
+  if (!isDbAvailable()) return;
+  updateManualTestSessionStatusDb(milestoneId, startedAt, status);
+}
+
+// ─── Fix Prompt Management ────────────────────────────────────────────────────
+
+export function setPendingManualTestFix(milestoneId: string, fixPrompt: string): void {
+  if (!isDbAvailable()) return;
+  setManualTestFixPrompt(milestoneId, fixPrompt);
+}
+
+export function getPendingManualTestFix(milestoneId: string): { fixPrompt: string; sessionId: number } | null {
+  if (!isDbAvailable()) return null;
+  return getPendingFixFromDb(milestoneId);
+}
+
+export function clearManualTestFixPrompt(milestoneId: string): void {
+  if (!isDbAvailable()) return;
+  clearFixFromDb(milestoneId);
+}
+
+// ─── Outstanding Failures (opportunistic fix dispatch) ────────────────────────
+
+/**
+ * Find a session with outstanding test failures that hasn't been dispatched
+ * for fixing yet (fix_prompt IS NULL). Used by the opportunistic-fix dispatch
+ * rule to detect unfixed failures at natural stopping points.
+ */
+export function getOutstandingFailures(milestoneId: string): ManualTestSession | null {
+  if (!isDbAvailable()) return null;
+  const row = getOutstandingTestFailures(milestoneId);
+  if (!row) return null;
+  return rowToSession(row);
+}
+
+// ─── Incremental Persistence ──────────────────────────────────────────────────
+
+/**
+ * Update session results in-place (incremental save after each verdict).
+ * Guard: returns early if session has no DB id or DB is unavailable.
+ */
+export function updateSessionResults(session: ManualTestSession): void {
+  if (!session.id || !isDbAvailable()) return;
+  const counts = sessionCounts(session);
+  updateManualTestSessionResults(
+    session.id,
+    JSON.stringify(session.checks),
+    counts.total,
+    counts.passed,
+    counts.failed,
+    counts.skipped,
+  );
+}
+
+/**
+ * Load the latest in-progress session for a milestone (+ optional slice).
+ * Returns null if no in-progress session exists or DB is unavailable.
+ */
+export function getInProgressSession(
+  milestoneId: string,
+  sliceId: string | null,
+): ManualTestSession | null {
+  if (!isDbAvailable()) return null;
+  const row = getInProgressSessionRow(milestoneId, sliceId);
+  if (!row) return null;
+  return rowToSession(row);
+}
+
+// ─── Artifact Writer ──────────────────────────────────────────────────────────
+
+/**
+ * Write the manual test result markdown artifact to disk.
+ * Returns the relative path of the written file.
+ */
+export function writeArtifactDirect(
+  session: ManualTestSession,
+  content: string,
+  basePath: string,
+): string {
+  const root = gsdRoot(basePath);
+  const milestonesDir = join(root, "milestones");
+
+  if (session.sliceId) {
+    // Write to the slice directory
+    // Find the milestone dir on disk
+    const mDir = findMilestoneDir(milestonesDir, session.milestoneId);
+    const sliceDir = join(mDir, "slices", session.sliceId);
+    mkdirSync(sliceDir, { recursive: true });
+    const fileName = `${session.sliceId}-MANUAL-TEST-RESULT.md`;
+    const fullPath = join(sliceDir, fileName);
+    writeFileSync(fullPath, content, "utf-8");
+    return `.gsd/milestones/${session.milestoneId}/slices/${session.sliceId}/${fileName}`;
+  } else {
+    // Write to the milestone directory
+    const mDir = findMilestoneDir(milestonesDir, session.milestoneId);
+    mkdirSync(mDir, { recursive: true });
+    const fileName = `${session.milestoneId}-MANUAL-TEST-RESULT.md`;
+    const fullPath = join(mDir, fileName);
+    writeFileSync(fullPath, content, "utf-8");
+    return `.gsd/milestones/${session.milestoneId}/${fileName}`;
+  }
+}
+
+/**
+ * Find the actual milestone directory on disk, which may include a unique suffix.
+ * Falls back to bare milestone ID if no suffixed directory exists.
+ */
+function findMilestoneDir(milestonesDir: string, milestoneId: string): string {
+  const bare = join(milestonesDir, milestoneId);
+  if (existsSync(bare)) return bare;
+
+  // Check for unique-ID directories like M001-abc123
+  try {
+    const entries = readdirSync(milestonesDir, { withFileTypes: true });
+    for (const entry of entries) {
+      if (entry.isDirectory() && (entry.name === milestoneId || entry.name.startsWith(milestoneId + "-"))) {
+        return join(milestonesDir, entry.name);
+      }
+    }
+  } catch { /* directory doesn't exist yet */ }
+
+  // Fallback: create bare directory
+  mkdirSync(bare, { recursive: true });
+  return bare;
+}

--- a/src/resources/extensions/gsd/manual-test-ui.ts
+++ b/src/resources/extensions/gsd/manual-test-ui.ts
@@ -1,0 +1,418 @@
+/**
+ * manual-test-ui.ts — TUI overlay for interactive manual test runner.
+ *
+ * Renders one test case at a time with pass/fail/skip controls.
+ * Uses the shared UI design system for consistent styling.
+ *
+ * Navigation:
+ *   p / P / Enter   Pass — mark current check as passed, advance
+ *   f / F           Fail — open notes input, then advance
+ *   s / S           Skip — mark as skipped, advance
+ *   ← / →           Navigate between checks (review previous)
+ *   q / Esc          Quit early (saves partial progress)
+ *   ?               Show commands
+ */
+
+import type { ExtensionCommandContext } from "@gsd/pi-coding-agent";
+import { type Theme } from "@gsd/pi-coding-agent";
+import { Key, matchesKey, truncateToWidth, wrapTextWithAnsi, type TUI } from "@gsd/pi-tui";
+import { makeUI, GLYPH } from "../shared/ui.js";
+
+import type { ManualTestCheck, ManualTestSession, TestVerdict } from "./manual-test.js";
+import { sessionCounts } from "./manual-test.js";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface ManualTestUIResult {
+  /** Whether the session completed (all checks seen) or was quit early */
+  completed: boolean;
+  /** The session with verdicts filled in */
+  session: ManualTestSession;
+}
+
+type UIMode = "check" | "fail-notes" | "help" | "summary";
+
+// ─── Overlay ──────────────────────────────────────────────────────────────────
+
+/**
+ * Show the interactive manual test runner overlay.
+ * Returns the session with verdicts filled in, or null if UI was unavailable.
+ *
+ * Options:
+ *   onVerdictRecorded — called after each verdict and on session finish, for incremental persistence
+ *   startIndex — resume from this check index (clamped to valid range)
+ */
+export async function showManualTestRunner(
+  ctx: ExtensionCommandContext,
+  session: ManualTestSession,
+  options?: { onVerdictRecorded?: (session: ManualTestSession) => void; startIndex?: number },
+): Promise<ManualTestUIResult | null> {
+  if (!ctx.hasUI || session.checks.length === 0) return null;
+
+  const initialIndex = Math.max(0, Math.min(options?.startIndex ?? 0, session.checks.length - 1));
+
+  return ctx.ui.custom<ManualTestUIResult>(
+    (tui: TUI, theme: Theme, _kb, done) => {
+      let currentIndex = initialIndex;
+      let mode: UIMode = "check";
+      let failNotesBuffer = "";
+      let cachedLines: string[] | undefined;
+
+      function refresh() {
+        cachedLines = undefined;
+        tui.requestRender();
+      }
+
+      function currentCheck(): ManualTestCheck {
+        return session.checks[currentIndex];
+      }
+
+      function recordVerdict(verdict: TestVerdict, notes = "") {
+        const check = currentCheck();
+        check.verdict = verdict;
+        check.notes = notes;
+        check.timestamp = new Date().toISOString();
+        options?.onVerdictRecorded?.(session);
+      }
+
+      function advance() {
+        if (currentIndex < session.checks.length - 1) {
+          currentIndex++;
+          mode = "check";
+          failNotesBuffer = "";
+          refresh();
+        } else {
+          mode = "summary";
+          refresh();
+        }
+      }
+
+      function finishSession(completed: boolean) {
+        session.status = completed ? "complete" : "abandoned";
+        session.completedAt = new Date().toISOString();
+        options?.onVerdictRecorded?.(session);
+        done({ completed, session });
+      }
+
+      function handleInput(data: string) {
+        // ── Help mode ────────────────────────────────────────────────────
+        if (mode === "help") {
+          mode = "check";
+          refresh();
+          return;
+        }
+
+        // ── Summary mode ─────────────────────────────────────────────────
+        if (mode === "summary") {
+          if (matchesKey(data, Key.enter) || matchesKey(data, Key.escape) || data === "q" || data === "Q") {
+            finishSession(true);
+          }
+          return;
+        }
+
+        // ── Fail-notes mode (simple inline text buffer) ──────────────────
+        if (mode === "fail-notes") {
+          if (matchesKey(data, Key.enter)) {
+            const notes = failNotesBuffer.trim() || "(no details provided)";
+            recordVerdict("fail", notes);
+            failNotesBuffer = "";
+            advance();
+            return;
+          }
+          if (matchesKey(data, Key.escape)) {
+            failNotesBuffer = "";
+            mode = "check";
+            refresh();
+            return;
+          }
+          if (matchesKey(data, Key.backspace) || data === "\x7f") {
+            if (failNotesBuffer.length > 0) {
+              failNotesBuffer = failNotesBuffer.slice(0, -1);
+              refresh();
+            }
+            return;
+          }
+          // Printable characters
+          if (data.length === 1 && data.charCodeAt(0) >= 32) {
+            failNotesBuffer += data;
+            refresh();
+            return;
+          }
+          return;
+        }
+
+        // ── Check mode ───────────────────────────────────────────────────
+        if (data === "p" || data === "P" || matchesKey(data, Key.enter)) {
+          recordVerdict("pass");
+          advance();
+          return;
+        }
+        if (data === "f" || data === "F") {
+          mode = "fail-notes";
+          failNotesBuffer = "";
+          refresh();
+          return;
+        }
+        if (data === "s" || data === "S") {
+          recordVerdict("skip");
+          advance();
+          return;
+        }
+        if (matchesKey(data, Key.left) && currentIndex > 0) {
+          currentIndex--;
+          refresh();
+          return;
+        }
+        if (matchesKey(data, Key.right) && currentIndex < session.checks.length - 1) {
+          currentIndex++;
+          refresh();
+          return;
+        }
+        if (data === "?" || data === "h" || data === "H") {
+          mode = "help";
+          refresh();
+          return;
+        }
+        if (data === "q" || data === "Q" || matchesKey(data, Key.escape)) {
+          finishSession(false);
+          return;
+        }
+      }
+
+      function render(width: number): string[] {
+        if (cachedLines) return cachedLines;
+
+        const ui = makeUI(theme, width);
+        const lines: string[] = [];
+        const push = (...rows: string[][]) => { for (const r of rows) lines.push(...r); };
+
+        const sliceLabel = session.sliceId ?? "All Slices";
+
+        // ── Help screen ─────────────────────────────────────────────────
+        if (mode === "help") {
+          push(ui.bar(), ui.blank());
+          push(ui.header("  Manual Testing — Help"));
+          push(ui.blank());
+          lines.push(truncateToWidth(theme.fg("text", "  Keyboard:"), width));
+          lines.push(truncateToWidth(theme.fg("muted", "    P / Enter    Mark as PASS and advance"), width));
+          lines.push(truncateToWidth(theme.fg("muted", "    F           Mark as FAIL (enter notes)"), width));
+          lines.push(truncateToWidth(theme.fg("muted", "    S           Skip this check"), width));
+          lines.push(truncateToWidth(theme.fg("muted", "    ← / →       Navigate between checks"), width));
+          lines.push(truncateToWidth(theme.fg("muted", "    Q / Esc     Quit (saves partial progress)"), width));
+          lines.push(truncateToWidth(theme.fg("muted", "    ?           Show this help"), width));
+          push(ui.blank());
+          push(ui.hints(["any key to return"]));
+          push(ui.bar());
+          cachedLines = lines;
+          return lines;
+        }
+
+        // ── Summary screen ──────────────────────────────────────────────
+        if (mode === "summary") {
+          const counts = sessionCounts(session);
+          push(ui.bar(), ui.blank());
+          push(ui.header("  Manual Testing Complete"));
+          push(ui.blank());
+
+          const verdict = counts.failed > 0 ? "FAIL" : counts.skipped > 0 ? "PARTIAL" : "PASS";
+          const verdictColor = verdict === "PASS" ? "success" : verdict === "FAIL" ? "error" : "warning";
+          lines.push(truncateToWidth(`  ${theme.fg(verdictColor, theme.bold(`Verdict: ${verdict}`))}`, width));
+          push(ui.blank());
+          lines.push(truncateToWidth(`  ${theme.fg("success", `${GLYPH.check} ${counts.passed} passed`)}  ${theme.fg("error", `${GLYPH.statusFailed} ${counts.failed} failed`)}  ${theme.fg("dim", `${GLYPH.statusSkipped} ${counts.skipped} skipped`)}`, width));
+          push(ui.blank());
+
+          const failed = session.checks.filter(c => c.verdict === "fail");
+          if (failed.length > 0) {
+            lines.push(truncateToWidth(theme.fg("text", "  Failed:"), width));
+            for (const c of failed) {
+              lines.push(truncateToWidth(`    ${theme.fg("error", GLYPH.statusFailed)} ${theme.fg("text", c.name)} ${theme.fg("dim", `— ${c.notes}`)}`, width));
+            }
+            push(ui.blank());
+          }
+
+          push(ui.hints(["Enter to finish"]));
+          push(ui.bar());
+          cachedLines = lines;
+          return lines;
+        }
+
+        // ── Main check screen ───────────────────────────────────────────
+        push(ui.bar(), ui.blank());
+        push(ui.header(`  Manual Testing: ${sliceLabel}`));
+        push(ui.blank());
+
+        // Progress bar
+        const progressDone = session.checks.filter(c => c.verdict !== null).length;
+        const progressTotal = session.checks.length;
+        const barWidth = Math.max(10, Math.min(30, width - 30));
+        const filledCount = Math.round((progressDone / progressTotal) * barWidth);
+        const progressBar = GLYPH.squareFilled.repeat(filledCount) + GLYPH.squareEmpty.repeat(barWidth - filledCount);
+        lines.push(truncateToWidth(`  Test ${currentIndex + 1} of ${progressTotal}  ${theme.fg("accent", progressBar)}  ${Math.round((progressDone / progressTotal) * 100)}%`, width));
+        push(ui.blank());
+
+        const check = currentCheck();
+
+        // Category badge
+        const categoryBadge = check.category === "smoke" ? theme.fg("warning", "[SMOKE]")
+          : check.category === "edge-case" ? theme.fg("accent", "[EDGE]")
+          : theme.fg("dim", "[TEST]");
+        lines.push(truncateToWidth(`  ${categoryBadge} ${theme.bold(theme.fg("text", check.name))}`, width));
+        push(ui.blank());
+
+        if (check.preconditions) {
+          lines.push(truncateToWidth(theme.fg("muted", `  Preconditions: ${check.preconditions.split("\n")[0]}`), width));
+          push(ui.blank());
+        }
+
+        if (check.steps.length > 0) {
+          lines.push(truncateToWidth(theme.fg("text", "  Steps:"), width));
+          for (let i = 0; i < check.steps.length; i++) {
+            const wrapped = wrapTextWithAnsi(`    ${theme.fg("muted", `${i + 1}. ${check.steps[i]}`)}`, width);
+            lines.push(...wrapped);
+          }
+          push(ui.blank());
+        }
+
+        if (check.expected) {
+          const wrapped = wrapTextWithAnsi(`  ${theme.fg("text", "Expected: ")}${theme.fg("accent", check.expected)}`, width);
+          lines.push(...wrapped);
+          push(ui.blank());
+        }
+
+        // Current verdict (if navigating back to an already-judged check)
+        if (check.verdict !== null) {
+          const vIcon = check.verdict === "pass" ? theme.fg("success", `${GLYPH.check} PASS`)
+            : check.verdict === "fail" ? theme.fg("error", `${GLYPH.statusFailed} FAIL`)
+            : theme.fg("dim", `${GLYPH.statusSkipped} SKIP`);
+          lines.push(truncateToWidth(`  Current: ${vIcon}${check.notes ? theme.fg("dim", ` — ${check.notes}`) : ""}`, width));
+          push(ui.blank());
+        }
+
+        // Separator
+        lines.push(truncateToWidth(theme.fg("dim", `  ${GLYPH.separator.repeat(Math.max(1, width - 4))}`), width));
+
+        if (mode === "fail-notes") {
+          lines.push(truncateToWidth(theme.fg("error", "  What went wrong?"), width));
+          push(ui.blank());
+          const displayText = failNotesBuffer || theme.fg("dim", "(type your notes)");
+          lines.push(truncateToWidth(`   ${displayText}${theme.fg("accent", "▎")}`, width));
+          push(ui.blank());
+          push(ui.hints(["Enter to submit", "Esc to cancel"]));
+        } else {
+          push(ui.hints(["[P]ass", "[F]ail", "[S]kip", "[Q]uit", "[?] Help"]));
+        }
+
+        // Recent results (last 3)
+        const recent = session.checks
+          .slice(0, currentIndex)
+          .filter(c => c.verdict !== null)
+          .slice(-3);
+        if (recent.length > 0) {
+          push(ui.blank());
+          lines.push(truncateToWidth(theme.fg("dim", "  Recent:"), width));
+          for (const r of recent) {
+            const icon = r.verdict === "pass" ? theme.fg("success", GLYPH.check)
+              : r.verdict === "fail" ? theme.fg("error", GLYPH.statusFailed)
+              : theme.fg("dim", GLYPH.statusSkipped);
+            const note = r.verdict === "fail" && r.notes ? theme.fg("dim", ` (${r.notes})`) : "";
+            lines.push(truncateToWidth(`    ${icon} ${theme.fg("dim", r.name)}${note}`, width));
+          }
+        }
+
+        push(ui.bar());
+        cachedLines = lines;
+        return lines;
+      }
+
+      return { handleInput, render, invalidate: () => { cachedLines = undefined; } };
+    },
+    {
+      overlay: true,
+      overlayOptions: {
+        width: "70%",
+        minWidth: 50,
+        maxHeight: "90%",
+        anchor: "center",
+      },
+    },
+  );
+}
+
+// ─── Post-test Action Picker ──────────────────────────────────────────────────
+
+export type PostTestAction = "fix-now" | "fix-later" | "ignore";
+
+/**
+ * Show the post-test action picker when failures exist.
+ * Returns the user's chosen action.
+ */
+export async function showPostTestActionPicker(
+  ctx: ExtensionCommandContext,
+  failCount: number,
+): Promise<PostTestAction> {
+  if (!ctx.hasUI) return "fix-later";
+
+  const result = await ctx.ui.custom<PostTestAction>(
+    (tui: TUI, theme: Theme, _kb, done) => {
+      let cursor = 0;
+      let cachedLines: string[] | undefined;
+      const options: Array<{ key: PostTestAction; label: string; desc: string }> = [
+        { key: "fix-now", label: "Fix now", desc: "Agent analyzes failures and fixes them before continuing" },
+        { key: "fix-later", label: "Fix later", desc: "Save results, you can resume fixing manually" },
+        { key: "ignore", label: "Accept as-is", desc: "Mark failures as known issues, continue pipeline" },
+      ];
+
+      function refresh() { cachedLines = undefined; tui.requestRender(); }
+
+      function handleInput(data: string) {
+        if (matchesKey(data, Key.up) && cursor > 0) { cursor--; refresh(); return; }
+        if (matchesKey(data, Key.down) && cursor < options.length - 1) { cursor++; refresh(); return; }
+        if (data === "1") { done("fix-now"); return; }
+        if (data === "2") { done("fix-later"); return; }
+        if (data === "3") { done("ignore"); return; }
+        if (matchesKey(data, Key.enter) || matchesKey(data, Key.space)) { done(options[cursor].key); return; }
+        if (matchesKey(data, Key.escape)) { done("fix-later"); return; }
+      }
+
+      function render(width: number): string[] {
+        if (cachedLines) return cachedLines;
+        const ui = makeUI(theme, width);
+        const lines: string[] = [];
+        const push = (...rows: string[][]) => { for (const r of rows) lines.push(...r); };
+
+        push(ui.bar(), ui.blank());
+        push(ui.header(`  ${failCount} test(s) failed`));
+        push(ui.blank());
+        push(ui.question("  What would you like to do?"));
+        push(ui.blank());
+
+        for (let i = 0; i < options.length; i++) {
+          if (i === cursor) {
+            push(ui.optionSelected(i + 1, options[i].label, options[i].desc));
+          } else {
+            push(ui.optionUnselected(i + 1, options[i].label, options[i].desc));
+          }
+        }
+
+        push(ui.blank());
+        push(ui.hints(["↑/↓ to move", "Enter to select"]));
+        push(ui.bar());
+        cachedLines = lines;
+        return lines;
+      }
+
+      return { handleInput, render, invalidate: () => { cachedLines = undefined; } };
+    },
+    {
+      overlay: true,
+      overlayOptions: {
+        width: "60%",
+        minWidth: 40,
+        maxHeight: "60%",
+        anchor: "center",
+      },
+    },
+  );
+
+  return result ?? "fix-later";
+}

--- a/src/resources/extensions/gsd/manual-test.ts
+++ b/src/resources/extensions/gsd/manual-test.ts
@@ -1,0 +1,1220 @@
+/**
+ * manual-test.ts — Core logic for `/gsd test` interactive manual testing.
+ *
+ * Responsibilities:
+ * - Parse UAT files into structured test cases
+ * - Manage manual test sessions (DB + artifact persistence)
+ * - Build prompts for agent-driven fix flow
+ *
+ * Leaf-ish in the import DAG: depends on files, paths, gsd-db, state.
+ */
+
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { join, resolve, relative, extname } from "node:path";
+
+import { extractSection, extractAllSections, parseBullets, parseSummary, parseTaskPlanIO } from "./files.js";
+import { resolveSliceFile, resolveMilestoneFile, resolveTasksDir, resolveTaskFiles } from "./paths.js";
+import { getMilestoneSlices, isDbAvailable } from "./gsd-db.js";
+import type { SliceRow } from "./gsd-db.js";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export type TestVerdict = "pass" | "fail" | "skip";
+
+export interface ManualTestCheck {
+  /** Stable id like "S01-smoke" or "S01-TC01" or "S01-EC01" */
+  id: string;
+  /** Human-readable test name */
+  name: string;
+  /** Which slice this belongs to */
+  sliceId: string;
+  /** Category: smoke | test-case | edge-case */
+  category: "smoke" | "test-case" | "edge-case";
+  /** Step-by-step instructions */
+  steps: string[];
+  /** Expected result */
+  expected: string;
+  /** Preconditions (from the UAT file header, shared across checks) */
+  preconditions: string;
+  /** User's verdict after manual execution */
+  verdict: TestVerdict | null;
+  /** User's failure notes (empty when pass/skip) */
+  notes: string;
+  /** ISO 8601 timestamp when verdict was recorded */
+  timestamp: string;
+}
+
+export interface ManualTestSession {
+  id?: number;
+  milestoneId: string;
+  /** NULL for 'all' mode */
+  sliceId: string | null;
+  status: "in-progress" | "complete" | "abandoned" | "needs-fix";
+  startedAt: string;
+  completedAt: string | null;
+  checks: ManualTestCheck[];
+  /** State snapshot at session start */
+  snapshot: {
+    phase: string;
+    milestoneProgress: string;
+    slicesComplete: string[];
+  };
+}
+
+// ─── UAT Parsing ──────────────────────────────────────────────────────────────
+
+/**
+ * Parse a UAT markdown file into structured test checks.
+ * Handles the standard UAT template format with:
+ * - ## Smoke Test
+ * - ## Test Cases → ### N. Name
+ * - ## Edge Cases → ### Name
+ * - ## Preconditions
+ */
+export function parseUatIntoChecks(content: string, sliceId: string): ManualTestCheck[] {
+  const checks: ManualTestCheck[] = [];
+  const preconditions = extractSection(content, "Preconditions") ?? "";
+
+  const base = {
+    sliceId,
+    preconditions,
+    verdict: null as TestVerdict | null,
+    notes: "",
+    timestamp: "",
+  };
+
+  // Smoke test
+  const smokeSection = extractSection(content, "Smoke Test");
+  if (smokeSection) {
+    const { steps, expected } = parseStepsAndExpected(smokeSection);
+    checks.push({
+      ...base,
+      id: `${sliceId}-smoke`,
+      name: "Smoke Test",
+      category: "smoke",
+      steps: steps.length > 0 ? steps : [smokeSection.trim()],
+      expected: expected || "Basic functionality works",
+    });
+  }
+
+  // Test Cases (### N. Name format)
+  const testCasesSection = extractSection(content, "Test Cases");
+  if (testCasesSection) {
+    const subSections = extractAllSections(testCasesSection, 3);
+    let tcIndex = 1;
+    for (const [heading, body] of subSections) {
+      const { steps, expected } = parseStepsAndExpected(body);
+      // Strip leading number+dot from heading: "1. User Login" → "User Login"
+      const name = heading.replace(/^\d+\.\s*/, "").trim();
+      checks.push({
+        ...base,
+        id: `${sliceId}-TC${String(tcIndex).padStart(2, "0")}`,
+        name,
+        category: "test-case",
+        steps,
+        expected,
+      });
+      tcIndex++;
+    }
+  }
+
+  // Edge Cases (### Name format)
+  const edgeCasesSection = extractSection(content, "Edge Cases");
+  if (edgeCasesSection) {
+    const subSections = extractAllSections(edgeCasesSection, 3);
+    let ecIndex = 1;
+    for (const [heading, body] of subSections) {
+      const { steps, expected } = parseStepsAndExpected(body);
+      const name = heading.replace(/^\d+\.\s*/, "").trim();
+      checks.push({
+        ...base,
+        id: `${sliceId}-EC${String(ecIndex).padStart(2, "0")}`,
+        name,
+        category: "edge-case",
+        steps,
+        expected,
+      });
+      ecIndex++;
+    }
+  }
+
+  return checks;
+}
+
+/**
+ * Extract numbered steps and the **Expected:** line from a test case body.
+ */
+function parseStepsAndExpected(body: string): { steps: string[]; expected: string } {
+  const lines = body.split("\n").map(l => l.trim()).filter(Boolean);
+  const steps: string[] = [];
+  let expected = "";
+
+  for (const line of lines) {
+    // Match "**Expected:**" in any form
+    const expectedMatch = line.match(/^\*?\*?Expected:?\*?\*?\s*(.+)/i);
+    if (expectedMatch) {
+      expected = expectedMatch[1].trim();
+      continue;
+    }
+    // Match numbered steps: "1. step" or "- step"
+    const stepMatch = line.match(/^(?:\d+\.\s*|-\s+)(.+)/);
+    if (stepMatch) {
+      // If the step itself contains "Expected:", split it
+      const innerExpected = stepMatch[1].match(/^\*?\*?Expected:?\*?\*?\s*(.+)/i);
+      if (innerExpected) {
+        expected = innerExpected[1].trim();
+      } else {
+        steps.push(stepMatch[1].trim());
+      }
+    }
+  }
+
+  return { steps, expected };
+}
+
+// ─── Smart Test Case Generation ───────────────────────────────────────────────
+
+/** A testable signal extracted from source code via heuristic regex matching. */
+export interface TestableSignal {
+  /** Signal category: api-route, react-component, validation, error-handler, cli-command, exported-function */
+  type: string;
+  /** Matched code context (the line or pattern that matched) */
+  context: string;
+  /** Human-readable description of what's testable about this signal */
+  testableAspect: string;
+}
+
+/** Binary/media file extensions to skip during source file collection. */
+const BINARY_EXTENSIONS = new Set([
+  ".png", ".jpg", ".jpeg", ".gif", ".ico", ".webp",
+  ".woff", ".woff2", ".ttf", ".eot", ".svg",
+  ".mp3", ".mp4", ".wav", ".ogg",
+  ".zip", ".tar", ".gz", ".bz2",
+  ".pdf", ".doc", ".docx",
+  ".exe", ".dll", ".so", ".dylib",
+]);
+
+/** Maximum file size in bytes for source file reading (100KB). */
+const MAX_SOURCE_FILE_SIZE = 100 * 1024;
+
+/** Maximum signals to return per file to avoid flooding from large files. */
+const MAX_SIGNALS_PER_FILE = 10;
+
+/**
+ * Collect source file paths referenced in task SUMMARY and PLAN artifacts.
+ *
+ * Reads task summaries for `frontmatter.key_files` and `filesModified[].path`,
+ * and task plans for `outputFiles`. Deduplicates, resolves relative to basePath,
+ * and filters out non-existent, binary, oversized, and out-of-basePath files.
+ *
+ * All I/O is synchronous.
+ */
+export function collectSourceFilePaths(
+  basePath: string, milestoneId: string, sliceId: string,
+): string[] {
+  const rawPaths: string[] = [];
+  const tasksDir = resolveTasksDir(basePath, milestoneId, sliceId);
+  if (!tasksDir) return [];
+
+  // Extract paths from task summaries
+  const summaryFiles = resolveTaskFiles(tasksDir, "SUMMARY");
+  for (const fileName of summaryFiles) {
+    try {
+      const content = readFileSync(join(tasksDir, fileName), "utf-8");
+      const summary = parseSummary(content);
+      if (summary.frontmatter.key_files) {
+        rawPaths.push(...summary.frontmatter.key_files);
+      }
+      if (summary.filesModified) {
+        for (const fm of summary.filesModified) {
+          if (fm.path) rawPaths.push(fm.path);
+        }
+      }
+    } catch {
+      // Skip unreadable summaries
+    }
+  }
+
+  // Extract paths from task plans
+  const planFiles = resolveTaskFiles(tasksDir, "PLAN");
+  for (const fileName of planFiles) {
+    try {
+      const content = readFileSync(join(tasksDir, fileName), "utf-8");
+      const io = parseTaskPlanIO(content);
+      rawPaths.push(...io.outputFiles);
+    } catch {
+      // Skip unreadable plans
+    }
+  }
+
+  // Deduplicate and resolve
+  const seen = new Set<string>();
+  const result: string[] = [];
+  const resolvedBase = resolve(basePath);
+
+  for (const rawPath of rawPaths) {
+    if (!rawPath || typeof rawPath !== "string") continue;
+
+    const absPath = rawPath.startsWith("/") ? rawPath : resolve(basePath, rawPath);
+    const normalized = resolve(absPath); // normalize ../ etc.
+
+    // Skip duplicates
+    if (seen.has(normalized)) continue;
+    seen.add(normalized);
+
+    // Skip paths outside basePath
+    const rel = relative(resolvedBase, normalized);
+    if (rel.startsWith("..") || resolve(resolvedBase, rel) !== normalized) continue;
+
+    // Skip binary extensions
+    const ext = extname(normalized).toLowerCase();
+    if (BINARY_EXTENSIONS.has(ext)) continue;
+
+    // Skip non-existent files
+    if (!existsSync(normalized)) continue;
+
+    // Skip oversized files
+    try {
+      const stat = statSync(normalized);
+      if (!stat.isFile() || stat.size > MAX_SOURCE_FILE_SIZE) continue;
+    } catch {
+      continue;
+    }
+
+    result.push(normalized);
+  }
+
+  return result;
+}
+
+// ─── Signal Extractors ────────────────────────────────────────────────────────
+
+/**
+ * Extract API route signals from source code.
+ * Matches Express-style app/router methods, Next.js route handlers, and req.body/params patterns.
+ */
+export function extractApiRoutes(content: string): TestableSignal[] {
+  const signals: TestableSignal[] = [];
+
+  // Express-style: app.get('/path', ...) or router.post('/path', ...)
+  const expressPattern = /(?:app|router)\.(get|post|put|delete|patch)\s*\(\s*['"`]([^'"`]+)['"`]/gi;
+  let match: RegExpExecArray | null;
+  while ((match = expressPattern.exec(content)) !== null) {
+    signals.push({
+      type: "api-route",
+      context: match[0],
+      testableAspect: `${match[1].toUpperCase()} ${match[2]} endpoint — verify request/response`,
+    });
+  }
+
+  // Next.js route handlers: export async function GET/POST/PUT/DELETE/PATCH
+  const nextPattern = /export\s+(?:async\s+)?function\s+(GET|POST|PUT|DELETE|PATCH)\s*\(/gi;
+  while ((match = nextPattern.exec(content)) !== null) {
+    signals.push({
+      type: "api-route",
+      context: match[0],
+      testableAspect: `Next.js ${match[1]} handler — verify request handling and response`,
+    });
+  }
+
+  return signals;
+}
+
+/**
+ * Extract React component signals from source code.
+ * Matches exported function/const components, useState, useEffect usage.
+ */
+export function extractReactComponents(content: string): TestableSignal[] {
+  const signals: TestableSignal[] = [];
+
+  // Named component exports: export function ComponentName or export const ComponentName
+  const namedPattern = /export\s+(?:default\s+)?(?:function|const)\s+([A-Z][A-Za-z0-9]*)/g;
+  let match: RegExpExecArray | null;
+  while ((match = namedPattern.exec(content)) !== null) {
+    signals.push({
+      type: "react-component",
+      context: match[0],
+      testableAspect: `<${match[1]} /> component — verify rendering and interactions`,
+    });
+  }
+
+  // export default function (anonymous)
+  if (/export\s+default\s+function\s*\(/.test(content) && signals.length === 0) {
+    signals.push({
+      type: "react-component",
+      context: "export default function",
+      testableAspect: "Default exported component — verify rendering",
+    });
+  }
+
+  // useState hooks — indicate interactive state
+  const useStatePattern = /useState\s*(?:<[^>]+>)?\s*\(\s*([^)]*)\)/g;
+  while ((match = useStatePattern.exec(content)) !== null) {
+    signals.push({
+      type: "react-component",
+      context: match[0],
+      testableAspect: `State management — verify state transitions with initial value: ${match[1].slice(0, 40)}`,
+    });
+  }
+
+  return signals;
+}
+
+/**
+ * Extract validation-related signals from source code.
+ * Matches Zod schemas, manual validation checks, and required field patterns.
+ */
+export function extractValidation(content: string): TestableSignal[] {
+  const signals: TestableSignal[] = [];
+
+  // Zod schemas: z.object, z.string, z.number, etc.
+  const zodPattern = /(?:const|let|export\s+(?:const|let))\s+(\w+)\s*=\s*z\.(?:object|string|number|array|enum|union|intersection|literal|boolean)\s*\(/g;
+  let match: RegExpExecArray | null;
+  while ((match = zodPattern.exec(content)) !== null) {
+    signals.push({
+      type: "validation",
+      context: match[0],
+      testableAspect: `Zod schema '${match[1]}' — verify valid input passes and invalid input is rejected`,
+    });
+  }
+
+  // Manual validation: if (!x) throw / if (!x) return
+  const manualPattern = /if\s*\(\s*!(\w+(?:\.\w+)?)\s*\)\s*(?:throw|return)/g;
+  while ((match = manualPattern.exec(content)) !== null) {
+    signals.push({
+      type: "validation",
+      context: match[0],
+      testableAspect: `Required field check for '${match[1]}' — verify missing value is handled`,
+    });
+  }
+
+  return signals;
+}
+
+/**
+ * Extract error handling signals from source code.
+ * Matches catch blocks, .catch(), error response patterns, and throw statements.
+ */
+export function extractErrorHandlers(content: string): TestableSignal[] {
+  const signals: TestableSignal[] = [];
+
+  // Error response patterns: res.status(4xx/5xx)
+  const errorResPattern = /res\.status\s*\(\s*(4\d{2}|5\d{2})\s*\)/g;
+  let match: RegExpExecArray | null;
+  while ((match = errorResPattern.exec(content)) !== null) {
+    signals.push({
+      type: "error-handler",
+      context: match[0],
+      testableAspect: `Error response ${match[1]} — verify correct error status and message`,
+    });
+  }
+
+  // try/catch blocks — just note their presence for testability
+  const catchPattern = /catch\s*\(\s*(\w+)\s*\)\s*\{/g;
+  while ((match = catchPattern.exec(content)) !== null) {
+    signals.push({
+      type: "error-handler",
+      context: match[0],
+      testableAspect: `Error handler (catch ${match[1]}) — verify errors are caught and handled gracefully`,
+    });
+  }
+
+  // throw new Error
+  const throwPattern = /throw\s+new\s+(\w*Error)\s*\(\s*['"`]([^'"`]{0,60})/g;
+  while ((match = throwPattern.exec(content)) !== null) {
+    signals.push({
+      type: "error-handler",
+      context: match[0],
+      testableAspect: `Throws ${match[1]}: "${match[2]}" — verify error is thrown under expected conditions`,
+    });
+  }
+
+  return signals;
+}
+
+/**
+ * Extract CLI command signals from source code.
+ * Matches commander/yargs command registrations and handler patterns.
+ */
+export function extractCliCommands(content: string): TestableSignal[] {
+  const signals: TestableSignal[] = [];
+
+  // .command('name', ...) — commander, yargs, etc.
+  const commandPattern = /\.command\s*\(\s*['"`]([^'"`]+)['"`]/g;
+  let match: RegExpExecArray | null;
+  while ((match = commandPattern.exec(content)) !== null) {
+    signals.push({
+      type: "cli-command",
+      context: match[0],
+      testableAspect: `CLI command '${match[1]}' — verify command executes correctly with valid/invalid args`,
+    });
+  }
+
+  return signals;
+}
+
+/**
+ * Extract exported function signals from source code.
+ * Serves as a fallback for functions not caught by specific extractors.
+ */
+export function extractExportedFunctions(content: string): TestableSignal[] {
+  const signals: TestableSignal[] = [];
+
+  // export function name or export const name =
+  const exportPattern = /export\s+(?:async\s+)?(?:function|const)\s+([a-z_$][\w$]*)/gi;
+  let match: RegExpExecArray | null;
+  while ((match = exportPattern.exec(content)) !== null) {
+    const name = match[1];
+    // Skip PascalCase (those are components, handled by extractReactComponents)
+    if (/^[A-Z]/.test(name)) continue;
+    signals.push({
+      type: "exported-function",
+      context: match[0],
+      testableAspect: `Exported function '${name}' — verify expected behavior with representative inputs`,
+    });
+  }
+
+  // export default function (lowercase)
+  const defaultPattern = /export\s+default\s+(?:async\s+)?function\s+([a-z_$][\w$]*)/gi;
+  while ((match = defaultPattern.exec(content)) !== null) {
+    signals.push({
+      type: "exported-function",
+      context: match[0],
+      testableAspect: `Default export '${match[1]}' — verify expected behavior`,
+    });
+  }
+
+  return signals;
+}
+
+/**
+ * Run all signal extractors on a source file's content and return combined results.
+ * Applies a relevance cap: prioritizes routes > validation > error handlers > components > CLI > exports.
+ * Returns at most MAX_SIGNALS_PER_FILE signals.
+ */
+export function extractSignalsFromFile(filePath: string, content: string): TestableSignal[] {
+  // Run all extractors
+  const routes = extractApiRoutes(content);
+  const validation = extractValidation(content);
+  const errorHandlers = extractErrorHandlers(content);
+  const components = extractReactComponents(content);
+  const cliCommands = extractCliCommands(content);
+  const exports = extractExportedFunctions(content);
+
+  // Prioritized merge: routes > validation > error handlers > components > CLI > exports
+  const all: TestableSignal[] = [
+    ...routes,
+    ...validation,
+    ...errorHandlers,
+    ...components,
+    ...cliCommands,
+    ...exports,
+  ];
+
+  // Deduplicate by context (same matched text shouldn't produce duplicate signals)
+  const seen = new Set<string>();
+  const deduped: TestableSignal[] = [];
+  for (const signal of all) {
+    const key = `${signal.type}:${signal.context}`;
+    if (!seen.has(key)) {
+      seen.add(key);
+      deduped.push(signal);
+    }
+  }
+
+  return deduped.slice(0, MAX_SIGNALS_PER_FILE);
+}
+
+// ─── Check Synthesizer ────────────────────────────────────────────────────────
+
+/** Maximum total checks produced by the smart generation pipeline. */
+const MAX_SMART_CHECKS = 15;
+
+/** Plan context used by the synthesizer to ground checks in slice goals. */
+export interface PlanContext {
+  goal: string;
+  taskTitles: string[];
+  verifyFields: string[];
+}
+
+/**
+ * Synthesize ManualTestCheck objects from extracted code signals and plan context.
+ *
+ * Groups signals by type and generates concrete, code-aware checks:
+ * - API routes → HTTP method + path + expected status
+ * - React components → component name + UI interaction
+ * - Validation → specific invalid-input edge cases
+ * - Error handlers → error-path edge cases
+ * - Exported functions → smoke-level function calls
+ *
+ * Prioritizes: smoke (1 goal check) > test-case (routes, components) > edge-case (validation, errors).
+ * Caps total at MAX_SMART_CHECKS (~15).
+ */
+export function synthesizeChecks(
+  signals: TestableSignal[],
+  sliceId: string,
+  planContext: PlanContext,
+): ManualTestCheck[] {
+  if (signals.length === 0) return [];
+
+  const checks: ManualTestCheck[] = [];
+  const base = {
+    sliceId,
+    preconditions: "",
+    verdict: null as TestVerdict | null,
+    notes: "",
+    timestamp: "",
+  };
+
+  // 1. Goal-level smoke check from plan context (always first if goal exists)
+  if (planContext.goal) {
+    checks.push({
+      ...base,
+      id: `${sliceId}-smoke`,
+      name: "Goal Verification",
+      category: "smoke",
+      steps: [`Verify: ${planContext.goal}`],
+      expected: planContext.goal,
+      preconditions: "(Auto-generated from code analysis)",
+    });
+  }
+
+  // Group signals by type
+  const grouped: Record<string, TestableSignal[]> = {};
+  for (const sig of signals) {
+    if (!grouped[sig.type]) grouped[sig.type] = [];
+    grouped[sig.type].push(sig);
+  }
+
+  let tcIdx = 1;
+  let ecIdx = 1;
+
+  // 2. API route signals → test-case checks with HTTP detail
+  for (const sig of grouped["api-route"] ?? []) {
+    const methodMatch = sig.testableAspect.match(/^(GET|POST|PUT|DELETE|PATCH)\s+(\S+)/i);
+    const nextMatch = sig.testableAspect.match(/Next\.js\s+(GET|POST|PUT|DELETE|PATCH)/i);
+    if (methodMatch) {
+      const method = methodMatch[1].toUpperCase();
+      const path = methodMatch[2];
+      checks.push({
+        ...base,
+        id: `${sliceId}-TC${String(tcIdx).padStart(2, "0")}`,
+        name: `${method} ${path}`,
+        category: "test-case",
+        steps: [
+          `Send ${method} request to ${path}`,
+          method === "POST" || method === "PUT" || method === "PATCH"
+            ? `Include valid JSON body with required fields`
+            : `Include any required query parameters`,
+          `Verify response status is 2xx`,
+        ],
+        expected: `${method} ${path} returns a successful response with expected data shape`,
+      });
+      tcIdx++;
+    } else if (nextMatch) {
+      const method = nextMatch[1].toUpperCase();
+      checks.push({
+        ...base,
+        id: `${sliceId}-TC${String(tcIdx).padStart(2, "0")}`,
+        name: `Next.js ${method} handler`,
+        category: "test-case",
+        steps: [
+          `Send ${method} request to the route handler endpoint`,
+          `Verify response status and JSON structure`,
+        ],
+        expected: `${method} handler returns expected response`,
+      });
+      tcIdx++;
+    }
+  }
+
+  // 3. React component signals → test-case checks with component names
+  for (const sig of grouped["react-component"] ?? []) {
+    if (sig.testableAspect.includes("State management")) continue; // skip useState detail signals
+    const compMatch = sig.testableAspect.match(/<(\w+)\s*\/>/);
+    const compName = compMatch ? compMatch[1] : "Component";
+    checks.push({
+      ...base,
+      id: `${sliceId}-TC${String(tcIdx).padStart(2, "0")}`,
+      name: `${compName} renders correctly`,
+      category: "test-case",
+      steps: [
+        `Navigate to the page containing <${compName} />`,
+        `Verify the component renders without errors`,
+        `Interact with primary controls (buttons, inputs) if present`,
+      ],
+      expected: `<${compName} /> renders with expected content and responds to user interaction`,
+    });
+    tcIdx++;
+  }
+
+  // 4. Validation signals → edge-case checks with specific invalid inputs
+  for (const sig of grouped["validation"] ?? []) {
+    const zodMatch = sig.testableAspect.match(/Zod schema '(\w+)'/);
+    const fieldMatch = sig.testableAspect.match(/Required field check for '(\w+(?:\.\w+)?)'/);
+    if (zodMatch) {
+      checks.push({
+        ...base,
+        id: `${sliceId}-EC${String(ecIdx).padStart(2, "0")}`,
+        name: `${zodMatch[1]} rejects invalid input`,
+        category: "edge-case",
+        steps: [
+          `Submit data that violates the '${zodMatch[1]}' schema (e.g., missing required fields, wrong types)`,
+          `Verify a validation error is returned with a descriptive message`,
+        ],
+        expected: `Invalid input is rejected with a clear validation error`,
+      });
+      ecIdx++;
+    } else if (fieldMatch) {
+      checks.push({
+        ...base,
+        id: `${sliceId}-EC${String(ecIdx).padStart(2, "0")}`,
+        name: `Missing '${fieldMatch[1]}' is handled`,
+        category: "edge-case",
+        steps: [
+          `Submit request or call function with '${fieldMatch[1]}' missing or empty`,
+          `Verify the error is handled gracefully (error response or thrown error)`,
+        ],
+        expected: `Missing '${fieldMatch[1]}' produces a clear error, not a crash`,
+      });
+      ecIdx++;
+    }
+  }
+
+  // 5. Error handler signals → edge-case checks
+  for (const sig of grouped["error-handler"] ?? []) {
+    const statusMatch = sig.testableAspect.match(/Error response (\d{3})/);
+    const throwMatch = sig.testableAspect.match(/Throws (\w+):\s*"([^"]+)"/);
+    if (statusMatch) {
+      checks.push({
+        ...base,
+        id: `${sliceId}-EC${String(ecIdx).padStart(2, "0")}`,
+        name: `Triggers ${statusMatch[1]} error response`,
+        category: "edge-case",
+        steps: [
+          `Send a request designed to trigger the ${statusMatch[1]} error path`,
+          `Verify response status is ${statusMatch[1]} with an error message body`,
+        ],
+        expected: `Returns HTTP ${statusMatch[1]} with descriptive error`,
+      });
+      ecIdx++;
+    } else if (throwMatch) {
+      checks.push({
+        ...base,
+        id: `${sliceId}-EC${String(ecIdx).padStart(2, "0")}`,
+        name: `${throwMatch[1]}: ${throwMatch[2]}`,
+        category: "edge-case",
+        steps: [
+          `Trigger the condition that causes: ${throwMatch[2]}`,
+          `Verify the error is thrown or surfaced to the user`,
+        ],
+        expected: `${throwMatch[1]} is thrown with message "${throwMatch[2]}"`,
+      });
+      ecIdx++;
+    }
+    // Skip generic catch-block signals — not actionable enough
+  }
+
+  // 6. CLI command signals → test-case checks
+  for (const sig of grouped["cli-command"] ?? []) {
+    const cmdMatch = sig.testableAspect.match(/CLI command '([^']+)'/);
+    if (cmdMatch) {
+      checks.push({
+        ...base,
+        id: `${sliceId}-TC${String(tcIdx).padStart(2, "0")}`,
+        name: `CLI: ${cmdMatch[1]}`,
+        category: "test-case",
+        steps: [
+          `Run the '${cmdMatch[1]}' command with valid arguments`,
+          `Verify it completes successfully with expected output`,
+        ],
+        expected: `'${cmdMatch[1]}' command runs without errors`,
+      });
+      tcIdx++;
+    }
+  }
+
+  // 7. Exported function signals → smoke checks (only if we have room)
+  for (const sig of grouped["exported-function"] ?? []) {
+    const fnMatch = sig.testableAspect.match(/Exported function '(\w+)'/);
+    if (fnMatch) {
+      checks.push({
+        ...base,
+        id: `${sliceId}-TC${String(tcIdx).padStart(2, "0")}`,
+        name: `${fnMatch[1]}() works`,
+        category: "test-case",
+        steps: [
+          `Call ${fnMatch[1]}() with representative inputs`,
+          `Verify it returns expected output without throwing`,
+        ],
+        expected: `${fnMatch[1]}() returns expected result`,
+      });
+      tcIdx++;
+    }
+  }
+
+  // Cap total checks: prioritize smoke > test-case > edge-case
+  if (checks.length <= MAX_SMART_CHECKS) return checks;
+
+  const smoke = checks.filter(c => c.category === "smoke");
+  const testCases = checks.filter(c => c.category === "test-case");
+  const edgeCases = checks.filter(c => c.category === "edge-case");
+
+  const capped: ManualTestCheck[] = [...smoke];
+  const remaining = MAX_SMART_CHECKS - capped.length;
+  const tcSlots = Math.min(testCases.length, Math.ceil(remaining * 0.6));
+  const ecSlots = Math.min(edgeCases.length, remaining - tcSlots);
+
+  capped.push(...testCases.slice(0, tcSlots));
+  capped.push(...edgeCases.slice(0, ecSlots));
+
+  // Fill any leftover slots
+  if (capped.length < MAX_SMART_CHECKS) {
+    const leftover = MAX_SMART_CHECKS - capped.length;
+    const usedTc = testCases.slice(tcSlots, tcSlots + leftover);
+    capped.push(...usedTc);
+  }
+  if (capped.length < MAX_SMART_CHECKS) {
+    const leftover = MAX_SMART_CHECKS - capped.length;
+    capped.push(...edgeCases.slice(ecSlots, ecSlots + leftover));
+  }
+
+  return capped.slice(0, MAX_SMART_CHECKS);
+}
+
+/**
+ * Orchestrate the full smart test generation pipeline:
+ *   collectSourceFilePaths → readFileSync → extractSignalsFromFile → synthesizeChecks
+ *
+ * Reads the slice PLAN to extract goal, task titles, and verify fields for context.
+ * Returns enriched ManualTestCheck[], or empty array if nothing useful was extracted.
+ */
+export function generateSmartChecks(
+  basePath: string, milestoneId: string, sliceId: string,
+): ManualTestCheck[] {
+  // 1. Collect source file paths from task artifacts
+  const filePaths = collectSourceFilePaths(basePath, milestoneId, sliceId);
+
+  // 2. Extract signals from each file
+  const allSignals: TestableSignal[] = [];
+  for (const fp of filePaths) {
+    try {
+      const content = readFileSync(fp, "utf-8");
+      const signals = extractSignalsFromFile(fp, content);
+      allSignals.push(...signals);
+    } catch {
+      // Skip unreadable files — don't break the pipeline
+    }
+  }
+
+  if (allSignals.length === 0) return [];
+
+  // 3. Read plan context
+  const planContext = readPlanContext(basePath, milestoneId, sliceId);
+
+  // 4. Synthesize checks
+  return synthesizeChecks(allSignals, sliceId, planContext);
+}
+
+/**
+ * Read the slice PLAN file to extract goal, task titles, and verify fields
+ * for grounding synthesized checks in plan intent.
+ */
+function readPlanContext(
+  basePath: string, milestoneId: string, sliceId: string,
+): PlanContext {
+  const planFile = resolveSliceFile(basePath, milestoneId, sliceId, "PLAN");
+  if (!planFile || !existsSync(planFile)) {
+    return { goal: "", taskTitles: [], verifyFields: [] };
+  }
+
+  try {
+    const content = readFileSync(planFile, "utf-8");
+
+    // Extract goal
+    const goalMatch = content.match(/^\*\*Goal:\*\*\s*(.+)$/m);
+    const goal = goalMatch ? goalMatch[1].trim() : "";
+
+    // Extract task titles from task list: - [ ] **T01: Title** or - [x] **T01: Title**
+    const taskTitles: string[] = [];
+    const taskPattern = /- \[[ x]\] \*\*(T\d+):\s*(.+?)\*\*/g;
+    let match: RegExpExecArray | null;
+    while ((match = taskPattern.exec(content)) !== null) {
+      taskTitles.push(`${match[1]}: ${match[2].trim()}`);
+    }
+
+    // Extract verify fields from task blocks
+    const verifyFields: string[] = [];
+    const verifyPattern = /[-•]\s*Verify:\s*(.+)/gi;
+    while ((match = verifyPattern.exec(content)) !== null) {
+      verifyFields.push(match[1].trim());
+    }
+
+    return { goal, taskTitles, verifyFields };
+  } catch {
+    return { goal: "", taskTitles: [], verifyFields: [] };
+  }
+}
+
+// ─── Test Case Gathering ──────────────────────────────────────────────────────
+
+/**
+ * Gather test checks for a specific slice from its UAT file.
+ * Falls back to smart code-aware generation, then to plan-text generation.
+ *
+ * Fallback chain: UAT file → smart code-aware generation → plan-text generation
+ */
+export function gatherChecksForSlice(
+  basePath: string, milestoneId: string, sliceId: string,
+): ManualTestCheck[] {
+  // Try UAT file first (highest priority)
+  const uatFile = resolveSliceFile(basePath, milestoneId, sliceId, "UAT");
+  if (uatFile && existsSync(uatFile)) {
+    const content = readFileSync(uatFile, "utf-8");
+    const checks = parseUatIntoChecks(content, sliceId);
+    if (checks.length > 0) return checks;
+  }
+
+  // Try smart code-aware generation (NEW — inserted between UAT and plan-text)
+  const smartChecks = generateSmartChecks(basePath, milestoneId, sliceId);
+  if (smartChecks.length > 0) return smartChecks;
+
+  // Fallback: generate from PLAN, SUMMARY, and roadmap context
+  return generateChecksFromPlan(basePath, milestoneId, sliceId);
+}
+
+/**
+ * Gather test checks across all completed slices in a milestone.
+ * Falls back to plan-based generation per-slice if no UAT exists.
+ */
+export function gatherChecksForAllSlices(
+  basePath: string, milestoneId: string,
+): ManualTestCheck[] {
+  const completedSliceIds = getCompletedSliceIds(basePath, milestoneId);
+  const allChecks: ManualTestCheck[] = [];
+
+  for (const sid of completedSliceIds) {
+    allChecks.push(...gatherChecksForSlice(basePath, milestoneId, sid));
+  }
+
+  // If still empty, try roadmap-level success criteria as a last resort
+  if (allChecks.length === 0) {
+    allChecks.push(...generateChecksFromRoadmap(basePath, milestoneId));
+  }
+
+  return allChecks;
+}
+
+/**
+ * Generate test checks from a slice's PLAN file.
+ * Extracts: Goal (smoke test), Verification items, Must-Haves,
+ * and per-task Verify fields.
+ */
+function generateChecksFromPlan(
+  basePath: string, milestoneId: string, sliceId: string,
+): ManualTestCheck[] {
+  const checks: ManualTestCheck[] = [];
+  const base = {
+    sliceId,
+    preconditions: "",
+    verdict: null as TestVerdict | null,
+    notes: "",
+    timestamp: "",
+  };
+
+  // Read the PLAN file
+  const planFile = resolveSliceFile(basePath, milestoneId, sliceId, "PLAN");
+  if (!planFile || !existsSync(planFile)) return checks;
+  const planContent = readFileSync(planFile, "utf-8");
+
+  // Extract goal for a smoke test
+  const goalMatch = planContent.match(/^\*\*Goal:\*\*\s*(.+)$/m);
+  if (goalMatch) {
+    checks.push({
+      ...base,
+      id: `${sliceId}-smoke`,
+      name: "Goal Verification",
+      category: "smoke",
+      steps: [`Verify: ${goalMatch[1].trim()}`],
+      expected: goalMatch[1].trim(),
+    });
+  }
+
+  // Extract Verification section items
+  const verificationSection = extractSection(planContent, "Verification");
+  if (verificationSection) {
+    const bullets = parseBullets(verificationSection);
+    let vIdx = 1;
+    for (const bullet of bullets) {
+      if (!bullet || bullet.startsWith("#")) continue;
+      checks.push({
+        ...base,
+        id: `${sliceId}-VER${String(vIdx).padStart(2, "0")}`,
+        name: `Verify: ${bullet.slice(0, 80)}`,
+        category: "test-case",
+        steps: [bullet],
+        expected: "Passes successfully",
+      });
+      vIdx++;
+    }
+  }
+
+  // Extract per-task Verify fields from the Tasks section
+  const tasksSection = extractSection(planContent, "Tasks");
+  if (tasksSection) {
+    const taskBlocks = tasksSection.split(/^- \[[ x]\] \*\*/m).filter(Boolean);
+    let tIdx = 1;
+    for (const block of taskBlocks) {
+      // Extract task title
+      const titleMatch = block.match(/^(T\d+):\s*(.+?)\*\*/);
+      const taskTitle = titleMatch ? titleMatch[2].trim() : `Task ${tIdx}`;
+      const taskId = titleMatch ? titleMatch[1] : `T${String(tIdx).padStart(2, "0")}`;
+
+      // Extract Verify field
+      const verifyMatch = block.match(/[-•]\s*Verify:\s*(.+)/i);
+      if (verifyMatch) {
+        checks.push({
+          ...base,
+          id: `${sliceId}-${taskId}`,
+          name: `${taskTitle}`,
+          category: "test-case",
+          steps: [`Run: ${verifyMatch[1].trim()}`],
+          expected: "Verification passes",
+        });
+      }
+
+      // Extract "Done when" field as an additional check
+      const doneMatch = block.match(/[-•]\s*Done when:\s*(.+)/i);
+      if (doneMatch && !verifyMatch) {
+        checks.push({
+          ...base,
+          id: `${sliceId}-${taskId}`,
+          name: `${taskTitle}`,
+          category: "test-case",
+          steps: [`Confirm: ${doneMatch[1].trim()}`],
+          expected: doneMatch[1].trim(),
+        });
+      }
+      tIdx++;
+    }
+  }
+
+  // If PLAN didn't yield much, try the SUMMARY (if it exists)
+  if (checks.length <= 1) {
+    const summaryFile = resolveSliceFile(basePath, milestoneId, sliceId, "SUMMARY");
+    if (summaryFile && existsSync(summaryFile)) {
+      const summaryContent = readFileSync(summaryFile, "utf-8");
+      const whatHappened = extractSection(summaryContent, "What Happened");
+      if (whatHappened) {
+        const bullets = parseBullets(whatHappened);
+        let sIdx = 1;
+        for (const bullet of bullets.slice(0, 5)) {
+          if (!bullet) continue;
+          checks.push({
+            ...base,
+            id: `${sliceId}-SUM${String(sIdx).padStart(2, "0")}`,
+            name: `Verify: ${bullet.slice(0, 80)}`,
+            category: "test-case",
+            steps: [`Confirm that: ${bullet}`],
+            expected: "Feature works as described",
+          });
+          sIdx++;
+        }
+      }
+    }
+  }
+
+  // Tag auto-generated checks with a preconditions note
+  if (checks.length > 0) {
+    checks[0].preconditions = "(Auto-generated from slice plan — no UAT file found)";
+  }
+
+  return checks;
+}
+
+/**
+ * Generate test checks from the milestone roadmap's success criteria.
+ * Last-resort fallback when no slice-level context yields checks.
+ */
+function generateChecksFromRoadmap(
+  basePath: string, milestoneId: string,
+): ManualTestCheck[] {
+  const checks: ManualTestCheck[] = [];
+  const roadmapFile = resolveMilestoneFile(basePath, milestoneId, "ROADMAP");
+  if (!roadmapFile || !existsSync(roadmapFile)) return checks;
+
+  const content = readFileSync(roadmapFile, "utf-8");
+  const successSection = extractSection(content, "Success Criteria");
+  if (!successSection) return checks;
+
+  const bullets = parseBullets(successSection);
+  let idx = 1;
+  for (const bullet of bullets) {
+    if (!bullet) continue;
+    checks.push({
+      sliceId: milestoneId,
+      preconditions: idx === 1 ? "(Auto-generated from roadmap success criteria — no UAT files found)" : "",
+      verdict: null,
+      notes: "",
+      timestamp: "",
+      id: `${milestoneId}-SC${String(idx).padStart(2, "0")}`,
+      name: bullet.slice(0, 100),
+      category: "test-case",
+      steps: [`Verify: ${bullet}`],
+      expected: bullet,
+    });
+    idx++;
+  }
+
+  return checks;
+}
+
+/**
+ * Get IDs of completed slices for a milestone.
+ */
+export function getCompletedSliceIds(basePath: string, milestoneId: string): string[] {
+  if (isDbAvailable()) {
+    return getMilestoneSlices(milestoneId)
+      .filter((s: SliceRow) => s.status === "complete")
+      .map((s: SliceRow) => s.id);
+  }
+  return [];
+}
+
+// ─── Session Management ───────────────────────────────────────────────────────
+
+/**
+ * Compute summary counts from a session's checks.
+ */
+export function sessionCounts(session: ManualTestSession): {
+  total: number;
+  passed: number;
+  failed: number;
+  skipped: number;
+  pending: number;
+} {
+  const total = session.checks.length;
+  let passed = 0, failed = 0, skipped = 0, pending = 0;
+  for (const c of session.checks) {
+    if (c.verdict === "pass") passed++;
+    else if (c.verdict === "fail") failed++;
+    else if (c.verdict === "skip") skipped++;
+    else pending++;
+  }
+  return { total, passed, failed, skipped, pending };
+}
+
+/**
+ * Generate the markdown result artifact for a completed manual test session.
+ */
+export function renderManualTestResult(session: ManualTestSession): string {
+  const counts = sessionCounts(session);
+  const verdict = counts.failed > 0 ? "FAIL" : counts.skipped > 0 ? "PARTIAL" : "PASS";
+
+  const lines: string[] = [];
+
+  lines.push("---");
+  lines.push(`type: manual-test-result`);
+  lines.push(`milestoneId: ${session.milestoneId}`);
+  if (session.sliceId) lines.push(`sliceId: ${session.sliceId}`);
+  lines.push(`verdict: ${verdict}`);
+  lines.push(`date: ${session.completedAt ?? new Date().toISOString()}`);
+  lines.push(`totalChecks: ${counts.total}`);
+  lines.push(`passed: ${counts.passed}`);
+  lines.push(`failed: ${counts.failed}`);
+  lines.push(`skipped: ${counts.skipped}`);
+  lines.push("---");
+  lines.push("");
+  lines.push(`# Manual Test Result${session.sliceId ? ` — ${session.sliceId}` : " — All Slices"}`);
+  lines.push("");
+  lines.push("## Summary");
+  lines.push("");
+  lines.push(`${counts.passed} passed, ${counts.failed} failed, ${counts.skipped} skipped out of ${counts.total} checks.`);
+  lines.push("");
+
+  // Results table
+  lines.push("## Results");
+  lines.push("");
+  lines.push("| # | Slice | Check | Verdict | Notes |");
+  lines.push("|---|-------|-------|---------|-------|");
+
+  for (let i = 0; i < session.checks.length; i++) {
+    const c = session.checks[i];
+    const icon = c.verdict === "pass" ? "✓ PASS" : c.verdict === "fail" ? "✗ FAIL" : c.verdict === "skip" ? "– SKIP" : "○ PENDING";
+    const notes = c.notes ? c.notes.replace(/\|/g, "\\|").replace(/\n/g, " ") : "";
+    lines.push(`| ${i + 1} | ${c.sliceId} | ${c.name} | ${icon} | ${notes} |`);
+  }
+  lines.push("");
+
+  // Failed checks detail
+  const failed = session.checks.filter(c => c.verdict === "fail");
+  if (failed.length > 0) {
+    lines.push("## Failed Checks Detail");
+    lines.push("");
+    for (const c of failed) {
+      lines.push(`### ${c.id}: ${c.name}`);
+      lines.push(`- **Slice:** ${c.sliceId}`);
+      if (c.steps.length > 0) {
+        lines.push(`- **Steps:** ${c.steps.join(" → ")}`);
+      }
+      if (c.expected) {
+        lines.push(`- **Expected:** ${c.expected}`);
+      }
+      lines.push(`- **Actual (user notes):** ${c.notes}`);
+      lines.push("");
+    }
+  }
+
+  // State snapshot
+  lines.push("## State Snapshot");
+  lines.push("");
+  lines.push(`- Phase: ${session.snapshot.phase}`);
+  lines.push(`- Milestone: ${session.milestoneId} (${session.snapshot.milestoneProgress})`);
+  if (session.snapshot.slicesComplete.length > 0) {
+    lines.push(`- Tested after: ${session.snapshot.slicesComplete.join(", ")} complete`);
+  }
+
+  return lines.join("\n");
+}
+
+/**
+ * Build the prompt for the agent to fix manual test failures.
+ */
+export function buildFixManualTestsPrompt(session: ManualTestSession, basePath: string): string {
+  const failed = session.checks.filter(c => c.verdict === "fail");
+  if (failed.length === 0) return "";
+
+  const lines: string[] = [];
+  lines.push(`You are executing GSD auto-mode.\n`);
+  lines.push(`## UNIT: Fix Manual Test Failures — ${session.milestoneId}${session.sliceId ? `/${session.sliceId}` : ""}\n`);
+  lines.push(`## Working Directory\n`);
+  lines.push(`Your working directory is \`${basePath}\`. All file reads, writes, and shell commands MUST operate relative to this directory.\n`);
+  lines.push(`---\n`);
+  lines.push(`## Manual Test Failures\n`);
+  lines.push(`The user ran manual testing and found ${failed.length} failure(s). Fix each one.\n`);
+
+  for (const c of failed) {
+    lines.push(`### ${c.id}: ${c.name}`);
+    lines.push(`- **Slice:** ${c.sliceId}`);
+    if (c.steps.length > 0) {
+      lines.push(`- **Steps to reproduce:** ${c.steps.join(" → ")}`);
+    }
+    if (c.expected) {
+      lines.push(`- **Expected:** ${c.expected}`);
+    }
+    lines.push(`- **User reported:** ${c.notes}`);
+    lines.push("");
+  }
+
+  lines.push("## Instructions\n");
+  lines.push("For each failure:");
+  lines.push("1. Read the relevant source code for the failing feature");
+  lines.push("2. Diagnose the root cause based on the user's notes");
+  lines.push("3. Fix the code");
+  lines.push("4. Verify the fix addresses the specific complaint");
+  lines.push("5. Run any existing tests to ensure no regressions\n");
+  lines.push("After fixing all failures, summarize what was changed.\n");
+  lines.push(`When done, say: "Manual test fixes complete — ${failed.length} issue(s) addressed."`);
+
+  return lines.join("\n");
+}

--- a/src/resources/extensions/gsd/preferences-models.ts
+++ b/src/resources/extensions/gsd/preferences-models.ts
@@ -62,6 +62,7 @@ export function resolveModelWithFallbacksForUnit(unitType: string): ResolvedMode
       break;
     case "execute-task":
     case "reactive-execute":
+    case "fix-manual-tests":
       phaseConfig = m.execution;
       break;
     case "execute-task-simple":

--- a/src/resources/extensions/gsd/preferences-types.ts
+++ b/src/resources/extensions/gsd/preferences-types.ts
@@ -101,7 +101,7 @@ export const KNOWN_UNIT_TYPES = [
   "research-milestone", "plan-milestone", "research-slice", "plan-slice",
   "execute-task", "reactive-execute", "gate-evaluate", "complete-slice", "replan-slice", "reassess-roadmap",
   "run-uat", "complete-milestone", "validate-milestone", "rewrite-docs",
-  "discuss-milestone", "discuss-slice", "worktree-merge",
+  "discuss-milestone", "discuss-slice", "worktree-merge", "fix-manual-tests",
 ] as const;
 export type UnitType = (typeof KNOWN_UNIT_TYPES)[number];
 

--- a/src/resources/extensions/gsd/tests/complete-slice.test.ts
+++ b/src/resources/extensions/gsd/tests/complete-slice.test.ts
@@ -125,9 +125,9 @@ console.log('\n=== complete-slice: schema v6 migration ===');
 
   const adapter = _getAdapter()!;
 
-  // Verify schema version is current (v14 after indexes + slice_dependencies)
+  // Verify schema version is current (v15 after manual_test_sessions)
   const versionRow = adapter.prepare('SELECT MAX(version) as v FROM schema_version').get();
-  assertEq(versionRow?.['v'], 14, 'schema version should be 14');
+  assertEq(versionRow?.['v'], 15, 'schema version should be 15');
 
   // Verify slices table has full_summary_md and full_uat_md columns
   const cols = adapter.prepare("PRAGMA table_info(slices)").all();

--- a/src/resources/extensions/gsd/tests/complete-task.test.ts
+++ b/src/resources/extensions/gsd/tests/complete-task.test.ts
@@ -109,9 +109,9 @@ console.log('\n=== complete-task: schema v5 migration ===');
 
   const adapter = _getAdapter()!;
 
-  // Verify schema version is current (v14 after indexes + slice_dependencies)
+  // Verify schema version is current (v15 after manual_test_sessions)
   const versionRow = adapter.prepare('SELECT MAX(version) as v FROM schema_version').get();
-  assertEq(versionRow?.['v'], 14, 'schema version should be 14');
+  assertEq(versionRow?.['v'], 15, 'schema version should be 15');
 
   // Verify all 4 new tables exist
   const tables = adapter.prepare(

--- a/src/resources/extensions/gsd/tests/gsd-db.test.ts
+++ b/src/resources/extensions/gsd/tests/gsd-db.test.ts
@@ -64,7 +64,7 @@ describe('gsd-db', () => {
     // Check schema_version table
     const adapter = _getAdapter()!;
     const version = adapter.prepare('SELECT MAX(version) as version FROM schema_version').get();
-    assert.deepStrictEqual(version?.['version'], 14, 'schema version should be 14');
+    assert.deepStrictEqual(version?.['version'], 15, 'schema version should be 15');
 
     // Check tables exist by querying them
     const dRows = adapter.prepare('SELECT count(*) as cnt FROM decisions').get();

--- a/src/resources/extensions/gsd/tests/manual-test-persistence.test.ts
+++ b/src/resources/extensions/gsd/tests/manual-test-persistence.test.ts
@@ -1,0 +1,474 @@
+/**
+ * Tests for incremental persistence, resume detection, and check merging.
+ *
+ * Covers:
+ * - gsd-db.ts: updateManualTestSessionResults, getInProgressSessionRow
+ * - commands-manual-test.ts: mergeChecks
+ * - Resume flow integration: in-progress session → merge → correct startIndex
+ */
+
+import { describe, test, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import {
+  openDatabase,
+  closeDatabase,
+  insertManualTestSession,
+  updateManualTestSessionResults,
+  getInProgressSessionRow,
+  _getAdapter,
+} from "../gsd-db.ts";
+import { mergeChecks } from "../commands-manual-test.ts";
+import type { ManualTestCheck } from "../manual-test.ts";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Create a ManualTestCheck with sensible defaults. */
+function makeCheck(overrides: Partial<ManualTestCheck> & { id: string }): ManualTestCheck {
+  return {
+    name: overrides.id,
+    sliceId: "S01",
+    category: "test-case",
+    steps: ["Step 1"],
+    expected: "Works",
+    preconditions: "",
+    verdict: null,
+    notes: "",
+    timestamp: "",
+    ...overrides,
+  };
+}
+
+/** Insert a basic in-progress session and return its row ID. */
+function insertInProgressSession(
+  milestoneId: string,
+  sliceId: string | null,
+  checks: ManualTestCheck[],
+): number {
+  return insertManualTestSession({
+    milestoneId,
+    sliceId,
+    status: "in-progress",
+    startedAt: new Date().toISOString(),
+    completedAt: null,
+    totalChecks: checks.length,
+    passed: 0,
+    failed: 0,
+    skipped: 0,
+    resultsJson: JSON.stringify(checks),
+    snapshotJson: JSON.stringify({ phase: "test", milestoneProgress: "1/3", slicesComplete: [] }),
+  });
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Group 1: DB Functions
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe("updateManualTestSessionResults", () => {
+  beforeEach(() => {
+    openDatabase(":memory:");
+  });
+
+  afterEach(() => {
+    closeDatabase();
+  });
+
+  test("updates results_json and counts on an existing row", () => {
+    const checks = [makeCheck({ id: "S01-TC01" }), makeCheck({ id: "S01-TC02" })];
+    const id = insertInProgressSession("M001", "S01", checks);
+    assert.ok(id > 0, "session should be inserted");
+
+    // Now update with verdicts
+    const updatedChecks = [
+      makeCheck({ id: "S01-TC01", verdict: "pass", notes: "", timestamp: "2026-01-01T00:00:00Z" }),
+      makeCheck({ id: "S01-TC02", verdict: "fail", notes: "Broken", timestamp: "2026-01-01T00:01:00Z" }),
+    ];
+    updateManualTestSessionResults(id, JSON.stringify(updatedChecks), 2, 1, 1, 0);
+
+    // Verify by reading the row directly
+    const adapter = _getAdapter()!;
+    const row = adapter.prepare("SELECT * FROM manual_test_sessions WHERE id = ?").get(id) as Record<string, unknown>;
+    assert.equal(row["total_checks"], 2);
+    assert.equal(row["passed"], 1);
+    assert.equal(row["failed"], 1);
+    assert.equal(row["skipped"], 0);
+
+    const storedChecks = JSON.parse(row["results_json"] as string);
+    assert.equal(storedChecks[0].verdict, "pass");
+    assert.equal(storedChecks[1].verdict, "fail");
+    assert.equal(storedChecks[1].notes, "Broken");
+  });
+
+  test("no-ops silently for non-existent ID", () => {
+    // Should not throw
+    updateManualTestSessionResults(99999, JSON.stringify([]), 0, 0, 0, 0);
+
+    // Verify nothing was inserted
+    const adapter = _getAdapter()!;
+    const row = adapter.prepare("SELECT count(*) as cnt FROM manual_test_sessions").get() as Record<string, unknown>;
+    assert.equal(row["cnt"], 0);
+  });
+});
+
+describe("getInProgressSessionRow", () => {
+  beforeEach(() => {
+    openDatabase(":memory:");
+  });
+
+  afterEach(() => {
+    closeDatabase();
+  });
+
+  test("returns the latest in-progress session matching milestone+slice", () => {
+    const checks = [makeCheck({ id: "S01-TC01" })];
+    // Insert two in-progress sessions — should return the latest (highest id)
+    insertInProgressSession("M001", "S01", []);
+    const id2 = insertInProgressSession("M001", "S01", checks);
+
+    const row = getInProgressSessionRow("M001", "S01");
+    assert.ok(row, "should find a row");
+    assert.equal(row!.id, id2, "should return the latest session");
+    assert.equal(row!.milestone_id, "M001");
+    assert.equal(row!.slice_id, "S01");
+    assert.equal(row!.status, "in-progress");
+  });
+
+  test("returns null when no in-progress session exists", () => {
+    const row = getInProgressSessionRow("M001", "S01");
+    assert.equal(row, null);
+  });
+
+  test("ignores completed sessions", () => {
+    // Insert a completed session
+    insertManualTestSession({
+      milestoneId: "M001",
+      sliceId: "S01",
+      status: "complete",
+      startedAt: new Date().toISOString(),
+      completedAt: new Date().toISOString(),
+      totalChecks: 1,
+      passed: 1,
+      failed: 0,
+      skipped: 0,
+      resultsJson: JSON.stringify([makeCheck({ id: "S01-TC01", verdict: "pass" })]),
+      snapshotJson: "{}",
+    });
+
+    const row = getInProgressSessionRow("M001", "S01");
+    assert.equal(row, null, "should not return completed sessions");
+  });
+
+  test("ignores abandoned sessions", () => {
+    insertManualTestSession({
+      milestoneId: "M001",
+      sliceId: "S01",
+      status: "abandoned",
+      startedAt: new Date().toISOString(),
+      completedAt: null,
+      totalChecks: 2,
+      passed: 0,
+      failed: 0,
+      skipped: 0,
+      resultsJson: "[]",
+      snapshotJson: "{}",
+    });
+
+    const row = getInProgressSessionRow("M001", "S01");
+    assert.equal(row, null, "should not return abandoned sessions");
+  });
+
+  test("matches null sliceId correctly (all mode)", () => {
+    // Insert session with null sliceId
+    const id = insertInProgressSession("M001", null, [makeCheck({ id: "S01-TC01" })]);
+
+    // Query with null sliceId
+    const row = getInProgressSessionRow("M001", null);
+    assert.ok(row, "should find null-sliceId session");
+    assert.equal(row!.id, id);
+    assert.equal(row!.slice_id, null);
+
+    // Query with a specific sliceId should NOT match the null-sliceId session
+    const otherRow = getInProgressSessionRow("M001", "S01");
+    assert.equal(otherRow, null, "specific sliceId should not match null-sliceId session");
+  });
+
+  test("does not cross-match milestone IDs", () => {
+    insertInProgressSession("M002", "S01", [makeCheck({ id: "S01-TC01" })]);
+
+    const row = getInProgressSessionRow("M001", "S01");
+    assert.equal(row, null, "should not match different milestone");
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Group 2: Check Merging (mergeChecks)
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe("mergeChecks", () => {
+  test("matching checks: verdicts transfer from persisted to fresh by check.id", () => {
+    const persisted = [
+      makeCheck({ id: "S01-TC01", verdict: "pass", notes: "Looks good", timestamp: "2026-01-01T00:00:00Z" }),
+      makeCheck({ id: "S01-TC02", verdict: "fail", notes: "Broken button", timestamp: "2026-01-01T00:01:00Z" }),
+    ];
+    const fresh = [
+      makeCheck({ id: "S01-TC01" }),
+      makeCheck({ id: "S01-TC02" }),
+    ];
+
+    const merged = mergeChecks(fresh, persisted);
+    assert.equal(merged.length, 2);
+    assert.equal(merged[0].verdict, "pass");
+    assert.equal(merged[0].notes, "Looks good");
+    assert.equal(merged[0].timestamp, "2026-01-01T00:00:00Z");
+    assert.equal(merged[1].verdict, "fail");
+    assert.equal(merged[1].notes, "Broken button");
+  });
+
+  test("new checks in fresh set get null verdicts", () => {
+    const persisted = [
+      makeCheck({ id: "S01-TC01", verdict: "pass", timestamp: "2026-01-01T00:00:00Z" }),
+    ];
+    const fresh = [
+      makeCheck({ id: "S01-TC01" }),
+      makeCheck({ id: "S01-TC03" }),  // new check not in persisted
+    ];
+
+    const merged = mergeChecks(fresh, persisted);
+    assert.equal(merged.length, 2);
+    assert.equal(merged[0].verdict, "pass", "existing check should have verdict");
+    assert.equal(merged[1].verdict, null, "new check should have null verdict");
+    assert.equal(merged[1].id, "S01-TC03");
+  });
+
+  test("removed checks (in persisted but not in fresh) are dropped", () => {
+    const persisted = [
+      makeCheck({ id: "S01-TC01", verdict: "pass", timestamp: "2026-01-01T00:00:00Z" }),
+      makeCheck({ id: "S01-TC02", verdict: "fail", timestamp: "2026-01-01T00:01:00Z" }),
+    ];
+    const fresh = [
+      makeCheck({ id: "S01-TC01" }),
+      // S01-TC02 is gone from fresh — should be dropped
+    ];
+
+    const merged = mergeChecks(fresh, persisted);
+    assert.equal(merged.length, 1);
+    assert.equal(merged[0].id, "S01-TC01");
+    assert.equal(merged[0].verdict, "pass");
+  });
+
+  test("mixed scenario: some matched, some new, some removed", () => {
+    const persisted = [
+      makeCheck({ id: "S01-TC01", verdict: "pass", notes: "OK", timestamp: "2026-01-01T00:00:00Z" }),
+      makeCheck({ id: "S01-TC02", verdict: "fail", notes: "Bad", timestamp: "2026-01-01T00:01:00Z" }),
+      makeCheck({ id: "S01-TC03", verdict: "skip", notes: "N/A", timestamp: "2026-01-01T00:02:00Z" }),
+    ];
+    const fresh = [
+      makeCheck({ id: "S01-TC01" }),  // matched — gets persisted verdict
+      makeCheck({ id: "S01-TC03" }),  // matched — gets persisted verdict
+      makeCheck({ id: "S01-TC04" }),  // new — stays null
+      // S01-TC02 is removed — dropped from result
+    ];
+
+    const merged = mergeChecks(fresh, persisted);
+    assert.equal(merged.length, 3);
+    assert.equal(merged[0].id, "S01-TC01");
+    assert.equal(merged[0].verdict, "pass");
+    assert.equal(merged[1].id, "S01-TC03");
+    assert.equal(merged[1].verdict, "skip");
+    assert.equal(merged[2].id, "S01-TC04");
+    assert.equal(merged[2].verdict, null);
+  });
+
+  test("verdict fields (verdict, notes, timestamp) all transfer correctly", () => {
+    const persisted = [
+      makeCheck({
+        id: "S01-TC01",
+        verdict: "fail",
+        notes: "Button doesn't respond to clicks",
+        timestamp: "2026-03-15T14:30:00Z",
+      }),
+    ];
+    const fresh = [
+      makeCheck({
+        id: "S01-TC01",
+        name: "Updated Check Name",  // fresh may have different name/steps
+        steps: ["New step 1", "New step 2"],
+        expected: "New expected result",
+      }),
+    ];
+
+    const merged = mergeChecks(fresh, persisted);
+    assert.equal(merged.length, 1);
+    // Verdict fields come from persisted
+    assert.equal(merged[0].verdict, "fail");
+    assert.equal(merged[0].notes, "Button doesn't respond to clicks");
+    assert.equal(merged[0].timestamp, "2026-03-15T14:30:00Z");
+    // Non-verdict fields come from fresh
+    assert.equal(merged[0].name, "Updated Check Name");
+    assert.deepEqual(merged[0].steps, ["New step 1", "New step 2"]);
+    assert.equal(merged[0].expected, "New expected result");
+  });
+
+  test("empty fresh checks returns empty array", () => {
+    const persisted = [
+      makeCheck({ id: "S01-TC01", verdict: "pass", timestamp: "2026-01-01T00:00:00Z" }),
+    ];
+    const merged = mergeChecks([], persisted);
+    assert.equal(merged.length, 0);
+  });
+
+  test("empty persisted checks returns fresh checks unchanged", () => {
+    const fresh = [
+      makeCheck({ id: "S01-TC01" }),
+      makeCheck({ id: "S01-TC02" }),
+    ];
+    const merged = mergeChecks(fresh, []);
+    assert.equal(merged.length, 2);
+    assert.equal(merged[0].verdict, null);
+    assert.equal(merged[1].verdict, null);
+  });
+
+  test("all checks already judged — startIndex equals length", () => {
+    const persisted = [
+      makeCheck({ id: "S01-TC01", verdict: "pass", timestamp: "2026-01-01T00:00:00Z" }),
+      makeCheck({ id: "S01-TC02", verdict: "fail", timestamp: "2026-01-01T00:01:00Z" }),
+    ];
+    const fresh = [
+      makeCheck({ id: "S01-TC01" }),
+      makeCheck({ id: "S01-TC02" }),
+    ];
+
+    const merged = mergeChecks(fresh, persisted);
+    const startIndex = merged.findIndex((c) => c.verdict === null);
+    // When all judged, findIndex returns -1 (which the handler treats as "restart from 0")
+    assert.equal(startIndex, -1, "no unjudged checks → findIndex returns -1");
+  });
+
+  test("persisted checks with null verdict are not transferred", () => {
+    // If a persisted check has null verdict (unjudged), it should NOT override fresh
+    const persisted = [
+      makeCheck({ id: "S01-TC01", verdict: null }),  // unjudged persisted
+    ];
+    const fresh = [
+      makeCheck({ id: "S01-TC01" }),
+    ];
+
+    const merged = mergeChecks(fresh, persisted);
+    assert.equal(merged[0].verdict, null, "null-verdict persisted should not transfer");
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Group 3: Resume Flow Integration
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe("resume flow integration", () => {
+  beforeEach(() => {
+    openDatabase(":memory:");
+  });
+
+  afterEach(() => {
+    closeDatabase();
+  });
+
+  test("in-progress session → merge with fresh checks → correct startIndex", () => {
+    // Simulate: user judged 2 of 4 checks, then quit
+    const persistedChecks = [
+      makeCheck({ id: "S01-smoke", verdict: "pass", notes: "", timestamp: "2026-01-01T00:00:00Z" }),
+      makeCheck({ id: "S01-TC01", verdict: "fail", notes: "Error shown", timestamp: "2026-01-01T00:01:00Z" }),
+      makeCheck({ id: "S01-TC02" }),  // unjudged
+      makeCheck({ id: "S01-TC03" }),  // unjudged
+    ];
+
+    const sessionId = insertInProgressSession("M001", "S01", persistedChecks);
+    assert.ok(sessionId > 0, "session should be inserted");
+
+    // Simulate: on resume, fresh checks are regenerated (may differ)
+    const freshChecks = [
+      makeCheck({ id: "S01-smoke", name: "Smoke Test (updated)" }),
+      makeCheck({ id: "S01-TC01", name: "Test Case 1 (updated)" }),
+      makeCheck({ id: "S01-TC02" }),
+      makeCheck({ id: "S01-TC03" }),
+      makeCheck({ id: "S01-TC04" }),  // new check added since last run
+    ];
+
+    // Step 1: load the in-progress session from DB
+    const row = getInProgressSessionRow("M001", "S01");
+    assert.ok(row, "should find in-progress session");
+
+    // Step 2: parse persisted checks from DB row
+    const dbChecks: ManualTestCheck[] = JSON.parse(row!.results_json!);
+    assert.equal(dbChecks.length, 4);
+
+    // Step 3: merge
+    const merged = mergeChecks(freshChecks, dbChecks);
+    assert.equal(merged.length, 5, "merged should have all fresh checks");
+
+    // Verdicts from first two should transfer
+    assert.equal(merged[0].verdict, "pass");
+    assert.equal(merged[1].verdict, "fail");
+    assert.equal(merged[1].notes, "Error shown");
+
+    // Unjudged checks should be null
+    assert.equal(merged[2].verdict, null);
+    assert.equal(merged[3].verdict, null);
+    assert.equal(merged[4].verdict, null);  // new check
+
+    // Step 4: startIndex should point to first null-verdict check
+    const startIndex = merged.findIndex((c) => c.verdict === null);
+    assert.equal(startIndex, 2, "should start at index 2 (third check)");
+
+    // Fresh metadata should be preserved
+    assert.equal(merged[0].name, "Smoke Test (updated)");
+    assert.equal(merged[1].name, "Test Case 1 (updated)");
+  });
+
+  test("merged session preserves the original DB row ID", () => {
+    const checks = [makeCheck({ id: "S01-TC01", verdict: "pass", timestamp: "2026-01-01T00:00:00Z" })];
+    const sessionId = insertInProgressSession("M001", "S01", checks);
+
+    const row = getInProgressSessionRow("M001", "S01");
+    assert.ok(row);
+    assert.equal(row!.id, sessionId, "DB row ID should be the same as the inserted session ID");
+  });
+
+  test("resume with all checks already judged → findIndex returns -1", () => {
+    const persistedChecks = [
+      makeCheck({ id: "S01-TC01", verdict: "pass", timestamp: "2026-01-01T00:00:00Z" }),
+      makeCheck({ id: "S01-TC02", verdict: "skip", timestamp: "2026-01-01T00:01:00Z" }),
+    ];
+
+    insertInProgressSession("M001", "S01", persistedChecks);
+
+    const freshChecks = [
+      makeCheck({ id: "S01-TC01" }),
+      makeCheck({ id: "S01-TC02" }),
+    ];
+
+    const row = getInProgressSessionRow("M001", "S01");
+    const dbChecks: ManualTestCheck[] = JSON.parse(row!.results_json!);
+    const merged = mergeChecks(freshChecks, dbChecks);
+
+    const startIndex = merged.findIndex((c) => c.verdict === null);
+    assert.equal(startIndex, -1, "all judged → -1 (handler resets to 0)");
+  });
+
+  test("no in-progress session → getInProgressSessionRow returns null → new session path", () => {
+    // Only completed sessions exist
+    insertManualTestSession({
+      milestoneId: "M001",
+      sliceId: "S01",
+      status: "complete",
+      startedAt: new Date().toISOString(),
+      completedAt: new Date().toISOString(),
+      totalChecks: 1,
+      passed: 1,
+      failed: 0,
+      skipped: 0,
+      resultsJson: JSON.stringify([makeCheck({ id: "S01-TC01", verdict: "pass" })]),
+      snapshotJson: "{}",
+    });
+
+    const row = getInProgressSessionRow("M001", "S01");
+    assert.equal(row, null, "no in-progress session → null → handler creates new session");
+  });
+});

--- a/src/resources/extensions/gsd/tests/manual-test-smart-gen.test.ts
+++ b/src/resources/extensions/gsd/tests/manual-test-smart-gen.test.ts
@@ -1,0 +1,1189 @@
+/**
+ * Tests for smart test case generation: collectSourceFilePaths() and signal extractors.
+ *
+ * Uses temp directories with mock task SUMMARY/PLAN artifacts to verify the collector,
+ * and inline code snippets to verify each extractor individually.
+ */
+
+import { describe, test, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  collectSourceFilePaths,
+  extractApiRoutes,
+  extractReactComponents,
+  extractValidation,
+  extractErrorHandlers,
+  extractCliCommands,
+  extractExportedFunctions,
+  extractSignalsFromFile,
+  synthesizeChecks,
+  generateSmartChecks,
+  gatherChecksForSlice,
+} from "../manual-test.ts";
+import type { TestableSignal, PlanContext } from "../manual-test.ts";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+let tempDir: string;
+let cleanupDirs: string[] = [];
+
+function createTempProject(): string {
+  const dir = join(tmpdir(), `gsd-smart-gen-test-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
+  mkdirSync(dir, { recursive: true });
+  cleanupDirs.push(dir);
+  return dir;
+}
+
+function setupGsdStructure(base: string, milestoneId: string, sliceId: string): string {
+  const tasksDir = join(base, ".gsd", "milestones", milestoneId, "slices", sliceId, "tasks");
+  mkdirSync(tasksDir, { recursive: true });
+  return tasksDir;
+}
+
+function writeSummaryFile(tasksDir: string, taskId: string, opts: {
+  keyFiles?: string[];
+  filesModified?: Array<{ path: string; description: string }>;
+}): void {
+  const keyFilesYaml = (opts.keyFiles ?? []).map(f => `  - ${f}`).join("\n");
+  const fmLines = [
+    "---",
+    `id: ${taskId}`,
+    "parent: S01",
+    "milestone: M001",
+    "provides: []",
+    "key_files:",
+    keyFilesYaml || "  []",
+    "key_decisions: []",
+    "patterns_established: []",
+    "observability_surfaces: []",
+    "duration: 30m",
+    "verification_result: passed",
+    "completed_at: 2026-01-01T00:00:00Z",
+    "blocker_discovered: false",
+    "---",
+    "",
+    `# ${taskId}: Test Task`,
+    "",
+    "**Did something**",
+    "",
+    "## What Happened",
+    "",
+    "Something happened.",
+    "",
+  ];
+
+  if (opts.filesModified && opts.filesModified.length > 0) {
+    fmLines.push("## Files Created/Modified", "");
+    for (const fm of opts.filesModified) {
+      fmLines.push(`- \`${fm.path}\` — ${fm.description}`);
+    }
+    fmLines.push("");
+  }
+
+  writeFileSync(join(tasksDir, `${taskId}-SUMMARY.md`), fmLines.join("\n"));
+}
+
+function writePlanFile(tasksDir: string, taskId: string, opts: {
+  outputFiles?: string[];
+}): void {
+  const outputLines = (opts.outputFiles ?? []).map(f => `- \`${f}\` — output file`);
+  const content = [
+    "---",
+    "estimated_steps: 10",
+    "estimated_files: 2",
+    "skills_used: []",
+    "---",
+    "",
+    `# ${taskId}: Test Task`,
+    "",
+    "## Description",
+    "",
+    "A test task.",
+    "",
+    "## Inputs",
+    "",
+    "- `src/input.ts` — input file",
+    "",
+    "## Expected Output",
+    "",
+    ...outputLines,
+    "",
+  ].join("\n");
+  writeFileSync(join(tasksDir, `${taskId}-PLAN.md`), content);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// collectSourceFilePaths
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe("collectSourceFilePaths", () => {
+  afterEach(() => {
+    for (const dir of cleanupDirs) {
+      try { rmSync(dir, { recursive: true, force: true }); } catch {}
+    }
+    cleanupDirs = [];
+  });
+
+  test("collects key_files from task summaries", () => {
+    const base = createTempProject();
+    const tasksDir = setupGsdStructure(base, "M001", "S01");
+
+    // Create a source file that the summary references
+    const srcDir = join(base, "src");
+    mkdirSync(srcDir, { recursive: true });
+    writeFileSync(join(srcDir, "app.ts"), "export function main() {}");
+
+    writeSummaryFile(tasksDir, "T01", {
+      keyFiles: ["src/app.ts"],
+    });
+
+    const result = collectSourceFilePaths(base, "M001", "S01");
+    assert.equal(result.length, 1, "should find one file");
+    assert.ok(result[0].endsWith("src/app.ts"), "should resolve to src/app.ts");
+  });
+
+  test("collects filesModified paths from task summaries", () => {
+    const base = createTempProject();
+    const tasksDir = setupGsdStructure(base, "M001", "S01");
+
+    const srcDir = join(base, "src");
+    mkdirSync(srcDir, { recursive: true });
+    writeFileSync(join(srcDir, "handler.ts"), "export function handle() {}");
+
+    writeSummaryFile(tasksDir, "T01", {
+      filesModified: [{ path: "src/handler.ts", description: "Added handler" }],
+    });
+
+    const result = collectSourceFilePaths(base, "M001", "S01");
+    assert.ok(result.some(p => p.endsWith("src/handler.ts")), "should include filesModified path");
+  });
+
+  test("collects outputFiles from task plans", () => {
+    const base = createTempProject();
+    const tasksDir = setupGsdStructure(base, "M001", "S01");
+
+    const srcDir = join(base, "lib");
+    mkdirSync(srcDir, { recursive: true });
+    writeFileSync(join(srcDir, "output.ts"), "export const x = 1;");
+
+    writePlanFile(tasksDir, "T01", {
+      outputFiles: ["lib/output.ts"],
+    });
+
+    const result = collectSourceFilePaths(base, "M001", "S01");
+    assert.ok(result.some(p => p.endsWith("lib/output.ts")), "should include plan output file");
+  });
+
+  test("deduplicates files referenced in multiple summaries", () => {
+    const base = createTempProject();
+    const tasksDir = setupGsdStructure(base, "M001", "S01");
+
+    const srcDir = join(base, "src");
+    mkdirSync(srcDir, { recursive: true });
+    writeFileSync(join(srcDir, "shared.ts"), "export const shared = true;");
+
+    // Same file referenced in two different task summaries
+    writeSummaryFile(tasksDir, "T01", { keyFiles: ["src/shared.ts"] });
+    writeSummaryFile(tasksDir, "T02", { keyFiles: ["src/shared.ts"] });
+
+    const result = collectSourceFilePaths(base, "M001", "S01");
+    const sharedMatches = result.filter(p => p.endsWith("src/shared.ts"));
+    assert.equal(sharedMatches.length, 1, "should deduplicate — same file appears once");
+  });
+
+  test("skips non-existent files", () => {
+    const base = createTempProject();
+    const tasksDir = setupGsdStructure(base, "M001", "S01");
+
+    writeSummaryFile(tasksDir, "T01", {
+      keyFiles: ["src/does-not-exist.ts"],
+    });
+
+    const result = collectSourceFilePaths(base, "M001", "S01");
+    assert.equal(result.length, 0, "should skip non-existent file");
+  });
+
+  test("skips binary file extensions", () => {
+    const base = createTempProject();
+    const tasksDir = setupGsdStructure(base, "M001", "S01");
+
+    const assetsDir = join(base, "assets");
+    mkdirSync(assetsDir, { recursive: true });
+    writeFileSync(join(assetsDir, "logo.png"), "fake png data");
+    writeFileSync(join(assetsDir, "font.woff2"), "fake font data");
+
+    writeSummaryFile(tasksDir, "T01", {
+      keyFiles: ["assets/logo.png", "assets/font.woff2"],
+    });
+
+    const result = collectSourceFilePaths(base, "M001", "S01");
+    assert.equal(result.length, 0, "should skip binary files");
+  });
+
+  test("skips files larger than 100KB", () => {
+    const base = createTempProject();
+    const tasksDir = setupGsdStructure(base, "M001", "S01");
+
+    const srcDir = join(base, "src");
+    mkdirSync(srcDir, { recursive: true });
+    // Write a file just over 100KB
+    writeFileSync(join(srcDir, "huge.ts"), "x".repeat(101 * 1024));
+
+    writeSummaryFile(tasksDir, "T01", {
+      keyFiles: ["src/huge.ts"],
+    });
+
+    const result = collectSourceFilePaths(base, "M001", "S01");
+    assert.equal(result.length, 0, "should skip oversized file");
+  });
+
+  test("rejects paths outside basePath", () => {
+    const base = createTempProject();
+    const tasksDir = setupGsdStructure(base, "M001", "S01");
+
+    // Create a file at an absolute path outside the project
+    const outside = createTempProject();
+    writeFileSync(join(outside, "secret.ts"), "export const s = 'x';");
+
+    writeSummaryFile(tasksDir, "T01", {
+      keyFiles: [join(outside, "secret.ts")],
+    });
+
+    const result = collectSourceFilePaths(base, "M001", "S01");
+    assert.equal(result.length, 0, "should reject paths outside basePath");
+  });
+
+  test("handles empty tasks directory gracefully", () => {
+    const base = createTempProject();
+    setupGsdStructure(base, "M001", "S01");
+    // No summary or plan files created
+
+    const result = collectSourceFilePaths(base, "M001", "S01");
+    assert.equal(result.length, 0, "should return empty for no task files");
+  });
+
+  test("handles missing tasks directory gracefully", () => {
+    const base = createTempProject();
+    // Don't create any .gsd structure
+
+    const result = collectSourceFilePaths(base, "M001", "S01");
+    assert.equal(result.length, 0, "should return empty when tasks dir doesn't exist");
+  });
+
+  test("handles summaries with empty key_files", () => {
+    const base = createTempProject();
+    const tasksDir = setupGsdStructure(base, "M001", "S01");
+
+    const content = [
+      "---",
+      "id: T01",
+      "parent: S01",
+      "milestone: M001",
+      "provides: []",
+      "key_files: []",
+      "key_decisions: []",
+      "patterns_established: []",
+      "observability_surfaces: []",
+      "duration: 10m",
+      "verification_result: passed",
+      "completed_at: 2026-01-01T00:00:00Z",
+      "blocker_discovered: false",
+      "---",
+      "",
+      "# T01: Empty",
+      "",
+      "**Nothing**",
+    ].join("\n");
+    writeFileSync(join(tasksDir, "T01-SUMMARY.md"), content);
+
+    const result = collectSourceFilePaths(base, "M001", "S01");
+    assert.equal(result.length, 0, "should handle empty key_files gracefully");
+  });
+
+  test("handles plan files with no output section", () => {
+    const base = createTempProject();
+    const tasksDir = setupGsdStructure(base, "M001", "S01");
+
+    const content = [
+      "---",
+      "estimated_steps: 5",
+      "---",
+      "",
+      "# T01: No Output",
+      "",
+      "## Description",
+      "",
+      "A task with no Expected Output section.",
+    ].join("\n");
+    writeFileSync(join(tasksDir, "T01-PLAN.md"), content);
+
+    const result = collectSourceFilePaths(base, "M001", "S01");
+    assert.equal(result.length, 0, "should handle missing output section");
+  });
+
+  test("collects from both summaries and plans combined", () => {
+    const base = createTempProject();
+    const tasksDir = setupGsdStructure(base, "M001", "S01");
+
+    const srcDir = join(base, "src");
+    mkdirSync(srcDir, { recursive: true });
+    writeFileSync(join(srcDir, "from-summary.ts"), "export const a = 1;");
+    writeFileSync(join(srcDir, "from-plan.ts"), "export const b = 2;");
+
+    writeSummaryFile(tasksDir, "T01", { keyFiles: ["src/from-summary.ts"] });
+    writePlanFile(tasksDir, "T02", { outputFiles: ["src/from-plan.ts"] });
+
+    const result = collectSourceFilePaths(base, "M001", "S01");
+    assert.ok(result.some(p => p.endsWith("from-summary.ts")), "should include summary file");
+    assert.ok(result.some(p => p.endsWith("from-plan.ts")), "should include plan file");
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// extractApiRoutes
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe("extractApiRoutes", () => {
+  test("matches Express app.get/post/put/delete/patch routes", () => {
+    const code = `
+app.get('/api/users', handler);
+app.post('/api/users', createUser);
+app.put('/api/users/:id', updateUser);
+app.delete('/api/users/:id', deleteUser);
+app.patch('/api/users/:id/status', patchStatus);
+`;
+    const signals = extractApiRoutes(code);
+    assert.equal(signals.length, 5, "should find 5 Express routes");
+    assert.ok(signals[0].testableAspect.includes("GET /api/users"), "first route is GET /api/users");
+    assert.ok(signals[1].testableAspect.includes("POST /api/users"), "second route is POST /api/users");
+  });
+
+  test("matches router.get/post patterns", () => {
+    const code = `
+const router = express.Router();
+router.get('/health', (req, res) => res.send('ok'));
+router.post('/submit', handleSubmit);
+`;
+    const signals = extractApiRoutes(code);
+    assert.equal(signals.length, 2, "should find 2 router routes");
+  });
+
+  test("matches Next.js route handlers", () => {
+    const code = `
+export async function GET(request: NextRequest) {
+  return NextResponse.json({ items });
+}
+
+export async function POST(request: NextRequest) {
+  const body = await request.json();
+  return NextResponse.json(created, { status: 201 });
+}
+`;
+    const signals = extractApiRoutes(code);
+    assert.equal(signals.length, 2, "should find 2 Next.js handlers");
+    assert.ok(signals[0].testableAspect.includes("Next.js GET"), "first is GET handler");
+    assert.ok(signals[1].testableAspect.includes("Next.js POST"), "second is POST handler");
+  });
+
+  test("returns empty for non-route code", () => {
+    const code = `
+export function helper() {
+  return "no routes here";
+}
+`;
+    const signals = extractApiRoutes(code);
+    assert.equal(signals.length, 0, "no routes in helper code");
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// extractReactComponents
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe("extractReactComponents", () => {
+  test("matches named exported components", () => {
+    const code = `
+export function UserProfile({ name, email }: Props) {
+  return <div>{name}</div>;
+}
+
+export const DashboardCard = ({ title }: CardProps) => {
+  return <div>{title}</div>;
+};
+`;
+    const signals = extractReactComponents(code);
+    const compSignals = signals.filter(s => s.testableAspect.includes("component"));
+    assert.ok(compSignals.length >= 2, "should find at least 2 components");
+    assert.ok(compSignals.some(s => s.testableAspect.includes("UserProfile")));
+    assert.ok(compSignals.some(s => s.testableAspect.includes("DashboardCard")));
+  });
+
+  test("matches export default function", () => {
+    const code = `
+export default function HomePage() {
+  return <main>Home</main>;
+}
+`;
+    const signals = extractReactComponents(code);
+    assert.ok(signals.some(s => s.testableAspect.includes("HomePage")), "should find default export component");
+  });
+
+  test("detects useState for interactive state", () => {
+    const code = `
+export function Counter() {
+  const [count, setCount] = useState(0);
+  const [name, setName] = useState<string>("");
+  return <div>{count}</div>;
+}
+`;
+    const signals = extractReactComponents(code);
+    const stateSignals = signals.filter(s => s.testableAspect.includes("State management"));
+    assert.ok(stateSignals.length >= 1, "should detect useState hooks");
+  });
+
+  test("returns empty for non-React code", () => {
+    const code = `
+export function calculateTotal(items: Item[]) {
+  return items.reduce((sum, item) => sum + item.price, 0);
+}
+`;
+    // calculateTotal is lowercase — should not match as component
+    const signals = extractReactComponents(code);
+    const compSignals = signals.filter(s => s.type === "react-component");
+    assert.equal(compSignals.length, 0, "lowercase functions should not be components");
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// extractValidation
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe("extractValidation", () => {
+  test("matches Zod schemas", () => {
+    const code = `
+const userSchema = z.object({
+  name: z.string().min(1),
+  email: z.string().email(),
+  age: z.number().min(0),
+});
+
+export const querySchema = z.string().uuid();
+`;
+    const signals = extractValidation(code);
+    assert.ok(signals.some(s => s.testableAspect.includes("userSchema")), "should find userSchema");
+    assert.ok(signals.some(s => s.testableAspect.includes("querySchema")), "should find querySchema");
+  });
+
+  test("matches manual validation checks", () => {
+    const code = `
+if (!name) throw new Error('Name is required');
+if (!email) return { error: 'Email is required' };
+if (!req.body) throw new BadRequestError('Missing body');
+`;
+    const signals = extractValidation(code);
+    assert.ok(signals.length >= 2, "should find manual validation checks");
+    assert.ok(signals.some(s => s.testableAspect.includes("name")), "should detect name check");
+    assert.ok(signals.some(s => s.testableAspect.includes("email")), "should detect email check");
+  });
+
+  test("returns empty for code without validation", () => {
+    const code = `
+export function greet(name: string) {
+  return \`Hello, \${name}!\`;
+}
+`;
+    const signals = extractValidation(code);
+    assert.equal(signals.length, 0, "no validation in simple function");
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// extractErrorHandlers
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe("extractErrorHandlers", () => {
+  test("matches error response patterns", () => {
+    const code = `
+res.status(404).json({ error: 'Not Found' });
+res.status(500).json({ error: 'Internal Server Error' });
+res.status(400).json({ error: 'Bad Request' });
+`;
+    const signals = extractErrorHandlers(code);
+    assert.ok(signals.length >= 3, "should find error response patterns");
+    assert.ok(signals.some(s => s.testableAspect.includes("404")), "should find 404");
+    assert.ok(signals.some(s => s.testableAspect.includes("500")), "should find 500");
+  });
+
+  test("matches catch blocks", () => {
+    const code = `
+try {
+  await doSomething();
+} catch (err) {
+  console.error(err);
+}
+`;
+    const signals = extractErrorHandlers(code);
+    assert.ok(signals.some(s => s.testableAspect.includes("catch err")), "should find catch block");
+  });
+
+  test("matches throw new Error", () => {
+    const code = `
+throw new Error('Connection timeout');
+throw new ValidationError('Invalid input format');
+`;
+    const signals = extractErrorHandlers(code);
+    assert.ok(signals.some(s => s.testableAspect.includes("Connection timeout")), "should find thrown Error");
+    assert.ok(signals.some(s => s.testableAspect.includes("ValidationError")), "should find thrown ValidationError");
+  });
+
+  test("returns empty for code without error handling", () => {
+    const code = `
+export const add = (a: number, b: number) => a + b;
+`;
+    const signals = extractErrorHandlers(code);
+    assert.equal(signals.length, 0, "no error handling in pure function");
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// extractCliCommands
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe("extractCliCommands", () => {
+  test("matches .command() registrations", () => {
+    const code = `
+program
+  .command('init')
+  .description('Initialize a new project')
+  .action(handleInit);
+
+program
+  .command('build')
+  .description('Build the project')
+  .action(handleBuild);
+`;
+    const signals = extractCliCommands(code);
+    assert.equal(signals.length, 2, "should find 2 CLI commands");
+    assert.ok(signals[0].testableAspect.includes("init"), "first command is init");
+    assert.ok(signals[1].testableAspect.includes("build"), "second command is build");
+  });
+
+  test("matches yargs-style commands", () => {
+    const code = `
+yargs.command('serve', 'Start the server', (yargs) => {
+  return yargs.option('port', { type: 'number', default: 3000 });
+});
+`;
+    const signals = extractCliCommands(code);
+    assert.ok(signals.some(s => s.testableAspect.includes("serve")), "should find yargs command");
+  });
+
+  test("returns empty for non-CLI code", () => {
+    const code = `
+export function processData(data: any[]) {
+  return data.map(item => item.value);
+}
+`;
+    const signals = extractCliCommands(code);
+    assert.equal(signals.length, 0, "no CLI commands in utility code");
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// extractExportedFunctions
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe("extractExportedFunctions", () => {
+  test("matches export function and export const", () => {
+    const code = `
+export function calculateTotal(items: Item[]) {
+  return items.reduce((sum, i) => sum + i.price, 0);
+}
+
+export const formatCurrency = (amount: number) => {
+  return '$' + amount.toFixed(2);
+};
+
+export async function fetchData(url: string) {
+  return fetch(url).then(r => r.json());
+}
+`;
+    const signals = extractExportedFunctions(code);
+    assert.ok(signals.some(s => s.testableAspect.includes("calculateTotal")), "should find calculateTotal");
+    assert.ok(signals.some(s => s.testableAspect.includes("formatCurrency")), "should find formatCurrency");
+    assert.ok(signals.some(s => s.testableAspect.includes("fetchData")), "should find fetchData");
+  });
+
+  test("skips PascalCase names (those are components)", () => {
+    const code = `
+export function MyComponent() {
+  return <div />;
+}
+export function helperFunction() {
+  return 42;
+}
+`;
+    const signals = extractExportedFunctions(code);
+    assert.ok(!signals.some(s => s.testableAspect.includes("MyComponent")), "should skip PascalCase");
+    assert.ok(signals.some(s => s.testableAspect.includes("helperFunction")), "should include camelCase");
+  });
+
+  test("returns empty for non-exported code", () => {
+    const code = `
+function internalHelper() {
+  return "not exported";
+}
+const privateFn = () => "also not exported";
+`;
+    const signals = extractExportedFunctions(code);
+    assert.equal(signals.length, 0, "non-exported functions should not match");
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// extractSignalsFromFile — combined extraction with cap
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe("extractSignalsFromFile", () => {
+  test("combines signals from multiple extractors", () => {
+    const code = `
+app.get('/api/users', handler);
+const userSchema = z.object({ name: z.string() });
+export function processUser(user: User) {
+  if (!user.name) throw new Error('Name required');
+}
+`;
+    const signals = extractSignalsFromFile("test.ts", code);
+    const types = new Set(signals.map(s => s.type));
+    assert.ok(types.has("api-route"), "should include route signals");
+    assert.ok(types.has("validation"), "should include validation signals");
+    assert.ok(types.has("exported-function"), "should include exported function signals");
+  });
+
+  test("caps signals at MAX_SIGNALS_PER_FILE (10)", () => {
+    // Generate code with many routes to exceed the cap
+    const routes = Array.from({ length: 15 }, (_, i) =>
+      `app.get('/api/resource${i}', handler${i});`
+    ).join("\n");
+    const signals = extractSignalsFromFile("many-routes.ts", routes);
+    assert.ok(signals.length <= 10, `should cap at 10 but got ${signals.length}`);
+  });
+
+  test("returns empty for code with zero signals", () => {
+    const code = `
+// Just a comment file
+const x = 1;
+let y = 2;
+`;
+    const signals = extractSignalsFromFile("empty.ts", code);
+    assert.equal(signals.length, 0, "no signals in trivial code");
+  });
+
+  test("deduplicates signals with identical context", () => {
+    // The same pattern matched by two different extractors shouldn't produce
+    // exact duplicates — but within a single extractor, the same regex hit is
+    // naturally deduplicated by our Set.
+    const code = `
+export function processItems(items: Item[]) {
+  return items;
+}
+`;
+    const signals = extractSignalsFromFile("dedup.ts", code);
+    const contexts = signals.map(s => `${s.type}:${s.context}`);
+    const unique = new Set(contexts);
+    assert.equal(contexts.length, unique.size, "no duplicate signals");
+  });
+
+  test("prioritizes routes over exports (routes come first)", () => {
+    const code = `
+app.get('/api/data', handler);
+export function getData() { return []; }
+`;
+    const signals = extractSignalsFromFile("priority.ts", code);
+    assert.ok(signals.length >= 2, "should have at least 2 signals");
+    assert.equal(signals[0].type, "api-route", "routes should come first");
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// synthesizeChecks
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe("synthesizeChecks", () => {
+  const defaultPlanContext: PlanContext = {
+    goal: "Users can create and manage their accounts",
+    taskTitles: ["T01: Build user API", "T02: Build user UI"],
+    verifyFields: ["POST /api/users returns 201"],
+  };
+
+  test("generates smoke check from plan goal", () => {
+    const signals: TestableSignal[] = [
+      { type: "api-route", context: "app.get('/api/users', handler)", testableAspect: "GET /api/users endpoint — verify request/response" },
+    ];
+    const checks = synthesizeChecks(signals, "S01", defaultPlanContext);
+    assert.ok(checks.length >= 1, "should produce checks");
+    const smoke = checks.find(c => c.category === "smoke");
+    assert.ok(smoke, "should have a smoke check");
+    assert.ok(smoke!.steps[0].includes("Users can create"), "smoke check references goal");
+    assert.equal(smoke!.preconditions, "(Auto-generated from code analysis)");
+  });
+
+  test("generates route checks with HTTP method and path", () => {
+    const signals: TestableSignal[] = [
+      { type: "api-route", context: "app.get('/api/users')", testableAspect: "GET /api/users endpoint — verify request/response" },
+      { type: "api-route", context: "app.post('/api/users')", testableAspect: "POST /api/users endpoint — verify request/response" },
+    ];
+    const checks = synthesizeChecks(signals, "S01", defaultPlanContext);
+    const routeChecks = checks.filter(c => c.name.includes("/api/users"));
+    assert.ok(routeChecks.length >= 2, "should produce checks for each route");
+    assert.ok(routeChecks.some(c => c.name.includes("GET")), "should include GET");
+    assert.ok(routeChecks.some(c => c.name.includes("POST")), "should include POST");
+    assert.ok(routeChecks[0].steps.some(s => s.includes("Send")), "steps should include HTTP action");
+  });
+
+  test("generates component checks with component name", () => {
+    const signals: TestableSignal[] = [
+      { type: "react-component", context: "export function UserProfile", testableAspect: "<UserProfile /> component — verify rendering and interactions" },
+    ];
+    const checks = synthesizeChecks(signals, "S01", defaultPlanContext);
+    const compChecks = checks.filter(c => c.name.includes("UserProfile"));
+    assert.ok(compChecks.length >= 1, "should produce component check");
+    assert.ok(compChecks[0].steps.some(s => s.includes("<UserProfile />")), "steps reference component name");
+  });
+
+  test("generates validation edge-case checks", () => {
+    const signals: TestableSignal[] = [
+      { type: "validation", context: "const userSchema = z.object(", testableAspect: "Zod schema 'userSchema' — verify valid input passes and invalid input is rejected" },
+    ];
+    const checks = synthesizeChecks(signals, "S01", defaultPlanContext);
+    const edgeCases = checks.filter(c => c.category === "edge-case");
+    assert.ok(edgeCases.length >= 1, "should produce edge-case check");
+    assert.ok(edgeCases[0].name.includes("userSchema"), "edge case references schema name");
+    assert.ok(edgeCases[0].steps.some(s => s.includes("userSchema")), "steps reference schema");
+  });
+
+  test("generates error handler edge-case checks", () => {
+    const signals: TestableSignal[] = [
+      { type: "error-handler", context: "res.status(404)", testableAspect: "Error response 404 — verify correct error status and message" },
+      { type: "error-handler", context: "throw new Error('Not found')", testableAspect: 'Throws Error: "Not found" — verify error is thrown under expected conditions' },
+    ];
+    const checks = synthesizeChecks(signals, "S01", defaultPlanContext);
+    const edgeCases = checks.filter(c => c.category === "edge-case");
+    assert.ok(edgeCases.length >= 2, "should produce edge cases for each error signal");
+    assert.ok(edgeCases.some(c => c.name.includes("404")), "should reference 404 status");
+    assert.ok(edgeCases.some(c => c.name.includes("Not found")), "should reference thrown error");
+  });
+
+  test("generates CLI command test-case checks", () => {
+    const signals: TestableSignal[] = [
+      { type: "cli-command", context: ".command('init')", testableAspect: "CLI command 'init' — verify command executes correctly with valid/invalid args" },
+    ];
+    const checks = synthesizeChecks(signals, "S01", defaultPlanContext);
+    const cliChecks = checks.filter(c => c.name.includes("init"));
+    assert.ok(cliChecks.length >= 1, "should produce CLI check");
+    assert.ok(cliChecks[0].steps.some(s => s.includes("init")), "steps reference command name");
+  });
+
+  test("generates exported function checks", () => {
+    const signals: TestableSignal[] = [
+      { type: "exported-function", context: "export function calculateTotal", testableAspect: "Exported function 'calculateTotal' — verify expected behavior with representative inputs" },
+    ];
+    const checks = synthesizeChecks(signals, "S01", defaultPlanContext);
+    const fnChecks = checks.filter(c => c.name.includes("calculateTotal"));
+    assert.ok(fnChecks.length >= 1, "should produce function check");
+    assert.ok(fnChecks[0].steps.some(s => s.includes("calculateTotal")), "steps reference function name");
+  });
+
+  test("caps total checks at 15", () => {
+    // Generate many signals to exceed the cap
+    const signals: TestableSignal[] = Array.from({ length: 20 }, (_, i) => ({
+      type: "api-route",
+      context: `app.get('/api/resource${i}')`,
+      testableAspect: `GET /api/resource${i} endpoint — verify request/response`,
+    }));
+    const checks = synthesizeChecks(signals, "S01", defaultPlanContext);
+    assert.ok(checks.length <= 15, `should cap at 15 but got ${checks.length}`);
+  });
+
+  test("returns empty for zero signals", () => {
+    const checks = synthesizeChecks([], "S01", defaultPlanContext);
+    assert.equal(checks.length, 0, "empty signals → empty checks");
+  });
+
+  test("handles signals with empty context strings", () => {
+    const signals: TestableSignal[] = [
+      { type: "api-route", context: "", testableAspect: "GET /api/empty endpoint — verify request/response" },
+    ];
+    // Should not crash
+    const checks = synthesizeChecks(signals, "S01", defaultPlanContext);
+    assert.ok(Array.isArray(checks), "should return array");
+  });
+
+  test("handles plan context with no goal", () => {
+    const signals: TestableSignal[] = [
+      { type: "api-route", context: "app.get('/test')", testableAspect: "GET /test endpoint — verify request/response" },
+    ];
+    const checks = synthesizeChecks(signals, "S01", { goal: "", taskTitles: [], verifyFields: [] });
+    // Should still produce route checks, just no smoke check
+    const smoke = checks.filter(c => c.category === "smoke");
+    assert.equal(smoke.length, 0, "no smoke check without goal");
+    assert.ok(checks.length >= 1, "should still produce route checks");
+  });
+
+  test("exactly 15 signals → no truncation needed", () => {
+    const signals: TestableSignal[] = Array.from({ length: 14 }, (_, i) => ({
+      type: "api-route",
+      context: `app.get('/api/item${i}')`,
+      testableAspect: `GET /api/item${i} endpoint — verify request/response`,
+    }));
+    // 14 routes + 1 smoke = 15
+    const checks = synthesizeChecks(signals, "S01", defaultPlanContext);
+    assert.ok(checks.length <= 15, "should be at or under 15");
+  });
+
+  test("sets correct categories: route/component as test-case, validation/error as edge-case", () => {
+    const signals: TestableSignal[] = [
+      { type: "api-route", context: "app.get('/test')", testableAspect: "GET /test endpoint — verify request/response" },
+      { type: "react-component", context: "export function App", testableAspect: "<App /> component — verify rendering and interactions" },
+      { type: "validation", context: "const s = z.object(", testableAspect: "Zod schema 's' — verify valid input passes and invalid input is rejected" },
+      { type: "error-handler", context: "res.status(500)", testableAspect: "Error response 500 — verify correct error status and message" },
+    ];
+    const checks = synthesizeChecks(signals, "S01", defaultPlanContext);
+    const routeCheck = checks.find(c => c.name.includes("GET /test"));
+    const compCheck = checks.find(c => c.name.includes("App"));
+    const valCheck = checks.find(c => c.category === "edge-case" && c.name.includes("s"));
+    const errCheck = checks.find(c => c.name.includes("500"));
+
+    assert.equal(routeCheck?.category, "test-case", "route is test-case");
+    assert.equal(compCheck?.category, "test-case", "component is test-case");
+    assert.equal(valCheck?.category, "edge-case", "validation is edge-case");
+    assert.equal(errCheck?.category, "edge-case", "error is edge-case");
+  });
+
+  test("generates Next.js handler checks", () => {
+    const signals: TestableSignal[] = [
+      { type: "api-route", context: "export async function POST(", testableAspect: "Next.js POST handler — verify request handling and response" },
+    ];
+    const checks = synthesizeChecks(signals, "S01", defaultPlanContext);
+    const nextChecks = checks.filter(c => c.name.includes("Next.js"));
+    assert.ok(nextChecks.length >= 1, "should produce Next.js handler check");
+  });
+
+  test("skips useState detail signals for components", () => {
+    const signals: TestableSignal[] = [
+      { type: "react-component", context: "export function Counter", testableAspect: "<Counter /> component — verify rendering and interactions" },
+      { type: "react-component", context: "useState(0)", testableAspect: "State management — verify state transitions with initial value: 0" },
+    ];
+    const checks = synthesizeChecks(signals, "S01", defaultPlanContext);
+    const compChecks = checks.filter(c => c.category === "test-case" && c.name.includes("Counter"));
+    assert.equal(compChecks.length, 1, "should produce 1 component check, not 2");
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// generateSmartChecks — end-to-end pipeline
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe("generateSmartChecks", () => {
+  afterEach(() => {
+    for (const dir of cleanupDirs) {
+      try { rmSync(dir, { recursive: true, force: true }); } catch {}
+    }
+    cleanupDirs = [];
+  });
+
+  test("end-to-end: produces enriched checks from source files with Express routes and Zod schemas", () => {
+    const base = createTempProject();
+    const tasksDir = setupGsdStructure(base, "M001", "S01");
+
+    // Create source files with known patterns
+    const srcDir = join(base, "src");
+    mkdirSync(srcDir, { recursive: true });
+
+    writeFileSync(join(srcDir, "api.ts"), `
+import express from 'express';
+const app = express();
+app.get('/api/users', (req, res) => res.json([]));
+app.post('/api/users', (req, res) => res.status(201).json(req.body));
+`);
+
+    writeFileSync(join(srcDir, "schema.ts"), `
+import { z } from 'zod';
+const userSchema = z.object({
+  name: z.string().min(1),
+  email: z.string().email(),
+});
+`);
+
+    // Create task summary referencing these files
+    writeSummaryFile(tasksDir, "T01", {
+      keyFiles: ["src/api.ts", "src/schema.ts"],
+    });
+
+    // Create a minimal slice plan
+    const sliceDir = join(base, ".gsd", "milestones", "M001", "slices", "S01");
+    writeFileSync(join(sliceDir, "S01-PLAN.md"), `---
+type: slice-plan
+---
+
+# S01: User Management
+
+**Goal:** Users can create and list user accounts via REST API
+
+## Tasks
+
+- [ ] **T01: Build user API** \`est:1h\`
+  - Verify: POST /api/users returns 201
+`);
+
+    const checks = generateSmartChecks(base, "M001", "S01");
+    assert.ok(checks.length >= 3, `should produce at least 3 checks (smoke + routes + validation) but got ${checks.length}`);
+
+    // Verify checks contain concrete code-derived details
+    const routeChecks = checks.filter(c => c.name.includes("/api/users"));
+    assert.ok(routeChecks.length >= 1, "should have route checks with /api/users path");
+
+    const smokeCheck = checks.find(c => c.category === "smoke");
+    assert.ok(smokeCheck, "should have a smoke check");
+    assert.ok(smokeCheck!.steps[0].includes("REST API"), "smoke check references plan goal");
+
+    // Should have auto-generated preconditions note
+    assert.ok(checks[0].preconditions.includes("Auto-generated"), "first check notes auto-generation");
+  });
+
+  test("returns empty array when no source files exist", () => {
+    const base = createTempProject();
+    const tasksDir = setupGsdStructure(base, "M001", "S01");
+
+    // Summary references non-existent file
+    writeSummaryFile(tasksDir, "T01", {
+      keyFiles: ["src/does-not-exist.ts"],
+    });
+
+    const checks = generateSmartChecks(base, "M001", "S01");
+    assert.equal(checks.length, 0, "no source files → empty checks");
+  });
+
+  test("returns empty array when source files have no signals", () => {
+    const base = createTempProject();
+    const tasksDir = setupGsdStructure(base, "M001", "S01");
+
+    const srcDir = join(base, "src");
+    mkdirSync(srcDir, { recursive: true });
+    writeFileSync(join(srcDir, "empty.ts"), "// just a comment\nconst x = 1;\n");
+
+    writeSummaryFile(tasksDir, "T01", { keyFiles: ["src/empty.ts"] });
+
+    const checks = generateSmartChecks(base, "M001", "S01");
+    assert.equal(checks.length, 0, "no signals → empty checks");
+  });
+
+  test("handles unreadable source file mid-pipeline gracefully", () => {
+    const base = createTempProject();
+    const tasksDir = setupGsdStructure(base, "M001", "S01");
+
+    const srcDir = join(base, "src");
+    mkdirSync(srcDir, { recursive: true });
+    // One good file, one directory (unreadable as file)
+    writeFileSync(join(srcDir, "good.ts"), "app.get('/api/health', handler);");
+    mkdirSync(join(srcDir, "bad.ts"), { recursive: true }); // directory, not file
+
+    writeSummaryFile(tasksDir, "T01", { keyFiles: ["src/good.ts", "src/bad.ts"] });
+
+    // Should still produce checks from the good file — statSync filters directories
+    // but collectSourceFilePaths checks isFile(), so bad.ts is filtered out
+    const checks = generateSmartChecks(base, "M001", "S01");
+    // Only "good.ts" is a real file, so we get at least one route check from it
+    assert.ok(checks.length >= 1, "should still produce checks from readable file");
+  });
+
+  test("reads plan context when slice plan exists", () => {
+    const base = createTempProject();
+    const tasksDir = setupGsdStructure(base, "M001", "S01");
+
+    const srcDir = join(base, "src");
+    mkdirSync(srcDir, { recursive: true });
+    writeFileSync(join(srcDir, "app.ts"), "app.get('/api/items', handler);");
+
+    writeSummaryFile(tasksDir, "T01", { keyFiles: ["src/app.ts"] });
+
+    const sliceDir = join(base, ".gsd", "milestones", "M001", "slices", "S01");
+    writeFileSync(join(sliceDir, "S01-PLAN.md"), `---
+type: slice-plan
+---
+
+# S01: Item Management
+
+**Goal:** Items can be listed and searched
+
+## Tasks
+
+- [ ] **T01: Build item API** \`est:1h\`
+  - Verify: GET /api/items returns 200
+`);
+
+    const checks = generateSmartChecks(base, "M001", "S01");
+    const smoke = checks.find(c => c.category === "smoke");
+    assert.ok(smoke, "should have smoke check from plan goal");
+    assert.ok(smoke!.steps[0].includes("Items can be listed"), "smoke check uses plan goal");
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// gatherChecksForSlice — fallback chain regression
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe("gatherChecksForSlice fallback chain", () => {
+  afterEach(() => {
+    for (const dir of cleanupDirs) {
+      try { rmSync(dir, { recursive: true, force: true }); } catch {}
+    }
+    cleanupDirs = [];
+  });
+
+  test("returns UAT checks when UAT file exists (regression)", () => {
+    const base = createTempProject();
+    const tasksDir = setupGsdStructure(base, "M001", "S01");
+
+    // Create UAT file
+    const sliceDir = join(base, ".gsd", "milestones", "M001", "slices", "S01");
+    writeFileSync(join(sliceDir, "S01-UAT.md"), `# UAT — S01
+
+## Smoke Test
+
+1. Open the app
+2. Verify the dashboard loads
+
+**Expected:** Dashboard renders with user data
+
+## Test Cases
+
+### 1. Login Flow
+
+1. Navigate to /login
+2. Enter valid credentials
+3. Click submit
+
+**Expected:** User is redirected to dashboard
+`);
+
+    // Also create source files (should be ignored because UAT exists)
+    const srcDir = join(base, "src");
+    mkdirSync(srcDir, { recursive: true });
+    writeFileSync(join(srcDir, "api.ts"), "app.get('/api/users', handler);");
+    writeSummaryFile(tasksDir, "T01", { keyFiles: ["src/api.ts"] });
+
+    const checks = gatherChecksForSlice(base, "M001", "S01");
+    assert.ok(checks.length >= 2, "should return UAT checks");
+    assert.ok(checks.some(c => c.name === "Smoke Test"), "should include smoke test from UAT");
+    assert.ok(checks.some(c => c.name === "Login Flow"), "should include test case from UAT");
+    // Should NOT have auto-generated note (these are from UAT)
+    assert.ok(!checks[0].preconditions.includes("Auto-generated from code analysis"), "UAT checks don't have auto-generated note");
+  });
+
+  test("returns smart checks when no UAT but source files exist", () => {
+    const base = createTempProject();
+    const tasksDir = setupGsdStructure(base, "M001", "S01");
+
+    // No UAT file — but create source files with signals
+    const srcDir = join(base, "src");
+    mkdirSync(srcDir, { recursive: true });
+    writeFileSync(join(srcDir, "api.ts"), `
+app.get('/api/products', handler);
+app.post('/api/products', createHandler);
+`);
+    writeSummaryFile(tasksDir, "T01", { keyFiles: ["src/api.ts"] });
+
+    // Create plan file
+    const sliceDir = join(base, ".gsd", "milestones", "M001", "slices", "S01");
+    writeFileSync(join(sliceDir, "S01-PLAN.md"), `---
+type: slice-plan
+---
+
+# S01: Product API
+
+**Goal:** Products can be created and listed
+
+## Tasks
+
+- [ ] **T01: Build product API** \`est:1h\`
+  - Verify: GET /api/products returns 200
+`);
+
+    const checks = gatherChecksForSlice(base, "M001", "S01");
+    assert.ok(checks.length >= 2, `should return smart checks but got ${checks.length}`);
+    // Should contain route-derived checks with specific paths
+    assert.ok(checks.some(c => c.name.includes("/api/products")), "should have route-specific checks");
+    assert.ok(checks[0].preconditions.includes("Auto-generated from code analysis"), "first check notes code analysis");
+  });
+
+  test("falls through to plan-text when no UAT and no source files with signals", () => {
+    const base = createTempProject();
+    const tasksDir = setupGsdStructure(base, "M001", "S01");
+
+    // No UAT, no source files — only a plan
+    const sliceDir = join(base, ".gsd", "milestones", "M001", "slices", "S01");
+    writeFileSync(join(sliceDir, "S01-PLAN.md"), `---
+type: slice-plan
+---
+
+# S01: Documentation Update
+
+**Goal:** All README files are up to date
+
+## Verification
+
+- All links in README.md are valid
+- API docs match current endpoints
+
+## Tasks
+
+- [ ] **T01: Update README** \`est:30m\`
+  - Verify: README contains current API endpoints
+`);
+
+    const checks = gatherChecksForSlice(base, "M001", "S01");
+    assert.ok(checks.length >= 1, "should return plan-text checks");
+    // Plan-text checks have different preconditions note
+    assert.ok(
+      checks[0].preconditions.includes("Auto-generated from slice plan"),
+      "plan-text checks note they're from plan"
+    );
+  });
+
+  test("falls through to plan-text when source files exist but have no signals", () => {
+    const base = createTempProject();
+    const tasksDir = setupGsdStructure(base, "M001", "S01");
+
+    // Source file with no testable signals
+    const srcDir = join(base, "src");
+    mkdirSync(srcDir, { recursive: true });
+    writeFileSync(join(srcDir, "config.ts"), "// just config\nconst x = 1;\nlet y = 2;\n");
+    writeSummaryFile(tasksDir, "T01", { keyFiles: ["src/config.ts"] });
+
+    const sliceDir = join(base, ".gsd", "milestones", "M001", "slices", "S01");
+    writeFileSync(join(sliceDir, "S01-PLAN.md"), `---
+type: slice-plan
+---
+
+# S01: Config Setup
+
+**Goal:** Configuration is centralized
+
+## Tasks
+
+- [ ] **T01: Setup config** \`est:15m\`
+  - Verify: Config loads without errors
+`);
+
+    const checks = gatherChecksForSlice(base, "M001", "S01");
+    assert.ok(checks.length >= 1, "should fall through to plan-text checks");
+    assert.ok(
+      checks[0].preconditions.includes("Auto-generated from slice plan"),
+      "should have plan-text preconditions note"
+    );
+  });
+});

--- a/src/resources/extensions/gsd/tests/md-importer.test.ts
+++ b/src/resources/extensions/gsd/tests/md-importer.test.ts
@@ -363,7 +363,7 @@ test('md-importer: schema v1→v2 migration', () => {
   openDatabase(':memory:');
   const adapter = _getAdapter();
   const version = adapter?.prepare('SELECT MAX(version) as v FROM schema_version').get();
-  assert.deepStrictEqual(version?.v, 14, 'new DB should be at schema version 14');
+  assert.deepStrictEqual(version?.v, 15, 'new DB should be at schema version 15');
 
   // Artifacts table should exist
   const tableCheck = adapter?.prepare("SELECT count(*) as c FROM sqlite_master WHERE type='table' AND name='artifacts'").get();

--- a/src/resources/extensions/gsd/tests/memory-store.test.ts
+++ b/src/resources/extensions/gsd/tests/memory-store.test.ts
@@ -323,9 +323,9 @@ test('memory-store: schema includes memories table', () => {
   const viewCount = adapter.prepare('SELECT count(*) as cnt FROM active_memories').get();
   assert.deepStrictEqual(viewCount?.['cnt'], 0, 'active_memories view should exist');
 
-  // Verify schema version is 14 (after indexes + slice_dependencies)
+  // Verify schema version is 15 (after manual_test_sessions)
   const version = adapter.prepare('SELECT MAX(version) as v FROM schema_version').get();
-  assert.deepStrictEqual(version?.['v'], 14, 'schema version should be 14');
+  assert.deepStrictEqual(version?.['v'], 15, 'schema version should be 15');
 
   closeDatabase();
 });

--- a/src/resources/extensions/gsd/tests/opportunistic-fix-dispatch.test.ts
+++ b/src/resources/extensions/gsd/tests/opportunistic-fix-dispatch.test.ts
@@ -1,0 +1,325 @@
+/**
+ * Tests for opportunistic fix dispatch — DB query, bridge function, and rule ordering.
+ *
+ * Covers:
+ * - gsd-db.ts: getOutstandingTestFailures (positive, negative, edge cases)
+ * - manual-test-db.ts: getOutstandingFailures (bridge → ManualTestSession)
+ * - auto-dispatch.ts: rule ordering for opportunistic-fix-manual-tests
+ */
+
+import { describe, test, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import {
+  openDatabase,
+  closeDatabase,
+  insertManualTestSession,
+  getOutstandingTestFailures,
+  _getAdapter,
+} from "../gsd-db.ts";
+import { getOutstandingFailures } from "../manual-test-db.ts";
+import { getDispatchRuleNames } from "../auto-dispatch.ts";
+import type { ManualTestCheck } from "../manual-test.ts";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Create a ManualTestCheck with sensible defaults. */
+function makeCheck(overrides: Partial<ManualTestCheck> & { id: string }): ManualTestCheck {
+  return {
+    name: overrides.id,
+    sliceId: "S01",
+    category: "test-case",
+    steps: ["Step 1"],
+    expected: "Works",
+    preconditions: "",
+    verdict: null,
+    notes: "",
+    timestamp: "",
+    ...overrides,
+  };
+}
+
+/** Insert a session with configurable status and failure counts. */
+function insertSession(opts: {
+  milestoneId: string;
+  sliceId?: string | null;
+  status?: string;
+  failed?: number;
+  passed?: number;
+  fixPrompt?: string | null;
+  checks?: ManualTestCheck[];
+}): number {
+  const checks = opts.checks ?? [makeCheck({ id: "TC01" })];
+  const failed = opts.failed ?? 0;
+  const passed = opts.passed ?? 0;
+  const total = checks.length;
+  const id = insertManualTestSession({
+    milestoneId: opts.milestoneId,
+    sliceId: opts.sliceId ?? "S01",
+    status: opts.status ?? "needs-fix",
+    startedAt: new Date().toISOString(),
+    completedAt: null,
+    totalChecks: total,
+    passed,
+    failed,
+    skipped: total - passed - failed,
+    resultsJson: JSON.stringify(checks),
+    snapshotJson: JSON.stringify({ phase: "test", milestoneProgress: "1/3", slicesComplete: [] }),
+  });
+
+  // If fixPrompt is explicitly provided, set it via raw SQL
+  if (opts.fixPrompt !== undefined && opts.fixPrompt !== null) {
+    const adapter = _getAdapter()!;
+    adapter.prepare("UPDATE manual_test_sessions SET fix_prompt = :prompt WHERE id = :id").run({
+      ":prompt": opts.fixPrompt,
+      ":id": id,
+    });
+  }
+
+  return id;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Group 1: DB Query — getOutstandingTestFailures
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe("getOutstandingTestFailures", () => {
+  beforeEach(() => {
+    openDatabase(":memory:");
+  });
+  afterEach(() => {
+    closeDatabase();
+  });
+
+  test("returns row when session has failed > 0 and fix_prompt IS NULL", () => {
+    const checks = [
+      makeCheck({ id: "TC01", verdict: "pass" }),
+      makeCheck({ id: "TC02", verdict: "fail" }),
+    ];
+    insertSession({ milestoneId: "M001", failed: 1, passed: 1, checks });
+
+    const row = getOutstandingTestFailures("M001");
+    assert.ok(row, "should find a row with outstanding failures");
+    assert.equal(row!.milestone_id, "M001");
+    assert.equal(row!.failed, 1);
+    assert.equal(row!.fix_prompt, null);
+  });
+
+  test("returns null when no sessions exist", () => {
+    const row = getOutstandingTestFailures("M001");
+    assert.equal(row, null, "empty DB should return null");
+  });
+
+  test("returns null when session has failed = 0", () => {
+    const checks = [makeCheck({ id: "TC01", verdict: "pass" })];
+    insertSession({ milestoneId: "M001", failed: 0, passed: 1, checks });
+
+    const row = getOutstandingTestFailures("M001");
+    assert.equal(row, null, "zero failures should return null");
+  });
+
+  test("returns null when session has fix_prompt already set", () => {
+    const checks = [makeCheck({ id: "TC01", verdict: "fail" })];
+    insertSession({
+      milestoneId: "M001",
+      failed: 1,
+      passed: 0,
+      checks,
+      fixPrompt: "Please fix the failing tests",
+    });
+
+    const row = getOutstandingTestFailures("M001");
+    assert.equal(row, null, "session with fix_prompt set should be excluded");
+  });
+
+  test("returns latest session when multiple exist (ORDER BY id DESC)", () => {
+    const oldChecks = [makeCheck({ id: "TC01", verdict: "fail" })];
+    insertSession({ milestoneId: "M001", failed: 1, checks: oldChecks });
+
+    const newChecks = [
+      makeCheck({ id: "TC01", verdict: "fail" }),
+      makeCheck({ id: "TC02", verdict: "fail" }),
+    ];
+    const newId = insertSession({ milestoneId: "M001", failed: 2, checks: newChecks });
+
+    const row = getOutstandingTestFailures("M001");
+    assert.ok(row, "should return a row");
+    assert.equal(row!.id, newId, "should return the latest session (highest id)");
+    assert.equal(row!.failed, 2);
+  });
+
+  test("cross-milestone isolation — session in M002 not returned for M001", () => {
+    const checks = [makeCheck({ id: "TC01", verdict: "fail" })];
+    insertSession({ milestoneId: "M002", failed: 1, checks });
+
+    const row = getOutstandingTestFailures("M001");
+    assert.equal(row, null, "M002 session should not appear for M001 query");
+  });
+
+  test("returns null when DB is not open", () => {
+    closeDatabase();
+    const row = getOutstandingTestFailures("M001");
+    assert.equal(row, null, "closed DB should return null");
+    // Re-open for afterEach cleanup
+    openDatabase(":memory:");
+  });
+
+  test("session with failed > 0 but complete status is excluded (prevents dispatch loop)", () => {
+    // Sessions marked complete (e.g., user chose "Accept as-is") must not trigger
+    // opportunistic dispatch — the status filter prevents infinite dispatch loops
+    const checks = [makeCheck({ id: "TC01", verdict: "fail" })];
+    insertSession({ milestoneId: "M001", status: "complete", failed: 1, checks });
+
+    const row = getOutstandingTestFailures("M001");
+    assert.equal(row, null, "complete session with failures should NOT be returned");
+  });
+
+  test("session with needs-fix status and failures is returned", () => {
+    const checks = [makeCheck({ id: "TC01", verdict: "fail" })];
+    insertSession({ milestoneId: "M001", status: "needs-fix", failed: 1, checks });
+
+    const row = getOutstandingTestFailures("M001");
+    assert.ok(row, "needs-fix session with failures should be returned");
+    assert.equal(row!.failed, 1);
+  });
+
+  test("session with in-progress status and failures is returned", () => {
+    const checks = [makeCheck({ id: "TC01", verdict: "fail" })];
+    insertSession({ milestoneId: "M001", status: "in-progress", failed: 1, checks });
+
+    const row = getOutstandingTestFailures("M001");
+    assert.ok(row, "in-progress session with failures should be returned");
+    assert.equal(row!.failed, 1);
+  });
+
+  test("skips sessions where all checks passed even if total is high", () => {
+    const checks = [
+      makeCheck({ id: "TC01", verdict: "pass" }),
+      makeCheck({ id: "TC02", verdict: "pass" }),
+      makeCheck({ id: "TC03", verdict: "pass" }),
+    ];
+    insertSession({ milestoneId: "M001", failed: 0, passed: 3, checks });
+
+    const row = getOutstandingTestFailures("M001");
+    assert.equal(row, null, "all-passing session should return null");
+  });
+
+  test("results_json is correctly stored and retrievable", () => {
+    const checks = [
+      makeCheck({ id: "TC01", verdict: "fail", notes: "Login broken" }),
+      makeCheck({ id: "TC02", verdict: "pass" }),
+    ];
+    insertSession({ milestoneId: "M001", failed: 1, passed: 1, checks });
+
+    const row = getOutstandingTestFailures("M001");
+    assert.ok(row);
+    const parsed = JSON.parse(row!.results_json!);
+    assert.equal(parsed.length, 2);
+    assert.equal(parsed[0].verdict, "fail");
+    assert.equal(parsed[0].notes, "Login broken");
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Group 2: Bridge Function — getOutstandingFailures
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe("getOutstandingFailures", () => {
+  beforeEach(() => {
+    openDatabase(":memory:");
+  });
+  afterEach(() => {
+    closeDatabase();
+  });
+
+  test("returns ManualTestSession with parsed checks when outstanding failures exist", () => {
+    const checks = [
+      makeCheck({ id: "TC01", verdict: "fail", notes: "Broken button" }),
+      makeCheck({ id: "TC02", verdict: "pass" }),
+    ];
+    insertSession({ milestoneId: "M001", failed: 1, passed: 1, checks });
+
+    const session = getOutstandingFailures("M001");
+    assert.ok(session, "should return a ManualTestSession");
+    assert.equal(session!.milestoneId, "M001");
+    assert.equal(session!.sliceId, "S01");
+    assert.ok(Array.isArray(session!.checks), "checks should be an array");
+    assert.equal(session!.checks.length, 2);
+    assert.equal(session!.checks[0].verdict, "fail");
+    assert.equal(session!.checks[0].notes, "Broken button");
+    assert.equal(session!.checks[1].verdict, "pass");
+    assert.ok(session!.id, "session should have a numeric id");
+    assert.ok(session!.startedAt, "session should have startedAt");
+  });
+
+  test("returns null when no outstanding failures exist", () => {
+    const checks = [makeCheck({ id: "TC01", verdict: "pass" })];
+    insertSession({ milestoneId: "M001", failed: 0, passed: 1, checks });
+
+    const session = getOutstandingFailures("M001");
+    assert.equal(session, null, "no failures → null");
+  });
+
+  test("returns null when fix_prompt already set", () => {
+    const checks = [makeCheck({ id: "TC01", verdict: "fail" })];
+    insertSession({
+      milestoneId: "M001",
+      failed: 1,
+      checks,
+      fixPrompt: "Fix these tests",
+    });
+
+    const session = getOutstandingFailures("M001");
+    assert.equal(session, null, "fix_prompt set → already dispatched → null");
+  });
+
+  test("returns null when DB is not open", () => {
+    closeDatabase();
+    const session = getOutstandingFailures("M001");
+    assert.equal(session, null, "closed DB → null via isDbAvailable guard");
+    openDatabase(":memory:");
+  });
+
+  test("snapshot fields are parsed from snapshot_json", () => {
+    const checks = [makeCheck({ id: "TC01", verdict: "fail" })];
+    insertSession({ milestoneId: "M001", failed: 1, checks });
+
+    const session = getOutstandingFailures("M001");
+    assert.ok(session);
+    assert.ok(session!.snapshot, "snapshot should be present");
+    assert.equal(session!.snapshot.phase, "test");
+    assert.equal(session!.snapshot.milestoneProgress, "1/3");
+    assert.deepEqual(session!.snapshot.slicesComplete, []);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Group 3: Dispatch Rule Ordering
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe("dispatch rule ordering", () => {
+  test("getDispatchRuleNames contains opportunistic-fix-manual-tests rule", () => {
+    const names = getDispatchRuleNames();
+    const hasRule = names.some((n) => n.includes("opportunistic-fix-manual-tests"));
+    assert.ok(hasRule, `rule list should contain opportunistic-fix-manual-tests, got: ${names.join(", ")}`);
+  });
+
+  test("opportunistic rule appears after fix-manual-tests and before summarizing → complete-slice", () => {
+    const names = getDispatchRuleNames();
+    const fixIdx = names.findIndex((n) => n.includes("fix-manual-tests") && !n.includes("opportunistic"));
+    const oppIdx = names.findIndex((n) => n.includes("opportunistic-fix-manual-tests"));
+    const summIdx = names.findIndex((n) => n.includes("summarizing → complete-slice"));
+
+    assert.ok(fixIdx >= 0, "fix-manual-tests rule should exist");
+    assert.ok(oppIdx >= 0, "opportunistic-fix-manual-tests rule should exist");
+    assert.ok(summIdx >= 0, "summarizing → complete-slice rule should exist");
+
+    assert.ok(
+      oppIdx > fixIdx,
+      `opportunistic (idx ${oppIdx}) should come after fix-manual-tests (idx ${fixIdx})`,
+    );
+    assert.ok(
+      oppIdx < summIdx,
+      `opportunistic (idx ${oppIdx}) should come before summarizing → complete-slice (idx ${summIdx})`,
+    );
+  });
+});


### PR DESCRIPTION
## TL;DR

**What:** Adds `/gsd test` interactive manual testing with smart code-aware test generation, crash-safe verdict persistence, session resume, and auto-mode opportunistic fix dispatch.
**Why:** Test cases were shallow (reformatted UAT bullets), verdicts were lost on crash, and failures required manual "fix now" selection.
**How:** Three-tier check generation pipeline (UAT → source code analysis → plan-text), pre-insert + callback pattern for instant DB persistence, mergeChecks for resume, and a new dispatch rule at natural stopping points.

## What

Adds the `/gsd test` command — an interactive manual test runner with four connected capabilities:

- **Smart test case generation** (`manual-test.ts`) — `collectSourceFilePaths` reads task summaries/plans to discover referenced source files. Six regex-based signal extractors (`extractApiRoutes`, `extractReactComponents`, `extractValidation`, `extractErrorHandlers`, `extractCliCommands`, `extractExportedFunctions`) identify testable patterns. `synthesizeChecks` converts signals into concrete `ManualTestCheck` objects with specific HTTP methods/paths, component names, and expected behaviors. Wired into `gatherChecksForSlice` as the middle tier of a three-tier fallback (UAT → smart → plan-text). Capped at 15 checks per slice.

- **Incremental verdict persistence** (`commands-manual-test.ts`, `gsd-db.ts`) — Session row pre-inserted before TUI launch. `onVerdictRecorded` callback fires inside `recordVerdict()` and `finishSession()`, calling `updateManualTestSessionResults` to persist the full check state after each action. Crash or Ctrl+C preserves all recorded work.

- **Session resume** (`commands-manual-test.ts`) — `getInProgressSession` detects interrupted sessions. `mergeChecks` transfers persisted verdicts onto freshly-generated checks by `check.id` (handles added/removed/reordered checks). `startIndex` advances to the first unjudged check. Reuses existing DB row ID.

- **Opportunistic fix dispatch** (`auto-dispatch.ts`, `gsd-db.ts`) — `getOutstandingTestFailures` finds sessions with `failed > 0 AND fix_prompt IS NULL AND status IN ('needs-fix', 'in-progress')`. New `opportunistic-fix-manual-tests` dispatch rule fires at `summarizing`, `validating-milestone`, and `completing-milestone` phases. `setPendingManualTestFix` sets `fix_prompt` before dispatch to prevent re-fire.

### New files
- `src/resources/extensions/gsd/manual-test.ts` — core logic, UAT parsing, smart signal extraction pipeline, check synthesis
- `src/resources/extensions/gsd/manual-test-ui.ts` — TUI overlay with `onVerdictRecorded` callback and `startIndex` support
- `src/resources/extensions/gsd/manual-test-db.ts` — DB persistence layer, incremental update, resume queries
- `src/resources/extensions/gsd/commands-manual-test.ts` — command handler with pre-insert, resume detection, mergeChecks
- `src/resources/extensions/gsd/tests/manual-test-smart-gen.test.ts` — 63 tests
- `src/resources/extensions/gsd/tests/manual-test-persistence.test.ts` — 21 tests
- `src/resources/extensions/gsd/tests/opportunistic-fix-dispatch.test.ts` — 19 tests

### Modified files
- `gsd-db.ts` — schema v15, `manual_test_sessions` table, session CRUD, incremental updates, outstanding failure queries
- `auto-dispatch.ts` — `fix-manual-tests` + `opportunistic-fix-manual-tests` dispatch rules
- `commands/catalog.ts` — registered `test` command + tab completions
- `commands/handlers/core.ts` — help text entry
- `commands/handlers/ops.ts` — `test` command routing
- `auto-dashboard.ts` — display label for `fix-manual-tests`
- `complexity-classifier.ts` — `fix-manual-tests` → standard tier
- `preferences-models.ts` — `fix-manual-tests` → execution model tier
- `preferences-types.ts` — added to `KNOWN_UNIT_TYPES`
- `docs/commands.md` — Manual Testing section with smart generation, persistence, resume, opportunistic dispatch
- `docs/auto-mode.md` — manual testing subsection
- `mintlify-docs/guides/commands.mdx` — manual testing section
- `mintlify-docs/guides/auto-mode.mdx` — manual testing reference

## Why

Three gaps in the existing `/gsd test` flow:

1. **Shallow test cases** — reformatted UAT bullets and plan text, not derived from actual code. Human testers got vague instructions like "Verify: Goal verification" instead of "POST `/api/users` with `{name: "test"}` → expect 201."
2. **Lost verdicts on crash** — sessions only saved on `finishSession()`. Process crash mid-session lost all recorded work.
3. **Manual fix trigger only** — test failures only got fixed when the user explicitly picked "fix now" in the post-test picker. No automatic detection at natural stopping points.

## How

- **Signal extraction**: Regex-based heuristics (not AST) — prioritized as routes > validation > error handlers > components > CLI > exports. 10-signal-per-file cap, 15-check-per-slice cap with 60/40 test-case/edge-case allocation.
- **Persistence**: Pre-insert session row before TUI launch → `onVerdictRecorded` callback on each verdict → single `UPDATE` by row ID. Non-blocking (SQLite single-row UPDATE is < 1ms). Errors logged to stderr (not silently swallowed).
- **Resume**: Fresh checks are canonical (determines ordering). Persisted verdicts transfer by `check.id`. New checks get null verdicts, removed checks dropped.
- **Dispatch**: Rule positioned between `fix-manual-tests` and `summarizing → complete-slice`. Dynamic imports consistent with existing dispatch patterns. Anti-refire via `fix_prompt IS NULL` WHERE clause + `status IN ('needs-fix', 'in-progress')` filter to prevent dispatch loops on accepted sessions.
- **Milestone dir lookup**: `findMilestoneDir` uses exact match or `milestoneId + "-"` prefix to prevent `M00` matching `M001-abc`.

## Change type

- [x] `feat` — New feature or capability
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [x] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] New/updated tests included
- [x] 103 tests pass (63 smart-gen + 21 persistence + 19 dispatch), 0 failures
- [x] TypeScript compiles clean (`tsc --noEmit`)
- [ ] Manual testing — steps:
  - Run `/gsd test` in a project with completed slices — TUI shows code-aware checks
  - Press P/F/S to record verdicts; F prompts for notes
  - Quit with Q or Ctrl+C — re-run `/gsd test` → resumes from first unjudged check
  - After failures, "Fix now" creates `fix-manual-tests` dispatch unit
  - `/gsd test results` shows last session summary
  - `/gsd test S01` targets a specific slice
  - Schema migration to v15 runs cleanly on existing databases

## AI disclosure

- [x] This PR includes AI-assisted code — built with Claude Code, all code verified by 103 passing tests and TypeScript compilation
