### PR TITLE
feat/tui chat dialog blend gsd

### DIFF
--- a/packages/pi-coding-agent/src/core/agent-session.ts
+++ b/packages/pi-coding-agent/src/core/agent-session.ts
@@ -1558,9 +1558,12 @@ export class AgentSession {
 			}
 		}
 
-		this._disconnectFromAgent();
-		await this.abort();
-		this.agent.reset();
+	// #4243: Must call abort() BEFORE _disconnectFromAgent() so that
+	// message_end/agent_end events fire and the #4216 finalization code
+	// can run before we unsubscribe from the event bus.
+	await this.abort();
+	this._disconnectFromAgent();
+	this.agent.reset();
 		// Update cwd to current process directory — auto-mode may have chdir'd
 		// into a worktree since the original session was created.
 		const previousCwd = this._cwd;
@@ -2411,9 +2414,12 @@ export class AgentSession {
 			}
 		}
 
-		this._disconnectFromAgent();
-		await this.abort();
-		this._steeringMessages = [];
+	// #4243: Must call abort() BEFORE _disconnectFromAgent() so that
+	// message_end/agent_end events fire and the #4216 finalization code
+	// can run before we unsubscribe from the event bus.
+	await this.abort();
+	this._disconnectFromAgent();
+	this._steeringMessages = [];
 		this._followUpMessages = [];
 		this._pendingNextTurnMessages = [];
 

--- a/packages/pi-coding-agent/src/core/chat-controller-ordering.test.ts
+++ b/packages/pi-coding-agent/src/core/chat-controller-ordering.test.ts
@@ -450,6 +450,89 @@ test("chat-controller keeps pre-tool thinking visible for claude-code MCP turns 
 	await handleAgentEvent(host, { type: "message_end", message: makeAssistant([thinkingOnly[0], mcpTool]) } as any);
 });
 
