### PR TITLE
fix(bun): support bunx runtime for extension loading

### DIFF
--- a/packages/pi-coding-agent/src/config.ts
+++ b/packages/pi-coding-agent/src/config.ts
@@ -18,7 +18,7 @@ export const isBunBinary =
 	import.meta.url.includes("$bunfs") || import.meta.url.includes("~BUN") || import.meta.url.includes("%7EBUN");
 
 /** Detect if Bun is the runtime (compiled binary or bun run) */
-const isBunRuntime = !!process.versions.bun;
+export const isBunRuntime = !!process.versions.bun;
 
 // =============================================================================
 // Install Method Detection

--- a/packages/pi-coding-agent/src/core/extensions/loader.test.ts
+++ b/packages/pi-coding-agent/src/core/extensions/loader.test.ts
@@ -4,7 +4,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { isProjectTrusted, trustProject, getUntrustedExtensionPaths } from "./project-trust.js";
-import { containsTypeScriptSyntax, loadExtensions } from "./loader.js";
+import { containsTypeScriptSyntax, loadExtensions, VIRTUAL_MODULES } from "./loader.js";
 
 // ─── helpers ──────────────────────────────────────────────────────────────────
 
@@ -15,6 +15,31 @@ function makeTempDir(): string {
 function cleanDir(dir: string): void {
 	fs.rmSync(dir, { recursive: true, force: true });
 }
+
+// ─── VIRTUAL_MODULES: bundled module coverage ──────────────────────────────────
+//
+// These tests ensure that modules used by bundled extensions are present in
+// VIRTUAL_MODULES — the map jiti uses when running under Bun (compiled binary
+// or bunx).  A missing entry here causes "Cannot find module" errors when
+// extensions are loaded under bunx gsd (issue #3504).
+
+describe("VIRTUAL_MODULES", () => {
+	it("contains @sinclair/typebox", () => {
+		assert.ok("@sinclair/typebox" in VIRTUAL_MODULES, "expected @sinclair/typebox in VIRTUAL_MODULES");
+	});
+
+	it("contains yaml", () => {
+		assert.ok("yaml" in VIRTUAL_MODULES, "expected yaml in VIRTUAL_MODULES");
+	});
+
+	it("contains picomatch (used by ttsr extension, was missing for bunx)", () => {
+		assert.ok("picomatch" in VIRTUAL_MODULES, "expected picomatch in VIRTUAL_MODULES");
+	});
+
+	it("contains @modelcontextprotocol/sdk/client", () => {
+		assert.ok("@modelcontextprotocol/sdk/client" in VIRTUAL_MODULES, "expected @modelcontextprotocol/sdk/client in VIRTUAL_MODULES");
+	});
+});
 
 // ─── isProjectTrusted ─────────────────────────────────────────────────────────
 

--- a/packages/pi-coding-agent/src/core/extensions/loader.ts
+++ b/packages/pi-coding-agent/src/core/extensions/loader.ts
@@ -20,6 +20,7 @@ import * as _bundledPiTui from "@gsd/pi-tui";
 // The virtualModules option then makes them available to extensions.
 import * as _bundledTypebox from "@sinclair/typebox";
 import * as _bundledYaml from "yaml";
+import * as _bundledPicomatch from "picomatch";
 import * as _bundledMcpClient from "@modelcontextprotocol/sdk/client";
 import * as _bundledMcpStdio from "@modelcontextprotocol/sdk/client/stdio.js";
 import * as _bundledMcpStreamableHttp from "@modelcontextprotocol/sdk/client/streamableHttp.js";
@@ -29,7 +30,7 @@ import * as _bundledMcpServerStdio from "@modelcontextprotocol/sdk/server/stdio.
 import * as _bundledMcpServerSse from "@modelcontextprotocol/sdk/server/sse.js";
 import * as _bundledMcpServerStreamableHttp from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import * as _bundledMcpTypes from "@modelcontextprotocol/sdk/types.js";
-import { getAgentDir, isBunBinary } from "../../config.js";
+import { getAgentDir, isBunBinary, isBunRuntime } from "../../config.js";
 // NOTE: This import works because loader.ts exports are NOT re-exported from index.ts,
 // avoiding a circular dependency. Extensions can import from @gsd/pi-coding-agent.
 import * as _bundledPiCodingAgent from "../../index.js";
@@ -57,6 +58,7 @@ import type {
  */
 const STATIC_BUNDLED_MODULES: Record<string, unknown> = {
 	"@sinclair/typebox": _bundledTypebox,
+	"picomatch": _bundledPicomatch,
 	"@gsd/pi-agent-core": _bundledPiAgentCore,
 	"@gsd/pi-tui": _bundledPiTui,
 	"@gsd/pi-ai": _bundledPiAi,
@@ -87,8 +89,8 @@ const STATIC_BUNDLED_MODULES: Record<string, unknown> = {
 	"@mariozechner/pi-coding-agent": _bundledPiCodingAgent,
 };
 
-/** Modules available to extensions via virtualModules (for compiled Bun binary) */
-const VIRTUAL_MODULES: Record<string, unknown> = { ...STATIC_BUNDLED_MODULES };
+/** Modules available to extensions via virtualModules (for Bun binary and bun runtime) */
+export const VIRTUAL_MODULES: Record<string, unknown> = { ...STATIC_BUNDLED_MODULES };
 
 const require = createRequire(import.meta.url);
 const EXTENSION_TIMING_ENABLED = process.env.GSD_STARTUP_TIMING === "1" || process.env.PI_TIMING === "1";
@@ -342,7 +344,14 @@ function getAliases(): Record<string, string> {
 }
 
 function getJitiOptions() {
-	return isBunBinary ? { virtualModules: VIRTUAL_MODULES, tryNative: false } : { alias: getAliases() };
+	// Use virtualModules for both compiled Bun binaries and bunx/bun-runtime invocations.
+	// In Bun runtime mode (bunx gsd), require.resolve() cannot find bundled packages
+	// like @sinclair/typebox or picomatch because they are not installed on the user's
+	// disk — they only exist in GSD's own node_modules. virtualModules bypasses filesystem
+	// resolution entirely by injecting the pre-imported module objects directly.
+	return isBunBinary || isBunRuntime
+		? { virtualModules: VIRTUAL_MODULES, tryNative: false }
+		: { alias: getAliases() };
 }
 
 const _moduleImporters = new Map<string, ReturnType<typeof createJiti>>();

--- a/src/resources/extensions/browser-tools/capture.ts
+++ b/src/resources/extensions/browser-tools/capture.ts
@@ -6,7 +6,22 @@
  */
 
 import type { Frame, Page } from "playwright";
-import sharp from "sharp";
+
+// sharp is an optional native dependency. Load it lazily so that the extension
+// can still be loaded on platforms where sharp is unavailable (e.g. bunx on
+// Raspberry Pi). constrainScreenshot falls back to returning the raw buffer
+// when sharp is not installed, which means screenshots won't be resized but
+// the tool remains functional.
+let _sharp: typeof import("sharp") | null | undefined;
+async function getSharp(): Promise<typeof import("sharp") | null> {
+	if (_sharp !== undefined) return _sharp;
+	try {
+		_sharp = (await import("sharp")).default;
+	} catch {
+		_sharp = null;
+	}
+	return _sharp;
+}
 import type { CompactPageState, CompactSelectorState } from "./state.js";
 import { formatCompactStateSummary } from "./utils.js";
 
@@ -168,6 +183,9 @@ export async function constrainScreenshot(
 	mimeType: string,
 	quality: number,
 ): Promise<Buffer> {
+	const sharp = await getSharp();
+	if (!sharp) return buffer;
+
 	const meta = await sharp(buffer).metadata();
 	const width = meta.width;
 	const height = meta.height;


### PR DESCRIPTION
## TL;DR

**What:** GSD extensions fail to load when invoked via `bunx gsd` — all bundled packages like `@sinclair/typebox`, `yaml`, and `picomatch` produce `Cannot find module` errors, and `browser-tools` fails entirely due to a missing `sharp` native binary.
**Why:** The extension loader has two separate module resolution paths — `virtualModules` for compiled Bun binaries and `require.resolve()` aliases for Node.js — but `bunx` was incorrectly routed to the Node.js path, where bundled packages are not available on the user's disk.
**How:** Route `bunx`/Bun-runtime invocations through the existing `virtualModules` path (same as compiled binaries); add the missing `picomatch` to the bundled module set; make `sharp` a lazy optional import in `browser-tools`.

Closes #3504

---

## What

Four files changed across two packages:

**`packages/pi-coding-agent/src/config.ts`**
- Export `isBunRuntime` (was module-private, needed by the loader and for testing)

**`packages/pi-coding-agent/src/core/extensions/loader.ts`**
- `getJitiOptions()`: extend the `virtualModules` branch to cover `isBunRuntime`, not just `isBunBinary`
- Add `picomatch` as a static import and register it in `STATIC_BUNDLED_MODULES`
- Export `VIRTUAL_MODULES` (enables the regression tests below)

**`src/resources/extensions/browser-tools/capture.ts`**
- Replace the top-level `import sharp from "sharp"` with a lazy `getSharp()` helper that catches import failures
- `constrainScreenshot` returns the raw buffer unchanged when `sharp` is unavailable — screenshots work, just without resizing

**`packages/pi-coding-agent/src/core/extensions/loader.test.ts`**
- New `VIRTUAL_MODULES` describe block with four regression tests verifying that `@sinclair/typebox`, `yaml`, `picomatch`, and `@modelcontextprotocol/sdk/client` are all present in the bundled module map

---

## Why

### Root cause

The extension loader (`loader.ts`) has two code paths for module resolution inside jiti:

```typescript
// Before this fix:
function getJitiOptions() {
    return isBunBinary
        ? { virtualModules: VIRTUAL_MODULES, tryNative: false }  // compiled binary ✅
        : { alias: getAliases() };                                // bunx lands here ❌
}
```

`isBunBinary` is `true` only for compiled Bun executables — it detects Bun's virtual filesystem markers in `import.meta.url` (`$bunfs`, `~BUN`, `%7EBUN`). When running via `bunx gsd`, those markers are absent, so `isBunBinary` is `false`.

`isBunRuntime` (`!!process.versions.bun`) correctly identifies any Bun runtime, but was not checked in `getJitiOptions()`.

The Node.js alias path calls `require.resolve("@sinclair/typebox")` etc. to build filesystem paths that jiti uses to locate modules. This works fine after `npm install -g gsd` because the packages land in `node_modules`. Under `bunx`, there is no global install — the packages only exist inside GSD's own bundled `node_modules` and are not reachable via `require.resolve()` from an arbitrary working directory.

The fix is a one-liner:

```typescript
// After this fix:
function getJitiOptions() {
    return isBunBinary || isBunRuntime
        ? { virtualModules: VIRTUAL_MODULES, tryNative: false }
        : { alias: getAliases() };
}
```

### Missing picomatch

`picomatch` was used by the `ttsr` extension (`ttsr-manager.ts`) but was never added to `STATIC_BUNDLED_MODULES`. It therefore wasn't available in `virtualModules` even in the compiled binary. Added alongside the other bundled packages.

### sharp / browser-tools

`sharp` is a native addon with platform-specific prebuilt binaries. On Raspberry Pi (ARM), the prebuilt binary for the current platform may not be available, and under `bunx` the package is not installed at all. The top-level static import caused `browser-tools` to fail at load time — before any tool was ever called.

Making it a lazy import means:
- The extension loads successfully on all platforms
- `constrainScreenshot` silently skips resizing when `sharp` is unavailable, returning the original buffer
- On platforms where `sharp` is present and functional, behaviour is identical to before

---

## How

### getJitiOptions — routing bunx to virtualModules

`isBunRuntime` was already computed in `config.ts` but was `const` (not exported). Exporting it allows `loader.ts` to include it in the `isBunBinary || isBunRuntime` check. No new detection logic was introduced — the variable already existed.

The `virtualModules` map (`VIRTUAL_MODULES`) is built from `STATIC_BUNDLED_MODULES`, which consists of packages imported statically at the top of `loader.ts`. Static imports are required so that Bun bundles them into the compiled binary; the same map now also serves `bunx` invocations, where the modules are available in memory as part of the running GSD process.

### picomatch

Added as a static import alongside `@sinclair/typebox` and `yaml`, and registered in `STATIC_BUNDLED_MODULES` under the `"picomatch"` specifier. No special handling needed — it's a pure JS package.

### sharp lazy load

```typescript
let _sharp: typeof import("sharp") | null | undefined;
async function getSharp(): Promise<typeof import("sharp") | null> {
    if (_sharp !== undefined) return _sharp;
    try {
        _sharp = (await import("sharp")).default;
    } catch {
        _sharp = null;
    }
    return _sharp;
}
```

The result is cached after the first call. `constrainScreenshot` calls `getSharp()` and returns early with the unmodified buffer if the result is `null`.

### Tests

The new `VIRTUAL_MODULES` test block in `loader.test.ts` asserts that each commonly-needed bundled package is present in the map. The `picomatch` test specifically fails on the codebase before this fix (the key does not exist in the map) and passes after. All 223 existing tests continue to pass.