### PR TITLE
Fix: Auto-mode stuck loop: context exhaustion invisible to stuck detection

### DIFF
--- a/src/resources/extensions/gsd/auto/detect-stuck.ts
+++ b/src/resources/extensions/gsd/auto/detect-stuck.ts
@@ -19,7 +19,7 @@ const ENOENT_PATH_RE = /ENOENT[^']*'([^']+)'/;
  * Returns a signal with reason if stuck, null otherwise.
  *
  * Rule 1: Same error string twice in a row → stuck immediately.
- * Rule 2: Same unit key 3+ consecutive times → stuck (preserves prior behavior).
+ * Rule 2: Same unit key 3+ times in the window → stuck (handles non-consecutive repeats).
  * Rule 3: Oscillation A→B→A→B in last 4 entries → stuck.
  * Rule 4: Same ENOENT path in any 2 entries within the window → stuck (#3575).
  *         Missing files don't self-heal between retries — retrying wastes budget.
@@ -47,15 +47,19 @@ export function detectStuck(
     };
   }
 
-  // Rule 2: Same unit 3+ consecutive times
-  if (window.length >= 3) {
+  // Rule 2: Same unit 3+ times in the window
+  // Catch repeats even if interrupted by lifecycle units (e.g. reassess-roadmap).
+  const unitOccurrences = window.filter((u) => u.key === last.key).length;
+  if (unitOccurrences >= 3) {
     const lastThree = window.slice(-3);
-    if (lastThree.every((u) => u.key === last.key)) {
-      return {
-        stuck: true,
-        reason: `${last.key} derived 3 consecutive times without progress${suffix}`,
-      };
-    }
+    const isConsecutive = lastThree.every((u) => u.key === last.key);
+    const detail = isConsecutive
+      ? "3 consecutive times"
+      : `${unitOccurrences} times in last ${window.length} attempts`;
+    return {
+      stuck: true,
+      reason: `${last.key} dispatched ${detail} without progress${suffix}`,
+    };
   }
 
   // Rule 3: Oscillation (A→B→A→B in last 4)


### PR DESCRIPTION
Updated Rule 2 in `detectStuck` to identify stuck loops where a unit is repeated 3 or more times within the sliding window, regardless of whether those repeats are consecutive. Previously, Rule 2 only triggered if the unit appeared 3 times consecutively, which allowed intervening lifecycle units (like `reassess-roadmap` or `plan-slice`) to break the detection logic. The new implementation counts all occurrences of the last unit's key in the window and provides a detailed reason message that distinguishes between consecutive and non-consecutive repetitions. I also updated the JSDoc and internal comments to reflect this broader detection capability.

Test: 1. Prepare a mock `WindowEntry` array with non-consecutive repeats, e.g., `[ { key: 'task-1' }, { key: 'task-1' }, { key: 'roadmap-reassess' }, { key: 'task-1' } ]`.
2. Call `detectStuck(window)`.
3. Assert that it returns `{ stuck: true, reason: 'task-1 dispatched 3 times in last 4 attempts without progress' }` (plus any logger suffix).
4. Prepare a mock with consecutive repeats, e.g., `[ { key: 'task-1' }, { key: 'task-1' }, { key: 'task-1' } ]`.
5. Call `detectStuck(window)`.
6. Assert that it returns `{ stuck: true, reason: 'task-1 dispatched 3 consecutive times without progress' }`.
7. Verify that Rule 3 (oscillation) and Rule 4 (ENOENT) still function as expected by testing those specific patterns.