### PR TITLE
fix(pi-ai): use bearer auth for MiniMax Anthropic API

### DIFF
--- a/packages/pi-ai/src/providers/anthropic-auth.test.ts
+++ b/packages/pi-ai/src/providers/anthropic-auth.test.ts
@@ -1,0 +1,32 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { usesAnthropicBearerAuth } from "./anthropic.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+test("usesAnthropicBearerAuth covers Bearer-only Anthropic-compatible providers (#3783)", () => {
+	assert.equal(usesAnthropicBearerAuth("alibaba-coding-plan"), true);
+	assert.equal(usesAnthropicBearerAuth("minimax"), true);
+	assert.equal(usesAnthropicBearerAuth("minimax-cn"), true);
+	assert.equal(usesAnthropicBearerAuth("anthropic"), false);
+});
+
+test("createClient routes Bearer-auth providers through authToken (#3783)", () => {
+	const source = readFileSync(join(__dirname, "..", "..", "src", "providers", "anthropic.ts"), "utf-8");
+	assert.ok(
+		source.includes("const usesBearerAuth = usesAnthropicBearerAuth(model.provider);"),
+		"createClient should derive auth mode from usesAnthropicBearerAuth",
+	);
+	assert.ok(
+		source.includes("apiKey: usesBearerAuth ? null : apiKey"),
+		"Bearer-auth providers should skip x-api-key auth",
+	);
+	assert.ok(
+		source.includes("authToken: usesBearerAuth ? apiKey : undefined"),
+		"Bearer-auth providers should send authToken instead",
+	);
+});

--- a/packages/pi-ai/src/providers/anthropic.ts
+++ b/packages/pi-ai/src/providers/anthropic.ts
@@ -44,6 +44,10 @@ function mergeHeaders(...headerSources: (Record<string, string> | undefined)[]):
 	return merged;
 }
 
+export function usesAnthropicBearerAuth(provider: Model<"anthropic-messages">["provider"]): boolean {
+	return provider === "alibaba-coding-plan" || provider === "minimax" || provider === "minimax-cn";
+}
+
 async function createClient(
 	model: Model<"anthropic-messages">,
 	apiKey: string,
@@ -91,11 +95,11 @@ async function createClient(
 	}
 
 	// API key auth (Anthropic OAuth removed per TOS compliance — use API keys or Claude CLI)
-	// Alibaba Coding Plan uses Bearer token auth instead of x-api-key
-	const isAlibabaProvider = model.provider === "alibaba-coding-plan";
+	// Some Anthropic-compatible providers require Bearer auth instead of x-api-key.
+	const usesBearerAuth = usesAnthropicBearerAuth(model.provider);
 	const client = new AnthropicClass({
-		apiKey: isAlibabaProvider ? null : apiKey,
-		authToken: isAlibabaProvider ? apiKey : undefined,
+		apiKey: usesBearerAuth ? null : apiKey,
+		authToken: usesBearerAuth ? apiKey : undefined,
 		baseURL: model.baseUrl,
 		dangerouslyAllowBrowser: true,
 		defaultHeaders: mergeHeaders(


### PR DESCRIPTION
## TL;DR

**What:** Route MiniMax Anthropic-compatible requests through Bearer auth instead of `x-api-key`.
**Why:** MiniMax rejects the current auth mode with 401 even when the configured token is valid.
**How:** Centralize the Bearer-auth provider check and cover both the provider map and client wiring with regression tests.

## What

This updates the Anthropic provider client setup so MiniMax and MiniMax CN use `authToken` instead of `apiKey`/`x-api-key`.

The diff also extracts the provider rule into `usesAnthropicBearerAuth()` and adds a regression test that covers both the supported providers and the client wiring that switches between header styles.

## Why

Closes #3783.

MiniMax exposes an Anthropic-compatible endpoint, but it expects the token in the Authorization header. The current code only special-cased Alibaba Coding Plan, so MiniMax requests were still sent with `x-api-key` and failed with 401.

## How

The provider auth rule now lives in one helper used by `createClient()`. Providers that require Bearer auth skip `apiKey` and send the token through `authToken`, while ordinary Anthropic-compatible providers keep the existing `x-api-key` path.

## Change type

- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [x] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [ ] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [ ] Manual testing — steps described above
- [ ] No tests needed — explained above

Automated verification:
- `npm run build`
- `npm run typecheck:extensions`
- `node --test packages/pi-ai/dist/providers/anthropic-auth.test.js packages/pi-ai/dist/models.test.js`
- `npm run test:unit`
- `npm run secret-scan -- --diff upstream/main`

Broader suite note:
- `npm run test:packages` hit the unrelated `packages/pi-coding-agent/dist/core/model-registry-auth-mode.test.js` failure, and that same failing assertion reproduces on clean `upstream/main`.

## AI disclosure

- [x] This PR includes AI-assisted code

Prepared with Codex and verified as described in the test plan above.
