### PR TITLE
fix(ci): build artifacts in integration-tests job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,6 +179,17 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # Integration tests need the same compiled artifacts as the build job:
+      # - dist/loader.js and packages/pi-coding-agent/dist/** from `npm run build`
+      # - web/node_modules/.bin/next for tests that shell `build:web-host` at runtime
+      # Duplicating the build here (instead of sharing artifacts via needs: build)
+      # preserves wall-clock parallelism with the build job — see PR #4093.
+      - name: Install web host dependencies
+        run: npm --prefix web ci
+
+      - name: Build
+        run: npm run build
+
       - name: Run integration tests
         run: npm run test:integration
 


### PR DESCRIPTION
## Summary

PR #4093 split `build` and `integration-tests` into parallel CI jobs, but the new `integration-tests` job only ran `npm ci` — leaving tests without the compiled artifacts they spawn at runtime. This added steps to build those artifacts before running tests.

Run [24325713845](https://github.com/gsd-build/gsd-2/actions/runs/24325713845/job/71020504030) failed on main with 8 integration test failures in three categories:

1. **`dist/loader.js not found`** — `e2e-headless.test.ts:30`, `e2e-smoke.test.ts:29`, `pack-install.test.ts:23`. These spawn `node dist/loader.js`, produced by the `tsc` step of `npm run build`.
2. **`session manager module not found; checked=packages/pi-coding-agent/dist/core/session-manager.js`** — 4 tests in `web-session-parity-contract.test.ts` / `web-live-state-contract.test.ts`, loaded via `src/web/bridge-service.ts:745`. Produced by `build:pi-coding-agent` (part of `npm run build`).
3. **`sh: 1: next: not found`** — `web-mode-onboarding.test.ts` calls `ensureRuntimeArtifacts` → shells `npm run build:web-host` → `next build`. The `next` binary lives in `web/node_modules/.bin/`, which only exists if `npm --prefix web ci` was run.

## Fix

Add `npm --prefix web ci` and `npm run build` to the `integration-tests` job before `Run integration tests`, matching what the `build` job already runs.

### Why duplicate the build instead of `needs: build` + artifact sharing?

Using `needs: build` would serialize the two jobs and undo the wall-clock parallelism PR #4093 was trying to buy. Artifact upload/download also adds overhead and surface area for stale-artifact bugs. The build is duplicated intentionally; a comment in the workflow explains this so a future author doesn't re-split it thinking the jobs are orthogonal.

## Test plan

- [ ] CI's `integration-tests` job passes on this PR
- [ ] `build` and `integration-tests` still run in parallel (both start after `detect-changes`, neither waits on the other)
- [ ] The 8 previously failing tests pass: `e2e-headless`, `e2e-smoke`, `pack-install`, 4 `web-session-parity-contract` / `web-live-state-contract` tests, `web-mode-onboarding`