### PR TITLE
fix(ui): display 'anthropic-api' in model selector to distinguish from claude-code

### DIFF
--- a/packages/pi-coding-agent/src/modes/interactive/components/__tests__/provider-display-name.test.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/components/__tests__/provider-display-name.test.ts
@@ -1,0 +1,16 @@
+// GSD-2 — Provider display name mapping tests
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { providerDisplayName } from "../model-selector.js";
+
+describe("providerDisplayName", () => {
+	test("renames 'anthropic' to 'anthropic-api'", () => {
+		assert.equal(providerDisplayName("anthropic"), "anthropic-api");
+	});
+
+	test("passes through unmapped providers unchanged", () => {
+		assert.equal(providerDisplayName("claude-code"), "claude-code");
+		assert.equal(providerDisplayName("openai"), "openai");
+		assert.equal(providerDisplayName("bedrock"), "bedrock");
+	});
+});

--- a/packages/pi-coding-agent/src/modes/interactive/components/model-selector.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/components/model-selector.ts
@@ -20,7 +20,7 @@ const PROVIDER_DISPLAY_NAMES: Record<string, string> = {
 	anthropic: "anthropic-api",
 };
 
-function providerDisplayName(provider: string): string {
+export function providerDisplayName(provider: string): string {
 	return PROVIDER_DISPLAY_NAMES[provider] ?? provider;
 }
 


### PR DESCRIPTION
## Summary

- Renames `anthropic` to `anthropic-api` in the model selector UI to clearly distinguish direct API access from the `claude-code` CLI provider
- Helps subscription users understand which provider routes through the CLI (uses subscription) vs direct API (requires API key / extra usage)

## Context

Follow-up to #3794. With both `claude-code` and `anthropic` showing models with the same IDs, users need a clear visual distinction in the model picker.

## Test plan

- [x] Build passes
- [x] Display-only change — no logic affected