### PR TITLE
fix(web): add claude-code ExternalCli provider to onboarding catalog

### DIFF
--- a/src/tests/integration/web-mode-assembled.test.ts
+++ b/src/tests/integration/web-mode-assembled.test.ts
@@ -352,6 +352,7 @@ test("assembled lifecycle: boot → onboard → prompt → streaming text → to
     authStorage,
     getEnvApiKey: () => undefined,
     validateApiKey: async () => ({ ok: true, message: "openai credentials validated" }),
+    isExternalCliProvider: () => false,
   });
 
   t.after(async () => {

--- a/src/tests/integration/web-mode-onboarding.test.ts
+++ b/src/tests/integration/web-mode-onboarding.test.ts
@@ -302,6 +302,7 @@ test("successful browser onboarding restarts the stale bridge child and unlocks 
   onboarding.configureOnboardingServiceForTests({
     authStorage,
     getEnvApiKey: () => undefined,
+    isExternalCliProvider: () => false,
     validateApiKey: async () => ({ ok: true, message: "openai credentials validated" }),
   });
 
@@ -370,6 +371,7 @@ test("refresh failures keep the workspace locked and expose the failed bridge-re
   onboarding.configureOnboardingServiceForTests({
     authStorage,
     getEnvApiKey: () => undefined,
+    isExternalCliProvider: () => false,
     validateApiKey: async () => ({ ok: true, message: "openai credentials validated" }),
   });
 

--- a/src/tests/integration/web-mode-onboarding.test.ts
+++ b/src/tests/integration/web-mode-onboarding.test.ts
@@ -451,6 +451,7 @@ test("fresh gsd --web browser onboarding stays locked on failed validation and u
     browserLogPath,
     env: {
       GSD_WEB_TEST_FAKE_API_KEY_VALIDATION: "1",
+      GSD_WEB_TEST_DISABLE_EXTERNAL_CLI: "1",
       ANTHROPIC_API_KEY: "",
       OPENAI_API_KEY: "",
       GOOGLE_API_KEY: "",

--- a/src/tests/integration/web-onboarding-contract.test.ts
+++ b/src/tests/integration/web-onboarding-contract.test.ts
@@ -309,7 +309,7 @@ test("boot and onboarding routes expose locked required state plus explicitly sk
   clearOnboardingEnv();
   const authStorage = AuthStorage.inMemory({});
   configureBridgeFixture(fixture, "sess-missing-auth");
-  onboarding.configureOnboardingServiceForTests({ authStorage, getEnvApiKey: noEnvApiKey });
+  onboarding.configureOnboardingServiceForTests({ authStorage, getEnvApiKey: noEnvApiKey, isExternalCliProvider: () => false });
 
   t.after(async () => {
     onboarding.resetOnboardingServiceForTests();
@@ -345,6 +345,7 @@ test("boot and onboarding routes expose locked required state plus explicitly sk
     "xai",
     "openrouter",
     "mistral",
+    "claude-code",
   ]);
   const anthropicProvider = bootPayload.onboarding.required.providers.find((provider: any) => provider.id === "anthropic");
   assert.equal(anthropicProvider.supports.apiKey, true);
@@ -406,6 +407,7 @@ test("failed API-key validation stays locked, redacts the error, and is reflecte
   onboarding.configureOnboardingServiceForTests({
     authStorage,
     getEnvApiKey: noEnvApiKey,
+    isExternalCliProvider: () => false,
     validateApiKey: async () => ({
       ok: false,
       message: "OpenAI rejected the provided key because Bearer invalid-demo-key is invalid",
@@ -456,7 +458,7 @@ test("direct prompt commands cannot bypass onboarding while required setup is st
   clearOnboardingEnv();
   const authStorage = AuthStorage.inMemory({});
   const harness = configureBridgeFixture(fixture, "sess-command-locked");
-  onboarding.configureOnboardingServiceForTests({ authStorage, getEnvApiKey: noEnvApiKey });
+  onboarding.configureOnboardingServiceForTests({ authStorage, getEnvApiKey: noEnvApiKey, isExternalCliProvider: () => false });
 
   t.after(async () => {
     onboarding.resetOnboardingServiceForTests();
@@ -602,7 +604,7 @@ test("logout_provider removes saved auth, refreshes the bridge, and relocks onbo
     openai: { type: "api_key", key: "sk-saved-logout" },
   } as any);
   const harness = configureBridgeFixture(fixture, "sess-logout-success");
-  onboarding.configureOnboardingServiceForTests({ authStorage, getEnvApiKey: noEnvApiKey });
+  onboarding.configureOnboardingServiceForTests({ authStorage, getEnvApiKey: noEnvApiKey, isExternalCliProvider: () => false });
 
   t.after(async () => {
     onboarding.resetOnboardingServiceForTests();
@@ -690,4 +692,117 @@ test("logout_provider fails clearly for environment-backed auth that the browser
   assert.equal(logoutPayload.onboarding.locked, false);
   assert.equal(logoutPayload.onboarding.required.satisfiedBy.providerId, "github-copilot");
   assert.equal(logoutPayload.onboarding.required.satisfiedBy.source, "environment");
+});
+
+test("claude-code ExternalCli provider is recognized as configured and unlocks onboarding", async (t) => {
+  const fixture = makeWorkspaceFixture();
+  clearOnboardingEnv();
+  const authStorage = AuthStorage.inMemory({});
+  configureBridgeFixture(fixture, "sess-claude-code-extcli");
+  onboarding.configureOnboardingServiceForTests({
+    authStorage,
+    getEnvApiKey: noEnvApiKey,
+  });
+
+  t.after(async () => {
+    onboarding.resetOnboardingServiceForTests();
+    await bridge.resetBridgeServiceForTests();
+    restoreOnboardingEnv();
+    fixture.cleanup();
+  });
+
+  const bootResponse = await bootRoute.GET(projectRequest(fixture.projectCwd, "/api/boot"));
+  assert.equal(bootResponse.status, 200);
+  const bootPayload = (await bootResponse.json()) as any;
+
+  assert.equal(
+    bootPayload.onboardingNeeded,
+    false,
+    "onboardingNeeded must be false when only claude-code is present",
+  );
+  assert.equal(bootPayload.onboarding.locked, false);
+  assert.equal(bootPayload.onboarding.lockReason, null);
+  assert.equal(bootPayload.onboarding.required.satisfied, true);
+  assert.deepEqual(bootPayload.onboarding.required.satisfiedBy, {
+    providerId: "claude-code",
+    source: "external_cli",
+  });
+
+  const claudeCodeProvider = bootPayload.onboarding.required.providers.find(
+    (provider: any) => provider.id === "claude-code",
+  );
+  assert.ok(claudeCodeProvider, "claude-code must appear in the providers list");
+  assert.equal(claudeCodeProvider.configured, true);
+  assert.equal(claudeCodeProvider.configuredVia, "external_cli");
+  assert.equal(claudeCodeProvider.supports.externalCli, true);
+  assert.equal(claudeCodeProvider.supports.apiKey, false);
+  assert.equal(claudeCodeProvider.supports.oauth, false);
+  assert.equal(claudeCodeProvider.recommended, true);
+});
+
+test("validateAndSaveApiKey throws for claude-code because supportsApiKey is false", async (t) => {
+  const fixture = makeWorkspaceFixture();
+  clearOnboardingEnv();
+  const authStorage = AuthStorage.inMemory({});
+  configureBridgeFixture(fixture, "sess-claude-code-validate-apikey");
+  onboarding.configureOnboardingServiceForTests({
+    authStorage,
+    getEnvApiKey: noEnvApiKey,
+    isExternalCliProvider: (id) => id === "claude-code",
+  });
+
+  t.after(async () => {
+    onboarding.resetOnboardingServiceForTests();
+    await bridge.resetBridgeServiceForTests();
+    restoreOnboardingEnv();
+    fixture.cleanup();
+  });
+
+  const response = await onboardingRoute.POST(
+    projectRequest(fixture.projectCwd, "/api/onboarding", {
+      method: "POST",
+      body: JSON.stringify({
+        action: "save_api_key",
+        providerId: "claude-code",
+        apiKey: "somekey",
+      }),
+    }),
+  );
+
+  assert.equal(response.status, 400);
+  const payload = (await response.json()) as any;
+  assert.match(payload.error, /browser sign-in|does not support/i);
+});
+
+test("logoutProvider throws for claude-code because configuredVia is external_cli not auth_file", async (t) => {
+  const fixture = makeWorkspaceFixture();
+  clearOnboardingEnv();
+  const authStorage = AuthStorage.inMemory({});
+  configureBridgeFixture(fixture, "sess-claude-code-logout");
+  onboarding.configureOnboardingServiceForTests({
+    authStorage,
+    getEnvApiKey: noEnvApiKey,
+    isExternalCliProvider: (id) => id === "claude-code",
+  });
+
+  t.after(async () => {
+    onboarding.resetOnboardingServiceForTests();
+    await bridge.resetBridgeServiceForTests();
+    restoreOnboardingEnv();
+    fixture.cleanup();
+  });
+
+  const response = await onboardingRoute.POST(
+    projectRequest(fixture.projectCwd, "/api/onboarding", {
+      method: "POST",
+      body: JSON.stringify({
+        action: "logout_provider",
+        providerId: "claude-code",
+      }),
+    }),
+  );
+
+  assert.equal(response.status, 400);
+  const payload = (await response.json()) as any;
+  assert.match(payload.error, /cannot be logged out from the browser surface/i);
 });

--- a/src/web/onboarding-service.ts
+++ b/src/web/onboarding-service.ts
@@ -10,6 +10,7 @@ type RequiredProviderCatalogEntry = {
   label: string;
   supportsApiKey: boolean;
   supportsOAuth: boolean;
+  supportsExternalCli?: boolean;
   recommended?: boolean;
 };
 
@@ -39,9 +40,10 @@ type OnboardingServiceDeps = {
   createFlowId?: () => string;
   getEnvApiKey?: GetEnvApiKeyFn;
   refreshBridgeAuth?: () => Promise<void>;
+  isExternalCliProvider?: (providerId: string) => boolean;
 };
 
-export type OnboardingCredentialSource = "auth_file" | "environment" | "runtime";
+export type OnboardingCredentialSource = "auth_file" | "environment" | "runtime" | "external_cli";
 export type OnboardingValidationStatus = "succeeded" | "failed";
 export type OnboardingFlowStatus =
   | "idle"
@@ -66,6 +68,7 @@ export interface OnboardingProviderState {
     oauth: boolean;
     oauthAvailable: boolean;
     usesCallbackServer: boolean;
+    externalCli: boolean;
   };
 }
 
@@ -141,6 +144,17 @@ type ProviderFlowRuntime = {
   abortController: AbortController;
 };
 
+/**
+ * Ordered catalog of required AI providers shown in the onboarding wizard.
+ *
+ * **Precedence contract:** `satisfiedBy` is set to the first *configured*
+ * provider in this list. Reordering entries changes which provider wins when
+ * multiple are configured simultaneously — do so intentionally.
+ *
+ * ExternalCli providers (those with `supportsExternalCli: true`) are always
+ * treated as configured by the onboarding service regardless of auth-file
+ * contents, so placing them higher in the list gives them higher precedence.
+ */
 const REQUIRED_PROVIDER_CATALOG: RequiredProviderCatalogEntry[] = [
   { id: "anthropic", label: "Anthropic (Claude)", supportsApiKey: true, supportsOAuth: false, recommended: true },
   { id: "openai", label: "OpenAI", supportsApiKey: true, supportsOAuth: false },
@@ -153,6 +167,7 @@ const REQUIRED_PROVIDER_CATALOG: RequiredProviderCatalogEntry[] = [
   { id: "xai", label: "xAI (Grok)", supportsApiKey: true, supportsOAuth: false },
   { id: "openrouter", label: "OpenRouter", supportsApiKey: true, supportsOAuth: false },
   { id: "mistral", label: "Mistral", supportsApiKey: true, supportsOAuth: false },
+  { id: "claude-code", label: "Claude Code (Local CLI)", supportsApiKey: false, supportsOAuth: false, supportsExternalCli: true, recommended: true },
 ];
 
 const OPTIONAL_SECTION_CATALOG: OptionalSectionCatalogEntry[] = [
@@ -182,6 +197,25 @@ const OPTIONAL_SECTION_CATALOG: OptionalSectionCatalogEntry[] = [
     ],
   },
 ];
+
+/**
+ * ExternalCli providers authenticate through a local CLI tool rather than
+ * storing credentials in GSD. They are always treated as "configured" by the
+ * onboarding service — if the binary is missing, inference will fail at
+ * runtime (the correct place to surface that error).
+ *
+ * **Sync requirement:** This set must stay in sync with `CLI_AUTH_PROVIDERS`
+ * in `src/resources/extensions/gsd/doctor-providers.ts`. If a new ExternalCli
+ * provider is added to one set but not the other, onboarding will silently
+ * mis-classify it (treating it as unconfigured or vice-versa).
+ */
+const CLI_AUTH_PROVIDER_IDS = new Set([
+  "claude-code",
+]);
+
+function defaultIsExternalCliProvider(id: string): boolean {
+  return CLI_AUTH_PROVIDER_IDS.has(id);
+}
 
 let onboardingServiceOverrides: Partial<OnboardingServiceDeps> | null = null;
 let onboardingServiceSingleton: OnboardingService | null = null;
@@ -242,7 +276,13 @@ function resolveCredentialSource(
   authStorage: AuthStorageInstance,
   providerId: string,
   getEnvApiKeyFn: GetEnvApiKeyFn,
+  isExternalCliProviderFn: (id: string) => boolean,
 ): OnboardingCredentialSource | null {
+  // ExternalCli providers authenticate through a local CLI — no credentials
+  // are stored in GSD. Treat them as always configured.
+  if (isExternalCliProviderFn(providerId)) {
+    return "external_cli";
+  }
   if (hasStoredCredentialValue(authStorage, providerId)) {
     return "auth_file";
   }
@@ -658,10 +698,11 @@ export class OnboardingService {
     getEnvApiKeyFn: GetEnvApiKeyFn,
   ): OnboardingProviderState[] {
     const oauthProviders = new Map(authStorage.getOAuthProviders().map((provider) => [provider.id, provider]));
+    const isExternalCliProviderFn = this.deps.isExternalCliProvider ?? defaultIsExternalCliProvider;
 
     return REQUIRED_PROVIDER_CATALOG.map((provider) => {
       const oauthProvider = oauthProviders.get(provider.id);
-      const configuredVia = resolveCredentialSource(authStorage, provider.id, getEnvApiKeyFn);
+      const configuredVia = resolveCredentialSource(authStorage, provider.id, getEnvApiKeyFn, isExternalCliProviderFn);
       return {
         id: provider.id,
         label: oauthProvider?.name ?? provider.label,
@@ -674,6 +715,7 @@ export class OnboardingService {
           oauth: provider.supportsOAuth,
           oauthAvailable: provider.supportsOAuth ? Boolean(oauthProvider) : false,
           usesCallbackServer: Boolean(oauthProvider?.usesCallbackServer),
+          externalCli: Boolean(provider.supportsExternalCli),
         },
       };
     });

--- a/src/web/onboarding-service.ts
+++ b/src/web/onboarding-service.ts
@@ -418,6 +418,13 @@ async function defaultValidateApiKey(
   }
 }
 
+function resolveRuntimeTestIsExternalCliProvider(env: NodeJS.ProcessEnv): OnboardingServiceDeps["isExternalCliProvider"] | undefined {
+  if (env.GSD_WEB_TEST_DISABLE_EXTERNAL_CLI !== "1") {
+    return undefined;
+  }
+  return () => false;
+}
+
 function resolveRuntimeTestValidateApiKey(env: NodeJS.ProcessEnv): OnboardingServiceDeps["validateApiKey"] | undefined {
   if (env.GSD_WEB_TEST_FAKE_API_KEY_VALIDATION !== "1") {
     return undefined;
@@ -448,6 +455,7 @@ function getOnboardingDeps(): OnboardingServiceDeps {
     now: () => new Date(),
     createFlowId: () => randomUUID(),
     validateApiKey: resolveRuntimeTestValidateApiKey(process.env),
+    isExternalCliProvider: resolveRuntimeTestIsExternalCliProvider(process.env),
     refreshBridgeAuth: onboardingBridgeAuthRefresher ?? undefined,
     ...(onboardingServiceOverrides ?? {}),
   };

--- a/web/components/gsd/onboarding/step-authenticate.tsx
+++ b/web/components/gsd/onboarding/step-authenticate.tsx
@@ -111,9 +111,11 @@ export function StepAuthenticate({
 
   const isBusy = requestState !== "idle"
   const isThisProviderBusy = requestProviderId === provider.id && isBusy
+  const isExternalCli = provider.supports.externalCli
   const isValidated = lastValidation?.status === "succeeded" && lastValidation.providerId === provider.id
   const isBridgeDone = bridgeRefreshPhase === "succeeded" || bridgeRefreshPhase === "idle"
-  const canProceed = isValidated && isBridgeDone
+  // ExternalCli providers are always configured — no key validation step.
+  const canProceed = (isExternalCli && provider.configured) || (isValidated && isBridgeDone)
   const validationFailed = lastValidation?.status === "failed" && lastValidation.providerId === provider.id
   const parsedError = validationFailed ? parseValidationError(lastValidation.message) : null
 
@@ -163,11 +165,13 @@ export function StepAuthenticate({
         <p className="mt-2 max-w-sm text-sm leading-relaxed text-muted-foreground">
           {canProceed
             ? "Authenticated and ready to go."
-            : hasApiKey && hasOAuth
-              ? "Paste an API key or sign in through your browser."
-              : hasApiKey
-                ? "Paste your API key to authenticate."
-                : "Sign in through your browser to authenticate."}
+            : isExternalCli
+              ? "Authentication is handled by the Claude CLI. Make sure it is installed and signed in."
+              : hasApiKey && hasOAuth
+                ? "Paste an API key or sign in through your browser."
+                : hasApiKey
+                  ? "Paste your API key to authenticate."
+                  : "Sign in through your browser to authenticate."}
         </p>
       </motion.div>
 

--- a/web/components/gsd/onboarding/step-provider.tsx
+++ b/web/components/gsd/onboarding/step-provider.tsx
@@ -23,6 +23,7 @@ function capabilityBadges(provider: WorkspaceOnboardingProviderState): string[] 
   if (provider.supports.apiKey) badges.push("API key")
   if (provider.supports.oauth)
     badges.push(provider.supports.oauthAvailable ? "Browser sign-in" : "OAuth unavailable")
+  if (provider.supports.externalCli) badges.push("CLI auth")
   return badges
 }
 
@@ -31,6 +32,7 @@ function configuredViaLabel(source: WorkspaceOnboardingProviderState["configured
     case "auth_file": return "Saved auth"
     case "environment": return "Environment variable"
     case "runtime": return "Runtime"
+    case "external_cli": return "CLI"
     default: return "Not configured"
   }
 }
@@ -147,7 +149,9 @@ export function StepProvider({ providers, selectedId, onSelect, onNext, onBack }
                               ? "Enter an API key to authenticate"
                               : cap === "Browser sign-in"
                                 ? "Authenticate through your browser"
-                                : "This auth method is not available"}
+                                : cap === "CLI auth"
+                                  ? "Authenticated via local CLI — no API key needed"
+                                  : "This auth method is not available"}
                           </TooltipContent>
                         </Tooltip>
                       ))}

--- a/web/lib/gsd-workspace-store.tsx
+++ b/web/lib/gsd-workspace-store.tsx
@@ -195,12 +195,13 @@ export interface WorkspaceOnboardingProviderState {
   required: true
   recommended: boolean
   configured: boolean
-  configuredVia: "auth_file" | "environment" | "runtime" | null
+  configuredVia: "auth_file" | "environment" | "runtime" | "external_cli" | null
   supports: {
     apiKey: boolean
     oauth: boolean
     oauthAvailable: boolean
     usesCallbackServer: boolean
+    externalCli: boolean
   }
 }
 
@@ -258,7 +259,7 @@ export interface WorkspaceOnboardingState {
     blocking: true
     skippable: false
     satisfied: boolean
-    satisfiedBy: { providerId: string; source: "auth_file" | "environment" | "runtime" } | null
+    satisfiedBy: { providerId: string; source: "auth_file" | "environment" | "runtime" | "external_cli" } | null
     providers: WorkspaceOnboardingProviderState[]
   }
   optional: {


### PR DESCRIPTION
## TL;DR

**What:** Adds `claude-code` (ExternalCli) as a recognized provider in the web UI onboarding wizard.
**Why:** Users with only a Claude Code subscription (no Anthropic API key) were permanently blocked at setup step 1 in `gsd --web`.
**How:** Add `claude-code` to `REQUIRED_PROVIDER_CATALOG` with a new `supportsExternalCli` path that bypasses API-key/OAuth credential checks.

## What

Changed files:
- `src/web/onboarding-service.ts` — core fix: catalog entry, `"external_cli"` credential source, injectable dep for test isolation
- `web/lib/gsd-workspace-store.tsx` — browser-side type parity
- `web/components/gsd/onboarding/step-provider.tsx` — `"CLI auth"` badge with correct tooltip
- `web/components/gsd/onboarding/step-authenticate.tsx` — `canProceed` short-circuits for ExternalCli (no `lastValidation` required)
- `src/tests/integration/web-onboarding-contract.test.ts` — regression test + `logoutProvider`/`validateAndSaveApiKey` coverage
- `src/tests/integration/web-mode-onboarding.test.ts` — test isolation fix

## Why

`REQUIRED_PROVIDER_CATALOG` had no `claude-code` entry. `resolveCredentialSource()` only checked API-key storage and env vars — neither applies to `authMode: "externalCli"` providers. Result: `satisfiedByProvider = null` → `lockReason = "required_setup"` → web UI permanently blocked.

The TUI already handled this correctly via `CLI_AUTH_PROVIDERS` in `doctor-providers.ts`. This fix brings the web onboarding surface to parity.

Closes #4271

## How

- Added `supportsExternalCli?: boolean` to `RequiredProviderCatalogEntry` and `externalCli: boolean` to `OnboardingProviderState.supports`
- Added `"external_cli"` to `OnboardingCredentialSource` union
- Added `CLI_AUTH_PROVIDER_IDS` constant and `defaultIsExternalCliProvider()` — mirrors `CLI_AUTH_PROVIDERS` in `doctor-providers.ts`
- `resolveCredentialSource()` returns `"external_cli"` immediately for ExternalCli providers (no auth storage or env var check needed)
- `isExternalCliProvider` is injectable via `OnboardingServiceDeps` for test isolation
- UI: `step-authenticate.tsx` sets `canProceed = true` when `supports.externalCli && configured` without requiring `lastValidation`

- [x] `fix` — Bug fix

_AI-assisted contribution (Claude Code)._