### PR TITLE
fix(gsd): open project DB in headless query

### DIFF
--- a/src/headless-query.ts
+++ b/src/headless-query.ts
@@ -38,7 +38,9 @@ async function loadExtensionModules() {
   const dispatchModule = await jiti.import(gsdExtensionPath('auto-dispatch.ts'), {}) as any
   const sessionModule = await jiti.import(gsdExtensionPath('session-status-io.ts'), {}) as any
   const prefsModule = await jiti.import(gsdExtensionPath('preferences.ts'), {}) as any
+  const autoStartModule = await jiti.import(gsdExtensionPath('auto-start.ts'), {}) as any
   return {
+    openProjectDbIfPresent: autoStartModule.openProjectDbIfPresent as (basePath: string) => Promise<void>,
     deriveState: stateModule.deriveState as (basePath: string) => Promise<GSDState>,
     resolveDispatch: dispatchModule.resolveDispatch as (opts: any) => Promise<any>,
     readAllSessionStatuses: sessionModule.readAllSessionStatuses as (basePath: string) => any[],
@@ -76,7 +78,14 @@ export interface QueryResult {
 // ─── Implementation ─────────────────────────────────────────────────────────
 
 export async function handleQuery(basePath: string): Promise<QueryResult> {
-  const { deriveState, resolveDispatch, readAllSessionStatuses, loadEffectiveGSDPreferences } = await loadExtensionModules()
+  const {
+    openProjectDbIfPresent,
+    deriveState,
+    resolveDispatch,
+    readAllSessionStatuses,
+    loadEffectiveGSDPreferences,
+  } = await loadExtensionModules()
+  await openProjectDbIfPresent(basePath)
   const state = await deriveState(basePath)
 
   // Derive next dispatch action

--- a/src/tests/headless-query-db-open.test.ts
+++ b/src/tests/headless-query-db-open.test.ts
@@ -1,0 +1,29 @@
+/**
+ * Regression test for #4123: headless-query must open the project DB
+ * before deriveState(), otherwise it falls back to filesystem parsing.
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const src = readFileSync(join(__dirname, "..", "headless-query.ts"), "utf-8");
+
+test("headless-query loads openProjectDbIfPresent from extension modules (#4123)", () => {
+  assert.match(
+    src,
+    /openProjectDbIfPresent:\s*autoStartModule\.openProjectDbIfPresent/,
+    "headless-query should load openProjectDbIfPresent from auto-start.ts",
+  );
+});
+
+test("headless-query opens the DB before deriveState (#4123)", () => {
+  const openIdx = src.indexOf("await openProjectDbIfPresent(basePath)");
+  const deriveIdx = src.indexOf("const state = await deriveState(basePath)");
+  assert.ok(openIdx !== -1, "headless-query should open the project DB");
+  assert.ok(deriveIdx !== -1, "headless-query should still derive state");
+  assert.ok(openIdx < deriveIdx, "headless-query should open the DB before deriveState()");
+});


### PR DESCRIPTION
Closes #4123

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Open the project DB before `gsd headless query` derives state.
**Why:** Headless query could ignore DB-backed state and fall back to filesystem parsing even when an existing project DB was present.
**How:** Load `openProjectDbIfPresent` from the same extension bundle as the other headless-query helpers and call it before `deriveState()`, with a regression test that locks that import-and-call order.

## What

`gsd headless query` now opens an existing project DB before it asks the extension state layer to derive the project snapshot.

The change is limited to `src/headless-query.ts`, plus a focused regression test that verifies the DB-open helper is loaded and called before `deriveState()`.

## Why

`deriveState()` only takes the DB-backed path when the DB is already open.
Because `headless-query` skipped that open step, DB-backed projects could still be interpreted from filesystem state instead of the canonical DB state.

## How

The loader now imports `openProjectDbIfPresent` from `auto-start.ts` through the same extension-resolution path that `headless-query` already uses for state and dispatch helpers.

At runtime, `handleQuery()` calls that helper before `deriveState(basePath)`, which keeps the fix narrow and aligned with the existing project-DB bootstrap behavior.

## Change type

- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [ ] Manual testing — steps described above
- [ ] No tests needed — explained above

Automated verification:

1. `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/tests/headless-query-extension-path.test.ts src/tests/headless-query-db-open.test.ts`
2. `npm run build`
3. `npm run typecheck:extensions`
4. `npm run test:unit` — the same two known failures also reproduce on clean `upstream/main`: `resolvePreferredModelConfig returns undefined for copilot start model` and `flat-rate provider routing guard (#3453)`
5. `src/tests/integration/pack-install.test.ts` reproduces the same late `stuck-after-failure` shape on clean `upstream/main`, so broader integration remains blocked by clean-upstream verifier debt

## AI disclosure

- [x] This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.
