### PR TITLE
fix(cli): use junction symlinks in merged node_modules path

### DIFF
--- a/src/resource-loader.ts
+++ b/src/resource-loader.ts
@@ -393,7 +393,7 @@ function reconcileMergedNodeModules(
       // Skip the gsd-pi package itself and dotfiles
       if (entry.name === basename(packageRoot)) continue
       if (entry.name.startsWith('.')) continue
-      try { symlinkSync(join(hoisted, entry.name), join(agentNodeModules, entry.name)); linkedCount++ } catch { /* skip individual */ }
+      try { symlinkSync(join(hoisted, entry.name), join(agentNodeModules, entry.name), 'junction'); linkedCount++ } catch { /* skip individual */ }
     }
   } catch (err) {
     console.error(`[gsd] WARN: Failed to read hoisted node_modules at ${hoisted}: ${err instanceof Error ? err.message : err}`)
@@ -408,7 +408,7 @@ function reconcileMergedNodeModules(
       const link = join(agentNodeModules, entry.name)
       // Replace hoisted symlink with internal version (internal takes precedence)
       try { lstatSync(link); unlinkSync(link) } catch { /* didn't exist — will create below */ }
-      try { symlinkSync(join(internal, entry.name), link); linkedCount++ } catch { /* skip individual */ }
+      try { symlinkSync(join(internal, entry.name), link, 'junction'); linkedCount++ } catch { /* skip individual */ }
     }
   } catch (err) {
     console.error(`[gsd] WARN: Failed to read internal node_modules at ${internal}: ${err instanceof Error ? err.message : err}`)

--- a/src/tests/node-modules-symlink.test.ts
+++ b/src/tests/node-modules-symlink.test.ts
@@ -5,8 +5,9 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { existsSync, lstatSync, mkdirSync, mkdtempSync, readFileSync, readlinkSync, readdirSync, rmSync, symlinkSync, unlinkSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
 
 // --- Integration tests via initResources (source/monorepo path) ---
 
@@ -283,4 +284,20 @@ test("merged node_modules marker uses fingerprint including directory entries", 
   const h2 = readdirSync(hoisted).sort().join(",");
   const fingerprint2 = `${fakePackageRoot}\n${h2}\n${i}`;
   assert.notEqual(fingerprint, fingerprint2, "fingerprint should change when deps change");
+});
+
+test("reconcileMergedNodeModules uses junction symlinks for Windows compatibility", () => {
+  const testDir = dirname(fileURLToPath(import.meta.url));
+  const source = readFileSync(join(testDir, "..", "resource-loader.ts"), "utf-8");
+
+  assert.match(
+    source,
+    /symlinkSync\(join\(hoisted,\s*entry\.name\),\s*join\(agentNodeModules,\s*entry\.name\),\s*'junction'\)/,
+    "hoisted merged symlink must use 'junction'",
+  );
+  assert.match(
+    source,
+    /symlinkSync\(join\(internal,\s*entry\.name\),\s*link,\s*'junction'\)/,
+    "internal merged symlink must use 'junction'",
+  );
 });


### PR DESCRIPTION
## TL;DR

**What:** Fix Windows extension bootstrap by using junction symlinks in the pnpm merged `node_modules` path.
**Why:** On Windows without Developer Mode, plain directory symlink creation fails and silently breaks GSD slash-command registration.
**How:** Add `'junction'` to both `symlinkSync` calls in `reconcileMergedNodeModules()` and add a regression test that enforces this invariant.

## What

This PR updates the merged-node_modules branch in `src/resource-loader.ts` to pass `'junction'` for both symlink creation points:

- hoisted entries symlinked into `~/.gsd/agent/node_modules`
- internal entries overlayed into the same merged directory

It also adds a regression test in `src/tests/node-modules-symlink.test.ts` that asserts both merged-path `symlinkSync(...)` calls include `'junction'`.

## Why

`reconcileMergedNodeModules()` previously created directory symlinks without specifying a type, which can fail with `EPERM` on Windows machines that do not have Developer Mode enabled. Those failures were swallowed by per-entry `catch` blocks, leaving the merged directory incomplete and causing GSD extension load failures.

Closes #4158

## How

- Changed:
  - `symlinkSync(join(hoisted, entry.name), join(agentNodeModules, entry.name), 'junction')`
  - `symlinkSync(join(internal, entry.name), link, 'junction')`
- Added regression guard test:
  - `reconcileMergedNodeModules uses junction symlinks for Windows compatibility`

Manual verification executed locally:

- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/tests/node-modules-symlink.test.ts`
- Result: `9 passed, 0 failed`

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [ ] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

## AI disclosure

- [x] This PR includes AI-assisted code (Codex). Verified by targeted unit test execution shown above.
