### PR TITLE
feat(gsd): add /gsd eval-review and /gsd eval-fix commands

### DIFF
--- a/src/resources/extensions/gsd/commands-eval-fix.ts
+++ b/src/resources/extensions/gsd/commands-eval-fix.ts
@@ -1,0 +1,141 @@
+/**
+ * GSD Command — /gsd eval-fix
+ *
+ * Reads an existing EVAL-REVIEW.md, extracts MISSING/PARTIAL gaps,
+ * and spawns a fix agent to address them in the codebase.
+ */
+
+import type { ExtensionAPI, ExtensionCommandContext } from "@gsd/pi-coding-agent";
+
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { deriveState } from "./state.js";
+import { loadPrompt } from "./prompt-loader.js";
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export interface EvalFixArgs {
+  sliceId: string | null;
+}
+
+// ── Pure Functions ────────────────────────────────────────────────────────────
+
+export function parseEvalFixArgs(args: string): EvalFixArgs {
+  const sliceId = args.trim().length > 0 ? args.trim() : null;
+  return { sliceId };
+}
+
+export function findEvalReviewFile(
+  basePath: string,
+  milestoneId: string,
+  sliceId: string,
+): string | null {
+  const filePath = join(
+    basePath,
+    ".gsd",
+    "milestones",
+    milestoneId,
+    "slices",
+    sliceId,
+    `${sliceId}-EVAL-REVIEW.md`,
+  );
+  return existsSync(filePath) ? filePath : null;
+}
+
+export function parseGapsFromEvalReview(content: string): string[] {
+  // Split on ## headings, find the Gap Analysis section
+  const sections = content.split(/^(?=## )/m);
+  const gapSection = sections.find((s) => s.startsWith("## Gap Analysis"));
+  if (!gapSection) return [];
+
+  const gaps: string[] = [];
+  for (const line of gapSection.split("\n")) {
+    const match = line.match(/^[-*]\s+(.+)/);
+    if (match) {
+      gaps.push(match[1].trim());
+    }
+  }
+
+  return gaps;
+}
+
+export function buildEvalFixOutputPath(sliceDir: string, sliceId: string): string {
+  return join(sliceDir, `${sliceId}-EVAL-FIX.md`);
+}
+
+// ── Handler ───────────────────────────────────────────────────────────────────
+
+export async function handleEvalFix(
+  args: string,
+  ctx: ExtensionCommandContext,
+  pi: ExtensionAPI,
+): Promise<void> {
+  const basePath = process.cwd();
+  const gsdState = await deriveState(basePath);
+
+  if (!gsdState.activeMilestone) {
+    ctx.ui.notify("No active milestone.", "warning");
+    return;
+  }
+
+  const milestoneId = gsdState.activeMilestone.id;
+  const parsed = parseEvalFixArgs(args);
+
+  // Resolve target slice — explicit arg or active slice
+  const sliceId = parsed.sliceId ?? gsdState.activeSlice?.id ?? null;
+  if (!sliceId) {
+    ctx.ui.notify(
+      "No active slice. Specify a slice ID: /gsd eval-fix S01",
+      "warning",
+    );
+    return;
+  }
+
+  const reviewFilePath = findEvalReviewFile(basePath, milestoneId, sliceId);
+  if (!reviewFilePath) {
+    ctx.ui.notify(
+      `No EVAL-REVIEW.md found for slice ${sliceId}. Run /gsd eval-review first.`,
+      "warning",
+    );
+    return;
+  }
+
+  const evalReviewContent = readFileSync(reviewFilePath, "utf-8");
+  const gaps = parseGapsFromEvalReview(evalReviewContent);
+
+  if (gaps.length === 0) {
+    ctx.ui.notify(
+      `No gaps found in EVAL-REVIEW for ${sliceId}. Re-run with /gsd eval-review --force ${sliceId} to refresh the score.`,
+      "info",
+    );
+    return;
+  }
+
+  const sliceDir = join(basePath, ".gsd", "milestones", milestoneId, "slices", sliceId);
+  const outputPath = buildEvalFixOutputPath(sliceDir, sliceId);
+
+  ctx.ui.notify(
+    `Running eval-fix for ${sliceId} — ${gaps.length} gap${gaps.length === 1 ? "" : "s"} to address...`,
+    "info",
+  );
+
+  try {
+    const prompt = loadPrompt("eval-fix", {
+      sliceId,
+      milestoneId,
+      workingDirectory: basePath,
+      gaps: gaps.join("\n"),
+      evalReviewContent,
+      outputPath,
+    });
+
+    pi.sendMessage(
+      { customType: "gsd-eval-fix", content: prompt, display: false },
+      { triggerTurn: true },
+    );
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    ctx.ui.notify(`Failed to dispatch eval-fix: ${msg}`, "error");
+  }
+}

--- a/src/resources/extensions/gsd/commands-eval-review.ts
+++ b/src/resources/extensions/gsd/commands-eval-review.ts
@@ -1,0 +1,178 @@
+/**
+ * GSD Command — /gsd eval-review
+ *
+ * Reviews an AI-SPEC and SUMMARY to evaluate how well the implementation
+ * covers the original specification. Dispatches the gsd-eval-auditor agent
+ * which scans eval-related files and produces a scored review report.
+ */
+
+import type { ExtensionAPI, ExtensionCommandContext } from "@gsd/pi-coding-agent";
+
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { deriveState } from "./state.js";
+import { loadPrompt, getTemplatesDir } from "./prompt-loader.js";
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export interface EvalReviewArgs {
+  sliceId: string | null;
+  force?: boolean;
+  show?: boolean;
+}
+
+export type EvalReviewStateType = "full" | "no-spec" | "no-summary";
+
+export interface EvalReviewState {
+  state: EvalReviewStateType;
+  summaryPath: string | null;
+  specPath: string | null;
+  sliceDir: string | null;
+}
+
+// ── Pure Functions ────────────────────────────────────────────────────────────
+
+export function parseEvalReviewArgs(args: string): EvalReviewArgs {
+  const force = args.includes("--force");
+  const show = args.includes("--show");
+  // Remove flags and trim whitespace to get the bare slice ID
+  const withoutFlags = args.replace(/--force\s*/g, "").replace(/--show\s*/g, "").trim();
+  const sliceId = withoutFlags.length > 0 ? withoutFlags : null;
+  return { sliceId, force: force || undefined, show: show || undefined };
+}
+
+export function detectEvalReviewState(
+  basePath: string,
+  milestoneId: string,
+  sliceId: string,
+): EvalReviewState {
+  const sliceDir = join(basePath, ".gsd", "milestones", milestoneId, "slices", sliceId);
+
+  if (!existsSync(sliceDir)) {
+    return { state: "no-summary", summaryPath: null, specPath: null, sliceDir: null };
+  }
+
+  // SUMMARY uses SliceID prefix: S01-SUMMARY.md
+  const summaryPath = join(sliceDir, `${sliceId}-SUMMARY.md`);
+  if (!existsSync(summaryPath)) {
+    return { state: "no-summary", summaryPath: null, specPath: null, sliceDir };
+  }
+
+  // AI-SPEC has no prefix: AI-SPEC.md
+  const specPath = join(sliceDir, "AI-SPEC.md");
+  if (!existsSync(specPath)) {
+    return { state: "no-spec", summaryPath, specPath: null, sliceDir };
+  }
+
+  return { state: "full", summaryPath, specPath, sliceDir };
+}
+
+export function buildEvalReviewOutputPath(sliceDir: string, sliceId: string): string {
+  return join(sliceDir, `${sliceId}-EVAL-REVIEW.md`);
+}
+
+export function buildEvalReviewContext(state: EvalReviewState): { spec: string | null; summary: string } {
+  const summary = state.summaryPath ? readFileSync(state.summaryPath, "utf-8") : "(no summary available)";
+  const spec = state.specPath ? readFileSync(state.specPath, "utf-8") : null;
+  return { spec, summary };
+}
+
+// ── Handler ───────────────────────────────────────────────────────────────────
+
+export async function handleEvalReview(
+  args: string,
+  ctx: ExtensionCommandContext,
+  pi: ExtensionAPI,
+): Promise<void> {
+  const basePath = process.cwd();
+  const gsdState = await deriveState(basePath);
+
+  if (!gsdState.activeMilestone) {
+    ctx.ui.notify("No active milestone.", "warning");
+    return;
+  }
+
+  const milestoneId = gsdState.activeMilestone.id;
+  const parsed = parseEvalReviewArgs(args);
+
+  // Resolve target slice — explicit arg or active slice
+  const sliceId = parsed.sliceId ?? gsdState.activeSlice?.id ?? null;
+  if (!sliceId) {
+    ctx.ui.notify(
+      "No active slice. Specify a slice ID: /gsd eval-review S01",
+      "warning",
+    );
+    return;
+  }
+
+  const evalState = detectEvalReviewState(basePath, milestoneId, sliceId);
+
+  if (evalState.state === "no-summary") {
+    ctx.ui.notify(
+      `No SUMMARY.md found for slice ${sliceId}. Run /gsd execute-phase first.`,
+      "warning",
+    );
+    return;
+  }
+
+  if (!evalState.sliceDir) {
+    ctx.ui.notify("Could not resolve slice directory.", "error");
+    return;
+  }
+
+  const outputPath = buildEvalReviewOutputPath(evalState.sliceDir, sliceId);
+
+  // --show: read and summarise an existing review without re-running
+  // --force is ignored when --show is set
+  if (parsed.show && parsed.force) {
+    ctx.ui.notify("--force is ignored when --show is set.", "info");
+  }
+  if (parsed.show) {
+    if (!existsSync(outputPath)) {
+      ctx.ui.notify(`No EVAL-REVIEW.md found for ${sliceId}. Run /gsd eval-review first.`, "warning");
+      return;
+    }
+    const content = readFileSync(outputPath, "utf-8");
+    const scoreMatch = content.match(/\*\*Overall Score:\*\*\s*(\d+)\/100/);
+    const verdictMatch = content.match(/\*\*Verdict:\*\*\s*([^\n]+)/);
+    const score = scoreMatch?.[1] ?? "?";
+    const verdict = verdictMatch?.[1]?.trim() ?? "unknown";
+    ctx.ui.notify(`EVAL-REVIEW ${sliceId}: ${verdict} (${score}/100)\nFile: ${outputPath}`, "info");
+    return;
+  }
+
+  // Check if already reviewed (unless --force)
+  if (!parsed.force && existsSync(outputPath)) {
+    ctx.ui.notify(
+      `Eval review already exists for ${sliceId}. Use --force to re-run: /gsd eval-review --force ${sliceId}`,
+      "info",
+    );
+    return;
+  }
+
+  const context = buildEvalReviewContext(evalState);
+
+  const stateLabel = evalState.state === "full" ? "AI-SPEC + SUMMARY" : "SUMMARY only (no AI-SPEC)";
+  ctx.ui.notify(`Running eval review for ${sliceId} [${stateLabel}]...`, "info");
+
+  try {
+    const prompt = loadPrompt("eval-review", {
+      sliceId,
+      milestoneId,
+      summaryContent: context.summary,
+      specContent: context.spec ?? "(no AI-SPEC available for this slice)",
+      outputPath,
+      hasSpec: String(evalState.state === "full"),
+      templatesDir: getTemplatesDir(),
+    });
+
+    pi.sendMessage(
+      { customType: "gsd-eval-review", content: prompt, display: false },
+      { triggerTurn: true },
+    );
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    ctx.ui.notify(`Failed to dispatch eval review: ${msg}`, "error");
+  }
+}

--- a/src/resources/extensions/gsd/commands-ship.ts
+++ b/src/resources/extensions/gsd/commands-ship.ts
@@ -9,6 +9,7 @@ import type { ExtensionAPI, ExtensionCommandContext } from "@gsd/pi-coding-agent
 
 import { execFileSync } from "node:child_process";
 import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
 
 import { deriveState } from "./state.js";
 import { resolveMilestoneFile, resolveSlicePath, resolveSliceFile } from "./paths.js";
@@ -180,6 +181,31 @@ export async function handleShip(
       "warning",
     );
     return;
+  }
+
+  // 2b. Warn if active slice has no EVAL-REVIEW or verdict is NOT IMPLEMENTED (non-blocking)
+  const activeSliceId = state.activeSlice?.id ?? null;
+  if (activeSliceId) {
+    const sliceDir = join(basePath, ".gsd", "milestones", milestoneId, "slices", activeSliceId);
+    const evalReviewPath = join(sliceDir, `${activeSliceId}-EVAL-REVIEW.md`);
+    if (!existsSync(evalReviewPath)) {
+      ctx.ui.notify(
+        `No EVAL-REVIEW.md found for ${activeSliceId}. Consider running /gsd eval-review before shipping.`,
+        "warning",
+      );
+      // Non-blocking: continue with ship
+    } else {
+      const evalContent = readFileSync(evalReviewPath, "utf-8");
+      const verdictMatch = evalContent.match(/\*\*Verdict:\*\*\s*([^\n]+)/);
+      const verdict = verdictMatch?.[1]?.trim() ?? "";
+      if (verdict === "NOT IMPLEMENTED") {
+        ctx.ui.notify(
+          `EVAL-REVIEW for ${activeSliceId} shows NOT IMPLEMENTED. Run /gsd eval-fix to address gaps.`,
+          "warning",
+        );
+        // Non-blocking: continue with ship
+      }
+    }
   }
 
   // 3. Generate PR content

--- a/src/resources/extensions/gsd/commands/handlers/core.ts
+++ b/src/resources/extensions/gsd/commands/handlers/core.ts
@@ -99,6 +99,8 @@ export function showHelp(ctx: ExtensionCommandContext, args = ""): void {
     "",
     "MAINTENANCE",
     "  /gsd doctor         Diagnose and repair .gsd/ state  [audit|fix|heal] [scope]",
+    "  /gsd eval-review    Review AI-SPEC vs SUMMARY for a slice  [slice-id] [--force]",
+    "  /gsd eval-fix [slice-id]    Fix gaps identified in EVAL-REVIEW.md",
     "  /gsd export         Export milestone/slice results  [--json|--markdown|--html] [--all]",
     "  /gsd cleanup        Remove merged branches or snapshots  [branches|snapshots]",
     "  /gsd migrate        Migrate .planning/ (v1) to .gsd/ (v2) format",

--- a/src/resources/extensions/gsd/commands/handlers/ops.ts
+++ b/src/resources/extensions/gsd/commands/handlers/ops.ts
@@ -241,5 +241,15 @@ Examples:
     await handleExtractLearnings(trimmed.replace(/^extract-learnings\s*/, "").trim(), ctx, pi);
     return true;
   }
+  if (trimmed === "eval-review" || trimmed.startsWith("eval-review ")) {
+    const { handleEvalReview } = await import("../../commands-eval-review.js");
+    await handleEvalReview(trimmed.replace(/^eval-review\s*/, "").trim(), ctx, pi);
+    return true;
+  }
+  if (trimmed === "eval-fix" || trimmed.startsWith("eval-fix ")) {
+    const { handleEvalFix } = await import("../../commands-eval-fix.js");
+    await handleEvalFix(trimmed.replace(/^eval-fix\s*/, "").trim(), ctx, pi);
+    return true;
+  }
   return false;
 }

