### PR TITLE
Add user feedback when completing steps in step mode

### DIFF
--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -234,6 +234,18 @@ export function detectRogueFileWrites(
   return rogues;
 }
 
+export const STEP_COMPLETE_FALLBACK_MESSAGE =
+  "Step complete. Run /clear, then /gsd to continue (or /gsd auto to run continuously).";
+
+export function buildStepCompleteMessage(nextState: import("./types.js").GSDState): string {
+  if (nextState.phase === "complete") {
+    return "Step complete — milestone finished. Run /gsd status to review, or start the next milestone.";
+  }
+  const next = describeNextUnit(nextState);
+  return `Step complete. Next: ${next.label}\n`
+    + `Run /clear, then /gsd to continue (or /gsd auto to run continuously).`;
+}
+
 export interface PreVerificationOpts {
   skipSettleDelay?: boolean;
   skipWorktreeSync?: boolean;
@@ -1032,25 +1044,10 @@ export async function postUnitPostVerification(pctx: PostUnitContext): Promise<"
   if (s.stepMode) {
     try {
       const nextState = await deriveState(s.basePath);
-      if (nextState.phase === "complete") {
-        ctx.ui.notify(
-          "Step complete — milestone finished. Run /gsd status to review, or start the next milestone.",
-          "info",
-        );
-      } else {
-        const next = describeNextUnit(nextState);
-        ctx.ui.notify(
-          `Step complete. Next: ${next.label}\n`
-          + `Run /clear, then /gsd to continue (or /gsd auto to run continuously).`,
-          "info",
-        );
-      }
+      ctx.ui.notify(buildStepCompleteMessage(nextState), "info");
     } catch (e) {
       debugLog("postUnit", { phase: "step-wizard-notify", error: String(e) });
-      ctx.ui.notify(
-        "Step complete. Run /clear, then /gsd to continue (or /gsd auto to run continuously).",
-        "info",
-      );
+      ctx.ui.notify(STEP_COMPLETE_FALLBACK_MESSAGE, "info");
     }
     return "step-wizard";
   }

--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -104,6 +104,7 @@ import {
   updateSliceProgressCache,
   unitVerb,
   hideFooter,
+  describeNextUnit,
 } from "./auto-dashboard.js";
 import { existsSync, unlinkSync } from "node:fs";
 import { join } from "node:path";
@@ -1025,8 +1026,32 @@ export async function postUnitPostVerification(pctx: PostUnitContext): Promise<"
     }
   }
 
-  // Step mode → show wizard instead of dispatch
+  // Step mode → show wizard instead of dispatch.
+  // Without this notify(), /gsd in step mode finishes a unit and silently
+  // exits the loop, leaving the user with no hint to /clear and /gsd again.
   if (s.stepMode) {
+    try {
+      const nextState = await deriveState(s.basePath);
+      if (nextState.phase === "complete") {
+        ctx.ui.notify(
+          "Step complete — milestone finished. Run /gsd status to review, or start the next milestone.",
+          "info",
+        );
+      } else {
+        const next = describeNextUnit(nextState);
+        ctx.ui.notify(
+          `Step complete. Next: ${next.label}\n`
+          + `Run /clear, then /gsd to continue (or /gsd auto to run continuously).`,
+          "info",
+        );
+      }
+    } catch (e) {
+      debugLog("postUnit", { phase: "step-wizard-notify", error: String(e) });
+      ctx.ui.notify(
+        "Step complete. Run /clear, then /gsd to continue (or /gsd auto to run continuously).",
+        "info",
+      );
+    }
     return "step-wizard";
   }
 

