### PR TITLE
fix(gsd): set completed_at when reconciling task status to complete

### DIFF
--- a/src/resources/extensions/gsd/state.ts
+++ b/src/resources/extensions/gsd/state.ts
@@ -684,7 +684,7 @@ async function reconcileSliceTasks(
     const summaryPath = resolveTaskFile(basePath, milestoneId, sliceId, t.id, "SUMMARY");
     if (summaryPath && existsSync(summaryPath)) {
       try {
-        updateTaskStatus(milestoneId, sliceId, t.id, "complete");
+        updateTaskStatus(milestoneId, sliceId, t.id, "complete", new Date().toISOString());
         logWarning("reconcile", `task ${milestoneId}/${sliceId}/${t.id} status reconciled from "${t.status}" to "complete" (#2514)`, { mid: milestoneId, sid: sliceId, tid: t.id });
         reconciled = true;
       } catch (e) {

--- a/src/resources/extensions/gsd/tests/completed-at-reconcile.test.ts
+++ b/src/resources/extensions/gsd/tests/completed-at-reconcile.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Regression test for #4129: tasks.completed_at stays NULL when status is
+ * reconciled to 'complete' via the file-existence path in state.ts.
+ *
+ * Root cause: reconcileSliceTasks called
+ *   updateTaskStatus(milestoneId, sliceId, t.id, "complete")
+ * without a completedAt timestamp, so the column stays NULL.
+ *
+ * Fix: pass new Date().toISOString() as the 5th argument.
+ */
+
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const stateSource = readFileSync(join(__dirname, "..", "state.ts"), "utf-8");
+
+describe("completed-at reconcile (#4129)", () => {
+  test("reconcileSliceTasks passes a completedAt timestamp when setting status to complete", () => {
+    // Before the fix, state.ts had:
+    //   updateTaskStatus(milestoneId, sliceId, t.id, "complete")
+    // which leaves completed_at NULL in the DB.
+    // After the fix, a timestamp must be passed as the 5th argument.
+    assert.doesNotMatch(
+      stateSource,
+      /updateTaskStatus\(\s*milestoneId\s*,\s*sliceId\s*,\s*t\.id\s*,\s*["']complete["']\s*\)/,
+      "updateTaskStatus must not be called without a completedAt timestamp when reconciling tasks to 'complete' (#4129)",
+    );
+  });
+
+  test("reconcileSliceTasks passes new Date().toISOString() as the completedAt argument", () => {
+    // Positive assertion: the fixed call must include a timestamp.
+    assert.match(
+      stateSource,
+      /updateTaskStatus\(\s*milestoneId\s*,\s*sliceId\s*,\s*t\.id\s*,\s*["']complete["']\s*,\s*new Date\(\)\.toISOString\(\)\s*\)/,
+      "reconcileSliceTasks must pass new Date().toISOString() as completedAt when setting task status to 'complete' (#4129)",
+    );
+  });
+});


### PR DESCRIPTION
## TL;DR

**What:** Populate `completed_at` when `reconcileSliceTasks` sets a task's status to `complete` via the file-existence reconcile path.
**Why:** The column was always `NULL` for tasks completed through this path, making it useless for analytics, UI sorting, and telemetry.
**How:** Pass `new Date().toISOString()` as the fifth argument to `updateTaskStatus` at the reconcile call site in `state.ts`.

## What

Single-line change in `src/resources/extensions/gsd/state.ts` (`reconcileSliceTasks`, line 687):

```diff
- updateTaskStatus(milestoneId, sliceId, t.id, "complete");
+ updateTaskStatus(milestoneId, sliceId, t.id, "complete", new Date().toISOString());
```

Includes a new regression test (`tests/completed-at-reconcile.test.ts`) with two source-level assertions that fail before the fix and pass after.

## Why

`updateTaskStatus` accepts an optional `completedAt` parameter (5th argument). When omitted, it defaults to `null`. The reconcile path in `reconcileSliceTasks` — which marks tasks complete based on the presence of a `SUMMARY` file on disk — was calling this function without the timestamp, leaving `tasks.completed_at = NULL` for every task completed through that path.

The `completed_at` column exists in the schema and is already populated correctly by other paths (`auto-recovery.ts`, `workflow-reconcile.ts`). This was the only call site that missed the argument.

Closes #4129

## How

`updateTaskStatus` already handles the timestamp correctly — it simply needed to be passed. No changes to `gsd-db.ts` or the schema were required.

The regression test follows the source-level assertion pattern established in `stale-slice-rows.test.ts`: it reads `state.ts` as a string and asserts on the call pattern directly, which makes it deterministic and fast without requiring a full filesystem fixture.

## Change type checklist

- [x] `fix` — Bug fix

> 🤖 Generated by Claude