### PR TITLE
Fix onboarding default-provider persistence to prevent Bedrock fallback (#4368)

### DIFF
--- a/src/onboarding.ts
+++ b/src/onboarding.ts
@@ -160,6 +160,25 @@ function openBrowser(url: string): void {
   }
 }
 
+/**
+ * Persist the selected default provider to settings.json.
+ *
+ * This ensures first startup after onboarding prefers the provider the user
+ * just configured, instead of falling back to the first "available" provider
+ * (which can be influenced by unrelated env auth like AWS_PROFILE).
+ */
+function persistDefaultProvider(providerId: string): void {
+  const settingsPath = join(agentDir, 'settings.json')
+  try {
+    const raw = existsSync(settingsPath) ? JSON.parse(readFileSync(settingsPath, 'utf-8')) : {}
+    raw.defaultProvider = providerId
+    mkdirSync(dirname(settingsPath), { recursive: true })
+    writeFileSync(settingsPath, JSON.stringify(raw, null, 2), 'utf-8')
+  } catch {
+    // Non-fatal: startup fallback logic will still run.
+  }
+}
+
 /** Sentinel returned by runStep when the user cancels — tells the caller
  *  to abort the entire wizard. */
 const STEP_CANCELLED = Symbol('step-cancelled')
@@ -349,15 +368,8 @@ async function runLlmStep(p: ClackModule, pc: PicoModule, authStorage: AuthStora
     p.log.info('Your Claude subscription will be used for inference. No API key needed.')
     // Store sentinel so hasAuth('claude-code') returns true on future boots
     authStorage.set('claude-code', { type: 'api_key', key: 'cli' })
-    // Persist claude-code as the default provider so the startup migration in
-    // cli.ts does not need to fire and the user is not left on "anthropic".
-    const settingsPath = join(agentDir, 'settings.json')
-    try {
-      const raw = existsSync(settingsPath) ? JSON.parse(readFileSync(settingsPath, 'utf-8')) : {}
-      raw.defaultProvider = 'claude-code'
-      mkdirSync(dirname(settingsPath), { recursive: true })
-      writeFileSync(settingsPath, JSON.stringify(raw, null, 2), 'utf-8')
-    } catch { /* non-fatal — startup migration will catch it */ }
+    // Persist claude-code so startup does not keep users on anthropic direct API.
+    persistDefaultProvider('claude-code')
     return true
   }
 
@@ -454,6 +466,7 @@ async function runOAuthFlow(
     }
 
     await authStorage.login(providerId as LoginProviderId, loginCallbacks)
+    persistDefaultProvider(providerId)
 
     p.log.success(`Authenticated with ${pc.green(providerName)}`)
     return true
@@ -502,6 +515,7 @@ async function runApiKeyFlow(
   }
 
   authStorage.set(providerId, { type: 'api_key', key: trimmed })
+  persistDefaultProvider(providerId)
   p.log.success(`API key saved for ${pc.green(providerLabel)}`)
 
   // Provider-specific post-setup hints
