### PR TITLE
fix(subagent): support list-style tools frontmatter

### DIFF
--- a/src/resources/extensions/gsd/tests/subagent-agent-discovery.test.ts
+++ b/src/resources/extensions/gsd/tests/subagent-agent-discovery.test.ts
@@ -42,3 +42,50 @@ test("discoverAgents falls back to legacy .pi/agents when needed", (t) => {
 	assert.equal(discovery.projectAgentsDir, agentsDir);
 	assert.deepEqual(discovery.agents.map((agent) => agent.name), ["ping"]);
 });
+
+test("discoverAgents accepts tools frontmatter as a YAML list", (t) => {
+	const root = makeProjectRoot(t);
+	const agentsDir = join(root, ".gsd", "agents");
+	mkdirSync(agentsDir, { recursive: true });
+	writeFileSync(
+		join(agentsDir, "reviewer.md"),
+		[
+			"---",
+			"name: reviewer",
+			"description: review agent",
+			"tools:",
+			"  - bash",
+			"  - read",
+			"---",
+			"Review code",
+			"",
+		].join("\n"),
+	);
+
+	const discovery = discoverAgents(root, "project");
+
+	assert.deepEqual(discovery.agents.map((agent) => agent.name), ["reviewer"]);
+	assert.deepEqual(discovery.agents[0]?.tools, ["bash", "read"]);
+});
+
+test("discoverAgents still accepts comma-separated tools frontmatter", (t) => {
+	const root = makeProjectRoot(t);
+	const agentsDir = join(root, ".gsd", "agents");
+	mkdirSync(agentsDir, { recursive: true });
+	writeFileSync(
+		join(agentsDir, "reviewer.md"),
+		[
+			"---",
+			"name: reviewer",
+			"description: review agent",
+			"tools: bash, read",
+			"---",
+			"Review code",
+			"",
+		].join("\n"),
+	);
+
+	const discovery = discoverAgents(root, "project");
+
+	assert.deepEqual(discovery.agents[0]?.tools, ["bash", "read"]);
+});

--- a/src/resources/extensions/subagent/agents.ts
+++ b/src/resources/extensions/subagent/agents.ts
@@ -25,6 +25,33 @@ export interface AgentDiscoveryResult {
 	projectAgentsDir: string | null;
 }
 
+interface AgentFrontmatter extends Record<string, unknown> {
+	name?: string;
+	description?: string;
+	tools?: string | string[];
+	model?: string;
+}
+
+function parseAgentTools(value: string | string[] | undefined): string[] | undefined {
+	if (typeof value === "string") {
+		const tools = value
+			.split(",")
+			.map((tool) => tool.trim())
+			.filter(Boolean);
+		return tools.length > 0 ? tools : undefined;
+	}
+
+	if (Array.isArray(value)) {
+		const tools = value
+			.flatMap((tool) => typeof tool === "string" ? tool.split(",") : [])
+			.map((tool) => tool.trim())
+			.filter(Boolean);
+		return tools.length > 0 ? tools : undefined;
+	}
+
+	return undefined;
+}
+
 function loadAgentsFromDir(dir: string, source: "user" | "project"): AgentConfig[] {
 	const agents: AgentConfig[] = [];
 
@@ -51,16 +78,13 @@ function loadAgentsFromDir(dir: string, source: "user" | "project"): AgentConfig
 			continue;
 		}
 
-		const { frontmatter, body } = parseFrontmatter<Record<string, string>>(content);
+		const { frontmatter, body } = parseFrontmatter<AgentFrontmatter>(content);
 
-		if (!frontmatter.name || !frontmatter.description) {
+		if (typeof frontmatter.name !== "string" || typeof frontmatter.description !== "string") {
 			continue;
 		}
 
-		const tools = frontmatter.tools
-			?.split(",")
-			.map((t: string) => t.trim())
-			.filter(Boolean);
+		const tools = parseAgentTools(frontmatter.tools);
 
 		agents.push({
 			name: frontmatter.name,


### PR DESCRIPTION
## TL;DR

**What:** Support YAML list-style `tools` frontmatter in discovered subagent markdown files.
**Why:** `/subagent` currently crashes when an agent definition uses a YAML list instead of a comma-separated string.
**How:** Normalize `tools` from either string or list form during agent discovery and lock both formats with regression tests.

## What

Updates `src/resources/extensions/subagent/agents.ts` so discovered agents can declare `tools` as either a comma-separated string or a YAML list. Adds regression coverage in `src/resources/extensions/gsd/tests/subagent-agent-discovery.test.ts` for both formats.

## Why

Closes #3705.

Some agent packs define `tools` as a YAML array in frontmatter. The old discovery path unconditionally called `.split(",")`, so `/subagent` failed before it could list available agents.

## How

Adds a small `parseAgentTools` normalizer, widens the frontmatter shape to accept `string | string[]`, and preserves the legacy comma-separated format so existing agent files keep working.

## Change type

- [x] `fix` — Bug fix
- [x] `test` — Adding or updating tests
- [ ] `feat` — New feature or capability
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [x] `pi-coding-agent` — Coding agent
- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

Automated verification:

1. `npm run build`
2. `npm run typecheck:extensions`
3. `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/subagent-agent-discovery.test.ts`
4. `npm run secret-scan -- --diff upstream/main`

Manual testing:

1. Create a temporary `.gsd/agents/demo.md` agent file with `tools:` declared as a YAML list.
2. Load `discoverAgents(...)` against that project directory.
3. Confirm the agent loads with `["bash", "read"]` instead of throwing.

Before fix: list-style `tools` frontmatter triggered `frontmatter.tools?.split is not a function`.
After fix: list-style and comma-separated `tools` frontmatter both load cleanly.

## AI disclosure

- [x] This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.