### PR TITLE
fix(state): parse depends_on from CONTEXT.md during disk-to-DB reconciliation

### DIFF
--- a/src/resources/extensions/gsd/milestone-ids.ts
+++ b/src/resources/extensions/gsd/milestone-ids.ts
@@ -37,9 +37,17 @@ export function parseMilestoneId(id: string): { suffix?: string; num: number } {
 
 // ─── Sorting ────────────────────────────────────────────────────────────────
 
-/** Comparator for sorting milestone IDs by sequential number. */
+/** Comparator for sorting milestone IDs by sequential number.
+ * When two IDs share the same sequence number (e.g. M001-fkbvng vs M001-1jp4m8),
+ * the suffix is used as a lexicographic tiebreaker so the sort is deterministic
+ * and does not depend on the runtime's unstable sort behaviour (#3340).
+ */
 export function milestoneIdSort(a: string, b: string): number {
-  return extractMilestoneSeq(a) - extractMilestoneSeq(b);
+  const seqDiff = extractMilestoneSeq(a) - extractMilestoneSeq(b);
+  if (seqDiff !== 0) return seqDiff;
+  // Same sequence number — fall back to full-ID lexicographic comparison so that
+  // unique IDs (M001-abc vs M001-xyz) always sort in a deterministic order.
+  return a < b ? -1 : a > b ? 1 : 0;
 }
 
 // ─── Generation ─────────────────────────────────────────────────────────────

--- a/src/resources/extensions/gsd/state.ts
+++ b/src/resources/extensions/gsd/state.ts
@@ -338,7 +338,16 @@ export async function deriveStateFromDb(basePath: string): Promise<GSDState> {
   let synced = false;
   for (const diskId of diskIds) {
     if (!dbIdSet.has(diskId) && !isGhostMilestone(basePath, diskId)) {
-      insertMilestone({ id: diskId, status: 'active' });
+      // Parse depends_on from CONTEXT.md (or CONTEXT-DRAFT.md) so the DB row
+      // reflects the real dependency list. Without this, the row is inserted
+      // with depends_on:[] and Phase 2 promotes the milestone to 'active' even
+      // when its dependencies are unmet (#3340).
+      const contextPath = resolveMilestoneFile(basePath, diskId, "CONTEXT");
+      const draftPath = !contextPath ? resolveMilestoneFile(basePath, diskId, "CONTEXT-DRAFT") : null;
+      let contextContent: string | null = null;
+      try { contextContent = contextPath ? readFileSync(contextPath, "utf-8") : (draftPath ? readFileSync(draftPath, "utf-8") : null); }
+      catch { /* leave null — insertMilestone will default to [] */ }
+      insertMilestone({ id: diskId, status: 'active', depends_on: parseContextDependsOn(contextContent) });
       synced = true;
     }
   }
@@ -384,11 +393,18 @@ export async function deriveStateFromDb(basePath: string): Promise<GSDState> {
     if (!dbMilestoneIds.has(diskId)) {
       // Synthesize a minimal MilestoneRow for the disk-only milestone.
       // Title and status will be resolved from disk files in the loop below.
+      // Parse depends_on from CONTEXT.md / CONTEXT-DRAFT.md so dep resolution
+      // in Phase 2 (m.depends_on) reflects the real dependency list (#3340).
+      const contextPath2 = resolveMilestoneFile(basePath, diskId, "CONTEXT");
+      const draftPath2 = !contextPath2 ? resolveMilestoneFile(basePath, diskId, "CONTEXT-DRAFT") : null;
+      let contextContent2: string | null = null;
+      try { contextContent2 = contextPath2 ? readFileSync(contextPath2, "utf-8") : (draftPath2 ? readFileSync(draftPath2, "utf-8") : null); }
+      catch { /* leave null — parseContextDependsOn(null) returns [] */ }
       allMilestones.push({
         id: diskId,
         title: diskId,
         status: 'active',
-        depends_on: [] as string[],
+        depends_on: parseContextDependsOn(contextContent2),
         created_at: new Date().toISOString(),
       } as MilestoneRow);
     }

--- a/src/resources/extensions/gsd/tests/reconcile-depends-on.test.ts
+++ b/src/resources/extensions/gsd/tests/reconcile-depends-on.test.ts
@@ -1,0 +1,264 @@
+/**
+ * reconcile-depends-on.test.ts — Regression test for #3340
+ *
+ * When milestones exist on disk but not in the DB, reconciliation in
+ * deriveStateFromDb() inserts them via insertMilestone() without parsing
+ * depends_on from CONTEXT.md. The DB row is then read back in Phase 2 and
+ * m.depends_on comes back as [], so depsUnmet is always false. A milestone
+ * whose dependency is incomplete gets promoted to 'active' — the wrong
+ * milestone is dispatched.
+ *
+ * Two fixes are covered:
+ *   1. insertMilestone() at the incremental disk→DB sync site must be called
+ *      with the depends_on parsed from CONTEXT.md (or CONTEXT-DRAFT.md).
+ *   2. The allMilestones.push() fallback that synthesises a MilestoneRow for
+ *      disk-only milestones must also populate depends_on from disk.
+ *   3. milestoneIdSort() must return a stable order for same-sequence IDs
+ *      (e.g. M001-fkbvng vs M001-1jp4m8) by adding a suffix tiebreaker.
+ */
+
+import { describe, test, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { deriveStateFromDb, invalidateStateCache } from "../state.ts";
+import { openDatabase, closeDatabase, insertMilestone, insertSlice } from "../gsd-db.ts";
+import { milestoneIdSort } from "../milestone-ids.ts";
+
+// ─── Fixture Helpers ─────────────────────────────────────────────────────────
+
+function createFixtureBase(): string {
+  const base = mkdtempSync(join(tmpdir(), "gsd-reconcile-deps-"));
+  mkdirSync(join(base, ".gsd", "milestones"), { recursive: true });
+  return base;
+}
+
+function writeGsdFile(base: string, relativePath: string, content: string): void {
+  const full = join(base, ".gsd", relativePath);
+  mkdirSync(join(full, ".."), { recursive: true });
+  writeFileSync(full, content);
+}
+
+// ─── Test Suite ──────────────────────────────────────────────────────────────
+
+describe("reconcile-depends-on (#3340)", async () => {
+  let base: string;
+
+  beforeEach(() => {
+    base = createFixtureBase();
+  });
+
+  afterEach(() => {
+    closeDatabase();
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  // ── Test 1: reconciliation drops depends_on → wrong milestone dispatched ──
+  //
+  // Setup:
+  //   M001 — complete (DB + SUMMARY on disk)
+  //   M002 — disk-only, depends_on: [M003] (dep M003 is not yet complete)
+  //   M003 — disk-only, no deps
+  //
+  // Expected (correct) behaviour:
+  //   M002 is pending (dep M003 not complete)
+  //   M003 is active  (no unmet deps)
+  //
+  // Before the fix, reconciliation inserted both M002 and M003 with depends_on:[].
+  // When Phase 2 evaluated M002 (processed before M003 numerically), it saw
+  // deps=[] → depsUnmet=false → promoted M002 to 'active' — skipping M003
+  // entirely. The wrong milestone was dispatched and M003 was silently blocked.
+  test("disk-only milestone with unmet depends_on must not be promoted to active", async () => {
+    openDatabase(":memory:");
+
+    // M001: complete in DB + SUMMARY on disk
+    insertMilestone({ id: "M001", title: "M001: Done", status: "complete", depends_on: [] });
+    insertSlice({ id: "S01", milestoneId: "M001", title: "S01: Done", status: "complete", depends: [] });
+    writeGsdFile(base, "milestones/M001/M001-SUMMARY.md", "# M001: Done\n\nComplete.");
+
+    // M002: disk-only, depends_on: [M003] — M003 is not complete yet
+    writeGsdFile(
+      base,
+      "milestones/M002/M002-CONTEXT.md",
+      [
+        "---",
+        "depends_on: [M003]",
+        "---",
+        "",
+        "# M002: Blocked Milestone",
+        "",
+        "Depends on M003 which is not yet done.",
+      ].join("\n"),
+    );
+    writeGsdFile(
+      base,
+      "milestones/M002/M002-ROADMAP.md",
+      [
+        "# M002: Blocked Milestone",
+        "",
+        "**Vision:** Must wait for M003.",
+        "",
+        "## Slices",
+        "",
+        "- [ ] **S01: Work** `risk:low` `depends:[]`",
+        "  > After this: done.",
+      ].join("\n"),
+    );
+
+    // M003: disk-only, no deps — should be the active milestone
+    writeGsdFile(
+      base,
+      "milestones/M003/M003-CONTEXT.md",
+      [
+        "---",
+        "depends_on: []",
+        "---",
+        "",
+        "# M003: Independent Milestone",
+        "",
+        "No dependencies.",
+      ].join("\n"),
+    );
+    writeGsdFile(
+      base,
+      "milestones/M003/M003-ROADMAP.md",
+      [
+        "# M003: Independent Milestone",
+        "",
+        "**Vision:** No dependencies.",
+        "",
+        "## Slices",
+        "",
+        "- [ ] **S01: Work** `risk:low` `depends:[]`",
+        "  > After this: done.",
+      ].join("\n"),
+    );
+
+    invalidateStateCache();
+    const state = await deriveStateFromDb(base);
+
+    // M003 has no unmet deps and must be the active milestone
+    assert.equal(
+      state.activeMilestone?.id,
+      "M003",
+      "M003 (no deps) must be the active milestone, not M002 (#3340)",
+    );
+
+    // M002 depends on incomplete M003 — must be pending, not active
+    const m002 = state.registry.find((m) => m.id === "M002");
+    assert.ok(m002 !== undefined, "M002 should appear in registry");
+    assert.equal(
+      m002?.status,
+      "pending",
+      "M002 depends on incomplete M003 — must be pending (#3340: was incorrectly 'active' before fix)",
+    );
+  });
+
+  // ── Test 2: CONTEXT-DRAFT depends_on is also preserved ───────────────────
+  // Same bug via the draft-only code path: a disk-only milestone that has only
+  // CONTEXT-DRAFT.md (not CONTEXT.md) must also have its depends_on parsed.
+  test("disk-only milestone with CONTEXT-DRAFT must also have depends_on preserved", async () => {
+    openDatabase(":memory:");
+
+    // M001: complete in DB + SUMMARY
+    insertMilestone({ id: "M001", title: "M001: Done", status: "complete", depends_on: [] });
+    writeGsdFile(base, "milestones/M001/M001-SUMMARY.md", "# M001: Done\n\nComplete.");
+
+    // M002: disk-only CONTEXT-DRAFT only, depends_on: [M003]
+    writeGsdFile(
+      base,
+      "milestones/M002/M002-CONTEXT-DRAFT.md",
+      [
+        "---",
+        "depends_on: [M003]",
+        "---",
+        "",
+        "# M002: Draft Milestone",
+        "",
+        "Draft depends on M003.",
+      ].join("\n"),
+    );
+
+    // M003: disk-only, no deps
+    writeGsdFile(
+      base,
+      "milestones/M003/M003-CONTEXT.md",
+      [
+        "---",
+        "depends_on: []",
+        "---",
+        "",
+        "# M003: Independent Milestone",
+        "",
+        "No deps.",
+      ].join("\n"),
+    );
+    writeGsdFile(
+      base,
+      "milestones/M003/M003-ROADMAP.md",
+      [
+        "# M003: Independent Milestone",
+        "",
+        "**Vision:** No deps.",
+        "",
+        "## Slices",
+        "",
+        "- [ ] **S01: Work** `risk:low` `depends:[]`",
+        "  > After this: done.",
+      ].join("\n"),
+    );
+
+    invalidateStateCache();
+    const state = await deriveStateFromDb(base);
+
+    // M003 must be active (no unmet deps)
+    assert.equal(
+      state.activeMilestone?.id,
+      "M003",
+      "M003 must be active when M002 (CONTEXT-DRAFT) has unmet dep on M003 (#3340)",
+    );
+
+    // M002 draft-only with unmet dep must be pending
+    const m002 = state.registry.find((m) => m.id === "M002");
+    assert.ok(m002 !== undefined, "draft M002 should appear in registry");
+    assert.equal(
+      m002?.status,
+      "pending",
+      "draft M002 with unmet depends_on must be pending (#3340)",
+    );
+  });
+
+  // ── Test 3: milestoneIdSort tiebreaker for same-sequence IDs ─────────────
+  // milestoneIdSort returned 0 for M001-fkbvng vs M001-1jp4m8, making sort
+  // non-deterministic. The fix adds a suffix comparison as tiebreaker.
+  test("milestoneIdSort: deterministic ordering for same-sequence unique IDs", () => {
+    const ids = ["M001-zzz000", "M001-aaa111", "M002-abc123", "M001-mmm555"];
+    const sorted = [...ids].sort(milestoneIdSort);
+
+    // All M001-* variants must come before M002-*
+    const m002Index = sorted.indexOf("M002-abc123");
+    const lastM001Index = Math.max(
+      sorted.indexOf("M001-zzz000"),
+      sorted.indexOf("M001-aaa111"),
+      sorted.indexOf("M001-mmm555"),
+    );
+    assert.ok(
+      lastM001Index < m002Index,
+      "All M001-* IDs should sort before M002-abc123",
+    );
+
+    // Among M001-* variants, order must be deterministic (lexicographic by suffix)
+    const m001Variants = sorted.filter((id) => id.startsWith("M001-"));
+    assert.deepEqual(
+      m001Variants,
+      ["M001-aaa111", "M001-mmm555", "M001-zzz000"],
+      "M001-* variants must be sorted lexicographically by suffix for deterministic dispatch",
+    );
+
+    // Two independent sorts must agree
+    const sorted2 = [...ids].sort(milestoneIdSort);
+    assert.deepEqual(sorted, sorted2, "sort must produce identical results across calls");
+  });
+});


### PR DESCRIPTION
## TL;DR

**What:** Parse `depends_on` from CONTEXT.md frontmatter at all three disk→DB milestone reconciliation sites in `state.ts`
**Why:** Reconciliation inserts disk-only milestones with `depends_on:[]`, causing auto-mode to skip prerequisites and dispatch dependent milestones prematurely (#3340)
**How:** Call `parseContextDependsOn()` (already used by the filesystem fallback path) at both reconciliation sites; add suffix tiebreaker to `milestoneIdSort` for deterministic ordering of same-sequence unique IDs

## What

Two files changed:

**`src/resources/extensions/gsd/state.ts`** — two reconciliation sites fixed:

1. *Incremental disk→DB sync* (line ~307): `insertMilestone({ id: diskId, status: 'active' })` was called without `depends_on`. The DB row was therefore stored with `depends_on:[]`. When Phase 2 of `deriveStateFromDb` evaluated that row's `m.depends_on`, it always saw an empty array, so `depsUnmet` was always `false` — the milestone was promoted to `active` regardless of whether its dependencies were actually satisfied.

   After the fix: CONTEXT.md (falling back to CONTEXT-DRAFT.md) is read synchronously before the insert, and the parsed `depends_on` is passed to `insertMilestone()`.

2. *`allMilestones.push()` fallback* (line ~353): A second code path synthesises a `MilestoneRow` directly for disk-only milestones that weren't caught by the first loop. It hardcoded `depends_on: [] as string[]`. Same root effect as above.

   After the fix: same CONTEXT.md parse before the push.

**`src/resources/extensions/gsd/milestone-ids.ts`** — `milestoneIdSort` fixed:

`milestoneIdSort` returned `0` for any two IDs with the same sequence number (e.g. `M001-fkbvng` vs `M001-1jp4m8`). A comparator that returns 0 for distinct elements makes `Array.sort` non-deterministic across V8 versions and input orderings. The fix adds a full-ID lexicographic tiebreaker when sequence numbers match.

## Why

Closes #3340

When a project uses both DB-backed state and disk-managed milestones (e.g. after adding a new milestone via `/gsd queue` or by writing CONTEXT.md directly), the reconciliation code in `deriveStateFromDb` must sync disk milestones into the DB before Phase 2 evaluates them. The `depends_on` field was silently dropped during that sync.

The practical consequence: if milestone M002 `depends_on: [M003]` and both are disk-only, the reconciliation inserted M002 with `depends_on:[]`. Phase 2 evaluated M002 first (numeric sort: M002 < M003), saw no unmet deps, and promoted M002 to `active`. M003 — the prerequisite — was never dispatched. Every auto-mode cycle then ran M002 against an unmet precondition, burning token budget without making progress.

## How

`parseContextDependsOn()` already existed and was already used by the filesystem fallback path (`_deriveStateImpl`). The fix just calls it at the two DB reconciliation sites that previously bypassed it.

The CONTEXT-DRAFT.md fallback mirrors the existing pattern in Phase 2 of `deriveStateFromDb` (line ~469): CONTEXT.md is preferred; CONTEXT-DRAFT.md is used when CONTEXT.md is absent.

The `milestoneIdSort` tiebreaker (full-ID lexicographic comparison when sequence numbers match) ensures that teams using unique milestone IDs get a stable dispatch order regardless of input ordering or V8 sort implementation details.

## Change type

- [x] `fix` — Bug fix

## Scope

- [x] `gsd extension` — GSD workflow

## Breaking changes

- [x] No breaking changes

## Test plan

- [x] New/updated tests included
- [x] CI passes

New test file: `src/resources/extensions/gsd/tests/reconcile-depends-on.test.ts`

Three regression tests:

1. **`disk-only milestone with unmet depends_on must not be promoted to active`** — Seeds M001 (complete, in DB), M002 (disk-only, `depends_on:[M003]`), M003 (disk-only, no deps). Before the fix: M002 was promoted to `active` because its `depends_on` was silently dropped. After the fix: M003 is `active`, M002 is `pending`.

2. **`disk-only milestone with CONTEXT-DRAFT must also have depends_on preserved`** — Same scenario with M002 using only CONTEXT-DRAFT.md. Verifies the draft-file fallback path is also fixed.

3. **`milestoneIdSort: deterministic ordering for same-sequence unique IDs`** — Sorts `[M001-zzz000, M001-aaa111, M002-abc123, M001-mmm555]` and asserts that M001-* variants are in lexicographic suffix order. Fails before the fix (non-deterministic), passes after.

All three tests were confirmed to fail before the fix and pass after.

## AI disclosure

- [x] This PR includes AI-assisted code (Claude Code — regression tests written first to confirm failure, fix verified locally against all three tests and the full build)