### PR TITLE
fix(gsd): stop stale forensics context hijacks

### DIFF
--- a/src/resources/extensions/gsd/bootstrap/system-context.ts
+++ b/src/resources/extensions/gsd/bootstrap/system-context.ts
@@ -168,7 +168,7 @@ export async function buildBeforeAgentStartResult(
   const injection = await buildGuidedExecuteContextInjection(event.prompt, process.cwd());
 
   // Re-inject forensics context on follow-up turns (#2941)
-  const forensicsInjection = !injection ? buildForensicsContextInjection(process.cwd()) : null;
+  const forensicsInjection = !injection ? buildForensicsContextInjection(process.cwd(), event.prompt) : null;
 
   const worktreeBlock = buildWorktreeContextBlock();
   const fullSystem = `${event.systemPrompt}\n\n[SYSTEM CONTEXT — GSD]\n\n${systemContent}${preferenceBlock}${knowledgeBlock}${codebaseBlock}${memoryBlock}${newSkillsBlock}${worktreeBlock}`;
@@ -481,13 +481,19 @@ function oneLine(text: string): string {
  * Check for an active forensics session and return the prompt content
  * so it can be re-injected on follow-up turns.
  */
-function buildForensicsContextInjection(basePath: string): string | null {
+export function buildForensicsContextInjection(basePath: string, prompt: string): string | null {
   const marker = readForensicsMarker(basePath);
   if (!marker) return null;
 
   // Expire markers older than 2 hours to avoid stale context
   const age = Date.now() - new Date(marker.createdAt).getTime();
   if (age > 2 * 60 * 60 * 1000) {
+    clearForensicsMarker(basePath);
+    return null;
+  }
+
+  const trimmed = prompt.trim().toLowerCase().replace(/[.!?,]+$/g, "");
+  if (trimmed && !RESUME_INTENT_PATTERNS.test(trimmed)) {
     clearForensicsMarker(basePath);
     return null;
   }

--- a/src/resources/extensions/gsd/tests/forensics-context-persist.test.ts
+++ b/src/resources/extensions/gsd/tests/forensics-context-persist.test.ts
@@ -126,4 +126,34 @@ describe("forensics context persistence (#2941)", () => {
     // Should not throw
     clearForensicsMarker(join(tmpBase, "nonexistent"));
   });
+
+  it("buildForensicsContextInjection keeps marker for low-entropy resume prompts", async () => {
+    const { buildForensicsContextInjection } = await import("../bootstrap/system-context.ts");
+
+    const markerPath = join(tmpBase, ".gsd", "runtime", "active-forensics.json");
+    writeFileSync(markerPath, JSON.stringify({
+      reportPath: "/some/report.md",
+      promptContent: "forensics prompt",
+      createdAt: new Date().toISOString(),
+    }), "utf-8");
+
+    const result = buildForensicsContextInjection(tmpBase, "continue");
+    assert.equal(result, "forensics prompt");
+    assert.ok(existsSync(markerPath), "resume-like follow-up should keep marker intact");
+  });
+
+  it("buildForensicsContextInjection clears marker on unrelated user prompts", async () => {
+    const { buildForensicsContextInjection } = await import("../bootstrap/system-context.ts");
+
+    const markerPath = join(tmpBase, ".gsd", "runtime", "active-forensics.json");
+    writeFileSync(markerPath, JSON.stringify({
+      reportPath: "/some/report.md",
+      promptContent: "forensics prompt",
+      createdAt: new Date().toISOString(),
+    }), "utf-8");
+
+    const result = buildForensicsContextInjection(tmpBase, "please summarize the README");
+    assert.equal(result, null);
+    assert.ok(!existsSync(markerPath), "unrelated follow-up should clear the stale marker");
+  });
 });


### PR DESCRIPTION
## TL;DR

**What:** Stop stale forensics markers from being re-injected into unrelated follow-up turns.
**Why:** A completed `/gsd forensics` run could keep hijacking normal conversation for up to two hours.
**How:** Only keep the forensics marker active for low-entropy resume prompts, and clear it as soon as a new unrelated user turn arrives.

## What

This updates `bootstrap/system-context.ts` and extends `forensics-context-persist.test.ts`.

## Why

Closes #3859.

The original persistence fix for forensics context kept the marker alive on every later turn. That preserved context, but it also meant ordinary user prompts could be contaminated by an old forensic investigation long after the original command finished.

## How

The bootstrap reinjection path now treats the marker as a short-lived resume aid instead of a general-purpose conversation override. Resume-like prompts such as `continue` still reuse the marker, while unrelated prompts clear it and proceed without stale forensics context.

## Change type

- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

Automated verification:
1. `npm run build`
2. `npm run typecheck:extensions`
3. `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/forensics-context-persist.test.ts`
4. `npm run secret-scan -- --diff upstream/main`

Manual testing:
1. Create an active forensics marker and call `buildForensicsContextInjection(..., "continue")`.
2. Confirm the prompt content is reused and the marker remains present for the resume-style follow-up.
3. Then call `buildForensicsContextInjection(..., "please summarize the README")`.
4. Before fix: the old forensics prompt would still be injected.
5. After fix: the marker is cleared and no stale forensics context is injected.

## AI disclosure

- [x] This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.