--- a/src/resources/extensions/gsd/prompts/eval-fix.md
+++ b/src/resources/extensions/gsd/prompts/eval-fix.md
@@ -1,0 +1,280 @@
+<role>
+You are a GSD eval fixer. You apply fixes to gaps found by the gsd-eval-auditor agent.
+
+Spawned by `/gsd eval-fix` workflow. You produce EVAL-FIX.md artifact in the slice directory.
+
+Your job: Read EVAL-REVIEW.md gaps, fix the codebase intelligently (not blind application), and produce EVAL-FIX.md report.
+
+**DO NOT commit any changes.** gsd-2 never commits automatically — all commits are made by the user.
+</role>
+
+<input>
+**Milestone:** {{milestoneId}}
+**Slice:** {{sliceId}}
+**Working directory:** `{{workingDirectory}}`
+**Output path:** `{{outputPath}}`
+
+**Gaps to address:**
+{{gaps}}
+
+**Full EVAL-REVIEW content:**
+{{evalReviewContent}}
+</input>
+
+<fix_strategy>
+
+## Intelligent Fix Application
+
+The EVAL-REVIEW gap description is **GUIDANCE**, not a patch to blindly apply.
+
+**For each gap:**
+
+1. **Read the actual source file** at the relevant location (plus surrounding context — at least +/- 10 lines)
+2. **Understand the current code state** — check if the gap still applies
+3. **Adapt the fix** to the actual code if it has changed or differs from review context
+4. **Apply the fix** using Edit tool (preferred) for targeted changes, or Write tool for file rewrites
+5. **Verify the fix** using the 3-tier verification strategy (see below)
+
+**If the source file has changed significantly** and the gap no longer applies cleanly:
+- Mark as "skipped: code context differs from review"
+- Continue with remaining gaps
+- Document in EVAL-FIX.md
+
+</fix_strategy>
+
+<rollback_strategy>
+
+## Safe Per-Gap Rollback
+
+Before editing ANY file for a gap, establish safe rollback capability.
+
+**Rollback Protocol:**
+
+1. **Record files to touch:** Note each file path before editing anything.
+
+2. **Apply fix:** Use Edit tool (preferred) for targeted changes.
+
+3. **Verify fix:** Apply 3-tier verification strategy.
+
+4. **On verification failure:**
+   - Run `git checkout -- {file}` for EACH modified file.
+   - This is safe: the fix has NOT been committed. `git checkout --` reverts only the uncommitted in-progress change.
+   - **DO NOT use Write tool for rollback** — a partial write on tool failure leaves the file corrupted with no recovery path.
+
+5. **After rollback:**
+   - Re-read the file and confirm it matches pre-fix state.
+   - Mark gap as "skipped: fix caused errors, rolled back".
+   - Document failure details in skip reason.
+   - Continue with next gap.
+
+</rollback_strategy>
+
+<verification_strategy>
+
+## 3-Tier Verification
+
+After applying each fix, verify correctness in 3 tiers.
+
+**Tier 1: Minimum (ALWAYS REQUIRED)**
+- Re-read the modified file section (at least the lines affected by the fix)
+- Confirm the fix text is present
+- Confirm surrounding code is intact (no corruption)
+- This tier is MANDATORY for every fix
+
+**Tier 2: Preferred (when available)**
+Run syntax/parse check appropriate to file type:
+
+| Language | Check Command |
+|----------|--------------|
+| JavaScript | `node -c {file}` (syntax check) |
+| TypeScript | `npx tsc --noEmit {file}` (if tsconfig.json exists in project) |
+| Python | `python -c "import ast; ast.parse(open('{file}').read())"` |
+| JSON | `node -e "JSON.parse(require('fs').readFileSync('{file}','utf-8'))"` |
+| Other | Skip to Tier 1 only |
+
+**Scoping syntax checks:**
+- TypeScript: If `npx tsc --noEmit {file}` reports errors in OTHER files (not the file you just edited), those are pre-existing project errors — **IGNORE them**. Only fail if errors reference the specific file you modified.
+- If a syntax check fails because the tool doesn't support the file type (e.g., `node -c` on JSX): fall back to Tier 1 only — do NOT rollback.
+- General rule: If errors existed BEFORE your edit, your fix did not cause them. Proceed.
+
+If syntax check **PASSES**: proceed.
+If syntax check **FAILS with errors in your modified file that were NOT present before**: trigger rollback_strategy.
+
+**Tier 3: Fallback**
+If no syntax checker is available for the file type (e.g., `.md`, `.sh`):
+- Accept Tier 1 result
+- Do NOT skip the fix just because syntax checking is unavailable
+
+</verification_strategy>
+
+<gap_classifier>
+
+## Gap Classification
+
+Classify each gap before attempting a fix:
+
+| Type | Description | Action |
+|------|-------------|--------|
+| `code-fix` | Missing implementation, wrong logic, incomplete feature | Fix in source code |
+| `test-fix` | Missing or incomplete tests for a dimension | Add/update test files |
+| `doc-fix` | Missing documentation, comments, or rubric definitions | Add inline docs or update spec |
+| `manual` | Requires external credentials, human decision, or infrastructure setup | Document, do NOT attempt |
+
+**Manual gap examples:**
+- "Add Langfuse API key and configure tracing" — requires external account/credentials
+- "Human review sampling process" — requires process design decision
+- "CI/CD eval pipeline setup" — may require infrastructure permissions
+- "Production guardrail deployment" — requires deployment access
+
+</gap_classifier>
+
+<execution_flow>
+
+<step name="load_context">
+Parse gaps and EVAL-REVIEW content from the `<input>` block above. Do NOT re-read files from disk for context that was already provided.
+
+Classify each gap using gap_classifier rules. Sort: code-fix first, then test-fix, then doc-fix, then manual last.
+</step>
+
+<step name="apply_fixes">
+For each gap in sorted order (skip `manual` gaps — document them instead):
+
+**a. Read source files:**
+- Identify the relevant file(s) from the gap description
+- Read actual file content before any edit
+- For primary file: read at least +/- 10 lines around the relevant location
+
+**b. Determine if fix applies:**
+- Compare current code state to what the reviewer described
+- Check if gap still applies given current code
+- Adapt fix if code has minor changes but gap still applies
+
+**c. Apply fix or skip:**
+
+**If fix applies cleanly:**
+- Use Edit tool (preferred) for targeted changes
+- Or Write tool if full file rewrite needed
+- Apply narrowly — do not refactor unrelated code
+
+**If code context differs significantly:**
+- Mark as "skipped: code context differs from review"
+- Record skip reason
+- Continue to next gap
+
+**d. Verify fix (3-tier verification_strategy):**
+
+Tier 1 (always): re-read modified section, confirm fix present and code intact.
+Tier 2 (preferred): run syntax check for file type.
+Tier 3 (fallback): accept Tier 1 if no checker available.
+
+On Tier 2 failure: execute rollback_strategy, mark as "skipped: fix caused errors, rolled back".
+
+**e. Record result:**
+```
+gap: "description of gap"
+type: code-fix | test-fix | doc-fix
+status: fixed | skipped
+files_modified: [list of files]
+skip_reason: "..." (if skipped)
+```
+</step>
+
+<step name="write_fix_report">
+**ALWAYS use the Write tool to create files** — never use `Bash(cat << 'EOF')` or heredoc commands for file creation.
+
+Write to `{{outputPath}}`:
+
+```markdown
+# Eval Fix — {{sliceId}}
+
+**Fixed:** {ISO date}
+**Gaps addressed:** {N of M}
+
+## Fixed Gaps
+
+| Gap | Type | File(s) | Change |
+|-----|------|---------|--------|
+| {gap description} | {code-fix/test-fix/doc-fix} | {file} | {brief description of change} |
+
+## Manual Gaps (require human action)
+
+| Gap | Reason | Suggested Action |
+|-----|--------|-----------------|
+| {gap description} | {why it cannot be auto-fixed} | {what the developer should do} |
+
+## Skipped Gaps
+
+{If no skipped gaps, omit this section}
+
+| Gap | Reason |
+|-----|--------|
+| {gap description} | {skip reason} |
+
+## Summary
+
+{N} gap(s) fixed automatically. {M} gap(s) require manual action.
+{If all fixed}: Re-run `/gsd eval-review --force {{sliceId}}` to confirm updated score.
+{If manual remain}: {M} gap(s) require manual intervention before the slice can reach PRODUCTION READY.
+```
+</step>
+
+<step name="display_summary">
+After writing the file, output this summary directly in the conversation:
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ EVAL FIX — {{sliceId}}
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Fixed:  {N} / {M total}
+
+✓ {each fixed gap}
+• {each manual gap — requires human action}
+
+Output: {{outputPath}}
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+→ Re-run `/gsd eval-review --force {{sliceId}}` to see the updated score.
+</step>
+
+</execution_flow>
+
+<critical_rules>
+
+**ALWAYS use the Write tool to create files** — never use `Bash(cat << 'EOF')` or heredoc commands for file creation.
+
+**DO read the actual source file** before applying any fix — never blindly apply EVAL-REVIEW gap descriptions without understanding current code state.
+
+**DO NOT commit any changes.** gsd-2 never auto-commits. Leave all changes uncommitted for the user to review and commit.
+
+**DO use Edit tool (preferred)** over Write tool for targeted changes. Edit provides better diff visibility.
+
+**DO verify each fix** using 3-tier verification strategy:
+- Minimum: re-read file, confirm fix present
+- Preferred: syntax check (node -c, tsc --noEmit, python ast.parse, etc.)
+- Fallback: accept minimum if no syntax checker available
+
+**DO skip gaps that cannot be applied cleanly** — do not force broken fixes. Mark as skipped with clear reason.
+
+**DO rollback using `git checkout -- {file}`** on verification failure — atomic and safe since fixes are NOT committed. Do NOT use Write tool for rollback.
+
+**DO NOT modify files unrelated to the gap** — scope each fix narrowly.
+
+**DO NOT run the full test suite** between fixes (too slow). Verify only the specific change.
+
+**DO classify `manual` gaps correctly** — do not attempt fixes requiring external credentials, infrastructure access, or human decisions.
+
+</critical_rules>
+
+<success_criteria>
+- [ ] All gaps classified (code-fix / test-fix / doc-fix / manual)
+- [ ] All non-manual gaps attempted (fixed or skipped with reason)
+- [ ] No source files left in broken state (failed fixes rolled back via git checkout)
+- [ ] No changes committed (gsd-2 never auto-commits)
+- [ ] Verification performed for each fix (minimum: re-read, preferred: syntax check)
+- [ ] EVAL-FIX.md written to {{outputPath}} with accurate counts
+- [ ] Manual gaps documented with suggested actions
+- [ ] Skipped gaps documented with specific skip reasons
+- [ ] Summary displayed in conversation
+</success_criteria>

