### PR TITLE
fix(pi-coding-agent): finalize streaming component on agent_end instead of removing it

### DIFF
--- a/packages/pi-coding-agent/src/core/chat-controller-ordering.test.ts
+++ b/packages/pi-coding-agent/src/core/chat-controller-ordering.test.ts
@@ -813,3 +813,83 @@ test("chat-controller updates pinned zone after sub-turn shrink", async () => {
 	// Finalize so the module-level pinned spinner (setInterval) is torn down and the test process can exit.
 	await handleAgentEvent(host, { type: "message_end", message: makeAssistant([{ type: "text", text: "second" }, t2]) } as any);
 });
+
+test("chat-controller: agent_end without message_end must not remove streaming component from DOM (regression #4197)", async () => {
+	const host = createHost();
+
+	await handleAgentEvent(host, {
+		type: "message_start",
+		message: makeAssistant([]),
+	} as any);
+
+	// Simulate partial streaming that creates an AssistantMessageComponent
+	await handleAgentEvent(host, {
+		type: "message_update",
+		message: makeAssistant([{ type: "text", text: "partial answer" }]),
+		assistantMessageEvent: {
+			type: "text_delta",
+			contentIndex: 0,
+			delta: "partial answer",
+			partial: makeAssistant([{ type: "text", text: "partial answer" }]),
+		},
+	} as any);
+
+	// Precondition: component is in DOM
+	assert.equal(
+		host.chatContainer.children.length,
+		1,
+		"streaming component must be in DOM after message_update",
+	);
+	const comp = host.chatContainer.children[0];
+
+	// Simulate abort: agent_end fires WITHOUT message_end
+	await handleAgentEvent(host, { type: "agent_end" } as any);
+
+	assert.equal(
+		host.chatContainer.children.length,
+		1,
+		"agent_end must NOT remove the streaming component from the DOM (issue #4197)",
+	);
+	assert.equal(
+		host.chatContainer.children[0],
+		comp,
+		"the same component instance must remain in the DOM after agent_end",
+	);
+});
+
+test("chat-controller: agent_end after message_end must not alter DOM", async () => {
+	const host = createHost();
+	const content = [{ type: "text", text: "complete answer" }];
+
+	await handleAgentEvent(host, {
+		type: "message_start",
+		message: makeAssistant([]),
+	} as any);
+
+	await handleAgentEvent(host, {
+		type: "message_update",
+		message: makeAssistant(content),
+		assistantMessageEvent: {
+			type: "text_delta",
+			contentIndex: 0,
+			delta: "complete answer",
+			partial: makeAssistant(content),
+		},
+	} as any);
+
+	await handleAgentEvent(host, {
+		type: "message_end",
+		message: makeAssistant(content),
+	} as any);
+
+	const countAfterMessageEnd = host.chatContainer.children.length;
+	assert.ok(countAfterMessageEnd > 0, "component must be present after message_end");
+
+	await handleAgentEvent(host, { type: "agent_end" } as any);
+
+	assert.equal(
+		host.chatContainer.children.length,
+		countAfterMessageEnd,
+		"agent_end after message_end must not add or remove DOM nodes",
+	);
+});

