### PR TITLE
fix(gsd): keep parallel auto workers alive between events

### DIFF
--- a/src/headless-events.ts
+++ b/src/headless-events.ts
@@ -65,11 +65,13 @@ export function mapStatusToExitCode(status: string): number {
  * Blocked detection is separate — checked via isBlockedNotification.
  */
 export const TERMINAL_PREFIXES = ['auto-mode stopped', 'step-mode stopped']
+export const DEFAULT_HEADLESS_TIMEOUT_MS = 300_000
 export const IDLE_TIMEOUT_MS = 15_000
 // new-milestone is a long-running creative task where the LLM may pause
 // between tool calls (e.g. after mkdir, before writing files). Use a
 // longer idle timeout to avoid killing the session prematurely (#808).
 export const NEW_MILESTONE_IDLE_TIMEOUT_MS = 120_000
+export const NEW_MILESTONE_HEADLESS_TIMEOUT_MS = 600_000
 const INTERACTIVE_HEADLESS_TOOLS = new Set(['ask_user_questions', 'secure_env_collect'])
 const MULTI_TURN_HEADLESS_COMMANDS = new Set(['auto', 'next', 'discuss', 'plan'])
 
@@ -98,6 +100,21 @@ export function getHeadlessRuntimeState(command: string): HeadlessRuntimeState {
     isNewMilestone: command === 'new-milestone',
     isMultiTurnCommand: MULTI_TURN_HEADLESS_COMMANDS.has(command),
   }
+}
+
+export function resolveHeadlessOverallTimeout(
+  command: string,
+  timeoutMs: number,
+  timeoutExplicit: boolean,
+): number {
+  if (timeoutExplicit) return timeoutMs
+  if (command === 'new-milestone' && timeoutMs === DEFAULT_HEADLESS_TIMEOUT_MS) {
+    return NEW_MILESTONE_HEADLESS_TIMEOUT_MS
+  }
+  if (command === 'auto' && timeoutMs === DEFAULT_HEADLESS_TIMEOUT_MS) {
+    return 0
+  }
+  return timeoutMs
 }
 
 export function shouldArmHeadlessIdleTimer(

--- a/src/headless-events.ts
+++ b/src/headless-events.ts
@@ -71,6 +71,15 @@ export const IDLE_TIMEOUT_MS = 15_000
 // longer idle timeout to avoid killing the session prematurely (#808).
 export const NEW_MILESTONE_IDLE_TIMEOUT_MS = 120_000
 const INTERACTIVE_HEADLESS_TOOLS = new Set(['ask_user_questions', 'secure_env_collect'])
+const MULTI_TURN_HEADLESS_COMMANDS = new Set(['auto', 'next', 'discuss', 'plan'])
+
+export interface HeadlessRuntimeState {
+  command: string
+  idleTimeoutMs: number
+  isAutoMode: boolean
+  isNewMilestone: boolean
+  isMultiTurnCommand: boolean
+}
 
 export function getHeadlessIdleTimeout(command: string): number {
   if (command === 'new-milestone') return NEW_MILESTONE_IDLE_TIMEOUT_MS
@@ -81,8 +90,22 @@ export function getHeadlessIdleTimeout(command: string): number {
   return IDLE_TIMEOUT_MS
 }
 
-export function shouldArmIdleTimeout(toolCallCount: number, idleTimeoutMs: number): boolean {
-  return toolCallCount > 0 && idleTimeoutMs > 0
+export function getHeadlessRuntimeState(command: string): HeadlessRuntimeState {
+  return {
+    command,
+    idleTimeoutMs: getHeadlessIdleTimeout(command),
+    isAutoMode: command === 'auto',
+    isNewMilestone: command === 'new-milestone',
+    isMultiTurnCommand: MULTI_TURN_HEADLESS_COMMANDS.has(command),
+  }
+}
+
+export function shouldArmHeadlessIdleTimer(
+  toolCallCount: number,
+  interactiveToolCount: number,
+  idleTimeoutMs: number,
+): boolean {
+  return toolCallCount > 0 && interactiveToolCount === 0 && idleTimeoutMs > 0
 }
 
 export function isTerminalNotification(event: Record<string, unknown>): boolean {
@@ -105,10 +128,6 @@ export function isMilestoneReadyNotification(event: Record<string, unknown>): bo
 
 export function isInteractiveHeadlessTool(toolName: string | undefined): boolean {
   return INTERACTIVE_HEADLESS_TOOLS.has(String(toolName ?? ''))
-}
-
-export function shouldArmHeadlessIdleTimeout(toolCallCount: number, interactiveToolCount: number): boolean {
-  return toolCallCount > 0 && interactiveToolCount === 0
 }
 
 // ---------------------------------------------------------------------------

--- a/src/headless-events.ts
+++ b/src/headless-events.ts
@@ -72,6 +72,19 @@ export const IDLE_TIMEOUT_MS = 15_000
 export const NEW_MILESTONE_IDLE_TIMEOUT_MS = 120_000
 const INTERACTIVE_HEADLESS_TOOLS = new Set(['ask_user_questions', 'secure_env_collect'])
 
+export function getHeadlessIdleTimeout(command: string): number {
+  if (command === 'new-milestone') return NEW_MILESTONE_IDLE_TIMEOUT_MS
+  // auto-mode workers can spend long stretches in internal orchestration or
+  // await_job waits without emitting RPC events. Let terminal notifications
+  // drive completion there instead of the generic idle fallback (#3428).
+  if (command === 'auto') return 0
+  return IDLE_TIMEOUT_MS
+}
+
+export function shouldArmIdleTimeout(toolCallCount: number, idleTimeoutMs: number): boolean {
+  return toolCallCount > 0 && idleTimeoutMs > 0
+}
+
 export function isTerminalNotification(event: Record<string, unknown>): boolean {
   if (event.type !== 'extension_ui_request' || event.method !== 'notify') return false
   const message = String(event.message ?? '').toLowerCase()

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -29,7 +29,9 @@ import {
   isQuickCommand,
   FIRE_AND_FORGET_METHODS,
   isInteractiveHeadlessTool,
+  DEFAULT_HEADLESS_TIMEOUT_MS,
   getHeadlessRuntimeState,
+  resolveHeadlessOverallTimeout,
   shouldArmHeadlessIdleTimer,
   EXIT_SUCCESS,
   EXIT_ERROR,
@@ -66,6 +68,7 @@ export interface HeadlessOptions {
   timeout: number
   json: boolean
   outputFormat: OutputFormat
+  timeoutExplicit?: boolean
   model?: string
   command: string
   commandArgs: string[]
@@ -145,7 +148,7 @@ export function resolveResumeSession(sessions: SessionInfo[], prefix: string): R
 
 export function parseHeadlessArgs(argv: string[]): HeadlessOptions {
   const options: HeadlessOptions = {
-    timeout: 300_000,
+    timeout: DEFAULT_HEADLESS_TIMEOUT_MS,
     json: false,
     outputFormat: 'text',
     command: 'auto',
@@ -161,6 +164,7 @@ export function parseHeadlessArgs(argv: string[]): HeadlessOptions {
     if (arg.startsWith('--')) {
       if (arg === '--timeout' && i + 1 < args.length) {
         options.timeout = parseInt(args[++i], 10)
+        options.timeoutExplicit = true
         if (Number.isNaN(options.timeout) || options.timeout < 0) {
           process.stderr.write('[headless] Error: --timeout must be a non-negative integer (milliseconds, 0 to disable)\n')
           process.exit(1)
@@ -271,21 +275,15 @@ async function runHeadlessOnce(options: HeadlessOptions, restartCount: number): 
   let currentCommand = runtimeState.command
   const isNewMilestone = runtimeState.isNewMilestone
 
-  // new-milestone involves codebase investigation + artifact writing — needs more time
-  if (isNewMilestone && options.timeout === 300_000) {
-    options.timeout = 600_000 // 10 minutes
-  }
-
   // auto-mode sessions are long-running (minutes to hours) with their own internal
   // per-unit timeout via auto-supervisor. Disable the overall timeout unless the
   // user explicitly set --timeout.
+  const timeoutExplicit = options.timeoutExplicit === true
+  options.timeout = resolveHeadlessOverallTimeout(currentCommand, options.timeout, timeoutExplicit)
   const isAutoMode = runtimeState.isAutoMode
   // discuss and plan are multi-turn: they involve multiple question rounds,
   // codebase scanning, and artifact writing before the workflow completes (#3547).
   let isMultiTurnCommand = runtimeState.isMultiTurnCommand
-  if (isAutoMode && options.timeout === 300_000) {
-    options.timeout = 0
-  }
 
   // Supervised mode cannot share stdin with --context -
   if (options.supervised && options.context === '-') {
@@ -521,7 +519,7 @@ async function runHeadlessOnce(options: HeadlessOptions, restartCount: number): 
   const responseTimeout = options.responseTimeout ?? 30_000
 
   // Overall timeout (disabled when options.timeout === 0, e.g. auto-mode)
-  const timeoutTimer = options.timeout > 0
+  let timeoutTimer = options.timeout > 0
     ? setTimeout(() => {
         process.stderr.write(`[headless] Timeout after ${options.timeout / 1000}s\n`)
         exitCode = EXIT_ERROR
@@ -921,7 +919,10 @@ async function runHeadlessOnce(options: HeadlessOptions, restartCount: number): 
 
     // Reset completion state for the auto-mode phase.
     // Disable the overall timeout — auto-mode has its own internal supervisor.
-    if (timeoutTimer) clearTimeout(timeoutTimer)
+    if (timeoutTimer && !timeoutExplicit) {
+      clearTimeout(timeoutTimer)
+      timeoutTimer = null
+    }
     if (idleTimer) {
       clearTimeout(idleTimer)
       idleTimer = null

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -501,7 +501,7 @@ async function runHeadlessOnce(options: HeadlessOptions, restartCount: number): 
 
   // Idle timeout — fallback completion detection
   let idleTimer: ReturnType<typeof setTimeout> | null = null
-  const effectiveIdleTimeout = getHeadlessIdleTimeout(options.command)
+  let effectiveIdleTimeout = getHeadlessIdleTimeout(options.command)
 
   function resetIdleTimer(): void {
     if (idleTimer) clearTimeout(idleTimer)
@@ -921,6 +921,11 @@ async function runHeadlessOnce(options: HeadlessOptions, restartCount: number): 
     // Reset completion state for the auto-mode phase.
     // Disable the overall timeout — auto-mode has its own internal supervisor.
     if (timeoutTimer) clearTimeout(timeoutTimer)
+    if (idleTimer) {
+      clearTimeout(idleTimer)
+      idleTimer = null
+    }
+    effectiveIdleTimeout = getHeadlessIdleTimeout('auto')
     completed = false
     milestoneReady = false
     blocked = false

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -268,7 +268,8 @@ export async function runHeadless(options: HeadlessOptions): Promise<void> {
 async function runHeadlessOnce(options: HeadlessOptions, restartCount: number): Promise<{ exitCode: number; interrupted: boolean }> {
   let interrupted = false
   const startTime = Date.now()
-  const isNewMilestone = options.command === 'new-milestone'
+  let currentCommand = options.command
+  const isNewMilestone = currentCommand === 'new-milestone'
 
   // new-milestone involves codebase investigation + artifact writing — needs more time
   if (isNewMilestone && options.timeout === 300_000) {
@@ -278,10 +279,10 @@ async function runHeadlessOnce(options: HeadlessOptions, restartCount: number): 
   // auto-mode sessions are long-running (minutes to hours) with their own internal
   // per-unit timeout via auto-supervisor. Disable the overall timeout unless the
   // user explicitly set --timeout.
-  const isAutoMode = options.command === 'auto'
+  const isAutoMode = currentCommand === 'auto'
   // discuss and plan are multi-turn: they involve multiple question rounds,
   // codebase scanning, and artifact writing before the workflow completes (#3547).
-  const isMultiTurnCommand = isMultiTurnHeadlessCommand(options.command)
+  let isMultiTurnCommand = isMultiTurnHeadlessCommand(options.command)
   if (isAutoMode && options.timeout === 300_000) {
     options.timeout = 0
   }
@@ -501,7 +502,7 @@ async function runHeadlessOnce(options: HeadlessOptions, restartCount: number): 
 
   // Idle timeout — fallback completion detection
   let idleTimer: ReturnType<typeof setTimeout> | null = null
-  let effectiveIdleTimeout = getHeadlessIdleTimeout(options.command)
+  let effectiveIdleTimeout = getHeadlessIdleTimeout(currentCommand)
 
   function resetIdleTimer(): void {
     if (idleTimer) clearTimeout(idleTimer)
@@ -762,7 +763,7 @@ async function runHeadlessOnce(options: HeadlessOptions, restartCount: number): 
     }
 
     // Quick commands: resolve on first agent_end
-    if (eventObj.type === 'agent_end' && isQuickCommand(options.command, options.commandArgs) && !completed) {
+    if (eventObj.type === 'agent_end' && isQuickCommand(currentCommand, options.commandArgs) && !completed) {
       completed = true
       resolveCompletion()
       return
@@ -925,7 +926,9 @@ async function runHeadlessOnce(options: HeadlessOptions, restartCount: number): 
       clearTimeout(idleTimer)
       idleTimer = null
     }
-    effectiveIdleTimeout = getHeadlessIdleTimeout('auto')
+    currentCommand = 'auto'
+    isMultiTurnCommand = true
+    effectiveIdleTimeout = getHeadlessIdleTimeout(currentCommand)
     completed = false
     milestoneReady = false
     blocked = false

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -29,9 +29,8 @@ import {
   isQuickCommand,
   FIRE_AND_FORGET_METHODS,
   isInteractiveHeadlessTool,
-  shouldArmHeadlessIdleTimeout,
-  getHeadlessIdleTimeout,
-  shouldArmIdleTimeout,
+  getHeadlessRuntimeState,
+  shouldArmHeadlessIdleTimer,
   EXIT_SUCCESS,
   EXIT_ERROR,
   EXIT_BLOCKED,
@@ -268,8 +267,9 @@ export async function runHeadless(options: HeadlessOptions): Promise<void> {
 async function runHeadlessOnce(options: HeadlessOptions, restartCount: number): Promise<{ exitCode: number; interrupted: boolean }> {
   let interrupted = false
   const startTime = Date.now()
-  let currentCommand = options.command
-  const isNewMilestone = currentCommand === 'new-milestone'
+  let runtimeState = getHeadlessRuntimeState(options.command)
+  let currentCommand = runtimeState.command
+  const isNewMilestone = runtimeState.isNewMilestone
 
   // new-milestone involves codebase investigation + artifact writing — needs more time
   if (isNewMilestone && options.timeout === 300_000) {
@@ -279,10 +279,10 @@ async function runHeadlessOnce(options: HeadlessOptions, restartCount: number): 
   // auto-mode sessions are long-running (minutes to hours) with their own internal
   // per-unit timeout via auto-supervisor. Disable the overall timeout unless the
   // user explicitly set --timeout.
-  const isAutoMode = currentCommand === 'auto'
+  const isAutoMode = runtimeState.isAutoMode
   // discuss and plan are multi-turn: they involve multiple question rounds,
   // codebase scanning, and artifact writing before the workflow completes (#3547).
-  let isMultiTurnCommand = isMultiTurnHeadlessCommand(options.command)
+  let isMultiTurnCommand = runtimeState.isMultiTurnCommand
   if (isAutoMode && options.timeout === 300_000) {
     options.timeout = 0
   }
@@ -502,14 +502,14 @@ async function runHeadlessOnce(options: HeadlessOptions, restartCount: number): 
 
   // Idle timeout — fallback completion detection
   let idleTimer: ReturnType<typeof setTimeout> | null = null
-  let effectiveIdleTimeout = getHeadlessIdleTimeout(currentCommand)
+  let effectiveIdleTimeout = runtimeState.idleTimeoutMs
 
   function resetIdleTimer(): void {
-    if (idleTimer) clearTimeout(idleTimer)
-    if (
-      shouldArmIdleTimeout(toolCallCount, effectiveIdleTimeout) &&
-      shouldArmHeadlessIdleTimeout(toolCallCount, interactiveToolCallIds.size)
-    ) {
+    if (idleTimer) {
+      clearTimeout(idleTimer)
+      idleTimer = null
+    }
+    if (shouldArmHeadlessIdleTimer(toolCallCount, interactiveToolCallIds.size, effectiveIdleTimeout)) {
       idleTimer = setTimeout(() => {
         completed = true
         resolveCompletion()
@@ -926,9 +926,10 @@ async function runHeadlessOnce(options: HeadlessOptions, restartCount: number): 
       clearTimeout(idleTimer)
       idleTimer = null
     }
-    currentCommand = 'auto'
-    isMultiTurnCommand = true
-    effectiveIdleTimeout = getHeadlessIdleTimeout(currentCommand)
+    runtimeState = getHeadlessRuntimeState('auto')
+    currentCommand = runtimeState.command
+    isMultiTurnCommand = runtimeState.isMultiTurnCommand
+    effectiveIdleTimeout = runtimeState.idleTimeoutMs
     completed = false
     milestoneReady = false
     blocked = false

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -28,10 +28,10 @@ import {
   isMilestoneReadyNotification,
   isQuickCommand,
   FIRE_AND_FORGET_METHODS,
-  IDLE_TIMEOUT_MS,
-  NEW_MILESTONE_IDLE_TIMEOUT_MS,
   isInteractiveHeadlessTool,
   shouldArmHeadlessIdleTimeout,
+  getHeadlessIdleTimeout,
+  shouldArmIdleTimeout,
   EXIT_SUCCESS,
   EXIT_ERROR,
   EXIT_BLOCKED,
@@ -501,11 +501,14 @@ async function runHeadlessOnce(options: HeadlessOptions, restartCount: number): 
 
   // Idle timeout — fallback completion detection
   let idleTimer: ReturnType<typeof setTimeout> | null = null
-  const effectiveIdleTimeout = isNewMilestone ? NEW_MILESTONE_IDLE_TIMEOUT_MS : IDLE_TIMEOUT_MS
+  const effectiveIdleTimeout = getHeadlessIdleTimeout(options.command)
 
   function resetIdleTimer(): void {
     if (idleTimer) clearTimeout(idleTimer)
-    if (shouldArmHeadlessIdleTimeout(toolCallCount, interactiveToolCallIds.size)) {
+    if (
+      shouldArmIdleTimeout(toolCallCount, effectiveIdleTimeout) &&
+      shouldArmHeadlessIdleTimeout(toolCallCount, interactiveToolCallIds.size)
+    ) {
       idleTimer = setTimeout(() => {
         completed = true
         resolveCompletion()

--- a/src/resources/extensions/gsd/parallel-orchestrator.ts
+++ b/src/resources/extensions/gsd/parallel-orchestrator.ts
@@ -999,6 +999,9 @@ export function refreshWorkerStatuses(
         worker.process = null;
         continue;
       }
+      // If disk state disappears before we observed a terminal state, a dead
+      // PID means the worker can no longer make progress. Classify that as an
+      // error instead of preserving a forever-running zombie.
       if (!isPidAlive(worker.pid)) {
         worker.cleanup?.();
         worker.cleanup = undefined;

--- a/src/resources/extensions/gsd/parallel-orchestrator.ts
+++ b/src/resources/extensions/gsd/parallel-orchestrator.ts
@@ -995,6 +995,10 @@ export function refreshWorkerStatuses(
   for (const [mid, worker] of state.workers) {
     const diskStatus = statusMap.get(mid);
     if (!diskStatus) {
+      if (worker.state === "stopped" || worker.state === "error") {
+        worker.process = null;
+        continue;
+      }
       if (!isPidAlive(worker.pid)) {
         worker.cleanup?.();
         worker.cleanup = undefined;

--- a/src/resources/extensions/gsd/tests/parallel-orchestrator-zombie-cleanup.test.ts
+++ b/src/resources/extensions/gsd/tests/parallel-orchestrator-zombie-cleanup.test.ts
@@ -275,3 +275,56 @@ test("#2736: restoreRuntimeState clears stale state when all workers are stopped
   const stateFile = join(base, ".gsd", "orchestrator.json");
   assert.equal(existsSync(stateFile), false, "orchestrator.json should be removed");
 });
+
+test("#3428: refreshWorkerStatuses preserves stopped workers when disk status is missing", (t) => {
+  const base = makeTmpBase();
+  t.after(() => {
+    resetOrchestrator();
+    cleanup(base);
+  });
+
+  const persisted: PersistedState = {
+    active: true,
+    workers: [
+      {
+        milestoneId: "M001",
+        title: "Milestone 1",
+        pid: process.pid,
+        worktreePath: join(base, "worktrees", "M001"),
+        startedAt: Date.now() - 60_000,
+        state: "running",
+        cost: 0.5,
+      },
+      {
+        milestoneId: "M002",
+        title: "Milestone 2",
+        pid: process.pid,
+        worktreePath: join(base, "worktrees", "M002"),
+        startedAt: Date.now() - 60_000,
+        state: "running",
+        cost: 0.25,
+      },
+    ],
+    totalCost: 0.75,
+    startedAt: Date.now() - 60_000,
+    configSnapshot: { max_workers: 3 },
+  };
+  writePersistedState(base, persisted);
+
+  writeSessionStatusFile(base, "M002", "running", process.pid);
+  getWorkerStatuses(base);
+
+  const orchestrator = getOrchestratorState();
+  assert.ok(orchestrator, "state should be restored");
+  const stoppedWorker = orchestrator!.workers.get("M001");
+  assert.ok(stoppedWorker, "M001 should exist in restored state");
+  stoppedWorker!.state = "stopped";
+  stoppedWorker!.pid = DEAD_PID;
+
+  refreshWorkerStatuses(base);
+
+  const refreshed = getOrchestratorState();
+  assert.ok(refreshed, "orchestrator should remain active while M002 is still running");
+  assert.equal(refreshed!.workers.get("M001")?.state, "stopped", "missing disk status must not override a stopped worker to error");
+  assert.equal(refreshed!.workers.get("M002")?.state, "running", "live worker state should still refresh from disk");
+});

--- a/src/resources/extensions/gsd/tests/parallel-orchestrator-zombie-cleanup.test.ts
+++ b/src/resources/extensions/gsd/tests/parallel-orchestrator-zombie-cleanup.test.ts
@@ -326,5 +326,6 @@ test("#3428: refreshWorkerStatuses preserves stopped workers when disk status is
   const refreshed = getOrchestratorState();
   assert.ok(refreshed, "orchestrator should remain active while M002 is still running");
   assert.equal(refreshed!.workers.get("M001")?.state, "stopped", "missing disk status must not override a stopped worker to error");
+  assert.equal(refreshed!.workers.get("M001")?.process, null, "terminal workers with missing disk status should clear process handles");
   assert.equal(refreshed!.workers.get("M002")?.state, "running", "live worker state should still refresh from disk");
 });

--- a/src/resources/extensions/gsd/tests/parallel-orchestrator-zombie-cleanup.test.ts
+++ b/src/resources/extensions/gsd/tests/parallel-orchestrator-zombie-cleanup.test.ts
@@ -329,3 +329,57 @@ test("#3428: refreshWorkerStatuses preserves stopped workers when disk status is
   assert.equal(refreshed!.workers.get("M001")?.process, null, "terminal workers with missing disk status should clear process handles");
   assert.equal(refreshed!.workers.get("M002")?.state, "running", "live worker state should still refresh from disk");
 });
+
+test("#3428: refreshWorkerStatuses marks running workers with missing disk status and dead PID as error", (t) => {
+  const base = makeTmpBase();
+  t.after(() => {
+    resetOrchestrator();
+    cleanup(base);
+  });
+
+  const persisted: PersistedState = {
+    active: true,
+    workers: [
+      {
+        milestoneId: "M001",
+        title: "Milestone 1",
+        pid: process.pid,
+        worktreePath: join(base, "worktrees", "M001"),
+        startedAt: Date.now() - 60_000,
+        state: "running",
+        cost: 0.5,
+      },
+      {
+        milestoneId: "M002",
+        title: "Milestone 2",
+        pid: process.pid,
+        worktreePath: join(base, "worktrees", "M002"),
+        startedAt: Date.now() - 60_000,
+        state: "running",
+        cost: 0.25,
+      },
+    ],
+    totalCost: 0.75,
+    startedAt: Date.now() - 60_000,
+    configSnapshot: { max_workers: 3 },
+  };
+  writePersistedState(base, persisted);
+
+  writeSessionStatusFile(base, "M002", "running", process.pid);
+  getWorkerStatuses(base);
+
+  const orchestrator = getOrchestratorState();
+  assert.ok(orchestrator, "state should be restored");
+  const missingWorker = orchestrator!.workers.get("M001");
+  assert.ok(missingWorker, "M001 should exist in restored state");
+  missingWorker!.state = "running";
+  missingWorker!.pid = DEAD_PID;
+
+  refreshWorkerStatuses(base);
+
+  const refreshed = getOrchestratorState();
+  assert.ok(refreshed, "orchestrator should remain active while M002 is still running");
+  assert.equal(refreshed!.workers.get("M001")?.state, "error", "a missing running worker with a dead PID should be classified as error");
+  assert.equal(refreshed!.workers.get("M001")?.process, null, "dead missing workers should clear process handles");
+  assert.equal(refreshed!.workers.get("M002")?.state, "running", "live worker state should still refresh from disk");
+});

--- a/src/tests/headless-cli-surface.test.ts
+++ b/src/tests/headless-cli-surface.test.ts
@@ -26,6 +26,7 @@ import { VALID_OUTPUT_FORMATS } from '../headless-types.js'
 
 interface HeadlessOptions {
   timeout: number
+  timeoutExplicit?: boolean
   json: boolean
   outputFormat: OutputFormat
   model?: string
@@ -62,6 +63,7 @@ function parseHeadlessArgs(argv: string[]): HeadlessOptions {
     if (arg.startsWith('--')) {
       if (arg === '--timeout' && i + 1 < args.length) {
         options.timeout = parseInt(args[++i], 10)
+        options.timeoutExplicit = true
       } else if (arg === '--json') {
         options.json = true
         options.outputFormat = 'stream-json'
@@ -302,6 +304,13 @@ test('--events still works with new outputFormat default', () => {
 test('--timeout still works', () => {
   const opts = parseHeadlessArgs(['node', 'gsd', 'headless', '--timeout', '60000', 'auto'])
   assert.equal(opts.timeout, 60000)
+  assert.equal(opts.timeoutExplicit, true)
+})
+
+test('default timeout is implicit', () => {
+  const opts = parseHeadlessArgs(['node', 'gsd', 'headless', 'auto'])
+  assert.equal(opts.timeout, 300000)
+  assert.equal(opts.timeoutExplicit, undefined)
 })
 
 test('--supervised still works and implies stream-json', () => {

--- a/src/tests/headless-events.test.ts
+++ b/src/tests/headless-events.test.ts
@@ -156,8 +156,9 @@ import {
   EXIT_ERROR,
   EXIT_BLOCKED,
   EXIT_CANCELLED,
+  IDLE_TIMEOUT_MS,
   isInteractiveHeadlessTool,
-  shouldArmHeadlessIdleTimeout,
+  shouldArmHeadlessIdleTimer,
 } from '../headless-events.js'
 
 // ─── mapStatusToExitCode ─────────────────────────────────────────────────
@@ -207,17 +208,21 @@ test('isInteractiveHeadlessTool: non-interactive tools stay false', () => {
   assert.equal(isInteractiveHeadlessTool(undefined), false)
 })
 
-test('shouldArmHeadlessIdleTimeout: arms after tool calls when no interactive tool is in flight', () => {
-  assert.equal(shouldArmHeadlessIdleTimeout(1, 0), true)
-  assert.equal(shouldArmHeadlessIdleTimeout(3, 0), true)
+test('shouldArmHeadlessIdleTimer: arms after tool calls when no interactive tool is in flight', () => {
+  assert.equal(shouldArmHeadlessIdleTimer(1, 0, IDLE_TIMEOUT_MS), true)
+  assert.equal(shouldArmHeadlessIdleTimer(3, 0, IDLE_TIMEOUT_MS), true)
 })
 
-test('shouldArmHeadlessIdleTimeout: stays disarmed while interactive tools are in flight (#3714)', () => {
-  assert.equal(shouldArmHeadlessIdleTimeout(1, 1), false)
-  assert.equal(shouldArmHeadlessIdleTimeout(5, 2), false)
+test('shouldArmHeadlessIdleTimer: stays disarmed while interactive tools are in flight (#3714)', () => {
+  assert.equal(shouldArmHeadlessIdleTimer(1, 1, IDLE_TIMEOUT_MS), false)
+  assert.equal(shouldArmHeadlessIdleTimer(5, 2, IDLE_TIMEOUT_MS), false)
 })
 
-test('shouldArmHeadlessIdleTimeout: stays disarmed before any tool call has started', () => {
-  assert.equal(shouldArmHeadlessIdleTimeout(0, 0), false)
-  assert.equal(shouldArmHeadlessIdleTimeout(0, 1), false)
+test('shouldArmHeadlessIdleTimer: stays disarmed before any tool call has started', () => {
+  assert.equal(shouldArmHeadlessIdleTimer(0, 0, IDLE_TIMEOUT_MS), false)
+  assert.equal(shouldArmHeadlessIdleTimer(0, 1, IDLE_TIMEOUT_MS), false)
+})
+
+test('shouldArmHeadlessIdleTimer: stays disarmed when idle timeout is disabled', () => {
+  assert.equal(shouldArmHeadlessIdleTimer(1, 0, 0), false)
 })

--- a/src/tests/headless-idle-timeout.test.ts
+++ b/src/tests/headless-idle-timeout.test.ts
@@ -5,6 +5,7 @@ import {
   IDLE_TIMEOUT_MS,
   NEW_MILESTONE_IDLE_TIMEOUT_MS,
   getHeadlessIdleTimeout,
+  shouldArmHeadlessIdleTimeout,
   shouldArmIdleTimeout,
 } from "../headless-events.js";
 
@@ -24,4 +25,10 @@ test("shouldArmIdleTimeout requires both tool activity and a positive timeout", 
   assert.equal(shouldArmIdleTimeout(0, IDLE_TIMEOUT_MS), false);
   assert.equal(shouldArmIdleTimeout(1, 0), false);
   assert.equal(shouldArmIdleTimeout(2, IDLE_TIMEOUT_MS), true);
+});
+
+test("shouldArmHeadlessIdleTimeout stays disabled while interactive tools are pending", () => {
+  assert.equal(shouldArmHeadlessIdleTimeout(0, 0), false);
+  assert.equal(shouldArmHeadlessIdleTimeout(1, 1), false);
+  assert.equal(shouldArmHeadlessIdleTimeout(2, 0), true);
 });

--- a/src/tests/headless-idle-timeout.test.ts
+++ b/src/tests/headless-idle-timeout.test.ts
@@ -1,5 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 
 import {
   IDLE_TIMEOUT_MS,
@@ -8,6 +9,8 @@ import {
   shouldArmHeadlessIdleTimeout,
   shouldArmIdleTimeout,
 } from "../headless-events.js";
+
+const headlessSource = readFileSync(new URL("../headless.ts", import.meta.url), "utf8");
 
 test("getHeadlessIdleTimeout disables idle fallback for auto-mode (#3428)", () => {
   assert.equal(getHeadlessIdleTimeout("auto"), 0);
@@ -31,4 +34,24 @@ test("shouldArmHeadlessIdleTimeout stays disabled while interactive tools are pe
   assert.equal(shouldArmHeadlessIdleTimeout(0, 0), false);
   assert.equal(shouldArmHeadlessIdleTimeout(1, 1), false);
   assert.equal(shouldArmHeadlessIdleTimeout(2, 0), true);
+});
+
+test("new-milestone --auto switches the chained auto phase to auto idle policy", () => {
+  assert.match(
+    headlessSource,
+    /let\s+effectiveIdleTimeout\s*=\s*getHeadlessIdleTimeout\(options\.command\)/,
+    "the idle policy must be mutable when a headless command chains into auto-mode",
+  );
+
+  const chainStart = headlessSource.indexOf("if (isNewMilestone && options.auto && milestoneReady");
+  assert.notEqual(chainStart, -1, "expected new-milestone --auto chaining block");
+  const chainBlock = headlessSource.slice(chainStart, headlessSource.indexOf("try {", chainStart));
+
+  assert.match(chainBlock, /clearTimeout\(idleTimer\)/, "chaining into auto-mode should clear any milestone idle timer");
+  assert.match(chainBlock, /idleTimer\s*=\s*null/, "cleared idle timers should not remain addressable");
+  assert.match(
+    chainBlock,
+    /effectiveIdleTimeout\s*=\s*getHeadlessIdleTimeout\(['"]auto['"]\)/,
+    "the chained auto phase should use auto-mode idle timeout semantics",
+  );
 });

--- a/src/tests/headless-idle-timeout.test.ts
+++ b/src/tests/headless-idle-timeout.test.ts
@@ -2,10 +2,13 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import {
+  DEFAULT_HEADLESS_TIMEOUT_MS,
   IDLE_TIMEOUT_MS,
+  NEW_MILESTONE_HEADLESS_TIMEOUT_MS,
   NEW_MILESTONE_IDLE_TIMEOUT_MS,
   getHeadlessIdleTimeout,
   getHeadlessRuntimeState,
+  resolveHeadlessOverallTimeout,
   shouldArmHeadlessIdleTimer,
 } from "../headless-events.js";
 
@@ -44,4 +47,25 @@ test("new-milestone --auto switches the chained auto phase to auto idle policy",
     false,
     "a chained auto phase must not re-arm the generic idle timer",
   );
+});
+
+test("resolveHeadlessOverallTimeout preserves explicit user timeouts", () => {
+  assert.equal(
+    resolveHeadlessOverallTimeout("auto", DEFAULT_HEADLESS_TIMEOUT_MS, true),
+    DEFAULT_HEADLESS_TIMEOUT_MS,
+  );
+  assert.equal(
+    resolveHeadlessOverallTimeout("new-milestone", DEFAULT_HEADLESS_TIMEOUT_MS, true),
+    DEFAULT_HEADLESS_TIMEOUT_MS,
+  );
+});
+
+test("resolveHeadlessOverallTimeout applies command defaults only when timeout is implicit", () => {
+  assert.equal(resolveHeadlessOverallTimeout("auto", DEFAULT_HEADLESS_TIMEOUT_MS, false), 0);
+  assert.equal(
+    resolveHeadlessOverallTimeout("new-milestone", DEFAULT_HEADLESS_TIMEOUT_MS, false),
+    NEW_MILESTONE_HEADLESS_TIMEOUT_MS,
+  );
+  assert.equal(resolveHeadlessOverallTimeout("next", DEFAULT_HEADLESS_TIMEOUT_MS, false), DEFAULT_HEADLESS_TIMEOUT_MS);
+  assert.equal(resolveHeadlessOverallTimeout("auto", 42_000, false), 42_000);
 });

--- a/src/tests/headless-idle-timeout.test.ts
+++ b/src/tests/headless-idle-timeout.test.ts
@@ -39,8 +39,18 @@ test("shouldArmHeadlessIdleTimeout stays disabled while interactive tools are pe
 test("new-milestone --auto switches the chained auto phase to auto idle policy", () => {
   assert.match(
     headlessSource,
-    /let\s+effectiveIdleTimeout\s*=\s*getHeadlessIdleTimeout\(options\.command\)/,
+    /let\s+currentCommand\s*=\s*options\.command/,
+    "headless command state must be mutable when a command chains into another mode",
+  );
+  assert.match(
+    headlessSource,
+    /let\s+effectiveIdleTimeout\s*=\s*getHeadlessIdleTimeout\(currentCommand\)/,
     "the idle policy must be mutable when a headless command chains into auto-mode",
+  );
+  assert.match(
+    headlessSource,
+    /isQuickCommand\(currentCommand,\s*options\.commandArgs\)/,
+    "quick-command completion should use the current chained command, not only the initial command",
   );
 
   const chainStart = headlessSource.indexOf("if (isNewMilestone && options.auto && milestoneReady");
@@ -49,9 +59,11 @@ test("new-milestone --auto switches the chained auto phase to auto idle policy",
 
   assert.match(chainBlock, /clearTimeout\(idleTimer\)/, "chaining into auto-mode should clear any milestone idle timer");
   assert.match(chainBlock, /idleTimer\s*=\s*null/, "cleared idle timers should not remain addressable");
+  assert.match(chainBlock, /currentCommand\s*=\s*['"]auto['"]/, "the chained phase should switch current command state to auto");
+  assert.match(chainBlock, /isMultiTurnCommand\s*=\s*true/, "the chained auto phase should use multi-turn completion semantics");
   assert.match(
     chainBlock,
-    /effectiveIdleTimeout\s*=\s*getHeadlessIdleTimeout\(['"]auto['"]\)/,
+    /effectiveIdleTimeout\s*=\s*getHeadlessIdleTimeout\(currentCommand\)/,
     "the chained auto phase should use auto-mode idle timeout semantics",
   );
 });

--- a/src/tests/headless-idle-timeout.test.ts
+++ b/src/tests/headless-idle-timeout.test.ts
@@ -1,0 +1,27 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  IDLE_TIMEOUT_MS,
+  NEW_MILESTONE_IDLE_TIMEOUT_MS,
+  getHeadlessIdleTimeout,
+  shouldArmIdleTimeout,
+} from "../headless-events.js";
+
+test("getHeadlessIdleTimeout disables idle fallback for auto-mode (#3428)", () => {
+  assert.equal(getHeadlessIdleTimeout("auto"), 0);
+});
+
+test("getHeadlessIdleTimeout keeps extended timeout for new-milestone", () => {
+  assert.equal(getHeadlessIdleTimeout("new-milestone"), NEW_MILESTONE_IDLE_TIMEOUT_MS);
+});
+
+test("getHeadlessIdleTimeout keeps default timeout for ordinary commands", () => {
+  assert.equal(getHeadlessIdleTimeout("next"), IDLE_TIMEOUT_MS);
+});
+
+test("shouldArmIdleTimeout requires both tool activity and a positive timeout", () => {
+  assert.equal(shouldArmIdleTimeout(0, IDLE_TIMEOUT_MS), false);
+  assert.equal(shouldArmIdleTimeout(1, 0), false);
+  assert.equal(shouldArmIdleTimeout(2, IDLE_TIMEOUT_MS), true);
+});

--- a/src/tests/headless-idle-timeout.test.ts
+++ b/src/tests/headless-idle-timeout.test.ts
@@ -1,16 +1,13 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
 
 import {
   IDLE_TIMEOUT_MS,
   NEW_MILESTONE_IDLE_TIMEOUT_MS,
   getHeadlessIdleTimeout,
-  shouldArmHeadlessIdleTimeout,
-  shouldArmIdleTimeout,
+  getHeadlessRuntimeState,
+  shouldArmHeadlessIdleTimer,
 } from "../headless-events.js";
-
-const headlessSource = readFileSync(new URL("../headless.ts", import.meta.url), "utf8");
 
 test("getHeadlessIdleTimeout disables idle fallback for auto-mode (#3428)", () => {
   assert.equal(getHeadlessIdleTimeout("auto"), 0);
@@ -24,46 +21,27 @@ test("getHeadlessIdleTimeout keeps default timeout for ordinary commands", () =>
   assert.equal(getHeadlessIdleTimeout("next"), IDLE_TIMEOUT_MS);
 });
 
-test("shouldArmIdleTimeout requires both tool activity and a positive timeout", () => {
-  assert.equal(shouldArmIdleTimeout(0, IDLE_TIMEOUT_MS), false);
-  assert.equal(shouldArmIdleTimeout(1, 0), false);
-  assert.equal(shouldArmIdleTimeout(2, IDLE_TIMEOUT_MS), true);
-});
-
-test("shouldArmHeadlessIdleTimeout stays disabled while interactive tools are pending", () => {
-  assert.equal(shouldArmHeadlessIdleTimeout(0, 0), false);
-  assert.equal(shouldArmHeadlessIdleTimeout(1, 1), false);
-  assert.equal(shouldArmHeadlessIdleTimeout(2, 0), true);
+test("shouldArmHeadlessIdleTimer folds all idle-timer gates into one decision", () => {
+  assert.equal(shouldArmHeadlessIdleTimer(0, 0, IDLE_TIMEOUT_MS), false);
+  assert.equal(shouldArmHeadlessIdleTimer(1, 1, IDLE_TIMEOUT_MS), false);
+  assert.equal(shouldArmHeadlessIdleTimer(1, 0, 0), false);
+  assert.equal(shouldArmHeadlessIdleTimer(2, 0, IDLE_TIMEOUT_MS), true);
 });
 
 test("new-milestone --auto switches the chained auto phase to auto idle policy", () => {
-  assert.match(
-    headlessSource,
-    /let\s+currentCommand\s*=\s*options\.command/,
-    "headless command state must be mutable when a command chains into another mode",
-  );
-  assert.match(
-    headlessSource,
-    /let\s+effectiveIdleTimeout\s*=\s*getHeadlessIdleTimeout\(currentCommand\)/,
-    "the idle policy must be mutable when a headless command chains into auto-mode",
-  );
-  assert.match(
-    headlessSource,
-    /isQuickCommand\(currentCommand,\s*options\.commandArgs\)/,
-    "quick-command completion should use the current chained command, not only the initial command",
-  );
+  const milestonePhase = getHeadlessRuntimeState("new-milestone");
+  assert.equal(milestonePhase.command, "new-milestone");
+  assert.equal(milestonePhase.idleTimeoutMs, NEW_MILESTONE_IDLE_TIMEOUT_MS);
+  assert.equal(milestonePhase.isMultiTurnCommand, false);
+  assert.equal(shouldArmHeadlessIdleTimer(2, 0, milestonePhase.idleTimeoutMs), true);
 
-  const chainStart = headlessSource.indexOf("if (isNewMilestone && options.auto && milestoneReady");
-  assert.notEqual(chainStart, -1, "expected new-milestone --auto chaining block");
-  const chainBlock = headlessSource.slice(chainStart, headlessSource.indexOf("try {", chainStart));
-
-  assert.match(chainBlock, /clearTimeout\(idleTimer\)/, "chaining into auto-mode should clear any milestone idle timer");
-  assert.match(chainBlock, /idleTimer\s*=\s*null/, "cleared idle timers should not remain addressable");
-  assert.match(chainBlock, /currentCommand\s*=\s*['"]auto['"]/, "the chained phase should switch current command state to auto");
-  assert.match(chainBlock, /isMultiTurnCommand\s*=\s*true/, "the chained auto phase should use multi-turn completion semantics");
-  assert.match(
-    chainBlock,
-    /effectiveIdleTimeout\s*=\s*getHeadlessIdleTimeout\(currentCommand\)/,
-    "the chained auto phase should use auto-mode idle timeout semantics",
+  const chainedAutoPhase = getHeadlessRuntimeState("auto");
+  assert.equal(chainedAutoPhase.command, "auto");
+  assert.equal(chainedAutoPhase.idleTimeoutMs, 0);
+  assert.equal(chainedAutoPhase.isMultiTurnCommand, true);
+  assert.equal(
+    shouldArmHeadlessIdleTimer(2, 0, chainedAutoPhase.idleTimeoutMs),
+    false,
+    "a chained auto phase must not re-arm the generic idle timer",
   );
 });

--- a/src/tests/headless-multi-turn.test.ts
+++ b/src/tests/headless-multi-turn.test.ts
@@ -5,36 +5,28 @@
  * Previously this test grep'd `headless.ts` for the literal identifier
  * `discuss` inside the `isMultiTurnCommand =` RHS, which would pass on a
  * comment, an unrelated string constant, or a regression that left the
- * identifier in place but stopped using it. The classifier is now an
- * exported pure function so we can call it directly.
+ * identifier in place but stopped using it. The runtime-state helper now
+ * exposes the classification directly.
  */
-import { test } from 'node:test'
-import assert from 'node:assert/strict'
+import { test } from "node:test";
+import assert from "node:assert/strict";
 
-import { isMultiTurnHeadlessCommand } from '../headless.ts'
+import { getHeadlessRuntimeState } from "../headless-events.js";
 
-test('discuss is classified as multi-turn (#3547)', () => {
-  assert.equal(isMultiTurnHeadlessCommand('discuss'), true)
-})
+test("headless runtime classifies discuss and plan as multi-turn (#3547)", () => {
+  assert.equal(getHeadlessRuntimeState("discuss").isMultiTurnCommand, true);
+  assert.equal(getHeadlessRuntimeState("plan").isMultiTurnCommand, true);
+  assert.equal(getHeadlessRuntimeState("auto").isMultiTurnCommand, true);
+  assert.equal(getHeadlessRuntimeState("next").isMultiTurnCommand, true);
+  assert.equal(getHeadlessRuntimeState("new-milestone").isMultiTurnCommand, false);
+});
 
-test('plan is classified as multi-turn (#3547)', () => {
-  assert.equal(isMultiTurnHeadlessCommand('plan'), true)
-})
-
-test('auto is classified as multi-turn', () => {
-  assert.equal(isMultiTurnHeadlessCommand('auto'), true)
-})
-
-test('next is classified as multi-turn', () => {
-  assert.equal(isMultiTurnHeadlessCommand('next'), true)
-})
-
-test('single-turn commands are not multi-turn', () => {
-  for (const cmd of ['ask', 'chat', 'help', 'version', '', 'random-cmd']) {
+test("headless runtime classifies single-turn commands as non-multi-turn", () => {
+  for (const cmd of ["ask", "chat", "help", "version", "", "random-cmd"]) {
     assert.equal(
-      isMultiTurnHeadlessCommand(cmd),
+      getHeadlessRuntimeState(cmd).isMultiTurnCommand,
       false,
       `${cmd} should not be multi-turn`,
-    )
+    );
   }
-})
+});


### PR DESCRIPTION
## TL;DR

**What:** Stop parallel auto workers from dying on silent auto gaps and from being misclassified as `error` after they already reached a terminal stopped state.
**Why:** Parallel auto workers can sit between RPC events during internal orchestration or long waits, and the coordinator currently overwrites missing-disk stopped workers to `error`.
**How:** Disable the generic headless idle fallback for `auto` commands, preserve terminal worker states when disk status is missing, and add focused regression tests for both behaviors.

## What

This updates headless auto-mode completion handling and the parallel worker refresh path in the GSD extension. It also folds the headless runtime state helpers together so tests assert behavior through the exported contract instead of source-grep checks.

## Why

Parallel auto workers should not be killed just because they are in a quiet internal gap, and once a worker is already terminal it should not be reclassified to `error` only because its status file is gone. Those two behaviors combine into misleading parallel status output. Closes #3428.

## How

The headless runtime now treats `auto` as a terminal-notification-driven command with no generic idle fallback, while `new-milestone` and ordinary commands keep their existing timeout behavior. Explicit `--timeout` values remain honored. Separately, `refreshWorkerStatuses()` now preserves already-terminal `stopped` and `error` workers when disk status is missing instead of forcing them back through the dead-PID error path.

## Change type

- [x] `fix` — Bug fix
- [x] `test` — Adding or updating tests
- [ ] `feat` — New feature or capability
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [x] `gsd extension` — GSD workflow
- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [ ] Manual testing — steps described above
- [ ] No tests needed — explained above

Automated verification:
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/tests/headless-events.test.ts src/tests/headless-multi-turn.test.ts src/tests/headless-idle-timeout.test.ts src/tests/headless-cli-surface.test.ts src/resources/extensions/gsd/tests/parallel-orchestrator-zombie-cleanup.test.ts`
- `npm run build`
- `npm run typecheck:extensions`
- `npm run secret-scan -- --diff upstream/main`

Broader suite note:
- `npm run test:unit` was attempted on this branch. The headless-specific failures were fixed and covered by the targeted tests above; the remaining failures were in `src/tests/native-search.test.ts` and `src/tests/search-provider-command.test.ts`, and those same files fail on clean `upstream/main`.

## AI disclosure

- [x] This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-command headless timeouts: "new-milestone" gets an extended timeout, "auto" maps to zero (disables idle fallback), others use the default; idle fallback only arms after tool activity and when a positive idle timeout is computed. CLI now tracks explicit vs implicit timeouts.

* **Bug Fixes**
  * Worker refresh respects in-memory terminal state when disk status is missing.
  * Auto-mode chaining properly resets/derives timeout and idle timers and preserves explicit timeouts.

* **Tests**
  * Added/updated tests covering idle-timeout logic, explicit timeout parsing, multi-turn classification, and worker cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->