### PR TITLE
fix(gsd): health-widget false positives + longcat Bearer auth

### DIFF
--- a/packages/pi-ai/src/env-api-keys.ts
+++ b/packages/pi-ai/src/env-api-keys.ts
@@ -141,6 +141,7 @@ export function getEnvApiKey(provider: any): string | undefined {
 		ollama: "OLLAMA_API_KEY",
 		"ollama-cloud": "OLLAMA_API_KEY",
 		"custom-openai": "CUSTOM_OPENAI_API_KEY",
+		longcat: "LONGCAT_API_KEY",
 	};
 
 	const envVar = envMap[provider];

--- a/packages/pi-ai/src/providers/anthropic-auth.test.ts
+++ b/packages/pi-ai/src/providers/anthropic-auth.test.ts
@@ -12,6 +12,7 @@ test("usesAnthropicBearerAuth covers Bearer-only Anthropic-compatible providers 
 	assert.equal(usesAnthropicBearerAuth("alibaba-coding-plan"), true);
 	assert.equal(usesAnthropicBearerAuth("minimax"), true);
 	assert.equal(usesAnthropicBearerAuth("minimax-cn"), true);
+	assert.equal(usesAnthropicBearerAuth("longcat"), true);
 	assert.equal(usesAnthropicBearerAuth("anthropic"), false);
 });
 

--- a/packages/pi-ai/src/providers/anthropic.ts
+++ b/packages/pi-ai/src/providers/anthropic.ts
@@ -45,7 +45,12 @@ function mergeHeaders(...headerSources: (Record<string, string> | undefined)[]):
 }
 
 export function usesAnthropicBearerAuth(provider: Model<"anthropic-messages">["provider"]): boolean {
-	return provider === "alibaba-coding-plan" || provider === "minimax" || provider === "minimax-cn";
+	return (
+		provider === "alibaba-coding-plan" ||
+		provider === "minimax" ||
+		provider === "minimax-cn" ||
+		provider === "longcat"
+	);
 }
 
 async function createClient(

--- a/packages/pi-ai/src/types.ts
+++ b/packages/pi-ai/src/types.ts
@@ -46,7 +46,8 @@ export type KnownProvider =
 	| "alibaba-coding-plan"
 	| "alibaba-dashscope"
 	| "ollama"
-	| "ollama-cloud";
+	| "ollama-cloud"
+	| "longcat";
 export type Provider = KnownProvider | string;
 
 export type ThinkingLevel = "minimal" | "low" | "medium" | "high" | "xhigh";

--- a/src/resources/extensions/gsd/doctor-providers.ts
+++ b/src/resources/extensions/gsd/doctor-providers.ts
@@ -83,7 +83,8 @@ function collectConfiguredModelProviders(): Set<string> {
     const loaded = loadEffectiveGSDPreferences();
     const models = loaded?.preferences?.models;
     if (!models) {
-      // Default: Anthropic
+      // Cold start: no models block in preferences.md, assume Anthropic as the
+      // default target so a fresh install still warns the user to set a key.
       providers.add("anthropic");
       return providers;
     }
@@ -109,11 +110,20 @@ function collectConfiguredModelProviders(): Set<string> {
       }
     }
   } catch {
-    // Preferences not readable — assume Anthropic as default
+    // preferences.md unreadable — assume Anthropic as default so something
+    // actionable still appears in the widget rather than silent failure.
     providers.add("anthropic");
+    return providers;
   }
 
-  if (providers.size === 0) providers.add("anthropic");
+  // If we iterated model entries but recognised none of their providers, the
+  // user is using custom providers declared only in models.json (e.g. minimax,
+  // kimi-coding, zai, xiaomi-token-plan-ams) that this static analyser cannot
+  // identify without a runtime ModelRegistry reference. Return the empty set —
+  // the caller treats this as "no LLM key checks to run" rather than
+  // fabricating an Anthropic dependency the user never asked for.
+  // The cold-start default above still fires when preferences.md has no models
+  // block at all, so new-user messaging is preserved.
   return providers;
 }
 

--- a/src/resources/extensions/gsd/tests/doctor-providers.test.ts
+++ b/src/resources/extensions/gsd/tests/doctor-providers.test.ts
@@ -485,6 +485,51 @@ test("runProviderChecks uses object provider field for anthropic-vertex models",
   rmSync(tmpHome, { recursive: true, force: true });
 });
 
