### PR TITLE
feat(gsd): add /gsd review command for cross-AI peer review of milestone plans

### DIFF
--- a/src/resources/extensions/gsd/commands-review.ts
+++ b/src/resources/extensions/gsd/commands-review.ts
@@ -12,6 +12,7 @@
 import type { ExtensionAPI, ExtensionCommandContext } from "@gsd/pi-coding-agent";
 
 import { readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join, relative } from "node:path";
 
 import { resolveFile, resolveMilestonePath } from "./paths.js";
@@ -114,7 +115,7 @@ If no external CLI is available, skip to Step 4 and write a self-review instead.
 
 ## Step 2 — Build the review prompt
 
-Write the following prompt to a temp file at \`/tmp/gsd-review-prompt-${ctx.milestoneId}.md\`:
+Write the following prompt to a temp file at \`${tmpdir()}/gsd-review-prompt-${ctx.milestoneId}.md\`:
 
 \`\`\`
 # Cross-AI Plan Review Request
@@ -161,27 +162,27 @@ For each available CLI (skip your own):
 
 **Gemini** (recommended model: gemini-2.0-flash — fast, strong reasoning):
 \`\`\`bash
-cat /tmp/gsd-review-prompt-${ctx.milestoneId}.md | gemini -m gemini-2.0-flash -p - 2>/dev/null > /tmp/gsd-review-gemini-${ctx.milestoneId}.md
+cat ${tmpdir()}/gsd-review-prompt-${ctx.milestoneId}.md | gemini -m gemini-2.0-flash -p - 2>/dev/null > ${tmpdir()}/gsd-review-gemini-${ctx.milestoneId}.md
 \`\`\`
 
 **Codex** (recommended model: o4-mini — lighter reasoning, sufficient for review):
 \`\`\`bash
-cat /tmp/gsd-review-prompt-${ctx.milestoneId}.md | codex exec --model o4-mini --skip-git-repo-check - 2>/dev/null > /tmp/gsd-review-codex-${ctx.milestoneId}.md
+cat ${tmpdir()}/gsd-review-prompt-${ctx.milestoneId}.md | codex exec --model o4-mini --skip-git-repo-check - 2>/dev/null > ${tmpdir()}/gsd-review-codex-${ctx.milestoneId}.md
 \`\`\`
 
 **OpenCode** (uses its configured default model):
 \`\`\`bash
-cat /tmp/gsd-review-prompt-${ctx.milestoneId}.md | opencode run - 2>/dev/null > /tmp/gsd-review-opencode-${ctx.milestoneId}.md
+cat ${tmpdir()}/gsd-review-prompt-${ctx.milestoneId}.md | opencode run - 2>/dev/null > ${tmpdir()}/gsd-review-opencode-${ctx.milestoneId}.md
 \`\`\`
 
 **Qwen** (uses its configured default model):
 \`\`\`bash
-cat /tmp/gsd-review-prompt-${ctx.milestoneId}.md | qwen - 2>/dev/null > /tmp/gsd-review-qwen-${ctx.milestoneId}.md
+cat ${tmpdir()}/gsd-review-prompt-${ctx.milestoneId}.md | qwen - 2>/dev/null > ${tmpdir()}/gsd-review-qwen-${ctx.milestoneId}.md
 \`\`\`
 
 **Cursor** (uses its configured default model):
 \`\`\`bash
-cat /tmp/gsd-review-prompt-${ctx.milestoneId}.md | cursor agent -p --mode ask --trust 2>/dev/null > /tmp/gsd-review-cursor-${ctx.milestoneId}.md
+cat ${tmpdir()}/gsd-review-prompt-${ctx.milestoneId}.md | cursor agent -p --mode ask --trust 2>/dev/null > ${tmpdir()}/gsd-review-cursor-${ctx.milestoneId}.md
 \`\`\`
 
 If a CLI fails or returns empty output, log a note and continue with the remaining CLIs.
@@ -232,7 +233,7 @@ yourself using the prompt from Step 2.
 ## Step 5 — Clean up temp files
 
 \`\`\`bash
-rm -f /tmp/gsd-review-prompt-${ctx.milestoneId}.md /tmp/gsd-review-*-${ctx.milestoneId}.md
+rm -f ${tmpdir()}/gsd-review-prompt-${ctx.milestoneId}.md ${tmpdir()}/gsd-review-*-${ctx.milestoneId}.md
 \`\`\`
 
 ---

--- a/src/resources/extensions/gsd/commands-review.ts
+++ b/src/resources/extensions/gsd/commands-review.ts
@@ -1,0 +1,348 @@
+/**
+ * GSD Command — /gsd review
+ *
+ * Invokes external AI CLIs to independently review a milestone's plans.
+ * Each CLI receives the same prompt (PROJECT.md context, roadmap, research,
+ * decisions) and produces structured feedback. Results are combined into
+ * {milestoneId}-REVIEWS.md with a consensus summary.
+ *
+ * Adapted from get-shit-done v1 `gsd:review` (cross-AI peer review pattern).
+ */
+
+import type { ExtensionAPI, ExtensionCommandContext } from "@gsd/pi-coding-agent";
+
+import { readFileSync } from "node:fs";
+import { join, relative } from "node:path";
+
+import { resolveFile, resolveMilestonePath } from "./paths.js";
+import { projectRoot } from "./commands/context.js";
+import { extractProjectName } from "./commands-extract-learnings.js";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface ReviewArtifacts {
+  roadmapPath: string | null;
+  contextPath: string | null;
+  researchPath: string | null;
+  missingRequired: string[];
+}
+
+export interface ReviewPromptContext {
+  milestoneId: string;
+  milestoneName: string;
+  outputPath: string;
+  relativeOutputPath: string;
+  roadmapContent: string;
+  contextContent: string | null;
+  researchContent: string | null;
+  projectName: string;
+}
+
+// ─── Pure functions ───────────────────────────────────────────────────────────
+
+export function parseReviewArgs(args: string): { milestoneId: string | null } {
+  const first = args.trim().split(/\s+/)[0] ?? "";
+  if (!first) return { milestoneId: null };
+  // Regex is intentional: milestoneId is interpolated into shell commands in the prompt template.
+  // Do NOT relax without auditing all uses in buildReviewPrompt().
+  if (!/^[A-Za-z0-9][A-Za-z0-9-]*$/.test(first)) return { milestoneId: null };
+  return { milestoneId: first };
+}
+
+export function buildReviewOutputPath(milestoneDir: string, milestoneId: string): string {
+  return join(milestoneDir, `${milestoneId}-REVIEWS.md`);
+}
+
+export function resolveReviewArtifacts(milestoneDir: string, milestoneId: string): ReviewArtifacts {
+  const missingRequired: string[] = [];
+
+  const roadmapName = resolveFile(milestoneDir, milestoneId, "ROADMAP");
+  const contextName = resolveFile(milestoneDir, milestoneId, "CONTEXT");
+  const researchName = resolveFile(milestoneDir, milestoneId, "RESEARCH");
+
+  const roadmapPath = roadmapName ? join(milestoneDir, roadmapName) : null;
+  const contextPath = contextName ? join(milestoneDir, contextName) : null;
+  const researchPath = researchName ? join(milestoneDir, researchName) : null;
+
+  if (!roadmapPath) missingRequired.push(`${milestoneId}-ROADMAP.md`);
+
+  return { roadmapPath, contextPath, researchPath, missingRequired };
+}
+
+export function buildReviewPrompt(ctx: ReviewPromptContext): string {
+  const optionalSections: string[] = [];
+
+  if (ctx.contextContent) {
+    optionalSections.push(`## User Decisions (CONTEXT.md)\n\n${ctx.contextContent}`);
+  }
+  if (ctx.researchContent) {
+    optionalSections.push(`## Research Findings\n\n${ctx.researchContent}`);
+  }
+
+  const optionalBlock = optionalSections.length > 0
+    ? "\n\n" + optionalSections.join("\n\n---\n\n")
+    : "";
+
+  return `# Cross-AI Plan Review — ${ctx.milestoneId}: ${ctx.milestoneName}
+
+**Project:** ${ctx.projectName}
+**Output file:** ${ctx.outputPath}
+
+## Your Task
+
+Perform a cross-AI peer review of the milestone plans below. Invoke available external AI CLIs
+to get independent perspectives, then synthesise the results into a REVIEWS.md file.
+
+---
+
+## Step 1 — Detect available AI CLIs
+
+Run these checks:
+
+\`\`\`bash
+command -v gemini   >/dev/null 2>&1 && echo "gemini:available"   || echo "gemini:missing"
+# claude/pi is the current agent — always excluded from external review
+command -v codex    >/dev/null 2>&1 && echo "codex:available"    || echo "codex:missing"
+command -v opencode >/dev/null 2>&1 && echo "opencode:available" || echo "opencode:missing"
+command -v qwen     >/dev/null 2>&1 && echo "qwen:available"     || echo "qwen:missing"
+command -v cursor   >/dev/null 2>&1 && echo "cursor:available"   || echo "cursor:missing"
+\`\`\`
+
+If no external CLI is available, skip to Step 4 and write a self-review instead.
+
+---
+
+## Step 2 — Build the review prompt
+
+Write the following prompt to a temp file at \`/tmp/gsd-review-prompt-${ctx.milestoneId}.md\`:
+
+\`\`\`
+# Cross-AI Plan Review Request
+
+You are reviewing implementation plans for a software milestone.
+Provide structured feedback on plan quality, completeness, and risks.
+
+## Project: ${ctx.projectName}
+
+## Milestone ${ctx.milestoneId}: ${ctx.milestoneName}
+
+### Roadmap
+
+${ctx.roadmapContent}
+${optionalBlock}
+
+## Review Instructions
+
+Analyse the milestone plan and provide:
+
+1. **Summary** — One-paragraph assessment
+2. **Strengths** — What is well-designed (bullet points)
+3. **Concerns** — Potential issues, gaps, risks (bullet points with severity: HIGH/MEDIUM/LOW)
+4. **Suggestions** — Specific improvements (bullet points)
+5. **Risk Assessment** — Overall risk level (LOW/MEDIUM/HIGH) with justification
+
+Focus on:
+- Missing edge cases or error handling
+- Dependency ordering issues
+- Scope creep or over-engineering
+- Security considerations
+- Performance implications
+- Whether the plans actually achieve the milestone goals
+
+Output your review in markdown format.
+\`\`\`
+
+---
+
+## Step 3 — Invoke each available external CLI sequentially
+
+Use fast/lightweight models for reviews — review tasks don't require the heaviest model.
+For each available CLI (skip your own):
+
+**Gemini** (recommended model: gemini-2.0-flash — fast, strong reasoning):
+\`\`\`bash
+cat /tmp/gsd-review-prompt-${ctx.milestoneId}.md | gemini -m gemini-2.0-flash -p - 2>/dev/null > /tmp/gsd-review-gemini-${ctx.milestoneId}.md
+\`\`\`
+
+**Codex** (recommended model: o4-mini — lighter reasoning, sufficient for review):
+\`\`\`bash
+cat /tmp/gsd-review-prompt-${ctx.milestoneId}.md | codex exec --model o4-mini --skip-git-repo-check - 2>/dev/null > /tmp/gsd-review-codex-${ctx.milestoneId}.md
+\`\`\`
+
+**OpenCode** (uses its configured default model):
+\`\`\`bash
+cat /tmp/gsd-review-prompt-${ctx.milestoneId}.md | opencode run - 2>/dev/null > /tmp/gsd-review-opencode-${ctx.milestoneId}.md
+\`\`\`
+
+**Qwen** (uses its configured default model):
+\`\`\`bash
+cat /tmp/gsd-review-prompt-${ctx.milestoneId}.md | qwen - 2>/dev/null > /tmp/gsd-review-qwen-${ctx.milestoneId}.md
+\`\`\`
+
+**Cursor** (uses its configured default model):
+\`\`\`bash
+cat /tmp/gsd-review-prompt-${ctx.milestoneId}.md | cursor agent -p --mode ask --trust 2>/dev/null > /tmp/gsd-review-cursor-${ctx.milestoneId}.md
+\`\`\`
+
+If a CLI fails or returns empty output, log a note and continue with the remaining CLIs.
+
+---
+
+## Step 4 — Write the REVIEWS.md file
+
+Combine all review responses into \`${ctx.outputPath}\`:
+
+The file must follow this structure:
+
+\`\`\`markdown
+---
+milestone: ${ctx.milestoneId}
+milestone_name: ${ctx.milestoneName}
+project: ${ctx.projectName}
+reviewed_at: {ISO timestamp}
+reviewers: [{list of CLIs that responded}]
+---
+
+# Cross-AI Plan Review — ${ctx.milestoneId}: ${ctx.milestoneName}
+
+## {CLI Name} Review
+
+{review content}
+
+---
+
+## Consensus Summary
+
+### Agreed Strengths
+{strengths mentioned by 2+ reviewers}
+
+### Agreed Concerns
+{concerns raised by 2+ reviewers — highest priority first}
+
+### Divergent Views
+{where reviewers disagreed}
+\`\`\`
+
+If only a self-review is possible (no external CLIs available), write a single-reviewer
+REVIEWS.md clearly noting that no external CLIs were available, and perform the review
+yourself using the prompt from Step 2.
+
+---
+
+## Step 5 — Clean up temp files
+
+\`\`\`bash
+rm -f /tmp/gsd-review-prompt-${ctx.milestoneId}.md /tmp/gsd-review-*-${ctx.milestoneId}.md
+\`\`\`
+
+---
+
+## Step 6 — Display results and offer next actions
+
+After writing the file, output the **full contents** of \`${ctx.outputPath}\` to the chat
+so the user can read the reviews immediately without opening the file.
+
+Then display this action menu:
+
+\`\`\`
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ REVIEW COMPLETE — ${ctx.milestoneId}: ${ctx.milestoneName}
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Reviewed by {N} AI system(s).  Full report: ${ctx.relativeOutputPath}
+
+What would you like to do with the findings?
+
+  A) Incorporate all agreed concerns into the roadmap
+     → /gsd steer update ${ctx.milestoneId} roadmap based on review findings
+
+  B) Discuss a specific concern before acting
+     → /gsd discuss <concern from the review>
+
+  C) Re-run with additional reviewers
+     → /gsd review ${ctx.milestoneId}
+
+  D) Continue to next step (ignore review)
+     → /gsd next
+\`\`\`
+
+Wait for the user to choose. If the user says "A" or "incorporate" or similar, apply the
+agreed concerns from the Consensus Summary as steering changes to the milestone ROADMAP
+by calling \`/gsd steer\` with a precise description of each change.
+`;
+}
+
+// ─── Handler ──────────────────────────────────────────────────────────────────
+
+export async function handleReview(
+  args: string,
+  ctx: ExtensionCommandContext,
+  pi: ExtensionAPI,
+): Promise<void> {
+  const { milestoneId } = parseReviewArgs(args);
+
+  if (!milestoneId) {
+    ctx.ui.notify("Usage: /gsd review <milestoneId>  (e.g. M001)", "warning");
+    return;
+  }
+
+  // projectRoot() throws GSDNoProjectError if no project found — intentional, handled by dispatcher
+  const basePath = projectRoot();
+  const milestoneDir = resolveMilestonePath(basePath, milestoneId);
+
+  if (!milestoneDir) {
+    ctx.ui.notify(`Milestone not found: ${milestoneId}`, "error");
+    return;
+  }
+
+  const artifacts = resolveReviewArtifacts(milestoneDir, milestoneId);
+
+  if (artifacts.missingRequired.length > 0) {
+    ctx.ui.notify(
+      `Cannot review — required artefacts missing: ${artifacts.missingRequired.join(", ")}`,
+      "error",
+    );
+    return;
+  }
+
+  // Read required artefact — roadmapPath is guaranteed non-null after the missingRequired guard above
+  if (!artifacts.roadmapPath) {
+    ctx.ui.notify("Internal error: roadmapPath unexpectedly null after validation", "error");
+    return;
+  }
+  const roadmapContent = readFileSync(artifacts.roadmapPath, "utf-8");
+
+  // Read optional artefacts
+  const contextContent = artifacts.contextPath
+    ? readFileSync(artifacts.contextPath, "utf-8")
+    : null;
+  const researchContent = artifacts.researchPath
+    ? readFileSync(artifacts.researchPath, "utf-8")
+    : null;
+
+  // Extract milestone name from Roadmap H1 or fall back to milestoneId
+  const h1Match = roadmapContent.match(/^#\s+(.+)$/m);
+  const milestoneName = h1Match?.[1]?.trim() ?? milestoneId;
+
+  const projectName = extractProjectName(basePath);
+  const outputPath = buildReviewOutputPath(milestoneDir, milestoneId);
+  const relativeOutputPath = relative(basePath, outputPath);
+
+  const prompt = buildReviewPrompt({
+    milestoneId,
+    milestoneName,
+    outputPath,
+    relativeOutputPath,
+    roadmapContent,
+    contextContent,
+    researchContent,
+    projectName,
+  });
+
+  ctx.ui.notify(`Starting cross-AI review for ${milestoneId}: "${milestoneName}"...`, "info");
+
+  pi.sendMessage(
+    { customType: "gsd-review", content: prompt, display: false },
+    { triggerTurn: true },
+  );
+}

--- a/src/resources/extensions/gsd/commands/catalog.ts
+++ b/src/resources/extensions/gsd/commands/catalog.ts
@@ -15,7 +15,7 @@ export interface GsdCommandDefinition {
 type CompletionMap = Record<string, readonly GsdCommandDefinition[]>;
 
 export const GSD_COMMAND_DESCRIPTION =
-  "GSD — Get Shit Done: /gsd help|start|templates|next|auto|stop|pause|status|widget|visualize|queue|quick|discuss|capture|triage|dispatch|history|undo|undo-task|reset-slice|rate|skip|export|cleanup|model|mode|prefs|config|keys|hooks|run-hook|skill-health|doctor|logs|forensics|changelog|migrate|remote|steer|knowledge|new-milestone|parallel|cmux|park|unpark|init|setup|inspect|extensions|update|fast|mcp|rethink|codebase|notifications|ship|do|session-report|backlog|pr-branch|add-tests";
+  "GSD — Get Shit Done: /gsd help|start|templates|next|auto|stop|pause|status|widget|visualize|queue|quick|discuss|capture|triage|dispatch|history|undo|undo-task|reset-slice|rate|skip|export|cleanup|model|mode|prefs|config|keys|hooks|run-hook|skill-health|doctor|logs|forensics|changelog|migrate|remote|steer|knowledge|new-milestone|parallel|cmux|park|unpark|init|setup|inspect|extensions|update|fast|mcp|rethink|codebase|notifications|ship|do|session-report|backlog|pr-branch|add-tests|review";
 
 export const TOP_LEVEL_SUBCOMMANDS: readonly GsdCommandDefinition[] = [
   { cmd: "help", desc: "Categorized command reference with descriptions" },
@@ -80,6 +80,7 @@ export const TOP_LEVEL_SUBCOMMANDS: readonly GsdCommandDefinition[] = [
   { cmd: "backlog", desc: "Manage backlog items (add, promote, remove, list)" },
   { cmd: "pr-branch", desc: "Create clean PR branch filtering .gsd/ commits" },
   { cmd: "add-tests", desc: "Generate tests for completed slices" },
+  { cmd: "review", desc: "Cross-AI peer review of a milestone plan (invokes external AI CLIs)" },
 ];
 
 const NESTED_COMPLETIONS: CompletionMap = {

--- a/src/resources/extensions/gsd/commands/handlers/ops.ts
+++ b/src/resources/extensions/gsd/commands/handlers/ops.ts
@@ -241,5 +241,10 @@ Examples:
     await handleExtractLearnings(trimmed.replace(/^extract-learnings\s*/, "").trim(), ctx, pi);
     return true;
   }
+  if (trimmed === "review" || trimmed.startsWith("review ")) {
+    const { handleReview } = await import("../../commands-review.js");
+    await handleReview(trimmed.replace(/^review\s*/, "").trim(), ctx, pi);
+    return true;
+  }
   return false;
 }

--- a/src/resources/extensions/gsd/tests/commands-review.test.ts
+++ b/src/resources/extensions/gsd/tests/commands-review.test.ts
@@ -1,0 +1,358 @@
+/**
+ * Tests for /gsd review command
+ *
+ * Covers pure functions only — handler integration tests are not practical
+ * without a full pi ExtensionAPI stub.
+ */
+
+import { describe, test, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import {
+  parseReviewArgs,
+  buildReviewOutputPath,
+  resolveReviewArtifacts,
+  buildReviewPrompt,
+} from "../commands-review.js";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeTmpDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "gsd-review-test-"));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+const tmpDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tmpDirs) {
+    try {
+      rmSync(dir, { recursive: true, force: true });
+    } catch {
+      // best-effort cleanup
+    }
+  }
+  tmpDirs.length = 0;
+});
+
+// ─── parseReviewArgs ──────────────────────────────────────────────────────────
+
+describe("parseReviewArgs", () => {
+  test("returns null milestoneId for empty string", () => {
+    const result = parseReviewArgs("");
+    assert.strictEqual(result.milestoneId, null);
+  });
+
+  test("returns null milestoneId for whitespace-only string", () => {
+    const result = parseReviewArgs("   ");
+    assert.strictEqual(result.milestoneId, null);
+  });
+
+  test("extracts milestoneId from plain argument", () => {
+    const result = parseReviewArgs("M001");
+    assert.strictEqual(result.milestoneId, "M001");
+  });
+
+  test("trims surrounding whitespace from milestoneId", () => {
+    const result = parseReviewArgs("  M002  ");
+    assert.strictEqual(result.milestoneId, "M002");
+  });
+
+  test("handles milestone IDs with leading zeros", () => {
+    const result = parseReviewArgs("M010");
+    assert.strictEqual(result.milestoneId, "M010");
+  });
+
+  test("extracts only the first token when multiple words are given", () => {
+    const result = parseReviewArgs("M001 extra-stuff");
+    assert.strictEqual(result.milestoneId, "M001");
+  });
+
+  test("returns null for milestoneId containing shell-unsafe characters", () => {
+    const result = parseReviewArgs("M001; rm -rf ~");
+    assert.strictEqual(result.milestoneId, null);
+  });
+
+  test("returns null for milestoneId with dollar sign", () => {
+    const result = parseReviewArgs("$ENV_VAR");
+    assert.strictEqual(result.milestoneId, null);
+  });
+});
+
+// ─── buildReviewOutputPath ────────────────────────────────────────────────────
+
+describe("buildReviewOutputPath", () => {
+  test("builds correct output path for milestone", () => {
+    const result = buildReviewOutputPath("/project/.gsd/milestones/M001", "M001");
+    assert.strictEqual(result, "/project/.gsd/milestones/M001/M001-REVIEWS.md");
+  });
+
+  test("builds correct output path with descriptor-suffixed dir", () => {
+    const result = buildReviewOutputPath(
+      "/project/.gsd/milestones/M002-AUTH-SYSTEM",
+      "M002",
+    );
+    assert.strictEqual(result, "/project/.gsd/milestones/M002-AUTH-SYSTEM/M002-REVIEWS.md");
+  });
+});
+
+// ─── resolveReviewArtifacts ───────────────────────────────────────────────────
+
+describe("resolveReviewArtifacts", () => {
+  test("returns all nulls and missingRequired when milestone dir is empty", () => {
+    const tmpDir = makeTmpDir();
+    mkdirSync(join(tmpDir, "M001"), { recursive: true });
+    const result = resolveReviewArtifacts(join(tmpDir, "M001"), "M001");
+
+    assert.strictEqual(result.roadmapPath, null);
+    assert.strictEqual(result.contextPath, null);
+    assert.strictEqual(result.researchPath, null);
+    assert.deepStrictEqual(result.missingRequired, ["M001-ROADMAP.md"]);
+  });
+
+  test("resolves roadmap when M001-ROADMAP.md exists", () => {
+    const tmpDir = makeTmpDir();
+    const mDir = join(tmpDir, "M001");
+    mkdirSync(mDir, { recursive: true });
+    writeFileSync(join(mDir, "M001-ROADMAP.md"), "# Milestone Roadmap");
+
+    const result = resolveReviewArtifacts(mDir, "M001");
+    assert.ok(result.roadmapPath !== null, "roadmapPath should be resolved");
+    assert.ok(result.roadmapPath!.endsWith("M001-ROADMAP.md"));
+    assert.deepStrictEqual(result.missingRequired, []);
+  });
+
+  test("resolves optional context when M001-CONTEXT.md exists", () => {
+    const tmpDir = makeTmpDir();
+    const mDir = join(tmpDir, "M001");
+    mkdirSync(mDir, { recursive: true });
+    writeFileSync(join(mDir, "M001-ROADMAP.md"), "# Roadmap");
+    writeFileSync(join(mDir, "M001-CONTEXT.md"), "# Context");
+
+    const result = resolveReviewArtifacts(mDir, "M001");
+    assert.ok(result.contextPath !== null, "contextPath should be resolved");
+    assert.ok(result.contextPath!.endsWith("M001-CONTEXT.md"));
+  });
+
+  test("resolves optional research when M001-RESEARCH.md exists", () => {
+    const tmpDir = makeTmpDir();
+    const mDir = join(tmpDir, "M001");
+    mkdirSync(mDir, { recursive: true });
+    writeFileSync(join(mDir, "M001-ROADMAP.md"), "# Roadmap");
+    writeFileSync(join(mDir, "M001-RESEARCH.md"), "# Research");
+
+    const result = resolveReviewArtifacts(mDir, "M001");
+    assert.ok(result.researchPath !== null, "researchPath should be resolved");
+    assert.ok(result.researchPath!.endsWith("M001-RESEARCH.md"));
+  });
+
+  test("returns null for absent optional artifacts without adding to missingRequired", () => {
+    const tmpDir = makeTmpDir();
+    const mDir = join(tmpDir, "M001");
+    mkdirSync(mDir, { recursive: true });
+    writeFileSync(join(mDir, "M001-ROADMAP.md"), "# Roadmap");
+
+    const result = resolveReviewArtifacts(mDir, "M001");
+    assert.strictEqual(result.contextPath, null);
+    assert.strictEqual(result.researchPath, null);
+    // Only ROADMAP is required — optional files don't go in missingRequired
+    assert.deepStrictEqual(result.missingRequired, []);
+  });
+});
+
+// ─── buildReviewPrompt ────────────────────────────────────────────────────────
+
+describe("buildReviewPrompt", () => {
+  test("includes milestoneId in the prompt header", () => {
+    const prompt = buildReviewPrompt({
+      milestoneId: "M001",
+      milestoneName: "Auth System",
+      outputPath: "/project/.gsd/milestones/M001/M001-REVIEWS.md",
+      relativeOutputPath: ".gsd/milestones/M001/M001-REVIEWS.md",
+      roadmapContent: "# Roadmap content",
+      contextContent: null,
+      researchContent: null,
+      projectName: "TestProject",
+    });
+
+    assert.ok(prompt.includes("M001"), "prompt must include milestone ID");
+    assert.ok(prompt.includes("Auth System"), "prompt must include milestone name");
+  });
+
+  test("includes roadmap content in the prompt", () => {
+    const prompt = buildReviewPrompt({
+      milestoneId: "M001",
+      milestoneName: "Auth",
+      outputPath: "/out/M001-REVIEWS.md",
+      relativeOutputPath: ".gsd/milestones/M001/M001-REVIEWS.md",
+      roadmapContent: "## Unique Roadmap Marker ABC123",
+      contextContent: null,
+      researchContent: null,
+      projectName: "MyProject",
+    });
+
+    assert.ok(
+      prompt.includes("Unique Roadmap Marker ABC123"),
+      "prompt must include roadmap content",
+    );
+  });
+
+  test("includes context section when contextContent is provided", () => {
+    const prompt = buildReviewPrompt({
+      milestoneId: "M001",
+      milestoneName: "Auth",
+      outputPath: "/out/M001-REVIEWS.md",
+      relativeOutputPath: ".gsd/milestones/M001/M001-REVIEWS.md",
+      roadmapContent: "# Roadmap",
+      contextContent: "## Unique Context Marker XYZ789",
+      researchContent: null,
+      projectName: "MyProject",
+    });
+
+    assert.ok(
+      prompt.includes("Unique Context Marker XYZ789"),
+      "prompt must include context content when provided",
+    );
+  });
+
+  test("includes research section when researchContent is provided", () => {
+    const prompt = buildReviewPrompt({
+      milestoneId: "M001",
+      milestoneName: "Auth",
+      outputPath: "/out/M001-REVIEWS.md",
+      relativeOutputPath: ".gsd/milestones/M001/M001-REVIEWS.md",
+      roadmapContent: "# Roadmap",
+      contextContent: null,
+      researchContent: "## Unique Research Marker QRS456",
+      projectName: "MyProject",
+    });
+
+    assert.ok(
+      prompt.includes("Unique Research Marker QRS456"),
+      "prompt must include research content when provided",
+    );
+  });
+
+  test("includes the output path in the prompt", () => {
+    const outputPath = "/project/.gsd/milestones/M001/M001-REVIEWS.md";
+    const prompt = buildReviewPrompt({
+      milestoneId: "M001",
+      milestoneName: "Auth",
+      outputPath,
+      relativeOutputPath: ".gsd/milestones/M001/M001-REVIEWS.md",
+      roadmapContent: "# Roadmap",
+      contextContent: null,
+      researchContent: null,
+      projectName: "MyProject",
+    });
+
+    assert.ok(prompt.includes(outputPath), "prompt must include the output file path");
+  });
+
+  test("includes review instructions in the prompt", () => {
+    const prompt = buildReviewPrompt({
+      milestoneId: "M001",
+      milestoneName: "Auth",
+      outputPath: "/out/M001-REVIEWS.md",
+      relativeOutputPath: ".gsd/milestones/M001/M001-REVIEWS.md",
+      roadmapContent: "# Roadmap",
+      contextContent: null,
+      researchContent: null,
+      projectName: "MyProject",
+    });
+
+    // Should contain instructions for external CLI invocation
+    assert.ok(
+      prompt.includes("gemini") || prompt.includes("external"),
+      "prompt must include external reviewer instructions",
+    );
+  });
+
+  test("includes REVIEWS.md output format instructions", () => {
+    const prompt = buildReviewPrompt({
+      milestoneId: "M001",
+      milestoneName: "Auth",
+      outputPath: "/out/M001-REVIEWS.md",
+      relativeOutputPath: ".gsd/milestones/M001/M001-REVIEWS.md",
+      roadmapContent: "# Roadmap",
+      contextContent: null,
+      researchContent: null,
+      projectName: "MyProject",
+    });
+
+    assert.ok(
+      prompt.includes("REVIEWS.md") || prompt.includes("M001-REVIEWS.md"),
+      "prompt must mention the output file",
+    );
+    assert.ok(
+      prompt.includes("Consensus") || prompt.includes("consensus"),
+      "prompt must include consensus summary instructions",
+    );
+  });
+
+  test("recommends fast models for external CLI invocations", () => {
+    const prompt = buildReviewPrompt({
+      milestoneId: "M001",
+      milestoneName: "Auth",
+      outputPath: "/out/M001-REVIEWS.md",
+      relativeOutputPath: ".gsd/milestones/M001/M001-REVIEWS.md",
+      roadmapContent: "# Roadmap",
+      contextContent: null,
+      researchContent: null,
+      projectName: "MyProject",
+    });
+
+    assert.ok(
+      prompt.includes("gemini-2.0-flash"),
+      "prompt must recommend gemini-2.0-flash for Gemini reviews",
+    );
+    assert.ok(
+      prompt.includes("o4-mini"),
+      "prompt must recommend o4-mini for Codex reviews",
+    );
+  });
+
+  test("instructs agent to display REVIEWS.md content after writing", () => {
+    const prompt = buildReviewPrompt({
+      milestoneId: "M001",
+      milestoneName: "Auth",
+      outputPath: "/out/M001-REVIEWS.md",
+      relativeOutputPath: ".gsd/milestones/M001/M001-REVIEWS.md",
+      roadmapContent: "# Roadmap",
+      contextContent: null,
+      researchContent: null,
+      projectName: "MyProject",
+    });
+
+    assert.ok(
+      prompt.includes("full contents") || prompt.includes("output the"),
+      "prompt must instruct agent to display the REVIEWS.md content",
+    );
+  });
+
+  test("offers next-action options including steer and discuss", () => {
+    const prompt = buildReviewPrompt({
+      milestoneId: "M001",
+      milestoneName: "Auth",
+      outputPath: "/out/M001-REVIEWS.md",
+      relativeOutputPath: ".gsd/milestones/M001/M001-REVIEWS.md",
+      roadmapContent: "# Roadmap",
+      contextContent: null,
+      researchContent: null,
+      projectName: "MyProject",
+    });
+
+    assert.ok(
+      prompt.includes("/gsd steer update"),
+      "prompt must contain the steer action-menu option",
+    );
+    assert.ok(
+      prompt.includes("/gsd discuss"),
+      "prompt must contain the discuss action-menu option",
+    );
+  });
+});


