### PR TITLE
fix(gsd): flip uok.gitops.turn_action default to "commit" (#4419)

### DIFF
--- a/src/resources/extensions/gsd/docs/preferences-reference.md
+++ b/src/resources/extensions/gsd/docs/preferences-reference.md
@@ -201,7 +201,7 @@ Setting `prefer_skills: []` does **not** disable skill discovery — it just mea
   - `model_policy.enabled`: boolean — enforce policy filtering before model capability scoring. Default: `true`.
   - `execution_graph.enabled`: boolean — enable DAG scheduler facade/adapters for execution. Default: `true`.
   - `gitops.enabled`: boolean — persist turn-level git transaction records. Default: `true`.
-  - `gitops.turn_action`: `"commit"` | `"snapshot"` | `"status-only"` — turn transaction mode. Default: `"status-only"`.
+  - `gitops.turn_action`: `"commit"` | `"snapshot"` | `"status-only"` — turn transaction mode. Default: `"commit"` (per-task atomic commits).
   - `gitops.turn_push`: boolean — whether turn transactions should include push intent metadata. Default: `false`.
   - `audit_unified.enabled`: boolean — dual-write unified audit envelope events. Default: `true`.
   - `plan_v2.enabled`: boolean — enable bounded clarify/research/draft/compile planning flow. Default: `true`.

--- a/src/resources/extensions/gsd/templates/PREFERENCES.md
+++ b/src/resources/extensions/gsd/templates/PREFERENCES.md
@@ -51,7 +51,7 @@ uok:
     enabled: true
   gitops:
     enabled: true
-    turn_action: status-only
+    turn_action: commit
     turn_push: false
   audit_unified:
     enabled: true

--- a/src/resources/extensions/gsd/tests/uok-flags.test.ts
+++ b/src/resources/extensions/gsd/tests/uok-flags.test.ts
@@ -13,7 +13,7 @@ test("uok flags default to enabled when preference is unset", () => {
   assert.equal(flags.gitops, true);
   assert.equal(flags.auditUnified, true);
   assert.equal(flags.planV2, true);
-  assert.equal(flags.gitopsTurnAction, "status-only");
+  assert.equal(flags.gitopsTurnAction, "commit");
   assert.equal(flags.gitopsTurnPush, false);
 });
 

--- a/src/resources/extensions/gsd/uok/flags.ts
+++ b/src/resources/extensions/gsd/uok/flags.ts
@@ -32,7 +32,7 @@ export function resolveUokFlags(prefs: GSDPreferences | undefined): UokFlags {
     modelPolicy: uok?.model_policy?.enabled ?? true,
     executionGraph: uok?.execution_graph?.enabled ?? true,
     gitops: uok?.gitops?.enabled ?? true,
-    gitopsTurnAction: uok?.gitops?.turn_action ?? "status-only",
+    gitopsTurnAction: uok?.gitops?.turn_action ?? "commit",
     gitopsTurnPush: uok?.gitops?.turn_push === true,
     auditUnified: uok?.audit_unified?.enabled ?? true,
     planV2: uok?.plan_v2?.enabled ?? true,


### PR DESCRIPTION
## Summary

Flips the default value of `uok.gitops.turn_action` from `"status-only"` to `"commit"`, restoring the per-task atomic commit guarantee that GSD advertises in its skill description.

## Why

New projects with no `uok` block in PREFERENCES.md silently got zero per-task commits. All code changes accumulated as dirty state until a safety-net mechanism (doctor-proactive snapshot or milestone-merge sweeper) bulk-committed everything. GSD documented "atomic commits" as a built-in guarantee but the default broke that contract.

PR #4351 (ADR-009 Wave 8) would have fixed this as part of a larger defaults flip but was closed without merging. #4419 is a fresh report of the same root cause.

## Changes

- `src/resources/extensions/gsd/uok/flags.ts:35` — default `"status-only"` → `"commit"`
- `src/resources/extensions/gsd/tests/uok-flags.test.ts:16` — assertion updated
- `src/resources/extensions/gsd/docs/preferences-reference.md:204` — documented default updated
- `src/resources/extensions/gsd/templates/PREFERENCES.md:54` — template updated

Users who want the previous behavior can still opt in explicitly via `uok.gitops.turn_action: status-only`.

## Test plan

- [x] `uok-flags.test.ts` — default now asserts `"commit"`
- [x] `uok-preferences.test.ts` — explicit `"status-only"` override still validated
- [x] `uok-gitops-turn-action.test.ts` — all three modes (commit/snapshot/status-only) still behave correctly
- [x] `uok-gitops-wiring.test.ts` — post-unit pre-verification wiring intact

12/12 targeted tests pass locally.

Closes #4419

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated GitOps turn action configuration default and clarified semantics for per-task atomic commits.

* **Tests**
  * Updated test expectations to align with new default configuration behavior.

* **Chores**
  * Updated configuration template to reflect new default settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->