### PR TITLE
fix(gsd): reactivate deferred slice on plan-slice

### DIFF
--- a/src/resources/extensions/gsd/tests/plan-slice.test.ts
+++ b/src/resources/extensions/gsd/tests/plan-slice.test.ts
@@ -148,6 +148,23 @@ test('handlePlanSlice surfaces render failures without changing parse-visible ta
   }
 });
 
+test('handlePlanSlice reactivates a deferred parent slice to pending', async (t) => {
+  const base = makeTmpBase();
+  t.after(() => cleanup(base));
+  openDatabase(join(base, '.gsd', 'gsd.db'));
+
+  insertMilestone({ id: 'M001', title: 'Milestone', status: 'active' });
+  insertSlice({ id: 'S02', milestoneId: 'M001', title: 'Planning slice', status: 'deferred', demo: 'Rendered plans exist.' });
+
+  const result = await handlePlanSlice(validParams(), base);
+  assert.ok(!('error' in result), `unexpected error: ${'error' in result ? result.error : ''}`);
+
+  const slice = getSlice('M001', 'S02');
+  assert.ok(slice);
+  assert.equal(slice?.status, 'pending', 'deferred slice must be reactivated to pending so auto-mode can dispatch it');
+  assert.equal(slice?.goal, 'Persist slice planning through the DB.');
+});
+
 test('handlePlanSlice reruns idempotently and refreshes parse-visible state', async () => {
   const base = makeTmpBase();
   openDatabase(join(base, '.gsd', 'gsd.db'));

--- a/src/resources/extensions/gsd/tools/plan-slice.ts
+++ b/src/resources/extensions/gsd/tools/plan-slice.ts
@@ -1,5 +1,5 @@
 import { clearParseCache } from "../files.js";
-import { isClosedStatus } from "../status-guards.js";
+import { isClosedStatus, isDeferredStatus } from "../status-guards.js";
 import { isNonEmptyString, validateStringArray } from "../validation.js";
 import {
   transaction,
@@ -9,6 +9,7 @@ import {
   upsertSlicePlanning,
   upsertTaskPlanning,
   insertGateRow,
+  updateSliceStatus,
 } from "../gsd-db.js";
 import type { GateId } from "../types.js";
 import { invalidateStateCache } from "../state.js";
@@ -164,6 +165,10 @@ export async function handlePlanSlice(
       if (isClosedStatus(parentSlice.status)) {
         guardError = `cannot re-plan slice ${params.sliceId}: it is already complete — use gsd_slice_reopen first`;
         return;
+      }
+
+      if (isDeferredStatus(parentSlice.status)) {
+        updateSliceStatus(params.milestoneId, params.sliceId, "pending");
       }
 
       upsertSlicePlanning(params.milestoneId, params.sliceId, {


### PR DESCRIPTION
## TL;DR

**What:** `plan-slice` now reactivates a deferred parent slice to `pending`.
**Why:** Without it, auto-mode plans the slice successfully and then hard-blocks with `No slice eligible — check dependency ordering`.
**How:** Inside the existing `plan-slice` transaction, after the guard checks, flip `deferred → pending` via `updateSliceStatus`.

## What

- `src/resources/extensions/gsd/tools/plan-slice.ts` — inside the transaction, after the `isClosedStatus` guard, call `updateSliceStatus(..., "pending")` when `isDeferredStatus(parentSlice.status)` is true. Imports `isDeferredStatus` and `updateSliceStatus`.
- `src/resources/extensions/gsd/tests/plan-slice.test.ts` — new regression test that seeds a `deferred` parent slice, runs `handlePlanSlice`, and asserts the slice status is `pending` afterwards. Uses `t.after()` per `CONTRIBUTING.md`.

## Why

`plan-slice` accepted planning a deferred slice — it wrote plan rows and rendered artifacts — but never cleared the `deferred` status. State derivation in `state.ts` filters deferred slices out of eligibility, so the next auto-mode iteration saw no eligible slice and terminated.

This was the most dangerous failure mode: the tool reported success, the plan appeared on disk, but the dispatcher stranded. Manual recovery required re-planning the milestone to re-upsert the slice as pending.

The issue suggests two options: reactivate automatically, or fail loudly. The preferred option (reactivation) is implemented here — consistent with `reassess-roadmap`, which inserts new slices as `pending` via `insertSlice()`.

Closes #4407

## How

- Guard + write stay inside the single `transaction()` block that `plan-slice` already uses to prevent TOCTOU against concurrent state changes.
- The status flip happens after the `isClosedStatus` guard, so `complete`/`done`/`skipped` slices still get rejected with the existing "use gsd_slice_reopen first" error.
- `isDeferredStatus()` is used instead of a literal `status === "deferred"` comparison, matching the single-source-of-truth convention documented in `status-guards.ts`.
- Regression test uses `t.after()` for cleanup per `CONTRIBUTING.md` §Testing standards.

## Change type

- [x] `fix` — Bug fix
- [ ] `feat` — New feature or capability
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Breaking changes

None. Behavior only changes for the previously broken path (deferred slice being planned).

## AI assistance

This PR was written with AI assistance. All code was reviewed and verified locally: `npx tsx --test` passes (6/6 in `plan-slice.test.ts`, 13/13 in `status-guards.test.ts`) and `npx tsc --noEmit` is clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where deferred parent slices were not being automatically reactivated to pending status during plan operations.

* **Tests**
  * Added integration test to verify proper state transitions for deferred slices in planning workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->