### PR TITLE
ci: fix branch detection in require-tests and use unified typecheck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,8 +136,8 @@ jobs:
       - name: Build web host
         run: npm run build:web-host
 
-      - name: Typecheck extensions
-        run: npm run typecheck:extensions
+      - name: Typecheck
+        run: npm run typecheck
 
       - name: Validate package is installable
         run: npm run validate-pack
@@ -177,8 +177,8 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Typecheck extensions
-        run: npm run typecheck:extensions
+      - name: Typecheck
+        run: npm run typecheck
 
       - name: Run unit tests
         run: npm run test:unit

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "sync-pkg-version": "node scripts/sync-pkg-version.cjs",
     "sync-platform-versions": "node native/scripts/sync-platform-versions.cjs",
     "validate-pack": "node scripts/validate-pack.js",
+    "typecheck": "tsc --noEmit && tsc --noEmit --project tsconfig.extensions.json",
     "typecheck:extensions": "tsc --noEmit --project tsconfig.extensions.json",
     "pipeline:version-stamp": "node scripts/version-stamp.mjs",
     "release:changelog": "node scripts/generate-changelog.mjs",

--- a/scripts/require-tests.sh
+++ b/scripts/require-tests.sh
@@ -19,7 +19,9 @@ fi
 FILES=$(git diff --name-only "$BASE" HEAD 2>/dev/null || git diff --name-only HEAD~1)
 
 # --- exempt branch types that don't need tests ---
-BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+# In CI pull_request events, HEAD is detached so git rev-parse returns "HEAD".
+# GITHUB_HEAD_REF contains the actual PR branch name.
+BRANCH="${GITHUB_HEAD_REF:-$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")}"
 if [[ "$BRANCH" =~ ^(docs|chore|ci)/ ]]; then
   echo "✓ Branch type '${BRANCH%%/*}/' is exempt from test requirements"
   exit 0


### PR DESCRIPTION
## TL;DR

**What:** Fix branch name detection in \`require-tests.sh\` and use unified \`npm run typecheck\` in CI.
**Why:** PR CI runs in detached HEAD, so \`git rev-parse --abbrev-ref HEAD\` returns \`HEAD\` instead of the branch name. The \`chore/\`/\`docs/\`/\`ci/\` exemption never fires.
**How:** Read \`GITHUB_HEAD_REF\` (set by GitHub Actions for PR events) with fallback to \`git rev-parse\`.

## What

**\`scripts/require-tests.sh\`:** Use \`GITHUB_HEAD_REF\` environment variable (set by GitHub Actions for \`pull_request\` events) to detect the PR branch name. Falls back to \`git rev-parse\` for local runs.

**\`.github/workflows/ci.yml\`:** Replace \`npm run typecheck:extensions\` with \`npm run typecheck\` in both \`build\` and \`windows-portability\` jobs. The unified command runs both root and extensions typechecks.

## Why

The \`require-tests.sh\` script exempts \`chore/\`, \`docs/\`, and \`ci/\` branches from the test requirement. But in CI, \`git rev-parse --abbrev-ref HEAD\` returns \`HEAD\` (detached) because GitHub Actions checks out the merge commit, not the branch. The exemption never fires, causing \`chore/\` PRs with source changes to fail lint even when they're explicitly exempt.

This PR is AI-assisted.

## Change type

- [x] \`ci\` — CI/CD configuration