+test("runProviderChecks does not fabricate anthropic requirement for custom-provider-only models", () => {
+  // Regression: previously, if every model entry used a custom provider prefix
+  // the static analyser didn't recognise (e.g. "kimi-coding/k2p5",
+  // "minimax/MiniMax-M2.7"), collectConfiguredModelProviders() returned an
+  // empty set and a post-iteration fallback added "anthropic" anyway. This
+  // produced a bogus "Anthropic key missing" error in the health widget for
+  // users who had never asked for Anthropic at all.
+  const tmpHome = realpathSync(mkdtempSync(join(tmpdir(), "gsd-providers-custom-home-")));
+  const repo = realpathSync(mkdtempSync(join(tmpdir(), "gsd-providers-custom-repo-")));
+  mkdirSync(join(repo, ".gsd"), { recursive: true });
+  writeFileSync(
+    join(repo, ".gsd", "PREFERENCES.md"),
+    [
+      "---",
+      "models:",
+      "  execution: minimax/MiniMax-M2.7",
+      "  planning: kimi-coding/k2p5",
+      "  verification: zai/glm-4.7",
+      "---",
+      "",
+    ].join("\n"),
+  );
+
+  withEnv({
+    HOME: tmpHome,
+    ANTHROPIC_API_KEY: undefined,
+    ANTHROPIC_OAUTH_TOKEN: undefined,
+    COPILOT_GITHUB_TOKEN: undefined,
+    GH_TOKEN: undefined,
+    GITHUB_TOKEN: undefined,
+  }, () => {
+    withCwd(repo, () => {
+      const results = runProviderChecks();
+      const anthropic = results.find(r => r.name === "anthropic");
+      assert.ok(
+        !anthropic,
+        "anthropic must not appear when user configured only custom providers",
+      );
+    });
+  });
+
+  rmSync(repo, { recursive: true, force: true });
+  rmSync(tmpHome, { recursive: true, force: true });
+});
+
 // ─── Cross-provider routing: Codex & Gemini CLI (#2922) ────────────────────
 
 test("runProviderChecks reports ok for Google via google-gemini-cli auth.json (#2922)", () => {

--- a/src/resources/extensions/search-the-web/native-search.ts
+++ b/src/resources/extensions/search-the-web/native-search.ts
@@ -96,7 +96,14 @@ export function registerNativeSearchHooks(pi: NativeSearchPI): { getIsAnthropic:
     const wasAnthropic = isAnthropicProvider;
     isAnthropicProvider = event.model.provider === "anthropic";
 
-    const hasBrave = !!process.env.BRAVE_API_KEY;
+    // Any configured custom search backend counts — tavily, brave, or ollama
+    // (Ollama's hosted web_search product, authed via OLLAMA_API_KEY).
+    // Users with any one of these have a working search path; we must not nag
+    // them about missing BRAVE_API_KEY when their configured backend works.
+    const hasCustomSearchKey =
+      !!process.env.TAVILY_API_KEY ||
+      !!process.env.BRAVE_API_KEY ||
+      !!process.env.OLLAMA_API_KEY;
 
     // When Anthropic (and not preferring Brave): disable custom search tools —
     // native web_search is server-side and more reliable.
@@ -121,9 +128,9 @@ export function registerNativeSearchHooks(pi: NativeSearchPI): { getIsAnthropic:
       ctx.ui.notify("Native Anthropic web search active", "info");
     } else if (isAnthropicProvider && preferBraveSearch() && !wasAnthropic && event.source !== "restore") {
       ctx.ui.notify("Brave search active (PREFER_BRAVE_SEARCH)", "info");
-    } else if (!isAnthropicProvider && !hasBrave) {
+    } else if (!isAnthropicProvider && !hasCustomSearchKey) {
       ctx.ui.notify(
-        "Web search: Set BRAVE_API_KEY or use an Anthropic model for built-in search",
+        "Web search unavailable: set TAVILY_API_KEY, BRAVE_API_KEY, or OLLAMA_API_KEY",
         "warning"
       );
     }


### PR DESCRIPTION
Three independent small fixes bundled together:

## 1. `doctor-providers.ts` — fabricated anthropic requirement

`collectConfiguredModelProviders()` returned `{"anthropic"}` whenever the configured models all used provider prefixes the static analyser didn't know about (e.g. `minimax/`, `kimi-coding/`, `zai/`, `xiaomi-token-plan-ams/`). These providers are declared only in `~/.gsd/agent/models.json` and this static doctor can't reach them without a runtime `ModelRegistry` reference.

Result: the widget showed `✗ Anthropic (Claude) key missing` for users who never asked for Anthropic.

- Cold-start default (no `models` block in `preferences.md`) still falls back to anthropic so fresh installs get an actionable nudge.
- Catch-block default (unreadable `preferences.md`) still falls back to anthropic.
- When the `models` block IS iterated but every entry's provider is unknown, return the empty set. The caller treats an empty set as "no LLM key checks to run".

Regression test added.

## 2. `native-search.ts` — "BRAVE_API_KEY required" nag when tavily/ollama work

When switching away from Anthropic, the hook warned `Web search unavailable: set BRAVE_API_KEY or use an Anthropic model for built-in search` even when `TAVILY_API_KEY` or `OLLAMA_API_KEY` was set. Both of those are already wired up as search backends elsewhere in the codebase — the warning just hadn't caught up.

Check all three env vars and list all three in the warning when none are present.

## 3. `pi-ai` anthropic provider — longcat Bearer auth

LongCat (Meituan) ships an Anthropic-compatible endpoint at `https://api.longcat.chat/anthropic` that authenticates via `Authorization: Bearer $KEY` instead of Anthropic's native `x-api-key` header. Without this change, pi sends `x-api-key` and LongCat replies with `401 invalid_api_key / missing_api_key`.

Same topology as the existing `alibaba-coding-plan` / `minimax` / `minimax-cn` entries (#3783).

- Add `"longcat"` to `usesAnthropicBearerAuth()` so `createClient` routes the key through `authToken`.
- Add `"longcat": "LONGCAT_API_KEY"` to `env-api-keys.ts` envMap so `getEnvApiKey()` can resolve it when `options.apiKey` is absent.
- Add `"longcat"` to `KnownProvider` so the `===` literal check type-checks.
- Extend `anthropic-auth.test.ts` to assert `usesAnthropicBearerAuth` returns true for longcat.