### PR TITLE
fix(gsd): parse annotated pre-exec file paths

### DIFF
--- a/src/resources/extensions/gsd/pre-execution-checks.ts
+++ b/src/resources/extensions/gsd/pre-execution-checks.ts
@@ -238,8 +238,7 @@ export async function checkPackageExistence(
 export function normalizeFilePath(filePath: string): string {
   if (!filePath) return filePath;
 
-  // Strip backtick wrapping from LLM-generated paths (#3649)
-  let normalized = filePath.replace(/`/g, "");
+  let normalized = extractPathFromAnnotation(filePath);
 
   // Normalize path separators to forward slashes
   normalized = normalized.replace(/\\/g, "/");
@@ -258,6 +257,24 @@ export function normalizeFilePath(filePath: string): string {
   }
   
   return normalized;
+}
+
+function extractPathFromAnnotation(raw: string): string {
+  const trimmed = raw.trim();
+  if (!trimmed) return trimmed;
+
+  const backtickMatch = trimmed.match(/^`([^`]+)`(?:\s+[—–-]\s+.*)?$/);
+  if (backtickMatch) {
+    return backtickMatch[1].trim();
+  }
+
+  const annotatedMatch = trimmed.match(/^(.+?)\s+[—–-]\s+.+$/);
+  if (annotatedMatch) {
+    return annotatedMatch[1].trim();
+  }
+
+  // Fall back to the original behavior for already-plain paths.
+  return trimmed.replace(/`/g, "");
 }
 
 /**

--- a/src/resources/extensions/gsd/tests/pre-execution-checks.test.ts
+++ b/src/resources/extensions/gsd/tests/pre-execution-checks.test.ts
@@ -1083,11 +1083,77 @@ describe("checkTaskOrdering false positive regression (#3677)", () => {
     const results = checkTaskOrdering(tasks, "/tmp");
     assert.equal(results.length, 0, "Normalized task.files path should not trigger a false positive");
   });
+
+  test("annotated inputs still trigger ordering violations against later plain outputs", () => {
+    const tasks = [
+      createTask({
+        id: "T01",
+        sequence: 0,
+        files: [],
+        inputs: ["`later.ts` — needed first"],
+        expected_output: [],
+      }),
+      createTask({
+        id: "T02",
+        sequence: 1,
+        files: [],
+        inputs: [],
+        expected_output: ["later.ts"],
+      }),
+    ];
+
+    const results = checkTaskOrdering(tasks, "/tmp");
+    assert.equal(results.length, 1, "Annotated inputs should still match later plain expected_output entries");
+    assert.equal(results[0].target, "`later.ts` — needed first");
+    assert.ok(results[0].message.includes("sequence violation"));
+  });
 });
 
 // ─── checkFilePathConsistency additional edge cases ──────────────────────────
 
 describe("checkFilePathConsistency additional edge cases", () => {
+  test("annotated inputs match files that already exist on disk", () => {
+    const tempDir = join(tmpdir(), `pre-exec-test-annotated-input-${Date.now()}`);
+    mkdirSync(tempDir, { recursive: true });
+    writeFileSync(join(tempDir, "existing.ts"), "// content");
+
+    try {
+      const tasks = [
+        createTask({
+          id: "T01",
+          files: [],
+          inputs: ["`existing.ts` — file already on disk"],
+          expected_output: [],
+        }),
+      ];
+
+      const results = checkFilePathConsistency(tasks, tempDir);
+      assert.equal(results.length, 0, "Annotated inputs should resolve to the on-disk file path");
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  test("plain inputs match prior annotated expected outputs", () => {
+    const tasks = [
+      createTask({
+        id: "T01",
+        files: [],
+        inputs: [],
+        expected_output: ["`generated.ts` — created earlier"],
+      }),
+      createTask({
+        id: "T02",
+        files: [],
+        inputs: ["generated.ts"],
+        expected_output: [],
+      }),
+    ];
+
+    const results = checkFilePathConsistency(tasks, "/tmp");
+    assert.equal(results.length, 0, "Prior annotated expected_output entries should satisfy later plain inputs");
+  });
+
   test("inputs referencing glob-like patterns should not crash", () => {
     // A glob pattern in inputs is unusual but should be handled gracefully.
     // The file won't exist on disk, so it should produce a blocking result.


### PR DESCRIPTION
## TL;DR

**What:** Normalize annotated task-plan file entries before pre-execution checks compare inputs and expected outputs.
**Why:** Planner-style entries like `` `file.ts` — description `` are currently treated as literal file paths, causing false blocking failures.
**How:** Extract the actual path component before normalization and add regression coverage for on-disk checks, prior outputs, and ordering checks.

## What

This updates `pre-execution-checks.ts` so annotated file references are parsed down to their real path before consistency and ordering checks run. It also adds focused regression tests covering the annotated input and annotated expected-output cases that were blocking valid plans.

## Why

`checkFilePathConsistency` and `checkTaskOrdering` currently treat planner-style annotated entries as raw file paths. That makes valid plans fail pre-execution checks even when the referenced files already exist or were created by prior tasks.

Closes #3742

## How

The change teaches `normalizeFilePath` to extract the path portion from annotated strings before it applies the existing slash and dot normalization rules. The new tests lock three key cases:

- annotated inputs resolve against files that already exist on disk
- plain later inputs match prior annotated `expected_output` entries
- annotated inputs still trigger real ordering violations against later outputs

## Change type

- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [ ] CI passes
- [x] New/updated tests included
- [ ] Manual testing — steps described above
- [ ] No tests needed — explained above

Automated verification:

1. `npm run build`
2. `npm run typecheck:extensions`
3. `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/pre-execution-checks.test.ts src/resources/extensions/gsd/tests/pre-exec-backtick-strip.test.ts`
4. Standalone repro against `checkFilePathConsistency` and `checkTaskOrdering` showing:
   - before fix: annotated input falsely failed as missing, and prior annotated outputs did not satisfy later plain inputs
   - after fix: annotated paths resolve correctly while real ordering violations still trigger

`CI passes` is left unchecked because I did not run the broader unit/integration suites for this branch.

## AI disclosure

- [x] This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.
