### PR TITLE
fix(mcp-server): open the DB for inline workflow tools

### DIFF
--- a/packages/mcp-server/src/workflow-tools.test.ts
+++ b/packages/mcp-server/src/workflow-tools.test.ts
@@ -384,6 +384,116 @@ describe("workflow MCP tools", () => {
     }
   });
 
+  it("gsd_requirement_save opens the DB before inline requirement writes", async () => {
+    const base = makeTmpBase();
+    try {
+      const server = makeMockServer();
+      registerWorkflowTools(server as any);
+      const requirementTool = server.tools.find((t) => t.name === "gsd_requirement_save");
+      assert.ok(requirementTool, "requirement tool should be registered");
+
+      closeDatabase();
+
+      const result = await requirementTool!.handler({
+        projectDir: base,
+        class: "operability",
+        description: "Inline MCP requirement save regression",
+        why: "Reproduce missing ensureDbOpen in workflow-tools",
+        source: "user",
+        status: "active",
+        primary_owner: "M010/S10",
+        validation: "n/a",
+      });
+
+      assert.match((result as any).content[0].text as string, /Saved requirement R\d+/);
+      assert.ok(existsSync(join(base, ".gsd", "REQUIREMENTS.md")), "REQUIREMENTS.md should be written to disk");
+      const row = _getAdapter()!
+        .prepare("SELECT id, class, description FROM requirements WHERE description = ?")
+        .get("Inline MCP requirement save regression") as Record<string, unknown> | undefined;
+      assert.ok(row, "requirement should be written to the database");
+      assert.equal(row["class"], "operability");
+    } finally {
+      cleanup(base);
+    }
+  });
+
+  it("gsd_plan_task reopens the DB before inline task planning writes", async () => {
+    const base = makeTmpBase();
+    try {
+      const server = makeMockServer();
+      registerWorkflowTools(server as any);
+      const milestoneTool = server.tools.find((t) => t.name === "gsd_plan_milestone");
+      const sliceTool = server.tools.find((t) => t.name === "gsd_plan_slice");
+      const taskTool = server.tools.find((t) => t.name === "gsd_plan_task");
+      assert.ok(milestoneTool, "milestone planning tool should be registered");
+      assert.ok(sliceTool, "slice planning tool should be registered");
+      assert.ok(taskTool, "task planning tool should be registered");
+
+      await milestoneTool!.handler({
+        projectDir: base,
+        milestoneId: "M010",
+        title: "Inline task planning DB reopen",
+        vision: "Seed a slice, close the DB, then plan another task inline.",
+        slices: [
+          {
+            sliceId: "S10",
+            title: "Inline task planning",
+            risk: "medium",
+            depends: [],
+            demo: "Inline gsd_plan_task reopens the DB after it was closed.",
+            goal: "Preserve MCP task planning after the DB adapter is closed.",
+            successCriteria: "The second task plan persists after a closed DB is reopened.",
+            proofLevel: "integration",
+            integrationClosure: "The inline MCP handler reopens the DB before planning.",
+            observabilityImpact: "workflow-tools MCP tests cover the inline reopen path.",
+          },
+        ],
+      });
+      await sliceTool!.handler({
+        projectDir: base,
+        milestoneId: "M010",
+        sliceId: "S10",
+        goal: "Create the initial slice plan before closing the DB.",
+        tasks: [
+          {
+            taskId: "T10",
+            title: "Seed existing task",
+            description: "Create the initial task plan before closing the DB.",
+            estimate: "5m",
+            files: ["packages/mcp-server/src/workflow-tools.ts"],
+            verify: "node --test",
+            inputs: ["M010-ROADMAP.md"],
+            expectedOutput: ["T10-PLAN.md"],
+          },
+        ],
+      });
+
+      closeDatabase();
+
+      const result = await taskTool!.handler({
+        projectDir: base,
+        milestoneId: "M010",
+        sliceId: "S10",
+        taskId: "T11",
+        title: "Reopen and plan",
+        description: "Exercise the inline plan-task path after the DB was closed.",
+        estimate: "5m",
+        files: ["packages/mcp-server/src/workflow-tools.ts"],
+        verify: "node --test",
+        inputs: ["M010-ROADMAP.md", "S10-PLAN.md"],
+        expectedOutput: ["T11-PLAN.md"],
+      });
+
+      assert.match((result as any).content[0].text as string, /Planned task T11/);
+      assert.ok(
+        existsSync(join(base, ".gsd", "milestones", "M010", "slices", "S10", "tasks", "T11-PLAN.md")),
+        "T11 plan should be written after reopening the DB",
+      );
+    } finally {
+      cleanup(base);
+    }
+  });
+
   it("gsd_replan_slice and gsd_slice_replan work end-to-end", async () => {
     const base = makeTmpBase();
     try {

--- a/packages/mcp-server/src/workflow-tools.ts
+++ b/packages/mcp-server/src/workflow-tools.ts
@@ -244,6 +244,10 @@ type WorkflowWriteGateModule = {
   ) => { block: boolean; reason?: string };
 };
 
+type WorkflowDbBootstrapModule = {
+  ensureDbOpen: (basePath?: string) => Promise<boolean>;
+};
+
 let workflowToolExecutorsPromise: Promise<WorkflowToolExecutors> | null = null;
 let workflowExecutionQueue: Promise<void> = Promise.resolve();
 let workflowWriteGatePromise: Promise<WorkflowWriteGateModule> | null = null;
@@ -504,6 +508,22 @@ async function runSerializedWorkflowOperation<T>(fn: () => Promise<T>): Promise<
   } finally {
     release();
   }
+}
+
+async function runSerializedWorkflowDbOperation<T>(
+  projectDir: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  return runSerializedWorkflowOperation(async () => {
+    const { ensureDbOpen } = await importLocalModule<WorkflowDbBootstrapModule>(
+      "../../../src/resources/extensions/gsd/bootstrap/dynamic-tools.js",
+    );
+    const dbAvailable = await ensureDbOpen(projectDir);
+    if (!dbAvailable) {
+      throw new Error("GSD database is not available");
+    }
+    return fn();
+  });
 }
 
 async function enforceWorkflowWriteGate(
@@ -969,7 +989,7 @@ export function registerWorkflowTools(server: McpToolServer): void {
       const parsed = parseWorkflowArgs(decisionSaveSchema, args);
       const { projectDir, ...params } = parsed;
       await enforceWorkflowWriteGate("gsd_decision_save", projectDir);
-      const result = await runSerializedWorkflowOperation(async () => {
+      const result = await runSerializedWorkflowDbOperation(projectDir, async () => {
         const { saveDecisionToDb } = await importLocalModule<any>("../../../src/resources/extensions/gsd/db-writer.js");
         return saveDecisionToDb(params, projectDir);
       });
@@ -985,7 +1005,7 @@ export function registerWorkflowTools(server: McpToolServer): void {
       const parsed = parseWorkflowArgs(decisionSaveSchema, args);
       const { projectDir, ...params } = parsed;
       await enforceWorkflowWriteGate("gsd_decision_save", projectDir);
-      const result = await runSerializedWorkflowOperation(async () => {
+      const result = await runSerializedWorkflowDbOperation(projectDir, async () => {
         const { saveDecisionToDb } = await importLocalModule<any>("../../../src/resources/extensions/gsd/db-writer.js");
         return saveDecisionToDb(params, projectDir);
       });
@@ -1001,7 +1021,7 @@ export function registerWorkflowTools(server: McpToolServer): void {
       const parsed = parseWorkflowArgs(requirementUpdateSchema, args);
       const { projectDir, id, ...updates } = parsed;
       await enforceWorkflowWriteGate("gsd_requirement_update", projectDir);
-      await runSerializedWorkflowOperation(async () => {
+      await runSerializedWorkflowDbOperation(projectDir, async () => {
         const { updateRequirementInDb } = await importLocalModule<any>("../../../src/resources/extensions/gsd/db-writer.js");
         return updateRequirementInDb(id, updates, projectDir);
       });
@@ -1017,7 +1037,7 @@ export function registerWorkflowTools(server: McpToolServer): void {
       const parsed = parseWorkflowArgs(requirementUpdateSchema, args);
       const { projectDir, id, ...updates } = parsed;
       await enforceWorkflowWriteGate("gsd_requirement_update", projectDir);
-      await runSerializedWorkflowOperation(async () => {
+      await runSerializedWorkflowDbOperation(projectDir, async () => {
         const { updateRequirementInDb } = await importLocalModule<any>("../../../src/resources/extensions/gsd/db-writer.js");
         return updateRequirementInDb(id, updates, projectDir);
       });
@@ -1033,7 +1053,7 @@ export function registerWorkflowTools(server: McpToolServer): void {
       const parsed = parseWorkflowArgs(requirementSaveSchema, args);
       const { projectDir, ...params } = parsed;
       await enforceWorkflowWriteGate("gsd_requirement_save", projectDir);
-      const result = await runSerializedWorkflowOperation(async () => {
+      const result = await runSerializedWorkflowDbOperation(projectDir, async () => {
         const { saveRequirementToDb } = await importLocalModule<any>("../../../src/resources/extensions/gsd/db-writer.js");
         return saveRequirementToDb(params, projectDir);
       });
@@ -1049,7 +1069,7 @@ export function registerWorkflowTools(server: McpToolServer): void {
       const parsed = parseWorkflowArgs(requirementSaveSchema, args);
       const { projectDir, ...params } = parsed;
       await enforceWorkflowWriteGate("gsd_requirement_save", projectDir);
-      const result = await runSerializedWorkflowOperation(async () => {
+      const result = await runSerializedWorkflowDbOperation(projectDir, async () => {
         const { saveRequirementToDb } = await importLocalModule<any>("../../../src/resources/extensions/gsd/db-writer.js");
         return saveRequirementToDb(params, projectDir);
       });
@@ -1064,7 +1084,7 @@ export function registerWorkflowTools(server: McpToolServer): void {
     async (args: Record<string, unknown>) => {
       const { projectDir } = parseWorkflowArgs(milestoneGenerateIdSchema, args);
       await enforceWorkflowWriteGate("gsd_milestone_generate_id", projectDir);
-      const id = await runSerializedWorkflowOperation(async () => {
+      const id = await runSerializedWorkflowDbOperation(projectDir, async () => {
         const {
           claimReservedId,
           findMilestoneIds,
@@ -1092,7 +1112,7 @@ export function registerWorkflowTools(server: McpToolServer): void {
     async (args: Record<string, unknown>) => {
       const { projectDir } = parseWorkflowArgs(milestoneGenerateIdSchema, args);
       await enforceWorkflowWriteGate("gsd_milestone_generate_id", projectDir);
-      const id = await runSerializedWorkflowOperation(async () => {
+      const id = await runSerializedWorkflowDbOperation(projectDir, async () => {
         const {
           claimReservedId,
           findMilestoneIds,
@@ -1147,7 +1167,7 @@ export function registerWorkflowTools(server: McpToolServer): void {
       const parsed = parseWorkflowArgs(planTaskSchema, args);
       const { projectDir, ...params } = parsed;
       await enforceWorkflowWriteGate("gsd_plan_task", projectDir, params.milestoneId);
-      const result = await runSerializedWorkflowOperation(async () => {
+      const result = await runSerializedWorkflowDbOperation(projectDir, async () => {
         const { handlePlanTask } = await importLocalModule<any>("../../../src/resources/extensions/gsd/tools/plan-task.js");
         return handlePlanTask(params, projectDir);
       });
@@ -1168,7 +1188,7 @@ export function registerWorkflowTools(server: McpToolServer): void {
       const parsed = parseWorkflowArgs(planTaskSchema, args);
       const { projectDir, ...params } = parsed;
       await enforceWorkflowWriteGate("gsd_plan_task", projectDir, params.milestoneId);
-      const result = await runSerializedWorkflowOperation(async () => {
+      const result = await runSerializedWorkflowDbOperation(projectDir, async () => {
         const { handlePlanTask } = await importLocalModule<any>("../../../src/resources/extensions/gsd/tools/plan-task.js");
         return handlePlanTask(params, projectDir);
       });
@@ -1228,7 +1248,7 @@ export function registerWorkflowTools(server: McpToolServer): void {
     async (args: Record<string, unknown>) => {
       const { projectDir, milestoneId, sliceId, reason } = parseWorkflowArgs(skipSliceSchema, args);
       await enforceWorkflowWriteGate("gsd_skip_slice", projectDir, milestoneId);
-      await runSerializedWorkflowOperation(async () => {
+      await runSerializedWorkflowDbOperation(projectDir, async () => {
         const { getSlice, updateSliceStatus } = await importLocalModule<any>("../../../src/resources/extensions/gsd/gsd-db.js");
         const { invalidateStateCache } = await importLocalModule<any>("../../../src/resources/extensions/gsd/state.js");
         const { rebuildState } = await importLocalModule<any>("../../../src/resources/extensions/gsd/doctor.js");


### PR DESCRIPTION
## TL;DR

**What:** Open the GSD database before the remaining inline workflow MCP mutation handlers touch DB-backed modules.
**Why:** Several `packages/mcp-server/src/workflow-tools.ts` handlers could fail with `gsd-db: No database open` even when the target project already had a valid `.gsd` setup.
**How:** Add a shared serialized DB-open wrapper for the inline handlers and cover the requirement-save and task-plan reopen paths with MCP end-to-end regressions.

## What

This updates `packages/mcp-server/src/workflow-tools.ts` so the remaining inline mutation handlers open the project database before calling DB-backed helpers directly. That now covers the inline decision, requirement, milestone-ID, task-planning, and skip-slice paths instead of leaving them dependent on some earlier call having opened the adapter first.

It also adds focused end-to-end MCP tests in `packages/mcp-server/src/workflow-tools.test.ts` for two real failure shapes: saving a requirement into a fresh `.gsd` project, and planning another task after the database was explicitly closed.

## Why

Closes #3973.

The executor-backed workflow MCP handlers already call `ensureDbOpen(basePath)` before doing DB work. The remaining inline handlers had drifted away from that pattern, so interactive MCP calls could throw `gsd-db: No database open` outside the auto-mode paths that happened to open the adapter first.

## How

The fix keeps the current handler structure but adds one small helper that runs inside the existing serialized mutation queue, calls `ensureDbOpen(projectDir)`, and only then executes the inline DB-backed operation. Running the open step inside the same serialized section keeps the process-global adapter aligned with the write that follows instead of creating a separate open/write race.

The new regressions exercise both major inline families this issue called out:

1. `gsd_requirement_save` on a fresh `.gsd` project
2. `gsd_plan_task` after a prior workflow call opened and then closed the DB

## Change type

- [x] `fix` — Bug fix
- [x] `test` — Adding or updating tests
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `feat` — New feature or capability
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [ ] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [ ] Manual testing — steps described above
- [ ] No tests needed — explained above

Automated verification:

1. `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test packages/mcp-server/src/workflow-tools.test.ts`
2. `npm run build`
3. `npm run typecheck:extensions`
4. `npm run test:packages`  
   This still fails on this branch with the pre-existing `ModelRegistry authMode — getAvailable` assertion in `packages/pi-coding-agent/dist/core/model-registry-auth-mode.test.js`, and the same failure reproduces on clean `upstream/main`.
5. `tmpdir=$(mktemp -d) && HOME="$tmpdir" GSD_HOME="$tmpdir/.gsd" npm run test:unit; rc=$?; rm -rf "$tmpdir"; exit $rc`
6. `npm run secret-scan -- --diff upstream/main`

## AI disclosure

- [x] This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.
