### PR TITLE
fix(gsd): pre-exec checks false-positive on directory inputs and ~/ paths

### DIFF
--- a/src/resources/extensions/gsd/pre-execution-checks.ts
+++ b/src/resources/extensions/gsd/pre-execution-checks.ts
@@ -254,6 +254,8 @@ export function normalizeFilePath(filePath: string): string {
   } else if (normalized.startsWith("~/")) {
     normalized = resolve(homedir(), normalized.slice(2));
   }
+  // homedir()/resolve() can emit platform separators (e.g. "\" on Windows).
+  normalized = normalized.replace(/\\/g, "/");
 
   // Remove leading ./
   while (normalized.startsWith("./")) {

--- a/src/resources/extensions/gsd/pre-execution-checks.ts
+++ b/src/resources/extensions/gsd/pre-execution-checks.ts
@@ -16,6 +16,7 @@
 
 import { existsSync } from "node:fs";
 import { spawn } from "node:child_process";
+import { homedir } from "node:os";
 import { resolve } from "node:path";
 import type { TaskRow } from "./gsd-db.ts";
 import type { PreExecutionCheckJSON } from "./verification-evidence.ts";
@@ -245,21 +246,58 @@ export function normalizeFilePath(filePath: string): string {
 
   // Normalize path separators to forward slashes
   normalized = normalized.replace(/\\/g, "/");
-  
+
+  // Expand a leading ~ or ~/ so downstream resolve()/set lookups hit the real
+  // home directory instead of treating the tilde as a literal path segment.
+  if (normalized === "~") {
+    normalized = homedir();
+  } else if (normalized.startsWith("~/")) {
+    normalized = resolve(homedir(), normalized.slice(2));
+  }
+
   // Remove leading ./
   while (normalized.startsWith("./")) {
     normalized = normalized.slice(2);
   }
-  
+
   // Remove duplicate slashes
   normalized = normalized.replace(/\/+/g, "/");
-  
+
   // Remove trailing slash unless it's the root
   if (normalized.length > 1 && normalized.endsWith("/")) {
     normalized = normalized.slice(0, -1);
   }
-  
+
   return normalized;
+}
+
+/**
+ * Planning units sometimes pass a directory reference as task.inputs
+ * (e.g. `artifacts/M009-S03/`). The trailing slash is meaningful — the task
+ * reads whatever lands inside — but normalizeFilePath strips it, so call this
+ * helper against the raw input before normalization.
+ */
+function isDirectoryReference(raw: string): boolean {
+  const candidate = extractPathFromAnnotation(raw.trim());
+  if (!candidate) return false;
+  if (containsGlobPattern(candidate)) return false;
+  return candidate.endsWith("/");
+}
+
+/**
+ * True when any of `knownOutputs` lives under `normalizedDir` (i.e. the task
+ * directory input is the parent of something a prior/same task produces).
+ */
+function anyOutputUnderDirectory(
+  normalizedDir: string,
+  knownOutputs: Iterable<string>,
+): boolean {
+  const prefix = normalizedDir + "/";
+  for (const output of knownOutputs) {
+    if (output === normalizedDir) return true;
+    if (output.startsWith(prefix)) return true;
+  }
+  return false;
 }
 
 const URL_SCHEME_PATTERN = /^(https?|ftp|file|ssh|git):\/\//i;
@@ -397,7 +435,17 @@ export function checkFilePathConsistency(
       // Check if file is in prior expected outputs (priorOutputs already normalized)
       const inPriorOutputs = priorOutputs.has(normalizedFile);
 
-      if (!existsOnDisk && !inPriorOutputs) {
+      // Directory inputs are satisfied when something produces a file beneath
+      // them — either a prior task or the current task itself.
+      let directorySatisfied = false;
+      if (!existsOnDisk && !inPriorOutputs && isDirectoryReference(file)) {
+        const sameTaskOutputs = task.expected_output.map(normalizeFilePath);
+        directorySatisfied =
+          anyOutputUnderDirectory(normalizedFile, priorOutputs) ||
+          anyOutputUnderDirectory(normalizedFile, sameTaskOutputs);
+      }
+
+      if (!existsOnDisk && !inPriorOutputs && !directorySatisfied) {
         results.push({
           category: "file",
           target: file,
@@ -450,6 +498,10 @@ export function checkTaskOrdering(
 
       const normalizedFile = normalizeFilePath(file);
       if (containsGlobPattern(normalizedFile)) continue;
+      // A directory reference like `artifacts/M009-S03/` is never a concrete
+      // read-before-create dependency: the fileCreators map is keyed by leaf
+      // files, and a same-task output under the directory satisfies it.
+      if (isDirectoryReference(file)) continue;
       const creator = fileCreators.get(normalizedFile);
       const absolutePath = resolve(basePath, normalizedFile);
       const existsOnDisk = existsSync(absolutePath);

--- a/src/resources/extensions/gsd/tests/pre-execution-checks.test.ts
+++ b/src/resources/extensions/gsd/tests/pre-execution-checks.test.ts
@@ -10,7 +10,7 @@
 
 import { describe, test, mock } from "node:test";
 import assert from "node:assert/strict";
-import { tmpdir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import { mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 
@@ -1437,5 +1437,145 @@ describe("PreExecutionResult type", () => {
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }
+  });
+});
+
+// ─── Regression Tests: directory inputs and tilde paths (#4446) ──────────────
+
+describe("normalizeFilePath tilde expansion (#4446)", () => {
+  test("expands standalone ~ to homedir", () => {
+    assert.equal(normalizeFilePath("~"), homedir());
+  });
+
+  test("expands ~/ prefixed paths to homedir", () => {
+    assert.equal(
+      normalizeFilePath("~/.gsd/agent/extensions/gsd/native-git-bridge.js"),
+      join(homedir(), ".gsd/agent/extensions/gsd/native-git-bridge.js"),
+    );
+  });
+});
+
+describe("checkFilePathConsistency directory inputs (#4446)", () => {
+  test("directory input is satisfied by prior task's output under it", (t) => {
+    const tempDir = join(tmpdir(), `pre-exec-dir-prior-${Date.now()}`);
+    mkdirSync(tempDir, { recursive: true });
+    t.after(() => rmSync(tempDir, { recursive: true, force: true }));
+
+    const tasks = [
+      createTask({
+        id: "T01",
+        sequence: 0,
+        inputs: [],
+        expected_output: ["artifacts/M009-S03/summary.json"],
+      }),
+      createTask({
+        id: "T02",
+        sequence: 1,
+        inputs: ["artifacts/M009-S03/"],
+        expected_output: [],
+      }),
+    ];
+
+    const results = checkFilePathConsistency(tasks, tempDir);
+    assert.deepEqual(results, [], "Directory input with prior output beneath it should not be blocking");
+  });
+
+  test("directory input is satisfied by same task's output under it", (t) => {
+    const tempDir = join(tmpdir(), `pre-exec-dir-same-${Date.now()}`);
+    mkdirSync(tempDir, { recursive: true });
+    t.after(() => rmSync(tempDir, { recursive: true, force: true }));
+
+    const tasks = [
+      createTask({
+        id: "T06",
+        sequence: 0,
+        inputs: ["artifacts/M009-S03/"],
+        expected_output: [
+          "artifacts/M009-S03/summary.json",
+          "artifacts/M009-S03/VERIFICATION.md",
+        ],
+      }),
+    ];
+
+    const results = checkFilePathConsistency(tasks, tempDir);
+    assert.deepEqual(
+      results,
+      [],
+      "Directory input whose children are produced by the same task should not be blocking (M009-S03/T06 case)",
+    );
+  });
+
+  test("directory input still fails when nothing creates anything under it", (t) => {
+    const tempDir = join(tmpdir(), `pre-exec-dir-missing-${Date.now()}`);
+    mkdirSync(tempDir, { recursive: true });
+    t.after(() => rmSync(tempDir, { recursive: true, force: true }));
+
+    const tasks = [
+      createTask({
+        id: "T01",
+        inputs: ["artifacts/missing/"],
+        expected_output: [],
+      }),
+    ];
+
+    const results = checkFilePathConsistency(tasks, tempDir);
+    assert.equal(results.length, 1, "Unknown directory input must still be reported");
+    assert.equal(results[0].blocking, true);
+  });
+
+  test("tilde-prefixed input is matched against $HOME, not the project basePath", (t) => {
+    const fakeHome = join(tmpdir(), `pre-exec-tilde-home-${Date.now()}`);
+    const projectDir = join(tmpdir(), `pre-exec-tilde-proj-${Date.now()}`);
+    mkdirSync(join(fakeHome, ".gsd"), { recursive: true });
+    writeFileSync(join(fakeHome, ".gsd/tool.js"), "// present");
+    mkdirSync(projectDir, { recursive: true });
+
+    const originalHome = process.env.HOME;
+    const originalUserProfile = process.env.USERPROFILE;
+    process.env.HOME = fakeHome;
+    process.env.USERPROFILE = fakeHome;
+
+    t.after(() => {
+      if (originalHome === undefined) delete process.env.HOME;
+      else process.env.HOME = originalHome;
+      if (originalUserProfile === undefined) delete process.env.USERPROFILE;
+      else process.env.USERPROFILE = originalUserProfile;
+      rmSync(fakeHome, { recursive: true, force: true });
+      rmSync(projectDir, { recursive: true, force: true });
+    });
+
+    const tasks = [
+      createTask({
+        id: "T01",
+        inputs: ["~/.gsd/tool.js"],
+        expected_output: [],
+      }),
+    ];
+
+    const results = checkFilePathConsistency(tasks, projectDir);
+    assert.deepEqual(results, [], "~/-prefixed input should resolve against $HOME and pass when present");
+  });
+});
+
+describe("checkTaskOrdering directory inputs (#4446)", () => {
+  test("directory input with a same-task output under it does not produce a sequence violation", () => {
+    const tasks = [
+      createTask({
+        id: "T06",
+        sequence: 0,
+        inputs: ["artifacts/M009-S03/"],
+        expected_output: [
+          "artifacts/M009-S03/summary.json",
+          "artifacts/M009-S03/VERIFICATION.md",
+        ],
+      }),
+    ];
+
+    const results = checkTaskOrdering(tasks, "/tmp");
+    assert.deepEqual(
+      results,
+      [],
+      "Directory reference should not be treated as reading a file created later",
+    );
   });
 });


### PR DESCRIPTION
## TL;DR

**What:** Stops `pre-execution-checks` from blocking slice dispatch on directory-style `task.inputs` (trailing `/`) and `~/`-prefixed paths.
**Why:** Valid plans (e.g. `artifacts/M009-S03/` where the same task produces files under it, or `~/.gsd/...` tool references) were reported as `Pre-execution checks failed: blocking issue`, forcing human overrides on every affected slice.
**How:** Expand `~` / `~/` in `normalizeFilePath`, treat a directory input as satisfied when any prior or same-task `expected_output` is a descendant, and skip directory references in `checkTaskOrdering`.

## What

`src/resources/extensions/gsd/pre-execution-checks.ts`:

- `normalizeFilePath` now expands a leading `~` to `os.homedir()` and `~/foo` to `resolve(homedir(), "foo")` before the existing separator/slash normalization. No change for non-tilde paths.
- Two new pure helpers:
  - `isDirectoryReference(raw)` — inspects the **raw** input (pre-normalization) so the trailing `/` is still observable.
  - `anyOutputUnderDirectory(normalizedDir, outputs)` — prefix-match against a known-outputs set.
- `checkFilePathConsistency` now accepts a directory input when the current task's `expected_output` (or any prior task's) contains a descendant path. On-disk `existsSync` hits continue to satisfy the check exactly as before.
- `checkTaskOrdering` short-circuits for directory references: the `fileCreators` map is keyed by leaf files, so a directory read is never a concrete read-before-create.

`src/resources/extensions/gsd/tests/pre-execution-checks.test.ts`:

- 7 new regression tests in three describe blocks tagged `(#4446)`:
  - `normalizeFilePath tilde expansion` — standalone `~` and `~/foo`.
  - `checkFilePathConsistency directory inputs` — prior-task satisfaction, same-task satisfaction (the M009-S03/T06 reproducer), still-blocks-when-missing, and tilde-input resolved against a fake `$HOME` via `t.after()` cleanup.
  - `checkTaskOrdering directory inputs` — directory input with a same-task descendant output does not produce a sequence violation.
- 5 of the 7 new tests fail against `origin/main`; all 7 pass on this branch.

No other files touched. No public API changes.

## Why

Reported in #4446. `checkFilePathConsistency` used an exact-string set lookup for `priorOutputs`, which only stores leaf files — so a directory reference like `artifacts/M009-S03/` (valid planner output for audit-sweep tasks) was treated identically to a missing file. Separately, `normalizeFilePath` never expanded `~`, so `~/.gsd/...` resolved against the project base path and `existsSync` was always false.

Both gaps triggered blocking pre-exec failures that humans had to override. Forensic evidence in the issue shows this misfiring repeatedly on `execute-task/M009/S03/T06`, `execute-task/M009/S02/T06`, and `execute-task/M008/S03/T02`. #4070 and #4427 addressed neighbouring cases (glob handling, URL/prose annotations) but did not cover directory references or tilde paths.

Closes #4446

## How

- **Tilde expansion** lives in `normalizeFilePath` so every caller (`checkFilePathConsistency`, `checkTaskOrdering`, `getExpectedOutputsUpTo`) picks it up for free. `existsSync(resolve(basePath, expandedPath))` works because the expanded path is absolute.
- **Directory satisfaction** is computed on demand, per-input. An alternative was to store directory prefixes in `priorOutputs` itself, but that would have bled the concept into every consumer and changed the `Set<string>` contract. Keeping the derivation local costs one extra `Array.prototype.map` per directory input — negligible.
- **`checkTaskOrdering` guard** is conservative: directory references are filtered out entirely rather than prefix-matched against `fileCreators`. The planner already guarantees that concrete read-before-create dependencies are declared as concrete paths, and the existing glob-input `continue` in the same loop follows the same philosophy.
- **`isDirectoryReference` runs on the raw input** (pre-normalization) because `normalizeFilePath` strips the trailing `/`. Using `extractPathFromAnnotation` means backtick/prose-annotated inputs like `` `artifacts/M009-S03/` directory listing `` are still recognized.

### Alternatives considered

- Prefix-key `fileCreators` with directories — too invasive; risks false-positive ordering claims.
- Extend `shouldValidateInputAsPath` to skip directory inputs entirely — would silently pass truly missing directories (e.g. `artifacts/missing/` with no creator). The new test `directory input still fails when nothing creates anything under it` locks this down.

## Test plan

- [x] `node --test` against `src/resources/extensions/gsd/tests/pre-execution-checks.test.ts` — 75/75 pass (including all prior regressions for #3677, #3626, #4070, #4427).
- [x] `npx tsc --noEmit` — clean.
- [x] `npm run build` — clean.
- [x] Verified the 5 new directory/tilde tests fail on `origin/main` and pass on this branch (test-first per CONTRIBUTING §Test-first).

## Change type

- [x] `fix` — Bug fix

## AI assistance disclosure

This PR is AI-assisted. I directed the diagnosis and patch; I've read every line, understand the change, and can defend it in review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enabled tilde (`~` / `~/`) expansion to the user's home directory.
  * Improved handling of directory-style inputs (paths ending with `/`), excluding glob patterns, and treat them as satisfied when expected outputs exist beneath the directory.
  * Adjusted ordering checks to avoid false violations when a directory's files are produced by the same task.

* **Tests**
  * Added coverage for tilde expansion, directory-input handling (positive and negative cases), and ordering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->