### PR TITLE
fix(ci): install web host deps in dev-publish job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,6 @@ on:
       - '.github/workflows/ai-triage.yml'
       - '.github/workflows/build-native.yml'
       - '.github/workflows/cleanup-dev-versions.yml'
-      - '.github/workflows/pipeline.yml'
       - 'LICENSE'
   pull_request:
     branches: [main]
@@ -16,7 +15,6 @@ on:
       - '.github/workflows/ai-triage.yml'
       - '.github/workflows/build-native.yml'
       - '.github/workflows/cleanup-dev-versions.yml'
-      - '.github/workflows/pipeline.yml'
       - 'LICENSE'
 
 concurrency:

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -45,6 +45,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Install web host dependencies
+        run: npm --prefix web ci
+
       - name: Cache Next.js build
         uses: useblacksmith/cache@v5
         with:


### PR DESCRIPTION
## Summary
- Dev Publish job fails with `next: not found` when running `build:web-host`
- Root cause: [fd9ed40af](https://github.com/gsd-build/gsd-2/commit/fd9ed40af) split pipeline build into `build:core` + `build:web-host`, but `web/` has its own lockfile and is not an npm workspace. The previous `npm run build` step self-healed via `scripts/build-web-if-stale.cjs`; the direct `build:web-host` call does not.
- Fix: add `npm --prefix web ci` step after `npm ci` in `dev-publish`, matching the pattern already in `ci.yml:140-141`.

Only `dev-publish` needed the fix — `prod-release` still uses `npm run build` which self-heals.

## Test plan
- [ ] Pipeline workflow runs `Build web host` successfully on merge