### PR TITLE
fix(gsd): pre-exec checks false-positive on URL and prose-annotated inputs (#4421)

### DIFF
--- a/src/resources/extensions/gsd/pre-execution-checks.ts
+++ b/src/resources/extensions/gsd/pre-execution-checks.ts
@@ -262,6 +262,18 @@ export function normalizeFilePath(filePath: string): string {
   return normalized;
 }
 
+const URL_SCHEME_PATTERN = /^(https?|ftp|file|ssh|git):\/\//i;
+const SCP_PATTERN = /^[\w.-]+@[\w.-]+:[^/]/;
+
+function looksLikePathOrUrl(token: string): boolean {
+  if (URL_SCHEME_PATTERN.test(token)) return true;
+  if (SCP_PATTERN.test(token)) return true;
+  if (/^[./~]/.test(token)) return true;
+  if (/[\\/]/.test(token)) return true;
+  if (/\.[A-Za-z0-9]{1,8}$/.test(token)) return true;
+  return false;
+}
+
 function extractPathFromAnnotation(raw: string): string {
   const trimmed = raw.trim();
   if (!trimmed) return trimmed;
@@ -274,6 +286,20 @@ function extractPathFromAnnotation(raw: string): string {
   const annotatedMatch = trimmed.match(/^(.+?)\s+[—–-]\s+.+$/);
   if (annotatedMatch) {
     return annotatedMatch[1].trim();
+  }
+
+  // Fallback: scan all backticked tokens and return the first one that looks
+  // like a path or URL. Handles prose-annotated bullets such as:
+  //   `path/` directory listing (...)
+  //   Prefix prose `https://...` suffix prose
+  //   Citing `.gsd/REQUIREMENTS.md` mid-sentence
+  // Skips non-path backticked tokens like `note` or `npm test`.
+  const backtickTokens = trimmed.matchAll(/`([^`]+)`/g);
+  for (const match of backtickTokens) {
+    const token = match[1].trim();
+    if (looksLikePathOrUrl(token)) {
+      return token;
+    }
   }
 
   // Fall back to the original behavior for already-plain paths.
@@ -291,12 +317,16 @@ function shouldValidateInputAsPath(raw: string): boolean {
   const trimmed = raw.trim();
   if (!trimmed) return false;
 
+  const candidate = extractPathFromAnnotation(trimmed);
+  if (!candidate) return false;
+
+  // URLs and remote repo refs are not filesystem paths.
+  if (URL_SCHEME_PATTERN.test(candidate)) return false;
+  if (SCP_PATTERN.test(candidate)) return false;
+
   if (/^`+[^`]+`+/.test(trimmed)) {
     return true;
   }
-
-  const candidate = extractPathFromAnnotation(trimmed);
-  if (!candidate) return false;
 
   if (!/\s/.test(candidate)) {
     return true;

--- a/src/resources/extensions/gsd/tests/pre-execution-checks.test.ts
+++ b/src/resources/extensions/gsd/tests/pre-execution-checks.test.ts
@@ -1287,6 +1287,111 @@ describe("checkFilePathConsistency additional edge cases", () => {
       rmSync(tempDir, { recursive: true, force: true });
     }
   });
+
+  // Regression tests for issue #4421
+  test("backticked path with trailing prose and parens resolves to the path", () => {
+    const tempDir = join(tmpdir(), `pre-exec-test-4421-case1-${Date.now()}`);
+    const dirPath = join(tempDir, "assets");
+    mkdirSync(dirPath, { recursive: true });
+
+    try {
+      const tasks = [
+        createTask({
+          id: "T01",
+          inputs: [`\`${dirPath}/\` directory listing (shows the items that will match during the run)`],
+        }),
+      ];
+
+      const results = checkFilePathConsistency(tasks, tempDir);
+      assert.equal(results.length, 0, "Backticked dir path annotated with prose + parens should be recognized");
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  test("backticked URL with paren annotation is skipped (not a filesystem path)", () => {
+    const tasks = [
+      createTask({
+        id: "T01",
+        inputs: ["`https://example.com` (live HTTP target)"],
+      }),
+    ];
+
+    const results = checkFilePathConsistency(tasks, "/tmp");
+    assert.equal(results.length, 0, "Backticked URL should not be validated as a filesystem path");
+  });
+
+  test("URL embedded mid-sentence with prefix prose is skipped", () => {
+    const tasks = [
+      createTask({
+        id: "T01",
+        inputs: ["Live `https://example.com/docs` pages (reviewer WebFetches these)"],
+      }),
+    ];
+
+    const results = checkFilePathConsistency(tasks, "/tmp");
+    assert.equal(results.length, 0, "URLs cited mid-sentence should not be validated as filesystem paths");
+  });
+
+  test("backticked path cited mid-sentence resolves to the path", () => {
+    const tempDir = join(tmpdir(), `pre-exec-test-4421-case4-${Date.now()}`);
+    mkdirSync(join(tempDir, ".gsd"), { recursive: true });
+    writeFileSync(join(tempDir, ".gsd/REQUIREMENTS.md"), "# Requirements");
+
+    try {
+      const tasks = [
+        createTask({
+          id: "T01",
+          inputs: ["R014 verbatim text from `.gsd/REQUIREMENTS.md` (the owned requirement statement)"],
+        }),
+      ];
+
+      const results = checkFilePathConsistency(tasks, tempDir);
+      assert.equal(results.length, 0, "Backticked path cited mid-sentence should be recognized");
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  test("multi-backtick input picks the path-like token over non-path tokens", () => {
+    const tempDir = join(tmpdir(), `pre-exec-test-4421-multi-${Date.now()}`);
+    mkdirSync(join(tempDir, "src"), { recursive: true });
+    writeFileSync(join(tempDir, "src/a.ts"), "// content");
+
+    try {
+      const tasks = [
+        createTask({
+          id: "T01",
+          inputs: ["`note` use `src/a.ts` for edits"],
+        }),
+      ];
+
+      const results = checkFilePathConsistency(tasks, tempDir);
+      assert.equal(results.length, 0, "Should extract src/a.ts, not the leading `note` token");
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  test("multi-backtick input with command-like leading token picks the path", () => {
+    const tempDir = join(tmpdir(), `pre-exec-test-4421-cmd-${Date.now()}`);
+    mkdirSync(join(tempDir, "src"), { recursive: true });
+    writeFileSync(join(tempDir, "src/a.ts"), "// content");
+
+    try {
+      const tasks = [
+        createTask({
+          id: "T01",
+          inputs: ["Run `npm test` against `src/a.ts`"],
+        }),
+      ];
+
+      const results = checkFilePathConsistency(tasks, tempDir);
+      assert.equal(results.length, 0, "Should extract src/a.ts, not the `npm test` command token");
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
 });
 
 // ─── PreExecutionResult Type Tests ───────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes #4421. Pre-execution file-path checker was blocking `/gsd auto` on legitimate inputs — URLs, directory paths with prose annotations, and backticked paths cited mid-sentence — because `extractPathFromAnnotation` only recognized two anchored shapes and `shouldValidateInputAsPath` had no URL exclusion.

- Adds `looksLikePathOrUrl` heuristic; iterates backticked tokens to pick the first path-like one (skips `` `note` `` or `` `npm test` `` style tokens).
- Reorders `shouldValidateInputAsPath` so URL/SCP guards run after extraction and before the leading-backtick shortcut. Covers `http(s)`, `ftp`, `file`, `ssh`, `git` schemes and `git@host:org/repo` SCP syntax.
- 6 regression tests: 4 issue cases + 2 multi-backtick disambiguation cases from peer review.

Plan was peer-reviewed via Codex, which flagged the issue's original naive first-backtick fallback as too broad (would extract `note` from `` `note` use `src/a.ts` ``). Adopted the path-likeness heuristic instead.

## Test plan

- [x] `npx tsx --test src/resources/extensions/gsd/tests/pre-execution-checks.test.ts` — 68/68 pass
- [x] 4 issue false-positives now pass; genuinely missing files still fail
- [x] Multi-backtick inputs disambiguate correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file path validation to more accurately distinguish between filesystem paths and URLs in mixed prose contexts.
  * Enhanced path detection in backticked annotations with better heuristics for URL and remote reference identification.

* **Tests**
  * Added regression test cases for edge cases involving file paths and URLs in annotations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->