### PR TITLE
fix(gsd): wire /gsd extract-learnings into the knowledge workflow (#4429)

### DIFF
--- a/docs/user-docs/commands.md
+++ b/docs/user-docs/commands.md
@@ -31,6 +31,7 @@
 | `/gsd export --html --all` | Generate retrospective reports for all milestones at once |
 | `/gsd update` | Update GSD to the latest version in-session |
 | `/gsd knowledge` | Add persistent project knowledge (rule, pattern, or lesson) |
+| `/gsd extract-learnings <MID>` | Extract structured Decisions, Lessons, Patterns, and Surprises from a completed milestone — writes `<MID>-LEARNINGS.md` audit trail, appends Patterns and Lessons to `.gsd/KNOWLEDGE.md`, and persists Decisions via the DECISIONS database. Runs automatically at milestone completion. |
 | `/gsd fast` | Toggle service tier for supported models (prioritized API routing) |
 | `/gsd rate` | Rate last unit's model tier (over/ok/under) — improves adaptive routing |
 | `/gsd changelog` | Show categorized release notes |

--- a/src/resources/extensions/gsd/auto-prompts.ts
+++ b/src/resources/extensions/gsd/auto-prompts.ts
@@ -35,6 +35,7 @@ import { formatDecisionsCompact, formatRequirementsCompact } from "./structured-
 import { readPhaseAnchor, formatAnchorForPrompt } from "./phase-anchor.js";
 import { logWarning } from "./workflow-logger.js";
 import { inlineGraphSubgraph } from "./graph-context.js";
+import { buildExtractionStepsBlock } from "./commands-extract-learnings.js";
 
 // ─── Preamble Cap ─────────────────────────────────────────────────────────────
 
@@ -1692,6 +1693,14 @@ export async function buildCompleteMilestonePrompt(
 
   const milestoneSummaryPath = join(base, `${relMilestonePath(base, mid)}/${mid}-SUMMARY.md`);
 
+  const learningsRelPath = join(relMilestonePath(base, mid), `${mid}-LEARNINGS.md`);
+  const learningsAbsPath = join(base, learningsRelPath);
+  const extractLearningsSteps = buildExtractionStepsBlock({
+    milestoneId: mid,
+    outputPath: learningsAbsPath,
+    relativeOutputPath: learningsRelPath,
+  });
+
   return loadPrompt("complete-milestone", {
     workingDirectory: base,
     milestoneId: mid,
@@ -1699,6 +1708,7 @@ export async function buildCompleteMilestonePrompt(
     roadmapPath: roadmapRel,
     inlinedContext,
     milestoneSummaryPath,
+    extractLearningsSteps,
     skillActivation: buildSkillActivationBlock({
       base,
       milestoneId: mid,

--- a/src/resources/extensions/gsd/commands-extract-learnings.ts
+++ b/src/resources/extensions/gsd/commands-extract-learnings.ts
@@ -26,24 +26,51 @@ import { projectRoot } from "./commands/context.js";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
+/**
+ * Resolved paths for the four artefact files that feed a milestone-scoped
+ * learnings extraction. Paths are absolute when the file exists; `null`
+ * otherwise. `missingRequired` lists the filenames (not full paths) of the
+ * required artefacts that could not be found.
+ */
 export interface PhaseArtifacts {
-  plan: string | null;
+  /** Absolute path to `{MID}-ROADMAP.md`, or `null` if the file is missing. */
+  roadmap: string | null;
+  /** Absolute path to `{MID}-SUMMARY.md`, or `null` if the file is missing. */
   summary: string | null;
+  /** Absolute path to `{MID}-VERIFICATION.md` (optional), or `null`. */
   verification: string | null;
+  /** Absolute path to `{MID}-UAT.md` (optional), or `null`. */
   uat: string | null;
+  /** Filenames of required artefacts that could not be resolved. */
   missingRequired: string[];
 }
 
+/**
+ * Full context required by `buildExtractLearningsPrompt` to construct the
+ * manual `/gsd extract-learnings` dispatch prompt. Covers the milestone
+ * identity, the output target, the inlined artefact contents, and any
+ * missing optional artefacts that should be surfaced to the agent.
+ */
 export interface ExtractLearningsPromptContext {
+  /** Milestone identifier, e.g. `"M001"` or `"M001-ush8s3"` (team mode). */
   milestoneId: string;
+  /** Human-readable milestone title, taken from the roadmap H1 when present. */
   milestoneName: string;
+  /** Absolute filesystem path at which the LEARNINGS.md file will be written. */
   outputPath: string;
+  /** Project-root-relative path for the same file, used in prompt prose. */
   relativeOutputPath: string;
-  planContent: string;
+  /** Inlined contents of `{MID}-ROADMAP.md` (required). */
+  roadmapContent: string;
+  /** Inlined contents of `{MID}-SUMMARY.md` (required). */
   summaryContent: string;
+  /** Inlined contents of `{MID}-VERIFICATION.md` when the file exists, else `null`. */
   verificationContent: string | null;
+  /** Inlined contents of `{MID}-UAT.md` when the file exists, else `null`. */
   uatContent: string | null;
+  /** Filenames of optional artefacts that were not available for inlining. */
   missingArtifacts: string[];
+  /** Display name of the enclosing project (from `.gsd/PROJECT.md` or dir basename). */
   projectName: string;
 }
 
@@ -65,53 +92,85 @@ export interface ExtractionStepsContext {
   relativeOutputPath: string;
 }
 
+/**
+ * Shape of the YAML frontmatter written at the top of `{MID}-LEARNINGS.md`.
+ *
+ * Produced by `buildFrontmatter` — consumed only by the human-readable audit
+ * trail, not by any downstream automated pipeline. The `counts` object and
+ * `missing_artifacts` list exist so reviewers can spot truncated extractions
+ * at a glance.
+ */
 export interface FrontmatterContext {
+  /** Milestone identifier (becomes the `phase` key). */
   milestoneId: string;
+  /** Milestone title (becomes the `phase_name` key). */
   milestoneName: string;
+  /** Project display name. */
   projectName: string;
+  /** ISO-8601 UTC timestamp of when the extraction was performed. */
   generatedAt: string;
+  /** Counts of extracted items per category. */
   counts: {
     decisions: number;
     lessons: number;
     patterns: number;
     surprises: number;
   };
+  /** Filenames of optional artefacts that were not available during extraction. */
   missingArtifacts: string[];
 }
 
 // ─── Pure functions ───────────────────────────────────────────────────────────
 
+/**
+ * Parses the argument string passed to `/gsd extract-learnings`.
+ *
+ * Returns `{ milestoneId: null }` for empty / whitespace-only input — the
+ * handler surfaces a usage hint in that case. A non-empty trimmed value is
+ * returned as-is; the handler validates that the milestone actually exists.
+ */
 export function parseExtractLearningsArgs(args: string): { milestoneId: string | null } {
   const trimmed = args.trim();
   return { milestoneId: trimmed || null };
 }
 
+/**
+ * Builds the absolute path at which the LEARNINGS.md audit trail should be
+ * written for the given milestone.
+ */
 export function buildLearningsOutputPath(milestoneDir: string, milestoneId: string): string {
   return join(milestoneDir, `${milestoneId}-LEARNINGS.md`);
 }
 
+/**
+ * Resolves the milestone-scoped artefact paths needed to perform an
+ * extraction. The milestone's ROADMAP and SUMMARY files are required; the
+ * VERIFICATION and UAT files are optional. Missing required files are
+ * reported by filename in `missingRequired` so the handler can surface a
+ * precise error without swallowing the cause.
+ */
 export function resolvePhaseArtifacts(milestoneDir: string, milestoneId: string): PhaseArtifacts {
   const missingRequired: string[] = [];
 
-  const planFile = `${milestoneId}-ROADMAP.md`;
+  const roadmapFile = `${milestoneId}-ROADMAP.md`;
   const summaryFile = `${milestoneId}-SUMMARY.md`;
   const verificationFile = `${milestoneId}-VERIFICATION.md`;
   const uatFile = `${milestoneId}-UAT.md`;
 
-  const planPath = join(milestoneDir, planFile);
+  const roadmapPath = join(milestoneDir, roadmapFile);
   const summaryPath = join(milestoneDir, summaryFile);
   const verificationPath = join(milestoneDir, verificationFile);
   const uatPath = join(milestoneDir, uatFile);
 
-  const plan = existsSync(planPath) ? planPath : null;
+  const roadmap = existsSync(roadmapPath) ? roadmapPath : null;
   const summary = existsSync(summaryPath) ? summaryPath : null;
   const verification = existsSync(verificationPath) ? verificationPath : null;
   const uat = existsSync(uatPath) ? uatPath : null;
 
-  if (!plan) missingRequired.push(planFile);
+  if (!roadmap) missingRequired.push(roadmapFile);
   if (!summary) missingRequired.push(summaryFile);
 
-  return { plan, summary, verification, uat, missingRequired };
+  return { roadmap, summary, verification, uat, missingRequired };
 }
 
 /**
@@ -310,7 +369,7 @@ database so future milestone dispatches benefit from what was learned here.
 
 ### Roadmap
 
-${ctx.planContent}
+${ctx.roadmapContent}
 
 ---
 
@@ -324,6 +383,14 @@ ${stepsBlock}
 `;
 }
 
+/**
+ * Serialises the YAML frontmatter block prepended to `{MID}-LEARNINGS.md`.
+ *
+ * The output begins and ends with a `---` fence so it can be concatenated
+ * directly with the body. Empty `missingArtifacts` is rendered as an
+ * inline empty list (`missing_artifacts: []`) to keep the frontmatter valid
+ * YAML in every case.
+ */
 export function buildFrontmatter(ctx: FrontmatterContext): string {
   const missingList = ctx.missingArtifacts.length > 0
     ? ctx.missingArtifacts.map((a) => `  - ${a}`).join("\n")
@@ -347,6 +414,14 @@ missing_artifacts:${missingValue}
 ---`;
 }
 
+/**
+ * Extracts the project display name from `.gsd/PROJECT.md` frontmatter.
+ *
+ * Falls back to the project directory's basename if PROJECT.md is missing,
+ * unreadable, or has no `name:` field. Never throws — surfacing the raw
+ * directory name is preferable to crashing an extraction over a display
+ * string.
+ */
 export function extractProjectName(basePath: string): string {
   const projectMdPath = join(gsdRoot(basePath), "PROJECT.md");
 
@@ -365,6 +440,15 @@ export function extractProjectName(basePath: string): string {
 
 // ─── Handler ──────────────────────────────────────────────────────────────────
 
+/**
+ * Handles the `/gsd extract-learnings <MID>` slash command.
+ *
+ * Resolves and reads the milestone artefacts, constructs the dispatch prompt
+ * via {@link buildExtractLearningsPrompt}, and triggers a new LLM turn via
+ * `pi.sendMessage({ triggerTurn: true })`. Returns quickly with a UI
+ * notification (not an error) when the milestone cannot be found or required
+ * artefacts are missing, matching the behaviour of sibling `/gsd` commands.
+ */
 export async function handleExtractLearnings(
   args: string,
   ctx: ExtensionCommandContext,
@@ -396,7 +480,7 @@ export async function handleExtractLearnings(
     return;
   }
 
-  const planContent = readFileSync(artifacts.plan!, "utf-8");
+  const roadmapContent = readFileSync(artifacts.roadmap!, "utf-8");
   const summaryContent = readFileSync(artifacts.summary!, "utf-8");
 
   const verificationContent = artifacts.verification
@@ -410,7 +494,7 @@ export async function handleExtractLearnings(
   if (!artifacts.verification) missingArtifacts.push(`${milestoneId}-VERIFICATION.md`);
   if (!artifacts.uat) missingArtifacts.push(`${milestoneId}-UAT.md`);
 
-  const h1Match = planContent.match(/^#\s+(.+)$/m);
+  const h1Match = roadmapContent.match(/^#\s+(.+)$/m);
   const milestoneName = h1Match?.[1]?.trim() ?? milestoneId;
 
   const projectName = extractProjectName(basePath);
@@ -422,7 +506,7 @@ export async function handleExtractLearnings(
     milestoneName,
     outputPath,
     relativeOutputPath,
-    planContent,
+    roadmapContent,
     summaryContent,
     verificationContent,
     uatContent,

--- a/src/resources/extensions/gsd/commands-extract-learnings.ts
+++ b/src/resources/extensions/gsd/commands-extract-learnings.ts
@@ -2,8 +2,18 @@
  * GSD Command — /gsd extract-learnings
  *
  * Analyses completed milestone artefacts and dispatches an LLM turn that
- * extracts structured knowledge into 4 categories:
- *   Decisions · Lessons · Patterns · Surprises
+ * extracts structured knowledge into 4 categories (Decisions · Lessons ·
+ * Patterns · Surprises), writes a LEARNINGS.md audit trail, and persists
+ * the durable subset to GSD's cross-session surfaces:
+ *
+ *   - Patterns + Lessons → appended to .gsd/KNOWLEDGE.md (inlined into
+ *     every future dispatch prompt via auto-prompts::inlineGsdRootFile).
+ *   - Decisions → persisted via the gsd_save_decision MCP tool, which
+ *     regenerates .gsd/DECISIONS.md from the DB.
+ *   - Surprises → stay only in LEARNINGS.md (milestone-local context).
+ *
+ * The same extraction steps are reused by the complete-milestone prompt
+ * via buildExtractionStepsBlock — single source of truth.
  */
 
 import type { ExtensionAPI, ExtensionCommandContext } from "@gsd/pi-coding-agent";
@@ -37,6 +47,24 @@ export interface ExtractLearningsPromptContext {
   projectName: string;
 }
 
+/**
+ * Minimal context required to render the structured-extraction steps block.
+ *
+ * The block is milestone-scoped — it only needs the milestone ID (used for
+ * `scope` columns and `gsd_save_decision` calls) and the LEARNINGS.md output
+ * path (both absolute for unambiguous writes and relative for display in the
+ * prompt). Artefact content is NOT part of this context because both render
+ * sites (manual path and complete-milestone auto path) supply it separately.
+ */
+export interface ExtractionStepsContext {
+  /** Milestone identifier, e.g. `"M001"` or `"M001-ush8s3"` (team mode). */
+  milestoneId: string;
+  /** Absolute filesystem path at which the LEARNINGS.md file will be written. */
+  outputPath: string;
+  /** Project-root-relative path for the same file, used in prompt prose. */
+  relativeOutputPath: string;
+}
+
 export interface FrontmatterContext {
   milestoneId: string;
   milestoneName: string;
@@ -65,7 +93,7 @@ export function buildLearningsOutputPath(milestoneDir: string, milestoneId: stri
 export function resolvePhaseArtifacts(milestoneDir: string, milestoneId: string): PhaseArtifacts {
   const missingRequired: string[] = [];
 
-  const planFile = `${milestoneId}-PLAN.md`;
+  const planFile = `${milestoneId}-ROADMAP.md`;
   const summaryFile = `${milestoneId}-SUMMARY.md`;
   const verificationFile = `${milestoneId}-VERIFICATION.md`;
   const uatFile = `${milestoneId}-UAT.md`;
@@ -86,19 +114,183 @@ export function resolvePhaseArtifacts(milestoneDir: string, milestoneId: string)
   return { plan, summary, verification, uat, missingRequired };
 }
 
+/**
+ * Canonical structured-extraction instructions.
+ *
+ * Used in two places — kept in sync by construction:
+ *   1. /gsd extract-learnings manual path (buildExtractLearningsPrompt).
+ *   2. complete-milestone auto path ({{extractLearningsSteps}} placeholder,
+ *      injected by auto-prompts::buildCompleteMilestonePrompt).
+ *
+ * The block assumes the LLM already has the milestone artefacts available —
+ * either inlined directly in the manual path, or via {{inlinedContext}} in
+ * complete-milestone. It does not re-inline artefacts.
+ */
+export function buildExtractionStepsBlock(ctx: ExtractionStepsContext): string {
+  return `## Structured Learnings Extraction
+
+Perform the following steps IN ORDER. Each step is mandatory unless explicitly
+marked optional. These instructions are the single source of truth shared by
+\`/gsd extract-learnings\` and the auto-mode milestone-completion turn.
+
+### Step 1 — Classify findings into four categories
+
+Review the milestone artefacts (roadmap, slice summaries, verification report,
+UAT report) and structure your findings into exactly four categories:
+
+- **Decisions** — architectural or design choices made during this milestone, including rationale and alternatives considered.
+- **Lessons** — technical discoveries, process insights, knowledge gaps that were filled.
+- **Patterns** — reusable approaches or solutions that emerged and should be applied in future work.
+- **Surprises** — unexpected challenges, discoveries, or outcomes that deviated from assumptions.
+
+Every item MUST carry a \`Source:\` line using the format
+\`Source: {artifact-filename}/{section}\` (e.g.
+\`Source: ${ctx.milestoneId}-ROADMAP.md/Architecture Decisions\`).
+Items without a source attribution are invalid — drop them.
+
+### Step 2 — Write the LEARNINGS.md audit trail
+
+Using the \`write\` tool, persist the full structured report to
+\`${ctx.relativeOutputPath}\` with this shape:
+
+- YAML frontmatter with keys: \`phase\`, \`phase_name\`, \`project\`, \`generated\` (ISO-8601 UTC), \`counts\` (decisions / lessons / patterns / surprises), \`missing_artifacts\`.
+- Four H3 sections (\`### Decisions\`, \`### Lessons\`, \`### Patterns\`, \`### Surprises\`) containing bullet points. Each bullet is followed by its \`Source:\` line.
+
+LEARNINGS.md is the full, cited audit trail. Write it first — subsequent steps
+feed from its content.
+
+### Step 3 — Read \`.gsd/KNOWLEDGE.md\` to prepare append
+
+Read \`.gsd/KNOWLEDGE.md\`. It is a markdown file with three tables:
+\`## Rules\`, \`## Patterns\`, and \`## Lessons Learned\`.
+
+If the file does not exist yet, create it first using the \`write\` tool with
+exactly this canonical structure, then treat all tables as empty (next IDs
+\`P001\` / \`L001\`):
+
+\`\`\`
+# Project Knowledge
+
+Append-only register of project-specific rules, patterns, and lessons learned.
+Agents read this before every unit. Add entries when you discover something worth remembering.
+
+## Rules
+
+| # | Scope | Rule | Why | Added |
+|---|-------|------|-----|-------|
+
+## Patterns
+
+| # | Pattern | Where | Notes |
+|---|---------|-------|-------|
+
+## Lessons Learned
+
+| # | What Happened | Root Cause | Fix | Scope |
+|---|--------------|------------|-----|-------|
+\`\`\`
+
+If the file already exists:
+
+- find the highest existing \`P###\` ID in the \`## Patterns\` table — the next pattern ID is that + 1, zero-padded to three digits
+- find the highest existing \`L###\` ID in the \`## Lessons Learned\` table — same rule for the next lesson ID
+- read the existing \`Pattern\` and \`What Happened\` column text so you can skip semantic duplicates in steps 4 and 5
+
+### Step 4 — Append Patterns to \`## Patterns\`
+
+For each extracted Pattern that is **not** already represented in the table
+(semantic match, not exact-string match), append exactly one row to the
+\`## Patterns\` table in \`.gsd/KNOWLEDGE.md\`:
+
+\`\`\`
+| P<NNN> | <Pattern — one concise line> | <Where — component / file / subsystem> | ${ctx.milestoneId} |
+\`\`\`
+
+Rules:
+- Zero-pad IDs to three digits (\`P017\`, not \`P17\`).
+- Append-only — never reorder, edit, or delete existing rows.
+- If a column value is genuinely unknown, write \`—\` (em-dash). Never leave a cell empty.
+
+### Step 5 — Append Lessons to \`## Lessons Learned\`
+
+For each extracted Lesson that is not already represented, append one row to
+the \`## Lessons Learned\` table:
+
+\`\`\`
+| L<NNN> | <What happened> | <Root cause> | <Fix or forward guidance> | ${ctx.milestoneId} |
+\`\`\`
+
+Same ID numbering, append-only, and em-dash rules as Step 4.
+
+### Step 6 — Do NOT modify the \`## Rules\` table
+
+The \`## Rules\` table holds project-wide constraints authored manually via
+\`/gsd knowledge\`. Milestone learnings never produce rules — leave this
+table untouched.
+
+### Step 7 — Persist Decisions via \`gsd_save_decision\`
+
+For each extracted Decision, call the \`gsd_save_decision\` MCP tool exactly
+once with these parameters:
+
+- \`scope\` (string) — \`"${ctx.milestoneId}"\`
+- \`decision\` (string) — the question or issue that was decided
+- \`choice\` (string) — the concrete option selected
+- \`rationale\` (string) — why this choice was made, with a brief citation to the source artefact
+- \`made_by\` (string) — \`"agent"\`
+- \`revisable\` (string, optional) — \`"yes"\` or \`"no"\` only if the source artefact clearly indicates reversibility; otherwise omit
+
+The tool writes the decision to the GSD database and regenerates
+\`.gsd/DECISIONS.md\` atomically. Never edit \`DECISIONS.md\` manually — the
+file is DB-authoritative and manual edits will be overwritten.
+
+### Step 8 — Surprises stay only in LEARNINGS.md
+
+Surprises are milestone-local context and are NOT cross-session-reusable. Do
+not append them to \`KNOWLEDGE.md\`. Do not persist them via any MCP tool.
+They are captured only in the LEARNINGS.md file written in Step 2.
+
+### Step 9 — Deduplication rule (applies to Steps 4, 5, 7)
+
+Before appending a Pattern or Lesson row, or before calling
+\`gsd_save_decision\`, check whether a semantically equivalent entry already
+exists in the target surface. If so, skip that item entirely. Prefer skipping
+a near-duplicate over creating a second slightly-different row — redundancy
+degrades the signal.`;
+}
+
+/**
+ * Build the full dispatch prompt for the manual `/gsd extract-learnings` path.
+ *
+ * Composes a header block (title, project, output file), the inlined milestone
+ * artefacts (roadmap, summary, optional verification and UAT reports), and the
+ * canonical {@link buildExtractionStepsBlock} procedure. The same procedure is
+ * rendered verbatim in the auto-mode `complete-milestone` turn via the
+ * `{{extractLearningsSteps}}` placeholder, guaranteeing a single source of
+ * truth for how learnings flow into `KNOWLEDGE.md` and the DECISIONS database.
+ *
+ * Missing optional artefacts are surfaced as a note at the end of the artefact
+ * section so the LLM can mark them explicitly in the LEARNINGS frontmatter.
+ */
 export function buildExtractLearningsPrompt(ctx: ExtractLearningsPromptContext): string {
   const optionalSections: string[] = [];
 
   if (ctx.verificationContent) {
-    optionalSections.push(`## Verification Report\n\n${ctx.verificationContent}`);
+    optionalSections.push(`### Verification Report\n\n${ctx.verificationContent}`);
   }
   if (ctx.uatContent) {
-    optionalSections.push(`## UAT Report\n\n${ctx.uatContent}`);
+    optionalSections.push(`### UAT Report\n\n${ctx.uatContent}`);
   }
 
   const missingNote = ctx.missingArtifacts.length > 0
-    ? `\nNote: The following optional artefacts were not available: ${ctx.missingArtifacts.join(", ")}\n`
+    ? `\nNote: the following optional artefacts were not available: ${ctx.missingArtifacts.join(", ")}\n`
     : "";
+
+  const stepsBlock = buildExtractionStepsBlock({
+    milestoneId: ctx.milestoneId,
+    outputPath: ctx.outputPath,
+    relativeOutputPath: ctx.relativeOutputPath,
+  });
 
   return `# Extract Learnings — ${ctx.milestoneId}: ${ctx.milestoneName}
 
@@ -107,35 +299,16 @@ export function buildExtractLearningsPrompt(ctx: ExtractLearningsPromptContext):
 
 ## Your Task
 
-Analyse the artefacts below and extract structured knowledge from milestone **${ctx.milestoneId}**.
-
-Write a LEARNINGS document to \`${ctx.outputPath}\` with the following 4 sections:
-
-### Decisions
-Key architectural and design decisions made during this milestone, including the rationale and alternatives considered.
-
-### Lessons
-What the team learned — technical discoveries, process insights, and knowledge gaps that were filled.
-
-### Patterns
-Reusable patterns, approaches, or solutions that emerged and should be applied in future work.
-
-### Surprises
-Unexpected challenges, discoveries, or outcomes — things that deviated from assumptions.
-
-### Source Attribution (REQUIRED)
-
-Every extracted item MUST include a \`Source:\` line immediately after the item text.
-Format: \`Source: {artifact-filename}/{section}\`
-Example: \`Source: M001-PLAN.md/Architecture Decisions\`
-
-Items without a Source attribution are invalid and must not be included in the output.
+Analyse the milestone artefacts inlined below and follow the Structured
+Learnings Extraction procedure in full. The procedure writes LEARNINGS.md
+and routes the durable subset into \`.gsd/KNOWLEDGE.md\` and the DECISIONS
+database so future milestone dispatches benefit from what was learned here.
 
 ---
 
 ## Artefacts
 
-### Plan
+### Roadmap
 
 ${ctx.planContent}
 
@@ -144,44 +317,10 @@ ${ctx.planContent}
 ### Summary
 
 ${ctx.summaryContent}
-
-${optionalSections.join("\n\n---\n\n")}
-${missingNote}
+${optionalSections.length > 0 ? `\n---\n\n${optionalSections.join("\n\n---\n\n")}\n` : ""}${missingNote}
 ---
 
-## Output Format
-
-Write the LEARNINGS file to \`${ctx.relativeOutputPath}\` with YAML frontmatter followed by the 4 sections above.
-Each section should contain concise, actionable bullet points.
-Every bullet point MUST be followed by a source line, for example:
-
-\`\`\`
-### Decisions
-- Chose PostgreSQL over SQLite for concurrent write support.
-  Source: M001-PLAN.md/Architecture Decisions
-\`\`\`
-
-Items without a \`Source:\` line are invalid.
-
----
-
-## Optional: Capture Individual Learnings
-
-If the \`capture_thought\` tool is available, call it once for each extracted item with:
-- category: "decision" | "lesson" | "pattern" | "surprise"
-- phase: "${ctx.milestoneId}"
-- content: {the learning text}
-- source: {artifact filename}
-
-If \`capture_thought\` is not available, skip this step silently — do not report an error.
-
----
-
-## Rebuild Knowledge Graph
-
-After writing LEARNINGS.md, call the \`gsd_graph\` tool with \`{ "mode": "build" }\` to rebuild the knowledge graph so the new learnings are immediately queryable by future milestone prompts.
-
-If the \`gsd_graph\` tool is not available, skip this step silently.
+${stepsBlock}
 `;
 }
 
@@ -257,11 +396,9 @@ export async function handleExtractLearnings(
     return;
   }
 
-  // Read required artefacts
   const planContent = readFileSync(artifacts.plan!, "utf-8");
   const summaryContent = readFileSync(artifacts.summary!, "utf-8");
 
-  // Read optional artefacts
   const verificationContent = artifacts.verification
     ? readFileSync(artifacts.verification, "utf-8")
     : null;
@@ -269,12 +406,10 @@ export async function handleExtractLearnings(
     ? readFileSync(artifacts.uat, "utf-8")
     : null;
 
-  // Determine missing optional artefacts for context
   const missingArtifacts: string[] = [];
   if (!artifacts.verification) missingArtifacts.push(`${milestoneId}-VERIFICATION.md`);
   if (!artifacts.uat) missingArtifacts.push(`${milestoneId}-UAT.md`);
 
-  // Extract milestone name from Plan H1 or fall back to milestoneId
   const h1Match = planContent.match(/^#\s+(.+)$/m);
   const milestoneName = h1Match?.[1]?.trim() ?? milestoneId;
 

--- a/src/resources/extensions/gsd/commands-extract-learnings.ts
+++ b/src/resources/extensions/gsd/commands-extract-learnings.ts
@@ -19,7 +19,7 @@
 import type { ExtensionAPI, ExtensionCommandContext } from "@gsd/pi-coding-agent";
 
 import { existsSync, readFileSync } from "node:fs";
-import { join, basename } from "node:path";
+import { join, basename, relative } from "node:path";
 
 import { gsdRoot, resolveMilestonePath } from "./paths.js";
 import { projectRoot } from "./commands/context.js";
@@ -499,7 +499,7 @@ export async function handleExtractLearnings(
 
   const projectName = extractProjectName(basePath);
   const outputPath = buildLearningsOutputPath(milestoneDir, milestoneId);
-  const relativeOutputPath = outputPath.replace(basePath + "/", "");
+  const relativeOutputPath = relative(basePath, outputPath);
 
   const prompt = buildExtractLearningsPrompt({
     milestoneId,

--- a/src/resources/extensions/gsd/prompts/complete-milestone.md
+++ b/src/resources/extensions/gsd/prompts/complete-milestone.md
@@ -59,7 +59,10 @@ Then:
    - `followUps` (string) — Follow-up items for future milestones
    - `deviations` (string) — Deviations from the original plan
 11. Update `.gsd/PROJECT.md`: use the `write` tool with `path: ".gsd/PROJECT.md"` and `content` containing the full updated document reflecting milestone completion and current project state. Do NOT use the `edit` tool for this — PROJECT.md is a full-document refresh.
-12. Review all slice summaries for cross-cutting lessons, patterns, or gotchas that emerged during this milestone. Append any non-obvious, reusable insights to `.gsd/KNOWLEDGE.md`.
+12. Extract structured learnings from this milestone and persist them to the cross-session knowledge surfaces. Follow the procedure block immediately below — it writes `{{milestoneId}}-LEARNINGS.md`, appends Patterns and Lessons to `.gsd/KNOWLEDGE.md`, and persists Decisions via the `gsd_save_decision` MCP tool.
+
+{{extractLearningsSteps}}
+
 13. Do not commit manually — the system auto-commits your changes after this unit completes.
 - Say: "Milestone {{milestoneId}} complete."
 

--- a/src/resources/extensions/gsd/tests/commands-extract-learnings.test.ts
+++ b/src/resources/extensions/gsd/tests/commands-extract-learnings.test.ts
@@ -75,7 +75,7 @@ describe("resolvePhaseArtifacts", () => {
     writeFileSync(join(tmpBase, "M001-SUMMARY.md"), "# M001 Summary content", "utf-8");
 
     const result = resolvePhaseArtifacts(tmpBase, "M001");
-    assert.equal(result.plan, join(tmpBase, "M001-ROADMAP.md"));
+    assert.equal(result.roadmap, join(tmpBase, "M001-ROADMAP.md"));
     assert.equal(result.summary, join(tmpBase, "M001-SUMMARY.md"));
     assert.deepEqual(result.missingRequired, []);
   });
@@ -85,7 +85,7 @@ describe("resolvePhaseArtifacts", () => {
 
     const result = resolvePhaseArtifacts(tmpBase, "M001");
     assert.ok(result.missingRequired.includes("M001-ROADMAP.md"));
-    assert.equal(result.plan, null);
+    assert.equal(result.roadmap, null);
   });
 
   it("does NOT require M001-PLAN.md (regression for #4429 — milestones use ROADMAP)", () => {
@@ -160,7 +160,7 @@ describe("buildExtractLearningsPrompt", () => {
       milestoneName: "Test Milestone",
       outputPath: "/project/.gsd/milestones/M001/M001-LEARNINGS.md",
       relativeOutputPath: ".gsd/milestones/M001/M001-LEARNINGS.md",
-      planContent: "# Plan content",
+      roadmapContent: "# Roadmap content",
       summaryContent: "# Summary content",
       verificationContent: null,
       uatContent: null,
@@ -178,7 +178,7 @@ describe("buildExtractLearningsPrompt", () => {
       milestoneName: "Test Milestone",
       outputPath: "/out/M001-LEARNINGS.md",
       relativeOutputPath: ".gsd/milestones/M001/M001-LEARNINGS.md",
-      planContent: "# Plan",
+      roadmapContent: "# Roadmap",
       summaryContent: "# Summary",
       verificationContent: null,
       uatContent: null,
@@ -192,13 +192,13 @@ describe("buildExtractLearningsPrompt", () => {
     assert.ok(result.includes("Surprises"));
   });
 
-  it("includes plan and summary content", () => {
+  it("includes roadmap and summary content", () => {
     const result = buildExtractLearningsPrompt({
       milestoneId: "M001",
       milestoneName: "Test Milestone",
       outputPath: "/out/M001-LEARNINGS.md",
       relativeOutputPath: ".gsd/milestones/M001/M001-LEARNINGS.md",
-      planContent: "PLAN_CONTENT_UNIQUE_123",
+      roadmapContent: "ROADMAP_CONTENT_UNIQUE_123",
       summaryContent: "SUMMARY_CONTENT_UNIQUE_456",
       verificationContent: null,
       uatContent: null,
@@ -206,7 +206,7 @@ describe("buildExtractLearningsPrompt", () => {
       projectName: "MyProject",
     });
 
-    assert.ok(result.includes("PLAN_CONTENT_UNIQUE_123"));
+    assert.ok(result.includes("ROADMAP_CONTENT_UNIQUE_123"));
     assert.ok(result.includes("SUMMARY_CONTENT_UNIQUE_456"));
   });
 
@@ -216,7 +216,7 @@ describe("buildExtractLearningsPrompt", () => {
       milestoneName: "Test Milestone",
       outputPath: "/out/M001-LEARNINGS.md",
       relativeOutputPath: ".gsd/milestones/M001/M001-LEARNINGS.md",
-      planContent: "# Plan",
+      roadmapContent: "# Roadmap",
       summaryContent: "# Summary",
       verificationContent: "VERIFICATION_UNIQUE_789",
       uatContent: "UAT_UNIQUE_012",
@@ -234,7 +234,7 @@ describe("buildExtractLearningsPrompt", () => {
       milestoneName: "Test Milestone",
       outputPath: "/out/M001-LEARNINGS.md",
       relativeOutputPath: ".gsd/milestones/M001/M001-LEARNINGS.md",
-      planContent: "# Plan",
+      roadmapContent: "# Roadmap",
       summaryContent: "# Summary",
       verificationContent: null,
       uatContent: null,
@@ -251,7 +251,7 @@ describe("buildExtractLearningsPrompt", () => {
       milestoneName: "Test Milestone",
       outputPath: "/out/M001-LEARNINGS.md",
       relativeOutputPath: ".gsd/milestones/M001/M001-LEARNINGS.md",
-      planContent: "# Plan",
+      roadmapContent: "# Roadmap",
       summaryContent: "# Summary",
       verificationContent: null,
       uatContent: null,
@@ -271,7 +271,7 @@ describe("buildExtractLearningsPrompt", () => {
       milestoneName: "Test Milestone",
       outputPath: "/out/M001-LEARNINGS.md",
       relativeOutputPath: ".gsd/milestones/M001/M001-LEARNINGS.md",
-      planContent: "# Plan",
+      roadmapContent: "# Roadmap",
       summaryContent: "# Summary",
       verificationContent: null,
       uatContent: null,
@@ -291,7 +291,7 @@ describe("buildExtractLearningsPrompt", () => {
       milestoneName: "Test Milestone",
       outputPath: "/out/M001-LEARNINGS.md",
       relativeOutputPath: ".gsd/milestones/M001/M001-LEARNINGS.md",
-      planContent: "# Plan",
+      roadmapContent: "# Roadmap",
       summaryContent: "# Summary",
       verificationContent: null,
       uatContent: null,
@@ -561,7 +561,7 @@ describe("buildExtractLearningsPrompt composes the steps block", () => {
     const prompt = buildExtractLearningsPrompt({
       ...shared,
       milestoneName: "Composition",
-      planContent: "# Roadmap body",
+      roadmapContent: "# Roadmap body",
       summaryContent: "# Summary body",
       verificationContent: null,
       uatContent: null,
@@ -578,7 +578,7 @@ describe("buildExtractLearningsPrompt composes the steps block", () => {
       milestoneName: "Test",
       outputPath: "/out/M001-LEARNINGS.md",
       relativeOutputPath: ".gsd/milestones/M001/M001-LEARNINGS.md",
-      planContent: "# Plan",
+      roadmapContent: "# Roadmap",
       summaryContent: "# Summary",
       verificationContent: null,
       uatContent: null,

--- a/src/resources/extensions/gsd/tests/commands-extract-learnings.test.ts
+++ b/src/resources/extensions/gsd/tests/commands-extract-learnings.test.ts
@@ -1,15 +1,19 @@
 import { describe, it, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
-import { mkdirSync, writeFileSync, rmSync } from "node:fs";
-import { join } from "node:path";
+import { mkdirSync, writeFileSync, rmSync, readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
 import { tmpdir } from "node:os";
 import { randomUUID } from "node:crypto";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 import {
   parseExtractLearningsArgs,
   buildLearningsOutputPath,
   resolvePhaseArtifacts,
   buildExtractLearningsPrompt,
+  buildExtractionStepsBlock,
   buildFrontmatter,
   extractProjectName,
 } from "../commands-extract-learnings.js";
@@ -66,26 +70,38 @@ describe("resolvePhaseArtifacts", () => {
     rmSync(tmpBase, { recursive: true, force: true });
   });
 
-  it("finds required PLAN and SUMMARY when both present", () => {
-    writeFileSync(join(tmpBase, "M001-PLAN.md"), "# M001 Plan content", "utf-8");
+  it("finds required ROADMAP and SUMMARY when both present", () => {
+    writeFileSync(join(tmpBase, "M001-ROADMAP.md"), "# M001 Roadmap content", "utf-8");
     writeFileSync(join(tmpBase, "M001-SUMMARY.md"), "# M001 Summary content", "utf-8");
 
     const result = resolvePhaseArtifacts(tmpBase, "M001");
-    assert.equal(result.plan, join(tmpBase, "M001-PLAN.md"));
+    assert.equal(result.plan, join(tmpBase, "M001-ROADMAP.md"));
     assert.equal(result.summary, join(tmpBase, "M001-SUMMARY.md"));
     assert.deepEqual(result.missingRequired, []);
   });
 
-  it("reports missing PLAN as missingRequired", () => {
+  it("reports missing ROADMAP as missingRequired (regression for #4429)", () => {
     writeFileSync(join(tmpBase, "M001-SUMMARY.md"), "# Summary", "utf-8");
 
     const result = resolvePhaseArtifacts(tmpBase, "M001");
-    assert.ok(result.missingRequired.includes("M001-PLAN.md"));
+    assert.ok(result.missingRequired.includes("M001-ROADMAP.md"));
     assert.equal(result.plan, null);
   });
 
+  it("does NOT require M001-PLAN.md (regression for #4429 — milestones use ROADMAP)", () => {
+    writeFileSync(join(tmpBase, "M001-ROADMAP.md"), "# Roadmap", "utf-8");
+    writeFileSync(join(tmpBase, "M001-SUMMARY.md"), "# Summary", "utf-8");
+
+    const result = resolvePhaseArtifacts(tmpBase, "M001");
+    assert.ok(
+      !result.missingRequired.includes("M001-PLAN.md"),
+      "PLAN.md must not be demanded at milestone scope",
+    );
+    assert.deepEqual(result.missingRequired, []);
+  });
+
   it("reports missing SUMMARY as missingRequired", () => {
-    writeFileSync(join(tmpBase, "M001-PLAN.md"), "# Plan", "utf-8");
+    writeFileSync(join(tmpBase, "M001-ROADMAP.md"), "# Roadmap", "utf-8");
 
     const result = resolvePhaseArtifacts(tmpBase, "M001");
     assert.ok(result.missingRequired.includes("M001-SUMMARY.md"));
@@ -95,12 +111,12 @@ describe("resolvePhaseArtifacts", () => {
   it("reports both required files missing when neither present", () => {
     const result = resolvePhaseArtifacts(tmpBase, "M001");
     assert.equal(result.missingRequired.length, 2);
-    assert.ok(result.missingRequired.includes("M001-PLAN.md"));
+    assert.ok(result.missingRequired.includes("M001-ROADMAP.md"));
     assert.ok(result.missingRequired.includes("M001-SUMMARY.md"));
   });
 
   it("finds optional VERIFICATION when present", () => {
-    writeFileSync(join(tmpBase, "M001-PLAN.md"), "# Plan", "utf-8");
+    writeFileSync(join(tmpBase, "M001-ROADMAP.md"), "# Roadmap", "utf-8");
     writeFileSync(join(tmpBase, "M001-SUMMARY.md"), "# Summary", "utf-8");
     writeFileSync(join(tmpBase, "M001-VERIFICATION.md"), "# Verification", "utf-8");
 
@@ -109,7 +125,7 @@ describe("resolvePhaseArtifacts", () => {
   });
 
   it("returns null for optional VERIFICATION when absent", () => {
-    writeFileSync(join(tmpBase, "M001-PLAN.md"), "# Plan", "utf-8");
+    writeFileSync(join(tmpBase, "M001-ROADMAP.md"), "# Roadmap", "utf-8");
     writeFileSync(join(tmpBase, "M001-SUMMARY.md"), "# Summary", "utf-8");
 
     const result = resolvePhaseArtifacts(tmpBase, "M001");
@@ -117,7 +133,7 @@ describe("resolvePhaseArtifacts", () => {
   });
 
   it("finds optional UAT when present", () => {
-    writeFileSync(join(tmpBase, "M001-PLAN.md"), "# Plan", "utf-8");
+    writeFileSync(join(tmpBase, "M001-ROADMAP.md"), "# Roadmap", "utf-8");
     writeFileSync(join(tmpBase, "M001-SUMMARY.md"), "# Summary", "utf-8");
     writeFileSync(join(tmpBase, "M001-UAT.md"), "# UAT", "utf-8");
 
@@ -126,7 +142,7 @@ describe("resolvePhaseArtifacts", () => {
   });
 
   it("returns null for optional UAT when absent, no error", () => {
-    writeFileSync(join(tmpBase, "M001-PLAN.md"), "# Plan", "utf-8");
+    writeFileSync(join(tmpBase, "M001-ROADMAP.md"), "# Roadmap", "utf-8");
     writeFileSync(join(tmpBase, "M001-SUMMARY.md"), "# Summary", "utf-8");
 
     const result = resolvePhaseArtifacts(tmpBase, "M001");
@@ -227,6 +243,64 @@ describe("buildExtractLearningsPrompt", () => {
     });
 
     assert.ok(result.includes("M001-VERIFICATION.md"));
+  });
+
+  it("does NOT reference phantom capture_thought tool (regression for #4429)", () => {
+    const result = buildExtractLearningsPrompt({
+      milestoneId: "M001",
+      milestoneName: "Test Milestone",
+      outputPath: "/out/M001-LEARNINGS.md",
+      relativeOutputPath: ".gsd/milestones/M001/M001-LEARNINGS.md",
+      planContent: "# Plan",
+      summaryContent: "# Summary",
+      verificationContent: null,
+      uatContent: null,
+      missingArtifacts: [],
+      projectName: "MyProject",
+    });
+
+    assert.ok(
+      !result.includes("capture_thought"),
+      "prompt must not advertise the non-existent capture_thought tool",
+    );
+  });
+
+  it("does NOT reference phantom gsd_graph tool (regression for #4429)", () => {
+    const result = buildExtractLearningsPrompt({
+      milestoneId: "M001",
+      milestoneName: "Test Milestone",
+      outputPath: "/out/M001-LEARNINGS.md",
+      relativeOutputPath: ".gsd/milestones/M001/M001-LEARNINGS.md",
+      planContent: "# Plan",
+      summaryContent: "# Summary",
+      verificationContent: null,
+      uatContent: null,
+      missingArtifacts: [],
+      projectName: "MyProject",
+    });
+
+    assert.ok(
+      !result.includes("gsd_graph"),
+      "prompt must not advertise the non-existent gsd_graph tool",
+    );
+  });
+
+  it("source-attribution example references ROADMAP.md, not PLAN.md (regression for #4429)", () => {
+    const result = buildExtractLearningsPrompt({
+      milestoneId: "M001",
+      milestoneName: "Test Milestone",
+      outputPath: "/out/M001-LEARNINGS.md",
+      relativeOutputPath: ".gsd/milestones/M001/M001-LEARNINGS.md",
+      planContent: "# Plan",
+      summaryContent: "# Summary",
+      verificationContent: null,
+      uatContent: null,
+      missingArtifacts: [],
+      projectName: "MyProject",
+    });
+
+    assert.ok(result.includes("M001-ROADMAP.md/Architecture Decisions"));
+    assert.ok(!result.includes("M001-PLAN.md/Architecture Decisions"));
   });
 });
 
@@ -336,5 +410,243 @@ describe("extractProjectName", () => {
 
     const result = extractProjectName(tmpBase);
     assert.equal(result, tmpBase.split("/").at(-1));
+  });
+});
+
+// ─── buildExtractionStepsBlock ────────────────────────────────────────────────
+//
+// The steps block is the single source of truth for how learnings are routed
+// into KNOWLEDGE.md and the DECISIONS DB. Both the manual /gsd extract-learnings
+// path and the auto complete-milestone path render it verbatim, so every
+// structural assertion below protects both paths at once.
+
+describe("buildExtractionStepsBlock", () => {
+  const ctx = {
+    milestoneId: "M042",
+    outputPath: "/project/.gsd/milestones/M042/M042-LEARNINGS.md",
+    relativeOutputPath: ".gsd/milestones/M042/M042-LEARNINGS.md",
+  };
+
+  it("declares itself as the structured extraction procedure", () => {
+    const block = buildExtractionStepsBlock(ctx);
+    assert.ok(block.includes("Structured Learnings Extraction"));
+  });
+
+  it("instructs the LLM to write LEARNINGS.md at the given relative path", () => {
+    const block = buildExtractionStepsBlock(ctx);
+    assert.ok(block.includes(ctx.relativeOutputPath));
+    assert.ok(block.includes("YAML frontmatter"));
+  });
+
+  it("covers all four extraction categories", () => {
+    const block = buildExtractionStepsBlock(ctx);
+    assert.ok(block.includes("Decisions"));
+    assert.ok(block.includes("Lessons"));
+    assert.ok(block.includes("Patterns"));
+    assert.ok(block.includes("Surprises"));
+  });
+
+  it("requires a Source attribution for every item", () => {
+    const block = buildExtractionStepsBlock(ctx);
+    assert.ok(block.includes("Source:"));
+    assert.ok(block.includes("M042-ROADMAP.md"));
+  });
+
+  it("points the LLM at .gsd/KNOWLEDGE.md for append", () => {
+    const block = buildExtractionStepsBlock(ctx);
+    assert.ok(block.includes(".gsd/KNOWLEDGE.md"));
+  });
+
+  it("covers the missing-file case with the canonical KNOWLEDGE.md template", () => {
+    const block = buildExtractionStepsBlock(ctx);
+    assert.ok(block.includes("If the file does not exist yet, create it first"));
+    // Canonical column headers must be inlined so the LLM does not have to guess.
+    assert.ok(block.includes("| # | Scope | Rule | Why | Added |"));
+    assert.ok(block.includes("| # | Pattern | Where | Notes |"));
+    assert.ok(block.includes("| # | What Happened | Root Cause | Fix | Scope |"));
+  });
+
+  it("specifies the exact Patterns row format with milestone scope", () => {
+    const block = buildExtractionStepsBlock(ctx);
+    assert.ok(block.includes("| P<NNN>"));
+    assert.ok(block.includes(`| ${ctx.milestoneId} |`));
+  });
+
+  it("specifies the exact Lessons row format with milestone scope", () => {
+    const block = buildExtractionStepsBlock(ctx);
+    assert.ok(block.includes("| L<NNN>"));
+  });
+
+  it("enforces zero-padded three-digit IDs", () => {
+    const block = buildExtractionStepsBlock(ctx);
+    assert.ok(/zero[- ]pad/i.test(block));
+    assert.ok(block.includes("three digits") || block.includes("3 digits"));
+  });
+
+  it("instructs append-only behaviour (no edits to existing rows)", () => {
+    const block = buildExtractionStepsBlock(ctx);
+    assert.ok(block.includes("Append-only"));
+  });
+
+  it("uses em-dash as the placeholder for unknown column values", () => {
+    const block = buildExtractionStepsBlock(ctx);
+    assert.ok(block.includes("—"));
+    assert.ok(!block.includes("N/A"));
+  });
+
+  it("forbids modifications to the Rules table", () => {
+    const block = buildExtractionStepsBlock(ctx);
+    assert.ok(/do not.*rules/i.test(block.toLowerCase()) || block.includes("Do NOT modify"));
+    assert.ok(block.includes("## Rules"));
+  });
+
+  it("routes Decisions through the gsd_save_decision MCP tool", () => {
+    const block = buildExtractionStepsBlock(ctx);
+    assert.ok(block.includes("gsd_save_decision"));
+    assert.ok(block.includes("`scope`"));
+    assert.ok(block.includes("`decision`"));
+    assert.ok(block.includes("`choice`"));
+    assert.ok(block.includes("`rationale`"));
+    assert.ok(block.includes("`made_by`"));
+  });
+
+  it("forbids direct edits to DECISIONS.md (DB-authoritative)", () => {
+    const block = buildExtractionStepsBlock(ctx);
+    assert.ok(/never edit.+decisions\.md/i.test(block));
+  });
+
+  it("keeps Surprises milestone-local (not in KNOWLEDGE.md, no tool call)", () => {
+    const block = buildExtractionStepsBlock(ctx);
+    assert.ok(block.includes("Surprises stay only in LEARNINGS.md"));
+  });
+
+  it("enforces a deduplication rule across all persistence steps", () => {
+    const block = buildExtractionStepsBlock(ctx);
+    assert.ok(/deduplication/i.test(block) || /dedup/i.test(block));
+    assert.ok(/semantically equivalent/i.test(block));
+    assert.ok(/skip/i.test(block));
+  });
+
+  it("does NOT reference the non-existent capture_thought tool (#4429 regression)", () => {
+    const block = buildExtractionStepsBlock(ctx);
+    assert.ok(!block.includes("capture_thought"));
+  });
+
+  it("does NOT reference the non-existent gsd_graph tool (#4429 regression)", () => {
+    const block = buildExtractionStepsBlock(ctx);
+    assert.ok(!block.includes("gsd_graph"));
+  });
+
+  it("substitutes the milestone ID into every placeholder callout", () => {
+    const block = buildExtractionStepsBlock({
+      milestoneId: "M999",
+      outputPath: "/p/.gsd/milestones/M999/M999-LEARNINGS.md",
+      relativeOutputPath: ".gsd/milestones/M999/M999-LEARNINGS.md",
+    });
+    assert.ok(!block.includes("M042"));
+    assert.ok(block.includes("M999"));
+  });
+});
+
+// ─── buildExtractLearningsPrompt composition ──────────────────────────────────
+
+describe("buildExtractLearningsPrompt composes the steps block", () => {
+  it("embeds the exact buildExtractionStepsBlock output for the same context", () => {
+    const shared = {
+      milestoneId: "M007",
+      outputPath: "/p/.gsd/milestones/M007/M007-LEARNINGS.md",
+      relativeOutputPath: ".gsd/milestones/M007/M007-LEARNINGS.md",
+    };
+    const expected = buildExtractionStepsBlock(shared);
+    const prompt = buildExtractLearningsPrompt({
+      ...shared,
+      milestoneName: "Composition",
+      planContent: "# Roadmap body",
+      summaryContent: "# Summary body",
+      verificationContent: null,
+      uatContent: null,
+      missingArtifacts: [],
+      projectName: "TestProj",
+    });
+
+    assert.ok(prompt.includes(expected));
+  });
+
+  it("no longer contains the orphan-file disclaimer from the previous revision", () => {
+    const prompt = buildExtractLearningsPrompt({
+      milestoneId: "M001",
+      milestoneName: "Test",
+      outputPath: "/out/M001-LEARNINGS.md",
+      relativeOutputPath: ".gsd/milestones/M001/M001-LEARNINGS.md",
+      planContent: "# Plan",
+      summaryContent: "# Summary",
+      verificationContent: null,
+      uatContent: null,
+      missingArtifacts: [],
+      projectName: "P",
+    });
+
+    assert.ok(!prompt.includes("no automated pipeline currently consumes it"));
+  });
+});
+
+// ─── complete-milestone.md loadPrompt round-trip ─────────────────────────────
+
+describe("complete-milestone loadPrompt round-trip (#4429)", () => {
+  it("substitutes {{extractLearningsSteps}} end-to-end via prompt-loader", async () => {
+    const { loadPrompt } = await import("../prompt-loader.js");
+    const stepsBlock = buildExtractionStepsBlock({
+      milestoneId: "M123",
+      outputPath: "/p/.gsd/milestones/M123/M123-LEARNINGS.md",
+      relativeOutputPath: ".gsd/milestones/M123/M123-LEARNINGS.md",
+    });
+
+    const rendered = loadPrompt("complete-milestone", {
+      workingDirectory: "/p",
+      milestoneId: "M123",
+      milestoneTitle: "Test Milestone",
+      roadmapPath: ".gsd/milestones/M123/M123-ROADMAP.md",
+      inlinedContext: "(inlined context stub)",
+      milestoneSummaryPath: "/p/.gsd/milestones/M123/M123-SUMMARY.md",
+      extractLearningsSteps: stepsBlock,
+    });
+
+    // Placeholder must be gone — real content must be in.
+    assert.ok(!rendered.includes("{{extractLearningsSteps}}"));
+    assert.ok(rendered.includes("Structured Learnings Extraction"));
+    assert.ok(rendered.includes("gsd_save_decision"));
+    assert.ok(rendered.includes("M123"));
+  });
+});
+
+// ─── complete-milestone.md template wiring ────────────────────────────────────
+
+describe("complete-milestone.md template wiring (#4429)", () => {
+  const promptPath = join(
+    __dirname,
+    "..",
+    "prompts",
+    "complete-milestone.md",
+  );
+
+  it("declares the {{extractLearningsSteps}} placeholder", () => {
+    const content = readFileSync(promptPath, "utf-8");
+    assert.ok(content.includes("{{extractLearningsSteps}}"));
+  });
+
+  it("no longer contains the deprecated ad-hoc KNOWLEDGE.md step", () => {
+    const content = readFileSync(promptPath, "utf-8");
+    assert.ok(
+      !content.includes("Review all slice summaries for cross-cutting lessons, patterns, or gotchas"),
+      "the pre-#4429 one-sentence step 12 must be removed",
+    );
+  });
+
+  it("keeps the milestone-completion commit instruction after the placeholder", () => {
+    const content = readFileSync(promptPath, "utf-8");
+    const placeholderIdx = content.indexOf("{{extractLearningsSteps}}");
+    const commitIdx = content.indexOf("Do not commit manually");
+    assert.ok(placeholderIdx > 0);
+    assert.ok(commitIdx > placeholderIdx, "commit instruction must come after extraction block");
   });
 });


### PR DESCRIPTION
## TL;DR

**What:** Repairs `/gsd extract-learnings` so it actually feeds the cross-session knowledge surfaces it was always meant to populate, and wires it into `complete-milestone` as the structured replacement for the legacy one-sentence step 12.
**Why:** The command had three defects (#4429) that together made it non-functional — wrong artefact name, references to tools that don't exist, and an orphan output file nothing consumed.
**How:** Single source-of-truth `buildExtractionStepsBlock()` shared by the manual path and the auto-mode `complete-milestone` turn, routing Decisions through `gsd_save_decision`, Patterns/Lessons into `.gsd/KNOWLEDGE.md`, and leaving Surprises local to `LEARNINGS.md`.

## What

Five files changed, 540 insertions, 79 deletions.

- `src/resources/extensions/gsd/commands-extract-learnings.ts` — adds `buildExtractionStepsBlock()` as the canonical extraction procedure. `resolvePhaseArtifacts` now requires `{MID}-ROADMAP.md` (the real milestone plan artefact) instead of the non-existent `{MID}-PLAN.md`. Phantom `capture_thought` / `gsd_graph` tool references are removed. New `ExtractionStepsContext` interface and refactored `buildExtractLearningsPrompt` that composes header + artefacts + steps block.
- `src/resources/extensions/gsd/prompts/complete-milestone.md` — step 12's one-sentence "append insights to KNOWLEDGE.md" directive is replaced with the new `{{extractLearningsSteps}}` placeholder, so milestone-completion turns now run the same structured extraction as `/gsd extract-learnings`.
- `src/resources/extensions/gsd/auto-prompts.ts` — `buildCompleteMilestonePrompt` imports `buildExtractionStepsBlock` and injects the rendered block as the `extractLearningsSteps` var.
- `src/resources/extensions/gsd/tests/commands-extract-learnings.test.ts` — 31 new tests covering block content, composition, loadPrompt round-trip, and phantom-tool regression guards.
- `docs/user-docs/commands.md` — adds the previously undocumented `/gsd extract-learnings` to the commands table.

## Why

Closes #4429.

The issue documents three compounding bugs:

1. **Hard crash on missing artefact** — `resolvePhaseArtifacts()` hardcoded `{milestoneId}-PLAN.md` as required. Milestones produce `{milestoneId}-ROADMAP.md`; slices produce `-PLAN.md`. Every run on a real milestone failed with *"required artefacts missing: M001-PLAN.md"*. Verified across ten completed milestones in the reporting project — zero have a `{ID}-PLAN.md` file.
2. **Phantom tool dependencies** — the prompt told the agent to call `capture_thought` and `gsd_graph`, neither of which is registered anywhere in the codebase. The "skip silently if unavailable" fallback turned both advertised side effects (per-item memory capture + knowledge graph rebuild) into dead code.
3. **Dead-end output** — `LEARNINGS.md` was written but read by no code path (grep-confirmed zero references outside `commands-extract-learnings.ts`). Extracted learnings never reached any future dispatch.

The workflow intent (surface milestone learnings to future milestones) was already implemented on the **read** side via `KNOWLEDGE.md`, which is inlined into every major dispatch prompt (`research-milestone`, `plan-milestone`, `complete-slice`, `complete-milestone`, `execute-task`, `refine-slice`). What was missing was a high-quality, structured **write** path — which is what this PR adds.

## How

### Single source of truth

`buildExtractionStepsBlock(ctx)` returns the canonical procedure as a markdown block. Both call sites render it verbatim:

- **Manual**: `/gsd extract-learnings <MID>` → `buildExtractLearningsPrompt` composes header + inlined artefacts + the block.
- **Auto**: `complete-milestone.md` declares `{{extractLearningsSteps}}`, and `buildCompleteMilestonePrompt` substitutes it via the existing `loadPrompt` pipeline.

This guarantees the two paths cannot drift.

### What the block tells the agent to do

1. Classify findings into Decisions / Lessons / Patterns / Surprises, each item carrying a `Source: {artefact}/{section}` attribution.
2. Write the full `{MID}-LEARNINGS.md` audit trail via the `write` tool — YAML frontmatter + four H3 sections.
3. Read `.gsd/KNOWLEDGE.md`. If missing, create it from the canonical template inlined in the prompt. Otherwise, determine next `P###` / `L###` IDs and note existing entries for dedup.
4. Append each non-duplicate **Pattern** to the `## Patterns` table using the exact column layout from `templates/knowledge.md`.
5. Append each non-duplicate **Lesson** to the `## Lessons Learned` table, same rules.
6. Leave the `## Rules` table untouched — rules are authored manually via `/gsd knowledge`.
7. For each **Decision**, call the existing `gsd_save_decision` MCP tool once, which writes to the DB and regenerates `.gsd/DECISIONS.md` atomically.
8. Keep **Surprises** in `LEARNINGS.md` only (milestone-local, not cross-session-reusable).
9. Deduplicate semantically-equivalent entries across every persistence target.

### Why this composition

- **No new MCP tools introduced.** `gsd_save_decision` already exists (alias `gsd_decision_save`) and is the canonical path to DECISIONS.md. KNOWLEDGE.md writes go through the agent's standard `write`/`edit` tools — the block inlines the exact table format so the agent has no room to drift.
- **Append-only semantics** with milestone-scoped provenance in the table's last column — future pruning or audit is trivial.
- **Rules table left alone** — preserves the distinct semantics of manually-authored project-wide constraints vs. milestone-derived learnings.
- **Step 12 of `complete-milestone.md` replaced, not supplemented** — two parallel mechanisms for the same concern was exactly the problem, so the ad-hoc one-sentence directive is deleted. Numbered steps 1–11 and 13 remain unchanged.

### Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — succeeds
- [x] `npx tsx --test src/resources/extensions/gsd/tests/commands-extract-learnings.test.ts` — 55/55 pass (24 pre-existing + 31 new)
- [x] `npm test` — 6855 pass, 0 regressions (the 4 failing tests are pre-existing on `main` and unrelated to this PR; verified via `git stash` comparison on the same base)
- [ ] Run `/gsd extract-learnings <MID>` on a real completed milestone and confirm that LEARNINGS.md, KNOWLEDGE.md (Patterns + Lessons rows), and DECISIONS.md all receive the expected new content.
- [ ] Run `/gsd auto` through a milestone completion and verify the same three-way persistence happens during the `complete-milestone` turn without the old step-12 directive being needed.

### Breaking changes

None. `/gsd extract-learnings` was non-functional, so changing its behaviour does not break any working workflow. The public TypeScript exports are preserved (`PhaseArtifacts`, `ExtractLearningsPromptContext`, `buildExtractLearningsPrompt`, etc.); `ExtractionStepsContext` and `buildExtractionStepsBlock` are purely additive.

---

🤖 Generated with Claude Opus 4.7 via Claude Code. All changes were reviewed, architecture and scope decisions were human-directed, and the test suite was designed to protect the contract, not just the implementation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a command and automatic workflow to extract structured milestone learnings (Decisions, Lessons, Patterns, Surprises); creates a milestone learnings file, appends Patterns/Lessons to project knowledge, and persists Decisions. Roadmap is now the primary milestone artefact and extraction includes deduplication and source attribution.

* **Documentation**
  * Documented the new command and milestone completion behavior.

* **Tests**
  * Expanded tests covering prompt composition, extraction steps, and milestone artefact handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
