### PR TITLE
fix(cli): preserve anthropic api provider

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -18,6 +18,7 @@ import { ensureManagedTools } from './tool-bootstrap.js'
 import { loadStoredEnvKeys } from './wizard.js'
 import { migratePiCredentials } from './pi-migration.js'
 import { validateConfiguredModel } from './startup-model-validation.js'
+import { shouldMigrateAnthropicToClaudeCode } from './provider-migrations.js'
 import { shouldRunOnboarding, runOnboarding } from './onboarding.js'
 import chalk from 'chalk'
 import { checkForUpdates } from './update-check.js'
@@ -470,7 +471,11 @@ if (isPrintMode) {
   // Migrate anthropic OAuth users to claude-code provider when CLI is available (#3772).
   // Anthropic blocks third-party apps from using subscription quotas — routing through
   // the local claude CLI binary is TOS-compliant.
-  if (modelRegistry.isProviderRequestReady('claude-code') && settingsManager.getDefaultProvider() === 'anthropic') {
+  if (shouldMigrateAnthropicToClaudeCode({
+    authStorage,
+    isClaudeCodeReady: modelRegistry.isProviderRequestReady('claude-code'),
+    defaultProvider: settingsManager.getDefaultProvider(),
+  })) {
     const currentModelId = settingsManager.getDefaultModel()
     if (currentModelId) {
       const ccModel = modelRegistry.find('claude-code', currentModelId)
@@ -662,7 +667,11 @@ markStartup('createAgentSession')
 // Migrate anthropic OAuth users to claude-code provider when CLI is available (#3772).
 // Anthropic blocks third-party apps from using subscription quotas — routing through
 // the local claude CLI binary is TOS-compliant.
-if (modelRegistry.isProviderRequestReady('claude-code') && settingsManager.getDefaultProvider() === 'anthropic') {
+if (shouldMigrateAnthropicToClaudeCode({
+  authStorage,
+  isClaudeCodeReady: modelRegistry.isProviderRequestReady('claude-code'),
+  defaultProvider: settingsManager.getDefaultProvider(),
+})) {
   const currentModelId = settingsManager.getDefaultModel()
   if (currentModelId) {
     const ccModel = modelRegistry.find('claude-code', currentModelId)

--- a/src/provider-migrations.ts
+++ b/src/provider-migrations.ts
@@ -1,0 +1,34 @@
+import type { AuthStorage } from "@gsd/pi-coding-agent"
+
+type AnthropicMigrationDeps = {
+  authStorage: Pick<AuthStorage, "getCredentialsForProvider">
+  isClaudeCodeReady: boolean
+  defaultProvider: string | undefined
+  env?: NodeJS.ProcessEnv
+}
+
+export function hasDirectAnthropicApiKey(
+  authStorage: Pick<AuthStorage, "getCredentialsForProvider">,
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  if ((env.ANTHROPIC_API_KEY ?? "").trim()) {
+    return true
+  }
+
+  return authStorage.getCredentialsForProvider("anthropic").some((credential: any) =>
+    credential?.type === "api_key" && typeof credential?.key === "string" && credential.key.trim().length > 0,
+  )
+}
+
+export function shouldMigrateAnthropicToClaudeCode({
+  authStorage,
+  isClaudeCodeReady,
+  defaultProvider,
+  env = process.env,
+}: AnthropicMigrationDeps): boolean {
+  if (!isClaudeCodeReady || defaultProvider !== "anthropic") {
+    return false
+  }
+
+  return !hasDirectAnthropicApiKey(authStorage, env)
+}

--- a/src/tests/provider-migrations.test.ts
+++ b/src/tests/provider-migrations.test.ts
@@ -1,0 +1,77 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+import { hasDirectAnthropicApiKey, shouldMigrateAnthropicToClaudeCode } from "../provider-migrations.ts"
+
+function makeAuthStorage(credentials: unknown[]) {
+  return {
+    getCredentialsForProvider(provider: string) {
+      return provider === "anthropic" ? credentials : []
+    },
+  }
+}
+
+test("hasDirectAnthropicApiKey detects non-empty auth storage keys", () => {
+  assert.equal(
+    hasDirectAnthropicApiKey(
+      makeAuthStorage([{ type: "api_key", key: "sk-ant-test" }]) as any,
+      {} as NodeJS.ProcessEnv,
+    ),
+    true,
+  )
+})
+
+test("hasDirectAnthropicApiKey ignores empty placeholder keys", () => {
+  assert.equal(
+    hasDirectAnthropicApiKey(
+      makeAuthStorage([{ type: "api_key", key: "" }]) as any,
+      {} as NodeJS.ProcessEnv,
+    ),
+    false,
+  )
+})
+
+test("hasDirectAnthropicApiKey detects ANTHROPIC_API_KEY env fallback", () => {
+  assert.equal(
+    hasDirectAnthropicApiKey(
+      makeAuthStorage([]) as any,
+      { ANTHROPIC_API_KEY: "sk-ant-env" } as NodeJS.ProcessEnv,
+    ),
+    true,
+  )
+})
+
+test("shouldMigrateAnthropicToClaudeCode blocks migration for direct-key users", () => {
+  assert.equal(
+    shouldMigrateAnthropicToClaudeCode({
+      authStorage: makeAuthStorage([{ type: "api_key", key: "sk-ant-test" }]) as any,
+      isClaudeCodeReady: true,
+      defaultProvider: "anthropic",
+      env: {} as NodeJS.ProcessEnv,
+    }),
+    false,
+  )
+})
+
+test("shouldMigrateAnthropicToClaudeCode allows OAuth-only anthropic users", () => {
+  assert.equal(
+    shouldMigrateAnthropicToClaudeCode({
+      authStorage: makeAuthStorage([{ type: "oauth", accessToken: "oauth-token" }]) as any,
+      isClaudeCodeReady: true,
+      defaultProvider: "anthropic",
+      env: {} as NodeJS.ProcessEnv,
+    }),
+    true,
+  )
+})
+
+test("shouldMigrateAnthropicToClaudeCode stays off for other providers", () => {
+  assert.equal(
+    shouldMigrateAnthropicToClaudeCode({
+      authStorage: makeAuthStorage([{ type: "oauth", accessToken: "oauth-token" }]) as any,
+      isClaudeCodeReady: true,
+      defaultProvider: "openai",
+      env: {} as NodeJS.ProcessEnv,
+    }),
+    false,
+  )
+})

--- a/src/tests/provider-migrations.test.ts
+++ b/src/tests/provider-migrations.test.ts
@@ -55,7 +55,7 @@ test("shouldMigrateAnthropicToClaudeCode blocks migration for direct-key users",
 test("shouldMigrateAnthropicToClaudeCode allows OAuth-only anthropic users", () => {
   assert.equal(
     shouldMigrateAnthropicToClaudeCode({
-      authStorage: makeAuthStorage([{ type: "oauth", accessToken: "oauth-token" }]) as any,
+      authStorage: makeAuthStorage([{ type: "oauth" }]) as any,
       isClaudeCodeReady: true,
       defaultProvider: "anthropic",
       env: {} as NodeJS.ProcessEnv,
@@ -67,7 +67,7 @@ test("shouldMigrateAnthropicToClaudeCode allows OAuth-only anthropic users", () 
 test("shouldMigrateAnthropicToClaudeCode stays off for other providers", () => {
   assert.equal(
     shouldMigrateAnthropicToClaudeCode({
-      authStorage: makeAuthStorage([{ type: "oauth", accessToken: "oauth-token" }]) as any,
+      authStorage: makeAuthStorage([{ type: "oauth" }]) as any,
       isClaudeCodeReady: true,
       defaultProvider: "openai",
       env: {} as NodeJS.ProcessEnv,


### PR DESCRIPTION
## TL;DR

**What:** Preserve the `anthropic` default provider for users who have a direct Anthropic API key configured.
**Why:** Startup was silently rewriting those users to `claude-code` on every launch, even when they explicitly chose the direct API provider.
**How:** Add a small migration guard that only auto-migrates OAuth-only Anthropic setups, and cover it with focused regression tests.

## What

This updates the CLI startup migration that redirects some Anthropic users to `claude-code`.

The branch adds a dedicated helper for the migration decision and reuses it in both startup paths that previously contained the unconditional migration logic.

## Why

Closes #3911.

The existing migration correctly helps Anthropic OAuth users stay on the supported path, but it also caught users who intentionally configured the direct Anthropic API provider. That caused `defaultProvider` to be rewritten on every startup.

## How

The new helper checks for a real direct Anthropic API key first, from either stored credentials or `ANTHROPIC_API_KEY`. If a direct key exists, the migration stays off and the user's configured provider remains `anthropic`. If the setup is OAuth-only, the existing migration behavior still applies.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [ ] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [ ] Manual testing — steps described above
- [ ] No tests needed — explained above

Automated verification:
1. `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/tests/provider-migrations.test.ts`
2. `npm run build`
3. `npm run typecheck:extensions`
4. `tmpdir=$(mktemp -d); HOME="$tmpdir" GSD_HOME="$tmpdir/.gsd" npm run test:unit; rc=$?; rm -rf "$tmpdir"; exit $rc`
5. `npm run secret-scan -- --diff upstream/main`

## AI disclosure

- [x] This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.
