### PR TITLE
fix(gsd): increment unit dispatch counts on dispatch

### DIFF
--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -1241,6 +1241,8 @@ export async function runUnitPhase(
   // per-unit. Without this, the module-level _buffer accumulates across every
   // unit in the same Node process (see workflow-logger.ts module header).
   _resetLogs();
+  const dispatchKey = `${unitType}/${unitId}`;
+  s.unitDispatchCount.set(dispatchKey, (s.unitDispatchCount.get(dispatchKey) ?? 0) + 1);
   s.currentUnit = { type: unitType, id: unitId, startedAt: Date.now() };
   s.lastGitActionFailure = null;
   s.lastGitActionStatus = null;
@@ -1307,7 +1309,7 @@ export async function runUnitPhase(
         : s.pendingCrashRecovery;
     finalPrompt = `${capped}\n\n---\n\n${finalPrompt}`;
     s.pendingCrashRecovery = null;
-  } else if ((s.unitDispatchCount.get(`${unitType}/${unitId}`) ?? 0) > 1) {
+  } else if ((s.unitDispatchCount.get(dispatchKey) ?? 0) > 1) {
     const diagnostic = deps.getDeepDiagnostic(s.basePath);
     if (diagnostic) {
       const cappedDiag =
@@ -1666,7 +1668,7 @@ export async function runUnitPhase(
     skipArtifactVerification ||
     verifyExpectedArtifact(unitType, unitId, s.basePath);
   if (artifactVerified) {
-    s.unitDispatchCount.delete(`${unitType}/${unitId}`);
+    s.unitDispatchCount.delete(dispatchKey);
     s.unitRecoveryCount.delete(`${unitType}/${unitId}`);
   }
 

--- a/src/resources/extensions/gsd/tests/journal-integration.test.ts
+++ b/src/resources/extensions/gsd/tests/journal-integration.test.ts
@@ -380,6 +380,41 @@ test("runUnitPhase emits unit-start and unit-end with causedBy reference", async
   assert.equal(endEvents[0].causedBy!.seq, startEvents[0].seq, "unit-end causedBy.seq must match unit-start.seq");
 });
 
+test("runUnitPhase increments unitDispatchCount for repeated artifact-missing retries", async () => {
+  const capture = createEventCapture();
+  const { resolveAgentEnd, _resetPendingResolve } = await import("../auto-loop.js");
+  _resetPendingResolve();
+
+  const deps = makeMockDeps(capture);
+  const ic = makeIC(deps);
+  const iterData: IterationData = {
+    unitType: "execute-task",
+    unitId: "M001/S01/T01",
+    prompt: "do stuff",
+    finalPrompt: "do stuff",
+    pauseAfterUatDispatch: false,
+    state: { phase: "executing", activeMilestone: { id: "M001" }, activeSlice: { id: "S01" }, registry: [], blockers: [] } as any,
+    mid: "M001",
+    midTitle: "Test",
+    isRetry: false,
+    previousTier: undefined,
+  };
+  const loopState: LoopState = { recentUnits: [{ key: "execute-task/M001/S01/T01" }], stuckRecoveryAttempts: 0, consecutiveFinalizeTimeouts: 0 };
+
+  const firstRun = runUnitPhase(ic, iterData, loopState);
+  await new Promise(r => setTimeout(r, 50));
+  resolveAgentEnd({ messages: [{ role: "assistant" }] });
+  await firstRun;
+  assert.equal(ic.s.unitDispatchCount.get("execute-task/M001/S01/T01"), 1);
+
+  _resetPendingResolve();
+  const secondRun = runUnitPhase(ic, iterData, loopState);
+  await new Promise(r => setTimeout(r, 50));
+  resolveAgentEnd({ messages: [{ role: "assistant" }] });
+  await secondRun;
+  assert.equal(ic.s.unitDispatchCount.get("execute-task/M001/S01/T01"), 2);
+});
+
 test("all events from a mock iteration have monotonically increasing seq and same flowId", async () => {
   const capture = createEventCapture();
   const { resolveAgentEnd, _resetPendingResolve } = await import("../auto-loop.js");


### PR DESCRIPTION
## Linked issue

Closes #4232

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Increment `unitDispatchCount` as soon as a unit is dispatched.
**Why:** Repeated dispatches never raised the per-unit retry count, so the diagnostic prompt never escalated on stuck retries.
**How:** Update the counter at dispatch time in `runUnitPhase()` and add a journal integration regression test for repeated runs of the same unit.

## What

This fixes the `unitDispatchCount` bookkeeping in the auto loop by incrementing the per-unit counter when dispatch begins. It also adds regression coverage in `journal-integration.test.ts` to prove repeated dispatches of the same task advance the counter across runs.

## Why

The retry diagnostic prompt depends on accurate dispatch counts. Because the count was never incremented on the main dispatch path, repeated artifact-missing retries could keep happening without ever crossing the threshold that triggers better diagnostics.

## How

The implementation introduces one shared dispatch key at the start of `runUnitPhase()` and increments `s.unitDispatchCount` immediately. The new test calls `runUnitPhase()` twice for the same task and asserts the count rises from `1` to `2`.

## Change type

- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [ ] Manual testing — steps described above
- [ ] No tests needed — explained above

Automated verification:
1. `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/journal-integration.test.ts`
2. `npm run typecheck:extensions`
3. `npm run build`

## AI disclosure

- [x] This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.
