### PR TITLE
fix(gsd): detect property-value JSON invocation errors

### DIFF
--- a/src/resources/extensions/gsd/auto-tool-tracking.ts
+++ b/src/resources/extensions/gsd/auto-tool-tracking.ts
@@ -92,7 +92,7 @@ export function clearInFlightTools(): void {
  * handler. When these errors occur, retrying the same unit will produce the same
  * failure, so the retry loop must be broken.
  */
-const TOOL_INVOCATION_ERROR_RE = /Validation failed for tool|Expected ',' or '\}' in JSON|Unexpected end of JSON|Unexpected token.*in JSON/i;
+const TOOL_INVOCATION_ERROR_RE = /Validation failed for tool|Expected ',' or '\}'(?: after property value)?(?: in JSON)?|Unexpected end of JSON|Unexpected token.*in JSON/i;
 
 /**
  * Returns true if the error message indicates a tool invocation failure due to

--- a/src/resources/extensions/gsd/tests/tool-invocation-error-loop-break.test.ts
+++ b/src/resources/extensions/gsd/tests/tool-invocation-error-loop-break.test.ts
@@ -61,6 +61,13 @@ describe("#2883: isToolInvocationError classification", () => {
     );
   });
 
+  test("detects Node v18+ JSON parse variant with property-value text", () => {
+    assert.equal(
+      isToolInvocationError("Expected ',' or '}' after property value in JSON at position 4096"),
+      true,
+    );
+  });
+
   test("detects Unexpected end of JSON input", () => {
     assert.equal(
       isToolInvocationError("Unexpected end of JSON input"),


### PR DESCRIPTION
## TL;DR

**What:** Recognize the Node JSON parse variant that includes `after property value` as a tool invocation error.
**Why:** Auto-mode was retrying malformed GSD tool calls instead of pausing with a clear actionable error.
**How:** Broaden the classifier regex and add a regression test for the newer error wording.

## What

This updates the tool-invocation classifier in `auto-tool-tracking.ts` and extends the regression suite to cover the property-value JSON.parse wording emitted by newer Node versions.

## Why

`lastToolInvocationError` was not being set for this error string, so post-unit verification treated the failure like a missing artifact and retried the unit. That is the wrong control flow for a malformed tool payload that will not succeed on retry without intervention.

Closes #3924

## How

The regex now accepts the optional `after property value` phrase while preserving the existing malformed-JSON cases. The added regression test proves that the newer message variant is classified as a tool invocation error.

## Change type

- [x] `fix` — Bug fix
- [x] `test` — Adding or updating tests
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes
- [ ] `feat` — New feature or capability

## Scope

- [x] `gsd extension` — GSD workflow
- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

Automated verification:

1. `npm run build`
2. `npm run typecheck:extensions`
3. `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/tool-invocation-error-loop-break.test.ts`

Manual testing:

1. Run `node --input-type=module --experimental-strip-types` and import `isToolInvocationError` from `src/resources/extensions/gsd/auto-tool-tracking.ts`.
2. Evaluate `isToolInvocationError("Expected ',' or '}' after property value in JSON at position 4096")`.
3. Confirm it returns `true`.

## AI disclosure

- [x] This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.
