### PR TITLE
fix(doctor): suppress false 'Anthropic key missing' warning when using claude-code provider

### DIFF
--- a/packages/pi-coding-agent/src/core/auth-storage.test.ts
+++ b/packages/pi-coding-agent/src/core/auth-storage.test.ts
@@ -569,3 +569,44 @@ describe("AuthStorage — localhost baseUrl shortcut", () => {
 		assert.equal(key, "sk-myproxy-key");
 	});
 });
+
+// ─── hasLegacyOAuthCredential (Anthropic OAuth removed in v2.74.0, #3952) ────
+
+describe("AuthStorage — hasLegacyOAuthCredential (#4280)", () => {
+	it("returns true when anthropic has a type:oauth credential", () => {
+		const storage = inMemory({
+			anthropic: {
+				type: "oauth",
+				access: "ya29.fake-access-token",
+				refresh: "1//fake-refresh-token",
+				expires: Date.now() + 3_600_000,
+			},
+		});
+		assert.equal(storage.hasLegacyOAuthCredential("anthropic"), true);
+	});
+
+	it("returns false when anthropic has an api_key credential", () => {
+		const storage = inMemory({ anthropic: makeKey("sk-ant-fake") });
+		assert.equal(storage.hasLegacyOAuthCredential("anthropic"), false);
+	});
+
+	it("returns false when anthropic has no credential at all", () => {
+		const storage = inMemory({});
+		assert.equal(storage.hasLegacyOAuthCredential("anthropic"), false);
+	});
+
+	it("returns false for a provider with a legitimate OAuth credential (e.g. github-copilot)", () => {
+		const storage = inMemory({
+			"github-copilot": {
+				type: "oauth",
+				access: "gho_fake-token",
+				refresh: "ghr_fake-refresh",
+				expires: Date.now() + 28_800_000,
+			},
+		});
+		// hasLegacyOAuthCredential is intentionally provider-scoped — calling it
+		// for a provider that still supports OAuth (like github-copilot) is not
+		// expected in production, but the method must not explode.
+		assert.equal(storage.hasLegacyOAuthCredential("github-copilot"), true);
+	});
+});

