### PR TITLE
fix(mcp-server): URL scheme regex matches Windows drive letters

### DIFF
--- a/packages/mcp-server/src/workflow-tools.test.ts
+++ b/packages/mcp-server/src/workflow-tools.test.ts
@@ -974,3 +974,31 @@ describe("workflow MCP tools", () => {
     }
   });
 });
+
+describe("URL scheme regex — Windows drive letter safety", () => {
+  // This is the regex used in getWriteGateModuleCandidates() and
+  // getWorkflowExecutorModuleCandidates() to reject non-file URL schemes.
+  // It must NOT match single-letter Windows drive prefixes (C:, D:, etc.).
+  const urlSchemeRegex = /^[a-z]{2,}:/i;
+
+  it("rejects multi-letter URL schemes", () => {
+    assert.ok(urlSchemeRegex.test("http://example.com"), "http: should match");
+    assert.ok(urlSchemeRegex.test("https://example.com"), "https: should match");
+    assert.ok(urlSchemeRegex.test("ftp://files.example.com"), "ftp: should match");
+    assert.ok(urlSchemeRegex.test("file:///C:/Users"), "file: should match");
+    assert.ok(urlSchemeRegex.test("node:fs"), "node: should match");
+  });
+
+  it("allows single-letter Windows drive prefixes", () => {
+    assert.ok(!urlSchemeRegex.test("C:\\Users\\user\\project"), "C:\\ should not match");
+    assert.ok(!urlSchemeRegex.test("D:\\other\\path"), "D:\\ should not match");
+    assert.ok(!urlSchemeRegex.test("c:\\lowercase\\drive"), "c:\\ should not match");
+    assert.ok(!urlSchemeRegex.test("E:/forward/slash/path"), "E:/ should not match");
+  });
+
+  it("allows bare filesystem paths", () => {
+    assert.ok(!urlSchemeRegex.test("/usr/local/lib/module.js"), "unix absolute path should not match");
+    assert.ok(!urlSchemeRegex.test("./relative/path.js"), "relative path should not match");
+    assert.ok(!urlSchemeRegex.test("../parent/path.js"), "parent relative path should not match");
+  });
+});

--- a/packages/mcp-server/src/workflow-tools.ts
+++ b/packages/mcp-server/src/workflow-tools.ts
@@ -318,7 +318,7 @@ function getWriteGateModuleCandidates(): string[] {
   const candidates: string[] = [];
   const explicitModule = process.env.GSD_WORKFLOW_WRITE_GATE_MODULE?.trim();
   if (explicitModule) {
-    if (/^[a-z]+:/i.test(explicitModule) && !explicitModule.startsWith("file:")) {
+    if (/^[a-z]{2,}:/i.test(explicitModule) && !explicitModule.startsWith("file:")) {
       throw new Error("GSD_WORKFLOW_WRITE_GATE_MODULE only supports file: URLs or filesystem paths.");
     }
     candidates.push(explicitModule.startsWith("file:") ? explicitModule : toFileUrl(explicitModule));
@@ -340,7 +340,7 @@ function getWorkflowExecutorModuleCandidates(env: NodeJS.ProcessEnv = process.en
   const candidates: string[] = [];
   const explicitModule = env.GSD_WORKFLOW_EXECUTORS_MODULE?.trim();
   if (explicitModule) {
-    if (/^[a-z]+:/i.test(explicitModule) && !explicitModule.startsWith("file:")) {
+    if (/^[a-z]{2,}:/i.test(explicitModule) && !explicitModule.startsWith("file:")) {
       throw new Error("GSD_WORKFLOW_EXECUTORS_MODULE only supports file: URLs or filesystem paths.");
     }
     candidates.push(explicitModule.startsWith("file:") ? explicitModule : toFileUrl(explicitModule));


### PR DESCRIPTION
## TL;DR

**What:** Fix URL scheme detection regex to stop rejecting Windows drive letter paths.
**Why:** On Windows, `C:\path` matches `/^[a-z]+:/i` as a URL scheme, breaking all write-gate gsd_* tools.
**How:** Change `[a-z]+:` to `[a-z]{2,}:` — no IANA-registered URL scheme is a single letter.

## What

Two lines changed in `packages/mcp-server/src/workflow-tools.ts` (lines 321 and 343):
- `getWriteGateModuleCandidates()` — URL scheme guard regex
- `getWorkflowExecutorModuleCandidates()` — URL scheme guard regex

Also adds `.mcp.json` to `.gitignore` (local machine-specific MCP config containing the paths affected by this bug).

## Why

On Windows, `GSD_WORKFLOW_WRITE_GATE_MODULE` and `GSD_WORKFLOW_EXECUTORS_MODULE` env vars contain paths like `C:\Users\...`. The regex `/^[a-z]+:/i` matches `C:` as a URL scheme and throws:

> "Module specifier must be a file: URLs or filesystem paths"

Read-only tools work fine — only the write-gate module loader is affected.

Closes #3942

## How

Changed `/^[a-z]+:/i` to `/^[a-z]{2,}:/i`. Every IANA-registered URL scheme is 2+ characters (http, https, ftp, file, node, etc.). Windows drive letters are exactly 1 character (C, D, E). The `{2,}` quantifier excludes single-letter prefixes while still catching all real URL schemes.

Regression tests added covering:
- Multi-letter URL schemes still match (http:, https:, ftp:, file:, node:)
- Single-letter Windows drive prefixes do not match (C:\, D:\, c:\, E:/)
- Bare filesystem paths do not match (unix absolute, relative, parent)

### Change type

- [x] `fix` — Bug fix

> This PR is AI-assisted (Claude Code). The contributor understands and can explain all changes.