### PR TITLE
fix: use authMode apiKey for Ollama provider to avoid streamSimple crash (#3440)

### DIFF
--- a/src/resources/extensions/ollama/index.ts
+++ b/src/resources/extensions/ollama/index.ts
@@ -71,7 +71,8 @@ async function probeAndRegister(pi: ExtensionAPI): Promise<boolean> {
 	const baseUrl = getOllamaOpenAIBaseUrl();
 
 	pi.registerProvider("ollama", {
-		authMode: "none",
+		authMode: "apiKey",
+		apiKey: "ollama", // Ollama ignores auth keys; dummy value avoids the streamSimple requirement for authMode:"none"
 		baseUrl,
 		api: "openai-completions",
 		isReady: () => true,


### PR DESCRIPTION
Fixes #3440

## Problem
`model-registry.ts` line 699 now requires `streamSimple` when
`authMode` is `"none"`. The Ollama extension registers with
`authMode: "none"` but no `streamSimple` handler → crash when
opening `/model` selector with Ollama running.

## Fix
Switch Ollama's provider registration to `authMode: "apiKey"` with
a dummy `apiKey: "ollama"`. Ollama ignores authentication entirely,
so this has zero functional impact but satisfies the new validation.

## Testing
- TypeScript build passes with zero errors
- No changes to Ollama's actual HTTP requests or auth behavior