### PR TITLE
fix: keep assistant text visible when thinking traces are long

### DIFF
--- a/packages/pi-coding-agent/src/modes/interactive/components/assistant-message.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/components/assistant-message.ts
@@ -54,6 +54,7 @@ export class AssistantMessageComponent extends Container {
 		const hasVisibleContent = message.content.some(
 			(c) => (c.type === "text" && c.text.trim()) || (c.type === "thinking" && c.thinking.trim()),
 		);
+		const hasTextContent = message.content.some((c) => c.type === "text" && c.text.trim().length > 0);
 
 		if (hasVisibleContent) {
 			this.contentContainer.addChild(new Spacer(1));
@@ -81,12 +82,15 @@ export class AssistantMessageComponent extends Container {
 					}
 				} else {
 					// Thinking traces in thinkingText color, italic
-					this.contentContainer.addChild(
-						new Markdown(content.thinking.trim(), 1, 0, this.markdownTheme, {
-							color: (text: string) => theme.fg("thinkingText", text),
-							italic: true,
-						}),
-					);
+					const thinkingMarkdown = new Markdown(content.thinking.trim(), 1, 0, this.markdownTheme, {
+						color: (text: string) => theme.fg("thinkingText", text),
+						italic: true,
+					});
+					// Keep assistant text/questions visible even when thinking traces are long.
+					if (hasTextContent) {
+						thinkingMarkdown.maxLines = 8;
+					}
+					this.contentContainer.addChild(thinkingMarkdown);
 					if (hasVisibleContentAfter) {
 						this.contentContainer.addChild(new Spacer(1));
 					}

--- a/src/tests/assistant-message-thinking-visibility.test.ts
+++ b/src/tests/assistant-message-thinking-visibility.test.ts
@@ -1,0 +1,34 @@
+// Regression test for #4181:
+// When assistant messages include both thinking + text, cap visible thinking
+// lines so question/chat text remains visible without toggling thinking off.
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const assistantMessagePath = join(
+  process.cwd(),
+  "packages",
+  "pi-coding-agent",
+  "src",
+  "modes",
+  "interactive",
+  "components",
+  "assistant-message.ts",
+);
+
+test("assistant-message caps thinking block height when text content is present", () => {
+  const src = readFileSync(assistantMessagePath, "utf-8");
+
+  assert.match(
+    src,
+    /const hasTextContent = message\.content\.some\(\(c\) => c\.type === "text" && c\.text\.trim\(\)\.length > 0\);/,
+    "assistant-message should detect text presence in mixed thinking+text messages",
+  );
+
+  assert.match(
+    src,
+    /if \(hasTextContent\)\s*\{\s*thinkingMarkdown\.maxLines = 8;\s*\}/s,
+    "assistant-message should cap visible thinking lines when assistant text also exists",
+  );
+});


### PR DESCRIPTION
## Linked issue

Closes #4181

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Caps visible thinking block lines when an assistant message also contains normal text.
**Why:** Long thinking traces could push assistant question/chat text out of view, making guided prompts unreadable unless thinking was hidden.
**How:** In `AssistantMessageComponent`, detect mixed thinking+text content and set `thinkingMarkdown.maxLines = 8` for the thinking block; add a regression test that guards this behavior.

## What

This PR updates `packages/pi-coding-agent/src/modes/interactive/components/assistant-message.ts` to preserve visibility of assistant text/questions during mixed thinking+text messages.

A regression test was added at `src/tests/assistant-message-thinking-visibility.test.ts` to assert the mixed-content guard remains in place.

## Why

In interactive chat and guided flows, the model can emit both a long thinking trace and a user-facing question in the same assistant message. Before this change, long thinking content could consume enough viewport space that question text became effectively hidden.

This fixes that UI regression so users can keep thinking visible without losing question/chat readability.

## How

- Detect whether a message contains assistant text content.
- Keep existing thinking rendering behavior, but when text also exists, cap the thinking markdown to 8 visible lines.
- Preserve existing ordering/spacing behavior for thinking, text, tool output, and timestamps.
- Add source-level regression coverage for #4181.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [x] `pi-coding-agent` — Coding agent
- [ ] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [ ] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

Manual verification performed:
- `npm -C packages/pi-coding-agent run build`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/tests/assistant-message-thinking-visibility.test.ts`

## AI disclosure

- [x] This PR includes AI-assisted code (Codex). Validated via local build and targeted regression test.
