### PR TITLE
feat(mcp-server): add 6 read-only project state tools

### DIFF
--- a/packages/mcp-server/src/readers/captures.ts
+++ b/packages/mcp-server/src/readers/captures.ts
@@ -1,0 +1,57 @@
+/**
+ * gsd_captures — pending ideas/captures with filtering.
+ */
+
+import { join } from 'node:path';
+import { gsdDir, readFileSafe } from './shared.js';
+
+interface CaptureEntry {
+  id: string;
+  text: string;
+  status: 'pending' | 'resolved' | 'executed';
+  timestamp?: string;
+}
+
+interface CapturesResult {
+  total: number;
+  pending: number;
+  entries: CaptureEntry[];
+}
+
+export async function readCaptures(
+  projectDir: string,
+  filter: 'all' | 'pending' | 'actionable' = 'all',
+): Promise<CapturesResult> {
+  const base = gsdDir(projectDir);
+  const content = await readFileSafe(join(base, 'CAPTURES.md'));
+  if (!content) return { total: 0, pending: 0, entries: [] };
+
+  const entries: CaptureEntry[] = [];
+
+  // Parse capture entries: - [ ] text or - [x] text with optional (id) prefix
+  const lineRegex = /^- \[([ x~])\]\s*(?:\((\w+)\)\s*)?(.+)$/gm;
+  let match;
+  while ((match = lineRegex.exec(content)) !== null) {
+    const marker = match[1];
+    const id = match[2] || `c${entries.length + 1}`;
+    const text = match[3].trim();
+
+    let status: CaptureEntry['status'];
+    if (marker === 'x') status = 'executed';
+    else if (marker === '~') status = 'resolved';
+    else status = 'pending';
+
+    entries.push({ id, text, status });
+  }
+
+  const pending = entries.filter(e => e.status === 'pending').length;
+
+  let filtered = entries;
+  if (filter === 'pending') {
+    filtered = entries.filter(e => e.status === 'pending');
+  } else if (filter === 'actionable') {
+    filtered = entries.filter(e => e.status !== 'executed');
+  }
+
+  return { total: entries.length, pending, entries: filtered };
+}

