### PR TITLE
feat(web): add custom openai-compatible onboarding

### DIFF
--- a/packages/pi-ai/src/web-runtime-env-api-keys.ts
+++ b/packages/pi-ai/src/web-runtime-env-api-keys.ts
@@ -72,6 +72,7 @@ export function getEnvApiKey(provider: string): string | undefined {
     "vercel-ai-gateway": "AI_GATEWAY_API_KEY",
     zai: "ZAI_API_KEY",
     mistral: "MISTRAL_API_KEY",
+    "custom-openai": "CUSTOM_OPENAI_API_KEY",
     minimax: "MINIMAX_API_KEY",
     "minimax-cn": "MINIMAX_CN_API_KEY",
     huggingface: "HF_TOKEN",

--- a/src/custom-openai-config.ts
+++ b/src/custom-openai-config.ts
@@ -1,0 +1,104 @@
+import { existsSync, readFileSync } from "node:fs"
+import { join } from "node:path"
+
+import { ModelsJsonWriter } from "../packages/pi-coding-agent/src/core/models-json-writer.ts"
+
+import { agentDir } from "./app-paths.js"
+import { resolveModelsJsonPath } from "./models-resolver.js"
+
+export const CUSTOM_OPENAI_PROVIDER_ID = "custom-openai"
+export const CUSTOM_OPENAI_ENV_VAR = "CUSTOM_OPENAI_API_KEY"
+export const CUSTOM_OPENAI_PROVIDER_LABEL = "Custom (OpenAI-compatible)"
+
+export interface CustomOpenAIProviderInput {
+  baseUrl: string
+  apiKey: string
+  modelId: string
+}
+
+interface CustomOpenAICredentialStore {
+  set(provider: string, credential: { type: "api_key"; key: string }): void
+}
+
+type ProviderConfigRecord = {
+  providers?: Record<string, unknown>
+}
+
+export function normalizeCustomOpenAIProviderInput(input: CustomOpenAIProviderInput): CustomOpenAIProviderInput {
+  const baseUrl = input.baseUrl.trim()
+  const apiKey = input.apiKey.trim()
+  const modelId = input.modelId.trim()
+
+  if (!baseUrl) {
+    throw new Error("Base URL is required")
+  }
+  try {
+    new URL(baseUrl)
+  } catch {
+    throw new Error("Base URL must be a valid URL")
+  }
+  if (!apiKey) {
+    throw new Error("API key is required")
+  }
+  if (!modelId) {
+    throw new Error("Model ID is required")
+  }
+
+  return { baseUrl, apiKey, modelId }
+}
+
+export function getCustomOpenAIModelsJsonPath(): string {
+  return join(agentDir, "models.json")
+}
+
+export function buildCustomOpenAIProviderConfig(input: Pick<CustomOpenAIProviderInput, "baseUrl" | "modelId">) {
+  return {
+    baseUrl: input.baseUrl,
+    apiKey: `env:${CUSTOM_OPENAI_ENV_VAR}`,
+    api: "openai-completions",
+    models: [
+      {
+        id: input.modelId,
+        name: input.modelId,
+        reasoning: false,
+        input: ["text"],
+        contextWindow: 128000,
+        maxTokens: 16384,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      },
+    ],
+  }
+}
+
+export function saveCustomOpenAIProviderConfig(
+  authStorage: CustomOpenAICredentialStore,
+  input: CustomOpenAIProviderInput,
+  modelsJsonPath = getCustomOpenAIModelsJsonPath(),
+): CustomOpenAIProviderInput {
+  const normalized = normalizeCustomOpenAIProviderInput(input)
+  authStorage.set(CUSTOM_OPENAI_PROVIDER_ID, { type: "api_key", key: normalized.apiKey })
+
+  const writer = new ModelsJsonWriter(modelsJsonPath)
+  writer.setProvider(CUSTOM_OPENAI_PROVIDER_ID, buildCustomOpenAIProviderConfig(normalized))
+
+  process.env[CUSTOM_OPENAI_ENV_VAR] = normalized.apiKey
+  return normalized
+}
+
+export function removeCustomOpenAIProviderConfig(modelsJsonPath = getCustomOpenAIModelsJsonPath()): void {
+  const writer = new ModelsJsonWriter(modelsJsonPath)
+  writer.removeProvider(CUSTOM_OPENAI_PROVIDER_ID)
+}
+
+export function hasCustomOpenAIProviderConfig(modelsJsonPath = resolveModelsJsonPath()): boolean {
+  if (!existsSync(modelsJsonPath)) {
+    return false
+  }
+
+  try {
+    const parsed = JSON.parse(readFileSync(modelsJsonPath, "utf-8")) as ProviderConfigRecord
+    return typeof parsed.providers === "object" && parsed.providers !== null && CUSTOM_OPENAI_PROVIDER_ID in parsed.providers
+  } catch {
+    return false
+  }
+}

--- a/src/custom-openai-config.ts
+++ b/src/custom-openai-config.ts
@@ -24,6 +24,18 @@ type ProviderConfigRecord = {
   providers?: Record<string, unknown>
 }
 
+interface CustomOpenAIProviderConfigRecord {
+  baseUrl?: unknown
+  models?: Array<{
+    id?: unknown
+  }>
+}
+
+export interface CustomOpenAIProviderSnapshot {
+  baseUrl: string
+  modelId: string
+}
+
 export function normalizeCustomOpenAIProviderInput(input: CustomOpenAIProviderInput): CustomOpenAIProviderInput {
   const baseUrl = input.baseUrl.trim()
   const apiKey = input.apiKey.trim()
@@ -91,14 +103,35 @@ export function removeCustomOpenAIProviderConfig(modelsJsonPath = getCustomOpenA
 }
 
 export function hasCustomOpenAIProviderConfig(modelsJsonPath = resolveModelsJsonPath()): boolean {
+  return getCustomOpenAIProviderSnapshot(modelsJsonPath) !== null
+}
+
+export function getCustomOpenAIProviderSnapshot(
+  modelsJsonPath = resolveModelsJsonPath(),
+): CustomOpenAIProviderSnapshot | null {
   if (!existsSync(modelsJsonPath)) {
-    return false
+    return null
   }
 
   try {
     const parsed = JSON.parse(readFileSync(modelsJsonPath, "utf-8")) as ProviderConfigRecord
-    return typeof parsed.providers === "object" && parsed.providers !== null && CUSTOM_OPENAI_PROVIDER_ID in parsed.providers
+    if (typeof parsed.providers !== "object" || parsed.providers === null) {
+      return null
+    }
+
+    const provider = parsed.providers[CUSTOM_OPENAI_PROVIDER_ID] as CustomOpenAIProviderConfigRecord | undefined
+    if (!provider || typeof provider !== "object") {
+      return null
+    }
+
+    const baseUrl = typeof provider.baseUrl === "string" ? provider.baseUrl.trim() : ""
+    const modelId = typeof provider.models?.[0]?.id === "string" ? provider.models[0].id.trim() : ""
+    if (!baseUrl || !modelId) {
+      return null
+    }
+
+    return { baseUrl, modelId }
   } catch {
-    return false
+    return null
   }
 }

--- a/src/onboarding.ts
+++ b/src/onboarding.ts
@@ -11,11 +11,9 @@
  */
 
 import { execFile } from 'node:child_process'
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
-import { dirname, join } from 'node:path'
 import type { AuthStorage } from '@gsd/pi-coding-agent'
 import { renderLogo } from './logo.js'
-import { agentDir } from './app-paths.js'
+import { getCustomOpenAIModelsJsonPath, saveCustomOpenAIProviderConfig } from './custom-openai-config.js'
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -488,53 +486,15 @@ async function runCustomOpenAIFlow(
   if (p.isCancel(modelId) || !modelId) return false
   const trimmedModelId = (modelId as string).trim()
 
-  // Save API key to auth storage
-  authStorage.set('custom-openai', { type: 'api_key', key: trimmedKey })
-
-  // Write or merge into models.json
-  const modelsJsonPath = join(agentDir, 'models.json')
-  let config: { providers: Record<string, any> } = { providers: {} }
-
-  if (existsSync(modelsJsonPath)) {
-    try {
-      config = JSON.parse(readFileSync(modelsJsonPath, 'utf-8'))
-      if (!config.providers) config.providers = {}
-    } catch {
-      // If existing file is corrupt, start fresh
-      config = { providers: {} }
-    }
-  }
-
-  config.providers['custom-openai'] = {
+  saveCustomOpenAIProviderConfig(authStorage, {
     baseUrl: trimmedUrl,
-    apiKey: `env:CUSTOM_OPENAI_API_KEY`,
-    api: 'openai-completions',
-    models: [
-      {
-        id: trimmedModelId,
-        name: trimmedModelId,
-        reasoning: false,
-        input: ['text'],
-        contextWindow: 128000,
-        maxTokens: 16384,
-        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-      },
-    ],
-  }
-
-  // Ensure parent directory exists
-  const dir = dirname(modelsJsonPath)
-  if (!existsSync(dir)) {
-    mkdirSync(dir, { recursive: true })
-  }
-  writeFileSync(modelsJsonPath, JSON.stringify(config, null, 2), 'utf-8')
-
-  // Also set env var so the current session picks up the key via fallback resolver
-  process.env.CUSTOM_OPENAI_API_KEY = trimmedKey
+    apiKey: trimmedKey,
+    modelId: trimmedModelId,
+  })
 
   p.log.success(`Custom endpoint saved: ${pc.green(trimmedUrl)}`)
   p.log.info(`Model: ${pc.cyan(trimmedModelId)}`)
-  p.log.info(`Config written to ${pc.dim(modelsJsonPath)}`)
+  p.log.info(`Config written to ${pc.dim(getCustomOpenAIModelsJsonPath())}`)
   return true
 }
 
@@ -936,4 +896,3 @@ async function runDiscordChannelStep(p: ClackModule, pc: PicoModule, token: stri
   p.log.success(`Discord channel: ${pc.green(channelName ? `#${channelName}` : channelId)}`)
   return channelName ?? null
 }
-

--- a/src/tests/integration/web-mode-onboarding.test.ts
+++ b/src/tests/integration/web-mode-onboarding.test.ts
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { EventEmitter } from "node:events";
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { PassThrough } from "node:stream";
@@ -506,4 +506,75 @@ test("fresh gsd --web browser onboarding stays locked on failed validation and u
   const bootAfterPayload = await bootAfter.json() as any
   assert.equal(bootAfterPayload.onboarding.locked, false)
   assert.equal(bootAfterPayload.onboarding.lockReason, null)
+})
+
+test("fresh gsd --web browser onboarding can unlock through save_custom_provider for custom-openai", async (t) => {
+  if (process.platform === "win32") {
+    t.skip("runtime launch test uses POSIX browser-open stubs")
+    return
+  }
+
+  const tempRoot = mkdtempSync(join(tmpdir(), "gsd-web-onboarding-custom-openai-"))
+  const tempHome = join(tempRoot, "home")
+  const browserLogPath = join(tempRoot, "browser-open.log")
+  const expectedModelsPath = join(tempHome, ".gsd", "agent", "models.json")
+  let port: number | null = null
+
+  t.after(async () => {
+    if (port !== null) {
+      await killProcessOnPort(port)
+    }
+    rmSync(tempRoot, { recursive: true, force: true })
+  })
+
+  const launch = await launchPackagedWebHost({
+    launchCwd: repoRoot,
+    tempHome,
+    browserLogPath,
+    env: {
+      GSD_WEB_TEST_FAKE_API_KEY_VALIDATION: "1",
+      ANTHROPIC_API_KEY: "",
+      OPENAI_API_KEY: "",
+      GOOGLE_API_KEY: "",
+      CUSTOM_OPENAI_API_KEY: "",
+    },
+  })
+  port = launch.port
+
+  assert.equal(launch.exitCode, 0, `expected the web launcher to exit cleanly:\n${launch.stderr}`)
+  const auth = runtimeAuthHeaders(launch)
+  await waitForHttpOk(`${launch.url}/api/boot`, undefined, auth)
+
+  const saveResponse = await fetch(`${launch.url}/api/onboarding`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Accept: "application/json", ...auth },
+    body: JSON.stringify({
+      action: "save_custom_provider",
+      providerId: "custom-openai",
+      baseUrl: "https://proxy.example.com/v1",
+      apiKey: "sk-custom-runtime",
+      modelId: "gpt-4o-mini",
+    }),
+    signal: AbortSignal.timeout(60_000),
+  })
+
+  assert.equal(saveResponse.status, 200, `expected custom provider onboarding save to succeed: ${saveResponse.status}`)
+  const savePayload = await saveResponse.json() as any
+  assert.equal(savePayload.onboarding.locked, false)
+  assert.equal(savePayload.onboarding.required.satisfiedBy.providerId, "custom-openai")
+  assert.equal(existsSync(expectedModelsPath), true)
+
+  const modelsConfig = JSON.parse(readFileSync(expectedModelsPath, "utf-8")) as any
+  assert.equal(modelsConfig.providers["custom-openai"].baseUrl, "https://proxy.example.com/v1")
+  assert.equal(modelsConfig.providers["custom-openai"].models[0].id, "gpt-4o-mini")
+
+  const bootAfter = await fetch(`${launch.url}/api/boot`, {
+    method: "GET",
+    headers: { Accept: "application/json", ...auth },
+    signal: AbortSignal.timeout(10_000),
+  })
+  assert.equal(bootAfter.ok, true)
+  const bootAfterPayload = await bootAfter.json() as any
+  assert.equal(bootAfterPayload.onboarding.locked, false)
+  assert.equal(bootAfterPayload.onboarding.required.satisfiedBy.providerId, "custom-openai")
 })

