### PR TITLE
fix(notifications): call sendRemoteNotification from sendDesktopNotification

### DIFF
--- a/src/resources/extensions/gsd/notifications.ts
+++ b/src/resources/extensions/gsd/notifications.ts
@@ -5,6 +5,7 @@ import { execFileSync } from "node:child_process";
 import type { NotificationPreferences } from "./types.js";
 import { loadEffectiveGSDPreferences } from "./preferences.js";
 import { CmuxClient, emitOsc777Notification, resolveCmuxConfig } from "../cmux/index.js";
+import { sendRemoteNotification } from "../remote-questions/notify.js";
 
 export type NotifyLevel = "info" | "success" | "warning" | "error";
 export type NotificationKind = "complete" | "error" | "budget" | "milestone" | "attention";
@@ -32,6 +33,11 @@ export function sendDesktopNotification(
   }
   const loaded = loadEffectiveGSDPreferences()?.preferences;
   if (!shouldSendDesktopNotification(kind, loaded?.notifications)) return;
+
+  // Option A: fire remote notification from here so every call-site in phases.ts
+  // automatically triggers Telegram/Slack/Discord without touching loop-deps or phases.
+  // fire-and-forget — sendRemoteNotification is async, sendDesktopNotification is sync.
+  void sendRemoteNotification(title, message).catch(() => {});
 
   const cmux = resolveCmuxConfig(loaded);
   if (cmux.notifications) {

--- a/src/resources/extensions/gsd/notifications.ts
+++ b/src/resources/extensions/gsd/notifications.ts
@@ -32,12 +32,12 @@ export function sendDesktopNotification(
     title = formatNotificationTitle(projectName);
   }
   const loaded = loadEffectiveGSDPreferences()?.preferences;
-  if (!shouldSendDesktopNotification(kind, loaded?.notifications)) return;
 
-  // Option A: fire remote notification from here so every call-site in phases.ts
-  // automatically triggers Telegram/Slack/Discord without touching loop-deps or phases.
-  // fire-and-forget — sendRemoteNotification is async, sendDesktopNotification is sync.
+  // Remote notifications fire independently of desktop preferences.
+  // sendRemoteNotification handles "not configured" gracefully (early return).
   void sendRemoteNotification(title, message).catch(() => {});
+
+  if (!shouldSendDesktopNotification(kind, loaded?.notifications)) return;
 
   const cmux = resolveCmuxConfig(loaded);
   if (cmux.notifications) {

--- a/src/resources/extensions/gsd/tests/remote-notification-from-desktop.test.ts
+++ b/src/resources/extensions/gsd/tests/remote-notification-from-desktop.test.ts
@@ -1,0 +1,85 @@
+/**
+ * remote-notification-from-desktop.test.ts
+ *
+ * Regression guard: sendDesktopNotification must fire sendRemoteNotification
+ * as a fire-and-forget side-effect so that Telegram/Slack/Discord channels
+ * receive the same events as native desktop notifications.
+ *
+ * Testing strategy (structural analysis):
+ *   node:test does not support mock.module without --experimental-test-module-mocks,
+ *   so we use the same source-code structural approach established in this codebase
+ *   (see session-start-footer.test.ts). We read notifications.ts and assert that:
+ *     1. It imports sendRemoteNotification from the remote-questions/notify module.
+ *     2. The sendDesktopNotification function body calls sendRemoteNotification
+ *        with title and message as arguments.
+ *     3. The call uses the void fire-and-forget pattern with a .catch(() => {})
+ *        suppressor so that async failures never break the synchronous caller.
+ *
+ * Relates to #4341.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SOURCE = readFileSync(join(__dirname, "..", "notifications.ts"), "utf-8");
+
+test("notifications.ts imports sendRemoteNotification from remote-questions/notify", () => {
+  const hasImport =
+    SOURCE.includes('from "../remote-questions/notify.js"') ||
+    SOURCE.includes("from '../remote-questions/notify.js'");
+  assert.ok(
+    hasImport,
+    "notifications.ts must import from '../remote-questions/notify.js'",
+  );
+
+  const importLine = SOURCE.split("\n").find(
+    (line) =>
+      line.includes("sendRemoteNotification") &&
+      (line.includes("remote-questions/notify") || line.includes("remote-questions/notify.js")),
+  );
+  assert.ok(
+    importLine,
+    "The import statement must include sendRemoteNotification from the remote-questions/notify module",
+  );
+});
+
+test("sendDesktopNotification calls sendRemoteNotification(title, message)", () => {
+  // Extract the body of sendDesktopNotification — from its opening brace to the
+  // closing brace at the same indentation level.
+  const fnStart = SOURCE.indexOf("export function sendDesktopNotification(");
+  assert.ok(fnStart > -1, "sendDesktopNotification must be present in notifications.ts");
+
+  // Find the next exported function/const after sendDesktopNotification to bound the search.
+  const nextExportIdx = SOURCE.indexOf("\nexport ", fnStart + 1);
+  const fnBody = nextExportIdx > -1 ? SOURCE.slice(fnStart, nextExportIdx) : SOURCE.slice(fnStart);
+
+  assert.ok(
+    fnBody.includes("sendRemoteNotification"),
+    "sendDesktopNotification must call sendRemoteNotification",
+  );
+
+  assert.ok(
+    fnBody.includes("sendRemoteNotification(title") || fnBody.includes("sendRemoteNotification(title,"),
+    "sendRemoteNotification must be called with title as first argument",
+  );
+});
+
+test("sendRemoteNotification is invoked as void fire-and-forget with .catch(() => {})", () => {
+  const fnStart = SOURCE.indexOf("export function sendDesktopNotification(");
+  const nextExportIdx = SOURCE.indexOf("\nexport ", fnStart + 1);
+  const fnBody = nextExportIdx > -1 ? SOURCE.slice(fnStart, nextExportIdx) : SOURCE.slice(fnStart);
+
+  assert.ok(
+    fnBody.includes("void sendRemoteNotification("),
+    "sendRemoteNotification must be called with void (fire-and-forget)",
+  );
+
+  assert.ok(
+    fnBody.includes(".catch("),
+    "sendRemoteNotification call must be followed by .catch() to suppress unhandled-rejection warnings",
+  );
+});

--- a/src/resources/extensions/gsd/tests/remote-notification-from-desktop.test.ts
+++ b/src/resources/extensions/gsd/tests/remote-notification-from-desktop.test.ts
@@ -83,3 +83,25 @@ test("sendRemoteNotification is invoked as void fire-and-forget with .catch(() =
     "sendRemoteNotification call must be followed by .catch() to suppress unhandled-rejection warnings",
   );
 });
+
+test("sendRemoteNotification call appears before shouldSendDesktopNotification guard", () => {
+  // Regression guard for the HIGH-severity bug where remote notifications were
+  // gated behind the desktop-notification preference check. Users who disable
+  // desktop notifications must still receive Telegram/Slack/Discord messages.
+  const fnStart = SOURCE.indexOf("export function sendDesktopNotification(");
+  assert.ok(fnStart > -1, "sendDesktopNotification must be present in notifications.ts");
+
+  const nextExportIdx = SOURCE.indexOf("\nexport ", fnStart + 1);
+  const fnBody = nextExportIdx > -1 ? SOURCE.slice(fnStart, nextExportIdx) : SOURCE.slice(fnStart);
+
+  const remoteCallIdx = fnBody.indexOf("sendRemoteNotification(");
+  const guardIdx = fnBody.indexOf("shouldSendDesktopNotification(");
+
+  assert.ok(remoteCallIdx > -1, "sendRemoteNotification must be called inside sendDesktopNotification");
+  assert.ok(guardIdx > -1, "shouldSendDesktopNotification guard must be present inside sendDesktopNotification");
+
+  assert.ok(
+    remoteCallIdx < guardIdx,
+    `sendRemoteNotification (pos ${remoteCallIdx}) must appear BEFORE the shouldSendDesktopNotification guard (pos ${guardIdx}) so that remote channels fire even when desktop notifications are disabled`,
+  );
+});


### PR DESCRIPTION
## TL;DR

**What:** `sendRemoteNotification()` was never called by any auto-mode code path — users who configured Telegram, Slack, or Discord only received interactive questions, never informational notifications.

**Why:** `sendDesktopNotification()` in `notifications.ts` is the single call-site for all auto-mode events (milestone complete, blocker, budget alerts, etc.), but it had no knowledge of the remote notification system.

**How:** Added a fire-and-forget call to `sendRemoteNotification(title, message)` inside `sendDesktopNotification()`, placed *before* the `shouldSendDesktopNotification` guard so that server users with desktop notifications disabled still receive remote notifications. Added a regression test to lock in the behavior.

Closes #4341

---

## What Changed

### `src/resources/extensions/gsd/notifications.ts`

Two changes inside `sendDesktopNotification()`:

1. Added import of `sendRemoteNotification` from `../remote-questions/notify.js`
2. Added a fire-and-forget call **before** the desktop guard:

```ts
// Remote notifications fire independently of desktop preferences.
// sendRemoteNotification handles "not configured" gracefully (early return).
void sendRemoteNotification(title, message).catch(() => {});
```

The call is placed *before* `shouldSendDesktopNotification` so users who have desktop notifications disabled (e.g. headless servers) still receive Telegram/Slack/Discord messages. `sendRemoteNotification` already performs its own early return when no remote channel is configured, so existing users without a remote channel see zero behavior change.

### `src/resources/extensions/gsd/tests/remote-notification-from-desktop.test.ts` (new)

Regression test using the established structural source-analysis pattern (same approach as `session-start-footer.test.ts`). Locks in four invariants:

| # | What it checks |
|---|---|
| 1 | `notifications.ts` imports `sendRemoteNotification` from `remote-questions/notify` |
| 2 | `sendDesktopNotification` calls `sendRemoteNotification(title, message)` |
| 3 | The call uses the `void … .catch(() => {})` fire-and-forget pattern |
| 4 | The call appears *before* the `shouldSendDesktopNotification` guard in source order |

---

## Events Now Delivered to Remote Channels

After this fix, every event that produces a desktop notification will also be sent to configured Telegram/Slack/Discord channels:

| Event | Trigger |
|---|---|
| Milestone complete | Auto-mode finishes a milestone |
| All milestones complete | Project fully done |
| Dependency blocker | Auto-mode is blocked, needs input |
| Slice blocker (paused) | Slice paused, intervention needed |
| Budget HALT | 100% budget reached, auto-mode stops |
| Budget PAUSE | Budget threshold reached, auto-mode pauses |
| Budget warnings | Configurable threshold alerts |

Interactive questions (remote question race) continue to work as before — this fix only adds the missing informational notification path.

---

## Local Build Verification

<img width="548" height="328" alt="gsd-telegram" src="https://github.com/user-attachments/assets/4227ad17-0f53-4c1d-b6ba-5484c3902f46" />

 — showing Telegram receiving a notification during an auto-mode run with `GSD_VERSION=2.75.0 GSD_WORKFLOW_MCP_COMMAND="node packages/mcp-server/dist/cli.js" node dist/cli.js`

---

## Test Results

```
ok 1 - notifications.ts imports sendRemoteNotification from remote-questions/notify
ok 2 - sendDesktopNotification calls sendRemoteNotification(title, message)
ok 3 - sendRemoteNotification is invoked as void fire-and-forget with .catch(() => {})
ok 4 - sendRemoteNotification call appears before shouldSendDesktopNotification guard

# tests 4  |  pass 4  |  fail 0
```

`npx tsc --noEmit` — clean, zero errors.

---

## Notes

- **No behavior change for users without a remote channel** — `sendRemoteNotification` returns early when no channel is configured.
- **Non-fatal by design** — the `.catch(() => {})` plus `sendRemoteNotification`'s own internal try/catch ensure a failing remote endpoint never affects desktop notification delivery or auto-mode operation.
- **AI-assisted** — this fix was developed with Claude Code assistance. The author has reviewed and understands all changes.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)