### PR TITLE
fix(tui): stop pinned latest-output from duplicating streaming text

### DIFF
--- a/packages/pi-coding-agent/src/modes/interactive/controllers/chat-controller.test.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/controllers/chat-controller.test.ts
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { findLatestPinnableText } from "./chat-controller.js";
+
+test("findLatestPinnableText: empty content returns empty string", () => {
+	assert.equal(findLatestPinnableText([]), "");
+});
+
+test("findLatestPinnableText: no tool calls returns empty string", () => {
+	const blocks = [
+		{ type: "text", text: "hello" },
+		{ type: "text", text: "world" },
+	];
+	assert.equal(findLatestPinnableText(blocks), "");
+});
+
+test("findLatestPinnableText: returns text preceding a tool call", () => {
+	const blocks = [
+		{ type: "text", text: "doing the thing" },
+		{ type: "toolCall", id: "1", name: "Read" },
+	];
+	assert.equal(findLatestPinnableText(blocks), "doing the thing");
+});
+
+test("findLatestPinnableText: ignores trailing streaming text after the last tool call (regression: pinned mirror duplicated chat-container tokens)", () => {
+	const blocks = [
+		{ type: "text", text: "first prose" },
+		{ type: "toolCall", id: "1", name: "Read" },
+		{ type: "text", text: "second prose still streaming" },
+	];
+	assert.equal(findLatestPinnableText(blocks), "first prose");
+});
+
+test("findLatestPinnableText: with multiple tools, picks text before the most recent tool call", () => {
+	const blocks = [
+		{ type: "text", text: "first" },
+		{ type: "toolCall", id: "1", name: "Read" },
+		{ type: "text", text: "second" },
+		{ type: "toolCall", id: "2", name: "Grep" },
+		{ type: "text", text: "third streaming" },
+	];
+	assert.equal(findLatestPinnableText(blocks), "second");
+});
+
+test("findLatestPinnableText: treats serverToolUse the same as toolCall", () => {
+	const blocks = [
+		{ type: "text", text: "before web search" },
+		{ type: "serverToolUse", id: "ws1", name: "web_search" },
+		{ type: "text", text: "answer streaming" },
+	];
+	assert.equal(findLatestPinnableText(blocks), "before web search");
+});
+
+test("findLatestPinnableText: skips empty/whitespace-only text blocks", () => {
+	const blocks = [
+		{ type: "text", text: "real prose" },
+		{ type: "text", text: "   " },
+		{ type: "text", text: "" },
+		{ type: "toolCall", id: "1", name: "Read" },
+	];
+	assert.equal(findLatestPinnableText(blocks), "real prose");
+});
+
+test("findLatestPinnableText: thinking blocks are not pinnable", () => {
+	const blocks = [
+		{ type: "thinking", thinking: "internal" },
+		{ type: "toolCall", id: "1", name: "Read" },
+	];
+	assert.equal(findLatestPinnableText(blocks), "");
+});

--- a/packages/pi-coding-agent/src/modes/interactive/controllers/chat-controller.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/controllers/chat-controller.ts
@@ -22,6 +22,28 @@ function hasAssistantToolBlocks(message: { content: Array<any> }): boolean {
 	return message.content.some((c) => c.type === "toolCall" || c.type === "serverToolUse");
 }
 
+// Pick the latest non-empty text block that appears strictly before the most
+// recent tool call. Text blocks that come after the last tool call are still
+// streaming live into the chat container, so mirroring them into the pinned
+// "Latest Output" zone would render the same tokens twice.
+export function findLatestPinnableText(contentBlocks: Array<any>): string {
+	let lastToolIdx = -1;
+	for (let i = contentBlocks.length - 1; i >= 0; i--) {
+		const c = contentBlocks[i];
+		if (c?.type === "toolCall" || c?.type === "serverToolUse") {
+			lastToolIdx = i;
+			break;
+		}
+	}
+	for (let i = lastToolIdx - 1; i >= 0; i--) {
+		const c = contentBlocks[i];
+		if (c?.type === "text" && typeof c.text === "string" && c.text.trim()) {
+			return c.text.trim();
+		}
+	}
+	return "";
+}
+
 // Tracks the latest assistant text for the pinned message zone
 let lastPinnedText = "";
 // Whether any tool execution has been added in this assistant turn (triggers pinned display)
