### PR TITLE
fix(ui): remove 200-column cap on welcome screen width

### DIFF
--- a/src/tests/welcome-screen.test.ts
+++ b/src/tests/welcome-screen.test.ts
@@ -83,3 +83,18 @@ test('omits remote channel when not provided', () => {
   assert.ok(!out.includes('Slack'), 'should not show Slack when no remote')
   assert.ok(!out.includes('Telegram'), 'should not show Telegram when no remote')
 })
+
+test('separator lines extend to full terminal width on wide terminals', (t) => {
+  const origColumns = process.stderr.columns
+  ;(process.stderr as any).columns = 250
+  t.after(() => { ;(process.stderr as any).columns = origColumns })
+
+  const out = strip(capture({ version: '1.0.0' }))
+  const lines = out.split('\n')
+  // Top and bottom separator bars should be 249 chars (columns - 1)
+  const separatorLines = lines.filter(l => /^─+$/.test(l.trim()))
+  assert.ok(separatorLines.length >= 2, 'expected at least 2 full-width separator lines')
+  for (const sep of separatorLines) {
+    assert.equal(sep.trim().length, 249, `separator should be 249 chars wide, got ${sep.trim().length}`)
+  }
+})

--- a/src/welcome-screen.ts
+++ b/src/welcome-screen.ts
@@ -54,7 +54,7 @@ export function printWelcomeScreen(opts: WelcomeScreenOptions): void {
   const { version, modelName, provider, remoteChannel } = opts
   const shortCwd = getShortCwd()
   const branch = getGitBranch()
-  const termWidth = Math.min((process.stderr.columns || 80) - 1, 200)
+  const termWidth = (process.stderr.columns || 80) - 1
 
   // Narrow terminal fallback
   if (termWidth < 70) {


### PR DESCRIPTION
## TL;DR

**What:** Remove the 200-column cap on the welcome screen width.
**Why:** On wide terminals, separator lines stop short of the right edge.
**How:** Remove `Math.min(..., 200)` from `termWidth` calculation.

## What

Single-line change in `src/welcome-screen.ts` — removes the `200` column cap from the `termWidth` calculation in `printWelcomeScreen()`.

## Why

The welcome screen's top/bottom bars and `├───` divider lines were capped at 200 columns. On terminals wider than 200 columns, the lines stop visibly short of the right edge while the terminal continues.

## How

Changed `Math.min((process.stderr.columns || 80) - 1, 200)` to `(process.stderr.columns || 80) - 1`, allowing the separator lines to extend to the full terminal width.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## AI disclosure

This PR was AI-assisted.