### PR TITLE
fix(budget-engine): thread sessionContextWindow to fix 200K fallback (#4142)

### DIFF
--- a/src/resources/extensions/gsd/auto-direct-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-direct-dispatch.ts
@@ -104,7 +104,7 @@ export async function dispatchDirectPhase(
         }
         unitType = "plan-slice";
         unitId = `${mid}/${sid}`;
-        prompt = await buildPlanSlicePrompt(mid, midTitle, sid, sTitle, base);
+        prompt = await buildPlanSlicePrompt(mid, midTitle, sid, sTitle, base, undefined, ctx.model?.contextWindow);
       } else {
         unitType = "plan-milestone";
         unitId = mid;
@@ -129,7 +129,7 @@ export async function dispatchDirectPhase(
       }
       unitType = "execute-task";
       unitId = `${mid}/${sid}/${tid}`;
-      prompt = await buildExecuteTaskPrompt(mid, sid, sTitle, tid, tTitle, base);
+      prompt = await buildExecuteTaskPrompt(mid, sid, sTitle, tid, tTitle, base, { sessionContextWindow: ctx.model?.contextWindow });
       break;
     }
 

--- a/src/resources/extensions/gsd/auto-direct-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-direct-dispatch.ts
@@ -104,7 +104,7 @@ export async function dispatchDirectPhase(
         }
         unitType = "plan-slice";
         unitId = `${mid}/${sid}`;
-        prompt = await buildPlanSlicePrompt(mid, midTitle, sid, sTitle, base, undefined, ctx.model?.contextWindow);
+        prompt = await buildPlanSlicePrompt(mid, midTitle, sid, sTitle, base, undefined, ctx.model?.contextWindow, ctx.modelRegistry as import("./context-budget.js").MinimalModelRegistry | undefined);
       } else {
         unitType = "plan-milestone";
         unitId = mid;
@@ -129,7 +129,7 @@ export async function dispatchDirectPhase(
       }
       unitType = "execute-task";
       unitId = `${mid}/${sid}/${tid}`;
-      prompt = await buildExecuteTaskPrompt(mid, sid, sTitle, tid, tTitle, base, { sessionContextWindow: ctx.model?.contextWindow });
+      prompt = await buildExecuteTaskPrompt(mid, sid, sTitle, tid, tTitle, base, { sessionContextWindow: ctx.model?.contextWindow, modelRegistry: ctx.modelRegistry as import("./context-budget.js").MinimalModelRegistry | undefined });
       break;
     }
 

