### PR TITLE
fix(gsd): resolve resource-loader import for deployed extensions

### DIFF
--- a/scripts/pr-risk-check.mjs
+++ b/scripts/pr-risk-check.mjs
@@ -20,7 +20,7 @@ import { createInterface } from 'readline';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(__dirname, '..');
-const MAP_PATH = resolve(REPO_ROOT, 'docs/FILE-SYSTEM-MAP.md');
+const MAP_PATH = resolve(REPO_ROOT, 'docs/dev/FILE-SYSTEM-MAP.md');
 
 // ---------------------------------------------------------------------------
 // Risk tier definitions

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -125,8 +125,9 @@ import {
 } from "./metrics.js";
 import { setLogBasePath, logWarning, logError } from "./workflow-logger.js";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { join, dirname } from "node:path";
 import { readFileSync, existsSync, mkdirSync, writeFileSync, unlinkSync } from "node:fs";
+import { createRequire } from "node:module";
 import { atomicWriteSync } from "./atomic-write.js";
 import {
   autoCommitCurrentBranch,
@@ -1334,7 +1335,12 @@ export async function startAuto(
     // Re-sync managed resources on resume so long-lived auto sessions pick up
     // bundled extension updates before resume-time verification/state logic runs.
     const agentDir = process.env.GSD_CODING_AGENT_DIR || join(process.env.GSD_HOME || homedir(), ".gsd", "agent");
-    const { initResources } = await import("../../../" + "resource-loader.js");
+    // Resolve resource-loader from the gsd-pi package root — the relative
+    // "../../../resource-loader.js" path only works from the source tree but
+    // breaks when extensions are deployed to ~/.gsd/agent/extensions/gsd/.
+    const _req = createRequire(import.meta.url);
+    const pkgRoot = dirname(_req.resolve("gsd-pi/package.json"));
+    const { initResources } = await import(join(pkgRoot, "dist", "resource-loader.js"));
     initResources(agentDir);
     // Open the project DB before rebuild/derive so resume uses DB-backed
     // state instead of falling back to stale markdown parsing (#2940).

--- a/src/resources/extensions/gsd/tests/discord-invite-links.test.ts
+++ b/src/resources/extensions/gsd/tests/discord-invite-links.test.ts
@@ -18,7 +18,7 @@ const VALID_INVITE = "https://discord.com/invite/nKXTsAcmbT";
 /** Files that contain user-facing Discord invite links. */
 const FILES_WITH_INVITE_LINKS: string[] = [
   "README.md",
-  "docs/what-is-pi/15-pi-packages-the-ecosystem.md",
+  "docs/dev/what-is-pi/15-pi-packages-the-ecosystem.md",
 ];
 
 describe("Discord invite links (#2699)", () => {

--- a/src/resources/extensions/gsd/tests/resource-loader-import-path.test.ts
+++ b/src/resources/extensions/gsd/tests/resource-loader-import-path.test.ts
@@ -1,0 +1,37 @@
+// GSD2 — Regression test for broken resource-loader import path
+// Ensures auto.ts imports resource-loader via package resolution, not a
+// relative path that breaks when deployed to ~/.gsd/agent/extensions/gsd/.
+
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const autoSrc = readFileSync(join(import.meta.dirname, "..", "auto.ts"), "utf-8");
+
+describe("resource-loader import path", () => {
+  test("must not use relative import reaching above extensions/", () => {
+    // The old broken pattern: import("../../../" + "resource-loader.js")
+    // This resolves to ~/.gsd/resource-loader.js from deployed location, which
+    // doesn't exist. Regression introduced in #3899.
+    const brokenPattern = /import\(\s*["']\.\.\/\.\.\/\.\..*resource-loader/;
+    assert.ok(
+      !brokenPattern.test(autoSrc),
+      "auto.ts must not import resource-loader via relative path above extensions/ — " +
+      "breaks when deployed to ~/.gsd/agent/extensions/gsd/ (see #3899)",
+    );
+  });
+
+  test("uses createRequire to resolve resource-loader from package root", () => {
+    // The fix uses createRequire to find gsd-pi/package.json, then imports
+    // dist/resource-loader.js from there — works in both source and deployed.
+    assert.ok(
+      autoSrc.includes('createRequire(import.meta.url)'),
+      "auto.ts should use createRequire to resolve resource-loader",
+    );
+    assert.ok(
+      autoSrc.includes('resolve("gsd-pi/package.json")'),
+      "auto.ts should resolve gsd-pi package root via package.json",
+    );
+  });
+});


### PR DESCRIPTION
## TL;DR

**What:** Fix broken `resource-loader.js` import that crashes GSD on startup in non-dev projects.
**Why:** Relative import path works in the source tree but not when deployed to `~/.gsd/agent/`.
**How:** Use `createRequire` to resolve from the `gsd-pi` package root instead of a relative path.

## What

The dynamic import in `auto.ts` line 1337:
```js
await import("../../../" + "resource-loader.js")
```
resolves to `~/.gsd/resource-loader.js` when running from `~/.gsd/agent/extensions/gsd/auto.js` — that file doesn't exist.

Replaced with `createRequire` + `dirname` to resolve `gsd-pi/package.json` and import `dist/resource-loader.js` from the package root. Works in both source tree and deployed contexts.

## Why

Running `/gsd` in any non-dev project crashes immediately:
```
Extension "command:gsd" error: Cannot find module '/Users/.../.gsd/resource-loader.js'
  imported from /Users/.../.gsd/agent/extensions/gsd/auto.js
```

Regression from PR #3899 (`c4305403ea` — `fix(gsd): resync managed resources on auto resume`).

## How

- Import `dirname` from `node:path` and `createRequire` from `node:module`
- Use `createRequire(import.meta.url)` to resolve `gsd-pi/package.json`
- Derive package root with `dirname()`, then import `dist/resource-loader.js` from there
- This follows the same pattern already used in `search-the-web/provider.ts` (which had the same bug class and was fixed by avoiding relative imports above `extensions/`)

### Additional findings — same bug class in other files

A full import audit found 4 more production files with relative imports that reach above `extensions/` and break on deployment:

| File | Lines | Broken Target |
|------|-------|--------------|
| `workflow-mcp.ts` | 98-99 | `../../../../packages/mcp-server/dist/cli.js` |
| `workflow-mcp.ts` | 111 | `../../../../dist/resources/extensions/gsd/tools/workflow-tool-executors.js` |
| `workflow-mcp.ts` | 125 | `../../../../dist/resources/extensions/gsd/bootstrap/write-gate.js` |
| `mcp-project-config.ts` | 35-37 | `../../../../scripts/dev-cli.js`, `../../../../dist/loader.js` |

These should be addressed in follow-up PRs.

## Change type

- [x] `fix` — Bug fix

## Test plan

- [x] `npm run build` passes
- [ ] Launch GSD in a non-dev project and run `/gsd` — no longer crashes with `Cannot find module`
- [ ] Auto-mode resume re-syncs resources correctly

AI-assisted: This PR was developed with AI assistance. The fix, audit, and regression analysis have been reviewed and understood.