### PR TITLE
fix(gsd): rebuild STATE.md after unit completion

### DIFF
--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -25,6 +25,7 @@ import {
   buildTaskFileName,
 } from "./paths.js";
 import { invalidateAllCaches } from "./cache.js";
+import { rebuildState } from "./doctor.js";
 import { parseUnitId } from "./unit-id.js";
 import { closeoutUnit, type CloseoutOptions } from "./auto-unit-closeout.js";
 import {
@@ -365,6 +366,12 @@ export async function postUnitPreVerification(pctx: PostUnitContext, opts?: PreV
         await closeBrowser();
         debugLog("postUnit", { phase: "browser-teardown", status: "closed" });
       }
+    });
+
+    // Keep the on-disk STATE.md aligned with the live derived state after
+    // ordinary unit completion, before any worktree state is synced back.
+    await runSafely("postUnit", "state-rebuild", async () => {
+      await rebuildState(s.basePath);
     });
 
     // Sync worktree state back to project root (skipped for lightweight sidecars)

--- a/src/resources/extensions/gsd/tests/post-unit-state-rebuild.test.ts
+++ b/src/resources/extensions/gsd/tests/post-unit-state-rebuild.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Regression test for #3869: normal post-unit flow should rebuild STATE.md
+ * before syncing worktree state back to the project root.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const source = readFileSync(join(import.meta.dirname, "..", "auto-post-unit.ts"), "utf-8");
+
+test("auto-post-unit imports rebuildState", () => {
+  assert.ok(
+    source.includes('import { rebuildState } from "./doctor.js";'),
+    "auto-post-unit.ts should import rebuildState from doctor.ts",
+  );
+});
+
+test("postUnitPreVerification rebuilds STATE.md before worktree sync", () => {
+  const fnStart = source.indexOf("export async function postUnitPreVerification");
+  assert.ok(fnStart > 0, "postUnitPreVerification should exist");
+
+  const section = source.slice(fnStart, fnStart + 8000);
+  const rebuildIdx = section.indexOf('await runSafely("postUnit", "state-rebuild"');
+  const syncIdx = section.indexOf('await runSafely("postUnit", "worktree-sync"');
+
+  assert.ok(rebuildIdx > 0, "postUnitPreVerification should rebuild STATE.md after unit completion");
+  assert.ok(syncIdx > 0, "postUnitPreVerification should sync worktree state back to the project root");
+  assert.ok(
+    rebuildIdx < syncIdx,
+    "STATE.md rebuild should happen before worktree sync so synced state is fresh",
+  );
+});


### PR DESCRIPTION
## TL;DR

**What:** Rebuild `STATE.md` during normal post-unit completion before any worktree sync happens.
**Why:** Without that rebuild step, the synced on-disk state can stay stale after unit completion.
**How:** Call `rebuildState(s.basePath)` in `postUnitPreVerification()` and lock the ordering with a regression test.

## What

This updates `src/resources/extensions/gsd/auto-post-unit.ts` so the standard post-unit flow refreshes `STATE.md` before syncing worktree state back to the project root.

It also adds `src/resources/extensions/gsd/tests/post-unit-state-rebuild.test.ts` to verify that the rebuild step is present and runs before `worktree-sync`.

## Why

Closes #3869

The current flow claims to rebuild project state after unit completion, but the actual `postUnitPreVerification()` path skipped that call. That leaves a gap where `STATE.md` can stay stale even though the rest of the unit-completion flow has advanced.

## How

The change adds a focused `state-rebuild` `runSafely(...)` step that calls `rebuildState(s.basePath)` just before the existing `worktree-sync` step.

The regression test checks the source-level contract directly:
- `auto-post-unit.ts` imports `rebuildState`
- `postUnitPreVerification()` contains the `state-rebuild` step
- that step appears before `worktree-sync`

## Change type

- [x] `fix` — Bug fix
- [ ] `feat` — New feature or capability
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [x] `gsd extension` — GSD workflow
- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [ ] Manual testing — steps described above
- [ ] No tests needed — explained above

Automated verification:

1. `npm run build`
2. `npm run typecheck:extensions`
3. `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/post-unit-state-rebuild.test.ts src/resources/extensions/gsd/tests/milestone-transition-state-rebuild.test.ts`

## AI disclosure

- [x] This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.
