### PR TITLE
fix(gsd): reject empty roadmap stubs as milestone plans

### DIFF
--- a/src/resources/extensions/gsd/auto-recovery.ts
+++ b/src/resources/extensions/gsd/auto-recovery.ts
@@ -272,6 +272,16 @@ export function verifyExpectedArtifact(
     if (!isValidationTerminal(validationContent)) return false;
   }
 
+  if (unitType === "plan-milestone") {
+    try {
+      const roadmap = parseLegacyRoadmap(readFileSync(absPath, "utf-8"));
+      if (roadmap.slices.length === 0) return false;
+    } catch (err) {
+      logWarning("recovery", `plan-milestone roadmap verification failed: ${err instanceof Error ? err.message : String(err)}`);
+      return false;
+    }
+  }
+
   // plan-slice must produce a plan with actual task entries, not just a scaffold.
   // The plan file may exist from a prior discussion/context step with only headings
   // but no tasks. Without this check the artifact is considered "complete" and the

--- a/src/resources/extensions/gsd/tests/plan-milestone-artifact-verification.test.ts
+++ b/src/resources/extensions/gsd/tests/plan-milestone-artifact-verification.test.ts
@@ -1,0 +1,62 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { verifyExpectedArtifact } from "../auto-recovery.ts";
+
+function createFixtureBase(): string {
+  const base = mkdtempSync(join(tmpdir(), "gsd-plan-milestone-artifact-"));
+  mkdirSync(join(base, ".gsd", "milestones"), { recursive: true });
+  return base;
+}
+
+function writeRoadmap(base: string, milestoneId: string, content: string): void {
+  const milestoneDir = join(base, ".gsd", "milestones", milestoneId);
+  mkdirSync(milestoneDir, { recursive: true });
+  writeFileSync(join(milestoneDir, `${milestoneId}-ROADMAP.md`), content, "utf-8");
+}
+
+test("#3405: plan-milestone roadmap stub does not count as a verified artifact", () => {
+  const base = createFixtureBase();
+  try {
+    writeRoadmap(base, "M001", [
+      "# M001: Placeholder",
+      "",
+      "**Vision:** Stub only.",
+      "",
+      "## Slices",
+      "",
+      "_TBD_",
+      "",
+    ].join("\n"));
+
+    const result = verifyExpectedArtifact("plan-milestone", "M001", base);
+    assert.equal(result, false, "zero-slice roadmap stubs must fail verification");
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("#3405: plan-milestone roadmap with real slices still passes artifact verification", () => {
+  const base = createFixtureBase();
+  try {
+    writeRoadmap(base, "M001", [
+      "# M001: Real roadmap",
+      "",
+      "**Vision:** Real work.",
+      "",
+      "## Slices",
+      "",
+      "- [ ] **S01: First slice** `risk:low` `depends:[]`",
+      "  > After this: a real slice exists.",
+      "",
+    ].join("\n"));
+
+    const result = verifyExpectedArtifact("plan-milestone", "M001", base);
+    assert.equal(result, true, "real roadmap slices should keep passing verification");
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## TL;DR

**What:** Reject empty roadmap stubs as valid `plan-milestone` artifacts.
**Why:** A placeholder roadmap file with zero parsed slices was being treated as complete, which let auto-recovery skip real planning work and fall into a stuck loop.
**How:** Verify that `plan-milestone` artifacts parse to at least one real slice, and add before/after regression coverage for both the stub and the valid roadmap case.

## What

This tightens `verifyExpectedArtifact()` for `plan-milestone` so a roadmap file only counts when it contains real parsed slices.
It also adds focused regression coverage for the empty-stub case and the normal slice-bearing roadmap case.

## Why

Closes #3405.

## How

The artifact verifier now parses the roadmap content for `plan-milestone` units and returns false when no slices are present. Parse failures are also treated as a failed artifact check instead of a successful milestone plan.

## Change type

- [x] `fix` — Bug fix
- [ ] `feat` — New feature or capability
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [ ] Manual testing — steps described above
- [ ] No tests needed — explained above

Automated verification:
1. `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/plan-milestone-artifact-verification.test.ts`
2. `npm run build`
3. `npm run typecheck:extensions`
4. `npm run test:unit` currently reproduces the existing clean-upstream failures in `resolvePreferredModelConfig returns undefined for copilot start model` and `flat-rate provider routing guard (#3453)` on `upstream/main`, so I did not treat them as blocking this fix.

## AI disclosure

- [x] This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.
