### PR TITLE
fix(network): enable Happy Eyeballs for all fetch calls via global undici dispatcher

### DIFF
--- a/packages/pi-coding-agent/src/cli.ts
+++ b/packages/pi-coding-agent/src/cli.ts
@@ -9,10 +9,16 @@ process.title = "pi";
 
 import { setBedrockProviderModule } from "@gsd/pi-ai";
 import { bedrockProviderModule } from "@gsd/pi-ai/bedrock-provider";
-import { EnvHttpProxyAgent, setGlobalDispatcher } from "undici";
+import { EnvHttpProxyAgent, Agent, setGlobalDispatcher } from "undici";
 import { main } from "./main.js";
 
-setGlobalDispatcher(new EnvHttpProxyAgent());
+const hasProxy = process.env.HTTP_PROXY || process.env.HTTPS_PROXY ||
+                 process.env.http_proxy || process.env.https_proxy;
+if (hasProxy) {
+  setGlobalDispatcher(new EnvHttpProxyAgent({ connect: { autoSelectFamily: true } }));
+} else {
+  setGlobalDispatcher(new Agent({ connect: { autoSelectFamily: true } }));
+}
 setBedrockProviderModule(bedrockProviderModule);
 
 main(process.argv.slice(2));

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -169,9 +169,14 @@ process.env.GSD_BUNDLED_EXTENSION_PATHS = serializeBundledExtensionPaths(discove
 // pi-coding-agent's cli.ts sets this, but GSD bypasses that entry point — so we
 // must set it here before any SDK clients are created.
 // Lazy-load undici (~200ms) only when proxy env vars are actually set.
-if (process.env.HTTP_PROXY || process.env.HTTPS_PROXY || process.env.http_proxy || process.env.https_proxy) {
+const hasProxy = process.env.HTTP_PROXY || process.env.HTTPS_PROXY ||
+                 process.env.http_proxy || process.env.https_proxy
+if (hasProxy) {
   const { EnvHttpProxyAgent, setGlobalDispatcher } = await import('undici')
-  setGlobalDispatcher(new EnvHttpProxyAgent())
+  setGlobalDispatcher(new EnvHttpProxyAgent({ connect: { autoSelectFamily: true } }))
+} else {
+  const { Agent, setGlobalDispatcher } = await import('undici')
+  setGlobalDispatcher(new Agent({ connect: { autoSelectFamily: true } }))
 }
 
 // Ensure workspace packages are linked (or copied on Windows) before importing

--- a/src/resources/extensions/gsd/key-manager.ts
+++ b/src/resources/extensions/gsd/key-manager.ts
@@ -492,8 +492,8 @@ const TEST_ENDPOINTS: Record<string, { url: string; method?: string; headers?: (
 export async function testProviderKey(
   provider: ProviderInfo,
   auth: AuthStorage,
+  baseUrlOverride?: string,
 ): Promise<TestResult> {
-  // Get the API key
   const key = await auth.getApiKey(provider.id);
   if (!key || key === "<authenticated>") {
     if (!key) {
@@ -507,10 +507,12 @@ export async function testProviderKey(
     return { provider, status: "skipped", message: "no test endpoint configured" };
   }
 
-  // Special handling for Telegram (token in URL)
-  let url = endpoint.url;
+  let url: string;
   if (provider.id === "telegram_bot") {
-    url = `https://api.telegram.org/bot${key}/getMe`;
+    const base = baseUrlOverride ?? "https://api.telegram.org";
+    url = `${base}/bot${key}/getMe`;
+  } else {
+    url = baseUrlOverride ?? endpoint.url;
   }
 
   // Special handling for Tavily (API key in body)

--- a/src/resources/extensions/gsd/tests/key-manager.test.ts
+++ b/src/resources/extensions/gsd/tests/key-manager.test.ts
@@ -27,7 +27,7 @@ function startMockServer(statusCode: number, body = "{}", onRequest?: (req: http
       const addr = server.address() as { port: number };
       resolve({
         url: `http://127.0.0.1:${addr.port}`,
-        close: () => new Promise((r) => server.close(r)),
+        close: () => new Promise<void>((r) => server.close(() => r())),
       });
     });
   });

--- a/src/resources/extensions/gsd/tests/key-manager.test.ts
+++ b/src/resources/extensions/gsd/tests/key-manager.test.ts
@@ -1,5 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import http from "node:http";
 import { AuthStorage } from "@gsd/pi-coding-agent";
 import {
   maskKey,
@@ -11,8 +12,26 @@ import {
   formatTestResults,
   runKeyDoctor,
   formatDoctorFindings,
+  testProviderKey,
   PROVIDER_REGISTRY,
 } from "../key-manager.ts";
+
+function startMockServer(statusCode: number, body = "{}", onRequest?: (req: http.IncomingMessage) => void): Promise<{ url: string; close: () => Promise<void> }> {
+  return new Promise((resolve) => {
+    const server = http.createServer((req, res) => {
+      onRequest?.(req);
+      res.writeHead(statusCode, { "Content-Type": "application/json" });
+      res.end(body);
+    });
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address() as { port: number };
+      resolve({
+        url: `http://127.0.0.1:${addr.port}`,
+        close: () => new Promise((r) => server.close(r)),
+      });
+    });
+  });
+}
 
 function makeAuth(data: Record<string, any> = {}): AuthStorage {
   return AuthStorage.inMemory(data);
@@ -489,4 +508,92 @@ test("getAllKeyStatuses detects DASHSCOPE_API_KEY for alibaba-dashscope (failure
   } finally {
     if (saved !== undefined) process.env.DASHSCOPE_API_KEY = saved;
   }
+});
+
+// ─── testProviderKey ─────────────────────────────────────────────────────────────
+
+test("testProviderKey returns skipped when key is not configured", async () => {
+  const provider = findProvider("anthropic")!;
+  const auth = makeAuth();
+  const result = await testProviderKey(provider, auth);
+  assert.equal(result.status, "skipped");
+  assert.equal(result.message, "not configured");
+});
+
+test("testProviderKey returns skipped when provider has no test endpoint", async () => {
+  const provider = { id: "unknown-provider", label: "Test", category: "tool" as const };
+  const auth = makeAuth({ "unknown-provider": { type: "api_key", key: "some-key" } });
+  const result = await testProviderKey(provider, auth);
+  assert.equal(result.status, "skipped");
+  assert.equal(result.message, "no test endpoint configured");
+});
+
+test("testProviderKey returns skipped for OAuth credential chain providers", async () => {
+  const provider = findProvider("github-copilot")!;
+  const auth = makeAuth({ "github-copilot": { type: "api_key", key: "<authenticated>" } });
+  const result = await testProviderKey(provider, auth);
+  assert.equal(result.status, "skipped");
+  assert.equal(result.message, "uses credential chain (not testable)");
+});
+
+test("testProviderKey HTTP response mapping via local server: 200 → valid", async (t) => {
+  const mock = await startMockServer(200, "{}");
+  t.after(() => mock.close());
+  const provider = findProvider("brave")!;
+  const auth = makeAuth({ brave: { type: "api_key", key: "test-brave-key" } });
+  const result = await testProviderKey(provider, auth, mock.url);
+  assert.equal(result.status, "valid");
+  assert.ok(result.latencyMs !== undefined);
+});
+
+test("testProviderKey HTTP response mapping via local server: 401 → invalid", async (t) => {
+  const mock = await startMockServer(401);
+  t.after(() => mock.close());
+  const provider = findProvider("brave")!;
+  const auth = makeAuth({ brave: { type: "api_key", key: "test-brave-key" } });
+  const result = await testProviderKey(provider, auth, mock.url);
+  assert.equal(result.status, "invalid");
+  assert.ok(result.message.includes("401"));
+});
+
+test("testProviderKey HTTP response mapping via local server: 403 → invalid", async (t) => {
+  const mock = await startMockServer(403);
+  t.after(() => mock.close());
+  const provider = findProvider("brave")!;
+  const auth = makeAuth({ brave: { type: "api_key", key: "test-brave-key" } });
+  const result = await testProviderKey(provider, auth, mock.url);
+  assert.equal(result.status, "invalid");
+  assert.ok(result.message.includes("403"));
+});
+
+test("testProviderKey HTTP response mapping via local server: 429 → rate_limited", async (t) => {
+  const mock = await startMockServer(429);
+  t.after(() => mock.close());
+  const provider = findProvider("brave")!;
+  const auth = makeAuth({ brave: { type: "api_key", key: "test-brave-key" } });
+  const result = await testProviderKey(provider, auth, mock.url);
+  assert.equal(result.status, "rate_limited");
+});
+
+test("testProviderKey HTTP response mapping via local server: 500 → error with HTTP status", async (t) => {
+  const mock = await startMockServer(500);
+  t.after(() => mock.close());
+  const provider = findProvider("brave")!;
+  const auth = makeAuth({ brave: { type: "api_key", key: "test-brave-key" } });
+  const result = await testProviderKey(provider, auth, mock.url);
+  assert.equal(result.status, "error");
+  assert.ok(result.message.includes("500"));
+});
+
+test("testProviderKey telegram_bot embeds token in URL path not header", async (t) => {
+  let receivedPath = "";
+  const mock = await startMockServer(200, '{"ok":true,"result":{"id":1}}', (req) => {
+    receivedPath = req.url ?? "";
+  });
+  t.after(() => mock.close());
+  const provider = findProvider("telegram_bot")!;
+  const key = "123456789:AABBCCtest";
+  const auth = makeAuth({ telegram_bot: { type: "api_key", key } });
+  await testProviderKey(provider, auth, mock.url);
+  assert.ok(receivedPath.includes(`/bot${key}/getMe`), `Expected path to contain /bot${key}/getMe, got: ${receivedPath}`);
 });


### PR DESCRIPTION
## TL;DR

**What:** Sets a global undici dispatcher with `autoSelectFamily: true` (Happy Eyeballs / RFC 8305) at both CLI entry points, replacing a narrower per-function workaround.
**Why:** On Linux systems with IPv6 configured but unreachable (common in some regions and corporate networks), undici's default behavior tries IPv6 first and waits the full 15 s timeout before falling back — breaking Telegram token validation and any other `fetch()` call in the process.
**How:** Set the dispatcher once in `src/loader.ts` and `packages/pi-coding-agent/src/cli.ts` before any network I/O runs; proxy environments use `EnvHttpProxyAgent` with `autoSelectFamily: true` so both capabilities are preserved.

## What

- **`src/loader.ts`** — sets `setGlobalDispatcher` with proxy-conditional logic: `EnvHttpProxyAgent({ connect: { autoSelectFamily: true } })` when `HTTP_PROXY`/`HTTPS_PROXY` is set, `Agent({ connect: { autoSelectFamily: true } })` otherwise. Runs before `cli.ts` is imported, so all `fetch()` calls in the process are covered.
- **`packages/pi-coding-agent/src/cli.ts`** — same dispatcher logic for the standalone `pi` binary entry point.
- **`src/resources/extensions/gsd/key-manager.ts`** — removes the local `happyEyeballsAgent` workaround (now redundant); simplifies the Telegram URL construction to a single clean `if/else`; retains the `baseUrlOverride` parameter for test injection.
- **`src/resources/extensions/gsd/tests/key-manager.test.ts`** — adds 9 new tests for `testProviderKey`: skipped-state cases (no key, no endpoint, credential chain), full HTTP status mapping (200/401/403/429/500) via a local mock server, and an explicit assertion that the Telegram bot token is embedded in the URL path.

## Why

Closes #4290.

`undici` (Node.js native `fetch`) does not implement Happy Eyeballs. When `api.telegram.org` (or any dual-stack host) resolves to both IPv6 and IPv4, undici attempts IPv6 first and waits the full `AbortSignal.timeout` before reporting failure. `curl` succeeds on the same host because it implements RFC 8305. The workarounds that work for Node's built-in `http` module (`dns.setDefaultResultOrder`, `--dns-result-order`) are ignored by undici.

A previous narrower fix patched only `testProviderKey`. This PR promotes the fix to the process level so every `fetch()` call — search extensions, remote integrations, context providers — is covered without per-module changes.

## How

`undici` exposes a `setGlobalDispatcher` API that replaces the default dispatcher for all `fetch()` calls in the process. Passing `connect: { autoSelectFamily: true }` enables Happy Eyeballs: undici races IPv4 and IPv6 connections and uses whichever responds first, falling back gracefully when one family is unreachable.

The dispatcher is set at the earliest possible point in the startup path (`loader.ts` line ~172, before `await import('./cli.js')`), ensuring it is active for every subsequent network call including those made during module initialisation.

Proxy support is preserved: when proxy env vars are present the `EnvHttpProxyAgent` wrapper is used with the same `connect` option, so users in proxy environments retain outbound routing.

- [x] `fix` — Bug fix