### PR TITLE
fix(interactive): preserve chat/tool ordering across Claude MCP rebuild paths

### DIFF
--- a/packages/pi-coding-agent/src/modes/interactive/interactive-mode-ordering.test.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/interactive-mode-ordering.test.ts
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { buildAssistantReplaySegments } from "./interactive-mode.js";
+
+test("buildAssistantReplaySegments preserves tool-first ordering", () => {
+	const segments = buildAssistantReplaySegments([
+		{ type: "toolCall", id: "t1", name: "read", arguments: {} },
+		{ type: "text", text: "Done." },
+	]);
+
+	assert.deepEqual(segments, [
+		{ kind: "tool", contentIndex: 0 },
+		{ kind: "assistant", startIndex: 1, endIndex: 1 },
+	]);
+});
+
+test("buildAssistantReplaySegments preserves interleaved assistant-tool-assistant runs", () => {
+	const segments = buildAssistantReplaySegments([
+		{ type: "text", text: "Let me check." },
+		{ type: "serverToolUse", id: "s1", name: "mcp__fs__glob", input: {} },
+		{ type: "thinking", thinking: "Tool result looks good." },
+		{ type: "text", text: "Here is the answer." },
+	]);
+
+	assert.deepEqual(segments, [
+		{ kind: "assistant", startIndex: 0, endIndex: 0 },
+		{ kind: "tool", contentIndex: 1 },
+		{ kind: "assistant", startIndex: 2, endIndex: 3 },
+	]);
+});
+
+test("buildAssistantReplaySegments ignores non-rendered non-tool blocks", () => {
+	const segments = buildAssistantReplaySegments([
+		{ type: "text", text: "before" },
+		{ type: "webSearchResult", toolUseId: "s1", content: {} },
+		{ type: "text", text: "after" },
+	]);
+
+	assert.deepEqual(segments, [
+		{ kind: "assistant", startIndex: 0, endIndex: 0 },
+		{ kind: "assistant", startIndex: 2, endIndex: 2 },
+	]);
+});

--- a/packages/pi-coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/interactive-mode.ts
@@ -127,6 +127,45 @@ function isExpandable(obj: unknown): obj is Expandable {
 	return typeof obj === "object" && obj !== null && "setExpanded" in obj && typeof obj.setExpanded === "function";
 }
 
