### PR TITLE
fix(gsd): self-heal symlinked .gsd staging to prevent silent data loss (#4423)

### DIFF
--- a/src/resources/extensions/gsd/doctor-runtime-checks.ts
+++ b/src/resources/extensions/gsd/doctor-runtime-checks.ts
@@ -8,7 +8,7 @@ import { deriveState } from "./state.js";
 import { saveFile } from "./files.js";
 import { nativeIsRepo, nativeForEachRef, nativeUpdateRef } from "./native-git-bridge.js";
 import { readCrashLock, isLockProcessAlive, clearLock } from "./crash-recovery.js";
-import { ensureGitignore } from "./gitignore.js";
+import { ensureGitignore, isGsdGitignored } from "./gitignore.js";
 import { readAllSessionStatuses, isSessionStale, removeSessionStatus } from "./session-status-io.js";
 import { recoverFailedMigration } from "./migrate-external.js";
 import { splitCompletedKey } from "./forensics.js";
@@ -380,6 +380,27 @@ export async function checkRuntimeHealth(
             file: ".gsd",
             fixable: false,
           });
+        }
+
+        // ── Symlinked .gsd without .gitignore entry (#4423) ──
+        // When `.gsd` is a symlink AND not gitignored, `git add -A -- :!.gsd/...`
+        // pathspecs fail with "beyond a symbolic link". Without self-heal this
+        // silently drops new user files during auto-commit.
+        if (nativeIsRepo(basePath) && !isGsdGitignored(basePath)) {
+          issues.push({
+            severity: "warning",
+            code: "symlinked_gsd_unignored",
+            scope: "project",
+            unitId: "project",
+            message: ".gsd is a symlink to external state but is not listed in .gitignore. This causes git pathspec exclusions to fail and can lead to silently dropped new files during auto-commit. Add `.gsd` to .gitignore.",
+            file: ".gitignore",
+            fixable: true,
+          });
+
+          if (shouldFix("symlinked_gsd_unignored")) {
+            const modified = ensureGitignore(basePath);
+            if (modified) fixesApplied.push("added .gsd to .gitignore (symlinked external state)");
+          }
         }
       }
     }

--- a/src/resources/extensions/gsd/doctor-types.ts
+++ b/src/resources/extensions/gsd/doctor-types.ts
@@ -23,6 +23,7 @@ export type DoctorIssueCode =
   | "state_file_stale"
   | "state_file_missing"
   | "gitignore_missing_patterns"
+  | "symlinked_gsd_unignored"
   | "unresolvable_dependency"
   | "failed_migration"
   | "broken_symlink"

--- a/src/resources/extensions/gsd/native-git-bridge.ts
+++ b/src/resources/extensions/gsd/native-git-bridge.ts
@@ -6,7 +6,7 @@
 // execSync calls because git2 credential handling is too complex.
 
 import { execSync, execFileSync } from "node:child_process";
