### PR TITLE
fix(release): sync workspace versions and harden release scripts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -898,7 +898,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2615,7 +2614,6 @@
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.6.tgz",
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -2853,7 +2851,8 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-android-arm64": {
       "version": "4.59.0",
@@ -2867,7 +2866,8 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
       "version": "4.59.0",
@@ -2881,7 +2881,8 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-darwin-x64": {
       "version": "4.59.0",
@@ -2895,7 +2896,8 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
       "version": "4.59.0",
@@ -2909,7 +2911,8 @@
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
       "version": "4.59.0",
@@ -2923,7 +2926,8 @@
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
       "version": "4.59.0",
@@ -2937,7 +2941,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
       "version": "4.59.0",
@@ -2951,7 +2956,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
       "version": "4.59.0",
@@ -2965,7 +2971,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
       "version": "4.59.0",
@@ -2979,7 +2986,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
       "version": "4.59.0",
@@ -2993,7 +3001,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
       "version": "4.59.0",
@@ -3007,7 +3016,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
       "version": "4.59.0",
@@ -3021,7 +3031,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
       "version": "4.59.0",
@@ -3035,7 +3046,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
       "version": "4.59.0",
@@ -3049,7 +3061,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
       "version": "4.59.0",
@@ -3063,7 +3076,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
       "version": "4.59.0",
@@ -3077,7 +3091,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
       "version": "4.59.0",
@@ -3091,7 +3106,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
       "version": "4.59.0",
@@ -3105,7 +3121,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
       "version": "4.59.0",
