### PR TITLE
fix(gsd): notification overlay backdrop and truncation fixes

### DIFF
--- a/packages/pi-tui/src/__tests__/overlay-layout.test.ts
+++ b/packages/pi-tui/src/__tests__/overlay-layout.test.ts
@@ -34,7 +34,7 @@ describe("compositeOverlays — backdrop", () => {
 		assert.ok(dimmedLine.includes("\x1b[2m"), "base line should be dimmed");
 	});
 
-	it("backdrop uses 256-color dark gray background", () => {
+	it("backdrop uses gray foreground for dimming", () => {
 		const base = ["hello world", "second line"];
 		const overlay = makeEntry(["OV"], {
 			width: 2,
@@ -44,11 +44,11 @@ describe("compositeOverlays — backdrop", () => {
 
 		const result = compositeOverlays(base, [overlay], 20, 20, 2);
 
-		// Check a non-overlay line for full backdrop codes
+		// Check a non-overlay line for backdrop codes (dim + gray fg, no bg)
 		const line = result.find((l) => l.includes("second line"));
 		assert.ok(line, "should have a line containing 'second line'");
-		assert.ok(line.includes("\x1b[38;5;242m"), "backdrop should set gray foreground");
-		assert.ok(line.includes("\x1b[48;5;233m"), "backdrop should set dark gray background");
+		assert.ok(line.includes("\x1b[38;5;240m"), "backdrop should set gray foreground");
+		assert.ok(!line.includes("\x1b[48;"), "backdrop should not set background color");
 	});
 
 	it("does not dim when backdrop is false/absent", () => {

--- a/packages/pi-tui/src/overlay-layout.ts
+++ b/packages/pi-tui/src/overlay-layout.ts
@@ -325,11 +325,10 @@ export function compositeOverlays(
 	const viewportStart = Math.max(0, workingHeight - termHeight);
 
 	// Apply backdrop dimming if any visible overlay requests it.
-	// Uses dim + dark gray background (256-color 233) so the overlay pops visually.
+	// Uses dim + gray foreground so text fades without painting empty lines.
 	const hasBackdrop = visibleEntries.some((e) => e.options?.backdrop);
 	if (hasBackdrop) {
-		const dimFn = (text: string) =>
-			`\x1b[2m\x1b[38;5;242m\x1b[48;5;233m${text}\x1b[49m\x1b[39m\x1b[22m`;
+		const dimFn = (text: string) => `\x1b[2m\x1b[38;5;240m${text}\x1b[39m\x1b[22m`;
 		for (let i = viewportStart; i < result.length; i++) {
 			if (!isImageLine(result[i]) && result[i].length > 0) {
 				result[i] = applyBackgroundToLine(result[i], termWidth, dimFn);

--- a/src/resources/extensions/gsd/notification-overlay.ts
+++ b/src/resources/extensions/gsd/notification-overlay.ts
@@ -258,13 +258,13 @@ export class GSDNotificationOverlay {
       const time = th.fg("dim", formatTimestamp(entry.ts));
       const source = entry.source === "workflow-logger" ? th.fg("dim", " [engine]") : "";
 
-      // First line: icon + timestamp + source
-      const msgMaxWidth = contentWidth - 20;
-      const msg = entry.message.length > msgMaxWidth
-        ? entry.message.slice(0, msgMaxWidth - 1) + "…"
-        : entry.message;
+      // Measure actual prefix width to truncate message accurately
+      const prefix = `${coloredIcon} ${time}${source}  `;
+      const prefixWidth = visibleWidth(prefix);
+      const msgMaxWidth = Math.max(10, contentWidth - prefixWidth);
+      const msg = truncateToWidth(entry.message, msgMaxWidth, "…");
 
-      lines.push(row(`${coloredIcon} ${time}${source}  ${msg}`));
+      lines.push(row(`${prefix}${msg}`));
     }
 
     return lines;


### PR DESCRIPTION
## TL;DR

**What:** Fix notification overlay backdrop painting screen black, ghost artifacts on filter, and message overflow.
**Why:** #3646 introduced backdrop dimming that used a background color, causing the entire terminal to go black on empty lines.
**How:** Remove background color from backdrop (dim + gray foreground only), restore consistent overlay height, and use `visibleWidth()` for accurate message truncation.

## What

Three fixes to the notification overlay introduced in #3646:

1. **Backdrop dimming** (`packages/pi-tui/src/overlay-layout.ts`) — removed `\x1b[48;5;233m` background color that was painting all lines (including empty ones) with a dark gray background. Now uses only `\x1b[2m\x1b[38;5;240m` (dim + gray foreground).

2. **Consistent overlay height** (`src/resources/extensions/gsd/notification-overlay.ts`) — restored padding to `maxVisibleRows` so the overlay maintains the same height when cycling filters with `f`. Without this, the differential renderer leaves ghost copies of the header at previous positions.

3. **Message truncation** (`src/resources/extensions/gsd/notification-overlay.ts`) — replaced hardcoded 20-char prefix estimate with `visibleWidth(prefix)` measurement, and switched from `string.slice()` to `truncateToWidth()` for proper Unicode/ANSI-aware truncation with `…` ellipsis.

## Why

After #3646 was merged, the backdrop dimming made the entire screen go black (empty lines got a solid dark gray background). Filter cycling caused ghost header duplication because the overlay height changed between renders. Long notification messages could overflow the box border due to inaccurate prefix width estimation.

## How

- Backdrop: removed `\x1b[48;5;233m` (background) and `\x1b[38;5;242m` (was too light), kept `\x1b[2m` (dim) and switched to `\x1b[38;5;240m` (darker gray foreground)
- Height: pad `visibleContent` to `maxVisibleRows` so overlay size is constant regardless of filter state
- Truncation: compute `prefixWidth = visibleWidth(prefix)` then `truncateToWidth(entry.message, contentWidth - prefixWidth, "…")`

AI-assisted (Claude Code). All changes tested locally.

- [x] `fix` — Bug fix
- [x] `test` — Updated overlay-layout backdrop tests