### PR TITLE
feat(gsd): ADR-011 Phase 1 progressive planning (sketch-then-refine)

### DIFF
--- a/src/resources/extensions/gsd/auto-artifact-paths.ts
+++ b/src/resources/extensions/gsd/auto-artifact-paths.ts
@@ -50,6 +50,11 @@ export function resolveExpectedArtifactPath(
       const dir = resolveSlicePath(base, mid, sid!);
       return dir ? join(dir, buildSliceFileName(sid!, "PLAN")) : null;
     }
+    case "refine-slice": {
+      // ADR-011: refine-slice expands a sketch and writes the same PLAN.md as plan-slice.
+      const dir = resolveSlicePath(base, mid, sid!);
+      return dir ? join(dir, buildSliceFileName(sid!, "PLAN")) : null;
+    }
     case "reassess-roadmap": {
       const dir = resolveSlicePath(base, mid, sid!);
       return dir ? join(dir, buildSliceFileName(sid!, "ASSESSMENT")) : null;
@@ -112,6 +117,8 @@ export function diagnoseExpectedArtifact(
       return `${relSliceFile(base, mid, sid!, "RESEARCH")} (slice research)`;
     case "plan-slice":
       return `${relSliceFile(base, mid, sid!, "PLAN")} (slice plan)`;
+    case "refine-slice":
+      return `${relSliceFile(base, mid, sid!, "PLAN")} (refined slice plan from sketch)`;
     case "execute-task": {
       return `Task ${tid} marked [x] in ${relSliceFile(base, mid, sid!, "PLAN")} + summary written`;
     }

--- a/src/resources/extensions/gsd/auto-dashboard.ts
+++ b/src/resources/extensions/gsd/auto-dashboard.ts
@@ -96,6 +96,7 @@ export function unitVerb(unitType: string): string {
     case "research-slice": return "researching";
     case "plan-milestone":
     case "plan-slice": return "planning";
+    case "refine-slice": return "refining";
     case "execute-task": return "executing";
     case "complete-slice": return "completing";
     case "replan-slice": return "replanning";
@@ -116,6 +117,7 @@ export function unitPhaseLabel(unitType: string): string {
     case "research-slice": return "RESEARCH";
     case "plan-milestone": return "PLAN";
     case "plan-slice": return "PLAN";
+    case "refine-slice": return "REFINE";
     case "execute-task": return "EXECUTE";
     case "complete-slice": return "COMPLETE";
     case "replan-slice": return "REPLAN";
@@ -143,6 +145,7 @@ function peekNext(unitType: string, state: GSDState): string {
     case "plan-milestone": return "plan or execute first slice";
     case "research-slice": return `plan ${sid}`;
     case "plan-slice": return "execute first task";
+    case "refine-slice": return "execute first task";
     case "execute-task": return `continue ${sid}`;
     case "complete-slice": return "reassess roadmap";
     case "replan-slice": return `re-execute ${sid}`;

--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -39,6 +39,7 @@ import {
   buildPlanMilestonePrompt,
   buildResearchSlicePrompt,
   buildPlanSlicePrompt,
+  buildRefineSlicePrompt,
   buildExecuteTaskPrompt,
   buildCompleteSlicePrompt,
   buildCompleteMilestonePrompt,
@@ -477,6 +478,58 @@ export const DISPATCH_RULES: DispatchRule[] = [
           sTitle,
           basePath,
         ),
+      };
+    },
+  },
+  {
+    // ADR-011: sketch-then-refine. When `refining` phase fires, expand the
+    // sketch into a full plan using the prior slice's SUMMARY and the current
+    // codebase. If the user flipped `progressive_planning` off mid-milestone
+    // while a slice is still `is_sketch=1`, fall through to a standard
+    // plan-slice so the loop doesn't dead-end.
+    //
+    // Note on the flag-OFF downgrade: plan-slice does not explicitly clear
+    // `is_sketch`. After it writes PLAN.md, the auto-heal in state.ts's
+    // `deriveStateFromDb` (via `autoHealSketchFlags`) flips the flag on the
+    // next iteration. That implicit coupling is the sole mechanism that
+    // reconciles `is_sketch=1` on the plan-slice path — do not remove the
+    // auto-heal without either adding an explicit `setSliceSketchFlag(..., false)`
+    // call here or doing so inside the plan-slice tool handler.
+    name: "refining → refine-slice",
+    match: async ({ state, mid, midTitle, basePath, prefs }) => {
+      if (state.phase !== "refining") return null;
+      if (!state.activeSlice) return missingSliceStop(mid, state.phase);
+      const sid = state.activeSlice.id;
+      const sTitle = state.activeSlice.title;
+      const progressiveOn = prefs?.phases?.progressive_planning === true;
+      if (!progressiveOn) {
+        // Graceful downgrade: treat the sketch as a normal slice needing a plan,
+        // but forward the stored sketch_scope as a SOFT hint so the scope
+        // signal isn't silently lost. The planner may expand beyond it.
+        let softScopeHint = "";
+        try {
+          const { isDbAvailable, getSlice } = await import("./gsd-db.js");
+          if (isDbAvailable()) {
+            softScopeHint = getSlice(mid, sid)?.sketch_scope ?? "";
+          }
+        } catch {
+          softScopeHint = "";
+        }
+        return {
+          action: "dispatch",
+          unitType: "plan-slice",
+          unitId: `${mid}/${sid}`,
+          prompt: await buildPlanSlicePrompt(
+            mid, midTitle, sid, sTitle, basePath, undefined,
+            softScopeHint ? { softScopeHint } : undefined,
+          ),
+        };
+      }
+      return {
+        action: "dispatch",
+        unitType: "refine-slice",
+        unitId: `${mid}/${sid}`,
+        prompt: await buildRefineSlicePrompt(mid, midTitle, sid, sTitle, basePath),
       };
     },
   },

--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -99,7 +99,7 @@ function enqueueSidecar(
  *  next actual task commit via `smartStage()`. */
 const LIFECYCLE_ONLY_UNITS = new Set([
   "research-milestone", "discuss-milestone", "discuss-slice", "plan-milestone",
-  "validate-milestone", "research-slice", "plan-slice",
+  "validate-milestone", "research-slice", "plan-slice", "refine-slice",
   "replan-slice", "complete-slice", "run-uat",
   "reassess-roadmap", "rewrite-docs",
 ]);
@@ -190,7 +190,7 @@ export function detectRogueFileWrites(
     if (!hasPlanningState) {
       rogues.push({ path: roadmapPath, unitType, unitId });
     }
-  } else if (unitType === "plan-slice" || unitType === "replan-slice") {
+  } else if (unitType === "plan-slice" || unitType === "refine-slice" || unitType === "replan-slice") {
     if (!mid || !sid) return [];
 
     const planPath = resolveSliceFile(basePath, mid, sid, "PLAN");
@@ -1020,10 +1020,12 @@ export async function postUnitPostVerification(pctx: PostUnitContext): Promise<"
     }
   }
 
-  // ── Pre-execution checks (after plan-slice completes) ──
+  // ── Pre-execution checks (after plan-slice or ADR-011 refine-slice completes) ──
+  // Both emit the same PLAN.md + task artifacts via gsd_plan_slice, so the
+  // same structural validation applies to both.
   if (
     s.currentUnit &&
-    s.currentUnit.type === "plan-slice"
+    (s.currentUnit.type === "plan-slice" || s.currentUnit.type === "refine-slice")
   ) {
     const currentUnit = s.currentUnit;
     let preExecPauseNeeded = false;

--- a/src/resources/extensions/gsd/auto-prompts.ts
+++ b/src/resources/extensions/gsd/auto-prompts.ts
@@ -1216,10 +1216,28 @@ export async function buildResearchSlicePrompt(
   });
 }
 
-export async function buildPlanSlicePrompt(
-  mid: string, _midTitle: string, sid: string, sTitle: string, base: string, level?: InlineLevel,
-): Promise<string> {
-  const inlineLevel = level ?? resolveInlineLevel();
+/**
+ * Shared assembly for plan-slice and refine-slice prompts. Both builders need
+ * the same inlined context (roadmap excerpt, slice context, research, decisions,
+ * requirements, knowledge, graph subgraph, templates, dependency summaries,
+ * overrides). Extracted to prevent drift between the two sites.
+ *
+ * `prependBlocks` are pushed onto the start of the inlined array BEFORE any
+ * shared content, so callers can add unit-specific headers (e.g., the refine
+ * sketch-scope constraint).
+ */
+async function renderSlicePrompt(options: {
+  mid: string;
+  sid: string;
+  sTitle: string;
+  base: string;
+  level: InlineLevel;
+  promptTemplate: "plan-slice" | "refine-slice";
+  prependBlocks?: string[];
+  extraVars?: Record<string, string>;
+}): Promise<string> {
+  const { mid, sid, sTitle, base, level, promptTemplate, prependBlocks = [], extraVars = {} } = options;
+
   const roadmapPath = resolveMilestoneFile(base, mid, "ROADMAP");
   const roadmapRel = relMilestoneFile(base, mid, "ROADMAP");
   const researchPath = resolveSliceFile(base, mid, sid, "RESEARCH");
@@ -1227,18 +1245,17 @@ export async function buildPlanSlicePrompt(
   const sliceContextPath = resolveSliceFile(base, mid, sid, "CONTEXT");
   const sliceContextRel = relSliceFile(base, mid, sid, "CONTEXT");
 
-  const inlined: string[] = [];
+  const inlined: string[] = [...prependBlocks];
 
-  // Inject phase handoff anchor from research phase (if available)
+  // Phase handoff anchor from research phase (if available)
   const researchSliceAnchor = readPhaseAnchor(base, mid, "research-slice");
   if (researchSliceAnchor) inlined.push(formatAnchorForPrompt(researchSliceAnchor));
 
-  // Use roadmap excerpt instead of full roadmap for context reduction
-  const roadmapExcerptPS = await inlineRoadmapExcerpt(base, mid, sid);
-  if (roadmapExcerptPS) {
-    inlined.push(roadmapExcerptPS);
+  // Roadmap excerpt with full-roadmap fallback
+  const roadmapExcerpt = await inlineRoadmapExcerpt(base, mid, sid);
+  if (roadmapExcerpt) {
+    inlined.push(roadmapExcerpt);
   } else {
-    // Fall back to full roadmap if excerpt fails
     inlined.push(await inlineFile(roadmapPath, roadmapRel, "Milestone Roadmap"));
   }
 
@@ -1246,42 +1263,36 @@ export async function buildPlanSlicePrompt(
   if (sliceCtxInline) inlined.push(sliceCtxInline);
   const researchInline = await inlineFileOptional(researchPath, researchRel, "Slice Research");
   if (researchInline) inlined.push(researchInline);
-  if (inlineLevel !== "minimal") {
-    // Derive scope from slice title for decision filtering (R005)
-    const derivedScopePS = deriveSliceScope(sTitle);
-    const decisionsInline = await inlineDecisionsFromDb(base, mid, derivedScopePS, inlineLevel);
+
+  if (level !== "minimal") {
+    const derivedScope = deriveSliceScope(sTitle);
+    const decisionsInline = await inlineDecisionsFromDb(base, mid, derivedScope, level);
     if (decisionsInline) inlined.push(decisionsInline);
-    const requirementsInline = await inlineRequirementsFromDb(base, mid, sid, inlineLevel);
+    const requirementsInline = await inlineRequirementsFromDb(base, mid, sid, level);
     if (requirementsInline) inlined.push(requirementsInline);
   }
 
-  // Use scoped knowledge based on slice title keywords
-  const keywordsPS = extractKeywords(sTitle);
-  const knowledgeInlinePS = await inlineKnowledgeScoped(base, keywordsPS);
-  if (knowledgeInlinePS) inlined.push(knowledgeInlinePS);
+  const knowledgeInline = await inlineKnowledgeScoped(base, extractKeywords(sTitle));
+  if (knowledgeInline) inlined.push(knowledgeInline);
 
-  // Knowledge graph: subgraph for this slice (graceful — skipped if no graph.json)
-  const graphBlockPS = await inlineGraphSubgraph(base, `${sid} ${sTitle}`, { budget: 3000 });
-  if (graphBlockPS) inlined.push(graphBlockPS);
+  const graphBlock = await inlineGraphSubgraph(base, `${sid} ${sTitle}`, { budget: 3000 });
+  if (graphBlock) inlined.push(graphBlock);
 
   inlined.push(inlineTemplate("plan", "Slice Plan"));
-  if (inlineLevel === "full") {
+  if (level === "full") {
     inlined.push(inlineTemplate("task-plan", "Task Plan"));
   }
 
   const depContent = await inlineDependencySummaries(mid, sid, base);
-  const planActiveOverrides = await loadActiveOverrides(base);
-  const planOverridesInline = formatOverridesSection(planActiveOverrides);
-  if (planOverridesInline) inlined.unshift(planOverridesInline);
+  const overridesInline = formatOverridesSection(await loadActiveOverrides(base));
+  if (overridesInline) inlined.unshift(overridesInline);
 
   const inlinedContext = capPreamble(`## Inlined Context (preloaded — do not re-read these files)\n\n${inlined.join("\n\n---\n\n")}`);
-
-  // Build executor context constraints from the budget engine
   const executorContextConstraints = formatExecutorConstraints();
-
   const outputRelPath = relSliceFile(base, mid, sid, "PLAN");
   const commitInstruction = "Do not commit — .gsd/ planning docs are managed externally and not tracked in git.";
-  return loadPrompt("plan-slice", {
+
+  return loadPrompt(promptTemplate, {
     workingDirectory: base,
     milestoneId: mid, sliceId: sid, sliceTitle: sTitle,
     slicePath: relSlicePath(base, mid, sid),
@@ -1300,6 +1311,68 @@ export async function buildPlanSlicePrompt(
       sliceTitle: sTitle,
       extraContext: [inlinedContext, depContent],
     }),
+    ...extraVars,
+  });
+}
+
+export async function buildPlanSlicePrompt(
+  mid: string, _midTitle: string, sid: string, sTitle: string, base: string, level?: InlineLevel,
+  options?: { softScopeHint?: string },
+): Promise<string> {
+  const prependBlocks: string[] = [];
+  // ADR-011: when the refining-phase dispatch rule gracefully downgrades to
+  // plan-slice (progressive_planning was toggled off mid-milestone), it
+  // forwards the stored sketch_scope as a SOFT hint — context, not a hard
+  // constraint. The planner is free to expand beyond it.
+  if (options?.softScopeHint && options.softScopeHint.trim().length > 0) {
+    prependBlocks.push(
+      `## Prior Sketch Scope (soft hint — non-binding)\n\n${options.softScopeHint.trim()}\n\n` +
+      `This scope was captured during an earlier progressive-planning pass that was later disabled. Treat it as context only — you may plan beyond it if the work genuinely requires more scope. Do NOT treat this as a hard boundary.`,
+    );
+  }
+  return renderSlicePrompt({
+    mid, sid, sTitle, base,
+    level: level ?? resolveInlineLevel(),
+    promptTemplate: "plan-slice",
+    prependBlocks,
+  });
+}
+
+/**
+ * ADR-011 refine-slice: expand a sketch into a full plan using the current
+ * codebase state and prior slice summary. Mechanically similar to plan-slice
+ * but framed as a *transformation* (sketch → full plan) rather than a
+ * blank-sheet planning pass. Reuses inlineDependencySummaries for prior
+ * slice SUMMARY and inlines the stored sketch_scope as a hard constraint.
+ */
+export async function buildRefineSlicePrompt(
+  mid: string, _midTitle: string, sid: string, sTitle: string, base: string, level?: InlineLevel,
+): Promise<string> {
+  // Pull the stored sketch scope from the DB — the hard constraint we plan within.
+  let sketchScope = "";
+  try {
+    const { isDbAvailable, getSlice } = await import("./gsd-db.js");
+    if (isDbAvailable()) {
+      sketchScope = getSlice(mid, sid)?.sketch_scope ?? "";
+    }
+  } catch {
+    sketchScope = "";
+  }
+
+  const prependBlocks: string[] = [];
+  if (sketchScope.trim().length > 0) {
+    prependBlocks.push(
+      `## Sketch Scope (hard constraint)\n\n${sketchScope.trim()}\n\n` +
+      `Treat this as the authoritative boundary for the slice. Do not plan work outside this scope; if the scope is too narrow, surface it as a deviation rather than expanding silently.`,
+    );
+  }
+
+  return renderSlicePrompt({
+    mid, sid, sTitle, base,
+    level: level ?? resolveInlineLevel(),
+    promptTemplate: "refine-slice",
+    prependBlocks,
+    extraVars: { sketchScope },
   });
 }
 

--- a/src/resources/extensions/gsd/bootstrap/db-tools.ts
+++ b/src/resources/extensions/gsd/bootstrap/db-tools.ts
@@ -449,10 +449,14 @@ export function registerDbTools(pi: ExtensionAPI): void {
         depends: Type.Array(Type.String(), { description: "Slice dependency IDs" }),
         demo: Type.String({ description: "Roadmap demo text / After this" }),
         goal: Type.String({ description: "Slice goal" }),
-        successCriteria: Type.String({ description: "Slice success criteria block" }),
-        proofLevel: Type.String({ description: "Slice proof level" }),
-        integrationClosure: Type.String({ description: "Slice integration closure" }),
-        observabilityImpact: Type.String({ description: "Slice observability impact" }),
+        // ADR-011: heavy planning fields are optional for sketch slices; required for full slices.
+        successCriteria: Type.Optional(Type.String({ description: "Slice success criteria block (required for full slices; omit for sketches)" })),
+        proofLevel: Type.Optional(Type.String({ description: "Slice proof level (required for full slices; omit for sketches)" })),
+        integrationClosure: Type.Optional(Type.String({ description: "Slice integration closure (required for full slices; omit for sketches)" })),
+        observabilityImpact: Type.Optional(Type.String({ description: "Slice observability impact (required for full slices; omit for sketches)" })),
+        // ADR-011 sketch-then-refine fields.
+        isSketch: Type.Optional(Type.Boolean({ description: "ADR-011: true marks this slice as a sketch awaiting refine-slice expansion" })),
+        sketchScope: Type.Optional(Type.String({ description: "ADR-011: 2–3 sentence scope boundary, required when isSketch=true" })),
       }), { description: "Planned slices for the milestone" }),
       // ── Enrichment metadata (optional — defaults to empty) ────────────
       status: Type.Optional(Type.String({ description: "Milestone status (defaults to active)" })),

--- a/src/resources/extensions/gsd/gsd-db.ts
+++ b/src/resources/extensions/gsd/gsd-db.ts
@@ -180,7 +180,7 @@ function openRawDb(path: string): unknown {
   return new Database(path);
 }
 
-const SCHEMA_VERSION = 15;
+const SCHEMA_VERSION = 16;
 
 function indexExists(db: DbAdapter, name: string): boolean {
   return !!db.prepare(
@@ -334,6 +334,8 @@ function initSchema(db: DbAdapter, fileBacked: boolean): void {
         observability_impact TEXT NOT NULL DEFAULT '',
         sequence INTEGER DEFAULT 0, -- Ordering hint: tools may set this to control execution order
         replan_triggered_at TEXT DEFAULT NULL,
+        is_sketch INTEGER NOT NULL DEFAULT 0, -- ADR-011: 1 = slice is a sketch awaiting refinement
+        sketch_scope TEXT NOT NULL DEFAULT '', -- ADR-011: 2-3 sentence rough scope from plan-milestone
         PRIMARY KEY (milestone_id, id),
         FOREIGN KEY (milestone_id) REFERENCES milestones(id)
       )
@@ -951,6 +953,16 @@ function migrateSchema(db: DbAdapter): void {
       });
     }
 
+    if (currentVersion < 16) {
+      // ADR-011: sketch-then-refine progressive planning
+      ensureColumn(db, "slices", "is_sketch", `ALTER TABLE slices ADD COLUMN is_sketch INTEGER NOT NULL DEFAULT 0`);
+      ensureColumn(db, "slices", "sketch_scope", `ALTER TABLE slices ADD COLUMN sketch_scope TEXT NOT NULL DEFAULT ''`);
+      db.prepare("INSERT INTO schema_version (version, applied_at) VALUES (:version, :applied_at)").run({
+        ":version": 16,
+        ":applied_at": new Date().toISOString(),
+      });
+    }
+
     db.exec("COMMIT");
   } catch (err) {
     db.exec("ROLLBACK");
@@ -1455,16 +1467,20 @@ export function insertSlice(s: {
   depends?: string[];
   demo?: string;
   sequence?: number;
+  isSketch?: boolean;
+  sketchScope?: string;
   planning?: Partial<SlicePlanningRecord>;
 }): void {
   if (!currentDb) throw new GSDError(GSD_STALE_STATE, "gsd-db: No database open");
   currentDb.prepare(
     `INSERT INTO slices (
       milestone_id, id, title, status, risk, depends, demo, created_at,
-      goal, success_criteria, proof_level, integration_closure, observability_impact, sequence
+      goal, success_criteria, proof_level, integration_closure, observability_impact, sequence,
+      is_sketch, sketch_scope
     ) VALUES (
       :milestone_id, :id, :title, :status, :risk, :depends, :demo, :created_at,
-      :goal, :success_criteria, :proof_level, :integration_closure, :observability_impact, :sequence
+      :goal, :success_criteria, :proof_level, :integration_closure, :observability_impact, :sequence,
+      :is_sketch, :sketch_scope
     )
     ON CONFLICT (milestone_id, id) DO UPDATE SET
       title = CASE WHEN :raw_title IS NOT NULL THEN excluded.title ELSE slices.title END,
@@ -1477,7 +1493,9 @@ export function insertSlice(s: {
       proof_level = CASE WHEN :raw_proof_level IS NOT NULL THEN excluded.proof_level ELSE slices.proof_level END,
       integration_closure = CASE WHEN :raw_integration_closure IS NOT NULL THEN excluded.integration_closure ELSE slices.integration_closure END,
       observability_impact = CASE WHEN :raw_observability_impact IS NOT NULL THEN excluded.observability_impact ELSE slices.observability_impact END,
-      sequence = CASE WHEN :raw_sequence IS NOT NULL THEN excluded.sequence ELSE slices.sequence END`,
+      sequence = CASE WHEN :raw_sequence IS NOT NULL THEN excluded.sequence ELSE slices.sequence END,
+      is_sketch = CASE WHEN :raw_is_sketch IS NOT NULL THEN excluded.is_sketch ELSE slices.is_sketch END,
+      sketch_scope = CASE WHEN :raw_sketch_scope IS NOT NULL THEN excluded.sketch_scope ELSE slices.sketch_scope END`,
   ).run({
     ":milestone_id": s.milestoneId,
     ":id": s.id,
@@ -1493,6 +1511,8 @@ export function insertSlice(s: {
     ":integration_closure": s.planning?.integrationClosure ?? "",
     ":observability_impact": s.planning?.observabilityImpact ?? "",
     ":sequence": s.sequence ?? 0,
+    ":is_sketch": s.isSketch ? 1 : 0,
+    ":sketch_scope": s.sketchScope ?? "",
     // Raw sentinel params: NULL when caller omitted the field, used in ON CONFLICT guards
     ":raw_title": s.title ?? null,
     ":raw_risk": s.risk ?? null,
@@ -1503,7 +1523,50 @@ export function insertSlice(s: {
     ":raw_integration_closure": s.planning?.integrationClosure ?? null,
     ":raw_observability_impact": s.planning?.observabilityImpact ?? null,
     ":raw_sequence": s.sequence ?? null,
+    ":raw_is_sketch": s.isSketch === undefined ? null : (s.isSketch ? 1 : 0),
+    // NOTE: use !== undefined (not ??) so an explicit empty string "" is treated
+    // as a present value and correctly clears the existing sketch_scope on
+    // CONFLICT. ?? would incorrectly preserve the stale value.
+    ":raw_sketch_scope": s.sketchScope !== undefined ? s.sketchScope : null,
   });
+}
+
+// ADR-011: sketch-then-refine helpers
+export function setSliceSketchFlag(milestoneId: string, sliceId: string, isSketch: boolean): void {
+  if (!currentDb) throw new GSDError(GSD_STALE_STATE, "gsd-db: No database open");
+  currentDb.prepare(
+    `UPDATE slices SET is_sketch = :is_sketch WHERE milestone_id = :mid AND id = :sid`,
+  ).run({ ":is_sketch": isSketch ? 1 : 0, ":mid": milestoneId, ":sid": sliceId });
+}
+
+/**
+ * ADR-011 auto-heal: reconcile stale is_sketch=1 rows whose PLAN already exists.
+ *
+ * Callers pass a predicate that resolves whether a plan file exists for a slice.
+ * The predicate MUST use the canonical path resolver (`resolveSliceFile`, etc.)
+ * to keep path logic in one place — do not hand-roll the path inside the callback.
+ *
+ * Recovers from two scenarios:
+ *   1. Crash between `gsd_plan_slice` write and the sketch flag flip.
+ *   2. Flag-OFF downgrade path: when `progressive_planning` is off, the dispatch
+ *      rule routes sketch slices to plan-slice, which writes PLAN.md but leaves
+ *      `is_sketch=1` — the next state derivation auto-heals it to 0 here.
+ *
+ * Not aggressive in practice: PLAN.md is only written via the DB-backed
+ * `gsd_plan_slice` tool (which also inserts tasks), so a "stale PLAN.md with
+ * is_sketch=1" is extremely unlikely to indicate anything other than the two
+ * recovery scenarios above.
+ */
+export function autoHealSketchFlags(milestoneId: string, hasPlanFile: (sliceId: string) => boolean): void {
+  if (!currentDb) return;
+  const rows = currentDb.prepare(
+    `SELECT id FROM slices WHERE milestone_id = :mid AND is_sketch = 1`,
+  ).all({ ":mid": milestoneId }) as Array<{ id: string }>;
+  for (const row of rows) {
+    if (hasPlanFile(row.id)) {
+      setSliceSketchFlag(milestoneId, row.id, false);
+    }
+  }
 }
 
 export function upsertSlicePlanning(milestoneId: string, sliceId: string, planning: Partial<SlicePlanningRecord>): void {
@@ -1679,6 +1742,8 @@ export interface SliceRow {
   observability_impact: string;
   sequence: number;
   replan_triggered_at: string | null;
+  is_sketch: number;
+  sketch_scope: string;
 }
 
 function rowToSlice(row: Record<string, unknown>): SliceRow {
@@ -1701,6 +1766,8 @@ function rowToSlice(row: Record<string, unknown>): SliceRow {
     observability_impact: (row["observability_impact"] as string) ?? "",
     sequence: (row["sequence"] as number) ?? 0,
     replan_triggered_at: (row["replan_triggered_at"] as string) ?? null,
+    is_sketch: (row["is_sketch"] as number) ?? 0,
+    sketch_scope: (row["sketch_scope"] as string) ?? "",
   };
 }
 

--- a/src/resources/extensions/gsd/metrics.ts
+++ b/src/resources/extensions/gsd/metrics.ts
@@ -90,6 +90,7 @@ export function classifyUnitPhase(unitType: string): MetricsPhase {
       return "discussion";
     case "plan-milestone":
     case "plan-slice":
+    case "refine-slice":
       return "planning";
     case "execute-task":
       return "execution";

--- a/src/resources/extensions/gsd/preferences-models.ts
+++ b/src/resources/extensions/gsd/preferences-models.ts
@@ -55,6 +55,7 @@ export function resolveModelWithFallbacksForUnit(unitType: string): ResolvedMode
       break;
     case "plan-milestone":
     case "plan-slice":
+    case "refine-slice":
     case "replan-slice":
       phaseConfig = m.planning;
       break;

--- a/src/resources/extensions/gsd/preferences-types.ts
+++ b/src/resources/extensions/gsd/preferences-types.ts
@@ -120,7 +120,7 @@ export const KNOWN_PREFERENCE_KEYS = new Set<string>([
 
 /** Canonical list of all dispatch unit types. */
 export const KNOWN_UNIT_TYPES = [
-  "research-milestone", "plan-milestone", "research-slice", "plan-slice",
+  "research-milestone", "plan-milestone", "research-slice", "plan-slice", "refine-slice",
   "execute-task", "reactive-execute", "gate-evaluate", "complete-slice", "replan-slice", "reassess-roadmap",
   "run-uat", "complete-milestone", "validate-milestone", "rewrite-docs",
   "discuss-milestone", "discuss-slice", "worktree-merge",

--- a/src/resources/extensions/gsd/preferences-validation.ts
+++ b/src/resources/extensions/gsd/preferences-validation.ts
@@ -319,8 +319,9 @@ export function validatePreferences(preferences: GSDPreferences): {
       if (p.skip_milestone_validation !== undefined) validatedPhases.skip_milestone_validation = !!p.skip_milestone_validation;
       if (p.reassess_after_slice !== undefined) validatedPhases.reassess_after_slice = !!p.reassess_after_slice;
       if ((p as any).require_slice_discussion !== undefined) (validatedPhases as any).require_slice_discussion = !!(p as any).require_slice_discussion;
+      if (p.progressive_planning !== undefined) validatedPhases.progressive_planning = !!p.progressive_planning;
       // Warn on unknown phase keys
-      const knownPhaseKeys = new Set(["skip_research", "skip_reassess", "skip_slice_research", "skip_milestone_validation", "reassess_after_slice", "require_slice_discussion"]);
+      const knownPhaseKeys = new Set(["skip_research", "skip_reassess", "skip_slice_research", "skip_milestone_validation", "reassess_after_slice", "require_slice_discussion", "progressive_planning"]);
       for (const key of Object.keys(p)) {
         if (!knownPhaseKeys.has(key)) {
           warnings.push(`unknown phases key "${key}" — ignored`);

--- a/src/resources/extensions/gsd/prompts/plan-milestone.md
+++ b/src/resources/extensions/gsd/prompts/plan-milestone.md
@@ -78,6 +78,18 @@ Apply these when decomposing and ordering slices:
 - **Ambition matches the milestone.** The number and depth of slices should match the milestone's ambition. A milestone promising "core platform with auth, data model, and primary user loop" should have enough slices to actually deliver all three as working features — not two proof-of-concept slices and a note that "the rest will come in the next milestone." If the milestone's context promises an outcome, the roadmap must deliver it.
 - **Right-size the decomposition.** Match slice count to actual complexity. If the work is small enough to build and verify in one pass, it's one slice — don't split it into three just because you can identify sub-steps. Multiple requirements can share a single slice. Conversely, don't cram genuinely independent capabilities into one slice just to keep the count low. Let the work dictate the structure.
 
+## Progressive Planning (ADR-011)
+
+If the preference `phases.progressive_planning` is enabled and the roadmap has **2 or more slices**, you SHOULD plan S01 in full detail and S02+ as sketches. Plan S02+ full only when the slice is trivially determined (pure boilerplate that cannot meaningfully change based on what S01 ships).
+
+A **sketch slice** has the same roadmap entry as today (title, risk, depends, demo line) plus a `sketchScope` of 2–3 sentences describing the scope boundary. Do NOT attempt to decompose it into tasks during this unit — leave `goal`, `successCriteria`, `proofLevel`, `integrationClosure`, `observabilityImpact` blank (or provide them if genuinely known). When the prior slice completes, a separate `refine-slice` unit will expand the sketch into a full plan using the real codebase state and the prior slice SUMMARY.
+
+**To mark a slice as a sketch in the `gsd_plan_milestone` tool call:** set `isSketch: true` and `sketchScope: "<2-3 sentence scope>"` on that slice entry.
+
+S01 is never a sketch — it must always be fully decomposed in this unit.
+
+If the preference is off, ignore this section and plan every slice in full detail as you would normally.
+
 ## Single-Slice Fast Path
 
 If the roadmap has only one slice, also plan the slice and its tasks inline during this unit — don't leave them for a separate planning session.

--- a/src/resources/extensions/gsd/prompts/refine-slice.md
+++ b/src/resources/extensions/gsd/prompts/refine-slice.md
@@ -1,0 +1,69 @@
+You are executing GSD auto-mode.
+
+## UNIT: Refine Slice {{sliceId}} ("{{sliceTitle}}") — Milestone {{milestoneId}}
+
+## Working Directory
+
+Your working directory is `{{workingDirectory}}`. All file reads, writes, and shell commands MUST operate relative to this directory. Do NOT `cd` to any other directory.
+
+This unit **expands an approved sketch into a full plan**. It is not a blank-sheet planning pass — the sketch's scope is the authoritative boundary, and the prior slice's real outcomes are the authoritative context. Your job is to produce a detailed plan that fits inside the sketch while reflecting what actually shipped in earlier slices.
+
+All relevant context has been preloaded below — start working immediately without re-reading these files.
+
+{{inlinedContext}}
+
+### Dependency Slice Summaries
+
+Pay particular attention to **Forward Intelligence** sections — they contain hard-won knowledge about what's fragile, what assumptions changed, and what this slice should watch out for. These summaries are the single most important input to refinement: the sketch was written before these slices shipped, so your plan MUST reconcile against what they actually built.
+
+{{dependencySummaries}}
+
+## Your Role in the Pipeline
+
+### Respect the Sketch Scope
+
+The sketch scope inlined above is a **hard constraint**. Plan within it. If, after exploring the codebase, the scope is too narrow to deliver the goal, surface this as a deviation in the plan's narrative and still produce the plan — do not silently expand the scope.
+
+### Reconcile Against Reality
+
+Before decomposing:
+
+1. Read the prior slice SUMMARY files that were inlined above. Note any interface shifts, file-layout changes, or discovered constraints.
+2. Use `rg`, `find`, and targeted reads to confirm the current codebase state for files the sketch references. If an assumed module/type/API has moved or changed shape, your plan must reflect that.
+3. If prior slices flagged fragility or known issues relevant to this slice, fold them into task verification.
+
+### Source Files
+
+{{sourceFilePaths}}
+
+If slice research exists (inlined above), trust those findings and skip redundant exploration.
+
+After you finish, **executor agents** implement each task in isolated fresh context windows. They see only their task plan, the slice plan excerpt, and compressed summaries of prior tasks. Everything an executor needs must be in the task plan itself — file paths, specific steps, expected inputs and outputs.
+
+Narrate your decomposition reasoning in complete sentences. Explain what the sketch promised, what prior slices changed, and how those two inputs shape the decomposition. Keep narration proportional to the work.
+
+**Right-size the plan.** If the slice is simple enough to be 1 task, plan 1 task. Don't fill in sections with "None" — omit them entirely.
+
+{{executorContextConstraints}}
+
+Then:
+0. If `REQUIREMENTS.md` was preloaded above, identify which Active requirements the sketch says this slice owns or supports. Every owned requirement needs at least one task that directly advances it.
+1. Read the templates:
+   - `~/.gsd/agent/extensions/gsd/templates/plan.md`
+   - `~/.gsd/agent/extensions/gsd/templates/task-plan.md`
+2. {{skillActivation}} Record the installed skills you expect executors to use in each task plan's `skills_used` frontmatter.
+3. Define slice-level verification — the objective stopping condition. Plan real test files with real assertions; for simple slices, executable commands are fine.
+4. For non-trivial slices, plan observability / proof level / integration closure, threat surface, and requirement impact. Omit entirely for simple slices.
+5. Decompose the slice into tasks that fit one context window each. Every task must have Why / Files / Do / Verify / Done-when, plus a task plan with description, steps, must-haves, verification, inputs (backtick-wrapped paths), and expected output (backtick-wrapped paths).
+6. **Persist planning state through `gsd_plan_slice`.** Call it with the full payload. The tool writes to the DB and renders `{{outputPath}}` and `{{slicePath}}/tasks/T##-PLAN.md` automatically. Do NOT rely on direct `PLAN.md` writes.
+7. **Self-audit the plan.** If every task were completed exactly as written, the slice goal/demo should actually be true. Every must-have maps to at least one task. Inputs and Expected Output are backtick-wrapped file paths.
+8. If refinement produced structural decisions that diverge from the sketch, append them to `.gsd/DECISIONS.md`.
+9. {{commitInstruction}}
+
+The slice directory and tasks/ subdirectory already exist. Do NOT mkdir.
+
+**Autonomous execution:** Do not call `ask_user_questions` or `secure_env_collect`. Document assumptions in the plan.
+
+**You MUST call `gsd_plan_slice` to persist the planning state before finishing.** After it returns successfully, the pipeline will automatically clear the sketch flag on the next state derivation (the on-disk PLAN file is the signal).
+
+When done, say: "Slice {{sliceId}} refined."

--- a/src/resources/extensions/gsd/state.ts
+++ b/src/resources/extensions/gsd/state.ts
@@ -44,6 +44,7 @@ import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { debugCount, debugTime } from './debug-logger.js';
 import { logWarning, logError } from './workflow-logger.js';
 import { extractVerdict } from './verdict-parser.js';
+import { loadEffectiveGSDPreferences } from './preferences.js';
 
 import {
   isDbAvailable,
@@ -60,6 +61,7 @@ import {
   updateSliceStatus,
   updateTaskStatus,
   getPendingGateCountForTurn,
+  autoHealSketchFlags,
   type MilestoneRow,
   type SliceRow,
   type TaskRow,
@@ -849,7 +851,15 @@ export async function deriveStateFromDb(basePath: string): Promise<GSDState> {
     return handleAllSlicesDone(basePath, activeMilestone, registry, requirements, milestoneProgress, sliceProgress);
   }
 
-  const activeSliceContext = resolveSliceDependencies(activeMilestoneSlices);
+  // ADR-011 auto-heal: if a slice has a PLAN on disk but is still flagged is_sketch=1
+  // (e.g. a crash between plan-slice write and the sketch flip), reconcile before
+  // running phase derivation so the flag doesn't misroute state.
+  autoHealSketchFlags(activeMilestone.id, (sid) =>
+    !!resolveSliceFile(basePath, activeMilestone.id, sid, "PLAN"),
+  );
+  // Re-read slices after auto-heal so downstream reads see fresh is_sketch values.
+  const healedSlices = getMilestoneSlices(activeMilestone.id);
+  const activeSliceContext = resolveSliceDependencies(healedSlices);
   if (!activeSliceContext.activeSlice) {
     // If locked slice wasn't found, it returns null but logs warning, we need to return 'blocked'
     if (process.env.GSD_SLICE_LOCK) {
@@ -869,10 +879,24 @@ export async function deriveStateFromDb(basePath: string): Promise<GSDState> {
       progress: { milestones: milestoneProgress, slices: sliceProgress },
     };
   }
-  const { activeSlice } = activeSliceContext;
+  const { activeSlice, activeSliceRow } = activeSliceContext;
 
   const planFile = resolveSliceFile(basePath, activeMilestone.id, activeSlice.id, "PLAN");
   if (!planFile) {
+    // ADR-011: sketch slices with progressive_planning enabled enter the
+    // `refining` phase — a refine-slice unit expands the sketch into a full plan
+    // before execution. When the flag is off, sketches are indistinguishable
+    // from a missing plan and fall through to the normal `planning` phase.
+    const progressive = loadEffectiveGSDPreferences()?.preferences?.phases?.progressive_planning === true;
+    if (progressive && activeSliceRow?.is_sketch === 1) {
+      return {
+        activeMilestone, activeSlice, activeTask: null,
+        phase: 'refining', recentDecisions: [], blockers: [],
+        nextAction: `Refine sketch slice ${activeSlice.id} (${activeSlice.title}) using prior slice context.`,
+        registry, requirements,
+        progress: { milestones: milestoneProgress, slices: sliceProgress },
+      };
+    }
     return {
       activeMilestone, activeSlice, activeTask: null,
       phase: 'planning', recentDecisions: [], blockers: [],

--- a/src/resources/extensions/gsd/tests/artifact-corruption-2630.test.ts
+++ b/src/resources/extensions/gsd/tests/artifact-corruption-2630.test.ts
@@ -46,6 +46,8 @@ function makeSliceRow(overrides?: Partial<SliceRow>): SliceRow {
     observability_impact: '',
     sequence: 4,
     replan_triggered_at: null,
+    is_sketch: 0,
+    sketch_scope: '',
     ...overrides,
   };
 }

--- a/src/resources/extensions/gsd/tests/complete-slice.test.ts
+++ b/src/resources/extensions/gsd/tests/complete-slice.test.ts
@@ -125,9 +125,9 @@ console.log('\n=== complete-slice: schema v6 migration ===');
 
   const adapter = _getAdapter()!;
 
-  // Verify schema version is current (v15 with UOK projection tables)
+  // Verify schema version is current (v16 with ADR-011 sketch columns)
   const versionRow = adapter.prepare('SELECT MAX(version) as v FROM schema_version').get();
-  assertEq(versionRow?.['v'], 15, 'schema version should be 15');
+  assertEq(versionRow?.['v'], 16, 'schema version should be 16');
 
   // Verify slices table has full_summary_md and full_uat_md columns
   const cols = adapter.prepare("PRAGMA table_info(slices)").all();

--- a/src/resources/extensions/gsd/tests/complete-task.test.ts
+++ b/src/resources/extensions/gsd/tests/complete-task.test.ts
@@ -109,9 +109,9 @@ console.log('\n=== complete-task: schema v5 migration ===');
 
   const adapter = _getAdapter()!;
 
-  // Verify schema version is current (v15 with UOK projection tables)
+  // Verify schema version is current (v16 with ADR-011 sketch columns)
   const versionRow = adapter.prepare('SELECT MAX(version) as v FROM schema_version').get();
-  assertEq(versionRow?.['v'], 15, 'schema version should be 15');
+  assertEq(versionRow?.['v'], 16, 'schema version should be 16');
 
   // Verify all 4 new tables exist
   const tables = adapter.prepare(

--- a/src/resources/extensions/gsd/tests/gsd-db.test.ts
+++ b/src/resources/extensions/gsd/tests/gsd-db.test.ts
@@ -80,7 +80,7 @@ describe('gsd-db', () => {
     // Check schema_version table
     const adapter = _getAdapter()!;
     const version = adapter.prepare('SELECT MAX(version) as version FROM schema_version').get();
-    assert.deepStrictEqual(version?.['version'], 15, 'schema version should be 15');
+    assert.deepStrictEqual(version?.['version'], 16, 'schema version should be 16');
 
     // Check tables exist by querying them
     const dRows = adapter.prepare('SELECT count(*) as cnt FROM decisions').get();

--- a/src/resources/extensions/gsd/tests/md-importer.test.ts
+++ b/src/resources/extensions/gsd/tests/md-importer.test.ts
@@ -363,7 +363,7 @@ test('md-importer: schema v1→v2 migration', () => {
   openDatabase(':memory:');
   const adapter = _getAdapter();
   const version = adapter?.prepare('SELECT MAX(version) as v FROM schema_version').get();
-  assert.deepStrictEqual(version?.v, 15, 'new DB should be at schema version 15');
+  assert.deepStrictEqual(version?.v, 16, 'new DB should be at schema version 16');
 
   // Artifacts table should exist
   const tableCheck = adapter?.prepare("SELECT count(*) as c FROM sqlite_master WHERE type='table' AND name='artifacts'").get();

--- a/src/resources/extensions/gsd/tests/memory-store.test.ts
+++ b/src/resources/extensions/gsd/tests/memory-store.test.ts
@@ -325,7 +325,7 @@ test('memory-store: schema includes memories table', () => {
 
   // Verify schema version is 15 (UOK gate/git/audit projection tables included)
   const version = adapter.prepare('SELECT MAX(version) as v FROM schema_version').get();
-  assert.deepStrictEqual(version?.['v'], 15, 'schema version should be 15');
+  assert.deepStrictEqual(version?.['v'], 16, 'schema version should be 16');
 
   closeDatabase();
 });

--- a/src/resources/extensions/gsd/tests/model-unittype-mapping.test.ts
+++ b/src/resources/extensions/gsd/tests/model-unittype-mapping.test.ts
@@ -215,6 +215,65 @@ test("unitVerb handles discuss-slice", () => {
 // auto-artifact-paths.ts: artifact resolution
 // ═══════════════════════════════════════════════════════════════════════════
 
+// ═══════════════════════════════════════════════════════════════════════════
+// ADR-011: meta-test — every KNOWN_UNIT_TYPES entry must appear in all four
+// downstream registries so a future unit type added to KNOWN_UNIT_TYPES can't
+// silently fall through to wrong defaults in metrics/dashboard/artifacts/post-unit.
+// ═══════════════════════════════════════════════════════════════════════════
+
+// Intentional exceptions — unit types that legitimately rely on default/null
+// behavior in a specific registry. Entries captured here reflect the current
+// baseline at the time ADR-011 landed; adding to this allowlist for a NEW unit
+// type requires explicit justification in the commit.
+//
+// Test intent: catch the case where someone adds a new unit type to
+// KNOWN_UNIT_TYPES but forgets to wire it into one of the four registries.
+// The allowlist freezes the baseline so pre-existing omissions do not block
+// the test, but any brand-new addition must be either handled or justified.
+const REGISTRY_EXCEPTIONS: Record<string, Set<string>> = {
+  // metrics.ts classifyUnitPhase uses default → "execution" for most unit types.
+  "metrics.ts": new Set([
+    "worktree-merge", "custom-step",
+    "rewrite-docs", "run-uat", "gate-evaluate", "replan-slice",
+    "reactive-execute", "validate-milestone", "complete-milestone",
+  ]),
+  "auto-dashboard.ts": new Set([
+    "worktree-merge",
+    "gate-evaluate", "reactive-execute", "validate-milestone", "complete-milestone",
+  ]),
+  "auto-artifact-paths.ts": new Set([
+    "rewrite-docs", "gate-evaluate", "reactive-execute", "discuss-slice", "worktree-merge",
+  ]),
+  "auto-post-unit.ts": new Set([
+    "execute-task", "reactive-execute", "gate-evaluate", "worktree-merge",
+  ]),
+};
+
+const REGISTRY_SOURCES: Array<[string, string]> = [
+  ["metrics.ts", metricsSrc],
+  ["auto-dashboard.ts", dashboardSrc],
+  ["auto-artifact-paths.ts", artifactSrc],
+  ["auto-post-unit.ts", postUnitSrc],
+];
+
+test("ADR-011 meta: every KNOWN_UNIT_TYPES entry appears in all 4 downstream registries", () => {
+  const missing: Array<{ registry: string; unitType: string }> = [];
+  for (const [registry, src] of REGISTRY_SOURCES) {
+    for (const ut of ALL_KNOWN_UNIT_TYPES) {
+      if (REGISTRY_EXCEPTIONS[registry]?.has(ut)) continue;
+      if (!src.includes(`"${ut}"`)) {
+        missing.push({ registry, unitType: ut });
+      }
+    }
+  }
+  assert.deepEqual(
+    missing,
+    [],
+    "Each listed unit type is absent from the given registry — either add a handler or add to REGISTRY_EXCEPTIONS with justification:\n" +
+      missing.map((m) => `  ${m.registry}: "${m.unitType}"`).join("\n"),
+  );
+});
+
 test("resolveExpectedArtifactPath handles discuss-slice", () => {
   assert.ok(artifactSrc.includes('"discuss-slice"'), "missing discuss-slice in artifact paths");
 });

--- a/src/resources/extensions/gsd/tests/progressive-planning.test.ts
+++ b/src/resources/extensions/gsd/tests/progressive-planning.test.ts
@@ -1,0 +1,351 @@
+// GSD Extension — ADR-011 Progressive Planning tests
+// Sketch detection → refining phase, dispatch routing, auto-heal, migration idempotency.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import {
+  openDatabase,
+  closeDatabase,
+  insertMilestone,
+  insertSlice,
+  setSliceSketchFlag,
+  autoHealSketchFlags,
+  getSlice,
+} from "../gsd-db.ts";
+import { deriveStateFromDb } from "../state.ts";
+import { resolveDispatch } from "../auto-dispatch.ts";
+import type { DispatchContext } from "../auto-dispatch.ts";
+
+function makeFixtureBase(): string {
+  const base = mkdtempSync(join(tmpdir(), "gsd-adr011-"));
+  mkdirSync(join(base, ".gsd"), { recursive: true });
+  mkdirSync(join(base, ".gsd", "milestones", "M001", "slices", "S02"), { recursive: true });
+  mkdirSync(join(base, ".gsd", "milestones", "M001", "slices", "S01"), { recursive: true });
+  return base;
+}
+
+function writePreferences(base: string, phasesBlock: string): void {
+  const prefsPath = join(base, ".gsd", "PREFERENCES.md");
+  const body = [
+    "---",
+    "version: 1",
+    phasesBlock,
+    "---",
+  ].join("\n");
+  writeFileSync(prefsPath, body);
+}
+
+function seedMilestoneWithSketchedS02(base: string): void {
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M001", title: "Test", status: "active" });
+  // S01: full slice, complete
+  insertSlice({
+    id: "S01",
+    milestoneId: "M001",
+    title: "Foundation",
+    status: "complete",
+    risk: "high",
+    depends: [],
+    demo: "S01 done.",
+    sequence: 1,
+    isSketch: false,
+  });
+  // S02: sketch slice, pending
+  insertSlice({
+    id: "S02",
+    milestoneId: "M001",
+    title: "Feature",
+    status: "pending",
+    risk: "medium",
+    depends: ["S01"],
+    demo: "S02 demo.",
+    sequence: 2,
+    isSketch: true,
+    sketchScope: "Scope limited to feature X in module Y; no cross-cutting refactors.",
+  });
+}
+
+function writeS01Artifacts(base: string): void {
+  writeFileSync(join(base, ".gsd", "milestones", "M001", "slices", "S01", "S01-PLAN.md"), "# S01 Plan\n");
+  writeFileSync(join(base, ".gsd", "milestones", "M001", "slices", "S01", "S01-SUMMARY.md"), "# S01 Summary\n");
+}
+
+function cleanup(base: string, originalCwd: string): void {
+  try { closeDatabase(); } catch { /* noop */ }
+  process.chdir(originalCwd);
+  try { rmSync(base, { recursive: true, force: true }); } catch { /* noop */ }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Tests
+// ═══════════════════════════════════════════════════════════════════════════
+
+test("ADR-011: sketch slice + progressive_planning ON → phase='refining'", async (t) => {
+  const originalCwd = process.cwd();
+  const base = makeFixtureBase();
+  t.after(() => cleanup(base, originalCwd));
+
+  seedMilestoneWithSketchedS02(base);
+  writeS01Artifacts(base);
+  writePreferences(base, "phases:\n  progressive_planning: true");
+  process.chdir(base);
+
+  const state = await deriveStateFromDb(base);
+  assert.equal(state.activeSlice?.id, "S02", "S02 should be the active slice (S01 complete)");
+  assert.equal(state.phase, "refining", "sketch slice with flag ON must yield refining phase");
+});
+
+test("ADR-011: sketch slice + progressive_planning OFF → phase='planning' (backwards compat)", async (t) => {
+  const originalCwd = process.cwd();
+  const base = makeFixtureBase();
+  t.after(() => cleanup(base, originalCwd));
+
+  seedMilestoneWithSketchedS02(base);
+  writeS01Artifacts(base);
+  // Write a PREFERENCES.md without the flag so loadEffectiveGSDPreferences finds
+  // a valid file but progressive_planning resolves to undefined.
+  writePreferences(base, "phases:\n  skip_research: false");
+  process.chdir(base);
+
+  const state = await deriveStateFromDb(base);
+  assert.equal(state.activeSlice?.id, "S02");
+  assert.equal(state.phase, "planning", "flag absent → must fall through to planning");
+});
+
+test("ADR-011: dispatch rule maps refining → refine-slice unit", async (t) => {
+  const originalCwd = process.cwd();
+  const base = makeFixtureBase();
+  t.after(() => cleanup(base, originalCwd));
+
+  seedMilestoneWithSketchedS02(base);
+  writeS01Artifacts(base);
+  writePreferences(base, "phases:\n  progressive_planning: true");
+  process.chdir(base);
+
+  const state = await deriveStateFromDb(base);
+  const ctx: DispatchContext = {
+    basePath: base,
+    mid: "M001",
+    midTitle: "Test",
+    state,
+    // Disable reassess-roadmap so it doesn't fire first on the just-completed S01.
+    prefs: { phases: { progressive_planning: true, reassess_after_slice: false } } as any,
+  };
+  const result = await resolveDispatch(ctx);
+  assert.equal(result.action, "dispatch");
+  if (result.action === "dispatch") {
+    assert.equal(result.unitType, "refine-slice");
+    assert.equal(result.unitId, "M001/S02");
+  }
+});
+
+test("ADR-011: refining + flag flipped OFF mid-milestone → falls through to plan-slice (no dead-end)", async (t) => {
+  const originalCwd = process.cwd();
+  const base = makeFixtureBase();
+  t.after(() => cleanup(base, originalCwd));
+
+  seedMilestoneWithSketchedS02(base);
+  writeS01Artifacts(base);
+  // prefs ON so state derivation yields 'refining'...
+  writePreferences(base, "phases:\n  progressive_planning: true");
+  process.chdir(base);
+  const state = await deriveStateFromDb(base);
+  assert.equal(state.phase, "refining");
+
+  // ...then dispatch is invoked with the flag OFF (simulates user toggling
+  // progressive_planning off while a slice sits in 'refining'). The rule
+  // must gracefully downgrade to plan-slice, not return null (dead-end).
+  const ctx: DispatchContext = {
+    basePath: base,
+    mid: "M001",
+    midTitle: "Test",
+    state,
+    prefs: { phases: { progressive_planning: false, reassess_after_slice: false } } as any,
+  };
+  const result = await resolveDispatch(ctx);
+  assert.equal(result.action, "dispatch");
+  if (result.action === "dispatch") {
+    assert.equal(result.unitType, "plan-slice", "flag-off must downgrade to plan-slice");
+  }
+});
+
+test("ADR-011: autoHealSketchFlags flips is_sketch=0 when PLAN file exists", async (t) => {
+  const originalCwd = process.cwd();
+  const base = makeFixtureBase();
+  t.after(() => cleanup(base, originalCwd));
+
+  seedMilestoneWithSketchedS02(base);
+  writeS01Artifacts(base);
+  // Simulate crash between plan-slice write and sketch flip: PLAN.md exists
+  // but is_sketch is still 1.
+  writeFileSync(
+    join(base, ".gsd", "milestones", "M001", "slices", "S02", "S02-PLAN.md"),
+    "# S02 Plan\n",
+  );
+  assert.equal(getSlice("M001", "S02")?.is_sketch, 1, "pre: flagged as sketch");
+
+  const { existsSync } = await import("node:fs");
+  autoHealSketchFlags("M001", (sid) => {
+    const planPath = join(base, ".gsd", "milestones", "M001", "slices", sid, `${sid}-PLAN.md`);
+    return existsSync(planPath);
+  });
+
+  assert.equal(getSlice("M001", "S02")?.is_sketch, 0, "post-heal: flag cleared");
+});
+
+test("ADR-011: schema v16 is idempotent — re-opening DB preserves is_sketch and sketch_scope columns", async (t) => {
+  const originalCwd = process.cwd();
+  const base = mkdtempSync(join(tmpdir(), "gsd-adr011-schema-"));
+  t.after(() => {
+    try { closeDatabase(); } catch { /* noop */ }
+    // Restore cwd even though this test doesn't chdir — guards against
+    // leaked cwd from any earlier test in the file.
+    if (process.cwd() !== originalCwd) process.chdir(originalCwd);
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  const dbPath = join(base, "gsd.db");
+  openDatabase(dbPath);
+  // Insert a sketch slice — round-trip proves the columns exist with correct
+  // defaults. If migration hadn't run, insertSlice would throw on the new
+  // named params.
+  insertMilestone({ id: "M001", title: "Test", status: "active" });
+  insertSlice({
+    id: "S01",
+    milestoneId: "M001",
+    title: "X",
+    isSketch: true,
+    sketchScope: "narrow scope",
+  });
+  assert.equal(getSlice("M001", "S01")?.is_sketch, 1);
+  assert.equal(getSlice("M001", "S01")?.sketch_scope, "narrow scope");
+
+  // Close and re-open — migration must be a no-op the second time and
+  // data must persist.
+  closeDatabase();
+  openDatabase(dbPath);
+  assert.equal(getSlice("M001", "S01")?.is_sketch, 1, "data survives re-open");
+  assert.equal(getSlice("M001", "S01")?.sketch_scope, "narrow scope");
+
+  // Inserting a full (non-sketch) slice uses the default column values.
+  insertSlice({ id: "S02", milestoneId: "M001", title: "Y" });
+  assert.equal(getSlice("M001", "S02")?.is_sketch, 0, "default is_sketch=0");
+  assert.equal(getSlice("M001", "S02")?.sketch_scope, "", "default sketch_scope=''");
+
+  // setSliceSketchFlag round-trip.
+  setSliceSketchFlag("M001", "S01", false);
+  assert.equal(getSlice("M001", "S01")?.is_sketch, 0);
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// ADR-011: insertSlice ON CONFLICT sketch-flag preservation matrix
+// ═══════════════════════════════════════════════════════════════════════════
+// Regression coverage for the 3-valued isSketch semantics (true/false/undefined).
+// Re-planning a milestone must NOT silently flip a sketch slice to non-sketch
+// (or vice versa) unless the caller explicitly intends the change.
+
+test("ADR-011 ON CONFLICT: omitted isSketch preserves existing is_sketch=1", async (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-adr011-conflict-"));
+  t.after(() => {
+    try { closeDatabase(); } catch { /* noop */ }
+    rmSync(base, { recursive: true, force: true });
+  });
+  openDatabase(join(base, "gsd.db"));
+  insertMilestone({ id: "M001", title: "Test", status: "active" });
+
+  // Seed: S01 is a sketch.
+  insertSlice({
+    id: "S01", milestoneId: "M001", title: "X",
+    isSketch: true, sketchScope: "narrow scope",
+  });
+  assert.equal(getSlice("M001", "S01")?.is_sketch, 1);
+
+  // Re-plan with isSketch omitted (undefined) — MUST preserve sketch state.
+  insertSlice({
+    id: "S01", milestoneId: "M001", title: "X (updated title)",
+    // isSketch intentionally omitted
+  });
+  assert.equal(
+    getSlice("M001", "S01")?.is_sketch, 1,
+    "omitted isSketch must preserve the existing sketch flag on ON CONFLICT",
+  );
+  assert.equal(
+    getSlice("M001", "S01")?.sketch_scope, "narrow scope",
+    "omitted sketchScope must preserve existing scope on ON CONFLICT",
+  );
+});
+
+test("ADR-011 ON CONFLICT: explicit isSketch=false clears existing sketch flag", async (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-adr011-conflict-false-"));
+  t.after(() => {
+    try { closeDatabase(); } catch { /* noop */ }
+    rmSync(base, { recursive: true, force: true });
+  });
+  openDatabase(join(base, "gsd.db"));
+  insertMilestone({ id: "M001", title: "Test", status: "active" });
+
+  insertSlice({
+    id: "S01", milestoneId: "M001", title: "X",
+    isSketch: true, sketchScope: "narrow scope",
+  });
+  assert.equal(getSlice("M001", "S01")?.is_sketch, 1);
+
+  // Explicit isSketch=false intentionally clears the flag (e.g., user re-plans
+  // sketch as full slice).
+  insertSlice({
+    id: "S01", milestoneId: "M001", title: "X",
+    isSketch: false,
+  });
+  assert.equal(
+    getSlice("M001", "S01")?.is_sketch, 0,
+    "explicit isSketch=false must clear the sketch flag",
+  );
+});
+
+test("ADR-011 ON CONFLICT: isSketch=true upgrades existing non-sketch to sketch", async (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-adr011-conflict-true-"));
+  t.after(() => {
+    try { closeDatabase(); } catch { /* noop */ }
+    rmSync(base, { recursive: true, force: true });
+  });
+  openDatabase(join(base, "gsd.db"));
+  insertMilestone({ id: "M001", title: "Test", status: "active" });
+
+  // Seed as full slice.
+  insertSlice({ id: "S01", milestoneId: "M001", title: "X" });
+  assert.equal(getSlice("M001", "S01")?.is_sketch, 0);
+
+  // Re-plan upgrading to sketch.
+  insertSlice({
+    id: "S01", milestoneId: "M001", title: "X",
+    isSketch: true, sketchScope: "new scope",
+  });
+  assert.equal(getSlice("M001", "S01")?.is_sketch, 1);
+  assert.equal(getSlice("M001", "S01")?.sketch_scope, "new scope");
+});
+
+test("ADR-011 ON CONFLICT: empty-string sketchScope clears existing scope (not preserves it)", async (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-adr011-conflict-empty-"));
+  t.after(() => {
+    try { closeDatabase(); } catch { /* noop */ }
+    rmSync(base, { recursive: true, force: true });
+  });
+  openDatabase(join(base, "gsd.db"));
+  insertMilestone({ id: "M001", title: "Test", status: "active" });
+
+  insertSlice({
+    id: "S01", milestoneId: "M001", title: "X",
+    isSketch: true, sketchScope: "existing scope",
+  });
+  // Explicit empty string is the caller saying "clear it" — must not be
+  // treated as absent (the `?? null` footgun the peer review flagged).
+  insertSlice({
+    id: "S01", milestoneId: "M001", title: "X",
+    isSketch: false, sketchScope: "",
+  });
+  assert.equal(getSlice("M001", "S01")?.sketch_scope, "", "explicit '' must clear, not preserve");
+});

--- a/src/resources/extensions/gsd/tests/projection-regression.test.ts
+++ b/src/resources/extensions/gsd/tests/projection-regression.test.ts
@@ -30,6 +30,8 @@ function makeSliceRow(overrides?: Partial<SliceRow>): SliceRow {
     observability_impact: '',
     sequence: 0,
     replan_triggered_at: null,
+    is_sketch: 0,
+    sketch_scope: '',
     ...overrides,
   };
 }

--- a/src/resources/extensions/gsd/tests/prompt-contracts.test.ts
+++ b/src/resources/extensions/gsd/tests/prompt-contracts.test.ts
@@ -223,6 +223,30 @@ test("replan-slice prompt uses gsd_replan_slice as canonical DB-backed tool", ()
   assert.doesNotMatch(prompt, /Degraded fallback/i);
 });
 
+// ─── ADR-011 refine-slice prompt contracts ────────────────────────────
+
+test("refine-slice prompt names gsd_plan_slice as the DB-backed write path", () => {
+  const prompt = readPrompt("refine-slice");
+  assert.match(prompt, /gsd_plan_slice/, "refine-slice must call gsd_plan_slice to persist");
+});
+
+test("refine-slice prompt does not instruct direct PLAN.md writes", () => {
+  const prompt = readPrompt("refine-slice");
+  assert.match(
+    prompt,
+    /do NOT rely on direct `PLAN\.md` writes/i,
+    "refine-slice must not frame direct file writes as authoritative",
+  );
+});
+
+test("refine-slice prompt frames the unit as a transformation, not blank-sheet planning", () => {
+  const prompt = readPrompt("refine-slice");
+  // The framing language is load-bearing — the model should treat this as
+  // expanding an approved sketch, not planning from scratch.
+  assert.match(prompt, /expands an approved sketch/i);
+  assert.match(prompt, /Sketch Scope/);
+});
+
 test("reassess-roadmap prompt references gsd_reassess_roadmap tool", () => {
   const prompt = readPrompt("reassess-roadmap");
   assert.match(prompt, /gsd_reassess_roadmap/);

--- a/src/resources/extensions/gsd/tests/slice-context-injection.test.ts
+++ b/src/resources/extensions/gsd/tests/slice-context-injection.test.ts
@@ -31,18 +31,30 @@ describe("slice CONTEXT.md injection into prompt builders (#3452)", () => {
       const fnStart = source.indexOf(`export async function ${builder}`);
       assert.ok(fnStart !== -1, `${builder} should exist in auto-prompts.ts`);
 
-      // Get a reasonable chunk after the function start (enough to cover the inlining section)
+      // Get a reasonable chunk after the function start
       const chunk = source.slice(fnStart, fnStart + 3000);
+
+      // ADR-011: buildPlanSlicePrompt / buildRefineSlicePrompt now delegate to
+      // a shared helper (renderSlicePrompt) that performs the slice CONTEXT
+      // resolve. When a builder delegates, scan the helper's body instead.
+      const delegatesToHelper = chunk.includes("renderSlicePrompt(");
+      const bodyToCheck = delegatesToHelper
+        ? (() => {
+            const helperStart = source.indexOf("async function renderSlicePrompt");
+            assert.ok(helperStart !== -1, "renderSlicePrompt helper must exist");
+            return source.slice(helperStart, helperStart + 3000);
+          })()
+        : chunk;
 
       // Must resolve the slice CONTEXT path
       assert.ok(
-        chunk.includes('resolveSliceFile(base, mid,') && chunk.includes('"CONTEXT"'),
-        `${builder} should call resolveSliceFile with "CONTEXT"`,
+        bodyToCheck.includes('resolveSliceFile(base, mid,') && bodyToCheck.includes('"CONTEXT"'),
+        `${builder} should call resolveSliceFile with "CONTEXT" (directly or via renderSlicePrompt)`,
       );
 
       // Must inline it with inlineFileOptional
       assert.ok(
-        chunk.includes('Slice Context'),
+        bodyToCheck.includes("Slice Context"),
         `${builder} should inline slice CONTEXT with a "Slice Context" label`,
       );
     });

--- a/src/resources/extensions/gsd/tests/state-corruption-2945.test.ts
+++ b/src/resources/extensions/gsd/tests/state-corruption-2945.test.ts
@@ -93,6 +93,8 @@ function makeSliceRow(id: string, overrides: Partial<SliceRow> = {}): SliceRow {
     integration_closure: "",
     observability_impact: "",
     replan_triggered_at: null,
+    is_sketch: 0,
+    sketch_scope: "",
     ...overrides,
   };
 }

--- a/src/resources/extensions/gsd/tests/uok-contracts.test.ts
+++ b/src/resources/extensions/gsd/tests/uok-contracts.test.ts
@@ -64,8 +64,9 @@ test("uok contracts include required DAG node kinds", () => {
     "team-worker",
     "verification",
     "reprocess",
+    "refine",
   ];
-  assert.deepEqual(required.length, 6);
+  assert.deepEqual(required.length, 7);
 });
 
 test("uok audit envelope includes trace/turn/causality fields", () => {

--- a/src/resources/extensions/gsd/tests/workflow-projections.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-projections.test.ts
@@ -28,6 +28,8 @@ function makeSlice(overrides: Partial<SliceRow> = {}): SliceRow {
     completed_at: null,
     sequence: 1,
     replan_triggered_at: null,
+    is_sketch: 0,
+    sketch_scope: '',
     ...overrides,
   };
 }

--- a/src/resources/extensions/gsd/tools/plan-milestone.ts
+++ b/src/resources/extensions/gsd/tools/plan-milestone.ts
@@ -25,10 +25,18 @@ export interface PlanMilestoneSliceInput {
   depends: string[];
   demo: string;
   goal: string;
+  /** Required when isSketch is false/absent; may be empty for sketch slices (ADR-011). */
   successCriteria: string;
+  /** Required when isSketch is false/absent; may be empty for sketch slices (ADR-011). */
   proofLevel: string;
+  /** Required when isSketch is false/absent; may be empty for sketch slices (ADR-011). */
   integrationClosure: string;
+  /** Required when isSketch is false/absent; may be empty for sketch slices (ADR-011). */
   observabilityImpact: string;
+  /** ADR-011: when true, this slice is a sketch awaiting refine-slice expansion. */
+  isSketch?: boolean;
+  /** ADR-011: 2–3 sentence scope boundary, required when isSketch is true. */
+  sketchScope?: string;
 }
 
 export interface PlanMilestoneParams {
@@ -125,6 +133,16 @@ function validateSlices(value: unknown): PlanMilestoneSliceInput[] {
     const proofLevel = obj.proofLevel;
     const integrationClosure = obj.integrationClosure;
     const observabilityImpact = obj.observabilityImpact;
+    const isSketchRaw = obj.isSketch;
+    const sketchScopeRaw = obj.sketchScope;
+    // ADR-011: preserve the 3-valued semantics of isSketch (true / false / absent).
+    // Callers that omit isSketch must receive `undefined` here so `insertSlice`'s
+    // ON CONFLICT clause preserves any existing is_sketch on the row rather than
+    // silently overwriting a legitimate sketch to non-sketch.
+    const isSketch: boolean | undefined =
+      isSketchRaw === true ? true
+      : isSketchRaw === false ? false
+      : undefined;
 
     if (!isNonEmptyString(sliceId)) throw new Error(`slices[${index}].sliceId must be a non-empty string`);
     if (seen.has(sliceId)) throw new Error(`slices[${index}].sliceId must be unique`);
@@ -136,10 +154,18 @@ function validateSlices(value: unknown): PlanMilestoneSliceInput[] {
     }
     if (!isNonEmptyString(demo)) throw new Error(`slices[${index}].demo must be a non-empty string`);
     if (!isNonEmptyString(goal)) throw new Error(`slices[${index}].goal must be a non-empty string`);
-    if (!isNonEmptyString(successCriteria)) throw new Error(`slices[${index}].successCriteria must be a non-empty string`);
-    if (!isNonEmptyString(proofLevel)) throw new Error(`slices[${index}].proofLevel must be a non-empty string`);
-    if (!isNonEmptyString(integrationClosure)) throw new Error(`slices[${index}].integrationClosure must be a non-empty string`);
-    if (!isNonEmptyString(observabilityImpact)) throw new Error(`slices[${index}].observabilityImpact must be a non-empty string`);
+
+    // ADR-011: sketch slices may defer the heavyweight planning fields to refine-slice.
+    if (isSketch === true) {
+      if (!isNonEmptyString(sketchScopeRaw)) {
+        throw new Error(`slices[${index}].sketchScope must be a non-empty string when isSketch is true`);
+      }
+    } else {
+      if (!isNonEmptyString(successCriteria)) throw new Error(`slices[${index}].successCriteria must be a non-empty string`);
+      if (!isNonEmptyString(proofLevel)) throw new Error(`slices[${index}].proofLevel must be a non-empty string`);
+      if (!isNonEmptyString(integrationClosure)) throw new Error(`slices[${index}].integrationClosure must be a non-empty string`);
+      if (!isNonEmptyString(observabilityImpact)) throw new Error(`slices[${index}].observabilityImpact must be a non-empty string`);
+    }
 
     return {
       sliceId,
@@ -148,10 +174,14 @@ function validateSlices(value: unknown): PlanMilestoneSliceInput[] {
       depends,
       demo,
       goal,
-      successCriteria,
-      proofLevel,
-      integrationClosure,
-      observabilityImpact,
+      successCriteria: isNonEmptyString(successCriteria) ? successCriteria : "",
+      proofLevel: isNonEmptyString(proofLevel) ? proofLevel : "",
+      integrationClosure: isNonEmptyString(integrationClosure) ? integrationClosure : "",
+      observabilityImpact: isNonEmptyString(observabilityImpact) ? observabilityImpact : "",
+      isSketch,
+      // Only carry the sketch scope through if the caller explicitly provided it
+      // — preserves ON CONFLICT semantics for re-plans that omit the field.
+      sketchScope: sketchScopeRaw === undefined ? undefined : (isNonEmptyString(sketchScopeRaw) ? sketchScopeRaw : ""),
     };
   });
 }
@@ -274,6 +304,10 @@ export async function handlePlanMilestone(
           depends: slice.depends,
           demo: slice.demo,
           sequence: i + 1, // Preserve agent-ordered sequence (#3356)
+          // ADR-011: pass undefined through so ON CONFLICT preserves existing values
+          // when the caller omitted the fields on a re-plan.
+          isSketch: slice.isSketch,
+          sketchScope: slice.sketchScope,
         });
         upsertSlicePlanning(params.milestoneId, slice.sliceId, {
           goal: slice.goal,

--- a/src/resources/extensions/gsd/types.ts
+++ b/src/resources/extensions/gsd/types.ts
@@ -11,6 +11,7 @@ export type Phase =
   | "discussing"
   | "researching"
   | "planning"
+  | "refining"
   | "evaluating-gates"
   | "executing"
   | "verifying"
@@ -350,6 +351,8 @@ export interface PhaseSkipPreferences {
   reassess_after_slice?: boolean;
   /** When true, auto-mode pauses before each slice for discussion (#789). */
   require_slice_discussion?: boolean;
+  /** ADR-011: when true, plan S01 in full and S02+ as sketches refined just-in-time. */
+  progressive_planning?: boolean;
 }
 
 export interface NotificationPreferences {

--- a/src/resources/extensions/gsd/uok/contracts.ts
+++ b/src/resources/extensions/gsd/uok/contracts.ts
@@ -113,7 +113,8 @@ export type UokNodeKind =
   | "subagent"
   | "team-worker"
   | "verification"
-  | "reprocess";
+  | "reprocess"
+  | "refine";
 
 export interface UokGraphNode {
   id: string;

--- a/src/resources/extensions/gsd/workflow-manifest.ts
+++ b/src/resources/extensions/gsd/workflow-manifest.ts
@@ -117,6 +117,8 @@ export function snapshotState(): StateManifest {
     observability_impact: (r["observability_impact"] as string) ?? "",
     sequence: toNumeric(r["sequence"], 0) as number,
     replan_triggered_at: (r["replan_triggered_at"] as string) ?? null,
+    is_sketch: toNumeric(r["is_sketch"], 0) as number,
+    sketch_scope: (r["sketch_scope"] as string) ?? "",
   }));
 
   const rawTasks = db.prepare("SELECT * FROM tasks ORDER BY milestone_id, slice_id, sequence, id").all() as Record<string, unknown>[];


### PR DESCRIPTION
Implements **Phase 1 of ADR-011** (Progressive Planning — sketch-then-refine). Phase 2 (Mid-Execution Escalation) is a separate PR. Closes #3789.

## TL;DR

`plan-milestone` now plans S01 in full detail and S02+ as **sketches** (title, goal, risk, deps, 2–3 sentence scope). Before each sketch slice is executed, a new `refine-slice` unit expands it into a full plan using the prior slice's SUMMARY and current codebase state. Prevents plans from going stale against a moving codebase. Gated behind `phases.progressive_planning` — default **off**.

## What

- **DB (schema v16):** `is_sketch INTEGER DEFAULT 0`, `sketch_scope TEXT DEFAULT ''` on the `slices` table. New exports: `setSliceSketchFlag()`, `autoHealSketchFlags()`. `insertSlice` extended with 3-valued `isSketch` (true / false / undefined) so ON CONFLICT preserves existing values when the caller omits the field on a re-plan.
- **State (`state.ts`):** new `refining` phase fires when `is_sketch=1` AND `progressive_planning` is on. Auto-heal reconciles stale `is_sketch=1` rows whose PLAN.md exists (crash between plan-slice write and flag flip, or flag-OFF downgrade path).
- **Dispatch (`auto-dispatch.ts`):** new `refining → refine-slice` rule before `planning → plan-slice`. When the flag is toggled off mid-milestone on a sketch slice, the rule gracefully downgrades to `plan-slice` and forwards the stored `sketch_scope` as a **soft (non-binding) hint** so the scope signal isn't lost.
- **Prompts:** extracted `renderSlicePrompt` shared helper. `buildRefineSlicePrompt` prepends a "Sketch Scope (hard constraint)" block. New `prompts/refine-slice.md` template framed as a *transformation* (sketch → full plan), not blank-sheet planning. `prompts/plan-milestone.md` appended with the progressive-planning section.
- **Tool schema (`gsd_plan_milestone`):** heavy per-slice fields now optional; `isSketch` / `sketchScope` accepted per-slice. Validator enforces `sketchScope` required when `isSketch: true`.
- **Registries wired:** `refine-slice` handled in `metrics.ts`, `auto-dashboard.ts` (3 switches), `auto-artifact-paths.ts` (2 switches), `auto-post-unit.ts` (`LIFECYCLE_ONLY_UNITS` + pre-execution checks), `preferences-models.ts`, `preferences-validation.ts`.
- **Plan-gate:** existing `pre-execution-checks` now also run for `refine-slice` — same structural validation applied to both planning paths.
- **UOK:** `UokNodeKind += "refine"` (honors the ADR explicitly).

## Why

Per the ADR's Zylos 2026 research: planning S04 from a snapshot that predates S01–S03 shipping introduces compounding unreliability. `reassess-roadmap` is too coarse and "almost always says 'roadmap is fine.'" Progressive planning prevents the drift instead of catching it after the fact.

## How

Sketch-then-refine is implemented as a thin state-machine insertion. The dispatch table gains one new rule; state derivation gains one branch; the DB schema gains two additive columns. No changes to the execution-plane DAG beyond the new `UokNodeKind` label. Feature flag defaults off so existing milestones behave identically.

## Peer review

Two full peer-review rounds ran during implementation (pragmatic-architecture design + final-diff review). All HIGH/MED findings addressed:
- ✅ `SCHEMA_VERSION` bumped 15→16 (migration was dead code otherwise)
- ✅ `refine-slice` added to 4 downstream registries (prevents silent telemetry/dashboard bugs)
- ✅ 3-valued `isSketch` preserves existing values on re-plan (no silent flipping)
- ✅ `sketchScope !== undefined` check (empty string correctly clears, not preserves)
- ✅ Flag-OFF downgrade forwards scope as soft hint (not silently dropped)
- ✅ New registry meta-test prevents future unit types from missing a registry

## Tests

**6732 passing, 0 failing, 8 skipped.**

New tests:
- `progressive-planning.test.ts` — 10 tests: sketch→refining phase, backwards compat, dispatch routing, flag-OFF downgrade, auto-heal, schema idempotency, ON CONFLICT matrix (4 cases: omit preserves, false clears, true upgrades, empty-string clears)
- `prompt-contracts.test.ts` — 3 new contracts for `refine-slice`
- `model-unittype-mapping.test.ts` — meta-test asserting every `KNOWN_UNIT_TYPES` entry is covered in all 4 downstream registries

Updated 5 pre-existing tests (schema version 15→16, mock `SliceRow` helpers, `#3452` slice-context-injection to follow the `renderSlicePrompt` helper, `uok-contracts` required.length 6→7).

## Test plan

- [ ] `npx tsc --noEmit` — clean
- [ ] `npm run test:unit` — 6732 pass
- [ ] Enable `phases.progressive_planning: true` in a test project, run `/gsd plan-milestone` with ≥2 slices, verify S01 is fully decomposed and S02+ are sketches
- [ ] Run auto-mode through S01 completion, verify S02 dispatches `refine-slice` (not `plan-slice`), verify sketch scope appears in the prompt as a hard constraint
- [ ] Flip flag off mid-milestone on an `is_sketch=1` slice, verify dispatch downgrades to `plan-slice` with the soft hint
- [ ] Crash/kill auto-mode after `gsd_plan_slice` returns but before `is_sketch=0` flip — verify auto-heal on next iteration

## Deferred to fast-follow

- plan-gate LLM-driven quality validator (plan-slice itself has no pre-gate today; adding for both is scope creep beyond Phase 1)
- Threading prefs through `deriveStateFromDb` signature (peer review graded LOW — current lazy read follows `resolveSkillDiscoveryMode` pattern)
- Phase 2: Mid-Execution Escalation (separate PR)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added progressive planning mode enabling sketch-then-refine workflow for milestone slices
  * Introduced "refine-slice" unit type for expanding approved sketches into full implementation plans
  * Added "refining" phase to the planning workflow lifecycle

* **Database Updates**
  * Schema upgraded to v16 with sketch tracking support, enabling slices to be marked and scoped as sketches for later refinement

<!-- end of auto-generated comment: release notes by coderabbit.ai -->