### PR TITLE
fix(gsd): add disk-to-DB task reconciliation in deriveStateFromDb

### DIFF
--- a/src/resources/extensions/gsd/state.ts
+++ b/src/resources/extensions/gsd/state.ts
@@ -55,6 +55,7 @@ import {
   getSlice,
   insertMilestone,
   insertSlice,
+  insertTask,
   updateTaskStatus,
   getPendingSliceGateCount,
   type MilestoneRow,
@@ -737,6 +738,37 @@ export async function deriveStateFromDb(basePath: string): Promise<GSDState> {
 
   // ── Get tasks from DB ────────────────────────────────────────────────
   let tasks = getSliceTasks(activeMilestone.id, activeSlice.id);
+
+  // ── Disk→DB task reconciliation (#3592) ─────────────────────────────
+  // When the plan file exists on disk with task entries but the DB has no
+  // task rows, the LLM wrote plan files directly (e.g. gsd_plan_slice MCP
+  // tool unavailable) instead of persisting through the DB-backed tool.
+  // Parse the plan file and insert missing tasks so the state machine can
+  // advance instead of looping back to "planning" indefinitely.
+  // insertTask uses ON CONFLICT DO UPDATE, so existing rows are safe.
+  if (tasks.length === 0 && planFile) {
+    try {
+      const planContent = readFileSync(planFile, "utf-8");
+      const plan = parsePlan(planContent);
+      if (plan.tasks.length > 0) {
+        for (let i = 0; i < plan.tasks.length; i++) {
+          const t = plan.tasks[i];
+          insertTask({
+            id: t.id,
+            milestoneId: activeMilestone.id,
+            sliceId: activeSlice.id,
+            title: t.title || "",
+            status: t.done ? "complete" : "pending",
+            sequence: i,
+          });
+        }
+        tasks = getSliceTasks(activeMilestone.id, activeSlice.id);
+        logWarning("reconcile", `${plan.tasks.length} task(s) reconciled from disk plan file for ${activeMilestone.id}/${activeSlice.id} (#3592)`, { mid: activeMilestone.id, sid: activeSlice.id });
+      }
+    } catch (err) {
+      logWarning("reconcile", `task reconciliation from plan file failed: ${(err as Error).message}`, { mid: activeMilestone.id, sid: activeSlice.id });
+    }
+  }
 
   // ── Reconcile stale task status (#2514) ──────────────────────────────
   // When a session disconnects after the agent writes SUMMARY + VERIFY


### PR DESCRIPTION
## Summary

Fixes #3592

- **Root cause:** `deriveStateFromDb` had no disk-to-DB reconciliation for task *existence*. When `getSliceTasks()` returned empty but a valid plan file existed on disk (written directly by the LLM when MCP tools were unavailable), the function returned `phase: 'planning'`, triggering an infinite `plan-slice` re-dispatch loop that burned ~$3.50 and ~4M tokens per occurrence before the stuck detector fired.
- **Fix:** Added task reconciliation between the DB task fetch and the existing stale-status reconciliation (line ~739 in `state.ts`), following the same established pattern used for milestone (#2631) and slice (#2533) disk-to-DB reconciliation. When `tasks.length === 0` and a plan file exists, the code now parses the plan file with `parsePlan()`, inserts discovered tasks via `insertTask` (which uses `ON CONFLICT DO UPDATE`, so existing rows are safe), re-fetches tasks, and logs a warning for observability.
- **Scope:** Single file change (`src/resources/extensions/gsd/state.ts`) — added `insertTask` import and 31 lines of reconciliation logic.

## Test plan

- [ ] Verify `npx tsc --noEmit --project tsconfig.extensions.json` produces no new type errors (confirmed: all 8 errors are pre-existing and unrelated)
- [ ] Simulate the reproduction scenario: disable MCP server so `gsd_plan_slice` fails, let agent write plan files directly via `Write` tool, confirm `deriveStateFromDb` now reconciles tasks from disk and returns `phase: 'executing'` instead of looping on `phase: 'planning'`
- [ ] Verify existing `derive-state-db.test.ts` and `derive-state-db-disk-reconcile.test.ts` tests still pass
- [ ] Confirm `insertTask` ON CONFLICT behavior doesn't corrupt existing task rows when tasks already exist in DB
- [ ] Verify reconciliation warning appears in workflow logs for observability

🤖 Generated with [Claude Code](https://claude.com/claude-code)