### PR TITLE
fix(mcp-server): hydrate stored tool credentials on startup

### DIFF
--- a/docs/user-docs/configuration.md
+++ b/docs/user-docs/configuration.md
@@ -148,6 +148,7 @@ Recommended verification order:
 
 - Use absolute paths for local executables and scripts when possible.
 - For `stdio` servers, prefer setting required environment variables directly in the MCP config instead of relying on an interactive shell profile.
+- GSD and `gsd-mcp-server` both hydrate supported tool keys saved in `~/.gsd/agent/auth.json`, so MCP configs can safely reference them through `${ENV_VAR}` placeholders without committing raw credentials.
 - If a server is team-shared and safe to commit, `.mcp.json` is usually the better home.
 - If a server depends on machine-local paths, personal services, or local-only secrets, prefer `.gsd/mcp.json`.
 

--- a/docs/user-docs/configuration.md
+++ b/docs/user-docs/configuration.md
@@ -148,7 +148,7 @@ Recommended verification order:
 
 - Use absolute paths for local executables and scripts when possible.
 - For `stdio` servers, prefer setting required environment variables directly in the MCP config instead of relying on an interactive shell profile.
-- GSD and `gsd-mcp-server` both hydrate supported tool keys saved in `~/.gsd/agent/auth.json`, so MCP configs can safely reference them through `${ENV_VAR}` placeholders without committing raw credentials.
+- GSD and `gsd-mcp-server` both hydrate supported model and tool keys saved in `~/.gsd/agent/auth.json`, so MCP configs can safely reference them through `${ENV_VAR}` placeholders without committing raw credentials.
 - If a server is team-shared and safe to commit, `.mcp.json` is usually the better home.
 - If a server depends on machine-local paths, personal services, or local-only secrets, prefer `.gsd/mcp.json`.
 

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -234,7 +234,7 @@ Resolve a pending blocker in a session by sending a response to the blocked UI r
 | `GSD_CLI_PATH` | Absolute path to the GSD CLI binary. If not set, the server resolves `gsd` via `which`. |
 | `GSD_WORKFLOW_EXECUTORS_MODULE` | Optional absolute path or `file:` URL for the shared GSD workflow executor module used by workflow mutation tools. |
 
-The server also hydrates supported tool credentials from `~/.gsd/agent/auth.json` on startup. Keys saved through `/gsd config` become available to the MCP server process automatically, and any explicitly-set environment variable still wins.
+The server also hydrates supported model-provider and tool credentials from `~/.gsd/agent/auth.json` on startup. Keys saved through `/gsd config` or `/gsd keys` become available to the MCP server process automatically, and any explicitly-set environment variable still wins.
 
 ## Architecture
 

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -234,6 +234,8 @@ Resolve a pending blocker in a session by sending a response to the blocked UI r
 | `GSD_CLI_PATH` | Absolute path to the GSD CLI binary. If not set, the server resolves `gsd` via `which`. |
 | `GSD_WORKFLOW_EXECUTORS_MODULE` | Optional absolute path or `file:` URL for the shared GSD workflow executor module used by workflow mutation tools. |
 
