### PR TITLE
fix: break infinite notes loop on "None of the above"

### DIFF
--- a/src/resources/extensions/shared/interview-ui.ts
+++ b/src/resources/extensions/shared/interview-ui.ts
@@ -298,7 +298,9 @@ export async function showInterviewRound(
 			// Auto-open the notes field when "None of the above" is selected
 			// so the user can immediately provide a free-text explanation
 			// instead of being trapped in a re-asking loop (bug #2715).
-			if (!isMultiSelect(currentIdx) && states[currentIdx].cursorIndex === noneOrDoneIdx(currentIdx)) {
+			// Only auto-open if the user hasn't already provided notes —
+			// otherwise Enter from notes mode loops back here endlessly.
+			if (!isMultiSelect(currentIdx) && states[currentIdx].cursorIndex === noneOrDoneIdx(currentIdx) && !states[currentIdx].notes) {
 				states[currentIdx].notesVisible = true;
 				focusNotes = true;
 				loadStateToEditor();

--- a/src/resources/extensions/shared/tests/interview-notes-loop.test.ts
+++ b/src/resources/extensions/shared/tests/interview-notes-loop.test.ts
@@ -1,0 +1,144 @@
+// GSD2 — Regression test for interview-ui "None of the above" notes loop
+// Copyright (c) 2026 Jeremy McSpadden <jeremy@fluxlabs.net>
+
+/**
+ * Regression test for bug #3502:
+ *
+ * Selecting "None of the above" opens the notes field, but pressing Enter
+ * after typing a note called goNextOrSubmit() which saw the cursor still
+ * on the "None of the above" slot and re-opened notes — trapping the user
+ * in an infinite loop.
+ *
+ * The fix adds a `!states[currentIdx].notes` guard so auto-open only fires
+ * when notes are still empty.
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { showInterviewRound, type Question, type RoundResult } from "../interview-ui.js";
+
+// Raw terminal sequences that matchesKey() recognises
+const ENTER = "\r";
+const DOWN = "\x1b[B";
+const TAB = "\t";
+
+/**
+ * Drive showInterviewRound with a scripted sequence of key inputs.
+ * We mock ctx.ui.custom() to capture the widget, feed it inputs, and
+ * resolve when done() is called.
+ */
+function runWithInputs(
+	questions: Question[],
+	inputs: string[],
+): Promise<RoundResult> {
+	return new Promise((resolve, reject) => {
+		const timeout = setTimeout(() => reject(new Error("Timed out — likely stuck in infinite loop")), 3000);
+
+		const mockCtx = {
+			ui: {
+				custom: (factory: any) => {
+					const mockTui = {
+						requestRender: () => {},
+					};
+					const mockTheme = {
+						// Minimal theme stubs — render output is not asserted
+						fg: (_c: string, t: string) => t,
+						bold: (t: string) => t,
+						dim: (t: string) => t,
+						italic: (t: string) => t,
+						strikethrough: (t: string) => t,
+						accent: (t: string) => t,
+						success: (t: string) => t,
+						warning: (t: string) => t,
+						error: (t: string) => t,
+						info: (t: string) => t,
+						muted: (t: string) => t,
+						dimmed: (t: string) => t,
+					};
+					const mockKb = {};
+
+					const widget = factory(mockTui, mockTheme, mockKb, (result: RoundResult) => {
+						clearTimeout(timeout);
+						resolve(result);
+					});
+
+					// Feed each input sequentially
+					for (const input of inputs) {
+						widget.handleInput(input);
+					}
+				},
+			},
+		};
+
+		showInterviewRound(questions, {}, mockCtx as any).catch(reject);
+	});
+}
+
+describe("interview-ui notes loop regression (#3502)", () => {
+	const questions: Question[] = [
+		{
+			id: "q1",
+			header: "Project Type",
+			question: "What type of project?",
+			options: [
+				{ label: "Web App", description: "Frontend or full-stack" },
+				{ label: "CLI Tool", description: "Command-line utility" },
+			],
+		},
+	];
+
+	it("does not loop when Enter is pressed after typing a note on 'None of the above'", async () => {
+		// With 2 options, "None of the above" is index 2 (0-based)
+		// Cursor starts at 0, so press Down twice to reach it
+		const result = await runWithInputs(questions, [
+			DOWN,        // cursor → index 1 (CLI Tool)
+			DOWN,        // cursor → index 2 (None of the above)
+			ENTER,       // commit → auto-opens notes field
+			"u", "n", "s", "u", "r", "e",  // type "unsure"
+			ENTER,       // should advance to review, NOT reopen notes
+			ENTER,       // submit from review screen
+		]);
+
+		// If we get here, the loop did not occur (timeout would have fired)
+		assert.ok(result, "should return a result");
+		assert.equal(result.endInterview, false);
+
+		const answer = result.answers.q1;
+		assert.ok(answer, "answer for q1 should exist");
+		assert.equal(answer.notes, "unsure", "notes should contain typed text");
+		assert.equal(answer.selected, "None of the above");
+	});
+
+	it("still auto-opens notes when selecting 'None of the above' with no prior notes", async () => {
+		// Press Down twice to "None of the above", Enter to select
+		// Then immediately Enter again (empty notes) — this should re-open notes
+		// because the guard only skips when notes are non-empty.
+		// Type something on second open, then Enter to proceed.
+		const result = await runWithInputs(questions, [
+			DOWN,        // cursor → 1
+			DOWN,        // cursor → 2 (None of the above)
+			ENTER,       // commit → auto-opens notes
+			ENTER,       // empty notes → goNextOrSubmit → should re-open notes (empty guard)
+			"o", "k",    // type "ok"
+			ENTER,       // now notes = "ok" → should advance to review
+			ENTER,       // submit
+		]);
+
+		assert.ok(result, "should return a result");
+		const answer = result.answers.q1;
+		assert.ok(answer, "answer for q1 should exist");
+		assert.equal(answer.notes, "ok");
+	});
+
+	it("normal option selection is unaffected", async () => {
+		const result = await runWithInputs(questions, [
+			ENTER,       // select first option (Web App) and advance to review
+			ENTER,       // submit from review screen
+		]);
+
+		assert.ok(result, "should return a result");
+		const answer = result.answers.q1;
+		assert.ok(answer, "answer for q1 should exist");
+		assert.equal(answer.selected, "Web App");
+	});
+});


### PR DESCRIPTION
## TL;DR

**What:** Fix infinite loop when selecting "None of the above" in the interview UI and typing a note.
**Why:** Users get trapped — Enter from notes mode re-opens the notes field instead of advancing.
**How:** Add a `!notes` guard so the auto-open only fires when notes are still empty.

## What

`showInterviewRound()` in `interview-ui.ts` has a `goNextOrSubmit()` function that auto-opens the notes field when the cursor is on the "None of the above" slot. This was added in the bug #2715 fix to ensure users provide a free-text explanation.

The problem: when Enter is pressed in notes mode, it saves the text, exits notes mode, and calls `goNextOrSubmit()` — which sees the cursor *still* on "None of the above" and immediately re-opens notes. The user can never advance past the notes field.

## Why

Users selecting "None of the above" and typing a custom answer are permanently stuck. They can type their note but pressing Enter loops back to the notes field. The only escape is Esc (which discards the answer).

Closes #3502

## How

Added `&& !states[currentIdx].notes` to the condition at line 301 of `interview-ui.ts`. The auto-open now only triggers when:
- The cursor is on "None of the above" (existing check)
- AND the notes field is still empty (new guard)

Once the user has typed something, Enter proceeds normally to the next question or review screen. If the user presses Enter with empty notes, the auto-open still fires — preserving the original #2715 behavior.

No alternatives considered — the fix is minimal and directly addresses the loop condition.

### Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

### AI disclosure

This PR was AI-assisted using Claude Code.

### Test plan

- [x] Regression test added (`interview-notes-loop.test.ts`) with 3 cases:
  - Enter after typing a note advances instead of looping
  - Empty notes still trigger the auto-open (preserves #2715 fix)
  - Normal option selection is unaffected
- [x] Existing `ask-user-freetext.test.ts` tests still pass
- [x] CI green (lint, build, all portability checks)