### PR TITLE
feat: add Amazon Bedrock as a first-class LLM provider

### DIFF
--- a/src/resources/extensions/aws-auth/index.ts
+++ b/src/resources/extensions/aws-auth/index.ts
@@ -19,14 +19,22 @@
  *
  * This extension is completely inert unless BOTH conditions are met:
  *   1. A Bedrock API request fails with a recognized AWS auth error
- *   2. `awsAuthRefresh` is configured in settings.json
+ *   2. A refresh command is available (explicit config OR auto-detected SSO profile)
  *
- * Non-Bedrock users and Bedrock users without `awsAuthRefresh` configured
- * are not affected in any way.
+ * ## Credential refresh resolution (in order)
  *
- * ## Setup
+ *   1. Explicit `awsAuthRefresh` in settings.json (project-level, then global)
+ *   2. `AWS_PROFILE` env var → `aws sso login --profile $AWS_PROFILE`
+ *   3. Auto-detected SSO profile from ~/.aws/config:
+ *      - Prefers profiles whose role name contains "bedrock" (case-insensitive)
+ *      - Falls back to the first SSO profile found
  *
- * Add to ~/.gsd/agent/settings.json (or project-level .gsd/settings.json):
+ * Non-Bedrock users and users without SSO profiles are not affected.
+ *
+ * ## Setup (optional — auto-detection usually works)
+ *
+ * Override auto-detection by adding to ~/.gsd/agent/settings.json
+ * (or project-level .gsd/settings.json):
  *
  *   { "awsAuthRefresh": "aws sso login --profile my-profile" }
  *
@@ -54,8 +62,71 @@ const AWS_AUTH_ERROR_RE =
 	/ExpiredToken|security token.*expired|unable to locate credentials|SSO.*(?:session|token).*(?:expired|not found|invalid)|UnrecognizedClient|Could not load credentials|Invalid identity token|token is expired|credentials.*(?:could not|cannot|failed to).*(?:load|resolve|find)|The.*token.*is.*not.*valid|token has expired|SSOTokenProviderFailure|Error loading SSO Token|Token.*does not exist/i;
 
 /**
- * Reads the `awsAuthRefresh` command from settings.json.
- * Checks project-level first, then global (~/.gsd/agent/settings.json).
+ * Parses ~/.aws/config to find SSO profiles.
+ * Returns the best profile name for `aws sso login --profile <name>`.
+ * Prefers profiles whose sso_role_name contains "bedrock".
+ */
+function detectSsoProfile(): string | undefined {
+	const configPath = join(homedir(), ".aws", "config");
+	if (!existsSync(configPath)) return undefined;
+
+	let content: string;
+	try {
+		content = readFileSync(configPath, "utf-8");
+	} catch {
+		return undefined;
+	}
+
+	interface SsoProfile {
+		name: string;
+		roleName?: string;
+	}
+
+	const profiles: SsoProfile[] = [];
+	let currentProfile: string | undefined;
+	let currentRoleName: string | undefined;
+	let isSso = false;
+
+	for (const line of content.split("\n")) {
+		const trimmed = line.trim();
+
+		const profileMatch = trimmed.match(/^\[profile\s+(.+)\]$/);
+		if (profileMatch || trimmed === "[default]") {
+			if (currentProfile && isSso) {
+				profiles.push({ name: currentProfile, roleName: currentRoleName });
+			}
+			currentProfile = profileMatch ? profileMatch[1] : "default";
+			currentRoleName = undefined;
+			isSso = false;
+			continue;
+		}
+
+		if (trimmed.startsWith("sso_session") || trimmed.startsWith("sso_start_url")) {
+			isSso = true;
+		}
+		const roleMatch = trimmed.match(/^sso_role_name\s*=\s*(.+)$/);
+		if (roleMatch) {
+			currentRoleName = roleMatch[1].trim();
+		}
+	}
+	if (currentProfile && isSso) {
+		profiles.push({ name: currentProfile, roleName: currentRoleName });
+	}
+
+	if (profiles.length === 0) return undefined;
+
+	const bedrockProfile = profiles.find((p) =>
+		p.roleName && /bedrock/i.test(p.roleName),
+	);
+
+	return (bedrockProfile || profiles[0]).name;
+}
+
+/**
+ * Resolves the refresh command using a three-tier fallback:
+ *   1. Explicit `awsAuthRefresh` in settings.json
+ *   2. `AWS_PROFILE` env var
+ *   3. Auto-detected SSO profile from ~/.aws/config
  */
 function getAwsAuthRefreshCommand(): string | undefined {
 	const configDir = process.env.PI_CONFIG_DIR || ".gsd";
@@ -70,6 +141,13 @@ function getAwsAuthRefreshCommand(): string | undefined {
 			if (settings.awsAuthRefresh) return settings.awsAuthRefresh;
 		} catch {}
 	}