@@ -3119,7 +3136,8 @@
       "optional": true,
       "os": [
         "openbsd"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
       "version": "4.59.0",
@@ -3133,7 +3151,8 @@
       "optional": true,
       "os": [
         "openharmony"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
       "version": "4.59.0",
@@ -3147,7 +3166,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
       "version": "4.59.0",
@@ -3161,7 +3181,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
       "version": "4.59.0",
@@ -3175,7 +3196,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
       "version": "4.59.0",
@@ -3189,7 +3211,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@sapphire/async-queue": {
       "version": "1.5.5",
@@ -4291,7 +4314,8 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/hosted-git-info": {
       "version": "3.0.5",
@@ -4362,7 +4386,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -4686,7 +4709,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5559,7 +5581,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -5730,6 +5751,7 @@
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12.0.0"
       },
@@ -6244,7 +6266,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
       "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -7103,6 +7124,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -7434,7 +7456,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7515,6 +7536,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -7692,7 +7714,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7702,7 +7723,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -7816,6 +7836,7 @@
       "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -8376,6 +8397,7 @@
       "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fdir": "^6.5.0",
         "picomatch": "^4.0.3"
@@ -8670,6 +8692,7 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8687,6 +8710,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8704,6 +8728,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8721,6 +8746,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8738,6 +8764,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8755,6 +8782,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8772,6 +8800,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8789,6 +8818,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8806,6 +8836,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8823,6 +8854,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8840,6 +8872,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8857,6 +8890,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8874,6 +8908,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8891,6 +8926,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8908,6 +8944,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8925,6 +8962,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8942,6 +8980,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8959,6 +8998,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8976,6 +9016,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8993,6 +9034,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9010,6 +9052,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9027,6 +9070,7 @@
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9044,6 +9088,7 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9061,6 +9106,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9078,6 +9124,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9095,6 +9142,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9106,6 +9154,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -9334,7 +9383,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -9379,11 +9427,11 @@
     },
     "packages/daemon": {
       "name": "@gsd-build/daemon",
-      "version": "0.1.0",
+      "version": "2.74.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.52.0",
-        "@gsd-build/rpc-client": "^2.52.0",
+        "@gsd-build/rpc-client": "^2.74.0",
         "discord.js": "^14.25.1",
         "yaml": "^2.8.0",
         "zod": "^3.24.0"
@@ -9419,10 +9467,10 @@
     },
     "packages/mcp-server": {
       "name": "@gsd-build/mcp-server",
-      "version": "2.52.0",
+      "version": "2.74.0",
       "license": "MIT",
       "dependencies": {
-        "@gsd-build/rpc-client": "^2.52.0",
+        "@gsd-build/rpc-client": "^2.74.0",
         "@modelcontextprotocol/sdk": "^1.27.1",
         "zod": "^4.0.0"
       },
@@ -9439,16 +9487,16 @@
     },
     "packages/native": {
       "name": "@gsd/native",
-      "version": "0.1.0",
+      "version": "2.74.0",
       "license": "MIT"
     },
     "packages/pi-agent-core": {
       "name": "@gsd/pi-agent-core",
-      "version": "0.57.1"
+      "version": "2.74.0"
     },
     "packages/pi-ai": {
       "name": "@gsd/pi-ai",
-      "version": "0.57.1",
+      "version": "2.74.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.73.0",
         "@anthropic-ai/vertex-sdk": "^0.14.4",
@@ -9515,7 +9563,7 @@
     },
     "packages/pi-tui": {
       "name": "@gsd/pi-tui",
-      "version": "0.57.1",
+      "version": "2.74.0",
       "dependencies": {
         "chalk": "^5.6.2",
         "get-east-asian-width": "^1.3.0",
@@ -9531,7 +9579,7 @@
     },
     "packages/rpc-client": {
       "name": "@gsd-build/rpc-client",
-      "version": "2.52.0",
+      "version": "2.74.0",
       "license": "MIT",
       "engines": {
         "node": ">=22.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gsd-pi",
-  "version": "2.73.1",
+  "version": "2.74.0",
   "description": "GSD — Get Shit Done coding agent",
   "license": "MIT",
   "repository": {

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gsd-build/daemon",
-  "version": "0.1.0",
+  "version": "2.74.0",
   "description": "GSD daemon — background process for project monitoring and Discord integration",
   "license": "MIT",
   "repository": {
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.52.0",
-    "@gsd-build/rpc-client": "^2.52.0",
+    "@gsd-build/rpc-client": "^2.74.0",
     "discord.js": "^14.25.1",
     "yaml": "^2.8.0",
     "zod": "^3.24.0"

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gsd-build/mcp-server",
-  "version": "2.52.0",
+  "version": "2.74.0",
   "description": "MCP server exposing GSD orchestration tools for Claude Code, Cursor, and other MCP clients",
   "license": "MIT",
   "repository": {
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.27.1",
-    "@gsd-build/rpc-client": "^2.52.0",
+    "@gsd-build/rpc-client": "^2.74.0",
     "zod": "^4.0.0"
   },
   "devDependencies": {

--- a/packages/native/package.json
+++ b/packages/native/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@gsd/native",
-  "version": "0.1.0",
-  "description": "Native Rust bindings for GSD \u2014 high-performance native modules via N-API",
+  "version": "2.74.0",
+  "description": "Native Rust bindings for GSD — high-performance native modules via N-API",
   "type": "commonjs",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/pi-agent-core/package.json
+++ b/packages/pi-agent-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gsd/pi-agent-core",
-  "version": "0.57.1",
+  "version": "2.74.0",
   "description": "General-purpose agent core (vendored from pi-mono)",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/pi-ai/package.json
+++ b/packages/pi-ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gsd/pi-ai",
-  "version": "0.57.1",
+  "version": "2.74.0",
   "description": "Unified LLM API (vendored from pi-mono)",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/pi-tui/package.json
+++ b/packages/pi-tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gsd/pi-tui",
-  "version": "0.57.1",
+  "version": "2.74.0",
   "description": "Terminal User Interface library (vendored from pi-mono)",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/rpc-client/package.json
+++ b/packages/rpc-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gsd-build/rpc-client",
-  "version": "2.52.0",
+  "version": "2.74.0",
   "description": "Standalone RPC client SDK for GSD — zero internal dependencies",
   "license": "MIT",
   "repository": {

--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -25,12 +25,38 @@ pkg.version = newVersion;
 writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + "\n");
 console.log(`[bump-version] package.json: ${oldVersion} → ${newVersion}`);
 
-// 2. Update packages/pi-coding-agent/package.json (sync-pkg-version reads from here)
-const piPkgPath = resolve(root, "packages", "pi-coding-agent", "package.json");
-const piPkg = JSON.parse(readFileSync(piPkgPath, "utf-8"));
-piPkg.version = newVersion;
-writeFileSync(piPkgPath, JSON.stringify(piPkg, null, 2) + "\n");
-console.log(`[bump-version] pi-coding-agent: ${oldVersion} → ${newVersion}`);
+// 2. Update all non-private workspace packages under packages/
+//    These share the root version to keep the repo's source of truth coherent
+//    with what ships. Private packages (studio, web) are skipped — they're not
+//    published and have their own lifecycle.
+const workspacePackages = [
+  "daemon",
+  "mcp-server",
+  "native",
+  "pi-agent-core",
+  "pi-ai",
+  "pi-coding-agent",
+  "pi-tui",
+  "rpc-client",
+];
+for (const name of workspacePackages) {
+  const wsPath = resolve(root, "packages", name, "package.json");
+  if (!existsSync(wsPath)) continue;
+  const ws = JSON.parse(readFileSync(wsPath, "utf-8"));
+  const wsOld = ws.version;
+  ws.version = newVersion;
+  // Bump any internal @gsd-build/* or @gsd/* dep references to match.
+  for (const field of ["dependencies", "devDependencies", "peerDependencies"]) {
+    if (!ws[field]) continue;
+    for (const dep of Object.keys(ws[field])) {
+      if (workspacePackages.some((n) => dep === `@gsd-build/${n}` || dep === `@gsd/${n}`)) {
+        ws[field][dep] = `^${newVersion}`;
+      }
+    }
+  }
+  writeFileSync(wsPath, JSON.stringify(ws, null, 2) + "\n");
+  console.log(`[bump-version] ${name}: ${wsOld} → ${newVersion}`);
+}
 
 // 3. Sync platform package versions (reads from root package.json)
 execSync("node native/scripts/sync-platform-versions.cjs", { cwd: root, stdio: "inherit" });

--- a/scripts/generate-changelog.mjs
+++ b/scripts/generate-changelog.mjs
@@ -95,8 +95,23 @@ if (userFacingCount === 0) {
 // ---------------------------------------------------------------------------
 const bumpType = hasBreaking ? "major" : hasFeat ? "minor" : "patch";
 
+// Use the higher of (latest stable tag, package.json version) as the baseline.
+// Tag is the authoritative record of what's already published; package.json can
+// be clobbered by rebases. Taking the max prevents version regressions if the
+// source version is accidentally reverted.
+const tagVersion = stableTag.replace(/^v/, "");
 const currentPkg = JSON.parse(readFileSync(resolve(root, "package.json"), "utf-8"));
-const [major, minor, patch] = currentPkg.version.replace(/-.*$/, "").split(".").map(Number);
+const pkgVersion = currentPkg.version.replace(/-.*$/, "");
+const cmp = (a, b) => {
+  const [aMaj, aMin, aPat] = a.split(".").map(Number);
+  const [bMaj, bMin, bPat] = b.split(".").map(Number);
+  return aMaj - bMaj || aMin - bMin || aPat - bPat;
+};
+const baseline = cmp(pkgVersion, tagVersion) >= 0 ? pkgVersion : tagVersion;
+if (baseline !== pkgVersion) {
+  console.error(`[generate-changelog] package.json (${pkgVersion}) is behind latest tag (${tagVersion}); using tag as baseline.`);
+}
+const [major, minor, patch] = baseline.split(".").map(Number);
 
 let newVersion;
 switch (bumpType) {


### PR DESCRIPTION
## Summary

Two bugs were causing version drift across the repo and would have broken the next release.

### 1. Root package.json was silently reverted

Commit [`fd9ed40af`](https://github.com/gsd-build/gsd-2/commit/fd9ed40af) (a CI optimization rebase) reverted root `package.json` from `2.74.0` → `2.73.1`. Tag `v2.74.0` is already on npm, so the next release would have computed `2.73.2` — lower than what's already published — and shipped a broken version.

### 2. `scripts/bump-version.mjs` only syncs a subset of workspace packages

Everything else drifts:

| Package | Was | Now | Notes |
|---|---|---|---|
| `gsd-pi` (root) | 2.73.1 | **2.74.0** | restored |
| `@gsd-build/mcp-server` | 2.52.0 | **2.74.0** | 22 minor versions behind |
| `@gsd-build/rpc-client` | 2.52.0 | **2.74.0** | consumed by daemon + mcp-server |
| `@gsd-build/daemon` | 0.1.0 | **2.74.0** | |
| `@gsd/pi-ai` | 0.57.1 | **2.74.0** | |
| `@gsd/pi-tui` | 0.57.1 | **2.74.0** | |
| `@gsd/pi-agent-core` | 0.57.1 | **2.74.0** | |
| `@gsd/native` | 0.1.0 | **2.74.0** | |

Private packages (`studio`, `web`) are left alone — they're never published.

## Changes

- Bump all non-private workspace packages to `2.74.0`. Update `daemon` + `mcp-server` internal `rpc-client` dep from `^2.52.0` → `^2.74.0`. Regen root lockfile.
- **`scripts/generate-changelog.mjs`**: compute `newVersion` from `max(latest stable tag, package.json)` instead of `package.json` alone. Prevents version regressions when source is accidentally clobbered — logs a warning when it has to fall back to the tag.
- **`scripts/bump-version.mjs`**: extend to sync all eight non-private workspace packages on every release, including internal `@gsd-build/*` and `@gsd/*` dep references.

## Test plan
- [x] `node --check` on both scripts
- [x] `node scripts/generate-changelog.mjs` produces `newVersion: 2.75.0` (correct: `v2.74.0` tag + `minor` bump from `feat:` commit)
- [x] `npm install --package-lock-only` clean
- [ ] Next dev-publish run stamps `2.74.0-dev.<sha>` correctly
- [ ] Next prod-release computes a sensible version