### PR TITLE
fix(init): create gsd.db during fresh bootstrap

### DIFF
--- a/src/resources/extensions/gsd/init-wizard.ts
+++ b/src/resources/extensions/gsd/init-wizard.ts
@@ -235,6 +235,17 @@ export async function showProjectInit(
   // ── Step 9: Bootstrap .gsd/ ────────────────────────────────────────────────
   bootstrapGsdDirectory(basePath, prefs, signals);
 
+  // ── Step 10: Create database ──────────────────────────────────────────────
+  // Open (and create if needed) gsd.db immediately after .gsd/ is bootstrapped
+  // so the project starts with full DB-backed state instead of degraded mode.
+  // See: https://github.com/gsd-build/gsd-2/issues/3880
+  try {
+    const { ensureDbOpen } = await import("./bootstrap/dynamic-tools.js");
+    await ensureDbOpen();
+  } catch {
+    // Non-fatal — DB creation failure should not block project init
+  }
+
   // Ensure .gitignore
   ensureGitignore(basePath);
   untrackRuntimeFiles(basePath);

--- a/src/resources/extensions/gsd/tests/init-wizard-db-bootstrap.test.ts
+++ b/src/resources/extensions/gsd/tests/init-wizard-db-bootstrap.test.ts
@@ -1,0 +1,38 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { createTestContext } from "./test-helpers.ts";
+
+const { assertTrue, report } = createTestContext();
+
+const srcPath = join(import.meta.dirname, "..", "init-wizard.ts");
+const src = readFileSync(srcPath, "utf-8");
+
+console.log("\n=== #3880: gsd.db created during fresh bootstrap ===");
+
+// 1. ensureDbOpen is imported from dynamic-tools
+const importIdx = src.indexOf('import("./bootstrap/dynamic-tools.js")');
+assertTrue(importIdx >= 0, "init-wizard.ts imports dynamic-tools for ensureDbOpen (#3880)");
+
+// 2. ensureDbOpen() is called
+const callIdx = src.indexOf("ensureDbOpen()");
+assertTrue(callIdx >= 0, "init-wizard.ts calls ensureDbOpen() (#3880)");
+
+// 3. ensureDbOpen() is called AFTER bootstrapGsdDirectory()
+const bootstrapIdx = src.indexOf("bootstrapGsdDirectory(");
+assertTrue(bootstrapIdx >= 0, "init-wizard.ts calls bootstrapGsdDirectory()");
+assertTrue(
+  callIdx > bootstrapIdx,
+  "ensureDbOpen() is called after bootstrapGsdDirectory() so .gsd/ exists (#3880)",
+);
+
+// 4. The call is wrapped in try/catch (non-fatal)
+const ensureRegionStart = src.lastIndexOf("try", callIdx);
+const ensureRegionEnd = callIdx;
+const tryBeforeEnsure = ensureRegionStart >= 0 && ensureRegionEnd - ensureRegionStart < 200;
+assertTrue(
+  tryBeforeEnsure,
+  "ensureDbOpen() is wrapped in try/catch so failure does not block init (#3880)",
+);
+
+report();


### PR DESCRIPTION
## Summary

- Call `ensureDbOpen()` in the init wizard right after `bootstrapGsdDirectory()` creates `.gsd/`, so `gsd.db` is created immediately on fresh installs instead of waiting for a tool handler to trigger it
- Without this, `state.js` sees `isDbAvailable()=false` and the project starts in degraded (markdown-only) mode

Closes #3880

## Root cause

`bootstrapGsdDirectory()` creates `.gsd/` with `STATE.md`, `repo-meta.json`, etc. but never opens/creates the database. `ensureDbOpen()` is only reachable through auto-mode startup (`auto-start.ts`) or write tool handlers (`db-tools.js`), neither of which runs during interactive fresh init.

## Fix

Add an `ensureDbOpen()` call as Step 10 of the init wizard, immediately after `.gsd/` is bootstrapped. This mirrors the pattern already used in `auto-start.ts` (`openProjectDbIfPresent()`, fix for #2841). The call is wrapped in try/catch so DB creation failure never blocks project init.

## Test plan

- [ ] Fresh install: run `/gsd init` on a project with no `.gsd/` → verify `gsd.db` exists after init completes
- [ ] Verify `isDbAvailable()` returns `true` after init (no degraded mode)
- [ ] Existing projects: re-running init does not corrupt or duplicate the database
- [ ] DB creation failure (e.g. read-only filesystem): init completes successfully, project works in degraded mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)