### PR TITLE
fix(update): detect bun install via argv[1] path (#4145)

### DIFF
--- a/src/resources/extensions/gsd/commands-handlers.ts
+++ b/src/resources/extensions/gsd/commands-handlers.ts
@@ -7,7 +7,8 @@
 
 import type { ExtensionAPI, ExtensionCommandContext } from "@gsd/pi-coding-agent";
 import { existsSync, readFileSync, mkdirSync } from "node:fs";
-import { join } from "node:path";
+import { join, resolve as resolvePath, sep } from "node:path";
+import { homedir } from "node:os";
 import { deriveState } from "./state.js";
 import { gsdRoot } from "./paths.js";
 import { appendCapture, hasPendingCaptures, loadPendingCaptures } from "./captures.js";
@@ -28,8 +29,24 @@ import { loadPrompt } from "./prompt-loader.js";
 const UPDATE_REGISTRY_URL = "https://registry.npmjs.org/gsd-pi/latest";
 const UPDATE_FETCH_TIMEOUT_MS = 5000;
 
+// Detects a bun-installed gsd via `process.argv[1]`. Mirrors isBunInstall in
+// src/update-check.ts — duplicated because tsconfig.resources.json rootDir
+// prevents importing from src/. See #4145 for why the runtime-only check
+// (process.versions.bun) is insufficient: bun's global bin shims are plain
+// symlinks, so the target's #!/usr/bin/env node shebang runs the script under
+// Node even when it was installed by bun.
+function isBunInstall(argv1: string | undefined = process.argv[1]): boolean {
+  if ('bun' in process.versions) return true;
+  if (!argv1) return false;
+  const bunBinDirs: string[] = [];
+  if (process.env.BUN_INSTALL) bunBinDirs.push(join(process.env.BUN_INSTALL, "bin"));
+  bunBinDirs.push(join(homedir(), ".bun", "bin"));
+  const resolved = resolvePath(argv1);
+  return bunBinDirs.some((dir) => resolved.startsWith(resolvePath(dir) + sep));
+}
+
 function resolveInstallCommand(pkg: string): string {
-  if ('bun' in process.versions) return `bun add -g ${pkg}`;
+  if (isBunInstall()) return `bun add -g ${pkg}`;
   return `npm install -g ${pkg}`;
 }
 

--- a/src/tests/update-cmd-diagnostics.test.ts
+++ b/src/tests/update-cmd-diagnostics.test.ts
@@ -82,3 +82,65 @@ test("commands-handlers uses resolveInstallCommand instead of hardcoded npm (#41
     "/gsd update handler should use resolveInstallCommand for package manager detection",
   );
 });
+
+test("isBunInstall detects bun install via argv[1] even when process.versions.bun is undefined (#4145)", async () => {
+  const { isBunInstall } = await import("../update-check.js");
+  const orig = (process.versions as Record<string, string | undefined>).bun;
+  const origArgv1 = process.argv[1];
+  const origBunInstall = process.env.BUN_INSTALL;
+  try {
+    // Simulate running under Node (not Bun) — matches the real-world shim case
+    // where the bun-installed symlink's target has #!/usr/bin/env node.
+    delete (process.versions as Record<string, string | undefined>).bun;
+    delete process.env.BUN_INSTALL;
+
+    // argv[1] preserves the unresolved symlink path, not the realpath target.
+    process.argv[1] = join(process.env.HOME ?? "/home/user", ".bun", "bin", "gsd");
+    assert.equal(isBunInstall(), true, "should detect bun install from ~/.bun/bin/ argv[1]");
+
+    // Custom BUN_INSTALL location
+    process.env.BUN_INSTALL = "/opt/bun";
+    process.argv[1] = "/opt/bun/bin/gsd";
+    assert.equal(isBunInstall(), true, "should detect bun install from $BUN_INSTALL/bin/ argv[1]");
+
+    // Non-bun path must NOT match
+    delete process.env.BUN_INSTALL;
+    process.argv[1] = "/usr/local/lib/node_modules/gsd-pi/dist/loader.js";
+    assert.equal(isBunInstall(), false, "npm global install path should not match");
+
+    // Prefix false-positive guard: /.bun/bin-other should not match /.bun/bin
+    process.argv[1] = join(process.env.HOME ?? "/home/user", ".bun", "bin-other", "gsd");
+    assert.equal(isBunInstall(), false, "sibling dir with bin prefix should not match");
+  } finally {
+    if (orig === undefined) {
+      delete (process.versions as Record<string, string | undefined>).bun;
+    } else {
+      (process.versions as Record<string, string | undefined>).bun = orig;
+    }
+    process.argv[1] = origArgv1;
+    if (origBunInstall === undefined) {
+      delete process.env.BUN_INSTALL;
+    } else {
+      process.env.BUN_INSTALL = origBunInstall;
+    }
+  }
+});
+
+test("isBunInstall returns true when running under Bun runtime (#4145)", async () => {
+  const { isBunInstall } = await import("../update-check.js");
+  const orig = (process.versions as Record<string, string | undefined>).bun;
+  const origArgv1 = process.argv[1];
+  try {
+    (process.versions as Record<string, string | undefined>).bun = "1.0.0";
+    // Even with a non-bun argv[1], runtime detection wins
+    process.argv[1] = "/usr/local/lib/node_modules/gsd-pi/dist/loader.js";
+    assert.equal(isBunInstall(), true);
+  } finally {
+    if (orig === undefined) {
+      delete (process.versions as Record<string, string | undefined>).bun;
+    } else {
+      (process.versions as Record<string, string | undefined>).bun = orig;
+    }
+    process.argv[1] = origArgv1;
+  }
+});

