### PR TITLE
fix(gsd): stop wiping the artifacts table on every cache invalidation

### DIFF
--- a/src/resources/extensions/gsd/cache.ts
+++ b/src/resources/extensions/gsd/cache.ts
@@ -1,6 +1,6 @@
 // GSD Extension — Unified Cache Invalidation
 //
-// Three module-scoped caches exist across the GSD extension:
+// Three module-scoped read caches exist across the GSD extension:
 //   1. State cache (state.ts)  — memoized deriveState() result
 //   2. Path cache  (paths.ts)  — directory listing results (readdirSync)
 //   3. Parse cache (files.ts)  — parsed markdown file results
@@ -8,22 +8,33 @@
 // After any file write that changes .gsd/ contents, all three must be
 // invalidated together to prevent stale reads. This module provides a
 // single function that clears all three atomically.
+//
+// NOTE: The DB `artifacts` table is NOT included here. Earlier versions
+// called clearArtifacts() as part of this bundle (#793), intending to
+// force deriveState() to re-parse from disk when files were edited
+// out-of-band. But invalidateAllCaches() fires on every post-unit pass,
+// so bundling a DESTRUCTIVE `DELETE FROM artifacts` with routine cache
+// invalidation meant every row written by saveArtifactToDb / writeAndStore
+// was wiped within seconds — leaving the milestone completed on disk but
+// the `artifacts` table empty and the agent looping on "file exists but
+// DB record missing" recovery calls. If a call site genuinely needs the
+// artifact table cleared after an out-of-band file mutation, it should
+// invoke clearArtifacts() from gsd-db.js explicitly — do not add it back
+// here.
 
 import { invalidateStateCache } from './state.js';
 import { clearPathCache } from './paths.js';
 import { clearParseCache } from './files.js';
-import { clearArtifacts } from './gsd-db.js';
 
 /**
- * Invalidate all GSD runtime caches in one call.
+ * Invalidate all GSD runtime read caches in one call.
  *
  * Call this after file writes, milestone transitions, merge reconciliation,
  * or any operation that changes .gsd/ contents on disk. Forgetting to clear
- * any single cache causes stale reads (see #431, #793).
+ * any single cache causes stale reads (see #431).
  */
 export function invalidateAllCaches(): void {
   invalidateStateCache();
   clearPathCache();
   clearParseCache();
-  clearArtifacts();
 }

