### PR TITLE
fix(claude-code): use native Windows claude lookup

### DIFF
--- a/src/resources/extensions/claude-code-cli/stream-adapter.ts
+++ b/src/resources/extensions/claude-code-cli/stream-adapter.ts
@@ -50,6 +50,17 @@ function createAssistantStream(): AssistantMessageEventStream {
 
 let cachedClaudePath: string | null = null;
 
+export function getClaudeLookupCommand(platform: NodeJS.Platform = process.platform): string {
+	return platform === "win32" ? "where claude" : "which claude";
+}
+
+export function parseClaudeLookupOutput(output: Buffer | string): string {
+	return output
+		.toString()
+		.trim()
+		.split(/\r?\n/)[0] ?? "";
+}
+
 /**
  * Resolve the path to the system-installed `claude` binary.
  * The SDK defaults to a bundled cli.js which doesn't exist when
@@ -58,9 +69,7 @@ let cachedClaudePath: string | null = null;
 function getClaudePath(): string {
 	if (cachedClaudePath) return cachedClaudePath;
 	try {
-		cachedClaudePath = execSync("which claude", { timeout: 5_000, stdio: "pipe" })
-			.toString()
-			.trim();
+		cachedClaudePath = parseClaudeLookupOutput(execSync(getClaudeLookupCommand(), { timeout: 5_000, stdio: "pipe" }));
 	} catch {
 		cachedClaudePath = "claude"; // fall back to PATH resolution
 	}

--- a/src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts
+++ b/src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts
@@ -4,6 +4,8 @@ import {
 	makeStreamExhaustedErrorMessage,
 	buildPromptFromContext,
 	buildSdkOptions,
+	getClaudeLookupCommand,
+	parseClaudeLookupOutput,
 } from "../stream-adapter.ts";
 import type { Context, Message } from "@gsd/pi-ai";
 
@@ -124,5 +126,21 @@ describe("stream-adapter — session persistence (#2859)", () => {
 			Array.isArray(opusOpts.betas) && opusOpts.betas.length === 0,
 			"non-sonnet models should have empty betas",
 		);
+	});
+});
+
+describe("stream-adapter — Windows Claude path lookup (#3770)", () => {
+	test("getClaudeLookupCommand uses where on Windows", () => {
+		assert.equal(getClaudeLookupCommand("win32"), "where claude");
+	});
+
+	test("getClaudeLookupCommand uses which on non-Windows platforms", () => {
+		assert.equal(getClaudeLookupCommand("darwin"), "which claude");
+		assert.equal(getClaudeLookupCommand("linux"), "which claude");
+	});
+
+	test("parseClaudeLookupOutput keeps the first native path from multi-line lookup output", () => {
+		const output = "C:\\Users\\Binoy\\.local\\bin\\claude.exe\r\nC:\\Program Files\\Claude\\claude.exe\r\n";
+		assert.equal(parseClaudeLookupOutput(output), "C:\\Users\\Binoy\\.local\\bin\\claude.exe");
 	});
 });


### PR DESCRIPTION
## TL;DR

**What:** Use native Windows Claude binary lookup for the Claude Code provider and normalize multi-line lookup output.
**Why:** `which claude` can return a Git Bash/MSYS POSIX path on Windows, which then fails when the native Claude binary is spawned.
**How:** Resolve the lookup command per platform, keep only the first returned path, and cover the behavior with targeted tests.

## What

This change updates `src/resources/extensions/claude-code-cli/stream-adapter.ts` so Claude binary discovery uses the right command per platform:

- `where claude` on Windows
- `which claude` elsewhere

It also normalizes lookup output to the first returned path, which matters because `where` can return multiple matches.

The regression coverage lives in `src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts`.

## Why

Closes #3770

On Windows shells like Git Bash / MSYS2, `which claude` can return a POSIX-style path such as `/c/Users/...`, which the native process launch path cannot use directly. That makes the Claude Code provider fail even when `claude.exe` is correctly installed and available.

## How

The adapter now:

- exposes a small platform-aware lookup helper
- parses lookup output through a dedicated first-line normalizer
- keeps the rest of the provider flow unchanged

The new regression tests verify:

- Windows uses `where claude`
- non-Windows platforms still use `which claude`
- multi-line lookup output resolves to the first native path

## Change type

- [x] `fix` — Bug fix
- [x] `test` — Adding or updating tests
- [ ] `feat` — New feature or capability
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [x] `pi-coding-agent` — Coding agent
- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

Automated verification:

1. `npm run build`
2. `npm run typecheck:extensions`
3. `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts`

Manual testing:

1. Hand-ran the lookup helpers directly.
2. Confirmed `getClaudeLookupCommand("win32") === "where claude"`.
3. Confirmed `parseClaudeLookupOutput(...)` keeps the first Windows-native path from multi-line lookup output.

Additional context:

- A broader `npm run test:unit` sweep still hits two failures that also reproduce on clean `upstream/main`:
  - `src/resources/extensions/gsd/tests/flat-rate-routing-guard.test.ts`
  - `src/resources/extensions/gsd/tests/uat-stuck-loop-orphaned-worktree.test.ts`

## AI disclosure

- [x] This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.
