### PR TITLE
fix(pi-coding-agent): show full OAuth login URLs

### DIFF
--- a/packages/pi-coding-agent/src/modes/interactive/components/__tests__/login-dialog.test.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/components/__tests__/login-dialog.test.ts
@@ -1,0 +1,24 @@
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import { buildAuthUrlPresentation } from "../login-dialog.js";
+
+describe("LoginDialogComponent", () => {
+	test("shows the full OAuth URL when the hyperlink label is truncated", () => {
+		const presentation = buildAuthUrlPresentation(
+			"https://auth.example.com/device?code=ABCD-1234&callback=oauth&state=needs-full-visibility",
+			52,
+		);
+
+		assert.notEqual(
+			presentation.displayUrl,
+			"https://auth.example.com/device?code=ABCD-1234&callback=oauth&state=needs-full-visibility",
+			"narrow terminals should still truncate the hyperlink label",
+		);
+		assert.ok(presentation.fullUrlLines.length > 1, "truncated URLs should expose wrapped full-url lines");
+		assert.match(presentation.fullUrlLines[0] ?? "", /https:\/\/auth\.example\.com\/device\?code=ABCD-1234&/);
+		assert.match(
+			presentation.fullUrlLines[presentation.fullUrlLines.length - 1] ?? "",
+			/state=needs-full-visibility/,
+		);
+	});
+});

--- a/packages/pi-coding-agent/src/modes/interactive/components/login-dialog.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/components/login-dialog.ts
@@ -7,6 +7,27 @@ import { theme } from "../theme/theme.js";
 import { DynamicBorder } from "./dynamic-border.js";
 import { keyHint } from "./keybinding-hints.js";
 
+function wrapPlainText(text: string, width: number): string[] {
+	const lines: string[] = [];
+	const safeWidth = Math.max(1, width);
+	for (let idx = 0; idx < text.length; idx += safeWidth) {
+		lines.push(text.slice(idx, idx + safeWidth));
+	}
+	return lines.length > 0 ? lines : [""];
+}
+
+export function buildAuthUrlPresentation(url: string, terminalColumns: number): {
+	displayUrl: string;
+	fullUrlLines: string[];
+} {
+	const maxUrlWidth = Math.max(20, terminalColumns - 4);
+	const displayUrl = truncateToWidth(url, maxUrlWidth);
+	return {
+		displayUrl,
+		fullUrlLines: displayUrl === url ? [] : wrapPlainText(url, maxUrlWidth),
+	};
+}
+
 /**
  * Login dialog component - replaces editor during OAuth login flow.
  *
@@ -124,13 +145,20 @@ export class LoginDialogComponent extends Container implements Focusable {
 
 		// Truncate the visible URL text so it never wraps (which would break
 		// the OSC 8 hyperlink). The full URL is still the link target.
-		const maxUrlWidth = Math.max(20, this.tui.terminal.columns - 4);
-		const displayUrl = truncateToWidth(url, maxUrlWidth);
+		const { displayUrl, fullUrlLines } = buildAuthUrlPresentation(url, this.tui.terminal.columns);
 		const urlLink = `\x1b]8;;${url}\x07${theme.fg("accent", displayUrl)}\x1b]8;;\x07`;
 		this.contentContainer.addChild(new Text(urlLink, 1, 0));
 
 		const clickHint = process.platform === "darwin" ? "Cmd+click to open" : "Ctrl+click to open";
 		this.contentContainer.addChild(new Text(theme.fg("dim", clickHint), 1, 0));
+
+		if (fullUrlLines.length > 0) {
+			this.contentContainer.addChild(new Spacer(1));
+			this.contentContainer.addChild(new Text(theme.fg("dim", "Full URL:"), 1, 0));
+			for (const line of fullUrlLines) {
+				this.contentContainer.addChild(new Text(theme.fg("dim", line), 1, 0));
+			}
+		}
 
 		if (instructions) {
 			this.contentContainer.addChild(new Spacer(1));


### PR DESCRIPTION
## TL;DR

**What:** Show the full OAuth login URL when the interactive login dialog has to truncate the hyperlink label.
**Why:** The Anthropic OAuth flow worked, but narrow terminals hid the tail of the URL, which made it hard to inspect or copy the full link.
**How:** Split the auth-URL presentation into a reusable helper that keeps the clickable truncated label while also rendering wrapped full-URL lines underneath.

## What

This updates the interactive login dialog to keep the short clickable hyperlink label while also exposing the full OAuth URL when the label has to be truncated.
It also adds a focused regression test for the URL-presentation helper.

## Why

Closes #3402.

## How

`buildAuthUrlPresentation()` now returns both the visible hyperlink label and any wrapped full-URL lines that should be rendered below it. `showAuth()` uses that helper so narrow terminals still reveal the complete URL without breaking the OSC 8 hyperlink.

## Change type

- [x] `fix` — Bug fix
- [ ] `feat` — New feature or capability
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [x] `pi-coding-agent` — Coding agent
- [ ] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [ ] Manual testing — steps described above
- [ ] No tests needed — explained above

Automated verification:
1. `npm run build`
2. `npm run typecheck:extensions`
3. `node --test packages/pi-coding-agent/dist/modes/interactive/components/__tests__/login-dialog.test.js`
4. `npm run test:packages` currently reproduces the existing clean-upstream failure in `packages/pi-coding-agent/dist/core/model-registry-auth-mode.test.js` on `upstream/main`, so I did not treat it as blocking this fix.

## AI disclosure

- [x] This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.
