### PR TITLE
fix: auto-discover bundled workflow MCP server

### DIFF
--- a/src/resources/extensions/gsd/tests/workflow-mcp.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-mcp.test.ts
@@ -108,6 +108,17 @@ test("detectWorkflowMcpLaunchConfig resolves the bundled server relative to the 
   assert.match(launch?.args?.[0] ?? "", /packages[\/\\]mcp-server[\/\\]dist[\/\\]cli\.js$/);
 });
 
+test("detectWorkflowMcpLaunchConfig resolves the bundled server relative to the package without env hints", () => {
+  const launch = detectWorkflowMcpLaunchConfig("/tmp/project", {});
+
+  assert.equal(launch?.command, process.execPath);
+  assert.equal(launch?.cwd, "/tmp/project");
+  assert.equal(launch?.env?.GSD_CLI_PATH, undefined);
+  assert.equal(launch?.env?.GSD_WORKFLOW_PROJECT_ROOT, "/tmp/project");
+  assert.equal(typeof launch?.args?.[0], "string");
+  assert.match(launch?.args?.[0] ?? "", /packages[\/\\]mcp-server[\/\\]dist[\/\\]cli\.js$/);
+});
+
 test("usesWorkflowMcpTransport matches local externalCli providers", () => {
   assert.equal(usesWorkflowMcpTransport("externalCli", "local://claude-code"), true);
   assert.equal(usesWorkflowMcpTransport("externalCli", "https://api.example.com"), false);
@@ -131,7 +142,7 @@ test("transport compatibility passes when required tools fit current MCP surface
   assert.equal(error, null);
 });
 
-test("transport compatibility fails cleanly when MCP server is unavailable", () => {
+test("transport compatibility discovers the bundled MCP server without env overrides", () => {
   const error = getWorkflowTransportSupportError(
     "claude-code",
     ["gsd_task_complete"],
@@ -145,7 +156,7 @@ test("transport compatibility fails cleanly when MCP server is unavailable", () 
     },
   );
 
-  assert.match(error ?? "", /workflow MCP server is not configured or discoverable/);
+  assert.equal(error, null);
 });
 
 test("transport compatibility now allows auto execute-task over workflow MCP surface", () => {

--- a/src/resources/extensions/gsd/workflow-mcp.ts
+++ b/src/resources/extensions/gsd/workflow-mcp.ts
@@ -68,8 +68,6 @@ function lookupCommand(command: string, platform: NodeJS.Platform = process.plat
 }
 
 function getBundledWorkflowMcpCliPath(env: NodeJS.ProcessEnv): string | null {
-  if (!env.GSD_BIN_PATH?.trim() && !env.GSD_CLI_PATH?.trim()) return null;
-
   const candidates = [
     resolve(fileURLToPath(new URL("../../../../packages/mcp-server/dist/cli.js", import.meta.url))),
     resolve(fileURLToPath(new URL("../../../../../packages/mcp-server/dist/cli.js", import.meta.url))),


### PR DESCRIPTION
## Summary
- remove the env-hint gate that blocked bundled workflow MCP CLI discovery
- allow claude-code auto-mode to find the local bundled MCP server from a checkout without requiring GSD_BIN_PATH or GSD_CLI_PATH
- add a regression test covering bundled discovery with an empty env

## Testing
- node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/workflow-mcp.test.ts