--- a/packages/mcp-server/src/readers/doctor.ts
+++ b/packages/mcp-server/src/readers/doctor.ts
@@ -1,0 +1,99 @@
+/**
+ * gsd_doctor — lightweight structural health check (filesystem only).
+ */
+
+import { join } from 'node:path';
+import { gsdDir, readFileSafe, listDirs, fileExists } from './shared.js';
+
+interface HealthCheck {
+  name: string;
+  status: 'pass' | 'warn' | 'fail';
+  message: string;
+}
+
+interface DoctorResult {
+  healthy: boolean;
+  checks: HealthCheck[];
+}
+
+export async function readDoctor(projectDir: string): Promise<DoctorResult> {
+  const base = gsdDir(projectDir);
+  const checks: HealthCheck[] = [];
+
+  // 1. .gsd/ directory exists
+  if (await fileExists(base)) {
+    checks.push({ name: 'gsd-dir', status: 'pass', message: '.gsd/ directory exists' });
+  } else {
+    checks.push({ name: 'gsd-dir', status: 'fail', message: '.gsd/ directory not found' });
+    return { healthy: false, checks };
+  }
+
+  // 2. STATE.md exists
+  if (await readFileSafe(join(base, 'STATE.md'))) {
+    checks.push({ name: 'state-md', status: 'pass', message: 'STATE.md present' });
+  } else {
+    checks.push({ name: 'state-md', status: 'warn', message: 'STATE.md missing — state may be stale' });
+  }
+
+  // 3. Database file exists
+  if (await fileExists(join(base, 'gsd.db'))) {
+    checks.push({ name: 'database', status: 'pass', message: 'gsd.db present' });
+  } else {
+    checks.push({ name: 'database', status: 'warn', message: 'gsd.db missing — using markdown-only mode' });
+  }
+
+  // 4. Milestones directory
+  const milestones = await listDirs(join(base, 'milestones'));
+  if (milestones.length > 0) {
+    checks.push({ name: 'milestones', status: 'pass', message: `${milestones.length} milestone(s) found` });
+
+    // 5. Each milestone has a roadmap
+    for (const mid of milestones) {
+      const hasRoadmap = await fileExists(
+        join(base, 'milestones', mid, `${mid}-ROADMAP.md`),
+      );
+      if (!hasRoadmap) {
+        checks.push({
+          name: `milestone-${mid}-roadmap`,
+          status: 'warn',
+          message: `${mid} has no ROADMAP.md`,
+        });
+      }
+
+      // 6. Check for empty slice dirs (missing tasks/)
+      const sliceDir = join(base, 'milestones', mid, 'slices');
+      const sliceIds = await listDirs(sliceDir);
+      for (const sid of sliceIds) {
+        const tasksDir = join(sliceDir, sid, 'tasks');
+        const hasTasks = await fileExists(tasksDir);
+        const hasPlan = await fileExists(join(sliceDir, sid, `${sid}-PLAN.md`));
+        if (!hasPlan && !hasTasks) {
+          checks.push({
+            name: `slice-${mid}-${sid}-empty`,
+            status: 'warn',
+            message: `${mid}/${sid} has no PLAN.md and no tasks/ directory`,
+          });
+        }
+      }
+    }
+  } else {
+    checks.push({ name: 'milestones', status: 'warn', message: 'No milestones found' });
+  }
+
+  // 7. REQUIREMENTS.md
+  if (await readFileSafe(join(base, 'REQUIREMENTS.md'))) {
+    checks.push({ name: 'requirements', status: 'pass', message: 'REQUIREMENTS.md present' });
+  } else {
+    checks.push({ name: 'requirements', status: 'warn', message: 'REQUIREMENTS.md missing' });
+  }
+
+  // 8. DECISIONS.md
+  if (await readFileSafe(join(base, 'DECISIONS.md'))) {
+    checks.push({ name: 'decisions', status: 'pass', message: 'DECISIONS.md present' });
+  } else {
+    checks.push({ name: 'decisions', status: 'warn', message: 'DECISIONS.md missing' });
+  }
+
+  const healthy = checks.every(c => c.status !== 'fail');
+  return { healthy, checks };
+}

--- a/packages/mcp-server/src/readers/history.ts
+++ b/packages/mcp-server/src/readers/history.ts
@@ -1,0 +1,78 @@
+/**
+ * gsd_history — execution history from metrics.json.
+ */
+
+import { join } from 'node:path';
+import { gsdDir, readFileSafe } from './shared.js';
+
+interface HistoryEntry {
+  id: string;
+  type: string;
+  model: string;
+  startedAt: string;
+  finishedAt: string;
+  tokens: { input: number; output: number; total: number };
+  cost: number;
+  toolCalls: number;
+}
+
+interface HistoryResult {
+  totalUnits: number;
+  totalCost: number;
+  totalTokens: number;
+  entries: HistoryEntry[];
+}
+
+export async function readHistory(
+  projectDir: string,
+  limit = 50,
+): Promise<HistoryResult> {
+  const base = gsdDir(projectDir);
+  const raw = await readFileSafe(join(base, 'metrics.json'));
+  if (!raw) return { totalUnits: 0, totalCost: 0, totalTokens: 0, entries: [] };
+
+  let data: { units?: unknown[] };
+  try {
+    data = JSON.parse(raw);
+  } catch {
+    return { totalUnits: 0, totalCost: 0, totalTokens: 0, entries: [] };
+  }
+
+  const units = Array.isArray(data.units) ? data.units : [];
+  let totalCost = 0;
+  let totalTokens = 0;
+
+  const entries: HistoryEntry[] = [];
+  for (const u of units) {
+    const unit = u as Record<string, unknown>;
+    const tokens = (unit.tokens as Record<string, number>) ?? {};
+    const cost = (unit.cost as number) ?? 0;
+    totalCost += cost;
+    totalTokens += (tokens.total as number) ?? 0;
+
+    entries.push({
+      id: (unit.id as string) ?? 'unknown',
+      type: (unit.type as string) ?? 'unknown',
+      model: (unit.model as string) ?? 'unknown',
+      startedAt: new Date((unit.startedAt as number) ?? 0).toISOString(),
+      finishedAt: new Date((unit.finishedAt as number) ?? 0).toISOString(),
+      tokens: {
+        input: tokens.input ?? 0,
+        output: tokens.output ?? 0,
+        total: tokens.total ?? 0,
+      },
+      cost,
+      toolCalls: (unit.toolCalls as number) ?? 0,
+    });
+  }
+
+  // Return most recent entries up to limit
+  const sliced = entries.slice(-limit);
+
+  return {
+    totalUnits: units.length,
+    totalCost: Math.round(totalCost * 100) / 100,
+    totalTokens,
+    entries: sliced,
+  };
+}

