### PR TITLE
fix(gsd): stage untracked files on symlink add fallback

### DIFF
--- a/src/resources/extensions/gsd/native-git-bridge.ts
+++ b/src/resources/extensions/gsd/native-git-bridge.ts
@@ -690,6 +690,22 @@ export function nativeAddTracked(basePath: string): void {
   gitFileExec(basePath, ["add", "-u"]);
 }
 
+function isDotGsdIgnored(basePath: string): boolean {
+  for (const path of [".gsd", ".gsd/"]) {
+    try {
+      execFileSync("git", ["check-ignore", "-q", path], {
+        cwd: basePath,
+        stdio: "pipe",
+        env: GIT_NO_PROMPT_ENV,
+      });
+      return true;
+    } catch {
+      // exit 1 means this form is not ignored; try the next variant
+    }
+  }
+  return false;
+}
+
 /**
  * Stage all files with pathspec exclusions (git add -A -- ':!pattern' ...).
  * Excluded paths are never hashed by git, preventing hangs on large
@@ -724,12 +740,12 @@ export function nativeAddAllWithExclusions(basePath: string, exclusions: readonl
       return;
     }
     // When .gsd is a symlink, git rejects `:!.gsd/...` pathspecs with
-    // "beyond a symbolic link". Fall back to `git add -u` which only
-    // stages changes to already-tracked files — O(tracked) not O(filesystem).
-    // Using `git add -A` here would traverse the entire working tree,
-    // hanging indefinitely on repos with large untracked data dirs. (#1977)
+    // "beyond a symbolic link". If `.gsd` is already covered by .gitignore
+    // (the default external-state layout), a plain `git add -A` safely stages
+    // new files while still leaving `.gsd` excluded. Otherwise keep the
+    // tracked-only fallback to avoid staging unexpected external-state files.
     if (stderr.includes("beyond a symbolic link")) {
-      gitFileExec(basePath, ["add", "-u"]);
+      gitFileExec(basePath, isDotGsdIgnored(basePath) ? ["add", "-A"] : ["add", "-u"]);
       return;
     }
     throw new GSDError(GSD_GIT_ERROR, `git add -A with exclusions failed in ${basePath}: ${getErrorMessage(err)}`);

--- a/src/resources/extensions/gsd/tests/integration/git-service.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/git-service.test.ts
@@ -1247,8 +1247,8 @@ describe('git-service', async () => {
 
   test('nativeAddAllWithExclusions: symlinked .gsd fallback', () => {
     // When .gsd is a symlink, git rejects `:!.gsd/...` pathspecs with
-    // "fatal: pathspec '...' is beyond a symbolic link". The fix falls
-    // back to `git add -u` (tracked files only), NOT `git add -A`.
+    // "fatal: pathspec '...' is beyond a symbolic link". When `.gsd` is
+    // already gitignored, the fallback should still stage untracked real files.
     const repo = initTempRepo();
 
     // Create the real .gsd directory outside the repo, then symlink it
@@ -1269,9 +1269,9 @@ describe('git-service', async () => {
     run('git commit -m "add app"', repo);
     writeFileSync(join(repo, "src/app.ts"), "export const x = 2;");
 
-    // Create an untracked file simulating large data (NOT in .gitignore)
-    // This is the key scenario: large untracked dirs that git add -A would traverse
-    createFile(repo, "data/large-model.bin", "pretend this is 10GB");
+    // Create an untracked file that should still be staged by the fallback
+    // because `.gsd` itself is already protected by .gitignore.
+    createFile(repo, "src/new-feature.ts", "export const fresh = true;");
 
     // nativeAddAllWithExclusions should NOT throw despite .gsd being a symlink
     let threw = false;
@@ -1287,12 +1287,43 @@ describe('git-service', async () => {
     const staged = run("git diff --cached --name-only", repo);
     assert.ok(staged.includes("src/app.ts"), "modified tracked file staged despite symlinked .gsd");
 
-    // CRITICAL: untracked files must NOT be staged — the symlink fallback
-    // should use `git add -u` (tracked only), not `git add -A` (all files).
-    // Using `git add -A` on a repo with large untracked data dirs hangs. (#1977)
-    assert.ok(!staged.includes("data/large-model.bin"),
-      "symlink fallback must not stage untracked files (would hang on large repos)");
+    assert.ok(staged.includes("src/new-feature.ts"),
+      "symlink fallback should still stage new real files when .gsd is gitignored");
     assert.ok(!staged.includes(".gsd"), ".gsd content not staged");
+
+    rmSync(repo, { recursive: true, force: true });
+    rmSync(externalGsd, { recursive: true, force: true });
+  });
+
+  test('nativeAddAllWithExclusions: symlinked .gsd stays tracked-only when .gsd is not gitignored', () => {
+    const repo = initTempRepo();
+
+    const externalGsd = mkdtempSync(join(tmpdir(), "gsd-external-unignored-"));
+    mkdirSync(join(externalGsd, "activity"), { recursive: true });
+    writeFileSync(join(externalGsd, "activity", "log.jsonl"), "log data");
+    writeFileSync(join(externalGsd, "STATE.md"), "# State");
+
+    symlinkSync(externalGsd, join(repo, ".gsd"));
+
+    createFile(repo, "src/app.ts", "export const x = 1;");
+    run("git add -A", repo);
+    run('git commit -m "add app"', repo);
+    writeFileSync(join(repo, "src/app.ts"), "export const x = 2;");
+    createFile(repo, "src/new-feature.ts", "export const fresh = true;");
+
+    let threw = false;
+    try {
+      nativeAddAllWithExclusions(repo, RUNTIME_EXCLUSION_PATHS);
+    } catch (e) {
+      threw = true;
+      console.error("  unexpected error:", e);
+    }
+    assert.ok(!threw, "nativeAddAllWithExclusions does not throw with symlinked .gsd when .gsd is not gitignored");
+
+    const staged = run("git diff --cached --name-only", repo);
+    assert.ok(staged.includes("src/app.ts"), "tracked modifications still stage in the defensive fallback");
+    assert.ok(!staged.includes("src/new-feature.ts"),
+      "untracked files stay unstaged when the symlink target itself is not protected by .gitignore");
 
     rmSync(repo, { recursive: true, force: true });
     rmSync(externalGsd, { recursive: true, force: true });


### PR DESCRIPTION
## Linked issue

Closes #4125

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Stage new real files when symlinked `.gsd` pathspec exclusion falls back during `git add`.
**Why:** The current fallback uses `git add -u`, which silently drops untracked files and loses real task outputs in the default external-state layout.
**How:** Detect whether `.gsd` is already gitignored; when it is, use `git add -A` for the symlink fallback and keep tracked-only fallback for layouts that are not protected by `.gitignore`.

## What

This updates `nativeAddAllWithExclusions()` so the symlink-error fallback can still stage newly created project files in external-state repos. It also adds regression coverage for both sides of the decision: gitignored `.gsd` now stages new real files, while non-gitignored `.gsd` stays on the defensive tracked-only path.

## Why

The current `git add -u` fallback avoids staging `.gsd`, but it also drops every untracked real file. In the default symlinked external-state layout that means `execute-task` and auto-commit can miss the very files they just created.

## How

The fallback now checks whether `.gsd` is already ignored by git. If yes, a plain `git add -A` safely stages new real files while `.gsd` remains excluded by `.gitignore`. If no, the code preserves the old tracked-only fallback so unprotected external-state files still cannot be swept in accidentally.

## Change type

- [x] `fix` — Bug fix
- [x] `test` — Adding or updating tests

## Scope

- [x] `gsd extension` — GSD workflow

## Breaking changes

- [x] No breaking changes

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [ ] Manual testing — steps described above
- [ ] No tests needed — explained above

Automated verification:
1. `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test --test-name-pattern "nativeAddAllWithExclusions: symlinked \\.gsd" src/resources/extensions/gsd/tests/integration/git-service.test.ts`
2. `npm run typecheck:extensions`
3. `npm run build` in a plain verification clone at the exact branch head

## AI disclosure

- [x] This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.
