### PR TITLE
fix(pi-coding-agent): skip localhost dummy key when fallback resolver provides a configured key

### DIFF
--- a/packages/pi-coding-agent/src/core/auth-storage.test.ts
+++ b/packages/pi-coding-agent/src/core/auth-storage.test.ts
@@ -531,3 +531,41 @@ describe("AuthStorage — getEarliestBackoffExpiry", () => {
 		assert.equal(expiry, nearExpiry, "should return the nearest (smallest) expiry");
 	});
 });
+
+// ─── localhost baseUrl shortcut ────────────────────────────────────────────────
+
+describe("AuthStorage — localhost baseUrl shortcut", () => {
+	it("returns 'local-no-key-needed' for localhost provider with no configured key", async () => {
+		const storage = inMemory({});
+		const key = await storage.getApiKey("ollama", undefined, { baseUrl: "http://localhost:11434" });
+		assert.equal(key, "local-no-key-needed");
+	});
+
+	it("returns 'local-no-key-needed' for 127.0.0.1 provider with no configured key", async () => {
+		const storage = inMemory({});
+		const key = await storage.getApiKey("custom", undefined, { baseUrl: "http://127.0.0.1:8080/v1" });
+		assert.equal(key, "local-no-key-needed");
+	});
+
+	it("returns configured key from fallback resolver for localhost custom provider (#4106)", async () => {
+		// Regression test: compaction called getApiKey(model) where model.baseUrl is localhost.
+		// The localhost shortcut must NOT override an explicitly configured apiKey from models.json.
+		const storage = inMemory({});
+		storage.setFallbackResolver((provider) =>
+			provider === "cliproxy" ? "sk-real-proxy-key" : undefined,
+		);
+
+		const key = await storage.getApiKey("cliproxy", undefined, { baseUrl: "http://localhost:8317/v1" });
+		assert.equal(key, "sk-real-proxy-key");
+	});
+
+	it("returns configured key from fallback resolver when baseUrl uses 127.0.0.1 (#4106)", async () => {
+		const storage = inMemory({});
+		storage.setFallbackResolver((provider) =>
+			provider === "myproxy" ? "sk-myproxy-key" : undefined,
+		);
+
+		const key = await storage.getApiKey("myproxy", undefined, { baseUrl: "http://127.0.0.1:9000/v1" });
+		assert.equal(key, "sk-myproxy-key");
+	});
+});

--- a/packages/pi-coding-agent/src/core/auth-storage.ts
+++ b/packages/pi-coding-agent/src/core/auth-storage.ts
@@ -819,7 +819,7 @@ export class AuthStorage {
 	 */
 	async getApiKey(providerId: string, sessionId?: string, options?: { baseUrl?: string }): Promise<string | undefined> {
 		// If the model has a local baseUrl, return a dummy key to avoid auth blocking
-		if (options?.baseUrl) {
+		if (options?.baseUrl && !this.fallbackResolver?.(providerId)) {
 			try {
 				const hostname = new URL(options.baseUrl).hostname;
 				if (hostname === "localhost" || hostname === "127.0.0.1" || hostname === "0.0.0.0" || hostname === "::1") {


### PR DESCRIPTION
## TL;DR

**What:** `AuthStorage.getApiKey()` no longer returns `"local-no-key-needed"` for custom providers on localhost when an explicit API key is configured in `models.json`.
**Why:** Compaction was failing with 401 for custom OpenAI-compatible providers running on localhost because the dummy key bypassed the configured key.
**How:** Guard the localhost shortcut with `!this.fallbackResolver?.(providerId)`.

## What

Single-line condition change in `packages/pi-coding-agent/src/core/auth-storage.ts` plus 4 regression tests in `auth-storage.test.ts`.

## Why

`AuthStorage.getApiKey()` had an unconditional localhost shortcut: any provider with a localhost `baseUrl` would receive `"local-no-key-needed"` regardless of whether an explicit `apiKey` was configured in `models.json`.

Normal dispatch calls `ModelRegistry.getApiKeyForProvider()` which never passes `baseUrl`, so the fallback resolver (and the real key) was always reached. Compaction calls `ModelRegistry.getApiKey(model)` which passes `model.baseUrl` — hitting the localhost shortcut first and never reaching the fallback resolver.

Result: normal requests worked, compaction failed with `401 "Invalid API key"` on 100% of sessions once the context grew large enough to trigger compaction.

## How

The fix checks whether the fallback resolver would provide a key before activating the localhost shortcut. Providers without a configured key (e.g. plain Ollama) continue to receive `"local-no-key-needed"` as before.

Closes #4106