### PR TITLE
fix(resource-loader): track mod.ts-based extension dirs in managed-resources manifest

### DIFF
--- a/src/resource-loader.ts
+++ b/src/resource-loader.ts
@@ -90,6 +90,7 @@ function writeManagedResourceManifest(agentDir: string): void {
           // Only track directories that are actual extensions (contain index.js or index.ts)
           const dirPath = join(bundledExtensionsDir, e.name)
           return existsSync(join(dirPath, 'index.js')) || existsSync(join(dirPath, 'index.ts'))
+            || existsSync(join(dirPath, 'mod.js')) || existsSync(join(dirPath, 'mod.ts'))
         })
         .map(e => e.name)
     }

--- a/src/tests/resource-loader.test.ts
+++ b/src/tests/resource-loader.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join, parse } from "node:path";
 import { tmpdir } from "node:os";
 
@@ -95,6 +95,25 @@ test("buildResourceLoader excludes duplicate top-level pi extensions when bundle
     additionalExtensionPaths.some((entryPath) => entryPath.endsWith("custom-extension.ts")),
     true,
     "non-duplicate pi extensions should still load",
+  );
+});
+
+test("initResources tracks mod.ts-based extension dirs in managed-resources.json installedExtensionDirs", async (t) => {
+  const { initResources } = await import("../resource-loader.ts");
+  const tmp = mkdtempSync(join(tmpdir(), "gsd-resource-loader-manifest-"));
+  const fakeAgentDir = join(tmp, "agent");
+  const manifestPath = join(fakeAgentDir, "managed-resources.json");
+
+  t.after(() => { rmSync(tmp, { recursive: true, force: true }); });
+
+  initResources(fakeAgentDir);
+
+  const manifest = JSON.parse(readFileSync(manifestPath, "utf-8"));
+  const dirs: string[] = manifest.installedExtensionDirs ?? [];
+
+  assert.ok(
+    dirs.includes("remote-questions"),
+    `remote-questions must be in installedExtensionDirs (uses mod.ts entry point, not index.ts) — found: [${dirs.join(", ")}]`,
   );
 });
 


### PR DESCRIPTION
## TL;DR

**What:** `remote-questions` was silently excluded from `installedExtensionDirs` in `managed-resources.json`.
**Why:** The entry-point filter only checked for `index.js`/`index.ts`; `remote-questions` uses `mod.ts`.
**How:** Extend the filter to also match `mod.js`/`mod.ts`.

## What

- `src/resource-loader.ts` — one-line fix in `writeManagedResourceManifest`
- `src/tests/resource-loader.test.ts` — regression test (test-first, verified red before fix)

## Why

`writeManagedResourceManifest` builds `installedExtensionDirs` by scanning `bundledExtensionsDir` and keeping only subdirectories that contain `index.js` or `index.ts`. `remote-questions` uses `mod.ts` as its entry point and has no `index.*` file — so it was never recorded in the manifest.

This caused two problems:

1. **Partial copies not detected or repaired.** On upgrade, `initResources` skips the sync when version + content hash match. If a previous sync was interrupted and only 8 of 14 files landed, the missing files (`format.js`, `notify.js`, `telegram-adapter.js`, …) are never restored.
2. **Directory never pruned.** If `remote-questions` is removed from the bundle in a future release, the stale copy in `~/.gsd/agent/extensions/remote-questions/` would remain forever.

Observed crash symptom:
```
Cannot find module '/home/user/.gsd/agent/extensions/remote-questions/format.js'
imported from /home/user/.gsd/agent/extensions/remote-questions/mod.js
```

## How

Extended the filter from:
```ts
existsSync(join(dirPath, 'index.js')) || existsSync(join(dirPath, 'index.ts'))
```
to also match `mod.js`/`mod.ts` — the two entry-point conventions present in the bundled extensions directory.

The regression test runs `initResources()` against a temp dir and reads the resulting `managed-resources.json`, asserting that `remote-questions` appears in `installedExtensionDirs`.

Closes #2367

Verified with AI.