### PR TITLE
fix(gsd): preserve experimental preferences in merges

### DIFF
--- a/src/resources/extensions/gsd/preferences.ts
+++ b/src/resources/extensions/gsd/preferences.ts
@@ -389,6 +389,9 @@ function mergePreferences(base: GSDPreferences, override: GSDPreferences): GSDPr
     github: (base.github || override.github)
       ? { ...(base.github ?? {}), ...(override.github ?? {}) } as import("../github-sync/types.js").GitHubSyncConfig
       : undefined,
+    experimental: (base.experimental || override.experimental)
+      ? { ...(base.experimental ?? {}), ...(override.experimental ?? {}) }
+      : undefined,
     service_tier: override.service_tier ?? base.service_tier,
     forensics_dedup: override.forensics_dedup ?? base.forensics_dedup,
     show_token_cost: override.show_token_cost ?? base.show_token_cost,

--- a/src/resources/extensions/gsd/tests/preferences.test.ts
+++ b/src/resources/extensions/gsd/tests/preferences.test.ts
@@ -10,10 +10,14 @@
 
 import test from "node:test";
 import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
   validatePreferences,
   applyModeDefaults,
   getIsolationMode,
+  loadEffectiveGSDPreferences,
   parsePreferencesMarkdown,
   _resetParseWarningFlag,
 } from "../preferences.ts";
@@ -482,6 +486,55 @@ test("experimental.rtk parses correctly from preferences markdown", () => {
   const prefs = parsePreferencesMarkdown(content);
   assert.notEqual(prefs, null);
   assert.equal(prefs!.experimental?.rtk, true);
+});
+
+test("loadEffectiveGSDPreferences preserves experimental prefs across global+project merge", () => {
+  const originalCwd = process.cwd();
+  const originalGsdHome = process.env.GSD_HOME;
+  const tempProject = mkdtempSync(join(tmpdir(), "gsd-prefs-project-"));
+  const tempGsdHome = mkdtempSync(join(tmpdir(), "gsd-prefs-home-"));
+
+  try {
+    mkdirSync(join(tempProject, ".gsd"), { recursive: true });
+
+    writeFileSync(
+      join(tempGsdHome, "preferences.md"),
+      [
+        "---",
+        "version: 1",
+        "experimental:",
+        "  rtk: true",
+        "---",
+      ].join("\n"),
+      "utf-8",
+    );
+
+    writeFileSync(
+      join(tempProject, ".gsd", "PREFERENCES.md"),
+      [
+        "---",
+        "version: 1",
+        "git:",
+        "  isolation: none",
+        "---",
+      ].join("\n"),
+      "utf-8",
+    );
+
+    process.env.GSD_HOME = tempGsdHome;
+    process.chdir(tempProject);
+
+    const loaded = loadEffectiveGSDPreferences();
+    assert.notEqual(loaded, null);
+    assert.equal(loaded!.preferences.experimental?.rtk, true);
+    assert.equal(loaded!.preferences.git?.isolation, "none");
+  } finally {
+    process.chdir(originalCwd);
+    if (originalGsdHome === undefined) delete process.env.GSD_HOME;
+    else process.env.GSD_HOME = originalGsdHome;
+    rmSync(tempProject, { recursive: true, force: true });
+    rmSync(tempGsdHome, { recursive: true, force: true });
+  }
 });
 
 test("experimental.rtk defaults to off in new project preferences", () => {


### PR DESCRIPTION
## TL;DR

**What:** Preserve `experimental` preferences when global and project GSD preferences are merged.
**Why:** `experimental.rtk` was silently dropped as soon as a project-level preferences file existed, which disabled RTK unexpectedly.
**How:** Shallow-merge `experimental` in `mergePreferences()` and lock the behavior with a real `loadEffectiveGSDPreferences()` regression.

## What

This change updates the GSD preferences merge path so `experimental` is retained when both global and project preferences are present.

It also adds a regression test that exercises the real effective-preferences loader using a temporary `GSD_HOME` plus a project `.gsd/PREFERENCES.md`.

## Why

Closes #3840.

`mergePreferences()` explicitly merged many object fields but omitted `experimental`, so effective preferences silently lost `experimental.rtk` whenever both global and project preferences existed.

## How

The merge layer now shallow-merges `experimental` the same way it already does for similar preference objects.

The new regression test proves the actual reported scenario:
- global preferences enable `experimental.rtk`
- project preferences define an unrelated setting
- the merged effective preferences still keep `experimental.rtk: true`

## Change type

- [x] `fix` — Bug fix
- [x] `test` — Adding or updating tests

## Scope

- [x] `gsd extension` — GSD workflow

## Breaking changes

- [x] No breaking changes

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above

Automated verification:

1. `npm run build`
2. `npm run typecheck:extensions`
3. `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/preferences.test.ts`

Manual testing:

1. Reproduced on current `upstream/main` with a temp `GSD_HOME/preferences.md` containing `experimental.rtk: true` plus a project `.gsd/PREFERENCES.md` containing only `git.isolation`.
2. Before this fix, `loadEffectiveGSDPreferences()?.preferences.experimental` resolved to `undefined`.
3. After this fix, the same repro resolves to `{ rtk: true }` while preserving the project `git.isolation` setting.

## AI disclosure

- [x] This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.
