### PR TITLE
fix(headless): treat workflow validate and list as quick commands

### DIFF
--- a/src/headless-events.ts
+++ b/src/headless-events.ts
@@ -102,6 +102,11 @@ export const QUICK_COMMANDS = new Set([
   'triage', 'visualize',
 ])
 
-export function isQuickCommand(command: string): boolean {
-  return QUICK_COMMANDS.has(command)
+export const QUICK_WORKFLOW_SUBCOMMANDS = new Set(['validate', 'list'])
+
+export function isQuickCommand(command: string, commandArgs: string[] = []): boolean {
+  if (QUICK_COMMANDS.has(command)) return true
+  if (command !== 'workflow') return false
+  const subcommand = commandArgs[0]
+  return subcommand != null && QUICK_WORKFLOW_SUBCOMMANDS.has(subcommand)
 }

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -701,7 +701,7 @@ async function runHeadlessOnce(options: HeadlessOptions, restartCount: number): 
     }
 
     // Quick commands: resolve on first agent_end
-    if (eventObj.type === 'agent_end' && isQuickCommand(options.command) && !completed) {
+    if (eventObj.type === 'agent_end' && isQuickCommand(options.command, options.commandArgs) && !completed) {
       completed = true
       resolveCompletion()
       return

--- a/src/tests/headless-cli-surface.test.ts
+++ b/src/tests/headless-cli-surface.test.ts
@@ -17,6 +17,7 @@ import {
   EXIT_BLOCKED,
   EXIT_CANCELLED,
   mapStatusToExitCode,
+  isQuickCommand,
 } from '../headless-events.js'
 
 import type { OutputFormat, HeadlessJsonResult } from '../headless-types.js'
@@ -422,4 +423,23 @@ test('--bare does not affect other flags', () => {
   assert.equal(opts.timeout, 60000)
   assert.equal(opts.resumeSession, 'sess-abc')
   assert.equal(opts.command, 'auto')
+})
+
+// ─── Quick command classification for workflow subcommands ─────────────────
+
+test('workflow validate is treated as a quick command', () => {
+  assert.equal(isQuickCommand('workflow', ['validate', 'upgrade-probe']), true)
+})
+
+test('workflow list is treated as a quick command', () => {
+  assert.equal(isQuickCommand('workflow', ['list']), true)
+  assert.equal(isQuickCommand('workflow', ['list', 'upgrade-probe']), true)
+})
+
+test('workflow run is not treated as a quick command', () => {
+  assert.equal(isQuickCommand('workflow', ['run', 'upgrade-probe']), false)
+})
+
+test('workflow without a subcommand is not treated as a quick command', () => {
+  assert.equal(isQuickCommand('workflow', []), false)
 })


### PR DESCRIPTION
Closes #4131

**What:** Treat `workflow validate` and `workflow list` as short-lived headless commands.  
**Why:** Headless completion only checked the top-level command name, so nested `workflow` subcommands that are actually single-turn could fail to terminate cleanly.  
**How:** Extended quick-command detection to recognize `workflow validate` and `workflow list`, added regression coverage, and verified with targeted headless tests plus extension typecheck.

## What

This PR fixes headless quick-command classification for two nested workflow subcommands:

- `workflow validate`
- `workflow list`

Changed files:

- `src/headless-events.ts`
- `src/headless.ts`
- `src/tests/headless-cli-surface.test.ts`

The change is intentionally narrow: it does **not** reclassify all `workflow` subcommands as quick. `workflow run` remains non-quick.

Change type checklist:
- [x] `fix` — Bug fix
- [x] `test` — Adding or updating tests
- [ ] `feat` — New feature or capability
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

AI-assisted contribution: yes. The change was AI-assisted, but verified locally with targeted tests and extension typecheck.

## Why

In headless mode, quick-command completion depended on the top-level command name alone.

That worked for commands such as `status` and `doctor`, but not for nested workflow subcommands like:

```text
gsd headless workflow validate upgrade-probe
gsd headless workflow list
```

Those commands are effectively single-turn operations, but headless previously saw only `workflow` and treated them as non-quick. That meant completion could fall through to the longer-running notification/idle heuristics instead of resolving immediately after the first relevant `agent_end`.

This PR keeps the fix scoped to that headless classification seam.

## How

The change is small and local:

1. Extended `isQuickCommand()` in `src/headless-events.ts` so it can inspect both:
   - the top-level command
   - the nested workflow subcommand

2. Added a narrow allowlist for quick workflow subcommands:
   - `validate`
   - `list`

3. Updated `src/headless.ts` to call:

   ```ts
   isQuickCommand(options.command, options.commandArgs)
   ```

   instead of checking only `options.command`.

4. Added regression coverage in `src/tests/headless-cli-surface.test.ts` to prove:
   - `workflow validate` is quick
   - `workflow list` is quick
   - `workflow run` is still **not** quick
   - bare `workflow` is still **not** quick

### Verification

Ran locally:

```bash
node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/tests/headless-cli-surface.test.ts src/tests/headless-detection.test.ts src/tests/headless-multi-turn.test.ts
npm run typecheck:extensions
```

Results:
- targeted headless tests passed (`58` tests)
- extension typecheck passed

### Scope guard

This PR is intentionally limited to headless quick-command detection for nested workflow subcommands.
