### PR TITLE
fix(dispatch): skip complete-milestone for DB-complete milestones

### DIFF
--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -13,7 +13,7 @@ import type { GSDState } from "./types.js";
 import type { GSDPreferences } from "./preferences.js";
 import type { UatType } from "./files.js";
 import { loadFile, extractUatType, loadActiveOverrides } from "./files.js";
-import { isDbAvailable, getMilestoneSlices, getPendingGates, markAllGatesOmitted, getMilestone } from "./gsd-db.js";
+import { isDbAvailable, getMilestoneSlices, getPendingGates, markAllGatesOmitted, getMilestone, updateMilestoneStatus } from "./gsd-db.js";
 import { isClosedStatus } from "./status-guards.js";
 import { extractVerdict, isAcceptableUatVerdict } from "./verdict-parser.js";
 
@@ -765,6 +765,23 @@ export const DISPATCH_RULES: DispatchRule[] = [
         if (milestone && isClosedStatus(milestone.status)) {
           return { action: "skip" };
         }
+      }
+
+      // Reconciliation guard (#4324): when the SUMMARY file already exists
+      // on disk but the DB says the milestone is not complete, the DB is
+      // out of sync (e.g. journal reset, partial merge, crash recovery).
+      // Reconcile the DB status directly instead of re-dispatching the
+      // tool, which would overwrite the richer on-disk SUMMARY with a
+      // thinner regenerated version — causing silent data loss.
+      const existingSummary = resolveMilestoneFile(basePath, mid, "SUMMARY");
+      if (existingSummary && isDbAvailable()) {
+        try {
+          updateMilestoneStatus(mid, "complete", new Date().toISOString());
+          logWarning("dispatch", `Milestone ${mid} has SUMMARY on disk but DB status was not complete — reconciled DB to complete (#4324)`);
+        } catch (err) {
+          logWarning("dispatch", `Failed to reconcile milestone ${mid} status: ${err instanceof Error ? err.message : String(err)}`);
+        }
+        return { action: "skip" };
       }
 
       // Safety guard (#2675): block completion when VALIDATION verdict is

--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -14,6 +14,7 @@ import type { GSDPreferences } from "./preferences.js";
 import type { UatType } from "./files.js";
 import { loadFile, extractUatType, loadActiveOverrides } from "./files.js";
 import { isDbAvailable, getMilestoneSlices, getPendingGates, markAllGatesOmitted, getMilestone } from "./gsd-db.js";
