### PR TITLE
fix(docs): stop pointing repo documentation to gsd.build

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ See the full [Changelog](./CHANGELOG.md) for details on every release.
 
 ## Documentation
 
-Full documentation is available at **[gsd.build](https://gsd.build)** (powered by Mintlify) and in the [`docs/`](./docs/) directory:
+Full documentation is available in the [`docs/`](./docs/) directory:
 
 - **[Getting Started](./docs/getting-started.md)** — install, first run, basic usage
 - **[Auto Mode](./docs/auto-mode.md)** — autonomous execution deep-dive

--- a/mintlify-docs/docs.json
+++ b/mintlify-docs/docs.json
@@ -5,7 +5,7 @@
   "logo": {
     "light": "/images/logo.svg",
     "dark": "/images/logo.svg",
-    "href": "https://gsd.build"
+    "href": "https://github.com/gsd-build/gsd-2/tree/main/docs"
   },
   "favicon": "/images/favicon.svg",
   "colors": {


### PR DESCRIPTION
## TL;DR

**What:** Remove repo references that present `gsd.build` as the documentation site.
**Why:** The current link does not lead users to the project docs and gives a misleading first impression.
**How:** Update the README docs section to point at the checked-in docs and retarget the Mintlify logo link to the GitHub docs source.

## What

Removes the `gsd.build` documentation claim from `README.md` and updates `mintlify-docs/docs.json` so the Mintlify logo no longer links there.

## Why

Closes #3710.

`gsd.build` is not serving the repo documentation, but the README currently presents it as the primary docs destination. That sends readers to the wrong place and makes the docs story look sketchy.

## How

Keep the repo-facing documentation path simple and trustworthy:

- point the README back to the checked-in `docs/` directory
- point the Mintlify config at the GitHub docs source instead of `gsd.build`

## Change type

- [x] `fix` — Bug fix
- [x] `docs` — Documentation only
- [ ] `feat` — New feature or capability
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [x] `ci/build` — Workflows, scripts, config
- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [ ] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [ ] New/updated tests included
- [x] Manual testing — steps described above
- [x] No tests needed — explained above

Automated verification:

1. `npm run build`
2. `npm run typecheck:extensions`
3. `npm run secret-scan -- --diff upstream/main`

Manual testing:

1. Visit `https://gsd.build` and confirm it is not serving the repo documentation.
2. Confirm the repo no longer presents `gsd.build` as the docs destination.
3. Confirm the Mintlify config now points to the GitHub docs source instead of `gsd.build`.

Before fix: the README promoted `gsd.build` as the docs site, and the Mintlify config also linked there.
After fix: the repo points readers to the checked-in docs and GitHub docs source instead.

No tests needed:

This is a documentation/config cleanup that removes a misleading external docs link. The change does not alter runtime behavior.

## AI disclosure

- [x] This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.
