### PR TITLE
fix(gitignore): respect git.manage_gitignore:false in 4 call sites (#4161)

### DIFF
--- a/src/resources/extensions/gsd/doctor-runtime-checks.ts
+++ b/src/resources/extensions/gsd/doctor-runtime-checks.ts
@@ -332,7 +332,9 @@ export async function checkRuntimeHealth(
           });
 
           if (shouldFix("gitignore_missing_patterns")) {
-            ensureGitignore(basePath);
+            const gitPrefs = loadEffectiveGSDPreferences()?.preferences?.git;
+            const manageGitignore = gitPrefs?.manage_gitignore;
+            ensureGitignore(basePath, { manageGitignore });
             fixesApplied.push("added missing GSD runtime patterns to .gitignore");
           }
         }

--- a/src/resources/extensions/gsd/guided-flow.ts
+++ b/src/resources/extensions/gsd/guided-flow.ts
@@ -535,9 +535,11 @@ function bootstrapGsdProject(basePath: string): void {
   mkdirSync(join(root, "milestones"), { recursive: true });
   mkdirSync(join(root, "runtime"), { recursive: true });
 
-  ensureGitignore(basePath);
+  const prefs = loadEffectiveGSDPreferences()?.preferences ?? {};
+  const manageGitignore = prefs.git?.manage_gitignore;
+  ensureGitignore(basePath, { manageGitignore });
   ensurePreferences(basePath);
-  untrackRuntimeFiles(basePath);
+  if (manageGitignore !== false) untrackRuntimeFiles(basePath);
 }
 
 /**
@@ -1265,8 +1267,10 @@ export async function showSmartEntry(
   }
 
   // ── Ensure .gitignore has baseline patterns ──────────────────────────
-  ensureGitignore(basePath);
-  untrackRuntimeFiles(basePath);
+  const gitPrefs = loadEffectiveGSDPreferences()?.preferences?.git;
+  const manageGitignore = gitPrefs?.manage_gitignore;
+  ensureGitignore(basePath, { manageGitignore });
+  if (manageGitignore !== false) untrackRuntimeFiles(basePath);
 
   // ── Self-heal stale runtime records from crashed auto-mode sessions ──
   selfHealRuntimeRecords(basePath, ctx);

--- a/src/resources/extensions/gsd/init-wizard.ts
+++ b/src/resources/extensions/gsd/init-wizard.ts
@@ -246,8 +246,10 @@ export async function showProjectInit(
   }
 
   // Ensure .gitignore
-  ensureGitignore(basePath);
-  untrackRuntimeFiles(basePath);
+  const gitPrefs = loadEffectiveGSDPreferences()?.preferences?.git;
+  const manageGitignore = gitPrefs?.manage_gitignore;
+  ensureGitignore(basePath, { manageGitignore });
+  if (manageGitignore !== false) untrackRuntimeFiles(basePath);
 
   // Auto-generate codebase map for instant agent orientation
   try {


### PR DESCRIPTION
## Fix: git.manage_gitignore:false not respected (#4161)

### Problem
The `git.manage_gitignore: false` preference (introduced in #950/#952) was only checked in `auto-start.ts`. Four other call sites called `ensureGitignore()` without passing the preference, causing `.gitignore` to be modified even when user explicitly disabled it.

### Solution
All four call sites now read `git.manage_gitignore` from `loadEffectiveGSDPreferences()` and pass it through:

| File | Function |
|------|----------|
| `guided-flow.ts` | `bootstrapGsdProject()` |
| `guided-flow.ts` | `showHeadlessMilestoneCreation()` |
| `init-wizard.ts` | `runProjectInit()` |
| `doctor-runtime-checks.ts` | `checkGitignorePatterns()` |

All also applied the same `if (manageGitignore !== false)` guard to `untrackRuntimeFiles()`.

Closes #4161