### PR TITLE
fix(pi-ai): hide unsupported ChatGPT codex oauth models

### DIFF
--- a/packages/pi-ai/src/utils/oauth/openai-codex.ts
+++ b/packages/pi-ai/src/utils/oauth/openai-codex.ts
@@ -26,6 +26,14 @@ const TOKEN_URL = "https://auth.openai.com/oauth/token";
 const REDIRECT_URI = "http://localhost:1455/auth/callback";
 const SCOPE = "openid profile email offline_access";
 const JWT_CLAIM_PATH = "https://api.openai.com/auth";
+const CHATGPT_UNSUPPORTED_MODEL_IDS = new Set([
+	"gpt-5.2-codex",
+	"gpt-5.1-codex-mini",
+	"gpt-5.1-codex-max",
+	"gpt-5.1-codex",
+	"gpt-5.1",
+	"gpt-5",
+]);
 
 const SUCCESS_HTML = `<!doctype html>
 <html lang="en">
@@ -453,5 +461,12 @@ export const openaiCodexOAuthProvider: OAuthProviderInterface = {
 
 	getApiKey(credentials: OAuthCredentials): string {
 		return credentials.access;
+	},
+
+	modifyModels(models) {
+		return models.filter((model) => (
+			model.provider !== "openai-codex"
+			|| !CHATGPT_UNSUPPORTED_MODEL_IDS.has(model.id)
+		));
 	},
 };

--- a/packages/pi-coding-agent/src/core/model-registry-auth-mode.test.ts
+++ b/packages/pi-coding-agent/src/core/model-registry-auth-mode.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import type { Api, Model, SimpleStreamOptions, Context, AssistantMessageEventStream } from "@gsd/pi-ai";
 import { getApiProvider } from "@gsd/pi-ai";
-import type { AuthStorage } from "./auth-storage.js";
+import { AuthStorage, type AuthStorageData } from "./auth-storage.js";
 import { ModelRegistry } from "./model-registry.js";
 
 function createRegistry(hasAuthFn?: (provider: string) => boolean): ModelRegistry {
@@ -16,6 +16,10 @@ function createRegistry(hasAuthFn?: (provider: string) => boolean): ModelRegistr
 	} as unknown as AuthStorage;
 
 	return new ModelRegistry(authStorage, undefined);
+}
+
+function createInMemoryRegistry(data: AuthStorageData = {}): ModelRegistry {
+	return new ModelRegistry(AuthStorage.inMemory(data), undefined);
 }
 
 function createProviderModel(id: string, api?: string): NonNullable<Parameters<ModelRegistry["registerProvider"]>[1]["models"]>[number] {
@@ -388,6 +392,36 @@ describe("ModelRegistry authMode — getAvailable", () => {
 		const registry = createRegistry(() => false);
 		const available = registry.getAvailable();
 		assert.equal(available.length, 0);
+	});
+
+	it("prunes Codex models removed from ChatGPT-backed openai-codex OAuth", () => {
+		const registry = createInMemoryRegistry({
+			"openai-codex": {
+				type: "oauth",
+				access: "oauth-access",
+				refresh: "oauth-refresh",
+				expires: Date.now() + 60_000,
+				accountId: "acct_123",
+			},
+		});
+
+		assert.equal(registry.find("openai-codex", "gpt-5.1-codex-max"), undefined);
+		assert.equal(registry.find("openai-codex", "gpt-5.1"), undefined);
+		assert.equal(findModel(registry, "openai-codex", "gpt-5.2-codex"), undefined);
+		assert.ok(registry.find("openai-codex", "gpt-5.4"));
+		assert.ok(findModel(registry, "openai-codex", "gpt-5.4"));
+	});
+
+	it("keeps API-backed OpenAI Codex-capable models available", () => {
+		const registry = createInMemoryRegistry({
+			openai: {
+				type: "api_key",
+				key: "sk-test",
+			},
+		});
+
+		assert.ok(registry.find("openai", "gpt-5.2-codex"));
+		assert.ok(findModel(registry, "openai", "gpt-5.2-codex"));
 	});
 });
 


### PR DESCRIPTION
## TL;DR

**What:** Filter ChatGPT-unsupported Codex model IDs from the `openai-codex` OAuth provider.
**Why:** ChatGPT-backed Codex sign-in no longer supports the removed 5.1/5.2 Codex variants, so exposing them leads users into immediate model-selection failures.
**How:** Add an `openai-codex` OAuth-only denylist in `pi-ai` and cover it with a regression test in `pi-coding-agent` to ensure API-key-backed OpenAI models remain available.

## What

This change updates `packages/pi-ai/src/utils/oauth/openai-codex.ts` to hide model IDs that OpenAI removed for ChatGPT-backed Codex sign-in. It also adds regression coverage in `packages/pi-coding-agent/src/core/model-registry-auth-mode.test.ts` to verify that:

- `openai-codex` OAuth sessions no longer surface removed models
- API-key-backed `openai` model availability is unchanged

## Why

Users signing into Codex with a ChatGPT account can still hit model IDs that are no longer supported by that auth mode. That creates a bad UX where GSD surfaces models that fail immediately after selection. This fix keeps the OAuth-backed model list aligned with current ChatGPT Codex availability while avoiding regressions for API-key users.

## How

The provider now filters a hardcoded set of ChatGPT-unsupported model IDs only when the provider is `openai-codex`. The regression test builds an in-memory registry for both OAuth-backed `openai-codex` and API-key-backed `openai` cases to verify the filter is auth-mode-specific.

## Change type checklist

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Breaking changes

None.

## Validation

- `npm run build`
- `npm test`

## AI-assisted contribution

This PR is AI-assisted.