### PR TITLE
fix: check extension commands before unknown command error in dispatc…

### DIFF
--- a/packages/pi-coding-agent/src/modes/interactive/slash-command-handlers.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/slash-command-handlers.ts
@@ -236,8 +236,14 @@ export async function dispatchSlashCommand(
 		return true;
 	}
 
-	// If input starts with "/" but no command matched, show unknown command feedback
+	// If input starts with "/" but no command matched, check extension commands first
 	if (text.startsWith("/")) {
+		const spaceIndex = text.indexOf(" ");
+		const commandName = spaceIndex === -1 ? text.slice(1) : text.slice(1, spaceIndex);
+		// Check extension-registered commands before showing unknown command error
+		if (ctx.session.extensionRunner?.getCommand(commandName)) {
+			return false; // Let the extension handle it
+		}
 		const command = text.split(/\s/)[0];
 		ctx.showError(`Unknown command: ${command}. Type /help for available commands.`);
 		return true;


### PR DESCRIPTION
Fixes #3436

## Problem
`dispatchSlashCommand()` had a catch-all block that fired for any
`/`-prefixed input that didn't match a hardcoded built-in command —
including extension-registered commands like `/gsd` and `/help`.
This caused them to always return "Unknown command" in interactive mode.

## Fix
Added a check for `extensionRunner.getCommand()` before the catch-all
block. If the command is registered by an extension, we return `false`
and let the extension handle it normally.

## Changes
- `packages/pi-coding-agent/src/modes/interactive/slash-command-handlers.ts`
  - Check `ctx.session.extensionRunner?.getCommand(commandName)` before showing unknown command error

## Testing
- TypeScript build passes with zero errors
- Headless mode unaffected (bypasses dispatcher entirely)

## Note
The maintainer noted the canonical fix belongs upstream in `badlogic/pi-mono`.
This PR patches the vendored copy in `packages/pi-coding-agent` for immediate relief.
I will also open a PR upstream in `pi-mono`.