### PR TITLE
fix(ci): use full git history in lint job for require-tests.sh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          fetch-depth: 2
+          fetch-depth: 0
 
       - name: Scan for hardcoded secrets
         run: bash scripts/secret-scan.sh --diff origin/main


### PR DESCRIPTION
## Summary
- The lint job used `fetch-depth: 2`, which caused `PR_BASE_SHA` to be unresolvable in shallow clones
- `require-tests.sh` fell back to `HEAD~1`, only seeing the last commit instead of all PR files
- Changed to `fetch-depth: 0` to match `detect-changes` and `docs-check` jobs that already use full history

## Context
This was causing false failures on PR #4270 where the test file existed but wasn't visible to the lint check.

## Test plan
- [ ] CI passes on this PR (the lint job itself validates the fix)
- [ ] Re-run CI on #4270 after this merges — lint should pass