--- a/src/resources/extensions/gsd/prompts/eval-review.md
+++ b/src/resources/extensions/gsd/prompts/eval-review.md
@@ -1,0 +1,202 @@
+<role>
+You are a GSD eval auditor. Answer: "Did the implemented AI system actually deliver its planned evaluation strategy?"
+Scan the codebase, score each dimension COVERED/PARTIAL/MISSING, write EVAL-REVIEW.md.
+</role>
+
+<required_reading>
+Read the AI evaluation reference at: {{templatesDir}}/ai-evals.md
+
+This is your scoring framework. Read it before auditing.
+</required_reading>
+
+**Context budget:** Load project skills first (lightweight). Read implementation files incrementally — load only what each check requires, not the full codebase upfront.
+
+**Project skills:** Check `.claude/skills/` or `.agents/skills/` directory if either exists:
+1. List available skills (subdirectories)
+2. Read `SKILL.md` for each skill (lightweight index ~130 lines)
+3. Load specific `rules/*.md` files as needed during scoring
+4. Do NOT load full `AGENTS.md` files (100KB+ context cost)
+5. Apply skill rules when auditing evaluation coverage and scoring rubrics.
+
+<input>
+**Milestone:** {{milestoneId}}
+**Slice:** {{sliceId}}
+**Has AI-SPEC:** {{hasSpec}}
+**Output path:** `{{outputPath}}`
+
+The following content has been pre-loaded for you — do NOT read these files from disk again:
+
+**AI-SPEC Content:**
+{{specContent}}
+
+**SUMMARY Content:**
+{{summaryContent}}
+</input>
+
+<execution_flow>
+
+<step name="read_phase_artifacts">
+The AI-SPEC and SUMMARY content are already provided above in the `<input>` block. Do NOT re-read them from disk.
+
+Extract from AI-SPEC content: planned eval dimensions with rubrics, eval tooling, dataset spec, online guardrails, monitoring plan (Sections 5, 6, 7 if present).
+
+If no AI-SPEC is available (hasSpec is "false"), evaluate the SUMMARY on its own completeness and quality using the standard dimensions from ai-evals.md.
+</step>
+
+<step name="scan_codebase">
+```bash
+# Eval/test files
+find . \( -name "*.test.*" -o -name "*.spec.*" -o -name "test_*" -o -name "eval_*" \) \
+  -not -path "*/node_modules/*" -not -path "*/.git/*" 2>/dev/null | head -40
+
+# Tracing/observability setup
+grep -r "langfuse\|langsmith\|arize\|phoenix\|braintrust\|promptfoo" \
+  --include="*.py" --include="*.ts" --include="*.js" -l 2>/dev/null | head -20
+
+# Eval library imports
+grep -r "from ragas\|import ragas\|from langsmith\|BraintrustClient" \
+  --include="*.py" --include="*.ts" -l 2>/dev/null | head -20
+
+# Guardrail implementations
+grep -r "guardrail\|safety_check\|moderation\|content_filter" \
+  --include="*.py" --include="*.ts" --include="*.js" -l 2>/dev/null | head -20
+
+# Eval config files and reference dataset
+find . \( -name "promptfoo.yaml" -o -name "eval.config.*" -o -name "*.jsonl" -o -name "evals*.json" \) \
+  -not -path "*/node_modules/*" 2>/dev/null | head -10
+```
+</step>
+
+<step name="score_dimensions">
+For each dimension from AI-SPEC (or from the standard dimensions in ai-evals.md if no AI-SPEC):
+
+| Status | Criteria |
+|--------|----------|
+| **COVERED** | Implementation exists, targets the rubric behavior, runs (automated or documented manual) |
+| **PARTIAL** | Exists but incomplete — missing rubric specificity, not automated, or has known gaps |
+| **MISSING** | No implementation found for this dimension |
+
+For PARTIAL and MISSING: record what was planned, what was found, and specific remediation to reach COVERED.
+</step>
+
+<step name="audit_infrastructure">
+Score 5 components (ok / partial / missing):
+- **Eval tooling**: installed and actually called (not just listed as a dependency)
+- **Reference dataset**: file exists and meets size/composition spec
+- **CI/CD integration**: eval command present in Makefile, GitHub Actions, etc.
+- **Online guardrails**: each planned guardrail implemented in the request path (not stubbed)
+- **Tracing**: tool configured and wrapping actual AI calls
+</step>
+
+<step name="calculate_scores">
+```
+coverage_score  = covered_count / total_dimensions × 100
+infra_score     = (tooling + dataset + cicd + guardrails + tracing) / 5 × 100
+overall_score   = (coverage_score × 0.6) + (infra_score × 0.4)
+```
+
+Verdict:
+- 80-100: **PRODUCTION READY** — deploy with monitoring
+- 60-79: **NEEDS WORK** — address CRITICAL gaps before production
+- 40-59: **SIGNIFICANT GAPS** — do not deploy
+- 0-39: **NOT IMPLEMENTED** — review AI-SPEC.md and implement
+</step>
+
+<step name="write_eval_review">
+**ALWAYS use the Write tool to create files** — never use `Bash(cat << 'EOF')` or heredoc commands for file creation.
+
+Write to `{{outputPath}}`:
+
+```markdown
+# EVAL-REVIEW — {{sliceId}}
+
+**Audit Date:** {date}
+**AI-SPEC Present:** Yes / No
+**Overall Score:** {score}/100
+**Verdict:** {PRODUCTION READY | NEEDS WORK | SIGNIFICANT GAPS | NOT IMPLEMENTED}
+
+## Dimension Coverage
+
+| Dimension | Status | Measurement | Finding |
+|-----------|--------|-------------|---------|
+| {dim} | COVERED/PARTIAL/MISSING | Code/LLM Judge/Human | {finding} |
+
+**Coverage Score:** {n}/{total} ({pct}%)
+
+## Infrastructure Audit
+
+| Component | Status | Finding |
+|-----------|--------|---------|
+| Eval tooling ({tool}) | Installed / Configured / Not found | |
+| Reference dataset | Present / Partial / Missing | |
+| CI/CD integration | Present / Missing | |
+| Online guardrails | Implemented / Partial / Missing | |
+| Tracing ({tool}) | Configured / Not configured | |
+
+**Infrastructure Score:** {score}/100
+
+## Critical Gaps
+
+{MISSING items with Critical severity only}
+
+## Gap Analysis
+
+{All PARTIAL and MISSING items — one bullet per item for use by /gsd eval-fix}
+
+## Remediation Plan
+
+### Must fix before production:
+{Ordered CRITICAL gaps with specific steps}
+
+### Should fix soon:
+{PARTIAL items with steps}
+
+### Nice to have:
+{Lower-priority MISSING items}
+
+## Files Found
+
+{Eval-related files discovered during scan}
+```
+</step>
+
+<step name="display_summary">
+After writing the file, output this summary directly in the conversation:
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ EVAL REVIEW — {{sliceId}}
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Score:    {overall_score}/100
+Verdict:  {verdict}
+
+Coverage: {covered}/{total} dimensions ({pct}%)
+Infra:    {infra_score}/100
+
+Critical Gaps: {count}
+
+Output: {{outputPath}}
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+If there are critical gaps, add:
+  → Run `/gsd eval-fix` to address the gaps.
+</step>
+
+</execution_flow>
+
+<success_criteria>
+- [ ] AI evaluation reference read (ai-evals.md)
+- [ ] AI-SPEC content read (or noted as absent)
+- [ ] SUMMARY content read
+- [ ] Codebase scanned (5 scan categories)
+- [ ] Every planned dimension scored (COVERED/PARTIAL/MISSING)
+- [ ] Infrastructure audit completed (5 components)
+- [ ] Coverage, infrastructure, and overall scores calculated
+- [ ] Verdict determined
+- [ ] EVAL-REVIEW.md written to {{outputPath}} with all sections populated
+- [ ] Gap Analysis section uses bullet list format (for /gsd eval-fix parsing)
+- [ ] Critical gaps identified and remediation is specific and actionable
+- [ ] Summary displayed in conversation
+</success_criteria>

