### PR TITLE
fix(gsd): normalize described expected output paths

### DIFF
--- a/src/resources/extensions/gsd/files.ts
+++ b/src/resources/extensions/gsd/files.ts
@@ -113,6 +113,25 @@ function escapeRegex(s: string): string {
   return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
+/**
+ * Normalize a task-plan file reference that may include inline description text
+ * after the path, for example:
+ *   "docs/file.md — explanation"
+ *   "docs/file.md - explanation"
+ */
+export function normalizePlannedFileReference(value: string): string {
+  const trimmed = value.trim().replace(/`/g, "");
+  const match = /^(.*?)(?:\s+(?:—|-)\s+)(.+)$/.exec(trimmed);
+  if (!match) return trimmed;
+
+  const pathCandidate = match[1].trim();
+  if (pathCandidate.includes("/") || pathCandidate.includes("\\") || pathCandidate.includes(".")) {
+    return pathCandidate;
+  }
+
+  return trimmed;
+}
+
 /** Parse bullet list items from a text block. */
 export function parseBullets(text: string): string[] {
   return text.split('\n')
@@ -603,11 +622,11 @@ export function parseTaskPlanIO(content: string): { inputFiles: string[]; output
       let match: RegExpExecArray | null;
       backtickPathRegex.lastIndex = 0;
       while ((match = backtickPathRegex.exec(trimmed)) !== null) {
-        const candidate = match[1];
+        const candidate = normalizePlannedFileReference(match[1]);
         // Filter out things that look like code tokens rather than file paths
         // (e.g. `true`, `false`, `npm run test`). A file path has at least one
         // dot or slash.
-        if (candidate.includes("/") || candidate.includes(".")) {
+        if (candidate.includes("/") || candidate.includes("\\") || candidate.includes(".")) {
           paths.push(candidate);
         }
       }

--- a/src/resources/extensions/gsd/safety/file-change-validator.ts
+++ b/src/resources/extensions/gsd/safety/file-change-validator.ts
@@ -10,6 +10,7 @@
  */
 
 import { execFileSync } from "node:child_process";
+import { normalizePlannedFileReference } from "../files.js";
 import { logWarning } from "../workflow-logger.js";
 
 // ─── Types ──────────────────────────────────────────────────────────────────
@@ -57,7 +58,9 @@ export function validateFileChanges(
 
   // Normalize expected paths (strip leading ./ or /)
   const normalizedExpected = new Set(
-    [...allExpected].map(f => f.replace(/^\.\//, "").replace(/^\//, "")),
+    [...allExpected].map((f) =>
+      normalizePlannedFileReference(f).replace(/^\.\//, "").replace(/^\//, ""),
+    ),
   );
 
   // Compute symmetric difference

--- a/src/resources/extensions/gsd/tests/file-change-validator.test.ts
+++ b/src/resources/extensions/gsd/tests/file-change-validator.test.ts
@@ -1,0 +1,50 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { validateFileChanges } from "../safety/file-change-validator.ts";
+
+function git(cwd: string, ...args: string[]): string {
+  return execFileSync("git", args, {
+    cwd,
+    stdio: ["ignore", "pipe", "pipe"],
+    encoding: "utf-8",
+  }).trim();
+}
+
+test("validateFileChanges ignores inline descriptions in expected output paths", (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-file-change-validator-"));
+  t.after(() => rmSync(base, { recursive: true, force: true }));
+
+  mkdirSync(join(base, "definitions"), { recursive: true });
+  git(base, "init");
+  git(base, "config", "user.email", "test@example.com");
+  git(base, "config", "user.name", "Test User");
+
+  const target = join(base, "definitions", "ac-audit.md");
+  writeFileSync(target, "initial\n");
+  git(base, "add", ".");
+  git(base, "commit", "-m", "initial");
+
+  writeFileSync(target, "updated\n");
+  git(base, "add", ".");
+  git(base, "commit", "-m", "update");
+
+  const audit = validateFileChanges(
+    base,
+    ["definitions/ac-audit.md — current state of AC CRM, tags, pipelines, automations"],
+    [],
+  );
+
+  assert.ok(audit, "audit should be produced when expected output exists");
+  assert.deepEqual(audit.unexpectedFiles, []);
+  assert.deepEqual(audit.missingFiles, []);
+  assert.equal(
+    audit.violations.some((v) => v.severity === "warning"),
+    false,
+    "described expected output should not trigger unexpected-file warnings",
+  );
+});

--- a/src/resources/extensions/gsd/tests/reactive-graph.test.ts
+++ b/src/resources/extensions/gsd/tests/reactive-graph.test.ts
@@ -101,6 +101,25 @@ test("parseTaskPlanIO handles multiple backtick tokens on one line", () => {
   assert.deepEqual(io.outputFiles, ["src/c.ts"]);
 });
 
+test("parseTaskPlanIO strips inline descriptions from backtick-wrapped file references", () => {
+  const content = `# T01: Described Paths
+
+## Inputs
+
+- \`src/config.ts — existing configuration\`
+- \`src/flags.ts - feature flags\`
+
+## Expected Output
+
+- \`definitions/ac-audit.md — current state of AC CRM\`
+- \`docs/runbook.md - update deployment notes\`
+`;
+
+  const io = parseTaskPlanIO(content);
+  assert.deepEqual(io.inputFiles, ["src/config.ts", "src/flags.ts"]);
+  assert.deepEqual(io.outputFiles, ["definitions/ac-audit.md", "docs/runbook.md"]);
+});
+
 // ─── deriveTaskGraph ──────────────────────────────────────────────────────
 
 test("deriveTaskGraph: linear chain T01→T02→T03", () => {


### PR DESCRIPTION
## TL;DR

**What:** Normalizes described task-plan file references before treating them as expected output paths.
**Why:** The safety checker warns on planned file writes when `## Expected Output` descriptions are written inside the backticks.
**How:** Strip inline description suffixes from planned file references in both task-plan parsing and file-change validation, and add regression coverage for both paths.

## What

This updates the GSD extension's task-plan file parsing and safety validation so described expected-output entries like `` `definitions/ac-audit.md — description` `` are treated as the file path `definitions/ac-audit.md`.

The change touches:
- `parseTaskPlanIO` in `files.ts`
- `validateFileChanges` in `safety/file-change-validator.ts`
- targeted regression tests for both the parser and the validator

## Why

`gsd_plan_task` can store expected-output descriptions inside backticks, while the safety checker compares changed files against bare git paths. That mismatch causes false-positive "unexpected file change" warnings even when the file written was exactly the planned output.

Closes #3736

## How

The fix introduces one small normalization helper for planned file references that strips a trailing inline description only when the left side still looks like a path. The same normalization is applied in both task-plan parsing and expected-output validation so the two code paths stay in sync.

Regression coverage was added for:
- parsing described backtick-wrapped paths
- validating changed files against described expected-output entries

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [ ] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

Manual and automated verification:

1. Reproduced the parser case with a described expected-output entry inside backticks and confirmed it now resolves to the bare path `definitions/ac-audit.md`.
2. Ran `npm run build`.
3. Ran `npm run typecheck:extensions`.
4. Ran:

```bash
node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs \
  --experimental-strip-types \
  --test \
  src/resources/extensions/gsd/tests/reactive-graph.test.ts \
  src/resources/extensions/gsd/tests/file-change-validator.test.ts
```

5. A wider unit-suite snapshot on the same branch still hits pre-existing failures in `flat-rate-routing-guard.test.ts` and `uat-stuck-loop-orphaned-worktree.test.ts`, and those same failures reproduce on clean `upstream/main`.
6. `npm run test:integration` also passed in a clean verification clone (`1121 pass, 0 fail, 3 skipped`).

## AI disclosure

- [x] This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.