-import { existsSync, readFileSync, unlinkSync, rmSync } from "node:fs";
+import { existsSync, readFileSync, unlinkSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { GSDError, GSD_GIT_ERROR } from "./errors.js";
 import { GIT_NO_PROMPT_ENV } from "./git-constants.js";
@@ -707,6 +707,118 @@ function isDotGsdIgnored(basePath: string): boolean {
 }
 
 /**
+ * Determine whether the project opts out of GSD-managed `.gitignore` via
+ * `git.manage_gitignore: false` in `.gsd/PREFERENCES.md`. Uses a minimal
+ * inline parser to avoid importing the full preferences module (which would
+ * introduce a circular dependency back into this low-level bridge).
+ *
+ * Returns true when management is disabled. Any parse failure or missing
+ * file returns false (default: GSD may manage `.gitignore`).
+ */
+function isGitignoreManagementDisabled(basePath: string): boolean {
+  const prefsPath = join(basePath, ".gsd", "PREFERENCES.md");
+  if (!existsSync(prefsPath)) return false;
+  try {
+    const content = readFileSync(prefsPath, "utf-8");
+    // Look for `manage_gitignore: false` under a `git:` block. The preference
+    // is indented; a loose regex is sufficient since we only care about the
+    // explicit opt-out case.
+    return /^\s*manage_gitignore\s*:\s*false\s*$/m.test(content);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Self-heal path for the symlinked-`.gsd` staging failure: append `.gsd` to
+ * `.gitignore` so subsequent `git add -A` calls succeed without the symlink
+ * pathspec error. Honors the `git.manage_gitignore: false` opt-out.
+ *
+ * Returns true when `.gitignore` now contains an entry covering `.gsd`
+ * (either pre-existing or newly appended). Returns false when the opt-out
+ * is set or the write fails.
+ */
+function trySelfHealGsdGitignore(basePath: string): boolean {
+  if (isGitignoreManagementDisabled(basePath)) return false;
+
+  const gitignorePath = join(basePath, ".gitignore");
+  try {
+    const existing = existsSync(gitignorePath) ? readFileSync(gitignorePath, "utf-8") : "";
+    const lines = new Set(
+      existing.split("\n").map(l => l.trim()).filter(l => l && !l.startsWith("#")),
+    );
+    if (lines.has(".gsd") || lines.has(".gsd/")) return true;
+
+    const prefix = existing.length > 0 && !existing.endsWith("\n") ? "\n" : "";
+    const block = `${prefix}\n# ── GSD self-heal: .gsd is a symlink to external state ──\n.gsd\n`;
+    writeFileSync(gitignorePath, existing + block, "utf-8");
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Stage untracked files individually while skipping anything under `.gsd`.
+ * Used as a last-resort when `.gsd` is a symlink, not gitignored, and
+ * `git.manage_gitignore: false` forbids the self-heal path. Protects user
+ * work by never silently dropping new real files.
+ */
+function stageUntrackedExcludingDotGsd(basePath: string): void {
+  // Stage tracked modifications first. `git add -u` never fails on pathspec
+  // issues because it doesn't walk untracked trees.
+  gitFileExec(basePath, ["add", "-u"]);
+
+  // Enumerate untracked paths via porcelain output. `?? ` prefix marks
+  // untracked files (status respects `.gitignore`).
+  const status = gitFileExec(basePath, ["status", "--porcelain=v1", "-z"], true);
+  if (!status) return;
+
+  const untracked: string[] = [];
+  for (const entry of status.split("\0")) {
+    if (!entry) continue;
+    // Porcelain format: "XY path" where XY is the 2-char status code.
+    if (entry.length < 4) continue;
+    const code = entry.slice(0, 2);
+    const path = entry.slice(3);
+    if (code !== "??") continue;
+    // Skip GSD runtime artifacts. Under `manage_gitignore: false` the user
+    // may not have these in `.gitignore`, so we filter explicitly to avoid
+    // committing transient state (.gsd external link, migration lock,
+    // background shell scratch dir).
+    if (path === ".gsd" || path.startsWith(".gsd/")) continue;
+    if (path === ".gsd-id" || path === ".gsd.migrating") continue;
+    if (path === ".bg-shell" || path.startsWith(".bg-shell/")) continue;
+    untracked.push(path);
+  }
+
+  if (untracked.length === 0) return;
+  // Stage in chunks to avoid exceeding ARG_MAX on large change sets.
+  const CHUNK = 200;
+  for (let i = 0; i < untracked.length; i += CHUNK) {
+    gitFileExec(basePath, ["add", "--", ...untracked.slice(i, i + CHUNK)]);
+  }
+}
+
+/**
+ * Handle `nativeAddAllWithExclusions` failing with "beyond a symbolic link"
+ * when `.gsd` is a symlink. Self-heals by adding `.gsd` to `.gitignore`, or
+ * falls back to explicit per-file staging so user work is never dropped.
+ */
+function fallbackStageWithSymlinkedDotGsd(basePath: string): void {
+  if (isDotGsdIgnored(basePath)) {
+    gitFileExec(basePath, ["add", "-A"]);
+    return;
+  }
+  if (trySelfHealGsdGitignore(basePath)) {
+    gitFileExec(basePath, ["add", "-A"]);
+    return;
+  }
+  // `manage_gitignore: false` — protect work by staging files explicitly.
+  stageUntrackedExcludingDotGsd(basePath);
+}
+
+/**
  * Stage all files with pathspec exclusions (git add -A -- ':!pattern' ...).
  * Excluded paths are never hashed by git, preventing hangs on large
  * untracked artifact trees (57GB+, 11K+ files). See #1605.
@@ -740,12 +852,12 @@ export function nativeAddAllWithExclusions(basePath: string, exclusions: readonl
       return;
     }
     // When .gsd is a symlink, git rejects `:!.gsd/...` pathspecs with
-    // "beyond a symbolic link". If `.gsd` is already covered by .gitignore
-    // (the default external-state layout), a plain `git add -A` safely stages
-    // new files while still leaving `.gsd` excluded. Otherwise keep the
-    // tracked-only fallback to avoid staging unexpected external-state files.
+    // "beyond a symbolic link". Hand off to the self-heal fallback which
+    // either adds `.gsd` to `.gitignore` and retries `git add -A`, or stages
+    // real files explicitly when `git.manage_gitignore: false` forbids the
+    // self-heal path. Either way, user work is protected from silent drops.
     if (stderr.includes("beyond a symbolic link")) {
-      gitFileExec(basePath, isDotGsdIgnored(basePath) ? ["add", "-A"] : ["add", "-u"]);
+      fallbackStageWithSymlinkedDotGsd(basePath);
       return;
     }
     throw new GSDError(GSD_GIT_ERROR, `git add -A with exclusions failed in ${basePath}: ${getErrorMessage(err)}`);

--- a/src/resources/extensions/gsd/tests/integration/doctor-runtime.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/doctor-runtime.test.ts
@@ -9,7 +9,7 @@ import assert from 'node:assert/strict';
  *   state_file_stale, gitignore_missing_patterns
  */
 
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync, readFileSync, realpathSync } from "node:fs";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync, readFileSync, realpathSync, symlinkSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { execSync } from "node:child_process";
@@ -248,6 +248,37 @@ node_modules/
       const detect = await runGSDDoctor(dir);
       const gitignoreIssues = detect.issues.filter(i => i.code === "gitignore_missing_patterns");
       assert.deepStrictEqual(gitignoreIssues.length, 0, "no missing patterns when blanket .gsd/ present");
+    });
+    } else {
+    }
+
+    // ─── Test 8b: Symlinked .gsd without .gitignore entry (#4423) ─────
+    if (process.platform !== "win32") {
+    test('symlinked_gsd_unignored', async () => {
+      const dir = createGitProject();
+      cleanups.push(dir);
+
+      // Create .gsd as a symlink to an external directory (standard external
+      // state layout), and write a .gitignore that does NOT list .gsd.
+      const externalGsd = mkdtempSync(join(tmpdir(), "gsd-external-doctor-"));
+      cleanups.push(externalGsd);
+      writeFileSync(join(externalGsd, "STATE.md"), "# State\n");
+      symlinkSync(externalGsd, join(dir, ".gsd"));
+
+      writeFileSync(join(dir, ".gitignore"), "node_modules/\n");
+
+      const detect = await runGSDDoctor(dir);
+      const symlinkIssues = detect.issues.filter(i => i.code === "symlinked_gsd_unignored");
+      assert.ok(symlinkIssues.length > 0, "detects symlinked .gsd without gitignore entry");
+
+      const fixed = await runGSDDoctor(dir, { fix: true });
+      assert.ok(
+        fixed.fixesApplied.some(f => f.includes(".gitignore")),
+        "fix updates .gitignore",
+      );
+
+      const content = readFileSync(join(dir, ".gitignore"), "utf-8");
+      assert.ok(/^\.gsd\/?$/m.test(content), "gitignore now has .gsd entry");
     });
     } else {
     }

--- a/src/resources/extensions/gsd/tests/integration/git-service.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/git-service.test.ts
@@ -1,6 +1,6 @@
 import { describe, test } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync, symlinkSync } from "node:fs";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync, symlinkSync, readFileSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { tmpdir } from "node:os";
 import { execSync } from "node:child_process";