+test("chat-controller keeps pre-tool question text for claude-code MCP when post-tool prose exists", async () => {
+	(globalThis as any)[Symbol.for("@gsd/pi-coding-agent:theme")] = {
+		fg: (_key: string, text: string) => text,
+		bg: (_key: string, text: string) => text,
+		bold: (text: string) => text,
+		italic: (text: string) => text,
+		truncate: (text: string) => text,
+	};
+
+	const host = createHost();
+	host.getMarkdownThemeWithSettings = () => ({});
+
+	const mcpTool = {
+		type: "toolCall",
+		id: "mcp-tool-question-1",
+		name: "glob",
+		mcpServer: "filesystem",
+		arguments: { pattern: "**/*" },
+	};
+
+	await handleAgentEvent(host, { type: "message_start", message: makeAssistant([]) } as any);
+
+	const questionText = { type: "text", text: "Which file should I inspect?" };
+
+	await handleAgentEvent(
+		host,
+		{
+			type: "message_update",
+			message: makeAssistant([questionText]),
+			assistantMessageEvent: {
+				type: "text_delta",
+				contentIndex: 0,
+				delta: questionText.text,
+				partial: makeAssistant([questionText]),
+			},
+		} as any,
+	);
+
+	await handleAgentEvent(
+		host,
+		{
+			type: "message_update",
+			message: makeAssistant([questionText, mcpTool]),
+			assistantMessageEvent: {
+				type: "toolcall_end",
+				contentIndex: 1,
+				toolCall: {
+					...mcpTool,
+					externalResult: {
+						content: [{ type: "text", text: "glob output" }],
+						details: {},
+						isError: false,
+					},
+				},
+				partial: makeAssistant([questionText, mcpTool]),
+			},
+		} as any,
+	);
+
+	const postTool = { type: "text", text: "I'll review that next." };
+	const finalContent = [questionText, mcpTool, postTool];
+	await handleAgentEvent(
+		host,
+		{
+			type: "message_update",
+			message: makeAssistant(finalContent),
+			assistantMessageEvent: {
+				type: "text_delta",
+				contentIndex: 2,
+				delta: postTool.text,
+				partial: makeAssistant(finalContent),
+			},
+		} as any,
+	);
+
+	assert.equal(host.chatContainer.children.length, 3, "question text should remain alongside MCP tool and post-tool prose");
+	assert.equal(host.chatContainer.children[0]?.constructor?.name, "AssistantMessageComponent", "pre-tool question stays visible");
+	assert.equal(host.chatContainer.children[1]?.constructor?.name, "ToolExecutionComponent", "tool renders in the middle");
+	assert.equal(host.chatContainer.children[2]?.constructor?.name, "AssistantMessageComponent", "post-tool prose renders last");
+
+	await handleAgentEvent(host, { type: "message_end", message: makeAssistant(finalContent) } as any);
+});
+
 test("chat-controller prunes orphaned provisional text after claude-code sub-turn shrink when MCP tools appear", async () => {
 	(globalThis as any)[Symbol.for("@gsd/pi-coding-agent:theme")] = {
 		fg: (_key: string, text: string) => text,

--- a/packages/pi-coding-agent/src/modes/interactive/components/assistant-message.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/components/assistant-message.ts
@@ -1,7 +1,8 @@
 import type { AssistantMessage } from "@gsd/pi-ai";
 import { Container, Markdown, type MarkdownTheme, Spacer, Text } from "@gsd/pi-tui";
 import { getMarkdownTheme, theme } from "../theme/theme.js";
-import { formatTimestamp, type TimestampFormat } from "./timestamp.js";
+import { type TimestampFormat } from "./timestamp.js";
+import { renderChatFrame } from "./chat-frame.js";
 
 export interface ContentRange {
 	startIndex: number;
@@ -94,10 +95,6 @@ export class AssistantMessageComponent extends Container {
 		// manual thinking toggle every turn.
 		const shouldCapThinking = hasTextContent || hasToolContent || message.provider === "claude-code";
 
-		if (hasVisibleContent) {
-			this.contentContainer.addChild(new Spacer(1));
-		}
-
 		// Render content in order; non-text/thinking blocks are silently skipped
 		for (let i = 0; i < slice.length; i++) {
 			const content = slice[i];
@@ -160,10 +157,24 @@ export class AssistantMessageComponent extends Container {
 				}
 			}
 
-			if (message.stopReason && message.timestamp) {
-				const timeStr = formatTimestamp(message.timestamp, this.timestampFormat);
-				this.contentContainer.addChild(new Text(theme.fg("dim", timeStr), 1, 0));
-			}
 		}
+	}
+
+	override render(width: number): string[] {
+		const frameWidth = Math.max(20, width);
+		const contentWidth = Math.max(1, frameWidth - 4);
+		const lines = super.render(contentWidth);
+		const headerLabel = this.lastMessage?.model ? `GSD - ${this.lastMessage.model}` : "GSD";
+		const framed = renderChatFrame(lines, frameWidth, {
+			label: headerLabel,
+			tone: "assistant",
+			timestamp: this.lastMessage?.timestamp,
+			timestampFormat: this.timestampFormat,
+			showTimestamp: this.showMetadata,
+		});
+		if (framed.length === 0) {
+			return framed;
+		}
+		return ["", ...framed];
 	}
 }

--- a/packages/pi-coding-agent/src/modes/interactive/components/chat-frame.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/components/chat-frame.ts
@@ -1,0 +1,67 @@
+import { truncateToWidth, visibleWidth } from "@gsd/pi-tui";
+import { theme } from "../theme/theme.js";
+import { formatTimestamp, type TimestampFormat } from "./timestamp.js";
+
+type FrameTone = "assistant" | "user";
+
+function trimOuterBlankLines(lines: string[]): string[] {
+	let start = 0;
+	let end = lines.length;
+	while (start < end && lines[start].trim().length === 0) start++;
+	while (end > start && lines[end - 1].trim().length === 0) end--;
+	return lines.slice(start, end);
+}
+
+export function renderChatFrame(
+	contentLines: string[],
+	width: number,
+	opts: {
+		label: string;
+		tone: FrameTone;
+		timestamp?: number;
+		timestampFormat: TimestampFormat;
+		showTimestamp?: boolean;
+	},
+): string[] {
+	const outerWidth = Math.max(20, width);
+	const contentWidth = Math.max(1, outerWidth - 2); // "│ " + content
+	const borderColor = opts.tone === "user" ? "borderAccent" : "border";
+	const borderMuted = opts.tone === "user" ? "borderMuted" : "borderMuted";
+	const border = (s: string) => theme.fg(borderColor, s);
+	const leftRaw = `• ${opts.label}`;
+	const rightRaw =
+		opts.showTimestamp === false || !opts.timestamp
+			? ""
+			: formatTimestamp(opts.timestamp, opts.timestampFormat);
+
+	const leftBudget = rightRaw
+		? Math.max(1, outerWidth - visibleWidth(rightRaw) - 1)
+		: outerWidth;
+	const left = truncateToWidth(leftRaw, leftBudget, "");
+	const leftStyled =
+		opts.tone === "user"
+			? theme.fg("accent", theme.bold(left))
+			: theme.fg("muted", theme.bold(left));
+	const rightStyled = rightRaw ? theme.fg("dim", rightRaw) : "";
+	const gap =
+		rightRaw.length > 0
+			? Math.max(
+					1,
+					outerWidth - visibleWidth(leftStyled) - visibleWidth(rightStyled),
+				)
+			: Math.max(0, outerWidth - visibleWidth(leftStyled));
+	const headerRow = `${leftStyled}${" ".repeat(gap)}${rightStyled}`;
+	const headerPad = Math.max(0, outerWidth - visibleWidth(headerRow));
+
+	const sourceLines = trimOuterBlankLines(contentLines);
+	const bodyLines = (sourceLines.length > 0 ? sourceLines : [""]).map((line) => {
+		const clipped = truncateToWidth(line, contentWidth, "");
+		return border("│ ") + clipped;
+	});
+
+	return [
+		theme.fg(borderMuted, "─".repeat(outerWidth)),
+		headerRow + " ".repeat(headerPad),
+		...bodyLines,
+	];
+}

--- a/packages/pi-coding-agent/src/modes/interactive/components/user-message.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/components/user-message.ts
@@ -1,6 +1,7 @@
-import { Container, Markdown, type MarkdownTheme, Spacer, Text } from "@gsd/pi-tui";
-import { getMarkdownTheme, theme } from "../theme/theme.js";
-import { formatTimestamp, type TimestampFormat } from "./timestamp.js";
+import { Container, Markdown, type MarkdownTheme } from "@gsd/pi-tui";
+import { getMarkdownTheme } from "../theme/theme.js";
+import { type TimestampFormat } from "./timestamp.js";
+import { renderChatFrame } from "./chat-frame.js";
 
 const OSC133_ZONE_START = "\x1b]133;A\x07";
 const OSC133_ZONE_END = "\x1b]133;B\x07";
@@ -16,32 +17,28 @@ export class UserMessageComponent extends Container {
 		super();
 		this.timestamp = timestamp;
 		this.timestampFormat = timestampFormat;
-		this.addChild(new Spacer(1));
-		this.addChild(
-			new Markdown(text, 1, 1, markdownTheme, {
-				bgColor: (text: string) => theme.bg("userMessageBg", text),
-				color: (text: string) => theme.fg("userMessageText", text),
-			}),
-		);
+		this.addChild(new Markdown(text, 0, 0, markdownTheme));
 	}
 
 	override render(width: number): string[] {
-		const lines = super.render(width);
-		if (lines.length === 0) {
-			return lines;
+		const frameWidth = Math.max(20, width);
+		const contentWidth = Math.max(1, frameWidth - 4);
+		const lines = super.render(contentWidth);
+		const framed = renderChatFrame(lines, frameWidth, {
+			label: "You",
+			tone: "user",
+			timestamp: this.timestamp,
+			timestampFormat: this.timestampFormat,
+			showTimestamp: true,
+		});
+		if (framed.length === 0) {
+			return framed;
 		}
-
-		// Insert right-aligned timestamp above the message content
-		if (this.timestamp) {
-			const timeStr = formatTimestamp(this.timestamp, this.timestampFormat);
-			const label = theme.fg("dim", timeStr);
-			const padding = Math.max(0, width - timeStr.length - 1);
-			const timestampLine = " ".repeat(padding) + label;
-			lines.splice(0, 0, timestampLine);
-		}
-
-		lines[0] = OSC133_ZONE_START + lines[0];
-		lines[lines.length - 1] = lines[lines.length - 1] + OSC133_ZONE_END;
-		return lines;
+		const out = ["", ...framed];
+		const firstFrameLine = 1;
+		const lastFrameLine = out.length - 1;
+		out[firstFrameLine] = OSC133_ZONE_START + out[firstFrameLine];
+		out[lastFrameLine] = out[lastFrameLine] + OSC133_ZONE_END;
+		return out;
 	}
 }

--- a/packages/pi-coding-agent/src/modes/interactive/controllers/chat-controller.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/controllers/chat-controller.ts
@@ -348,7 +348,6 @@ export async function handleAgentEvent(host: InteractiveModeStateHost & {
 				let runStart = -1;
 				let runEnd = -1;
 				let runType: "text" | "thinking" | undefined;
-				const QUESTION_PROSE_MAX_LEN = 120;
 				const closeRun = () => {
 					if (runStart !== -1 && runType) {
 						desired.push({ kind: "text-run", startIndex: runStart, endIndex: runEnd, contentType: runType });
@@ -365,13 +364,11 @@ export async function handleAgentEvent(host: InteractiveModeStateHost & {
 					// For Claude Code MCP turns, prune only pre-tool prose, never thinking.
 					const textValue = blockType === "text" && typeof b?.text === "string" ? b.text : "";
 					const isLikelyQuestion = blockType === "text" && typeof textValue === "string" && /\?\s*$/.test(textValue.trim());
-					const isShortProse = blockType === "text" && typeof textValue === "string" && textValue.trim().length > 0 && textValue.trim().length <= QUESTION_PROSE_MAX_LEN;
 					const shouldSkipProse = shouldDropPreToolProse
 						&& firstToolIdx >= 0
 						&& i < firstToolIdx
 						&& blockType === "text"
-						&& !isLikelyQuestion
-						&& !isShortProse;
+						&& !isLikelyQuestion;
 					if (shouldSkipProse) {
 						closeRun();
 						continue;

--- a/packages/pi-coding-agent/src/modes/interactive/controllers/chat-controller.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/controllers/chat-controller.ts
@@ -95,6 +95,7 @@ export async function handleAgentEvent(host: InteractiveModeStateHost & {
 	}
 
 	host.footer.invalidate();
+	const timestampFormat = host.settingsManager.getTimestampFormat();
 
 	// Reset content index tracker and pinned state when a new assistant message starts
 	if (event.type === "message_start" && event.message.role === "assistant") {
@@ -468,7 +469,7 @@ export async function handleAgentEvent(host: InteractiveModeStateHost & {
 									undefined,
 									host.hideThinkingBlock,
 									host.getMarkdownThemeWithSettings(),
-									host.settingsManager.getTimestampFormat(),
+									timestampFormat,
 									{ startIndex: seg.startIndex, endIndex: seg.endIndex },
 								);
 								host.chatContainer.addChild(comp);
@@ -690,7 +691,7 @@ export async function handleAgentEvent(host: InteractiveModeStateHost & {
 								undefined,
 								host.hideThinkingBlock,
 								host.getMarkdownThemeWithSettings(),
-								host.settingsManager.getTimestampFormat(),
+								timestampFormat,
 								{ startIndex: seg.startIndex, endIndex: seg.endIndex },
 							);
 							comp.updateContent(host.streamingMessage);
@@ -710,9 +711,9 @@ export async function handleAgentEvent(host: InteractiveModeStateHost & {
 						host.streamingComponent = new AssistantMessageComponent(
 							undefined,
 							host.hideThinkingBlock,
-						host.getMarkdownThemeWithSettings(),
-						host.settingsManager.getTimestampFormat(),
-					);
+							host.getMarkdownThemeWithSettings(),
+							timestampFormat,
+						);
 					host.chatContainer.addChild(host.streamingComponent);
 				}
 				if (host.streamingComponent) {

--- a/packages/pi-coding-agent/src/modes/interactive/controllers/chat-controller.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/controllers/chat-controller.ts
@@ -344,29 +344,38 @@ export async function handleAgentEvent(host: InteractiveModeStateHost & {
 					type DesiredSegment =
 						| { kind: "text-run"; startIndex: number; endIndex: number; contentType: "text" | "thinking" }
 						| { kind: "tool"; contentIndex: number; toolId: string };
-					const desired: DesiredSegment[] = [];
-					let runStart = -1;
-					let runEnd = -1;
-					let runType: "text" | "thinking" | undefined;
-					const closeRun = () => {
-						if (runStart !== -1 && runType) {
-							desired.push({ kind: "text-run", startIndex: runStart, endIndex: runEnd, contentType: runType });
-							runStart = -1;
-							runEnd = -1;
-							runType = undefined;
+				const desired: DesiredSegment[] = [];
+				let runStart = -1;
+				let runEnd = -1;
+				let runType: "text" | "thinking" | undefined;
+				const QUESTION_PROSE_MAX_LEN = 120;
+				const closeRun = () => {
+					if (runStart !== -1 && runType) {
+						desired.push({ kind: "text-run", startIndex: runStart, endIndex: runEnd, contentType: runType });
+						runStart = -1;
+						runEnd = -1;
+						runType = undefined;
 						}
 					};
-					for (let i = 0; i < blocks.length; i++) {
-						const b = blocks[i];
-						const blockType = b.type === "text" || b.type === "thinking" ? b.type : undefined;
-						const isTextLike = blockType === "text" || blockType === "thinking";
-						const isTool = b.type === "toolCall" || b.type === "serverToolUse";
-						// For Claude Code MCP turns, prune only pre-tool prose, never thinking.
-						const shouldSkipProse = shouldDropPreToolProse && firstToolIdx >= 0 && i < firstToolIdx && blockType === "text";
-						if (shouldSkipProse) {
-							closeRun();
-							continue;
-						}
+				for (let i = 0; i < blocks.length; i++) {
+					const b = blocks[i];
+					const blockType = b.type === "text" || b.type === "thinking" ? b.type : undefined;
+					const isTextLike = blockType === "text" || blockType === "thinking";
+					const isTool = b.type === "toolCall" || b.type === "serverToolUse";
+					// For Claude Code MCP turns, prune only pre-tool prose, never thinking.
+					const textValue = blockType === "text" && typeof b?.text === "string" ? b.text : "";
+					const isLikelyQuestion = blockType === "text" && typeof textValue === "string" && /\?\s*$/.test(textValue.trim());
+					const isShortProse = blockType === "text" && typeof textValue === "string" && textValue.trim().length > 0 && textValue.trim().length <= QUESTION_PROSE_MAX_LEN;
+					const shouldSkipProse = shouldDropPreToolProse
+						&& firstToolIdx >= 0
+						&& i < firstToolIdx
+						&& blockType === "text"
+						&& !isLikelyQuestion
+						&& !isShortProse;
+					if (shouldSkipProse) {
+						closeRun();
+						continue;
+					}
 						if (isTextLike) {
 							if (runStart === -1) {
 								runStart = i;

--- a/packages/pi-coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/interactive-mode.ts
@@ -2117,6 +2117,7 @@ export class InteractiveMode {
 	}
 
 	private addMessageToChat(message: AgentMessage, options?: { populateHistory?: boolean }): void {
+		const timestampFormat = this.settingsManager.getTimestampFormat();
 		switch (message.role) {
 			case "bashExecution": {
 				const component = new BashExecutionComponent(message.command, this.ui, message.excludeFromContext);
@@ -2174,12 +2175,12 @@ export class InteractiveMode {
 								skillBlock.userMessage,
 								this.getMarkdownThemeWithSettings(),
 								message.timestamp,
-								this.settingsManager.getTimestampFormat(),
+								timestampFormat,
 							);
 							this.chatContainer.addChild(userComponent);
 						}
 					} else {
-						const userComponent = new UserMessageComponent(textContent, this.getMarkdownThemeWithSettings(), message.timestamp, this.settingsManager.getTimestampFormat());
+						const userComponent = new UserMessageComponent(textContent, this.getMarkdownThemeWithSettings(), message.timestamp, timestampFormat);
 						this.chatContainer.addChild(userComponent);
 					}
 					if (options?.populateHistory) {
@@ -2193,7 +2194,7 @@ export class InteractiveMode {
 					message,
 					this.hideThinkingBlock,
 					this.getMarkdownThemeWithSettings(),
-					this.settingsManager.getTimestampFormat(),
+					timestampFormat,
 				);
 				this.chatContainer.addChild(assistantComponent);
 				break;
@@ -2231,6 +2232,7 @@ export class InteractiveMode {
 		options: { updateFooter?: boolean; populateHistory?: boolean } = {},
 	): void {
 		this.pendingTools.clear();
+		const timestampFormat = this.settingsManager.getTimestampFormat();
 
 		if (options.updateFooter) {
 			this.footer.invalidate();
@@ -2255,7 +2257,7 @@ export class InteractiveMode {
 							message,
 							this.hideThinkingBlock,
 							this.getMarkdownThemeWithSettings(),
-							this.settingsManager.getTimestampFormat(),
+							timestampFormat,
 							{ startIndex: segment.startIndex, endIndex: segment.endIndex },
 						);
 						this.chatContainer.addChild(assistantComponent);

--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -1121,11 +1121,15 @@ export async function postUnitPostVerification(pctx: PostUnitContext): Promise<"
           });
         }
 
-        // Notify UI
+        // Notify UI — surface actionable details (#4259)
         if (result.status === "fail") {
-          const blockingCount = result.checks.filter(c => !c.passed && c.blocking).length;
+          const blockingChecks = result.checks.filter(c => !c.passed && c.blocking);
+          const blockingCount = blockingChecks.length;
+          const details = blockingChecks.slice(0, 3).map(c => `  \u2022 ${c.message}`).join("\n");
+          const suffix = blockingChecks.length > 3 ? `\n  \u2022 ...and ${blockingChecks.length - 3} more` : "";
+          const evidenceNote = `\nSee ${sid}-PRE-EXEC-VERIFY.json for full details.`;
           ctx.ui.notify(
-            `Pre-execution checks failed: ${blockingCount} blocking issue${blockingCount === 1 ? "" : "s"} found`,
+            `Pre-execution checks failed: ${blockingCount} blocking issue${blockingCount === 1 ? "" : "s"} found\n${details}${suffix}${evidenceNote}`,
             "error",
           );
           preExecPauseNeeded = true;

--- a/src/resources/extensions/gsd/bootstrap/register-hooks.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-hooks.ts
@@ -125,7 +125,10 @@ export function registerHooks(pi: ExtensionAPI): void {
     await ensureDbOpen();
     const state = await deriveState(basePath);
     if (!state.activeMilestone || !state.activeSlice || !state.activeTask) return;
-    if (state.phase !== "executing") return;
+    // Write checkpoint for ALL phases, not just "executing" — discuss, research,
+    // and planning also carry in-memory state (user answers, gate verification)
+    // that would be lost on compaction (#4258).
+    // if (state.phase !== "executing") return;
 
     const sliceDir = resolveSlicePath(basePath, state.activeMilestone.id, state.activeSlice.id);
     if (!sliceDir) return;


### PR DESCRIPTION
- **Keep pre-tool questions visible during Claude Code MCP turns**
- **Retain only question pre-tool prose for Claude Code MCP**
- **fix(gsd): expand pre-execution check notification with details + evidence path (#4259)**
- **fix(gsd): checkpoint all session phases during compaction, not just executing (#4258)**
- **fix(agent-session): call abort() before _disconnectFromAgent() in newSession/resumeSession (#4243)**
- **feat(tui): blend chat frame with shared timestamp and model header**
