### PR TITLE
fix(ci): move @next dist-tag when version already published

### DIFF
--- a/.github/workflows/next-publish.yml
+++ b/.github/workflows/next-publish.yml
@@ -92,7 +92,8 @@ jobs:
         run: |
           VERSION=$(node -e 'process.stdout.write(require("./package.json").version)')
           if npm view "gsd-pi@${VERSION}" version 2>/dev/null; then
-            echo "Version ${VERSION} already published — skipping"
+            echo "Version ${VERSION} already published — moving @next tag"
+            npm dist-tag add "gsd-pi@${VERSION}" next
           else
             npm publish --tag next
           fi


### PR DESCRIPTION
## Summary
- When the stamped pre-release version already exists on npm, `next-publish` was skipping the `npm publish` entirely — which also skipped the dist-tag update, leaving `@next` pinned to a stale version (observed: `2.33.1-dev.29a8268` persisted even after successful workflow runs stamping `2.75.0-next.*`).
- Now when the version is already published, we explicitly run `npm dist-tag add gsd-pi@<version> next` so the tag actually moves.

## Test plan
- [ ] Dispatch **Next Publish** on `main` — confirm the `already published` branch now moves `@next` instead of no-opping
- [ ] `npm dist-tag ls gsd-pi` shows `next: 2.75.0-next.<sha>`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the publishing workflow to reassign the `next` dist-tag to existing versions instead of skipping publication, ensuring proper version tagging consistency in the package registry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->