### PR TITLE
fix(context-budget): pass modelRegistry to resolveExecutorContextWindow (#4142)

### DIFF
--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -465,7 +465,7 @@ export const DISPATCH_RULES: DispatchRule[] = [
   },
   {
     name: "planning → plan-slice",
-    match: async ({ state, mid, midTitle, basePath }) => {
+    match: async ({ state, mid, midTitle, basePath, ctx }) => {
       if (state.phase !== "planning") return null;
       if (!state.activeSlice) return missingSliceStop(mid, state.phase);
       const sid = state.activeSlice!.id;
@@ -480,6 +480,7 @@ export const DISPATCH_RULES: DispatchRule[] = [
           sid,
           sTitle,
           basePath,
+          ctx,
         ),
       };
     },

--- a/src/resources/extensions/gsd/auto-prompts.ts
+++ b/src/resources/extensions/gsd/auto-prompts.ts
@@ -51,11 +51,11 @@ function capPreamble(preamble: string): string {
  * Uses the budget engine to compute task count ranges and inline context budgets
  * based on the configured executor model's context window.
  */
-function formatExecutorConstraints(): string {
+function formatExecutorConstraints(modelRegistry?: any): string {
   let windowTokens: number;
   try {
     const prefs = loadEffectiveGSDPreferences();
-    windowTokens = resolveExecutorContextWindow(undefined, prefs?.preferences);
+    windowTokens = resolveExecutorContextWindow(modelRegistry, prefs?.preferences);
   } catch (e) {
     logWarning("prompt", `resolveExecutorContextWindow failed: ${(e as Error).message}`);
     windowTokens = 200_000; // safe default
@@ -1207,7 +1207,7 @@ export async function buildResearchSlicePrompt(
 }
 
 export async function buildPlanSlicePrompt(
-  mid: string, _midTitle: string, sid: string, sTitle: string, base: string, level?: InlineLevel,
+  mid: string, _midTitle: string, sid: string, sTitle: string, base: string, ctx?: any, level?: InlineLevel,
 ): Promise<string> {
   const inlineLevel = level ?? resolveInlineLevel();
   const roadmapPath = resolveMilestoneFile(base, mid, "ROADMAP");
@@ -1263,7 +1263,7 @@ export async function buildPlanSlicePrompt(
   const inlinedContext = capPreamble(`## Inlined Context (preloaded — do not re-read these files)\n\n${inlined.join("\n\n---\n\n")}`);
 
   // Build executor context constraints from the budget engine
-  const executorContextConstraints = formatExecutorConstraints();
+  const executorContextConstraints = formatExecutorConstraints(ctx?.modelRegistry);
 
   const outputRelPath = relSliceFile(base, mid, sid, "PLAN");
   const commitInstruction = "Do not commit — .gsd/ planning docs are managed externally and not tracked in git.";
@@ -1381,7 +1381,7 @@ export async function buildExecuteTaskPrompt(
 
   // Compute verification budget for the executor's context window (issue #707)
   const prefs = loadEffectiveGSDPreferences();
-  const contextWindow = resolveExecutorContextWindow(undefined, prefs?.preferences);
+  const contextWindow = resolveExecutorContextWindow(ctx?.modelRegistry, prefs?.preferences, ctx?.model?.contextWindow);
   const budgets = computeBudgets(contextWindow);
   const verificationBudget = `~${Math.round(budgets.verificationBudgetChars / 1000)}K chars`;
 


### PR DESCRIPTION
## Fix: Budget engine hardcoded to 200K — ignores actual model context window (#4142)

### Problem
On 1M-token models (`claude-opus-4-6[1m]`), GSD's budget engine always resolves to 200K because `resolveExecutorContextWindow()` is called **without the model registry** at 2 of its 3 call sites in `auto-prompts.ts`. This causes:
- Truncation budgets 5× too small
- Task count ceiling of 6 instead of 8
- Forensics injection (~40KB) consumes disproportionate context

### Solution
Pass `ctx.modelRegistry` through the chain:

1. `auto-prompts.ts`: `formatExecutorConstraints()` now accepts `modelRegistry?` parameter and passes it to `resolveExecutorContextWindow`
2. `auto-prompts.ts`: `buildPlanSlicePrompt()` now accepts `ctx?` and passes `ctx?.modelRegistry` to `formatExecutorConstraints`
3. `auto-prompts.ts`: Second `resolveExecutorContextWindow` call also gets `ctx?.modelRegistry` and `ctx?.model?.contextWindow`
4. `auto-dispatch.ts`: Two `plan-slice` dispatch match functions now destructure `ctx` and pass it to `buildPlanSlicePrompt`

### Files Changed
| File | Change |
|------|--------|
| `auto-prompts.ts` | `formatExecutorConstraints(modelRegistry?)`, `buildPlanSlicePrompt(..., ctx?)`, both budget calls fixed |
| `auto-dispatch.ts` | Added `ctx` to match destructuring at 2 plan-slice dispatch sites |

Closes #4142