### PR TITLE
fix(gsd): park milestone when rewrite-docs resolves abandon override

### DIFF
--- a/src/resources/extensions/gsd/abandon-detect.ts
+++ b/src/resources/extensions/gsd/abandon-detect.ts
@@ -1,0 +1,61 @@
+/**
+ * Abandon-milestone detection for rewrite-docs overrides (#3490).
+ *
+ * Isolated from auto-post-unit.ts so behavioral tests can import this module
+ * without pulling in the full post-unit handler graph (which transitively
+ * loads model-router, workflow engine, etc.).
+ */
+
+import type { Override } from "./files.js";
+
+// Detect when a rewrite-docs override is about abandoning THE CURRENT
+// MILESTONE — not just any override containing an abandon verb. Naively
+// matching `/\b(abandon|cancel|drop|...)\b/` against override text produces
+// false positives on scope-change prose ("cancel the standup reminder",
+// "drop the dependency on X", "scrap the v1 design for the landing page").
+//
+// To qualify as an abandon-milestone signal, an override must contain both:
+//   1. An abandon-family verb (abandon|descope|cancel|shelve|drop|scrap)
+//   2. A milestone reference — either the literal word "milestone" or the
+//      current milestone ID — in the same override text.
+
+// Verb variants cover both US and UK inflections:
+//   cancel / canceled / canceling / cancelled / cancelling / cancels
+//   travel-style "l"-doubling also applies to shelve/drop/scrap.
+const ABANDON_VERB_RE = /\b(abandon(?:ed|ing|s)?|descope(?:d|s)?|cancel(?:led|ling|ed|ing|s)?|shelve(?:d|s)?|shelving|drop(?:ped|ping|s)?|scrap(?:ped|ping|s)?)\b/i;
+
+export interface AbandonDecision {
+  shouldPark: boolean;
+  reason: string;
+  matched: string[];
+}
+
+/**
+ * Decide whether a set of active overrides indicates the current milestone
+ * should be parked. Pure function — no I/O, no imports beyond types.
+ */
+export function detectAbandonMilestone(
+  overrides: Override[],
+  currentMilestoneId: string | null | undefined,
+): AbandonDecision {
+  if (!currentMilestoneId) {
+    return { shouldPark: false, reason: "", matched: [] };
+  }
+
+  const escapedId = currentMilestoneId.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const milestoneRefRe = new RegExp(`\\b(?:milestone|${escapedId})\\b`, "i");
+
+  const matched = overrides
+    .filter(o => ABANDON_VERB_RE.test(o.change) && milestoneRefRe.test(o.change))
+    .map(o => o.change);
+
+  if (matched.length === 0) {
+    return { shouldPark: false, reason: "", matched: [] };
+  }
+
+  return {
+    shouldPark: true,
+    reason: matched.join("; "),
+    matched,
+  };
+}

--- a/src/resources/extensions/gsd/abandon-detect.ts
+++ b/src/resources/extensions/gsd/abandon-detect.ts
@@ -22,7 +22,8 @@ import type { Override } from "./files.js";
 // Verb variants cover both US and UK inflections:
 //   cancel / canceled / canceling / cancelled / cancelling / cancels
 //   travel-style "l"-doubling also applies to shelve/drop/scrap.
-const ABANDON_VERB_RE = /\b(abandon(?:ed|ing|s)?|descope(?:d|s)?|cancel(?:led|ling|ed|ing|s)?|shelve(?:d|s)?|shelving|drop(?:ped|ping|s)?|scrap(?:ped|ping|s)?)\b/i;
+// "descope" also accepts "de-scope" and "de scope" (hyphen / space forms).
+const ABANDON_VERB_RE = /\b(abandon(?:ed|ing|s)?|de[-\s]?scope(?:d|s|ing)?|cancel(?:led|ling|ed|ing|s)?|shelve(?:d|s)?|shelving|drop(?:ped|ping|s)?|scrap(?:ped|ping|s)?)\b/i;
 
 export interface AbandonDecision {
   shouldPark: boolean;

--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -584,7 +584,9 @@ export async function postUnitPreVerification(pctx: PostUnitContext, opts?: PreV
             parkMilestone(s.basePath, s.currentMilestoneId, reason);
             ctx.ui.notify(`Milestone ${s.currentMilestoneId} parked: "${reason}"`, "info");
           }
-        } catch { /* non-fatal — override detection is best-effort */ }
+        } catch (err) {
+          process.stderr.write(`gsd: abandon-detect: ${(err as Error).message}\n`);
+        }
 
         await resolveAllOverrides(s.basePath);
         // Reset both disk and in-memory counters. Disk counter is authoritative

