### PR TITLE
fix(ollama): clear footer status when provider unavailable

### DIFF
--- a/src/resources/extensions/ollama/index.ts
+++ b/src/resources/extensions/ollama/index.ts
@@ -57,7 +57,15 @@ async function probeAndRegister(pi: ExtensionAPI): Promise<boolean> {
 	}
 
 	const models = await discoverModels();
-	if (models.length === 0) return true; // Running but no models pulled
+	if (models.length === 0) {
+		// No local models means there's nothing usable to register in GSD.
+		// Keep the footer/status clean instead of advertising Ollama availability.
+		if (providerRegistered) {
+			pi.unregisterProvider("ollama");
+			providerRegistered = false;
+		}
+		return false;
+	}
 
 	const baseUrl = client.getOllamaHost();
 
@@ -115,9 +123,11 @@ export default function ollama(pi: ExtensionAPI) {
 		} else {
 			probeAndRegister(pi)
 				.then((found) => {
-					if (found) ctx.ui.setStatus("ollama", "Ollama");
+					ctx.ui.setStatus("ollama", found ? "Ollama" : undefined);
 				})
-				.catch(() => {});
+				.catch(() => {
+					ctx.ui.setStatus("ollama", undefined);
+				});
 		}
 	});
 

--- a/src/resources/extensions/ollama/ollama-status-indicator.test.ts
+++ b/src/resources/extensions/ollama/ollama-status-indicator.test.ts
@@ -1,0 +1,28 @@
+/**
+ * Regression test: don't show an Ollama footer status unless Ollama is
+ * actually usable (running with at least one discovered model).
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const src = readFileSync(join(__dirname, "index.ts"), "utf-8");
+
+test("probeAndRegister returns false when no Ollama models are discovered", () => {
+	assert.match(
+		src,
+		/if \(models\.length === 0\)[\s\S]*return false;/,
+		"running-without-models should not be treated as available",
+	);
+});
+
+test("interactive session clears ollama footer status when unavailable", () => {
+	assert.match(
+		src,
+		/ctx\.ui\.setStatus\("ollama", found \? "Ollama" : undefined\)/,
+		"status should be cleared when probeAndRegister reports unavailable",
+	);
+});


### PR DESCRIPTION
## TL;DR

**What:** Fix Ollama extension footer status so `Ollama` is shown only when the provider is actually usable.
**Why:** Users can see misleading footer state like `auto Ollama` even when Ollama cannot be used for inference.
**How:** Treat the no-model discovery path as unavailable, clear stale footer status on unavailable/error paths, and add a regression test.

## What

This PR updates the Ollama extension status behavior in interactive mode:
- `probeAndRegister()` now returns unavailable when Ollama has zero discovered local models.
- If provider had previously been registered, it is unregistered when Ollama becomes unavailable.
- Interactive startup now sets `ctx.ui.setStatus("ollama", found ? "Ollama" : undefined)` and clears status on probe errors.
- Adds regression coverage in `ollama-status-indicator.test.ts`.

## Why

The footer combines extension statuses on one line. The GSD auto extension can set `auto`, and the Ollama extension could incorrectly set `Ollama`, producing a misleading `auto Ollama` label. This made Ollama appear available when it was not practically usable (e.g., no local models discovered).

Closes #4073

## How

- Changed no-model branch in `src/resources/extensions/ollama/index.ts` to:
  - unregister `ollama` provider if previously registered
  - return `false` (unavailable)
- Changed interactive session probe handling to explicitly clear status when unavailable or probe fails.
- Added `src/resources/extensions/ollama/ollama-status-indicator.test.ts` to guard both behaviors.

## Change type checklist

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Validation

- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/ollama/ollama-auth-mode.test.ts src/resources/extensions/ollama/ollama-status-indicator.test.ts`

## AI-assisted

This PR was prepared with AI assistance and manually reviewed/validated.
