### PR TITLE
fix(ci): address 5 pipeline integrity issues from release audit

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -177,7 +177,7 @@ jobs:
 
       - name: Run live LLM tests (optional)
         continue-on-error: true
-        run: npm run test:live
+        run: npm run test:live || echo "::warning::Live LLM tests failed — non-blocking, but worth investigating"
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
@@ -197,21 +197,26 @@ jobs:
           RELEASE_VERSION: ${{ steps.release.outputs.version }}
         run: node scripts/bump-version.mjs "$RELEASE_VERSION"
 
+      - name: Validate package files after version bump
+        run: |
+          node -e "require('./package.json')" && \
+          node -e "require('./packages/pi-coding-agent/package.json')" && \
+          node -e "require('./pkg/package.json')" && \
+          echo "All package.json files are valid"
+
       - name: Update CHANGELOG.md
         run: node scripts/update-changelog.mjs /tmp/changelog-entry.md
 
-      - name: Commit, tag, and push
+      - name: Commit and tag release
         env:
           RELEASE_VERSION: ${{ steps.release.outputs.version }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add package.json package-lock.json CHANGELOG.md native/npm/*/package.json pkg/package.json packages/pi-coding-agent/package.json
+          git add package.json package-lock.json web/package-lock.json CHANGELOG.md native/npm/*/package.json pkg/package.json packages/pi-coding-agent/package.json
           git commit -m "release: v${RELEASE_VERSION}"
           git tag "v${RELEASE_VERSION}"
           git pull --rebase origin main
-          git push origin main
-          git push origin "v${RELEASE_VERSION}"
 
       - name: Build release
         run: npm run build
@@ -230,6 +235,13 @@ jobs:
               exit 1
             fi
           }
+
+      - name: Push release commit and tag
+        env:
+          RELEASE_VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          git push origin main
+          git push origin "v${RELEASE_VERSION}"
 
       - name: Create GitHub Release
         env:

--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -3,7 +3,7 @@
  * Bump version in package.json, then sync platform packages and pkg/package.json.
  * Usage: node scripts/bump-version.mjs <new-version>
  */
-import { readFileSync, writeFileSync } from "fs";
+import { readFileSync, writeFileSync, existsSync } from "fs";
 import { resolve, dirname } from "path";
 import { execSync } from "child_process";
 import { fileURLToPath } from "url";
@@ -38,7 +38,14 @@ execSync("node native/scripts/sync-platform-versions.cjs", { cwd: root, stdio: "
 // 4. Sync pkg/package.json (reads from pi-coding-agent)
 execSync("node scripts/sync-pkg-version.cjs", { cwd: root, stdio: "inherit" });
 
-// 5. Regenerate package-lock.json to match the new version.
+// 5. Regenerate root package-lock.json to match the new version.
 //    --package-lock-only updates the lockfile in-place without touching node_modules.
-execSync("npm install --package-lock-only", { cwd: root, stdio: "inherit" });
+execSync("npm install --package-lock-only --ignore-scripts", { cwd: root, stdio: "inherit" });
 console.log(`[bump-version] package-lock.json regenerated at ${newVersion}`);
+
+// 6. Regenerate web/package-lock.json if the web app is present.
+const webDir = resolve(root, "web");
+if (existsSync(webDir)) {
+  execSync("npm install --package-lock-only --ignore-scripts", { cwd: webDir, stdio: "inherit" });
+  console.log(`[bump-version] web/package-lock.json regenerated`);
+}

--- a/scripts/version-stamp.mjs
+++ b/scripts/version-stamp.mjs
@@ -1,5 +1,10 @@
 import { readFileSync, writeFileSync } from "fs";
-import { execFileSync } from "child_process";
+import { execFileSync, execSync } from "child_process";
+import { fileURLToPath } from "url";
+import { dirname, resolve } from "path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, "..");
 
 const pkgPath = new URL("../package.json", import.meta.url);
 const pkg = JSON.parse(readFileSync(pkgPath, "utf8"));
@@ -9,5 +14,9 @@ const devVersion = `${pkg.version}-dev.${shortSha}`;
 
 pkg.version = devVersion;
 writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + "\n");
-
 console.log(`Stamped version: ${devVersion}`);
+
+// Regenerate package-lock.json to reflect the stamped dev version.
+// --package-lock-only updates the lockfile in-place without touching node_modules.
+execSync("npm install --package-lock-only --ignore-scripts", { cwd: root, stdio: "inherit" });
+console.log(`[version-stamp] package-lock.json regenerated at ${devVersion}`);


### PR DESCRIPTION
## Linked issue

Closes #4118

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Fix 5 CI/CD pipeline integrity issues found during the post-#4116 audit.
**Why:** version-stamp had the same lockfile bug as bump-version; the release pipeline was pushing tags before verifying the build; package.json corruption would only be caught after committing.
**How:** Three files changed — version-stamp.mjs, bump-version.mjs, pipeline.yml.

## What

### `scripts/version-stamp.mjs`
- Adds `npm install --package-lock-only --ignore-scripts` after writing the dev-stamped version, so `gsd-pi@dev` publishes with a lockfile that matches its `package.json` version. Mirrors the fix from #4116.

### `scripts/bump-version.mjs`
- Adds `existsSync` import
- Step 5: regenerates root `package-lock.json` after all version writes (from #4116, re-applied on current main)
- Step 6: regenerates `web/package-lock.json` if the `web/` directory exists

### `.github/workflows/pipeline.yml`
- **LLM test warning**: `npm run test:live || echo "::warning::..."` so failures surface as visible annotations instead of being silently swallowed by `continue-on-error`
- **Post-bump validation**: new step between bump and changelog that runs `node -e "require('./package.json')"` on all three key package files — catches malformed JSON before the release commit is made
- **Push deferred after publish**: renamed "Commit, tag, and push" → "Commit and tag release" (commit + tag + rebase only). Added new "Push release commit and tag" step *after* `npm publish` succeeds. If build or publish fails, the tag exists only locally and the release can be cleanly retried.

## Release pipeline step order (after this PR)

```
Install deps
Run live LLM tests (non-blocking, warns on failure)
Generate changelog + version
Bump version + sync packages
Validate package.json files          ← new
Update CHANGELOG.md
Commit + tag + rebase                ← no longer pushes
Build release
Publish to npm @latest
Push commit + tag to main            ← moved here
Create GitHub Release
```

## Change type

- [x] `fix` — Bug fix

## Scope

- [x] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes

## Test plan

- [x] CI passes
- [x] No tests needed — build script and workflow changes only