### PR TITLE
fix(tui): break enter key loop in interview notes mode

### DIFF
--- a/src/resources/extensions/shared/interview-ui.ts
+++ b/src/resources/extensions/shared/interview-ui.ts
@@ -385,12 +385,8 @@ export async function showInterviewRound(
 				if (matchesKey(data, Key.enter)) {
 					saveEditorToState();
 					focusNotes = false;
-					// Only default to "None of the above" if the cursor is actually
-					// on that option — otherwise Tab→Enter from a normal option would
-					// silently change the selection (#3449).
-					if (!multiSel && st.committedIndex === null) {
-						st.committedIndex = st.cursorIndex;
-					}
+					// goNextOrSubmit() unconditionally sets committedIndex = cursorIndex
+					// for single-select, so no pre-commit is needed here (#3449).
 					goNextOrSubmit();
 					return;
 				}

--- a/src/resources/extensions/shared/interview-ui.ts
+++ b/src/resources/extensions/shared/interview-ui.ts
@@ -298,9 +298,9 @@ export async function showInterviewRound(
 			// Auto-open the notes field when "None of the above" is selected
 			// so the user can immediately provide a free-text explanation
 			// instead of being trapped in a re-asking loop (bug #2715).
-			// Only auto-open if the user hasn't already provided notes —
-			// otherwise Enter from notes mode loops back here endlessly.
-			if (!isMultiSelect(currentIdx) && states[currentIdx].cursorIndex === noneOrDoneIdx(currentIdx) && !states[currentIdx].notes) {
+			// Only auto-open if notes are not already visible — otherwise
+			// Enter from notes mode loops back here endlessly (#3449).
+			if (!isMultiSelect(currentIdx) && states[currentIdx].cursorIndex === noneOrDoneIdx(currentIdx) && !states[currentIdx].notesVisible) {
 				states[currentIdx].notesVisible = true;
 				focusNotes = true;
 				loadStateToEditor();
@@ -385,7 +385,12 @@ export async function showInterviewRound(
 				if (matchesKey(data, Key.enter)) {
 					saveEditorToState();
 					focusNotes = false;
-					if (!multiSel && st.committedIndex === null) st.committedIndex = noneOrDoneIdx(currentIdx);
+					// Only default to "None of the above" if the cursor is actually
+					// on that option — otherwise Tab→Enter from a normal option would
+					// silently change the selection (#3449).
+					if (!multiSel && st.committedIndex === null) {
+						st.committedIndex = st.cursorIndex;
+					}
 					goNextOrSubmit();
 					return;
 				}

--- a/src/resources/extensions/shared/tests/interview-notes-loop.test.ts
+++ b/src/resources/extensions/shared/tests/interview-notes-loop.test.ts
@@ -109,25 +109,22 @@ describe("interview-ui notes loop regression (#3502)", () => {
 		assert.equal(answer.selected, "None of the above");
 	});
 
-	it("still auto-opens notes when selecting 'None of the above' with no prior notes", async () => {
-		// Press Down twice to "None of the above", Enter to select
-		// Then immediately Enter again (empty notes) — this should re-open notes
-		// because the guard only skips when notes are non-empty.
-		// Type something on second open, then Enter to proceed.
+	it("empty notes on 'None of the above' advances instead of looping (#3449)", async () => {
+		// Press Down twice to "None of the above", Enter to select → auto-opens notes.
+		// Then immediately Enter (empty notes) → should advance to review, NOT re-open.
+		// The notesVisible guard prevents the loop even with empty notes.
 		const result = await runWithInputs(questions, [
 			DOWN,        // cursor → 1
 			DOWN,        // cursor → 2 (None of the above)
-			ENTER,       // commit → auto-opens notes
-			ENTER,       // empty notes → goNextOrSubmit → should re-open notes (empty guard)
-			"o", "k",    // type "ok"
-			ENTER,       // now notes = "ok" → should advance to review
+			ENTER,       // commit → auto-opens notes (notesVisible was false)
+			ENTER,       // empty notes → notesVisible is true → skip auto-open → advance to review
 			ENTER,       // submit
 		]);
 
 		assert.ok(result, "should return a result");
 		const answer = result.answers.q1;
 		assert.ok(answer, "answer for q1 should exist");
-		assert.equal(answer.notes, "ok");
+		assert.equal(answer.selected, "None of the above");
 	});
 
 	it("normal option selection is unaffected", async () => {

--- a/src/resources/extensions/shared/tests/interview-notes-loop.test.ts
+++ b/src/resources/extensions/shared/tests/interview-notes-loop.test.ts
@@ -138,4 +138,63 @@ describe("interview-ui notes loop regression (#3502)", () => {
 		assert.ok(answer, "answer for q1 should exist");
 		assert.equal(answer.selected, "Web App");
 	});
+
+	// ─── Reviewer-requested regression coverage on #3551 ──────────────────
+	//
+	// Tab→notes→Enter from a NORMAL option (cursor not on "None of the above")
+	// must commit the normal option, not the done-sentinel. The prior fix in
+	// this PR set `st.committedIndex = st.cursorIndex` in the notes-Enter
+	// handler, which is correct ONLY if the invariant "committedIndex is null
+	// only when cursorIndex === noneOrDoneIdx" holds — and Tab-from-normal is
+	// the one reachable path where that invariant does NOT hold, so it must
+	// be exercised here.
+
+	it("Tab→notes→Enter from a normal option commits the normal option (#3449)", async () => {
+		// Cursor starts at 0 (Web App). Press Tab to open notes without
+		// committing, type nothing, press Enter — must commit index 0 (Web App),
+		// not silently jump to "None of the above".
+		const result = await runWithInputs(questions, [
+			TAB,         // open notes from cursor=0, committedIndex still null
+			ENTER,       // commit cursor=0 (Web App) and advance
+			ENTER,       // submit from review screen
+		]);
+
+		assert.ok(result, "should return a result");
+		const answer = result.answers.q1;
+		assert.ok(answer, "answer for q1 should exist");
+		assert.equal(answer.selected, "Web App", "Tab→Enter on Web App must commit Web App, not None of the above");
+	});
+
+	it("Tab→notes→Enter from a normal option preserves typed notes", async () => {
+		// Same path but user types notes before Enter — ensures notes content
+		// is captured even when opened via Tab on a normal option.
+		const result = await runWithInputs(questions, [
+			TAB,         // open notes from cursor=0
+			"w", "h", "y",  // type "why"
+			ENTER,       // commit cursor=0 with notes and advance
+			ENTER,       // submit
+		]);
+
+		assert.ok(result, "should return a result");
+		const answer = result.answers.q1;
+		assert.ok(answer, "answer for q1 should exist");
+		assert.equal(answer.selected, "Web App");
+		assert.equal(answer.notes, "why", "notes typed via Tab on a normal option must be preserved");
+	});
+
+	it("Tab→notes→Enter from CLI Tool commits CLI Tool, not None of the above", async () => {
+		// Move cursor to index 1 (CLI Tool), Tab open notes, Enter → commit 1.
+		const result = await runWithInputs(questions, [
+			DOWN,        // cursor → 1 (CLI Tool)
+			TAB,         // open notes from cursor=1
+			"c", "l", "i",
+			ENTER,       // commit cursor=1 (CLI Tool)
+			ENTER,       // submit
+		]);
+
+		assert.ok(result, "should return a result");
+		const answer = result.answers.q1;
+		assert.equal(answer.selected, "CLI Tool", "Tab→Enter must commit cursor position (CLI Tool), not the done sentinel");
+		assert.equal(answer.notes, "cli");
+	});
 });


### PR DESCRIPTION
## TL;DR
**What:** Fix infinite loop when pressing Enter in the interview UI notes field.
**Why:** Users are trapped — Enter re-opens notes instead of advancing to the next question.
**How:** Check `notesVisible` instead of `notes` content in auto-open guard; use `cursorIndex` instead of `noneOrDoneIdx` for uncommitted notes.

## What
Two fixes in `interview-ui.ts`:

1. **Auto-open guard (line ~303):** Changed `!states[currentIdx].notes` to `!states[currentIdx].notesVisible`. The old guard failed when notes were empty (falsy), causing the auto-open to re-trigger endlessly. The `notesVisible` check directly prevents re-opening notes that are already visible.

2. **Notes Enter handler (line ~388):** Changed `st.committedIndex = noneOrDoneIdx(currentIdx)` to `st.committedIndex = st.cursorIndex`. The old code forced "None of the above" selection regardless of cursor position when pressing Enter from notes opened via Tab.

## Why
- Pressing Enter after Tab notes traps the user in an infinite loop (#3449)
- Empty notes on "None of the above" also loops because `!""` is truthy
- The notes field closes momentarily and immediately re-opens, making the UI unusable

## Change type
- [x] fix

## Test plan
- [x] Enter after typing notes on "None of the above" advances (existing test, still passes)
- [x] Empty notes on "None of the above" advances instead of looping (updated test for #3449)
- [x] Normal option selection unaffected (existing test, still passes)

Closes #3449

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented notes from unintentionally re-opening for single-select questions when pressing Enter; forward progress now occurs as expected.
  * Fixed Enter key behavior in notes mode so the currently highlighted option is correctly committed and any typed notes are preserved (includes tab→notes→Enter flows).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->