### PR TITLE
fix(gsd): remove legacy ~/.gsd/agent/skills path from system prompt

### DIFF
--- a/mintlify-docs/guides/skills.mdx
+++ b/mintlify-docs/guides/skills.mdx
@@ -7,7 +7,7 @@ Skills are specialized instruction sets that GSD loads when the task matches. Th
 
 ## Bundled skills
 
-GSD ships with these skills, installed to `~/.gsd/agent/skills/`:
+GSD ships with these skills, installed to `~/.agents/skills/`:
 
 | Skill | Trigger | Description |
 |-------|---------|-------------|
@@ -51,8 +51,8 @@ skill_rules:
 
 ### Resolution order
 
-1. **Bare name** — e.g., `frontend-design` → scans `~/.gsd/agent/skills/` and project skills
-2. **Absolute path** — e.g., `/Users/you/.gsd/agent/skills/my-skill/SKILL.md`
+1. **Bare name** — e.g., `frontend-design` → scans `~/.agents/skills/` and project skills
+2. **Absolute path** — e.g., `/Users/you/.agents/skills/my-skill/SKILL.md`
 3. **Directory path** — looks for `SKILL.md` inside
 
 User skills take precedence over project skills.
@@ -62,7 +62,7 @@ User skills take precedence over project skills.
 Create a directory with a `SKILL.md` file:
 
 ```
-~/.gsd/agent/skills/my-skill/
+~/.agents/skills/my-skill/
   SKILL.md           — instructions for the LLM
   references/        — optional reference files
 ```
@@ -70,7 +70,7 @@ Create a directory with a `SKILL.md` file:
 ### Project-local skills
 
 ```
-.gsd/agent/skills/my-project-skill/
+.agents/skills/my-project-skill/
   SKILL.md
 ```
 

