### PR TITLE
fix(gsd): add .bg-shell/ to baseline gitignore patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -691,6 +691,9 @@ The best practice for working in teams is to ensure unique milestone names acros
 # Session-specific interrupted-work markers
 .gsd/milestones/**/continue.md
 .gsd/milestones/**/*-CONTINUE.md
+
+# ── bg-shell: Process manifest (per-developer, per-session) ───────────────
+.bg-shell/
 ```
 
 ### Unique Milestone Names

--- a/src/resources/extensions/gsd/gitignore.ts
+++ b/src/resources/extensions/gsd/gitignore.ts
@@ -43,6 +43,9 @@ const BASELINE_PATTERNS = [
   ".gsd",
   ".gsd-id",
 
+  // ── bg-shell process manifest (ephemeral runtime state) ──
+  ".bg-shell/",
+
   // ── OS junk ──
   ".DS_Store",
   "Thumbs.db",

--- a/src/resources/extensions/gsd/tests/integration/gitignore-bg-shell.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/gitignore-bg-shell.test.ts
@@ -1,0 +1,74 @@
+/**
+ * gitignore-bg-shell.test.ts — Regression test for .bg-shell/ gitignore coverage.
+ *
+ * Verifies that ensureGitignore() includes .bg-shell/ in baseline patterns,
+ * so freshly initialized projects ignore the bg-shell process manifest directory.
+ *
+ * Uses real temporary git repos — no mocks.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import {
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { ensureGitignore } from "../../gitignore.ts";
+
+// ─── Helpers ─────────────────────────────────────────────────────────
+
+function git(dir: string, ...args: string[]): string {
+  return execFileSync("git", args, { cwd: dir, stdio: "pipe", encoding: "utf-8" }).trim();
+}
+
+function makeTempRepo(): string {
+  const dir = mkdtempSync(join(tmpdir(), "gsd-bg-shell-gitignore-"));
+  git(dir, "init");
+  git(dir, "config", "user.email", "test@test.com");
+  git(dir, "config", "user.name", "Test");
+  writeFileSync(join(dir, "README.md"), "# init\n");
+  git(dir, "add", "-A");
+  git(dir, "commit", "-m", "init");
+  git(dir, "branch", "-M", "main");
+  return dir;
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────
+
+test("ensureGitignore includes .bg-shell/ in baseline patterns", (t) => {
+  const dir = makeTempRepo();
+  t.after(() => { rmSync(dir, { recursive: true, force: true }); });
+
+  ensureGitignore(dir);
+
+  const gitignore = readFileSync(join(dir, ".gitignore"), "utf-8");
+  const lines = gitignore.split("\n").map((l) => l.trim());
+  assert.ok(
+    lines.includes(".bg-shell/"),
+    `Expected .bg-shell/ in .gitignore baseline patterns, but it's missing:\n${gitignore}`,
+  );
+});
+
+test("ensureGitignore does not duplicate .bg-shell/ if already present", (t) => {
+  const dir = makeTempRepo();
+  t.after(() => { rmSync(dir, { recursive: true, force: true }); });
+
+  // Pre-populate with .bg-shell/ already present
+  writeFileSync(join(dir, ".gitignore"), ".bg-shell/\nnode_modules/\n");
+
+  ensureGitignore(dir);
+
+  const gitignore = readFileSync(join(dir, ".gitignore"), "utf-8");
+  const occurrences = gitignore.split("\n").filter((l) => l.trim() === ".bg-shell/");
+  assert.equal(
+    occurrences.length,
+    1,
+    `Expected exactly one .bg-shell/ entry, found ${occurrences.length}:\n${gitignore}`,
+  );
+});


### PR DESCRIPTION
## TL;DR

**What:** Add `.bg-shell/` to the auto-generated `.gitignore` baseline patterns.
**Why:** The bg-shell process manifest directory is ephemeral runtime state that should never be committed, but `ensureGitignore()` was not including it.
**How:** Add the pattern to `BASELINE_PATTERNS` in `gitignore.ts` and to the README's suggested `.gitignore` section.

Closes #3388

## What

- `src/resources/extensions/gsd/gitignore.ts` — Added `.bg-shell/` to `BASELINE_PATTERNS` array
- `README.md` — Added `.bg-shell/` to the "Suggested .gitignore setup" section under "Working in teams"
- `src/resources/extensions/gsd/tests/integration/gitignore-bg-shell.test.ts` — Regression test (2 cases: pattern applied + idempotency)

## Why

`bg-shell/process-manager.ts:428` creates `.bg-shell/` in the project root to persist process manifests across sessions. This is per-developer, per-session state — exactly the kind of thing `BASELINE_PATTERNS` exists to catch. The pattern was missing, so freshly initialized projects would surface `.bg-shell/` as untracked in `git status`.

## How

Added `.bg-shell/` alongside the existing `.gsd` and `.gsd-id` entries in `BASELINE_PATTERNS`. The existing `ensureGitignore()` logic handles the rest — dedup, append-only, idempotent.

## Change type

- [x] `fix` — Bug fix

## Scope

- [x] `gsd extension` — GSD workflow

## Breaking changes

- [x] No breaking changes

## Test plan

- [x] CI passes
- [x] New/updated tests included — 2 new integration tests
- [x] All 18 existing gitignore integration tests pass (zero regressions)

## AI disclosure

- [x] This PR includes AI-assisted code — generated with GSD/Claude, all tests verified locally