### PR TITLE
feat(gsd): add /gsd do command

### DIFF
--- a/src/resources/extensions/gsd/commands-do.ts
+++ b/src/resources/extensions/gsd/commands-do.ts
@@ -1,0 +1,109 @@
+/**
+ * GSD Command — /gsd do
+ *
+ * Routes freeform natural language to the correct /gsd subcommand
+ * using keyword matching. Falls back to /gsd quick for task-like input.
+ */
+
+import type { ExtensionAPI, ExtensionCommandContext } from "@gsd/pi-coding-agent";
+
+interface Route {
+  keywords: string[];
+  command: string;
+}
+
+const ROUTES: Route[] = [
+  { keywords: ["progress", "status", "dashboard", "how far", "where are we"], command: "status" },
+  { keywords: ["auto", "autonomous", "run all", "keep going", "start auto"], command: "auto" },
+  { keywords: ["stop", "halt", "abort"], command: "stop" },
+  { keywords: ["pause", "break", "take a break"], command: "pause" },
+  { keywords: ["history", "past", "what happened", "previous"], command: "history" },
+  { keywords: ["doctor", "health", "diagnose", "check health"], command: "doctor" },
+  { keywords: ["clean up", "cleanup", "remove old", "prune", "tidy"], command: "cleanup" },
+  { keywords: ["export", "report", "share results"], command: "export" },
+  { keywords: ["ship", "pull request", "create pr", "open pr", "merge"], command: "ship" },
+  { keywords: ["discuss", "talk about", "architecture", "design"], command: "discuss" },
+  { keywords: ["undo", "revert", "rollback", "take back"], command: "undo" },
+  { keywords: ["skip", "skip task", "skip this"], command: "skip" },
+  { keywords: ["queue", "reorder", "milestone order", "order milestones"], command: "queue" },
+  { keywords: ["visualize", "viz", "graph", "chart", "show graph"], command: "visualize" },
+  { keywords: ["capture", "note", "idea", "thought", "remember"], command: "capture" },
+  { keywords: ["inspect", "database", "sqlite", "db state"], command: "inspect" },
+  { keywords: ["knowledge", "rule", "pattern", "lesson"], command: "knowledge" },
+  { keywords: ["session report", "session summary", "cost summary", "how much"], command: "session-report" },
+  { keywords: ["backlog", "parking lot", "later", "someday"], command: "backlog" },
+  { keywords: ["pr branch", "clean branch", "filter commits"], command: "pr-branch" },
+  { keywords: ["add tests", "write tests", "generate tests", "test coverage"], command: "add-tests" },
+  { keywords: ["next", "step", "next step", "what's next"], command: "next" },
+  { keywords: ["migrate", "migration", "convert", "upgrade"], command: "migrate" },
+  { keywords: ["steer", "change direction", "pivot", "redirect"], command: "steer" },
+  { keywords: ["park", "shelve", "set aside"], command: "park" },
+  { keywords: ["widget", "toggle widget"], command: "widget" },
+  { keywords: ["logs", "debug logs", "log files"], command: "logs" },
+];
+
+interface MatchResult {
+  command: string;
+  remainingArgs: string;
+  score: number;
+}
+
+function matchRoute(input: string): MatchResult | null {
+  const lower = input.toLowerCase();
+  let bestMatch: MatchResult | null = null;
+
+  for (const route of ROUTES) {
+    for (const keyword of route.keywords) {
+      if (lower.includes(keyword)) {
+        const score = keyword.length; // Longer match = higher confidence
+        if (!bestMatch || score > bestMatch.score) {
+          // Strip the matched keyword from input to get remaining args
+          const idx = lower.indexOf(keyword);
+          const remaining = (input.slice(0, idx) + input.slice(idx + keyword.length)).trim();
+          bestMatch = { command: route.command, remainingArgs: remaining, score };
+        }
+      }
+    }
+  }
+
+  return bestMatch;
+}
+
+export async function handleDo(
+  args: string,
+  ctx: ExtensionCommandContext,
+  pi: ExtensionAPI,
+): Promise<void> {
+  if (!args.trim()) {
+    ctx.ui.notify(
+      "Usage: /gsd do <what you want to do>\n\n" +
+      "Examples:\n" +
+      "  /gsd do show me progress\n" +
+      "  /gsd do run autonomously\n" +
+      "  /gsd do clean up old branches\n" +
+      "  /gsd do fix the login bug",
+      "warning",
+    );
+    return;
+  }
+
+  const match = matchRoute(args);
+
+  if (match) {
+    const fullCommand = match.remainingArgs
+      ? `${match.command} ${match.remainingArgs}`
+      : match.command;
+
+    ctx.ui.notify(`→ /gsd ${fullCommand}`, "info");
+
+    // Re-dispatch through the main dispatcher
+    const { handleGSDCommand } = await import("./commands/dispatcher.js");
+    await handleGSDCommand(fullCommand, ctx, pi);
+    return;
+  }
+
+  // No keyword match → treat as quick task
+  ctx.ui.notify(`→ /gsd quick ${args}`, "info");
+  const { handleQuick } = await import("./quick.js");
+  await handleQuick(args, ctx, pi);
+}

