### PR TITLE
fix(pi-ai): honor bearer auth for custom providers

### DIFF
--- a/packages/pi-ai/src/providers/anthropic-bearer-auth.test.ts
+++ b/packages/pi-ai/src/providers/anthropic-bearer-auth.test.ts
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const source = readFileSync(join(import.meta.dirname, "anthropic.ts"), "utf-8");
+
+describe("anthropic bearer auth for custom providers (#3874)", () => {
+	it("treats Bearer Authorization headers as authToken-capable providers", () => {
+		assert.match(
+			source,
+			/model\.provider === "alibaba-coding-plan" \|\| hasBearerAuthorizationHeader\(model\)/,
+			"custom providers with Authorization headers should opt into bearer auth",
+		);
+		assert.match(
+			source,
+			/apiKey: useBearerAuth \? null : apiKey/,
+			"bearer-auth providers should not send x-api-key",
+		);
+		assert.match(
+			source,
+			/authToken: useBearerAuth \? apiKey : undefined/,
+			"bearer-auth providers should send authToken instead",
+		);
+	});
+});

--- a/packages/pi-ai/src/providers/anthropic-bearer-auth.test.ts
+++ b/packages/pi-ai/src/providers/anthropic-bearer-auth.test.ts
@@ -9,17 +9,17 @@ describe("anthropic bearer auth for custom providers (#3874)", () => {
 	it("treats Bearer Authorization headers as authToken-capable providers", () => {
 		assert.match(
 			source,
-			/model\.provider === "alibaba-coding-plan" \|\| hasBearerAuthorizationHeader\(model\)/,
+			/usesAnthropicBearerAuth\(model\.provider\) \|\| hasBearerAuthorizationHeader\(model\)/,
 			"custom providers with Authorization headers should opt into bearer auth",
 		);
 		assert.match(
 			source,
-			/apiKey: useBearerAuth \? null : apiKey/,
+			/apiKey: usesBearerAuth \? null : apiKey/,
 			"bearer-auth providers should not send x-api-key",
 		);
 		assert.match(
 			source,
-			/authToken: useBearerAuth \? apiKey : undefined/,
+			/authToken: usesBearerAuth \? apiKey : undefined/,
 			"bearer-auth providers should send authToken instead",
 		);
 	});

--- a/packages/pi-ai/src/providers/anthropic.ts
+++ b/packages/pi-ai/src/providers/anthropic.ts
@@ -66,6 +66,11 @@ export function usesAnthropicBearerAuth(provider: Model<"anthropic-messages">["p
 	return provider === "alibaba-coding-plan" || provider === "minimax" || provider === "minimax-cn";
 }
 
+function hasBearerAuthorizationHeader(model: Model<"anthropic-messages">): boolean {
+	const authHeader = model.headers?.Authorization ?? model.headers?.authorization;
+	return typeof authHeader === "string" && authHeader.trim().toLowerCase().startsWith("bearer ");
+}
+
 async function createClient(
 	model: Model<"anthropic-messages">,
 	apiKey: string,
@@ -114,7 +119,7 @@ async function createClient(
 
 	// API key auth (Anthropic OAuth removed per TOS compliance — use API keys or Claude CLI)
 	// Some Anthropic-compatible providers require Bearer auth instead of x-api-key.
-	const usesBearerAuth = usesAnthropicBearerAuth(model.provider);
+	const usesBearerAuth = usesAnthropicBearerAuth(model.provider) || hasBearerAuthorizationHeader(model);
 	const client = new AnthropicClass({
 		apiKey: usesBearerAuth ? null : apiKey,
 		authToken: usesBearerAuth ? apiKey : undefined,

--- a/packages/pi-coding-agent/src/core/model-registry-auth-header.test.ts
+++ b/packages/pi-coding-agent/src/core/model-registry-auth-header.test.ts
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { AuthStorage } from "./auth-storage.js";
+import { ModelRegistry } from "./model-registry.js";
+
+function createRegistry(): ModelRegistry {
+	const authStorage = {
+		setFallbackResolver: () => {},
+		onCredentialChange: () => {},
+		getOAuthProviders: () => [],
+		get: () => undefined,
+		hasAuth: () => false,
+		getApiKey: async () => undefined,
+	} as unknown as AuthStorage;
+
+	return new ModelRegistry(authStorage, undefined);
+}
+
+describe("ModelRegistry authHeader wiring (#3874)", () => {
+	it("adds Authorization bearer header for custom providers with authHeader enabled", () => {
+		const registry = createRegistry();
+		registry.registerProvider("bigmodel", {
+			baseUrl: "https://open.bigmodel.cn/api/anthropic",
+			api: "anthropic-messages",
+			apiKey: "bigmodel-test-key",
+			authHeader: true,
+			models: [
+				{
+					id: "glm-5.1",
+					name: "glm-5.1",
+					reasoning: false,
+					input: ["text"],
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+					contextWindow: 200000,
+					maxTokens: 128000,
+				},
+			],
+		});
+
+		const model = registry.getAll().find((m) => m.provider === "bigmodel" && m.id === "glm-5.1");
+		assert.ok(model, "custom provider model should be registered");
+		assert.equal(model.headers?.Authorization, "Bearer bigmodel-test-key");
+	});
+});


### PR DESCRIPTION
## TL;DR

**What:** Make Anthropic-compatible custom providers honor `Authorization: Bearer` auth when `authHeader: true` is configured.
**Why:** Today custom providers still fall back to `x-api-key`, which breaks Bearer-only endpoints like BigModel / Z.AI.
**How:** Treat Bearer Authorization headers as an `authToken` signal in the Anthropic provider and add regression coverage for both header wiring and client auth selection.

## What

This updates `packages/pi-ai/src/providers/anthropic.ts` so custom Anthropic-compatible providers can authenticate with Bearer auth when their model headers already include `Authorization: Bearer ...`.

It also adds focused regression coverage in:

- `packages/pi-ai/src/providers/anthropic-bearer-auth.test.ts`
- `packages/pi-coding-agent/src/core/model-registry-auth-header.test.ts`

## Why

Closes #3874

Custom providers can already request `Authorization: Bearer ...` through `authHeader: true`, but the Anthropic client path still treated them as `x-api-key` providers unless the provider name was hardcoded as `alibaba-coding-plan`.

That leaves Bearer-only Anthropic-compatible endpoints broken even though the configuration already carries the right header intent.

## How

The Anthropic provider now treats two cases as Bearer-auth providers:

- `alibaba-coding-plan`
- any custom provider model whose resolved headers already contain `Authorization: Bearer ...`

In those cases the client now uses:

- `authToken` for auth
- `apiKey: null` so it does not send `x-api-key`

The regression tests cover both sides of that path:

- `model-registry` still wires `authHeader: true` into `Authorization: Bearer ...`
- `anthropic.ts` switches to the Bearer-auth branch when that header is present

This keeps the fix focused on custom-provider Bearer auth and does not broaden scope into built-in provider registration or credential management.

## Change type

- [x] `fix` — Bug fix
- [x] `test` — Adding or updating tests
- [ ] `feat` — New feature or capability
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [x] `pi-ai` — AI/LLM layer
- [x] `pi-coding-agent` — Coding agent
- [ ] `pi-tui` — Terminal UI
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [ ] Manual testing — steps described above
- [ ] No tests needed — explained above

Automated verification:

1. `npm run build`
2. `npm run typecheck:extensions`
3. `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test packages/pi-ai/src/providers/anthropic-bearer-auth.test.ts packages/pi-coding-agent/src/core/model-registry-auth-header.test.ts`
4. `npm run test:packages`
5. `npm run secret-scan -- --diff upstream/main`

Notes:

- On this machine, `npm run test:packages` still hits the pre-existing `ModelRegistry authMode — getAvailable` failure.
- The same `test:packages` failure reproduces on clean `upstream/main`, so it is noted here as existing baseline rather than a regression from this diff.

## AI disclosure

- [x] This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for Bearer authorization headers in provider configurations, enabling custom providers to authenticate using Bearer tokens in request headers.

* **Tests**
  * Introduced comprehensive test coverage for Bearer authorization header detection and authentication handling, including model registry integration validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->