### PR TITLE
fix(auto): recover from OpenRouter affordability 402 errors

### DIFF
--- a/packages/pi-coding-agent/src/core/retry-handler.test.ts
+++ b/packages/pi-coding-agent/src/core/retry-handler.test.ts
@@ -171,6 +171,25 @@ describe("RetryHandler — long-context entitlement 429 (#2803)", () => {
 			const retryStart = emittedEvents.find((e) => e.type === "auto_retry_start");
 			assert.ok(retryStart, "Regular 429 should enter backoff retry");
 		});
+
+		it("classifies OpenRouter credit affordability errors as quota_exhausted", async () => {
+			const { deps, emittedEvents } = createMockDeps({
+				model: createMockModel("openrouter", "openai/gpt-5-pro"),
+				markUsageLimitReachedResult: false,
+				fallbackResult: null,
+			});
+
+			const handler = new RetryHandler(deps);
+			const msg = errorMessage(
+				"402 This request requires more credits, or fewer max_tokens. You requested up to 32000 tokens, but can only afford 329.",
+			);
+
+			const result = await handler.handleRetryableError(msg);
+
+			assert.equal(result, true, "affordability error should trigger credit-aware retry");
+			const retryStart = emittedEvents.find((e) => e.type === "auto_retry_start");
+			assert.ok(retryStart, "Expected immediate retry after reducing max tokens");
+		});
 	});
 
 	describe("long-context model downgrade", () => {
@@ -271,6 +290,61 @@ describe("RetryHandler — long-context entitlement 429 (#2803)", () => {
 		});
 	});
 
