### PR TITLE
fix(gsd): reset db-open attempted after intentional close

### DIFF
--- a/src/resources/extensions/gsd/gsd-db.ts
+++ b/src/resources/extensions/gsd/gsd-db.ts
@@ -856,6 +856,7 @@ export function closeDatabase(): void {
     currentDb = null;
     currentPath = null;
     currentPid = 0;
+    _dbOpenAttempted = false;
   }
 }
 

--- a/src/resources/extensions/gsd/tests/gsd-db.test.ts
+++ b/src/resources/extensions/gsd/tests/gsd-db.test.ts
@@ -347,15 +347,13 @@ describe('gsd-db', () => {
     assert.deepStrictEqual(ar, [], 'getActiveRequirements returns [] when DB closed');
   });
 
-  test('gsd-db: wasDbOpenAttempted tracks openDatabase calls', () => {
-    // wasDbOpenAttempted should return true once openDatabase has been called
-    // (previous tests in this suite already called openDatabase, so the flag is set)
+  test('gsd-db: closeDatabase resets wasDbOpenAttempted after an intentional close', () => {
+    openDatabase(':memory:');
     assert.ok(wasDbOpenAttempted(), 'wasDbOpenAttempted should be true after openDatabase was called');
 
-    // Verify the flag persists even after closeDatabase
     closeDatabase();
     assert.ok(!isDbAvailable(), 'DB should not be available after close');
-    assert.ok(wasDbOpenAttempted(), 'wasDbOpenAttempted should remain true after closeDatabase');
+    assert.ok(!wasDbOpenAttempted(), 'wasDbOpenAttempted should reset after closeDatabase');
   });
 
   // ─── Final Report ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## TL;DR

**What:** Reset the GSD DB open-attempt flag when the database is intentionally closed.
**Why:** Prevent a false degraded-mode warning after `stopAuto()` closes a healthy DB.
**How:** Clear `_dbOpenAttempted` in `closeDatabase()` and lock the lifecycle with a regression test.

## What

This updates `src/resources/extensions/gsd/gsd-db.ts` so an intentional `closeDatabase()` returns the module to the same idle state as "not opened yet".

It also updates `src/resources/extensions/gsd/tests/gsd-db.test.ts` with a regression that proves `wasDbOpenAttempted()` resets after a clean close.

## Why

Closes #4022.

After auto-mode finished and called `stopAuto()`, the DB was closed but `wasDbOpenAttempted()` stayed true. That made later state derivation show `DB unavailable — using filesystem state derivation (degraded mode)` even though the DB was healthy and simply not open anymore.

## How

The fix resets `_dbOpenAttempted` alongside the existing `currentDb/currentPath/currentPid` cleanup inside `closeDatabase()`.

That keeps the warning behavior aligned with the original intent: warn only after a real open failure, not after an intentional close.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [x] `test` — Adding or updating tests
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [ ] Manual testing — steps described above
- [ ] No tests needed — explained above

Automated verification:
1. `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/gsd-db.test.ts`
2. `npm run build`
3. `npm run typecheck:extensions`
4. `tmpdir=$(mktemp -d); HOME="$tmpdir" GSD_HOME="$tmpdir/.gsd" npm run test:unit; rc=$?; rm -rf "$tmpdir"; exit $rc`
5. `npm run secret-scan -- --diff upstream/main`

## AI disclosure

- [x] This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.
