### PR TITLE
fix(remote-questions): send GSD notify events to configured Telegram channel

### DIFF
--- a/src/resources/extensions/gsd/bootstrap/notify-interceptor.ts
+++ b/src/resources/extensions/gsd/bootstrap/notify-interceptor.ts
@@ -5,11 +5,55 @@
 
 import type { ExtensionContext } from "@gsd/pi-coding-agent";
 
+import { sendRemoteNotification } from "../../remote-questions/notify.js";
 import { appendNotification, type NotifySeverity } from "../notification-store.js";
 
 // Track which ui context objects have been wrapped to prevent double-install.
 // WeakSet allows GC to collect replaced uiContext instances after /reload.
 const _wrappedContexts = new WeakSet<object>();
+const REMOTE_DEDUP_WINDOW_MS = 30_000;
+const REMOTE_DEDUP_PRUNE_THRESHOLD = 200;
+const _recentRemoteNotificationTimestamps = new Map<string, number>();
+
+function shouldSendRemote(message: string, type?: "info" | "warning" | "error" | "success"): boolean {
+  const normalized = String(message ?? "").trim();
+  if (!normalized) return false;
+  return true;
+}
+
+function buildRemoteTitle(type?: "info" | "warning" | "error" | "success"): string {
+  switch (type) {
+    case "error":
+      return "GSD Error";
+    case "warning":
+      return "GSD Warning";
+    case "success":
+      return "GSD Success";
+    case "info":
+    default:
+      return "GSD Update";
+  }
+}
+
+function shouldSkipDuplicateRemote(message: string, type?: "info" | "warning" | "error" | "success"): boolean {
+  const severity = type ?? "info";
+  const normalized = String(message ?? "").trim();
+  const dedupKey = `${severity}:${normalized}`;
+  const now = Date.now();
+  const lastSeen = _recentRemoteNotificationTimestamps.get(dedupKey);
+  if (lastSeen !== undefined && now - lastSeen < REMOTE_DEDUP_WINDOW_MS) {
+    return true;
+  }
+
+  _recentRemoteNotificationTimestamps.set(dedupKey, now);
+  if (_recentRemoteNotificationTimestamps.size > REMOTE_DEDUP_PRUNE_THRESHOLD) {
+    for (const [key, ts] of _recentRemoteNotificationTimestamps) {
+      if (now - ts > REMOTE_DEDUP_WINDOW_MS) _recentRemoteNotificationTimestamps.delete(key);
+    }
+  }
+
+  return false;
+}
 
 /**
  * Install the notify interceptor on a context's UI object.
@@ -27,6 +71,15 @@ export function installNotifyInterceptor(ctx: ExtensionContext): void {
     } catch {
       // Non-fatal — never let persistence break the UI
     }
+
+    try {
+      if (shouldSendRemote(message, type) && !shouldSkipDuplicateRemote(message, type)) {
+        void sendRemoteNotification(buildRemoteTitle(type), String(message ?? ""));
+      }
+    } catch {
+      // Non-fatal — remote notifications are best-effort
+    }
+
     originalNotify(message, type);
   };
 

--- a/src/resources/extensions/gsd/bootstrap/notify-interceptor.ts
+++ b/src/resources/extensions/gsd/bootstrap/notify-interceptor.ts
@@ -15,7 +15,7 @@ const REMOTE_DEDUP_WINDOW_MS = 30_000;
 const REMOTE_DEDUP_PRUNE_THRESHOLD = 200;
 const _recentRemoteNotificationTimestamps = new Map<string, number>();
 
-function shouldSendRemote(message: string, type?: "info" | "warning" | "error" | "success"): boolean {
+function shouldSendRemote(message: string): boolean {
   const normalized = String(message ?? "").trim();
   if (!normalized) return false;
   return true;
@@ -35,15 +35,20 @@ function buildRemoteTitle(type?: "info" | "warning" | "error" | "success"): stri
   }
 }
 
-function shouldSkipDuplicateRemote(message: string, type?: "info" | "warning" | "error" | "success"): boolean {
+function isDuplicateRemote(message: string, type?: "info" | "warning" | "error" | "success"): boolean {
   const severity = type ?? "info";
   const normalized = String(message ?? "").trim();
   const dedupKey = `${severity}:${normalized}`;
   const now = Date.now();
   const lastSeen = _recentRemoteNotificationTimestamps.get(dedupKey);
-  if (lastSeen !== undefined && now - lastSeen < REMOTE_DEDUP_WINDOW_MS) {
-    return true;
-  }
+  return lastSeen !== undefined && now - lastSeen < REMOTE_DEDUP_WINDOW_MS;
+}
+
+function recordRemoteDelivery(message: string, type?: "info" | "warning" | "error" | "success"): void {
+  const severity = type ?? "info";
+  const normalized = String(message ?? "").trim();
+  const dedupKey = `${severity}:${normalized}`;
+  const now = Date.now();
 
   _recentRemoteNotificationTimestamps.set(dedupKey, now);
   if (_recentRemoteNotificationTimestamps.size > REMOTE_DEDUP_PRUNE_THRESHOLD) {
@@ -51,8 +56,6 @@ function shouldSkipDuplicateRemote(message: string, type?: "info" | "warning" | 
       if (now - ts > REMOTE_DEDUP_WINDOW_MS) _recentRemoteNotificationTimestamps.delete(key);
     }
   }
-
-  return false;
 }
 
 /**
@@ -72,12 +75,17 @@ export function installNotifyInterceptor(ctx: ExtensionContext): void {
       // Non-fatal — never let persistence break the UI
     }
 
-    try {
-      if (shouldSendRemote(message, type) && !shouldSkipDuplicateRemote(message, type)) {
-        void sendRemoteNotification(buildRemoteTitle(type), String(message ?? ""));
-      }
-    } catch {
-      // Non-fatal — remote notifications are best-effort
+    if (shouldSendRemote(message) && !isDuplicateRemote(message, type)) {
+      void (async () => {
+        try {
+          const delivered = await sendRemoteNotification(buildRemoteTitle(type), String(message ?? ""));
+          if (delivered) {
+            recordRemoteDelivery(message, type);
+          }
+        } catch {
+          // Non-fatal — remote notifications are best-effort
+        }
+      })();
     }
 
     originalNotify(message, type);

--- a/src/resources/extensions/remote-questions/notify.ts
+++ b/src/resources/extensions/remote-questions/notify.ts
@@ -38,6 +38,8 @@ export async function sendRemoteNotification(title: string, message: string): Pr
       case "telegram":
         await sendTelegramNotification(config, title, message);
         break;
+      default:
+        return false;
     }
     return true;
   } catch {

--- a/src/resources/extensions/remote-questions/notify.ts
+++ b/src/resources/extensions/remote-questions/notify.ts
@@ -18,14 +18,14 @@ import { PER_REQUEST_TIMEOUT_MS } from "./types.js";
  * SECURITY: This is intentionally one-way. Never use remote channels
  * to collect secrets or sensitive values.
  */
