### PR TITLE
fix(gsd): dedupe repeated notifications

### DIFF
--- a/src/resources/extensions/gsd/notification-store.ts
+++ b/src/resources/extensions/gsd/notification-store.ts
@@ -26,12 +26,15 @@ export interface NotificationEntry {
 const MAX_ENTRIES = 500;
 const FILENAME = "notifications.jsonl";
 const LOCKFILE = "notifications.lock";
+const DEDUP_WINDOW_MS = 30_000;
+const DEDUP_PRUNE_THRESHOLD = 200;
 
 // ─── Module State ───────────────────────────────────────────────────────
 
 let _basePath: string | null = null;
 let _lineCount = 0;  // Hint for rotation — not authoritative for public API
 let _suppressCount = 0;
+let _recentMessageTimestamps = new Map<string, number>();
 
 // ─── Public API ─────────────────────────────────────────────────────────
 
@@ -40,6 +43,9 @@ let _suppressCount = 0;
  * project root. Seeds in-memory counters from the existing file on disk.
  */
 export function initNotificationStore(basePath: string): void {
+  if (_basePath !== basePath) {
+    _recentMessageTimestamps.clear();
+  }
   _basePath = basePath;
   // Seed line count hint for rotation — public counters read from disk
   _lineCount = _readEntriesFromDisk(basePath).length;
@@ -56,12 +62,23 @@ export function appendNotification(
 ): void {
   if (!_basePath) return;
   if (_suppressCount > 0) return;
+  const persistedMessage = message.length > 500 ? message.slice(0, 500) + "…" : message;
+  const dedupKey = `${_basePath}:${severity}:${source}:${persistedMessage}`;
+  const now = Date.now();
+  const lastSeen = _recentMessageTimestamps.get(dedupKey);
+  if (lastSeen !== undefined && now - lastSeen < DEDUP_WINDOW_MS) return;
+  _recentMessageTimestamps.set(dedupKey, now);
+  if (_recentMessageTimestamps.size > DEDUP_PRUNE_THRESHOLD) {
+    for (const [key, ts] of _recentMessageTimestamps) {
+      if (now - ts > DEDUP_WINDOW_MS) _recentMessageTimestamps.delete(key);
+    }
+  }
 
   const entry: NotificationEntry = {
     id: randomUUID(),
     ts: new Date().toISOString(),
     severity,
-    message: message.length > 500 ? message.slice(0, 500) + "…" : message,
+    message: persistedMessage,
     source,
     read: false,
   };
@@ -181,6 +198,7 @@ export function _resetNotificationStore(): void {
   _basePath = null;
   _lineCount = 0;
   _suppressCount = 0;
+  _recentMessageTimestamps = new Map();
 }
 
 // ─── Internal ───────────────────────────────────────────────────────────

--- a/src/resources/extensions/gsd/notification-widget.ts
+++ b/src/resources/extensions/gsd/notification-widget.ts
@@ -25,7 +25,7 @@ export function buildNotificationWidgetLines(): string[] {
     ? latest.message.slice(0, msgMax - 1) + "…"
     : latest.message;
 
-  return [`  ${icon} [${badge}]  ${truncated}  (${formatShortcut("Ctrl+Alt+N")} to view)`];
+  return [`  ${icon} [${badge}]  ${truncated}  (${formatShortcut("Ctrl+Alt+N")} or /gsd notifications)`];
 }
 
 // ─── Widget init ────────────────────────────────────────────────────────

--- a/src/resources/extensions/gsd/tests/notification-store.test.ts
+++ b/src/resources/extensions/gsd/tests/notification-store.test.ts
@@ -187,6 +187,23 @@ describe("notification-store", () => {
     assert.ok(!entries.some((e) => e.message === "suppressed"));
   });
 
+  test("appendNotification suppresses identical messages within the dedup window", (t) => {
+    initNotificationStore(tmp);
+    let now = 1_000;
+    t.mock.method(Date, "now", () => now);
+
+    appendNotification("same", "warning");
+    now += 1_000;
+    appendNotification("same", "warning");
+    now += 31_000;
+    appendNotification("same", "warning");
+
+    const entries = readNotifications();
+    assert.equal(entries.length, 2);
+    assert.equal(entries[0].message, "same");
+    assert.equal(entries[1].message, "same");
+  });
+
   test("suppressPersistence is ref-counted", () => {
     initNotificationStore(tmp);
     suppressPersistence();

--- a/src/resources/extensions/gsd/tests/notification-widget.test.ts
+++ b/src/resources/extensions/gsd/tests/notification-widget.test.ts
@@ -1,0 +1,25 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { initNotificationStore, appendNotification, _resetNotificationStore } from "../notification-store.js";
+import { buildNotificationWidgetLines } from "../notification-widget.js";
+
+test("buildNotificationWidgetLines includes slash-command fallback for unread notifications", () => {
+  const tmp = mkdtempSync(join(tmpdir(), "gsd-notification-widget-"));
+  try {
+    mkdirSync(join(tmp, ".gsd"), { recursive: true });
+    _resetNotificationStore();
+    initNotificationStore(tmp);
+    appendNotification("Need attention", "warning");
+
+    const lines = buildNotificationWidgetLines();
+    assert.equal(lines.length, 1);
+    assert.match(lines[0]!, /\/gsd notifications/);
+  } finally {
+    _resetNotificationStore();
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## TL;DR

**What:** Repeated identical notifications are now deduped for a short window, and the notification widget shows a slash-command fallback.
**Why:** Embedded terminals can trap `Ctrl+Alt+N`, and repeated warnings were piling up as unread noise with no obvious recovery path.
**How:** Add a small in-memory dedup window in the notification store and update the widget copy to advertise `/gsd notifications`.

## What

Adds short-window deduplication for identical notification entries in the GSD notification store and updates the always-on widget text to point users at `/gsd notifications` when the keyboard shortcut is unavailable. The diff also adds focused regression coverage for the dedup behavior and the widget fallback text.

## Why

Closes #3762.

Without deduplication, the same warning could be appended repeatedly as separate unread entries. In embedded terminals, the widget also suggested only `Ctrl+Alt+N`, which is often intercepted by the host IDE before it reaches GSD.

## How

The notification store now suppresses identical `(severity, source, message)` entries within a 30 second window and prunes old dedup keys opportunistically. The widget copy now advertises `/gsd notifications` alongside the existing shortcut so users have a built-in fallback.

## Change type

- [x] `fix` — Bug fix
- [x] `test` — Adding or updating tests

## Scope

- [x] `gsd extension` — GSD workflow

## Breaking changes

- [x] No breaking changes

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [ ] Manual testing — steps described above
- [ ] No tests needed — explained above

Automated verification:
1. `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/notification-store.test.ts src/resources/extensions/gsd/tests/notification-widget.test.ts`
2. `npm run build`
3. `npm run typecheck:extensions`
4. `npm run secret-scan -- --diff upstream/main`

## AI disclosure

- [x] This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.
