### PR TITLE
feat(claude-code): forward thinking level as effort to Agent SDK

### DIFF
--- a/packages/pi-ai/src/providers/anthropic.ts
+++ b/packages/pi-ai/src/providers/anthropic.ts
@@ -21,9 +21,9 @@ import {
 	supportsAdaptiveThinking,
 } from "./anthropic-shared.js";
 
-// Re-export types used by other modules
+// Re-export types and helpers used by other modules
 export type { AnthropicEffort, AnthropicOptions };
-export { extractRetryAfterMs };
+export { extractRetryAfterMs, mapThinkingLevelToEffort, supportsAdaptiveThinking };
 
 let _AnthropicClass: typeof Anthropic | undefined;
 async function getAnthropicClass(): Promise<typeof Anthropic> {

--- a/src/resources/extensions/claude-code-cli/stream-adapter.ts
+++ b/src/resources/extensions/claude-code-cli/stream-adapter.ts
@@ -14,8 +14,9 @@ import type {
 	Context,
 	Model,
 	SimpleStreamOptions,
+	ThinkingLevel,
 } from "@gsd/pi-ai";
-import { EventStream } from "@gsd/pi-ai";
+import { EventStream, mapThinkingLevelToEffort, supportsAdaptiveThinking } from "@gsd/pi-ai";
 import { execSync } from "node:child_process";
 import { PartialMessageBuilder, ZERO_USAGE, mapUsage } from "./partial-builder.js";
 import { buildWorkflowMcpServers } from "../gsd/workflow-mcp.js";
@@ -246,8 +247,15 @@ export function buildFinalClaudeCodeContent(
  * Extracted for testability — callers can verify session persistence,
  * beta flags, and other configuration without mocking the full SDK.
  */
-export function buildSdkOptions(modelId: string, prompt: string): Record<string, unknown> {
+export function buildSdkOptions(
+	modelId: string,
+	prompt: string,
+	reasoning?: ThinkingLevel,
+): Record<string, unknown> {
 	const mcpServers = buildWorkflowMcpServers();
+	const effort = reasoning && supportsAdaptiveThinking(modelId)
+		? mapThinkingLevelToEffort(reasoning, modelId)
+		: undefined;
 	return {
 		pathToClaudeCodeExecutable: getClaudePath(),
 		model: modelId,
@@ -259,6 +267,7 @@ export function buildSdkOptions(modelId: string, prompt: string): Record<string,
 		settingSources: ["project"],
 		systemPrompt: { type: "preset", preset: "claude_code" },
 		...(mcpServers ? { mcpServers } : {}),
+		...(effort ? { effort } : {}),
 		betas: modelId.includes("sonnet") ? ["context-1m-2025-08-07"] : [],
 	};
 }
@@ -315,7 +324,7 @@ async function pumpSdkMessages(
 		}
 
 		const prompt = buildPromptFromContext(context);
-		const sdkOpts = buildSdkOptions(modelId, prompt);
+		const sdkOpts = buildSdkOptions(modelId, prompt, options?.reasoning);
 
 		const queryResult = sdk.query({
 			prompt,

--- a/src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts
+++ b/src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts
@@ -252,6 +252,52 @@ describe("stream-adapter — session persistence (#2859)", () => {
 	});
 });
 
+// ---------------------------------------------------------------------------
+// Thinking level → effort pass-through (#3917)
+// ---------------------------------------------------------------------------
+
+describe("stream-adapter — effort pass-through (#3917)", () => {
+	test("buildSdkOptions maps minimal reasoning to low effort", () => {
+		const options = buildSdkOptions("claude-sonnet-4-20250514", "test", "minimal");
+		assert.equal(options.effort, "low");
+	});
+
+	test("buildSdkOptions maps low reasoning to low effort", () => {
+		const options = buildSdkOptions("claude-sonnet-4-20250514", "test", "low");
+		assert.equal(options.effort, "low");
+	});
+
+	test("buildSdkOptions maps medium reasoning to medium effort", () => {
+		const options = buildSdkOptions("claude-sonnet-4-20250514", "test", "medium");
+		assert.equal(options.effort, "medium");
+	});
+
+	test("buildSdkOptions maps high reasoning to high effort", () => {
+		const options = buildSdkOptions("claude-sonnet-4-20250514", "test", "high");
+		assert.equal(options.effort, "high");
+	});
+
+	test("buildSdkOptions maps xhigh to max for opus models", () => {
+		const options = buildSdkOptions("claude-opus-4-6-20250514", "test", "xhigh");
+		assert.equal(options.effort, "max");
+	});
+
+	test("buildSdkOptions maps xhigh to high for non-opus models", () => {
+		const options = buildSdkOptions("claude-sonnet-4-20250514", "test", "xhigh");
+		assert.equal(options.effort, "high");
+	});
+
+	test("buildSdkOptions omits effort when reasoning is undefined (thinking off)", () => {
+		const options = buildSdkOptions("claude-sonnet-4-20250514", "test", undefined);
+		assert.equal(options.effort, undefined);
+	});
+
+	test("buildSdkOptions omits effort for models that do not support adaptive thinking", () => {
+		const options = buildSdkOptions("claude-haiku-4-5-20251001", "test", "high");
+		assert.equal(options.effort, undefined);
+	});
+});
+
 describe("stream-adapter — final content filtering (#3861)", () => {
 	test("buildFinalClaudeCodeContent strips intermediate tool calls from the final assistant message", () => {
 		const finalContent = buildFinalClaudeCodeContent(


### PR DESCRIPTION
## Summary

- Forward `options.reasoning` (thinking level) from the agent loop to the Claude Agent SDK's `effort` parameter when using the claude-code provider
- Matches the Anthropic provider's pattern: effort is only set when reasoning is defined and the model supports adaptive thinking
- Re-export `mapThinkingLevelToEffort()` and `supportsAdaptiveThinking()` from `@gsd/pi-ai`

## Details

- `buildSdkOptions()` in `stream-adapter.ts` accepts an optional `reasoning` parameter (`ThinkingLevel`)
- Guards with `supportsAdaptiveThinking(modelId)` before mapping — same as `anthropic.ts`
- When reasoning is undefined (thinking off), effort is omitted, allowing `.claude/settings.json` `effortLevel` to take effect
- 8 new tests covering all `ThinkingLevel` values, undefined, and unsupported models

Refs #3917