### PR TITLE
fix(claude-code): add pi-tool disclaimer before <prior_system_context>

### DIFF
--- a/src/resources/extensions/claude-code-cli/stream-adapter.ts
+++ b/src/resources/extensions/claude-code-cli/stream-adapter.ts
@@ -230,6 +230,16 @@ export function buildPromptFromContext(context: Context): string {
 	];
 
 	if (context.systemPrompt) {
+		// Pi-native tools (e.g. ask_user_questions, secure_env_collect) appear in the
+		// harness system prompt but are not registered as Claude Code tools. Surfacing
+		// this upfront prevents the model from spending reasoning cycles searching the
+		// deferred tool list for tools it cannot call.
+		parts.push(
+			"Note: The system context below is from the pi harness. " +
+			"Pi-native tools mentioned there (such as `ask_user_questions` and `secure_env_collect`) " +
+			"are NOT available as direct tools in this Claude Code session. " +
+			"To ask the user a question, output plain text.",
+		);
 		parts.push(`<prior_system_context>\n${context.systemPrompt}\n</prior_system_context>`);
 	}
 

--- a/src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts
+++ b/src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts
@@ -345,6 +345,39 @@ describe("stream-adapter — no transcript fabrication (#4102)", () => {
 		const prompt = buildPromptFromContext(context);
 		assert.equal(prompt, "", "empty context must not emit a bare directive");
 	});
+
+	test("buildPromptFromContext emits pi-tool disclaimer before <prior_system_context> when system prompt is present", () => {
+		const context: Context = {
+			systemPrompt: "You are helpful. Use ask_user_questions to prompt the user.",
+			messages: [{ role: "user", content: "Hello" } as Message],
+		};
+
+		const prompt = buildPromptFromContext(context);
+
+		assert.ok(prompt.includes("Pi-native tools"), "prompt must include pi-tool disclaimer");
+		assert.ok(prompt.includes("ask_user_questions"), "disclaimer must name the pi-specific tool");
+		// The disclaimer must appear before the system prompt content (not injected inside the block).
+		// We check against the system prompt text rather than the tag string, because the tag string
+		// also appears in the leading "do not emit" directive at the top of the prompt.
+		assert.ok(
+			prompt.indexOf("Pi-native tools") < prompt.indexOf("You are helpful"),
+			"disclaimer must precede the system prompt content",
+		);
+		assert.ok(
+			!prompt.includes("<prior_system_context>\nNote:"),
+			"disclaimer must not be injected inside the <prior_system_context> block",
+		);
+	});
+
+	test("buildPromptFromContext omits pi-tool disclaimer when no system prompt", () => {
+		const context: Context = {
+			messages: [{ role: "user", content: "Hello" } as Message],
+		};
+
+		const prompt = buildPromptFromContext(context);
+
+		assert.ok(!prompt.includes("Pi-native tools"), "no disclaimer when there is no system prompt to annotate");
+	});
 });
 
 describe("stream-adapter — Claude Code external tool results", () => {


### PR DESCRIPTION
## TL;DR

**What:** Add a disclaimer before `<prior_system_context>` in the Claude Code stream adapter naming pi-native tools as unavailable.
**Why:** Without it, the model sees guidelines for `ask_user_questions`/`secure_env_collect`, searches the deferred tool list, and wastes reasoning cycles on a dead path.
**How:** Inject a one-sentence note in `buildPromptFromContext` before the `<prior_system_context>` block; add two regression tests.

## What

Modifies `src/resources/extensions/claude-code-cli/stream-adapter.ts` (`buildPromptFromContext`) to prepend a disclaimer before the `<prior_system_context>` block. Two new tests in `stream-adapter.test.ts` cover the disclaimer-present and disclaimer-absent paths.

## Why

When the pi harness system prompt is injected verbatim into a Claude Code session, it includes prompt guidelines for pi-native tools (`ask_user_questions`, `secure_env_collect`). Those tools are never registered in Claude Code. The model sees the guidelines, scans the deferred tool list, fails to find them, and reasons its way to a plain-text fallback — producing unnecessary internal monologue on every message. The disclaimer surfaces the gap upfront.

Closes #4311

## How

A single string prepended in `buildPromptFromContext` before the `<prior_system_context>` tag. No structural change to the prompt pipeline. The disclaimer text calls out the unavailable tools by name and instructs the model to use plain-text output instead.

---

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

---

> AI-assisted PR (Claude Code).