### PR TITLE
fix(cli): clean up stdin after sessions command readline interface closes

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -281,6 +281,14 @@ if (cliFlags.messages[0] === 'sessions') {
   })
   rl.close()
 
+  // Clean up stdin state left by readline.createInterface().
+  // Without this, downstream TUI initialization gets corrupted listeners and exhibits
+  // duplicate terminal I/O. Match the pattern used after onboarding cleanup.
+  process.stdin.removeAllListeners('data')
+  process.stdin.removeAllListeners('keypress')
+  if (process.stdin.setRawMode) process.stdin.setRawMode(false)
+  process.stdin.pause()
+
   const choice = parseInt(answer, 10)
   if (isNaN(choice) || choice < 1 || choice > toShow.length) {
     process.stderr.write(chalk.dim('Cancelled.\n'))


### PR DESCRIPTION
## TL;DR

**What:** Clean up stdin event listeners after the sessions command closes its readline interface.

**Why:** Missing cleanup left stdin in a corrupted state, causing duplicate terminal I/O and making the CLI unusable when the TUI initialized.

**How:** Added proper stdin cleanup (removing listeners, resetting raw mode, pausing) to match the pattern already used after onboarding.

## What

The `gsd sessions` command uses `readline.createInterface()` to prompt users for session selection. After the readline interface closes with `rl.close()`, stdin was left with lingering event listeners and state issues that corrupted the terminal when the TUI subsequently took over input handling.

## Why

When users ran `gsd sessions` and selected a session to resume, the terminal CLI would display duplicated output and become unusable. The root cause was that Node.js's readline module attaches internal event listeners to stdin ('data', 'keypress') that remain active even after the interface is closed. These stale listeners interfere with the TUI's input initialization.

Closes #3718

## How

Added stdin cleanup immediately after `rl.close()` in the sessions command block:
- `process.stdin.removeAllListeners('data')` — removes readline data listeners
- `process.stdin.removeAllListeners('keypress')` — removes keypress listeners
- `process.stdin.setRawMode(false)` — resets raw mode flag
- `process.stdin.pause()` — pauses stdin for clean handoff to TUI

This mirrors the proven cleanup pattern already in use after the onboarding wizard flow, ensuring stdin is in a clean state when the interactive mode TUI takes over.

---

**PR Type:** `fix`

**AI-Assisted:** Yes — This PR was generated with AI assistance. The fix has been validated and the implementation follows established patterns in the codebase.