+export type AssistantReplaySegment =
+	| { kind: "assistant"; startIndex: number; endIndex: number }
+	| { kind: "tool"; contentIndex: number };
+
+/**
+ * Build replay segments for historical assistant messages so rebuild paths
+ * preserve the original content[] ordering between assistant prose and tools.
+ */
+export function buildAssistantReplaySegments(contentBlocks: Array<any>): AssistantReplaySegment[] {
+	const segments: AssistantReplaySegment[] = [];
+	let runStart = -1;
+
+	for (let i = 0; i < contentBlocks.length; i++) {
+		const block = contentBlocks[i];
+		const isAssistantText = block?.type === "text" || block?.type === "thinking";
+		const isTool = block?.type === "toolCall" || block?.type === "serverToolUse";
+
+		if (isAssistantText) {
+			if (runStart === -1) runStart = i;
+			continue;
+		}
+
+		if (runStart !== -1) {
+			segments.push({ kind: "assistant", startIndex: runStart, endIndex: i - 1 });
+			runStart = -1;
+		}
+
+		if (isTool) {
+			segments.push({ kind: "tool", contentIndex: i });
+		}
+	}
+
+	if (runStart !== -1) {
+		segments.push({ kind: "assistant", startIndex: runStart, endIndex: contentBlocks.length - 1 });
+	}
+
+	return segments;
+}
+
 type CompactionQueuedMessage = {
 	text: string;
 	mode: "steer" | "followUp";
@@ -2201,9 +2240,30 @@ export class InteractiveMode {
 		for (const message of sessionContext.messages) {
 			// Assistant messages need special handling for tool calls
 			if (message.role === "assistant") {
-				this.addMessageToChat(message);
-				// Render tool call components
-				for (const content of message.content) {
+				const hasToolBlocks = message.content.some((c) => c.type === "toolCall" || c.type === "serverToolUse");
+				if (!hasToolBlocks) {
+					this.addMessageToChat(message);
+					continue;
+				}
+
+				const assistantSegments: AssistantMessageComponent[] = [];
+				const replaySegments = buildAssistantReplaySegments(message.content);
+
+				for (const segment of replaySegments) {
+					if (segment.kind === "assistant") {
+						const assistantComponent = new AssistantMessageComponent(
+							message,
+							this.hideThinkingBlock,
+							this.getMarkdownThemeWithSettings(),
+							this.settingsManager.getTimestampFormat(),
+							{ startIndex: segment.startIndex, endIndex: segment.endIndex },
+						);
+						this.chatContainer.addChild(assistantComponent);
+						assistantSegments.push(assistantComponent);
+						continue;
+					}
+
+					const content = message.content[segment.contentIndex];
 					if (content.type === "toolCall") {
 						const component = new ToolExecutionComponent(
 							content.name,
@@ -2259,6 +2319,11 @@ export class InteractiveMode {
 						}
 					}
 				}
+
+				// Match streaming-mode behavior: show metadata once on the final
+				// assistant prose segment for this message.
+				const lastAssistantSegment = assistantSegments[assistantSegments.length - 1];
+				lastAssistantSegment?.setShowMetadata(true);
 			} else if (message.role === "toolResult") {
 				// Match tool results to pending tool components
 				const component = this.pendingTools.get(message.toolCallId);


### PR DESCRIPTION
## TL;DR

What: Fix Claude-code MCP chat ordering/visibility in both streaming and rebuild paths so assistant content does not disappear or jump above tool output.
Why: Users still had to toggle thinking to reveal chat, and rebuild paths could render assistant content before tool output regardless of content order.
How: Keep streaming prune safe for thinking/tool-only windows and render historical assistant/tool segments from content[] in order during rebuild.

## What

This PR includes the full Claude MCP ordering/visibility fix set:
- Streaming path (`chat-controller`)
  - Preserve pre-tool thinking visibility during tool-only windows.
  - Prune provisional pre-tool prose only after post-tool prose exists.
- Rebuild path (`interactive-mode`)
  - Replace assistant-first replay with content-order replay (assistant runs + tool segments interleaved by `content[]` index).
  - Ensure toggle/rebuild behavior keeps the same ordering model used during streaming.
- Thinking readability
  - Cap long reasoning blocks so chat remains visible in claude-code turns.

Added regressions:
- `chat-controller-ordering` coverage for deferred prose pruning and thinking+tool visibility.
- `interactive-mode-ordering` coverage for replay segment ordering used during rebuild.

## Why

Closes #4244.

The previous fix addressed streaming prune behavior but users could still hit incorrect ordering after rebuild/toggle flows (`Ctrl+T`), where assistant content was replayed before tools. That mismatch made chat visibility feel unstable and reintroduced the “hide thinking to see chat” workflow.

## How

Implementation details:
- Added `buildAssistantReplaySegments()` in interactive mode to derive replay segments from assistant message content.
- Updated `renderSessionContext()` to render assistant ranges and tool components in derived order instead of assistant-first.
- Kept metadata on the final assistant replay segment to match streaming behavior.

Validation performed:
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test packages/pi-coding-agent/src/core/chat-controller-ordering.test.ts`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test packages/pi-coding-agent/src/modes/interactive/controllers/chat-controller.test.ts src/tests/assistant-message-thinking-visibility.test.ts`
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test packages/pi-coding-agent/src/modes/interactive/interactive-mode-ordering.test.ts`

## Change type checklist

- [ ] feat — New feature or capability
- [x] fix — Bug fix
- [ ] refactor — Code restructuring (no behavior change)
- [x] test — Adding or updating tests
- [ ] docs — Documentation only
- [ ] chore — Build, CI, or tooling changes

## AI-assisted

This PR is AI-assisted; implementation and tests were reviewed and validated locally before submission.

## Supersedes

Supersedes #4245 with the additional rebuild-path ordering fix.