### PR TITLE
fix(pi-agent-core): case-insensitive tool lookup in prepareToolCall

### DIFF
--- a/packages/pi-agent-core/src/agent-loop.test.ts
+++ b/packages/pi-agent-core/src/agent-loop.test.ts
@@ -738,6 +738,13 @@ describe("agent-loop — case-insensitive tool lookup (#4342)", () => {
 			(e): e is Extract<AgentEvent, { type: "tool_execution_end" }> => e.type === "tool_execution_end",
 		);
 		assert.ok(toolEnd, "expected tool_execution_end event");
-		assert.equal(toolEnd.toolName, "Skill", "toolName in event should be the canonical registered name");
+		assert.equal(toolEnd.toolName, "Skill", "toolName in end event should be the canonical registered name");
+
+		// tool_execution_start must also carry the canonical name
+		const toolStart = events.find(
+			(e): e is Extract<AgentEvent, { type: "tool_execution_start" }> => e.type === "tool_execution_start",
+		);
+		assert.ok(toolStart, "expected tool_execution_start event");
+		assert.equal(toolStart.toolName, "Skill", "toolName in start event should be the canonical registered name");
 	});
 });

--- a/packages/pi-agent-core/src/agent-loop.test.ts
+++ b/packages/pi-agent-core/src/agent-loop.test.ts
@@ -609,8 +609,8 @@ describe("agent-loop — schema overload retry cap (#2783)", () => {
  * execute-task when the model emits a lowercase tool name (e.g. "skill"
  * instead of "Skill").
  *
- * The fix makes the lookup case-insensitive and normalizes toolCall.name to
- * the registered (canonical) tool name so the UI displays the correct casing.
+ * The fix makes the lookup case-insensitive and emits the registered
+ * (canonical) tool name so the UI displays the correct casing.
  */
 describe("agent-loop — case-insensitive tool lookup (#4342)", () => {
 	it("matches a tool when the model emits a differently-cased name", async () => {
@@ -674,6 +674,7 @@ describe("agent-loop — case-insensitive tool lookup (#4342)", () => {
 		);
 		assert.ok(toolEnd, "expected tool_execution_end event");
 		assert.equal(toolEnd.isError, false, "tool execution should succeed despite case mismatch");
+		assert.equal(toolEnd.toolName, "Skill", "toolName in end event should be the canonical registered name");
 		assert.deepEqual(toolEnd.result.content, [{ type: "text", text: "skill executed" }]);
 	});
 
@@ -746,5 +747,277 @@ describe("agent-loop — case-insensitive tool lookup (#4342)", () => {
 		);
 		assert.ok(toolStart, "expected tool_execution_start event");
 		assert.equal(toolStart.toolName, "Skill", "toolName in start event should be the canonical registered name");
+	});
+
+	it("does not mutate the assistant message tool call when normalizing name casing", async () => {
+		const tool: AgentTool<any> = {
+			name: "Skill",
+			label: "Skill",
+			description: "Run a skill",
+			parameters: Type.Object({
+				skill: Type.String(),
+			}),
+			execute: async () => ({
+				content: [{ type: "text" as const, text: "ok" }],
+				details: {},
+			}),
+		};
+
+		const assistantToolCall = {
+			type: "toolCall" as const,
+			id: `tc_immut_${Date.now()}`,
+			name: "skill",
+			arguments: { skill: "test-skill" },
+		};
+		const assistantMessage = makeAssistantMessage({
+			content: [assistantToolCall],
+			stopReason: "toolUse",
+		});
+		const finalStop = makeAssistantMessage({
+			content: [{ type: "text", text: "Done." }],
+			stopReason: "stop",
+		});
+
+		const mockStream = createMockStreamFn([assistantMessage, finalStop]);
+
+		const context: AgentContext = {
+			systemPrompt: "You are a test agent.",
+			messages: [{ role: "user", content: [{ type: "text", text: "Run skill" }], timestamp: Date.now() }],
+			tools: [tool],
+		};
+
+		const config: AgentLoopConfig = {
+			model: TEST_MODEL,
+			convertToLlm: (msgs) => msgs.filter((m): m is any => m.role !== "custom"),
+			toolExecution: "sequential",
+		};
+
+		const stream = agentLoop(
+			[{ role: "user", content: [{ type: "text", text: "Run skill" }], timestamp: Date.now() }],
+			context,
+			config,
+			undefined,
+			mockStream as any,
+		);
+
+		const events = await collectEvents(stream);
+		const toolEnd = events.find(
+			(e): e is Extract<AgentEvent, { type: "tool_execution_end" }> => e.type === "tool_execution_end",
+		);
+
+		assert.ok(toolEnd, "expected tool_execution_end event");
+		assert.equal(toolEnd.toolName, "Skill", "emitted toolName should be canonical");
+		assert.equal(assistantToolCall.name, "skill", "original assistant message tool call should keep model-emitted casing");
+	});
+
+	it("emits tool_execution_start before validation and beforeToolCall results", async () => {
+		const tool: AgentTool<any> = {
+			name: "Skill",
+			label: "Skill",
+			description: "Run a skill",
+			parameters: Type.Object({
+				skill: Type.String(),
+			}),
+			execute: async () => ({
+				content: [{ type: "text" as const, text: "should not execute" }],
+				details: {},
+			}),
+		};
+
+		const toolTurn = makeAssistantMessage({
+			content: [
+				{
+					type: "toolCall",
+					id: `tc_order_${Date.now()}`,
+					name: "skill",
+					arguments: { skill: "test-skill" },
+				},
+			],
+			stopReason: "toolUse",
+		});
+		const finalStop = makeAssistantMessage({
+			content: [{ type: "text", text: "Done." }],
+			stopReason: "stop",
+		});
+
+		const mockStream = createMockStreamFn([toolTurn, finalStop]);
+
+		const context: AgentContext = {
+			systemPrompt: "You are a test agent.",
+			messages: [{ role: "user", content: [{ type: "text", text: "Run skill" }], timestamp: Date.now() }],
+			tools: [tool],
+		};
+
+		const config: AgentLoopConfig = {
+			model: TEST_MODEL,
+			convertToLlm: (msgs) => msgs.filter((m): m is any => m.role !== "custom"),
+			toolExecution: "sequential",
+			beforeToolCall: async ({ toolCall }) => ({
+				block: true,
+				reason: `blocked ${toolCall.name}`,
+			}),
+		};
+
+		const stream = agentLoop(
+			[{ role: "user", content: [{ type: "text", text: "Run skill" }], timestamp: Date.now() }],
+			context,
+			config,
+			undefined,
+			mockStream as any,
+		);
+
+		const events = await collectEvents(stream);
+		const toolStartIndex = events.findIndex((e) => e.type === "tool_execution_start");
+		const toolEndIndex = events.findIndex((e) => e.type === "tool_execution_end");
+		const toolStart = events[toolStartIndex] as Extract<AgentEvent, { type: "tool_execution_start" }> | undefined;
+		const toolEnd = events[toolEndIndex] as Extract<AgentEvent, { type: "tool_execution_end" }> | undefined;
+
+		assert.notEqual(toolStartIndex, -1, "expected tool_execution_start event");
+		assert.notEqual(toolEndIndex, -1, "expected tool_execution_end event");
+		assert.ok(toolStartIndex < toolEndIndex, "tool_execution_start should be emitted before blocked outcome");
+		assert.equal(toolStart?.toolName, "Skill", "start event should use the canonical registered name");
+		assert.equal(toolEnd?.toolName, "Skill", "end event should use the canonical registered name");
+		assert.equal(toolEnd?.isError, true, "blocked tool call should be emitted as an error");
+		assert.deepEqual(toolEnd?.result.content, [{ type: "text", text: "blocked Skill" }]);
+	});
+
+	it("prefers exact case matches when registered tools differ only by case", async () => {
+		const skillTool: AgentTool<any> = {
+			name: "Skill",
+			label: "Skill",
+			description: "Run uppercase skill",
+			parameters: Type.Object({}),
+			execute: async () => ({
+				content: [{ type: "text" as const, text: "Skill executed" }],
+				details: {},
+			}),
+		};
+		const lowercaseSkillTool: AgentTool<any> = {
+			name: "skill",
+			label: "skill",
+			description: "Run lowercase skill",
+			parameters: Type.Object({}),
+			execute: async () => ({
+				content: [{ type: "text" as const, text: "skill executed" }],
+				details: {},
+			}),
+		};
+
+		const exactLowercaseToolCall = makeAssistantMessage({
+			content: [
+				{
+					type: "toolCall",
+					id: `tc_collision_${Date.now()}`,
+					name: "skill",
+					arguments: {},
+				},
+			],
+			stopReason: "toolUse",
+		});
+		const finalStop = makeAssistantMessage({
+			content: [{ type: "text", text: "Done." }],
+			stopReason: "stop",
+		});
+
+		const mockStream = createMockStreamFn([exactLowercaseToolCall, finalStop]);
+
+		const context: AgentContext = {
+			systemPrompt: "You are a test agent.",
+			messages: [{ role: "user", content: [{ type: "text", text: "Run skill" }], timestamp: Date.now() }],
+			tools: [skillTool, lowercaseSkillTool],
+		};
+
+		const config: AgentLoopConfig = {
+			model: TEST_MODEL,
+			convertToLlm: (msgs) => msgs.filter((m): m is any => m.role !== "custom"),
+			toolExecution: "sequential",
+		};
+
+		const stream = agentLoop(
+			[{ role: "user", content: [{ type: "text", text: "Run skill" }], timestamp: Date.now() }],
+			context,
+			config,
+			undefined,
+			mockStream as any,
+		);
+
+		const events = await collectEvents(stream);
+		const toolEnd = events.find(
+			(e): e is Extract<AgentEvent, { type: "tool_execution_end" }> => e.type === "tool_execution_end",
+		);
+
+		assert.ok(toolEnd, "expected tool_execution_end event");
+		assert.equal(toolEnd.toolName, "skill", "exact case match should win over an earlier case-insensitive match");
+		assert.deepEqual(toolEnd.result.content, [{ type: "text", text: "skill executed" }]);
+	});
+
+	it("uses the first registered case-insensitive match when colliding tools have no exact match", async () => {
+		const skillTool: AgentTool<any> = {
+			name: "Skill",
+			label: "Skill",
+			description: "Run uppercase skill",
+			parameters: Type.Object({}),
+			execute: async () => ({
+				content: [{ type: "text" as const, text: "Skill executed" }],
+				details: {},
+			}),
+		};
+		const lowercaseSkillTool: AgentTool<any> = {
+			name: "skill",
+			label: "skill",
+			description: "Run lowercase skill",
+			parameters: Type.Object({}),
+			execute: async () => ({
+				content: [{ type: "text" as const, text: "skill executed" }],
+				details: {},
+			}),
+		};
+
+		const ambiguousToolCall = makeAssistantMessage({
+			content: [
+				{
+					type: "toolCall",
+					id: `tc_first_match_${Date.now()}`,
+					name: "SKILL",
+					arguments: {},
+				},
+			],
+			stopReason: "toolUse",
+		});
+		const finalStop = makeAssistantMessage({
+			content: [{ type: "text", text: "Done." }],
+			stopReason: "stop",
+		});
+
+		const mockStream = createMockStreamFn([ambiguousToolCall, finalStop]);
+
+		const context: AgentContext = {
+			systemPrompt: "You are a test agent.",
+			messages: [{ role: "user", content: [{ type: "text", text: "Run skill" }], timestamp: Date.now() }],
+			tools: [skillTool, lowercaseSkillTool],
+		};
+
+		const config: AgentLoopConfig = {
+			model: TEST_MODEL,
+			convertToLlm: (msgs) => msgs.filter((m): m is any => m.role !== "custom"),
+			toolExecution: "sequential",
+		};
+
+		const stream = agentLoop(
+			[{ role: "user", content: [{ type: "text", text: "Run skill" }], timestamp: Date.now() }],
+			context,
+			config,
+			undefined,
+			mockStream as any,
+		);
+
+		const events = await collectEvents(stream);
+		const toolEnd = events.find(
+			(e): e is Extract<AgentEvent, { type: "tool_execution_end" }> => e.type === "tool_execution_end",
+		);
+
+		assert.ok(toolEnd, "expected tool_execution_end event");
+		assert.equal(toolEnd.toolName, "Skill", "first registered case-insensitive match should be used");
+		assert.deepEqual(toolEnd.result.content, [{ type: "text", text: "Skill executed" }]);
 	});
 });

--- a/packages/pi-agent-core/src/agent-loop.test.ts
+++ b/packages/pi-agent-core/src/agent-loop.test.ts
@@ -603,3 +603,141 @@ describe("agent-loop — schema overload retry cap (#2783)", () => {
 		}
 	});
 });
