### PR TITLE
fix(gsd): surface scoped doctor health warnings

### DIFF
--- a/src/resources/extensions/gsd/doctor-engine-checks.ts
+++ b/src/resources/extensions/gsd/doctor-engine-checks.ts
@@ -13,6 +13,20 @@ export async function checkEngineHealth(
   issues: DoctorIssue[],
   fixesApplied: string[],
 ): Promise<void> {
+  const dbPath = join(basePath, ".gsd", "gsd.db");
+
+  if (!isDbAvailable() && existsSync(dbPath)) {
+    issues.push({
+      severity: "warning",
+      code: "db_unavailable",
+      scope: "project",
+      unitId: "project",
+      message: "Database unavailable — using filesystem state derivation (degraded mode). State queries may be slower and less reliable.",
+      file: ".gsd/gsd.db",
+      fixable: false,
+    });
+  }
+
   // ── DB constraint violation detection (full doctor only, not pre-dispatch per D-10) ──
   try {
     if (isDbAvailable()) {

--- a/src/resources/extensions/gsd/doctor-format.ts
+++ b/src/resources/extensions/gsd/doctor-format.ts
@@ -2,6 +2,7 @@ import type { DoctorIssue, DoctorIssueCode, DoctorReport, DoctorSummary } from "
 
 function matchesScope(unitId: string, scope?: string): boolean {
   if (!scope) return true;
+  if (unitId === "project" || unitId === "environment") return true;
   return unitId === scope || unitId.startsWith(`${scope}/`) || unitId.startsWith(`${scope}`);
 }
 

--- a/src/resources/extensions/gsd/doctor-types.ts
+++ b/src/resources/extensions/gsd/doctor-types.ts
@@ -78,6 +78,7 @@ export type DoctorIssueCode =
   | "db_orphaned_slice"
   | "db_done_task_no_summary"
   | "db_duplicate_id"
+  | "db_unavailable"
   | "projection_drift";
 
 /**

--- a/src/resources/extensions/gsd/tests/doctor-scope-db-unavailable.test.ts
+++ b/src/resources/extensions/gsd/tests/doctor-scope-db-unavailable.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, test } from "node:test";
+import assert from "node:assert/strict";
+import { closeDatabase } from "../gsd-db.ts";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { filterDoctorIssues } from "../doctor-format.ts";
+import { checkEngineHealth } from "../doctor-engine-checks.ts";
+
+afterEach(() => {
+  closeDatabase();
+});
+
+test("filterDoctorIssues keeps project and environment issues in scoped reports", () => {
+  const issues = [
+    { severity: "error", code: "env_dependencies", scope: "project", unitId: "environment", message: "node_modules missing", fixable: false },
+    { severity: "warning", code: "db_unavailable", scope: "project", unitId: "project", message: "DB unavailable", fixable: false },
+    { severity: "warning", code: "state_file_missing", scope: "slice", unitId: "M016/S01", message: "slice warning", fixable: false },
+  ] as const;
+
+  const filtered = filterDoctorIssues([...issues], { scope: "M016", includeWarnings: true });
+  assert.deepEqual(
+    filtered.map((issue) => issue.unitId),
+    ["environment", "project", "M016/S01"],
+  );
+});
+
+test("checkEngineHealth reports db_unavailable when gsd.db exists but the DB is closed", async (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-doctor-db-unavailable-"));
+  t.after(() => rmSync(base, { recursive: true, force: true }));
+
+  const gsdDir = join(base, ".gsd");
+  mkdirSync(gsdDir, { recursive: true });
+  writeFileSync(join(gsdDir, "gsd.db"), "");
+
+  const issues: any[] = [];
+  await checkEngineHealth(base, issues, []);
+
+  const dbIssue = issues.find((issue) => issue.code === "db_unavailable");
+  assert.ok(dbIssue, "doctor should surface degraded DB mode when a DB file exists");
+  assert.equal(dbIssue.unitId, "project");
+  assert.equal(dbIssue.file, ".gsd/gsd.db");
+});


### PR DESCRIPTION
## TL;DR

**What:** Keep project/environment doctor issues visible in scoped reports and surface degraded DB mode when `.gsd/gsd.db` exists but the DB is unavailable.
**Why:** Scoped `/gsd doctor` could misleadingly report zero issues while hiding cross-cutting environment problems and silent DB degradation. Closes #3856.
**How:** Treat `project`/`environment` issues as cross-cutting during scoped filtering, add a `db_unavailable` doctor warning, and lock both behaviors with regression tests.

## What

This change fixes two doctor-reporting gaps:

- scoped doctor output now keeps `project` and `environment` issues instead of filtering them out when the active scope is a milestone or slice
- engine health now emits a `db_unavailable` warning when `.gsd/gsd.db` exists on disk but the DB is not actually open
- adds focused regression coverage for scoped filtering and degraded DB reporting

## Why

Closes #3856.

A scoped doctor report should still show cross-cutting health issues. Before this change, project/environment issues were silently dropped from scoped output, and degraded DB mode only appeared as a runtime warning instead of a doctor issue.

## How

- updated the scope matcher in `doctor-format.ts` so `project` and `environment` issues survive scoped filtering
- added `db_unavailable` to the doctor issue code set and emit it from `checkEngineHealth(...)` when a DB file exists but the DB is unavailable
- added regression tests covering both scoped filtering and degraded DB detection

## Change type

- [x] `fix` — Bug fix
- [x] `test` — Adding or updating tests
- [ ] `feat` — New feature or capability
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [x] `gsd extension` — GSD workflow
- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [ ] Manual testing — steps described above
- [ ] No tests needed — explained above

Automated verification:
1. `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/doctor-scope-db-unavailable.test.ts src/resources/extensions/gsd/tests/integration/doctor.test.ts`
2. `npm run build`
3. `npm run typecheck:extensions`
4. `npm run secret-scan -- --diff upstream/main`

## AI disclosure

- [x] This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.