### PR TITLE
fix(gsd): pause on complete-milestone disk/db mismatch

### DIFF
--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -848,6 +848,17 @@ export async function runDispatch(
           s.basePath,
         );
         if (artifactExists) {
+          if (unitType === "complete-milestone") {
+            const stuckDiag = diagnoseExpectedArtifact(unitType, unitId, s.basePath);
+            const stuckParts = [
+              `Detected ${unitType} ${unitId} output on disk, but the same unit is still being derived.`,
+              "This usually means the milestone summary exists while the DB row still does not mark the milestone complete.",
+            ];
+            if (stuckDiag) stuckParts.push(`Expected: ${stuckDiag}`);
+            ctx.ui.notify(stuckParts.join(" "), "warning");
+            await deps.pauseAuto(ctx, pi);
+            return { action: "break", reason: "complete-milestone-artifact-db-mismatch" };
+          }
           debugLog("autoLoop", {
             phase: "stuck-recovery",
             level: 1,

--- a/src/resources/extensions/gsd/tests/journal-integration.test.ts
+++ b/src/resources/extensions/gsd/tests/journal-integration.test.ts
@@ -10,6 +10,9 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { randomUUID } from "node:crypto";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import type { JournalEntry } from "../journal.js";
@@ -315,6 +318,75 @@ test("runDispatch checks prior-slice completion against the project root in work
       args: ["/tmp/project", "main", "execute-task", "M001/S01/T01"],
     },
   ]);
+});
+
+test("runDispatch pauses when complete-milestone summary exists on disk but the unit is still stuck (#4289)", async (t) => {
+  const capture = createEventCapture();
+  let pauseCalls = 0;
+  let stopCalls = 0;
+  const base = join(tmpdir(), `gsd-stuck-complete-${randomUUID()}`);
+  t.after(() => {
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  mkdirSync(join(base, ".gsd", "milestones", "M001"), { recursive: true });
+  mkdirSync(join(base, "src"), { recursive: true });
+  writeFileSync(join(base, ".gsd", "milestones", "M001", "M001-SUMMARY.md"), "# Summary\nDone.\n");
+  writeFileSync(join(base, "src", "app.ts"), "export const ok = true;\n");
+
+  execFileSync("git", ["init", "-b", "main"], { cwd: base, stdio: "ignore" });
+  execFileSync("git", ["config", "user.name", "Codex"], { cwd: base, stdio: "ignore" });
+  execFileSync("git", ["config", "user.email", "codex@example.com"], { cwd: base, stdio: "ignore" });
+  writeFileSync(join(base, "README.md"), "# test\n");
+  execFileSync("git", ["add", "README.md"], { cwd: base, stdio: "ignore" });
+  execFileSync("git", ["commit", "-m", "chore: seed"], { cwd: base, stdio: "ignore" });
+  execFileSync("git", ["checkout", "-b", "fix/test"], { cwd: base, stdio: "ignore" });
+  execFileSync("git", ["add", ".gsd/milestones/M001/M001-SUMMARY.md", "src/app.ts"], { cwd: base, stdio: "ignore" });
+  execFileSync("git", ["commit", "-m", "feat: summary exists but db is stale"], { cwd: base, stdio: "ignore" });
+
+  const deps = makeMockDeps(capture, {
+    pauseAuto: async () => { pauseCalls++; },
+    stopAuto: async () => { stopCalls++; },
+    resolveDispatch: async () => ({
+      action: "dispatch" as const,
+      unitType: "complete-milestone",
+      unitId: "M001",
+      prompt: "complete the milestone",
+      matchedRule: "completing-milestone-rule",
+    }),
+  });
+
+  const ic = makeIC(deps, {
+    s: {
+      ...makeSession(),
+      basePath: base,
+      currentMilestoneId: "M001",
+    } as any,
+  });
+  const preData: PreDispatchData = {
+    state: {
+      phase: "completing-milestone",
+      activeMilestone: { id: "M001", title: "Test", status: "active" },
+      registry: [{ id: "M001", status: "active" }],
+      blockers: [],
+    } as any,
+    mid: "M001",
+    midTitle: "Test Milestone",
+  };
+
+  const result = await runDispatch(ic, preData, {
+    recentUnits: [
+      { key: "complete-milestone/M001" },
+      { key: "complete-milestone/M001" },
+    ],
+    stuckRecoveryAttempts: 0,
+    consecutiveFinalizeTimeouts: 0,
+  });
+
+  assert.equal(result.action, "break");
+  assert.equal((result as any).reason, "complete-milestone-artifact-db-mismatch");
+  assert.equal(pauseCalls, 1, "complete-milestone disk/db mismatch should pause auto-mode");
+  assert.equal(stopCalls, 0, "mismatch pause should not hard-stop the loop");
 });
 
 test("runUnitPhase emits unit-start and unit-end with causedBy reference", async () => {


### PR DESCRIPTION
## Linked issue

Closes #4289

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Pause auto-mode when a `complete-milestone` summary already exists on disk but the same unit keeps being derived.
**Why:** That state points to a disk/DB mismatch, so retrying the same unit is noisy and wastes loop budget.
**How:** Special-case `complete-milestone` stuck recovery to fail closed and cover it with an integration-style regression test.

## What

This changes the stuck-recovery path in `runDispatch()` so `complete-milestone` is treated differently from ordinary artifact-on-disk retries. When the milestone summary is already present but the same `complete-milestone` unit is still being derived, auto-mode now pauses instead of invalidating caches and retrying.

## Why

A summary that already exists on disk means the milestone artifact was produced. If the unit is still being derived, the problem is usually stale DB state rather than missing output. Retrying the same unit hides the real mismatch and burns more attempts.

## How

The fix adds a narrow `complete-milestone` fail-closed branch in stuck recovery: it diagnoses the expected artifact, emits a warning, pauses auto-mode, and breaks the loop with a dedicated reason. The new regression test builds a temporary git repo with a real summary on disk and proves the loop pauses instead of retrying.

## Change type

- [x] `fix` — Bug fix
- [x] `test` — Adding or updating tests

## Scope

- [x] `gsd extension` — GSD workflow

## Breaking changes

- [x] No breaking changes

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [ ] Manual testing — steps described above
- [ ] No tests needed — explained above

Automated verification:
1. `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/journal-integration.test.ts`
2. `npm run typecheck:extensions`
3. `npm run build` in a plain verification clone at the exact branch head

## AI disclosure

- [x] This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.
