### PR TITLE
fix(gsd): add memory pressure watchdog and persist stuck detection state

### DIFF
--- a/src/resources/extensions/gsd/auto/loop.ts
+++ b/src/resources/extensions/gsd/auto/loop.ts
@@ -49,7 +49,8 @@ function loadStuckState(basePath: string): { recentUnits: Array<{ key: string }>
       recentUnits: Array.isArray(data.recentUnits) ? data.recentUnits : [],
       stuckRecoveryAttempts: typeof data.stuckRecoveryAttempts === "number" ? data.stuckRecoveryAttempts : 0,
     };
-  } catch {
+  } catch (err) {
+    debugLog("autoLoop", { phase: "load-stuck-state-failed", error: err instanceof Error ? err.message : String(err) });
     return { recentUnits: [], stuckRecoveryAttempts: 0 };
   }
 }
@@ -63,8 +64,8 @@ function saveStuckState(basePath: string, state: LoopState): void {
       stuckRecoveryAttempts: state.stuckRecoveryAttempts,
       updatedAt: new Date().toISOString(),
     }) + "\n");
-  } catch {
-    // Non-fatal — stuck detection still works within session
+  } catch (err) {
+    debugLog("autoLoop", { phase: "save-stuck-state-failed", error: err instanceof Error ? err.message : String(err) });
   }
 }
 
@@ -87,7 +88,7 @@ function checkMemoryPressure(): { pressured: boolean; heapMB: number; limitMB: n
     const v8 = require("node:v8");
     const stats = v8.getHeapStatistics();
     limitMB = Math.round(stats.heap_size_limit / 1024 / 1024);
-  } catch { /* fallback to default */ }
+  } catch { limitMB = 4096; /* v8 stats unavailable — use conservative default */ }
   const pct = heapMB / limitMB;
   return { pressured: pct > MEMORY_PRESSURE_THRESHOLD, heapMB, limitMB, pct };
 }