@@ -1295,7 +1295,10 @@ describe('git-service', async () => {
     rmSync(externalGsd, { recursive: true, force: true });
   });
 
-  test('nativeAddAllWithExclusions: symlinked .gsd stays tracked-only when .gsd is not gitignored', () => {
+  test('nativeAddAllWithExclusions: self-heals symlinked .gsd when .gitignore lacks it (#4423)', () => {
+    // When `.gsd` is a symlink AND not listed in `.gitignore`, the staging
+    // fallback must self-heal by appending `.gsd` to `.gitignore` and retrying
+    // `git add -A`. Without this, new user files are silently dropped.
     const repo = initTempRepo();
 
     const externalGsd = mkdtempSync(join(tmpdir(), "gsd-external-unignored-"));
@@ -1321,9 +1324,73 @@ describe('git-service', async () => {
     assert.ok(!threw, "nativeAddAllWithExclusions does not throw with symlinked .gsd when .gsd is not gitignored");
 
     const staged = run("git diff --cached --name-only", repo);
-    assert.ok(staged.includes("src/app.ts"), "tracked modifications still stage in the defensive fallback");
-    assert.ok(!staged.includes("src/new-feature.ts"),
-      "untracked files stay unstaged when the symlink target itself is not protected by .gitignore");
+    assert.ok(staged.includes("src/app.ts"), "tracked modifications stage");
+    assert.ok(
+      staged.includes("src/new-feature.ts"),
+      "self-heal adds .gsd to .gitignore so new user files are staged",
+    );
+    assert.ok(!staged.includes(".gsd"), ".gsd contents stay unstaged after self-heal");
+
+    // Verify the self-heal actually wrote to .gitignore
+    const gitignore = readFileSync(join(repo, ".gitignore"), "utf-8");
+    assert.ok(/^\.gsd\/?$/m.test(gitignore), ".gitignore contains .gsd entry after self-heal");
+
+    rmSync(repo, { recursive: true, force: true });
+    rmSync(externalGsd, { recursive: true, force: true });
+  });
+
+  test('nativeAddAllWithExclusions: explicit staging protects work when manage_gitignore:false (#4423)', () => {
+    // When `git.manage_gitignore: false` is set in PREFERENCES.md, the
+    // self-heal path is disabled. The fallback must still protect user work
+    // by explicitly staging untracked real files while skipping `.gsd`.
+    const repo = initTempRepo();
+
+    const externalGsd = mkdtempSync(join(tmpdir(), "gsd-external-optout-"));
+    mkdirSync(join(externalGsd, "activity"), { recursive: true });
+    writeFileSync(join(externalGsd, "activity", "log.jsonl"), "log data");
+    writeFileSync(join(externalGsd, "STATE.md"), "# State");
+
+    symlinkSync(externalGsd, join(repo, ".gsd"));
+
+    // Create PREFERENCES.md inside the symlink target (the linked .gsd dir)
+    // with the opt-out flag. The regex matches a top-level occurrence.
+    writeFileSync(
+      join(repo, ".gsd", "PREFERENCES.md"),
+      "---\nversion: 1\ngit:\n  manage_gitignore: false\n---\n",
+    );
+
+    createFile(repo, "src/app.ts", "export const x = 1;");
+    run("git add -A", repo);
+    run('git commit -m "add app"', repo);
+    writeFileSync(join(repo, "src/app.ts"), "export const x = 2;");
+    createFile(repo, "src/new-feature.ts", "export const fresh = true;");
+
+    let threw = false;
+    try {
+      nativeAddAllWithExclusions(repo, RUNTIME_EXCLUSION_PATHS);
+    } catch (e) {
+      threw = true;
+      console.error("  unexpected error:", e);
+    }
+    assert.ok(!threw, "nativeAddAllWithExclusions does not throw under manage_gitignore:false");
+
+    const staged = run("git diff --cached --name-only", repo);
+    assert.ok(staged.includes("src/app.ts"), "tracked modifications stage");
+    assert.ok(
+      staged.includes("src/new-feature.ts"),
+      "explicit staging protects new files even when self-heal is disabled",
+    );
+    assert.ok(!staged.includes(".gsd"), ".gsd contents stay unstaged");
+
+    // Self-heal must NOT have written to .gitignore
+    const gitignoreExists = existsSync(join(repo, ".gitignore"));
+    if (gitignoreExists) {
+      const gitignore = readFileSync(join(repo, ".gitignore"), "utf-8");
+      assert.ok(
+        !/^\.gsd\/?$/m.test(gitignore),
+        "manage_gitignore:false must prevent writes to .gitignore",
+      );
+    }
 
     rmSync(repo, { recursive: true, force: true });
     rmSync(externalGsd, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

Fixes #4423 — when `.gsd` is a symlink to external state AND not listed in `.gitignore`, GSD's auto-commit was silently dropping new user files.

- `git add -A -- :!.gsd/...` fails with `fatal: beyond a symbolic link`; the previous catch block degraded to `git add -u` (tracked-only), dropping new work
- Now self-heals by appending `.gsd` to `.gitignore` and retrying `git add -A`
- Respects `git.manage_gitignore: false` opt-out by falling back to explicit per-file staging that filters GSD runtime artifacts (`.gsd`, `.gsd-id`, `.gsd.migrating`, `.bg-shell/`)
- Surfaces the condition proactively via a new `symlinked_gsd_unignored` doctor warning with auto-fix

Peer-reviewed via codex-peer-review; filter list expanded from its feedback.

## Test plan

- [x] `git-service.test.ts` — 56/56 pass, including two new `#4423` tests
- [x] `doctor-runtime.test.ts` — 14/14 pass, including new `symlinked_gsd_unignored` test
- [x] `gitignore-tracked-gsd.test.ts` — 12/12 pass (regression)
- [x] Previous "tracked-only fallback" assertion inverted to verify self-heal stages new files
- [ ] Reviewer: verify reproduction with a symlinked `.gsd` + `.gitignore` missing `.gsd`; confirm subsequent auto-commit stages newly created files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added health check to detect symlinked `.gsd` directories not properly excluded from git tracking
  * Introduced automatic self-healing to configure `.gitignore` entries for symlinked `.gsd` setups

* **Improvements**
  * Enhanced git staging behavior when working with symlinked `.gsd` directories
  * Added preference controls to disable automatic `.gitignore` modifications if desired

<!-- end of auto-generated comment: release notes by coderabbit.ai -->