### PR TITLE
fix(gsd): require verification classes in validation prompts

### DIFF
--- a/src/resources/extensions/gsd/prompts/validate-milestone.md
+++ b/src/resources/extensions/gsd/prompts/validate-milestone.md
@@ -31,7 +31,7 @@ Prompt: "Review milestone {{milestoneId}} requirements coverage. Working directo
 Prompt: "Review milestone {{milestoneId}} cross-slice integration. Working directory: {{workingDirectory}}. Read `{{roadmapPath}}` and find the boundary map (produces/consumes contracts). For each boundary, check that the producing slice's SUMMARY confirms it produced the artifact, and the consuming slice's SUMMARY confirms it consumed it. Output a markdown table: Boundary | Producer Summary | Consumer Summary | Status. End with a one-line verdict: PASS if all boundaries honored, NEEDS-ATTENTION if any gaps."
 
 **Reviewer C — Assessment & Acceptance Criteria**
-Prompt: "Review milestone {{milestoneId}} assessment evidence and acceptance criteria. Working directory: {{workingDirectory}}. Read `.gsd/{{milestoneId}}/CONTEXT.md` for acceptance criteria. Check for ASSESSMENT files in each slice directory. Verify each acceptance criterion maps to either a passing assessment result or clear SUMMARY evidence. Output a checklist: [ ] Criterion | Evidence. End with a one-line verdict: PASS if all criteria met, NEEDS-ATTENTION if gaps exist."
+Prompt: "Review milestone {{milestoneId}} assessment evidence and acceptance criteria. Working directory: {{workingDirectory}}. Read `.gsd/{{milestoneId}}/CONTEXT.md` for acceptance criteria. Check for ASSESSMENT files in each slice directory. Verify each acceptance criterion maps to either a passing assessment result or clear SUMMARY evidence. Then review the inlined milestone verification classes from planning. For each non-empty planned class, output a markdown table: Class | Planned Check | Evidence | Verdict. Use the exact class names `Contract`, `Integration`, `Operational`, and `UAT` whenever those classes are present. If no verification classes were planned, say that explicitly. Output two sections: `Acceptance Criteria` with a checklist `[ ] Criterion | Evidence`, and `Verification Classes` with the table. End with a one-line verdict: PASS if all criteria and verification classes are covered, NEEDS-ATTENTION if gaps exist."
 
 ### Step 2 — Synthesize Findings
 
@@ -70,6 +70,7 @@ reviewers: 3
 ```
 
 Call `gsd_validate_milestone` with the camelCase fields `milestoneId`, `verdict`, `remediationRound`, `successCriteriaChecklist`, `sliceDeliveryAudit`, `crossSliceIntegration`, `requirementCoverage`, `verdictRationale`, and `remediationPlan` when needed. If you include verification-class analysis, pass it in `verificationClasses`.
+Extract the `Verification Classes` subsection from Reviewer C and pass it verbatim in `verificationClasses` so the persisted validation output uses the canonical class names `Contract`, `Integration`, `Operational`, and `UAT`.
 
 **DB access safety:** Do NOT query `.gsd/gsd.db` directly via `sqlite3` or `node -e require('better-sqlite3')` — the engine owns the WAL connection. Use `gsd_milestone_status` to read milestone and slice state. All data you need is already inlined in the context above or accessible via the `gsd_*` tools. Direct DB access corrupts the WAL and bypasses tool-level validation.
 

--- a/src/resources/extensions/gsd/tests/validate-milestone-prompt-verification-classes.test.ts
+++ b/src/resources/extensions/gsd/tests/validate-milestone-prompt-verification-classes.test.ts
@@ -1,0 +1,18 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const promptPath = join(process.cwd(), "src/resources/extensions/gsd/prompts/validate-milestone.md");
+const prompt = readFileSync(promptPath, "utf-8");
+
+test("validate-milestone reviewer C requires canonical verification class names", () => {
+  assert.match(prompt, /\*\*Reviewer C[\s\S]*Verification Classes/i);
+  assert.match(prompt, /exact class names [`']?Contract[`']?, [`']?Integration[`']?, [`']?Operational[`']?, and [`']?UAT[`']?/i);
+  assert.match(prompt, /If no verification classes were planned, say that explicitly/i);
+});
+
+test("validate-milestone prompt routes verification class analysis into verificationClasses", () => {
+  assert.match(prompt, /pass it in `verificationClasses`/i);
+  assert.match(prompt, /Extract the `Verification Classes` subsection from Reviewer C and pass it verbatim in `verificationClasses`/);
+});


### PR DESCRIPTION
## TL;DR

**What:** Teach the validate-milestone prompt to require explicit verification-class analysis with the canonical class names.
**Why:** Milestone validation could pass without ever saying `Operational`, which left the completion guard unable to see planned operational proof and deadlocked milestone completion.
**How:** Expand Reviewer C's instructions to emit a `Verification Classes` section using `Contract`, `Integration`, `Operational`, and `UAT`, then route that subsection into `verificationClasses` when calling `gsd_validate_milestone`.

## What

This updates `src/resources/extensions/gsd/prompts/validate-milestone.md` so Reviewer C no longer stops at acceptance criteria alone. The prompt now explicitly tells the reviewer to inspect the planned verification classes, emit a `Verification Classes` section, and use the exact canonical class names when they are present.

It also adds a focused prompt regression in `src/resources/extensions/gsd/tests/validate-milestone-prompt-verification-classes.test.ts` to lock in both halves of the behavior: Reviewer C must require canonical verification class names, and the prompt must tell the orchestrator to pass that subsection through `verificationClasses`.

## Why

Closes #3895.

The dispatch guard in `auto-dispatch.ts` already looks for `Operational` evidence before allowing milestone completion when an operational verification class was planned. The prompt, however, never instructed reviewers to produce that structured verification-class output. That mismatch meant a validation could be substantively correct but still omit the exact wording the guard relies on.

## How

The fix stays in the prompt layer instead of changing the dispatch guard. Reviewer C now has one extra responsibility: produce a `Verification Classes` table for any non-empty planned classes and use the exact names `Contract`, `Integration`, `Operational`, and `UAT`.

The persistence step then explicitly tells the orchestrator to extract that `Verification Classes` subsection and pass it verbatim in `verificationClasses`, which is what ultimately lands in the rendered validation artifact.

## Change type

- [x] `fix` — Bug fix
- [x] `test` — Adding or updating tests
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `feat` — New feature or capability
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [ ] Manual testing — steps described above
- [ ] No tests needed — explained above

Automated verification:

1. `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/validate-milestone-prompt-verification-classes.test.ts`
2. `npm run build`
3. `npm run typecheck:extensions`
4. `tmpdir=$(mktemp -d) && HOME="$tmpdir" GSD_HOME="$tmpdir/.gsd" npm run test:unit; rc=$?; rm -rf "$tmpdir"; exit $rc`
5. `npm run secret-scan -- --diff upstream/main`

## AI disclosure

- [x] This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.
