### PR TITLE
fix(auth): self-heal stale Anthropic OAuth credential (#4399)

### DIFF
--- a/packages/pi-coding-agent/src/core/auth-storage.test.ts
+++ b/packages/pi-coding-agent/src/core/auth-storage.test.ts
@@ -610,3 +610,45 @@ describe("AuthStorage — hasLegacyOAuthCredential (#4280)", () => {
 		assert.equal(storage.hasLegacyOAuthCredential("github-copilot"), true);
 	});
 });
+
+// ─── removeLegacyOAuthCredential (self-heal for #3952 / #4368) ───────────────
+
+describe("AuthStorage — removeLegacyOAuthCredential (#4368)", () => {
+	it("removes oauth entry and returns true when present", () => {
+		const storage = inMemory({
+			anthropic: {
+				type: "oauth",
+				access: "fake",
+				refresh: "fake",
+				expires: Date.now() + 3_600_000,
+			},
+		});
+		assert.equal(storage.removeLegacyOAuthCredential("anthropic"), true);
+		assert.equal(storage.hasLegacyOAuthCredential("anthropic"), false);
+		assert.equal(storage.has("anthropic"), false);
+	});
+
+	it("returns false when no oauth entry exists", () => {
+		const storage = inMemory({ anthropic: makeKey("sk-ant-fake") });
+		assert.equal(storage.removeLegacyOAuthCredential("anthropic"), false);
+		assert.equal(storage.get("anthropic")?.type, "api_key");
+	});
+
+	it("preserves api_key credentials alongside oauth entry", () => {
+		const storage = inMemory({
+			anthropic: [
+				makeKey("sk-ant-keep"),
+				{
+					type: "oauth",
+					access: "fake",
+					refresh: "fake",
+					expires: Date.now() + 3_600_000,
+				},
+			],
+		});
+		assert.equal(storage.removeLegacyOAuthCredential("anthropic"), true);
+		const remaining = storage.getCredentialsForProvider("anthropic");
+		assert.equal(remaining.length, 1);
+		assert.equal(remaining[0].type, "api_key");
+	});
+});