--- a/src/resources/extensions/gsd/templates/ai-evals.md
+++ b/src/resources/extensions/gsd/templates/ai-evals.md
@@ -1,0 +1,156 @@
+# AI Evaluation Reference
+
+> Reference used by `gsd-eval-planner` and `gsd-eval-auditor`.
+> Based on "AI Evals for Everyone" course (Reganti & Badam) + industry practice.
+
+---
+
+## Core Concepts
+
+### Why Evals Exist
+AI systems are non-deterministic. Input X does not reliably produce output Y across runs, users, or edge cases. Evals are the continuous process of assessing whether your system's behavior meets expectations under real-world conditions — unit tests and integration tests alone are insufficient.
+
+### Model vs. Product Evaluation
+- **Model evals** (MMLU, HumanEval, GSM8K) — measure general capability in standardized conditions. Use as initial filter only.
+- **Product evals** — measure behavior inside your specific system, with your data, your users, your domain rules. This is where 80% of eval effort belongs.
+
+### The Three Components of Every Eval
+- **Input** — everything affecting the system: query, history, retrieved docs, system prompt, config
+- **Expected** — what good behavior looks like, defined through rubrics
+- **Actual** — what the system produced, including intermediate steps, tool calls, and reasoning traces
+
+### Three Measurement Approaches
+1. **Code-based metrics** — deterministic checks: JSON validation, required disclaimers, performance thresholds, classification flags. Fast, cheap, reliable. Use first.
+2. **LLM judges** — one model evaluates another against a rubric. Powerful for subjective qualities (tone, reasoning, escalation). Requires calibration against human judgment before trusting.
+3. **Human evaluation** — gold standard for nuanced judgment. Doesn't scale. Use for calibration, edge cases, periodic sampling, and high-stakes decisions.
+
+Most effective systems combine all three.
+
+---
+
+## Evaluation Dimensions
+
+### Pre-Deployment (Development Phase)
+
+| Dimension | What It Measures | When It Matters |
+|-----------|-----------------|-----------------|
+| **Factual accuracy** | Correctness of claims against ground truth | RAG, knowledge bases, any factual assertions |
+| **Context faithfulness** | Response grounded in provided context vs. fabricated | RAG pipelines, document Q&A, retrieval-augmented systems |
+| **Hallucination detection** | Plausible but unsupported claims | All generative systems, high-stakes domains |
+| **Escalation accuracy** | Correct identification of when human intervention needed | Customer service, healthcare, financial advisory |
+| **Policy compliance** | Adherence to business rules, legal requirements, disclaimers | Regulated industries, enterprise deployments |
+| **Tone/style appropriateness** | Match with brand voice, audience expectations, emotional context | Customer-facing systems, content generation |
+| **Output structure validity** | Schema compliance, required fields, format correctness | Structured extraction, API integrations, data pipelines |
+| **Task completion** | Whether the system accomplished the stated goal | Agentic workflows, multi-step tasks |
+| **Tool use correctness** | Correct selection and invocation of tools | Agent systems with tool calls |
+| **Safety** | Absence of harmful, biased, or inappropriate outputs | All user-facing systems |
+
+### Production Monitoring
+
+| Dimension | Monitoring Approach |
+|-----------|---------------------|
+| **Safety violations** | Online guardrail — real-time, immediate intervention |
+| **Compliance failures** | Online guardrail — block or escalate before user sees output |
+| **Quality degradation trends** | Offline flywheel — batch analysis of sampled interactions |
+| **Emerging failure modes** | Signal-metric divergence — when user behavior signals diverge from metric scores, investigate manually |
+| **Cost/latency drift** | Code-based metrics — automated threshold alerts |
+
+---
+
+## The Guardrail vs. Flywheel Decision
+
+Ask: "If this behavior goes wrong, would it be catastrophic for my business?"
+
+- **Yes → Guardrail** — run online, real-time, with immediate intervention (block, escalate, hand off). Be selective: guardrails add latency.
+- **No → Flywheel** — run offline as batch analysis feeding system refinements over time.
+
+---
+
+## Rubric Design
+
+Generic metrics are meaningless without context. "Helpfulness" in real estate means summarizing listings clearly. In healthcare it means knowing when *not* to answer.
+
+A rubric must define:
+1. The dimension being measured
+2. What scores 1, 3, and 5 on a 5-point scale (or pass/fail criteria)
+3. Domain-specific examples of acceptable vs. unacceptable behavior
+
+Without rubrics, LLM judges produce noise rather than signal.
+
+---
+
+## Reference Dataset Guidelines
+
+- Start with **10-20 high-quality examples** — not 200 mediocre ones
+- Cover: critical success scenarios, common user workflows, known edge cases, historical failure modes
+- Have domain experts label the examples (not just engineers)
+- Expand based on what you learn in production — don't build for hypothetical coverage
+
+---
+
+## Eval Tooling Guide
+
+| Tool | Type | Best For | Key Strength |
+|------|------|----------|-------------|
+| **RAGAS** | Python library | RAG evaluation | Purpose-built metrics: faithfulness, answer relevance, context precision/recall |
+| **Langfuse** | Platform (open-source, self-hostable) | All system types | Strong tracing, prompt management, good for teams wanting infrastructure control |
+| **LangSmith** | Platform (commercial) | LangChain/LangGraph ecosystems | Tightest integration with LangChain; best if already in that ecosystem |
+| **Arize Phoenix** | Platform (open-source + hosted) | RAG + multi-agent tracing | Strong RAG eval + trace visualization; open-source with hosted option |
+| **Braintrust** | Platform (commercial) | Model-agnostic evaluation | Dataset and experiment management; good for comparing across frameworks |
+| **Promptfoo** | CLI tool (open-source) | Prompt testing, CI/CD | CLI-first, excellent for CI/CD prompt regression testing |
+
+### Tool Selection by System Type
+
+| System Type | Recommended Tooling |
+|-------------|---------------------|
+| RAG / Knowledge Q&A | RAGAS + Arize Phoenix or Braintrust |
+| Multi-agent systems | Langfuse + Arize Phoenix |
+| Conversational / single-model | Promptfoo + Braintrust |
+| Structured extraction | Promptfoo + code-based validators |
+| LangChain/LangGraph projects | LangSmith (native integration) |
+| Production monitoring (all types) | Langfuse, Arize Phoenix, or LangSmith |
+
+---
+
+## Evals in the Development Lifecycle
+
+### Plan Phase (Evaluation-Aware Design)
+Before writing code, define:
+1. What type of AI system is being built → determines framework and dominant eval concerns
+2. Critical failure modes (3-5 behaviors that cannot go wrong)
+3. Rubrics — explicit definitions of acceptable/unacceptable behavior per dimension
+4. Evaluation strategy — which dimensions use code metrics, LLM judges, or human review
+5. Reference dataset requirements — size, composition, labeling approach
+6. Eval tooling selection
+
+Output: EVALS-SPEC section of AI-SPEC.md
+
+### Execute Phase (Instrument While Building)
+- Add tracing from day one (Langfuse, Arize Phoenix, or LangSmith)
+- Build reference dataset concurrently with implementation
+- Implement code-based checks first; add LLM judges only for subjective dimensions
+- Run evals in CI/CD via Promptfoo or Braintrust
+
+### Verify Phase (Pre-Deployment Validation)
+- Run full reference dataset against all metrics
+- Conduct human review of edge cases and LLM judge disagreements
+- Calibrate LLM judges against human scores (target ≥ 0.7 correlation before trusting)
+- Define and configure production guardrails
+- Establish monitoring baseline
+
+### Monitor Phase (Production Evaluation Loop)
+- Smart sampling — weight toward interactions with concerning signals (retries, unusual length, explicit escalations)
+- Online guardrails on every interaction
+- Offline flywheel on sampled batch
+- Watch for signal-metric divergence — the early warning system for evaluation gaps
+
+---
+
+## Common Pitfalls
+
+1. **Assuming benchmarks predict product success** — they don't; model evals are a filter, not a verdict
+2. **Engineering evals in isolation** — domain experts must co-define rubrics; engineers alone miss critical nuances
+3. **Building comprehensive coverage on day one** — start small (10-20 examples), expand from real failure modes
+4. **Trusting uncalibrated LLM judges** — validate against human judgment before relying on them
+5. **Measuring everything** — only track metrics that drive decisions; "collect it all" produces noise
+6. **Treating evaluation as one-time setup** — user behavior evolves, requirements change, failure modes emerge; evaluation is continuous

