### PR TITLE
fix(pi-tui): clear autocomplete rows from content bottom

### DIFF
--- a/packages/pi-tui/src/tui.ts
+++ b/packages/pi-tui/src/tui.ts
@@ -616,9 +616,10 @@ export class TUI extends Container {
 		const height = this.terminal.rows;
 		let viewportTop = Math.max(0, this.maxLinesRendered - height);
 		let prevViewportTop = this.previousViewportTop;
+		let contentCursorRow = this.cursorRow;
 		let hardwareCursorRow = this.hardwareCursorRow;
 		const computeLineDiff = (targetRow: number): number => {
-			const currentScreenRow = hardwareCursorRow - prevViewportTop;
+			const currentScreenRow = contentCursorRow - prevViewportTop;
 			const targetScreenRow = targetRow - viewportTop;
 			return targetScreenRow - currentScreenRow;
 		};
@@ -805,6 +806,7 @@ export class TUI extends Container {
 			buffer += "\r\n".repeat(scroll);
 			prevViewportTop += scroll;
 			viewportTop += scroll;
+			contentCursorRow = moveTargetRow;
 			hardwareCursorRow = moveTargetRow;
 		}
 

--- a/src/tests/tui-autocomplete-ghost-lines.test.ts
+++ b/src/tests/tui-autocomplete-ghost-lines.test.ts
@@ -1,0 +1,85 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { CURSOR_MARKER, TUI, type Component, type Terminal } from "@gsd/pi-tui";
+
+class MockTTYTerminal implements Terminal {
+  public writtenData: string[] = [];
+
+  readonly isTTY = true;
+
+  start(_onInput: (data: string) => void, _onResize: () => void): void {}
+  stop(): void {}
+  async drainInput(_maxMs?: number, _idleMs?: number): Promise<void> {}
+
+  write(data: string): void {
+    this.writtenData.push(data);
+  }
+
+  get columns(): number {
+    return 80;
+  }
+
+  get rows(): number {
+    return 24;
+  }
+
+  get kittyProtocolActive(): boolean {
+    return false;
+  }
+
+  moveBy(_lines: number): void {}
+  hideCursor(): void {}
+  showCursor(): void {}
+  clearLine(): void {}
+  clearFromCursor(): void {}
+  clearScreen(): void {}
+  setTitle(_title: string): void {}
+}
+
+class DynamicLinesComponent implements Component {
+  public lines: string[];
+
+  constructor(lines: string[]) {
+    this.lines = lines;
+  }
+
+  render(_width: number): string[] {
+    return this.lines;
+  }
+
+  invalidate(): void {}
+}
+
+describe("TUI autocomplete shrink clearing (#3721)", () => {
+  it("clears deleted autocomplete rows relative to the content bottom, not the IME cursor row", () => {
+    const terminal = new MockTTYTerminal();
+    const tui = new TUI(terminal, false);
+    const component = new DynamicLinesComponent([
+      "top border",
+      `prompt${CURSOR_MARKER}`,
+      "editor body",
+      "autocomplete row 1",
+      "autocomplete row 2",
+      "autocomplete row 3",
+    ]);
+
+    tui.addChild(component);
+    (tui as any).doRender();
+
+    terminal.writtenData = [];
+    component.lines = [
+      "top border",
+      `prompt${CURSOR_MARKER}`,
+      "editor body",
+      "autocomplete row 1",
+    ];
+
+    (tui as any).doRender();
+
+    assert.ok(terminal.writtenData.length >= 1, "shrink render should write a differential buffer");
+    assert.ok(
+      terminal.writtenData[0].startsWith("\x1b[?2026h\x1b[2A\r"),
+      `expected shrink diff to move up from prior content bottom, got ${JSON.stringify(terminal.writtenData[0])}`,
+    );
+  });
+});


### PR DESCRIPTION
## TL;DR

**What:** Fix autocomplete shrink clearing so deleted rows are cleared relative to the rendered content bottom.
**Why:** The TUI currently reuses the IME cursor row as the shrink baseline, which leaves ghost autocomplete rows on screen after dismissal.
**How:** Keep shrink diffing anchored to the content row and add a focused fake-terminal regression test for the ghost-line path.

## What

This updates the differential render logic in `packages/pi-tui/src/tui.ts` so shrink-clearing calculations use the rendered content row instead of the hardware IME cursor row. It also adds a focused regression test that reproduces the autocomplete-dismiss path with a fake terminal and verifies the cursor movement goes upward from the prior content bottom.

## Why

When autocomplete is visible, the hardware cursor is repositioned back into the editor for IME support. On the next render tick, if autocomplete disappears, the shrink-clearing logic was using that IME cursor row as if it were the bottom of the rendered content. That makes the cleanup move in the wrong direction and leaves ghost lines on screen.

Closes #3721

## How

The fix keeps the shrink diff baseline tied to `cursorRow`, which already tracks the bottom of the rendered content. The new regression test exercises the exact sequence:

1. render content with autocomplete rows visible
2. render again with fewer lines
3. assert the differential buffer moves up from the prior content bottom before clearing deleted rows

## Change type

- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [x] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [ ] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [ ] CI passes
- [x] New/updated tests included
- [ ] Manual testing — steps described above
- [ ] No tests needed — explained above

Automated verification:

1. `npm run build`
2. `npm run typecheck:extensions`
3. `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/tests/tui-autocomplete-ghost-lines.test.ts src/tests/tui-non-tty-render-loop.test.ts`

The new regression proves the shrink-clearing path now moves relative to the content bottom rather than the IME cursor row. `CI passes` is left unchecked because I did not run the broader unit/integration suites for this branch.

## AI disclosure

- [x] This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.
