### PR TITLE
feat(gsd): ADR-011 Phase 2 mid-execution escalation

### DIFF
--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -190,6 +190,25 @@ export function isVerificationNotApplicable(value: string): boolean {
 
 export const DISPATCH_RULES: DispatchRule[] = [
   {
+    // ADR-011 Phase 2: pause-for-escalation must evaluate FIRST so phase-
+    // agnostic rules (rewrite-docs gate, UAT checks, reassess) cannot bypass
+    // the user's pending decision. Only fires for continueWithDefault=false
+    // escalations (those set escalation_pending=1); awaiting-review artifacts
+    // never enter the 'escalating-task' phase.
+    name: "escalating-task → pause-for-escalation",
+    match: async ({ state, mid }) => {
+      if (state.phase !== "escalating-task") return null;
+      if (!state.activeSlice) return missingSliceStop(mid, state.phase);
+      return {
+        action: "stop",
+        reason:
+          state.nextAction ||
+          `${mid}: task escalation awaits user resolution. Run /gsd escalate list to see pending items.`,
+        level: "info",
+      };
+    },
+  },
+  {
     name: "rewrite-docs (override gate)",
     match: async ({ mid, midTitle, state, basePath, session }) => {
       const pendingOverrides = await loadActiveOverrides(basePath);
@@ -552,25 +571,6 @@ export const DISPATCH_RULES: DispatchRule[] = [
           sTitle,
           basePath,
         ),
-      };
-    },
-  },
-  {
-    // ADR-011 Phase 2: pause auto-mode until the user resolves a pending
-    // escalation via `/gsd escalate resolve <taskId> <choice>`. Only fires
-    // for escalations with `continueWithDefault: false` — the
-    // `continueWithDefault: true` path writes an artifact without flipping
-    // `escalation_pending`, so it never enters this phase.
-    name: "escalating-task → pause-for-escalation",
-    match: async ({ state, mid }) => {
-      if (state.phase !== "escalating-task") return null;
-      if (!state.activeSlice) return missingSliceStop(mid, state.phase);
-      return {
-        action: "stop",
-        reason:
-          state.nextAction ||
-          `${mid}: task escalation awaits user resolution. Run /gsd escalate list to see pending items.`,
-        level: "info",
       };
     },
   },

--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -556,6 +556,25 @@ export const DISPATCH_RULES: DispatchRule[] = [
     },
   },
   {
+    // ADR-011 Phase 2: pause auto-mode until the user resolves a pending
+    // escalation via `/gsd escalate resolve <taskId> <choice>`. Only fires
+    // for escalations with `continueWithDefault: false` — the
+    // `continueWithDefault: true` path writes an artifact without flipping
+    // `escalation_pending`, so it never enters this phase.
+    name: "escalating-task → pause-for-escalation",
+    match: async ({ state, mid }) => {
+      if (state.phase !== "escalating-task") return null;
+      if (!state.activeSlice) return missingSliceStop(mid, state.phase);
+      return {
+        action: "stop",
+        reason:
+          state.nextAction ||
+          `${mid}: task escalation awaits user resolution. Run /gsd escalate list to see pending items.`,
+        level: "info",
+      };
+    },
+  },
+  {
     name: "executing → reactive-execute (parallel dispatch)",
     match: async ({ state, mid, midTitle, basePath, prefs }) => {
       if (state.phase !== "executing" || !state.activeTask) return null;

--- a/src/resources/extensions/gsd/auto-prompts.ts
+++ b/src/resources/extensions/gsd/auto-prompts.ts
@@ -1436,7 +1436,7 @@ export async function buildExecuteTaskPrompt(
       }
     } catch (escalationErr) {
       // Escalation module unavailable or threw — log and proceed.
-      logWarning("auto-prompts", `escalation override injection failed: ${(escalationErr as Error).message}`);
+      logWarning("prompt", `escalation override injection failed: ${(escalationErr as Error).message}`);
     }
   }
 