--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -76,6 +76,9 @@ export interface DispatchContext {
   state: GSDState;
   prefs: GSDPreferences | undefined;
   session?: import("./auto/session.js").AutoSession;
+  /** Session model context window in tokens — passed to prompt builders so the budget engine
+   *  uses the real executor window instead of the 200K fallback (issue #4142). */
+  sessionContextWindow?: number;
 }
 
 export interface DispatchRule {
@@ -465,7 +468,7 @@ export const DISPATCH_RULES: DispatchRule[] = [
   },
   {
     name: "planning → plan-slice",
-    match: async ({ state, mid, midTitle, basePath }) => {
+    match: async ({ state, mid, midTitle, basePath, sessionContextWindow }) => {
       if (state.phase !== "planning") return null;
       if (!state.activeSlice) return missingSliceStop(mid, state.phase);
       const sid = state.activeSlice!.id;
@@ -480,6 +483,8 @@ export const DISPATCH_RULES: DispatchRule[] = [
           sid,
           sTitle,
           basePath,
+          undefined,
+          sessionContextWindow,
         ),
       };
     },
@@ -634,7 +639,7 @@ export const DISPATCH_RULES: DispatchRule[] = [
   },
   {
     name: "executing → execute-task (recover missing task plan → plan-slice)",
-    match: async ({ state, mid, midTitle, basePath }) => {
+    match: async ({ state, mid, midTitle, basePath, sessionContextWindow }) => {
       if (state.phase !== "executing" || !state.activeTask) return null;
       if (!state.activeSlice) return missingSliceStop(mid, state.phase);
       const sid = state.activeSlice!.id;
@@ -658,6 +663,8 @@ export const DISPATCH_RULES: DispatchRule[] = [
             sid,
             sTitle,
             basePath,
+            undefined,
+            sessionContextWindow,
           ),
         };
       }
@@ -667,7 +674,7 @@ export const DISPATCH_RULES: DispatchRule[] = [
   },
   {
     name: "executing → execute-task",
-    match: async ({ state, mid, basePath }) => {
+    match: async ({ state, mid, basePath, sessionContextWindow }) => {
       if (state.phase !== "executing" || !state.activeTask) return null;
       if (!state.activeSlice) return missingSliceStop(mid, state.phase);
       const sid = state.activeSlice!.id;
@@ -686,6 +693,7 @@ export const DISPATCH_RULES: DispatchRule[] = [
           tid,
           tTitle,
           basePath,
+          { sessionContextWindow },
         ),
       };
     },

--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -12,6 +12,7 @@
 import type { GSDState } from "./types.js";
 import type { GSDPreferences } from "./preferences.js";
 import type { UatType } from "./files.js";
+import type { MinimalModelRegistry } from "./context-budget.js";
 import { loadFile, extractUatType, loadActiveOverrides } from "./files.js";
 import { isDbAvailable, getMilestoneSlices, getPendingGates, markAllGatesOmitted, getMilestone } from "./gsd-db.js";
 import { extractVerdict, isAcceptableUatVerdict } from "./verdict-parser.js";
@@ -79,6 +80,9 @@ export interface DispatchContext {
   /** Session model context window in tokens — passed to prompt builders so the budget engine
    *  uses the real executor window instead of the 200K fallback (issue #4142). */
   sessionContextWindow?: number;
+  /** Model registry — passed to prompt builders so the budget engine can look up the
+   *  configured executor model's context window (Step 1 of resolution chain, issue #4142). */
+  modelRegistry?: MinimalModelRegistry;
 }
 
 export interface DispatchRule {
@@ -468,7 +472,7 @@ export const DISPATCH_RULES: DispatchRule[] = [
   },
   {
     name: "planning → plan-slice",
-    match: async ({ state, mid, midTitle, basePath, sessionContextWindow }) => {
+    match: async ({ state, mid, midTitle, basePath, sessionContextWindow, modelRegistry }) => {
       if (state.phase !== "planning") return null;
       if (!state.activeSlice) return missingSliceStop(mid, state.phase);
       const sid = state.activeSlice!.id;
@@ -485,6 +489,7 @@ export const DISPATCH_RULES: DispatchRule[] = [
           basePath,
           undefined,
           sessionContextWindow,
+          modelRegistry,
         ),
       };
     },
@@ -639,7 +644,7 @@ export const DISPATCH_RULES: DispatchRule[] = [
   },
   {
     name: "executing → execute-task (recover missing task plan → plan-slice)",
-    match: async ({ state, mid, midTitle, basePath, sessionContextWindow }) => {
+    match: async ({ state, mid, midTitle, basePath, sessionContextWindow, modelRegistry }) => {
       if (state.phase !== "executing" || !state.activeTask) return null;
       if (!state.activeSlice) return missingSliceStop(mid, state.phase);
       const sid = state.activeSlice!.id;
@@ -665,6 +670,7 @@ export const DISPATCH_RULES: DispatchRule[] = [
             basePath,
             undefined,
             sessionContextWindow,
+            modelRegistry,
           ),
         };
       }
@@ -674,7 +680,7 @@ export const DISPATCH_RULES: DispatchRule[] = [
   },
   {
     name: "executing → execute-task",
-    match: async ({ state, mid, basePath, sessionContextWindow }) => {
+    match: async ({ state, mid, basePath, sessionContextWindow, modelRegistry }) => {
       if (state.phase !== "executing" || !state.activeTask) return null;
       if (!state.activeSlice) return missingSliceStop(mid, state.phase);
       const sid = state.activeSlice!.id;
@@ -693,7 +699,7 @@ export const DISPATCH_RULES: DispatchRule[] = [
           tid,
           tTitle,
           basePath,
-          { sessionContextWindow },
+          { sessionContextWindow, modelRegistry },
         ),
       };
     },

--- a/src/resources/extensions/gsd/auto-prompts.ts
+++ b/src/resources/extensions/gsd/auto-prompts.ts
@@ -51,14 +51,14 @@ function capPreamble(preamble: string): string {
  * Uses the budget engine to compute task count ranges and inline context budgets
  * based on the configured executor model's context window.
  */
-function formatExecutorConstraints(): string {
+function formatExecutorConstraints(sessionContextWindow?: number): string {
   let windowTokens: number;
   try {
     const prefs = loadEffectiveGSDPreferences();
-    windowTokens = resolveExecutorContextWindow(undefined, prefs?.preferences);
+    windowTokens = resolveExecutorContextWindow(undefined, prefs?.preferences, sessionContextWindow);
   } catch (e) {
     logWarning("prompt", `resolveExecutorContextWindow failed: ${(e as Error).message}`);
-    windowTokens = 200_000; // safe default
+    windowTokens = sessionContextWindow && sessionContextWindow > 0 ? sessionContextWindow : 200_000;
   }
   const budgets = computeBudgets(windowTokens);
   const { min, max } = budgets.taskCountRange;
@@ -1207,7 +1207,7 @@ export async function buildResearchSlicePrompt(
 }
 
 export async function buildPlanSlicePrompt(
-  mid: string, _midTitle: string, sid: string, sTitle: string, base: string, level?: InlineLevel,
+  mid: string, _midTitle: string, sid: string, sTitle: string, base: string, level?: InlineLevel, sessionContextWindow?: number,
 ): Promise<string> {
   const inlineLevel = level ?? resolveInlineLevel();
   const roadmapPath = resolveMilestoneFile(base, mid, "ROADMAP");
@@ -1263,7 +1263,7 @@ export async function buildPlanSlicePrompt(
   const inlinedContext = capPreamble(`## Inlined Context (preloaded — do not re-read these files)\n\n${inlined.join("\n\n---\n\n")}`);
 
   // Build executor context constraints from the budget engine
-  const executorContextConstraints = formatExecutorConstraints();
+  const executorContextConstraints = formatExecutorConstraints(sessionContextWindow);
 
   const outputRelPath = relSliceFile(base, mid, sid, "PLAN");
   const commitInstruction = "Do not commit — .gsd/ planning docs are managed externally and not tracked in git.";
@@ -1294,6 +1294,9 @@ export interface ExecuteTaskPromptOptions {
   level?: InlineLevel;
   /** Override carry-forward paths (dependency-based instead of order-based). */
   carryForwardPaths?: string[];
+  /** Session model context window in tokens — passed through to the budget engine so budgets
+   *  reflect the real executor window instead of the 200K fallback (issue #4142). */
+  sessionContextWindow?: number;
 }
 
 export async function buildExecuteTaskPrompt(
@@ -1379,9 +1382,9 @@ export async function buildExecuteTaskPrompt(
   const activeOverrides = await loadActiveOverrides(base);
   const overridesSection = formatOverridesSection(activeOverrides);
 
-  // Compute verification budget for the executor's context window (issue #707)
+  // Compute verification budget for the executor's context window (issue #707, #4142)
   const prefs = loadEffectiveGSDPreferences();
-  const contextWindow = resolveExecutorContextWindow(undefined, prefs?.preferences);
+  const contextWindow = resolveExecutorContextWindow(undefined, prefs?.preferences, opts.sessionContextWindow);
   const budgets = computeBudgets(contextWindow);
   const verificationBudget = `~${Math.round(budgets.verificationBudgetChars / 1000)}K chars`;
 

--- a/src/resources/extensions/gsd/auto-prompts.ts
+++ b/src/resources/extensions/gsd/auto-prompts.ts
@@ -23,7 +23,7 @@ import type { GSDPreferences } from "./preferences.js";
 import { getLoadedSkills, type Skill } from "@gsd/pi-coding-agent";
 import { join, basename } from "node:path";
 import { existsSync } from "node:fs";
-import { computeBudgets, resolveExecutorContextWindow, truncateAtSectionBoundary } from "./context-budget.js";
+import { computeBudgets, resolveExecutorContextWindow, truncateAtSectionBoundary, type MinimalModelRegistry } from "./context-budget.js";
 import { getPendingGates, getPendingGatesForTurn } from "./gsd-db.js";
 import {
   GATE_REGISTRY,
@@ -51,11 +51,11 @@ function capPreamble(preamble: string): string {
  * Uses the budget engine to compute task count ranges and inline context budgets
  * based on the configured executor model's context window.
  */
-function formatExecutorConstraints(sessionContextWindow?: number): string {
+function formatExecutorConstraints(sessionContextWindow?: number, modelRegistry?: MinimalModelRegistry): string {
   let windowTokens: number;
   try {
     const prefs = loadEffectiveGSDPreferences();
-    windowTokens = resolveExecutorContextWindow(undefined, prefs?.preferences, sessionContextWindow);
+    windowTokens = resolveExecutorContextWindow(modelRegistry, prefs?.preferences, sessionContextWindow);
   } catch (e) {
     logWarning("prompt", `resolveExecutorContextWindow failed: ${(e as Error).message}`);
     windowTokens = sessionContextWindow && sessionContextWindow > 0 ? sessionContextWindow : 200_000;
@@ -1207,7 +1207,7 @@ export async function buildResearchSlicePrompt(
 }
 
 export async function buildPlanSlicePrompt(
-  mid: string, _midTitle: string, sid: string, sTitle: string, base: string, level?: InlineLevel, sessionContextWindow?: number,
+  mid: string, _midTitle: string, sid: string, sTitle: string, base: string, level?: InlineLevel, sessionContextWindow?: number, modelRegistry?: MinimalModelRegistry,
 ): Promise<string> {
   const inlineLevel = level ?? resolveInlineLevel();
   const roadmapPath = resolveMilestoneFile(base, mid, "ROADMAP");
@@ -1263,7 +1263,7 @@ export async function buildPlanSlicePrompt(
   const inlinedContext = capPreamble(`## Inlined Context (preloaded — do not re-read these files)\n\n${inlined.join("\n\n---\n\n")}`);
 
   // Build executor context constraints from the budget engine
-  const executorContextConstraints = formatExecutorConstraints(sessionContextWindow);
+  const executorContextConstraints = formatExecutorConstraints(sessionContextWindow, modelRegistry);
 
   const outputRelPath = relSliceFile(base, mid, sid, "PLAN");
   const commitInstruction = "Do not commit — .gsd/ planning docs are managed externally and not tracked in git.";
@@ -1297,6 +1297,9 @@ export interface ExecuteTaskPromptOptions {
   /** Session model context window in tokens — passed through to the budget engine so budgets
    *  reflect the real executor window instead of the 200K fallback (issue #4142). */
   sessionContextWindow?: number;
+  /** Model registry — passed to the budget engine so it can look up the configured executor
+   *  model's context window (Step 1 of resolution chain, issue #4142). */
+  modelRegistry?: MinimalModelRegistry;
 }
 
 export async function buildExecuteTaskPrompt(
@@ -1384,7 +1387,7 @@ export async function buildExecuteTaskPrompt(
 
   // Compute verification budget for the executor's context window (issue #707, #4142)
   const prefs = loadEffectiveGSDPreferences();
-  const contextWindow = resolveExecutorContextWindow(undefined, prefs?.preferences, opts.sessionContextWindow);
+  const contextWindow = resolveExecutorContextWindow(opts.modelRegistry, prefs?.preferences, opts.sessionContextWindow);
   const budgets = computeBudgets(contextWindow);
   const verificationBudget = `~${Math.round(budgets.verificationBudgetChars / 1000)}K chars`;
 

--- a/src/resources/extensions/gsd/auto/loop-deps.ts
+++ b/src/resources/extensions/gsd/auto/loop-deps.ts
@@ -16,7 +16,7 @@ import type {
   VerificationContext,
   VerificationResult,
 } from "../auto-verification.js";
-import type { DispatchAction } from "../auto-dispatch.js";
+import type { DispatchAction, DispatchContext } from "../auto-dispatch.js";
 import type { WorktreeResolver } from "../worktree-resolver.js";
 import type { CmuxLogLevel } from "../../cmux/index.js";
 import type { JournalEntry } from "../journal.js";
@@ -144,14 +144,7 @@ export interface LoopDeps {
   } | null>;
 
   // Dispatch
-  resolveDispatch: (dctx: {
-    basePath: string;
-    mid: string;
-    midTitle: string;
-    state: GSDState;
-    prefs: GSDPreferences | undefined;
-    session?: AutoSession;
-  }) => Promise<DispatchAction>;
+  resolveDispatch: (dctx: DispatchContext) => Promise<DispatchAction>;
   runPreDispatchHooks: (
     unitType: string,
     unitId: string,

--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -621,6 +621,7 @@ export async function runDispatch(
     state,
     prefs,
     session: s,
+    sessionContextWindow: ctx.model?.contextWindow,
   });
 
   if (dispatchResult.action === "stop") {

--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -622,6 +622,7 @@ export async function runDispatch(
     prefs,
     session: s,
     sessionContextWindow: ctx.model?.contextWindow,
+    modelRegistry: ctx.modelRegistry as import("../context-budget.js").MinimalModelRegistry | undefined,
   });
 
   if (dispatchResult.action === "stop") {

--- a/src/resources/extensions/gsd/tests/prompt-budget-enforcement.test.ts
+++ b/src/resources/extensions/gsd/tests/prompt-budget-enforcement.test.ts
@@ -8,6 +8,8 @@
  *   2. plan-slice.md template includes {{executorContextConstraints}} placeholder
  *   3. Executor constraints formatting varies with context window size
  *   4. Different context windows produce different budget-constrained outputs
+ *   5. Regression: prompt builders expose sessionContextWindow so callers can pass the real
+ *      model context window instead of always falling back to the 200K default (issue #4142)
  */
 
 import { describe, it, beforeEach, afterEach } from "node:test";
@@ -460,5 +462,72 @@ describe("prompt-budget: execute-task builder truncation pattern", () => {
       assert.ok(result.content.includes("[...truncated"), "should truncate when content exceeds 128K budget");
       assert.ok(result.droppedSections > 0, "should report dropped sections");
     }
+  });
+});
+
+// ─── Regression: issue #4142 — prompt builders must expose sessionContextWindow ─
+
+describe("prompt-budget: sessionContextWindow propagation (regression #4142)", () => {
+  it("formatExecutorConstraints accepts sessionContextWindow parameter", () => {
+    const src = readFileSync(join(__dirname, "..", "auto-prompts.ts"), "utf-8");
+    // The function signature must include sessionContextWindow so callers can pass the
+    // real model context window instead of always falling back to the 200K default.
+    assert.match(
+      src,
+      /function formatExecutorConstraints\([^)]*sessionContextWindow[^)]*\)/,
+      "formatExecutorConstraints must accept a sessionContextWindow parameter (issue #4142)",
+    );
+  });
+
+  it("formatExecutorConstraints passes sessionContextWindow to resolveExecutorContextWindow", () => {
+    const src = readFileSync(join(__dirname, "..", "auto-prompts.ts"), "utf-8");
+    // resolveExecutorContextWindow must receive sessionContextWindow so Step 2 can kick in
+    // when no execution model is configured in preferences.
+    assert.match(
+      src,
+      /resolveExecutorContextWindow\(undefined,[^)]*sessionContextWindow/,
+      "formatExecutorConstraints must pass sessionContextWindow to resolveExecutorContextWindow (issue #4142)",
+    );
+  });
+
+  it("buildPlanSlicePrompt accepts sessionContextWindow and threads it through", () => {
+    const src = readFileSync(join(__dirname, "..", "auto-prompts.ts"), "utf-8");
+    assert.match(
+      src,
+      /function buildPlanSlicePrompt\([^)]*sessionContextWindow[^)]*\)/,
+      "buildPlanSlicePrompt must accept sessionContextWindow (issue #4142)",
+    );
+    assert.match(
+      src,
+      /formatExecutorConstraints\(sessionContextWindow\)/,
+      "buildPlanSlicePrompt must pass sessionContextWindow to formatExecutorConstraints (issue #4142)",
+    );
+  });
+
+  it("ExecuteTaskPromptOptions declares sessionContextWindow field", () => {
+    const src = readFileSync(join(__dirname, "..", "auto-prompts.ts"), "utf-8");
+    assert.match(
+      src,
+      /interface ExecuteTaskPromptOptions \{[^}]*sessionContextWindow\?/s,
+      "ExecuteTaskPromptOptions must include sessionContextWindow (issue #4142)",
+    );
+  });
+
+  it("buildExecuteTaskPrompt uses opts.sessionContextWindow for resolveExecutorContextWindow", () => {
+    const src = readFileSync(join(__dirname, "..", "auto-prompts.ts"), "utf-8");
+    assert.match(
+      src,
+      /resolveExecutorContextWindow\(undefined,[^)]*opts\.sessionContextWindow/,
+      "buildExecuteTaskPrompt must pass opts.sessionContextWindow to resolveExecutorContextWindow (issue #4142)",
+    );
+  });
+
+  it("DispatchContext declares sessionContextWindow field", () => {
+    const src = readFileSync(join(__dirname, "..", "auto-dispatch.ts"), "utf-8");
+    assert.match(
+      src,
+      /interface DispatchContext \{[^}]*sessionContextWindow\?/s,
+      "DispatchContext must include sessionContextWindow so dispatch rules can thread it through (issue #4142)",
+    );
   });
 });

--- a/src/resources/extensions/gsd/tests/prompt-budget-enforcement.test.ts
+++ b/src/resources/extensions/gsd/tests/prompt-budget-enforcement.test.ts
@@ -485,7 +485,7 @@ describe("prompt-budget: sessionContextWindow propagation (regression #4142)", (
     // when no execution model is configured in preferences.
     assert.match(
       src,
-      /resolveExecutorContextWindow\(undefined,[^)]*sessionContextWindow/,
+      /resolveExecutorContextWindow\([^)]*sessionContextWindow/,
       "formatExecutorConstraints must pass sessionContextWindow to resolveExecutorContextWindow (issue #4142)",
     );
   });
@@ -499,7 +499,7 @@ describe("prompt-budget: sessionContextWindow propagation (regression #4142)", (
     );
     assert.match(
       src,
-      /formatExecutorConstraints\(sessionContextWindow\)/,
+      /formatExecutorConstraints\(sessionContextWindow[^)]*\)/,
       "buildPlanSlicePrompt must pass sessionContextWindow to formatExecutorConstraints (issue #4142)",
     );
   });
@@ -517,7 +517,7 @@ describe("prompt-budget: sessionContextWindow propagation (regression #4142)", (
     const src = readFileSync(join(__dirname, "..", "auto-prompts.ts"), "utf-8");
     assert.match(
       src,
-      /resolveExecutorContextWindow\(undefined,[^)]*opts\.sessionContextWindow/,
+      /resolveExecutorContextWindow\([^)]*opts\.sessionContextWindow/,
       "buildExecuteTaskPrompt must pass opts.sessionContextWindow to resolveExecutorContextWindow (issue #4142)",
     );
   });
@@ -600,7 +600,7 @@ describe("prompt-budget: modelRegistry propagation (Fix C, issue #4142)", () => 
     // The planning→plan-slice rule must destructure and forward modelRegistry
     assert.match(
       src,
-      /name:\s*["']planning → plan-slice["'][^}]*modelRegistry[^}]*buildPlanSlicePrompt/s,
+      /name:\s*["']planning → plan-slice["'][\s\S]*?modelRegistry[\s\S]*?buildPlanSlicePrompt/s,
       "planning→plan-slice rule must destructure and pass modelRegistry (Fix C, issue #4142)",
     );
   });
@@ -609,7 +609,7 @@ describe("prompt-budget: modelRegistry propagation (Fix C, issue #4142)", () => 
     const src = readFileSync(join(__dirname, "..", "auto-dispatch.ts"), "utf-8");
     assert.match(
       src,
-      /name:\s*["']executing → execute-task["'][^}]*modelRegistry[^}]*buildExecuteTaskPrompt/s,
+      /name:\s*["']executing → execute-task["'][\s\S]*?modelRegistry[\s\S]*?buildExecuteTaskPrompt/s,
       "executing→execute-task rule must destructure and pass modelRegistry (Fix C, issue #4142)",
     );
   });

--- a/src/resources/extensions/gsd/tests/prompt-budget-enforcement.test.ts
+++ b/src/resources/extensions/gsd/tests/prompt-budget-enforcement.test.ts
@@ -531,3 +531,86 @@ describe("prompt-budget: sessionContextWindow propagation (regression #4142)", (
     );
   });
 });
+
+// ─── Regression: issue #4142 Fix C — modelRegistry threading ─────────────────
+
+describe("prompt-budget: modelRegistry propagation (Fix C, issue #4142)", () => {
+  it("formatExecutorConstraints accepts modelRegistry parameter", () => {
+    const src = readFileSync(join(__dirname, "..", "auto-prompts.ts"), "utf-8");
+    assert.match(
+      src,
+      /function formatExecutorConstraints\([^)]*modelRegistry[^)]*\)/,
+      "formatExecutorConstraints must accept a modelRegistry parameter (Fix C, issue #4142)",
+    );
+  });
+
+  it("formatExecutorConstraints passes modelRegistry (not undefined) to resolveExecutorContextWindow", () => {
+    const src = readFileSync(join(__dirname, "..", "auto-prompts.ts"), "utf-8");
+    // The call must pass modelRegistry as first arg (not hardcoded undefined) so Step 1 works
+    assert.match(
+      src,
+      /resolveExecutorContextWindow\(modelRegistry[^)]*\)/,
+      "formatExecutorConstraints must pass modelRegistry as first arg to resolveExecutorContextWindow (Fix C, issue #4142)",
+    );
+  });
+
+  it("buildPlanSlicePrompt accepts modelRegistry parameter and threads it to formatExecutorConstraints", () => {
+    const src = readFileSync(join(__dirname, "..", "auto-prompts.ts"), "utf-8");
+    assert.match(
+      src,
+      /function buildPlanSlicePrompt\([^)]*modelRegistry[^)]*\)/,
+      "buildPlanSlicePrompt must accept modelRegistry (Fix C, issue #4142)",
+    );
+    assert.match(
+      src,
+      /formatExecutorConstraints\(sessionContextWindow,\s*modelRegistry\)/,
+      "buildPlanSlicePrompt must pass modelRegistry to formatExecutorConstraints (Fix C, issue #4142)",
+    );
+  });
+
+  it("ExecuteTaskPromptOptions declares modelRegistry field", () => {
+    const src = readFileSync(join(__dirname, "..", "auto-prompts.ts"), "utf-8");
+    assert.match(
+      src,
+      /interface ExecuteTaskPromptOptions \{[^}]*modelRegistry\?/s,
+      "ExecuteTaskPromptOptions must include modelRegistry (Fix C, issue #4142)",
+    );
+  });
+
+  it("buildExecuteTaskPrompt passes opts.modelRegistry to resolveExecutorContextWindow", () => {
+    const src = readFileSync(join(__dirname, "..", "auto-prompts.ts"), "utf-8");
+    assert.match(
+      src,
+      /resolveExecutorContextWindow\(opts\.modelRegistry[^)]*\)/,
+      "buildExecuteTaskPrompt must pass opts.modelRegistry to resolveExecutorContextWindow (Fix C, issue #4142)",
+    );
+  });
+
+  it("DispatchContext declares modelRegistry field", () => {
+    const src = readFileSync(join(__dirname, "..", "auto-dispatch.ts"), "utf-8");
+    assert.match(
+      src,
+      /interface DispatchContext \{[^}]*modelRegistry\?/s,
+      "DispatchContext must include modelRegistry so dispatch rules can thread it through (Fix C, issue #4142)",
+    );
+  });
+
+  it("DISPATCH_RULES planning→plan-slice passes modelRegistry to buildPlanSlicePrompt", () => {
+    const src = readFileSync(join(__dirname, "..", "auto-dispatch.ts"), "utf-8");
+    // The planning→plan-slice rule must destructure and forward modelRegistry
+    assert.match(
+      src,
+      /name:\s*["']planning → plan-slice["'][^}]*modelRegistry[^}]*buildPlanSlicePrompt/s,
+      "planning→plan-slice rule must destructure and pass modelRegistry (Fix C, issue #4142)",
+    );
+  });
+
+  it("DISPATCH_RULES executing→execute-task passes modelRegistry to buildExecuteTaskPrompt", () => {
+    const src = readFileSync(join(__dirname, "..", "auto-dispatch.ts"), "utf-8");
+    assert.match(
+      src,
+      /name:\s*["']executing → execute-task["'][^}]*modelRegistry[^}]*buildExecuteTaskPrompt/s,
+      "executing→execute-task rule must destructure and pass modelRegistry (Fix C, issue #4142)",
+    );
+  });
+});


### PR DESCRIPTION
## TL;DR

**What:** Thread both `modelRegistry` and `sessionContextWindow` through to the budget engine so prompt builders use the real executor context window instead of always falling back to 200K.
**Why:** Two call sites passed `undefined` for the registry to `resolveExecutorContextWindow()`, always hitting the 200K default — even on 1M-token models or when an explicit executor model is configured.
**How:** Add `modelRegistry?` and `sessionContextWindow?` to `DispatchContext` and `ExecuteTaskPromptOptions`; populate both in `runDispatch()` and `dispatchDirectPhase()`; forward through every call to the budget engine.

## What

Five files changed across the auto-mode dispatch/prompt chain:

- **`auto-prompts.ts`**: `formatExecutorConstraints(sessionContextWindow?, modelRegistry?)` now accepts and forwards both values; `buildPlanSlicePrompt` gains both as trailing parameters; `ExecuteTaskPromptOptions` gains `sessionContextWindow?` and `modelRegistry?` fields; `buildExecuteTaskPrompt` passes both to `resolveExecutorContextWindow`.
- **`auto-dispatch.ts`**: `DispatchContext` gains `sessionContextWindow?` and `modelRegistry?`; the three dispatch rules that build plan-slice and execute-task prompts destructure and forward both.
- **`auto/phases.ts`**: `runDispatch()` populates `sessionContextWindow: ctx.model?.contextWindow` and `modelRegistry: ctx.modelRegistry` in the dispatch context it constructs.
- **`auto-direct-dispatch.ts`**: both `buildPlanSlicePrompt` and `buildExecuteTaskPrompt` calls now pass `ctx.model?.contextWindow` and `ctx.modelRegistry`.
- **`tests/prompt-budget-enforcement.test.ts`**: 14 regression tests (6 for Fix B, 8 for Fix C) verify the structural wiring at source-code level.

## Why

`resolveExecutorContextWindow()` has three resolution steps:

1. Look up the configured executor model in `modelRegistry`.
2. Fall back to `sessionContextWindow` if registry lookup fails/is absent.
3. Fall back to `DEFAULT_CONTEXT_WINDOW` (200 000).

The only correct prior call site was `auto-timers.ts`, which already passed both `ctx.modelRegistry` and `ctx.model?.contextWindow`. The two broken call sites in `auto-prompts.ts` passed `undefined` for both, always hitting step 3. On a 1M-token model this caused:

- Task count ceilings of 6 instead of 8 (wrong `max` from `computeBudgets`).
- Carry-forward budgets ~5× too small.
- Verification budget strings referencing the wrong window size.

Closes #4142

## How

**Fix C (full registry + sessionContextWindow threading)** was chosen:

- **Fix A (bump DEFAULT_CONTEXT_WINDOW)**: A stopgap — silences the symptom for one model family while hiding the root cause for any model whose window differs from the new default.
- **Fix B (sessionContextWindow only)**: Better than A, but still wrong when `preferences.models.execution` points to a model different from the session model — it would use the session window (too large) instead of the configured executor's window.
- **Fix C (registry + sessionContextWindow)**: Correct for all cases. Step 1 resolves the configured executor model's real window. Step 2 (sessionContextWindow) catches the common case where no executor model is explicitly configured. Step 3 (200K) is a last-resort fallback only. Matches exactly what `auto-timers.ts` already does correctly.

**Test-first approach**: The 14 regression tests in `prompt-budget-enforcement.test.ts` specify the required structural properties (function signatures, interface fields, call expressions) as a durable contract against future regressions.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

---

> This PR was generated with Claude (AI-assisted) per CONTRIBUTING.md disclosure requirement.