### PR TITLE
Split Container.clear() into clear() and detachChildren()

### DIFF
--- a/packages/pi-coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/interactive-mode.ts
@@ -1402,7 +1402,9 @@ export class InteractiveMode {
 
 		// widgetContainerAbove: spacer collapses when pinned content is visible
 		// so there's no extra blank line between pinned output and the editor border.
-		this.widgetContainerAbove.clear();
+		// Use detachChildren() (not clear()) — the extensionWidgetsAbove map owns
+		// disposal; clear() would dispose every mounted widget on every re-render.
+		this.widgetContainerAbove.detachChildren();
 		const pinned = this.pinnedMessageContainer;
 		this.widgetContainerAbove.addChild({
 			render: () => pinned.children.length > 0 ? [] : [""],
@@ -1422,7 +1424,9 @@ export class InteractiveMode {
 		spacerWhenEmpty: boolean,
 		leadingSpacer: boolean,
 	): void {
-		container.clear();
+		// Detach without disposing — the widgets map owns lifecycle; disposing
+		// here would kill refresh timers and subscriptions on every re-render.
+		container.detachChildren();
 
 		if (widgets.size === 0) {
 			if (spacerWhenEmpty) {

--- a/packages/pi-tui/src/__tests__/tui.test.ts
+++ b/packages/pi-tui/src/__tests__/tui.test.ts
@@ -1,7 +1,8 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
-import { TUI } from "../tui.js";
+import { Container, TUI } from "../tui.js";
+import type { Component } from "../tui.js";
 import type { Terminal } from "../terminal.js";
 
 function makeTerminal(): Terminal {
@@ -46,5 +47,41 @@ describe("TUI", () => {
 		assert.deepEqual(received, ["\x1b"]);
 		assert.equal(anyTui.cellSizeQueryPending, false);
 		assert.equal(anyTui.inputBuffer, "");
+	});
+});
+
+describe("Container", () => {
+	function makeDisposableChild(counter: { disposed: number }): Component & { dispose(): void } {
+		return {
+			render: () => [],
+			invalidate() {},
+			dispose() {
+				counter.disposed++;
+			},
+		};
+	}
+
+	it("detachChildren() removes children without disposing them", () => {
+		const c = new Container();
+		const counter = { disposed: 0 };
+		c.addChild(makeDisposableChild(counter));
+		c.addChild(makeDisposableChild(counter));
+
+		c.detachChildren();
+
+		assert.equal(c.children.length, 0);
+		assert.equal(counter.disposed, 0);
+	});
+
+	it("clear() still disposes children (regression guard for detach/dispose split)", () => {
+		const c = new Container();
+		const counter = { disposed: 0 };
+		c.addChild(makeDisposableChild(counter));
+		c.addChild(makeDisposableChild(counter));
+
+		c.clear();
+
+		assert.equal(c.children.length, 0);
+		assert.equal(counter.disposed, 2);
 	});
 });

--- a/packages/pi-tui/src/tui.ts
+++ b/packages/pi-tui/src/tui.ts
@@ -197,6 +197,17 @@ export class Container implements Component {
 		this._prevRender = null;
 	}
 
+	/**
+	 * Remove all children without calling dispose on them.
+	 * Use when child lifecycle is owned elsewhere and the container is only a
+	 * render mount (e.g. extension widget containers in InteractiveMode, where
+	 * the extensionWidgets* maps own disposal).
+	 */
+	detachChildren(): void {
+		this.children = [];
+		this._prevRender = null;
+	}
+
 	invalidate(): void {
 		for (const child of this.children) {
 			child.invalidate?.();

--- a/src/resources/extensions/gsd/auto-start.ts
+++ b/src/resources/extensions/gsd/auto-start.ts
@@ -806,6 +806,9 @@ export async function bootstrapAutoSession(
 
     ctx.ui.setStatus("gsd-auto", s.stepMode ? "next" : "auto");
     ctx.ui.setFooter(hideFooter);
+    // Hide gsd-health during AUTO — gsd-progress is the single source of truth
+    // for last-commit / cost / health signal while auto is running.
+    ctx.ui.setWidget("gsd-health", undefined);
     const modeLabel = s.stepMode ? "Step-mode" : "Auto-mode";
     const pendingCount = (state.registry ?? []).filter(
       (m) => m.status !== "complete" && m.status !== "parked",

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -199,6 +199,7 @@ import {
   postUnitPostVerification,
 } from "./auto-post-unit.js";
 import { bootstrapAutoSession, openProjectDbIfPresent, type BootstrapDeps } from "./auto-start.js";
+import { initHealthWidget } from "./health-widget.js";
 import { autoLoop, resolveAgentEnd, resolveAgentEndCancelled, _resetPendingResolve, isSessionSwitchInFlight, type LoopDeps, type ErrorContext } from "./auto-loop.js";
 // Slice-level parallelism (#2340)
 import { getEligibleSlices } from "./slice-parallel-eligibility.js";
@@ -650,6 +651,7 @@ function handleLostSessionLock(
   ctx?.ui.setStatus("gsd-auto", undefined);
   ctx?.ui.setWidget("gsd-progress", undefined);
   ctx?.ui.setFooter(undefined);
+  if (ctx) initHealthWidget(ctx);
 }
 
 /**
@@ -684,6 +686,7 @@ function cleanupAfterLoopExit(ctx: ExtensionContext): void {
     ctx.ui.setStatus("gsd-auto", undefined);
     ctx.ui.setWidget("gsd-progress", undefined);
     ctx.ui.setFooter(undefined);
+    initHealthWidget(ctx);
   }
 
   // Restore CWD out of worktree back to original project root
@@ -943,6 +946,7 @@ export async function stopAuto(
     ctx?.ui.setStatus("gsd-auto", undefined);
     ctx?.ui.setWidget("gsd-progress", undefined);
     ctx?.ui.setFooter(undefined);
+    if (ctx) initHealthWidget(ctx);
     restoreProjectRootEnv();
     restoreMilestoneLockEnv();
 
@@ -1044,6 +1048,7 @@ export async function pauseAuto(
   ctx?.ui.setStatus("gsd-auto", "paused");
   ctx?.ui.setWidget("gsd-progress", undefined);
   ctx?.ui.setFooter(undefined);
+  if (ctx) initHealthWidget(ctx);
   const resumeCmd = s.stepMode ? "/gsd next" : "/gsd auto";
   ctx?.ui.notify(
     `${s.stepMode ? "Step" : "Auto"}-mode paused (Escape). Type to interact, or ${resumeCmd} to resume.`,


### PR DESCRIPTION
Closes #4151

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Split `Container.clear()` into two methods: `clear()` (disposes children) and `detachChildren()` (removes without disposing).
**Why:** Widget containers in InteractiveMode and GSD extension own child lifecycle elsewhere; calling `clear()` on every re-render was incorrectly disposing widgets and killing their timers/subscriptions.
**How:** Add `detachChildren()` method and update call sites to use it when child disposal is owned externally.

## What

- Added `Container.detachChildren()` method that removes all children without calling `dispose()` on them
- Updated `InteractiveMode` to use `detachChildren()` instead of `clear()` for widget containers (widgetContainerAbove and the generic container in `_renderWidgetContainer()`)
- Updated GSD extension (`auto.ts`, `auto-start.ts`) to call `initHealthWidget()` at appropriate lifecycle points when clearing UI state
- Added unit tests to verify the distinction between `detachChildren()` (no disposal) and `clear()` (with disposal)

## Why

The `Container.clear()` method was being called on every re-render in InteractiveMode and GSD extension code, but the actual widget lifecycle (disposal) is owned by external maps (`extensionWidgetsAbove`, `extensionWidgets*`). Calling `clear()` was disposing widgets on every render cycle, killing their refresh timers and subscriptions prematurely. The container should only be a render mount point in these cases, not own the widget lifecycle.

## How

- Added `detachChildren()` as a new public method that clears the children array and `_prevRender` without calling `dispose()` on children
- Documented the use case: when child lifecycle is owned elsewhere and the container is only a render mount
- Updated InteractiveMode to use `detachChildren()` for widget containers
- Updated GSD extension cleanup/pause/stop handlers to call `initHealthWidget()` to properly manage the health widget state
- Added regression tests to ensure `detachChildren()` doesn't dispose and `clear()` still does

## Change type

- [x] `feat` — New feature or capability
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [x] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [x] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included — Added two unit tests for `Container.detachChildren()` and `Container.clear()` to verify disposal behavior
- [ ] Manual testing — steps described above
- [ ] No tests needed — explained above

## AI disclosure

- [ ] This PR includes AI-assisted code