+The server also hydrates supported tool credentials from `~/.gsd/agent/auth.json` on startup. Keys saved through `/gsd config` become available to the MCP server process automatically, and any explicitly-set environment variable still wins.
+
 ## Architecture
 
 ```

--- a/packages/mcp-server/src/cli.ts
+++ b/packages/mcp-server/src/cli.ts
@@ -7,10 +7,13 @@
 
 import { SessionManager } from './session-manager.js';
 import { createMcpServer } from './server.js';
+import { loadStoredToolEnvKeys } from './tool-credentials.js';
 
 const MCP_PKG = '@modelcontextprotocol/sdk';
 
 async function main(): Promise<void> {
+  loadStoredToolEnvKeys();
+
   const sessionManager = new SessionManager();
 
   // Create the configured MCP server with session, interactive, read-only,

--- a/packages/mcp-server/src/cli.ts
+++ b/packages/mcp-server/src/cli.ts
@@ -7,12 +7,12 @@
 
 import { SessionManager } from './session-manager.js';
 import { createMcpServer } from './server.js';
-import { loadStoredToolEnvKeys } from './tool-credentials.js';
+import { loadStoredCredentialEnvKeys } from './tool-credentials.js';
 
 const MCP_PKG = '@modelcontextprotocol/sdk';
 
 async function main(): Promise<void> {
-  loadStoredToolEnvKeys();
+  loadStoredCredentialEnvKeys();
 
   const sessionManager = new SessionManager();
 

--- a/packages/mcp-server/src/tool-credentials.test.ts
+++ b/packages/mcp-server/src/tool-credentials.test.ts
@@ -1,0 +1,66 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { loadStoredToolEnvKeys, resolveAuthPath } from "./tool-credentials.js";
+
+describe("tool credentials", () => {
+  it("hydrates supported keys from auth.json", () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "gsd-mcp-auth-"));
+    const authPath = join(tempRoot, "auth.json");
+    const env: NodeJS.ProcessEnv = {};
+
+    try {
+      writeFileSync(authPath, JSON.stringify({
+        tavily: { type: "api_key", key: "tvly-secret" },
+        context7: [{ type: "api_key", key: "ctx7-secret" }],
+        anthropic: { type: "api_key", key: "sk-ant-ignore" },
+      }));
+
+      const loaded = loadStoredToolEnvKeys({ authPath, env });
+      assert.deepEqual(loaded.sort(), ["CONTEXT7_API_KEY", "TAVILY_API_KEY"]);
+      assert.equal(env.TAVILY_API_KEY, "tvly-secret");
+      assert.equal(env.CONTEXT7_API_KEY, "ctx7-secret");
+      assert.equal(env.ANTHROPIC_API_KEY, undefined);
+    } finally {
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("does not overwrite explicit environment variables", () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "gsd-mcp-auth-"));
+    const authPath = join(tempRoot, "auth.json");
+    const env: NodeJS.ProcessEnv = {
+      BRAVE_API_KEY: "already-set",
+    };
+
+    try {
+      writeFileSync(authPath, JSON.stringify({
+        brave: { type: "api_key", key: "from-auth-json" },
+      }));
+
+      const loaded = loadStoredToolEnvKeys({ authPath, env });
+      assert.deepEqual(loaded, []);
+      assert.equal(env.BRAVE_API_KEY, "already-set");
+    } finally {
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("resolves auth.json from GSD_CODING_AGENT_DIR", () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "gsd-mcp-agent-dir-"));
+    const agentDir = join(tempRoot, "agent");
+    mkdirSync(agentDir, { recursive: true });
+
+    try {
+      assert.equal(
+        resolveAuthPath({ GSD_CODING_AGENT_DIR: agentDir }),
+        join(agentDir, "auth.json"),
+      );
+    } finally {
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/mcp-server/src/tool-credentials.test.ts
+++ b/packages/mcp-server/src/tool-credentials.test.ts
@@ -4,26 +4,33 @@ import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { loadStoredToolEnvKeys, resolveAuthPath } from "./tool-credentials.js";
+import { loadStoredCredentialEnvKeys, resolveAuthPath } from "./tool-credentials.js";
 
 describe("tool credentials", () => {
-  it("hydrates supported keys from auth.json", () => {
+  it("hydrates supported model and tool keys from auth.json", () => {
     const tempRoot = mkdtempSync(join(tmpdir(), "gsd-mcp-auth-"));
     const authPath = join(tempRoot, "auth.json");
     const env: NodeJS.ProcessEnv = {};
 
     try {
       writeFileSync(authPath, JSON.stringify({
+        anthropic: { type: "api_key", key: "sk-ant-secret" },
+        openai: { type: "api_key", key: "sk-openai-secret" },
         tavily: { type: "api_key", key: "tvly-secret" },
         context7: [{ type: "api_key", key: "ctx7-secret" }],
-        anthropic: { type: "api_key", key: "sk-ant-ignore" },
       }));
 
-      const loaded = loadStoredToolEnvKeys({ authPath, env });
-      assert.deepEqual(loaded.sort(), ["CONTEXT7_API_KEY", "TAVILY_API_KEY"]);
+      const loaded = loadStoredCredentialEnvKeys({ authPath, env });
+      assert.deepEqual(loaded.sort(), [
+        "ANTHROPIC_API_KEY",
+        "CONTEXT7_API_KEY",
+        "OPENAI_API_KEY",
+        "TAVILY_API_KEY",
+      ]);
+      assert.equal(env.ANTHROPIC_API_KEY, "sk-ant-secret");
+      assert.equal(env.OPENAI_API_KEY, "sk-openai-secret");
       assert.equal(env.TAVILY_API_KEY, "tvly-secret");
       assert.equal(env.CONTEXT7_API_KEY, "ctx7-secret");
-      assert.equal(env.ANTHROPIC_API_KEY, undefined);
     } finally {
       rmSync(tempRoot, { recursive: true, force: true });
     }
@@ -39,11 +46,33 @@ describe("tool credentials", () => {
     try {
       writeFileSync(authPath, JSON.stringify({
         brave: { type: "api_key", key: "from-auth-json" },
+        anthropic: { type: "api_key", key: "sk-ant-from-auth-json" },
       }));
 
-      const loaded = loadStoredToolEnvKeys({ authPath, env });
-      assert.deepEqual(loaded, []);
+      const loaded = loadStoredCredentialEnvKeys({ authPath, env });
+      assert.deepEqual(loaded, ["ANTHROPIC_API_KEY"]);
       assert.equal(env.BRAVE_API_KEY, "already-set");
+      assert.equal(env.ANTHROPIC_API_KEY, "sk-ant-from-auth-json");
+    } finally {
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("ignores oauth credentials because they are resolved through auth storage, not env hydration", () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "gsd-mcp-auth-"));
+    const authPath = join(tempRoot, "auth.json");
+    const env: NodeJS.ProcessEnv = {};
+
+    try {
+      writeFileSync(authPath, JSON.stringify({
+        openai: { type: "oauth", access: "oauth-access-token" },
+        "google-gemini-cli": { type: "oauth", token: "ya29.oauth-token" },
+      }));
+
+      const loaded = loadStoredCredentialEnvKeys({ authPath, env });
+      assert.deepEqual(loaded, []);
+      assert.equal(env.OPENAI_API_KEY, undefined);
+      assert.equal(env.GEMINI_API_KEY, undefined);
     } finally {
       rmSync(tempRoot, { recursive: true, force: true });
     }

--- a/packages/mcp-server/src/tool-credentials.ts
+++ b/packages/mcp-server/src/tool-credentials.ts
@@ -8,7 +8,28 @@ type AuthCredential =
 
 type AuthStorageData = Record<string, AuthCredential>;
 
-const TOOL_ENV_KEYS = [
+const AUTH_ENV_KEYS = [
+  ["anthropic", "ANTHROPIC_API_KEY"],
+  ["openai", "OPENAI_API_KEY"],
+  ["github-copilot", "GITHUB_TOKEN"],
+  ["google", "GEMINI_API_KEY"],
+  ["groq", "GROQ_API_KEY"],
+  ["xai", "XAI_API_KEY"],
+  ["openrouter", "OPENROUTER_API_KEY"],
+  ["mistral", "MISTRAL_API_KEY"],
+  ["ollama-cloud", "OLLAMA_API_KEY"],
+  ["custom-openai", "CUSTOM_OPENAI_API_KEY"],
+  ["cerebras", "CEREBRAS_API_KEY"],
+  ["azure-openai-responses", "AZURE_OPENAI_API_KEY"],
+  ["vercel-ai-gateway", "AI_GATEWAY_API_KEY"],
+  ["zai", "ZAI_API_KEY"],
+  ["minimax", "MINIMAX_API_KEY"],
+  ["minimax-cn", "MINIMAX_CN_API_KEY"],
+  ["huggingface", "HF_TOKEN"],
+  ["opencode", "OPENCODE_API_KEY"],
+  ["opencode-go", "OPENCODE_API_KEY"],
+  ["kimi-coding", "KIMI_API_KEY"],
+  ["alibaba-coding-plan", "ALIBABA_API_KEY"],
   ["brave", "BRAVE_API_KEY"],
   ["brave_answers", "BRAVE_ANSWERS_KEY"],
   ["context7", "CONTEXT7_API_KEY"],
@@ -17,9 +38,6 @@ const TOOL_ENV_KEYS = [
   ["slack_bot", "SLACK_BOT_TOKEN"],
   ["discord_bot", "DISCORD_BOT_TOKEN"],
   ["telegram_bot", "TELEGRAM_BOT_TOKEN"],
-  ["groq", "GROQ_API_KEY"],
-  ["ollama-cloud", "OLLAMA_API_KEY"],
-  ["custom-openai", "CUSTOM_OPENAI_API_KEY"],
 ] as const;
 
 function expandHome(pathValue: string): string {
@@ -48,7 +66,7 @@ export function resolveAuthPath(env: NodeJS.ProcessEnv = process.env): string {
   return join(homedir(), ".gsd", "agent", "auth.json");
 }
 
-export function loadStoredToolEnvKeys(options: {
+export function loadStoredCredentialEnvKeys(options: {
   env?: NodeJS.ProcessEnv;
   authPath?: string;
 } = {}): string[] {
@@ -67,7 +85,7 @@ export function loadStoredToolEnvKeys(options: {
   }
 
   const loaded: string[] = [];
-  for (const [providerId, envVar] of TOOL_ENV_KEYS) {
+  for (const [providerId, envVar] of AUTH_ENV_KEYS) {
     if (env[envVar]) continue;
     const key = getStoredApiKey(parsed, providerId);
     if (!key) continue;

--- a/packages/mcp-server/src/tool-credentials.ts
+++ b/packages/mcp-server/src/tool-credentials.ts
@@ -1,0 +1,79 @@
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+type AuthCredential =
+  | { type?: unknown; key?: unknown }
+  | Array<{ type?: unknown; key?: unknown }>;
+
+type AuthStorageData = Record<string, AuthCredential>;
+
+const TOOL_ENV_KEYS = [
+  ["brave", "BRAVE_API_KEY"],
+  ["brave_answers", "BRAVE_ANSWERS_KEY"],
+  ["context7", "CONTEXT7_API_KEY"],
+  ["jina", "JINA_API_KEY"],
+  ["tavily", "TAVILY_API_KEY"],
+  ["slack_bot", "SLACK_BOT_TOKEN"],
+  ["discord_bot", "DISCORD_BOT_TOKEN"],
+  ["telegram_bot", "TELEGRAM_BOT_TOKEN"],
+  ["groq", "GROQ_API_KEY"],
+  ["ollama-cloud", "OLLAMA_API_KEY"],
+  ["custom-openai", "CUSTOM_OPENAI_API_KEY"],
+] as const;
+
+function expandHome(pathValue: string): string {
+  if (pathValue === "~") return homedir();
+  if (pathValue.startsWith("~/")) return join(homedir(), pathValue.slice(2));
+  return pathValue;
+}
+
+function getStoredApiKey(data: AuthStorageData, providerId: string): string | undefined {
+  const raw = data[providerId];
+  const credentials = Array.isArray(raw) ? raw : raw ? [raw] : [];
+
+  for (const credential of credentials) {
+    if (credential?.type !== "api_key") continue;
+    if (typeof credential.key !== "string") continue;
+    if (credential.key.trim().length === 0) continue;
+    return credential.key;
+  }
+
+  return undefined;
+}
+
+export function resolveAuthPath(env: NodeJS.ProcessEnv = process.env): string {
+  const agentDir = env.GSD_CODING_AGENT_DIR?.trim();
+  if (agentDir) return join(expandHome(agentDir), "auth.json");
+  return join(homedir(), ".gsd", "agent", "auth.json");
+}
+
+export function loadStoredToolEnvKeys(options: {
+  env?: NodeJS.ProcessEnv;
+  authPath?: string;
+} = {}): string[] {
+  const env = options.env ?? process.env;
+  const authPath = options.authPath ?? resolveAuthPath(env);
+  if (!existsSync(authPath)) return [];
+
+  let parsed: AuthStorageData;
+  try {
+    const raw = readFileSync(authPath, "utf-8");
+    const data = JSON.parse(raw) as unknown;
+    if (!data || typeof data !== "object" || Array.isArray(data)) return [];
+    parsed = data as AuthStorageData;
+  } catch {
+    return [];
+  }
+
+  const loaded: string[] = [];
+  for (const [providerId, envVar] of TOOL_ENV_KEYS) {
+    if (env[envVar]) continue;
+    const key = getStoredApiKey(parsed, providerId);
+    if (!key) continue;
+    env[envVar] = key;
+    loaded.push(envVar);
+  }
+
+  return loaded;
+}


### PR DESCRIPTION
## TL;DR

**What:** Load supported model-provider and tool credentials from secure GSD auth storage when the standalone MCP server starts.
**Why:** MCP-hosted sessions could miss credentials already saved through `/gsd config` or `/gsd keys` because `gsd-mcp-server` did not hydrate `auth.json` like the main CLI does.
**How:** Add a small MCP-server-local auth loader, invoke it during startup, cover it with regression tests, and document the behavior.

## What

This change adds a startup credential hydrator for the standalone MCP server package. It reads supported API-key style model-provider and tool credentials from `~/.gsd/agent/auth.json`, respects `GSD_CODING_AGENT_DIR`, and exposes them to the server process through environment variables only when those env vars are not already set.

That means the MCP server process, and the RPC child it launches, inherit secure stored keys for common API-key-backed providers and tools.

It also adds regression tests for hydration and precedence behavior, plus docs updates in the MCP server README and user configuration guide.

## Why

The main GSD CLI already makes securely stored credentials available to runtime code, but the standalone `gsd-mcp-server` package did not. That created an inconsistency where users could have valid credentials stored securely and still see MCP-backed model or tool integrations fail unless they duplicated secrets in shell config or MCP config.

Closes #3950

## How

The implementation adds a small helper local to `packages/mcp-server` instead of pulling in the larger CLI auth stack. That keeps the package self-contained while matching the expected secure-key behavior.

The loader:
- reads `auth.json` safely
- hydrates only supported API-key-backed provider/tool env vars
- skips empty or missing keys
- preserves explicit environment variables as higher priority
- ignores `type: "oauth"` credentials, which should continue resolving through `AuthStorage`
- never emits secret values in output

OAuth note:
- This PR does not export OAuth credentials into environment variables.
- OAuth-backed providers still need to resolve through the child session's `AuthStorage` path, which is the safer boundary.

Verification run:
- `npm run build -w @gsd-build/mcp-server`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test packages/mcp-server/src/tool-credentials.test.ts packages/mcp-server/src/mcp-server.test.ts`

## Change Type Checklist

- [ ] feat — New feature or capability
- [x] fix — Bug fix
- [ ] refactor — Code restructuring (no behavior change)
- [x] test — Adding or updating tests
- [x] docs — Documentation only
- [ ] chore — Build, CI, or tooling changes

## AI Assistance

This PR is AI-assisted.
