### PR TITLE
fix(ollama): UI behavior - theme color, keypress dismiss, render+handleInput pattern

### DIFF
--- a/src/resources/extensions/ollama/ollama-commands-ui.test.ts
+++ b/src/resources/extensions/ollama/ollama-commands-ui.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Regression tests for ollama-commands.ts UI behavior fixes:
+ * - Theme color: "fg" replaced with "text" token
+ * - Keypress dismiss: handleInput used instead of setTimeout instant-dismiss
+ * - Overlay pattern: { render, handleInput, invalidate } structure
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const src = readFileSync(join(__dirname, "ollama-commands.ts"), "utf-8");
+
+test("ollama-commands uses 'text' theme token, not deprecated 'fg'", () => {
+  assert.ok(
+    !src.includes('"fg"'),
+    "Color token 'fg' is deprecated; use 'text' instead"
+  );
+});
+
+test("ollama-commands overlay dismissed via handleInput keypress, not setTimeout", () => {
+  assert.ok(
+    !src.includes("setTimeout"),
+    "Instant-dismiss via setTimeout removed; overlay must wait for keypress via handleInput"
+  );
+  assert.ok(
+    src.includes("handleInput"),
+    "handleInput must be present for keypress-dismiss behavior"
+  );
+});
+
+test("ollama-commands overlay uses render + handleInput + invalidate pattern", () => {
+  const hasRender      = src.includes("render");
+  const hasHandleInput = src.includes("handleInput");
+  const hasInvalidate  = src.includes("invalidate");
+  assert.ok(
+    hasRender && hasHandleInput && hasInvalidate,
+    "Overlay must use { render, handleInput, invalidate } pattern"
+  );
+});

--- a/src/resources/extensions/ollama/ollama-commands.ts
+++ b/src/resources/extensions/ollama/ollama-commands.ts
@@ -12,7 +12,6 @@
  */
 
 import type { ExtensionAPI } from "@gsd/pi-coding-agent";
-import { Text } from "@gsd/pi-tui";
 import * as client from "./ollama-client.js";
 import { discoverModels, formatModelForDisplay } from "./ollama-discovery.js";
 import { formatModelSize } from "./model-capabilities.js";
@@ -100,10 +99,18 @@ async function handleStatus(ctx: any): Promise<void> {
 	}
 
 	await ctx.ui.custom(
-		(tui: any, theme: any, _kb: any, done: (r: undefined) => void) => {
-			const text = new Text(lines.map((l) => theme.fg("fg", l)).join("\n"), 0, 0);
-			setTimeout(() => done(undefined), 0);
-			return text;
+		(_tui: any, theme: any, _kb: any, done: (r: undefined) => void) => {
+			function handleInput(_data: string) {
+				done(undefined);
+			}
+			function render(width: number): string[] {
+				return [
+					...lines.map((l) => theme.fg("text", l)),
+					"",
+					theme.fg("dim", " Press any key to dismiss"),
+				];
+			}
+			return { render, handleInput, invalidate: () => {} };
 		},
 	);
 }
@@ -127,10 +134,14 @@ async function handleList(ctx: any): Promise<void> {
 	}
 
 	await ctx.ui.custom(
-		(tui: any, theme: any, _kb: any, done: (r: undefined) => void) => {
-			const text = new Text(lines.map((l) => theme.fg("fg", l)).join("\n"), 0, 0);
-			setTimeout(() => done(undefined), 0);
-			return text;
+		(_tui: any, theme: any, _kb: any, done: (r: undefined) => void) => {
+			function handleInput(_data: string) {
+				done(undefined);
+			}
+			function render(width: number): string[] {
+				return lines.map((l) => theme.fg("text", l));
+			}
+			return { render, handleInput, invalidate: () => {} };
 		},
 	);
 }
@@ -233,10 +244,14 @@ async function handlePs(ctx: any): Promise<void> {
 		}
 
 		await ctx.ui.custom(
-			(tui: any, theme: any, _kb: any, done: (r: undefined) => void) => {
-				const text = new Text(lines.map((l) => theme.fg("fg", l)).join("\n"), 0, 0);
-				setTimeout(() => done(undefined), 0);
-				return text;
+			(_tui: any, theme: any, _kb: any, done: (r: undefined) => void) => {
+				function handleInput(_data: string) {
+					done(undefined);
+				}
+				function render(width: number): string[] {
+					return lines.map((l) => theme.fg("text", l));
+				}
+				return { render, handleInput, invalidate: () => {} };
 			},
 		);
 	} catch (err) {


### PR DESCRIPTION
Extracts the still-relevant ollama-commands.ts delta from #3425 as recommended by @tosoyn.

Changes:
- `ollama-commands.ts`: replace deprecated `fg` color token with `text`
- `ollama-commands.ts`: replace instant setTimeout dismiss with handleInput keypress-dismiss
- `ollama-commands.ts`: use `{ render, handleInput, invalidate }` overlay pattern

Regression tests:
- `ollama-commands-ui.test.ts`: 3 tests, all passing ✅

Note: slash-command routing and Ollama provider registration are already covered in main — this PR touches only the UI behavior change that was not yet merged.

Supersedes #3425 (UI portion only)

Closes #4564