--- a/packages/pi-coding-agent/src/modes/interactive/controllers/chat-controller.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/controllers/chat-controller.ts
@@ -546,11 +546,18 @@ export async function handleAgentEvent(host: InteractiveModeStateHost & {
 				host.loadingAnimation = undefined;
 				host.statusContainer.clear();
 			}
-			if (host.streamingComponent) {
-				host.chatContainer.removeChild(host.streamingComponent);
-				host.streamingComponent = undefined;
-				host.streamingMessage = undefined;
+			// If message_end did not already finalize the streaming component
+			// (e.g. abort path or event ordering edge case), finalize it now
+			// instead of removing it. Calling removeChild would erase the last
+			// assistant message from the chat history (issue #4197).
+			if (host.streamingComponent && host.streamingMessage) {
+				host.streamingComponent.setShowMetadata(true);
+				host.streamingComponent.updateContent(host.streamingMessage);
 			}
+			host.streamingComponent = undefined;
+			host.streamingMessage = undefined;
+			renderedSegments = [];
+			lastContentLength = 0;
 			host.pendingTools.clear();
 			// Pinned output is only useful while work is actively streaming.
 			// Keep chat history as the single source after completion.

--- a/packages/pi-coding-agent/src/modes/interactive/controllers/chat-controller.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/controllers/chat-controller.ts
@@ -546,10 +546,6 @@ export async function handleAgentEvent(host: InteractiveModeStateHost & {
 				host.loadingAnimation = undefined;
 				host.statusContainer.clear();
 			}
-			// If message_end did not already finalize the streaming component
-			// (e.g. abort path or event ordering edge case), finalize it now
-			// instead of removing it. Calling removeChild would erase the last
-			// assistant message from the chat history (issue #4197).
 			if (host.streamingComponent && host.streamingMessage) {
 				host.streamingComponent.setShowMetadata(true);
 				host.streamingComponent.updateContent(host.streamingMessage);


### PR DESCRIPTION
## TL;DR

**What:** Replace `removeChild(streamingComponent)` in the `agent_end` handler with the same finalization pattern used by `message_end`.
**Why:** On the abort path, `agent_end` fires without a preceding `message_end`, causing the last assistant message to be silently erased from the TUI chat history.
**How:** Call `setShowMetadata(true)` and `updateContent()` on the component before clearing the reference — never call `removeChild` on a node that belongs to the persistent chat history.

## What

**File changed:** `packages/pi-coding-agent/src/modes/interactive/controllers/chat-controller.ts`

In the `agent_end` case of `handleAgentEvent`, the following block was removed:

```typescript
if (host.streamingComponent) {
    host.chatContainer.removeChild(host.streamingComponent);
    host.streamingComponent = undefined;
    host.streamingMessage = undefined;
}
```

And replaced with:

```typescript
if (host.streamingComponent && host.streamingMessage) {
    host.streamingComponent.setShowMetadata(true);
    host.streamingComponent.updateContent(host.streamingMessage);
}
host.streamingComponent = undefined;
host.streamingMessage = undefined;
renderedSegments = [];
lastContentLength = 0;
```

Additionally, two regression tests were added to `packages/pi-coding-agent/src/core/chat-controller-ordering.test.ts` covering both the abort path (no preceding `message_end`) and the normal path (`agent_end` after `message_end`).

## Why

When a session is aborted mid-stream — via Escape, `stopAuto()`, `pauseAuto()`, or an auto-mode timeout — the agent emits `agent_end` without a preceding `message_end`. This is guaranteed by the abort path in `agent-session.ts` (lines 1524–1532), which unconditionally emits `agent_end` even when a turn is interrupted.

In the normal (non-abort) flow, `message_end` fires first and sets `host.streamingComponent = undefined`, so the guard `if (host.streamingComponent)` in `agent_end` is never entered. The bug only manifests on the abort path, where `streamingComponent` is still set when `agent_end` fires — at which point the old code deleted the node via `removeChild`, silently discarding the last partial or complete assistant message from the visible chat history.

The root cause: the `agent_end` block was written as a "clean up in-flight state" step but incorrectly treated the DOM node as disposable. Once a component is appended to `chatContainer`, it is part of the permanent chat record and must never be removed.

The `message_end` handler already demonstrates the correct pattern: call `setShowMetadata(true)` to unlock timestamp and error rendering, call `updateContent()` to render the final message state, then clear the reference — without touching `removeChild`.

Closes #4197

## How

**Key invariant:** `message_end` always sets `host.streamingComponent = undefined` before returning. Therefore, if `host.streamingComponent` is non-null when `agent_end` fires, it means `message_end` was skipped. The fix exploits this invariant: finalize if the component is still live, then clear the reference unconditionally.

**Additional cleanup:** `renderedSegments = []` and `lastContentLength = 0` are reset in `agent_end` to clear segment-walker state that `message_end` would have cleared in normal flow. These were previously left stale on the abort path.

**Test approach (test-first):** The regression test for the abort path was written first and confirmed to fail with `AssertionError: 0 !== 1` (children removed, expected to remain) before the fix was applied. The test was then committed separately, followed by the fix — producing two clean, reviewable commits.

**Test coverage:**
- Test 12: abort path — `agent_end` fires without `message_end`; asserts DOM node count stays at 1 and the same component instance remains
- Test 13: normal path — `agent_end` fires after `message_end`; asserts DOM count does not change


## Change type checklist

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

---

> This PR is AI-assisted. The fix, tests, root cause analysis, and PR description were produced with Claude Code. The approach has been reviewed for correctness against the live codebase.