--- a/src/resources/extensions/gsd/auto/loop.ts
+++ b/src/resources/extensions/gsd/auto/loop.ts
@@ -29,6 +29,68 @@ import {
 import { debugLog } from "../debug-logger.js";
 import { isInfrastructureError } from "./infra-errors.js";
 import { resolveEngine } from "../engine-resolver.js";
+import { logWarning } from "../workflow-logger.js";
+import { gsdRoot } from "../paths.js";
+import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+
+// ── Stuck detection persistence (#3704) ──────────────────────────────────
+// Persist stuck detection state to disk so it survives session restarts.
+// Without this, restarting auto-mode resets all counters, allowing the
+// same blocked unit to burn a full retry budget each session.
+function stuckStatePath(basePath: string): string {
+  return join(gsdRoot(basePath), "runtime", "stuck-state.json");
+}
+
+function loadStuckState(basePath: string): { recentUnits: Array<{ key: string }>; stuckRecoveryAttempts: number } {
+  try {
+    const data = JSON.parse(readFileSync(stuckStatePath(basePath), "utf-8"));
+    return {
+      recentUnits: Array.isArray(data.recentUnits) ? data.recentUnits : [],
+      stuckRecoveryAttempts: typeof data.stuckRecoveryAttempts === "number" ? data.stuckRecoveryAttempts : 0,
+    };
+  } catch {
+    return { recentUnits: [], stuckRecoveryAttempts: 0 };
+  }
+}
+
+function saveStuckState(basePath: string, state: LoopState): void {
+  try {
+    const filePath = stuckStatePath(basePath);
+    mkdirSync(join(gsdRoot(basePath), "runtime"), { recursive: true });
+    writeFileSync(filePath, JSON.stringify({
+      recentUnits: state.recentUnits.slice(-20), // keep last 20 entries
+      stuckRecoveryAttempts: state.stuckRecoveryAttempts,
+      updatedAt: new Date().toISOString(),
+    }) + "\n");
+  } catch {
+    // Non-fatal — stuck detection still works within session
+  }
+}
+
+// ── Memory pressure monitoring (#3331) ──────────────────────────────────
+// Check heap usage every N iterations and trigger graceful shutdown before
+// the OS OOM killer sends SIGKILL. The threshold is 90% of the V8 heap
+// limit (--max-old-space-size or default ~1.5-4GB depending on platform).
+const MEMORY_CHECK_INTERVAL = 5; // check every 5 iterations
+const MEMORY_PRESSURE_THRESHOLD = 0.85; // 85% of heap limit
+
+function checkMemoryPressure(): { pressured: boolean; heapMB: number; limitMB: number; pct: number } {
+  const mem = process.memoryUsage();
+  // v8.getHeapStatistics() gives heap_size_limit but requires import
+  // Use a conservative estimate: RSS > 3GB is danger zone on most systems
+  const heapMB = Math.round(mem.heapUsed / 1024 / 1024);
+  const rssMB = Math.round(mem.rss / 1024 / 1024);
+  // Try to get the actual V8 heap limit
+  let limitMB = 4096; // conservative default
+  try {
+    const v8 = require("node:v8");
+    const stats = v8.getHeapStatistics();
+    limitMB = Math.round(stats.heap_size_limit / 1024 / 1024);
+  } catch { /* fallback to default */ }
+  const pct = heapMB / limitMB;
+  return { pressured: pct > MEMORY_PRESSURE_THRESHOLD, heapMB, limitMB, pct };
+}
 
 /**
  * Main auto-mode execution loop. Iterates: derive → dispatch → guards →
@@ -46,7 +108,13 @@ export async function autoLoop(
 ): Promise<void> {
   debugLog("autoLoop", { phase: "enter" });
   let iteration = 0;
-  const loopState: LoopState = { recentUnits: [], stuckRecoveryAttempts: 0, consecutiveFinalizeTimeouts: 0 };
+  // Load persisted stuck state so counters survive session restarts (#3704)
+  const persisted = loadStuckState(s.basePath);
+  const loopState: LoopState = {
+    recentUnits: persisted.recentUnits,
+    stuckRecoveryAttempts: persisted.stuckRecoveryAttempts,
+    consecutiveFinalizeTimeouts: 0,
+  };
   let consecutiveErrors = 0;
   const recentErrorMessages: string[] = [];
 
@@ -71,6 +139,24 @@ export async function autoLoop(
         `Safety: loop exceeded ${MAX_LOOP_ITERATIONS} iterations — possible runaway`,
       );
       break;
+    }
+
+    // ── Memory pressure check (#3331) ──
+    // Graceful shutdown before OOM killer sends SIGKILL.
+    if (iteration % MEMORY_CHECK_INTERVAL === 0) {
+      const mem = checkMemoryPressure();
+      debugLog("autoLoop", { phase: "memory-check", ...mem });
+      if (mem.pressured) {
+        logWarning("autoLoop", `Memory pressure: ${mem.heapMB}MB / ${mem.limitMB}MB (${Math.round(mem.pct * 100)}%) — stopping auto-mode to prevent OOM kill`);
+        await deps.stopAuto(
+          ctx,
+          pi,
+          `Memory pressure: heap at ${mem.heapMB}MB / ${mem.limitMB}MB (${Math.round(mem.pct * 100)}%). ` +
+          `Stopping gracefully to prevent OOM kill after ${iteration} iterations. ` +
+          `Resume with /gsd auto to continue from where you left off.`,
+        );
+        break;
+      }
     }
 
     if (!s.cmdCtx) {
@@ -205,6 +291,7 @@ export async function autoLoop(
         consecutiveErrors = 0;
         recentErrorMessages.length = 0;
         deps.emitJournalEvent({ ts: new Date().toISOString(), flowId, seq: nextSeq(), eventType: "iteration-end", data: { iteration } });
+        saveStuckState(s.basePath, loopState); // persist across session restarts (#3704)
         debugLog("autoLoop", { phase: "iteration-complete", iteration });
         continue;
       }

--- a/src/resources/extensions/gsd/auto/loop.ts
+++ b/src/resources/extensions/gsd/auto/loop.ts
@@ -147,7 +147,7 @@ export async function autoLoop(
       const mem = checkMemoryPressure();
       debugLog("autoLoop", { phase: "memory-check", ...mem });
       if (mem.pressured) {
-        logWarning("autoLoop", `Memory pressure: ${mem.heapMB}MB / ${mem.limitMB}MB (${Math.round(mem.pct * 100)}%) — stopping auto-mode to prevent OOM kill`);
+        logWarning("dispatch", `Memory pressure: ${mem.heapMB}MB / ${mem.limitMB}MB (${Math.round(mem.pct * 100)}%) — stopping auto-mode to prevent OOM kill`);
         await deps.stopAuto(
           ctx,
           pi,

--- a/src/resources/extensions/gsd/tests/memory-pressure-stuck-state.test.ts
+++ b/src/resources/extensions/gsd/tests/memory-pressure-stuck-state.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Regression tests for memory pressure monitoring (#3331) and
+ * stuck detection persistence (#3704) in auto/loop.ts.
+ */
+
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const loopSource = readFileSync(join(__dirname, "..", "auto", "loop.ts"), "utf-8");
+
+describe("memory pressure monitoring (#3331)", () => {
+  test("checkMemoryPressure function exists", () => {
+    assert.match(loopSource, /function checkMemoryPressure/);
+  });
+
+  test("MEMORY_PRESSURE_THRESHOLD constant is defined", () => {
+    assert.match(loopSource, /MEMORY_PRESSURE_THRESHOLD\s*=\s*0\.\d+/);
+  });
+
+  test("memory check runs every MEMORY_CHECK_INTERVAL iterations", () => {
+    assert.match(loopSource, /iteration\s*%\s*MEMORY_CHECK_INTERVAL\s*===\s*0/);
+  });
+
+  test("memory pressure triggers graceful stopAuto", () => {
+    assert.match(loopSource, /mem\.pressured/);
+    assert.match(loopSource, /Stopping gracefully to prevent OOM/);
+  });
+});
+
+describe("stuck detection persistence (#3704)", () => {
+  test("loadStuckState function exists", () => {
+    assert.match(loopSource, /function loadStuckState/);
+  });
+
+  test("saveStuckState function exists", () => {
+    assert.match(loopSource, /function saveStuckState/);
+  });
+
+  test("loopState initialized from persisted state", () => {
+    assert.match(loopSource, /loadStuckState\(s\.basePath\)/);
+  });
+
+  test("stuck state saved after each iteration", () => {
+    assert.match(loopSource, /saveStuckState\(s\.basePath,\s*loopState\)/);
+  });
+
+  test("stuck state file path uses runtime directory", () => {
+    assert.match(loopSource, /stuck-state\.json/);
+  });
+});


### PR DESCRIPTION
## Summary
Two architectural improvements to auto-mode resilience:

### 1. Memory pressure monitoring (#3331)
- Checks `process.memoryUsage().heapUsed` against V8 heap limit every 5 iterations
- Triggers graceful `stopAuto` at 85% threshold with actionable message
- Prevents OOM SIGKILL after long-running sessions (131+ units / 7h+)

### 2. Stuck detection persistence (#3704)
- Saves `loopState` (recentUnits, stuckRecoveryAttempts) to `.gsd/runtime/stuck-state.json`
- Loads persisted state on `autoLoop` entry
- Prevents restarted sessions from burning full retry budgets on the same blocked unit
- Same disk-persistence pattern as `rewrite-count.json` and `uat-count.json`

Closes #3331
Closes #3704

## Test plan
- [ ] Verify memory check runs every 5 iterations (debug log)
- [ ] Verify auto-mode stops gracefully when heap exceeds 85%
- [ ] Verify stuck state persists across session restart
- [ ] Verify stuck detection still works within a single session
- [ ] Typecheck passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>