### PR TITLE
fix(gsd): open DB before bootstrap deriveState

### DIFF
--- a/src/resources/extensions/gsd/bootstrap/register-hooks.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-hooks.ts
@@ -117,6 +117,8 @@ export function registerHooks(pi: ExtensionAPI): void {
       return { cancel: true };
     }
     const basePath = process.cwd();
+    const { ensureDbOpen } = await import("./dynamic-tools.js");
+    await ensureDbOpen();
     const state = await deriveState(basePath);
     if (!state.activeMilestone || !state.activeSlice || !state.activeTask) return;
     if (state.phase !== "executing") return;

--- a/src/resources/extensions/gsd/bootstrap/system-context.ts
+++ b/src/resources/extensions/gsd/bootstrap/system-context.ts
@@ -289,6 +289,11 @@ function buildWorktreeContextBlock(): string {
 const RESUME_INTENT_PATTERNS = /^(continue|resume|ok|go|go ahead|proceed|keep going|carry on|next|yes|yeah|yep|sure|do it|let's go|pick up where you left off)$/;
 
 async function buildGuidedExecuteContextInjection(prompt: string, basePath: string): Promise<string | null> {
+  const ensureStateDbOpen = async () => {
+    const { ensureDbOpen } = await import("./dynamic-tools.js");
+    await ensureDbOpen();
+  };
+
   const executeMatch = prompt.match(/Execute the next task:\s+(T\d+)\s+\("([^"]+)"\)\s+in slice\s+(S\d+)\s+of milestone\s+(M\d+(?:-[a-z0-9]{6})?)/i);
   if (executeMatch) {
     const [, taskId, taskTitle, sliceId, milestoneId] = executeMatch;
@@ -298,6 +303,7 @@ async function buildGuidedExecuteContextInjection(prompt: string, basePath: stri
   const resumeMatch = prompt.match(/Resume interrupted work\.[\s\S]*?slice\s+(S\d+)\s+of milestone\s+(M\d+(?:-[a-z0-9]{6})?)/i);
   if (resumeMatch) {
     const [, sliceId, milestoneId] = resumeMatch;
+    await ensureStateDbOpen();
     const state = await deriveState(basePath);
     if (state.activeMilestone?.id === milestoneId && state.activeSlice?.id === sliceId && state.activeTask) {
       return buildTaskExecutionContextInjection(basePath, milestoneId, sliceId, state.activeTask.id, state.activeTask.title);
@@ -313,6 +319,7 @@ async function buildGuidedExecuteContextInjection(prompt: string, basePath: stri
   // replanning, gate evaluation, or other non-execution phases.
   const trimmed = prompt.trim().toLowerCase().replace(/[.!?,]+$/g, "");
   if (RESUME_INTENT_PATTERNS.test(trimmed)) {
+    await ensureStateDbOpen();
     const state = await deriveState(basePath);
     if (state.phase === "executing" && state.activeTask && state.activeMilestone && state.activeSlice) {
       return buildTaskExecutionContextInjection(

--- a/src/resources/extensions/gsd/tests/bootstrap-derive-state-db-open.test.ts
+++ b/src/resources/extensions/gsd/tests/bootstrap-derive-state-db-open.test.ts
@@ -1,0 +1,39 @@
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const systemContextSrc = readFileSync(
+  join(import.meta.dirname, "..", "bootstrap", "system-context.ts"),
+  "utf-8",
+);
+const registerHooksSrc = readFileSync(
+  join(import.meta.dirname, "..", "bootstrap", "register-hooks.ts"),
+  "utf-8",
+);
+
+describe("bootstrap deriveState DB guards (#3844)", () => {
+  test("system-context opens DB before deriveState in resume flows", () => {
+    const helperIdx = systemContextSrc.indexOf("const ensureStateDbOpen = async () => {");
+    const firstDeriveIdx = systemContextSrc.indexOf("const state = await deriveState(basePath);");
+    assert.ok(helperIdx > -1, "system-context should define a DB-open helper for deriveState callers");
+    assert.ok(firstDeriveIdx > -1, "system-context should still derive state for resume flows");
+    assert.ok(helperIdx < firstDeriveIdx, "system-context should prepare DB opening before deriveState resume calls");
+    assert.match(
+      systemContextSrc,
+      /await ensureStateDbOpen\(\);\s*\n\s*const state = await deriveState\(basePath\);/g,
+      "system-context resume flows should open DB before deriveState",
+    );
+  });
+
+  test("register-hooks opens DB before deriveState in session_before_compact", () => {
+    const compactIdx = registerHooksSrc.indexOf('pi.on("session_before_compact"');
+    assert.ok(compactIdx > -1, "register-hooks should define session_before_compact");
+    const compactSection = registerHooksSrc.slice(compactIdx, compactIdx + 1600);
+    const ensureIdx = compactSection.indexOf("ensureDbOpen()");
+    const deriveIdx = compactSection.indexOf("deriveState(basePath)");
+    assert.ok(ensureIdx > -1, "session_before_compact should call ensureDbOpen()");
+    assert.ok(deriveIdx > -1, "session_before_compact should derive state");
+    assert.ok(ensureIdx < deriveIdx, "session_before_compact should open DB before deriveState");
+  });
+});


### PR DESCRIPTION
## TL;DR

**What:** Open the project DB before bootstrap `deriveState()` calls in `system-context` and `register-hooks`.
**Why:** Without that guard, bootstrap paths can spam degraded-mode warnings and derive stale filesystem-only state.
**How:** Reuse the existing `ensureDbOpen()` pattern before the affected `deriveState()` calls and lock it with a regression test.

## What

This updates the bootstrap paths in:

- `src/resources/extensions/gsd/bootstrap/system-context.ts`
- `src/resources/extensions/gsd/bootstrap/register-hooks.ts`

Both paths now open the DB before calling `deriveState(basePath)`.

It also adds `src/resources/extensions/gsd/tests/bootstrap-derive-state-db-open.test.ts` to verify the ordering.

## Why

Closes #3844

These bootstrap hooks were still calling `deriveState()` directly even when the DB had not been opened for the current session. That produced repeated degraded-mode warnings and meant the guided resume / compact paths were working from filesystem-only state when DB-backed state should have been available.

## How

The fix mirrors the existing `ensureDbOpen()` pattern already used in other guarded bootstrap paths:

- `system-context.ts` now opens the DB before the resume-related `deriveState()` calls
- `register-hooks.ts` now opens the DB before `session_before_compact` derives state

The new regression test checks that the DB-open call appears before the relevant `deriveState()` calls in both files.

## Change type

- [x] `fix` — Bug fix
- [x] `test` — Adding or updating tests
- [ ] `feat` — New feature or capability
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [x] `gsd extension` — GSD workflow
- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [ ] Manual testing — steps described above
- [ ] No tests needed — explained above

Automated verification:

1. `npm run build`
2. `npm run typecheck:extensions`
3. `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/bootstrap-derive-state-db-open.test.ts src/resources/extensions/gsd/tests/status-db-open.test.ts`
4. `npm run secret-scan -- --diff upstream/main`

## AI disclosure

- [x] This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.
