### PR TITLE
fix(gsd): prevent auto-mode setModel calls from persisting to settings.json

### DIFF
--- a/packages/pi-coding-agent/src/core/agent-session-model-switch.test.ts
+++ b/packages/pi-coding-agent/src/core/agent-session-model-switch.test.ts
@@ -34,10 +34,35 @@ test("agent-session: transient model switches pass persist options into thinking
 test("agent-session: transient model switches do not persist thinking level defaults", () => {
 	const start = source.indexOf("private _applyThinkingLevel(");
 	assert.ok(start >= 0, "missing _applyThinkingLevel");
-	const window = source.slice(start, start + 900);
+	const window = source.slice(start, start + 1200);
 
 	assert.ok(
-		window.includes("options?.persist !== false && (this.supportsThinking() || effectiveLevel !== \"off\")"),
-		"_applyThinkingLevel should skip settings persistence when persist:false is used for transient model switches",
+		window.includes("if (options?.persist !== false)"),
+		"_applyThinkingLevel should gate all persistence (settings AND session history) behind persist check",
+	);
+	assert.ok(
+		window.includes("this.settingsManager.setDefaultThinkingLevel(effectiveLevel)"),
+		"settings persistence should be inside the persist guard",
+	);
+});
+
+test("agent-session: transient thinking-level changes do not leak into session history (#3486 review)", () => {
+	// Verifies jeremymcs' review finding: appendThinkingLevelChange must NOT run
+	// when persist:false, because session resume replays these entries via the
+	// public setThinkingLevel() which always persists — defeating the isolation.
+	const start = source.indexOf("private _applyThinkingLevel(");
+	assert.ok(start >= 0, "missing _applyThinkingLevel");
+	const window = source.slice(start, start + 900);
+
+	// appendThinkingLevelChange must be INSIDE the persist guard, not before it
+	const persistGuardIdx = window.indexOf("if (options?.persist !== false)");
+	const appendIdx = window.indexOf("this.sessionManager.appendThinkingLevelChange(effectiveLevel)");
+	assert.ok(persistGuardIdx >= 0, "missing persist guard in _applyThinkingLevel");
+	assert.ok(appendIdx >= 0, "missing appendThinkingLevelChange call");
+	assert.ok(
+		appendIdx > persistGuardIdx,
+		"appendThinkingLevelChange must be inside the persist:false guard — " +
+		"otherwise transient thinking-level changes survive in session history " +
+		"and get replayed on resume via setThinkingLevel() which always persists",
 	);
 });

--- a/packages/pi-coding-agent/src/core/agent-session-model-switch.test.ts
+++ b/packages/pi-coding-agent/src/core/agent-session-model-switch.test.ts
@@ -19,3 +19,25 @@ test("agent-session: explicit model switches cancel retry before applying new mo
 		"retry cancellation must happen before applying the new model to prevent stale provider retries",
 	);
 });
+
+test("agent-session: transient model switches pass persist options into thinking-level application", () => {
+	const start = source.indexOf("private async _applyModelChange(");
+	assert.ok(start >= 0, "missing _applyModelChange");
+	const window = source.slice(start, start + 900);
+
+	assert.ok(
+		window.includes("this._applyThinkingLevel(thinkingLevel, options);"),
+		"_applyModelChange should forward persist options when applying thinking level during model switches",
+	);
+});
+
+test("agent-session: transient model switches do not persist thinking level defaults", () => {
+	const start = source.indexOf("private _applyThinkingLevel(");
+	assert.ok(start >= 0, "missing _applyThinkingLevel");
+	const window = source.slice(start, start + 900);
+
+	assert.ok(
+		window.includes("options?.persist !== false && (this.supportsThinking() || effectiveLevel !== \"off\")"),
+		"_applyThinkingLevel should skip settings persistence when persist:false is used for transient model switches",
+	);
+});

