### PR TITLE
fix(headless): keep idle timeout off during interactive tools

### DIFF
--- a/src/headless-events.ts
+++ b/src/headless-events.ts
@@ -70,6 +70,7 @@ export const IDLE_TIMEOUT_MS = 15_000
 // between tool calls (e.g. after mkdir, before writing files). Use a
 // longer idle timeout to avoid killing the session prematurely (#808).
 export const NEW_MILESTONE_IDLE_TIMEOUT_MS = 120_000
+const INTERACTIVE_HEADLESS_TOOLS = new Set(['ask_user_questions', 'secure_env_collect'])
 
 export function isTerminalNotification(event: Record<string, unknown>): boolean {
   if (event.type !== 'extension_ui_request' || event.method !== 'notify') return false
@@ -87,6 +88,14 @@ export function isBlockedNotification(event: Record<string, unknown>): boolean {
 export function isMilestoneReadyNotification(event: Record<string, unknown>): boolean {
   if (event.type !== 'extension_ui_request' || event.method !== 'notify') return false
   return /milestone\s+m\d+.*ready/i.test(String(event.message ?? ''))
+}
+
+export function isInteractiveHeadlessTool(toolName: string | undefined): boolean {
+  return INTERACTIVE_HEADLESS_TOOLS.has(String(toolName ?? ''))
+}
+
+export function shouldArmHeadlessIdleTimeout(toolCallCount: number, interactiveToolCount: number): boolean {
+  return toolCallCount > 0 && interactiveToolCount === 0
 }
 
 // ---------------------------------------------------------------------------

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -30,6 +30,8 @@ import {
   FIRE_AND_FORGET_METHODS,
   IDLE_TIMEOUT_MS,
   NEW_MILESTONE_IDLE_TIMEOUT_MS,
+  isInteractiveHeadlessTool,
+  shouldArmHeadlessIdleTimeout,
   EXIT_SUCCESS,
   EXIT_ERROR,
   EXIT_BLOCKED,
@@ -367,6 +369,7 @@ async function runHeadlessOnce(options: HeadlessOptions, restartCount: number): 
   let exitCode = 0
   let milestoneReady = false  // tracks "Milestone X ready." for auto-chaining
   const recentEvents: TrackedEvent[] = []
+  const interactiveToolCallIds = new Set<string>()
 
   // JSON batch mode: cost aggregation (cumulative-max pattern per K004)
   let cumulativeCostUsd = 0
@@ -460,7 +463,7 @@ async function runHeadlessOnce(options: HeadlessOptions, restartCount: number): 
 
   function resetIdleTimer(): void {
     if (idleTimer) clearTimeout(idleTimer)
-    if (toolCallCount > 0) {
+    if (shouldArmHeadlessIdleTimeout(toolCallCount, interactiveToolCallIds.size)) {
       idleTimer = setTimeout(() => {
         completed = true
         resolveCompletion()
@@ -484,6 +487,20 @@ async function runHeadlessOnce(options: HeadlessOptions, restartCount: number): 
   client.onEvent((event) => {
     const eventObj = event as unknown as Record<string, unknown>
     trackEvent(eventObj)
+
+    const eventType = String(eventObj.type ?? '')
+    if (eventType === 'tool_execution_start') {
+      const toolCallId = String(eventObj.toolCallId ?? eventObj.id ?? '')
+      if (toolCallId && isInteractiveHeadlessTool(String(eventObj.toolName ?? ''))) {
+        interactiveToolCallIds.add(toolCallId)
+      }
+    } else if (eventType === 'tool_execution_end') {
+      const toolCallId = String(eventObj.toolCallId ?? eventObj.id ?? '')
+      if (toolCallId) {
+        interactiveToolCallIds.delete(toolCallId)
+      }
+    }
+
     resetIdleTimer()
 
     // Answer injector: observe events for question metadata
@@ -492,7 +509,6 @@ async function runHeadlessOnce(options: HeadlessOptions, restartCount: number): 
     // --json / --output-format stream-json: forward events as JSONL to stdout (filtered if --events)
     // --output-format json (batch mode): suppress streaming, track cost for final result
     if (options.json && options.outputFormat === 'stream-json') {
-      const eventType = String(eventObj.type ?? '')
       if (!options.eventFilter || options.eventFilter.has(eventType)) {
         process.stdout.write(JSON.stringify(eventObj) + '\n')
       }

--- a/src/tests/headless-events.test.ts
+++ b/src/tests/headless-events.test.ts
@@ -150,7 +150,15 @@ test('empty filter blocks all events', () => {
   assert.ok(!shouldEmit('message_update'))
 })
 
-import { mapStatusToExitCode, EXIT_SUCCESS, EXIT_ERROR, EXIT_BLOCKED, EXIT_CANCELLED } from '../headless-events.js'
+import {
+  mapStatusToExitCode,
+  EXIT_SUCCESS,
+  EXIT_ERROR,
+  EXIT_BLOCKED,
+  EXIT_CANCELLED,
+  isInteractiveHeadlessTool,
+  shouldArmHeadlessIdleTimeout,
+} from '../headless-events.js'
 
 // ─── mapStatusToExitCode ─────────────────────────────────────────────────
 
@@ -184,4 +192,32 @@ test('mapStatusToExitCode: "cancelled" returns EXIT_CANCELLED', () => {
 
 test('mapStatusToExitCode: unknown status returns EXIT_ERROR', () => {
   assert.equal(mapStatusToExitCode('unknown'), EXIT_ERROR)
+})
+
+test('isInteractiveHeadlessTool: ask_user_questions is interactive', () => {
+  assert.equal(isInteractiveHeadlessTool('ask_user_questions'), true)
+})
+
+test('isInteractiveHeadlessTool: secure_env_collect is interactive', () => {
+  assert.equal(isInteractiveHeadlessTool('secure_env_collect'), true)
+})
+
+test('isInteractiveHeadlessTool: non-interactive tools stay false', () => {
+  assert.equal(isInteractiveHeadlessTool('bash'), false)
+  assert.equal(isInteractiveHeadlessTool(undefined), false)
+})
+
+test('shouldArmHeadlessIdleTimeout: arms after tool calls when no interactive tool is in flight', () => {
+  assert.equal(shouldArmHeadlessIdleTimeout(1, 0), true)
+  assert.equal(shouldArmHeadlessIdleTimeout(3, 0), true)
+})
+
+test('shouldArmHeadlessIdleTimeout: stays disarmed while interactive tools are in flight (#3714)', () => {
+  assert.equal(shouldArmHeadlessIdleTimeout(1, 1), false)
+  assert.equal(shouldArmHeadlessIdleTimeout(5, 2), false)
+})
+
+test('shouldArmHeadlessIdleTimeout: stays disarmed before any tool call has started', () => {
+  assert.equal(shouldArmHeadlessIdleTimeout(0, 0), false)
+  assert.equal(shouldArmHeadlessIdleTimeout(0, 1), false)
 })


### PR DESCRIPTION
## TL;DR

**What:** Keep headless idle completion disabled while `ask_user_questions` or `secure_env_collect` is still in flight.
**Why:** Supervised headless flows can otherwise complete between sequential question prompts in one interactive tool call.
**How:** Track interactive tool call IDs in headless mode and only arm the idle timeout once those tools have actually finished.

## What

This updates headless completion detection so the fallback idle timer does not fire while a user-interactive tool is still executing.

The change tracks in-flight `ask_user_questions` and `secure_env_collect` calls, teaches the idle arming logic to stay disarmed during those calls, and adds a targeted headless regression test for the new helper behavior.

## Why

Closes #3714.

In supervised headless discuss mode, a multi-question `ask_user_questions` call can emit the first question, receive one response, and then get caught by idle completion before the same tool call surfaces the remaining questions. That makes the session exit early even though the interactive tool has not actually finished.

## How

Headless mode now classifies interactive tool names up front, stores their active tool-call IDs from `tool_execution_start` to `tool_execution_end`, and only arms the fallback idle timer when there are prior tool calls and no interactive tools still in flight.

## Change type

- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [ ] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [ ] Manual testing — steps described above
- [ ] No tests needed — explained above

Automated verification:
- `npm run build`
- `npm run typecheck:extensions`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/tests/headless-events.test.ts`
- `npm run test:unit`
- `npm run secret-scan -- --diff upstream/main`

## AI disclosure

- [x] This PR includes AI-assisted code

Prepared with Codex and verified as described in the test plan above.
