### PR TITLE
fix(gsd): detect repeated units across the stuck window

### DIFF
--- a/src/resources/extensions/gsd/auto/detect-stuck.ts
+++ b/src/resources/extensions/gsd/auto/detect-stuck.ts
@@ -20,6 +20,7 @@ const ENOENT_PATH_RE = /ENOENT[^']*'([^']+)'/;
  *
  * Rule 1: Same error string twice in a row → stuck immediately.
  * Rule 2: Same unit key 3+ consecutive times → stuck (preserves prior behavior).
+ * Rule 2b: Same unit key appears 3+ times anywhere in the active window → stuck.
  * Rule 3: Oscillation A→B→A→B in last 4 entries → stuck.
  * Rule 4: Same ENOENT path in any 2 entries within the window → stuck (#3575).
  *         Missing files don't self-heal between retries — retrying wastes budget.
@@ -56,6 +57,15 @@ export function detectStuck(
         reason: `${last.key} derived 3 consecutive times without progress${suffix}`,
       };
     }
+  }
+
+  // Rule 2b: Same unit key 3+ times anywhere in the active window
+  const countInWindow = window.filter((entry) => entry.key === last.key).length;
+  if (countInWindow >= 3) {
+    return {
+      stuck: true,
+      reason: `${last.key} derived ${countInWindow} times in last ${window.length} attempts without progress${suffix}`,
+    };
   }
 
   // Rule 3: Oscillation (A→B→A→B in last 4)

--- a/src/resources/extensions/gsd/tests/stuck-detection-coverage.test.ts
+++ b/src/resources/extensions/gsd/tests/stuck-detection-coverage.test.ts
@@ -79,6 +79,21 @@ test("Rule 2: interrupted sequence does not trigger", () => {
   );
 });
 
+test("Rule 2b: same unit repeated 3 times in the window triggers stuck even with an intervening unit", () => {
+  const result = detectStuck([
+    { key: "execute-task/M002/S03/T01" },
+    { key: "execute-task/M002/S03/T01" },
+    { key: "reassess-roadmap/M002/S02" },
+    { key: "execute-task/M002/S03/T01" },
+  ]);
+  assert.notEqual(result, null);
+  assert.equal(result!.stuck, true);
+  assert.ok(
+    result!.reason.includes("3 times in last 4 attempts"),
+    `reason was: ${result!.reason}`,
+  );
+});
+
 // ─── Rule 3: Oscillation A→B→A→B ─────────────────────────────────────────────
 
 test("Rule 3: A-B-A-B oscillation triggers stuck", () => {


### PR DESCRIPTION
## Linked issue

Closes #4220

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Detect repeated unit keys across the recent stuck window, not just consecutive repeats.
**Why:** A unit can still be stuck in an A-A-B-A style loop even when the repeats are interrupted.
**How:** Add a new window-based stuck rule in `detectStuck()` and cover it with a regression test.

## What

This updates `detectStuck()` so it can flag a unit as stuck when the same unit key appears three or more times anywhere inside the active recent-unit window. The change keeps the existing consecutive-repeat rule intact and adds a focused regression test that covers an interrupted repeat pattern.

## Why

Current stuck detection only fires when the same unit repeats three times consecutively. That misses short loops where the same unit keeps coming back with no real progress, which still burns retries and wall time.

## How

The implementation counts how many times the latest unit key appears in the active window and treats three-or-more occurrences as stuck. The new test proves that an intervening different unit no longer hides that loop.

## Change type

- [x] `fix` — Bug fix
- [x] `test` — Adding or updating tests

## Scope

- [x] `gsd extension` — GSD workflow

## Breaking changes

- [x] No breaking changes

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [ ] Manual testing — steps described above
- [ ] No tests needed — explained above

Automated verification:
1. `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/stuck-detection-coverage.test.ts`
2. `npm run typecheck:extensions`
3. `npm run build` in a plain verification clone at the exact branch head

## AI disclosure

- [x] This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.
