### PR TITLE
fix(gsd): tolerate corrupt task arrays

### DIFF
--- a/src/resources/extensions/gsd/gsd-db.ts
+++ b/src/resources/extensions/gsd/gsd-db.ts
@@ -1564,6 +1564,23 @@ export interface TaskRow {
   sequence: number;
 }
 
+function parseTaskArrayColumn(raw: unknown): string[] {
+  if (typeof raw !== "string" || raw.trim() === "") return [];
+
+  try {
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed)) return parsed.map((value) => String(value));
+    if (parsed === null || parsed === undefined || parsed === "") return [];
+    return [String(parsed)];
+  } catch {
+    // Older/corrupt rows may contain comma-separated strings instead of JSON.
+    return raw
+      .split(",")
+      .map((value) => value.trim())
+      .filter(Boolean);
+  }
+}
+
 function rowToTask(row: Record<string, unknown>): TaskRow {
   const parseTaskArray = (value: unknown): string[] => {
     if (Array.isArray(value)) {
@@ -1603,8 +1620,8 @@ function rowToTask(row: Record<string, unknown>): TaskRow {
     blocker_discovered: (row["blocker_discovered"] as number) === 1,
     deviations: row["deviations"] as string,
     known_issues: row["known_issues"] as string,
-    key_files: JSON.parse((row["key_files"] as string) || "[]"),
-    key_decisions: JSON.parse((row["key_decisions"] as string) || "[]"),
+    key_files: parseTaskArrayColumn(row["key_files"]),
+    key_decisions: parseTaskArrayColumn(row["key_decisions"]),
     full_summary_md: row["full_summary_md"] as string,
     description: (row["description"] as string) ?? "",
     estimate: (row["estimate"] as string) ?? "",

--- a/src/resources/extensions/gsd/tests/gsd-db.test.ts
+++ b/src/resources/extensions/gsd/tests/gsd-db.test.ts
@@ -15,10 +15,14 @@ import {
   getRequirementById,
   getActiveDecisions,
   getActiveRequirements,
-  getTask,
   transaction,
   _getAdapter,
   _resetProvider,
+  insertMilestone,
+  insertSlice,
+  insertTask,
+  getTask,
+  getSliceTasks,
 } from '../gsd-db.ts';
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -458,6 +462,60 @@ describe('gsd-db', () => {
     closeDatabase();
     assert.ok(!isDbAvailable(), 'DB should not be available after close');
     assert.ok(!wasDbOpenAttempted(), 'wasDbOpenAttempted should reset after closeDatabase');
+  });
+
+  test('gsd-db: rowToTask tolerates corrupt comma-separated task arrays', () => {
+    openDatabase(':memory:');
+    insertMilestone({ id: 'M001', status: 'active' });
+    insertSlice({ milestoneId: 'M001', id: 'S01', status: 'active' });
+    insertTask({
+      milestoneId: 'M001',
+      sliceId: 'S01',
+      id: 'T01',
+      title: 'Recover corrupt arrays',
+      planning: {
+        description: 'desc',
+        estimate: 'small',
+        files: ['src/original.ts'],
+        verify: 'npm test',
+        inputs: ['docs/original.md'],
+        expectedOutput: ['dist/original.md'],
+        observabilityImpact: '',
+      },
+    });
+
+    const adapter = _getAdapter()!;
+    adapter.prepare(
+      `UPDATE tasks
+         SET files = ?, inputs = ?, expected_output = ?, key_files = ?, key_decisions = ?
+       WHERE milestone_id = ? AND slice_id = ? AND id = ?`,
+    ).run(
+      'src-erf/Models/foo.cs, src-erf/Models/bar.cs',
+      'docs/input-a.md, docs/input-b.md',
+      'dist/out-a.md, dist/out-b.md',
+      'src/resources/extensions/gsd/gsd-db.ts, src/resources/extensions/gsd/state.ts',
+      '"decision-1"',
+      'M001',
+      'S01',
+      'T01',
+    );
+
+    const task = getTask('M001', 'S01', 'T01');
+    assert.ok(task, 'getTask should still return the corrupt row');
+    assert.deepStrictEqual(task!.files, ['src-erf/Models/foo.cs', 'src-erf/Models/bar.cs']);
+    assert.deepStrictEqual(task!.inputs, ['docs/input-a.md', 'docs/input-b.md']);
+    assert.deepStrictEqual(task!.expected_output, ['dist/out-a.md', 'dist/out-b.md']);
+    assert.deepStrictEqual(
+      task!.key_files,
+      ['src/resources/extensions/gsd/gsd-db.ts', 'src/resources/extensions/gsd/state.ts'],
+    );
+    assert.deepStrictEqual(task!.key_decisions, ['decision-1']);
+
+    const sliceTasks = getSliceTasks('M001', 'S01');
+    assert.equal(sliceTasks.length, 1, 'getSliceTasks should also survive corrupt rows');
+    assert.deepStrictEqual(sliceTasks[0]!.files, task!.files);
+
+    closeDatabase();
   });
 
   // ─── Final Report ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## TL;DR

**What:** Makes task-row decoding tolerate old or corrupt non-JSON array columns instead of crashing auto-mode.
**Why:** Issue #4049 reports `JSON.parse` crashes when task table columns contain comma-separated strings rather than JSON arrays.
**How:** `rowToTask()` now normalizes those columns through a tolerant parser, and a regression test covers both direct reads and slice listing.

## What

Updates `src/resources/extensions/gsd/gsd-db.ts` so task-array columns (`files`, `inputs`, `expected_output`, `key_files`, `key_decisions`) are parsed defensively. Adds a regression test in `src/resources/extensions/gsd/tests/gsd-db.test.ts` that corrupts stored task rows and verifies `getTask()` and `getSliceTasks()` still return normalized arrays.

## Why

Closes #4049.

Older or corrupt rows can contain comma-separated strings or scalar JSON instead of JSON arrays. The previous `JSON.parse(... || "[]")` path crashed on those rows and stopped auto-mode before it could recover or continue reading the task.

## How

A small `parseTaskArrayColumn()` helper now accepts valid JSON arrays, wraps scalar JSON values, and falls back to comma-splitting for legacy or corrupt rows. The regression test exercises the broken storage shapes described in the issue.

## Change type

- [x] `fix` — Bug fix
- [x] `test` — Adding or updating tests
- [ ] `feat` — New feature or capability
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [x] `gsd extension` — GSD workflow
- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [ ] Manual testing — steps described above
- [ ] No tests needed — explained above

Automated verification:
1. `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/gsd-db.test.ts`
2. `npm run build`
3. `npm run typecheck:extensions`
4. `npm run test:unit` (fails only in `src/resources/extensions/gsd/tests/flat-rate-routing-guard.test.ts`, which reproduces on clean `upstream/main`)

## AI disclosure

- [x] This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.
