### PR TITLE
fix(cli): honor custom-provider defaults before onboarding

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -341,7 +341,7 @@ const modelsJsonPath = resolveModelsJsonPath()
 
 const modelRegistry = new ModelRegistry(authStorage, modelsJsonPath)
 markStartup('ModelRegistry')
-const settingsManager = SettingsManager.create(agentDir)
+const settingsManager = SettingsManager.create(process.cwd(), agentDir)
 applySecurityOverrides(settingsManager)
 markStartup('SettingsManager.create')
 

--- a/src/tests/cli-onboarding-custom-provider.test.ts
+++ b/src/tests/cli-onboarding-custom-provider.test.ts
@@ -1,0 +1,37 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { SettingsManager } from "../../packages/pi-coding-agent/src/core/settings-manager.ts";
+
+test("SettingsManager reads defaultProvider/defaultModel from the explicit agentDir used by CLI (#3860)", () => {
+  const root = mkdtempSync(join(tmpdir(), "gsd-cli-settings-"));
+  const cwd = join(root, "project");
+  const agentDir = join(root, ".gsd", "agent");
+
+  try {
+    mkdirSync(cwd, { recursive: true });
+    mkdirSync(agentDir, { recursive: true });
+    writeFileSync(
+      join(agentDir, "settings.json"),
+      JSON.stringify({
+        defaultProvider: "example-provider",
+        defaultModel: "gpt-5.4",
+      }),
+      "utf-8",
+    );
+
+    const settingsManager = SettingsManager.create(cwd, agentDir);
+    assert.equal(settingsManager.getDefaultProvider(), "example-provider");
+    assert.equal(settingsManager.getDefaultModel(), "gpt-5.4");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("cli.ts wires SettingsManager.create with both cwd and agentDir (#3860)", () => {
+  const cliSource = readFileSync(join(import.meta.dirname, "..", "cli.ts"), "utf-8");
+  assert.match(cliSource, /SettingsManager\.create\(process\.cwd\(\),\s*agentDir\)/);
+});


### PR DESCRIPTION
## TL;DR

**What:** CLI startup now honors `defaultProvider` / `defaultModel` from the configured GSD agent dir before deciding to run onboarding.
**Why:** Custom providers that are already configured should not trigger the first-launch onboarding flow on every command.
**How:** Pass both `cwd` and `agentDir` into `SettingsManager.create(...)` and lock it with a focused regression test.

## What

Fixes the CLI startup path so `SettingsManager` reads settings from the intended `~/.gsd/agent/settings.json` location even when the current working directory is a project path. The change is limited to the CLI wiring in `src/cli.ts` plus a regression test covering the explicit-agent-dir case.

## Why

Closes #3860.

Users with a named custom provider in `models.json` and matching `defaultProvider` / `defaultModel` in `settings.json` were still getting the onboarding wizard first, even though their setup was already valid.

## How

`src/cli.ts` now constructs `SettingsManager` with both `process.cwd()` and `agentDir`, matching the `SettingsManager.create(cwd, agentDir)` contract. The new regression test proves the explicit agent dir loads the configured defaults and that the CLI wiring keeps using both arguments.

## Change type

- [x] `fix` — Bug fix
- [x] `test` — Adding or updating tests

## Scope

- [x] `pi-coding-agent` — Coding agent

## Breaking changes

- [x] No breaking changes

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [ ] Manual testing — steps described above
- [ ] No tests needed — explained above

Automated verification:
1. `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/tests/cli-onboarding-custom-provider.test.ts`
2. `npm run build`
3. `npm run typecheck:extensions`
4. `npm run secret-scan -- --diff upstream/main`

## AI disclosure

- [x] This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.
