### PR TITLE
fix(gsd): disable dynamic model routing for flat-rate providers

### DIFF
--- a/src/resources/extensions/gsd/auto-model-selection.ts
+++ b/src/resources/extensions/gsd/auto-model-selection.ts
@@ -31,6 +31,9 @@ export function resolvePreferredModelConfig(
   const routingConfig = resolveDynamicRoutingConfig();
   if (!routingConfig.enabled || !routingConfig.tier_models) return undefined;
 
+  // Don't synthesize a routing config for flat-rate providers (#3453).
+  if (autoModeStartModel && isFlatRateProvider(autoModeStartModel.provider)) return undefined;
+
   const ceilingModel = routingConfig.tier_models.heavy
     ?? (autoModeStartModel ? `${autoModeStartModel.provider}/${autoModeStartModel.id}` : undefined);
   if (!ceilingModel) return undefined;
@@ -70,6 +73,16 @@ export async function selectAndApplyModel(
     const routingConfig = resolveDynamicRoutingConfig();
     let effectiveModelConfig = modelConfig;
     let routingTierLabel = "";
+
+    // Disable routing for flat-rate providers like GitHub Copilot (#3453).
+    // All models cost the same per request, so downgrading to a cheaper
+    // model provides no cost benefit — it only degrades quality.
+    if (routingConfig.enabled) {
+      const primaryModel = resolveModelId(modelConfig.primary, availableModels, ctx.model?.provider);
+      if (primaryModel && isFlatRateProvider(primaryModel.provider)) {
+        routingConfig.enabled = false;
+      }
+    }
 
     if (routingConfig.enabled) {
       let budgetPct: number | undefined;
@@ -319,4 +332,14 @@ export function resolveModelId<T extends { id: string; provider: string }>(
 
   // Fall back to first non-extension candidate, or any candidate
   return candidates.find(m => !EXTENSION_PROVIDERS.has(m.provider)) ?? candidates[0];
+}
+
+/**
+ * Flat-rate providers charge the same per request regardless of model.
+ * Dynamic routing provides no cost benefit — it only degrades quality (#3453).
+ */
+const FLAT_RATE_PROVIDERS = new Set(["github-copilot"]);
+
+export function isFlatRateProvider(provider: string): boolean {
+  return FLAT_RATE_PROVIDERS.has(provider);
 }

--- a/src/resources/extensions/gsd/tests/flat-rate-routing-guard.test.ts
+++ b/src/resources/extensions/gsd/tests/flat-rate-routing-guard.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Regression test for #3453: dynamic model routing must be disabled for
+ * flat-rate providers like GitHub Copilot where all models cost the same
+ * per request — routing only degrades quality with no cost benefit.
+ */
+
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import { isFlatRateProvider, resolvePreferredModelConfig } from "../auto-model-selection.ts";
+
+describe("flat-rate provider routing guard (#3453)", () => {
+
+  test("isFlatRateProvider returns true for github-copilot", () => {
+    assert.equal(isFlatRateProvider("github-copilot"), true);
+  });
+
+  test("isFlatRateProvider returns false for anthropic", () => {
+    assert.equal(isFlatRateProvider("anthropic"), false);
+  });
+
+  test("isFlatRateProvider returns false for openai", () => {
+    assert.equal(isFlatRateProvider("openai"), false);
+  });
+
+  test("resolvePreferredModelConfig returns undefined for copilot start model", () => {
+    // When the user's start model is on a flat-rate provider,
+    // resolvePreferredModelConfig should not synthesize a routing
+    // config from tier_models — it should return undefined so the
+    // user's selected model is preserved.
+    const result = resolvePreferredModelConfig("execute-task", {
+      provider: "github-copilot",
+      id: "claude-sonnet-4",
+    });
+
+    // Should be undefined (no routing config created for flat-rate)
+    // Note: this only tests the guard — if explicit per-unit config exists
+    // in preferences, that takes precedence regardless.
+    assert.equal(result, undefined, "Should not create routing config for copilot");
+  });
+});


### PR DESCRIPTION
## TL;DR
**What:** Skip dynamic model routing when the user's model is on a flat-rate provider (GitHub Copilot).
**Why:** Copilot charges the same per request regardless of model — routing to cheaper models only degrades quality.
**How:** Check provider against a flat-rate set before routing; skip if matched.

## What
Dynamic model routing exists to downgrade models under complexity/budget pressure to save costs. For flat-rate providers like GitHub Copilot, all models cost the same per request, so routing provides zero cost benefit — it only degrades quality by silently switching to worse models (e.g., gemini-2.5 instead of the user's selected claude-sonnet-4).

Two guards added in `auto-model-selection.ts`:

1. **`resolvePreferredModelConfig()`:** When the user's start model is on a flat-rate provider, don't synthesize a routing config from `tier_models`. Returns `undefined` so the user's selected model is preserved.

2. **`selectAndApplyModel()`:** After resolving the routing config, check if the primary model belongs to a flat-rate provider. If so, set `routingConfig.enabled = false` before any classification or routing decisions.

## Why
- Copilot users saw their selected model silently replaced with gemini-2.5 (#3453)
- All copilot models cost the same — routing has no cost benefit
- This is a regression — models stayed put before dynamic routing was added

## How
- Added `isFlatRateProvider()` helper with a `FLAT_RATE_PROVIDERS` set (currently `github-copilot`)
- Guard in `resolvePreferredModelConfig()` returns early for flat-rate start models
- Guard in `selectAndApplyModel()` disables routing config for flat-rate primary models
- Easily extensible — add providers to the set as needed

## Change type
- [x] fix

## Test plan
- [x] `isFlatRateProvider` returns true for github-copilot (new test)
- [x] `isFlatRateProvider` returns false for anthropic/openai (new test)
- [x] `resolvePreferredModelConfig` returns undefined for copilot start model (new test)

Closes #3453

🤖 Generated with [Claude Code](https://claude.com/claude-code)