### PR TITLE
fix(tui): unstick tool cards after compaction and promote success notifications

### DIFF
--- a/packages/pi-coding-agent/src/modes/interactive/components/tool-execution.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/components/tool-execution.ts
@@ -428,6 +428,23 @@ export class ToolExecutionComponent extends Container {
 	}
 
 	/**
+	 * Mark a tool call as historical when replaying from session context and
+	 * no matching tool result is available. Happens after compaction squashes
+	 * tool_result messages out of history — the tool call block survives but
+	 * the result is gone. Without this, the component stays in "Running" state
+	 * forever even though the tool completed long ago.
+	 */
+	markHistoricalNoResult(): void {
+		if (this.result) return; // real result already set, nothing to do
+		this.isPartial = false;
+		this.result = {
+			content: [],
+			isError: false,
+		};
+		this.updateDisplay();
+	}
+
+	/**
 	 * Finalize a pending tool call as failed/interrupted while preserving any streamed partial output.
 	 */
 	completeWithError(message?: string): void {

--- a/packages/pi-coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/interactive-mode.ts
@@ -1827,6 +1827,8 @@ export class InteractiveMode {
 			this.showError(message);
 		} else if (type === "warning") {
 			this.showWarning(message);
+		} else if (type === "success") {
+			this.showSuccess(message);
 		} else {
 			this.showStatus(message, { append: true });
 		}
@@ -2339,6 +2341,12 @@ export class InteractiveMode {
 			}
 		}
 
+		// Any pendingTools entries left over after replay are historical tool
+		// calls whose results were squashed out of session context (commonly by
+		// compaction). Mark them finished so the frame stops showing "Running".
+		for (const component of this.pendingTools.values()) {
+			component.markHistoricalNoResult();
+		}
 		this.pendingTools.clear();
 		this.trimChatHistory();
 		this.ui.requestRender();
