### PR TITLE
fix(gsd): disable db mmap on darwin

### DIFF
--- a/src/resources/extensions/gsd/gsd-db.ts
+++ b/src/resources/extensions/gsd/gsd-db.ts
@@ -168,7 +168,7 @@ function initSchema(db: DbAdapter, fileBacked: boolean): void {
   if (fileBacked) db.exec("PRAGMA synchronous = NORMAL");
   if (fileBacked) db.exec("PRAGMA auto_vacuum = INCREMENTAL");
   if (fileBacked) db.exec("PRAGMA cache_size = -8000");   // 8 MB page cache
-  if (fileBacked) db.exec("PRAGMA mmap_size = 67108864");  // 64 MB mmap
+  if (fileBacked && process.platform !== "darwin") db.exec("PRAGMA mmap_size = 67108864");  // 64 MB mmap
   db.exec("PRAGMA temp_store = MEMORY");
   db.exec("PRAGMA foreign_keys = ON");
 

--- a/src/resources/extensions/gsd/tests/gsd-db.test.ts
+++ b/src/resources/extensions/gsd/tests/gsd-db.test.ts
@@ -43,6 +43,16 @@ function cleanup(dbPath: string): void {
   }
 }
 
+function withPlatform<T>(platform: NodeJS.Platform, fn: () => T): T {
+  const original = process.platform;
+  Object.defineProperty(process, 'platform', { value: platform });
+  try {
+    return fn();
+  } finally {
+    Object.defineProperty(process, 'platform', { value: original });
+  }
+}
+
 // ═══════════════════════════════════════════════════════════════════════════
 // gsd-db tests
 // ═══════════════════════════════════════════════════════════════════════════
@@ -277,6 +287,26 @@ describe('gsd-db', () => {
     assert.deepStrictEqual(mode?.['journal_mode'], 'wal', 'journal_mode should be wal for file-backed DB');
 
     cleanup(dbPath);
+  });
+
+  test('gsd-db: mmap stays disabled on darwin file-backed DBs', () => {
+    const darwinDbPath = tempDbPath();
+    withPlatform('darwin', () => {
+      openDatabase(darwinDbPath);
+      const adapter = _getAdapter()!;
+      const mmap = adapter.prepare('PRAGMA mmap_size').get();
+      assert.deepStrictEqual(mmap?.['mmap_size'], 0, 'darwin should leave mmap_size disabled');
+      cleanup(darwinDbPath);
+    });
+
+    const linuxDbPath = tempDbPath();
+    withPlatform('linux', () => {
+      openDatabase(linuxDbPath);
+      const adapter = _getAdapter()!;
+      const mmap = adapter.prepare('PRAGMA mmap_size').get();
+      assert.deepStrictEqual(mmap?.['mmap_size'], 67108864, 'non-darwin should still enable mmap_size');
+      cleanup(linuxDbPath);
+    });
   });
 
   test('gsd-db: transaction rollback on error', () => {


### PR DESCRIPTION
## TL;DR

**What:** Disable SQLite mmap for file-backed GSD databases on Darwin and lock that behavior with a regression test.
**Why:** #3900 reports WAL + mmap as a corruption path on macOS during long auto-mode runs.
**How:** Gate the `mmap_size` pragma on `process.platform !== "darwin"` and assert Darwin vs non-Darwin behavior in `gsd-db.test.ts`.

## What

- skip `PRAGMA mmap_size = 67108864` when `gsd-db` opens a file-backed database on Darwin
- add a regression test that opens real file-backed DBs under mocked Darwin and Linux platforms and checks the resulting `mmap_size`

## Why

Closes #3900.

The current schema setup always enables mmap for file-backed DBs. On macOS that is the risky path called out in the issue, so this change removes that platform-specific footgun without changing the existing non-Darwin tuning.

## How

The change is intentionally surgical: all existing file-backed pragmas stay the same, and only the mmap line is platform-guarded. The new test exercises actual file-backed opens instead of source-matching, so it proves the adapter ends up with the expected pragma value on both branches.

## Change type

- [x] `fix` — Bug fix
- [x] `test` — Adding or updating tests
- [ ] `feat` — New feature or capability
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [x] `gsd extension` — GSD workflow
- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [ ] Manual testing — steps described above
- [ ] No tests needed — explained above

Automated verification:
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/gsd-db.test.ts`
- `npm run build`
- `npm run typecheck:extensions`
- `HOME="$(mktemp -d)" GSD_HOME="$HOME/.gsd" npm run test:unit`

## AI disclosure

- [x] This PR includes AI-assisted code
