### PR TITLE
fix(gsd): warn when memory extraction has no model

### DIFF
--- a/src/resources/extensions/gsd/memory-extractor.ts
+++ b/src/resources/extensions/gsd/memory-extractor.ts
@@ -15,6 +15,7 @@ import {
   decayStaleMemories,
 } from './memory-store.js';
 import type { MemoryAction } from './memory-store.js';
+import { logWarning } from './workflow-logger.js';
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -24,6 +25,7 @@ export type LLMCallFn = (system: string, user: string) => Promise<string>;
 
 let _extracting = false;
 let _lastExtractionTime = 0;
+let _warnedNoModel = false;
 
 const MIN_EXTRACTION_INTERVAL_MS = 30_000;
 
@@ -69,9 +71,21 @@ function redactSecrets(text: string): string {
  * Returns null if no models available.
  */
 export function buildMemoryLLMCall(ctx: ExtensionContext): LLMCallFn | null {
+  const warnNoModel = (reason: string): null => {
+    if (!_warnedNoModel) {
+      _warnedNoModel = true;
+      const message = `memory extraction disabled — ${reason}`;
+      ctx.ui?.notify?.(message, 'warning');
+      logWarning('engine', message);
+    }
+    return null;
+  };
+
   try {
     const available = ctx.modelRegistry.getAvailable();
-    if (!available || available.length === 0) return null;
+    if (!available || available.length === 0) {
+      return warnNoModel('no model available in registry');
+    }
 
     // Prefer Haiku by ID substring match
     let model = available.find(m =>
@@ -80,10 +94,14 @@ export function buildMemoryLLMCall(ctx: ExtensionContext): LLMCallFn | null {
 
     // Fallback: cheapest by input cost
     if (!model) {
-      model = [...available].sort((a, b) => a.cost.input - b.cost.input)[0];
+      model = [...available].sort(
+        (a, b) => (a.cost?.input ?? Number.POSITIVE_INFINITY) - (b.cost?.input ?? Number.POSITIVE_INFINITY),
+      )[0];
     }
 
-    if (!model) return null;
+    if (!model) {
+      return warnNoModel('no usable model available in registry');
+    }
 
     const selectedModel = model as Model<Api>;
 
@@ -111,8 +129,8 @@ export function buildMemoryLLMCall(ctx: ExtensionContext): LLMCallFn | null {
         .map(c => c.text);
       return textParts.join('');
     };
-  } catch {
-    return null;
+  } catch (error) {
+    return warnNoModel(error instanceof Error ? error.message : String(error));
   }
 }
 
@@ -357,4 +375,5 @@ export async function extractMemoriesFromUnit(
 export function _resetExtractionState(): void {
   _extracting = false;
   _lastExtractionTime = 0;
+  _warnedNoModel = false;
 }

--- a/src/resources/extensions/gsd/tests/memory-extractor.test.ts
+++ b/src/resources/extensions/gsd/tests/memory-extractor.test.ts
@@ -176,7 +176,7 @@ test('memory-extractor: reset extraction state', () => {
 // ═══════════════════════════════════════════════════════════════════════════
 
 test('memory-extractor: buildMemoryLLMCall resolves API key from modelRegistry for OAuth users', async () => {
-  const OAUTH_TOKEN = 'sk-ant-oat-test-oauth-token-12345';
+  const OAUTH_PLACEHOLDER = 'oauth-test';
   let getApiKeyCalled = false;
 
   const fakeModel = {
@@ -191,7 +191,7 @@ test('memory-extractor: buildMemoryLLMCall resolves API key from modelRegistry f
       getAvailable: () => [fakeModel],
       getApiKey: async (_model: any) => {
         getApiKeyCalled = true;
-        return OAUTH_TOKEN;
+        return OAUTH_PLACEHOLDER;
       },
     },
   } as any;
@@ -206,15 +206,31 @@ test('memory-extractor: buildMemoryLLMCall resolves API key from modelRegistry f
 });
 
 test('memory-extractor: buildMemoryLLMCall returns null when no models available', () => {
+  const notifications: Array<{ message: string; level: string }> = [];
   const ctx = {
     modelRegistry: {
       getAvailable: () => [],
       getApiKey: async () => undefined,
     },
+    ui: {
+      notify: (message: string, level: string) => {
+        notifications.push({ message, level });
+      },
+    },
   } as any;
 
   const llmCallFn = buildMemoryLLMCall(ctx);
   assert.strictEqual(llmCallFn, null, 'should return null when no models available');
+  assert.deepStrictEqual(notifications, [
+    {
+      message: 'memory extraction disabled — no model available in registry',
+      level: 'warning',
+    },
+  ], 'should surface a one-time warning when memory extraction has no model');
+
+  const second = buildMemoryLLMCall(ctx);
+  assert.strictEqual(second, null, 'subsequent calls should still return null');
+  assert.strictEqual(notifications.length, 1, 'warning should only fire once per session');
 });
 
 test('memory-extractor: buildMemoryLLMCall prefers haiku model', async () => {
@@ -238,7 +254,7 @@ test('memory-extractor: buildMemoryLLMCall prefers haiku model', async () => {
       getAvailable: () => [sonnetModel, haikuModel],
       getApiKey: async (model: any) => {
         resolvedModelId = model.id;
-        return 'sk-ant-oat-test-token';
+        return 'oauth-test';
       },
     },
   } as any;
@@ -252,3 +268,44 @@ test('memory-extractor: buildMemoryLLMCall prefers haiku model', async () => {
     'should resolve API key for haiku model, not sonnet');
 });
 
+test('memory-extractor: buildMemoryLLMCall ignores missing input cost when choosing fallback model', async () => {
+  let resolvedModelId: string | undefined;
+
+  const unknownCostModel = {
+    id: 'unknown-cost',
+    provider: 'anthropic',
+    api: 'anthropic-messages',
+    cost: {},
+  };
+  const cheapModel = {
+    id: 'cheap-sonnet',
+    provider: 'anthropic',
+    api: 'anthropic-messages',
+    cost: { input: 0.4, output: 1.5 },
+  };
+  const noCostFieldModel = {
+    id: 'no-cost-field',
+    provider: 'anthropic',
+    api: 'anthropic-messages',
+  };
+
+  const ctx = {
+    modelRegistry: {
+      getAvailable: () => [unknownCostModel, cheapModel, noCostFieldModel],
+      getApiKey: async (model: any) => {
+        resolvedModelId = model.id;
+        return 'oauth-test';
+      },
+    },
+  } as any;
+
+  const llmCallFn = buildMemoryLLMCall(ctx);
+  assert.ok(llmCallFn !== null, 'should still return a function when some models lack input cost');
+
+  await new Promise(resolve => setTimeout(resolve, 50));
+  assert.strictEqual(
+    resolvedModelId,
+    'cheap-sonnet',
+    'should choose the cheapest model with a real input cost instead of failing on missing metadata',
+  );
+});


### PR DESCRIPTION
## TL;DR

**What:** Adds a one-time warning when memory extraction cannot select any model and hardens the fallback model picker against missing `cost.input` metadata.
**Why:** Memory extraction could silently disable itself with no user signal, and provider models without cost metadata could make the fallback path fail the same quiet way.
**How:** Route the no-model path through a single warning helper in `memory-extractor.ts`, use a null-safe cheapest-model sort, and cover both behaviors with focused regression tests.

## What

This changes [`src/resources/extensions/gsd/memory-extractor.ts`](src/resources/extensions/gsd/memory-extractor.ts) so `buildMemoryLLMCall()` no longer returns `null` silently when the registry cannot provide a usable extraction model. It now emits a single warning through the workflow logger and UI notification path, and it tolerates models that omit `cost.input` when choosing the cheapest non-Haiku fallback.

It also updates [`src/resources/extensions/gsd/tests/memory-extractor.test.ts`](src/resources/extensions/gsd/tests/memory-extractor.test.ts) with regression coverage for the new warning behavior and for fallback model selection when some registry entries lack cost metadata.

## Why

Closes #3372.

Before this change, memory extraction could be permanently disabled without any visible signal when no model resolved from the registry. That made the memory pipeline look healthy while silently skipping every extraction attempt. There was also a second silent-failure path when fallback selection encountered models without `cost.input`, because the comparator assumed cost metadata always existed.

## How

The implementation keeps the fix narrowly scoped:

- add a module-local one-shot warning gate for the no-model path
- surface that warning through both `logWarning()` and `ctx.ui.notify()`
- treat missing `cost.input` as `Infinity` during cheapest-model fallback
- reset the one-shot warning state in the existing test-only reset helper
- add regression tests for no-model warning behavior and missing-cost fallback selection

## Change type

- [x] `fix` — Bug fix
- [x] `test` — Adding or updating tests
- [ ] `feat` — New feature or capability
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [x] `gsd extension` — GSD workflow
- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [ ] Manual testing — steps described above
- [ ] No tests needed — explained above

Automated verification:

1. `npm run build`
2. `npm run typecheck:extensions`
3. `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/memory-extractor.test.ts`
4. `tmp_home=$(mktemp -d); HOME="$tmp_home" GSD_HOME="$tmp_home/.gsd" npm run test:unit`
5. `npm run secret-scan -- --diff upstream/main`

Broader suite note:

- `npm run test:integration` entered a late-suite hang after `src/resources/extensions/async-jobs/await-tool.test.ts` had already printed all passing assertions.
- The same hang reproduced on clean `upstream/main` by running `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/async-jobs/await-tool.test.ts`, so I treated it as a clean-upstream integration-suite hang rather than a regression from this diff.

## AI disclosure

- [x] This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.