--- a/src/resources/extensions/gsd/tests/artifacts-table-preserved-on-cache-invalidate.test.ts
+++ b/src/resources/extensions/gsd/tests/artifacts-table-preserved-on-cache-invalidate.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Regression test: invalidateAllCaches() must NOT wipe the artifacts table.
+ *
+ * Prior to this fix, `cache.ts` bundled `clearArtifacts()` (which runs
+ * `DELETE FROM artifacts`) into `invalidateAllCaches()`. That helper fires
+ * on every post-unit pass, so rows written by `saveArtifactToDb` and
+ * `writeAndStore` (RESEARCH, CONTEXT, VALIDATION, ASSESSMENT, PLAN,
+ * ROADMAP, task PLAN, task SUMMARY) got deleted within seconds of being
+ * written. The milestone completed on disk, but `SELECT COUNT(*) FROM
+ * artifacts` returned 0, and the agent fell into a "file exists but DB
+ * record missing" recovery loop.
+ *
+ * The artifacts table is a write-through store, not a read cache. Routine
+ * cache invalidation must preserve its contents.
+ *
+ * Copyright (c) 2026 Jeremy McSpadden <jeremy@fluxlabs.net>
+ */
+
+import { describe, test, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { invalidateAllCaches } from "../cache.ts";
+import {
+  openDatabase,
+  closeDatabase,
+  insertArtifact,
+  isDbAvailable,
+  _getAdapter,
+} from "../gsd-db.ts";
+
+afterEach(() => {
+  if (isDbAvailable()) {
+    try {
+      closeDatabase();
+    } catch {
+      /* best-effort teardown */
+    }
+  }
+});
+
+describe("invalidateAllCaches() must preserve the artifacts table", () => {
+  test("rows survive a single invalidate call", () => {
+    const opened = openDatabase(":memory:");
+    assert.equal(opened, true, "in-memory DB must open");
+
+    insertArtifact({
+      path: "milestones/M001/slices/S01/S01-RESEARCH.md",
+      artifact_type: "RESEARCH",
+      milestone_id: "M001",
+      slice_id: "S01",
+      task_id: null,
+      full_content: "# Research\n\nFindings go here.\n",
+    });
+
+    invalidateAllCaches();
+
+    const adapter = _getAdapter();
+    assert.ok(adapter, "adapter should be available");
+    const row = adapter!
+      .prepare(
+        "SELECT path, artifact_type, length(full_content) AS len FROM artifacts WHERE path = :path",
+      )
+      .get({ ":path": "milestones/M001/slices/S01/S01-RESEARCH.md" }) as
+      | { path: string; artifact_type: string; len: number }
+      | undefined;
+
+    assert.ok(
+      row,
+      "artifact row must still exist after invalidateAllCaches — this is the Phase B bug",
+    );
+    assert.equal(row!.artifact_type, "RESEARCH");
+    assert.ok((row!.len ?? 0) > 0, "full_content must not be truncated");
+  });
+
+  test("multiple rows for a full milestone survive repeated invalidates", () => {
+    openDatabase(":memory:");
+
+    const inserts = [
+      {
+        path: "milestones/M001/M001-ROADMAP.md",
+        artifact_type: "ROADMAP",
+        milestone_id: "M001",
+        slice_id: null,
+        task_id: null,
+      },
+      {
+        path: "milestones/M001/slices/S01/S01-RESEARCH.md",
+        artifact_type: "RESEARCH",
+        milestone_id: "M001",
+        slice_id: "S01",
+        task_id: null,
+      },
+      {
+        path: "milestones/M001/slices/S01/S01-PLAN.md",
+        artifact_type: "PLAN",
+        milestone_id: "M001",
+        slice_id: "S01",
+        task_id: null,
+      },
+      {
+        path: "milestones/M001/slices/S01/tasks/T01-PLAN.md",
+        artifact_type: "PLAN",
+        milestone_id: "M001",
+        slice_id: "S01",
+        task_id: "T01",
+      },
+      {
+        path: "milestones/M001/slices/S01/tasks/T01-SUMMARY.md",
+        artifact_type: "SUMMARY",
+        milestone_id: "M001",
+        slice_id: "S01",
+        task_id: "T01",
+      },
+      {
+        path: "milestones/M001/M001-SUMMARY.md",
+        artifact_type: "SUMMARY",
+        milestone_id: "M001",
+        slice_id: null,
+        task_id: null,
+      },
+    ];
+
+    for (const i of inserts) {
+      insertArtifact({ ...i, full_content: `# ${i.artifact_type} content\n` });
+    }
+
+    // Simulate a full milestone's worth of post-unit cycles.
+    for (let i = 0; i < 10; i++) {
+      invalidateAllCaches();
+    }
+
+    const adapter = _getAdapter()!;
+    const count = (
+      adapter.prepare("SELECT COUNT(*) AS n FROM artifacts").get() as { n: number }
+    ).n;
+
+    assert.equal(
+      count,
+      inserts.length,
+      `all ${inserts.length} artifact rows must survive repeated invalidate calls; got ${count}`,
+    );
+  });
+});
+
+describe("cache.ts must not re-import clearArtifacts into invalidateAllCaches", () => {
+  const src = readFileSync(
+    resolve(process.cwd(), "src", "resources", "extensions", "gsd", "cache.ts"),
+    "utf-8",
+  );
+
+  test("clearArtifacts is not imported from gsd-db", () => {
+    assert.ok(
+      !/import\s*\{[^}]*clearArtifacts[^}]*\}\s*from\s*['"]\.\/gsd-db/.test(src),
+      "cache.ts must not import clearArtifacts — it causes the artifacts-table-wipe regression",
+    );
+  });
+
+  test("invalidateAllCaches does not call clearArtifacts", () => {
+    const fnIdx = src.indexOf("function invalidateAllCaches");
+    assert.ok(fnIdx !== -1);
+    const body = src.slice(fnIdx, fnIdx + 1000);
+    assert.ok(
+      !/\bclearArtifacts\s*\(/.test(body),
+      "invalidateAllCaches must not call clearArtifacts() — it wipes the write-through store",
+    );
+  });
+
+  test("cache.ts documents why clearArtifacts is not bundled here", () => {
+    // Future reviewers need to see the rationale or they'll re-add it.
+    assert.ok(
+      /artifacts.*NOT included|write-through store/i.test(src),
+      "cache.ts must explain why the artifacts table is NOT invalidated here",
+    );
+  });
+});


### PR DESCRIPTION
Closes #4291

## Summary

`cache.ts::invalidateAllCaches()` was bundling `clearArtifacts()` (literal `DELETE FROM artifacts`) into the routine cache invalidation path. Because `invalidateAllCaches()` fires multiple times per post-unit pass and at several points during auto-mode setup, every row written by `saveArtifactToDb` or `writeAndStore` was deleted within seconds of being written. On a test project where a milestone completed successfully with every artifact file on disk, `SELECT COUNT(*) FROM artifacts;` returned **0**.

The rationale in the commit that introduced the bundling (`a2453fa0e`, PR #793) was *"the artifacts table is a read cache — clearing it forces the next `deriveState()` to fall through to disk reads"*. That premise is wrong: the table is a write-through store, not a read cache. `saveArtifactToDb` and `writeAndStore` populate it as they go, and later reads (D004 content lookup, cross-process access, recovery paths) depend on it being populated.

## Symptoms this explains

- **Empty `artifacts` table on completed projects** — `a45/.gsd/gsd.db` shows 9 markdown files on disk for M001 but zero rows in the table.
- **Per-unit retry loop** — event log shows `plan-slice M001/S01` dispatched twice one minute apart, even on a clean fresh project with no prior state.
- **Agent "file exists but DB record missing" reasoning** — captured in live runs. Agent is factually correct; the row really is missing because we just wiped it.
- **Every artifact type affected:** RESEARCH, CONTEXT, VALIDATION, ASSESSMENT (via `gsd_summary_save` → `saveArtifactToDb`), PLAN, ROADMAP, task PLAN, task SUMMARY (via `renderPlanFromDb` / `renderTaskPlanFromDb` / `renderRoadmapFromDb` → `writeAndStore`).

## Fix

Remove `clearArtifacts()` from `invalidateAllCaches()`. The function itself stays in `gsd-db.ts` so a future caller that genuinely needs to drop cached content after an out-of-band file mutation can invoke it explicitly — but there's no such caller today, and re-adding it to the routine invalidate path would reintroduce the bug.

`cache.ts` now documents the rationale in the file header so future reviewers don't re-bundle it.

## Regression test

`src/resources/extensions/gsd/tests/artifacts-table-preserved-on-cache-invalidate.test.ts`:

- **Functional:** opens an in-memory DB, inserts a RESEARCH artifact, calls `invalidateAllCaches()`, confirms the row is still there. Second test inserts six rows for a full milestone's worth of artifacts, calls `invalidateAllCaches()` ten times in a row, confirms all six survive.
- **Source shape:** asserts `cache.ts` no longer imports `clearArtifacts`, asserts `invalidateAllCaches()` body does not call it, asserts the file header explains why — these guard against someone re-adding it without reading the commit history.

## Scope note

This is orthogonal to PR #4288 (MCP external-state worktree routing). That PR addresses a different mismatch between tool-write location and verify-check location in the symlink-based external state layout. Both bugs were contributing to per-unit retries in different projects / different layouts. Ship both.

## Test plan

- [x] `npm run test:unit` → 6359 passed, 0 failed
- [x] `npm run copy-resources` clean
- [x] Functional regression test written (in-memory DB with real `insertArtifact` + `invalidateAllCaches` cycle)
- [ ] Live auto-mode run against a fresh project — confirm `sqlite3 .gsd/gsd.db "SELECT COUNT(*) FROM artifacts"` returns a non-zero count after milestone completion
- [ ] Live auto-mode run — confirm no per-unit retries (single dispatch of research-slice / plan-slice / validate-milestone per event log)