### PR TITLE
fix(gsd): normalize auto prompt workingDirectory to POSIX

### DIFF
--- a/src/resources/extensions/gsd/auto-prompts.ts
+++ b/src/resources/extensions/gsd/auto-prompts.ts
@@ -28,6 +28,7 @@ import { getPendingGates } from "./gsd-db.js";
 import { formatDecisionsCompact, formatRequirementsCompact } from "./structured-data-formatter.js";
 import { readPhaseAnchor, formatAnchorForPrompt } from "./phase-anchor.js";
 import { logWarning } from "./workflow-logger.js";
+import { toPosixPath } from "../shared/mod.js";
 
 // ─── Preamble Cap ─────────────────────────────────────────────────────────────
 
@@ -891,7 +892,7 @@ export async function buildResearchMilestonePrompt(mid: string, midTitle: string
 
   const outputRelPath = relMilestoneFile(base, mid, "RESEARCH");
   return loadPrompt("research-milestone", {
-    workingDirectory: base,
+    workingDirectory: toPosixPath(base),
     milestoneId: mid, milestoneTitle: midTitle,
     milestonePath: relMilestonePath(base, mid),
     contextPath: contextRel,
@@ -964,7 +965,7 @@ export async function buildPlanMilestonePrompt(mid: string, midTitle: string, ba
   const researchOutputPath = join(base, relMilestoneFile(base, mid, "RESEARCH"));
   const secretsOutputPath = join(base, relMilestoneFile(base, mid, "SECRETS"));
   return loadPrompt("plan-milestone", {
-    workingDirectory: base,
+    workingDirectory: toPosixPath(base),
     milestoneId: mid, milestoneTitle: midTitle,
     milestonePath: relMilestonePath(base, mid),
     contextPath: contextRel,
@@ -1022,7 +1023,7 @@ export async function buildResearchSlicePrompt(
 
   const outputRelPath = relSliceFile(base, mid, sid, "RESEARCH");
   return loadPrompt("research-slice", {
-    workingDirectory: base,
+    workingDirectory: toPosixPath(base),
     milestoneId: mid, sliceId: sid, sliceTitle: sTitle,
     slicePath: relSlicePath(base, mid, sid),
     roadmapPath: roadmapRel,
@@ -1090,7 +1091,7 @@ export async function buildPlanSlicePrompt(
   const outputRelPath = relSliceFile(base, mid, sid, "PLAN");
   const commitInstruction = "Do not commit — .gsd/ planning docs are managed externally and not tracked in git.";
   return loadPrompt("plan-slice", {
-    workingDirectory: base,
+    workingDirectory: toPosixPath(base),
     milestoneId: mid, sliceId: sid, sliceTitle: sTitle,
     slicePath: relSlicePath(base, mid, sid),
     roadmapPath: roadmapRel,
@@ -1227,7 +1228,7 @@ export async function buildExecuteTaskPrompt(
     overridesSection,
     runtimeContext,
     phaseAnchorSection,
-    workingDirectory: base,
+    workingDirectory: toPosixPath(base),
     milestoneId: mid, sliceId: sid, sliceTitle: sTitle, taskId: tid, taskTitle: tTitle,
     planPath: join(base, relSliceFile(base, mid, sid, "PLAN")),
     slicePath: relSlicePath(base, mid, sid),
@@ -1306,7 +1307,7 @@ export async function buildCompleteSlicePrompt(
   const sliceUatPath = join(base, `${sliceRel}/${sid}-UAT.md`);
 
   return loadPrompt("complete-slice", {
-    workingDirectory: base,
+    workingDirectory: toPosixPath(base),
     milestoneId: mid, sliceId: sid, sliceTitle: sTitle,
     slicePath: sliceRel,
     roadmapPath: join(base, roadmapRel),
@@ -1375,7 +1376,7 @@ export async function buildCompleteMilestonePrompt(
   const milestoneSummaryPath = join(base, `${relMilestonePath(base, mid)}/${mid}-SUMMARY.md`);
 
   return loadPrompt("complete-milestone", {
-    workingDirectory: base,
+    workingDirectory: toPosixPath(base),
     milestoneId: mid,
     milestoneTitle: midTitle,
     roadmapPath: roadmapRel,
@@ -1500,7 +1501,7 @@ export async function buildValidateMilestonePrompt(
   const roadmapOutputPath = `${relMilestonePath(base, mid)}/${mid}-ROADMAP.md`;
 
   return loadPrompt("validate-milestone", {
-    workingDirectory: base,
+    workingDirectory: toPosixPath(base),
     milestoneId: mid,
     milestoneTitle: midTitle,
     roadmapPath: roadmapOutputPath,
@@ -1577,7 +1578,7 @@ export async function buildReplanSlicePrompt(
   }
 
   return loadPrompt("replan-slice", {
-    workingDirectory: base,
+    workingDirectory: toPosixPath(base),
     milestoneId: mid,
     sliceId: sid,
     sliceTitle: sTitle,
@@ -1620,7 +1621,7 @@ export async function buildRunUatPrompt(
   const uatType = getUatType(uatContent);
 
   return loadPrompt("run-uat", {
-    workingDirectory: base,
+    workingDirectory: toPosixPath(base),
     milestoneId: mid,
     sliceId,
     uatPath,
@@ -1684,7 +1685,7 @@ export async function buildReassessRoadmapPrompt(
   const reassessCommitInstruction = "Do not commit — .gsd/ planning docs are managed externally and not tracked in git.";
 
   return loadPrompt("reassess-roadmap", {
-    workingDirectory: base,
+    workingDirectory: toPosixPath(base),
     milestoneId: mid,
     milestoneTitle: midTitle,
     completedSliceId,
@@ -1765,7 +1766,7 @@ export async function buildReactiveExecutePrompt(
   const inlinedTemplates = inlineTemplate("task-summary", "Task Summary");
 
   return loadPrompt("reactive-execute", {
-    workingDirectory: base,
+    workingDirectory: toPosixPath(base),
     milestoneId: mid,
     milestoneTitle: midTitle,
     sliceId: sid,
@@ -1856,7 +1857,7 @@ export async function buildGateEvaluatePrompt(
   }
 
   return loadPrompt("gate-evaluate", {
-    workingDirectory: base,
+    workingDirectory: toPosixPath(base),
     milestoneId: mid,
     milestoneTitle: midTitle,
     sliceId: sid,
@@ -1948,4 +1949,3 @@ export async function buildRewriteDocsPrompt(
     overridesPath: relGsdRootFile("OVERRIDES"),
   });
 }
-

--- a/src/resources/extensions/gsd/tests/auto-prompts-working-directory-path.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-prompts-working-directory-path.test.ts
@@ -1,0 +1,22 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const autoPromptsPath = join(__dirname, "..", "auto-prompts.ts");
+
+test("auto-prompts normalizes workingDirectory to POSIX paths", () => {
+  const src = readFileSync(autoPromptsPath, "utf-8");
+
+  const normalizedAssignments = src.match(/workingDirectory:\s*toPosixPath\(base\),/g) ?? [];
+  const rawAssignments = src.match(/workingDirectory:\s*base,/g) ?? [];
+
+  assert.equal(rawAssignments.length, 0, "workingDirectory should not use raw base paths");
+  assert.ok(
+    normalizedAssignments.length >= 10,
+    "expected multiple workingDirectory assignments to be POSIX-normalized",
+  );
+});


### PR DESCRIPTION
## Summary
- normalize `workingDirectory` prompt variables in `auto-prompts.ts` via `toPosixPath(base)`
- add a regression test to ensure prompt builders never emit raw `workingDirectory: base`

## Validation
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/auto-prompts-working-directory-path.test.ts`

Closes #4048
