### PR TITLE
fix(gsd): handle auto-mode limit errors with model fallback

### DIFF
--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -488,6 +488,15 @@ export function getAutoModeStartModel(): {
   return s.autoModeStartModel;
 }
 
+/**
+ * Update the dashboard-facing dispatched model label.
+ * Used when runtime recovery switches models mid-unit (e.g. provider fallback)
+ * so the AUTO box reflects the active model immediately.
+ */
+export function setCurrentDispatchedModelId(model: { provider: string; id: string } | null): void {
+  s.currentDispatchedModelId = model ? `${model.provider}/${model.id}` : null;
+}
+
 // Tool tracking — delegates to auto-tool-tracking.ts
 export function markToolStart(toolCallId: string, toolName?: string): void {
   _markToolStart(toolCallId, s.active, toolName);

--- a/src/resources/extensions/gsd/bootstrap/agent-end-recovery.ts
+++ b/src/resources/extensions/gsd/bootstrap/agent-end-recovery.ts
@@ -2,7 +2,7 @@ import type { ExtensionAPI, ExtensionContext } from "@gsd/pi-coding-agent";
 
 import { logWarning } from "../workflow-logger.js";
 import { checkAutoStartAfterDiscuss } from "../guided-flow.js";
-import { getAutoDashboardData, getAutoModeStartModel, isAutoActive, pauseAuto } from "../auto.js";
+import { getAutoDashboardData, getAutoModeStartModel, isAutoActive, pauseAuto, setCurrentDispatchedModelId } from "../auto.js";
 import { getNextFallbackModel, resolveModelWithFallbacksForUnit } from "../preferences.js";
 import { pauseAutoForProviderError } from "../provider-error-pause.js";
 import { isSessionSwitchInFlight, resolveAgentEnd } from "../auto-loop.js";
@@ -124,26 +124,11 @@ export async function handleAgentEnd(
     // ── 1. Classify using rawErrorMsg to avoid prose false-positives ────
     const cls = classifyError(rawErrorMsg, explicitRetryAfterMs);
 
-    // ── 1b. Defer to Core RetryHandler for transient errors ─────────────
-    // The Core RetryHandler (agent-session.ts) processes retryable errors
-    // AFTER this extension handler, in the same _processAgentEvent() call.
-    // For transient errors (overloaded, rate limit, server), the Core will
-    // retry in-context — same session, same conversation — which is strictly
-    // better than our Layer 2 pause+resume (which creates a new session).
-    //
-    // If we react here AND the Core also retries, we race: pauseAuto tears
-    // down the session while agent.continue() starts a new turn.
-    //
-    // Solution: Do nothing for transient errors. The Core RetryHandler
-    // runs next in _processAgentEvent and will either:
-    //   a) Retry successfully → new agent_end (success) → we see it next time
-    //   b) Exhaust retries → the agent stays idle, autoLoop's unit timeout
-    //      or stuck detection handles it
-    //
-    // We do NOT call resolveAgentEnd here — that would unblock autoLoop
-    // prematurely while the Core is still retrying in the same session.
-    // We do NOT call pauseAuto — that would tear down the session.
-    if (isTransient(cls)) {
+    // ── 1b. Defer to Core RetryHandler for most transient errors ────────
+    // Core retries transient failures in-session after this handler.
+    // Keep that behavior for non-rate-limit classes to avoid pause/retry races,
+    // but let rate-limit continue into model fallback logic below (#4373).
+    if (isTransient(cls) && cls.kind !== "rate-limit") {
       return;
     }
 
@@ -202,6 +187,7 @@ export async function handleAgentEnd(
             if (modelToSet) {
               const ok = await pi.setModel(modelToSet, { persist: false });
               if (ok) {
+                setCurrentDispatchedModelId({ provider: modelToSet.provider, id: modelToSet.id });
                 ctx.ui.notify(`Model error${errorDetail}. Switched to fallback: ${nextModelId} and resuming.`, "warning");
                 pi.sendMessage({ customType: "gsd-auto-timeout-recovery", content: "Continue execution.", display: false }, { triggerTurn: true });
                 return;
@@ -219,6 +205,7 @@ export async function handleAgentEnd(
           if (startModel) {
             const ok = await pi.setModel(startModel, { persist: false });
             if (ok) {
+              setCurrentDispatchedModelId({ provider: startModel.provider, id: startModel.id });
               retryState.networkRetryCount = 0;
               retryState.currentRetryModelId = undefined;
               ctx.ui.notify(`Model error${errorDetail}. Restored session model: ${sessionModel.provider}/${sessionModel.id} and resuming.`, "warning");

--- a/src/resources/extensions/gsd/error-classifier.ts
+++ b/src/resources/extensions/gsd/error-classifier.ts
@@ -43,7 +43,10 @@ export function resetRetryState(state: RetryState): void {
 // ── Classification ──────────────────────────────────────────────────────────
 
 const PERMANENT_RE = /auth|unauthorized|forbidden|invalid.*key|invalid.*api|billing|quota exceeded|account/i;
-const RATE_LIMIT_RE = /rate.?limit|too many requests|429/i;
+// Include provider-specific quota-window phrasing like:
+// - "You've hit your limit"
+// - "usage limit" / "quota reached"
+const RATE_LIMIT_RE = /rate.?limit|too many requests|429|hit your limit|usage limit|quota (?:reached|hit)|limit.*resets?/i;
 // OpenRouter affordability-style quota errors should be treated as transient
 // so core retry logic can lower maxTokens and continue in-session.
 const AFFORDABILITY_RE = /requires more credits|can only afford|insufficient credits|not enough credits|fewer max_tokens/i;
@@ -61,7 +64,7 @@ const RESET_DELAY_RE = /reset in (\d+)s/i;
  *
  * Classification order:
  *  1. Permanent (auth/billing/quota) — unless also rate-limited
- *  2. Rate limit (429, rate.?limit, too many requests)
+ *  2. Rate limit (429, rate.?limit, too many requests, hit-your-limit/quota-window phrasing)
  *  3. Network (ECONNRESET, ETIMEDOUT, socket hang up, fetch failed, dns)
  *  4. Stream truncation (malformed JSON from mid-stream cut)
  *  5. Server (500/502/503, overloaded, server_error)

--- a/src/resources/extensions/gsd/tests/provider-errors.test.ts
+++ b/src/resources/extensions/gsd/tests/provider-errors.test.ts
@@ -32,6 +32,19 @@ test("classifyError detects rate limit from message", () => {
   assert.equal(result.kind, "rate-limit");
 });
 
+test("classifyError treats Anthropic quota-window phrasing as transient rate-limit (#4373)", () => {
+  const result = classifyError("You've hit your limit · resets soon");
+  assert.ok(isTransient(result));
+  assert.equal(result.kind, "rate-limit");
+  assert.ok("retryAfterMs" in result && result.retryAfterMs === 60_000);
+});
+
+test("classifyError treats usage-limit phrasing as transient rate-limit (#4373)", () => {
+  const result = classifyError("usage limit reached for this workspace");
+  assert.ok(isTransient(result));
+  assert.equal(result.kind, "rate-limit");
+});
+
 test("classifyError treats OpenRouter affordability errors as transient rate-limit class", () => {
   const result = classifyError(
     "402 This request requires more credits, or fewer max_tokens. You requested up to 32000 tokens, but can only afford 329.",
@@ -456,6 +469,22 @@ test("agent-end-recovery.ts resumes transient provider pauses through startAuto 
   assert.ok(
     !src.includes('Continue execution — provider error recovery delay elapsed.'),
     "transient provider resume must not rely on a hidden continue prompt (#2813)",
+  );
+});
+
+test("agent-end-recovery.ts does not defer rate-limit errors to core retry handler before fallback (#4373)", () => {
+  const src = readFileSync(join(__dirname, "..", "bootstrap", "agent-end-recovery.ts"), "utf-8");
+  assert.ok(
+    src.includes('if (isTransient(cls) && cls.kind !== "rate-limit")'),
+    "rate-limit errors must bypass transient core-retry deferral so fallback can execute (#4373)",
+  );
+});
+
+test("agent-end-recovery.ts updates dashboard dispatched model after fallback switch", () => {
+  const src = readFileSync(join(__dirname, "..", "bootstrap", "agent-end-recovery.ts"), "utf-8");
+  assert.ok(
+    src.includes("setCurrentDispatchedModelId"),
+    "agent-end-recovery.ts should update currentDispatchedModelId when recovery switches model",
   );
 });
 


### PR DESCRIPTION
## TL;DR

**What:** Auto-mode now runs model fallback before deferring to the core retry handler on rate-limit errors, and correctly syncs the dashboard model label after a fallback switch.
**Why:** Anthropic quota-window errors ("You've hit your limit", "usage limit reached") were not being classified as rate-limits, so auto-mode stalled instead of switching to a fallback model.
**How:** Expanded `RATE_LIMIT_RE` to cover quota-window phrasing, and moved rate-limit errors out of the early transient-deferral branch so the fallback path executes first.

## What

- `error-classifier.ts` — expanded `RATE_LIMIT_RE` to match Anthropic quota-window phrasing: "hit your limit", "usage limit", "quota reached/hit", "limit resets"
- `bootstrap/agent-end-recovery.ts` — rate-limit errors now bypass the transient core-retry deferral (`cls.kind !== "rate-limit"` guard), so model fallback executes before the core handler can short-circuit; added `setCurrentDispatchedModelId` calls when switching fallback/session model to keep the dashboard label in sync
- `auto.ts` — exported `setCurrentDispatchedModelId` for use in the recovery handler
- `tests/provider-errors.test.ts` — 4 new regression tests: 2 for quota-window classifier coverage, 2 structural assertions for the rate-limit bypass and dashboard sync

## Why

Closes #4373

When Anthropic throttles a session with a quota-window message ("You've hit your limit · resets soon"), the error was not matching `RATE_LIMIT_RE`. It fell through to the generic transient-deferral branch, which returns early and hands off to core's retry handler — which pauses indefinitely with no fallback. Auto-mode stalled until the user manually resumed.

Even when the pattern did match, the `isTransient(cls)` early-return was catching rate-limits before the fallback logic, meaning rate-limit errors never reached the model-switching code.

## How

Two independent fixes composed together:

1. **Pattern expansion** — added `hit your limit|usage limit|quota (?:reached|hit)|limit.*resets?` to `RATE_LIMIT_RE` to cover the quota-window phrasing Anthropic uses.

2. **Execution order fix** — changed the early transient guard from `if (isTransient(cls))` to `if (isTransient(cls) && cls.kind !== "rate-limit")`. This lets rate-limit errors fall through to the model-fallback block where they were already handled — the guard was the only thing stopping them from reaching it.

The `setCurrentDispatchedModelId` fix is independent: after a successful `pi.setModel()`, the auto dashboard was still showing the previous model ID because the dispatched-model state wasn't being updated. Two call sites in the fallback and session-restore paths now update it.

---

- [x] `fix` — Bug fix

> This PR is AI-assisted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automatic fallback to alternative models when rate limits are encountered, improving service continuity.
  * Dashboard now displays the currently active model being used for better transparency.

* **Bug Fixes**
  * Enhanced rate-limit error detection to recognize additional provider-specific quota language variations (e.g., "hit your limit", "usage limit", "quota reached").

<!-- end of auto-generated comment: release notes by coderabbit.ai -->