### PR TITLE
fix(gsd): suppress built-in footer on session_start when auto-mode is active

### DIFF
--- a/src/resources/extensions/gsd/bootstrap/register-hooks.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-hooks.ts
@@ -18,6 +18,7 @@ import { loadToolApiKeys } from "../commands-config.js";
 import { loadFile, saveFile, formatContinue } from "../files.js";
 import { deriveState } from "../state.js";
 import { getAutoDashboardData, isAutoActive, isAutoPaused, markToolEnd, markToolStart, recordToolInvocationError } from "../auto.js";
+import { hideFooter } from "../auto-dashboard.js";
 import { isParallelActive, shutdownParallel } from "../parallel-orchestrator.js";
 import { checkToolCallLoop, resetToolCallLoopGuard } from "./tool-call-loop-guard.js";
 import { saveActivityLog } from "../activity-log.js";
@@ -88,6 +89,9 @@ export function registerHooks(
       } catch { /* non-fatal */ }
     }
     loadToolApiKeys();
+    if (isAutoActive()) {
+      ctx.ui.setFooter(hideFooter);
+    }
   });
 
   pi.on("session_switch", async (_event, ctx) => {
@@ -108,6 +112,9 @@ export function registerHooks(
       prepareWorkflowMcpForProject(ctx, process.cwd());
     }
     loadToolApiKeys();
+    if (isAutoActive()) {
+      ctx.ui.setFooter(hideFooter);
+    }
   });
 
   pi.on("before_agent_start", async (event, ctx: ExtensionContext) => {

--- a/src/resources/extensions/gsd/tests/session-start-footer.test.ts
+++ b/src/resources/extensions/gsd/tests/session-start-footer.test.ts
@@ -1,0 +1,153 @@
+/**
+ * session-start-footer.test.ts
+ *
+ * Verifies that register-hooks.ts suppresses the built-in footer by calling
+ * ctx.ui.setFooter(hideFooter) in both session_start and session_switch when
+ * isAutoActive() is true.
+ *
+ * Testing strategy:
+ *   Two layers:
+ *   1. Source-code regression guard: ensures the guard and setFooter call are
+ *      structurally present in register-hooks.ts for both event handlers.
+ *      (node:test does not support mock.module without --experimental-test-module-mocks,
+ *       so structural analysis is the correct approach here.)
+ *   2. Behavioral integration test: fires the live session_start handler with a
+ *      fake ctx when isAutoActive() is false (its default at test time) and
+ *      confirms setFooter is NOT called — verifying the guard is conditional.
+ *
+ * Relates to #4314.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, readFileSync, rmSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
+
+import { registerHooks } from "../bootstrap/register-hooks.ts";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const HOOKS_SOURCE = readFileSync(
+  join(__dirname, "..", "bootstrap", "register-hooks.ts"),
+  "utf-8",
+);
+
+// ─── Source-code regression guards ──────────────────────────────────────────
+
+test("register-hooks.ts imports hideFooter from auto-dashboard", () => {
+  assert.ok(
+    HOOKS_SOURCE.includes('import { hideFooter } from "../auto-dashboard.js"') ||
+    HOOKS_SOURCE.includes("import { hideFooter } from '../auto-dashboard.js'"),
+    "register-hooks.ts must import hideFooter from auto-dashboard.js",
+  );
+});
+
+test("session_start handler calls ctx.ui.setFooter(hideFooter) when isAutoActive()", () => {
+  // Locate the session_start handler body (up to the next pi.on call)
+  const sessionStartIdx = HOOKS_SOURCE.indexOf('"session_start"');
+  assert.ok(sessionStartIdx > -1, "session_start handler must exist");
+
+  const sessionSwitchIdx = HOOKS_SOURCE.indexOf('"session_switch"');
+  assert.ok(sessionSwitchIdx > sessionStartIdx, "session_switch handler must follow session_start");
+
+  const sessionStartBody = HOOKS_SOURCE.slice(sessionStartIdx, sessionSwitchIdx);
+
+  assert.ok(
+    sessionStartBody.includes("isAutoActive()"),
+    "session_start handler must call isAutoActive()",
+  );
+  assert.ok(
+    sessionStartBody.includes("ctx.ui.setFooter(hideFooter)"),
+    "session_start handler must call ctx.ui.setFooter(hideFooter)",
+  );
+
+  // Guard must wrap the setFooter call
+  const guardIdx = sessionStartBody.indexOf("isAutoActive()");
+  const setFooterIdx = sessionStartBody.indexOf("ctx.ui.setFooter(hideFooter)");
+  assert.ok(
+    guardIdx < setFooterIdx,
+    "isAutoActive() guard must appear before ctx.ui.setFooter(hideFooter) in session_start",
+  );
+});
+
+test("session_switch handler calls ctx.ui.setFooter(hideFooter) when isAutoActive()", () => {
+  const sessionSwitchIdx = HOOKS_SOURCE.indexOf('"session_switch"');
+  assert.ok(sessionSwitchIdx > -1, "session_switch handler must exist");
+
+  const beforeAgentStartIdx = HOOKS_SOURCE.indexOf('"before_agent_start"');
+  assert.ok(beforeAgentStartIdx > sessionSwitchIdx, "before_agent_start handler must follow session_switch");
+
+  const sessionSwitchBody = HOOKS_SOURCE.slice(sessionSwitchIdx, beforeAgentStartIdx);
+
+  assert.ok(
+    sessionSwitchBody.includes("isAutoActive()"),
+    "session_switch handler must call isAutoActive()",
+  );
+  assert.ok(
+    sessionSwitchBody.includes("ctx.ui.setFooter(hideFooter)"),
+    "session_switch handler must call ctx.ui.setFooter(hideFooter)",
+  );
+
+  const guardIdx = sessionSwitchBody.indexOf("isAutoActive()");
+  const setFooterIdx = sessionSwitchBody.indexOf("ctx.ui.setFooter(hideFooter)");
+  assert.ok(
+    guardIdx < setFooterIdx,
+    "isAutoActive() guard must appear before ctx.ui.setFooter(hideFooter) in session_switch",
+  );
+});
+
+// ─── Behavioral test: setFooter NOT called when auto-mode is inactive ────────
+
+test("session_start does NOT call setFooter when isAutoActive() is false (default)", async (t) => {
+  const dir = join(
+    tmpdir(),
+    `gsd-footer-test-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+  );
+  mkdirSync(dir, { recursive: true });
+
+  const originalCwd = process.cwd();
+  process.chdir(dir);
+  t.after(() => {
+    process.chdir(originalCwd);
+    try { rmSync(dir, { recursive: true, force: true }); } catch { /* best-effort */ }
+  });
+
+  let setFooterCallCount = 0;
+
+  const handlers = new Map<string, (event: unknown, ctx: any) => Promise<void> | void>();
+  const pi = {
+    on(event: string, handler: (event: unknown, ctx: any) => Promise<void> | void) {
+      handlers.set(event, handler);
+    },
+  } as any;
+
+  registerHooks(pi, []);
+
+  const sessionStart = handlers.get("session_start");
+  assert.ok(sessionStart, "session_start handler must be registered");
+
+  await sessionStart!({}, {
+    hasUI: true,
+    ui: {
+      notify: () => {},
+      setStatus: () => {},
+      setFooter: (_footer: unknown) => {
+        setFooterCallCount++;
+      },
+      setWorkingMessage: () => {},
+      onTerminalInput: () => () => {},
+      setWidget: () => {},
+    },
+    sessionManager: { getSessionId: () => null },
+    model: null,
+  } as any);
+
+  // isAutoActive() is false at test time (no auto session started),
+  // so setFooter must not be called.
+  assert.equal(
+    setFooterCallCount,
+    0,
+    "setFooter must NOT be called when isAutoActive() returns false",
+  );
+});


