### PR TITLE
fix(pi-coding-agent): resolve model fallback race that ignores configured provider

### DIFF
--- a/packages/pi-coding-agent/src/core/model-resolver.ts
+++ b/packages/pi-coding-agent/src/core/model-resolver.ts
@@ -13,7 +13,7 @@ import type { ModelRegistry } from "./model-registry.js";
 /** Default model IDs for each known provider */
 const defaultModelPerProvider: Record<KnownProvider, string> = {
 	"amazon-bedrock": "us.anthropic.claude-opus-4-6-v1",
-	anthropic: "claude-opus-4-6[1m]",
+	anthropic: "claude-opus-4-6",
 	"anthropic-vertex": "claude-sonnet-4-6",
 	openai: "gpt-5.4",
 	"azure-openai-responses": "gpt-5.2",
@@ -24,7 +24,7 @@ const defaultModelPerProvider: Record<KnownProvider, string> = {
 	"google-vertex": "gemini-3-pro-preview",
 	"github-copilot": "gpt-4o",
 	openrouter: "openai/gpt-5.1-codex",
-	"vercel-ai-gateway": "anthropic/claude-opus-4-6[1m]",
+	"vercel-ai-gateway": "anthropic/claude-opus-4-6",
 	xai: "grok-4-fast-non-reasoning",
 	groq: "openai/gpt-oss-120b",
 	cerebras: "zai-glm-4.6",
@@ -507,7 +507,7 @@ export async function findInitialModel(options: {
 		const found = modelRegistry.find(defaultProvider, defaultModelId);
 		if (found) {
 			// Check if the provider's recommended default is a higher-capability variant
-			// of the saved model (e.g. saved "claude-opus-4-6" vs recommended "claude-opus-4-6[1m]").
+			// of the saved model (e.g. saved "claude-opus-4-6" vs recommended "claude-opus-4-6-extended").
 			// If so, prefer the recommended variant to avoid using a smaller context window (#1125).
 			const recommendedId = defaultModelPerProvider[defaultProvider as KnownProvider];
 			if (recommendedId && recommendedId !== defaultModelId && recommendedId.startsWith(defaultModelId)) {

--- a/packages/pi-coding-agent/src/core/sdk.ts
+++ b/packages/pi-coding-agent/src/core/sdk.ts
@@ -214,6 +214,17 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		}
 	}
 
+	// Flush extension provider registrations so extension-provided models (e.g. claude-code/*)
+	// are available in the registry before model resolution. Without this, findInitialModel()
+	// cannot find extension models and falls back to built-in providers (#3534).
+	const extensionsForModelResolution = resourceLoader.getExtensions();
+	for (const { name, config } of extensionsForModelResolution.runtime.pendingProviderRegistrations) {
+		modelRegistry.registerProvider(name, config);
+	}
+	// Note: we do NOT clear pendingProviderRegistrations here — bindCore() will iterate
+	// an empty array harmlessly, and clearing here would require the runtime to track
+	// whether the flush already happened.
+
 	// If still no model, use findInitialModel (checks settings default, then provider defaults)
 	if (!model) {
 		const result = await findInitialModel({

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -467,6 +467,19 @@ if (isPrintMode) {
   // registry, causing the user's valid choice to be silently overwritten.
   validateConfiguredModel(modelRegistry, settingsManager)
 
+  // Re-apply the validated model to the session. findInitialModel() may have picked
+  // a fallback if extension models weren't yet registered at that point (#3534).
+  {
+    const validatedProvider = settingsManager.getDefaultProvider()
+    const validatedModelId = settingsManager.getDefaultModel()
+    if (validatedProvider && validatedModelId) {
+      const correctModel = modelRegistry.find(validatedProvider, validatedModelId)
+      if (correctModel) {
+        session.setModel(correctModel)
+      }
+    }
+  }
+
   if (extensionsResult.errors.length > 0) {
     for (const err of extensionsResult.errors) {
       // Downgrade conflicts with built-in tools to warnings (#1347)
@@ -619,6 +632,19 @@ markStartup('createAgentSession')
 // Before this, extension-provided models (e.g. claude-code/*) were not yet in the
 // registry, causing the user's valid choice to be silently overwritten.
 validateConfiguredModel(modelRegistry, settingsManager)
+
+// Re-apply the validated model to the session. findInitialModel() may have picked
+// a fallback if extension models weren't yet registered at that point (#3534).
+{
+  const validatedProvider = settingsManager.getDefaultProvider()
+  const validatedModelId = settingsManager.getDefaultModel()
+  if (validatedProvider && validatedModelId) {
+    const correctModel = modelRegistry.find(validatedProvider, validatedModelId)
+    if (correctModel) {
+      session.setModel(correctModel)
+    }
+  }
+}
 
 if (extensionsResult.errors.length > 0) {
   for (const err of extensionsResult.errors) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -453,7 +453,7 @@ if (isPrintMode) {
   await resourceLoader.reload()
   markStartup('resourceLoader.reload')
 
-  const { session, extensionsResult } = await createAgentSession({
+  const { session, extensionsResult, modelFallbackMessage } = await createAgentSession({
     authStorage,
     modelRegistry,
     settingsManager,
@@ -467,15 +467,21 @@ if (isPrintMode) {
   // registry, causing the user's valid choice to be silently overwritten.
   validateConfiguredModel(modelRegistry, settingsManager)
 
-  // Re-apply the validated model to the session. findInitialModel() may have picked
-  // a fallback if extension models weren't yet registered at that point (#3534).
-  {
+  // Re-apply the validated model to the session only when findInitialModel() used a
+  // fallback (not when restoring an existing session's model). This prevents silently
+  // overriding the persisted model of resumed conversations (#3534).
+  if (modelFallbackMessage) {
     const validatedProvider = settingsManager.getDefaultProvider()
     const validatedModelId = settingsManager.getDefaultModel()
     if (validatedProvider && validatedModelId) {
-      const correctModel = modelRegistry.find(validatedProvider, validatedModelId)
+      const correctModel = modelRegistry.getAvailable()
+        .find((m) => m.provider === validatedProvider && m.id === validatedModelId)
       if (correctModel) {
-        session.setModel(correctModel)
+        try {
+          await session.setModel(correctModel)
+        } catch {
+          // Provider not ready — leave session on its current model
+        }
       }
     }
   }
@@ -619,7 +625,7 @@ const resourceLoadPromise = resourceLoader.reload()
 await resourceLoadPromise
 markStartup('resourceLoader.reload')
 
-const { session, extensionsResult } = await createAgentSession({
+const { session, extensionsResult, modelFallbackMessage: interactiveFallbackMsg } = await createAgentSession({
   authStorage,
   modelRegistry,
   settingsManager,
@@ -633,15 +639,21 @@ markStartup('createAgentSession')
 // registry, causing the user's valid choice to be silently overwritten.
 validateConfiguredModel(modelRegistry, settingsManager)
 
-// Re-apply the validated model to the session. findInitialModel() may have picked
-// a fallback if extension models weren't yet registered at that point (#3534).
-{
+// Re-apply the validated model to the session only when findInitialModel() used a
+// fallback (not when restoring an existing session's model). This prevents silently
+// overriding the persisted model of resumed conversations (#3534).
+if (interactiveFallbackMsg) {
   const validatedProvider = settingsManager.getDefaultProvider()
   const validatedModelId = settingsManager.getDefaultModel()
   if (validatedProvider && validatedModelId) {
-    const correctModel = modelRegistry.find(validatedProvider, validatedModelId)
+    const correctModel = modelRegistry.getAvailable()
+      .find((m) => m.provider === validatedProvider && m.id === validatedModelId)
     if (correctModel) {
-      session.setModel(correctModel)
+      try {
+        await session.setModel(correctModel)
+      } catch {
+        // Provider not ready — leave session on its current model
+      }
     }
   }
 }

--- a/src/tests/startup-model-validation.test.ts
+++ b/src/tests/startup-model-validation.test.ts
@@ -1,0 +1,124 @@
+/**
+ * GSD-2 — Regression tests for startup model validation (#3534)
+ *
+ * Verifies that validateConfiguredModel() correctly handles extension-provided
+ * models and that stale model IDs (e.g. claude-opus-4-6[1m]) trigger fallback.
+ */
+
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { validateConfiguredModel } from "../startup-model-validation.js";
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+interface MockModel {
+	provider: string;
+	id: string;
+}
+
+function createMockRegistry(allModels: MockModel[], availableModels?: MockModel[]) {
+	return {
+		getAll: () => allModels,
+		getAvailable: () => availableModels ?? allModels,
+	};
+}
+
+function createMockSettings(defaults: { provider?: string; model?: string; thinking?: "off" | "high" }) {
+	let currentProvider = defaults.provider;
+	let currentModel = defaults.model;
+	let currentThinking: "off" | "minimal" | "low" | "medium" | "high" | "xhigh" = defaults.thinking ?? "off";
+
+	return {
+		getDefaultProvider: () => currentProvider,
+		getDefaultModel: () => currentModel,
+		getDefaultThinkingLevel: () => currentThinking,
+		setDefaultModelAndProvider: (provider: string, modelId: string) => {
+			currentProvider = provider;
+			currentModel = modelId;
+		},
+		setDefaultThinkingLevel: (level: "off" | "minimal" | "low" | "medium" | "high" | "xhigh") => {
+			currentThinking = level;
+		},
+		// Expose for assertions
+		get _provider() { return currentProvider; },
+		get _model() { return currentModel; },
+		get _thinking() { return currentThinking; },
+	};
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe("validateConfiguredModel — regression #3534", () => {
+	it("preserves valid extension-provided model without overwriting", () => {
+		// Simulate: user configured claude-code/claude-opus-4-6, extension has registered it
+		const registry = createMockRegistry([
+			{ provider: "claude-code", id: "claude-opus-4-6" },
+			{ provider: "google", id: "gemini-2.5-pro" },
+		]);
+		const settings = createMockSettings({ provider: "claude-code", model: "claude-opus-4-6" });
+
+		validateConfiguredModel(registry, settings);
+
+		// Should NOT have changed the settings — the model is valid
+		assert.equal(settings._provider, "claude-code");
+		assert.equal(settings._model, "claude-opus-4-6");
+	});
+
+	it("falls back when configured model ID does not exist in registry", () => {
+		// Simulate: user configured claude-opus-4-6[1m] but registry only has claude-opus-4-6
+		const registry = createMockRegistry([
+			{ provider: "anthropic", id: "claude-opus-4-6" },
+			{ provider: "google", id: "gemini-2.5-pro" },
+		]);
+		const settings = createMockSettings({ provider: "anthropic", model: "claude-opus-4-6[1m]" });
+
+		validateConfiguredModel(registry, settings);
+
+		// Should have replaced with a fallback — the [1m] variant doesn't exist
+		assert.notEqual(settings._model, "claude-opus-4-6[1m]");
+	});
+
+	it("does not fall back to google when anthropic models are available", () => {
+		// Simulate: stale setting triggers fallback, anthropic should be preferred over google
+		const registry = createMockRegistry([
+			{ provider: "anthropic", id: "claude-opus-4-6" },
+			{ provider: "google", id: "gemini-2.5-pro" },
+		]);
+		const settings = createMockSettings({ provider: "anthropic", model: "nonexistent-model" });
+
+		validateConfiguredModel(registry, settings);
+
+		// Should pick anthropic fallback, not google
+		assert.equal(settings._provider, "anthropic");
+		assert.equal(settings._model, "claude-opus-4-6");
+	});
+
+	it("resets thinking level when model is replaced", () => {
+		const registry = createMockRegistry([
+			{ provider: "anthropic", id: "claude-opus-4-6" },
+		]);
+		const settings = createMockSettings({
+			provider: "anthropic",
+			model: "nonexistent-model",
+			thinking: "high",
+		});
+
+		validateConfiguredModel(registry, settings);
+
+		assert.equal(settings._thinking, "off");
+	});
+
+	it("is a no-op when no model is configured at all", () => {
+		const registry = createMockRegistry([
+			{ provider: "anthropic", id: "claude-opus-4-6" },
+			{ provider: "google", id: "gemini-2.5-pro" },
+		]);
+		const settings = createMockSettings({ provider: undefined, model: undefined });
+
+		validateConfiguredModel(registry, settings);
+
+		// Should pick a fallback since nothing was configured
+		assert.ok(settings._provider);
+		assert.ok(settings._model);
+	});
+});


### PR DESCRIPTION
## TL;DR

**What:** Fix session model falling back to Google Gemini despite explicit `claude-code` provider configuration.
**Why:** Three compounding bugs in model initialization cause extension-provided models to be ignored at startup.
**How:** Flush extension registrations before model selection, re-apply validated model to session, and fix stale default model ID.

## What

Fixes a regression introduced in v2.62.0 where `findInitialModel()` runs before extension-provided models are registered in the ModelRegistry. This causes `modelRegistry.find("claude-code", "claude-opus-4-6")` to return `undefined`, and the fallback chain selects `google/gemini-2.5-pro` instead.

**Files changed:**
- `packages/pi-coding-agent/src/core/sdk.ts` — Flush `pendingProviderRegistrations` before `findInitialModel()`
- `src/cli.ts` — Re-apply validated model to session in both print and interactive mode paths
- `packages/pi-coding-agent/src/core/model-resolver.ts` — Update stale `[1m]` model IDs in `defaultModelPerProvider`
- `src/tests/startup-model-validation.test.ts` — Regression tests

## Why

Users configuring `defaultProvider: "claude-code"` with `defaultModel: "claude-opus-4-6"` experience:
- Interactive mode: status bar shows `(google) gemini-2.5-pro` instead of configured model
- Non-interactive mode (`gsd --print`): always attempts Gemini, fails with API errors if no Google credentials
- No workaround for non-interactive mode

Root cause is three compounding issues:

1. **Timing race** — `findInitialModel()` (sdk.ts:219) runs before `bindCore()` flushes `pendingProviderRegistrations` (runner.ts:263-267)
2. **Missing session re-application** — `validateConfiguredModel()` updates `settingsManager` but never calls `session.setModel()`
3. **Stale default model ID** — `defaultModelPerProvider.anthropic` references `claude-opus-4-6[1m]` which was removed from the registry when the base model was upgraded to 1M context

Closes #3534

## How

**(A)** Flush `pendingProviderRegistrations` early in `createAgentSession()` before `findInitialModel()` runs. This mirrors what `main.ts:438-443` already does in a different code path. `registerProvider()` is idempotent, so the later flush in `bindCore()` is harmless.

**(B)** After `validateConfiguredModel()` in both print mode (cli.ts:468) and interactive mode (cli.ts:621), read the validated provider/model from settings and call `session.setModel()` to apply it. This is a safety net for any case where the initial model selection diverged from the user's config.

**(C)** Update `defaultModelPerProvider` entries from `claude-opus-4-6[1m]` to `claude-opus-4-6` (and same for `vercel-ai-gateway`). The `[1m]` variant was intentionally removed from `models.generated.ts` when the base model was upgraded to 1M context, but the default references were not updated.

### Change type checklist

- [x] `fix` — Bug fix

### AI-assisted

This PR was developed with AI assistance (Claude Code). Root cause analysis performed by reading source and tracing execution paths. All changes have been built and tested locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)