### PR TITLE
fix(pi-coding-agent): retry after cancelled overflow compaction

### DIFF
--- a/packages/pi-coding-agent/src/core/compaction-orchestrator.test.ts
+++ b/packages/pi-coding-agent/src/core/compaction-orchestrator.test.ts
@@ -1,0 +1,154 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it, mock, type Mock } from "node:test";
+
+import type { Agent } from "@gsd/pi-agent-core";
+import type { Api, AssistantMessage, Model } from "@gsd/pi-ai";
+
+import { CompactionOrchestrator, type CompactionOrchestratorDeps } from "./compaction-orchestrator.js";
+import { SessionManager } from "./session-manager.js";
+
+function createMockModel(): Model<Api> {
+	return {
+		id: "claude-opus-4-6",
+		name: "Claude Opus 4.6",
+		api: "anthropic-messages" as Api,
+		provider: "anthropic",
+		baseUrl: "https://api.anthropic.com",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 200_000,
+		maxTokens: 16_384,
+	} as Model<Api>;
+}
+
+function createAssistantMessage(
+	stopReason: AssistantMessage["stopReason"],
+	contentText: string,
+): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "text", text: contentText }],
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "claude-opus-4-6",
+		usage: {
+			input: 100,
+			output: 100,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 200,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason,
+		timestamp: Date.now(),
+		errorMessage: stopReason === "error" ? contentText : undefined,
+	} as AssistantMessage;
+}
+
+function wait(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function createHarness(overrides?: {
+	cancelResult?: boolean;
+	willRetry?: boolean;
+	hasQueuedMessages?: boolean;
+}) {
+	const dir = mkdtempSync(join(tmpdir(), "compaction-orchestrator-test-"));
+	const sessionManager = SessionManager.create(dir, dir);
+	sessionManager.appendMessage({ role: "user", content: "First user message" } as any);
+	sessionManager.appendMessage(createAssistantMessage("stop", "First assistant message"));
+	sessionManager.appendMessage({ role: "user", content: "Second user message" } as any);
+
+	const emittedEvents: Array<Record<string, unknown>> = [];
+	const continueFn = mock.fn(async () => {});
+	const replaceMessages = mock.fn((nextMessages: unknown[]) => {
+		(agent.state.messages as unknown[]) = nextMessages;
+	});
+	const agent = {
+		state: {
+			messages: [
+				{ role: "user", content: "queued follow-up" },
+				createAssistantMessage("error", "context overflow"),
+			],
+		},
+		continue: continueFn,
+		replaceMessages,
+		hasQueuedMessages: () => overrides?.hasQueuedMessages ?? false,
+	} as unknown as Agent;
+
+	const extensionRunner = {
+		hasHandlers: mock.fn(() => true),
+		emit: mock.fn(async () => ({ cancel: overrides?.cancelResult ?? true })),
+	};
+
+	const deps: CompactionOrchestratorDeps = {
+		agent,
+		sessionManager,
+		settingsManager: {
+			getCompactionSettings: () => ({
+				enabled: true,
+				reserveTokens: 16_384,
+				keepRecentTokens: 1,
+			}),
+		} as any,
+		modelRegistry: {
+			isProviderRequestReady: () => true,
+			getApiKey: async () => undefined,
+		} as any,
+		getModel: () => createMockModel(),
+		getSessionId: () => "test-session",
+		getExtensionRunner: () => extensionRunner as any,
+		emit: (event) => emittedEvents.push(event as unknown as Record<string, unknown>),
+		disconnectFromAgent: () => {},
+		reconnectToAgent: () => {},
+		abort: async () => {},
+	};
+
+	return {
+		dir,
+		agent,
+		continueFn,
+		replaceMessages,
+		emittedEvents,
+		extensionRunner,
+		orchestrator: new CompactionOrchestrator(deps),
+		cleanup: () => rmSync(dir, { recursive: true, force: true }),
+	};
+}
+
+describe("CompactionOrchestrator", () => {
+	it("overflow cancel keeps retry intent and resumes the agent (#3971)", async (t) => {
+		const harness = createHarness({ willRetry: true });
+		t.after(harness.cleanup);
+
+		await (harness.orchestrator as any)._runAutoCompaction("overflow", true);
+		await wait(150);
+
+		const endEvent = harness.emittedEvents.find((event) => event.type === "auto_compaction_end");
+		assert.ok(endEvent, "should emit auto_compaction_end");
+		assert.equal(endEvent?.aborted, true, "cancelled compaction should be marked aborted");
+		assert.equal(endEvent?.willRetry, true, "overflow cancel should preserve retry intent");
+		assert.equal(harness.continueFn.mock.callCount(), 1, "overflow cancel should resume the agent");
+		assert.equal(harness.replaceMessages.mock.callCount(), 1, "retry follow-up should trim the error message when present");
+	});
+
+	it("threshold cancel stays non-retrying when no queued messages exist", async (t) => {
+		const harness = createHarness({ willRetry: false, hasQueuedMessages: false });
+		t.after(harness.cleanup);
+
+		await (harness.orchestrator as any)._runAutoCompaction("threshold", false);
+		await wait(150);
+
+		const endEvent = harness.emittedEvents.find((event) => event.type === "auto_compaction_end");
+		assert.ok(endEvent, "should emit auto_compaction_end");
+		assert.equal(endEvent?.aborted, true, "cancelled compaction should be marked aborted");
+		assert.equal(endEvent?.willRetry, false, "threshold cancel should stay non-retrying");
+		assert.equal(harness.continueFn.mock.callCount(), 0, "threshold cancel should not resume the agent without queued work");
+		assert.equal(harness.replaceMessages.mock.callCount(), 0, "non-retry cancel should not trim messages");
+	});
+});

--- a/packages/pi-coding-agent/src/core/compaction-orchestrator.ts
+++ b/packages/pi-coding-agent/src/core/compaction-orchestrator.ts
@@ -332,8 +332,9 @@ export class CompactionOrchestrator {
 						type: "auto_compaction_end",
 						result: undefined,
 						aborted: true,
-						willRetry: false,
+						willRetry,
 					});
