### PR TITLE
fix(gsd): suppress model change notification in auto-mode unless verbose

### DIFF
--- a/src/resources/extensions/gsd/auto-model-selection.ts
+++ b/src/resources/extensions/gsd/auto-model-selection.ts
@@ -246,11 +246,13 @@ export async function selectAndApplyModel(
       const ok = await pi.setModel(model, { persist: false });
       if (ok) {
         appliedModel = model;
-        const fallbackNote = modelId === effectiveModelConfig.primary
-          ? ""
-          : ` (fallback from ${effectiveModelConfig.primary})`;
-        const phase = unitPhaseLabel(unitType);
-        ctx.ui.notify(`Model [${phase}]${routingTierLabel}: ${model.provider}/${model.id}${fallbackNote}`, "info");
+        if (verbose) {
+          const fallbackNote = modelId === effectiveModelConfig.primary
+            ? ""
+            : ` (fallback from ${effectiveModelConfig.primary})`;
+          const phase = unitPhaseLabel(unitType);
+          ctx.ui.notify(`Model [${phase}]${routingTierLabel}: ${model.provider}/${model.id}${fallbackNote}`, "info");
+        }
         break;
       } else {
         const nextModel = modelsToTry[modelsToTry.indexOf(modelId) + 1];

--- a/src/resources/extensions/gsd/tests/auto-model-selection.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-model-selection.test.ts
@@ -1,8 +1,11 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
 import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 import { resolvePreferredModelConfig, resolveModelId } from "../auto-model-selection.js";
 
@@ -194,6 +197,34 @@ test("resolveModelId: bare ID with claude-code as only provider still resolves",
   const result = resolveModelId("claude-sonnet-4-6", availableModels, "claude-code");
   assert.ok(result, "should resolve even when only available via claude-code");
   assert.equal(result.provider, "claude-code");
+});
+
+// ─── selectAndApplyModel verbose-gating tests ──────────────────────────
+
+test("model change notify in selectAndApplyModel is gated behind verbose flag", () => {
+  // The Model [phase] [tier] notification should only fire when verbose=true.
+  // The dashboard header already shows the active model, so the notification
+  // is redundant noise during auto-mode (#3719).
+  const gsdDir = join(__dirname, "..");
+  const src = readFileSync(join(gsdDir, "auto-model-selection.ts"), "utf-8");
+
+  // Find the block where setModel succeeds (appliedModel = model) and
+  // verify notify is inside an `if (verbose)` guard.
+  const setModelBlock = src.match(
+    /const ok = await pi\.setModel\(model[\s\S]*?appliedModel = model;([\s\S]*?)break;/,
+  );
+  assert.ok(setModelBlock, "should find the setModel success block");
+
+  const blockBody = setModelBlock![1];
+  // The notify call must be inside an if (verbose) block
+  assert.ok(
+    blockBody.includes("if (verbose)"),
+    "Model change ctx.ui.notify must be gated behind if (verbose) to avoid auto-mode notification noise",
+  );
+  assert.ok(
+    blockBody.includes("ctx.ui.notify"),
+    "notify call should still exist (just verbose-gated)",
+  );
 });
 
 test("resolveModelId: anthropic wins over claude-code regardless of list order", () => {


### PR DESCRIPTION
## Summary
- Gate the `Model [phase] [tier]: provider/model` notification behind the `verbose` flag during auto-mode
- The dashboard header already displays the active model, making this notification redundant noise
- Consistent with all other model routing notifications in the same function which are already verbose-gated

## Test plan
- [ ] Run auto-mode and verify no model change notifications appear in the bottom widget
- [ ] Enable verbose mode and verify model change notifications still appear
- [ ] Confirm dashboard header still shows the active model

🤖 Generated with [Claude Code](https://claude.com/claude-code)