### PR TITLE
fix: enable structured questions on MCP transport (ElicitRequest supported)

### DIFF
--- a/src/resources/extensions/gsd/tests/workflow-mcp.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-mcp.test.ts
@@ -441,13 +441,14 @@ test("usesWorkflowMcpTransport matches local externalCli providers", () => {
   assert.equal(usesWorkflowMcpTransport("oauth", "local://custom"), false);
 });
 
-test("supportsStructuredQuestions disables structured ask flow on workflow MCP transports", () => {
+test("supportsStructuredQuestions allows MCP transports now that ElicitRequest is supported", () => {
+  // MCP transport (Claude Code CLI) supports form elicitation — no longer blocked
   assert.equal(
     supportsStructuredQuestions(["ask_user_questions"], {
       authMode: "externalCli",
       baseUrl: "local://claude-code",
     }),
-    false,
+    true,
   );
   assert.equal(
     supportsStructuredQuestions(["ask_user_questions"], {
@@ -456,6 +457,7 @@ test("supportsStructuredQuestions disables structured ask flow on workflow MCP t
     }),
     true,
   );
+  // Still false when ask_user_questions is not in the tool set
   assert.equal(
     supportsStructuredQuestions([], {
       authMode: "oauth",

--- a/src/resources/extensions/gsd/workflow-mcp.ts
+++ b/src/resources/extensions/gsd/workflow-mcp.ts
@@ -350,16 +350,14 @@ export function usesWorkflowMcpTransport(
 
 export function supportsStructuredQuestions(
   activeTools: string[],
-  options: Pick<WorkflowCapabilityOptions, "authMode" | "baseUrl"> = {},
+  _options: Pick<WorkflowCapabilityOptions, "authMode" | "baseUrl"> = {},
 ): boolean {
   if (!activeTools.includes("ask_user_questions")) return false;
 
-  // Workflow MCP currently exposes ask_user_questions via MCP form elicitation.
-  // Local external CLI transports such as Claude Code can invoke the tool, but
-  // do not reliably complete that elicitation round-trip yet, so guided discuss
-  // prompts must fall back to plain-text questioning.
-  if (usesWorkflowMcpTransport(options.authMode, options.baseUrl)) return false;
-
+  // MCP transport (Claude Code CLI) now supports form elicitation via
+  // ElicitRequest in the MCP server. The discuss prompt templates include a
+  // "Tool fallback" instruction so the LLM gracefully degrades to plain-text
+  // questioning if the elicitation round-trip fails at runtime.
   return true;
 }
 


### PR DESCRIPTION
## TL;DR

**What:** Remove the `usesWorkflowMcpTransport()` guard from `supportsStructuredQuestions()`.
**Why:** The MCP server now supports form elicitation via `ElicitRequest`, making the guard obsolete.
**How:** Drop the transport check so MCP-based discuss flows use `ask_user_questions` instead of falling back to plain text.

## What

| File | Change |
|------|--------|
| `src/resources/extensions/gsd/workflow-mcp.ts` | Remove MCP transport block in `supportsStructuredQuestions()` |
| `src/resources/extensions/gsd/tests/workflow-mcp.test.ts` | Update test expectations — MCP transport now returns `true` |

## Why

`supportsStructuredQuestions()` was gated to return `false` for workflow MCP transports (Claude Code CLI with `authMode: "externalCli"` and `baseUrl: "local://..."`) because the MCP server did not support form elicitation when the guard was originally added.

The MCP server now implements `ElicitRequest` for `ask_user_questions` (the elicitation handler is wired in `packages/mcp-server/src/server.ts`). The transport block causes discuss flows routed through the Claude Code provider to unnecessarily fall back to plain-text questioning, losing the structured question UX.

The discuss prompt templates already include a "Tool fallback" instruction that tells the LLM to gracefully degrade to plain text if `ask_user_questions` fails at runtime, providing a safety net independent of this compile-time check.

## How

- Removed the `if (usesWorkflowMcpTransport(...)) return false` check
- The function now returns `true` whenever `ask_user_questions` is in the active tool set, regardless of transport
- `usesWorkflowMcpTransport()` itself is unchanged — still used by `getWorkflowTransportSupportError()` for other transport compatibility checks

## Test Evidence

- Updated `workflow-mcp.test.ts`: MCP transport (`externalCli` + `local://`) now expects `true`
- Non-MCP transports still return `true` (no regression)
- Missing `ask_user_questions` tool still returns `false` (guard preserved)
- Build passes, all existing tests pass

---

> AI-assisted contribution — reviewed and tested by contributor.

- [x] `fix`