### PR TITLE
docs: add Analysis & Review section to commands.md and fill catalog gaps

### DIFF
--- a/docs/user-docs/commands.md
+++ b/docs/user-docs/commands.md
@@ -79,6 +79,21 @@
 
 See [Parallel Orchestration](./parallel-orchestration.md) for full documentation.
 
+## Analysis & Review
+
+| Command | Description |
+|---------|-------------|
+| `/gsd scan` | Rapid codebase assessment — lightweight alternative to full map. Use `--focus tech\|arch\|quality\|concerns\|tech+arch` (default: `tech+arch`) |
+| `/gsd graph build` | Build or rebuild the knowledge graph from `.gsd/` artifacts |
+| `/gsd graph status` | Show graph freshness, node count, and edge count |
+| `/gsd graph query <term>` | BFS search for nodes semantically related to `<term>` |
+| `/gsd graph diff` | Show added/removed/changed nodes and edges since last build |
+| `/gsd extract-learnings` | Extract and persist learnings from completed milestone artifacts into `LEARNINGS.md` |
+| `/gsd explore <topic>` | Socratic ideation session — think through a topic with guided questions and produce a structured output |
+| `/gsd eval-review [sliceId]` | Review how well the implementation covers an AI-SPEC — produces a scored `EVAL-REVIEW.md` |
+| `/gsd eval-fix [sliceId]` | Read `EVAL-REVIEW.md` gaps and spawn a fix agent to address `MISSING`/`PARTIAL` coverage |
+| `/gsd review` | Cross-AI peer review of the active milestone plan — invokes external AI CLIs and produces a consensus `REVIEWS.md` |
+
 ## Workflow Templates (v2.42)
 
 | Command | Description |

--- a/src/resources/extensions/gsd/commands/catalog.ts
+++ b/src/resources/extensions/gsd/commands/catalog.ts
@@ -15,7 +15,7 @@ export interface GsdCommandDefinition {
 type CompletionMap = Record<string, readonly GsdCommandDefinition[]>;
 
 export const GSD_COMMAND_DESCRIPTION =
-  "GSD — Get Shit Done: /gsd help|start|templates|next|auto|stop|pause|status|widget|visualize|queue|quick|discuss|capture|triage|dispatch|history|undo|undo-task|reset-slice|rate|skip|export|cleanup|model|mode|prefs|config|keys|hooks|run-hook|skill-health|doctor|logs|forensics|changelog|migrate|remote|steer|knowledge|new-milestone|parallel|cmux|park|unpark|init|setup|inspect|extensions|update|fast|mcp|rethink|codebase|notifications|ship|do|session-report|backlog|pr-branch|add-tests";
+  "GSD — Get Shit Done: /gsd help|start|templates|next|auto|stop|pause|status|widget|visualize|queue|quick|discuss|capture|triage|dispatch|history|undo|undo-task|reset-slice|rate|skip|export|cleanup|model|mode|prefs|config|keys|hooks|run-hook|skill-health|doctor|logs|forensics|changelog|migrate|remote|steer|knowledge|new-milestone|parallel|cmux|park|unpark|init|setup|inspect|extensions|update|fast|mcp|rethink|codebase|notifications|ship|do|session-report|backlog|pr-branch|add-tests|scan|graph|extract-learnings|explore|eval-review|eval-fix|review";
 
 export const TOP_LEVEL_SUBCOMMANDS: readonly GsdCommandDefinition[] = [
   { cmd: "help", desc: "Categorized command reference with descriptions" },
@@ -80,6 +80,13 @@ export const TOP_LEVEL_SUBCOMMANDS: readonly GsdCommandDefinition[] = [
   { cmd: "backlog", desc: "Manage backlog items (add, promote, remove, list)" },
   { cmd: "pr-branch", desc: "Create clean PR branch filtering .gsd/ commits" },
   { cmd: "add-tests", desc: "Generate tests for completed slices" },
+  { cmd: "scan", desc: "Rapid codebase assessment — lightweight alternative to full map (--focus tech|arch|quality|concerns|tech+arch)" },
+  { cmd: "graph", desc: "Knowledge graph — build, query, diff, and inspect semantic relationships across .gsd/ artifacts" },
+  { cmd: "extract-learnings", desc: "Extract and persist learnings from completed milestone artifacts into LEARNINGS.md" },
+  { cmd: "explore", desc: "Socratic ideation session — think through a topic with guided questions" },
+  { cmd: "eval-review", desc: "Review how well the implementation covers an AI-SPEC — produces a scored EVAL-REVIEW.md" },
+  { cmd: "eval-fix", desc: "Read EVAL-REVIEW.md gaps and spawn a fix agent to address MISSING/PARTIAL coverage" },
+  { cmd: "review", desc: "Cross-AI peer review of a milestone plan — invokes external AI CLIs, produces consensus REVIEWS.md" },
 ];
 
 const NESTED_COMPLETIONS: CompletionMap = {

--- a/src/resources/extensions/gsd/tests/commands-catalog-new.test.ts
+++ b/src/resources/extensions/gsd/tests/commands-catalog-new.test.ts
@@ -1,0 +1,34 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  TOP_LEVEL_SUBCOMMANDS,
+  GSD_COMMAND_DESCRIPTION,
+} from "../commands/catalog.js";
+
+const NEW_COMMANDS = [
+  "scan",
+  "graph",
+  "extract-learnings",
+  "explore",
+  "eval-review",
+  "eval-fix",
+  "review",
+] as const;
+
+for (const cmd of NEW_COMMANDS) {
+  test(`catalog: TOP_LEVEL_SUBCOMMANDS contains "${cmd}"`, () => {
+    assert.ok(
+      TOP_LEVEL_SUBCOMMANDS.some((entry) => entry.cmd === cmd),
+      `Expected "${cmd}" in TOP_LEVEL_SUBCOMMANDS`,
+    );
+  });
+
+  test(`catalog: GSD_COMMAND_DESCRIPTION includes "${cmd}"`, () => {
+    assert.ok(
+      GSD_COMMAND_DESCRIPTION.includes(`|${cmd}`) ||
+        GSD_COMMAND_DESCRIPTION.endsWith(`|${cmd}`),
+      `Expected "${cmd}" in GSD_COMMAND_DESCRIPTION pipe list`,
+    );
+  });
+}


### PR DESCRIPTION
## Summary

Several recently added commands were missing from `docs/user-docs/commands.md` and `src/resources/extensions/gsd/commands/catalog.ts` (`/gsd help`). This PR adds them all.

## Changes

**`docs/user-docs/commands.md`** — new **Analysis & Review** section:

| Command | Source |
|---|---|
| `/gsd scan` | #4254 |
| `/gsd graph build/status/query/diff` | #4212 (merged) |
| `/gsd extract-learnings` | #4227 (merged) |
| `/gsd explore` | #4222 |
| `/gsd eval-review` / `/gsd eval-fix` | #4247 |
| `/gsd review` | #4252 |

**`catalog.ts`** — adds all six to `TOP_LEVEL_SUBCOMMANDS` and `GSD_COMMAND_DESCRIPTION` so they appear in `/gsd help`.

> Note: `scan`, `explore`, and `review` carry their own catalog entries in their respective PRs — this PR adds them at the `main` baseline so `/gsd help` is complete regardless of merge order. Any duplicate entries from open PRs will be a one-line conflict to resolve.

## Related

Closes #4255
Follow-up to #4212, #4222, #4227, #4247, #4252, #4254