### PR TITLE
fix(gsd): preserve quoted workflow run overrides

### DIFF
--- a/src/resources/extensions/gsd/commands/handlers/workflow.ts
+++ b/src/resources/extensions/gsd/commands/handlers/workflow.ts
@@ -38,6 +38,67 @@ const WORKFLOW_USAGE = [
   "  resume            — Resume paused custom workflow auto-mode",
 ].join("\n");
 
+function splitWorkflowRunArgs(input: string): string[] {
+  const tokens: string[] = [];
+  let current = "";
+  let quote: '"' | "'" | null = null;
+  let escapeNext = false;
+
+  for (const ch of input) {
+    if (escapeNext) {
+      current += ch;
+      escapeNext = false;
+      continue;
+    }
+
+    if (ch === "\\") {
+      escapeNext = true;
+      continue;
+    }
+
+    if (quote) {
+      if (ch === quote) {
+        quote = null;
+      } else {
+        current += ch;
+      }
+      continue;
+    }
+
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      continue;
+    }
+
+    if (/\s/.test(ch)) {
+      if (current) {
+        tokens.push(current);
+        current = "";
+      }
+      continue;
+    }
+
+    current += ch;
+  }
+
+  if (escapeNext) current += "\\";
+  if (current) tokens.push(current);
+  return tokens;
+}
+
+export function parseWorkflowRunArgs(args: string): { defName: string; overrides: Record<string, string> } {
+  const parts = splitWorkflowRunArgs(args);
+  const defName = parts[0] ?? "";
+  const overrides: Record<string, string> = {};
+  for (let i = 1; i < parts.length; i++) {
+    const eqIdx = parts[i].indexOf("=");
+    if (eqIdx > 0) {
+      overrides[parts[i].slice(0, eqIdx)] = parts[i].slice(eqIdx + 1);
+    }
+  }
+  return { defName, overrides };
+}
+
 async function handleCustomWorkflow(
   sub: string,
   ctx: ExtensionCommandContext,
@@ -62,15 +123,7 @@ async function handleCustomWorkflow(
       ctx.ui.notify("Usage: /gsd workflow run <name> [param=value ...]", "warning");
       return true;
     }
-    const parts = args.split(/\s+/);
-    const defName = parts[0];
-    const overrides: Record<string, string> = {};
-    for (let i = 1; i < parts.length; i++) {
-      const eqIdx = parts[i].indexOf("=");
-      if (eqIdx > 0) {
-        overrides[parts[i].slice(0, eqIdx)] = parts[i].slice(eqIdx + 1);
-      }
-    }
+    const { defName, overrides } = parseWorkflowRunArgs(args);
     try {
       const base = projectRoot();
       const runDir = createRun(base, defName, Object.keys(overrides).length > 0 ? overrides : undefined);

--- a/src/resources/extensions/gsd/tests/commands-workflow-custom.test.ts
+++ b/src/resources/extensions/gsd/tests/commands-workflow-custom.test.ts
@@ -217,6 +217,20 @@ describe("workflow command handler", () => {
     );
   });
 
+  it("preserves quoted workflow run overrides (#4130)", async () => {
+    const { parseWorkflowRunArgs } = await import("../commands/handlers/workflow.ts");
+    assert.deepStrictEqual(
+      parseWorkflowRunArgs('demo-workflow target="multi word target" region=\'us east\''),
+      {
+        defName: "demo-workflow",
+        overrides: {
+          target: "multi word target",
+          region: "us east",
+        },
+      },
+    );
+  });
+
   it("'/gsd workflow run nonexistent' shows error for missing definition", async () => {
     const { handled, notifications } = await callHandler("workflow run nonexistent-def-12345");
     assert.ok(handled, "should be handled");


### PR DESCRIPTION
Closes #4130

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Preserve quoted parameter values passed to `/gsd workflow run`.
**Why:** Multi-word overrides were split on whitespace, so workflow runs received truncated values.
**How:** Replace the naive whitespace split with a small quoted-argument tokenizer and cover it with a regression test.

## What

`/gsd workflow run` now preserves quoted `key=value` overrides such as `target="multi word target"` instead of truncating them at the first space.

The change stays local to the workflow command handler, and the command test suite now covers quoted overrides directly.

## Why

Custom workflow definitions can take parameter overrides for names, labels, paths, and targets that contain spaces.
The old `args.split(/\s+/)` parsing broke those values before `createRun()` wrote `PARAMS.json`, so runs could start with the wrong substituted inputs.

## How

The handler now tokenizes the `run` argument tail with basic single-quote, double-quote, and escape support, then builds the overrides map from those tokens.

That keeps the fix surgical: run creation and parameter substitution stay unchanged, and only the command parsing behavior is corrected.

## Change type

- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [ ] Manual testing — steps described above
- [ ] No tests needed — explained above

Automated verification:

1. `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/commands-workflow-custom.test.ts`
2. `npm run build`
3. `npm run typecheck:extensions`
4. `npm run test:unit` — the same two known failures also reproduce on clean `upstream/main`: `resolvePreferredModelConfig returns undefined for copilot start model` and `flat-rate provider routing guard (#3453)`
5. `npm run test:integration` advanced into the late `pack-install` phase; the narrower `src/tests/integration/pack-install.test.ts` reproduces the same late `stuck-after-failure` shape on clean `upstream/main`

## AI disclosure

- [x] This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.
