### PR TITLE
fix(gsd): reconcile stale slice rows and rebuild STATE.md before DB close

### DIFF
--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -703,7 +703,22 @@ export async function stopAuto(
       debugLog("stop-cleanup-worktree", { error: e instanceof Error ? e.message : String(e) });
     }
 
-    // ── Step 5: DB cleanup ──
+    // ── Step 5: Rebuild state while DB is still open (#3599) ──
+    // rebuildState() calls deriveState() which needs the DB for authoritative
+    // state. Previously this ran after closeDatabase(), forcing a filesystem
+    // fallback that could disagree with the DB-backed dispatch decisions —
+    // a split-brain where dispatch says "blocked" but STATE.md shows work.
+    if (s.basePath) {
+      try {
+        await rebuildState(s.basePath);
+      } catch (e) {
+        debugLog("stop-rebuild-state-failed", {
+          error: e instanceof Error ? e.message : String(e),
+        });
+      }
+    }
+
+    // ── Step 6: DB cleanup ──
     if (isDbAvailable()) {
       try {
         const { closeDatabase } = await import("./gsd-db.js");
@@ -715,7 +730,7 @@ export async function stopAuto(
       }
     }
 
-    // ── Step 6: Restore basePath and chdir ──
+    // ── Step 7: Restore basePath and chdir ──
     try {
       if (s.originalBasePath) {
         s.basePath = s.originalBasePath;
@@ -730,7 +745,7 @@ export async function stopAuto(
       debugLog("stop-cleanup-basepath", { error: e instanceof Error ? e.message : String(e) });
     }
 
-    // ── Step 7: Ledger notification ──
+    // ── Step 8: Ledger notification ──
     try {
       const ledger = getLedger();
       if (ledger && ledger.units.length > 0) {
@@ -744,17 +759,6 @@ export async function stopAuto(
       }
     } catch (e) {
       debugLog("stop-cleanup-ledger", { error: e instanceof Error ? e.message : String(e) });
-    }
-
-    // ── Step 8: Rebuild state ──
-    if (s.basePath) {
-      try {
-        await rebuildState(s.basePath);
-      } catch (e) {
-        debugLog("stop-rebuild-state-failed", {
-          error: e instanceof Error ? e.message : String(e),
-        });
-      }
     }
 
     // ── Step 9: Cmux sidebar / event log ──

--- a/src/resources/extensions/gsd/state.ts
+++ b/src/resources/extensions/gsd/state.ts
@@ -56,6 +56,7 @@ import {
   insertMilestone,
   insertSlice,
   insertTask,
+  updateSliceStatus,
   updateTaskStatus,
   getPendingSliceGateCount,
   type MilestoneRow,
@@ -365,6 +366,25 @@ export async function deriveStateFromDb(basePath: string): Promise<GSDState> {
         status: sliceStatus, risk: s.risk,
         depends: s.depends, demo: s.demo,
       });
+    }
+
+    // Reconcile stale *existing* slice rows (#3599): a slice row may exist in
+    // the DB with status "pending" even though disk artifacts (SUMMARY) prove
+    // completion — the same class of desync that task-level reconciliation
+    // (further below) already handles.  Without this, the dependency resolver
+    // builds doneSliceIds from stale DB rows and downstream slices stay blocked
+    // forever with "No slice eligible".
+    for (const dbSlice of dbSlices) {
+      if (isStatusDone(dbSlice.status)) continue;
+      const summaryPath = resolveSliceFile(basePath, mid, dbSlice.id, "SUMMARY");
+      if (summaryPath) {
+        try {
+          updateSliceStatus(mid, dbSlice.id, "complete");
+          logWarning("reconcile", `slice ${mid}/${dbSlice.id} status reconciled from "${dbSlice.status}" to "complete" (#3599)`, { mid, sid: dbSlice.id });
+        } catch (e) {
+          logError("reconcile", `failed to update slice ${dbSlice.id}`, { sid: dbSlice.id, error: (e as Error).message });
+        }
+      }
     }
   }
 

--- a/src/resources/extensions/gsd/tests/stale-slice-rows.test.ts
+++ b/src/resources/extensions/gsd/tests/stale-slice-rows.test.ts
@@ -1,0 +1,41 @@
+/**
+ * stale-slice-rows.test.ts — #3658
+ *
+ * Verify that state.ts contains slice-level status reconciliation that
+ * updates stale DB rows (status "pending") when disk artifacts (SUMMARY)
+ * prove the slice is complete. Without this, the dependency resolver builds
+ * doneSliceIds from stale DB rows and downstream slices stay blocked.
+ */
+
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const sourceFile = join(__dirname, "..", "state.ts");
+
+describe("stale slice row reconciliation (#3658)", () => {
+  const source = readFileSync(sourceFile, "utf-8");
+
+  test("imports updateSliceStatus from gsd-db", () => {
+    assert.match(source, /import\s*\{[^}]*updateSliceStatus[^}]*\}\s*from/);
+  });
+
+  test("checks isStatusDone before reconciling slice rows", () => {
+    assert.match(source, /isStatusDone\(dbSlice\.status\)/);
+  });
+
+  test("resolves SUMMARY file to detect completed slices on disk", () => {
+    assert.match(source, /resolveSliceFile\(basePath,\s*mid,\s*dbSlice\.id,\s*["']SUMMARY["']\)/);
+  });
+
+  test("calls updateSliceStatus to reconcile stale rows", () => {
+    assert.match(source, /updateSliceStatus\(mid,\s*dbSlice\.id,\s*["']complete["']\)/);
+  });
+
+  test("references issue #3599 in reconciliation comment", () => {
+    assert.match(source, /#3599/);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #3599 — auto-mode split-brain where stale slice rows false-block dispatch, then stopAuto rewrites STATE.md from filesystem fallback.

- **Stale slice reconciliation**: `deriveStateFromDb()` already reconciled *missing* slice rows (insert) and *stale task* rows (update), but never repaired *existing stale slice* rows. A slice marked `pending` in the DB despite having a SUMMARY file on disk would permanently block downstream slices via `doneSliceIds`. Added slice-level stale-status reconciliation matching the existing task-level pattern (#2514).
- **Stop-time split-brain**: `stopAuto()` called `closeDatabase()` (Step 5) before `rebuildState()` (Step 8), forcing `deriveState()` into filesystem fallback mode. Moved `rebuildState()` before `closeDatabase()` so the stop-time STATE.md snapshot uses the same authoritative DB backend that dispatch used.

## Test plan

- [ ] Verify `npx tsc --noEmit --project tsconfig.extensions.json` produces no new errors (pre-existing errors in ollama/bootstrap are unchanged)
- [ ] Simulate stale slice: create a slice SUMMARY file on disk while the DB row remains `pending` — confirm `deriveStateFromDb()` reconciles the slice to `complete` and downstream slices are no longer blocked
- [ ] Simulate stop-time split-brain: confirm `stopAuto()` now rebuilds STATE.md while DB is open, producing DB-backed state (not filesystem fallback)
- [ ] Verify the reconciliation log warning appears: `slice M.../S... status reconciled from "pending" to "complete" (#3599)`
- [ ] Run a full auto-mode session through milestone completion and confirm no regression in stop behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)