### PR TITLE
fix(gsd): cancel auto unit when model restore fails

### DIFF
--- a/src/resources/extensions/gsd/auto/run-unit.ts
+++ b/src/resources/extensions/gsd/auto/run-unit.ts
@@ -82,10 +82,20 @@ export async function runUnit(
   if (s.currentUnitModel && typeof pi.setModel === "function") {
     const restored = await pi.setModel(s.currentUnitModel, { persist: false });
     if (!restored) {
+      const message =
+        `Failed to restore configured model ${s.currentUnitModel.provider}/${s.currentUnitModel.id} after session creation`;
       ctx.ui.notify(
-        `Failed to restore ${s.currentUnitModel.provider}/${s.currentUnitModel.id} after session creation. Using session default.`,
+        `${message}. Cancelling unit before dispatch.`,
         "warning",
       );
+      return {
+        status: "cancelled",
+        errorContext: {
+          message,
+          category: "session-failed",
+          isTransient: false,
+        },
+      };
     }
   }
 

--- a/src/resources/extensions/gsd/tests/auto-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-loop.test.ts
@@ -313,6 +313,42 @@ test("runUnit re-applies the selected unit model after newSession before dispatc
   assert.equal(pi.calls.length, 1);
 });
 
+test("runUnit cancels before dispatch when model restore fails after newSession", async () => {
+  _resetPendingResolve();
+
+  const notifications: Array<{ message: string; level: string }> = [];
+  const ctx = makeMockCtx();
+  ctx.ui.notify = (message: string, level: string) => {
+    notifications.push({ message, level });
+  };
+
+  const pi = makeMockPi();
+  pi.setModel = async (...args: unknown[]) => {
+    pi.setModelCalls.push(args);
+    return false;
+  };
+
+  const s = makeMockSession();
+  s.currentUnitModel = { provider: "openai-codex", id: "gpt-5.4" };
+
+  const result = await runUnit(ctx, pi, s, "task", "T01", "prompt");
+
+  assert.equal(result.status, "cancelled");
+  assert.equal(result.errorContext?.category, "session-failed");
+  assert.match(
+    result.errorContext?.message ?? "",
+    /Failed to restore configured model openai-codex\/gpt-5\.4 after session creation/,
+  );
+  assert.equal(pi.setModelCalls.length, 1);
+  assert.equal(pi.calls.length, 0, "unit must not dispatch on the session default model");
+  assert.deepEqual(notifications, [
+    {
+      message: "Failed to restore configured model openai-codex/gpt-5.4 after session creation. Cancelling unit before dispatch.",
+      level: "warning",
+    },
+  ]);
+});
+
 // ─── Structural assertions ───────────────────────────────────────────────────
 
 test("auto-loop.ts exports autoLoop, runUnit, resolveAgentEnd", async () => {


### PR DESCRIPTION
## Linked issue

Closes #4278

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Cancel the auto unit before dispatch if the configured model cannot be restored after `newSession()`.
**Why:** The current flow falls through to the session default model, so the unit can run against the wrong model after a restore failure.
**How:** Return a `cancelled` unit result with `session-failed` context instead of sending the prompt, and cover the fail-closed path with a regression test.

## What

This updates `runUnit()` in the GSD extension auto loop so a failed post-`newSession()` model restore stops the unit before dispatch. It also adds regression coverage in `auto-loop.test.ts` for the exact fail-closed path.

## Why

Issue #4278 reports that a unit can keep running on the session default model even when GSD fails to restore the configured model after `newSession()`. That is the wrong recovery shape: the unit should stop and surface the failure instead of quietly using a different model.

## How

When `pi.setModel(s.currentUnitModel, { persist: false })` returns `false`, `runUnit()` now notifies once and returns a `cancelled` result with `session-failed` error context. The new regression test asserts that no dispatch happens on the default model and that the warning text matches the fail-closed behavior.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

Automated verification:
1. `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/auto-loop.test.ts`
2. `npm run build`
3. `npm run typecheck:extensions`
4. `npm run test:unit`
   `test:unit` currently fails on `flat-rate provider routing guard (#3453)`, and that same failure reproduces on clean `upstream/main`.
5. `npm run test:integration`
   The late `src/tests/integration/pack-install.test.ts` phase stalled in this branch, and the same stuck-after-failure shape reproduced on clean `upstream/main`.

Manual verification:
1. Run `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/auto-loop.test.ts`.
2. Confirm `runUnit cancels before dispatch when model restore fails after newSession` passes.
3. Before fix: the issue report describes the unit falling through to the session default model after restore failure.
4. After fix: the unit returns `cancelled`, reports `session-failed`, and never dispatches on the default model.

## AI disclosure

- [x] This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.