+					this._scheduleAutoCompactionFollowup(willRetry);
 					return;
 				}
 
@@ -391,22 +392,7 @@ export class CompactionOrchestrator {
 
 			const result: CompactionResult = { summary, firstKeptEntryId, tokensBefore, details };
 			this._deps.emit({ type: "auto_compaction_end", result, aborted: false, willRetry });
-
-			if (willRetry) {
-				const messages = this._deps.agent.state.messages;
-				const lastMsg = messages[messages.length - 1];
-				if (lastMsg?.role === "assistant" && (lastMsg as AssistantMessage).stopReason === "error") {
-					this._deps.agent.replaceMessages(messages.slice(0, -1));
-				}
-
-				setTimeout(() => {
-					this._deps.agent.continue().catch(() => {});
-				}, 100);
-			} else if (this._deps.agent.hasQueuedMessages()) {
-				setTimeout(() => {
-					this._deps.agent.continue().catch(() => {});
-				}, 100);
-			}
+			this._scheduleAutoCompactionFollowup(willRetry);
 		} catch (error) {
 			const errorMessage = getErrorMessage(error);
 			this._deps.emit({
@@ -421,6 +407,27 @@ export class CompactionOrchestrator {
 			});
 		} finally {
 			this._autoCompactionAbortController = undefined;
+		}
+	}
+
+	private _scheduleAutoCompactionFollowup(willRetry: boolean): void {
+		if (willRetry) {
+			const messages = this._deps.agent.state.messages;
+			const lastMsg = messages[messages.length - 1];
+			if (lastMsg?.role === "assistant" && (lastMsg as AssistantMessage).stopReason === "error") {
+				this._deps.agent.replaceMessages(messages.slice(0, -1));
+			}
+
+			setTimeout(() => {
+				this._deps.agent.continue().catch(() => {});
+			}, 100);
+			return;
+		}
+
+		if (this._deps.agent.hasQueuedMessages()) {
+			setTimeout(() => {
+				this._deps.agent.continue().catch(() => {});
+			}, 100);
 		}
 	}
 }


### PR DESCRIPTION
## TL;DR

**What:** Preserve retry intent when overflow compaction is cancelled and resume the agent instead of silently idling.
**Why:** #3971 reports that cancelled overflow recovery emits `willRetry: false` and returns without `agent.continue()`, leaving auto-mode stuck until timeout.
**How:** Reuse one auto-compaction follow-up path for both success and cancel branches, and cover overflow-vs-threshold cancellation with a focused orchestrator test.

## What

- propagate `willRetry` through cancelled `auto_compaction_end` events
- schedule the same post-compaction follow-up used after successful auto-compaction when cancelled overflow recovery still needs a retry
- add a focused `CompactionOrchestrator` regression test for overflow cancellation and a guard test that threshold cancellation stays non-retrying without queued work

## Why

Closes #3971.

Today the extension-cancel path drops overflow recovery on the floor: it hardcodes `willRetry: false` and returns before the agent is resumed. That leaves the session idle even though the overflow branch explicitly asked for a retry.

## How

The behavior change stays narrow by factoring the existing post-compaction follow-up into a helper and calling it from both the success and cancel paths. That keeps the existing threshold semantics while letting overflow recovery preserve its retry contract when an extension vetoes compaction.

## Change type

- [x] `fix` — Bug fix
- [x] `test` — Adding or updating tests
- [ ] `feat` — New feature or capability
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [x] `pi-coding-agent` — Coding agent
- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [ ] Manual testing — steps described above
- [ ] No tests needed — explained above

Automated verification:
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test packages/pi-coding-agent/src/core/compaction-orchestrator.test.ts`
- `npm run build`
- `npm run typecheck:extensions`
- `HOME="$(mktemp -d)" GSD_HOME="$HOME/.gsd" npm run test:unit`
- `HOME="$(mktemp -d)" GSD_HOME="$HOME/.gsd" npm run test:packages`

## AI disclosure

- [x] This PR includes AI-assisted code
