### PR TITLE
fix(gsd): replace hardcoded agent skill paths with dynamic resolution

### DIFF
--- a/src/resources/extensions/gsd/auto/detect-stuck.ts
+++ b/src/resources/extensions/gsd/auto/detect-stuck.ts
@@ -7,12 +7,21 @@
 import type { WindowEntry } from "./types.js";
 
 /**
+ * Pattern matching ENOENT errors with a file path.
+ * Matches: "ENOENT: no such file or directory, access '/path/to/file'"
+ * and similar Node.js filesystem error messages.
+ */
+const ENOENT_PATH_RE = /ENOENT[^']*'([^']+)'/;
+
+/**
  * Analyze a sliding window of recent unit dispatches for stuck patterns.
  * Returns a signal with reason if stuck, null otherwise.
  *
  * Rule 1: Same error string twice in a row → stuck immediately.
  * Rule 2: Same unit key 3+ consecutive times → stuck (preserves prior behavior).
  * Rule 3: Oscillation A→B→A→B in last 4 entries → stuck.
+ * Rule 4: Same ENOENT path in any 2 entries within the window → stuck (#3575).
+ *         Missing files don't self-heal between retries — retrying wastes budget.
  */
 export function detectStuck(
   window: readonly WindowEntry[],
@@ -54,6 +63,24 @@ export function detectStuck(
         reason: `Oscillation detected: ${w[0].key} ↔ ${w[1].key}`,
       };
     }
+  }
+
+  // Rule 4: Same ENOENT path seen twice in window (#3575)
+  // Missing files don't appear between retries — stop immediately.
+  const enoentPaths = new Map<string, number>();
+  for (const entry of window) {
+    if (!entry.error) continue;
+    const match = ENOENT_PATH_RE.exec(entry.error);
+    if (!match) continue;
+    const filePath = match[1];
+    const count = (enoentPaths.get(filePath) ?? 0) + 1;
+    if (count >= 2) {
+      return {
+        stuck: true,
+        reason: `Missing file referenced twice: ${filePath} (ENOENT)`,
+      };
+    }
+    enoentPaths.set(filePath, count);
   }
 
   return null;

--- a/src/resources/extensions/gsd/bootstrap/system-context.ts
+++ b/src/resources/extensions/gsd/bootstrap/system-context.ts
@@ -6,9 +6,10 @@ import type { ExtensionContext } from "@gsd/pi-coding-agent";
 
 import { logWarning } from "../workflow-logger.js";
 import { debugTime } from "../debug-logger.js";
-import { loadPrompt } from "../prompt-loader.js";
+import { loadPrompt, getTemplatesDir } from "../prompt-loader.js";
 import { readForensicsMarker } from "../forensics.js";
 import { resolveAllSkillReferences, renderPreferencesForSystemPrompt, loadEffectiveGSDPreferences } from "../preferences.js";
+import { resolveSkillReference } from "../preferences-skills.js";
 import { resolveGsdRootFile, resolveSliceFile, resolveSlicePath, resolveTaskFile, resolveTaskFiles, resolveTasksDir, relSliceFile, relSlicePath, relTaskFile } from "../paths.js";
 import { hasSkillSnapshot, detectNewSkills, formatSkillsXml } from "../skill-discovery.js";
 import { getActiveAutoWorktreeContext } from "../auto-worktree.js";
@@ -19,6 +20,31 @@ import { toPosixPath } from "../../shared/mod.js";
 import { markCmuxPromptShown, shouldPromptToEnableCmux } from "../../cmux/index.js";
 
 const gsdHome = process.env.GSD_HOME || join(homedir(), ".gsd");
+
+/**
+ * Bundled skill triggers — resolved dynamically at runtime instead of
+ * hardcoding absolute paths in the system prompt template. Only skills
+ * that actually exist on disk are included in the table. (#3575)
+ */
+const BUNDLED_SKILL_TRIGGERS: Array<{ trigger: string; skill: string }> = [
+  { trigger: "Frontend UI - web components, pages, landing pages, dashboards, React/HTML/CSS, styling", skill: "frontend-design" },
+  { trigger: "macOS or iOS apps - SwiftUI, Xcode, App Store", skill: "swiftui" },
+  { trigger: "Debugging - complex bugs, failing tests, root-cause investigation after standard approaches fail", skill: "debug-like-expert" },
+];
+
+function buildBundledSkillsTable(): string {
+  const cwd = process.cwd();
+  const rows: string[] = [];
+  for (const { trigger, skill } of BUNDLED_SKILL_TRIGGERS) {
+    const resolution = resolveSkillReference(skill, cwd);
+    if (resolution.method === "unresolved") continue; // skill not installed — omit from prompt
+    rows.push(`| ${trigger} | \`${resolution.resolvedPath}\` |`);
+  }
+  if (rows.length === 0) {
+    return "*No bundled skills found. Install skills to `~/.agents/skills/` or `~/.claude/skills/`.*";
+  }
+  return `| Trigger | Skill to load |\n|---|---|\n${rows.join("\n")}`;
+}
 
 function warnDeprecatedAgentInstructions(): void {
   const paths = [
@@ -43,7 +69,10 @@ export async function buildBeforeAgentStartResult(
   if (!existsSync(join(process.cwd(), ".gsd"))) return undefined;
 
   const stopContextTimer = debugTime("context-inject");
-  const systemContent = loadPrompt("system");
+  const systemContent = loadPrompt("system", {
+    bundledSkillsTable: buildBundledSkillsTable(),
+    templatesDir: getTemplatesDir(),
+  });
   const loadedPreferences = loadEffectiveGSDPreferences();
   if (shouldPromptToEnableCmux(loadedPreferences?.preferences)) {
     markCmuxPromptShown();

--- a/src/resources/extensions/gsd/prompt-loader.ts
+++ b/src/resources/extensions/gsd/prompt-loader.ts
@@ -51,6 +51,14 @@ const __extensionDir = resolveExtensionDir();
 const promptsDir = join(__extensionDir, "prompts");
 const templatesDir = join(__extensionDir, "templates");
 
+/**
+ * Return the resolved templates directory path for use in prompts.
+ * Avoids hardcoding `~/.gsd/agent/extensions/gsd/templates/` in templates. (#3575)
+ */
+export function getTemplatesDir(): string {
+  return templatesDir;
+}
+
 // Cache all templates eagerly at module load — a running session uses the
 // template versions that were on disk at startup, immune to later overwrites.
 const templateCache = new Map<string, string>();

--- a/src/resources/extensions/gsd/prompts/system.md
+++ b/src/resources/extensions/gsd/prompts/system.md
@@ -24,13 +24,9 @@ Leave the project in a state where the next agent can immediately understand wha
 
 ## Skills
 
-GSD ships with bundled skills. Load the relevant skill file with the `read` tool before starting work when the task matches.
+GSD ships with bundled skills. Load the relevant skill file with the `read` tool before starting work when the task matches. Use bare skill names — GSD resolves them to the correct path automatically.
 
-| Trigger | Skill to load |
-|---|---|
-| Frontend UI - web components, pages, landing pages, dashboards, React/HTML/CSS, styling | `~/.gsd/agent/skills/frontend-design/SKILL.md` |
-| macOS or iOS apps - SwiftUI, Xcode, App Store | `~/.gsd/agent/skills/swiftui/SKILL.md` |
-| Debugging - complex bugs, failing tests, root-cause investigation after standard approaches fail | `~/.gsd/agent/skills/debug-like-expert/SKILL.md` |
+{{bundledSkillsTable}}
 
 ## Hard Rules
 
@@ -119,7 +115,7 @@ In all modes, slices commit sequentially on the active branch; there are no per-
 ### Artifact Templates
 
 Templates showing the expected format for each artifact type are in:
-`~/.gsd/agent/extensions/gsd/templates/`
+`{{templatesDir}}`
 
 **Always read the relevant template before writing an artifact** to match the expected structure exactly. The parsers that read these files depend on specific formatting:
 

--- a/src/resources/extensions/gsd/tests/stuck-detection-coverage.test.ts
+++ b/src/resources/extensions/gsd/tests/stuck-detection-coverage.test.ts
@@ -123,6 +123,48 @@ test("Rule 3: A-A-A-A triggers Rule 2 not Rule 3", () => {
   );
 });
 
+// ─── Rule 4: ENOENT same path twice in window (#3575) ───────────────────────
+
+test("Rule 4: same ENOENT path in two entries triggers stuck", () => {
+  const result = detectStuck([
+    { key: "A", error: "ENOENT: no such file or directory, access '/home/user/.gsd/agent/skills/debug-like-expert/SKILL.md'" },
+    { key: "B" },
+    { key: "A", error: "ENOENT: no such file or directory, access '/home/user/.gsd/agent/skills/debug-like-expert/SKILL.md'" },
+  ]);
+  assert.notEqual(result, null);
+  assert.equal(result!.stuck, true);
+  assert.ok(result!.reason.includes("Missing file"), `reason was: ${result!.reason}`);
+  assert.ok(result!.reason.includes("ENOENT"), `reason was: ${result!.reason}`);
+});
+
+test("Rule 4: different ENOENT paths do not trigger stuck", () => {
+  const result = detectStuck([
+    { key: "A", error: "ENOENT: no such file or directory, access '/path/a'" },
+    { key: "B", error: "ENOENT: no such file or directory, access '/path/b'" },
+  ]);
+  assert.equal(result, null);
+});
+
+test("Rule 4: single ENOENT does not trigger stuck", () => {
+  const result = detectStuck([
+    { key: "A", error: "ENOENT: no such file or directory, access '/path/a'" },
+    { key: "B" },
+  ]);
+  assert.equal(result, null);
+});
+
+test("Rule 4: ENOENT paths non-consecutive still triggers", () => {
+  const result = detectStuck([
+    { key: "A", error: "ENOENT: no such file or directory, access '/missing/skill'" },
+    { key: "B" },
+    { key: "C" },
+    { key: "D", error: "ENOENT: no such file or directory, access '/missing/skill'" },
+  ]);
+  assert.notEqual(result, null);
+  assert.equal(result!.stuck, true);
+  assert.ok(result!.reason.includes("/missing/skill"), `reason was: ${result!.reason}`);
+});
+
 // ─── Gap documentation: 3-unit cycle evades detection ────────────────────────
 
 test("Three-unit cycle A-B-C-A-B-C does NOT trigger stuck (documents gap L13)", () => {


### PR DESCRIPTION
## TL;DR

**What:** Replace hardcoded `~/.gsd/agent/skills/` paths in the system prompt with dynamically resolved paths, and add ENOENT-specific stuck-loop detection.
**Why:** Hardcoded paths cause infinite auto-mode loops when skills aren't installed at the expected location (#3575).
**How:** Template variables resolved at runtime via `resolveSkillReference()`, plus a new Rule 4 in `detectStuck()` that catches repeated ENOENT on the same file path.

## What

Five files changed across the GSD extension:

- `prompts/system.md` — replaced 3 hardcoded skill paths and 1 hardcoded templates directory with `{{bundledSkillsTable}}` and `{{templatesDir}}` template variables
- `bootstrap/system-context.ts` — added `buildBundledSkillsTable()` which resolves each bundled skill via `resolveSkillReference()` at runtime; only skills that exist on disk appear in the prompt
- `prompt-loader.ts` — exported `getTemplatesDir()` so the templates path isn't hardcoded in the prompt
- `auto/detect-stuck.ts` — added Rule 4: same ENOENT file path seen twice in the sliding window triggers immediate stuck detection
- `tests/stuck-detection-coverage.test.ts` — 4 new tests for Rule 4

## Why

The system prompt template hardcoded three legacy skill paths (`~/.gsd/agent/skills/{frontend-design,swiftui,debug-like-expert}/SKILL.md`). When these files didn't exist (common on non-legacy installs), the agent would read the table, try to load the skill, get ENOENT, and the auto-mode loop would retry — ENOENT wasn't classified as an infrastructure error, so it was treated as transient. The unit would be re-dispatched repeatedly, wasting budget and blocking progress.

The skill resolution system (`preferences-skills.ts`) already handles dynamic path resolution across `~/.agents/skills/`, `~/.claude/skills/`, and legacy `~/.gsd/agent/skills/` — but the system prompt wasn't using it.

Closes #3575

## How

**Primary fix:** The system prompt now uses template variables instead of hardcoded paths. `buildBundledSkillsTable()` iterates the bundled skill definitions, calls `resolveSkillReference()` for each, and only includes skills that resolve to an existing file. If none are found, a helpful message directs users to install skills.

**Safety net:** Even with the primary fix, future template changes could re-introduce hardcoded paths. Rule 4 in `detectStuck()` catches the pattern at the loop level: if two entries in the sliding window contain ENOENT errors referencing the same file path, the loop stops immediately. Missing files don't self-heal between retries.

### Change type

- [x] `fix` — Bug fix
- [x] `test` — Adding tests

### AI disclosure

This PR was developed with AI assistance (Claude Code).