### PR TITLE
fix(gsd): suppress repeated preferences section warnings

### DIFF
--- a/src/resources/extensions/gsd/preferences.ts
+++ b/src/resources/extensions/gsd/preferences.ts
@@ -200,11 +200,13 @@ function loadPreferencesFile(path: string, scope: "global" | "project"): LoadedG
 }
 
 let _warnedUnrecognizedFormat = false;
+let _warnedSectionParse = false;
 
 /** @internal Reset the warn-once flags — exported for testing only. */
 export function _resetParseWarningFlag(): void {
   _warnedUnrecognizedFormat = false;
   _warnedFrontmatterParse = false;
+  _warnedSectionParse = false;
 }
 
 /** @internal Exported for testing only */
@@ -309,7 +311,10 @@ function parseHeadingListFormat(content: string): GSDPreferences {
 
       typed[targetSection] = value;
     } catch (e) {
-      logWarning("guided", `preferences section parse failed: ${(e as Error).message}`);
+      if (!_warnedSectionParse) {
+        _warnedSectionParse = true;
+        logWarning("guided", `preferences section parse failed: ${(e as Error).message}`);
+      }
     }
   }
 

--- a/src/resources/extensions/gsd/tests/preferences.test.ts
+++ b/src/resources/extensions/gsd/tests/preferences.test.ts
@@ -17,6 +17,7 @@ import {
   parsePreferencesMarkdown,
   _resetParseWarningFlag,
 } from "../preferences.ts";
+import { _resetLogs, peekLogs } from "../workflow-logger.ts";
 import type { GSDPreferences, GSDModelConfigV2, GSDPhaseModelConfig } from "../preferences.ts";
 
 // ── Git preferences ──────────────────────────────────────────────────────────
@@ -420,6 +421,25 @@ test("parsePreferencesMarkdown parses heading+list format without frontmatter (#
   const result = parsePreferencesMarkdown(content);
   assert.notEqual(result, null, "heading+list content should be parsed");
   assert.deepStrictEqual(result!.git, { isolation: "none" });
+});
+
+test("section parse warning is emitted at most once for heading+list YAML failures (#3759)", () => {
+  _resetParseWarningFlag();
+  _resetLogs();
+
+  const content = `## Git
+bad: [
+`;
+
+  parsePreferencesMarkdown(content);
+  parsePreferencesMarkdown(content);
+  parsePreferencesMarkdown(content);
+
+  const warnings = peekLogs().filter((entry) => entry.component === "guided" && entry.message.includes("preferences section parse failed"));
+  assert.equal(warnings.length, 1, `expected exactly 1 guided warning, got ${warnings.length}`);
+
+  _resetParseWarningFlag();
+  _resetLogs();
 });
 
 // ── Experimental preferences ─────────────────────────────────────────────────


### PR DESCRIPTION
## TL;DR

**What:** Suppress repeated guided warnings when the same heading+list preferences section fails to parse.
**Why:** A malformed heading+list preferences block currently logs the same section-parse warning every time preferences are re-read, which creates noisy repeated warnings for one unchanged error.
**How:** Add a dedicated warn-once flag for section parse failures and lock it with a regression test.

## What

This change updates the heading+list preferences parser in `src/resources/extensions/gsd/preferences.ts` so section parse failures only emit one guided warning per process instead of logging the same warning on every read.

It also adds a regression test in `src/resources/extensions/gsd/tests/preferences.test.ts` covering repeated parses of the same malformed heading+list block.

## Why

Closes #3759

Malformed heading+list preferences should fail closed, but they should not spam the same warning repeatedly when preferences are loaded again and again. The current behavior makes one bad block look noisier than it is and buries more useful log signal.

## How

The parser already had warn-once flags for other preferences parse paths. This applies the same idea to heading+list section parse failures:

- add `_warnedSectionParse`
- reset it in the existing test-only reset helper
- guard the `preferences section parse failed` warning behind that flag
- verify via regression test that repeated parses only record one guided warning

## Change type

- [x] `fix` — Bug fix
- [x] `test` — Adding or updating tests
- [ ] `feat` — New feature or capability
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [x] `gsd extension` — GSD workflow
- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

Automated verification:

1. `npm run build`
2. `npm run typecheck:extensions`
3. `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/preferences.test.ts`

Manual testing:

1. Hand-ran `parsePreferencesMarkdown(...)` three times against:

   ```yaml
   ## Git
   bad: [
   ```

2. Before fix: the same guided section-parse warning was emitted repeatedly for the same malformed content.
3. After fix: parsing still fails closed, but only one guided warning is recorded for repeated reads of the same malformed section.

Additional context:

- A broader `npm run test:unit` sweep still hits two failures that also reproduce on clean `upstream/main`:
  - `src/resources/extensions/gsd/tests/flat-rate-routing-guard.test.ts`
  - `src/resources/extensions/gsd/tests/uat-stuck-loop-orphaned-worktree.test.ts`

## AI disclosure

- [x] This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.
