### PR TITLE
fix(gsd): add missing dirs to codebase generator exclude list

### DIFF
--- a/src/resources/extensions/gsd/codebase-generator.ts
+++ b/src/resources/extensions/gsd/codebase-generator.ts
@@ -71,13 +71,23 @@ interface EnumeratedFiles {
 // ─── Defaults ────────────────────────────────────────────────────────────────
 
 const DEFAULT_EXCLUDES = [
+  // ── AI / tooling meta ──
+  ".agents/",
   ".gsd/",
   ".planning/",
   ".plans/",
   ".claude/",
   ".cursor/",
+  ".bg-shell/",
+
+  // ── Editor / IDE ──
   ".vscode/",
+  ".idea/",
+
+  // ── VCS ──
   ".git/",
+
+  // ── Dependencies & build artifacts ──
   "node_modules/",
   "dist/",
   "build/",
@@ -85,7 +95,13 @@ const DEFAULT_EXCLUDES = [
   "coverage/",
   "__pycache__/",
   ".venv/",
+  "venv/",
   "vendor/",
+  "target/",
+
+  // ── Misc ──
+  ".cache/",
+  "tmp/",
 ];
 
 const DEFAULT_MAX_FILES = 500;

--- a/src/resources/extensions/gsd/tests/codebase-generator.test.ts
+++ b/src/resources/extensions/gsd/tests/codebase-generator.test.ts
@@ -162,6 +162,34 @@ test("generateCodebaseMap: excludes .claude/ and other tool directories", () => 
   }
 });
 
+test("generateCodebaseMap: excludes .agents/ and other tooling directories", () => {
+  const base = makeTmpRepo();
+  try {
+    addFile(base, "src/main.ts");
+    addFile(base, ".agents/skills/pdf/SKILL.md");
+    addFile(base, ".agents/skills/find-skills/SKILL.md");
+    addFile(base, ".bg-shell/session.json");
+    addFile(base, ".idea/workspace.xml");
+    addFile(base, ".cache/data.bin");
+    addFile(base, "tmp/scratch.ts");
+    addFile(base, "target/debug/build.rs");
+    addFile(base, "venv/lib/site.py");
+
+    const result = generateCodebaseMap(base);
+    assert.ok(result.content.includes("`src/main.ts`"), "should include src/main.ts");
+    assert.ok(!result.content.includes("SKILL.md"), "should exclude .agents/ files");
+    assert.ok(!result.content.includes(".bg-shell"), "should exclude .bg-shell/ files");
+    assert.ok(!result.content.includes(".idea"), "should exclude .idea/ files");
+    assert.ok(!result.content.includes(".cache"), "should exclude .cache/ files");
+    assert.ok(!result.content.includes("tmp/"), "should exclude tmp/ files");
+    assert.ok(!result.content.includes("target"), "should exclude target/ files");
+    assert.ok(!result.content.includes("venv"), "should exclude venv/ files");
+    assert.equal(result.fileCount, 1);
+  } finally {
+    cleanup(base);
+  }
+});
+
 test("generateCodebaseMap: excludes binary and lock files", () => {
   const base = makeTmpRepo();
   try {


### PR DESCRIPTION
## TL;DR

**What:** Add missing directories to codebase generator's DEFAULT_EXCLUDES list.
**Why:** `/gsd-new-project` scans .agents/ skill files as project code, confusing researcher agents.
**How:** Add `.agents/`, `.bg-shell/`, `.idea/`, `venv/`, `target/`, `.cache/`, `tmp/` to the exclude array, aligning with gitignore.ts patterns.

## What

Adds 7 missing directories to `DEFAULT_EXCLUDES` in `codebase-generator.ts` and adds a regression test covering all new exclusions.

Files changed:
- `src/resources/extensions/gsd/codebase-generator.ts` — added entries to `DEFAULT_EXCLUDES`
- `src/resources/extensions/gsd/tests/codebase-generator.test.ts` — regression test

## Why

When running `/gsd-new-project` on a project with an `.agents/skills/` directory, the codebase generator includes SKILL.md and other agent files in CODEBASE.md. Researcher agents then receive these as context and misidentify the project as an "agent skills repository."

All of these directories are already in GSD's gitignore template (`gitignore.ts`) but were missing from the scanner's exclude list.

Closes #3940

## How

Added the missing directories to the `DEFAULT_EXCLUDES` array, organized by category (AI/tooling, editor/IDE, dependencies/build, misc). Added a regression test that creates files in all newly excluded directories and verifies none appear in the generated codebase map.

- [x] `fix` — Bug fix
- [x] `test` — Adding or updating tests

AI-assisted: This PR was developed with AI assistance.