--- a/packages/pi-coding-agent/src/core/auth-storage.ts
+++ b/packages/pi-coding-agent/src/core/auth-storage.ts
@@ -466,6 +466,16 @@ export class AuthStorage {
 	}
 
 	/**
+	 * Returns true if the stored credential for a provider is of type "oauth".
+	 * Used to detect stale OAuth credentials for providers where OAuth has been
+	 * removed (e.g. Anthropic, #3952) so callers can surface a targeted
+	 * migration message instead of a generic cooldown error.
+	 */
+	hasLegacyOAuthCredential(provider: string): boolean {
+		return this.getCredentialsForProvider(provider).some((c) => c.type === "oauth");
+	}
+
+	/**
 	 * Get all credentials (for passing to getOAuthApiKey).
 	 * Returns normalized format where each provider has a single credential
 	 * (the first one) for backward compatibility with OAuth refresh.

--- a/packages/pi-coding-agent/src/core/sdk.ts
+++ b/packages/pi-coding-agent/src/core/sdk.ts
@@ -438,6 +438,20 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			// the retry handler and creating cascading error entries (#3429).
 			const hasAuth = modelRegistry.authStorage.hasAuth(resolvedProvider);
 			if (hasAuth) {
+				// Anthropic OAuth was removed in v2.74.0 for TOS compliance (#3952).
+				// Users who upgraded from an older version may still have OAuth
+				// credentials in auth.json that will never resolve to a valid API key.
+				// Surface a targeted migration message instead of the generic cooldown.
+				if (
+					resolvedProvider === "anthropic" &&
+					modelRegistry.authStorage.hasLegacyOAuthCredential(resolvedProvider)
+				) {
+					throw new Error(
+						`Your Anthropic credentials were set up via OAuth, which is no longer supported. ` +
+							`Please re-authenticate: run '/login', select 'Paste an API key' → Anthropic. ` +
+							`Alternatively, switch to the Claude Code CLI provider.`,
+					);
+				}
 				const expiry = modelRegistry.authStorage.getEarliestBackoffExpiry(resolvedProvider);
 				const retryAfterMs = expiry !== undefined ? Math.max(0, expiry - Date.now()) : undefined;
 				throw new CredentialCooldownError(resolvedProvider, retryAfterMs);

--- a/src/resources/extensions/gsd/doctor-providers.ts
+++ b/src/resources/extensions/gsd/doctor-providers.ts
@@ -37,6 +37,30 @@ export interface ProviderCheckResult {
   required: boolean;
 }
 
+// ── Provider routing constants ────────────────────────────────────────────────
+
+/**
+ * Providers that use external CLI authentication (not API keys).
+ * These are always considered "found" — the host CLI handles auth.
+ */
+const CLI_AUTH_PROVIDERS = new Set([
+  "claude-code",
+  "openai-codex",
+  "google-gemini-cli",
+  "google-antigravity",
+]);
+
+/**
+ * Providers that can serve models normally associated with another provider.
+ * Key = the provider whose models can be served, Value = alternative providers to check.
+ * e.g. GitHub Copilot subscriptions can access Claude and GPT models.
+ */
+const PROVIDER_ROUTES: Record<string, string[]> = {
+  anthropic: ["github-copilot", "claude-code"],
+  openai: ["github-copilot", "openai-codex"],
+  google: ["google-gemini-cli"],
+};
+
 // ── Model → Provider ID mapping ───────────────────────────────────────────────
 
 /**
@@ -125,8 +149,36 @@ interface KeyLookup {
   backedOff: boolean;
 }
 
+/**
+ * Map of CLI provider IDs to their binary names on disk.
+ * Used for lightweight binary-presence checks (PATH scan, no subprocess).
+ */
+const CLI_BINARY_MAP: Record<string, string> = {
+  "claude-code": "claude",
+  "openai-codex": "codex",
+  "google-gemini-cli": "gemini",
+  "google-antigravity": "antigravity",
+};
+
+/**
+ * Check if a CLI provider's binary exists anywhere in PATH.
+ * Fast filesystem scan — no subprocess, no network, sub-1ms.
+ */
+function isCliBinaryInPath(providerId: string): boolean {
+  const binary = CLI_BINARY_MAP[providerId];
+  if (!binary) return false;
+  const pathDirs = (process.env.PATH ?? "").split(":");
+  return pathDirs.some(dir => dir && existsSync(join(dir, binary)));
+}
+
 function resolveKey(providerId: string): KeyLookup {
   const info = PROVIDER_REGISTRY.find(p => p.id === providerId);
+
+  // claude-code never stores credentials in auth.json — GSD delegates entirely to
+  // the local CLI binary. Presence of the binary in PATH is the only signal.
+  if (providerId === "claude-code") {
+    return { found: isCliBinaryInPath("claude-code"), source: "env", backedOff: false };
+  }
 
   if (providerId === "anthropic-vertex" && process.env.ANTHROPIC_VERTEX_PROJECT_ID) {
     return { found: true, source: "env", backedOff: false };
@@ -173,28 +225,6 @@ function resolveKey(providerId: string): KeyLookup {
 }
 
 // ── Individual check groups ────────────────────────────────────────────────────
-
-/**
- * Providers that can serve models normally associated with another provider.
- * Key = the provider whose models can be served, Value = alternative providers to check.
- * e.g. GitHub Copilot subscriptions can access Claude and GPT models.
- */
-const PROVIDER_ROUTES: Record<string, string[]> = {
-  anthropic: ["github-copilot"],
-  openai: ["github-copilot", "openai-codex"],
-  google: ["google-gemini-cli"],
-};
-
-/**
- * Providers that use external CLI authentication (not API keys).
- * These are always considered "ok" — the host CLI handles auth.
- */
-const CLI_AUTH_PROVIDERS = new Set([
-  "claude-code",
-  "openai-codex",
-  "google-gemini-cli",
-  "google-antigravity",
-]);
 
 function checkLlmProviders(): ProviderCheckResult[] {
   const required = collectConfiguredModelProviders();

--- a/src/resources/extensions/gsd/tests/doctor-providers.test.ts
+++ b/src/resources/extensions/gsd/tests/doctor-providers.test.ts
@@ -14,7 +14,7 @@
 
 import test from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync, realpathSync } from "node:fs";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, realpathSync, chmodSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
@@ -219,6 +219,9 @@ test("runProviderChecks returns error for Anthropic when no key present", () => 
     GH_TOKEN: undefined,
     GITHUB_TOKEN: undefined,
     HOME: tmpHome,
+    // Use a PATH that contains no AI CLI binaries (claude, codex, gemini, etc.)
+    // so the claude-code route is not considered available
+    PATH: tmpHome,
   }, () => {
     try {
       const results = runProviderChecks();
@@ -295,26 +298,33 @@ test("runProviderChecks detects key from auth.json", () => {
 });
 
 test("runProviderChecks ignores empty placeholder keys in auth.json", () => {
-  withEnv({ ANTHROPIC_API_KEY: undefined, ANTHROPIC_OAUTH_TOKEN: undefined, COPILOT_GITHUB_TOKEN: undefined, GH_TOKEN: undefined, GITHUB_TOKEN: undefined }, () => {
-    const tmpHome = realpathSync(mkdtempSync(join(tmpdir(), "gsd-providers-test-")));
-    const agentDir = join(tmpHome, ".gsd", "agent");
-    mkdirSync(agentDir, { recursive: true });
+  const tmpHome = realpathSync(mkdtempSync(join(tmpdir(), "gsd-providers-test-")));
+  const agentDir = join(tmpHome, ".gsd", "agent");
+  mkdirSync(agentDir, { recursive: true });
 
-    // Empty key — what onboarding writes when user skips
-    const authData = {
-      anthropic: { type: "api_key", key: "" },
-    };
-    writeFileSync(join(agentDir, "auth.json"), JSON.stringify(authData));
+  // Empty key — what onboarding writes when user skips
+  const authData = {
+    anthropic: { type: "api_key", key: "" },
+  };
+  writeFileSync(join(agentDir, "auth.json"), JSON.stringify(authData));
 
-    withEnv({ HOME: tmpHome }, () => {
-      const results = runProviderChecks();
-      const anthropic = results.find(r => r.name === "anthropic");
-      assert.ok(anthropic, "anthropic should be present");
-      assert.equal(anthropic!.status, "error", "empty placeholder key should count as not configured");
-    });
-
-    rmSync(tmpHome, { recursive: true, force: true });
+  withEnv({
+    ANTHROPIC_API_KEY: undefined,
+    ANTHROPIC_OAUTH_TOKEN: undefined,
+    COPILOT_GITHUB_TOKEN: undefined,
+    GH_TOKEN: undefined,
+    GITHUB_TOKEN: undefined,
+    HOME: tmpHome,
+    // Exclude AI CLI binaries so the claude-code route is not considered available
+    PATH: tmpHome,
+  }, () => {
+    const results = runProviderChecks();
+    const anthropic = results.find(r => r.name === "anthropic");
+    assert.ok(anthropic, "anthropic should be present");
+    assert.equal(anthropic!.status, "error", "empty placeholder key should count as not configured");
   });
+
+  rmSync(tmpHome, { recursive: true, force: true });
 });
 
 // ─── runProviderChecks — cross-provider routing ──────────────────────────────
@@ -608,6 +618,40 @@ test("runProviderChecks reports ok for claude-code without any API key", () => {
 
   rmSync(repo, { recursive: true, force: true });
   rmSync(tmpHome, { recursive: true, force: true });
+});
+
+test("runProviderChecks reports ok for Anthropic via claude-code binary in PATH", () => {
+  // Simulate a user who has no Anthropic API key but has the claude CLI installed.
+  // Their PREFERENCES use a claude model without an explicit provider, so the doctor
+  // infers "anthropic" — but the claude-code route should satisfy it.
+  const tmpHome = realpathSync(mkdtempSync(join(tmpdir(), "gsd-providers-cc-route-home-")));
+  const binDir = join(tmpHome, "bin");
+  mkdirSync(binDir, { recursive: true });
+
+  // Create a fake `claude` binary so the PATH scan finds it
+  const fakeClaude = join(binDir, "claude");
+  writeFileSync(fakeClaude, "#!/bin/sh\necho mock\n");
+  chmodSync(fakeClaude, 0o755);
+
+  withEnv({
+    HOME: tmpHome,
+    ANTHROPIC_API_KEY: undefined,
+    ANTHROPIC_OAUTH_TOKEN: undefined,
+    COPILOT_GITHUB_TOKEN: undefined,
+    GH_TOKEN: undefined,
+    GITHUB_TOKEN: undefined,
+    PATH: `${binDir}:${process.env.PATH ?? ""}`,
+  }, () => {
+    try {
+      const results = runProviderChecks();
+      const anthropic = results.find(r => r.name === "anthropic");
+      assert.ok(anthropic, "anthropic result should exist");
+      assert.equal(anthropic!.status, "ok", "should be ok when claude CLI binary is in PATH");
+      assert.ok(anthropic!.message.toLowerCase().includes("claude"), "should mention claude-code as source");
+    } finally {
+      rmSync(tmpHome, { recursive: true, force: true });
+    }
+  });
 });
 
 test("PROVIDER_ROUTES includes google-gemini-cli as route for google (#2922)", async () => {


### PR DESCRIPTION
## TL;DR

**What:** Remove the false `✗ Anthropic (Claude) key missing` health widget warning when the active provider is `claude-code`.
**Why:** The provider doctor infers `anthropic` from claude model names but had no route for `claude-code`, causing a spurious error for users who authenticate via the Claude Code CLI.
**How:** Add `claude-code` to `PROVIDER_ROUTES["anthropic"]` backed by a lightweight binary-presence check (PATH scan, no subprocess).

## What

- `claude-code` added as a fallback route for `anthropic` in `PROVIDER_ROUTES` (after `github-copilot`)
- New `isCliBinaryInPath()` helper — sub-1ms filesystem PATH scan, no subprocess, no network
- `resolveKey("claude-code")` returns `found: true` iff the `claude` binary exists in PATH
- Affected tests updated to control `PATH` for deterministic binary-presence checks
- Regression test added: fake `claude` binary in a temp dir proves the route resolves correctly
- `hasLegacyOAuthCredential()` added to `AuthStorage` + targeted migration hint in `sdk.ts` for users with stale Anthropic OAuth credentials (the cooldown error root cause from #4277)

## Why

Reported by @aloxuhik in #4277 — after switching to the Claude Code CLI provider, the status bar still showed `✗ Anthropic (Claude) key missing`. The doctor inferred `anthropic` from the model name `claude-opus-4-6` and found no key, but `claude-code` can serve those models via CLI auth without any API key.

## How

`PROVIDER_ROUTES` already handles analogous cases (GitHub Copilot → anthropic/openai, google-gemini-cli → google). `claude-code` is unique: GSD never stores credentials for it in `auth.json` — it delegates entirely to the local `claude` binary. So the route check uses `existsSync` on each PATH directory instead of checking auth.json.

- [x] `fix` — Bug fix
- [x] `test` — Regression test added

> This PR is AI-assisted.

Closes #4307