### PR TITLE
fix: pre-execution notifications, session compaction phases, and abort ordering (#4259, #4258, #4243)

### DIFF
--- a/packages/pi-coding-agent/src/core/agent-session.ts
+++ b/packages/pi-coding-agent/src/core/agent-session.ts
@@ -1558,9 +1558,12 @@ export class AgentSession {
 			}
 		}
 
-		this._disconnectFromAgent();
-		await this.abort();
-		this.agent.reset();
+	// #4243: Must call abort() BEFORE _disconnectFromAgent() so that
+	// message_end/agent_end events fire and the #4216 finalization code
+	// can run before we unsubscribe from the event bus.
+	await this.abort();
+	this._disconnectFromAgent();
+	this.agent.reset();
 		// Update cwd to current process directory — auto-mode may have chdir'd
 		// into a worktree since the original session was created.
 		const previousCwd = this._cwd;
@@ -2411,9 +2414,12 @@ export class AgentSession {
 			}
 		}
 
-		this._disconnectFromAgent();
-		await this.abort();
-		this._steeringMessages = [];
+	// #4243: Must call abort() BEFORE _disconnectFromAgent() so that
+	// message_end/agent_end events fire and the #4216 finalization code
+	// can run before we unsubscribe from the event bus.
+	await this.abort();
+	this._disconnectFromAgent();
+	this._steeringMessages = [];
 		this._followUpMessages = [];
 		this._pendingNextTurnMessages = [];
 

--- a/packages/pi-coding-agent/src/core/chat-controller-ordering.test.ts
+++ b/packages/pi-coding-agent/src/core/chat-controller-ordering.test.ts
@@ -450,6 +450,89 @@ test("chat-controller keeps pre-tool thinking visible for claude-code MCP turns 
 	await handleAgentEvent(host, { type: "message_end", message: makeAssistant([thinkingOnly[0], mcpTool]) } as any);
 });
 
