### PR TITLE
fix(clipboard): support WSLg BMP image paste fallback paths

### DIFF
--- a/packages/pi-coding-agent/src/core/clipboard-image.test.ts
+++ b/packages/pi-coding-agent/src/core/clipboard-image.test.ts
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict";
+import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { delimiter, join } from "node:path";
+import test from "node:test";
+
+import { readClipboardImage } from "../utils/clipboard-image.js";
+
+test(
+	"Wayland BMP clipboard requests PNG transcode via wl-paste first (WSLg regression)",
+	{ skip: process.platform !== "linux" },
+	async (t) => {
+		const tempDir = mkdtempSync(join(tmpdir(), "clipboard-image-test-"));
+		const wlPastePath = join(tempDir, "wl-paste");
+		const logPath = join(tempDir, "wl-paste.log");
+
+		const oldPath = process.env.PATH;
+		const oldLog = process.env.FAKE_WL_LOG_PATH;
+
+		t.after(() => {
+			if (oldPath === undefined) {
+				delete process.env.PATH;
+			} else {
+				process.env.PATH = oldPath;
+			}
+
+			if (oldLog === undefined) {
+				delete process.env.FAKE_WL_LOG_PATH;
+			} else {
+				process.env.FAKE_WL_LOG_PATH = oldLog;
+			}
+
+			rmSync(tempDir, { recursive: true, force: true });
+		});
+
+		const fakeWlPaste = [
+			"#!/usr/bin/env bash",
+			"set -euo pipefail",
+			"printf '%s\\n' \"$*\" >> \"${FAKE_WL_LOG_PATH}\"",
+			"if [ \"${1:-}\" = \"--list-types\" ]; then",
+			"  printf 'image/bmp\\n'",
+			"  exit 0",
+			"fi",
+			"if [ \"${1:-}\" = \"--type\" ] && [ \"${2:-}\" = \"image/png\" ]; then",
+			"  printf 'PNGDATA'",
+			"  exit 0",
+			"fi",
+			"if [ \"${1:-}\" = \"--type\" ] && [ \"${2:-}\" = \"image/bmp\" ]; then",
+			"  printf 'BM'",
+			"  exit 0",
+			"fi",
+			"exit 1",
+		].join("\n");
+
+		writeFileSync(wlPastePath, fakeWlPaste, { encoding: "utf-8" });
+		chmodSync(wlPastePath, 0o755);
+
+		process.env.FAKE_WL_LOG_PATH = logPath;
+		process.env.PATH = [tempDir, oldPath].filter(Boolean).join(delimiter);
+
+		const image = await readClipboardImage({
+			platform: "linux",
+			env: {
+				...process.env,
+				WAYLAND_DISPLAY: "wayland-0",
+				XDG_SESSION_TYPE: "wayland",
+			},
+		});
+
+		const callLog = existsSync(logPath) ? readFileSync(logPath, "utf-8") : "<missing wl-paste log>";
+
+		assert.ok(image, `Expected an image from clipboard. wl-paste log:\n${callLog}`);
+		assert.equal(image.mimeType, "image/png");
+		assert.equal(Buffer.from(image.bytes).toString("utf-8"), "PNGDATA");
+
+		assert.match(callLog, /--list-types/);
+		assert.match(callLog, /--type image\/bmp --no-newline/);
+		assert.match(callLog, /--type image\/png --no-newline/);
+	},
+);

--- a/packages/pi-coding-agent/src/utils/clipboard-image.ts
+++ b/packages/pi-coding-agent/src/utils/clipboard-image.ts
@@ -60,15 +60,33 @@ function isSupportedImageMimeType(mimeType: string): boolean {
 }
 
 /**
- * Convert unsupported image formats to PNG using the native Rust image module.
- * Returns null if conversion fails.
+ * Convert unsupported image formats to PNG.
+ *
+ * Primary path uses native Rust image decoding. For WSLg BMP clipboard payloads,
+ * fall back to ImageMagick when native decoding doesn't support BMP.
  */