-export async function sendRemoteNotification(title: string, message: string): Promise<void> {
+export async function sendRemoteNotification(title: string, message: string): Promise<boolean> {
   let config: ResolvedConfig | null;
   try {
     config = resolveRemoteConfig();
   } catch {
-    return; // Remote not configured — skip silently
+    return false; // Remote not configured — skip silently
   }
-  if (!config) return;
+  if (!config) return false;
 
   try {
     switch (config.channel) {
@@ -39,8 +39,10 @@ export async function sendRemoteNotification(title: string, message: string): Pr
         await sendTelegramNotification(config, title, message);
         break;
     }
+    return true;
   } catch {
     // Non-fatal — remote notifications are best-effort
+    return false;
   }
 }
 

--- a/src/resources/extensions/remote-questions/notify.ts
+++ b/src/resources/extensions/remote-questions/notify.ts
@@ -61,7 +61,18 @@ async function sendSlackNotification(config: ResolvedConfig, title: string, mess
     }),
     signal: AbortSignal.timeout(PER_REQUEST_TIMEOUT_MS),
   });
-  if (!response.ok) throw new Error(`Slack HTTP ${response.status}`);
+
+  let payload: any;
+  try {
+    payload = await response.json();
+  } catch (error) {
+    throw new Error(`Slack HTTP ${response.status} ${response.statusText} (invalid JSON: ${error instanceof Error ? error.message : String(error)})`);
+  }
+
+  if (!response.ok || payload?.ok !== true) {
+    const detail = payload?.error ? String(payload.error) : JSON.stringify(payload);
+    throw new Error(`Slack HTTP ${response.status} ${response.statusText}: ${detail}`);
+  }
 }
 
 async function sendDiscordNotification(config: ResolvedConfig, title: string, message: string): Promise<void> {

--- a/src/resources/extensions/remote-questions/remote-command.ts
+++ b/src/resources/extensions/remote-questions/remote-command.ts
@@ -157,7 +157,7 @@ async function handleSetupDiscord(ctx: ExtensionCommandContext): Promise<void> {
 }
 
 async function handleSetupTelegram(ctx: ExtensionCommandContext): Promise<void> {
-  const token = await promptMaskedInput(ctx, "Telegram Bot Token", "Paste your bot token from @BotFather. If you can't paste token here, setup the ENV and restart GSD.");
+  const token = await promptMaskedInput(ctx, "Telegram Bot Token", "Paste your bot token from @BotFather. If you can't paste the token here, set up TELEGRAM_BOT_TOKEN and restart GSD.");
   if (!token) return void ctx.ui.notify("Telegram setup cancelled.", "info");
   if (!/^\d+:[A-Za-z0-9_-]+$/.test(token)) return void ctx.ui.notify("Invalid token format — Telegram bot tokens look like 123456789:ABCdefGHI...", "warning");
 

--- a/src/resources/extensions/remote-questions/remote-command.ts
+++ b/src/resources/extensions/remote-questions/remote-command.ts
@@ -157,7 +157,7 @@ async function handleSetupDiscord(ctx: ExtensionCommandContext): Promise<void> {
 }
 
 async function handleSetupTelegram(ctx: ExtensionCommandContext): Promise<void> {
-  const token = await promptMaskedInput(ctx, "Telegram Bot Token", "Paste your bot token from @BotFather");
+  const token = await promptMaskedInput(ctx, "Telegram Bot Token", "Paste your bot token from @BotFather. If you can't paste token here, setup the ENV and restart GSD.");
   if (!token) return void ctx.ui.notify("Telegram setup cancelled.", "info");
   if (!/^\d+:[A-Za-z0-9_-]+$/.test(token)) return void ctx.ui.notify("Invalid token format — Telegram bot tokens look like 123456789:ABCdefGHI...", "warning");
 


### PR DESCRIPTION
## TL;DR

**What:** Wire normal GSD `ctx.ui.notify(...)` events to the configured remote channel and clarify the Telegram setup prompt when token paste is not possible.

**Why:** Remote questions were working, but informational notifications documented for remote channels were not actually being delivered in the installed runtime.

**How:** Fan out `notify` interceptor events through `sendRemoteNotification(...)` with duplicate suppression, and update the Telegram token prompt to mention ENV setup + restart as a fallback.

## What

This PR fixes a gap between the documented remote-questions behavior and the shipped runtime behavior.

Changes:
- `src/resources/extensions/gsd/bootstrap/notify-interceptor.ts`
  - imports and calls `sendRemoteNotification(...)`
  - forwards normal `ctx.ui.notify(...)` events to the configured remote channel
  - keeps local persistence via `appendNotification(...)`
  - adds duplicate suppression for repeated identical notifications within a short window
- `src/resources/extensions/remote-questions/remote-command.ts`
  - updates the Telegram token setup prompt to include a fallback instruction:
    - `If you can't paste token here, setup the ENV and restart GSD.`

The intent is to make remote informational notifications actually work when `remote_questions.channel` is configured, while preserving the existing local notification behavior.

## Why

The documentation for remote questions says that important auto-mode events are also routed to the configured remote channel, including milestone completions, blockers, budget alerts, and other significant status events.

In practice, the current runtime had:
- a working remote prompt path for `ask_user_questions`
- a `sendRemoteNotification(...)` implementation
- but no call site wiring normal `ctx.ui.notify(...)` events into that remote notifier

That meant:
- remote questions worked
- ordinary GSD notifications persisted locally
- but Telegram/Slack/Discord informational notifications were effectively dead code

This also surfaced a setup UX issue for Telegram:
- if token paste is not available in the prompt flow, the user was not explicitly told to set the environment variable and restart GSD

This PR closes both gaps.

## How

### Notification fan-out

The `notify` interceptor is the most centralized place to hook standard GSD notifications without changing many individual auto-mode call sites.

The updated flow is:
1. `ctx.ui.notify(...)` is called
2. notification is persisted locally via `appendNotification(...)`
3. if a remote channel is configured, the message is also sent through `sendRemoteNotification(...)`
4. the original UI notification still renders normally

To reduce spam, repeated identical notifications are suppressed for a short dedupe window.

### Telegram setup guidance

The Telegram setup prompt now explicitly tells the user what to do if token paste is not possible:
- set the token via ENV
- restart GSD

That keeps setup behavior aligned with how remote config resolution already hydrates tokens from auth/env.

## Change type

- [x] `fix` — Bug fix
- [ ] `feat` — New feature or capability
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Breaking changes

None.

## AI-assisted disclosure

This PR was prepared with AI assistance. The behavior was verified manually against a configured Telegram bot:
- success notification delivered
- warning notification delivered
- remote prompt delivered
- Telegram reply was ingested successfully by the remote question flow

## Verification

Manual verification performed against a configured Telegram remote channel:

1. Configure Telegram remote channel
2. Trigger a success notification
3. Trigger a warning notification
4. Trigger a remote question
5. Reply in Telegram

Observed result:
- both notifications arrived
- the prompt arrived
- the reply was parsed and returned to the runtime

## Notes

This is intended as a focused bug fix, not a redesign of remote notification policy. It keeps the existing remote-question architecture and only wires the already-existing notifier into the standard notification path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Notifications now attempt remote delivery (best-effort) alongside local alerts, with in-memory deduplication to avoid duplicate sends within 30 seconds.

* **Bug Fixes / Reliability**
  * Remote delivery failures are isolated and won’t interrupt local notification persistence or user flows.
  * Improved remote delivery validation for greater reliability of sent messages.

* **Documentation**
  * Telegram bot token hint updated to recommend using environment variables and restarting if the token cannot be pasted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->