### PR TITLE
fix(gsd): preserve paused auto badge after provider pause

### DIFF
--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -622,9 +622,13 @@ function cleanupAfterLoopExit(ctx: ExtensionContext): void {
     logWarning("session", `lock cleanup failed: ${err instanceof Error ? err.message : String(err)}`, { file: "auto.ts" });
   }
 
-  ctx.ui.setStatus("gsd-auto", undefined);
-  ctx.ui.setWidget("gsd-progress", undefined);
-  ctx.ui.setFooter(undefined);
+  // A transient provider-error pause intentionally leaves the paused badge
+  // visible so the user still has a resumable auto-mode signal on screen.
+  if (!s.paused) {
+    ctx.ui.setStatus("gsd-auto", undefined);
+    ctx.ui.setWidget("gsd-progress", undefined);
+    ctx.ui.setFooter(undefined);
+  }
 
   // Restore CWD out of worktree back to original project root
   if (s.originalBasePath) {

--- a/src/resources/extensions/gsd/tests/auto-paused-ui-cleanup.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-paused-ui-cleanup.test.ts
@@ -1,0 +1,27 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const autoSource = readFileSync(join(__dirname, "..", "auto.ts"), "utf-8");
+
+test("#3370: cleanupAfterLoopExit preserves paused auto badge after provider pause", () => {
+  const cleanupIdx = autoSource.indexOf("function cleanupAfterLoopExit");
+  assert.ok(cleanupIdx > -1, "auto.ts should define cleanupAfterLoopExit");
+
+  const dispatchIdx = autoSource.indexOf("export async function dispatchHookUnit", cleanupIdx);
+  assert.ok(dispatchIdx > cleanupIdx, "cleanupAfterLoopExit body should be bounded by the next export");
+
+  const cleanupBody = autoSource.slice(cleanupIdx, dispatchIdx);
+  const pausedGuardIdx = cleanupBody.indexOf("if (!s.paused) {");
+  const clearStatusIdx = cleanupBody.indexOf('ctx.ui.setStatus("gsd-auto", undefined);');
+
+  assert.ok(pausedGuardIdx > -1, "loop-exit cleanup must guard UI clearing when auto is paused");
+  assert.ok(clearStatusIdx > pausedGuardIdx, "status clearing must live behind the paused guard");
+  assert.ok(
+    autoSource.includes('ctx?.ui.setStatus("gsd-auto", "paused");'),
+    "pauseAuto must still set the paused badge for transient provider pauses",
+  );
+});


### PR DESCRIPTION
## TL;DR

**What:** Preserve the paused auto badge when auto-mode exits after a transient provider-error pause.
**Why:** `cleanupAfterLoopExit()` was clearing the paused UI state even when auto-mode had intentionally paused for recovery.
**How:** Guard the loop-exit UI cleanup behind `!s.paused` and add a regression test that locks that behavior in place.

## What

This keeps the `gsd-auto` paused badge visible when auto-mode leaves the loop through the transient provider-error pause path.
The change is limited to the loop-exit cleanup branch in `auto.ts` plus a focused regression test for the paused cleanup guard.

## Why

Closes #3370.

## How

`pauseAuto()` already marks the session as paused and sets the paused badge on purpose. This change makes `cleanupAfterLoopExit()` preserve that UI state when the session is paused instead of unconditionally clearing it on loop exit.

## Change type

- [x] `fix` — Bug fix
- [ ] `feat` — New feature or capability
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [ ] Manual testing — steps described above
- [ ] No tests needed — explained above

Automated verification:
1. `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/auto-paused-ui-cleanup.test.ts`
2. `npm run build`
3. `npm run typecheck:extensions`
4. `npm run test:unit` currently reproduces the existing clean-upstream failures in `resolvePreferredModelConfig returns undefined for copilot start model` and `flat-rate provider routing guard (#3453)` on `upstream/main`, so I did not treat them as blocking this fix.

## AI disclosure

- [x] This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.
