### PR TITLE
fix(remote-questions): normalize remote answers to RoundResult shape

### DIFF
--- a/src/resources/extensions/ask-user-questions.ts
+++ b/src/resources/extensions/ask-user-questions.ts
@@ -37,7 +37,7 @@ interface RemoteResultDetails {
 	threadUrl?: string;
 	status?: string;
 	questions?: Question[];
-	response?: import("./remote-questions/types.js").RemoteAnswer;
+	response?: RoundResult;
 	error?: boolean;
 }
 
@@ -435,10 +435,13 @@ export default function AskUserQuestions(pi: ExtensionAPI) {
 							lines.push(`${theme.fg("accent", q.header)}: ${theme.fg("dim", "(no answer)")}`);
 							continue;
 						}
-						const answerText = answer.answers.length > 0 ? answer.answers.join(", ") : "(custom)";
+						const selected = answer.selected;
+						const answerText = Array.isArray(selected)
+							? (selected.length > 0 ? selected.join(", ") : "(custom)")
+							: (selected || "(custom)");
 						let line = `${theme.fg("success", "✓ ")}${theme.fg("accent", q.header)}: ${answerText}`;
-						if (answer.user_note) {
-							line += ` ${theme.fg("muted", `[note: ${answer.user_note}]`)}`;
+						if (answer.notes) {
+							line += ` ${theme.fg("muted", `[note: ${answer.notes}]`)}`;
 						}
 						lines.push(line);
 					}

--- a/src/resources/extensions/gsd/tests/register-hooks-depth-verification.test.ts
+++ b/src/resources/extensions/gsd/tests/register-hooks-depth-verification.test.ts
@@ -10,6 +10,7 @@ import {
   resetWriteGateState,
   shouldBlockContextArtifactSave,
 } from "../bootstrap/write-gate.ts";
