### PR TITLE
fix(ci): stage all workspace package.json files in release commit

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -219,7 +219,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add package.json package-lock.json web/package-lock.json CHANGELOG.md native/npm/*/package.json pkg/package.json packages/pi-coding-agent/package.json
+          git add package.json package-lock.json web/package-lock.json CHANGELOG.md native/npm/*/package.json pkg/package.json packages/*/package.json
           git commit -m "release: v${RELEASE_VERSION}"
           git tag "v${RELEASE_VERSION}"
           git pull --rebase origin main


### PR DESCRIPTION
## Summary

The v2.75.0 production release failed at the "Commit and tag release" step with:

\`\`\`
error: cannot pull with rebase: You have unstaged changes.
error: Please commit or stash them.
\`\`\`

[Failing run →](https://github.com/gsd-build/gsd-2/actions/runs/24481288730/job/71546808649)

## Root cause

Commit \`481880670 fix(release): sync all workspace versions and harden release scripts\` (Apr 14) expanded \`scripts/bump-version.mjs\` to update every workspace package under \`packages/*\` — 8 packages: \`daemon\`, \`mcp-server\`, \`native\`, \`pi-agent-core\`, \`pi-ai\`, \`pi-coding-agent\`, \`pi-tui\`, \`rpc-client\`. The goal was to stop those packages from drifting minor versions behind the root.

But the corresponding \`git add\` in \`pipeline.yml:222\` was not updated to match. It still only staged \`packages/pi-coding-agent/package.json\`, missing the other 7. The v2.75.0 run therefore:

1. \`bump-version.mjs\` modified all 8 workspace package.json files
2. \`git commit\` staged just 1 of them → commit succeeded (\`[main d5b6658ad] release: v2.75.0\`, 10 files)
3. \`git tag v2.75.0\` succeeded
4. \`git pull --rebase origin main\` refused because the other 7 \`packages/*/package.json\` were still dirty

## Fix

Swap the single \`packages/pi-coding-agent/package.json\` add for a \`packages/*/package.json\` glob so every workspace bumped by \`bump-version.mjs\` lands in the release commit.

\`\`\`diff
-git add ... packages/pi-coding-agent/package.json
+git add ... packages/*/package.json
\`\`\`

The glob expands to exactly the 8 packages the script touches (verified locally) and stays forward-compatible: any new workspace added to both the script's hardcoded list and the \`packages/*\` directory is picked up automatically.

## Test plan

No test runner exercises the prod-release workflow locally — it only runs on pushes to main. The real verification will be the next version bump. This PR is a single-line glob change in the workflow file, reviewed via:

- [x] Confirmed glob expansion matches the 8 packages in \`scripts/bump-version.mjs\`'s hardcoded list
- [x] Confirmed no other files modified by the script chain are missing from the \`git add\` line
  - root \`package.json\` ✓
  - root \`package-lock.json\` ✓
  - \`web/package-lock.json\` ✓
  - \`CHANGELOG.md\` ✓
  - \`native/npm/*/package.json\` ✓
  - \`pkg/package.json\` ✓
  - \`packages/*/package.json\` ✓ (this PR)