### PR TITLE
fix(gsd): treat unexpected eof as transient network error

### DIFF
--- a/src/resources/extensions/gsd/error-classifier.ts
+++ b/src/resources/extensions/gsd/error-classifier.ts
@@ -47,7 +47,7 @@ const RATE_LIMIT_RE = /rate.?limit|too many requests|429/i;
 // OpenRouter affordability-style quota errors should be treated as transient
 // so core retry logic can lower maxTokens and continue in-session.
 const AFFORDABILITY_RE = /requires more credits|can only afford|insufficient credits|not enough credits|fewer max_tokens/i;
-const NETWORK_RE = /network|ECONNRESET|ETIMEDOUT|ECONNREFUSED|socket hang up|fetch failed|connection.*reset|dns/i;
+const NETWORK_RE = /network|ECONNRESET|ETIMEDOUT|ECONNREFUSED|socket hang up|fetch failed|connection.*reset|dns|unexpected eof/i;
 const SERVER_RE = /internal server error|500|502|503|overloaded|server_error|api_error|service.?unavailable/i;
 // ECONNRESET/ECONNREFUSED are in NETWORK_RE (same-model retry first).
 const CONNECTION_RE = /terminated|connection.?(?:refused|error)|other side closed|EPIPE|network.?(?:is\s+)?unavailable|stream_exhausted(?:_without_result)?/i;

--- a/src/resources/extensions/gsd/tests/provider-errors.test.ts
+++ b/src/resources/extensions/gsd/tests/provider-errors.test.ts
@@ -202,6 +202,10 @@ test("isTransientNetworkError detects DNS errors", () => {
   assert.ok(isTransientNetworkError("dns resolution failed"));
 });
 
+test("isTransientNetworkError detects unexpected EOF", () => {
+  assert.ok(isTransientNetworkError("unexpected EOF"));
+});
+
 test("isTransientNetworkError rejects auth errors", () => {
   assert.ok(!isTransientNetworkError("unauthorized: invalid API key"));
 });


### PR DESCRIPTION
## Linked issue

Closes #4319

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Treat `unexpected EOF` provider failures as transient network errors.
**Why:** Custom providers can surface EOF transport failures without matching the current transient classifier, which makes auto recovery too pessimistic.
**How:** Extend the network error matcher and lock it in with a focused provider error regression test.

## What

This updates the GSD provider error classifier so `unexpected EOF` lands in the transient network bucket. The change is intentionally small: one classifier adjustment in `error-classifier.ts` plus a regression test in `provider-errors.test.ts`.

## Why

When a provider or proxy closes the connection mid-response, GSD should treat that as a retryable network-style failure rather than a hard non-transient error. Without that classification, recovery paths pause or stop more aggressively than they should for a temporary transport blip.

## How

The implementation adds `unexpected eof` to the existing network error matcher and adds a targeted test that proves the classifier now recognizes that shape as transient.

## Change type

- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [ ] Manual testing — steps described above
- [ ] No tests needed — explained above

Automated verification:
1. `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/provider-errors.test.ts`
2. `npm run typecheck:extensions`
3. `npm run build`

## AI disclosure

- [x] This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.
