### PR TITLE
fix: preserve quoted overrides in workflow run

### DIFF
--- a/src/resources/extensions/gsd/commands/handlers/workflow.ts
+++ b/src/resources/extensions/gsd/commands/handlers/workflow.ts
@@ -38,6 +38,72 @@ const WORKFLOW_USAGE = [
   "  resume            — Resume paused custom workflow auto-mode",
 ].join("\n");
 
+export function parseWorkflowRunArgs(args: string): {
+  defName: string;
+  overrides: Record<string, string>;
+} {
+  const parts: string[] = [];
+  let current = "";
+  let quote: '"' | "'" | null = null;
+  let escape = false;
+
+  for (const ch of args) {
+    if (escape) {
+      current += ch;
+      escape = false;
+      continue;
+    }
+
+    if (ch === "\\") {
+      escape = true;
+      continue;
+    }
+
+    if (quote) {
+      if (ch === quote) {
+        quote = null;
+      } else {
+        current += ch;
+      }
+      continue;
+    }
+
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      continue;
+    }
+
+    if (/\s/.test(ch)) {
+      if (current) {
+        parts.push(current);
+        current = "";
+      }
+      continue;
+    }
+
+    current += ch;
+  }
+
+  if (escape) {
+    current += "\\";
+  }
+  if (current) {
+    parts.push(current);
+  }
+
+  const defName = parts[0] ?? "";
+  const overrides: Record<string, string> = {};
+
+  for (let i = 1; i < parts.length; i++) {
+    const eqIdx = parts[i].indexOf("=");
+    if (eqIdx > 0) {
+      overrides[parts[i].slice(0, eqIdx)] = parts[i].slice(eqIdx + 1);
+    }
+  }
+
+  return { defName, overrides };
+}
+
 async function handleCustomWorkflow(
   sub: string,
   ctx: ExtensionCommandContext,
@@ -62,15 +128,7 @@ async function handleCustomWorkflow(
       ctx.ui.notify("Usage: /gsd workflow run <name> [param=value ...]", "warning");
       return true;
     }
-    const parts = args.split(/\s+/);
-    const defName = parts[0];
-    const overrides: Record<string, string> = {};
-    for (let i = 1; i < parts.length; i++) {
-      const eqIdx = parts[i].indexOf("=");
-      if (eqIdx > 0) {
-        overrides[parts[i].slice(0, eqIdx)] = parts[i].slice(eqIdx + 1);
-      }
-    }
+    const { defName, overrides } = parseWorkflowRunArgs(args);
     try {
       const base = projectRoot();
       const runDir = createRun(base, defName, Object.keys(overrides).length > 0 ? overrides : undefined);

--- a/src/resources/extensions/gsd/tests/commands-workflow-custom.test.ts
+++ b/src/resources/extensions/gsd/tests/commands-workflow-custom.test.ts
@@ -13,11 +13,14 @@ import {
   mkdirSync,
   writeFileSync,
   existsSync,
+  readFileSync,
 } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
 import { getGsdArgumentCompletions, TOP_LEVEL_SUBCOMMANDS } from "../commands/catalog.ts";
+import { createRun } from "../run-manager.ts";
+import { parseWorkflowRunArgs } from "../commands/handlers/workflow.ts";
 
 // ─── Helpers ─────────────────────────────────────────────────────────────
 
@@ -87,6 +90,19 @@ steps:
   - id: step-1
     name: First Step
     prompt: Do step 1
+    requires: []
+    produces: []
+`;
+
+const PARAM_DEF = `
+version: 1
+name: upgrade-probe
+params:
+  target: default-target
+steps:
+  - id: build
+    name: Build
+    prompt: Build {{target}}
     requires: []
     produces: []
 `;
@@ -205,6 +221,28 @@ describe("workflow command handler", () => {
     assert.ok(
       notifications.some((n) => n.message.includes("create-workflow")),
       "should mention create-workflow skill",
+    );
+  });
+
+  it("preserves quoted override values through run creation", async () => {
+    const base = makeTmpBase();
+    writeDefinition(base, "upgrade-probe", PARAM_DEF);
+
+    const { defName, overrides } = parseWorkflowRunArgs(
+      'upgrade-probe target="multi word target"',
+    );
+
+    assert.equal(defName, "upgrade-probe");
+
+    const runDir = createRun(base, defName, overrides);
+    const params = JSON.parse(readFileSync(join(runDir, "PARAMS.json"), "utf-8"));
+    const frozenDef = readFileSync(join(runDir, "DEFINITION.yaml"), "utf-8");
+
+    assert.deepStrictEqual(overrides, { target: "multi word target" });
+    assert.deepStrictEqual(params, { target: "multi word target" });
+    assert.ok(
+      frozenDef.includes("Build multi word target"),
+      "frozen definition should preserve the full quoted override value",
     );
   });
 


### PR DESCRIPTION
Closes #4130

## TL;DR

**What:** Preserve quoted override values in `/gsd workflow run` by replacing naive whitespace splitting with quote-aware argument parsing.  
**Why:** Quoted values like `target=&#34;multi word target&#34;` were truncated before run creation, corrupting `PARAMS.json` and frozen workflow artifacts.  
**How:** Extracted workflow run parsing into a small helper in `workflow.ts`, added a regression test, and verified with targeted test, extension typecheck, and full build.

## What

This PR fixes quoted parameter override parsing for the custom workflow run command.

Changed files:

- `src/resources/extensions/gsd/commands/handlers/workflow.ts`
- `src/resources/extensions/gsd/tests/commands-workflow-custom.test.ts`

The handler previously parsed run arguments with naive whitespace splitting before extracting `key=value` pairs. This PR replaces that with a small quote-aware tokenizer scoped to the `workflow run` path.

The regression test proves that a command like:

```text
/gsd workflow run upgrade-probe target=&#34;multi word target&#34;
```

preserves the full value through parsing and into the created run artifacts.

Change type checklist:
- [x] `fix` — Bug fix
- [x] `test` — Adding or updating tests
- [ ] `feat` — New feature or capability
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

AI-assisted contribution: yes. The change was AI-assisted, but verified locally with regression testing, typecheck, and build.

## Why

Quoted override values containing spaces were being truncated before `createRun()`.

Example:

```text
/gsd workflow run upgrade-probe target=&#34;multi word target&#34;
```

Before this fix, the parsed override became:

```json
{ &#34;target&#34;: &#34;\&#34;multi&#34; }
```

That broken value then propagated into:
- `PARAMS.json`
- frozen `DEFINITION.yaml`
- frozen `GRAPH.yaml`

So the workflow started from corrupted input even when the workflow definition itself was valid.

This is a narrow command-parsing bug in the CLI/slash-command layer, not a workflow engine bug.

Related but distinct issues:
- #3189 — spaced placeholder substitution like `{{ key }}`
- #3188 — custom workflow bootstrap/handoff

This PR does not address either of those.

## How

The change is intentionally small and local:

1. Extracted `workflow run` argument parsing into `parseWorkflowRunArgs()` in:
   - `src/resources/extensions/gsd/commands/handlers/workflow.ts`

2. Replaced:
   ```ts
   args.split(/\s+/)
   ```
   with a small quote-aware tokenizer that:
   - preserves double-quoted segments
   - preserves single-quoted segments
   - strips wrapping quotes during tokenization
   - keeps the output shape identical to what `createRun()` already expects

3. Added a regression test in:
   - `src/resources/extensions/gsd/tests/commands-workflow-custom.test.ts`

   The test verifies:
   - parsed overrides are correct
   - `PARAMS.json` contains the full value
   - frozen `DEFINITION.yaml` contains the fully rendered prompt text

### Verification

Ran locally:

```bash
node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/commands-workflow-custom.test.ts
npm run typecheck:extensions
npm run build
```

All passed.

### Scope guard

This PR is intentionally limited to quoted override parsing only.
