### PR TITLE
fix(gsd): repair execute-task plan recovery checkboxes

### DIFF
--- a/src/resources/extensions/gsd/auto-recovery.ts
+++ b/src/resources/extensions/gsd/auto-recovery.ts
@@ -462,7 +462,22 @@ export function writeBlockerPlaceholder(
     const { milestone: mid, slice: sid, task: tid } = parseUnitId(unitId);
     const ts = new Date().toISOString();
     if (unitType === "execute-task" && mid && sid && tid) {
-      try { updateTaskStatus(mid, sid, tid, "complete", ts); } catch (e) { logWarning("recovery", `updateTaskStatus failed during context exhaustion: ${e instanceof Error ? e.message : String(e)}`); }
+      try {
+        updateTaskStatus(mid, sid, tid, "complete", ts);
+        const planPath = resolveSliceFile(base, mid, sid, "PLAN");
+        if (planPath && existsSync(planPath)) {
+          const planContent = readFileSync(planPath, "utf-8");
+          const updatedPlan = planContent.replace(
+            new RegExp(`^(\\s*-\\s+)\\[ \\]\\s+\\*\\*${tid}:`, "m"),
+            `$1[x] **${tid}:`,
+          );
+          if (updatedPlan !== planContent) {
+            atomicWriteSync(planPath, updatedPlan);
+          }
+        }
+      } catch (e) {
+        logWarning("recovery", `updateTaskStatus failed during context exhaustion: ${e instanceof Error ? e.message : String(e)}`);
+      }
       // Append event so worktree reconciliation can replay this recovery completion
       try { appendEvent(base, { cmd: "complete-task", params: { milestoneId: mid, sliceId: sid, taskId: tid }, ts, actor: "system", trigger_reason: "blocker-placeholder-recovery" }); } catch (e) { logWarning("recovery", `appendEvent failed for task recovery: ${e instanceof Error ? e.message : String(e)}`); }
     }

--- a/src/resources/extensions/gsd/tests/integration/idle-recovery.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/idle-recovery.test.ts
@@ -358,6 +358,57 @@ test('writeBlockerPlaceholder: does NOT update DB for non-execute-task types', a
   }
 });
 
+test('writeBlockerPlaceholder: updates execute-task plan checkbox after DB recovery (#4126)', async () => {
+  const base = createFixtureBase();
+  try {
+    const {
+      openDatabase,
+      closeDatabase,
+      insertMilestone,
+      insertSlice,
+      insertTask,
+      getTask,
+      isDbAvailable,
+    } = await import("../../gsd-db.ts");
+
+    const dbPath = join(base, ".gsd", "gsd.db");
+    const sliceDir = join(base, ".gsd", "milestones", "M001", "slices", "S01");
+    const tasksDir = join(sliceDir, "tasks");
+
+    mkdirSync(tasksDir, { recursive: true });
+    writeFileSync(join(sliceDir, "S01-PLAN.md"), [
+      "# S01: Test Slice",
+      "",
+      "## Tasks",
+      "",
+      "- [ ] **T01: Recoverable task** `est:5m`",
+    ].join("\n"));
+
+    openDatabase(dbPath);
+    try {
+      insertMilestone({ id: "M001", title: "Test", status: "active" });
+      insertSlice({ id: "S01", milestoneId: "M001", title: "Slice", status: "active" });
+      insertTask({ id: "T01", sliceId: "S01", milestoneId: "M001", title: "Recoverable task", status: "pending" });
+
+      writeBlockerPlaceholder("execute-task", "M001/S01/T01", base, "context exhaustion recovery");
+
+      const task = getTask("M001", "S01", "T01");
+      assert.equal(task?.status, "complete", "execute-task recovery should still mark the DB task complete");
+
+      const planContent = readFileSync(join(sliceDir, "S01-PLAN.md"), "utf-8");
+      assert.match(
+        planContent,
+        /\- \[x\] \*\*T01: Recoverable task\*\*/,
+        "execute-task recovery should re-render the slice plan checkbox after marking the DB row complete",
+      );
+    } finally {
+      if (isDbAvailable()) closeDatabase();
+    }
+  } finally {
+    cleanup(base);
+  }
+});
+
 test('writeBlockerPlaceholder: updates DB slice status for complete-slice (#2653)', async () => {
   const base = createFixtureBase();
   try {


### PR DESCRIPTION
## Linked issue

Closes #4126

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** This updates execute-task blocker recovery to re-check the matching task checkbox in the slice plan.
**Why:** Recovery could mark the DB row complete while leaving the existing `PLAN.md` checkbox unchecked.
**How:** After the DB recovery write succeeds, the recovery path now rewrites the matching task checkbox in the slice plan and adds an integration regression test for the before/after behavior.

## What

This keeps execute-task blocker recovery in sync across the DB and the slice plan file. The recovery path now repairs the matching task checkbox in `PLAN.md`, and the integration suite gets a regression that proves both the DB status and plan file are updated together.

## Why

Issue #4126 reports that recovery runs could complete the DB task without updating the visible slice plan checkbox. That leaves stale task state on disk even though the system thinks the task recovered cleanly.

## How

`writeBlockerPlaceholder()` still updates the DB row first, then resolves the slice plan file and rewrites only the matching unchecked checkbox for that task when the file exists. The new integration test builds the recovery case end-to-end and asserts both the DB row and the plan file are corrected.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [ ] Manual testing — steps described above
- [ ] No tests needed — explained above

Automated verification:
1. `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/integration/idle-recovery.test.ts`
2. `npm run typecheck:extensions`
3. `npm run build`

## AI disclosure

- [x] This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.
