### PR TITLE
fix(ci): prevent stale resources tsbuildinfo from skipping output

### DIFF
--- a/tsconfig.resources.json
+++ b/tsconfig.resources.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "incremental": false,
     "rootDir": "src/resources",
     "outDir": "dist/resources",
     "declaration": false,


### PR DESCRIPTION
## Summary
- disable incremental compilation for `tsconfig.resources.json`
- prevent stale `tsconfig.resources.tsbuildinfo` cache state from causing skipped re-emit after `dist/resources` cleanup

## Why
Issue #4195 documents CI-wide breakage after #4187 where resource outputs (notably `url-utils.js`) were missing because resources builds inherited `incremental: true` and reused stale build info from cache.

## Validation
- reproduced pre-fix behavior locally (second `tsc --project tsconfig.resources.json` after deleting `dist/resources` skipped output)
- verified post-fix behavior: `dist/resources/extensions/search-the-web/url-utils.js` is emitted after repeated builds
- ran `npm run build:core` successfully
- ran targeted tests:
  - `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/tests/security-overrides.test.ts src/tests/url-utils.test.ts src/tests/search-tavily.test.ts src/tests/llm-context-tavily.test.ts`
