### PR TITLE
fix(ci): remove unsound tsbuildinfo cache causing TS2307 on fresh runners

### DIFF
--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -200,16 +200,6 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Cache TypeScript incremental state
-        uses: useblacksmith/cache@v5
-        with:
-          path: |
-            *.tsbuildinfo
-            packages/*/*.tsbuildinfo
-          key: tsbuild-${{ runner.os }}-${{ hashFiles('package-lock.json', 'tsconfig*.json', 'packages/*/tsconfig.json') }}
-          restore-keys: |
-            tsbuild-${{ runner.os }}-
-
       - name: Build
         run: npm run build
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,18 +147,6 @@ jobs:
             nextjs-${{ runner.os }}-${{ hashFiles('web/package-lock.json') }}-
             nextjs-${{ runner.os }}-
 
-      - name: Cache TypeScript incremental state
-        uses: useblacksmith/cache@v5
-        with:
-          path: |
-            *.tsbuildinfo
-            packages/*/*.tsbuildinfo
-            dist
-            packages/*/dist
-          key: tsbuild-${{ runner.os }}-${{ hashFiles('package-lock.json', 'tsconfig*.json', 'packages/*/tsconfig.json', 'src/**/*.ts', 'packages/*/src/**/*.ts') }}
-          restore-keys: |
-            tsbuild-${{ runner.os }}-
-
       - name: Build core
         run: npm run build:core
 
@@ -216,18 +204,6 @@ jobs:
             nextjs-${{ runner.os }}-${{ hashFiles('web/package-lock.json') }}-
             nextjs-${{ runner.os }}-
 
-      - name: Cache TypeScript incremental state
-        uses: useblacksmith/cache@v5
-        with:
-          path: |
-            *.tsbuildinfo
-            packages/*/*.tsbuildinfo
-            dist
-            packages/*/dist
-          key: tsbuild-${{ runner.os }}-${{ hashFiles('package-lock.json', 'tsconfig*.json', 'packages/*/tsconfig.json', 'src/**/*.ts', 'packages/*/src/**/*.ts') }}
-          restore-keys: |
-            tsbuild-${{ runner.os }}-
-
       - name: Build core
         run: npm run build:core
 
@@ -254,18 +230,6 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
-
-      - name: Cache TypeScript incremental state
-        uses: useblacksmith/cache@v5
-        with:
-          path: |
-            *.tsbuildinfo
-            packages/*/*.tsbuildinfo
-            dist
-            packages/*/dist
-          key: tsbuild-${{ runner.os }}-${{ hashFiles('package-lock.json', 'tsconfig*.json', 'packages/*/tsconfig.json', 'src/**/*.ts', 'packages/*/src/**/*.ts') }}
-          restore-keys: |
-            tsbuild-${{ runner.os }}-
 
       - name: Build core
         run: npm run build:core

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -57,16 +57,6 @@ jobs:
             nextjs-${{ runner.os }}-${{ hashFiles('web/package-lock.json') }}-
             nextjs-${{ runner.os }}-
 
-      - name: Cache TypeScript incremental state
-        uses: useblacksmith/cache@v5
-        with:
-          path: |
-            *.tsbuildinfo
-            packages/*/*.tsbuildinfo
-          key: tsbuild-${{ runner.os }}-${{ hashFiles('package-lock.json', 'tsconfig*.json', 'packages/*/tsconfig.json') }}
-          restore-keys: |
-            tsbuild-${{ runner.os }}-
-
       - name: Build core
         run: npm run build:core
 
@@ -190,16 +180,6 @@ jobs:
           restore-keys: |
             nextjs-${{ runner.os }}-${{ hashFiles('web/package-lock.json') }}-
             nextjs-${{ runner.os }}-
-
-      - name: Cache TypeScript incremental state
-        uses: useblacksmith/cache@v5
-        with:
-          path: |
-            *.tsbuildinfo
-            packages/*/*.tsbuildinfo
-          key: tsbuild-${{ runner.os }}-${{ hashFiles('package-lock.json', 'tsconfig*.json', 'packages/*/tsconfig.json') }}
-          restore-keys: |
-            tsbuild-${{ runner.os }}-
 
       - name: Run live LLM tests (optional)
         continue-on-error: true


### PR DESCRIPTION
## Summary

The `Cache TypeScript incremental state` steps across `pipeline.yml`, `ci.yml`, and `build-native.yml` persist `*.tsbuildinfo` without reliably pairing it with the corresponding `dist/` outputs. On a fresh runner, tsc restores the tsbuildinfo, sees no input changes since the cache snapshot, and **skips emit entirely** — leaving e.g. `packages/native/dist/fd/index.d.ts` missing. Subsequent packages then fail Node16 module resolution on subpath exports:

```
packages/pi-tui/src/autocomplete.ts(4,27): error TS2307: Cannot find module '@gsd/native/fd'
packages/pi-tui/src/terminal-image.ts(212,45): error TS2307: Cannot find module '@gsd/native/image'
packages/pi-tui/src/utils.ts(8,8): error TS2307: Cannot find module '@gsd/native/text'
```

See failing run: https://github.com/gsd-build/gsd-2/actions/runs/24430768314/job/71376011431

The cascading `seg: any` error in `autocomplete.ts:607` is a consequence — `fuzzyFind` resolves to `any` after the failed import, so `.map((seg) => ...)` infers seg as any.

`ci.yml`'s variant did include `dist/` and `packages/*/dist` in the cache paths with source-hash keys, but it shared the `tsbuild-${{ runner.os }}-` restore-keys prefix with the broken `pipeline.yml` and `build-native.yml` caches — so it could still fall back to a dist-less snapshot written by one of those jobs. Removing all six steps eliminates the shared namespace entirely.

Reproduces locally: delete `packages/native/dist`, keep `packages/native/tsconfig.tsbuildinfo`, run `npm run build -w @gsd/native` → tsbuildinfo mtime unchanged, no files emitted. Then `npm run build -w @gsd/pi-tui` reproduces the exact TS2307 errors from CI.

## Test plan

- [x] Delete `packages/native/dist` + keep `tsconfig.tsbuildinfo` → confirm `build -w @gsd/native` no-ops (repro)
- [x] After fix: clean rebuild from scratch emits `dist/{fd,image,text}/index.d.ts`
- [x] After fix: `npm run build -w @gsd/pi-tui` succeeds with no TS2307 errors
- [ ] CI `dev-publish` Build core step passes on this branch