### PR TITLE
fix(gsd-db): add gsd_checkpoint_db tool to flush WAL during active session

### DIFF
--- a/src/resources/extensions/gsd/bootstrap/query-tools.ts
+++ b/src/resources/extensions/gsd/bootstrap/query-tools.ts
@@ -4,6 +4,7 @@ import { Type } from "@sinclair/typebox";
 import type { ExtensionAPI } from "@gsd/pi-coding-agent";
 import { ensureDbOpen } from "./dynamic-tools.js";
 import { executeMilestoneStatus } from "../tools/workflow-tool-executors.js";
+import { checkpointDatabase } from "../gsd-db.js";
 
 export function registerQueryTools(pi: ExtensionAPI): void {
   pi.registerTool({
@@ -29,6 +30,36 @@ export function registerQueryTools(pi: ExtensionAPI): void {
         };
       }
       return executeMilestoneStatus(params);
+    },
+  });
+
+  pi.registerTool({
+    name: "gsd_checkpoint_db",
+    label: "Checkpoint GSD Database",
+    description:
+      "Flush the SQLite WAL (Write-Ahead Log) into the base gsd.db file. " +
+      "Call this before `git add .gsd/gsd.db` to ensure the committed database " +
+      "contains current milestone/slice/task state rather than stale pre-session content. " +
+      "Safe to call at any time while GSD is running.",
+    promptSnippet: "Flush WAL into gsd.db so git add stages current state",
+    promptGuidelines: [
+      "Call gsd_checkpoint_db immediately before staging .gsd/gsd.db with git add.",
+      "Do not use sqlite3 or shell commands to checkpoint — they are blocked. Use this tool instead.",
+    ],
+    parameters: Type.Object({}),
+    async execute(_toolCallId, _params, _signal, _onUpdate, _ctx) {
+      const dbAvailable = await ensureDbOpen();
+      if (!dbAvailable) {
+        return {
+          content: [{ type: "text", text: "Error: GSD database is not available. Cannot checkpoint." }],
+          details: { operation: "checkpoint_db", error: "db_unavailable" },
+        };
+      }
+      checkpointDatabase();
+      return {
+        content: [{ type: "text", text: "WAL checkpoint complete. gsd.db is now up to date and safe to stage with git add." }],
+        details: { operation: "checkpoint_db", status: "ok" },
+      };
     },
   });
 }

--- a/src/resources/extensions/gsd/gsd-db.ts
+++ b/src/resources/extensions/gsd/gsd-db.ts
@@ -1089,6 +1089,14 @@ export function vacuumDatabase(): void {
   } catch (e) { logWarning("db", `VACUUM failed: ${(e as Error).message}`); }
 }
 
