### PR TITLE
fix(pi-coding-agent): match renderable tools case-insensitively

### DIFF
--- a/packages/pi-coding-agent/src/core/agent-session-renderable-tools.test.ts
+++ b/packages/pi-coding-agent/src/core/agent-session-renderable-tools.test.ts
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, it } from "node:test";
+
+import { Agent } from "@gsd/pi-agent-core";
+import { Type } from "@sinclair/typebox";
+import type { ToolDefinition } from "./extensions/types.js";
+import { AgentSession } from "./agent-session.js";
+import { AuthStorage } from "./auth-storage.js";
+import { ModelRegistry } from "./model-registry.js";
+import { DefaultResourceLoader } from "./resource-loader.js";
+import { SessionManager } from "./session-manager.js";
+import { SettingsManager } from "./settings-manager.js";
+
+let testDir: string;
+
+async function createSession() {
+	const agentDir = join(testDir, "agent-home");
+	const authStorage = AuthStorage.inMemory({});
+	const modelRegistry = new ModelRegistry(authStorage, join(agentDir, "models.json"));
+	const settingsManager = SettingsManager.inMemory();
+	const resourceLoader = new DefaultResourceLoader({
+		cwd: testDir,
+		agentDir,
+		settingsManager,
+		noExtensions: true,
+		noPromptTemplates: true,
+		noThemes: true,
+	});
+	await resourceLoader.reload();
+
+	return new AgentSession({
+		agent: new Agent(),
+		sessionManager: SessionManager.inMemory(testDir),
+		settingsManager,
+		cwd: testDir,
+		resourceLoader,
+		modelRegistry,
+	});
+}
+
+describe("AgentSession renderable tool lookup", () => {
+	beforeEach(() => {
+		testDir = mkdtempSync(join(tmpdir(), "agent-session-tools-"));
+	});
+
+	afterEach(() => {
+		rmSync(testDir, { recursive: true, force: true });
+	});
+
+	it("matches registered tool definitions case-insensitively (#3780)", async () => {
+		const session = await createSession();
+		const bashDefinition = {
+			name: "bash",
+			label: "bash",
+			description: "Execute a shell command",
+			parameters: Type.Object({}),
+			execute: async () => ({ content: [], details: undefined }),
+		} satisfies ToolDefinition;
+
+		(session as any)._extensionRunner = {
+			getAllRegisteredTools: () => [{ definition: bashDefinition }],
+		};
+
+		assert.equal(session.getRenderableToolDefinition("Bash"), bashDefinition);
+		assert.equal(session.getRenderableToolDefinition("BASH"), bashDefinition);
+	});
+});

--- a/packages/pi-coding-agent/src/core/agent-session.ts
+++ b/packages/pi-coding-agent/src/core/agent-session.ts
@@ -1275,8 +1275,9 @@ export class AgentSession {
 	}
 
 	getRenderableToolDefinition(toolName: string): ToolDefinition | undefined {
+		const normalizedToolName = toolName.toLowerCase();
 		return [...this._getBuiltinToolDefinitions(), ...this._getRegisteredToolDefinitions()].find(
-			(tool) => tool.name === toolName,
+			(tool) => tool.name.toLowerCase() === normalizedToolName,
 		);
 	}
 


### PR DESCRIPTION
## TL;DR

**What:** Make renderable tool-definition lookup case-insensitive in the coding agent session.
**Why:** Claude Agent SDK can report PascalCase tool names like `Bash`, which currently breaks the TUI lookup path.
**How:** Normalize the lookup path in `getRenderableToolDefinition()` and cover it with a focused regression test.

## What

This PR fixes the remaining PascalCase tool-rendering gap in the coding agent session lookup.

`AgentSession.getRenderableToolDefinition()` now matches registered tool definitions case-insensitively, and the new regression test verifies that a lowercase registered tool can still be resolved from `Bash` and `BASH` lookup inputs.

## Why

Closes #3780.

The upstream rendering pipeline already normalized tool names in other places, but this lookup path still required an exact case match. That meant Claude Agent SDK tool names like `Bash` could still miss the registered lowercase tool definition and break renderable tool output in the TUI.

## How

The fix keeps the scope narrow: normalize the tool-name comparison inside `getRenderableToolDefinition()` and add a package-level regression test for the exact case-mismatch path.

## Change type

- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [x] `pi-coding-agent` — Coding agent
- [ ] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [ ] Manual testing — steps described above
- [ ] No tests needed — explained above

Automated verification:
- `npm run build`
- `npm run typecheck:extensions`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test packages/pi-coding-agent/src/core/agent-session-renderable-tools.test.ts`
- `npm run test:unit`
- `npm run secret-scan -- --diff upstream/main`

Broader suite note:
- `npm run test:packages` hit the unrelated `packages/pi-coding-agent/dist/core/model-registry-auth-mode.test.js` failure, and that same failing assertion reproduces on clean `upstream/main`.

## AI disclosure

- [x] This PR includes AI-assisted code

Prepared with Codex and verified as described in the test plan above.
