### PR TITLE
fix(mcp-server): importLocalModule resolves src/ paths from dist/ context

### DIFF
--- a/packages/mcp-server/src/import-candidates.test.ts
+++ b/packages/mcp-server/src/import-candidates.test.ts
@@ -1,0 +1,48 @@
+// GSD-2 — Regression tests for importLocalModule candidate resolution (#3954)
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { _buildImportCandidates } from "./workflow-tools.js";
+
+describe("_buildImportCandidates", () => {
+  it("includes dist/ fallback for src/ paths", () => {
+    const candidates = _buildImportCandidates("../../../src/resources/extensions/gsd/db-writer.js");
+    assert.ok(
+      candidates.some((c) => c.includes("/dist/resources/extensions/gsd/db-writer.js")),
+      "should include dist/ swapped candidate",
+    );
+  });
+
+  it("includes src/ fallback for dist/ paths", () => {
+    const candidates = _buildImportCandidates("../../../dist/resources/extensions/gsd/db-writer.js");
+    assert.ok(
+      candidates.some((c) => c.includes("/src/resources/extensions/gsd/db-writer.js")),
+      "should include src/ swapped candidate",
+    );
+  });
+
+  it("includes .ts variants for .js paths", () => {
+    const candidates = _buildImportCandidates("../../../src/resources/extensions/gsd/db-writer.js");
+    assert.ok(
+      candidates.some((c) => c.endsWith("db-writer.ts") && c.includes("/src/")),
+      "should include .ts variant for original src/ path",
+    );
+    assert.ok(
+      candidates.some((c) => c.endsWith("db-writer.ts") && c.includes("/dist/")),
+      "should include .ts variant for swapped dist/ path",
+    );
+  });
+
+  it("returns original path first", () => {
+    const input = "../../../src/resources/extensions/gsd/db-writer.js";
+    const candidates = _buildImportCandidates(input);
+    assert.equal(candidates[0], input, "first candidate should be the original path");
+  });
+
+  it("handles paths without src/ or dist/ gracefully", () => {
+    const candidates = _buildImportCandidates("./local-module.js");
+    assert.equal(candidates.length, 2, "should have original + .ts variant only");
+    assert.equal(candidates[0], "./local-module.js");
+    assert.equal(candidates[1], "./local-module.ts");
+  });
+});

--- a/packages/mcp-server/src/workflow-tools.ts
+++ b/packages/mcp-server/src/workflow-tools.ts
@@ -337,24 +337,29 @@ function toFileUrl(modulePath: string): string {
   return pathToFileURL(resolve(modulePath)).href;
 }
 