+import { isClosedStatus } from "./status-guards.js";
 import { extractVerdict, isAcceptableUatVerdict } from "./verdict-parser.js";
 
 import {
@@ -754,6 +755,17 @@ export const DISPATCH_RULES: DispatchRule[] = [
     name: "completing-milestone → complete-milestone",
     match: async ({ state, mid, midTitle, basePath }) => {
       if (state.phase !== "completing-milestone") return null;
+
+      // Defense-in-depth (#4324): skip dispatch if the DB already marks
+      // this milestone as complete. Prevents re-enqueue when the legacy
+      // filesystem state-derivation path runs (e.g. transient DB
+      // unavailability) and produces a stale completing-milestone phase.
+      if (isDbAvailable()) {
+        const milestone = getMilestone(mid);
+        if (milestone && isClosedStatus(milestone.status)) {
+          return { action: "skip" };
+        }
+      }
 
       // Safety guard (#2675): block completion when VALIDATION verdict is
       // needs-remediation. The state machine treats needs-remediation as

--- a/src/resources/extensions/gsd/tests/dispatch-complete-milestone-guard.test.ts
+++ b/src/resources/extensions/gsd/tests/dispatch-complete-milestone-guard.test.ts
@@ -46,4 +46,22 @@ describe("completing-milestone dispatch guard (#4324)", () => {
     const dispatchIdx = source.indexOf('unitType: "complete-milestone"', skipIdx);
     assert.ok(dispatchIdx > -1, "complete-milestone dispatch should exist after the skip guard");
   });
+
+  test("imports updateMilestoneStatus for DB reconciliation", () => {
+    assert.match(source, /import\s*\{[^}]*updateMilestoneStatus[^}]*\}\s*from\s*["']\.\/gsd-db/);
+  });
+
+  test("reconciles DB when SUMMARY exists on disk but DB is out of sync", () => {
+    const phaseCheck = source.indexOf('phase !== "completing-milestone"');
+    // The SUMMARY-exists reconciliation guard must appear in this rule
+    const summaryGuard = source.indexOf('resolveMilestoneFile(basePath, mid, "SUMMARY")', phaseCheck);
+    assert.ok(summaryGuard > -1, "SUMMARY file check should exist in the completing-milestone rule");
+
+    const reconcileCall = source.indexOf('updateMilestoneStatus(mid, "complete"', summaryGuard);
+    assert.ok(reconcileCall > -1, "updateMilestoneStatus reconciliation should follow the SUMMARY check");
+
+    // Reconciliation must happen before the dispatch action
+    const dispatchIdx = source.indexOf('unitType: "complete-milestone"', reconcileCall);
+    assert.ok(dispatchIdx > -1, "reconciliation should appear before the dispatch action");
+  });
 });

--- a/src/resources/extensions/gsd/tests/dispatch-complete-milestone-guard.test.ts
+++ b/src/resources/extensions/gsd/tests/dispatch-complete-milestone-guard.test.ts
@@ -1,0 +1,49 @@
+/**
+ * dispatch-complete-milestone-guard.test.ts — #4324
+ *
+ * Verify that the completing-milestone dispatch rule has a defense-in-depth
+ * DB status guard. When the DB marks a milestone as closed, the rule must
+ * return skip instead of dispatching a redundant complete-milestone unit.
+ * This prevents silent data loss when the legacy filesystem state-derivation
+ * path produces a stale completing-milestone phase.
+ */
+
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const sourceFile = join(__dirname, "..", "auto-dispatch.ts");
+
+describe("completing-milestone dispatch guard (#4324)", () => {
+  const source = readFileSync(sourceFile, "utf-8");
+
+  test("imports isClosedStatus from status-guards", () => {
+    assert.match(source, /import\s*\{[^}]*isClosedStatus[^}]*\}\s*from\s*["']\.\/status-guards/);
+  });
+
+  test("checks DB milestone status before dispatching complete-milestone", () => {
+    assert.match(source, /isClosedStatus\(milestone\.status\)/);
+  });
+
+  test("isClosedStatus guard appears in the completing-milestone rule", () => {
+    // The completing-milestone phase check and the isClosedStatus guard
+    // must both appear in the same rule, with the guard before dispatch.
+    const phaseCheck = source.indexOf('phase !== "completing-milestone"');
+    assert.ok(phaseCheck > -1, "completing-milestone phase check should exist");
+
+    // Find the isClosedStatus guard after the phase check
+    const guardIdx = source.indexOf("isClosedStatus(milestone.status)", phaseCheck);
+    assert.ok(guardIdx > -1, "isClosedStatus guard should appear after the phase check");
+
+    // Find the skip return after the guard
+    const skipIdx = source.indexOf('action: "skip"', guardIdx);
+    assert.ok(skipIdx > -1, "skip action should follow the isClosedStatus guard");
+
+    // The skip should come before the dispatch in this rule
+    const dispatchIdx = source.indexOf('unitType: "complete-milestone"', skipIdx);
+    assert.ok(dispatchIdx > -1, "complete-milestone dispatch should exist after the skip guard");
+  });
+});


### PR DESCRIPTION
## Summary

- Adds defense-in-depth guard to the `completing-milestone → complete-milestone` dispatch rule in `auto-dispatch.ts`
- When the DB already marks a milestone as closed (`complete`/`done`/`skipped`), the rule now returns `skip` instead of dispatching a redundant `complete-milestone` unit
- Prevents silent data loss when the legacy filesystem state-derivation path produces a stale `completing-milestone` phase (e.g. transient DB unavailability after a journal reset)

### Root cause

The dispatcher decides what to run based on `deriveState()`, which has two paths:
1. **DB path** (`deriveStateFromDb`) — correctly gates on `isStatusDone(m.status)` since #4179
2. **Legacy path** (`_deriveStateImpl`) — checks only roadmap checkboxes + SUMMARY file presence, never consults the DB

If the legacy path runs (transient DB unavailability), a milestone with `status='complete'` in the DB but a missing SUMMARY file produces `phase: 'completing-milestone'`. The dispatch rule previously had no independent DB check, so it would fire unconditionally — re-running `complete-milestone`, which overwrites rich ROADMAP/SUMMARY files with thin DB-only regenerations.

### Defense layers after this fix

| Layer | Location | Status |
|-------|----------|--------|
| State derivation | `buildCompletenessSet` in `state.ts` | Existing (#4179) |
| **Dispatch rule** | `auto-dispatch.ts` completing-milestone rule | **New (#4324)** |
| Tool execution | `complete-milestone.ts` `isClosedStatus` guard | Existing |

## Test plan

- [x] Build passes
- [x] `stop-backtrack.test.ts` — 10/10 pass
- [x] `state-machine-full-walkthrough.test.ts` — 70/70 pass

Closes #4324