### PR TITLE
fix(gsd): auto-mode retry bug, .mcp.json churn, and MCP worktree routing

### DIFF
--- a/packages/mcp-server/src/workflow-tools.ts
+++ b/packages/mcp-server/src/workflow-tools.ts
@@ -2,7 +2,8 @@
  * Workflow MCP tools — exposes the core GSD mutation/read handlers over MCP.
  */
 
-import { isAbsolute, relative, resolve } from "node:path";
+import { realpathSync } from "node:fs";
+import { isAbsolute, join, relative, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import { z } from "zod";
 
@@ -262,6 +263,22 @@ function isWithinRoot(candidatePath: string, rootPath: string): boolean {
   return rel === "" || (!rel.startsWith("..") && !isAbsolute(rel));
 }
 
+/**
+ * Resolve the symlink target of `<allowedRoot>/.gsd` when it points into the
+ * external state layout (`~/.gsd/projects/<hash>/`). Returns the realpath of
+ * that target so callers can accept worktree paths that live under
+ * `<external-state>/worktrees/<MID>/`. Returns null when `.gsd` is absent or
+ * resolution fails — the caller should fall back to the direct containment
+ * check in that case.
+ */
+function resolveExternalStateRoot(allowedRoot: string): string | null {
+  try {
+    return realpathSync(join(allowedRoot, ".gsd"));
+  } catch {
+    return null;
+  }
+}
+
 function validateProjectDir(projectDir: string, env: NodeJS.ProcessEnv = process.env): string {
   if (!isAbsolute(projectDir)) {
     throw new Error(`projectDir must be an absolute path. Received: ${projectDir}`);
@@ -269,13 +286,23 @@ function validateProjectDir(projectDir: string, env: NodeJS.ProcessEnv = process
 
   const resolvedProjectDir = resolve(projectDir);
   const allowedRoot = getAllowedProjectRoot(env);
-  if (allowedRoot && !isWithinRoot(resolvedProjectDir, allowedRoot)) {
-    throw new Error(
-      `projectDir must stay within the configured workflow project root. Received: ${resolvedProjectDir}; allowed root: ${allowedRoot}`,
-    );
+  if (!allowedRoot) return resolvedProjectDir;
+
+  if (isWithinRoot(resolvedProjectDir, allowedRoot)) return resolvedProjectDir;
+
+  // External state layout: `<allowedRoot>/.gsd` may be a symlink into
+  // `~/.gsd/projects/<hash>/`, and auto-worktrees live under
+  // `~/.gsd/projects/<hash>/worktrees/<MID>/`. Accept candidates that are
+  // under the realpath of `<allowedRoot>/.gsd` — they belong to this project
+  // even though their absolute path is outside allowedRoot (#issue-a44).
+  const externalRoot = resolveExternalStateRoot(allowedRoot);
+  if (externalRoot && isWithinRoot(resolvedProjectDir, externalRoot)) {
+    return resolvedProjectDir;
   }
 
-  return resolvedProjectDir;
+  throw new Error(
+    `projectDir must stay within the configured workflow project root. Received: ${resolvedProjectDir}; allowed root: ${allowedRoot}`,
+  );
 }
 
 function parseToolArgs<T>(schema: z.ZodType<T>, args: Record<string, unknown>): T {

--- a/packages/mcp-server/src/workflow-tools.ts
+++ b/packages/mcp-server/src/workflow-tools.ts
@@ -309,14 +309,18 @@ function parseToolArgs<T>(schema: z.ZodType<T>, args: Record<string, unknown>): 
   return schema.parse(args);
 }
 
-function parseWorkflowArgs<T extends { projectDir: string }>(
+function parseWorkflowArgs<T extends { projectDir?: string }>(
   schema: z.ZodType<T>,
   args: Record<string, unknown>,
-): T {
+): T & { projectDir: string } {
   const parsed = parseToolArgs(schema, args);
+  // Default to process.cwd() when omitted — the server is already cwd'd into
+  // the right project or worktree root by auto-mode, so we don't need the
+  // agent to guess and pass an absolute path string.
+  const candidate = parsed.projectDir ?? process.cwd();
   return {
     ...parsed,
-    projectDir: validateProjectDir(parsed.projectDir),
+    projectDir: validateProjectDir(candidate),
   };
 }
 
@@ -691,7 +695,14 @@ async function ensureMilestoneDbRow(milestoneId: string): Promise<void> {
   }
 }
 
-const projectDirParam = z.string().describe("Absolute path to the project directory within the configured workflow root");
+// projectDir is optional. When omitted, the server uses process.cwd(). This
+// prevents the agent from burning tokens reasoning about which absolute path
+// to pass (git root vs worktree vs symlink-resolved external state layout) —
+// the server already knows where it is running.
+const projectDirParam = z
+  .string()
+  .optional()
+  .describe("Optional. Omit this field — the server defaults to its current working directory, which is already the correct project or worktree root.");
 
 const planMilestoneParams = {
   projectDir: projectDirParam,

--- a/packages/mcp-server/src/workflow-tools.ts
+++ b/packages/mcp-server/src/workflow-tools.ts
@@ -2,7 +2,7 @@
  * Workflow MCP tools — exposes the core GSD mutation/read handlers over MCP.
  */
 
-import { realpathSync } from "node:fs";
+import { existsSync, realpathSync } from "node:fs";
 import { isAbsolute, join, relative, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import { z } from "zod";
@@ -309,18 +309,65 @@ function parseToolArgs<T>(schema: z.ZodType<T>, args: Record<string, unknown>): 
   return schema.parse(args);
 }
 
+/**
+ * Extract a milestone ID from parsed tool args, trying common field names.
+ * Returns null when no field is present or the value is not a string.
+ */
+function extractMilestoneId(parsed: Record<string, unknown>): string | null {
+  const candidates = [parsed.milestoneId, parsed.milestone_id, parsed.mid];
+  for (const c of candidates) {
+    if (typeof c === "string" && c.trim() !== "") return c.trim();
+  }
+  return null;
+}
+
+/**
+ * If an auto-worktree exists for the given milestone under
+ * `<projectRoot>/.gsd/worktrees/<milestoneId>/`, return that path as the
+ * basePath the tool should write against. Returns null when no worktree
+ * exists for this milestone, leaving the caller to use the project root.
+ *
+ * This unbreaks the external-state layout where the MCP server's process.cwd()
+ * is the project root (set at Claude Code launch) but auto-mode is actually
+ * working inside a per-milestone worktree. Without this, tool writes go to
+ * the shared project `.gsd/` and auto-mode's verifyExpectedArtifact (which
+ * uses the worktree `.gsd/`) fails, triggering a guaranteed retry per unit.
+ */
+function resolveActiveWorktreeBasePath(
+  projectRoot: string,
+  milestoneId: string | null,
+): string | null {
+  if (!milestoneId) return null;
+  const wtPath = join(projectRoot, ".gsd", "worktrees", milestoneId);
+  if (!existsSync(wtPath)) return null;
+  // Sanity check: a real git worktree has a `.git` file with a gitdir pointer.
+  // Bare directories without it shouldn't hijack the write path.
+  if (!existsSync(join(wtPath, ".git"))) return null;
+  return wtPath;
+}
+
 function parseWorkflowArgs<T extends { projectDir?: string }>(
   schema: z.ZodType<T>,
   args: Record<string, unknown>,
 ): T & { projectDir: string } {
   const parsed = parseToolArgs(schema, args);
-  // Default to process.cwd() when omitted — the server is already cwd'd into
-  // the right project or worktree root by auto-mode, so we don't need the
-  // agent to guess and pass an absolute path string.
-  const candidate = parsed.projectDir ?? process.cwd();
+  // Step 1: figure out the project root. The agent shouldn't need to pass
+  // projectDir — default to process.cwd() which the MCP server inherited from
+  // Claude Code (launched at the project root).
+  const projectRootCandidate = parsed.projectDir ?? process.cwd();
+  const projectRoot = validateProjectDir(projectRootCandidate);
+
+  // Step 2: if this tool call is scoped to a milestone that has an active
+  // auto-worktree, re-route writes to the worktree's .gsd rather than the
+  // project's shared .gsd. auto-mode's verifyExpectedArtifact runs against
+  // the worktree, and a mismatch here causes every unit to retry once.
+  const milestoneId = extractMilestoneId(parsed as Record<string, unknown>);
+  const worktreeBasePath = resolveActiveWorktreeBasePath(projectRoot, milestoneId);
+  const effectiveBasePath = worktreeBasePath ?? projectRoot;
+
   return {
     ...parsed,
-    projectDir: validateProjectDir(candidate),
+    projectDir: effectiveBasePath,
   };
 }
 

--- a/src/resources/extensions/gsd/auto-recovery.ts
+++ b/src/resources/extensions/gsd/auto-recovery.ts
@@ -264,18 +264,30 @@ export function verifyExpectedArtifact(
   const absPath = resolveExpectedArtifactPath(unitType, unitId, base);
   // For unit types with no verifiable artifact (null path), the parent directory
   // is missing on disk — treat as stale completion state so the key gets evicted (#313).
-  if (!absPath) return false;
-  if (!existsSync(absPath)) return false;
+  if (!absPath) {
+    logWarning("recovery", `verify-fail ${unitType} ${unitId}: resolveExpectedArtifactPath returned null (parent dir missing)`);
+    return false;
+  }
+  if (!existsSync(absPath)) {
+    logWarning("recovery", `verify-fail ${unitType} ${unitId}: existsSync false for ${absPath}`);
+    return false;
+  }
 
   if (unitType === "validate-milestone") {
     const validationContent = readFileSync(absPath, "utf-8");
-    if (!isValidationTerminal(validationContent)) return false;
+    if (!isValidationTerminal(validationContent)) {
+      logWarning("recovery", `verify-fail ${unitType} ${unitId}: validation not terminal (len=${validationContent.length}) at ${absPath}`);
+      return false;
+    }
   }
 
   if (unitType === "plan-milestone") {
     try {
       const roadmap = parseLegacyRoadmap(readFileSync(absPath, "utf-8"));
-      if (roadmap.slices.length === 0) return false;
+      if (roadmap.slices.length === 0) {
+        logWarning("recovery", `verify-fail ${unitType} ${unitId}: roadmap has zero slices at ${absPath}`);
+        return false;
+      }
     } catch (err) {
       logWarning("recovery", `plan-milestone roadmap verification failed: ${err instanceof Error ? err.message : String(err)}`);
       return false;
@@ -292,7 +304,10 @@ export function verifyExpectedArtifact(
     // Accept checkbox-style (- [x] **T01: ...) or heading-style (### T01 -- / ### T01: / ### T01 —)
     const hasCheckboxTask = /^- \[[xX ]\] \*\*T\d+:/m.test(planContent);
     const hasHeadingTask = /^#{2,4}\s+T\d+\s*(?:--|—|:)/m.test(planContent);
-    if (!hasCheckboxTask && !hasHeadingTask) return false;
+    if (!hasCheckboxTask && !hasHeadingTask) {
+      logWarning("recovery", `verify-fail ${unitType} ${unitId}: plan has no task checkbox/heading (len=${planContent.length}) at ${absPath}`);
+      return false;
+    }
   }
 
   // execute-task: DB status is authoritative. Fall back to checked-checkbox
@@ -349,10 +364,15 @@ export function verifyExpectedArtifact(
 
         if (taskIds && taskIds.length > 0) {
           const tasksDir = resolveTasksDir(base, mid, sid);
-          if (tasksDir) {
-            for (const tid of taskIds) {
-              const taskPlanFile = join(tasksDir, `${tid}-PLAN.md`);
-              if (!existsSync(taskPlanFile)) return false;
+          if (!tasksDir) {
+            logWarning("recovery", `verify-fail ${unitType} ${unitId}: resolveTasksDir returned null for ${mid}/${sid}`);
+            return false;
+          }
+          for (const tid of taskIds) {
+            const taskPlanFile = join(tasksDir, `${tid}-PLAN.md`);
+            if (!existsSync(taskPlanFile)) {
+              logWarning("recovery", `verify-fail ${unitType} ${unitId}: task plan missing ${taskPlanFile}`);
+              return false;
             }
           }
         }

--- a/src/resources/extensions/gsd/bootstrap/register-hooks.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-hooks.ts
@@ -45,8 +45,12 @@ export function registerHooks(pi: ExtensionAPI): void {
     resetToolCallLoopGuard();
     resetAskUserQuestionsCache();
     await syncServiceTierStatus(ctx);
-    const { prepareWorkflowMcpForProject } = await import("../workflow-mcp-auto-prep.js");
-    prepareWorkflowMcpForProject(ctx, process.cwd());
+    // Skip MCP auto-prep when running inside an auto-worktree (see session_switch below).
+    const { isInAutoWorktree } = await import("../auto-worktree.js");
+    if (!isInAutoWorktree(process.cwd())) {
+      const { prepareWorkflowMcpForProject } = await import("../workflow-mcp-auto-prep.js");
+      prepareWorkflowMcpForProject(ctx, process.cwd());
+    }
 
     // Apply show_token_cost preference (#1515)
     try {
@@ -87,8 +91,15 @@ export function registerHooks(pi: ExtensionAPI): void {
     resetAskUserQuestionsCache();
     clearDiscussionFlowState();
     await syncServiceTierStatus(ctx);
-    const { prepareWorkflowMcpForProject } = await import("../workflow-mcp-auto-prep.js");
-    prepareWorkflowMcpForProject(ctx, process.cwd());
+    // Skip MCP auto-prep when running inside an auto-worktree. The worktree
+    // already has .mcp.json from createAutoWorktree, and re-running the writer
+    // post-chdir rewrites the file mid-run (non-idempotent due to cwd-relative
+    // CLI path resolution), dirtying the tree and breaking the milestone merge.
+    const { isInAutoWorktree } = await import("../auto-worktree.js");
+    if (!isInAutoWorktree(process.cwd())) {
+      const { prepareWorkflowMcpForProject } = await import("../workflow-mcp-auto-prep.js");
+      prepareWorkflowMcpForProject(ctx, process.cwd());
+    }
     loadToolApiKeys();
   });
 
@@ -261,7 +272,7 @@ export function registerHooks(pi: ExtensionAPI): void {
   // ── Safety harness: evidence collection + destructive command warnings ──
   pi.on("tool_call", async (event, ctx) => {
     if (!isAutoActive()) return;
-    safetyRecordToolCall(event.toolName, event.input as Record<string, unknown>);
+    safetyRecordToolCall(event.toolCallId, event.toolName, event.input as Record<string, unknown>);
 
     // Destructive command classification (warn only, never block)
     if (isToolCallEventType("bash", event)) {

--- a/src/resources/extensions/gsd/safety/evidence-collector.ts
+++ b/src/resources/extensions/gsd/safety/evidence-collector.ts
@@ -68,11 +68,11 @@ export function getFilePaths(): string[] {
  * Record a tool call at dispatch time (before execution).
  * Exit codes and output are filled in by recordToolResult after execution.
  */
-export function recordToolCall(toolName: string, input: Record<string, unknown>): void {
+export function recordToolCall(toolCallId: string, toolName: string, input: Record<string, unknown>): void {
   if (toolName === "bash" || toolName === "Bash") {
     unitEvidence.push({
       kind: "bash",
-      toolCallId: "",
+      toolCallId,
       command: String(input.command ?? ""),
       exitCode: -1,
       outputSnippet: "",
@@ -81,14 +81,14 @@ export function recordToolCall(toolName: string, input: Record<string, unknown>)
   } else if (toolName === "write" || toolName === "Write") {
     unitEvidence.push({
       kind: "write",
-      toolCallId: "",
+      toolCallId,
       path: String(input.file_path ?? input.path ?? ""),
       timestamp: Date.now(),
     });
   } else if (toolName === "edit" || toolName === "Edit") {
     unitEvidence.push({
       kind: "edit",
-      toolCallId: "",
+      toolCallId,
       path: String(input.file_path ?? input.path ?? ""),
       timestamp: Date.now(),
     });
@@ -96,8 +96,9 @@ export function recordToolCall(toolName: string, input: Record<string, unknown>)
 }
 
 /**
- * Record a tool execution result. Matches the most recent unresolved entry
- * of the same kind and fills in the toolCallId, exit code, and output.
+ * Record a tool execution result. Matches the entry by toolCallId (assigned
+ * at dispatch time) and fills in exit code + output. Prior versions matched
+ * by `kind + empty-string` which corrupted parallel tool calls.
  */
 export function recordToolResult(
   toolCallId: string,
@@ -105,35 +106,18 @@ export function recordToolResult(
   result: unknown,
   isError: boolean,
 ): void {
-  const normalizedName = toolName.toLowerCase();
+  const entry = unitEvidence.find(e => e.toolCallId === toolCallId);
+  if (!entry) return;
 
-  if (normalizedName === "bash") {
-    const entry = findLastUnresolved("bash") as BashEvidence | undefined;
-    if (entry) {
-      entry.toolCallId = toolCallId;
-      const text = extractResultText(result);
-      entry.outputSnippet = text.slice(0, 500);
-      const exitMatch = text.match(/Command exited with code (\d+)/);
-      entry.exitCode = exitMatch ? Number(exitMatch[1]) : (isError ? 1 : 0);
-    }
-  } else if (normalizedName === "write" || normalizedName === "edit") {
-    const entry = findLastUnresolved(normalizedName as "write" | "edit");
-    if (entry) {
-      entry.toolCallId = toolCallId;
-    }
+  if (entry.kind === "bash") {
+    const text = extractResultText(result);
+    entry.outputSnippet = text.slice(0, 500);
+    const exitMatch = text.match(/Command exited with code (\d+)/);
+    entry.exitCode = exitMatch ? Number(exitMatch[1]) : (isError ? 1 : 0);
   }
 }
 
 // ─── Internals ──────────────────────────────────────────────────────────────
-
-function findLastUnresolved(kind: string): EvidenceEntry | undefined {
-  for (let i = unitEvidence.length - 1; i >= 0; i--) {
-    if (unitEvidence[i].kind === kind && unitEvidence[i].toolCallId === "") {
-      return unitEvidence[i];
-    }
-  }
-  return undefined;
-}
 
 function extractResultText(result: unknown): string {
   if (typeof result === "string") return result;

--- a/src/resources/extensions/gsd/tests/auto-retry-mcp-churn-fixes.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-retry-mcp-churn-fixes.test.ts
@@ -1,0 +1,272 @@
+/**
+ * Regression tests for PR #4288 — auto-retry bug, .mcp.json churn, and MCP
+ * worktree routing fixes.
+ *
+ * Covers four source-file changes:
+ *   1. src/resources/extensions/gsd/safety/evidence-collector.ts (functional)
+ *   2. src/resources/extensions/gsd/bootstrap/register-hooks.ts (source shape)
+ *   3. src/resources/extensions/gsd/auto-recovery.ts (source shape)
+ *   4. packages/mcp-server/src/workflow-tools.ts (source shape)
+ *
+ * Copyright (c) 2026 Jeremy McSpadden <jeremy@fluxlabs.net>
+ */
+
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import {
+  resetEvidence,
+  getEvidence,
+  recordToolCall,
+  recordToolResult,
+  type BashEvidence,
+} from "../safety/evidence-collector.js";
+
+// ─── 1. evidence-collector: functional ─────────────────────────────────────
+
+describe("evidence-collector: toolCallId-based matching (A-3)", () => {
+  beforeEach(() => {
+    resetEvidence();
+  });
+
+  it("records bash calls with their toolCallId at dispatch time", () => {
+    recordToolCall("tc-1", "bash", { command: "ls -la" });
+    recordToolCall("tc-2", "bash", { command: "git status" });
+
+    const entries = getEvidence();
+    assert.equal(entries.length, 2);
+    assert.equal(entries[0].toolCallId, "tc-1");
+    assert.equal(entries[1].toolCallId, "tc-2");
+  });
+
+  it("matches results to the correct entry by toolCallId, not insertion order", () => {
+    // Simulate two parallel bash calls dispatched in order tc-1, tc-2.
+    recordToolCall("tc-1", "bash", { command: "slow-thing" });
+    recordToolCall("tc-2", "bash", { command: "fast-thing" });
+
+    // Results arrive out of order: tc-2 first (fast), then tc-1 (slow).
+    // With the old empty-string-matching strategy, tc-2's result would be
+    // stapled to tc-1's entry because findLastUnresolved scanned backwards
+    // for empty ids. Now we match by id directly.
+    recordToolResult("tc-2", "bash", "Command exited with code 0\nfast-output", false);
+    recordToolResult("tc-1", "bash", "Command exited with code 1\nslow-failure", true);
+
+    const entries = getEvidence() as readonly BashEvidence[];
+    const tc1 = entries.find(e => e.toolCallId === "tc-1") as BashEvidence | undefined;
+    const tc2 = entries.find(e => e.toolCallId === "tc-2") as BashEvidence | undefined;
+
+    assert.ok(tc1, "tc-1 entry must exist");
+    assert.ok(tc2, "tc-2 entry must exist");
+
+    // The original command stays attached to the entry it was recorded with,
+    // and the result matches the id it was reported for.
+    assert.equal(tc1.command, "slow-thing");
+    assert.equal(tc1.exitCode, 1);
+    assert.ok(tc1.outputSnippet.includes("slow-failure"));
+
+    assert.equal(tc2.command, "fast-thing");
+    assert.equal(tc2.exitCode, 0);
+    assert.ok(tc2.outputSnippet.includes("fast-output"));
+  });
+
+  it("ignores results with unknown toolCallIds rather than corrupting nearby entries", () => {
+    recordToolCall("tc-1", "bash", { command: "real" });
+    recordToolResult("tc-UNKNOWN", "bash", "Command exited with code 0\n", false);
+
+    const entries = getEvidence() as readonly BashEvidence[];
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].toolCallId, "tc-1");
+    // tc-1 must be untouched — no result was reported for it.
+    assert.equal(entries[0].exitCode, -1);
+    assert.equal(entries[0].outputSnippet, "");
+  });
+
+  it("records write/edit entries with their toolCallId", () => {
+    recordToolCall("tc-write", "write", { file_path: "/tmp/a.md" });
+    recordToolCall("tc-edit", "edit", { file_path: "/tmp/b.md" });
+
+    const entries = getEvidence();
+    assert.equal(entries.length, 2);
+    assert.equal(entries[0].kind, "write");
+    assert.equal(entries[0].toolCallId, "tc-write");
+    assert.equal(entries[1].kind, "edit");
+    assert.equal(entries[1].toolCallId, "tc-edit");
+  });
+});
+
+// ─── 2. register-hooks: MCP auto-prep gated inside auto-worktrees (A-1) ────
+
+describe("register-hooks: skip prepareWorkflowMcpForProject inside auto-worktrees (A-1)", () => {
+  const src = readFileSync(
+    resolve(process.cwd(), "src", "resources", "extensions", "gsd", "bootstrap", "register-hooks.ts"),
+    "utf-8",
+  );
+
+  it("session_start hook is gated on isInAutoWorktree", () => {
+    const idx = src.indexOf('pi.on("session_start"');
+    assert.ok(idx !== -1, "session_start handler must exist");
+    const block = src.slice(idx, idx + 2500);
+    assert.ok(
+      block.includes("isInAutoWorktree"),
+      "session_start must consult isInAutoWorktree before preparing MCP",
+    );
+    assert.ok(
+      block.includes("prepareWorkflowMcpForProject"),
+      "session_start still prepares MCP for non-worktree paths",
+    );
+  });
+
+  it("session_switch hook is gated on isInAutoWorktree", () => {
+    const idx = src.indexOf('pi.on("session_switch"');
+    assert.ok(idx !== -1, "session_switch handler must exist");
+    const block = src.slice(idx, idx + 2500);
+    assert.ok(
+      block.includes("isInAutoWorktree"),
+      "session_switch must consult isInAutoWorktree before preparing MCP",
+    );
+  });
+
+  it("tool_call hook forwards event.toolCallId into safetyRecordToolCall (A-3)", () => {
+    // Find the call site (skip the import line by looking for the opening paren).
+    const idx = src.indexOf("safetyRecordToolCall(");
+    assert.ok(idx !== -1, "safetyRecordToolCall call must exist");
+    const line = src.slice(idx, src.indexOf("\n", idx));
+    assert.ok(
+      line.includes("event.toolCallId"),
+      "safetyRecordToolCall must receive event.toolCallId as the first argument",
+    );
+  });
+});
+
+// ─── 3. auto-recovery: verify-fail instrumentation ─────────────────────────
+
+describe("verifyExpectedArtifact: verify-fail exit-point logging (Phase B diag)", () => {
+  const src = readFileSync(
+    resolve(process.cwd(), "src", "resources", "extensions", "gsd", "auto-recovery.ts"),
+    "utf-8",
+  );
+
+  it("logs a verify-fail warning on the null-absPath exit", () => {
+    assert.ok(
+      src.includes('verify-fail ${unitType} ${unitId}: resolveExpectedArtifactPath returned null'),
+      "null-absPath branch must emit a diagnostic line",
+    );
+  });
+
+  it("logs a verify-fail warning on the existsSync-false exit", () => {
+    assert.ok(
+      src.includes("verify-fail ${unitType} ${unitId}: existsSync false"),
+      "existsSync-false branch must emit a diagnostic line",
+    );
+  });
+
+  it("logs a verify-fail warning on the plan-slice no-task-entry exit", () => {
+    assert.ok(
+      src.includes("verify-fail ${unitType} ${unitId}: plan has no task checkbox/heading"),
+      "plan-slice no-task branch must emit a diagnostic line",
+    );
+  });
+
+  it("plan-slice task-plan-files check fails fast on missing tasks dir (hardening)", () => {
+    // The original check silently passed when resolveTasksDir returned null.
+    // The new check returns false with a diagnostic, which is correct — if
+    // the tool successfully planned tasks, the tasks/ dir must exist.
+    const idx = src.indexOf('verify-fail ${unitType} ${unitId}: resolveTasksDir returned null');
+    assert.ok(
+      idx !== -1,
+      "resolveTasksDir-null branch must emit a diagnostic and return false",
+    );
+  });
+});
+
+// ─── 4. workflow-tools (mcp-server): guard + optional projectDir + routing ─
+
+describe("mcp-server workflow-tools: projectDir routing (Phase B root cause)", () => {
+  const src = readFileSync(
+    resolve(process.cwd(), "packages", "mcp-server", "src", "workflow-tools.ts"),
+    "utf-8",
+  );
+
+  it("projectDirParam is optional and documents the default", () => {
+    const idx = src.indexOf("const projectDirParam");
+    assert.ok(idx !== -1, "projectDirParam definition must exist");
+    const block = src.slice(idx, idx + 600);
+    assert.ok(
+      block.includes(".optional()"),
+      "projectDirParam must be optional so the agent stops deliberating",
+    );
+    assert.ok(
+      /Omit this field/i.test(block),
+      "description must tell the agent to omit the field",
+    );
+  });
+
+  it("parseWorkflowArgs defaults projectDir to process.cwd() when omitted", () => {
+    const idx = src.indexOf("function parseWorkflowArgs");
+    assert.ok(idx !== -1, "parseWorkflowArgs must exist");
+    const block = src.slice(idx, idx + 1500);
+    assert.ok(
+      block.includes("parsed.projectDir ?? process.cwd()"),
+      "parseWorkflowArgs must fall back to process.cwd() when projectDir is omitted",
+    );
+  });
+
+  it("validateProjectDir accepts external-state worktree paths via .gsd symlink target", () => {
+    const idx = src.indexOf("function validateProjectDir");
+    assert.ok(idx !== -1, "validateProjectDir must exist");
+    const block = src.slice(idx, idx + 2500);
+    assert.ok(
+      block.includes("resolveExternalStateRoot"),
+      "validateProjectDir must consult resolveExternalStateRoot for external-state layouts",
+    );
+
+    const helperIdx = src.indexOf("function resolveExternalStateRoot");
+    assert.ok(helperIdx !== -1, "resolveExternalStateRoot helper must exist");
+    const helperBlock = src.slice(helperIdx, helperIdx + 600);
+    assert.ok(
+      helperBlock.includes("realpathSync"),
+      "resolveExternalStateRoot must use realpathSync to follow the symlink",
+    );
+    assert.ok(
+      /join\([^)]*\.gsd/.test(helperBlock),
+      "resolveExternalStateRoot must resolve <allowedRoot>/.gsd",
+    );
+  });
+
+  it("parseWorkflowArgs routes tool writes to the active worktree when one exists", () => {
+    // This is the Phase B root-cause fix: when the tool call is scoped to a
+    // milestone that has an auto-worktree at <projectRoot>/.gsd/worktrees/<MID>/,
+    // tool writes must go to the worktree .gsd rather than the shared project .gsd.
+    const parseIdx = src.indexOf("function parseWorkflowArgs");
+    const parseBlock = src.slice(parseIdx, parseIdx + 2500);
+    assert.ok(
+      parseBlock.includes("resolveActiveWorktreeBasePath"),
+      "parseWorkflowArgs must consult resolveActiveWorktreeBasePath",
+    );
+    assert.ok(
+      parseBlock.includes("extractMilestoneId"),
+      "parseWorkflowArgs must extract the milestoneId to locate the worktree",
+    );
+  });
+
+  it("resolveActiveWorktreeBasePath checks .git presence to avoid hijacking stray directories", () => {
+    const idx = src.indexOf("function resolveActiveWorktreeBasePath");
+    assert.ok(idx !== -1, "resolveActiveWorktreeBasePath helper must exist");
+    const block = src.slice(idx, idx + 1200);
+    assert.ok(
+      block.includes('existsSync(join(wtPath, ".git"))'),
+      "resolveActiveWorktreeBasePath must verify a .git file exists in the worktree",
+    );
+  });
+
+  it("extractMilestoneId handles camelCase, snake_case, and short aliases", () => {
+    const idx = src.indexOf("function extractMilestoneId");
+    assert.ok(idx !== -1, "extractMilestoneId helper must exist");
+    const block = src.slice(idx, idx + 600);
+    assert.ok(block.includes("milestoneId"), "must check milestoneId");
+    assert.ok(block.includes("milestone_id"), "must check milestone_id");
+    assert.ok(block.includes("mid"), "must check mid");
+  });
+});


### PR DESCRIPTION
## Summary

Fixes three compounding bugs surfaced by a full auto-mode run on a project using the external-state `.gsd` layout (`~/.gsd/projects/<hash>/`). Each of these was contributing to the symptom "every slice/milestone unit retries once and the final milestone merge fails with a dirty `.mcp.json`".

### A-1 — `.mcp.json` churn breaking milestone merge (`238bd942b`)

`session_start` and `session_switch` unconditionally called `prepareWorkflowMcpForProject`, which rewrites `.mcp.json` with cwd-relative CLI paths. Inside an auto-worktree the file was already written at `createAutoWorktree` time, so every session event post-chdir dirtied the tree mid-run and caused the final `git squash-merge` to reject with:

> Squash merge of milestone/M001 rejected: working tree has dirty or untracked files that conflict with the merge. Dirty files: .mcp.json

Directly confirmed in `a44/.gsd/journal/` — both M001 and M002 failed with that exact error. Gate both hooks on `isInAutoWorktree(process.cwd())`.

### A-3 — Evidence collector corrupting parallel tool calls (`238bd942b`)

`recordToolCall` stored `toolCallId: ""` and `recordToolResult` matched by `findLastUnresolved(kind)` — a backwards scan for entries with empty id. With parallel bash calls, results came back out of order and exit codes/output got stapled onto the wrong entry. Pass the real `toolCallId` at dispatch time and match by id in `recordToolResult`. Dead helper `findLastUnresolved` removed.

### Phase B — The per-unit retry bug (`2139dc052`, `fccc1f79c`, `f8977b022`)

Every `research-slice`, `plan-slice`, `validate-milestone`, `reassess-roadmap`, and `execute-task` dispatched exactly twice in the a44 metrics. Root cause walked through three layers:

**Layer 1 — MCP guard rejected external-state worktree paths (`2139dc052`)**
`validateProjectDir` compared candidate against `GSD_WORKFLOW_PROJECT_ROOT` via literal path containment. When `<project>/.gsd` is a symlink into `~/.gsd/projects/<hash>/`, auto-worktree paths like `~/.gsd/projects/<hash>/worktrees/M003` are outside the literal allowedRoot subtree and got rejected with:

> gsd_complete_slice: projectDir must stay within the configured workflow project root. Received: /Users/.../.gsd/projects/2c7391a6c984/worktrees/M003; allowed root: /Users/.../Github/a44

Fix: on rejection, try `realpathSync(allowedRoot/.gsd)` and accept candidates under the resolved external-state root.

**Layer 2 — Agents burned minutes deliberating which projectDir to pass (`fccc1f79c`)**
With the guard fixed, the schema still required `projectDir` as a string. The agent saw three plausible candidates (git root, worktree path, realpath-resolved external state) and spent 15-minute reasoning loops picking one. Make `projectDirParam` optional with a description that tells the agent to omit it. `parseWorkflowArgs` defaults to `process.cwd()` — the server already knows where it's running.

**Layer 3 — MCP tool writes went to the wrong `.gsd` entirely (`f8977b022`)**
The actual Phase B root cause. The MCP server is a stdio subprocess of Claude Code, so its `process.cwd()` is frozen at Claude Code launch time (the project root `a44`). When auto-mode later chdirs into the worktree, the MCP server doesn't know. Tool writes went to `a44/.gsd/milestones/M004/...` which — because `.gsd` is a symlink into `~/.gsd/projects/<hash>/` — resolves to the **shared project** `.gsd`, not the **per-worktree** `.gsd`. Meanwhile `verifyExpectedArtifact` ran against the worktree path directly. Mismatch → `existsSync` false → retry.

Evidence from `a44/.gsd/projects/2c7391a6c984/worktrees/M004/.gsd/notifications.jsonl` (UTC):
```
16:49:10.566  verify-fail research-slice M004/S01: existsSync false
16:49:10.765  S01-RESEARCH.md mtime in worktree
              (199ms gap = retry's pre-dispatch syncProjectRootToWorktree
               copying project→worktree, not a write race)
17:02:00.340  verify-fail reassess-roadmap M004/S01: existsSync false
17:03:10.278  S01-ASSESSMENT.md mtime in worktree (70s after verify-fail)
```

Fix: in `parseWorkflowArgs`, after resolving projectRoot, check whether an auto-worktree exists at `<projectRoot>/.gsd/worktrees/<milestoneId>/`. If so, use that as the effective basePath so writes land where verify checks. Guarded by a `.git` file presence check to avoid hijacking bare directories. Applies to every workflow tool that takes a `milestoneId`/`milestone_id`/`mid`.

### Diagnostic instrumentation (`69c0552de`)

Added `logWarning("recovery", "verify-fail <type> <id>: <reason>")` at each early-false exit in `verifyExpectedArtifact`. This was the breakthrough — without it the retry bug was invisible. Shipping it so future regressions are diagnosable without a code change. Secondary hardening: `plan-slice` task-plan-files check now fails fast when `resolveTasksDir` returns null instead of silently passing.

## Test plan

- [x] `npm run test:unit` — 6352 passed, 0 failed, 8 skipped
- [x] `npm run build` — clean
- [x] MCP server builds clean (`npm run build:mcp-server`)
- [x] A-1 directly validated against a44 journal (both failed merges show the exact error)
- [x] Phase B root cause validated with subsecond mtimes + verify-fail logs
- [ ] Full auto-mode run against a44 with all four fixes active (pending — user verification)
- [ ] Confirm zero `verify-fail` entries post-fix
- [ ] Confirm milestone merges cleanly without `.mcp.json` dirty error

## Notes for reviewers

- The Layer 3 fix (`f8977b022`) is the highest-leverage but touches parseWorkflowArgs which is hot path for every workflow tool call. The routing logic is guarded so it only kicks in when (a) a milestoneId is present in args and (b) `<projectRoot>/.gsd/worktrees/<milestoneId>/.git` exists. Non-worktree flows are unaffected.
- The instrumentation (`69c0552de`) includes a tightening of the `plan-slice` check (silent-pass → hard-fail when `resolveTasksDir` is null). If `tools` dir not existing is legitimate in some flows, this could cause new retries — mark for careful review.
- `.mcp.json` gate only covers `session_start` + `session_switch`. A fresh Claude Code session started with cwd already inside a worktree would bypass `isInAutoWorktree` because it depends on module-level `originalBase` state only set by `enterAutoWorktree`. Low-frequency path, follow-up.