--- a/src/resources/extensions/gsd/commands/catalog.ts
+++ b/src/resources/extensions/gsd/commands/catalog.ts
@@ -15,7 +15,7 @@ export interface GsdCommandDefinition {
 type CompletionMap = Record<string, readonly GsdCommandDefinition[]>;
 
 export const GSD_COMMAND_DESCRIPTION =
-  "GSD — Get Shit Done: /gsd help|start|templates|next|auto|stop|pause|status|widget|visualize|queue|quick|discuss|capture|triage|dispatch|history|undo|undo-task|reset-slice|rate|skip|export|cleanup|model|mode|prefs|config|keys|hooks|run-hook|skill-health|doctor|logs|forensics|changelog|migrate|remote|steer|knowledge|new-milestone|parallel|cmux|park|unpark|init|setup|inspect|extensions|update|fast|mcp|rethink|codebase|notifications";
+  "GSD — Get Shit Done: /gsd help|start|templates|next|auto|stop|pause|status|widget|visualize|queue|quick|discuss|capture|triage|dispatch|history|undo|undo-task|reset-slice|rate|skip|export|cleanup|model|mode|prefs|config|keys|hooks|run-hook|skill-health|doctor|logs|forensics|changelog|migrate|remote|steer|knowledge|new-milestone|parallel|cmux|park|unpark|init|setup|inspect|extensions|update|fast|mcp|rethink|codebase|notifications|do";
 
 export const TOP_LEVEL_SUBCOMMANDS: readonly GsdCommandDefinition[] = [
   { cmd: "help", desc: "Categorized command reference with descriptions" },
@@ -74,6 +74,7 @@ export const TOP_LEVEL_SUBCOMMANDS: readonly GsdCommandDefinition[] = [
   { cmd: "rethink", desc: "Conversational project reorganization — reorder, park, discard, add milestones" },
   { cmd: "workflow", desc: "Custom workflow lifecycle (new, run, list, validate, pause, resume)" },
   { cmd: "codebase", desc: "Generate, refresh, and inspect the codebase map cache (.gsd/CODEBASE.md)" },
+  { cmd: "do", desc: "Route freeform text to the right GSD command" },
 ];
 
 const NESTED_COMPLETIONS: CompletionMap = {

--- a/src/resources/extensions/gsd/commands/handlers/workflow.ts
+++ b/src/resources/extensions/gsd/commands/handlers/workflow.ts
@@ -221,6 +221,12 @@ async function handleCustomWorkflow(
 }
 
 export async function handleWorkflowCommand(trimmed: string, ctx: ExtensionCommandContext, pi: ExtensionAPI): Promise<boolean> {
+  // ── /gsd do — natural language routing (must be early to route to other commands) ──
+  if (trimmed === "do" || trimmed.startsWith("do ")) {
+    const { handleDo } = await import("../../commands-do.js");
+    await handleDo(trimmed.replace(/^do\s*/, "").trim(), ctx, pi);
+    return true;
+  }
   // ── Custom workflow commands (`/gsd workflow ...`) ──
   if (trimmed === "workflow" || trimmed.startsWith("workflow ")) {
     const sub = trimmed.slice("workflow".length).trim();

--- a/src/resources/extensions/gsd/tests/commands-do.test.ts
+++ b/src/resources/extensions/gsd/tests/commands-do.test.ts
@@ -1,0 +1,127 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+// ─── Mock dispatcher to capture routed commands ─────────────────────────
+
+let lastRouted: string | null = null;
+let lastQuick: string | null = null;
+
+const mockCtx = {
+  ui: {
+    notify: (_msg: string, _level: string) => {},
+  },
+} as any;
+
+// We test the keyword matching logic directly since the handler imports
+// the dispatcher dynamically (which requires the full extension runtime).
+
+// Inline the route-matching logic from commands-do.ts for unit testing.
+interface Route {
+  keywords: string[];
+  command: string;
+}
+
+const ROUTES: Route[] = [
+  { keywords: ["progress", "status", "dashboard", "how far", "where are we"], command: "status" },
+  { keywords: ["auto", "autonomous", "run all", "keep going", "start auto"], command: "auto" },
+  { keywords: ["stop", "halt", "abort"], command: "stop" },
+  { keywords: ["pause", "break", "take a break"], command: "pause" },
+  { keywords: ["history", "past", "what happened", "previous"], command: "history" },
+  { keywords: ["doctor", "health", "diagnose", "check health"], command: "doctor" },
+  { keywords: ["clean up", "cleanup", "remove old", "prune", "tidy"], command: "cleanup" },
+  { keywords: ["ship", "pull request", "create pr", "open pr", "merge"], command: "ship" },
+  { keywords: ["discuss", "talk about", "architecture", "design"], command: "discuss" },
+  { keywords: ["undo", "revert", "rollback", "take back"], command: "undo" },
+  { keywords: ["skip", "skip task", "skip this"], command: "skip" },
+  { keywords: ["visualize", "viz", "graph", "chart", "show graph"], command: "visualize" },
+  { keywords: ["capture", "note", "idea", "thought", "remember"], command: "capture" },
+  { keywords: ["inspect", "database", "sqlite", "db state"], command: "inspect" },
+  { keywords: ["session report", "session summary", "cost summary", "how much"], command: "session-report" },
+  { keywords: ["backlog", "parking lot", "later", "someday"], command: "backlog" },
+  { keywords: ["add tests", "write tests", "generate tests", "test coverage"], command: "add-tests" },
+  { keywords: ["next", "step", "next step", "what's next"], command: "next" },
+];
+
+interface MatchResult {
+  command: string;
+  remainingArgs: string;
+  score: number;
+}
+
+function matchRoute(input: string): MatchResult | null {
+  const lower = input.toLowerCase();
+  let bestMatch: MatchResult | null = null;
+
+  for (const route of ROUTES) {
+    for (const keyword of route.keywords) {
+      if (lower.includes(keyword)) {
+        const score = keyword.length;
+        if (!bestMatch || score > bestMatch.score) {
+          const idx = lower.indexOf(keyword);
+          const remaining = (input.slice(0, idx) + input.slice(idx + keyword.length)).trim();
+          bestMatch = { command: route.command, remainingArgs: remaining, score };
+        }
+      }
+    }
+  }
+
+  return bestMatch;
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────
+
+test("/gsd do: routes 'show me progress' to status", () => {
+  const match = matchRoute("show me progress");
+  assert.ok(match);
+  assert.equal(match.command, "status");
+});
+
+test("/gsd do: routes 'run autonomously' to auto", () => {
+  const match = matchRoute("run autonomously");
+  assert.ok(match);
+  assert.equal(match.command, "auto");
+});
+
+test("/gsd do: routes 'clean up old branches' to cleanup", () => {
+  const match = matchRoute("clean up old branches");
+  assert.ok(match);
+  assert.equal(match.command, "cleanup");
+  assert.equal(match.remainingArgs, "old branches");
+});
+
+test("/gsd do: routes 'create pr for milestone' to ship", () => {
+  const match = matchRoute("create pr for milestone");
+  assert.ok(match);
+  assert.equal(match.command, "ship");
+});
+
+test("/gsd do: routes 'add tests for S03' to add-tests", () => {
+  const match = matchRoute("add tests for S03");
+  assert.ok(match);
+  assert.equal(match.command, "add-tests");
+});
+
+test("/gsd do: routes 'what is next' to next", () => {
+  const match = matchRoute("what's next");
+  assert.ok(match);
+  assert.equal(match.command, "next");
+});
+
+test("/gsd do: returns null for unrecognized input", () => {
+  const match = matchRoute("florbinate the gizmo");
+  assert.equal(match, null);
+});
+
+test("/gsd do: prefers longer keyword match", () => {
+  // "check health" (12 chars) should beat "health" (6 chars)
+  const match = matchRoute("check health of the system");
+  assert.ok(match);
+  assert.equal(match.command, "doctor");
+  assert.ok(match.score >= 12);
+});
+
+test("/gsd do: routes 'session report' to session-report", () => {
+  const match = matchRoute("show me the session report");
+  assert.ok(match);
+  assert.equal(match.command, "session-report");
+});


### PR DESCRIPTION
## Summary
Adds `/gsd do <freeform text>` — a natural-language router that maps user phrases to existing GSD subcommands via keyword matching. Zero new infrastructure, pure dispatch.

## Changes
- `commands-do.ts` — keyword-to-command routing with longest-match preference
- `handlers/workflow.ts` — early-fire routing block (runs before `workflow`)
- `commands/catalog.ts` — registration + top-level completion entry

## Test plan
- [x] `tests/commands-do.test.ts` — 9 routing cases (pass)
- [x] Module-load check on `handlers/workflow.ts`

Split from #2282. Part of 6-PR series adding v1→v2 command parity.