@@ -535,6 +549,7 @@ async function runOllamaLocalFlow(
       s.stop(`Ollama is running at ${pc.green(host)}`)
       // Store a placeholder so the provider is recognized as authenticated
       authStorage.set('ollama', { type: 'api_key', key: 'ollama' })
+      persistDefaultProvider('ollama')
       p.log.success(`${pc.green('Ollama (Local)')} configured — no API key needed`)
       p.log.info(pc.dim('Models are discovered automatically from your local Ollama instance.'))
       return true
@@ -557,6 +572,7 @@ async function runOllamaLocalFlow(
   if (p.isCancel(proceed) || !proceed) return false
 
   authStorage.set('ollama', { type: 'api_key', key: 'ollama' })
+  persistDefaultProvider('ollama')
   p.log.success(`${pc.green('Ollama (Local)')} saved — models will appear when Ollama is running`)
   return true
 }
@@ -609,6 +625,7 @@ async function runCustomOpenAIFlow(
 
   // Save API key to auth storage
   authStorage.set('custom-openai', { type: 'api_key', key: trimmedKey })
+  persistDefaultProvider('custom-openai')
 
   // Write or merge into models.json
   const modelsJsonPath = join(agentDir, 'models.json')

--- a/src/tests/onboarding-claude-cli-provider.test.ts
+++ b/src/tests/onboarding-claude-cli-provider.test.ts
@@ -5,8 +5,8 @@ import { join } from "node:path"
 
 /**
  * Source-level regression test: the claude-cli onboarding path must persist
- * defaultProvider = 'claude-code' in settings.json so the user is not left
- * on the 'anthropic' direct-API provider after selecting Claude Code CLI.
+ * defaultProvider = 'claude-code' so the user is not left on the
+ * 'anthropic' direct-API provider after selecting Claude Code CLI.
  *
  * Without this, the auto-migration in cli.ts does not fire when the user
  * also has a stored Anthropic API key, leaving them on the wrong provider.
@@ -17,7 +17,7 @@ test("onboarding claude-cli path persists defaultProvider to settings.json", () 
     "utf-8",
   )
 
-  // The claude-cli branch must write defaultProvider = 'claude-code' to settings.json
+  // The claude-cli branch must persist defaultProvider = 'claude-code'
   const cliBlock = source.slice(
     source.indexOf("method === 'claude-cli'"),
     source.indexOf("// ── Step 2"),
@@ -25,7 +25,7 @@ test("onboarding claude-cli path persists defaultProvider to settings.json", () 
   assert.ok(cliBlock.length > 0, "claude-cli block not found in onboarding.ts")
   assert.match(
     cliBlock,
-    /raw\.defaultProvider\s*=\s*['"]claude-code['"]/,
-    "claude-cli onboarding path must set defaultProvider = 'claude-code' in settings.json",
+    /persistDefaultProvider\(\s*['"]claude-code['"]\s*\)/,
+    "claude-cli onboarding path must set defaultProvider = 'claude-code'",
   )
 })

--- a/src/tests/onboarding-default-provider-persistence.test.ts
+++ b/src/tests/onboarding-default-provider-persistence.test.ts
@@ -1,0 +1,30 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+
+test("onboarding persists defaultProvider for API-key and OAuth flows", () => {
+  const source = readFileSync(
+    join(import.meta.dirname, "..", "onboarding.ts"),
+    "utf-8",
+  )
+
+  assert.match(
+    source,
+    /function persistDefaultProvider\(providerId: string\)/,
+    "onboarding.ts must define persistDefaultProvider(providerId)",
+  )
+
+  assert.match(
+    source,
+    /await authStorage\.login\(providerId as LoginProviderId, loginCallbacks\)\s*\n\s*persistDefaultProvider\(providerId\)/,
+    "OAuth onboarding must persist selected provider as defaultProvider",
+  )
+
+  assert.match(
+    source,
+    /authStorage\.set\(providerId, \{ type: 'api_key', key: trimmed \}\)\s*\n\s*persistDefaultProvider\(providerId\)/,
+    "API-key onboarding must persist selected provider as defaultProvider",
+  )
+})
+


### PR DESCRIPTION
## Summary
Fixes #4368: onboarding saved OpenAI credentials but did not persist the selected provider as default, so startup could silently pick Bedrock when AWS env auth markers were present.

## Changes
- Persist `defaultProvider` after successful onboarding LLM auth across all relevant flows in `src/onboarding.ts`.
- Add/update regression tests:
  - `src/tests/onboarding-default-provider-persistence.test.ts`
  - `src/tests/onboarding-claude-cli-provider.test.ts`

## Validation
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/tests/onboarding-claude-cli-provider.test.ts src/tests/onboarding-default-provider-persistence.test.ts src/tests/startup-model-validation.test.ts`
- All passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an issue where your chosen AI provider preference was not being properly saved during authentication and onboarding workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->