--- a/packages/pi-coding-agent/src/core/auth-storage.ts
+++ b/packages/pi-coding-agent/src/core/auth-storage.ts
@@ -476,6 +476,31 @@ export class AuthStorage {
 	}
 
 	/**
+	 * Remove only oauth-type credentials for a provider, preserving any api_key
+	 * entries. Used to self-heal stale OAuth credentials for providers where
+	 * OAuth support has been removed (e.g. Anthropic, #3952) without destroying
+	 * a user's valid API keys. Returns true if any oauth entries were removed.
+	 */
+	removeLegacyOAuthCredential(provider: string): boolean {
+		const existing = this.getCredentialsForProvider(provider);
+		const remaining = existing.filter((c) => c.type !== "oauth");
+		if (remaining.length === existing.length) return false;
+
+		if (remaining.length === 0) {
+			delete this.data[provider];
+			this.persistProviderChange(provider, undefined);
+		} else {
+			const next = remaining.length === 1 ? remaining[0] : remaining;
+			this.data[provider] = next;
+			this.persistProviderChange(provider, next);
+		}
+		this.providerRoundRobinIndex.delete(provider);
+		this.credentialBackoff.delete(provider);
+		this.providerBackoff.delete(provider);
+		return true;
+	}
+
+	/**
 	 * Get all credentials (for passing to getOAuthApiKey).
 	 * Returns normalized format where each provider has a single credential
 	 * (the first one) for backward compatibility with OAuth refresh.

--- a/packages/pi-coding-agent/src/core/sdk.ts
+++ b/packages/pi-coding-agent/src/core/sdk.ts
@@ -1,4 +1,16 @@
+import { existsSync } from "node:fs";
 import { join } from "node:path";
+
+/**
+ * Lightweight PATH scan for the `claude` binary — no subprocess, no network.
+ * Mirrors the check in src/resources/extensions/gsd/doctor-providers.ts so the
+ * legacy Anthropic OAuth self-heal path can only trigger when the user has a
+ * working Claude Code CLI to fall back to.
+ */
+function isClaudeCodeBinaryInPath(): boolean {
+	const pathDirs = (process.env.PATH ?? "").split(":");
+	return pathDirs.some((dir) => dir && existsSync(join(dir, "claude")));
+}
 
 /**
  * Structured error thrown when all credentials for a provider are in a
@@ -441,15 +453,30 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				// Anthropic OAuth was removed in v2.74.0 for TOS compliance (#3952).
 				// Users who upgraded from an older version may still have OAuth
 				// credentials in auth.json that will never resolve to a valid API key.
-				// Surface a targeted migration message instead of the generic cooldown.
 				if (
 					resolvedProvider === "anthropic" &&
 					modelRegistry.authStorage.hasLegacyOAuthCredential(resolvedProvider)
 				) {
+					// Self-heal: strip the stale oauth entry so hasAuth() stops lying
+					// about anthropic being configured. This preserves any api_key
+					// credentials alongside it.
+					const removed = modelRegistry.authStorage.removeLegacyOAuthCredential(resolvedProvider);
+					if (removed) {
+						console.warn(
+							`[auth] Removed unsupported Anthropic OAuth credential from auth.json (#3952).`,
+						);
+					}
+					if (isClaudeCodeBinaryInPath()) {
+						throw new Error(
+							`Removed stale Anthropic OAuth credential (OAuth support removed in v2.74.0). ` +
+								`Your current model's provider is set to "anthropic" but the local Claude Code CLI ` +
+								`is available — switch the model's provider to "claude-code" in your preferences ` +
+								`to use it, or set ANTHROPIC_API_KEY to continue with the Anthropic API directly.`,
+						);
+					}
 					throw new Error(
-						`Your Anthropic credentials were set up via OAuth, which is no longer supported. ` +
-							`Please re-authenticate: run '/login', select 'Paste an API key' → Anthropic. ` +
-							`Alternatively, switch to the Claude Code CLI provider.`,
+						`Removed stale Anthropic OAuth credential (OAuth support removed in v2.74.0). ` +
+							`Set ANTHROPIC_API_KEY, run '/login' and paste an API key, or switch to a different provider.`,
 					);
 				}
 				const expiry = modelRegistry.authStorage.getEarliestBackoffExpiry(resolvedProvider);


### PR DESCRIPTION
## Summary

- Self-heal stale Anthropic OAuth credentials in `auth.json` (fallout from #3952) instead of forcing users to hand-edit the file.
- When detected: strip only `type:"oauth"` entries (preserving any api_key), log a one-line warning, then throw an actionable message — pointing to the `claude-code` provider if the `claude` binary is in PATH, otherwise to `ANTHROPIC_API_KEY`.
- Adds 3 regression tests for `removeLegacyOAuthCredential`.

Closes #4399

## Background

#3952 (`c2acb1fb4`) removed the Anthropic OAuth flow for TOS compliance. #4308 (`2dab94ad0`) replaced the generic cooldown error with a targeted migration message, but did not clean up the stale entry. That left `hasAuth("anthropic")` reporting true indefinitely and masking the `claude-code` fallback path — the only workaround was editing `auth.json` by hand.

## Changes

- `packages/pi-coding-agent/src/core/auth-storage.ts` — new `removeLegacyOAuthCredential(provider)` method.
- `packages/pi-coding-agent/src/core/sdk.ts` — add `isClaudeCodeBinaryInPath()` PATH scan (mirrors the one in `doctor-providers.ts`); rewrite the legacy-OAuth branch to self-heal and surface an actionable error.
- `packages/pi-coding-agent/src/core/auth-storage.test.ts` — 3 new tests covering removal, preservation of api_key, and no-op when absent.

## Test plan

- [x] `npm run build:pi-coding-agent` clean
- [x] `node --test packages/pi-coding-agent/dist/core/auth-storage.test.js` — 49/49 pass (3 new)
- [ ] Manual: with a stale `anthropic` oauth entry in `auth.json` and `claude` in PATH, trigger a request and confirm the credential is removed and the new error text appears.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to remove stale legacy OAuth credentials during authentication resolution.
  * Enhanced error messaging with provider-specific guidance for credential migration.

* **Bug Fixes**
  * Improved handling of mixed credential types to prevent authentication failures.

* **Tests**
  * Added test coverage for legacy credential removal functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->