### PR TITLE
fix(tui): slash command fallback must not block extension commands

### DIFF
--- a/packages/pi-coding-agent/src/modes/interactive/slash-command-handlers.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/slash-command-handlers.ts
@@ -236,8 +236,17 @@ export async function dispatchSlashCommand(
 		return true;
 	}
 
-	// If input starts with "/" but no command matched, show unknown command feedback
+	// If input starts with "/" but no built-in command matched, check if an
+	// extension owns this command before showing an error.  Returning false
+	// lets the caller (input-controller) fall through to session.prompt() which
+	// routes extension commands correctly.
 	if (text.startsWith("/")) {
+		const spaceIdx = text.indexOf(" ");
+		const commandName = spaceIdx === -1 ? text.slice(1) : text.slice(1, spaceIdx);
+		const extensionRunner = ctx.session.extensionRunner;
+		if (extensionRunner?.getCommand(commandName)) {
+			return false; // handled by extension system
+		}
 		const command = text.split(/\s/)[0];
 		ctx.showError(`Unknown command: ${command}. Type /help for available commands.`);
 		return true;


### PR DESCRIPTION
## Summary

Fixes #3421

The unknown-command fallback added in `91f0286` (PR #2312, merged into `main` at `394cb18`) returns `true` for **any** unrecognised `/` input before the extension system gets a chance to handle it. This breaks every extension-registered command (`/gsd`, `/kill`, `/worktree`, `/exit`, etc.).

**Affected version:** `main` at `394cb18` (HEAD as of 2026-04-02). Not present in npm v2.58.0.

## Changes

- `slash-command-handlers.ts`: before showing "Unknown command", check `extensionRunner.getCommand(commandName)`. If the extension owns the command, return `false` so `input-controller` falls through to `session.prompt()` which routes it correctly.

## Test plan

- [ ] Start `gsd` from patched `main`
- [ ] Verify `/gsd` executes normally
- [ ] Verify `/kill`, `/worktree`, `/exit` work
- [ ] Verify truly unknown commands (e.g. `/asdf`) still show the error
- [ ] Verify built-in commands (`/help`, `/model`, `/settings`) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)