### PR TITLE
feat(gsd): add /gsd add-tests command

### DIFF
--- a/src/resources/extensions/gsd/commands-add-tests.ts
+++ b/src/resources/extensions/gsd/commands-add-tests.ts
@@ -1,0 +1,137 @@
+/**
+ * GSD Command — /gsd add-tests
+ *
+ * Generates tests for a completed slice by dispatching an LLM prompt
+ * with implementation context (summaries, changed files, test patterns).
+ */
+
+import type { ExtensionAPI, ExtensionCommandContext } from "@gsd/pi-coding-agent";
+
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
+import { deriveState } from "./state.js";
+import { gsdRoot, resolveSliceFile } from "./paths.js";
+import { loadPrompt } from "./prompt-loader.js";
+
+function findLastCompletedSlice(basePath: string, milestoneId: string): string | null {
+  // Scan disk for slices that have a SUMMARY.md (indicating completion)
+  const slicesDir = join(gsdRoot(basePath), "milestones", milestoneId, "slices");
+  if (!existsSync(slicesDir)) return null;
+
+  try {
+    const entries = readdirSync(slicesDir, { withFileTypes: true })
+      .filter((e) => e.isDirectory() && /^S\d+$/.test(e.name))
+      .sort((a, b) => b.name.localeCompare(a.name)); // reverse order — latest first
+
+    for (const entry of entries) {
+      const summaryPath = join(slicesDir, entry.name, `${entry.name}-SUMMARY.md`);
+      if (existsSync(summaryPath)) return entry.name;
+    }
+  } catch {
+    // non-fatal
+  }
+  return null;
+}
+
+function readSliceSummary(basePath: string, milestoneId: string, sliceId: string): { title: string; content: string } {
+  const summaryPath = resolveSliceFile(basePath, milestoneId, sliceId, "SUMMARY");
+  if (summaryPath && existsSync(summaryPath)) {
+    const content = readFileSync(summaryPath, "utf-8");
+    const titleMatch = content.match(/^#\s+(.+)/m);
+    return { title: titleMatch?.[1] ?? sliceId, content };
+  }
+  return { title: sliceId, content: "(no summary available)" };
+}
+
+function detectTestPatterns(basePath: string): string {
+  const patterns: string[] = [];
+
+  // Check for common test configs
+  const checks = [
+    { file: "jest.config.ts", name: "Jest" },
+    { file: "jest.config.js", name: "Jest" },
+    { file: "vitest.config.ts", name: "Vitest" },
+    { file: "vitest.config.js", name: "Vitest" },
+    { file: ".mocharc.yml", name: "Mocha" },
+  ];
+
+  for (const check of checks) {
+    if (existsSync(join(basePath, check.file))) {
+      patterns.push(`Framework: ${check.name} (${check.file})`);
+    }
+  }
+
+  // Look for existing test files to infer patterns
+  const testDirs = ["tests", "test", "src/__tests__", "__tests__"];
+  for (const dir of testDirs) {
+    const fullDir = join(basePath, dir);
+    if (existsSync(fullDir)) {
+      try {
+        const files = readdirSync(fullDir).filter((f) => f.endsWith(".test.ts") || f.endsWith(".spec.ts") || f.endsWith(".test.js"));
+        if (files.length > 0) {
+          patterns.push(`Test directory: ${dir}/ (${files.length} test files)`);
+          // Read first test file for patterns
+          const samplePath = join(fullDir, files[0]);
+          const sample = readFileSync(samplePath, "utf-8").slice(0, 500);
+          patterns.push(`Sample pattern from ${files[0]}:\n${sample}`);
+          break;
+        }
+      } catch {
+        // non-fatal
+      }
+    }
+  }
+
+  return patterns.length > 0 ? patterns.join("\n") : "No test framework detected. Use Node.js built-in test runner.";
+}
+
+export async function handleAddTests(
+  args: string,
+  ctx: ExtensionCommandContext,
+  pi: ExtensionAPI,
+): Promise<void> {
+  const basePath = process.cwd();
+  const state = await deriveState(basePath);
+
+  if (!state.activeMilestone) {
+    ctx.ui.notify("No active milestone.", "warning");
+    return;
+  }
+
+  const milestoneId = state.activeMilestone.id;
+
+  // Determine target
+  const targetId = args.trim() || findLastCompletedSlice(basePath, milestoneId);
+  if (!targetId) {
+    ctx.ui.notify(
+      "No completed slices found. Specify a slice ID: /gsd add-tests S03",
+      "warning",
+    );
+    return;
+  }
+
+  // Gather context
+  const summary = readSliceSummary(basePath, milestoneId, targetId);
+  const testPatterns = detectTestPatterns(basePath);
+
+  ctx.ui.notify(`Generating tests for ${targetId}: "${summary.title}"...`, "info");
+
+  try {
+    const prompt = loadPrompt("add-tests", {
+      sliceId: targetId,
+      sliceTitle: summary.title,
+      sliceSummary: summary.content,
+      existingTestPatterns: testPatterns,
+      workingDirectory: basePath,
+    });
+
+    pi.sendMessage(
+      { customType: "gsd-add-tests", content: prompt, display: false },
+      { triggerTurn: true },
+    );
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    ctx.ui.notify(`Failed to dispatch test generation: ${msg}`, "error");
+  }
+}

--- a/src/resources/extensions/gsd/commands/catalog.ts
+++ b/src/resources/extensions/gsd/commands/catalog.ts
@@ -15,7 +15,7 @@ export interface GsdCommandDefinition {
 type CompletionMap = Record<string, readonly GsdCommandDefinition[]>;
 
 export const GSD_COMMAND_DESCRIPTION =
-  "GSD — Get Shit Done: /gsd help|start|templates|next|auto|stop|pause|status|widget|visualize|queue|quick|discuss|capture|triage|dispatch|history|undo|undo-task|reset-slice|rate|skip|export|cleanup|model|mode|prefs|config|keys|hooks|run-hook|skill-health|doctor|logs|forensics|changelog|migrate|remote|steer|knowledge|new-milestone|parallel|cmux|park|unpark|init|setup|inspect|extensions|update|fast|mcp|rethink|codebase|notifications";
+  "GSD — Get Shit Done: /gsd help|start|templates|next|auto|stop|pause|status|widget|visualize|queue|quick|discuss|capture|triage|dispatch|history|undo|undo-task|reset-slice|rate|skip|export|cleanup|model|mode|prefs|config|keys|hooks|run-hook|skill-health|doctor|logs|forensics|changelog|migrate|remote|steer|knowledge|new-milestone|parallel|cmux|park|unpark|init|setup|inspect|extensions|update|fast|mcp|rethink|codebase|notifications|add-tests";
 
 export const TOP_LEVEL_SUBCOMMANDS: readonly GsdCommandDefinition[] = [
   { cmd: "help", desc: "Categorized command reference with descriptions" },
@@ -74,6 +74,7 @@ export const TOP_LEVEL_SUBCOMMANDS: readonly GsdCommandDefinition[] = [
   { cmd: "rethink", desc: "Conversational project reorganization — reorder, park, discard, add milestones" },
   { cmd: "workflow", desc: "Custom workflow lifecycle (new, run, list, validate, pause, resume)" },
   { cmd: "codebase", desc: "Generate, refresh, and inspect the codebase map cache (.gsd/CODEBASE.md)" },
+  { cmd: "add-tests", desc: "Generate tests for completed slices" },
 ];
 
 const NESTED_COMPLETIONS: CompletionMap = {

--- a/src/resources/extensions/gsd/commands/handlers/ops.ts
+++ b/src/resources/extensions/gsd/commands/handlers/ops.ts
@@ -216,5 +216,10 @@ Examples:
     await handleCodebase(trimmed.replace(/^codebase\s*/, "").trim(), ctx, pi);
     return true;
   }
+  if (trimmed === "add-tests" || trimmed.startsWith("add-tests ")) {
+    const { handleAddTests } = await import("../../commands-add-tests.js");
+    await handleAddTests(trimmed.replace(/^add-tests\s*/, "").trim(), ctx, pi);
+    return true;
+  }
   return false;
 }

--- a/src/resources/extensions/gsd/prompts/add-tests.md
+++ b/src/resources/extensions/gsd/prompts/add-tests.md
@@ -1,0 +1,35 @@
+You are generating tests for recently completed GSD work.
+
+## Slice: {{sliceId}} — {{sliceTitle}}
+
+### Summary
+
+{{sliceSummary}}
+
+### Existing Test Patterns
+
+{{existingTestPatterns}}
+
+## Working Directory
+
+`{{workingDirectory}}`
+
+## Instructions
+
+1. Read the slice summary above to understand what was built
+2. Identify the source files that were created or modified for this slice
+3. Read the implementation code to understand behavior, edge cases, and error paths
+4. Write comprehensive tests following the project's existing test patterns and framework
+5. Run the tests to verify they pass
+6. Fix any failures
+
+### Rules
+
+- Follow the project's existing test patterns (framework, assertions, file structure)
+- Test behavior, not implementation details
+- Cover: happy path, edge cases, error conditions, boundary values
+- Do NOT modify implementation files — only create or update test files
+- Name test files consistently with the project's conventions
+- Keep tests focused and readable
+
+{{skillActivation}}


### PR DESCRIPTION
## Summary
Adds `/gsd add-tests` — generates tests for completed slices by dispatching a structured LLM prompt loaded from `prompts/add-tests.md`. Uses `resolveSliceFile(..., \"SUMMARY\")` for canonical slice-artifact lookup.

## Changes
- `commands-add-tests.ts` — slice selection + prompt dispatch
- `prompts/add-tests.md` — LLM instruction template
- `handlers/ops.ts` — dynamic-import routing block
- `commands/catalog.ts` — registration + top-level entry

## Test plan
- [x] Module-load check on `commands-add-tests.ts` and `handlers/ops.ts`
- No unit tests on source branch; command is a thin dispatcher that delegates to the LLM

Split from #2282. Part of 6-PR series adding v1→v2 command parity.