### PR TITLE
feat(gsd): ADR-011 Phase 3 integration tests (+ Phase 1 & 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [2.75.0] - 2026-04-15
 
 ### Added
+
 - **tui**: render compaction notice in the shared chat-frame style
 - **prefs**: add persistent language preference via /gsd language
 - **tui**: align tool execution cards with chat frame styling
@@ -27,6 +28,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **gsd**: add v1→v2 command parity — 12 missing commands
 
 ### Fixed
+
 - **ci**: stage all workspace package.json files in release commit
 - **tui**: pin rendered block to terminal bottom on clear
 - **gsd**: silence benign auto-mode warnings and bind getProviderAuthMode correctly
@@ -38,7 +40,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **gsd**: stop .mcp.json churn in auto-worktrees and fix evidence id matching
 - **auto**: reset session timeout counter on auto-resume
 - **auto**: schedule auto-resume timer for session creation timeouts
-- **agent-session**: call abort() before _disconnectFromAgent() in newSession/resumeSession (#4243)
+- **agent-session**: call abort() before \_disconnectFromAgent() in newSession/resumeSession (#4243)
 - **gsd**: checkpoint all session phases during compaction, not just executing (#4258)
 - **gsd**: expand pre-execution check notification with details + evidence path (#4259)
 - **chat**: replay final assistant content on message end
@@ -69,16 +71,19 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **pi-coding-agent**: fall back to env keys for built-ins
 
 ### Changed
+
 - **gsd**: remove /gsd map-codebase command
 - **gsd**: enforce single-writer invariant for engine DB
 
 ## [2.74.0] - 2026-04-14
 
 ### Added
+
 - **gsd**: extend flat-rate provider detection to custom/externalCli providers
 - **claude-code**: pass thinking level as effort
 
 ### Fixed
+
 - **claude-code-cli**: forward image blocks in SDK query prompt (#4183)
 - keep assistant text visible when thinking traces are long
 - **state**: DB-authoritative milestone completeness (#4179)
@@ -100,12 +105,14 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **pi-ai**: detect claude-code overflow text
 
 ### Changed
+
 - remove stale src/app-paths.js leftover
 - **cli**: slim down top-level src/ — dedup, unused fallbacks, onboarding
 
 ## [2.73.1] - 2026-04-13
 
 ### Fixed
+
 - **gsd**: address 3 silent-crash secondary issues from #3348 post-#3696 (#4133)
 - **gsd**: tolerate corrupt task arrays (#4056)
 - **gsd**: discard milestone DB and worktree state (#4065)
@@ -117,15 +124,18 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **pi-coding-agent**: skip localhost dummy key when fallback resolver provides a configured key
 
 ### Changed
+
 - **gsd**: delete 3 unreferenced dead files and orphaned test (#3728)
 
 ## [2.73.0] - 2026-04-13
 
 ### Added
+
 - **pi-ai**: add Alibaba DashScope as standalone provider (#3891)
 - **gsd**: add layered depth enforcement to discuss.md (#4079)
 
 ### Fixed
+
 - **gsd**: reconcile stale slice rows and rebuild STATE.md before DB close (#3658)
 - **gsd**: block direct writes to gsd.db via hooks to prevent corruption (#3674)
 - **gsd**: break 3 circular dependencies in extension modules (#3730)
@@ -158,17 +168,20 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - clean up MCP tool rendering in Claude Code CLI stream
 
 ### Changed
+
 - **pi-ai**: regenerate model registry from upstream APIs (#3887)
 - require linked issue in PR template (#4112)
 
 ## [2.72.0] - 2026-04-13
 
 ### Added
+
 - **agents**: add GSD phase guard to prevent subagent/phase conflicts
 - **agents**: add 8 specialist subagents and slim pro agents
 - **tui**: improve gsd overlays, shortcuts, and notification flows
 
 ### Fixed
+
 - **ci**: build artifacts in integration-tests job
 - **auto**: recover from OpenRouter credit affordability errors
 - **gsd**: cast unknown gate id in test to satisfy GateId type
@@ -220,6 +233,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **commands**: show friendly message when /gsd runs from $HOME instead of unhandled error
 
 ### Changed
+
 - **ci**: run integration tests in parallel with build
 - **ci**: cache Next.js build artifacts with Blacksmith cache
 - sync package-lock.json version fields to 2.68.0
@@ -228,9 +242,11 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [2.71.0] - 2026-04-11
 
 ### Added
+
 - **mcp-server**: add secure_env_collect tool via MCP form elicitation
 
 ### Fixed
+
 - **tui**: clear pinned output on message_end to prevent duplicate display
 - **tui**: clear pinned latest output on turn completion
 - **tui**: restore pinned output above editor during tool execution
@@ -248,12 +264,14 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **web**: drop provisional pre-tool question text
 
 ### Changed
+
 - extract deriveStateFromDb logic into composable helpers
 - **pr**: drop web-layer changes from MCP stream-order fix
 
 ## [2.70.1] - 2026-04-11
 
 ### Fixed
+
 - **routing**: address codex review — complete interactive bypass and accurate banner
 - **routing**: skip dynamic routing for interactive dispatches, always show model changes (#3962)
 - **ci**: trim windows portability integration load
@@ -272,9 +290,11 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [2.70.0] - 2026-04-10
 
 ### Added
+
 - **mcp-server**: expose ask_user_questions via elicitation
 
 ### Fixed
+
 - **pi-ai**: remove Anthropic OAuth flow for TOS compliance
 - **mcp-server**: hydrate model credentials into env
 - **mcp-server**: hydrate stored tool credentials on startup
@@ -284,10 +304,12 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [2.69.0] - 2026-04-10
 
 ### Added
+
 - **gsd**: implement ADR-005 multi-model provider and tool strategy
 - **gsd**: complete ADR-004 capability-aware model routing implementation
 
 ### Fixed
+
 - **gsd**: add missing directories to codebase generator exclude list
 - **gsd**: wire ADR-005 infrastructure into live paths
 - **gsd**: replace empty catch with logWarning for CI compliance
@@ -297,6 +319,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [2.68.1] - 2026-04-10
 
 ### Fixed
+
 - **ci**: update FILE-SYSTEM-MAP.md path after docs reorganization
 - **test**: update discord invite test path after docs reorganization
 - **gsd**: resolve resource-loader import for deployed extensions
@@ -304,6 +327,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [2.68.0] - 2026-04-10
 
 ### Added
+
 - expose slice replanning over workflow MCP
 - expose milestone workflow tools over MCP
 - expose slice completion over workflow MCP
@@ -314,6 +338,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - add contextual tips system for TUI and web terminal
 
 ### Fixed
+
 - **state**: prevent false degraded-mode warning when DB not yet initialized
 - **gsd**: use debugLog in catch block to satisfy empty-catch lint
 - **gsd**: avoid false manifest and skipped-slice warnings
@@ -360,6 +385,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - suppress stale interrupted-session resume prompts
 
 ### Changed
+
 - harden workflow MCP executor loading
 - **ci**: add weekly workflow to regenerate model registry
 - **deps**: refresh audited package locks
@@ -367,10 +393,12 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [2.67.0] - 2026-04-09
 
 ### Added
+
 - **context**: implement R005 decision scope cascade and derive scope from slice metadata
 - **M005**: Tiered Context Injection - relevance-scoped context with 65%+ reduction
 
 ### Fixed
+
 - **test**: align auto-loop test timers with updated session timeout
 - **gsd**: repair CI after branch split
 - **gsd**: repair CI after branch split
@@ -402,6 +430,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [2.66.1] - 2026-04-08
 
 ### Fixed
+
 - **pi-tui**: revert contentCursorRow, use hardwareCursorRow as movement baseline
 - **pi-tui**: use contentCursorRow for render movement baseline instead of cursorRow
 - **gsd**: add logWarning to empty catch block in orphaned worktree cleanup
@@ -417,6 +446,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [2.66.0] - 2026-04-08
 
 ### Added
+
 - **gsd**: add fast path for queued milestone discussion
 - **gsd**: add /gsd show-config command
 - **reactive**: graph diagnostics and subagent_model config
@@ -424,6 +454,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **parallel**: worker model override for parallel milestone workers
 
 ### Fixed
+
 - **gsd**: validate depth verification answer before unlocking write-gate
 - **gsd**: revert unknown artifact check to warn-and-proceed
 - **gsd**: add missing cmd field to test base WorkflowEvent
@@ -521,6 +552,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **gsd**: add fastPathInstruction to buildDiscussMilestonePrompt loadPrompt call
 
 ### Changed
+
 - auto-commit after quick-task
 - auto-commit after quick-task
 - auto-commit after quick-task
@@ -532,12 +564,14 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [2.65.0] - 2026-04-07
 
 ### Added
+
 - **gsd**: persistent notification panel with TUI overlay, widget, and web API
 - **gsd**: wire blocking behavior and strict mode for enhanced verification
 - **gsd**: add post-execution cross-task consistency checks
 - **gsd**: add pre-execution plan verification checks
 
 ### Fixed
+
 - **gsd**: wrap long notification messages and fit overlay to content
 - **gsd**: remove background color from backdrop, fix message truncation
 - **gsd**: restore consistent overlay height to prevent ghost artifacts
@@ -556,18 +590,21 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **headless**: treat discuss and plan as multi-turn commands
 
 ### Changed
+
 - **interactive**: cap rendered chat components + kill orphan descendants
 - **tui**: render-skip, frame isolation, Text cache guard, dispose
 
 ## [2.64.0] - 2026-04-06
 
 ### Added
+
 - **gsd**: add LLM safety harness for auto-mode damage control
 - **ollama**: native /api/chat provider with full option exposure
 - **parallel**: slice-level parallelism with dependency-aware dispatch (#3315)
 - **mcp-client**: add OAuth auth provider for HTTP transport (#3295)
 
 ### Fixed
+
 - **ui**: remove 200-column cap on welcome screen width
 - address adversarial review findings for #3576
 - **gsd**: replace hardcoded agent skill paths with dynamic resolution (#3575)
@@ -619,6 +656,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - dashboard model label shows dispatched model, not stale previous unit (#3320)
 
 ### Changed
+
 - **gsd**: remove copyright line from test file
 - **gsd**: trim promptGuidelines to 1 line to reduce per-turn token cost
 - **web**: consolidate subprocess boilerplate into shared runner (#1899)
@@ -626,9 +664,11 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [2.63.0] - 2026-04-05
 
 ### Added
+
 - **mcp-server**: add 6 read-only tools for project state queries (#3515)
 
 ### Fixed
+
 - **gsd**: enrich vague diagnostic messages with root-cause context
 - **test**: reset dedup cache between ask-user-freetext tests
 - **db**: delete orphaned WAL/SHM files alongside empty gsd.db (#2478)
@@ -643,17 +683,20 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **pi-coding-agent**: cancel stale retries after model switch
 
 ### Changed
+
 - untrack .repowise/ and add to .gitignore
 
 ## [2.62.1] - 2026-04-05
 
 ### Fixed
+
 - **gsd**: gate steer worktree routing on active session, fix messaging
 - **gsd**: resolve steer overrides to worktree path when worktree is active
 
 ## [2.62.0] - 2026-04-04
 
 ### Added
+
 - **gsd**: enhance /gsd codebase with preferences, --collapse-threshold, and auto-init
 - **01-05**: fire before_model_select hook, add verbose scoring output, load capability overrides
 - **01-04**: register before_model_select placeholder handler in GSD hooks
@@ -664,6 +707,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **01-01**: add capability types, data tables, and scoring functions to model-router
 
 ### Fixed
+
 - **gsd**: add codebase validation in validatePreferences so preferences are not silently dropped
 - **test**: update db-path-worktree-symlink test for simplified diagnostic logging
 - **gsd**: update tests for errors-only audit persistence, fix empty catch blocks
@@ -679,26 +723,31 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **remote-questions**: fire configured channels in interactive mode
 
 ### Changed
+
 - **gsd**: migrate all catch blocks to centralized workflow-logger
 - init gsd
 
 ## [2.61.0] - 2026-04-04
 
 ### Added
+
 - stop/backtrack capture classifications for milestone regression (#3488)
 - GSD context optimization with model routing and context masking
 
 ## [2.60.0] - 2026-04-04
 
 ### Added
+
 - add /btw skill — ephemeral side questions from conversation context
 
 ### Fixed
+
 - **btw**: remove LLM-specific references from skill description
 
 ## [2.59.0] - 2026-04-03
 
 ### Added
+
 - **extensions**: add Ollama extension for first-class local LLM support (#3371)
 - **doctor**: stale commit safety check with gsd snapshot and auto-cleanup
 - **extensions**: wire up topological sort and unified registry filtering (#3152)
@@ -710,6 +759,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **gsd**: add codebase map — structural orientation for fresh agent contexts
 
 ### Fixed
+
 - **worktree**: resolve merge conflict for PR #3322 — adopt comprehensive pre-merge cleanup
 - **merge**: clean stale MERGE_HEAD before squash merge (#2912)
 - **state**: always run disk→DB reconciliation when DB is available (#2631)
@@ -779,7 +829,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - make claude-code provider stateful with full context and sidechain events (#2859) (#3254)
 - **worktree**: preserve non-empty gsd.db during sync to prevent truncation (#2815) (#3255)
 - align @gsd/native module type with compiled output (#3253)
-- parse hook/* completed-unit keys correctly in forensics + doctor (#2826) (#3252)
+- parse hook/\* completed-unit keys correctly in forensics + doctor (#2826) (#3252)
 - copy mcp.json into auto-mode worktrees (#2791) (#3251)
 - add gsd_requirement_save and upsert path for requirement updates (#3249)
 - handle pause_turn stop reason to prevent 400 errors with native web search (#2869) (#3248)
@@ -802,11 +852,12 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **mcp**: handle server names with spaces in mcp_discover (#3037)
 - **gsd**: detect markdown body verdicts and guard plan-milestone against completed slices (#2960) (#3035)
 - **error-classifier**: replace STREAM_RE whack-a-mole with catch-all V8 JSON.parse pattern
-- type _borderColorKey as 'dim' | 'bashMode' to match ThemeColor
+- type \_borderColorKey as 'dim' | 'bashMode' to match ThemeColor
 - **tui**: comprehensive TUI review — layout, flow, rendering, and state fixes
 - **gsd**: harden codebase-map — bug fixes, UX polish, and expanded tests
 
 ### Changed
+
 - **state**: centralize pipeline logging through workflow logger (#3282)
 - **gitignore**: exclude src/ build artifacts, scratch files, and .plans/
 - **complexity**: reclassify planning phases from standard to heavy tier
@@ -814,9 +865,11 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [2.58.0] - 2026-03-28
 
 ### Added
+
 - Added 6 discord.js shard/error/warn event listeners for reconnect…
 
 ### Fixed
+
 - **auto**: guard startAuto() against concurrent invocation (#2923)
 - **auto-dispatch**: widen operational verification gate regex (fixes #2866) (#2898)
 - **parallel**: three bugs preventing reliable parallel worker execution (#2801)
@@ -831,6 +884,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [2.57.0] - 2026-03-28
 
 ### Added
+
 - Extended DaemonConfig with control_channel_id and orchestrator se…
 - Created pure-function event formatters (10 functions) mapping RPC…
 - **models**: add GLM-5.1 to Z.AI provider in custom models
@@ -841,6 +895,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Migrated headless orchestrator to use execution_complete events,…
 
 ### Fixed
+
 - **headless**: match "completed" status from RPC v2 in exit code mapper
 - show external drives in directory browser on Linux
 - Regenerate package-lock.json after merge
@@ -852,14 +907,17 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - revert jsonl.ts to inline implementation — @gsd-build/rpc-client not available at source-level test time in CI
 
 ### Changed
+
 - auto-commit after complete-milestone
 
 ## [2.56.0] - 2026-03-27
 
 ### Added
+
 - **parallel**: /gsd parallel watch — native TUI overlay for worker monitoring (#2806)
 
 ### Fixed
+
 - **ci**: copy web/components to dist-test for xterm-theme test (#2891)
 - **gsd**: prefer PREFERENCES.md in worktrees (#2796)
 - **gsd**: resume auto-mode after transient provider pause (#2822)
@@ -868,15 +926,18 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **gsd**: preserve auto start model through discuss (#2837)
 
 ### Changed
+
 - **test**: compile unit tests with esbuild, reclassify integration tests, fix node_modules symlink (#2809)
 
 ## [2.55.0] - 2026-03-27
 
 ### Added
+
 - colorized headless verbose output with thinking, phases, cost, and durations (#2886)
 - headless text mode observability + skip UAT pause (#2867)
 
 ### Fixed
+
 - **cli**: let gsd update bypass version mismatch gate (#2845)
 - **contracts**: add isWorkspaceEvent guard + close routeLiveInteractionEvent exhaustiveness gap (#2878)
 - **gsd**: use project root for prior-slice dispatch guard (#2863)
@@ -889,16 +950,19 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [2.54.0] - 2026-03-27
 
 ### Added
+
 - Headless Integration Hardening & Release (M002) (#2811)
 - **parallel**: add real-time TUI monitor dashboard with self-healing (#2799)
 
 ## [2.53.0] - 2026-03-27
 
 ### Added
+
 - **vscode**: activity feed, workflow controls, session forking, enhanced code lens [2/3] (#2656)
 - **gsd**: enable safety mechanisms by default (snapshots, pre-merge checks) (#2678)
 
 ### Fixed
+
 - hydrate collected secrets for current session (#2788)
 - resolve stash pop conflicts and stop swallowing merge errors (#2780)
 - treat any extracted verdict as terminal in isValidationTerminal (#2774)
@@ -913,11 +977,13 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - add shell flag for Windows spawn in VSCode extension (#2781)
 
 ### Changed
+
 - **gsd**: extract duplicated status guards and validation helpers (#2767)
 
 ## [2.52.0] - 2026-03-27
 
 ### Added
+
 - **vscode**: status bar, file decorations, bash terminal, session tree, conversation history, code lens [1/2] (#2651)
 - **web**: Dark mode contrast — raise token floor and flatten opacity tier system (#2734)
 - Wire --bare mode across headless → pi-coding-agent → resource-loa…
@@ -925,11 +991,12 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Added RPC protocol v2 types, init handshake with version detectio…
 
 ### Fixed
+
 - auto-mode stops after provider errors (#2762) (#2764)
 - add missing runtime stage name to Dockerfile (#2765)
 - make transaction() re-entrant and add slice_dependencies to initSchema
 - remove preferences.md from ROOT_STATE_FILES to prevent back-sync overwrite
-- wire tool handlers through DB port layer, remove _getAdapter from all tools
+- wire tool handlers through DB port layer, remove \_getAdapter from all tools
 - **gsd**: move state machine guards inside transaction in 5 tool handlers (#2752)
 - reconcile disk milestones into empty DB before deriveStateFromDb guard (#2686)
 - **gsd**: seed preferences.md into auto-mode worktrees (#2693)
@@ -953,6 +1020,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - include preferences.md in worktree sync and initial seed
 
 ### Changed
+
 - **pi-ai**: replace model-ID pattern matching with capability metadata (#2548)
 - **gsd-db**: comprehensive SQLite audit fixes — indexes, caching, safety, reconciliation
 - rename preferences.md to PREFERENCES.md for consistency (#2700) (#2738)
@@ -961,6 +1029,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [2.51.0] - 2026-03-26
 
 ### Added
+
 - add /terminal slash command for direct shell execution (#2349)
 - **auto**: check verification class compliance before milestone completion (#2623)
 - **validate**: extract followUps and knownLimitations in parseSummary (#2622)
@@ -976,6 +1045,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **skills**: use ~/.agents/skills/ as primary skills directory with curated catalog
 
 ### Fixed
+
 - improve light theme warning contrast (#2674)
 - honor explicit model config when model is not in known tier map (#2643)
 - exclude lastReasoning from retry diagnostic to prevent hallucination loops (#2663)
@@ -1029,17 +1099,20 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **gsd extension**: detect initialized projects in health widget
 
 ### Changed
+
 - consolidate docs, remove stale artifacts, and repo hygiene (#2665)
 - extract runSafely helper for try-catch-debug-continue pattern (#2611)
 
 ## [2.50.0] - 2026-03-26
 
 ### Added
+
 - **gsd**: wire structured error propagation through UnitResult
 - add parallel quality gate evaluation with evaluating-gates phase
 - add 8-question quality gates to planning and completion templates
 
 ### Fixed
+
 - reconcile stale task status in filesystem-based state derivation (#2514)
 - merge duplicate extractUatType imports in auto-dispatch
 - use Record<string, any> for hasNonEmptyFields to accept typed DB rows
@@ -1073,7 +1146,8 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **web**: lazily compute default package root to avoid Windows standalone crash
 
 ### Changed
-- adopt parseUnitId utility across all auto-* modules
+
+- adopt parseUnitId utility across all auto-\* modules
 - flatten syncMilestoneDir nesting with shared helper
 - extract merge-state cleanup helper in reconcileMergeState
 - extract planning-state validation helpers in detectRogueFileWrites
@@ -1089,24 +1163,29 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [2.49.0] - 2026-03-25
 
 ### Added
+
 - add --yolo flag to /gsd auto for non-interactive project init
 
 ### Fixed
+
 - use full git log in merge tests to match trailer-based milestone IDs
 - update parallel-merge test assertion for new trailer format
 - clarify regex alternation in test assertion
 - verdict gate accepts PARTIAL for mixed/human-experience/live-runtime UATs
 
 ### Changed
+
 - move GSD metadata from commit subject scopes to git trailers
 
 ## [2.48.0] - 2026-03-25
 
 ### Added
+
 - **discuss**: allow /gsd discuss to target queued milestones
 - enhance /gsd forensics with journal and activity log awareness
 
 ### Fixed
+
 - make journal scanning intelligent — limit parsed files, line-count older ones
 - **model-registry**: scope custom provider stream handlers to prevent clobbering built-in API handlers
 - **forensics**: filter benign bash exit-code-1 and user skips from error traces
@@ -1115,18 +1194,22 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **auto**: skip CONTEXT-DRAFT warning for completed/parked milestones
 
 ### Changed
+
 - address review - extract RAPID_ITERATION_THRESHOLD_MS, simplify data access
 
 ### Removed
+
 - remove insertChildBefore usage in chat-controller
 
 ## [2.47.0] - 2026-03-25
 
 ### Added
+
 - **agent-core**: add externalToolExecution mode for external providers
 - **provider**: add Claude Code CLI provider extension
 
 ### Fixed
+
 - **claude-code-cli**: render tool calls above text response
 - **ci**: update FILE-SYSTEM-MAP.md path after docs→docs-internal move
 - isInheritedRepo false negative when parent has stale .gsd; defense-in-depth local .git check in bootstrap
@@ -1139,23 +1222,27 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [2.46.1] - 2026-03-25
 
 ### Fixed
+
 - **ci**: prevent windows-portability from blocking pipeline
 - **ci**: prevent pipeline race condition on release push
 - **gsd**: create empty DB for fresh projects with empty .gsd/ (#2510)
 - **remote-questions**: hydrate remote channel tokens from auth.json on startup
 
 ### Changed
+
 - trigger CI to pick up pipeline race condition fix
 - trigger pipeline with race condition fix
 
 ## [2.46.0] - 2026-03-25
 
 ### Added
+
 - **gsd**: single-writer engine v3 — state machine guards, actor identity, reversibility
 - **gsd**: single-writer state engine v2 — discipline layer on DB architecture
 - **gsd**: add workflow-logger and wire into engine, tool, manifest, reconcile paths (#2494)
 
 ### Fixed
+
 - **gsd**: align prompts with single-writer tool API
 - **gsd**: integration-proof — check DB state not roadmap projection after reset
 - **gsd**: block milestone completion when verification fails (#2500)
@@ -1177,6 +1264,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [2.45.0] - 2026-03-25
 
 ### Added
+
 - **web**: make web UI mobile responsive (#2354)
 - **gsd**: add `/gsd rethink` command for conversational project reorganization (#2459)
 - **gsd**: add renderCall/renderResult previews to DB tools (#2273)
@@ -1186,6 +1274,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **system-context**: inject global ~/.gsd/agent/KNOWLEDGE.md into system prompt (#2331)
 
 ### Fixed
+
 - **gsd**: handle retentionDays=0 on Windows + run windows-portability on PRs (#2460)
 - use Array.from instead of Buffer.from for native processStreamChunk state (#2348)
 - **gsd**: isInheritedRepo conflates ~/.gsd with project .gsd when git root is $HOME (#2398)
@@ -1214,6 +1303,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **ci**: separate cross-compilation target from toolchain install
 
 ### Changed
+
 - migrate D-G test files from createTestContext to node:test (#2418)
 - **test**: replace try/finally with beforeEach/afterEach in packages tests (#2390)
 - **test**: migrate gsd/tests s-z from custom harness to node:test (#2397)
@@ -1228,6 +1318,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [2.44.0] - 2026-03-24
 
 ### Added
+
 - **core**: support for 'non-api-key' provider extensions like Claude Code CLI (#2382)
 - **docker**: add official Docker sandbox template for isolated GSD auto mode (#2360)
 - **gsd**: show per-prompt token cost in footer behind show_token_cost preference (#2357)
@@ -1245,6 +1336,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **gsd**: tool-driven write-side state transitions (M001)
 
 ### Fixed
+
 - post-migration cleanup — pragmas, rollbacks, tool gaps, stale code (#2410)
 - **test**: normalize CRLF in auto-stash-merge assertion for Windows
 - **test**: swallow EPERM on Windows temp dir cleanup in auto-stash-merge test
@@ -1274,6 +1366,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **tests**: remove invalid `seq` property from insertMilestone calls
 
 ### Changed
+
 - **contrib**: add CODEOWNERS and team workflow docs (#2286)
 - **M001**: auto-commit after complete-milestone
 - **M001**: auto-commit after validate-milestone
@@ -1296,9 +1389,11 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [2.43.0] - 2026-03-23
 
 ### Added
+
 - **forensics**: opt-in duplicate detection before issue creation (#2105)
 
 ### Fixed
+
 - prevent banner from printing twice on first run (#2251)
 - **test**: Windows CI — use double quotes in git commit message (#2252)
 - **async-jobs**: suppress duplicate follow-up for awaited job results (#2248) (#2250)
@@ -1326,11 +1421,13 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **pi-ai**: correct Copilot context window and output token limits (#2118)
 
 ### Changed
+
 - startup optimizations — pre-compiled extensions, compile cache, batch discovery (#2125)
 
 ## [2.42.0] - 2026-03-22
 
 ### Added
+
 - **gsd**: declarative workflow engine — YAML-defined workflows through the auto-loop (#2024)
 - **gsd**: unified rule registry, event journal, journal query tool, and tool naming convention (#1928)
 - **ci**: PR risk checker — classify changed files by system and surface risk level (#1930)
@@ -1339,6 +1436,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - add --host, --port, --allowed-origins flags for web mode (#1847) (#1873)
 
 ### Fixed
+
 - **tests**: wrap rmSync cleanup in try/catch for Windows EPERM
 - **tests**: add maxRetries to rmSync cleanup for Windows EPERM compatibility
 - recursive key sorting in tool-call loop guard hash function (#1962)
@@ -1358,7 +1456,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **auto**: broaden worktree health check to all ecosystems (#1860)
 - **doctor**: cascade slice uncheck when task_done_missing_summary unchecks tasks (#1850) (#1858)
 - defend exit path against ESM module cache mismatch (#1854)
-- escape parentheses in paths before bash shell-out, fix __extensionDir fallback (#1872)
+- escape parentheses in paths before bash shell-out, fix \_\_extensionDir fallback (#1872)
 - use PowerShell Start-Process for Windows browser launch, prevent URL wrapping (#1870)
 - clear stale unit state and restore CWD when step-wizard exits auto-loop (#1869)
 - prevent cross-project state leak in brand-new directories (#1639) (#1861)
@@ -1370,6 +1468,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [2.41.0] - 2026-03-21
 
 ### Added
+
 - **doctor**: worktree lifecycle checks, cleanup consolidation, enhanced /worktree list (#1814)
 - **web**: browser-based web interface (#1717)
 - **ci**: skip build/test for docs-only PRs and add prompt injection scan (#1699)
@@ -1378,6 +1477,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **cleanup**: add ~/.gsd/projects/ orphan detection and pruning (#1686)
 
 ### Fixed
+
 - skip web build on Windows — Next.js webpack hits EPERM on system dirs
 - include web build in main build command
 - fall through to prose slice parser when checkbox parser yields empty under ## Slices (#1744)
@@ -1466,6 +1566,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **worktree**: recurse into tasks/ when syncing slice artifacts back to project root (#1678) (#1681)
 
 ### Changed
+
 - split shared/mod.ts into pure and TUI-dependent barrels (#1807)
 - replace hardcoded /tmp paths with os.tmpdir()/homedir() (#1708)
 - **ci**: reduce pipeline minutes with shallow clones, npm caching, and exponential backoff (#1700)
@@ -1474,11 +1575,13 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [2.40.0] - 2026-03-20
 
 ### Added
+
 - **pi**: add Skill tool resolution (#1661)
 - health check phase 2 — real-time doctor issue visibility across widget, visualizer, and HTML reports (#1644)
 - upgrade forensics prompt to full-access GSD debugger (#1660)
 
 ### Fixed
+
 - prune stale env-utils.js from extensions root, preventing startup load error (#1655)
 - **splash**: replace box corners with full-width bars for visual unity with auto-mode widget (#1654)
 - add runtime paths to forensics prompt to prevent path hallucination (#1657)
@@ -1487,11 +1590,13 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - cancel trailing async jobs on session switch to prevent wasted LLM turns (#1643)
 
 ### Changed
+
 - decompose autoLoop into pipeline phases (#1615) (#1659)
 
 ## [2.39.0] - 2026-03-20
 
 ### Added
+
 - **gsd**: activate matching skills in dispatched prompts (#1630)
 - **gsd**: add .gsd/RUNTIME.md template for declared runtime context (#1626)
 - **gsd**: create draft PR on milestone completion when git.auto_pr enabled (#1627)
@@ -1504,6 +1609,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - feat(ui): minimal GSD welcome screen on startup (#1584)
 
 ### Fixed
+
 - recover + prevent #1364 .gsd/ data-loss (v2.30.0–v2.38.0) (#1635)
 - treat summary as terminal artifact even when roadmap slices are unchecked (#1632)
 - **gsd**: close residual #1364 data-loss vectors on v2.36.0+ (#1637)
@@ -1525,6 +1631,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - detect worktree paths resolved through .gsd symlinks (#1585)
 
 ### Changed
+
 - **gsd**: unify sidecar mini-loop into main dispatch path (#1617)
 - **auto-loop**: initial cleanup — hoist constant, cache prefs per iteration (#1616)
 - **gsd**: add 30K char hard cap on prompt preamble (#1619)
@@ -1537,10 +1644,12 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [2.38.0] - 2026-03-20
 
 ### Added
+
 - **gsd**: ADR-004 — derived-graph reactive task execution (#1546)
 - add anthropic-vertex provider for Claude on Vertex AI (#1533)
 
 ### Fixed
+
 - **ci**: reduce GitHub Actions minutes ~60-70% (~10k → ~3-4k/month) (#1552)
 - **gsd**: reactive batch verification + dependency-based carry-forward (#1549)
 - **gsd**: enforce backtick file paths in task plan IO sections (#1548)
@@ -1548,6 +1657,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [2.37.1] - 2026-03-20
 
 ### Fixed
+
 - interactive guard menu for remote auto-mode sessions (#1507) (#1524)
 - use pull_request_target so AI triage has secret access on PRs
 - cmux library directory incorrectly loaded as extension (#1537)
@@ -1558,19 +1668,23 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [2.37.0] - 2026-03-20
 
 ### Added
+
 - **dashboard**: two-column layout with redesigned widget (#1530)
 - integrate cmux with gsd runtime (#1532)
 
 ### Fixed
+
 - add session-level search budget to prevent unbounded native web search (#1309) (#1529)
 
 ## [2.36.0] - 2026-03-20
 
 ### Added
+
 - deprecate agent-instructions.md in favor of AGENTS.md / CLAUDE.md (#1492) (#1514)
 - AI-powered issue and PR triage via Claude Haiku (#1510)
 
 ### Fixed
+
 - preserve user messages during abort with origin-aware queue clearing (#1439) (#1521)
 - remove broken SwiftUI skill and add CI reference check (#1476) (#1520)
 - wire escalateTier into auto-loop retry path (#1505) (#1519)
@@ -1597,9 +1711,11 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [2.35.0] - 2026-03-19
 
 ### Added
+
 - **gsd**: add /gsd changelog command with LLM-summarized release notes (#1465)
 
 ### Fixed
+
 - restore lsp single-server selector export
 - **mcp**: preserve args for mcp_call tool invocations (#1354)
 - accumulate session cost independently of message array (#1423)
@@ -1609,6 +1725,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **prefs**: close merge, validation, serialization, and docs gaps
 
 ### Changed
+
 - deduplicate error emission and message patterns in agent-core (#1444)
 - simplify settings manager with generic setter helpers (#1461)
 - consolidate theme files and remove manual schema (#1478)
@@ -1633,9 +1750,11 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [2.34.0] - 2026-03-19
 
 ### Added
+
 - auto-generate OpenRouter model registry from API + add missing models (#1407) (#1426)
 
 ### Fixed
+
 - release stranded bootstrap locks and handle re-entrant reacquire (#1352)
 - add JS fallbacks for wrapTextWithAnsi and visibleWidth when native addon unavailable (#1418) (#1428)
 - emit agent_end after abort during tool execution (#1414) (#1417)
@@ -1649,18 +1768,22 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [2.33.1] - 2026-03-19
 
 ### Fixed
+
 - clean up stale numbered lock files and harden signal/exit handling (#1315) (#1323)
 - worktree sync and home-directory safety check (#1311, #1317) (#1322)
 
 ### Changed
+
 - remove orphaned mcporter extension manifest (#1318)
 
 ## [2.33.0] - 2026-03-19
 
 ### Added
+
 - add live regression test harness for post-build pipeline validation (#1316)
 
 ### Fixed
+
 - align retry lock path with primary lock settings to prevent ECOMPROMISED (#1307)
 - skip symlinks in makeTreeWritable to prevent EPERM on NixOS/nix-darwin (#1303)
 - handle Windows EPERM on .gsd migration rename with copy+delete fallback (#1296)
@@ -1669,6 +1792,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - merge quick-task branch back to original after completion (#1293)
 
 ### Changed
+
 - extract tryMergeMilestone to eliminate 4 duplicate merge paths in auto.ts (#1314)
 - dispatch loop hardening — defensive guards, regression tests, lock alignment (#1310)
 - extract parseUnitId() to centralize unit ID parsing (#1282)
@@ -1678,16 +1802,19 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [2.32.0] - 2026-03-19
 
 ### Added
+
 - always-on health widget and visualizer health tab expansion (#1286)
 - environment health checks, progress score, and status integration (#1263)
 
 ### Fixed
+
 - skip crash recovery when auto.lock was written by current process (#1289)
 - load worktree-cli extension modules via jiti instead of static ESM imports (#1285)
 - **gsd**: prevent concurrent dispatch during skip chains (#1272) (#1283)
 - skip non-artifact UAT dispatch in auto-mode (#1277)
 
 ### Changed
+
 - deduplicate knownUnitTypes and STATE_REBUILD_MIN_INTERVAL_MS constants (#1281)
 - extract prompt builder helpers for inlined context and source file lists (#1279)
 - extract createGitService() factory, remove debug logs (#1278)
@@ -1697,21 +1824,24 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [2.31.2] - 2026-03-18
 
 ### Fixed
+
 - **gsd**: stop replaying completed run-uat units (#1270)
 
 ## [2.31.1] - 2026-03-18
 
 ### Fixed
-- prevent false-positive 'Session lock lost' during auto-mode (#1257)
 
+- prevent false-positive 'Session lock lost' during auto-mode (#1257)
 
 ## [2.31.0] - 2026-03-18
 
 ### Added
+
 - add aws-auth extension for automatic Bedrock credential refresh (#1253)
 - add -w/--worktree CLI flag for isolated worktree sessions (#1247)
 
 ### Fixed
+
 - remove stale git-commit assertion in worktree test after commit_docs removal
 - remove commit_docs test that broke CI after type removal (#1258)
 - replace blanket git clean .gsd/ with targeted runtime file removal (#1252)
@@ -1720,11 +1850,13 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - clean up stranded .gsd.lock/ directory to prevent false lock conflicts (#1251)
 
 ### Changed
+
 - remove dead commit_docs preference (incompatible with external .gsd/ state) (#1258)
 
 ## [2.30.0] - 2026-03-18
 
 ### Added
+
 - add extension manifest + registry for user-managed enable/disable (#1238)
 - add model health indicator to auto-mode progress widget (#1232)
 - simplify auto pipeline — merge research into planning, mechanical completion (ADR-003) (#1235)
@@ -1734,6 +1866,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - workflow templates — right-sized workflows for every task type (#1185)
 
 ### Fixed
+
 - align react-best-practices skill name with directory name (#1234)
 - gate slice progression on UAT verdict, not just file existence (#1241)
 - invalidate caches before roadmap check in /gsd discuss (#1240)
@@ -1746,6 +1879,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Two-column dashboard layout with task checklist (#1195)
 
 ### Changed
+
 - move .gsd/ to external state directory with symlink (ADR-002) (#1242)
 - replace MCPorter with native MCP client (#1210)
 - extend json-persistence utility and migrate top JSON I/O callsites (#1216)
@@ -1756,6 +1890,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [2.29.0] - 2026-03-18
 
 ### Added
+
 - add searchExcludeDirs setting for @ file autocomplete blacklist (#1202)
 - **ci**: automate prod-release with version bump, changelog, and tag push (#1194)
 - auto-open HTML reports in default browser on manual export (#1164)
@@ -1788,6 +1923,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - add project onboarding detection and init wizard
 
 ### Fixed
+
 - **ci**: add npm publish to prod-release and prevent mid-deploy cancellation (#1208)
 - **ci**: use env var for Discord webhook secret in if-condition
 - complete shared barrel exports and add import-claude to help text (#1198)
@@ -1888,6 +2024,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - inline bundled extension path parsing in subagent
 
 ### Changed
+
 - extract numeric validation helpers in prefs wizard (#1205)
 - deduplicate projectRoot() and dispatchDoctorHeal() between commands.ts and commands-handlers.ts (#1203)
 - extract shared JSON persistence utility, migrate metrics + routing-history + unit-runtime (#1206)
@@ -1927,11 +2064,13 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [2.28.0] - 2026-03-17
 
 ### Added
+
 - `gsd headless query` command for instant, read-only state inspection — returns phase, cost, progress, and next-unit as parseable JSON without spawning an LLM session
 - `/gsd update` slash command for in-session self-update
 - `/gsd export --html --all` for retrospective milestone reports
 
 ### Fixed
+
 - Failure recovery & resume safeguards: atomic file writes, OAuth fetch timeouts (30s), RPC subprocess exit detection, extension command context guards, bash temp file cleanup, settings write queue flush, LSP init retry with backoff, crash detection on session resume, blob garbage collection
 - Consolidated duplicate `mcp-server.ts` into single implementation
 - Consolidated duplicate `bundled-extension-paths.ts` into single module
@@ -1941,6 +2080,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Prompt system requires grammatical narration for clearer agent output
 
 ### Changed
+
 - Updated documentation for v2.26 and v2.27.0 features
 - Documented all `preferences.md` fields in reference and template
 - Removed stale `.pi/agents/` files superseded by built-in agent definitions
@@ -1948,6 +2088,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [2.27.0] - 2026-03-17
 
 ### Added
+
 - HTML report generator with progression index across milestones
 - Crash recovery for parallel orchestrator — persisted state with PID liveness detection
 - Headless orchestration skill with supervised mode
@@ -1955,12 +2096,14 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `git.manage_gitignore` preference to opt out of automatic `.gitignore` changes
 
 ### Changed
+
 - Encapsulated auto.ts state into AutoSession class (cleaner session lifecycle)
 - Extracted 7 focused modules from auto.ts (auto-worktree-sync, resource staleness, stale escape)
 - TUI dashboard cleanup, dedup, and feature improvements
 - Reordered visualizer tabs and HTML report sections into logical groupings
 
 ### Fixed
+
 - Single ENTER now correctly submits slash command argument autocomplete
 - Web search loop broken with consecutive duplicate guard
 - Transient network errors retried before model fallback
@@ -1986,6 +2129,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [2.26.0] - 2026-03-17
 
 ### Added
+
 - Model selector grouped by provider with model type, provider, and API docs fields
 - `require_slice_discussion` option to pause auto-mode before each slice for human review
 - Discussion status indicators in `/gsd discuss` slice picker
@@ -1996,6 +2140,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Fallback parser for prose-style roadmaps without `## Slices` section
 
 ### Fixed
+
 - Windows path normalization in LLM-visible text to prevent bash failures
 - Async bash job completion no longer triggers spurious LLM turns
 - Native web_search limited to max 5 uses per response
@@ -2020,9 +2165,11 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Headless mode no longer exits early on progress notifications containing 'complete'
 
 ### Removed
+
 - Symlink-based development workflow (reverted PR #744)
 
 ### Changed
+
 - Explicit Gemini OAuth ToS warning added to README — recommends API keys over OAuth
 - Documentation updated for v2.24 release features
 - Bug report template updated with model type, provider, and API docs fields
@@ -2030,6 +2177,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [2.25.0] - 2026-03-16
 
 ### Added
+
 - Native web search results rendering in TUI with `PREFER_BRAVE_SEARCH` environment variable toggle
 - Meaningful commit messages generated from task summaries instead of generic messages
 - Incremental memory system for auto-mode sessions
@@ -2037,18 +2185,21 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - 14 new E2E smoke tests for CLI verification
 
 ### Fixed
+
 - Phantom skip loop caused by stale crash recovery context
 - Skip-loop now interruptible and counts toward lifetime cap
 - Cache invalidation consistency — orphaned `invalidateStateCache()` calls replaced, DB artifact cache included in `invalidateAllCaches()`
 - Plan checkbox reconciliation on worktree re-attach after crash
 
 ### Changed
+
 - Removed unnecessary `as any` casts, dead exports, and duplicate code
 - Updated documentation for v2.22 and v2.23 release features
 
 ## [2.24.0] - 2026-03-16
 
 ### Added
+
 - **Parallel milestone orchestration** — run multiple workers across phases simultaneously
 - Dashboard view for parallel workers with 80% budget alert
 - Headless `new-milestone` command for programmatic milestone creation
@@ -2058,6 +2209,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `validate-milestone` phase and dispatch
 
 ### Fixed
+
 - Sync `completed-units.json` across worktree boundaries
 - Worktree artifact verification uses correct base path
 - Auto-resume auto-mode after rate limit cooldown
@@ -2073,11 +2225,13 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Strip clack UI from postinstall, keep silent Playwright download
 
 ### Changed
+
 - Lazy-load LLM provider SDKs to reduce startup time
 
 ## [2.23.0] - 2026-03-16
 
 ### Added
+
 - **VS Code extension** — full extension with chat participant, RPC integration, marketplace publishing under FluxLabs publisher
 - **`gsd headless`** — redesigned headless mode for full workflow orchestration: auto-responds to prompts, detects completion, supports `--json` output and `--timeout` flags
 - **`gsd sessions`** — interactive session picker for browsing and resuming saved sessions (#721)
@@ -2087,9 +2241,11 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **`models.json` resolution** — custom model definitions with fallback to `~/.pi/agent/models.json`
 
 ### Changed
+
 - **Background shell performance** — optimized hot path with parallel git queries and lazy workspace validation
 
 ### Fixed
+
 - Forensics uses `GSD_VERSION` env var instead of fragile package.json path traversal; now worktree-aware to prevent stale root misdiagnosis
 - Background commands rewritten to prevent pipe-open hang; stalled-tool detection added with prompt guidance
 - Auto mode breaks infinite skip loop on repeatedly-skipped completed units
@@ -2107,6 +2263,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [2.22.0] - 2026-03-16
 
 ### Added
+
 - **`/gsd forensics`** — post-mortem investigation of auto-mode failures with structured root-cause analysis
 - **Claude marketplace import** — import Claude marketplace plugins as namespaced GSD components
 - **MCP server mode** — run GSD as an MCP server with `--mode mcp`
@@ -2120,6 +2277,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **Subcommand help** — inline help text for all GSD subcommands
 
 ### Fixed
+
 - `verificationBudget` passed correctly to execute-task prompt template
 - Background shell worktree cwd detection normalized to prevent stale paths
 - Skill loading made an active directive in auto-mode units
@@ -2140,17 +2298,20 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [2.21.0] - 2026-03-16
 
 ### Added
+
 - **Browser tools TypeScript conversion** — `browser-tools/core.js` converted to TypeScript with c8 test coverage
 - **SSRF protection on `fetch_page`** — blocks private IPs, metadata endpoints, and non-HTTP protocols
 - **Stale async job cancellation** — heuristic prevents outdated results in auto-mode
 
 ### Changed
+
 - **Pause/resume recovery** — reuses crash recovery infrastructure for more reliable context restoration
 - **Build scripts extracted** — inline package.json scripts moved to standalone files for cross-platform support
 - **Help text deduplicated** — consolidated across CLI entry points
 - **Dependency alignment** — `@types/mime-types` moved to devDependencies, chalk versions consolidated
 
 ### Fixed
+
 - Task counter display no longer shows "task 5/4" after loop recovery
 - Browser-tools TypeScript type errors in CI
 - 4 small issues (#663): Windows GitHub Copilot login, Tavily display, MCPorter auto-install, notification preferences
@@ -2159,6 +2320,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [2.20.0] - 2026-03-16
 
 ### Added
+
 - **Telegram remote questions** — receive and respond to GSD questions via Telegram bot alongside existing Slack and Discord channels (#645)
 - **`/gsd quick`** — execute a quick task with GSD guarantees (atomic commits, state tracking) without the full planning overhead (#437)
 - **`/gsd mode`** — workflow mode system with solo and team presets that configure defaults for milestone IDs, git commit behavior, and documentation settings (#651)
@@ -2174,6 +2336,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **Worktree post-create hook** — run custom setup scripts when GSD creates a new worktree (#597)
 
 ### Fixed
+
 - **CPU spinning from regex backtracking** — replaced `[\s\S]*?` regex in preferences parser with indexOf-based scanning (#468)
 - **Model config bleed between concurrent GSD instances** — isolated model configuration per session (#650)
 - **Onboarding wizard repeats** — skip onboarding for extension-based providers that don't require auth.json credentials (#589)
@@ -2184,6 +2347,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **Google Search OAuth fallback** — uses Google Cloud Code Assist API when `GEMINI_API_KEY` is not set (#466)
 
 ### Changed
+
 - **Preferences wizard** — replaced serial flow with categorized menu for faster configuration (#623)
 - **Slack remote questions** — brought to feature parity with Discord integration (#628)
 - **YAML support in hooks** — hooks now support YAML configuration alongside JSON (#637)
@@ -2191,6 +2355,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [2.19.0] - 2026-03-16
 
 ### Added
+
 - **Workflow visualizer** — `/gsd visualize` opens a full-screen TUI overlay with four tabs: Progress (milestone/slice/task tree), Dependencies (ASCII dep graph), Metrics (cost/token bar charts), and Timeline (chronological execution history). Supports Tab/1-4 switching, per-tab scrolling, auto-refresh every 2s, and optional auto-trigger after milestone completion via `auto_visualize` preference (#626)
 - **Mid-execution capture & triage** — `/gsd capture` lets you fire-and-forget thoughts during auto-mode. The system triages accumulated captures at natural seams between tasks, classifies impact into five types (quick-task, inject, defer, replan, note), and proposes action with user confirmation. Dashboard shows pending capture count badge. Capture context injected into replan and reassess prompts (#512)
 - **Dynamic model routing** — complexity-based model routing classifies units into light/standard/heavy tiers and routes to cheaper models when appropriate, reducing token consumption 20-50% on capped plans. Includes budget-pressure-aware routing, cross-provider cost comparison, escalation on failure, adaptive learning from routing history (rolling 50-entry window with user feedback support), and task plan introspection (code block counting, complexity keyword detection) (#579)
@@ -2198,6 +2363,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **Discord integration parity with Slack** — plus new remote-questions documentation (#620)
 
 ### Fixed
+
 - **Absolute paths in auto-mode prompts** — write-target variables now passed as absolute paths, eliminating LLM path confusion in worktree contexts that caused artifacts written to wrong location and loop detection (#627)
 - **Worktree lifecycle on mid-session milestone transitions** (#616, #618)
 - **Eager template cache warming** — prevents version-skew crash in long auto-mode sessions (#621)
@@ -2205,6 +2371,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [2.18.0] - 2026-03-16
 
 ### Added
+
 - **Milestone queue reorder** — `/gsd queue` supports reordering milestone execution priority with dependency-aware validation, persistent ordering via `.gsd/QUEUE-ORDER.json` (#460)
 - **`.gsd/KNOWLEDGE.md`** — persistent project-specific context file loaded into agent prompts. New `/gsd knowledge` command with `rule`, `pattern`, and `lesson` subcommands for adding entries (#585)
 - **Dynamic model discovery** — runtime model enumeration from provider APIs (Ollama, OpenAI, Google, OpenRouter) with per-provider TTL caching and discovery adapters. New `ProviderManagerComponent` TUI for managing providers with auth status and model counts (#581)
@@ -2214,6 +2381,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **1,813 lines of new tests** — 13 new test files covering discovery cache, model discovery, model registry, models-json-writer, auto-worktree, derive-state-deps, in-flight tool tracking, knowledge, memory leak guards, preferences wizard fields, queue order, queue reorder E2E, and stale worktree cwd
 
 ### Fixed
+
 - **Heap OOM during long-running auto-mode sessions** — four sources of unbounded memory growth: activity log serialized all entries for SHA1 dedup (now streaming writes with lightweight fingerprint), uncleaned `activityLogState` Map between sessions, unbounded `completedUnits` array (now capped at 200), and `dirEntryCache`/`dirListCache` growing without bounds (now evicted at 200 entries) (#611)
 - **Stale worktree cwd after milestone completion** — three-layer fix: `escapeStaleWorktree()` at auto-mode entry, unconditional cwd restore in `stopAuto()`, and cwd restore on partial merge failure (#608)
 - **Worktree created from integration branch instead of main** — `createAutoWorktree` reads integration branch from META.json, merge targets integration branch not hardcoded main (#606)
@@ -2224,20 +2392,24 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **`showNextAction` crash** — falls back to `select()` when `custom()` returns undefined (#447, #615)
 
 ### Changed
+
 - Comprehensive update to preferences reference and configuration guide (#614)
 - Auto-mode artifact writes scoped to active milestone worktree, preventing cross-milestone pollution (#590)
 
 ## [2.17.0] - 2026-03-15
 
 ### Added
+
 - **Token optimization profiles** — `budget`, `balanced`, and `quality` presets that coordinate model selection, phase skipping, and context compression to reduce token usage by 40-60% on budget mode
 - **Complexity-based task routing** — automatically classifies tasks as simple/standard/heavy and routes to appropriate models, with persistent learning from routing history
 - **`git.commit_docs` preference** — set to `false` to keep `.gsd/` planning artifacts local-only, useful for teams where only some members use GSD
 
 ### Changed
+
 - Updated Ollama cloud provider model catalog
 
 ### Fixed
+
 - Native binary hangs in GSD auto-mode paths (#453)
 - Auto-mode can be stopped from a different terminal (#586)
 - Parse cache collision causing false loop detection on `complete-slice` (#583)
@@ -2246,6 +2418,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [2.16.0] - 2026-03-15
 
 ### Added
+
 - `/gsd steer` command — hard-steer plan documents during execution without stopping the pipeline
 - Native git operations via libgit2 — ~70 fewer process spawns per dispatch cycle
 - Native performance optimizations for `deriveState`, JSONL parsing, and path resolution
@@ -2253,6 +2426,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - PR template and bug report issue template
 
 ### Fixed
+
 - Auto-mode continues after guided milestone planning instead of stalling at "Milestone planned"
 - Git commands no longer fail when repo path contains spaces
 - Arrow key cursor updates and Shift+Enter newline insertion in TUI
@@ -2260,12 +2434,14 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - TypeScript errors resolved across extension, test, and async-jobs files
 
 ### Changed
+
 - Hot-path lookup caching and error resilience optimizations
 - Extension type-checking added to CI pipeline
 
 ## [2.15.1] - 2026-03-15
 
 ### Fixed
+
 - Auto-mode worktree path resolution — prompt templates now include working directory, preventing artifacts from being written to the wrong location and causing infinite re-dispatches
 - Auto-mode resource sync detection — gracefully stops when resources change mid-session instead of crashing
 - Auto-mode missing import for `resolveSkillDiscoveryMode` causing crash on startup
@@ -2274,20 +2450,24 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Undo command now invalidates all caches (not just state cache), preventing stale results after undoing completed tasks
 
 ### Changed
+
 - CI pipeline supports prerelease publishing with `--tag next` for testing before stable release
 
 ### Added
+
 - Unit tests for auto-dashboard, auto-recovery, and crash-recovery modules (46 new tests)
 
 ## [2.15.0] - 2026-03-15
 
 ### Added
+
 - **8 new commands**: budget enforcement, notifications, and quality-of-life improvements (#441)
 - **Preferences schema validation**: detects unknown/typo'd preference keys and surfaces warnings instead of silently ignoring them (#542)
 - **Pipeline-aware prompts**: each agent phase (research, plan, execute, complete) now knows its role in the pipeline, eliminating redundant code exploration between phases (#543)
 - **Research depth calibration**: three-tier system (deep/targeted/light) so agents match effort to actual complexity (#543)
 
 ### Changed
+
 - Auto-mode decomposed into focused modules for maintainability (#534)
 - Dispatch logic extracted from if-else chain to dispatch table (#539)
 - v1 migration code gated behind dynamic import — only loaded when needed (#541)
@@ -2295,6 +2475,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Unified cache invalidation into single `invalidateAllCaches()` function (#545)
 
 ### Fixed
+
 - Executor agents now receive explicit working directory, preventing writes to main repo instead of worktree (#543)
 - Merge loop and .gsd/ conflict auto-resolution in worktree model, `git.isolation` preference restored (#536)
 - Arrow keys no longer insert escape sequences as text during LLM streaming (#493)
@@ -2310,16 +2491,19 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [2.14.4] - 2026-03-15
 
 ### Fixed
+
 - **Session cwd update** — `newSession()` now updates the LLM's perceived working directory to reflect `process.chdir()` into auto-worktrees. Previously the system prompt was frozen at the original project root, causing the LLM to `cd` back and write files to the wrong location. This was the root cause of complete-slice and plan-slice loops in worktree-based projects.
 
 ## [2.14.3] - 2026-03-15
 
 ### Fixed
+
 - **Copy planning artifacts into new auto-worktrees** — `createAutoWorktree` now copies `.gsd/milestones/`, `DECISIONS.md`, `REQUIREMENTS.md`, `PROJECT.md` from the source repo into the worktree. Prevents plan-slice loops in projects with pre-v2.14.0 `.gitignore`.
 
 ## [2.14.2] - 2026-03-15
 
 ### Fixed
+
 - **Dispatch reentrancy deadlock** — `_dispatching` flag was never reset after first dispatch, permanently blocking all subsequent unit dispatches. Wrapped in try/finally.
 - **`.gitignore` self-heal** — existing projects with blanket `.gsd/` ignore now auto-remove it on next auto-mode start, replacing with explicit runtime-only patterns so planning artifacts are tracked in git.
 - **Discuss depth verification** — render summary as chat text (markdown renders), use ask_user_questions for short confirmation only.
@@ -2327,23 +2511,27 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [2.14.1] - 2026-03-15
 
 ### Fixed
+
 - **Quiet auto-mode warnings** — internal recovery machinery (dispatch gap watchdog, model fallback chain) downgraded to verbose-only. Users only see warnings when action is needed.
 - **Dispatch recovery hardening** — artifact fallback when completion key missing, TUI freeze prevention, reentrancy guard, atomic writes, stale runtime record cleanup
 
 ## [2.14.0] - 2026-03-15
 
 ### Added
+
 - **Discussion manifest** — mechanical process verification for multi-milestone context discussions
 - **Session-internal `/gsd config`** — configure GSD settings within a running session
 - **Model selection UI** — select list instead of free-text input for model preferences
 - **Startup performance** — faster GSD launch via optimized initialization
 
 ### Changed
+
 - **Branchless worktree architecture** — eliminated slice branches entirely. All work commits sequentially on `milestone/<MID>` within auto-mode worktrees. No branch creation, switching, or merging within a worktree. ~2600 lines of merge/conflict/branch-switching code removed.
 - **`.gitignore` overhaul** — planning artifacts (`.gsd/milestones/`) are tracked in git naturally. Only runtime files are gitignored. No more force-add hacks.
 - **Multi-milestone enforcement** — `depends_on` frontmatter enforced in multi-milestone CONTEXT.md
 
 ### Fixed
+
 - **Auto-mode loop detection failures** — artifacts on wrong branch or invisible after branch switch no longer possible (root cause eliminated by branchless architecture)
 - **Nested worktree creation** — auto-mode no longer creates worktrees inside existing manual worktrees, preventing wrong-repo state reads and "All milestones complete" false positives
 - **Dispatch recovery hardening** — artifact fallback when completion key missing, TUI freeze prevention on cascading skips, reentrancy guard, atomic writes, stale runtime record cleanup, git index.lock cleanup
@@ -2353,6 +2541,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **Discussion routing** — `/gsd discuss` routes to draft when phase is needs-discussion
 
 ### Removed
+
 - `ensureSliceBranch()`, `switchToMain()`, `mergeSliceToMain()`, `mergeSliceToMilestone()`
 - `shouldUseWorktreeIsolation()`, `getMergeToMainMode()`, `buildFixMergePrompt()`
 - `withMergeHeal()`, `recoverCheckout()`, `fix-merge` unit type
@@ -2361,6 +2550,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [2.13.1] - 2026-03-15
 
 ### Fixed
+
 - Windows: multi-line commit messages in `mergeSliceToMilestone` broke shell parsing — switched to `execFileSync` with argument arrays
 - Windows: single-quoted git arguments and bash-only redirects in test files
 - Windows: worktree path normalization for `shouldUseWorktreeIsolation` and stale branch detection
@@ -2368,12 +2558,14 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [2.13.0] - 2026-03-15
 
 ### Added
+
 - **Worktree isolation for auto-mode** — auto-mode creates isolated git worktrees per milestone, with `--no-ff` slice merges preserving commit history and squash merge to main on milestone completion
 - **Self-healing git repair** — automatic recovery from detached HEAD, stale locks, and orphaned worktrees
 - **Worktree-aware doctor** — git health diagnostics and worktree integrity checks
 - **Isolation preferences** — choose between worktree and branch isolation modes
 
 ### Fixed
+
 - **Dispatch loop: parse cache stale data** — `dispatchNextUnit()` cleared path cache but not parse cache, allowing stale roadmap checkbox state to persist through doctor→dispatch transitions (#462)
 - **Dispatch loop: completion not persisted after agent session** — `handleAgentEnd()` now verifies artifacts and persists the completion key before re-entering the dispatch loop, preventing re-dispatch when `deriveState()` sees pre-merge branch state (#462)
 - **Dispatch loop: recovery counter reset without persistence** — loop-recovery and self-repair paths now persist completion keys and include a hard lifetime dispatch cap of 6 (#462, #463)
@@ -2385,15 +2577,18 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [2.12.0] - 2026-03-15
 
 ### Added
+
 - **Parallel tool calling** — tools from a single assistant message execute concurrently by default, with sequential mode as opt-in (`toolExecution: "sequential"`) and `beforeToolCall`/`afterToolCall` hooks for interception
 - **Ollama Cloud** as model and web tool provider
 - **Extensible hook system** for auto-mode state machine — post-unit hooks fire after unit completion
 - **Event queue settlement** for parallel tool execution — extension `tool_call`/`tool_result` handlers always see settled agent state
 
 ### Changed
+
 - Inline static templates into prompt builders, eliminating ~44 READ tool calls per milestone
 
 ### Fixed
+
 - Auto-mode dispatch loop when `cachedReaddir` returns stale data after unit writes files
 - Parse and path caches cleared alongside state cache after unit completion
 - `bg_shell` hangs indefinitely when `ready_port` server fails to start — now transitions to error state with stderr context
@@ -2404,11 +2599,13 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [2.11.1] - 2026-03-15
 
 ### Fixed
+
 - **URGENT: auto-mode loops on research-slice and plan-slice** — `handleAgentEnd` called `invalidateStateCache()` but not `clearPathCache()` or `clearParseCache()`. The in-process directory listing cache in `paths.ts` retained the pre-subagent empty directory snapshot, so `resolveSliceFile()` returned `null` for artifacts the subagent had just written. This caused `dispatchNextUnit` to re-dispatch the same unit (`research-slice` or `plan-slice`) instead of advancing, incrementing the dispatch counter until the `MAX_UNIT_DISPATCHES=3` limit triggered a hard stop with "Loop detected" (#421)
 
 ## [2.11.0] - 2026-03-14
 
 ### Added
+
 - Cross-provider fallback when rate or quota limits are hit (#125)
 - Custom OpenAI-compatible endpoint option in onboarding wizard (#335)
 - Model provider selection in preferences (#350)
@@ -2416,6 +2613,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Native libgit2-backed git read operations for dispatch hotpath (#388)
 
 ### Changed
+
 - Replace hardcoded extension list with dynamic discovery in loader
 - Deduplicate transitive dependency summaries in prompt builders
 - Reduce dispatch gap timeout from 30s to 5s
@@ -2425,6 +2623,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Optimize discovery and interactive hot paths
 
 ### Fixed
+
 - Resolve OpenRouter model IDs in auto-mode and show active model per phase
 - Suppress git-svn noise causing confusing errors on affected systems (#404)
 - Include export-html templates in pkg/ shim (#370, #395)
@@ -2441,14 +2640,17 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [2.10.12] - 2026-03-14
 
 ### Added
+
 - Multi-milestone readiness flow with per-milestone discussion gate (#377)
 
 ### Fixed
+
 - Fix `npx gsd-pi@latest` failing with `ERR_MODULE_NOT_FOUND: Cannot find package '@gsd/pi-coding-agent'`. The loader now creates workspace package symlinks at runtime before importing, so it works even when `npx` skips postinstall scripts (#380)
 
 ## [2.10.11] - 2026-03-14
 
 ### Fixed
+
 - Hoist workspace package dependencies (undici, anthropic SDK, openai, chalk, etc.) into root `dependencies` so they install for end users. v2.10.10 removed `bundleDependencies` but didn't promote the transitive deps (#376)
 - Add `undici` as root dependency to resolve startup crash (#372)
 - Check `GROQ_API_KEY` before entering voice mode to prevent crash (#367)
@@ -2456,11 +2658,13 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [2.10.10] - 2026-03-14
 
 ### Added
+
 - Alibaba Cloud coding-plan provider support (#295)
 - Linux voice mode: Groq Whisper API backend for fast, accurate speech-to-text (#366)
 - Opus 4.6 1M as default model, model selector UX improvements, Discord onboarding (#290)
 
 ### Fixed
+
 - Fix broken `npm install` / `npx gsd-pi@latest` caused by unpublished `@gsd/*` workspace packages leaking into npm dependencies. Workspace cross-references removed from published package metadata; packages resolve via bundled `node_modules/` at runtime (#369)
 - Add pre-publish tarball install validation (`validate-pack`) to CI and publish pipeline, preventing broken packages from reaching npm
 - Handle empty index after runtime file stripping in squash-merge (#364)
@@ -2470,13 +2674,16 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [2.10.9] - 2026-03-14
 
 ### Added
+
 - Team collaboration: multiple users can work on the same repo without milestone name clashes by checking in `.gsd/` planning artifacts (#338)
 
 ### Changed
+
 - Execute-task loop detection uses adaptive reconciliation instead of hard-stopping, reducing false positives (#342)
 - Memory storage switched from better-sqlite3 to sql.js (WASM) for Node 25+ compatibility (#356)
 
 ### Fixed
+
 - Node 22.22+ compatibility: `.ts` import extensions normalized to `.js` for module resolution (#354)
 - Infinite loop when complete-slice merges to main are interrupted (#345)
 - Credential backoff no longer triggers on transport errors; quota exhaustion handled gracefully (#353)
@@ -2491,32 +2698,38 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [2.10.8] - 2026-03-14
 
 ### Fixed
+
 - Publish verification checks `dist/loader.js` is non-empty (`-s`) and uses `--ignore-scripts` on `npm pack --dry-run` to match actual publish behaviour (#298)
 
 ## [2.10.7] - 2026-03-14
 
 ### Added
+
 - GitHub Workflows skill with CI workflow template and `ci_monitor` tool (#294)
 - Auto-resolve merge conflicts via LLM-powered fix-merge session
 - Auto-update integration branch when user starts auto-mode from a different branch (#300)
 
 ### Changed
+
 - Secrets manifest is re-checked before every dispatch, not just at auto mode start
 - Replaced TS parameter properties with explicit fields for Node strip-types compatibility
 - Hardened CI publish pipeline to prevent broken releases (#304)
 
 ### Fixed
+
 - Unresolvable artifact paths now correctly treated as stale completion state, preventing OOM crashes (#313)
 - Eliminated branch checkout during slice merge that caused STATE.md conflicts (#307)
 - Removed infinite delivery retry loop for background job completions (#301)
 - Display ⌥ instead of Alt for keybindings on macOS (#299)
 
 ### Removed
+
 - Deprecated legacy dead code from OAuth module
 
 ## [2.10.6] - 2026-03-13
 
 ### Added
+
 - Native Rust output truncation module for efficient large-output handling (#268)
 - Native Rust xxHash32 hasher for hashline IDs — faster line hashing (#272)
 - Native Rust bash stream processor for single-pass chunk processing (#271)
@@ -2524,6 +2737,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `claude-opus-4-6` model with 1M context window (#288)
 
 ### Fixed
+
 - Oversized TUI lines now truncated instead of crashing (#287)
 - Anthropic rate limit backoff now respects server-requested retry delay
 - CI publish guard: skip main package publish if already on npm
@@ -2532,6 +2746,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [2.10.5] - 2026-03-13
 
 ### Added
+
 - Async background jobs extension for non-blocking task execution (#260)
 - Multi-credential round-robin with rate-limit fallback across API keys
 - Bash interceptor to block commands that duplicate dedicated tools (Read, Write, Edit, Grep, Glob)
@@ -2541,9 +2756,11 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Web search provider selection added to onboarding wizard (#278)
 
 ### Changed
+
 - Simplified onboarding into two-step auth flow — plain language instead of OAuth jargon (#274)
 
 ### Fixed
+
 - `optionalDependencies` in published `gsd-pi@2.10.4` were still pinned to `2.10.2`, causing users to install the broken engine binaries that 2.10.4 was meant to fix (#276)
 - Auto-resolve `.gsd/` planning artifact conflicts during slice merge (#264)
 - Use version ranges for native engine optional dependencies (#286)
@@ -2555,10 +2772,12 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [2.10.4] - 2026-03-13
 
 ### Fixed
+
 - Native binary distribution — `.node` binaries were missing from the npm tarball, causing startup crashes on all platforms since v2.10.0
 - Native loader resolution chain: tries `@gsd-build/engine-{platform}` npm package first, then local dev build, with clear error messages listing supported platforms
 
 ### Added
+
 - Per-platform optional dependency packages (`@gsd-build/engine-*`) for macOS (ARM64/x64), Linux (x64/ARM64), and Windows (x64)
 - Cross-platform native binary CI build and publish workflow
 - Version synchronization script for lock-step platform package releases
@@ -2566,6 +2785,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [2.10.2] - 2026-03-13
 
 ### Added
+
 - Native Rust TTSR regex engine — pre-compiles all stream rule conditions into a single `RegexSet` for one-pass DFA matching instead of O(rules × conditions) JS regex iteration
 - Native Rust diff engine — fuzzy text matching (`fuzzyFindText`, `normalizeForFuzzyMatch`) and unified diff generation (`generateDiff`) via the `similar` crate, replacing the `diff` npm package
 - Native Rust GSD file parser — frontmatter parsing, section extraction, batch `.gsd/` directory parsing, and structured roadmap parsing with transparent JS fallback
@@ -2573,11 +2793,13 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [2.10.1] - 2026-03-13
 
 ### Fixed
+
 - `@gsd/native` package ships pre-compiled JavaScript instead of raw TypeScript, fixing startup crashes on Node.js 20, 22, and 24 (#248)
 
 ## [2.10.0] - 2026-03-13
 
 ### Added
+
 - Native Rust engine with high-performance N-API modules replacing JS/WASM dependencies:
   - **grep** — ripgrep-backed content and filesystem search
   - **glob** — gitignore-aware file discovery with scan caching
@@ -2596,6 +2818,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Universal config discovery extension
 
 ### Changed
+
 - Find tool uses native Rust glob instead of `fd` CLI binary
 - Syntax highlighting uses native syntect instead of `cli-highlight` npm package
 - Autocomplete uses native fd module instead of `fd` CLI subprocess
@@ -2604,6 +2827,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Image processing uses native Rust `image` crate instead of Photon WASM
 
 ### Fixed
+
 - Prevent move operation from silently overwriting existing files
 - Separate access/unlink error handling in delete path
 - Untrack runtime files from slice branch before squash-merge
@@ -2613,12 +2837,14 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [2.9.0] - 2026-03-13
 
 ### Added
+
 - LSP tool — full Language Server Protocol integration with diagnostics, go-to-definition, references, hover, document/workspace symbols, rename, code actions, type definition, and implementation support
 - `/thinking` slash command for toggling thinking level during sessions
 - Interactive wizard mode for `/gsd prefs` with guided configuration
 - Startup update check with 24-hour cache — notifies when a new version is available
 
 ### Fixed
+
 - TypeScript type errors across gsd, browser-tools, search-the-web, and misc extension files
 - Milestone ID generation uses max-based approach instead of length+1 (prevents ID collisions)
 - Non-thinking models handled correctly in `/thinking` command
@@ -2633,6 +2859,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [2.8.3] - 2026-03-13
 
 ### Fixed
+
 - `ask_user_questions` handles undefined `custom()` result in RPC mode
 - Provider-aware model resolution for per-phase preferences (respects `provider` field instead of parsing model name prefixes)
 - Execute-task artifact verification aligned with `deriveState` — adds self-repair for missing artifacts
@@ -2644,6 +2871,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [2.8.2] - 2026-03-13
 
 ### Fixed
+
 - Path operations use `node:path` stdlib instead of hardcoded forward slashes, fixing cross-platform compatibility
 - Prompts use relative paths to prevent Windows drive letter mangling
 - Runtime files already in the git index are untracked to prevent merge conflicts
@@ -2651,17 +2879,20 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Windows NUL redirects sanitized to /dev/null in Git Bash environments
 
 ### Changed
+
 - `.claude/` and `.gsd/` directories untracked from repo, `*.tgz` gitignored
 
 ## [2.8.1] - 2026-03-13
 
 ### Added
+
 - Discussion depth verification and context write-gate for richer milestone discussions
 - TTSR + blob/artifact storage (ported from oh-my-pi)
 - Skip/discard escape hatches in no-roadmap wizard
 - Configurable `merge_strategy` preference for slice completion
 
 ### Fixed
+
 - `fsevents` bumped to ~2.3.3 for Node 25 compatibility; added as optional dep for Linux installs
 - Observability warnings injected into agent prompt for enforcement
 - Auto-detect headless environment for Playwright browser launch
@@ -2673,12 +2904,14 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [2.8.0] - 2026-03-13
 
 ### Added
+
 - Browser tools: `browser_analyze_form` and `browser_fill_form` — form field inventory and intelligent filling by label/name/placeholder
 - Browser tools: `browser_find_best` — scored element candidates for semantic intents
 - Browser tools: `browser_act` — execute common browser micro-tasks in one call
 - Browser tools: 108 unit and integration tests covering all new components
 
 ### Changed
+
 - Browser tools: decomposed 5000-line monolithic `index.ts` into focused modules (state, capture, settle, lifecycle, refs, utils) with 11 categorized tool files
 - Browser tools: consolidated state capture reduces evaluate round-trips per action
 - Browser tools: zero-mutation settle short-circuit for faster page interaction
@@ -2689,10 +2922,12 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [2.7.1] - 2026-03-13
 
 ### Added
+
 - Model fallback support for auto-mode phases — if the configured model fails, GSD tries alternate models before stopping
 - `/kill` command for immediate process termination
 
 ### Fixed
+
 - `npm install -g gsd-pi` now works — workspace packages bundled in npm tarball via `bundleDependencies`
 - External PI ecosystem packages (pi-rtk, pi-context, etc.) can now resolve `@mariozechner/*` imports through jiti aliases
 - Missing `export-html` vendor files (marked.min.js, highlight.min.js) restored
@@ -2700,11 +2935,13 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Provider config and extension loading reused correctly
 
 ### Changed
+
 - `/exit` uses graceful shutdown (saves session state); `/kill` replaces the old immediate-exit behavior
 
 ## [2.7.0] - 2026-03-12
 
 ### Changed
+
 - Vendor Pi SDK source (tui, ai, agent-core, coding-agent) into workspace monorepo under `packages/`, replacing the compiled npm dependency and patch-package workflow. Pi internals are now directly modifiable as TypeScript source.
 - Existing patches (setModel persist option, Windows VT input caching) applied as source edits.
 - Build pipeline runs workspace packages in dependency order before GSD compilation.
@@ -2713,10 +2950,12 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [2.6.0] - 2026-03-12
 
 ### Added
+
 - Proactive secret management — planning phase forecasts required API keys into a manifest; auto-mode collects pending secrets before dispatching the first slice
 - `--continue` / `-c` CLI flag to resume the most recent session
 
 ### Fixed
+
 - Doctor post-hook no longer preempts `complete-slice` dispatch
 - `main_branch` preference restored; `runPreMergeCheck` implemented for merge safety
 - Recovery/retry prompt injection capped to prevent V8 OOM on large sessions
@@ -2725,19 +2964,23 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [2.5.1] - 2026-03-12
 
 ### Added
+
 - `secure_env_collect` now auto-detects existing keys, destination files, and provides guidance field for better onboarding UX
 
 ### Changed
+
 - Right-sized pipeline for simple work — single-slice milestones skip redundant research/plan sessions, reducing 9-10 sessions to 5-6
 - Heavyweight plan sections (Proof Level, Integration Closure, Observability) are now conditional, omitted for simple slices
 
 ### Fixed
+
 - Squash-merge now aborts cleanly on conflict and stops auto-mode instead of looping with corrupted state
 - Resolved baked-in merge conflict markers in loader.ts, logo.ts, and postinstall.js
 
 ## [2.5.0] - 2026-03-12
 
 ### Added
+
 - Native Anthropic web search — Claude models get server-side web search automatically, no Brave API key required
 - GitService fully wired into codebase — programmatic git operations replace shell-based git commands in prompts
 - Merge guards prevent slice completion when uncommitted changes or conflicts exist
@@ -2746,6 +2989,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Rich commit messages with structured metadata
 
 ### Fixed
+
 - State machine deadlock when units fail to produce expected artifacts — retry and cross-validation now gate completion
 - Duplicate Brave search tools when toggling providers repeatedly
 - Windows test glob patterns (single quotes → unquoted for shell expansion)
@@ -2756,47 +3000,57 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [2.4.0] - 2026-03-12
 
 ### Added
+
 - Automatic migration of provider credentials from existing Pi installations — skip re-authentication when switching to GSD
 - Pi extensions from `~/.pi/agent/extensions/` discoverable in interactive mode
 - GitService core implementation for programmatic git operations
 
 ### Changed
+
 - System prompt compressed by 48% (360 → 187 lines) for better context efficiency
 - Refined agent character and communication style prompts
 - Added craft standards, self-debugging awareness, and work narration to agent prompts
 
 ### Fixed
+
 - RPC mode crash when `ctx.ui.theme` is undefined (#121)
 
 ## [2.3.11] - 2026-03-12
 
 ### Added
+
 - Branded clack-based onboarding wizard on first launch — LLM provider selection (OAuth + API key), optional tool API keys, and setup summary (#118)
 - `gsd config` subcommand to re-run the setup wizard anytime
 - Shared `src/logo.ts` module as single source of truth for ASCII banner
 
 ### Fixed
+
 - Parallel subagent results no longer truncated at 200 characters
 
 ### Changed
+
 - `wizard.ts` trimmed to env hydration only — onboarding logic moved to `onboarding.ts`
 - First-launch banner removed from `loader.ts` (onboarding wizard handles branding)
 
 ## [2.3.10] - 2026-03-12
 
 ### Added
+
 - Branded postinstall experience with animated spinners, progress indicators, and clean summary (#115)
 
 ### Fixed
+
 - Ctrl+Alt shortcuts (dashboard, bg manager, voice) now show slash-command fallback in terminals that lack Kitty keyboard protocol support — macOS Terminal.app, JetBrains IDEs (#100, #104)
 
 ## [2.3.9] - 2026-03-12
 
 ### Added
+
 - Tavily as alternative web search provider alongside Brave Search (#102)
 - Auto-mode progress widget now shows all stats; footer hidden during auto-mode (#75)
 
 ### Fixed
+
 - Auto-mode infinite loop and closeout instability — idempotent unit dispatch, retry caps, and atomic closeout (#96, #109)
 - Migration no longer requires ROADMAP.md — milestones inferred from phases/ directory when missing (#93, #90)
 - Worktree branch safety — proper namespacing and slice branch base selection (#92)
@@ -2812,15 +3066,18 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [2.3.8] - 2026-03-11
 
 ### Fixed
+
 - Worktree file operations (Write, Read, Edit) now resolve paths against the active working directory instead of the launch directory (#72)
 - Auto-mode merge guard handles all slice completion paths, preventing infinite dispatch loops when `complete-slice` is bypassed (#71)
 
 ## [2.3.7] - 2026-03-11
 
 ### Added
+
 - Remote user questions via Slack/Discord for headless auto-mode sessions
 
 ### Fixed
+
 - Auto-mode model switches no longer persist as the user's global default (#30)
 - Auto-mode resume now rebuilds disk state and runs doctor before dispatching, preventing inline execution after pause (#16)
 - Silent dispatch failure when command context is null now surfaces an error notification
@@ -2834,25 +3091,30 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - TypeScript parameter properties desugared for `--experimental-strip-types` compatibility
 
 ### Changed
+
 - Remote question result details use discriminated union type
 
 ## [2.3.6] - 2026-03-11
 
 ### Fixed
+
 - Postinstall no longer triggers hidden `sudo` prompt on Linux — Playwright's `--with-deps` flag is no longer run automatically, preventing `npm install -g` from appearing to hang (#67)
 - Auto-commit dirty files before branch switch to prevent lost work during slice transitions
 
 ### Changed
+
 - Updated README to reflect current commands, extensions, and step mode workflow
 
 ## [2.3.5] - 2026-03-11
 
 ### Fixed
+
 - Voice extension: transcription no longer lost when pausing and resuming recording
 
 ## [2.3.4] - 2026-03-11
 
 ### Added
+
 - CHANGELOG.md with curated history from v0.1.6 onwards
 - Project-local `/publish-version` command for npm releases
 - GitHub Sponsors funding configuration
@@ -2861,6 +3123,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [0.3.3] - 2026-03-11
 
 ### Added
+
 - `/gsd next` step mode — walk through units one at a time with a wizard between each
 - `/gsd` bare command defaults to step mode
 - `/exit` command to kill the GSD process immediately
@@ -2871,20 +3134,24 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Post-hook bookkeeping: auto-run doctor + rebuild STATE.md after each unit
 
 ### Changed
+
 - Improved worktree merge, create, remove, and reload resilience
 - Discuss prompt rewritten with reflection step and depth enforcement
 
 ### Fixed
+
 - Idle watchdog false-firing on active agents — tasks >10min no longer get incorrectly skipped (#52)
 - Browser screenshots constrained to 1568px max dimension (#56)
 - Pi extensions loaded from `~/.pi/agent/extensions/` (#51)
 
 ### Removed
+
 - `/gsd-run` command (replaced by `/gsd` and `/gsd next`)
 
 ## [0.3.1] - 2026-03-11
 
 ### Fixed
+
 - Windows VT input restored after child processes exit (#41)
 - Print/JSON mode in cli.js so subagents don't hang
 - Discuss prompt loop prevention
@@ -2895,15 +3162,18 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Windows backspace in masked input + custom browser path support (#36, #34)
 
 ### Changed
+
 - Renamed "Get Stuff Done" to "Get Shit Done"
 
 ## [0.3.0] - 2026-03-11
 
 ### Added
+
 - `/worktree` (`/wt`) — git worktree lifecycle management (#31)
 - `/gsd migrate` — `.planning` to `.gsd` migration tool (#28)
 
 ### Fixed
+
 - Skipped API keys now persist so wizard doesn't repeat on every launch (#27)
 - Scoped models restored from settings on new session startup (#22)
 - Startup fallback no longer overwrites user's default model with Sonnet (#29)
@@ -2911,6 +3181,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [0.2.9] - 2026-03-11
 
 ### Fixed
+
 - Idle recovery skips stuck units instead of silently stalling (#19)
 - `pkg/package.json` version synced with pi-coding-agent to prevent false update banner
 - Milestones with summary but no roadmap treated as complete (#13)
@@ -2918,26 +3189,31 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [0.2.8] - 2026-03-11
 
 ### Added
+
 - Mac-tools extension (macOS native automation)
 
 ## [0.2.6] - 2026-03-11
 
 ### Fixed
+
 - Default model validated against full registry on every startup
 
 ## [0.2.5] - 2026-03-11
 
 ### Fixed
+
 - Circular self-dependency removed, default model set to anthropic/claude-sonnet-4-6 with thinking off
 
 ## [0.2.4] - 2026-03-11
 
 ### Added
+
 - Branded setup wizard UI with visual hierarchy, descriptions, and status feedback
 - Branded banner on first launch
 - Postinstall banner with version and next-step hint
 
 ### Fixed
+
 - All `.pi/` paths updated to `.gsd/`
 - Default model matching by `id.includes('sonnet')` for dated API IDs
 - Circular gsd-pi self-dependency removed
@@ -2947,16 +3223,19 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [0.1.6] - 2026-03-11
 
 ### Added
+
 - GitHub extension tool suite with confirmation gate
 - Bundled skills: frontend-design, swiftui, debug-like-expert
 - Skills trigger table in system prompt
 - Resource loader syncs bundled skills to `~/.gsd/agent/skills/`
 
 ### Fixed
+
 - `~/.gsd/agent/` paths in prompt templates instead of `~/.pi/agent/` (#10)
 - Guard against re-injecting discuss prompt when session already in flight
 
 ### Changed
+
 - License updated to MIT
 
 [Unreleased]: https://github.com/gsd-build/gsd-2/compare/v2.75.0...HEAD

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,15 +17,15 @@ Always work on a dedicated branch. Never push directly to `main`.
 
 **Branch naming:** `<type>/<short-description>`
 
-| Type | When to use |
-|------|-------------|
-| `feat/` | New functionality |
-| `fix/` | Bug or defect correction |
+| Type        | When to use                            |
+| ----------- | -------------------------------------- |
+| `feat/`     | New functionality                      |
+| `fix/`      | Bug or defect correction               |
 | `refactor/` | Code restructuring, no behavior change |
-| `test/` | Adding or updating tests |
-| `docs/` | Documentation only |
-| `chore/` | Dependencies, tooling, housekeeping |
-| `ci/` | CI/CD configuration |
+| `test/`     | Adding or updating tests               |
+| `docs/`     | Documentation only                     |
+| `chore/`    | Dependencies, tooling, housekeeping    |
+| `ci/`       | CI/CD configuration                    |
 
 **Commit messages** must follow [Conventional Commits](https://www.conventionalcommits.org/). The commit-msg hook enforces this locally; CI enforces it on push.
 
@@ -140,20 +140,20 @@ See [VISION.md](VISION.md) for the full list of what we won't accept.
 
 The codebase is organized into these areas. All are open to contributions:
 
-| Area | Path | Notes |
-|------|------|-------|
-| Terminal UI | `packages/pi-tui` | Components, themes, rendering |
-| AI/LLM layer | `packages/pi-ai` | Provider integrations, model handling |
-| Agent core | `packages/pi-agent-core` | Agent orchestration — RFC required for changes |
-| Coding agent | `packages/pi-coding-agent` | The main coding agent |
-| MCP server | `packages/mcp-server` | Project state tools and MCP protocol |
-| GSD extension | `src/resources/extensions/gsd/` | GSD workflow — RFC required for auto-mode |
-| Other extensions | `src/resources/extensions/` | Browser, search, voice, MCP client, etc. |
-| Native engine | `native/` | Rust N-API modules (grep, git, AST, etc.) |
-| VS Code extension | `vscode-extension/` | Chat participant, sidebar, RPC integration |
-| Web interface | `web/` | Browser-based dashboard |
-| CI/Build | `.github/`, `scripts/` | Workflows, build scripts |
-| Documentation | `docs/` | User guides, ADRs, SDK docs |
+| Area              | Path                            | Notes                                          |
+| ----------------- | ------------------------------- | ---------------------------------------------- |
+| Terminal UI       | `packages/pi-tui`               | Components, themes, rendering                  |
+| AI/LLM layer      | `packages/pi-ai`                | Provider integrations, model handling          |
+| Agent core        | `packages/pi-agent-core`        | Agent orchestration — RFC required for changes |
+| Coding agent      | `packages/pi-coding-agent`      | The main coding agent                          |
+| MCP server        | `packages/mcp-server`           | Project state tools and MCP protocol           |
+| GSD extension     | `src/resources/extensions/gsd/` | GSD workflow — RFC required for auto-mode      |
+| Other extensions  | `src/resources/extensions/`     | Browser, search, voice, MCP client, etc.       |
+| Native engine     | `native/`                       | Rust N-API modules (grep, git, AST, etc.)      |
+| VS Code extension | `vscode-extension/`             | Chat participant, sidebar, RPC integration     |
+| Web interface     | `web/`                          | Browser-based dashboard                        |
+| CI/Build          | `.github/`, `scripts/`          | Workflows, build scripts                       |
+| Documentation     | `docs/`                         | User guides, ADRs, SDK docs                    |
 
 ## Review process
 
@@ -208,16 +208,24 @@ Do not use `createTestContext()` from `test-helpers.ts` (legacy, being removed).
 // ✅ CORRECT — shared fixture with beforeEach/afterEach
 describe("feature", () => {
   let tmp: string;
-  beforeEach(() => { tmp = mkdtempSync(join(tmpdir(), "test-")); });
-  afterEach(() => { rmSync(tmp, { recursive: true, force: true }); });
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "test-"));
+  });
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
 
-  test("case", () => { /* clean test body */ });
+  test("case", () => {
+    /* clean test body */
+  });
 });
 
 // ✅ CORRECT — per-test cleanup with t.after()
 test("case", (t) => {
   const tmp = mkdtempSync(join(tmpdir(), "test-"));
-  t.after(() => { rmSync(tmp, { recursive: true, force: true }); });
+  t.after(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
   // test body
 });
 
@@ -233,6 +241,7 @@ test("case", () => {
 ```
 
 **When to use which:**
+
 - `beforeEach`/`afterEach` — when all tests in a `describe` block share the same setup/teardown pattern
 - `t.after()` — when each test has unique cleanup (different fixtures, env vars, etc.)
 - `try`/`finally` — only inside standalone helper functions that don't have access to the test context `t` (e.g., `withEnv()`, `capture()`)
@@ -281,6 +290,7 @@ npx tsc --noEmit
 ```
 
 Run `npm run secret-scan:install-hook` once after cloning. It installs two hooks:
+
 - **pre-commit** — blocks commits containing hardcoded secrets or credentials
 - **commit-msg** — validates Conventional Commits format before the commit lands
 

--- a/README.md
+++ b/README.md
@@ -210,8 +210,8 @@ GSD v2 solves all of these because it's not a prompt framework anymore — it's 
 | Roadmap reassessment | Manual                       | Automatic after each slice completes                    |
 | Skill discovery      | None                         | Auto-detect and install relevant skills during research |
 | Verification         | Manual                       | Automated verification commands with auto-fix retries   |
-| Reporting            | None                         | Self-contained HTML reports with metrics and dep graphs  |
-| Parallel execution   | None                         | Multi-worker parallel milestone orchestration            |
+| Reporting            | None                         | Self-contained HTML reports with metrics and dep graphs |
+| Parallel execution   | None                         | Multi-worker parallel milestone orchestration           |
 
 ### Migrating from v1
 
@@ -407,47 +407,47 @@ On first run, GSD launches a branded setup wizard that walks you through LLM pro
 
 ### Commands
 
-| Command                 | What it does                                                    |
-| ----------------------- | --------------------------------------------------------------- |
-| `/gsd`                  | Step mode — executes one unit at a time, pauses between each    |
-| `/gsd next`             | Explicit step mode (same as bare `/gsd`)                        |
-| `/gsd auto`             | Autonomous mode — researches, plans, executes, commits, repeats |
-| `/gsd quick`            | Execute a quick task with GSD guarantees, skip planning overhead |
-| `/gsd stop`             | Stop auto mode gracefully                                       |
-| `/gsd steer`            | Hard-steer plan documents during execution                      |
-| `/gsd discuss`          | Discuss architecture and decisions (works alongside auto mode)  |
-| `/gsd rethink`          | Conversational project reorganization                           |
-| `/gsd mcp`              | MCP server status and connectivity                              |
-| `/gsd status`           | Progress dashboard                                              |
-| `/gsd queue`            | Queue future milestones (safe during auto mode)                 |
-| `/gsd prefs`            | Model selection, timeouts, budget ceiling                       |
-| `/gsd migrate`          | Migrate a v1 `.planning` directory to `.gsd` format             |
-| `/gsd help`             | Categorized command reference for all GSD subcommands           |
-| `/gsd mode`             | Switch workflow mode (solo/team) with coordinated defaults      |
-| `/gsd workflow`         | Unified workflow plugins — list, run `<name>`, install, info, validate |
-| `/gsd start <template>` | Launch a bundled or custom workflow template (bugfix, release, etc.) |
-| `/gsd forensics`        | Full-access GSD debugger for auto-mode failure investigation    |
-| `/gsd cleanup`          | Archive phase directories from completed milestones             |
+| Command                 | What it does                                                                  |
+| ----------------------- | ----------------------------------------------------------------------------- |
+| `/gsd`                  | Step mode — executes one unit at a time, pauses between each                  |
+| `/gsd next`             | Explicit step mode (same as bare `/gsd`)                                      |
+| `/gsd auto`             | Autonomous mode — researches, plans, executes, commits, repeats               |
+| `/gsd quick`            | Execute a quick task with GSD guarantees, skip planning overhead              |
+| `/gsd stop`             | Stop auto mode gracefully                                                     |
+| `/gsd steer`            | Hard-steer plan documents during execution                                    |
+| `/gsd discuss`          | Discuss architecture and decisions (works alongside auto mode)                |
+| `/gsd rethink`          | Conversational project reorganization                                         |
+| `/gsd mcp`              | MCP server status and connectivity                                            |
+| `/gsd status`           | Progress dashboard                                                            |
+| `/gsd queue`            | Queue future milestones (safe during auto mode)                               |
+| `/gsd prefs`            | Model selection, timeouts, budget ceiling                                     |
+| `/gsd migrate`          | Migrate a v1 `.planning` directory to `.gsd` format                           |
+| `/gsd help`             | Categorized command reference for all GSD subcommands                         |
+| `/gsd mode`             | Switch workflow mode (solo/team) with coordinated defaults                    |
+| `/gsd workflow`         | Unified workflow plugins — list, run `<name>`, install, info, validate        |
+| `/gsd start <template>` | Launch a bundled or custom workflow template (bugfix, release, etc.)          |
+| `/gsd forensics`        | Full-access GSD debugger for auto-mode failure investigation                  |
+| `/gsd cleanup`          | Archive phase directories from completed milestones                           |
 | `/gsd doctor`           | Runtime health checks — issues surface across widget, visualizer, and reports |
-| `/gsd keys`             | API key manager — list, add, remove, test, rotate, doctor       |
-| `/gsd logs`             | Browse activity, debug, and metrics logs                        |
-| `/gsd export --html`    | Generate HTML report for current or completed milestone         |
-| `/worktree` (`/wt`)     | Git worktree lifecycle — create, switch, merge, remove          |
-| `/voice`                | Toggle real-time speech-to-text (macOS, Linux)                  |
-| `/exit`                 | Graceful shutdown — saves session state before exiting          |
-| `/kill`                 | Kill GSD process immediately                                    |
-| `/clear`                | Start a new session (alias for `/new`)                          |
-| `Ctrl+Alt+G`            | Toggle dashboard overlay                                        |
-| `Ctrl+Alt+V`            | Toggle voice transcription                                      |
-| `Ctrl+Alt+B`            | Show background shell processes                                 |
-| `Alt+V`                 | Paste clipboard image (macOS)                                   |
-| `gsd config`            | Re-run the setup wizard (LLM provider + tool keys)              |
-| `gsd update`            | Update GSD to the latest version                                |
-| `gsd headless [cmd]`    | Run `/gsd` commands without TUI (CI, cron, scripts)             |
-| `gsd headless query`    | Instant JSON snapshot — state, next dispatch, costs (no LLM)    |
-| `gsd --continue` (`-c`) | Resume the most recent session for the current directory        |
-| `gsd --worktree` (`-w`) | Launch an isolated worktree session for the active milestone    |
-| `gsd sessions`          | Interactive session picker — browse and resume any saved session |
+| `/gsd keys`             | API key manager — list, add, remove, test, rotate, doctor                     |
+| `/gsd logs`             | Browse activity, debug, and metrics logs                                      |
+| `/gsd export --html`    | Generate HTML report for current or completed milestone                       |
+| `/worktree` (`/wt`)     | Git worktree lifecycle — create, switch, merge, remove                        |
+| `/voice`                | Toggle real-time speech-to-text (macOS, Linux)                                |
+| `/exit`                 | Graceful shutdown — saves session state before exiting                        |
+| `/kill`                 | Kill GSD process immediately                                                  |
+| `/clear`                | Start a new session (alias for `/new`)                                        |
+| `Ctrl+Alt+G`            | Toggle dashboard overlay                                                      |
+| `Ctrl+Alt+V`            | Toggle voice transcription                                                    |
+| `Ctrl+Alt+B`            | Show background shell processes                                               |
+| `Alt+V`                 | Paste clipboard image (macOS)                                                 |
+| `gsd config`            | Re-run the setup wizard (LLM provider + tool keys)                            |
+| `gsd update`            | Update GSD to the latest version                                              |
+| `gsd headless [cmd]`    | Run `/gsd` commands without TUI (CI, cron, scripts)                           |
+| `gsd headless query`    | Instant JSON snapshot — state, next dispatch, costs (no LLM)                  |
+| `gsd --continue` (`-c`) | Resume the most recent session for the current directory                      |
+| `gsd --worktree` (`-w`) | Launch an isolated worktree session for the active milestone                  |
+| `gsd sessions`          | Interactive session picker — browse and resume any saved session              |
 
 ---
 
@@ -556,24 +556,24 @@ auto_report: true
 
 **Key settings:**
 
-| Setting                | What it controls                                                                                      |
-| ---------------------- | ----------------------------------------------------------------------------------------------------- |
-| `models.*`             | Per-phase model selection — string for a single model, or `{model, fallbacks}` for automatic failover |
-| `skill_discovery`      | `auto` / `suggest` / `off` — how GSD finds and applies skills                                         |
-| `auto_supervisor.*`    | Timeout thresholds for auto mode supervision                                                          |
-| `budget_ceiling`       | USD ceiling — auto mode pauses when reached                                                           |
-| `uat_dispatch`         | Enable automatic UAT runs after slice completion                                                      |
-| `always_use_skills`    | Skills to always load when relevant                                                                   |
-| `skill_rules`          | Situational rules for skill routing                                                                   |
-| `skill_staleness_days` | Skills unused for N days get deprioritized (default: 60, 0 = disabled)                                |
-| `unique_milestone_ids` | Uses unique milestone names to avoid clashes when working in teams of people                          |
-| `git.isolation`        | `none` (default), `worktree`, or `branch` — enable worktree or branch isolation for milestone work               |
-| `git.manage_gitignore` | Set `false` to prevent GSD from modifying `.gitignore`                                                           |
-| `verification_commands`| Array of shell commands to run after task execution (e.g., `["npm run lint", "npm run test"]`)        |
-| `verification_auto_fix`| Auto-retry on verification failures (default: true)                                                   |
-| `verification_max_retries` | Max retries for verification failures (default: 2)                                               |
-| `phases.require_slice_discussion` | Pause auto-mode before each slice for human discussion review                                    |
-| `auto_report`          | Auto-generate HTML reports after milestone completion (default: true)                                 |
+| Setting                           | What it controls                                                                                      |
+| --------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| `models.*`                        | Per-phase model selection — string for a single model, or `{model, fallbacks}` for automatic failover |
+| `skill_discovery`                 | `auto` / `suggest` / `off` — how GSD finds and applies skills                                         |
+| `auto_supervisor.*`               | Timeout thresholds for auto mode supervision                                                          |
+| `budget_ceiling`                  | USD ceiling — auto mode pauses when reached                                                           |
+| `uat_dispatch`                    | Enable automatic UAT runs after slice completion                                                      |
+| `always_use_skills`               | Skills to always load when relevant                                                                   |
+| `skill_rules`                     | Situational rules for skill routing                                                                   |
+| `skill_staleness_days`            | Skills unused for N days get deprioritized (default: 60, 0 = disabled)                                |
+| `unique_milestone_ids`            | Uses unique milestone names to avoid clashes when working in teams of people                          |
+| `git.isolation`                   | `none` (default), `worktree`, or `branch` — enable worktree or branch isolation for milestone work    |
+| `git.manage_gitignore`            | Set `false` to prevent GSD from modifying `.gitignore`                                                |
+| `verification_commands`           | Array of shell commands to run after task execution (e.g., `["npm run lint", "npm run test"]`)        |
+| `verification_auto_fix`           | Auto-retry on verification failures (default: true)                                                   |
+| `verification_max_retries`        | Max retries for verification failures (default: 2)                                                    |
+| `phases.require_slice_discussion` | Pause auto-mode before each slice for human discussion review                                         |
+| `auto_report`                     | Auto-generate HTML reports after milestone completion (default: true)                                 |
 
 ### Agent Instructions
 
@@ -590,14 +590,14 @@ Start GSD with `gsd --debug` to enable structured JSONL diagnostic logging. Debu
 GSD includes a coordinated token optimization system that reduces usage by 40-60% on cost-sensitive workloads. Set a single preference to coordinate model selection, phase skipping, and context compression:
 
 ```yaml
-token_profile: budget      # or balanced (default), quality
+token_profile: budget # or balanced (default), quality
 ```
 
-| Profile | Savings | What It Does |
-|---------|---------|-------------|
-| `budget` | 40-60% | Cheap models, skip research/reassess, minimal context inlining |
-| `balanced` | 10-20% | Default models, skip slice research, standard context |
-| `quality` | 0% | All phases, all context, full model power |
+| Profile    | Savings | What It Does                                                   |
+| ---------- | ------- | -------------------------------------------------------------- |
+| `budget`   | 40-60%  | Cheap models, skip research/reassess, minimal context inlining |
+| `balanced` | 10-20%  | Default models, skip slice research, standard context          |
+| `quality`  | 0%      | All phases, all context, full model power                      |
 
 **Complexity-based routing** automatically classifies tasks as simple/standard/complex and routes to appropriate models. Simple docs tasks get Haiku; complex architectural work gets Opus. The classification is heuristic (sub-millisecond, no LLM calls) and learns from outcomes via a persistent routing history.
 
@@ -609,44 +609,44 @@ See the full [Token Optimization Guide](./docs/user-docs/token-optimization.md) 
 
 GSD ships with 24 extensions, all loaded automatically:
 
-| Extension              | What it provides                                                                                                       |
-| ---------------------- | ---------------------------------------------------------------------------------------------------------------------- |
-| **GSD**                | Core workflow engine, auto mode, commands, dashboard                                                                   |
+| Extension              | What it provides                                                                                                                                                                                                                                                                     |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **GSD**                | Core workflow engine, auto mode, commands, dashboard                                                                                                                                                                                                                                 |
 | **Browser Tools**      | Playwright-based browser with form intelligence, intent-ranked element finding, semantic actions, PDF export, session state persistence, network mocking, device emulation, structured extraction, visual diffing, region zoom, test code generation, and prompt injection detection |
-| **Search the Web**     | Brave Search, Tavily, or Jina page extraction                                                                          |
-| **Google Search**      | Gemini-powered web search with AI-synthesized answers                                                                  |
-| **Context7**           | Up-to-date library/framework documentation                                                                             |
-| **Background Shell**   | Long-running process management with readiness detection                                                               |
-| **Async Jobs**         | Background bash commands with job tracking and cancellation                                                            |
-| **Subagent**           | Delegated tasks with isolated context windows                                                                          |
-| **GitHub**             | Full-suite GitHub issues and PR management via `/gh` command                                                           |
-| **Mac Tools**          | macOS native app automation via Accessibility APIs                                                                     |
-| **MCP Client**         | Native MCP server integration via @modelcontextprotocol/sdk                                                            |
-| **Voice**              | Real-time speech-to-text transcription (macOS, Linux — Ubuntu 22.04+)                                                  |
-| **Slash Commands**     | Custom command creation                                                                                                |
-| **Ask User Questions** | Structured user input with single/multi-select                                                                         |
-| **Secure Env Collect** | Masked secret collection without manual .env editing                                                                   |
-| **Remote Questions**   | Route decisions to Slack/Discord when human input is needed in headless/CI mode                                         |
-| **Universal Config**   | Discover and import MCP servers and rules from other AI coding tools                                                    |
-| **AWS Auth**           | Automatic Bedrock credential refresh for AWS-hosted models                                                              |
-| **Ollama**             | First-class local LLM support via Ollama                                                                                |
-| **Claude Code CLI**    | External provider extension for Claude Code CLI                                                                         |
-| **cmux**               | Claude multiplexer integration — desktop notifications, sidebar metadata, visual subagent splits                        |
-| **GitHub Sync**        | Auto-sync milestones to GitHub Issues, PRs, and Milestones                                                              |
-| **LSP**                | Language Server Protocol — diagnostics, definitions, references, hover, rename                                          |
-| **TTSR**               | Tool-triggered system rules — conditional context injection based on tool usage                                         |
+| **Search the Web**     | Brave Search, Tavily, or Jina page extraction                                                                                                                                                                                                                                        |
+| **Google Search**      | Gemini-powered web search with AI-synthesized answers                                                                                                                                                                                                                                |
+| **Context7**           | Up-to-date library/framework documentation                                                                                                                                                                                                                                           |
+| **Background Shell**   | Long-running process management with readiness detection                                                                                                                                                                                                                             |
+| **Async Jobs**         | Background bash commands with job tracking and cancellation                                                                                                                                                                                                                          |
+| **Subagent**           | Delegated tasks with isolated context windows                                                                                                                                                                                                                                        |
+| **GitHub**             | Full-suite GitHub issues and PR management via `/gh` command                                                                                                                                                                                                                         |
+| **Mac Tools**          | macOS native app automation via Accessibility APIs                                                                                                                                                                                                                                   |
+| **MCP Client**         | Native MCP server integration via @modelcontextprotocol/sdk                                                                                                                                                                                                                          |
+| **Voice**              | Real-time speech-to-text transcription (macOS, Linux — Ubuntu 22.04+)                                                                                                                                                                                                                |
+| **Slash Commands**     | Custom command creation                                                                                                                                                                                                                                                              |
+| **Ask User Questions** | Structured user input with single/multi-select                                                                                                                                                                                                                                       |
+| **Secure Env Collect** | Masked secret collection without manual .env editing                                                                                                                                                                                                                                 |
+| **Remote Questions**   | Route decisions to Slack/Discord when human input is needed in headless/CI mode                                                                                                                                                                                                      |
+| **Universal Config**   | Discover and import MCP servers and rules from other AI coding tools                                                                                                                                                                                                                 |
+| **AWS Auth**           | Automatic Bedrock credential refresh for AWS-hosted models                                                                                                                                                                                                                           |
+| **Ollama**             | First-class local LLM support via Ollama                                                                                                                                                                                                                                             |
+| **Claude Code CLI**    | External provider extension for Claude Code CLI                                                                                                                                                                                                                                      |
+| **cmux**               | Claude multiplexer integration — desktop notifications, sidebar metadata, visual subagent splits                                                                                                                                                                                     |
+| **GitHub Sync**        | Auto-sync milestones to GitHub Issues, PRs, and Milestones                                                                                                                                                                                                                           |
+| **LSP**                | Language Server Protocol — diagnostics, definitions, references, hover, rename                                                                                                                                                                                                       |
+| **TTSR**               | Tool-triggered system rules — conditional context injection based on tool usage                                                                                                                                                                                                      |
 
 ### Bundled Agents
 
 Five specialized subagents for delegated work:
 
-| Agent               | Role                                                         |
-| ------------------- | ------------------------------------------------------------ |
-| **Scout**           | Fast codebase recon — returns compressed context for handoff |
-| **Researcher**      | Web research — finds and synthesizes current information     |
-| **Worker**          | General-purpose execution in an isolated context window      |
-| **JavaScript Pro**  | JavaScript-specialized execution and debugging               |
-| **TypeScript Pro**  | TypeScript-specialized execution and debugging               |
+| Agent              | Role                                                         |
+| ------------------ | ------------------------------------------------------------ |
+| **Scout**          | Fast codebase recon — returns compressed context for handoff |
+| **Researcher**     | Web research — finds and synthesizes current information     |
+| **Worker**         | General-purpose execution in an isolated context window      |
+| **JavaScript Pro** | JavaScript-specialized execution and debugging               |
+| **TypeScript Pro** | TypeScript-specialized execution and debugging               |
 
 ---
 
@@ -806,8 +806,8 @@ Use expensive models where quality matters (planning, complex execution) and che
 
 ## Ecosystem
 
-| Project | Description |
-| ------- | ----------- |
+| Project                                                         | Description                                                                         |
+| --------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
 | [GSD2 Config Utility](https://github.com/jeremymcs/gsd2-config) | Standalone configuration tool for managing GSD preferences, providers, and API keys |
 
 ---

--- a/src/resources/extensions/gsd/auto-artifact-paths.ts
+++ b/src/resources/extensions/gsd/auto-artifact-paths.ts
@@ -50,6 +50,11 @@ export function resolveExpectedArtifactPath(
       const dir = resolveSlicePath(base, mid, sid!);
       return dir ? join(dir, buildSliceFileName(sid!, "PLAN")) : null;
     }
+    case "refine-slice": {
+      // ADR-011: refine-slice expands a sketch and writes the same PLAN.md as plan-slice.
+      const dir = resolveSlicePath(base, mid, sid!);
+      return dir ? join(dir, buildSliceFileName(sid!, "PLAN")) : null;
+    }
     case "reassess-roadmap": {
       const dir = resolveSlicePath(base, mid, sid!);
       return dir ? join(dir, buildSliceFileName(sid!, "ASSESSMENT")) : null;
@@ -112,6 +117,8 @@ export function diagnoseExpectedArtifact(
       return `${relSliceFile(base, mid, sid!, "RESEARCH")} (slice research)`;
     case "plan-slice":
       return `${relSliceFile(base, mid, sid!, "PLAN")} (slice plan)`;
+    case "refine-slice":
+      return `${relSliceFile(base, mid, sid!, "PLAN")} (refined slice plan from sketch)`;
     case "execute-task": {
       return `Task ${tid} marked [x] in ${relSliceFile(base, mid, sid!, "PLAN")} + summary written`;
     }

--- a/src/resources/extensions/gsd/auto-dashboard.ts
+++ b/src/resources/extensions/gsd/auto-dashboard.ts
@@ -96,6 +96,7 @@ export function unitVerb(unitType: string): string {
     case "research-slice": return "researching";
     case "plan-milestone":
     case "plan-slice": return "planning";
+    case "refine-slice": return "refining";
     case "execute-task": return "executing";
     case "complete-slice": return "completing";
     case "replan-slice": return "replanning";
@@ -116,6 +117,7 @@ export function unitPhaseLabel(unitType: string): string {
     case "research-slice": return "RESEARCH";
     case "plan-milestone": return "PLAN";
     case "plan-slice": return "PLAN";
+    case "refine-slice": return "REFINE";
     case "execute-task": return "EXECUTE";
     case "complete-slice": return "COMPLETE";
     case "replan-slice": return "REPLAN";
@@ -143,6 +145,7 @@ function peekNext(unitType: string, state: GSDState): string {
     case "plan-milestone": return "plan or execute first slice";
     case "research-slice": return `plan ${sid}`;
     case "plan-slice": return "execute first task";
+    case "refine-slice": return "execute first task";
     case "execute-task": return `continue ${sid}`;
     case "complete-slice": return "reassess roadmap";
     case "replan-slice": return `re-execute ${sid}`;

--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -39,6 +39,7 @@ import {
   buildPlanMilestonePrompt,
   buildResearchSlicePrompt,
   buildPlanSlicePrompt,
+  buildRefineSlicePrompt,
   buildExecuteTaskPrompt,
   buildCompleteSlicePrompt,
   buildCompleteMilestonePrompt,
@@ -477,6 +478,58 @@ export const DISPATCH_RULES: DispatchRule[] = [
           sTitle,
           basePath,
         ),
+      };
+    },
+  },
+  {
+    // ADR-011: sketch-then-refine. When `refining` phase fires, expand the
+    // sketch into a full plan using the prior slice's SUMMARY and the current
+    // codebase. If the user flipped `progressive_planning` off mid-milestone
+    // while a slice is still `is_sketch=1`, fall through to a standard
+    // plan-slice so the loop doesn't dead-end.
+    //
+    // Note on the flag-OFF downgrade: plan-slice does not explicitly clear
+    // `is_sketch`. After it writes PLAN.md, the auto-heal in state.ts's
+    // `deriveStateFromDb` (via `autoHealSketchFlags`) flips the flag on the
+    // next iteration. That implicit coupling is the sole mechanism that
+    // reconciles `is_sketch=1` on the plan-slice path — do not remove the
+    // auto-heal without either adding an explicit `setSliceSketchFlag(..., false)`
+    // call here or doing so inside the plan-slice tool handler.
+    name: "refining → refine-slice",
+    match: async ({ state, mid, midTitle, basePath, prefs }) => {
+      if (state.phase !== "refining") return null;
+      if (!state.activeSlice) return missingSliceStop(mid, state.phase);
+      const sid = state.activeSlice.id;
+      const sTitle = state.activeSlice.title;
+      const progressiveOn = prefs?.phases?.progressive_planning === true;
+      if (!progressiveOn) {
+        // Graceful downgrade: treat the sketch as a normal slice needing a plan,
+        // but forward the stored sketch_scope as a SOFT hint so the scope
+        // signal isn't silently lost. The planner may expand beyond it.
+        let softScopeHint = "";
+        try {
+          const { isDbAvailable, getSlice } = await import("./gsd-db.js");
+          if (isDbAvailable()) {
+            softScopeHint = getSlice(mid, sid)?.sketch_scope ?? "";
+          }
+        } catch {
+          softScopeHint = "";
+        }
+        return {
+          action: "dispatch",
+          unitType: "plan-slice",
+          unitId: `${mid}/${sid}`,
+          prompt: await buildPlanSlicePrompt(
+            mid, midTitle, sid, sTitle, basePath, undefined,
+            softScopeHint ? { softScopeHint } : undefined,
+          ),
+        };
+      }
+      return {
+        action: "dispatch",
+        unitType: "refine-slice",
+        unitId: `${mid}/${sid}`,
+        prompt: await buildRefineSlicePrompt(mid, midTitle, sid, sTitle, basePath),
       };
     },
   },

--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -190,6 +190,25 @@ export function isVerificationNotApplicable(value: string): boolean {
 
 export const DISPATCH_RULES: DispatchRule[] = [
   {
+    // ADR-011 Phase 2: pause-for-escalation must evaluate FIRST so phase-
+    // agnostic rules (rewrite-docs gate, UAT checks, reassess) cannot bypass
+    // the user's pending decision. Only fires for continueWithDefault=false
+    // escalations (those set escalation_pending=1); awaiting-review artifacts
+    // never enter the 'escalating-task' phase.
+    name: "escalating-task → pause-for-escalation",
+    match: async ({ state, mid }) => {
+      if (state.phase !== "escalating-task") return null;
+      if (!state.activeSlice) return missingSliceStop(mid, state.phase);
+      return {
+        action: "stop",
+        reason:
+          state.nextAction ||
+          `${mid}: task escalation awaits user resolution. Run /gsd escalate list to see pending items.`,
+        level: "info",
+      };
+    },
+  },
+  {
     name: "rewrite-docs (override gate)",
     match: async ({ mid, midTitle, state, basePath, session }) => {
       const pendingOverrides = await loadActiveOverrides(basePath);
@@ -552,25 +571,6 @@ export const DISPATCH_RULES: DispatchRule[] = [
           sTitle,
           basePath,
         ),
-      };
-    },
-  },
-  {
-    // ADR-011 Phase 2: pause auto-mode until the user resolves a pending
-    // escalation via `/gsd escalate resolve <taskId> <choice>`. Only fires
-    // for escalations with `continueWithDefault: false` — the
-    // `continueWithDefault: true` path writes an artifact without flipping
-    // `escalation_pending`, so it never enters this phase.
-    name: "escalating-task → pause-for-escalation",
-    match: async ({ state, mid }) => {
-      if (state.phase !== "escalating-task") return null;
-      if (!state.activeSlice) return missingSliceStop(mid, state.phase);
-      return {
-        action: "stop",
-        reason:
-          state.nextAction ||
-          `${mid}: task escalation awaits user resolution. Run /gsd escalate list to see pending items.`,
-        level: "info",
       };
     },
   },

--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -39,6 +39,7 @@ import {
   buildPlanMilestonePrompt,
   buildResearchSlicePrompt,
   buildPlanSlicePrompt,
+  buildRefineSlicePrompt,
   buildExecuteTaskPrompt,
   buildCompleteSlicePrompt,
   buildCompleteMilestonePrompt,
@@ -496,6 +497,58 @@ export const DISPATCH_RULES: DispatchRule[] = [
           sTitle,
           basePath,
         ),
+      };
+    },
+  },
+  {
+    // ADR-011: sketch-then-refine. When `refining` phase fires, expand the
+    // sketch into a full plan using the prior slice's SUMMARY and the current
+    // codebase. If the user flipped `progressive_planning` off mid-milestone
+    // while a slice is still `is_sketch=1`, fall through to a standard
+    // plan-slice so the loop doesn't dead-end.
+    //
+    // Note on the flag-OFF downgrade: plan-slice does not explicitly clear
+    // `is_sketch`. After it writes PLAN.md, the auto-heal in state.ts's
+    // `deriveStateFromDb` (via `autoHealSketchFlags`) flips the flag on the
+    // next iteration. That implicit coupling is the sole mechanism that
+    // reconciles `is_sketch=1` on the plan-slice path — do not remove the
+    // auto-heal without either adding an explicit `setSliceSketchFlag(..., false)`
+    // call here or doing so inside the plan-slice tool handler.
+    name: "refining → refine-slice",
+    match: async ({ state, mid, midTitle, basePath, prefs }) => {
+      if (state.phase !== "refining") return null;
+      if (!state.activeSlice) return missingSliceStop(mid, state.phase);
+      const sid = state.activeSlice.id;
+      const sTitle = state.activeSlice.title;
+      const progressiveOn = prefs?.phases?.progressive_planning === true;
+      if (!progressiveOn) {
+        // Graceful downgrade: treat the sketch as a normal slice needing a plan,
+        // but forward the stored sketch_scope as a SOFT hint so the scope
+        // signal isn't silently lost. The planner may expand beyond it.
+        let softScopeHint = "";
+        try {
+          const { isDbAvailable, getSlice } = await import("./gsd-db.js");
+          if (isDbAvailable()) {
+            softScopeHint = getSlice(mid, sid)?.sketch_scope ?? "";
+          }
+        } catch {
+          softScopeHint = "";
+        }
+        return {
+          action: "dispatch",
+          unitType: "plan-slice",
+          unitId: `${mid}/${sid}`,
+          prompt: await buildPlanSlicePrompt(
+            mid, midTitle, sid, sTitle, basePath, undefined,
+            softScopeHint ? { softScopeHint } : undefined,
+          ),
+        };
+      }
+      return {
+        action: "dispatch",
+        unitType: "refine-slice",
+        unitId: `${mid}/${sid}`,
+        prompt: await buildRefineSlicePrompt(mid, midTitle, sid, sTitle, basePath),
       };
     },
   },

--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -556,6 +556,25 @@ export const DISPATCH_RULES: DispatchRule[] = [
     },
   },
   {
+    // ADR-011 Phase 2: pause auto-mode until the user resolves a pending
+    // escalation via `/gsd escalate resolve <taskId> <choice>`. Only fires
+    // for escalations with `continueWithDefault: false` — the
+    // `continueWithDefault: true` path writes an artifact without flipping
+    // `escalation_pending`, so it never enters this phase.
+    name: "escalating-task → pause-for-escalation",
+    match: async ({ state, mid }) => {
+      if (state.phase !== "escalating-task") return null;
+      if (!state.activeSlice) return missingSliceStop(mid, state.phase);
+      return {
+        action: "stop",
+        reason:
+          state.nextAction ||
+          `${mid}: task escalation awaits user resolution. Run /gsd escalate list to see pending items.`,
+        level: "info",
+      };
+    },
+  },
+  {
     name: "executing → reactive-execute (parallel dispatch)",
     match: async ({ state, mid, midTitle, basePath, prefs }) => {
       if (state.phase !== "executing" || !state.activeTask) return null;

--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -99,7 +99,7 @@ function enqueueSidecar(
  *  next actual task commit via `smartStage()`. */
 const LIFECYCLE_ONLY_UNITS = new Set([
   "research-milestone", "discuss-milestone", "discuss-slice", "plan-milestone",
-  "validate-milestone", "research-slice", "plan-slice",
+  "validate-milestone", "research-slice", "plan-slice", "refine-slice",
   "replan-slice", "complete-slice", "run-uat",
   "reassess-roadmap", "rewrite-docs",
 ]);
@@ -190,7 +190,7 @@ export function detectRogueFileWrites(
     if (!hasPlanningState) {
       rogues.push({ path: roadmapPath, unitType, unitId });
     }
-  } else if (unitType === "plan-slice" || unitType === "replan-slice") {
+  } else if (unitType === "plan-slice" || unitType === "refine-slice" || unitType === "replan-slice") {
     if (!mid || !sid) return [];
 
     const planPath = resolveSliceFile(basePath, mid, sid, "PLAN");
@@ -1020,10 +1020,12 @@ export async function postUnitPostVerification(pctx: PostUnitContext): Promise<"
     }
   }
 
-  // ── Pre-execution checks (after plan-slice completes) ──
+  // ── Pre-execution checks (after plan-slice or ADR-011 refine-slice completes) ──
+  // Both emit the same PLAN.md + task artifacts via gsd_plan_slice, so the
+  // same structural validation applies to both.
   if (
     s.currentUnit &&
-    s.currentUnit.type === "plan-slice"
+    (s.currentUnit.type === "plan-slice" || s.currentUnit.type === "refine-slice")
   ) {
     const currentUnit = s.currentUnit;
     let preExecPauseNeeded = false;

--- a/src/resources/extensions/gsd/auto-prompts.ts
+++ b/src/resources/extensions/gsd/auto-prompts.ts
@@ -1216,10 +1216,28 @@ export async function buildResearchSlicePrompt(
   });
 }
 
-export async function buildPlanSlicePrompt(
-  mid: string, _midTitle: string, sid: string, sTitle: string, base: string, level?: InlineLevel,
-): Promise<string> {
-  const inlineLevel = level ?? resolveInlineLevel();
+/**
+ * Shared assembly for plan-slice and refine-slice prompts. Both builders need
+ * the same inlined context (roadmap excerpt, slice context, research, decisions,
+ * requirements, knowledge, graph subgraph, templates, dependency summaries,
+ * overrides). Extracted to prevent drift between the two sites.
+ *
+ * `prependBlocks` are pushed onto the start of the inlined array BEFORE any
+ * shared content, so callers can add unit-specific headers (e.g., the refine
+ * sketch-scope constraint).
+ */
+async function renderSlicePrompt(options: {
+  mid: string;
+  sid: string;
+  sTitle: string;
+  base: string;
+  level: InlineLevel;
+  promptTemplate: "plan-slice" | "refine-slice";
+  prependBlocks?: string[];
+  extraVars?: Record<string, string>;
+}): Promise<string> {
+  const { mid, sid, sTitle, base, level, promptTemplate, prependBlocks = [], extraVars = {} } = options;
+
   const roadmapPath = resolveMilestoneFile(base, mid, "ROADMAP");
   const roadmapRel = relMilestoneFile(base, mid, "ROADMAP");
   const researchPath = resolveSliceFile(base, mid, sid, "RESEARCH");
@@ -1227,18 +1245,17 @@ export async function buildPlanSlicePrompt(
   const sliceContextPath = resolveSliceFile(base, mid, sid, "CONTEXT");
   const sliceContextRel = relSliceFile(base, mid, sid, "CONTEXT");
 
-  const inlined: string[] = [];
+  const inlined: string[] = [...prependBlocks];
 
-  // Inject phase handoff anchor from research phase (if available)
+  // Phase handoff anchor from research phase (if available)
   const researchSliceAnchor = readPhaseAnchor(base, mid, "research-slice");
   if (researchSliceAnchor) inlined.push(formatAnchorForPrompt(researchSliceAnchor));
 
-  // Use roadmap excerpt instead of full roadmap for context reduction
-  const roadmapExcerptPS = await inlineRoadmapExcerpt(base, mid, sid);
-  if (roadmapExcerptPS) {
-    inlined.push(roadmapExcerptPS);
+  // Roadmap excerpt with full-roadmap fallback
+  const roadmapExcerpt = await inlineRoadmapExcerpt(base, mid, sid);
+  if (roadmapExcerpt) {
+    inlined.push(roadmapExcerpt);
   } else {
-    // Fall back to full roadmap if excerpt fails
     inlined.push(await inlineFile(roadmapPath, roadmapRel, "Milestone Roadmap"));
   }
 
@@ -1246,42 +1263,36 @@ export async function buildPlanSlicePrompt(
   if (sliceCtxInline) inlined.push(sliceCtxInline);
   const researchInline = await inlineFileOptional(researchPath, researchRel, "Slice Research");
   if (researchInline) inlined.push(researchInline);
-  if (inlineLevel !== "minimal") {
-    // Derive scope from slice title for decision filtering (R005)
-    const derivedScopePS = deriveSliceScope(sTitle);
-    const decisionsInline = await inlineDecisionsFromDb(base, mid, derivedScopePS, inlineLevel);
+
+  if (level !== "minimal") {
+    const derivedScope = deriveSliceScope(sTitle);
+    const decisionsInline = await inlineDecisionsFromDb(base, mid, derivedScope, level);
     if (decisionsInline) inlined.push(decisionsInline);
-    const requirementsInline = await inlineRequirementsFromDb(base, mid, sid, inlineLevel);
+    const requirementsInline = await inlineRequirementsFromDb(base, mid, sid, level);
     if (requirementsInline) inlined.push(requirementsInline);
   }
 
-  // Use scoped knowledge based on slice title keywords
-  const keywordsPS = extractKeywords(sTitle);
-  const knowledgeInlinePS = await inlineKnowledgeScoped(base, keywordsPS);
-  if (knowledgeInlinePS) inlined.push(knowledgeInlinePS);
+  const knowledgeInline = await inlineKnowledgeScoped(base, extractKeywords(sTitle));
+  if (knowledgeInline) inlined.push(knowledgeInline);
 
-  // Knowledge graph: subgraph for this slice (graceful — skipped if no graph.json)
-  const graphBlockPS = await inlineGraphSubgraph(base, `${sid} ${sTitle}`, { budget: 3000 });
-  if (graphBlockPS) inlined.push(graphBlockPS);
+  const graphBlock = await inlineGraphSubgraph(base, `${sid} ${sTitle}`, { budget: 3000 });
+  if (graphBlock) inlined.push(graphBlock);
 
   inlined.push(inlineTemplate("plan", "Slice Plan"));
-  if (inlineLevel === "full") {
+  if (level === "full") {
     inlined.push(inlineTemplate("task-plan", "Task Plan"));
   }
 
   const depContent = await inlineDependencySummaries(mid, sid, base);
-  const planActiveOverrides = await loadActiveOverrides(base);
-  const planOverridesInline = formatOverridesSection(planActiveOverrides);
-  if (planOverridesInline) inlined.unshift(planOverridesInline);
+  const overridesInline = formatOverridesSection(await loadActiveOverrides(base));
+  if (overridesInline) inlined.unshift(overridesInline);
 
   const inlinedContext = capPreamble(`## Inlined Context (preloaded — do not re-read these files)\n\n${inlined.join("\n\n---\n\n")}`);
-
-  // Build executor context constraints from the budget engine
   const executorContextConstraints = formatExecutorConstraints();
-
   const outputRelPath = relSliceFile(base, mid, sid, "PLAN");
   const commitInstruction = "Do not commit — .gsd/ planning docs are managed externally and not tracked in git.";
-  return loadPrompt("plan-slice", {
+
+  return loadPrompt(promptTemplate, {
     workingDirectory: base,
     milestoneId: mid, sliceId: sid, sliceTitle: sTitle,
     slicePath: relSlicePath(base, mid, sid),
@@ -1300,6 +1311,68 @@ export async function buildPlanSlicePrompt(
       sliceTitle: sTitle,
       extraContext: [inlinedContext, depContent],
     }),
+    ...extraVars,
+  });
+}
+
+export async function buildPlanSlicePrompt(
+  mid: string, _midTitle: string, sid: string, sTitle: string, base: string, level?: InlineLevel,
+  options?: { softScopeHint?: string },
+): Promise<string> {
+  const prependBlocks: string[] = [];
+  // ADR-011: when the refining-phase dispatch rule gracefully downgrades to
+  // plan-slice (progressive_planning was toggled off mid-milestone), it
+  // forwards the stored sketch_scope as a SOFT hint — context, not a hard
+  // constraint. The planner is free to expand beyond it.
+  if (options?.softScopeHint && options.softScopeHint.trim().length > 0) {
+    prependBlocks.push(
+      `## Prior Sketch Scope (soft hint — non-binding)\n\n${options.softScopeHint.trim()}\n\n` +
+      `This scope was captured during an earlier progressive-planning pass that was later disabled. Treat it as context only — you may plan beyond it if the work genuinely requires more scope. Do NOT treat this as a hard boundary.`,
+    );
+  }
+  return renderSlicePrompt({
+    mid, sid, sTitle, base,
+    level: level ?? resolveInlineLevel(),
+    promptTemplate: "plan-slice",
+    prependBlocks,
+  });
+}
+
+/**
+ * ADR-011 refine-slice: expand a sketch into a full plan using the current
+ * codebase state and prior slice summary. Mechanically similar to plan-slice
+ * but framed as a *transformation* (sketch → full plan) rather than a
+ * blank-sheet planning pass. Reuses inlineDependencySummaries for prior
+ * slice SUMMARY and inlines the stored sketch_scope as a hard constraint.
+ */
+export async function buildRefineSlicePrompt(
+  mid: string, _midTitle: string, sid: string, sTitle: string, base: string, level?: InlineLevel,
+): Promise<string> {
+  // Pull the stored sketch scope from the DB — the hard constraint we plan within.
+  let sketchScope = "";
+  try {
+    const { isDbAvailable, getSlice } = await import("./gsd-db.js");
+    if (isDbAvailable()) {
+      sketchScope = getSlice(mid, sid)?.sketch_scope ?? "";
+    }
+  } catch {
+    sketchScope = "";
+  }
+
+  const prependBlocks: string[] = [];
+  if (sketchScope.trim().length > 0) {
+    prependBlocks.push(
+      `## Sketch Scope (hard constraint)\n\n${sketchScope.trim()}\n\n` +
+      `Treat this as the authoritative boundary for the slice. Do not plan work outside this scope; if the scope is too narrow, surface it as a deviation rather than expanding silently.`,
+    );
+  }
+
+  return renderSlicePrompt({
+    mid, sid, sTitle, base,
+    level: level ?? resolveInlineLevel(),
+    promptTemplate: "refine-slice",
+    prependBlocks,
+    extraVars: { sketchScope },
   });
 }
 

--- a/src/resources/extensions/gsd/auto-prompts.ts
+++ b/src/resources/extensions/gsd/auto-prompts.ts
@@ -1436,7 +1436,7 @@ export async function buildExecuteTaskPrompt(
       }
     } catch (escalationErr) {
       // Escalation module unavailable or threw — log and proceed.
-      logWarning("auto-prompts", `escalation override injection failed: ${(escalationErr as Error).message}`);
+      logWarning("prompt", `escalation override injection failed: ${(escalationErr as Error).message}`);
     }
   }
 

--- a/src/resources/extensions/gsd/auto-prompts.ts
+++ b/src/resources/extensions/gsd/auto-prompts.ts
@@ -1417,7 +1417,28 @@ export async function buildExecuteTaskPrompt(
     ? `### Runtime Context\nSource: \`.gsd/RUNTIME.md\`\n\n${runtimeContent.trim()}`
     : "";
 
-  const phaseAnchorSection = planAnchor ? formatAnchorForPrompt(planAnchor) : "";
+  let phaseAnchorSection = planAnchor ? formatAnchorForPrompt(planAnchor) : "";
+
+  // ADR-011 Phase 2: inject any resolved-but-unapplied escalation override
+  // into this task's prompt. Claim is atomic via DB UPDATE WHERE IS NULL, so
+  // if a parallel build already injected it, we skip. Feature-gated by
+  // phases.mid_execution_escalation. Prepended to phaseAnchorSection so it
+  // appears near the top of the prompt above planning anchors.
+  if (prefs?.preferences?.phases?.mid_execution_escalation === true) {
+    try {
+      const { claimOverrideForInjection } = await import("./escalation.js");
+      const claimed = claimOverrideForInjection(base, mid, sid);
+      if (claimed) {
+        const block = claimed.injectionBlock + "\n\n---\n\n";
+        phaseAnchorSection = phaseAnchorSection
+          ? `${block}${phaseAnchorSection}`
+          : block;
+      }
+    } catch (escalationErr) {
+      // Escalation module unavailable or threw — log and proceed.
+      logWarning("auto-prompts", `escalation override injection failed: ${(escalationErr as Error).message}`);
+    }
+  }
 
   // Task-scoped gates owned by execute-task (Q5/Q6/Q7). Pull only the
   // gates that plan-slice actually seeded for this task — tasks with no

--- a/src/resources/extensions/gsd/bootstrap/db-tools.ts
+++ b/src/resources/extensions/gsd/bootstrap/db-tools.ts
@@ -638,7 +638,7 @@ export function registerDbTools(pi: ExtensionAPI): void {
           id: Type.String({ description: "Short id (e.g. 'A', 'B') used by /gsd escalate resolve." }),
           label: Type.String({ description: "One-line label." }),
           tradeoffs: Type.String({ description: "1-2 sentences on the tradeoffs of this option." }),
-        }), { description: "2–4 options the user can choose between." }),
+        }), { minItems: 2, maxItems: 4, description: "2–4 options the user can choose between." }),
         recommendation: Type.String({ description: "Option id the executor recommends." }),
         recommendationRationale: Type.String({ description: "Why the recommendation — 1–2 sentences." }),
         continueWithDefault: Type.Boolean({

--- a/src/resources/extensions/gsd/bootstrap/db-tools.ts
+++ b/src/resources/extensions/gsd/bootstrap/db-tools.ts
@@ -449,10 +449,14 @@ export function registerDbTools(pi: ExtensionAPI): void {
         depends: Type.Array(Type.String(), { description: "Slice dependency IDs" }),
         demo: Type.String({ description: "Roadmap demo text / After this" }),
         goal: Type.String({ description: "Slice goal" }),
-        successCriteria: Type.String({ description: "Slice success criteria block" }),
-        proofLevel: Type.String({ description: "Slice proof level" }),
-        integrationClosure: Type.String({ description: "Slice integration closure" }),
-        observabilityImpact: Type.String({ description: "Slice observability impact" }),
+        // ADR-011: heavy planning fields are optional for sketch slices; required for full slices.
+        successCriteria: Type.Optional(Type.String({ description: "Slice success criteria block (required for full slices; omit for sketches)" })),
+        proofLevel: Type.Optional(Type.String({ description: "Slice proof level (required for full slices; omit for sketches)" })),
+        integrationClosure: Type.Optional(Type.String({ description: "Slice integration closure (required for full slices; omit for sketches)" })),
+        observabilityImpact: Type.Optional(Type.String({ description: "Slice observability impact (required for full slices; omit for sketches)" })),
+        // ADR-011 sketch-then-refine fields.
+        isSketch: Type.Optional(Type.Boolean({ description: "ADR-011: true marks this slice as a sketch awaiting refine-slice expansion" })),
+        sketchScope: Type.Optional(Type.String({ description: "ADR-011: 2–3 sentence scope boundary, required when isSketch=true" })),
       }), { description: "Planned slices for the milestone" }),
       // ── Enrichment metadata (optional — defaults to empty) ────────────
       status: Type.Optional(Type.String({ description: "Milestone status (defaults to active)" })),

--- a/src/resources/extensions/gsd/bootstrap/db-tools.ts
+++ b/src/resources/extensions/gsd/bootstrap/db-tools.ts
@@ -631,6 +631,20 @@ export function registerDbTools(pi: ExtensionAPI): void {
       keyFiles: Type.Optional(Type.Array(Type.String(), { description: "List of key files created or modified" })),
       keyDecisions: Type.Optional(Type.Array(Type.String(), { description: "List of key decisions made during this task" })),
       blockerDiscovered: Type.Optional(Type.Boolean({ description: "Whether a plan-invalidating blocker was discovered" })),
+      // ADR-011 Phase 2: mid-execution escalation — agent asks the user to resolve an ambiguity.
+      escalation: Type.Optional(Type.Object({
+        question: Type.String({ description: "The question the user needs to answer — one clear sentence." }),
+        options: Type.Array(Type.Object({
+          id: Type.String({ description: "Short id (e.g. 'A', 'B') used by /gsd escalate resolve." }),
+          label: Type.String({ description: "One-line label." }),
+          tradeoffs: Type.String({ description: "1-2 sentences on the tradeoffs of this option." }),
+        }), { description: "2–4 options the user can choose between." }),
+        recommendation: Type.String({ description: "Option id the executor recommends." }),
+        recommendationRationale: Type.String({ description: "Why the recommendation — 1–2 sentences." }),
+        continueWithDefault: Type.Boolean({
+          description: "When true, loop continues (artifact logged for later review). When false, auto-mode pauses until the user resolves via /gsd escalate resolve.",
+        }),
+      }, { description: "ADR-011 Phase 2: optional escalation payload. Only honored when phases.mid_execution_escalation is true." })),
       verificationEvidence: Type.Optional(Type.Array(
         Type.Union([
           Type.Object({

--- a/src/resources/extensions/gsd/commands/handlers/escalate.ts
+++ b/src/resources/extensions/gsd/commands/handlers/escalate.ts
@@ -89,13 +89,38 @@ export async function handleEscalateCommand(
     return;
   }
 
-  // ── show <taskId> ───────────────────────────────────────────────────────
+  // Parse a possibly-slice-qualified task id: "Sxx/Tyy" or plain "Tyy".
+  // Returns { sliceId?, taskId }.
+  const parseTaskRef = (ref: string): { sliceId?: string; taskId: string } => {
+    const slash = ref.indexOf("/");
+    if (slash > 0) {
+      return { sliceId: ref.slice(0, slash), taskId: ref.slice(slash + 1) };
+    }
+    return { taskId: ref };
+  };
+
+  // Resolve a task ref to a single row, surfacing ambiguity when a bare task
+  // id matches more than one slice.
+  const locateRow = (ref: string): ReturnType<typeof listAllEscalations>[number] | "ambiguous" | "not-found" => {
+    const { sliceId, taskId } = parseTaskRef(ref);
+    const rows = listAllEscalations(milestoneId).filter(
+      (t) => t.id === taskId && (sliceId === undefined || t.slice_id === sliceId),
+    );
+    if (rows.length === 0) return "not-found";
+    if (rows.length > 1) return "ambiguous";
+    return rows[0]!;
+  };
+
+  // ── show <taskRef> ──────────────────────────────────────────────────────
   if (trimmed.startsWith("show ")) {
-    const taskId = trimmed.slice(5).trim();
-    const rows = listAllEscalations(milestoneId).filter((t) => t.id === taskId);
-    const row = rows[0];
-    if (!row || !row.escalation_artifact_path) {
-      ctx.ui.notify(`No escalation found for task ${taskId} in ${milestoneId}.`, "warning");
+    const ref = trimmed.slice(5).trim();
+    const row = locateRow(ref);
+    if (row === "ambiguous") {
+      ctx.ui.notify(`Task ${ref} matches multiple slices. Use Sxx/Tyy format.`, "warning");
+      return;
+    }
+    if (row === "not-found" || !row.escalation_artifact_path) {
+      ctx.ui.notify(`No escalation found for ${ref} in ${milestoneId}.`, "warning");
       return;
     }
     const art = readEscalationArtifact(row.escalation_artifact_path);
@@ -107,24 +132,27 @@ export async function handleEscalateCommand(
     return;
   }
 
-  // ── resolve <taskId> <choice> [rationale...] ────────────────────────────
+  // ── resolve <taskRef> <choice> [rationale...] ───────────────────────────
   if (trimmed.startsWith("resolve ")) {
     const parts = trimmed.slice(8).trim().split(/\s+/);
-    const taskId = parts[0];
+    const ref = parts[0];
     const choice = parts[1];
     const rationale = parts.slice(2).join(" ").trim();
-    if (!taskId || !choice) {
-      ctx.ui.notify("Usage: /gsd escalate resolve <taskId> <choice> [rationale...]", "warning");
+    if (!ref || !choice) {
+      ctx.ui.notify("Usage: /gsd escalate resolve <taskId|Sxx/Tyy> <choice> [rationale...]", "warning");
       return;
     }
 
-    // Locate the slice id — scan the milestone for a matching task.
-    const rows = listAllEscalations(milestoneId).filter((t) => t.id === taskId);
-    const row = rows[0];
-    if (!row) {
-      ctx.ui.notify(`No escalation found for task ${taskId} in ${milestoneId}.`, "warning");
+    const row = locateRow(ref);
+    if (row === "ambiguous") {
+      ctx.ui.notify(`Task ${ref} matches multiple slices. Use Sxx/Tyy format.`, "warning");
       return;
     }
+    if (row === "not-found") {
+      ctx.ui.notify(`No escalation found for ${ref} in ${milestoneId}.`, "warning");
+      return;
+    }
+    const taskId = row.id;
 
     const result = resolveEscalation(basePath, milestoneId, row.slice_id, taskId, choice, rationale);
     invalidateStateCache();

--- a/src/resources/extensions/gsd/commands/handlers/escalate.ts
+++ b/src/resources/extensions/gsd/commands/handlers/escalate.ts
@@ -1,0 +1,188 @@
+// GSD Extension — /gsd escalate Command Handler (ADR-011 Phase 2)
+// Surface and resolve mid-execution escalations from the CLI.
+
+import type { ExtensionAPI, ExtensionCommandContext } from "@gsd/pi-coding-agent";
+
+import { projectRoot } from "../context.js";
+import { getActiveMilestoneId } from "../../state.js";
+import {
+  readEscalationArtifact,
+  formatEscalationForDisplay,
+  resolveEscalation,
+  listActionableEscalations,
+  listAllEscalations,
+} from "../../escalation.js";
+import { saveDecisionToDb } from "../../db-writer.js";
+import { loadEffectiveGSDPreferences } from "../../preferences.js";
+import { invalidateStateCache } from "../../state.js";
+import { emitUokAuditEvent, buildAuditEnvelope } from "../../uok/audit.js";
+
+function helpMessage(): string {
+  return [
+    "/gsd escalate — manage mid-execution escalations (ADR-011 Phase 2)",
+    "",
+    "Subcommands:",
+    "  list [--all]           show pending escalations (use --all to include resolved)",
+    "  show <taskId>          print the escalation artifact",
+    "  resolve <taskId> <choice> [rationale...]",
+    "                         resolve an escalation — choice is an option id,",
+    "                         `accept` (use recommendation), or `reject-blocker`",
+    "                         (convert to a blocker and trigger slice replan)",
+    "",
+    "Note: disabling `phases.mid_execution_escalation` does NOT clear pending",
+    "escalations. If you need to drain them, re-enable the flag, resolve via",
+    "`/gsd escalate resolve`, then disable.",
+  ].join("\n");
+}
+
+function formatListEntries(
+  rows: ReturnType<typeof listActionableEscalations>,
+  basePath: string,
+): string {
+  if (rows.length === 0) return "No escalations.";
+  return rows.map((t) => {
+    const art = t.escalation_artifact_path ? readEscalationArtifact(t.escalation_artifact_path) : null;
+    const status = t.escalation_pending ? "PENDING (paused)" : t.escalation_awaiting_review ? "awaiting-review" : "resolved";
+    const question = art?.question ?? "(artifact missing)";
+    return `  ${t.slice_id}/${t.id}  [${status}]  ${question}`;
+  }).join("\n");
+}
+
+export async function handleEscalateCommand(
+  args: string,
+  ctx: ExtensionCommandContext,
+  pi: ExtensionAPI,
+): Promise<void> {
+  void pi;
+
+  const trimmed = args.trim();
+  if (trimmed === "" || trimmed === "help") {
+    ctx.ui.notify(helpMessage(), "info");
+    return;
+  }
+
+  const basePath = projectRoot();
+  const prefs = loadEffectiveGSDPreferences()?.preferences;
+  if (prefs?.phases?.mid_execution_escalation !== true) {
+    ctx.ui.notify(
+      "Escalation is off. Enable with `phases: { mid_execution_escalation: true }` in your PREFERENCES.md.",
+      "warning",
+    );
+    return;
+  }
+
+  const milestoneId = await getActiveMilestoneId(basePath);
+  if (!milestoneId) {
+    ctx.ui.notify("No active milestone — cannot list escalations.", "warning");
+    return;
+  }
+
+  // ── list ────────────────────────────────────────────────────────────────
+  if (trimmed === "list" || trimmed === "list --all" || trimmed === "--all") {
+    const includeAll = trimmed.includes("--all");
+    const rows = includeAll ? listAllEscalations(milestoneId) : listActionableEscalations(milestoneId);
+    const body = formatListEntries(rows, basePath);
+    ctx.ui.notify(
+      `${includeAll ? "All escalations" : "Actionable escalations"} for ${milestoneId}:\n${body}`,
+      "info",
+    );
+    return;
+  }
+
+  // ── show <taskId> ───────────────────────────────────────────────────────
+  if (trimmed.startsWith("show ")) {
+    const taskId = trimmed.slice(5).trim();
+    const rows = listAllEscalations(milestoneId).filter((t) => t.id === taskId);
+    const row = rows[0];
+    if (!row || !row.escalation_artifact_path) {
+      ctx.ui.notify(`No escalation found for task ${taskId} in ${milestoneId}.`, "warning");
+      return;
+    }
+    const art = readEscalationArtifact(row.escalation_artifact_path);
+    if (!art) {
+      ctx.ui.notify(`Escalation artifact at ${row.escalation_artifact_path} is missing or malformed.`, "error");
+      return;
+    }
+    ctx.ui.notify(formatEscalationForDisplay(art), "info");
+    return;
+  }
+
+  // ── resolve <taskId> <choice> [rationale...] ────────────────────────────
+  if (trimmed.startsWith("resolve ")) {
+    const parts = trimmed.slice(8).trim().split(/\s+/);
+    const taskId = parts[0];
+    const choice = parts[1];
+    const rationale = parts.slice(2).join(" ").trim();
+    if (!taskId || !choice) {
+      ctx.ui.notify("Usage: /gsd escalate resolve <taskId> <choice> [rationale...]", "warning");
+      return;
+    }
+
+    // Locate the slice id — scan the milestone for a matching task.
+    const rows = listAllEscalations(milestoneId).filter((t) => t.id === taskId);
+    const row = rows[0];
+    if (!row) {
+      ctx.ui.notify(`No escalation found for task ${taskId} in ${milestoneId}.`, "warning");
+      return;
+    }
+
+    const result = resolveEscalation(basePath, milestoneId, row.slice_id, taskId, choice, rationale);
+    invalidateStateCache();
+
+    if (result.status !== "resolved" && result.status !== "rejected-to-blocker") {
+      ctx.ui.notify(result.message, result.status === "invalid-choice" ? "warning" : "error");
+      return;
+    }
+
+    // Persist the user's choice as a decision (only for resolved, not reject-blocker).
+    if (result.status === "resolved") {
+      try {
+        const art = row.escalation_artifact_path ? readEscalationArtifact(row.escalation_artifact_path) : null;
+        const scope = `${milestoneId}/${row.slice_id}/${taskId}`;
+        const decisionText = art?.question ?? `escalation on ${taskId}`;
+        const choiceLabel = choice === "accept"
+          ? `${art?.recommendation ?? "accepted"} (recommended)`
+          : (result.chosenOption?.label ?? choice);
+        const { id: decisionId } = await saveDecisionToDb({
+          scope,
+          decision: decisionText,
+          choice: choiceLabel,
+          rationale: rationale || result.chosenOption?.tradeoffs || "User-resolved escalation.",
+          made_by: "human",
+          source: "escalation",
+          when_context: `ADR-011 escalation resolved ${new Date().toISOString()}`,
+        }, basePath);
+
+        emitUokAuditEvent(basePath, buildAuditEnvelope({
+          traceId: `escalation:${milestoneId}:${row.slice_id}:${taskId}`,
+          category: "gate",
+          type: "escalation-decision-persisted",
+          payload: {
+            milestoneId,
+            sliceId: row.slice_id,
+            taskId,
+            decisionId,
+            choice,
+          },
+        }));
+
+        ctx.ui.notify(
+          `${result.message}\nDecision recorded as ${decisionId}. Run /gsd auto to continue.`,
+          "success",
+        );
+      } catch (decErr) {
+        ctx.ui.notify(
+          `${result.message}\nWARN: decision persistence failed: ${(decErr as Error).message}`,
+          "warning",
+        );
+      }
+      return;
+    }
+
+    // rejected-to-blocker path
+    ctx.ui.notify(`${result.message} Run /gsd auto to trigger the replan.`, "success");
+    return;
+  }
+
+  ctx.ui.notify(`Unknown subcommand. ${helpMessage()}`, "warning");
+}

--- a/src/resources/extensions/gsd/commands/handlers/ops.ts
+++ b/src/resources/extensions/gsd/commands/handlers/ops.ts
@@ -191,6 +191,11 @@ Examples:
     await handleNotificationsCommand(trimmed.replace(/^notifications\s*/, "").trim(), ctx, pi);
     return true;
   }
+  if (trimmed === "escalate" || trimmed.startsWith("escalate ")) {
+    const { handleEscalateCommand } = await import("./escalate.js");
+    await handleEscalateCommand(trimmed.replace(/^escalate\s*/, "").trim(), ctx, pi);
+    return true;
+  }
   if (trimmed === "inspect") {
     await handleInspect(ctx);
     return true;

--- a/src/resources/extensions/gsd/db-writer.ts
+++ b/src/resources/extensions/gsd/db-writer.ts
@@ -373,6 +373,8 @@ export interface SaveDecisionFields {
   revisable?: string;
   when_context?: string;
   made_by?: import('./types.js').DecisionMadeBy;
+  /** ADR-011 Phase 2: origin of the decision — "discussion" (default), "planning", "escalation". */
+  source?: string;
 }
 
 /**
@@ -415,6 +417,7 @@ export async function saveDecisionToDb(
         rationale: fields.rationale,
         revisable: fields.revisable ?? 'Yes',
         made_by: fields.made_by ?? 'agent',
+        source: fields.source ?? 'discussion',
         superseded_by: null,
       });
 

--- a/src/resources/extensions/gsd/escalation.ts
+++ b/src/resources/extensions/gsd/escalation.ts
@@ -51,6 +51,19 @@ export function buildEscalationArtifact(params: {
   recommendationRationale: string;
   continueWithDefault: boolean;
 }): EscalationArtifact {
+  // Server-side validation — the MCP Type schema already constrains shape,
+  // but we belt-and-suspenders here so non-MCP callers can't construct
+  // malformed artifacts. These checks match readEscalationArtifact's.
+  if (!Array.isArray(params.options) || params.options.length < 2 || params.options.length > 4) {
+    throw new Error(`escalation.options must have between 2 and 4 entries (got ${params.options?.length ?? 0})`);
+  }
+  const optionIds = new Set(params.options.map((o) => o.id));
+  if (optionIds.size !== params.options.length) {
+    throw new Error("escalation.options must have unique ids");
+  }
+  if (!optionIds.has(params.recommendation)) {
+    throw new Error(`escalation.recommendation "${params.recommendation}" is not one of the option ids: ${[...optionIds].join(", ")}`);
+  }
   return {
     version: 1,
     taskId: params.taskId,
@@ -108,9 +121,29 @@ export function readEscalationArtifact(path: string): EscalationArtifact | null 
     const raw = readFileSync(path, "utf-8");
     const parsed = JSON.parse(raw) as unknown;
     if (!parsed || typeof parsed !== "object") return null;
-    const art = parsed as EscalationArtifact;
-    if (art.version !== 1 || !art.taskId || !art.question) return null;
-    return art;
+    const art = parsed as Partial<EscalationArtifact>;
+    // Full schema validation — invalid artifacts return null so downstream
+    // code (formatEscalationForDisplay, resolveEscalation, carry-forward)
+    // never crashes on malformed input.
+    if (art.version !== 1) return null;
+    if (typeof art.taskId !== "string" || art.taskId.length === 0) return null;
+    if (typeof art.sliceId !== "string" || art.sliceId.length === 0) return null;
+    if (typeof art.milestoneId !== "string" || art.milestoneId.length === 0) return null;
+    if (typeof art.question !== "string" || art.question.length === 0) return null;
+    if (!Array.isArray(art.options) || art.options.length === 0) return null;
+    for (const opt of art.options) {
+      if (!opt || typeof opt !== "object") return null;
+      const o = opt as Partial<EscalationOption>;
+      if (typeof o.id !== "string" || o.id.length === 0) return null;
+      if (typeof o.label !== "string") return null;
+      if (typeof o.tradeoffs !== "string") return null;
+    }
+    if (typeof art.recommendation !== "string") return null;
+    // Recommendation must reference a real option id.
+    if (!art.options.some((o) => o.id === art.recommendation)) return null;
+    if (typeof art.continueWithDefault !== "boolean") return null;
+    if (typeof art.createdAt !== "string") return null;
+    return art as EscalationArtifact;
   } catch {
     return null;
   }
@@ -240,20 +273,20 @@ export function claimOverrideForInjection(
 ): { injectionBlock: string; sourceTaskId: string } | null {
   const unapplied = findUnappliedEscalationOverride(milestoneId, sliceId);
   if (!unapplied) return null;
-  const claimed = claimEscalationOverride(milestoneId, sliceId, unapplied.taskId);
-  if (!claimed) return null; // lost the race
+  // Validate artifact BEFORE claiming so a missing/malformed file doesn't
+  // mark the DB row as applied (which would silently swallow the override
+  // forever). If the artifact is bad, return null without touching the row.
   const art = readEscalationArtifact(unapplied.artifactPath);
-  // We've already claimed the override in the DB but the file is missing or
-  // mid-resolution. Surface a warning so operators can unstick the row if
-  // needed — the override is effectively orphaned until a doctor/reset runs.
   if (!art) {
     logWarning(
       "tool",
-      `escalation: claim succeeded but artifact missing/malformed at ${unapplied.artifactPath} (task ${unapplied.taskId}); override will not be injected`,
+      `escalation: artifact missing/malformed at ${unapplied.artifactPath} (task ${unapplied.taskId}); skipping without claim — operator should resolve or remove the row`,
     );
     return null;
   }
   if (!art.respondedAt || !art.userChoice) return null;
+  const claimed = claimEscalationOverride(milestoneId, sliceId, unapplied.taskId);
+  if (!claimed) return null; // lost the race
   void basePath;
   return {
     injectionBlock: formatOverrideBlock(art),

--- a/src/resources/extensions/gsd/escalation.ts
+++ b/src/resources/extensions/gsd/escalation.ts
@@ -130,13 +130,18 @@ export function readEscalationArtifact(path: string): EscalationArtifact | null 
     if (typeof art.sliceId !== "string" || art.sliceId.length === 0) return null;
     if (typeof art.milestoneId !== "string" || art.milestoneId.length === 0) return null;
     if (typeof art.question !== "string" || art.question.length === 0) return null;
-    if (!Array.isArray(art.options) || art.options.length === 0) return null;
+    // Option array constraints — kept in sync with buildEscalationArtifact so
+    // a hand-edited artifact cannot be weaker than what the writer would emit.
+    if (!Array.isArray(art.options) || art.options.length < 2 || art.options.length > 4) return null;
+    const optionIds = new Set<string>();
     for (const opt of art.options) {
       if (!opt || typeof opt !== "object") return null;
       const o = opt as Partial<EscalationOption>;
       if (typeof o.id !== "string" || o.id.length === 0) return null;
       if (typeof o.label !== "string") return null;
       if (typeof o.tradeoffs !== "string") return null;
+      if (optionIds.has(o.id)) return null;
+      optionIds.add(o.id);
     }
     if (typeof art.recommendation !== "string") return null;
     // Recommendation must reference a real option id.
@@ -296,13 +301,19 @@ export function claimOverrideForInjection(
 
 function formatOverrideBlock(art: EscalationArtifact): string {
   const isReject = art.userChoice === "reject-blocker";
+  const isAccept = art.userChoice === "accept";
+  const isOptionChoice = !!art.userChoice && !isReject && !isAccept;
+  // Include the stable option id in the block so downstream prompts and
+  // parsers have a machine-readable token, not just the display label.
   const choiceLabel = isReject
     ? "rejected — blocker path"
-    : art.userChoice === "accept"
+    : isAccept
       ? `accepted recommendation (${art.recommendation})`
-      : (art.options.find((o) => o.id === art.userChoice)?.label ?? art.userChoice ?? "unknown");
+      : isOptionChoice
+        ? `${art.options.find((o) => o.id === art.userChoice)?.label ?? art.userChoice} (id: ${art.userChoice})`
+        : (art.userChoice ?? "unknown");
 
-  const tradeoffs = art.userChoice && art.userChoice !== "accept" && art.userChoice !== "reject-blocker"
+  const tradeoffs = isOptionChoice
     ? art.options.find((o) => o.id === art.userChoice)?.tradeoffs ?? ""
     : "";
 

--- a/src/resources/extensions/gsd/escalation.ts
+++ b/src/resources/extensions/gsd/escalation.ts
@@ -1,0 +1,323 @@
+// GSD Extension — ADR-011 Phase 2 Mid-Execution Escalation
+//
+// A single module that owns: escalation artifact I/O, detection, resolution,
+// carry-forward injection lookup, and audit-event emission. Scoped to
+// execute-task only (refine-slice escalation is deferred per ADR-011).
+
+import { existsSync, mkdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import type { EscalationArtifact, EscalationOption } from "./types.js";
+import { resolveSlicePath } from "./paths.js";
+import { atomicWriteSync } from "./atomic-write.js";
+import {
+  getTask,
+  setTaskEscalationPending,
+  setTaskEscalationAwaitingReview,
+  clearTaskEscalationFlags,
+  claimEscalationOverride,
+  findUnappliedEscalationOverride,
+  setTaskBlockerSource,
+  listEscalationArtifacts,
+  type TaskRow,
+} from "./gsd-db.js";
+import { emitUokAuditEvent, buildAuditEnvelope } from "./uok/audit.js";
+import { logWarning } from "./workflow-logger.js";
+
+// ─── Paths ────────────────────────────────────────────────────────────────
+
+/**
+ * Canonical escalation artifact path, parallel to T##-SUMMARY.md:
+ *   .gsd/milestones/{M}/slices/{S}/tasks/{T}-ESCALATION.json
+ */
+export function escalationArtifactPath(
+  basePath: string, milestoneId: string, sliceId: string, taskId: string,
+): string | null {
+  const sDir = resolveSlicePath(basePath, milestoneId, sliceId);
+  if (!sDir) return null;
+  return join(sDir, "tasks", `${taskId}-ESCALATION.json`);
+}
+
+// ─── Artifact I/O ─────────────────────────────────────────────────────────
+
+/** Build an EscalationArtifact from a gsd_complete_task escalation payload. */
+export function buildEscalationArtifact(params: {
+  taskId: string;
+  sliceId: string;
+  milestoneId: string;
+  question: string;
+  options: EscalationOption[];
+  recommendation: string;
+  recommendationRationale: string;
+  continueWithDefault: boolean;
+}): EscalationArtifact {
+  return {
+    version: 1,
+    taskId: params.taskId,
+    sliceId: params.sliceId,
+    milestoneId: params.milestoneId,
+    question: params.question,
+    options: params.options,
+    recommendation: params.recommendation,
+    recommendationRationale: params.recommendationRationale,
+    continueWithDefault: params.continueWithDefault,
+    createdAt: new Date().toISOString(),
+  };
+}
+
+/** Atomically write an escalation artifact and flip the appropriate DB flag. */
+export function writeEscalationArtifact(
+  basePath: string, artifact: EscalationArtifact,
+): string {
+  const path = escalationArtifactPath(basePath, artifact.milestoneId, artifact.sliceId, artifact.taskId);
+  if (!path) {
+    throw new Error(
+      `escalation: cannot resolve tasks dir for ${artifact.milestoneId}/${artifact.sliceId} — run doctor`,
+    );
+  }
+  mkdirSync(join(path, ".."), { recursive: true });
+  atomicWriteSync(path, JSON.stringify(artifact, null, 2));
+
+  if (artifact.continueWithDefault) {
+    setTaskEscalationAwaitingReview(artifact.milestoneId, artifact.sliceId, artifact.taskId, path);
+  } else {
+    setTaskEscalationPending(artifact.milestoneId, artifact.sliceId, artifact.taskId, path);
+  }
+
+  emitUokAuditEvent(basePath, buildAuditEnvelope({
+    traceId: `escalation:${artifact.milestoneId}:${artifact.sliceId}:${artifact.taskId}`,
+    category: "gate",
+    type: "escalation-manual-attention-created",
+    payload: {
+      milestoneId: artifact.milestoneId,
+      sliceId: artifact.sliceId,
+      taskId: artifact.taskId,
+      continueWithDefault: artifact.continueWithDefault,
+      optionCount: artifact.options.length,
+      recommendation: artifact.recommendation,
+    },
+  }));
+
+  return path;
+}
+
+/** Read an escalation artifact by path. Returns null when missing or malformed. */
+export function readEscalationArtifact(path: string): EscalationArtifact | null {
+  if (!existsSync(path)) return null;
+  try {
+    const raw = readFileSync(path, "utf-8");
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== "object") return null;
+    const art = parsed as EscalationArtifact;
+    if (art.version !== 1 || !art.taskId || !art.question) return null;
+    return art;
+  } catch {
+    return null;
+  }
+}
+
+// ─── Detection ────────────────────────────────────────────────────────────
+
+/**
+ * Returns the task id of the first task with an un-resolved pause-escalation
+ * (escalation_pending=1, not yet respondedAt). awaiting_review slices are NOT
+ * returned — they don't pause the loop.
+ */
+export function detectPendingEscalation(tasks: TaskRow[], basePath: string): string | null {
+  for (const t of tasks) {
+    if (t.escalation_pending !== 1) continue;
+    if (!t.escalation_artifact_path) continue;
+    const art = readEscalationArtifact(t.escalation_artifact_path);
+    if (art && !art.respondedAt) return t.id;
+  }
+  return null;
+}
+
+// ─── Resolution ───────────────────────────────────────────────────────────
+
+export interface ResolveEscalationResult {
+  status: "resolved" | "not-found" | "already-resolved" | "invalid-choice" | "rejected-to-blocker";
+  message: string;
+  artifactPath?: string;
+  chosenOption?: EscalationOption;
+}
+
+/**
+ * Apply a user response to a pending escalation:
+ *  1) Update the artifact with respondedAt/userChoice/userRationale.
+ *  2) Clear the DB escalation flags.
+ *  3) For "reject-blocker": set blocker_discovered=1 + blocker_source='reject-escalation'.
+ *  4) Emit audit events.
+ *
+ * Note: this does NOT persist a decision via saveDecisionToDb — the caller
+ * (commands/handlers/escalate.ts) owns that step so it can fail gracefully
+ * and surface the decision id in the user-visible message.
+ */
+export function resolveEscalation(
+  basePath: string, milestoneId: string, sliceId: string, taskId: string,
+  choice: string, rationale: string,
+): ResolveEscalationResult {
+  const task = getTask(milestoneId, sliceId, taskId);
+  if (!task || !task.escalation_artifact_path) {
+    return { status: "not-found", message: `No escalation artifact found for ${milestoneId}/${sliceId}/${taskId}.` };
+  }
+  const art = readEscalationArtifact(task.escalation_artifact_path);
+  if (!art) {
+    return { status: "not-found", message: `Escalation artifact at ${task.escalation_artifact_path} is missing or malformed.` };
+  }
+  if (art.respondedAt) {
+    return { status: "already-resolved", message: `Escalation for ${taskId} was already resolved at ${art.respondedAt}.` };
+  }
+
+  // Resolve `choice` into a concrete option.
+  let chosenOption: EscalationOption | undefined;
+  if (choice === "accept") {
+    chosenOption = art.options.find((o) => o.id === art.recommendation);
+  } else if (choice === "reject-blocker") {
+    // Handled below; no option selection.
+  } else {
+    chosenOption = art.options.find((o) => o.id === choice);
+    if (!chosenOption) {
+      const valid = ["accept", "reject-blocker", ...art.options.map((o) => o.id)].join(", ");
+      return { status: "invalid-choice", message: `Unknown choice "${choice}". Valid choices: ${valid}.` };
+    }
+  }
+
+  const respondedAt = new Date().toISOString();
+  const updated: EscalationArtifact = {
+    ...art,
+    respondedAt,
+    userChoice: choice,
+    userRationale: rationale,
+  };
+  atomicWriteSync(task.escalation_artifact_path, JSON.stringify(updated, null, 2));
+  clearTaskEscalationFlags(milestoneId, sliceId, taskId);
+
+  if (choice === "reject-blocker") {
+    setTaskBlockerSource(milestoneId, sliceId, taskId, "reject-escalation");
+    emitUokAuditEvent(basePath, buildAuditEnvelope({
+      traceId: `escalation:${milestoneId}:${sliceId}:${taskId}`,
+      category: "gate",
+      type: "escalation-rejected-to-blocker",
+      payload: { milestoneId, sliceId, taskId, rationale },
+    }));
+    return {
+      status: "rejected-to-blocker",
+      message: `Escalation rejected. Task ${taskId} now flagged as a blocker — next /gsd auto will replan slice ${sliceId}.`,
+      artifactPath: task.escalation_artifact_path,
+    };
+  }
+
+  emitUokAuditEvent(basePath, buildAuditEnvelope({
+    traceId: `escalation:${milestoneId}:${sliceId}:${taskId}`,
+    category: "gate",
+    type: "escalation-user-responded",
+    payload: {
+      milestoneId, sliceId, taskId,
+      chosenOptionId: chosenOption?.id,
+      rationale,
+    },
+  }));
+
+  return {
+    status: "resolved",
+    message: `Escalation resolved. Next task in ${sliceId} will receive the override.`,
+    artifactPath: task.escalation_artifact_path,
+    chosenOption,
+  };
+}
+
+// ─── Carry-forward lookup ─────────────────────────────────────────────────
+
+/**
+ * If this slice has a resolved-but-unapplied escalation override, atomically
+ * claim it (via DB UPDATE) and return the markdown block to prepend to the
+ * next task's prompt. Returns null when there's no unapplied override OR
+ * when another caller claimed it first (idempotent).
+ */
+export function claimOverrideForInjection(
+  basePath: string, milestoneId: string, sliceId: string,
+): { injectionBlock: string; sourceTaskId: string } | null {
+  const unapplied = findUnappliedEscalationOverride(milestoneId, sliceId);
+  if (!unapplied) return null;
+  const claimed = claimEscalationOverride(milestoneId, sliceId, unapplied.taskId);
+  if (!claimed) return null; // lost the race
+  const art = readEscalationArtifact(unapplied.artifactPath);
+  // We've already claimed the override in the DB but the file is missing or
+  // mid-resolution. Surface a warning so operators can unstick the row if
+  // needed — the override is effectively orphaned until a doctor/reset runs.
+  if (!art) {
+    logWarning(
+      "escalation",
+      `claim succeeded but artifact missing/malformed at ${unapplied.artifactPath} (task ${unapplied.taskId}); override will not be injected`,
+    );
+    return null;
+  }
+  if (!art.respondedAt || !art.userChoice) return null;
+  void basePath;
+  return {
+    injectionBlock: formatOverrideBlock(art),
+    sourceTaskId: unapplied.taskId,
+  };
+}
+
+function formatOverrideBlock(art: EscalationArtifact): string {
+  const isReject = art.userChoice === "reject-blocker";
+  const choiceLabel = isReject
+    ? "rejected — blocker path"
+    : art.userChoice === "accept"
+      ? `accepted recommendation (${art.recommendation})`
+      : (art.options.find((o) => o.id === art.userChoice)?.label ?? art.userChoice ?? "unknown");
+
+  const tradeoffs = art.userChoice && art.userChoice !== "accept" && art.userChoice !== "reject-blocker"
+    ? art.options.find((o) => o.id === art.userChoice)?.tradeoffs ?? ""
+    : "";
+
+  const rationale = art.userRationale ? `\n\n**User rationale:** ${art.userRationale}` : "";
+
+  return [
+    `## Escalation Override (from ${art.taskId})`,
+    "",
+    `During ${art.taskId} the executor escalated: **${art.question}**`,
+    "",
+    `The user's resolution: **${choiceLabel}**.${rationale}`,
+    tradeoffs ? `\n**Tradeoffs of this choice:** ${tradeoffs}` : "",
+    "",
+    "Apply this decision as a hard constraint for the current task. If it contradicts the task plan, surface the conflict in your summary rather than silently deviating.",
+  ].filter((line) => line !== undefined).join("\n");
+}
+
+// ─── Display ──────────────────────────────────────────────────────────────
+
+/** Human-readable summary of an artifact for `/gsd escalate show`. */
+export function formatEscalationForDisplay(art: EscalationArtifact): string {
+  const resolved = art.respondedAt
+    ? `\nResolved: ${art.respondedAt} — user chose "${art.userChoice}"${art.userRationale ? ` (rationale: ${art.userRationale})` : ""}`
+    : "\nStatus: awaiting user response";
+  const optionLines = art.options.map((o) =>
+    `  [${o.id}] ${o.label}${o.id === art.recommendation ? "  (recommended)" : ""}\n      ${o.tradeoffs}`,
+  ).join("\n");
+  return [
+    `Task ${art.taskId} (slice ${art.sliceId})`,
+    `continueWithDefault: ${art.continueWithDefault}`,
+    `Question: ${art.question}`,
+    "",
+    "Options:",
+    optionLines,
+    "",
+    `Recommendation: ${art.recommendation} — ${art.recommendationRationale}`,
+    resolved,
+    "",
+    `Resolve with: /gsd escalate resolve ${art.taskId} <${art.options.map((o) => o.id).join("|")}|accept|reject-blocker> [rationale...]`,
+  ].join("\n");
+}
+
+/** List actionable (unresolved) escalations for `/gsd escalate list`. */
+export function listActionableEscalations(milestoneId: string): TaskRow[] {
+  return listEscalationArtifacts(milestoneId, /* includeResolved */ false);
+}
+
+/** List every escalation (including resolved) for `/gsd escalate list --all`. */
+export function listAllEscalations(milestoneId: string): TaskRow[] {
+  return listEscalationArtifacts(milestoneId, /* includeResolved */ true);
+}

--- a/src/resources/extensions/gsd/escalation.ts
+++ b/src/resources/extensions/gsd/escalation.ts
@@ -248,8 +248,8 @@ export function claimOverrideForInjection(
   // needed — the override is effectively orphaned until a doctor/reset runs.
   if (!art) {
     logWarning(
-      "escalation",
-      `claim succeeded but artifact missing/malformed at ${unapplied.artifactPath} (task ${unapplied.taskId}); override will not be injected`,
+      "tool",
+      `escalation: claim succeeded but artifact missing/malformed at ${unapplied.artifactPath} (task ${unapplied.taskId}); override will not be injected`,
     );
     return null;
   }

--- a/src/resources/extensions/gsd/gsd-db.ts
+++ b/src/resources/extensions/gsd/gsd-db.ts
@@ -531,6 +531,9 @@ function initSchema(db: DbAdapter, fileBacked: boolean): void {
     db.exec("CREATE INDEX IF NOT EXISTS idx_turn_git_tx_turn ON turn_git_transactions(trace_id, turn_id)");
     db.exec("CREATE INDEX IF NOT EXISTS idx_audit_events_trace ON audit_events(trace_id, ts)");
     db.exec("CREATE INDEX IF NOT EXISTS idx_audit_events_turn ON audit_events(trace_id, turn_id, ts)");
+    // ADR-011 Phase 2 — also created by the v17 migration; fresh installs
+    // skip migrations so the index must be created here too.
+    db.exec("CREATE INDEX IF NOT EXISTS idx_tasks_escalation_pending ON tasks(milestone_id, slice_id, escalation_pending)");
 
     db.exec(`CREATE VIEW IF NOT EXISTS active_decisions AS SELECT * FROM decisions WHERE superseded_by IS NULL`);
     db.exec(`CREATE VIEW IF NOT EXISTS active_requirements AS SELECT * FROM requirements WHERE superseded_by IS NULL`);
@@ -3179,14 +3182,16 @@ export function restoreManifest(manifest: StateManifest): void {
       );
     }
 
-    // Restore tasks
+    // Restore tasks (ADR-011 P2: includes blocker_source + escalation_* columns)
     const tkStmt = db.prepare(
       `INSERT INTO tasks (milestone_id, slice_id, id, title, status,
         one_liner, narrative, verification_result, duration, completed_at,
         blocker_discovered, deviations, known_issues, key_files, key_decisions,
         full_summary_md, description, estimate, files, verify,
-        inputs, expected_output, observability_impact, sequence)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        inputs, expected_output, observability_impact, sequence,
+        blocker_source, escalation_pending, escalation_awaiting_review,
+        escalation_artifact_path, escalation_override_applied_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     );
     for (const t of manifest.tasks) {
       tkStmt.run(
@@ -3197,16 +3202,21 @@ export function restoreManifest(manifest: StateManifest): void {
         t.full_summary_md, t.description, t.estimate, JSON.stringify(t.files), t.verify,
         JSON.stringify(t.inputs), JSON.stringify(t.expected_output),
         t.observability_impact, t.sequence,
+        t.blocker_source ?? "",
+        t.escalation_pending ?? 0,
+        t.escalation_awaiting_review ?? 0,
+        t.escalation_artifact_path ?? null,
+        t.escalation_override_applied_at ?? null,
       );
     }
 
-    // Restore decisions
+    // Restore decisions (ADR-011 P2: include source so escalation decisions survive)
     const dcStmt = db.prepare(
-      `INSERT INTO decisions (seq, id, when_context, scope, decision, choice, rationale, revisable, made_by, superseded_by)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      `INSERT INTO decisions (seq, id, when_context, scope, decision, choice, rationale, revisable, made_by, source, superseded_by)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     );
     for (const d of manifest.decisions) {
-      dcStmt.run(d.seq, d.id, d.when_context, d.scope, d.decision, d.choice, d.rationale, d.revisable, d.made_by, d.superseded_by);
+      dcStmt.run(d.seq, d.id, d.when_context, d.scope, d.decision, d.choice, d.rationale, d.revisable, d.made_by, d.source ?? "discussion", d.superseded_by);
     }
 
     // Restore verification evidence

--- a/src/resources/extensions/gsd/gsd-db.ts
+++ b/src/resources/extensions/gsd/gsd-db.ts
@@ -180,7 +180,7 @@ function openRawDb(path: string): unknown {
   return new Database(path);
 }
 
-const SCHEMA_VERSION = 15;
+const SCHEMA_VERSION = 16;
 
 function indexExists(db: DbAdapter, name: string): boolean {
   return !!db.prepare(
@@ -334,6 +334,8 @@ function initSchema(db: DbAdapter, fileBacked: boolean): void {
         observability_impact TEXT NOT NULL DEFAULT '',
         sequence INTEGER DEFAULT 0, -- Ordering hint: tools may set this to control execution order
         replan_triggered_at TEXT DEFAULT NULL,
+        is_sketch INTEGER NOT NULL DEFAULT 0, -- ADR-011: 1 = slice is a sketch awaiting refinement
+        sketch_scope TEXT NOT NULL DEFAULT '', -- ADR-011: 2-3 sentence rough scope from plan-milestone
         PRIMARY KEY (milestone_id, id),
         FOREIGN KEY (milestone_id) REFERENCES milestones(id)
       )
@@ -951,6 +953,16 @@ function migrateSchema(db: DbAdapter): void {
       });
     }
 
+    if (currentVersion < 16) {
+      // ADR-011: sketch-then-refine progressive planning
+      ensureColumn(db, "slices", "is_sketch", `ALTER TABLE slices ADD COLUMN is_sketch INTEGER NOT NULL DEFAULT 0`);
+      ensureColumn(db, "slices", "sketch_scope", `ALTER TABLE slices ADD COLUMN sketch_scope TEXT NOT NULL DEFAULT ''`);
+      db.prepare("INSERT INTO schema_version (version, applied_at) VALUES (:version, :applied_at)").run({
+        ":version": 16,
+        ":applied_at": new Date().toISOString(),
+      });
+    }
+
     db.exec("COMMIT");
   } catch (err) {
     db.exec("ROLLBACK");
@@ -1455,16 +1467,20 @@ export function insertSlice(s: {
   depends?: string[];
   demo?: string;
   sequence?: number;
+  isSketch?: boolean;
+  sketchScope?: string;
   planning?: Partial<SlicePlanningRecord>;
 }): void {
   if (!currentDb) throw new GSDError(GSD_STALE_STATE, "gsd-db: No database open");
   currentDb.prepare(
     `INSERT INTO slices (
       milestone_id, id, title, status, risk, depends, demo, created_at,
-      goal, success_criteria, proof_level, integration_closure, observability_impact, sequence
+      goal, success_criteria, proof_level, integration_closure, observability_impact, sequence,
+      is_sketch, sketch_scope
     ) VALUES (
       :milestone_id, :id, :title, :status, :risk, :depends, :demo, :created_at,
-      :goal, :success_criteria, :proof_level, :integration_closure, :observability_impact, :sequence
+      :goal, :success_criteria, :proof_level, :integration_closure, :observability_impact, :sequence,
+      :is_sketch, :sketch_scope
     )
     ON CONFLICT (milestone_id, id) DO UPDATE SET
       title = CASE WHEN :raw_title IS NOT NULL THEN excluded.title ELSE slices.title END,
@@ -1477,7 +1493,9 @@ export function insertSlice(s: {
       proof_level = CASE WHEN :raw_proof_level IS NOT NULL THEN excluded.proof_level ELSE slices.proof_level END,
       integration_closure = CASE WHEN :raw_integration_closure IS NOT NULL THEN excluded.integration_closure ELSE slices.integration_closure END,
       observability_impact = CASE WHEN :raw_observability_impact IS NOT NULL THEN excluded.observability_impact ELSE slices.observability_impact END,
-      sequence = CASE WHEN :raw_sequence IS NOT NULL THEN excluded.sequence ELSE slices.sequence END`,
+      sequence = CASE WHEN :raw_sequence IS NOT NULL THEN excluded.sequence ELSE slices.sequence END,
+      is_sketch = CASE WHEN :raw_is_sketch IS NOT NULL THEN excluded.is_sketch ELSE slices.is_sketch END,
+      sketch_scope = CASE WHEN :raw_sketch_scope IS NOT NULL THEN excluded.sketch_scope ELSE slices.sketch_scope END`,
   ).run({
     ":milestone_id": s.milestoneId,
     ":id": s.id,
@@ -1493,6 +1511,8 @@ export function insertSlice(s: {
     ":integration_closure": s.planning?.integrationClosure ?? "",
     ":observability_impact": s.planning?.observabilityImpact ?? "",
     ":sequence": s.sequence ?? 0,
+    ":is_sketch": s.isSketch ? 1 : 0,
+    ":sketch_scope": s.sketchScope ?? "",
     // Raw sentinel params: NULL when caller omitted the field, used in ON CONFLICT guards
     ":raw_title": s.title ?? null,
     ":raw_risk": s.risk ?? null,
@@ -1503,7 +1523,50 @@ export function insertSlice(s: {
     ":raw_integration_closure": s.planning?.integrationClosure ?? null,
     ":raw_observability_impact": s.planning?.observabilityImpact ?? null,
     ":raw_sequence": s.sequence ?? null,
+    ":raw_is_sketch": s.isSketch === undefined ? null : (s.isSketch ? 1 : 0),
+    // NOTE: use !== undefined (not ??) so an explicit empty string "" is treated
+    // as a present value and correctly clears the existing sketch_scope on
+    // CONFLICT. ?? would incorrectly preserve the stale value.
+    ":raw_sketch_scope": s.sketchScope !== undefined ? s.sketchScope : null,
   });
+}
+
+// ADR-011: sketch-then-refine helpers
+export function setSliceSketchFlag(milestoneId: string, sliceId: string, isSketch: boolean): void {
+  if (!currentDb) throw new GSDError(GSD_STALE_STATE, "gsd-db: No database open");
+  currentDb.prepare(
+    `UPDATE slices SET is_sketch = :is_sketch WHERE milestone_id = :mid AND id = :sid`,
+  ).run({ ":is_sketch": isSketch ? 1 : 0, ":mid": milestoneId, ":sid": sliceId });
+}
+
+/**
+ * ADR-011 auto-heal: reconcile stale is_sketch=1 rows whose PLAN already exists.
+ *
+ * Callers pass a predicate that resolves whether a plan file exists for a slice.
+ * The predicate MUST use the canonical path resolver (`resolveSliceFile`, etc.)
+ * to keep path logic in one place — do not hand-roll the path inside the callback.
+ *
+ * Recovers from two scenarios:
+ *   1. Crash between `gsd_plan_slice` write and the sketch flag flip.
+ *   2. Flag-OFF downgrade path: when `progressive_planning` is off, the dispatch
+ *      rule routes sketch slices to plan-slice, which writes PLAN.md but leaves
+ *      `is_sketch=1` — the next state derivation auto-heals it to 0 here.
+ *
+ * Not aggressive in practice: PLAN.md is only written via the DB-backed
+ * `gsd_plan_slice` tool (which also inserts tasks), so a "stale PLAN.md with
+ * is_sketch=1" is extremely unlikely to indicate anything other than the two
+ * recovery scenarios above.
+ */
+export function autoHealSketchFlags(milestoneId: string, hasPlanFile: (sliceId: string) => boolean): void {
+  if (!currentDb) return;
+  const rows = currentDb.prepare(
+    `SELECT id FROM slices WHERE milestone_id = :mid AND is_sketch = 1`,
+  ).all({ ":mid": milestoneId }) as Array<{ id: string }>;
+  for (const row of rows) {
+    if (hasPlanFile(row.id)) {
+      setSliceSketchFlag(milestoneId, row.id, false);
+    }
+  }
 }
 
 export function upsertSlicePlanning(milestoneId: string, sliceId: string, planning: Partial<SlicePlanningRecord>): void {
@@ -1679,6 +1742,8 @@ export interface SliceRow {
   observability_impact: string;
   sequence: number;
   replan_triggered_at: string | null;
+  is_sketch: number;
+  sketch_scope: string;
 }
 
 function rowToSlice(row: Record<string, unknown>): SliceRow {
@@ -1701,6 +1766,8 @@ function rowToSlice(row: Record<string, unknown>): SliceRow {
     observability_impact: (row["observability_impact"] as string) ?? "",
     sequence: (row["sequence"] as number) ?? 0,
     replan_triggered_at: (row["replan_triggered_at"] as string) ?? null,
+    is_sketch: (row["is_sketch"] as number) ?? 0,
+    sketch_scope: (row["sketch_scope"] as string) ?? "",
   };
 }
 

--- a/src/resources/extensions/gsd/gsd-db.ts
+++ b/src/resources/extensions/gsd/gsd-db.ts
@@ -1964,7 +1964,7 @@ export function getSliceTasks(milestoneId: string, sliceId: string): TaskRow[] {
 
 // ─── ADR-011 Phase 2 escalation helpers ──────────────────────────────────
 
-/** Set pause-on-escalation state on a completed task. */
+/** Set pause-on-escalation state on a completed task. Mutually exclusive with awaiting_review. */
 export function setTaskEscalationPending(
   milestoneId: string, sliceId: string, taskId: string,
   artifactPath: string,
@@ -1973,12 +1973,13 @@ export function setTaskEscalationPending(
   currentDb.prepare(
     `UPDATE tasks
        SET escalation_pending = 1,
+           escalation_awaiting_review = 0,
            escalation_artifact_path = :path
      WHERE milestone_id = :mid AND slice_id = :sid AND id = :tid`,
   ).run({ ":path": artifactPath, ":mid": milestoneId, ":sid": sliceId, ":tid": taskId });
 }
 
-/** Set awaiting-review state (artifact exists but continueWithDefault=true, no pause). */
+/** Set awaiting-review state (artifact exists but continueWithDefault=true, no pause). Mutually exclusive with pending. */
 export function setTaskEscalationAwaitingReview(
   milestoneId: string, sliceId: string, taskId: string,
   artifactPath: string,
@@ -1987,6 +1988,7 @@ export function setTaskEscalationAwaitingReview(
   currentDb.prepare(
     `UPDATE tasks
        SET escalation_awaiting_review = 1,
+           escalation_pending = 0,
            escalation_artifact_path = :path
      WHERE milestone_id = :mid AND slice_id = :sid AND id = :tid`,
   ).run({ ":path": artifactPath, ":mid": milestoneId, ":sid": sliceId, ":tid": taskId });
@@ -2392,8 +2394,13 @@ export function reconcileWorktreeDb(
     try {
       const wtInfo = adapter.prepare("PRAGMA wt.table_info('decisions')").all();
       const hasMadeBy = wtInfo.some((col) => col["name"] === "made_by");
-      // ADR-011 P2: worktree may predate schema v16/v17; fall back to defaults when columns are missing.
+      // ADR-011: worktree may predate schema v16/v17. For missing columns we
+      // fall through to the main DB's existing value (not a literal default)
+      // so reconcile never silently clears state the main tree has recorded.
       const hasDecisionSource = wtInfo.some((col) => col["name"] === "source");
+      const wtSliceInfo = adapter.prepare("PRAGMA wt.table_info('slices')").all();
+      const hasIsSketch = wtSliceInfo.some((col) => col["name"] === "is_sketch");
+      const hasSketchScope = wtSliceInfo.some((col) => col["name"] === "sketch_scope");
       const wtTaskInfo = adapter.prepare("PRAGMA wt.table_info('tasks')").all();
       const hasBlockerSource = wtTaskInfo.some((col) => col["name"] === "blocker_source");
       const hasEscalationPending = wtTaskInfo.some((col) => col["name"] === "escalation_pending");
@@ -2421,15 +2428,20 @@ export function reconcileWorktreeDb(
 
       adapter.exec("BEGIN");
       try {
+        // Join the target decisions so we can prefer an existing main.source
+        // when the worktree predates v16 — otherwise a write-through reconcile
+        // would clobber 'escalation'-sourced decisions with the literal default.
         merged.decisions = countChanges(adapter.prepare(`
           INSERT OR REPLACE INTO decisions (
             id, when_context, scope, decision, choice, rationale, revisable, made_by, source, superseded_by
           )
-          SELECT id, when_context, scope, decision, choice, rationale, revisable, ${
-            hasMadeBy ? "made_by" : "'agent'"
+          SELECT w.id, w.when_context, w.scope, w.decision, w.choice, w.rationale, w.revisable, ${
+            hasMadeBy ? "w.made_by" : "COALESCE(m.made_by, 'agent')"
           }, ${
-            hasDecisionSource ? "source" : "'discussion'"
-          }, superseded_by FROM wt.decisions
+            hasDecisionSource ? "w.source" : "COALESCE(m.source, 'discussion')"
+          }, w.superseded_by
+          FROM wt.decisions w
+          LEFT JOIN decisions m ON m.id = w.id
         `).run());
 
         merged.requirements = countChanges(adapter.prepare(`
@@ -2466,13 +2478,15 @@ export function reconcileWorktreeDb(
         `).run());
 
         // Merge slices — preserve worktree progress but never downgrade completed status (#2558).
-        // Uses INSERT OR REPLACE with a subquery that picks the best status — if the main DB
-        // already has a completed slice, keep that status even if the worktree copy is stale.
+        // ADR-011 Phase 1: carry is_sketch + sketch_scope so reconcile doesn't
+        // silently clear sketch metadata. When the worktree predates v16,
+        // fall back to the main DB's existing value rather than a literal 0/''.
         merged.slices = countChanges(adapter.prepare(`
           INSERT OR REPLACE INTO slices (
             milestone_id, id, title, status, risk, depends, demo, created_at, completed_at,
             full_summary_md, full_uat_md, goal, success_criteria, proof_level,
-            integration_closure, observability_impact, sequence, replan_triggered_at
+            integration_closure, observability_impact, sequence, replan_triggered_at,
+            is_sketch, sketch_scope
           )
           SELECT w.milestone_id, w.id, w.title,
                  CASE
@@ -2485,7 +2499,9 @@ export function reconcileWorktreeDb(
                    THEN m.completed_at ELSE w.completed_at
                  END,
                  w.full_summary_md, w.full_uat_md, w.goal, w.success_criteria, w.proof_level,
-                 w.integration_closure, w.observability_impact, w.sequence, w.replan_triggered_at
+                 w.integration_closure, w.observability_impact, w.sequence, w.replan_triggered_at,
+                 ${hasIsSketch ? "w.is_sketch" : "COALESCE(m.is_sketch, 0)"},
+                 ${hasSketchScope ? "w.sketch_scope" : "COALESCE(m.sketch_scope, '')"}
           FROM wt.slices w
           LEFT JOIN slices m ON m.milestone_id = w.milestone_id AND m.id = w.id
         `).run());
@@ -2518,11 +2534,11 @@ export function reconcileWorktreeDb(
                  w.deviations, w.known_issues, w.key_files, w.key_decisions, w.full_summary_md,
                  w.description, w.estimate, w.files, w.verify, w.inputs, w.expected_output,
                  w.observability_impact, w.full_plan_md, w.sequence,
-                 ${hasBlockerSource ? "w.blocker_source" : "''"},
-                 ${hasEscalationPending ? "w.escalation_pending" : "0"},
-                 ${hasEscalationAwaiting ? "w.escalation_awaiting_review" : "0"},
-                 ${hasEscalationArtifact ? "w.escalation_artifact_path" : "NULL"},
-                 ${hasEscalationOverride ? "w.escalation_override_applied_at" : "NULL"}
+                 ${hasBlockerSource ? "w.blocker_source" : "COALESCE(m.blocker_source, '')"},
+                 ${hasEscalationPending ? "w.escalation_pending" : "COALESCE(m.escalation_pending, 0)"},
+                 ${hasEscalationAwaiting ? "w.escalation_awaiting_review" : "COALESCE(m.escalation_awaiting_review, 0)"},
+                 ${hasEscalationArtifact ? "w.escalation_artifact_path" : "m.escalation_artifact_path"},
+                 ${hasEscalationOverride ? "w.escalation_override_applied_at" : "m.escalation_override_applied_at"}
           FROM wt.tasks w
           LEFT JOIN tasks m ON m.milestone_id = w.milestone_id AND m.slice_id = w.slice_id AND m.id = w.id
         `).run());
@@ -3244,13 +3260,13 @@ export function restoreManifest(manifest: StateManifest): void {
       );
     }
 
-    // Restore slices
+    // Restore slices (ADR-011 Phase 1: includes is_sketch + sketch_scope)
     const slStmt = db.prepare(
       `INSERT INTO slices (milestone_id, id, title, status, risk, depends, demo,
         created_at, completed_at, full_summary_md, full_uat_md,
         goal, success_criteria, proof_level, integration_closure, observability_impact,
-        sequence, replan_triggered_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        sequence, replan_triggered_at, is_sketch, sketch_scope)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     );
     for (const s of manifest.slices) {
       slStmt.run(
@@ -3259,6 +3275,8 @@ export function restoreManifest(manifest: StateManifest): void {
         s.created_at, s.completed_at, s.full_summary_md, s.full_uat_md,
         s.goal, s.success_criteria, s.proof_level, s.integration_closure, s.observability_impact,
         s.sequence, s.replan_triggered_at,
+        s.is_sketch ?? 0,
+        s.sketch_scope ?? "",
       );
     }
 

--- a/src/resources/extensions/gsd/gsd-db.ts
+++ b/src/resources/extensions/gsd/gsd-db.ts
@@ -1207,6 +1207,7 @@ export function getActiveDecisions(): Decision[] {
     rationale: row["rationale"] as string,
     revisable: row["revisable"] as string,
     made_by: (row["made_by"] as string as import("./types.js").DecisionMadeBy) ?? "agent",
+    source: (row["source"] as string) ?? "discussion",
     superseded_by: null,
   }));
 }
@@ -2331,6 +2332,14 @@ export function reconcileWorktreeDb(
     try {
       const wtInfo = adapter.prepare("PRAGMA wt.table_info('decisions')").all();
       const hasMadeBy = wtInfo.some((col) => col["name"] === "made_by");
+      // ADR-011 P2: worktree may predate schema v16/v17; fall back to defaults when columns are missing.
+      const hasDecisionSource = wtInfo.some((col) => col["name"] === "source");
+      const wtTaskInfo = adapter.prepare("PRAGMA wt.table_info('tasks')").all();
+      const hasBlockerSource = wtTaskInfo.some((col) => col["name"] === "blocker_source");
+      const hasEscalationPending = wtTaskInfo.some((col) => col["name"] === "escalation_pending");
+      const hasEscalationAwaiting = wtTaskInfo.some((col) => col["name"] === "escalation_awaiting_review");
+      const hasEscalationArtifact = wtTaskInfo.some((col) => col["name"] === "escalation_artifact_path");
+      const hasEscalationOverride = wtTaskInfo.some((col) => col["name"] === "escalation_override_applied_at");
 
       const decConf = adapter.prepare(
         `SELECT m.id FROM decisions m INNER JOIN wt.decisions w ON m.id = w.id WHERE m.decision != w.decision OR m.choice != w.choice OR m.rationale != w.rationale OR ${
@@ -2354,10 +2363,12 @@ export function reconcileWorktreeDb(
       try {
         merged.decisions = countChanges(adapter.prepare(`
           INSERT OR REPLACE INTO decisions (
-            id, when_context, scope, decision, choice, rationale, revisable, made_by, superseded_by
+            id, when_context, scope, decision, choice, rationale, revisable, made_by, source, superseded_by
           )
           SELECT id, when_context, scope, decision, choice, rationale, revisable, ${
             hasMadeBy ? "made_by" : "'agent'"
+          }, ${
+            hasDecisionSource ? "source" : "'discussion'"
           }, superseded_by FROM wt.decisions
         `).run());
 
@@ -2419,14 +2430,18 @@ export function reconcileWorktreeDb(
           LEFT JOIN slices m ON m.milestone_id = w.milestone_id AND m.id = w.id
         `).run());
 
-        // Merge tasks — preserve execution results, never downgrade completed status (#2558)
+        // Merge tasks — preserve execution results, never downgrade completed status (#2558).
+        // ADR-011 P2: carry blocker_source + escalation_* columns so worktree reconcile
+        // doesn't silently clear escalation state back to defaults.
         merged.tasks = countChanges(adapter.prepare(`
           INSERT OR REPLACE INTO tasks (
             milestone_id, slice_id, id, title, status, one_liner, narrative,
             verification_result, duration, completed_at, blocker_discovered,
             deviations, known_issues, key_files, key_decisions, full_summary_md,
             description, estimate, files, verify, inputs, expected_output,
-            observability_impact, full_plan_md, sequence
+            observability_impact, full_plan_md, sequence,
+            blocker_source, escalation_pending, escalation_awaiting_review,
+            escalation_artifact_path, escalation_override_applied_at
           )
           SELECT w.milestone_id, w.slice_id, w.id, w.title,
                  CASE
@@ -2442,7 +2457,12 @@ export function reconcileWorktreeDb(
                  w.blocker_discovered,
                  w.deviations, w.known_issues, w.key_files, w.key_decisions, w.full_summary_md,
                  w.description, w.estimate, w.files, w.verify, w.inputs, w.expected_output,
-                 w.observability_impact, w.full_plan_md, w.sequence
+                 w.observability_impact, w.full_plan_md, w.sequence,
+                 ${hasBlockerSource ? "w.blocker_source" : "''"},
+                 ${hasEscalationPending ? "w.escalation_pending" : "0"},
+                 ${hasEscalationAwaiting ? "w.escalation_awaiting_review" : "0"},
+                 ${hasEscalationArtifact ? "w.escalation_artifact_path" : "NULL"},
+                 ${hasEscalationOverride ? "w.escalation_override_applied_at" : "NULL"}
           FROM wt.tasks w
           LEFT JOIN tasks m ON m.milestone_id = w.milestone_id AND m.slice_id = w.slice_id AND m.id = w.id
         `).run());

--- a/src/resources/extensions/gsd/gsd-db.ts
+++ b/src/resources/extensions/gsd/gsd-db.ts
@@ -335,6 +335,8 @@ function initSchema(db: DbAdapter, fileBacked: boolean): void {
         observability_impact TEXT NOT NULL DEFAULT '',
         sequence INTEGER DEFAULT 0, -- Ordering hint: tools may set this to control execution order
         replan_triggered_at TEXT DEFAULT NULL,
+        is_sketch INTEGER NOT NULL DEFAULT 0, -- ADR-011: 1 = slice is a sketch awaiting refinement
+        sketch_scope TEXT NOT NULL DEFAULT '', -- ADR-011: 2-3 sentence rough scope from plan-milestone
         PRIMARY KEY (milestone_id, id),
         FOREIGN KEY (milestone_id) REFERENCES milestones(id)
       )
@@ -961,6 +963,9 @@ function migrateSchema(db: DbAdapter): void {
     }
 
     if (currentVersion < 16) {
+      // ADR-011 Phase 1: sketch-then-refine progressive planning — sketch columns on slices.
+      ensureColumn(db, "slices", "is_sketch", `ALTER TABLE slices ADD COLUMN is_sketch INTEGER NOT NULL DEFAULT 0`);
+      ensureColumn(db, "slices", "sketch_scope", `ALTER TABLE slices ADD COLUMN sketch_scope TEXT NOT NULL DEFAULT ''`);
       // ADR-011 Phase 2: decisions can now be sourced from escalation resolutions.
       ensureColumn(db, "decisions", "source", `ALTER TABLE decisions ADD COLUMN source TEXT NOT NULL DEFAULT 'discussion'`);
       db.prepare("INSERT INTO schema_version (version, applied_at) VALUES (:version, :applied_at)").run({
@@ -1492,16 +1497,20 @@ export function insertSlice(s: {
   depends?: string[];
   demo?: string;
   sequence?: number;
+  isSketch?: boolean;
+  sketchScope?: string;
   planning?: Partial<SlicePlanningRecord>;
 }): void {
   if (!currentDb) throw new GSDError(GSD_STALE_STATE, "gsd-db: No database open");
   currentDb.prepare(
     `INSERT INTO slices (
       milestone_id, id, title, status, risk, depends, demo, created_at,
-      goal, success_criteria, proof_level, integration_closure, observability_impact, sequence
+      goal, success_criteria, proof_level, integration_closure, observability_impact, sequence,
+      is_sketch, sketch_scope
     ) VALUES (
       :milestone_id, :id, :title, :status, :risk, :depends, :demo, :created_at,
-      :goal, :success_criteria, :proof_level, :integration_closure, :observability_impact, :sequence
+      :goal, :success_criteria, :proof_level, :integration_closure, :observability_impact, :sequence,
+      :is_sketch, :sketch_scope
     )
     ON CONFLICT (milestone_id, id) DO UPDATE SET
       title = CASE WHEN :raw_title IS NOT NULL THEN excluded.title ELSE slices.title END,
@@ -1514,7 +1523,9 @@ export function insertSlice(s: {
       proof_level = CASE WHEN :raw_proof_level IS NOT NULL THEN excluded.proof_level ELSE slices.proof_level END,
       integration_closure = CASE WHEN :raw_integration_closure IS NOT NULL THEN excluded.integration_closure ELSE slices.integration_closure END,
       observability_impact = CASE WHEN :raw_observability_impact IS NOT NULL THEN excluded.observability_impact ELSE slices.observability_impact END,
-      sequence = CASE WHEN :raw_sequence IS NOT NULL THEN excluded.sequence ELSE slices.sequence END`,
+      sequence = CASE WHEN :raw_sequence IS NOT NULL THEN excluded.sequence ELSE slices.sequence END,
+      is_sketch = CASE WHEN :raw_is_sketch IS NOT NULL THEN excluded.is_sketch ELSE slices.is_sketch END,
+      sketch_scope = CASE WHEN :raw_sketch_scope IS NOT NULL THEN excluded.sketch_scope ELSE slices.sketch_scope END`,
   ).run({
     ":milestone_id": s.milestoneId,
     ":id": s.id,
@@ -1530,6 +1541,8 @@ export function insertSlice(s: {
     ":integration_closure": s.planning?.integrationClosure ?? "",
     ":observability_impact": s.planning?.observabilityImpact ?? "",
     ":sequence": s.sequence ?? 0,
+    ":is_sketch": s.isSketch ? 1 : 0,
+    ":sketch_scope": s.sketchScope ?? "",
     // Raw sentinel params: NULL when caller omitted the field, used in ON CONFLICT guards
     ":raw_title": s.title ?? null,
     ":raw_risk": s.risk ?? null,
@@ -1540,7 +1553,50 @@ export function insertSlice(s: {
     ":raw_integration_closure": s.planning?.integrationClosure ?? null,
     ":raw_observability_impact": s.planning?.observabilityImpact ?? null,
     ":raw_sequence": s.sequence ?? null,
+    ":raw_is_sketch": s.isSketch === undefined ? null : (s.isSketch ? 1 : 0),
+    // NOTE: use !== undefined (not ??) so an explicit empty string "" is treated
+    // as a present value and correctly clears the existing sketch_scope on
+    // CONFLICT. ?? would incorrectly preserve the stale value.
+    ":raw_sketch_scope": s.sketchScope !== undefined ? s.sketchScope : null,
   });
+}
+
+// ADR-011: sketch-then-refine helpers
+export function setSliceSketchFlag(milestoneId: string, sliceId: string, isSketch: boolean): void {
+  if (!currentDb) throw new GSDError(GSD_STALE_STATE, "gsd-db: No database open");
+  currentDb.prepare(
+    `UPDATE slices SET is_sketch = :is_sketch WHERE milestone_id = :mid AND id = :sid`,
+  ).run({ ":is_sketch": isSketch ? 1 : 0, ":mid": milestoneId, ":sid": sliceId });
+}
+
+/**
+ * ADR-011 auto-heal: reconcile stale is_sketch=1 rows whose PLAN already exists.
+ *
+ * Callers pass a predicate that resolves whether a plan file exists for a slice.
+ * The predicate MUST use the canonical path resolver (`resolveSliceFile`, etc.)
+ * to keep path logic in one place — do not hand-roll the path inside the callback.
+ *
+ * Recovers from two scenarios:
+ *   1. Crash between `gsd_plan_slice` write and the sketch flag flip.
+ *   2. Flag-OFF downgrade path: when `progressive_planning` is off, the dispatch
+ *      rule routes sketch slices to plan-slice, which writes PLAN.md but leaves
+ *      `is_sketch=1` — the next state derivation auto-heals it to 0 here.
+ *
+ * Not aggressive in practice: PLAN.md is only written via the DB-backed
+ * `gsd_plan_slice` tool (which also inserts tasks), so a "stale PLAN.md with
+ * is_sketch=1" is extremely unlikely to indicate anything other than the two
+ * recovery scenarios above.
+ */
+export function autoHealSketchFlags(milestoneId: string, hasPlanFile: (sliceId: string) => boolean): void {
+  if (!currentDb) return;
+  const rows = currentDb.prepare(
+    `SELECT id FROM slices WHERE milestone_id = :mid AND is_sketch = 1`,
+  ).all({ ":mid": milestoneId }) as Array<{ id: string }>;
+  for (const row of rows) {
+    if (hasPlanFile(row.id)) {
+      setSliceSketchFlag(milestoneId, row.id, false);
+    }
+  }
 }
 
 export function upsertSlicePlanning(milestoneId: string, sliceId: string, planning: Partial<SlicePlanningRecord>): void {
@@ -1716,6 +1772,8 @@ export interface SliceRow {
   observability_impact: string;
   sequence: number;
   replan_triggered_at: string | null;
+  is_sketch: number;
+  sketch_scope: string;
 }
 
 function rowToSlice(row: Record<string, unknown>): SliceRow {
@@ -1738,6 +1796,8 @@ function rowToSlice(row: Record<string, unknown>): SliceRow {
     observability_impact: (row["observability_impact"] as string) ?? "",
     sequence: (row["sequence"] as number) ?? 0,
     replan_triggered_at: (row["replan_triggered_at"] as string) ?? null,
+    is_sketch: (row["is_sketch"] as number) ?? 0,
+    sketch_scope: (row["sketch_scope"] as string) ?? "",
   };
 }
 

--- a/src/resources/extensions/gsd/gsd-db.ts
+++ b/src/resources/extensions/gsd/gsd-db.ts
@@ -180,7 +180,7 @@ function openRawDb(path: string): unknown {
   return new Database(path);
 }
 
-const SCHEMA_VERSION = 15;
+const SCHEMA_VERSION = 17;
 
 function indexExists(db: DbAdapter, name: string): boolean {
   return !!db.prepare(
@@ -235,6 +235,7 @@ function initSchema(db: DbAdapter, fileBacked: boolean): void {
         rationale TEXT NOT NULL DEFAULT '',
         revisable TEXT NOT NULL DEFAULT '',
         made_by TEXT NOT NULL DEFAULT 'agent',
+        source TEXT NOT NULL DEFAULT 'discussion', -- ADR-011 P2: 'discussion' | 'planning' | 'escalation'
         superseded_by TEXT DEFAULT NULL
       )
     `);
@@ -352,6 +353,11 @@ function initSchema(db: DbAdapter, fileBacked: boolean): void {
         duration TEXT NOT NULL DEFAULT '',
         completed_at TEXT DEFAULT NULL,
         blocker_discovered INTEGER DEFAULT 0,
+        blocker_source TEXT NOT NULL DEFAULT '', -- ADR-011 P2: provenance for blocker_discovered (e.g. 'reject-escalation')
+        escalation_pending INTEGER NOT NULL DEFAULT 0, -- ADR-011 P2: pause-on-escalation flag
+        escalation_awaiting_review INTEGER NOT NULL DEFAULT 0, -- ADR-011 P2: artifact exists but continueWithDefault=true (no pause)
+        escalation_artifact_path TEXT DEFAULT NULL, -- ADR-011 P2: path to T##-ESCALATION.json
+        escalation_override_applied_at TEXT DEFAULT NULL, -- ADR-011 P2: DB claim lock for idempotent override injection
         deviations TEXT NOT NULL DEFAULT '',
         known_issues TEXT NOT NULL DEFAULT '',
         key_files TEXT NOT NULL DEFAULT '[]',
@@ -951,6 +957,29 @@ function migrateSchema(db: DbAdapter): void {
       });
     }
 
+    if (currentVersion < 16) {
+      // ADR-011 Phase 2: decisions can now be sourced from escalation resolutions.
+      ensureColumn(db, "decisions", "source", `ALTER TABLE decisions ADD COLUMN source TEXT NOT NULL DEFAULT 'discussion'`);
+      db.prepare("INSERT INTO schema_version (version, applied_at) VALUES (:version, :applied_at)").run({
+        ":version": 16,
+        ":applied_at": new Date().toISOString(),
+      });
+    }
+
+    if (currentVersion < 17) {
+      // ADR-011 Phase 2: mid-execution escalation — columns on the tasks table.
+      ensureColumn(db, "tasks", "blocker_source", `ALTER TABLE tasks ADD COLUMN blocker_source TEXT NOT NULL DEFAULT ''`);
+      ensureColumn(db, "tasks", "escalation_pending", `ALTER TABLE tasks ADD COLUMN escalation_pending INTEGER NOT NULL DEFAULT 0`);
+      ensureColumn(db, "tasks", "escalation_awaiting_review", `ALTER TABLE tasks ADD COLUMN escalation_awaiting_review INTEGER NOT NULL DEFAULT 0`);
+      ensureColumn(db, "tasks", "escalation_artifact_path", `ALTER TABLE tasks ADD COLUMN escalation_artifact_path TEXT DEFAULT NULL`);
+      ensureColumn(db, "tasks", "escalation_override_applied_at", `ALTER TABLE tasks ADD COLUMN escalation_override_applied_at TEXT DEFAULT NULL`);
+      db.exec("CREATE INDEX IF NOT EXISTS idx_tasks_escalation_pending ON tasks(milestone_id, slice_id, escalation_pending)");
+      db.prepare("INSERT INTO schema_version (version, applied_at) VALUES (:version, :applied_at)").run({
+        ":version": 17,
+        ":applied_at": new Date().toISOString(),
+      });
+    }
+
     db.exec("COMMIT");
   } catch (err) {
     db.exec("ROLLBACK");
@@ -1127,8 +1156,8 @@ export function readTransaction<T>(fn: () => T): T {
 export function insertDecision(d: Omit<Decision, "seq">): void {
   if (!currentDb) throw new GSDError(GSD_STALE_STATE, "gsd-db: No database open");
   currentDb.prepare(
-    `INSERT INTO decisions (id, when_context, scope, decision, choice, rationale, revisable, made_by, superseded_by)
-     VALUES (:id, :when_context, :scope, :decision, :choice, :rationale, :revisable, :made_by, :superseded_by)`,
+    `INSERT INTO decisions (id, when_context, scope, decision, choice, rationale, revisable, made_by, source, superseded_by)
+     VALUES (:id, :when_context, :scope, :decision, :choice, :rationale, :revisable, :made_by, :source, :superseded_by)`,
   ).run({
     ":id": d.id,
     ":when_context": d.when_context,
@@ -1138,6 +1167,7 @@ export function insertDecision(d: Omit<Decision, "seq">): void {
     ":rationale": d.rationale,
     ":revisable": d.revisable,
     ":made_by": d.made_by ?? "agent",
+    ":source": d.source ?? "discussion",
     ":superseded_by": d.superseded_by,
   });
 }
@@ -1156,6 +1186,7 @@ export function getDecisionById(id: string): Decision | null {
     rationale: row["rationale"] as string,
     revisable: row["revisable"] as string,
     made_by: (row["made_by"] as string as import("./types.js").DecisionMadeBy) ?? "agent",
+    source: (row["source"] as string) ?? "discussion",
     superseded_by: (row["superseded_by"] as string) ?? null,
   };
 }
@@ -1261,8 +1292,8 @@ export function upsertDecision(d: Omit<Decision, "seq">): void {
   // seq column. INSERT OR REPLACE deletes then reinserts, resetting seq and
   // corrupting decision ordering in DECISIONS.md after reconcile replay.
   currentDb.prepare(
-    `INSERT INTO decisions (id, when_context, scope, decision, choice, rationale, revisable, made_by, superseded_by)
-     VALUES (:id, :when_context, :scope, :decision, :choice, :rationale, :revisable, :made_by, :superseded_by)
+    `INSERT INTO decisions (id, when_context, scope, decision, choice, rationale, revisable, made_by, source, superseded_by)
+     VALUES (:id, :when_context, :scope, :decision, :choice, :rationale, :revisable, :made_by, :source, :superseded_by)
      ON CONFLICT(id) DO UPDATE SET
        when_context = excluded.when_context,
        scope = excluded.scope,
@@ -1271,6 +1302,7 @@ export function upsertDecision(d: Omit<Decision, "seq">): void {
        rationale = excluded.rationale,
        revisable = excluded.revisable,
        made_by = excluded.made_by,
+       source = excluded.source,
        superseded_by = excluded.superseded_by`,
   ).run({
     ":id": d.id,
@@ -1281,6 +1313,7 @@ export function upsertDecision(d: Omit<Decision, "seq">): void {
     ":rationale": d.rationale,
     ":revisable": d.revisable,
     ":made_by": d.made_by ?? "agent",
+    ":source": d.source ?? "discussion",
     ":superseded_by": d.superseded_by ?? null,
   });
 }
@@ -1764,6 +1797,12 @@ export interface TaskRow {
   observability_impact: string;
   full_plan_md: string;
   sequence: number;
+  // ADR-011 Phase 2 escalation fields
+  blocker_source: string;
+  escalation_pending: number;
+  escalation_awaiting_review: number;
+  escalation_artifact_path: string | null;
+  escalation_override_applied_at: string | null;
 }
 
 function parseTaskArrayColumn(raw: unknown): string[] {
@@ -1834,6 +1873,11 @@ function rowToTask(row: Record<string, unknown>): TaskRow {
     observability_impact: (row["observability_impact"] as string) ?? "",
     full_plan_md: (row["full_plan_md"] as string) ?? "",
     sequence: (row["sequence"] as number) ?? 0,
+    blocker_source: (row["blocker_source"] as string) ?? "",
+    escalation_pending: (row["escalation_pending"] as number) ?? 0,
+    escalation_awaiting_review: (row["escalation_awaiting_review"] as number) ?? 0,
+    escalation_artifact_path: (row["escalation_artifact_path"] as string) ?? null,
+    escalation_override_applied_at: (row["escalation_override_applied_at"] as string) ?? null,
   };
 }
 
@@ -1851,6 +1895,123 @@ export function getSliceTasks(milestoneId: string, sliceId: string): TaskRow[] {
   const rows = currentDb.prepare(
     "SELECT * FROM tasks WHERE milestone_id = :mid AND slice_id = :sid ORDER BY sequence, id",
   ).all({ ":mid": milestoneId, ":sid": sliceId });
+  return rows.map(rowToTask);
+}
+
+// ─── ADR-011 Phase 2 escalation helpers ──────────────────────────────────
+
+/** Set pause-on-escalation state on a completed task. */
+export function setTaskEscalationPending(
+  milestoneId: string, sliceId: string, taskId: string,
+  artifactPath: string,
+): void {
+  if (!currentDb) throw new GSDError(GSD_STALE_STATE, "gsd-db: No database open");
+  currentDb.prepare(
+    `UPDATE tasks
+       SET escalation_pending = 1,
+           escalation_artifact_path = :path
+     WHERE milestone_id = :mid AND slice_id = :sid AND id = :tid`,
+  ).run({ ":path": artifactPath, ":mid": milestoneId, ":sid": sliceId, ":tid": taskId });
+}
+
+/** Set awaiting-review state (artifact exists but continueWithDefault=true, no pause). */
+export function setTaskEscalationAwaitingReview(
+  milestoneId: string, sliceId: string, taskId: string,
+  artifactPath: string,
+): void {
+  if (!currentDb) throw new GSDError(GSD_STALE_STATE, "gsd-db: No database open");
+  currentDb.prepare(
+    `UPDATE tasks
+       SET escalation_awaiting_review = 1,
+           escalation_artifact_path = :path
+     WHERE milestone_id = :mid AND slice_id = :sid AND id = :tid`,
+  ).run({ ":path": artifactPath, ":mid": milestoneId, ":sid": sliceId, ":tid": taskId });
+}
+
+/** Clear escalation-pending and awaiting-review flags once the user has resolved it. */
+export function clearTaskEscalationFlags(
+  milestoneId: string, sliceId: string, taskId: string,
+): void {
+  if (!currentDb) throw new GSDError(GSD_STALE_STATE, "gsd-db: No database open");
+  currentDb.prepare(
+    `UPDATE tasks
+       SET escalation_pending = 0,
+           escalation_awaiting_review = 0
+     WHERE milestone_id = :mid AND slice_id = :sid AND id = :tid`,
+  ).run({ ":mid": milestoneId, ":sid": sliceId, ":tid": taskId });
+}
+
+/**
+ * Atomically claim a resolved escalation override for injection into a downstream
+ * task's prompt. Returns true if this caller claimed it (must inject), false if
+ * another caller already claimed it (must skip).
+ */
+export function claimEscalationOverride(
+  milestoneId: string, sliceId: string, sourceTaskId: string,
+): boolean {
+  if (!currentDb) return false;
+  const now = new Date().toISOString();
+  const result = currentDb.prepare(
+    `UPDATE tasks
+       SET escalation_override_applied_at = :now
+     WHERE milestone_id = :mid AND slice_id = :sid AND id = :tid
+       AND escalation_override_applied_at IS NULL
+       AND escalation_artifact_path IS NOT NULL`,
+  ).run({ ":now": now, ":mid": milestoneId, ":sid": sliceId, ":tid": sourceTaskId });
+  // node:sqlite + better-sqlite3 both surface `changes` on the run result.
+  const changes = (result as { changes?: number }).changes ?? 0;
+  return changes > 0;
+}
+
+/** Find the most recent resolved-but-unapplied escalation override in a slice. */
+export function findUnappliedEscalationOverride(
+  milestoneId: string, sliceId: string,
+): { taskId: string; artifactPath: string } | null {
+  if (!currentDb) return null;
+  // Filter BOTH flags: escalation_pending=0 AND escalation_awaiting_review=0
+  // ensures we only claim overrides the user has explicitly resolved.
+  // Without the awaiting_review filter, continueWithDefault=true artifacts
+  // (not yet responded to) would be prematurely claimed, causing the override
+  // to be lost when the user later resolves (#ADR-011 Phase 2 peer-review Bug 2).
+  const row = currentDb.prepare(
+    `SELECT id, escalation_artifact_path AS path
+       FROM tasks
+      WHERE milestone_id = :mid AND slice_id = :sid
+        AND escalation_artifact_path IS NOT NULL
+        AND escalation_override_applied_at IS NULL
+        AND escalation_pending = 0
+        AND escalation_awaiting_review = 0
+      ORDER BY sequence DESC, id DESC
+      LIMIT 1`,
+  ).get({ ":mid": milestoneId, ":sid": sliceId }) as
+    | { id: string; path: string | null }
+    | undefined;
+  if (!row || !row.path) return null;
+  return { taskId: row.id, artifactPath: row.path };
+}
+
+/** Set the blocker_source provenance field (used when rejecting an escalation). */
+export function setTaskBlockerSource(
+  milestoneId: string, sliceId: string, taskId: string, source: string,
+): void {
+  if (!currentDb) throw new GSDError(GSD_STALE_STATE, "gsd-db: No database open");
+  currentDb.prepare(
+    `UPDATE tasks
+       SET blocker_discovered = 1,
+           blocker_source = :src
+     WHERE milestone_id = :mid AND slice_id = :sid AND id = :tid`,
+  ).run({ ":src": source, ":mid": milestoneId, ":sid": sliceId, ":tid": taskId });
+}
+
+/** List tasks with active escalation artifacts across a milestone (for /gsd escalate list). */
+export function listEscalationArtifacts(milestoneId: string, includeResolved: boolean = false): TaskRow[] {
+  if (!currentDb) return [];
+  const filter = includeResolved
+    ? "escalation_artifact_path IS NOT NULL"
+    : "(escalation_pending = 1 OR escalation_awaiting_review = 1) AND escalation_artifact_path IS NOT NULL";
+  const rows = currentDb.prepare(
+    `SELECT * FROM tasks WHERE milestone_id = :mid AND ${filter} ORDER BY slice_id, sequence, id`,
+  ).all({ ":mid": milestoneId });
   return rows.map(rowToTask);
 }
 

--- a/src/resources/extensions/gsd/metrics.ts
+++ b/src/resources/extensions/gsd/metrics.ts
@@ -90,6 +90,7 @@ export function classifyUnitPhase(unitType: string): MetricsPhase {
       return "discussion";
     case "plan-milestone":
     case "plan-slice":
+    case "refine-slice":
       return "planning";
     case "execute-task":
       return "execution";

--- a/src/resources/extensions/gsd/preferences-models.ts
+++ b/src/resources/extensions/gsd/preferences-models.ts
@@ -55,6 +55,7 @@ export function resolveModelWithFallbacksForUnit(unitType: string): ResolvedMode
       break;
     case "plan-milestone":
     case "plan-slice":
+    case "refine-slice":
     case "replan-slice":
       phaseConfig = m.planning;
       break;

--- a/src/resources/extensions/gsd/preferences-types.ts
+++ b/src/resources/extensions/gsd/preferences-types.ts
@@ -120,7 +120,7 @@ export const KNOWN_PREFERENCE_KEYS = new Set<string>([
 
 /** Canonical list of all dispatch unit types. */
 export const KNOWN_UNIT_TYPES = [
-  "research-milestone", "plan-milestone", "research-slice", "plan-slice",
+  "research-milestone", "plan-milestone", "research-slice", "plan-slice", "refine-slice",
   "execute-task", "reactive-execute", "gate-evaluate", "complete-slice", "replan-slice", "reassess-roadmap",
   "run-uat", "complete-milestone", "validate-milestone", "rewrite-docs",
   "discuss-milestone", "discuss-slice", "worktree-merge",

--- a/src/resources/extensions/gsd/preferences-validation.ts
+++ b/src/resources/extensions/gsd/preferences-validation.ts
@@ -313,14 +313,34 @@ export function validatePreferences(preferences: GSDPreferences): {
     if (typeof preferences.phases === "object" && preferences.phases !== null) {
       const validatedPhases: PhaseSkipPreferences = {};
       const p = preferences.phases as Record<string, unknown>;
-      if (p.skip_research !== undefined) validatedPhases.skip_research = !!p.skip_research;
-      if (p.skip_reassess !== undefined) validatedPhases.skip_reassess = !!p.skip_reassess;
-      if (p.skip_slice_research !== undefined) validatedPhases.skip_slice_research = !!p.skip_slice_research;
-      if (p.skip_milestone_validation !== undefined) validatedPhases.skip_milestone_validation = !!p.skip_milestone_validation;
-      if (p.reassess_after_slice !== undefined) validatedPhases.reassess_after_slice = !!p.reassess_after_slice;
-      if ((p as any).require_slice_discussion !== undefined) (validatedPhases as any).require_slice_discussion = !!(p as any).require_slice_discussion;
-      if (p.mid_execution_escalation !== undefined) validatedPhases.mid_execution_escalation = !!p.mid_execution_escalation;
-      if (p.progressive_planning !== undefined) validatedPhases.progressive_planning = !!p.progressive_planning;
+      // Strict boolean parsing — YAML usually delivers real booleans, but
+      // hand-edits like `progressive_planning: "false"` otherwise coerce to
+      // truthy via `!!`. Accept only real booleans or the literal strings
+      // "true"/"false"; anything else becomes a warning + ignored.
+      const parseStrictBoolean = (key: string, raw: unknown): boolean | undefined => {
+        if (typeof raw === "boolean") return raw;
+        if (typeof raw === "string") {
+          if (raw === "true") return true;
+          if (raw === "false") return false;
+        }
+        warnings.push(`phases.${key} must be a boolean (got ${typeof raw}: ${JSON.stringify(raw)}) — ignored`);
+        return undefined;
+      };
+      const assignBool = (key: keyof PhaseSkipPreferences, raw: unknown): void => {
+        const v = parseStrictBoolean(String(key), raw);
+        if (v !== undefined) (validatedPhases as Record<string, boolean>)[key as string] = v;
+      };
+      if (p.skip_research !== undefined) assignBool("skip_research", p.skip_research);
+      if (p.skip_reassess !== undefined) assignBool("skip_reassess", p.skip_reassess);
+      if (p.skip_slice_research !== undefined) assignBool("skip_slice_research", p.skip_slice_research);
+      if (p.skip_milestone_validation !== undefined) assignBool("skip_milestone_validation", p.skip_milestone_validation);
+      if (p.reassess_after_slice !== undefined) assignBool("reassess_after_slice", p.reassess_after_slice);
+      if ((p as any).require_slice_discussion !== undefined) {
+        const v = parseStrictBoolean("require_slice_discussion", (p as any).require_slice_discussion);
+        if (v !== undefined) (validatedPhases as any).require_slice_discussion = v;
+      }
+      if (p.mid_execution_escalation !== undefined) assignBool("mid_execution_escalation", p.mid_execution_escalation);
+      if (p.progressive_planning !== undefined) assignBool("progressive_planning", p.progressive_planning);
       // Warn on unknown phase keys
       const knownPhaseKeys = new Set(["skip_research", "skip_reassess", "skip_slice_research", "skip_milestone_validation", "reassess_after_slice", "require_slice_discussion", "mid_execution_escalation", "progressive_planning"]);
       for (const key of Object.keys(p)) {

--- a/src/resources/extensions/gsd/preferences-validation.ts
+++ b/src/resources/extensions/gsd/preferences-validation.ts
@@ -320,8 +320,9 @@ export function validatePreferences(preferences: GSDPreferences): {
       if (p.reassess_after_slice !== undefined) validatedPhases.reassess_after_slice = !!p.reassess_after_slice;
       if ((p as any).require_slice_discussion !== undefined) (validatedPhases as any).require_slice_discussion = !!(p as any).require_slice_discussion;
       if (p.mid_execution_escalation !== undefined) validatedPhases.mid_execution_escalation = !!p.mid_execution_escalation;
+      if (p.progressive_planning !== undefined) validatedPhases.progressive_planning = !!p.progressive_planning;
       // Warn on unknown phase keys
-      const knownPhaseKeys = new Set(["skip_research", "skip_reassess", "skip_slice_research", "skip_milestone_validation", "reassess_after_slice", "require_slice_discussion", "mid_execution_escalation"]);
+      const knownPhaseKeys = new Set(["skip_research", "skip_reassess", "skip_slice_research", "skip_milestone_validation", "reassess_after_slice", "require_slice_discussion", "mid_execution_escalation", "progressive_planning"]);
       for (const key of Object.keys(p)) {
         if (!knownPhaseKeys.has(key)) {
           warnings.push(`unknown phases key "${key}" — ignored`);

--- a/src/resources/extensions/gsd/preferences-validation.ts
+++ b/src/resources/extensions/gsd/preferences-validation.ts
@@ -319,8 +319,9 @@ export function validatePreferences(preferences: GSDPreferences): {
       if (p.skip_milestone_validation !== undefined) validatedPhases.skip_milestone_validation = !!p.skip_milestone_validation;
       if (p.reassess_after_slice !== undefined) validatedPhases.reassess_after_slice = !!p.reassess_after_slice;
       if ((p as any).require_slice_discussion !== undefined) (validatedPhases as any).require_slice_discussion = !!(p as any).require_slice_discussion;
+      if (p.progressive_planning !== undefined) validatedPhases.progressive_planning = !!p.progressive_planning;
       // Warn on unknown phase keys
-      const knownPhaseKeys = new Set(["skip_research", "skip_reassess", "skip_slice_research", "skip_milestone_validation", "reassess_after_slice", "require_slice_discussion"]);
+      const knownPhaseKeys = new Set(["skip_research", "skip_reassess", "skip_slice_research", "skip_milestone_validation", "reassess_after_slice", "require_slice_discussion", "progressive_planning"]);
       for (const key of Object.keys(p)) {
         if (!knownPhaseKeys.has(key)) {
           warnings.push(`unknown phases key "${key}" — ignored`);

--- a/src/resources/extensions/gsd/preferences-validation.ts
+++ b/src/resources/extensions/gsd/preferences-validation.ts
@@ -319,8 +319,9 @@ export function validatePreferences(preferences: GSDPreferences): {
       if (p.skip_milestone_validation !== undefined) validatedPhases.skip_milestone_validation = !!p.skip_milestone_validation;
       if (p.reassess_after_slice !== undefined) validatedPhases.reassess_after_slice = !!p.reassess_after_slice;
       if ((p as any).require_slice_discussion !== undefined) (validatedPhases as any).require_slice_discussion = !!(p as any).require_slice_discussion;
+      if (p.mid_execution_escalation !== undefined) validatedPhases.mid_execution_escalation = !!p.mid_execution_escalation;
       // Warn on unknown phase keys
-      const knownPhaseKeys = new Set(["skip_research", "skip_reassess", "skip_slice_research", "skip_milestone_validation", "reassess_after_slice", "require_slice_discussion"]);
+      const knownPhaseKeys = new Set(["skip_research", "skip_reassess", "skip_slice_research", "skip_milestone_validation", "reassess_after_slice", "require_slice_discussion", "mid_execution_escalation"]);
       for (const key of Object.keys(p)) {
         if (!knownPhaseKeys.has(key)) {
           warnings.push(`unknown phases key "${key}" — ignored`);

--- a/src/resources/extensions/gsd/prompts/execute-task.md
+++ b/src/resources/extensions/gsd/prompts/execute-task.md
@@ -69,6 +69,18 @@ Then:
     - Know when to stop. If you've tried 3+ fixes without progress, your mental model is probably wrong. Stop. List what you know for certain. List what you've ruled out. Form fresh hypotheses from there.
     - Don't fix symptoms. Understand *why* something fails before changing code. A test that passes after a change you don't understand is luck, not a fix.
 16. **Blocker discovery:** If execution reveals that the remaining slice plan is fundamentally invalid — not just a bug or minor deviation, but a plan-invalidating finding like a wrong API, missing capability, or architectural mismatch — set `blocker_discovered: true` in the task summary frontmatter and describe the blocker clearly in the summary narrative. Do NOT set `blocker_discovered: true` for ordinary debugging, minor deviations, or issues that can be fixed within the current task or the remaining plan. This flag triggers an automatic replan of the slice.
+16a. **Mid-execution escalation (ADR-011 Phase 2):** If you hit an ambiguity that is *not* a plan-invalidating blocker but whose resolution materially affects downstream work AND cannot be derived from the task plan, CONTEXT.md, DECISIONS.md, or codebase evidence, you MAY escalate to the user. Populate an `escalation` object alongside the milestoneId/sliceId/taskId fields on your completion tool call with:
+    - `question` — one clear sentence
+    - `options` — 2–4 entries with `id` (short, e.g. "A", "B"), `label`, and 1–2 sentence `tradeoffs`
+    - `recommendation` — the option `id` you recommend
+    - `recommendationRationale` — 1–2 sentences on why
+    - `continueWithDefault` — `true` means finish the task using your recommendation now and let the user's later response inject a correction into the NEXT task; `false` means auto-mode pauses until the user resolves via `/gsd escalate resolve <taskId> <choice>`.
+
+    Escalate ONLY when the answer materially affects downstream tasks AND cannot be resolved from available context. Do NOT escalate for implementation style, minor deviations, or anything already covered by DECISIONS.md. Escalations must include a real recommendation — do not ask the user to pick without giving your best judgment.
+
+    **Scope:** Escalation is instrumented only in `execute-task`. Refine-slice escalation is deferred. Reactive-execute batches run to completion before escalations are surfaced — the dispatch pause happens on the next loop iteration, not mid-batch.
+
+    The `escalation` payload is ignored unless `phases.mid_execution_escalation` is enabled; populate it anyway for audit logs.
 17. If you made an architectural, pattern, library, or observability decision during this task that downstream work should know about, append it to `.gsd/DECISIONS.md` (read the template at `~/.gsd/agent/extensions/gsd/templates/decisions.md` if the file doesn't exist yet). Not every task produces decisions — only append when a meaningful choice was made.
 18. If you discover a non-obvious rule, recurring gotcha, or useful pattern during execution, append it to `.gsd/KNOWLEDGE.md`. Only add entries that would save future agents from repeating your investigation. Don't add obvious things.
 19. Read the template at `~/.gsd/agent/extensions/gsd/templates/task-summary.md`

--- a/src/resources/extensions/gsd/prompts/plan-milestone.md
+++ b/src/resources/extensions/gsd/prompts/plan-milestone.md
@@ -78,6 +78,18 @@ Apply these when decomposing and ordering slices:
 - **Ambition matches the milestone.** The number and depth of slices should match the milestone's ambition. A milestone promising "core platform with auth, data model, and primary user loop" should have enough slices to actually deliver all three as working features — not two proof-of-concept slices and a note that "the rest will come in the next milestone." If the milestone's context promises an outcome, the roadmap must deliver it.
 - **Right-size the decomposition.** Match slice count to actual complexity. If the work is small enough to build and verify in one pass, it's one slice — don't split it into three just because you can identify sub-steps. Multiple requirements can share a single slice. Conversely, don't cram genuinely independent capabilities into one slice just to keep the count low. Let the work dictate the structure.
 
+## Progressive Planning (ADR-011)
+
+If the preference `phases.progressive_planning` is enabled and the roadmap has **2 or more slices**, you SHOULD plan S01 in full detail and S02+ as sketches. Plan S02+ full only when the slice is trivially determined (pure boilerplate that cannot meaningfully change based on what S01 ships).
+
+A **sketch slice** has the same roadmap entry as today (title, risk, depends, demo line) plus a `sketchScope` of 2–3 sentences describing the scope boundary. Do NOT attempt to decompose it into tasks during this unit — leave `goal`, `successCriteria`, `proofLevel`, `integrationClosure`, `observabilityImpact` blank (or provide them if genuinely known). When the prior slice completes, a separate `refine-slice` unit will expand the sketch into a full plan using the real codebase state and the prior slice SUMMARY.
+
+**To mark a slice as a sketch in the `gsd_plan_milestone` tool call:** set `isSketch: true` and `sketchScope: "<2-3 sentence scope>"` on that slice entry.
+
+S01 is never a sketch — it must always be fully decomposed in this unit.
+
+If the preference is off, ignore this section and plan every slice in full detail as you would normally.
+
 ## Single-Slice Fast Path
 
 If the roadmap has only one slice, also plan the slice and its tasks inline during this unit — don't leave them for a separate planning session.

--- a/src/resources/extensions/gsd/prompts/plan-milestone.md
+++ b/src/resources/extensions/gsd/prompts/plan-milestone.md
@@ -82,7 +82,7 @@ Apply these when decomposing and ordering slices:
 
 If the preference `phases.progressive_planning` is enabled and the roadmap has **2 or more slices**, you SHOULD plan S01 in full detail and S02+ as sketches. Plan S02+ full only when the slice is trivially determined (pure boilerplate that cannot meaningfully change based on what S01 ships).
 
-A **sketch slice** has the same roadmap entry as today (title, risk, depends, demo line) plus a `sketchScope` of 2–3 sentences describing the scope boundary. Do NOT attempt to decompose it into tasks during this unit — leave `goal`, `successCriteria`, `proofLevel`, `integrationClosure`, `observabilityImpact` blank (or provide them if genuinely known). When the prior slice completes, a separate `refine-slice` unit will expand the sketch into a full plan using the real codebase state and the prior slice SUMMARY.
+A **sketch slice** has the same roadmap entry as today (title, risk, depends, demo line) plus a `sketchScope` of 2–3 sentences describing the scope boundary. Do NOT attempt to decompose it into tasks during this unit — provide a one-sentence `goal` (the tool schema requires it; keep it at the same level of detail as the roadmap demo line) and leave `successCriteria`, `proofLevel`, `integrationClosure`, `observabilityImpact` blank (or provide them if genuinely known). When the prior slice completes, a separate `refine-slice` unit will expand the sketch into a full plan using the real codebase state and the prior slice SUMMARY.
 
 **To mark a slice as a sketch in the `gsd_plan_milestone` tool call:** set `isSketch: true` and `sketchScope: "<2-3 sentence scope>"` on that slice entry.
 

--- a/src/resources/extensions/gsd/prompts/refine-slice.md
+++ b/src/resources/extensions/gsd/prompts/refine-slice.md
@@ -1,0 +1,69 @@
+You are executing GSD auto-mode.
+
+## UNIT: Refine Slice {{sliceId}} ("{{sliceTitle}}") — Milestone {{milestoneId}}
+
+## Working Directory
+
+Your working directory is `{{workingDirectory}}`. All file reads, writes, and shell commands MUST operate relative to this directory. Do NOT `cd` to any other directory.
+
+This unit **expands an approved sketch into a full plan**. It is not a blank-sheet planning pass — the sketch's scope is the authoritative boundary, and the prior slice's real outcomes are the authoritative context. Your job is to produce a detailed plan that fits inside the sketch while reflecting what actually shipped in earlier slices.
+
+All relevant context has been preloaded below — start working immediately without re-reading these files.
+
+{{inlinedContext}}
+
+### Dependency Slice Summaries
+
+Pay particular attention to **Forward Intelligence** sections — they contain hard-won knowledge about what's fragile, what assumptions changed, and what this slice should watch out for. These summaries are the single most important input to refinement: the sketch was written before these slices shipped, so your plan MUST reconcile against what they actually built.
+
+{{dependencySummaries}}
+
+## Your Role in the Pipeline
+
+### Respect the Sketch Scope
+
+The sketch scope inlined above is a **hard constraint**. Plan within it. If, after exploring the codebase, the scope is too narrow to deliver the goal, surface this as a deviation in the plan's narrative and still produce the plan — do not silently expand the scope.
+
+### Reconcile Against Reality
+
+Before decomposing:
+
+1. Read the prior slice SUMMARY files that were inlined above. Note any interface shifts, file-layout changes, or discovered constraints.
+2. Use `rg`, `find`, and targeted reads to confirm the current codebase state for files the sketch references. If an assumed module/type/API has moved or changed shape, your plan must reflect that.
+3. If prior slices flagged fragility or known issues relevant to this slice, fold them into task verification.
+
+### Source Files
+
+{{sourceFilePaths}}
+
+If slice research exists (inlined above), trust those findings and skip redundant exploration.
+
+After you finish, **executor agents** implement each task in isolated fresh context windows. They see only their task plan, the slice plan excerpt, and compressed summaries of prior tasks. Everything an executor needs must be in the task plan itself — file paths, specific steps, expected inputs and outputs.
+
+Narrate your decomposition reasoning in complete sentences. Explain what the sketch promised, what prior slices changed, and how those two inputs shape the decomposition. Keep narration proportional to the work.
+
+**Right-size the plan.** If the slice is simple enough to be 1 task, plan 1 task. Don't fill in sections with "None" — omit them entirely.
+
+{{executorContextConstraints}}
+
+Then:
+0. If `REQUIREMENTS.md` was preloaded above, identify which Active requirements the sketch says this slice owns or supports. Every owned requirement needs at least one task that directly advances it.
+1. Read the templates:
+   - `~/.gsd/agent/extensions/gsd/templates/plan.md`
+   - `~/.gsd/agent/extensions/gsd/templates/task-plan.md`
+2. {{skillActivation}} Record the installed skills you expect executors to use in each task plan's `skills_used` frontmatter.
+3. Define slice-level verification — the objective stopping condition. Plan real test files with real assertions; for simple slices, executable commands are fine.
+4. For non-trivial slices, plan observability / proof level / integration closure, threat surface, and requirement impact. Omit entirely for simple slices.
+5. Decompose the slice into tasks that fit one context window each. Every task must have Why / Files / Do / Verify / Done-when, plus a task plan with description, steps, must-haves, verification, inputs (backtick-wrapped paths), and expected output (backtick-wrapped paths).
+6. **Persist planning state through `gsd_plan_slice`.** Call it with the full payload. The tool writes to the DB and renders `{{outputPath}}` and `{{slicePath}}/tasks/T##-PLAN.md` automatically. Do NOT rely on direct `PLAN.md` writes.
+7. **Self-audit the plan.** If every task were completed exactly as written, the slice goal/demo should actually be true. Every must-have maps to at least one task. Inputs and Expected Output are backtick-wrapped file paths.
+8. If refinement produced structural decisions that diverge from the sketch, append them to `.gsd/DECISIONS.md`.
+9. {{commitInstruction}}
+
+The slice directory and tasks/ subdirectory already exist. Do NOT mkdir.
+
+**Autonomous execution:** Do not call `ask_user_questions` or `secure_env_collect`. Document assumptions in the plan.
+
+**You MUST call `gsd_plan_slice` to persist the planning state before finishing.** After it returns successfully, the pipeline will automatically clear the sketch flag on the next state derivation (the on-disk PLAN file is the signal).
+
+When done, say: "Slice {{sliceId}} refined."

--- a/src/resources/extensions/gsd/state.ts
+++ b/src/resources/extensions/gsd/state.ts
@@ -44,6 +44,7 @@ import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { debugCount, debugTime } from './debug-logger.js';
 import { logWarning, logError } from './workflow-logger.js';
 import { extractVerdict } from './verdict-parser.js';
+import { loadEffectiveGSDPreferences } from './preferences.js';
 
 import {
   isDbAvailable,
@@ -60,6 +61,7 @@ import {
   updateSliceStatus,
   updateTaskStatus,
   getPendingGateCountForTurn,
+  autoHealSketchFlags,
   type MilestoneRow,
   type SliceRow,
   type TaskRow,
@@ -849,7 +851,15 @@ export async function deriveStateFromDb(basePath: string): Promise<GSDState> {
     return handleAllSlicesDone(basePath, activeMilestone, registry, requirements, milestoneProgress, sliceProgress);
   }
 
-  const activeSliceContext = resolveSliceDependencies(activeMilestoneSlices);
+  // ADR-011 auto-heal: if a slice has a PLAN on disk but is still flagged is_sketch=1
+  // (e.g. a crash between plan-slice write and the sketch flip), reconcile before
+  // running phase derivation so the flag doesn't misroute state.
+  autoHealSketchFlags(activeMilestone.id, (sid) =>
+    !!resolveSliceFile(basePath, activeMilestone.id, sid, "PLAN"),
+  );
+  // Re-read slices after auto-heal so downstream reads see fresh is_sketch values.
+  const healedSlices = getMilestoneSlices(activeMilestone.id);
+  const activeSliceContext = resolveSliceDependencies(healedSlices);
   if (!activeSliceContext.activeSlice) {
     // If locked slice wasn't found, it returns null but logs warning, we need to return 'blocked'
     if (process.env.GSD_SLICE_LOCK) {
@@ -869,10 +879,24 @@ export async function deriveStateFromDb(basePath: string): Promise<GSDState> {
       progress: { milestones: milestoneProgress, slices: sliceProgress },
     };
   }
-  const { activeSlice } = activeSliceContext;
+  const { activeSlice, activeSliceRow } = activeSliceContext;
 
   const planFile = resolveSliceFile(basePath, activeMilestone.id, activeSlice.id, "PLAN");
   if (!planFile) {
+    // ADR-011: sketch slices with progressive_planning enabled enter the
+    // `refining` phase — a refine-slice unit expands the sketch into a full plan
+    // before execution. When the flag is off, sketches are indistinguishable
+    // from a missing plan and fall through to the normal `planning` phase.
+    const progressive = loadEffectiveGSDPreferences()?.preferences?.phases?.progressive_planning === true;
+    if (progressive && activeSliceRow?.is_sketch === 1) {
+      return {
+        activeMilestone, activeSlice, activeTask: null,
+        phase: 'refining', recentDecisions: [], blockers: [],
+        nextAction: `Refine sketch slice ${activeSlice.id} (${activeSlice.title}) using prior slice context.`,
+        registry, requirements,
+        progress: { milestones: milestoneProgress, slices: sliceProgress },
+      };
+    }
     return {
       activeMilestone, activeSlice, activeTask: null,
       phase: 'planning', recentDecisions: [], blockers: [],

--- a/src/resources/extensions/gsd/state.ts
+++ b/src/resources/extensions/gsd/state.ts
@@ -62,6 +62,7 @@ import {
   updateSliceStatus,
   updateTaskStatus,
   getPendingGateCountForTurn,
+  autoHealSketchFlags,
   type MilestoneRow,
   type SliceRow,
   type TaskRow,
@@ -851,7 +852,15 @@ export async function deriveStateFromDb(basePath: string): Promise<GSDState> {
     return handleAllSlicesDone(basePath, activeMilestone, registry, requirements, milestoneProgress, sliceProgress);
   }
 
-  const activeSliceContext = resolveSliceDependencies(activeMilestoneSlices);
+  // ADR-011 auto-heal: if a slice has a PLAN on disk but is still flagged is_sketch=1
+  // (e.g. a crash between plan-slice write and the sketch flip), reconcile before
+  // running phase derivation so the flag doesn't misroute state.
+  autoHealSketchFlags(activeMilestone.id, (sid) =>
+    !!resolveSliceFile(basePath, activeMilestone.id, sid, "PLAN"),
+  );
+  // Re-read slices after auto-heal so downstream reads see fresh is_sketch values.
+  const healedSlices = getMilestoneSlices(activeMilestone.id);
+  const activeSliceContext = resolveSliceDependencies(healedSlices);
   if (!activeSliceContext.activeSlice) {
     // If locked slice wasn't found, it returns null but logs warning, we need to return 'blocked'
     if (process.env.GSD_SLICE_LOCK) {
@@ -871,10 +880,24 @@ export async function deriveStateFromDb(basePath: string): Promise<GSDState> {
       progress: { milestones: milestoneProgress, slices: sliceProgress },
     };
   }
-  const { activeSlice } = activeSliceContext;
+  const { activeSlice, activeSliceRow } = activeSliceContext;
 
   const planFile = resolveSliceFile(basePath, activeMilestone.id, activeSlice.id, "PLAN");
   if (!planFile) {
+    // ADR-011: sketch slices with progressive_planning enabled enter the
+    // `refining` phase — a refine-slice unit expands the sketch into a full plan
+    // before execution. When the flag is off, sketches are indistinguishable
+    // from a missing plan and fall through to the normal `planning` phase.
+    const progressive = loadEffectiveGSDPreferences()?.preferences?.phases?.progressive_planning === true;
+    if (progressive && activeSliceRow?.is_sketch === 1) {
+      return {
+        activeMilestone, activeSlice, activeTask: null,
+        phase: 'refining', recentDecisions: [], blockers: [],
+        nextAction: `Refine sketch slice ${activeSlice.id} (${activeSlice.title}) using prior slice context.`,
+        registry, requirements,
+        progress: { milestones: milestoneProgress, slices: sliceProgress },
+      };
+    }
     return {
       activeMilestone, activeSlice, activeTask: null,
       phase: 'planning', recentDecisions: [], blockers: [],

--- a/src/resources/extensions/gsd/state.ts
+++ b/src/resources/extensions/gsd/state.ts
@@ -993,20 +993,24 @@ export async function deriveStateFromDb(basePath: string): Promise<GSDState> {
   // ADR-011 Phase 2: pause-on-escalation takes precedence over dispatching the
   // next task. `awaiting_review` tasks (continueWithDefault=true) are NOT
   // surfaced here — they let the loop continue.
-  const escalationEnabled = loadEffectiveGSDPreferences()?.preferences?.phases?.mid_execution_escalation === true;
-  if (escalationEnabled) {
-    const escalatingTaskId = detectPendingEscalation(tasks, basePath);
-    if (escalatingTaskId) {
-      return {
-        activeMilestone, activeSlice, activeTask,
-        phase: 'escalating-task', recentDecisions: [],
-        blockers: [`Task ${escalatingTaskId} requires a user decision before the loop can proceed`],
-        nextAction: `Run /gsd escalate show ${escalatingTaskId} to review, then /gsd escalate resolve ${escalatingTaskId} <choice> to proceed.`,
-        activeWorkspace: undefined,
-        registry, requirements,
-        progress: { milestones: milestoneProgress, slices: sliceProgress, tasks: taskProgress },
-      };
-    }
+  //
+  // We do NOT gate this on `phases.mid_execution_escalation` — creation of
+  // new escalations is gated at the write site (tools/complete-task.ts:315),
+  // but any escalation_pending row already persisted in the DB must be
+  // honored even if the user later toggles the flag off. Otherwise those
+  // rows would silently orphan, the loop would advance past the paused task,
+  // and the user's prior resolution never lands.
+  const escalatingTaskId = detectPendingEscalation(tasks, basePath);
+  if (escalatingTaskId) {
+    return {
+      activeMilestone, activeSlice, activeTask,
+      phase: 'escalating-task', recentDecisions: [],
+      blockers: [`Task ${escalatingTaskId} requires a user decision before the loop can proceed`],
+      nextAction: `Run /gsd escalate show ${escalatingTaskId} to review, then /gsd escalate resolve ${escalatingTaskId} <choice> to proceed.`,
+      activeWorkspace: undefined,
+      registry, requirements,
+      progress: { milestones: milestoneProgress, slices: sliceProgress, tasks: taskProgress },
+    };
   }
 
   if (!blockerTaskId) {

--- a/src/resources/extensions/gsd/state.ts
+++ b/src/resources/extensions/gsd/state.ts
@@ -44,6 +44,8 @@ import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { debugCount, debugTime } from './debug-logger.js';
 import { logWarning, logError } from './workflow-logger.js';
 import { extractVerdict } from './verdict-parser.js';
+import { loadEffectiveGSDPreferences } from './preferences.js';
+import { detectPendingEscalation } from './escalation.js';
 
 import {
   isDbAvailable,
@@ -958,6 +960,25 @@ export async function deriveStateFromDb(basePath: string): Promise<GSDState> {
         phase: 'replanning-slice', recentDecisions: [],
         blockers: [`Task ${blockerTaskId} discovered a blocker requiring slice replan`],
         nextAction: `Task ${blockerTaskId} reported blocker_discovered. Replan slice ${activeSlice.id} before continuing.`,
+        activeWorkspace: undefined,
+        registry, requirements,
+        progress: { milestones: milestoneProgress, slices: sliceProgress, tasks: taskProgress },
+      };
+    }
+  }
+
+  // ADR-011 Phase 2: pause-on-escalation takes precedence over dispatching the
+  // next task. `awaiting_review` tasks (continueWithDefault=true) are NOT
+  // surfaced here — they let the loop continue.
+  const escalationEnabled = loadEffectiveGSDPreferences()?.preferences?.phases?.mid_execution_escalation === true;
+  if (escalationEnabled) {
+    const escalatingTaskId = detectPendingEscalation(tasks, basePath);
+    if (escalatingTaskId) {
+      return {
+        activeMilestone, activeSlice, activeTask,
+        phase: 'escalating-task', recentDecisions: [],
+        blockers: [`Task ${escalatingTaskId} requires a user decision before the loop can proceed`],
+        nextAction: `Run /gsd escalate show ${escalatingTaskId} to review, then /gsd escalate resolve ${escalatingTaskId} <choice> to proceed.`,
         activeWorkspace: undefined,
         registry, requirements,
         progress: { milestones: milestoneProgress, slices: sliceProgress, tasks: taskProgress },

--- a/src/resources/extensions/gsd/tests/artifact-corruption-2630.test.ts
+++ b/src/resources/extensions/gsd/tests/artifact-corruption-2630.test.ts
@@ -77,6 +77,11 @@ function makeTaskRow(overrides?: Partial<TaskRow>): TaskRow {
     expected_output: [],
     observability_impact: '',
     sequence: 0,
+    blocker_source: '',
+    escalation_pending: 0,
+    escalation_awaiting_review: 0,
+    escalation_artifact_path: null,
+    escalation_override_applied_at: null,
     ...overrides,
   };
 }

--- a/src/resources/extensions/gsd/tests/artifact-corruption-2630.test.ts
+++ b/src/resources/extensions/gsd/tests/artifact-corruption-2630.test.ts
@@ -46,6 +46,8 @@ function makeSliceRow(overrides?: Partial<SliceRow>): SliceRow {
     observability_impact: '',
     sequence: 4,
     replan_triggered_at: null,
+    is_sketch: 0,
+    sketch_scope: '',
     ...overrides,
   };
 }

--- a/src/resources/extensions/gsd/tests/complete-slice.test.ts
+++ b/src/resources/extensions/gsd/tests/complete-slice.test.ts
@@ -125,9 +125,9 @@ console.log('\n=== complete-slice: schema v6 migration ===');
 
   const adapter = _getAdapter()!;
 
-  // Verify schema version is current (v15 with UOK projection tables)
+  // Verify schema version is current (v17 with ADR-011 P2 escalation columns)
   const versionRow = adapter.prepare('SELECT MAX(version) as v FROM schema_version').get();
-  assertEq(versionRow?.['v'], 15, 'schema version should be 15');
+  assertEq(versionRow?.['v'], 17, 'schema version should be 17');
 
   // Verify slices table has full_summary_md and full_uat_md columns
   const cols = adapter.prepare("PRAGMA table_info(slices)").all();

--- a/src/resources/extensions/gsd/tests/complete-slice.test.ts
+++ b/src/resources/extensions/gsd/tests/complete-slice.test.ts
@@ -125,9 +125,9 @@ console.log('\n=== complete-slice: schema v6 migration ===');
 
   const adapter = _getAdapter()!;
 
-  // Verify schema version is current (v15 with UOK projection tables)
+  // Verify schema version is current (v16 with ADR-011 sketch columns)
   const versionRow = adapter.prepare('SELECT MAX(version) as v FROM schema_version').get();
-  assertEq(versionRow?.['v'], 15, 'schema version should be 15');
+  assertEq(versionRow?.['v'], 16, 'schema version should be 16');
 
   // Verify slices table has full_summary_md and full_uat_md columns
   const cols = adapter.prepare("PRAGMA table_info(slices)").all();

--- a/src/resources/extensions/gsd/tests/complete-task.test.ts
+++ b/src/resources/extensions/gsd/tests/complete-task.test.ts
@@ -109,9 +109,9 @@ console.log('\n=== complete-task: schema v5 migration ===');
 
   const adapter = _getAdapter()!;
 
-  // Verify schema version is current (v15 with UOK projection tables)
+  // Verify schema version is current (v17 with ADR-011 P2 escalation columns)
   const versionRow = adapter.prepare('SELECT MAX(version) as v FROM schema_version').get();
-  assertEq(versionRow?.['v'], 15, 'schema version should be 15');
+  assertEq(versionRow?.['v'], 17, 'schema version should be 17');
 
   // Verify all 4 new tables exist
   const tables = adapter.prepare(

--- a/src/resources/extensions/gsd/tests/complete-task.test.ts
+++ b/src/resources/extensions/gsd/tests/complete-task.test.ts
@@ -109,9 +109,9 @@ console.log('\n=== complete-task: schema v5 migration ===');
 
   const adapter = _getAdapter()!;
 
-  // Verify schema version is current (v15 with UOK projection tables)
+  // Verify schema version is current (v16 with ADR-011 sketch columns)
   const versionRow = adapter.prepare('SELECT MAX(version) as v FROM schema_version').get();
-  assertEq(versionRow?.['v'], 15, 'schema version should be 15');
+  assertEq(versionRow?.['v'], 16, 'schema version should be 16');
 
   // Verify all 4 new tables exist
   const tables = adapter.prepare(

--- a/src/resources/extensions/gsd/tests/enhanced-verification-integration.test.ts
+++ b/src/resources/extensions/gsd/tests/enhanced-verification-integration.test.ts
@@ -70,6 +70,11 @@ function createTask(overrides: Partial<TaskRow> = {}): TaskRow {
     observability_impact: "",
     full_plan_md: "",
     sequence: overrides.sequence ?? 0,
+    blocker_source: "",
+    escalation_pending: 0,
+    escalation_awaiting_review: 0,
+    escalation_artifact_path: null,
+    escalation_override_applied_at: null,
     ...overrides,
   };
 }

--- a/src/resources/extensions/gsd/tests/escalation.test.ts
+++ b/src/resources/extensions/gsd/tests/escalation.test.ts
@@ -1,0 +1,446 @@
+// GSD Extension — ADR-011 Phase 2 Mid-Execution Escalation tests
+// Covers: artifact write/read, detection, resolution (A|B|accept|reject-blocker),
+// DB claim race, carry-forward injection, schema v16/v17 migration, feature flag.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import {
+  openDatabase,
+  closeDatabase,
+  insertMilestone,
+  insertSlice,
+  insertTask,
+  updateTaskStatus,
+  getTask,
+  claimEscalationOverride,
+  findUnappliedEscalationOverride,
+  listEscalationArtifacts,
+  _getAdapter,
+} from "../gsd-db.ts";
+import {
+  buildEscalationArtifact,
+  writeEscalationArtifact,
+  readEscalationArtifact,
+  detectPendingEscalation,
+  resolveEscalation,
+  claimOverrideForInjection,
+  escalationArtifactPath,
+} from "../escalation.ts";
+import type { EscalationOption } from "../types.ts";
+
+// ─── Fixture helpers ──────────────────────────────────────────────────────
+
+function makeBase(): string {
+  const base = mkdtempSync(join(tmpdir(), "gsd-adr011-p2-"));
+  mkdirSync(join(base, ".gsd", "milestones", "M001", "slices", "S01", "tasks"), { recursive: true });
+  return base;
+}
+
+function cleanup(base: string): void {
+  try { closeDatabase(); } catch { /* noop */ }
+  try { rmSync(base, { recursive: true, force: true }); } catch { /* noop */ }
+}
+
+function writePrefs(base: string, enabled: boolean): void {
+  const path = join(base, ".gsd", "PREFERENCES.md");
+  writeFileSync(path, [
+    "---",
+    "version: 1",
+    "phases:",
+    `  mid_execution_escalation: ${enabled}`,
+    "---",
+  ].join("\n"));
+}
+
+function seedCompletedTask(base: string, taskId: string): void {
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M001", title: "Test", status: "active" });
+  insertSlice({ id: "S01", milestoneId: "M001", title: "Slice" });
+  insertTask({
+    id: taskId, sliceId: "S01", milestoneId: "M001", title: "Task",
+    status: "complete",
+  });
+}
+
+const sampleOptions: EscalationOption[] = [
+  { id: "A", label: "Separate table", tradeoffs: "More flexible; requires migration." },
+  { id: "B", label: "JSON array", tradeoffs: "Simpler; limited to ~1000 entries." },
+];
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Tests
+// ═══════════════════════════════════════════════════════════════════════════
+
+test("ADR-011 P2: writeEscalationArtifact persists canonical JSON at tasks/T##-ESCALATION.json", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  seedCompletedTask(base, "T03");
+
+  const art = buildEscalationArtifact({
+    taskId: "T03", sliceId: "S01", milestoneId: "M001",
+    question: "Where should we store notifications?",
+    options: sampleOptions,
+    recommendation: "B",
+    recommendationRationale: "Single-user display only.",
+    continueWithDefault: false,
+  });
+  const path = writeEscalationArtifact(base, art);
+  assert.ok(existsSync(path), "artifact file must exist");
+  assert.ok(path.endsWith("/tasks/T03-ESCALATION.json"), `path should end with tasks/T03-ESCALATION.json, got ${path}`);
+
+  const roundTrip = readEscalationArtifact(path);
+  assert.ok(roundTrip, "artifact must round-trip");
+  assert.equal(roundTrip!.taskId, "T03");
+  assert.equal(roundTrip!.recommendation, "B");
+  assert.equal(roundTrip!.options.length, 2);
+
+  // DB flag flipped to pending (continueWithDefault=false).
+  const row = getTask("M001", "S01", "T03");
+  assert.equal(row?.escalation_pending, 1);
+  assert.equal(row?.escalation_awaiting_review, 0);
+  assert.equal(row?.escalation_artifact_path, path);
+});
+
+test("ADR-011 P2: continueWithDefault=true sets awaiting_review (NOT pending) — no pause", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  seedCompletedTask(base, "T04");
+
+  const art = buildEscalationArtifact({
+    taskId: "T04", sliceId: "S01", milestoneId: "M001",
+    question: "Q",
+    options: sampleOptions,
+    recommendation: "A",
+    recommendationRationale: "r",
+    continueWithDefault: true,
+  });
+  writeEscalationArtifact(base, art);
+
+  const row = getTask("M001", "S01", "T04");
+  assert.equal(row?.escalation_pending, 0, "fire-and-correct must NOT set escalation_pending");
+  assert.equal(row?.escalation_awaiting_review, 1);
+});
+
+test("ADR-011 P2: detectPendingEscalation returns only pause-scoped escalations", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  seedCompletedTask(base, "T01");
+  seedCompletedTask(base, "T02");
+
+  // T01: continueWithDefault=true (awaiting_review, not pending)
+  writeEscalationArtifact(base, buildEscalationArtifact({
+    taskId: "T01", sliceId: "S01", milestoneId: "M001",
+    question: "Q1", options: sampleOptions, recommendation: "A", recommendationRationale: "r",
+    continueWithDefault: true,
+  }));
+  // T02: continueWithDefault=false (pause)
+  writeEscalationArtifact(base, buildEscalationArtifact({
+    taskId: "T02", sliceId: "S01", milestoneId: "M001",
+    question: "Q2", options: sampleOptions, recommendation: "B", recommendationRationale: "r",
+    continueWithDefault: false,
+  }));
+
+  const tasks = [getTask("M001", "S01", "T01")!, getTask("M001", "S01", "T02")!];
+  const id = detectPendingEscalation(tasks, base);
+  assert.equal(id, "T02", "only T02 is pause-worthy; T01 is awaiting_review");
+});
+
+test("ADR-011 P2: resolveEscalation(accept) marks artifact + clears flags", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  seedCompletedTask(base, "T05");
+
+  writeEscalationArtifact(base, buildEscalationArtifact({
+    taskId: "T05", sliceId: "S01", milestoneId: "M001",
+    question: "Q", options: sampleOptions, recommendation: "B", recommendationRationale: "r",
+    continueWithDefault: false,
+  }));
+
+  const result = resolveEscalation(base, "M001", "S01", "T05", "accept", "looks good");
+  assert.equal(result.status, "resolved");
+  assert.equal(result.chosenOption?.id, "B");
+
+  const row = getTask("M001", "S01", "T05");
+  assert.equal(row?.escalation_pending, 0);
+  assert.equal(row?.escalation_awaiting_review, 0);
+
+  const artPath = escalationArtifactPath(base, "M001", "S01", "T05")!;
+  const art = readEscalationArtifact(artPath);
+  assert.ok(art?.respondedAt, "artifact must record respondedAt");
+  assert.equal(art?.userChoice, "accept");
+  assert.equal(art?.userRationale, "looks good");
+});
+
+test("ADR-011 P2: resolveEscalation(reject-blocker) sets blocker_discovered + blocker_source", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  seedCompletedTask(base, "T06");
+
+  writeEscalationArtifact(base, buildEscalationArtifact({
+    taskId: "T06", sliceId: "S01", milestoneId: "M001",
+    question: "Q", options: sampleOptions, recommendation: "A", recommendationRationale: "r",
+    continueWithDefault: false,
+  }));
+
+  const result = resolveEscalation(base, "M001", "S01", "T06", "reject-blocker", "none of these work");
+  assert.equal(result.status, "rejected-to-blocker");
+
+  const row = getTask("M001", "S01", "T06");
+  assert.equal(row?.blocker_discovered, true, "reject-blocker must flip blocker_discovered=1");
+  assert.equal(row?.blocker_source, "reject-escalation", "blocker_source must record provenance");
+  assert.equal(row?.escalation_pending, 0);
+});
+
+test("ADR-011 P2: resolveEscalation(invalid-choice) returns error + leaves state untouched", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  seedCompletedTask(base, "T07");
+
+  writeEscalationArtifact(base, buildEscalationArtifact({
+    taskId: "T07", sliceId: "S01", milestoneId: "M001",
+    question: "Q", options: sampleOptions, recommendation: "A", recommendationRationale: "r",
+    continueWithDefault: false,
+  }));
+
+  const result = resolveEscalation(base, "M001", "S01", "T07", "Z", "");
+  assert.equal(result.status, "invalid-choice");
+
+  // State must NOT have changed.
+  const row = getTask("M001", "S01", "T07");
+  assert.equal(row?.escalation_pending, 1, "flag must still be pending after invalid choice");
+});
+
+test("ADR-011 P2: claimEscalationOverride is atomic — only one claimer wins the race", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  seedCompletedTask(base, "T08");
+
+  writeEscalationArtifact(base, buildEscalationArtifact({
+    taskId: "T08", sliceId: "S01", milestoneId: "M001",
+    question: "Q", options: sampleOptions, recommendation: "A", recommendationRationale: "r",
+    continueWithDefault: false,
+  }));
+  resolveEscalation(base, "M001", "S01", "T08", "A", "pick A");
+
+  const first = claimEscalationOverride("M001", "S01", "T08");
+  const second = claimEscalationOverride("M001", "S01", "T08");
+  assert.equal(first, true, "first claim wins");
+  assert.equal(second, false, "second claim must fail — override already applied");
+});
+
+test("ADR-011 P2: claimOverrideForInjection returns null when flag ON but no unapplied override", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  seedCompletedTask(base, "T09");
+
+  const claimed = claimOverrideForInjection(base, "M001", "S01");
+  assert.equal(claimed, null);
+});
+
+test("ADR-011 P2: claim does NOT fire on unresolved awaiting_review — resolution is preserved until user responds", (t) => {
+  // Regression for peer-review Bug 2: previously findUnappliedEscalationOverride
+  // matched `escalation_pending=0` alone, so an awaiting_review task (created
+  // by continueWithDefault=true) was silently claimed before the user had
+  // a chance to resolve, permanently dropping the override.
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  seedCompletedTask(base, "T09a");
+  seedCompletedTask(base, "T09b");
+
+  // Write a continueWithDefault=true artifact (awaiting_review=1, no respondedAt).
+  writeEscalationArtifact(base, buildEscalationArtifact({
+    taskId: "T09a", sliceId: "S01", milestoneId: "M001",
+    question: "Which DB?", options: sampleOptions,
+    recommendation: "A", recommendationRationale: "r",
+    continueWithDefault: true,
+  }));
+
+  // NEXT task's prompt build — must NOT claim the unresolved awaiting_review.
+  const premature = claimOverrideForInjection(base, "M001", "S01");
+  assert.equal(premature, null, "awaiting_review without respondedAt must not be claimed");
+
+  const midState = getTask("M001", "S01", "T09a");
+  assert.equal(midState?.escalation_override_applied_at, null, "applied_at must still be null");
+
+  // User now resolves.
+  resolveEscalation(base, "M001", "S01", "T09a", "B", "actually B is better");
+
+  // NEXT task's prompt build — NOW the override must be claimed and injected.
+  const claimed = claimOverrideForInjection(base, "M001", "S01");
+  assert.ok(claimed, "after user resolution, the override must be injectable");
+  assert.equal(claimed!.sourceTaskId, "T09a");
+  assert.match(claimed!.injectionBlock, /Escalation Override/);
+});
+
+test("ADR-011 P2: claimOverrideForInjection returns markdown block once, then null", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  seedCompletedTask(base, "T10");
+
+  writeEscalationArtifact(base, buildEscalationArtifact({
+    taskId: "T10", sliceId: "S01", milestoneId: "M001",
+    question: "Which storage?",
+    options: sampleOptions,
+    recommendation: "A",
+    recommendationRationale: "r",
+    continueWithDefault: false,
+  }));
+  resolveEscalation(base, "M001", "S01", "T10", "A", "pick A");
+
+  const first = claimOverrideForInjection(base, "M001", "S01");
+  assert.ok(first, "first claim returns the override");
+  assert.match(first!.injectionBlock, /Escalation Override/);
+  assert.equal(first!.sourceTaskId, "T10");
+
+  const second = claimOverrideForInjection(base, "M001", "S01");
+  assert.equal(second, null, "second call returns null (idempotent)");
+});
+
+test("ADR-011 P2: listEscalationArtifacts filters to actionable by default", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  seedCompletedTask(base, "T11");
+  seedCompletedTask(base, "T12");
+
+  // Pending (actionable)
+  writeEscalationArtifact(base, buildEscalationArtifact({
+    taskId: "T11", sliceId: "S01", milestoneId: "M001",
+    question: "Q", options: sampleOptions, recommendation: "A", recommendationRationale: "r",
+    continueWithDefault: false,
+  }));
+  // Resolved (not actionable by default)
+  writeEscalationArtifact(base, buildEscalationArtifact({
+    taskId: "T12", sliceId: "S01", milestoneId: "M001",
+    question: "Q", options: sampleOptions, recommendation: "A", recommendationRationale: "r",
+    continueWithDefault: false,
+  }));
+  resolveEscalation(base, "M001", "S01", "T12", "A", "");
+
+  const actionable = listEscalationArtifacts("M001", false);
+  const all = listEscalationArtifacts("M001", true);
+  assert.equal(actionable.length, 1, "only T11 is actionable");
+  assert.equal(actionable[0]!.id, "T11");
+  assert.equal(all.length, 2, "both surface with --all");
+});
+
+test("ADR-011 P2: schema v17 fresh DB has all escalation columns on tasks + source on decisions", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  openDatabase(join(base, ".gsd", "gsd.db"));
+
+  const adapter = _getAdapter()!;
+  const tasksCols = adapter.prepare("PRAGMA table_info(tasks)").all().map((r) => r["name"] as string);
+  for (const col of [
+    "blocker_source",
+    "escalation_pending",
+    "escalation_awaiting_review",
+    "escalation_artifact_path",
+    "escalation_override_applied_at",
+  ]) {
+    assert.ok(tasksCols.includes(col), `tasks table must have ${col} column`);
+  }
+
+  const decCols = adapter.prepare("PRAGMA table_info(decisions)").all().map((r) => r["name"] as string);
+  assert.ok(decCols.includes("source"), "decisions table must have source column");
+
+  const version = adapter.prepare("SELECT MAX(version) as v FROM schema_version").get();
+  assert.equal(version?.["v"], 17);
+});
+
+test("ADR-011 P2: findUnappliedEscalationOverride returns null when escalation_pending=1 (still pending)", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  seedCompletedTask(base, "T13");
+
+  writeEscalationArtifact(base, buildEscalationArtifact({
+    taskId: "T13", sliceId: "S01", milestoneId: "M001",
+    question: "Q", options: sampleOptions, recommendation: "A", recommendationRationale: "r",
+    continueWithDefault: false,
+  }));
+
+  // Don't resolve — just query.
+  const found = findUnappliedEscalationOverride("M001", "S01");
+  assert.equal(found, null, "pending escalation must not surface as unapplied override");
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// ADR-011 Phase 3 integration-style tests (concurrent / timeout / recovery /
+// latency — adapted from refine-slice phase patterns).
+// ═══════════════════════════════════════════════════════════════════════════
+
+test("ADR-011 P3: concurrent escalations queue in arrival order — list returns multiple", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  seedCompletedTask(base, "T20");
+  seedCompletedTask(base, "T21");
+
+  writeEscalationArtifact(base, buildEscalationArtifact({
+    taskId: "T20", sliceId: "S01", milestoneId: "M001",
+    question: "Q1", options: sampleOptions, recommendation: "A", recommendationRationale: "r",
+    continueWithDefault: false,
+  }));
+  writeEscalationArtifact(base, buildEscalationArtifact({
+    taskId: "T21", sliceId: "S01", milestoneId: "M001",
+    question: "Q2", options: sampleOptions, recommendation: "B", recommendationRationale: "r",
+    continueWithDefault: false,
+  }));
+
+  const pending = listEscalationArtifacts("M001", false);
+  assert.equal(pending.length, 2);
+  // Both are pause-worthy — state derivation returns the first.
+  const first = detectPendingEscalation([getTask("M001", "S01", "T20")!, getTask("M001", "S01", "T21")!], base);
+  assert.equal(first, "T20", "detection returns first pending in arrival order");
+});
+
+test("ADR-011 P3: recovery — malformed artifact returns null from read, does not crash", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  seedCompletedTask(base, "T22");
+
+  const artPath = escalationArtifactPath(base, "M001", "S01", "T22")!;
+  mkdirSync(join(artPath, ".."), { recursive: true });
+  writeFileSync(artPath, "{ this is not json");
+  const result = readEscalationArtifact(artPath);
+  assert.equal(result, null, "malformed JSON must return null (no throw)");
+});
+
+test("ADR-011 P3: resolve-on-missing-artifact returns not-found without partial state", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  seedCompletedTask(base, "T23");
+
+  const result = resolveEscalation(base, "M001", "S01", "T23", "A", "");
+  assert.equal(result.status, "not-found");
+  const row = getTask("M001", "S01", "T23");
+  assert.equal(row?.escalation_pending, 0, "untouched");
+});
+
+test("ADR-011 P3: escalation write + detect latency — 20 tasks, one escalation, detection under 100ms", (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M001", title: "Test", status: "active" });
+  insertSlice({ id: "S01", milestoneId: "M001", title: "Slice" });
+  for (let i = 1; i <= 20; i++) {
+    const tid = `T${String(i).padStart(2, "0")}`;
+    insertTask({ id: tid, sliceId: "S01", milestoneId: "M001", title: `Task ${i}`, status: "complete" });
+  }
+  // Escalation on T15 only.
+  mkdirSync(join(base, ".gsd", "milestones", "M001", "slices", "S01", "tasks"), { recursive: true });
+  writeEscalationArtifact(base, buildEscalationArtifact({
+    taskId: "T15", sliceId: "S01", milestoneId: "M001",
+    question: "Q", options: sampleOptions, recommendation: "A", recommendationRationale: "r",
+    continueWithDefault: false,
+  }));
+
+  const tasks = Array.from({ length: 20 }, (_, i) => getTask("M001", "S01", `T${String(i + 1).padStart(2, "0")}`)!);
+  const start = Date.now();
+  const found = detectPendingEscalation(tasks, base);
+  const elapsed = Date.now() - start;
+  assert.equal(found, "T15");
+  assert.ok(elapsed < 100, `detection must complete under 100ms, took ${elapsed}ms`);
+});

--- a/src/resources/extensions/gsd/tests/escalation.test.ts
+++ b/src/resources/extensions/gsd/tests/escalation.test.ts
@@ -619,3 +619,200 @@ test("ADR-011 P3 #22: ADR-009 audit envelopes emitted across the escalation life
     assert.ok(payload["taskId"] === "T50" || payload["taskId"] === "T51");
   }
 });
+
+test("ADR-011 P3 #23: concurrent escalations across parallel slices — only the escalating branch pauses", (t) => {
+  // In parallel-slice execution each slice has its own active-task view.
+  // The scheduler calls detectPendingEscalation(tasks, base) with *that
+  // slice's* tasks only (state.ts:998). So if S01-T60 escalates and S02-T70
+  // does not, the S02 branch must remain dispatchable while S01 waits.
+  //
+  // This test pins: (a) each slice's detectPendingEscalation returns only
+  // its own pending tasks, (b) neither branch can see the other's
+  // escalation by accident, and (c) resolving one slice's escalation does
+  // not clear the other's pause signal.
+  const base = makeBase();
+  t.after(() => cleanup(base));
+
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M001", title: "Test", status: "active" });
+  insertSlice({ id: "S01", milestoneId: "M001", title: "Slice A" });
+  insertSlice({ id: "S02", milestoneId: "M001", title: "Slice B" });
+  mkdirSync(join(base, ".gsd", "milestones", "M001", "slices", "S02", "tasks"), { recursive: true });
+  insertTask({ id: "T60", sliceId: "S01", milestoneId: "M001", title: "Task A", status: "complete" });
+  insertTask({ id: "T70", sliceId: "S02", milestoneId: "M001", title: "Task B", status: "complete" });
+  insertTask({ id: "T71", sliceId: "S02", milestoneId: "M001", title: "Task B2", status: "complete" });
+
+  // Both slices escalate at the same time (parallel execution scenario).
+  writeEscalationArtifact(base, buildEscalationArtifact({
+    taskId: "T60", sliceId: "S01", milestoneId: "M001",
+    question: "S01 ambiguity?", options: sampleOptions,
+    recommendation: "A", recommendationRationale: "r",
+    continueWithDefault: false,
+  }));
+  writeEscalationArtifact(base, buildEscalationArtifact({
+    taskId: "T70", sliceId: "S02", milestoneId: "M001",
+    question: "S02 ambiguity?", options: sampleOptions,
+    recommendation: "B", recommendationRationale: "r",
+    continueWithDefault: false,
+  }));
+
+  // Per-slice detection: each branch sees only its own pending task.
+  const s01Tasks = [getTask("M001", "S01", "T60")!];
+  const s02Tasks = [getTask("M001", "S02", "T70")!, getTask("M001", "S02", "T71")!];
+  assert.equal(detectPendingEscalation(s01Tasks, base), "T60");
+  assert.equal(detectPendingEscalation(s02Tasks, base), "T70");
+
+  // Resolve S01's escalation — must NOT clear S02's pause signal.
+  resolveEscalation(base, "M001", "S01", "T60", "A", "pick A");
+  assert.equal(detectPendingEscalation([getTask("M001", "S01", "T60")!], base), null);
+  assert.equal(
+    detectPendingEscalation([getTask("M001", "S02", "T70")!, getTask("M001", "S02", "T71")!], base),
+    "T70",
+    "resolving one slice's escalation must leave the other slice paused",
+  );
+
+  // Resolving S02 independently clears the second pause.
+  resolveEscalation(base, "M001", "S02", "T70", "B", "pick B");
+  assert.equal(detectPendingEscalation([getTask("M001", "S02", "T70")!], base), null);
+});
+
+test("ADR-011 P3 #24: continueWithDefault timeout — late user response injects into the next task dispatched AFTER the response", (t) => {
+  // Timeline this test pins (the "timeout" is implicit — it's just the
+  // elapsed wall-clock where the loop keeps running after T80's
+  // continueWithDefault=true write):
+  //
+  //   1. T80 writes continueWithDefault=true → awaiting_review=1, loop
+  //      continues dispatching T81, T82. Neither claim fires because the
+  //      user has not responded (pins Bug 2 behavior, tested at line 244).
+  //   2. The user responds LATE (after T81/T82 already dispatched).
+  //   3. The very next prompt build (for T83) claims the override exactly
+  //      once. T81/T82 are in the past — they must not retroactively
+  //      receive the injection even though they ran during the window.
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  seedCompletedTask(base, "T80");
+  seedCompletedTask(base, "T81");
+  seedCompletedTask(base, "T82");
+  seedCompletedTask(base, "T83");
+
+  // Phase 1 — T80 escalates with continueWithDefault=true, loop continues.
+  writeEscalationArtifact(base, buildEscalationArtifact({
+    taskId: "T80", sliceId: "S01", milestoneId: "M001",
+    question: "Which cache strategy?", options: sampleOptions,
+    recommendation: "A", recommendationRationale: "A matches current telemetry",
+    continueWithDefault: true,
+  }));
+
+  // T80 is awaiting_review (not pending) — scheduler does not pause.
+  assert.equal(getTask("M001", "S01", "T80")?.escalation_awaiting_review, 1);
+  assert.equal(getTask("M001", "S01", "T80")?.escalation_pending, 0);
+  assert.equal(detectPendingEscalation([getTask("M001", "S01", "T80")!], base), null);
+
+  // T81 + T82 dispatch during the response window — neither gets the injection.
+  assert.equal(
+    claimOverrideForInjection(base, "M001", "S01"),
+    null,
+    "T81's prompt build must not claim the unresolved awaiting_review",
+  );
+  assert.equal(
+    claimOverrideForInjection(base, "M001", "S01"),
+    null,
+    "T82's prompt build must also not claim the unresolved awaiting_review",
+  );
+
+  // The response window remains open across N tasks — still no override applied.
+  assert.equal(
+    getTask("M001", "S01", "T80")?.escalation_override_applied_at,
+    null,
+    "applied_at must stay null throughout the response window",
+  );
+
+  // Phase 2 — user responds LATE with a different option than the recommendation.
+  const resolveResult = resolveEscalation(
+    base, "M001", "S01", "T80", "B", "after reviewing, B is the call",
+  );
+  assert.equal(resolveResult.status, "resolved");
+  assert.equal(resolveResult.chosenOption?.id, "B");
+
+  // Phase 3 — the very next prompt build (T83) claims the override exactly once.
+  const claimed = claimOverrideForInjection(base, "M001", "S01");
+  assert.ok(claimed, "T83's prompt build must claim the late-resolved override");
+  assert.equal(claimed!.sourceTaskId, "T80");
+  assert.match(claimed!.injectionBlock, /Escalation Override/);
+  assert.match(
+    claimed!.injectionBlock,
+    /JSON array|B/,
+    "injection must reflect the user's B choice, NOT the original A recommendation",
+  );
+
+  // Idempotent — subsequent prompts do not re-inject.
+  assert.equal(claimOverrideForInjection(base, "M001", "S01"), null);
+});
+
+test("ADR-011 P3 #25: artifact write failure surfaces, leaves DB flags clean, and retries successfully once recovered", async (t) => {
+  // Failure modes covered:
+  //   1. writeEscalationArtifact with an unresolvable slice path (no slice
+  //      dir on disk) throws synchronously — no DB flag flip, no audit.
+  //   2. After the flag still reads 0, the caller can retry once the dir
+  //      exists. Retry succeeds and atomically flips escalation_pending=1
+  //      plus emits exactly one audit envelope (not two — idempotent
+  //      recovery, not replay).
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M001", title: "Test", status: "active" });
+  insertSlice({ id: "S09", milestoneId: "M001", title: "Unseeded slice" });
+  insertTask({ id: "T90", sliceId: "S09", milestoneId: "M001", title: "T", status: "complete" });
+
+  const artifact = buildEscalationArtifact({
+    taskId: "T90", sliceId: "S09", milestoneId: "M001",
+    question: "Q", options: sampleOptions, recommendation: "A", recommendationRationale: "r",
+    continueWithDefault: false,
+  });
+
+  // Phase 1 — slice dir does NOT exist yet; write must throw.
+  // escalationArtifactPath returns null, writeEscalationArtifact throws.
+  assert.throws(
+    () => writeEscalationArtifact(base, artifact),
+    /cannot resolve tasks dir/,
+    "missing slice dir must raise — caller is expected to run doctor before retry",
+  );
+
+  // DB flag must NOT be set — atomic failure semantics.
+  const midRow = getTask("M001", "S09", "T90");
+  assert.equal(midRow?.escalation_pending, 0, "failed write must leave escalation_pending=0");
+  assert.equal(midRow?.escalation_awaiting_review, 0);
+  assert.equal(midRow?.escalation_artifact_path, null);
+
+  // Audit log must have no escalation-created events from the failed write.
+  const logPath = join(base, ".gsd", "audit", "events.jsonl");
+  const preLines = existsSync(logPath)
+    ? readFileSync(logPath, "utf-8").split("\n").filter((l) => l.length > 0)
+    : [];
+  const preCount = preLines.filter((l) => l.includes("escalation-manual-attention-created")).length;
+  assert.equal(preCount, 0, "failed write must not emit an audit envelope");
+
+  // Phase 2 — caller recovers (creates the slice dir), retries.
+  // clearPathCache() because resolveSlicePath caches directory reads and
+  // the first failed attempt populated a miss for S09.
+  mkdirSync(join(base, ".gsd", "milestones", "M001", "slices", "S09", "tasks"), { recursive: true });
+  const { clearPathCache } = await import("../paths.ts");
+  clearPathCache();
+  const path = writeEscalationArtifact(base, artifact);
+  assert.ok(existsSync(path), "retry must atomically land the artifact on disk");
+
+  // DB flag flipped on successful retry.
+  const afterRow = getTask("M001", "S09", "T90");
+  assert.equal(afterRow?.escalation_pending, 1, "successful retry must flip escalation_pending=1");
+  assert.equal(afterRow?.escalation_artifact_path, path);
+
+  // Audit log now contains exactly one escalation-created event for T90.
+  const postLines = readFileSync(logPath, "utf-8").split("\n").filter((l) => l.length > 0);
+  const t90Events = postLines
+    .map((l) => JSON.parse(l) as Record<string, unknown>)
+    .filter((e) =>
+      e["type"] === "escalation-manual-attention-created"
+      && (e["payload"] as Record<string, unknown>)?.["taskId"] === "T90",
+    );
+  assert.equal(t90Events.length, 1, "successful retry must emit exactly one audit envelope");
+});

--- a/src/resources/extensions/gsd/tests/escalation.test.ts
+++ b/src/resources/extensions/gsd/tests/escalation.test.ts
@@ -4,7 +4,7 @@
 
 import test from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync, existsSync } from "node:fs";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
@@ -443,4 +443,179 @@ test("ADR-011 P3: escalation write + detect latency — 20 tasks, one escalation
   const elapsed = Date.now() - start;
   assert.equal(found, "T15");
   assert.ok(elapsed < 100, `detection must complete under 100ms, took ${elapsed}ms`);
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// ADR-011 Phase 3 — Integration: Mid-Execution Escalation
+// ═══════════════════════════════════════════════════════════════════════════
+
+test("ADR-011 P3 #20: E2E escalation lifecycle — write → pause → resolve → resume via override injection", (t) => {
+  // Exercises the full escalation loop across two tasks in one slice:
+  //   1. Executor writes ESCALATION.json on T30 with continueWithDefault=false.
+  //   2. detectPendingEscalation returns T30 (state.ts:998 is what pauses the loop).
+  //   3. User calls resolveEscalation with a specific option choice.
+  //   4. detectPendingEscalation returns null — pause condition cleared.
+  //   5. The *next* task (T31) in the slice picks up the override block via
+  //      claimOverrideForInjection exactly once (idempotent across retries).
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  seedCompletedTask(base, "T30");
+  seedCompletedTask(base, "T31");
+
+  // Step 1: executor escalates on T30 (pause-scoped).
+  writeEscalationArtifact(base, buildEscalationArtifact({
+    taskId: "T30", sliceId: "S01", milestoneId: "M001",
+    question: "Storage format for the new metrics table?",
+    options: sampleOptions, recommendation: "A", recommendationRationale: "A is simpler",
+    continueWithDefault: false,
+  }));
+
+  // Step 2: scheduler sees the pause signal.
+  let tasks = [getTask("M001", "S01", "T30")!, getTask("M001", "S01", "T31")!];
+  assert.equal(
+    detectPendingEscalation(tasks, base),
+    "T30",
+    "scheduler must pause on T30 before dispatching T31",
+  );
+
+  // Claim attempted mid-pause must fail (override not yet resolved).
+  assert.equal(
+    claimOverrideForInjection(base, "M001", "S01"),
+    null,
+    "no injection should fire while escalation is still pending",
+  );
+
+  // Step 3: user responds with option B + rationale.
+  const result = resolveEscalation(base, "M001", "S01", "T30", "B", "B fits better");
+  assert.equal(result.status, "resolved");
+  assert.equal(result.chosenOption?.id, "B");
+
+  // Step 4: pause condition clears.
+  tasks = [getTask("M001", "S01", "T30")!, getTask("M001", "S01", "T31")!];
+  assert.equal(
+    detectPendingEscalation(tasks, base),
+    null,
+    "after resolve, scheduler must not re-pause on T30",
+  );
+
+  // Step 5: next task (T31) picks up the override exactly once.
+  const injected = claimOverrideForInjection(base, "M001", "S01");
+  assert.ok(injected, "T31's prompt build must claim the resolved override");
+  assert.equal(injected!.sourceTaskId, "T30");
+  assert.match(injected!.injectionBlock, /Escalation Override/);
+  assert.match(injected!.injectionBlock, /B/, "injection must reflect user's chosen option id");
+
+  const secondClaim = claimOverrideForInjection(base, "M001", "S01");
+  assert.equal(secondClaim, null, "override must be consumed exactly once");
+});
+
+test("ADR-011 P3 #21: blocker takes priority over escalation when both flags coexist on same task", (t) => {
+  // Two invariants together give blocker-priority:
+  //   a) state.ts:977-991 checks detectBlockers BEFORE the escalation branch
+  //      at state.ts:996-1010, so a blocker flag short-circuits the escalation
+  //      pause.
+  //   b) resolveEscalation(reject-blocker) atomically clears escalation flags
+  //      AND sets blocker_discovered=1 (escalation.ts:227-230), so there is no
+  //      post-resolve window where both flags could surface simultaneously.
+  // This test pins (b): after reject-blocker, the escalation pause signal is
+  // gone and the task is exclusively in blocker-state.
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  seedCompletedTask(base, "T40");
+
+  writeEscalationArtifact(base, buildEscalationArtifact({
+    taskId: "T40", sliceId: "S01", milestoneId: "M001",
+    question: "Which storage?", options: sampleOptions,
+    recommendation: "A", recommendationRationale: "r",
+    continueWithDefault: false,
+  }));
+
+  // Pre-condition: escalation is active, blocker is not.
+  let row = getTask("M001", "S01", "T40");
+  assert.equal(row?.escalation_pending, 1);
+  assert.equal(row?.blocker_discovered, false);
+  assert.equal(detectPendingEscalation([row!], base), "T40");
+
+  // User rejects to blocker — single transition.
+  const result = resolveEscalation(
+    base, "M001", "S01", "T40", "reject-blocker", "none of these fit the observed constraints",
+  );
+  assert.equal(result.status, "rejected-to-blocker");
+
+  // Post-condition: blocker is set, escalation flags are cleared.
+  row = getTask("M001", "S01", "T40");
+  assert.equal(row?.blocker_discovered, true, "blocker_discovered must be set after reject-blocker");
+  assert.equal(row?.blocker_source, "reject-escalation", "blocker_source records provenance");
+  assert.equal(row?.escalation_pending, 0, "escalation_pending must be cleared");
+  assert.equal(row?.escalation_awaiting_review, 0, "escalation_awaiting_review must be cleared");
+
+  // detectPendingEscalation must no longer return T40 — scheduler would
+  // otherwise race the blocker branch and pick the wrong phase.
+  assert.equal(
+    detectPendingEscalation([row!], base),
+    null,
+    "after reject-blocker, escalation must not pause — blocker path owns the task",
+  );
+});
+
+test("ADR-011 P3 #22: ADR-009 audit envelopes emitted across the escalation lifecycle", (t) => {
+  // Verifies that every user-visible escalation event writes a structured
+  // audit envelope (eventId, traceId, category, type, ts, payload) to
+  // .gsd/audit/events.jsonl. ADR-009 control-plane consumers depend on this
+  // shape. Covered event types:
+  //   - escalation-manual-attention-created (on write)
+  //   - escalation-user-responded            (on resolve with option)
+  //   - escalation-rejected-to-blocker       (on reject-blocker)
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  seedCompletedTask(base, "T50");
+  seedCompletedTask(base, "T51");
+
+  // 1) write → created
+  writeEscalationArtifact(base, buildEscalationArtifact({
+    taskId: "T50", sliceId: "S01", milestoneId: "M001",
+    question: "Q50", options: sampleOptions, recommendation: "A", recommendationRationale: "r",
+    continueWithDefault: false,
+  }));
+
+  // 2) resolve(accept) → responded
+  resolveEscalation(base, "M001", "S01", "T50", "accept", "sounds right");
+
+  // 3) another write + reject-blocker → rejected
+  writeEscalationArtifact(base, buildEscalationArtifact({
+    taskId: "T51", sliceId: "S01", milestoneId: "M001",
+    question: "Q51", options: sampleOptions, recommendation: "B", recommendationRationale: "r",
+    continueWithDefault: false,
+  }));
+  resolveEscalation(base, "M001", "S01", "T51", "reject-blocker", "blocker path");
+
+  // Read audit log and parse each JSONL envelope.
+  const logPath = join(base, ".gsd", "audit", "events.jsonl");
+  assert.ok(existsSync(logPath), "audit log must exist at .gsd/audit/events.jsonl");
+  const lines = readFileSync(logPath, "utf-8").split("\n").filter((l) => l.length > 0);
+  const events = lines.map((l) => JSON.parse(l) as Record<string, unknown>);
+  const escalationEvents = events.filter((e) => typeof e["type"] === "string" && (e["type"] as string).startsWith("escalation-"));
+
+  // All four lifecycle events must be present.
+  const types = escalationEvents.map((e) => e["type"] as string).sort();
+  assert.deepEqual(types, [
+    "escalation-manual-attention-created",
+    "escalation-manual-attention-created",
+    "escalation-rejected-to-blocker",
+    "escalation-user-responded",
+  ]);
+
+  // Every envelope must carry the ADR-009 contract fields.
+  for (const env of escalationEvents) {
+    assert.equal(typeof env["eventId"], "string", "envelope must include eventId");
+    assert.equal(typeof env["traceId"], "string", "envelope must include traceId");
+    assert.match(env["traceId"] as string, /^escalation:M001:S01:T5[01]$/, "traceId must be stable and task-scoped");
+    assert.equal(env["category"], "gate", "escalation events belong to the gate control plane");
+    assert.equal(typeof env["ts"], "string");
+    assert.ok(env["payload"] && typeof env["payload"] === "object", "payload must be an object");
+    const payload = env["payload"] as Record<string, unknown>;
+    assert.equal(payload["milestoneId"], "M001");
+    assert.equal(payload["sliceId"], "S01");
+    assert.ok(payload["taskId"] === "T50" || payload["taskId"] === "T51");
+  }
 });

--- a/src/resources/extensions/gsd/tests/gsd-db.test.ts
+++ b/src/resources/extensions/gsd/tests/gsd-db.test.ts
@@ -80,7 +80,7 @@ describe('gsd-db', () => {
     // Check schema_version table
     const adapter = _getAdapter()!;
     const version = adapter.prepare('SELECT MAX(version) as version FROM schema_version').get();
-    assert.deepStrictEqual(version?.['version'], 15, 'schema version should be 15');
+    assert.deepStrictEqual(version?.['version'], 16, 'schema version should be 16');
 
     // Check tables exist by querying them
     const dRows = adapter.prepare('SELECT count(*) as cnt FROM decisions').get();

--- a/src/resources/extensions/gsd/tests/gsd-db.test.ts
+++ b/src/resources/extensions/gsd/tests/gsd-db.test.ts
@@ -80,7 +80,7 @@ describe('gsd-db', () => {
     // Check schema_version table
     const adapter = _getAdapter()!;
     const version = adapter.prepare('SELECT MAX(version) as version FROM schema_version').get();
-    assert.deepStrictEqual(version?.['version'], 15, 'schema version should be 15');
+    assert.deepStrictEqual(version?.['version'], 17, 'schema version should be 17');
 
     // Check tables exist by querying them
     const dRows = adapter.prepare('SELECT count(*) as cnt FROM decisions').get();

--- a/src/resources/extensions/gsd/tests/md-importer.test.ts
+++ b/src/resources/extensions/gsd/tests/md-importer.test.ts
@@ -363,7 +363,7 @@ test('md-importer: schema v1→v2 migration', () => {
   openDatabase(':memory:');
   const adapter = _getAdapter();
   const version = adapter?.prepare('SELECT MAX(version) as v FROM schema_version').get();
-  assert.deepStrictEqual(version?.v, 15, 'new DB should be at schema version 15');
+  assert.deepStrictEqual(version?.v, 17, 'new DB should be at schema version 17');
 
   // Artifacts table should exist
   const tableCheck = adapter?.prepare("SELECT count(*) as c FROM sqlite_master WHERE type='table' AND name='artifacts'").get();

--- a/src/resources/extensions/gsd/tests/md-importer.test.ts
+++ b/src/resources/extensions/gsd/tests/md-importer.test.ts
@@ -363,7 +363,7 @@ test('md-importer: schema v1→v2 migration', () => {
   openDatabase(':memory:');
   const adapter = _getAdapter();
   const version = adapter?.prepare('SELECT MAX(version) as v FROM schema_version').get();
-  assert.deepStrictEqual(version?.v, 15, 'new DB should be at schema version 15');
+  assert.deepStrictEqual(version?.v, 16, 'new DB should be at schema version 16');
 
   // Artifacts table should exist
   const tableCheck = adapter?.prepare("SELECT count(*) as c FROM sqlite_master WHERE type='table' AND name='artifacts'").get();

--- a/src/resources/extensions/gsd/tests/memory-store.test.ts
+++ b/src/resources/extensions/gsd/tests/memory-store.test.ts
@@ -323,9 +323,9 @@ test('memory-store: schema includes memories table', () => {
   const viewCount = adapter.prepare('SELECT count(*) as cnt FROM active_memories').get();
   assert.deepStrictEqual(viewCount?.['cnt'], 0, 'active_memories view should exist');
 
-  // Verify schema version is 15 (UOK gate/git/audit projection tables included)
+  // Verify schema version is 17 (ADR-011 P2 escalation columns included)
   const version = adapter.prepare('SELECT MAX(version) as v FROM schema_version').get();
-  assert.deepStrictEqual(version?.['v'], 15, 'schema version should be 15');
+  assert.deepStrictEqual(version?.['v'], 17, 'schema version should be 17');
 
   closeDatabase();
 });

--- a/src/resources/extensions/gsd/tests/memory-store.test.ts
+++ b/src/resources/extensions/gsd/tests/memory-store.test.ts
@@ -325,7 +325,7 @@ test('memory-store: schema includes memories table', () => {
 
   // Verify schema version is 15 (UOK gate/git/audit projection tables included)
   const version = adapter.prepare('SELECT MAX(version) as v FROM schema_version').get();
-  assert.deepStrictEqual(version?.['v'], 15, 'schema version should be 15');
+  assert.deepStrictEqual(version?.['v'], 16, 'schema version should be 16');
 
   closeDatabase();
 });

--- a/src/resources/extensions/gsd/tests/model-unittype-mapping.test.ts
+++ b/src/resources/extensions/gsd/tests/model-unittype-mapping.test.ts
@@ -215,6 +215,65 @@ test("unitVerb handles discuss-slice", () => {
 // auto-artifact-paths.ts: artifact resolution
 // ═══════════════════════════════════════════════════════════════════════════
 
+// ═══════════════════════════════════════════════════════════════════════════
+// ADR-011: meta-test — every KNOWN_UNIT_TYPES entry must appear in all four
+// downstream registries so a future unit type added to KNOWN_UNIT_TYPES can't
+// silently fall through to wrong defaults in metrics/dashboard/artifacts/post-unit.
+// ═══════════════════════════════════════════════════════════════════════════
+
+// Intentional exceptions — unit types that legitimately rely on default/null
+// behavior in a specific registry. Entries captured here reflect the current
+// baseline at the time ADR-011 landed; adding to this allowlist for a NEW unit
+// type requires explicit justification in the commit.
+//
+// Test intent: catch the case where someone adds a new unit type to
+// KNOWN_UNIT_TYPES but forgets to wire it into one of the four registries.
+// The allowlist freezes the baseline so pre-existing omissions do not block
+// the test, but any brand-new addition must be either handled or justified.
+const REGISTRY_EXCEPTIONS: Record<string, Set<string>> = {
+  // metrics.ts classifyUnitPhase uses default → "execution" for most unit types.
+  "metrics.ts": new Set([
+    "worktree-merge", "custom-step",
+    "rewrite-docs", "run-uat", "gate-evaluate", "replan-slice",
+    "reactive-execute", "validate-milestone", "complete-milestone",
+  ]),
+  "auto-dashboard.ts": new Set([
+    "worktree-merge",
+    "gate-evaluate", "reactive-execute", "validate-milestone", "complete-milestone",
+  ]),
+  "auto-artifact-paths.ts": new Set([
+    "rewrite-docs", "gate-evaluate", "reactive-execute", "discuss-slice", "worktree-merge",
+  ]),
+  "auto-post-unit.ts": new Set([
+    "execute-task", "reactive-execute", "gate-evaluate", "worktree-merge",
+  ]),
+};
+
+const REGISTRY_SOURCES: Array<[string, string]> = [
+  ["metrics.ts", metricsSrc],
+  ["auto-dashboard.ts", dashboardSrc],
+  ["auto-artifact-paths.ts", artifactSrc],
+  ["auto-post-unit.ts", postUnitSrc],
+];
+
+test("ADR-011 meta: every KNOWN_UNIT_TYPES entry appears in all 4 downstream registries", () => {
+  const missing: Array<{ registry: string; unitType: string }> = [];
+  for (const [registry, src] of REGISTRY_SOURCES) {
+    for (const ut of ALL_KNOWN_UNIT_TYPES) {
+      if (REGISTRY_EXCEPTIONS[registry]?.has(ut)) continue;
+      if (!src.includes(`"${ut}"`)) {
+        missing.push({ registry, unitType: ut });
+      }
+    }
+  }
+  assert.deepEqual(
+    missing,
+    [],
+    "Each listed unit type is absent from the given registry — either add a handler or add to REGISTRY_EXCEPTIONS with justification:\n" +
+      missing.map((m) => `  ${m.registry}: "${m.unitType}"`).join("\n"),
+  );
+});
+
 test("resolveExpectedArtifactPath handles discuss-slice", () => {
   assert.ok(artifactSrc.includes('"discuss-slice"'), "missing discuss-slice in artifact paths");
 });

--- a/src/resources/extensions/gsd/tests/post-execution-checks.test.ts
+++ b/src/resources/extensions/gsd/tests/post-execution-checks.test.ts
@@ -56,6 +56,11 @@ function createTask(overrides: Partial<TaskRow> = {}): TaskRow {
     observability_impact: "",
     full_plan_md: "",
     sequence: overrides.sequence ?? 0,
+    blocker_source: "",
+    escalation_pending: 0,
+    escalation_awaiting_review: 0,
+    escalation_artifact_path: null,
+    escalation_override_applied_at: null,
     ...overrides,
   };
 }

--- a/src/resources/extensions/gsd/tests/pre-execution-checks.test.ts
+++ b/src/resources/extensions/gsd/tests/pre-execution-checks.test.ts
@@ -57,6 +57,11 @@ function createTask(overrides: Partial<TaskRow> = {}): TaskRow {
     observability_impact: "",
     full_plan_md: "",
     sequence: overrides.sequence ?? 0,
+    blocker_source: "",
+    escalation_pending: 0,
+    escalation_awaiting_review: 0,
+    escalation_artifact_path: null,
+    escalation_override_applied_at: null,
     ...overrides,
   };
 }

--- a/src/resources/extensions/gsd/tests/progressive-planning.test.ts
+++ b/src/resources/extensions/gsd/tests/progressive-planning.test.ts
@@ -349,3 +349,191 @@ test("ADR-011 ON CONFLICT: empty-string sketchScope clears existing scope (not p
   });
   assert.equal(getSlice("M001", "S01")?.sketch_scope, "", "explicit '' must clear, not preserve");
 });
+
+// ═══════════════════════════════════════════════════════════════════════════
+// ADR-011 Phase 3 — Integration: Progressive Planning
+// ═══════════════════════════════════════════════════════════════════════════
+
+test("ADR-011 P3 #19: refine-slice prompt incorporates prior slice findings + sketch scope as hard constraint", async (t) => {
+  // Exercises the end-to-end path that makes progressive planning useful:
+  //   1. M001 has 3 slices. S01 is full and complete, with a SUMMARY.md that
+  //      contains specific findings. S02 is a sketch that depends on S01.
+  //   2. The refining-phase dispatch builds S02's prompt via buildRefineSlicePrompt.
+  //   3. The generated prompt must contain BOTH the S01 findings (via
+  //      inlineDependencySummaries, same path plan-slice uses) AND the stored
+  //      sketch_scope prepended as a hard-constraint block (escalation-free
+  //      Phase 1 contract).
+  //
+  // This is the core value proposition of ADR-011: refine against the latest
+  // codebase state + upstream findings, not the blank snapshot from initial
+  // plan-milestone. If either piece is missing, the refine flow has regressed.
+  const originalCwd = process.cwd();
+  const base = makeFixtureBase();
+  t.after(() => cleanup(base, originalCwd));
+
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M001", title: "Integration test milestone", status: "active" });
+  insertSlice({
+    id: "S01", milestoneId: "M001", title: "Foundation",
+    status: "complete", risk: "high", depends: [], sequence: 1,
+    isSketch: false,
+  });
+  insertSlice({
+    id: "S02", milestoneId: "M001", title: "Feature built on foundation",
+    status: "pending", risk: "medium", depends: ["S01"], sequence: 2,
+    isSketch: true,
+    sketchScope: "Feature X in module Y only; do not refactor the foundation.",
+  });
+  insertSlice({
+    id: "S03", milestoneId: "M001", title: "Polish",
+    status: "pending", risk: "low", depends: ["S02"], sequence: 3,
+    isSketch: true,
+    sketchScope: "Polish + docs for Feature X.",
+  });
+
+  // Minimal roadmap so inlineRoadmapExcerpt has something to read.
+  writeFileSync(
+    join(base, ".gsd", "milestones", "M001", "ROADMAP.md"),
+    [
+      "# M001: Integration test milestone",
+      "",
+      "## Slices",
+      "",
+      "- [x] **S01: Foundation** `risk:high` `depends:[]`",
+      "- [ ] **S02: Feature built on foundation** `risk:medium` `depends:[S01]`",
+      "- [ ] **S03: Polish** `risk:low` `depends:[S02]`",
+      "",
+    ].join("\n"),
+  );
+
+  // Write S01 artifacts — the SUMMARY carries findings that S02's refine pass
+  // must incorporate. The specific markers below are what the assertion pins.
+  writeFileSync(
+    join(base, ".gsd", "milestones", "M001", "slices", "S01", "S01-PLAN.md"),
+    "# S01 Plan\n",
+  );
+  const s01Findings = [
+    "# S01 Summary",
+    "",
+    "## Findings",
+    "",
+    "- FINDING-MARKER-AUTH: chose JWT over sessions for statelessness.",
+    "- FINDING-MARKER-DB: schema v17 migration required before S02 can safely add the feature table.",
+    "",
+    "## Key Decisions",
+    "",
+    "- Do not introduce a background worker yet — premature.",
+  ].join("\n");
+  writeFileSync(
+    join(base, ".gsd", "milestones", "M001", "slices", "S01", "S01-SUMMARY.md"),
+    s01Findings,
+  );
+
+  writePreferences(base, "phases:\n  progressive_planning: true");
+  process.chdir(base);
+
+  // Build the refine prompt for S02 — the same call the refining-phase
+  // dispatch rule would make in production.
+  const { buildRefineSlicePrompt } = await import("../auto-prompts.ts");
+  const prompt = await buildRefineSlicePrompt(
+    "M001", "Integration test milestone", "S02", "Feature built on foundation", base,
+  );
+
+  // ── Sketch scope injected as a hard constraint ─────────────────────────
+  assert.match(
+    prompt,
+    /## Sketch Scope \(hard constraint\)/,
+    "refine prompt must frame sketch_scope as a hard constraint",
+  );
+  assert.match(
+    prompt,
+    /Feature X in module Y only/,
+    "refine prompt must include the stored sketch_scope text verbatim",
+  );
+
+  // ── Prior slice findings carried forward from S01-SUMMARY ──────────────
+  assert.match(
+    prompt,
+    /FINDING-MARKER-AUTH/,
+    "S01's auth finding must surface in the S02 refine prompt",
+  );
+  assert.match(
+    prompt,
+    /FINDING-MARKER-DB/,
+    "S01's DB finding must surface in the S02 refine prompt",
+  );
+  assert.match(
+    prompt,
+    /S01 Summary/,
+    "inlineDependencySummaries must label the injected block with S01's section header",
+  );
+
+  // ── Not the stale blank-slate plan-slice framing ───────────────────────
+  // The refine prompt is a *transformation*, not a blank-sheet plan. Pin the
+  // distinction so future prompt edits don't silently collapse the two paths.
+  assert.doesNotMatch(
+    prompt,
+    /Prior Sketch Scope \(soft hint — non-binding\)/,
+    "refine prompt must NOT use the soft-hint framing (that's the plan-slice flag-off downgrade)",
+  );
+});
+
+test("ADR-011 P3 #26: refine-slice dispatch latency is bounded vs plan-slice baseline", async (t) => {
+  // Pins the Zylos 2026 research claim that progressive planning trades a
+  // small dispatch-time cost for significant plan quality. The refine path
+  // does extra work: it reads sketch_scope from the DB and inlines the
+  // dependency summaries. Neither operation should dominate the prompt build.
+  //
+  // Absolute: < 500ms wall clock. Relative: < 3x plan-slice baseline.
+  // Both bounds are deliberately generous — this test is a regression gate,
+  // not a benchmark. The goal is catching accidental O(N) fs walks or DB
+  // queries that would multiply dispatch time as milestones grow.
+  const originalCwd = process.cwd();
+  const base = makeFixtureBase();
+  t.after(() => cleanup(base, originalCwd));
+
+  seedMilestoneWithSketchedS02(base);
+  writeS01Artifacts(base);
+  writeFileSync(
+    join(base, ".gsd", "milestones", "M001", "ROADMAP.md"),
+    [
+      "# M001: Test",
+      "",
+      "## Slices",
+      "",
+      "- [x] **S01: Foundation** `risk:high` `depends:[]`",
+      "- [ ] **S02: Feature** `risk:medium` `depends:[S01]`",
+      "",
+    ].join("\n"),
+  );
+  writePreferences(base, "phases:\n  progressive_planning: true");
+  process.chdir(base);
+
+  const { buildRefineSlicePrompt, buildPlanSlicePrompt } = await import("../auto-prompts.ts");
+
+  // Warm-up pass — first call loads the prompt template from disk and primes
+  // fs/DB caches. Measuring the cold path would be noisy and misleading.
+  await buildPlanSlicePrompt("M001", "Test", "S02", "Feature", base);
+  await buildRefineSlicePrompt("M001", "Test", "S02", "Feature", base);
+
+  const planStart = Date.now();
+  await buildPlanSlicePrompt("M001", "Test", "S02", "Feature", base);
+  const planElapsed = Date.now() - planStart;
+
+  const refineStart = Date.now();
+  await buildRefineSlicePrompt("M001", "Test", "S02", "Feature", base);
+  const refineElapsed = Date.now() - refineStart;
+
+  assert.ok(
+    refineElapsed < 500,
+    `refine-slice prompt build must complete under 500ms (took ${refineElapsed}ms)`,
+  );
+  // Guard the ratio only when the baseline is large enough to be meaningful —
+  // if plan-slice measures 0-2ms the ratio is dominated by timer noise.
+  if (planElapsed >= 5) {
+    assert.ok(
+      refineElapsed < planElapsed * 3,
+      `refine-slice must not exceed 3x plan-slice baseline (refine=${refineElapsed}ms, plan=${planElapsed}ms)`,
+    );
+  }
+});

--- a/src/resources/extensions/gsd/tests/progressive-planning.test.ts
+++ b/src/resources/extensions/gsd/tests/progressive-planning.test.ts
@@ -1,0 +1,351 @@
+// GSD Extension — ADR-011 Progressive Planning tests
+// Sketch detection → refining phase, dispatch routing, auto-heal, migration idempotency.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import {
+  openDatabase,
+  closeDatabase,
+  insertMilestone,
+  insertSlice,
+  setSliceSketchFlag,
+  autoHealSketchFlags,
+  getSlice,
+} from "../gsd-db.ts";
+import { deriveStateFromDb } from "../state.ts";
+import { resolveDispatch } from "../auto-dispatch.ts";
+import type { DispatchContext } from "../auto-dispatch.ts";
+
+function makeFixtureBase(): string {
+  const base = mkdtempSync(join(tmpdir(), "gsd-adr011-"));
+  mkdirSync(join(base, ".gsd"), { recursive: true });
+  mkdirSync(join(base, ".gsd", "milestones", "M001", "slices", "S02"), { recursive: true });
+  mkdirSync(join(base, ".gsd", "milestones", "M001", "slices", "S01"), { recursive: true });
+  return base;
+}
+
+function writePreferences(base: string, phasesBlock: string): void {
+  const prefsPath = join(base, ".gsd", "PREFERENCES.md");
+  const body = [
+    "---",
+    "version: 1",
+    phasesBlock,
+    "---",
+  ].join("\n");
+  writeFileSync(prefsPath, body);
+}
+
+function seedMilestoneWithSketchedS02(base: string): void {
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M001", title: "Test", status: "active" });
+  // S01: full slice, complete
+  insertSlice({
+    id: "S01",
+    milestoneId: "M001",
+    title: "Foundation",
+    status: "complete",
+    risk: "high",
+    depends: [],
+    demo: "S01 done.",
+    sequence: 1,
+    isSketch: false,
+  });
+  // S02: sketch slice, pending
+  insertSlice({
+    id: "S02",
+    milestoneId: "M001",
+    title: "Feature",
+    status: "pending",
+    risk: "medium",
+    depends: ["S01"],
+    demo: "S02 demo.",
+    sequence: 2,
+    isSketch: true,
+    sketchScope: "Scope limited to feature X in module Y; no cross-cutting refactors.",
+  });
+}
+
+function writeS01Artifacts(base: string): void {
+  writeFileSync(join(base, ".gsd", "milestones", "M001", "slices", "S01", "S01-PLAN.md"), "# S01 Plan\n");
+  writeFileSync(join(base, ".gsd", "milestones", "M001", "slices", "S01", "S01-SUMMARY.md"), "# S01 Summary\n");
+}
+
+function cleanup(base: string, originalCwd: string): void {
+  try { closeDatabase(); } catch { /* noop */ }
+  process.chdir(originalCwd);
+  try { rmSync(base, { recursive: true, force: true }); } catch { /* noop */ }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Tests
+// ═══════════════════════════════════════════════════════════════════════════
+
+test("ADR-011: sketch slice + progressive_planning ON → phase='refining'", async (t) => {
+  const originalCwd = process.cwd();
+  const base = makeFixtureBase();
+  t.after(() => cleanup(base, originalCwd));
+
+  seedMilestoneWithSketchedS02(base);
+  writeS01Artifacts(base);
+  writePreferences(base, "phases:\n  progressive_planning: true");
+  process.chdir(base);
+
+  const state = await deriveStateFromDb(base);
+  assert.equal(state.activeSlice?.id, "S02", "S02 should be the active slice (S01 complete)");
+  assert.equal(state.phase, "refining", "sketch slice with flag ON must yield refining phase");
+});
+
+test("ADR-011: sketch slice + progressive_planning OFF → phase='planning' (backwards compat)", async (t) => {
+  const originalCwd = process.cwd();
+  const base = makeFixtureBase();
+  t.after(() => cleanup(base, originalCwd));
+
+  seedMilestoneWithSketchedS02(base);
+  writeS01Artifacts(base);
+  // Write a PREFERENCES.md without the flag so loadEffectiveGSDPreferences finds
+  // a valid file but progressive_planning resolves to undefined.
+  writePreferences(base, "phases:\n  skip_research: false");
+  process.chdir(base);
+
+  const state = await deriveStateFromDb(base);
+  assert.equal(state.activeSlice?.id, "S02");
+  assert.equal(state.phase, "planning", "flag absent → must fall through to planning");
+});
+
+test("ADR-011: dispatch rule maps refining → refine-slice unit", async (t) => {
+  const originalCwd = process.cwd();
+  const base = makeFixtureBase();
+  t.after(() => cleanup(base, originalCwd));
+
+  seedMilestoneWithSketchedS02(base);
+  writeS01Artifacts(base);
+  writePreferences(base, "phases:\n  progressive_planning: true");
+  process.chdir(base);
+
+  const state = await deriveStateFromDb(base);
+  const ctx: DispatchContext = {
+    basePath: base,
+    mid: "M001",
+    midTitle: "Test",
+    state,
+    // Disable reassess-roadmap so it doesn't fire first on the just-completed S01.
+    prefs: { phases: { progressive_planning: true, reassess_after_slice: false } } as any,
+  };
+  const result = await resolveDispatch(ctx);
+  assert.equal(result.action, "dispatch");
+  if (result.action === "dispatch") {
+    assert.equal(result.unitType, "refine-slice");
+    assert.equal(result.unitId, "M001/S02");
+  }
+});
+
+test("ADR-011: refining + flag flipped OFF mid-milestone → falls through to plan-slice (no dead-end)", async (t) => {
+  const originalCwd = process.cwd();
+  const base = makeFixtureBase();
+  t.after(() => cleanup(base, originalCwd));
+
+  seedMilestoneWithSketchedS02(base);
+  writeS01Artifacts(base);
+  // prefs ON so state derivation yields 'refining'...
+  writePreferences(base, "phases:\n  progressive_planning: true");
+  process.chdir(base);
+  const state = await deriveStateFromDb(base);
+  assert.equal(state.phase, "refining");
+
+  // ...then dispatch is invoked with the flag OFF (simulates user toggling
+  // progressive_planning off while a slice sits in 'refining'). The rule
+  // must gracefully downgrade to plan-slice, not return null (dead-end).
+  const ctx: DispatchContext = {
+    basePath: base,
+    mid: "M001",
+    midTitle: "Test",
+    state,
+    prefs: { phases: { progressive_planning: false, reassess_after_slice: false } } as any,
+  };
+  const result = await resolveDispatch(ctx);
+  assert.equal(result.action, "dispatch");
+  if (result.action === "dispatch") {
+    assert.equal(result.unitType, "plan-slice", "flag-off must downgrade to plan-slice");
+  }
+});
+
+test("ADR-011: autoHealSketchFlags flips is_sketch=0 when PLAN file exists", async (t) => {
+  const originalCwd = process.cwd();
+  const base = makeFixtureBase();
+  t.after(() => cleanup(base, originalCwd));
+
+  seedMilestoneWithSketchedS02(base);
+  writeS01Artifacts(base);
+  // Simulate crash between plan-slice write and sketch flip: PLAN.md exists
+  // but is_sketch is still 1.
+  writeFileSync(
+    join(base, ".gsd", "milestones", "M001", "slices", "S02", "S02-PLAN.md"),
+    "# S02 Plan\n",
+  );
+  assert.equal(getSlice("M001", "S02")?.is_sketch, 1, "pre: flagged as sketch");
+
+  const { existsSync } = await import("node:fs");
+  autoHealSketchFlags("M001", (sid) => {
+    const planPath = join(base, ".gsd", "milestones", "M001", "slices", sid, `${sid}-PLAN.md`);
+    return existsSync(planPath);
+  });
+
+  assert.equal(getSlice("M001", "S02")?.is_sketch, 0, "post-heal: flag cleared");
+});
+
+test("ADR-011: schema v16 is idempotent — re-opening DB preserves is_sketch and sketch_scope columns", async (t) => {
+  const originalCwd = process.cwd();
+  const base = mkdtempSync(join(tmpdir(), "gsd-adr011-schema-"));
+  t.after(() => {
+    try { closeDatabase(); } catch { /* noop */ }
+    // Restore cwd even though this test doesn't chdir — guards against
+    // leaked cwd from any earlier test in the file.
+    if (process.cwd() !== originalCwd) process.chdir(originalCwd);
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  const dbPath = join(base, "gsd.db");
+  openDatabase(dbPath);
+  // Insert a sketch slice — round-trip proves the columns exist with correct
+  // defaults. If migration hadn't run, insertSlice would throw on the new
+  // named params.
+  insertMilestone({ id: "M001", title: "Test", status: "active" });
+  insertSlice({
+    id: "S01",
+    milestoneId: "M001",
+    title: "X",
+    isSketch: true,
+    sketchScope: "narrow scope",
+  });
+  assert.equal(getSlice("M001", "S01")?.is_sketch, 1);
+  assert.equal(getSlice("M001", "S01")?.sketch_scope, "narrow scope");
+
+  // Close and re-open — migration must be a no-op the second time and
+  // data must persist.
+  closeDatabase();
+  openDatabase(dbPath);
+  assert.equal(getSlice("M001", "S01")?.is_sketch, 1, "data survives re-open");
+  assert.equal(getSlice("M001", "S01")?.sketch_scope, "narrow scope");
+
+  // Inserting a full (non-sketch) slice uses the default column values.
+  insertSlice({ id: "S02", milestoneId: "M001", title: "Y" });
+  assert.equal(getSlice("M001", "S02")?.is_sketch, 0, "default is_sketch=0");
+  assert.equal(getSlice("M001", "S02")?.sketch_scope, "", "default sketch_scope=''");
+
+  // setSliceSketchFlag round-trip.
+  setSliceSketchFlag("M001", "S01", false);
+  assert.equal(getSlice("M001", "S01")?.is_sketch, 0);
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// ADR-011: insertSlice ON CONFLICT sketch-flag preservation matrix
+// ═══════════════════════════════════════════════════════════════════════════
+// Regression coverage for the 3-valued isSketch semantics (true/false/undefined).
+// Re-planning a milestone must NOT silently flip a sketch slice to non-sketch
+// (or vice versa) unless the caller explicitly intends the change.
+
+test("ADR-011 ON CONFLICT: omitted isSketch preserves existing is_sketch=1", async (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-adr011-conflict-"));
+  t.after(() => {
+    try { closeDatabase(); } catch { /* noop */ }
+    rmSync(base, { recursive: true, force: true });
+  });
+  openDatabase(join(base, "gsd.db"));
+  insertMilestone({ id: "M001", title: "Test", status: "active" });
+
+  // Seed: S01 is a sketch.
+  insertSlice({
+    id: "S01", milestoneId: "M001", title: "X",
+    isSketch: true, sketchScope: "narrow scope",
+  });
+  assert.equal(getSlice("M001", "S01")?.is_sketch, 1);
+
+  // Re-plan with isSketch omitted (undefined) — MUST preserve sketch state.
+  insertSlice({
+    id: "S01", milestoneId: "M001", title: "X (updated title)",
+    // isSketch intentionally omitted
+  });
+  assert.equal(
+    getSlice("M001", "S01")?.is_sketch, 1,
+    "omitted isSketch must preserve the existing sketch flag on ON CONFLICT",
+  );
+  assert.equal(
+    getSlice("M001", "S01")?.sketch_scope, "narrow scope",
+    "omitted sketchScope must preserve existing scope on ON CONFLICT",
+  );
+});
+
+test("ADR-011 ON CONFLICT: explicit isSketch=false clears existing sketch flag", async (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-adr011-conflict-false-"));
+  t.after(() => {
+    try { closeDatabase(); } catch { /* noop */ }
+    rmSync(base, { recursive: true, force: true });
+  });
+  openDatabase(join(base, "gsd.db"));
+  insertMilestone({ id: "M001", title: "Test", status: "active" });
+
+  insertSlice({
+    id: "S01", milestoneId: "M001", title: "X",
+    isSketch: true, sketchScope: "narrow scope",
+  });
+  assert.equal(getSlice("M001", "S01")?.is_sketch, 1);
+
+  // Explicit isSketch=false intentionally clears the flag (e.g., user re-plans
+  // sketch as full slice).
+  insertSlice({
+    id: "S01", milestoneId: "M001", title: "X",
+    isSketch: false,
+  });
+  assert.equal(
+    getSlice("M001", "S01")?.is_sketch, 0,
+    "explicit isSketch=false must clear the sketch flag",
+  );
+});
+
+test("ADR-011 ON CONFLICT: isSketch=true upgrades existing non-sketch to sketch", async (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-adr011-conflict-true-"));
+  t.after(() => {
+    try { closeDatabase(); } catch { /* noop */ }
+    rmSync(base, { recursive: true, force: true });
+  });
+  openDatabase(join(base, "gsd.db"));
+  insertMilestone({ id: "M001", title: "Test", status: "active" });
+
+  // Seed as full slice.
+  insertSlice({ id: "S01", milestoneId: "M001", title: "X" });
+  assert.equal(getSlice("M001", "S01")?.is_sketch, 0);
+
+  // Re-plan upgrading to sketch.
+  insertSlice({
+    id: "S01", milestoneId: "M001", title: "X",
+    isSketch: true, sketchScope: "new scope",
+  });
+  assert.equal(getSlice("M001", "S01")?.is_sketch, 1);
+  assert.equal(getSlice("M001", "S01")?.sketch_scope, "new scope");
+});
+
+test("ADR-011 ON CONFLICT: empty-string sketchScope clears existing scope (not preserves it)", async (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-adr011-conflict-empty-"));
+  t.after(() => {
+    try { closeDatabase(); } catch { /* noop */ }
+    rmSync(base, { recursive: true, force: true });
+  });
+  openDatabase(join(base, "gsd.db"));
+  insertMilestone({ id: "M001", title: "Test", status: "active" });
+
+  insertSlice({
+    id: "S01", milestoneId: "M001", title: "X",
+    isSketch: true, sketchScope: "existing scope",
+  });
+  // Explicit empty string is the caller saying "clear it" — must not be
+  // treated as absent (the `?? null` footgun the peer review flagged).
+  insertSlice({
+    id: "S01", milestoneId: "M001", title: "X",
+    isSketch: false, sketchScope: "",
+  });
+  assert.equal(getSlice("M001", "S01")?.sketch_scope, "", "explicit '' must clear, not preserve");
+});

--- a/src/resources/extensions/gsd/tests/projection-regression.test.ts
+++ b/src/resources/extensions/gsd/tests/projection-regression.test.ts
@@ -30,6 +30,8 @@ function makeSliceRow(overrides?: Partial<SliceRow>): SliceRow {
     observability_impact: '',
     sequence: 0,
     replan_triggered_at: null,
+    is_sketch: 0,
+    sketch_scope: '',
     ...overrides,
   };
 }

--- a/src/resources/extensions/gsd/tests/projection-regression.test.ts
+++ b/src/resources/extensions/gsd/tests/projection-regression.test.ts
@@ -61,6 +61,11 @@ function makeTaskRow(overrides?: Partial<TaskRow>): TaskRow {
     expected_output: [],
     observability_impact: '',
     sequence: 0,
+    blocker_source: '',
+    escalation_pending: 0,
+    escalation_awaiting_review: 0,
+    escalation_artifact_path: null,
+    escalation_override_applied_at: null,
     ...overrides,
   };
 }

--- a/src/resources/extensions/gsd/tests/prompt-contracts.test.ts
+++ b/src/resources/extensions/gsd/tests/prompt-contracts.test.ts
@@ -223,6 +223,30 @@ test("replan-slice prompt uses gsd_replan_slice as canonical DB-backed tool", ()
   assert.doesNotMatch(prompt, /Degraded fallback/i);
 });
 
+// ─── ADR-011 refine-slice prompt contracts ────────────────────────────
+
+test("refine-slice prompt names gsd_plan_slice as the DB-backed write path", () => {
+  const prompt = readPrompt("refine-slice");
+  assert.match(prompt, /gsd_plan_slice/, "refine-slice must call gsd_plan_slice to persist");
+});
+
+test("refine-slice prompt does not instruct direct PLAN.md writes", () => {
+  const prompt = readPrompt("refine-slice");
+  assert.match(
+    prompt,
+    /do NOT rely on direct `PLAN\.md` writes/i,
+    "refine-slice must not frame direct file writes as authoritative",
+  );
+});
+
+test("refine-slice prompt frames the unit as a transformation, not blank-sheet planning", () => {
+  const prompt = readPrompt("refine-slice");
+  // The framing language is load-bearing — the model should treat this as
+  // expanding an approved sketch, not planning from scratch.
+  assert.match(prompt, /expands an approved sketch/i);
+  assert.match(prompt, /Sketch Scope/);
+});
+
 test("reassess-roadmap prompt references gsd_reassess_roadmap tool", () => {
   const prompt = readPrompt("reassess-roadmap");
   assert.match(prompt, /gsd_reassess_roadmap/);

--- a/src/resources/extensions/gsd/tests/slice-context-injection.test.ts
+++ b/src/resources/extensions/gsd/tests/slice-context-injection.test.ts
@@ -31,18 +31,30 @@ describe("slice CONTEXT.md injection into prompt builders (#3452)", () => {
       const fnStart = source.indexOf(`export async function ${builder}`);
       assert.ok(fnStart !== -1, `${builder} should exist in auto-prompts.ts`);
 
-      // Get a reasonable chunk after the function start (enough to cover the inlining section)
+      // Get a reasonable chunk after the function start
       const chunk = source.slice(fnStart, fnStart + 3000);
+
+      // ADR-011: buildPlanSlicePrompt / buildRefineSlicePrompt now delegate to
+      // a shared helper (renderSlicePrompt) that performs the slice CONTEXT
+      // resolve. When a builder delegates, scan the helper's body instead.
+      const delegatesToHelper = chunk.includes("renderSlicePrompt(");
+      const bodyToCheck = delegatesToHelper
+        ? (() => {
+            const helperStart = source.indexOf("async function renderSlicePrompt");
+            assert.ok(helperStart !== -1, "renderSlicePrompt helper must exist");
+            return source.slice(helperStart, helperStart + 3000);
+          })()
+        : chunk;
 
       // Must resolve the slice CONTEXT path
       assert.ok(
-        chunk.includes('resolveSliceFile(base, mid,') && chunk.includes('"CONTEXT"'),
-        `${builder} should call resolveSliceFile with "CONTEXT"`,
+        bodyToCheck.includes('resolveSliceFile(base, mid,') && bodyToCheck.includes('"CONTEXT"'),
+        `${builder} should call resolveSliceFile with "CONTEXT" (directly or via renderSlicePrompt)`,
       );
 
       // Must inline it with inlineFileOptional
       assert.ok(
-        chunk.includes('Slice Context'),
+        bodyToCheck.includes("Slice Context"),
         `${builder} should inline slice CONTEXT with a "Slice Context" label`,
       );
     });

--- a/src/resources/extensions/gsd/tests/state-corruption-2945.test.ts
+++ b/src/resources/extensions/gsd/tests/state-corruption-2945.test.ts
@@ -93,6 +93,8 @@ function makeSliceRow(id: string, overrides: Partial<SliceRow> = {}): SliceRow {
     integration_closure: "",
     observability_impact: "",
     replan_triggered_at: null,
+    is_sketch: 0,
+    sketch_scope: "",
     ...overrides,
   };
 }

--- a/src/resources/extensions/gsd/tests/summary-render-parity.test.ts
+++ b/src/resources/extensions/gsd/tests/summary-render-parity.test.ts
@@ -50,6 +50,11 @@ const taskRow: TaskRow = {
   observability_impact: "",
   full_plan_md: "",
   sequence: 1,
+  blocker_source: "",
+  escalation_pending: 0,
+  escalation_awaiting_review: 0,
+  escalation_artifact_path: null,
+  escalation_override_applied_at: null,
 };
 
 const verificationEvidence = [

--- a/src/resources/extensions/gsd/tests/uok-contracts.test.ts
+++ b/src/resources/extensions/gsd/tests/uok-contracts.test.ts
@@ -64,8 +64,9 @@ test("uok contracts include required DAG node kinds", () => {
     "team-worker",
     "verification",
     "reprocess",
+    "refine",
   ];
-  assert.deepEqual(required.length, 6);
+  assert.deepEqual(required.length, 7);
 });
 
 test("uok audit envelope includes trace/turn/causality fields", () => {

--- a/src/resources/extensions/gsd/tests/workflow-projections.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-projections.test.ts
@@ -59,6 +59,11 @@ function makeTask(overrides: Partial<TaskRow> = {}): TaskRow {
     expected_output: [],
     observability_impact: '',
     sequence: 1,
+    blocker_source: '',
+    escalation_pending: 0,
+    escalation_awaiting_review: 0,
+    escalation_artifact_path: null,
+    escalation_override_applied_at: null,
     ...overrides,
   };
 }

--- a/src/resources/extensions/gsd/tests/workflow-projections.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-projections.test.ts
@@ -28,6 +28,8 @@ function makeSlice(overrides: Partial<SliceRow> = {}): SliceRow {
     completed_at: null,
     sequence: 1,
     replan_triggered_at: null,
+    is_sketch: 0,
+    sketch_scope: '',
     ...overrides,
   };
 }

--- a/src/resources/extensions/gsd/tools/complete-task.ts
+++ b/src/resources/extensions/gsd/tools/complete-task.ts
@@ -341,11 +341,17 @@ export async function handleCompleteTask(
 
   // ── ADR-011 Phase 2: write escalation artifact (opt-in) ────────────────
   // Validation already happened BEFORE side effects — this block only
-  // performs the disk write for a pre-validated artifact. Only transient
-  // filesystem errors can fail here. For continueWithDefault=false we still
-  // surface the error; the side effects already landed (task complete +
-  // SUMMARY.md + gates closed), so the caller sees inconsistent state and
-  // must run /gsd recover or manually re-escalate.
+  // performs the disk write for a pre-validated artifact. For
+  // continueWithDefault=false, a write failure here would otherwise leave
+  // the task marked complete with SUMMARY.md + closed gates but no
+  // escalation, which silently advances the loop past a pause the user
+  // asked for. We compensate by reverting the DB-level completion: set
+  // status back to 'pending' and delete the verification_evidence rows
+  // (same shape as the disk-render-failure rollback above). SUMMARY.md
+  // on disk is left in place because the next complete-task retry will
+  // overwrite it; gate rows are UPSERT-keyed per task and will also be
+  // overwritten. This restores the invariant that deriveState() sees a
+  // consistent "task not done" view so the loop re-dispatches the task.
   if (validatedEscalationArtifact) {
     try {
       writeEscalationArtifact(basePath, validatedEscalationArtifact);
@@ -353,6 +359,23 @@ export async function handleCompleteTask(
       const msg = `complete-task escalation write failed for ${params.milestoneId}/${params.sliceId}/${params.taskId}: ${(escalationErr as Error).message}`;
       logWarning("tool", msg);
       if (validatedEscalationArtifact.continueWithDefault === false) {
+        // Compensating rollback: revert DB completion so the loop pauses on
+        // re-dispatch instead of silently advancing. Mirror the existing
+        // renderErr rollback (line ~261).
+        try {
+          deleteVerificationEvidence(params.milestoneId, params.sliceId, params.taskId);
+          updateTaskStatus(params.milestoneId, params.sliceId, params.taskId, 'pending');
+          invalidateStateCache();
+          logWarning(
+            "tool",
+            `complete-task rolled back DB completion for ${params.milestoneId}/${params.sliceId}/${params.taskId} after escalation write failure; SUMMARY.md left on disk for retry.`,
+          );
+        } catch (rollbackErr) {
+          logWarning(
+            "tool",
+            `complete-task rollback failed after escalation write failure for ${params.milestoneId}/${params.sliceId}/${params.taskId}: ${(rollbackErr as Error).message}`,
+          );
+        }
         return { error: msg };
       }
     }

--- a/src/resources/extensions/gsd/tools/complete-task.ts
+++ b/src/resources/extensions/gsd/tools/complete-task.ts
@@ -113,6 +113,11 @@ function paramsToTaskRow(params: CompleteTaskParams, completedAt: string): TaskR
     observability_impact: "",
     full_plan_md: "",
     sequence: 0,
+    blocker_source: "",
+    escalation_pending: 0,
+    escalation_awaiting_review: 0,
+    escalation_artifact_path: null,
+    escalation_override_applied_at: null,
   };
 }
 

--- a/src/resources/extensions/gsd/tools/complete-task.ts
+++ b/src/resources/extensions/gsd/tools/complete-task.ts
@@ -160,6 +160,39 @@ export async function handleCompleteTask(
   const completedAt = new Date().toISOString();
   let guardError: string | null = null;
 
+  // ── ADR-011 Phase 2: validate escalation payload BEFORE any side effects ─
+  // Building the artifact runs the full shape validation (2-4 options, unique
+  // ids, recommendation references a real id). If the payload is malformed
+  // we must reject the call before marking the task complete, writing
+  // SUMMARY.md, flipping the plan checkbox, or closing execute-task gates —
+  // otherwise a rejected payload would leave the task marked complete with
+  // no escalation recorded, and the loop would silently advance past it.
+  // The filesystem write happens later (after side effects) because that's
+  // the cheapest ordering and validation is where 99% of failures live.
+  let validatedEscalationArtifact: ReturnType<typeof buildEscalationArtifact> | null = null;
+  let escalationWriteEnabled = false;
+  if (params.escalation) {
+    escalationWriteEnabled = loadEffectiveGSDPreferences()?.preferences?.phases?.mid_execution_escalation === true;
+    if (escalationWriteEnabled) {
+      try {
+        validatedEscalationArtifact = buildEscalationArtifact({
+          taskId: params.taskId,
+          sliceId: params.sliceId,
+          milestoneId: params.milestoneId,
+          question: params.escalation.question,
+          options: params.escalation.options,
+          recommendation: params.escalation.recommendation,
+          recommendationRationale: params.escalation.recommendationRationale,
+          continueWithDefault: params.escalation.continueWithDefault,
+        });
+      } catch (validationErr) {
+        return {
+          error: `complete-task escalation payload invalid for ${params.milestoneId}/${params.sliceId}/${params.taskId}: ${(validationErr as Error).message}`,
+        };
+      }
+    }
+  }
+
   transaction(() => {
     // State machine preconditions (inside txn for atomicity).
     // Milestone/slice not existing is OK — insertMilestone/insertSlice below will auto-create.
@@ -307,43 +340,27 @@ export async function handleCompleteTask(
   }
 
   // ── ADR-011 Phase 2: write escalation artifact (opt-in) ────────────────
-  // The executor may include an `escalation` payload when they need the user
-  // to resolve an ambiguity. We write the artifact + flip the DB flag only
-  // when `phases.mid_execution_escalation` is enabled — otherwise the
-  // payload is ignored so agents can safely populate it before users opt in.
-  if (params.escalation) {
-    const escalationEnabled = loadEffectiveGSDPreferences()?.preferences?.phases?.mid_execution_escalation === true;
-    if (escalationEnabled) {
-      try {
-        const artifact = buildEscalationArtifact({
-          taskId: params.taskId,
-          sliceId: params.sliceId,
-          milestoneId: params.milestoneId,
-          question: params.escalation.question,
-          options: params.escalation.options,
-          recommendation: params.escalation.recommendation,
-          recommendationRationale: params.escalation.recommendationRationale,
-          continueWithDefault: params.escalation.continueWithDefault,
-        });
-        writeEscalationArtifact(basePath, artifact);
-      } catch (escalationErr) {
-        const msg = `complete-task escalation write failed for ${params.milestoneId}/${params.sliceId}/${params.taskId}: ${(escalationErr as Error).message}`;
-        logWarning("tool", msg);
-        // For pause-required escalations (continueWithDefault=false), the
-        // loop MUST pause — so if we can't write the artifact we must surface
-        // the failure instead of silently allowing the task to "complete" and
-        // the loop to advance. For fire-and-correct (continueWithDefault=true)
-        // the task proceeds and the warning is enough.
-        if (params.escalation.continueWithDefault === false) {
-          return { error: msg };
-        }
+  // Validation already happened BEFORE side effects — this block only
+  // performs the disk write for a pre-validated artifact. Only transient
+  // filesystem errors can fail here. For continueWithDefault=false we still
+  // surface the error; the side effects already landed (task complete +
+  // SUMMARY.md + gates closed), so the caller sees inconsistent state and
+  // must run /gsd recover or manually re-escalate.
+  if (validatedEscalationArtifact) {
+    try {
+      writeEscalationArtifact(basePath, validatedEscalationArtifact);
+    } catch (escalationErr) {
+      const msg = `complete-task escalation write failed for ${params.milestoneId}/${params.sliceId}/${params.taskId}: ${(escalationErr as Error).message}`;
+      logWarning("tool", msg);
+      if (validatedEscalationArtifact.continueWithDefault === false) {
+        return { error: msg };
       }
-    } else {
-      logWarning(
-        "tool",
-        `complete-task received escalation payload but phases.mid_execution_escalation is not enabled; ignoring (${params.milestoneId}/${params.sliceId}/${params.taskId})`,
-      );
     }
+  } else if (params.escalation && !escalationWriteEnabled) {
+    logWarning(
+      "tool",
+      `complete-task received escalation payload but phases.mid_execution_escalation is not enabled; ignoring (${params.milestoneId}/${params.sliceId}/${params.taskId})`,
+    );
   }
 
   // Invalidate all caches

--- a/src/resources/extensions/gsd/tools/complete-task.ts
+++ b/src/resources/extensions/gsd/tools/complete-task.ts
@@ -327,12 +327,16 @@ export async function handleCompleteTask(
         });
         writeEscalationArtifact(basePath, artifact);
       } catch (escalationErr) {
-        // Non-fatal: the task itself completed successfully. Surface the
-        // escalation failure so the user knows why no pause happened.
-        logWarning(
-          "tool",
-          `complete-task escalation write failed for ${params.milestoneId}/${params.sliceId}/${params.taskId}: ${(escalationErr as Error).message}`,
-        );
+        const msg = `complete-task escalation write failed for ${params.milestoneId}/${params.sliceId}/${params.taskId}: ${(escalationErr as Error).message}`;
+        logWarning("tool", msg);
+        // For pause-required escalations (continueWithDefault=false), the
+        // loop MUST pause — so if we can't write the artifact we must surface
+        // the failure instead of silently allowing the task to "complete" and
+        // the loop to advance. For fire-and-correct (continueWithDefault=true)
+        // the task proceeds and the warning is enough.
+        if (params.escalation.continueWithDefault === false) {
+          return { error: msg };
+        }
       }
     } else {
       logWarning(

--- a/src/resources/extensions/gsd/tools/complete-task.ts
+++ b/src/resources/extensions/gsd/tools/complete-task.ts
@@ -37,6 +37,8 @@ import { renderAllProjections, renderSummaryContent } from "../workflow-projecti
 import { writeManifest } from "../workflow-manifest.js";
 import { appendEvent } from "../workflow-events.js";
 import { logWarning, logError } from "../workflow-logger.js";
+import { loadEffectiveGSDPreferences } from "../preferences.js";
+import { buildEscalationArtifact, writeEscalationArtifact } from "../escalation.js";
 
 export interface CompleteTaskResult {
   taskId: string;
@@ -297,6 +299,42 @@ export async function handleCompleteTask(
       "tool",
       `complete-task gate close warning for ${params.milestoneId}/${params.sliceId}/${params.taskId}: ${(gateErr as Error).message}`,
     );
+  }
+
+  // ── ADR-011 Phase 2: write escalation artifact (opt-in) ────────────────
+  // The executor may include an `escalation` payload when they need the user
+  // to resolve an ambiguity. We write the artifact + flip the DB flag only
+  // when `phases.mid_execution_escalation` is enabled — otherwise the
+  // payload is ignored so agents can safely populate it before users opt in.
+  if (params.escalation) {
+    const escalationEnabled = loadEffectiveGSDPreferences()?.preferences?.phases?.mid_execution_escalation === true;
+    if (escalationEnabled) {
+      try {
+        const artifact = buildEscalationArtifact({
+          taskId: params.taskId,
+          sliceId: params.sliceId,
+          milestoneId: params.milestoneId,
+          question: params.escalation.question,
+          options: params.escalation.options,
+          recommendation: params.escalation.recommendation,
+          recommendationRationale: params.escalation.recommendationRationale,
+          continueWithDefault: params.escalation.continueWithDefault,
+        });
+        writeEscalationArtifact(basePath, artifact);
+      } catch (escalationErr) {
+        // Non-fatal: the task itself completed successfully. Surface the
+        // escalation failure so the user knows why no pause happened.
+        logWarning(
+          "tool",
+          `complete-task escalation write failed for ${params.milestoneId}/${params.sliceId}/${params.taskId}: ${(escalationErr as Error).message}`,
+        );
+      }
+    } else {
+      logWarning(
+        "tool",
+        `complete-task received escalation payload but phases.mid_execution_escalation is not enabled; ignoring (${params.milestoneId}/${params.sliceId}/${params.taskId})`,
+      );
+    }
   }
 
   // Invalidate all caches

--- a/src/resources/extensions/gsd/tools/plan-milestone.ts
+++ b/src/resources/extensions/gsd/tools/plan-milestone.ts
@@ -25,10 +25,18 @@ export interface PlanMilestoneSliceInput {
   depends: string[];
   demo: string;
   goal: string;
+  /** Required when isSketch is false/absent; may be empty for sketch slices (ADR-011). */
   successCriteria: string;
+  /** Required when isSketch is false/absent; may be empty for sketch slices (ADR-011). */
   proofLevel: string;
+  /** Required when isSketch is false/absent; may be empty for sketch slices (ADR-011). */
   integrationClosure: string;
+  /** Required when isSketch is false/absent; may be empty for sketch slices (ADR-011). */
   observabilityImpact: string;
+  /** ADR-011: when true, this slice is a sketch awaiting refine-slice expansion. */
+  isSketch?: boolean;
+  /** ADR-011: 2–3 sentence scope boundary, required when isSketch is true. */
+  sketchScope?: string;
 }
 
 export interface PlanMilestoneParams {
@@ -125,6 +133,16 @@ function validateSlices(value: unknown): PlanMilestoneSliceInput[] {
     const proofLevel = obj.proofLevel;
     const integrationClosure = obj.integrationClosure;
     const observabilityImpact = obj.observabilityImpact;
+    const isSketchRaw = obj.isSketch;
+    const sketchScopeRaw = obj.sketchScope;
+    // ADR-011: preserve the 3-valued semantics of isSketch (true / false / absent).
+    // Callers that omit isSketch must receive `undefined` here so `insertSlice`'s
+    // ON CONFLICT clause preserves any existing is_sketch on the row rather than
+    // silently overwriting a legitimate sketch to non-sketch.
+    const isSketch: boolean | undefined =
+      isSketchRaw === true ? true
+      : isSketchRaw === false ? false
+      : undefined;
 
     if (!isNonEmptyString(sliceId)) throw new Error(`slices[${index}].sliceId must be a non-empty string`);
     if (seen.has(sliceId)) throw new Error(`slices[${index}].sliceId must be unique`);
@@ -136,10 +154,18 @@ function validateSlices(value: unknown): PlanMilestoneSliceInput[] {
     }
     if (!isNonEmptyString(demo)) throw new Error(`slices[${index}].demo must be a non-empty string`);
     if (!isNonEmptyString(goal)) throw new Error(`slices[${index}].goal must be a non-empty string`);
-    if (!isNonEmptyString(successCriteria)) throw new Error(`slices[${index}].successCriteria must be a non-empty string`);
-    if (!isNonEmptyString(proofLevel)) throw new Error(`slices[${index}].proofLevel must be a non-empty string`);
-    if (!isNonEmptyString(integrationClosure)) throw new Error(`slices[${index}].integrationClosure must be a non-empty string`);
-    if (!isNonEmptyString(observabilityImpact)) throw new Error(`slices[${index}].observabilityImpact must be a non-empty string`);
+
+    // ADR-011: sketch slices may defer the heavyweight planning fields to refine-slice.
+    if (isSketch === true) {
+      if (!isNonEmptyString(sketchScopeRaw)) {
+        throw new Error(`slices[${index}].sketchScope must be a non-empty string when isSketch is true`);
+      }
+    } else {
+      if (!isNonEmptyString(successCriteria)) throw new Error(`slices[${index}].successCriteria must be a non-empty string`);
+      if (!isNonEmptyString(proofLevel)) throw new Error(`slices[${index}].proofLevel must be a non-empty string`);
+      if (!isNonEmptyString(integrationClosure)) throw new Error(`slices[${index}].integrationClosure must be a non-empty string`);
+      if (!isNonEmptyString(observabilityImpact)) throw new Error(`slices[${index}].observabilityImpact must be a non-empty string`);
+    }
 
     return {
       sliceId,
@@ -148,10 +174,14 @@ function validateSlices(value: unknown): PlanMilestoneSliceInput[] {
       depends,
       demo,
       goal,
-      successCriteria,
-      proofLevel,
-      integrationClosure,
-      observabilityImpact,
+      successCriteria: isNonEmptyString(successCriteria) ? successCriteria : "",
+      proofLevel: isNonEmptyString(proofLevel) ? proofLevel : "",
+      integrationClosure: isNonEmptyString(integrationClosure) ? integrationClosure : "",
+      observabilityImpact: isNonEmptyString(observabilityImpact) ? observabilityImpact : "",
+      isSketch,
+      // Only carry the sketch scope through if the caller explicitly provided it
+      // — preserves ON CONFLICT semantics for re-plans that omit the field.
+      sketchScope: sketchScopeRaw === undefined ? undefined : (isNonEmptyString(sketchScopeRaw) ? sketchScopeRaw : ""),
     };
   });
 }
@@ -274,6 +304,10 @@ export async function handlePlanMilestone(
           depends: slice.depends,
           demo: slice.demo,
           sequence: i + 1, // Preserve agent-ordered sequence (#3356)
+          // ADR-011: pass undefined through so ON CONFLICT preserves existing values
+          // when the caller omitted the fields on a re-plan.
+          isSketch: slice.isSketch,
+          sketchScope: slice.sketchScope,
         });
         upsertSlicePlanning(params.milestoneId, slice.sliceId, {
           goal: slice.goal,

--- a/src/resources/extensions/gsd/types.ts
+++ b/src/resources/extensions/gsd/types.ts
@@ -11,6 +11,7 @@ export type Phase =
   | "discussing"
   | "researching"
   | "planning"
+  | "refining"
   | "evaluating-gates"
   | "executing"
   | "verifying"
@@ -353,6 +354,8 @@ export interface PhaseSkipPreferences {
   require_slice_discussion?: boolean;
   /** ADR-011 Phase 2: when true, executors may escalate task-level ambiguity via T##-ESCALATION.json. */
   mid_execution_escalation?: boolean;
+  /** ADR-011 Phase 1: when true, plan S01 in full and S02+ as sketches refined just-in-time. */
+  progressive_planning?: boolean;
 }
 
 // ─── ADR-011 Phase 2 Escalation ──────────────────────────────────────────

--- a/src/resources/extensions/gsd/types.ts
+++ b/src/resources/extensions/gsd/types.ts
@@ -11,6 +11,7 @@ export type Phase =
   | "discussing"
   | "researching"
   | "planning"
+  | "refining"
   | "evaluating-gates"
   | "executing"
   | "verifying"
@@ -350,6 +351,8 @@ export interface PhaseSkipPreferences {
   reassess_after_slice?: boolean;
   /** When true, auto-mode pauses before each slice for discussion (#789). */
   require_slice_discussion?: boolean;
+  /** ADR-011: when true, plan S01 in full and S02+ as sketches refined just-in-time. */
+  progressive_planning?: boolean;
 }
 
 export interface NotificationPreferences {

--- a/src/resources/extensions/gsd/types.ts
+++ b/src/resources/extensions/gsd/types.ts
@@ -19,6 +19,7 @@ export type Phase =
   | "validating-milestone"
   | "completing-milestone"
   | "replanning-slice"
+  | "escalating-task"
   | "complete"
   | "paused"
   | "blocked";
@@ -350,6 +351,49 @@ export interface PhaseSkipPreferences {
   reassess_after_slice?: boolean;
   /** When true, auto-mode pauses before each slice for discussion (#789). */
   require_slice_discussion?: boolean;
+  /** ADR-011 Phase 2: when true, executors may escalate task-level ambiguity via T##-ESCALATION.json. */
+  mid_execution_escalation?: boolean;
+}
+
+// ─── ADR-011 Phase 2 Escalation ──────────────────────────────────────────
+
+export interface EscalationOption {
+  /** Short identifier, e.g. "A", "B". Used as the `choice` value in `/gsd escalate resolve <taskId> <id>`. */
+  id: string;
+  /** One-line label for the option. */
+  label: string;
+  /** 1-2 sentence description of the tradeoffs of this option. */
+  tradeoffs: string;
+}
+
+export interface EscalationArtifact {
+  /** Schema version for the artifact file — bumps if we change the shape. */
+  version: 1;
+  taskId: string;
+  sliceId: string;
+  milestoneId: string;
+  /** The question the executor needs the user to resolve. */
+  question: string;
+  /** 2-4 options the user can choose between. */
+  options: EscalationOption[];
+  /** Which option the executor recommends (references `options[].id`). */
+  recommendation: string;
+  /** Why the executor recommends that option (1-2 sentences). */
+  recommendationRationale: string;
+  /**
+   * When true, the executor proceeds with the recommendation as the answer
+   * and the loop continues. User's later choice becomes a carry-forward
+   * override for the NEXT task. When false, auto-mode pauses until the
+   * user resolves via `/gsd escalate resolve`.
+   */
+  continueWithDefault: boolean;
+  createdAt: string;
+  /** Populated by `/gsd escalate resolve`. */
+  respondedAt?: string;
+  /** User's choice — either an option id, "accept" (use recommendation), or "reject-blocker". */
+  userChoice?: string;
+  /** Optional free-text rationale from the user. */
+  userRationale?: string;
 }
 
 export interface NotificationPreferences {
@@ -435,6 +479,7 @@ export interface Decision {
   rationale: string; // why this choice
   revisable: string; // whether/when revisable
   made_by: DecisionMadeBy; // who made the decision: human, agent, or collaborative
+  source?: string; // ADR-011 P2: origin — "discussion" (default) | "planning" | "escalation"
   superseded_by: string | null; // ID of superseding decision, or null
 }
 
@@ -542,6 +587,20 @@ export interface CompleteTaskParams {
   knownIssues?: string;
   /** @optional — defaults to false when omitted */
   blockerDiscovered?: boolean;
+  /**
+   * ADR-011 Phase 2 — optional escalation payload. When populated, the executor
+   * is asking the user to resolve an ambiguity. If `continueWithDefault: true`
+   * the task still completes (using the recommendation) but an artifact is
+   * written for later user review. If false, auto-mode pauses.
+   * @optional
+   */
+  escalation?: {
+    question: string;
+    options: EscalationOption[];
+    recommendation: string;
+    recommendationRationale: string;
+    continueWithDefault: boolean;
+  };
   /** @optional — defaults to [] when omitted by models with limited tool-calling */
   verificationEvidence?: Array<{
     command: string;

--- a/src/resources/extensions/gsd/uok/contracts.ts
+++ b/src/resources/extensions/gsd/uok/contracts.ts
@@ -113,7 +113,8 @@ export type UokNodeKind =
   | "subagent"
   | "team-worker"
   | "verification"
-  | "reprocess";
+  | "reprocess"
+  | "refine";
 
 export interface UokGraphNode {
   id: string;

--- a/src/resources/extensions/gsd/workflow-manifest.ts
+++ b/src/resources/extensions/gsd/workflow-manifest.ts
@@ -164,6 +164,7 @@ export function snapshotState(): StateManifest {
     rationale: (r["rationale"] as string) ?? "",
     revisable: (r["revisable"] as string) ?? "",
     made_by: (r["made_by"] as string as Decision["made_by"]) ?? "agent",
+    source: (r["source"] as string) ?? "discussion",
     superseded_by: (r["superseded_by"] as string) ?? null,
   }));
 

--- a/src/resources/extensions/gsd/workflow-manifest.ts
+++ b/src/resources/extensions/gsd/workflow-manifest.ts
@@ -117,6 +117,8 @@ export function snapshotState(): StateManifest {
     observability_impact: (r["observability_impact"] as string) ?? "",
     sequence: toNumeric(r["sequence"], 0) as number,
     replan_triggered_at: (r["replan_triggered_at"] as string) ?? null,
+    is_sketch: toNumeric(r["is_sketch"], 0) as number,
+    sketch_scope: (r["sketch_scope"] as string) ?? "",
   }));
 
   const rawTasks = db.prepare("SELECT * FROM tasks ORDER BY milestone_id, slice_id, sequence, id").all() as Record<string, unknown>[];

--- a/src/resources/extensions/gsd/workflow-manifest.ts
+++ b/src/resources/extensions/gsd/workflow-manifest.ts
@@ -146,6 +146,11 @@ export function snapshotState(): StateManifest {
     observability_impact: (r["observability_impact"] as string) ?? "",
     full_plan_md: (r["full_plan_md"] as string) ?? "",
     sequence: toNumeric(r["sequence"], 0) as number,
+    blocker_source: (r["blocker_source"] as string) ?? "",
+    escalation_pending: toNumeric(r["escalation_pending"], 0) as number,
+    escalation_awaiting_review: toNumeric(r["escalation_awaiting_review"], 0) as number,
+    escalation_artifact_path: (r["escalation_artifact_path"] as string) ?? null,
+    escalation_override_applied_at: (r["escalation_override_applied_at"] as string) ?? null,
   }));
 
   const rawDecisions = db.prepare("SELECT * FROM decisions ORDER BY seq").all() as Record<string, unknown>[];

--- a/tests/fixtures/provider.ts
+++ b/tests/fixtures/provider.ts
@@ -52,7 +52,10 @@ export function getFixtureMode(): "record" | "replay" | "off" {
  * Returns the fixture recordings directory path.
  */
 export function getFixtureDir(): string {
-  return process.env.GSD_FIXTURE_DIR || new URL("recordings", import.meta.url).pathname;
+  return (
+    process.env.GSD_FIXTURE_DIR ||
+    new URL("recordings", import.meta.url).pathname
+  );
 }
 
 /**
@@ -66,7 +69,10 @@ export function loadFixture(filePath: string): FixtureRecording {
 /**
  * Saves a fixture recording to a JSON file.
  */
-export function saveFixture(filePath: string, recording: FixtureRecording): void {
+export function saveFixture(
+  filePath: string,
+  recording: FixtureRecording,
+): void {
   mkdirSync(dirname(filePath), { recursive: true });
   writeFileSync(filePath, JSON.stringify(recording, null, 2) + "\n");
 }
@@ -75,7 +81,9 @@ export function saveFixture(filePath: string, recording: FixtureRecording): void
  * Creates a readable stream of responses from a fixture recording,
  * returning one assistant turn at a time.
  */
-export function createReplayStream(recording: FixtureRecording): Iterator<FixtureTurn> {
+export function createReplayStream(
+  recording: FixtureRecording,
+): Iterator<FixtureTurn> {
   const assistantTurns = recording.turns.filter((t) => t.role === "assistant");
   let index = 0;
   return {

--- a/tests/fixtures/record.ts
+++ b/tests/fixtures/record.ts
@@ -40,7 +40,9 @@ if (mode !== "record") {
   console.log("");
   console.log("Usage:");
   console.log("  npm run test:fixtures:record    # Start recording");
-  console.log("  npm run test:fixtures            # Replay and verify recordings");
+  console.log(
+    "  npm run test:fixtures            # Replay and verify recordings",
+  );
   console.log("");
   console.log(`Recordings directory: ${dir}`);
   process.exit(0);

--- a/tests/fixtures/run.ts
+++ b/tests/fixtures/run.ts
@@ -31,12 +31,16 @@ for (const file of files) {
 
     // Replay through FixtureReplayer and verify responses
     const replayer = new FixtureReplayer(recording);
-    const assistantTurns = recording.turns.filter((t) => t.role === "assistant");
+    const assistantTurns = recording.turns.filter(
+      (t) => t.role === "assistant",
+    );
 
     for (let i = 0; i < assistantTurns.length; i++) {
       const response = replayer.nextResponse();
       if (!response) {
-        throw new Error(`Replayer exhausted at turn ${i}, expected ${assistantTurns.length} assistant turns`);
+        throw new Error(
+          `Replayer exhausted at turn ${i}, expected ${assistantTurns.length} assistant turns`,
+        );
       }
       assertTurnShape(response, `${label} turn ${i}`);
 
@@ -51,7 +55,9 @@ for (const file of files) {
     // Verify replayer is exhausted
     const extra = replayer.nextResponse();
     if (extra !== null) {
-      throw new Error("Replayer returned extra responses beyond expected count");
+      throw new Error(
+        "Replayer returned extra responses beyond expected count",
+      );
     }
 
     console.log(`  PASS  ${label}`);
@@ -65,7 +71,10 @@ for (const file of files) {
 console.log(`\nFixture tests: ${passed} passed, ${failed} failed`);
 if (failed > 0) process.exit(1);
 
-function assertRecordingShape(recording: FixtureRecording, label: string): void {
+function assertRecordingShape(
+  recording: FixtureRecording,
+  label: string,
+): void {
   if (!recording.name || typeof recording.name !== "string") {
     throw new Error(`${label}: missing or invalid 'name'`);
   }

--- a/tests/live-regression/run.ts
+++ b/tests/live-regression/run.ts
@@ -21,7 +21,15 @@
  */
 
 import { execFileSync, execSync } from "child_process";
-import { mkdtempSync, mkdirSync, writeFileSync, existsSync, readFileSync, rmSync, unlinkSync } from "fs";
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  existsSync,
+  readFileSync,
+  rmSync,
+  unlinkSync,
+} from "fs";
 import { join, dirname } from "path";
 import { tmpdir } from "os";
 
@@ -47,29 +55,47 @@ function assert(condition: boolean, message: string): void {
   if (!condition) throw new Error(message);
 }
 
-function gsd(args: string[], cwd: string, env?: Record<string, string>): { stdout: string; stderr: string; code: number } {
+function gsd(
+  args: string[],
+  cwd: string,
+  env?: Record<string, string>,
+): { stdout: string; stderr: string; code: number } {
   try {
-    const stdout = execFileSync(binary === "gsd" ? "gsd" : "node", 
-      binary === "gsd" ? args : [binary, ...args], {
-      cwd,
-      encoding: "utf-8",
-      timeout: 30_000,
-      stdio: ["pipe", "pipe", "pipe"],
-      env: { ...process.env, ...env, GSD_NON_INTERACTIVE: "1" },
-    });
+    const stdout = execFileSync(
+      binary === "gsd" ? "gsd" : "node",
+      binary === "gsd" ? args : [binary, ...args],
+      {
+        cwd,
+        encoding: "utf-8",
+        timeout: 30_000,
+        stdio: ["pipe", "pipe", "pipe"],
+        env: { ...process.env, ...env, GSD_NON_INTERACTIVE: "1" },
+      },
+    );
     return { stdout, stderr: "", code: 0 };
   } catch (err: any) {
-    return { stdout: err.stdout || "", stderr: err.stderr || "", code: err.status ?? 1 };
+    return {
+      stdout: err.stdout || "",
+      stderr: err.stderr || "",
+      code: err.status ?? 1,
+    };
   }
 }
 
 function createTempProject(name: string): string {
   const dir = mkdtempSync(join(tmpdir(), `gsd-live-${name}-`));
-  try { execSync("git init && git config user.email test@test.com && git config user.name Test && git commit --allow-empty -m init", { cwd: dir, stdio: "pipe" }); } catch {}
+  try {
+    execSync(
+      "git init && git config user.email test@test.com && git config user.name Test && git commit --allow-empty -m init",
+      { cwd: dir, stdio: "pipe" },
+    );
+  } catch {}
   return dir;
 }
 
-function buildMinimalRoadmap(slices: Array<{ id: string; title: string; done: boolean }>): string {
+function buildMinimalRoadmap(
+  slices: Array<{ id: string; title: string; done: boolean }>,
+): string {
   const lines = ["# M001: Test Milestone", "", "## Slices", ""];
   for (const s of slices) {
     const cb = s.done ? "x" : " ";
@@ -80,7 +106,9 @@ function buildMinimalRoadmap(slices: Array<{ id: string; title: string; done: bo
   return lines.join("\n");
 }
 
-function buildMinimalPlan(tasks: Array<{ id: string; title: string; done: boolean }>): string {
+function buildMinimalPlan(
+  tasks: Array<{ id: string; title: string; done: boolean }>,
+): string {
   const lines = ["# S01: Test Slice", "", "**Goal:** test", "", "## Tasks", ""];
   for (const t of tasks) {
     const cb = t.done ? "x" : " ";
@@ -100,13 +128,22 @@ run("headless query returns valid JSON on initialized project", () => {
   try {
     const gsdDir = join(dir, ".gsd");
     mkdirSync(join(gsdDir, "milestones"), { recursive: true });
-    
+
     const result = gsd(["headless", "query"], dir);
-    assert(result.code === 0, `expected exit 0, got ${result.code}: ${result.stderr}`);
-    
+    assert(
+      result.code === 0,
+      `expected exit 0, got ${result.code}: ${result.stderr}`,
+    );
+
     const json = JSON.parse(result.stdout);
-    assert(typeof ((json.state?.phase ?? json.phase)) === "string", "response should have phase field");
-    assert(Array.isArray(json.milestones) || json.milestones === undefined, "milestones should be array or undefined");
+    assert(
+      typeof (json.state?.phase ?? json.phase) === "string",
+      "response should have phase field",
+    );
+    assert(
+      Array.isArray(json.milestones) || json.milestones === undefined,
+      "milestones should be array or undefined",
+    );
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
@@ -118,13 +155,16 @@ run("headless query: empty project reports pre-planning", () => {
   const dir = createTempProject("empty");
   try {
     mkdirSync(join(dir, ".gsd", "milestones"), { recursive: true });
-    
+
     const result = gsd(["headless", "query"], dir);
     assert(result.code === 0, `expected exit 0, got ${result.code}`);
-    
+
     const json = JSON.parse(result.stdout);
-    assert((json.state?.phase ?? json.phase) === "pre-planning" || (json.state?.phase ?? json.phase) === "idle", 
-      `expected pre-planning or idle, got: ${(json.state?.phase ?? json.phase)}`);
+    assert(
+      (json.state?.phase ?? json.phase) === "pre-planning" ||
+        (json.state?.phase ?? json.phase) === "idle",
+      `expected pre-planning or idle, got: ${json.state?.phase ?? json.phase}`,
+    );
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
@@ -138,17 +178,24 @@ run("headless query: milestone with roadmap reports planning phase", () => {
     const mDir = join(dir, ".gsd", "milestones", "M001");
     mkdirSync(join(mDir, "slices", "S01"), { recursive: true });
     writeFileSync(join(mDir, "M001-CONTEXT.md"), "# M001\n\nContext.");
-    writeFileSync(join(mDir, "M001-ROADMAP.md"), buildMinimalRoadmap([
-      { id: "S01", title: "First Slice", done: false },
-    ]));
-    
+    writeFileSync(
+      join(mDir, "M001-ROADMAP.md"),
+      buildMinimalRoadmap([{ id: "S01", title: "First Slice", done: false }]),
+    );
+
     const result = gsd(["headless", "query"], dir);
     assert(result.code === 0, `expected exit 0, got ${result.code}`);
-    
+
     const json = JSON.parse(result.stdout);
-    assert((json.state?.phase ?? json.phase) === "planning", `expected planning, got: ${(json.state?.phase ?? json.phase)}`);
-    assert((json.state?.activeMilestone ?? json.activeMilestone) === "M001" || (json.state?.activeMilestone ?? json.activeMilestone)?.id === "M001",
-      `expected active milestone M001`);
+    assert(
+      (json.state?.phase ?? json.phase) === "planning",
+      `expected planning, got: ${json.state?.phase ?? json.phase}`,
+    );
+    assert(
+      (json.state?.activeMilestone ?? json.activeMilestone) === "M001" ||
+        (json.state?.activeMilestone ?? json.activeMilestone)?.id === "M001",
+      `expected active milestone M001`,
+    );
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
@@ -163,19 +210,27 @@ run("headless query: all tasks done reports summarizing phase", () => {
     const sDir = join(mDir, "slices", "S01");
     mkdirSync(join(sDir, "tasks"), { recursive: true });
     writeFileSync(join(mDir, "M001-CONTEXT.md"), "# M001\n\nContext.");
-    writeFileSync(join(mDir, "M001-ROADMAP.md"), buildMinimalRoadmap([
-      { id: "S01", title: "First Slice", done: false },
-    ]));
-    writeFileSync(join(sDir, "S01-PLAN.md"), buildMinimalPlan([
-      { id: "T01", title: "Task One", done: true },
-    ]));
-    writeFileSync(join(sDir, "tasks", "T01-SUMMARY.md"), buildTaskSummary("T01"));
-    
+    writeFileSync(
+      join(mDir, "M001-ROADMAP.md"),
+      buildMinimalRoadmap([{ id: "S01", title: "First Slice", done: false }]),
+    );
+    writeFileSync(
+      join(sDir, "S01-PLAN.md"),
+      buildMinimalPlan([{ id: "T01", title: "Task One", done: true }]),
+    );
+    writeFileSync(
+      join(sDir, "tasks", "T01-SUMMARY.md"),
+      buildTaskSummary("T01"),
+    );
+
     const result = gsd(["headless", "query"], dir);
     assert(result.code === 0, `expected exit 0, got ${result.code}`);
-    
+
     const json = JSON.parse(result.stdout);
-    assert((json.state?.phase ?? json.phase) === "summarizing", `expected summarizing, got: ${(json.state?.phase ?? json.phase)}`);
+    assert(
+      (json.state?.phase ?? json.phase) === "summarizing",
+      `expected summarizing, got: ${json.state?.phase ?? json.phase}`,
+    );
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
@@ -188,17 +243,22 @@ run("headless query: milestone with summary reports complete", () => {
   try {
     const mDir = join(dir, ".gsd", "milestones", "M001");
     mkdirSync(mDir, { recursive: true });
-    writeFileSync(join(mDir, "M001-ROADMAP.md"), buildMinimalRoadmap([
-      { id: "S01", title: "Done", done: true },
-    ]));
+    writeFileSync(
+      join(mDir, "M001-ROADMAP.md"),
+      buildMinimalRoadmap([{ id: "S01", title: "Done", done: true }]),
+    );
     writeFileSync(join(mDir, "M001-SUMMARY.md"), "# M001 Summary\n\nComplete.");
-    
+
     const result = gsd(["headless", "query"], dir);
     assert(result.code === 0, `expected exit 0, got ${result.code}`);
-    
+
     const json = JSON.parse(result.stdout);
-    assert((json.state?.phase ?? json.phase) === "complete" || (json.state?.phase ?? json.phase) === "idle" || (json.state?.phase ?? json.phase) === "pre-planning",
-      `expected complete/idle/pre-planning, got: ${(json.state?.phase ?? json.phase)}`);
+    assert(
+      (json.state?.phase ?? json.phase) === "complete" ||
+        (json.state?.phase ?? json.phase) === "idle" ||
+        (json.state?.phase ?? json.phase) === "pre-planning",
+      `expected complete/idle/pre-planning, got: ${json.state?.phase ?? json.phase}`,
+    );
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
@@ -212,18 +272,27 @@ run("stale auto.lock with dead PID does not block --version", () => {
     const gsdDir = join(dir, ".gsd");
     mkdirSync(gsdDir, { recursive: true });
     // Write a lock with a PID that doesn't exist
-    writeFileSync(join(gsdDir, "auto.lock"), JSON.stringify({
-      pid: 99999999,
-      startedAt: new Date().toISOString(),
-      unitType: "starting",
-      unitId: "bootstrap",
-      unitStartedAt: new Date().toISOString(),
-      completedUnits: 0,
-    }));
-    
+    writeFileSync(
+      join(gsdDir, "auto.lock"),
+      JSON.stringify({
+        pid: 99999999,
+        startedAt: new Date().toISOString(),
+        unitType: "starting",
+        unitId: "bootstrap",
+        unitStartedAt: new Date().toISOString(),
+        completedUnits: 0,
+      }),
+    );
+
     const result = gsd(["--version"], dir);
-    assert(result.code === 0, `--version should succeed even with stale lock, got code ${result.code}`);
-    assert(/\d+\.\d+\.\d+/.test(result.stdout.trim()), `should output version, got: ${result.stdout}`);
+    assert(
+      result.code === 0,
+      `--version should succeed even with stale lock, got code ${result.code}`,
+    );
+    assert(
+      /\d+\.\d+\.\d+/.test(result.stdout.trim()),
+      `should output version, got: ${result.stdout}`,
+    );
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
@@ -236,15 +305,18 @@ run("crash recovery shows actionable guidance", () => {
   try {
     const gsdDir = join(dir, ".gsd");
     mkdirSync(join(gsdDir, "milestones"), { recursive: true });
-    writeFileSync(join(gsdDir, "auto.lock"), JSON.stringify({
-      pid: 99999999,
-      startedAt: new Date().toISOString(),
-      unitType: "execute-task",
-      unitId: "M001/S01/T02",
-      unitStartedAt: new Date().toISOString(),
-      completedUnits: 5,
-    }));
-    
+    writeFileSync(
+      join(gsdDir, "auto.lock"),
+      JSON.stringify({
+        pid: 99999999,
+        startedAt: new Date().toISOString(),
+        unitType: "execute-task",
+        unitId: "M001/S01/T02",
+        unitStartedAt: new Date().toISOString(),
+        completedUnits: 5,
+      }),
+    );
+
     // headless query should still work — lock is for auto-mode, not query
     const result = gsd(["headless", "query"], dir);
     assert(result.code === 0, `query should succeed with stale lock`);
@@ -261,12 +333,17 @@ run("non-TTY invocation exits quickly with clean error", () => {
     const start = Date.now();
     const result = gsd([], dir); // No args, no TTY
     const elapsed = Date.now() - start;
-    
-    assert(result.code === 1, `expected exit 1 for non-TTY, got ${result.code}`);
+
+    assert(
+      result.code === 1,
+      `expected exit 1 for non-TTY, got ${result.code}`,
+    );
     assert(elapsed < 5000, `should exit within 5s, took ${elapsed}ms`);
     assert(
-      result.stderr.includes("TTY") || result.stderr.includes("terminal") || result.stderr.includes("Interactive"),
-      `should mention TTY requirement in stderr`
+      result.stderr.includes("TTY") ||
+        result.stderr.includes("terminal") ||
+        result.stderr.includes("Interactive"),
+      `should mention TTY requirement in stderr`,
     );
   } finally {
     rmSync(dir, { recursive: true, force: true });
@@ -281,17 +358,23 @@ run("version skew is detected before TTY check", () => {
     // Create a fake managed-resources.json with a future version
     const agentDir = join(dir, ".gsd-test-agent");
     mkdirSync(agentDir, { recursive: true });
-    writeFileSync(join(agentDir, "managed-resources.json"), JSON.stringify({
-      gsdVersion: "999.0.0",
-    }));
-    
+    writeFileSync(
+      join(agentDir, "managed-resources.json"),
+      JSON.stringify({
+        gsdVersion: "999.0.0",
+      }),
+    );
+
     // Set HOME to the temp dir so GSD reads the fake agent dir
     const fakeHome = dir;
     mkdirSync(join(fakeHome, ".gsd", "agent"), { recursive: true });
-    writeFileSync(join(fakeHome, ".gsd", "agent", "managed-resources.json"), JSON.stringify({
-      gsdVersion: "999.0.0",
-    }));
-    
+    writeFileSync(
+      join(fakeHome, ".gsd", "agent", "managed-resources.json"),
+      JSON.stringify({
+        gsdVersion: "999.0.0",
+      }),
+    );
+
     const result = gsd([], dir, { HOME: fakeHome });
     // Should either exit with version mismatch or TTY error — both are fine
     assert(result.code === 1, `expected exit 1, got ${result.code}`);
@@ -305,8 +388,11 @@ run("version skew is detected before TTY check", () => {
 run("gsd --help works (native addon loads or falls back gracefully)", () => {
   const result = gsd(["--help"], process.cwd());
   assert(result.code === 0, `--help should exit 0, got ${result.code}`);
-  assert(result.stdout.toLowerCase().includes("gsd") || result.stdout.toLowerCase().includes("usage"),
-    `help output should contain gsd or usage`);
+  assert(
+    result.stdout.toLowerCase().includes("gsd") ||
+      result.stdout.toLowerCase().includes("usage"),
+    `help output should contain gsd or usage`,
+  );
 });
 
 // ─── Summary ─────────────────────────────────────────────────────────────

--- a/tests/live/run.ts
+++ b/tests/live/run.ts
@@ -48,5 +48,7 @@ for (const file of testFiles) {
   }
 }
 
-console.log(`\nLive tests: ${passed} passed, ${failed} failed, ${skipped} skipped`);
+console.log(
+  `\nLive tests: ${passed} passed, ${failed} failed, ${skipped} skipped`,
+);
 if (failed > 0) process.exit(1);

--- a/tests/live/test-openai-roundtrip.ts
+++ b/tests/live/test-openai-roundtrip.ts
@@ -23,7 +23,9 @@ if (!response.ok) {
   process.exit(1);
 }
 
-const data = (await response.json()) as { choices: Array<{ message: { content: string } }> };
+const data = (await response.json()) as {
+  choices: Array<{ message: { content: string } }>;
+};
 const text = data.choices?.[0]?.message?.content || "";
 
 if (!text.includes("LIVE_TEST_OK")) {

--- a/tests/repro-worktree-bug/repro.mjs
+++ b/tests/repro-worktree-bug/repro.mjs
@@ -16,7 +16,13 @@
  * user-level ~/.gsd), causing resolveProjectRoot() to return /root (home dir).
  */
 
-import { mkdirSync, symlinkSync, existsSync, realpathSync, mkdtempSync } from "node:fs";
+import {
+  mkdirSync,
+  symlinkSync,
+  existsSync,
+  realpathSync,
+  mkdtempSync,
+} from "node:fs";
 import { execSync } from "node:child_process";
 import { join } from "node:path";
 import { homedir, tmpdir } from "node:os";
@@ -34,7 +40,10 @@ function findWorktreeSegment(normalizedPath) {
   const symlinkRe = /\/\.gsd\/projects\/[a-f0-9]+\/worktrees\//;
   const match = normalizedPath.match(symlinkRe);
   if (match && match.index !== undefined) {
-    return { gsdIdx: match.index, afterWorktrees: match.index + match[0].length };
+    return {
+      gsdIdx: match.index,
+      afterWorktrees: match.index + match[0].length,
+    };
   }
   return null;
 }
@@ -79,8 +88,14 @@ console.log(`Symlink: ${PROJECT_GSD_LINK} → ${PROJECT_GSD_STORAGE}`);
 // 4. Init git in project dir
 execSync("git init -b main", { cwd: PROJECT_DIR, stdio: "pipe" });
 execSync('git config user.name "Test"', { cwd: PROJECT_DIR, stdio: "pipe" });
-execSync('git config user.email "test@test.com"', { cwd: PROJECT_DIR, stdio: "pipe" });
-execSync("git commit --allow-empty -m init", { cwd: PROJECT_DIR, stdio: "pipe" });
+execSync('git config user.email "test@test.com"', {
+  cwd: PROJECT_DIR,
+  stdio: "pipe",
+});
+execSync("git commit --allow-empty -m init", {
+  cwd: PROJECT_DIR,
+  stdio: "pipe",
+});
 console.log(`Git init: ${PROJECT_DIR}`);
 
 console.log("\n=== Path Resolution Tests ===\n");
@@ -93,18 +108,24 @@ console.log(`  Input:    ${logicalPath}`);
 console.log(`  Expected: ${PROJECT_DIR}`);
 const result1 = resolveProjectRoot(logicalPath);
 console.log(`  Got:      ${result1}`);
-console.log(`  Status:   ${result1 === PROJECT_DIR ? "✅ PASS" : "❌ FAIL — BUG NOT TRIGGERED (logical path)"}`);
+console.log(
+  `  Status:   ${result1 === PROJECT_DIR ? "✅ PASS" : "❌ FAIL — BUG NOT TRIGGERED (logical path)"}`,
+);
 
 // ── Test 2: Resolved path (what process.cwd() returns) ──────────────────
 
 const resolvedPath = realpathSync(logicalPath);
-console.log(`\nTest 2: Resolved path (what process.cwd() returns after chdir to worktree)`);
+console.log(
+  `\nTest 2: Resolved path (what process.cwd() returns after chdir to worktree)`,
+);
 console.log(`  Input:    ${resolvedPath}`);
 console.log(`  Expected: ${PROJECT_DIR}`);
 const result2 = resolveProjectRoot(resolvedPath);
 console.log(`  Got:      ${result2}`);
 const isBuggy = result2 !== PROJECT_DIR;
-console.log(`  Status:   ${isBuggy ? "🐛 BUG REPRODUCED — resolves to wrong directory!" : "✅ PASS"}`);
+console.log(
+  `  Status:   ${isBuggy ? "🐛 BUG REPRODUCED — resolves to wrong directory!" : "✅ PASS"}`,
+);
 
 // ── Test 3: Simulate what actually happens in a worker ──────────────────
 
@@ -117,7 +138,9 @@ console.log(`  Expected project root: ${PROJECT_DIR}`);
 const result3 = resolveProjectRoot(workerCwd);
 console.log(`  resolveProjectRoot():  ${result3}`);
 const workerBuggy = result3 !== PROJECT_DIR;
-console.log(`  Status:   ${workerBuggy ? "🐛 BUG REPRODUCED — worker would use wrong project root!" : "✅ PASS"}`);
+console.log(
+  `  Status:   ${workerBuggy ? "🐛 BUG REPRODUCED — worker would use wrong project root!" : "✅ PASS"}`,
+);
 
 // ── Test 4: Show the cascade ────────────────────────────────────────────
 
@@ -125,8 +148,10 @@ if (workerBuggy) {
   console.log(`\n=== Cascade Analysis ===\n`);
   console.log(`The worker thinks project root is: ${result3}`);
   console.log(`It would look for .gsd at:         ${result3}/.gsd`);
-  console.log(`That path exists:                   ${existsSync(join(result3, ".gsd"))}`);
-  
+  console.log(
+    `That path exists:                   ${existsSync(join(result3, ".gsd"))}`,
+  );
+
   if (existsSync(join(result3, ".gsd"))) {
     const resolvedGsd = realpathSync(join(result3, ".gsd"));
     console.log(`It resolves to:                    ${resolvedGsd}`);
@@ -148,15 +173,23 @@ if (seg) {
   console.log(`  gsdIdx:         ${seg.gsdIdx}`);
   console.log(`  afterWorktrees: ${seg.afterWorktrees}`);
   console.log(`  Path before /.gsd/: "${resolvedPath.slice(0, seg.gsdIdx)}"`);
-  console.log(`  This is: ${resolvedPath.slice(0, seg.gsdIdx) === USER_HOME ? "THE HOME DIRECTORY (bug!)" : "some other directory"}`);
-  
+  console.log(
+    `  This is: ${resolvedPath.slice(0, seg.gsdIdx) === USER_HOME ? "THE HOME DIRECTORY (bug!)" : "some other directory"}`,
+  );
+
   // Show which regex matched
   const directMarker = "/.gsd/worktrees/";
   const directIdx = resolvedPath.indexOf(directMarker);
   if (directIdx !== -1) {
-    console.log(`\n  Matched by: direct marker "/.gsd/worktrees/" at index ${directIdx}`);
-    console.log(`  The /.gsd/ it found is at: "${resolvedPath.slice(0, directIdx + 5)}"`);
-    console.log(`  This /.gsd/ is the USER-LEVEL ~/.gsd, not the project .gsd!`);
+    console.log(
+      `\n  Matched by: direct marker "/.gsd/worktrees/" at index ${directIdx}`,
+    );
+    console.log(
+      `  The /.gsd/ it found is at: "${resolvedPath.slice(0, directIdx + 5)}"`,
+    );
+    console.log(
+      `  This /.gsd/ is the USER-LEVEL ~/.gsd, not the project .gsd!`,
+    );
   } else {
     console.log(`\n  Matched by: symlink regex`);
   }

--- a/tests/repro-worktree-bug/verify-fix.mjs
+++ b/tests/repro-worktree-bug/verify-fix.mjs
@@ -6,7 +6,13 @@
  */
 
 import {
-  mkdirSync, symlinkSync, existsSync, readFileSync, realpathSync, writeFileSync, mkdtempSync,
+  mkdirSync,
+  symlinkSync,
+  existsSync,
+  readFileSync,
+  realpathSync,
+  writeFileSync,
+  mkdtempSync,
 } from "node:fs";
 import { execSync } from "node:child_process";
 import { join, resolve } from "node:path";
@@ -23,7 +29,10 @@ function findWorktreeSegment(normalizedPath) {
   const symlinkRe = /\/\.gsd\/projects\/[a-f0-9]+\/worktrees\//;
   const match = normalizedPath.match(symlinkRe);
   if (match && match.index !== undefined) {
-    return { gsdIdx: match.index, afterWorktrees: match.index + match[0].length };
+    return {
+      gsdIdx: match.index,
+      afterWorktrees: match.index + match[0].length,
+    };
   }
   return null;
 }
@@ -38,7 +47,11 @@ function resolveProjectRootFromGitFile(worktreePath) {
         if (content.startsWith("gitdir: ")) {
           const gitDir = resolve(dir, content.slice(8));
           const dotGitDir = resolve(gitDir, "..", "..");
-          if (dotGitDir.endsWith(".git") || dotGitDir.endsWith(".git/") || dotGitDir.endsWith(".git\\")) {
+          if (
+            dotGitDir.endsWith(".git") ||
+            dotGitDir.endsWith(".git/") ||
+            dotGitDir.endsWith(".git\\")
+          ) {
             return resolve(dotGitDir, "..");
           }
           const commonDirPath = join(gitDir, "commondir");
@@ -54,7 +67,7 @@ function resolveProjectRootFromGitFile(worktreePath) {
       if (parent === dir) break;
       dir = parent;
     }
-  } catch { }
+  } catch {}
   return null;
 }
 
@@ -83,15 +96,19 @@ function resolveProjectRoot(basePath) {
   const sepChar = basePath.includes("\\") ? "\\" : "/";
   const gsdMarker = `${sepChar}.gsd${sepChar}`;
   const gsdIdx = basePath.indexOf(gsdMarker);
-  const candidate = gsdIdx !== -1
-    ? basePath.slice(0, gsdIdx)
-    : basePath.slice(0, seg.gsdIdx);
+  const candidate =
+    gsdIdx !== -1 ? basePath.slice(0, gsdIdx) : basePath.slice(0, seg.gsdIdx);
 
   // Layer 2: Guard against resolving to the user's home directory.
-  const gsdHome = normalizePathForCompare(process.env.GSD_HOME || join(homedir(), ".gsd"));
+  const gsdHome = normalizePathForCompare(
+    process.env.GSD_HOME || join(homedir(), ".gsd"),
+  );
   const candidateGsdPath = normalizePathForCompare(join(candidate, ".gsd"));
 
-  if (candidateGsdPath === gsdHome || candidateGsdPath.startsWith(gsdHome + "/")) {
+  if (
+    candidateGsdPath === gsdHome ||
+    candidateGsdPath.startsWith(gsdHome + "/")
+  ) {
     const realRoot = resolveProjectRootFromGitFile(basePath);
     if (realRoot) return realRoot;
     return basePath;
@@ -124,9 +141,15 @@ symlinkSync(PROJECT_GSD_STORAGE, PROJECT_GSD_LINK);
 // Init git in project dir
 execSync("git init -b main", { cwd: PROJECT_DIR, stdio: "pipe" });
 execSync('git config user.name "Test"', { cwd: PROJECT_DIR, stdio: "pipe" });
-execSync('git config user.email "test@test.com"', { cwd: PROJECT_DIR, stdio: "pipe" });
+execSync('git config user.email "test@test.com"', {
+  cwd: PROJECT_DIR,
+  stdio: "pipe",
+});
 writeFileSync(join(PROJECT_DIR, "README.md"), "hello\n");
-execSync("git add -A && git commit -m init", { cwd: PROJECT_DIR, stdio: "pipe" });
+execSync("git add -A && git commit -m init", {
+  cwd: PROJECT_DIR,
+  stdio: "pipe",
+});
 
 // Create a REAL git worktree (so .git file exists with gitdir pointer)
 execSync("git worktree add .gsd/worktrees/M001 -b worktree/M001", {
@@ -198,11 +221,7 @@ test(
 );
 
 // Verify it's NOT the home directory
-test(
-  "Result is not the home directory",
-  result !== USER_HOME,
-  true,
-);
+test("Result is not the home directory", result !== USER_HOME, true);
 
 // ── Test 4: Verify the git file fallback works ──────────────────────────
 
@@ -246,11 +265,7 @@ test(
   EXPECTED_BUGGY_ROOT,
 );
 
-test(
-  "New code does NOT return home directory",
-  result !== USER_HOME,
-  true,
-);
+test("New code does NOT return home directory", result !== USER_HOME, true);
 
 // ── Summary ──────────────────────────────────────────────────────────────
 

--- a/tests/repro-worktree-bug/verify-integration.mjs
+++ b/tests/repro-worktree-bug/verify-integration.mjs
@@ -15,8 +15,13 @@
  */
 
 import {
-  mkdirSync, symlinkSync, existsSync, readFileSync, realpathSync,
-  writeFileSync, mkdtempSync,
+  mkdirSync,
+  symlinkSync,
+  existsSync,
+  readFileSync,
+  realpathSync,
+  writeFileSync,
+  mkdtempSync,
 } from "node:fs";
 import { execSync } from "node:child_process";
 import { join, resolve } from "node:path";
@@ -33,7 +38,10 @@ function findWorktreeSegment(normalizedPath) {
   const symlinkRe = /\/\.gsd\/projects\/[a-f0-9]+\/worktrees\//;
   const match = normalizedPath.match(symlinkRe);
   if (match && match.index !== undefined) {
-    return { gsdIdx: match.index, afterWorktrees: match.index + match[0].length };
+    return {
+      gsdIdx: match.index,
+      afterWorktrees: match.index + match[0].length,
+    };
   }
   return null;
 }
@@ -48,7 +56,11 @@ function resolveProjectRootFromGitFile(worktreePath) {
         if (content.startsWith("gitdir: ")) {
           const gitDir = resolve(dir, content.slice(8));
           const dotGitDir = resolve(gitDir, "..", "..");
-          if (dotGitDir.endsWith(".git") || dotGitDir.endsWith(".git/") || dotGitDir.endsWith(".git\\")) {
+          if (
+            dotGitDir.endsWith(".git") ||
+            dotGitDir.endsWith(".git/") ||
+            dotGitDir.endsWith(".git\\")
+          ) {
             return resolve(dotGitDir, "..");
           }
           const commonDirPath = join(gitDir, "commondir");
@@ -64,7 +76,7 @@ function resolveProjectRootFromGitFile(worktreePath) {
       if (parent === dir) break;
       dir = parent;
     }
-  } catch { }
+  } catch {}
   return null;
 }
 
@@ -93,12 +105,16 @@ function resolveProjectRoot(basePath) {
   const sepChar = basePath.includes("\\") ? "\\" : "/";
   const gsdMarker = `${sepChar}.gsd${sepChar}`;
   const gsdIdx = basePath.indexOf(gsdMarker);
-  const candidate = gsdIdx !== -1
-    ? basePath.slice(0, gsdIdx)
-    : basePath.slice(0, seg.gsdIdx);
-  const gsdHome = normalizePathForCompare(process.env.GSD_HOME || join(homedir(), ".gsd"));
+  const candidate =
+    gsdIdx !== -1 ? basePath.slice(0, gsdIdx) : basePath.slice(0, seg.gsdIdx);
+  const gsdHome = normalizePathForCompare(
+    process.env.GSD_HOME || join(homedir(), ".gsd"),
+  );
   const candidateGsdPath = normalizePathForCompare(join(candidate, ".gsd"));
-  if (candidateGsdPath === gsdHome || candidateGsdPath.startsWith(gsdHome + "/")) {
+  if (
+    candidateGsdPath === gsdHome ||
+    candidateGsdPath.startsWith(gsdHome + "/")
+  ) {
     const realRoot = resolveProjectRootFromGitFile(basePath);
     if (realRoot) return realRoot;
     return basePath;
@@ -116,15 +132,27 @@ function gsdRoot(basePath) {
 // Simplified validateDirectory — matches validate-directory.ts
 function validateDirectory(dirPath) {
   let resolved;
-  try { resolved = realpathSync(resolve(dirPath)); } catch { resolved = resolve(dirPath); }
+  try {
+    resolved = realpathSync(resolve(dirPath));
+  } catch {
+    resolved = resolve(dirPath);
+  }
   let normalized = resolved.replace(/[/\\]+$/, "");
   if (normalized === "") normalized = "/";
 
   let resolvedHome;
-  try { resolvedHome = realpathSync(resolve(homedir())).replace(/[/\\]+$/, ""); } catch { resolvedHome = resolve(homedir()).replace(/[/\\]+$/, ""); }
+  try {
+    resolvedHome = realpathSync(resolve(homedir())).replace(/[/\\]+$/, "");
+  } catch {
+    resolvedHome = resolve(homedir()).replace(/[/\\]+$/, "");
+  }
 
   if (normalized === resolvedHome) {
-    return { safe: false, severity: "blocked", reason: `Refusing to run in home directory: ${normalized}` };
+    return {
+      safe: false,
+      severity: "blocked",
+      reason: `Refusing to run in home directory: ${normalized}`,
+    };
   }
   return { safe: true, severity: "ok" };
 }
@@ -153,17 +181,33 @@ PROJECT_STORAGE_REAL = normalizePathForCompare(PROJECT_GSD_STORAGE);
 
 execSync("git init -b main", { cwd: PROJECT_DIR, stdio: "pipe" });
 execSync('git config user.name "Test"', { cwd: PROJECT_DIR, stdio: "pipe" });
-execSync('git config user.email "test@test.com"', { cwd: PROJECT_DIR, stdio: "pipe" });
+execSync('git config user.email "test@test.com"', {
+  cwd: PROJECT_DIR,
+  stdio: "pipe",
+});
 writeFileSync(join(PROJECT_DIR, "README.md"), "hello\n");
-execSync("git add -A && git commit -m init", { cwd: PROJECT_DIR, stdio: "pipe" });
-execSync("git worktree add .gsd/worktrees/M001 -b worktree/M001", { cwd: PROJECT_DIR, stdio: "pipe" });
+execSync("git add -A && git commit -m init", {
+  cwd: PROJECT_DIR,
+  stdio: "pipe",
+});
+execSync("git worktree add .gsd/worktrees/M001 -b worktree/M001", {
+  cwd: PROJECT_DIR,
+  stdio: "pipe",
+});
 console.log("Created project with symlinked .gsd and real git worktree\n");
 
 let passed = 0;
 let failed = 0;
 function test(name, actual, expected) {
-  if (actual === expected) { console.log(`  ✅ ${name}`); passed++; }
-  else { console.log(`  ❌ ${name}\n     Expected: ${expected}\n     Got:      ${actual}`); failed++; }
+  if (actual === expected) {
+    console.log(`  ✅ ${name}`);
+    passed++;
+  } else {
+    console.log(
+      `  ❌ ${name}\n     Expected: ${expected}\n     Got:      ${actual}`,
+    );
+    failed++;
+  }
 }
 
 // ── Simulate worker environment ──────────────────────────────────────────
@@ -177,7 +221,11 @@ console.log(`  Worker cwd (resolved): ${workerCwd}`);
 const projectRoot = resolveProjectRoot(workerCwd);
 console.log(`  Resolved project root: ${projectRoot}`);
 test("resolveProjectRoot returns real project root", projectRoot, PROJECT_REAL);
-test("resolveProjectRoot does NOT return home dir", projectRoot !== USER_HOME, true);
+test(
+  "resolveProjectRoot does NOT return home dir",
+  projectRoot !== USER_HOME,
+  true,
+);
 
 console.log("\n=== Test 2: gsdRoot finds project .gsd ===\n");
 
@@ -189,7 +237,11 @@ test("gsdRoot points to project .gsd", gsd, `${PROJECT_REAL}/.gsd`);
 const gsdReal = realpathSync(gsd);
 console.log(`  gsdRoot resolves to: ${gsdReal}`);
 test("gsdRoot resolves to project storage", gsdReal, PROJECT_STORAGE_REAL);
-test("gsdRoot does NOT resolve to user-level ~/.gsd", gsdReal !== USER_GSD, true);
+test(
+  "gsdRoot does NOT resolve to user-level ~/.gsd",
+  gsdReal !== USER_GSD,
+  true,
+);
 
 console.log("\n=== Test 3: parallel/ directory targets project .gsd ===\n");
 
@@ -197,37 +249,73 @@ const parallelDir = join(gsd, "parallel");
 console.log(`  Parallel dir would be: ${parallelDir}`);
 const parallelReal = join(gsdReal, "parallel");
 console.log(`  Resolves physically to: ${parallelReal}`);
-test("parallel dir is under project .gsd", parallelDir.startsWith(PROJECT_REAL), true);
-test("parallel dir is NOT under ~/.gsd root", !parallelDir.startsWith(USER_GSD) || parallelDir.startsWith(`${USER_GSD}/projects/`), true);
+test(
+  "parallel dir is under project .gsd",
+  parallelDir.startsWith(PROJECT_REAL),
+  true,
+);
+test(
+  "parallel dir is NOT under ~/.gsd root",
+  !parallelDir.startsWith(USER_GSD) ||
+    parallelDir.startsWith(`${USER_GSD}/projects/`),
+  true,
+);
 
 // Actually create it and verify
 mkdirSync(parallelDir, { recursive: true });
 test("parallel dir was created", existsSync(parallelDir), true);
-test("parallel dir physically exists in project storage", existsSync(parallelReal), true);
+test(
+  "parallel dir physically exists in project storage",
+  existsSync(parallelReal),
+  true,
+);
 
 // Write a session status file
 const statusFile = join(parallelDir, "M001.status.json");
-writeFileSync(statusFile, JSON.stringify({ milestoneId: "M001", pid: 12345, state: "running" }));
-test("session status file written to project parallel/", existsSync(statusFile), true);
+writeFileSync(
+  statusFile,
+  JSON.stringify({ milestoneId: "M001", pid: 12345, state: "running" }),
+);
+test(
+  "session status file written to project parallel/",
+  existsSync(statusFile),
+  true,
+);
 
 console.log("\n=== Test 4: orchestrator.json targets project .gsd ===\n");
 
 const orchestratorPath = join(gsd, "orchestrator.json");
 console.log(`  orchestrator.json would be at: ${orchestratorPath}`);
 writeFileSync(orchestratorPath, JSON.stringify({ active: true }));
-test("orchestrator.json written to project .gsd", existsSync(orchestratorPath), true);
+test(
+  "orchestrator.json written to project .gsd",
+  existsSync(orchestratorPath),
+  true,
+);
 
 // Verify nothing leaked to user-level ~/.gsd root
 const userParallelDir = join(USER_GSD, "parallel");
 const userOrchestratorPath = join(USER_GSD, "orchestrator.json");
-test("NO parallel/ dir at user-level ~/.gsd root", !existsSync(userParallelDir), true);
-test("NO orchestrator.json at user-level ~/.gsd root", !existsSync(userOrchestratorPath), true);
+test(
+  "NO parallel/ dir at user-level ~/.gsd root",
+  !existsSync(userParallelDir),
+  true,
+);
+test(
+  "NO orchestrator.json at user-level ~/.gsd root",
+  !existsSync(userOrchestratorPath),
+  true,
+);
 
 console.log("\n=== Test 5: validateDirectory blocks ~ as project root ===\n");
 
 const homeValidation = validateDirectory(USER_HOME);
 test("validateDirectory blocks home dir", homeValidation.safe, false);
-test("validateDirectory blocks with 'blocked' severity", homeValidation.severity, "blocked");
+test(
+  "validateDirectory blocks with 'blocked' severity",
+  homeValidation.severity,
+  "blocked",
+);
 
 const projectValidation = validateDirectory(PROJECT_DIR);
 test("validateDirectory allows project dir", projectValidation.safe, true);
@@ -241,8 +329,16 @@ delete process.env.GSD_PROJECT_ROOT;
 
 console.log("\n=== Test 7: Non-worktree paths unaffected ===\n");
 
-test("Regular project path unchanged", resolveProjectRoot("/some/project"), "/some/project");
-test("Direct worktree layout still works", resolveProjectRoot("/foo/.gsd/worktrees/M001"), "/foo");
+test(
+  "Regular project path unchanged",
+  resolveProjectRoot("/some/project"),
+  "/some/project",
+);
+test(
+  "Direct worktree layout still works",
+  resolveProjectRoot("/foo/.gsd/worktrees/M001"),
+  "/foo",
+);
 
 // ── Summary ──────────────────────────────────────────────────────────────
 

--- a/tests/smoke/test-help.ts
+++ b/tests/smoke/test-help.ts
@@ -1,9 +1,7 @@
 import { execFileSync } from "child_process";
 
 const binary = process.env.GSD_SMOKE_BINARY || "npx";
-const args = process.env.GSD_SMOKE_BINARY
-  ? ["--help"]
-  : ["gsd-pi", "--help"];
+const args = process.env.GSD_SMOKE_BINARY ? ["--help"] : ["gsd-pi", "--help"];
 
 const output = execFileSync(binary, args, {
   encoding: "utf8",

--- a/tests/smoke/test-init.ts
+++ b/tests/smoke/test-init.ts
@@ -13,9 +13,7 @@ const tmpDir = mkdtempSync(join(tmpdir(), "gsd-smoke-init-"));
 
 try {
   const binary = process.env.GSD_SMOKE_BINARY || "npx";
-  const args = process.env.GSD_SMOKE_BINARY
-    ? ["init"]
-    : ["gsd-pi", "init"];
+  const args = process.env.GSD_SMOKE_BINARY ? ["init"] : ["gsd-pi", "init"];
 
   execFileSync(binary, args, {
     encoding: "utf8",

--- a/tsconfig.resources.json
+++ b/tsconfig.resources.json
@@ -9,5 +9,9 @@
     "sourceMap": false
   },
   "include": ["src/resources/extensions/**/*.ts"],
-  "exclude": ["src/resources/extensions/**/tests/**", "src/resources/extensions/**/*.test.ts", "src/resources/extensions/**/*.test.mts"]
+  "exclude": [
+    "src/resources/extensions/**/tests/**",
+    "src/resources/extensions/**/*.test.ts",
+    "src/resources/extensions/**/*.test.mts"
+  ]
 }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -4,6 +4,13 @@
     "declaration": false,
     "noEmit": false
   },
-  "include": ["src/tests/headless-cli-surface.test.ts", "src/tests/ensure-workspace-builds.test.ts", "src/headless-events.ts", "src/headless-types.ts", "src/tests/google-search-oauth-shape.test.ts", "src/tests/google-search-auth.repro.test.ts"],
+  "include": [
+    "src/tests/headless-cli-surface.test.ts",
+    "src/tests/ensure-workspace-builds.test.ts",
+    "src/headless-events.ts",
+    "src/headless-types.ts",
+    "src/tests/google-search-oauth-shape.test.ts",
+    "src/tests/google-search-auth.repro.test.ts"
+  ],
   "exclude": []
 }


### PR DESCRIPTION
Closes #3789.

## TL;DR

Ships **Phase 3: Integration Testing** for ADR-011, completing items 19–26 as 8 new integration tests. Because Phase 3 exercises code from both Phase 1 (progressive planning) and Phase 2 (mid-execution escalation), this branch merges both prior PRs and stacks Phase 3 on top, so all three phases land together in one atomically-reviewable tree.

**This PR supersedes #4408 (Phase 1) and #4410 (Phase 2)** — those can be closed on merge.

## What's in here

| Source | Commits | Scope |
|---|---|---|
| PR #4410 base | 4a17d33 → fc41860 | Phase 2 mid-execution escalation + post-review fixes + reconcileWorktreeDb fix |
| PR #4408 merge | 2c18ca9 | Phase 1 progressive planning merged in (496e7be) |
| New — Wave 1 | 71053c8 | Phase 3 #20 (E2E lifecycle), #21 (blocker priority), #22 (ADR-009 audit envelopes) |
| New — Wave 2 | f9cb58f | Phase 3 #19 (refine-slice prompt incorporates findings + sketch scope), #26 (refine dispatch latency bound) |
| New — Wave 3 | 4036160 | Phase 3 #23 (concurrent parallel-slice escalations), #24 (continueWithDefault timeout + late-response injection), #25 (artifact write failure + recovery) |

## Phase 3 item-by-item coverage

- **#19** — `progressive-planning.test.ts` seeds a 3-slice milestone (S01 full+complete, S02/S03 sketches). S01's SUMMARY carries specific findings. Asserts `buildRefineSlicePrompt` for S02 surfaces the findings via `inlineDependencySummaries` AND frames the stored `sketch_scope` as a hard constraint.
- **#20** — Full escalation lifecycle: write ESCALATION.json → `detectPendingEscalation` returns the task id → user resolves with a specific option → pause clears → next task picks up the override block exactly once.
- **#21** — Resolves via `reject-blocker`, pins that `blocker_discovered=1 ∧ blocker_source="reject-escalation" ∧ escalation_pending=0`. Paired with the source-level ordering at `state.ts:977-991` (blocker) before `state.ts:996-1010` (escalation), guarantees blocker priority when both could fire.
- **#22** — Reads `.gsd/audit/events.jsonl` after a full lifecycle and verifies `AuditEventEnvelope` shape (`eventId`, task-scoped `traceId`, `category:"gate"`, `ts`, `payload`) for `escalation-manual-attention-created`, `escalation-user-responded`, `escalation-rejected-to-blocker`.
- **#23** — Two slices escalate in parallel. Asserts each slice's `detectPendingEscalation` call surfaces only its own task, and resolving one slice leaves the other paused. Scheduler branches are independent.
- **#24** — `continueWithDefault=true` on T80; T81+T82 dispatch during the response window (neither claims). User responds LATE with a different option than the recommendation; T83's prompt build claims exactly once with the user's actual choice (not the original recommendation).
- **#25** — `writeEscalationArtifact` with an unresolvable slice path throws, leaves `escalation_pending=0`, and emits no audit envelope. After creating the dir and clearing the path cache, retry lands atomically with exactly one audit event (idempotent recovery, not replay).
- **#26** — Warm-up-then-measure comparison of `buildRefineSlicePrompt` vs `buildPlanSlicePrompt`. Regression gate: absolute bound 500ms, relative bound 3× baseline (skipped when baseline <5ms to dodge timer noise). Catches future O(N) fs walks or DB queries in the refine path.

## Tests

**6783 passed, 0 failed, 8 skipped.** (+8 Phase 3 tests over the Phase 1+2 merged baseline of 6775.)

## Test plan

- [ ] `npx tsc -p tsconfig.extensions.json --noEmit` — clean
- [ ] `npm run test:unit` — 6783 pass
- [ ] Spot-check `escalation.test.ts` and `progressive-planning.test.ts` added tests individually
- [ ] Confirm #4408 and #4410 can be closed (or merged separately) once this lands

## Notes

- The reconcileWorktreeDb fix (`fc41860`) that was Phase 2 follow-up is included here via the Phase 2 commits.
- No production code changes in the three Wave commits — test additions only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mid-execution escalation: tasks can surface structured escalation questions/options; new escalate command to list/show/resolve escalations.
  * Progressive planning & refine-slice unit: sketch-based planning and a dedicated refine flow to convert sketches into plans.

* **Changes**
  * Database/schema expanded to track sketch flags, escalation state, and decision provenance.
  * New workflow phases: "refining" and "escalating-task".
  * New types and prompts supporting refine/escalation flows.

* **Tests**
  * Extensive new and updated tests covering escalation, progressive planning, prompts, and migrations.

* **Documentation**
  * Formatting and table alignment updates in README/CONTRIBUTING/CHANGELOG.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->