### PR TITLE
test(gsd): cover note-capture executed stamping in triage resolution

### DIFF
--- a/src/resources/extensions/gsd/tests/triage-resolution.test.ts
+++ b/src/resources/extensions/gsd/tests/triage-resolution.test.ts
@@ -258,6 +258,55 @@ test("resolution: markCaptureExecuted is idempotent", () => {
   }
 });
 
+// ─── executeTriageResolutions + note execution (#3578) ──────────────────────
+
+test("resolution: executeTriageResolutions stamps note captures as executed", () => {
+  const tmp = makeTempDir("res-exec-note");
+  try {
+    const id = appendCapture(tmp, "FYI the API changed");
+    markCaptureResolved(tmp, id, "note", "acknowledged", "informational");
+
+    const result = executeTriageResolutions(tmp, "M001", "S01");
+
+    // The note should now be marked as executed
+    const all = loadAllCaptures(tmp);
+    assert.strictEqual(all.length, 1);
+    assert.strictEqual(all[0].executed, true, "note capture should be marked as executed");
+
+    // It should appear in the actions log
+    assert.ok(
+      result.actions.some(a => a.includes(id) && a.includes("Note acknowledged")),
+      "actions should include a note-acknowledged entry",
+    );
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("resolution: executeTriageResolutions does not double-stamp already-executed notes", () => {
+  const tmp = makeTempDir("res-exec-note-idem");
+  try {
+    const id = appendCapture(tmp, "informational note");
+    markCaptureResolved(tmp, id, "note", "acknowledged", "info");
+
+    // First execution — stamps the note
+    executeTriageResolutions(tmp, "M001", "S01");
+
+    // Second execution — should be a no-op for the note
+    const result2 = executeTriageResolutions(tmp, "M001", "S01");
+
+    assert.strictEqual(result2.actions.length, 0, "second call should produce no actions");
+
+    // Verify the Executed field was not duplicated in the file
+    const filePath = join(tmp, ".gsd", "CAPTURES.md");
+    const content = readFileSync(filePath, "utf-8");
+    const executedMatches = content.match(/\*\*Executed:\*\*/g);
+    assert.strictEqual(executedMatches?.length, 1, "should have exactly one Executed field");
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
 // ─── loadActionableCaptures ──────────────────────────────────────────────────
 
 test("resolution: loadActionableCaptures returns only unexecuted actionable captures", () => {
@@ -387,8 +436,7 @@ test("resolution: executeTriageResolutions handles mixed classifications", () =>
     assert.strictEqual(result.injected, 1, "should inject 1 task");
     assert.strictEqual(result.replanned, 0);
     assert.strictEqual(result.quickTasks.length, 1, "should queue 1 quick-task");
-    // inject + quick-task + note acknowledged = 3 actions (defer still excluded)
-    assert.strictEqual(result.actions.length, 3, "should have 3 action entries (defer excluded, note now included)");
+    assert.strictEqual(result.actions.length, 3, "should have 3 action entries (inject + quick-task + note acknowledged; defer excluded)");
   } finally {
     rmSync(tmp, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

**Test-only coverage** for #3578. The implementation fix already landed on main via PR #3555 (commit `e263ef0f`), which added the note-capture branch to `executeTriageResolutions` at `triage-resolution.ts:519-526`.

This PR was opened in parallel with #3555 and initially included a duplicate of the same implementation change. That duplicate was removed in commit `6104dff1` ("fix: remove duplicate note-capture block causing TS2451 redeclare error"), leaving this PR as regression-test coverage for the fix.

## What this PR adds

Two behavioral tests in `triage-resolution.test.ts`:

1. **`executeTriageResolutions stamps note captures as executed`** — creates a real note capture, runs resolution, and asserts:
   - `executed` is set to `true` on the capture
   - The actions log contains a `"Note acknowledged"` entry referencing the capture ID

2. **`executeTriageResolutions does not double-stamp already-executed notes`** — runs resolution twice and asserts:
   - The second call produces zero actions
   - The raw `CAPTURES.md` file contains exactly one `**Executed:**` field (regex match count), guarding against a class of double-stamp bugs a pure API test would miss

Plus an updated assertion message on the existing `mixed classifications` test to reflect the new expected action count.

## Verification that tests provide real coverage

The tests assert on the exact strings/behaviors introduced by the e263ef0f implementation:
- `"Note acknowledged"` in `actions[]` ← matches `result.actions.push(\`Note acknowledged: ${cap.id} — "${cap.text}"\`)` at line 525
- `executed === true` ← matches `markCaptureExecuted(basePath, cap.id)` at line 524
- Filtered to `classification === "note"` ← matches the filter at line 521

Without the e263ef0f diff, both new tests would fail: the note would never be stamped, `executed` would remain `false`, and `actions[]` would not contain any note-acknowledged entry.

## Test plan

- [x] `executeTriageResolutions stamps note captures as executed` passes on main (implementation present)
- [x] `executeTriageResolutions does not double-stamp already-executed notes` passes on main
- [x] Both tests would fail on the commit immediately before `e263ef0f` (confirmed by diff inspection — the note handler is the only change that makes them pass)
- [x] Existing `mixed classifications` test still passes with updated assertion message

References: #3578 (issue), #3555 (implementation PR, merged 2026-04-07), commit `e263ef0f`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added unit tests validating note capture acknowledgment and execution state management in triage workflows.
  * Enhanced test coverage to prevent duplicate note processing and updated assertion documentation for mixed classification scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->