### PR TITLE
fix(gsd-auto): persist stuck-state on dev-path iterations (#4231)

### DIFF
--- a/packages/pi-coding-agent/src/core/chat-controller-ordering.test.ts
+++ b/packages/pi-coding-agent/src/core/chat-controller-ordering.test.ts
@@ -320,6 +320,105 @@ test("chat-controller drops provisional pre-tool text for claude-code MCP turns"
 	await handleAgentEvent(host, { type: "message_end", message: makeAssistant(finalContent) } as any);
 });
 
+test("chat-controller prunes orphaned provisional text after claude-code sub-turn shrink when MCP tools appear", async () => {
+	(globalThis as any)[Symbol.for("@gsd/pi-coding-agent:theme")] = {
+		fg: (_key: string, text: string) => text,
+		bg: (_key: string, text: string) => text,
+		bold: (text: string) => text,
+		italic: (text: string) => text,
+		truncate: (text: string) => text,
+	};
+
+	const host = createHost();
+	host.getMarkdownThemeWithSettings = () => ({});
+
+	const mcpTool = {
+		type: "toolCall",
+		id: "mcp-tool-shrink-1",
+		name: "glob",
+		mcpServer: "filesystem",
+		arguments: { pattern: "**/*" },
+	};
+
+	await handleAgentEvent(host, { type: "message_start", message: makeAssistant([]) } as any);
+
+	// Sub-turn 1: generate longer provisional text content.
+	await handleAgentEvent(
+		host,
+		{
+			type: "message_update",
+			message: makeAssistant([{ type: "text", text: "Old provisional preface." }, { type: "text", text: "More old text." }]),
+			assistantMessageEvent: {
+				type: "text_delta",
+				contentIndex: 1,
+				delta: "More old text.",
+				partial: makeAssistant([{ type: "text", text: "Old provisional preface." }, { type: "text", text: "More old text." }]),
+			},
+		} as any,
+	);
+	assert.equal(host.chatContainer.children.length, 1, "first sub-turn text run should render");
+
+	// Sub-turn 2 starts (content shrink): old component is orphaned by design.
+	await handleAgentEvent(
+		host,
+		{
+			type: "message_update",
+			message: makeAssistant([{ type: "text", text: "New provisional text before tool." }]),
+			assistantMessageEvent: {
+				type: "text_delta",
+				contentIndex: 0,
+				delta: "New provisional text before tool.",
+				partial: makeAssistant([{ type: "text", text: "New provisional text before tool." }]),
+			},
+		} as any,
+	);
+	assert.equal(host.chatContainer.children.length, 2, "shrink keeps prior text until MCP tool context appears");
+
+	// MCP tool appears in sub-turn 2: both old orphaned text and current pre-tool text should be pruned.
+	await handleAgentEvent(
+		host,
+		{
+			type: "message_update",
+			message: makeAssistant([{ type: "text", text: "New provisional text before tool." }, mcpTool]),
+			assistantMessageEvent: {
+				type: "toolcall_end",
+				contentIndex: 1,
+				toolCall: {
+					...mcpTool,
+					externalResult: {
+						content: [{ type: "text", text: "glob output" }],
+						details: {},
+						isError: false,
+					},
+				},
+				partial: makeAssistant([{ type: "text", text: "New provisional text before tool." }, mcpTool]),
+			},
+		} as any,
+	);
+	assert.equal(host.chatContainer.children.length, 1, "stale text runs should be removed once MCP tool is present");
+	assert.equal(host.chatContainer.children[0]?.constructor?.name, "ToolExecutionComponent");
+
+	const finalContent = [mcpTool, { type: "text", text: "Final visible question?" }];
+	await handleAgentEvent(
+		host,
+		{
+			type: "message_update",
+			message: makeAssistant(finalContent),
+			assistantMessageEvent: {
+				type: "text_delta",
+				contentIndex: 1,
+				delta: "Final visible question?",
+				partial: makeAssistant(finalContent),
+			},
+		} as any,
+	);
+	assert.equal(host.chatContainer.children.length, 2);
+	assert.equal(host.chatContainer.children[0]?.constructor?.name, "ToolExecutionComponent");
+	assert.equal(host.chatContainer.children[1]?.constructor?.name, "AssistantMessageComponent");
+
+	await handleAgentEvent(host, { type: "message_end", message: makeAssistant(finalContent) } as any);
+});
+
 test("chat-controller pins latest assistant text above editor when tool calls are present", async () => {
 	(globalThis as any)[Symbol.for("@gsd/pi-coding-agent:theme")] = {
 		fg: (_key: string, text: string) => text,

--- a/packages/pi-coding-agent/src/modes/interactive/controllers/chat-controller.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/controllers/chat-controller.ts
@@ -20,6 +20,10 @@ type RenderedSegment =
 	| { kind: "tool"; contentIndex: number; component: ToolExecutionComponent };
 
 let renderedSegments: RenderedSegment[] = [];
+// When providers reuse one assistant lifecycle across internal sub-turns,
+// a content[] shrink resets renderedSegments. Keep the displaced segments so
+// claude-code MCP pruning can remove stale provisional text later.
+let orphanedSegments: RenderedSegment[] = [];
 
 function hasVisibleAssistantContent(message: { content: Array<any> }): boolean {
 	return message.content.some(
@@ -93,6 +97,7 @@ export async function handleAgentEvent(host: InteractiveModeStateHost & {
 		lastPinnedText = "";
 		hasToolsInTurn = false;
 		renderedSegments = [];
+		orphanedSegments = [];
 		if (pinnedBorder) pinnedBorder.stopSpinner();
 		pinnedBorder = undefined;
 		pinnedTextComponent = undefined;
@@ -113,6 +118,7 @@ export async function handleAgentEvent(host: InteractiveModeStateHost & {
 					lastPinnedText = "";
 					hasToolsInTurn = false;
 					renderedSegments = [];
+					orphanedSegments = [];
 					lastContentLength = 0;
 					if (pinnedBorder) pinnedBorder.stopSpinner();
 					pinnedBorder = undefined;
@@ -226,6 +232,7 @@ export async function handleAgentEvent(host: InteractiveModeStateHost & {
 				// content (#4144 regression). Prior sub-turn children stay in
 				// chatContainer as frozen history; new segments append after them.
 				if (contentBlocks.length < lastContentLength) {
+					orphanedSegments = [...renderedSegments];
 					renderedSegments = [];
 					lastPinnedText = "";
 					lastProcessedContentIndex = 0;
@@ -346,6 +353,20 @@ export async function handleAgentEvent(host: InteractiveModeStateHost & {
 					// superseded by post-tool output. Prune stale text-run segments so
 					// the final assistant output remains below tool output.
 					if (shouldDropPreToolText && firstToolIdx >= 0) {
+						if (orphanedSegments.length > 0) {
+							const remainingOrphans: RenderedSegment[] = [];
+							for (const orphan of orphanedSegments) {
+								if (orphan.kind === "text-run") {
+									host.chatContainer.removeChild(orphan.component);
+									if (host.streamingComponent === orphan.component) {
+										host.streamingComponent = undefined;
+									}
+									continue;
+								}
+								remainingOrphans.push(orphan);
+							}
+							orphanedSegments = remainingOrphans;
+						}
 						const desiredTextStarts = new Set(
 							desired
 								.filter((seg): seg is Extract<DesiredSegment, { kind: "text-run" }> => seg.kind === "text-run")
@@ -536,6 +557,7 @@ export async function handleAgentEvent(host: InteractiveModeStateHost & {
 				host.streamingComponent = undefined;
 				host.streamingMessage = undefined;
 				renderedSegments = [];
+				orphanedSegments = [];
 				lastContentLength = 0;
 				// Clear pinned output once the message is finalized in the chat
 				// container — prevents duplicate display when the agent continues
@@ -599,6 +621,7 @@ export async function handleAgentEvent(host: InteractiveModeStateHost & {
 			host.streamingComponent = undefined;
 			host.streamingMessage = undefined;
 			renderedSegments = [];
+			orphanedSegments = [];
 			lastContentLength = 0;
 			host.pendingTools.clear();
 			// Pinned output is only useful while work is actively streaming.


### PR DESCRIPTION
## TL;DR

**What:** Call `saveStuckState` after iteration-end on the dev path and the error catch block in `auto/loop.ts`.
**Why:** Stuck detection state never persisted on the normal dev path, so crashes lost the sliding window and the same blocked unit burned a full retry budget every session restart.
**How:** Add two `saveStuckState(s.basePath, loopState)` calls matching the pattern already used on the custom-engine path, plus a regression test.

## What

- `src/resources/extensions/gsd/auto/loop.ts` — add `saveStuckState` calls after the `iteration-end` journal event in the dev-path success branch and in the blanket catch block, mirroring the existing call in the custom-engine branch.
- `src/resources/extensions/gsd/tests/auto-loop.test.ts` — add a regression test that runs one dev-path iteration against an isolated temp `basePath` and asserts `.gsd/runtime/stuck-state.json` is written with a non-empty `recentUnits` window. `makeLoopSession` now clears any leaked stuck-state file for its basePath so shared `/tmp/project` tests stay isolated.

## Why

Reported in #4231. `saveStuckState` was only called inside the custom-engine code path. The normal dev path — used by every non-engine project — had no persistence call after either a successful iteration or an error iteration. Effects:

1. On session start, `loadStuckState` reads an empty/stale window.
2. During iteration, `loopState.recentUnits` accumulates in memory.
3. Context exhaustion crashes the process before any graceful save.
4. On restart, the window loads empty → stuck detection sees zero repeated dispatches.
5. The blocked unit redispatches with a clean slate, burning another ~80K tokens.

Field evidence in the issue showed `execute-task/M002/S03/T01` redispatched 5 times in a row with no stuck-state file ever written to `.gsd/runtime/` — because `saveStuckState` was never reached on that code path.

Closes #4231.

## How

Two one-line inserts wrap an existing invariant rather than introducing new logic:

```ts
// dev-path success branch
deps.emitJournalEvent({ ..., eventType: "iteration-end", data: { iteration } });
saveStuckState(s.basePath, loopState); // persist across session restarts (#4231)
debugLog("autoLoop", { phase: "iteration-complete", iteration });

// blanket catch block
deps.emitJournalEvent({ ..., eventType: "iteration-end", data: { iteration, error: msg } });
saveStuckState(s.basePath, loopState); // persist across session restarts (#4231)
```

This matches exactly the pattern already present in the custom-engine path (~line 373). The placement after `iteration-end` is intentional — the journal event closes out the iteration semantically, and the state file should reflect the post-iteration window.

### Regression test

`#4231 dev-path iteration persists stuck-state.json to disk` creates a fresh tempdir via `mkdtempSync`, runs one dev-path iteration, and asserts the state file exists and contains a non-empty `recentUnits` array. Verified to fail on HEAD without the fix and pass with it.

### Test isolation fix

Several existing stuck-detection tests share `basePath: \"/tmp/project\"`. With `saveStuckState` now actually running on the dev path, state leaked across tests. `makeLoopSession` now clears `<basePath>/.gsd/runtime/stuck-state.json` up-front so each test starts with an empty window. No behavior change — tests that override `basePath` still get their own cleanup.

## Checklist

- [x] `fix` — Bug fix
- [x] Tests pass locally (`auto-loop.test.ts`: 62 passed, 0 failed)
- [x] `tsc --noEmit` clean
- [x] Regression test verified to fail without the fix
- [x] AI-assisted: written with Claude Code

## Type

- [ ] feat
- [x] fix
- [ ] refactor
- [ ] test
- [ ] docs
- [ ] chore