+
+/**
+ * Regression test for #4342: prepareToolCall case-sensitive tool lookup breaks
+ * execute-task when the model emits a lowercase tool name (e.g. "skill"
+ * instead of "Skill").
+ *
+ * The fix makes the lookup case-insensitive and normalizes toolCall.name to
+ * the registered (canonical) tool name so the UI displays the correct casing.
+ */
+describe("agent-loop — case-insensitive tool lookup (#4342)", () => {
+	it("matches a tool when the model emits a differently-cased name", async () => {
+		const tool: AgentTool<any> = {
+			name: "Skill",
+			label: "Skill",
+			description: "Run a skill",
+			parameters: Type.Object({
+				skill: Type.String(),
+			}),
+			execute: async () => ({
+				content: [{ type: "text" as const, text: "skill executed" }],
+				details: {},
+			}),
+		};
+
+		// Model emits lowercase "skill" instead of "Skill"
+		const lowercaseToolCall = makeAssistantMessage({
+			content: [
+				{
+					type: "toolCall",
+					id: `tc_case_${Date.now()}`,
+					name: "skill",
+					arguments: { skill: "test-skill" },
+				},
+			],
+			stopReason: "toolUse",
+		});
+		const finalStop = makeAssistantMessage({
+			content: [{ type: "text", text: "Done." }],
+			stopReason: "stop",
+		});
+
+		const mockStream = createMockStreamFn([lowercaseToolCall, finalStop]);
+
+		const context: AgentContext = {
+			systemPrompt: "You are a test agent.",
+			messages: [{ role: "user", content: [{ type: "text", text: "Run skill" }], timestamp: Date.now() }],
+			tools: [tool],
+		};
+
+		const config: AgentLoopConfig = {
+			model: TEST_MODEL,
+			convertToLlm: (msgs) => msgs.filter((m): m is any => m.role !== "custom"),
+			toolExecution: "sequential",
+		};
+
+		const stream = agentLoop(
+			[{ role: "user", content: [{ type: "text", text: "Run skill" }], timestamp: Date.now() }],
+			context,
+			config,
+			undefined,
+			mockStream as any,
+		);
+
+		const events = await collectEvents(stream);
+
+		// The tool must execute successfully — no "Tool skill not found" error
+		const toolEnd = events.find(
+			(e): e is Extract<AgentEvent, { type: "tool_execution_end" }> => e.type === "tool_execution_end",
+		);
+		assert.ok(toolEnd, "expected tool_execution_end event");
+		assert.equal(toolEnd.isError, false, "tool execution should succeed despite case mismatch");
+		assert.deepEqual(toolEnd.result.content, [{ type: "text", text: "skill executed" }]);
+	});
+
+	it("normalizes the tool call name to the canonical registered name for UI display", async () => {
+		const tool: AgentTool<any> = {
+			name: "Skill",
+			label: "Skill",
+			description: "Run a skill",
+			parameters: Type.Object({
+				skill: Type.String(),
+			}),
+			execute: async () => ({
+				content: [{ type: "text" as const, text: "ok" }],
+				details: {},
+			}),
+		};
+
+		// Model emits "SKILL" (all-caps) instead of "Skill"
+		const wrongCaseToolCall = makeAssistantMessage({
+			content: [
+				{
+					type: "toolCall",
+					id: `tc_norm_${Date.now()}`,
+					name: "SKILL",
+					arguments: { skill: "test-skill" },
+				},
+			],
+			stopReason: "toolUse",
+		});
+		const finalStop = makeAssistantMessage({
+			content: [{ type: "text", text: "Done." }],
+			stopReason: "stop",
+		});
+
+		const mockStream = createMockStreamFn([wrongCaseToolCall, finalStop]);
+
+		const context: AgentContext = {
+			systemPrompt: "You are a test agent.",
+			messages: [{ role: "user", content: [{ type: "text", text: "Run skill" }], timestamp: Date.now() }],
+			tools: [tool],
+		};
+
+		const config: AgentLoopConfig = {
+			model: TEST_MODEL,
+			convertToLlm: (msgs) => msgs.filter((m): m is any => m.role !== "custom"),
+			toolExecution: "sequential",
+		};
+
+		const stream = agentLoop(
+			[{ role: "user", content: [{ type: "text", text: "Run skill" }], timestamp: Date.now() }],
+			context,
+			config,
+			undefined,
+			mockStream as any,
+		);
+
+		const events = await collectEvents(stream);
+
+		// The tool_execution_end event's toolName should be the canonical "Skill",
+		// not the model-emitted "SKILL" — this is what the UI displays.
+		const toolEnd = events.find(
+			(e): e is Extract<AgentEvent, { type: "tool_execution_end" }> => e.type === "tool_execution_end",
+		);
+		assert.ok(toolEnd, "expected tool_execution_end event");
+		assert.equal(toolEnd.toolName, "Skill", "toolName in event should be the canonical registered name");
+	});
+});

