### PR TITLE
fix(gsd): resync managed resources on auto resume

### DIFF
--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -118,6 +118,7 @@ import {
   formatTokenCount,
 } from "./metrics.js";
 import { setLogBasePath, logWarning, logError } from "./workflow-logger.js";
+import { homedir } from "node:os";
 import { join } from "node:path";
 import { readFileSync, existsSync, mkdirSync, writeFileSync, unlinkSync } from "node:fs";
 import { atomicWriteSync } from "./atomic-write.js";
@@ -1248,6 +1249,11 @@ export async function startAuto(
       "info",
     );
     restoreHookState(s.basePath);
+    // Re-sync managed resources on resume so long-lived auto sessions pick up
+    // bundled extension updates before resume-time verification/state logic runs.
+    const agentDir = process.env.GSD_CODING_AGENT_DIR || join(process.env.GSD_HOME || homedir(), ".gsd", "agent");
+    const { initResources } = await import("../../../" + "resource-loader.js");
+    initResources(agentDir);
     // Open the project DB before rebuild/derive so resume uses DB-backed
     // state instead of falling back to stale markdown parsing (#2940).
     await openProjectDbIfPresent(s.basePath);
@@ -1569,4 +1575,3 @@ export {
   buildLoopRemediationSteps,
 } from "./auto-recovery.js";
 export { resolveExpectedArtifactPath } from "./auto-artifact-paths.js";
-

--- a/src/resources/extensions/gsd/tests/cold-resume-db-reopen.test.ts
+++ b/src/resources/extensions/gsd/tests/cold-resume-db-reopen.test.ts
@@ -18,21 +18,32 @@ const { assertTrue, report } = createTestContext();
 
 const autoSrc = readFileSync(join(import.meta.dirname, "..", "auto.ts"), "utf-8");
 
-console.log("\n=== #2940: resume path opens DB before rebuildState/deriveState ===");
+console.log("\n=== resume path refreshes resources and opens DB before rebuildState/deriveState ===");
 
 // The resume block is the `if (s.paused) { ... }` section that calls rebuildState/deriveState.
 // Locate the resume section by finding `s.paused = false;` followed by `rebuildState`.
 const resumeSectionStart = autoSrc.indexOf("if (s.paused) {", autoSrc.indexOf("// If resuming from paused state"));
 assertTrue(resumeSectionStart > 0, "auto.ts has the paused-session resume block");
 
-const resumeSection = autoSrc.slice(resumeSectionStart, resumeSectionStart + 3000);
+const resumeSectionEnd = autoSrc.indexOf("await autoLoop(", resumeSectionStart);
+assertTrue(resumeSectionEnd > resumeSectionStart, "resume block reaches autoLoop");
 
-// The resume path must open the DB before rebuildState/deriveState
+const resumeSection = autoSrc.slice(resumeSectionStart, resumeSectionEnd);
+
+// The resume path must refresh managed resources and open the DB before
+// rebuildState/deriveState so resumed auto-mode uses current extension code.
 const rebuildIdx = resumeSection.indexOf("rebuildState(");
 assertTrue(rebuildIdx > 0, "resume block calls rebuildState");
 
 const deriveIdx = resumeSection.indexOf("deriveState(");
 assertTrue(deriveIdx > 0, "resume block calls deriveState");
+
+const preDeriveSection = resumeSection.slice(0, rebuildIdx);
+
+assertTrue(
+  preDeriveSection.includes("initResources("),
+  "resume path must refresh managed resources before rebuildState/deriveState (#3761)",
+);
 
 // There must be a DB open call before the first rebuildState call
 const dbOpenPatterns = [
@@ -41,7 +52,6 @@ const dbOpenPatterns = [
   "ensureDbOpen(",
 ];
 
-const preDeriveSection = resumeSection.slice(0, rebuildIdx);
 const hasDbOpen = dbOpenPatterns.some(pat => preDeriveSection.includes(pat));
 assertTrue(
   hasDbOpen,


### PR DESCRIPTION
## TL;DR

**What:** Refresh managed agent resources when auto-mode resumes from a paused session.
**Why:** Resumed auto sessions can keep running stale extension code until a full restart, even after the installed package changed.
**How:** Re-run `initResources()` before resume-time state rebuild and add a regression that locks the resume ordering.

## What

Update the paused-session resume path in `src/resources/extensions/gsd/auto.ts` to re-sync managed resources before resume-time state rebuild/derive work begins. Extend `src/resources/extensions/gsd/tests/cold-resume-db-reopen.test.ts` so the resume block is required to refresh resources before `rebuildState()` and `deriveState()`.

## Why

Closes #3761.

`initResources()` currently runs during CLI startup, but not in the auto-mode resume path itself. If the installed package changes while a session is paused, resumed auto-mode can keep executing stale extension code, which is especially painful around resume-time verification and state rebuild.

## How

During `startAuto()` resume, compute the managed agent directory, dynamically import `initResources()`, and re-sync resources immediately before opening the DB and rebuilding state. Keep the change surgical and lock the ordering with a resume-block regression.

## Change type

- [x] `fix` — Bug fix
- [x] `test` — Adding or updating tests
- [ ] `feat` — New feature or capability
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [x] `gsd extension` — GSD workflow
- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

Automated verification:

1. `npm run build`
2. `npm run typecheck:extensions`
3. `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/cold-resume-db-reopen.test.ts`
4. `npm run secret-scan -- --diff upstream/main`

Manual testing:

1. Run a small Node script that reads `src/resources/extensions/gsd/auto.ts`.
2. Slice the paused-session resume block up to `rebuildState(`.
3. Verify that block now contains both `initResources(` and the DB-open call.

Before fix: resumed auto-mode rebuilt state without refreshing managed resources first.
After fix: the resume block refreshes resources before DB-backed rebuild/derive logic runs.

## AI disclosure

- [x] This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.
