### PR TITLE
fix(claude-code-cli): detect Windows .cmd shim in CLI readiness checks

### DIFF
--- a/src/claude-cli-check.ts
+++ b/src/claude-cli-check.ts
@@ -5,11 +5,22 @@
 import { execFileSync } from 'node:child_process'
 
 /**
+ * Platform-correct binary name for the Claude Code CLI.
+ *
+ * On Windows, npm-global binaries are installed as `.cmd` shims and
+ * `execFileSync` does not auto-resolve the extension — calling bare
+ * `claude` would fail with ENOENT even when the CLI is installed and
+ * authenticated. Mirrors the `NPM_COMMAND` pattern in
+ * `src/resources/extensions/gsd/pre-execution-checks.ts`.
+ */
+export const CLAUDE_COMMAND = process.platform === 'win32' ? 'claude.cmd' : 'claude'
+
+/**
  * Check if the `claude` binary is installed (regardless of auth state).
  */
 export function isClaudeBinaryInstalled(): boolean {
   try {
-    execFileSync('claude', ['--version'], { timeout: 5_000, stdio: 'pipe' })
+    execFileSync(CLAUDE_COMMAND, ['--version'], { timeout: 5_000, stdio: 'pipe' })
     return true
   } catch {
     return false
@@ -21,13 +32,13 @@ export function isClaudeBinaryInstalled(): boolean {
  */
 export function isClaudeCliReady(): boolean {
   try {
-    execFileSync('claude', ['--version'], { timeout: 5_000, stdio: 'pipe' })
+    execFileSync(CLAUDE_COMMAND, ['--version'], { timeout: 5_000, stdio: 'pipe' })
   } catch {
     return false
   }
 
   try {
-    const output = execFileSync('claude', ['auth', 'status'], { timeout: 5_000, stdio: 'pipe' })
+    const output = execFileSync(CLAUDE_COMMAND, ['auth', 'status'], { timeout: 5_000, stdio: 'pipe' })
       .toString()
       .toLowerCase()
     return !(/not logged in|no credentials|unauthenticated|not authenticated/i.test(output))

--- a/src/resources/extensions/claude-code-cli/readiness.ts
+++ b/src/resources/extensions/claude-code-cli/readiness.ts
@@ -11,6 +11,17 @@
 
 import { execFileSync } from "node:child_process";
 
+/**
+ * Platform-correct binary name for the Claude Code CLI.
+ *
+ * On Windows, npm-global binaries are installed as `.cmd` shims and
+ * `execFileSync` does not auto-resolve the extension — calling bare
+ * `claude` would fail with ENOENT even when the CLI is installed and
+ * authenticated. Mirrors the `NPM_COMMAND` pattern in
+ * `src/resources/extensions/gsd/pre-execution-checks.ts`.
+ */
+const CLAUDE_COMMAND = process.platform === "win32" ? "claude.cmd" : "claude";
+
 let cachedBinaryPresent: boolean | null = null;
 let cachedAuthed: boolean | null = null;
 let lastCheckMs = 0;
@@ -27,7 +38,7 @@ function refreshCache(): void {
 
 	// Check binary presence
 	try {
-		execFileSync("claude", ["--version"], { timeout: 5_000, stdio: "pipe" });
+		execFileSync(CLAUDE_COMMAND, ["--version"], { timeout: 5_000, stdio: "pipe" });
 		cachedBinaryPresent = true;
 	} catch {
 		cachedBinaryPresent = false;
@@ -37,7 +48,7 @@ function refreshCache(): void {
 
 	// Check auth status — exit code 0 with non-error output means authenticated
 	try {
-		const output = execFileSync("claude", ["auth", "status"], { timeout: 5_000, stdio: "pipe" })
+		const output = execFileSync(CLAUDE_COMMAND, ["auth", "status"], { timeout: 5_000, stdio: "pipe" })
 			.toString()
 			.toLowerCase();
 		// The CLI outputs "not logged in", "no credentials", or similar when unauthenticated

--- a/src/tests/claude-cli-windows-detection.test.ts
+++ b/src/tests/claude-cli-windows-detection.test.ts
@@ -13,11 +13,27 @@ import { join } from "node:path";
  * Both the lightweight onboarding check (`src/claude-cli-check.ts`) and
  * the cached readiness check
  * (`src/resources/extensions/claude-code-cli/readiness.ts`) must carry
- * the `process.platform === 'win32'` ? 'claude.cmd' : 'claude'` guard —
+ * the `process.platform === 'win32' ? 'claude.cmd' : 'claude'` guard —
  * analogous to the existing `NPM_COMMAND` pattern in
  * `src/resources/extensions/gsd/pre-execution-checks.ts`.
  */
 
+/**
+ * Proximity regex matching the full ternary expression. Validates the
+ * real command-selection logic rather than individual tokens — keyword-
+ * only assertions (e.g. `/win32/`, `/claude\.cmd/`) can be satisfied by
+ * documentation or comments alone and would fail to catch a regression
+ * that removes the code path while leaving the JSDoc in place.
+ */
+const WINDOWS_CLAUDE_SELECTOR =
+	/process\.platform\s*===\s*['"]win32['"]\s*\?\s*['"]claude\.cmd['"]\s*:\s*['"]claude['"]/;
+
+/**
+ * Verifies the onboarding-level readiness check (`claude-cli-check.ts`)
+ * carries the `process.platform === 'win32' ? 'claude.cmd' : 'claude'`
+ * selector used by `execFileSync`. Guards the wizard path from Issue
+ * #4424 where Windows users never saw the "Use Claude Code CLI" option.
+ */
 test("claude-cli-check.ts selects claude.cmd on win32", () => {
 	const source = readFileSync(
 		join(import.meta.dirname, "..", "claude-cli-check.ts"),
@@ -26,16 +42,16 @@ test("claude-cli-check.ts selects claude.cmd on win32", () => {
 
 	assert.match(
 		source,
-		/win32/,
-		"claude-cli-check.ts must branch on process.platform === 'win32'",
-	);
-	assert.match(
-		source,
-		/claude\.cmd/,
-		"claude-cli-check.ts must reference 'claude.cmd' for Windows shim detection",
+		WINDOWS_CLAUDE_SELECTOR,
+		"claude-cli-check.ts must implement process.platform === 'win32' ? 'claude.cmd' : 'claude'",
 	);
 });
 
+/**
+ * Verifies the cached extension-level readiness check (`readiness.ts`)
+ * carries the same Windows shim selector, so provider gating succeeds
+ * on Windows installs where `claude` is an npm-shipped `.cmd` shim.
+ */
 test("readiness.ts selects claude.cmd on win32", () => {
 	const source = readFileSync(
 		join(
@@ -51,12 +67,7 @@ test("readiness.ts selects claude.cmd on win32", () => {
 
 	assert.match(
 		source,
-		/win32/,
-		"readiness.ts must branch on process.platform === 'win32'",
-	);
-	assert.match(
-		source,
-		/claude\.cmd/,
-		"readiness.ts must reference 'claude.cmd' for Windows shim detection",
+		WINDOWS_CLAUDE_SELECTOR,
+		"readiness.ts must implement process.platform === 'win32' ? 'claude.cmd' : 'claude'",
 	);
 });

--- a/src/tests/claude-cli-windows-detection.test.ts
+++ b/src/tests/claude-cli-windows-detection.test.ts
@@ -1,0 +1,62 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Source-level regression test for Issue #4424: the Claude Code CLI
+ * binary check must use the `.cmd` shim on Windows. Node's
+ * `execFileSync('claude', ...)` does not resolve `.cmd`/`.bat` endings
+ * automatically on win32, so npm-global installs fail to be detected and
+ * the "Use Claude Code CLI" onboarding option silently disappears.
+ *
+ * Both the lightweight onboarding check (`src/claude-cli-check.ts`) and
+ * the cached readiness check
+ * (`src/resources/extensions/claude-code-cli/readiness.ts`) must carry
+ * the `process.platform === 'win32'` ? 'claude.cmd' : 'claude'` guard —
+ * analogous to the existing `NPM_COMMAND` pattern in
+ * `src/resources/extensions/gsd/pre-execution-checks.ts`.
+ */
+
+test("claude-cli-check.ts selects claude.cmd on win32", () => {
+	const source = readFileSync(
+		join(import.meta.dirname, "..", "claude-cli-check.ts"),
+		"utf-8",
+	);
+
+	assert.match(
+		source,
+		/win32/,
+		"claude-cli-check.ts must branch on process.platform === 'win32'",
+	);
+	assert.match(
+		source,
+		/claude\.cmd/,
+		"claude-cli-check.ts must reference 'claude.cmd' for Windows shim detection",
+	);
+});
+
+test("readiness.ts selects claude.cmd on win32", () => {
+	const source = readFileSync(
+		join(
+			import.meta.dirname,
+			"..",
+			"resources",
+			"extensions",
+			"claude-code-cli",
+			"readiness.ts",
+		),
+		"utf-8",
+	);
+
+	assert.match(
+		source,
+		/win32/,
+		"readiness.ts must branch on process.platform === 'win32'",
+	);
+	assert.match(
+		source,
+		/claude\.cmd/,
+		"readiness.ts must reference 'claude.cmd' for Windows shim detection",
+	);
+});

--- a/src/tests/claude-cli-windows-detection.test.ts
+++ b/src/tests/claude-cli-windows-detection.test.ts
@@ -34,7 +34,7 @@ const WINDOWS_CLAUDE_SELECTOR =
  * selector used by `execFileSync`. Guards the wizard path from Issue
  * #4424 where Windows users never saw the "Use Claude Code CLI" option.
  */
-test("claude-cli-check.ts selects claude.cmd on win32", () => {
+function verifyCliCheckSelector(): void {
 	const source = readFileSync(
 		join(import.meta.dirname, "..", "claude-cli-check.ts"),
 		"utf-8",
@@ -45,14 +45,14 @@ test("claude-cli-check.ts selects claude.cmd on win32", () => {
 		WINDOWS_CLAUDE_SELECTOR,
 		"claude-cli-check.ts must implement process.platform === 'win32' ? 'claude.cmd' : 'claude'",
 	);
-});
+}
 
 /**
  * Verifies the cached extension-level readiness check (`readiness.ts`)
  * carries the same Windows shim selector, so provider gating succeeds
  * on Windows installs where `claude` is an npm-shipped `.cmd` shim.
  */
-test("readiness.ts selects claude.cmd on win32", () => {
+function verifyReadinessSelector(): void {
 	const source = readFileSync(
 		join(
 			import.meta.dirname,
@@ -70,4 +70,7 @@ test("readiness.ts selects claude.cmd on win32", () => {
 		WINDOWS_CLAUDE_SELECTOR,
 		"readiness.ts must implement process.platform === 'win32' ? 'claude.cmd' : 'claude'",
 	);
-});
+}
+
+test("claude-cli-check.ts selects claude.cmd on win32", verifyCliCheckSelector);
+test("readiness.ts selects claude.cmd on win32", verifyReadinessSelector);


### PR DESCRIPTION
## TL;DR

**What:** Fix Claude Code CLI detection on Windows by using `claude.cmd` instead of bare `claude` in both readiness checks.
**Why:** Node's `execFileSync` does not auto-resolve `.cmd`/`.bat` extensions on Windows, so a correctly installed & authenticated CLI was reported as missing — hiding the "Use Claude Code CLI" wizard option and blocking the only TOS-compliant Anthropic-subscription path.
**How:** Introduce a `CLAUDE_COMMAND` constant that branches on `process.platform === 'win32'`, mirroring the existing `NPM_COMMAND` pattern in `pre-execution-checks.ts`. Add a source-level regression test guarding both call sites.

## What

Two files perform the same check:

- `src/claude-cli-check.ts` — lightweight check consumed by the onboarding wizard (`src/onboarding.ts:345`)
- `src/resources/extensions/claude-code-cli/readiness.ts` — cached readiness check consumed by provider gating

Both previously called `execFileSync('claude', ['--version'], ...)` and `execFileSync('claude', ['auth', 'status'], ...)` directly. On Windows, where npm installs global binaries as `.cmd` shim wrappers, this failed with `ENOENT` even when `claude --version` worked in the user's shell. `isClaudeCliReady()` therefore returned `false`, the "Use Claude Code CLI" option never appeared in the onboarding wizard, and `~/.gsd/agent/auth.json` stayed empty.

This PR adds a platform-branching constant in each file and routes every `execFileSync` call through it. A new source-level test in `src/tests/claude-cli-windows-detection.test.ts` asserts the pattern is present in both files so the bug cannot silently regress.

## Why

Reported by @kubacvanci in #4277 after following the full recovery guide from that thread. The user confirmed `claude --version` and `claude auth status` both worked on Windows, yet GSD's onboarding still offered only Browser / API key / Skip.

Since #3953 removed the Anthropic OAuth flow for TOS compliance, the Claude Code CLI subprocess path is the only sanctioned way to use a Claude Pro/Max subscription from GSD. On Windows, that path was broken for every user whose CLI lived behind a `.cmd` shim (i.e. the default npm-global install).

The same `NPM_COMMAND` pattern already exists in the codebase (`src/resources/extensions/gsd/pre-execution-checks.ts:23`) and the `stream-adapter.ts` already uses a Windows-aware `where claude` lookup — the two readiness checks were the last call sites that hadn't been adapted.

Closes #4424
Related: #4277, #3772, #3953

## How

Added a single constant to each file:

```ts
const CLAUDE_COMMAND = process.platform === 'win32' ? 'claude.cmd' : 'claude'
```

All `execFileSync('claude', ...)` calls in both files now use `CLAUDE_COMMAND`. The constant is exported from `claude-cli-check.ts` (the file already exports its functions) and module-local in `readiness.ts` (which is internal to the extension). JSDoc on each constant documents the Windows rationale and points at the `NPM_COMMAND` precedent.

The regression test is intentionally static — it uses `readFileSync` + `assert.match` to verify both files reference `win32` and `claude.cmd`, matching the existing pattern in `src/tests/windows-portability.test.ts:56-78` (which also relies on static checks for cross-platform guarantees that can't be meaningfully exercised on the CI host).

### Verification

- `npx tsc --noEmit` — clean
- `node --test src/tests/claude-cli-windows-detection.test.ts` — 2/2 pass
- Pre-fix (`upstream/main` version): neither file contained `win32` or `claude.cmd`, so the test would have failed (RED → GREEN confirmed)
- Docstring coverage on changed files: 7/7 exported symbols documented (100%)

### Alternatives considered

A dynamic approach (resolving the real binary path via `where claude` / `which claude` first, then invoking it) is more robust against non-npm installs (`claude.exe`, Scoop, manual). But it adds a second subprocess call per readiness check and the existing `NPM_COMMAND` approach has already proven sufficient in the same codebase. Keeping symmetry with `NPM_COMMAND` makes this a minimal, reviewable fix; a dynamic lookup can follow if non-npm Windows installs turn out to be common.

## Change type

- [x] `fix` — Bug fix
- [ ] `feat` — New feature or capability
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Breaking changes

None. Behavior on non-Windows platforms is identical (`CLAUDE_COMMAND === 'claude'`).

## AI-assisted disclosure

This PR was AI-assisted by Claude Opus 4.7. I reviewed and verified the diff, regression test, and build/test results before opening.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved cross-platform CLI handling so the app detects and uses the correct executable name on Windows and other OSes.

* **Tests**
  * Added regression tests to verify the Windows-specific CLI command selection and detection works reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
