### PR TITLE
Fix: [Bug]: flat-rate auth-mode lookup failed

### DIFF
--- a/web/lib/pty-manager.ts
+++ b/web/lib/pty-manager.ts
@@ -285,10 +285,11 @@ export function getOrCreateSession(sessionId: string, projectCwd?: string, comma
   const spawnSpec = resolveTerminalSpawnSpec(cwd, command, commandArgs);
   console.log("[pty] Spawning command:", spawnSpec.label, "cwd:", cwd, "node-pty:", nodePtyRoot);
 
-  // Build a clean env — remove GSD-specific vars that would confuse a shell
+  // Build a clean env — remove GSD-specific vars that would confuse a shell.
+  // We preserve them if the command is "gsd" because the CLI needs its configuration.
   const cleanEnv: Record<string, string> = {};
   for (const [key, value] of Object.entries(process.env)) {
-    if (value !== undefined && !key.startsWith("GSD_WEB_")) {
+    if (value !== undefined && (command === "gsd" || !key.startsWith("GSD_WEB_"))) {
       cleanEnv[key] = value;
     }
   }


### PR DESCRIPTION
The issue was caused by environment variable stripping in the `getOrCreateSession` function. When spawning a PTY session, the code intentionally removes environment variables starting with `GSD_WEB_` to prevent them from leaking into generic user shells (like bash or zsh). However, the `gsd` CLI itself (the Goose command) depends on these variables (specifically `GSD_WEB_HOST_KIND` and `GSD_WEB_PACKAGE_ROOT`) to correctly initialize its internal provider registry when running in web-mode. Removing them caused the 'flat-rate auth-mode lookup' to fail because the provider registry was never initialized, leading to the 'Cannot read properties of undefined (reading 'registeredProviders')' error. I updated the environment cleanup logic to preserve `GSD_WEB_` variables if the command being executed is 'gsd'.

Test: 1. Configure the GSD application with a GitHub Copilot model.
2. Open the web terminal interface which uses the pty-manager.
3. Run the command `/gsd notifications`.
4. Verify that the command executes successfully and displays notification status without emitting the 'registeredProviders' error in the logs or terminal output.