### PR TITLE
fix(gsd): pin explicit phase models

### DIFF
--- a/src/resources/extensions/gsd/auto-model-selection.ts
+++ b/src/resources/extensions/gsd/auto-model-selection.ts
@@ -26,13 +26,24 @@ export interface ModelSelectionResult {
   appliedModel: Model<Api> | null;
 }
 
+export interface PreferredModelConfig {
+  primary: string;
+  fallbacks: string[];
+  source: "explicit" | "synthesized";
+}
+
 export function resolvePreferredModelConfig(
   unitType: string,
   autoModeStartModel: { provider: string; id: string; flatRateCtx?: FlatRateContext } | null,
   isAutoMode = true,
-) {
+): PreferredModelConfig | undefined {
   const explicitConfig = resolveModelWithFallbacksForUnit(unitType);
-  if (explicitConfig) return explicitConfig;
+  if (explicitConfig) {
+    return {
+      ...explicitConfig,
+      source: "explicit",
+    };
+  }
 
   // In interactive mode, don't synthesize a routing-based model config.
   // The user's session model (/model) should be used as-is (#3962).
@@ -59,6 +70,7 @@ export function resolvePreferredModelConfig(
   return {
     primary: ceilingModel,
     fallbacks: [],
+    source: "synthesized",
   };
 }
 
@@ -122,6 +134,11 @@ export async function selectAndApplyModel(
     }
     // burn-max defaults to quality-first dispatch (no downgrade routing).
     if (prefs?.token_profile === "burn-max") {
+      routingConfig.enabled = false;
+    }
+    if (modelConfig.source === "explicit") {
+      // Explicit per-phase model preferences express hard user intent.
+      // Dynamic routing may only treat synthesized tier ceilings as downgradeable.
       routingConfig.enabled = false;
     }
     let effectiveModelConfig = modelConfig;
@@ -286,6 +303,7 @@ export async function selectAndApplyModel(
           effectiveModelConfig = {
             primary: routingResult.modelId,
             fallbacks: routingResult.fallbacks,
+            source: modelConfig.source,
           };
           // Always notify on model downgrade — users should see when their
           // model selection is overridden, not just in verbose mode (#3962).

--- a/src/resources/extensions/gsd/tests/auto-model-selection.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-model-selection.test.ts
@@ -7,7 +7,7 @@ import { fileURLToPath } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-import { resolvePreferredModelConfig, resolveModelId } from "../auto-model-selection.js";
+import { resolvePreferredModelConfig, resolveModelId, selectAndApplyModel } from "../auto-model-selection.js";
 
 function makeTempDir(prefix: string): string {
   return mkdtempSync(join(tmpdir(), prefix));
@@ -46,6 +46,7 @@ test("resolvePreferredModelConfig synthesizes heavy routing ceiling when models 
     assert.deepEqual(config, {
       primary: "claude-opus-4-6",
       fallbacks: [],
+      source: "synthesized",
     });
   } finally {
     process.chdir(originalCwd);
@@ -88,6 +89,7 @@ test("resolvePreferredModelConfig falls back to auto start model when heavy tier
     assert.deepEqual(config, {
       primary: "openai/gpt-5.4",
       fallbacks: [],
+      source: "synthesized",
     });
   } finally {
     process.chdir(originalCwd);
@@ -131,7 +133,86 @@ test("resolvePreferredModelConfig keeps explicit phase models as the ceiling", (
     assert.deepEqual(config, {
       primary: "claude-sonnet-4-6",
       fallbacks: [],
+      source: "explicit",
     });
+  } finally {
+    process.chdir(originalCwd);
+    if (originalGsdHome === undefined) delete process.env.GSD_HOME;
+    else process.env.GSD_HOME = originalGsdHome;
+    rmSync(tempProject, { recursive: true, force: true });
+    rmSync(tempGsdHome, { recursive: true, force: true });
+  }
+});
+
+test("selectAndApplyModel honors explicit phase models without downgrading (#3617)", async () => {
+  const originalCwd = process.cwd();
+  const originalGsdHome = process.env.GSD_HOME;
+  const tempProject = makeTempDir("gsd-routing-project-");
+  const tempGsdHome = makeTempDir("gsd-routing-home-");
+  const setModelCalls: string[] = [];
+  let beforeModelSelectCalled = false;
+
+  try {
+    mkdirSync(join(tempProject, ".gsd"), { recursive: true });
+    writeFileSync(
+      join(tempProject, ".gsd", "PREFERENCES.md"),
+      [
+        "---",
+        "models:",
+        "  planning: claude-opus-4-6",
+        "dynamic_routing:",
+        "  enabled: true",
+        "  tier_models:",
+        "    light: gpt-4o-mini",
+        "    standard: claude-sonnet-4-6",
+        "    heavy: claude-opus-4-6",
+        "---",
+      ].join("\n"),
+      "utf-8",
+    );
+    process.env.GSD_HOME = tempGsdHome;
+    process.chdir(tempProject);
+
+    const availableModels = [
+      { id: "claude-opus-4-6", provider: "anthropic", api: "anthropic-messages" },
+      { id: "claude-sonnet-4-6", provider: "anthropic", api: "anthropic-messages" },
+      { id: "gpt-4o-mini", provider: "openai", api: "responses" },
+    ];
+
+    const result = await selectAndApplyModel(
+      {
+        modelRegistry: { getAvailable: () => availableModels },
+        ui: { notify: () => {} },
+        model: { provider: "anthropic", id: "claude-opus-4-6", api: "anthropic-messages" },
+      } as any,
+      {
+        setModel: async (model: { provider: string; id: string }) => {
+          setModelCalls.push(`${model.provider}/${model.id}`);
+          return true;
+        },
+        emitBeforeModelSelect: async () => {
+          beforeModelSelectCalled = true;
+          return undefined;
+        },
+        getActiveTools: () => [],
+        emitAdjustToolSet: async () => undefined,
+        setActiveTools: () => {},
+      } as any,
+      "plan-slice",
+      "slice-1",
+      tempProject,
+      undefined,
+      false,
+      { provider: "anthropic", id: "claude-opus-4-6" },
+      undefined,
+      true,
+    );
+
+    assert.equal(beforeModelSelectCalled, false, "explicit phase models should skip dynamic routing hooks");
+    assert.deepEqual(setModelCalls, ["anthropic/claude-opus-4-6"]);
+    assert.equal(result.routing, null, "explicit phase models should not record a routing downgrade");
+    assert.equal(result.appliedModel?.provider, "anthropic");
+    assert.equal(result.appliedModel?.id, "claude-opus-4-6");
   } finally {
     process.chdir(originalCwd);
     if (originalGsdHome === undefined) delete process.env.GSD_HOME;

--- a/src/resources/extensions/gsd/tests/auto-model-selection.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-model-selection.test.ts
@@ -182,6 +182,7 @@ test("selectAndApplyModel honors explicit phase models without downgrading (#361
     const result = await selectAndApplyModel(
       {
         modelRegistry: { getAvailable: () => availableModels },
+        sessionManager: { getSessionId: () => "test-session" },
         ui: { notify: () => {} },
         model: { provider: "anthropic", id: "claude-opus-4-6", api: "anthropic-messages" },
       } as any,

--- a/src/resources/extensions/gsd/tests/flat-rate-routing-guard.test.ts
+++ b/src/resources/extensions/gsd/tests/flat-rate-routing-guard.test.ts
@@ -39,19 +39,50 @@ describe("flat-rate provider routing guard (#3453)", () => {
   });
 
   test("resolvePreferredModelConfig returns undefined for copilot start model", () => {
+    const originalCwd = process.cwd();
+    const originalGsdHome = process.env.GSD_HOME;
+    const tempProject = mkdtempSync(join(tmpdir(), "gsd-flat-rate-project-"));
+    const tempGsdHome = mkdtempSync(join(tmpdir(), "gsd-flat-rate-home-"));
+
     // When the user's start model is on a flat-rate provider,
     // resolvePreferredModelConfig should not synthesize a routing
     // config from tier_models — it should return undefined so the
     // user's selected model is preserved.
-    const result = resolvePreferredModelConfig("execute-task", {
-      provider: "github-copilot",
-      id: "claude-sonnet-4",
-    });
+    try {
+      mkdirSync(join(tempProject, ".gsd"), { recursive: true });
+      writeFileSync(
+        join(tempProject, ".gsd", "PREFERENCES.md"),
+        [
+          "---",
+          "dynamic_routing:",
+          "  enabled: true",
+          "  tier_models:",
+          "    light: gpt-4o-mini",
+          "    standard: claude-sonnet-4-6",
+          "    heavy: claude-opus-4-6",
+          "---",
+        ].join("\n"),
+        "utf-8",
+      );
+      process.env.GSD_HOME = tempGsdHome;
+      process.chdir(tempProject);
 
-    // Should be undefined (no routing config created for flat-rate)
-    // Note: this only tests the guard — if explicit per-unit config exists
-    // in preferences, that takes precedence regardless.
-    assert.equal(result, undefined, "Should not create routing config for copilot");
+      const result = resolvePreferredModelConfig("execute-task", {
+        provider: "github-copilot",
+        id: "claude-sonnet-4",
+      });
+
+      // Should be undefined (no routing config created for flat-rate)
+      // Note: this only tests the synthesis guard — explicit per-unit config
+      // still takes precedence when the user configured one.
+      assert.equal(result, undefined, "Should not create routing config for copilot");
+    } finally {
+      process.chdir(originalCwd);
+      if (originalGsdHome === undefined) delete process.env.GSD_HOME;
+      else process.env.GSD_HOME = originalGsdHome;
+      rmSync(tempProject, { recursive: true, force: true });
+      rmSync(tempGsdHome, { recursive: true, force: true });
+    }
   });
 });
 

--- a/src/resources/extensions/gsd/tests/interactive-routing-bypass.test.ts
+++ b/src/resources/extensions/gsd/tests/interactive-routing-bypass.test.ts
@@ -62,7 +62,7 @@ describe("interactive routing bypass (#3962)", () => {
     );
     // The function should check isAutoMode before routing synthesis
     const fnIdx = modelSelectionSrc.indexOf("function resolvePreferredModelConfig");
-    const fnBody = modelSelectionSrc.slice(fnIdx, fnIdx + 600);
+    const fnBody = modelSelectionSrc.slice(fnIdx, fnIdx + 900);
     assert.ok(
       fnBody.includes("isAutoMode"),
       "resolvePreferredModelConfig should accept isAutoMode parameter",


### PR DESCRIPTION
## TL;DR

**What:** Treat explicit per-phase model preferences as hard pins instead of downgrade ceilings.
**Why:** Auto-mode could silently override `models.<phase>` even when the user set an exact model on purpose.
**How:** Tag preferred model configs as explicit vs synthesized, disable dynamic routing for explicit configs, and add focused regression coverage around full model selection.

## What

This updates `src/resources/extensions/gsd/auto-model-selection.ts` so explicit per-phase model preferences are no longer fed into dynamic routing as if they were soft ceilings.

It also adds focused regression coverage in:
- `src/resources/extensions/gsd/tests/auto-model-selection.test.ts`
- `src/resources/extensions/gsd/tests/flat-rate-routing-guard.test.ts`
- `src/resources/extensions/gsd/tests/interactive-routing-bypass.test.ts`

## Why

Closes #3617.

Before this change, `resolvePreferredModelConfig()` returned the same shape for two different cases:
- an explicit user preference like `models.planning: claude-opus-4-6`
- a synthesized routing ceiling derived from `dynamic_routing.tier_models`

That made the routing layer treat both as downgradeable ceilings, so auto-mode could silently switch an explicitly configured phase model to a cheaper model.

## How

The fix stays narrow:
- add a `source` tag to preferred model configs (`explicit` vs `synthesized`)
- disable dynamic routing when the config came from explicit phase preferences
- keep synthesized tier ceilings downgradeable as before
- add a runtime regression proving `selectAndApplyModel()` keeps an explicit planning model pinned and skips routing hooks
- harden nearby source-level tests so they run in isolated temp preference roots instead of inheriting unrelated local config

## Change type

- [x] `fix` — Bug fix
- [x] `test` — Adding or updating tests
- [ ] `feat` — New feature or capability
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [x] `gsd extension` — GSD workflow
- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [ ] Manual testing — steps described above
- [ ] No tests needed — explained above

Automated verification:

1. `npm run build`
2. `npm run typecheck:extensions`
3. `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/auto-model-selection.test.ts src/resources/extensions/gsd/tests/flat-rate-routing-guard.test.ts src/resources/extensions/gsd/tests/interactive-routing-bypass.test.ts`
4. `HOME=$(mktemp -d) GSD_HOME=$HOME/.gsd npm run test:unit`
5. `HOME=$(mktemp -d) GSD_HOME=$HOME/.gsd npm run test:integration`
6. `npm run secret-scan -- --diff upstream/main`

Notes:

- The focused local proof above is green.
- `test:unit` still reproduces clean `upstream/main` failures in `none-mode-gates.test.ts`, `remote-status.test.ts`, and `rtk.test.ts`.
- `test:integration` still reproduces clean `upstream/main` failures in `browser-tools-integration.test.mjs` (Playwright browser missing in temp HOME), `pack-install.test.ts`, `web-mode-cli.test.ts`, and `web-mode-onboarding.test.ts`.

## AI disclosure

- [x] This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.
