### PR TITLE
perf: remove redundant makeTreeWritable(agentDir) from initResources

### DIFF
--- a/src/resource-loader.ts
+++ b/src/resource-loader.ts
@@ -460,9 +460,12 @@ export function initResources(agentDir: string): void {
     try { copyFileSync(workflowSrc, join(agentDir, 'GSD-WORKFLOW.md')) } catch { /* non-fatal */ }
   }
 
-  // Ensure all newly copied files are owner-writable so the next run can
-  // overwrite them (covers extensions, agents, and skills in one walk).
-  makeTreeWritable(agentDir)
+  // makeTreeWritable is NOT called on agentDir here — syncResourceDir() already
+  // makes each destination writable before and after copying (pre-copy unlocks
+  // read-only Nix store copies, post-copy ensures next upgrade can overwrite).
+  // Calling it on the full agentDir would redundantly walk node_modules (33k+
+  // files via symlink), blobs, compile-cache, skills, and sessions — adding
+  // 60+ seconds to every boot that triggers a resource sync.
 
   writeManagedResourceManifest(agentDir)
   ensureRegistryEntries(join(agentDir, 'extensions'))

--- a/src/tests/resource-loader-maketreewritable.test.ts
+++ b/src/tests/resource-loader-maketreewritable.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Regression test: initResources must NOT call makeTreeWritable on the
+ * full agentDir — only the directories it actually syncs (extensions, agents).
+ *
+ * The bug: makeTreeWritable(agentDir) walks the entire ~/.gsd/agent/ tree,
+ * including node_modules (33k+ files via symlink), blobs, compile-cache, etc.
+ * This caused 60+ second boot hangs under memory pressure.
+ *
+ * The fix: syncResourceDir() already calls makeTreeWritable(destDir) before
+ * and after copying each target directory, so the standalone call on agentDir
+ * was redundant. It has been removed.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const resourceLoaderPath = join(import.meta.dirname, "..", "resource-loader.ts");
+
+test("initResources does not call makeTreeWritable on the full agentDir", () => {
+  const src = readFileSync(resourceLoaderPath, "utf-8");
+
+  // Extract the initResources function body
+  const fnStart = src.indexOf("export function initResources(");
+  assert.ok(fnStart > -1, "initResources must exist in resource-loader.ts");
+
+  // Find the closing brace (track brace depth)
+  let depth = 0;
+  let fnEnd = -1;
+  for (let i = src.indexOf("{", fnStart); i < src.length; i++) {
+    if (src[i] === "{") depth++;
+    if (src[i] === "}") depth--;
+    if (depth === 0) { fnEnd = i; break; }
+  }
+  assert.ok(fnEnd > fnStart, "initResources function body must be parseable");
+
+  const fnBody = src.slice(fnStart, fnEnd + 1);
+
+  // The redundant call was: makeTreeWritable(agentDir)
+  // It must NOT appear in the function body.
+  // syncResourceDir's internal calls (makeTreeWritable(destDir)) are fine —
+  // they're inside syncResourceDir, not in initResources.
+  const directCalls = fnBody.match(/makeTreeWritable\s*\(\s*agentDir\s*\)/g);
+  assert.equal(
+    directCalls,
+    null,
+    "initResources must NOT call makeTreeWritable(agentDir) — " +
+    "syncResourceDir already handles writability for each target directory. " +
+    "Calling it on agentDir walks node_modules (33k+ files), blobs, " +
+    "compile-cache, etc. and causes 60+ second boot hangs.",
+  );
+});
+
+test("syncResourceDir calls makeTreeWritable on its destDir argument", () => {
+  const src = readFileSync(resourceLoaderPath, "utf-8");
+
+  // Verify syncResourceDir has the pre-copy and post-copy makeTreeWritable calls
+  const fnStart = src.indexOf("function syncResourceDir(");
+  assert.ok(fnStart > -1, "syncResourceDir must exist");
+
+  let depth = 0;
+  let fnEnd = -1;
+  for (let i = src.indexOf("{", fnStart); i < src.length; i++) {
+    if (src[i] === "{") depth++;
+    if (src[i] === "}") depth--;
+    if (depth === 0) { fnEnd = i; break; }
+  }
+  const fnBody = src.slice(fnStart, fnEnd + 1);
+
+  const calls = fnBody.match(/makeTreeWritable\s*\(\s*destDir\s*\)/g);
+  assert.ok(
+    calls && calls.length >= 2,
+    "syncResourceDir must call makeTreeWritable(destDir) at least twice " +
+    "(pre-copy to unlock read-only files, post-copy to ensure next upgrade can overwrite)",
+  );
+});


### PR DESCRIPTION
## TL;DR

**What:** Remove the redundant `makeTreeWritable(agentDir)` call at the end of `initResources()`.
**Why:** It walks the entire `~/.gsd/agent/` directory including `node_modules` (33k+ files via symlink), `blobs`, `compile-cache`, and `skills` — adding 60+ seconds to every boot that triggers resource sync.
**How:** Delete the call; `syncResourceDir()` already calls `makeTreeWritable(destDir)` before and after copying each target directory.

## What

| File | Change |
|------|--------|
| `src/resource-loader.ts` | Remove `makeTreeWritable(agentDir)` from `initResources()`, add explanatory comment |

## Why

`initResources()` calls `syncResourceDir()` for `extensions/` and `agents/`. Each `syncResourceDir()` call already wraps its work with `makeTreeWritable(destDir)` — once before copying (to unlock read-only Nix store files, #1298) and once after (to ensure the next upgrade can overwrite).

The final `makeTreeWritable(agentDir)` was added by #1023 as a consolidation of 6 individual calls into 2 broader calls. However, the consolidation was too broad — `agentDir` contains:

- `node_modules` — symlink to the GSD package's `node_modules` (33,824 files). `makeTreeWritable` correctly skips the symlink itself (via the `lstatSync` check from #1303), but only at the top level. When `~/.gsd/agent/node_modules` is a real directory (e.g. after a botched sync or manual copy), all 33k files get `chmod`'d.
- `blobs/` — 200-300 content-addressed files
- `skills/` — 500+ files across installed skills
- `.compile-cache/` — V8 bytecode cache files
- `sessions/` — session state files

None of these directories are targets of `syncResourceDir()`, so making them writable is unnecessary. The recursive `stat` + `chmod` walk on ~34k files causes 60+ second boot hangs under memory pressure (when pages must be faulted in from the compressor for each syscall).

Related: #1023, #1303

## How

Remove the `makeTreeWritable(agentDir)` call and replace with a comment explaining why it's not needed. The two `syncResourceDir()` calls handle writability for their respective target directories.

## Test Evidence

- Boot time with the redundant call during resource sync: **60+ seconds** (process stuck in uninterruptible sleep walking 34k files)
- Boot time without it: **~5 seconds**
- Verified `syncResourceDir()` still makes `extensions/` and `agents/` writable via its internal `makeTreeWritable(destDir)` calls
- All existing tests pass (`npm run test:unit`)

---

> AI-assisted contribution — reviewed and tested by contributor.

- [x] `perf`