### PR TITLE
fix(gsd): ignore filename headings in parsePlan

### DIFF
--- a/src/resources/extensions/gsd/parsers-legacy.ts
+++ b/src/resources/extensions/gsd/parsers-legacy.ts
@@ -210,7 +210,9 @@ function _parsePlanImpl(content: string): SlicePlan {
     for (const line of lines) {
       const cbMatch = line.match(/^-\s+\[([ xX])\]\s+\*\*([\w.]+):\s+(.+?)\*\*\s*(.*)/);
       // Heading-style: ### T01 -- Title, ### T01: Title, ### T01 — Title
-      const hdMatch = !cbMatch ? line.match(/^#{2,4}\s+([\w.]+)\s*(?:--|—|:)\s*(.+)/) : null;
+      const hdMatch = !cbMatch
+        ? line.match(/^#{2,4}\s+([A-Z]+\d+(?:\.[A-Z]+\d+)*)\s*(?:--|—|:)\s*(.+)/)
+        : null;
       if (cbMatch || hdMatch) {
         const taskId = cbMatch ? cbMatch[2] : hdMatch![1];
         // Skip tasks already found in the Tasks section

--- a/src/resources/extensions/gsd/tests/parsers.test.ts
+++ b/src/resources/extensions/gsd/tests/parsers.test.ts
@@ -703,6 +703,31 @@ Widget description.
   assert.deepStrictEqual(p.tasks[0].title, 'Build the widget', 'em-dash heading T01 title');
 });
 
+test('parsePlan: filename subheadings do not become task ids', () => {
+  const content = `# S15: Filename Headings
+
+**Goal:** Ignore file-reference subheadings inside task descriptions.
+**Demo:** Only real task ids are parsed.
+
+## Tasks
+
+- [ ] **T01: First task** \`est:10m\`
+  Implement the feature.
+
+### constraints.py — \`add_off_request_tiered()\`
+- preserve behavior
+
+### annotations.py — \`annotate()\`
+- keep metadata
+`;
+
+  const p = parsePlan(content);
+  assert.deepStrictEqual(p.tasks.map((task) => task.id), ['T01'], 'filename subheadings should not create extra tasks');
+  assert.deepStrictEqual(p.tasks[0].title, 'First task', 'real task should still parse normally');
+  assert.ok(p.tasks[0].description.includes('preserve behavior'), 'detail lines under filename subheadings should remain attached to the task');
+  assert.ok(p.tasks[0].description.includes('keep metadata'), 'later detail lines should also remain attached to the task');
+});
+
 test('parsePlan: mixed checkbox and heading-style tasks', () => {
   const content = `# S14: Mixed Format
 


### PR DESCRIPTION
## TL;DR

**What:** Stop `parsePlan` from treating filename subheadings like `### constraints.py — ...` as task entries.
**Why:** Those filename headings create fake task IDs such as `constraints.py`, which leaves slices permanently pending and can trigger plan-slice redispatch loops.
**How:** Tighten the heading-style task ID matcher to only accept real task ID shapes and lock the filename case with a parser regression test.

## What

This change narrows the heading-style task parser in `src/resources/extensions/gsd/parsers-legacy.ts` so it only recognizes real task IDs in heading form.

It also adds a regression test in `src/resources/extensions/gsd/tests/parsers.test.ts` covering the reported case where markdown subheadings reference filenames inside a task description.

## Why

Closes #3778

`parsePlan` currently accepts heading-style entries with a very broad identifier match, so subheadings like:

- `### constraints.py — ...`
- `### annotations.py — ...`

get parsed as real task entries. That creates spurious pending tasks in the database and can keep a slice stuck in a redispatch loop even though the real tasks are already complete.

## How

The fix is intentionally small:

- keep the existing heading-style task support
- restrict the heading-style ID matcher to real task-ID shapes instead of arbitrary `[\w.]+`
- add a regression test proving that filename subheadings no longer create extra task IDs while their detail lines still stay attached to the surrounding task description

## Change type

- [x] `fix` — Bug fix
- [x] `test` — Adding or updating tests

## Scope

- [x] `gsd extension` — GSD workflow

## Breaking changes

- [x] No breaking changes

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above

Automated verification:

1. `npm run build`
2. `npm run typecheck:extensions`
3. `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/parsers.test.ts`

Manual repro:

1. Run `parsePlan(...)` against a slice plan containing one real task plus filename subheadings like `### constraints.py — ...` and `### annotations.py — ...`.
2. Before the fix: the parsed task IDs include `T01`, `constraints.py`, and `annotations.py`.
3. After the fix: the parsed task IDs contain only `T01`, and the detail lines under those filename subheadings remain attached to the real task description.

## AI disclosure

- [x] This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.
