### PR TITLE
ci: add dev/test/release branching with @next and @hotfix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,14 +3,14 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, dev, test, 'hotfix/**']
     paths-ignore:
       - '.github/workflows/ai-triage.yml'
       - '.github/workflows/build-native.yml'
       - '.github/workflows/cleanup-dev-versions.yml'
       - 'LICENSE'
   pull_request:
-    branches: [main]
+    branches: [main, dev, test]
     paths-ignore:
       - '.github/workflows/ai-triage.yml'
       - '.github/workflows/build-native.yml'

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -4,20 +4,23 @@ on:
   workflow_run:
     workflows: ["CI"]
     types: [completed]
-    branches: [main]
+    branches: [main, dev, test, 'hotfix/**']
 
 concurrency:
-  group: pipeline-main
+  group: pipeline-${{ github.event.workflow_run.head_branch }}
   cancel-in-progress: false
 
 permissions:
   contents: write
   packages: write
+  pull-requests: write
 
 jobs:
   dev-publish:
     name: Dev Publish
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: >-
+      ${{ github.event.workflow_run.conclusion == 'success' &&
+          github.event.workflow_run.head_branch == 'dev' }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     container:
       image: ghcr.io/gsd-build/gsd-ci-builder:latest
@@ -32,6 +35,10 @@ jobs:
       dev-version: ${{ steps.stamp.outputs.version }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+          token: ${{ secrets.RELEASE_PAT }}
+          fetch-depth: 0
 
       - name: Mark workspace safe for git
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
@@ -65,6 +72,8 @@ jobs:
 
       - name: Stamp dev version and sync platform packages
         id: stamp
+        env:
+          VERSION_CHANNEL: dev
         run: |
           npm run pipeline:version-stamp
           npm run sync-platform-versions
@@ -87,12 +96,35 @@ jobs:
           export GSD_SMOKE_BINARY="$(pwd)/dist/loader.js"
           npm run test:smoke
 
+      - name: Fast-forward test branch to dev
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          REPO: ${{ github.repository }}
+        run: |
+          if gh api "repos/${REPO}/git/refs/heads/test" >/dev/null 2>&1; then
+            if gh api -X PATCH "repos/${REPO}/git/refs/heads/test" \
+                -f sha="$HEAD_SHA" -F force=false >/dev/null 2>&1; then
+              echo "Fast-forwarded test to $HEAD_SHA"
+            else
+              echo "::warning::Could not fast-forward test — diverged from dev. Open a PR dev→test manually."
+            fi
+          else
+            echo "test branch does not exist; creating from $HEAD_SHA"
+            gh api -X POST "repos/${REPO}/git/refs" \
+              -f ref="refs/heads/test" -f sha="$HEAD_SHA"
+          fi
+
   test-verify:
     name: Test & Verify
-    needs: dev-publish
+    if: >-
+      ${{ github.event.workflow_run.conclusion == 'success' &&
+          github.event.workflow_run.head_branch == 'test' }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
 
       - uses: actions/setup-node@v6
         with:
@@ -100,14 +132,26 @@ jobs:
           registry-url: https://registry.npmjs.org
           cache: 'npm'
 
+      - name: Resolve dev version from package.json
+        id: resolve
+        env:
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          SHORT_SHA=$(echo "$HEAD_SHA" | cut -c1-7)
+          BASE_VERSION=$(node -e 'process.stdout.write(require("./package.json").version)')
+          DEV_VERSION="${BASE_VERSION}-dev.${SHORT_SHA}"
+          echo "dev-version=$DEV_VERSION" >> "$GITHUB_OUTPUT"
+
       - name: Install gsd-pi@dev globally (with registry propagation retry)
+        env:
+          DEV_VERSION: ${{ steps.resolve.outputs.dev-version }}
         run: |
           for i in 1 2 3 4 5 6; do
-            npm install -g gsd-pi@dev && exit 0
+            npm install -g "gsd-pi@${DEV_VERSION}" && exit 0
             echo "Attempt $i failed — waiting 10s for npm registry propagation..."
             sleep 10
           done
-          echo "Failed to install gsd-pi@dev after 6 attempts"
+          echo "Failed to install gsd-pi@${DEV_VERSION} after 6 attempts"
           exit 1
 
       - name: Run smoke tests (against installed binary)
@@ -130,7 +174,7 @@ jobs:
 
       - name: Promote to @next
         env:
-          DEV_VERSION: ${{ needs.dev-publish.outputs.dev-version }}
+          DEV_VERSION: ${{ steps.resolve.outputs.dev-version }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm dist-tag add "gsd-pi@${DEV_VERSION}" next
 
@@ -143,7 +187,7 @@ jobs:
 
       - name: Build and push runtime Docker image
         env:
-          DEV_VERSION: ${{ needs.dev-publish.outputs.dev-version }}
+          DEV_VERSION: ${{ steps.resolve.outputs.dev-version }}
         run: |
           docker build --target runtime \
             -t "ghcr.io/gsd-build/gsd-pi:next" \
@@ -154,12 +198,15 @@ jobs:
 
   prod-release:
     name: Production Release
-    needs: [dev-publish, test-verify]
+    if: >-
+      ${{ github.event.workflow_run.conclusion == 'success' &&
+          github.event.workflow_run.head_branch == 'main' }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     environment: prod
     steps:
       - uses: actions/checkout@v6
         with:
+          ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
           token: ${{ secrets.RELEASE_PAT }}
 
@@ -279,15 +326,95 @@ jobs:
 
       - name: Tag runtime Docker image as latest
         env:
-          DEV_VERSION: ${{ needs.dev-publish.outputs.dev-version }}
+          RELEASE_VERSION: ${{ steps.release.outputs.version }}
         run: |
-          docker pull "ghcr.io/gsd-build/gsd-pi:${DEV_VERSION}"
-          docker tag "ghcr.io/gsd-build/gsd-pi:${DEV_VERSION}" ghcr.io/gsd-build/gsd-pi:latest
+          docker pull ghcr.io/gsd-build/gsd-pi:next
+          docker tag ghcr.io/gsd-build/gsd-pi:next "ghcr.io/gsd-build/gsd-pi:${RELEASE_VERSION}"
+          docker tag ghcr.io/gsd-build/gsd-pi:next ghcr.io/gsd-build/gsd-pi:latest
+          docker push "ghcr.io/gsd-build/gsd-pi:${RELEASE_VERSION}"
           docker push ghcr.io/gsd-build/gsd-pi:latest
+
+      - name: Open back-merge PR main→dev if behind
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
+          RELEASE_VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          git fetch origin dev main
+          BEHIND=$(git rev-list --count origin/dev..origin/main)
+          if [ "$BEHIND" -gt 0 ]; then
+            BRANCH="backmerge/main-to-dev-v${RELEASE_VERSION}"
+            git checkout -B "$BRANCH" origin/main
+            git push origin "$BRANCH" --force-with-lease
+            gh pr create --base dev --head "$BRANCH" \
+              --title "chore: back-merge main to dev (v${RELEASE_VERSION})" \
+              --body "Sync release commit and version bump from main into dev." || true
+          else
+            echo "dev is up to date with main; no back-merge needed"
+          fi
+
+  hotfix-verify:
+    name: Hotfix Verify
+    if: >-
+      ${{ github.event.workflow_run.conclusion == 'success' &&
+          startsWith(github.event.workflow_run.head_branch, 'hotfix/') }}
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    container:
+      image: ghcr.io/gsd-build/gsd-ci-builder:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+          fetch-depth: 0
+
+      - name: Mark workspace safe for git
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install web host dependencies
+        run: npm --prefix web ci
+
+      - name: Build core
+        run: npm run build:core
+
+      - name: Build web host
+        run: npm run build:web-host
+
+      - name: Stamp hotfix prerelease (validation build)
+        env:
+          VERSION_CHANNEL: hotfix
+        run: |
+          npm run pipeline:version-stamp
+          npm run sync-platform-versions
+
+      - name: Smoke test hotfix build
+        run: |
+          chmod +x dist/loader.js
+          export GSD_SMOKE_BINARY="$(pwd)/dist/loader.js"
+          npm run test:smoke
+
+      - name: Notify hotfix branch ready for PR to main
+        env:
+          BRANCH: ${{ github.event.workflow_run.head_branch }}
+        run: |
+          echo "::notice::Hotfix branch ${BRANCH} passed CI and smoke tests."
+          echo "::notice::Open a PR to main to fast-track to @latest via prod-release."
 
   update-builder:
     name: Update CI Builder Image
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: >-
+      ${{ github.event.workflow_run.conclusion == 'success' &&
+          github.event.workflow_run.head_branch == 'main' }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v6

--- a/scripts/version-stamp.mjs
+++ b/scripts/version-stamp.mjs
@@ -10,7 +10,8 @@ const pkgPath = new URL("../package.json", import.meta.url);
 const pkg = JSON.parse(readFileSync(pkgPath, "utf8"));
 
 const shortSha = execFileSync("git", ["rev-parse", "--short", "HEAD"], { encoding: "utf8" }).trim();
-const devVersion = `${pkg.version}-dev.${shortSha}`;
+const channel = process.env.VERSION_CHANNEL || "dev";
+const devVersion = `${pkg.version}-${channel}.${shortSha}`;
 
 pkg.version = devVersion;
 writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + "\n");


### PR DESCRIPTION
## Summary
Refactors the single-main trunk pipeline into a branch-gated promotion flow:

- `dev` → `@dev` (auto fast-forwards `test`)
- `test` → `@next` + docker `:next`
- `main` → `@latest` + docker `:latest` + conditional back-merge PR to `dev`
- `hotfix/*` → CI + smoke validation; PR to `main` fast-tracks to `@latest`

## Design notes

- **Single `pipeline.yml` with branch-conditional jobs** instead of three separate workflows. Chained `workflow_run` workflows ignore the `branches:` filter and resolve from the default branch ([actions/runner#1628](https://github.com/actions/runner/issues/1628)), so gating via `if: github.event.workflow_run.head_branch == '...'` is the only reliable option.
- **Dropped `@hotfix` dist-tag** — `npm i gsd-pi@hotfix` would point to a lower semver than `@latest` once any later minor shipped, which is misleading. Hotfixes now fast-track directly to `@latest` via PR from `hotfix/*` → `main`.
- **Version stamp channel** — `scripts/version-stamp.mjs` now reads `VERSION_CHANNEL` (default `dev`). Hotfix validation builds stamp as `-hotfix.<sha>` to avoid ambiguity between concurrent dev and hotfix publishes.
- **Concurrency** — each pipeline branch gets its own concurrency group with `cancel-in-progress: false` so an in-flight publish is never killed.
- **Back-merge main→dev** — only opened conditionally (`git rev-list --count origin/dev..origin/main > 0`) to avoid noisy empty PRs.

## Manual setup required post-merge
1. Create `dev` and `test` branches from `main`.
2. Configure branch protection rulesets:
   - `dev` / `test`: PR required, CI must pass.
   - `main`: PR from `test` or `hotfix/*`, 1 reviewer, all checks, no force push.
   - `hotfix/**`: maintainer push allowed, CI required before merge.
3. Confirm `RELEASE_PAT` secret is scoped to allow writes on `test` (used by auto-FF step).

## Test plan
- [ ] Merge to `main`, confirm existing `prod-release` path still fires (branch-gate `head_branch == 'main'`).
- [ ] Push to `dev`, confirm `@dev` publishes and `test` fast-forwards.
- [ ] Push to `test`, confirm `@next` + `:next` docker publish.
- [ ] Create `hotfix/smoke-test` branch, confirm `hotfix-verify` runs without publishing.

Replaces #4358 (which accidentally included 47 unrelated commits from a long-lived feature branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)