### PR TITLE
feat(gsd): /gsd onboarding re-entry + setup hub disambiguation

### DIFF
--- a/src/onboarding.ts
+++ b/src/onboarding.ts
@@ -17,6 +17,13 @@ import type { AuthStorage } from '@gsd/pi-coding-agent'
 import { renderLogo } from './logo.js'
 import { agentDir } from './app-paths.js'
 import { isClaudeCliReady } from './claude-cli-check.js'
+import {
+  markOnboardingComplete,
+  markStepCompleted,
+  markStepSkipped,
+  isOnboardingComplete,
+} from './resources/extensions/gsd/onboarding-state.js'
+import { getLlmProviderIds } from './resources/extensions/gsd/setup-catalog.js'
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -73,25 +80,17 @@ const TOOL_KEYS: ToolKeyConfig[] = [
   },
 ]
 
-/** Known LLM provider IDs that, if authed, mean the user doesn't need onboarding */
-const LLM_PROVIDER_IDS = [
-  'anthropic',
+/**
+ * Known LLM provider IDs that, if authed, mean the user doesn't need onboarding.
+ * Sourced from the shared setup-catalog so adding a provider lands in one place.
+ * 'anthropic-vertex' and 'ollama' aren't in PROVIDER_REGISTRY but are still
+ * treated as "authed = no onboarding needed" for back-compat.
+ */
+const LLM_PROVIDER_IDS = Array.from(new Set([
+  ...getLlmProviderIds(),
   'anthropic-vertex',
-  'claude-code',
-  'openai',
-  'github-copilot',
-  'openai-codex',
-  'google-gemini-cli',
-  'google-antigravity',
-  'google',
-  'groq',
-  'xai',
-  'openrouter',
-  'mistral',
   'ollama',
-  'ollama-cloud',
-  'custom-openai',
-]
+]))
 
 /** API key prefix validation — loose checks to catch obvious mistakes */
 const API_KEY_PREFIXES: Record<string, string[]> = {
@@ -226,6 +225,9 @@ async function runStep<T>(
  */
 export function shouldRunOnboarding(authStorage: AuthStorage, settingsDefaultProvider?: string): boolean {
   if (!process.stdin.isTTY) return false
+  // Explicit completion record wins — user has already finished onboarding (and
+  // our flowVersion hasn't bumped since).
+  if (isOnboardingComplete()) return false
   if (settingsDefaultProvider) return false
   // Check if any LLM provider has credentials
   const hasLlmAuth = LLM_PROVIDER_IDS.some(id => authStorage.hasAuth(id))
@@ -259,31 +261,37 @@ export async function runOnboarding(authStorage: AuthStorage): Promise<void> {
   process.stderr.write(renderLogo(pc.cyan))
   p.intro(pc.bold('Welcome to GSD — let\'s get you set up'))
 
+  const completedSteps: string[] = []
+
   // ── LLM Provider Selection ────────────────────────────────────────────────
   const llmResult = await runStep(p, 'LLM setup failed', () => runLlmStep(p, pc, authStorage), {
-    cancelMessage: 'Setup cancelled — you can run /login inside GSD later.',
+    cancelMessage: 'Setup cancelled — you can run /gsd onboarding --resume later.',
     errorInfo: 'You can configure your LLM provider later with /login inside GSD.',
   })
   if (llmResult === STEP_CANCELLED) return
   const llmConfigured = llmResult ?? false
+  if (llmConfigured) { markStepCompleted('llm'); completedSteps.push('llm') } else { markStepSkipped('llm') }
 
   // ── Web Search Provider ──────────────────────────────────────────────────
   const searchResult = await runStep(p, 'Web search setup failed',
     () => runWebSearchStep(p, pc, authStorage, llmConfigured))
   if (searchResult === STEP_CANCELLED) return
   const searchConfigured = searchResult
+  if (searchConfigured) { markStepCompleted('search'); completedSteps.push('search') } else { markStepSkipped('search') }
 
   // ── Remote Questions ─────────────────────────────────────────────────────
   const remoteResult = await runStep(p, 'Remote questions setup failed',
     () => runRemoteQuestionsStep(p, pc, authStorage))
   if (remoteResult === STEP_CANCELLED) return
   const remoteConfigured = remoteResult
+  if (remoteConfigured) { markStepCompleted('remote'); completedSteps.push('remote') } else { markStepSkipped('remote') }
 
   // ── Tool API Keys ─────────────────────────────────────────────────────────
   const toolResult = await runStep(p, 'Tool key setup failed',
     () => runToolKeysStep(p, pc, authStorage))
   if (toolResult === STEP_CANCELLED) return
   const toolKeyCount = toolResult ?? 0
+  if (toolKeyCount > 0) { markStepCompleted('tool-keys'); completedSteps.push('tool-keys') } else { markStepSkipped('tool-keys') }
 
   // ── Summary ───────────────────────────────────────────────────────────────
   const summaryLines: string[] = []
@@ -318,13 +326,21 @@ export async function runOnboarding(authStorage: AuthStorage): Promise<void> {
     summaryLines.push(`${pc.dim('↷')} Tool keys: none configured`)
   }
 
+  // Persist completion record so re-entry, web boot probe, and shouldRunOnboarding
+  // all agree the wizard finished. Required steps drive the "complete" semantics
+  // in onboarding-state.ts; here we mark wizard-level completion regardless.
+  markOnboardingComplete(completedSteps)
+
+  summaryLines.push('')
+  summaryLines.push(`${pc.dim('Tip:')} re-run anytime with ${pc.cyan('/gsd onboarding')}`)
+
   p.note(summaryLines.join('\n'), 'Setup complete')
   p.outro(pc.dim('Launching GSD...'))
 }
 
 // ─── LLM Authentication Step ──────────────────────────────────────────────────
 
-async function runLlmStep(p: ClackModule, pc: PicoModule, authStorage: AuthStorage): Promise<boolean> {
+export async function runLlmStep(p: ClackModule, pc: PicoModule, authStorage: AuthStorage): Promise<boolean> {
   // Build the OAuth provider list dynamically from what's registered
   const oauthProviders = authStorage.getOAuthProviders()
   const oauthMap = new Map(oauthProviders.map(op => [op.id, op]))
@@ -678,7 +694,7 @@ async function runCustomOpenAIFlow(
 
 // ─── Web Search Provider Step ─────────────────────────────────────────────────
 
-async function runWebSearchStep(
+export async function runWebSearchStep(
   p: ClackModule,
   pc: PicoModule,
   authStorage: AuthStorage,
@@ -759,7 +775,7 @@ async function runWebSearchStep(
 
 // ─── Tool API Keys Step ───────────────────────────────────────────────────────
 
-async function runToolKeysStep(
+export async function runToolKeysStep(
   p: ClackModule,
   pc: PicoModule,
   authStorage: AuthStorage,
@@ -802,7 +818,7 @@ async function runToolKeysStep(
 
 // ─── Remote Questions Step ────────────────────────────────────────────────────
 
-async function runRemoteQuestionsStep(
+export async function runRemoteQuestionsStep(
   p: ClackModule,
   pc: PicoModule,
   authStorage: AuthStorage,

--- a/src/resources/extensions/gsd/commands-config.ts
+++ b/src/resources/extensions/gsd/commands-config.ts
@@ -55,7 +55,17 @@ export function getConfigAuthStorage(): AuthStorage {
   return AuthStorage.create(authPath);
 }
 
+let deprecationWarned = false;
+
 export async function handleConfig(ctx: ExtensionCommandContext): Promise<void> {
+  if (!deprecationWarned) {
+    ctx.ui.notify(
+      "/gsd config is deprecated and will be removed. Use /gsd keys (manages both LLM and tool API keys).",
+      "warning",
+    );
+    deprecationWarned = true;
+  }
+
   const auth = getConfigAuthStorage();
 
   // Show current status

--- a/src/resources/extensions/gsd/commands/catalog.ts
+++ b/src/resources/extensions/gsd/commands/catalog.ts
@@ -15,7 +15,7 @@ export interface GsdCommandDefinition {
 type CompletionMap = Record<string, readonly GsdCommandDefinition[]>;
 
 export const GSD_COMMAND_DESCRIPTION =
-  "GSD — Get Shit Done: /gsd help|start|templates|next|auto|stop|pause|status|widget|visualize|queue|quick|discuss|capture|triage|dispatch|history|undo|undo-task|reset-slice|rate|skip|export|cleanup|model|mode|prefs|config|keys|hooks|run-hook|skill-health|doctor|debug|logs|forensics|changelog|migrate|remote|steer|knowledge|new-milestone|parallel|cmux|park|unpark|init|setup|inspect|extensions|update|fast|mcp|rethink|codebase|notifications|ship|do|session-report|backlog|pr-branch|add-tests|scan|language";
+  "GSD — Get Shit Done: /gsd help|start|templates|next|auto|stop|pause|status|widget|visualize|queue|quick|discuss|capture|triage|dispatch|history|undo|undo-task|reset-slice|rate|skip|export|cleanup|model|mode|prefs|config|keys|hooks|run-hook|skill-health|doctor|debug|logs|forensics|changelog|migrate|remote|steer|knowledge|new-milestone|parallel|cmux|park|unpark|init|setup|onboarding|inspect|extensions|update|fast|mcp|rethink|codebase|notifications|ship|do|session-report|backlog|pr-branch|add-tests|scan|language";
 
 export const TOP_LEVEL_SUBCOMMANDS: readonly GsdCommandDefinition[] = [
   { cmd: "help", desc: "Categorized command reference with descriptions" },
@@ -44,7 +44,7 @@ export const TOP_LEVEL_SUBCOMMANDS: readonly GsdCommandDefinition[] = [
   { cmd: "model", desc: "Switch the active session model or open a picker" },
   { cmd: "mode", desc: "Switch workflow mode (solo/team)" },
   { cmd: "prefs", desc: "Manage preferences (model selection, timeouts, etc.)" },
-  { cmd: "config", desc: "Set API keys for external tools" },
+  { cmd: "config", desc: "(deprecated) Set tool API keys — use /gsd keys instead" },
   { cmd: "keys", desc: "API key manager — list, add, remove, test, rotate, doctor" },
   { cmd: "hooks", desc: "Show configured post-unit and pre-dispatch hooks" },
   { cmd: "run-hook", desc: "Manually trigger a specific hook" },
@@ -55,7 +55,8 @@ export const TOP_LEVEL_SUBCOMMANDS: readonly GsdCommandDefinition[] = [
   { cmd: "debug", desc: "Create and inspect persistent /gsd debug sessions" },
   { cmd: "forensics", desc: "Examine execution logs" },
   { cmd: "init", desc: "Project init wizard — detect, configure, bootstrap .gsd/" },
-  { cmd: "setup", desc: "Global setup status and configuration" },
+  { cmd: "setup", desc: "Configuration hub: status + sub-routes (llm, model, search, remote, keys, prefs, onboarding)" },
+  { cmd: "onboarding", desc: "Re-run the setup wizard  [--resume|--reset|--step <name>]" },
   { cmd: "migrate", desc: "Migrate a v1 .planning directory to .gsd format" },
   { cmd: "remote", desc: "Control remote auto-mode" },
   { cmd: "steer", desc: "Hard-steer plan documents during execution" },
@@ -115,11 +116,18 @@ const NESTED_COMPLETIONS: CompletionMap = {
     { cmd: "watch", desc: "Live TUI dashboard monitoring all workers" },
   ],
   setup: [
-    { cmd: "llm", desc: "Configure LLM provider settings" },
+    { cmd: "llm", desc: "Configure LLM provider & auth" },
+    { cmd: "model", desc: "Pick default model for the active provider" },
     { cmd: "search", desc: "Configure web search provider" },
-    { cmd: "remote", desc: "Configure remote integrations" },
-    { cmd: "keys", desc: "Manage API keys" },
-    { cmd: "prefs", desc: "Configure global preferences" },
+    { cmd: "remote", desc: "Configure remote integrations (Discord/Slack/Telegram)" },
+    { cmd: "keys", desc: "Manage API keys (alias for /gsd keys)" },
+    { cmd: "prefs", desc: "Global preferences wizard (alias for /gsd prefs)" },
+    { cmd: "onboarding", desc: "Run the full onboarding wizard (alias for /gsd onboarding)" },
+  ],
+  onboarding: [
+    { cmd: "--resume", desc: "Resume from the last completed step" },
+    { cmd: "--reset", desc: "Reset onboarding state and start over (does not clear API keys)" },
+    { cmd: "--step", desc: "Run a single step: llm|model|search|remote|tool-keys|prefs|skills|doctor|project" },
   ],
   notifications: [
     { cmd: "clear", desc: "Clear all notifications" },

--- a/src/resources/extensions/gsd/commands/handlers/core.ts
+++ b/src/resources/extensions/gsd/commands/handlers/core.ts
@@ -41,10 +41,12 @@ export function showHelp(ctx: ExtensionCommandContext, args = ""): void {
     "  /gsd debug          Create/list/continue persistent debug sessions",
     "",
     "SETUP",
+    "  /gsd onboarding     Re-run setup wizard  [--resume|--reset|--step <name>]",
+    "  /gsd setup          Configuration hub  [llm|model|search|remote|keys|prefs|onboarding]",
     "  /gsd init           Project init wizard",
-    "  /gsd setup          Global setup status  [llm|search|remote|keys|prefs]",
     "  /gsd model          Switch active session model",
-    "  /gsd prefs          Manage preferences",
+    "  /gsd prefs          Manage preferences (alias for /gsd setup prefs)",
+    "  /gsd keys           API key manager (LLM + tool keys)",
     "  /gsd doctor         Diagnose and repair .gsd/ state",
     "",
     "Use /gsd help full for the complete command reference.",
@@ -89,14 +91,15 @@ export function showHelp(ctx: ExtensionCommandContext, args = ""): void {
     "  /gsd codebase [generate|update|stats]   Manage the CODEBASE.md cache used in prompt context",
     "",
     "SETUP & CONFIGURATION",
+    "  /gsd onboarding     Re-run setup wizard  [--resume|--reset|--step <name>]",
+    "  /gsd setup          Configuration hub  [llm|model|search|remote|keys|prefs|onboarding]",
     "  /gsd init           Project init wizard — detect, configure, bootstrap .gsd/",
-    "  /gsd setup          Global setup status  [llm|search|remote|keys|prefs]",
     "  /gsd model          Switch active session model  [provider/model|model-id]",
     "  /gsd mode           Set workflow mode (solo/team)  [global|project]",
-    "  /gsd prefs          Manage preferences  [global|project|status|wizard|setup|import-claude]",
+    "  /gsd prefs          Manage preferences  [global|project|status|wizard|setup|import-claude]  (alias for /gsd setup prefs)",
     "  /gsd cmux           Manage cmux integration  [status|on|off|notifications|sidebar|splits|browser]",
-    "  /gsd config         Set API keys for external tools",
-    "  /gsd keys           API key manager  [list|add|remove|test|rotate|doctor]",
+    "  /gsd keys           API key manager (LLM + tool keys)  [list|add|remove|test|rotate|doctor]",
+    "  /gsd config         (deprecated) Set tool API keys — use /gsd keys instead",
     "  /gsd show-config    Show effective configuration (models, routing, toggles)",
     "  /gsd hooks          Show post-unit hook configuration",
     "  /gsd extensions     Manage extensions  [list|enable|disable|info]",
@@ -178,30 +181,37 @@ export async function handleVisualize(ctx: ExtensionCommandContext): Promise<voi
 
 export async function handleSetup(args: string, ctx: ExtensionCommandContext): Promise<void> {
   const { detectProjectState, hasGlobalSetup } = await import("../../detection.js");
+  const { isOnboardingComplete, readOnboardingRecord } = await import("../../onboarding-state.js");
 
-  const globalConfigured = hasGlobalSetup();
-  const detection = detectProjectState(projectRoot());
-
-  const statusLines = ["GSD Setup Status\n"];
-  statusLines.push(`  Global preferences: ${globalConfigured ? "configured" : "not set"}`);
-  statusLines.push(`  Project state: ${detection.state}`);
-  if (detection.projectSignals.primaryLanguage) {
-    statusLines.push(`  Detected: ${detection.projectSignals.primaryLanguage}`);
+  // Sub-route dispatch — keep redirects but route the canonical work to /gsd
+  // onboarding (single source for wizard steps) and /gsd keys (single source
+  // for credentials).
+  if (args === "onboarding" || args === "wizard") {
+    const { handleOnboarding } = await import("./onboarding.js");
+    await handleOnboarding("", ctx);
+    return;
   }
-
   if (args === "llm" || args === "auth") {
-    ctx.ui.notify("Use /login to configure LLM authentication.", "info");
+    const { handleOnboarding } = await import("./onboarding.js");
+    await handleOnboarding("--step llm", ctx);
     return;
   }
   if (args === "search") {
-    ctx.ui.notify("Use /search-provider to configure web search.", "info");
+    const { handleOnboarding } = await import("./onboarding.js");
+    await handleOnboarding("--step search", ctx);
     return;
   }
   if (args === "remote") {
-    ctx.ui.notify("Use /gsd remote to configure remote questions.", "info");
+    const { handleOnboarding } = await import("./onboarding.js");
+    await handleOnboarding("--step remote", ctx);
+    return;
+  }
+  if (args === "model") {
+    await handleModel("", ctx);
     return;
   }
   if (args === "keys") {
+    ctx.ui.notify("Tip: /gsd keys is the canonical command for API key management.", "info");
     const { handleKeys } = await import("../../key-manager.js");
     await handleKeys("", ctx);
     return;
@@ -212,14 +222,35 @@ export async function handleSetup(args: string, ctx: ExtensionCommandContext): P
     return;
   }
 
+  // Bare /gsd setup — render the hub: status + actions
+  const globalConfigured = hasGlobalSetup();
+  const detection = detectProjectState(projectRoot());
+  const onboardingDone = isOnboardingComplete();
+  const record = readOnboardingRecord();
+
+  const statusLines: string[] = ["GSD Setup\n"];
+  statusLines.push(
+    onboardingDone
+      ? `  Onboarding:         ✓ complete${record.completedAt ? ` (${record.completedAt.slice(0, 10)})` : ""}`
+      : `  Onboarding:         ○ not complete  —  /gsd onboarding to start`,
+  );
+  statusLines.push(`  Global preferences: ${globalConfigured ? "configured" : "not set"}`);
+  statusLines.push(`  Project state:      ${detection.state}`);
+  if (detection.projectSignals.primaryLanguage) {
+    statusLines.push(`  Detected:           ${detection.projectSignals.primaryLanguage}`);
+  }
+
   ctx.ui.notify(statusLines.join("\n"), "info");
   ctx.ui.notify(
-    "Available setup commands:\n" +
-    "  /gsd setup llm     — LLM authentication\n" +
-    "  /gsd setup search  — Web search provider\n" +
-    "  /gsd setup remote  — Remote questions (Discord/Slack/Telegram)\n" +
-    "  /gsd setup keys    — Tool API keys\n" +
-    "  /gsd setup prefs   — Global preferences wizard",
+    "Configuration hub:\n" +
+    "  /gsd setup llm        — LLM provider & auth\n" +
+    "  /gsd setup model      — Default model picker\n" +
+    "  /gsd setup search     — Web search provider\n" +
+    "  /gsd setup remote     — Remote questions (Discord/Slack/Telegram)\n" +
+    "  /gsd setup keys       — API keys (alias for /gsd keys)\n" +
+    "  /gsd setup prefs      — Global preferences (alias for /gsd prefs)\n" +
+    "  /gsd setup onboarding — Full wizard (alias for /gsd onboarding)\n\n" +
+    "Tip: /gsd onboarding --resume to continue an incomplete setup.",
     "info",
   );
 }
@@ -430,6 +461,11 @@ export async function handleCoreCommand(
   }
   if (trimmed === "setup" || trimmed.startsWith("setup ")) {
     await handleSetup(trimmed.replace(/^setup\s*/, "").trim(), ctx);
+    return true;
+  }
+  if (trimmed === "onboarding" || trimmed.startsWith("onboarding ")) {
+    const { handleOnboarding } = await import("./onboarding.js");
+    await handleOnboarding(trimmed.replace(/^onboarding\s*/, "").trim(), ctx);
     return true;
   }
   return false;

--- a/src/resources/extensions/gsd/commands/handlers/core.ts
+++ b/src/resources/extensions/gsd/commands/handlers/core.ts
@@ -179,7 +179,7 @@ export async function handleVisualize(ctx: ExtensionCommandContext): Promise<voi
   }
 }
 
-export async function handleSetup(args: string, ctx: ExtensionCommandContext): Promise<void> {
+export async function handleSetup(args: string, ctx: ExtensionCommandContext, pi?: ExtensionAPI): Promise<void> {
   const { detectProjectState, hasGlobalSetup } = await import("../../detection.js");
   const { isOnboardingComplete, readOnboardingRecord } = await import("../../onboarding-state.js");
 
@@ -207,9 +207,7 @@ export async function handleSetup(args: string, ctx: ExtensionCommandContext): P
     return;
   }
   if (args === "model") {
-    // pi (ExtensionAPI) isn't threaded into handleSetup today — handleModel
-    // accepts undefined and falls back to the no-pi code path.
-    await handleModel("", ctx, undefined);
+    await handleModel("", ctx, pi);
     return;
   }
   if (args === "keys") {
@@ -462,7 +460,7 @@ export async function handleCoreCommand(
     return true;
   }
   if (trimmed === "setup" || trimmed.startsWith("setup ")) {
-    await handleSetup(trimmed.replace(/^setup\s*/, "").trim(), ctx);
+    await handleSetup(trimmed.replace(/^setup\s*/, "").trim(), ctx, pi);
     return true;
   }
   if (trimmed === "onboarding" || trimmed.startsWith("onboarding ")) {

--- a/src/resources/extensions/gsd/commands/handlers/core.ts
+++ b/src/resources/extensions/gsd/commands/handlers/core.ts
@@ -207,7 +207,9 @@ export async function handleSetup(args: string, ctx: ExtensionCommandContext): P
     return;
   }
   if (args === "model") {
-    await handleModel("", ctx);
+    // pi (ExtensionAPI) isn't threaded into handleSetup today — handleModel
+    // accepts undefined and falls back to the no-pi code path.
+    await handleModel("", ctx, undefined);
     return;
   }
   if (args === "keys") {

--- a/src/resources/extensions/gsd/commands/handlers/onboarding.ts
+++ b/src/resources/extensions/gsd/commands/handlers/onboarding.ts
@@ -1,0 +1,199 @@
+// GSD — /gsd onboarding command handler (re-entry, --resume, --reset, --step)
+//
+// Provides the discoverable re-entry point for the onboarding wizard. The
+// first-run wizard in src/onboarding.ts is hidden behind shouldRunOnboarding;
+// this handler lets users re-launch it on demand.
+
+import type { ExtensionCommandContext } from "@gsd/pi-coding-agent"
+import { AuthStorage } from "@gsd/pi-coding-agent"
+import { authFilePath } from "../../../../../app-paths.js"
+import {
+  ONBOARDING_STEPS,
+  isValidStepId,
+  nearestResumeStep,
+  type OnboardingStepId,
+} from "../../setup-catalog.js"
+import {
+  isOnboardingComplete,
+  readOnboardingRecord,
+  resetOnboarding,
+} from "../../onboarding-state.js"
+
+interface ParsedArgs {
+  resume: boolean
+  reset: boolean
+  step: string | null
+  stepValid: boolean | null
+}
+
+function parseArgs(raw: string): ParsedArgs {
+  const tokens = raw.split(/\s+/).filter(Boolean)
+  const out: ParsedArgs = { resume: false, reset: false, step: null, stepValid: null }
+  for (let i = 0; i < tokens.length; i++) {
+    const t = tokens[i]
+    if (t === "--resume" || t === "resume") out.resume = true
+    else if (t === "--reset" || t === "reset") out.reset = true
+    else if (t === "--step" || t === "step") {
+      const next = tokens[i + 1]
+      if (next) {
+        out.step = next
+        out.stepValid = isValidStepId(next)
+        i++
+      }
+    } else if (t.startsWith("--step=")) {
+      const v = t.slice(7)
+      out.step = v
+      out.stepValid = isValidStepId(v)
+    }
+  }
+  return out
+}
+
+async function getAuthStorage(): Promise<AuthStorage> {
+  return AuthStorage.create(authFilePath)
+}
+
+async function runWholeWizard(ctx: ExtensionCommandContext, fromStep?: OnboardingStepId): Promise<void> {
+  const authStorage = await getAuthStorage()
+  // The first-run wizard ignores the resume hint today — it always walks the
+  // full sequence with skip prompts. We still mark completion at the end and
+  // record the resume hint for next time. This keeps the wizard linear and
+  // simple; per-step jump support comes via --step.
+  if (fromStep) {
+    ctx.ui.notify(
+      `Resuming from step: ${fromStep}. The wizard runs all remaining steps; press skip on any you've already configured.`,
+      "info",
+    )
+  }
+  const { runOnboarding } = await import("../../../../../onboarding.js")
+  await runOnboarding(authStorage)
+}
+
+async function runSingleStep(ctx: ExtensionCommandContext, stepId: OnboardingStepId): Promise<void> {
+  const authStorage = await getAuthStorage()
+  const ob = await import("../../../../../onboarding.js")
+  // Lazy-load clack + chalk via the same path the wizard uses
+  const p = await import("@clack/prompts")
+  const { default: chalk } = await import("chalk")
+  const pc = {
+    cyan: chalk.cyan, green: chalk.green, yellow: chalk.yellow,
+    dim: chalk.dim, bold: chalk.bold, red: chalk.red, reset: chalk.reset,
+  }
+
+  switch (stepId) {
+    case "llm":
+      await ob.runLlmStep(p as any, pc as any, authStorage)
+      return
+    case "search":
+      await ob.runWebSearchStep(p as any, pc as any, authStorage, false)
+      return
+    case "remote":
+      await ob.runRemoteQuestionsStep(p as any, pc as any, authStorage)
+      return
+    case "tool-keys":
+      await ob.runToolKeysStep(p as any, pc as any, authStorage)
+      return
+    case "model": {
+      // Delegate to /gsd model picker
+      const { handleCoreCommand } = await import("./core.js")
+      await handleCoreCommand("model", ctx)
+      return
+    }
+    case "prefs": {
+      const { ensurePreferencesFile, handlePrefsWizard } = await import("../../commands-prefs-wizard.js")
+      const { getGlobalGSDPreferencesPath } = await import("../../preferences.js")
+      await ensurePreferencesFile(getGlobalGSDPreferencesPath(), ctx, "global")
+      await handlePrefsWizard(ctx, "global")
+      return
+    }
+    case "doctor": {
+      // Best-effort: surface provider doctor results inline
+      try {
+        const { runProviderDoctor } = await import("../../doctor-providers.js") as any
+        if (typeof runProviderDoctor === "function") {
+          await runProviderDoctor(ctx)
+          return
+        }
+      } catch { /* fall through */ }
+      ctx.ui.notify("Run /gsd doctor to validate your setup.", "info")
+      return
+    }
+    case "skills": {
+      ctx.ui.notify("Skill install runs automatically during /gsd init. Use /gsd init or /skill manage.", "info")
+      return
+    }
+    case "project": {
+      const { handleCoreCommand } = await import("./core.js")
+      await handleCoreCommand("init", ctx)
+      return
+    }
+  }
+}
+
+function renderStatus(): string {
+  const r = readOnboardingRecord()
+  const lines: string[] = ["GSD Onboarding\n"]
+  if (r.completedAt) {
+    lines.push(`  Completed: ${r.completedAt}`)
+  } else {
+    lines.push(`  Status: not complete`)
+  }
+  if (r.lastResumePoint) lines.push(`  Last step: ${r.lastResumePoint}`)
+  lines.push("")
+  lines.push("  Steps:")
+  for (const step of ONBOARDING_STEPS) {
+    const mark = r.completedSteps.includes(step.id)
+      ? "✓"
+      : r.skippedSteps.includes(step.id)
+        ? "↷"
+        : "○"
+    const reqTag = step.required ? " (required)" : ""
+    lines.push(`    ${mark} ${step.id.padEnd(10)} — ${step.label}${reqTag}`)
+  }
+  return lines.join("\n")
+}
+
+export async function handleOnboarding(rawArgs: string, ctx: ExtensionCommandContext): Promise<void> {
+  const args = parseArgs(rawArgs.trim())
+
+  if (args.step !== null) {
+    if (!args.stepValid) {
+      const validIds = ONBOARDING_STEPS.map(s => s.id).join(", ")
+      ctx.ui.notify(`Unknown step "${args.step}". Valid: ${validIds}`, "warning")
+      return
+    }
+    await runSingleStep(ctx, args.step as OnboardingStepId)
+    return
+  }
+
+  if (args.reset) {
+    resetOnboarding()
+    ctx.ui.notify(
+      "Onboarding reset. Existing API keys/credentials are unchanged — manage them with /gsd keys.",
+      "info",
+    )
+    await runWholeWizard(ctx)
+    return
+  }
+
+  if (args.resume) {
+    const r = readOnboardingRecord()
+    const next = nearestResumeStep(r.lastResumePoint, r.completedSteps)
+    await runWholeWizard(ctx, next)
+    return
+  }
+
+  // No flags. If already complete, show status + offer choice.
+  if (isOnboardingComplete()) {
+    ctx.ui.notify(renderStatus(), "info")
+    ctx.ui.notify(
+      "Onboarding already complete. Use /gsd onboarding --reset to start over, or --step <name> to redo one section.",
+      "info",
+    )
+    return
+  }
+
+  await runWholeWizard(ctx)
+}
+
+export { renderStatus as renderOnboardingStatus }

--- a/src/resources/extensions/gsd/commands/handlers/onboarding.ts
+++ b/src/resources/extensions/gsd/commands/handlers/onboarding.ts
@@ -6,7 +6,8 @@
 
 import type { ExtensionCommandContext } from "@gsd/pi-coding-agent"
 import { AuthStorage } from "@gsd/pi-coding-agent"
-import { authFilePath } from "../../../../../app-paths.js"
+import { homedir } from "node:os"
+import { join } from "node:path"
 import {
   ONBOARDING_STEPS,
   isValidStepId,
@@ -18,6 +19,35 @@ import {
   readOnboardingRecord,
   resetOnboarding,
 } from "../../onboarding-state.js"
+
+// Inline auth path (mirrors src/app-paths.ts) — keep this module rootDir-clean
+// for the resources tsconfig. Importing from src/ pulls files outside
+// src/resources and breaks the build.
+const AUTH_FILE_PATH = join(
+  process.env.GSD_CODING_AGENT_DIR ||
+    join(process.env.GSD_HOME || join(homedir(), ".gsd"), "agent"),
+  "auth.json",
+)
+
+/**
+ * Dynamic import shim for the first-run wizard.
+ *
+ * src/onboarding.ts lives outside the resources rootDir, so a static import
+ * pulls it into this tsconfig project and triggers TS6059. We resolve the
+ * specifier through a variable + opaque type so TS can't pull the file at
+ * compile time; the path resolves correctly at runtime via dist/onboarding.js.
+ */
+type FirstRunWizardModule = {
+  runOnboarding: (storage: AuthStorage) => Promise<void>
+  runLlmStep: (...args: unknown[]) => Promise<unknown>
+  runWebSearchStep: (...args: unknown[]) => Promise<unknown>
+  runRemoteQuestionsStep: (...args: unknown[]) => Promise<unknown>
+  runToolKeysStep: (...args: unknown[]) => Promise<unknown>
+}
+async function loadFirstRunWizard(): Promise<FirstRunWizardModule> {
+  const specifier = "../../../../../onboarding.js"
+  return (await import(/* @vite-ignore */ specifier)) as FirstRunWizardModule
+}
 
 interface ParsedArgs {
   resume: boolean
@@ -50,7 +80,7 @@ function parseArgs(raw: string): ParsedArgs {
 }
 
 async function getAuthStorage(): Promise<AuthStorage> {
-  return AuthStorage.create(authFilePath)
+  return AuthStorage.create(AUTH_FILE_PATH)
 }
 
 async function runWholeWizard(ctx: ExtensionCommandContext, fromStep?: OnboardingStepId): Promise<void> {
@@ -65,13 +95,13 @@ async function runWholeWizard(ctx: ExtensionCommandContext, fromStep?: Onboardin
       "info",
     )
   }
-  const { runOnboarding } = await import("../../../../../onboarding.js")
+  const { runOnboarding } = await loadFirstRunWizard()
   await runOnboarding(authStorage)
 }
 
 async function runSingleStep(ctx: ExtensionCommandContext, stepId: OnboardingStepId): Promise<void> {
   const authStorage = await getAuthStorage()
-  const ob = await import("../../../../../onboarding.js")
+  const ob = await loadFirstRunWizard()
   // Lazy-load clack + chalk via the same path the wizard uses
   const p = await import("@clack/prompts")
   const { default: chalk } = await import("chalk")

--- a/src/resources/extensions/gsd/onboarding-state.ts
+++ b/src/resources/extensions/gsd/onboarding-state.ts
@@ -7,6 +7,7 @@
 import { existsSync, mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs"
 import { homedir } from "node:os"
 import { dirname, join } from "node:path"
+import { logWarning } from "./workflow-logger.js"
 
 /**
  * Bump `FLOW_VERSION` whenever a new required step is added to ONBOARDING_STEPS.
@@ -87,10 +88,10 @@ export function writeOnboardingRecord(patch: Partial<OnboardingRecord>): Onboard
   } catch (err) {
     // Non-fatal for the wizard, but make the failure diagnosable. The next boot
     // will re-prompt for onboarding because the record didn't persist; the
-    // stderr message tells the user why.
-    process.stderr.write(
-      `[gsd] Failed to persist onboarding record (${FILE}): ${err instanceof Error ? err.message : String(err)}\n`,
-    )
+    // logWarning entry tells the user why.
+    logWarning("state", `Failed to persist onboarding record: ${err instanceof Error ? err.message : String(err)}`, {
+      file: FILE,
+    })
   }
   return next
 }

--- a/src/resources/extensions/gsd/onboarding-state.ts
+++ b/src/resources/extensions/gsd/onboarding-state.ts
@@ -1,0 +1,139 @@
+// GSD — Onboarding completion record (~/.gsd/agent/onboarding.json)
+//
+// First-class state for the onboarding wizard so re-entry, resume, and the
+// web boot probe all read the same source of truth. Replaces the implicit
+// "settings.defaultProvider exists" heuristic.
+
+import { existsSync, mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs"
+import { dirname, join } from "node:path"
+import { agentDir } from "../../../app-paths.js"
+
+/**
+ * Bump `FLOW_VERSION` whenever a new required step is added to ONBOARDING_STEPS.
+ * Records with an older flowVersion are treated as "needs partial re-onboarding"
+ * by isOnboardingComplete().
+ */
+export const FLOW_VERSION = 1
+
+const RECORD_VERSION = 1
+const FILE = join(agentDir, "onboarding.json")
+
+export interface OnboardingRecord {
+  version: number
+  flowVersion: number
+  completedAt: string | null
+  completedSteps: string[]
+  skippedSteps: string[]
+  lastResumePoint: string | null
+}
+
+const DEFAULT: OnboardingRecord = {
+  version: RECORD_VERSION,
+  flowVersion: FLOW_VERSION,
+  completedAt: null,
+  completedSteps: [],
+  skippedSteps: [],
+  lastResumePoint: null,
+}
+
+export function readOnboardingRecord(): OnboardingRecord {
+  if (!existsSync(FILE)) return { ...DEFAULT }
+  try {
+    const raw = JSON.parse(readFileSync(FILE, "utf-8")) as Partial<OnboardingRecord>
+    return {
+      version: typeof raw.version === "number" ? raw.version : RECORD_VERSION,
+      flowVersion: typeof raw.flowVersion === "number" ? raw.flowVersion : 0,
+      completedAt: typeof raw.completedAt === "string" ? raw.completedAt : null,
+      completedSteps: Array.isArray(raw.completedSteps) ? raw.completedSteps.filter(s => typeof s === "string") : [],
+      skippedSteps: Array.isArray(raw.skippedSteps) ? raw.skippedSteps.filter(s => typeof s === "string") : [],
+      lastResumePoint: typeof raw.lastResumePoint === "string" ? raw.lastResumePoint : null,
+    }
+  } catch {
+    // Corrupt/unreadable — fall back to defaults rather than crashing onboarding flow
+    return { ...DEFAULT }
+  }
+}
+
+function atomicWrite(record: OnboardingRecord): void {
+  mkdirSync(dirname(FILE), { recursive: true })
+  const tmp = `${FILE}.tmp.${process.pid}.${Date.now()}`
+  try {
+    writeFileSync(tmp, JSON.stringify(record, null, 2), "utf-8")
+    renameSync(tmp, FILE)
+  } catch (err) {
+    // Best-effort: drop the tmp file if the rename failed (don't leak stale tmps)
+    try { if (existsSync(tmp)) unlinkSync(tmp) } catch { /* swallow secondary error */ }
+    throw err
+  }
+}
+
+export function writeOnboardingRecord(patch: Partial<OnboardingRecord>): OnboardingRecord {
+  const current = readOnboardingRecord()
+  const next: OnboardingRecord = {
+    ...current,
+    ...patch,
+    version: RECORD_VERSION,
+    // flowVersion is sticky on writes unless explicitly patched
+    flowVersion: typeof patch.flowVersion === "number" ? patch.flowVersion : current.flowVersion,
+  }
+  try {
+    atomicWrite(next)
+  } catch (err) {
+    // Non-fatal for the wizard, but make the failure diagnosable. The next boot
+    // will re-prompt for onboarding because the record didn't persist; the
+    // stderr message tells the user why.
+    process.stderr.write(
+      `[gsd] Failed to persist onboarding record (${FILE}): ${err instanceof Error ? err.message : String(err)}\n`,
+    )
+  }
+  return next
+}
+
+/**
+ * Onboarding is "complete" when there's a completedAt timestamp AND the
+ * flowVersion matches the current FLOW_VERSION. A flowVersion bump means
+ * a new required step exists and the user should re-enter to configure it.
+ */
+export function isOnboardingComplete(): boolean {
+  const r = readOnboardingRecord()
+  return r.completedAt !== null && r.flowVersion === FLOW_VERSION
+}
+
+export function markStepCompleted(stepId: string): void {
+  const r = readOnboardingRecord()
+  if (r.completedSteps.includes(stepId)) {
+    writeOnboardingRecord({ lastResumePoint: stepId })
+    return
+  }
+  writeOnboardingRecord({
+    completedSteps: [...r.completedSteps, stepId],
+    skippedSteps: r.skippedSteps.filter(s => s !== stepId),
+    lastResumePoint: stepId,
+  })
+}
+
+export function markStepSkipped(stepId: string): void {
+  const r = readOnboardingRecord()
+  if (r.skippedSteps.includes(stepId) || r.completedSteps.includes(stepId)) return
+  writeOnboardingRecord({
+    skippedSteps: [...r.skippedSteps, stepId],
+    lastResumePoint: stepId,
+  })
+}
+
+export function markOnboardingComplete(completedSteps: string[]): void {
+  writeOnboardingRecord({
+    completedAt: new Date().toISOString(),
+    flowVersion: FLOW_VERSION,
+    completedSteps,
+  })
+}
+
+export function resetOnboarding(): void {
+  writeOnboardingRecord({
+    completedAt: null,
+    completedSteps: [],
+    skippedSteps: [],
+    lastResumePoint: null,
+  })
+}

--- a/src/resources/extensions/gsd/onboarding-state.ts
+++ b/src/resources/extensions/gsd/onboarding-state.ts
@@ -5,8 +5,8 @@
 // "settings.defaultProvider exists" heuristic.
 
 import { existsSync, mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs"
+import { homedir } from "node:os"
 import { dirname, join } from "node:path"
-import { agentDir } from "../../../app-paths.js"
 
 /**
  * Bump `FLOW_VERSION` whenever a new required step is added to ONBOARDING_STEPS.
@@ -16,7 +16,13 @@ import { agentDir } from "../../../app-paths.js"
 export const FLOW_VERSION = 1
 
 const RECORD_VERSION = 1
-const FILE = join(agentDir, "onboarding.json")
+// Inline agentDir computation (mirrors src/app-paths.ts) — keep this module
+// rootDir-clean for the resources tsconfig; importing from src/ pulls files
+// outside src/resources and breaks the build.
+const AGENT_DIR =
+  process.env.GSD_CODING_AGENT_DIR ||
+  join(process.env.GSD_HOME || join(homedir(), ".gsd"), "agent")
+const FILE = join(AGENT_DIR, "onboarding.json")
 
 export interface OnboardingRecord {
   version: number

--- a/src/resources/extensions/gsd/setup-catalog.ts
+++ b/src/resources/extensions/gsd/setup-catalog.ts
@@ -1,0 +1,104 @@
+// GSD — Setup catalog (single source of truth for onboarding steps + provider sub-views)
+//
+// Re-exports filtered views over PROVIDER_REGISTRY (key-manager.ts) and owns the
+// canonical ONBOARDING_STEPS list. Consumers (CLI wizard, /gsd setup hub,
+// onboarding handler, web alignment) all read from here so adding a step or
+// provider lands in one place. Keep this module thin: no behavior beyond
+// filters + lookup helpers, so it stays cycle-safe even though it depends on
+// key-manager for the provider catalog.
+
+import { PROVIDER_REGISTRY, type ProviderInfo } from "./key-manager.js"
+
+export type OnboardingStepId =
+  | "llm"
+  | "model"
+  | "search"
+  | "remote"
+  | "tool-keys"
+  | "prefs"
+  | "skills"
+  | "doctor"
+  | "project"
+
+export interface OnboardingStepDef {
+  id: OnboardingStepId
+  label: string
+  /** Required steps gate the "complete" flag. Skipped required steps mark the wizard incomplete. */
+  required: boolean
+  /** Short description shown in /gsd setup status hub. */
+  hint: string
+}
+
+/**
+ * Canonical ordered list of onboarding steps.
+ *
+ * To add a new step:
+ *   1. Append here (or insert at the right position).
+ *   2. Bump FLOW_VERSION in onboarding-state.ts so existing users get re-prompted.
+ *   3. Wire its CLI runner in src/onboarding.ts (and handlers/onboarding.ts for --step).
+ */
+export const ONBOARDING_STEPS: readonly OnboardingStepDef[] = [
+  { id: "llm",       label: "LLM provider & auth",      required: true,  hint: "Sign in or paste an API key" },
+  { id: "model",     label: "Default model",            required: false, hint: "Pick a default model for the chosen provider" },
+  { id: "search",    label: "Web search provider",      required: false, hint: "Brave, Tavily, or Anthropic built-in" },
+  { id: "remote",    label: "Remote questions",         required: false, hint: "Discord / Slack / Telegram notifications" },
+  { id: "tool-keys", label: "Tool API keys",            required: false, hint: "Context7, Jina, Groq voice, etc." },
+  { id: "prefs",     label: "Global preferences",       required: false, hint: "Mode, profile, notifications" },
+  { id: "skills",    label: "Skills install",           required: false, hint: "Browse and install skill plugins" },
+  { id: "doctor",    label: "Validate setup",           required: false, hint: "Run provider doctor checks" },
+  { id: "project",   label: "Project init",             required: false, hint: "Bootstrap .gsd/ in this repo" },
+]
+
+const STEP_INDEX = new Map(ONBOARDING_STEPS.map((s, i) => [s.id, i]))
+
+export function getStep(id: string): OnboardingStepDef | undefined {
+  return ONBOARDING_STEPS.find(s => s.id === id)
+}
+
+export function isValidStepId(id: string): id is OnboardingStepId {
+  return STEP_INDEX.has(id as OnboardingStepId)
+}
+
+/**
+ * Given a possibly-stale resume point, return the nearest next step that is
+ * still defined in the catalog. Falls back to the first step.
+ */
+export function nearestResumeStep(lastResumePoint: string | null, completedSteps: string[]): OnboardingStepId {
+  const completed = new Set(completedSteps)
+  // First incomplete step at or after the lastResumePoint
+  let startIdx = 0
+  if (lastResumePoint && STEP_INDEX.has(lastResumePoint as OnboardingStepId)) {
+    startIdx = STEP_INDEX.get(lastResumePoint as OnboardingStepId) ?? 0
+  }
+  for (let i = startIdx; i < ONBOARDING_STEPS.length; i++) {
+    if (!completed.has(ONBOARDING_STEPS[i].id)) return ONBOARDING_STEPS[i].id
+  }
+  // Everything from the resume point is complete — try from the start
+  for (const step of ONBOARDING_STEPS) {
+    if (!completed.has(step.id)) return step.id
+  }
+  return ONBOARDING_STEPS[0].id
+}
+
+// ─── Provider catalog views ───────────────────────────────────────────────────
+
+export function getLlmProviders(): ProviderInfo[] {
+  return PROVIDER_REGISTRY.filter(p => p.category === "llm")
+}
+
+export function getToolProviders(): ProviderInfo[] {
+  return PROVIDER_REGISTRY.filter(p => p.category === "tool")
+}
+
+export function getSearchProviders(): ProviderInfo[] {
+  return PROVIDER_REGISTRY.filter(p => p.category === "search")
+}
+
+export function getRemoteProviders(): ProviderInfo[] {
+  return PROVIDER_REGISTRY.filter(p => p.category === "remote")
+}
+
+/** Provider IDs that count as "the user has an LLM configured" for shouldRunOnboarding. */
+export function getLlmProviderIds(): string[] {
+  return getLlmProviders().map(p => p.id).concat(["claude-code"])
+}

--- a/src/resources/extensions/gsd/setup-catalog.ts
+++ b/src/resources/extensions/gsd/setup-catalog.ts
@@ -52,7 +52,8 @@ export const ONBOARDING_STEPS: readonly OnboardingStepDef[] = [
 const STEP_INDEX = new Map(ONBOARDING_STEPS.map((s, i) => [s.id, i]))
 
 export function getStep(id: string): OnboardingStepDef | undefined {
-  return ONBOARDING_STEPS.find(s => s.id === id)
+  const idx = STEP_INDEX.get(id as OnboardingStepId)
+  return idx === undefined ? undefined : ONBOARDING_STEPS[idx]
 }
 
 export function isValidStepId(id: string): id is OnboardingStepId {
@@ -100,5 +101,5 @@ export function getRemoteProviders(): ProviderInfo[] {
 
 /** Provider IDs that count as "the user has an LLM configured" for shouldRunOnboarding. */
 export function getLlmProviderIds(): string[] {
-  return getLlmProviders().map(p => p.id).concat(["claude-code"])
+  return Array.from(new Set([...getLlmProviders().map(p => p.id), "claude-code"]))
 }

--- a/src/resources/extensions/gsd/tests/onboarding-state.test.ts
+++ b/src/resources/extensions/gsd/tests/onboarding-state.test.ts
@@ -1,0 +1,105 @@
+// GSD — Onboarding state record tests.
+// Verifies the explicit completion record (onboarding-state.ts) and step-evolution
+// behavior in setup-catalog.ts, including stale-resume fallback and version semantics.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// Tests must isolate per-process to avoid clobbering the user's real ~/.gsd/agent/onboarding.json.
+// We point GSD_HOME at a fresh tmp dir before importing the modules under test.
+const tmpHome = mkdtempSync(join(tmpdir(), "gsd-onboarding-state-test-"));
+process.env.GSD_HOME = tmpHome;
+
+const state = await import("../onboarding-state.ts");
+const catalog = await import("../setup-catalog.ts");
+
+test.after(() => {
+  try { rmSync(tmpHome, { recursive: true, force: true }); } catch { /* ignore */ }
+});
+
+test("default record returns when no file exists", () => {
+  const r = state.readOnboardingRecord();
+  assert.equal(r.completedAt, null);
+  assert.deepEqual(r.completedSteps, []);
+  assert.equal(r.flowVersion, state.FLOW_VERSION);
+});
+
+test("isOnboardingComplete is false until markOnboardingComplete is called", () => {
+  state.resetOnboarding();
+  assert.equal(state.isOnboardingComplete(), false);
+  state.markOnboardingComplete(["llm"]);
+  assert.equal(state.isOnboardingComplete(), true);
+});
+
+test("markStepCompleted updates lastResumePoint and dedupes", () => {
+  state.resetOnboarding();
+  state.markStepCompleted("llm");
+  state.markStepCompleted("search");
+  state.markStepCompleted("llm"); // dup
+  const r = state.readOnboardingRecord();
+  assert.deepEqual(r.completedSteps.filter(s => s === "llm"), ["llm"]);
+  assert.equal(r.lastResumePoint, "llm"); // last write wins, even on dup
+});
+
+test("markStepSkipped excludes already-completed steps", () => {
+  state.resetOnboarding();
+  state.markStepCompleted("llm");
+  state.markStepSkipped("llm");
+  const r = state.readOnboardingRecord();
+  assert.equal(r.skippedSteps.includes("llm"), false);
+});
+
+test("resetOnboarding clears completion but preserves flowVersion", () => {
+  state.markOnboardingComplete(["llm", "search"]);
+  state.resetOnboarding();
+  const r = state.readOnboardingRecord();
+  assert.equal(r.completedAt, null);
+  assert.deepEqual(r.completedSteps, []);
+  assert.equal(r.flowVersion, state.FLOW_VERSION);
+});
+
+test("flowVersion mismatch invalidates completion (forces re-onboarding)", () => {
+  state.markOnboardingComplete(["llm"]);
+  // Simulate a flow version bump after the user completed an older flow.
+  state.writeOnboardingRecord({ flowVersion: state.FLOW_VERSION - 1 });
+  assert.equal(state.isOnboardingComplete(), false);
+});
+
+test("nearestResumeStep returns first incomplete when resume point is stale", () => {
+  // Stale ID — not in catalog
+  const next = catalog.nearestResumeStep("nonexistent-step", []);
+  assert.equal(next, "llm"); // first step in ONBOARDING_STEPS
+});
+
+test("nearestResumeStep skips already-completed steps from the resume point", () => {
+  const completed = ["llm", "model"];
+  const next = catalog.nearestResumeStep("llm", completed);
+  // First step at-or-after llm that isn't in completed
+  assert.equal(next, "search");
+});
+
+test("nearestResumeStep wraps to start when everything from the point is complete", () => {
+  const allDone = catalog.ONBOARDING_STEPS.map(s => s.id);
+  const next = catalog.nearestResumeStep("llm", allDone.slice(0, allDone.length - 1));
+  // Only the last step is incomplete
+  assert.equal(next, allDone[allDone.length - 1]);
+});
+
+test("isValidStepId accepts catalog ids and rejects others", () => {
+  assert.equal(catalog.isValidStepId("llm"), true);
+  assert.equal(catalog.isValidStepId("tool-keys"), true);
+  assert.equal(catalog.isValidStepId("garbage"), false);
+});
+
+test("corrupt onboarding.json falls back to defaults instead of crashing", async () => {
+  const { writeFileSync } = await import("node:fs");
+  const { join } = await import("node:path");
+  const filePath = join(tmpHome, "agent", "onboarding.json");
+  writeFileSync(filePath, "{ this is not json", "utf-8");
+  const r = state.readOnboardingRecord();
+  assert.equal(r.completedAt, null);
+  assert.deepEqual(r.completedSteps, []);
+});

--- a/src/web/onboarding-service.ts
+++ b/src/web/onboarding-service.ts
@@ -117,6 +117,22 @@ export interface OnboardingBridgeAuthRefreshState {
   error: string | null;
 }
 
+/**
+ * CLI-side onboarding completion record exposed to the web client.
+ *
+ * Mirrors the JSON written by `src/resources/extensions/gsd/onboarding-state.ts`.
+ * Read-only metadata: lets the web UI render "setup complete (date)" indicators
+ * and offer a "re-run setup" affordance. Does NOT influence the `locked` flag —
+ * lock semantics still depend on whether a required provider is configured.
+ */
+export interface OnboardingCompletionRecord {
+  completedAt: string | null;
+  completedSteps: string[];
+  skippedSteps: string[];
+  lastResumePoint: string | null;
+  flowVersion: number;
+}
+
 export interface OnboardingState {
   status: "blocked" | "ready";
   locked: boolean;
@@ -136,6 +152,8 @@ export interface OnboardingState {
   lastValidation: OnboardingValidationResult | null;
   activeFlow: OnboardingProviderFlowState | null;
   bridgeAuthRefresh: OnboardingBridgeAuthRefreshState;
+  /** CLI-side onboarding wizard completion record. Null if never completed. Optional for back-compat with existing fixtures. */
+  completionRecord?: OnboardingCompletionRecord | null;
 }
 
 type ProviderFlowRuntime = {
@@ -739,6 +757,24 @@ export class OnboardingService {
     const optionalSections = this.buildOptionalSectionState(authStorage);
     const lockReason = resolveOnboardingLockReason(Boolean(satisfiedByProvider), this.bridgeAuthRefresh);
 
+    // Read CLI-side completion record (best-effort — never throw)
+    let completionRecord: OnboardingCompletionRecord | null = null;
+    try {
+      const { readOnboardingRecord, isOnboardingComplete } = await import(
+        "../resources/extensions/gsd/onboarding-state.js"
+      );
+      const r = readOnboardingRecord();
+      completionRecord = {
+        completedAt: isOnboardingComplete() ? r.completedAt : null,
+        completedSteps: r.completedSteps,
+        skippedSteps: r.skippedSteps,
+        lastResumePoint: r.lastResumePoint,
+        flowVersion: r.flowVersion,
+      };
+    } catch {
+      completionRecord = null;
+    }
+
     return {
       status: lockReason ? "blocked" : "ready",
       locked: lockReason !== null,
@@ -763,6 +799,7 @@ export class OnboardingService {
       lastValidation: this.lastValidation ? { ...this.lastValidation } : null,
       activeFlow: this.activeFlow ? structuredClone(this.activeFlow.state) : null,
       bridgeAuthRefresh: { ...this.bridgeAuthRefresh },
+      completionRecord,
     };
   }
 


### PR DESCRIPTION
## TL;DR

**What:** Adds `/gsd onboarding` (re-entry with `--resume` / `--reset` / `--step`), turns `/gsd setup` into a real status hub, and consolidates duplicated provider catalogs into one source of truth.
**Why:** Users had no way back into the onboarding wizard after dismissing it, and `/gsd setup` vs `/gsd prefs` vs `/gsd config` vs `/gsd keys` was confusing — partly because `setup` was just a redirect hub and `setup prefs` was a literal alias for `prefs`.
**How:** Persist completion in `~/.gsd/agent/onboarding.json`, dispatch `/gsd onboarding` against exported step functions in `src/onboarding.ts`, route the `/gsd setup` sub-routes through canonical commands, deprecate `/gsd config` (one-shot warning).

## What

**New files**
- `src/resources/extensions/gsd/onboarding-state.ts` — explicit completion record at `~/.gsd/agent/onboarding.json`. Atomic writes, tmp cleanup on rename failure, stderr diagnostics, `flowVersion` for step-evolution semantics.
- `src/resources/extensions/gsd/setup-catalog.ts` — single source for \`ONBOARDING_STEPS\` + filtered views over \`PROVIDER_REGISTRY\`. Eliminates 3 duplicated \`TOOL_KEYS\` / \`LLM_PROVIDER_IDS\` lists across the codebase.
- `src/resources/extensions/gsd/commands/handlers/onboarding.ts` — `/gsd onboarding` handler. Parses `--resume` / `--reset` / `--step <id>`. Stale-resume falls back to the nearest incomplete step.
- `src/resources/extensions/gsd/tests/onboarding-state.test.ts` — 11 tests.

**Modified**
- `src/onboarding.ts` — exports the four step runners (so the handler can target one), sources LLM IDs from the catalog, marks per-step completion, and calls `markOnboardingComplete` at the end. `shouldRunOnboarding` consults `isOnboardingComplete()`.
- `commands/handlers/core.ts` — `handleSetup` is now a status hub (with `model` and `onboarding` subroutes). `/gsd onboarding` is wired in `handleCoreCommand`. Help text updated.
- `commands/catalog.ts` — adds `onboarding` to top-level subcommands, expands `setup` completions, marks `config` as deprecated.
- `commands-config.ts` — one-shot session deprecation warning for `/gsd config`.
- `src/web/onboarding-service.ts` — exposes optional `completionRecord` on `OnboardingState`. Web lock semantics unchanged.

## Why

Three real pain points before this:

1. **No re-entry.** Once a user dismissed/finished the first-run wizard, there was no command, flag, or env var to re-launch it. The only mechanism was a dev-only \`forceOnboarding\` override on the web side.
2. **`setup` vs `prefs` overlap.** `/gsd setup prefs`, `/gsd prefs`, `/gsd prefs global`, and `/gsd prefs wizard` were all the same function call — but the help text didn't say so. `/gsd setup` (bare) was effectively a read-only redirect hub.
3. **Catalog drift.** Three independent \`TOOL_KEYS\` declarations (in \`src/onboarding.ts\`, \`commands-config.ts\`, plus \`PROVIDER_REGISTRY\` in \`key-manager.ts\`) and a separate web optional-section catalog meant adding a provider had to land in 3-4 places.

## How

- **Completion record.** \`~/.gsd/agent/onboarding.json\` with \`completedAt\`, \`completedSteps\`, \`skippedSteps\`, \`lastResumePoint\`, \`flowVersion\`. Atomic \`renameSync\` writes via tmp file. \`flowVersion\` lets us bump \"required steps\" later and force partial re-onboarding without invalidating credentials.
- **\`/gsd onboarding\` handler.** Parses three flags. \`--resume\` reads \`lastResumePoint\` and falls back to the nearest catalog step if it's stale. \`--reset\` clears the record (does **not** clear API keys; that's \`/gsd keys\`). \`--step <id>\` validates against the catalog and dispatches to a single step runner.
- **\`/gsd setup\` hub.** Bare \`setup\` shows status (onboarding state + global prefs + project detection) plus the menu of subroutes. Subroutes like \`setup llm\` / \`setup search\` / \`setup remote\` now delegate to \`/gsd onboarding --step\`. \`setup keys\` delegates to \`/gsd keys\` with a tip noting the canonical command. \`setup prefs\` is preserved as an alias for \`/gsd prefs\` so existing muscle memory keeps working.
- **Setup catalog.** \`ONBOARDING_STEPS\` registry + helpers (\`getLlmProviders\`, \`getToolProviders\`, etc.) on top of \`PROVIDER_REGISTRY\`. \`src/onboarding.ts\` no longer maintains its own \`LLM_PROVIDER_IDS\` array.
- **Web alignment.** \`buildState\` reads the CLI completion record and exposes it on the response. The field is optional so existing fixtures don't break. Web UI integration is a follow-up.

## Testing

- 11 new tests in \`onboarding-state.test.ts\` (defaults, completion, dedup, version mismatch, stale-resume, corrupt-file fallback).
- All 4 pre-existing onboarding tests still pass.
- \`tsc --noEmit\` clean.
- Existing tests not regressed (5 unrelated failures in the worktree are missing build artifacts — they pass on a built tree).

## Follow-ups (already filed)

- Closes nothing in this PR. Three follow-ups filed:
  - #4453 — refactor \`/gsd init\` to route project preferences through \`handlePrefsWizard\` (eliminate the parallel write path).
  - #4454 — surface the new \`completionRecord\` in the web UI (\"Re-run setup\" affordance).
  - #4455 — hard-remove \`/gsd config\` after one release of the warn-and-redirect.

## Breaking changes

None intentional. \`/gsd config\` still works (with a one-shot deprecation warning). All existing commands and aliases preserved.

## AI-assisted

This PR was AI-assisted. Design + implementation reviewed by a peer-review pass and a 3-reviewer code review pass; high-confidence findings addressed in-PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `/gsd onboarding` command to manage setup wizard flow with `--resume`, `--reset`, and `--step` flags.
  * Onboarding progress now persists, allowing users to resume from their last step.
  * Onboarding status displays completion time and step-by-step progress tracking.

* **Deprecations**
  * `/gsd config` is deprecated; use `/gsd keys` instead.

* **Improvements**
  * `/gsd setup` now displays as a configuration hub with onboarding status and available options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->