### PR TITLE
fix: suppress Claude Code internal tool noise in TUI

### DIFF
--- a/src/resources/extensions/claude-code-cli/stream-adapter.ts
+++ b/src/resources/extensions/claude-code-cli/stream-adapter.ts
@@ -152,6 +152,32 @@ export function makeStreamExhaustedErrorMessage(model: string, lastTextContent: 
 	return message;
 }
 
+/**
+ * Claude Code executes its own internal tool loop inside the SDK call. The
+ * final assistant message should therefore contain only user-facing content
+ * (text/thinking), not replayable toolCall blocks that GSD would render again.
+ */
+export function buildFinalClaudeCodeContent(
+	blocks: AssistantMessage["content"],
+	lastThinkingContent: string,
+	lastTextContent: string,
+	resultText?: string,
+): AssistantMessage["content"] {
+	const finalContent = blocks.filter((block) => block.type === "text" || block.type === "thinking");
+	if (finalContent.length > 0) return finalContent;
+
+	if (lastThinkingContent) {
+		finalContent.push({ type: "thinking", thinking: lastThinkingContent });
+	}
+	if (lastTextContent) {
+		finalContent.push({ type: "text", text: lastTextContent });
+	}
+	if (finalContent.length === 0 && resultText) {
+		finalContent.push({ type: "text", text: resultText });
+	}
+	return finalContent;
+}
+
 // ---------------------------------------------------------------------------
 // SDK options builder
 // ---------------------------------------------------------------------------
@@ -211,8 +237,6 @@ async function pumpSdkMessages(
 	/** Track the last text content seen across all assistant turns for the final message. */
 	let lastTextContent = "";
 	let lastThinkingContent = "";
-	/** Collect tool calls from intermediate SDK turns for tool_execution events. */
-	const intermediateToolCalls: AssistantMessage["content"] = [];
 
 	try {
 		// Dynamic import — the SDK is an optional dependency.
@@ -318,9 +342,6 @@ async function pumpSdkMessages(
 								lastTextContent = block.text;
 							} else if (block.type === "thinking" && block.thinking) {
 								lastThinkingContent = block.thinking;
-							} else if (block.type === "toolCall") {
-								// Collect tool calls for externalToolExecution rendering
-								intermediateToolCalls.push(block);
 							}
 						}
 					}
@@ -331,35 +352,12 @@ async function pumpSdkMessages(
 				// -- Result (terminal) --
 				case "result": {
 					const result = msg as SDKResultMessage;
-
-					// Build final message. Include intermediate tool calls so the
-					// agent loop's externalToolExecution path emits tool_execution
-					// events for proper TUI rendering, followed by the text response.
-					const finalContent: AssistantMessage["content"] = [];
-
-					// Add tool calls from intermediate turns first (renders above text)
-					finalContent.push(...intermediateToolCalls);
-
-					// Add text/thinking from the last turn
-					if (builder && builder.message.content.length > 0) {
-						for (const block of builder.message.content) {
-							if (block.type === "text" || block.type === "thinking") {
-								finalContent.push(block);
-							}
-						}
-					} else {
-						if (lastThinkingContent) {
-							finalContent.push({ type: "thinking", thinking: lastThinkingContent });
-						}
-						if (lastTextContent) {
-							finalContent.push({ type: "text", text: lastTextContent });
-						}
-					}
-
-					// Fallback: use the SDK's result text if we have no content
-					if (finalContent.length === 0 && result.subtype === "success" && result.result) {
-						finalContent.push({ type: "text", text: result.result });
-					}
+					const finalContent = buildFinalClaudeCodeContent(
+						builder?.message.content ?? [],
+						lastThinkingContent,
+						lastTextContent,
+						result.subtype === "success" ? result.result : undefined,
+					);
 
 					const finalMessage: AssistantMessage = {
 						role: "assistant",

--- a/src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts
+++ b/src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts
@@ -1,10 +1,11 @@
 import { describe, test } from "node:test";
 import assert from "node:assert/strict";
 import {
-	makeStreamExhaustedErrorMessage,
 	buildPromptFromContext,
+	buildFinalClaudeCodeContent,
 	buildSdkOptions,
 	getClaudeLookupCommand,
+	makeStreamExhaustedErrorMessage,
 	parseClaudeLookupOutput,
 } from "../stream-adapter.ts";
 import type { Context, Message } from "@gsd/pi-ai";
@@ -126,6 +127,37 @@ describe("stream-adapter — session persistence (#2859)", () => {
 			Array.isArray(opusOpts.betas) && opusOpts.betas.length === 0,
 			"non-sonnet models should have empty betas",
 		);
+	});
+});
+
+describe("stream-adapter — final content filtering (#3861)", () => {
+	test("buildFinalClaudeCodeContent strips intermediate tool calls from the final assistant message", () => {
+		const finalContent = buildFinalClaudeCodeContent(
+			[
+				{ type: "toolCall", id: "tc_1", name: "Read", arguments: {} },
+				{ type: "thinking", thinking: "Planning next step" },
+				{ type: "text", text: "Done." },
+			] as any,
+			"",
+			"",
+		);
+
+		assert.deepEqual(finalContent, [
+			{ type: "thinking", thinking: "Planning next step" },
+			{ type: "text", text: "Done." },
+		]);
+	});
+
+	test("buildFinalClaudeCodeContent falls back to cached text when the final turn only had tool calls", () => {
+		const finalContent = buildFinalClaudeCodeContent(
+			[
+				{ type: "toolCall", id: "tc_2", name: "Edit", arguments: { file_path: "app.ts" } },
+			] as any,
+			"",
+			"User-facing answer",
+		);
+
+		assert.deepEqual(finalContent, [{ type: "text", text: "User-facing answer" }]);
 	});
 });
 


### PR DESCRIPTION
## TL;DR

**What:** Stops the Claude Code provider from replaying internal SDK tool calls as user-visible tool execution blocks in the TUI.
**Why:** Claude Code was appending a long wall of empty `Read {}` / `Edit {}` entries after normal answers, making responses hard to read.
**How:** Filters Claude Code final assistant messages down to user-facing text/thinking content only, and adds regression coverage for the final message shape.

## What

This PR fixes the Claude Code CLI provider output noise tracked in #3861.

- Removes intermediate `toolCall` blocks from the terminal `AssistantMessage` produced by `stream-adapter.ts`.
- Keeps normal streaming behavior for text/thinking updates intact.
- Adds regression tests covering both direct filtering and fallback-to-cached-text behavior when the final SDK turn contains only tool calls.

## Why

Claude Code executes its own internal multi-turn tool loop inside the SDK call. GSD was then taking those already-executed internal tool calls, injecting them into the final assistant message, and letting the generic external-tool renderer replay them as visible `tool_execution_start` / `tool_execution_end` UI noise.

The result was a response surface dominated by empty `Read {}` / `Edit {}` blocks instead of the actual answer.

Closes #3861

## How

- Introduced `buildFinalClaudeCodeContent(...)` to centralize the final-message shaping rules for the Claude Code provider.
- Limited the final assistant message to `text` and `thinking` blocks only.
- Preserved cached final text/thinking fallback behavior when the last SDK turn boundary has already reset the partial builder.

## Change Type Checklist

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [x] `test` — Adding or updating tests
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Verification

- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts`
- `npm run typecheck:extensions`

## AI Assistance

This PR was AI-assisted. The change was reviewed locally and verified with the commands listed above.
