### PR TITLE
fix(ci): remove duplicate tmpdir import blocking main

### DIFF
--- a/src/resources/extensions/gsd/tests/journal-integration.test.ts
+++ b/src/resources/extensions/gsd/tests/journal-integration.test.ts
@@ -11,11 +11,9 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { randomUUID } from "node:crypto";
 import { execFileSync } from "node:child_process";
-import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { mkdtempSync } from "node:fs";
-import { tmpdir } from "node:os";
 
 import type { JournalEntry } from "../journal.js";
 import type { LoopDeps } from "../auto/loop-deps.js";


### PR DESCRIPTION
## Summary
- PR #4329 landed on `main` with a duplicate `import { tmpdir } from \"node:os\"` in `src/resources/extensions/gsd/tests/journal-integration.test.ts`, failing `typecheck:extensions` with `TS2300: Duplicate identifier 'tmpdir'`.
- That broke both the `build` and `windows-portability` jobs in CI on `main`, which in turn caused the `Pipeline` workflow to be skipped (it's gated by `github.event.workflow_run.conclusion == 'success'`).
- Fix: consolidate `mkdtempSync` into the existing `node:fs` import and drop the duplicate `tmpdir` import.

## Test plan
- [x] `npm run typecheck:extensions` passes locally
- [ ] CI goes green on `main` after merge
- [ ] Pipeline workflow runs (no longer skipped) on the next push to `main`