### PR TITLE
fix: suppress streamed Claude Code internal tool noise

### DIFF
--- a/src/resources/extensions/claude-code-cli/stream-adapter.ts
+++ b/src/resources/extensions/claude-code-cli/stream-adapter.ts
@@ -154,16 +154,73 @@ export function makeStreamExhaustedErrorMessage(model: string, lastTextContent: 
 
 /**
  * Claude Code executes its own internal tool loop inside the SDK call. The
- * final assistant message should therefore contain only user-facing content
- * (text/thinking), not replayable toolCall blocks that GSD would render again.
+ * streamed and final assistant messages should therefore contain only
+ * user-facing content (text/thinking), not replayable tool blocks that GSD
+ * would render again.
  */
+function isUserFacingClaudeCodeBlock(block: AssistantMessage["content"][number]): boolean {
+	return block.type === "text" || block.type === "thinking";
+}
+
+function filterUserFacingClaudeCodeContent(
+	blocks: AssistantMessage["content"],
+): AssistantMessage["content"] {
+	return blocks.filter(isUserFacingClaudeCodeBlock);
+}
+
+function remapClaudeCodeContentIndex(
+	blocks: AssistantMessage["content"],
+	contentIndex: number,
+): number {
+	let visibleCount = 0;
+	for (let i = 0; i <= contentIndex && i < blocks.length; i++) {
+		if (isUserFacingClaudeCodeBlock(blocks[i]!)) visibleCount++;
+	}
+	return Math.max(0, visibleCount - 1);
+}
+
+function sanitizeClaudeCodePartial(
+	partial: AssistantMessage,
+): AssistantMessage {
+	return {
+		...partial,
+		content: filterUserFacingClaudeCodeContent(partial.content),
+	};
+}
+
+export function sanitizeClaudeCodeStreamingEvent(
+	event: AssistantMessageEvent,
+): AssistantMessageEvent | null {
+	switch (event.type) {
+		case "toolcall_start":
+		case "toolcall_delta":
+		case "toolcall_end":
+		case "server_tool_use":
+		case "web_search_result":
+			return null;
+		case "text_start":
+		case "text_delta":
+		case "text_end":
+		case "thinking_start":
+		case "thinking_delta":
+		case "thinking_end":
+			return {
+				...event,
+				contentIndex: remapClaudeCodeContentIndex(event.partial.content, event.contentIndex),
+				partial: sanitizeClaudeCodePartial(event.partial),
+			};
+		default:
+			return event;
+	}
+}
+
 export function buildFinalClaudeCodeContent(
 	blocks: AssistantMessage["content"],
 	lastThinkingContent: string,
 	lastTextContent: string,
 	resultText?: string,
 ): AssistantMessage["content"] {
-	const finalContent = blocks.filter((block) => block.type === "text" || block.type === "thinking");
+	const finalContent = filterUserFacingClaudeCodeContent(blocks);
 	if (finalContent.length > 0) return finalContent;
 
 	if (lastThinkingContent) {
@@ -305,16 +362,10 @@ async function pumpSdkMessages(
 					if (!builder) break;
 
 					const assistantEvent = builder.handleEvent(event);
-					if (assistantEvent) {
-						// Skip toolcall events — the agent loop's externalToolExecution
-						// path emits tool_execution_start/end events after streamSimple
-						// returns. Streaming toolcall events would render tool calls
-						// out of order in the TUI's accumulated message content.
-						const t = assistantEvent.type;
-						if (t !== "toolcall_start" && t !== "toolcall_delta" && t !== "toolcall_end") {
-							stream.push(assistantEvent);
-						}
-					}
+					const sanitizedEvent = assistantEvent
+						? sanitizeClaudeCodeStreamingEvent(assistantEvent)
+						: null;
+					if (sanitizedEvent) stream.push(sanitizedEvent);
 					break;
 				}
 

--- a/src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts
+++ b/src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts
@@ -7,8 +7,9 @@ import {
 	getClaudeLookupCommand,
 	makeStreamExhaustedErrorMessage,
 	parseClaudeLookupOutput,
+	sanitizeClaudeCodeStreamingEvent,
 } from "../stream-adapter.ts";
-import type { Context, Message } from "@gsd/pi-ai";
+import type { AssistantMessage, Context, Message } from "@gsd/pi-ai";
 
 // ---------------------------------------------------------------------------
 // Existing tests — exhausted stream fallback (#2575)
@@ -158,6 +159,61 @@ describe("stream-adapter — final content filtering (#3861)", () => {
 		);
 
 		assert.deepEqual(finalContent, [{ type: "text", text: "User-facing answer" }]);
+	});
+});
+
+describe("stream-adapter — streaming content filtering follow-up (#3867)", () => {
+	function makePartial(content: AssistantMessage["content"]): AssistantMessage {
+		return {
+			role: "assistant",
+			content,
+			api: "anthropic-messages",
+			provider: "claude-code",
+			model: "claude-sonnet-4-20250514",
+			usage: {
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 0,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "stop",
+			timestamp: Date.now(),
+		};
+	}
+
+	test("sanitizeClaudeCodeStreamingEvent strips tool calls from streamed partials and remaps contentIndex", () => {
+		const event = sanitizeClaudeCodeStreamingEvent({
+			type: "text_delta",
+			contentIndex: 2,
+			delta: "Done.",
+			partial: makePartial([
+				{ type: "toolCall", id: "tc_1", name: "ToolSearch", arguments: {} },
+				{ type: "thinking", thinking: "Planning next step" },
+				{ type: "text", text: "Done." },
+			] as any),
+		});
+
+		assert.ok(event, "text events should still be forwarded");
+		assert.equal(event!.type, "text_delta");
+		assert.equal((event! as any).contentIndex, 1);
+		assert.deepEqual((event! as any).partial.content, [
+			{ type: "thinking", thinking: "Planning next step" },
+			{ type: "text", text: "Done." },
+		]);
+	});
+
+	test("sanitizeClaudeCodeStreamingEvent suppresses internal tool streaming events entirely", () => {
+		const event = sanitizeClaudeCodeStreamingEvent({
+			type: "toolcall_start",
+			contentIndex: 0,
+			partial: makePartial([
+				{ type: "toolCall", id: "tc_1", name: "Bash", arguments: {} },
+			] as any),
+		});
+
+		assert.equal(event, null);
 	});
 });
 


### PR DESCRIPTION
## TL;DR

**What:** This follow-up fixes the remaining Claude Code internal tool noise that still leaked into the interactive UI after #3867.
**Why:** The previous fix sanitized only the final assistant message, but streamed partials still exposed internal toolCall blocks that the TUI rendered as real tool widgets.
**How:** The Claude Code stream adapter now sanitizes streamed partials and suppresses internal tool-like streaming events before downstream consumers see them, with regression tests covering the streaming path.

## What

This change updates the Claude Code stream adapter in src/resources/extensions/claude-code-cli/stream-adapter.ts so streamed assistant partials contain only user-facing text and thinking blocks. It also suppresses internal Claude Code tool-like streaming events and remaps content indexes so downstream renderers stay consistent. The adapter tests in src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts now cover streamed partial sanitization in addition to the final-message filtering added in #3867.

## Why

PR #3867 fixed only the terminal assistant message. That was not sufficient for the interactive TUI, which inspects streamed message_update content and creates tool widgets as soon as it sees toolCall blocks. Because Claude Code partials still contained those internal blocks, users could still see empty ToolSearch / Bash output even though the final message was sanitized.

## How

The fix stays provider-local instead of changing shared TUI behavior. The adapter now filters streamed Claude Code partial content to user-facing blocks, drops internal tool streaming events entirely, and remaps contentIndex for forwarded text/thinking events so consumers receive a coherent partial message. Regression tests verify both suppression of internal tool streaming events and correct content-index remapping.

## Testing

- [x] node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts src/resources/extensions/claude-code-cli/tests/partial-builder.test.ts
- [x] npm run typecheck:extensions
- [x] npm run build

## Change Type

- [ ] feat — New feature or capability
- [x] fix — Bug fix
- [ ] refactor — Code restructuring (no behavior change)
- [x] test — Adding or updating tests
- [ ] docs — Documentation only
- [ ] chore — Build, CI, or tooling changes

## Breaking Changes

None.

## AI Assistance

This PR was AI-assisted.

Follow-up to #3867.
