### PR TITLE
ci: optimize build workflows and caching

### DIFF
--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -108,6 +108,7 @@ jobs:
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
+          cache: "npm"
 
       - name: Download all artifacts
         uses: actions/download-artifact@v4
@@ -198,6 +199,16 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+
+      - name: Cache TypeScript incremental state
+        uses: useblacksmith/cache@v5
+        with:
+          path: |
+            *.tsbuildinfo
+            packages/*/*.tsbuildinfo
+          key: tsbuild-${{ runner.os }}-${{ hashFiles('package-lock.json', 'tsconfig*.json', 'packages/*/tsconfig.json') }}
+          restore-keys: |
+            tsbuild-${{ runner.os }}-
 
       - name: Build
         run: npm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     outputs:
       docs-only: ${{ steps.check.outputs.docs-only }}
+      portability-changed: ${{ steps.check.outputs.portability-changed }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -58,6 +59,15 @@ jobs:
             echo "docs-only=false" >> "$GITHUB_OUTPUT"
             echo "Non-docs files changed:"
             echo "$NON_DOCS"
+          fi
+          PORTABILITY=$(echo "$NON_DOCS" | grep -E '^(src/|packages/|native/|scripts/|web/|package\.json$|package-lock\.json$|web/package-lock\.json$|tsconfig[^/]*\.json$|packages/.*/tsconfig\.json$)' || true)
+          if [ -n "$PORTABILITY" ]; then
+            echo "portability-changed=true" >> "$GITHUB_OUTPUT"
+            echo "Portability-relevant files changed:"
+            echo "$PORTABILITY"
+          else
+            echo "portability-changed=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::No portability-relevant changes detected — skipping portability matrix jobs"
           fi
 
   docs-check:
@@ -139,8 +149,18 @@ jobs:
             nextjs-${{ runner.os }}-${{ hashFiles('web/package-lock.json') }}-
             nextjs-${{ runner.os }}-
 
-      - name: Build
-        run: npm run build
+      - name: Cache TypeScript incremental state
+        uses: useblacksmith/cache@v5
+        with:
+          path: |
+            *.tsbuildinfo
+            packages/*/*.tsbuildinfo
+          key: tsbuild-${{ runner.os }}-${{ hashFiles('package-lock.json', 'tsconfig*.json', 'packages/*/tsconfig.json') }}
+          restore-keys: |
+            tsbuild-${{ runner.os }}-
+
+      - name: Build core
+        run: npm run build:core
 
       - name: Build web host
         run: npm run build:web-host
@@ -179,16 +199,35 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      # Integration tests need the same compiled artifacts as the build job:
-      # - dist/loader.js and packages/pi-coding-agent/dist/** from `npm run build`
+      # Integration tests need core compiled artifacts:
+      # - dist/loader.js and packages/pi-coding-agent/dist/** from `npm run build:core`
       # - web/node_modules/.bin/next for tests that shell `build:web-host` at runtime
-      # Duplicating the build here (instead of sharing artifacts via needs: build)
+      # Duplicating the core build here (instead of sharing artifacts via needs: build)
       # preserves wall-clock parallelism with the build job — see PR #4093.
       - name: Install web host dependencies
         run: npm --prefix web ci
 
-      - name: Build
-        run: npm run build
+      - name: Cache Next.js build
+        uses: useblacksmith/cache@v5
+        with:
+          path: web/.next/cache
+          key: nextjs-${{ runner.os }}-${{ hashFiles('web/package-lock.json') }}-${{ hashFiles('web/app/**', 'web/components/**', 'web/lib/**', 'web/hooks/**') }}
+          restore-keys: |
+            nextjs-${{ runner.os }}-${{ hashFiles('web/package-lock.json') }}-
+            nextjs-${{ runner.os }}-
+
+      - name: Cache TypeScript incremental state
+        uses: useblacksmith/cache@v5
+        with:
+          path: |
+            *.tsbuildinfo
+            packages/*/*.tsbuildinfo
+          key: tsbuild-${{ runner.os }}-${{ hashFiles('package-lock.json', 'tsconfig*.json', 'packages/*/tsconfig.json') }}
+          restore-keys: |
+            tsbuild-${{ runner.os }}-
+
+      - name: Build core
+        run: npm run build:core
 
       - name: Run integration tests
         run: npm run test:integration
@@ -197,7 +236,8 @@ jobs:
     timeout-minutes: 25
     needs: detect-changes
     if: >-
-      needs.detect-changes.outputs.docs-only != 'true'
+      needs.detect-changes.outputs.docs-only != 'true' &&
+      needs.detect-changes.outputs.portability-changed == 'true'
     runs-on: blacksmith-4vcpu-windows-2025
 
     steps:
@@ -213,8 +253,18 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Build
-        run: npm run build
+      - name: Cache TypeScript incremental state
+        uses: useblacksmith/cache@v5
+        with:
+          path: |
+            *.tsbuildinfo
+            packages/*/*.tsbuildinfo
+          key: tsbuild-${{ runner.os }}-${{ hashFiles('package-lock.json', 'tsconfig*.json', 'packages/*/tsconfig.json') }}
+          restore-keys: |
+            tsbuild-${{ runner.os }}-
+
+      - name: Build core
+        run: npm run build:core
 
       - name: Typecheck extensions
         run: npm run typecheck:extensions
@@ -233,7 +283,9 @@ jobs:
   rtk-portability:
     timeout-minutes: 20
     needs: detect-changes
-    if: needs.detect-changes.outputs.docs-only != 'true'
+    if: >-
+      needs.detect-changes.outputs.docs-only != 'true' &&
+      needs.detect-changes.outputs.portability-changed == 'true'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -54,8 +54,21 @@ jobs:
             nextjs-${{ runner.os }}-${{ hashFiles('web/package-lock.json') }}-
             nextjs-${{ runner.os }}-
 
-      - name: Build
-        run: npm run build
+      - name: Cache TypeScript incremental state
+        uses: useblacksmith/cache@v5
+        with:
+          path: |
+            *.tsbuildinfo
+            packages/*/*.tsbuildinfo
+          key: tsbuild-${{ runner.os }}-${{ hashFiles('package-lock.json', 'tsconfig*.json', 'packages/*/tsconfig.json') }}
+          restore-keys: |
+            tsbuild-${{ runner.os }}-
+
+      - name: Build core
+        run: npm run build:core
+
+      - name: Build web host
+        run: npm run build:web-host
 
       - name: Stamp dev version and sync platform packages
         id: stamp
@@ -174,6 +187,16 @@ jobs:
           restore-keys: |
             nextjs-${{ runner.os }}-${{ hashFiles('web/package-lock.json') }}-
             nextjs-${{ runner.os }}-
+
+      - name: Cache TypeScript incremental state
+        uses: useblacksmith/cache@v5
+        with:
+          path: |
+            *.tsbuildinfo
+            packages/*/*.tsbuildinfo
+          key: tsbuild-${{ runner.os }}-${{ hashFiles('package-lock.json', 'tsconfig*.json', 'packages/*/tsconfig.json') }}
+          restore-keys: |
+            tsbuild-${{ runner.os }}-
 
       - name: Run live LLM tests (optional)
         continue-on-error: true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gsd-pi",
-  "version": "2.74.0",
+  "version": "2.73.1",
   "description": "GSD — Get Shit Done coding agent",
   "license": "MIT",
   "repository": {
@@ -49,7 +49,8 @@
     "build:rpc-client": "npm run build -w @gsd-build/rpc-client",
     "build:pi": "npm run build:native-pkg && npm run build:pi-tui && npm run build:pi-ai && npm run build:pi-agent-core && npm run build:pi-coding-agent",
     "build:mcp-server": "npm run build -w @gsd-build/mcp-server",
-    "build": "npm run build:pi && npm run build:rpc-client && npm run build:mcp-server && tsc && npm run copy-resources && npm run copy-themes && npm run copy-export-html && node scripts/build-web-if-stale.cjs",
+    "build:core": "npm run build:pi && npm run build:rpc-client && npm run build:mcp-server && tsc && npm run copy-resources && npm run copy-themes && npm run copy-export-html",
+    "build": "npm run build:core && node scripts/build-web-if-stale.cjs",
     "stage:web-host": "node scripts/stage-web-standalone.cjs",
     "build:web-host": "npm --prefix web run build && npm run stage:web-host",
     "copy-resources": "node scripts/copy-resources.cjs",

--- a/packages/mcp-server/tsconfig.json
+++ b/packages/mcp-server/tsconfig.json
@@ -6,6 +6,7 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
+    "incremental": true,
     "forceConsistentCasingInFileNames": true,
     "declaration": true,
     "declarationMap": true,

--- a/packages/pi-agent-core/tsconfig.json
+++ b/packages/pi-agent-core/tsconfig.json
@@ -6,6 +6,7 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
+    "incremental": true,
     "forceConsistentCasingInFileNames": true,
     "declaration": true,
     "declarationMap": true,

--- a/packages/pi-ai/tsconfig.json
+++ b/packages/pi-ai/tsconfig.json
@@ -6,6 +6,7 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
+    "incremental": true,
     "forceConsistentCasingInFileNames": true,
     "declaration": true,
     "declarationMap": true,

--- a/packages/pi-coding-agent/tsconfig.json
+++ b/packages/pi-coding-agent/tsconfig.json
@@ -6,6 +6,7 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
+    "incremental": true,
     "forceConsistentCasingInFileNames": true,
     "declaration": true,
     "declarationMap": true,

--- a/packages/pi-tui/tsconfig.json
+++ b/packages/pi-tui/tsconfig.json
@@ -6,6 +6,7 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
+    "incremental": true,
     "forceConsistentCasingInFileNames": true,
     "declaration": true,
     "declarationMap": true,

--- a/packages/rpc-client/tsconfig.json
+++ b/packages/rpc-client/tsconfig.json
@@ -6,6 +6,7 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
+    "incremental": true,
     "forceConsistentCasingInFileNames": true,
     "declaration": true,
     "declarationMap": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "rootDir": "src",
     "strict": true,
     "declaration": true,
+    "incremental": true,
     "esModuleInterop": true,
     "skipLibCheck": true
   },


### PR DESCRIPTION
## Summary
- add build:core and keep build behavior via build:core + stale web build check
- split core/web build steps and add missing Next.js, npm, and TypeScript incremental caches
- gate portability matrix jobs behind portability-changed output
- apply the same cache/build improvements to pipeline and build-native workflows
- enable TypeScript incremental compilation in root and key packages

## Validation
- npm run build:core
- npm run build

## Notes
- excludes local untracked .mcp.json
