### PR TITLE
fix(gsd): keep project db path after worktree enter

### DIFF
--- a/src/resources/extensions/gsd/auto-start.ts
+++ b/src/resources/extensions/gsd/auto-start.ts
@@ -678,7 +678,7 @@ export async function bootstrapAutoSession(
     }
 
     // ── DB lifecycle ──
-    const gsdDbPath = join(s.basePath, ".gsd", "gsd.db");
+    const gsdDbPath = resolveProjectRootDbPath(s.basePath);
     const gsdDirPath = join(s.basePath, ".gsd");
     if (existsSync(gsdDirPath) && !existsSync(gsdDbPath)) {
       const hasDecisions = existsSync(join(gsdDirPath, "DECISIONS.md"));

--- a/src/resources/extensions/gsd/tests/auto-start-worktree-db-path.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-start-worktree-db-path.test.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { createTestContext } from "./test-helpers.ts";
+
+const { assertTrue, report } = createTestContext();
+
+const srcPath = join(import.meta.dirname, "..", "auto-start.ts");
+const src = readFileSync(srcPath, "utf-8");
+
+console.log("\n=== #3822: worktree bootstrap uses project DB path ===");
+
+const dbLifecycleIdx = src.indexOf("// ── DB lifecycle ──");
+assertTrue(dbLifecycleIdx > 0, "auto-start.ts has a DB lifecycle section");
+
+const dbLifecycleRegion = dbLifecycleIdx > 0 ? src.slice(dbLifecycleIdx, dbLifecycleIdx + 600) : "";
+
+assertTrue(
+  dbLifecycleRegion.includes("const gsdDbPath = resolveProjectRootDbPath(s.basePath);"),
+  "DB lifecycle resolves the project-root DB path after worktree entry (#3822)",
+);
+
+assertTrue(
+  !dbLifecycleRegion.includes('join(s.basePath, ".gsd", "gsd.db")'),
+  "DB lifecycle no longer derives gsd.db directly from the worktree path (#3822)",
+);
+
+report();


### PR DESCRIPTION
## TL;DR

**What:** Keep auto-start's DB lifecycle on the project-root database after entering a worktree.
**Why:** Worktree bootstrap could switch to a non-existent worktree-local `gsd.db`, which dropped the real DB connection and triggered degraded fallback.
**How:** Reuse the existing project-root DB resolver in the post-enter DB lifecycle block and lock it in with a regression test.

## What

This updates the worktree bootstrap path in `auto-start.ts` so the DB lifecycle block continues to point at the project-root SQLite database even after `enterMilestone()` moves `s.basePath` into a worktree.

It also adds a focused regression test that verifies the worktree-enter path resolves `gsdDbPath` through `resolveProjectRootDbPath(s.basePath)` instead of rebuilding a worktree-local `.gsd/gsd.db` path.

## Why

Closes #3822.

The initial project DB open path was already fixed to use the project-root resolver, but the later DB lifecycle block still rebuilt `gsdDbPath` from `s.basePath`. After worktree entry that meant `auto-start` could target a worktree-local DB path, close the real project DB, and fall back to degraded filesystem state.

## How

The fix changes the DB lifecycle block to resolve `gsdDbPath` from `resolveProjectRootDbPath(s.basePath)`, matching the existing helper used earlier in bootstrap.

That keeps all three DB-open / DB-gate checks in that section aligned on the real project database, even after `s.basePath` has changed to a milestone worktree.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [ ] Manual testing — steps described above
- [ ] No tests needed — explained above

Automated verification:
1. `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/auto-start-worktree-db-path.test.ts src/resources/extensions/gsd/tests/auto-start-cold-db-bootstrap.test.ts src/resources/extensions/gsd/tests/shared-wal.test.ts src/resources/extensions/gsd/tests/sqlite-unavailable-gate.test.ts`
2. `npm run build`
3. `npm run typecheck:extensions`
4. `tmpdir=$(mktemp -d); HOME="$tmpdir" GSD_HOME="$tmpdir/.gsd" npm run test:unit; rc=$?; rm -rf "$tmpdir"; exit $rc`
5. `npm run secret-scan -- --diff upstream/main`

## AI disclosure

- [x] This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.
