### PR TITLE
feat(pi-ai): add GLM-5.1 via OpenRouter to custom models

### DIFF
--- a/packages/pi-ai/src/models.custom.ts
+++ b/packages/pi-ai/src/models.custom.ts
@@ -194,4 +194,27 @@ export const CUSTOM_MODELS = {
 			compat: { thinkingFormat: "zai", supportsDeveloperRole: false },
 		} satisfies Model<"openai-completions">,
 	},
+
+	// ─── OpenRouter (GLM-5.1) ─────────────────────────────────────────
+	// GLM-5.1 via OpenRouter, not yet in the auto-generated catalog.
+	// Ref: https://openrouter.ai/z-ai/glm-5.1
+	"openrouter": {
+		"z-ai/glm-5.1": {
+			id: "z-ai/glm-5.1",
+			name: "Z.ai: GLM 5.1",
+			api: "openai-completions",
+			provider: "openrouter",
+			baseUrl: "https://openrouter.ai/api/v1",
+			reasoning: true,
+			input: ["text"],
+			cost: {
+				input: 0.95,
+				output: 3.15,
+				cacheRead: 0,
+				cacheWrite: 0,
+			},
+			contextWindow: 202752,
+			maxTokens: 131072,
+		} satisfies Model<"openai-completions">,
+	},
 } as const;


### PR DESCRIPTION
## TL;DR

**What:** Add `z-ai/glm-5.1` as an OpenRouter model entry in `models.custom.ts`.
**Why:** GLM-5.1 is live on OpenRouter but not yet in the models.dev catalog, so the auto-generated registry doesn't include it.
**How:** Add a single model definition to `CUSTOM_MODELS` under the `openrouter` provider key.

## What

Adds `z-ai/glm-5.1` (Zhipu AI's GLM-5.1) to `packages/pi-ai/src/models.custom.ts` as an OpenRouter-routed model. This is a single model entry — no other files are touched.

Note: GLM-5.1 already exists under the `zai` provider (direct Z.AI endpoint). This adds the OpenRouter route as an alternative for users who prefer a unified OpenRouter API key.

Closes #4069

## Why

GLM-5.1 was released on OpenRouter on Apr 7, 2026 but hasn't been picked up by the models.dev catalog yet, so `generate-models.ts` doesn't produce an entry for it. Adding it to `models.custom.ts` makes it available immediately. The additive merge logic in `models.ts` will silently defer to the auto-generated entry once the catalog catches up.

## How

Single entry in `CUSTOM_MODELS` following the exact pattern of existing OpenRouter GLM models (e.g., `z-ai/glm-5` in `models.generated.ts`):

- **ID:** `z-ai/glm-5.1`
- **Provider:** `openrouter`
- **Pricing:** $0.95/M input, $3.15/M output (from OpenRouter listing)
- **Context window:** 202,752 tokens
- **Max output:** 131,072 tokens
- **Reasoning:** enabled

## Change type

- [x] `feat` — New feature or capability

## Scope

- [x] `pi-ai` — AI/LLM layer

## Breaking changes

- [x] No breaking changes

## Test plan

- [x] CI passes
- [x] No tests needed — additive model catalog entry with no logic changes; TypeScript compiles cleanly

## AI disclosure

- [x] This PR includes AI-assisted code — authored with Claude Code, reviewed and verified by contributor