### PR TITLE
fix(gsd): accept em-dash none verification rationale

### DIFF
--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -178,7 +178,7 @@ export function incrementUatCount(basePath: string, mid: string, sid: string): n
 export function isVerificationNotApplicable(value: string): boolean {
   const v = (value ?? "").toLowerCase().trim().replace(/[.\s]+$/, "");
   if (!v || v === "none") return true;
-  return /^(?:none[\s._-]*(?:required|needed|planned)?|n\/?a|not[\s._-]+(?:applicable|required|needed|provided)|no[\s._-]+operational[\s\S]*)$/i.test(v);
+  return /^(?:none(?:[\s._\u2014-]+[\s\S]*)?|n\/?a|not[\s._-]+(?:applicable|required|needed|provided)|no[\s._-]+operational[\s\S]*)$/i.test(v);
 }
 
 // ─── Rules ────────────────────────────────────────────────────────────────

--- a/src/resources/extensions/gsd/tests/verification-operational-gate.test.ts
+++ b/src/resources/extensions/gsd/tests/verification-operational-gate.test.ts
@@ -32,6 +32,17 @@ test("isVerificationNotApplicable: 'None planned' is not applicable", () => {
   assert.equal(isVerificationNotApplicable("None planned"), true);
 });
 
+test("isVerificationNotApplicable: 'None — <rationale>' is not applicable (#3897)", () => {
+  assert.equal(
+    isVerificationNotApplicable("None — no new background jobs, workers, or lifecycle changes introduced."),
+    true,
+  );
+});
+
+test("isVerificationNotApplicable: em dash without spaces is not applicable (#3897)", () => {
+  assert.equal(isVerificationNotApplicable("none—inline"), true);
+});
+
 test("isVerificationNotApplicable: 'N/A' is not applicable", () => {
   assert.equal(isVerificationNotApplicable("N/A"), true);
 });


### PR DESCRIPTION
## TL;DR

**What:** Teach `isVerificationNotApplicable()` to treat `None — <rationale>` as a not-applicable operational-verification value.
**Why:** Milestone completion can get stuck in a `dispatch-stop` loop when the planner uses the common em-dash rationale form.
**How:** Widen the `none` matcher to accept em-dash-separated rationale text and add targeted regressions for both spaced and inline em-dash variants.

## What

Update `isVerificationNotApplicable()` in `src/resources/extensions/gsd/auto-dispatch.ts` so `none` remains not-applicable when followed by rationale text after an em dash. Add focused regression coverage in `src/resources/extensions/gsd/tests/verification-operational-gate.test.ts`.

## Why

Closes #3897.

The current helper accepts `None`, `None required`, and similar ASCII variants, but misses `None — no new background jobs...`, which is a common LLM output shape. That makes the completing-milestone guard think operational verification is still required and keeps redispatching validation.

## How

Use a broader `none` branch that accepts separator-plus-rationale text, including U+2014 em dash. Lock the behavior with regression tests for both `None — <rationale>` and `none—inline`.

## Change type

- [x] `fix` — Bug fix
- [x] `test` — Adding or updating tests
- [ ] `feat` — New feature or capability
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [x] `gsd extension` — GSD workflow
- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

Automated verification:

1. `npm run build`
2. `npm run typecheck:extensions`
3. `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/verification-operational-gate.test.ts`

Manual testing:

1. Run `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --input-type=module`.
2. Import `isVerificationNotApplicable` from `src/resources/extensions/gsd/auto-dispatch.ts`.
3. Evaluate `None — no new background jobs introduced.` and `none—inline`.

Before fix: em-dash rationale forms were treated as applicable and could trip the completing-milestone guard.
After fix: both forms return `true` and are treated as not applicable.

## AI disclosure

- [x] This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.