--- a/src/update-check.ts
+++ b/src/update-check.ts
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs'
-import { dirname, join } from 'node:path'
+import { dirname, join, resolve as resolvePath, sep } from 'node:path'
+import { homedir } from 'node:os'
 import chalk from 'chalk'
 import { appRoot } from './app-paths.js'
 import { execSync } from 'node:child_process'
@@ -74,10 +75,29 @@ export async function fetchLatestVersionFromRegistry(
   }
 }
 
+/**
+ * Detects whether the currently-running gsd binary was installed via `bun add -g`.
+ *
+ * Bun's global bin entries on macOS/Linux are plain symlinks that point at the
+ * package's bin file. The OS honors the target file's shebang, so a bin with
+ * `#!/usr/bin/env node` runs under Node and `process.versions.bun` is undefined
+ * — even though the binary was installed by bun. Checking the runtime alone
+ * (PR #4147) misses this path. Inspect the unresolved invocation path instead.
+ */
+export function isBunInstall(argv1: string | undefined = process.argv[1]): boolean {
+  if ('bun' in process.versions) return true
+  if (!argv1) return false
+
+  const bunBinDirs: string[] = []
+  if (process.env.BUN_INSTALL) bunBinDirs.push(join(process.env.BUN_INSTALL, 'bin'))
+  bunBinDirs.push(join(homedir(), '.bun', 'bin'))
+
+  const resolved = resolvePath(argv1)
+  return bunBinDirs.some((dir) => resolved.startsWith(resolvePath(dir) + sep))
+}
+
 export function resolveInstallCommand(pkg: string): string {
-  if ('bun' in process.versions) {
-    return `bun add -g ${pkg}`
-  }
+  if (isBunInstall()) return `bun add -g ${pkg}`
   return `npm install -g ${pkg}`
 }
 


### PR DESCRIPTION
## TL;DR

**What:** `gsd update` now correctly picks `bun add -g` vs `npm install -g` when gsd-pi was installed via `bun add -g`.
**Why:** PR #4147 tried to fix #4145 with `'bun' in process.versions`, but that check is always false for the actual bug case — so #4145 is still broken.
**How:** Detect the invocation path (`process.argv[1]`) against `$BUN_INSTALL/bin` / `~/.bun/bin`, not the runtime.

## Why PR #4147 didn't work

PR #4147's description claimed: *"Bun's global install shims invoke the script via bun directly, bypassing the `#!/usr/bin/env node` shebang in loader.ts, so this property is reliably set for Bun-installed instances."*

That premise is **factually wrong**, verified empirically on bun 1.3.8 / macOS:

1. \`bun add -g cowsay\` creates \`~/.bun/bin/cowsay\` as a **plain symlink** pointing at the package's bin file (not a wrapper script that re-invokes bun).
2. The target file has \`#!/usr/bin/env node\`.
3. When the user runs \`~/.bun/bin/cowsay\`, the OS follows the symlink and honors the \`#!/usr/bin/env node\` shebang → script executes under **Node**, not Bun.
4. Inside the process: \`process.versions.bun\` is \`undefined\`, \`process.execPath\` is Node, so \`resolveInstallCommand\` falls through to \`npm install -g\` — the exact path the fix was supposed to prevent.

gsd-pi's \`dist/loader.js\` has \`#!/usr/bin/env node\`, so \`bun add -g gsd-pi\` hits this case on any system that has both \`node\` and \`bun\` installed (which is every Ubuntu box the reporter had — their npm EACCES on \`/usr/local/lib/node_modules/gsd-pi\` is proof that Node+npm were in PATH).

## How the new fix works

\`process.argv[1]\` preserves the **unresolved** shim path (\`~/.bun/bin/gsd\`) regardless of which runtime executes the script. New \`isBunInstall()\` helper:

1. Runtime check first — \`'bun' in process.versions\` still wins for users who invoke \`bun /path/to/gsd\` directly.
2. Path check — \`process.argv[1]\` under \`\$BUN_INSTALL/bin\` or \`~/.bun/bin\` (with trailing \`path.sep\` to guard against prefix collisions like \`.bun/bin-other/\`).

On Windows, \`os.homedir()\` returns \`%USERPROFILE%\`, so \`~/.bun/bin\` resolves correctly there too.

## What

- \`src/update-check.ts\` — new exported \`isBunInstall(argv1?)\` helper; \`resolveInstallCommand\` delegates to it.
- \`src/resources/extensions/gsd/commands-handlers.ts\` — mirrored helper. Same tsconfig rootDir constraint as PR #4147 blocks cross-import.
- \`src/tests/update-cmd-diagnostics.test.ts\` — 2 new regression tests covering:
  - \`~/.bun/bin/gsd\` argv detection under Node
  - Custom \`\$BUN_INSTALL\` path
  - npm-global path negative case
  - Prefix false-positive guard (\`.bun/bin-other\`)
  - Runtime-wins-over-argv case

## Test plan

- [x] \`npm run build\` passes
- [x] \`npx tsx --test src/tests/update-cmd-diagnostics.test.ts\` — 9/9 pass
- [x] \`npx tsx --test src/tests/update-cmd-diagnostics.test.ts src/tests/cross-platform-filesystem-safety.test.ts\` — 16/16 pass
- [x] End-to-end smoke on built artifact: imported \`dist/update-check.js\`, set \`process.argv[1] = ~/.bun/bin/gsd\`, confirmed \`resolveInstallCommand('gsd-pi@latest')\` returns \`bun add -g gsd-pi@latest\`
- [ ] Manual verification on a Linux box with both node and bun installed (follow-up — I don't have a bun-installed gsd-pi on my macOS dev box and didn't want to pollute it)

Closes #4145.