--- a/packages/pi-coding-agent/src/core/agent-session.ts
+++ b/packages/pi-coding-agent/src/core/agent-session.ts
@@ -1660,7 +1660,7 @@ export class AgentSession {
 		if (options?.persist !== false) {
 			this.settingsManager.setDefaultModelAndProvider(model.provider, model.id);
 		}
-		this.setThinkingLevel(thinkingLevel);
+		this._applyThinkingLevel(thinkingLevel, options);
 		await this._emitModelSelect(model, previousModel, source);
 		this._emitSessionStateChanged("set_model");
 	}
@@ -1746,6 +1746,18 @@ export class AgentSession {
 	 * Saves to session and settings only if the level actually changes.
 	 */
 	setThinkingLevel(level: ThinkingLevel): void {
+		this._applyThinkingLevel(level);
+	}
+
+	/**
+	 * Internal thinking level setter that respects persist option.
+	 * When called from _applyModelChange with { persist: false }, the thinking
+	 * level is applied in-memory and appended to the session log, but the
+	 * default in settings.json is left untouched. This prevents transient
+	 * model switches (auto-mode dispatches) from silently overwriting the
+	 * user's saved thinking level preference.
+	 */
+	private _applyThinkingLevel(level: ThinkingLevel, options?: { persist?: boolean }): void {
 		const availableLevels = this.getAvailableThinkingLevels();
 		const effectiveLevel = availableLevels.includes(level) ? level : this._clampThinkingLevel(level, availableLevels);
 
@@ -1756,7 +1768,7 @@ export class AgentSession {
 
 		if (isChanging) {
 			this.sessionManager.appendThinkingLevelChange(effectiveLevel);
-			if (this.supportsThinking() || effectiveLevel !== "off") {
+			if (options?.persist !== false && (this.supportsThinking() || effectiveLevel !== "off")) {
 				this.settingsManager.setDefaultThinkingLevel(effectiveLevel);
 			}
 			this._emitSessionStateChanged("set_thinking_level");

--- a/packages/pi-coding-agent/src/core/agent-session.ts
+++ b/packages/pi-coding-agent/src/core/agent-session.ts
@@ -1767,9 +1767,15 @@ export class AgentSession {
 		this.agent.setThinkingLevel(effectiveLevel);
 
 		if (isChanging) {
-			this.sessionManager.appendThinkingLevelChange(effectiveLevel);
-			if (options?.persist !== false && (this.supportsThinking() || effectiveLevel !== "off")) {
-				this.settingsManager.setDefaultThinkingLevel(effectiveLevel);
+			// Only record in session history when persisting — transient switches
+			// (auto-mode dispatches with persist:false) must not leave durable
+			// thinking_level_change entries, because session resume replays them
+			// via the public setThinkingLevel() path which always persists.
+			if (options?.persist !== false) {
+				this.sessionManager.appendThinkingLevelChange(effectiveLevel);
+				if (this.supportsThinking() || effectiveLevel !== "off") {
+					this.settingsManager.setDefaultThinkingLevel(effectiveLevel);
+				}
 			}
 			this._emitSessionStateChanged("set_thinking_level");
 		}

--- a/packages/pi-coding-agent/src/core/extensions/loader-model-options.test.ts
+++ b/packages/pi-coding-agent/src/core/extensions/loader-model-options.test.ts
@@ -1,0 +1,17 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const source = readFileSync(join(process.cwd(), "packages/pi-coding-agent/src/core/extensions/loader.ts"), "utf-8");
+
+test("loader: extension API forwards setModel options to runtime", () => {
+	const start = source.indexOf("setModel(model, options) {");
+	assert.ok(start >= 0, "missing ExtensionAPI setModel wrapper");
+	const window = source.slice(start, start + 140);
+
+	assert.ok(
+		window.includes("return runtime.setModel(model, options);"),
+		"ExtensionAPI setModel wrapper should forward options such as persist:false to the runtime",
+	);
+});

--- a/packages/pi-coding-agent/src/core/extensions/loader.ts
+++ b/packages/pi-coding-agent/src/core/extensions/loader.ts
@@ -567,8 +567,8 @@ function createExtensionAPI(
 			return runtime.getCommands();
 		},
 
-		setModel(model) {
-			return runtime.setModel(model);
+		setModel(model, options) {
+			return runtime.setModel(model, options);
 		},
 
 		getThinkingLevel() {

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -939,7 +939,7 @@ export async function stopAuto(
           s.originalModelProvider,
           s.originalModelId,
         );
-        if (original) await pi.setModel(original);
+        if (original) await pi.setModel(original, { persist: false });
       }
     } catch (e) {
       debugLog("stop-cleanup-model", { error: e instanceof Error ? e.message : String(e) });
@@ -1705,7 +1705,7 @@ export async function dispatchHookUnit(
     const match = resolveModelId(hookModel, availableModels, ctx.model?.provider);
     if (match) {
       try {
-        await pi.setModel(match);
+        await pi.setModel(match, { persist: false });
       } catch (err) {
         /* non-fatal */
         logWarning("dispatch", `hook model set failed: ${err instanceof Error ? err.message : String(err)}`, { file: "auto.ts" });

--- a/src/resources/extensions/gsd/tests/model-isolation.test.ts
+++ b/src/resources/extensions/gsd/tests/model-isolation.test.ts
@@ -5,11 +5,14 @@
  * provider precedence over PREFERENCES.md when set via `/gsd model` (#4122).
  */
 
-import { describe, it, beforeEach, afterEach } from "node:test";
+import { describe, it, test, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
 import { mkdirSync, writeFileSync, rmSync, existsSync, readFileSync } from "node:fs";
-import { join } from "node:path";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
 import { tmpdir } from "node:os";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 // ─── Test helpers ─────────────────────────────────────────────────────────────
 
@@ -303,3 +306,31 @@ describe("custom provider session model overrides PREFERENCES.md (#4122)", () =>
   });
 });
 
+// ─── Structural guard: no setModel calls in auto.ts should persist ────────────
+
+test("all setModel calls in auto.ts use persist: false", () => {
+  // Regression test: auto-mode's transient model switches must never persist
+  // to settings.json. If they do, the user's chosen default model is silently
+  // overwritten and every subsequent session starts with the wrong model.
+  // See #650 for the original model-bleed report.
+  const autoSrc = readFileSync(
+    join(__dirname, "..", "auto.ts"),
+    "utf-8",
+  );
+
+  // Find all setModel calls (pi.setModel or await pi.setModel)
+  const setModelCalls = autoSrc.match(/\.setModel\([^)]*\)/g) ?? [];
+  assert.ok(
+    setModelCalls.length > 0,
+    "Expected at least one setModel call in auto.ts",
+  );
+
+  for (const call of setModelCalls) {
+    assert.ok(
+      call.includes("persist: false"),
+      `setModel call in auto.ts is missing { persist: false }: ${call}\n` +
+      "Auto-mode model switches are transient — they must not overwrite " +
+      "the user's saved default in settings.json.",
+    );
+  }
+});


### PR DESCRIPTION
## Problem

Auto-mode temporarily switches models for hook dispatch and stop/restore operations. These transient `setModel` calls persist the model choice to `settings.json`, silently overwriting the user's default model preference.

**Root cause:** `ExtensionAPI.setModel()` in `loader.ts` drops the `options` argument, so `{ persist: false }` never reaches the session layer.

**Secondary leak:** `_applyThinkingLevel()` unconditionally appends `thinking_level_change` to session history, which on resume re-persists via `setThinkingLevel()`.

Closes #4339

## Fix

Three layers:
1. **`loader.ts`** — forward `options` through `setModel` wrapper
2. **`auto.ts`** — pass `{ persist: false }` for all transient model switches
3. **`agent-session.ts`** — gate `appendThinkingLevelChange()` and `setDefaultThinkingLevel()` behind persist check

## Tests

- Structural guard: all `setModel` calls in `auto.ts` must include `persist: false`
- `loader.ts`: options forwarding unit test
- `agent-session.ts`: thinking-level history entry gated by persist option
- `appendThinkingLevelChange` index vs persist-guard index ordering test