### PR TITLE
perf(ci): cache Next.js build artifacts with Blacksmith

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,15 @@ jobs:
       - name: Install web host dependencies
         run: npm --prefix web ci
 
+      - name: Cache Next.js build
+        uses: useblacksmith/cache@v5
+        with:
+          path: web/.next/cache
+          key: nextjs-${{ runner.os }}-${{ hashFiles('web/package-lock.json') }}-${{ hashFiles('web/app/**', 'web/components/**', 'web/lib/**', 'web/hooks/**') }}
+          restore-keys: |
+            nextjs-${{ runner.os }}-${{ hashFiles('web/package-lock.json') }}-
+            nextjs-${{ runner.os }}-
+
       - name: Build
         run: npm run build
 

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -24,6 +24,10 @@ jobs:
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
+      env:
+        BLACKSMITH_CACHE_TOKEN: ${{ env.BLACKSMITH_CACHE_TOKEN }}
+        BLACKSMITH_CACHE_URL: ${{ env.BLACKSMITH_CACHE_URL }}
+        GITHUB_REPO_NAME: ${{ github.repository }}
     outputs:
       dev-version: ${{ steps.stamp.outputs.version }}
     steps:
@@ -40,6 +44,15 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+
+      - name: Cache Next.js build
+        uses: useblacksmith/cache@v5
+        with:
+          path: web/.next/cache
+          key: nextjs-${{ runner.os }}-${{ hashFiles('web/package-lock.json') }}-${{ hashFiles('web/app/**', 'web/components/**', 'web/lib/**', 'web/hooks/**') }}
+          restore-keys: |
+            nextjs-${{ runner.os }}-${{ hashFiles('web/package-lock.json') }}-
+            nextjs-${{ runner.os }}-
 
       - name: Build
         run: npm run build
@@ -152,6 +165,15 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+
+      - name: Cache Next.js build
+        uses: useblacksmith/cache@v5
+        with:
+          path: web/.next/cache
+          key: nextjs-${{ runner.os }}-${{ hashFiles('web/package-lock.json') }}-${{ hashFiles('web/app/**', 'web/components/**', 'web/lib/**', 'web/hooks/**') }}
+          restore-keys: |
+            nextjs-${{ runner.os }}-${{ hashFiles('web/package-lock.json') }}-
+            nextjs-${{ runner.os }}-
 
       - name: Run live LLM tests (optional)
         continue-on-error: true


### PR DESCRIPTION
## Summary
- Adds `useblacksmith/cache@v5` to persist `web/.next/cache` (Webpack compilation artifacts) across CI runs
- Applied to `ci.yml` build job and `pipeline.yml` dev-publish + prod-release jobs
- Passes Blacksmith cache env vars through to the dev-publish container job

## Why
Next.js warns "No build cache found" on every CI run, meaning Webpack recompiles all pages from scratch each time. Caching `.next/cache` lets subsequent runs skip recompilation of unchanged pages/components.

## Test plan
- [ ] First CI run: cache miss expected, populates the cache
- [ ] Second CI run on same branch: cache hit, faster `build:web-host` step
- [ ] Verify pipeline.yml container job (dev-publish) can access Blacksmith cache