### PR TITLE
fix(pi-coding-agent): fall back to env keys for built-ins

### DIFF
--- a/packages/pi-coding-agent/src/core/model-registry-env-fallback.test.ts
+++ b/packages/pi-coding-agent/src/core/model-registry-env-fallback.test.ts
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { AuthStorage } from "./auth-storage.js";
+import { ModelRegistry } from "./model-registry.js";
+
+function createRegistryWithCapturedResolver() {
+	let capturedResolver: ((provider: string) => string | undefined) | undefined;
+	const authStorage = {
+		setFallbackResolver: (resolver: (provider: string) => string | undefined) => {
+			capturedResolver = resolver;
+		},
+		onCredentialChange: () => {},
+		getOAuthProviders: () => [],
+		get: () => undefined,
+		hasAuth: () => false,
+		getApiKey: async () => undefined,
+	} as unknown as AuthStorage;
+
+	new ModelRegistry(authStorage, undefined);
+	assert.ok(capturedResolver, "ModelRegistry should register a fallback resolver");
+	return capturedResolver!;
+}
+
+describe("ModelRegistry env fallback resolver (#3782)", () => {
+	it("falls back to built-in provider env vars when models.json has no custom key", () => {
+		const prev = process.env.MINIMAX_API_KEY;
+		process.env.MINIMAX_API_KEY = "minimax-env-test-key";
+
+		try {
+			const resolver = createRegistryWithCapturedResolver();
+			assert.equal(
+				resolver("minimax"),
+				"minimax-env-test-key",
+				"fallback resolver should return built-in provider env keys",
+			);
+		} finally {
+			if (prev === undefined) {
+				delete process.env.MINIMAX_API_KEY;
+			} else {
+				process.env.MINIMAX_API_KEY = prev;
+			}
+		}
+	});
+
+	it("still returns undefined when no custom or built-in env key exists", () => {
+		const prev = process.env.MINIMAX_API_KEY;
+		delete process.env.MINIMAX_API_KEY;
+
+		try {
+			const resolver = createRegistryWithCapturedResolver();
+			assert.equal(resolver("minimax"), undefined);
+			assert.equal(resolver("totally-unknown-provider"), undefined);
+		} finally {
+			if (prev !== undefined) {
+				process.env.MINIMAX_API_KEY = prev;
+			}
+		}
+	});
+});

--- a/packages/pi-coding-agent/src/core/model-registry.ts
+++ b/packages/pi-coding-agent/src/core/model-registry.ts
@@ -8,6 +8,7 @@ import {
 	type AssistantMessageEventStream,
 	type Context,
 	getApiProvider,
+	getEnvApiKey,
 	getModels,
 	getProviders,
 	type KnownProvider,
@@ -245,7 +246,7 @@ export class ModelRegistry {
 			if (keyConfig) {
 				return resolveConfigValue(keyConfig);
 			}
-			return undefined;
+			return getEnvApiKey(provider);
 		});
 
 		// Refresh models when credentials change (e.g., OAuth token refresh with new model limits)


### PR DESCRIPTION
## TL;DR

**What:** Let the model registry fall back to built-in provider env keys when `models.json` does not define a custom key.
**Why:** Built-in providers like MiniMax could lose auth after restart because the fallback resolver ignored `getEnvApiKey()`.
**How:** Delegate the no-custom-key branch to `getEnvApiKey(provider)` and add a regression test for the fallback resolver.

## What

This updates `packages/pi-coding-agent/src/core/model-registry.ts` so the auth fallback resolver no longer stops at `customProviderApiKeys`.

It also adds `packages/pi-coding-agent/src/core/model-registry-env-fallback.test.ts` to verify that built-in provider env vars are used when there is no `models.json` override.

## Why

Closes #3782

The current fallback resolver only checks custom provider keys loaded from `models.json`. For built-in providers like `minimax`, that means a missing custom entry falls straight through to `undefined` even when the correct built-in env var is already set.

That breaks the “works before restart, fails after restart” path described in the issue.

## How

The resolver now works in two stages:

1. use the custom provider API key when `models.json` defines one
2. otherwise fall back to `getEnvApiKey(provider)` for built-in providers

The regression test covers both:

- built-in env key is returned for `minimax`
- `undefined` is still returned for providers with no custom or built-in mapping

## Change type

- [x] `fix` — Bug fix
- [x] `test` — Adding or updating tests
- [ ] `feat` — New feature or capability
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [x] `pi-coding-agent` — Coding agent
- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [ ] Manual testing — steps described above
- [ ] No tests needed — explained above

Automated verification:

1. `npm run build`
2. `npm run typecheck:extensions`
3. `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test packages/pi-coding-agent/src/core/model-registry-env-fallback.test.ts`
4. `npm run test:packages`
5. `npm run secret-scan -- --diff upstream/main`

Notes:

- On this machine, `npm run test:packages` still hits the pre-existing `ModelRegistry authMode — getAvailable` failure.
- The same `test:packages` failure reproduces on clean `upstream/main`, so it is noted here as existing baseline rather than a regression from this diff.

## AI disclosure

- [x] This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.