--- a/src/resources/extensions/gsd/tests/auto-post-unit-step-message.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-post-unit-step-message.test.ts
@@ -1,0 +1,53 @@
+// GSD-2 — Tests for step-mode completion messages in auto-post-unit
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { buildStepCompleteMessage, STEP_COMPLETE_FALLBACK_MESSAGE } from "../auto-post-unit.ts";
+import type { GSDState } from "../types.ts";
+
+function makeState(overrides: Partial<GSDState>): GSDState {
+  return {
+    activeMilestone: null,
+    activeSlice: null,
+    activeTask: null,
+    phase: "executing",
+    recentDecisions: [],
+    blockers: [],
+    nextAction: "",
+    registry: [],
+    ...overrides,
+  };
+}
+
+test("buildStepCompleteMessage: milestone complete surfaces review guidance", () => {
+  const msg = buildStepCompleteMessage(makeState({ phase: "complete" }));
+  assert.match(msg, /milestone finished/);
+  assert.match(msg, /\/gsd status/);
+  assert.doesNotMatch(msg, /Next:/);
+});
+
+test("buildStepCompleteMessage: mid-flight step includes next unit label and /clear hint", () => {
+  const state = makeState({
+    phase: "executing",
+    activeSlice: { id: "S01", title: "Core" },
+    activeTask: { id: "T03", title: "Wire notify" },
+  });
+  const msg = buildStepCompleteMessage(state);
+  assert.match(msg, /Next: Execute T03: Wire notify/);
+  assert.match(msg, /\/clear/);
+  assert.match(msg, /\/gsd to continue/);
+});
+
+test("buildStepCompleteMessage: unknown phase falls back to generic continue label", () => {
+  // Cast to bypass Phase union so we exercise the default branch of describeNextUnit.
+  const state = makeState({ phase: "totally-unknown" as unknown as GSDState["phase"] });
+  const msg = buildStepCompleteMessage(state);
+  assert.match(msg, /Next: Continue/);
+  assert.match(msg, /\/clear/);
+});
+
+test("STEP_COMPLETE_FALLBACK_MESSAGE: used when deriveState throws, still points users at /clear + /gsd", () => {
+  assert.match(STEP_COMPLETE_FALLBACK_MESSAGE, /\/clear/);
+  assert.match(STEP_COMPLETE_FALLBACK_MESSAGE, /\/gsd/);
+});


### PR DESCRIPTION
Closes #4174

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Add informative notifications when users complete a step in step mode, indicating whether the milestone is finished or what the next unit is.
**Why:** Without feedback, users don't know whether to continue with `/gsd` or if they've finished the milestone, leading to confusion.
**How:** After step completion, derive the next state and notify the user with either a milestone completion message or the next unit's label and instructions.

## What

Modified `src/resources/extensions/gsd/auto-post-unit.ts` to add user-facing notifications in step mode after a unit is posted. The change:

- Imports `describeNextUnit` from `auto-dashboard.js`
- Wraps the step mode completion logic in a try-catch block
- Derives the next state to determine if the milestone is complete
- Notifies the user with contextual information:
  - If milestone is complete: "Step complete — milestone finished" with instructions to review or start next milestone
  - If more steps remain: "Step complete. Next: [unit label]" with instructions to run `/clear` and `/gsd`
  - On error: Falls back to generic completion message

## Why

In step mode, `/gsd` would silently finish a unit and exit the loop without any user feedback. This left users uncertain about whether they should run `/gsd` again, run `/clear` first, or if they'd completed the entire milestone. The notification provides clear guidance on next steps.

## How

The implementation:
1. Calls `deriveState()` to determine the workflow state after the current unit
2. Uses `describeNextUnit()` to get a human-readable label for the next unit
3. Provides phase-aware messaging (milestone complete vs. more steps)
4. Includes error handling with a fallback message to ensure users always get feedback
5. Maintains the existing "step-wizard" return value

## Change type

- [x] `feat` — New feature or capability
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [ ] CI passes
- [ ] New/updated tests included
- [x] Manual testing — Verify step mode completion messages appear correctly when running `/gsd` in step mode, and that the appropriate message displays for both milestone completion and intermediate steps
- [ ] No tests needed — explained above

## AI disclosure

- [ ] This PR includes AI-assisted code
