### PR TITLE
perf(ci): run integration tests in parallel with build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,11 +157,30 @@ jobs:
       - name: Run package tests
         run: npm run test:packages
 
-      - name: Run integration tests
-        run: npm run test:integration
-
       - name: Check test coverage thresholds
         run: npm run test:coverage
+
+  integration-tests:
+    timeout-minutes: 15
+    needs: detect-changes
+    if: needs.detect-changes.outputs.docs-only != 'true'
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run integration tests
+        run: npm run test:integration
 
   windows-portability:
     timeout-minutes: 25


### PR DESCRIPTION
## Summary
- Splits integration tests into a separate `integration-tests` job that runs concurrently with `build`
- Integration tests run from TypeScript source via `--experimental-strip-types` — no build artifact dependency
- `build` job retains unit tests, package tests, and coverage (which need compiled output)

## Why
The `build` job ran everything sequentially: compile, typecheck, unit tests, package tests, integration tests (90 files), coverage. Integration tests don't depend on build artifacts, so they can start immediately after `detect-changes`, saving wall-clock time equal to the full build+unit test duration.

## Cost impact
~1 min extra setup overhead (checkout + npm ci on a second runner), but significant wall-clock savings from parallelism.

## Test plan
- [ ] `build` job passes (unit tests, package tests, coverage)
- [ ] `integration-tests` job passes (all 90 integration test files)
- [ ] Both jobs run in parallel (check Actions timeline view)