### PR TITLE
fix(gsd): repair DB-only milestone unpark state

### DIFF
--- a/src/resources/extensions/gsd/milestone-actions.ts
+++ b/src/resources/extensions/gsd/milestone-actions.ts
@@ -20,7 +20,7 @@ import {
 } from "./paths.js";
 import { invalidateAllCaches } from "./cache.js";
 import { loadQueueOrder, saveQueueOrder } from "./queue-order.js";
-import { isDbAvailable, updateMilestoneStatus } from "./gsd-db.js";
+import { getMilestone, isDbAvailable, updateMilestoneStatus } from "./gsd-db.js";
 import { logWarning } from "./workflow-logger.js";
 
 // ─── Park ──────────────────────────────────────────────────────────────────
@@ -77,9 +77,16 @@ export function unparkMilestone(basePath: string, milestoneId: string): boolean 
   if (!mDir || !existsSync(mDir)) return false;
 
   const parkedPath = join(mDir, buildMilestoneFileName(milestoneId, "PARKED"));
-  if (!existsSync(parkedPath)) return false; // not parked
+  const hadParkedFile = existsSync(parkedPath);
+  const dbThinksParked = isDbAvailable() && getMilestone(milestoneId)?.status === "parked";
 
-  unlinkSync(parkedPath);
+  // Recover the reverse desync too: DB can still say "parked" even when the
+  // PARKED marker was lost on disk, and /gsd unpark should repair that state.
+  if (!hadParkedFile && !dbThinksParked) return false;
+
+  if (hadParkedFile) {
+    unlinkSync(parkedPath);
+  }
   // Sync DB status so deriveStateFromDb picks up the unparked milestone (#2694)
   if (isDbAvailable()) {
     try {

--- a/src/resources/extensions/gsd/tests/park-db-sync.test.ts
+++ b/src/resources/extensions/gsd/tests/park-db-sync.test.ts
@@ -69,6 +69,24 @@ test("unparkMilestone updates DB status to 'active' (#2694)", () => {
   }
 });
 
+test("unparkMilestone repairs parked DB state when PARKED.md is missing (#3707)", () => {
+  const base = createBase();
+  try {
+    openDatabase(":memory:");
+    insertMilestone({ id: "M001", title: "Test", status: "parked" });
+
+    const unparked = unparkMilestone(base, "M001");
+
+    assert.ok(unparked, "unparkMilestone should recover DB-only parked state");
+    assert.equal(getMilestone("M001")!.status, "active", "DB status should be repaired to active");
+
+    closeDatabase();
+  } finally {
+    closeDatabase();
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
 test("park/unpark are safe when DB is not available (#2694 guard)", () => {
   const base = createBase();
   try {


### PR DESCRIPTION
## TL;DR

**What:** Repair milestone unparking when the database still says `parked` but `PARKED.md` is already gone.
**Why:** That reverse-skew state leaves the milestone stuck because `unparkMilestone()` refuses to recover.
**How:** Reconcile the DB status with the on-disk marker during unpark and cover the recovery path with a regression test.

## What

This updates the milestone unpark path so it no longer assumes `PARKED.md` is the only source of truth.

The change teaches `unparkMilestone()` to recover when the database still reports `parked` but the marker file is missing. The regression test covers the exact skewed state from the issue: DB says parked, disk no longer has the parked marker, and unpark should still clear the stale DB state.

## Why

Closes #3707.

Right now that DB-only parked state strands the milestone in an inconsistent half-parked state. The user-visible result is that unpark cannot recover even though the disk marker is already gone.

## How

The fix checks both persistence layers during unpark instead of trusting the file marker alone. If the parked file is missing but the DB still says parked, the stale DB flag is cleared and the milestone can continue normally.

## Change type

- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [ ] Manual testing — steps described above
- [ ] No tests needed — explained above

Automated verification:
- `npm run build`
- `npm run typecheck:extensions`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/park-db-sync.test.ts`
- `npm run test:unit`
- `npm run secret-scan -- --diff upstream/main`

Broader suite note:
- `npm run test:integration` hit unrelated integration debt. On the branch it also exposed a local Playwright-cache prerequisite when run under a temp `HOME`, and the remaining failing `pack-install.test.ts` assertion reproduces on clean `upstream/main`.

## AI disclosure

- [x] This PR includes AI-assisted code

Prepared with Codex and verified as described in the test plan above.
