### PR TITLE
fix(gsd): skip skipped slices in milestone prompts

### DIFF
--- a/src/resources/extensions/gsd/auto-prompts.ts
+++ b/src/resources/extensions/gsd/auto-prompts.ts
@@ -1503,7 +1503,9 @@ export async function buildCompleteMilestonePrompt(
   try {
     const { isDbAvailable, getMilestoneSlices } = await import("./gsd-db.js");
     if (isDbAvailable()) {
-      sliceIds = getMilestoneSlices(mid).map(s => s.id);
+      sliceIds = getMilestoneSlices(mid)
+        .filter(s => s.status !== "skipped")
+        .map(s => s.id);
     }
   } catch (err) {
     logWarning("prompt", `buildCompleteMilestonePrompt DB lookup failed: ${err instanceof Error ? err.message : String(err)}`);
@@ -1597,7 +1599,9 @@ export async function buildValidateMilestonePrompt(
   try {
     const { isDbAvailable, getMilestoneSlices } = await import("./gsd-db.js");
     if (isDbAvailable()) {
-      valSliceIds = getMilestoneSlices(mid).map(s => s.id);
+      valSliceIds = getMilestoneSlices(mid)
+        .filter(s => s.status !== "skipped")
+        .map(s => s.id);
     }
   } catch (err) {
     logWarning("prompt", `buildValidateMilestonePrompt slice IDs lookup failed: ${err instanceof Error ? err.message : String(err)}`);

--- a/src/resources/extensions/gsd/tests/validate-milestone.test.ts
+++ b/src/resources/extensions/gsd/tests/validate-milestone.test.ts
@@ -9,10 +9,11 @@ import { deriveState, isValidationTerminal } from "../state.ts";
 import { resolveExpectedArtifactPath, diagnoseExpectedArtifact } from "../auto-artifact-paths.ts";
 import { verifyExpectedArtifact, buildLoopRemediationSteps } from "../auto-recovery.ts";
 import { resolveDispatch, type DispatchContext } from "../auto-dispatch.ts";
-import { buildValidateMilestonePrompt } from "../auto-prompts.ts";
+import { buildCompleteMilestonePrompt, buildValidateMilestonePrompt } from "../auto-prompts.ts";
 import type { GSDState } from "../types.ts";
 import { clearPathCache } from "../paths.ts";
 import { clearParseCache } from "../files.ts";
+import { closeDatabase, insertMilestone, insertSlice, openDatabase } from "../gsd-db.ts";
 
 // ─── Helpers ──────────────────────────────────────────────────────────────
 
@@ -25,7 +26,13 @@ function makeTmpBase(): string {
 function cleanup(base: string): void {
   clearPathCache();
   clearParseCache();
+  closeDatabase();
   try { rmSync(base, { recursive: true, force: true }); } catch { /* */ }
+}
+
+function openTestDb(base: string): void {
+  const dbPath = join(base, ".gsd", "gsd.db");
+  assert.equal(openDatabase(dbPath), true, "test DB should open");
 }
 
 function writeRoadmap(base: string, mid: string, content: string): void {
@@ -213,6 +220,85 @@ test("buildValidateMilestonePrompt inlines ASSESSMENT evidence instead of UAT sp
     assert.match(prompt, /S01 Assessment/i, "prompt should inline assessment evidence");
     assert.match(prompt, /verdict: PASS/i, "prompt should include the assessment verdict");
     assert.doesNotMatch(prompt, /UAT Spec/i, "prompt should not inline the raw UAT spec as evidence");
+  } finally {
+    cleanup(base);
+  }
+});
+
+test("buildCompleteMilestonePrompt skips skipped slices from DB-backed summary inlining", async () => {
+  const base = makeTmpBase();
+  try {
+    writeRoadmap(base, "M001", `# M001: Test Milestone
+
+## Vision
+Test
+
+## Success Criteria
+- It works
+
+## Slices
+
+- [x] **S01: First slice** \`risk:low\` \`depends:[]\`
+  > Done
+- [ ] **S02: Skipped slice** \`risk:low\` \`depends:[]\`
+  > Intentionally skipped
+
+## Boundary Map
+
+| From | To | Produces | Consumes |
+|------|-----|----------|----------|
+| S01  | terminal | output | nothing |
+`);
+    openTestDb(base);
+    insertMilestone({ id: "M001", title: "Test Milestone", status: "active" });
+    insertSlice({ id: "S01", milestoneId: "M001", title: "First slice", status: "complete", depends: [], sequence: 1 });
+    insertSlice({ id: "S02", milestoneId: "M001", title: "Skipped slice", status: "skipped", depends: [], sequence: 2 });
+    writeSliceSummary(base, "M001", "S01", "# S01 Summary\nDelivered.");
+
+    const prompt = await buildCompleteMilestonePrompt("M001", "Test Milestone", base);
+    assert.match(prompt, /S01 Summary/i, "prompt should inline non-skipped slice summaries");
+    assert.doesNotMatch(prompt, /### S02 Summary/i, "prompt should not inline skipped slice summaries");
+    assert.doesNotMatch(prompt, /not found — file does not exist yet/i, "prompt should not emit skipped-slice missing-file placeholders");
+  } finally {
+    cleanup(base);
+  }
+});
+
+test("buildValidateMilestonePrompt skips skipped slices from DB-backed summary inlining", async () => {
+  const base = makeTmpBase();
+  try {
+    writeRoadmap(base, "M001", `# M001: Test Milestone
+
+## Vision
+Test
+
+## Success Criteria
+- It works
+
+## Slices
+
+- [x] **S01: First slice** \`risk:low\` \`depends:[]\`
+  > Done
+- [ ] **S02: Skipped slice** \`risk:low\` \`depends:[]\`
+  > Intentionally skipped
+
+## Boundary Map
+
+| From | To | Produces | Consumes |
+|------|-----|----------|----------|
+| S01  | terminal | output | nothing |
+`);
+    openTestDb(base);
+    insertMilestone({ id: "M001", title: "Test Milestone", status: "active" });
+    insertSlice({ id: "S01", milestoneId: "M001", title: "First slice", status: "complete", depends: [], sequence: 1 });
+    insertSlice({ id: "S02", milestoneId: "M001", title: "Skipped slice", status: "skipped", depends: [], sequence: 2 });
+    writeSliceSummary(base, "M001", "S01", "# S01 Summary\nDelivered.");
+    writeSliceAssessment(base, "M001", "S01", "---\nverdict: PASS\n---\n# Assessment\nEvidence captured.");
+
+    const prompt = await buildValidateMilestonePrompt("M001", "Test Milestone", base);
+    assert.match(prompt, /S01 Summary/i, "prompt should inline non-skipped slice summaries");
+    assert.doesNotMatch(prompt, /### S02 Summary/i, "prompt should not inline skipped slice summaries");
+    assert.doesNotMatch(prompt, /not found — file does not exist yet/i, "prompt should not emit skipped-slice missing-file placeholders");
   } finally {
     cleanup(base);
   }


### PR DESCRIPTION
## TL;DR

**What:** Stop milestone-completion prompt builders from inlining missing summary placeholders for skipped slices.
**Why:** Skipped slices intentionally have no SUMMARY file, but the prompts were treating them like missing artifacts and sending agents into spurious ENOENT checks.
**How:** Filter DB-backed slice IDs by status before inlining and add regression coverage for both complete and validate milestone prompts.

## What

This changes `buildCompleteMilestonePrompt` and `buildValidateMilestonePrompt` so DB-backed prompt assembly excludes slices with `status === "skipped"`. It also adds regression tests that prove skipped slices no longer inject summary placeholders into the prompt context.

## Why

Skipped slices are an expected terminal state, not a missing-artifact problem. Inlining `_(not found — file does not exist yet)_` for those slices wastes tool calls, produces ENOENT noise, and can nudge the agent toward the wrong verification conclusion.

Closes #3912

## How

When the DB is available, both prompt builders now filter out skipped slices before collecting summary IDs. The new tests cover both complete-milestone and validate-milestone prompt assembly so the prompt context stays aligned with the intended slice lifecycle.

## Change type

- [x] `fix` — Bug fix
- [x] `test` — Adding or updating tests
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes
- [ ] `feat` — New feature or capability

## Scope

- [x] `gsd extension` — GSD workflow
- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

Automated verification:

1. `npm run build`
2. `npm run typecheck:extensions`
3. `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/validate-milestone.test.ts`

Manual testing:

1. Create a milestone with one completed slice and one DB-marked `skipped` slice.
2. Run `buildCompleteMilestonePrompt` and `buildValidateMilestonePrompt`.
3. Confirm the prompts do not include an `S02 Summary` section or the missing-file placeholder for the skipped slice.

## AI disclosure

- [x] This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.