-async function convertToPng(bytes: Uint8Array): Promise<Uint8Array | null> {
+async function convertToPng(
+	bytes: Uint8Array,
+	sourceMimeType?: string,
+): Promise<Uint8Array | null> {
 	try {
 		const image = await parseImage(bytes);
 		const pngBytes = await image.encode(ImageFormat.PNG, 100);
 		return new Uint8Array(pngBytes);
 	} catch {
+		if (sourceMimeType && baseMimeType(sourceMimeType) === "image/bmp") {
+			const converted = spawnSync("convert", ["bmp:-", "png:-"], {
+				input: Buffer.from(bytes),
+				timeout: 5000,
+				maxBuffer: DEFAULT_MAX_BUFFER_BYTES,
+			});
+			if (!converted.error && converted.status === 0 && converted.stdout.length > 0) {
+				const stdout = Buffer.isBuffer(converted.stdout)
+					? converted.stdout
+					: Buffer.from(converted.stdout);
+				return new Uint8Array(stdout);
+			}
+		}
 		return null;
 	}
 }
@@ -117,7 +135,15 @@ function readClipboardImageViaWlPaste(): ClipboardImage | null {
 	if (selectedType) {
 		const data = runCommand("wl-paste", ["--type", selectedType, "--no-newline"]);
 		if (data.ok && data.stdout.length > 0) {
-			return { bytes: data.stdout, mimeType: baseMimeType(selectedType) };
+			const selectedBase = baseMimeType(selectedType);
+			if (selectedBase === "image/bmp") {
+				// WSLg often advertises only BMP; ask wl-paste to transcode to PNG first.
+				const pngData = runCommand("wl-paste", ["--type", "image/png", "--no-newline"]);
+				if (pngData.ok && pngData.stdout.length > 0) {
+					return { bytes: pngData.stdout, mimeType: "image/png" };
+				}
+			}
+			return { bytes: data.stdout, mimeType: selectedBase };
 		}
 	}
 
@@ -216,7 +242,7 @@ export async function readClipboardImage(options?: {
 
 	// Convert unsupported formats (e.g., BMP from WSLg) to PNG
 	if (!isSupportedImageMimeType(image.mimeType)) {
-		const pngBytes = await convertToPng(image.bytes);
+		const pngBytes = await convertToPng(image.bytes, image.mimeType);
 		if (!pngBytes) {
 			return null;
 		}


### PR DESCRIPTION
## TL;DR

**What:** Improves Linux Wayland/WSLg clipboard image handling when only `image/bmp` is advertised.
**Why:** In WSLg, `wl-paste --list-types` can return only BMP, and the existing path could fail to produce a usable image for paste.
**How:** Prefer compositor-side transcode (`wl-paste --type image/png`) for BMP-only cases, and keep a BMP decode fallback via conversion when needed.

## What

- Updated `packages/pi-coding-agent/src/utils/clipboard-image.ts` to:
  - attempt PNG fetch when selected MIME type is BMP,
  - pass source MIME type into conversion logic,
  - add BMP-specific `convert bmp:- png:-` fallback when native decode fails.
- Added regression test:
  - `packages/pi-coding-agent/src/core/clipboard-image.test.ts`

## Why

Some Wayland/WSLg environments expose only `image/bmp` for clipboard image content. The prior flow could return `null` in those scenarios, so image paste failed despite valid clipboard data.

Closes #4654
Related: #813

## How

1. Detect BMP in the primary `selectedType` path and request `image/png` from `wl-paste` first.
2. If an unsupported format still reaches conversion, pass `sourceMimeType` and allow BMP-specific ImageMagick fallback.
3. Validate with a regression test that stubs `wl-paste` to BMP-only and asserts PNG transcode request/usage.

## Verification

- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test packages/pi-coding-agent/src/core/clipboard-image.test.ts`
- Result: **pass (1/1)**

## Change type checklist

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Breaking changes

None.

## AI-assisted disclosure

This PR was AI-assisted. I reviewed the diff and verified the behavior with targeted regression testing before opening/updating this PR.

## Note

PR #841 (fix for #813) merged the BMP fallback, but the key fallback block only runs when `!selectedType && hasBmp`.

In common WSLg BMP-only clipboard cases, `selectPreferredImageMimeType(...)` returns `image/bmp`, so `selectedType` is truthy and that fallback never executes.

That leaves the flow dependent on later BMP decoding, which can still fail and return `null` for paste.

This PR fixes that by handling `selectedType === image/bmp` explicitly (request PNG first) and keeping a BMP-aware conversion fallback path.
