### PR TITLE
fix(gsd): preserve ROADMAP.md sections after projection hook

### DIFF
--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -735,7 +735,7 @@ export async function postUnitPreVerification(pctx: PostUnitContext, opts?: PreV
         try {
           const { milestone: mid, slice: sid } = parseUnitId(s.currentUnit.id);
           if (mid && sid) {
-            const regenerated = regenerateIfMissing(s.basePath, mid, sid, "PLAN");
+            const regenerated = await regenerateIfMissing(s.basePath, mid, sid, "PLAN");
             if (regenerated) {
               // Re-check after regeneration
               triggerArtifactVerified = verifyExpectedArtifact(s.currentUnit.type, s.currentUnit.id, s.basePath);

--- a/src/resources/extensions/gsd/markdown-renderer.ts
+++ b/src/resources/extensions/gsd/markdown-renderer.ts
@@ -169,7 +169,7 @@ function renderRoadmapMarkdown(milestone: MilestoneRow, slices: SliceRow[]): str
   lines.push("## Slices");
   lines.push("");
   for (const slice of slices) {
-    const done = slice.status === "complete" ? "x" : " ";
+    const done = isClosedStatus(slice.status) ? "x" : " ";
     const depends = `[${(slice.depends ?? []).join(",")}]`;
     lines.push(`- [${done}] **${slice.id}: ${slice.title}** \`risk:${slice.risk}\` \`depends:${depends}\``);
     lines.push(`  > After this: ${slice.demo}`);

--- a/src/resources/extensions/gsd/markdown-renderer.ts
+++ b/src/resources/extensions/gsd/markdown-renderer.ts
@@ -496,7 +496,7 @@ export async function renderRoadmapCheckboxes(
   // Apply checkbox patches for each slice
   let updated = content;
   for (const slice of slices) {
-    const isDone = slice.status === "complete";
+    const isDone = isClosedStatus(slice.status);
     const sid = slice.id;
 
     if (isDone) {
@@ -821,19 +821,19 @@ export function detectStaleRenders(basePath: string): StaleEntry[] {
         const parsed = parseRoadmap(content);
 
         for (const slice of slices) {
-          const isCompleteInDb = slice.status === "complete";
+          const isCompleteInDb = isClosedStatus(slice.status);
           const roadmapSlice = parsed.slices.find((s: { id: string }) => s.id === slice.id);
           if (!roadmapSlice) continue;
 
           if (isCompleteInDb && !roadmapSlice.done) {
             stale.push({
               path: roadmapPath,
-              reason: `${slice.id} is complete in DB but unchecked in roadmap`,
+              reason: `${slice.id} is closed in DB but unchecked in roadmap`,
             });
           } else if (!isCompleteInDb && roadmapSlice.done) {
             stale.push({
               path: roadmapPath,
-              reason: `${slice.id} is not complete in DB but checked in roadmap`,
+              reason: `${slice.id} is not closed in DB but checked in roadmap`,
             });
           }
         }

--- a/src/resources/extensions/gsd/tests/complete-slice.test.ts
+++ b/src/resources/extensions/gsd/tests/complete-slice.test.ts
@@ -231,13 +231,11 @@ console.log('\n=== complete-slice: handler happy path ===');
     assertMatch(uatContent, /Milestone:\*\* M001/, 'UAT should reference milestone');
     assertMatch(uatContent, /Smoke Test/, 'UAT should contain smoke test from params');
 
-    // (c) Verify roadmap shows S01 complete (✅) and S02 pending (⬜) in table format
-    // Projection renders roadmap as a Slice Overview table, not checkbox list
+    // (c) Verify roadmap shows S01 complete ([x]) and S02 pending ([ ]) in checkbox list.
+    // Authoritative renderer (renderRoadmapFromDb) emits a checkbox list (#4402).
     const roadmapContent = fs.readFileSync(roadmapPath, 'utf-8');
-    assertMatch(roadmapContent, /\| S01 \|/, 'S01 should appear in roadmap table');
-    assertTrue(roadmapContent.includes('✅'), 'completed S01 should show ✅ in roadmap table');
-    assertMatch(roadmapContent, /\| S02 \|/, 'S02 should appear in roadmap table');
-    assertTrue(roadmapContent.includes('⬜'), 'pending S02 should show ⬜ in roadmap table');
+    assertMatch(roadmapContent, /- \[x\] \*\*S01:/, 'completed S01 should be a checked checkbox list item');
+    assertMatch(roadmapContent, /- \[ \] \*\*S02:/, 'pending S02 should be an unchecked checkbox list item');
 
     // (d) Verify full_summary_md and full_uat_md stored in DB for D004 recovery
     const sliceAfter = getSlice('M001', 'S01');

--- a/src/resources/extensions/gsd/tests/integration/integration-proof.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/integration-proof.test.ts
@@ -356,10 +356,10 @@ test("full lifecycle: migration through completion through doctor", async (t) =>
       assert.match(sliceSummary, /Core feature proven/, "Slice summary should contain one-liner");
     }
 
-    // Verify roadmap checkbox toggled
+    // Verify roadmap checkbox toggled — authoritative renderer emits a checkbox list.
     const roadmapPath = join(base, ".gsd", "milestones", "M001", "M001-ROADMAP.md");
     const roadmapAfter = readFileSync(roadmapPath, "utf-8");
-    assert.ok(roadmapAfter.includes("\u2705"), "S01 should be checked in roadmap (✅ emoji in table format)");
+    assert.match(roadmapAfter, /- \[x\] \*\*S01:/, "S01 should be checked ([x]) in roadmap");
 
     // Verify slice status in DB
     const sliceRow = getSlice("M001", "S01");

--- a/src/resources/extensions/gsd/tests/plan-milestone-boundary-map-preservation.test.ts
+++ b/src/resources/extensions/gsd/tests/plan-milestone-boundary-map-preservation.test.ts
@@ -1,0 +1,102 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, rmSync, readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { openDatabase, closeDatabase } from '../gsd-db.ts';
+import { handlePlanMilestone } from '../tools/plan-milestone.ts';
+
+const boundaryMap = [
+  '| From | To | Produces | Consumes |',
+  '|------|----|----------|----------|',
+  '| S01 | S02 | roadmap | plan |',
+  '| S02 | S03 | plan | tasks |',
+].join('\n');
+
+function planParams() {
+  return {
+    milestoneId: 'M001',
+    title: 'Preserve Boundary Map',
+    vision: 'Roadmap survives projection hook.',
+    successCriteria: ['Boundary Map section survives post-mutation hook'],
+    keyRisks: [
+      { risk: 'Projection clobber', whyItMatters: 'Authoritative roadmap would be overwritten.' },
+    ],
+    proofStrategy: [
+      { riskOrUnknown: 'Roadmap overwrite', retireIn: 'S01', whatWillBeProven: 'ROADMAP.md still contains ## Boundary Map after plan-milestone.' },
+    ],
+    verificationContract: 'Contract check',
+    verificationIntegration: 'Integration check',
+    verificationOperational: 'Operational check',
+    verificationUat: 'UAT check',
+    definitionOfDone: ['Regression test green'],
+    requirementCoverage: 'Covers #4402.',
+    boundaryMapMarkdown: boundaryMap,
+    slices: [
+      {
+        sliceId: 'S01',
+        title: 'First',
+        risk: 'low',
+        depends: [] as string[],
+        demo: 'demo 1',
+        goal: 'goal 1',
+        successCriteria: 'sc 1',
+        proofLevel: 'unit',
+        integrationClosure: 'ic 1',
+        observabilityImpact: 'oi 1',
+      },
+      {
+        sliceId: 'S02',
+        title: 'Second',
+        risk: 'low',
+        depends: ['S01'],
+        demo: 'demo 2',
+        goal: 'goal 2',
+        successCriteria: 'sc 2',
+        proofLevel: 'unit',
+        integrationClosure: 'ic 2',
+        observabilityImpact: 'oi 2',
+      },
+      {
+        sliceId: 'S03',
+        title: 'Third',
+        risk: 'low',
+        depends: ['S02'],
+        demo: 'demo 3',
+        goal: 'goal 3',
+        successCriteria: 'sc 3',
+        proofLevel: 'unit',
+        integrationClosure: 'ic 3',
+        observabilityImpact: 'oi 3',
+      },
+    ],
+  };
+}
+
+test('#4402 plan-milestone preserves ## Boundary Map after post-mutation projections', async (t) => {
+  const base = mkdtempSync(join(tmpdir(), 'gsd-4402-'));
+  mkdirSync(join(base, '.gsd', 'milestones', 'M001'), { recursive: true });
+  openDatabase(join(base, '.gsd', 'gsd.db'));
+
+  t.after(() => {
+    try { closeDatabase(); } catch { /* noop */ }
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  const result = await handlePlanMilestone(planParams(), base);
+  assert.ok(!('error' in result), `unexpected error: ${'error' in result ? result.error : ''}`);
+
+  const roadmapPath = join(base, '.gsd', 'milestones', 'M001', 'M001-ROADMAP.md');
+  assert.ok(existsSync(roadmapPath), 'ROADMAP.md must exist on disk');
+
+  const roadmap = readFileSync(roadmapPath, 'utf-8');
+
+  assert.match(
+    roadmap,
+    /^## Boundary Map$/m,
+    'final on-disk ROADMAP.md must still contain the Boundary Map heading after projection hook',
+  );
+  assert.match(roadmap, /\| S01 \| S02 \| roadmap \| plan \|/, 'boundary map row S01→S02 must survive');
+  assert.match(roadmap, /\| S02 \| S03 \| plan \| tasks \|/, 'boundary map row S02→S03 must survive');
+});

--- a/src/resources/extensions/gsd/tests/plan-milestone-boundary-map-preservation.test.ts
+++ b/src/resources/extensions/gsd/tests/plan-milestone-boundary-map-preservation.test.ts
@@ -12,6 +12,16 @@ const boundaryMap = [
   '|------|----|----------|----------|',
   '| S01 | S02 | roadmap | plan |',
   '| S02 | S03 | plan | tasks |',
+  '',
+  '### S01 → S02',
+  '',
+  '- Produces: roadmap',
+  '- Consumes: plan',
+  '',
+  '### S02 → S03',
+  '',
+  '- Produces: plan',
+  '- Consumes: tasks',
 ].join('\n');
 
 function planParams() {
@@ -99,4 +109,6 @@ test('#4402 plan-milestone preserves ## Boundary Map after post-mutation project
   );
   assert.match(roadmap, /\| S01 \| S02 \| roadmap \| plan \|/, 'boundary map row S01→S02 must survive');
   assert.match(roadmap, /\| S02 \| S03 \| plan \| tasks \|/, 'boundary map row S02→S03 must survive');
+  assert.match(roadmap, /^### S01 → S02$/m, 'boundary map edge subsection S01→S02 must survive');
+  assert.match(roadmap, /^### S02 → S03$/m, 'boundary map edge subsection S02→S03 must survive');
 });

--- a/src/resources/extensions/gsd/tests/plan-milestone.test.ts
+++ b/src/resources/extensions/gsd/tests/plan-milestone.test.ts
@@ -92,11 +92,10 @@ test('handlePlanMilestone writes milestone and slice planning state and renders 
     assert.ok(existsSync(roadmapPath), 'roadmap should be rendered to disk');
     const roadmap = readFileSync(roadmapPath, 'utf-8');
     assert.match(roadmap, /# M001: DB-backed planning/);
-    assert.match(roadmap, /## Vision/);
-    assert.match(roadmap, /Make planning write through the database\./);
-    assert.match(roadmap, /## Slice Overview/);
-    assert.match(roadmap, /\| S01 \| Tool wiring \| medium \|/);
-    assert.match(roadmap, /\| S02 \| Prompt migration \| low \| S01 \|/);
+    assert.match(roadmap, /\*\*Vision:\*\* Make planning write through the database\./);
+    assert.match(roadmap, /^## Slices$/m);
+    assert.match(roadmap, /- \[ \] \*\*S01: Tool wiring\*\* `risk:medium` `depends:\[\]`/);
+    assert.match(roadmap, /- \[ \] \*\*S02: Prompt migration\*\* `risk:low` `depends:\[S01\]`/);
   } finally {
     cleanup(base);
   }

--- a/src/resources/extensions/gsd/tests/projection-no-plan-overwrite.test.ts
+++ b/src/resources/extensions/gsd/tests/projection-no-plan-overwrite.test.ts
@@ -67,9 +67,18 @@ describe('renderAllProjections must not overwrite PLAN.md (#3651)', () => {
     const fnEnd = src.indexOf('\n// ─── ', fnStart + 1)
     const fnBody = src.slice(fnStart, fnEnd)
 
+    // #4402: ROADMAP.md is now rendered by the authoritative renderer
+    // (renderRoadmapFromDb) to preserve ## Boundary Map and other sections
+    // that the reduced renderRoadmapProjection would strip.
     assert.ok(
-      fnBody.includes('renderRoadmapProjection('),
-      'renderRoadmapProjection must still be called',
+      fnBody.includes('renderRoadmapFromDb('),
+      'renderRoadmapFromDb must be called (authoritative roadmap renderer)',
+    )
+    assert.ok(
+      !/renderRoadmapProjection\s*\(/.test(
+        fnBody.split('\n').filter(l => !l.trim().startsWith('//')).join('\n'),
+      ),
+      'renderRoadmapProjection must NOT be called — it clobbers Boundary Map (#4402)',
     )
     assert.ok(
       fnBody.includes('renderSummaryProjection('),

--- a/src/resources/extensions/gsd/workflow-projections.ts
+++ b/src/resources/extensions/gsd/workflow-projections.ts
@@ -19,6 +19,7 @@ import { logWarning } from "./workflow-logger.js";
 import { isClosedStatus } from "./status-guards.js";
 import { deriveState } from "./state.js";
 import type { GSDState } from "./types.js";
+import { renderRoadmapFromDb } from "./markdown-renderer.js";
 
 // ─── Helpers ─────────────────────────────────────────────────────────────
 
@@ -375,11 +376,13 @@ export async function renderStateProjection(basePath: string): Promise<void> {
  * All calls are wrapped in try/catch — projection failure is non-fatal per D-02.
  */
 export async function renderAllProjections(basePath: string, milestoneId: string): Promise<void> {
-  // Render ROADMAP.md for the milestone
+  // Delegate to the authoritative roadmap renderer — the reduced
+  // renderRoadmapProjection omits sections like ## Boundary Map and would
+  // clobber the output written by plan-milestone / reassess-roadmap.
   try {
-    renderRoadmapProjection(basePath, milestoneId);
+    await renderRoadmapFromDb(basePath, milestoneId);
   } catch (err) {
-    logWarning("projection", `renderRoadmapProjection failed for ${milestoneId}: ${(err as Error).message}`);
+    logWarning("projection", `renderRoadmapFromDb failed for ${milestoneId}: ${(err as Error).message}`);
   }
 
   // Query all slices for this milestone
@@ -473,8 +476,13 @@ export function regenerateIfMissing(
         renderPlanProjection(basePath, milestoneId, sliceId);
         break;
       case "ROADMAP":
-        renderRoadmapProjection(basePath, milestoneId);
-        break;
+        // Authoritative renderer keeps all sections the reduced projection
+        // would strip. Async fire-and-forget like STATE: file appears on
+        // the next post-mutation cycle.
+        void renderRoadmapFromDb(basePath, milestoneId).catch((err) => {
+          logWarning("projection", `regenerateIfMissing ROADMAP failed: ${(err as Error).message}`);
+        });
+        return false;
       case "STATE":
         // renderStateProjection is async — fire-and-forget.
         // Return false since the file isn't written yet; it will appear

--- a/src/resources/extensions/gsd/workflow-projections.ts
+++ b/src/resources/extensions/gsd/workflow-projections.ts
@@ -470,21 +470,20 @@ export async function regenerateIfMissing(
     return false;
   }
 
-  // Regenerate the missing file
+  // Regenerate the missing file. Each renderer may swallow its own errors
+  // (e.g. renderStateProjection), so confirm the file actually exists on
+  // disk before reporting success — true must mean "file is there now".
   try {
     switch (fileType) {
       case "PLAN":
         renderPlanProjection(basePath, milestoneId, sliceId);
-        return true;
+        return existsSync(filePath);
       case "ROADMAP":
-        // Authoritative renderer keeps all sections the reduced projection
-        // would strip. Await so callers can rely on the "regenerate on demand"
-        // contract — returning true only when the file was actually written.
         await renderRoadmapFromDb(basePath, milestoneId);
-        return true;
+        return existsSync(filePath);
       case "STATE":
         await renderStateProjection(basePath);
-        return true;
+        return existsSync(filePath);
     }
   } catch (err) {
     logWarning("projection", `regenerateIfMissing ${fileType} failed: ${(err as Error).message}`);

--- a/src/resources/extensions/gsd/workflow-projections.ts
+++ b/src/resources/extensions/gsd/workflow-projections.ts
@@ -419,15 +419,16 @@ export async function renderAllProjections(basePath: string, milestoneId: string
 
 /**
  * Check if a projection file exists on disk. If missing, regenerate it from DB.
- * Returns true if the file was regenerated, false if it already existed.
+ * Returns true if the file was regenerated, false if it already existed or
+ * regeneration failed.
  * Satisfies PROJ-05 (corrupted/deleted projections regenerate on demand).
  */
-export function regenerateIfMissing(
+export async function regenerateIfMissing(
   basePath: string,
   milestoneId: string,
   sliceId: string,
   fileType: "PLAN" | "ROADMAP" | "SUMMARY" | "STATE",
-): boolean {
+): Promise<boolean> {
   let filePath: string;
 
   switch (fileType) {
@@ -474,23 +475,17 @@ export function regenerateIfMissing(
     switch (fileType) {
       case "PLAN":
         renderPlanProjection(basePath, milestoneId, sliceId);
-        break;
+        return true;
       case "ROADMAP":
         // Authoritative renderer keeps all sections the reduced projection
-        // would strip. Async fire-and-forget like STATE: file appears on
-        // the next post-mutation cycle.
-        void renderRoadmapFromDb(basePath, milestoneId).catch((err) => {
-          logWarning("projection", `regenerateIfMissing ROADMAP failed: ${(err as Error).message}`);
-        });
-        return false;
+        // would strip. Await so callers can rely on the "regenerate on demand"
+        // contract — returning true only when the file was actually written.
+        await renderRoadmapFromDb(basePath, milestoneId);
+        return true;
       case "STATE":
-        // renderStateProjection is async — fire-and-forget.
-        // Return false since the file isn't written yet; it will appear
-        // on the next post-mutation hook cycle.
-        void renderStateProjection(basePath);
-        return false;
+        await renderStateProjection(basePath);
+        return true;
     }
-    return true;
   } catch (err) {
     logWarning("projection", `regenerateIfMissing ${fileType} failed: ${(err as Error).message}`);
     return false;


### PR DESCRIPTION
## TL;DR

**What:** Stop the post-mutation projection hook from overwriting the authoritative `ROADMAP.md` and stripping `## Boundary Map`.
**Why:** `gsd_plan_milestone` persists `boundaryMapMarkdown` and renders the full roadmap, but the reduced projection clobbers the file seconds later, breaking downstream consumers like S06/T01 in M001-i8ewog.
**How:** Route `renderAllProjections` and `regenerateIfMissing` through the authoritative `renderRoadmapFromDb` instead of the reduced `renderRoadmapProjection`, mirroring the existing `PLAN.md` protection.

## What

- `src/resources/extensions/gsd/workflow-projections.ts` — `renderAllProjections` and the `regenerateIfMissing` ROADMAP branch now delegate to `renderRoadmapFromDb` from `markdown-renderer.ts`. The ROADMAP branch returns `false` (fire-and-forget, matching the STATE branch).
- `src/resources/extensions/gsd/markdown-renderer.ts` — `renderRoadmapMarkdown`'s checkbox predicate uses `isClosedStatus(slice.status)` instead of a bare `=== "complete"`, aligning with `reactive-graph`, `doctor`, `auto-dashboard`, and the status-guards convention.
- New regression test `tests/plan-milestone-boundary-map-preservation.test.ts` — runs `handlePlanMilestone` with a non-empty `boundaryMapMarkdown` and asserts the final on-disk `ROADMAP.md` still contains the `## Boundary Map` heading and its rows.
- Updated existing assertions in `plan-milestone.test.ts`, `complete-slice.test.ts`, and `projection-no-plan-overwrite.test.ts` to match the authoritative checkbox-list output (previously they asserted the reduced table output that the clobber produced).

The reduced `renderRoadmapProjection` / `renderRoadmapContent` functions stay exported for their own test coverage but are no longer on the live write path.

## Why

`gsd_plan_milestone` (and `gsd_reassess_roadmap`) call `renderRoadmapFromDb`, which writes the authoritative roadmap including the required `## Boundary Map` section documented in `GSD-WORKFLOW.md`. The post-mutation hook `renderAllProjections` then called `renderRoadmapProjection`, which writes only title + vision + a slice-overview table to the same file path. Whichever ran last won — and the projection always ran last.

Forensics on `execute-task/M001-i8ewog/S06/T01` showed the authoritative roadmap row in the DB was correct, but the on-disk `ROADMAP.md` was missing `## Boundary Map` and all 11 expected H3 edge sections, hard-blocking T02.

Closes #4402

## How

Option 2 from the issue (delegate the projection to the authoritative renderer) rather than Option 1 (drop the call entirely). Option 1 would have required every state-transition tool (complete-slice, complete-task, reopen-*, etc.) to gain its own roadmap re-render call to keep slice checkboxes in sync. Delegating inside `renderAllProjections` keeps the existing call sites working and gives us a single roadmap renderer.

The secondary `renderRoadmapMarkdown` change fixes a latent inconsistency: the projection correctly treated `done`/`skipped` slices as closed (via `isClosedStatus`), while the authoritative renderer only checked for literal `"complete"`. Without this, delegating the live path to `renderRoadmapMarkdown` would have regressed slices with legacy status values.

`migrate/writer.ts`'s stale `// Skip Boundary Map section entirely per D004` is intentionally out of scope — it runs only during one-time migration, is not the live overwrite path, and follows a different structured-entry model. A separate consistency fix is warranted per "one concern per PR".

## Test plan

- [x] New regression test fails before the fix, passes after
- [x] `npx tsc --noEmit` clean
- [x] Full GSD test suite: 5122/5123 passing (one pre-existing failure in `flat-rate-routing-guard.test.ts` for #3453, unrelated and present on `main`)
- [x] Updated existing assertions validated against the new authoritative output

## Change type

- [x] `fix` — Bug fix

## AI-assisted

This PR was developed with AI assistance. The root-cause analysis, code changes, and tests were reviewed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Roadmap and plan checkboxes now treat all "closed" statuses consistently and stale-detection messages reference "closed".
  * Projection regeneration now awaits rendering and accurately reports whether files were produced, improving reliability.

* **Style**
  * Roadmap output moved from table/emoji rows to markdown checkbox-style lists with inline metadata.

* **Tests**
  * Added and updated tests covering boundary-map preservation, checklist rendering, projection/regeneration behavior, and end-to-end roadmap assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->