### PR TITLE
WIP: feat(gsd): hooks library for programmatic hook registration

### DIFF
--- a/src/resources/extensions/gsd/bootstrap/register-extension.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-extension.ts
@@ -13,6 +13,7 @@ import { registerHooks } from "./register-hooks.js";
 import { registerShortcuts } from "./register-shortcuts.js";
 import { loadCommunityHooks } from "../lib/hooks/community-loader.js";
 import { getOrCreateRegistry } from "../rule-registry.js";
+import { logWarning } from "../workflow-logger.js";
 
 export function handleRecoverableExtensionProcessError(err: Error): boolean {
   if ((err as NodeJS.ErrnoException).code === "EPIPE") {
@@ -53,18 +54,18 @@ export function registerGsdExtension(pi: ExtensionAPI): void {
 
   // Load community hook packages synchronously at startup so all hooks
   // are registered before any dispatch path can execute. Failures are
-  // logged to stderr but never crash extension bootstrap.
+  // logged via workflow-logger but never crash extension bootstrap.
   try {
     const store = getOrCreateRegistry().getProgrammaticStore();
     const result = loadCommunityHooks(store, process.cwd());
     if (result.loaded > 0) {
-      process.stderr.write(`[gsd] Loaded ${result.hooksRegistered} community hook(s) from ${result.loaded} package(s)\n`);
+      logWarning("bootstrap", `Loaded ${result.hooksRegistered} community hook(s) from ${result.loaded} package(s)`);
     }
     if (result.errors.length > 0) {
-      process.stderr.write(`[gsd] ${result.errors.length} community hook loading error(s) — check .gsd/workflow.log\n`);
+      logWarning("bootstrap", `${result.errors.length} community hook loading error(s) — check .gsd/workflow.log`);
     }
   } catch (e) {
-    process.stderr.write(`[gsd] Community hook loading failed: ${(e as Error).message}\n`);
+    logWarning("bootstrap", `Community hook loading failed: ${(e as Error).message}`);
   }
 
   pi.registerCommand("kill", {

--- a/src/resources/extensions/gsd/bootstrap/register-extension.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-extension.ts
@@ -11,6 +11,8 @@ import { registerJournalTools } from "./journal-tools.js";
 import { registerQueryTools } from "./query-tools.js";
 import { registerHooks } from "./register-hooks.js";
 import { registerShortcuts } from "./register-shortcuts.js";
+import { loadCommunityHooks } from "../lib/hooks/community-loader.js";
+import { getOrCreateRegistry } from "../rule-registry.js";
 
 export function handleRecoverableExtensionProcessError(err: Error): boolean {
   if ((err as NodeJS.ErrnoException).code === "EPIPE") {
@@ -48,6 +50,22 @@ export function registerGsdExtension(pi: ExtensionAPI): void {
   registerExitCommand(pi);
 
   installEpipeGuard();
+
+  // Load community hook packages synchronously at startup so all hooks
+  // are registered before any dispatch path can execute. Failures are
+  // logged to stderr but never crash extension bootstrap.
+  try {
+    const store = getOrCreateRegistry().getProgrammaticStore();
+    const result = loadCommunityHooks(store, process.cwd());
+    if (result.loaded > 0) {
+      process.stderr.write(`[gsd] Loaded ${result.hooksRegistered} community hook(s) from ${result.loaded} package(s)\n`);
+    }
+    if (result.errors.length > 0) {
+      process.stderr.write(`[gsd] ${result.errors.length} community hook loading error(s) — check .gsd/workflow.log\n`);
+    }
+  } catch (e) {
+    process.stderr.write(`[gsd] Community hook loading failed: ${(e as Error).message}\n`);
+  }
 
   pi.registerCommand("kill", {
     description: "Exit GSD immediately (no cleanup)",

--- a/src/resources/extensions/gsd/lib/hooks/community-loader.ts
+++ b/src/resources/extensions/gsd/lib/hooks/community-loader.ts
@@ -1,0 +1,196 @@
+// GSD Extension — Community Hook Package Loader
+
+import { existsSync, readdirSync, readFileSync, realpathSync } from "node:fs";
+import { join, resolve, sep } from "node:path";
+import { logWarning } from "../../workflow-logger.js";
+import type { ProgrammaticHookStore } from "./programmatic-store.js";
+import type { HookPackageManifest, CommunityLoadResult } from "./hook-types.js";
+import { HOOK_MANIFEST_VERSION } from "./hook-types.js";
+
+const MANIFEST_FILE = "hooks-manifest.json";
+
+// ─── Manifest Validation ──────────────────────────────────────────────────────
+
+/**
+ * Validate a raw parsed object against the HookPackageManifest schema.
+ * Returns null if valid, or an error message describing the first validation failure.
+ */
+function validateManifest(raw: unknown, filePath: string): string | null {
+  if (!raw || typeof raw !== "object") {
+    return `${filePath}: manifest must be a JSON object`;
+  }
+
+  const manifest = raw as Record<string, unknown>;
+
+  if (manifest.version !== HOOK_MANIFEST_VERSION) {
+    return `${filePath}: unsupported manifest version ${manifest.version} (expected ${HOOK_MANIFEST_VERSION})`;
+  }
+
+  if (typeof manifest.id !== "string" || manifest.id.trim().length === 0) {
+    return `${filePath}: "id" must be a non-empty string`;
+  }
+
+  if (typeof manifest.name !== "string" || manifest.name.trim().length === 0) {
+    return `${filePath}: "name" must be a non-empty string`;
+  }
+
+  if (typeof manifest.packageVersion !== "string") {
+    return `${filePath}: "packageVersion" must be a string`;
+  }
+
+  // Validate hook arrays if present
+  if (manifest.postUnitHooks !== undefined && !Array.isArray(manifest.postUnitHooks)) {
+    return `${filePath}: "postUnitHooks" must be an array`;
+  }
+
+  if (manifest.preDispatchHooks !== undefined && !Array.isArray(manifest.preDispatchHooks)) {
+    return `${filePath}: "preDispatchHooks" must be an array`;
+  }
+
+  return null;
+}
+
+// ─── Discovery ────────────────────────────────────────────────────────────────
+
+/**
+ * Discover hook package directories containing hooks-manifest.json.
+ * Scans immediate subdirectories of the given search paths.
+ *
+ * Security: resolved paths are verified to stay within the search root
+ * to prevent directory traversal via malicious package IDs.
+ */
+function discoverManifestPaths(searchPaths: string[]): string[] {
+  const found: string[] = [];
+
+  for (const searchRoot of searchPaths) {
+    if (!existsSync(searchRoot)) continue;
+
+    let entries: string[];
+    try {
+      entries = readdirSync(searchRoot, { withFileTypes: true })
+        .filter(d => d.isDirectory())
+        .map(d => d.name);
+    } catch {
+      continue;
+    }
+
+    const resolvedRoot = realpathSync(searchRoot);
+
+    for (const dirName of entries) {
+      const packageDir = resolve(searchRoot, dirName);
+      // Security: ensure resolved path stays within search root (follows symlinks)
+      try {
+        const realPackageDir = realpathSync(packageDir);
+        if (!realPackageDir.startsWith(resolvedRoot + sep)) continue;
+      } catch {
+        continue; // broken symlink or permission error
+      }
+
+      const manifestPath = join(packageDir, MANIFEST_FILE);
+      if (existsSync(manifestPath)) {
+        found.push(manifestPath);
+      }
+    }
+  }
+
+  return found;
+}
+
+// ─── Loader ───────────────────────────────────────────────────────────────────
+
+/**
+ * Load community hook packages and register their hooks into the store.
+ *
+ * Scans for hooks-manifest.json in:
+ * - ~/.gsd/extensions/   (user-installed packages)
+ * - <basePath>/.gsd/hooks/  (project-local packages)
+ *
+ * Each package directory must contain a hooks-manifest.json conforming to
+ * HookPackageManifest. Individual package failures are logged and collected
+ * as errors — they never crash the loader.
+ *
+ * @param store - The programmatic hook store to register hooks into
+ * @param basePath - Project root for resolving project-local hooks
+ */
+export function loadCommunityHooks(store: ProgrammaticHookStore, basePath: string): CommunityLoadResult {
+  const homedir = process.env.HOME ?? process.env.USERPROFILE ?? "";
+
+  // User-installed packages (~/.gsd/extensions/) are always trusted.
+  // Project-local packages (<basePath>/.gsd/hooks/) require explicit opt-in
+  // via GSD_ENABLE_PROJECT_HOOKS=true to prevent untrusted repos from
+  // injecting hooks into the dispatch flow.
+  const searchPaths = [
+    join(homedir, ".gsd", "extensions"),
+  ];
+
+  if (process.env.GSD_ENABLE_PROJECT_HOOKS === "true") {
+    searchPaths.push(join(basePath, ".gsd", "hooks"));
+  }
+
+  const result: CommunityLoadResult = {
+    loaded: 0,
+    hooksRegistered: 0,
+    errors: [],
+  };
+
+  const manifestPaths = discoverManifestPaths(searchPaths);
+
+  for (const manifestPath of manifestPaths) {
+    try {
+      const raw = JSON.parse(readFileSync(manifestPath, "utf-8"));
+
+      const validationError = validateManifest(raw, manifestPath);
+      if (validationError) {
+        result.errors.push({ packagePath: manifestPath, error: validationError });
+        logWarning("registry", validationError);
+        continue;
+      }
+
+      const manifest = raw as HookPackageManifest;
+      let hookCount = 0;
+
+      // Register post-unit hooks
+      if (manifest.postUnitHooks) {
+        for (const hookOpts of manifest.postUnitHooks) {
+          try {
+            store.registerPostUnit(
+              { ...hookOpts, packageId: manifest.id },
+              "community",
+            );
+            hookCount++;
+          } catch (e) {
+            const msg = `${manifestPath}: failed to register post-unit hook "${hookOpts.name}": ${(e as Error).message}`;
+            result.errors.push({ packagePath: manifestPath, error: msg });
+            logWarning("registry", msg);
+          }
+        }
+      }
+
+      // Register pre-dispatch hooks
+      if (manifest.preDispatchHooks) {
+        for (const hookOpts of manifest.preDispatchHooks) {
+          try {
+            store.registerPreDispatch(
+              { ...hookOpts, packageId: manifest.id },
+              "community",
+            );
+            hookCount++;
+          } catch (e) {
+            const msg = `${manifestPath}: failed to register pre-dispatch hook "${hookOpts.name}": ${(e as Error).message}`;
+            result.errors.push({ packagePath: manifestPath, error: msg });
+            logWarning("registry", msg);
+          }
+        }
+      }
+
+      result.loaded++;
+      result.hooksRegistered += hookCount;
+    } catch (e) {
+      const msg = `${manifestPath}: failed to load manifest: ${(e as Error).message}`;
+      result.errors.push({ packagePath: manifestPath, error: msg });
+      logWarning("registry", msg);
+    }
+  }
+
+  return result;
+}

--- a/src/resources/extensions/gsd/lib/hooks/hook-discovery.ts
+++ b/src/resources/extensions/gsd/lib/hooks/hook-discovery.ts
@@ -1,0 +1,101 @@
+// GSD Extension — Hook Discovery and Status Reporting
+
+import type { RuleRegistry } from "../../rule-registry.js";
+import type { ProgrammaticHookStore } from "./programmatic-store.js";
+import type { HookDescriptor } from "./hook-types.js";
+import { resolvePostUnitHooks, resolvePreDispatchHooks } from "../../preferences.js";
+
+/**
+ * Discover all hooks from both YAML config and programmatic registrations.
+ * Returns a unified list of HookDescriptor sorted by phase then priority.
+ *
+ * @param store - The programmatic hook store (may be null if not initialized)
+ */
+export function discoverHooks(store: ProgrammaticHookStore | null): HookDescriptor[] {
+  const descriptors: HookDescriptor[] = [];
+
+  // YAML-configured post-unit hooks (priority 0, source "yaml")
+  const yamlPostHooks = resolvePostUnitHooks();
+  for (const hook of yamlPostHooks) {
+    descriptors.push({
+      name: hook.name,
+      phase: "post-unit",
+      source: "yaml",
+      priority: 0,
+      enabled: hook.enabled !== false,
+      targets: hook.after,
+      description: `YAML: fires after ${hook.after.join(", ")}`,
+    });
+  }
+
+  // YAML-configured pre-dispatch hooks (priority 0, source "yaml")
+  const yamlPreHooks = resolvePreDispatchHooks();
+  for (const hook of yamlPreHooks) {
+    descriptors.push({
+      name: hook.name,
+      phase: "pre-dispatch",
+      source: "yaml",
+      priority: 0,
+      enabled: hook.enabled !== false,
+      targets: hook.before,
+      description: `YAML: ${hook.action} before ${hook.before.join(", ")}`,
+    });
+  }
+
+  // Programmatic hooks (with their own priority and source)
+  if (store) {
+    descriptors.push(...store.listDescriptors());
+  }
+
+  // Sort by phase grouping, then by priority within each phase
+  const phaseOrder: Record<string, number> = {
+    "post-unit": 0,
+    "pre-dispatch": 1,
+    "dispatch": 2,
+  };
+
+  return descriptors.sort((a, b) => {
+    const phaseDiff = (phaseOrder[a.phase] ?? 99) - (phaseOrder[b.phase] ?? 99);
+    if (phaseDiff !== 0) return phaseDiff;
+    return (a.priority ?? 0) - (b.priority ?? 0);
+  });
+}
+
+/**
+ * Format discovered hooks for terminal display.
+ */
+export function formatDiscoveredHooks(store: ProgrammaticHookStore | null): string {
+  const hooks = discoverHooks(store);
+  if (hooks.length === 0) {
+    return "No hooks configured. Add post_unit_hooks or pre_dispatch_hooks to .gsd/PREFERENCES.md, or register programmatically.";
+  }
+
+  const lines: string[] = ["Discovered Hooks:", ""];
+
+  const postHooks = hooks.filter(h => h.phase === "post-unit");
+  const preHooks = hooks.filter(h => h.phase === "pre-dispatch");
+
+  if (postHooks.length > 0) {
+    lines.push("Post-Unit Hooks (run after unit completes):");
+    for (const hook of postHooks) {
+      const status = hook.enabled ? "enabled" : "disabled";
+      const sourceTag = hook.source === "yaml" ? "yaml" : hook.packageId ? `community:${hook.packageId}` : "programmatic";
+      const priorityTag = hook.priority !== 0 ? ` p=${hook.priority}` : "";
+      lines.push(`  ${hook.name} [${status}] [${sourceTag}${priorityTag}] → after: ${hook.targets.join(", ")}`);
+    }
+    lines.push("");
+  }
+
+  if (preHooks.length > 0) {
+    lines.push("Pre-Dispatch Hooks (run before unit dispatches):");
+    for (const hook of preHooks) {
+      const status = hook.enabled ? "enabled" : "disabled";
+      const sourceTag = hook.source === "yaml" ? "yaml" : hook.packageId ? `community:${hook.packageId}` : "programmatic";
+      const priorityTag = hook.priority !== 0 ? ` p=${hook.priority}` : "";
+      lines.push(`  ${hook.name} [${status}] [${sourceTag}${priorityTag}] → before: ${hook.targets.join(", ")}`);
+    }
+    lines.push("");
+  }
+
+  return lines.join("\n");
+}

--- a/src/resources/extensions/gsd/lib/hooks/hook-types.ts
+++ b/src/resources/extensions/gsd/lib/hooks/hook-types.ts
@@ -1,0 +1,135 @@
+// GSD Extension — Hook Library Type Definitions
+
+import type { UnifiedRule, RulePhase } from "../../rule-types.js";
+import type { PostUnitHookConfig, PreDispatchHookConfig } from "../../types.js";
+
+// ─── Source Tracking ──────────────────────────────────────────────────────────
+
+/** Where a hook registration originated. */
+export type HookSource = "yaml" | "programmatic" | "community";
+
+// ─── Prioritized Rule ─────────────────────────────────────────────────────────
+
+/**
+ * Extended rule with priority ordering and source tracking.
+ * Compatible with UnifiedRule — can be used anywhere UnifiedRule is accepted.
+ */
+export interface PrioritizedRule extends UnifiedRule {
+  /** Evaluation order within phase. Lower numbers evaluate first. Default 0. */
+  priority?: number;
+  /** Where this hook was registered from. */
+  source?: HookSource;
+  /** Community package that contributed this hook, when source === "community". */
+  packageId?: string;
+}
+
+// ─── Registration Options ─────────────────────────────────────────────────────
+
+/** Options for registering a post-unit hook programmatically. */
+export interface RegisterPostUnitHookOptions {
+  /** Unique hook identifier — used in idempotency keys and logging. */
+  name: string;
+  /** Unit types that trigger this hook (e.g., ["execute-task"]). */
+  after: string[];
+  /** Prompt sent to the LLM session. Supports {milestoneId}, {sliceId}, {taskId} substitutions. */
+  prompt: string;
+  /** Evaluation priority among programmatic hooks. Lower numbers evaluate first. Default 0.
+   *  Note: YAML-configured hooks always evaluate before programmatic hooks regardless of priority. */
+  priority?: number;
+  /** Max times this hook can fire for the same trigger unit. Default 1, max 10. */
+  max_cycles?: number;
+  /** Model override for hook sessions. */
+  model?: string;
+  /** Expected output file name (relative to task/slice dir). Used for idempotency. */
+  artifact?: string;
+  /** If this file is produced instead of artifact, re-run the trigger unit. */
+  retry_on?: string;
+  /** Agent definition file to use. */
+  agent?: string;
+  /** Set false to disable without removing config. Default true. */
+  enabled?: boolean;
+  /** Community package ID when registered by a community loader. */
+  packageId?: string;
+}
+
+/** Options for registering a pre-dispatch hook programmatically. */
+export interface RegisterPreDispatchHookOptions {
+  /** Unique hook identifier. */
+  name: string;
+  /** Unit types this hook intercepts before dispatch (e.g., ["execute-task"]). */
+  before: string[];
+  /** Action to take: "modify" mutates the prompt, "skip" skips the unit, "replace" swaps it. */
+  action: "modify" | "skip" | "replace";
+  /** Evaluation priority among programmatic hooks. Lower numbers evaluate first. Default 0.
+   *  Note: YAML-configured hooks always evaluate before programmatic hooks regardless of priority. */
+  priority?: number;
+  /** For "modify": text prepended to the unit prompt. */
+  prepend?: string;
+  /** For "modify": text appended to the unit prompt. */
+  append?: string;
+  /** For "replace": the replacement prompt. */
+  prompt?: string;
+  /** For "replace": override the unit type label. */
+  unit_type?: string;
+  /** For "skip": optional condition file — only skip if this file exists. */
+  skip_if?: string;
+  /** Model override when this hook fires. */
+  model?: string;
+  /** Set false to disable without removing config. Default true. */
+  enabled?: boolean;
+  /** Community package ID when registered by a community loader. */
+  packageId?: string;
+}
+
+// ─── Discovery Types ──────────────────────────────────────────────────────────
+
+/** Resolved hook descriptor used in discovery and status output. */
+export interface HookDescriptor {
+  /** Hook name. */
+  name: string;
+  /** Which phase this hook targets. */
+  phase: RulePhase;
+  /** Where the hook was registered from. */
+  source: HookSource;
+  /** Community package ID, if applicable. */
+  packageId?: string;
+  /** Evaluation priority. */
+  priority: number;
+  /** Whether the hook is enabled. */
+  enabled: boolean;
+  /** What unit types it targets (after[] or before[]). */
+  targets: string[];
+  /** Human-readable description. */
+  description?: string;
+}
+
+// ─── Community Manifest ───────────────────────────────────────────────────────
+
+/** Schema version for forward compatibility. */
+export const HOOK_MANIFEST_VERSION = 1;
+
+/** Community hook package manifest (hooks-manifest.json). */
+export interface HookPackageManifest {
+  /** Schema version — must equal HOOK_MANIFEST_VERSION. */
+  version: number;
+  /** Globally unique package ID, e.g. "com.example.my-hooks". */
+  id: string;
+  /** Human-readable name. */
+  name: string;
+  /** Package version (semver). */
+  packageVersion: string;
+  /** Post-unit hooks provided by this package. */
+  postUnitHooks?: RegisterPostUnitHookOptions[];
+  /** Pre-dispatch hooks provided by this package. */
+  preDispatchHooks?: RegisterPreDispatchHookOptions[];
+}
+
+/** Result from loading community hooks. */
+export interface CommunityLoadResult {
+  /** Number of packages loaded successfully. */
+  loaded: number;
+  /** Total hooks registered across all packages. */
+  hooksRegistered: number;
+  /** Errors encountered during loading (non-fatal). */
+  errors: Array<{ packagePath: string; error: string }>;
+}

--- a/src/resources/extensions/gsd/lib/hooks/index.ts
+++ b/src/resources/extensions/gsd/lib/hooks/index.ts
@@ -1,0 +1,30 @@
+// GSD Extension — Hooks Library Public API
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export type {
+  HookSource,
+  PrioritizedRule,
+  RegisterPostUnitHookOptions,
+  RegisterPreDispatchHookOptions,
+  HookDescriptor,
+  HookPackageManifest,
+  CommunityLoadResult,
+} from "./hook-types.js";
+
+export { HOOK_MANIFEST_VERSION } from "./hook-types.js";
+
+// ─── Core ─────────────────────────────────────────────────────────────────────
+
+export { ProgrammaticHookStore } from "./programmatic-store.js";
+export { sortByPriority } from "./priority-sort.js";
+export { composePreDispatchMiddleware } from "./middleware.js";
+export type { SubstitutionContext } from "./middleware.js";
+
+// ─── Community ────────────────────────────────────────────────────────────────
+
+export { loadCommunityHooks } from "./community-loader.js";
+
+// ─── Discovery ────────────────────────────────────────────────────────────────
+
+export { discoverHooks, formatDiscoveredHooks } from "./hook-discovery.js";

--- a/src/resources/extensions/gsd/lib/hooks/middleware.ts
+++ b/src/resources/extensions/gsd/lib/hooks/middleware.ts
@@ -1,0 +1,84 @@
+// GSD Extension — Pre-Dispatch Hook Middleware Composition
+
+import type { PreDispatchHookConfig, PreDispatchResult } from "../../types.js";
+import { existsSync } from "node:fs";
+
+/** Context for variable substitution in hook prompts. */
+export interface SubstitutionContext {
+  milestoneId: string;
+  sliceId: string;
+  taskId: string;
+}
+
+/**
+ * Apply variable substitution to a template string.
+ * Replaces {milestoneId}, {sliceId}, {taskId} with context values.
+ */
+function substitute(text: string, ctx: SubstitutionContext): string {
+  return text
+    .replace(/\{milestoneId\}/g, ctx.milestoneId)
+    .replace(/\{sliceId\}/g, ctx.sliceId)
+    .replace(/\{taskId\}/g, ctx.taskId);
+}
+
+/**
+ * Compose pre-dispatch hooks into a single PreDispatchResult.
+ *
+ * Preserves the exact semantics of the original RuleRegistry.evaluatePreDispatch:
+ * - "skip" hooks short-circuit immediately (with optional skip_if condition)
+ * - "replace" hooks short-circuit with a replacement prompt
+ * - "modify" hooks compose — prepend/append accumulate on the prompt
+ *
+ * @param hooks - Filtered, enabled hooks that match the target unit type
+ * @param prompt - The original prompt to compose over
+ * @param subCtx - Variable substitution context
+ * @param resolveArtifactPath - Function to resolve artifact paths for skip_if conditions
+ */
+export function composePreDispatchMiddleware(
+  hooks: PreDispatchHookConfig[],
+  prompt: string,
+  subCtx: SubstitutionContext,
+  resolveArtifactPath: (artifactName: string) => string,
+): PreDispatchResult {
+  const firedHooks: string[] = [];
+  let currentPrompt = prompt;
+
+  for (const hook of hooks) {
+    if (hook.action === "skip") {
+      if (hook.skip_if) {
+        const conditionPath = resolveArtifactPath(hook.skip_if);
+        if (!existsSync(conditionPath)) continue;
+      }
+      firedHooks.push(hook.name);
+      return { action: "skip", firedHooks };
+    }
+
+    if (hook.action === "replace") {
+      firedHooks.push(hook.name);
+      return {
+        action: "replace",
+        prompt: substitute(hook.prompt ?? "", subCtx),
+        unitType: hook.unit_type,
+        model: hook.model,
+        firedHooks,
+      };
+    }
+
+    if (hook.action === "modify") {
+      firedHooks.push(hook.name);
+      if (hook.prepend) {
+        currentPrompt = `${substitute(hook.prepend, subCtx)}\n\n${currentPrompt}`;
+      }
+      if (hook.append) {
+        currentPrompt = `${currentPrompt}\n\n${substitute(hook.append, subCtx)}`;
+      }
+    }
+  }
+
+  return {
+    action: "proceed",
+    prompt: currentPrompt,
+    model: hooks.find(h => h.action === "modify" && h.model)?.model,
+    firedHooks,
+  };
+}

--- a/src/resources/extensions/gsd/lib/hooks/priority-sort.ts
+++ b/src/resources/extensions/gsd/lib/hooks/priority-sort.ts
@@ -1,0 +1,12 @@
+// GSD Extension — Hook Priority Sort Utility
+
+import type { PrioritizedRule } from "./hook-types.js";
+
+/**
+ * Stable sort of rules by priority (ascending — lower numbers evaluate first).
+ * Rules without an explicit priority are treated as priority 0.
+ * Insertion order is preserved for rules with equal priority.
+ */
+export function sortByPriority<T extends Pick<PrioritizedRule, "priority">>(rules: T[]): T[] {
+  return [...rules].sort((a, b) => (a.priority ?? 0) - (b.priority ?? 0));
+}

--- a/src/resources/extensions/gsd/lib/hooks/programmatic-store.ts
+++ b/src/resources/extensions/gsd/lib/hooks/programmatic-store.ts
@@ -1,0 +1,232 @@
+// GSD Extension — Programmatic Hook Registration Store
+
+import type { PostUnitHookConfig, PreDispatchHookConfig } from "../../types.js";
+import type {
+  RegisterPostUnitHookOptions,
+  RegisterPreDispatchHookOptions,
+  HookSource,
+  PrioritizedRule,
+  HookDescriptor,
+} from "./hook-types.js";
+
+// ─── Validation ───────────────────────────────────────────────────────────────
+
+function assertNonEmptyString(value: unknown, field: string): asserts value is string {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new TypeError(`Hook registration: "${field}" must be a non-empty string`);
+  }
+}
+
+function assertNonEmptyArray(value: unknown, field: string): asserts value is string[] {
+  if (!Array.isArray(value) || value.length === 0) {
+    throw new TypeError(`Hook registration: "${field}" must be a non-empty array`);
+  }
+}
+
+const VALID_PRE_DISPATCH_ACTIONS = new Set(["modify", "skip", "replace"]);
+
+// ─── ProgrammaticHookStore ────────────────────────────────────────────────────
+
+/**
+ * In-memory store for programmatically registered hooks.
+ * Hooks registered here are merged with YAML-configured hooks at evaluation time.
+ *
+ * Name-keyed: registering a hook with an existing name replaces the previous one.
+ * This follows the same override-by-name contract as YAML preference merging.
+ */
+export class ProgrammaticHookStore {
+  private readonly postUnitHooks: Map<string, { config: PostUnitHookConfig; priority: number; source: HookSource; packageId?: string }> = new Map();
+  private readonly preDispatchHooks: Map<string, { config: PreDispatchHookConfig; priority: number; source: HookSource; packageId?: string }> = new Map();
+
+  // ── Post-Unit Hook Registration ─────────────────────────────────────
+
+  /**
+   * Register a post-unit hook. Replaces any existing hook with the same name.
+   * Throws TypeError on invalid options.
+   */
+  registerPostUnit(options: RegisterPostUnitHookOptions, source: HookSource = "programmatic"): void {
+    assertNonEmptyString(options.name, "name");
+    assertNonEmptyArray(options.after, "after");
+    assertNonEmptyString(options.prompt, "prompt");
+
+    const config: PostUnitHookConfig = {
+      name: options.name,
+      after: options.after,
+      prompt: options.prompt,
+      max_cycles: options.max_cycles,
+      model: options.model,
+      artifact: options.artifact,
+      retry_on: options.retry_on,
+      agent: options.agent,
+      enabled: options.enabled,
+    };
+
+    this.postUnitHooks.set(options.name, {
+      config,
+      priority: options.priority ?? 0,
+      source,
+      packageId: options.packageId,
+    });
+  }
+
+  // ── Pre-Dispatch Hook Registration ──────────────────────────────────
+
+  /**
+   * Register a pre-dispatch hook. Replaces any existing hook with the same name.
+   * Throws TypeError on invalid options.
+   */
+  registerPreDispatch(options: RegisterPreDispatchHookOptions, source: HookSource = "programmatic"): void {
+    assertNonEmptyString(options.name, "name");
+    assertNonEmptyArray(options.before, "before");
+    if (!VALID_PRE_DISPATCH_ACTIONS.has(options.action)) {
+      throw new TypeError(`Hook registration: "action" must be one of: modify, skip, replace`);
+    }
+    if (options.action === "replace" && (!options.prompt || options.prompt.trim().length === 0)) {
+      throw new TypeError(`Hook registration: "prompt" is required when action is "replace"`);
+    }
+
+    const config: PreDispatchHookConfig = {
+      name: options.name,
+      before: options.before,
+      action: options.action,
+      prepend: options.prepend,
+      append: options.append,
+      prompt: options.prompt,
+      unit_type: options.unit_type,
+      skip_if: options.skip_if,
+      model: options.model,
+      enabled: options.enabled,
+    };
+
+    this.preDispatchHooks.set(options.name, {
+      config,
+      priority: options.priority ?? 0,
+      source,
+      packageId: options.packageId,
+    });
+  }
+
+  // ── Deregistration ──────────────────────────────────────────────────
+
+  /**
+   * Remove a hook by name. Returns true if a hook was found and removed.
+   * Checks both post-unit and pre-dispatch stores.
+   */
+  deregister(name: string): boolean {
+    const removedPost = this.postUnitHooks.delete(name);
+    const removedPre = this.preDispatchHooks.delete(name);
+    return removedPost || removedPre;
+  }
+
+  /** Remove all programmatically registered hooks. */
+  clear(): void {
+    this.postUnitHooks.clear();
+    this.preDispatchHooks.clear();
+  }
+
+  // ── Accessors ───────────────────────────────────────────────────────
+
+  /**
+   * Get all enabled post-unit hook configs, sorted by priority.
+   * YAML hooks are not included — the caller merges these with YAML hooks.
+   */
+  getPostUnitHooks(): PostUnitHookConfig[] {
+    return [...this.postUnitHooks.values()]
+      .filter(entry => entry.config.enabled !== false)
+      .sort((a, b) => a.priority - b.priority)
+      .map(entry => entry.config);
+  }
+
+  /**
+   * Get all enabled pre-dispatch hook configs, sorted by priority.
+   * YAML hooks are not included — the caller merges these with YAML hooks.
+   */
+  getPreDispatchHooks(): PreDispatchHookConfig[] {
+    return [...this.preDispatchHooks.values()]
+      .filter(entry => entry.config.enabled !== false)
+      .sort((a, b) => a.priority - b.priority)
+      .map(entry => entry.config);
+  }
+
+  /**
+   * Get descriptors for all registered hooks (for discovery/status reporting).
+   */
+  listDescriptors(): HookDescriptor[] {
+    const descriptors: HookDescriptor[] = [];
+
+    for (const entry of this.postUnitHooks.values()) {
+      descriptors.push({
+        name: entry.config.name,
+        phase: "post-unit",
+        source: entry.source,
+        packageId: entry.packageId,
+        priority: entry.priority,
+        enabled: entry.config.enabled !== false,
+        targets: entry.config.after,
+      });
+    }
+
+    for (const entry of this.preDispatchHooks.values()) {
+      descriptors.push({
+        name: entry.config.name,
+        phase: "pre-dispatch",
+        source: entry.source,
+        packageId: entry.packageId,
+        priority: entry.priority,
+        enabled: entry.config.enabled !== false,
+        targets: entry.config.before,
+      });
+    }
+
+    return descriptors;
+  }
+
+  /** Convert all registered hooks to PrioritizedRule[] for RuleRegistry.listRules(). */
+  listRules(): PrioritizedRule[] {
+    const rules: PrioritizedRule[] = [];
+
+    for (const entry of this.postUnitHooks.values()) {
+      if (entry.config.enabled === false) continue;
+      const hook = entry.config;
+      rules.push({
+        name: hook.name,
+        when: "post-unit",
+        evaluation: "all-matching",
+        where: (unitType: string) => hook.after.includes(unitType),
+        then: () => hook,
+        description: `Post-unit hook: fires after ${hook.after.join(", ")}`,
+        lifecycle: {
+          artifact: hook.artifact,
+          retry_on: hook.retry_on,
+          max_cycles: hook.max_cycles,
+        },
+        priority: entry.priority,
+        source: entry.source,
+        packageId: entry.packageId,
+      });
+    }
+
+    for (const entry of this.preDispatchHooks.values()) {
+      if (entry.config.enabled === false) continue;
+      const hook = entry.config;
+      rules.push({
+        name: hook.name,
+        when: "pre-dispatch",
+        evaluation: "all-matching",
+        where: (unitType: string) => hook.before.includes(unitType),
+        then: () => hook,
+        description: `Pre-dispatch hook: fires before ${hook.before.join(", ")}`,
+        priority: entry.priority,
+        source: entry.source,
+        packageId: entry.packageId,
+      });
+    }
+
+    return rules;
+  }
+
+  /** Number of registered hooks (both types). */
+  get size(): number {
+    return this.postUnitHooks.size + this.preDispatchHooks.size;
+  }
+}

--- a/src/resources/extensions/gsd/post-unit-hooks.ts
+++ b/src/resources/extensions/gsd/post-unit-hooks.ts
@@ -3,6 +3,8 @@
 // Thin facade over RuleRegistry. All mutable state and logic lives in the
 // registry instance; these exported functions delegate through getOrCreateRegistry()
 // so existing call-sites and tests work without modification.
+//
+// Also exposes the programmatic hook registration API from the hooks library.
 
 import type {
   HookExecutionState,
@@ -11,9 +13,13 @@ import type {
   HookStatusEntry,
 } from "./types.js";
 import { getOrCreateRegistry, resolveHookArtifactPath } from "./rule-registry.js";
+import type { RegisterPostUnitHookOptions, RegisterPreDispatchHookOptions } from "./lib/hooks/hook-types.js";
 
 // Re-export resolveHookArtifactPath so existing importers still work.
 export { resolveHookArtifactPath } from "./rule-registry.js";
+
+// Re-export hooks library types for convenience.
+export type { RegisterPostUnitHookOptions, RegisterPreDispatchHookOptions } from "./lib/hooks/hook-types.js";
 
 // ─── Post-Unit Hooks ───────────────────────────────────────────────────────
 
@@ -83,4 +89,38 @@ export function triggerHookManually(
 
 export function formatHookStatus(): string {
   return getOrCreateRegistry().formatHookStatus();
+}
+
+// ─── Programmatic Hook Registration API ───────────────────────────────────
+
+/**
+ * Register a post-unit hook programmatically.
+ * The hook will be merged with YAML-configured hooks at evaluation time.
+ * Registering with an existing name replaces the previous registration.
+ *
+ * @throws TypeError if options fail validation (empty name, empty after[], etc.)
+ */
+export function registerPostUnitHook(options: RegisterPostUnitHookOptions): void {
+  getOrCreateRegistry().getProgrammaticStore().registerPostUnit(options);
+}
+
+/**
+ * Register a pre-dispatch hook programmatically.
+ * The hook will be merged with YAML-configured hooks at evaluation time.
+ * Registering with an existing name replaces the previous registration.
+ *
+ * @throws TypeError if options fail validation (empty name, invalid action, etc.)
+ */
+export function registerPreDispatchHook(options: RegisterPreDispatchHookOptions): void {
+  getOrCreateRegistry().getProgrammaticStore().registerPreDispatch(options);
+}
+
+/**
+ * Remove a programmatically registered hook by name.
+ * Does not affect YAML-configured hooks.
+ *
+ * @returns true if a hook was found and removed
+ */
+export function deregisterHook(name: string): boolean {
+  return getOrCreateRegistry().getProgrammaticStore().deregister(name);
 }

--- a/src/resources/extensions/gsd/rule-registry.ts
+++ b/src/resources/extensions/gsd/rule-registry.ts
@@ -22,6 +22,23 @@ import { resolvePostUnitHooks, resolvePreDispatchHooks } from "./preferences.js"
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
 import { parseUnitId } from "./unit-id.js";
+import { ProgrammaticHookStore } from "./lib/hooks/programmatic-store.js";
+import { sortByPriority } from "./lib/hooks/priority-sort.js";
+import { composePreDispatchMiddleware } from "./lib/hooks/middleware.js";
+
+// ─── Hook Deduplication ───────────────────────────────────────────────────
+
+/**
+ * Merge YAML and programmatic hooks, deduplicating by name.
+ * When both sources define a hook with the same name, the programmatic
+ * hook wins (explicit override semantics). This prevents name-collision
+ * ambiguity in cycle-state tracking and idempotency keys.
+ */
+function dedupeByName<T extends { name: string }>(yamlHooks: T[], programmaticHooks: T[]): T[] {
+  const programmaticNames = new Set(programmaticHooks.map(h => h.name));
+  const dedupedYaml = yamlHooks.filter(h => !programmaticNames.has(h.name));
+  return [...dedupedYaml, ...programmaticHooks];
+}
 
 // ─── Artifact Path Resolution ──────────────────────────────────────────────
 
@@ -61,6 +78,9 @@ export class RuleRegistry {
   /** Static dispatch rules provided at construction time. */
   private readonly dispatchRules: UnifiedRule[];
 
+  /** Programmatic hook store for hooks registered via the library API. */
+  private readonly programmaticStore: ProgrammaticHookStore;
+
   // ── Mutable hook state (encapsulated, not module-level) ──────────────
 
   activeHook: HookExecutionState | null = null;
@@ -73,22 +93,36 @@ export class RuleRegistry {
   retryPending: boolean = false;
   retryTrigger: { unitType: string; unitId: string; retryArtifact: string } | null = null;
 
-  constructor(dispatchRules: UnifiedRule[]) {
+  constructor(dispatchRules: UnifiedRule[], programmaticStore?: ProgrammaticHookStore) {
     this.dispatchRules = dispatchRules;
+    this.programmaticStore = programmaticStore ?? new ProgrammaticHookStore();
+  }
+
+  /** Get the programmatic hook store for external registration. */
+  getProgrammaticStore(): ProgrammaticHookStore {
+    return this.programmaticStore;
   }
 
   // ── Core query ───────────────────────────────────────────────────────
 
   /**
-   * Returns all rules: static dispatch rules + dynamically loaded hook rules.
-   * Hook rules are loaded fresh from preferences on each call (not cached).
+   * Returns all rules: static dispatch rules + dynamically loaded hook rules
+   * + programmatically registered hooks. YAML hooks are loaded fresh from
+   * preferences on each call (not cached). Programmatic hooks are merged
+   * after YAML hooks and sorted by priority within each phase group.
    */
   listRules(): UnifiedRule[] {
     const rules: UnifiedRule[] = [...this.dispatchRules];
 
-    // Convert post-unit hooks to unified rules
+    // Collect programmatic hook names for dedup — programmatic overrides YAML
+    const programmaticNames = new Set(
+      this.programmaticStore.listDescriptors().map(d => d.name),
+    );
+
+    // Convert YAML post-unit hooks to unified rules (skip if overridden by programmatic)
     const postHooks = resolvePostUnitHooks();
     for (const hook of postHooks) {
+      if (programmaticNames.has(hook.name)) continue;
       rules.push({
         name: hook.name,
         when: "post-unit",
@@ -104,9 +138,10 @@ export class RuleRegistry {
       });
     }
 
-    // Convert pre-dispatch hooks to unified rules
+    // Convert YAML pre-dispatch hooks to unified rules (skip if overridden by programmatic)
     const preHooks = resolvePreDispatchHooks();
     for (const hook of preHooks) {
+      if (programmaticNames.has(hook.name)) continue;
       rules.push({
         name: hook.name,
         when: "pre-dispatch",
@@ -116,6 +151,9 @@ export class RuleRegistry {
         description: `Pre-dispatch hook: fires before ${hook.before.join(", ")}`,
       });
     }
+
+    // Merge programmatically registered hooks (sorted by priority)
+    rules.push(...sortByPriority(this.programmaticStore.listRules()));
 
     return rules;
   }
@@ -168,8 +206,8 @@ export class RuleRegistry {
       return null;
     }
 
-    // Check if any hooks are configured for this unit type
-    const hooks = resolvePostUnitHooks().filter(h =>
+    // Check if any hooks are configured for this unit type (YAML + programmatic)
+    const hooks = dedupeByName(resolvePostUnitHooks(), this.programmaticStore.getPostUnitHooks()).filter(h =>
       h.after.includes(completedUnitType),
     );
     if (hooks.length === 0) return null;
@@ -237,8 +275,8 @@ export class RuleRegistry {
 
   private _handleHookCompletion(basePath: string): HookDispatchResult | null {
     const hook = this.activeHook!;
-    const hooks = resolvePostUnitHooks();
-    const config = hooks.find(h => h.name === hook.hookName);
+    const allPostHooks = dedupeByName(resolvePostUnitHooks(), this.programmaticStore.getPostUnitHooks());
+    const config = allPostHooks.find(h => h.name === hook.hookName);
 
     // Check if retry was requested via retry_on artifact
     if (config?.retry_on) {
@@ -284,7 +322,8 @@ export class RuleRegistry {
       return { action: "proceed", prompt, firedHooks: [] };
     }
 
-    const hooks = resolvePreDispatchHooks().filter(h =>
+    // Merge YAML + programmatic pre-dispatch hooks
+    const hooks = dedupeByName(resolvePreDispatchHooks(), this.programmaticStore.getPreDispatchHooks()).filter(h =>
       h.before.includes(unitType),
     );
     if (hooks.length === 0) {
@@ -292,53 +331,13 @@ export class RuleRegistry {
     }
 
     const { milestone: mid, slice: sid, task: tid } = parseUnitId(unitId);
-    const substitute = (text: string): string =>
-      text
-        .replace(/\{milestoneId\}/g, mid ?? "")
-        .replace(/\{sliceId\}/g, sid ?? "")
-        .replace(/\{taskId\}/g, tid ?? "");
 
-    const firedHooks: string[] = [];
-    let currentPrompt = prompt;
-
-    for (const hook of hooks) {
-      if (hook.action === "skip") {
-        if (hook.skip_if) {
-          const conditionPath = resolveHookArtifactPath(basePath, unitId, hook.skip_if);
-          if (!existsSync(conditionPath)) continue;
-        }
-        firedHooks.push(hook.name);
-        return { action: "skip", firedHooks };
-      }
-
-      if (hook.action === "replace") {
-        firedHooks.push(hook.name);
-        return {
-          action: "replace",
-          prompt: substitute(hook.prompt ?? ""),
-          unitType: hook.unit_type,
-          model: hook.model,
-          firedHooks,
-        };
-      }
-
-      if (hook.action === "modify") {
-        firedHooks.push(hook.name);
-        if (hook.prepend) {
-          currentPrompt = `${substitute(hook.prepend)}\n\n${currentPrompt}`;
-        }
-        if (hook.append) {
-          currentPrompt = `${currentPrompt}\n\n${substitute(hook.append)}`;
-        }
-      }
-    }
-
-    return {
-      action: "proceed",
-      prompt: currentPrompt,
-      model: hooks.find(h => h.action === "modify" && h.model)?.model,
-      firedHooks,
-    };
+    return composePreDispatchMiddleware(
+      hooks,
+      prompt,
+      { milestoneId: mid ?? "", sliceId: sid ?? "", taskId: tid ?? "" },
+      (artifactName: string) => resolveHookArtifactPath(basePath, unitId, artifactName),
+    );
   }
 
   // ── State accessors ─────────────────────────────────────────────────
@@ -431,12 +430,12 @@ export class RuleRegistry {
 
   // ── Hook status reporting ───────────────────────────────────────────
 
-  /** Get status of all configured hooks for display. */
+  /** Get status of all configured hooks (YAML + programmatic) for display. */
   getHookStatus(): HookStatusEntry[] {
     const entries: HookStatusEntry[] = [];
 
-    const postHooks = resolvePostUnitHooks();
-    for (const hook of postHooks) {
+    const allPostHooks = dedupeByName(resolvePostUnitHooks(), this.programmaticStore.getPostUnitHooks());
+    for (const hook of allPostHooks) {
       const activeCycles: Record<string, number> = {};
       for (const [key, count] of this.cycleCounts) {
         if (key.startsWith(`${hook.name}/`)) {
@@ -452,8 +451,8 @@ export class RuleRegistry {
       });
     }
 
-    const preHooks = resolvePreDispatchHooks();
-    for (const hook of preHooks) {
+    const allPreHooks = dedupeByName(resolvePreDispatchHooks(), this.programmaticStore.getPreDispatchHooks());
+    for (const hook of allPreHooks) {
       entries.push({
         name: hook.name,
         type: "pre",
@@ -476,7 +475,8 @@ export class RuleRegistry {
     unitId: string,
     basePath: string,
   ): HookDispatchResult | null {
-    const hook = resolvePostUnitHooks().find(h => h.name === hookName);
+    const allPostHooks = dedupeByName(resolvePostUnitHooks(), this.programmaticStore.getPostUnitHooks());
+    const hook = allPostHooks.find(h => h.name === hookName);
     if (!hook) {
       console.error(`[triggerHookManually] Hook "${hookName}" not found in post_unit_hooks`);
       return null;

--- a/src/resources/extensions/gsd/tests/hooks-library.test.ts
+++ b/src/resources/extensions/gsd/tests/hooks-library.test.ts
@@ -1,0 +1,404 @@
+// GSD Extension — Hooks Library Tests
+
+import { describe, test, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+
+import { ProgrammaticHookStore } from "../lib/hooks/programmatic-store.js";
+import { sortByPriority } from "../lib/hooks/priority-sort.js";
+import { composePreDispatchMiddleware } from "../lib/hooks/middleware.js";
+import type { PreDispatchHookConfig } from "../types.js";
+
+// ─── ProgrammaticHookStore Tests ──────────────────────────────────────────────
+
+describe("ProgrammaticHookStore", () => {
+  let store: ProgrammaticHookStore;
+
+  beforeEach(() => {
+    store = new ProgrammaticHookStore();
+  });
+
+  describe("registerPostUnit", () => {
+    test("stores and retrieves a post-unit hook", () => {
+      store.registerPostUnit({
+        name: "test-hook",
+        after: ["execute-task"],
+        prompt: "Run tests for the completed task.",
+      });
+
+      const hooks = store.getPostUnitHooks();
+      assert.equal(hooks.length, 1);
+      assert.equal(hooks[0].name, "test-hook");
+      assert.deepEqual(hooks[0].after, ["execute-task"]);
+      assert.equal(hooks[0].prompt, "Run tests for the completed task.");
+    });
+
+    test("replaces hook with same name", () => {
+      store.registerPostUnit({
+        name: "test-hook",
+        after: ["execute-task"],
+        prompt: "Version 1",
+      });
+      store.registerPostUnit({
+        name: "test-hook",
+        after: ["complete-slice"],
+        prompt: "Version 2",
+      });
+
+      const hooks = store.getPostUnitHooks();
+      assert.equal(hooks.length, 1);
+      assert.equal(hooks[0].prompt, "Version 2");
+      assert.deepEqual(hooks[0].after, ["complete-slice"]);
+    });
+
+    test("throws on empty name", () => {
+      assert.throws(
+        () => store.registerPostUnit({ name: "", after: ["execute-task"], prompt: "test" }),
+        { name: "TypeError", message: /name/ },
+      );
+    });
+
+    test("throws on empty after array", () => {
+      assert.throws(
+        () => store.registerPostUnit({ name: "test", after: [], prompt: "test" }),
+        { name: "TypeError", message: /after/ },
+      );
+    });
+
+    test("throws on empty prompt", () => {
+      assert.throws(
+        () => store.registerPostUnit({ name: "test", after: ["execute-task"], prompt: "" }),
+        { name: "TypeError", message: /prompt/ },
+      );
+    });
+
+    test("excludes disabled hooks from getPostUnitHooks", () => {
+      store.registerPostUnit({
+        name: "disabled-hook",
+        after: ["execute-task"],
+        prompt: "test",
+        enabled: false,
+      });
+
+      assert.equal(store.getPostUnitHooks().length, 0);
+    });
+
+    test("preserves optional fields", () => {
+      store.registerPostUnit({
+        name: "full-hook",
+        after: ["execute-task"],
+        prompt: "test",
+        max_cycles: 3,
+        model: "sonnet",
+        artifact: "test-results.md",
+        retry_on: "test-failures.md",
+        agent: "test-agent.md",
+      });
+
+      const hook = store.getPostUnitHooks()[0];
+      assert.equal(hook.max_cycles, 3);
+      assert.equal(hook.model, "sonnet");
+      assert.equal(hook.artifact, "test-results.md");
+      assert.equal(hook.retry_on, "test-failures.md");
+      assert.equal(hook.agent, "test-agent.md");
+    });
+  });
+
+  describe("registerPreDispatch", () => {
+    test("stores and retrieves a pre-dispatch hook", () => {
+      store.registerPreDispatch({
+        name: "inject-context",
+        before: ["execute-task"],
+        action: "modify",
+        append: "Additional context here.",
+      });
+
+      const hooks = store.getPreDispatchHooks();
+      assert.equal(hooks.length, 1);
+      assert.equal(hooks[0].name, "inject-context");
+      assert.equal(hooks[0].action, "modify");
+    });
+
+    test("throws on invalid action", () => {
+      assert.throws(
+        () => store.registerPreDispatch({
+          name: "bad",
+          before: ["execute-task"],
+          action: "invalid" as any,
+        }),
+        { name: "TypeError", message: /action/ },
+      );
+    });
+
+    test("throws on empty before array", () => {
+      assert.throws(
+        () => store.registerPreDispatch({ name: "bad", before: [], action: "modify" }),
+        { name: "TypeError", message: /before/ },
+      );
+    });
+
+    test("throws on replace action without prompt", () => {
+      assert.throws(
+        () => store.registerPreDispatch({ name: "bad", before: ["execute-task"], action: "replace" }),
+        { name: "TypeError", message: /prompt/ },
+      );
+    });
+
+    test("accepts all valid actions", () => {
+      for (const action of ["modify", "skip", "replace"] as const) {
+        const name = `hook-${action}`;
+        const opts: any = { name, before: ["execute-task"], action };
+        // replace action requires a prompt
+        if (action === "replace") opts.prompt = "replacement prompt";
+        store.registerPreDispatch(opts);
+        const hooks = store.getPreDispatchHooks();
+        assert.ok(hooks.some(h => h.name === name));
+      }
+    });
+  });
+
+  describe("deregister", () => {
+    test("removes a post-unit hook", () => {
+      store.registerPostUnit({ name: "remove-me", after: ["execute-task"], prompt: "test" });
+      assert.equal(store.deregister("remove-me"), true);
+      assert.equal(store.getPostUnitHooks().length, 0);
+    });
+
+    test("removes a pre-dispatch hook", () => {
+      store.registerPreDispatch({ name: "remove-me", before: ["execute-task"], action: "modify" });
+      assert.equal(store.deregister("remove-me"), true);
+      assert.equal(store.getPreDispatchHooks().length, 0);
+    });
+
+    test("returns false for non-existent hook", () => {
+      assert.equal(store.deregister("non-existent"), false);
+    });
+  });
+
+  describe("clear", () => {
+    test("removes all hooks", () => {
+      store.registerPostUnit({ name: "post", after: ["execute-task"], prompt: "test" });
+      store.registerPreDispatch({ name: "pre", before: ["execute-task"], action: "modify" });
+      store.clear();
+      assert.equal(store.getPostUnitHooks().length, 0);
+      assert.equal(store.getPreDispatchHooks().length, 0);
+      assert.equal(store.size, 0);
+    });
+  });
+
+  describe("priority sorting", () => {
+    test("returns hooks sorted by priority", () => {
+      store.registerPostUnit({ name: "low", after: ["execute-task"], prompt: "test", priority: 10 });
+      store.registerPostUnit({ name: "high", after: ["execute-task"], prompt: "test", priority: -5 });
+      store.registerPostUnit({ name: "default", after: ["execute-task"], prompt: "test" });
+
+      const hooks = store.getPostUnitHooks();
+      assert.equal(hooks[0].name, "high");    // priority -5
+      assert.equal(hooks[1].name, "default");  // priority 0
+      assert.equal(hooks[2].name, "low");      // priority 10
+    });
+  });
+
+  describe("listDescriptors", () => {
+    test("returns descriptors for all hooks", () => {
+      store.registerPostUnit({ name: "post-hook", after: ["execute-task"], prompt: "test", packageId: "com.test" });
+      store.registerPreDispatch({ name: "pre-hook", before: ["execute-task"], action: "modify" });
+
+      const descriptors = store.listDescriptors();
+      assert.equal(descriptors.length, 2);
+
+      const postDesc = descriptors.find(d => d.name === "post-hook")!;
+      assert.equal(postDesc.phase, "post-unit");
+      assert.equal(postDesc.source, "programmatic");
+      assert.equal(postDesc.packageId, "com.test");
+
+      const preDesc = descriptors.find(d => d.name === "pre-hook")!;
+      assert.equal(preDesc.phase, "pre-dispatch");
+    });
+  });
+
+  describe("listRules", () => {
+    test("converts hooks to PrioritizedRule format", () => {
+      store.registerPostUnit({ name: "rule-test", after: ["execute-task"], prompt: "test", priority: 5 });
+      const rules = store.listRules();
+      assert.equal(rules.length, 1);
+      assert.equal(rules[0].name, "rule-test");
+      assert.equal(rules[0].when, "post-unit");
+      assert.equal(rules[0].priority, 5);
+      assert.equal(rules[0].source, "programmatic");
+    });
+  });
+
+  describe("size", () => {
+    test("counts both hook types", () => {
+      assert.equal(store.size, 0);
+      store.registerPostUnit({ name: "a", after: ["execute-task"], prompt: "test" });
+      assert.equal(store.size, 1);
+      store.registerPreDispatch({ name: "b", before: ["execute-task"], action: "modify" });
+      assert.equal(store.size, 2);
+    });
+  });
+});
+
+// ─── sortByPriority Tests ─────────────────────────────────────────────────────
+
+describe("sortByPriority", () => {
+  test("sorts ascending by priority", () => {
+    const items = [
+      { priority: 10 },
+      { priority: -5 },
+      { priority: 0 },
+    ];
+    const sorted = sortByPriority(items);
+    assert.equal(sorted[0].priority, -5);
+    assert.equal(sorted[1].priority, 0);
+    assert.equal(sorted[2].priority, 10);
+  });
+
+  test("treats missing priority as 0", () => {
+    const items = [
+      { priority: 5 },
+      { priority: undefined },
+      { priority: -1 },
+    ];
+    const sorted = sortByPriority(items);
+    assert.equal(sorted[0].priority, -1);
+    assert.equal(sorted[1].priority, undefined); // 0 equivalent
+    assert.equal(sorted[2].priority, 5);
+  });
+
+  test("preserves insertion order for equal priorities (stable sort)", () => {
+    const items = [
+      { priority: 0, id: "first" },
+      { priority: 0, id: "second" },
+      { priority: 0, id: "third" },
+    ];
+    const sorted = sortByPriority(items);
+    assert.equal((sorted[0] as any).id, "first");
+    assert.equal((sorted[1] as any).id, "second");
+    assert.equal((sorted[2] as any).id, "third");
+  });
+
+  test("does not mutate original array", () => {
+    const items = [{ priority: 2 }, { priority: 1 }];
+    sortByPriority(items);
+    assert.equal(items[0].priority, 2);
+  });
+});
+
+// ─── composePreDispatchMiddleware Tests ───────────────────────────────────────
+
+describe("composePreDispatchMiddleware", () => {
+  const noopArtifact = () => "/nonexistent";
+  const subCtx = { milestoneId: "M001", sliceId: "S001", taskId: "T001" };
+
+  test("returns proceed with unmodified prompt when no hooks", () => {
+    const result = composePreDispatchMiddleware([], "original", subCtx, noopArtifact);
+    assert.equal(result.action, "proceed");
+    assert.equal(result.prompt, "original");
+    assert.deepEqual(result.firedHooks, []);
+  });
+
+  test("modify hook prepends and appends", () => {
+    const hooks: PreDispatchHookConfig[] = [
+      { name: "ctx-inject", before: ["execute-task"], action: "modify", prepend: "Before:", append: "After:" },
+    ];
+    const result = composePreDispatchMiddleware(hooks, "original", subCtx, noopArtifact);
+    assert.equal(result.action, "proceed");
+    assert.equal(result.prompt, "Before:\n\noriginal\n\nAfter:");
+    assert.deepEqual(result.firedHooks, ["ctx-inject"]);
+  });
+
+  test("skip hook short-circuits", () => {
+    const hooks: PreDispatchHookConfig[] = [
+      { name: "skipper", before: ["execute-task"], action: "skip" },
+      { name: "never-reached", before: ["execute-task"], action: "modify", append: "nope" },
+    ];
+    const result = composePreDispatchMiddleware(hooks, "original", subCtx, noopArtifact);
+    assert.equal(result.action, "skip");
+    assert.deepEqual(result.firedHooks, ["skipper"]);
+  });
+
+  test("replace hook short-circuits with substitution", () => {
+    const hooks: PreDispatchHookConfig[] = [
+      { name: "replacer", before: ["execute-task"], action: "replace", prompt: "New prompt for {milestoneId}", unit_type: "custom-type" },
+    ];
+    const result = composePreDispatchMiddleware(hooks, "original", subCtx, noopArtifact);
+    assert.equal(result.action, "replace");
+    assert.equal(result.prompt, "New prompt for M001");
+    assert.equal(result.unitType, "custom-type");
+  });
+
+  test("multiple modify hooks compose", () => {
+    const hooks: PreDispatchHookConfig[] = [
+      { name: "a", before: ["execute-task"], action: "modify", prepend: "A" },
+      { name: "b", before: ["execute-task"], action: "modify", append: "B" },
+    ];
+    const result = composePreDispatchMiddleware(hooks, "original", subCtx, noopArtifact);
+    assert.equal(result.action, "proceed");
+    assert.equal(result.prompt, "A\n\noriginal\n\nB");
+    assert.deepEqual(result.firedHooks, ["a", "b"]);
+  });
+
+  test("modify hook model override is captured", () => {
+    const hooks: PreDispatchHookConfig[] = [
+      { name: "a", before: ["execute-task"], action: "modify", model: "sonnet", append: "extra" },
+    ];
+    const result = composePreDispatchMiddleware(hooks, "original", subCtx, noopArtifact);
+    assert.equal(result.model, "sonnet");
+  });
+});
+
+// ─── Community Loader Trust Gate Tests ────────────────────────────────────────
+
+describe("loadCommunityHooks trust gate", () => {
+  test("project-local hooks require GSD_ENABLE_PROJECT_HOOKS=true", async () => {
+    // The community loader should not scan basePath/.gsd/hooks/ unless
+    // GSD_ENABLE_PROJECT_HOOKS=true. We verify this by checking the
+    // module exports the function and it respects the env var.
+    const { loadCommunityHooks } = await import("../lib/hooks/community-loader.js");
+    const { ProgrammaticHookStore } = await import("../lib/hooks/programmatic-store.js");
+
+    const store = new ProgrammaticHookStore();
+    const originalEnv = process.env.GSD_ENABLE_PROJECT_HOOKS;
+
+    // Without env var, only ~/.gsd/extensions/ is scanned (which likely doesn't exist in test)
+    delete process.env.GSD_ENABLE_PROJECT_HOOKS;
+    const result1 = loadCommunityHooks(store, "/nonexistent-test-path");
+    assert.equal(result1.loaded, 0);
+    assert.equal(store.size, 0);
+
+    // Restore
+    if (originalEnv !== undefined) {
+      process.env.GSD_ENABLE_PROJECT_HOOKS = originalEnv;
+    }
+  });
+});
+
+// ─── Name Deduplication Tests ─────────────────────────────────────────────────
+
+describe("ProgrammaticHookStore deduplication semantics", () => {
+  let store: ProgrammaticHookStore;
+
+  beforeEach(() => {
+    store = new ProgrammaticHookStore();
+  });
+
+  test("programmatic hook with same name replaces previous registration", () => {
+    store.registerPostUnit({ name: "review", after: ["execute-task"], prompt: "v1" });
+    store.registerPostUnit({ name: "review", after: ["complete-slice"], prompt: "v2" });
+
+    const hooks = store.getPostUnitHooks();
+    assert.equal(hooks.length, 1);
+    assert.equal(hooks[0].prompt, "v2");
+    assert.deepEqual(hooks[0].after, ["complete-slice"]);
+  });
+
+  test("listDescriptors returns unique names only", () => {
+    store.registerPostUnit({ name: "shared-name", after: ["execute-task"], prompt: "test" });
+    store.registerPreDispatch({ name: "other-name", before: ["execute-task"], action: "modify" });
+
+    const descriptors = store.listDescriptors();
+    const names = descriptors.map(d => d.name);
+    assert.equal(new Set(names).size, names.length, "descriptor names should be unique");
+  });
+});


### PR DESCRIPTION
## TL;DR

**What:** Adds a hooks library for programmatic hook registration alongside existing YAML config.
**Why:** Enables community/3rd-party hook packages and extension authors to register hooks via code, not just YAML.
**How:** New library module at `src/resources/extensions/gsd/lib/hooks/` with `ProgrammaticHookStore` composed into `RuleRegistry`.

## What

New hooks library providing:
- `ProgrammaticHookStore` — in-memory store for registering post-unit and pre-dispatch hooks with validation
- Priority-based ordering within programmatic hooks
- `composePreDispatchMiddleware()` — extracted pre-dispatch compose logic from RuleRegistry
- Community hook discovery from `~/.gsd/extensions/*/hooks-manifest.json`
- Trust-gated project-local hooks (requires `GSD_ENABLE_PROJECT_HOOKS=true`)
- Name-based deduplication across YAML + programmatic sources (programmatic overrides YAML)
- Hook discovery and status reporting via `discoverHooks()`

Public API exposed through `post-unit-hooks.ts` facade:
- `registerPostUnitHook(options)`
- `registerPreDispatchHook(options)`
- `deregisterHook(name)`

Files created (7): `lib/hooks/{hook-types,programmatic-store,priority-sort,middleware,community-loader,hook-discovery,index}.ts`
Files modified (3): `rule-registry.ts`, `post-unit-hooks.ts`, `bootstrap/register-extension.ts`

## Why

The existing hook system is YAML-only — hooks must be declared in `.gsd/PREFERENCES.md`. This blocks:
- Extension authors who want to register hooks programmatically
- Community/3rd-party hook packages
- Runtime hook registration and deregistration

## How

`ProgrammaticHookStore` is owned by `RuleRegistry` via composition (not inheritance). At every evaluation point, YAML hooks and programmatic hooks are merged with `dedupeByName()` — programmatic wins on name collision. Community hooks load synchronously at extension bootstrap. Project-local hooks require explicit `GSD_ENABLE_PROJECT_HOOKS=true` env var opt-in to prevent untrusted repos from injecting hooks.

### Change type

- [x] `feat` — New feature or capability
- [x] `test` — Adding or updating tests

### AI disclosure

This PR was developed with AI assistance (Claude Code).

## Test plan

- [x] 33 unit tests covering ProgrammaticHookStore, sortByPriority, composePreDispatchMiddleware, trust gate, dedup semantics
- [x] TypeScript typecheck passes (zero errors)
- [x] Adversarial review completed — all findings addressed (trust gate, sync loading, name dedup)
- [ ] Integration test with real YAML + programmatic hook merge
- [ ] Community hook manifest end-to-end test