@@ -2734,6 +2742,17 @@ export class InteractiveMode {
 	showWarning(warningMessage: string): void {
 		this.chatContainer.addChild(new Spacer(1));
 		this.chatContainer.addChild(new Text(theme.fg("warning", `Warning: ${warningMessage}`), 1, 0));
+		this.ui.requestRender();
+	}
+
+	showSuccess(successMessage: string): void {
+		this.chatContainer.addChild(new Spacer(1));
+		this.chatContainer.addChild(new DynamicBorder((text) => theme.fg("success", text)));
+		this.chatContainer.addChild(
+			new Text(theme.fg("success", successMessage), 1, 0),
+		);
+		this.chatContainer.addChild(new DynamicBorder((text) => theme.fg("success", text)));
+		this.chatContainer.addChild(new Spacer(1));
 		this.ui.requestRender();
 	}
 

--- a/src/resources/extensions/gsd/guided-flow.ts
+++ b/src/resources/extensions/gsd/guided-flow.ts
@@ -272,7 +272,7 @@ export function checkAutoStartAfterDiscuss(): boolean {
   try { unlinkSync(manifestPath); } catch (e) { logWarning("guided", `manifest unlink failed: ${(e as Error).message}`); }
 
   pendingAutoStartMap.delete(basePath);
-  ctx.ui.notify(`Milestone ${milestoneId} ready.`, "info");
+  ctx.ui.notify(`Milestone ${milestoneId} ready.`, "success");
   startAutoDetached(ctx, pi, basePath, false, { step });
   return true;
 }

--- a/src/tests/tui-running-and-success-box.test.ts
+++ b/src/tests/tui-running-and-success-box.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Regression tests for two TUI bugs:
+ *
+ *   1. Tool execution cards stuck in "Running" state after compaction.
+ *      When the session is rebuilt from history (post-compaction or session
+ *      switch), tool result messages may have been squashed out of context.
+ *      ToolExecutionComponent instances created from history without a result
+ *      stay in `isPartial = true` forever, rendering the "Running" badge long
+ *      after the tool completed. Fix: markHistoricalNoResult() flips them to
+ *      a finished, no-result state and renderSessionContext calls it on any
+ *      leftover pendingTools before clearing the map.
+ *
+ *   2. Completion notifications rendered as plain dim text.
+ *      `ctx.ui.notify("…", "info")` routed through showStatus which produced
+ *      a single-line dim Text component — indistinguishable from chatter.
+ *      Completion messages (notify type = "success") now render inside a
+ *      green DynamicBorder frame via showSuccess, matching the design of
+ *      showNewVersionNotification but in success color.
+ *
+ * These tests are source-shape assertions (not runtime exercises) to keep
+ * the test cheap — the actual components depend on the TUI runtime stack
+ * which isn't easily instantiable in unit tests.
+ *
+ * Copyright (c) 2026 Jeremy McSpadden <jeremy@fluxlabs.net>
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const toolExecSrc = readFileSync(
+  resolve(
+    process.cwd(),
+    "packages",
+    "pi-coding-agent",
+    "src",
+    "modes",
+    "interactive",
+    "components",
+    "tool-execution.ts",
+  ),
+  "utf-8",
+);
+
+const interactiveSrc = readFileSync(
+  resolve(
+    process.cwd(),
+    "packages",
+    "pi-coding-agent",
+    "src",
+    "modes",
+    "interactive",
+    "interactive-mode.ts",
+  ),
+  "utf-8",
+);
+
+const guidedFlowSrc = readFileSync(
+  resolve(process.cwd(), "src", "resources", "extensions", "gsd", "guided-flow.ts"),
+  "utf-8",
+);
+
+// ─── Bug 1: tools stuck in "Running" after compaction ────────────────────
+
+describe("ToolExecutionComponent.markHistoricalNoResult (post-compaction fix)", () => {
+  it("defines markHistoricalNoResult on ToolExecutionComponent", () => {
+    assert.ok(
+      /markHistoricalNoResult\s*\(\s*\)\s*:\s*void/.test(toolExecSrc),
+      "ToolExecutionComponent must expose markHistoricalNoResult(): void",
+    );
+  });
+
+  it("markHistoricalNoResult clears isPartial and sets an empty result", () => {
+    const idx = toolExecSrc.indexOf("markHistoricalNoResult");
+    assert.ok(idx !== -1);
+    // Find the method body window
+    const body = toolExecSrc.slice(idx, idx + 600);
+    assert.ok(
+      body.includes("this.isPartial = false"),
+      "markHistoricalNoResult must set isPartial = false so the frame flips out of Running",
+    );
+    assert.ok(
+      body.includes("this.result"),
+      "markHistoricalNoResult must populate this.result so !this.result is false",
+    );
+    assert.ok(
+      body.includes("updateDisplay"),
+      "markHistoricalNoResult must trigger a re-render",
+    );
+  });
+
+  it("markHistoricalNoResult is idempotent when a real result already exists", () => {
+    // The method returns early if this.result is already set so a late-
+    // arriving stream update doesn't clobber legitimate result content.
+    const idx = toolExecSrc.indexOf("markHistoricalNoResult");
+    const body = toolExecSrc.slice(idx, idx + 600);
+    assert.ok(
+      /if\s*\(\s*this\.result\s*\)\s*return/.test(body),
+      "markHistoricalNoResult must early-return when a result is already present",
+    );
+  });
+
+  it("frameStatus still reads isPartial + result to derive Running/Done", () => {
+    // Guard against accidental regression: the status label depends on both
+    // fields being in the correct state after markHistoricalNoResult runs.
+    assert.ok(
+      /frameStatus\s*=\s*this\.isPartial\s*\|\|\s*!this\.result\s*\?\s*"Running"/.test(toolExecSrc),
+      "frameStatus derivation must remain: Running when isPartial || !result, otherwise Done/Error",
+    );
+  });
+
+  it("renderSessionContext marks leftover pendingTools as historical before clearing", () => {
+    // After replay, any pendingTools without matching toolResult messages are
+    // compaction survivors. Without this call they'd remain "Running" forever.
+    const renderIdx = interactiveSrc.indexOf("private renderSessionContext");
+    assert.ok(renderIdx !== -1, "renderSessionContext must exist");
+    // The method defines-its-scope with the next `private ` member that
+    // follows. Grab the full body so we can assert the end-of-method sweep.
+    const nextMemberIdx = interactiveSrc.indexOf("\n\trenderInitialMessages", renderIdx);
+    assert.ok(nextMemberIdx !== -1, "could not locate end of renderSessionContext body");
+    const block = interactiveSrc.slice(renderIdx, nextMemberIdx);
+    assert.ok(
+      block.includes("markHistoricalNoResult"),
+      "renderSessionContext must call markHistoricalNoResult on leftover pendingTools before clearing",
+    );
+    assert.ok(
+      /for\s*\(\s*const\s+\w+\s+of\s+this\.pendingTools\.values\(\)\s*\)/.test(block),
+      "the sweep must iterate this.pendingTools.values()",
+    );
+  });
+});
+
+// ─── Bug 2: completion messages should be a green bordered box ───────────
+
+describe("showSuccess bordered notification (completion message styling)", () => {
+  it("defines showSuccess(message: string): void on interactive-mode", () => {
+    assert.ok(
+      /showSuccess\s*\(\s*\w+\s*:\s*string\s*\)\s*:\s*void/.test(interactiveSrc),
+      "interactive-mode must expose showSuccess(message: string): void",
+    );
+  });
+
+  it("showSuccess uses DynamicBorder with the success theme color", () => {
+    // Locate the METHOD DEFINITION (not a call site). The definition has a
+    // typed parameter signature like `showSuccess(successMessage: string)`.
+    const methodMatch = interactiveSrc.match(/showSuccess\s*\(\s*\w+\s*:\s*string\s*\)\s*:\s*void\s*\{/);
+    assert.ok(methodMatch && methodMatch.index !== undefined, "showSuccess method definition must exist");
+    const body = interactiveSrc.slice(methodMatch.index, methodMatch.index + 900);
+    assert.ok(
+      body.includes("DynamicBorder"),
+      "showSuccess must wrap the message in a DynamicBorder (matches showNewVersionNotification style)",
+    );
+    assert.ok(
+      /theme\.fg\(\s*["']success["']/.test(body),
+      'showSuccess must color the border/text via theme.fg("success", …)',
+    );
+    // Two borders — top and bottom — for the boxed look.
+    const borderMatches = body.match(/new\s+DynamicBorder\b/g) ?? [];
+    assert.ok(
+      borderMatches.length >= 2,
+      "showSuccess must add both a top and bottom DynamicBorder for the boxed frame",
+    );
+  });
+
+  it("showExtensionNotify routes type='success' to showSuccess", () => {
+    const idx = interactiveSrc.indexOf("showExtensionNotify");
+    assert.ok(idx !== -1);
+    const body = interactiveSrc.slice(idx, idx + 1200);
+    assert.ok(
+      /type\s*===\s*["']success["']/.test(body),
+      "showExtensionNotify must branch on type === 'success'",
+    );
+    // The success branch must reach showSuccess, not fall through to showStatus.
+    const successIdx = body.indexOf('type === "success"');
+    const successBranch = body.slice(successIdx, successIdx + 300);
+    assert.ok(
+      successBranch.includes("showSuccess"),
+      "type === 'success' must be routed to this.showSuccess",
+    );
+  });
+
+  it('guided-flow emits "Milestone ready" as a success notification', () => {
+    assert.ok(
+      guidedFlowSrc.includes('ctx.ui.notify(`Milestone ${milestoneId} ready.`, "success")'),
+      "guided-flow must emit the milestone-ready notification with type 'success' so it renders in the green box",
+    );
+  });
+});


### PR DESCRIPTION
Two independent TUI bugs surfaced during a full auto-mode run.

## Bug 1 — tool execution cards stuck in "Running" forever after compaction

**Symptom:** after a session compaction, every historical tool card in the chat scroll still showed the yellow **Running** badge, even though the tools had completed long ago.

**Cause:** when the session is rebuilt from history (`rebuildChatFromMessages` → `renderSessionContext`), `pendingTools` gets new `ToolExecutionComponent` instances for every tool_call block in the replayed content. Each starts with `isPartial = true` and no result. Matching is then done against `toolResult` messages later in the replayed stream — but after compaction, tool results are squashed out of context entirely, so those components stay in the "Running" state forever even though the tool completed long ago.

**Fix:** `ToolExecutionComponent.markHistoricalNoResult()` flips `isPartial` to `false` and assigns an empty result so `frameStatus` flows into the "Done" branch. Guarded by an early return when a real result is already present so late stream updates can't be clobbered. `renderSessionContext` walks any `pendingTools` entries still leftover after replay and marks them historical before clearing the map.

## Bug 2 — completion notifications rendered as plain dim text

**Symptom:** `ctx.ui.notify("Milestone M001 ready.", "info")` fell through `showExtensionNotify` into `showStatus`, producing a single-line dim `Text` component indistinguishable from progress chatter. Completion events deserve a distinct visual design.

**Fix:** new `interactive-mode.showSuccess(message)` method that wraps the message in a green `DynamicBorder` frame with a trailing `Spacer(1)` for breathing room — same structure as `showNewVersionNotification` but `theme.fg("success", …)` instead of `"warning"`. `showExtensionNotify` now routes `type === "success"` to this method. `guided-flow.ts` updates the "Milestone ready" notify call from `"info"` → `"success"` so it lands in the green box.

## Visual

**Before** (1 line of dim plain text):
```
Milestone M001 ready.
```

**After** (bordered frame with breathing room):
```

───────────────────────────────────────────────────
 Milestone M001 ready.
───────────────────────────────────────────────────

```
Where all three `─` lines and the message itself render through `theme.fg("success", …)`.

## Files changed

- `packages/pi-coding-agent/src/modes/interactive/components/tool-execution.ts` — `markHistoricalNoResult()` method
- `packages/pi-coding-agent/src/modes/interactive/interactive-mode.ts` — `showSuccess()` method, route `"success"` from `showExtensionNotify`, call `markHistoricalNoResult()` on leftover `pendingTools` in `renderSessionContext`
- `src/resources/extensions/gsd/guided-flow.ts` — notify type for milestone-ready message
- `src/tests/tui-running-and-success-box.test.ts` — eight source-shape regression assertions covering both fixes

## Test plan

- [x] `npm run build:pi-coding-agent` clean
- [x] `npm run copy-resources` clean
- [x] `npm run test:unit` → 6403 passed, 0 failed, 8 skipped
- [x] `bash scripts/require-tests.sh` gate satisfied
- [ ] Live auto-mode run — visually confirm the green completion box appears and historical tool cards show "Done" after compaction