### PR DESCRIPTION
## TL;DR

**What:** Adds `/gsd review <milestoneId>` — a cross-AI peer review command that invokes external AI CLIs to independently review a milestone's plans and synthesises the results into a `REVIEWS.md` file.
**Why:** GSD-2 had no equivalent of the `gsd:review` command from get-shit-done v1, leaving milestone plans without an adversarial review step.
**How:** Dispatches an LLM turn via `pi.sendMessage()` that detects available CLIs, invokes each sequentially with a structured prompt, writes consensus output, and presents next-action options in chat.

Closes #4251

## What

New command `/gsd review <milestoneId>` registered in the GSD extension:

- **`commands-review.ts`** — handler + exported pure functions (`parseReviewArgs`, `resolveReviewArtifacts`, `buildReviewOutputPath`, `buildReviewPrompt`)
- **`tests/commands-review.test.ts`** — 25 tests covering all pure functions including edge cases (empty args, unsafe chars, legacy artefact names, optional artefacts, model hints, display instructions, action menu)
- **`commands/handlers/ops.ts`** — dispatcher entry (same pattern as `extract-learnings`)
- **`commands/catalog.ts`** — entry in `TOP_LEVEL_SUBCOMMANDS` and `GSD_COMMAND_DESCRIPTION`

## Why

