### PR TITLE
feat: add codex-cli provider integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -594,6 +594,7 @@ GSD ships with 24 extensions, all loaded automatically:
 | **AWS Auth**           | Automatic Bedrock credential refresh for AWS-hosted models                                                              |
 | **Ollama**             | First-class local LLM support via Ollama                                                                                |
 | **Claude Code CLI**    | External provider extension for Claude Code CLI                                                                         |
+| **Codex CLI**          | External provider extension for the local Codex CLI                                                                     |
 | **cmux**               | Claude multiplexer integration — desktop notifications, sidebar metadata, visual subagent splits                        |
 | **GitHub Sync**        | Auto-sync milestones to GitHub Issues, PRs, and Milestones                                                              |
 | **LSP**                | Language Server Protocol — diagnostics, definitions, references, hover, rename                                          |
@@ -725,6 +726,8 @@ Anthropic, Anthropic (Vertex AI), OpenAI, Google (Gemini), OpenRouter, GitHub Co
 ### OAuth / Max Plans
 
 If you have a **Claude Max**, **Codex**, or **GitHub Copilot** subscription, you can use those directly — Pi handles the OAuth flow. No API key needed.
+
+If you prefer the local agent loop, GSD also bundles CLI-based providers such as **Claude Code CLI** and **Codex CLI** as separate routes from the OAuth-backed providers.
 
 > **⚠️ Important:** Using OAuth tokens from subscription plans outside their native applications may violate the provider's Terms of Service. In particular:
 >

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,6 +23,8 @@ Guides for installing, configuring, and using GSD day-to-day. Located in [`user-
 | [Git Strategy](./user-docs/git-strategy.md) | Worktree isolation, branching model, and merge behavior |
 | [Parallel Orchestration](./user-docs/parallel-orchestration.md) | Run multiple milestones simultaneously with worker isolation and coordination |
 | [Working in Teams](./user-docs/working-in-teams.md) | Unique milestone IDs, `.gitignore` setup, and shared planning artifacts |
+| [GSD + Codex PR Workflow](./user-docs/gsd-codex-pr-workflow.md) | Combine GSD planning/verification with Codex review/debugging to produce a strong pull request |
+| [GSD + Codex PR Workflow（中文）](./user-docs/gsd-codex-pr-workflow.zh-CN.md) | 使用 GSD 负责规划和验证，用 Codex 负责审查、调试和 PR 文案，协作产出高质量 PR |
 | [Skills](./user-docs/skills.md) | Bundled skills, skill discovery, and custom skill authoring |
 | [Migration from v1](./user-docs/migration.md) | Migrating `.planning` directories from the original GSD |
 | [Troubleshooting](./user-docs/troubleshooting.md) | Common issues, `/gsd doctor` (real-time visibility v2.40), `/gsd forensics` (full debugger v2.40), and recovery procedures |

--- a/docs/user-docs/gsd-codex-pr-workflow.md
+++ b/docs/user-docs/gsd-codex-pr-workflow.md
@@ -1,0 +1,428 @@
+# GSD + Codex PR Workflow
+
+[中文版](./gsd-codex-pr-workflow.zh-CN.md)
+
+This guide shows a practical way to combine GSD and Codex to produce a focused, reviewable pull request with real verification behind it.
+
+## Why use both
+
+Use the two tools for different jobs:
+
+- **GSD** owns scope, state, verification, git workflow, and PR structure.
+- **Codex** is the sidecar for deep implementation help, debugging, adversarial review, and PR writing.
+
+The combination works well because GSD keeps the work bounded and durable in `.gsd/`, while Codex gives you a second, independent pass on design and correctness.
+
+## The Core Rules
+
+If you want this workflow to produce a good PR instead of a messy AI diff, keep these rules:
+
+1. **One writer at a time.** Do not let GSD and Codex edit the same files simultaneously.
+2. **Mechanical gates decide done.** `build`, `typecheck`, `lint`, and `test` matter more than model confidence.
+3. **Keep the PR focused.** One concern per PR.
+4. **Use Codex as a reviewer, not just a generator.**
+5. **You must be able to explain the final diff yourself.**
+
+## Two Ways To Combine Them
+
+### Recommended: GSD Leads, Codex Reviews
+
+Use this for most work.
+
+- GSD plans the PR, tracks progress, runs verification, and manages the branch.
+- Codex reviews the plan, helps with hard debugging, and performs a strict pre-PR review.
+
+This keeps `.gsd/` state truthful and avoids the hardest coordination problems.
+
+### Advanced: Codex Edits the Active GSD Branch
+
+Use this only if you are comfortable coordinating two tools manually.
+
+- Pause GSD before letting Codex edit.
+- Prefer `git.isolation: branch` so both tools operate in the project root.
+- If you use `git.isolation: worktree`, launch Codex inside the active `.gsd/worktrees/<MID>/` path, not the main repo root.
+
+If you skip these precautions, GSD may be planning in one tree while Codex is editing another.
+
+## Prerequisites
+
+In the target repository:
+
+```bash
+npm install -g gsd-pi
+gh auth login          # optional, but recommended if you open PRs with gh
+```
+
+Then start GSD:
+
+```bash
+gsd
+```
+
+Inside GSD:
+
+```text
+/login
+/model
+```
+
+Notes:
+
+- GSD can run on many providers. If you have a **Codex** subscription, GSD can also use it directly via OAuth.
+- This guide assumes you are running **Codex as a separate tool** and using GSD as the workflow engine.
+
+## Recommended Project Preferences
+
+Create or update `.gsd/PREFERENCES.md` in the target repo:
+
+```yaml
+---
+version: 1
+mode: team
+token_profile: quality
+
+git:
+  isolation: branch
+  push_branches: true
+  auto_push: false
+  auto_pr: false
+  pre_merge_check: true
+
+verification_commands:
+  - npm run build
+  - npm run typecheck
+  - npm run lint
+  - npm run test
+verification_auto_fix: true
+verification_max_retries: 2
+
+post_unit_hooks:
+  - name: code-review
+    after: [execute-task]
+    prompt: "Review the latest task for correctness, regressions, missing tests, API breakage, and security issues. If blockers remain, write NEEDS-REWORK.md with exact fixes."
+    retry_on: NEEDS-REWORK.md
+---
+```
+
+Why this setup:
+
+- `mode: team` gives you safer PR-oriented defaults.
+- `git.isolation: branch` makes Codex coordination easier than `worktree`.
+- `verification_commands` ensures the PR is judged by commands, not vibes.
+- `post_unit_hooks` adds a review pass after execution.
+
+If you are the only person using GSD in the repo and do not want to commit `.gsd/` artifacts, see [`working-in-teams.md`](./working-in-teams.md) and set `git.commit_docs: false`.
+
+## Recommended Workflow
+
+### 1. Define the PR before code exists
+
+Start in the target repository:
+
+```bash
+gsd
+```
+
+Then use one of these entry points:
+
+- Bug fix PR: `/gsd start bugfix`
+- General feature/refactor PR: `/gsd discuss`
+
+Give GSD a brief like this:
+
+```text
+We are preparing one focused PR.
+
+Goal:
+- <what should land in this PR>
+
+Non-goals:
+- <what must not be included>
+
+Issue / context:
+- <issue link, bug report, or motivation>
+
+Acceptance:
+- <observable outcomes>
+
+Verification:
+- npm run build
+- npm run typecheck
+- npm run lint
+- npm run test
+
+Risk boundaries:
+- <APIs, migrations, behavior, or docs that need extra care>
+```
+
+What GSD should produce:
+
+- `.gsd/PROJECT.md`
+- `.gsd/REQUIREMENTS.md`
+- milestone context and roadmap
+- a small number of slices/tasks with explicit verification
+
+### 2. Let GSD plan first, not free-run blindly
+
+Before letting either tool implement, get a concrete plan:
+
+```text
+/gsd
+```
+
+or:
+
+```text
+/gsd next
+```
+
+Advance until you have a current task plan. Review:
+
+- `.gsd/STATE.md`
+- `.gsd/PROJECT.md`
+- `.gsd/DECISIONS.md`
+- current slice plan
+- current task plan
+
+At this point, ask Codex for a **read-only plan review**.
+
+Prompt for Codex:
+
+```text
+Read the current GSD plan and review it before implementation.
+
+Files to read:
+- .gsd/STATE.md
+- .gsd/PROJECT.md
+- .gsd/DECISIONS.md
+- the active slice plan
+- the active task plan
+
+Check for:
+- scope creep
+- hidden regressions
+- missing tests
+- API or migration risks
+- simpler implementation paths
+
+Do not edit yet. Return concrete findings only.
+```
+
+If Codex finds a plan flaw, fix the plan first with `/gsd discuss` or `/gsd steer`.
+
+### 3. Let GSD execute, and use Codex as the sidecar
+
+Now run:
+
+```text
+/gsd auto
+```
+
+or continue step-by-step with:
+
+```text
+/gsd
+```
+
+Recommended usage:
+
+- Let GSD do the normal task execution.
+- Use Codex when one of these happens:
+  - the task is tricky and you want a second design opinion
+  - GSD stalls or loops
+  - verification fails in a non-obvious way
+  - you want a strict review before moving on
+
+When GSD is actively editing, Codex should stay read-only.
+
+If you want Codex to patch code:
+
+1. Pause GSD with `Escape` or `/gsd pause`
+2. Let Codex edit
+3. Return to GSD and resume with `/gsd auto`
+
+This preserves a single active writer.
+
+### 4. Use Codex for hard debugging
+
+When GSD gets stuck on a bug or failing verification, pause it and hand the failure to Codex.
+
+Prompt for Codex:
+
+```text
+Debug this failure without expanding scope.
+
+Read:
+- current GSD task plan
+- failing command output
+- changed files in this branch
+
+Goal:
+- find the root cause
+- propose the smallest correct fix
+- preserve the intended PR scope
+
+Return:
+- root cause
+- fix plan
+- tests or verification that prove the fix
+```
+
+Once you have a credible fix, either:
+
+- steer GSD with `/gsd steer`, or
+- let Codex patch while GSD is paused, then resume GSD
+
+### 5. Run an adversarial pre-PR review in Codex
+
+Before opening the PR, do not trust the authoring pass alone.
+
+Ask Codex to review the branch like a strict reviewer:
+
+```text
+Review this branch as if you are blocking the PR unless it is clearly correct.
+
+Check for:
+- correctness bugs
+- regressions
+- missing regression tests
+- public API / CLI / config breakage
+- docs or migration gaps
+- security issues
+
+Read the full changed files, not just the diff.
+Return findings ordered by severity with file references.
+If there are no findings, say that explicitly and list residual risks.
+```
+
+Fix anything real before moving on.
+
+### 6. Verify mechanically
+
+Even if GSD already ran the checks, run the final gates you want reviewers to trust.
+
+Typical Node/TS repo:
+
+```bash
+npm run build
+npm run typecheck
+npm run lint
+npm run test
+```
+
+If the repo uses a different stack, swap in the real commands.
+
+For bug fixes, ensure you have a regression test that would fail without the fix.
+
+### 7. Draft the PR body with Codex or by hand
+
+This repository's contribution guide expects a PR body with **TL;DR**, **What**, **Why**, and **How**. See [`../CONTRIBUTING.md`](../CONTRIBUTING.md).
+
+Use this template:
+
+```md
+## TL;DR
+
+**What:** <one sentence describing the change>
+**Why:** <one sentence describing the problem>
+**How:** <one sentence describing the approach>
+
+## What
+
+<Describe the user-visible and code-level changes. Keep it focused on this PR.>
+
+## Why
+
+<Describe the problem, root cause, or motivation. Link the issue if one exists.>
+
+## How
+
+<Explain the implementation approach, important tradeoffs, and why this design was chosen.>
+
+## Verification
+
+- npm run build
+- npm run typecheck
+- npm run lint
+- npm run test
+
+## AI-assisted disclosure
+
+This PR was prepared with AI assistance. I reviewed the final diff, ran verification locally, and can explain the changes and tradeoffs.
+```
+
+Prompt for Codex:
+
+```text
+Draft a PR body from this branch.
+
+Inputs:
+- issue or problem statement
+- final diff
+- verification commands and results
+
+Format:
+- TL;DR
+- What
+- Why
+- How
+- Verification
+- AI-assisted disclosure
+
+Do not invent checks or results that did not happen.
+```
+
+### 8. Open the PR
+
+Manual path:
+
+```bash
+git push -u origin <branch>
+gh pr create
+```
+
+Automated path:
+
+```yaml
+git:
+  auto_push: true
+  auto_pr: true
+  pr_target_branch: main
+```
+
+Only turn on `auto_pr` once you trust your verification and review loop.
+
+## A Safe Day-To-Day Pattern
+
+If you want a simple rule set that works well:
+
+1. Use GSD to define and plan the PR
+2. Use GSD to execute normal tasks
+3. Use Codex to review plans before coding
+4. Pause GSD and use Codex only for hard patches or hard debugging
+5. Use Codex again for strict pre-PR review
+6. Run the final command checks
+7. Open the PR with a body you can defend
+
+## Anti-Patterns
+
+Avoid these if you want clean PRs:
+
+- Running GSD auto-mode while Codex is editing the same files
+- Asking Codex to "fix everything in the repo"
+- Opening a PR before `build`, `lint`, `typecheck`, and `test` pass
+- Letting AI generate a PR description you cannot explain
+- Bundling drive-by refactors into a bug-fix PR
+- Using GSD worktree mode while Codex is still attached to the repo root
+
+## Definition Of Done For An AI-Assisted PR
+
+You are ready to open the PR when all of these are true:
+
+- The diff is focused on one concern
+- The final state matches the GSD plan
+- Verification commands pass
+- A regression test exists for every bug fix
+- Codex has done a strict review pass
+- The PR body explains **what**, **why**, and **how**
+- You can answer reviewer questions without asking the model again

--- a/docs/user-docs/gsd-codex-pr-workflow.zh-CN.md
+++ b/docs/user-docs/gsd-codex-pr-workflow.zh-CN.md
@@ -1,0 +1,441 @@
+# GSD + Codex 协作 PR 教程（中文版）
+
+[English version](./gsd-codex-pr-workflow.md)
+
+这篇教程讲的是一套实用工作流：用 **GSD** 负责规划、状态、验证、分支和 PR 流程，用 **Codex** 负责方案审查、难点调试、严格 review 和 PR 文案整理，最终产出一个聚焦、可审查、能自证的 PR。
+
+## 为什么要一起用
+
+两者最好分工明确：
+
+- **GSD** 负责范围控制、任务拆解、状态持久化、验证命令、分支策略和 PR 流程。
+- **Codex** 负责实现难点、根因分析、对抗式 review、以及最终 PR 说明整理。
+
+这样做的好处是：
+
+- GSD 把工作沉淀在 `.gsd/` 里，不容易跑偏。
+- Codex 提供第二视角，避免“作者自己给自己打高分”。
+
+## 核心规则
+
+如果你想要的是一个好 PR，而不是一坨 AI diff，先守住这几条：
+
+1. **同一时间只能有一个 writer。** 不要让 GSD 和 Codex 同时改同一批文件。
+2. **是否完成由机械校验决定。** `build`、`typecheck`、`lint`、`test` 比模型“感觉没问题”更重要。
+3. **PR 必须聚焦。** 一个 PR 只解决一个主题。
+4. **Codex 要当 reviewer，不只是 generator。**
+5. **你自己必须能解释最终 diff。**
+
+## 两种组合方式
+
+### 推荐方式：GSD 主导，Codex 辅助审查
+
+大多数场景都建议这样用：
+
+- GSD 负责拆解、执行、校验、推进分支。
+- Codex 负责读计划、挑问题、帮你解难 bug、做严格 pre-PR review。
+
+这是最稳的方式，因为 `.gsd/` 状态始终可信，也最不容易出现两边上下文不一致。
+
+### 进阶方式：Codex 直接改 GSD 当前分支
+
+这个方式可以用，但要求你手动控场：
+
+- 先暂停 GSD，再让 Codex 动手。
+- 优先使用 `git.isolation: branch`，这样 GSD 和 Codex 都在仓库根目录工作。
+- 如果你使用 `git.isolation: worktree`，那 Codex 必须进入当前活跃的 `.gsd/worktrees/<MID>/` 目录里工作，不能还停留在主仓库根目录。
+
+否则很容易出现：GSD 在 A 工作树里规划，Codex 在 B 工作树里改代码。
+
+## 前置准备
+
+在目标仓库里执行：
+
+```bash
+npm install -g gsd-pi
+gh auth login
+```
+
+其中 `gh auth login` 不是必须，但如果你准备 `gh pr create`，最好先配好。
+
+然后启动 GSD：
+
+```bash
+gsd
+```
+
+进入 GSD 后：
+
+```text
+/login
+/model
+```
+
+说明：
+
+- GSD 支持很多模型提供方。
+- 如果你有 **Codex** 订阅，GSD 也可以直接通过 OAuth 使用它。
+- 这篇教程默认你是把 **Codex 当成独立工具** 使用，而让 **GSD 充当工作流引擎**。
+
+## 推荐的项目配置
+
+在目标仓库里创建或更新 `.gsd/PREFERENCES.md`：
+
+```yaml
+---
+version: 1
+mode: team
+token_profile: quality
+
+git:
+  isolation: branch
+  push_branches: true
+  auto_push: false
+  auto_pr: false
+  pre_merge_check: true
+
+verification_commands:
+  - npm run build
+  - npm run typecheck
+  - npm run lint
+  - npm run test
+verification_auto_fix: true
+verification_max_retries: 2
+
+post_unit_hooks:
+  - name: code-review
+    after: [execute-task]
+    prompt: "Review the latest task for correctness, regressions, missing tests, API breakage, and security issues. If blockers remain, write NEEDS-REWORK.md with exact fixes."
+    retry_on: NEEDS-REWORK.md
+---
+```
+
+这套配置的意义：
+
+- `mode: team` 会启用更偏 PR 场景的安全默认值。
+- `git.isolation: branch` 比 `worktree` 更方便和 Codex 配合。
+- `verification_commands` 把完成条件落到命令上。
+- `post_unit_hooks` 会在任务执行后追加一轮 review。
+
+如果你是个人使用，不想把 `.gsd/` 工件提交进仓库，可以看 [working-in-teams.md](./working-in-teams.md)，并考虑设置 `git.commit_docs: false`。
+
+## 推荐工作流
+
+### 1. 先定义 PR，再开始写代码
+
+在目标仓库启动：
+
+```bash
+gsd
+```
+
+然后根据场景选择：
+
+- 修 bug 型 PR：`/gsd start bugfix`
+- 一般功能 / 重构型 PR：`/gsd discuss`
+
+你可以直接给 GSD 下面这种 brief：
+
+```text
+我们要准备一个聚焦的 PR。
+
+目标：
+- <这个 PR 要交付什么>
+
+非目标：
+- <这个 PR 明确不做什么>
+
+背景 / issue：
+- <issue 链接、bug 描述或动机>
+
+验收标准：
+- <用户可观察结果>
+
+验证命令：
+- npm run build
+- npm run typecheck
+- npm run lint
+- npm run test
+
+风险边界：
+- <API、迁移、兼容性、文档、数据结构等需要特别小心的点>
+```
+
+这一阶段你希望 GSD 产出的是：
+
+- `.gsd/PROJECT.md`
+- `.gsd/REQUIREMENTS.md`
+- milestone context 和 roadmap
+- 少量、明确、可验证的 slices / tasks
+
+### 2. 先让 GSD 做计划，不要一上来就自由发挥
+
+在开始实现前，先拿到明确任务计划：
+
+```text
+/gsd
+```
+
+或者：
+
+```text
+/gsd next
+```
+
+推进到当前 task plan 已经成型为止。重点看：
+
+- `.gsd/STATE.md`
+- `.gsd/PROJECT.md`
+- `.gsd/DECISIONS.md`
+- 当前 slice plan
+- 当前 task plan
+
+这时让 Codex 做一次**只读计划审查**。
+
+可以直接把下面这段发给 Codex：
+
+```text
+先不要改代码。先读当前 GSD 计划并做审查。
+
+请读取：
+- .gsd/STATE.md
+- .gsd/PROJECT.md
+- .gsd/DECISIONS.md
+- 当前 slice plan
+- 当前 task plan
+
+请检查：
+- 是否有 scope creep
+- 是否遗漏回归风险
+- 是否缺少测试
+- 是否有 API / migration 风险
+- 是否有更简单的实现路径
+
+只返回具体发现，不要先动手修改。
+```
+
+如果 Codex 发现计划本身有问题，先用 `/gsd discuss` 或 `/gsd steer` 修计划，再进入实现阶段。
+
+### 3. 让 GSD 执行，Codex 作为 sidecar
+
+现在可以运行：
+
+```text
+/gsd auto
+```
+
+或者继续一步一步：
+
+```text
+/gsd
+```
+
+推荐用法：
+
+- 正常任务交给 GSD 执行。
+- 遇到以下情况再叫 Codex 介入：
+  - 任务比较难，想要第二设计意见
+  - GSD 卡住了或者开始绕圈
+  - 验证失败，但原因不明显
+  - 你想在推进前做一次更严格的 review
+
+**关键规则：** 当 GSD 正在写文件时，Codex 应保持只读。
+
+如果你想让 Codex 真正补丁：
+
+1. 用 `Escape` 或 `/gsd pause` 暂停 GSD
+2. 让 Codex 修改代码
+3. 回到 GSD，用 `/gsd auto` 恢复
+
+这样可以保证始终只有一个活跃 writer。
+
+### 4. 把 Codex 用在难调试的问题上
+
+当 GSD 遇到难 bug 或验证失败时，先暂停，再把问题交给 Codex 做根因分析。
+
+你可以这样问 Codex：
+
+```text
+请调试这个失败，但不要扩大范围。
+
+请读取：
+- 当前 GSD task plan
+- 失败命令输出
+- 当前分支改过的文件
+
+目标：
+- 找到 root cause
+- 给出最小且正确的修复方案
+- 不要把 PR 范围扩出去
+
+输出：
+- 根因
+- 修复计划
+- 证明修复有效的测试或验证方式
+```
+
+拿到可信方案后，你可以选择：
+
+- 用 `/gsd steer` 把方案反馈给 GSD
+- 或者在 GSD 暂停时让 Codex 直接补丁，再恢复 GSD
+
+### 5. 在开 PR 前，让 Codex 做一次对抗式 review
+
+不要只相信“作者模式”的输出。开 PR 前，最好让 Codex 站在严格 reviewer 角度再看一遍。
+
+可以直接这样问：
+
+```text
+请把这个分支当成待审 PR 来 review。
+
+如果不够扎实，就按 blocker 标准提问题。
+
+重点检查：
+- 正确性 bug
+- 回归风险
+- 是否缺少 regression test
+- 公共 API / CLI / 配置兼容性破坏
+- 文档或迁移说明缺口
+- 安全问题
+
+请读取完整变更文件，不要只看 diff。
+按严重程度排序返回 findings，并带文件引用。
+如果没有发现，也要明确说 no findings，并列出剩余风险。
+```
+
+这一步非常重要。它能显著降低“功能做出来了，但 PR 说不圆、测不实、边界没兜住”的概率。
+
+### 6. 做最终机械验证
+
+即使 GSD 已经跑过，也建议在开 PR 前再手动跑一遍你真正希望 reviewer 信任的命令。
+
+典型 Node / TypeScript 仓库：
+
+```bash
+npm run build
+npm run typecheck
+npm run lint
+npm run test
+```
+
+如果目标仓库不是这个栈，就换成它自己的真实命令。
+
+对于 bug fix，最好确认：
+
+- 有 regression test
+- 没修复前它会失败
+- 修复后它会通过
+
+### 7. 用 Codex 或你自己整理 PR 文案
+
+这个仓库自己的贡献规范要求 PR 说明里至少要有 **TL;DR / What / Why / How**。见 [../CONTRIBUTING.md](../CONTRIBUTING.md)。
+
+推荐模板：
+
+```md
+## TL;DR
+
+**What:** <一句话描述改了什么>
+**Why:** <一句话描述为什么要改>
+**How:** <一句话描述怎么改的>
+
+## What
+
+<描述这个 PR 做了哪些变化。聚焦在当前 PR。>
+
+## Why
+
+<描述问题、根因或动机。必要时链接 issue。>
+
+## How
+
+<说明实现路径、关键取舍，以及为什么这样设计。>
+
+## Verification
+
+- npm run build
+- npm run typecheck
+- npm run lint
+- npm run test
+
+## AI-assisted disclosure
+
+This PR was prepared with AI assistance. I reviewed the final diff, ran verification locally, and can explain the changes and tradeoffs.
+```
+
+你也可以让 Codex 帮你起草，但要约束它不要编造结果：
+
+```text
+请根据这个分支起草 PR 文案。
+
+输入：
+- 问题背景或 issue
+- 最终 diff
+- 实际执行过的验证命令和结果
+
+输出格式：
+- TL;DR
+- What
+- Why
+- How
+- Verification
+- AI-assisted disclosure
+
+不要编造任何没有真实执行过的检查结果。
+```
+
+### 8. 开 PR
+
+手动开：
+
+```bash
+git push -u origin <branch>
+gh pr create
+```
+
+自动开：
+
+```yaml
+git:
+  auto_push: true
+  auto_pr: true
+  pr_target_branch: main
+```
+
+只有当你已经信任自己的校验和 review 流程时，才建议打开 `auto_pr`。
+
+## 一套最稳的日常模式
+
+如果你想记一套简单规则，照这个顺序走就够了：
+
+1. 用 GSD 定义 PR 目标和边界
+2. 用 GSD 做计划
+3. 用 Codex 做只读计划审查
+4. 用 GSD 执行大部分任务
+5. 遇到难题时暂停 GSD，再让 Codex 补丁或调试
+6. 开 PR 前让 Codex 做严格 review
+7. 跑最终命令校验
+8. 提交一个你自己讲得清楚的 PR
+
+## 常见反模式
+
+下面这些做法很容易把 PR 搞坏：
+
+- GSD 在 `auto`，Codex 还在同时改同一批文件
+- 一上来就让 Codex “把整个仓库都修一遍”
+- `build / lint / typecheck / test` 没过就开 PR
+- PR 文案是 AI 写的，但你自己解释不出来
+- 在 bugfix PR 里顺手塞一堆无关重构
+- 用 `worktree` 模式跑 GSD，但 Codex 还在主仓库根目录里工作
+
+## AI 辅助 PR 的完成定义
+
+当下面这些条件都满足时，你再开 PR：
+
+- diff 只围绕一个主题
+- 最终实现和 GSD 计划一致
+- 验证命令全部通过
+- 每个 bug fix 都有回归测试
+- Codex 做过严格 review
+- PR 文案能清楚说明 **What / Why / How**
+- reviewer 问你问题时，你不用再去反问模型

--- a/docs/user-docs/providers.md
+++ b/docs/user-docs/providers.md
@@ -8,6 +8,7 @@ Step-by-step setup instructions for every LLM provider GSD supports. If you ran 
 - [Built-in Providers](#built-in-providers)
   - [Anthropic (Claude)](#anthropic-claude)
   - [OpenAI](#openai)
+  - [Codex CLI](#codex-cli)
   - [Google Gemini](#google-gemini)
   - [OpenRouter](#openrouter)
   - [Groq](#groq)
@@ -32,6 +33,7 @@ Step-by-step setup instructions for every LLM provider GSD supports. If you ran 
 |----------|-------------|-------------|-------------|
 | Anthropic | API key | `ANTHROPIC_API_KEY` | — |
 | OpenAI | API key | `OPENAI_API_KEY` | — |
+| Codex CLI | Local CLI login | — | — |
 | Google Gemini | API key | `GEMINI_API_KEY` | — |
 | OpenRouter | API key | `OPENROUTER_API_KEY` | Optional `models.json` |
 | Groq | API key | `GROQ_API_KEY` | — |
@@ -149,6 +151,22 @@ export OPENAI_API_KEY="sk-..."
 Or run `gsd config` and choose "Paste an API key" then "OpenAI".
 
 **Get a key:** [platform.openai.com/api-keys](https://platform.openai.com/api-keys)
+
+### Codex CLI
+
+`codex-cli` is a separate local-CLI provider. It does **not** replace the existing `openai-codex` browser OAuth path.
+
+Recommended when you already have the `codex` binary installed and authenticated locally and want GSD to use the local Codex agent loop:
+
+```bash
+codex login
+gsd config
+# Choose "Use Codex CLI"
+```
+
+Inside GSD, models appear with the `codex-cli/` provider prefix (for example `codex-cli/gpt-5.4`).
+
+Use `openai-codex` when you want the existing ChatGPT Plus/Pro OAuth-backed provider. Use `codex-cli` when you want GSD to delegate execution through the local Codex agent loop.
 
 ### Google Gemini
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -75,6 +75,7 @@
         "@gsd-build/engine-linux-arm64-gnu": ">=2.10.2",
         "@gsd-build/engine-linux-x64-gnu": ">=2.10.2",
         "@gsd-build/engine-win32-x64-msvc": ">=2.10.2",
+        "@openai/codex-sdk": "^0.118.0",
         "fsevents": "~2.3.3",
         "koffi": "^2.9.0"
       }
@@ -899,6 +900,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2615,6 +2617,7 @@
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.6.tgz",
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -2756,6 +2759,142 @@
         "@octokit/openapi-types": "^27.0.0"
       }
     },
+    "node_modules/@openai/codex": {
+      "version": "0.118.0",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.118.0.tgz",
+      "integrity": "sha512-oJhNOsP/Vu7DBUhodpP15z60cCZv3sKORqUn1+pepleqSTmc0zXJZSjz6fQOLzny9Ra6sRcvprFFKmQ3Q6+E6w==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "bin": {
+        "codex": "bin/codex.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.118.0-darwin-arm64",
+        "@openai/codex-darwin-x64": "npm:@openai/codex@0.118.0-darwin-x64",
+        "@openai/codex-linux-arm64": "npm:@openai/codex@0.118.0-linux-arm64",
+        "@openai/codex-linux-x64": "npm:@openai/codex@0.118.0-linux-x64",
+        "@openai/codex-win32-arm64": "npm:@openai/codex@0.118.0-win32-arm64",
+        "@openai/codex-win32-x64": "npm:@openai/codex@0.118.0-win32-x64"
+      }
+    },
+    "node_modules/@openai/codex-darwin-arm64": {
+      "name": "@openai/codex",
+      "version": "0.118.0-darwin-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.118.0-darwin-arm64.tgz",
+      "integrity": "sha512-sxq7Q2q9YiJN1wNrzvFRCC5oQKXPVUvu9Ejg6SI/CvyyI9YdtyLTO633wQJALGB7XQfT+3tyM5nNBivnSzLA3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-darwin-x64": {
+      "name": "@openai/codex",
+      "version": "0.118.0-darwin-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.118.0-darwin-x64.tgz",
+      "integrity": "sha512-iIvrqzsh1iJmVfqyYwLZBiuh0MkN1Suqniz9hBfmRmE6txMWhRVfigb9SMBiOkfCW1C4sjBwLCsCSzg11rvppQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-linux-arm64": {
+      "name": "@openai/codex",
+      "version": "0.118.0-linux-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.118.0-linux-arm64.tgz",
+      "integrity": "sha512-YKWmIqLBu9mmBhN3JHQNkLzk0BtAtV6LBPvhnL5eeHkNrChvA6PKrhsjy0O7wvRkiByZY/1dD14qVdAUfxcbiA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-linux-x64": {
+      "name": "@openai/codex",
+      "version": "0.118.0-linux-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.118.0-linux-x64.tgz",
+      "integrity": "sha512-vzU2d/gwAmZbf/DnwVzfQiNN3Ri04XpaZiJkHElIvGoqFbdrxRQFYTtslGDISYIO3o+POADZcFZIfamFsZj9yQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-sdk": {
+      "version": "0.118.0",
+      "resolved": "https://registry.npmjs.org/@openai/codex-sdk/-/codex-sdk-0.118.0.tgz",
+      "integrity": "sha512-cMisxx4CGQL44yv2USqdgcPhxPOhv227+CJiF9snn2X7nL+6wary4g38OknornjlrPob7LyzdIFB7dXqjkXKxg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@openai/codex": "0.118.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@openai/codex-win32-arm64": {
+      "name": "@openai/codex",
+      "version": "0.118.0-win32-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.118.0-win32-arm64.tgz",
+      "integrity": "sha512-AU7GPVFqd0Ml3P2OXfy6K6TONcxfCZLUh1zjYkkoPGWJ4A3BVMkOmMP9CAdSiQsnU/RQfdV/9IGqo1xwUQDdjA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-win32-x64": {
+      "name": "@openai/codex",
+      "version": "0.118.0-win32-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.118.0-win32-x64.tgz",
+      "integrity": "sha512-9vKW1ANQxIUsLpiY0VsOM+1avZjqxDZgqgxKABJHWRlLMuaSykwXexf8Hqq+BnYFfmn0d6MjxTuE1UtVvg9caw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/@phosphor-icons/react": {
       "version": "2.1.10",
       "resolved": "https://registry.npmjs.org/@phosphor-icons/react/-/react-2.1.10.tgz",
@@ -2852,8 +2991,7 @@
       "optional": true,
       "os": [
         "android"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
       "version": "4.59.0",
@@ -2867,8 +3005,7 @@
       "optional": true,
       "os": [
         "android"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
       "version": "4.59.0",
@@ -2882,8 +3019,7 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
       "version": "4.59.0",
@@ -2897,8 +3033,7 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
       "version": "4.59.0",
@@ -2912,8 +3047,7 @@
       "optional": true,
       "os": [
         "freebsd"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
       "version": "4.59.0",
@@ -2927,8 +3061,7 @@
       "optional": true,
       "os": [
         "freebsd"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
       "version": "4.59.0",
@@ -2942,8 +3075,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
       "version": "4.59.0",
@@ -2957,8 +3089,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
       "version": "4.59.0",
@@ -2972,8 +3103,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
       "version": "4.59.0",
@@ -2987,8 +3117,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
       "version": "4.59.0",
@@ -3002,8 +3131,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
       "version": "4.59.0",
@@ -3017,8 +3145,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
       "version": "4.59.0",
@@ -3032,8 +3159,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
       "version": "4.59.0",
@@ -3047,8 +3173,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
       "version": "4.59.0",
@@ -3062,8 +3187,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
       "version": "4.59.0",
@@ -3077,8 +3201,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
       "version": "4.59.0",
@@ -3092,8 +3215,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
       "version": "4.59.0",
@@ -3107,8 +3229,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
       "version": "4.59.0",
@@ -3122,8 +3243,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
       "version": "4.59.0",
@@ -3137,8 +3257,7 @@
       "optional": true,
       "os": [
         "openbsd"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
       "version": "4.59.0",
@@ -3152,8 +3271,7 @@
       "optional": true,
       "os": [
         "openharmony"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
       "version": "4.59.0",
@@ -3167,8 +3285,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
       "version": "4.59.0",
@@ -3182,8 +3299,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
       "version": "4.59.0",
@@ -3197,8 +3313,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
       "version": "4.59.0",
@@ -3212,8 +3327,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@sapphire/async-queue": {
       "version": "1.5.5",
@@ -4315,8 +4429,7 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/hosted-git-info": {
       "version": "3.0.5",
@@ -4387,6 +4500,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -4710,6 +4824,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5582,6 +5697,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -5752,7 +5868,6 @@
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12.0.0"
       },
@@ -6267,6 +6382,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
       "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -7125,7 +7241,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -7456,6 +7571,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7536,7 +7652,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -7714,6 +7829,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7723,6 +7839,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -7836,7 +7953,6 @@
       "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -8397,7 +8513,6 @@
       "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fdir": "^6.5.0",
         "picomatch": "^4.0.3"
@@ -8692,7 +8807,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8710,7 +8824,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8728,7 +8841,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8746,7 +8858,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8764,7 +8875,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8782,7 +8892,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8800,7 +8909,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8818,7 +8926,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8836,7 +8943,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8854,7 +8960,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8872,7 +8977,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8890,7 +8994,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8908,7 +9011,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8926,7 +9028,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8944,7 +9045,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8962,7 +9062,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8980,7 +9079,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8998,7 +9096,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9016,7 +9113,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9034,7 +9130,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9052,7 +9147,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9070,7 +9164,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9088,7 +9181,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9106,7 +9198,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9124,7 +9215,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9142,7 +9232,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9154,7 +9243,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -9383,6 +9471,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "copy-themes": "node scripts/copy-themes.cjs",
     "copy-export-html": "node scripts/copy-export-html.cjs",
     "test:compile": "node scripts/compile-tests.mjs",
-    "test:unit": "npm run test:compile && node --import ./scripts/dist-test-resolve.mjs --experimental-test-isolation=process --test-reporter=./scripts/test-reporter-compact.mjs --test \"dist-test/src/tests/*.test.js\" \"dist-test/src/resources/extensions/gsd/tests/*.test.js\" \"dist-test/src/resources/extensions/gsd/tests/*.test.mjs\" \"dist-test/src/resources/extensions/shared/tests/*.test.js\" \"dist-test/src/resources/extensions/claude-code-cli/tests/*.test.js\" \"dist-test/src/resources/extensions/github-sync/tests/*.test.js\" \"dist-test/src/resources/extensions/universal-config/tests/*.test.js\" \"dist-test/src/resources/extensions/voice/tests/*.test.js\" \"dist-test/src/resources/extensions/mcp-client/tests/*.test.js\"",
+    "test:unit": "npm run test:compile && node --import ./scripts/dist-test-resolve.mjs --experimental-test-isolation=process --test-reporter=./scripts/test-reporter-compact.mjs --test \"dist-test/src/tests/*.test.js\" \"dist-test/src/resources/extensions/gsd/tests/*.test.js\" \"dist-test/src/resources/extensions/gsd/tests/*.test.mjs\" \"dist-test/src/resources/extensions/shared/tests/*.test.js\" \"dist-test/src/resources/extensions/claude-code-cli/tests/*.test.js\" \"dist-test/src/resources/extensions/codex-cli/tests/*.test.js\" \"dist-test/src/resources/extensions/github-sync/tests/*.test.js\" \"dist-test/src/resources/extensions/universal-config/tests/*.test.js\" \"dist-test/src/resources/extensions/voice/tests/*.test.js\" \"dist-test/src/resources/extensions/mcp-client/tests/*.test.js\"",
     "test:packages": "node --test packages/pi-coding-agent/dist/core/*.test.js packages/pi-coding-agent/dist/core/tools/spawn-shell-windows.test.js",
     "test:marketplace": "node scripts/with-env.mjs GSD_TEST_CLONE_MARKETPLACES=1 -- node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/claude-import-tui.test.ts src/resources/extensions/gsd/tests/plugin-importer-live.test.ts src/tests/marketplace-discovery.test.ts",
     "test:coverage": "c8 --reporter=text --reporter=lcov --exclude=\"src/resources/extensions/gsd/tests/**\" --exclude=\"src/tests/**\" --exclude=\"scripts/**\" --exclude=\"native/**\" --exclude=\"node_modules/**\" --check-coverage --statements=40 --lines=40 --branches=20 --functions=20 node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --experimental-test-isolation=process --test src/resources/extensions/gsd/tests/*.test.ts src/resources/extensions/gsd/tests/*.test.mjs src/tests/*.test.ts src/resources/extensions/shared/tests/*.test.ts",
@@ -145,6 +145,7 @@
   },
   "optionalDependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.83",
+    "@openai/codex-sdk": "^0.118.0",
     "@gsd-build/engine-darwin-arm64": ">=2.10.2",
     "@gsd-build/engine-darwin-x64": ">=2.10.2",
     "@gsd-build/engine-linux-arm64-gnu": ">=2.10.2",

--- a/packages/pi-coding-agent/src/core/model-resolver.ts
+++ b/packages/pi-coding-agent/src/core/model-resolver.ts
@@ -11,13 +11,14 @@ import { DEFAULT_THINKING_LEVEL } from "./defaults.js";
 import type { ModelRegistry } from "./model-registry.js";
 
 /** Default model IDs for each known provider */
-const defaultModelPerProvider: Record<KnownProvider, string> = {
+const defaultModelPerProvider: Record<string, string> = {
 	"amazon-bedrock": "us.anthropic.claude-opus-4-6-v1",
 	anthropic: "claude-opus-4-6",
 	"anthropic-vertex": "claude-sonnet-4-6",
 	openai: "gpt-5.4",
 	"azure-openai-responses": "gpt-5.2",
 	"openai-codex": "gpt-5.4",
+	"codex-cli": "gpt-5.4",
 	google: "gemini-2.5-pro",
 	"google-gemini-cli": "gemini-2.5-pro",
 	"google-antigravity": "gemini-3.1-pro-high",
@@ -122,7 +123,7 @@ function buildFallbackModel(provider: string, modelId: string, availableModels: 
 	const providerModels = availableModels.filter((m) => m.provider === provider);
 	if (providerModels.length === 0) return undefined;
 
-	const defaultId = defaultModelPerProvider[provider as KnownProvider];
+	const defaultId = defaultModelPerProvider[provider];
 	const baseModel = defaultId
 		? (providerModels.find((m) => m.id === defaultId) ?? providerModels[0])
 		: providerModels[0];
@@ -537,7 +538,7 @@ export async function findInitialModel(options: {
 
 	if (availableModels.length > 0) {
 		// Try to find a default model from known providers
-		for (const provider of Object.keys(defaultModelPerProvider) as KnownProvider[]) {
+		for (const provider of Object.keys(defaultModelPerProvider)) {
 			const defaultId = defaultModelPerProvider[provider];
 			const match = availableModels.find((m) => m.provider === provider && m.id === defaultId);
 			if (match) {

--- a/packages/pi-coding-agent/src/modes/interactive/components/oauth-selector.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/components/oauth-selector.ts
@@ -6,11 +6,17 @@ import { theme } from "../theme/theme.js";
 import { DynamicBorder } from "./dynamic-border.js";
 
 /**
- * Component that renders an OAuth provider selector
+ * Component that renders a login/logout provider selector.
  */
+export interface AuthSelectorProvider {
+	id: string;
+	name: string;
+	authMode: "oauth" | "externalCli";
+}
+
 export class OAuthSelectorComponent extends Container {
 	private listContainer: Container;
-	private allProviders: OAuthProviderInterface[] = [];
+	private allProviders: AuthSelectorProvider[] = [];
 	private selectedIndex: number = 0;
 	private mode: "login" | "logout";
 	private authStorage: AuthStorage;
@@ -22,6 +28,7 @@ export class OAuthSelectorComponent extends Container {
 		authStorage: AuthStorage,
 		onSelect: (providerId: string) => void,
 		onCancel: () => void,
+		providers?: AuthSelectorProvider[],
 	) {
 		super();
 
@@ -31,7 +38,7 @@ export class OAuthSelectorComponent extends Container {
 		this.onCancelCallback = onCancel;
 
 		// Load all OAuth providers
-		this.loadProviders();
+		this.loadProviders(providers);
 
 		// Add top border
 		this.addChild(new DynamicBorder());
@@ -55,8 +62,17 @@ export class OAuthSelectorComponent extends Container {
 		this.updateList();
 	}
 
-	private loadProviders(): void {
-		this.allProviders = getOAuthProviders();
+	private loadProviders(providers?: AuthSelectorProvider[]): void {
+		if (providers) {
+			this.allProviders = providers;
+			return;
+		}
+
+		this.allProviders = getOAuthProviders().map((provider: OAuthProviderInterface) => ({
+			id: provider.id,
+			name: provider.name,
+			authMode: "oauth",
+		}));
 	}
 
 	private updateList(): void {
@@ -68,10 +84,12 @@ export class OAuthSelectorComponent extends Container {
 
 			const isSelected = i === this.selectedIndex;
 
-			// Check if user is logged in for this provider
+			// Check if user is configured for this provider
 			const credentials = this.authStorage.get(provider.id);
-			const isLoggedIn = credentials?.type === "oauth";
-			const statusIndicator = isLoggedIn ? theme.fg("success", " ✓ logged in") : "";
+			const isConfigured = provider.authMode === "oauth" ? credentials?.type === "oauth" : Boolean(credentials);
+			const statusIndicator = isConfigured
+				? theme.fg("success", provider.authMode === "oauth" ? " ✓ logged in" : " ✓ configured")
+				: "";
 
 			let line = "";
 			if (isSelected) {
@@ -89,12 +107,19 @@ export class OAuthSelectorComponent extends Container {
 		// Show "no providers" if empty
 		if (this.allProviders.length === 0) {
 			const message =
-				this.mode === "login" ? "No OAuth providers available" : "No OAuth providers logged in. Use /login first.";
+				this.mode === "login" ? "No login providers available" : "No providers logged in. Use /login first.";
 			this.listContainer.addChild(new TruncatedText(theme.fg("muted", `  ${message}`), 0, 0));
 		}
 	}
 
 	handleInput(keyData: string): void {
+		if (this.allProviders.length === 0) {
+			if (getEditorKeybindings().matches(keyData, "selectCancel")) {
+				this.onCancelCallback();
+			}
+			return;
+		}
+
 		const kb = getEditorKeybindings();
 		// Up arrow (wrap)
 		if (kb.matches(keyData, "selectUp")) {

--- a/packages/pi-coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/interactive-mode.ts
@@ -80,7 +80,7 @@ import { FooterComponent } from "./components/footer.js";
 import { appKey, appKeyHint, editorKey, formatKeyForDisplay, keyHint, rawKeyHint } from "./components/keybinding-hints.js";
 import { LoginDialogComponent } from "./components/login-dialog.js";
 import { ModelSelectorComponent, providerDisplayName } from "./components/model-selector.js";
-import { OAuthSelectorComponent } from "./components/oauth-selector.js";
+import { type AuthSelectorProvider, OAuthSelectorComponent } from "./components/oauth-selector.js";
 import { ProviderManagerComponent } from "./components/provider-manager.js";
 import { ScopedModelsSelectorComponent } from "./components/scoped-models-selector.js";
 import { SessionSelectorComponent } from "./components/session-selector.js";
@@ -130,6 +130,16 @@ function isExpandable(obj: unknown): obj is Expandable {
 type CompactionQueuedMessage = {
 	text: string;
 	mode: "steer" | "followUp";
+};
+
+const LOCAL_CLI_PROVIDER_SELECTOR_NAMES: Record<string, string> = {
+	"claude-code": "Use Claude Code CLI (recommended)",
+	"codex-cli": "Use Codex CLI (recommended)",
+};
+
+const LOCAL_CLI_PROVIDER_STATUS_NAMES: Record<string, string> = {
+	"claude-code": "Claude Code CLI",
+	"codex-cli": "Codex CLI",
 };
 
 /**
@@ -3501,15 +3511,10 @@ export class InteractiveMode {
 	}
 
 	private async showOAuthSelector(mode: "login" | "logout"): Promise<void> {
-		if (mode === "logout") {
-			const providers = this.session.modelRegistry.authStorage.list();
-			const loggedInProviders = providers.filter(
-				(p) => this.session.modelRegistry.authStorage.get(p)?.type === "oauth",
-			);
-			if (loggedInProviders.length === 0) {
-				this.showStatus("No OAuth providers logged in. Use /login first.");
-				return;
-			}
+		const providers = this.getAuthSelectorProviders(mode);
+		if (providers.length === 0) {
+			this.showStatus(mode === "login" ? "No login providers available." : "No providers logged in. Use /login first.");
+			return;
 		}
 
 		this.showSelector((done) => {
@@ -3524,38 +3529,39 @@ export class InteractiveMode {
 					// when the user cancels the login dialog (#821).
 					const handleAsync = async () => {
 						if (mode === "login") {
-							await this.showLoginDialog(providerId);
-						} else {
-						// Logout flow
-						const providerInfo = this.session.modelRegistry.authStorage
-							.getOAuthProviders()
-							.find((p) => p.id === providerId);
-						const providerName = providerInfo?.name || providerId;
-
-						try {
-							this.session.modelRegistry.authStorage.logout(providerId);
-							this.session.modelRegistry.refresh();
-							await this.updateAvailableProviderCount();
-
-							// Auto-switch model if current model belongs to the logged-out provider
-							const currentModel = this.session.model;
-							if (currentModel?.provider === providerId) {
-								try {
-									const available = this.session.modelRegistry.getAvailable();
-									const fallback = available.find((m) => m.provider !== providerId);
-									if (fallback) {
-										await this.session.setModel(fallback);
-									}
-								} catch {
-									// Model switch failed — user can manually switch via /model
-								}
+							if (this.session.modelRegistry.getProviderAuthMode(providerId) === "externalCli") {
+								await this.loginExternalCliProvider(providerId);
+							} else {
+								await this.showLoginDialog(providerId);
 							}
+						} else {
+							// Logout flow
+							const providerName = this.getAuthProviderStatusName(providerId);
 
-							this.showStatus(`Logged out of ${providerName}`);
-						} catch (error: unknown) {
-							this.showError(`Logout failed: ${error instanceof Error ? error.message : String(error)}`);
+							try {
+								this.session.modelRegistry.authStorage.logout(providerId);
+								this.session.modelRegistry.refresh();
+								await this.updateAvailableProviderCount();
+
+								// Auto-switch model if current model belongs to the logged-out provider
+								const currentModel = this.session.model;
+								if (currentModel?.provider === providerId) {
+									try {
+										const available = this.session.modelRegistry.getAvailable();
+										const fallback = available.find((m) => m.provider !== providerId);
+										if (fallback) {
+											await this.session.setModel(fallback);
+										}
+									} catch {
+										// Model switch failed — user can manually switch via /model
+									}
+								}
+
+								this.showStatus(`Logged out of ${providerName}`);
+							} catch (error: unknown) {
+								this.showError(`Logout failed: ${error instanceof Error ? error.message : String(error)}`);
+							}
 						}
-					}
 					};
 					handleAsync().catch(() => {
 						// Swallow — showLoginDialog already handles its own errors.
@@ -3566,9 +3572,83 @@ export class InteractiveMode {
 					done();
 					this.ui.requestRender();
 				},
+				providers,
 			);
 			return { component: selector, focus: selector };
 		});
+	}
+
+	private getExternalCliAuthProviders(mode: "login" | "logout"): AuthSelectorProvider[] {
+		if (mode === "logout") return [];
+
+		const authStorage = this.session.modelRegistry.authStorage;
+		const providerIds = [...new Set(this.session.modelRegistry.getAll().map((model) => model.provider))]
+			.filter((providerId) => this.session.modelRegistry.getProviderAuthMode(providerId) === "externalCli");
+
+		return providerIds
+			.filter((providerId) =>
+				mode === "login"
+					? this.session.modelRegistry.isProviderRequestReady(providerId)
+					: authStorage.hasAuth(providerId),
+			)
+			.map((providerId) => ({
+				id: providerId,
+				name: LOCAL_CLI_PROVIDER_SELECTOR_NAMES[providerId] ?? providerDisplayName(providerId),
+				authMode: "externalCli" as const,
+			}));
+	}
+
+	private getAuthSelectorProviders(mode: "login" | "logout"): AuthSelectorProvider[] {
+		const authStorage = this.session.modelRegistry.authStorage;
+		const oauthProviders = authStorage
+			.getOAuthProviders()
+			.filter((provider) => mode === "login" || authStorage.get(provider.id)?.type === "oauth")
+			.map((provider) => ({
+				id: provider.id,
+				name: provider.name,
+				authMode: "oauth" as const,
+			}));
+
+		return [...this.getExternalCliAuthProviders(mode), ...oauthProviders];
+	}
+
+	private getAuthProviderStatusName(providerId: string): string {
+		const oauthProvider = this.session.modelRegistry.authStorage.getOAuthProviders().find((provider) => provider.id === providerId);
+		if (oauthProvider) return oauthProvider.name;
+		return LOCAL_CLI_PROVIDER_STATUS_NAMES[providerId] ?? providerDisplayName(providerId);
+	}
+
+	private async loginExternalCliProvider(providerId: string): Promise<void> {
+		const providerName = this.getAuthProviderStatusName(providerId);
+
+		if (!this.session.modelRegistry.isProviderRequestReady(providerId)) {
+			this.showError(`${providerName} is not ready. Make sure the local CLI is installed and authenticated.`);
+			return;
+		}
+
+		this.session.modelRegistry.authStorage.set(providerId, { type: "api_key", key: "cli" });
+		this.session.modelRegistry.refresh();
+		await this.updateAvailableProviderCount();
+
+		try {
+			const currentModel = this.session.model;
+			if (currentModel) {
+				const currentKey = await this.session.modelRegistry.getApiKey(currentModel);
+				if (!currentKey) {
+					const available = this.session.modelRegistry.getAvailable();
+					const newProviderModel = available.find((model) => model.provider === providerId);
+					if (newProviderModel) {
+						await this.session.setModel(newProviderModel);
+					} else if (available.length > 0) {
+						await this.session.setModel(available[0]);
+					}
+				}
+			}
+		} catch {
+			// Model switch failed — user can manually switch via /model
+		}
+
+		this.showStatus(`Configured ${providerName}. Credentials saved to ${getAuthPath()}`);
 	}
 
 	private async showLoginDialog(providerId: string): Promise<void> {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -206,7 +206,7 @@ if (packageCommand.handled) {
 if (cliFlags.messages[0] === 'config') {
   const authStorage = AuthStorage.create(authFilePath)
   loadStoredEnvKeys(authStorage)
-  await runOnboarding(authStorage)
+  await runOnboarding(authStorage, { launchAfter: false })
   process.exit(0)
 }
 

--- a/src/codex-cli-check.ts
+++ b/src/codex-cli-check.ts
@@ -1,0 +1,37 @@
+// GSD2 — Codex CLI binary detection for onboarding
+// Lightweight check used at onboarding time (before extensions load).
+// The full readiness check with caching lives in the codex-cli extension.
+
+import { execFileSync } from "node:child_process";
+
+/**
+ * Check if the `codex` binary is installed (regardless of auth state).
+ */
+export function isCodexBinaryInstalled(): boolean {
+	try {
+		execFileSync("codex", ["--version"], { timeout: 5_000, stdio: "pipe" });
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Check if the `codex` CLI is installed AND authenticated.
+ */
+export function isCodexCliReady(): boolean {
+	try {
+		execFileSync("codex", ["--version"], { timeout: 5_000, stdio: "pipe" });
+	} catch {
+		return false;
+	}
+
+	try {
+		const output = execFileSync("codex", ["login", "status"], { timeout: 5_000, stdio: "pipe" })
+			.toString()
+			.toLowerCase();
+		return !(/not logged in|logged out|unauthenticated|not authenticated/i.test(output));
+	} catch {
+		return false;
+	}
+}

--- a/src/onboarding.ts
+++ b/src/onboarding.ts
@@ -17,6 +17,7 @@ import type { AuthStorage } from '@gsd/pi-coding-agent'
 import { renderLogo } from './logo.js'
 import { agentDir } from './app-paths.js'
 import { isClaudeCliReady } from './claude-cli-check.js'
+import { isCodexCliReady } from './codex-cli-check.js'
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -66,6 +67,7 @@ const LLM_PROVIDER_IDS = [
   'anthropic',
   'anthropic-vertex',
   'claude-code',
+  'codex-cli',
   'openai',
   'github-copilot',
   'openai-codex',
@@ -175,7 +177,11 @@ export function shouldRunOnboarding(authStorage: AuthStorage, settingsDefaultPro
  * All steps are skippable. All errors are recoverable.
  * Writes status to stderr during execution.
  */
-export async function runOnboarding(authStorage: AuthStorage): Promise<void> {
+export async function runOnboarding(
+  authStorage: AuthStorage,
+  options: { launchAfter?: boolean } = {},
+): Promise<void> {
+  const launchAfter = options.launchAfter ?? true
   let p: ClackModule
   let pc: PicoModule
   try {
@@ -274,7 +280,7 @@ export async function runOnboarding(authStorage: AuthStorage): Promise<void> {
   }
 
   p.note(summaryLines.join('\n'), 'Setup complete')
-  p.outro(pc.dim('Launching GSD...'))
+  p.outro(pc.dim(launchAfter ? 'Launching GSD...' : 'Setup saved.'))
 }
 
 // ─── LLM Authentication Step ──────────────────────────────────────────────────
@@ -303,6 +309,12 @@ async function runLlmStep(p: ClackModule, pc: PicoModule, authStorage: AuthStora
     )
   }
 
+  if (isCodexCliReady()) {
+    authOptions.push(
+      { value: 'codex-cli', label: 'Use Codex CLI', hint: 'recommended — uses your existing local Codex login' },
+    )
+  }
+
   authOptions.push(
     { value: 'browser', label: 'Sign in with your browser', hint: 'GitHub Copilot, ChatGPT, Google, etc.' },
     { value: 'api-key', label: 'Paste an API key', hint: 'from your provider dashboard' },
@@ -323,6 +335,13 @@ async function runLlmStep(p: ClackModule, pc: PicoModule, authStorage: AuthStora
     p.log.info('Your Claude subscription will be used for inference. No API key needed.')
     // Store sentinel so hasAuth('claude-code') returns true on future boots
     authStorage.set('claude-code', { type: 'api_key', key: 'cli' })
+    return true
+  }
+
+  if (method === 'codex-cli') {
+    p.log.success('Codex CLI detected — routing through local CLI')
+    p.log.info('Your local Codex login will be used for inference. No API key needed.')
+    authStorage.set('codex-cli', { type: 'api_key', key: 'cli' })
     return true
   }
 
@@ -1020,4 +1039,3 @@ async function runDiscordChannelStep(p: ClackModule, pc: PicoModule, token: stri
   p.log.success(`Discord channel: ${pc.green(channelName ? `#${channelName}` : channelId)}`)
   return channelName ?? null
 }
-

--- a/src/pi-migration.ts
+++ b/src/pi-migration.ts
@@ -15,6 +15,7 @@ const PI_SETTINGS_PATH = join(homedir(), '.pi', 'agent', 'settings.json')
 const LLM_PROVIDER_IDS = [
   'anthropic',
   'openai',
+  'codex-cli',
   'github-copilot',
   'openai-codex',
   'google-gemini-cli',

--- a/src/resources/extensions/codex-cli/index.ts
+++ b/src/resources/extensions/codex-cli/index.ts
@@ -1,0 +1,25 @@
+/**
+ * Codex CLI Provider Extension
+ *
+ * Registers a model provider that delegates inference to the user's
+ * locally-installed Codex CLI via the official TypeScript SDK.
+ *
+ * Users can keep the existing openai-codex OAuth provider and opt into this
+ * separate local CLI route when they prefer Codex's native agent loop.
+ */
+
+import type { ExtensionAPI } from "@gsd/pi-coding-agent";
+import { CODEX_CLI_MODELS } from "./models.js";
+import { isCodexCliReady } from "./readiness.js";
+import { streamViaCodexCli } from "./stream-adapter.js";
+
+export default function codexCli(pi: ExtensionAPI) {
+	pi.registerProvider("codex-cli", {
+		authMode: "externalCli",
+		api: "openai-codex-responses",
+		baseUrl: "local://codex-cli",
+		isReady: isCodexCliReady,
+		streamSimple: streamViaCodexCli,
+		models: CODEX_CLI_MODELS,
+	});
+}

--- a/src/resources/extensions/codex-cli/models.ts
+++ b/src/resources/extensions/codex-cli/models.ts
@@ -1,0 +1,12 @@
+import { getModels, type Api, type Model } from "@gsd/pi-ai";
+
+const ZERO_COST = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
+
+export const CODEX_CLI_MODELS: Model<Api>[] = getModels("openai-codex").map((model) => ({
+	...model,
+	provider: "codex-cli",
+	baseUrl: "local://codex-cli",
+	name: `${model.name} (via Codex CLI)`,
+	input: ["text"],
+	cost: { ...ZERO_COST },
+}));

--- a/src/resources/extensions/codex-cli/package.json
+++ b/src/resources/extensions/codex-cli/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@gsd/codex-cli",
+  "private": true,
+  "version": "1.0.0",
+  "type": "module",
+  "pi": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/src/resources/extensions/codex-cli/readiness.ts
+++ b/src/resources/extensions/codex-cli/readiness.ts
@@ -1,0 +1,75 @@
+/**
+ * Readiness check for the Codex CLI provider.
+ *
+ * Verifies the `codex` binary is installed, responsive, AND authenticated.
+ * Results are cached for 30 seconds to avoid shelling out on every
+ * model-availability check.
+ */
+
+import { execFileSync } from "node:child_process";
+
+type CodexCommandRunner = (args: string[]) => Buffer;
+
+let commandRunnerForTests: CodexCommandRunner | null = null;
+let cachedBinaryPresent: boolean | null = null;
+let cachedAuthed: boolean | null = null;
+let lastCheckMs = 0;
+const CHECK_INTERVAL_MS = 30_000;
+
+function runCodex(args: string[]): Buffer {
+	if (commandRunnerForTests) {
+		return commandRunnerForTests(args);
+	}
+	return execFileSync("codex", args, { timeout: 5_000, stdio: "pipe" });
+}
+
+function refreshCache(): void {
+	const now = Date.now();
+	if (cachedBinaryPresent !== null && now - lastCheckMs < CHECK_INTERVAL_MS) {
+		return;
+	}
+
+	lastCheckMs = now;
+
+	try {
+		runCodex(["--version"]);
+		cachedBinaryPresent = true;
+	} catch {
+		cachedBinaryPresent = false;
+		cachedAuthed = false;
+		return;
+	}
+
+	try {
+		const output = runCodex(["login", "status"]).toString().toLowerCase();
+		cachedAuthed = !(/not logged in|logged out|unauthenticated|not authenticated/i.test(output));
+	} catch {
+		cachedAuthed = false;
+	}
+}
+
+export function isCodexBinaryPresent(): boolean {
+	refreshCache();
+	return cachedBinaryPresent ?? false;
+}
+
+export function isCodexCliAuthed(): boolean {
+	refreshCache();
+	return (cachedBinaryPresent ?? false) && (cachedAuthed ?? false);
+}
+
+export function isCodexCliReady(): boolean {
+	refreshCache();
+	return (cachedBinaryPresent ?? false) && (cachedAuthed ?? false);
+}
+
+export function clearReadinessCache(): void {
+	cachedBinaryPresent = null;
+	cachedAuthed = null;
+	lastCheckMs = 0;
+}
+
+export function setCodexCommandRunnerForTests(runner?: CodexCommandRunner): void {
+	commandRunnerForTests = runner ?? null;
+	clearReadinessCache();
+}

--- a/src/resources/extensions/codex-cli/sdk-types.ts
+++ b/src/resources/extensions/codex-cli/sdk-types.ts
@@ -1,0 +1,137 @@
+/**
+ * Lightweight type mirrors for @openai/codex-sdk.
+ *
+ * These stubs allow the extension to compile without a hard dependency on
+ * `@openai/codex-sdk`. The real SDK is imported dynamically at runtime in
+ * stream-adapter.ts.
+ */
+
+export type CodexApprovalMode = "never" | "on-request" | "on-failure" | "untrusted";
+export type CodexSandboxMode = "read-only" | "workspace-write" | "danger-full-access";
+export type CodexReasoningEffort = "minimal" | "low" | "medium" | "high" | "xhigh";
+
+export interface CodexUsage {
+	input_tokens: number;
+	cached_input_tokens: number;
+	output_tokens: number;
+}
+
+export interface CodexAgentMessageItem {
+	id: string;
+	type: "agent_message";
+	text: string;
+}
+
+export interface CodexReasoningItem {
+	id: string;
+	type: "reasoning";
+	text: string;
+}
+
+export interface CodexCommandExecutionItem {
+	id: string;
+	type: "command_execution";
+	command: string;
+	aggregated_output: string;
+	exit_code?: number;
+	status: "in_progress" | "completed" | "failed";
+}
+
+export interface CodexFileChangeItem {
+	id: string;
+	type: "file_change";
+	changes: Array<{ path: string; kind: "add" | "delete" | "update" }>;
+	status: "completed" | "failed";
+}
+
+export interface CodexMcpToolCallItem {
+	id: string;
+	type: "mcp_tool_call";
+	server: string;
+	tool: string;
+	arguments: unknown;
+	result?: unknown;
+	error?: { message: string };
+	status: "in_progress" | "completed" | "failed";
+}
+
+export interface CodexWebSearchItem {
+	id: string;
+	type: "web_search";
+	query: string;
+}
+
+export interface CodexTodoListItem {
+	id: string;
+	type: "todo_list";
+	items: Array<{ text: string; completed: boolean }>;
+}
+
+export interface CodexErrorItem {
+	id: string;
+	type: "error";
+	message: string;
+}
+
+export type CodexThreadItem =
+	| CodexAgentMessageItem
+	| CodexReasoningItem
+	| CodexCommandExecutionItem
+	| CodexFileChangeItem
+	| CodexMcpToolCallItem
+	| CodexWebSearchItem
+	| CodexTodoListItem
+	| CodexErrorItem;
+
+export type CodexThreadEvent =
+	| { type: "thread.started"; thread_id: string }
+	| { type: "turn.started" }
+	| { type: "turn.completed"; usage: CodexUsage }
+	| { type: "turn.failed"; error: { message: string } }
+	| { type: "item.started"; item: CodexThreadItem }
+	| { type: "item.updated"; item: CodexThreadItem }
+	| { type: "item.completed"; item: CodexThreadItem }
+	| { type: "error"; message: string };
+
+export interface CodexThreadOptions {
+	model?: string;
+	sandboxMode?: CodexSandboxMode;
+	workingDirectory?: string;
+	skipGitRepoCheck?: boolean;
+	modelReasoningEffort?: CodexReasoningEffort;
+	networkAccessEnabled?: boolean;
+	approvalPolicy?: CodexApprovalMode;
+	additionalDirectories?: string[];
+}
+
+export interface CodexTurnOptions {
+	signal?: AbortSignal;
+	outputSchema?: unknown;
+}
+
+export interface CodexThreadLike {
+	runStreamed(
+		input: string,
+		turnOptions?: CodexTurnOptions,
+	): Promise<{ events: AsyncGenerator<CodexThreadEvent> }>;
+}
+
+export interface CodexClientOptions {
+	codexPathOverride?: string;
+	baseUrl?: string;
+	apiKey?: string;
+	config?: Record<string, unknown>;
+	env?: Record<string, string>;
+}
+
+export interface CodexClientLike {
+	startThread(options?: CodexThreadOptions): CodexThreadLike;
+}
+
+export interface CodexConstructor {
+	new (options?: CodexClientOptions): CodexClientLike;
+}
+
+export interface CodexSdkModule {
+	Codex: CodexConstructor;
+}

--- a/src/resources/extensions/codex-cli/stream-adapter.ts
+++ b/src/resources/extensions/codex-cli/stream-adapter.ts
@@ -1,0 +1,439 @@
+/**
+ * Stream adapter: bridges the Codex SDK into GSD's streamSimple contract.
+ *
+ * The SDK runs a full Codex turn and exposes structured thread events.
+ * This adapter maps the stable subset we care about today — reasoning,
+ * assistant text, usage, and terminal errors — into AssistantMessageEvents.
+ */
+
+import type {
+	Api,
+	AssistantMessage,
+	AssistantMessageEvent,
+	AssistantMessageEventStream,
+	Context,
+	Model,
+	SimpleStreamOptions,
+	TextContent,
+	ThinkingContent,
+	Usage,
+} from "@gsd/pi-ai";
+import { EventStream } from "@gsd/pi-ai";
+import { execSync } from "node:child_process";
+import type {
+	CodexClientLike,
+	CodexSdkModule,
+	CodexThreadEvent,
+	CodexThreadItem,
+	CodexThreadOptions,
+	CodexUsage,
+} from "./sdk-types.js";
+
+const ZERO_USAGE: Usage = {
+	input: 0,
+	output: 0,
+	cacheRead: 0,
+	cacheWrite: 0,
+	totalTokens: 0,
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+};
+
+type RenderableKind = "text" | "thinking";
+type RenderableEvent = Extract<CodexThreadEvent, { type: "item.started" | "item.updated" | "item.completed" }>;
+
+interface RenderableState {
+	contentIndex: number;
+	kind: RenderableKind;
+	text: string;
+	ended: boolean;
+}
+
+let cachedCodexPath: string | null = null;
+let codexPathOverrideForTests: string | null = null;
+let sdkLoaderForTests: (() => Promise<CodexSdkModule>) | null = null;
+
+function createStream(): AssistantMessageEventStream {
+	return new EventStream<AssistantMessageEvent, AssistantMessage>(
+		(event) => event.type === "done" || event.type === "error",
+		(event) => {
+			if (event.type === "done") return event.message;
+			if (event.type === "error") return event.error;
+			throw new Error("Unexpected event type for final result");
+		},
+	) as AssistantMessageEventStream;
+}
+
+export function getCodexLookupCommand(platform: NodeJS.Platform = process.platform): string {
+	return platform === "win32" ? "where codex" : "which codex";
+}
+
+export function parseCodexLookupOutput(output: Buffer | string): string {
+	return output
+		.toString()
+		.trim()
+		.split(/\r?\n/)[0] ?? "";
+}
+
+function getCodexPath(): string {
+	if (codexPathOverrideForTests) return codexPathOverrideForTests;
+	if (cachedCodexPath) return cachedCodexPath;
+	try {
+		cachedCodexPath = parseCodexLookupOutput(
+			execSync(getCodexLookupCommand(), { timeout: 5_000, stdio: "pipe" }),
+		);
+	} catch {
+		cachedCodexPath = "codex";
+	}
+	return cachedCodexPath;
+}
+
+async function loadCodexSdk(): Promise<CodexSdkModule> {
+	if (sdkLoaderForTests) {
+		return sdkLoaderForTests();
+	}
+	const sdkModule = "@openai/codex-sdk";
+	return import(/* webpackIgnore: true */ sdkModule) as Promise<CodexSdkModule>;
+}
+
+function extractMessageText(msg: { role: string; content: unknown }): string {
+	if (typeof msg.content === "string") return msg.content;
+	if (Array.isArray(msg.content)) {
+		const textParts = msg.content
+			.filter((part: any) => part.type === "text")
+			.map((part: any) => part.text ?? "");
+		if (textParts.length > 0) return textParts.join("\n");
+	}
+	return "";
+}
+
+export function buildPromptFromContext(context: Context): string {
+	const parts: string[] = [];
+
+	if (context.systemPrompt) {
+		parts.push(`[System]\n${context.systemPrompt}`);
+	}
+
+	for (const msg of context.messages) {
+		const text = extractMessageText(msg);
+		if (!text) continue;
+
+		const label = msg.role === "user" ? "User" : msg.role === "assistant" ? "Assistant" : "System";
+		parts.push(`[${label}]\n${text}`);
+	}
+
+	return parts.join("\n\n");
+}
+
+export function buildCodexClientOptions() {
+	return {
+		codexPathOverride: getCodexPath(),
+	};
+}
+
+export function buildThreadOptions(
+	model: Model<any>,
+	options?: SimpleStreamOptions,
+): CodexThreadOptions {
+	return {
+		model: model.id,
+		sandboxMode: "danger-full-access",
+		workingDirectory: process.cwd(),
+		skipGitRepoCheck: true,
+		approvalPolicy: "never",
+		...(options?.reasoning ? { modelReasoningEffort: options.reasoning } : {}),
+	};
+}
+
+export function mapUsage(usage: CodexUsage): Usage {
+	return {
+		input: usage.input_tokens,
+		output: usage.output_tokens,
+		cacheRead: usage.cached_input_tokens,
+		cacheWrite: 0,
+		totalTokens: usage.input_tokens + usage.cached_input_tokens + usage.output_tokens,
+		cost: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			total: 0,
+		},
+	};
+}
+
+function createInitialMessage(modelId: string): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [],
+		api: "openai-codex-responses" as Api,
+		provider: "codex-cli",
+		model: modelId,
+		usage: { ...ZERO_USAGE },
+		stopReason: "stop",
+		timestamp: Date.now(),
+	};
+}
+
+function buildFailureMessage(
+	output: AssistantMessage,
+	errorMsg: string,
+	reason: "error" | "aborted" = "error",
+): AssistantMessage {
+	if (output.content.length > 0) {
+		return {
+			...output,
+			content: output.content.map((block) => ({ ...block })) as AssistantMessage["content"],
+			stopReason: reason,
+			errorMessage: errorMsg,
+			timestamp: Date.now(),
+		};
+	}
+
+	return {
+		...createInitialMessage(output.model),
+		content: [{ type: "text", text: `Codex CLI error: ${errorMsg}` }],
+		stopReason: reason,
+		errorMessage: errorMsg,
+		timestamp: Date.now(),
+	};
+}
+
+export function makeStreamExhaustedErrorMessage(output: AssistantMessage): AssistantMessage {
+	return buildFailureMessage(output, "stream_exhausted_without_result");
+}
+
+function getRenderableItem(item: CodexThreadItem): { id: string; kind: RenderableKind; text: string } | null {
+	if (item.type === "agent_message") {
+		return { id: item.id, kind: "text", text: item.text };
+	}
+	if (item.type === "reasoning") {
+		return { id: item.id, kind: "thinking", text: item.text };
+	}
+	return null;
+}
+
+function createContentBlock(kind: RenderableKind): TextContent | ThinkingContent {
+	return kind === "text" ? { type: "text", text: "" } : { type: "thinking", thinking: "" };
+}
+
+function setBlockText(output: AssistantMessage, state: RenderableState, text: string): void {
+	const block = output.content[state.contentIndex];
+	if (block.type === "text") {
+		block.text = text;
+	} else if (block.type === "thinking") {
+		block.thinking = text;
+	}
+	state.text = text;
+}
+
+function ensureRenderableState(
+	output: AssistantMessage,
+	stream: AssistantMessageEventStream,
+	states: Map<string, RenderableState>,
+	item: { id: string; kind: RenderableKind },
+): RenderableState {
+	const existing = states.get(item.id);
+	if (existing) return existing;
+
+	const contentIndex = output.content.length;
+	output.content.push(createContentBlock(item.kind));
+	const state: RenderableState = {
+		contentIndex,
+		kind: item.kind,
+		text: "",
+		ended: false,
+	};
+	states.set(item.id, state);
+
+	stream.push(
+		item.kind === "text"
+			? { type: "text_start", contentIndex, partial: output }
+			: { type: "thinking_start", contentIndex, partial: output },
+	);
+	return state;
+}
+
+function emitAppendDelta(
+	output: AssistantMessage,
+	stream: AssistantMessageEventStream,
+	state: RenderableState,
+	nextText: string,
+): void {
+	if (nextText === state.text) return;
+
+	if (nextText.startsWith(state.text)) {
+		const delta = nextText.slice(state.text.length);
+		setBlockText(output, state, nextText);
+		stream.push(
+			state.kind === "text"
+				? { type: "text_delta", contentIndex: state.contentIndex, delta, partial: output }
+				: { type: "thinking_delta", contentIndex: state.contentIndex, delta, partial: output },
+		);
+		return;
+	}
+
+	setBlockText(output, state, nextText);
+}
+
+function closeRenderableState(
+	output: AssistantMessage,
+	stream: AssistantMessageEventStream,
+	state: RenderableState,
+): void {
+	if (state.ended) return;
+	state.ended = true;
+	stream.push(
+		state.kind === "text"
+			? {
+					type: "text_end",
+					contentIndex: state.contentIndex,
+					content: state.text,
+					partial: output,
+				}
+			: {
+					type: "thinking_end",
+					contentIndex: state.contentIndex,
+					content: state.text,
+					partial: output,
+				},
+	);
+}
+
+function handleRenderableEvent(
+	output: AssistantMessage,
+	stream: AssistantMessageEventStream,
+	states: Map<string, RenderableState>,
+	event: RenderableEvent,
+): void {
+	const renderable = getRenderableItem(event.item);
+	if (!renderable) return;
+
+	const state = ensureRenderableState(output, stream, states, renderable);
+	emitAppendDelta(output, stream, state, renderable.text);
+
+	if (event.type === "item.completed") {
+		closeRenderableState(output, stream, state);
+	}
+}
+
+function closeOpenStates(
+	output: AssistantMessage,
+	stream: AssistantMessageEventStream,
+	states: Map<string, RenderableState>,
+): void {
+	for (const state of states.values()) {
+		closeRenderableState(output, stream, state);
+	}
+}
+
+function isAbortError(error: unknown, signal?: AbortSignal): boolean {
+	if (signal?.aborted) return true;
+	const message = error instanceof Error ? error.message : String(error);
+	return /aborted|aborterror|request was aborted/i.test(message);
+}
+
+function normalizeSdkLoadError(error: unknown): string {
+	const message = error instanceof Error ? error.message : String(error);
+	if (/Cannot find package ['"]@openai\/codex-sdk['"]|ERR_MODULE_NOT_FOUND/.test(message)) {
+		return "Codex CLI provider requires the optional dependency @openai/codex-sdk. Reinstall GSD with optional dependencies enabled.";
+	}
+	return message;
+}
+
+export function streamViaCodexCli(
+	model: Model<any>,
+	context: Context,
+	options?: SimpleStreamOptions,
+): AssistantMessageEventStream {
+	const stream = createStream();
+	void pumpCodexMessages(model, context, options, stream);
+	return stream;
+}
+
+async function pumpCodexMessages(
+	model: Model<any>,
+	context: Context,
+	options: SimpleStreamOptions | undefined,
+	stream: AssistantMessageEventStream,
+): Promise<void> {
+	const output = createInitialMessage(model.id);
+	const renderableStates = new Map<string, RenderableState>();
+	let sawTerminalEvent = false;
+	let turnFailureMessage: string | null = null;
+
+	stream.push({ type: "start", partial: output });
+
+	try {
+		if (options?.signal?.aborted) {
+			const aborted = buildFailureMessage(output, "Request was aborted", "aborted");
+			stream.push({ type: "error", reason: "aborted", error: aborted });
+			stream.end(aborted);
+			return;
+		}
+
+		const sdk = await loadCodexSdk();
+		const client: CodexClientLike = new sdk.Codex(buildCodexClientOptions());
+		const thread = client.startThread(buildThreadOptions(model, options));
+		const prompt = buildPromptFromContext(context);
+		const { events } = await thread.runStreamed(prompt, { signal: options?.signal });
+
+		for await (const event of events) {
+			switch (event.type) {
+				case "item.started":
+				case "item.updated":
+				case "item.completed":
+					handleRenderableEvent(output, stream, renderableStates, event);
+					break;
+				case "turn.completed":
+					output.usage = mapUsage(event.usage);
+					sawTerminalEvent = true;
+					break;
+				case "turn.failed":
+					turnFailureMessage = event.error.message;
+					sawTerminalEvent = true;
+					break;
+				case "error":
+					turnFailureMessage = event.message;
+					sawTerminalEvent = true;
+					break;
+				default:
+					break;
+			}
+		}
+
+		closeOpenStates(output, stream, renderableStates);
+
+		if (turnFailureMessage) {
+			const errorReason = isAbortError(turnFailureMessage, options?.signal) ? "aborted" : "error";
+			const failed = buildFailureMessage(output, turnFailureMessage, errorReason);
+			stream.push({ type: "error", reason: errorReason, error: failed });
+			stream.end(failed);
+			return;
+		}
+
+		if (!sawTerminalEvent) {
+			const exhausted = makeStreamExhaustedErrorMessage(output);
+			stream.push({ type: "error", reason: "error", error: exhausted });
+			stream.end(exhausted);
+			return;
+		}
+
+		stream.push({ type: "done", reason: "stop", message: output });
+		stream.end(output);
+	} catch (error) {
+		closeOpenStates(output, stream, renderableStates);
+		const errorReason = isAbortError(error, options?.signal) ? "aborted" : "error";
+		const failure = buildFailureMessage(output, normalizeSdkLoadError(error), errorReason);
+		stream.push({ type: "error", reason: errorReason, error: failure });
+		stream.end(failure);
+	}
+}
+
+export function setCodexSdkLoaderForTests(loader?: (() => Promise<CodexSdkModule>) | null): void {
+	sdkLoaderForTests = loader ?? null;
+}
+
+export function setCodexPathForTests(path?: string | null): void {
+	codexPathOverrideForTests = path ?? null;
+	cachedCodexPath = null;
+}

--- a/src/resources/extensions/codex-cli/tests/readiness.test.ts
+++ b/src/resources/extensions/codex-cli/tests/readiness.test.ts
@@ -1,0 +1,66 @@
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import {
+	clearReadinessCache,
+	isCodexBinaryPresent,
+	isCodexCliAuthed,
+	isCodexCliReady,
+	setCodexCommandRunnerForTests,
+} from "../readiness.ts";
+
+describe("codex-cli readiness", () => {
+	test("reports ready when binary exists and login status succeeds", () => {
+		setCodexCommandRunnerForTests((args) => {
+			if (args[0] === "--version") return Buffer.from("codex 0.1.0");
+			if (args[0] === "login" && args[1] === "status") return Buffer.from("Logged in using ChatGPT");
+			throw new Error(`unexpected args: ${args.join(" ")}`);
+		});
+
+		assert.equal(isCodexBinaryPresent(), true);
+		assert.equal(isCodexCliAuthed(), true);
+		assert.equal(isCodexCliReady(), true);
+	});
+
+	test("reports not authenticated when login status fails", () => {
+		setCodexCommandRunnerForTests((args) => {
+			if (args[0] === "--version") return Buffer.from("codex 0.1.0");
+			if (args[0] === "login" && args[1] === "status") {
+				throw new Error("not logged in");
+			}
+			throw new Error(`unexpected args: ${args.join(" ")}`);
+		});
+
+		assert.equal(isCodexBinaryPresent(), true);
+		assert.equal(isCodexCliAuthed(), false);
+		assert.equal(isCodexCliReady(), false);
+	});
+
+	test("caches command results for the check window", () => {
+		let calls = 0;
+		setCodexCommandRunnerForTests((args) => {
+			calls += 1;
+			if (args[0] === "--version") return Buffer.from("codex 0.1.0");
+			if (args[0] === "login" && args[1] === "status") return Buffer.from("Logged in using ChatGPT");
+			throw new Error(`unexpected args: ${args.join(" ")}`);
+		});
+
+		assert.equal(isCodexCliReady(), true);
+		assert.equal(isCodexCliReady(), true);
+		assert.equal(calls, 2, "binary check and auth check should each run once while cached");
+	});
+
+	test("clearReadinessCache forces the next check to re-run commands", () => {
+		let calls = 0;
+		setCodexCommandRunnerForTests((args) => {
+			calls += 1;
+			if (args[0] === "--version") return Buffer.from("codex 0.1.0");
+			if (args[0] === "login" && args[1] === "status") return Buffer.from("Logged in using ChatGPT");
+			throw new Error(`unexpected args: ${args.join(" ")}`);
+		});
+
+		assert.equal(isCodexCliReady(), true);
+		clearReadinessCache();
+		assert.equal(isCodexCliReady(), true);
+		assert.equal(calls, 4, "clearReadinessCache should invalidate both cached checks");
+	});
+});

--- a/src/resources/extensions/codex-cli/tests/stream-adapter.test.ts
+++ b/src/resources/extensions/codex-cli/tests/stream-adapter.test.ts
@@ -1,0 +1,306 @@
+import { afterEach, describe, test } from "node:test";
+import assert from "node:assert/strict";
+import type {
+	AssistantMessageEvent,
+	Context,
+	Message,
+	Model,
+	ServerToolUseContent,
+	TextContent,
+	ThinkingContent,
+	ToolCall,
+	WebSearchResultContent,
+} from "@gsd/pi-ai";
+import {
+	buildCodexClientOptions,
+	buildPromptFromContext,
+	buildThreadOptions,
+	getCodexLookupCommand,
+	makeStreamExhaustedErrorMessage,
+	mapUsage,
+	parseCodexLookupOutput,
+	setCodexPathForTests,
+	setCodexSdkLoaderForTests,
+	streamViaCodexCli,
+} from "../stream-adapter.ts";
+import type {
+	CodexClientLike,
+	CodexThreadEvent,
+	CodexThreadOptions,
+	CodexTurnOptions,
+} from "../sdk-types.ts";
+
+afterEach(() => {
+	setCodexSdkLoaderForTests(null);
+	setCodexPathForTests(null);
+});
+
+function makeModel(id = "gpt-5.4"): Model<any> {
+	return {
+		id,
+		name: id,
+		api: "openai-codex-responses",
+		provider: "codex-cli",
+		baseUrl: "local://codex-cli",
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 272000,
+		maxTokens: 128000,
+	};
+}
+
+async function collectEvents(stream: AsyncIterable<AssistantMessageEvent>): Promise<AssistantMessageEvent[]> {
+	const events: AssistantMessageEvent[] = [];
+	for await (const event of stream) {
+		events.push(event);
+	}
+	return events;
+}
+
+function createSdk(eventsFactory: (input: string, options?: CodexTurnOptions) => AsyncGenerator<CodexThreadEvent>) {
+	let capturedOptions: CodexThreadOptions | undefined;
+	let capturedInput = "";
+
+	class FakeCodex implements CodexClientLike {
+		startThread(options?: CodexThreadOptions) {
+			capturedOptions = options;
+			return {
+				runStreamed: async (input: string, turnOptions?: CodexTurnOptions) => {
+					capturedInput = input;
+					return { events: eventsFactory(input, turnOptions) };
+				},
+			};
+		}
+	}
+
+	return {
+		module: async () => ({ Codex: FakeCodex as any }),
+		getCapturedOptions: () => capturedOptions,
+		getCapturedInput: () => capturedInput,
+	};
+}
+
+describe("codex-cli stream adapter", () => {
+	test("buildPromptFromContext includes system, user, and assistant text", () => {
+		const context: Context = {
+			systemPrompt: "You are a helpful assistant.",
+			messages: [
+				{ role: "user", content: "What is 2+2?" } as Message,
+				{
+					role: "assistant",
+					content: [{ type: "text", text: "4" }],
+					api: "openai-codex-responses",
+					provider: "codex-cli",
+					model: "gpt-5.4",
+					usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } },
+					stopReason: "stop",
+					timestamp: Date.now(),
+				} as Message,
+				{ role: "user", content: "Now multiply that by 3" } as Message,
+			],
+		};
+
+		const prompt = buildPromptFromContext(context);
+		assert.ok(prompt.includes("helpful assistant"));
+		assert.ok(prompt.includes("2+2"));
+		assert.ok(prompt.includes("4"));
+		assert.ok(prompt.includes("multiply"));
+	});
+
+	test("buildThreadOptions sets Codex execution defaults", () => {
+		const options = buildThreadOptions(makeModel(), { reasoning: "high" });
+		assert.equal(options.model, "gpt-5.4");
+		assert.equal(options.sandboxMode, "danger-full-access");
+		assert.equal(options.approvalPolicy, "never");
+		assert.equal(options.skipGitRepoCheck, true);
+		assert.equal(options.workingDirectory, process.cwd());
+		assert.equal(options.modelReasoningEffort, "high");
+	});
+
+	test("buildCodexClientOptions uses the resolved codex binary path", () => {
+		setCodexPathForTests("/usr/local/bin/codex");
+		assert.deepEqual(buildCodexClientOptions(), { codexPathOverride: "/usr/local/bin/codex" });
+	});
+
+	test("mapUsage converts Codex usage to zero-cost GSD usage", () => {
+		assert.deepEqual(mapUsage({
+			input_tokens: 10,
+			cached_input_tokens: 2,
+			output_tokens: 5,
+		}), {
+			input: 10,
+			output: 5,
+			cacheRead: 2,
+			cacheWrite: 0,
+			totalTokens: 17,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		});
+	});
+
+	test("maps reasoning, text, and usage events into a completed assistant turn", async () => {
+		const sdk = createSdk(async function* () {
+			yield { type: "thread.started", thread_id: "thread_1" };
+			yield { type: "item.started", item: { id: "r1", type: "reasoning", text: "" } };
+			yield { type: "item.updated", item: { id: "r1", type: "reasoning", text: "Plan" } };
+			yield { type: "item.completed", item: { id: "r1", type: "reasoning", text: "Plan done" } };
+			yield { type: "item.started", item: { id: "a1", type: "agent_message", text: "" } };
+			yield { type: "item.updated", item: { id: "a1", type: "agent_message", text: "Hello" } };
+			yield { type: "item.completed", item: { id: "a1", type: "agent_message", text: "Hello world" } };
+			yield {
+				type: "turn.completed",
+				usage: { input_tokens: 10, cached_input_tokens: 2, output_tokens: 5 },
+			};
+		});
+		setCodexSdkLoaderForTests(sdk.module);
+		setCodexPathForTests("/usr/local/bin/codex");
+
+		const stream = streamViaCodexCli(makeModel(), { messages: [{ role: "user", content: "hi", timestamp: Date.now() }] });
+		const events = await collectEvents(stream);
+		const result = await stream.result();
+
+		assert.equal(events[0]?.type, "start");
+		assert.ok(events.some((event) => event.type === "thinking_start"));
+		assert.ok(events.some((event) => event.type === "thinking_delta" && event.delta === "Plan"));
+		assert.ok(events.some((event) => event.type === "text_start"));
+		assert.ok(events.some((event) => event.type === "text_delta" && event.delta === "Hello"));
+		assert.equal(events.at(-1)?.type, "done");
+		assert.deepEqual(result.usage, {
+			input: 10,
+			output: 5,
+			cacheRead: 2,
+			cacheWrite: 0,
+			totalTokens: 17,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		});
+			assert.deepEqual(
+				result.content.map(
+					(
+						block:
+							| TextContent
+							| ThinkingContent
+							| ToolCall
+							| ServerToolUseContent
+							| WebSearchResultContent,
+					) => {
+						switch (block.type) {
+							case "text":
+								return block.text;
+							case "thinking":
+								return block.thinking;
+							default:
+								return block.type;
+						}
+					},
+				),
+				["Plan done", "Hello world"],
+			);
+		assert.equal(sdk.getCapturedOptions()?.model, "gpt-5.4");
+		assert.ok(sdk.getCapturedInput().includes("hi"));
+	});
+
+	test("non-prefix rewrites are not emitted as deltas but final content is preserved", async () => {
+		const sdk = createSdk(async function* () {
+			yield { type: "thread.started", thread_id: "thread_1" };
+			yield { type: "item.started", item: { id: "a1", type: "agent_message", text: "" } };
+			yield { type: "item.updated", item: { id: "a1", type: "agent_message", text: "First draft" } };
+			yield { type: "item.completed", item: { id: "a1", type: "agent_message", text: "Final answer" } };
+			yield {
+				type: "turn.completed",
+				usage: { input_tokens: 1, cached_input_tokens: 0, output_tokens: 2 },
+			};
+		});
+		setCodexSdkLoaderForTests(sdk.module);
+		setCodexPathForTests("/usr/local/bin/codex");
+
+		const stream = streamViaCodexCli(makeModel(), { messages: [{ role: "user", content: "hi", timestamp: Date.now() }] });
+		const events = await collectEvents(stream);
+		const textDeltas = events.filter((event) => event.type === "text_delta");
+		const textEnd = events.find((event) => event.type === "text_end");
+
+		assert.equal(textDeltas.length, 1, "only the append-only update should produce a delta");
+		assert.equal(textDeltas[0]?.delta, "First draft");
+		assert.equal(textEnd?.type, "text_end");
+		if (textEnd?.type === "text_end") {
+			assert.equal(textEnd.content, "Final answer");
+		}
+	});
+
+	test("surfaces a helpful error when the optional SDK is missing", async () => {
+		setCodexSdkLoaderForTests(async () => {
+			throw new Error("Cannot find package '@openai/codex-sdk'");
+		});
+
+		const stream = streamViaCodexCli(makeModel(), { messages: [{ role: "user", content: "hi", timestamp: Date.now() }] });
+		const events = await collectEvents(stream);
+		const result = await stream.result();
+
+		assert.equal(events.at(-1)?.type, "error");
+		assert.equal(result.stopReason, "error");
+		assert.match(result.errorMessage ?? "", /@openai\/codex-sdk/);
+	});
+
+	test("turn failure becomes an assistant error message", async () => {
+		const sdk = createSdk(async function* () {
+			yield { type: "thread.started", thread_id: "thread_1" };
+			yield { type: "turn.failed", error: { message: "codex turn failed" } };
+		});
+		setCodexSdkLoaderForTests(sdk.module);
+		setCodexPathForTests("/usr/local/bin/codex");
+
+		const stream = streamViaCodexCli(makeModel(), { messages: [{ role: "user", content: "hi", timestamp: Date.now() }] });
+		const events = await collectEvents(stream);
+		const result = await stream.result();
+
+		assert.equal(events.at(-1)?.type, "error");
+		assert.equal(result.stopReason, "error");
+		assert.equal(result.errorMessage, "codex turn failed");
+	});
+
+	test("aborted signals become aborted assistant messages", async () => {
+		const controller = new AbortController();
+		controller.abort();
+
+		const stream = streamViaCodexCli(makeModel(), {
+			messages: [{ role: "user", content: "hi", timestamp: Date.now() }],
+		}, {
+			signal: controller.signal,
+		});
+		const events = await collectEvents(stream);
+		const result = await stream.result();
+
+		assert.equal(events.at(-1)?.type, "error");
+		assert.equal(result.stopReason, "aborted");
+	});
+
+	test("generator exhaustion becomes a classifiable error", () => {
+		const message = makeStreamExhaustedErrorMessage({
+			role: "assistant",
+			content: [{ type: "text", text: "partial answer" }],
+			api: "openai-codex-responses",
+			provider: "codex-cli",
+			model: "gpt-5.4",
+			usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } },
+			stopReason: "stop",
+			timestamp: Date.now(),
+		});
+		assert.equal(message.stopReason, "error");
+		assert.equal(message.errorMessage, "stream_exhausted_without_result");
+	});
+});
+
+describe("codex-cli path lookup helpers", () => {
+	test("getCodexLookupCommand uses where on Windows", () => {
+		assert.equal(getCodexLookupCommand("win32"), "where codex");
+	});
+
+	test("getCodexLookupCommand uses which on non-Windows platforms", () => {
+		assert.equal(getCodexLookupCommand("darwin"), "which codex");
+		assert.equal(getCodexLookupCommand("linux"), "which codex");
+	});
+
+	test("parseCodexLookupOutput keeps the first lookup result", () => {
+		const output = "/opt/homebrew/bin/codex\n/usr/local/bin/codex\n";
+		assert.equal(parseCodexLookupOutput(output), "/opt/homebrew/bin/codex");
+	});
+});

--- a/src/resources/extensions/gsd/auto-model-selection.ts
+++ b/src/resources/extensions/gsd/auto-model-selection.ts
@@ -383,18 +383,17 @@ export function resolveModelId<T extends { id: string; provider: string }>(
   if (candidates.length === 0) return undefined;
   if (candidates.length === 1) return candidates[0];
 
-  // When the user's current provider is claude-code (set by startup migration
-  // or explicit selection), honour it for bare IDs.  Routing back to anthropic
-  // would undo the migration and hit the third-party subscription block (#3772).
-  if (currentProvider === "claude-code") {
-    const ccMatch = candidates.find(m => m.provider === "claude-code");
-    if (ccMatch) return ccMatch;
+  // When the user's current provider is a CLI wrapper they explicitly selected,
+  // honour it for bare IDs instead of silently routing back to the API provider.
+  if (currentProvider === "claude-code" || currentProvider === "codex-cli") {
+    const extensionMatch = candidates.find(m => m.provider === currentProvider);
+    if (extensionMatch) return extensionMatch;
   }
 
   // Extension / CLI-wrapper providers that should not win bare-ID resolution
   // when a first-class API provider also offers the same model AND the user
   // has not explicitly chosen the extension provider.
-  const EXTENSION_PROVIDERS = new Set(["claude-code"]);
+  const EXTENSION_PROVIDERS = new Set(["claude-code", "codex-cli"]);
 
   // Prefer currentProvider only when it is a first-class API provider
   if (currentProvider && !EXTENSION_PROVIDERS.has(currentProvider)) {
@@ -416,7 +415,7 @@ export function resolveModelId<T extends { id: string; provider: string }>(
  * Uses case-insensitive matching with alias support to prevent fail-open on
  * provider naming variations (e.g. "copilot" vs "github-copilot").
  */
-const FLAT_RATE_PROVIDERS = new Set(["github-copilot", "copilot", "claude-code"]);
+const FLAT_RATE_PROVIDERS = new Set(["github-copilot", "copilot", "claude-code", "codex-cli"]);
 
 export function isFlatRateProvider(provider: string): boolean {
   return FLAT_RATE_PROVIDERS.has(provider.toLowerCase());

--- a/src/resources/extensions/gsd/bootstrap/agent-end-recovery.ts
+++ b/src/resources/extensions/gsd/bootstrap/agent-end-recovery.ts
@@ -147,11 +147,11 @@ export async function handleAgentEnd(
       return;
     }
 
-    // Cap rate-limit backoff for CLI-style providers (openai-codex, google-gemini-cli)
+    // Cap rate-limit backoff for CLI-style providers (openai-codex, codex-cli, google-gemini-cli)
     // which use per-user quotas with shorter windows (#2922).
     if (cls.kind === "rate-limit") {
       const currentProvider = ctx.model?.provider;
-      if (currentProvider === "openai-codex" || currentProvider === "google-gemini-cli") {
+      if (currentProvider === "openai-codex" || currentProvider === "codex-cli" || currentProvider === "google-gemini-cli") {
         cls.retryAfterMs = Math.min(cls.retryAfterMs, 30_000);
       }
     }

--- a/src/resources/extensions/gsd/doctor-providers.ts
+++ b/src/resources/extensions/gsd/doctor-providers.ts
@@ -59,6 +59,7 @@ function modelToProviderId(model: string): string | null {
       "google-vertex": "google-vertex",
       anthropic: "anthropic",
       openai: "openai",
+      "codex-cli": "codex-cli",
       "github-copilot": "github-copilot",
     };
     if (prefixMap[prefix]) return prefixMap[prefix];
@@ -181,7 +182,7 @@ function resolveKey(providerId: string): KeyLookup {
  */
 const PROVIDER_ROUTES: Record<string, string[]> = {
   anthropic: ["github-copilot"],
-  openai: ["github-copilot", "openai-codex"],
+  openai: ["github-copilot", "openai-codex", "codex-cli"],
   google: ["google-gemini-cli"],
 };
 
@@ -249,6 +250,8 @@ function checkLlmProviders(): ProviderCheckResult[] {
         message: `${label} — not configured`,
         detail: providerId === "anthropic-vertex"
           ? "Set ANTHROPIC_VERTEX_PROJECT_ID and authenticate with Google ADC"
+          : providerId === "codex-cli"
+          ? "Run `codex login`, then re-run `gsd config` and choose `Use Codex CLI`"
           : info?.hasOAuth
           ? `Run /gsd keys to authenticate`
           : `Set ${envVar} or run /gsd keys`,
@@ -270,7 +273,9 @@ function checkLlmProviders(): ProviderCheckResult[] {
         label,
         category: "llm",
         status: "ok",
-        message: `${label} — key present (${lookup.source})`,
+        message: providerId === "codex-cli"
+          ? `${label} — CLI ready (${lookup.source})`
+          : `${label} — key present (${lookup.source})`,
         required: true,
       });
     }

--- a/src/resources/extensions/gsd/key-manager.ts
+++ b/src/resources/extensions/gsd/key-manager.ts
@@ -38,6 +38,7 @@ export const PROVIDER_REGISTRY: ProviderInfo[] = [
   { id: "openai",           label: "OpenAI",                  category: "llm", envVar: "OPENAI_API_KEY",         prefixes: ["sk-"],     dashboardUrl: "platform.openai.com/api-keys" },
   { id: "github-copilot",   label: "GitHub Copilot",          category: "llm", envVar: "GITHUB_TOKEN",           hasOAuth: true },
   { id: "openai-codex",     label: "ChatGPT Plus/Pro (Codex)",category: "llm",                                   hasOAuth: true },
+  { id: "codex-cli",        label: "Codex CLI",               category: "llm" },
   { id: "google-gemini-cli",label: "Google Gemini CLI",       category: "llm",                                   hasOAuth: true },
   { id: "google-antigravity",label: "Antigravity",            category: "llm",                                   hasOAuth: true },
   { id: "google",           label: "Google (Gemini)",         category: "llm", envVar: "GEMINI_API_KEY",         dashboardUrl: "aistudio.google.com/apikey" },

--- a/src/resources/extensions/gsd/state.ts
+++ b/src/resources/extensions/gsd/state.ts
@@ -738,10 +738,10 @@ export async function deriveStateFromDb(basePath: string): Promise<GSDState> {
   }
 
   const { completeMilestoneIds, parkedMilestoneIds } = buildCompletenessSet(basePath, milestones);
-  
+
   const registryContext = await buildRegistryAndFindActive(basePath, milestones, completeMilestoneIds, parkedMilestoneIds);
   const { registry, activeMilestone, activeMilestoneSlices, activeMilestoneHasDraft } = registryContext;
-  
+
   const milestoneProgress = {
     done: registry.filter(e => e.status === 'complete').length,
     total: registry.length,
@@ -820,7 +820,7 @@ export async function deriveStateFromDb(basePath: string): Promise<GSDState> {
   }
 
   const tasks = await reconcileSliceTasks(basePath, activeMilestone.id, activeSlice.id, planFile);
-  
+
   const taskProgress = {
     done: tasks.filter(t => isStatusDone(t.status)).length,
     total: tasks.length,

--- a/src/resources/extensions/gsd/tests/auto-model-selection.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-model-selection.test.ts
@@ -156,6 +156,17 @@ test("resolveModelId: bare ID resolves to claude-code when session is claude-cod
   assert.equal(result.provider, "claude-code", "bare ID must resolve to claude-code when session provider is claude-code");
 });
 
+test("resolveModelId: bare ID resolves to codex-cli when session is codex-cli", () => {
+  const availableModels = [
+    { id: "gpt-5.4", provider: "openai-codex" },
+    { id: "gpt-5.4", provider: "codex-cli" },
+  ];
+
+  const result = resolveModelId("gpt-5.4", availableModels, "codex-cli");
+  assert.ok(result, "should resolve a model");
+  assert.equal(result.provider, "codex-cli", "bare ID must resolve to codex-cli when session provider is codex-cli");
+});
+
 test("resolveModelId: bare ID still prefers current provider when it is a first-class API provider", () => {
   const availableModels = [
     { id: "claude-sonnet-4-6", provider: "anthropic" },
@@ -176,6 +187,17 @@ test("resolveModelId: explicit provider/model format still resolves to claude-co
   const result = resolveModelId("claude-code/claude-sonnet-4-6", availableModels, "anthropic");
   assert.ok(result, "should resolve a model");
   assert.equal(result.provider, "claude-code", "explicit provider prefix must be respected");
+});
+
+test("resolveModelId: openai-codex wins over codex-cli when session provider is not codex-cli", () => {
+  const availableModels = [
+    { id: "gpt-5.4", provider: "codex-cli" },
+    { id: "gpt-5.4", provider: "openai-codex" },
+  ];
+
+  const result = resolveModelId("gpt-5.4", availableModels, undefined);
+  assert.ok(result, "should resolve a model");
+  assert.equal(result.provider, "openai-codex", "canonical API provider must win when session is not codex-cli");
 });
 
 test("resolveModelId: bare ID with only one provider works normally", () => {

--- a/src/resources/extensions/gsd/tests/cli-provider-rate-limit.test.ts
+++ b/src/resources/extensions/gsd/tests/cli-provider-rate-limit.test.ts
@@ -1,6 +1,6 @@
 /**
  * cli-provider-rate-limit.test.ts — Verify rate-limit backoff capping
- * for CLI-style providers (openai-codex, google-gemini-cli). (#2922)
+ * for CLI-style providers (openai-codex, codex-cli, google-gemini-cli). (#2922)
  *
  * These providers use per-user quotas with shorter windows, so the
  * default 60s backoff should be capped at 30s to avoid leaving users
@@ -33,6 +33,14 @@ test("agent-end-recovery references google-gemini-cli for rate-limit handling (#
   assert.ok(
     src.includes("google-gemini-cli"),
     'agent-end-recovery.ts must reference "google-gemini-cli" for CLI provider rate-limit handling (#2922)',
+  );
+});
+
+test("agent-end-recovery references codex-cli for rate-limit handling", () => {
+  const src = getRecoverySource();
+  assert.ok(
+    src.includes("codex-cli"),
+    'agent-end-recovery.ts must reference "codex-cli" for CLI provider rate-limit handling',
   );
 });
 

--- a/src/resources/extensions/gsd/tests/doctor-providers.test.ts
+++ b/src/resources/extensions/gsd/tests/doctor-providers.test.ts
@@ -610,6 +610,46 @@ test("runProviderChecks reports ok for claude-code without any API key", () => {
   rmSync(tmpHome, { recursive: true, force: true });
 });
 
+test("runProviderChecks recognizes codex-cli sentinel auth for explicit codex-cli preferences", () => {
+  const repo = realpathSync(mkdtempSync(join(tmpdir(), "gsd-providers-codex-cli-repo-")));
+  mkdirSync(join(repo, ".gsd"), { recursive: true });
+  writeFileSync(
+    join(repo, ".gsd", "PREFERENCES.md"),
+    [
+      "---",
+      "models:",
+      "  execution:",
+      "    model: gpt-5.4",
+      "    provider: codex-cli",
+      "---",
+      "",
+    ].join("\n"),
+  );
+
+  const tmpHome = realpathSync(mkdtempSync(join(tmpdir(), "gsd-providers-codex-cli-home-")));
+  const agentDir = join(tmpHome, ".gsd", "agent");
+  mkdirSync(agentDir, { recursive: true });
+  writeFileSync(join(agentDir, "auth.json"), JSON.stringify({
+    "codex-cli": { type: "api_key", key: "cli" },
+  }));
+
+  withEnv({
+    HOME: tmpHome,
+    OPENAI_API_KEY: undefined,
+  }, () => {
+    withCwd(repo, () => {
+      const results = runProviderChecks();
+      const codex = results.find(r => r.name === "codex-cli");
+      assert.ok(codex, "codex-cli result should exist");
+      assert.equal(codex!.status, "ok", "codex-cli sentinel auth should be treated as configured");
+      assert.ok(codex!.message.includes("CLI ready"), "message should mention CLI readiness");
+    });
+  });
+
+  rmSync(repo, { recursive: true, force: true });
+  rmSync(tmpHome, { recursive: true, force: true });
+});
+
 test("PROVIDER_ROUTES includes google-gemini-cli as route for google (#2922)", async () => {
   const { readFileSync: readFS } = await import("node:fs");
   const { dirname: dirn, join: joinPath } = await import("node:path");
@@ -635,5 +675,18 @@ test("PROVIDER_ROUTES includes openai-codex as route for openai (#2922)", async 
   assert.ok(
     src.includes('"openai-codex"'),
     'PROVIDER_ROUTES must include "openai-codex" as a route (#2922)',
+  );
+});
+
+test("PROVIDER_ROUTES includes codex-cli as route for openai", async () => {
+  const { readFileSync: readFS } = await import("node:fs");
+  const { dirname: dirn, join: joinPath } = await import("node:path");
+  const { fileURLToPath: fileUrl } = await import("node:url");
+  const __dir = dirn(fileUrl(import.meta.url));
+  const src = readFS(joinPath(__dir, "..", "doctor-providers.ts"), "utf-8");
+
+  assert.ok(
+    src.includes('"codex-cli"'),
+    'PROVIDER_ROUTES must include "codex-cli" as a route for openai',
   );
 });

--- a/src/resources/extensions/gsd/tests/flat-rate-routing-guard.test.ts
+++ b/src/resources/extensions/gsd/tests/flat-rate-routing-guard.test.ts
@@ -18,6 +18,10 @@ describe("flat-rate provider routing guard (#3453)", () => {
     assert.equal(isFlatRateProvider("copilot"), true);
   });
 
+  test("isFlatRateProvider returns true for codex-cli", () => {
+    assert.equal(isFlatRateProvider("codex-cli"), true);
+  });
+
   test("isFlatRateProvider is case-insensitive", () => {
     assert.equal(isFlatRateProvider("GitHub-Copilot"), true);
     assert.equal(isFlatRateProvider("GITHUB-COPILOT"), true);

--- a/src/resources/extensions/gsd/workflow-events.ts
+++ b/src/resources/extensions/gsd/workflow-events.ts
@@ -130,11 +130,11 @@ export function compactMilestoneEvents(
 
   return withFileLockSync(logPath, () => {
     const allEvents = readEvents(logPath);
-    
+
     // Single-pass partition to halve the work (per reviewer agent)
     const toArchive: WorkflowEvent[] = [];
     const remaining: WorkflowEvent[] = [];
-    
+
     for (const e of allEvents) {
       if ((e.params as { milestoneId?: string }).milestoneId === milestoneId) {
         toArchive.push(e);


### PR DESCRIPTION
## TL;DR

**What:** Add a standalone `codex-cli` provider so GSD can use a locally authenticated Codex CLI, alongside the existing `openai-codex` subscription/OAuth path.
**Why:** GSD already supported Codex as a hosted provider, but it did not have a first-class local CLI integration comparable to `claude-code`.
**How:** Introduce a new `externalCli` provider backed by `@openai/codex-sdk`, then wire it through readiness, onboarding, `/login`, model resolution, health checks, tests, and docs.

## What

This PR adds a new `codex-cli` provider and keeps it separate from the existing `openai-codex` provider.

Key changes:
- Add a new `src/resources/extensions/codex-cli/` extension with:
  - provider registration
  - readiness checks
  - derived model catalog
  - Codex SDK stream adapter
  - unit tests
- Add a lightweight `src/codex-cli-check.ts` helper for onboarding-time CLI detection.
- Update onboarding and interactive auth flows so ready local CLI providers can be selected:
  - show `Use Codex CLI` during setup when `codex` is installed and logged in
  - surface ready `externalCli` providers in `/login`
  - exclude `externalCli` providers from `/logout`
- Wire `codex-cli` into the GSD provider seams:
  - model resolver default
  - auto model selection / bare model ID resolution
  - flat-rate routing / backoff handling
  - doctor provider checks
  - key-manager labeling
  - provider migration helpers
- Add and update docs for provider setup and the GSD + Codex PR workflow.
- Align the Codex workflow docs with the new `docs/user-docs/` layout introduced on `main`.

## Why

Today GSD can use Codex through the existing `openai-codex` hosted/subscription path, but that is not the same thing as using a locally authenticated `codex` CLI.

This caused two practical gaps:
- users with an existing local Codex CLI login had no first-class way to select it as a provider
- the CLI-provider behavior and lifecycle were being conflated with OAuth/API-key-based providers

This PR closes that gap by making `codex-cli` a separate provider with explicit local-CLI semantics, similar in shape to `claude-code`, while preserving the existing `openai-codex` path.

## How

The implementation follows the `externalCli` provider pattern rather than trying to emulate an OpenAI API provider.

Key decisions:
- Add `codex-cli` as a standalone provider instead of replacing or aliasing `openai-codex`.
- Use `@openai/codex-sdk` to drive the local Codex CLI.
- Keep v1 intentionally narrow:
  - support text, reasoning, usage, completion, abort, and error mapping
  - do not yet project advanced Codex events such as command execution, file changes, MCP tool calls, todo lists, or web search into dedicated GSD UI events
- Gate the provider behind readiness checks:
  - `codex --version`
  - `codex login status`
- Treat `codex-cli` as a local flat-rate/CLI-style provider in routing and health checks.
- Add targeted tests around:
  - readiness caching and auth detection
  - stream event mapping
  - bare model resolution
  - doctor/provider reporting
  - CLI provider rate-limit handling

## Change type

- [x] `feat` — New feature or capability
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [x] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [x] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [x] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [ ] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

Commands run:
- `npm run build:pi`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/codex-cli/tests/*.test.ts src/resources/extensions/gsd/tests/auto-model-selection.test.ts src/resources/extensions/gsd/tests/flat-rate-routing-guard.test.ts src/resources/extensions/gsd/tests/doctor-providers.test.ts src/resources/extensions/gsd/tests/cli-provider-rate-limit.test.ts`

Manual verification:
1. Run `GSD_HOME=/tmp/gsd-local-devhome node dist/loader.js config`
2. Confirm `Use Codex CLI` appears when local `codex` is installed and logged in
3. Complete setup with `codex-cli` selected
4. Confirm setup persists and GSD starts with the configured provider

## AI disclosure

- [x] This PR includes AI-assisted code

AI assistance:
- Tool: Codex
- Verified with `npm run build:pi`, targeted provider/routing/doctor tests, and manual local onboarding checks
