### PR TITLE
docs: update README for v2.71 and add Ecosystem section

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,33 @@ One command. Walk away. Come back to a built project with clean git history.
 - **isError flag propagation** — workflow tool execution failures now correctly return `isError: true`, so MCP clients can distinguish success from failure.
 - **Multi-round discuss questions** — new-project discuss phase supports multi-round questioning with structured question gates.
 
-### TUI Fixes
+### Model Selection Hardening
 
+- **Unconfigured models blocked** — models without a configured provider are filtered from selection surfaces, preventing dispatch failures.
+- **Provider readiness required** — saved default model selection now verifies the provider is ready before accepting it.
+- **Session override honored** — `/gsd model` selection persists as a session override across all dispatch phases.
+- **Minimal context guard** — model override logic is skipped in minimal command contexts where it doesn't apply.
+
+### Auto-Mode Resilience
+
+- **Credential cooldown recovery** — auto-mode survives transient 429 rate-limit responses with structured cooldown errors and a bounded retry budget.
+- **Fire-and-forget auto start** — auto start is detached from active turns to prevent blocking.
+- **Scoped forensics** — stuck-loop forensics are now scoped to auto sessions only, preventing false positives in interactive use.
+
+### TUI Improvements
+
+- **Overlay subscription fix** — resolved overlay subscription lifecycle and `Ctrl+Shift+P` shortcut conflict.
+- **Improved overlays and shortcuts** — GSD overlays, keyboard shortcuts, and notification flows redesigned for consistency.
 - **Pinned output restored** — pinned output bar displays above the editor during tool execution again.
 - **Turn completion cleanup** — pinned latest output is cleared on turn completion, preventing stale output from persisting.
 - **Secure input masking** — extension input values are masked in interactive mode when collecting secrets.
+
+### Provider Fixes
+
+- **Full OAuth login URLs** — OAuth login URLs are now displayed in full instead of being truncated.
+- **MiniMax bearer auth** — MiniMax Anthropic API requests use proper bearer authentication.
+- **Case-insensitive tool rendering** — renderable tool matching is now case-insensitive, fixing missed tool output.
+- **Headless idle timeout** — idle timeout is kept off during interactive tool execution in headless mode.
 
 ### Reliability & Internals
 
@@ -54,6 +76,9 @@ One command. Walk away. Come back to a built project with clean git history.
 - **Model routing transparency** — dynamic routing is skipped for interactive dispatches; model changes are always shown in the banner.
 - **Capability-aware routing (ADR-004)** — full implementation of capability scoring, `before_model_select` hook, and task metadata extraction.
 - **Multi-model provider strategy (ADR-005)** — infrastructure for multi-provider model selection wired into live paths.
+- **Anti-fabrication guardrails** — discuss prompts enforce turn-taking to prevent fabricated user responses.
+- **Milestone worktree cleanup** — merged worktree cleanup uses the milestone branch instead of generic lookups.
+- **Tool cache control** — `cache_control` breakpoints added to tool definitions for improved prompt caching.
 
 See the full [Changelog](./CHANGELOG.md) for details on every release.
 
@@ -729,6 +754,14 @@ models:
 ```
 
 Use expensive models where quality matters (planning, complex execution) and cheaper/faster models where speed matters (research, simple completions). Each phase accepts a simple model string or an object with `model` and `fallbacks` — if the primary model fails (provider outage, rate limit, credit exhaustion), GSD automatically tries the next fallback. GSD tracks cost per-model so you can see exactly where your budget goes.
+
+---
+
+## Ecosystem
+
+| Project | Description |
+| ------- | ----------- |
+| [GSD2 Config Utility](https://github.com/jeremymcs/gsd2-config) | Standalone configuration tool for managing GSD preferences, providers, and API keys |
 
 ---
 


### PR DESCRIPTION
## Summary
- Expand What's New in v2.71 with post-release fixes: model selection hardening, credential cooldown recovery, TUI improvements, provider fixes
- Add 3 new bullets to Reliability & Internals (anti-fabrication, worktree cleanup, tool cache control)
- Add **Ecosystem** section with [GSD2 Config Utility](https://github.com/jeremymcs/gsd2-config)

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Confirm all links resolve