### PR TITLE
feat(routing): allow_flat_rate_providers opt-in for claude-code subscribers (#4386)

### DIFF
--- a/docs/user-docs/dynamic-model-routing.md
+++ b/docs/user-docs/dynamic-model-routing.md
@@ -48,7 +48,23 @@ dynamic_routing:
   cross_provider: true            # consider models from other providers (default: true)
   hooks: true                     # apply routing to post-unit hooks (default: true)
   capability_routing: true        # enable capability scoring within tier (default: true)
+  allow_flat_rate_providers: false # opt into routing for flat-rate providers (default: false)
 ```
+
+### `allow_flat_rate_providers`
+
+By default, dynamic routing is suppressed when the active provider is flat-rate (`claude-code`, GitHub Copilot, user-declared subscription proxies, or `externalCli` providers) because per-request cost is identical and downgrading only degrades quality.
+
+Set to `true` to opt into routing across a flat-rate subscription — useful when you want intelligent per-task selection (e.g. haiku for research, opus for architecture) within a single subscription's token budget:
+
+```yaml
+dynamic_routing:
+  enabled: true
+  allow_flat_rate_providers: true
+  cross_provider: false           # recommended: keep routing inside the subscription
+```
+
+Keep `cross_provider: false` when enabling this flag unless every flat-rate provider you use exposes the full tier of models — otherwise the router may attempt to escape to a provider you haven't configured.
 
 ### `tier_models`
 

--- a/src/resources/extensions/gsd/auto-model-selection.ts
+++ b/src/resources/extensions/gsd/auto-model-selection.ts
@@ -42,7 +42,15 @@ export function resolvePreferredModelConfig(
   if (!routingConfig.enabled || !routingConfig.tier_models) return undefined;
 
   // Don't synthesize a routing config for flat-rate providers (#3453).
-  if (autoModeStartModel && isFlatRateProvider(autoModeStartModel.provider, autoModeStartModel.flatRateCtx)) return undefined;
+  // Users can opt into routing for flat-rate subscriptions (e.g. claude-code)
+  // via dynamic_routing.allow_flat_rate_providers (#4386).
+  if (
+    !routingConfig.allow_flat_rate_providers &&
+    autoModeStartModel &&
+    isFlatRateProvider(autoModeStartModel.provider, autoModeStartModel.flatRateCtx)
+  ) {
+    return undefined;
+  }
 
   const ceilingModel = routingConfig.tier_models.heavy
     ?? (autoModeStartModel ? `${autoModeStartModel.provider}/${autoModeStartModel.id}` : undefined);
@@ -152,7 +160,10 @@ export async function selectAndApplyModel(
     // model provides no cost benefit — it only degrades quality.
     // Fail-closed: if primary model can't be resolved, fall back to
     // provider-level signals rather than allowing unwanted downgrades.
-    if (routingConfig.enabled) {
+    // Opt-in: dynamic_routing.allow_flat_rate_providers skips the bypass so
+    // claude-code subscribers can still get intelligent per-task selection
+    // across their subscription (#4386).
+    if (routingConfig.enabled && !routingConfig.allow_flat_rate_providers) {
       const primaryModel = resolveModelId(modelConfig.primary, routingEligibleModels, ctx.model?.provider);
       if (primaryModel) {
         const primaryFlatRateCtx = buildFlatRateContext(primaryModel.provider, ctx, prefs);

--- a/src/resources/extensions/gsd/auto-start.ts
+++ b/src/resources/extensions/gsd/auto-start.ts
@@ -837,10 +837,11 @@ export async function bootstrapAutoSession(
     const bannerPrefs = loadEffectiveGSDPreferences()?.preferences;
     const effectiveProvider = s.autoModeStartModel?.provider ?? ctx.model?.provider;
     const effectivelyEnabled = routingConfig.enabled
-      && !(effectiveProvider && isFlatRateProvider(
-        effectiveProvider,
-        buildFlatRateContext(effectiveProvider, ctx, bannerPrefs),
-      ));
+      && (routingConfig.allow_flat_rate_providers
+        || !(effectiveProvider && isFlatRateProvider(
+          effectiveProvider,
+          buildFlatRateContext(effectiveProvider, ctx, bannerPrefs),
+        )));
 
     // The actual ceiling may come from tier_models.heavy, not the start model.
     const effectiveCeiling = (routingConfig.enabled && routingConfig.tier_models?.heavy)

--- a/src/resources/extensions/gsd/model-router.ts
+++ b/src/resources/extensions/gsd/model-router.ts
@@ -23,6 +23,14 @@ export interface DynamicRoutingConfig {
   budget_pressure?: boolean;       // default: true
   cross_provider?: boolean;        // default: true
   hooks?: boolean;                 // default: true
+  /**
+   * Opt into dynamic routing for flat-rate providers (e.g. claude-code,
+   * GitHub Copilot). Default false preserves the #3453 bypass that skips
+   * routing when the subscription makes per-request cost identical.
+   * Enable only when you want per-task model selection across a flat-rate
+   * subscription (e.g. haiku for research, opus for architecture). (#4386)
+   */
+  allow_flat_rate_providers?: boolean;
 }
 
 export interface RoutingDecision {

--- a/src/resources/extensions/gsd/preferences-validation.ts
+++ b/src/resources/extensions/gsd/preferences-validation.ts
@@ -560,6 +560,10 @@ export function validatePreferences(preferences: GSDPreferences): {
         if (typeof dr.capability_routing === "boolean") validDr.capability_routing = dr.capability_routing;
         else errors.push("dynamic_routing.capability_routing must be a boolean");
       }
+      if (dr.allow_flat_rate_providers !== undefined) {
+        if (typeof dr.allow_flat_rate_providers === "boolean") validDr.allow_flat_rate_providers = dr.allow_flat_rate_providers;
+        else errors.push("dynamic_routing.allow_flat_rate_providers must be a boolean");
+      }
       if (dr.tier_models !== undefined) {
         if (typeof dr.tier_models === "object" && dr.tier_models !== null) {
           const tm = dr.tier_models as Record<string, unknown>;

--- a/src/resources/extensions/gsd/tests/flat-rate-routing-guard.test.ts
+++ b/src/resources/extensions/gsd/tests/flat-rate-routing-guard.test.ts
@@ -6,7 +6,13 @@
 
 import { describe, test } from "node:test";
 import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { buildFlatRateContext, isFlatRateProvider, resolvePreferredModelConfig } from "../auto-model-selection.ts";
+
+const __dirname_4386 = dirname(fileURLToPath(import.meta.url));
 
 describe("flat-rate provider routing guard (#3453)", () => {
 
@@ -182,5 +188,105 @@ describe("buildFlatRateContext()", () => {
     };
     const result = buildFlatRateContext("anything", ctx);
     assert.equal(result.authMode, undefined);
+  });
+});
+
+// ─── #4386: allow_flat_rate_providers opt-in ────────────────────────────────
+
+describe("flat-rate routing opt-in (#4386)", () => {
+  function withPrefs(prefsYaml: string, fn: () => void): void {
+    const originalCwd = process.cwd();
+    const originalGsdHome = process.env.GSD_HOME;
+    const tempProject = mkdtempSync(join(tmpdir(), "gsd-4386-project-"));
+    const tempGsdHome = mkdtempSync(join(tmpdir(), "gsd-4386-home-"));
+    try {
+      mkdirSync(join(tempProject, ".gsd"), { recursive: true });
+      writeFileSync(
+        join(tempProject, ".gsd", "PREFERENCES.md"),
+        ["---", "version: 1", prefsYaml, "---"].join("\n"),
+        "utf-8",
+      );
+      process.env.GSD_HOME = tempGsdHome;
+      process.chdir(tempProject);
+      fn();
+    } finally {
+      process.chdir(originalCwd);
+      if (originalGsdHome === undefined) delete process.env.GSD_HOME;
+      else process.env.GSD_HOME = originalGsdHome;
+      rmSync(tempProject, { recursive: true, force: true });
+      rmSync(tempGsdHome, { recursive: true, force: true });
+    }
+  }
+
+  test("default (opt-in absent): flat-rate start model still returns undefined", () => {
+    withPrefs(
+      [
+        "dynamic_routing:",
+        "  enabled: true",
+        "  tier_models:",
+        "    heavy: claude-opus-4-6",
+      ].join("\n"),
+      () => {
+        const result = resolvePreferredModelConfig("execute-task", {
+          provider: "claude-code",
+          id: "claude-opus-4-6",
+        });
+        assert.equal(result, undefined, "default must preserve #3453 bypass");
+      },
+    );
+  });
+
+  test("opt-in: synthesizes a routing config for flat-rate start model", () => {
+    withPrefs(
+      [
+        "dynamic_routing:",
+        "  enabled: true",
+        "  allow_flat_rate_providers: true",
+        "  tier_models:",
+        "    heavy: claude-opus-4-6",
+      ].join("\n"),
+      () => {
+        const result = resolvePreferredModelConfig("execute-task", {
+          provider: "claude-code",
+          id: "claude-opus-4-6",
+        });
+        assert.ok(result, "routing config should be synthesized");
+        assert.equal(result!.primary, "claude-opus-4-6");
+      },
+    );
+  });
+
+  test("explicit opt-out: flat-rate bypass still fires", () => {
+    withPrefs(
+      [
+        "dynamic_routing:",
+        "  enabled: true",
+        "  allow_flat_rate_providers: false",
+        "  tier_models:",
+        "    heavy: claude-opus-4-6",
+      ].join("\n"),
+      () => {
+        const result = resolvePreferredModelConfig("execute-task", {
+          provider: "claude-code",
+          id: "claude-opus-4-6",
+        });
+        assert.equal(result, undefined, "explicit opt-out behaves like default");
+      },
+    );
+  });
+});
+
+// ─── Banner transparency: auto-start respects the opt-in (#4386) ────────────
+
+describe("auto-start banner respects allow_flat_rate_providers (#4386)", () => {
+  test("banner expression gates flat-rate disable on allow_flat_rate_providers", () => {
+    const src = readFileSync(
+      join(__dirname_4386, "..", "auto-start.ts"),
+      "utf-8",
+    );
+    assert.ok(
+      src.includes("routingConfig.allow_flat_rate_providers"),
+      "auto-start banner must read allow_flat_rate_providers so the banner reflects the opt-in",
+    );
   });
 });


### PR DESCRIPTION
## Summary

- Add `dynamic_routing.allow_flat_rate_providers` (default `false`) so users on flat-rate subscriptions (`claude-code`, GitHub Copilot, `externalCli` CLIs) can opt into intelligent per-task model selection.
- All three flat-rate guard sites now respect the flag: config synthesis (`resolvePreferredModelConfig`), dispatch-time gate (`selectAndApplyModel`), and the auto-mode banner.
- Validation layer accepts the new boolean field; docs updated with guidance to keep `cross_provider: false` when opting in.

Closes #4386

## Background

PR #3453 introduced a blanket suppression of dynamic routing for flat-rate providers because per-request cost is identical. For `claude-code` subscribers that is the wrong default — they want haiku for research, opus for architecture, all within the same flat-rate subscription. This PR makes the suppression an opt-out rather than a mandatory bypass.

## Changes

- `src/resources/extensions/gsd/model-router.ts` — add `allow_flat_rate_providers?: boolean` to `DynamicRoutingConfig` with a docstring explaining the tradeoff.
- `src/resources/extensions/gsd/auto-model-selection.ts` — wrap both the config-synthesis guard (line 45) and the dispatch-time guard (line 155) with `!routingConfig.allow_flat_rate_providers`.
- `src/resources/extensions/gsd/auto-start.ts` — banner `effectivelyEnabled` respects the opt-in so UX matches behavior.
- `src/resources/extensions/gsd/preferences-validation.ts` — validate the new boolean.
- `docs/user-docs/dynamic-model-routing.md` — document with a recommendation to keep `cross_provider: false` to prevent accidental escape to unconfigured providers.
- `src/resources/extensions/gsd/tests/flat-rate-routing-guard.test.ts` — 4 new tests: default preserves bypass, opt-in synthesizes config, explicit opt-out equals default, banner reads the flag.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `flat-rate-routing-guard.test.ts` — 23/23 pass (4 new)
- [x] `preferences.test.ts`, `interactive-routing-bypass.test.ts` — 85/85 pass
- [ ] Manual: set `allow_flat_rate_providers: true` on a `claude-code` setup, run auto-mode, confirm banner shows "enabled" and tier routing is applied.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new configuration option to control whether dynamic routing is applied to flat-rate providers. By default, routing remains disabled for flat-rate subscriptions. Users can now opt-in to enable routing for these providers via configuration.

* **Documentation**
  * Updated documentation with guidance on the new flat-rate provider routing configuration option and usage recommendations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->