### PR TITLE
feat(skills): add MiniMax-AI/cli as default skill tap

### DIFF
--- a/src/resources/extensions/gsd/skill-catalog.ts
+++ b/src/resources/extensions/gsd/skill-catalog.ts
@@ -617,6 +617,13 @@ export const SKILL_CATALOG: SkillPack[] = [
     skills: ["pdf", "docx", "xlsx", "pptx"],
     matchAlways: true,
   },
+  {
+    label: "MiniMax AI",
+    description: "Generate text, images, video, speech, and music via MiniMax AI platform",
+    repo: "MiniMax-AI/cli",
+    skills: ["mmx-cli"],
+    matchAlways: true,
+  },
   // ── Code Quality (wshobson/agents — matchAlways) ──────────────────────────
   {
     label: "Code Review & Quality",

--- a/src/resources/extensions/gsd/skill-catalog.ts
+++ b/src/resources/extensions/gsd/skill-catalog.ts
@@ -622,7 +622,6 @@ export const SKILL_CATALOG: SkillPack[] = [
     description: "Generate text, images, video, speech, and music via MiniMax AI platform",
     repo: "MiniMax-AI/cli",
     skills: ["mmx-cli"],
-    matchAlways: true,
   },
   // ── Code Quality (wshobson/agents — matchAlways) ──────────────────────────
   {

--- a/src/resources/extensions/gsd/tests/skill-catalog.test.ts
+++ b/src/resources/extensions/gsd/tests/skill-catalog.test.ts
@@ -182,6 +182,23 @@ test("SKILL_CATALOG: every matchFiles entry is backed by detection", () => {
   }
 });
 
+// ── MiniMax AI catalog entry ─────────────────────────────────────────────────
+// Smoke tests for the opt-in MiniMax pack: it requires an API key and a
+// MiniMax account, so it must not appear in default brownfield recommendations.
+
+test("SKILL_CATALOG: MiniMax AI entry has required fields", () => {
+  const minimax = SKILL_CATALOG.find((p) => p.label === "MiniMax AI");
+  assert.ok(minimax, "MiniMax AI entry should exist in SKILL_CATALOG");
+  assert.equal(minimax!.repo, "MiniMax-AI/cli");
+  assert.ok(minimax!.skills.length > 0, "MiniMax AI should declare at least one skill");
+  assert.ok(minimax!.description.length > 0, "MiniMax AI should have a description");
+});
+
+test("matchPacksForProject: MiniMax AI is opt-in (not in default recommendations)", () => {
+  const labels = packLabels(makeSignals());
+  assert.ok(!labels.includes("MiniMax AI"), "MiniMax AI requires explicit opt-in and must not be matched for empty signals");
+});
+
 test("GREENFIELD_STACKS: every pack label resolves to SKILL_CATALOG", () => {
   const labels = new Set(SKILL_CATALOG.map((pack) => pack.label));
 


### PR DESCRIPTION
## TL;DR

**What:** Add `MiniMax-AI/cli` to `SKILL_CATALOG` in `skill-catalog.ts` so it is discoverable and installable as a default skill — opt-in, not auto-suggested.
**Why:** MiniMax provides powerful multimodal AI capabilities (text, image, video, speech, music) via a CLI tool with a compliant SKILL.md.
**How:** Add one `SkillPack` entry (no `matchAlways`) to the General Tooling section. Users discover it via skill search and install it explicitly when they want MiniMax integration.

## What

Added `MiniMax-AI/cli` (`mmx-cli` skill) to `src/resources/extensions/gsd/skill-catalog.ts`:

- Repository: `MiniMax-AI/cli`
- Skill path: `skill/` (contains `SKILL.md` following the [agentskills.io](https://agentskills.io) standard)
- **No `matchAlways`** — opt-in only (per @trek-e review). Behaves like other platform-specific entries; users opt in via skill search rather than seeing it during default `gsd init`.

## Why

`MiniMax-AI/cli` is a CLI tool for the MiniMax AI platform. Its SKILL.md exposes:
- **Text generation** (MiniMax-M2.7 model)
- **Image generation** (image-01)
- **Video generation** (Hailuo-2.3)
- **Speech synthesis** (speech-2.8-hd, 300+ voices)
- **Music generation** (music-2.6, with lyrics, cover, and instrumental modes)
- **Web search**

Including it in the catalog lets agents discover and install MiniMax capabilities when needed, without surfacing it for every `gsd init`.

## How

Followed the existing `SkillPack` pattern. Entry placed in the `// ── General Tooling` section. Added two tests to `skill-catalog.test.ts`:
- catalog-shape test (entry has required fields, non-empty)
- opt-in test (entry must NOT appear in default brownfield recommendations for empty signals)

## Open questions for maintainers (per @trek-e review)

These are policy decisions that need a maintainer call before merge — happy to revise based on the answers:

1. **Vetting process for third-party commercial AI CLIs.** I do not have visibility into the maintainer vetting process. If there is a checklist (license review, supply-chain check on the upstream repo, API/credential disclosure), please point me at it and I will run through it.
2. **Acceptance bar for commercial tools in the catalog.** With `matchAlways` removed, the entry is opt-in — users only see it when they search for AI/media skills. Is opt-in inclusion acceptable for credential-requiring external services, or does the project want a separate `requiresApiKey` flag / a different catalog tier? I am happy to add such a flag if that is the preferred shape.
3. **Install-path verification.** I have not done an end-to-end smoke test of `npx skills add MiniMax-AI/cli --skill mmx-cli` against the current loader because the in-tree tests only cover catalog shape. If there is an existing harness for live install checks of catalog entries, I will wire this entry into it; otherwise I am happy to add a documented manual smoke step.

## Test plan

- [x] `feat` — New entry in SKILL_CATALOG
- [x] Catalog shape test (required fields present, non-empty)
- [x] Opt-in test (not surfaced in default brownfield recommendations)
- [ ] Live install smoke (`npx skills add MiniMax-AI/cli --skill mmx-cli -y`) — pending guidance on harness above

*This PR was generated with AI assistance.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MiniMax AI skill pack, enabling generation of text, images, video, speech, and music through the MiniMax AI platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->