### PR TITLE
fix(captures): insert injected tasks into DB so deriveState dispatches them

### DIFF
--- a/src/resources/extensions/gsd/tests/triage-resolution.test.ts
+++ b/src/resources/extensions/gsd/tests/triage-resolution.test.ts
@@ -104,6 +104,31 @@ test("resolution: executeInject returns null when plan doesn't exist", () => {
   }
 });
 
+test("resolution: executeInject creates task plan file in tasks/ directory", () => {
+  const tmp = makeTempDir("res-inject-planfile");
+  try {
+    setupPlanFile(tmp, "M001", "S01", SAMPLE_PLAN);
+    const captureId = appendCapture(tmp, "add error handling");
+    const captures = loadAllCaptures(tmp);
+
+    const newId = executeInject(tmp, "M001", "S01", captures[0]);
+    assert.strictEqual(newId, "T04");
+
+    // Verify task plan file was created
+    const taskPlanPath = join(
+      tmp, ".gsd", "milestones", "M001", "slices", "S01", "tasks", "T04-PLAN.md",
+    );
+    assert.ok(existsSync(taskPlanPath), "task plan file should exist");
+
+    const planContent = readFileSync(taskPlanPath, "utf-8");
+    assert.ok(planContent.includes("# T04:"), "should have task heading");
+    assert.ok(planContent.includes("add error handling"), "should include capture text");
+    assert.ok(planContent.includes(captures[0].id), "should reference capture ID");
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
 // ─── executeReplan ────────────────────────────────────────────────────────────
 
 test("resolution: executeReplan writes REPLAN-TRIGGER.md", () => {

--- a/src/resources/extensions/gsd/triage-resolution.ts
+++ b/src/resources/extensions/gsd/triage-resolution.ts
@@ -13,7 +13,7 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { createRequire } from "node:module";
-import { gsdRoot, milestonesDir } from "./paths.js";
+import { gsdRoot, milestonesDir, buildTaskFileName } from "./paths.js";
 import { MILESTONE_ID_RE } from "./milestone-ids.js";
 import type { Classification, CaptureEntry } from "./captures.js";
 import {
@@ -24,6 +24,7 @@ import {
   markCaptureExecuted,
   stampCaptureMilestone,
 } from "./captures.js";
+import { isDbAvailable, insertTask, getSliceTasks } from "./gsd-db.js";
 
 // ─── Resolution Executors ─────────────────────────────────────────────────────
 
@@ -69,6 +70,63 @@ export function executeInject(
     } else {
       // No Files section — append at end
       writeFileSync(planPath, content.trimEnd() + "\n\n" + newTask + "\n", "utf-8");
+    }
+
+    // Insert into DB so deriveState() sees the task and dispatches it.
+    // Without this, the state machine reads tasks from the DB only and
+    // skips markdown-only tasks, causing injected work to be lost (#2890).
+    if (isDbAvailable()) {
+      try {
+        const existingTasks = getSliceTasks(mid, sid);
+        const maxSequence = existingTasks.reduce(
+          (max, t) => Math.max(max, t.sequence ?? 0), 0,
+        );
+        insertTask({
+          id: newId,
+          sliceId: sid,
+          milestoneId: mid,
+          title: capture.text,
+          status: "pending",
+          sequence: maxSequence + 1,
+          planning: {
+            description: `Injected from capture ${capture.id}: ${capture.text}`,
+            estimate: "30m",
+          },
+        });
+      } catch (dbErr) {
+        // DB insert is best-effort — the markdown write already succeeded,
+        // and the reconciliation path in state.ts may pick it up eventually.
+        process.stderr.write(
+          `gsd-inject: DB insert for ${newId} failed: ${(dbErr as Error).message}\n`,
+        );
+      }
+    }
+
+    // Write a minimal task plan file so the dispatch rule does not
+    // fall back to plan-slice regeneration (#909 guard).
+    try {
+      const tasksDir = join(gsdRoot(basePath), "milestones", mid, "slices", sid, "tasks");
+      if (!existsSync(tasksDir)) mkdirSync(tasksDir, { recursive: true });
+      const taskPlanPath = join(tasksDir, buildTaskFileName(newId, "PLAN"));
+      if (!existsSync(taskPlanPath)) {
+        const taskPlanContent = [
+          `# ${newId}: ${capture.text}`,
+          ``,
+          `**Injected from:** capture ${capture.id}`,
+          `**Estimate:** 30m`,
+          ``,
+          `## Steps`,
+          ``,
+          `1. ${capture.text}`,
+          ``,
+          `## Verify`,
+          ``,
+          `- Capture intent fulfilled`,
+        ].join("\n");
+        writeFileSync(taskPlanPath, taskPlanContent, "utf-8");
+      }
+    } catch {
+      // Non-fatal — dispatch will trigger plan-slice if plan file is missing
     }
 
     return newId;


### PR DESCRIPTION
## Problem

`executeInject()` in `triage-resolution.ts` only wrote injected tasks to the markdown plan file (`S##-PLAN.md`), but `deriveState()` reads tasks exclusively from the SQLite DB via `getSliceTasks()`. Injected tasks were invisible to the auto-mode state machine — the loop would skip them, complete the slice, and finish the milestone without executing captured work.

## Root Cause

Markdown ↔ DB desync: the inject path wrote to markdown but not to the DB, which is the single source of truth for task state.

## Fix

In `executeInject()`, after the markdown write:
1. Call `insertTask()` to add the task to the DB with `status: 'pending'` and correct sequence ordering
2. Create a minimal task plan file in `tasks/T##-PLAN.md` to avoid unnecessary plan-slice regeneration

Both operations degrade gracefully — markdown write is primary, DB/plan file are best-effort with logged warnings.

## Test Coverage

- Added test verifying task plan file creation on inject
- All 79 existing tests across captures, triage-resolution, and triage-dispatch pass with no regressions