### PR TITLE
fix(gsd): let doctor heal dispatch fixable warnings

### DIFF
--- a/src/resources/extensions/gsd/commands-handlers.ts
+++ b/src/resources/extensions/gsd/commands-handlers.ts
@@ -58,6 +58,10 @@ export function parseDoctorArgs(args: string) {
   return { jsonMode, dryRun, fixFlag, includeBuild, includeTests, mode, requestedScope };
 }
 
+export function isDoctorHealActionable(issue: { fixable: boolean; severity: string }): boolean {
+  return issue.fixable && issue.severity !== "info";
+}
+
 export async function handleDoctor(args: string, ctx: ExtensionCommandContext, pi: ExtensionAPI): Promise<void> {
   const { jsonMode, dryRun, fixFlag, includeBuild, includeTests, mode, requestedScope } = parseDoctorArgs(args);
   const scope = await selectDoctorScope(projectRoot(), requestedScope);
@@ -89,7 +93,7 @@ export async function handleDoctor(args: string, ctx: ExtensionCommandContext, p
       scope: effectiveScope,
       includeWarnings: true,
     });
-    const actionable = unresolved.filter(issue => issue.severity === "error");
+    const actionable = unresolved.filter(isDoctorHealActionable);
     if (actionable.length === 0) {
       ctx.ui.notify("Doctor heal found nothing actionable to hand off to the LLM.", "info");
       return;

--- a/src/resources/extensions/gsd/tests/doctor-heal-fixable-warnings.test.ts
+++ b/src/resources/extensions/gsd/tests/doctor-heal-fixable-warnings.test.ts
@@ -1,0 +1,14 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { isDoctorHealActionable } from "../commands-handlers.js";
+
+test("doctor heal actionable filter keeps fixable warnings and errors", () => {
+  assert.equal(isDoctorHealActionable({ fixable: true, severity: "warning" }), true);
+  assert.equal(isDoctorHealActionable({ fixable: true, severity: "error" }), true);
+});
+
+test("doctor heal actionable filter excludes info and non-fixable issues", () => {
+  assert.equal(isDoctorHealActionable({ fixable: true, severity: "info" }), false);
+  assert.equal(isDoctorHealActionable({ fixable: false, severity: "warning" }), false);
+  assert.equal(isDoctorHealActionable({ fixable: false, severity: "error" }), false);
+});


### PR DESCRIPTION
## TL;DR

**What:** Let `gsd doctor heal` dispatch fixable warnings instead of only errors.
**Why:** The heal flow was dropping the most common fixable doctor findings before they ever reached the LLM.
**How:** Replace the severity-only filter with a small `isDoctorHealActionable(...)` predicate and lock it with a focused regression test.

## What

This change updates the doctor heal path so it no longer throws away fixable warning-level issues before dispatch.

It also adds a focused regression test for the new actionable predicate used by the heal flow.

## Why

Closes #3870.

`gsd doctor heal` already requests doctor issues with warnings included, but it then filtered the unresolved list down to `severity === "error"` only. That meant common fixable warning-level issues like stale state, delimiter problems, or stale uncommitted changes could still produce:

`Doctor heal found nothing actionable to hand off to the LLM.`

That behavior was too strict for the intended heal flow.

## How

The fix is intentionally small:

- introduce `isDoctorHealActionable(...)`
- treat fixable warnings and fixable errors as actionable
- continue excluding info-level items from LLM dispatch
- add a regression test that proves the predicate keeps fixable warnings/errors and rejects info or non-fixable issues

## Change type

- [x] `fix` — Bug fix
- [x] `test` — Adding or updating tests

## Scope

- [x] `gsd extension` — GSD workflow

## Breaking changes

- [x] No breaking changes

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [ ] Manual testing — steps described above
- [ ] No tests needed — explained above

Automated verification:

1. `npm run build`
2. `npm run typecheck:extensions`
3. `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/doctor-heal-fixable-warnings.test.ts src/resources/extensions/gsd/tests/doctor-fix-flag.test.ts`

The new regression proves that `gsd doctor heal` now keeps fixable warnings and fixable errors while still excluding info-level and non-fixable issues.

## AI disclosure

- [x] This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.
