### PR TITLE
fix(gsd): honour require_slice_discussion in auto-mode dispatch

### DIFF
--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -389,8 +389,12 @@ export const DISPATCH_RULES: DispatchRule[] = [
       if (!prefs?.phases?.require_slice_discussion) return null;
       if (!state.activeSlice) return null;
       // Only pause if the slice has no context file yet (discussion not done).
+      // resolveSliceFile returns null when the file does not exist on disk,
+      // but cachedReaddir could return a stale hit — verify with existsSync
+      // so the guard is defence-in-depth and the contract is explicit at the
+      // call site.
       const sliceContextFile = resolveSliceFile(basePath, mid, state.activeSlice.id, "CONTEXT");
-      if (sliceContextFile) return null; // discussion already done, proceed
+      if (sliceContextFile && existsSync(sliceContextFile)) return null; // discussion already done, proceed
       return {
         action: "stop" as const,
         reason: `Slice ${state.activeSlice.id} requires discussion before planning (require_slice_discussion is enabled). Run /gsd discuss to discuss this slice, then /gsd auto to resume.`,

--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -383,6 +383,22 @@ export const DISPATCH_RULES: DispatchRule[] = [
     },
   },
   {
+    name: "planning (require_slice_discussion) → pause for discussion (#3454)",
+    match: async ({ state, mid, basePath, prefs }) => {
+      if (state.phase !== "planning") return null;
+      if (!prefs?.phases?.require_slice_discussion) return null;
+      if (!state.activeSlice) return null;
+      // Only pause if the slice has no context file yet (discussion not done).
+      const sliceContextFile = resolveSliceFile(basePath, mid, state.activeSlice.id, "CONTEXT");
+      if (sliceContextFile) return null; // discussion already done, proceed
+      return {
+        action: "stop" as const,
+        reason: `Slice ${state.activeSlice.id} requires discussion before planning (require_slice_discussion is enabled). Run /gsd discuss to discuss this slice, then /gsd auto to resume.`,
+        level: "info" as const,
+      };
+    },
+  },
+  {
     // Keep this rule before the single-slice research rule so the multi-slice
     // path wins whenever 2+ slices are ready.
     name: "planning (multiple slices need research) → parallel-research-slices",

--- a/src/resources/extensions/gsd/tests/require-slice-discussion-dispatch.test.ts
+++ b/src/resources/extensions/gsd/tests/require-slice-discussion-dispatch.test.ts
@@ -1,19 +1,164 @@
 /**
- * Regression test for #3454: auto-dispatch must honour
- * require_slice_discussion preference and stop before plan-slice.
+ * Regression tests for #3454: auto-dispatch must honour
+ * require_slice_discussion and pause before plan-slice when:
+ *   1. state.phase === "planning"
+ *   2. require_slice_discussion is enabled in preferences
+ *   3. state.activeSlice is non-null
+ *   4. the slice has no CONTEXT file on disk
+ *
+ * Exercises the dispatch rule from DISPATCH_RULES directly with a
+ * DispatchContext built against a real temp directory — no source-string
+ * matching, no brittle rename dependencies.
  */
-import { test } from "node:test";
+import { test, describe } from "node:test";
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { DISPATCH_RULES, type DispatchContext } from "../auto-dispatch.ts";
+import type { GSDState, GSDPreferences } from "../types.ts";
 
-test("auto-dispatch has require_slice_discussion rule before plan-slice (#3454)", () => {
-  const src = readFileSync(
-    join(import.meta.dirname, "..", "auto-dispatch.ts"),
-    "utf-8",
-  );
-  const discussIdx = src.indexOf("require_slice_discussion");
-  const planIdx = src.indexOf('"planning → plan-slice"');
-  assert.ok(discussIdx !== -1, "auto-dispatch must check require_slice_discussion");
-  assert.ok(discussIdx < planIdx, "Discussion check must come before plan-slice rule");
+const RULE_NAME = "planning (require_slice_discussion) → pause for discussion (#3454)";
+
+function findRule() {
+  const rule = DISPATCH_RULES.find(r => r.name === RULE_NAME);
+  if (!rule) throw new Error(`dispatch rule not found: ${RULE_NAME}`);
+  return rule;
+}
+
+function buildState(overrides: Partial<GSDState> = {}): GSDState {
+  return {
+    activeMilestone: { id: "M001", title: "Test milestone" },
+    activeSlice: { id: "S01", title: "Test slice" },
+    activeTask: null,
+    phase: "planning",
+    recentDecisions: [],
+    blockers: [],
+    nextAction: "",
+    registry: [],
+    ...overrides,
+  };
+}
+
+function makeBasePath(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), `gsd-req-slice-${prefix}-`));
+  mkdirSync(join(dir, ".gsd", "milestones", "M001", "slices", "S01"), { recursive: true });
+  return dir;
+}
+
+function buildCtx(
+  basePath: string,
+  prefs: GSDPreferences | undefined,
+  state: GSDState = buildState(),
+): DispatchContext {
+  return {
+    basePath,
+    mid: "M001",
+    midTitle: "Test milestone",
+    state,
+    prefs,
+  };
+}
+
+describe("require_slice_discussion dispatch rule (#3454)", () => {
+  // ─── Positive case: rule fires ────────────────────────────────────────
+
+  test("returns stop action when preference enabled and CONTEXT missing", async () => {
+    const basePath = makeBasePath("fire");
+    try {
+      const prefs = { phases: { require_slice_discussion: true } } as unknown as GSDPreferences;
+      const action = await findRule().match(buildCtx(basePath, prefs));
+      assert.ok(action, "rule must return a non-null action when pausing is required");
+      assert.strictEqual(action!.action, "stop");
+      if (action!.action === "stop") {
+        assert.match(action!.reason, /S01/);
+        assert.match(action!.reason, /require_slice_discussion/);
+        assert.match(action!.reason, /\/gsd discuss/);
+        assert.strictEqual(action!.level, "info");
+      }
+    } finally {
+      rmSync(basePath, { recursive: true, force: true });
+    }
+  });
+
+  // ─── Negative cases: rule falls through ───────────────────────────────
+
+  test("falls through (null) when preference is disabled", async () => {
+    const basePath = makeBasePath("pref-disabled");
+    try {
+      const prefs = { phases: { require_slice_discussion: false } } as unknown as GSDPreferences;
+      const action = await findRule().match(buildCtx(basePath, prefs));
+      assert.strictEqual(action, null);
+    } finally {
+      rmSync(basePath, { recursive: true, force: true });
+    }
+  });
+
+  test("falls through (null) when preference is absent / undefined", async () => {
+    const basePath = makeBasePath("pref-absent");
+    try {
+      const action = await findRule().match(buildCtx(basePath, undefined));
+      assert.strictEqual(action, null);
+    } finally {
+      rmSync(basePath, { recursive: true, force: true });
+    }
+  });
+
+  test("falls through (null) when phase is not 'planning'", async () => {
+    const basePath = makeBasePath("wrong-phase");
+    try {
+      const prefs = { phases: { require_slice_discussion: true } } as unknown as GSDPreferences;
+      const state = buildState({ phase: "executing" });
+      const action = await findRule().match(buildCtx(basePath, prefs, state));
+      assert.strictEqual(action, null);
+    } finally {
+      rmSync(basePath, { recursive: true, force: true });
+    }
+  });
+
+  test("falls through (null) when no active slice", async () => {
+    const basePath = makeBasePath("no-slice");
+    try {
+      const prefs = { phases: { require_slice_discussion: true } } as unknown as GSDPreferences;
+      const state = buildState({ activeSlice: null });
+      const action = await findRule().match(buildCtx(basePath, prefs, state));
+      assert.strictEqual(action, null);
+    } finally {
+      rmSync(basePath, { recursive: true, force: true });
+    }
+  });
+
+  // ─── Context-file present: should not pause ───────────────────────────
+
+  test("falls through (null) when CONTEXT file already exists on disk", async () => {
+    const basePath = makeBasePath("ctx-present");
+    try {
+      // Seed the CONTEXT file that /gsd discuss would have written.
+      const sliceDir = join(basePath, ".gsd", "milestones", "M001", "slices", "S01");
+      writeFileSync(join(sliceDir, "S01-CONTEXT.md"), "# Discussion notes\n", "utf-8");
+
+      const prefs = { phases: { require_slice_discussion: true } } as unknown as GSDPreferences;
+      const action = await findRule().match(buildCtx(basePath, prefs));
+      assert.strictEqual(
+        action,
+        null,
+        "once the slice has a CONTEXT file, the rule must fall through so planning proceeds",
+      );
+    } finally {
+      rmSync(basePath, { recursive: true, force: true });
+    }
+  });
+
+  // ─── Rule ordering: must run before the plan-slice rule ──────────────
+
+  test("rule is ordered before the 'planning → plan-slice' rule", () => {
+    const discussIdx = DISPATCH_RULES.findIndex(r => r.name === RULE_NAME);
+    const planIdx = DISPATCH_RULES.findIndex(r => r.name.startsWith("planning → plan-slice"));
+    assert.ok(discussIdx >= 0, "require_slice_discussion rule must be registered");
+    assert.ok(planIdx >= 0, "plan-slice rule must be registered");
+    assert.ok(
+      discussIdx < planIdx,
+      "require_slice_discussion rule must be ordered before plan-slice so it preempts dispatch",
+    );
+  });
 });

--- a/src/resources/extensions/gsd/tests/require-slice-discussion-dispatch.test.ts
+++ b/src/resources/extensions/gsd/tests/require-slice-discussion-dispatch.test.ts
@@ -19,12 +19,17 @@ import { DISPATCH_RULES, type DispatchContext } from "../auto-dispatch.ts";
 import type { GSDState } from "../types.ts";
 import type { GSDPreferences } from "../preferences.ts";
 
-const RULE_NAME = "planning (require_slice_discussion) → pause for discussion (#3454)";
+// Use a stable token (the preference name) for rule lookup instead of the
+// full human-readable title — copy edits to the rule name will not break
+// these tests as long as the rule still references the preference it gates.
+const RULE_NAME_TOKEN = "require_slice_discussion";
 
 function findRule() {
-  const rule = DISPATCH_RULES.find(r => r.name === RULE_NAME);
-  if (!rule) throw new Error(`dispatch rule not found: ${RULE_NAME}`);
-  return rule;
+  const matches = DISPATCH_RULES.filter(r => r.name.includes(RULE_NAME_TOKEN));
+  if (matches.length !== 1) {
+    throw new Error(`expected exactly one dispatch rule containing "${RULE_NAME_TOKEN}", found ${matches.length}`);
+  }
+  return matches[0];
 }
 
 function buildState(overrides: Partial<GSDState> = {}): GSDState {
@@ -153,7 +158,7 @@ describe("require_slice_discussion dispatch rule (#3454)", () => {
   // ─── Rule ordering: must run before the plan-slice rule ──────────────
 
   test("rule is ordered before the 'planning → plan-slice' rule", () => {
-    const discussIdx = DISPATCH_RULES.findIndex(r => r.name === RULE_NAME);
+    const discussIdx = DISPATCH_RULES.findIndex(r => r.name.includes(RULE_NAME_TOKEN));
     const planIdx = DISPATCH_RULES.findIndex(r => r.name.startsWith("planning → plan-slice"));
     assert.ok(discussIdx >= 0, "require_slice_discussion rule must be registered");
     assert.ok(planIdx >= 0, "plan-slice rule must be registered");

--- a/src/resources/extensions/gsd/tests/require-slice-discussion-dispatch.test.ts
+++ b/src/resources/extensions/gsd/tests/require-slice-discussion-dispatch.test.ts
@@ -1,0 +1,19 @@
+/**
+ * Regression test for #3454: auto-dispatch must honour
+ * require_slice_discussion preference and stop before plan-slice.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+test("auto-dispatch has require_slice_discussion rule before plan-slice (#3454)", () => {
+  const src = readFileSync(
+    join(import.meta.dirname, "..", "auto-dispatch.ts"),
+    "utf-8",
+  );
+  const discussIdx = src.indexOf("require_slice_discussion");
+  const planIdx = src.indexOf('"planning → plan-slice"');
+  assert.ok(discussIdx !== -1, "auto-dispatch must check require_slice_discussion");
+  assert.ok(discussIdx < planIdx, "Discussion check must come before plan-slice rule");
+});

--- a/src/resources/extensions/gsd/tests/require-slice-discussion-dispatch.test.ts
+++ b/src/resources/extensions/gsd/tests/require-slice-discussion-dispatch.test.ts
@@ -16,7 +16,8 @@ import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { DISPATCH_RULES, type DispatchContext } from "../auto-dispatch.ts";
-import type { GSDState, GSDPreferences } from "../types.ts";
+import type { GSDState } from "../types.ts";
+import type { GSDPreferences } from "../preferences.ts";
 
 const RULE_NAME = "planning (require_slice_discussion) → pause for discussion (#3454)";
 


### PR DESCRIPTION
## TL;DR
**What:** Auto-mode now pauses before planning a slice when `require_slice_discussion` is enabled.
**Why:** The documented preference was silently ignored — auto-mode proceeded directly to plan-slice.
**How:** Added a dispatch rule before research/plan-slice that stops auto-mode when the slice has no context file.

## What
`phases.require_slice_discussion: true` is a documented preference that should pause auto-mode before each new slice for a discussion round (especially useful with remote questions via Telegram/Discord/Slack). The direct dispatch path (`/gsd plan`) already checked this preference, but the auto-mode dispatch table (`auto-dispatch.ts`) did not — it jumped straight to `research-slice` or `plan-slice`.

Added a new dispatch rule `"planning (require_slice_discussion) → pause for discussion"` that fires BEFORE the research and plan rules. When:
1. `phase === "planning"` (slice needs planning)
2. `require_slice_discussion` is enabled in preferences
3. The slice has no `CONTEXT` file (discussion not yet done)

...auto-mode stops with an info message telling the user to run `/gsd discuss`.

Once the user discusses the slice (creating a `S##-CONTEXT.md` file), `/gsd auto` resumes normally — the rule sees the context file exists and falls through to research/plan.

## Why
- Documented preference was silently ignored (#3454)
- Users expected remote question routing for slice-level discussion
- The direct dispatch path had the guard but auto-mode didn't

## Change type
- [x] fix

## Test plan
- [ ] Set `require_slice_discussion: true` → `/gsd auto` pauses before plan-slice with info message
- [ ] Run `/gsd discuss` for the slice → creates context file → `/gsd auto` proceeds normally
- [ ] Without the preference → auto-mode proceeds to plan-slice as before (unchanged)
- [ ] Slice that already has context file → auto-mode proceeds even with preference enabled

Closes #3454

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Auto-dispatch now halts during the planning phase if a slice discussion context is missing and the preference gate is enabled, prompting users to run the discussion command before continuing.

* **Tests**
  * Added regression tests that validate the discussion-enforcement rule across phases, preference states, presence/absence of an active slice and existing context, and confirm the rule’s evaluation order among dispatch rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->