### PR TITLE
fix(gsd): persist active custom workflow steps before dispatch

### DIFF
--- a/src/resources/extensions/gsd/custom-workflow-engine.ts
+++ b/src/resources/extensions/gsd/custom-workflow-engine.ts
@@ -26,6 +26,7 @@ import {
   readGraph,
   writeGraph,
   getNextPendingStep,
+  markStepActive,
   markStepComplete,
   expandIteration,
   type WorkflowGraph,
@@ -90,78 +91,90 @@ export class CustomWorkflowEngine implements WorkflowEngine {
     state: EngineState,
     _context: { basePath: string },
   ): Promise<EngineDispatchAction> {
-    let graph = state.raw as WorkflowGraph;
-    let next = getNextPendingStep(graph);
+    const graphPath = join(this.runDir, "GRAPH.yaml");
 
-    if (!next) {
-      return {
-        action: "stop",
-        reason: "All steps complete",
-        level: "info",
-      };
-    }
-
-    // Check frozen DEFINITION.yaml for iterate config on this step
-    const def = readFrozenDefinition(this.runDir);
-    const stepDef = def.steps.find((s: StepDefinition) => s.id === next!.id);
-
-    if (stepDef?.iterate) {
-      const iterate = stepDef.iterate;
-
-      // Read source artifact
-      const sourcePath = join(this.runDir, iterate.source);
-      let sourceContent: string;
-      try {
-        sourceContent = readFileSync(sourcePath, "utf-8");
-      } catch {
-        throw new Error(
-          `Iterate source artifact not found: ${sourcePath} (step "${next.id}", source: "${iterate.source}")`,
-        );
-      }
-
-      // Extract items via regex with global+multiline flags.
-      // Guard against ReDoS: if matching takes too long on large inputs, bail.
-      const regex = new RegExp(iterate.pattern, "gm");
-      const items: string[] = [];
-      const matchStart = Date.now();
-      let match: RegExpExecArray | null;
-      while ((match = regex.exec(sourceContent)) !== null) {
-        if (match[1] !== undefined) items.push(match[1]);
-        if (Date.now() - matchStart > 5_000) {
-          throw new Error(
-            `Iterate pattern "${iterate.pattern}" exceeded 5s timeout on step "${next.id}" — possible ReDoS`,
-          );
-        }
-      }
-
-      // Expand the graph
-      const expandedGraph = expandIteration(graph, next.id, items, next.prompt);
-      writeGraph(this.runDir, expandedGraph);
-      graph = expandedGraph;
-
-      // Re-query for first instance step
-      next = getNextPendingStep(expandedGraph);
+    return await withFileLock(graphPath, () => {
+      let graph = readGraph(this.runDir);
+      let next = getNextPendingStep(graph);
 
       if (!next) {
         return {
           action: "stop",
-          reason: "Iterate expansion produced no instances",
+          reason: "All steps complete",
           level: "info",
         };
       }
-    }
 
-    // Enrich prompt with context from prior step artifacts
-    const enrichedPrompt = injectContext(this.runDir, next.id, next.prompt);
+      // Check frozen DEFINITION.yaml for iterate config on this step
+      const def = readFrozenDefinition(this.runDir);
+      const stepDef = def.steps.find((s: StepDefinition) => s.id === next!.id);
 
-    return {
-      action: "dispatch",
-      step: {
-        unitType: "custom-step",
-        unitId: `${graph.metadata.name}/${next.id}`,
-        prompt: enrichedPrompt,
-      },
-    };
+      if (stepDef?.iterate) {
+        const iterate = stepDef.iterate;
+
+        // Read source artifact
+        const sourcePath = join(this.runDir, iterate.source);
+        let sourceContent: string;
+        try {
+          sourceContent = readFileSync(sourcePath, "utf-8");
+        } catch {
+          throw new Error(
+            `Iterate source artifact not found: ${sourcePath} (step "${next.id}", source: "${iterate.source}")`,
+          );
+        }
+
+        // Extract items via regex with global+multiline flags.
+        // Guard against ReDoS: if matching takes too long on large inputs, bail.
+        const regex = new RegExp(iterate.pattern, "gm");
+        const items: string[] = [];
+        const matchStart = Date.now();
+        let match: RegExpExecArray | null;
+        while ((match = regex.exec(sourceContent)) !== null) {
+          if (match[1] !== undefined) items.push(match[1]);
+          if (Date.now() - matchStart > 5_000) {
+            throw new Error(
+              `Iterate pattern "${iterate.pattern}" exceeded 5s timeout on step "${next.id}" — possible ReDoS`,
+            );
+          }
+        }
+
+        // Expand the graph
+        const expandedGraph = expandIteration(graph, next.id, items, next.prompt);
+        writeGraph(this.runDir, expandedGraph);
+        graph = expandedGraph;
+
+        // Re-query for first instance step
+        next = getNextPendingStep(expandedGraph);
+
+        if (!next) {
+          return {
+            action: "stop",
+            reason: "Iterate expansion produced no instances",
+            level: "info",
+          };
+        }
+      }
+
+      const activeGraph = markStepActive(graph, next.id);
+      writeGraph(this.runDir, activeGraph);
+
+      const activeStep = activeGraph.steps.find((s) => s.id === next.id);
+      if (!activeStep) {
+        throw new Error(`Active step not found after GRAPH.yaml update: ${next.id}`);
+      }
+
+      // Enrich prompt with context from prior step artifacts
+      const enrichedPrompt = injectContext(this.runDir, activeStep.id, activeStep.prompt);
+
+      return {
+        action: "dispatch" as const,
+        step: {
+          unitType: "custom-step",
+          unitId: `${activeGraph.metadata.name}/${activeStep.id}`,
+          prompt: enrichedPrompt,
+        },
+      };
+    });
   }
 
   /**

--- a/src/resources/extensions/gsd/custom-workflow-engine.ts
+++ b/src/resources/extensions/gsd/custom-workflow-engine.ts
@@ -95,6 +95,18 @@ export class CustomWorkflowEngine implements WorkflowEngine {
 
     return await withFileLock(graphPath, () => {
       let graph = readGraph(this.runDir);
+      const active = graph.steps.find((step) => step.status === "active");
+      if (active) {
+        return {
+          action: "dispatch" as const,
+          step: {
+            unitType: "custom-step",
+            unitId: `${graph.metadata.name}/${active.id}`,
+            prompt: injectContext(this.runDir, active.id, active.prompt),
+          },
+        };
+      }
+
       let next = getNextPendingStep(graph);
 
       if (!next) {

--- a/src/resources/extensions/gsd/graph.ts
+++ b/src/resources/extensions/gsd/graph.ts
@@ -202,6 +202,39 @@ export function markStepComplete(
   };
 }
 
+/**
+ * Return a new graph with the specified step marked as "active".
+ * Immutable — does not mutate the input graph.
+ *
+ * @param graph — the current workflow graph
+ * @param stepId — ID of the step to mark active
+ * @returns New graph with the step's status set to "active"
+ * @throws Error if stepId is not found in the graph
+ */
+export function markStepActive(
+  graph: WorkflowGraph,
+  stepId: string,
+): WorkflowGraph {
+  const found = graph.steps.some((s) => s.id === stepId);
+  if (!found) {
+    throw new Error(`Step not found: ${stepId}`);
+  }
+
+  const startedAt = new Date().toISOString();
+  return {
+    ...graph,
+    steps: graph.steps.map((s) =>
+      s.id === stepId
+        ? {
+            ...s,
+            status: "active" as const,
+            startedAt: s.startedAt ?? startedAt,
+          }
+        : s,
+    ),
+  };
+}
+
 // ─── Iteration expansion ─────────────────────────────────────────────────
 
 /**

--- a/src/resources/extensions/gsd/tests/custom-workflow-engine.test.ts
+++ b/src/resources/extensions/gsd/tests/custom-workflow-engine.test.ts
@@ -139,6 +139,22 @@ describe("CustomWorkflowEngine.resolveDispatch", () => {
     }
   });
 
+  it("persists the dispatched step as active in GRAPH.yaml before returning", async () => {
+    const { engine, runDir } = setupEngine([
+      makeStep({ id: "step-1", prompt: "Do the first thing" }),
+      makeStep({ id: "step-2", dependsOn: ["step-1"] }),
+    ], "my-workflow");
+
+    const state = await engine.deriveState("/unused");
+    const dispatch = await engine.resolveDispatch(state, { basePath: "/unused" });
+
+    assert.equal(dispatch.action, "dispatch");
+    const graph = readGraph(runDir);
+    assert.equal(graph.steps[0].status, "active");
+    assert.ok(graph.steps[0].startedAt, "startedAt should be persisted before dispatch returns");
+    assert.equal(graph.steps[1].status, "pending");
+  });
+
   it("returns stop when all steps are complete", async () => {
     const { engine } = setupEngine([
       makeStep({ id: "a", status: "complete" }),
@@ -279,6 +295,31 @@ describe("CustomWorkflowEngine.reconcile", () => {
     assert.equal(graph.steps[0].status, "complete");
     assert.equal(graph.steps[1].status, "pending");
     assert.equal(graph.steps[2].status, "pending");
+  });
+
+  it("reconcile completes a step that was previously persisted as active", async () => {
+    const { engine, runDir } = setupEngine([
+      makeStep({ id: "step-1", prompt: "Do the first thing" }),
+      makeStep({ id: "step-2", dependsOn: ["step-1"] }),
+    ], "wf");
+
+    const state = await engine.deriveState("/unused");
+    const dispatch = await engine.resolveDispatch(state, { basePath: "/unused" });
+    assert.equal(dispatch.action, "dispatch");
+
+    const activeState = await engine.deriveState("/unused");
+    const result = await engine.reconcile(activeState, {
+      unitType: "custom-step",
+      unitId: "wf/step-1",
+      startedAt: Date.now() - 1000,
+      finishedAt: Date.now(),
+    });
+
+    assert.equal(result.outcome, "continue");
+    const graph = readGraph(runDir);
+    assert.equal(graph.steps[0].status, "complete");
+    assert.ok(graph.steps[0].startedAt, "startedAt should survive reconcile");
+    assert.ok(graph.steps[0].finishedAt, "finishedAt should be persisted on completion");
   });
 });
 

--- a/src/resources/extensions/gsd/tests/custom-workflow-engine.test.ts
+++ b/src/resources/extensions/gsd/tests/custom-workflow-engine.test.ts
@@ -155,6 +155,28 @@ describe("CustomWorkflowEngine.resolveDispatch", () => {
     assert.equal(graph.steps[1].status, "pending");
   });
 
+  it("reuses an already active step on a subsequent dispatch before reconcile", async () => {
+    const { engine } = setupEngine([
+      makeStep({ id: "step-1", prompt: "Do the first thing" }),
+      makeStep({ id: "step-2", dependsOn: ["step-1"] }),
+    ], "my-workflow");
+
+    let state = await engine.deriveState("/unused");
+    const firstDispatch = await engine.resolveDispatch(state, { basePath: "/unused" });
+    assert.equal(firstDispatch.action, "dispatch");
+    if (firstDispatch.action === "dispatch") {
+      assert.equal(firstDispatch.step.unitId, "my-workflow/step-1");
+    }
+
+    state = await engine.deriveState("/unused");
+    const secondDispatch = await engine.resolveDispatch(state, { basePath: "/unused" });
+    assert.equal(secondDispatch.action, "dispatch");
+    if (secondDispatch.action === "dispatch") {
+      assert.equal(secondDispatch.step.unitId, "my-workflow/step-1");
+      assert.equal(secondDispatch.step.prompt, "Do the first thing");
+    }
+  });
+
   it("returns stop when all steps are complete", async () => {
     const { engine } = setupEngine([
       makeStep({ id: "a", status: "complete" }),


### PR DESCRIPTION
## Linked issue

Closes #4132

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** This persists the selected custom workflow step as `active` in `GRAPH.yaml` before dispatch returns.
**Why:** The dispatcher could return a step without first recording that state on disk, which let later reconcile/dispatch logic observe stale graph state.
**How:** The engine now locks and reloads `GRAPH.yaml`, marks the chosen step active before returning it, and adds a regression test that proves the on-disk state is updated first.

## What

This updates the custom workflow engine to persist dispatch state in `GRAPH.yaml` before returning the next `custom-step` unit. It adds a small graph helper for marking a step active and regression coverage around both dispatch persistence and later reconcile behavior.

## Why

Issue #4132 reports that custom workflow dispatch could hand back a pending step without first persisting that it was active. That makes the on-disk graph lag behind the real dispatcher state and can confuse later reconciliation.

## How

`resolveDispatch()` now runs under the graph file lock, reloads the current graph, expands iterate steps if needed, marks the chosen step active, writes the updated graph, and only then returns the dispatch payload. The new tests prove the active state is visible on disk before dispatch returns and that reconcile still completes the persisted active step cleanly.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [ ] Manual testing — steps described above
- [ ] No tests needed — explained above

Automated verification:
1. `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/custom-workflow-engine.test.ts`
2. `npm run typecheck:extensions`
3. `npm run build`

## AI disclosure

- [x] This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.
