### PR TITLE
fix(gsd): skip same-path planning artifact copies

### DIFF
--- a/src/resources/extensions/gsd/auto-worktree.ts
+++ b/src/resources/extensions/gsd/auto-worktree.ts
@@ -1137,6 +1137,7 @@ function copyPlanningArtifacts(srcBase: string, wtPath: string): void {
   const srcGsd = join(srcBase, ".gsd");
   const dstGsd = join(wtPath, ".gsd");
   if (!existsSync(srcGsd)) return;
+  if (isSamePath(srcGsd, dstGsd)) return;
 
   // Copy milestones/ directory (planning files, roadmaps, plans, research)
   safeCopyRecursive(join(srcGsd, "milestones"), join(dstGsd, "milestones"), {
@@ -2020,4 +2021,3 @@ export function mergeMilestoneToMain(
 
   return { commitMessage, pushed, prCreated, codeFilesChanged };
 }
-

--- a/src/resources/extensions/gsd/tests/copy-planning-artifacts-samepath.test.ts
+++ b/src/resources/extensions/gsd/tests/copy-planning-artifacts-samepath.test.ts
@@ -1,0 +1,21 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+test("copyPlanningArtifacts skips when source and destination .gsd resolve to the same path", () => {
+  const srcPath = join(import.meta.dirname, "..", "auto-worktree.ts");
+  const src = readFileSync(srcPath, "utf-8");
+
+  const fnIdx = src.indexOf("function copyPlanningArtifacts");
+  assert.ok(fnIdx !== -1, "copyPlanningArtifacts function exists");
+
+  const fnBody = src.slice(fnIdx, fnIdx + 2400);
+
+  const guardIdx = fnBody.indexOf("if (isSamePath(srcGsd, dstGsd)) return;");
+  const copyIdx = fnBody.indexOf("safeCopyRecursive(join(srcGsd, \"milestones\")");
+
+  assert.ok(guardIdx !== -1, "copyPlanningArtifacts should guard same-path .gsd copies");
+  assert.ok(copyIdx !== -1, "copyPlanningArtifacts should still copy milestones when paths differ");
+  assert.ok(guardIdx < copyIdx, "same-path guard should run before any copy attempt");
+});


### PR DESCRIPTION
## TL;DR

**What:** Add the missing same-path guard to `copyPlanningArtifacts(...)`.
**Why:** Symlinked `.gsd` layouts can make the source and destination resolve to the same physical directory, which currently produces noisy `ERR_FS_CP_EINVAL` copy warnings during worktree creation.
**How:** Mirror the existing `isSamePath(...)` bailout already used by the sibling `.gsd` sync helpers and lock it with a regression test.

## What

This change adds the missing same-path early return to `copyPlanningArtifacts(...)` in `auto-worktree.ts`.

It also adds a focused regression test that proves the function body now includes the guard before any copy calls, matching the behavior already used by the sibling `.gsd` sync helpers.

## Why

Closes #3868.

When `.gsd` is a symlink and the project root and worktree resolve to the same physical `.gsd` directory, `copyPlanningArtifacts(...)` currently tries to copy files onto themselves. That produces repeated `ERR_FS_CP_EINVAL` warnings even though there is no real work to do.

The two sibling helpers already defend against this case with `isSamePath(...)`, but `copyPlanningArtifacts(...)` never got the same protection.

## How

The fix is intentionally small:

- compute `srcGsd` and `dstGsd` as before
- keep the existing `existsSync(srcGsd)` early return
- add `if (isSamePath(srcGsd, dstGsd)) return;` before the first copy operation
- add a regression test that asserts the guard exists and appears before the recursive copy call

## Change type

- [x] `fix` — Bug fix
- [x] `test` — Adding or updating tests

## Scope

- [x] `gsd extension` — GSD workflow

## Breaking changes

- [x] No breaking changes

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [ ] Manual testing — steps described above
- [ ] No tests needed — explained above

Automated verification:

1. `npm run build`
2. `npm run typecheck:extensions`
3. `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/copy-planning-artifacts-samepath.test.ts src/resources/extensions/gsd/tests/preferences-worktree-sync.test.ts`

The new regression locks the missing `isSamePath(...)` guard into `copyPlanningArtifacts(...)` and verifies it appears before the first copy operation.

## AI disclosure

- [x] This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.
