### PR TITLE
fix: honor subagent model preferences and expose all prefs model phases

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -175,15 +175,19 @@ models:
     model: claude-opus-4-6
     fallbacks:
       - openrouter/z-ai/glm-5
+  discuss: claude-opus-4-6
   execution: claude-sonnet-4-6
   execution_simple: claude-haiku-4-5-20250414
   completion: claude-sonnet-4-6
+  validation: claude-opus-4-6
   subagent: claude-sonnet-4-6
 ```
 
-**Phases:** `research`, `planning`, `execution`, `execution_simple`, `completion`, `subagent`
+**Phases:** `research`, `planning`, `discuss`, `execution`, `execution_simple`, `completion`, `validation`, `subagent`
 
+- `discuss` — used for milestone/slice discussion and falls back to `planning` when unset
 - `execution_simple` — used for tasks classified as "simple" by the [complexity router](./token-optimization.md#complexity-based-task-routing)
+- `validation` — used for gate evaluation, milestone validation, and doc rewrites; falls back to `planning` when unset
 - `subagent` — model for delegated subagent tasks (scout, researcher, worker)
 - Provider targeting: use `provider/model` format (e.g., `bedrock/claude-sonnet-4-6`) or the `provider` field in object format
 - Omit a key to use whatever model is currently active
@@ -776,9 +780,12 @@ models:
     model: claude-opus-4-6
     fallbacks:
       - openrouter/z-ai/glm-5
+  discuss: claude-opus-4-6
   execution: claude-sonnet-4-6
   execution_simple: claude-haiku-4-5-20250414
   completion: claude-sonnet-4-6
+  validation: claude-opus-4-6
+  subagent: claude-sonnet-4-6
 
 # Token optimization
 token_profile: balanced

--- a/src/resources/extensions/gsd/commands-prefs-wizard.ts
+++ b/src/resources/extensions/gsd/commands-prefs-wizard.ts
@@ -158,6 +158,43 @@ export async function handlePrefsMode(ctx: ExtensionCommandContext, scope: "glob
   ctx.ui.notify(`Saved ${scope} preferences to ${path}`, "info");
 }
 
+export const MODEL_PHASES = [
+  "research",
+  "planning",
+  "discuss",
+  "execution",
+  "execution_simple",
+  "completion",
+  "validation",
+  "subagent",
+] as const;
+
+export function getModelConfigInputValue(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (!value || typeof value !== "object") return "";
+
+  const config = value as Record<string, unknown>;
+  const model = typeof config.model === "string" ? config.model.trim() : "";
+  const provider = typeof config.provider === "string" ? config.provider.trim() : "";
+
+  if (!model) return "";
+  if (provider && !model.includes("/")) return `${provider}/${model}`;
+  return model;
+}
+
+export function formatModelConfigForDisplay(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (!value || typeof value !== "object") return "";
+
+  const config = value as Record<string, unknown>;
+  const primary = getModelConfigInputValue(config);
+  if (!primary) return "(invalid model config)";
+
+  const fallbackCount = Array.isArray(config.fallbacks) ? config.fallbacks.length : 0;
+  const fallbackSuffix = fallbackCount > 0 ? ` (+${fallbackCount} fallback${fallbackCount === 1 ? "" : "s"})` : "";
+  return `${primary}${fallbackSuffix}`;
+}
+
 /** Build short summary strings for each preference category. */
 export function buildCategorySummaries(prefs: Record<string, unknown>): Record<string, string> {
   // Mode
@@ -165,10 +202,10 @@ export function buildCategorySummaries(prefs: Record<string, unknown>): Record<s
   const modeSummary = mode ?? "(not set)";
 
   // Models
-  const models = prefs.models as Record<string, string> | undefined;
+  const models = prefs.models as Record<string, unknown> | undefined;
   let modelsSummary = "(not configured)";
   if (models && Object.keys(models).length > 0) {
-    const parts = Object.entries(models).map(([phase, model]) => `${phase}: ${model}`);
+    const parts = Object.entries(models).map(([phase, model]) => `${phase}: ${formatModelConfigForDisplay(model)}`);
     modelsSummary = parts.join(", ");
   }
 
@@ -284,9 +321,11 @@ async function configureModels(ctx: ExtensionCommandContext, prefs: Record<strin
     });
     providerOptions.push("(keep current)", "(clear)", "(type manually)");
 
-    for (const phase of modelPhases) {
-      const current = models[phase] ?? "";
-      const phaseLabel = `Model for ${phase} phase${current ? ` (current: ${current})` : ""}`;
+    for (const phase of MODEL_PHASES) {
+      const currentValue = models[phase];
+      const currentDisplay = formatModelConfigForDisplay(currentValue);
+      const currentInputValue = getModelConfigInputValue(currentValue);
+      const phaseLabel = `Model for ${phase} phase${currentDisplay ? ` (current: ${currentDisplay})` : ""}`;
 
       // Step 1: pick provider
       const providerChoice = await ctx.ui.select(`${phaseLabel} — choose provider:`, providerOptions);
@@ -300,11 +339,15 @@ async function configureModels(ctx: ExtensionCommandContext, prefs: Record<strin
       if (providerChoice === "(type manually)") {
         const input = await ctx.ui.input(
           `${phaseLabel} — enter model ID:`,
-          current || "e.g. claude-sonnet-4-20250514",
+          currentInputValue || "e.g. claude-sonnet-4-20250514",
         );
         if (input !== null && input !== undefined) {
           const val = input.trim();
-          if (val) models[phase] = val;
+          if (val) {
+            models[phase] = val;
+          } else if (currentValue !== undefined) {
+            delete models[phase];
+          }
         }
         continue;
       }
@@ -327,17 +370,19 @@ async function configureModels(ctx: ExtensionCommandContext, prefs: Record<strin
       }
     }
   } else {
-    for (const phase of modelPhases) {
-      const current = models[phase] ?? "";
+    for (const phase of MODEL_PHASES) {
+      const currentValue = models[phase];
+      const currentDisplay = formatModelConfigForDisplay(currentValue);
+      const currentInputValue = getModelConfigInputValue(currentValue);
       const input = await ctx.ui.input(
-        `Model for ${phase} phase${current ? ` (current: ${current})` : ""}:`,
-        current || "e.g. claude-sonnet-4-20250514",
+        `Model for ${phase} phase${currentDisplay ? ` (current: ${currentDisplay})` : ""}:`,
+        currentInputValue || "e.g. claude-sonnet-4-20250514",
       );
       if (input !== null && input !== undefined) {
         const val = input.trim();
         if (val) {
           models[phase] = val;
-        } else if (current) {
+        } else if (currentValue !== undefined) {
           delete models[phase];
         }
       }
@@ -345,6 +390,8 @@ async function configureModels(ctx: ExtensionCommandContext, prefs: Record<strin
   }
   if (Object.keys(models).length > 0) {
     prefs.models = models;
+  } else {
+    delete prefs.models;
   }
 }
 

--- a/src/resources/extensions/gsd/tests/preferences.test.ts
+++ b/src/resources/extensions/gsd/tests/preferences.test.ts
@@ -17,6 +17,12 @@ import {
   parsePreferencesMarkdown,
   _resetParseWarningFlag,
 } from "../preferences.ts";
+import {
+  MODEL_PHASES,
+  buildCategorySummaries,
+  formatModelConfigForDisplay,
+  getModelConfigInputValue,
+} from "../commands-prefs-wizard.ts";
 import type { GSDPreferences, GSDModelConfigV2, GSDPhaseModelConfig } from "../preferences.ts";
 
 // ── Git preferences ──────────────────────────────────────────────────────────
@@ -168,6 +174,40 @@ test("notification fields validate correctly", () => {
   assert.equal(errors.length, 0);
   assert.equal(preferences.notifications?.enabled, true);
   assert.equal(preferences.notifications?.on_complete, false);
+});
+
+test("wizard exposes all model phases that runtime supports", () => {
+  assert.deepEqual(
+    [...MODEL_PHASES],
+    ["research", "planning", "discuss", "execution", "execution_simple", "completion", "validation", "subagent"],
+  );
+});
+
+test("wizard model display formats provider and fallbacks cleanly", () => {
+  const display = formatModelConfigForDisplay({
+    model: "claude-opus-4-6",
+    provider: "bedrock",
+    fallbacks: ["glm-5", "minimax-m2.5"],
+  });
+  assert.equal(display, "bedrock/claude-opus-4-6 (+2 fallbacks)");
+  assert.equal(getModelConfigInputValue({ model: "claude-opus-4-6", provider: "bedrock" }), "bedrock/claude-opus-4-6");
+});
+
+test("wizard model summaries include object-based phase configs", () => {
+  const summaries = buildCategorySummaries({
+    models: {
+      planning: {
+        model: "claude-opus-4-6",
+        provider: "bedrock",
+        fallbacks: ["glm-5"],
+      },
+      validation: "openai-codex/gpt-5.4",
+    },
+  });
+  assert.equal(
+    summaries.models,
+    "planning: bedrock/claude-opus-4-6 (+1 fallback), validation: openai-codex/gpt-5.4",
+  );
 });
 
 test("cmux fields validate correctly", () => {

--- a/src/resources/extensions/gsd/tests/subagent-model-selection.test.ts
+++ b/src/resources/extensions/gsd/tests/subagent-model-selection.test.ts
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { formatSubagentModelLabel, resolveSubagentLaunchModel } from "../../subagent/model-selection.ts";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const subagentIndexSource = readFileSync(join(__dirname, "../../subagent/index.ts"), "utf-8");
+
+test("subagent preferences override agent frontmatter pins", () => {
+  assert.equal(
+    resolveSubagentLaunchModel("sonnet", "openai-codex/gpt-5.4"),
+    "openai-codex/gpt-5.4",
+  );
+  assert.equal(
+    formatSubagentModelLabel("sonnet", "openai-codex/gpt-5.4"),
+    "openai-codex/gpt-5.4 via prefs; overrides sonnet",
+  );
+});
+
+test("agent frontmatter pin remains fallback when no subagent preference exists", () => {
+  assert.equal(resolveSubagentLaunchModel("sonnet", undefined), "sonnet");
+  assert.equal(formatSubagentModelLabel("sonnet", undefined), "sonnet");
+});
+
+test("subagent tool reads models.subagent from GSD preferences", () => {
+  assert.ok(
+    subagentIndexSource.includes('resolveModelWithFallbacksForUnit("subagent")?.primary'),
+    "subagent runtime should resolve a preferred model from GSD preferences",
+  );
+});

--- a/src/resources/extensions/subagent/index.ts
+++ b/src/resources/extensions/subagent/index.ts
@@ -34,8 +34,9 @@ import {
 	readIsolationMode,
 } from "./isolation.js";
 import { registerWorker, updateWorker } from "./worker-registry.js";
-import { loadEffectiveGSDPreferences } from "../gsd/preferences.js";
+import { loadEffectiveGSDPreferences, resolveModelWithFallbacksForUnit } from "../gsd/preferences.js";
 import { CmuxClient, shellEscape } from "../cmux/index.js";
+import { formatSubagentModelLabel, resolveSubagentLaunchModel } from "./model-selection.js";
 
 const MAX_PARALLEL_TASKS = 8;
 const MAX_CONCURRENCY = 4;
@@ -263,9 +264,11 @@ function buildSubagentProcessArgs(
 	agent: AgentConfig,
 	task: string,
 	tmpPromptPath: string | null,
+	preferredModel: string | undefined,
 ): string[] {
 	const args: string[] = ["--mode", "json", "-p", "--no-session"];
-	if (agent.model) args.push("--model", agent.model);
+	const launchModel = resolveSubagentLaunchModel(agent.model, preferredModel);
+	if (launchModel) args.push("--model", launchModel);
 	if (agent.tools && agent.tools.length > 0) args.push("--tools", agent.tools.join(","));
 	if (tmpPromptPath) args.push("--append-system-prompt", tmpPromptPath);
 	args.push(`Task: ${task}`);
@@ -300,7 +303,7 @@ function processSubagentEventLine(
 				currentResult.usage.cost += usage.cost?.total || 0;
 				currentResult.usage.contextTokens = usage.totalTokens || 0;
 			}
-			if (!currentResult.model && msg.model) currentResult.model = msg.model;
+			if (msg.model) currentResult.model = msg.model;
 			if (msg.stopReason) currentResult.stopReason = msg.stopReason;
 			if (msg.errorMessage) currentResult.errorMessage = msg.errorMessage;
 		}
@@ -335,6 +338,7 @@ async function runSingleAgent(
 	signal: AbortSignal | undefined,
 	onUpdate: OnUpdateCallback | undefined,
 	makeDetails: (results: SingleResult[]) => SubagentDetails,
+	preferredModel: string | undefined,
 ): Promise<SingleResult> {
 	const agent = agents.find((a) => a.name === agentName);
 
@@ -363,7 +367,7 @@ async function runSingleAgent(
 		messages: [],
 		stderr: "",
 		usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, contextTokens: 0, turns: 0 },
-		model: agent.model,
+		model: resolveSubagentLaunchModel(agent.model, preferredModel),
 		step,
 	};
 
@@ -382,7 +386,7 @@ async function runSingleAgent(
 			tmpPromptDir = tmp.dir;
 			tmpPromptPath = tmp.filePath;
 		}
-		const args = buildSubagentProcessArgs(agent, task, tmpPromptPath);
+		const args = buildSubagentProcessArgs(agent, task, tmpPromptPath, preferredModel);
 		let wasAborted = false;
 
 		const exitCode = await new Promise<number>((resolve) => {
@@ -462,10 +466,11 @@ async function runSingleAgentInCmuxSplit(
 	signal: AbortSignal | undefined,
 	onUpdate: OnUpdateCallback | undefined,
 	makeDetails: (results: SingleResult[]) => SubagentDetails,
+	preferredModel: string | undefined,
 ): Promise<SingleResult> {
 	const agent = agents.find((a) => a.name === agentName);
 	if (!agent) {
-		return runSingleAgent(defaultCwd, agents, agentName, task, cwd, step, signal, onUpdate, makeDetails);
+		return runSingleAgent(defaultCwd, agents, agentName, task, cwd, step, signal, onUpdate, makeDetails, preferredModel);
 	}
 
 	let tmpPromptDir: string | null = null;
@@ -480,7 +485,7 @@ async function runSingleAgentInCmuxSplit(
 		messages: [],
 		stderr: "",
 		usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, contextTokens: 0, turns: 0 },
-		model: agent.model,
+		model: resolveSubagentLaunchModel(agent.model, preferredModel),
 		step,
 	};
 
@@ -510,12 +515,16 @@ async function runSingleAgentInCmuxSplit(
 			? await cmuxClient.createSplit(directionOrSurfaceId as "right" | "down" | "left" | "up")
 			: directionOrSurfaceId;
 		if (!cmuxSurfaceId) {
-			return runSingleAgent(defaultCwd, agents, agentName, task, cwd, step, signal, onUpdate, makeDetails);
+			return runSingleAgent(defaultCwd, agents, agentName, task, cwd, step, signal, onUpdate, makeDetails, preferredModel);
 		}
 
 		const bundledPaths = (process.env.GSD_BUNDLED_EXTENSION_PATHS ?? "").split(path.delimiter).map((s) => s.trim()).filter(Boolean);
 		const extensionArgs = bundledPaths.flatMap((p) => ["--extension", p]);
-		const processArgs = [process.env.GSD_BIN_PATH!, ...extensionArgs, ...buildSubagentProcessArgs(agent, task, tmpPromptPath)];
+		const processArgs = [
+			process.env.GSD_BIN_PATH!,
+			...extensionArgs,
+			...buildSubagentProcessArgs(agent, task, tmpPromptPath, preferredModel),
+		];
 		// Normalize all paths to forward slashes before embedding in bash strings.
 		// On Windows, backslashes are interpreted as escape characters by bash,
 		// mangling paths like C:\Users\user into C:Useruser (#1436).
@@ -530,7 +539,7 @@ async function runSingleAgentInCmuxSplit(
 
 		const sent = await cmuxClient.sendSurface(cmuxSurfaceId, `bash -lc ${shellEscape(innerScript)}`);
 		if (!sent) {
-			return runSingleAgent(defaultCwd, agents, agentName, task, cwd, step, signal, onUpdate, makeDetails);
+			return runSingleAgent(defaultCwd, agents, agentName, task, cwd, step, signal, onUpdate, makeDetails, preferredModel);
 		}
 
 		const finished = await waitForFile(exitPath, signal);
@@ -625,9 +634,11 @@ export default function (pi: ExtensionAPI) {
 				ctx.ui.notify("No agents found. Add .md files to ~/.gsd/agent/agents/ or .gsd/agents/", "warning");
 				return;
 			}
-			const lines = discovery.agents.map(
-				(a) => `  ${a.name} [${a.source}]${a.model ? ` (${a.model})` : ""}: ${a.description}`,
-			);
+			const preferredSubagentModel = resolveModelWithFallbacksForUnit("subagent")?.primary;
+			const lines = discovery.agents.map((a) => {
+				const modelLabel = formatSubagentModelLabel(a.model, preferredSubagentModel);
+				return `  ${a.name} [${a.source}]${modelLabel ? ` (${modelLabel})` : ""}: ${a.description}`;
+			});
 			ctx.ui.notify(`Available agents (${discovery.agents.length}):\n${lines.join("\n")}`, "info");
 		},
 	});
@@ -657,6 +668,7 @@ export default function (pi: ExtensionAPI) {
 			const discovery = discoverAgents(ctx.cwd, agentScope);
 			const agents = discovery.agents;
 			const confirmProjectAgents = params.confirmProjectAgents ?? false;
+			const preferredSubagentModel = resolveModelWithFallbacksForUnit("subagent")?.primary;
 			const cmuxClient = CmuxClient.fromPreferences(loadEffectiveGSDPreferences()?.preferences);
 			const cmuxSplitsEnabled = cmuxClient.getConfig().splits;
 
@@ -749,6 +761,7 @@ export default function (pi: ExtensionAPI) {
 						signal,
 						chainUpdate,
 						makeDetails("chain"),
+						preferredSubagentModel,
 					);
 					results.push(result);
 
@@ -839,6 +852,7 @@ export default function (pi: ExtensionAPI) {
 								}
 							},
 							makeDetails("parallel"),
+							preferredSubagentModel,
 						)
 						: runSingleAgent(
 							ctx.cwd,
@@ -855,6 +869,7 @@ export default function (pi: ExtensionAPI) {
 								}
 							},
 							makeDetails("parallel"),
+							preferredSubagentModel,
 						);
 					let result = await runTask();
 
@@ -913,6 +928,7 @@ export default function (pi: ExtensionAPI) {
 							signal,
 							onUpdate,
 							makeDetails("single"),
+							preferredSubagentModel,
 						)
 						: await runSingleAgent(
 							ctx.cwd,
@@ -924,6 +940,7 @@ export default function (pi: ExtensionAPI) {
 							signal,
 							onUpdate,
 							makeDetails("single"),
+							preferredSubagentModel,
 						);
 
 					// Capture and merge delta if isolated

--- a/src/resources/extensions/subagent/model-selection.ts
+++ b/src/resources/extensions/subagent/model-selection.ts
@@ -1,0 +1,29 @@
+export function resolveSubagentLaunchModel(
+  agentModel: string | undefined,
+  preferredModel: string | undefined,
+): string | undefined {
+  const preferred = preferredModel?.trim();
+  if (preferred) return preferred;
+
+  const pinned = agentModel?.trim();
+  return pinned || undefined;
+}
+
+export function formatSubagentModelLabel(
+  agentModel: string | undefined,
+  preferredModel: string | undefined,
+): string {
+  const resolved = resolveSubagentLaunchModel(agentModel, preferredModel);
+  if (!resolved) return "";
+
+  const preferred = preferredModel?.trim();
+  const pinned = agentModel?.trim();
+  if (preferred) {
+    if (pinned && pinned !== preferred) {
+      return `${preferred} via prefs; overrides ${pinned}`;
+    }
+    return `${preferred} via prefs`;
+  }
+
+  return resolved;
+}


### PR DESCRIPTION
## TL;DR

**What:** Make `/gsd prefs` expose all runtime-supported model phases and make generic subagent launches honor `models.subagent` preferences.
**Why:** The runtime already supports `discuss`, `execution_simple`, `validation`, and `subagent`, but the prefs wizard hid part of that surface and generic subagent launches could still prefer agent frontmatter `model` pins.
**How:** Replace the wizard's hardcoded phase list with the full supported set, normalize wizard display/input handling for object model configs, and resolve the preferred subagent model before building child-process args.

## What

This change keeps the fix narrowly scoped to model routing and preferences UX.

| File | Change |
|------|--------|
| `src/resources/extensions/gsd/commands-prefs-wizard.ts` | Expose all runtime-supported model phases in `/gsd prefs` and render object model configs cleanly in prompts and summaries. |
| `src/resources/extensions/subagent/index.ts` | Resolve the preferred subagent model from GSD preferences and pass it through every generic subagent launch path. |
| `src/resources/extensions/subagent/model-selection.ts` | Add a tiny precedence helper so `models.subagent` overrides agent frontmatter `model` when configured. |
| `src/resources/extensions/gsd/tests/preferences.test.ts` | Add regression coverage for wizard phase coverage and object-model summary/display behavior. |
| `src/resources/extensions/gsd/tests/subagent-model-selection.test.ts` | Add regression coverage for subagent preference-overrides-frontmatter precedence. |
| `docs/configuration.md` | Align the documented model phase list with the runtime-supported phase set. |

## Why

The root cause was split across two seams:

1. `commands-prefs-wizard.ts` used a hardcoded phase list of `research`, `planning`, `execution`, and `completion`, even though runtime model resolution also supports `discuss`, `execution_simple`, `validation`, and `subagent`.
2. `subagent/index.ts` only forwarded `agent.model` into child-process args, so a generic subagent launch could bypass `models.subagent` even when the user had configured that preference.

That combination made model routing harder to understand and made the configured preferences a weaker source of truth than intended.

Related to #3706

## How

- Define one exported wizard phase list that matches the runtime-supported phase set.
- Normalize object-shaped model configs into a single display/input string so the wizard does not show misleading `[object Object]`-style output and can preserve provider-qualified values cleanly.
- Resolve the preferred subagent model once from `resolveModelWithFallbacksForUnit("subagent")?.primary` and thread it through single, parallel, chain, and cmux-backed launch paths.
- Keep the change intentionally small: no refactor of the wider model router, no change to unrelated agent-loading behavior, and no new config format.

## Test Evidence

### Reproduction

1. Configure `models.subagent` in `PREFERENCES.md`.
2. Use an agent file that also declares a frontmatter `model:`.
3. Run a generic subagent task or inspect `/subagent` output.
4. Before this fix, the frontmatter pin could still win and the prefs wizard did not expose the full runtime model surface.

### Expected behavior after fix

- `/gsd prefs` exposes `research`, `planning`, `discuss`, `execution`, `execution_simple`, `completion`, `validation`, and `subagent`.
- Generic subagent launches prefer `models.subagent` when it is configured.
- Wizard summaries and prompts display object model configs in a readable form.

### Verification

- `npm run test:compile`
- `node --import ./scripts/dist-test-resolve.mjs --experimental-test-isolation=process --test-reporter=./scripts/test-reporter-compact.mjs --test dist-test/src/resources/extensions/gsd/tests/preferences.test.js dist-test/src/resources/extensions/gsd/tests/subagent-model-selection.test.js`

---

> AI-assisted contribution — reviewed and tested by contributor.

- [x] `fix`