-async function importLocalModule<T>(relativePath: string): Promise<T> {
+/** @internal — exported for testing only */
+export function _buildImportCandidates(relativePath: string): string[] {
   // Build candidate paths: try the given path first, then swap src/<->dist/
   // and try .ts extension. This handles both dev (tsx from src/) and prod
   // (compiled from dist/) execution contexts.
-  const candidates: string[] = [
-    new URL(relativePath, import.meta.url).href,
-  ];
+  const candidates: string[] = [relativePath];
   const swapped = relativePath.includes("/src/")
     ? relativePath.replace("/src/", "/dist/")
     : relativePath.includes("/dist/")
       ? relativePath.replace("/dist/", "/src/")
       : null;
-  if (swapped) candidates.push(new URL(swapped, import.meta.url).href);
+  if (swapped) candidates.push(swapped);
   // Also try .ts variants for dev-mode tsx execution
   if (relativePath.endsWith(".js")) {
-    candidates.push(new URL(relativePath.replace(/\.js$/, ".ts"), import.meta.url).href);
-    if (swapped) candidates.push(new URL(swapped.replace(/\.js$/, ".ts"), import.meta.url).href);
+    candidates.push(relativePath.replace(/\.js$/, ".ts"));
+    if (swapped) candidates.push(swapped.replace(/\.js$/, ".ts"));
   }
+  return candidates;
+}
+
+async function importLocalModule<T>(relativePath: string): Promise<T> {
+  const candidates = _buildImportCandidates(relativePath)
+    .map((p) => new URL(p, import.meta.url).href);
 
   let lastErr: unknown;
   for (const candidate of candidates) {

--- a/packages/mcp-server/src/workflow-tools.ts
+++ b/packages/mcp-server/src/workflow-tools.ts
@@ -326,6 +326,7 @@ function getWriteGateModuleCandidates(): string[] {
 
   candidates.push(
     new URL("../../../src/resources/extensions/gsd/bootstrap/write-gate.js", import.meta.url).href,
+    new URL("../../../dist/resources/extensions/gsd/bootstrap/write-gate.js", import.meta.url).href,
     new URL("../../../src/resources/extensions/gsd/bootstrap/write-gate.ts", import.meta.url).href,
   );
 
@@ -337,7 +338,33 @@ function toFileUrl(modulePath: string): string {
 }
 
 async function importLocalModule<T>(relativePath: string): Promise<T> {
-  return import(new URL(relativePath, import.meta.url).href) as Promise<T>;
+  // Build candidate paths: try the given path first, then swap src/<->dist/
+  // and try .ts extension. This handles both dev (tsx from src/) and prod
+  // (compiled from dist/) execution contexts.
+  const candidates: string[] = [
+    new URL(relativePath, import.meta.url).href,
+  ];
+  const swapped = relativePath.includes("/src/")
+    ? relativePath.replace("/src/", "/dist/")
+    : relativePath.includes("/dist/")
+      ? relativePath.replace("/dist/", "/src/")
+      : null;
+  if (swapped) candidates.push(new URL(swapped, import.meta.url).href);
+  // Also try .ts variants for dev-mode tsx execution
+  if (relativePath.endsWith(".js")) {
+    candidates.push(new URL(relativePath.replace(/\.js$/, ".ts"), import.meta.url).href);
+    if (swapped) candidates.push(new URL(swapped.replace(/\.js$/, ".ts"), import.meta.url).href);
+  }
+
+  let lastErr: unknown;
+  for (const candidate of candidates) {
+    try {
+      return await import(candidate) as T;
+    } catch (err) {
+      lastErr = err;
+    }
+  }
+  throw lastErr;
 }
 
 function getWorkflowExecutorModuleCandidates(env: NodeJS.ProcessEnv = process.env): string[] {
@@ -352,6 +379,7 @@ function getWorkflowExecutorModuleCandidates(env: NodeJS.ProcessEnv = process.en
 
   candidates.push(
     new URL("../../../src/resources/extensions/gsd/tools/workflow-tool-executors.js", import.meta.url).href,
+    new URL("../../../dist/resources/extensions/gsd/tools/workflow-tool-executors.js", import.meta.url).href,
     new URL("../../../src/resources/extensions/gsd/tools/workflow-tool-executors.ts", import.meta.url).href,
   );
 


### PR DESCRIPTION
## TL;DR

**What:** Fix `importLocalModule()` failing to resolve modules when running from `dist/`.
**Why:** All 9 MCP workflow tools that use `importLocalModule()` break with "Cannot find module" on npm global installs.
**How:** Try `src/` ↔ `dist/` path swaps and `.ts` extension fallbacks when resolving dynamic imports.

## What

`importLocalModule()` in `packages/mcp-server/src/workflow-tools.ts` resolves paths relative to `import.meta.url`. All 9 call sites use `../../../src/.../*.js` paths. When the file runs from its compiled location in `dist/`, these resolve to `src/` where only `.ts` source files exist — no `.js` files.

Also affects the write-gate and workflow-executor candidate lists which had the same `src/`-only pattern.

Extracted `_buildImportCandidates()` as a testable function with 5 regression tests covering the path resolution logic.

## Why

Every MCP tool that calls `importLocalModule()` fails silently on npm global installs. Reported in #3954 with detailed forensics. The user's workaround was manually symlinking `dist/*.js` → `src/*.js`.

Closes #3954

## How

- `_buildImportCandidates()` generates an ordered list of candidate paths: original → `src/`↔`dist/` swap → `.ts` variants of both
- `importLocalModule()` tries each candidate in order, returning on first success
- Write-gate and workflow-executor candidate lists now include `dist/` paths alongside existing `src/` paths
- Works in both dev (tsx from `src/`) and prod (compiled from `dist/`) contexts

## Change type

- [x] `fix` �� Bug fix
- [x] `test` — Adding regression tests