### PR TITLE
Fix: unitDispatchCount never incremented — retry diagnostic prompt never fires on repeated dispatches

### DIFF
--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -823,8 +823,8 @@ export async function stopAuto(
           resolver.mergeAndExit(s.currentMilestoneId, notifyCtx);
         } else {
           // Milestone still in progress — preserve branch for later resumption
-          resolver.exitMilestone(s.currentMilestoneId, notifyCtx, {
-            preserveBranch: true,
+          resolver.exitMilestone(s.currentMilestoneId, notifyCtx, { 
+            preserveBranch: true, 
           });
         }
       }
@@ -1654,6 +1654,9 @@ function ensurePreconditions(
   base: string,
   state: GSDState,
 ): void {
+  const dispatchKey = `${unitType}/${unitId}`;
+  s.unitDispatchCount.set(dispatchKey, (s.unitDispatchCount.get(dispatchKey) ?? 0) + 1);
+
   const { milestone: mid, slice: sid } = parseUnitId(unitId);
 
   const mDir = resolveMilestonePath(base, mid);
@@ -1720,6 +1723,9 @@ export async function dispatchHookUnit(
     id: triggerUnitId,
     startedAt: hookStartedAt,
   };
+
+  const dispatchKey = `${hookUnitType}/${triggerUnitId}`;
+  s.unitDispatchCount.set(dispatchKey, (s.unitDispatchCount.get(dispatchKey) ?? 0) + 1);
 
   if (hookModel) {
     const availableModels = ctx.modelRegistry.getAvailable();


### PR DESCRIPTION
The issue was that `unitDispatchCount` was initialized and cleared but never actually incremented when a unit of work was dispatched. This caused the retry diagnostic injection logic (which checks if the count is > 1) to never trigger. I've added the increment logic in two key places in `auto.ts`: 

1. In `ensurePreconditions`: This function is called by the main auto-mode loop (`autoLoop`) via `LoopDeps` just before a unit is dispatched. Incrementing here ensures that every time a main task unit (like executing a task or completing a slice) is attempted, its dispatch count increases.
2. In `dispatchHookUnit`: This function handles the dispatch of post-unit hooks. Incrementing here ensures hooks also track their dispatch attempts consistently.

These changes allow the system to correctly identify repeated attempts on the same unit and provide the necessary 'RETRY' hint to the agent.

Test: 1. Run auto-mode on a project and identify a task unit (e.g., 'execute-task').
2. Allow the task to complete but manually ensure the required artifact is missing (or mock the verification to fail).
3. Wait for auto-mode to re-dispatch the same task unit.
4. Inspect the prompt sent to the LLM for the second attempt. It should now contain the string: "RETRY — your previous attempt did not produce the required artifact".