### PR TITLE
fix(pi-tui): stop kitty keypad glyph leakage

### DIFF
--- a/packages/pi-tui/src/components/__tests__/editor.test.ts
+++ b/packages/pi-tui/src/components/__tests__/editor.test.ts
@@ -61,4 +61,22 @@ describe("Editor", () => {
 
 		assert.ok(rendered.includes(CURSOR_MARKER));
 	});
+
+	it("maps kitty keypad digits to plain editor text", () => {
+		const editor = new Editor(new TUI(makeTerminal()), theme);
+		editor.focused = true;
+
+		editor.handleInput("\x1b[57404;129u");
+
+		assert.equal(editor.getText(), "5");
+	});
+
+	it("does not insert kitty keypad navigation private-use glyphs into the editor", () => {
+		const editor = new Editor(new TUI(makeTerminal()), theme);
+		editor.focused = true;
+
+		editor.handleInput("\x1b[57419u");
+
+		assert.equal(editor.getText(), "");
+	});
 });

--- a/packages/pi-tui/src/components/__tests__/input.test.ts
+++ b/packages/pi-tui/src/components/__tests__/input.test.ts
@@ -43,4 +43,22 @@ describe("Input", () => {
 		assert.ok(!line.includes("secret123"), "rendered line must not expose raw secret text");
 		assert.ok(line.includes("*********"), "rendered line should include masked characters");
 	});
+
+	it("maps kitty keypad digits to text instead of inserting private-use glyphs", () => {
+		const input = new Input();
+		input.focused = true;
+
+		input.handleInput("\x1b[57400;129u");
+
+		assert.equal(input.getValue(), "1");
+	});
+
+	it("ignores kitty keypad navigation keys in text input", () => {
+		const input = new Input();
+		input.focused = true;
+
+		input.handleInput("\x1b[57417u");
+
+		assert.equal(input.getValue(), "");
+	});
 });

--- a/packages/pi-tui/src/keys.ts
+++ b/packages/pi-tui/src/keys.ts
@@ -309,6 +309,28 @@ const CODEPOINTS = {
 	kpEnter: 57414, // Numpad Enter (Kitty protocol)
 } as const;
 
+const KITTY_PRIVATE_USE_RANGE = { start: 57344, end: 63743 } as const;
+
+const KITTY_KEYPAD_PRINTABLES = new Map<number, string>([
+	[57399, "0"], // KP_0
+	[57400, "1"], // KP_1
+	[57401, "2"], // KP_2
+	[57402, "3"], // KP_3
+	[57403, "4"], // KP_4
+	[57404, "5"], // KP_5
+	[57405, "6"], // KP_6
+	[57406, "7"], // KP_7
+	[57407, "8"], // KP_8
+	[57408, "9"], // KP_9
+	[57409, "."], // KP_DECIMAL
+	[57410, "/"], // KP_DIVIDE
+	[57411, "*"], // KP_MULTIPLY
+	[57412, "-"], // KP_SUBTRACT
+	[57413, "+"], // KP_ADD
+	[57415, "="], // KP_EQUAL
+	[57416, ","], // KP_SEPARATOR
+]);
+
 const ARROW_CODEPOINTS = {
 	up: -1,
 	down: -2,
@@ -1167,6 +1189,16 @@ export function decodeKittyPrintable(data: string): string | undefined {
 	}
 	// Drop control characters or invalid codepoints.
 	if (!Number.isFinite(effectiveCodepoint) || effectiveCodepoint < 32) return undefined;
+
+	const keypadPrintable = KITTY_KEYPAD_PRINTABLES.get(effectiveCodepoint);
+	if (keypadPrintable !== undefined) return keypadPrintable;
+
+	if (
+		effectiveCodepoint >= KITTY_PRIVATE_USE_RANGE.start &&
+		effectiveCodepoint <= KITTY_PRIVATE_USE_RANGE.end
+	) {
+		return undefined;
+	}
 
 	try {
 		return String.fromCodePoint(effectiveCodepoint);


### PR DESCRIPTION
## TL;DR

**What:** Stop Kitty keypad CSI-u private-use codepoints from leaking raw glyphs into TUI text entry.
**Why:** Keypad digits and keypad navigation keys currently corrupt the prompt/editor with private-use characters.
**How:** Map printable keypad codepoints to their textual equivalents, reject the remaining private-use keypad events, and cover both input and editor paths with tests.

## What

This updates `packages/pi-tui/src/keys.ts` so `decodeKittyPrintable()` no longer turns Kitty keypad private-use codepoints directly into visible Unicode glyphs.

It also adds focused regressions in `packages/pi-tui/src/components/__tests__/input.test.ts` and `packages/pi-tui/src/components/__tests__/editor.test.ts` for keypad digits and keypad navigation sequences.

## Why

Closes #3999.

When Kitty keyboard protocol is active, keypad keys can arrive as CSI-u private-use codepoints. The existing printable decoder passes those codepoints through `String.fromCodePoint(...)`, which makes keypad digits and keypad navigation appear in the prompt/editor as garbage glyphs instead of digits or harmless ignored navigation events.

## How

The fix adds an explicit mapping for printable Kitty keypad codepoints (`0-9`, arithmetic keys, decimal/separator) and returns those plain characters for text entry.

For the rest of the Kitty private-use keypad range, the decoder now returns `undefined` so input/editor components stop inserting glyphs for keypad navigation events.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [x] `test` — Adding or updating tests
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [x] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [ ] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [ ] Manual testing — steps described above
- [ ] No tests needed — explained above

Automated verification:
1. `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test packages/pi-tui/src/components/__tests__/input.test.ts packages/pi-tui/src/components/__tests__/editor.test.ts`
2. `npm run build`
3. `npm run typecheck:extensions`
4. `tmpdir=$(mktemp -d); HOME="$tmpdir" GSD_HOME="$tmpdir/.gsd" npm run test:unit; rc=$?; rm -rf "$tmpdir"; exit $rc`
5. `tmpdir=$(mktemp -d); HOME="$tmpdir" GSD_HOME="$tmpdir/.gsd" npm run test:packages; rc=$?; rm -rf "$tmpdir"; exit $rc`
6. `npm run secret-scan -- --diff upstream/main`

## AI disclosure

- [x] This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.
