### PR TITLE
fix(pi-ai): filter unavailable GitHub Copilot models

### DIFF
--- a/packages/pi-ai/src/utils/oauth/github-copilot.test.ts
+++ b/packages/pi-ai/src/utils/oauth/github-copilot.test.ts
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { Api, Model } from "../../types.js";
+import type { OAuthCredentials } from "./index.js";
+import { githubCopilotOAuthProvider } from "./github-copilot.js";
+
+function makeModel(provider: string, id: string): Model<Api> {
+	return {
+		id,
+		name: id,
+		api: "openai-completions",
+		provider,
+		baseUrl: `${provider}:`,
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 128000,
+		maxTokens: 16384,
+	};
+}
+
+function makeCredentials(overrides: Partial<OAuthCredentials & { modelLimits?: Record<string, { contextWindow: number; maxTokens: number }> }> = {}) {
+	return {
+		type: "oauth" as const,
+		access: "copilot-token",
+		refresh: "refresh-token",
+		expires: Date.now() + 60_000,
+		...overrides,
+	};
+}
+
+test("githubCopilotOAuthProvider.modifyModels filters unavailable copilot models (#3849)", () => {
+	const models = [
+		makeModel("github-copilot", "gpt-5"),
+		makeModel("github-copilot", "claude-sonnet-4"),
+		makeModel("openai", "gpt-4.1"),
+	];
+
+	assert.ok(githubCopilotOAuthProvider.modifyModels, "github copilot provider should expose modifyModels");
+	const modified = githubCopilotOAuthProvider.modifyModels(models, makeCredentials({
+		modelLimits: {
+			"gpt-5": { contextWindow: 256000, maxTokens: 32000 },
+		},
+	}));
+
+	assert.deepEqual(
+		modified.map((model) => `${model.provider}/${model.id}`),
+		["github-copilot/gpt-5", "openai/gpt-4.1"],
+	);
+
+	const copilotModel = modified.find((model) => model.provider === "github-copilot" && model.id === "gpt-5");
+	assert.ok(copilotModel, "available copilot model should remain");
+	assert.equal(copilotModel.contextWindow, 256000);
+	assert.equal(copilotModel.maxTokens, 32000);
+	assert.match(copilotModel.baseUrl, /githubcopilot\.com/);
+});
+
+test("githubCopilotOAuthProvider.modifyModels keeps all copilot models when limits are unavailable", () => {
+	const models = [
+		makeModel("github-copilot", "gpt-5"),
+		makeModel("github-copilot", "claude-sonnet-4"),
+	];
+
+	assert.ok(githubCopilotOAuthProvider.modifyModels, "github copilot provider should expose modifyModels");
+	const modified = githubCopilotOAuthProvider.modifyModels(models, makeCredentials());
+
+	assert.equal(modified.length, 2, "lack of limits should not hide every copilot model");
+	assert.ok(modified.every((model) => model.provider === "github-copilot"));
+	assert.ok(modified.every((model) => model.baseUrl.includes("githubcopilot.com")));
+});

--- a/packages/pi-ai/src/utils/oauth/github-copilot.ts
+++ b/packages/pi-ai/src/utils/oauth/github-copilot.ts
@@ -441,8 +441,11 @@ export const githubCopilotOAuthProvider: OAuthProviderInterface = {
 		const domain = creds.enterpriseUrl ? (normalizeDomain(creds.enterpriseUrl) ?? undefined) : undefined;
 		const baseUrl = getGitHubCopilotBaseUrl(creds.access, domain);
 		const limits = creds.modelLimits;
-		return models.map((m) => {
+		const availableModelIds = limits ? new Set(Object.keys(limits)) : null;
+		const shouldFilterByAvailability = !!availableModelIds && availableModelIds.size > 0;
+		return models.flatMap((m) => {
 			if (m.provider !== "github-copilot") return m;
+			if (shouldFilterByAvailability && !availableModelIds.has(m.id)) return [];
 			const modelLimits = limits?.[m.id];
 			return {
 				...m,


### PR DESCRIPTION
## TL;DR

**What:** Filter GitHub Copilot model lists down to models the current OAuth session can actually use.
**Why:** The UI currently offers unavailable Copilot models, and selecting one can fail with a 400.
**How:** Reuse the Copilot `/models` availability data already stored in `modelLimits` to prune unavailable models while keeping the old fallback when limits are unavailable.

## What

This updates the GitHub Copilot OAuth model modifier in `packages/pi-ai` so it only keeps Copilot models that appear in the provider's discovered model limits for the current OAuth session. It also adds a focused regression test that covers both the filtered and no-limits fallback paths.

## Why

This fixes users seeing and selecting Copilot models that their subscription or organization does not actually expose. That mismatch can break manual model selection and dynamic routing. Closes #3849.

## How

The provider already fetches model availability and limits from the Copilot API after login and refresh. This change treats a non-empty `modelLimits` map as the authoritative availability set for Copilot models, filters the registry output accordingly, and preserves the existing non-filtering behavior when limits are unavailable.

## Change type

- [x] `fix` — Bug fix
- [x] `test` — Adding or updating tests
- [ ] `feat` — New feature or capability
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [x] `pi-ai` — AI/LLM layer
- [ ] `pi-tui` — Terminal UI
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [ ] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [ ] Manual testing — steps described above
- [ ] No tests needed — explained above

Automated verification:
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test packages/pi-ai/src/utils/oauth/github-copilot.test.ts`
- `npm run build`
- `npm run typecheck:extensions`
- `npm run test:unit`
- `npm run test:packages`
- `npm run secret-scan -- --diff upstream/main`

## AI disclosure

- [x] This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.
