### PR TITLE
fix(gsd): use argv git fallbacks on windows

### DIFF
--- a/src/resources/extensions/gsd/native-git-bridge.ts
+++ b/src/resources/extensions/gsd/native-git-bridge.ts
@@ -323,7 +323,7 @@ export function nativeIsRepo(basePath: string): boolean {
     return native.gitIsRepo(basePath);
   }
   try {
-    gitFileExec(basePath, ["rev-parse", "--git-dir"], true);
+    gitFileExec(basePath, ["rev-parse", "--git-dir"]);
     return true;
   } catch {
     return false;

--- a/src/resources/extensions/gsd/native-git-bridge.ts
+++ b/src/resources/extensions/gsd/native-git-bridge.ts
@@ -323,7 +323,7 @@ export function nativeIsRepo(basePath: string): boolean {
     return native.gitIsRepo(basePath);
   }
   try {
-    execFileSync("git", ["rev-parse", "--git-dir"], { cwd: basePath, stdio: "pipe" });
+    gitFileExec(basePath, ["rev-parse", "--git-dir"], true);
     return true;
   } catch {
     return false;
@@ -1067,7 +1067,7 @@ export function nativeResetHard(basePath: string): void {
     native.gitResetHard(basePath);
     return;
   }
-  execFileSync("git", ["reset", "--hard", "HEAD"], { cwd: basePath, stdio: "pipe" });
+  gitFileExec(basePath, ["reset", "--hard", "HEAD"], true);
 }
 
 /**

--- a/src/resources/extensions/gsd/native-git-bridge.ts
+++ b/src/resources/extensions/gsd/native-git-bridge.ts
@@ -1067,7 +1067,7 @@ export function nativeResetHard(basePath: string): void {
     native.gitResetHard(basePath);
     return;
   }
-  gitFileExec(basePath, ["reset", "--hard", "HEAD"], true);
+  gitFileExec(basePath, ["reset", "--hard", "HEAD"]);
 }
 
 /**

--- a/src/resources/extensions/gsd/tests/native-git-fallback-cli.test.ts
+++ b/src/resources/extensions/gsd/tests/native-git-fallback-cli.test.ts
@@ -28,8 +28,8 @@ describe("native git fallback uses argv-based execution (#4180)", () => {
     assert.doesNotMatch(block, /execSync\(/, "nativeIsRepo should not shell out with execSync");
     assert.match(
       block,
-      /gitFileExec\(basePath,\s*\["rev-parse",\s*"--git-dir"\],\s*true\)/,
-      "nativeIsRepo should use argv-based git execution",
+      /gitFileExec\(basePath,\s*\["rev-parse",\s*"--git-dir"\]\)/,
+      "nativeIsRepo should use argv-based git execution without swallowing non-repo failures",
     );
   });
 

--- a/src/resources/extensions/gsd/tests/native-git-fallback-cli.test.ts
+++ b/src/resources/extensions/gsd/tests/native-git-fallback-cli.test.ts
@@ -16,6 +16,9 @@ const source = readFileSync(join(__dirname, "..", "native-git-bridge.ts"), "utf-
 function section(startMarker: string, endMarker: string): string {
   const start = source.indexOf(startMarker);
   const end = source.indexOf(endMarker, start);
+  assert.notEqual(start, -1, `Missing start marker: ${startMarker}`);
+  assert.notEqual(end, -1, `Missing end marker: ${endMarker}`);
+  assert.ok(end > start, `Invalid section bounds: ${startMarker} -> ${endMarker}`);
   return source.slice(start, end);
 }
 
@@ -54,8 +57,8 @@ describe("native git fallback uses argv-based execution (#4180)", () => {
     assert.doesNotMatch(block, /execSync\(/, "nativeResetHard should not shell out with execSync");
     assert.match(
       block,
-      /gitFileExec\(basePath,\s*\["reset",\s*"--hard",\s*"HEAD"\],\s*true\)/,
-      "nativeResetHard should use argv-based git execution",
+      /gitFileExec\(basePath,\s*\["reset",\s*"--hard",\s*"HEAD"\]\)/,
+      "nativeResetHard should use argv-based git execution without swallowing reset failures",
     );
   });
 });

--- a/src/resources/extensions/gsd/tests/native-git-fallback-cli.test.ts
+++ b/src/resources/extensions/gsd/tests/native-git-fallback-cli.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Regression test for #4180: command-string git fallbacks break on Windows.
+ * The fallback path should use argv-based git execution for repo checks,
+ * commits, and hard resets.
+ */
+
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const source = readFileSync(join(__dirname, "..", "native-git-bridge.ts"), "utf-8");
+
+function section(startMarker: string, endMarker: string): string {
+  const start = source.indexOf(startMarker);
+  const end = source.indexOf(endMarker, start);
+  return source.slice(start, end);
+}
+
+describe("native git fallback uses argv-based execution (#4180)", () => {
+  test("nativeIsRepo avoids execSync command strings", () => {
+    const block = section(
+      "export function nativeIsRepo",
+      "export function nativeHasStagedChanges",
+    );
+    assert.doesNotMatch(block, /execSync\(/, "nativeIsRepo should not shell out with execSync");
+    assert.match(
+      block,
+      /gitFileExec\(basePath,\s*\["rev-parse",\s*"--git-dir"\],\s*true\)/,
+      "nativeIsRepo should use argv-based git execution",
+    );
+  });
+
+  test("nativeCommit uses execFileSync with argv", () => {
+    const block = section(
+      "export function nativeCommit",
+      "export function nativeCheckoutBranch",
+    );
+    assert.doesNotMatch(block, /execSync\(/, "nativeCommit should not shell out with execSync");
+    assert.match(
+      block,
+      /execFileSync\("git",\s*args,/,
+      "nativeCommit should use execFileSync with argv",
+    );
+  });
+
+  test("nativeResetHard avoids execSync command strings", () => {
+    const block = section(
+      "export function nativeResetHard",
+      "export function nativeResetSoft",
+    );
+    assert.doesNotMatch(block, /execSync\(/, "nativeResetHard should not shell out with execSync");
+    assert.match(
+      block,
+      /gitFileExec\(basePath,\s*\["reset",\s*"--hard",\s*"HEAD"\],\s*true\)/,
+      "nativeResetHard should use argv-based git execution",
+    );
+  });
+});


### PR DESCRIPTION
Closes #4180

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Replace command-string git fallbacks with argv-based execution in the Windows-sensitive fallback paths.
**Why:** `nativeCommit` and nearby git fallbacks could break under Windows command-string execution and PATH handling.
**How:** Reuse argv-based git execution for repo checks, commits, and hard resets, and lock those paths with a regression test.

## What

This changes the non-native git fallback path in `native-git-bridge.ts` so the Windows-sensitive command-string calls no longer shell out as `execSync("git ...")`.

The affected fallback paths are `nativeIsRepo()`, `nativeCommit()`, and `nativeResetHard()`, and a focused regression test now verifies that those code paths stay argv-based.

## Why

The issue was reported through `nativeCommit`, but the same command-string pattern also existed in adjacent fallback paths.
That shape is brittle on Windows because it depends on shell command-string parsing instead of invoking `git` directly with argv.

## How

`nativeIsRepo()` and `nativeResetHard()` now go through the existing argv-based git helper, and `nativeCommit()` now uses `execFileSync("git", args, ...)` with stdin for the commit message.

The accompanying regression test is structural on purpose: this behavior is specifically about the fallback invocation shape, and the problematic execution path is Windows-specific.

## Change type

- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [ ] Manual testing — steps described above
- [ ] No tests needed — explained above

Automated verification:

1. `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/native-git-fallback-cli.test.ts`
2. `npm run build`
3. `npm run typecheck:extensions`
4. `npm run test:unit` — the same two known failures also reproduce on clean `upstream/main`: `resolvePreferredModelConfig returns undefined for copilot start model` and `flat-rate provider routing guard (#3453)`
5. `src/tests/integration/pack-install.test.ts` reproduces the same late `stuck-after-failure` shape on clean `upstream/main`, so broader integration remains blocked by clean-upstream verifier debt

## AI disclosure

- [x] This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized native Git command execution for more consistent behavior and error handling across platforms, improving repository detection and hard-reset reliability (notably on Windows).

* **Tests**
  * Added regression tests covering native Git fallback behavior to prevent regressions and ensure cross-platform consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->