### PR TITLE
feat: add built-in file ignore rules, Exa search extension, and simpl…

### DIFF
--- a/packages/pi-coding-agent/src/core/tools/file-ignore.test.ts
+++ b/packages/pi-coding-agent/src/core/tools/file-ignore.test.ts
@@ -1,0 +1,156 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+// TDD: 先写测试，再实现功能
+// 导入待实现的模块
+import { FileIgnore } from "./file-ignore.js";
+
+describe("FileIgnore", () => {
+  describe("FOLDERS", () => {
+    it("should contain essential ignore directories", () => {
+      const essentialDirs = [
+        "node_modules", "dist", "build", "out", ".next",
+        "target", "__pycache__", ".cache", "coverage", "vendor",
+        ".git", ".vscode", ".idea", ".turbo",
+        "bower_components", ".pnpm-store",
+      ];
+      for (const dir of essentialDirs) {
+        assert.ok(FileIgnore.FOLDERS.has(dir), `Missing essential directory: ${dir}`);
+      }
+    });
+
+    it("should be a Set of strings", () => {
+      assert.ok(FileIgnore.FOLDERS instanceof Set);
+      for (const dir of FileIgnore.FOLDERS) {
+        assert.strictEqual(typeof dir, "string");
+      }
+    });
+  });
+
+  describe("FILES", () => {
+    it("should contain essential file patterns", () => {
+      const essentialPatterns = [
+        "**/*.swp", "**/*.pyc",
+        "**/.DS_Store", "**/Thumbs.db",
+        "**/*.log",
+      ];
+      for (const pattern of essentialPatterns) {
+        assert.ok(FileIgnore.FILES.includes(pattern), `Missing essential pattern: ${pattern}`);
+      }
+    });
+
+    it("should be an array of glob patterns", () => {
+      assert.ok(Array.isArray(FileIgnore.FILES));
+    });
+  });
+
+  describe("match()", () => {
+    it("should ignore paths with FOLDERS in any segment", () => {
+      assert.ok(FileIgnore.match("src/node_modules/react/index.js"));
+      assert.ok(FileIgnore.match("project/dist/bundle.js"));
+      assert.ok(FileIgnore.match("app/__pycache__/main.pyc"));
+      assert.ok(FileIgnore.match("coverage/lcov-report/index.html"));
+      assert.ok(FileIgnore.match(".git/HEAD"));
+      assert.ok(FileIgnore.match("packages/native/src/.cache/data.json"));
+    });
+
+    it("should ignore paths matching FILES patterns", () => {
+      assert.ok(FileIgnore.match("src/file.swp"));
+      assert.ok(FileIgnore.match("src/__pycache__/main.pyc"));
+      assert.ok(FileIgnore.match(".DS_Store"));
+      assert.ok(FileIgnore.match("logs/app.log"));
+    });
+
+    it("should NOT ignore normal source files", () => {
+      assert.ok(!FileIgnore.match("src/index.ts"));
+      assert.ok(!FileIgnore.match("packages/core/lib.rs"));
+      assert.ok(!FileIgnore.match("README.md"));
+      assert.ok(!FileIgnore.match("app/components/Button.tsx"));
+      assert.ok(!FileIgnore.match("tests/unit.test.ts"));
+    });
+
+    it("should respect whitelist patterns", () => {
+      // node_modules is normally ignored
+      assert.ok(FileIgnore.match("node_modules/react/index.js"));
+      // but whitelist overrides
+      assert.ok(!FileIgnore.match("node_modules/react/index.js", {
+        whitelist: ["node_modules/react/**"],
+      }));
+    });
+
+    it("should support extra ignore patterns", () => {
+      // Not ignored by default
+      assert.ok(!FileIgnore.match("secrets/api-key.pem"));
+      // But extra patterns can add it
+      assert.ok(FileIgnore.match("secrets/api-key.pem", {
+        extra: ["**/*.pem"],
+      }));
+    });
+
+    it("should handle Windows-style backslash paths", () => {
+      assert.ok(FileIgnore.match("src\\node_modules\\react\\index.js"));
+      assert.ok(FileIgnore.match("project\\dist\\bundle.js"));
+    });
+
+    it("should handle paths with multiple directory segments", () => {
+      assert.ok(FileIgnore.match("apps/web/node_modules/lodash/index.js"));
+      assert.ok(FileIgnore.match("packages/api/dist/controllers/user.js"));
+    });
+
+    it("should NOT ignore files that happen to contain a folder name as substring", () => {
+      // "node_modules_test" should NOT be ignored — it's not the "node_modules" directory
+      // But "my_node_modules" IS ignored because the path segment is exactly "my_node_modules",
+      // not "node_modules". Let's test with exact segment matching.
+      assert.ok(!FileIgnore.match("src/node_modules_utils/helper.ts"));
+    });
+  });
+
+  describe("ripgrepNegateGlobs()", () => {
+    it("should return an array of strings", () => {
+      const globs = FileIgnore.ripgrepNegateGlobs();
+      assert.ok(Array.isArray(globs));
+      assert.ok(globs.length > 0);
+    });
+
+    it("should prefix all patterns with !", () => {
+      const globs = FileIgnore.ripgrepNegateGlobs();
+      for (const g of globs) {
+        assert.ok(g.startsWith("!"), `Pattern should start with !: ${g}`);
+      }
+    });
+
+    it("should include negate patterns for key directories", () => {
+      const globs = FileIgnore.ripgrepNegateGlobs();
+      assert.ok(globs.includes("!node_modules/"), "Should include !node_modules/");
+      assert.ok(globs.includes("!dist/"), "Should include !dist/");
+      assert.ok(globs.includes("!build/"), "Should include !build/");
+      assert.ok(globs.includes("!__pycache__/"), "Should include !__pycache__/");
+    });
+
+    it("should include negate patterns for file patterns", () => {
+      const globs = FileIgnore.ripgrepNegateGlobs();
+      assert.ok(globs.some(g => g.includes(".swp")), "Should include .swp pattern");
+      assert.ok(globs.some(g => g.includes(".pyc")), "Should include .pyc pattern");
+    });
+  });
+
+  describe("nativeGlobPatterns()", () => {
+    it("should return an array of strings", () => {
+      const patterns = FileIgnore.nativeGlobPatterns();
+      assert.ok(Array.isArray(patterns));
+      assert.ok(patterns.length > 0);
+    });
+
+    it("should wrap folder names with **/ prefix and /** suffix", () => {
+      const patterns = FileIgnore.nativeGlobPatterns();
+      assert.ok(patterns.includes("**/node_modules/**"), "Should include **/node_modules/**");
+      assert.ok(patterns.includes("**/dist/**"), "Should include **/dist/**");
+      assert.ok(patterns.includes("**/__pycache__/**"), "Should include **/__pycache__/**");
+    });
+
+    it("should have one pattern per FOLDERS entry", () => {
+      const patterns = FileIgnore.nativeGlobPatterns();
+      assert.strictEqual(patterns.length, FileIgnore.FOLDERS.size);
+    });
+  });
+});