+
+	const envProfile = process.env.AWS_PROFILE;
+	if (envProfile) return `aws sso login --profile ${envProfile}`;
+
+	const detected = detectSsoProfile();
+	if (detected) return `aws sso login --profile ${detected}`;
+
 	return undefined;
 }
 

--- a/src/resources/extensions/gsd/doctor-providers.ts
+++ b/src/resources/extensions/gsd/doctor-providers.ts
@@ -60,6 +60,7 @@ function modelToProviderId(model: string): string | null {
       anthropic: "anthropic",
       openai: "openai",
       "github-copilot": "github-copilot",
+      "amazon-bedrock": "amazon-bedrock",
     };
     if (prefixMap[prefix]) return prefixMap[prefix];
   }
@@ -71,6 +72,7 @@ function modelToProviderId(model: string): string | null {
   if (lower.startsWith("llama") || lower.startsWith("mixtral")) return "groq";
   if (lower.startsWith("grok"))          return "xai";
   if (lower.startsWith("mistral") || lower.startsWith("codestral")) return "mistral";
+  if (lower.startsWith("amazon.") || lower.startsWith("us.amazon.")) return "amazon-bedrock";
 
   return null;
 }
@@ -194,6 +196,7 @@ const CLI_AUTH_PROVIDERS = new Set([
   "openai-codex",
   "google-gemini-cli",
   "google-antigravity",
+  "amazon-bedrock",
 ]);
 
 function checkLlmProviders(): ProviderCheckResult[] {

--- a/src/resources/extensions/gsd/key-manager.ts
+++ b/src/resources/extensions/gsd/key-manager.ts
@@ -49,6 +49,7 @@ export const PROVIDER_REGISTRY: ProviderInfo[] = [
   { id: "custom-openai",    label: "Custom (OpenAI-compat)",  category: "llm", envVar: "CUSTOM_OPENAI_API_KEY" },
   { id: "cerebras",         label: "Cerebras",                category: "llm", envVar: "CEREBRAS_API_KEY" },
   { id: "azure-openai-responses", label: "Azure OpenAI",      category: "llm", envVar: "AZURE_OPENAI_API_KEY" },
+  { id: "amazon-bedrock",     label: "Amazon Bedrock",         category: "llm" },
   { id: "alibaba-coding-plan", label: "Alibaba Coding Plan",  category: "llm", envVar: "ALIBABA_API_KEY",      dashboardUrl: "bailian.console.aliyun.com" },
   { id: "alibaba-dashscope",   label: "Alibaba DashScope",    category: "llm", envVar: "DASHSCOPE_API_KEY",    dashboardUrl: "dashscope.console.aliyun.com" },
 


### PR DESCRIPTION
## Summary

- **key-manager.ts**: Adds `amazon-bedrock` to `PROVIDER_REGISTRY` — no `envVar` needed since Bedrock uses the AWS credential chain (IAM/SSO), not API keys
- **doctor-providers.ts**: Adds `amazon-bedrock` to the prefix map, model-name inference for `amazon.*` / `us.amazon.*` model IDs, and `CLI_AUTH_PROVIDERS` so the doctor doesn't flag it as missing a key
- **aws-auth/index.ts**: Enhances `getAwsAuthRefreshCommand()` with a three-tier fallback so SSO users don't need to manually configure `awsAuthRefresh`:
  1. Explicit `awsAuthRefresh` in settings.json (unchanged, always wins)
  2. `AWS_PROFILE` env var → generates `aws sso login --profile $AWS_PROFILE`
  3. Auto-detects SSO profile from `~/.aws/config` — prefers profiles whose `sso_role_name` contains "bedrock", falls back to first SSO profile

## Motivation

`token-counter.ts` already has a `bedrock: 3.5` entry, indicating Bedrock support was anticipated but never completed. This PR closes that gap so Bedrock users get the same first-class experience as other providers — automatic doctor checks, model resolution, and credential refresh.

## Test plan

- [ ] `amazon-bedrock` appears in `/gsd doctor` output as "CLI auth (no key needed)"
- [ ] Model string `amazon-bedrock/claude-sonnet-4-6` resolves to `amazon-bedrock` provider
- [ ] Model string `amazon.nova-pro-v1:0` resolves to `amazon-bedrock` provider
- [ ] With `AWS_PROFILE=my-profile` set, aws-auth auto-generates refresh command without explicit config
- [ ] With no env var but `~/.aws/config` containing SSO profiles, auto-detection picks the bedrock-related profile
- [ ] Explicit `awsAuthRefresh` in settings.json still takes priority over auto-detection
- [ ] Users without AWS config or SSO profiles see no behavior change