### PR TITLE
fix(gsd): track queued wrapup skips before execution

### DIFF
--- a/src/resources/extensions/gsd/bootstrap/register-hooks.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-hooks.ts
@@ -325,6 +325,7 @@ export function registerHooks(
   // ── Safety harness: evidence collection + destructive command warnings ──
   pi.on("tool_call", async (event, ctx) => {
     if (!isAutoActive()) return;
+    markToolStart(event.toolCallId, event.toolName);
     safetyRecordToolCall(event.toolCallId, event.toolName, event.input as Record<string, unknown>);
 
     // Destructive command classification (warn only, never block)
@@ -343,6 +344,20 @@ export function registerHooks(
   });
 
   pi.on("tool_result", async (event) => {
+    if (isAutoActive() && typeof event.toolCallId === "string") {
+      markToolEnd(event.toolCallId);
+    }
+    if (isAutoActive() && event.isError && event.toolName.startsWith("gsd_")) {
+      const resultPayload = ("result" in event ? event.result : undefined) as any;
+      const errorText = typeof resultPayload === "string"
+        ? resultPayload
+        : (typeof resultPayload?.content?.[0]?.text === "string"
+            ? resultPayload.content[0].text
+            : (typeof (event as any).content === "string"
+                ? (event as any).content
+                : String(resultPayload ?? "")));
+      recordToolInvocationError(event.toolName, errorText);
+    }
     if (event.toolName !== "ask_user_questions") return;
     const milestoneId = getDiscussionMilestoneId(process.cwd());
     const queueActive = isQueuePhaseActive();

--- a/src/resources/extensions/gsd/tests/auto-wrapup-inflight-guard.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-wrapup-inflight-guard.test.ts
@@ -15,6 +15,9 @@ const autoSrc = readFileSync(autoPath, "utf-8");
 const runUnitPath = join(import.meta.dirname, "..", "auto", "run-unit.ts");
 const runUnitSrc = readFileSync(runUnitPath, "utf-8");
 
+const registerHooksPath = join(import.meta.dirname, "..", "bootstrap", "register-hooks.ts");
+const registerHooksSrc = readFileSync(registerHooksPath, "utf-8");
+
 describe("#3512: gsd-auto-wrapup must not interrupt in-flight tool calls", () => {
   test("soft timeout wrapup gates triggerTurn on getInFlightToolCount() === 0", () => {
     // The soft timeout sendMessage must NOT use a hardcoded `triggerTurn: true`.
@@ -66,6 +69,42 @@ describe("#3512: gsd-auto-wrapup must not interrupt in-flight tool calls", () =>
     assert.ok(
       !contextSection.includes("triggerTurn: true"),
       "Context budget wrapup must not use hardcoded triggerTurn: true",
+    );
+  });
+});
+
+describe("#4276: pending/skipped tools stay visible to auto-mode hooks", () => {
+  test("tool_call handler marks GSD tools in-flight before execution_start", () => {
+    const startMarker = 'pi.on("tool_call", async (event, ctx) => {';
+    const endMarker = 'pi.on("tool_result", async (event) => {';
+    const toolCallSection = registerHooksSrc.slice(
+      registerHooksSrc.indexOf(startMarker),
+      registerHooksSrc.indexOf(endMarker),
+    );
+
+    assert.ok(toolCallSection.length > 0, "Could not locate tool_call handler section");
+    assert.ok(
+      toolCallSection.includes("markToolStart(event.toolCallId, event.toolName)"),
+      "tool_call handler must mark tools pending before tool_execution_start fires",
+    );
+  });
+
+  test("tool_result handler clears pending tools and records queued-skip errors", () => {
+    const startMarker = 'pi.on("tool_result", async (event) => {';
+    const endMarker = 'pi.on("tool_execution_start", async (event) => {';
+    const toolResultSection = registerHooksSrc.slice(
+      registerHooksSrc.indexOf(startMarker),
+      registerHooksSrc.indexOf(endMarker),
+    );
+
+    assert.ok(toolResultSection.length > 0, "Could not locate tool_result handler section");
+    assert.ok(
+      toolResultSection.includes("markToolEnd(event.toolCallId)"),
+      "tool_result handler must clear pending tool tracking even when execution hooks never fire",
+    );
+    assert.ok(
+      toolResultSection.includes("recordToolInvocationError(event.toolName, errorText)"),
+      "tool_result handler must surface queued-skip errors for GSD tools",
     );
   });
 });


### PR DESCRIPTION
## Linked issue

Closes #4276

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Track pending tool calls before `tool_execution_start` and record queued-message skips from `tool_result`.
**Why:** The auto wrapup timer can currently race a just-issued tool call, and skipped tools bypass the existing invocation-error pause path because they never reach `tool_execution_end`.
**How:** Mark tools in-flight at `tool_call`, clear them at `tool_result`, and surface queued-skip errors from the tool-result hook so auto-mode can pause instead of silently retrying.

## What

This updates the GSD extension hook wiring so pending tool calls become visible to the in-flight tracker as soon as the tool call is issued, not only after execution starts. It also teaches the `tool_result` hook to clear pending tracking and route queued-message skip errors through the existing tool-invocation-error path.

## Why

Issue #4276 reports a wrapup-timer race where `gsd-auto-wrapup` can land between the tool call and `tool_execution_start`, causing the tool to be skipped with `Skipped due to queued user message.` That skipped path never reaches `tool_execution_end`, so `lastToolInvocationError` stays empty and auto-mode falls through to the wrong retry path.

## How

The safety `tool_call` hook now marks the tool as in-flight immediately, which closes the race window used by wrapup-trigger gating. The `tool_result` hook now clears the pending tracking entry and records queued-skip tool errors for `gsd_` tools even when the execution hooks never fire.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

Automated verification:
1. `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/auto-wrapup-inflight-guard.test.ts`
2. `npm run build`
3. `npm run typecheck:extensions`
4. `npm run test:unit`
   `test:unit` currently fails on `flat-rate provider routing guard (#3453)`, and that same failure reproduces on clean `upstream/main` in this environment.
5. `npm run test:integration`
   The run reached the late `src/tests/integration/pack-install.test.ts` pack/install phase. Current local integration verification is limited by the same pack-install stall that reproduces on clean `upstream/main` in this environment.

Manual verification:
1. Run `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/auto-wrapup-inflight-guard.test.ts`.
2. Confirm the regression tests show that pending tools are marked from `tool_call` and that queued-skip tool results are recorded from `tool_result`.
3. Before fix: wrapup could hit the gap before `tool_execution_start`, and skipped tools bypassed the queued-skip error path because `tool_execution_end` never fired.
4. After fix: pending tools are visible immediately from `tool_call`, and queued-skip results still reach the existing pause logic through `tool_result`.

## AI disclosure

- [x] This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.
