### PR TITLE
fix(pi-tui): separate content and ime cursor rows

### DIFF
--- a/packages/pi-tui/src/__tests__/tui.test.ts
+++ b/packages/pi-tui/src/__tests__/tui.test.ts
@@ -1,11 +1,13 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
-import { TUI } from "../tui.js";
+import { CURSOR_MARKER, TUI, type Component } from "../tui.js";
 import type { Terminal } from "../terminal.js";
 
-function makeTerminal(): Terminal {
+function makeTerminal(): Terminal & { writes: string[] } {
+	const writes: string[] = [];
 	return {
+		writes,
 		isTTY: true,
 		columns: 80,
 		rows: 24,
@@ -13,7 +15,9 @@ function makeTerminal(): Terminal {
 		start() {},
 		stop() {},
 		drainInput: async () => {},
-		write() {},
+		write(data: string) {
+			writes.push(data);
+		},
 		moveBy() {},
 		hideCursor() {},
 		showCursor() {},
@@ -46,5 +50,50 @@ describe("TUI", () => {
 		assert.deepEqual(received, ["\x1b"]);
 		assert.equal(anyTui.cellSizeQueryPending, false);
 		assert.equal(anyTui.inputBuffer, "");
+	});
+
+	it("uses the content-bottom row, not the IME row, when clearing removed lines", () => {
+		const terminal = makeTerminal();
+		const tui = new TUI(terminal);
+
+		let lines = [
+			"title",
+			`input ${CURSOR_MARKER}`,
+			"results",
+			"footer",
+			"autocomplete a",
+			"autocomplete b",
+		];
+
+		const component: Component = {
+			render: () => [...lines],
+			invalidate() {},
+		};
+
+		tui.addChild(component);
+
+		const anyTui = tui as any;
+		anyTui.doRender();
+
+		terminal.writes.length = 0;
+		lines = [
+			"title",
+			`input ${CURSOR_MARKER}`,
+			"results",
+			"footer",
+		];
+
+		anyTui.doRender();
+
+		assert.equal(anyTui.contentCursorRow, 3, "content cursor should track the bottom of rendered content");
+		assert.equal(anyTui.hardwareCursorRow, 1, "hardware cursor should still follow the IME row");
+		assert.ok(
+			terminal.writes.some((write) => write.includes("\x1b[2A")),
+			"shrink render should move up from the previous content bottom before clearing deleted lines",
+		);
+		assert.ok(
+			terminal.writes.every((write) => !write.includes("\x1b[2B")),
+			"shrink render must not move down from the IME row baseline when clearing deleted lines",
+		);
 	});
 });

--- a/packages/pi-tui/src/tui.ts
+++ b/packages/pi-tui/src/tui.ts
@@ -239,6 +239,7 @@ export class TUI extends Container {
 	public onDebug?: () => void;
 	private renderRequested = false;
 	private cursorRow = 0; // Logical cursor row (end of rendered content)
+	private contentCursorRow = 0; // Terminal row at end of rendered content before IME repositioning
 	private hardwareCursorRow = 0; // Actual terminal cursor row (may differ due to IME positioning)
 	private inputBuffer = ""; // Buffer for parsing terminal responses
 	private cellSizeQueryPending = false;
@@ -498,6 +499,7 @@ export class TUI extends Container {
 			this.previousWidth = -1; // -1 triggers widthChanged, forcing a full clear
 			this.previousHeight = -1; // -1 triggers heightChanged, forcing a full clear
 			this.cursorRow = 0;
+			this.contentCursorRow = 0;
 			this.hardwareCursorRow = 0;
 			this.maxLinesRendered = 0;
 			this.previousViewportTop = 0;
@@ -625,7 +627,7 @@ export class TUI extends Container {
 		const height = this.terminal.rows;
 		let viewportTop = Math.max(0, this.maxLinesRendered - height);
 		let prevViewportTop = this.previousViewportTop;
-		let hardwareCursorRow = this.hardwareCursorRow;
+		let hardwareCursorRow = this.contentCursorRow;
 		const computeLineDiff = (targetRow: number): number => {
 			const currentScreenRow = hardwareCursorRow - prevViewportTop;
 			const targetScreenRow = targetRow - viewportTop;
@@ -672,6 +674,7 @@ export class TUI extends Container {
 			buffer += "\x1b[?2026l"; // End synchronized output
 			this.terminal.write(buffer);
 			this.cursorRow = Math.max(0, newLines.length - 1);
+			this.contentCursorRow = this.cursorRow;
 			this.hardwareCursorRow = this.cursorRow;
 			// Reset max lines when clearing, otherwise track growth
 			if (clear) {
@@ -779,6 +782,7 @@ export class TUI extends Container {
 				buffer += "\x1b[?2026l";
 				this.terminal.write(buffer);
 				this.cursorRow = targetRow;
+				this.contentCursorRow = targetRow;
 				this.hardwareCursorRow = targetRow;
 			}
 			this.positionHardwareCursor(cursorPos, newLines.length);
@@ -898,6 +902,7 @@ export class TUI extends Container {
 		// cursorRow tracks end of content (for viewport calculation)
 		// hardwareCursorRow tracks actual terminal cursor position (for movement)
 		this.cursorRow = Math.max(0, newLines.length - 1);
+		this.contentCursorRow = finalCursorRow;
 		this.hardwareCursorRow = finalCursorRow;
 		// Track terminal's working area (grows but doesn't shrink unless cleared)
 		this.maxLinesRendered = Math.max(this.maxLinesRendered, newLines.length);


### PR DESCRIPTION
## TL;DR

**What:** Separate the TUI's content-bottom cursor tracking from the IME hardware cursor row.
**Why:** Autocomplete shrink renders were using the IME row as the next diff baseline, which left ghost lines behind and could stair-step the cursor.
**How:** Track a dedicated content cursor row for render diffs while leaving the hardware cursor row responsible for IME positioning, and cover the shrink path with a regression test.

## What

This updates `packages/pi-tui/src/tui.ts` so diff rendering keeps a stable baseline for the bottom of rendered content even after `positionHardwareCursor()` moves the terminal cursor for IME support.

It also expands `packages/pi-tui/src/__tests__/tui.test.ts` with a regression case for the autocomplete-shrink scenario where deleted lines must be cleared from the previous content bottom, not from the IME cursor row.

## Why

Closes #3906.

`doRender()` was reusing `hardwareCursorRow` as both the content-bottom baseline and the IME cursor position. Once `positionHardwareCursor()` moved the cursor to the editor row, the next shrink render computed line movement from the wrong row and could clear the wrong part of the screen.

## How

The fix introduces a dedicated `contentCursorRow` that tracks the terminal row where rendered content actually ended before any IME repositioning happens.

Render diff logic now uses that stable content-bottom row, while `hardwareCursorRow` continues to follow the IME cursor for candidate-window placement. The new regression asserts that shrink clears move upward from the previous content bottom instead of downward from the IME row.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [x] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [ ] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [ ] Manual testing — steps described above
- [ ] No tests needed — explained above

Automated verification:
1. `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test packages/pi-tui/src/__tests__/tui.test.ts`
2. `npm run build`
3. `npm run typecheck:extensions`
4. `tmpdir=$(mktemp -d); HOME="$tmpdir" GSD_HOME="$tmpdir/.gsd" npm run test:unit; rc=$?; rm -rf "$tmpdir"; exit $rc`
5. `npm run test:packages` currently reproduces an unrelated clean-upstream failure in `packages/pi-coding-agent/dist/core/model-registry-auth-mode.test.js` on both this branch and clean `upstream/main`
6. `npm run secret-scan -- --diff upstream/main`

## AI disclosure

- [x] This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.