--- a/src/tests/integration/web-onboarding-contract.test.ts
+++ b/src/tests/integration/web-onboarding-contract.test.ts
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { EventEmitter } from "node:events";
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { PassThrough } from "node:stream";
@@ -35,6 +35,7 @@ const ONBOARDING_ENV_KEYS = [
   "AI_GATEWAY_API_KEY",
   "ZAI_API_KEY",
   "MISTRAL_API_KEY",
+  "CUSTOM_OPENAI_API_KEY",
   "MINIMAX_API_KEY",
   "MINIMAX_CN_API_KEY",
   "HF_TOKEN",
@@ -345,6 +346,7 @@ test("boot and onboarding routes expose locked required state plus explicitly sk
     "xai",
     "openrouter",
     "mistral",
+    "custom-openai",
   ]);
   const anthropicProvider = bootPayload.onboarding.required.providers.find((provider: any) => provider.id === "anthropic");
   assert.equal(anthropicProvider.supports.apiKey, true);
@@ -595,6 +597,115 @@ test("successful API-key validation persists the credential and unlocks onboardi
   assert.equal(bootPayload.onboardingNeeded, false);
 });
 
+test("custom-openai stays unconfigured until both auth and models.json provider config exist, then unlocks through save_custom_provider", async (t) => {
+  const fixture = makeWorkspaceFixture();
+  clearOnboardingEnv();
+  const authStorage = AuthStorage.inMemory({
+    "custom-openai": { type: "api_key", key: "sk-auth-only" },
+  } as any);
+  const harness = configureBridgeFixture(fixture, "sess-custom-openai");
+  const modelsDir = join(tmpdir(), `gsd-custom-openai-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  const modelsJsonPath = join(modelsDir, "models.json");
+  onboarding.configureOnboardingServiceForTests({
+    authStorage,
+    getEnvApiKey: noEnvApiKey,
+    modelsJsonPath,
+  });
+
+  t.after(async () => {
+    onboarding.resetOnboardingServiceForTests();
+    await bridge.resetBridgeServiceForTests();
+    restoreOnboardingEnv();
+    rmSync(modelsDir, { recursive: true, force: true });
+    fixture.cleanup();
+  });
+
+  const bootBefore = await bootRoute.GET(projectRequest(fixture.projectCwd, "/api/boot"));
+  const bootBeforePayload = (await bootBefore.json()) as any;
+  const customBefore = bootBeforePayload.onboarding.required.providers.find((provider: any) => provider.id === "custom-openai");
+  assert.equal(customBefore.configured, false);
+  assert.equal(bootBeforePayload.onboarding.locked, true);
+
+  const saveResponse = await onboardingRoute.POST(
+    projectRequest(fixture.projectCwd, "/api/onboarding", {
+      method: "POST",
+      body: JSON.stringify({
+        action: "save_custom_provider",
+        providerId: "custom-openai",
+        baseUrl: "https://proxy.example.com/v1",
+        apiKey: "sk-custom-live",
+        modelId: "gpt-4o-mini",
+      }),
+    }),
+  );
+
+  assert.equal(saveResponse.status, 200);
+  const savePayload = (await saveResponse.json()) as any;
+  assert.equal(savePayload.onboarding.locked, false);
+  assert.deepEqual(savePayload.onboarding.required.satisfiedBy, {
+    providerId: "custom-openai",
+    source: "auth_file",
+  });
+  assert.equal(savePayload.onboarding.lastValidation.status, "succeeded");
+  assert.equal(harness.spawnCalls, 2);
+  assert.equal(authStorage.hasAuth("custom-openai"), true);
+  assert.equal(existsSync(modelsJsonPath), true);
+
+  const modelsConfig = JSON.parse(readFileSync(modelsJsonPath, "utf-8")) as any;
+  assert.equal(modelsConfig.providers["custom-openai"].baseUrl, "https://proxy.example.com/v1");
+  assert.equal(modelsConfig.providers["custom-openai"].apiKey, "env:CUSTOM_OPENAI_API_KEY");
+  assert.equal(modelsConfig.providers["custom-openai"].api, "openai-completions");
+  assert.equal(modelsConfig.providers["custom-openai"].models[0].id, "gpt-4o-mini");
+
+  const bootAfter = await bootRoute.GET(projectRequest(fixture.projectCwd, "/api/boot"));
+  const bootAfterPayload = (await bootAfter.json()) as any;
+  assert.equal(bootAfterPayload.onboarding.locked, false);
+  assert.equal(bootAfterPayload.onboarding.required.satisfiedBy.providerId, "custom-openai");
+});
+
+test("save_custom_provider rejects invalid input without persisting auth or models config", async (t) => {
+  const fixture = makeWorkspaceFixture();
+  clearOnboardingEnv();
+  const authStorage = AuthStorage.inMemory({});
+  const modelsDir = join(tmpdir(), `gsd-custom-openai-invalid-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  const modelsJsonPath = join(modelsDir, "models.json");
+  configureBridgeFixture(fixture, "sess-custom-openai-invalid");
+  onboarding.configureOnboardingServiceForTests({
+    authStorage,
+    getEnvApiKey: noEnvApiKey,
+    modelsJsonPath,
+  });
+
+  t.after(async () => {
+    onboarding.resetOnboardingServiceForTests();
+    await bridge.resetBridgeServiceForTests();
+    restoreOnboardingEnv();
+    rmSync(modelsDir, { recursive: true, force: true });
+    fixture.cleanup();
+  });
+
+  const saveResponse = await onboardingRoute.POST(
+    projectRequest(fixture.projectCwd, "/api/onboarding", {
+      method: "POST",
+      body: JSON.stringify({
+        action: "save_custom_provider",
+        providerId: "custom-openai",
+        baseUrl: "not-a-url",
+        apiKey: "sk-custom-live",
+        modelId: "",
+      }),
+    }),
+  );
+
+  assert.equal(saveResponse.status, 422);
+  const savePayload = (await saveResponse.json()) as any;
+  assert.equal(savePayload.onboarding.lastValidation.status, "failed");
+  assert.match(savePayload.onboarding.lastValidation.message, /Base URL must be a valid URL/i);
+  assert.equal(savePayload.onboarding.locked, true);
+  assert.equal(authStorage.hasAuth("custom-openai"), false);
+  assert.equal(existsSync(modelsJsonPath), false);
+});
+
 test("logout_provider removes saved auth, refreshes the bridge, and relocks onboarding when it was the only provider", async (t) => {
   const fixture = makeWorkspaceFixture();
   clearOnboardingEnv();
@@ -642,6 +753,70 @@ test("logout_provider removes saved auth, refreshes the bridge, and relocks onbo
   assert.equal(bootAfterPayload.onboarding.lockReason, "required_setup");
   assert.equal(bootAfterPayload.onboarding.bridgeAuthRefresh.phase, "succeeded");
   assert.equal(bootAfterPayload.onboarding.required.satisfied, false);
+});
+
+test("logout_provider removes custom-openai auth and provider config together", async (t) => {
+  const fixture = makeWorkspaceFixture();
+  clearOnboardingEnv();
+  const authStorage = AuthStorage.inMemory({
+    "custom-openai": { type: "api_key", key: "sk-custom-logout" },
+  } as any);
+  const modelsDir = join(tmpdir(), `gsd-custom-openai-logout-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  const modelsJsonPath = join(modelsDir, "models.json");
+  mkdirSync(modelsDir, { recursive: true });
+  writeFileSync(modelsJsonPath, JSON.stringify({
+    providers: {
+      "custom-openai": {
+        baseUrl: "https://proxy.example.com/v1",
+        apiKey: "env:CUSTOM_OPENAI_API_KEY",
+        api: "openai-completions",
+        models: [{ id: "gpt-4o-mini" }],
+      },
+      openai: {
+        baseUrl: "https://api.openai.com/v1",
+      },
+    },
+  }, null, 2));
+  const harness = configureBridgeFixture(fixture, "sess-custom-openai-logout");
+  onboarding.configureOnboardingServiceForTests({
+    authStorage,
+    getEnvApiKey: noEnvApiKey,
+    modelsJsonPath,
+  });
+
+  t.after(async () => {
+    onboarding.resetOnboardingServiceForTests();
+    await bridge.resetBridgeServiceForTests();
+    restoreOnboardingEnv();
+    rmSync(modelsDir, { recursive: true, force: true });
+    fixture.cleanup();
+  });
+
+  const bootBefore = await bootRoute.GET(projectRequest(fixture.projectCwd, "/api/boot"));
+  const bootBeforePayload = (await bootBefore.json()) as any;
+  assert.equal(bootBeforePayload.onboarding.required.satisfiedBy.providerId, "custom-openai");
+  assert.equal(harness.spawnCalls, 1);
+
+  const logoutResponse = await onboardingRoute.POST(
+    projectRequest(fixture.projectCwd, "/api/onboarding", {
+      method: "POST",
+      body: JSON.stringify({
+        action: "logout_provider",
+        providerId: "custom-openai",
+      }),
+    }),
+  );
+
+  assert.equal(logoutResponse.status, 200);
+  const logoutPayload = (await logoutResponse.json()) as any;
+  assert.equal(logoutPayload.onboarding.locked, true);
+  assert.equal(logoutPayload.onboarding.lockReason, "required_setup");
+  assert.equal(authStorage.hasAuth("custom-openai"), false);
+  assert.equal(harness.spawnCalls, 2);
+
+  const modelsConfig = JSON.parse(readFileSync(modelsJsonPath, "utf-8")) as any;
+  assert.equal("custom-openai" in modelsConfig.providers, false);
+  assert.equal("openai" in modelsConfig.providers, true);
 });
 
 test("logout_provider fails clearly for environment-backed auth that the browser cannot remove", async (t) => {

--- a/src/tests/integration/web-onboarding-contract.test.ts
+++ b/src/tests/integration/web-onboarding-contract.test.ts
@@ -646,6 +646,11 @@ test("custom-openai stays unconfigured until both auth and models.json provider 
     providerId: "custom-openai",
     source: "auth_file",
   });
+  const customAfterSave = savePayload.onboarding.required.providers.find((provider: any) => provider.id === "custom-openai");
+  assert.deepEqual(customAfterSave.configuration, {
+    baseUrl: "https://proxy.example.com/v1",
+    modelId: "gpt-4o-mini",
+  });
   assert.equal(savePayload.onboarding.lastValidation.status, "succeeded");
   assert.equal(harness.spawnCalls, 2);
   assert.equal(authStorage.hasAuth("custom-openai"), true);
@@ -661,6 +666,11 @@ test("custom-openai stays unconfigured until both auth and models.json provider 
   const bootAfterPayload = (await bootAfter.json()) as any;
   assert.equal(bootAfterPayload.onboarding.locked, false);
   assert.equal(bootAfterPayload.onboarding.required.satisfiedBy.providerId, "custom-openai");
+  const customAfterBoot = bootAfterPayload.onboarding.required.providers.find((provider: any) => provider.id === "custom-openai");
+  assert.deepEqual(customAfterBoot.configuration, {
+    baseUrl: "https://proxy.example.com/v1",
+    modelId: "gpt-4o-mini",
+  });
 });
 
 test("save_custom_provider rejects invalid input without persisting auth or models config", async (t) => {

--- a/src/web/onboarding-service.ts
+++ b/src/web/onboarding-service.ts
@@ -3,6 +3,14 @@ import { randomUUID } from "node:crypto";
 import { getEnvApiKey } from "../../packages/pi-ai/src/web-runtime-env-api-keys.ts";
 import type { OAuthAuthInfo, OAuthPrompt, OAuthProviderInterface } from "../../packages/pi-ai/dist/oauth.js";
 import { authFilePath } from "../app-paths.ts";
+import {
+  CUSTOM_OPENAI_PROVIDER_ID,
+  CUSTOM_OPENAI_PROVIDER_LABEL,
+  hasCustomOpenAIProviderConfig,
+  normalizeCustomOpenAIProviderInput,
+  removeCustomOpenAIProviderConfig,
+  saveCustomOpenAIProviderConfig,
+} from "../custom-openai-config.ts";
 import { createOnboardingAuthStorage, type OnboardingAuthStorage as AuthStorageInstance } from "./web-auth-storage.ts";
 
 type RequiredProviderCatalogEntry = {
@@ -31,6 +39,7 @@ let onboardingBridgeAuthRefresher: BridgeAuthRefresher | null = null;
 type OnboardingServiceDeps = {
   env?: NodeJS.ProcessEnv;
   authPath?: string;
+  modelsJsonPath?: string;
   authStorage?: AuthStorageInstance;
   createAuthStorage?: (authPath: string) => AuthStorageInstance | Promise<AuthStorageInstance>;
   validateApiKey?: (providerId: string, apiKey: string) => Promise<ValidationProbeResult>;
@@ -153,6 +162,7 @@ const REQUIRED_PROVIDER_CATALOG: RequiredProviderCatalogEntry[] = [
   { id: "xai", label: "xAI (Grok)", supportsApiKey: true, supportsOAuth: false },
   { id: "openrouter", label: "OpenRouter", supportsApiKey: true, supportsOAuth: false },
   { id: "mistral", label: "Mistral", supportsApiKey: true, supportsOAuth: false },
+  { id: CUSTOM_OPENAI_PROVIDER_ID, label: CUSTOM_OPENAI_PROVIDER_LABEL, supportsApiKey: true, supportsOAuth: false },
 ];
 
 const OPTIONAL_SECTION_CATALOG: OptionalSectionCatalogEntry[] = [
@@ -234,6 +244,15 @@ function hasStoredCredentialValue(authStorage: AuthStorageInstance, providerId: 
     if (credential.type === "oauth") return true;
     return typeof credential.key === "string" && credential.key.trim().length > 0;
   });
+}
+
+function hasConfiguredCustomOpenAI(
+  authStorage: AuthStorageInstance,
+  getEnvApiKeyFn: GetEnvApiKeyFn,
+  modelsJsonPath?: string,
+): boolean {
+  const hasCredential = resolveCredentialSource(authStorage, CUSTOM_OPENAI_PROVIDER_ID, getEnvApiKeyFn) !== null;
+  return hasCredential && hasCustomOpenAIProviderConfig(modelsJsonPath);
 }
 
 function resolveCredentialSource(
@@ -434,6 +453,9 @@ export class OnboardingService {
     if (!provider) {
       throw new Error(`Unknown onboarding provider: ${providerId}`);
     }
+    if (providerId === CUSTOM_OPENAI_PROVIDER_ID) {
+      throw new Error(`${CUSTOM_OPENAI_PROVIDER_LABEL} must be configured with the custom provider action`);
+    }
     if (!provider.supportsApiKey) {
       throw new Error(`${providerId} must be configured with browser sign-in`);
     }
@@ -476,6 +498,43 @@ export class OnboardingService {
     };
     await this.refreshBridgeAuth();
 
+    return await this.buildState();
+  }
+
+  async saveCustomProvider(providerId: string, baseUrl: string, apiKey: string, modelId: string): Promise<OnboardingState> {
+    if (providerId !== CUSTOM_OPENAI_PROVIDER_ID) {
+      throw new Error(`Unsupported custom provider: ${providerId}`);
+    }
+
+    let normalized;
+    try {
+      normalized = normalizeCustomOpenAIProviderInput({ baseUrl, apiKey, modelId });
+    } catch (error) {
+      this.lastValidation = {
+        status: "failed",
+        providerId,
+        method: "api_key",
+        checkedAt: nowIso(this.deps.now ?? (() => new Date())),
+        message: sanitizeMessage(error),
+        persisted: false,
+      };
+      return await this.buildState();
+    }
+
+    const authStorage = await this.getAuthStorage();
+    authStorage.reload();
+    saveCustomOpenAIProviderConfig(authStorage, normalized, this.deps.modelsJsonPath);
+
+    const checkedAt = nowIso(this.deps.now ?? (() => new Date()));
+    this.lastValidation = {
+      status: "succeeded",
+      providerId,
+      method: "api_key",
+      checkedAt,
+      message: `${CUSTOM_OPENAI_PROVIDER_LABEL} saved`,
+      persisted: true,
+    };
+    await this.refreshBridgeAuth();
     return await this.buildState();
   }
 
@@ -577,6 +636,10 @@ export class OnboardingService {
     }
 
     authStorage.logout(resolvedProviderId);
+    if (resolvedProviderId === CUSTOM_OPENAI_PROVIDER_ID) {
+      removeCustomOpenAIProviderConfig(this.deps.modelsJsonPath);
+      delete process.env.CUSTOM_OPENAI_API_KEY;
+    }
     this.lastValidation = null;
     await this.refreshBridgeAuth();
     return await this.buildState();
@@ -662,7 +725,12 @@ export class OnboardingService {
 
     return REQUIRED_PROVIDER_CATALOG.map((provider) => {
       const oauthProvider = oauthProviders.get(provider.id);
-      const configuredVia = resolveCredentialSource(authStorage, provider.id, getEnvApiKeyFn);
+      const configuredVia =
+        provider.id === CUSTOM_OPENAI_PROVIDER_ID
+          ? hasConfiguredCustomOpenAI(authStorage, getEnvApiKeyFn, this.deps.modelsJsonPath)
+            ? resolveCredentialSource(authStorage, provider.id, getEnvApiKeyFn)
+            : null
+          : resolveCredentialSource(authStorage, provider.id, getEnvApiKeyFn);
       return {
         id: provider.id,
         label: oauthProvider?.name ?? provider.label,

--- a/src/web/onboarding-service.ts
+++ b/src/web/onboarding-service.ts
@@ -6,6 +6,7 @@ import { authFilePath } from "../app-paths.ts";
 import {
   CUSTOM_OPENAI_PROVIDER_ID,
   CUSTOM_OPENAI_PROVIDER_LABEL,
+  getCustomOpenAIProviderSnapshot,
   hasCustomOpenAIProviderConfig,
   normalizeCustomOpenAIProviderInput,
   removeCustomOpenAIProviderConfig,
@@ -70,6 +71,10 @@ export interface OnboardingProviderState {
   recommended: boolean;
   configured: boolean;
   configuredVia: OnboardingCredentialSource | null;
+  configuration: {
+    baseUrl: string;
+    modelId: string;
+  } | null;
   supports: {
     apiKey: boolean;
     oauth: boolean;
@@ -722,6 +727,7 @@ export class OnboardingService {
     getEnvApiKeyFn: GetEnvApiKeyFn,
   ): OnboardingProviderState[] {
     const oauthProviders = new Map(authStorage.getOAuthProviders().map((provider) => [provider.id, provider]));
+    const customProviderSnapshot = getCustomOpenAIProviderSnapshot(this.deps.modelsJsonPath);
 
     return REQUIRED_PROVIDER_CATALOG.map((provider) => {
       const oauthProvider = oauthProviders.get(provider.id);
@@ -738,6 +744,7 @@ export class OnboardingService {
         recommended: Boolean(provider.recommended),
         configured: configuredVia !== null,
         configuredVia,
+        configuration: provider.id === CUSTOM_OPENAI_PROVIDER_ID ? customProviderSnapshot : null,
         supports: {
           apiKey: provider.supportsApiKey,
           oauth: provider.supportsOAuth,

--- a/web/app/api/onboarding/route.ts
+++ b/web/app/api/onboarding/route.ts
@@ -11,6 +11,7 @@ type OnboardingAction =
   | { action: "discover_providers" }
   | { action: "recheck" }
   | { action: "save_api_key"; providerId: string; apiKey: string }
+  | { action: "save_custom_provider"; providerId: string; baseUrl: string; apiKey: string; modelId: string }
   | { action: "start_provider_flow"; providerId: string }
   | { action: "continue_provider_flow"; flowId: string; input: string }
   | { action: "cancel_provider_flow"; flowId: string }
@@ -90,6 +91,28 @@ export async function POST(request: Request): Promise<Response> {
                   : onboarding.lockReason === "bridge_refresh_pending"
                     ? 202
                     : 200,
+            headers: noStoreHeaders(),
+          },
+        );
+      }
+      case "save_custom_provider": {
+        const onboarding = await onboardingService.saveCustomProvider(
+          payload.providerId,
+          payload.baseUrl,
+          payload.apiKey,
+          payload.modelId,
+        );
+        return Response.json(
+          { onboarding },
+          {
+            status:
+              onboarding.lastValidation?.status === "failed"
+                ? 422
+                : onboarding.lockReason === "bridge_refresh_failed"
+                ? 503
+                : onboarding.lockReason === "bridge_refresh_pending"
+                  ? 202
+                  : 200,
             headers: noStoreHeaders(),
           },
         );

--- a/web/components/gsd/command-surface.tsx
+++ b/web/components/gsd/command-surface.tsx
@@ -351,6 +351,7 @@ export function CommandSurface() {
     forkSessionFromSurface,
     compactSessionFromSurface,
     saveApiKeyFromSurface,
+    saveCustomProviderFromSurface,
     startProviderFlowFromSurface,
     submitProviderFlowInputFromSurface,
     cancelProviderFlowFromSurface,
@@ -374,6 +375,8 @@ export function CommandSurface() {
   const currentModelLabel = getModelLabel(workspace.boot?.bridge)
   const currentSessionLabel = getSessionLabelFromBridge(workspace.boot?.bridge)
   const [apiKeys, setApiKeys] = useState<Record<string, string>>({})
+  const [customBaseUrls, setCustomBaseUrls] = useState<Record<string, string>>({})
+  const [customModelIds, setCustomModelIds] = useState<Record<string, string>>({})
   const [flowInput, setFlowInput] = useState("")
   const commandSurfaceViewportRef = useRef<HTMLDivElement>(null)
 
@@ -600,6 +603,8 @@ export function CommandSurface() {
   const autoRetryBusy = settingsRequests.autoRetry.pending
   const abortRetryBusy = settingsRequests.abortRetry.pending
   const selectedProviderApiKey = selectedAuthProvider ? apiKeys[selectedAuthProvider.id] ?? "" : ""
+  const selectedProviderBaseUrl = selectedAuthProvider ? customBaseUrls[selectedAuthProvider.id] ?? "" : ""
+  const selectedProviderModelId = selectedAuthProvider ? customModelIds[selectedAuthProvider.id] ?? "" : ""
   const devOverrides = useDevOverrides()
   const surfaceSections = availableSectionsForSurface(commandSurface.activeSurface, devOverrides.isDevMode)
   const surfaceKindLabel = `/${commandSurface.activeSurface ?? "settings"}`
@@ -1797,7 +1802,74 @@ export function CommandSurface() {
             </div>
 
             {/* API key form */}
-            {selectedAuthProvider.supports.apiKey && (
+            {selectedAuthProvider.id === "custom-openai" ? (
+              <form
+                className="space-y-3"
+                onSubmit={(e) => {
+                  e.preventDefault()
+                  if (!selectedProviderBaseUrl.trim() || !selectedProviderApiKey.trim() || !selectedProviderModelId.trim()) return
+                  void saveCustomProviderFromSurface(
+                    selectedAuthProvider.id,
+                    selectedProviderBaseUrl,
+                    selectedProviderApiKey,
+                    selectedProviderModelId,
+                  )
+                }}
+              >
+                <div className="space-y-2">
+                  <Input
+                    type="url"
+                    autoComplete="off"
+                    value={selectedProviderBaseUrl}
+                    onChange={(e) =>
+                      setCustomBaseUrls((prev) => ({ ...prev, [selectedAuthProvider.id]: e.target.value }))
+                    }
+                    placeholder="https://my-proxy.example.com/v1"
+                    className="h-8 text-xs"
+                    disabled={authBusy}
+                    data-testid="command-surface-custom-base-url-input"
+                  />
+                  <Input
+                    type="password"
+                    autoComplete="off"
+                    value={selectedProviderApiKey}
+                    onChange={(e) =>
+                      setApiKeys((prev) => ({ ...prev, [selectedAuthProvider.id]: e.target.value }))
+                    }
+                    placeholder="Paste API key"
+                    className="h-8 flex-1 text-xs"
+                    disabled={authBusy}
+                    data-testid="command-surface-api-key-input"
+                  />
+                  <Input
+                    type="text"
+                    autoComplete="off"
+                    value={selectedProviderModelId}
+                    onChange={(e) =>
+                      setCustomModelIds((prev) => ({ ...prev, [selectedAuthProvider.id]: e.target.value }))
+                    }
+                    placeholder="gpt-4o"
+                    className="h-8 text-xs font-mono"
+                    disabled={authBusy}
+                    data-testid="command-surface-custom-model-id-input"
+                  />
+                </div>
+                <Button
+                  type="submit"
+                  size="sm"
+                  disabled={!selectedProviderBaseUrl.trim() || !selectedProviderApiKey.trim() || !selectedProviderModelId.trim() || authBusy}
+                  data-testid="command-surface-save-custom-provider"
+                  className="h-8 gap-1.5"
+                >
+                  {commandSurface.pendingAction === "save_custom_provider" ? (
+                    <LoaderCircle className="h-3.5 w-3.5 animate-spin" />
+                  ) : (
+                    <KeyRound className="h-3.5 w-3.5" />
+                  )}
+                  Save provider
+                </Button>
+              </form>
+            ) : selectedAuthProvider.supports.apiKey && (
               <form
                 className="space-y-3"
                 onSubmit={(e) => {
@@ -1839,7 +1911,7 @@ export function CommandSurface() {
 
             {/* OAuth / sign-in buttons */}
             <div className="flex flex-wrap gap-2">
-              {selectedAuthProvider.supports.oauth && selectedAuthProvider.supports.oauthAvailable && (
+              {selectedAuthProvider.id !== "custom-openai" && selectedAuthProvider.supports.oauth && selectedAuthProvider.supports.oauthAvailable && (
                 <Button
                   type="button"
                   variant="outline"

--- a/web/components/gsd/command-surface.tsx
+++ b/web/components/gsd/command-surface.tsx
@@ -609,6 +609,19 @@ export function CommandSurface() {
   const surfaceSections = availableSectionsForSurface(commandSurface.activeSurface, devOverrides.isDevMode)
   const surfaceKindLabel = `/${commandSurface.activeSurface ?? "settings"}`
 
+  useEffect(() => {
+    if (!selectedAuthProvider || selectedAuthProvider.id !== "custom-openai") return
+    const configuration = selectedAuthProvider.configuration
+    if (!configuration) return
+
+    setCustomBaseUrls((prev) =>
+      prev[selectedAuthProvider.id] !== undefined ? prev : { ...prev, [selectedAuthProvider.id]: configuration.baseUrl },
+    )
+    setCustomModelIds((prev) =>
+      prev[selectedAuthProvider.id] !== undefined ? prev : { ...prev, [selectedAuthProvider.id]: configuration.modelId },
+    )
+  }, [selectedAuthProvider])
+
   const triggerRecoveryBrowserAction = (actionId: string) => {
     switch (actionId) {
       case "refresh_diagnostics":

--- a/web/components/gsd/onboarding-gate.tsx
+++ b/web/components/gsd/onboarding-gate.tsx
@@ -86,6 +86,7 @@ export function OnboardingGate() {
   const {
     refreshOnboarding,
     saveApiKey,
+    saveCustomProvider,
     startProviderFlow,
     submitProviderFlowInput,
     cancelProviderFlow,
@@ -232,6 +233,15 @@ export function OnboardingGate() {
                   requestProviderId={workspace.onboardingRequestProviderId}
                   onSaveApiKey={async (pid, key) => {
                     const next = await saveApiKey(pid, key)
+                    const settled = Boolean(
+                      next && !next.locked &&
+                      (next.bridgeAuthRefresh.phase === "succeeded" || next.bridgeAuthRefresh.phase === "idle"),
+                    )
+                    if (settled) { setDismissedAfterSuccess(true); void refreshBoot() }
+                    return next
+                  }}
+                  onSaveCustomProvider={async (pid, baseUrl, apiKey, modelId) => {
+                    const next = await saveCustomProvider(pid, baseUrl, apiKey, modelId)
                     const settled = Boolean(
                       next && !next.locked &&
                       (next.bridgeAuthRefresh.phase === "succeeded" || next.bridgeAuthRefresh.phase === "idle"),

--- a/web/components/gsd/onboarding/step-authenticate.tsx
+++ b/web/components/gsd/onboarding/step-authenticate.tsx
@@ -149,6 +149,15 @@ export function StepAuthenticate({
   }, [lastValidation?.checkedAt, lastValidation?.providerId, lastValidation?.status])
 
   useEffect(() => {
+    if (provider.id !== "custom-openai" || !provider.configuration) return
+    const t = window.setTimeout(() => {
+      setCustomBaseUrl((current) => current || provider.configuration?.baseUrl || "")
+      setCustomModelId((current) => current || provider.configuration?.modelId || "")
+    }, 0)
+    return () => window.clearTimeout(t)
+  }, [provider.configuration, provider.id])
+
+  useEffect(() => {
     const t = window.setTimeout(() => setFlowInput(""), 0)
     return () => window.clearTimeout(t)
   }, [activeFlow?.flowId])

--- a/web/components/gsd/onboarding/step-authenticate.tsx
+++ b/web/components/gsd/onboarding/step-authenticate.tsx
@@ -81,6 +81,7 @@ interface StepAuthenticateProps {
   requestState: WorkspaceOnboardingRequestState
   requestProviderId: string | null
   onSaveApiKey: (providerId: string, apiKey: string) => Promise<WorkspaceOnboardingState | null>
+  onSaveCustomProvider: (providerId: string, baseUrl: string, apiKey: string, modelId: string) => Promise<WorkspaceOnboardingState | null>
   onStartFlow: (providerId: string) => void
   onSubmitFlowInput: (flowId: string, input: string) => void
   onCancelFlow: (flowId: string) => void
@@ -97,6 +98,7 @@ export function StepAuthenticate({
   requestState,
   requestProviderId,
   onSaveApiKey,
+  onSaveCustomProvider,
   onStartFlow,
   onSubmitFlowInput,
   onCancelFlow,
@@ -106,6 +108,8 @@ export function StepAuthenticate({
   bridgeRefreshError,
 }: StepAuthenticateProps) {
   const [apiKey, setApiKey] = useState("")
+  const [customBaseUrl, setCustomBaseUrl] = useState("")
+  const [customModelId, setCustomModelId] = useState("")
   const [flowInput, setFlowInput] = useState("")
   const [copied, setCopied] = useState(false)
 
@@ -116,8 +120,8 @@ export function StepAuthenticate({
   const canProceed = isValidated && isBridgeDone
   const validationFailed = lastValidation?.status === "failed" && lastValidation.providerId === provider.id
   const parsedError = validationFailed ? parseValidationError(lastValidation.message) : null
+  const isCustomOpenAI = provider.id === "custom-openai"
 
-  const isOAuthOnly = !provider.supports.apiKey && provider.supports.oauth
   const hasOAuth = provider.supports.oauth && provider.supports.oauthAvailable
   const hasApiKey = provider.supports.apiKey
 
@@ -133,6 +137,16 @@ export function StepAuthenticate({
     const t = window.setTimeout(() => setApiKey(""), 0)
     return () => window.clearTimeout(t)
   }, [lastValidation?.checkedAt, lastValidation?.status])
+
+  useEffect(() => {
+    if (lastValidation?.status !== "succeeded" || lastValidation.providerId !== "custom-openai") return
+    const t = window.setTimeout(() => {
+      setApiKey("")
+      setCustomBaseUrl("")
+      setCustomModelId("")
+    }, 0)
+    return () => window.clearTimeout(t)
+  }, [lastValidation?.checkedAt, lastValidation?.providerId, lastValidation?.status])
 
   useEffect(() => {
     const t = window.setTimeout(() => setFlowInput(""), 0)
@@ -227,7 +241,7 @@ export function StepAuthenticate({
         )}
 
         {/* ─── API key form ─── */}
-        {hasApiKey && !canProceed && (
+        {hasApiKey && !canProceed && !isCustomOpenAI && (
           <div className="space-y-3 rounded-xl border border-border/50 bg-card/50 p-4">
             <div className="text-sm font-medium text-foreground">API key</div>
             <form
@@ -270,8 +284,71 @@ export function StepAuthenticate({
           </div>
         )}
 
+        {isCustomOpenAI && !canProceed && (
+          <div className="space-y-3 rounded-xl border border-border/50 bg-card/50 p-4">
+            <div className="text-sm font-medium text-foreground">Custom OpenAI-compatible provider</div>
+            <form
+              className="space-y-3"
+              onSubmit={async (e) => {
+                e.preventDefault()
+                if (!customBaseUrl.trim() || !apiKey.trim() || !customModelId.trim()) return
+                const next = await onSaveCustomProvider(provider.id, customBaseUrl, apiKey, customModelId)
+                if (next && !next.locked && (next.bridgeAuthRefresh.phase === "succeeded" || next.bridgeAuthRefresh.phase === "idle")) {
+                  onNext()
+                }
+              }}
+            >
+              <Input
+                data-testid="onboarding-custom-base-url-input"
+                type="url"
+                autoComplete="off"
+                value={customBaseUrl}
+                onChange={(e) => setCustomBaseUrl(e.target.value)}
+                placeholder="https://my-proxy.example.com/v1"
+                disabled={isBusy}
+                className="text-sm"
+              />
+              <Input
+                data-testid="onboarding-api-key-input"
+                type="password"
+                autoComplete="off"
+                value={apiKey}
+                onChange={(e) => setApiKey(e.target.value)}
+                placeholder="Paste API key"
+                disabled={isBusy}
+                className="font-mono text-sm"
+              />
+              <Input
+                data-testid="onboarding-custom-model-id-input"
+                type="text"
+                autoComplete="off"
+                value={customModelId}
+                onChange={(e) => setCustomModelId(e.target.value)}
+                placeholder="gpt-4o"
+                disabled={isBusy}
+                className="font-mono text-sm"
+              />
+              <div className="flex items-center gap-2">
+                <Button
+                  type="submit"
+                  disabled={!customBaseUrl.trim() || !apiKey.trim() || !customModelId.trim() || isBusy}
+                  className="gap-2 transition-transform active:scale-[0.96]"
+                  data-testid="onboarding-save-custom-provider"
+                >
+                  {isThisProviderBusy && requestState === "saving_custom_provider" ? (
+                    <LoaderCircle className="h-4 w-4 animate-spin" />
+                  ) : (
+                    <KeyRound className="h-4 w-4" />
+                  )}
+                  Save provider
+                </Button>
+              </div>
+            </form>
+          </div>
+        )}
+
         {/* ─── OAuth section ─── */}
-        {hasOAuth && !canProceed && (
+        {hasOAuth && !canProceed && !isCustomOpenAI && (
           <div className="space-y-3">
             {/* Divider between API key and OAuth */}
             {hasApiKey && (

--- a/web/lib/command-surface-contract.ts
+++ b/web/lib/command-surface-contract.ts
@@ -77,6 +77,7 @@ export type CommandSurfacePendingAction =
   | "load_session_browser"
   | "rename_session"
   | "save_api_key"
+  | "save_custom_provider"
   | "start_provider_flow"
   | "submit_provider_flow_input"
   | "cancel_provider_flow"

--- a/web/lib/gsd-workspace-store.tsx
+++ b/web/lib/gsd-workspace-store.tsx
@@ -225,6 +225,10 @@ export interface WorkspaceOnboardingProviderState {
   recommended: boolean
   configured: boolean
   configuredVia: "auth_file" | "environment" | "runtime" | null
+  configuration: {
+    baseUrl: string
+    modelId: string
+  } | null
   supports: {
     apiKey: boolean
     oauth: boolean

--- a/web/lib/gsd-workspace-store.tsx
+++ b/web/lib/gsd-workspace-store.tsx
@@ -504,6 +504,7 @@ export type WorkspaceOnboardingRequestState =
   | "idle"
   | "refreshing"
   | "saving_api_key"
+  | "saving_custom_provider"
   | "starting_provider_flow"
   | "submitting_provider_flow_input"
   | "cancelling_provider_flow"
@@ -1506,6 +1507,15 @@ export function getOnboardingPresentation(
       phase: "validating",
       label: "Validating credentials",
       detail: "Checking the provider key and saving it only if validation succeeds.",
+      tone: "info",
+    }
+  }
+
+  if (state.onboardingRequestState === "saving_custom_provider") {
+    return {
+      phase: "validating",
+      label: "Saving custom provider",
+      detail: "Persisting the endpoint, model, and API key before the bridge reloads onto the new provider.",
       tone: "info",
     }
   }
@@ -3777,6 +3787,68 @@ export class GSDWorkspaceStore {
     return onboarding
   }
 
+  saveCustomProviderFromSurface = async (
+    providerId: string,
+    baseUrl: string,
+    apiKey: string,
+    modelId: string,
+  ): Promise<WorkspaceOnboardingState | null> => {
+    const selectedTarget: CommandSurfaceTarget = { kind: "auth", providerId, intent: "manage" }
+    this.patchState({
+      commandSurface: setCommandSurfacePending(this.state.commandSurface, "save_custom_provider", selectedTarget),
+    })
+
+    const onboarding = await this.saveCustomProvider(providerId, baseUrl, apiKey, modelId)
+    const providerLabel = onboarding ? findOnboardingProviderLabel(onboarding, providerId) : providerId
+
+    if (!onboarding) {
+      this.patchState({
+        commandSurface: applyCommandSurfaceActionResult(this.state.commandSurface, {
+          action: "save_custom_provider",
+          success: false,
+          message: this.state.lastClientError ?? `${providerLabel} setup failed`,
+          selectedTarget,
+        }),
+      })
+      return null
+    }
+
+    if (onboarding.lastValidation?.status === "failed") {
+      this.patchState({
+        commandSurface: applyCommandSurfaceActionResult(this.state.commandSurface, {
+          action: "save_custom_provider",
+          success: false,
+          message: onboarding.lastValidation.message,
+          selectedTarget,
+        }),
+      })
+      return onboarding
+    }
+
+    if (onboarding.bridgeAuthRefresh.phase === "failed") {
+      this.patchState({
+        commandSurface: applyCommandSurfaceActionResult(this.state.commandSurface, {
+          action: "save_custom_provider",
+          success: false,
+          message: onboarding.bridgeAuthRefresh.error ?? `${providerLabel} saved but bridge auth refresh failed`,
+          selectedTarget,
+        }),
+      })
+      return onboarding
+    }
+
+    this.patchState({
+      commandSurface: applyCommandSurfaceActionResult(this.state.commandSurface, {
+        action: "save_custom_provider",
+        success: true,
+        message: `${providerLabel} saved and ready.`,
+        selectedTarget,
+      }),
+    })
+
+    return onboarding
+  }
+
   startProviderFlowFromSurface = async (providerId: string): Promise<WorkspaceOnboardingState | null> => {
     const selectedTarget: CommandSurfaceTarget = { kind: "auth", providerId, intent: "login" }
     this.patchState({
@@ -4492,6 +4564,43 @@ export class GSDWorkspaceStore {
       this.patchState({
         lastClientError: message,
         terminalLines: withTerminalLine(this.state.terminalLines, createTerminalLine("error", `Credential setup failed — ${message}`)),
+      })
+      return null
+    } finally {
+      this.patchState({
+        onboardingRequestState: "idle",
+        onboardingRequestProviderId: null,
+      })
+    }
+  }
+
+  saveCustomProvider = async (
+    providerId: string,
+    baseUrl: string,
+    apiKey: string,
+    modelId: string,
+  ): Promise<WorkspaceOnboardingState | null> => {
+    this.patchState({
+      onboardingRequestState: "saving_custom_provider",
+      onboardingRequestProviderId: providerId,
+      lastClientError: null,
+    })
+
+    try {
+      const onboarding = await this.postOnboardingAction({
+        action: "save_custom_provider",
+        providerId,
+        baseUrl,
+        apiKey,
+        modelId,
+      })
+      await this.syncAfterOnboardingMutation(onboarding)
+      return onboarding
+    } catch (error) {
+      const message = normalizeClientError(error)
+      this.patchState({
+        lastClientError: message,
+        terminalLines: withTerminalLine(this.state.terminalLines, createTerminalLine("error", `Custom provider setup failed — ${message}`)),
       })
       return null
     } finally {
@@ -5268,7 +5377,9 @@ export function useGSDWorkspaceActions(): Pick<
   | "forkSessionFromSurface"
   | "compactSessionFromSurface"
   | "saveApiKey"
+  | "saveCustomProvider"
   | "saveApiKeyFromSurface"
+  | "saveCustomProviderFromSurface"
   | "startProviderFlow"
   | "startProviderFlowFromSurface"
   | "submitProviderFlowInput"
@@ -5332,7 +5443,9 @@ export function useGSDWorkspaceActions(): Pick<
     forkSessionFromSurface: store.forkSessionFromSurface,
     compactSessionFromSurface: store.compactSessionFromSurface,
     saveApiKey: store.saveApiKey,
+    saveCustomProvider: store.saveCustomProvider,
     saveApiKeyFromSurface: store.saveApiKeyFromSurface,
+    saveCustomProviderFromSurface: store.saveCustomProviderFromSurface,
     startProviderFlow: store.startProviderFlow,
     startProviderFlowFromSurface: store.startProviderFlowFromSurface,
     submitProviderFlowInput: store.submitProviderFlowInput,


### PR DESCRIPTION
## TL;DR

**What:** Adds browser onboarding support for a custom OpenAI-compatible provider in GSD web mode.
**Why:** Web onboarding previously handled only built-in providers, so users could not configure custom OpenAI-compatible endpoints from the browser.
**How:** Adds a dedicated `save_custom_provider` onboarding flow that persists auth plus `models.json` provider config, exposes the saved config back to the UI, and updates the web onboarding/command-surface
state to manage it.

## What

This PR adds first-class browser onboarding for a `custom-openai` provider in web mode.

Affected areas:
- `src/custom-openai-config.ts`
  Adds shared helpers to validate, save, load, and remove custom OpenAI-compatible provider config.
- `src/web/onboarding-service.ts`
  Registers `custom-openai` as a required provider option, adds `saveCustomProvider()`, tracks saved `baseUrl` and `modelId`, and treats the provider as configured only when both auth and `models.json` config
exist.
- `web/app/api/onboarding/route.ts`
  Adds a new onboarding action: `save_custom_provider`.
- `web/components/gsd/onboarding/step-authenticate.tsx`
  Adds the custom provider form for `baseUrl`, `apiKey`, and `modelId`, plus success/error handling.
- `web/components/gsd/command-surface.tsx`
  Surfaces the saved custom provider settings in the auth/settings UI and hydrates them correctly after save.
- `web/lib/gsd-workspace-store.tsx`
  Extends onboarding state typing/client state to carry provider configuration details.
- `packages/pi-ai/src/web-runtime-env-api-keys.ts`
  Adds `CUSTOM_OPENAI_API_KEY` lookup for the standalone web host.
- Tests:
  - `src/tests/integration/web-mode-onboarding.test.ts`
  - `src/tests/integration/web-onboarding-contract.test.ts`

## Why

Users running GSD in browser/web mode need parity with CLI onboarding when they use OpenAI-compatible proxies or self-hosted endpoints. Before this change, the web onboarding flow could save standard API-key
providers, but it had no way to capture the extra configuration required for a custom endpoint: base URL and model ID.

This left browser users blocked from completing onboarding with a custom OpenAI-compatible backend even though the runtime already supported custom providers via `models.json`.

## How

The implementation introduces a dedicated custom-provider path instead of trying to force `custom-openai` through the generic API-key flow.

Key decisions:
- Custom providers require both credential storage and provider-definition storage.
  `auth.json` stores the API key, while `models.json` stores `baseUrl`, API type, and model metadata.
- The onboarding service now treats `custom-openai` as configured only when both pieces are present.
  This avoids false-positive “configured” states when auth exists but the provider definition is missing.
- A new `save_custom_provider` API action persists both artifacts and refreshes bridge auth so the running web session can use the provider immediately.
- Logout for `custom-openai` removes both auth and provider config together.
- The web UI now renders a custom form for `custom-openai` and hydrates previously saved `baseUrl` and `modelId` back into the onboarding/settings surfaces.

The follow-up fix in this branch ensures the saved custom provider settings are hydrated back into the command surface correctly after onboarding.

## Change type

- [x] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [x] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [ ] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

Automated coverage added:
- `src/tests/integration/web-mode-onboarding.test.ts`
- `src/tests/integration/web-onboarding-contract.test.ts`

## AI disclosure

- [x] This PR includes AI-assisted code