### PR TITLE
chore: require linked issue in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,16 @@
+## Linked issue
+
+<!--
+PRs without a linked issue will be closed.
+Open or find an issue first: https://github.com/gsd-build/gsd-2/issues
+-->
+
+Closes #<!-- issue number — required -->
+
+- [ ] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.
+
+---
+
 ## TL;DR
 
 **What:** <!-- One sentence — what does this change? -->
@@ -10,7 +23,7 @@
 
 ## Why
 
-<!-- The motivation. What problem does this solve? Link issues: Closes #123 -->
+<!-- The motivation. What problem does this solve? -->
 
 ## How
 


### PR DESCRIPTION
## Linked issue

Closes #<!-- none — this is a meta-contribution from the repo owner -->

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Adds a required linked-issue section at the top of the PR template.
**Why:** 16 PRs were closed today for missing issue links; the old template didn't make this requirement visible enough.
**How:** Prominent section with a `Closes #` placeholder and a required acknowledgement checkbox at the very top, before any other content.

## Change type

- [x] \`chore\` — Build, CI, or tooling changes

## Test plan

- [x] No tests needed — template change only