--- a/packages/pi-coding-agent/src/core/tools/file-ignore.ts
+++ b/packages/pi-coding-agent/src/core/tools/file-ignore.ts
@@ -1,0 +1,155 @@
+/**
+ * 内置文件忽略规则
+ *
+ * 在搜索操作中自动排除常见的噪声目录和文件，
+ * 确保用户无需手动配置即可获得干净的搜索结果。
+ *
+ * 规则合并自 opencode 的 FileIgnore 和 IGNORE_PATTERNS，
+ * 并补充了 gsd-2 特有的模式。
+ */
+
+export namespace FileIgnore {
+  /** 始终排除的目录名（路径中任一段匹配即排除） */
+  export const FOLDERS = new Set([
+    // JavaScript/TypeScript
+    "node_modules",
+    "bower_components",
+    ".pnpm-store",
+    ".npm",
+    // 构建输出
+    "dist",
+    "build",
+    "out",
+    ".next",
+    ".output",
+    ".turbo",
+    // Java/JVM
+    "target",
+    "bin",
+    "obj",
+    ".gradle",
+    // Python
+    "__pycache__",
+    ".pytest_cache",
+    "mypy_cache",
+    ".venv",
+    "venv",
+    "env",
+    // Go/Rust/Zig
+    "vendor",
+    ".zig-cache",
+    "zig-out",
+    // 版本控制
+    ".git",
+    ".svn",
+    ".hg",
+    // IDE
+    ".vscode",
+    ".idea",
+    // 缓存
+    ".cache",
+    "cache",
+    ".webkit-cache",
+    // 测试/覆盖率
+    "coverage",
+    ".coverage",
+    ".nyc_output",
+    // 临时/日志
+    "tmp",
+    "temp",
+    "logs",
+    // 其他
+    ".sst",
+    "desktop",
+    ".history",
+  ]);
+
+  /** 始终排除的文件 glob 模式 */
+  export const FILES = [
+    "**/*.swp",
+    "**/*.swo",
+    "**/*.pyc",
+    // OS 文件
+    "**/.DS_Store",
+    "**/Thumbs.db",
+    // 日志
+    "**/*.log",
+  ];
+
+  /**
+   * 检查文件路径是否应被忽略
+   * @param filepath 文件路径（相对或绝对）
+   * @param opts.extra 额外的 glob 忽略模式
+   * @param opts.whitelist 白名单模式（匹配则不忽略）
+   */
+  export function match(
+    filepath: string,
+    opts?: {
+      extra?: string[];
+      whitelist?: string[];
+    },
+  ): boolean {
+    // 白名单优先
+    for (const pattern of opts?.whitelist || []) {
+      if (globMatch(pattern, filepath)) return false;
+    }
+
+    // 目录名匹配：分割路径为段，精确匹配 FOLDERS 中的目录名
+    const parts = filepath.split(/[/\\]/);
+    for (const part of parts) {
+      if (FOLDERS.has(part)) return true;
+    }
+
+    // 文件模式匹配
+    const extra = opts?.extra || [];
+    for (const pattern of [...FILES, ...extra]) {
+      if (globMatch(pattern, filepath)) return true;
+    }
+
+    return false;
+  }
+
+  /**
+   * 导出用于 ripgrep 的负 glob 模式列表
+   * 格式：!pattern（ripgrep --glob 参数）
+   */
+  export function ripgrepNegateGlobs(): string[] {
+    const globs: string[] = [];
+    for (const folder of FOLDERS) {
+      globs.push(`!${folder}/`);
+    }
+    for (const filePattern of FILES) {
+      globs.push(`!${filePattern}`);
+    }
+    return globs;
+  }
+
+  /**
+   * 导出用于原生 glob 模块的忽略模式列表
+   * 格式: double-star-slash-folder-slash-double-star (native glob ignore pattern)
+   */
+  export function nativeGlobPatterns(): string[] {
+    const patterns: string[] = [];
+    for (const folder of FOLDERS) {
+      patterns.push(`**/${folder}/**`);
+    }
+    return patterns;
+  }
+}
+
+/** Glob pattern matcher supporting double-star and single-star wildcards. */
+function globMatch(pattern: string, path: string): boolean {
+  const GLOBSTAR_SLASH = "\x00GSS\x00";
+  const GLOBSTAR = "\x00GS\x00";
+  const STAR = "\x00S\x00";
+  let regex = pattern
+    .replace(/\*\*\//g, GLOBSTAR_SLASH)   // **/ as a unit (includes the slash)
+    .replace(/\*\*/g, GLOBSTAR)            // standalone **
+    .replace(/\*/g, STAR);
+  regex = regex.replace(/[.+^${}()|[\]\\]/g, "\\$&");
+  regex = regex
+    .replace(new RegExp(GLOBSTAR_SLASH.replace(/\x00/g, "\\x00"), "g"), "(?:.*/)?")   // **/ => optional prefix dirs
+    .replace(new RegExp(GLOBSTAR.replace(/\x00/g, "\\x00"), "g"), ".*")               // **  => match anything
+    .replace(new RegExp(STAR.replace(/\x00/g, "\\x00"), "g"), "[^/]*");
+  return new RegExp(`^${regex}$`).test(path);
+}

--- a/packages/pi-coding-agent/src/core/tools/find.ts
+++ b/packages/pi-coding-agent/src/core/tools/find.ts
@@ -6,6 +6,7 @@ import path from "path";
 import { FIND_DEFAULT_LIMIT } from "../constants.js";
 import { resolveToCwd } from "./path-utils.js";
 import { DEFAULT_MAX_BYTES, formatSize, type TruncationResult, truncateHead } from "./truncate.js";
+import { FileIgnore } from "./file-ignore.js";
 
 const findSchema = Type.Object({
 	pattern: Type.String({
@@ -84,7 +85,7 @@ export function createFindTool(cwd: string, options?: FindToolOptions): AgentToo
 							}
 
 							const results = await ops.glob(pattern, searchPath, {
-								ignore: ["**/node_modules/**", "**/.git/**"],
+								ignore: FileIgnore.nativeGlobPatterns(),
 								limit: effectiveLimit,
 							});
 

--- a/packages/pi-coding-agent/src/core/tools/grep.ts
+++ b/packages/pi-coding-agent/src/core/tools/grep.ts
@@ -14,6 +14,7 @@ import {
 	truncateHead,
 	truncateLine,
 } from "./truncate.js";
+import { FileIgnore } from "./file-ignore.js";
 
 const grepSchema = Type.Object({
 	pattern: Type.String({ description: "Search pattern (regex or literal string)" }),
@@ -150,6 +151,11 @@ export function createGrepTool(cwd: string, options?: GrepToolOptions): AgentToo
 						};
 
 						const args: string[] = ["--json", "--line-number", "--color=never", "--hidden"];
+
+						// Add built-in ignore rules to filter common noise directories
+						for (const negGlob of FileIgnore.ripgrepNegateGlobs()) {
+							args.push("--glob", negGlob);
+						}
 
 						if (ignoreCase) {
 							args.push("--ignore-case");

--- a/packages/pi-coding-agent/src/core/tools/ls.ts
+++ b/packages/pi-coding-agent/src/core/tools/ls.ts
@@ -4,6 +4,7 @@ import { existsSync, readdirSync, statSync } from "fs";
 import nodePath from "path";
 import { resolveToCwd } from "./path-utils.js";
 import { DEFAULT_MAX_BYTES, formatSize, type TruncationResult, truncateHead } from "./truncate.js";
+import { FileIgnore } from "./file-ignore.js";
 
 const lsSchema = Type.Object({
 	path: Type.Optional(Type.String({ description: "Directory to list (default: current directory)" })),
@@ -92,8 +93,11 @@ export function createLsTool(cwd: string, options?: LsToolOptions): AgentTool<ty
 							return;
 						}
 
-						// Sort alphabetically (case-insensitive)
-						entries.sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()));
+							// Filter out ignored directories and files
+							entries = entries.filter((entry) => !FileIgnore.match(entry));
+
+							// Sort alphabetically (case-insensitive)
+							entries.sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()));
 
 						// Format entries with directory indicators
 						const results: string[] = [];

--- a/src/resources/extensions/exa-search/extension-manifest.json
+++ b/src/resources/extensions/exa-search/extension-manifest.json
@@ -1,0 +1,12 @@
+{
+  "id": "exa-search",
+  "name": "Exa Search",
+  "version": "1.0.0",
+  "description": "Code context search and web search via Exa API — no API key required",
+  "tier": "bundled",
+  "requires": { "platform": ">=2.29.0" },
+  "provides": {
+    "tools": ["codesearch", "websearch"],
+    "hooks": ["session_start", "session_shutdown"]
+  }
+}

--- a/src/resources/extensions/exa-search/index.ts
+++ b/src/resources/extensions/exa-search/index.ts
@@ -1,0 +1,304 @@
+/**
+ * Exa Search Extension — 原生 pi 扩展
+ *
+ * 提供两个搜索工具：
+ *   codesearch  — 代码上下文搜索（API、库、SDK 文档与示例）
+ *   websearch   — 通用网页搜索
+ *
+ * 通过 Exa MCP 兼容端点实现，无需 API Key。
+ * 参照 Context7 扩展模式实现，使用共享 exa.ts 模块。
+ */
+
+import type { ExtensionAPI } from "@gsd/pi-coding-agent";
+import {
+	truncateHead,
+	DEFAULT_MAX_BYTES,
+	DEFAULT_MAX_LINES,
+	formatSize,
+} from "@gsd/pi-coding-agent";
+import { Text } from "@gsd/pi-tui";
+import { Type } from "@sinclair/typebox";
+import { callExaCodeSearch, callExaWebSearch } from "../search-the-web/exa.js";
+
+// ─── 会话缓存 ────────────────────────────────────────────────────────────────
+
+const codeSearchCache = new Map<string, { text: string; timestamp: number }>();
+const webSearchCache = new Map<string, { text: string; timestamp: number }>();
+const CACHE_TTL_MS = 10 * 60 * 1000; // 10 minutes
+
+// ─── 缓存辅助 ────────────────────────────────────────────────────────────────
+
+function getCached(
+	cache: Map<string, { text: string; timestamp: number }>,
+	key: string,
+): string | null {
+	const entry = cache.get(key);
+	if (!entry) return null;
+	if (Date.now() - entry.timestamp > CACHE_TTL_MS) {
+		cache.delete(key);
+		return null;
+	}
+	return entry.text;
+}
+
+function setCached(
+	cache: Map<string, { text: string; timestamp: number }>,
+	key: string,
+	text: string,
+): void {
+	cache.set(key, { text, timestamp: Date.now() });
+}
+
+function truncateOutput(text: string): { content: string; truncated: boolean } {
+	const truncation = truncateHead(text, {
+		maxLines: DEFAULT_MAX_LINES,
+		maxBytes: DEFAULT_MAX_BYTES,
+	});
+	let content = truncation.content;
+	if (truncation.truncated) {
+		content += `\n\n[Truncated: ${truncation.outputLines}/${truncation.totalLines} lines (${formatSize(truncation.outputBytes)} of ${formatSize(truncation.totalBytes)})]`;
+	}
+	return { content, truncated: truncation.truncated };
+}
+
+// ─── 扩展 ────────────────────────────────────────────────────────────────────
+
+export default function (pi: ExtensionAPI) {
+	// ── codesearch 工具 ────────────────────────────────────────────────────
+
+	pi.registerTool({
+		name: "codesearch",
+		label: "Code Search",
+		description:
+			"Search for code context, API documentation, and SDK examples using Exa. " +
+			"Use this to find relevant code snippets, library documentation, and programming examples. " +
+			"Works for any programming language, framework, or library.",
+		promptSnippet: "Search for code examples and API documentation",
+		promptGuidelines: [
+			"Use codesearch when you need current documentation, code examples, or API references for a library or framework.",
+			"Be specific in your query — 'React useState hook cleanup pattern' returns better results than just 'React hooks'.",
+			"Start with tokensNum=5000. Increase to 10000-20000 only if you need more comprehensive documentation.",
+			"codesearch returns content from across the web — it's not limited to the current project.",
+		],
+		parameters: Type.Object({
+			query: Type.String({
+				description:
+					"Search query for code context, e.g. 'React useState hook examples', " +
+					"'Python pandas dataframe filtering', 'Express.js middleware setup'",
+			}),
+			tokensNum: Type.Optional(
+				Type.Number({
+					description:
+						"Number of tokens to return (1000-50000, default 5000). " +
+						"Use lower values for focused queries, higher for comprehensive docs.",
+					minimum: 1000,
+					maximum: 50000,
+				}),
+			),
+		}),
+
+		async execute(_toolCallId, params, signal) {
+			const query = params.query.trim();
+			const tokensNum = params.tokensNum ?? 5000;
+			const cacheKey = `code:${query}::${tokensNum}`;
+
+			// Check cache
+            const cached = getCached(codeSearchCache, cacheKey);
+            if (cached) {
+                return {
+                    content: [{ type: "text", text: cached }],
+                    details: { query, tokensNum, cached: true as const, truncated: false as const, charCount: cached.length },
+                };
+            }
+
+			// Call Exa API
+			const result = await callExaCodeSearch(query, tokensNum, signal);
+
+			const output =
+				result ||
+				"No code snippets or documentation found. " +
+					"Try a different query or be more specific about the library or framework.";
+
+			const { content: finalText, truncated } = truncateOutput(output);
+			setCached(codeSearchCache, cacheKey, finalText);
+
+			return {
+				content: [{ type: "text", text: finalText }],
+				details: {
+					query,
+					tokensNum,
+					cached: false,
+					truncated,
+					charCount: finalText.length,
+				},
+			};
+		},
+
+		renderCall(args, theme) {
+			let text = theme.fg("toolTitle", theme.bold("codesearch "));
+			text += theme.fg("accent", `"${args.query}"`);
+			if (args.tokensNum && args.tokensNum !== 5000) {
+				text += theme.fg("dim", ` (${args.tokensNum} tokens)`);
+			}
+			return new Text(text, 0, 0);
+		},
+
+		renderResult(result, { isPartial, expanded }, theme) {
+			const d = result.details as {
+				query: string;
+				tokensNum: number;
+				cached: boolean;
+				truncated: boolean;
+				charCount: number;
+			} | undefined;
+
+			if (isPartial) return new Text(theme.fg("warning", "Searching Exa..."), 0, 0);
+
+			let text = theme.fg("success", `${(d?.charCount ?? 0).toLocaleString()} chars`);
+			if (d?.cached) text += theme.fg("dim", " (cached)");
+			if (d?.truncated) text += theme.fg("warning", " truncated");
+			text += theme.fg("dim", ` · "${d?.query}"`);
+
+			if (expanded) {
+				const content = result.content[0];
+				if (content?.type === "text") {
+					const preview = content.text.split("\n").slice(0, 12).join("\n");
+					text += "\n\n" + theme.fg("dim", preview);
+				}
+			}
+
+			return new Text(text, 0, 0);
+		},
+	});
+
+	// ── websearch 工具 ────────────────────────────────────────────────────
+
+	pi.registerTool({
+		name: "websearch",
+		label: "Web Search",
+		description:
+			"Search the web using Exa. Returns relevant web pages with content. " +
+			"Supports different search depths and live crawling for up-to-date results. " +
+			"No API key required.",
+		promptSnippet: "Search the web for information",
+		promptGuidelines: [
+			"Use websearch for general information queries, current events, or when codesearch doesn't cover the topic.",
+			"Use type='deep' for comprehensive research queries, 'fast' for quick lookups, or 'auto' for balanced results.",
+			"Set livecrawl='preferred' when you need the most current information from web pages.",
+			"Limit numResults to 3-5 for focused queries, 8-10 for broader research.",
+		],
+		parameters: Type.Object({
+			query: Type.String({
+				description: "Web search query",
+			}),
+			numResults: Type.Optional(
+				Type.Number({
+					description: "Number of search results to return (default: 8)",
+					minimum: 1,
+					maximum: 20,
+				}),
+			),
+			type: Type.Optional(
+				Type.Union(
+					[Type.Literal("auto"), Type.Literal("fast"), Type.Literal("deep")],
+					{
+						description:
+							"Search type: 'auto' (balanced, default), 'fast' (quick), 'deep' (comprehensive)",
+					},
+				),
+			),
+			livecrawl: Type.Optional(
+				Type.Union([Type.Literal("fallback"), Type.Literal("preferred")], {
+					description:
+						"Live crawl mode: 'fallback' (default) or 'preferred' (prioritize fresh content)",
+				}),
+			),
+			contextMaxCharacters: Type.Optional(
+				Type.Number({
+					description: "Maximum characters for context (default: 10000)",
+				}),
+			),
+		}),
+
+		async execute(_toolCallId, params, signal) {
+			const query = params.query.trim();
+			const cacheKey = `web:${query}::${params.type ?? "auto"}::${params.numResults ?? 8}`;
+
+            const cached = getCached(webSearchCache, cacheKey);
+            if (cached) {
+                return {
+                    content: [{ type: "text", text: cached }],
+                    details: { query, cached: true as const, truncated: false as const, charCount: cached.length },
+                };
+            }
+
+			const result = await callExaWebSearch(query, {
+				numResults: params.numResults,
+				type: params.type,
+				livecrawl: params.livecrawl,
+				contextMaxCharacters: params.contextMaxCharacters,
+			}, signal);
+
+			const output = result || "No search results found. Try a different query.";
+
+			const { content: finalText, truncated } = truncateOutput(output);
+			setCached(webSearchCache, cacheKey, finalText);
+
+			return {
+				content: [{ type: "text", text: finalText }],
+				details: {
+					query,
+					cached: false,
+					truncated,
+					charCount: finalText.length,
+				},
+			};
+		},
+
+		renderCall(args, theme) {
+			let text = theme.fg("toolTitle", theme.bold("websearch "));
+			text += theme.fg("accent", `"${args.query}"`);
+			if (args.type && args.type !== "auto") {
+				text += theme.fg("dim", ` (${args.type})`);
+			}
+			return new Text(text, 0, 0);
+		},
+
+		renderResult(result, { isPartial, expanded }, theme) {
+			const d = result.details as {
+				query: string;
+				cached: boolean;
+				truncated: boolean;
+				charCount: number;
+			} | undefined;
+
+			if (isPartial) return new Text(theme.fg("warning", "Searching web..."), 0, 0);
+
+			let text = theme.fg("success", `${(d?.charCount ?? 0).toLocaleString()} chars`);
+			if (d?.cached) text += theme.fg("dim", " (cached)");
+			if (d?.truncated) text += theme.fg("warning", " truncated");
+			text += theme.fg("dim", ` · "${d?.query}"`);
+
+			if (expanded) {
+				const content = result.content[0];
+				if (content?.type === "text") {
+					const preview = content.text.split("\n").slice(0, 12).join("\n");
+					text += "\n\n" + theme.fg("dim", preview);
+				}
+			}
+
+			return new Text(text, 0, 0);
+		},
+	});
+
+	// ── 生命周期 ──────────────────────────────────────────────────────────
+
+	pi.on("session_start", async (_event, ctx) => {
+		ctx.ui.notify("Exa search ready — no API key required", "info");
+	});
+
+	pi.on("session_shutdown", async () => {
+		codeSearchCache.clear();
+		webSearchCache.clear();
+	});
+}

--- a/src/resources/extensions/search-the-web/command-search-provider.ts
+++ b/src/resources/extensions/search-the-web/command-search-provider.ts
@@ -1,9 +1,9 @@
 /**
  * /search-provider slash command.
  *
- * Lets users switch between tavily, brave, and auto search backends.
+ * Lets users switch between tavily, brave, ollama, exa, and auto search backends.
  * Supports direct arg (`/search-provider tavily`) or interactive select UI.
- * Tab completion provides the three valid options with key status.
+ * Tab completion provides the valid options with key status.
  *
  * All provider logic lives in provider.ts (S01) — this is pure UI wiring.
  */
@@ -20,9 +20,10 @@ import {
   type SearchProviderPreference,
 } from './provider.js'
 
-const VALID_PREFERENCES: SearchProviderPreference[] = ['tavily', 'brave', 'ollama', 'auto']
+const VALID_PREFERENCES: SearchProviderPreference[] = ['tavily', 'brave', 'ollama', 'exa', 'auto']
 
-function keyStatus(provider: 'tavily' | 'brave' | 'ollama'): string {
+function keyStatus(provider: 'tavily' | 'brave' | 'ollama' | 'exa'): string {
+  if (provider === 'exa') return 'no key needed'
   if (provider === 'tavily') return getTavilyApiKey() ? '✓' : '✗'
   if (provider === 'ollama') return getOllamaApiKey() ? '✓' : '✗'
   return getBraveApiKey() ? '✓' : '✗'
@@ -33,6 +34,7 @@ function buildSelectOptions(): string[] {
     `tavily (key: ${keyStatus('tavily')})`,
     `brave (key: ${keyStatus('brave')})`,
     `ollama (key: ${keyStatus('ollama')})`,
+    `exa (no key required)`,
     `auto`,
   ]
 }
@@ -41,12 +43,13 @@ function parseSelectChoice(choice: string): SearchProviderPreference {
   if (choice.startsWith('tavily')) return 'tavily'
   if (choice.startsWith('brave')) return 'brave'
   if (choice.startsWith('ollama')) return 'ollama'
+  if (choice.startsWith('exa')) return 'exa'
   return 'auto'
 }
 
 export function registerSearchProviderCommand(pi: ExtensionAPI): void {
   pi.registerCommand('search-provider', {
-    description: 'Switch search provider (tavily, brave, ollama, auto)',
+    description: 'Switch search provider (tavily, brave, ollama, exa, auto)',
 
     getArgumentCompletions(prefix: string): AutocompleteItem[] | null {
       const trimmed = prefix.trim().toLowerCase()
@@ -55,7 +58,9 @@ export function registerSearchProviderCommand(pi: ExtensionAPI): void {
         .map((p) => {
           let description: string
           if (p === 'auto') {
-            description = `Auto-select (tavily: ${keyStatus('tavily')}, brave: ${keyStatus('brave')}, ollama: ${keyStatus('ollama')})`
+            description = `Auto-select (tavily: ${keyStatus('tavily')}, brave: ${keyStatus('brave')}, ollama: ${keyStatus('ollama')}, exa: no key needed)`
+          } else if (p === 'exa') {
+            description = 'no API key required'
           } else {
             description = `key: ${keyStatus(p)}`
           }
@@ -93,7 +98,7 @@ export function registerSearchProviderCommand(pi: ExtensionAPI): void {
       const isAnthropic = ctx.model?.provider === 'anthropic'
       const nativeNote = isAnthropic ? '\nNote: Native Anthropic web search is also active (automatic, no API key needed).' : ''
       ctx.ui.notify(
-        `Search provider set to ${chosen}. Effective provider: ${effective ?? 'none (no API keys)'}${nativeNote}`,
+        `Search provider set to ${chosen}. Effective provider: ${effective ?? 'none'}${nativeNote}`,
         'info',
       )
     },

--- a/src/resources/extensions/search-the-web/exa.test.ts
+++ b/src/resources/extensions/search-the-web/exa.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+
+// Mock fetch for testing
+let lastFetchRequest: { url: string; method: string; headers: Record<string, string>; body: string } | null = null;
+let mockFetchResponse: { ok: boolean; status: number; body: string } | null = null;
+const originalFetch = globalThis.fetch;
+
+function mockFetch(_url: string | URL, init?: RequestInit): Promise<Response> {
+  lastFetchRequest = {
+    url: typeof _url === "string" ? _url : _url.toString(),
+    method: init?.method ?? "GET",
+    headers: init?.headers as Record<string, string> ?? {},
+    body: init?.body as string ?? "",
+  };
+  if (!mockFetchResponse) {
+    return Promise.resolve(new Response("not configured", { status: 500 }));
+  }
+  return Promise.resolve(
+    new Response(mockFetchResponse.body, { status: mockFetchResponse.status }),
+  );
+}
+
+beforeEach(() => {
+  globalThis.fetch = mockFetch as typeof fetch;
+  lastFetchRequest = null;
+  mockFetchResponse = null;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+// Import after mock setup
+import { callExaCodeSearch, callExaWebSearch } from "./exa.js";
+
+describe("Exa API module", () => {
+  describe("callExaCodeSearch()", () => {
+    it("should send JSON-RPC request to Exa MCP endpoint", async () => {
+      mockFetchResponse = {
+        ok: true,
+        status: 200,
+        body: 'data: {"jsonrpc":"2.0","result":{"content":[{"type":"text","text":"React useState example code"}]}}\n\n',
+      };
+
+      const result = await callExaCodeSearch("React useState", 5000);
+
+      assert.ok(lastFetchRequest, "fetch should have been called");
+      assert.strictEqual(lastFetchRequest!.method, "POST");
+      assert.strictEqual(lastFetchRequest!.url, "https://mcp.exa.ai/mcp");
+      assert.strictEqual(lastFetchRequest!.headers["content-type"], "application/json");
+
+      const body = JSON.parse(lastFetchRequest!.body);
+      assert.strictEqual(body.jsonrpc, "2.0");
+      assert.strictEqual(body.method, "tools/call");
+      assert.strictEqual(body.params.name, "get_code_context_exa");
+      assert.strictEqual(body.params.arguments.query, "React useState");
+      assert.strictEqual(body.params.arguments.tokensNum, 5000);
+
+      assert.strictEqual(result, "React useState example code");
+    });
+
+    it("should return empty string when no results found", async () => {
+      mockFetchResponse = {
+        ok: true,
+        status: 200,
+        body: 'data: {"jsonrpc":"2.0","result":{"content":[]}}\n\n',
+      };
+
+      const result = await callExaCodeSearch("nonexistent query", 5000);
+      assert.strictEqual(result, "");
+    });
+
+    it("should throw on HTTP error", async () => {
+      mockFetchResponse = {
+        ok: false,
+        status: 429,
+        body: "rate limited",
+      };
+
+      await assert.rejects(
+        () => callExaCodeSearch("test", 5000),
+        (err: Error) => err.message.includes("429"),
+      );
+    });
+
+    it("should throw on API error response", async () => {
+      mockFetchResponse = {
+        ok: true,
+        status: 200,
+        body: 'data: {"jsonrpc":"2.0","error":{"code":-32600,"message":"Invalid request"}}\n\n',
+      };
+
+      await assert.rejects(
+        () => callExaCodeSearch("test", 5000),
+        (err: Error) => err.message.includes("Invalid request"),
+      );
+    });
+  });
+
+  describe("callExaWebSearch()", () => {
+    it("should send JSON-RPC request with web_search_exa tool name", async () => {
+      mockFetchResponse = {
+        ok: true,
+        status: 200,
+        body: 'data: {"jsonrpc":"2.0","result":{"content":[{"type":"text","text":"Search results here"}]}}\n\n',
+      };
+
+      const result = await callExaWebSearch("Node.js 22 release", {
+        numResults: 5,
+        type: "fast",
+        livecrawl: "fallback",
+      });
+
+      assert.ok(lastFetchRequest, "fetch should have been called");
+      const body = JSON.parse(lastFetchRequest!.body);
+      assert.strictEqual(body.params.name, "web_search_exa");
+      assert.strictEqual(body.params.arguments.query, "Node.js 22 release");
+      assert.strictEqual(body.params.arguments.type, "fast");
+      assert.strictEqual(body.params.arguments.numResults, 5);
+      assert.strictEqual(body.params.arguments.livecrawl, "fallback");
+
+      assert.strictEqual(result, "Search results here");
+    });
+
+    it("should use default values when options are not provided", async () => {
+      mockFetchResponse = {
+        ok: true,
+        status: 200,
+        body: 'data: {"jsonrpc":"2.0","result":{"content":[{"type":"text","text":"results"}]}}\n\n',
+      };
+
+      await callExaWebSearch("test query");
+
+      const body = JSON.parse(lastFetchRequest!.body);
+      assert.strictEqual(body.params.arguments.type, "auto");
+      assert.strictEqual(body.params.arguments.numResults, 8);
+      assert.strictEqual(body.params.arguments.livecrawl, "fallback");
+    });
+
+    it("should handle SSE responses with multiple data lines", async () => {
+      mockFetchResponse = {
+        ok: true,
+        status: 200,
+        body: 'event: ping\ndata: {}\n\ndata: {"jsonrpc":"2.0","result":{"content":[{"type":"text","text":"real results"}]}}\n\n',
+      };
+
+      const result = await callExaWebSearch("test");
+      assert.strictEqual(result, "real results");
+    });
+  });
+});

--- a/src/resources/extensions/search-the-web/exa.ts
+++ b/src/resources/extensions/search-the-web/exa.ts
@@ -1,0 +1,159 @@
+/**
+ * Exa API 共享调用模块
+ *
+ * 提供 callExaCodeSearch() 和 callExaWebSearch() 函数，
+ * 供 search-the-web 工具和 exa-search 扩展共同使用。
+ *
+ * 通过 Exa MCP 兼容端点通信，使用 JSON-RPC 2.0 格式，
+ * 无需 API Key。
+ */
+
+const API_CONFIG = {
+  BASE_URL: "https://mcp.exa.ai",
+  ENDPOINT: "/mcp",
+  CODE_SEARCH_TIMEOUT_MS: 30000,
+  WEB_SEARCH_TIMEOUT_MS: 25000,
+} as const;
+
+interface McpRequest {
+  jsonrpc: "2.0";
+  id: number;
+  method: "tools/call";
+  params: {
+    name: string;
+    arguments: Record<string, unknown>;
+  };
+}
+
+interface McpResponse {
+  jsonrpc: string;
+  result?: {
+    content: Array<{
+      type: string;
+      text: string;
+    }>;
+  };
+  error?: {
+    code: number;
+    message: string;
+  };
+}
+
+async function callExa(
+  toolName: string,
+  args: Record<string, unknown>,
+  timeoutMs: number,
+  signal?: AbortSignal,
+): Promise<string> {
+  const request: McpRequest = {
+    jsonrpc: "2.0",
+    id: 1,
+    method: "tools/call",
+    params: { name: toolName, arguments: args },
+  };
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+
+  if (signal) {
+    signal.addEventListener("abort", () => controller.abort(), { once: true });
+  }
+
+  try {
+    const response = await fetch(`${API_CONFIG.BASE_URL}${API_CONFIG.ENDPOINT}`, {
+      method: "POST",
+      headers: {
+        accept: "application/json, text/event-stream",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify(request),
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Exa API error (${response.status}): ${errorText.slice(0, 300)}`);
+    }
+
+    const responseText = await response.text();
+
+    // Parse SSE response
+    const lines = responseText.split("\n");
+    for (const line of lines) {
+      if (line.startsWith("data: ")) {
+        const data: McpResponse = JSON.parse(line.substring(6));
+        if (data.error) {
+          throw new Error(`Exa API error: ${data.error.message}`);
+        }
+        if (data.result?.content?.length && data.result.content[0].text) {
+          return data.result.content[0].text;
+        }
+      }
+    }
+
+    return "";
+  } catch (error) {
+    if (error instanceof Error && error.name === "AbortError") {
+      throw new Error("Exa search request timed out");
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+export interface ExaCodeSearchOptions {
+  query: string;
+  tokensNum?: number;
+}
+
+export interface ExaWebSearchOptions {
+  query: string;
+  numResults?: number;
+  type?: "auto" | "fast" | "deep";
+  livecrawl?: "fallback" | "preferred";
+  contextMaxCharacters?: number;
+}
+
+/**
+ * Call Exa code context search
+ * @param query Search query for code context
+ * @param tokensNum Number of tokens to return (1000-50000, default 5000)
+ * @param signal Optional abort signal
+ */
+export async function callExaCodeSearch(
+  query: string,
+  tokensNum: number = 5000,
+  signal?: AbortSignal,
+): Promise<string> {
+  return callExa(
+    "get_code_context_exa",
+    { query, tokensNum },
+    API_CONFIG.CODE_SEARCH_TIMEOUT_MS,
+    signal,
+  );
+}
+
+/**
+ * Call Exa web search
+ * @param opts Search options
+ * @param signal Optional abort signal
+ */
+export async function callExaWebSearch(
+  query: string,
+  opts?: Omit<ExaWebSearchOptions, "query">,
+  signal?: AbortSignal,
+): Promise<string> {
+  return callExa(
+    "web_search_exa",
+    {
+      query,
+      type: opts?.type ?? "auto",
+      numResults: opts?.numResults ?? 8,
+      livecrawl: opts?.livecrawl ?? "fallback",
+      contextMaxCharacters: opts?.contextMaxCharacters,
+    },
+    API_CONFIG.WEB_SEARCH_TIMEOUT_MS,
+    signal,
+  );
+}

--- a/src/resources/extensions/search-the-web/native-search.ts
+++ b/src/resources/extensions/search-the-web/native-search.ts
@@ -123,8 +123,8 @@ export function registerNativeSearchHooks(pi: NativeSearchPI): { getIsAnthropic:
       ctx.ui.notify("Brave search active (PREFER_BRAVE_SEARCH)", "info");
     } else if (!isAnthropicProvider && !hasBrave) {
       ctx.ui.notify(
-        "Web search: Set BRAVE_API_KEY or use an Anthropic model for built-in search",
-        "warning"
+        "Web search: Using Exa (no API key needed). Set BRAVE_API_KEY for Brave search.",
+        "info"
       );
     }
   });

--- a/src/resources/extensions/search-the-web/provider.ts
+++ b/src/resources/extensions/search-the-web/provider.ts
@@ -20,10 +20,10 @@ import { resolveSearchProviderFromPreferences } from '../gsd/preferences.js'
 const gsdHome = process.env.GSD_HOME || join(homedir(), '.gsd')
 const authFilePath = join(gsdHome, 'agent', 'auth.json')
 
-export type SearchProvider = 'tavily' | 'brave' | 'ollama'
+export type SearchProvider = 'tavily' | 'brave' | 'ollama' | 'exa'
 export type SearchProviderPreference = SearchProvider | 'auto'
 
-const VALID_PREFERENCES = new Set<string>(['tavily', 'brave', 'ollama', 'auto'])
+const VALID_PREFERENCES = new Set<string>(['tavily', 'brave', 'ollama', 'exa', 'auto'])
 const PREFERENCE_KEY = 'search_provider'
 
 /** Returns the Tavily API key from the environment, or empty string if not set. */
@@ -117,33 +117,37 @@ export function resolveSearchProvider(overridePreference?: string): SearchProvid
   }
 
   // Resolve based on preference
+  if (pref === 'exa') {
+    return 'exa' // Exa never needs an API key
+  }
+
   if (pref === 'auto') {
     if (hasTavily) return 'tavily'
     if (hasBrave) return 'brave'
     if (hasOllama) return 'ollama'
-    return null
+    return 'exa' // Fallback to Exa (no API key needed)
   }
 
   if (pref === 'tavily') {
     if (hasTavily) return 'tavily'
     if (hasBrave) return 'brave'
     if (hasOllama) return 'ollama'
-    return null
+    return 'exa'
   }
 
   if (pref === 'brave') {
     if (hasBrave) return 'brave'
     if (hasTavily) return 'tavily'
     if (hasOllama) return 'ollama'
-    return null
+    return 'exa'
   }
 
   if (pref === 'ollama') {
     if (hasOllama) return 'ollama'
     if (hasTavily) return 'tavily'
     if (hasBrave) return 'brave'
-    return null
+    return 'exa'
   }
 
-  return null
+  return 'exa'
 }

--- a/src/resources/extensions/search-the-web/tool-llm-context.ts
+++ b/src/resources/extensions/search-the-web/tool-llm-context.ts
@@ -27,7 +27,8 @@ import { normalizeQuery, extractDomain } from "./url-utils.js";
 import { formatLLMContext, type LLMContextSnippet, type LLMContextSource } from "./format.js";
 import type { TavilyResult, TavilySearchResponse } from "./tavily.js";
 import { publishedDateToAge } from "./tavily.js";
-import { getTavilyApiKey, getOllamaApiKey, getBraveApiKey, braveHeaders, resolveSearchProvider } from "./provider.js";
+import { getTavilyApiKey, getOllamaApiKey, getBraveApiKey, braveHeaders, resolveSearchProvider, type SearchProvider } from "./provider.js";
+import { callExaWebSearch } from "./exa.js";
 
 // =============================================================================
 // Types
@@ -79,7 +80,7 @@ interface LLMContextDetails {
   errorKind?: string;
   error?: string;
   retryAfterMs?: number;
-  provider?: 'tavily' | 'brave' | 'ollama';
+  provider?: SearchProvider;
 }
 
 // =============================================================================
@@ -405,6 +406,21 @@ export function registerLLMContextTool(pi: ExtensionAPI) {
           result = ollamaResult.cached;
           latencyMs = ollamaResult.latencyMs;
           rateLimit = ollamaResult.rateLimit;
+        } else if (provider === "exa") {
+          // Exa path — no API key needed, returns pre-formatted text
+          const exaResult = await callExaWebSearch(params.query, {
+            numResults: count,
+          }, signal);
+
+          // Wrap Exa text result into the LLM context format
+          const grounding: LLMContextSnippet[] = exaResult
+            ? [{ url: "", title: "Exa Search", snippets: [exaResult.slice(0, 2000)] }]
+            : [];
+          result = {
+            grounding,
+            sources: {},
+            estimatedTokens: Math.ceil((exaResult?.length ?? 0) / 4),
+          };
         } else {
           // ================================================================
           // BRAVE PATH (unchanged API logic)

--- a/src/resources/extensions/search-the-web/tool-search.ts
+++ b/src/resources/extensions/search-the-web/tool-search.ts
@@ -20,8 +20,9 @@ import { LRUTTLCache } from "./cache.js";
 import { fetchWithRetryTimed, fetchWithRetry, classifyError, type RateLimitInfo } from "./http.js";
 import { normalizeQuery, toDedupeKey, detectFreshness } from "./url-utils.js";
 import { formatSearchResults, type SearchResultFormatted, type FormatSearchOptions } from "./format.js";
-import { getTavilyApiKey, getOllamaApiKey, getBraveApiKey, braveHeaders, resolveSearchProvider } from "./provider.js";
+import { getTavilyApiKey, getOllamaApiKey, getBraveApiKey, braveHeaders, resolveSearchProvider, type SearchProvider } from "./provider.js";
 import { normalizeTavilyResult, mapFreshnessToTavily, type TavilySearchResponse } from "./tavily.js";
+import { callExaWebSearch } from "./exa.js";
 
 // =============================================================================
 // Types
@@ -93,7 +94,7 @@ interface SearchDetails {
   errorKind?: string;
   error?: string;
   retryAfterMs?: number;
-  provider?: 'tavily' | 'brave' | 'ollama';
+  provider?: SearchProvider;
 }
 
 // =============================================================================
@@ -355,11 +356,13 @@ export function registerSearchTool(pi: ExtensionAPI) {
       // Resolve search provider
       // ------------------------------------------------------------------
       const provider = resolveSearchProvider();
+      // Exa is always available as fallback, so provider should never be null.
+      // Keep null check as defensive guard for unexpected edge cases.
       if (!provider) {
         return {
-          content: [{ type: "text", text: "Web search unavailable: No search API key is set. Use secure_env_collect to set TAVILY_API_KEY, BRAVE_API_KEY, or OLLAMA_API_KEY." }],
+          content: [{ type: "text", text: "Web search unavailable: No search provider could be resolved. Please check your configuration." }],
           isError: true,
-          details: { errorKind: "auth_error", error: "No search API key set" } satisfies Partial<SearchDetails>,
+          details: { errorKind: "auth_error", error: "No search provider resolved" } satisfies Partial<SearchDetails>,
         };
       }
 
@@ -490,7 +493,44 @@ export function registerSearchTool(pi: ExtensionAPI) {
         let latencyMs: number | undefined;
         let rateLimit: RateLimitInfo | undefined;
 
-        if (provider === "tavily") {
+        if (provider === "exa") {
+          // Exa path — no API key needed
+          const exaResult = await callExaWebSearch(params.query, {
+            numResults: count,
+          }, signal);
+
+          // Exa returns pre-formatted text, use it directly
+          const exaResults: SearchResultFormatted[] = exaResult
+            ? [{ title: "Exa Search Result", url: "", description: exaResult.slice(0, 500) }]
+            : [];
+
+          searchResult = {
+            results: exaResults,
+          };
+
+          // For Exa, bypass the normal formatting and return the raw text
+          const output = exaResult || "No search results found. Try a different query.";
+          const truncation = truncateHead(output, { maxLines: DEFAULT_MAX_LINES, maxBytes: DEFAULT_MAX_BYTES });
+          let content = truncation.content;
+          if (truncation.truncated) {
+            content += `\n\n[Truncated: ${truncation.outputLines}/${truncation.totalLines} lines (${formatSize(truncation.outputBytes)}/${formatSize(truncation.totalBytes)})]`;
+          }
+
+          searchCache.set(cacheKey, searchResult);
+
+          const details: SearchDetails = {
+            query: params.query,
+            effectiveQuery,
+            results: exaResults,
+            count: exaResults.length,
+            cached: false,
+            freshness: freshness || "none",
+            hasSummary: false,
+            provider,
+          };
+
+          return { content: [{ type: "text", text: content }], details };
+        } else if (provider === "tavily") {
           const tavilyResult = await executeTavilySearch(
             { query: params.query, freshness, domain: params.domain, wantSummary },
             signal

--- a/src/tests/native-search.test.ts
+++ b/src/tests/native-search.test.ts
@@ -403,7 +403,7 @@ test("model_select shows 'Native Anthropic web search active' for Anthropic prov
   );
 });
 
-test("model_select shows warning for non-Anthropic without Brave key", async (t) => {
+test("model_select shows info for non-Anthropic without Brave key (Exa fallback)", async (t) => {
   const originalKey = process.env.BRAVE_API_KEY;
   delete process.env.BRAVE_API_KEY;
 
@@ -421,11 +421,11 @@ test("model_select shows warning for non-Anthropic without Brave key", async (t)
     source: "set",
   });
 
-  const warning = pi.notifications.find((n) => n.level === "warning");
-  assert.ok(warning, "Should show warning for non-Anthropic without Brave key");
+  const info = pi.notifications.find((n) => n.level === "info" && n.message.includes("Exa"));
+  assert.ok(info, "Should show info about Exa fallback for non-Anthropic without Brave key");
   assert.ok(
-    warning!.message.includes("Anthropic"),
-    `Warning should mention Anthropic — got: ${warning!.message}`
+    info!.message.includes("Exa"),
+    `Info should mention Exa — got: ${info!.message}`
   );
 });
 

--- a/src/tests/provider.test.ts
+++ b/src/tests/provider.test.ts
@@ -106,13 +106,13 @@ test('resolveSearchProvider returns brave when both keys set and preference is b
   })
 })
 
-test('resolveSearchProvider returns null when neither key is set', async () => {
+test('resolveSearchProvider returns exa when neither key is set', async () => {
   const { resolveSearchProvider } = await import(
     '../resources/extensions/search-the-web/provider.ts'
   )
   withEnv({ TAVILY_API_KEY: undefined, BRAVE_API_KEY: undefined, OLLAMA_API_KEY: undefined }, () => {
     const result = resolveSearchProvider('auto')
-    assert.equal(result, null)
+    assert.equal(result, 'exa')
   })
 })
 

--- a/src/tests/search-provider-command.test.ts
+++ b/src/tests/search-provider-command.test.ts
@@ -191,7 +191,7 @@ test('direct arg "auto" sets preference and notifies', async (t) => {
 // 4. No arg — shows select UI, user picks one
 // ═══════════════════════════════════════════════════════════════════════════
 
-test('no arg shows select UI with 3 options, user picks brave', async () => {
+test('no arg shows select UI with options including exa, user picks brave', async () => {
   const cmd = await loadCommand()
 
   await withEnv({ TAVILY_API_KEY: 'tvly-test', BRAVE_API_KEY: 'BSA-test' }, async () => {
@@ -200,13 +200,14 @@ test('no arg shows select UI with 3 options, user picks brave', async () => {
 
     // Select UI shown
     assert.equal(ctx.ui.selectCalls.length, 1, 'should show select UI')
-    assert.equal(ctx.ui.selectCalls[0].options.length, 4)
+    assert.equal(ctx.ui.selectCalls[0].options.length, 5)
 
     // Options show key status
     assert.match(ctx.ui.selectCalls[0].options[0], /tavily \(key: ✓\)/)
     assert.match(ctx.ui.selectCalls[0].options[1], /brave \(key: ✓\)/)
     assert.match(ctx.ui.selectCalls[0].options[2], /ollama \(key:/)
-    assert.equal(ctx.ui.selectCalls[0].options[3], 'auto')
+    assert.match(ctx.ui.selectCalls[0].options[3], /exa/)
+    assert.equal(ctx.ui.selectCalls[0].options[4], 'auto')
 
     // Title shows current preference
     assert.match(ctx.ui.selectCalls[0].title, /current:/)
@@ -263,19 +264,19 @@ test('invalid arg "google" falls back to interactive select', async () => {
 })
 
 // ═══════════════════════════════════════════════════════════════════════════
-// 7. Tab completion — all 3 options when prefix is empty
+// 7. Tab completion — all options when prefix is empty
 // ═══════════════════════════════════════════════════════════════════════════
 
-test('tab completion returns all 4 options when prefix is empty', async () => {
+test('tab completion returns all 5 options when prefix is empty', async () => {
   const cmd = await loadCommand()
 
   withEnv({ TAVILY_API_KEY: 'tvly-test', BRAVE_API_KEY: 'BSA-test' }, () => {
     const items = cmd.getArgumentCompletions!('')
     assert.ok(items, 'completions should not be null')
-    assert.equal(items!.length, 4)
+    assert.equal(items!.length, 5)
 
     const values = items!.map((i: any) => i.value)
-    assert.deepEqual(values, ['tavily', 'brave', 'ollama', 'auto'])
+    assert.deepEqual(values, ['tavily', 'brave', 'ollama', 'exa', 'auto'])
 
     // Each item has label and description
     assert.ok(items!.every((i: any) => i.label), 'every item should have a label')
@@ -318,10 +319,10 @@ test('notify message shows effective provider (fallback case)', async () => {
 })
 
 // ═══════════════════════════════════════════════════════════════════════════
-// 10. Notify message shows "none" when no keys available
+// 10. Notify message shows "exa" when no keys available (Exa is always fallback)
 // ═══════════════════════════════════════════════════════════════════════════
 
-test('notify message shows "none" when no API keys available', async () => {
+test('notify message shows "exa" when no API keys available', async () => {
   const cmd = await loadCommand()
 
   await withEnv({ TAVILY_API_KEY: undefined, BRAVE_API_KEY: undefined }, async () => {
@@ -329,7 +330,7 @@ test('notify message shows "none" when no API keys available', async () => {
     await cmd.handler('auto', ctx)
 
     assert.equal(ctx.ui.notifyCalls.length, 1)
-    assert.match(ctx.ui.notifyCalls[0].message, /Effective provider: none/)
+    assert.match(ctx.ui.notifyCalls[0].message, /Effective provider: exa/)
   })
 })
 

--- a/src/tests/search-tavily.test.ts
+++ b/src/tests/search-tavily.test.ts
@@ -181,7 +181,7 @@ test("resolveSearchProvider returns 'brave' when only BRAVE_API_KEY is set", (t)
   assert.equal(provider, "brave");
 });
 
-test("resolveSearchProvider returns null when neither key is set", (t) => {
+test("resolveSearchProvider returns exa when neither key is set", (t) => {
   const origTavily = process.env.TAVILY_API_KEY;
   const origBrave = process.env.BRAVE_API_KEY;
 
@@ -196,7 +196,7 @@ test("resolveSearchProvider returns null when neither key is set", (t) => {
   });
 
   const provider = resolveSearchProvider();
-  assert.equal(provider, null);
+  assert.equal(provider, "exa");
 });
 
 // =============================================================================


### PR DESCRIPTION
…ified search provider config

- Add FileIgnore module with common ignore directories (node_modules, dist, .git, etc.) and file patterns (*.swp, *.pyc, .DS_Store, etc.) for grep/find/ls tools
- Add Exa search as native pi extension (no API key required) with codesearch and websearch tools
- Add Exa as fallback search provider when no API keys are configured
- Update search provider selection UI to include Exa option
- Add shared exa.ts module for JSON-RPC 2.0 communication with Exa MCP endpoint
- Update related tests for new Exa fallback behavior

## TL;DR

**What:** <!-- One sentence — what does this change? -->
**Why:** <!-- One sentence — why is it needed? -->
**How:** <!-- One sentence — what's the approach? -->

## What

<!-- Detailed description of the change. What files, modules, or systems are affected? -->

## Why

<!-- The motivation. What problem does this solve? Link issues: Closes #123 -->

## How

<!-- The approach. How does the implementation work? Key decisions and alternatives considered? -->

## Change type

- [ ] `feat` — New feature or capability
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [ ] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [ ] No breaking changes
- [ ] Yes — described above

## Test plan

- [ ] CI passes
- [ ] New/updated tests included
- [ ] Manual testing — steps described above
- [ ] No tests needed — explained above

## AI disclosure

- [ ] This PR includes AI-assisted code <!-- If so, note the tool and what was tested -->
