### PR TITLE
fix(gsd): classify plain 'Connection error.' as transient for auto-mode retry

### DIFF
--- a/src/resources/extensions/gsd/error-classifier.ts
+++ b/src/resources/extensions/gsd/error-classifier.ts
@@ -47,7 +47,7 @@ const RATE_LIMIT_RE = /rate.?limit|too many requests|429/i;
 const NETWORK_RE = /network|ECONNRESET|ETIMEDOUT|ECONNREFUSED|socket hang up|fetch failed|connection.*reset|dns/i;
 const SERVER_RE = /internal server error|500|502|503|overloaded|server_error|api_error|service.?unavailable/i;
 // ECONNRESET/ECONNREFUSED are in NETWORK_RE (same-model retry first).
-const CONNECTION_RE = /terminated|connection.?refused|other side closed|EPIPE|network.?(?:is\s+)?unavailable|stream_exhausted(?:_without_result)?/i;
+const CONNECTION_RE = /terminated|connection.?(?:refused|error)|other side closed|EPIPE|network.?(?:is\s+)?unavailable|stream_exhausted(?:_without_result)?/i;
 // Catch-all for V8 JSON.parse errors: all modern variants end with "in JSON at position \d+".
 // This eliminates the need to enumerate every error message variant individually.
 const STREAM_RE = /in JSON at position \d+|Unexpected end of JSON|SyntaxError.*JSON/i;

--- a/src/resources/extensions/gsd/tests/provider-errors.test.ts
+++ b/src/resources/extensions/gsd/tests/provider-errors.test.ts
@@ -101,6 +101,13 @@ test("classifyError detects quota exceeded as permanent", () => {
   assert.ok(!isTransient(result));
 });
 
+test("classifyError treats plain 'Connection error.' as transient connection failure (#3594)", () => {
+  const result = classifyError("Connection error.");
+  assert.ok(isTransient(result));
+  assert.equal(result.kind, "connection");
+  assert.ok("retryAfterMs" in result && result.retryAfterMs === 15_000);
+});
+
 test("classifyError treats unknown error as not transient", () => {
   const result = classifyError("something went wrong");
   assert.ok(!isTransient(result));


### PR DESCRIPTION
## Summary
- Fixes #3594
- Adds `connection.?error` to the `CONNECTION_RE` regex in `error-classifier.ts` so plain "Connection error." messages are classified as transient connection errors instead of "unknown"
- Auto-mode now retries on this error instead of pausing indefinitely

## Changes
- `src/resources/extensions/gsd/error-classifier.ts`: Changed `connection.?refused` to `connection.?(?:refused|error)` in `CONNECTION_RE`
- `src/resources/extensions/gsd/tests/provider-errors.test.ts`: Added regression test for plain "Connection error." classification

## Test plan
- [x] New test passes: `classifyError("Connection error.")` returns `{ kind: "connection", retryAfterMs: 15000 }`
- [x] All 50 existing provider-errors tests still pass
- [x] No TypeScript errors in modified files
- [ ] Verify auto-mode retries on "Connection error." instead of pausing indefinitely

🤖 Generated with [Claude Code](https://claude.com/claude-code)