### PR TITLE
fix(gsd): auto-mode stuck loop on research dispatch (#4414)

### DIFF
--- a/src/resources/extensions/gsd/auto-artifact-paths.ts
+++ b/src/resources/extensions/gsd/auto-artifact-paths.ts
@@ -43,6 +43,16 @@ export function resolveExpectedArtifactPath(
       return dir ? join(dir, buildMilestoneFileName(mid, "ROADMAP")) : null;
     }
     case "research-slice": {
+      // #4414: Sentinel unitId "{mid}/parallel-research" fans out across
+      // multiple slices. Resolve to a milestone-level placeholder path so
+      // blocker escalation has somewhere to write. Verification for this
+      // sentinel is handled directly in verifyExpectedArtifact.
+      if (sid === "parallel-research") {
+        const mdir = resolveMilestonePath(base, mid);
+        return mdir
+          ? join(mdir, buildMilestoneFileName(mid, "PARALLEL-BLOCKER"))
+          : null;
+      }
       const dir = resolveSlicePath(base, mid, sid!);
       return dir ? join(dir, buildSliceFileName(sid!, "RESEARCH")) : null;
     }
@@ -114,6 +124,9 @@ export function diagnoseExpectedArtifact(
     case "plan-milestone":
       return `${relMilestoneFile(base, mid, "ROADMAP")} (milestone roadmap)`;
     case "research-slice":
+      if (sid === "parallel-research") {
+        return `${relMilestoneFile(base, mid, "PARALLEL-BLOCKER")} (parallel slice research sentinel)`;
+      }
       return `${relSliceFile(base, mid, sid!, "RESEARCH")} (slice research)`;
     case "plan-slice":
       return `${relSliceFile(base, mid, sid!, "PLAN")} (slice plan)`;

--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -452,6 +452,12 @@ export const DISPATCH_RULES: DispatchRule[] = [
       // Only dispatch parallel if 2+ slices are ready
       if (researchReadySlices.length < 2) return null;
 
+      // #4414: If a previous parallel-research attempt escalated to a blocker
+      // placeholder, skip this rule and fall through to per-slice research
+      // (or other rules) rather than re-dispatching the same failing unit.
+      const parallelBlocker = resolveMilestoneFile(basePath, mid, "PARALLEL-BLOCKER");
+      if (parallelBlocker) return null;
+
       return {
         action: "dispatch",
         unitType: "research-slice",

--- a/src/resources/extensions/gsd/auto-recovery.ts
+++ b/src/resources/extensions/gsd/auto-recovery.ts
@@ -261,6 +261,45 @@ export function verifyExpectedArtifact(
     return true;
   }
 
+  // #4414: research-slice parallel-research sentinel. The unitId
+  // `{mid}/parallel-research` is not a real slice — it triggers a single agent
+  // that fans out research across multiple slices. Verify success by checking
+  // that every slice which was "research-ready" in the roadmap now has a
+  // RESEARCH file. Without this, resolveExpectedArtifactPath returns null and
+  // the retry/escalation machinery silently re-dispatches forever.
+  //
+  // NOTE: this predicate mirrors the dispatch rule at
+  // auto-dispatch.ts parallel-research-slices — keep the two in sync.
+  if (unitType === "research-slice" && unitId.endsWith("/parallel-research")) {
+    const { milestone: mid } = parseUnitId(unitId);
+    if (!mid) return false;
+    const roadmapFile = resolveMilestoneFile(base, mid, "ROADMAP");
+    if (!roadmapFile || !existsSync(roadmapFile)) {
+      logWarning("recovery", `verify-fail ${unitType} ${unitId}: roadmap missing`);
+      return false;
+    }
+    try {
+      const roadmap = parseLegacyRoadmap(readFileSync(roadmapFile, "utf-8"));
+      const milestoneResearchFile = resolveMilestoneFile(base, mid, "RESEARCH");
+      for (const slice of roadmap.slices) {
+        if (slice.done) continue;
+        if (milestoneResearchFile && slice.id === "S01") continue;
+        const depsComplete = (slice.depends ?? []).every((depId) =>
+          !!resolveSliceFile(base, mid, depId, "SUMMARY"),
+        );
+        if (!depsComplete) continue;
+        if (!resolveSliceFile(base, mid, slice.id, "RESEARCH")) {
+          logWarning("recovery", `verify-fail ${unitType} ${unitId}: slice ${slice.id} missing RESEARCH`);
+          return false;
+        }
+      }
+      return true;
+    } catch (err) {
+      logWarning("recovery", `parallel-research verification failed: ${err instanceof Error ? err.message : String(err)}`);
+      return false;
+    }
+  }
+
   const absPath = resolveExpectedArtifactPath(unitType, unitId, base);
   // For unit types with no verifiable artifact (null path), the parent directory
   // is missing on disk — treat as stale completion state so the key gets evicted (#313).
@@ -454,6 +493,14 @@ export function writeBlockerPlaceholder(
     `Review and replace this file before relying on downstream artifacts.`,
   ].join("\n");
   writeFileSync(absPath, content, "utf-8");
+
+  // #4414: Clear caches so subsequent dispatch guards (e.g.
+  // resolveMilestoneFile) see the placeholder file. Without this, the
+  // cached directory listing is stale and the dispatch rule re-fires,
+  // producing an infinite loop despite the placeholder being on disk.
+  // Matches the pattern used in verifyExpectedArtifact above.
+  clearPathCache();
+  clearParseCache();
 
   // Mark the task/slice as complete in the DB so verifyExpectedArtifact passes.
   // Without this, the DB status stays "pending" and the dispatch loop

--- a/src/resources/extensions/gsd/doctor.ts
+++ b/src/resources/extensions/gsd/doctor.ts
@@ -172,8 +172,14 @@ function auditRequirements(content: string | null): DoctorIssue[] {
     const notes = block.match(/^-\s+Notes:\s+(.+)$/m)?.[1]?.trim().toLowerCase() ?? "";
 
     if (status === "active" && (!owner || owner === "none" || owner === "none yet")) {
+      // #4414: Downgrade to warning. A newly-created requirement has
+      // primary_owner='' by default until the planning agent wires it to
+      // a slice via gsd_requirement_update. Flagging this as an error
+      // during normal planning is noisy — the real failure mode is when
+      // it persists past milestone completion, which is covered by other
+      // audits. Keep the signal but don't treat it as a blocker.
       issues.push({
-        severity: "error",
+        severity: "warning",
         code: "active_requirement_missing_owner",
         scope: "project",
         unitId: requirementId,

--- a/src/resources/extensions/gsd/tests/auto-recovery.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-recovery.test.ts
@@ -5,7 +5,8 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { randomUUID } from "node:crypto";
 
-import { verifyExpectedArtifact, hasImplementationArtifacts, resolveExpectedArtifactPath, diagnoseExpectedArtifact, buildLoopRemediationSteps } from "../auto-recovery.ts";
+import { verifyExpectedArtifact, hasImplementationArtifacts, resolveExpectedArtifactPath, diagnoseExpectedArtifact, buildLoopRemediationSteps, writeBlockerPlaceholder } from "../auto-recovery.ts";
+import { resolveMilestoneFile } from "../paths.ts";
 import { openDatabase, closeDatabase, insertMilestone, insertSlice, insertGateRow } from "../gsd-db.ts";
 import { clearParseCache } from "../files.ts";
 import { parseRoadmap } from "../parsers-legacy.ts";
@@ -711,4 +712,125 @@ test("verifyExpectedArtifact checks pending gate-evaluate artifacts without ESM 
   const verified = verifyExpectedArtifact("gate-evaluate", "M001/S01/gates+Q3", base);
 
   assert.equal(verified, false, "pending gates should keep gate-evaluate unverified");
+});
+
+// ─── #4414 regressions ────────────────────────────────────────────────────────
+
+test("#4414: writeBlockerPlaceholder invalidates path cache so dispatch guard sees file", () => {
+  const base = makeTmpBase();
+  try {
+    // Prime the readdir cache by resolving a DIFFERENT file first — this
+    // mirrors the stuck-loop condition where the dispatch guard cached an
+    // empty directory listing before the placeholder was written.
+    invalidateAllCaches();
+    assert.equal(
+      resolveMilestoneFile(base, "M001", "RESEARCH"),
+      null,
+      "no RESEARCH file yet",
+    );
+
+    const result = writeBlockerPlaceholder(
+      "research-milestone",
+      "M001",
+      base,
+      "verification retries exhausted",
+    );
+    assert.ok(result, "placeholder path returned");
+
+    // After writeBlockerPlaceholder, the dispatch guard must see the new file
+    // immediately — otherwise the rule re-fires (#4414, 7× re-dispatch).
+    const postResolve = resolveMilestoneFile(base, "M001", "RESEARCH");
+    assert.ok(
+      postResolve,
+      "resolveMilestoneFile finds the placeholder post-write (cache invalidated)",
+    );
+  } finally {
+    cleanup(base);
+  }
+});
+
+test("#4414: parallel-research sentinel path does not collide with RESEARCH suffix", () => {
+  const base = makeTmpBase();
+  try {
+    // Write only the parallel-research blocker (sentinel).
+    const sentinel = resolveExpectedArtifactPath(
+      "research-slice",
+      "M001/parallel-research",
+      base,
+    );
+    assert.ok(sentinel, "sentinel path resolves for parallel-research");
+    writeFileSync(sentinel!, "# blocker\n", "utf-8");
+
+    // Critical: the sentinel filename must NOT be matched by the legacy regex
+    // used when callers look up milestone-level RESEARCH. Otherwise the
+    // dispatch guard for research-milestone would short-circuit falsely.
+    const milestoneResearch = resolveMilestoneFile(base, "M001", "RESEARCH");
+    assert.equal(
+      milestoneResearch,
+      null,
+      "sentinel must not be mistaken for M001-RESEARCH.md via legacy pattern match",
+    );
+  } finally {
+    cleanup(base);
+  }
+});
+
+test("#4414: verifyExpectedArtifact parallel-research succeeds when all research-ready slices have RESEARCH", () => {
+  const base = makeTmpBase();
+  try {
+    mkdirSync(join(base, ".gsd", "milestones", "M001", "slices", "S02", "tasks"), { recursive: true });
+    mkdirSync(join(base, ".gsd", "milestones", "M001", "slices", "S03", "tasks"), { recursive: true });
+
+    // Minimal roadmap with three slices
+    writeFileSync(
+      join(base, ".gsd", "milestones", "M001", "M001-ROADMAP.md"),
+      [
+        "# M001: Regression",
+        "",
+        "## Slices",
+        "",
+        "- [ ] **S01: Alpha** `risk:low` `depends:[]`",
+        "- [ ] **S02: Beta** `risk:low` `depends:[]`",
+        "- [ ] **S03: Gamma** `risk:low` `depends:[]`",
+        "",
+      ].join("\n"),
+      "utf-8",
+    );
+
+    // Only 2 of 3 have RESEARCH — should fail verification
+    writeFileSync(
+      join(base, ".gsd", "milestones", "M001", "slices", "S01", "S01-RESEARCH.md"),
+      "# research",
+      "utf-8",
+    );
+    writeFileSync(
+      join(base, ".gsd", "milestones", "M001", "slices", "S02", "S02-RESEARCH.md"),
+      "# research",
+      "utf-8",
+    );
+
+    clearParseCache();
+    invalidateAllCaches();
+    assert.equal(
+      verifyExpectedArtifact("research-slice", "M001/parallel-research", base),
+      false,
+      "missing S03 RESEARCH → verification fails",
+    );
+
+    // All three RESEARCH present → verification passes
+    writeFileSync(
+      join(base, ".gsd", "milestones", "M001", "slices", "S03", "S03-RESEARCH.md"),
+      "# research",
+      "utf-8",
+    );
+    clearParseCache();
+    invalidateAllCaches();
+    assert.equal(
+      verifyExpectedArtifact("research-slice", "M001/parallel-research", base),
+      true,
+      "all slices have RESEARCH → verification passes",
+    );
+  } finally {
+    cleanup(base);
+  }
 });

--- a/src/resources/extensions/gsd/tests/requirements.test.ts
+++ b/src/resources/extensions/gsd/tests/requirements.test.ts
@@ -95,6 +95,15 @@ describe('requirements', () => {
     assert.ok(report.issues.some(issue => issue.code === "active_requirement_missing_owner"), "doctor flags missing owner");
   });
 
+  // #4414: active_requirement_missing_owner is a planning-hygiene signal,
+  // not a correctness blocker — severity must be warning, not error.
+  test('#4414: active_requirement_missing_owner is a warning, not an error', async () => {
+    const report = await runGSDDoctor(base);
+    const issue = report.issues.find(i => i.code === "active_requirement_missing_owner");
+    assert.ok(issue, "issue is present");
+    assert.equal(issue!.severity, "warning", "severity downgraded so doctor report.ok is not flipped to false");
+  });
+
   after(() => {
     rmSync(base, { recursive: true, force: true });
   });


### PR DESCRIPTION
## Summary
Fixes #4414 — GSD auto-mode entering a stuck loop, re-dispatching `research-milestone` and `research-slice/parallel-research` units without successful verification.

Three root causes:

- **Stale path cache after blocker placeholder write.** `writeBlockerPlaceholder` wrote the placeholder file but did not invalidate `cachedReaddir`, so the dispatch guard (`resolveMilestoneFile`) kept missing the file and re-fired the rule. Added `clearPathCache()` + `clearParseCache()` after the write, matching the pattern used elsewhere in `auto-recovery.ts`.
- **`research-slice/{mid}/parallel-research` sentinel had no expected artifact.** `resolveSlicePath(base, mid, "parallel-research")` returned null, so `verifyExpectedArtifact` returned false, `resolveExpectedArtifactPath` returned null, and the retry/escalation machinery silently fell through. Added an explicit verification branch that walks the roadmap and checks each research-ready slice has a RESEARCH file, a canonical milestone-level blocker path `M###-PARALLEL-BLOCKER.md`, and a dispatch-rule short-circuit when the blocker sentinel exists.
- **`active_requirement_missing_owner` doctor severity.** Downgraded from error to warning — `primary_owner` defaults to `''` on creation and is populated by later planning updates; flagging as error during normal flow is noise. Sibling `blocked_requirement_missing_reason` is already warning.

### Peer-review fixes
Codex peer review caught that suffix `PARALLEL-RESEARCH` would collide with `resolveFile`'s legacy regex `^M###-.*-RESEARCH\.md$`, falsely resolving the blocker as milestone research. Renamed to `PARALLEL-BLOCKER`.

## Test plan
- [x] `auto-recovery.test.ts` — 28/28 pass
- [x] `parallel-research-dispatch.test.ts` — 8/8 pass
- [x] `requirements.test.ts` — 3/3 pass
- [x] `dispatch-guard.test.ts` — 14/14 pass
- [x] `doctor-fix-flag.test.ts` — 18/18 pass
- [x] `cache-staleness-regression.test.ts` — pass
- [x] Typecheck clean for edited files
- [ ] Manual verification in a stuck auto-mode session

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a parallel-research workflow with a milestone-level blocker to coordinate multi-slice research and prevent premature dispatch.

* **Improvements**
  * Updated artifact resolution and verification to treat parallel-research as a milestone-level concern.
  * Ensured caches are refreshed after creating blocker placeholders so subsequent operations observe filesystem changes.
  * Downgraded unowned-requirement reports from error to warning.

* **Tests**
  * Added regression tests covering blocker creation, resolution, and verification behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->