--- a/packages/mcp-server/src/readers/index.ts
+++ b/packages/mcp-server/src/readers/index.ts
@@ -1,0 +1,14 @@
+/**
+ * Lightweight .gsd/ filesystem readers for read-only MCP tools.
+ *
+ * These parse the on-disk markdown/JSON artifacts directly — no DB
+ * dependency, no extension imports. The .gsd/ file format is the
+ * stable contract.
+ */
+
+export { readProgress } from './progress.js';
+export { readRoadmap } from './roadmap.js';
+export { readHistory } from './history.js';
+export { readDoctor } from './doctor.js';
+export { readCaptures } from './captures.js';
+export { readKnowledge } from './knowledge.js';

--- a/packages/mcp-server/src/readers/knowledge.ts
+++ b/packages/mcp-server/src/readers/knowledge.ts
@@ -1,0 +1,40 @@
+/**
+ * gsd_knowledge — project knowledge base (rules, patterns, lessons).
+ */
+
+import { join } from 'node:path';
+import { gsdDir, readFileSafe } from './shared.js';
+
+interface KnowledgeEntry {
+  section: string;
+  text: string;
+}
+
+interface KnowledgeResult {
+  entries: KnowledgeEntry[];
+  raw: string | null;
+}
+
+export async function readKnowledge(projectDir: string): Promise<KnowledgeResult> {
+  const base = gsdDir(projectDir);
+  const content = await readFileSafe(join(base, 'KNOWLEDGE.md'));
+  if (!content) return { entries: [], raw: null };
+
+  const entries: KnowledgeEntry[] = [];
+  let currentSection = 'General';
+
+  for (const line of content.split('\n')) {
+    const headerMatch = line.match(/^##\s+(.+)/);
+    if (headerMatch) {
+      currentSection = headerMatch[1].trim();
+      continue;
+    }
+
+    const bulletMatch = line.match(/^[-*]\s+(.+)/);
+    if (bulletMatch) {
+      entries.push({ section: currentSection, text: bulletMatch[1].trim() });
+    }
+  }
+
+  return { entries, raw: content };
+}

--- a/packages/mcp-server/src/readers/progress.ts
+++ b/packages/mcp-server/src/readers/progress.ts
@@ -1,0 +1,116 @@
+/**
+ * gsd_progress — active milestone/slice/task, phase, completion counts.
+ */
+
+import { join } from 'node:path';
+import { gsdDir, readFileSafe, listDirs, fileExists } from './shared.js';
+
+interface SliceStatus {
+  id: string;
+  title: string;
+  done: boolean;
+  risk?: string;
+}
+
+interface ProgressResult {
+  activeMilestone: string | null;
+  phase: string;
+  slices: { total: number; complete: number; items: SliceStatus[] };
+  activeSlice: string | null;
+  activeTask: string | null;
+  blockers: string[];
+  nextAction: string;
+}
+
+export async function readProgress(projectDir: string): Promise<ProgressResult> {
+  const base = gsdDir(projectDir);
+  const stateContent = await readFileSafe(join(base, 'STATE.md'));
+
+  // Parse STATE.md for active milestone
+  let activeMilestone: string | null = null;
+  let phase = 'unknown';
+  let activeSlice: string | null = null;
+  let activeTask: string | null = null;
+  const blockers: string[] = [];
+
+  if (stateContent) {
+    const midMatch = stateContent.match(/active.milestone[:\s]+(\S+)/i);
+    if (midMatch) activeMilestone = midMatch[1];
+
+    const phaseMatch = stateContent.match(/phase[:\s]+(\S+)/i);
+    if (phaseMatch) phase = phaseMatch[1];
+
+    const sliceMatch = stateContent.match(/active.slice[:\s]+(\S+)/i);
+    if (sliceMatch) activeSlice = sliceMatch[1];
+
+    const taskMatch = stateContent.match(/active.task[:\s]+(\S+)/i);
+    if (taskMatch) activeTask = taskMatch[1];
+
+    const blockerSection = stateContent.match(/## Blockers?\n([\s\S]*?)(?=\n##|$)/i);
+    if (blockerSection) {
+      const lines = blockerSection[1].split('\n').filter(l => l.trim().startsWith('-'));
+      for (const l of lines) blockers.push(l.replace(/^-\s*/, '').trim());
+    }
+  }
+
+  // If no STATE.md, try to infer from milestone dirs
+  if (!activeMilestone) {
+    const milestones = await listDirs(join(base, 'milestones'));
+    if (milestones.length > 0) {
+      // Pick the first non-completed milestone
+      for (const mid of milestones.sort()) {
+        const hasSummary = await fileExists(join(base, 'milestones', mid, `${mid}-SUMMARY.md`));
+        if (!hasSummary) {
+          activeMilestone = mid;
+          break;
+        }
+      }
+      if (!activeMilestone) activeMilestone = milestones[milestones.length - 1];
+    }
+  }
+
+  // Parse roadmap for slice status
+  const slices: SliceStatus[] = [];
+  if (activeMilestone) {
+    const roadmap = await readFileSafe(
+      join(base, 'milestones', activeMilestone, `${activeMilestone}-ROADMAP.md`),
+    );
+    if (roadmap) {
+      const sliceRegex = /- \[([ x])\] \*\*(\w+): ([^*]+)\*\*\s*(?:`risk:(\w+)`)?/g;
+      let match;
+      while ((match = sliceRegex.exec(roadmap)) !== null) {
+        slices.push({
+          id: match[2],
+          title: match[3].trim(),
+          done: match[1] === 'x',
+          risk: match[4] || undefined,
+        });
+      }
+    }
+  }
+
+  const complete = slices.filter(s => s.done).length;
+  let nextAction = 'No project state found. Run /gsd to initialize.';
+  if (activeMilestone && slices.length === 0) {
+    nextAction = `Milestone ${activeMilestone} needs planning.`;
+  } else if (activeTask) {
+    nextAction = `Continue ${activeTask} in ${activeSlice ?? 'current slice'}.`;
+  } else if (activeSlice) {
+    nextAction = `Continue ${activeSlice} in ${activeMilestone}.`;
+  } else if (complete < slices.length) {
+    const next = slices.find(s => !s.done);
+    nextAction = next ? `Start ${next.id}: ${next.title}` : 'Determine next slice.';
+  } else if (slices.length > 0 && complete === slices.length) {
+    nextAction = `All slices complete. Validate and close ${activeMilestone}.`;
+  }
+
+  return {
+    activeMilestone,
+    phase,
+    slices: { total: slices.length, complete, items: slices },
+    activeSlice,
+    activeTask,
+    blockers,
+    nextAction,
+  };
+}

--- a/packages/mcp-server/src/readers/readers.test.ts
+++ b/packages/mcp-server/src/readers/readers.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Tests for read-only MCP project state readers (#3515).
+ */
+
+import { describe, test, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { readProgress } from "./progress.js";
+import { readRoadmap } from "./roadmap.js";
+import { readHistory } from "./history.js";
+import { readDoctor } from "./doctor.js";
+import { readCaptures } from "./captures.js";
+import { readKnowledge } from "./knowledge.js";
+
+function makeTmp(): string {
+  return mkdtempSync(join(tmpdir(), "gsd-mcp-reader-"));
+}
+
+function scaffold(tmp: string): void {
+  const gsd = join(tmp, ".gsd");
+  mkdirSync(gsd, { recursive: true });
+  mkdirSync(join(gsd, "milestones", "M001", "slices", "S01", "tasks"), { recursive: true });
+
+  writeFileSync(join(gsd, "STATE.md"), [
+    "## Status",
+    "active_milestone: M001",
+    "phase: executing",
+    "active_slice: S01",
+    "active_task: T01",
+  ].join("\n"));
+
+  writeFileSync(join(gsd, "milestones", "M001", "M001-ROADMAP.md"), [
+    "# M001 — Foundation",
+    "",
+    "## Slices",
+    "- [x] **S01: Setup** `risk:low` `depends:[]`",
+    "- [ ] **S02: Core** `risk:medium` `depends:[S01]`",
+  ].join("\n"));
+
+  writeFileSync(join(gsd, "milestones", "M001", "slices", "S01", "S01-PLAN.md"), [
+    "# S01 Plan",
+    "",
+    "## Tasks",
+    "- [x] **T01: Init project** `est:15min`",
+    "- [ ] **T02: Add tests** `est:30min`",
+  ].join("\n"));
+
+  writeFileSync(join(gsd, "REQUIREMENTS.md"), "# Requirements\n\n## Active\n");
+  writeFileSync(join(gsd, "DECISIONS.md"), "# Decisions Register\n");
+  writeFileSync(join(gsd, "KNOWLEDGE.md"), [
+    "# Knowledge",
+    "",
+    "## Patterns",
+    "- Always run tests before committing",
+    "- Use conventional commits",
+    "",
+    "## Lessons",
+    "- DB must be opened before deriveState",
+  ].join("\n"));
+
+  writeFileSync(join(gsd, "CAPTURES.md"), [
+    "# Captures",
+    "- [ ] (c1) Add CI pipeline",
+    "- [x] (c2) Fix README typo",
+    "- [ ] (c3) Consider caching layer",
+  ].join("\n"));
+
+  writeFileSync(join(gsd, "metrics.json"), JSON.stringify({
+    units: [
+      { id: "M001/S01/T01", type: "execute-task", model: "sonnet", startedAt: 1000000, finishedAt: 1060000, tokens: { input: 500, output: 200, total: 700 }, cost: 0.02, toolCalls: 5 },
+      { id: "M001/S01/T02", type: "execute-task", model: "opus", startedAt: 1100000, finishedAt: 1200000, tokens: { input: 1000, output: 500, total: 1500 }, cost: 0.08, toolCalls: 12 },
+    ],
+  }));
+
+  // Create gsd.db as empty file (just to pass the exists check)
+  writeFileSync(join(gsd, "gsd.db"), "");
+}
+
+describe("MCP readers (#3515)", () => {
+  let tmp: string;
+  beforeEach(() => { tmp = makeTmp(); scaffold(tmp); });
+  afterEach(() => { rmSync(tmp, { recursive: true, force: true }); });
+
+  // ── gsd_progress ────────────────────────────────────────────────────────
+
+  test("readProgress returns active milestone and slice counts", async () => {
+    const result = await readProgress(tmp);
+    assert.equal(result.activeMilestone, "M001");
+    assert.equal(result.phase, "executing");
+    assert.equal(result.activeSlice, "S01");
+    assert.equal(result.slices.total, 2);
+    assert.equal(result.slices.complete, 1);
+  });
+
+  test("readProgress returns sensible nextAction", async () => {
+    const result = await readProgress(tmp);
+    assert.ok(result.nextAction.includes("T01") || result.nextAction.includes("S01"));
+  });
+
+  // ── gsd_roadmap ─────────────────────────────────────────────────────────
+
+  test("readRoadmap returns milestone and slice structure", async () => {
+    const result = await readRoadmap(tmp);
+    assert.equal(result.milestones.length, 1);
+    assert.equal(result.milestones[0].id, "M001");
+    assert.equal(result.milestones[0].slices.length, 2);
+    assert.equal(result.milestones[0].slices[0].done, true);
+    assert.equal(result.milestones[0].slices[1].done, false);
+    assert.deepEqual(result.milestones[0].slices[1].depends, ["S01"]);
+  });
+
+  test("readRoadmap parses tasks within slices", async () => {
+    const result = await readRoadmap(tmp);
+    const tasks = result.milestones[0].slices[0].tasks;
+    assert.equal(tasks.length, 2);
+    assert.equal(tasks[0].id, "T01");
+    assert.equal(tasks[0].done, true);
+    assert.equal(tasks[1].estimate, "30min");
+  });
+
+  // ── gsd_history ─────────────────────────────────────────────────────────
+
+  test("readHistory returns execution metrics", async () => {
+    const result = await readHistory(tmp);
+    assert.equal(result.totalUnits, 2);
+    assert.equal(result.totalCost, 0.1);
+    assert.equal(result.totalTokens, 2200);
+    assert.equal(result.entries.length, 2);
+  });
+
+  // ── gsd_doctor ──────────────────────────────────────────────────────────
+
+  test("readDoctor returns healthy for well-formed project", async () => {
+    const result = await readDoctor(tmp);
+    assert.equal(result.healthy, true);
+    assert.ok(result.checks.some(c => c.name === "gsd-dir" && c.status === "pass"));
+    assert.ok(result.checks.some(c => c.name === "database" && c.status === "pass"));
+  });
+
+  test("readDoctor returns fail when .gsd/ missing", async () => {
+    const empty = makeTmp();
+    const result = await readDoctor(empty);
+    assert.equal(result.healthy, false);
+    rmSync(empty, { recursive: true, force: true });
+  });
+
+  // ── gsd_captures ────────────────────────────────────────────────────────
+
+  test("readCaptures returns all captures", async () => {
+    const result = await readCaptures(tmp);
+    assert.equal(result.total, 3);
+    assert.equal(result.pending, 2);
+    assert.equal(result.entries.length, 3);
+  });
+
+  test("readCaptures filters pending only", async () => {
+    const result = await readCaptures(tmp, "pending");
+    assert.equal(result.entries.length, 2);
+    assert.ok(result.entries.every(e => e.status === "pending"));
+  });
+
+  // ── gsd_knowledge ───────────────────────────────────────────────────────
+
+  test("readKnowledge parses sections and entries", async () => {
+    const result = await readKnowledge(tmp);
+    assert.equal(result.entries.length, 3);
+    assert.ok(result.entries.some(e => e.section === "Patterns" && e.text.includes("conventional commits")));
+    assert.ok(result.entries.some(e => e.section === "Lessons" && e.text.includes("deriveState")));
+    assert.ok(result.raw !== null);
+  });
+});

--- a/packages/mcp-server/src/readers/roadmap.ts
+++ b/packages/mcp-server/src/readers/roadmap.ts
@@ -1,0 +1,94 @@
+/**
+ * gsd_roadmap — full project structure with status, risk, and dependencies.
+ */
+
+import { join } from 'node:path';
+import { gsdDir, readFileSafe, listDirs, fileExists } from './shared.js';
+
+interface TaskEntry {
+  id: string;
+  title: string;
+  done: boolean;
+  estimate?: string;
+}
+
+interface SliceEntry {
+  id: string;
+  title: string;
+  done: boolean;
+  risk?: string;
+  depends?: string[];
+  tasks: TaskEntry[];
+}
+
+interface MilestoneEntry {
+  id: string;
+  title: string;
+  complete: boolean;
+  slices: SliceEntry[];
+}
+
+interface RoadmapResult {
+  milestones: MilestoneEntry[];
+}
+
+export async function readRoadmap(projectDir: string): Promise<RoadmapResult> {
+  const base = gsdDir(projectDir);
+  const milestoneIds = await listDirs(join(base, 'milestones'));
+  const milestones: MilestoneEntry[] = [];
+
+  for (const mid of milestoneIds.sort()) {
+    const mDir = join(base, 'milestones', mid);
+    const complete = await fileExists(join(mDir, `${mid}-SUMMARY.md`));
+
+    // Parse title from roadmap
+    const roadmap = await readFileSafe(join(mDir, `${mid}-ROADMAP.md`));
+    let title = mid;
+    if (roadmap) {
+      const titleMatch = roadmap.match(/^#\s+(.+)/m);
+      if (titleMatch) title = titleMatch[1].trim();
+    }
+
+    // Parse slices from roadmap
+    const slices: SliceEntry[] = [];
+    if (roadmap) {
+      const sliceRegex = /- \[([ x])\] \*\*(\w+): ([^*]+)\*\*\s*(?:`risk:(\w+)`)?(?:\s*`depends:\[([^\]]*)\]`)?/g;
+      let match;
+      while ((match = sliceRegex.exec(roadmap)) !== null) {
+        const sid = match[2];
+        const depends = match[5] ? match[5].split(',').map(s => s.trim()).filter(Boolean) : undefined;
+
+        // Parse tasks from plan
+        const tasks: TaskEntry[] = [];
+        const planContent = await readFileSafe(
+          join(mDir, 'slices', sid, `${sid}-PLAN.md`),
+        );
+        if (planContent) {
+          const taskRegex = /- \[([ x])\] \*\*(\w+): ([^*]+)\*\*\s*(?:`est:([^`]+)`)?/g;
+          let tm;
+          while ((tm = taskRegex.exec(planContent)) !== null) {
+            tasks.push({
+              id: tm[2],
+              title: tm[3].trim(),
+              done: tm[1] === 'x',
+              estimate: tm[4] || undefined,
+            });
+          }
+        }
+
+        slices.push({
+          id: sid,
+          title: match[3].trim(),
+          done: match[1] === 'x',
+          risk: match[4] || undefined,
+          depends,
+          tasks,
+        });
+      }
+    }
+
+    milestones.push({ id: mid, title, complete, slices });
+  }
+
+  return { milestones };
+}

--- a/packages/mcp-server/src/readers/shared.ts
+++ b/packages/mcp-server/src/readers/shared.ts
@@ -1,0 +1,32 @@
+import { readFile, readdir, stat } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+
+export function gsdDir(projectDir: string): string {
+  return join(resolve(projectDir), '.gsd');
+}
+
+export async function readFileSafe(path: string): Promise<string | null> {
+  try {
+    return await readFile(path, 'utf-8');
+  } catch {
+    return null;
+  }
+}
+
+export async function fileExists(path: string): Promise<boolean> {
+  try {
+    await stat(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function listDirs(dir: string): Promise<string[]> {
+  try {
+    const entries = await readdir(dir, { withFileTypes: true });
+    return entries.filter(e => e.isDirectory()).map(e => e.name);
+  } catch {
+    return [];
+  }
+}

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -274,5 +274,99 @@ export async function createMcpServer(sessionManager: SessionManager): Promise<{
     },
   );
 
+  // ─── Read-only project state tools (#3515) ────────────────────────────
+  // These parse .gsd/ directly — no session needed, no DB dependency.
+
+  const { readProgress } = await import('./readers/progress.js');
+  const { readRoadmap } = await import('./readers/roadmap.js');
+  const { readHistory } = await import('./readers/history.js');
+  const { readDoctor } = await import('./readers/doctor.js');
+  const { readCaptures } = await import('./readers/captures.js');
+  const { readKnowledge } = await import('./readers/knowledge.js');
+
+  server.tool(
+    'gsd_progress',
+    'Get active milestone, slice, task, phase, completion counts, blockers, and next action. No session needed.',
+    { projectDir: z.string().describe('Absolute path to the project directory') },
+    async (args: Record<string, unknown>) => {
+      try {
+        return jsonContent(await readProgress(args.projectDir as string));
+      } catch (err) {
+        return errorContent(err instanceof Error ? err.message : String(err));
+      }
+    },
+  );
+
+  server.tool(
+    'gsd_roadmap',
+    'Get full project structure with milestones, slices, tasks, status, risk, and dependencies. No session needed.',
+    { projectDir: z.string().describe('Absolute path to the project directory') },
+    async (args: Record<string, unknown>) => {
+      try {
+        return jsonContent(await readRoadmap(args.projectDir as string));
+      } catch (err) {
+        return errorContent(err instanceof Error ? err.message : String(err));
+      }
+    },
+  );
+
+  server.tool(
+    'gsd_history',
+    'Get execution history — cost, tokens, model, duration per unit. No session needed.',
+    {
+      projectDir: z.string().describe('Absolute path to the project directory'),
+      limit: z.number().optional().describe('Max entries to return (default: 50)'),
+    },
+    async (args: Record<string, unknown>) => {
+      try {
+        return jsonContent(await readHistory(args.projectDir as string, (args.limit as number) ?? 50));
+      } catch (err) {
+        return errorContent(err instanceof Error ? err.message : String(err));
+      }
+    },
+  );
+
+  server.tool(
+    'gsd_doctor',
+    'Lightweight structural health check — verifies .gsd/ directory, milestones, roadmaps, and required files. No session needed.',
+    { projectDir: z.string().describe('Absolute path to the project directory') },
+    async (args: Record<string, unknown>) => {
+      try {
+        return jsonContent(await readDoctor(args.projectDir as string));
+      } catch (err) {
+        return errorContent(err instanceof Error ? err.message : String(err));
+      }
+    },
+  );
+
+  server.tool(
+    'gsd_captures',
+    'Get pending ideas and captures with filtering. No session needed.',
+    {
+      projectDir: z.string().describe('Absolute path to the project directory'),
+      filter: z.enum(['all', 'pending', 'actionable']).optional().describe('Filter captures (default: all)'),
+    },
+    async (args: Record<string, unknown>) => {
+      try {
+        return jsonContent(await readCaptures(args.projectDir as string, (args.filter as 'all' | 'pending' | 'actionable') ?? 'all'));
+      } catch (err) {
+        return errorContent(err instanceof Error ? err.message : String(err));
+      }
+    },
+  );
+
+  server.tool(
+    'gsd_knowledge',
+    'Get project knowledge base — rules, patterns, and lessons learned. No session needed.',
+    { projectDir: z.string().describe('Absolute path to the project directory') },
+    async (args: Record<string, unknown>) => {
+      try {
+        return jsonContent(await readKnowledge(args.projectDir as string));
+      } catch (err) {
+        return errorContent(err instanceof Error ? err.message : String(err));
+      }
+    },
+  );
+
   return { server };
 }


### PR DESCRIPTION
## TL;DR

**What:** Add 6 read-only MCP tools that parse `.gsd/` directly — no session needed.
**Why:** External tools, CI, dashboards, and other agents cannot observe GSD project state without a running session.
**How:** Standalone filesystem readers in `packages/mcp-server/src/readers/` with no cross-package imports.

---

## What

The MCP server currently exposes 6 session-oriented tools (`gsd_execute`, `gsd_status`, `gsd_result`, `gsd_cancel`, `gsd_query`, `gsd_resolve_blocker`). GSD produces rich structured state on disk (`.gsd/`) that external tools cannot access without a running session.

This adds 6 new read-only tools:

| Tool | Description |
|------|-------------|
| `gsd_progress` | Active milestone/slice/task, phase, completion counts, blockers, next action |
| `gsd_roadmap` | Full project structure with milestones, slices, tasks, status, risk, dependencies |
| `gsd_history` | Execution history from metrics.json — cost, tokens, model, duration per unit |
| `gsd_doctor` | Lightweight structural health check (filesystem only, no shell) |
| `gsd_captures` | Pending ideas/captures with all/pending/actionable filtering |
| `gsd_knowledge` | Project knowledge base — rules, patterns, lessons learned |

## Why

From #3515:
- Other agents can observe GSD state without running GSD
- CI pipelines can health-check projects via MCP
- Web/dashboard can consume structured data via MCP tools
- Cursor/Windsurf users get GSD project visibility without the full extension

## How

Each reader is a standalone module in `packages/mcp-server/src/readers/`:

```
readers/
  shared.ts      — gsdDir(), readFileSafe(), fileExists(), listDirs()
  progress.ts    — STATE.md + ROADMAP.md parsing
  roadmap.ts     — milestone/slice/task tree construction
  history.ts     — metrics.json parsing
  doctor.ts      — structural health checks
  captures.ts    — CAPTURES.md parsing with status filtering
  knowledge.ts   — KNOWLEDGE.md section/entry parsing
  index.ts       — barrel export
```

**Zero new dependencies.** Readers use only `node:fs/promises` and `node:path`. No imports from the GSD extension or any other package. The `.gsd/` on-disk format is the stable contract.

Tools are registered via dynamic imports in `server.ts` after the existing session tools.

## Testing

10 tests covering all 6 readers with a scaffolded `.gsd/` fixture:
- Progress: active milestone, slice counts, next action
- Roadmap: milestone/slice/task structure, dependencies
- History: execution metrics, cost aggregation
- Doctor: healthy project, missing .gsd/ detection
- Captures: all/pending filtering
- Knowledge: section parsing

## Change type

- [x] `feat` — New feature

Addresses #3515