### PR TITLE
fix(agent-session): call abort() before _disconnectFromAgent() in newSession/resumeSession (#4243)

### DIFF
--- a/packages/pi-coding-agent/src/core/agent-session-abort-order.test.ts
+++ b/packages/pi-coding-agent/src/core/agent-session-abort-order.test.ts
@@ -1,0 +1,56 @@
+import test, { describe } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const source = readFileSync(
+	join(process.cwd(), "packages/pi-coding-agent/src/core/agent-session.ts"),
+	"utf-8",
+);
+
+describe("#4243 — abort() must be called before _disconnectFromAgent()", () => {
+	test("newSession() calls abort() before _disconnectFromAgent()", () => {
+		// Find the newSession method body where the fix was applied
+		const newSessionStart = source.indexOf("async newSession(options?:");
+		assert.ok(newSessionStart >= 0, "should find newSession method");
+
+		// Get a window that includes the abort/disconnect section
+		const window = source.slice(newSessionStart, newSessionStart + 1200);
+
+		// Find the abort and _disconnectFromAgent calls
+		const abortIdx = window.indexOf("await this.abort();");
+		const disconnectIdx = window.indexOf("this._disconnectFromAgent();");
+
+		assert.ok(abortIdx >= 0, "newSession should call await this.abort()");
+		assert.ok(disconnectIdx >= 0, "newSession should call this._disconnectFromAgent()");
+		assert.ok(
+			abortIdx < disconnectIdx,
+			"abort() must be called BEFORE _disconnectFromAgent() so that message_end/agent_end events fire before unsubscribing from the event bus",
+		);
+	});
+
+	test("newSession() references #4243 in the abort/disconnect comment", () => {
+		const idx = source.indexOf("#4243");
+		assert.ok(idx >= 0, "source should reference issue #4243 for the abort-order fix");
+	});
+
+	test("switchSession() calls abort() before _disconnectFromAgent()", () => {
+		// Find the switchSession method body
+		const switchStart = source.indexOf("async switchSession(sessionPath:");
+		assert.ok(switchStart >= 0, "should find switchSession method");
+
+		// Get a window that includes the abort/disconnect section
+		const window = source.slice(switchStart, switchStart + 800);
+
+		// Find the abort and _disconnectFromAgent calls
+		const abortIdx = window.indexOf("await this.abort();");
+		const disconnectIdx = window.indexOf("this._disconnectFromAgent();");
+
+		assert.ok(abortIdx >= 0, "switchSession should call await this.abort()");
+		assert.ok(disconnectIdx >= 0, "switchSession should call this._disconnectFromAgent()");
+		assert.ok(
+			abortIdx < disconnectIdx,
+			"abort() must be called BEFORE _disconnectFromAgent() in switchSession so that events fire before unsubscribing",
+		);
+	});
+});

--- a/packages/pi-coding-agent/src/core/agent-session.ts
+++ b/packages/pi-coding-agent/src/core/agent-session.ts
@@ -1558,9 +1558,12 @@ export class AgentSession {
 			}
 		}
 
-		this._disconnectFromAgent();
-		await this.abort();
-		this.agent.reset();
+	// #4243: Must call abort() BEFORE _disconnectFromAgent() so that
+	// message_end/agent_end events fire and the #4216 finalization code
+	// can run before we unsubscribe from the event bus.
+	await this.abort();
+	this._disconnectFromAgent();
+	this.agent.reset();
 		// Update cwd to current process directory — auto-mode may have chdir'd
 		// into a worktree since the original session was created.
 		const previousCwd = this._cwd;
@@ -2411,9 +2414,12 @@ export class AgentSession {
 			}
 		}
 
-		this._disconnectFromAgent();
-		await this.abort();
-		this._steeringMessages = [];
+	// #4243: Must call abort() BEFORE _disconnectFromAgent() so that
+	// message_end/agent_end events fire and the #4216 finalization code
+	// can run before we unsubscribe from the event bus.
+	await this.abort();
+	this._disconnectFromAgent();
+	this._steeringMessages = [];
 		this._followUpMessages = [];
 		this._pendingNextTurnMessages = [];
 


### PR DESCRIPTION
## Fixes #4243

In both `newSession()` and `resumeSession()`, the order of operations was:

1. `_disconnectFromAgent()` — unsubscribes from the event bus
2. `await this.abort()` — fires `message_end`/`agent_end` events

Since `_disconnectFromAgent()` runs first, the abort events had no subscribers and the #4216 finalization code never executed, leaving streaming components in an inconsistent state.

### Changes
- In both `newSession()` and `resumeSession()` (switchSession), swap the order so `await this.abort()` runs first, then `_disconnectFromAgent()`
- This ensures message finalization events fire and the #4216 handler runs before we unsubscribe from the event bus

### Testing
Trigger a `newSession` or `resumeSession` and verify that message finalization events (message_end, agent_end) fire correctly before disconnection.