### PR TITLE
fix(pi-ai): detect claude-code overflow text

### DIFF
--- a/packages/pi-ai/src/utils/overflow.ts
+++ b/packages/pi-ai/src/utils/overflow.ts
@@ -104,6 +104,19 @@ export function isContextOverflow(message: AssistantMessage, contextWindow?: num
 		}
 	}
 
+	// Some providers surface overflow as assistant text while putting a generic
+	// classifier value in errorMessage (e.g. claude-code: errorMessage="success",
+	// text="Prompt is too long"). Check rendered text as a fallback.
+	if (message.stopReason === "error") {
+		const assistantText = message.content
+			.filter((block) => block.type === "text")
+			.map((block) => block.text)
+			.join("\n");
+		if (assistantText && OVERFLOW_PATTERNS.some((p) => p.test(assistantText))) {
+			return true;
+		}
+	}
+
 	// Case 2: Silent overflow (z.ai style) - successful but usage exceeds context
 	if (contextWindow && message.stopReason === "stop") {
 		const inputTokens = message.usage.input + message.usage.cacheRead;

--- a/packages/pi-ai/src/utils/tests/overflow.test.ts
+++ b/packages/pi-ai/src/utils/tests/overflow.test.ts
@@ -1,0 +1,58 @@
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+
+import { isContextOverflow } from "../overflow.js";
+import type { AssistantMessage } from "../../types.js";
+
+function makeAssistantMessage(overrides: Partial<AssistantMessage> = {}): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [],
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "claude-sonnet-4-6",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "error",
+		timestamp: Date.now(),
+		...overrides,
+	};
+}
+
+describe("isContextOverflow", () => {
+	test("detects overflow from provider errorMessage", () => {
+		const message = makeAssistantMessage({
+			errorMessage: "prompt is too long: 213462 tokens > 200000 maximum",
+		});
+
+		assert.equal(isContextOverflow(message, 200000), true);
+	});
+
+	test("detects claude-code overflow when text contains the error but errorMessage is generic (#3925)", () => {
+		const message = makeAssistantMessage({
+			provider: "claude-code",
+			api: "anthropic-messages",
+			model: "claude-sonnet-4-6",
+			errorMessage: "success",
+			content: [{ type: "text", text: "Prompt is too long" }],
+		});
+
+		assert.equal(isContextOverflow(message, 200000), true);
+	});
+
+	test("does not treat normal non-error text as overflow", () => {
+		const message = makeAssistantMessage({
+			stopReason: "stop",
+			errorMessage: undefined,
+			content: [{ type: "text", text: "Prompt is too long" }],
+		});
+
+		assert.equal(isContextOverflow(message, 200000), false);
+	});
+});


### PR DESCRIPTION
## TL;DR

**What:** Detect claude-code context overflow from assistant text when the provider emits a generic `errorMessage`.
**Why:** Switching a large session to claude-code can get stuck on repeated `Prompt is too long` failures because overflow recovery never recognizes the error.
**How:** Keep the existing `errorMessage` matching, add a fallback that scans assistant text blocks for known overflow phrases, and cover it with focused regression tests.

## What

This updates `packages/pi-ai/src/utils/overflow.ts` so `isContextOverflow()` can still identify provider overflows when the provider writes the real error into assistant text instead of `errorMessage`.

It also adds focused coverage in `packages/pi-ai/src/utils/tests/overflow.test.ts` for:
- standard overflow detection from `errorMessage`
- claude-code's `errorMessage="success"` + `text="Prompt is too long"` shape
- a non-error guard so normal assistant text is not misclassified

## Why

Closes #3925.

The reported claude-code failure shape places `Prompt is too long` in assistant text while leaving `errorMessage` as a generic classifier value. That bypasses `isContextOverflow()`, so the normal compaction-based recovery path never kicks in and the session stays stuck on repeated overflow errors.

## How

The overflow matcher still prioritizes the existing `errorMessage` regex checks. When the assistant message is an error, it now also inspects text content blocks as a fallback and reuses the same overflow patterns there. That keeps the fix surgical while making the existing recovery logic see the claude-code error shape.

## Change type

- [x] `fix` — Bug fix
- [x] `test` — Adding or updating tests
- [ ] `feat` — New feature or capability
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [x] `pi-ai` — AI/LLM layer
- [ ] `pi-tui` — Terminal UI
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [ ] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [ ] Manual testing — steps described above
- [ ] No tests needed — explained above

Automated verification:

1. `npm run build`
2. `npm run typecheck:extensions`
3. `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test packages/pi-ai/src/utils/tests/overflow.test.ts`
4. `npm run test:packages`
5. `HOME=$(mktemp -d) GSD_HOME=$HOME/.gsd npm run test:unit`

Notes:

- `test:packages` still hits the pre-existing `packages/pi-coding-agent/dist/core/model-registry-auth-mode.test.js` failure, and the same failure reproduces on clean `upstream/main`.
- I also checked `src/tests/integration/pack-install.test.ts` on clean `upstream/main`; it currently fails there with an unrelated TTY assertion, so that broader integration signal was not treated as a blocker for this focused `pi-ai` fix.

## AI disclosure

- [x] This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.