--- a/src/resources/extensions/gsd/tests/stuck-detection-coverage.test.ts
+++ b/src/resources/extensions/gsd/tests/stuck-detection-coverage.test.ts
@@ -127,9 +127,9 @@ test("Rule 3: A-A-A-A triggers Rule 2 not Rule 3", () => {
 
 test("Rule 4: same ENOENT path in two entries triggers stuck", () => {
   const result = detectStuck([
-    { key: "A", error: "ENOENT: no such file or directory, access '/home/user/.gsd/agent/skills/debug-like-expert/SKILL.md'" },
+    { key: "A", error: "ENOENT: no such file or directory, access '/home/user/.agents/skills/debug-like-expert/SKILL.md'" },
     { key: "B" },
-    { key: "A", error: "ENOENT: no such file or directory, access '/home/user/.gsd/agent/skills/debug-like-expert/SKILL.md'" },
+    { key: "A", error: "ENOENT: no such file or directory, access '/home/user/.agents/skills/debug-like-expert/SKILL.md'" },
   ]);
   assert.notEqual(result, null);
   assert.equal(result!.stuck, true);

--- a/src/resources/skills/create-skill/SKILL.md
+++ b/src/resources/skills/create-skill/SKILL.md
@@ -86,8 +86,8 @@ Then proceed directly to the workflow.
 ## Skill Structure Quick Reference
 
 **Skill directories:**
-- Global: `~/.gsd/agent/skills/{skill-name}/`
-- Project-local: `.pi/agent/skills/{skill-name}/`
+- Global: `~/.agents/skills/{skill-name}/`
+- Project-local: `.agents/skills/{skill-name}/`
 
 **Simple skill (single file):**
 ```yaml

--- a/src/resources/skills/create-skill/references/gsd-skill-ecosystem.md
+++ b/src/resources/skills/create-skill/references/gsd-skill-ecosystem.md
@@ -5,13 +5,13 @@ GSD-specific skill ecosystem details: directory conventions, discovery mechanics
 <skill_directories>
 GSD supports two skill directories, checked in order:
 
-**User-scope (global):** `~/.gsd/agent/skills/`
+**User-scope (global):** `~/.agents/skills/`
 - Available in every GSD session regardless of working directory
-- Installed by default or by the user
+- Installed via [skills.sh](https://skills.sh) or manually
 
-**Project-scope (local):** `.pi/agent/skills/`
+**Project-scope (local):** `.agents/skills/`
 - Available only when GSD runs inside the project directory
-- The project-local directory uses `.pi` (inherited from the pi base), **not** `.gsd`
+- Committable to version control so team members share the same skill set
 - Ideal for project-specific workflows, deploy scripts, or conventions
 
 Skills in both directories follow the same SKILL.md format and router pattern conventions.

--- a/src/resources/skills/create-skill/workflows/audit-skill.md
+++ b/src/resources/skills/create-skill/workflows/audit-skill.md
@@ -16,22 +16,22 @@
 Enumerate skills from both directories:
 ```bash
 echo "=== Global skills ==="
-ls ~/.gsd/agent/skills/ 2>/dev/null || echo "(none)"
+ls ~/.agents/skills/ 2>/dev/null || echo "(none)"
 
 echo "=== Project-local skills ==="
-ls .pi/agent/skills/ 2>/dev/null || echo "(none)"
+ls .agents/skills/ 2>/dev/null || echo "(none)"
 ```
 
 Present as:
 ```
 Available skills:
 
-Global (~/.gsd/agent/skills/):
+Global (~/.agents/skills/):
 1. create-skill
 2. manage-stripe
 ...
 
-Project-local (.pi/agent/skills/):
+Project-local (.agents/skills/):
 3. project-deploy
 ...
 ```

--- a/src/resources/skills/create-skill/workflows/create-new-skill.md
+++ b/src/resources/skills/create-skill/workflows/create-new-skill.md
@@ -103,7 +103,7 @@ Use the scope selected in Step 1 to determine the base path:
 - **Project-local:** `.agents/skills/{skill-name}`
 
 ```bash
-BASE_PATH="{selected-base}/agent/skills/{skill-name}"
+BASE_PATH="{selected-base}/skills/{skill-name}"
 mkdir -p $BASE_PATH
 # If complex:
 mkdir -p $BASE_PATH/workflows

--- a/src/resources/skills/create-skill/workflows/create-new-skill.md
+++ b/src/resources/skills/create-skill/workflows/create-new-skill.md
@@ -15,8 +15,8 @@
 **Ask the user:**
 "Should this skill be global or project-local?"
 
-1. **Global** (`~/.gsd/agent/skills/`) — Available in all GSD sessions
-2. **Project-local** (`.pi/agent/skills/`) — Available only in this project
+1. **Global** (`~/.agents/skills/`) — Available in all GSD sessions
+2. **Project-local** (`.agents/skills/`) — Available only in this project
 
 ## Step 2: Adaptive Requirements Gathering
 
@@ -99,8 +99,8 @@ See references/recommended-structure.md for templates.
 ## Step 5: Create Directory
 
 Use the scope selected in Step 1 to determine the base path:
-- **Global:** `~/.gsd/agent/skills/{skill-name}`
-- **Project-local:** `.pi/agent/skills/{skill-name}`
+- **Global:** `~/.agents/skills/{skill-name}`
+- **Project-local:** `.agents/skills/{skill-name}`
 
 ```bash
 BASE_PATH="{selected-base}/agent/skills/{skill-name}"


### PR DESCRIPTION
## Summary
- Fixes #3573
- Replaces all user-facing references to the legacy `~/.gsd/agent/skills/` and `.pi/agent/skills/` paths with the current `~/.agents/skills/` and `.agents/skills/` ecosystem paths
- Updates bundled skill templates (create-skill SKILL.md, workflows, references), mintlify docs, and stuck-detection test fixtures
- Leaves migration-related comments in `resource-loader.ts`, `preferences-skills.ts`, and `skills.ts` intact since they document why the legacy fallback code exists

## Test plan
- [x] `npx tsc --noEmit --project tsconfig.extensions.json` passes (pre-existing errors unrelated to this change)
- [ ] Verify system prompt no longer references `~/.gsd/agent/skills`
- [ ] Confirm `~/.agents/skills/` is referenced correctly in skill templates and docs
- [ ] Verify stuck-detection test still passes with updated path fixtures

🤖 Generated with [Claude Code](https://claude.com/claude-code)