--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -585,7 +585,7 @@ export async function postUnitPreVerification(pctx: PostUnitContext, opts?: PreV
             ctx.ui.notify(`Milestone ${s.currentMilestoneId} parked: "${reason}"`, "info");
           }
         } catch (err) {
-          process.stderr.write(`gsd: abandon-detect: ${(err as Error).message}\n`);
+          logWarning("postUnit", `abandon-detect failed: ${(err as Error).message}`);
         }
 
         await resolveAllOverrides(s.basePath);

--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -569,6 +569,23 @@ export async function postUnitPreVerification(pctx: PostUnitContext, opts?: PreV
     // Rewrite-docs completion
     if (s.currentUnit.type === "rewrite-docs") {
       await runSafely("postUnit", "rewrite-docs-resolve", async () => {
+        // Detect abandon/descope overrides BEFORE resolving them (#3490).
+        // If an override is about abandoning the milestone, park it so the
+        // state engine skips it. Without this, rewrite-docs only edits
+        // markdown but the DB still has the milestone as active.
+        try {
+          const { loadActiveOverrides } = await import("./files.js");
+          const overrides = await loadActiveOverrides(s.basePath);
+          const abandonPattern = /\b(abandon|descope|cancel|shelve|drop|scrap)\b/i;
+          const abandonOverrides = overrides.filter(o => abandonPattern.test(o.change));
+          if (abandonOverrides.length > 0 && s.currentMilestoneId) {
+            const { parkMilestone } = await import("./milestone-actions.js");
+            const reason = abandonOverrides.map(o => o.change).join("; ");
+            parkMilestone(s.basePath, s.currentMilestoneId, reason);
+            ctx.ui.notify(`Milestone ${s.currentMilestoneId} parked: "${reason}"`, "info");
+          }
+        } catch { /* non-fatal — override detection is best-effort */ }
+
         await resolveAllOverrides(s.basePath);
         // Reset both disk and in-memory counters. Disk counter is authoritative
         // (survives restarts); in-memory is kept in sync for the current session.

--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -71,6 +71,7 @@ import { resolveUokFlags } from "./uok/flags.js";
 import { UokGateRunner } from "./uok/gate-runner.js";
 import { writeTurnGitTransaction } from "./uok/gitops.js";
 import { isClosedStatus } from "./status-guards.js";
+import { detectAbandonMilestone } from "./abandon-detect.js";
 
 /** Maximum verification retry attempts before escalating to blocker placeholder (#2653). */
 const MAX_VERIFICATION_RETRIES = 3;
@@ -576,13 +577,15 @@ export async function postUnitPreVerification(pctx: PostUnitContext, opts?: PreV
         try {
           const { loadActiveOverrides } = await import("./files.js");
           const overrides = await loadActiveOverrides(s.basePath);
-          const abandonPattern = /\b(abandon|descope|cancel|shelve|drop|scrap)\b/i;
-          const abandonOverrides = overrides.filter(o => abandonPattern.test(o.change));
-          if (abandonOverrides.length > 0 && s.currentMilestoneId) {
+          const decision = detectAbandonMilestone(overrides, s.currentMilestoneId);
+          if (decision.shouldPark && s.currentMilestoneId) {
             const { parkMilestone } = await import("./milestone-actions.js");
-            const reason = abandonOverrides.map(o => o.change).join("; ");
-            parkMilestone(s.basePath, s.currentMilestoneId, reason);
-            ctx.ui.notify(`Milestone ${s.currentMilestoneId} parked: "${reason}"`, "info");
+            const parked = parkMilestone(s.basePath, s.currentMilestoneId, decision.reason);
+            if (parked) {
+              ctx.ui.notify(`Milestone ${s.currentMilestoneId} parked: "${decision.reason}"`, "info");
+            } else {
+              logWarning("postUnit", `abandon detected for ${s.currentMilestoneId} but parkMilestone returned false (already parked, completed, or not found)`);
+            }
           }
         } catch (err) {
           logWarning("postUnit", `abandon-detect failed: ${(err as Error).message}`);

--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -584,11 +584,19 @@ export async function postUnitPreVerification(pctx: PostUnitContext, opts?: PreV
             if (parked) {
               ctx.ui.notify(`Milestone ${s.currentMilestoneId} parked: "${decision.reason}"`, "info");
             } else {
-              logWarning("postUnit", `abandon detected for ${s.currentMilestoneId} but parkMilestone returned false (already parked, completed, or not found)`);
+              // Park refused: milestone directory missing, milestone already
+              // completed (SUMMARY present), or PARKED.md already exists.
+              // resolveAllOverrides below will still consume the override —
+              // surface this loudly so the user notices state drift rather
+              // than silently losing the abandon directive.
+              const msg = `Abandon detected for ${s.currentMilestoneId} but park refused (milestone is completed, already parked, or missing). Override will be resolved anyway — verify state is correct.`;
+              logError("engine", msg);
+              ctx.ui.notify(msg, "warning");
             }
           }
         } catch (err) {
-          logWarning("postUnit", `abandon-detect failed: ${(err as Error).message}`);
+          logError("engine", `abandon-detect failed: ${(err as Error).message}`);
+          ctx.ui.notify(`Abandon detection failed — check logs. Overrides will still be resolved.`, "warning");
         }
 
         await resolveAllOverrides(s.basePath);

--- a/src/resources/extensions/gsd/tests/rewrite-docs-abandon-detect.test.ts
+++ b/src/resources/extensions/gsd/tests/rewrite-docs-abandon-detect.test.ts
@@ -1,20 +1,171 @@
 /**
- * Regression test for #3490: post-unit handler for rewrite-docs must
- * detect abandon/descope overrides and park the milestone.
+ * Regression tests for #3490: post-unit handler for rewrite-docs must
+ * detect abandon/descope overrides that target the current milestone and
+ * park it — without false-positive parking on unrelated scope-change
+ * overrides that merely contain an abandon-family verb.
+ *
+ * Exercises detectAbandonMilestone() directly — a pure function over
+ * Override objects, no I/O and no production-code import chain.
+ * parkMilestone() end-to-end behavior is covered by the existing
+ * park-milestone.test.ts / park-edge-cases.test.ts / park-db-sync.test.ts
+ * suites; here we only validate the decision layer that feeds it.
  */
-import { test } from "node:test";
+import { test, describe } from "node:test";
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
+import { detectAbandonMilestone } from "../abandon-detect.ts";
+import type { Override } from "../files.ts";
 
-test("rewrite-docs post-unit detects abandon overrides (#3490)", () => {
-  const src = readFileSync(
-    join(import.meta.dirname, "..", "auto-post-unit.ts"),
-    "utf-8",
-  );
-  // The fix adds abandon pattern detection before resolveAllOverrides
-  assert.ok(src.includes("abandonPattern") || src.includes("abandon|descope"),
-    "Post-unit handler must detect abandon-like override text");
-  assert.ok(src.includes("parkMilestone"),
-    "Post-unit handler must call parkMilestone for abandon overrides");
+function mkOverride(change: string): Override {
+  return {
+    timestamp: "2026-04-21T00:00:00.000Z",
+    change,
+    scope: "active",
+    appliedAt: "M001/S01/T01",
+  };
+}
+
+describe("detectAbandonMilestone (#3490)", () => {
+  test("parks on explicit abandon-milestone phrasing", () => {
+    const d = detectAbandonMilestone(
+      [mkOverride("abandon this milestone, it's no longer relevant")],
+      "M001",
+    );
+    assert.strictEqual(d.shouldPark, true);
+    assert.strictEqual(d.matched.length, 1);
+    assert.match(d.reason, /abandon this milestone/);
+  });
+
+  test("parks on descope-milestone phrasing", () => {
+    const d = detectAbandonMilestone(
+      [mkOverride("descope the entire milestone")],
+      "M001",
+    );
+    assert.strictEqual(d.shouldPark, true);
+  });
+
+  test("parks when override references milestone by ID instead of the word", () => {
+    const d = detectAbandonMilestone(
+      [mkOverride("shelve M003 for now, coming back next quarter")],
+      "M003",
+    );
+    assert.strictEqual(d.shouldPark, true);
+    assert.strictEqual(d.matched[0], "shelve M003 for now, coming back next quarter");
+  });
+
+  test("parks on past-tense / gerund verb forms (UK spelling)", () => {
+    const d = detectAbandonMilestone(
+      [mkOverride("this milestone was cancelled by product")],
+      "M001",
+    );
+    assert.strictEqual(d.shouldPark, true);
+  });
+
+  test("parks on US spelling 'canceled' (single-l)", () => {
+    const d = detectAbandonMilestone(
+      [mkOverride("the milestone was canceled by the PM")],
+      "M001",
+    );
+    assert.strictEqual(d.shouldPark, true);
+  });
+
+  // ─── False-positive guards ────────────────────────────────────────────
+
+  test("does NOT park on 'cancel the standup reminder' (no milestone ref)", () => {
+    const d = detectAbandonMilestone(
+      [mkOverride("cancel the daily standup reminder")],
+      "M001",
+    );
+    assert.strictEqual(d.shouldPark, false);
+    assert.deepStrictEqual(d.matched, []);
+  });
+
+  test("does NOT park on 'drop the dependency on X' (no milestone ref)", () => {
+    const d = detectAbandonMilestone(
+      [mkOverride("drop the dependency on X and use Y instead")],
+      "M001",
+    );
+    assert.strictEqual(d.shouldPark, false);
+  });
+
+  test("does NOT park on 'scrap the v1 design' (no milestone ref)", () => {
+    const d = detectAbandonMilestone(
+      [mkOverride("scrap the v1 design for the landing page")],
+      "M001",
+    );
+    assert.strictEqual(d.shouldPark, false);
+  });
+
+  test("does NOT park on override with milestone word but no abandon verb", () => {
+    const d = detectAbandonMilestone(
+      [mkOverride("change the milestone title to something clearer")],
+      "M001",
+    );
+    assert.strictEqual(d.shouldPark, false);
+  });
+
+  test("does NOT park when a different milestone ID is referenced", () => {
+    // The abandon verb is present and an MID is present, but the MID is
+    // not the current milestone. We require either the literal word
+    // "milestone" OR the current MID — a reference to a different MID
+    // (M007) with neither the word "milestone" nor the current ID (M001)
+    // should not trigger.
+    const d = detectAbandonMilestone(
+      [mkOverride("drop M007")],
+      "M001",
+    );
+    assert.strictEqual(d.shouldPark, false);
+  });
+
+  // ─── Edge cases ───────────────────────────────────────────────────────
+
+  test("empty overrides list returns no-park", () => {
+    const d = detectAbandonMilestone([], "M001");
+    assert.strictEqual(d.shouldPark, false);
+    assert.deepStrictEqual(d.matched, []);
+  });
+
+  test("null/undefined currentMilestoneId returns no-park even with matching text", () => {
+    const d1 = detectAbandonMilestone(
+      [mkOverride("abandon this milestone")],
+      null,
+    );
+    assert.strictEqual(d1.shouldPark, false);
+
+    const d2 = detectAbandonMilestone(
+      [mkOverride("abandon this milestone")],
+      undefined,
+    );
+    assert.strictEqual(d2.shouldPark, false);
+  });
+
+  test("multiple abandon overrides are concatenated in reason", () => {
+    const d = detectAbandonMilestone(
+      [
+        mkOverride("abandon this milestone"),
+        mkOverride("cancel the standup"),           // filtered out (no ref)
+        mkOverride("descope the milestone entirely"),
+      ],
+      "M001",
+    );
+    assert.strictEqual(d.shouldPark, true);
+    assert.strictEqual(d.matched.length, 2, "only the two milestone-scoped overrides match");
+    assert.match(d.reason, /abandon this milestone/);
+    assert.match(d.reason, /descope the milestone entirely/);
+    assert.doesNotMatch(d.reason, /cancel the standup/);
+  });
+
+  // ─── Regex-injection guard on milestone ID ────────────────────────────
+
+  test("milestone ID with regex metacharacters is escaped, not interpreted", () => {
+    // A pathological MID should not break the matcher — the function
+    // escapes regex metacharacters before building the pattern.
+    const d = detectAbandonMilestone(
+      [mkOverride("abandon M.01 the milestone")],
+      "M.01",
+    );
+    // 'milestone' is present, so this parks regardless of escaping,
+    // but the test confirms the RegExp construction does not throw.
+    assert.strictEqual(d.shouldPark, true);
+  });
 });
+

--- a/src/resources/extensions/gsd/tests/rewrite-docs-abandon-detect.test.ts
+++ b/src/resources/extensions/gsd/tests/rewrite-docs-abandon-detect.test.ts
@@ -1,0 +1,20 @@
+/**
+ * Regression test for #3490: post-unit handler for rewrite-docs must
+ * detect abandon/descope overrides and park the milestone.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+test("rewrite-docs post-unit detects abandon overrides (#3490)", () => {
+  const src = readFileSync(
+    join(import.meta.dirname, "..", "auto-post-unit.ts"),
+    "utf-8",
+  );
+  // The fix adds abandon pattern detection before resolveAllOverrides
+  assert.ok(src.includes("abandonPattern") || src.includes("abandon|descope"),
+    "Post-unit handler must detect abandon-like override text");
+  assert.ok(src.includes("parkMilestone"),
+    "Post-unit handler must call parkMilestone for abandon overrides");
+});

--- a/src/resources/extensions/gsd/tests/rewrite-docs-abandon-detect.test.ts
+++ b/src/resources/extensions/gsd/tests/rewrite-docs-abandon-detect.test.ts
@@ -68,6 +68,30 @@ describe("detectAbandonMilestone (#3490)", () => {
     assert.strictEqual(d.shouldPark, true);
   });
 
+  test("parks on hyphenated 'de-scope' variant", () => {
+    const d = detectAbandonMilestone(
+      [mkOverride("de-scope this milestone — moved to v2")],
+      "M001",
+    );
+    assert.strictEqual(d.shouldPark, true);
+  });
+
+  test("parks on space-separated 'de scope' variant", () => {
+    const d = detectAbandonMilestone(
+      [mkOverride("de scope the milestone entirely")],
+      "M001",
+    );
+    assert.strictEqual(d.shouldPark, true);
+  });
+
+  test("parks on 'de-scoped' past-tense hyphen variant", () => {
+    const d = detectAbandonMilestone(
+      [mkOverride("M003 was de-scoped last week")],
+      "M003",
+    );
+    assert.strictEqual(d.shouldPark, true);
+  });
+
   // ─── False-positive guards ────────────────────────────────────────────
 
   test("does NOT park on 'cancel the standup reminder' (no milestone ref)", () => {

--- a/src/resources/extensions/gsd/workflow-logger.ts
+++ b/src/resources/extensions/gsd/workflow-logger.ts
@@ -59,7 +59,8 @@ export type LogComponent =
   | "memory-ingest"     // Memory layer ingestion pipeline
   | "memory-backfill"   // ADR-013: decisions->memories backfill
   | "context-mode"     // Context-mode exec sandbox and compaction snapshot
-  | "preflight";       // Clean-root preflight gate at milestone completion
+  | "preflight"        // Clean-root preflight gate at milestone completion
+  | "postUnit";     // Post-unit processing (abandon detection, overrides)
 
 export interface LogEntry {
   ts: string;


### PR DESCRIPTION
## TL;DR
**What:** Auto-detect "abandon" overrides after rewrite-docs and park the milestone in the DB.
**Why:** Rewrite-docs only edits markdown — the DB still has the milestone as active, so auto-mode keeps dispatching it.
**How:** Pattern-match override text before resolving, call `parkMilestone()` if abandon intent detected.

## What
When a user writes an override like "abandon this milestone", rewrite-docs rewrites the markdown plans but never calls any DB mutation. The state engine reads from DB and still sees the milestone as active, causing auto-mode to keep dispatching work for the abandoned milestone.

The fix adds abandon detection in the post-unit handler, BEFORE overrides are resolved. If any active override matches abandon-like language (abandon, descope, cancel, shelve, drop, scrap), the milestone is parked via `parkMilestone()` which updates both the DB status and creates the PARKED.md marker file.

## Why
- Auto-mode cycles through summarizing→complete-slice for abandoned milestones (#3490)
- rewrite-docs is markdown-only but state derivation is DB-first
- No `gsd_park_milestone` tool exists for the LLM to call

## Change type
- [x] fix

## Test plan
- [ ] Write override "abandon this milestone" → run auto → verify milestone is parked after rewrite-docs
- [ ] Write override "change approach to X" (non-abandon) → verify milestone is NOT parked
- [ ] Verify `parkMilestone()` updates DB status to "parked" and creates PARKED.md

Closes #3490

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic milestone parking when override text contains abandon/descope language; UI notifies on success or warns on parking refusal.

* **Bug Fixes / Reliability**
  * Parking step isolated with error handling so override resolution continues if detection or parking fails.

* **Tests**
  * New unit tests covering abandon/descope phrasing variants, edge cases, and safety with special-character milestone IDs.

* **Style / Logging**
  * Workflow logging extended to include post-unit processing events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->