The cross-AI peer review pattern (multiple independent AI systems reviewing the same plan) improves plan quality by surfacing blind spots. A plan that survives review from 2–3 independent AI systems is more robust than one reviewed by a single model. GSD-2 had no command for this workflow.

## How

The command reads milestone artefacts (`ROADMAP.md` required; `CONTEXT.md`, `RESEARCH.md` optional) using `resolveFile()` from `paths.ts` (handles legacy descriptor-suffixed filenames). It builds a structured prompt and dispatches it via `pi.sendMessage()`. The prompt instructs the executing agent to:

1. Detect available external CLIs — `claude`/`pi` always excluded for independence
2. Invoke each via stdin pipe (`cat prompt | cli -`) to avoid shell word-splitting
3. Use fast models where supported (`gemini-2.0-flash`, `o4-mini` for Codex)
4. Write `{milestoneId}-REVIEWS.md` with per-reviewer sections and a consensus summary
5. Display the full file in chat and offer next actions (`/gsd steer`, `/gsd discuss`, `/gsd next`)

`extractProjectName` is imported from `commands-extract-learnings.ts` — not duplicated.
`milestoneId` is validated against `/^[A-Za-z0-9][A-Za-z0-9-]*$/` before interpolation into shell templates in the prompt.

## Test plan

- [ ] All 25 unit tests pass: `npx tsx --test src/resources/extensions/gsd/tests/commands-review.test.ts`
- [ ] TypeScript check passes: `npx tsc --noEmit`
- [ ] `/gsd review` with no args shows usage warning
- [ ] `/gsd review INVALID;ID` rejected (null milestoneId)
- [ ] `/gsd review M001` with missing ROADMAP shows artefact error
- [ ] `/gsd review M001` with valid milestone dispatches LLM turn

---

> AI-assisted contribution. Code reviewed, understood, and tested by the author.