### PR TITLE
fix(resource-loader): resolve hoisted node_modules for bun global installs

### DIFF
--- a/src/resource-loader.ts
+++ b/src/resource-loader.ts
@@ -284,9 +284,18 @@ function copyDirRecursive(src: string, dest: string): void {
  * @gsd/* packages fail. The symlink makes Node's standard resolution find
  * them without requiring every call site to use jiti.
  */
+export function resolveGsdNodeModules(pkgRoot: string): string {
+  const nested = join(pkgRoot, 'node_modules')
+  const hoisted = dirname(pkgRoot)
+  if (!existsSync(join(nested, 'yaml')) && existsSync(join(hoisted, 'yaml'))) {
+    return hoisted
+  }
+  return nested
+}
+
 function ensureNodeModulesSymlink(agentDir: string): void {
   const agentNodeModules = join(agentDir, 'node_modules')
-  const gsdNodeModules = join(packageRoot, 'node_modules')
+  const gsdNodeModules = resolveGsdNodeModules(packageRoot)
 
   try {
     const stat = lstatSync(agentNodeModules)

--- a/src/tests/resource-loader.test.ts
+++ b/src/tests/resource-loader.test.ts
@@ -127,3 +127,26 @@ test("initResources prunes stale top-level extension siblings next to bundled co
   assert.equal(existsSync(staleSiblingPath), false, "stale top-level sibling should be removed during sync");
   assert.equal(existsSync(bundledPath), true, "bundled extension should remain after cleanup");
 });
+
+test("resolveGsdNodeModules returns nested node_modules when yaml is present there", async (t) => {
+  const tmp = mkdtempSync(join(tmpdir(), "gsd-nm-"));
+  t.after(() => { rmSync(tmp, { recursive: true, force: true }); });
+
+  const fakePkgRoot = join(tmp, "gsd-pi");
+  mkdirSync(join(fakePkgRoot, "node_modules", "yaml"), { recursive: true });
+
+  const { resolveGsdNodeModules } = await import("../resource-loader.ts");
+  assert.equal(resolveGsdNodeModules(fakePkgRoot), join(fakePkgRoot, "node_modules"));
+});
+
+test("resolveGsdNodeModules falls back to parent node_modules when yaml is absent in nested but present in hoisted", async (t) => {
+  const tmp = mkdtempSync(join(tmpdir(), "gsd-nm-"));
+  t.after(() => { rmSync(tmp, { recursive: true, force: true }); });
+
+  const fakePkgRoot = join(tmp, "gsd-pi");
+  mkdirSync(join(fakePkgRoot, "node_modules"), { recursive: true });
+  mkdirSync(join(tmp, "yaml"), { recursive: true });
+
+  const { resolveGsdNodeModules } = await import("../resource-loader.ts");
+  assert.equal(resolveGsdNodeModules(fakePkgRoot), tmp);
+});


### PR DESCRIPTION
## TL;DR

**What:** `ensureNodeModulesSymlink` now correctly targets the hoisted `node_modules` directory when bun or pnpm installs `gsd-pi` globally.
**Why:** Bun global installs hoist runtime dependencies (e.g. `yaml`) one level above the package root — the previous hardcoded path `join(packageRoot, 'node_modules')` only contained `@gsd/*` workspace symlinks, causing `ERR_MODULE_NOT_FOUND` for `yaml` on every extension load.
**How:** Probe for `yaml` in the nested directory first; fall back to `dirname(packageRoot)` when it is absent there but present in the parent. npm nested installs are unaffected.

## What

`src/resource-loader.ts` — `ensureNodeModulesSymlink` creates a symlink at `~/.gsd/agent/node_modules` so that extensions can resolve packages without Node's ESM resolver walking up into GSD's install directory. The symlink target was previously hardcoded to `join(packageRoot, 'node_modules')`.

The detection logic is extracted into a new exported function `resolveGsdNodeModules(pkgRoot: string): string` that is used by `ensureNodeModulesSymlink`. Two regression tests cover both resolution paths.

## Why

Package managers differ in how they lay out dependencies for a globally installed package:

| Package manager | Location of `yaml` relative to `packageRoot` |
|---|---|
| npm (nested) | `packageRoot/node_modules/yaml` |
| bun global | `dirname(packageRoot)/yaml` (hoisted to global `node_modules`) |
| pnpm global | `dirname(packageRoot)/yaml` (hoisted) |

With `join(packageRoot, 'node_modules')` hardcoded, bun global installs produced:

```
[gsd] Extension load error: Failed to load extension:
Cannot find package 'yaml' imported from ~/.gsd/agent/extensions/gsd/preferences.js
```

Because `gsd-pi/node_modules` in a bun global install only contains `@gsd/*` workspace symlinks — all other runtime dependencies are one directory up in the shared global `node_modules`.

The result is that every `/gsd` slash command fails to register and GSD reports `Error: Unknown command: /gsd` on startup.

## How

`resolveGsdNodeModules(pkgRoot)` probes whether `yaml` exists inside `join(pkgRoot, 'node_modules')`. If it does not, but does exist in `dirname(pkgRoot)`, the hoisted path is returned. Otherwise the nested path is returned — preserving the existing behaviour for npm installs.

```
npm:  packageRoot/node_modules/yaml  ✓  → symlink → packageRoot/node_modules
bun:  dirname(packageRoot)/yaml      ✓  → symlink → dirname(packageRoot)
```

`yaml` is used as the probe package because it is a direct runtime dependency that is imported by extension files early in the load sequence (specifically `preferences.js`). Its absence is precisely what triggers the reported failure.

Extracting into `resolveGsdNodeModules` makes the detection logic independently testable without mocking module-level constants. The two new tests construct temporary directory trees representing each layout and assert the correct path is returned.

Closes #3529