### PR TITLE
fix(gsd): enable structured milestone questions in auto mode

### DIFF
--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -78,6 +78,7 @@ export interface DispatchContext {
   state: GSDState;
   prefs: GSDPreferences | undefined;
   session?: import("./auto/session.js").AutoSession;
+  structuredQuestionsAvailable?: "true" | "false";
 }
 
 export interface DispatchRule {
@@ -331,19 +332,24 @@ export const DISPATCH_RULES: DispatchRule[] = [
   },
   {
     name: "needs-discussion → discuss-milestone",
-    match: async ({ state, mid, midTitle, basePath }) => {
+    match: async ({ state, mid, midTitle, basePath, structuredQuestionsAvailable }) => {
       if (state.phase !== "needs-discussion") return null;
       return {
         action: "dispatch",
         unitType: "discuss-milestone",
         unitId: mid,
-        prompt: await buildDiscussMilestonePrompt(mid, midTitle, basePath),
+        prompt: await buildDiscussMilestonePrompt(
+          mid,
+          midTitle,
+          basePath,
+          structuredQuestionsAvailable,
+        ),
       };
     },
   },
   {
     name: "pre-planning (no context) → discuss-milestone",
-    match: async ({ state, mid, midTitle, basePath }) => {
+    match: async ({ state, mid, midTitle, basePath, structuredQuestionsAvailable }) => {
       if (state.phase !== "pre-planning") return null;
       const contextFile = resolveMilestoneFile(basePath, mid, "CONTEXT");
       const hasContext = !!(contextFile && (await loadFile(contextFile)));
@@ -352,7 +358,12 @@ export const DISPATCH_RULES: DispatchRule[] = [
         action: "dispatch",
         unitType: "discuss-milestone",
         unitId: mid,
-        prompt: await buildDiscussMilestonePrompt(mid, midTitle, basePath),
+        prompt: await buildDiscussMilestonePrompt(
+          mid,
+          midTitle,
+          basePath,
+          structuredQuestionsAvailable,
+        ),
       };
     },
   },

--- a/src/resources/extensions/gsd/auto-prompts.ts
+++ b/src/resources/extensions/gsd/auto-prompts.ts
@@ -997,14 +997,19 @@ export async function checkNeedsRunUat(
  * as a seed when present. The discussion agent interviews the user, writes
  * a full CONTEXT.md, and the phase transitions to pre-planning automatically.
  */
-export async function buildDiscussMilestonePrompt(mid: string, midTitle: string, base: string): Promise<string> {
+export async function buildDiscussMilestonePrompt(
+  mid: string,
+  midTitle: string,
+  base: string,
+  structuredQuestionsAvailable = "false",
+): Promise<string> {
   const discussTemplates = inlineTemplate("context", "Context");
 
   const basePrompt = loadPrompt("guided-discuss-milestone", {
     milestoneId: mid,
     milestoneTitle: midTitle,
     inlinedTemplates: discussTemplates,
-    structuredQuestionsAvailable: "false",
+    structuredQuestionsAvailable,
     commitInstruction: "Do not commit planning artifacts — .gsd/ is managed externally.",
     fastPathInstruction: "",
   });

--- a/src/resources/extensions/gsd/auto/loop-deps.ts
+++ b/src/resources/extensions/gsd/auto/loop-deps.ts
@@ -152,6 +152,7 @@ export interface LoopDeps {
     state: GSDState;
     prefs: GSDPreferences | undefined;
     session?: AutoSession;
+    structuredQuestionsAvailable?: "true" | "false";
   }) => Promise<DispatchAction>;
   runPreDispatchHooks: (
     unitType: string,

--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -59,6 +59,7 @@ import { resolveSafetyHarnessConfig } from "../safety/safety-harness.js";
 import {
   getWorkflowTransportSupportError,
   getRequiredWorkflowToolsForAutoUnit,
+  supportsStructuredQuestions,
 } from "../workflow-mcp.js";
 
 // ─── Session timeout auto-resume state ────────────────────────────────────────
@@ -781,6 +782,15 @@ export async function runDispatch(
   const { ctx, pi, s, deps, prefs } = ic;
   const { state, mid, midTitle } = preData;
   const STUCK_WINDOW_SIZE = 6;
+  const provider = ctx.model?.provider;
+  const authMode = provider && typeof ctx.modelRegistry?.getProviderAuthMode === "function"
+    ? ctx.modelRegistry.getProviderAuthMode(provider)
+    : undefined;
+  const activeTools = typeof pi.getActiveTools === "function" ? pi.getActiveTools() : [];
+  const structuredQuestionsAvailable = supportsStructuredQuestions(activeTools, {
+    authMode,
+    baseUrl: ctx.model?.baseUrl,
+  }) ? "true" : "false";
 
   debugLog("autoLoop", { phase: "dispatch-resolve", iteration: ic.iteration });
   const dispatchResult = await deps.resolveDispatch({
@@ -790,6 +800,7 @@ export async function runDispatch(
     state,
     prefs,
     session: s,
+    structuredQuestionsAvailable,
   });
 
   if (dispatchResult.action === "stop") {

--- a/src/resources/extensions/gsd/tests/discuss-milestone-structured-questions.test.ts
+++ b/src/resources/extensions/gsd/tests/discuss-milestone-structured-questions.test.ts
@@ -1,0 +1,64 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { resolveDispatch, type DispatchContext } from "../auto-dispatch.ts";
+import type { GSDState } from "../types.ts";
+
+function makeState(phase: GSDState["phase"]): GSDState {
+  return {
+    activeMilestone: { id: "M001", title: "Structured Questions" },
+    activeSlice: null,
+    activeTask: null,
+    phase,
+    recentDecisions: [],
+    blockers: [],
+    nextAction: "",
+    registry: [],
+  };
+}
+
+function makeContext(
+  basePath: string,
+  phase: GSDState["phase"],
+  structuredQuestionsAvailable: "true" | "false",
+): DispatchContext {
+  return {
+    basePath,
+    mid: "M001",
+    midTitle: "Structured Questions",
+    state: makeState(phase),
+    prefs: undefined,
+    structuredQuestionsAvailable,
+  };
+}
+
+test("auto-dispatch passes structuredQuestionsAvailable=true into discuss-milestone prompt", async (t) => {
+  const tmp = mkdtempSync(join(tmpdir(), "gsd-discuss-milestone-structured-"));
+  t.after(() => rmSync(tmp, { recursive: true, force: true }));
+
+  const result = await resolveDispatch(makeContext(tmp, "needs-discussion", "true"));
+
+  assert.equal(result.action, "dispatch");
+  assert.equal(result.unitType, "discuss-milestone");
+  assert.match(
+    result.prompt,
+    /\*\*Structured questions available: true\*\*/,
+  );
+});
+
+test("auto-dispatch preserves structuredQuestionsAvailable=false for discuss-milestone prompt", async (t) => {
+  const tmp = mkdtempSync(join(tmpdir(), "gsd-discuss-milestone-plain-"));
+  t.after(() => rmSync(tmp, { recursive: true, force: true }));
+
+  const result = await resolveDispatch(makeContext(tmp, "pre-planning", "false"));
+
+  assert.equal(result.action, "dispatch");
+  assert.equal(result.unitType, "discuss-milestone");
+  assert.match(
+    result.prompt,
+    /\*\*Structured questions available: false\*\*/,
+  );
+});

--- a/src/resources/extensions/gsd/tests/workflow-mcp.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-mcp.test.ts
@@ -441,13 +441,13 @@ test("usesWorkflowMcpTransport matches local externalCli providers", () => {
   assert.equal(usesWorkflowMcpTransport("oauth", "local://custom"), false);
 });
 
-test("supportsStructuredQuestions disables structured ask flow on workflow MCP transports", () => {
+test("supportsStructuredQuestions stays enabled on workflow MCP transports when ask_user_questions is available", () => {
   assert.equal(
     supportsStructuredQuestions(["ask_user_questions"], {
       authMode: "externalCli",
       baseUrl: "local://claude-code",
     }),
-    false,
+    true,
   );
   assert.equal(
     supportsStructuredQuestions(["ask_user_questions"], {

--- a/src/resources/extensions/gsd/workflow-mcp.ts
+++ b/src/resources/extensions/gsd/workflow-mcp.ts
@@ -354,12 +354,6 @@ export function supportsStructuredQuestions(
 ): boolean {
   if (!activeTools.includes("ask_user_questions")) return false;
 
-  // Workflow MCP currently exposes ask_user_questions via MCP form elicitation.
-  // Local external CLI transports such as Claude Code can invoke the tool, but
-  // do not reliably complete that elicitation round-trip yet, so guided discuss
-  // prompts must fall back to plain-text questioning.
-  if (usesWorkflowMcpTransport(options.authMode, options.baseUrl)) return false;
-
   return true;
 }
 


### PR DESCRIPTION
## Linked issue

Closes #4191

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Re-enable structured discuss-milestone questions when `ask_user_questions` is available, including workflow MCP transports.
**Why:** Auto-mode currently forces milestone discussion down the plain-text path by both blanket-disabling workflow MCP transports and hardcoding `structuredQuestionsAvailable: false` in the prompt builder.
**How:** Keep `supportsStructuredQuestions()` transport-agnostic, thread the computed availability through `runDispatch`, and cover the prompt wiring with a regression test.

## What

This updates the GSD extension milestone discussion path so auto dispatch can pass the real `structuredQuestionsAvailable` value into `buildDiscussMilestonePrompt()`. The workflow MCP capability check now allows structured questions whenever `ask_user_questions` is present, and a new regression test verifies that the dispatch result renders the discuss prompt with the expected `true` / `false` value.

## Why

Issue #4191 reports that structured questions never render during the discuss phase. That was still true on current `main` because workflow MCP transports were blanket-disabled in `supportsStructuredQuestions()`, and the auto-mode discuss-milestone prompt builder still hardcoded `structuredQuestionsAvailable: "false"`.

## How

`runDispatch()` now computes structured-question availability once from the active tools and current model transport, and threads that into the dispatch context. The discuss-milestone prompt builder accepts the computed value instead of hardcoding `false`, and the workflow MCP support check now only requires that `ask_user_questions` actually be available.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

Automated verification:
1. `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/workflow-mcp.test.ts src/resources/extensions/gsd/tests/discuss-milestone-structured-questions.test.ts`
2. `npm run build`
3. `npm run typecheck:extensions`
4. `npm run test:unit`
   `test:unit` currently fails on `flat-rate provider routing guard (#3453)`, and that same failure reproduces on clean `upstream/main` in this environment.
5. Current local integration verification is limited by the same late `src/tests/integration/pack-install.test.ts` pack/install stall that reproduces on clean `upstream/main` in this environment.

Manual verification:
1. Run `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/workflow-mcp.test.ts src/resources/extensions/gsd/tests/discuss-milestone-structured-questions.test.ts`.
2. Confirm the workflow MCP structured-questions test passes and the discuss-milestone dispatch prompt renders `Structured questions available: true` when availability is enabled.
3. Before fix: workflow MCP transports were forced to `false`, and auto discuss-milestone always rendered with `structuredQuestionsAvailable: false`.
4. After fix: auto dispatch passes the real availability into the prompt, so structured questions stay enabled when `ask_user_questions` is actually available.

## AI disclosure

- [x] This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.
