### PR TITLE
fix(provider-manager): handle Enter key to initiate provider auth setup

### DIFF
--- a/packages/pi-coding-agent/src/modes/interactive/components/provider-manager.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/components/provider-manager.ts
@@ -43,6 +43,7 @@ export class ProviderManagerComponent extends Container implements Focusable {
 	private modelsJsonWriter: ModelsJsonWriter;
 	private onDone: () => void;
 	private onDiscover: (provider: string) => void;
+	private onSetupAuth: (provider: string) => void;
 	private confirmingRemove = false;
 	private hintsContainer: Container;
 
@@ -52,6 +53,7 @@ export class ProviderManagerComponent extends Container implements Focusable {
 		modelRegistry: ModelRegistry,
 		onDone: () => void,
 		onDiscover: (provider: string) => void,
+		onSetupAuth: (provider: string) => void,
 	) {
 		super();
 
@@ -61,6 +63,7 @@ export class ProviderManagerComponent extends Container implements Focusable {
 		this.modelsJsonWriter = new ModelsJsonWriter(this.modelRegistry.modelsJsonPath);
 		this.onDone = onDone;
 		this.onDiscover = onDiscover;
+		this.onSetupAuth = onSetupAuth;
 
 		// Header
 		this.addChild(new Text(theme.fg("accent", "Provider Manager"), 0, 0));
@@ -125,6 +128,7 @@ export class ProviderManagerComponent extends Container implements Focusable {
 			this.hintsContainer.addChild(new Text(hints, 0, 0));
 		} else {
 			const hints = [
+				rawKeyHint("enter", "setup auth"),
 				rawKeyHint("d", "discover"),
 				rawKeyHint("r", "remove auth"),
 				rawKeyHint("esc", "close"),
@@ -172,6 +176,11 @@ export class ProviderManagerComponent extends Container implements Focusable {
 			this.selectedIndex = this.selectedIndex === this.providers.length - 1 ? 0 : this.selectedIndex + 1;
 			this.updateList();
 			this.tui.requestRender();
+		} else if (kb.matches(keyData, "selectConfirm")) {
+			const provider = this.providers[this.selectedIndex];
+			if (provider) {
+				this.onSetupAuth(provider.name);
+			}
 		} else if (kb.matches(keyData, "selectCancel")) {
 			if (this.confirmingRemove) {
 				this.confirmingRemove = false;

--- a/packages/pi-coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/interactive-mode.ts
@@ -3378,6 +3378,10 @@ export class InteractiveMode {
 					done();
 					this.ui.requestRender();
 				},
+				async (provider: string) => {
+					done();
+					await this.showLoginDialog(provider);
+				},
 			);
 			return { component, focus: component };
 		});

--- a/src/tests/provider-manager-auth.test.ts
+++ b/src/tests/provider-manager-auth.test.ts
@@ -1,0 +1,152 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const { ModelsJsonWriter } = await import("../../packages/pi-coding-agent/src/core/models-json-writer.ts");
+const { ProviderManagerComponent } = await import(
+  "../../packages/pi-coding-agent/src/modes/interactive/components/provider-manager.ts"
+);
+const { initTheme } = await import(
+  "../../packages/pi-coding-agent/src/modes/interactive/theme/theme.ts"
+);
+
+initTheme();
+
+function createTempModelsJsonPath(): string {
+  const dir = mkdtempSync(join(tmpdir(), "provider-manager-auth-test-"));
+  return join(dir, "models.json");
+}
+
+function createComponent(options: {
+  modelsJsonPath: string;
+  authProviders?: string[];
+  providers: Array<{ name: string; modelIds: string[] }>;
+  onSetupAuth?: (provider: string) => void;
+}) {
+  const writer = new ModelsJsonWriter(options.modelsJsonPath);
+  for (const provider of options.providers) {
+    writer.setProvider(provider.name, {
+      models: provider.modelIds.map((id: string) => ({ id })),
+    });
+  }
+  // Ensure models.json exists even when no providers are written
+  try {
+    readFileSync(options.modelsJsonPath, "utf-8");
+  } catch {
+    writeFileSync(options.modelsJsonPath, JSON.stringify({ providers: {} }), "utf-8");
+  }
+
+  const authProviders = new Set(options.authProviders ?? []);
+
+  const authStorage = {
+    hasAuth(provider: string) {
+      return authProviders.has(provider);
+    },
+    remove(provider: string) {
+      authProviders.delete(provider);
+    },
+  } as any;
+
+  const modelRegistry = {
+    modelsJsonPath: options.modelsJsonPath,
+    getAll() {
+      const config = JSON.parse(readFileSync(options.modelsJsonPath, "utf-8")) as {
+        providers?: Record<string, { models?: Array<{ id: string }> }>;
+      };
+      return Object.entries(config.providers ?? {}).flatMap(([provider, providerConfig]) =>
+        (providerConfig.models ?? []).map((model) => ({
+          id: model.id,
+          provider,
+        })),
+      );
+    },
+    refresh() {},
+  } as any;
+
+  const tui = {
+    requestRender() {},
+  } as any;
+
+  const setupAuthCalls: string[] = [];
+  const onSetupAuth = options.onSetupAuth ?? ((provider: string) => { setupAuthCalls.push(provider); });
+
+  const component = new ProviderManagerComponent(
+    tui,
+    authStorage,
+    modelRegistry,
+    () => {},
+    () => {},
+    onSetupAuth,
+  );
+
+  return { component, setupAuthCalls };
+}
+
+test("provider manager calls onSetupAuth with selected provider when Enter is pressed", (t) => {
+  const modelsJsonPath = createTempModelsJsonPath();
+  const rootDir = join(modelsJsonPath, "..");
+  t.after(() => rmSync(rootDir, { recursive: true, force: true }));
+
+  const { component, setupAuthCalls } = createComponent({
+    modelsJsonPath,
+    providers: [{ name: "zzz-custom-provider", modelIds: ["model-1"] }],
+  });
+
+  // Navigate to the last provider (zzz-custom-provider, sorted last)
+  const providers = (component as any).providers as Array<{ name: string }>;
+  const idx = providers.findIndex((p) => p.name === "zzz-custom-provider");
+  (component as any).selectedIndex = idx;
+
+  component.handleInput("\r");
+
+  assert.deepEqual(setupAuthCalls, ["zzz-custom-provider"]);
+});
+
+test("provider manager calls onSetupAuth for the currently selected provider", (t) => {
+  const modelsJsonPath = createTempModelsJsonPath();
+  const rootDir = join(modelsJsonPath, "..");
+  t.after(() => rmSync(rootDir, { recursive: true, force: true }));
+
+  const { component, setupAuthCalls } = createComponent({
+    modelsJsonPath,
+    providers: [
+      { name: "zzz-provider-a", modelIds: ["a-1"] },
+      { name: "zzz-provider-b", modelIds: ["b-1"] },
+    ],
+  });
+
+  // Select zzz-provider-b explicitly
+  const providers = (component as any).providers as Array<{ name: string }>;
+  const idx = providers.findIndex((p) => p.name === "zzz-provider-b");
+  (component as any).selectedIndex = idx;
+
+  component.handleInput("\r");
+
+  assert.deepEqual(setupAuthCalls, ["zzz-provider-b"]);
+});
+
+test("provider manager does not call onSetupAuth when Enter is pressed with no providers", (t) => {
+  const modelsJsonPath = createTempModelsJsonPath();
+  const rootDir = join(modelsJsonPath, "..");
+  t.after(() => rmSync(rootDir, { recursive: true, force: true }));
+
+  const setupAuthCalls: string[] = [];
+
+  // Create component with no custom providers — only discoverable providers may exist
+  // We override the provider list to be empty to test the guard condition
+  const { component } = createComponent({
+    modelsJsonPath,
+    providers: [],
+    onSetupAuth: (p) => { setupAuthCalls.push(p); },
+  });
+
+  // Force empty provider list to test guard
+  (component as any).providers = [];
+  (component as any).selectedIndex = 0;
+
+  component.handleInput("\r");
+
+  assert.deepEqual(setupAuthCalls, []);
+});

--- a/src/tests/provider-manager-remove.test.ts
+++ b/src/tests/provider-manager-remove.test.ts
@@ -77,7 +77,7 @@ function createComponent(options: {
     },
   } as any;
 
-  const component = new ProviderManagerComponent(tui, authStorage, modelRegistry, () => {}, () => {});
+  const component = new ProviderManagerComponent(tui, authStorage, modelRegistry, () => {}, () => {}, () => {});
   return {
     component,
     removedProviders,


### PR DESCRIPTION
## TL;DR

**What:** Pressing Enter in the `/provider` manager now triggers the auth setup flow for the selected provider.
**Why:** The Enter key had no effect — users could navigate the provider list but had no way to set up authentication from within the manager, making the `/provider` command nearly useless for its primary purpose.
**How:** Added an `onSetupAuth` callback parameter to `ProviderManagerComponent` and a `selectConfirm` (Enter) handler in `handleInput` that invokes it; wired the callback in `showProviderManager()` to route to the existing `showLoginDialog()` flow.

## What

Three files changed:

- **`packages/pi-coding-agent/src/modes/interactive/components/provider-manager.ts`**
  - Added `onSetupAuth: (provider: string) => void` private field and constructor parameter (6th arg)
  - Added `selectConfirm` (Enter key) branch in `handleInput()` that calls `onSetupAuth` with the selected provider, guarded by `provider` existence check
  - Added `enter: setup auth` to the normal-mode hints bar so users can discover the action

- **`packages/pi-coding-agent/src/modes/interactive/interactive-mode.ts`**
  - Passed the new `onSetupAuth` callback to `ProviderManagerComponent` in `showProviderManager()`
  - The callback closes the provider manager (`done()`) and then delegates to the existing `showLoginDialog(provider)` flow, reusing all existing auth UI and error handling

- **`src/tests/provider-manager-auth.test.ts`** *(new)*
  - Three regression tests covering: Enter triggers `onSetupAuth` for the selected provider, Enter triggers for a non-first provider after navigation, Enter is a no-op when the provider list is empty

- **`src/tests/provider-manager-remove.test.ts`**
  - Updated the `ProviderManagerComponent` constructor call to pass a no-op 6th argument (required by the new signature)

## Why

Fixes #3567. The `/provider` command displays the provider list and allows navigation (up/down arrows) and auth removal (`r` key), but pressing Enter had no effect. There was no `selectConfirm` handler in `handleInput()` and no mechanism to initiate the auth setup flow from the component.

Root cause: `ProviderManagerComponent` was designed with only two callbacks (`onDone`, `onDiscover`) and never had an `onSetupAuth` path wired in. The Enter key is handled in every comparable selector in the codebase (`session-selector.ts`, `model-selector.ts`, `oauth-selector.ts`, `extension-selector.ts`) via `kb.matches(keyData, "selectConfirm")` — the provider manager was the only one missing it.

## How

The fix follows the exact pattern used by every other selector component in the codebase:

1. `kb.matches(keyData, "selectConfirm")` — the standard keybinding check, consistent with `session-selector`, `model-selector`, etc.
2. Guard: `if (provider)` — same defensive check used throughout `handleInput()`
3. Callback delegation: the component stays unaware of the auth flow details; `interactive-mode.ts` owns the routing logic, delegating to `showLoginDialog()` which already handles both OAuth and API-key providers, error display, and focus restoration

The `onSetupAuth` callback is added as a 6th constructor argument rather than a method call or event to stay consistent with the existing `onDone` / `onDiscover` callback pattern already established in the component.

The hint bar update (`enter: setup auth` in normal mode) follows the same `rawKeyHint` pattern used for `d: discover`, `r: remove auth`, and `esc: close`.

## Change type

- [x] `fix` — Bug fix

## AI-assisted disclosure

This PR was produced with AI assistance (Claude Code). The root cause analysis, implementation, and regression tests were reviewed and verified before submission.