### PR TITLE
Fix thinking block overflow in tool-bearing turns

### DIFF
--- a/packages/pi-coding-agent/src/modes/interactive/components/assistant-message.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/components/assistant-message.ts
@@ -88,6 +88,7 @@ export class AssistantMessageComponent extends Container {
 			(c) => (c.type === "text" && c.text.trim()) || (c.type === "thinking" && c.thinking.trim()),
 		);
 		const hasTextContent = message.content.some((c) => c.type === "text" && c.text.trim().length > 0);
+		const hasToolContent = message.content.some((c) => c.type === "toolCall" || c.type === "serverToolUse");
 
 		if (hasVisibleContent) {
 			this.contentContainer.addChild(new Spacer(1));
@@ -119,8 +120,9 @@ export class AssistantMessageComponent extends Container {
 						color: (text: string) => theme.fg("thinkingText", text),
 						italic: true,
 					});
-					// Keep assistant text/questions visible even when thinking traces are long.
-					if (hasTextContent) {
+					// Keep visible chat output readable when thinking traces are long.
+					// Tool-bearing turns can stream text in a later assistant message.
+					if (hasTextContent || hasToolContent) {
 						thinkingMarkdown.maxLines = 8;
 					}
 					this.contentContainer.addChild(thinkingMarkdown);

--- a/src/tests/assistant-message-thinking-visibility.test.ts
+++ b/src/tests/assistant-message-thinking-visibility.test.ts
@@ -28,7 +28,13 @@ test("assistant-message caps thinking block height when text content is present"
 
   assert.match(
     src,
-    /if \(hasTextContent\)\s*\{\s*thinkingMarkdown\.maxLines = 8;\s*\}/s,
-    "assistant-message should cap visible thinking lines when assistant text also exists",
+    /const hasToolContent = message\.content\.some\(\(c\) => c\.type === "toolCall" \|\| c\.type === "serverToolUse"\);/,
+    "assistant-message should detect tool blocks in mixed turns",
+  );
+
+  assert.match(
+    src,
+    /if \(hasTextContent \|\| hasToolContent\)\s*\{\s*thinkingMarkdown\.maxLines = 8;\s*\}/s,
+    "assistant-message should cap visible thinking lines when assistant text exists or tool blocks are present",
   );
 });


### PR DESCRIPTION
## Summary
- cap assistant thinking markdown to 8 lines when a message includes tool blocks (`toolCall` or `serverToolUse`), even if text is not in the same message
- keep the existing cap behavior for mixed thinking+text messages
- extend the regression test to assert the tool-bearing condition

## Why
Some providers split long thinking/tool content and final text across separate assistant turns. The previous cap only triggered when text was present in the same message, so long thinking blocks could still dominate the viewport and effectively hide readable output.

Fixes #4185

## Testing
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/tests/assistant-message-thinking-visibility.test.ts`