--- a/packages/pi-agent-core/src/agent-loop.ts
+++ b/packages/pi-agent-core/src/agent-loop.ts
@@ -514,16 +514,18 @@ async function executeToolCalls(
 	stream: EventStream<AgentEvent, AgentMessage[]>,
 ): Promise<ToolExecutionResult> {
 	const toolCalls = assistantMessage.content.filter((c) => c.type === "toolCall") as AgentToolCall[];
+	const toolLookup = createToolLookup(currentContext.tools);
 	if (config.toolExecution === "sequential") {
-		return executeToolCallsSequential(currentContext, assistantMessage, toolCalls, config, signal, stream);
+		return executeToolCallsSequential(currentContext, assistantMessage, toolCalls, toolLookup, config, signal, stream);
 	}
-	return executeToolCallsParallel(currentContext, assistantMessage, toolCalls, config, signal, stream);
+	return executeToolCallsParallel(currentContext, assistantMessage, toolCalls, toolLookup, config, signal, stream);
 }
 
 async function executeToolCallsSequential(
 	currentContext: AgentContext,
 	assistantMessage: AssistantMessage,
 	toolCalls: AgentToolCall[],
+	toolLookup: ToolLookup,
 	config: AgentLoopConfig,
 	signal: AbortSignal | undefined,
 	stream: EventStream<AgentEvent, AgentMessage[]>,
@@ -533,21 +535,21 @@ async function executeToolCallsSequential(
 	let preparationErrorCount = 0;
 
 	for (let index = 0; index < toolCalls.length; index++) {
-		const toolCall = toolCalls[index];
+		const resolved = resolveToolCall(toolLookup, toolCalls[index]);
 
-		const preparation = await prepareToolCall(currentContext, assistantMessage, toolCall, config, signal);
 		stream.push({
 			type: "tool_execution_start",
-			toolCallId: toolCall.id,
-			toolName: toolCall.name,
-			args: toolCall.arguments,
+			toolCallId: resolved.toolCall.id,
+			toolName: resolved.toolCall.name,
+			args: resolved.toolCall.arguments,
 		});
 
+		const preparation = await prepareToolCall(currentContext, assistantMessage, resolved, config, signal);
 		if (preparation.kind === "immediate") {
 			if (preparation.isError) {
 				preparationErrorCount++;
 			}
-			results.push(emitToolCallOutcome(toolCall, preparation.result, preparation.isError, stream));
+			results.push(emitToolCallOutcome(resolved.toolCall, preparation.result, preparation.isError, stream));
 		} else {
 			const executed = await executePreparedToolCall(preparation, signal, stream);
 			results.push(
@@ -569,7 +571,7 @@ async function executeToolCallsSequential(
 				steeringMessages = steering;
 				const remainingCalls = toolCalls.slice(index + 1);
 				for (const skipped of remainingCalls) {
-					results.push(skipToolCall(skipped, stream));
+					results.push(skipToolCall(resolveToolCall(toolLookup, skipped).toolCall, stream));
 				}
 				break;
 			}
@@ -583,6 +585,7 @@ async function executeToolCallsParallel(
 	currentContext: AgentContext,
 	assistantMessage: AssistantMessage,
 	toolCalls: AgentToolCall[],
+	toolLookup: ToolLookup,
 	config: AgentLoopConfig,
 	signal: AbortSignal | undefined,
 	stream: EventStream<AgentEvent, AgentMessage[]>,
@@ -593,21 +596,21 @@ async function executeToolCallsParallel(
 	let preparationErrorCount = 0;
 
 	for (let index = 0; index < toolCalls.length; index++) {
-		const toolCall = toolCalls[index];
+		const resolved = resolveToolCall(toolLookup, toolCalls[index]);
 
-		const preparation = await prepareToolCall(currentContext, assistantMessage, toolCall, config, signal);
 		stream.push({
 			type: "tool_execution_start",
-			toolCallId: toolCall.id,
-			toolName: toolCall.name,
-			args: toolCall.arguments,
+			toolCallId: resolved.toolCall.id,
+			toolName: resolved.toolCall.name,
+			args: resolved.toolCall.arguments,
 		});
 
+		const preparation = await prepareToolCall(currentContext, assistantMessage, resolved, config, signal);
 		if (preparation.kind === "immediate") {
 			if (preparation.isError) {
 				preparationErrorCount++;
 			}
-			results.push(emitToolCallOutcome(toolCall, preparation.result, preparation.isError, stream));
+			results.push(emitToolCallOutcome(resolved.toolCall, preparation.result, preparation.isError, stream));
 		} else {
 			runnableCalls.push(preparation);
 		}
@@ -621,7 +624,7 @@ async function executeToolCallsParallel(
 				}
 				const remainingCalls = toolCalls.slice(index + 1);
 				for (const skipped of remainingCalls) {
-					results.push(skipToolCall(skipped, stream));
+					results.push(skipToolCall(resolveToolCall(toolLookup, skipped).toolCall, stream));
 				}
 				return { toolResults: results, steeringMessages, preparationErrorCount };
 			}
@@ -676,15 +679,49 @@ type ExecutedToolCallOutcome = {
 	isError: boolean;
 };
 
+type ToolLookup = {
+	exact: Map<string, AgentTool<any>>;
+	caseInsensitive: Map<string, AgentTool<any>>;
+};
+
+type ResolvedToolCall = {
+	toolCall: AgentToolCall;
+	tool: AgentTool<any> | undefined;
+};
+
+function createToolLookup(tools: AgentTool<any>[] | undefined): ToolLookup {
+	const exact = new Map<string, AgentTool<any>>();
+	const caseInsensitive = new Map<string, AgentTool<any>>();
+
+	for (const tool of tools ?? []) {
+		if (!exact.has(tool.name)) {
+			exact.set(tool.name, tool);
+		}
+		const lowerName = tool.name.toLowerCase();
+		if (!caseInsensitive.has(lowerName)) {
+			caseInsensitive.set(lowerName, tool);
+		}
+	}
+
+	return { exact, caseInsensitive };
+}
+
+function resolveToolCall(toolLookup: ToolLookup, toolCall: AgentToolCall): ResolvedToolCall {
+	const tool = toolLookup.exact.get(toolCall.name) ?? toolLookup.caseInsensitive.get(toolCall.name.toLowerCase());
+	return {
+		toolCall: tool && tool.name !== toolCall.name ? { ...toolCall, name: tool.name } : toolCall,
+		tool,
+	};
+}
+
 async function prepareToolCall(
 	currentContext: AgentContext,
 	assistantMessage: AssistantMessage,
-	toolCall: AgentToolCall,
+	resolved: ResolvedToolCall,
 	config: AgentLoopConfig,
 	signal: AbortSignal | undefined,
 ): Promise<PreparedToolCall | ImmediateToolCallOutcome> {
-	const lowerName = toolCall.name.toLowerCase();
-	const tool = currentContext.tools?.find((t) => t.name.toLowerCase() === lowerName);
+	const { toolCall, tool } = resolved;
 	if (!tool) {
 		return {
 			kind: "immediate",
@@ -692,9 +729,6 @@ async function prepareToolCall(
 			isError: true,
 		};
 	}
-	// Normalize to the registered tool name so the UI shows the canonical
-	// casing (e.g. "Skill") instead of whatever the model emitted ("skill").
-	toolCall.name = tool.name;
 
 	try {
 		const validatedArgs = validateToolArguments(tool, toolCall);

--- a/packages/pi-agent-core/src/agent-loop.ts
+++ b/packages/pi-agent-core/src/agent-loop.ts
@@ -534,6 +534,8 @@ async function executeToolCallsSequential(
 
 	for (let index = 0; index < toolCalls.length; index++) {
 		const toolCall = toolCalls[index];
+
+		const preparation = await prepareToolCall(currentContext, assistantMessage, toolCall, config, signal);
 		stream.push({
 			type: "tool_execution_start",
 			toolCallId: toolCall.id,
@@ -541,7 +543,6 @@ async function executeToolCallsSequential(
 			args: toolCall.arguments,
 		});
 
-		const preparation = await prepareToolCall(currentContext, assistantMessage, toolCall, config, signal);
 		if (preparation.kind === "immediate") {
 			if (preparation.isError) {
 				preparationErrorCount++;
@@ -593,6 +594,8 @@ async function executeToolCallsParallel(
 
 	for (let index = 0; index < toolCalls.length; index++) {
 		const toolCall = toolCalls[index];
+
+		const preparation = await prepareToolCall(currentContext, assistantMessage, toolCall, config, signal);
 		stream.push({
 			type: "tool_execution_start",
 			toolCallId: toolCall.id,
@@ -600,7 +603,6 @@ async function executeToolCallsParallel(
 			args: toolCall.arguments,
 		});
 
-		const preparation = await prepareToolCall(currentContext, assistantMessage, toolCall, config, signal);
 		if (preparation.kind === "immediate") {
 			if (preparation.isError) {
 				preparationErrorCount++;

--- a/packages/pi-agent-core/src/agent-loop.ts
+++ b/packages/pi-agent-core/src/agent-loop.ts
@@ -681,7 +681,8 @@ async function prepareToolCall(
 	config: AgentLoopConfig,
 	signal: AbortSignal | undefined,
 ): Promise<PreparedToolCall | ImmediateToolCallOutcome> {
-	const tool = currentContext.tools?.find((t) => t.name === toolCall.name);
+	const lowerName = toolCall.name.toLowerCase();
+	const tool = currentContext.tools?.find((t) => t.name.toLowerCase() === lowerName);
 	if (!tool) {
 		return {
 			kind: "immediate",
@@ -689,6 +690,9 @@ async function prepareToolCall(
 			isError: true,
 		};
 	}
+	// Normalize to the registered tool name so the UI shows the canonical
+	// casing (e.g. "Skill") instead of whatever the model emitted ("skill").
+	toolCall.name = tool.name;
 
 	try {
 		const validatedArgs = validateToolArguments(tool, toolCall);


### PR DESCRIPTION
## TL;DR

**What:** Makes `prepareToolCall` match tool names case-insensitively and normalizes to the canonical registered name.
**Why:** Models on the standard API key path can emit lowercase tool names (e.g. `skill` instead of `Skill`), causing a hard "Tool not found" error.
**How:** Case-insensitive `.find()` in `prepareToolCall`, plus name normalization so the UI shows the registered casing.

## What

Two changes in `packages/pi-agent-core/src/agent-loop.ts`:
1. Tool lookup in `prepareToolCall` uses `.toLowerCase()` on both sides instead of exact `===`
2. After matching, `toolCall.name` is overwritten with `tool.name` (the canonical registered name)

Regression tests added in `agent-loop.test.ts`:
- Verifies a lowercase tool name (`skill`) matches a PascalCase registration (`Skill`)
- Verifies the `toolName` in `tool_execution_end` events carries the canonical name, not the model-emitted one

## Why

When using the standard Anthropic API key path (not OAuth), `fromClaudeCodeName` normalization is not applied. If the model emits a tool name with different casing, the exact-match lookup at `agent-loop.ts:670` fails, blocking the task with an unrecoverable error.

Closes #4342

## How

The fix is at the single dispatch bottleneck — `prepareToolCall` — so it covers all providers regardless of how they pass tool names. The `fromClaudeCodeName` function in `anthropic-shared.ts` remains untouched; it serves a different purpose (OAuth name translation) and is not redundant with this fix.

- [x] `fix` — Bug fix

---
Generated with Claude Code (Opus 4.6).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Tool resolution is now case-insensitive. Tool names are normalized to their canonical registered names in UI events and execution results.

* **Tests**
  * Added comprehensive test suite for case-insensitive tool matching and canonical name normalization during tool execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->