### PR TITLE
fix(gsd): skip reverse dependents in dispatch fallback

### DIFF
--- a/src/resources/extensions/gsd/dispatch-guard.ts
+++ b/src/resources/extensions/gsd/dispatch-guard.ts
@@ -107,10 +107,27 @@ export function getPriorSliceCompletionBlocker(
         // it may be a cross-milestone reference handled elsewhere.
       }
     } else {
+      // Positional fallback is only a heuristic for legacy slices with no
+      // declared dependencies. Skip any earlier slice that depends on the
+      // target, directly or transitively, or we can deadlock a valid zero-dep
+      // slice behind its own downstream dependents (#3720).
+      const reverseDependents = new Set<string>();
+      let changed = true;
+      while (changed) {
+        changed = false;
+        for (const slice of slices) {
+          if (reverseDependents.has(slice.id)) continue;
+          if (slice.depends.some((depId) => depId === targetSid || reverseDependents.has(depId))) {
+            reverseDependents.add(slice.id);
+            changed = true;
+          }
+        }
+      }
+
       const targetIndex = slices.findIndex((slice) => slice.id === targetSid);
       const incomplete = slices
         .slice(0, targetIndex)
-        .find((slice) => !slice.done);
+        .find((slice) => !slice.done && !reverseDependents.has(slice.id));
       if (incomplete) {
         return `Cannot dispatch ${unitType} ${unitId}: earlier slice ${targetMid}/${incomplete.id} is not complete.`;
       }

--- a/src/resources/extensions/gsd/tests/dispatch-guard.test.ts
+++ b/src/resources/extensions/gsd/tests/dispatch-guard.test.ts
@@ -145,6 +145,33 @@ test("dispatch guard falls back to positional ordering when no dependencies decl
   );
 });
 
+test("dispatch guard ignores positionally-earlier reverse dependents for zero-dependency slices (#3720)", (t) => {
+  const repo = setupRepo();
+  t.after(() => teardownRepo(repo));
+
+  mkdirSync(join(repo, ".gsd", "milestones", "M015"), { recursive: true });
+
+  insertMilestone({ id: "M015", title: "Reverse dependency fallback" });
+  insertSlice({ id: "S03", milestoneId: "M015", title: "Complete prerequisite", status: "complete", depends: [], sequence: 0 });
+  insertSlice({ id: "S04", milestoneId: "M015", title: "Depends on S04A", status: "pending", depends: ["S03", "S04A"], sequence: 0 });
+  insertSlice({ id: "S04A", milestoneId: "M015", title: "No explicit deps", status: "pending", depends: [], sequence: 0 });
+
+  writeFileSync(join(repo, ".gsd", "milestones", "M015", "M015-ROADMAP.md"), "# M015\n");
+
+  // S04A has no declared dependencies and should not be blocked by S04, because
+  // S04 itself depends on S04A. With sequence=0, DB ordering falls back to id.
+  assert.equal(
+    getPriorSliceCompletionBlocker(repo, "main", "execute-task", "M015/S04A/T02"),
+    null,
+  );
+
+  // The reverse direction is still blocked normally.
+  assert.equal(
+    getPriorSliceCompletionBlocker(repo, "main", "execute-task", "M015/S04/T01"),
+    "Cannot dispatch execute-task M015/S04/T01: dependency slice M015/S04A is not complete.",
+  );
+});
+
 test("dispatch guard allows slice with all declared dependencies complete", (t) => {
   const repo = setupRepo();
   t.after(() => teardownRepo(repo));


### PR DESCRIPTION
## TL;DR

**What:** Fix `dispatch-guard` so the positional fallback does not block a zero-dependency slice behind its own reverse dependents.
**Why:** `#3720` reproduces when a positionally-earlier slice depends on the target slice, but the fallback still treats it as a hard predecessor.
**How:** Build a reverse-dependent closure during the fallback, skip those slices when searching for an earlier incomplete blocker, and add a regression test for the `S04`/`S04A` shape from the issue.

## What

This changes `dispatch-guard`'s positional fallback for slices with no declared dependencies.

Before this patch, a zero-dependency slice could still be blocked by an incomplete earlier slice even when that earlier slice depended on the target. That contradicted the dependency-aware state selection and deadlocked a valid dispatch path.

The regression test covers the concrete `#3720` shape:
- `S04A` has no explicit dependencies
- `S04` appears earlier by fallback ordering
- `S04` depends on `S04A`
- `S04A/T02` must still dispatch

## Why

Closes #3720.

The old fallback assumed that all earlier slices had to finish first whenever the target slice had `depends: []`. That assumption breaks as soon as fallback ordering and dependency ordering disagree.

## How

When the fallback path is used, the guard now:
- computes the set of slices that depend on the target, directly or transitively
- ignores those reverse dependents when looking for an incomplete earlier blocker

That keeps the legacy positional heuristic for genuinely unrelated earlier slices, without blocking the target behind its own downstream dependents.

## Change type

- [x] `fix` — Bug fix
- [x] `test` — Adding or updating tests

## Scope

- [x] `gsd extension` — GSD workflow

## Breaking changes

- [x] No breaking changes

## Test plan

- [ ] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

Manual testing:
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/dispatch-guard.test.ts`
- `npm run build`
- `npm run typecheck:extensions`

GitHub CI will rerun on this cleaned branch.

## AI disclosure

- [x] This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.
