### PR TITLE
fix(tui): clear pinned latest output on turn completion

### DIFF
--- a/packages/pi-coding-agent/src/core/chat-controller-ordering.test.ts
+++ b/packages/pi-coding-agent/src/core/chat-controller-ordering.test.ts
@@ -338,6 +338,54 @@ test("chat-controller clears pinned zone when a new assistant message starts", a
 	assert.equal(host.pinnedMessageContainer.children.length, 0, "pinned zone should clear on new assistant message");
 });
 
+test("chat-controller clears pinned zone when the agent turn ends", async () => {
+	(globalThis as any)[Symbol.for("@gsd/pi-coding-agent:theme")] = {
+		fg: (_key: string, text: string) => text,
+		bg: (_key: string, text: string) => text,
+		bold: (text: string) => text,
+		italic: (text: string) => text,
+		truncate: (text: string) => text,
+	};
+
+	const host = createHost();
+	const toolCall = {
+		type: "toolCall",
+		id: "tool-clear-on-end-1",
+		name: "exec_command",
+		arguments: { cmd: "echo hi" },
+	};
+
+	await handleAgentEvent(host, { type: "message_start", message: makeAssistant([]) } as any);
+
+	host.getMarkdownThemeWithSettings = () => ({});
+	await handleAgentEvent(
+		host,
+		{
+			type: "message_update",
+			message: makeAssistant([{ type: "text", text: "Working on it." }, toolCall]),
+			assistantMessageEvent: {
+				type: "toolcall_end",
+				contentIndex: 1,
+				toolCall: {
+					...toolCall,
+					externalResult: {
+						content: [{ type: "text", text: "ok" }],
+						details: {},
+						isError: false,
+					},
+				},
+				partial: makeAssistant([{ type: "text", text: "Working on it." }, toolCall]),
+			},
+		} as any,
+	);
+
+	assert.ok(host.pinnedMessageContainer.children.length > 0, "pinned zone should be populated before agent_end");
+
+	await handleAgentEvent(host, { type: "agent_end" } as any);
+
+	assert.equal(host.pinnedMessageContainer.children.length, 0, "pinned zone should clear on agent_end");
+});
+
 test("chat-controller does not pin when there are no tool calls", async () => {
 	(globalThis as any)[Symbol.for("@gsd/pi-coding-agent:theme")] = {
 		fg: (_key: string, text: string) => text,

--- a/packages/pi-coding-agent/src/modes/interactive/controllers/chat-controller.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/controllers/chat-controller.ts
@@ -432,12 +432,12 @@ export async function handleAgentEvent(host: InteractiveModeStateHost & {
 				host.streamingMessage = undefined;
 			}
 			host.pendingTools.clear();
-			// Stop spinner on pinned border and switch label from "Working · Latest Output" to "Latest Output"
+			// Pinned output is only useful while work is actively streaming.
+			// Keep chat history as the single source after completion.
 			if (pinnedBorder) {
 				pinnedBorder.stopSpinner();
-				pinnedBorder.setLabel("Latest Output");
 			}
-			// Keep pinned message visible until the next assistant turn starts.
+			host.pinnedMessageContainer.clear();
 			lastPinnedText = "";
 			hasToolsInTurn = false;
 			pinnedBorder = undefined;


### PR DESCRIPTION
## TL;DR

**What:** Clear the pinned "Latest Output" panel when the agent turn ends instead of leaving it visible.
**Why:** Stale pinned output after completion is confusing — chat history already has the full record.
**How:** Call `pinnedMessageContainer.clear()` on `agent_end` and add a regression test.

## What

Two files changed:
- `packages/pi-coding-agent/src/modes/interactive/controllers/chat-controller.ts` — clear the pinned message container on `agent_end` instead of keeping it visible with a "Latest Output" label
- `packages/pi-coding-agent/src/core/chat-controller-ordering.test.ts` — regression test confirming the pinned zone is cleared when the agent turn ends

## Why

The pinned output panel was designed to show in-flight context while tools are running. After the turn completes, leaving it visible with stale content is misleading — the chat history is the single source of truth. Clearing it on `agent_end` keeps the UI clean.

## How

On `agent_end`, the handler now calls `host.pinnedMessageContainer.clear()` instead of relabeling the border to "Latest Output" and keeping it visible. The spinner is still stopped (if present), and all pinned state is reset.

The regression test simulates a full tool call cycle, asserts the pinned zone is populated mid-turn, fires `agent_end`, then asserts the pinned zone is empty.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## AI disclosure

This PR was prepared with AI assistance.