### PR TITLE
fix(gsd): honour git.snapshots preference in doctor snapshot paths (#4420)

### DIFF
--- a/src/resources/extensions/gsd/docs/preferences-reference.md
+++ b/src/resources/extensions/gsd/docs/preferences-reference.md
@@ -130,7 +130,7 @@ Setting `prefer_skills: []` does **not** disable skill discovery — it just mea
   - `auto_push`: boolean — automatically push commits to the remote after committing. Default: `false`.
   - `push_branches`: boolean — push the milestone branch to the remote after commits. Default: `false`.
   - `remote`: string — git remote name to push to. Default: `"origin"`.
-  - `snapshots`: boolean — create snapshot commits (WIP saves) during long-running tasks. Default: `true`.
+  - `snapshots`: boolean — create WIP snapshot commits (e.g. pre-dispatch and stale-uncommitted-changes safety commits emitted by the doctor). Set to `false` to suppress all doctor-initiated `gsd snapshot:` commits. Default: `true`.
   - `pre_merge_check`: boolean or `"auto"` — run pre-merge checks before merging a worktree back to the integration branch. `true` always runs, `false` never runs, `"auto"` runs when CI is detected. Default: `"auto"`.
   - `commit_type`: string — override the conventional commit type prefix. Must be one of: `feat`, `fix`, `refactor`, `docs`, `test`, `chore`, `perf`, `ci`, `build`, `style`. Default: inferred from diff content.
   - `main_branch`: string — the primary branch name for new git repos (e.g., `"main"`, `"master"`, `"trunk"`). Also used by `getMainBranch()` as the preferred branch when auto-detection is ambiguous. Default: `"main"`.

--- a/src/resources/extensions/gsd/doctor-git-checks.ts
+++ b/src/resources/extensions/gsd/doctor-git-checks.ts
@@ -369,9 +369,13 @@ export async function checkGitHealth(
   // auto-commit a safety snapshot so work isn't lost.
   try {
     const prefs = loadEffectiveGSDPreferences()?.preferences ?? {};
+    // `git.snapshots: false` is the canonical toggle that disables WIP
+    // snapshot commits — honour it here as well so both the proactive gate
+    // and the doctor-run path stay consistent (#4420).
+    const snapshotsEnabled = prefs.git?.snapshots !== false;
     const thresholdMinutes = prefs.stale_commit_threshold_minutes ?? 30;
 
-    if (thresholdMinutes > 0) {
+    if (snapshotsEnabled && thresholdMinutes > 0) {
       const dirty = nativeHasChanges(basePath);
       if (dirty) {
         const branch = nativeGetCurrentBranch(basePath);

--- a/src/resources/extensions/gsd/doctor-proactive.ts
+++ b/src/resources/extensions/gsd/doctor-proactive.ts
@@ -301,9 +301,12 @@ export async function preDispatchHealthGate(basePath: string): Promise<PreDispat
   try {
     if (nativeIsRepo(basePath)) {
       const prefs = loadEffectiveGSDPreferences()?.preferences ?? {};
+      // `git.snapshots: false` is the canonical toggle that disables WIP
+      // snapshot commits — honour it before touching the threshold path (#4420).
+      const snapshotsEnabled = prefs.git?.snapshots !== false;
       const thresholdMinutes = prefs.stale_commit_threshold_minutes ?? 30;
 
-      if (thresholdMinutes > 0 && nativeHasChanges(basePath)) {
+      if (snapshotsEnabled && thresholdMinutes > 0 && nativeHasChanges(basePath)) {
         const branch = nativeGetCurrentBranch(basePath);
         const lastEpoch = nativeLastCommitEpoch(basePath, branch || "HEAD");
         const nowEpoch = Math.floor(Date.now() / 1000);

--- a/src/resources/extensions/gsd/tests/integration/doctor-git.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/doctor-git.test.ts
@@ -696,6 +696,45 @@ describe('doctor-git', async () => {
       assert.deepStrictEqual(staleIssues.length, 0, "recent commit with dirty tree NOT flagged as stale");
     });
 
+    // ─── Test: stale_uncommitted_changes suppressed by git.snapshots:false (#4420) ──
+    test('stale_uncommitted_changes (suppressed by git.snapshots:false)', async () => {
+      const dir = createRepoWithActiveMilestone();
+      cleanups.push(dir);
+
+      const pastDate = new Date(Date.now() - 45 * 60 * 1000).toISOString();
+      run(`git commit --amend --no-edit --date="${pastDate}"`, dir);
+      execSync(`git commit --amend --no-edit`, {
+        cwd: dir,
+        stdio: ["ignore", "pipe", "pipe"],
+        encoding: "utf-8",
+        env: { ...process.env, GIT_COMMITTER_DATE: pastDate },
+      });
+
+      writeFileSync(join(dir, "README.md"), "# test\nmodified content\n");
+      writeFileSync(join(dir, ".gsd", "PREFERENCES.md"), `---\ngit:\n  snapshots: false\n---\n`);
+
+      const commitsBefore = run("git rev-list --count HEAD", dir);
+
+      const previousCwd = process.cwd();
+      process.chdir(dir);
+      try {
+        const detect = await runGSDDoctor(dir);
+        const staleIssues = detect.issues.filter(i => i.code === "stale_uncommitted_changes");
+        assert.deepStrictEqual(staleIssues.length, 0, "git.snapshots:false suppresses stale detection");
+
+        const fixed = await runGSDDoctor(dir, { fix: true });
+        assert.ok(
+          !fixed.fixesApplied.some(f => f.includes("gsd snapshot")),
+          `git.snapshots:false suppresses snapshot fix (got: ${JSON.stringify(fixed.fixesApplied)})`,
+        );
+      } finally {
+        process.chdir(previousCwd);
+      }
+
+      const commitsAfter = run("git rev-list --count HEAD", dir);
+      assert.strictEqual(commitsAfter, commitsBefore, "no snapshot commit was created when git.snapshots:false");
+    });
+
     // ─── Test: stale_uncommitted_changes NOT flagged when tree is clean ──
     test('stale_uncommitted_changes (no false positive on clean tree)', async () => {
       const dir = createRepoWithActiveMilestone();

--- a/src/resources/extensions/gsd/tests/integration/doctor-proactive.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/doctor-proactive.test.ts
@@ -316,6 +316,50 @@ describe('doctor-proactive', async () => {
       }
     });
 
+    test('health gate: git.snapshots:false suppresses stale-commit snapshot (#4420)', async () => {
+      // Build a repo whose HEAD commit is far enough in the past that the
+      // default stale-commit threshold (30 min) is exceeded, then dirty the
+      // tracked file so the snapshot path has material to commit.
+      const dir = realpathSync(mkdtempSync(join(tmpdir(), "doc-proactive-4420-")));
+      cleanups.push(dir);
+      const oldDate = "2020-01-01T00:00:00Z";
+      const env = { ...process.env, GIT_AUTHOR_DATE: oldDate, GIT_COMMITTER_DATE: oldDate };
+      execSync("git init", { cwd: dir, stdio: "ignore", env });
+      execSync("git config user.email test@test.com", { cwd: dir, stdio: "ignore", env });
+      execSync("git config user.name Test", { cwd: dir, stdio: "ignore", env });
+      writeFileSync(join(dir, "README.md"), "# test\n");
+      execSync("git add .", { cwd: dir, stdio: "ignore", env });
+      execSync('git commit -m init', { cwd: dir, stdio: "ignore", env });
+      execSync("git branch -M main", { cwd: dir, stdio: "ignore", env });
+      mkdirSync(join(dir, ".gsd"), { recursive: true });
+
+      writeFileSync(join(dir, "README.md"), "# test\n\ndirty\n");
+      assert.ok(run("git status --porcelain", dir).length > 0, "working tree is dirty");
+
+      writeFileSync(
+        join(dir, ".gsd", "PREFERENCES.md"),
+        `---\ngit:\n  snapshots: false\n---\n`,
+      );
+
+      const commitCountBefore = run("git rev-list --count HEAD", dir);
+
+      const previousCwd = process.cwd();
+      process.chdir(dir);
+      try {
+        const result = await preDispatchHealthGate(dir);
+        assert.ok(result.proceed, "gate proceeds when snapshots are disabled");
+        assert.ok(
+          !result.fixesApplied.some(f => f.includes("gsd snapshot")),
+          `no snapshot fix reported when git.snapshots:false (got: ${JSON.stringify(result.fixesApplied)})`,
+        );
+      } finally {
+        process.chdir(previousCwd);
+      }
+
+      const commitCountAfter = run("git rev-list --count HEAD", dir);
+      assert.strictEqual(commitCountAfter, commitCountBefore, "no snapshot commit was created");
+    });
+
   } finally {
     resetProactiveHealing();
     for (const dir of cleanups) {


### PR DESCRIPTION
## TL;DR

**What:** Make `git.snapshots: false` actually suppress the `gsd snapshot:` commits produced by `doctor-proactive` and `doctor-git-checks`.
**Why:** The preference was silently ignored — users who disabled snapshots still got pre-dispatch and stale-uncommitted-changes safety commits, as reported in #4420.
**How:** Short-circuit both doctor snapshot paths when `prefs.git?.snapshots === false`, add regression tests, and clarify the preferences reference.

## What

Two code paths emit `gsd snapshot:` commits when the working tree has stale uncommitted changes:

- `src/resources/extensions/gsd/doctor-proactive.ts` — pre-dispatch stale-uncommitted-changes watchdog (`gsd snapshot: pre-dispatch, …`).
- `src/resources/extensions/gsd/doctor-git-checks.ts` — `stale_uncommitted_changes` doctor check and fix (`gsd snapshot: uncommitted changes after …`).

Both now honour `git.snapshots` before evaluating the stale-commit threshold.

Also:
- `src/resources/extensions/gsd/docs/preferences-reference.md` — reword the `git.snapshots` entry to state explicitly that `false` suppresses all doctor-initiated `gsd snapshot:` commits.
- `src/resources/extensions/gsd/tests/integration/doctor-proactive.test.ts` — new regression test covering the pre-dispatch gate.
- `src/resources/extensions/gsd/tests/integration/doctor-git.test.ts` — new regression test covering the full doctor run (detection + fix).

## Why

`git.snapshots: false` is documented as the canonical toggle for WIP snapshot commits, but the two doctor snapshot paths only consulted `stale_commit_threshold_minutes`. The preference therefore had no effect on either flow, producing the exact symptom reported in #4420:

```
ca37291 gsd snapshot: pre-dispatch, uncommitted changes after 31m inactivity
da0cc31 gsd snapshot: pre-dispatch, uncommitted changes after 30m inactivity
d3215f5 gsd snapshot: pre-dispatch, uncommitted changes after 466m inactivity
```

Closes #4420

## How

```ts
const snapshotsEnabled = prefs.git?.snapshots !== false;
const thresholdMinutes = prefs.stale_commit_threshold_minutes ?? 30;

if (snapshotsEnabled && thresholdMinutes > 0 /* && working tree is dirty */) {
  // …create `gsd snapshot:` commit…
}
```

The check is placed before the threshold evaluation in both paths so no side effects (issue emission, `fixesApplied` entries, commits) are produced when snapshots are disabled. Other `nativeCommit` call sites were audited and are unrelated (different commit prefixes and semantics — `chore:`, `docs:`, worktree teardown, etc.).

The two regression tests were verified red-before / green-after by reverting just the guard and re-running each test. Each fails at the expected assertion without the fix and passes with it.

### Change type checklist

- [x] `fix` — Bug fix
- [ ] `feat` — New feature or capability
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

### Breaking changes

None. `git.snapshots` already exists in the preference schema with default `true`; this PR only makes the existing documented behaviour actually take effect when users set it to `false`.

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.resources.json` — clean
- [x] `node --test src/resources/extensions/gsd/tests/integration/doctor-proactive.test.ts` — 19/19 pass
- [x] `node --test src/resources/extensions/gsd/tests/integration/doctor-git.test.ts` — 25/25 pass
- [x] Regression tests verified red without the guard, green with it

## AI-assisted contribution

This PR is AI-assisted (Claude Opus 4.7). The diff, commit message, and this description were drafted with AI assistance; the author has reviewed and understands every change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The `git.snapshots` preference now properly suppresses automatic WIP snapshot commits when disabled.

* **Documentation**
  * Updated preference documentation with concrete examples of snapshot commit types and clarified that disabling this setting prevents all doctor-initiated snapshot commits.

* **Tests**
  * Added integration tests to verify snapshot suppression when the preference is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->