### PR TITLE
fix(tui): treat absolute file paths as plain text, not commands

### DIFF
--- a/packages/pi-coding-agent/src/modes/interactive/controllers/input-controller.test.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/controllers/input-controller.test.ts
@@ -154,3 +154,30 @@ test("input-controller: truly unknown slash commands stop before session.prompt"
 	);
 	assert.equal(getEditorText(), "", "unknown slash commands should clear the editor after showing the error");
 });
+
+test("input-controller: absolute file paths are not treated as slash commands (#3478)", async () => {
+	const { host, prompted, errors } = createHost();
+
+	await host.defaultEditor.onSubmit("/Users/name/Desktop/screenshot.png");
+
+	assert.deepEqual(errors, [], "file paths should not trigger unknown command error");
+	assert.deepEqual(prompted, ["/Users/name/Desktop/screenshot.png"], "file paths should be sent as plain input");
+});
+
+test("input-controller: Linux absolute paths are not treated as slash commands (#3478)", async () => {
+	const { host, prompted, errors } = createHost();
+
+	await host.defaultEditor.onSubmit("/home/user/documents/file.txt");
+
+	assert.deepEqual(errors, [], "Linux paths should not trigger unknown command error");
+	assert.deepEqual(prompted, ["/home/user/documents/file.txt"], "Linux paths should be sent as plain input");
+});
+
+test("input-controller: /tmp paths are not treated as slash commands (#3478)", async () => {
+	const { host, prompted, errors } = createHost();
+
+	await host.defaultEditor.onSubmit("/tmp/some-file.log");
+
+	assert.deepEqual(errors, []);
+	assert.deepEqual(prompted, ["/tmp/some-file.log"]);
+});

--- a/packages/pi-coding-agent/src/modes/interactive/controllers/input-controller.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/controllers/input-controller.ts
@@ -18,7 +18,7 @@ export function setupEditorSubmitHandler(host: InteractiveModeStateHost & {
 		text = text.trim();
 		if (!text) return;
 
-		if (text.startsWith("/")) {
+		if (text.startsWith("/") && !looksLikeFilePath(text)) {
 			const handled = await dispatchSlashCommand(text, host.getSlashCommandContext());
 			if (handled) {
 				host.editor.setText("");
@@ -103,4 +103,19 @@ export function setupEditorSubmitHandler(host: InteractiveModeStateHost & {
 			host.showError(errorMessage);
 		}
 	};
+}
+
+/**
+ * Distinguish absolute file paths from slash commands (#3478).
+ * Drag-and-drop inserts paths like "/Users/name/Desktop/file.png" which
+ * should be treated as plain text input, not a /Users command.
+ *
+ * Heuristic: a slash command is a single token like "/help" or "/gsd auto".
+ * File paths have a second "/" within the first token (e.g., "/Users/...").
+ */
+function looksLikeFilePath(text: string): boolean {
+	const firstToken = text.split(/\s/)[0];
+	// Slash commands: /help, /gsd, /commit — single "/" at start only.
+	// File paths: /Users/name/file, /home/user/file, /tmp/x — contain "/" after position 0.
+	return firstToken.indexOf("/", 1) !== -1;
 }


### PR DESCRIPTION
## TL;DR
**What:** Dragging a file into Pi no longer triggers "Unknown command" errors.
**Why:** Absolute paths like `/Users/name/file.png` were parsed as `/Users` slash command.
**How:** Detect file paths (contain `/` after position 0) and bypass slash command dispatch.

## What
When a file is dragged into the Pi TUI input field, the absolute path (e.g., `/Users/name/Desktop/screenshot.png`) starts with `/` and is interpreted as a slash command. This shows `Error: Unknown command: /Users/name/Desktop/screenshot.png`.

The fix adds a `looksLikeFilePath()` heuristic before the slash command check: if the first token contains a `/` after position 0 (like `/Users/name/...`), it's a file path, not a command. Slash commands are single tokens like `/help` or `/gsd` — they never contain embedded slashes.

## Why
- Drag-and-drop is a common workflow, especially for screenshots (#3478)
- The error is confusing — users don't expect file paths to be parsed as commands
- This worked in GSD v1 (Claude Code) — regression in Pi

## How
- `input-controller.ts`: Added `looksLikeFilePath()` guard before `text.startsWith("/")` command dispatch
- Heuristic: first whitespace-delimited token has `/` at position >0 → file path, not command
- File path text falls through to `session.prompt()` as normal user input

## Change type
- [x] fix

## Test plan
- [x] `/Users/name/Desktop/screenshot.png` sent as plain input (new test)
- [x] `/home/user/documents/file.txt` sent as plain input (new test)
- [x] `/tmp/some-file.log` sent as plain input (new test)
- [x] `/settings` still dispatched as slash command (existing test)
- [x] `/gsd help` still dispatched as slash command (existing test)
- [x] Unknown commands still show error (existing test)
- [x] All 10 tests pass (7 existing + 3 new)

Closes #3478

🤖 Generated with [Claude Code](https://claude.com/claude-code)