### PR TITLE
docs: update model examples to claude-opus-4-7

### DIFF
--- a/README.md
+++ b/README.md
@@ -532,7 +532,7 @@ version: 1
 models:
   research: claude-sonnet-4-6
   planning:
-    model: claude-opus-4-6
+    model: claude-opus-4-7
     fallbacks:
       - openrouter/z-ai/glm-5
       - openrouter/minimax/minimax-m2.5
@@ -791,7 +791,7 @@ In your preferences (`/gsd prefs`), assign different models to different phases:
 models:
   research: openrouter/deepseek/deepseek-r1
   planning:
-    model: claude-opus-4-6
+    model: claude-opus-4-7
     fallbacks:
       - openrouter/z-ai/glm-5
   execution: claude-sonnet-4-6

--- a/gitbook/configuration/preferences.md
+++ b/gitbook/configuration/preferences.md
@@ -31,7 +31,7 @@ version: 1
 # Model selection
 models:
   research: claude-sonnet-4-6
-  planning: claude-opus-4-6
+  planning: claude-opus-4-7
   execution: claude-sonnet-4-6
   completion: claude-sonnet-4-6
 
@@ -75,7 +75,7 @@ Per-phase model selection. See [Choosing a Model](../getting-started/choosing-a-
 models:
   research: claude-sonnet-4-6
   planning:
-    model: claude-opus-4-6
+    model: claude-opus-4-7
     fallbacks:
       - openrouter/z-ai/glm-5
   execution: claude-sonnet-4-6

--- a/gitbook/features/dynamic-model-routing.md
+++ b/gitbook/features/dynamic-model-routing.md
@@ -32,7 +32,7 @@ dynamic_routing:
   tier_models:                    # optional: explicit model per tier
     light: claude-haiku-4-5
     standard: claude-sonnet-4-6
-    heavy: claude-opus-4-6
+    heavy: claude-opus-4-7
   escalate_on_failure: true       # bump tier on failure (default)
   budget_pressure: true           # auto-downgrade near budget ceiling (default)
   cross_provider: true            # consider models from other providers (default)

--- a/gitbook/getting-started/choosing-a-model.md
+++ b/gitbook/getting-started/choosing-a-model.md
@@ -19,7 +19,7 @@ Different phases of work have different requirements. You can assign specific mo
 ```yaml
 models:
   research: claude-sonnet-4-6        # scouting and research
-  planning: claude-opus-4-6          # architectural decisions
+  planning: claude-opus-4-7          # architectural decisions
   execution: claude-sonnet-4-6       # writing code
   execution_simple: claude-haiku-4-5 # simple tasks (docs, config)
   completion: claude-sonnet-4-6      # summaries and wrap-up
@@ -35,7 +35,7 @@ If a model is unavailable (provider down, rate limited, credits exhausted), GSD 
 ```yaml
 models:
   planning:
-    model: claude-opus-4-6
+    model: claude-opus-4-7
     fallbacks:
       - openrouter/z-ai/glm-5
       - openrouter/moonshotai/kimi-k2.5


### PR DESCRIPTION
## TL;DR

**What:** Updates all user-facing documentation to reference `claude-opus-4-7` as the recommended planning/heavy-tier model.
**Why:** Anthropic released Claude Opus 4.7 on 2026-04-16 and the docs still pointed users at `claude-opus-4-6`.
**How:** Simple string replacement across README and gitbook guides — no logic changes.

## What

Updates `claude-opus-4-6` → `claude-opus-4-7` in all example configurations:
- `README.md` (2 occurrences in preferences examples)
- `gitbook/configuration/preferences.md` (2 occurrences)
- `gitbook/features/dynamic-model-routing.md` (1 occurrence — heavy tier example)
- `gitbook/getting-started/choosing-a-model.md` (2 occurrences)

`claude-opus-4-6` remains fully supported in the codebase — this only updates the recommended example configs shown to users.

## Why

Documentation should reflect the current recommended model. Users following the getting-started guide or preferences docs would be directed to a previous-generation model.

## How

Documentation-only change. No logic, no tests affected.

---

- [ ] `docs` — Documentation only

> AI-assisted contribution. Depends on gsd-build/gsd-2#4352 (API support) being merged first, though this PR can be reviewed independently.

Closes #4348