### PR TITLE
fix(async-jobs): stop await-tool timers from hanging tests

### DIFF
--- a/src/resources/extensions/async-jobs/await-tool.test.ts
+++ b/src/resources/extensions/async-jobs/await-tool.test.ts
@@ -20,6 +20,8 @@ test("await_job returns immediately when no running jobs exist", async () => {
 	const result = await tool.execute("tc1", {}, noopSignal, () => {}, undefined as never);
 	const text = getTextFromResult(result);
 	assert.match(text, /No running background jobs/);
+
+	manager.shutdown();
 });
 
 test("await_job returns immediately when all watched jobs are already completed", async () => {

--- a/src/resources/extensions/async-jobs/await-tool.test.ts
+++ b/src/resources/extensions/async-jobs/await-tool.test.ts
@@ -36,6 +36,8 @@ test("await_job returns immediately when all watched jobs are already completed"
 	const text = getTextFromResult(result);
 	assert.match(text, /fast-job/);
 	assert.match(text, /completed/);
+
+	manager.shutdown();
 });
 
 test("await_job returns on timeout when jobs are still running", async () => {
@@ -162,6 +164,26 @@ test("unawaited jobs still get follow-up delivery (#2248)", async () => {
 
 	assert.equal(followUps.length, 1, "onJobComplete should deliver follow-up for unawaited jobs");
 	assert.equal(followUps[0], jobId);
+
+	manager.shutdown();
+});
+
+test("completed jobs use unref'd eviction timers so await-tool tests can exit cleanly", async () => {
+	const manager = new AsyncJobManager();
+
+	const jobId = manager.register("bash", "completed-job", async () => "done");
+	const job = manager.getJob(jobId)!;
+	await job.promise;
+
+	const timers = (manager as unknown as {
+		evictionTimers: Map<string, ReturnType<typeof setTimeout>>;
+	}).evictionTimers;
+	const timer = timers.get(jobId);
+
+	assert.ok(timer, "Expected eviction timer for completed job");
+	if (typeof timer === "object" && "hasRef" in timer) {
+		assert.equal(timer.hasRef(), false, "Eviction timer should not keep the process alive");
+	}
 
 	manager.shutdown();
 });

--- a/src/resources/extensions/async-jobs/job-manager.ts
+++ b/src/resources/extensions/async-jobs/job-manager.ts
@@ -186,6 +186,7 @@ export class AsyncJobManager {
 			this.evictionTimers.delete(id);
 			this.jobs.delete(id);
 		}, this.evictionMs);
+		if (typeof timer === "object" && "unref" in timer) timer.unref();
 
 		this.evictionTimers.set(id, timer);
 	}


### PR DESCRIPTION
## TL;DR

**What:** Stop `await_tool` test hangs by making completed-job eviction timers non-blocking and shutting test managers down explicitly.
**Why:** The async-jobs test path could keep otherwise-finished test processes alive after the assertions had already passed.
**How:** `unref()` the eviction timer in `AsyncJobManager` and add explicit manager teardown/assertions in the await-tool tests.

## What

This change updates the async-jobs cleanup path and the matching await-tool tests.

Affected files:
- `src/resources/extensions/async-jobs/job-manager.ts`
- `src/resources/extensions/async-jobs/await-tool.test.ts`

## Why

Completed async jobs should not keep the host process alive until their best-effort eviction timeout expires.

Without this, the await-tool test path could pass its assertions and still leave the test process alive longer than necessary.

## How

- `AsyncJobManager.scheduleEviction()` now `unref()`s its timer when available
- the await-tool tests shut their managers down explicitly
- the regression coverage asserts the completed-job timer behavior directly

## Change type

- [x] `fix` — Bug fix
- [x] `test` — Adding or updating tests

## Scope

- [x] `gsd extension` — GSD workflow

## Breaking changes

- [x] No breaking changes

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [ ] Manual testing — steps described above
- [ ] No tests needed — explained above

Verified locally with:
- `npm run build`
- `npm run typecheck:extensions`
- `npm run test:unit`
- `npm run test:integration`

## AI disclosure

- [x] This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.
