### PR TITLE
fix(gsd): add per-category search hints to extract-learnings prompt

### DIFF
--- a/src/resources/extensions/gsd/commands-extract-learnings.ts
+++ b/src/resources/extensions/gsd/commands-extract-learnings.ts
@@ -114,14 +114,38 @@ Write a LEARNINGS document to \`${ctx.outputPath}\` with the following 4 section
 ### Decisions
 Key architectural and design decisions made during this milestone, including the rationale and alternatives considered.
 
+Look for:
+- Explicit decisions documented in PLAN.md or SUMMARY.md
+- Technology choices and their rationale
+- Trade-offs that were evaluated and why one option was chosen
+- Design decisions referenced in implementation notes
+
 ### Lessons
 What the team learned — technical discoveries, process insights, and knowledge gaps that were filled.
+
+Look for:
+- Unexpected complexity called out in SUMMARY.md
+- Issues discovered during verification (VERIFICATION.md)
+- Failed approaches and what replaced them
+- UAT feedback that revealed gaps in the original plan
 
 ### Patterns
 Reusable patterns, approaches, or solutions that emerged and should be applied in future work.
 
+Look for:
+- Successful implementation approaches described in SUMMARY.md
+- Testing patterns from VERIFICATION.md or UAT.md
+- Workflow or process patterns that saved time
+- Code or architecture patterns worth repeating
+
 ### Surprises
 Unexpected challenges, discoveries, or outcomes — things that deviated from assumptions.
+
+Look for:
+- Tasks that took significantly longer or shorter than expected
+- Unexpected dependencies or interactions between components
+- Edge cases not anticipated in planning
+- External factors (API changes, environment issues) that required adaptation
 
 ### Source Attribution (REQUIRED)
 

--- a/src/resources/extensions/gsd/commands/catalog.ts
+++ b/src/resources/extensions/gsd/commands/catalog.ts
@@ -15,7 +15,7 @@ export interface GsdCommandDefinition {
 type CompletionMap = Record<string, readonly GsdCommandDefinition[]>;
 
 export const GSD_COMMAND_DESCRIPTION =
-  "GSD — Get Shit Done: /gsd help|start|templates|next|auto|stop|pause|status|widget|visualize|queue|quick|discuss|capture|triage|dispatch|history|undo|undo-task|reset-slice|rate|skip|export|cleanup|model|mode|prefs|config|keys|hooks|run-hook|skill-health|doctor|logs|forensics|changelog|migrate|remote|steer|knowledge|new-milestone|parallel|cmux|park|unpark|init|setup|inspect|extensions|update|fast|mcp|rethink|codebase|notifications|ship|do|session-report|backlog|pr-branch|add-tests";
+  "GSD — Get Shit Done: /gsd help|start|templates|next|auto|stop|pause|status|widget|visualize|queue|quick|discuss|capture|triage|dispatch|history|undo|undo-task|reset-slice|rate|skip|export|cleanup|model|mode|prefs|config|keys|hooks|run-hook|skill-health|doctor|logs|forensics|changelog|migrate|remote|steer|knowledge|new-milestone|parallel|cmux|park|unpark|init|setup|inspect|extensions|update|fast|mcp|rethink|codebase|notifications|ship|do|session-report|backlog|pr-branch|add-tests|extract-learnings";
 
 export const TOP_LEVEL_SUBCOMMANDS: readonly GsdCommandDefinition[] = [
   { cmd: "help", desc: "Categorized command reference with descriptions" },
@@ -80,6 +80,7 @@ export const TOP_LEVEL_SUBCOMMANDS: readonly GsdCommandDefinition[] = [
   { cmd: "backlog", desc: "Manage backlog items (add, promote, remove, list)" },
   { cmd: "pr-branch", desc: "Create clean PR branch filtering .gsd/ commits" },
   { cmd: "add-tests", desc: "Generate tests for completed slices" },
+  { cmd: "extract-learnings", desc: "Extract structured learnings from milestone artifacts into a LEARNINGS document" },
 ];
 
 const NESTED_COMPLETIONS: CompletionMap = {

--- a/src/resources/extensions/gsd/tests/commands-extract-learnings.test.ts
+++ b/src/resources/extensions/gsd/tests/commands-extract-learnings.test.ts
@@ -12,6 +12,7 @@ import {
   buildExtractLearningsPrompt,
   buildFrontmatter,
   extractProjectName,
+  type ExtractLearningsPromptContext,
 } from "../commands-extract-learnings.js";
 
 // ─── parseExtractLearningsArgs ────────────────────────────────────────────────
@@ -336,5 +337,77 @@ describe("extractProjectName", () => {
 
     const result = extractProjectName(tmpBase);
     assert.equal(result, tmpBase.split("/").at(-1));
+  });
+});
+
+// ─── buildExtractLearningsPrompt — Look for hints ────────────────────────────
+
+describe("buildExtractLearningsPrompt — Look for hints", () => {
+  function makeCtx(overrides: Partial<ExtractLearningsPromptContext> = {}): ExtractLearningsPromptContext {
+    return {
+      milestoneId: "M001",
+      milestoneName: "Auth System",
+      outputPath: "/project/.gsd/milestones/M001/M001-LEARNINGS.md",
+      relativeOutputPath: ".gsd/milestones/M001/M001-LEARNINGS.md",
+      planContent: "# M001 Plan\n\nDecided to use JWT.",
+      summaryContent: "# M001 Summary\n\nCompleted auth flow.",
+      verificationContent: null,
+      uatContent: null,
+      missingArtifacts: [],
+      projectName: "my-project",
+      ...overrides,
+    };
+  }
+
+  it("prompt includes Look for: block for Decisions", () => {
+    const prompt = buildExtractLearningsPrompt(makeCtx());
+    assert.ok(
+      prompt.includes("Look for:"),
+      "Expected at least one 'Look for:' block in prompt",
+    );
+  });
+
+  it("prompt has Look for: block in each of the 4 categories", () => {
+    const prompt = buildExtractLearningsPrompt(makeCtx());
+    const count = (prompt.match(/^Look for:/gm) ?? []).length;
+    assert.equal(count, 4, `Expected 4 'Look for:' blocks, got ${count}`);
+  });
+
+  it("Decisions Look for: block references PLAN.md", () => {
+    const prompt = buildExtractLearningsPrompt(makeCtx());
+    const decisionsSection = prompt.slice(
+      prompt.indexOf("### Decisions"),
+      prompt.indexOf("### Lessons"),
+    );
+    assert.ok(
+      decisionsSection.includes("PLAN.md"),
+      "Decisions Look for: block should reference PLAN.md",
+    );
+  });
+
+  it("Lessons Look for: block references VERIFICATION.md", () => {
+    const prompt = buildExtractLearningsPrompt(makeCtx());
+    const lessonsSection = prompt.slice(
+      prompt.indexOf("### Lessons"),
+      prompt.indexOf("### Patterns"),
+    );
+    assert.ok(
+      lessonsSection.includes("VERIFICATION.md"),
+      "Lessons Look for: block should reference VERIFICATION.md",
+    );
+  });
+
+  it("Surprises Look for: block mentions unexpected or deviation", () => {
+    const prompt = buildExtractLearningsPrompt(makeCtx());
+    const surprisesSection = prompt.slice(
+      prompt.indexOf("### Surprises"),
+      prompt.indexOf("### Source Attribution"),
+    );
+    assert.ok(
+      surprisesSection.toLowerCase().includes("unexpected") ||
+        surprisesSection.toLowerCase().includes("longer") ||
+        surprisesSection.toLowerCase().includes("shorter"),
+      "Surprises Look for: block should mention unexpected durations or deviations",
+    );
   });
 });


### PR DESCRIPTION
## TL;DR

**What:** Adds \`Look for:\` guidance blocks to each of the 4 extraction categories in the \`/gsd extract-learnings\` prompt, and registers the command in the catalog for tab-completion.
**Why:** Without artifact-specific hints, the LLM may produce sparse output on milestones with thin \`SUMMARY.md\` files. The command was also missing from tab-completion.
**How:** Four \`Look for:\` lists added to \`buildExtractLearningsPrompt\`, each naming the specific artifact files and sections to scan. \`extract-learnings\` added to \`GSD_COMMAND_DESCRIPTION\` and \`TOP_LEVEL_SUBCOMMANDS\` in \`catalog.ts\`.

## What

- Modified \`buildExtractLearningsPrompt\` in \`commands-extract-learnings.ts\` to add a \`Look for:\` block under each category heading.
- Registered \`extract-learnings\` in \`commands/catalog.ts\` — added to \`GSD_COMMAND_DESCRIPTION\` (help string) and \`TOP_LEVEL_SUBCOMMANDS\` (tab-completion).
- Five regression tests added to \`commands-extract-learnings.test.ts\`.

## Why

Closes #4248

The prompt previously described *what* to extract but gave no guidance on *where* to look. This made output quality dependent on artifact verbosity — milestones with thin \`SUMMARY.md\` or no \`VERIFICATION.md\` often yielded fewer learnings than were actually present in \`PLAN.md\`.

Additionally, \`extract-learnings\` was not registered in the command catalog, so it was invisible to tab-completion and the GSD help string.

## How

Each \`Look for:\` block names 3–4 specific artifacts and the type of content expected in each. The blocks are integrated into the template literal in \`buildExtractLearningsPrompt\` and do not affect the function signature or test surface area beyond the prompt text.

The catalog fix adds one entry to \`TOP_LEVEL_SUBCOMMANDS\` and appends \`|extract-learnings\` to \`GSD_COMMAND_DESCRIPTION\`.

## Change type

- [x] \`fix\` — Bug fix

> AI-assisted PR. Code reviewed, tests verified locally, behavior understood and explainable.