@@ -286,26 +308,7 @@ export async function handleAgentEvent(host: InteractiveModeStateHost & {
 				if (hasTools) hasToolsInTurn = true;
 
 				if (hasToolsInTurn) {
-					// Mirror the latest text block that precedes the most recent tool
-					// call. Text blocks that come *after* the last tool call are still
-					// streaming live into the chat container, so mirroring them would
-					// duplicate the same tokens in two places at once.
-					let lastToolIdx = -1;
-					for (let i = contentBlocks.length - 1; i >= 0; i--) {
-						const c = contentBlocks[i] as any;
-						if (c.type === "toolCall" || c.type === "serverToolUse") {
-							lastToolIdx = i;
-							break;
-						}
-					}
-					let latestText = "";
-					for (let i = lastToolIdx - 1; i >= 0; i--) {
-						const c = contentBlocks[i] as any;
-						if (c.type === "text" && c.text?.trim()) {
-							latestText = c.text.trim();
-							break;
-						}
-					}
+					const latestText = findLatestPinnableText(contentBlocks);
 
 					if (latestText && latestText !== lastPinnedText) {
 						lastPinnedText = latestText;

--- a/packages/pi-coding-agent/src/modes/interactive/controllers/chat-controller.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/controllers/chat-controller.ts
@@ -286,9 +286,20 @@ export async function handleAgentEvent(host: InteractiveModeStateHost & {
 				if (hasTools) hasToolsInTurn = true;
 
 				if (hasToolsInTurn) {
-					// Collect the latest text block(s) from the assistant message
-					let latestText = "";
+					// Mirror the latest text block that precedes the most recent tool
+					// call. Text blocks that come *after* the last tool call are still
+					// streaming live into the chat container, so mirroring them would
+					// duplicate the same tokens in two places at once.
+					let lastToolIdx = -1;
 					for (let i = contentBlocks.length - 1; i >= 0; i--) {
+						const c = contentBlocks[i] as any;
+						if (c.type === "toolCall" || c.type === "serverToolUse") {
+							lastToolIdx = i;
+							break;
+						}
+					}
+					let latestText = "";
+					for (let i = lastToolIdx - 1; i >= 0; i--) {
 						const c = contentBlocks[i] as any;
 						if (c.type === "text" && c.text?.trim()) {
 							latestText = c.text.trim();


### PR DESCRIPTION
## Summary

- The pinned `Working · Latest Output` border duplicated streaming tokens with the chat container when the assistant produced text after a tool call.
- Restrict the mirror to text blocks that precede the most recent tool call so live-streaming text stays in the chat container only.

Fixes #4120

## Root cause

`chat-controller.ts` walked content blocks from the end and picked the last text block to mirror. For the sequence `[text1, tool1, text2_streaming]`, that picked `text2` — but `text2` is the live block already rendering in the chat container, so the user saw identical tokens grow in two places.

## Fix

Find the index of the latest tool call, then search for the latest text block strictly before it. Earlier prose (`text1`) stays mirrored the entire time the new text streams, so context isn't lost and the loading-animation handoff is undisturbed.

## Dependency

Builds on the pinned-output feature in #4051 / #4003 / #4008 / #4009. Should land after those merge (this branch is currently based on `feat/tui-work`).

## Test plan

- [ ] Run `pi` interactive mode, ask the agent to perform a task with at least one tool call followed by explanatory text.
- [ ] Confirm the explanatory text renders only once (in the chat history), not duplicated in the pinned border.
- [ ] Confirm the previous prose remains pinned the entire time the new text streams.
- [ ] Confirm the pinned border still appears for the original case (long tool output scrolling text off-screen).

🤖 Generated with [Claude Code](https://claude.com/claude-code)