### PR TITLE
fix(gsd): normalize windows workingDirectory prompts

### DIFF
--- a/src/resources/extensions/gsd/prompt-loader.ts
+++ b/src/resources/extensions/gsd/prompt-loader.ts
@@ -143,10 +143,15 @@ export function loadPrompt(name: string, vars: Record<string, string> = {}): str
   }
 
   for (const [key, value] of Object.entries(effectiveVars)) {
+    const safeValue =
+      key === "workingDirectory" && typeof value === "string"
+        ? value.replaceAll("\\", "/")
+        : value;
+
     // Use split/join instead of replaceAll to avoid JavaScript's special
     // replacement patterns ($', $`, $&) being interpreted in the value.
     // See: https://github.com/gsd-build/gsd-2/issues/2968
-    content = content.split(`{{${key}}}`).join(value);
+    content = content.split(`{{${key}}}`).join(safeValue);
   }
 
   return content.trim();

--- a/src/resources/extensions/gsd/tests/prompt-loader-working-directory.test.ts
+++ b/src/resources/extensions/gsd/tests/prompt-loader-working-directory.test.ts
@@ -1,0 +1,19 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { loadPrompt } from "../prompt-loader.ts";
+
+test("loadPrompt normalizes workingDirectory backslashes for bash-friendly prompts (#4048)", () => {
+  const prompt = loadPrompt("research-milestone", {
+    milestoneId: "M001",
+    milestoneTitle: "Windows path fix",
+    workingDirectory: "C:\\Dev\\NB\\TR",
+    inlinedContext: "context",
+    skillActivation: "skill activation",
+    skillDiscoveryMode: "off",
+    skillDiscoveryInstructions: " disabled",
+  });
+
+  assert.match(prompt, /Your working directory is `C:\/Dev\/NB\/TR`/);
+  assert.doesNotMatch(prompt, /C:\\Dev\\NB\\TR/);
+});


### PR DESCRIPTION
## TL;DR

**What:** Normalizes Windows `workingDirectory` prompt substitutions to forward slashes.
**Why:** Issue #4048 reports that raw backslashes break bash `cd` commands in auto-prompts on Windows.
**How:** `loadPrompt()` now rewrites only the `workingDirectory` placeholder to bash-friendly slashes, with a regression test that exercises the real prompt template.

## What

Updates `src/resources/extensions/gsd/prompt-loader.ts` so prompt substitution normalizes the `workingDirectory` variable before it is inserted into prompt content. Adds `src/resources/extensions/gsd/tests/prompt-loader-working-directory.test.ts` to verify the rendered `research-milestone` prompt uses `C:/...` instead of raw backslashes.

## Why

Closes #4048.

On Windows, prompt text that includes a raw path like `C:\foo\bar` can be copied directly into bash-oriented flows. That leaves the model with a broken `cd` target even though the underlying directory is valid.

## How

The change stays surgical: only the `workingDirectory` placeholder is normalized, and all other prompt substitutions keep their existing behavior. The regression test calls the real prompt loader against the real prompt template so future prompt edits keep this path safe.

## Change type

- [x] `fix` — Bug fix
- [x] `test` — Adding or updating tests
- [ ] `feat` — New feature or capability
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [x] `gsd extension` — GSD workflow
- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [ ] Manual testing — steps described above
- [ ] No tests needed — explained above

Automated verification:
1. `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/prompt-loader-working-directory.test.ts`
2. `npm run build`
3. `npm run typecheck:extensions`

Note: the broader unit suite currently has an unrelated failure in `src/resources/extensions/gsd/tests/flat-rate-routing-guard.test.ts` on clean `upstream/main`, so the required local proof was used as the publication gate for this branch.

## AI disclosure

- [x] This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.
