### PR TITLE
fix(gsd): handle doubled-backtick pre-exec paths

### DIFF
--- a/src/resources/extensions/gsd/pre-execution-checks.ts
+++ b/src/resources/extensions/gsd/pre-execution-checks.ts
@@ -263,9 +263,9 @@ function extractPathFromAnnotation(raw: string): string {
   const trimmed = raw.trim();
   if (!trimmed) return trimmed;
 
-  const backtickMatch = trimmed.match(/^`([^`]+)`(?:\s+[—–-]\s+.*)?$/);
+  const backtickMatch = trimmed.match(/^(`+)([^`]+)\1(?:(?:\s+[—–-]\s+.+)|(?:\s+\([^()]+\)))?$/);
   if (backtickMatch) {
-    return backtickMatch[1].trim();
+    return backtickMatch[2].trim();
   }
 
   const annotatedMatch = trimmed.match(/^(.+?)\s+[—–-]\s+.+$/);

--- a/src/resources/extensions/gsd/tests/pre-exec-backtick-strip.test.ts
+++ b/src/resources/extensions/gsd/tests/pre-exec-backtick-strip.test.ts
@@ -12,7 +12,7 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
 import { normalizeFilePath, checkFilePathConsistency } from '../pre-execution-checks.ts'
-import { readFileSync } from 'node:fs'
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 
 const src = readFileSync(
@@ -23,6 +23,11 @@ const src = readFileSync(
 describe('normalizeFilePath backtick stripping (#3649)', () => {
   it('strips backticks from file paths', () => {
     assert.equal(normalizeFilePath('`src/foo.ts`'), 'src/foo.ts')
+  })
+
+  it('strips doubled backticks and trailing notes from file paths', () => {
+    assert.equal(normalizeFilePath('``src/foo.ts`` - current state'), 'src/foo.ts')
+    assert.equal(normalizeFilePath('``src/foo.ts`` (current state)'), 'src/foo.ts')
   })
 
   it('strips backticks even when mixed with other normalization', () => {
@@ -64,5 +69,47 @@ describe('checkFilePathConsistency checks task.inputs not task.files (#3626)', (
       'filesToCheck must NOT reference task.files — files likely touched include ' +
         'files the task will create, so they do not need to pre-exist',
     )
+  })
+})
+
+describe('checkFilePathConsistency handles doubled-backtick annotations (#3892)', () => {
+  it('accepts existing files when task.inputs include doubled-backtick notes', () => {
+    const task = {
+      milestone_id: 'M001',
+      slice_id: 'S01',
+      id: 'T01',
+      title: 'Test Task',
+      status: 'pending',
+      one_liner: '',
+      narrative: '',
+      verification_result: '',
+      duration: '',
+      completed_at: null,
+      blocker_discovered: false,
+      deviations: '',
+      known_issues: '',
+      key_files: [],
+      key_decisions: [],
+      full_summary_md: '',
+      description: '',
+      estimate: '',
+      files: [],
+      verify: '',
+      inputs: ['``src/foo.ts`` (current state)'],
+      expected_output: [],
+      observability_impact: '',
+      full_plan_md: '',
+      sequence: 0,
+    }
+
+    const tmp = resolve(process.cwd(), '.tmp-pre-exec-3892')
+    try {
+      mkdirSync(resolve(tmp, 'src'), { recursive: true })
+      writeFileSync(resolve(tmp, 'src', 'foo.ts'), '// ok')
+      const results = checkFilePathConsistency([task as any], tmp)
+      assert.deepEqual(results, [])
+    } finally {
+      rmSync(tmp, { recursive: true, force: true })
+    }
   })
 })


### PR DESCRIPTION
## TL;DR

**What:** Normalize doubled-backtick pre-execution file references before path checks run.
**Why:** Inputs like ``src/lib/server/schema.ts`` with trailing notes were still treated as literal file paths and produced false missing-file failures.
**How:** Expand the annotation parser to accept repeated backtick wrappers plus trailing note forms, and lock it with targeted regressions.

## What

This updates the pre-execution path normalization in `pre-execution-checks.ts` and adds focused regression coverage in `pre-exec-backtick-strip.test.ts`.

## Why

Closes #3892.

The existing parser already handled plain paths, single backticks, and dashed annotations, but doubled-backtick variants with trailing notes still leaked through as malformed filenames. That makes pre-execution checks block valid work with a false “doesn't exist” error.

## How

The parser now accepts matching backtick wrappers of any length and strips optional trailing note forms before the rest of path normalization runs. The regression test covers both normalization and a real file-consistency check against an existing file.

## Change type

- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

Automated verification:
1. `npm run build`
2. `npm run typecheck:extensions`
3. `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/pre-execution-checks.test.ts src/resources/extensions/gsd/tests/pre-exec-backtick-strip.test.ts`
4. `npm run secret-scan -- --diff upstream/main`

Manual testing:
1. Run a small pre-execution repro with an input like ``src/lib/server/schema.ts`` `(current state)` against an existing file.
2. Before fix: normalization kept the annotation and `checkFilePathConsistency(...)` reported a false missing-file failure.
3. After fix: normalization resolves to the plain path and the consistency check passes.

## AI disclosure

- [x] This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.
