### PR TITLE
fix(context): cap KNOWLEDGE.md injection at 8K chars (#4143)

### DIFF
--- a/src/resources/extensions/gsd/bootstrap/system-context.ts
+++ b/src/resources/extensions/gsd/bootstrap/system-context.ts
@@ -237,9 +237,23 @@ export function loadKnowledgeBlock(gsdHomeDir: string, cwd: string): { block: st
     return { block: "", globalSizeKb: 0 };
   }
 
+  // Cap knowledge block to ~8 000 chars to avoid bloating every system prompt.
+  // Same cap as CODEBASE.md — both are injected on every prompt round-trip.
+  const MAX_KNOWLEDGE_CHARS = 8_000;
+
   const parts: string[] = [];
-  if (globalKnowledge) parts.push(`## Global Knowledge\n\n${globalKnowledge}`);
-  if (projectKnowledge) parts.push(`## Project Knowledge\n\n${projectKnowledge}`);
+  if (globalKnowledge) {
+    const truncated = globalKnowledge.length > MAX_KNOWLEDGE_CHARS
+      ? globalKnowledge.slice(0, MAX_KNOWLEDGE_CHARS) + "\n\n*(truncated — see ~/.gsd/agent/KNOWLEDGE.md for full content)*"
+      : globalKnowledge;
+    parts.push(`## Global Knowledge\n\n${truncated}`);
+  }
+  if (projectKnowledge) {
+    const truncated = projectKnowledge.length > MAX_KNOWLEDGE_CHARS
+      ? projectKnowledge.slice(0, MAX_KNOWLEDGE_CHARS) + "\n\n*(truncated — see .gsd/KNOWLEDGE.md for full content)*"
+      : projectKnowledge;
+    parts.push(`## Project Knowledge\n\n${truncated}`);
+  }
   return {
     block: `\n\n[KNOWLEDGE — Rules, patterns, and lessons learned]\n\n${parts.join("\n\n")}`,
     globalSizeKb,


### PR DESCRIPTION
## Fix: KNOWLEDGE.md injected without size cap (#4143)

### Problem
`loadKnowledgeBlock()` reads entire KNOWLEDGE.md files and injects them raw into the system prompt. A 101KB KNOWLEDGE.md (~25K tokens) causes context bloat — "Compacted from 1,614,431 tokens" after just 2-3 turns.

### Solution
Adds `MAX_KNOWLEDGE_CHARS = 8_000` cap to `loadKnowledgeBlock()`, matching the existing CODEBASE.md truncation strategy. Both global and project knowledge now truncate with a note pointing to the full file.

### Changed
`src/resources/extensions/gsd/bootstrap/system-context.ts`
- `loadKnowledgeBlock()`: truncate each knowledge block at 8,000 chars

Closes #4143