### PR TITLE
fix(gsd): skip glob-like inputs in pre-execution checks

### DIFF
--- a/src/resources/extensions/gsd/pre-execution-checks.ts
+++ b/src/resources/extensions/gsd/pre-execution-checks.ts
@@ -312,6 +312,10 @@ function shouldValidateInputAsPath(raw: string): boolean {
   );
 }
 
+function containsGlobPattern(candidate: string): boolean {
+  return ["*", "?", "[", "]", "{", "}"].some((char) => candidate.includes(char));
+}
+
 /**
  * Build a set of files that will be created by tasks up to (but not including) taskIndex.
  * All paths are normalized for consistent comparison.
@@ -354,6 +358,7 @@ export function checkFilePathConsistency(
 
       // Normalize path for consistent comparison
       const normalizedFile = normalizeFilePath(file);
+      if (containsGlobPattern(normalizedFile)) continue;
 
       // Check if file exists on disk
       const absolutePath = resolve(basePath, normalizedFile);
@@ -414,6 +419,7 @@ export function checkTaskOrdering(
       if (!shouldValidateInputAsPath(file)) continue;
 
       const normalizedFile = normalizeFilePath(file);
+      if (containsGlobPattern(normalizedFile)) continue;
       const creator = fileCreators.get(normalizedFile);
       const absolutePath = resolve(basePath, normalizedFile);
       const existsOnDisk = existsSync(absolutePath);

--- a/src/resources/extensions/gsd/tests/pre-execution-checks.test.ts
+++ b/src/resources/extensions/gsd/tests/pre-execution-checks.test.ts
@@ -1139,6 +1139,28 @@ describe("checkTaskOrdering false positive regression (#3677)", () => {
       rmSync(tempDir, { recursive: true, force: true });
     }
   });
+
+  test("glob-like inputs do not trigger ordering violations against later concrete outputs", () => {
+    const tasks = [
+      createTask({
+        id: "T01",
+        sequence: 0,
+        files: [],
+        inputs: ["Artifacts/pruned_networks/cell_line=*/"],
+        expected_output: [],
+      }),
+      createTask({
+        id: "T02",
+        sequence: 1,
+        files: [],
+        inputs: [],
+        expected_output: ["Artifacts/pruned_networks/cell_line=HT-29/"],
+      }),
+    ];
+
+    const results = checkTaskOrdering(tasks, "/tmp");
+    assert.equal(results.length, 0, "Glob-pattern inputs should not be treated as literal read-before-create dependencies");
+  });
 });
 
 // ─── checkFilePathConsistency additional edge cases ──────────────────────────
@@ -1186,9 +1208,7 @@ describe("checkFilePathConsistency additional edge cases", () => {
     assert.equal(results.length, 0, "Prior annotated expected_output entries should satisfy later plain inputs");
   });
 
-  test("inputs referencing glob-like patterns should not crash", () => {
-    // A glob pattern in inputs is unusual but should be handled gracefully.
-    // The file won't exist on disk, so it should produce a blocking result.
+  test("inputs referencing glob-like patterns are skipped by path consistency checks", () => {
     const tasks = [
       createTask({
         id: "T01",
@@ -1203,8 +1223,7 @@ describe("checkFilePathConsistency additional edge cases", () => {
     assert.doesNotThrow(() => {
       results = checkFilePathConsistency(tasks, "/tmp");
     });
-    assert.equal(results!.length, 1, "Glob-pattern input that doesn't exist should produce a blocking result");
-    assert.equal(results![0].blocking, true);
+    assert.equal(results!.length, 0, "Glob-pattern inputs should not produce false blocking failures");
   });
 
   test("multi-word prose inputs are ignored by path consistency checks", () => {


### PR DESCRIPTION
## Linked issue

Closes #4070

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Stop treating glob-like task inputs as literal missing paths in pre-execution file checks.
**Why:** Globs such as `Artifacts/pruned_networks/cell_line=*/` currently trigger false blocking failures and pause auto-mode.
**How:** Skip glob-like inputs in both path-consistency and task-ordering checks, with regressions covering both paths.

## What

This teaches pre-execution checks to ignore glob-like task inputs instead of feeding them through literal `existsSync()` and later-file creator checks. The change covers both `checkFilePathConsistency()` and `checkTaskOrdering()`, and updates the regression suite accordingly.

## Why

Planning prompts sometimes describe a set of files with a glob-style input. Those entries are still useful for the planner, but they are not concrete filesystem paths. Treating them literally creates false blocking failures that pause auto-mode even when the underlying artifact set already exists.

## How

The implementation adds a small glob-pattern guard after input normalization and before the on-disk/order checks. Tests now prove that glob-like inputs no longer create false blockers and no longer look like impossible read-before-create dependencies.

## Change type

- [x] `fix` — Bug fix
- [x] `test` — Adding or updating tests

## Scope

- [x] `gsd extension` — GSD workflow

## Breaking changes

- [x] No breaking changes

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [ ] Manual testing — steps described above
- [ ] No tests needed — explained above

Automated verification:
1. `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/pre-execution-checks.test.ts`
2. `npm run typecheck:extensions`
3. `npm run build` in a plain verification clone at the exact branch head

## AI disclosure

- [x] This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.
