### PR TITLE
fix(gsd): fail closed on finalize timeouts

### DIFF
--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -216,6 +216,62 @@ async function emitCancelledUnitEnd(
   });
 }
 
+async function failClosedOnFinalizeTimeout(
+  ic: IterationContext,
+  iterData: IterationData,
+  loopState: LoopState,
+  stage: "pre" | "post",
+  startedAt: number,
+): Promise<PhaseResult> {
+  const { ctx, pi, s, deps } = ic;
+  const now = Date.now();
+  const unitType = iterData.unitType;
+  const unitId = iterData.unitId;
+  const timeoutMs = stage === "pre" ? FINALIZE_PRE_TIMEOUT_MS : FINALIZE_POST_TIMEOUT_MS;
+  const progressKind = stage === "pre" ? "finalize-pre-timeout" : "finalize-post-timeout";
+
+  writeUnitRuntimeRecord(s.basePath, unitType, unitId, startedAt, {
+    phase: "finalize-timeout",
+    timeoutAt: now,
+    lastProgressAt: now,
+    lastProgressKind: progressKind,
+  });
+
+  deps.emitJournalEvent({
+    ts: new Date(now).toISOString(),
+    flowId: ic.flowId,
+    seq: ic.nextSeq(),
+    eventType: "unit-end",
+    data: {
+      unitType,
+      unitId,
+      status: "timed-out-finalize",
+      artifactVerified: false,
+      finalizeStage: stage,
+    },
+  });
+
+  loopState.consecutiveFinalizeTimeouts++;
+  debugLog("autoLoop", {
+    phase: progressKind,
+    iteration: ic.iteration,
+    unitType,
+    unitId,
+    consecutiveTimeouts: loopState.consecutiveFinalizeTimeouts,
+  });
+
+  ctx.ui.notify(
+    `${stage === "pre" ? "postUnitPreVerification" : "postUnitPostVerification"} timed out after ${timeoutMs / 1000}s for ${unitType} ${unitId} (${loopState.consecutiveFinalizeTimeouts}/${MAX_FINALIZE_TIMEOUTS}) — pausing auto-mode for recovery.`,
+    "warning",
+  );
+
+  await deps.pauseAuto(ctx, pi);
+  s.currentUnit = null;
+  clearCurrentPhase();
+  drainLogs();
+  return { action: "break", reason: progressKind };
+}
+
 // ─── runPreDispatch ───────────────────────────────────────────────────────────
 
 /**
@@ -433,8 +489,9 @@ export async function runPreDispatch(
             return { action: "break", reason: "slice-parallel-dispatched" };
           }
           // Fall through to sequential if no workers started
-        }
-      }
+  }
+}
+
     } catch (err) {
       debugLog("autoLoop", {
         phase: "slice-parallel-check-error",
@@ -1771,36 +1828,13 @@ export async function runFinalize(
   );
 
   if (preResultGuard.timedOut) {
-    // Detach session from the timed-out unit so late async completions
-    // cannot mutate state for the next unit (#3757).
-    s.currentUnit = null;
-    clearCurrentPhase();
-    // Drop any logger entries from the timed-out unit so they don't bleed
-    // into the next iteration's drain.
-    drainLogs();
-    loopState.consecutiveFinalizeTimeouts++;
-    debugLog("autoLoop", {
-      phase: "pre-verification-timeout",
-      iteration: ic.iteration,
-      unitType: iterData.unitType,
-      unitId: iterData.unitId,
-      consecutiveTimeouts: loopState.consecutiveFinalizeTimeouts,
-    });
-
-    if (loopState.consecutiveFinalizeTimeouts >= MAX_FINALIZE_TIMEOUTS) {
-      ctx.ui.notify(
-        `postUnitPreVerification timed out ${loopState.consecutiveFinalizeTimeouts} consecutive times — stopping auto-mode to prevent budget waste`,
-        "error",
-      );
-      await deps.stopAuto(ctx, pi, `${loopState.consecutiveFinalizeTimeouts} consecutive finalize timeouts`);
-      return { action: "break", reason: "finalize-timeout-escalation" };
-    }
-
-    ctx.ui.notify(
-      `postUnitPreVerification timed out after ${FINALIZE_PRE_TIMEOUT_MS / 1000}s for ${iterData.unitType} ${iterData.unitId} (${loopState.consecutiveFinalizeTimeouts}/${MAX_FINALIZE_TIMEOUTS}) — continuing to next iteration`,
-      "warning",
+    return failClosedOnFinalizeTimeout(
+      ic,
+      iterData,
+      loopState,
+      "pre",
+      preUnitSnapshot?.startedAt ?? Date.now(),
     );
-    return { action: "next", data: undefined as void };
   }
 
   const preResult = preResultGuard.value;
@@ -1876,36 +1910,13 @@ export async function runFinalize(
   );
 
   if (postResultGuard.timedOut) {
-    // Detach session from the timed-out unit so late async completions
-    // cannot mutate state for the next unit (#3757).
-    s.currentUnit = null;
-    clearCurrentPhase();
-    // Drop any logger entries from the timed-out unit so they don't bleed
-    // into the next iteration's drain.
-    drainLogs();
-    loopState.consecutiveFinalizeTimeouts++;
-    debugLog("autoLoop", {
-      phase: "post-verification-timeout",
-      iteration: ic.iteration,
-      unitType: iterData.unitType,
-      unitId: iterData.unitId,
-      consecutiveTimeouts: loopState.consecutiveFinalizeTimeouts,
-    });
-
-    if (loopState.consecutiveFinalizeTimeouts >= MAX_FINALIZE_TIMEOUTS) {
-      ctx.ui.notify(
-        `postUnitPostVerification timed out ${loopState.consecutiveFinalizeTimeouts} consecutive times — stopping auto-mode to prevent budget waste`,
-        "error",
-      );
-      await deps.stopAuto(ctx, pi, `${loopState.consecutiveFinalizeTimeouts} consecutive finalize timeouts`);
-      return { action: "break", reason: "finalize-timeout-escalation" };
-    }
-
-    ctx.ui.notify(
-      `postUnitPostVerification timed out after ${FINALIZE_POST_TIMEOUT_MS / 1000}s for ${iterData.unitType} ${iterData.unitId} (${loopState.consecutiveFinalizeTimeouts}/${MAX_FINALIZE_TIMEOUTS}) — continuing to next iteration`,
-      "warning",
+    return failClosedOnFinalizeTimeout(
+      ic,
+      iterData,
+      loopState,
+      "post",
+      preUnitSnapshot?.startedAt ?? Date.now(),
     );
-    return { action: "next", data: undefined as void };
   }
 
   const postResult = postResultGuard.value;

--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -489,9 +489,8 @@ export async function runPreDispatch(
             return { action: "break", reason: "slice-parallel-dispatched" };
           }
           // Fall through to sequential if no workers started
-  }
-}
-
+        }
+      }
     } catch (err) {
       debugLog("autoLoop", {
         phase: "slice-parallel-check-error",

--- a/src/resources/extensions/gsd/tests/finalize-timeout-guard.test.ts
+++ b/src/resources/extensions/gsd/tests/finalize-timeout-guard.test.ts
@@ -213,25 +213,42 @@ function getRunFinalizeBody(phasesSource: string): string {
 
   const fnBody = getRunFinalizeBody(phasesSource);
 
-  // Both timeout handlers should increment consecutiveFinalizeTimeouts
-  const incrementCount = (fnBody.match(/consecutiveFinalizeTimeouts\+\+/g) || []).length;
+  const helperCallCount = (fnBody.match(/failClosedOnFinalizeTimeout\(/g) || []).length;
   assertTrue(
-    incrementCount >= 2,
-    `should increment consecutiveFinalizeTimeouts in both pre and post handlers (found ${incrementCount})`,
+    helperCallCount >= 2,
+    `runFinalize should route both timeout branches through failClosedOnFinalizeTimeout (found ${helperCallCount})`,
   );
 
-  // Both timeout handlers should check MAX_FINALIZE_TIMEOUTS for escalation
-  const escalationCount = (fnBody.match(/MAX_FINALIZE_TIMEOUTS/g) || []).length;
+  const helperStart = phasesSource.indexOf("async function failClosedOnFinalizeTimeout");
+  assertTrue(helperStart > 0, "failClosedOnFinalizeTimeout helper should exist");
+  const helperEnd = phasesSource.indexOf("// ─── runPreDispatch", helperStart);
+  const helperBody = phasesSource.slice(helperStart, helperEnd > helperStart ? helperEnd : undefined);
+
+  const incrementCount = (helperBody.match(/consecutiveFinalizeTimeouts\+\+/g) || []).length;
   assertTrue(
-    escalationCount >= 2,
-    `should check MAX_FINALIZE_TIMEOUTS in both handlers (found ${escalationCount})`,
+    incrementCount >= 1,
+    `timeout helper should increment consecutiveFinalizeTimeouts (found ${incrementCount})`,
   );
 
-  // Both timeout handlers should null out s.currentUnit to prevent late mutations
-  const detachCount = (fnBody.match(/s\.currentUnit\s*=\s*null/g) || []).length;
+  const detachCount = (helperBody.match(/s\.currentUnit\s*=\s*null/g) || []).length;
   assertTrue(
-    detachCount >= 2,
-    `should detach s.currentUnit in both timeout handlers (found ${detachCount})`,
+    detachCount >= 1,
+    `timeout helper should detach s.currentUnit (found ${detachCount})`,
+  );
+
+  const pauseCount = (helperBody.match(/pauseAuto\(/g) || []).length;
+  assertTrue(
+    pauseCount >= 1,
+    `timeout helper should pause auto-mode (found ${pauseCount})`,
+  );
+
+  assertTrue(
+    helperBody.includes('eventType: "unit-end"'),
+    "timeout helper should emit a terminal unit-end event",
+  );
+  assertTrue(
+    helperBody.includes('phase: "finalize-timeout"'),
+    "timeout helper should persist finalize-timeout runtime state",
   );
 
   // Successful finalize should reset the counter

--- a/src/resources/extensions/gsd/tests/journal-integration.test.ts
+++ b/src/resources/extensions/gsd/tests/journal-integration.test.ts
@@ -11,12 +11,15 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { randomUUID } from "node:crypto";
 import { join } from "node:path";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
 
 import type { JournalEntry } from "../journal.js";
 import type { LoopDeps } from "../auto/loop-deps.js";
 import type { IterationContext, LoopState, PreDispatchData, IterationData } from "../auto/types.js";
 import type { SessionLockStatus } from "../session-lock.js";
-import { runDispatch, runUnitPhase, runPreDispatch } from "../auto/phases.js";
+import { runDispatch, runUnitPhase, runPreDispatch, runFinalize } from "../auto/phases.js";
+import { readUnitRuntimeRecord } from "../unit-runtime.js";
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -666,4 +669,66 @@ test("session-failed cancellations close out and emit unit-end before hard stop"
   assert.equal((endEvents[0].data as any).status, "cancelled");
   assert.equal((endEvents[0].data as any).artifactVerified, false);
   assert.equal((endEvents[0].data as any).errorContext.category, "session-failed");
+});
+
+test("runFinalize pauses and emits unit-end when pre-verification times out", async () => {
+  const capture = createEventCapture();
+  let pauseCalls = 0;
+  const basePath = mkdtempSync(join(tmpdir(), "gsd-finalize-timeout-"));
+
+  const deps = makeMockDeps(capture, {
+    pauseAuto: async () => { pauseCalls++; },
+    postUnitPreVerification: async () => {
+      await new Promise(() => {});
+      return "continue" as const;
+    },
+  });
+
+  const ic = makeIC(deps, {
+    s: {
+      ...makeSession(),
+      basePath,
+      currentUnit: { type: "execute-task", id: "M001/S01/T01", startedAt: 1234 },
+    } as any,
+  });
+  const iterData: IterationData = {
+    unitType: "execute-task",
+    unitId: "M001/S01/T01",
+    prompt: "do stuff",
+    finalPrompt: "do stuff",
+    pauseAfterUatDispatch: false,
+    state: { phase: "executing", activeMilestone: { id: "M001" }, activeSlice: { id: "S01" }, registry: [], blockers: [] } as any,
+    mid: "M001",
+    midTitle: "Test",
+    isRetry: false,
+    previousTier: undefined,
+  };
+  const loopState: LoopState = { recentUnits: [], stuckRecoveryAttempts: 0, consecutiveFinalizeTimeouts: 0 };
+
+  const originalSetTimeout = globalThis.setTimeout;
+  try {
+    globalThis.setTimeout = ((handler: (...args: any[]) => void, _timeout?: number, ...args: any[]) =>
+      originalSetTimeout(handler, 0, ...args)) as typeof setTimeout;
+
+    const result = await runFinalize(ic, iterData, loopState);
+    assert.equal(result.action, "break");
+    assert.equal((result as any).reason, "finalize-pre-timeout");
+  } finally {
+    globalThis.setTimeout = originalSetTimeout;
+  }
+
+  assert.equal(pauseCalls, 1, "pre-verification timeout should pause auto-mode");
+  assert.equal(loopState.consecutiveFinalizeTimeouts, 1, "timeout should increment finalize timeout counter");
+  assert.equal(ic.s.currentUnit, null, "timed-out finalize should detach currentUnit");
+
+  const runtime = readUnitRuntimeRecord(basePath, "execute-task", "M001/S01/T01");
+  assert.ok(runtime, "timed-out finalize should persist a runtime record");
+  assert.equal(runtime?.phase, "finalize-timeout");
+  assert.equal(runtime?.lastProgressKind, "finalize-pre-timeout");
+
+  const endEvents = capture.events.filter((e) => e.eventType === "unit-end");
+  assert.equal(endEvents.length, 1, "timed-out finalize should emit terminal unit-end");
+  assert.equal((endEvents[0].data as any).status, "timed-out-finalize");
+  assert.equal((endEvents[0].data as any).artifactVerified, false);
+  assert.equal((endEvents[0].data as any).finalizeStage, "pre");
 });

--- a/src/resources/extensions/gsd/tests/workflow-logger-wiring.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-logger-wiring.test.ts
@@ -88,15 +88,24 @@ test("runFinalize drains and surfaces logger buffer via ctx.ui.notify", () => {
 });
 
 test("runFinalize timeout branches drain the buffer to prevent bleed", () => {
-  // Both timeout branches null out s.currentUnit — they should also drain
-  // so accumulated logs for the timed-out unit don't leak into the next.
+  // Both timeout branches route through failClosedOnFinalizeTimeout; that
+  // helper must drain the buffer so timed-out unit logs do not bleed into
+  // the next unit.
   const runFinalizeIdx = phasesSrc.indexOf("export async function runFinalize");
   const finalizeBody = phasesSrc.slice(runFinalizeIdx);
-  const drainCallCount =
-    (finalizeBody.match(/drainLogs\(\)/g) ?? []).length;
+  const timeoutHelperCalls =
+    (finalizeBody.match(/failClosedOnFinalizeTimeout\(/g) ?? []).length;
   assert.ok(
-    drainCallCount >= 2,
-    `runFinalize timeout branches should each call drainLogs() (found ${drainCallCount}, expected >= 2)`,
+    timeoutHelperCalls >= 2,
+    `runFinalize timeout branches should each route through failClosedOnFinalizeTimeout() (found ${timeoutHelperCalls}, expected >= 2)`,
+  );
+
+  const helperMatch = phasesSrc.match(
+    /async function failClosedOnFinalizeTimeout[\s\S]*?drainLogs\(\)/,
+  );
+  assert.ok(
+    helperMatch,
+    "failClosedOnFinalizeTimeout should drain the logger buffer before returning",
   );
 });
 

--- a/src/resources/extensions/gsd/unit-runtime.ts
+++ b/src/resources/extensions/gsd/unit-runtime.ts
@@ -14,6 +14,7 @@ export type UnitRuntimePhase =
   | "dispatched"
   | "wrapup-warning-sent"
   | "timeout"
+  | "finalize-timeout"
   | "recovered"
   | "finalized"
   | "paused"


### PR DESCRIPTION
## Linked issue

Closes #4267

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** This makes finalize timeouts fail closed instead of silently continuing the auto loop.
**Why:** When finalize hung, the unit lifecycle could be lost and auto-mode could keep moving without a terminal `unit-end` or durable timeout state.
**How:** Both pre- and post-finalize timeout branches now share one helper that records a `finalize-timeout`, emits `unit-end`, detaches the unit, and pauses auto-mode for recovery.

## What

This changes the GSD auto loop timeout handling around finalize so both timeout branches produce the same fail-closed outcome. It also extends runtime metadata with a `finalize-timeout` phase and adds regression coverage for both the structural guard and the observed journal/runtime behavior.

## Why

Issue #4267 reports that finalize timeouts could lose the unit lifecycle and let the loop continue in a half-closed state. That weakens recovery and makes the journal/runtime trail incomplete.

## How

A shared `failClosedOnFinalizeTimeout()` helper now writes the timeout runtime record, emits a terminal `unit-end` with `timed-out-finalize`, increments the timeout counter, pauses auto-mode, detaches the current unit, and returns a break reason. Tests cover both the timeout-guard structure and the concrete pre-verification timeout path.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [ ] Manual testing — steps described above
- [ ] No tests needed — explained above

Automated verification:
1. `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/finalize-timeout-guard.test.ts src/resources/extensions/gsd/tests/journal-integration.test.ts`
2. `npm run typecheck:extensions`
3. `npm run build`

## AI disclosure

- [x] This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.
