### PR TITLE
feat(prompts): inject slice discussion context into downstream agent prompts

### DIFF
--- a/src/resources/extensions/gsd/auto-prompts.ts
+++ b/src/resources/extensions/gsd/auto-prompts.ts
@@ -984,6 +984,10 @@ export async function buildResearchSlicePrompt(
   inlined.push(await inlineFile(roadmapPath, roadmapRel, "Milestone Roadmap"));
   const contextInline = await inlineFileOptional(contextPath, contextRel, "Milestone Context");
   if (contextInline) inlined.push(contextInline);
+  const sliceContextPath = resolveSliceFile(base, mid, sid, "CONTEXT");
+  const sliceContextRel = relSliceFile(base, mid, sid, "CONTEXT");
+  const sliceContextInline = await inlineFileOptional(sliceContextPath, sliceContextRel, "Slice Context (from discussion)");
+  if (sliceContextInline) inlined.push(sliceContextInline);
   const researchInline = await inlineFileOptional(milestoneResearchPath, milestoneResearchRel, "Milestone Research");
   if (researchInline) inlined.push(researchInline);
   const decisionsInline = await inlineDecisionsFromDb(base, mid);
@@ -1034,6 +1038,10 @@ export async function buildPlanSlicePrompt(
 
   const inlined: string[] = [];
   inlined.push(await inlineFile(roadmapPath, roadmapRel, "Milestone Roadmap"));
+  const sliceContextPathPS = resolveSliceFile(base, mid, sid, "CONTEXT");
+  const sliceContextRelPS = relSliceFile(base, mid, sid, "CONTEXT");
+  const sliceContextInlinePS = await inlineFileOptional(sliceContextPathPS, sliceContextRelPS, "Slice Context (from discussion)");
+  if (sliceContextInlinePS) inlined.push(sliceContextInlinePS);
   const researchInline = await inlineFileOptional(researchPath, researchRel, "Slice Research");
   if (researchInline) inlined.push(researchInline);
   if (inlineLevel !== "minimal") {
@@ -1232,6 +1240,10 @@ export async function buildCompleteSlicePrompt(
   const inlined: string[] = [];
   inlined.push(await inlineFile(roadmapPath, roadmapRel, "Milestone Roadmap"));
   inlined.push(await inlineFile(slicePlanPath, slicePlanRel, "Slice Plan"));
+  const sliceContextPathCS = resolveSliceFile(base, mid, sid, "CONTEXT");
+  const sliceContextRelCS = relSliceFile(base, mid, sid, "CONTEXT");
+  const sliceContextInlineCS = await inlineFileOptional(sliceContextPathCS, sliceContextRelCS, "Slice Context (from discussion)");
+  if (sliceContextInlineCS) inlined.push(sliceContextInlineCS);
   if (inlineLevel !== "minimal") {
     const requirementsInline = await inlineRequirementsFromDb(base, sid, inlineLevel);
     if (requirementsInline) inlined.push(requirementsInline);
@@ -1483,6 +1495,10 @@ export async function buildReplanSlicePrompt(
   const inlined: string[] = [];
   inlined.push(await inlineFile(roadmapPath, roadmapRel, "Milestone Roadmap"));
   inlined.push(await inlineFile(slicePlanPath, slicePlanRel, "Current Slice Plan"));
+  const sliceContextPathRP = resolveSliceFile(base, mid, sid, "CONTEXT");
+  const sliceContextRelRP = relSliceFile(base, mid, sid, "CONTEXT");
+  const sliceContextInlineRP = await inlineFileOptional(sliceContextPathRP, sliceContextRelRP, "Slice Context (from discussion)");
+  if (sliceContextInlineRP) inlined.push(sliceContextInlineRP);
 
   // Find the blocker task summary — the completed task with blocker_discovered: true
   let blockerTaskId = "";
@@ -1600,6 +1616,10 @@ export async function buildReassessRoadmapPrompt(
   const inlined: string[] = [];
   inlined.push(await inlineFile(roadmapPath, roadmapRel, "Current Roadmap"));
   inlined.push(await inlineFile(summaryPath, summaryRel, `${completedSliceId} Summary`));
+  const sliceContextPathRA = resolveSliceFile(base, mid, completedSliceId, "CONTEXT");
+  const sliceContextRelRA = relSliceFile(base, mid, completedSliceId, "CONTEXT");
+  const sliceContextInlineRA = await inlineFileOptional(sliceContextPathRA, sliceContextRelRA, `${completedSliceId} Slice Context (from discussion)`);
+  if (sliceContextInlineRA) inlined.push(sliceContextInlineRA);
   if (inlineLevel !== "minimal") {
     const projectInline = await inlineProjectFromDb(base);
     if (projectInline) inlined.push(projectInline);

--- a/src/resources/extensions/gsd/prompts/plan-slice.md
+++ b/src/resources/extensions/gsd/prompts/plan-slice.md
@@ -34,7 +34,7 @@ Read the code files relevant to this slice. Confirm the roadmap's description of
 
 If slice research exists (inlined above), trust those findings and skip redundant exploration.
 
-After you finish, **executor agents** implement each task in isolated fresh context windows. They see only their task plan, the slice plan excerpt (goal/demo/verification), and compressed summaries of prior tasks. They do not see the research doc, the roadmap, or REQUIREMENTS.md. Everything an executor needs must be in the task plan itself — file paths, specific steps, expected inputs and outputs.
+After you finish, **executor agents** implement each task in isolated fresh context windows. They see only their task plan, the slice plan excerpt (goal/demo/verification), and compressed summaries of prior tasks. They do not see the research doc, the slice context, the roadmap, or REQUIREMENTS.md. Everything an executor needs must be in the task plan itself — file paths, specific steps, expected inputs and outputs.
 
 Narrate your decomposition reasoning — why you're grouping work this way, what risks are driving the order, what verification strategy you're choosing and why. Keep the narration proportional to the work — a simple slice doesn't need a long justification — but write in complete sentences, not planner shorthand.
 

--- a/src/resources/extensions/gsd/tests/slice-context-injection.test.ts
+++ b/src/resources/extensions/gsd/tests/slice-context-injection.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Slice context injection contract tests.
+ *
+ * Verifies that S-CONTEXT files from slice discussion are injected into the
+ * correct prompt builders in auto-prompts.ts and that the plan-slice template
+ * warns planners that executors don't see slice context.
+ *
+ * Uses source-code inspection (same pattern as triage-dispatch.test.ts) because
+ * the prompt builders have deep runtime dependencies (DB, preferences, etc.)
+ * that make direct invocation impractical in unit tests.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const autoPromptsSrc = readFileSync(join(__dirname, "..", "auto-prompts.ts"), "utf-8");
+const promptsDir = join(__dirname, "..", "prompts");
+
+function readPrompt(name: string): string {
+  return readFileSync(join(promptsDir, `${name}.md`), "utf-8");
+}
+
+/**
+ * Extract the body of a named function from auto-prompts.ts source.
+ * Finds `function name(` and returns everything up to the next top-level
+ * `export` or end of file.
+ */
+function extractFunctionBody(name: string): string {
+  const fnStart = autoPromptsSrc.indexOf(`function ${name}(`);
+  assert.ok(fnStart >= 0, `function ${name} should exist in auto-prompts.ts`);
+  const nextExport = autoPromptsSrc.indexOf("\nexport ", fnStart + 1);
+  return autoPromptsSrc.slice(fnStart, nextExport > 0 ? nextExport : undefined);
+}
+
+// ─── Slice context injection in prompt builders ─────────────────────────────
+
+test("research-slice prompt builder inlines S-CONTEXT when available", () => {
+  const body = extractFunctionBody("buildResearchSlicePrompt");
+  assert.match(body, /resolveSliceFile\(base, mid, sid, "CONTEXT"\)/,
+    "should resolve slice CONTEXT path");
+  assert.match(body, /inlineFileOptional\(.*"Slice Context \(from discussion\)"\)/,
+    "should inline slice context with descriptive label");
+});
+
+test("plan-slice prompt builder inlines S-CONTEXT when available", () => {
+  const body = extractFunctionBody("buildPlanSlicePrompt");
+  assert.match(body, /resolveSliceFile\(base, mid, sid, "CONTEXT"\)/,
+    "should resolve slice CONTEXT path");
+  assert.match(body, /inlineFileOptional\(.*"Slice Context \(from discussion\)"\)/,
+    "should inline slice context with descriptive label");
+});
+
+test("complete-slice prompt builder inlines S-CONTEXT when available", () => {
+  const body = extractFunctionBody("buildCompleteSlicePrompt");
+  assert.match(body, /resolveSliceFile\(base, mid, sid, "CONTEXT"\)/,
+    "should resolve slice CONTEXT path");
+  assert.match(body, /inlineFileOptional\(.*"Slice Context \(from discussion\)"\)/,
+    "should inline slice context with descriptive label");
+});
+
+test("replan-slice prompt builder inlines S-CONTEXT when available", () => {
+  const body = extractFunctionBody("buildReplanSlicePrompt");
+  assert.match(body, /resolveSliceFile\(base, mid, sid, "CONTEXT"\)/,
+    "should resolve slice CONTEXT path");
+  assert.match(body, /inlineFileOptional\(.*"Slice Context \(from discussion\)"\)/,
+    "should inline slice context with descriptive label");
+});
+
+test("reassess-roadmap prompt builder inlines completed slice's S-CONTEXT", () => {
+  const body = extractFunctionBody("buildReassessRoadmapPrompt");
+  assert.match(body, /resolveSliceFile\(base, mid, completedSliceId, "CONTEXT"\)/,
+    "should resolve completed slice CONTEXT path");
+  assert.match(body, /inlineFileOptional\(.*Slice Context \(from discussion\)/,
+    "should inline slice context with descriptive label");
+});
+
+// ─── Prompt template: executor visibility warning ───────────────────────────
+
+test("plan-slice prompt warns that executors do not see slice context", () => {
+  const prompt = readPrompt("plan-slice");
+  assert.match(prompt, /slice context/i,
+    "plan-slice template should mention slice context in executor visibility note");
+  assert.match(prompt, /They do not see the research doc, the slice context, the roadmap/,
+    "executor visibility note should list slice context alongside other excluded artifacts");
+});
+
+// ─── Negative: execute-task should NOT inject S-CONTEXT ─────────────────────
+
+test("execute-task prompt builder does NOT inline S-CONTEXT", () => {
+  const body = extractFunctionBody("buildExecuteTaskPrompt");
+  assert.doesNotMatch(body, /resolveSliceFile\(base, mid, sid, "CONTEXT"\)/,
+    "executors should not get slice context — planners distill it into task plans");
+});


### PR DESCRIPTION
## TL;DR

**What:** Inject slice-level CONTEXT files (from `discuss-slice`) into five downstream prompt builders so agents can see the user's discussed requirements.
**Why:** Slice CONTEXT files were write-only — produced during discussion but never fed back to researchers, planners, completers, replanners, or reassessors. This completes the `require_slice_discussion` feature (#845).
**How:** Add optional `inlineFileOptional()` calls for S-CONTEXT in five `auto-prompts.ts` builders; update plan-slice.md executor visibility note; add 7 source-inspection regression tests.

## What

| File | Change |
|------|--------|
| `src/resources/extensions/gsd/auto-prompts.ts` | Add optional S-CONTEXT inline to `buildResearchSlicePrompt`, `buildPlanSlicePrompt`, `buildCompleteSlicePrompt`, `buildReplanSlicePrompt`, `buildReassessRoadmapPrompt` |
| `src/resources/extensions/gsd/prompts/plan-slice.md` | Add "the slice context" to executor visibility warning so planners distill discussed requirements into task plans |
| `src/resources/extensions/gsd/tests/slice-context-injection.test.ts` | 7 regression tests: 5 positive (each builder resolves+inlines S-CONTEXT), 1 prompt template assertion, 1 negative (execute-task must NOT inject S-CONTEXT) |

## Why

PR #845 introduced `require_slice_discussion` — a preference that pauses auto-mode before each slice until a CONTEXT file exists from discussion. However, the resulting `S##-CONTEXT.md` files (5–9K of user-discussed requirements, acceptance criteria, and design decisions) were never injected into any downstream prompt builder.

**Observed impact in production:** Running Opus 4.6 planning with GPT-5.4 execution (all high reasoning effort) on a real 6-slice milestone (IronWing M002 — Mission Editor), then reviewing with Claude Code, revealed that most missing requirements traced back to discussed context that executors and planners never saw:

| Slice | Done | Partial | Missing | Completion |
|-------|------|---------|---------|------------|
| S01 Command Metadata | 11 | 1 | 0 | ~96% |
| S02 Editing UX | 6 | 1 | 2 | ~72% |
| S03 Terrain Profile | 6 | 4 | 3 | ~54% |
| S04 Map Path Rendering | 4 | 4 | 2 | ~50% |
| S05 File I/O | 10 | 0 | 3 | ~77% |
| S06 Mission Statistics | 7 | 2 | 5 | ~52% |

Slices that had detailed discussion context (S03–S06 each had 6–9K CONTEXT files with specific acceptance criteria) showed 50–77% completion — the missing items were predominantly requirements captured in `S##-CONTEXT.md` that the planner never saw and therefore never decomposed into tasks. S01 hit ~96% because its requirements were straightforward enough to derive from the roadmap excerpt alone.

Without this fix, the `require_slice_discussion` feature produces artifacts that are effectively write-only — the user invests time discussing requirements, but the pipeline ignores them.

## How

Each injection follows the existing `inlineFileOptional()` pattern used throughout `auto-prompts.ts` for milestone CONTEXT, RESEARCH, DECISIONS, etc.:

```typescript
const sliceContextPath = resolveSliceFile(base, mid, sid, "CONTEXT");
const sliceContextRel = relSliceFile(base, mid, sid, "CONTEXT");
const sliceContextInline = await inlineFileOptional(sliceContextPath, sliceContextRel, "Slice Context (from discussion)");
if (sliceContextInline) inlined.push(sliceContextInline);
```

**Backwards compatible:** When S-CONTEXT doesn't exist (projects not using slice discussion), `inlineFileOptional` returns null and nothing changes.

**Deliberately excluded from execute-task:** Executors operate in tight context windows. The planner should distill discussed requirements into task plans — the plan-slice.md prompt now explicitly warns about this.

**Alternatives considered:**
- Injecting into execute-task — rejected due to context window pressure; planner distillation is the better path
- Injecting M-CONTEXT into plan-slice — considered but dropped; milestone context is already available via research-slice which feeds into planning

## Test Evidence

| Step | Result |
|---|---|
| `npm run build` | pass |
| `npx tsc --noEmit` | pass (0 errors) |
| New tests (7/7) | pass |
| Full suite | 4520 pass, 8 fail (all pre-existing) |

## Change type

- [x] `feat` — New feature (non-breaking addition)

## Scope

- [x] `gsd extension` — GSD workflow

## Breaking changes

- [x] No breaking changes

> AI-assisted contribution — reviewed and tested by contributor.