### PR TITLE
ci: restore dev-publish workflow with manual approval gate

### DIFF
--- a/.github/workflows/dev-publish.yml
+++ b/.github/workflows/dev-publish.yml
@@ -127,8 +127,6 @@ jobs:
           exit 1
 
       - name: Run smoke tests (against installed binary)
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           export GSD_SMOKE_BINARY=$(which gsd)
           npm run test:smoke

--- a/.github/workflows/dev-publish.yml
+++ b/.github/workflows/dev-publish.yml
@@ -1,0 +1,154 @@
+# gsd-pi + CI: manual @dev channel publish with approval gate
+name: Dev Publish
+
+# Manual pre-release. Click "Run workflow" in the Actions tab to stamp a
+# version and publish @dev to npm. Gated by the `dev` GitHub Environment
+# (configure reviewers in repo Settings -> Environments).
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Branch or SHA to publish as @dev'
+        required: false
+        default: 'main'
+
+concurrency:
+  group: dev-publish-${{ github.event.inputs.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  dev-publish:
+    name: Dev Publish
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    environment: dev
+    container:
+      image: ghcr.io/gsd-build/gsd-ci-builder:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      env:
+        GITHUB_REPO_NAME: ${{ github.repository }}
+    outputs:
+      dev-version: ${{ steps.stamp.outputs.version }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.inputs.ref }}
+          token: ${{ secrets.RELEASE_PAT }}
+          fetch-depth: 0
+
+      - name: Mark workspace safe for git
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install web host dependencies
+        run: npm --prefix web ci
+
+      - name: Cache Next.js build
+        uses: useblacksmith/cache@v5
+        with:
+          path: web/.next/cache
+          key: nextjs-${{ runner.os }}-${{ hashFiles('web/package-lock.json') }}-${{ hashFiles('web/app/**', 'web/components/**', 'web/lib/**', 'web/hooks/**') }}
+          restore-keys: |
+            nextjs-${{ runner.os }}-${{ hashFiles('web/package-lock.json') }}-
+            nextjs-${{ runner.os }}-
+
+      - name: Build core
+        run: npm run build:core
+
+      - name: Build web host
+        run: npm run build:web-host
+
+      - name: Stamp dev version and sync platform packages
+        id: stamp
+        env:
+          VERSION_CHANNEL: dev
+        run: |
+          npm run pipeline:version-stamp
+          npm run sync-platform-versions
+          echo "version=$(node -e 'process.stdout.write(require("./package.json").version)')" >> "$GITHUB_OUTPUT"
+
+      - name: Smoke test
+        run: |
+          chmod +x dist/loader.js
+          export GSD_SMOKE_BINARY="$(pwd)/dist/loader.js"
+          npm run test:smoke
+
+      - name: Publish @dev
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          VERSION=$(node -e 'process.stdout.write(require("./package.json").version)')
+          if npm view "gsd-pi@${VERSION}" version 2>/dev/null; then
+            echo "Version ${VERSION} already published — moving @dev tag"
+            npm dist-tag add "gsd-pi@${VERSION}" dev
+          else
+            npm publish --tag dev
+          fi
+
+  dev-verify:
+    name: Dev Verify (installed package)
+    needs: dev-publish
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.inputs.ref }}
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+          cache: 'npm'
+
+      - name: Install published gsd-pi@dev globally (with registry propagation retry)
+        env:
+          DEV_VERSION: ${{ needs.dev-publish.outputs.dev-version }}
+        run: |
+          for i in 1 2 3 4 5 6; do
+            npm install -g "gsd-pi@${DEV_VERSION}" && exit 0
+            echo "Attempt $i failed — waiting 10s for npm registry propagation..."
+            sleep 10
+          done
+          echo "::error::Failed to install gsd-pi@${DEV_VERSION} after 6 attempts. The @dev tag may point at a broken artifact — deprecate it with: npm deprecate gsd-pi@${DEV_VERSION} 'broken build'"
+          exit 1
+
+      - name: Run smoke tests (against installed binary)
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          export GSD_SMOKE_BINARY=$(which gsd)
+          npm run test:smoke
+
+      - name: Install repo dependencies (for fixture + regression harnesses)
+        run: npm ci
+
+      - name: Run fixture tests
+        run: npm run test:fixtures
+
+      - name: Run live regression tests (against installed binary)
+        run: |
+          export GSD_SMOKE_BINARY=$(which gsd)
+          npm run test:live-regression
+
+      - name: Warn on verify failure
+        if: failure()
+        env:
+          DEV_VERSION: ${{ needs.dev-publish.outputs.dev-version }}
+        run: |
+          echo "::error::Post-publish verification failed for gsd-pi@${DEV_VERSION}. The @dev tag still points at this version on npm."
+          echo "::error::Recommended actions: (1) investigate the failing step above, (2) deprecate the broken version with 'npm deprecate gsd-pi@${DEV_VERSION} \"broken build; see Actions run\"', (3) cut a fix and re-run Dev Publish."
+          exit 1


### PR DESCRIPTION
## Summary
- Restores `.github/workflows/dev-publish.yml` (removed in `e71b2e5a9` when dev-publish was renamed to next-publish)
- Manual-only (`workflow_dispatch`), gated by the existing `dev` GitHub Environment
- Defaults to publishing `main` as `@dev`; ref input overridable
- Mirrors `next-publish.yml`: container creds, version-stamp (`VERSION_CHANNEL=dev`), smoke test, dist-tag move when version already published, and post-publish verify job

Publishes `2.75.0-dev.<sha>` to `@dev` on npm. Does not collide with `@next` (separate tag, separate env gate) or `@latest` (prod-release is hardcoded `ref: main` under `environment: prod`).

## Test plan
- [ ] Confirm `dev` environment still exists at Settings → Environments with reviewer list intact
- [ ] Actions → Dev Publish → Run workflow (default ref: main) → approve in `dev` environment → verify `gsd-pi@dev` on npm points to the new `2.75.0-dev.<sha>` version
- [ ] Verify the `dev-verify` job installs the published build globally and smoke/fixture/live-regression tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated, manually-triggerable pipeline to publish development releases to the npm @dev dist-tag, including build smoke tests, post-publish verification that retries on propagation delays, and end-to-end regression checks to ensure published dev artifacts are installable and functional.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->