### PR TITLE
fix(gsd): resolve asset imports in post-execution checks (#4411)

### DIFF
--- a/src/resources/extensions/gsd/post-execution-checks.ts
+++ b/src/resources/extensions/gsd/post-execution-checks.ts
@@ -118,8 +118,12 @@ export function extractRelativeImports(
 
 /**
  * Check if a relative import resolves to an existing file.
- * Handles .ts, .tsx, .js, .jsx extensions and index files.
- * Also handles TypeScript ESM convention where imports use .js but resolve to .ts.
+ * Resolution order:
+ *   1. Imports carrying an explicit extension are checked as-is (handles assets
+ *      like .css/.scss/images/fonts and .json, not just code extensions).
+ *   2. TypeScript ESM convention where .js imports resolve to .ts files.
+ *   3. Extensionless imports resolved against .ts/.tsx/.js/.jsx/.mjs/.cjs.
+ *   4. Directory imports resolved against index.{ts,tsx,js,jsx,mjs,cjs}.
  */
 export function resolveImportPath(
   importPath: string,
@@ -128,6 +132,18 @@ export function resolveImportPath(
 ): { exists: boolean; resolvedPath: string | null } {
   const sourceDir = dirname(resolve(basePath, sourceFile));
   const extensions = [".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"];
+
+  // If the import already has an explicit extension, check it as-is first.
+  // This correctly resolves asset imports like .css, .scss, images, fonts
+  // without requiring each extension to be enumerated (issue #4411). We only
+  // do this when the import carries an extension so that extensionless module
+  // imports still flow through the TS ESM convention and index-file resolvers.
+  if (extname(importPath) !== "") {
+    const directPath = resolve(sourceDir, importPath);
+    if (existsSync(directPath)) {
+      return { exists: true, resolvedPath: directPath };
+    }
+  }
 
   // Handle TypeScript ESM convention: .js imports resolve to .ts files
   // e.g., import './types.js' -> ./types.ts
@@ -142,7 +158,7 @@ export function resolveImportPath(
     normalizedPath = importPath.slice(0, -4);
   }
 
-  // Try the normalized path with common extensions first
+  // Try the normalized path with common extensions
   for (const ext of extensions) {
     const fullPath = resolve(sourceDir, normalizedPath + ext);
     if (existsSync(fullPath)) {
@@ -155,17 +171,6 @@ export function resolveImportPath(
     const indexPath = resolve(sourceDir, normalizedPath, `index${ext}`);
     if (existsSync(indexPath)) {
       return { exists: true, resolvedPath: indexPath };
-    }
-  }
-
-  // Check if path already has extension (for .json, etc.)
-  const hasExt = [".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs", ".json"].some(
-    (ext) => importPath.endsWith(ext)
-  );
-  if (hasExt) {
-    const fullPath = resolve(sourceDir, importPath);
-    if (existsSync(fullPath)) {
-      return { exists: true, resolvedPath: fullPath };
     }
   }
 
@@ -227,11 +232,20 @@ export function checkImportResolution(
 
 // ─── Cross-Task Signature Check ──────────────────────────────────────────────
 
+/**
+ * Normalized function signature extracted from a source file.
+ * Used to compare definitions across tasks and detect signature drift.
+ */
 interface FunctionSignature {
+  /** Function or exported const name. */
   name: string;
+  /** Parameter list with defaults and comments stripped. */
   params: string;
+  /** Declared return type, or "void" when none is annotated. */
   returnType: string;
+  /** Source file the signature was extracted from. */
   file: string;
+  /** 1-based line number of the declaration. */
   lineNum: number;
 }
 

--- a/src/resources/extensions/gsd/post-execution-checks.ts
+++ b/src/resources/extensions/gsd/post-execution-checks.ts
@@ -138,10 +138,19 @@ export function resolveImportPath(
   // without requiring each extension to be enumerated (issue #4411). We only
   // do this when the import carries an extension so that extensionless module
   // imports still flow through the TS ESM convention and index-file resolvers.
-  if (extname(importPath) !== "") {
+  const explicitExt = extname(importPath);
+  if (explicitExt !== "") {
     const directPath = resolve(sourceDir, importPath);
     if (existsSync(directPath)) {
       return { exists: true, resolvedPath: directPath };
+    }
+    // Only .js/.jsx/.mjs/.cjs imports legitimately fall through for the TS
+    // ESM convention (.js → .ts). Any other explicit extension (.css, .json,
+    // .svg, images, fonts, .ts, .tsx, …) must stay unresolved when the direct
+    // path is missing — otherwise a stray `./missing.css.ts` could shadow a
+    // genuinely missing `./missing.css` import.
+    if (![".js", ".jsx", ".mjs", ".cjs"].includes(explicitExt)) {
+      return { exists: false, resolvedPath: null };
     }
   }
 

--- a/src/resources/extensions/gsd/tests/post-execution-checks.test.ts
+++ b/src/resources/extensions/gsd/tests/post-execution-checks.test.ts
@@ -275,6 +275,35 @@ describe("resolveImportPath", () => {
     assert.ok(!result.exists);
     assert.equal(result.resolvedPath, null);
   });
+
+  // Pin TS ESM convention: explicit .js import must still resolve to the
+  // sibling .ts file when only the .ts exists.
+  test("resolves .js import to sibling .ts (TS ESM convention)", (t) => {
+    const dir = mkdtempSync(join(tmpdir(), "post-exec-test-tsesm-"));
+    t.after(() => rmSync(dir, { recursive: true, force: true }));
+    mkdirSync(join(dir, "src"), { recursive: true });
+    writeFileSync(join(dir, "src", "types.ts"), "export {};");
+    writeFileSync(join(dir, "src", "main.ts"), "");
+
+    const result = resolveImportPath("./types.js", "src/main.ts", dir);
+    assert.ok(result.exists);
+    assert.ok(result.resolvedPath?.endsWith("types.ts"));
+  });
+
+  // Non-code explicit extensions must not fall through to code-extension
+  // shadows: a missing ./missing.css must stay unresolved even if a stray
+  // ./missing.css.ts happens to exist.
+  test("missing asset import does not match code-extension shadow", (t) => {
+    const dir = mkdtempSync(join(tmpdir(), "post-exec-test-shadow-"));
+    t.after(() => rmSync(dir, { recursive: true, force: true }));
+    mkdirSync(join(dir, "src"), { recursive: true });
+    writeFileSync(join(dir, "src", "missing.css.ts"), "export {};");
+    writeFileSync(join(dir, "src", "main.ts"), "");
+
+    const result = resolveImportPath("./missing.css", "src/main.ts", dir);
+    assert.ok(!result.exists);
+    assert.equal(result.resolvedPath, null);
+  });
 });
 
 // ─── Import Resolution Check Tests ───────────────────────────────────────────

--- a/src/resources/extensions/gsd/tests/post-execution-checks.test.ts
+++ b/src/resources/extensions/gsd/tests/post-execution-checks.test.ts
@@ -10,7 +10,7 @@
 import { describe, test } from "node:test";
 import assert from "node:assert/strict";
 import { tmpdir } from "node:os";
-import { mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, writeFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 
 import {
@@ -229,6 +229,52 @@ describe("resolveImportPath", () => {
       rmSync(tempDir, { recursive: true, force: true });
     }
   });
+
+  // Regression: issue #4411 — side-effect asset imports (CSS/SCSS/images/fonts)
+  // were misclassified as unresolved because only code extensions were tried.
+  test("resolves side-effect CSS import with explicit extension", (t) => {
+    const dir = mkdtempSync(join(tmpdir(), "post-exec-test-css-"));
+    t.after(() => rmSync(dir, { recursive: true, force: true }));
+    // frontend/src/routes/root.tsx imports '../../styles/globals.css' →
+    // resolves to frontend/styles/globals.css.
+    mkdirSync(join(dir, "frontend", "src", "routes"), { recursive: true });
+    mkdirSync(join(dir, "frontend", "styles"), { recursive: true });
+    writeFileSync(join(dir, "frontend", "styles", "globals.css"), "");
+    writeFileSync(
+      join(dir, "frontend", "src", "routes", "root.tsx"),
+      "import '../../styles/globals.css';"
+    );
+
+    const result = resolveImportPath(
+      "../../styles/globals.css",
+      "frontend/src/routes/root.tsx",
+      dir
+    );
+    assert.ok(result.exists, "CSS side-effect import should resolve");
+    assert.ok(result.resolvedPath?.endsWith("globals.css"));
+  });
+
+  test("resolves SCSS asset import", (t) => {
+    const dir = mkdtempSync(join(tmpdir(), "post-exec-test-scss-"));
+    t.after(() => rmSync(dir, { recursive: true, force: true }));
+    mkdirSync(join(dir, "src"), { recursive: true });
+    writeFileSync(join(dir, "src", "theme.scss"), "");
+    writeFileSync(join(dir, "src", "main.ts"), "");
+
+    const result = resolveImportPath("./theme.scss", "src/main.ts", dir);
+    assert.ok(result.exists);
+  });
+
+  test("still fails for missing asset import", (t) => {
+    const dir = mkdtempSync(join(tmpdir(), "post-exec-test-missing-"));
+    t.after(() => rmSync(dir, { recursive: true, force: true }));
+    mkdirSync(join(dir, "src"), { recursive: true });
+    writeFileSync(join(dir, "src", "main.ts"), "");
+
+    const result = resolveImportPath("./missing.css", "src/main.ts", dir);
+    assert.ok(!result.exists);
+    assert.equal(result.resolvedPath, null);
+  });
 });
 
 // ─── Import Resolution Check Tests ───────────────────────────────────────────
@@ -348,6 +394,30 @@ describe("checkImportResolution", () => {
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }
+  });
+
+  // Regression: issue #4411 — CSS side-effect import inside a .tsx key_file
+  // must not produce a blocking post-execution failure.
+  test("does not block on valid CSS side-effect import in .tsx key_file", (t) => {
+    const dir = mkdtempSync(join(tmpdir(), "post-exec-test-asset-"));
+    t.after(() => rmSync(dir, { recursive: true, force: true }));
+    // frontend/src/routes/root.tsx imports '../../styles/globals.css' →
+    // resolves to frontend/styles/globals.css.
+    mkdirSync(join(dir, "frontend", "src", "routes"), { recursive: true });
+    mkdirSync(join(dir, "frontend", "styles"), { recursive: true });
+    writeFileSync(join(dir, "frontend", "styles", "globals.css"), "");
+    writeFileSync(
+      join(dir, "frontend", "src", "routes", "root.tsx"),
+      "import '../../styles/globals.css';\nexport default function Root() { return null; }"
+    );
+
+    const task = createTask({
+      id: "T03",
+      key_files: ["frontend/src/routes/root.tsx"],
+    });
+
+    const results = checkImportResolution(task, [], dir);
+    assert.deepEqual(results, [], "valid CSS import must not be flagged");
   });
 });
 


### PR DESCRIPTION
## TL;DR

**What:** `resolveImportPath()` now resolves valid asset imports (CSS/SCSS/images/fonts/any explicit extension) instead of falsely flagging them as unresolved.
**Why:** A valid `import '../../styles/globals.css';` side-effect import was classified as a blocking post-execution failure, pausing auto-mode for human review even though the task had completed and passed its main verification (#4411).
**How:** When the import carries an explicit extension, check it directly with `existsSync` before falling back to the existing TS ESM normalization, extension loop, and index-file resolution.

## What

- **`src/resources/extensions/gsd/post-execution-checks.ts`** — `resolveImportPath()` gets a first step: if `extname(importPath) !== ""`, resolve the path as written and return on hit. The legacy `hasExt` branch (which hard-coded only `.json` alongside code extensions) is removed — fully superseded by the new direct check. Also adds a docstring to the internal `FunctionSignature` interface and updates the `resolveImportPath` header to reflect the new resolution order.
- **`src/resources/extensions/gsd/tests/post-execution-checks.test.ts`** — four regression tests using `t.after()` + `mkdtempSync` (per CONTRIBUTING.md testing standards):
  - `resolves side-effect CSS import with explicit extension`
  - `resolves SCSS asset import`
  - `still fails for missing asset import` (guards against silently masking real failures)
  - `does not block on valid CSS side-effect import in .tsx key_file` (end-to-end through `checkImportResolution`)

## Why

In auto-mode, `checkImportResolution()` extracts every relative import from a completed task's `key_files` and calls `resolveImportPath()`. Prior to this fix, `resolveImportPath()` only enumerated `.ts/.tsx/.js/.jsx/.mjs/.cjs` and `.json`. Any other explicit extension — the common case for stylesheet, image, and font side-effect imports — was never tried directly.

The resulting false unresolved finding became a blocking post-execution failure in `auto-verification.ts`, and auto-mode paused immediately with `Post-execution checks failed — cross-task consistency issue detected, pausing for human review`, with no automatic recovery path.

Closes #4411.

## How

The fix matches the concrete suggestion in the issue. `resolveImportPath()` now starts with:

```ts
if (extname(importPath) !== "") {
  const directPath = resolve(sourceDir, importPath);
  if (existsSync(directPath)) {
    return { exists: true, resolvedPath: directPath };
  }
}
```

The `extname` guard is intentional: an extensionless module import like `./utils` must not resolve to the directory itself when `./utils/index.ts` is the intended target. Only imports carrying an explicit extension take the direct path; everything else flows through the existing TS ESM normalization (`.js` → `.ts`), the extension loop, and the index-file loop unchanged.

The change is strictly less false-positive than the prior logic: every case that previously resolved still resolves (including `.json`, the only non-code extension the old code handled), and previously missed asset paths now resolve when they exist on disk. Missing assets still produce a blocking failure — verified by the `still fails for missing asset import` test.

## Change type

- [x] `fix` — Bug fix

## Verification

- Regression tests verified to fail before the fix and pass after.
- 41/41 tests in `post-execution-checks.test.ts` pass via both `node --test --experimental-strip-types` and the CI-compiled runner (`npm run test:compile` + `dist-test/` path).
- `npx tsc --noEmit` clean.

---

> AI-assisted PR (Claude Code). Reviewed and tested locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved import-resolution behavior for non-code assets: explicit extensions (e.g., .css/.scss) are checked first and will not be incorrectly resolved to code files; explicit unknown extensions fail fast.

* **Tests**
  * Added and expanded tests covering asset imports, explicit-missing assets, and regression cases to prevent incorrect fallthrough.

* **Documentation**
  * Clarified import-resolution behavior in internal docs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->