### PR TITLE
feat(extensions): add GSDExtensionAPI for .gsd/extensions/ (#3338)

### DIFF
--- a/src/resources/extensions/gsd/bootstrap/register-extension.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-extension.ts
@@ -4,6 +4,8 @@ import type { ExtensionAPI, ExtensionCommandContext } from "@gsd/pi-coding-agent
 
 import { registerExitCommand } from "../exit-command.js";
 import { registerWorktreeCommand } from "../worktree-command.js";
+import type { GSDEcosystemBeforeAgentStartHandler } from "../ecosystem/gsd-extension-api.js";
+import { loadEcosystemExtensions } from "../ecosystem/loader.js";
 import { registerDbTools } from "./db-tools.js";
 import { registerDynamicTools } from "./dynamic-tools.js";
 import { registerJournalTools } from "./journal-tools.js";
@@ -65,6 +67,10 @@ export function registerGsdExtension(pi: ExtensionAPI): void {
 
   installEpipeGuard();
 
+  // Ecosystem handlers captured by the GSDExtensionAPI wrapper for the
+  // GSD-owned `before_agent_start` dispatch step (#3338).
+  const ecosystemHandlers: GSDEcosystemBeforeAgentStartHandler[] = [];
+
   pi.registerCommand("kill", {
     description: "Exit GSD immediately (no cleanup)",
     handler: async (_args: string, _ctx: ExtensionCommandContext) => {
@@ -80,7 +86,15 @@ export function registerGsdExtension(pi: ExtensionAPI): void {
     ["journal-tools", () => registerJournalTools(pi)],
     ["query-tools", () => registerQueryTools(pi)],
     ["shortcuts", () => registerShortcuts(pi)],
-    ["hooks", () => registerHooks(pi)],
+    ["hooks", () => registerHooks(pi, ecosystemHandlers)],
+    ["ecosystem", () => {
+      void loadEcosystemExtensions(pi, ecosystemHandlers).catch((err) => {
+        logWarning(
+          "ecosystem",
+          `loader failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      });
+    }],
   ];
 
   for (const [name, register] of nonCriticalRegistrations) {

--- a/src/resources/extensions/gsd/bootstrap/register-hooks.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-hooks.ts
@@ -3,6 +3,10 @@ import { join } from "node:path";
 import type { ExtensionAPI, ExtensionContext } from "@gsd/pi-coding-agent";
 import { isToolCallEventType } from "@gsd/pi-coding-agent";
 
+import type { GSDEcosystemBeforeAgentStartHandler } from "../ecosystem/gsd-extension-api.js";
+import { updateSnapshot } from "../ecosystem/gsd-extension-api.js";
+import { getEcosystemReadyPromise } from "../ecosystem/loader.js";
+
 import { buildMilestoneFileName, resolveMilestonePath, resolveSliceFile, resolveSlicePath } from "../paths.js";
 import { buildBeforeAgentStartResult } from "./system-context.js";
 import { handleAgentEnd } from "./agent-end-recovery.js";
@@ -35,7 +39,10 @@ async function syncServiceTierStatus(ctx: ExtensionContext): Promise<void> {
   ctx.ui.setStatus("gsd-fast", formatServiceTierFooterStatus(getEffectiveServiceTier(), ctx.model?.id));
 }
 
-export function registerHooks(pi: ExtensionAPI): void {
+export function registerHooks(
+  pi: ExtensionAPI,
+  ecosystemHandlers: GSDEcosystemBeforeAgentStartHandler[],
+): void {
   pi.on("session_start", async (_event, ctx) => {
     initNotificationStore(process.cwd());
     installNotifyInterceptor(ctx);
@@ -93,7 +100,50 @@ export function registerHooks(pi: ExtensionAPI): void {
   });
 
   pi.on("before_agent_start", async (event, ctx: ExtensionContext) => {
-    return buildBeforeAgentStartResult(event, ctx);
+    // Wait for ecosystem loader to finish (no-op after first turn).
+    await getEcosystemReadyPromise();
+
+    // GSD's own context injection (existing behavior — unchanged).
+    const gsdResult = await buildBeforeAgentStartResult(event, ctx);
+
+    // Refresh the snapshot used by ecosystem getPhase()/getActiveUnit().
+    // deriveState has its own ~100ms cache so this is cheap on repeat calls.
+    try {
+      const state = await deriveState(process.cwd());
+      updateSnapshot(state);
+    } catch {
+      updateSnapshot(null);
+    }
+
+    // Chain ecosystem handlers using pi's runner.ts chaining protocol:
+    // each handler sees the systemPrompt mutated by prior handlers.
+    let currentSystemPrompt = gsdResult?.systemPrompt ?? event.systemPrompt;
+    // `any` because pi's BeforeAgentStartEventResult.message uses an internal
+    // CustomMessage type that's not re-exported (see ecosystem/gsd-extension-api.ts).
+    let lastMessage: any = gsdResult?.message;
+
+    for (const handler of ecosystemHandlers) {
+      try {
+        const r = await handler(
+          { ...event, systemPrompt: currentSystemPrompt },
+          ctx,
+        );
+        if (r?.systemPrompt !== undefined) currentSystemPrompt = r.systemPrompt;
+        if (r?.message) lastMessage = r.message;
+      } catch (err) {
+        safetyLogWarning(
+          "ecosystem",
+          `before_agent_start handler failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
+
+    // Compose result. Return undefined if nothing changed (preserves runner contract).
+    if (currentSystemPrompt === event.systemPrompt && !lastMessage) return undefined;
+    return {
+      systemPrompt: currentSystemPrompt !== event.systemPrompt ? currentSystemPrompt : undefined,
+      message: lastMessage,
+    };
   });
 
   pi.on("agent_end", async (event, ctx: ExtensionContext) => {

--- a/src/resources/extensions/gsd/ecosystem/gsd-extension-api.ts
+++ b/src/resources/extensions/gsd/ecosystem/gsd-extension-api.ts
@@ -1,0 +1,228 @@
+// GSD2 — Ecosystem Extension API wrapper
+// Wraps pi's ExtensionAPI to expose typed GSD context (phase + active unit)
+// to extensions loaded from `./.gsd/extensions/`. The wrapper intercepts only
+// `on("before_agent_start", ...)` so GSD can dispatch ecosystem handlers AFTER
+// refreshing state — fixing the load-order race where third-party
+// `.pi/extensions/` handlers see a stale module-level snapshot (#3338).
+//
+// SINGLE-SESSION INVARIANT: the module-level `_snapshot` is per-process.
+// Worktree or project switches do NOT reload extensions, matching pi's
+// `.pi/extensions/` behavior. Only re-launching the CLI rebinds the snapshot.
+
+import type {
+  BeforeAgentStartEvent,
+  ExtensionAPI,
+  ExtensionHandler,
+} from "@gsd/pi-coding-agent";
+
+// Structural mirror of pi's internal BeforeAgentStartEventResult. The internal
+// type is not re-exported from the package root, and constraint #3 forbids
+// changes to packages/pi-coding-agent/, so we mirror the public shape here.
+// `any` on inner fields keeps assignability bidirectional with pi's stricter
+// `Pick<CustomMessage, ...>` shape (CustomMessage is also not re-exported).
+// Source of truth: packages/pi-coding-agent/src/core/extensions/types.ts
+export interface BeforeAgentStartEventResult {
+  message?: {
+    customType: string;
+    content?: any;
+    display?: any;
+    details?: any;
+  };
+  systemPrompt?: string;
+}
+
+import type { GSDActiveUnit, GSDState, Phase } from "../types.js";
+import { isGSDActive, getCurrentPhase } from "../../shared/gsd-phase-state.js";
+import { logWarning } from "../workflow-logger.js";
+
+// ─── Public Interface ───────────────────────────────────────────────────
+
+export interface GSDExtensionAPI extends ExtensionAPI {
+  /** Current GSD workflow phase, or null if no project state. */
+  getPhase(): Phase | null;
+  /** Currently active milestone/slice/task triple, or null if none. */
+  getActiveUnit(): GSDActiveUnit | null;
+}
+
+export type GSDEcosystemBeforeAgentStartHandler = ExtensionHandler<
+  BeforeAgentStartEvent,
+  BeforeAgentStartEventResult
+>;
+
+// ─── Auto-loop phase mapping ────────────────────────────────────────────
+
+const AUTO_LOOP_PHASE_MAP: Record<string, Phase> = {
+  "plan-milestone": "planning",
+  "plan-slice": "planning",
+  "research": "researching",
+  "discuss": "discussing",
+  "execute-task": "executing",
+  "verify": "verifying",
+  "summarize-task": "summarizing",
+  "summarize-slice": "summarizing",
+  "advance": "advancing",
+  "validate-milestone": "validating-milestone",
+  "complete-milestone": "completing-milestone",
+  "replan-slice": "replanning-slice",
+};
+
+/** Exposed for unit tests. Returns null for unknown keys (does NOT default). */
+export function mapAutoLoopPhase(raw: string): Phase | null {
+  return AUTO_LOOP_PHASE_MAP[raw] ?? null;
+}
+
+function resolvePhase(state: GSDState | null): Phase | null {
+  if (!state) return null;
+  if (isGSDActive()) {
+    const raw = getCurrentPhase();
+    if (raw != null) {
+      const mapped = AUTO_LOOP_PHASE_MAP[raw];
+      if (mapped) return mapped;
+      logWarning("ecosystem", `unknown auto-loop phase: ${raw}`);
+      // FALL THROUGH to state.phase rather than defaulting to "executing".
+    }
+  }
+  return state.phase;
+}
+
+function resolveActiveUnit(state: GSDState | null): GSDActiveUnit | null {
+  if (!state) return null;
+  const m = state.activeMilestone;
+  const s = state.activeSlice;
+  const t = state.activeTask;
+  if (!m || !s || !t) return null;
+  return {
+    milestoneId: m.id,
+    milestoneTitle: m.title,
+    sliceId: s.id,
+    sliceTitle: s.title,
+    taskId: t.id,
+    taskTitle: t.title,
+  };
+}
+
+// ─── Module-level snapshot ──────────────────────────────────────────────
+
+interface Snapshot {
+  phase: Phase | null;
+  activeUnit: GSDActiveUnit | null;
+}
+
+let _snapshot: Snapshot = { phase: null, activeUnit: null };
+
+/** Refresh the snapshot from a freshly derived GSDState (or null on failure). */
+export function updateSnapshot(state: GSDState | null): void {
+  _snapshot = {
+    phase: resolvePhase(state),
+    activeUnit: resolveActiveUnit(state),
+  };
+}
+
+export function getSnapshotPhase(): Phase | null {
+  return _snapshot.phase;
+}
+
+export function getSnapshotActiveUnit(): GSDActiveUnit | null {
+  return _snapshot.activeUnit;
+}
+
+/** Test-only: reset the snapshot to its initial empty state. */
+export function _resetSnapshot(): void {
+  _snapshot = { phase: null, activeUnit: null };
+}
+
+// ─── Wrapper factory ────────────────────────────────────────────────────
+
+/**
+ * Build a GSDExtensionAPI by manually delegating every ExtensionAPI method
+ * to the underlying pi instance, except `on("before_agent_start", ...)`
+ * which is captured into `sharedHandlers` for GSD-owned dispatch.
+ *
+ * Uses `satisfies GSDExtensionAPI` (NOT `as`) so TypeScript catches drift
+ * when pi adds new ExtensionAPI methods.
+ */
+export function createGSDExtensionAPI(
+  pi: ExtensionAPI,
+  sharedHandlers: GSDEcosystemBeforeAgentStartHandler[],
+): GSDExtensionAPI {
+  const wrapper = {
+    // ── Event subscription (single intercept point) ────────────────────
+    on(event: any, handler: any): void {
+      if (event === "before_agent_start") {
+        sharedHandlers.push(handler as GSDEcosystemBeforeAgentStartHandler);
+        return;
+      }
+      (pi.on as (e: any, h: any) => void)(event, handler);
+    },
+
+    // ── Event emission ─────────────────────────────────────────────────
+    emitBeforeModelSelect: (...args: Parameters<ExtensionAPI["emitBeforeModelSelect"]>) =>
+      pi.emitBeforeModelSelect(...args),
+    emitAdjustToolSet: (...args: Parameters<ExtensionAPI["emitAdjustToolSet"]>) =>
+      pi.emitAdjustToolSet(...args),
+
+    // ── Tool / command / shortcut / flag registration ──────────────────
+    registerTool: ((tool: any) => pi.registerTool(tool)) as ExtensionAPI["registerTool"],
+    registerCommand: (...args: Parameters<ExtensionAPI["registerCommand"]>) =>
+      pi.registerCommand(...args),
+    registerBeforeInstall: (...args: Parameters<ExtensionAPI["registerBeforeInstall"]>) =>
+      pi.registerBeforeInstall(...args),
+    registerAfterInstall: (...args: Parameters<ExtensionAPI["registerAfterInstall"]>) =>
+      pi.registerAfterInstall(...args),
+    registerBeforeRemove: (...args: Parameters<ExtensionAPI["registerBeforeRemove"]>) =>
+      pi.registerBeforeRemove(...args),
+    registerAfterRemove: (...args: Parameters<ExtensionAPI["registerAfterRemove"]>) =>
+      pi.registerAfterRemove(...args),
+    registerShortcut: (...args: Parameters<ExtensionAPI["registerShortcut"]>) =>
+      pi.registerShortcut(...args),
+    registerFlag: (...args: Parameters<ExtensionAPI["registerFlag"]>) =>
+      pi.registerFlag(...args),
+    getFlag: (...args: Parameters<ExtensionAPI["getFlag"]>) => pi.getFlag(...args),
+
+    // ── Message rendering ──────────────────────────────────────────────
+    registerMessageRenderer: ((customType: string, renderer: any) =>
+      pi.registerMessageRenderer(customType, renderer)) as ExtensionAPI["registerMessageRenderer"],
+
+    // ── Actions ────────────────────────────────────────────────────────
+    sendMessage: ((message: any, options?: any) =>
+      pi.sendMessage(message, options)) as ExtensionAPI["sendMessage"],
+    sendUserMessage: (...args: Parameters<ExtensionAPI["sendUserMessage"]>) =>
+      pi.sendUserMessage(...args),
+    retryLastTurn: () => pi.retryLastTurn(),
+    appendEntry: ((customType: string, data?: any) =>
+      pi.appendEntry(customType, data)) as ExtensionAPI["appendEntry"],
+
+    // ── Session metadata ───────────────────────────────────────────────
+    setSessionName: (...args: Parameters<ExtensionAPI["setSessionName"]>) =>
+      pi.setSessionName(...args),
+    getSessionName: () => pi.getSessionName(),
+    setLabel: (...args: Parameters<ExtensionAPI["setLabel"]>) => pi.setLabel(...args),
+    exec: (...args: Parameters<ExtensionAPI["exec"]>) => pi.exec(...args),
+    getActiveTools: () => pi.getActiveTools(),
+    getAllTools: () => pi.getAllTools(),
+    setActiveTools: (...args: Parameters<ExtensionAPI["setActiveTools"]>) =>
+      pi.setActiveTools(...args),
+    getCommands: () => pi.getCommands(),
+
+    // ── Model & thinking ───────────────────────────────────────────────
+    setModel: (...args: Parameters<ExtensionAPI["setModel"]>) => pi.setModel(...args),
+    getThinkingLevel: () => pi.getThinkingLevel(),
+    setThinkingLevel: (...args: Parameters<ExtensionAPI["setThinkingLevel"]>) =>
+      pi.setThinkingLevel(...args),
+
+    // ── Provider registration ──────────────────────────────────────────
+    registerProvider: (...args: Parameters<ExtensionAPI["registerProvider"]>) =>
+      pi.registerProvider(...args),
+    unregisterProvider: (...args: Parameters<ExtensionAPI["unregisterProvider"]>) =>
+      pi.unregisterProvider(...args),
+
+    // ── Shared event bus (passthrough property) ────────────────────────
+    events: pi.events,
+
+    // ── GSD-specific additions ─────────────────────────────────────────
+    getPhase: (): Phase | null => _snapshot.phase,
+    getActiveUnit: (): GSDActiveUnit | null => _snapshot.activeUnit,
+  } satisfies GSDExtensionAPI;
+
+  return wrapper;
+}

--- a/src/resources/extensions/gsd/ecosystem/loader.ts
+++ b/src/resources/extensions/gsd/ecosystem/loader.ts
@@ -1,0 +1,201 @@
+// GSD2 — Ecosystem extension loader for ./.gsd/extensions/
+// Discovers and registers single-file extensions that consume GSDExtensionAPI.
+// Trust-gated (mirrors pi's `.pi/extensions/` model) and isolated from pi's
+// own loader chain — handlers run in GSD's own dispatch step, not pi's.
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { pathToFileURL } from "node:url";
+
+import type { ExtensionAPI } from "@gsd/pi-coding-agent";
+import { getAgentDir } from "@gsd/pi-coding-agent";
+
+import { logWarning } from "../workflow-logger.js";
+import {
+  createGSDExtensionAPI,
+  type GSDEcosystemBeforeAgentStartHandler,
+  type GSDExtensionAPI,
+} from "./gsd-extension-api.js";
+
+// ─── Trust check (inlined; pi does not export isProjectTrusted from its
+// package root, and constraint forbids modifying packages/pi-coding-agent/) ─
+
+const TRUSTED_PROJECTS_FILE = "trusted-projects.json";
+
+function isProjectTrusted(projectPath: string, agentDir: string): boolean {
+  const canonical = path.resolve(projectPath);
+  const trustedPath = path.join(agentDir, TRUSTED_PROJECTS_FILE);
+  try {
+    const content = fs.readFileSync(trustedPath, "utf-8");
+    const parsed = JSON.parse(content);
+    if (Array.isArray(parsed)) {
+      return parsed.includes(canonical);
+    }
+  } catch {
+    // missing or malformed — treat as untrusted
+  }
+  return false;
+}
+
+// ─── Ready-promise singleton ────────────────────────────────────────────
+
+let _readyPromise: Promise<void> | null = null;
+let _untrustedWarned = false;
+
+/**
+ * Discover and register ecosystem extensions from `./.gsd/extensions/`.
+ * Idempotent: subsequent calls with the same arguments return the same
+ * pending promise (no double-load).
+ */
+export function loadEcosystemExtensions(
+  pi: ExtensionAPI,
+  sharedHandlers: GSDEcosystemBeforeAgentStartHandler[],
+  cwd: string = process.cwd(),
+): Promise<void> {
+  if (_readyPromise) return _readyPromise;
+  _readyPromise = _loadEcosystemExtensionsImpl(pi, sharedHandlers, cwd);
+  return _readyPromise;
+}
+
+/**
+ * Returns a promise that resolves when ecosystem loading has completed.
+ * If loading was never kicked off this returns a resolved promise so the
+ * `before_agent_start` handler can `await` unconditionally.
+ */
+export function getEcosystemReadyPromise(): Promise<void> {
+  return _readyPromise ?? Promise.resolve();
+}
+
+/** Test-only: clear the singleton so tests can re-run loading. */
+export function _resetEcosystemLoader(): void {
+  _readyPromise = null;
+  _untrustedWarned = false;
+}
+
+// ─── Implementation ─────────────────────────────────────────────────────
+
+async function _loadEcosystemExtensionsImpl(
+  pi: ExtensionAPI,
+  sharedHandlers: GSDEcosystemBeforeAgentStartHandler[],
+  cwd: string,
+): Promise<void> {
+  const extDir = path.join(cwd, ".gsd", "extensions");
+  if (!fs.existsSync(extDir)) return;
+
+  // Trust gate: refuse to load arbitrary code from untrusted project dirs.
+  if (!isProjectTrusted(cwd, getAgentDir())) {
+    if (!_untrustedWarned) {
+      _untrustedWarned = true;
+      logWarning(
+        "ecosystem",
+        ".gsd/extensions present but project is not trusted — skipping ecosystem extensions. Run `pi trust` to opt in.",
+      );
+    }
+    return;
+  }
+
+  // Resolve realpath ONCE so symlink-escape detection has a stable anchor.
+  let realExtDir: string;
+  try {
+    realExtDir = fs.realpathSync(extDir);
+  } catch (err) {
+    logWarning(
+      "ecosystem",
+      `failed to resolve extensions dir: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return;
+  }
+
+  let entries: string[];
+  try {
+    entries = fs
+      .readdirSync(extDir)
+      .filter((f) => f.endsWith(".js") || f.endsWith(".ts"))
+      .sort(); // deterministic load order
+  } catch (err) {
+    logWarning(
+      "ecosystem",
+      `failed to read extensions dir: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return;
+  }
+
+  // The wrapper api is built once per loader run and shared by all extensions
+  // so they all read from the same module-level snapshot.
+  const api: GSDExtensionAPI = createGSDExtensionAPI(pi, sharedHandlers);
+
+  for (const entry of entries) {
+    await _loadOne(extDir, realExtDir, entry, api);
+  }
+}
+
+async function _loadOne(
+  extDir: string,
+  realExtDir: string,
+  entry: string,
+  api: GSDExtensionAPI,
+): Promise<void> {
+  const fullPath = path.join(extDir, entry);
+
+  // Symlink-escape guard: reject entries whose realpath is not under realExtDir.
+  let realFullPath: string;
+  try {
+    realFullPath = fs.realpathSync(fullPath);
+  } catch (err) {
+    logWarning(
+      "ecosystem",
+      `failed to resolve ${entry}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return;
+  }
+  const realExtDirWithSep = realExtDir.endsWith(path.sep) ? realExtDir : realExtDir + path.sep;
+  if (
+    realFullPath !== realExtDir &&
+    !realFullPath.startsWith(realExtDirWithSep)
+  ) {
+    logWarning("ecosystem", `rejecting ${entry}: realpath escapes extensions dir`);
+    return;
+  }
+
+  // For .ts files, require a sibling compiled .js — we do not run a TS loader
+  // in production. Drop mtime heuristics: if .js exists, prefer it; otherwise warn.
+  let importPath = realFullPath;
+  if (entry.endsWith(".ts")) {
+    const jsSibling = realFullPath.slice(0, -3) + ".js";
+    if (fs.existsSync(jsSibling)) {
+      importPath = jsSibling;
+    } else {
+      logWarning(
+        "ecosystem",
+        `${entry}: TypeScript source has no compiled .js sibling — compile it first`,
+      );
+      return;
+    }
+  }
+
+  let mod: any;
+  try {
+    mod = await import(pathToFileURL(importPath).href);
+  } catch (err) {
+    logWarning(
+      "ecosystem",
+      `failed to import ${entry}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return;
+  }
+
+  const factory = mod?.default;
+  if (typeof factory !== "function") {
+    logWarning("ecosystem", `${entry}: default export is not a function`);
+    return;
+  }
+
+  try {
+    await factory(api);
+  } catch (err) {
+    logWarning(
+      "ecosystem",
+      `factory threw for ${entry}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}

--- a/src/resources/extensions/gsd/tests/health-widget.test.ts
+++ b/src/resources/extensions/gsd/tests/health-widget.test.ts
@@ -198,7 +198,7 @@ test("session_start bootstraps the health widget alongside notifications", async
     },
   } as any;
 
-  registerHooks(pi);
+  registerHooks(pi, []);
   const sessionStart = handlers.get("session_start");
   assert.ok(sessionStart, "session_start handler is registered");
 

--- a/src/resources/extensions/gsd/tests/register-hooks-depth-verification.test.ts
+++ b/src/resources/extensions/gsd/tests/register-hooks-depth-verification.test.ts
@@ -41,7 +41,7 @@ test("register-hooks unlocks milestone depth verification from question id witho
     },
   } as any;
 
-  registerHooks(pi);
+  registerHooks(pi, []);
 
   const questionId = "depth_verification_M001_confirm";
   const questions = [

--- a/src/resources/extensions/gsd/types.ts
+++ b/src/resources/extensions/gsd/types.ts
@@ -253,6 +253,19 @@ export interface GSDState {
   lastCompletedMilestone?: ActiveRef | null;
 }
 
+// ─── GSD Ecosystem Extension API Types ────────────────────────────────────
+// Pure data type — no runtime deps. The GSDExtensionAPI interface itself
+// lives in ecosystem/gsd-extension-api.ts (it imports from pi).
+
+export interface GSDActiveUnit {
+  milestoneId: string;
+  milestoneTitle: string;
+  sliceId: string;
+  sliceTitle: string;
+  taskId: string;
+  taskTitle: string;
+}
+
 // ─── Post-Unit Hook Types ─────────────────────────────────────────────────
 
 export interface PostUnitHookConfig {

--- a/src/resources/extensions/gsd/workflow-logger.ts
+++ b/src/resources/extensions/gsd/workflow-logger.ts
@@ -53,7 +53,8 @@ export type LogComponent =
   | "guided"        // Guided flow (discuss, plan wizards)
   | "registry"      // Rule registry hook state
   | "renderer"      // Markdown renderer and projections
-  | "safety";       // LLM safety harness
+  | "safety"        // LLM safety harness
+  | "ecosystem";    // GSD ecosystem extension loader and dispatch
 
 export interface LogEntry {
   ts: string;

--- a/src/tests/ecosystem-extensions.test.ts
+++ b/src/tests/ecosystem-extensions.test.ts
@@ -1,0 +1,228 @@
+// GSD2 — Tests for the ecosystem extension wrapper (#3338)
+// Covers: AUTO_LOOP_PHASE_MAP behavior, before_agent_start interception,
+// snapshot reads, and a key-drift guard against pi's ExtensionAPI surface.
+
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+
+import {
+  _resetSnapshot,
+  createGSDExtensionAPI,
+  type GSDEcosystemBeforeAgentStartHandler,
+  getSnapshotActiveUnit,
+  getSnapshotPhase,
+  mapAutoLoopPhase,
+  updateSnapshot,
+} from "../resources/extensions/gsd/ecosystem/gsd-extension-api.js";
+import type { GSDState } from "../resources/extensions/gsd/types.js";
+
+// ─── Test fixtures ──────────────────────────────────────────────────────
+
+function buildPiStub(): {
+  pi: any;
+  onCalls: Array<{ event: string; handler: unknown }>;
+} {
+  const onCalls: Array<{ event: string; handler: unknown }> = [];
+  const noop = (): void => {};
+  const noopAsync = async (): Promise<undefined> => undefined;
+  const pi = {
+    on: (event: string, handler: unknown): void => {
+      onCalls.push({ event, handler });
+    },
+    emitBeforeModelSelect: noopAsync,
+    emitAdjustToolSet: noopAsync,
+    registerTool: noop,
+    registerCommand: noop,
+    registerBeforeInstall: noop,
+    registerAfterInstall: noop,
+    registerBeforeRemove: noop,
+    registerAfterRemove: noop,
+    registerShortcut: noop,
+    registerFlag: noop,
+    getFlag: () => undefined,
+    registerMessageRenderer: noop,
+    sendMessage: noop,
+    sendUserMessage: noop,
+    retryLastTurn: noop,
+    appendEntry: noop,
+    setSessionName: noop,
+    getSessionName: () => undefined,
+    setLabel: noop,
+    exec: async () => ({ stdout: "", stderr: "", exitCode: 0 }),
+    getActiveTools: () => [],
+    getAllTools: () => [],
+    setActiveTools: noop,
+    getCommands: () => [],
+    setModel: async () => true,
+    getThinkingLevel: () => "off" as const,
+    setThinkingLevel: noop,
+    registerProvider: noop,
+    unregisterProvider: noop,
+    events: {
+      emit: noop,
+      on: () => noop,
+    },
+  };
+  return { pi, onCalls };
+}
+
+function buildState(overrides: Partial<GSDState> = {}): GSDState {
+  return {
+    activeMilestone: { id: "M001", title: "Milestone One" },
+    activeSlice: { id: "S01", title: "Slice One" },
+    activeTask: { id: "T01", title: "Task One" },
+    phase: "executing",
+    recentDecisions: [],
+    blockers: [],
+    nextAction: "",
+    registry: [],
+    ...overrides,
+  };
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────
+
+test("mapAutoLoopPhase returns mapped phase for known keys", () => {
+  assert.equal(mapAutoLoopPhase("plan-milestone"), "planning");
+  assert.equal(mapAutoLoopPhase("plan-slice"), "planning");
+  assert.equal(mapAutoLoopPhase("execute-task"), "executing");
+  assert.equal(mapAutoLoopPhase("verify"), "verifying");
+  assert.equal(mapAutoLoopPhase("summarize-task"), "summarizing");
+  assert.equal(mapAutoLoopPhase("summarize-slice"), "summarizing");
+  assert.equal(mapAutoLoopPhase("advance"), "advancing");
+  assert.equal(mapAutoLoopPhase("validate-milestone"), "validating-milestone");
+  assert.equal(mapAutoLoopPhase("complete-milestone"), "completing-milestone");
+  assert.equal(mapAutoLoopPhase("replan-slice"), "replanning-slice");
+});
+
+test("mapAutoLoopPhase returns null for unknown keys (does not default)", () => {
+  assert.equal(mapAutoLoopPhase("not-a-real-phase"), null);
+  assert.equal(mapAutoLoopPhase(""), null);
+  assert.notEqual(mapAutoLoopPhase("not-a-real-phase"), "executing");
+});
+
+test("createGSDExtensionAPI intercepts before_agent_start", () => {
+  const { pi, onCalls } = buildPiStub();
+  const shared: GSDEcosystemBeforeAgentStartHandler[] = [];
+  const api = createGSDExtensionAPI(pi, shared);
+
+  const handler: GSDEcosystemBeforeAgentStartHandler = async () => undefined;
+  api.on("before_agent_start", handler);
+
+  assert.equal(shared.length, 1);
+  assert.equal(shared[0], handler);
+  assert.equal(onCalls.length, 0, "pi.on should NOT be invoked for before_agent_start");
+});
+
+test("createGSDExtensionAPI delegates non-intercepted events to pi.on", () => {
+  const { pi, onCalls } = buildPiStub();
+  const shared: GSDEcosystemBeforeAgentStartHandler[] = [];
+  const api = createGSDExtensionAPI(pi, shared);
+
+  const handler = (): void => {};
+  api.on("session_start", handler);
+
+  assert.equal(shared.length, 0, "shared handlers should be empty");
+  assert.equal(onCalls.length, 1);
+  assert.equal(onCalls[0].event, "session_start");
+  assert.equal(onCalls[0].handler, handler);
+});
+
+test("getPhase / getActiveUnit read from module snapshot", () => {
+  _resetSnapshot();
+  const { pi } = buildPiStub();
+  const api = createGSDExtensionAPI(pi, []);
+
+  // Initial state: nothing loaded
+  assert.equal(api.getPhase(), null);
+  assert.equal(api.getActiveUnit(), null);
+
+  updateSnapshot(buildState());
+  assert.equal(api.getPhase(), "executing");
+  assert.deepEqual(api.getActiveUnit(), {
+    milestoneId: "M001",
+    milestoneTitle: "Milestone One",
+    sliceId: "S01",
+    sliceTitle: "Slice One",
+    taskId: "T01",
+    taskTitle: "Task One",
+  });
+
+  // Snapshot getters mirror the api methods
+  assert.equal(getSnapshotPhase(), "executing");
+  assert.notEqual(getSnapshotActiveUnit(), null);
+});
+
+test("getActiveUnit returns null when state has no active triple", () => {
+  _resetSnapshot();
+  const { pi } = buildPiStub();
+  const api = createGSDExtensionAPI(pi, []);
+
+  updateSnapshot(buildState({ activeTask: null }));
+  assert.equal(api.getActiveUnit(), null);
+  // Phase still resolves even when active unit is missing
+  assert.equal(api.getPhase(), "executing");
+});
+
+test("updateSnapshot(null) resets both snapshot fields", () => {
+  _resetSnapshot();
+  updateSnapshot(buildState());
+  assert.notEqual(getSnapshotPhase(), null);
+
+  updateSnapshot(null);
+  assert.equal(getSnapshotPhase(), null);
+  assert.equal(getSnapshotActiveUnit(), null);
+});
+
+test("wrapper key-drift guard: every ExtensionAPI method is delegated", () => {
+  // If pi adds a new method to ExtensionAPI and the wrapper isn't updated,
+  // the `satisfies GSDExtensionAPI` check will fail at compile time. This
+  // runtime test catches a different failure: a method becoming a no-op
+  // on the wrapper because the wrapper key doesn't exist.
+  const { pi } = buildPiStub();
+  const api = createGSDExtensionAPI(pi, []);
+
+  const expectedKeys = [
+    "on",
+    "emitBeforeModelSelect",
+    "emitAdjustToolSet",
+    "registerTool",
+    "registerCommand",
+    "registerBeforeInstall",
+    "registerAfterInstall",
+    "registerBeforeRemove",
+    "registerAfterRemove",
+    "registerShortcut",
+    "registerFlag",
+    "getFlag",
+    "registerMessageRenderer",
+    "sendMessage",
+    "sendUserMessage",
+    "retryLastTurn",
+    "appendEntry",
+    "setSessionName",
+    "getSessionName",
+    "setLabel",
+    "exec",
+    "getActiveTools",
+    "getAllTools",
+    "setActiveTools",
+    "getCommands",
+    "setModel",
+    "getThinkingLevel",
+    "setThinkingLevel",
+    "registerProvider",
+    "unregisterProvider",
+    "events",
+    "getPhase",
+    "getActiveUnit",
+  ];
+
+  const wrapperKeys = new Set(Object.keys(api));
+  for (const key of expectedKeys) {
+    assert.ok(
+      wrapperKeys.has(key),
+      `wrapper missing key "${key}" — pi's ExtensionAPI may have drifted`,
+    );
+  }
+});


### PR DESCRIPTION
## Summary
- Adds `GSDExtensionAPI extends ExtensionAPI` with sync `getPhase()` + `getActiveUnit()` for single-file extensions in `./.gsd/extensions/`.
- New ecosystem loader (trust-gated, realpath-escape guarded, alphabetically deterministic, ready-promise singleton) — fully isolated from pi's `.pi/extensions/` chain so no changes to `packages/pi-coding-agent/`.
- Fixes #3338 load-order race: ecosystem `before_agent_start` handlers now run after a fresh `deriveState()` snapshot refresh, instead of seeing a stale module-level cache.

## Design highlights
- `Phase` resolved as `deriveState().phase` overlaid with auto-loop phase from `gsd-phase-state.ts`. Unknown auto-loop keys fall through to `state.phase` + warn (no `"executing"` default).
- Wrapper uses `satisfies GSDExtensionAPI` (not `as`) so TypeScript catches drift when pi adds new ExtensionAPI methods. Backed by a runtime key-drift unit test.
- `BeforeAgentStartEventResult` and `isProjectTrusted` are not re-exported from pi's package root, and constraint forbids modifying pi — so both are mirrored locally (10-line trust check inline; structural type for the result). Documented in code.

## Test plan
- [x] `tsc --noEmit` clean across `tsconfig.json`, `tsconfig.resources.json`, `tsconfig.extensions.json`, `tsconfig.test.json`
- [x] New `src/tests/ecosystem-extensions.test.ts` — 8/8 passing (AUTO_LOOP_PHASE_MAP known/unknown, before_agent_start interception, non-intercepted delegation, snapshot read/reset, key-drift guard)
- [x] Existing tests still pass after `registerHooks` signature change (`health-widget.test.ts`, `register-hooks-depth-verification.test.ts` updated to pass `[]`)
- [ ] Manual smoke: drop `./.gsd/extensions/test-ext.js` exporting `default function(api) { api.on("before_agent_start", () => console.error("phase:", api.getPhase())); }` in a trusted project, run a turn, confirm phase prints fresh.

Closes #3338