+test("chat-controller keeps pre-tool question text for claude-code MCP when post-tool prose exists", async () => {
+	(globalThis as any)[Symbol.for("@gsd/pi-coding-agent:theme")] = {
+		fg: (_key: string, text: string) => text,
+		bg: (_key: string, text: string) => text,
+		bold: (text: string) => text,
+		italic: (text: string) => text,
+		truncate: (text: string) => text,
+	};
+
+	const host = createHost();
+	host.getMarkdownThemeWithSettings = () => ({});
+
+	const mcpTool = {
+		type: "toolCall",
+		id: "mcp-tool-question-1",
+		name: "glob",
+		mcpServer: "filesystem",
+		arguments: { pattern: "**/*" },
+	};
+
+	await handleAgentEvent(host, { type: "message_start", message: makeAssistant([]) } as any);
+
+	const questionText = { type: "text", text: "Which file should I inspect?" };
+
+	await handleAgentEvent(
+		host,
+		{
+			type: "message_update",
+			message: makeAssistant([questionText]),
+			assistantMessageEvent: {
+				type: "text_delta",
+				contentIndex: 0,
+				delta: questionText.text,
+				partial: makeAssistant([questionText]),
+			},
+		} as any,
+	);
+
+	await handleAgentEvent(
+		host,
+		{
+			type: "message_update",
+			message: makeAssistant([questionText, mcpTool]),
+			assistantMessageEvent: {
+				type: "toolcall_end",
+				contentIndex: 1,
+				toolCall: {
+					...mcpTool,
+					externalResult: {
+						content: [{ type: "text", text: "glob output" }],
+						details: {},
+						isError: false,
+					},
+				},
+				partial: makeAssistant([questionText, mcpTool]),
+			},
+		} as any,
+	);
+
+	const postTool = { type: "text", text: "I'll review that next." };
+	const finalContent = [questionText, mcpTool, postTool];
+	await handleAgentEvent(
+		host,
+		{
+			type: "message_update",
+			message: makeAssistant(finalContent),
+			assistantMessageEvent: {
+				type: "text_delta",
+				contentIndex: 2,
+				delta: postTool.text,
+				partial: makeAssistant(finalContent),
+			},
+		} as any,
+	);
+
+	assert.equal(host.chatContainer.children.length, 3, "question text should remain alongside MCP tool and post-tool prose");
+	assert.equal(host.chatContainer.children[0]?.constructor?.name, "AssistantMessageComponent", "pre-tool question stays visible");
+	assert.equal(host.chatContainer.children[1]?.constructor?.name, "ToolExecutionComponent", "tool renders in the middle");
+	assert.equal(host.chatContainer.children[2]?.constructor?.name, "AssistantMessageComponent", "post-tool prose renders last");
+
+	await handleAgentEvent(host, { type: "message_end", message: makeAssistant(finalContent) } as any);
+});
+
 test("chat-controller prunes orphaned provisional text after claude-code sub-turn shrink when MCP tools appear", async () => {
 	(globalThis as any)[Symbol.for("@gsd/pi-coding-agent:theme")] = {
 		fg: (_key: string, text: string) => text,

--- a/packages/pi-coding-agent/src/core/chat-controller-ordering.test.ts
+++ b/packages/pi-coding-agent/src/core/chat-controller-ordering.test.ts
@@ -234,6 +234,64 @@ test("chat-controller renders serverToolUse before trailing text matching conten
 	assert.equal(host.chatContainer.children[1]?.constructor?.name, "AssistantMessageComponent");
 });
 
+test("chat-controller replays final message_end content when result adds unstreamed trailing text", async () => {
+	(globalThis as any)[Symbol.for("@gsd/pi-coding-agent:theme")] = {
+		fg: (_key: string, text: string) => text,
+		bg: (_key: string, text: string) => text,
+		bold: (text: string) => text,
+		italic: (text: string) => text,
+		truncate: (text: string) => text,
+	};
+
+	const host = createHost();
+	host.getMarkdownThemeWithSettings = () => ({});
+
+	const tool = {
+		type: "toolCall",
+		id: "mcp-end-replay-1",
+		name: "read",
+		mcpServer: "filesystem",
+		arguments: { filePath: "/tmp/demo.txt" },
+	};
+
+	await handleAgentEvent(host, { type: "message_start", message: makeAssistant([]) } as any);
+
+	const streamedContent = [
+		tool,
+		{ type: "thinking", thinking: "I am analyzing tool output..." },
+	];
+	await handleAgentEvent(
+		host,
+		{
+			type: "message_update",
+			message: makeAssistant(streamedContent),
+			assistantMessageEvent: {
+				type: "thinking_delta",
+				contentIndex: 1,
+				delta: "I am analyzing tool output...",
+				partial: makeAssistant(streamedContent),
+			},
+		} as any,
+	);
+
+	assert.equal(host.chatContainer.children.length, 2, "streaming shows tool + thinking only");
+	assert.equal(host.chatContainer.children[0]?.constructor?.name, "ToolExecutionComponent");
+	assert.equal(host.chatContainer.children[1]?.constructor?.name, "AssistantMessageComponent");
+
+	// Final payload includes trailing text that never arrived as message_update.
+	const finalContent = [
+		tool,
+		{ type: "thinking", thinking: "I am analyzing tool output..." },
+		{ type: "text", text: "Correct anything important I missed?" },
+	];
+	await handleAgentEvent(host, { type: "message_end", message: makeAssistant(finalContent) } as any);
+
+	assert.equal(host.chatContainer.children.length, 3, "message_end should replay and include trailing text segment");
+	assert.equal(host.chatContainer.children[0]?.constructor?.name, "ToolExecutionComponent");
+	assert.equal(host.chatContainer.children[1]?.constructor?.name, "AssistantMessageComponent");
+	assert.equal(host.chatContainer.children[2]?.constructor?.name, "AssistantMessageComponent");
+});
+
 test("chat-controller keeps pre-tool prose visible until post-tool prose arrives, then prunes it", async () => {
 	(globalThis as any)[Symbol.for("@gsd/pi-coding-agent:theme")] = {
 		fg: (_key: string, text: string) => text,
@@ -487,6 +545,138 @@ test("chat-controller prunes orphaned provisional text after claude-code sub-tur
 		} as any,
 	);
 	assert.equal(host.chatContainer.children.length, 2);
+	assert.equal(host.chatContainer.children[0]?.constructor?.name, "ToolExecutionComponent");
+	assert.equal(host.chatContainer.children[1]?.constructor?.name, "AssistantMessageComponent");
+
+	await handleAgentEvent(host, { type: "message_end", message: makeAssistant(finalContent) } as any);
+});
+
+test("chat-controller prunes orphans from multiple sub-turn shrinks before MCP post-tool prose", async () => {
+	(globalThis as any)[Symbol.for("@gsd/pi-coding-agent:theme")] = {
+		fg: (_key: string, text: string) => text,
+		bg: (_key: string, text: string) => text,
+		bold: (text: string) => text,
+		italic: (text: string) => text,
+		truncate: (text: string) => text,
+	};
+
+	const host = createHost();
+	host.getMarkdownThemeWithSettings = () => ({});
+
+	const mcpTool = {
+		type: "toolCall",
+		id: "mcp-tool-multi-shrink-1",
+		name: "glob",
+		mcpServer: "filesystem",
+		arguments: { pattern: "**/*" },
+	};
+
+	await handleAgentEvent(host, { type: "message_start", message: makeAssistant([]) } as any);
+
+	// Sub-turn 1: 3 text blocks (merged into one text-run).
+	const subTurn1 = [
+		{ type: "text", text: "First provisional A." },
+		{ type: "text", text: "First provisional B." },
+		{ type: "text", text: "First provisional C." },
+	];
+	await handleAgentEvent(
+		host,
+		{
+			type: "message_update",
+			message: makeAssistant(subTurn1),
+			assistantMessageEvent: {
+				type: "text_delta",
+				contentIndex: 2,
+				delta: "First provisional C.",
+				partial: makeAssistant(subTurn1),
+			},
+		} as any,
+	);
+	assert.equal(host.chatContainer.children.length, 1, "first sub-turn renders 1 text-run");
+
+	// Sub-turn 2 (first shrink 3 → 2 blocks).
+	const subTurn2 = [
+		{ type: "text", text: "Second provisional A." },
+		{ type: "text", text: "Second provisional B." },
+	];
+	await handleAgentEvent(
+		host,
+		{
+			type: "message_update",
+			message: makeAssistant(subTurn2),
+			assistantMessageEvent: {
+				type: "text_delta",
+				contentIndex: 1,
+				delta: "Second provisional B.",
+				partial: makeAssistant(subTurn2),
+			},
+		} as any,
+	);
+	assert.equal(host.chatContainer.children.length, 2, "first shrink appends, keeps prior text as frozen history");
+
+	// Sub-turn 3 (second shrink 2 → 1 block). This is the critical step —
+	// without orphan accumulation, sub-turn 1's orphaned segment would be
+	// dropped from tracking here and later strand in the container.
+	const subTurn3 = [{ type: "text", text: "Third provisional." }];
+	await handleAgentEvent(
+		host,
+		{
+			type: "message_update",
+			message: makeAssistant(subTurn3),
+			assistantMessageEvent: {
+				type: "text_delta",
+				contentIndex: 0,
+				delta: "Third provisional.",
+				partial: makeAssistant(subTurn3),
+			},
+		} as any,
+	);
+	assert.equal(host.chatContainer.children.length, 3, "second shrink appends again, still no prune (no post-tool text)");
+
+	// MCP tool appears — tool-only window still keeps provisional prose visible.
+	await handleAgentEvent(
+		host,
+		{
+			type: "message_update",
+			message: makeAssistant([{ type: "text", text: "Third provisional." }, mcpTool]),
+			assistantMessageEvent: {
+				type: "toolcall_end",
+				contentIndex: 1,
+				toolCall: {
+					...mcpTool,
+					externalResult: {
+						content: [{ type: "text", text: "glob output" }],
+						details: {},
+						isError: false,
+					},
+				},
+				partial: makeAssistant([{ type: "text", text: "Third provisional." }, mcpTool]),
+			},
+		} as any,
+	);
+	assert.equal(host.chatContainer.children.length, 4, "tool-only window keeps all three provisional text-runs");
+
+	// Final post-tool text arrives — prune must drop ALL three pre-tool
+	// provisional text-runs across both shrinks, leaving only tool + final text.
+	const finalContent = [mcpTool, { type: "text", text: "Final answer." }];
+	await handleAgentEvent(
+		host,
+		{
+			type: "message_update",
+			message: makeAssistant(finalContent),
+			assistantMessageEvent: {
+				type: "text_delta",
+				contentIndex: 1,
+				delta: "Final answer.",
+				partial: makeAssistant(finalContent),
+			},
+		} as any,
+	);
+	assert.equal(
+		host.chatContainer.children.length,
+		2,
+		"all pre-tool provisional segments from every shrink must be pruned once post-tool prose arrives",
+	);
 	assert.equal(host.chatContainer.children[0]?.constructor?.name, "ToolExecutionComponent");
 	assert.equal(host.chatContainer.children[1]?.constructor?.name, "AssistantMessageComponent");
 

--- a/packages/pi-coding-agent/src/modes/interactive/controllers/chat-controller.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/controllers/chat-controller.ts
@@ -348,7 +348,6 @@ export async function handleAgentEvent(host: InteractiveModeStateHost & {
 				let runStart = -1;
 				let runEnd = -1;
 				let runType: "text" | "thinking" | undefined;
-				const QUESTION_PROSE_MAX_LEN = 120;
 				const closeRun = () => {
 					if (runStart !== -1 && runType) {
 						desired.push({ kind: "text-run", startIndex: runStart, endIndex: runEnd, contentType: runType });
@@ -365,13 +364,11 @@ export async function handleAgentEvent(host: InteractiveModeStateHost & {
 					// For Claude Code MCP turns, prune only pre-tool prose, never thinking.
 					const textValue = blockType === "text" && typeof b?.text === "string" ? b.text : "";
 					const isLikelyQuestion = blockType === "text" && typeof textValue === "string" && /\?\s*$/.test(textValue.trim());
-					const isShortProse = blockType === "text" && typeof textValue === "string" && textValue.trim().length > 0 && textValue.trim().length <= QUESTION_PROSE_MAX_LEN;
 					const shouldSkipProse = shouldDropPreToolProse
 						&& firstToolIdx >= 0
 						&& i < firstToolIdx
 						&& blockType === "text"
-						&& !isLikelyQuestion
-						&& !isShortProse;
+						&& !isLikelyQuestion;
 					if (shouldSkipProse) {
 						closeRun();
 						continue;

--- a/packages/pi-coding-agent/src/modes/interactive/controllers/chat-controller.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/controllers/chat-controller.ts
@@ -238,7 +238,10 @@ export async function handleAgentEvent(host: InteractiveModeStateHost & {
 				// content (#4144 regression). Prior sub-turn children stay in
 				// chatContainer as frozen history; new segments append after them.
 				if (contentBlocks.length < lastContentLength) {
-					orphanedSegments = [...renderedSegments];
+					// Accumulate across successive shrinks — overwriting would drop
+					// segments displaced by an earlier shrink, leaving them stranded
+					// in chatContainer once the prune pass finally runs.
+					orphanedSegments = [...orphanedSegments, ...renderedSegments];
 					renderedSegments = [];
 					lastPinnedText = "";
 					lastProcessedContentIndex = 0;
@@ -553,11 +556,11 @@ export async function handleAgentEvent(host: InteractiveModeStateHost & {
 			}
 			break;
 
-		case "message_end":
-			if (event.message.role === "user") break;
-			if (event.message.role === "assistant") {
-				host.streamingMessage = event.message;
-				let errorMessage: string | undefined;
+			case "message_end":
+				if (event.message.role === "user") break;
+				if (event.message.role === "assistant") {
+					host.streamingMessage = event.message;
+					let errorMessage: string | undefined;
 				if (host.streamingMessage.stopReason === "aborted") {
 					const retryAttempt = host.session.retryAttempt;
 					errorMessage = retryAttempt > 0
@@ -566,15 +569,141 @@ export async function handleAgentEvent(host: InteractiveModeStateHost & {
 					host.streamingMessage.errorMessage = errorMessage;
 				}
 
-				const shouldRenderAssistant = hasVisibleAssistantContent(host.streamingMessage)
-					|| (
-						(host.streamingMessage.stopReason === "aborted" || host.streamingMessage.stopReason === "error")
-						&& !hasAssistantToolBlocks(host.streamingMessage)
-					);
-				if (!host.streamingComponent && shouldRenderAssistant) {
-					host.streamingComponent = new AssistantMessageComponent(
-						undefined,
-						host.hideThinkingBlock,
+					const shouldRenderAssistant = hasVisibleAssistantContent(host.streamingMessage)
+						|| (
+							(host.streamingMessage.stopReason === "aborted" || host.streamingMessage.stopReason === "error")
+							&& !hasAssistantToolBlocks(host.streamingMessage)
+						);
+
+					// The final message_end payload can contain additional text/thinking
+					// blocks that never arrived via message_update (e.g. SDK result
+					// aggregation). Rebuild this in-flight turn from final content so
+					// ranges/components don't keep stale partial indices.
+					if (renderedSegments.length > 0) {
+						const finalBlocks = host.streamingMessage.content;
+						type DesiredSegment =
+							| { kind: "text-run"; startIndex: number; endIndex: number; contentType: "text" | "thinking" }
+							| { kind: "tool"; contentIndex: number; toolId: string };
+						const desired: DesiredSegment[] = [];
+						let runStart = -1;
+						let runEnd = -1;
+						let runType: "text" | "thinking" | undefined;
+						const closeRun = () => {
+							if (runStart !== -1 && runType) {
+								desired.push({ kind: "text-run", startIndex: runStart, endIndex: runEnd, contentType: runType });
+								runStart = -1;
+								runEnd = -1;
+								runType = undefined;
+							}
+						};
+
+						for (let i = 0; i < finalBlocks.length; i++) {
+							const block = finalBlocks[i] as any;
+							const blockType = block?.type === "text" || block?.type === "thinking" ? block.type : undefined;
+							const isTextLike = blockType === "text" || blockType === "thinking";
+							const isTool = block?.type === "toolCall" || block?.type === "serverToolUse";
+
+							if (isTextLike) {
+								if (runStart === -1) {
+									runStart = i;
+									runEnd = i;
+									runType = blockType;
+								} else if (runType !== blockType) {
+									closeRun();
+									runStart = i;
+									runEnd = i;
+									runType = blockType;
+								} else {
+									runEnd = i;
+								}
+							} else {
+								closeRun();
+								if (isTool) {
+									desired.push({ kind: "tool", contentIndex: i, toolId: block.id });
+								}
+							}
+						}
+						closeRun();
+
+						const toolComponentsById = new Map<string, ToolExecutionComponent>();
+						for (const [toolId, component] of host.pendingTools.entries()) {
+							toolComponentsById.set(toolId, component);
+						}
+
+						for (const seg of renderedSegments) {
+							host.chatContainer.removeChild(seg.component);
+							if (seg.kind === "tool") {
+								const priorBlocks = host.streamingMessage.content;
+								const priorBlock = priorBlocks[seg.contentIndex] as any;
+								if (priorBlock?.id && !toolComponentsById.has(priorBlock.id)) {
+									toolComponentsById.set(priorBlock.id, seg.component);
+								}
+							}
+						}
+						renderedSegments = [];
+						host.streamingComponent = undefined;
+
+						for (const seg of desired) {
+							if (seg.kind === "tool") {
+								const finalBlock = finalBlocks[seg.contentIndex] as any;
+								let component = toolComponentsById.get(seg.toolId);
+								if (!component && finalBlock?.id) {
+									component = host.pendingTools.get(finalBlock.id);
+								}
+								if (!component && finalBlock?.type === "toolCall") {
+									component = new ToolExecutionComponent(
+										finalBlock.name,
+										finalBlock.arguments,
+										{ showImages: host.settingsManager.getShowImages() },
+										host.getRegisteredToolDefinition(finalBlock.name),
+										host.ui,
+									);
+									component.setExpanded(host.toolOutputExpanded);
+									host.pendingTools.set(finalBlock.id, component);
+									toolComponentsById.set(finalBlock.id, component);
+								} else if (!component && finalBlock?.type === "serverToolUse") {
+									component = new ToolExecutionComponent(
+										finalBlock.name,
+										finalBlock.input ?? {},
+										{ showImages: host.settingsManager.getShowImages() },
+										undefined,
+										host.ui,
+									);
+									component.setExpanded(host.toolOutputExpanded);
+									host.pendingTools.set(finalBlock.id, component);
+									toolComponentsById.set(finalBlock.id, component);
+								}
+								if (component) {
+									host.chatContainer.addChild(component);
+									renderedSegments.push({ kind: "tool", contentIndex: seg.contentIndex, component });
+								}
+								continue;
+							}
+
+							const comp = new AssistantMessageComponent(
+								undefined,
+								host.hideThinkingBlock,
+								host.getMarkdownThemeWithSettings(),
+								host.settingsManager.getTimestampFormat(),
+								{ startIndex: seg.startIndex, endIndex: seg.endIndex },
+							);
+							comp.updateContent(host.streamingMessage);
+							host.chatContainer.addChild(comp);
+							renderedSegments.push({
+								kind: "text-run",
+								startIndex: seg.startIndex,
+								endIndex: seg.endIndex,
+								contentType: seg.contentType,
+								component: comp,
+							});
+							host.streamingComponent = comp;
+						}
+					}
+
+					if (!host.streamingComponent && shouldRenderAssistant) {
+						host.streamingComponent = new AssistantMessageComponent(
+							undefined,
+							host.hideThinkingBlock,
 						host.getMarkdownThemeWithSettings(),
 						host.settingsManager.getTimestampFormat(),
 					);

--- a/packages/pi-coding-agent/src/modes/interactive/controllers/chat-controller.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/controllers/chat-controller.ts
@@ -344,29 +344,38 @@ export async function handleAgentEvent(host: InteractiveModeStateHost & {
 					type DesiredSegment =
 						| { kind: "text-run"; startIndex: number; endIndex: number; contentType: "text" | "thinking" }
 						| { kind: "tool"; contentIndex: number; toolId: string };
-					const desired: DesiredSegment[] = [];
-					let runStart = -1;
-					let runEnd = -1;
-					let runType: "text" | "thinking" | undefined;
-					const closeRun = () => {
-						if (runStart !== -1 && runType) {
-							desired.push({ kind: "text-run", startIndex: runStart, endIndex: runEnd, contentType: runType });
-							runStart = -1;
-							runEnd = -1;
-							runType = undefined;
+				const desired: DesiredSegment[] = [];
+				let runStart = -1;
+				let runEnd = -1;
+				let runType: "text" | "thinking" | undefined;
+				const QUESTION_PROSE_MAX_LEN = 120;
+				const closeRun = () => {
+					if (runStart !== -1 && runType) {
+						desired.push({ kind: "text-run", startIndex: runStart, endIndex: runEnd, contentType: runType });
+						runStart = -1;
+						runEnd = -1;
+						runType = undefined;
 						}
 					};
-					for (let i = 0; i < blocks.length; i++) {
-						const b = blocks[i];
-						const blockType = b.type === "text" || b.type === "thinking" ? b.type : undefined;
-						const isTextLike = blockType === "text" || blockType === "thinking";
-						const isTool = b.type === "toolCall" || b.type === "serverToolUse";
-						// For Claude Code MCP turns, prune only pre-tool prose, never thinking.
-						const shouldSkipProse = shouldDropPreToolProse && firstToolIdx >= 0 && i < firstToolIdx && blockType === "text";
-						if (shouldSkipProse) {
-							closeRun();
-							continue;
-						}
+				for (let i = 0; i < blocks.length; i++) {
+					const b = blocks[i];
+					const blockType = b.type === "text" || b.type === "thinking" ? b.type : undefined;
+					const isTextLike = blockType === "text" || blockType === "thinking";
+					const isTool = b.type === "toolCall" || b.type === "serverToolUse";
+					// For Claude Code MCP turns, prune only pre-tool prose, never thinking.
+					const textValue = blockType === "text" && typeof b?.text === "string" ? b.text : "";
+					const isLikelyQuestion = blockType === "text" && typeof textValue === "string" && /\?\s*$/.test(textValue.trim());
+					const isShortProse = blockType === "text" && typeof textValue === "string" && textValue.trim().length > 0 && textValue.trim().length <= QUESTION_PROSE_MAX_LEN;
+					const shouldSkipProse = shouldDropPreToolProse
+						&& firstToolIdx >= 0
+						&& i < firstToolIdx
+						&& blockType === "text"
+						&& !isLikelyQuestion
+						&& !isShortProse;
+					if (shouldSkipProse) {
+						closeRun();
+						continue;
+					}
 						if (isTextLike) {
 							if (runStart === -1) {
 								runStart = i;

--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -1121,11 +1121,15 @@ export async function postUnitPostVerification(pctx: PostUnitContext): Promise<"
           });
         }
 
-        // Notify UI
+        // Notify UI — surface actionable details (#4259)
         if (result.status === "fail") {
-          const blockingCount = result.checks.filter(c => !c.passed && c.blocking).length;
+          const blockingChecks = result.checks.filter(c => !c.passed && c.blocking);
+          const blockingCount = blockingChecks.length;
+          const details = blockingChecks.slice(0, 3).map(c => `  \u2022 ${c.message}`).join("\n");
+          const suffix = blockingChecks.length > 3 ? `\n  \u2022 ...and ${blockingChecks.length - 3} more` : "";
+          const evidenceNote = `\nSee ${sid}-PRE-EXEC-VERIFY.json for full details.`;
           ctx.ui.notify(
-            `Pre-execution checks failed: ${blockingCount} blocking issue${blockingCount === 1 ? "" : "s"} found`,
+            `Pre-execution checks failed: ${blockingCount} blocking issue${blockingCount === 1 ? "" : "s"} found\n${details}${suffix}${evidenceNote}`,
             "error",
           );
           preExecPauseNeeded = true;

--- a/src/resources/extensions/gsd/bootstrap/register-hooks.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-hooks.ts
@@ -125,7 +125,10 @@ export function registerHooks(pi: ExtensionAPI): void {
     await ensureDbOpen();
     const state = await deriveState(basePath);
     if (!state.activeMilestone || !state.activeSlice || !state.activeTask) return;
-    if (state.phase !== "executing") return;
+    // Write checkpoint for ALL phases, not just "executing" — discuss, research,
+    // and planning also carry in-memory state (user answers, gate verification)
+    // that would be lost on compaction (#4258).
+    // if (state.phase !== "executing") return;
 
     const sliceDir = resolveSlicePath(basePath, state.activeMilestone.id, state.activeSlice.id);
     if (!sliceDir) return;


### PR DESCRIPTION
## Summary

Three independent bug fixes for issues found via dry-run cross-reference of open issues vs merged PRs:

---

### fix(gsd): expand pre-execution check notification with details + evidence path (#4259)

**File:** `src/resources/extensions/gsd/auto-post-unit.ts`

Pre-execution blocking checks were showing only a count (e.g. '3 blocking issues found') without revealing what the checks were or where to find full evidence.

- Filter `result.checks` for blocking failures and surface up to 3 check messages in the notification
- Append the evidence file path (`<sid>-PRE-EXEC-VERIFY.json>`) so users can inspect full results

---

### fix(gsd): checkpoint all session phases during compaction, not just executing (#4258)

**File:** `src/resources/extensions/gsd/bootstrap/register-hooks.ts`

The `session_before_compact` hook was gated on `if (state.phase !== 'executing') return;` — meaning only the executing phase was checkpointed. Non-executing phases (discuss, research, planning) carry in-memory state (user answers, gate verification) that was being lost on compaction.

- Remove the phase guard so all phases write a CONTINUE checkpoint before compaction

---

### fix(agent-session): call abort() before _disconnectFromAgent() in newSession/resumeSession (#4243)

**File:** `packages/pi-coding-agent/src/core/agent-session.ts`

In both `newSession()` and `resumeSession()`, the order was:
1. `_disconnectFromAgent()` — unsubscribes from event bus
2. `await this.abort()` — fires `message_end`/`agent_end` events

Since `_disconnectFromAgent()` runs first, the abort events had no subscribers and the #4216 finalization code never executed.

- Swap to: `await this.abort()` first, then `_disconnectFromAgent()` — so finalization events fire before we unsubscribe

---

### Testing

All three fixes are localized and have minimal blast radius. The #4243 fix should be verified by triggering a newSession or resumeSession and confirming message finalization events fire correctly.