### PR DESCRIPTION
## TL;DR

**What:** Hide the built-in `pi-coding-agent` footer when the GSD Auto-Dashboard is active.
**Why:** The footer duplicates information already visible in the dashboard (cost, branch, model, context %), creating visual noise below the input field.
**How:** Call `ctx.ui.setFooter(hideFooter)` in the `session_start` and `session_switch` hooks when `isAutoActive()` is true.

## What

Two files changed:

- `src/resources/extensions/gsd/bootstrap/register-hooks.ts` — import `hideFooter` from `auto-dashboard.js`; add a guard in both the `session_start` and `session_switch` handlers to call `ctx.ui.setFooter(hideFooter)` when auto-mode is active
- `src/resources/extensions/gsd/tests/session-start-footer.test.ts` — new regression test (4 tests, `node:test`)

## Why

The `hideFooter` mechanism already existed and was called from `bootstrapAutoSession()` (`auto-start.ts:808`) and the resume path (`auto.ts:1458`). However, on `/clear`, `interactive-mode.ts` resets the footer to the built-in `FooterComponent` before GSD's `session_start` hook fires. Since `session_start` never re-applied `hideFooter`, the redundant footer bar reappeared after every session restart while auto-mode was still active.

The footer shows: working directory, git branch, token I/O, cache metrics, cost, context %, and active model — all of which are already visible in the GSD Auto-Dashboard. When auto is not active, the footer remains the only source of this information and is correctly left in place.

Reported in #4277, tracked in #4314.

Closes #4314

## How

`setFooter` is already part of `ExtensionUIContext` (available as `ctx.ui` in all lifecycle hooks). No new API surface was needed. The fix adds the call in the two session lifecycle hooks that fire after `interactive-mode` resets extension state:

```typescript
if (isAutoActive()) {
  ctx.ui.setFooter(hideFooter);
}
```

The stop and pause paths in `auto.ts` that call `ctx.ui.setFooter(undefined)` to restore the default footer are untouched.

## Change type

- [x] `fix` — Bug fix

## AI-assisted

This PR was implemented with AI assistance. The change has been reviewed, tested locally (built from source, verified footer disappears when auto-mode is active), and the regression test was written and verified to pass.