### PR TITLE
fix: restore tool set after discuss flow exits

### DIFF
--- a/src/resources/extensions/gsd/bootstrap/register-hooks.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-hooks.ts
@@ -9,7 +9,7 @@ import { handleAgentEnd } from "./agent-end-recovery.js";
 import { clearDiscussionFlowState, isDepthVerified, isQueuePhaseActive, markDepthVerified, resetWriteGateState, shouldBlockContextWrite, shouldBlockQueueExecution } from "./write-gate.js";
 import { isBlockedStateFile, isBashWriteToStateFile, BLOCKED_WRITE_ERROR } from "../write-intercept.js";
 import { cleanupQuickBranch } from "../quick.js";
-import { getDiscussionMilestoneId } from "../guided-flow.js";
+import { getDiscussionMilestoneId, restoreToolsAfterDiscuss } from "../guided-flow.js";
 import { loadToolApiKeys } from "../commands-config.js";
 import { loadFile, saveFile, formatContinue } from "../files.js";
 import { deriveState } from "../state.js";
@@ -93,6 +93,10 @@ export function registerHooks(pi: ExtensionAPI): void {
   pi.on("agent_end", async (event, ctx: ExtensionContext) => {
     resetToolCallLoopGuard();
     resetAskUserQuestionsCache();
+    // Restore the full tool set if a discuss-flow dispatch scoped it down.
+    // Must run before handleAgentEnd so that any follow-up dispatches
+    // (e.g. auto-start after discuss) have access to the complete tool set.
+    restoreToolsAfterDiscuss(pi);
     await handleAgentEnd(pi, event, ctx);
   });
 

--- a/src/resources/extensions/gsd/guided-flow.ts
+++ b/src/resources/extensions/gsd/guided-flow.ts
@@ -89,6 +89,25 @@ interface PendingAutoStartEntry {
 
 const pendingAutoStartMap = new Map<string, PendingAutoStartEntry>();
 
+// ── Discuss-flow tool scoping state ──────────────────────────────────────────
+// dispatchWorkflow strips non-allowlisted GSD tools for discuss flows (#2949).
+// We save the original tool set so it can be restored once the discuss turn
+// completes (agent_end hook). Without this, subsequent guided-flow dispatches
+// run with the reduced tool set — breaking plan/execute phases.
+let _savedToolsBeforeDiscuss: string[] | null = null;
+
+/**
+ * Restore the full tool set after a discuss-flow dispatch.
+ * Called from the agent_end hook. No-op when no discuss scoping is active.
+ */
+export function restoreToolsAfterDiscuss(pi: ExtensionAPI): void {
+  if (_savedToolsBeforeDiscuss) {
+    pi.setActiveTools(_savedToolsBeforeDiscuss);
+    debugLog("discuss-tool-restore", { restored: _savedToolsBeforeDiscuss.length });
+    _savedToolsBeforeDiscuss = null;
+  }
+}
+
 /**
  * Backward-compat bridge: returns a mutable reference to the entry matching
  * basePath, or the sole entry when only one session exists.
@@ -297,6 +316,10 @@ async function dispatchWorkflow(
   // planning/execution/completion tools to keep the grammar within limits.
   if (unitType?.startsWith("discuss-")) {
     const currentTools = pi.getActiveTools();
+    // Save the full tool set so agent_end can restore it after the discuss
+    // turn completes. Without this, subsequent dispatches (plan/execute)
+    // would run with the reduced discuss-only tool set.
+    _savedToolsBeforeDiscuss = currentTools;
     // Keep all non-GSD tools (builtins, other extensions) and only the
     // GSD tools on the discuss allowlist.
     const scopedTools = currentTools.filter(


### PR DESCRIPTION
## Summary

Fixes GSD tools being permanently disabled after exiting discuss flows.

- Save the active tool set before discuss-flow scoping in `dispatchWorkflow()`
- Restore the original tool set in the `agent_end` hook via `restoreToolsAfterDiscuss()`
- Ensures subsequent plan/execute/complete phases have access to all GSD tools

Fixes #3628

## Root Cause

`dispatchWorkflow()` calls `pi.setActiveTools(scopedTools)` for discuss flows but never restores the original tools. Since `setActiveTools()` permanently modifies the session's tool registry, all subsequent flows lose access to 20 of 30 GSD tools.

## Changes

- **`guided-flow.ts`**: Added `_savedToolsBeforeDiscuss` state and exported `restoreToolsAfterDiscuss(pi)` function
- **`register-hooks.ts`**: Call `restoreToolsAfterDiscuss(pi)` in `agent_end` hook before `handleAgentEnd()`

## Test plan

- [ ] Start GSD session, enter discuss-slice, exit → verify `gsd_complete_slice` is available
- [ ] Enter discuss-milestone, exit → verify all tools restored
- [ ] Verify discuss flow itself still has scoped tools (allowlist still applies during discuss)
- [ ] Verify error during discuss doesn't leave tools in scoped state