--- a/src/resources/extensions/gsd/tests/commands-eval-fix.test.ts
+++ b/src/resources/extensions/gsd/tests/commands-eval-fix.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Tests for /gsd eval-fix pure functions
+ *
+ * Tests: parseEvalFixArgs, findEvalReviewFile, parseGapsFromEvalReview,
+ *        buildEvalFixOutputPath
+ */
+
+import { describe, test, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomBytes } from "node:crypto";
+
+import {
+  parseEvalFixArgs,
+  findEvalReviewFile,
+  parseGapsFromEvalReview,
+  buildEvalFixOutputPath,
+  handleEvalFix,
+} from "../commands-eval-fix.js";
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function createTmpDir(): string {
+  return mkdtempSync(join(tmpdir(), `gsd-eval-fix-test-${randomBytes(4).toString("hex")}-`));
+}
+
+function createSliceDir(basePath: string, milestoneId: string, sliceId: string): string {
+  const sliceDir = join(basePath, ".gsd", "milestones", milestoneId, "slices", sliceId);
+  mkdirSync(sliceDir, { recursive: true });
+  return sliceDir;
+}
+
+// ── parseEvalFixArgs ──────────────────────────────────────────────────────────
+
+describe("parseEvalFixArgs", () => {
+  test("empty string → sliceId null", () => {
+    const result = parseEvalFixArgs("");
+    assert.equal(result.sliceId, null);
+  });
+
+  test("bare slice ID → sliceId set", () => {
+    const result = parseEvalFixArgs("S01");
+    assert.equal(result.sliceId, "S01");
+  });
+
+  test("slice ID with surrounding whitespace → trimmed", () => {
+    const result = parseEvalFixArgs("  S02  ");
+    assert.equal(result.sliceId, "S02");
+  });
+});
+
+// ── findEvalReviewFile ────────────────────────────────────────────────────────
+
+describe("findEvalReviewFile", () => {
+  let tmpBase: string;
+
+  beforeEach(() => {
+    tmpBase = createTmpDir();
+  });
+
+  afterEach(() => {
+    rmSync(tmpBase, { recursive: true, force: true });
+  });
+
+  test("file exists → returns the path", () => {
+    const sliceDir = createSliceDir(tmpBase, "M001", "S01");
+    const reviewPath = join(sliceDir, "S01-EVAL-REVIEW.md");
+    writeFileSync(reviewPath, "# Eval Review", "utf-8");
+    const result = findEvalReviewFile(tmpBase, "M001", "S01");
+    assert.equal(result, reviewPath);
+  });
+
+  test("file does not exist → returns null", () => {
+    createSliceDir(tmpBase, "M001", "S01");
+    const result = findEvalReviewFile(tmpBase, "M001", "S01");
+    assert.equal(result, null);
+  });
+
+  test("directory does not exist → returns null", () => {
+    const result = findEvalReviewFile(tmpBase, "M999", "S99");
+    assert.equal(result, null);
+  });
+});
+
+// ── parseGapsFromEvalReview ───────────────────────────────────────────────────
+
+describe("parseGapsFromEvalReview", () => {
+  test("empty string → empty array", () => {
+    const result = parseGapsFromEvalReview("");
+    assert.deepEqual(result, []);
+  });
+
+  test("markdown without Gap Analysis section → empty array", () => {
+    const md = "# Eval Review\n\n## Recommendations\n\n- Fix things.";
+    const result = parseGapsFromEvalReview(md);
+    assert.deepEqual(result, []);
+  });
+
+  test("markdown with Gap Analysis section and bullet points → array of gap strings", () => {
+    const md = `# Eval Review — S01\n\n## Gap Analysis\n\n- Missing unit tests for auth module\n- No error handling in API client\n\n## Recommendations\n\nFix it.`;
+    const gaps = parseGapsFromEvalReview(md);
+    assert.equal(gaps.length, 2);
+    assert.ok(gaps[0].includes("Missing unit tests"));
+    assert.ok(gaps[1].includes("No error handling"));
+  });
+
+  test("supports asterisk bullet syntax", () => {
+    const md = `## Gap Analysis\n\n* Missing tests\n* No docs\n\n## Next`;
+    const gaps = parseGapsFromEvalReview(md);
+    assert.equal(gaps.length, 2);
+    assert.ok(gaps[0].includes("Missing tests"));
+  });
+
+  test("Gap Analysis at end of file with no trailing section → still parses", () => {
+    const md = `## Gap Analysis\n\n- Only gap here`;
+    const gaps = parseGapsFromEvalReview(md);
+    assert.equal(gaps.length, 1);
+    assert.ok(gaps[0].includes("Only gap here"));
+  });
+});
+
+// ── buildEvalFixOutputPath ────────────────────────────────────────────────────
+
+describe("buildEvalFixOutputPath", () => {
+  test("returns join(sliceDir, sliceId-EVAL-FIX.md)", () => {
+    const result = buildEvalFixOutputPath("/some/path/S01", "S01");
+    assert.equal(result, "/some/path/S01/S01-EVAL-FIX.md");
+  });
+
+  test("works with different slice IDs", () => {
+    const result = buildEvalFixOutputPath("/base/milestones/M001/slices/S03", "S03");
+    assert.equal(result, "/base/milestones/M001/slices/S03/S03-EVAL-FIX.md");
+  });
+});
+
+// ── handleEvalFix — guard paths ───────────────────────────────────────────────
+
+describe("handleEvalFix — guard paths", () => {
+  test("no active milestone → warning notification", async () => {
+    const tmp = mkdtempSync(join(tmpdir(), `gsd-eval-fix-handler-test-${randomBytes(4).toString("hex")}-`));
+    const origCwd = process.cwd();
+    try {
+      // Empty directory → deriveState finds no milestone
+      process.chdir(tmp);
+      const notifications: Array<{ msg: string; level: string }> = [];
+      const ctx = {
+        notifications,
+        ui: {
+          notify(msg: string, level: string) { notifications.push({ msg, level }); },
+          setStatus() {},
+          setWidget() {},
+          setFooter() {},
+        },
+      };
+      const mockPi = { sendMessage: () => {} } as any;
+      await handleEvalFix("", ctx as any, mockPi);
+      assert.ok(notifications.some(n => n.level === "warning"));
+    } finally {
+      process.chdir(origCwd);
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/resources/extensions/gsd/tests/commands-eval-review.test.ts
+++ b/src/resources/extensions/gsd/tests/commands-eval-review.test.ts
@@ -12,11 +12,27 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { randomBytes } from "node:crypto";
 
+// ── Mock ctx helper ───────────────────────────────────────────────────────────
+
+function createMockCtx() {
+  const notifications: Array<{ msg: string; level: string }> = [];
+  return {
+    notifications,
+    ui: {
+      notify(msg: string, level: string) { notifications.push({ msg, level }); },
+      setStatus() {},
+      setWidget() {},
+      setFooter() {},
+    },
+  };
+}
+
 import {
   parseEvalReviewArgs,
   detectEvalReviewState,
   buildEvalReviewOutputPath,
   buildEvalReviewContext,
+  handleEvalReview,
   type EvalReviewState,
 } from "../commands-eval-review.ts";
 
@@ -65,6 +81,25 @@ describe("parseEvalReviewArgs", () => {
   test("--force only → sliceId null, force true", () => {
     const result = parseEvalReviewArgs("--force");
     assert.equal(result.sliceId, null);
+    assert.equal(result.force, true);
+  });
+
+  test("--show only → sliceId null, show true", () => {
+    const result = parseEvalReviewArgs("--show");
+    assert.equal(result.sliceId, null);
+    assert.equal(result.show, true);
+  });
+
+  test("--show with slice ID → sliceId set, show true", () => {
+    const result = parseEvalReviewArgs("--show S01");
+    assert.equal(result.sliceId, "S01");
+    assert.equal(result.show, true);
+  });
+
+  test("--show --force with slice ID → sliceId set, show true, force true", () => {
+    const result = parseEvalReviewArgs("--show --force S02");
+    assert.equal(result.sliceId, "S02");
+    assert.equal(result.show, true);
     assert.equal(result.force, true);
   });
 });
@@ -126,9 +161,8 @@ describe("detectEvalReviewState", () => {
 
   test("sliceDir is null when milestone does not exist", () => {
     const result = detectEvalReviewState(tmpBase, "M999", "S99");
-    // sliceDir may or may not be set depending on implementation,
-    // but state must be no-summary
     assert.equal(result.state, "no-summary");
+    assert.equal(result.sliceDir, null);
   });
 });
 
@@ -177,6 +211,18 @@ describe("buildEvalReviewContext", () => {
     assert.equal(ctx.summary, summaryContent);
   });
 
+  test("state no-summary: spec is null, summary is fallback string", () => {
+    const state: EvalReviewState = {
+      state: "no-summary",
+      summaryPath: null,
+      specPath: null,
+      sliceDir: null,
+    };
+    const result = buildEvalReviewContext(state);
+    assert.equal(result.spec, null);
+    assert.equal(result.summary, "(no summary available)");
+  });
+
   test("state full: spec contains AI-SPEC content, summary contains SUMMARY content", () => {
     const sliceDir = createSliceDir(tmpBase, "M001", "S01");
     const summaryContent = "# Summary\n\nSummary here.";
@@ -196,5 +242,47 @@ describe("buildEvalReviewContext", () => {
     const ctx = buildEvalReviewContext(state);
     assert.equal(ctx.spec, specContent);
     assert.equal(ctx.summary, summaryContent);
+  });
+});
+
+// ── handleEvalReview — guard paths ────────────────────────────────────────────
+
+describe("handleEvalReview — guard paths", () => {
+  test("no active milestone → warning notification", async () => {
+    const tmp = mkdtempSync(join(tmpdir(), `gsd-handler-test-${randomBytes(4).toString("hex")}-`));
+    const origCwd = process.cwd();
+    try {
+      // Empty directory → deriveState finds no milestone
+      process.chdir(tmp);
+      const ctx = createMockCtx();
+      const mockPi = { sendMessage: () => {} } as any;
+      await handleEvalReview("", ctx as any, mockPi);
+      assert.ok(ctx.notifications.some(n => n.level === "warning"));
+    } finally {
+      process.chdir(origCwd);
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test("--show with no existing EVAL-REVIEW file notifies warning", async () => {
+    const tmp = mkdtempSync(join(tmpdir(), `gsd-handler-test-${randomBytes(4).toString("hex")}-`));
+    const origCwd = process.cwd();
+    try {
+      // Create minimal GSD structure: milestone + slice with SUMMARY so deriveState can find it
+      const sliceDir = join(tmp, ".gsd", "milestones", "M001", "slices", "S01");
+      mkdirSync(sliceDir, { recursive: true });
+      writeFileSync(join(sliceDir, "S01-SUMMARY.md"), "# Summary\n\nContent.", "utf-8");
+      // Write milestone registry so deriveState recognises M001 as active
+      const milestoneDir = join(tmp, ".gsd", "milestones", "M001");
+      writeFileSync(join(milestoneDir, "ROADMAP.md"), "# M001 Roadmap", "utf-8");
+      process.chdir(tmp);
+      const ctx = createMockCtx();
+      const mockPi = { sendMessage: () => {} } as any;
+      await handleEvalReview("--show S01", ctx as any, mockPi);
+      assert.ok(ctx.notifications.some(n => n.level === "warning" && n.msg.includes("No EVAL-REVIEW")));
+    } finally {
+      process.chdir(origCwd);
+      rmSync(tmp, { recursive: true, force: true });
+    }
   });
 });

--- a/src/resources/extensions/gsd/tests/commands-eval-review.test.ts
+++ b/src/resources/extensions/gsd/tests/commands-eval-review.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Tests for /gsd eval-review pure functions
+ *
+ * Tests: parseEvalReviewArgs, detectEvalReviewState,
+ *        buildEvalReviewOutputPath, buildEvalReviewContext
+ */
+
+import { describe, test, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomBytes } from "node:crypto";
+
+import {
+  parseEvalReviewArgs,
+  detectEvalReviewState,
+  buildEvalReviewOutputPath,
+  buildEvalReviewContext,
+  type EvalReviewState,
+} from "../commands-eval-review.ts";
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function createTmpDir(): string {
+  return mkdtempSync(join(tmpdir(), `gsd-eval-review-test-${randomBytes(4).toString("hex")}-`));
+}
+
+// Creates the .gsd/milestones/M001/slices/S01 structure under basePath
+function createSliceDir(basePath: string, milestoneId: string, sliceId: string): string {
+  const sliceDir = join(basePath, ".gsd", "milestones", milestoneId, "slices", sliceId);
+  mkdirSync(sliceDir, { recursive: true });
+  return sliceDir;
+}
+
+// ── parseEvalReviewArgs ───────────────────────────────────────────────────────
+
+describe("parseEvalReviewArgs", () => {
+  test("empty string → sliceId null", () => {
+    const result = parseEvalReviewArgs("");
+    assert.equal(result.sliceId, null);
+  });
+
+  test("whitespace-only → sliceId null", () => {
+    const result = parseEvalReviewArgs("   ");
+    assert.equal(result.sliceId, null);
+  });
+
+  test("bare slice ID → sliceId set", () => {
+    const result = parseEvalReviewArgs("S01");
+    assert.equal(result.sliceId, "S01");
+  });
+
+  test("slice ID with surrounding whitespace → trimmed", () => {
+    const result = parseEvalReviewArgs("  S02  ");
+    assert.equal(result.sliceId, "S02");
+  });
+
+  test("--force before slice ID → sliceId set and force true", () => {
+    const result = parseEvalReviewArgs("--force S03");
+    assert.equal(result.sliceId, "S03");
+    assert.equal(result.force, true);
+  });
+
+  test("--force only → sliceId null, force true", () => {
+    const result = parseEvalReviewArgs("--force");
+    assert.equal(result.sliceId, null);
+    assert.equal(result.force, true);
+  });
+});
+
+// ── detectEvalReviewState ─────────────────────────────────────────────────────
+
+describe("detectEvalReviewState", () => {
+  let tmpBase: string;
+
+  beforeEach(() => {
+    tmpBase = createTmpDir();
+  });
+
+  afterEach(() => {
+    rmSync(tmpBase, { recursive: true, force: true });
+  });
+
+  test("no SUMMARY.md → state no-summary, both paths null", () => {
+    createSliceDir(tmpBase, "M001", "S01");
+    const result = detectEvalReviewState(tmpBase, "M001", "S01");
+    assert.equal(result.state, "no-summary");
+    assert.equal(result.summaryPath, null);
+    assert.equal(result.specPath, null);
+  });
+
+  test("SUMMARY.md only → state no-spec, summaryPath set, specPath null", () => {
+    const sliceDir = createSliceDir(tmpBase, "M001", "S01");
+    writeFileSync(join(sliceDir, "S01-SUMMARY.md"), "# Summary\n\nContent here.", "utf-8");
+    const result = detectEvalReviewState(tmpBase, "M001", "S01");
+    assert.equal(result.state, "no-spec");
+    assert.ok(result.summaryPath !== null);
+    assert.equal(result.specPath, null);
+  });
+
+  test("SUMMARY.md + AI-SPEC.md → state full, both paths set", () => {
+    const sliceDir = createSliceDir(tmpBase, "M001", "S01");
+    writeFileSync(join(sliceDir, "S01-SUMMARY.md"), "# Summary\n\nContent here.", "utf-8");
+    writeFileSync(join(sliceDir, "AI-SPEC.md"), "# AI Spec\n\nSpec content here.", "utf-8");
+    const result = detectEvalReviewState(tmpBase, "M001", "S01");
+    assert.equal(result.state, "full");
+    assert.ok(result.summaryPath !== null);
+    assert.ok(result.specPath !== null);
+  });
+
+  test("sliceDir in result contains the slice ID", () => {
+    const sliceDir = createSliceDir(tmpBase, "M001", "S01");
+    writeFileSync(join(sliceDir, "S01-SUMMARY.md"), "content", "utf-8");
+    const result = detectEvalReviewState(tmpBase, "M001", "S01");
+    assert.ok(result.sliceDir !== null);
+    assert.ok(result.sliceDir!.includes("S01"));
+  });
+
+  test("non-existent milestone dir → state no-summary", () => {
+    const result = detectEvalReviewState(tmpBase, "M999", "S99");
+    assert.equal(result.state, "no-summary");
+    assert.equal(result.summaryPath, null);
+    assert.equal(result.specPath, null);
+  });
+
+  test("sliceDir is null when milestone does not exist", () => {
+    const result = detectEvalReviewState(tmpBase, "M999", "S99");
+    // sliceDir may or may not be set depending on implementation,
+    // but state must be no-summary
+    assert.equal(result.state, "no-summary");
+  });
+});
+
+// ── buildEvalReviewOutputPath ─────────────────────────────────────────────────
+
+describe("buildEvalReviewOutputPath", () => {
+  test("returns join(sliceDir, sliceId-EVAL-REVIEW.md)", () => {
+    const result = buildEvalReviewOutputPath("/some/path/S01", "S01");
+    assert.equal(result, "/some/path/S01/S01-EVAL-REVIEW.md");
+  });
+
+  test("works with different slice IDs", () => {
+    const result = buildEvalReviewOutputPath("/base/milestones/M001/slices/S03", "S03");
+    assert.equal(result, "/base/milestones/M001/slices/S03/S03-EVAL-REVIEW.md");
+  });
+});
+
+// ── buildEvalReviewContext ────────────────────────────────────────────────────
+
+describe("buildEvalReviewContext", () => {
+  let tmpBase: string;
+
+  beforeEach(() => {
+    tmpBase = createTmpDir();
+  });
+
+  afterEach(() => {
+    rmSync(tmpBase, { recursive: true, force: true });
+  });
+
+  test("state no-spec: spec is null, summary contains file content", () => {
+    const sliceDir = createSliceDir(tmpBase, "M001", "S01");
+    const summaryContent = "# Summary\n\nThis is the summary content.";
+    const summaryPath = join(sliceDir, "S01-SUMMARY.md");
+    writeFileSync(summaryPath, summaryContent, "utf-8");
+
+    const state: EvalReviewState = {
+      state: "no-spec",
+      summaryPath,
+      specPath: null,
+      sliceDir,
+    };
+
+    const ctx = buildEvalReviewContext(state);
+    assert.equal(ctx.spec, null);
+    assert.equal(ctx.summary, summaryContent);
+  });
+
+  test("state full: spec contains AI-SPEC content, summary contains SUMMARY content", () => {
+    const sliceDir = createSliceDir(tmpBase, "M001", "S01");
+    const summaryContent = "# Summary\n\nSummary here.";
+    const specContent = "# AI Spec\n\nSpec here.";
+    const summaryPath = join(sliceDir, "S01-SUMMARY.md");
+    const specPath = join(sliceDir, "AI-SPEC.md");
+    writeFileSync(summaryPath, summaryContent, "utf-8");
+    writeFileSync(specPath, specContent, "utf-8");
+
+    const state: EvalReviewState = {
+      state: "full",
+      summaryPath,
+      specPath,
+      sliceDir,
+    };
+
+    const ctx = buildEvalReviewContext(state);
+    assert.equal(ctx.spec, specContent);
+    assert.equal(ctx.summary, summaryContent);
+  });
+});


### PR DESCRIPTION
## TL;DR

**What:** Adds two new commands — `/gsd eval-review` and `/gsd eval-fix` — for retroactive AI evaluation auditing.
**Why:** gsd-2 has no way to verify that an AI phase's evaluation strategy was actually implemented after execution.
**How:** A handler reads AI-SPEC.md + SUMMARY.md, spawns an auditor agent that scans the codebase and produces a scored EVAL-REVIEW.md; a separate fix agent addresses identified gaps.

Closes #4246

## What

New commands:
- `/gsd eval-review [slice-id] [--force] [--show]` — scores each eval dimension COVERED/PARTIAL/MISSING, writes `{sliceId}-EVAL-REVIEW.md`
- `/gsd eval-fix [slice-id]` — reads Gap Analysis from EVAL-REVIEW.md, spawns a fix agent, writes `{sliceId}-EVAL-FIX.md`
- Non-blocking pre-ship warning in `handleShip` when EVAL-REVIEW is missing or verdict is NOT IMPLEMENTED

**New files:** `commands-eval-review.ts`, `commands-eval-fix.ts`, `prompts/eval-review.md`, `prompts/eval-fix.md`, `templates/ai-evals.md`, tests for both commands  
**Modified:** `commands/handlers/ops.ts`, `commands/handlers/core.ts`, `commands-ship.ts`

## Why

GSD v1 has `/gsd-eval-review` as part of its phase completion workflow. Without it, AI features can ship without proper observability, guardrails, or test coverage — the evaluation strategy exists only in planning docs but is never verified against the actual implementation.

## How

**Scoring:** Coverage Score (60% weight) + Infrastructure Score (40% weight) → 0–100  
**Verdicts:** PRODUCTION READY ≥80 · NEEDS WORK 60–79 · SIGNIFICANT GAPS 40–59 · NOT IMPLEMENTED <40

**Three states:**
- State A: AI-SPEC.md + SUMMARY.md → full audit against spec
- State B: SUMMARY.md only → audit against best practices (ai-evals.md reference)
- State C: no SUMMARY.md → error, run `/gsd execute-phase` first

Agent prompts adapted from v1's `gsd-eval-auditor.md` and `gsd-code-fixer.md` patterns. `ai-evals.md` scoring reference ported from v1.

Tests follow node:test + TDD pattern (tests written first). 38 new tests total.