### PR TITLE
fix(gsd): prefer canonical preferences paths

### DIFF
--- a/src/resources/extensions/gsd/commands-cmux.ts
+++ b/src/resources/extensions/gsd/commands-cmux.ts
@@ -15,7 +15,7 @@ import { ensurePreferencesFile, serializePreferencesToFrontmatter } from "./comm
  * Returns true if preferences were written, false if skipped.
  */
 export function autoEnableCmuxPreferences(): boolean {
-  const path = getProjectGSDPreferencesPath();
+  const path = resolveProjectPreferencesWritePath();
   if (!existsSync(path)) return false;
 
   const existing = loadProjectGSDPreferences();
@@ -53,7 +53,7 @@ async function writeProjectCmuxPreferences(
   ctx: ExtensionCommandContext,
   updater: (prefs: Record<string, unknown>) => void,
 ): Promise<void> {
-  const path = getProjectGSDPreferencesPath();
+  const path = resolveProjectPreferencesWritePath();
   await ensurePreferencesFile(path, ctx, "project");
 
   const existing = loadProjectGSDPreferences();
@@ -71,6 +71,10 @@ async function writeProjectCmuxPreferences(
   await saveFile(path, `---\n${frontmatter}---${body}`);
   await ctx.waitForIdle();
   await ctx.reload();
+}
+
+function resolveProjectPreferencesWritePath(): string {
+  return loadProjectGSDPreferences()?.path ?? getProjectGSDPreferencesPath();
 }
 
 function formatCmuxStatus(): string {

--- a/src/resources/extensions/gsd/commands-prefs-wizard.ts
+++ b/src/resources/extensions/gsd/commands-prefs-wizard.ts
@@ -866,7 +866,7 @@ export async function ensurePreferencesFile(
 /**
  * Handle `/gsd language [code]` — set or clear the global language preference.
  * Without an argument, shows the current setting.
- * Project-level override can be set by editing `.gsd/preferences.md` directly
+ * Project-level override can be set by editing `.gsd/PREFERENCES.md` directly
  * (project language overrides global when both are set).
  */
 export async function handleLanguage(args: string, ctx: ExtensionCommandContext): Promise<void> {

--- a/src/resources/extensions/gsd/preferences.ts
+++ b/src/resources/extensions/gsd/preferences.ts
@@ -102,7 +102,7 @@ function gsdHome(): string {
 }
 
 function globalPreferencesPath(): string {
-  return join(gsdHome(), "preferences.md");
+  return join(gsdHome(), "PREFERENCES.md");
 }
 
 function legacyGlobalPreferencesPath(): string {
@@ -110,15 +110,15 @@ function legacyGlobalPreferencesPath(): string {
 }
 
 function projectPreferencesPath(): string {
-  return join(gsdRoot(process.cwd()), "preferences.md");
-}
-// Bootstrap in gitignore.ts historically created PREFERENCES.md (uppercase) by mistake.
-// Check uppercase as a fallback so those files aren't silently ignored.
-function globalPreferencesPathUppercase(): string {
-  return join(gsdHome(), "PREFERENCES.md");
-}
-function projectPreferencesPathUppercase(): string {
   return join(gsdRoot(process.cwd()), "PREFERENCES.md");
+}
+// Legacy lowercase files can still exist in older projects. Keep them as a
+// compatibility-only fallback, but route new reads/writes through PREFERENCES.md.
+function legacyGlobalPreferencesPathLowercase(): string {
+  return join(gsdHome(), "preferences.md");
+}
+function legacyProjectPreferencesPathLowercase(): string {
+  return join(gsdRoot(process.cwd()), "preferences.md");
 }
 
 export function getGlobalGSDPreferencesPath(): string {
@@ -137,13 +137,13 @@ export function getProjectGSDPreferencesPath(): string {
 
 export function loadGlobalGSDPreferences(): LoadedGSDPreferences | null {
   return loadPreferencesFile(globalPreferencesPath(), "global")
-    ?? loadPreferencesFile(globalPreferencesPathUppercase(), "global")
+    ?? loadPreferencesFile(legacyGlobalPreferencesPathLowercase(), "global")
     ?? loadPreferencesFile(legacyGlobalPreferencesPath(), "global");
 }
 
 export function loadProjectGSDPreferences(): LoadedGSDPreferences | null {
   return loadPreferencesFile(projectPreferencesPath(), "project")
-    ?? loadPreferencesFile(projectPreferencesPathUppercase(), "project");
+    ?? loadPreferencesFile(legacyProjectPreferencesPathLowercase(), "project");
 }
 
 export function loadEffectiveGSDPreferences(): LoadedGSDPreferences | null {

--- a/src/resources/extensions/gsd/tests/preferences.test.ts
+++ b/src/resources/extensions/gsd/tests/preferences.test.ts
@@ -12,12 +12,16 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 import {
   validatePreferences,
   applyModeDefaults,
   getIsolationMode,
+  getGlobalGSDPreferencesPath,
+  getProjectGSDPreferencesPath,
   loadEffectiveGSDPreferences,
+  loadGlobalGSDPreferences,
+  loadProjectGSDPreferences,
   parsePreferencesMarkdown,
   renderPreferencesForSystemPrompt,
   _resetParseWarningFlag,
@@ -593,6 +597,70 @@ test("loadEffectiveGSDPreferences preserves experimental prefs across global+pro
     assert.notEqual(loaded, null);
     assert.equal(loaded!.preferences.experimental?.rtk, true);
     assert.equal(loaded!.preferences.git?.isolation, "none");
+  } finally {
+    process.chdir(originalCwd);
+    if (originalGsdHome === undefined) delete process.env.GSD_HOME;
+    else process.env.GSD_HOME = originalGsdHome;
+    rmSync(tempProject, { recursive: true, force: true });
+    rmSync(tempGsdHome, { recursive: true, force: true });
+  }
+});
+
+test("preferences paths use canonical uppercase filenames", () => {
+  const originalCwd = process.cwd();
+  const originalGsdHome = process.env.GSD_HOME;
+  const tempProject = mkdtempSync(join(tmpdir(), "gsd-prefs-canonical-project-"));
+  const tempGsdHome = mkdtempSync(join(tmpdir(), "gsd-prefs-canonical-home-"));
+
+  try {
+    mkdirSync(join(tempProject, ".gsd"), { recursive: true });
+    process.env.GSD_HOME = tempGsdHome;
+    process.chdir(tempProject);
+
+    assert.equal(basename(getGlobalGSDPreferencesPath()), "PREFERENCES.md");
+    assert.ok(
+      getProjectGSDPreferencesPath().endsWith("/.gsd/PREFERENCES.md")
+        || getProjectGSDPreferencesPath().endsWith("\\.gsd\\PREFERENCES.md"),
+      "project preferences path should use .gsd/PREFERENCES.md",
+    );
+  } finally {
+    process.chdir(originalCwd);
+    if (originalGsdHome === undefined) delete process.env.GSD_HOME;
+    else process.env.GSD_HOME = originalGsdHome;
+    rmSync(tempProject, { recursive: true, force: true });
+    rmSync(tempGsdHome, { recursive: true, force: true });
+  }
+});
+
+test("uppercase PREFERENCES.md wins over legacy lowercase preferences.md", () => {
+  const originalCwd = process.cwd();
+  const originalGsdHome = process.env.GSD_HOME;
+  const tempProject = mkdtempSync(join(tmpdir(), "gsd-prefs-priority-project-"));
+  const tempGsdHome = mkdtempSync(join(tmpdir(), "gsd-prefs-priority-home-"));
+
+  try {
+    mkdirSync(join(tempProject, ".gsd"), { recursive: true });
+
+    writeFileSync(join(tempGsdHome, "preferences.md"), "---\nversion: 1\nmode: solo\n---\n", "utf-8");
+    writeFileSync(join(tempGsdHome, "PREFERENCES.md"), "---\nversion: 1\nmode: team\n---\n", "utf-8");
+    writeFileSync(join(tempProject, ".gsd", "preferences.md"), "---\nversion: 1\nlanguage: German\n---\n", "utf-8");
+    writeFileSync(join(tempProject, ".gsd", "PREFERENCES.md"), "---\nversion: 1\nlanguage: Japanese\n---\n", "utf-8");
+
+    process.env.GSD_HOME = tempGsdHome;
+    process.chdir(tempProject);
+
+    const globalPrefs = loadGlobalGSDPreferences();
+    const projectPrefs = loadProjectGSDPreferences();
+    assert.notEqual(globalPrefs, null);
+    assert.notEqual(projectPrefs, null);
+    assert.equal(globalPrefs!.preferences.mode, "team");
+    assert.equal(projectPrefs!.preferences.language, "Japanese");
+    assert.equal(basename(globalPrefs!.path), "PREFERENCES.md");
+    assert.ok(
+      projectPrefs!.path.endsWith("/.gsd/PREFERENCES.md")
+        || projectPrefs!.path.endsWith("\\.gsd\\PREFERENCES.md"),
+      "project loader should prefer .gsd/PREFERENCES.md",
+    );
   } finally {
     process.chdir(originalCwd);
     if (originalGsdHome === undefined) delete process.env.GSD_HOME;


### PR DESCRIPTION
## Linked issue

Closes #4318

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Canonicalize GSD preference paths to `PREFERENCES.md` while keeping legacy lowercase files as read fallbacks.
**Why:** Current code still prefers `preferences.md`, which creates split-brain behavior against the uppercase file names already used elsewhere in GSD.
**How:** Switch the canonical global and project paths to uppercase, keep lowercase compatibility-only fallbacks, update the wizard text, and add precedence tests.

## What

This updates the GSD preference path helpers so new reads and writes target `PREFERENCES.md` for both global and project preferences. It keeps legacy lowercase files readable as compatibility fallbacks, updates the language command help text, and adds regression coverage for canonical path selection and fallback precedence.

## Why

Issue #4318 reports a split-brain state where parts of GSD use `PREFERENCES.md` while the preference loader still prefers `preferences.md`. That can make the canonical file look ignored and creates unnecessary confusion about which file is authoritative.

## How

The canonical path getters now return uppercase `PREFERENCES.md`, and the loaders try that path first before falling back to legacy lowercase files. The tests cover both the canonical file names and the precedence rule where uppercase wins when both variants exist.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

Automated verification:
1. `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/preferences.test.ts`
2. `npm run build`
3. `npm run typecheck:extensions`
4. `npm run test:unit`
   `test:unit` currently fails on `flat-rate provider routing guard (#3453)`, and that same failure reproduces on clean `upstream/main`.
5. Current integration verification is limited by a late `src/tests/integration/pack-install.test.ts` stall that reproduces on clean `upstream/main` during this verification round.

Manual verification:
1. Run `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/preferences.test.ts`.
2. Confirm `preferences paths use canonical uppercase filenames` and `uppercase PREFERENCES.md wins over legacy lowercase preferences.md` pass.
3. Before fix: the loader still preferred lowercase `preferences.md`, creating disagreement with the canonical uppercase path used elsewhere.
4. After fix: canonical getters point to `PREFERENCES.md`, and the loader prefers uppercase while still reading legacy lowercase files.

## AI disclosure

- [x] This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.
