### PR TITLE
fix(gsd): add Claude Code official skill directories to skill resolution

### DIFF
--- a/src/resources/extensions/gsd/preferences-skills.ts
+++ b/src/resources/extensions/gsd/preferences-skills.ts
@@ -24,13 +24,18 @@ export type { GSDSkillRule, SkillDiscoveryMode, SkillResolution, SkillResolution
 
 /**
  * Known skill directories, in priority order.
- * Global skills (~/.agents/skills/) take precedence over project skills.
+ * Searches both the skills.sh ecosystem directory (~/.agents/skills/) and
+ * Claude Code's official directory (~/.claude/skills/). Project-level
+ * directories for both conventions are included as well.
  * Legacy ~/.gsd/agent/skills/ is included as a fallback for pre-migration installs.
  */
 export function getSkillSearchDirs(cwd: string): Array<{ dir: string; method: SkillResolution["method"] }> {
   const dirs: Array<{ dir: string; method: SkillResolution["method"] }> = [
     { dir: join(homedir(), ".agents", "skills"), method: "user-skill" },
     { dir: join(cwd, ".agents", "skills"), method: "project-skill" },
+    // Claude Code official skill directories
+    { dir: join(homedir(), ".claude", "skills"), method: "user-skill" },
+    { dir: join(cwd, ".claude", "skills"), method: "project-skill" },
   ];
   // Legacy fallback — read skills from old GSD directory only if migration hasn't completed
   const legacyDir = join(homedir(), ".gsd", "agent", "skills");

--- a/src/resources/extensions/gsd/skill-catalog.ts
+++ b/src/resources/extensions/gsd/skill-catalog.ts
@@ -935,13 +935,16 @@ export async function installPacksBatched(
 
 /**
  * Check if any skills from a pack are already installed.
+ * Searches both the skills.sh ecosystem directory and Claude Code's official directory.
  */
 export function isPackInstalled(pack: SkillPack): boolean {
-  const skillsDir = join(homedir(), ".agents", "skills");
-  if (!existsSync(skillsDir)) return false;
+  const skillsDirs = [
+    join(homedir(), ".agents", "skills"),
+    join(homedir(), ".claude", "skills"),
+  ];
 
   return pack.skills.every((name) =>
-    existsSync(join(skillsDir, name, "SKILL.md")),
+    skillsDirs.some((dir) => existsSync(join(dir, name, "SKILL.md"))),
   );
 }
 

--- a/src/resources/extensions/gsd/skill-discovery.ts
+++ b/src/resources/extensions/gsd/skill-discovery.ts
@@ -12,8 +12,9 @@ import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { homedir } from "node:os";
 
-/** Industry-standard skills.sh global skills directory */
+/** Skills directories — skills.sh ecosystem + Claude Code official */
 const SKILLS_DIR = join(homedir(), ".agents", "skills");
+const CLAUDE_SKILLS_DIR = join(homedir(), ".claude", "skills");
 
 export interface DiscoveredSkill {
   name: string;
@@ -58,8 +59,9 @@ export function detectNewSkills(): DiscoveredSkill[] {
   for (const dir of current) {
     if (baselineSkills.has(dir)) continue;
 
-    const skillMdPath = join(SKILLS_DIR, dir, "SKILL.md");
-    if (!existsSync(skillMdPath)) continue;
+    // Check both skill directories for the SKILL.md file
+    const skillMdPath = resolveSkillMdPath(dir);
+    if (!skillMdPath) continue;
 
     const meta = parseSkillFrontmatter(skillMdPath);
     if (meta) {
@@ -97,15 +99,22 @@ ${entries}
 
 // ─── Internals ────────────────────────────────────────────────────────────────
 
-function listSkillDirs(): string[] {
-  if (!existsSync(SKILLS_DIR)) return [];
+function listSkillDirsFrom(dir: string): string[] {
+  if (!existsSync(dir)) return [];
   try {
-    return readdirSync(SKILLS_DIR, { withFileTypes: true })
+    return readdirSync(dir, { withFileTypes: true })
       .filter(d => d.isDirectory())
       .map(d => d.name);
   } catch {
     return [];
   }
+}
+
+function listSkillDirs(): string[] {
+  const names = new Set<string>();
+  for (const name of listSkillDirsFrom(SKILLS_DIR)) names.add(name);
+  for (const name of listSkillDirsFrom(CLAUDE_SKILLS_DIR)) names.add(name);
+  return [...names];
 }
 
 function parseSkillFrontmatter(path: string): { name?: string; description?: string } | null {
@@ -129,6 +138,14 @@ function parseSkillFrontmatter(path: string): { name?: string; description?: str
   } catch {
     return null;
   }
+}
+
+function resolveSkillMdPath(skillName: string): string | null {
+  for (const dir of [SKILLS_DIR, CLAUDE_SKILLS_DIR]) {
+    const candidate = join(dir, skillName, "SKILL.md");
+    if (existsSync(candidate)) return candidate;
+  }
+  return null;
 }
 
 function escapeXml(text: string): string {

--- a/src/resources/extensions/gsd/skill-health.ts
+++ b/src/resources/extensions/gsd/skill-health.ts
@@ -207,9 +207,13 @@ export function formatSkillDetail(basePath: string, skillName: string): string {
     lines.push(`  ${date}  ${u.id.padEnd(20)}  ${formatTokenCount(u.tokens.total).padStart(8)} tokens  ${formatCost(u.cost)}`);
   }
 
-  // Check for SKILL.md existence
-  const skillPath = join(homedir(), ".agents", "skills", skillName, "SKILL.md");
-  if (existsSync(skillPath)) {
+  // Check for SKILL.md existence — search both ecosystem and Claude Code directories
+  const candidatePaths = [
+    join(homedir(), ".agents", "skills", skillName, "SKILL.md"),
+    join(homedir(), ".claude", "skills", skillName, "SKILL.md"),
+  ];
+  const skillPath = candidatePaths.find(p => existsSync(p));
+  if (skillPath) {
     const stat = statSync(skillPath);
     lines.push("");
     lines.push(`SKILL.md: ${skillPath}`);

--- a/src/resources/extensions/gsd/skill-telemetry.ts
+++ b/src/resources/extensions/gsd/skill-telemetry.ts
@@ -31,12 +31,14 @@ const activelyLoadedSkills = new Set<string>();
  */
 export function captureAvailableSkills(): void {
   const skillsDir = join(homedir(), ".agents", "skills");
+  const claudeSkillsDir = join(homedir(), ".claude", "skills");
   const legacyDir = join(homedir(), ".gsd", "agent", "skills");
   const names = listSkillNames(skillsDir);
+  const claudeNames = listSkillNames(claudeSkillsDir);
   // Include skills still in the legacy directory only if migration hasn't completed
   const legacyMigrated = existsSync(join(legacyDir, ".migrated-to-agents"));
   const legacyNames = legacyMigrated ? [] : listSkillNames(legacyDir);
-  const all = new Set([...names, ...legacyNames]);
+  const all = new Set([...names, ...claudeNames, ...legacyNames]);
   availableSkills = [...all];
   activelyLoadedSkills.clear();
 }
@@ -106,10 +108,11 @@ export function detectStaleSkills(
 
   // Check all installed skills, not just those with usage data
   const skillsDir = join(homedir(), ".agents", "skills");
+  const claudeSkillsDir = join(homedir(), ".claude", "skills");
   const legacyDir = join(homedir(), ".gsd", "agent", "skills");
   const legacyMigrated = existsSync(join(legacyDir, ".migrated-to-agents"));
   const legacyNames = legacyMigrated ? [] : listSkillNames(legacyDir);
-  const installedSet = new Set([...listSkillNames(skillsDir), ...legacyNames]);
+  const installedSet = new Set([...listSkillNames(skillsDir), ...listSkillNames(claudeSkillsDir), ...legacyNames]);
   const installed = [...installedSet];
 
   for (const skill of installed) {

--- a/src/resources/extensions/gsd/tests/claude-skill-dirs.test.ts
+++ b/src/resources/extensions/gsd/tests/claude-skill-dirs.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Tests for Claude Code skill directory support in getSkillSearchDirs().
+ *
+ * Verifies that ~/.claude/skills/ and .claude/skills/ are included in
+ * the skill search path alongside ~/.agents/skills/ and .agents/skills/.
+ */
+
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import { join } from "node:path";
+import { homedir } from "node:os";
+import { getSkillSearchDirs } from "../preferences-skills.ts";
+
+describe("getSkillSearchDirs — Claude Code directory support", () => {
+  const cwd = "/tmp/test-project";
+
+  test("includes ~/.agents/skills/ as user-skill", () => {
+    const dirs = getSkillSearchDirs(cwd);
+    const agents = dirs.find((d) => d.dir === join(homedir(), ".agents", "skills"));
+    assert.ok(agents, "should include ~/.agents/skills/");
+    assert.equal(agents!.method, "user-skill");
+  });
+
+  test("includes .agents/skills/ as project-skill", () => {
+    const dirs = getSkillSearchDirs(cwd);
+    const projectAgents = dirs.find((d) => d.dir === join(cwd, ".agents", "skills"));
+    assert.ok(projectAgents, "should include .agents/skills/");
+    assert.equal(projectAgents!.method, "project-skill");
+  });
+
+  test("includes ~/.claude/skills/ as user-skill", () => {
+    const dirs = getSkillSearchDirs(cwd);
+    const claude = dirs.find((d) => d.dir === join(homedir(), ".claude", "skills"));
+    assert.ok(claude, "should include ~/.claude/skills/");
+    assert.equal(claude!.method, "user-skill");
+  });
+
+  test("includes .claude/skills/ as project-skill", () => {
+    const dirs = getSkillSearchDirs(cwd);
+    const projectClaude = dirs.find((d) => d.dir === join(cwd, ".claude", "skills"));
+    assert.ok(projectClaude, "should include .claude/skills/");
+    assert.equal(projectClaude!.method, "project-skill");
+  });
+
+  test("~/.agents/skills/ appears before ~/.claude/skills/ (priority order)", () => {
+    const dirs = getSkillSearchDirs(cwd);
+    const agentsIdx = dirs.findIndex((d) => d.dir === join(homedir(), ".agents", "skills"));
+    const claudeIdx = dirs.findIndex((d) => d.dir === join(homedir(), ".claude", "skills"));
+    assert.ok(agentsIdx < claudeIdx, "~/.agents/skills/ should have higher priority than ~/.claude/skills/");
+  });
+});


### PR DESCRIPTION
## TL;DR

**What:** Add `~/.claude/skills/` and `.claude/skills/` to GSD-2's skill search path.  
**Why:** GSD-2 is blind to skills in Claude Code's official directories — the only directories Claude Code itself uses.  
**How:** Five surgical edits to include the Claude Code paths alongside the existing `~/.agents/skills/` entries.

---

## What

GSD-2's skill resolution only searches `~/.agents/skills/` (skills.sh ecosystem) and `.agents/skills/` (project-level). It does not search `~/.claude/skills/` or `.claude/skills/` — the directories that Claude Code officially uses for skill storage.

This means any skills installed or managed through Claude Code's native conventions are invisible to GSD-2.

## Why

Claude Code stores user-level skills in `~/.claude/skills/` and project-level skills in `.claude/skills/`. This is Claude Code's documented, official convention. Tools like `gsd-skill-creator` and other Claude Code ecosystem tooling use these paths.

The `skills.sh` CLI — which GSD-2 itself recommends via `npx skills add` — already recognises both `~/.agents/skills/` and `~/.claude/skills/` as valid global skill directories. Running `npx skills list -g` lists skills from both locations. GSD-2 is the outlier.

**Concrete impact on a real system:**

| Directory | Skills found | Visible to GSD-2 before this PR |
|---|---|---|
| `~/.agents/skills/` | 3 | ✅ Yes |
| `~/.claude/skills/` | 61 | ❌ No |

The 61 skills in `~/.claude/skills/` are managed by [`gsd-skill-creator`](https://github.com/Tibsfox/gsd-skill-creator), a Claude Code companion tool that follows Claude Code's official skill format and directory conventions. None of them are discoverable by GSD-2 today.

## How

Five files in `src/resources/extensions/gsd/` are updated to include the Claude Code directories:

### 1. `preferences-skills.ts` — Central skill resolution

`getSkillSearchDirs()` is the single source of truth for skill directory scanning, used by `resolveSkillReference()` for bare skill name resolution. Two entries added:

```typescript
// Claude Code official skill directories
{ dir: join(homedir(), ".claude", "skills"), method: "user-skill" },
{ dir: join(cwd, ".claude", "skills"), method: "project-skill" },
```

**Priority order** (first match wins): `~/.agents/skills/` → `.agents/skills/` → `~/.claude/skills/` → `.claude/skills/` → legacy `~/.gsd/agent/skills/`. Existing resolution behaviour is unchanged — `~/.agents/skills/` still takes precedence.

### 2. `skill-discovery.ts` — Auto-mode skill detection

`listSkillDirs()` and `detectNewSkills()` now scan both directories. A new `CLAUDE_SKILLS_DIR` constant and `resolveSkillMdPath()` helper handle the dual-directory lookup. Skill names are deduped via `Set` so a skill present in both directories appears once.

### 3. `skill-telemetry.ts` — Usage tracking

`captureAvailableSkills()` and `detectStaleSkills()` now include `~/.claude/skills/` when building the installed skill inventory. Without this, skills in the Claude Code directory would never appear in telemetry or staleness reports.

### 4. `skill-health.ts` — Skill health dashboard

`formatSkillDetail()` checks both directories when resolving a skill's `SKILL.md` path for the health display.

### 5. `skill-catalog.ts` — Init wizard pack detection

`isPackInstalled()` now checks both directories. Without this, the init wizard would recommend installing skill packs that are already present in `~/.claude/skills/`.

## What this does NOT change

- No new dependencies.
- No change to the SKILL.md format or frontmatter schema.
- No change to `~/.agents/skills/` priority — it still wins on name collisions.
- No change to the legacy `~/.gsd/agent/skills/` migration path.
- No change to `installSkillPack()` or `installPacksBatched()` — installation still targets `~/.agents/skills/` via `npx skills add`.

## Change type

- [x] `fix` — Bug fix (skills in Claude Code's official directories are not discovered)

## Testing

All five changed files pass Node.js syntax validation (`node --experimental-strip-types --check`). The existing test suites (`skill-catalog.test.ts`, `skill-lifecycle.test.ts`) test pure functions that don't touch the filesystem for directory scanning, so they are unaffected.

The change is straightforward to verify manually:

1. Place a skill in `~/.claude/skills/test-skill/SKILL.md`
2. Confirm GSD-2 resolves it via bare name (`test-skill`)
3. Confirm `npx skills list -g` already shows it (proving `skills.sh` sees it)

## Disclosure

This PR was authored with AI assistance (Claude). All changes have been reviewed and are understood by the submitter.