+	describe("credit-aware maxTokens retry", () => {
+		it("reduces maxTokens on same model when provider reports affordable cap", async () => {
+			const expensiveModel = createMockModel("openrouter", "openai/gpt-5-pro");
+			expensiveModel.maxTokens = 128000;
+
+			const { deps, emittedEvents, onModelChangeFn } = createMockDeps({
+				model: expensiveModel,
+				markUsageLimitReachedResult: false,
+				fallbackResult: null,
+			});
+
+			const handler = new RetryHandler(deps);
+			const msg = errorMessage(
+				"402 This request requires more credits, or fewer max_tokens. You requested up to 32000 tokens, but can only afford 329.",
+			);
+
+			const result = await handler.handleRetryableError(msg);
+			assert.equal(result, true, "should retry after reducing maxTokens");
+
+			const setModelCalls = (deps.agent.setModel as any).mock.calls;
+			assert.equal(setModelCalls.length, 1, "should apply one model downgrade");
+			const downgraded = setModelCalls[0].arguments[0] as Model<Api>;
+			assert.equal(downgraded.provider, "openrouter");
+			assert.equal(downgraded.id, "openai/gpt-5-pro");
+			assert.equal(downgraded.maxTokens, 297, "expected affordability cap with safety buffer");
+
+			assert.equal(onModelChangeFn.mock.calls.length, 1, "should notify about model update");
+			const switchEvent = emittedEvents.find((e) => e.type === "fallback_provider_switch");
+			assert.ok(switchEvent, "should emit model-adjustment event");
+			assert.ok(
+				String(switchEvent?.reason || "").includes("credit-aware retry"),
+				"switch reason should mention credit-aware retry",
+			);
+		});
+
+		it("does not mark credentials in cooldown for affordability quota errors", async () => {
+			const expensiveModel = createMockModel("openrouter", "openai/gpt-5-pro");
+			expensiveModel.maxTokens = 128000;
+
+			const { deps, markUsageLimitReached } = createMockDeps({
+				model: expensiveModel,
+				markUsageLimitReachedResult: false,
+				fallbackResult: null,
+			});
+
+			const handler = new RetryHandler(deps);
+			const msg = errorMessage(
+				"402 This request requires more credits, or fewer max_tokens. You requested up to 32000 tokens, but can only afford 329.",
+			);
+
+			await handler.handleRetryableError(msg);
+			assert.equal(markUsageLimitReached.mock.calls.length, 0, "quota error should skip credential cooldown");
+		});
+	});
+
 	describe("isRetryableError", () => {
 		it("considers long-context entitlement error as retryable", () => {
 			const { deps } = createMockDeps();
@@ -290,6 +364,15 @@ describe("RetryHandler — long-context entitlement 429 (#2803)", () => {
 				'Please wait a moment and try again, or switch to a different provider.',
 			);
 			assert.equal(handler.isRetryableError(msg), false);
+		});
+
+		it("considers OpenRouter affordability credit errors as retryable", () => {
+			const { deps } = createMockDeps();
+			const handler = new RetryHandler(deps);
+			const msg = errorMessage(
+				"402 This request requires more credits, or fewer max_tokens. You requested up to 32000 tokens, but can only afford 329.",
+			);
+			assert.equal(handler.isRetryableError(msg), true);
 		});
 	});
 

--- a/packages/pi-coding-agent/src/core/retry-handler.ts
+++ b/packages/pi-coding-agent/src/core/retry-handler.ts
@@ -116,7 +116,7 @@ export class RetryHandler {
 		// generated error from getApiKey() when credentials are in a backoff window.
 		// Re-entering the retry handler for that message creates a cascade of empty
 		// error entries in the session file, breaking resume (#3429).
-		return /overloaded|rate.?limit|too many requests|429|500|502|503|504|service.?unavailable|server.?error|internal.?error|connection.?error|connection.?refused|other side closed|fetch failed|upstream.?connect|reset before headers|terminated|retry delay|network.?(?:is\s+)?unavailable|credentials.*expired|extra usage is required|(?:out of|no) extra usage|third.party.*draw from extra|third.party.*not.*available/i.test(
+		return /overloaded|rate.?limit|too many requests|402|429|500|502|503|504|service.?unavailable|server.?error|internal.?error|connection.?error|connection.?refused|other side closed|fetch failed|upstream.?connect|reset before headers|terminated|retry delay|network.?(?:is\s+)?unavailable|credentials.*expired|requires more credits|can only afford|insufficient credits|not enough credits|extra usage is required|(?:out of|no) extra usage|third.party.*draw from extra|third.party.*not.*available/i.test(
 			err,
 		);
 	}
@@ -157,6 +157,14 @@ export class RetryHandler {
 			const errorType = this._classifyErrorType(message.errorMessage);
 			const isRateLimit = errorType === "rate_limit";
 			const isQuotaError = errorType === "quota_exhausted";
+
+			// Credit-aware retry (OpenRouter-style 402 affordability errors):
+			// when provider reports "can only afford N", lower maxTokens and retry
+			// on the same model before rotating credentials/providers.
+			if (isQuotaError) {
+				const adjusted = this._tryAffordableMaxTokensRetry(message, retryGeneration);
+				if (adjusted) return true;
+			}
 
 			// Credential rotation — only for transient rate limits (#3430).
 			// Quota errors ("Extra usage is required") are account-level billing
@@ -409,10 +417,61 @@ export class RetryHandler {
 		// Long-context entitlement errors are billing gates, not transient rate limits.
 		// Must be checked before the generic 429/rate_limit regex.
 		if (/extra usage is required|long context required/i.test(err)) return "quota_exhausted";
+		if (/requires more credits|can only afford|insufficient credits|not enough credits|credit balance/i.test(err))
+			return "quota_exhausted";
 		if (/quota|billing|exceeded.*limit|usage.*limit/i.test(err)) return "quota_exhausted";
 		if (/rate.?limit|too many requests|429/i.test(err)) return "rate_limit";
 		if (/500|502|503|504|server.?error|internal.?error|service.?unavailable/i.test(err)) return "server_error";
 		return "unknown";
+	}
+
+	/**
+	 * Attempt a same-model retry by reducing maxTokens when provider reports
+	 * an affordability cap (e.g., "can only afford 329").
+	 */
+	private _tryAffordableMaxTokensRetry(message: AssistantMessage, retryGeneration: number): boolean {
+		const currentModel = this._deps.getModel();
+		if (!currentModel || !message.errorMessage) return false;
+
+		// Example: "can only afford 329"
+		const match = message.errorMessage.match(/can only afford\s+([\d,]+)/i);
+		if (!match?.[1]) return false;
+
+		const affordable = Number.parseInt(match[1].replace(/,/g, ""), 10);
+		if (!Number.isFinite(affordable) || affordable <= 0) return false;
+
+		// Leave a small buffer so slight input variance doesn't immediately re-fail.
+		const safetyBuffer = Math.min(64, Math.max(16, Math.floor(affordable * 0.1)));
+		const targetMaxTokens = Math.max(64, affordable - safetyBuffer);
+		const downgradedMaxTokens = Math.min(currentModel.maxTokens, targetMaxTokens);
+		if (downgradedMaxTokens >= currentModel.maxTokens) return false;
+
+		const downgradedModel = {
+			...currentModel,
+			maxTokens: downgradedMaxTokens,
+		};
+
+		this._deps.agent.setModel(downgradedModel);
+		this._deps.onModelChange(downgradedModel);
+		this._removeLastAssistantError();
+
+		this._deps.emit({
+			type: "fallback_provider_switch",
+			from: `${currentModel.provider}/${currentModel.id} (maxTokens=${currentModel.maxTokens})`,
+			to: `${downgradedModel.provider}/${downgradedModel.id} (maxTokens=${downgradedModel.maxTokens})`,
+			reason: `credit-aware retry: provider affordable cap ${affordable} tokens`,
+		});
+
+		this._deps.emit({
+			type: "auto_retry_start",
+			attempt: this._retryAttempt + 1,
+			maxAttempts: this._deps.settingsManager.getRetrySettings().maxRetries,
+			delayMs: 0,
+			errorMessage: `${message.errorMessage} (reducing max tokens)`,
+		});
+
+		this._scheduleContinue(retryGeneration);
+		return true;
 	}
 
 	/**

--- a/src/resources/extensions/gsd/error-classifier.ts
+++ b/src/resources/extensions/gsd/error-classifier.ts
@@ -44,6 +44,9 @@ export function resetRetryState(state: RetryState): void {
 
 const PERMANENT_RE = /auth|unauthorized|forbidden|invalid.*key|invalid.*api|billing|quota exceeded|account/i;
 const RATE_LIMIT_RE = /rate.?limit|too many requests|429/i;
+// OpenRouter affordability-style quota errors should be treated as transient
+// so core retry logic can lower maxTokens and continue in-session.
+const AFFORDABILITY_RE = /requires more credits|can only afford|insufficient credits|not enough credits|fewer max_tokens/i;
 const NETWORK_RE = /network|ECONNRESET|ETIMEDOUT|ECONNREFUSED|socket hang up|fetch failed|connection.*reset|dns/i;
 const SERVER_RE = /internal server error|500|502|503|overloaded|server_error|api_error|service.?unavailable/i;
 // ECONNRESET/ECONNREFUSED are in NETWORK_RE (same-model retry first).
@@ -67,7 +70,7 @@ const RESET_DELAY_RE = /reset in (\d+)s/i;
  */
 export function classifyError(errorMsg: string, retryAfterMs?: number): ErrorClass {
   const isPermanent = PERMANENT_RE.test(errorMsg);
-  const isRateLimit = RATE_LIMIT_RE.test(errorMsg);
+  const isRateLimit = RATE_LIMIT_RE.test(errorMsg) || AFFORDABILITY_RE.test(errorMsg);
 
   // 1. Permanent — but rate limit takes precedence
   if (isPermanent && !isRateLimit) {

--- a/src/resources/extensions/gsd/tests/provider-errors.test.ts
+++ b/src/resources/extensions/gsd/tests/provider-errors.test.ts
@@ -32,6 +32,15 @@ test("classifyError detects rate limit from message", () => {
   assert.equal(result.kind, "rate-limit");
 });
 
+test("classifyError treats OpenRouter affordability errors as transient rate-limit class", () => {
+  const result = classifyError(
+    "402 This request requires more credits, or fewer max_tokens. You requested up to 32000 tokens, but can only afford 329.",
+  );
+  assert.ok(isTransient(result));
+  assert.equal(result.kind, "rate-limit");
+  assert.ok("retryAfterMs" in result && result.retryAfterMs > 0);
+});
+
 test("classifyError extracts reset delay from message", () => {
   const result = classifyError("rate limit exceeded, reset in 45s");
   assert.equal(result.kind, "rate-limit");


### PR DESCRIPTION
## TL;DR

**What:** Fixes auto-mode recovery for OpenRouter affordability `402` errors by treating them as retryable and retrying with a reduced token cap.
**Why:** Sessions were hard-pausing on low-credit responses (`can only afford N`) even after model switches, blocking progress.
**How:** Adds affordability classification + same-model credit-aware `maxTokens` retry in core retry handling, and aligns the GSD provider classifier so auto-mode stays in the transient/retry path.

## What

This PR updates affordability error handling in two places:

- `packages/pi-coding-agent/src/core/retry-handler.ts`
  - Recognizes affordability/credit-cap messages as retryable quota errors.
  - Parses provider affordability cap from messages like `can only afford N`.
  - Performs an immediate same-model retry with reduced `maxTokens` (with safety buffer).
  - Avoids treating this class as credential-cooldown failures.
- `src/resources/extensions/gsd/error-classifier.ts`
  - Classifies affordability errors as transient/rate-limit class so auto-mode does not hard-pause before retry logic executes.
- Tests:
  - `packages/pi-coding-agent/src/core/retry-handler.test.ts`
  - `src/resources/extensions/gsd/tests/provider-errors.test.ts`

## Why

OpenRouter low-credit responses currently surface as provider errors that pause auto-mode instead of allowing recovery. That behavior causes repeated failure across model choices when the underlying issue is request affordability, not model incompatibility.

Closes #4091

## How

- Expanded retryable/affordability pattern matching to include OpenRouter affordability language.
- Mapped affordability failures to `quota_exhausted`.
- Added a targeted retry path that:
  - extracts affordable max token value,
  - clamps request `maxTokens` downward with margin,
  - retries immediately on the same model.
- Added/updated regression tests for classification and retry behavior.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [x] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [ ] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

Manual validation executed locally:

- `npm run build -w @gsd/pi-coding-agent`
- `node --test packages/pi-coding-agent/dist/core/retry-handler.test.js`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/provider-errors.test.ts`

## AI disclosure

- [x] This PR includes AI-assisted code (Codex-assisted implementation and test updates; tests above were executed locally)