--- a/src/resources/extensions/gsd/auto-prompts.ts
+++ b/src/resources/extensions/gsd/auto-prompts.ts
@@ -1417,7 +1417,28 @@ export async function buildExecuteTaskPrompt(
     ? `### Runtime Context\nSource: \`.gsd/RUNTIME.md\`\n\n${runtimeContent.trim()}`
     : "";
 
-  const phaseAnchorSection = planAnchor ? formatAnchorForPrompt(planAnchor) : "";
+  let phaseAnchorSection = planAnchor ? formatAnchorForPrompt(planAnchor) : "";
+
+  // ADR-011 Phase 2: inject any resolved-but-unapplied escalation override
+  // into this task's prompt. Claim is atomic via DB UPDATE WHERE IS NULL, so
+  // if a parallel build already injected it, we skip. Feature-gated by
+  // phases.mid_execution_escalation. Prepended to phaseAnchorSection so it
+  // appears near the top of the prompt above planning anchors.
+  if (prefs?.preferences?.phases?.mid_execution_escalation === true) {
+    try {
+      const { claimOverrideForInjection } = await import("./escalation.js");
+      const claimed = claimOverrideForInjection(base, mid, sid);
+      if (claimed) {
+        const block = claimed.injectionBlock + "\n\n---\n\n";
+        phaseAnchorSection = phaseAnchorSection
+          ? `${block}${phaseAnchorSection}`
+          : block;
+      }
+    } catch (escalationErr) {
+      // Escalation module unavailable or threw — log and proceed.
+      logWarning("auto-prompts", `escalation override injection failed: ${(escalationErr as Error).message}`);
+    }
+  }
 
   // Task-scoped gates owned by execute-task (Q5/Q6/Q7). Pull only the
   // gates that plan-slice actually seeded for this task — tasks with no

--- a/src/resources/extensions/gsd/bootstrap/db-tools.ts
+++ b/src/resources/extensions/gsd/bootstrap/db-tools.ts
@@ -638,7 +638,7 @@ export function registerDbTools(pi: ExtensionAPI): void {
           id: Type.String({ description: "Short id (e.g. 'A', 'B') used by /gsd escalate resolve." }),
           label: Type.String({ description: "One-line label." }),
           tradeoffs: Type.String({ description: "1-2 sentences on the tradeoffs of this option." }),
-        }), { description: "2–4 options the user can choose between." }),
+        }), { minItems: 2, maxItems: 4, description: "2–4 options the user can choose between." }),
         recommendation: Type.String({ description: "Option id the executor recommends." }),
         recommendationRationale: Type.String({ description: "Why the recommendation — 1–2 sentences." }),
         continueWithDefault: Type.Boolean({

--- a/src/resources/extensions/gsd/bootstrap/db-tools.ts
+++ b/src/resources/extensions/gsd/bootstrap/db-tools.ts
@@ -631,6 +631,20 @@ export function registerDbTools(pi: ExtensionAPI): void {
       keyFiles: Type.Optional(Type.Array(Type.String(), { description: "List of key files created or modified" })),
       keyDecisions: Type.Optional(Type.Array(Type.String(), { description: "List of key decisions made during this task" })),
       blockerDiscovered: Type.Optional(Type.Boolean({ description: "Whether a plan-invalidating blocker was discovered" })),
+      // ADR-011 Phase 2: mid-execution escalation — agent asks the user to resolve an ambiguity.
+      escalation: Type.Optional(Type.Object({
+        question: Type.String({ description: "The question the user needs to answer — one clear sentence." }),
+        options: Type.Array(Type.Object({
+          id: Type.String({ description: "Short id (e.g. 'A', 'B') used by /gsd escalate resolve." }),
+          label: Type.String({ description: "One-line label." }),
+          tradeoffs: Type.String({ description: "1-2 sentences on the tradeoffs of this option." }),
+        }), { description: "2–4 options the user can choose between." }),
+        recommendation: Type.String({ description: "Option id the executor recommends." }),
+        recommendationRationale: Type.String({ description: "Why the recommendation — 1–2 sentences." }),
+        continueWithDefault: Type.Boolean({
+          description: "When true, loop continues (artifact logged for later review). When false, auto-mode pauses until the user resolves via /gsd escalate resolve.",
+        }),
+      }, { description: "ADR-011 Phase 2: optional escalation payload. Only honored when phases.mid_execution_escalation is true." })),
       verificationEvidence: Type.Optional(Type.Array(
         Type.Union([
           Type.Object({

--- a/src/resources/extensions/gsd/commands/handlers/escalate.ts
+++ b/src/resources/extensions/gsd/commands/handlers/escalate.ts
@@ -89,13 +89,38 @@ export async function handleEscalateCommand(
     return;
   }
 
-  // ── show <taskId> ───────────────────────────────────────────────────────
+  // Parse a possibly-slice-qualified task id: "Sxx/Tyy" or plain "Tyy".
+  // Returns { sliceId?, taskId }.
+  const parseTaskRef = (ref: string): { sliceId?: string; taskId: string } => {
+    const slash = ref.indexOf("/");
+    if (slash > 0) {
+      return { sliceId: ref.slice(0, slash), taskId: ref.slice(slash + 1) };
+    }
+    return { taskId: ref };
+  };
+
+  // Resolve a task ref to a single row, surfacing ambiguity when a bare task
+  // id matches more than one slice.
+  const locateRow = (ref: string): ReturnType<typeof listAllEscalations>[number] | "ambiguous" | "not-found" => {
+    const { sliceId, taskId } = parseTaskRef(ref);
+    const rows = listAllEscalations(milestoneId).filter(
+      (t) => t.id === taskId && (sliceId === undefined || t.slice_id === sliceId),
+    );
+    if (rows.length === 0) return "not-found";
+    if (rows.length > 1) return "ambiguous";
+    return rows[0]!;
+  };
+
+  // ── show <taskRef> ──────────────────────────────────────────────────────
   if (trimmed.startsWith("show ")) {
-    const taskId = trimmed.slice(5).trim();
-    const rows = listAllEscalations(milestoneId).filter((t) => t.id === taskId);
-    const row = rows[0];
-    if (!row || !row.escalation_artifact_path) {
-      ctx.ui.notify(`No escalation found for task ${taskId} in ${milestoneId}.`, "warning");
+    const ref = trimmed.slice(5).trim();
+    const row = locateRow(ref);
+    if (row === "ambiguous") {
+      ctx.ui.notify(`Task ${ref} matches multiple slices. Use Sxx/Tyy format.`, "warning");
+      return;
+    }
+    if (row === "not-found" || !row.escalation_artifact_path) {
+      ctx.ui.notify(`No escalation found for ${ref} in ${milestoneId}.`, "warning");
       return;
     }
     const art = readEscalationArtifact(row.escalation_artifact_path);
@@ -107,24 +132,27 @@ export async function handleEscalateCommand(
     return;
   }
 
-  // ── resolve <taskId> <choice> [rationale...] ────────────────────────────
+  // ── resolve <taskRef> <choice> [rationale...] ───────────────────────────
   if (trimmed.startsWith("resolve ")) {
     const parts = trimmed.slice(8).trim().split(/\s+/);
-    const taskId = parts[0];
+    const ref = parts[0];
     const choice = parts[1];
     const rationale = parts.slice(2).join(" ").trim();
-    if (!taskId || !choice) {
-      ctx.ui.notify("Usage: /gsd escalate resolve <taskId> <choice> [rationale...]", "warning");
+    if (!ref || !choice) {
+      ctx.ui.notify("Usage: /gsd escalate resolve <taskId|Sxx/Tyy> <choice> [rationale...]", "warning");
       return;
     }
 
-    // Locate the slice id — scan the milestone for a matching task.
-    const rows = listAllEscalations(milestoneId).filter((t) => t.id === taskId);
-    const row = rows[0];
-    if (!row) {
-      ctx.ui.notify(`No escalation found for task ${taskId} in ${milestoneId}.`, "warning");
+    const row = locateRow(ref);
+    if (row === "ambiguous") {
+      ctx.ui.notify(`Task ${ref} matches multiple slices. Use Sxx/Tyy format.`, "warning");
       return;
     }
+    if (row === "not-found") {
+      ctx.ui.notify(`No escalation found for ${ref} in ${milestoneId}.`, "warning");
+      return;
+    }
+    const taskId = row.id;
 
     const result = resolveEscalation(basePath, milestoneId, row.slice_id, taskId, choice, rationale);
     invalidateStateCache();

--- a/src/resources/extensions/gsd/commands/handlers/escalate.ts
+++ b/src/resources/extensions/gsd/commands/handlers/escalate.ts
@@ -1,0 +1,188 @@
+// GSD Extension — /gsd escalate Command Handler (ADR-011 Phase 2)
+// Surface and resolve mid-execution escalations from the CLI.
+
+import type { ExtensionAPI, ExtensionCommandContext } from "@gsd/pi-coding-agent";
+
+import { projectRoot } from "../context.js";
+import { getActiveMilestoneId } from "../../state.js";
+import {
+  readEscalationArtifact,
+  formatEscalationForDisplay,
+  resolveEscalation,
+  listActionableEscalations,
+  listAllEscalations,
+} from "../../escalation.js";
+import { saveDecisionToDb } from "../../db-writer.js";
+import { loadEffectiveGSDPreferences } from "../../preferences.js";
+import { invalidateStateCache } from "../../state.js";
+import { emitUokAuditEvent, buildAuditEnvelope } from "../../uok/audit.js";
+
+function helpMessage(): string {
+  return [
+    "/gsd escalate — manage mid-execution escalations (ADR-011 Phase 2)",
+    "",
+    "Subcommands:",
+    "  list [--all]           show pending escalations (use --all to include resolved)",
+    "  show <taskId>          print the escalation artifact",
+    "  resolve <taskId> <choice> [rationale...]",
+    "                         resolve an escalation — choice is an option id,",
+    "                         `accept` (use recommendation), or `reject-blocker`",
+    "                         (convert to a blocker and trigger slice replan)",
+    "",
+    "Note: disabling `phases.mid_execution_escalation` does NOT clear pending",
+    "escalations. If you need to drain them, re-enable the flag, resolve via",
+    "`/gsd escalate resolve`, then disable.",
+  ].join("\n");
+}
+
+function formatListEntries(
+  rows: ReturnType<typeof listActionableEscalations>,
+  basePath: string,
+): string {
+  if (rows.length === 0) return "No escalations.";
+  return rows.map((t) => {
+    const art = t.escalation_artifact_path ? readEscalationArtifact(t.escalation_artifact_path) : null;
+    const status = t.escalation_pending ? "PENDING (paused)" : t.escalation_awaiting_review ? "awaiting-review" : "resolved";
+    const question = art?.question ?? "(artifact missing)";
+    return `  ${t.slice_id}/${t.id}  [${status}]  ${question}`;
+  }).join("\n");
+}
+
+export async function handleEscalateCommand(
+  args: string,
+  ctx: ExtensionCommandContext,
+  pi: ExtensionAPI,
+): Promise<void> {
+  void pi;
+
+  const trimmed = args.trim();
+  if (trimmed === "" || trimmed === "help") {
+    ctx.ui.notify(helpMessage(), "info");
+    return;
+  }
+
+  const basePath = projectRoot();
+  const prefs = loadEffectiveGSDPreferences()?.preferences;
+  if (prefs?.phases?.mid_execution_escalation !== true) {
+    ctx.ui.notify(
+      "Escalation is off. Enable with `phases: { mid_execution_escalation: true }` in your PREFERENCES.md.",
+      "warning",
+    );
+    return;
+  }
+
+  const milestoneId = await getActiveMilestoneId(basePath);
+  if (!milestoneId) {
+    ctx.ui.notify("No active milestone — cannot list escalations.", "warning");
+    return;
+  }
+
+  // ── list ────────────────────────────────────────────────────────────────
+  if (trimmed === "list" || trimmed === "list --all" || trimmed === "--all") {
+    const includeAll = trimmed.includes("--all");
+    const rows = includeAll ? listAllEscalations(milestoneId) : listActionableEscalations(milestoneId);
+    const body = formatListEntries(rows, basePath);
+    ctx.ui.notify(
+      `${includeAll ? "All escalations" : "Actionable escalations"} for ${milestoneId}:\n${body}`,
+      "info",
+    );
+    return;
+  }
+
+  // ── show <taskId> ───────────────────────────────────────────────────────
+  if (trimmed.startsWith("show ")) {
+    const taskId = trimmed.slice(5).trim();
+    const rows = listAllEscalations(milestoneId).filter((t) => t.id === taskId);
+    const row = rows[0];
+    if (!row || !row.escalation_artifact_path) {
+      ctx.ui.notify(`No escalation found for task ${taskId} in ${milestoneId}.`, "warning");
+      return;
+    }
+    const art = readEscalationArtifact(row.escalation_artifact_path);
+    if (!art) {
+      ctx.ui.notify(`Escalation artifact at ${row.escalation_artifact_path} is missing or malformed.`, "error");
+      return;
+    }
+    ctx.ui.notify(formatEscalationForDisplay(art), "info");
+    return;
+  }
+
+  // ── resolve <taskId> <choice> [rationale...] ────────────────────────────
+  if (trimmed.startsWith("resolve ")) {
+    const parts = trimmed.slice(8).trim().split(/\s+/);
+    const taskId = parts[0];
+    const choice = parts[1];
+    const rationale = parts.slice(2).join(" ").trim();
+    if (!taskId || !choice) {
+      ctx.ui.notify("Usage: /gsd escalate resolve <taskId> <choice> [rationale...]", "warning");
+      return;
+    }
+
+    // Locate the slice id — scan the milestone for a matching task.
+    const rows = listAllEscalations(milestoneId).filter((t) => t.id === taskId);
+    const row = rows[0];
+    if (!row) {
+      ctx.ui.notify(`No escalation found for task ${taskId} in ${milestoneId}.`, "warning");
+      return;
+    }
+
+    const result = resolveEscalation(basePath, milestoneId, row.slice_id, taskId, choice, rationale);
+    invalidateStateCache();
+
+    if (result.status !== "resolved" && result.status !== "rejected-to-blocker") {
+      ctx.ui.notify(result.message, result.status === "invalid-choice" ? "warning" : "error");
+      return;
+    }
+
+    // Persist the user's choice as a decision (only for resolved, not reject-blocker).
+    if (result.status === "resolved") {
+      try {
+        const art = row.escalation_artifact_path ? readEscalationArtifact(row.escalation_artifact_path) : null;
+        const scope = `${milestoneId}/${row.slice_id}/${taskId}`;
+        const decisionText = art?.question ?? `escalation on ${taskId}`;
+        const choiceLabel = choice === "accept"
+          ? `${art?.recommendation ?? "accepted"} (recommended)`
+          : (result.chosenOption?.label ?? choice);
+        const { id: decisionId } = await saveDecisionToDb({
+          scope,
+          decision: decisionText,
+          choice: choiceLabel,
+          rationale: rationale || result.chosenOption?.tradeoffs || "User-resolved escalation.",
+          made_by: "human",
+          source: "escalation",
+          when_context: `ADR-011 escalation resolved ${new Date().toISOString()}`,
+        }, basePath);
+
+        emitUokAuditEvent(basePath, buildAuditEnvelope({
+          traceId: `escalation:${milestoneId}:${row.slice_id}:${taskId}`,
+          category: "gate",
+          type: "escalation-decision-persisted",
+          payload: {
+            milestoneId,
+            sliceId: row.slice_id,
+            taskId,
+            decisionId,
+            choice,
+          },
+        }));
+
+        ctx.ui.notify(
+          `${result.message}\nDecision recorded as ${decisionId}. Run /gsd auto to continue.`,
+          "success",
+        );
+      } catch (decErr) {
+        ctx.ui.notify(
+          `${result.message}\nWARN: decision persistence failed: ${(decErr as Error).message}`,
+          "warning",
+        );
+      }
+      return;
+    }
+
+    // rejected-to-blocker path
+    ctx.ui.notify(`${result.message} Run /gsd auto to trigger the replan.`, "success");
+    return;
+  }
+
+  ctx.ui.notify(`Unknown subcommand. ${helpMessage()}`, "warning");
+}

--- a/src/resources/extensions/gsd/commands/handlers/ops.ts
+++ b/src/resources/extensions/gsd/commands/handlers/ops.ts
@@ -191,6 +191,11 @@ Examples:
     await handleNotificationsCommand(trimmed.replace(/^notifications\s*/, "").trim(), ctx, pi);
     return true;
   }
+  if (trimmed === "escalate" || trimmed.startsWith("escalate ")) {
+    const { handleEscalateCommand } = await import("./escalate.js");
+    await handleEscalateCommand(trimmed.replace(/^escalate\s*/, "").trim(), ctx, pi);
+    return true;
+  }
   if (trimmed === "inspect") {
     await handleInspect(ctx);
     return true;

--- a/src/resources/extensions/gsd/db-writer.ts
+++ b/src/resources/extensions/gsd/db-writer.ts
@@ -373,6 +373,8 @@ export interface SaveDecisionFields {
   revisable?: string;
   when_context?: string;
   made_by?: import('./types.js').DecisionMadeBy;
+  /** ADR-011 Phase 2: origin of the decision — "discussion" (default), "planning", "escalation". */
+  source?: string;
 }
 
 /**
@@ -415,6 +417,7 @@ export async function saveDecisionToDb(
         rationale: fields.rationale,
         revisable: fields.revisable ?? 'Yes',
         made_by: fields.made_by ?? 'agent',
+        source: fields.source ?? 'discussion',
         superseded_by: null,
       });
 

--- a/src/resources/extensions/gsd/escalation.ts
+++ b/src/resources/extensions/gsd/escalation.ts
@@ -51,6 +51,19 @@ export function buildEscalationArtifact(params: {
   recommendationRationale: string;
   continueWithDefault: boolean;
 }): EscalationArtifact {
+  // Server-side validation — the MCP Type schema already constrains shape,
+  // but we belt-and-suspenders here so non-MCP callers can't construct
+  // malformed artifacts. These checks match readEscalationArtifact's.
+  if (!Array.isArray(params.options) || params.options.length < 2 || params.options.length > 4) {
+    throw new Error(`escalation.options must have between 2 and 4 entries (got ${params.options?.length ?? 0})`);
+  }
+  const optionIds = new Set(params.options.map((o) => o.id));
+  if (optionIds.size !== params.options.length) {
+    throw new Error("escalation.options must have unique ids");
+  }
+  if (!optionIds.has(params.recommendation)) {
+    throw new Error(`escalation.recommendation "${params.recommendation}" is not one of the option ids: ${[...optionIds].join(", ")}`);
+  }
   return {
     version: 1,
     taskId: params.taskId,
@@ -108,9 +121,29 @@ export function readEscalationArtifact(path: string): EscalationArtifact | null 
     const raw = readFileSync(path, "utf-8");
     const parsed = JSON.parse(raw) as unknown;
     if (!parsed || typeof parsed !== "object") return null;
-    const art = parsed as EscalationArtifact;
-    if (art.version !== 1 || !art.taskId || !art.question) return null;
-    return art;
+    const art = parsed as Partial<EscalationArtifact>;
+    // Full schema validation — invalid artifacts return null so downstream
+    // code (formatEscalationForDisplay, resolveEscalation, carry-forward)
+    // never crashes on malformed input.
+    if (art.version !== 1) return null;
+    if (typeof art.taskId !== "string" || art.taskId.length === 0) return null;
+    if (typeof art.sliceId !== "string" || art.sliceId.length === 0) return null;
+    if (typeof art.milestoneId !== "string" || art.milestoneId.length === 0) return null;
+    if (typeof art.question !== "string" || art.question.length === 0) return null;
+    if (!Array.isArray(art.options) || art.options.length === 0) return null;
+    for (const opt of art.options) {
+      if (!opt || typeof opt !== "object") return null;
+      const o = opt as Partial<EscalationOption>;
+      if (typeof o.id !== "string" || o.id.length === 0) return null;
+      if (typeof o.label !== "string") return null;
+      if (typeof o.tradeoffs !== "string") return null;
+    }
+    if (typeof art.recommendation !== "string") return null;
+    // Recommendation must reference a real option id.
+    if (!art.options.some((o) => o.id === art.recommendation)) return null;
+    if (typeof art.continueWithDefault !== "boolean") return null;
+    if (typeof art.createdAt !== "string") return null;
+    return art as EscalationArtifact;
   } catch {
     return null;
   }
@@ -240,20 +273,20 @@ export function claimOverrideForInjection(
 ): { injectionBlock: string; sourceTaskId: string } | null {
   const unapplied = findUnappliedEscalationOverride(milestoneId, sliceId);
   if (!unapplied) return null;
-  const claimed = claimEscalationOverride(milestoneId, sliceId, unapplied.taskId);
-  if (!claimed) return null; // lost the race
+  // Validate artifact BEFORE claiming so a missing/malformed file doesn't
+  // mark the DB row as applied (which would silently swallow the override
+  // forever). If the artifact is bad, return null without touching the row.
   const art = readEscalationArtifact(unapplied.artifactPath);
-  // We've already claimed the override in the DB but the file is missing or
-  // mid-resolution. Surface a warning so operators can unstick the row if
-  // needed — the override is effectively orphaned until a doctor/reset runs.
   if (!art) {
     logWarning(
       "tool",
-      `escalation: claim succeeded but artifact missing/malformed at ${unapplied.artifactPath} (task ${unapplied.taskId}); override will not be injected`,
+      `escalation: artifact missing/malformed at ${unapplied.artifactPath} (task ${unapplied.taskId}); skipping without claim — operator should resolve or remove the row`,
     );
     return null;
   }
   if (!art.respondedAt || !art.userChoice) return null;
+  const claimed = claimEscalationOverride(milestoneId, sliceId, unapplied.taskId);
+  if (!claimed) return null; // lost the race
   void basePath;
   return {
     injectionBlock: formatOverrideBlock(art),

--- a/src/resources/extensions/gsd/escalation.ts
+++ b/src/resources/extensions/gsd/escalation.ts
@@ -1,0 +1,323 @@
+// GSD Extension — ADR-011 Phase 2 Mid-Execution Escalation
+//
+// A single module that owns: escalation artifact I/O, detection, resolution,
+// carry-forward injection lookup, and audit-event emission. Scoped to
+// execute-task only (refine-slice escalation is deferred per ADR-011).
+
+import { existsSync, mkdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import type { EscalationArtifact, EscalationOption } from "./types.js";
+import { resolveSlicePath } from "./paths.js";
+import { atomicWriteSync } from "./atomic-write.js";
+import {
+  getTask,
+  setTaskEscalationPending,
+  setTaskEscalationAwaitingReview,
+  clearTaskEscalationFlags,
+  claimEscalationOverride,
+  findUnappliedEscalationOverride,
+  setTaskBlockerSource,
+  listEscalationArtifacts,
+  type TaskRow,
+} from "./gsd-db.js";
+import { emitUokAuditEvent, buildAuditEnvelope } from "./uok/audit.js";
+import { logWarning } from "./workflow-logger.js";
+
+// ─── Paths ────────────────────────────────────────────────────────────────
+
+/**
+ * Canonical escalation artifact path, parallel to T##-SUMMARY.md:
+ *   .gsd/milestones/{M}/slices/{S}/tasks/{T}-ESCALATION.json
+ */
+export function escalationArtifactPath(
+  basePath: string, milestoneId: string, sliceId: string, taskId: string,
+): string | null {
+  const sDir = resolveSlicePath(basePath, milestoneId, sliceId);
+  if (!sDir) return null;
+  return join(sDir, "tasks", `${taskId}-ESCALATION.json`);
+}
+
+// ─── Artifact I/O ─────────────────────────────────────────────────────────
+
+/** Build an EscalationArtifact from a gsd_complete_task escalation payload. */
+export function buildEscalationArtifact(params: {
+  taskId: string;
+  sliceId: string;
+  milestoneId: string;
+  question: string;
+  options: EscalationOption[];
+  recommendation: string;
+  recommendationRationale: string;
+  continueWithDefault: boolean;
+}): EscalationArtifact {
+  return {
+    version: 1,
+    taskId: params.taskId,
+    sliceId: params.sliceId,
+    milestoneId: params.milestoneId,
+    question: params.question,
+    options: params.options,
+    recommendation: params.recommendation,
+    recommendationRationale: params.recommendationRationale,
+    continueWithDefault: params.continueWithDefault,
+    createdAt: new Date().toISOString(),
+  };
+}
+
+/** Atomically write an escalation artifact and flip the appropriate DB flag. */
+export function writeEscalationArtifact(
+  basePath: string, artifact: EscalationArtifact,
+): string {
+  const path = escalationArtifactPath(basePath, artifact.milestoneId, artifact.sliceId, artifact.taskId);
+  if (!path) {
+    throw new Error(
+      `escalation: cannot resolve tasks dir for ${artifact.milestoneId}/${artifact.sliceId} — run doctor`,
+    );
+  }
+  mkdirSync(join(path, ".."), { recursive: true });
+  atomicWriteSync(path, JSON.stringify(artifact, null, 2));
+
+  if (artifact.continueWithDefault) {
+    setTaskEscalationAwaitingReview(artifact.milestoneId, artifact.sliceId, artifact.taskId, path);
+  } else {
+    setTaskEscalationPending(artifact.milestoneId, artifact.sliceId, artifact.taskId, path);
+  }
+
+  emitUokAuditEvent(basePath, buildAuditEnvelope({
+    traceId: `escalation:${artifact.milestoneId}:${artifact.sliceId}:${artifact.taskId}`,
+    category: "gate",
+    type: "escalation-manual-attention-created",
+    payload: {
+      milestoneId: artifact.milestoneId,
+      sliceId: artifact.sliceId,
+      taskId: artifact.taskId,
+      continueWithDefault: artifact.continueWithDefault,
+      optionCount: artifact.options.length,
+      recommendation: artifact.recommendation,
+    },
+  }));
+
+  return path;
+}
+
+/** Read an escalation artifact by path. Returns null when missing or malformed. */
+export function readEscalationArtifact(path: string): EscalationArtifact | null {
+  if (!existsSync(path)) return null;
+  try {
+    const raw = readFileSync(path, "utf-8");
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== "object") return null;
+    const art = parsed as EscalationArtifact;
+    if (art.version !== 1 || !art.taskId || !art.question) return null;
+    return art;
+  } catch {
+    return null;
+  }
+}
+
+// ─── Detection ────────────────────────────────────────────────────────────
+
+/**
+ * Returns the task id of the first task with an un-resolved pause-escalation
+ * (escalation_pending=1, not yet respondedAt). awaiting_review slices are NOT
+ * returned — they don't pause the loop.
+ */
+export function detectPendingEscalation(tasks: TaskRow[], basePath: string): string | null {
+  for (const t of tasks) {
+    if (t.escalation_pending !== 1) continue;
+    if (!t.escalation_artifact_path) continue;
+    const art = readEscalationArtifact(t.escalation_artifact_path);
+    if (art && !art.respondedAt) return t.id;
+  }
+  return null;
+}
+
+// ─── Resolution ───────────────────────────────────────────────────────────
+
+export interface ResolveEscalationResult {
+  status: "resolved" | "not-found" | "already-resolved" | "invalid-choice" | "rejected-to-blocker";
+  message: string;
+  artifactPath?: string;
+  chosenOption?: EscalationOption;
+}
+
+/**
+ * Apply a user response to a pending escalation:
+ *  1) Update the artifact with respondedAt/userChoice/userRationale.
+ *  2) Clear the DB escalation flags.
+ *  3) For "reject-blocker": set blocker_discovered=1 + blocker_source='reject-escalation'.
+ *  4) Emit audit events.
+ *
+ * Note: this does NOT persist a decision via saveDecisionToDb — the caller
+ * (commands/handlers/escalate.ts) owns that step so it can fail gracefully
+ * and surface the decision id in the user-visible message.
+ */
+export function resolveEscalation(
+  basePath: string, milestoneId: string, sliceId: string, taskId: string,
+  choice: string, rationale: string,
+): ResolveEscalationResult {
+  const task = getTask(milestoneId, sliceId, taskId);
+  if (!task || !task.escalation_artifact_path) {
+    return { status: "not-found", message: `No escalation artifact found for ${milestoneId}/${sliceId}/${taskId}.` };
+  }
+  const art = readEscalationArtifact(task.escalation_artifact_path);
+  if (!art) {
+    return { status: "not-found", message: `Escalation artifact at ${task.escalation_artifact_path} is missing or malformed.` };
+  }
+  if (art.respondedAt) {
+    return { status: "already-resolved", message: `Escalation for ${taskId} was already resolved at ${art.respondedAt}.` };
+  }
+
+  // Resolve `choice` into a concrete option.
+  let chosenOption: EscalationOption | undefined;
+  if (choice === "accept") {
+    chosenOption = art.options.find((o) => o.id === art.recommendation);
+  } else if (choice === "reject-blocker") {
+    // Handled below; no option selection.
+  } else {
+    chosenOption = art.options.find((o) => o.id === choice);
+    if (!chosenOption) {
+      const valid = ["accept", "reject-blocker", ...art.options.map((o) => o.id)].join(", ");
+      return { status: "invalid-choice", message: `Unknown choice "${choice}". Valid choices: ${valid}.` };
+    }
+  }
+
+  const respondedAt = new Date().toISOString();
+  const updated: EscalationArtifact = {
+    ...art,
+    respondedAt,
+    userChoice: choice,
+    userRationale: rationale,
+  };
+  atomicWriteSync(task.escalation_artifact_path, JSON.stringify(updated, null, 2));
+  clearTaskEscalationFlags(milestoneId, sliceId, taskId);
+
+  if (choice === "reject-blocker") {
+    setTaskBlockerSource(milestoneId, sliceId, taskId, "reject-escalation");
+    emitUokAuditEvent(basePath, buildAuditEnvelope({
+      traceId: `escalation:${milestoneId}:${sliceId}:${taskId}`,
+      category: "gate",
+      type: "escalation-rejected-to-blocker",
+      payload: { milestoneId, sliceId, taskId, rationale },
+    }));
+    return {
+      status: "rejected-to-blocker",
+      message: `Escalation rejected. Task ${taskId} now flagged as a blocker — next /gsd auto will replan slice ${sliceId}.`,
+      artifactPath: task.escalation_artifact_path,
+    };
+  }
+
+  emitUokAuditEvent(basePath, buildAuditEnvelope({
+    traceId: `escalation:${milestoneId}:${sliceId}:${taskId}`,
+    category: "gate",
+    type: "escalation-user-responded",
+    payload: {
+      milestoneId, sliceId, taskId,
+      chosenOptionId: chosenOption?.id,
+      rationale,
+    },
+  }));
+
+  return {
+    status: "resolved",
+    message: `Escalation resolved. Next task in ${sliceId} will receive the override.`,
+    artifactPath: task.escalation_artifact_path,
+    chosenOption,
+  };
+}
+
+// ─── Carry-forward lookup ─────────────────────────────────────────────────
+
+/**
+ * If this slice has a resolved-but-unapplied escalation override, atomically
+ * claim it (via DB UPDATE) and return the markdown block to prepend to the
+ * next task's prompt. Returns null when there's no unapplied override OR
+ * when another caller claimed it first (idempotent).
+ */
+export function claimOverrideForInjection(
+  basePath: string, milestoneId: string, sliceId: string,
+): { injectionBlock: string; sourceTaskId: string } | null {
+  const unapplied = findUnappliedEscalationOverride(milestoneId, sliceId);
+  if (!unapplied) return null;
+  const claimed = claimEscalationOverride(milestoneId, sliceId, unapplied.taskId);
+  if (!claimed) return null; // lost the race
+  const art = readEscalationArtifact(unapplied.artifactPath);
+  // We've already claimed the override in the DB but the file is missing or
+  // mid-resolution. Surface a warning so operators can unstick the row if
+  // needed — the override is effectively orphaned until a doctor/reset runs.
+  if (!art) {
+    logWarning(
+      "escalation",
+      `claim succeeded but artifact missing/malformed at ${unapplied.artifactPath} (task ${unapplied.taskId}); override will not be injected`,
+    );
+    return null;
+  }
+  if (!art.respondedAt || !art.userChoice) return null;
+  void basePath;
+  return {
+    injectionBlock: formatOverrideBlock(art),
+    sourceTaskId: unapplied.taskId,
+  };
+}
+
+function formatOverrideBlock(art: EscalationArtifact): string {
+  const isReject = art.userChoice === "reject-blocker";
+  const choiceLabel = isReject
+    ? "rejected — blocker path"
+    : art.userChoice === "accept"
+      ? `accepted recommendation (${art.recommendation})`
+      : (art.options.find((o) => o.id === art.userChoice)?.label ?? art.userChoice ?? "unknown");
+
+  const tradeoffs = art.userChoice && art.userChoice !== "accept" && art.userChoice !== "reject-blocker"
+    ? art.options.find((o) => o.id === art.userChoice)?.tradeoffs ?? ""
+    : "";
+
+  const rationale = art.userRationale ? `\n\n**User rationale:** ${art.userRationale}` : "";
+
+  return [
+    `## Escalation Override (from ${art.taskId})`,
+    "",
+    `During ${art.taskId} the executor escalated: **${art.question}**`,
+    "",
+    `The user's resolution: **${choiceLabel}**.${rationale}`,
+    tradeoffs ? `\n**Tradeoffs of this choice:** ${tradeoffs}` : "",
+    "",
+    "Apply this decision as a hard constraint for the current task. If it contradicts the task plan, surface the conflict in your summary rather than silently deviating.",
+  ].filter((line) => line !== undefined).join("\n");
+}
+
+// ─── Display ──────────────────────────────────────────────────────────────
+
+/** Human-readable summary of an artifact for `/gsd escalate show`. */
+export function formatEscalationForDisplay(art: EscalationArtifact): string {
+  const resolved = art.respondedAt
+    ? `\nResolved: ${art.respondedAt} — user chose "${art.userChoice}"${art.userRationale ? ` (rationale: ${art.userRationale})` : ""}`
+    : "\nStatus: awaiting user response";
+  const optionLines = art.options.map((o) =>
+    `  [${o.id}] ${o.label}${o.id === art.recommendation ? "  (recommended)" : ""}\n      ${o.tradeoffs}`,
+  ).join("\n");
+  return [
+    `Task ${art.taskId} (slice ${art.sliceId})`,
+    `continueWithDefault: ${art.continueWithDefault}`,
+    `Question: ${art.question}`,
+    "",
+    "Options:",
+    optionLines,
+    "",
+    `Recommendation: ${art.recommendation} — ${art.recommendationRationale}`,
+    resolved,
+    "",
+    `Resolve with: /gsd escalate resolve ${art.taskId} <${art.options.map((o) => o.id).join("|")}|accept|reject-blocker> [rationale...]`,
+  ].join("\n");
+}
+
+/** List actionable (unresolved) escalations for `/gsd escalate list`. */
+export function listActionableEscalations(milestoneId: string): TaskRow[] {
+  return listEscalationArtifacts(milestoneId, /* includeResolved */ false);
+}
+
+/** List every escalation (including resolved) for `/gsd escalate list --all`. */
+export function listAllEscalations(milestoneId: string): TaskRow[] {
+  return listEscalationArtifacts(milestoneId, /* includeResolved */ true);
+}

--- a/src/resources/extensions/gsd/escalation.ts
+++ b/src/resources/extensions/gsd/escalation.ts
@@ -248,8 +248,8 @@ export function claimOverrideForInjection(
   // needed — the override is effectively orphaned until a doctor/reset runs.
   if (!art) {
     logWarning(
-      "escalation",
-      `claim succeeded but artifact missing/malformed at ${unapplied.artifactPath} (task ${unapplied.taskId}); override will not be injected`,
+      "tool",
+      `escalation: claim succeeded but artifact missing/malformed at ${unapplied.artifactPath} (task ${unapplied.taskId}); override will not be injected`,
     );
     return null;
   }

--- a/src/resources/extensions/gsd/gsd-db.ts
+++ b/src/resources/extensions/gsd/gsd-db.ts
@@ -531,6 +531,9 @@ function initSchema(db: DbAdapter, fileBacked: boolean): void {
     db.exec("CREATE INDEX IF NOT EXISTS idx_turn_git_tx_turn ON turn_git_transactions(trace_id, turn_id)");
     db.exec("CREATE INDEX IF NOT EXISTS idx_audit_events_trace ON audit_events(trace_id, ts)");
     db.exec("CREATE INDEX IF NOT EXISTS idx_audit_events_turn ON audit_events(trace_id, turn_id, ts)");
+    // ADR-011 Phase 2 — also created by the v17 migration; fresh installs
+    // skip migrations so the index must be created here too.
+    db.exec("CREATE INDEX IF NOT EXISTS idx_tasks_escalation_pending ON tasks(milestone_id, slice_id, escalation_pending)");
 
     db.exec(`CREATE VIEW IF NOT EXISTS active_decisions AS SELECT * FROM decisions WHERE superseded_by IS NULL`);
     db.exec(`CREATE VIEW IF NOT EXISTS active_requirements AS SELECT * FROM requirements WHERE superseded_by IS NULL`);
@@ -3179,14 +3182,16 @@ export function restoreManifest(manifest: StateManifest): void {
       );
     }
 
-    // Restore tasks
+    // Restore tasks (ADR-011 P2: includes blocker_source + escalation_* columns)
     const tkStmt = db.prepare(
       `INSERT INTO tasks (milestone_id, slice_id, id, title, status,
         one_liner, narrative, verification_result, duration, completed_at,
         blocker_discovered, deviations, known_issues, key_files, key_decisions,
         full_summary_md, description, estimate, files, verify,
-        inputs, expected_output, observability_impact, sequence)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        inputs, expected_output, observability_impact, sequence,
+        blocker_source, escalation_pending, escalation_awaiting_review,
+        escalation_artifact_path, escalation_override_applied_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     );
     for (const t of manifest.tasks) {
       tkStmt.run(
@@ -3197,16 +3202,21 @@ export function restoreManifest(manifest: StateManifest): void {
         t.full_summary_md, t.description, t.estimate, JSON.stringify(t.files), t.verify,
         JSON.stringify(t.inputs), JSON.stringify(t.expected_output),
         t.observability_impact, t.sequence,
+        t.blocker_source ?? "",
+        t.escalation_pending ?? 0,
+        t.escalation_awaiting_review ?? 0,
+        t.escalation_artifact_path ?? null,
+        t.escalation_override_applied_at ?? null,
       );
     }
 
-    // Restore decisions
+    // Restore decisions (ADR-011 P2: include source so escalation decisions survive)
     const dcStmt = db.prepare(
-      `INSERT INTO decisions (seq, id, when_context, scope, decision, choice, rationale, revisable, made_by, superseded_by)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      `INSERT INTO decisions (seq, id, when_context, scope, decision, choice, rationale, revisable, made_by, source, superseded_by)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     );
     for (const d of manifest.decisions) {
-      dcStmt.run(d.seq, d.id, d.when_context, d.scope, d.decision, d.choice, d.rationale, d.revisable, d.made_by, d.superseded_by);
+      dcStmt.run(d.seq, d.id, d.when_context, d.scope, d.decision, d.choice, d.rationale, d.revisable, d.made_by, d.source ?? "discussion", d.superseded_by);
     }
 
     // Restore verification evidence

--- a/src/resources/extensions/gsd/gsd-db.ts
+++ b/src/resources/extensions/gsd/gsd-db.ts
@@ -1207,6 +1207,7 @@ export function getActiveDecisions(): Decision[] {
     rationale: row["rationale"] as string,
     revisable: row["revisable"] as string,
     made_by: (row["made_by"] as string as import("./types.js").DecisionMadeBy) ?? "agent",
+    source: (row["source"] as string) ?? "discussion",
     superseded_by: null,
   }));
 }
@@ -2331,6 +2332,14 @@ export function reconcileWorktreeDb(
     try {
       const wtInfo = adapter.prepare("PRAGMA wt.table_info('decisions')").all();
       const hasMadeBy = wtInfo.some((col) => col["name"] === "made_by");
+      // ADR-011 P2: worktree may predate schema v16/v17; fall back to defaults when columns are missing.
+      const hasDecisionSource = wtInfo.some((col) => col["name"] === "source");
+      const wtTaskInfo = adapter.prepare("PRAGMA wt.table_info('tasks')").all();
+      const hasBlockerSource = wtTaskInfo.some((col) => col["name"] === "blocker_source");
+      const hasEscalationPending = wtTaskInfo.some((col) => col["name"] === "escalation_pending");
+      const hasEscalationAwaiting = wtTaskInfo.some((col) => col["name"] === "escalation_awaiting_review");
+      const hasEscalationArtifact = wtTaskInfo.some((col) => col["name"] === "escalation_artifact_path");
+      const hasEscalationOverride = wtTaskInfo.some((col) => col["name"] === "escalation_override_applied_at");
 
       const decConf = adapter.prepare(
         `SELECT m.id FROM decisions m INNER JOIN wt.decisions w ON m.id = w.id WHERE m.decision != w.decision OR m.choice != w.choice OR m.rationale != w.rationale OR ${
@@ -2354,10 +2363,12 @@ export function reconcileWorktreeDb(
       try {
         merged.decisions = countChanges(adapter.prepare(`
           INSERT OR REPLACE INTO decisions (
-            id, when_context, scope, decision, choice, rationale, revisable, made_by, superseded_by
+            id, when_context, scope, decision, choice, rationale, revisable, made_by, source, superseded_by
           )
           SELECT id, when_context, scope, decision, choice, rationale, revisable, ${
             hasMadeBy ? "made_by" : "'agent'"
+          }, ${
+            hasDecisionSource ? "source" : "'discussion'"
           }, superseded_by FROM wt.decisions
         `).run());
 
@@ -2419,14 +2430,18 @@ export function reconcileWorktreeDb(
           LEFT JOIN slices m ON m.milestone_id = w.milestone_id AND m.id = w.id
         `).run());
 
-        // Merge tasks — preserve execution results, never downgrade completed status (#2558)
+        // Merge tasks — preserve execution results, never downgrade completed status (#2558).
+        // ADR-011 P2: carry blocker_source + escalation_* columns so worktree reconcile
+        // doesn't silently clear escalation state back to defaults.
         merged.tasks = countChanges(adapter.prepare(`
           INSERT OR REPLACE INTO tasks (
             milestone_id, slice_id, id, title, status, one_liner, narrative,
             verification_result, duration, completed_at, blocker_discovered,
             deviations, known_issues, key_files, key_decisions, full_summary_md,
             description, estimate, files, verify, inputs, expected_output,
-            observability_impact, full_plan_md, sequence
+            observability_impact, full_plan_md, sequence,
+            blocker_source, escalation_pending, escalation_awaiting_review,
+            escalation_artifact_path, escalation_override_applied_at
           )
           SELECT w.milestone_id, w.slice_id, w.id, w.title,
                  CASE
@@ -2442,7 +2457,12 @@ export function reconcileWorktreeDb(
                  w.blocker_discovered,
                  w.deviations, w.known_issues, w.key_files, w.key_decisions, w.full_summary_md,
                  w.description, w.estimate, w.files, w.verify, w.inputs, w.expected_output,
-                 w.observability_impact, w.full_plan_md, w.sequence
+                 w.observability_impact, w.full_plan_md, w.sequence,
+                 ${hasBlockerSource ? "w.blocker_source" : "''"},
+                 ${hasEscalationPending ? "w.escalation_pending" : "0"},
+                 ${hasEscalationAwaiting ? "w.escalation_awaiting_review" : "0"},
+                 ${hasEscalationArtifact ? "w.escalation_artifact_path" : "NULL"},
+                 ${hasEscalationOverride ? "w.escalation_override_applied_at" : "NULL"}
           FROM wt.tasks w
           LEFT JOIN tasks m ON m.milestone_id = w.milestone_id AND m.slice_id = w.slice_id AND m.id = w.id
         `).run());

--- a/src/resources/extensions/gsd/gsd-db.ts
+++ b/src/resources/extensions/gsd/gsd-db.ts
@@ -180,7 +180,7 @@ function openRawDb(path: string): unknown {
   return new Database(path);
 }
 
-const SCHEMA_VERSION = 15;
+const SCHEMA_VERSION = 17;
 
 function indexExists(db: DbAdapter, name: string): boolean {
   return !!db.prepare(
@@ -235,6 +235,7 @@ function initSchema(db: DbAdapter, fileBacked: boolean): void {
         rationale TEXT NOT NULL DEFAULT '',
         revisable TEXT NOT NULL DEFAULT '',
         made_by TEXT NOT NULL DEFAULT 'agent',
+        source TEXT NOT NULL DEFAULT 'discussion', -- ADR-011 P2: 'discussion' | 'planning' | 'escalation'
         superseded_by TEXT DEFAULT NULL
       )
     `);
@@ -352,6 +353,11 @@ function initSchema(db: DbAdapter, fileBacked: boolean): void {
         duration TEXT NOT NULL DEFAULT '',
         completed_at TEXT DEFAULT NULL,
         blocker_discovered INTEGER DEFAULT 0,
+        blocker_source TEXT NOT NULL DEFAULT '', -- ADR-011 P2: provenance for blocker_discovered (e.g. 'reject-escalation')
+        escalation_pending INTEGER NOT NULL DEFAULT 0, -- ADR-011 P2: pause-on-escalation flag
+        escalation_awaiting_review INTEGER NOT NULL DEFAULT 0, -- ADR-011 P2: artifact exists but continueWithDefault=true (no pause)
+        escalation_artifact_path TEXT DEFAULT NULL, -- ADR-011 P2: path to T##-ESCALATION.json
+        escalation_override_applied_at TEXT DEFAULT NULL, -- ADR-011 P2: DB claim lock for idempotent override injection
         deviations TEXT NOT NULL DEFAULT '',
         known_issues TEXT NOT NULL DEFAULT '',
         key_files TEXT NOT NULL DEFAULT '[]',
@@ -951,6 +957,29 @@ function migrateSchema(db: DbAdapter): void {
       });
     }
 
+    if (currentVersion < 16) {
+      // ADR-011 Phase 2: decisions can now be sourced from escalation resolutions.
+      ensureColumn(db, "decisions", "source", `ALTER TABLE decisions ADD COLUMN source TEXT NOT NULL DEFAULT 'discussion'`);
+      db.prepare("INSERT INTO schema_version (version, applied_at) VALUES (:version, :applied_at)").run({
+        ":version": 16,
+        ":applied_at": new Date().toISOString(),
+      });
+    }
+
+    if (currentVersion < 17) {
+      // ADR-011 Phase 2: mid-execution escalation — columns on the tasks table.
+      ensureColumn(db, "tasks", "blocker_source", `ALTER TABLE tasks ADD COLUMN blocker_source TEXT NOT NULL DEFAULT ''`);
+      ensureColumn(db, "tasks", "escalation_pending", `ALTER TABLE tasks ADD COLUMN escalation_pending INTEGER NOT NULL DEFAULT 0`);
+      ensureColumn(db, "tasks", "escalation_awaiting_review", `ALTER TABLE tasks ADD COLUMN escalation_awaiting_review INTEGER NOT NULL DEFAULT 0`);
+      ensureColumn(db, "tasks", "escalation_artifact_path", `ALTER TABLE tasks ADD COLUMN escalation_artifact_path TEXT DEFAULT NULL`);
+      ensureColumn(db, "tasks", "escalation_override_applied_at", `ALTER TABLE tasks ADD COLUMN escalation_override_applied_at TEXT DEFAULT NULL`);
+      db.exec("CREATE INDEX IF NOT EXISTS idx_tasks_escalation_pending ON tasks(milestone_id, slice_id, escalation_pending)");
+      db.prepare("INSERT INTO schema_version (version, applied_at) VALUES (:version, :applied_at)").run({
+        ":version": 17,
+        ":applied_at": new Date().toISOString(),
+      });
+    }
+
     db.exec("COMMIT");
   } catch (err) {
     db.exec("ROLLBACK");
@@ -1127,8 +1156,8 @@ export function readTransaction<T>(fn: () => T): T {
 export function insertDecision(d: Omit<Decision, "seq">): void {
   if (!currentDb) throw new GSDError(GSD_STALE_STATE, "gsd-db: No database open");
   currentDb.prepare(
-    `INSERT INTO decisions (id, when_context, scope, decision, choice, rationale, revisable, made_by, superseded_by)
-     VALUES (:id, :when_context, :scope, :decision, :choice, :rationale, :revisable, :made_by, :superseded_by)`,
+    `INSERT INTO decisions (id, when_context, scope, decision, choice, rationale, revisable, made_by, source, superseded_by)
+     VALUES (:id, :when_context, :scope, :decision, :choice, :rationale, :revisable, :made_by, :source, :superseded_by)`,
   ).run({
     ":id": d.id,
     ":when_context": d.when_context,
@@ -1138,6 +1167,7 @@ export function insertDecision(d: Omit<Decision, "seq">): void {
     ":rationale": d.rationale,
     ":revisable": d.revisable,
     ":made_by": d.made_by ?? "agent",
+    ":source": d.source ?? "discussion",
     ":superseded_by": d.superseded_by,
   });
 }
@@ -1156,6 +1186,7 @@ export function getDecisionById(id: string): Decision | null {
     rationale: row["rationale"] as string,
     revisable: row["revisable"] as string,
     made_by: (row["made_by"] as string as import("./types.js").DecisionMadeBy) ?? "agent",
+    source: (row["source"] as string) ?? "discussion",
     superseded_by: (row["superseded_by"] as string) ?? null,
   };
 }
@@ -1261,8 +1292,8 @@ export function upsertDecision(d: Omit<Decision, "seq">): void {
   // seq column. INSERT OR REPLACE deletes then reinserts, resetting seq and
   // corrupting decision ordering in DECISIONS.md after reconcile replay.
   currentDb.prepare(
-    `INSERT INTO decisions (id, when_context, scope, decision, choice, rationale, revisable, made_by, superseded_by)
-     VALUES (:id, :when_context, :scope, :decision, :choice, :rationale, :revisable, :made_by, :superseded_by)
+    `INSERT INTO decisions (id, when_context, scope, decision, choice, rationale, revisable, made_by, source, superseded_by)
+     VALUES (:id, :when_context, :scope, :decision, :choice, :rationale, :revisable, :made_by, :source, :superseded_by)
      ON CONFLICT(id) DO UPDATE SET
        when_context = excluded.when_context,
        scope = excluded.scope,
@@ -1271,6 +1302,7 @@ export function upsertDecision(d: Omit<Decision, "seq">): void {
        rationale = excluded.rationale,
        revisable = excluded.revisable,
        made_by = excluded.made_by,
+       source = excluded.source,
        superseded_by = excluded.superseded_by`,
   ).run({
     ":id": d.id,
@@ -1281,6 +1313,7 @@ export function upsertDecision(d: Omit<Decision, "seq">): void {
     ":rationale": d.rationale,
     ":revisable": d.revisable,
     ":made_by": d.made_by ?? "agent",
+    ":source": d.source ?? "discussion",
     ":superseded_by": d.superseded_by ?? null,
   });
 }
@@ -1764,6 +1797,12 @@ export interface TaskRow {
   observability_impact: string;
   full_plan_md: string;
   sequence: number;
+  // ADR-011 Phase 2 escalation fields
+  blocker_source: string;
+  escalation_pending: number;
+  escalation_awaiting_review: number;
+  escalation_artifact_path: string | null;
+  escalation_override_applied_at: string | null;
 }
 
 function parseTaskArrayColumn(raw: unknown): string[] {
@@ -1834,6 +1873,11 @@ function rowToTask(row: Record<string, unknown>): TaskRow {
     observability_impact: (row["observability_impact"] as string) ?? "",
     full_plan_md: (row["full_plan_md"] as string) ?? "",
     sequence: (row["sequence"] as number) ?? 0,
+    blocker_source: (row["blocker_source"] as string) ?? "",
+    escalation_pending: (row["escalation_pending"] as number) ?? 0,
+    escalation_awaiting_review: (row["escalation_awaiting_review"] as number) ?? 0,
+    escalation_artifact_path: (row["escalation_artifact_path"] as string) ?? null,
+    escalation_override_applied_at: (row["escalation_override_applied_at"] as string) ?? null,
   };
 }
 
@@ -1851,6 +1895,123 @@ export function getSliceTasks(milestoneId: string, sliceId: string): TaskRow[] {
   const rows = currentDb.prepare(
     "SELECT * FROM tasks WHERE milestone_id = :mid AND slice_id = :sid ORDER BY sequence, id",
   ).all({ ":mid": milestoneId, ":sid": sliceId });
+  return rows.map(rowToTask);
+}
+
+// ─── ADR-011 Phase 2 escalation helpers ──────────────────────────────────
+
+/** Set pause-on-escalation state on a completed task. */
+export function setTaskEscalationPending(
+  milestoneId: string, sliceId: string, taskId: string,
+  artifactPath: string,
+): void {
+  if (!currentDb) throw new GSDError(GSD_STALE_STATE, "gsd-db: No database open");
+  currentDb.prepare(
+    `UPDATE tasks
+       SET escalation_pending = 1,
+           escalation_artifact_path = :path
+     WHERE milestone_id = :mid AND slice_id = :sid AND id = :tid`,
+  ).run({ ":path": artifactPath, ":mid": milestoneId, ":sid": sliceId, ":tid": taskId });
+}
+
+/** Set awaiting-review state (artifact exists but continueWithDefault=true, no pause). */
+export function setTaskEscalationAwaitingReview(
+  milestoneId: string, sliceId: string, taskId: string,
+  artifactPath: string,
+): void {
+  if (!currentDb) throw new GSDError(GSD_STALE_STATE, "gsd-db: No database open");
+  currentDb.prepare(
+    `UPDATE tasks
+       SET escalation_awaiting_review = 1,
+           escalation_artifact_path = :path
+     WHERE milestone_id = :mid AND slice_id = :sid AND id = :tid`,
+  ).run({ ":path": artifactPath, ":mid": milestoneId, ":sid": sliceId, ":tid": taskId });
+}
+
+/** Clear escalation-pending and awaiting-review flags once the user has resolved it. */
+export function clearTaskEscalationFlags(
+  milestoneId: string, sliceId: string, taskId: string,
+): void {
+  if (!currentDb) throw new GSDError(GSD_STALE_STATE, "gsd-db: No database open");
+  currentDb.prepare(
+    `UPDATE tasks
+       SET escalation_pending = 0,
+           escalation_awaiting_review = 0
+     WHERE milestone_id = :mid AND slice_id = :sid AND id = :tid`,
+  ).run({ ":mid": milestoneId, ":sid": sliceId, ":tid": taskId });
+}
+
+/**
+ * Atomically claim a resolved escalation override for injection into a downstream
+ * task's prompt. Returns true if this caller claimed it (must inject), false if
+ * another caller already claimed it (must skip).
+ */
+export function claimEscalationOverride(
+  milestoneId: string, sliceId: string, sourceTaskId: string,
+): boolean {
+  if (!currentDb) return false;
+  const now = new Date().toISOString();
+  const result = currentDb.prepare(
+    `UPDATE tasks
+       SET escalation_override_applied_at = :now
+     WHERE milestone_id = :mid AND slice_id = :sid AND id = :tid
+       AND escalation_override_applied_at IS NULL
+       AND escalation_artifact_path IS NOT NULL`,
+  ).run({ ":now": now, ":mid": milestoneId, ":sid": sliceId, ":tid": sourceTaskId });
+  // node:sqlite + better-sqlite3 both surface `changes` on the run result.
+  const changes = (result as { changes?: number }).changes ?? 0;
+  return changes > 0;
+}
+
+/** Find the most recent resolved-but-unapplied escalation override in a slice. */
+export function findUnappliedEscalationOverride(
+  milestoneId: string, sliceId: string,
+): { taskId: string; artifactPath: string } | null {
+  if (!currentDb) return null;
+  // Filter BOTH flags: escalation_pending=0 AND escalation_awaiting_review=0
+  // ensures we only claim overrides the user has explicitly resolved.
+  // Without the awaiting_review filter, continueWithDefault=true artifacts
+  // (not yet responded to) would be prematurely claimed, causing the override
+  // to be lost when the user later resolves (#ADR-011 Phase 2 peer-review Bug 2).
+  const row = currentDb.prepare(
+    `SELECT id, escalation_artifact_path AS path
+       FROM tasks
+      WHERE milestone_id = :mid AND slice_id = :sid
+        AND escalation_artifact_path IS NOT NULL
+        AND escalation_override_applied_at IS NULL
+        AND escalation_pending = 0
+        AND escalation_awaiting_review = 0
+      ORDER BY sequence DESC, id DESC
+      LIMIT 1`,
+  ).get({ ":mid": milestoneId, ":sid": sliceId }) as
+    | { id: string; path: string | null }
+    | undefined;
+  if (!row || !row.path) return null;
+  return { taskId: row.id, artifactPath: row.path };
+}
+
+/** Set the blocker_source provenance field (used when rejecting an escalation). */
+export function setTaskBlockerSource(
+  milestoneId: string, sliceId: string, taskId: string, source: string,
+): void {
+  if (!currentDb) throw new GSDError(GSD_STALE_STATE, "gsd-db: No database open");
+  currentDb.prepare(
+    `UPDATE tasks
+       SET blocker_discovered = 1,
+           blocker_source = :src
+     WHERE milestone_id = :mid AND slice_id = :sid AND id = :tid`,
+  ).run({ ":src": source, ":mid": milestoneId, ":sid": sliceId, ":tid": taskId });
+}
+
+/** List tasks with active escalation artifacts across a milestone (for /gsd escalate list). */
+export function listEscalationArtifacts(milestoneId: string, includeResolved: boolean = false): TaskRow[] {
+  if (!currentDb) return [];
+  const filter = includeResolved
+    ? "escalation_artifact_path IS NOT NULL"
+    : "(escalation_pending = 1 OR escalation_awaiting_review = 1) AND escalation_artifact_path IS NOT NULL";
+  const rows = currentDb.prepare(
+    `SELECT * FROM tasks WHERE milestone_id = :mid AND ${filter} ORDER BY slice_id, sequence, id`,
+  ).all({ ":mid": milestoneId });
   return rows.map(rowToTask);
 }
 

--- a/src/resources/extensions/gsd/preferences-validation.ts
+++ b/src/resources/extensions/gsd/preferences-validation.ts
@@ -319,8 +319,9 @@ export function validatePreferences(preferences: GSDPreferences): {
       if (p.skip_milestone_validation !== undefined) validatedPhases.skip_milestone_validation = !!p.skip_milestone_validation;
       if (p.reassess_after_slice !== undefined) validatedPhases.reassess_after_slice = !!p.reassess_after_slice;
       if ((p as any).require_slice_discussion !== undefined) (validatedPhases as any).require_slice_discussion = !!(p as any).require_slice_discussion;
+      if (p.mid_execution_escalation !== undefined) validatedPhases.mid_execution_escalation = !!p.mid_execution_escalation;
       // Warn on unknown phase keys
-      const knownPhaseKeys = new Set(["skip_research", "skip_reassess", "skip_slice_research", "skip_milestone_validation", "reassess_after_slice", "require_slice_discussion"]);
+      const knownPhaseKeys = new Set(["skip_research", "skip_reassess", "skip_slice_research", "skip_milestone_validation", "reassess_after_slice", "require_slice_discussion", "mid_execution_escalation"]);
       for (const key of Object.keys(p)) {
         if (!knownPhaseKeys.has(key)) {
           warnings.push(`unknown phases key "${key}" — ignored`);

--- a/src/resources/extensions/gsd/prompts/execute-task.md
+++ b/src/resources/extensions/gsd/prompts/execute-task.md
@@ -69,6 +69,18 @@ Then:
     - Know when to stop. If you've tried 3+ fixes without progress, your mental model is probably wrong. Stop. List what you know for certain. List what you've ruled out. Form fresh hypotheses from there.
     - Don't fix symptoms. Understand *why* something fails before changing code. A test that passes after a change you don't understand is luck, not a fix.
 16. **Blocker discovery:** If execution reveals that the remaining slice plan is fundamentally invalid — not just a bug or minor deviation, but a plan-invalidating finding like a wrong API, missing capability, or architectural mismatch — set `blocker_discovered: true` in the task summary frontmatter and describe the blocker clearly in the summary narrative. Do NOT set `blocker_discovered: true` for ordinary debugging, minor deviations, or issues that can be fixed within the current task or the remaining plan. This flag triggers an automatic replan of the slice.
+16a. **Mid-execution escalation (ADR-011 Phase 2):** If you hit an ambiguity that is *not* a plan-invalidating blocker but whose resolution materially affects downstream work AND cannot be derived from the task plan, CONTEXT.md, DECISIONS.md, or codebase evidence, you MAY escalate to the user. Populate an `escalation` object alongside the milestoneId/sliceId/taskId fields on your completion tool call with:
+    - `question` — one clear sentence
+    - `options` — 2–4 entries with `id` (short, e.g. "A", "B"), `label`, and 1–2 sentence `tradeoffs`
+    - `recommendation` — the option `id` you recommend
+    - `recommendationRationale` — 1–2 sentences on why
+    - `continueWithDefault` — `true` means finish the task using your recommendation now and let the user's later response inject a correction into the NEXT task; `false` means auto-mode pauses until the user resolves via `/gsd escalate resolve <taskId> <choice>`.
+
+    Escalate ONLY when the answer materially affects downstream tasks AND cannot be resolved from available context. Do NOT escalate for implementation style, minor deviations, or anything already covered by DECISIONS.md. Escalations must include a real recommendation — do not ask the user to pick without giving your best judgment.
+
+    **Scope:** Escalation is instrumented only in `execute-task`. Refine-slice escalation is deferred. Reactive-execute batches run to completion before escalations are surfaced — the dispatch pause happens on the next loop iteration, not mid-batch.
+
+    The `escalation` payload is ignored unless `phases.mid_execution_escalation` is enabled; populate it anyway for audit logs.
 17. If you made an architectural, pattern, library, or observability decision during this task that downstream work should know about, append it to `.gsd/DECISIONS.md` (read the template at `~/.gsd/agent/extensions/gsd/templates/decisions.md` if the file doesn't exist yet). Not every task produces decisions — only append when a meaningful choice was made.
 18. If you discover a non-obvious rule, recurring gotcha, or useful pattern during execution, append it to `.gsd/KNOWLEDGE.md`. Only add entries that would save future agents from repeating your investigation. Don't add obvious things.
 19. Read the template at `~/.gsd/agent/extensions/gsd/templates/task-summary.md`

--- a/src/resources/extensions/gsd/state.ts
+++ b/src/resources/extensions/gsd/state.ts
@@ -44,6 +44,8 @@ import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { debugCount, debugTime } from './debug-logger.js';
 import { logWarning, logError } from './workflow-logger.js';
 import { extractVerdict } from './verdict-parser.js';
+import { loadEffectiveGSDPreferences } from './preferences.js';
+import { detectPendingEscalation } from './escalation.js';
 
 import {
   isDbAvailable,
@@ -958,6 +960,25 @@ export async function deriveStateFromDb(basePath: string): Promise<GSDState> {
         phase: 'replanning-slice', recentDecisions: [],
         blockers: [`Task ${blockerTaskId} discovered a blocker requiring slice replan`],
         nextAction: `Task ${blockerTaskId} reported blocker_discovered. Replan slice ${activeSlice.id} before continuing.`,
+        activeWorkspace: undefined,
+        registry, requirements,
+        progress: { milestones: milestoneProgress, slices: sliceProgress, tasks: taskProgress },
+      };
+    }
+  }
+
+  // ADR-011 Phase 2: pause-on-escalation takes precedence over dispatching the
+  // next task. `awaiting_review` tasks (continueWithDefault=true) are NOT
+  // surfaced here — they let the loop continue.
+  const escalationEnabled = loadEffectiveGSDPreferences()?.preferences?.phases?.mid_execution_escalation === true;
+  if (escalationEnabled) {
+    const escalatingTaskId = detectPendingEscalation(tasks, basePath);
+    if (escalatingTaskId) {
+      return {
+        activeMilestone, activeSlice, activeTask,
+        phase: 'escalating-task', recentDecisions: [],
+        blockers: [`Task ${escalatingTaskId} requires a user decision before the loop can proceed`],
+        nextAction: `Run /gsd escalate show ${escalatingTaskId} to review, then /gsd escalate resolve ${escalatingTaskId} <choice> to proceed.`,
         activeWorkspace: undefined,
         registry, requirements,
         progress: { milestones: milestoneProgress, slices: sliceProgress, tasks: taskProgress },

--- a/src/resources/extensions/gsd/tests/artifact-corruption-2630.test.ts
+++ b/src/resources/extensions/gsd/tests/artifact-corruption-2630.test.ts
@@ -77,6 +77,11 @@ function makeTaskRow(overrides?: Partial<TaskRow>): TaskRow {
     expected_output: [],
     observability_impact: '',
     sequence: 0,
+    blocker_source: '',
+    escalation_pending: 0,
+    escalation_awaiting_review: 0,
+    escalation_artifact_path: null,
+    escalation_override_applied_at: null,
     ...overrides,
   };
 }

--- a/src/resources/extensions/gsd/tests/complete-slice.test.ts
+++ b/src/resources/extensions/gsd/tests/complete-slice.test.ts
@@ -125,9 +125,9 @@ console.log('\n=== complete-slice: schema v6 migration ===');
 
   const adapter = _getAdapter()!;
 
-  // Verify schema version is current (v15 with UOK projection tables)
+  // Verify schema version is current (v17 with ADR-011 P2 escalation columns)
   const versionRow = adapter.prepare('SELECT MAX(version) as v FROM schema_version').get();
-  assertEq(versionRow?.['v'], 15, 'schema version should be 15');
+  assertEq(versionRow?.['v'], 17, 'schema version should be 17');
 
   // Verify slices table has full_summary_md and full_uat_md columns
   const cols = adapter.prepare("PRAGMA table_info(slices)").all();

--- a/src/resources/extensions/gsd/tests/complete-task.test.ts
+++ b/src/resources/extensions/gsd/tests/complete-task.test.ts
@@ -109,9 +109,9 @@ console.log('\n=== complete-task: schema v5 migration ===');
 
   const adapter = _getAdapter()!;
 
-  // Verify schema version is current (v15 with UOK projection tables)
+  // Verify schema version is current (v17 with ADR-011 P2 escalation columns)
   const versionRow = adapter.prepare('SELECT MAX(version) as v FROM schema_version').get();
-  assertEq(versionRow?.['v'], 15, 'schema version should be 15');
+  assertEq(versionRow?.['v'], 17, 'schema version should be 17');
 
   // Verify all 4 new tables exist
   const tables = adapter.prepare(

--- a/src/resources/extensions/gsd/tests/enhanced-verification-integration.test.ts
+++ b/src/resources/extensions/gsd/tests/enhanced-verification-integration.test.ts
@@ -70,6 +70,11 @@ function createTask(overrides: Partial<TaskRow> = {}): TaskRow {
     observability_impact: "",
     full_plan_md: "",
     sequence: overrides.sequence ?? 0,
+    blocker_source: "",
+    escalation_pending: 0,
+    escalation_awaiting_review: 0,
+    escalation_artifact_path: null,
+    escalation_override_applied_at: null,
     ...overrides,
   };
 }

--- a/src/resources/extensions/gsd/tests/escalation.test.ts
+++ b/src/resources/extensions/gsd/tests/escalation.test.ts
@@ -1,0 +1,446 @@
+// GSD Extension — ADR-011 Phase 2 Mid-Execution Escalation tests
+// Covers: artifact write/read, detection, resolution (A|B|accept|reject-blocker),
+// DB claim race, carry-forward injection, schema v16/v17 migration, feature flag.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import {
+  openDatabase,
+  closeDatabase,
+  insertMilestone,
+  insertSlice,
+  insertTask,
+  updateTaskStatus,
+  getTask,
+  claimEscalationOverride,
+  findUnappliedEscalationOverride,
+  listEscalationArtifacts,
+  _getAdapter,
+} from "../gsd-db.ts";
+import {
+  buildEscalationArtifact,
+  writeEscalationArtifact,
+  readEscalationArtifact,
+  detectPendingEscalation,
+  resolveEscalation,
+  claimOverrideForInjection,
+  escalationArtifactPath,
+} from "../escalation.ts";
+import type { EscalationOption } from "../types.ts";
+
+// ─── Fixture helpers ──────────────────────────────────────────────────────
+
+function makeBase(): string {
+  const base = mkdtempSync(join(tmpdir(), "gsd-adr011-p2-"));
+  mkdirSync(join(base, ".gsd", "milestones", "M001", "slices", "S01", "tasks"), { recursive: true });
+  return base;
+}
+
+function cleanup(base: string): void {
+  try { closeDatabase(); } catch { /* noop */ }
+  try { rmSync(base, { recursive: true, force: true }); } catch { /* noop */ }
+}
+
+function writePrefs(base: string, enabled: boolean): void {
+  const path = join(base, ".gsd", "PREFERENCES.md");
+  writeFileSync(path, [
+    "---",
+    "version: 1",
+    "phases:",
+    `  mid_execution_escalation: ${enabled}`,
+    "---",
+  ].join("\n"));
+}
+
+function seedCompletedTask(base: string, taskId: string): void {
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M001", title: "Test", status: "active" });
+  insertSlice({ id: "S01", milestoneId: "M001", title: "Slice" });
+  insertTask({
+    id: taskId, sliceId: "S01", milestoneId: "M001", title: "Task",
+    status: "complete",
+  });
+}
+
+const sampleOptions: EscalationOption[] = [
+  { id: "A", label: "Separate table", tradeoffs: "More flexible; requires migration." },
+  { id: "B", label: "JSON array", tradeoffs: "Simpler; limited to ~1000 entries." },
+];
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Tests
+// ═══════════════════════════════════════════════════════════════════════════
+
+test("ADR-011 P2: writeEscalationArtifact persists canonical JSON at tasks/T##-ESCALATION.json", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  seedCompletedTask(base, "T03");
+
+  const art = buildEscalationArtifact({
+    taskId: "T03", sliceId: "S01", milestoneId: "M001",
+    question: "Where should we store notifications?",
+    options: sampleOptions,
+    recommendation: "B",
+    recommendationRationale: "Single-user display only.",
+    continueWithDefault: false,
+  });
+  const path = writeEscalationArtifact(base, art);
+  assert.ok(existsSync(path), "artifact file must exist");
+  assert.ok(path.endsWith("/tasks/T03-ESCALATION.json"), `path should end with tasks/T03-ESCALATION.json, got ${path}`);
+
+  const roundTrip = readEscalationArtifact(path);
+  assert.ok(roundTrip, "artifact must round-trip");
+  assert.equal(roundTrip!.taskId, "T03");
+  assert.equal(roundTrip!.recommendation, "B");
+  assert.equal(roundTrip!.options.length, 2);
+
+  // DB flag flipped to pending (continueWithDefault=false).
+  const row = getTask("M001", "S01", "T03");
+  assert.equal(row?.escalation_pending, 1);
+  assert.equal(row?.escalation_awaiting_review, 0);
+  assert.equal(row?.escalation_artifact_path, path);
+});
+
+test("ADR-011 P2: continueWithDefault=true sets awaiting_review (NOT pending) — no pause", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  seedCompletedTask(base, "T04");
+
+  const art = buildEscalationArtifact({
+    taskId: "T04", sliceId: "S01", milestoneId: "M001",
+    question: "Q",
+    options: sampleOptions,
+    recommendation: "A",
+    recommendationRationale: "r",
+    continueWithDefault: true,
+  });
+  writeEscalationArtifact(base, art);
+
+  const row = getTask("M001", "S01", "T04");
+  assert.equal(row?.escalation_pending, 0, "fire-and-correct must NOT set escalation_pending");
+  assert.equal(row?.escalation_awaiting_review, 1);
+});
+
+test("ADR-011 P2: detectPendingEscalation returns only pause-scoped escalations", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  seedCompletedTask(base, "T01");
+  seedCompletedTask(base, "T02");
+
+  // T01: continueWithDefault=true (awaiting_review, not pending)
+  writeEscalationArtifact(base, buildEscalationArtifact({
+    taskId: "T01", sliceId: "S01", milestoneId: "M001",
+    question: "Q1", options: sampleOptions, recommendation: "A", recommendationRationale: "r",
+    continueWithDefault: true,
+  }));
+  // T02: continueWithDefault=false (pause)
+  writeEscalationArtifact(base, buildEscalationArtifact({
+    taskId: "T02", sliceId: "S01", milestoneId: "M001",
+    question: "Q2", options: sampleOptions, recommendation: "B", recommendationRationale: "r",
+    continueWithDefault: false,
+  }));
+
+  const tasks = [getTask("M001", "S01", "T01")!, getTask("M001", "S01", "T02")!];
+  const id = detectPendingEscalation(tasks, base);
+  assert.equal(id, "T02", "only T02 is pause-worthy; T01 is awaiting_review");
+});
+
+test("ADR-011 P2: resolveEscalation(accept) marks artifact + clears flags", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  seedCompletedTask(base, "T05");
+
+  writeEscalationArtifact(base, buildEscalationArtifact({
+    taskId: "T05", sliceId: "S01", milestoneId: "M001",
+    question: "Q", options: sampleOptions, recommendation: "B", recommendationRationale: "r",
+    continueWithDefault: false,
+  }));
+
+  const result = resolveEscalation(base, "M001", "S01", "T05", "accept", "looks good");
+  assert.equal(result.status, "resolved");
+  assert.equal(result.chosenOption?.id, "B");
+
+  const row = getTask("M001", "S01", "T05");
+  assert.equal(row?.escalation_pending, 0);
+  assert.equal(row?.escalation_awaiting_review, 0);
+
+  const artPath = escalationArtifactPath(base, "M001", "S01", "T05")!;
+  const art = readEscalationArtifact(artPath);
+  assert.ok(art?.respondedAt, "artifact must record respondedAt");
+  assert.equal(art?.userChoice, "accept");
+  assert.equal(art?.userRationale, "looks good");
+});
+
+test("ADR-011 P2: resolveEscalation(reject-blocker) sets blocker_discovered + blocker_source", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  seedCompletedTask(base, "T06");
+
+  writeEscalationArtifact(base, buildEscalationArtifact({
+    taskId: "T06", sliceId: "S01", milestoneId: "M001",
+    question: "Q", options: sampleOptions, recommendation: "A", recommendationRationale: "r",
+    continueWithDefault: false,
+  }));
+
+  const result = resolveEscalation(base, "M001", "S01", "T06", "reject-blocker", "none of these work");
+  assert.equal(result.status, "rejected-to-blocker");
+
+  const row = getTask("M001", "S01", "T06");
+  assert.equal(row?.blocker_discovered, true, "reject-blocker must flip blocker_discovered=1");
+  assert.equal(row?.blocker_source, "reject-escalation", "blocker_source must record provenance");
+  assert.equal(row?.escalation_pending, 0);
+});
+
+test("ADR-011 P2: resolveEscalation(invalid-choice) returns error + leaves state untouched", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  seedCompletedTask(base, "T07");
+
+  writeEscalationArtifact(base, buildEscalationArtifact({
+    taskId: "T07", sliceId: "S01", milestoneId: "M001",
+    question: "Q", options: sampleOptions, recommendation: "A", recommendationRationale: "r",
+    continueWithDefault: false,
+  }));
+
+  const result = resolveEscalation(base, "M001", "S01", "T07", "Z", "");
+  assert.equal(result.status, "invalid-choice");
+
+  // State must NOT have changed.
+  const row = getTask("M001", "S01", "T07");
+  assert.equal(row?.escalation_pending, 1, "flag must still be pending after invalid choice");
+});
+
+test("ADR-011 P2: claimEscalationOverride is atomic — only one claimer wins the race", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  seedCompletedTask(base, "T08");
+
+  writeEscalationArtifact(base, buildEscalationArtifact({
+    taskId: "T08", sliceId: "S01", milestoneId: "M001",
+    question: "Q", options: sampleOptions, recommendation: "A", recommendationRationale: "r",
+    continueWithDefault: false,
+  }));
+  resolveEscalation(base, "M001", "S01", "T08", "A", "pick A");
+
+  const first = claimEscalationOverride("M001", "S01", "T08");
+  const second = claimEscalationOverride("M001", "S01", "T08");
+  assert.equal(first, true, "first claim wins");
+  assert.equal(second, false, "second claim must fail — override already applied");
+});
+
+test("ADR-011 P2: claimOverrideForInjection returns null when flag ON but no unapplied override", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  seedCompletedTask(base, "T09");
+
+  const claimed = claimOverrideForInjection(base, "M001", "S01");
+  assert.equal(claimed, null);
+});
+
+test("ADR-011 P2: claim does NOT fire on unresolved awaiting_review — resolution is preserved until user responds", (t) => {
+  // Regression for peer-review Bug 2: previously findUnappliedEscalationOverride
+  // matched `escalation_pending=0` alone, so an awaiting_review task (created
+  // by continueWithDefault=true) was silently claimed before the user had
+  // a chance to resolve, permanently dropping the override.
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  seedCompletedTask(base, "T09a");
+  seedCompletedTask(base, "T09b");
+
+  // Write a continueWithDefault=true artifact (awaiting_review=1, no respondedAt).
+  writeEscalationArtifact(base, buildEscalationArtifact({
+    taskId: "T09a", sliceId: "S01", milestoneId: "M001",
+    question: "Which DB?", options: sampleOptions,
+    recommendation: "A", recommendationRationale: "r",
+    continueWithDefault: true,
+  }));
+
+  // NEXT task's prompt build — must NOT claim the unresolved awaiting_review.
+  const premature = claimOverrideForInjection(base, "M001", "S01");
+  assert.equal(premature, null, "awaiting_review without respondedAt must not be claimed");
+
+  const midState = getTask("M001", "S01", "T09a");
+  assert.equal(midState?.escalation_override_applied_at, null, "applied_at must still be null");
+
+  // User now resolves.
+  resolveEscalation(base, "M001", "S01", "T09a", "B", "actually B is better");
+
+  // NEXT task's prompt build — NOW the override must be claimed and injected.
+  const claimed = claimOverrideForInjection(base, "M001", "S01");
+  assert.ok(claimed, "after user resolution, the override must be injectable");
+  assert.equal(claimed!.sourceTaskId, "T09a");
+  assert.match(claimed!.injectionBlock, /Escalation Override/);
+});
+
+test("ADR-011 P2: claimOverrideForInjection returns markdown block once, then null", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  seedCompletedTask(base, "T10");
+
+  writeEscalationArtifact(base, buildEscalationArtifact({
+    taskId: "T10", sliceId: "S01", milestoneId: "M001",
+    question: "Which storage?",
+    options: sampleOptions,
+    recommendation: "A",
+    recommendationRationale: "r",
+    continueWithDefault: false,
+  }));
+  resolveEscalation(base, "M001", "S01", "T10", "A", "pick A");
+
+  const first = claimOverrideForInjection(base, "M001", "S01");
+  assert.ok(first, "first claim returns the override");
+  assert.match(first!.injectionBlock, /Escalation Override/);
+  assert.equal(first!.sourceTaskId, "T10");
+
+  const second = claimOverrideForInjection(base, "M001", "S01");
+  assert.equal(second, null, "second call returns null (idempotent)");
+});
+
+test("ADR-011 P2: listEscalationArtifacts filters to actionable by default", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  seedCompletedTask(base, "T11");
+  seedCompletedTask(base, "T12");
+
+  // Pending (actionable)
+  writeEscalationArtifact(base, buildEscalationArtifact({
+    taskId: "T11", sliceId: "S01", milestoneId: "M001",
+    question: "Q", options: sampleOptions, recommendation: "A", recommendationRationale: "r",
+    continueWithDefault: false,
+  }));
+  // Resolved (not actionable by default)
+  writeEscalationArtifact(base, buildEscalationArtifact({
+    taskId: "T12", sliceId: "S01", milestoneId: "M001",
+    question: "Q", options: sampleOptions, recommendation: "A", recommendationRationale: "r",
+    continueWithDefault: false,
+  }));
+  resolveEscalation(base, "M001", "S01", "T12", "A", "");
+
+  const actionable = listEscalationArtifacts("M001", false);
+  const all = listEscalationArtifacts("M001", true);
+  assert.equal(actionable.length, 1, "only T11 is actionable");
+  assert.equal(actionable[0]!.id, "T11");
+  assert.equal(all.length, 2, "both surface with --all");
+});
+
+test("ADR-011 P2: schema v17 fresh DB has all escalation columns on tasks + source on decisions", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  openDatabase(join(base, ".gsd", "gsd.db"));
+
+  const adapter = _getAdapter()!;
+  const tasksCols = adapter.prepare("PRAGMA table_info(tasks)").all().map((r) => r["name"] as string);
+  for (const col of [
+    "blocker_source",
+    "escalation_pending",
+    "escalation_awaiting_review",
+    "escalation_artifact_path",
+    "escalation_override_applied_at",
+  ]) {
+    assert.ok(tasksCols.includes(col), `tasks table must have ${col} column`);
+  }
+
+  const decCols = adapter.prepare("PRAGMA table_info(decisions)").all().map((r) => r["name"] as string);
+  assert.ok(decCols.includes("source"), "decisions table must have source column");
+
+  const version = adapter.prepare("SELECT MAX(version) as v FROM schema_version").get();
+  assert.equal(version?.["v"], 17);
+});
+
+test("ADR-011 P2: findUnappliedEscalationOverride returns null when escalation_pending=1 (still pending)", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  seedCompletedTask(base, "T13");
+
+  writeEscalationArtifact(base, buildEscalationArtifact({
+    taskId: "T13", sliceId: "S01", milestoneId: "M001",
+    question: "Q", options: sampleOptions, recommendation: "A", recommendationRationale: "r",
+    continueWithDefault: false,
+  }));
+
+  // Don't resolve — just query.
+  const found = findUnappliedEscalationOverride("M001", "S01");
+  assert.equal(found, null, "pending escalation must not surface as unapplied override");
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// ADR-011 Phase 3 integration-style tests (concurrent / timeout / recovery /
+// latency — adapted from refine-slice phase patterns).
+// ═══════════════════════════════════════════════════════════════════════════
+
+test("ADR-011 P3: concurrent escalations queue in arrival order — list returns multiple", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  seedCompletedTask(base, "T20");
+  seedCompletedTask(base, "T21");
+
+  writeEscalationArtifact(base, buildEscalationArtifact({
+    taskId: "T20", sliceId: "S01", milestoneId: "M001",
+    question: "Q1", options: sampleOptions, recommendation: "A", recommendationRationale: "r",
+    continueWithDefault: false,
+  }));
+  writeEscalationArtifact(base, buildEscalationArtifact({
+    taskId: "T21", sliceId: "S01", milestoneId: "M001",
+    question: "Q2", options: sampleOptions, recommendation: "B", recommendationRationale: "r",
+    continueWithDefault: false,
+  }));
+
+  const pending = listEscalationArtifacts("M001", false);
+  assert.equal(pending.length, 2);
+  // Both are pause-worthy — state derivation returns the first.
+  const first = detectPendingEscalation([getTask("M001", "S01", "T20")!, getTask("M001", "S01", "T21")!], base);
+  assert.equal(first, "T20", "detection returns first pending in arrival order");
+});
+
+test("ADR-011 P3: recovery — malformed artifact returns null from read, does not crash", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  seedCompletedTask(base, "T22");
+
+  const artPath = escalationArtifactPath(base, "M001", "S01", "T22")!;
+  mkdirSync(join(artPath, ".."), { recursive: true });
+  writeFileSync(artPath, "{ this is not json");
+  const result = readEscalationArtifact(artPath);
+  assert.equal(result, null, "malformed JSON must return null (no throw)");
+});
+
+test("ADR-011 P3: resolve-on-missing-artifact returns not-found without partial state", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  seedCompletedTask(base, "T23");
+
+  const result = resolveEscalation(base, "M001", "S01", "T23", "A", "");
+  assert.equal(result.status, "not-found");
+  const row = getTask("M001", "S01", "T23");
+  assert.equal(row?.escalation_pending, 0, "untouched");
+});
+
+test("ADR-011 P3: escalation write + detect latency — 20 tasks, one escalation, detection under 100ms", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M001", title: "Test", status: "active" });
+  insertSlice({ id: "S01", milestoneId: "M001", title: "Slice" });
+  for (let i = 1; i <= 20; i++) {
+    const tid = `T${String(i).padStart(2, "0")}`;
+    insertTask({ id: tid, sliceId: "S01", milestoneId: "M001", title: `Task ${i}`, status: "complete" });
+  }
+  // Escalation on T15 only.
+  mkdirSync(join(base, ".gsd", "milestones", "M001", "slices", "S01", "tasks"), { recursive: true });
+  writeEscalationArtifact(base, buildEscalationArtifact({
+    taskId: "T15", sliceId: "S01", milestoneId: "M001",
+    question: "Q", options: sampleOptions, recommendation: "A", recommendationRationale: "r",
+    continueWithDefault: false,
+  }));
+
+  const tasks = Array.from({ length: 20 }, (_, i) => getTask("M001", "S01", `T${String(i + 1).padStart(2, "0")}`)!);
+  const start = Date.now();
+  const found = detectPendingEscalation(tasks, base);
+  const elapsed = Date.now() - start;
+  assert.equal(found, "T15");
+  assert.ok(elapsed < 100, `detection must complete under 100ms, took ${elapsed}ms`);
+});

--- a/src/resources/extensions/gsd/tests/gsd-db.test.ts
+++ b/src/resources/extensions/gsd/tests/gsd-db.test.ts
@@ -80,7 +80,7 @@ describe('gsd-db', () => {
     // Check schema_version table
     const adapter = _getAdapter()!;
     const version = adapter.prepare('SELECT MAX(version) as version FROM schema_version').get();
-    assert.deepStrictEqual(version?.['version'], 15, 'schema version should be 15');
+    assert.deepStrictEqual(version?.['version'], 17, 'schema version should be 17');
 
     // Check tables exist by querying them
     const dRows = adapter.prepare('SELECT count(*) as cnt FROM decisions').get();

--- a/src/resources/extensions/gsd/tests/md-importer.test.ts
+++ b/src/resources/extensions/gsd/tests/md-importer.test.ts
@@ -363,7 +363,7 @@ test('md-importer: schema v1→v2 migration', () => {
   openDatabase(':memory:');
   const adapter = _getAdapter();
   const version = adapter?.prepare('SELECT MAX(version) as v FROM schema_version').get();
-  assert.deepStrictEqual(version?.v, 15, 'new DB should be at schema version 15');
+  assert.deepStrictEqual(version?.v, 17, 'new DB should be at schema version 17');
 
   // Artifacts table should exist
   const tableCheck = adapter?.prepare("SELECT count(*) as c FROM sqlite_master WHERE type='table' AND name='artifacts'").get();

--- a/src/resources/extensions/gsd/tests/memory-store.test.ts
+++ b/src/resources/extensions/gsd/tests/memory-store.test.ts
@@ -323,9 +323,9 @@ test('memory-store: schema includes memories table', () => {
   const viewCount = adapter.prepare('SELECT count(*) as cnt FROM active_memories').get();
   assert.deepStrictEqual(viewCount?.['cnt'], 0, 'active_memories view should exist');
 
-  // Verify schema version is 15 (UOK gate/git/audit projection tables included)
+  // Verify schema version is 17 (ADR-011 P2 escalation columns included)
   const version = adapter.prepare('SELECT MAX(version) as v FROM schema_version').get();
-  assert.deepStrictEqual(version?.['v'], 15, 'schema version should be 15');
+  assert.deepStrictEqual(version?.['v'], 17, 'schema version should be 17');
 
   closeDatabase();
 });

--- a/src/resources/extensions/gsd/tests/post-execution-checks.test.ts
+++ b/src/resources/extensions/gsd/tests/post-execution-checks.test.ts
@@ -56,6 +56,11 @@ function createTask(overrides: Partial<TaskRow> = {}): TaskRow {
     observability_impact: "",
     full_plan_md: "",
     sequence: overrides.sequence ?? 0,
+    blocker_source: "",
+    escalation_pending: 0,
+    escalation_awaiting_review: 0,
+    escalation_artifact_path: null,
+    escalation_override_applied_at: null,
     ...overrides,
   };
 }

--- a/src/resources/extensions/gsd/tests/pre-execution-checks.test.ts
+++ b/src/resources/extensions/gsd/tests/pre-execution-checks.test.ts
@@ -57,6 +57,11 @@ function createTask(overrides: Partial<TaskRow> = {}): TaskRow {
     observability_impact: "",
     full_plan_md: "",
     sequence: overrides.sequence ?? 0,
+    blocker_source: "",
+    escalation_pending: 0,
+    escalation_awaiting_review: 0,
+    escalation_artifact_path: null,
+    escalation_override_applied_at: null,
     ...overrides,
   };
 }

--- a/src/resources/extensions/gsd/tests/projection-regression.test.ts
+++ b/src/resources/extensions/gsd/tests/projection-regression.test.ts
@@ -61,6 +61,11 @@ function makeTaskRow(overrides?: Partial<TaskRow>): TaskRow {
     expected_output: [],
     observability_impact: '',
     sequence: 0,
+    blocker_source: '',
+    escalation_pending: 0,
+    escalation_awaiting_review: 0,
+    escalation_artifact_path: null,
+    escalation_override_applied_at: null,
     ...overrides,
   };
 }

--- a/src/resources/extensions/gsd/tests/summary-render-parity.test.ts
+++ b/src/resources/extensions/gsd/tests/summary-render-parity.test.ts
@@ -50,6 +50,11 @@ const taskRow: TaskRow = {
   observability_impact: "",
   full_plan_md: "",
   sequence: 1,
+  blocker_source: "",
+  escalation_pending: 0,
+  escalation_awaiting_review: 0,
+  escalation_artifact_path: null,
+  escalation_override_applied_at: null,
 };
 
 const verificationEvidence = [

--- a/src/resources/extensions/gsd/tests/workflow-projections.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-projections.test.ts
@@ -59,6 +59,11 @@ function makeTask(overrides: Partial<TaskRow> = {}): TaskRow {
     expected_output: [],
     observability_impact: '',
     sequence: 1,
+    blocker_source: '',
+    escalation_pending: 0,
+    escalation_awaiting_review: 0,
+    escalation_artifact_path: null,
+    escalation_override_applied_at: null,
     ...overrides,
   };
 }

--- a/src/resources/extensions/gsd/tools/complete-task.ts
+++ b/src/resources/extensions/gsd/tools/complete-task.ts
@@ -113,6 +113,11 @@ function paramsToTaskRow(params: CompleteTaskParams, completedAt: string): TaskR
     observability_impact: "",
     full_plan_md: "",
     sequence: 0,
+    blocker_source: "",
+    escalation_pending: 0,
+    escalation_awaiting_review: 0,
+    escalation_artifact_path: null,
+    escalation_override_applied_at: null,
   };
 }
 

--- a/src/resources/extensions/gsd/tools/complete-task.ts
+++ b/src/resources/extensions/gsd/tools/complete-task.ts
@@ -327,12 +327,16 @@ export async function handleCompleteTask(
         });
         writeEscalationArtifact(basePath, artifact);
       } catch (escalationErr) {
-        // Non-fatal: the task itself completed successfully. Surface the
-        // escalation failure so the user knows why no pause happened.
-        logWarning(
-          "tool",
-          `complete-task escalation write failed for ${params.milestoneId}/${params.sliceId}/${params.taskId}: ${(escalationErr as Error).message}`,
-        );
+        const msg = `complete-task escalation write failed for ${params.milestoneId}/${params.sliceId}/${params.taskId}: ${(escalationErr as Error).message}`;
+        logWarning("tool", msg);
+        // For pause-required escalations (continueWithDefault=false), the
+        // loop MUST pause — so if we can't write the artifact we must surface
+        // the failure instead of silently allowing the task to "complete" and
+        // the loop to advance. For fire-and-correct (continueWithDefault=true)
+        // the task proceeds and the warning is enough.
+        if (params.escalation.continueWithDefault === false) {
+          return { error: msg };
+        }
       }
     } else {
       logWarning(

--- a/src/resources/extensions/gsd/tools/complete-task.ts
+++ b/src/resources/extensions/gsd/tools/complete-task.ts
@@ -37,6 +37,8 @@ import { renderAllProjections, renderSummaryContent } from "../workflow-projecti
 import { writeManifest } from "../workflow-manifest.js";
 import { appendEvent } from "../workflow-events.js";
 import { logWarning, logError } from "../workflow-logger.js";
+import { loadEffectiveGSDPreferences } from "../preferences.js";
+import { buildEscalationArtifact, writeEscalationArtifact } from "../escalation.js";
 
 export interface CompleteTaskResult {
   taskId: string;
@@ -297,6 +299,42 @@ export async function handleCompleteTask(
       "tool",
       `complete-task gate close warning for ${params.milestoneId}/${params.sliceId}/${params.taskId}: ${(gateErr as Error).message}`,
     );
+  }
+
+  // ── ADR-011 Phase 2: write escalation artifact (opt-in) ────────────────
+  // The executor may include an `escalation` payload when they need the user
+  // to resolve an ambiguity. We write the artifact + flip the DB flag only
+  // when `phases.mid_execution_escalation` is enabled — otherwise the
+  // payload is ignored so agents can safely populate it before users opt in.
+  if (params.escalation) {
+    const escalationEnabled = loadEffectiveGSDPreferences()?.preferences?.phases?.mid_execution_escalation === true;
+    if (escalationEnabled) {
+      try {
+        const artifact = buildEscalationArtifact({
+          taskId: params.taskId,
+          sliceId: params.sliceId,
+          milestoneId: params.milestoneId,
+          question: params.escalation.question,
+          options: params.escalation.options,
+          recommendation: params.escalation.recommendation,
+          recommendationRationale: params.escalation.recommendationRationale,
+          continueWithDefault: params.escalation.continueWithDefault,
+        });
+        writeEscalationArtifact(basePath, artifact);
+      } catch (escalationErr) {
+        // Non-fatal: the task itself completed successfully. Surface the
+        // escalation failure so the user knows why no pause happened.
+        logWarning(
+          "tool",
+          `complete-task escalation write failed for ${params.milestoneId}/${params.sliceId}/${params.taskId}: ${(escalationErr as Error).message}`,
+        );
+      }
+    } else {
+      logWarning(
+        "tool",
+        `complete-task received escalation payload but phases.mid_execution_escalation is not enabled; ignoring (${params.milestoneId}/${params.sliceId}/${params.taskId})`,
+      );
+    }
   }
 
   // Invalidate all caches

--- a/src/resources/extensions/gsd/types.ts
+++ b/src/resources/extensions/gsd/types.ts
@@ -19,6 +19,7 @@ export type Phase =
   | "validating-milestone"
   | "completing-milestone"
   | "replanning-slice"
+  | "escalating-task"
   | "complete"
   | "paused"
   | "blocked";
@@ -350,6 +351,49 @@ export interface PhaseSkipPreferences {
   reassess_after_slice?: boolean;
   /** When true, auto-mode pauses before each slice for discussion (#789). */
   require_slice_discussion?: boolean;
+  /** ADR-011 Phase 2: when true, executors may escalate task-level ambiguity via T##-ESCALATION.json. */
+  mid_execution_escalation?: boolean;
+}
+
+// ─── ADR-011 Phase 2 Escalation ──────────────────────────────────────────
+
+export interface EscalationOption {
+  /** Short identifier, e.g. "A", "B". Used as the `choice` value in `/gsd escalate resolve <taskId> <id>`. */
+  id: string;
+  /** One-line label for the option. */
+  label: string;
+  /** 1-2 sentence description of the tradeoffs of this option. */
+  tradeoffs: string;
+}
+
+export interface EscalationArtifact {
+  /** Schema version for the artifact file — bumps if we change the shape. */
+  version: 1;
+  taskId: string;
+  sliceId: string;
+  milestoneId: string;
+  /** The question the executor needs the user to resolve. */
+  question: string;
+  /** 2-4 options the user can choose between. */
+  options: EscalationOption[];
+  /** Which option the executor recommends (references `options[].id`). */
+  recommendation: string;
+  /** Why the executor recommends that option (1-2 sentences). */
+  recommendationRationale: string;
+  /**
+   * When true, the executor proceeds with the recommendation as the answer
+   * and the loop continues. User's later choice becomes a carry-forward
+   * override for the NEXT task. When false, auto-mode pauses until the
+   * user resolves via `/gsd escalate resolve`.
+   */
+  continueWithDefault: boolean;
+  createdAt: string;
+  /** Populated by `/gsd escalate resolve`. */
+  respondedAt?: string;
+  /** User's choice — either an option id, "accept" (use recommendation), or "reject-blocker". */
+  userChoice?: string;
+  /** Optional free-text rationale from the user. */
+  userRationale?: string;
 }
 
 export interface NotificationPreferences {
@@ -435,6 +479,7 @@ export interface Decision {
   rationale: string; // why this choice
   revisable: string; // whether/when revisable
   made_by: DecisionMadeBy; // who made the decision: human, agent, or collaborative
+  source?: string; // ADR-011 P2: origin — "discussion" (default) | "planning" | "escalation"
   superseded_by: string | null; // ID of superseding decision, or null
 }
 
@@ -542,6 +587,20 @@ export interface CompleteTaskParams {
   knownIssues?: string;
   /** @optional — defaults to false when omitted */
   blockerDiscovered?: boolean;
+  /**
+   * ADR-011 Phase 2 — optional escalation payload. When populated, the executor
+   * is asking the user to resolve an ambiguity. If `continueWithDefault: true`
+   * the task still completes (using the recommendation) but an artifact is
+   * written for later user review. If false, auto-mode pauses.
+   * @optional
+   */
+  escalation?: {
+    question: string;
+    options: EscalationOption[];
+    recommendation: string;
+    recommendationRationale: string;
+    continueWithDefault: boolean;
+  };
   /** @optional — defaults to [] when omitted by models with limited tool-calling */
   verificationEvidence?: Array<{
     command: string;

--- a/src/resources/extensions/gsd/workflow-manifest.ts
+++ b/src/resources/extensions/gsd/workflow-manifest.ts
@@ -164,6 +164,7 @@ export function snapshotState(): StateManifest {
     rationale: (r["rationale"] as string) ?? "",
     revisable: (r["revisable"] as string) ?? "",
     made_by: (r["made_by"] as string as Decision["made_by"]) ?? "agent",
+    source: (r["source"] as string) ?? "discussion",
     superseded_by: (r["superseded_by"] as string) ?? null,
   }));
 

--- a/src/resources/extensions/gsd/workflow-manifest.ts
+++ b/src/resources/extensions/gsd/workflow-manifest.ts
@@ -146,6 +146,11 @@ export function snapshotState(): StateManifest {
     observability_impact: (r["observability_impact"] as string) ?? "",
     full_plan_md: (r["full_plan_md"] as string) ?? "",
     sequence: toNumeric(r["sequence"], 0) as number,
+    blocker_source: (r["blocker_source"] as string) ?? "",
+    escalation_pending: toNumeric(r["escalation_pending"], 0) as number,
+    escalation_awaiting_review: toNumeric(r["escalation_awaiting_review"], 0) as number,
+    escalation_artifact_path: (r["escalation_artifact_path"] as string) ?? null,
+    escalation_override_applied_at: (r["escalation_override_applied_at"] as string) ?? null,
   }));
 
   const rawDecisions = db.prepare("SELECT * FROM decisions ORDER BY seq").all() as Record<string, unknown>[];


### PR DESCRIPTION
Implements **Phase 2 of ADR-011** (Mid-Execution Escalation). Phase 1 (progressive planning) is in #4408. Closes the escalation half of #3789.

## TL;DR

Adds a third option for executors between "guess" and "blocker". When an executor hits an ambiguity that matters but isn't plan-invalidating, it populates an `escalation` object on `gsd_complete_task` with the question, 2–4 options, a recommendation, and a `continueWithDefault` boolean:

- `continueWithDefault: false` → auto-mode pauses at `escalating-task` phase until the user resolves via `/gsd escalate resolve <taskId> <choice>`
- `continueWithDefault: true` → task completes with the recommendation as the answer; if the user later chooses differently, the override injects into the NEXT task's carry-forward

Gated behind `phases.mid_execution_escalation` — default off. Audit events emitted at every transition. Follows the exact same state-machine pattern as `blocker_discovered` → `replanning-slice`.

## What

- **DB (v16 + v17):** `decisions.source` (`discussion | planning | escalation`), 5 columns on `tasks` (`blocker_source`, `escalation_pending`, `escalation_awaiting_review`, `escalation_artifact_path`, `escalation_override_applied_at`), index on `(mid, sid, escalation_pending)`. Atomic DB claim for carry-forward injection closes the race between parallel prompt builds.
- **State (`state.ts`):** `detectPendingEscalation` branches in after `detectBlockers`. Returns `phase: 'escalating-task'` only for `continueWithDefault: false` artifacts that haven't been resolved. `awaiting_review` (continueWithDefault=true) never enters this phase.
- **Dispatch (`auto-dispatch.ts`):** new `escalating-task → pause-for-escalation` rule returns `{action: "stop", level: "info"}` with actionable `nextAction` text.
- **Module `escalation.ts`:** single file, ~310 lines. Artifact I/O via `atomicWriteSync`, detection, resolution (accept / option-id / reject-blocker), carry-forward claim + markdown formatting, audit emission (`category: "gate"`, 4 event types).
- **Tool (`gsd_complete_task`):** MCP schema adds nested optional `escalation` object with 2–4 options. Handler writes artifact + flips the appropriate flag when feature enabled; silently logs-and-ignores when disabled.
- **Command (`/gsd escalate`):** new file `commands/handlers/escalate.ts`, wired through `ops.ts`. Subcommands: `list [--all]`, `show <taskId>`, `resolve <taskId> <choice> [rationale...]`. `resolve` persists a decision via `saveDecisionToDb({source: "escalation"})`, emits 2 audit events, prints "run /gsd auto to continue."
- **reject-blocker path:** flips `blocker_discovered=1` + `blocker_source='reject-escalation'`. State derivation's existing `detectBlockers()` finds it on the next loop and routes to `replanning-slice` via the normal path.
- **Carry-forward (`buildExecuteTaskPrompt`):** atomically claims any unapplied resolved override via `claimEscalationOverride` (conditional UPDATE) and prepends `## Escalation Override` block. Race-safe — DB column owns the lock, artifact JSON is the audit record.
- **Prompt (`execute-task.md` step 16a):** when/how/why to escalate, 5 required fields, scope note (execute-task only; reactive-execute batches surface escalations after batch completes).

## Why

Per ADR-011: executors currently pick between "guess" (document an assumption, proceed) and "blocker" (trigger full slice replan). The guess path creates silent context drift — small wrong assumptions cascade through downstream tasks. The blocker path overreacts to things a human could resolve in 10 seconds. Escalation adds the middle option: ask, persist, and move on.

Research: 65% of AI failures come from context drift (Zylos 2026); training rewards confident guessing over calibrated uncertainty (OpenAI 2025).

## How

Mechanical parallel to the blocker mechanism:

| | Blocker | Escalation |
|---|---|---|
| Task signal | `blockerDiscovered: true` | `escalation: { ... }` |
| DB column | `blocker_discovered` | `escalation_pending` / `escalation_awaiting_review` |
| Detection | `detectBlockers()` | `detectPendingEscalation()` |
| Phase | `replanning-slice` | `escalating-task` |
| Dispatch result | runs `replan-slice` unit | stops loop; user resolves via command |
| Resumption | automatic after replan | `/gsd auto` after `/gsd escalate resolve` |
| Audit | existing | `category: "gate"`, 4 `escalation-*` types |

No new Gate Plane plumbing. No new TUI widget. No changes to UOK scheduler. Feature flag defaults off.

## Peer review

Two rounds during implementation. Final diff review caught:

- 🔴 **HIGH Bug 2** — `findUnappliedEscalationOverride` SQL missed `AND escalation_awaiting_review = 0`. An awaiting-review artifact (not yet resolved by user) was claimed prematurely and the user's later choice silently dropped. **Fixed** with explicit filter + regression test.
- 🟡 **MED** — `claimOverrideForInjection` now `logWarning`s when the DB claim succeeds but the artifact file is missing/malformed (rather than silently returning null).
- 🟡 **MED** — Documented in `/gsd escalate` help that toggling the flag off does NOT clear pending escalations; re-enable + drain + disable is the recommended flow.
- 🟢 Bug 1 (reviewer flagged "reject-blocker doesn't set blocker_discovered") — **false positive** verified by code + existing test.

Remaining low-severity findings accepted as-is (audit event schema matches existing patterns; MCP nested schema pattern matches `verificationEvidence[]`).

## Tests

**6761 passing, 0 failing, 8 skipped.**

New: 17 tests in `escalation.test.ts` covering artifact round-trip, `continueWithDefault` branching, detection filter, resolve variants (accept / option-id / reject-blocker / invalid), claim atomicity, the awaiting-review regression for Bug 2, carry-forward idempotency, list filtering, schema v17 columns, concurrent escalations queuing, malformed-artifact recovery, not-found guard, sub-100ms detection latency on 20 tasks.

Updated: 5 pre-existing schema-version asserts (15→17), execute-task prompt camelCase regex accommodation in the prompt itself.

## Test plan

- [ ] `npx tsc --noEmit` — clean
- [ ] `npm run test:unit` — 6761 pass
- [ ] Enable `phases.mid_execution_escalation: true`, run a slice where an executor populates an `escalation` with `continueWithDefault: false`, verify auto-mode stops at `escalating-task`, `/gsd escalate list` surfaces it, `/gsd escalate show T##` prints options, `/gsd escalate resolve T## A` persists decision + resumes on next `/gsd auto`
- [ ] Same flow with `continueWithDefault: true` — verify task completes without pause, user resolves later, NEXT task's prompt contains the override block
- [ ] `reject-blocker` path — verify `blocker_discovered=1` + `blocker_source='reject-escalation'` + replan-slice fires on next auto iteration
- [ ] Flag off — verify escalation payload is logged-and-ignored, no artifact written, no phase change

## Deferred (explicit)

- Refine-slice escalation (ADR says execute-task only for Phase 2)
- Reactive-execute mid-batch pause (documented limitation)
- Escalation cap per milestone (open question in the ADR — no practical signal yet)
- Cleanup command for stale `escalation_pending=1` rows after flag toggle-off (low priority; documented workaround in `/gsd escalate` help)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mid-execution escalation: task execution can pause into an "escalating-task" state requiring user resolution; complete-task can carry an escalation payload; decisions record a source; carry‑forward overrides can be injected once.
  * New /gsd escalate command: list, show, and resolve escalations (with resolve persisting decisions and triggering replans).

* **Documentation**
  * Execute-task prompt updated with ADR-011 Phase 2 escalation guidance.

* **Tests**
  * New and expanded tests covering escalation artifacts, detection, resolution, concurrency, and schema migration.

* **Chores**
  * Database schema bumped to v17 to store escalation and decision fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->