+import { toRoundResultResponse } from "../../remote-questions/manager.ts";
 
 function makeTempDir(prefix: string): string {
   const dir = join(
@@ -93,5 +94,71 @@ test("register-hooks unlocks milestone depth verification from question id witho
     shouldBlockContextArtifactSave("CONTEXT", "M001").block,
     false,
     "question-id milestone inference should unlock the matching milestone context write",
+  );
+});
+
+test("register-hooks clears depth gate when remote (Telegram/Slack/Discord) answer is normalized (#4406)", async (t) => {
+  const dir = makeTempDir("remote");
+  const originalCwd = process.cwd();
+  process.chdir(dir);
+  resetWriteGateState();
+
+  t.after(() => {
+    resetWriteGateState();
+    process.chdir(originalCwd);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  const handlers = new Map<string, Array<(event: any, ctx?: any) => Promise<void> | void>>();
+  const pi = {
+    on(event: string, handler: (event: any, ctx?: any) => Promise<void> | void) {
+      const existing = handlers.get(event) ?? [];
+      existing.push(handler);
+      handlers.set(event, existing);
+    },
+  } as any;
+
+  registerHooks(pi, []);
+
+  const questionId = "depth_verification_M002_confirm";
+  const questions = [
+    {
+      id: questionId,
+      question: "Do you agree?",
+      options: [
+        { label: "Yes, you got it (Recommended)" },
+        { label: "Needs adjustment" },
+      ],
+    },
+  ];
+
+  for (const handler of handlers.get("tool_call") ?? []) {
+    await handler({ toolName: "ask_user_questions", input: { questions } });
+  }
+  assert.equal(getPendingGate(), questionId);
+
+  // Simulate the normalized response the remote manager now emits:
+  // a Telegram button press returns a RemoteAnswer that is fed through
+  // toRoundResultResponse before reaching details.response.
+  const remoteAnswer = {
+    answers: {
+      [questionId]: { answers: ["Yes, you got it (Recommended)"] },
+    },
+  };
+  const normalized = toRoundResultResponse(remoteAnswer);
+
+  for (const handler of handlers.get("tool_result") ?? []) {
+    await handler({
+      toolName: "ask_user_questions",
+      input: { questions },
+      details: { response: normalized },
+    });
+  }
+
+  assert.equal(getPendingGate(), null, "normalized remote answer must clear the gate");
+  assert.equal(
+    shouldBlockContextArtifactSave("CONTEXT", "M002").block,
+    false,
+    "remote confirmation must unlock the matching milestone context write",
   );
 });

--- a/src/resources/extensions/remote-questions/manager.ts
+++ b/src/resources/extensions/remote-questions/manager.ts
@@ -4,6 +4,7 @@
 
 import { randomUUID } from "node:crypto";
 import type { ChannelAdapter, RemotePrompt, RemoteQuestion, RemoteAnswer } from "./types.js";
+import type { RoundResult } from "../shared/interview-ui.js";
 import { resolveRemoteConfig, type ResolvedConfig } from "./config.js";
 import { DiscordAdapter } from "./discord-adapter.js";
 import { SlackAdapter } from "./slack-adapter.js";
@@ -135,10 +136,21 @@ export async function tryRemoteQuestions(
       promptId: prompt.id,
       threadUrl: dispatch.ref.threadUrl ?? null,
       questions,
-      response: answer,
+      response: toRoundResultResponse(answer),
       status: "answered",
     },
   };
+}
+
+/** Normalize a RemoteAnswer to the RoundResult shape consumed by the gsd write-gate hook. */
+export function toRoundResultResponse(answer: RemoteAnswer): RoundResult {
+  const normalized: RoundResult["answers"] = {};
+  for (const [id, data] of Object.entries(answer.answers)) {
+    const list = data.answers ?? [];
+    const selected: string | string[] = list.length <= 1 ? (list[0] ?? "") : list;
+    normalized[id] = { selected, notes: data.user_note ?? "" };
+  }
+  return { endInterview: false, answers: normalized };
 }
 
 function createPrompt(questions: QuestionInput[], config: ResolvedConfig): RemotePrompt {

--- a/src/resources/extensions/remote-questions/tests/remote-answer-normalization.test.ts
+++ b/src/resources/extensions/remote-questions/tests/remote-answer-normalization.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Regression tests for #4406 — remote-channel answers must be normalized to
+ * the RoundResult shape { selected, notes } so the depth-verification gate
+ * hook in gsd/bootstrap/register-hooks.ts recognizes them. Before the fix,
+ * Telegram/Slack/Discord answers arrived as { answers: string[], user_note }
+ * and `answer.selected` was always undefined, leaving the gate locked.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { toRoundResultResponse } from "../manager.ts";
+import type { RemoteAnswer } from "../types.ts";
+import { isDepthConfirmationAnswer } from "../../gsd/bootstrap/write-gate.ts";
+
+const STANDARD_OPTIONS = [
+  { label: "Yes, you got it (Recommended)" },
+  { label: "Not quite — let me clarify" },
+];
+
+test("remote normalization: single-select Telegram answer clears depth gate (#4406)", () => {
+  const remote: RemoteAnswer = {
+    answers: {
+      depth_verification_confirm: { answers: ["Yes, you got it (Recommended)"] },
+    },
+  };
+
+  const normalized = toRoundResultResponse(remote);
+  const answer = normalized.answers.depth_verification_confirm;
+
+  assert.equal(answer.selected, "Yes, you got it (Recommended)");
+  assert.equal(answer.notes, "");
+  assert.equal(
+    isDepthConfirmationAnswer(answer.selected, STANDARD_OPTIONS),
+    true,
+    "normalized remote answer must unlock the depth-verification gate",
+  );
+});
+
+test("remote normalization: multi-select answers stay as arrays", () => {
+  const remote: RemoteAnswer = {
+    answers: {
+      multi_q: { answers: ["A", "B"] },
+    },
+  };
+
+  const { answers } = toRoundResultResponse(remote);
+  assert.deepEqual(answers.multi_q.selected, ["A", "B"]);
+  assert.equal(answers.multi_q.notes, "");
+});
+
+test("remote normalization: user_note maps to notes", () => {
+  const remote: RemoteAnswer = {
+    answers: {
+      q1: { answers: ["Not quite — let me clarify"], user_note: "Please include timeouts" },
+    },
+  };
+
+  const { answers } = toRoundResultResponse(remote);
+  assert.equal(answers.q1.selected, "Not quite — let me clarify");
+  assert.equal(answers.q1.notes, "Please include timeouts");
+});
+
+test("remote normalization: empty answers array collapses to empty string (never undefined)", () => {
+  const remote: RemoteAnswer = {
+    answers: {
+      q1: { answers: [], user_note: "No response provided" },
+    },
+  };
+
+  const { answers } = toRoundResultResponse(remote);
+  assert.equal(answers.q1.selected, "");
+  assert.equal(answers.q1.notes, "No response provided");
+  // Must NOT accidentally pass the gate when no selection was made.
+  assert.equal(isDepthConfirmationAnswer(answers.q1.selected, STANDARD_OPTIONS), false);
+});
+
+test("remote normalization: independent entries per question id", () => {
+  const remote: RemoteAnswer = {
+    answers: {
+      depth_verification_M001_confirm: { answers: ["Yes, you got it (Recommended)"] },
+      followup: { answers: ["Option A", "Option B"], user_note: "extra" },
+    },
+  };
+
+  const { answers } = toRoundResultResponse(remote);
+  assert.equal(answers.depth_verification_M001_confirm.selected, "Yes, you got it (Recommended)");
+  assert.equal(answers.depth_verification_M001_confirm.notes, "");
+  assert.deepEqual(answers.followup.selected, ["Option A", "Option B"]);
+  assert.equal(answers.followup.notes, "extra");
+});

--- a/src/resources/extensions/remote-questions/tests/remote-answer-normalization.test.ts
+++ b/src/resources/extensions/remote-questions/tests/remote-answer-normalization.test.ts
@@ -28,6 +28,7 @@ test("remote normalization: single-select Telegram answer clears depth gate (#44
   const normalized = toRoundResultResponse(remote);
   const answer = normalized.answers.depth_verification_confirm;
 
+  assert.equal(normalized.endInterview, false);
   assert.equal(answer.selected, "Yes, you got it (Recommended)");
   assert.equal(answer.notes, "");
   assert.equal(


### PR DESCRIPTION
## TL;DR

**What:** Normalize answers from remote channels (Telegram, Slack, Discord) to the canonical `RoundResult` shape before handing them to the gsd write-gate hook.
**Why:** Remote answers arrived as `{answers: string[], user_note?}` while consumers read `{selected, notes}`, so `depth_verification` gates stayed hard-blocked forever when users replied remotely — #4406.
**How:** Added `toRoundResultResponse(answer)` in the remote-questions manager, tightened the `RemoteResultDetails.response` type, fixed the matching TUI renderer branch, and added unit + integration tests for the full pipeline.

## What

- `src/resources/extensions/remote-questions/manager.ts` — new exported helper `toRoundResultResponse(answer: RemoteAnswer): RoundResult`; `tryRemoteQuestions` now sets `details.response` to the normalized shape.
- `src/resources/extensions/ask-user-questions.ts` — `RemoteResultDetails.response` retyped from `RemoteAnswer` to `RoundResult`; `renderResult` remote branch reads `.selected` / `.notes` instead of the obsolete `.answers` / `.user_note` fields.
- `src/resources/extensions/remote-questions/tests/remote-answer-normalization.test.ts` — new unit suite: single-select Telegram regression (#4406), multi-select preservation, `user_note` → `notes` mapping, empty-answers fallback, multi-question independence.
- `src/resources/extensions/gsd/tests/register-hooks-depth-verification.test.ts` — new integration test feeds a Telegram-shaped `RemoteAnswer` through `toRoundResultResponse` and the full `registerHooks` pipeline, asserting the pending gate clears and milestone `CONTEXT` writes unlock.

No changes to adapters, wire formats, the LLM-facing tool output, persisted prompt records, or public docs (remote-questions docs already cover Telegram).

## Why

Forensics on the original session (Telegram button press → callback `{q.id}:{idx}` → `parseTelegramResponse`) showed the remote manager emitting

```js
details.response = { answers: { [id]: { answers: ["Yes, you got it (Recommended)"] } } }
```

while `src/resources/extensions/gsd/bootstrap/register-hooks.ts` reads `details.response.answers[id].selected`. `answer.selected` was always `undefined`, so `isDepthConfirmationAnswer` returned `false`, the pending gate never cleared, and every subsequent tool call hit `HARD BLOCK`. The DISCUSSION.md logger in the same hook and the TUI `renderResult` remote branch also relied on the same stale shape.

Closes #4406

## How

**Single source of truth for `details.response`.** The local interview UI already produces `RoundResult` (`{selected, notes}`). The remote path now normalizes `RemoteAnswer` (`{answers: string[], user_note?}`) to the same shape inside the manager before publishing it. Adapters and the internal `RemoteAnswer` type are untouched — only the external consumer contract changes.

Shape rules in `toRoundResultResponse`:
- `answers.length === 1` → `selected: string`
- `answers.length > 1` → `selected: string[]` (multi-select)
- `answers.length === 0` → `selected: ""` (never `undefined`; prevents accidental gate bypass on empty input)
- `user_note ?? ""` → `notes`

Alternatives considered: making the hook tolerant of both shapes. Rejected because it would leave the stale shape leaking into two more consumers (TUI renderer, DISCUSSION.md logger), and because keeping one canonical shape is simpler and less error-prone.

## Test plan

- [x] `npm run typecheck:extensions` — clean
- [x] `node --test` across `write-gate.test.ts`, `remote-questions/tests/*`, and `register-hooks-depth-verification.test.ts` — 54/54 passing, including the new regression + integration tests
- [x] Manual trace of the Telegram session from the issue forensics against the new code path — gate clears on `Yes, you got it (Recommended)` callback
- [ ] Suggested manual follow-up by a reviewer: run `/gsd auto` with a Telegram adapter configured, trigger a `depth_verification` gate, press the Recommended button in Telegram, confirm the agent proceeds to write `M…-CONTEXT.md`

## Notes

AI-assisted PR (per CONTRIBUTING §AI-assisted contributions). One concern per PR. No drive-by formatting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized how answers from remote channels are normalized and rendered (single vs. multi-select).

* **Bug Fixes**
  * Remote answers now correctly unlock milestone/context saves when a normalized confirmation is received.
  * Empty or missing selections display as "(custom)"; notes are read from the normalized notes field.

* **Tests**
  * Added tests covering remote answer normalization and depth-verification behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->