### PR TITLE
feat(gsd-extension): add opt-in context-pressure wrapup disable

### DIFF
--- a/src/resources/extensions/gsd/auto-timers.ts
+++ b/src/resources/extensions/gsd/auto-timers.ts
@@ -278,6 +278,16 @@ export function startUnitSupervision(sctx: SupervisionContext): void {
     prefs as Parameters<typeof resolveExecutorContextWindow>[1],
     ctx.model?.contextWindow,
   );
+  if (supervisor.disable_context_pressure_wrapup) {
+    if (s.verbose) {
+      ctx.ui.notify(
+        "Context-pressure continue-here monitor disabled by auto_supervisor.disable_context_pressure_wrapup.",
+        "info",
+      );
+    }
+    return;
+  }
+
   const continueHereThreshold = computeBudgets(executorContextWindow).continueThresholdPercent;
   s.continueHereHandle = setInterval(() => {
     if (!s.active || !s.currentUnit || !s.cmdCtx) return;

--- a/src/resources/extensions/gsd/docs/preferences-reference.md
+++ b/src/resources/extensions/gsd/docs/preferences-reference.md
@@ -123,6 +123,7 @@ Setting `prefer_skills: []` does **not** disable skill discovery — it just mea
   - `soft_timeout_minutes`: minutes before the supervisor issues a soft warning (default: 20).
   - `idle_timeout_minutes`: minutes of inactivity before the supervisor intervenes (default: 10).
   - `hard_timeout_minutes`: minutes before the supervisor forces termination (default: 30).
+  - `disable_context_pressure_wrapup`: boolean — opt-in. Disables the context-pressure continue-here / wrap-up monitor while keeping the soft, idle, and hard timeout supervisor checks active. Default: `false`.
 
 - `git`: configures GSD's git behavior. All fields are optional — omit any to use defaults. Keys:
   - `auto_push`: boolean — automatically push commits to the remote after committing. Default: `false`.

--- a/src/resources/extensions/gsd/preferences-models.ts
+++ b/src/resources/extensions/gsd/preferences-models.ts
@@ -308,6 +308,7 @@ export function resolveAutoSupervisorConfig(): AutoSupervisorConfig {
     soft_timeout_minutes: configured.soft_timeout_minutes ?? 20,
     idle_timeout_minutes: configured.idle_timeout_minutes ?? 10,
     hard_timeout_minutes: configured.hard_timeout_minutes ?? 30,
+    disable_context_pressure_wrapup: configured.disable_context_pressure_wrapup === true,
     ...(configured.model ? { model: configured.model } : {}),
   };
 }

--- a/src/resources/extensions/gsd/preferences-types.ts
+++ b/src/resources/extensions/gsd/preferences-types.ts
@@ -190,6 +190,8 @@ export interface AutoSupervisorConfig {
   soft_timeout_minutes?: number;
   idle_timeout_minutes?: number;
   hard_timeout_minutes?: number;
+  /** Opt-in: disable the context-pressure continue-here wrap-up monitor while keeping timeout supervision active. */
+  disable_context_pressure_wrapup?: boolean;
 }
 
 export interface RemoteQuestionsConfig {

--- a/src/resources/extensions/gsd/templates/PREFERENCES.md
+++ b/src/resources/extensions/gsd/templates/PREFERENCES.md
@@ -9,7 +9,11 @@ custom_instructions: []
 models: {}
 skill_discovery:
 skill_staleness_days:
-auto_supervisor: {}
+auto_supervisor:
+  soft_timeout_minutes:
+  idle_timeout_minutes:
+  hard_timeout_minutes:
+  disable_context_pressure_wrapup:
 git:
   auto_push:
   push_branches:

--- a/src/resources/extensions/gsd/tests/auto-supervisor.test.mjs
+++ b/src/resources/extensions/gsd/tests/auto-supervisor.test.mjs
@@ -1,16 +1,140 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, readFileSync } from 'node:fs';
+import { mkdtempSync, readFileSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { writeUnitRuntimeRecord, readUnitRuntimeRecord } from '../unit-runtime.ts';
 import { resolveAutoSupervisorConfig } from '../preferences.ts';
+import { startUnitSupervision } from '../auto-timers.ts';
 
-test('resolveAutoSupervisorConfig provides safe timeout defaults', () => {
+function isolatePreferences(t, preferenceBlock = '') {
+  const base = mkdtempSync(join(tmpdir(), 'gsd-auto-supervisor-'));
+  const fakeHome = mkdtempSync(join(tmpdir(), 'gsd-auto-supervisor-home-'));
+  mkdirSync(join(base, '.gsd'), { recursive: true });
+  if (preferenceBlock) {
+    writeFileSync(join(base, '.gsd', 'PREFERENCES.md'), `---\nversion: 1\n${preferenceBlock}\n---\n`, 'utf8');
+  }
+
+  const savedCwd = process.cwd();
+  const savedGsdHome = process.env.GSD_HOME;
+  process.chdir(base);
+  process.env.GSD_HOME = fakeHome;
+
+  t.after(() => {
+    process.chdir(savedCwd);
+    if (savedGsdHome === undefined) delete process.env.GSD_HOME;
+    else process.env.GSD_HOME = savedGsdHome;
+    rmSync(base, { recursive: true, force: true });
+    rmSync(fakeHome, { recursive: true, force: true });
+  });
+
+  return base;
+}
+
+function makeSupervisionContext(base) {
+  const s = {
+    active: true,
+    basePath: base,
+    verbose: false,
+    currentMilestoneId: null,
+    currentUnit: {
+      type: 'task',
+      id: 'T01',
+      startedAt: Date.now(),
+    },
+    cmdCtx: {
+      getContextUsage: () => null,
+    },
+    continueHereHandle: null,
+    wrapupWarningHandle: null,
+    idleWatchdogHandle: null,
+    unitTimeoutHandle: null,
+  };
+
+  const ctx = {
+    ui: {
+      notify: () => {},
+    },
+    modelRegistry: {
+      getAll: () => [],
+    },
+    model: {
+      contextWindow: 128_000,
+    },
+  };
+
+  const pi = {
+    sendMessage: () => {},
+  };
+
+  return {
+    s,
+    sctx: {
+      s,
+      ctx,
+      pi,
+      unitType: 'task',
+      unitId: 'T01',
+      prefs: undefined,
+      buildSnapshotOpts: () => ({}),
+      buildRecoveryContext: () => ({}),
+      pauseAuto: async () => {},
+      taskEstimate: '10m',
+    },
+  };
+}
+
+function clearSupervisionHandles(s) {
+  if (s.wrapupWarningHandle) clearTimeout(s.wrapupWarningHandle);
+  if (s.idleWatchdogHandle) clearInterval(s.idleWatchdogHandle);
+  if (s.unitTimeoutHandle) clearTimeout(s.unitTimeoutHandle);
+  if (s.continueHereHandle) clearInterval(s.continueHereHandle);
+}
+
+test('resolveAutoSupervisorConfig provides safe timeout defaults', (t) => {
+  isolatePreferences(t);
+
   const supervisor = resolveAutoSupervisorConfig();
   assert.equal(supervisor.soft_timeout_minutes, 20);
   assert.equal(supervisor.idle_timeout_minutes, 10);
   assert.equal(supervisor.hard_timeout_minutes, 30);
+  assert.equal(supervisor.disable_context_pressure_wrapup, false);
+});
+
+test('resolveAutoSupervisorConfig honors disable_context_pressure_wrapup from project preferences', (t) => {
+  isolatePreferences(t, 'auto_supervisor:\n  disable_context_pressure_wrapup: true');
+
+  const supervisor = resolveAutoSupervisorConfig();
+  assert.equal(supervisor.disable_context_pressure_wrapup, true);
+  assert.equal(supervisor.soft_timeout_minutes, 20);
+  assert.equal(supervisor.idle_timeout_minutes, 10);
+  assert.equal(supervisor.hard_timeout_minutes, 30);
+});
+
+test('startUnitSupervision keeps continue-here enabled by default', (t) => {
+  const base = isolatePreferences(t);
+  const { s, sctx } = makeSupervisionContext(base);
+  t.after(() => clearSupervisionHandles(s));
+
+  startUnitSupervision(sctx);
+
+  assert.notEqual(s.wrapupWarningHandle, null, 'soft timeout handle should be set');
+  assert.notEqual(s.idleWatchdogHandle, null, 'idle watchdog handle should be set');
+  assert.notEqual(s.unitTimeoutHandle, null, 'hard timeout handle should be set');
+  assert.notEqual(s.continueHereHandle, null, 'continue-here monitor should be enabled by default');
+});
+
+test('startUnitSupervision disables only continue-here when opt-out is enabled', (t) => {
+  const base = isolatePreferences(t, 'auto_supervisor:\n  disable_context_pressure_wrapup: true');
+  const { s, sctx } = makeSupervisionContext(base);
+  t.after(() => clearSupervisionHandles(s));
+
+  startUnitSupervision(sctx);
+
+  assert.notEqual(s.wrapupWarningHandle, null, 'soft timeout handle should still be set');
+  assert.notEqual(s.idleWatchdogHandle, null, 'idle watchdog handle should still be set');
+  assert.notEqual(s.unitTimeoutHandle, null, 'hard timeout handle should still be set');
+  assert.equal(s.continueHereHandle, null, 'continue-here monitor should be disabled by opt-out');
 });
 
 test('writeUnitRuntimeRecord persists progress and recovery metadata defaults', () => {
@@ -31,6 +155,8 @@ test('writeUnitRuntimeRecord persists progress and recovery metadata defaults', 
   assert.equal(runtime.progressCount, 1);
   assert.equal(runtime.lastProgressKind, 'dispatch');
   assert.equal(runtime.recoveryAttempts, 0);
+
+  rmSync(base, { recursive: true, force: true });
 });
 
 test('writeUnitRuntimeRecord keeps explicit recovery attempt fields', () => {
@@ -50,4 +176,6 @@ test('writeUnitRuntimeRecord keeps explicit recovery attempt fields', () => {
   assert.equal(runtime.recoveryAttempts, 2);
   assert.equal(runtime.lastRecoveryReason, 'idle');
   assert.equal(runtime.lastProgressKind, 'recovery-retry');
+
+  rmSync(base, { recursive: true, force: true });
 });

--- a/src/resources/extensions/gsd/tests/preferences.test.ts
+++ b/src/resources/extensions/gsd/tests/preferences.test.ts
@@ -234,7 +234,7 @@ test("all wizard fields together produce no errors", () => {
   const { errors, warnings } = validatePreferences({
     version: 1,
     models: { research: "claude-opus-4-6" },
-    auto_supervisor: { soft_timeout_minutes: 15 },
+    auto_supervisor: { soft_timeout_minutes: 15, disable_context_pressure_wrapup: true },
     git: { main_branch: "main", auto_push: true, isolation: "worktree" },
     skill_discovery: "suggest",
     unique_milestone_ids: false,


### PR DESCRIPTION
## TL;DR

**What:** Add an opt-in `auto_supervisor.disable_context_pressure_wrapup` preference that suppresses the context-pressure continue-here / wrap-up monitor.
**Why:** Some repos prefer to handle context pressure by splitting work into smaller follow-up tasks instead of steering the current unit toward closeout.
**How:** Extend `AutoSupervisorConfig`, resolve the new flag with a safe default of `false`, and skip only the continue-here monitor in `auto-timers` while leaving soft/idle/hard timeout supervision unchanged.

## What

This PR adds a small opt-in preference to the GSD auto supervisor:

```yaml
auto_supervisor:
  disable_context_pressure_wrapup: true
```

When enabled, `startUnitSupervision()` does **not** install the context-pressure continue-here monitor that emits the `gsd-auto-wrapup` message (`"**CONTEXT BUDGET WARNING — wrap up this unit now.**"`).

The rest of supervision remains intact:
- soft timeout warning
- idle watchdog
- hard timeout recovery/pause

Files changed:
- `src/resources/extensions/gsd/preferences-types.ts`
- `src/resources/extensions/gsd/preferences-models.ts`
- `src/resources/extensions/gsd/auto-timers.ts`
- `src/resources/extensions/gsd/docs/preferences-reference.md`
- `src/resources/extensions/gsd/templates/PREFERENCES.md`
- `src/resources/extensions/gsd/tests/auto-supervisor.test.mjs`
- `src/resources/extensions/gsd/tests/preferences.test.ts`

## Why

The existing context-pressure monitor is a sensible default, but it is not the right fit for every repository.

In some repos, the better behavior under rising context pressure is:
- split work into smaller follow-up tasks earlier
- preserve timeout-based safety rails
- avoid context pressure itself becoming a strong closeout steer

This PR makes that behavior available explicitly without changing the default experience for existing users.

Refs #3406.

## How

Implementation details:
- add `disable_context_pressure_wrapup?: boolean` to `AutoSupervisorConfig`
- have `resolveAutoSupervisorConfig()` return the flag with a strict default of `false`
- in `auto-timers.ts`, short-circuit only the continue-here setup when the flag is enabled
- document the preference in the reference docs and preferences template
- add config-backed tests that isolate project/global preference loading in temp directories and assert that only the continue-here timer is suppressed

I intentionally kept validation permissive and did not broaden schema cleanup in this PR. The goal is a small, focused behavior change with minimal blast radius.

## Verification

- `npm run typecheck:extensions`
- targeted compiled tests for:
  - `auto-supervisor.test.mjs`
  - `preferences.test.ts`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --experimental-test-isolation=process --test src/resources/extensions/gsd/tests/integration/continue-here.test.ts`
- `npm run build`

## Notes

- This PR is intentionally opt-in only.
- It does **not** change default timeout values.
- It does **not** remove or alter the existing continue-here behavior unless the new preference is explicitly set.
- AI-assisted contribution.