+/** Flush WAL into gsd.db so `git add .gsd/gsd.db` stages current state — safe while DB is open. */
+export function checkpointDatabase(): void {
+  if (!currentDb) return;
+  try {
+    currentDb.exec('PRAGMA wal_checkpoint(TRUNCATE)');
+  } catch (e) { logWarning("db", `WAL checkpoint failed: ${(e as Error).message}`); }
+}
+
 let _txDepth = 0;
 
 export function transaction<T>(fn: () => T): T {

--- a/src/resources/extensions/gsd/tests/gsd-db.test.ts
+++ b/src/resources/extensions/gsd/tests/gsd-db.test.ts
@@ -23,6 +23,7 @@ import {
   insertTask,
   getTask,
   getSliceTasks,
+  checkpointDatabase,
 } from '../gsd-db.ts';
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -516,6 +517,48 @@ describe('gsd-db', () => {
     assert.deepStrictEqual(sliceTasks[0]!.files, task!.files);
 
     closeDatabase();
+  });
+
+  // ─── checkpointDatabase ────────────────────────────────────────────────────
+
+  describe('checkpointDatabase', () => {
+    test('checkpointDatabase: flushes WAL into base file (TRUNCATE)', (t) => {
+      const dbPath = tempDbPath();
+      t.after(() => cleanup(dbPath));
+
+      openDatabase(dbPath);
+
+      // Write enough data to ensure WAL has content
+      transaction(() => {
+        insertDecision({
+          id: 'D001',
+          when_context: 'test',
+          scope: 'global',
+          decision: 'WAL flush test',
+          choice: 'checkpoint',
+          rationale: 'WAL checkpoint regression test — #4418',
+          revisable: 'yes',
+          made_by: 'agent',
+          superseded_by: null,
+        });
+      });
+
+      const walPath = dbPath + '-wal';
+      assert.ok(fs.existsSync(walPath), 'WAL file should exist after write');
+      const walSizeBefore = fs.statSync(walPath).size;
+      assert.ok(walSizeBefore > 0, 'WAL file should be non-empty after write');
+
+      checkpointDatabase();
+
+      const walSizeAfter = fs.existsSync(walPath) ? fs.statSync(walPath).size : 0;
+      assert.equal(walSizeAfter, 0, 'WAL file should be truncated to 0 after checkpoint');
+    });
+
+    test('checkpointDatabase: is a no-op when no database is open', () => {
+      closeDatabase();
+      // Must not throw
+      assert.doesNotThrow(() => checkpointDatabase());
+    });
   });
 
   // ─── Final Report ──────────────────────────────────────────────────────────

--- a/src/resources/extensions/gsd/tests/milestone-status-tool.test.ts
+++ b/src/resources/extensions/gsd/tests/milestone-status-tool.test.ts
@@ -79,8 +79,9 @@ function seedTask(milestoneId: string, sliceId: string, taskId: string, status: 
 test("registerQueryTools registers gsd_milestone_status tool", () => {
   const pi = makeMockPi();
   registerQueryTools(pi);
-  assert.equal(pi.tools.length, 1, "Should register exactly one tool");
-  assert.equal(pi.tools[0].name, "gsd_milestone_status");
+  const names = pi.tools.map((t: { name: string }) => t.name);
+  assert.ok(names.includes("gsd_milestone_status"), "Should register gsd_milestone_status");
+  assert.ok(names.includes("gsd_checkpoint_db"), "Should register gsd_checkpoint_db");
 });
 
 test("gsd_milestone_status has promptGuidelines mentioning prohibited alternatives", () => {

--- a/src/resources/extensions/gsd/workflow-mcp.ts
+++ b/src/resources/extensions/gsd/workflow-mcp.ts
@@ -30,6 +30,7 @@ const MCP_WORKFLOW_TOOL_SURFACE = new Set([
   "gsd_journal_query",
   "gsd_milestone_complete",
   "gsd_milestone_generate_id",
+  "gsd_checkpoint_db",
   "gsd_milestone_status",
   "gsd_milestone_validate",
   "gsd_plan_task",


### PR DESCRIPTION
## TL;DR

**What:** Adds a `gsd_checkpoint_db` MCP tool that flushes the SQLite WAL into the base `gsd.db` file on demand.
**Why:** During an active GSD session, `closeDatabase()` is never called, so the WAL grows indefinitely and `git add .gsd/gsd.db` commits stale pre-session content — all milestone/slice/task writes after session start are missing from the committed database.
**How:** Export `checkpointDatabase()` from `gsd-db.ts` (calls `PRAGMA wal_checkpoint(TRUNCATE)` via the already-open engine connection) and register it as an MCP tool agents can call before staging `gsd.db`.

## What

- **`gsd-db.ts`** — new exported `checkpointDatabase()` function; mirrors the existing `vacuumDatabase()` shape, uses the already-open `currentDb` adapter so `write-intercept.ts` is not triggered
- **`bootstrap/query-tools.ts`** — registers `gsd_checkpoint_db` MCP tool with `ensureDbOpen()` guard and `promptGuidelines` directing agents to call it before `git add .gsd/gsd.db`
- **`workflow-mcp.ts`** — adds `gsd_checkpoint_db` to `MCP_WORKFLOW_TOOL_SURFACE` so the tool is exposed through the workflow MCP server
- **`tests/gsd-db.test.ts`** — regression test: write data in a `transaction()` → assert WAL is non-empty → call `checkpointDatabase()` → assert WAL is truncated to 0 bytes; plus a no-op guard test
- **`tests/milestone-status-tool.test.ts`** — update registration assertion from 1 to 2 tools

## Why

As described in #4418: `PRAGMA journal_mode=WAL` is set at DB open (`gsd-db.ts:209`). The only checkpoint during normal operation runs inside `closeDatabase()`, which is never reached while the engine process is alive. Shell workarounds (`sqlite3`, `cp`, `python3 shutil.copy`) are all blocked by `write-intercept.ts`. The in-process PRAGMA via `currentDb.exec()` is the only unblocked path — matching the precedent already set by `closeDatabase()` (L1068) and the migration backup code (L586).

## How

`checkpointDatabase()` calls `PRAGMA wal_checkpoint(TRUNCATE)` through the single open WAL-mode connection owned by the GSD engine. This is non-destructive: it copies WAL frames into the base file and resets WAL size to zero without touching committed data. The MCP tool wraps this with the standard `ensureDbOpen()` guard and returns a plain-text confirmation.

Agents should call `gsd_checkpoint_db` immediately before `git add .gsd/gsd.db` to ensure the staged file contains current session state.

## Change type

- [x] `fix` — Bug fix

---

> AI-assisted PR (Claude Code). Reviewed and tested locally: `npx tsc --noEmit` clean, `npm test` — all pre-existing failures unchanged, new regression tests pass.

Closes #4418

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a database checkpoint tool that enables manual flushing of pending database changes to disk, improving data reliability and supporting regular database maintenance operations.

* **Tests**
  * Extended test coverage for the checkpoint functionality, validating correct operation when the database is available and ensuring safe behavior when the database is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->