### PR TITLE
refactor(gsd): route /gsd init preferences through unified writer

### DIFF
--- a/src/resources/extensions/gsd/commands-prefs-wizard.ts
+++ b/src/resources/extensions/gsd/commands-prefs-wizard.ts
@@ -700,8 +700,13 @@ export async function handlePrefsWizard(
   ctx: ExtensionCommandContext,
   scope: "global" | "project",
   prefill?: Record<string, unknown>,
+  opts?: { pathOverride?: string },
 ): Promise<void> {
-  const path = scope === "project" ? getProjectGSDPreferencesPath() : getGlobalGSDPreferencesPath();
+  // pathOverride lets callers like /gsd init pass a basePath-derived target
+  // path so the wizard doesn't fall back to cwd-based getProjectGSDPreferencesPath
+  // when the init target diverges from the current working directory.
+  const path = opts?.pathOverride
+    ?? (scope === "project" ? getProjectGSDPreferencesPath() : getGlobalGSDPreferencesPath());
   const existing = scope === "project" ? loadProjectGSDPreferences() : loadGlobalGSDPreferences();
   // Order: existing-on-disk values, overlaid with prefill (caller's seeded answers).
   // Callers like /gsd init pass freshly-collected init answers as prefill so the

--- a/src/resources/extensions/gsd/commands-prefs-wizard.ts
+++ b/src/resources/extensions/gsd/commands-prefs-wizard.ts
@@ -699,10 +699,17 @@ async function configureAdvanced(ctx: ExtensionCommandContext, prefs: Record<str
 export async function handlePrefsWizard(
   ctx: ExtensionCommandContext,
   scope: "global" | "project",
+  prefill?: Record<string, unknown>,
 ): Promise<void> {
   const path = scope === "project" ? getProjectGSDPreferencesPath() : getGlobalGSDPreferencesPath();
   const existing = scope === "project" ? loadProjectGSDPreferences() : loadGlobalGSDPreferences();
-  const prefs: Record<string, unknown> = existing?.preferences ? { ...existing.preferences } : {};
+  // Order: existing-on-disk values, overlaid with prefill (caller's seeded answers).
+  // Callers like /gsd init pass freshly-collected init answers as prefill so the
+  // wizard menu shows them populated and writeable in one place.
+  const prefs: Record<string, unknown> = {
+    ...(existing?.preferences ?? {}),
+    ...(prefill ?? {}),
+  };
 
   ctx.ui.notify(`GSD preferences (${scope}) — pick a category to configure.`, "info");
 
@@ -734,23 +741,48 @@ export async function handlePrefsWizard(
     else if (choice.startsWith("Advanced"))      await configureAdvanced(ctx, prefs);
   }
 
-  // ─── Serialize to frontmatter ───────────────────────────────────────────
-  prefs.version = prefs.version || 1;
-  const frontmatter = serializePreferencesToFrontmatter(prefs);
+  await writePreferencesFile(path, prefs, ctx, { scope });
+}
 
-  // Preserve existing body content (everything after closing ---)
-  let body = "\n# GSD Skill Preferences\n\nSee `~/.gsd/agent/extensions/gsd/docs/preferences-reference.md` for full field documentation and examples.\n";
+/**
+ * Single source of truth for writing a PREFERENCES.md file.
+ *
+ * Both `/gsd init` and the prefs wizard route through this helper so we can't
+ * drift on serialization, body preservation, or post-write reload. Callers
+ * pass `ctx` for the reload/notify side effects; the function is safe to call
+ * without a full UI context for tests via `ctx: null` (skips reload/notify).
+ */
+export async function writePreferencesFile(
+  path: string,
+  prefs: Record<string, unknown>,
+  ctx: ExtensionCommandContext | null,
+  opts?: { scope?: "global" | "project"; defaultBody?: string; notifyOnSave?: boolean },
+): Promise<void> {
+  const next = { ...prefs, version: prefs.version || 1 };
+  const frontmatter = serializePreferencesToFrontmatter(next);
+
+  const fallbackBody = opts?.defaultBody
+    ?? "\n# GSD Skill Preferences\n\nSee `~/.gsd/agent/extensions/gsd/docs/preferences-reference.md` for full field documentation and examples.\n";
+
+  // Preserve existing body content (everything after closing ---) so users
+  // who edited the markdown body don't lose their notes.
+  let body = fallbackBody;
   if (existsSync(path)) {
     const preserved = extractBodyAfterFrontmatter(readFileSync(path, "utf-8"));
     if (preserved) body = preserved;
   }
 
   const content = `---\n${frontmatter}---${body}`;
-
   await saveFile(path, content);
-  await ctx.waitForIdle();
-  await ctx.reload();
-  ctx.ui.notify(`Saved ${scope} preferences to ${path}`, "info");
+
+  if (ctx) {
+    await ctx.waitForIdle();
+    await ctx.reload();
+    if (opts?.notifyOnSave !== false) {
+      const scopeLabel = opts?.scope ? `${opts.scope} ` : "";
+      ctx.ui.notify(`Saved ${scopeLabel}preferences to ${path}`, "info");
+    }
+  }
 }
 
 /** Wrap a YAML value in double quotes if it contains special characters. */

--- a/src/resources/extensions/gsd/init-wizard.ts
+++ b/src/resources/extensions/gsd/init-wizard.ts
@@ -18,7 +18,6 @@ import type { ProjectDetection, ProjectSignals } from "./detection.js";
 import { runSkillInstallStep } from "./skill-catalog.js";
 import { generateCodebaseMap, writeCodebaseMap } from "./codebase-generator.js";
 import { handlePrefsWizard, writePreferencesFile } from "./commands-prefs-wizard.js";
-import { getProjectGSDPreferencesPath } from "./preferences.js";
 
 // ─── Types ──────────────────────────────────────────────────────────────────────
 
@@ -234,16 +233,12 @@ export async function showProjectInit(
     // Non-fatal — skill installation failure should never block project init
   }
 
-  // ── Step 9: Bootstrap .gsd/ ────────────────────────────────────────────────
-  // Create directory + context.md, then route preferences through the unified
+  // ── Step 9: Optional full-prefs review ─────────────────────────────────────
+  // Ask BEFORE bootstrapping so a defer (`not_yet`) leaves the project untouched.
+  // Once the user commits, we bootstrap and route preferences through the unified
   // writer (commands-prefs-wizard.writePreferencesFile) so init and the prefs
-  // wizard share one serializer. Optional follow-up step lets the user open
-  // the full prefs wizard with their init answers pre-populated, surfacing
-  // every configurable preference instead of just the init-wizard subset.
-  bootstrapGsdDirectoryStructure(basePath, signals);
-  const prefillPrefs = mapInitPrefsToWizardShape(prefs);
-
-  // ── Step 9b: Optional full-prefs review ────────────────────────────────────
+  // wizard share one serializer. The "Open full wizard" branch surfaces every
+  // configurable preference, prefilled with the init answers.
   const reviewChoice = await showNextAction(ctx, {
     title: "GSD — Review All Preferences (Optional)",
     summary: [
@@ -259,12 +254,27 @@ export async function showProjectInit(
     notYetMessage: "Run /gsd init when ready.",
   });
 
+  if (reviewChoice === "not_yet") {
+    // User deferred — don't create .gsd/ or persist preferences. Pre-step state
+    // (e.g. git init from Step 2) remains as-is, matching prior step semantics.
+    return { completed: false, bootstrapped: false };
+  }
+
+  // ── Step 10: Bootstrap .gsd/ + write preferences ───────────────────────────
+  bootstrapGsdDirectoryStructure(basePath, signals);
+  const prefillPrefs = mapInitPrefsToWizardShape(prefs);
+  // Always derive the preferences path from basePath so init writing the
+  // structure to one location and preferences to another (cwd-derived) is
+  // impossible — see #4457 codex review.
+  const projectPrefsPath = join(gsdRoot(basePath), "PREFERENCES.md");
+
   if (reviewChoice === "review") {
-    // The wizard handles its own write via writePreferencesFile internally.
-    await handlePrefsWizard(ctx, "project", prefillPrefs);
+    // Wizard writes via writePreferencesFile internally; pass pathOverride so it
+    // targets basePath rather than cwd.
+    await handlePrefsWizard(ctx, "project", prefillPrefs, { pathOverride: projectPrefsPath });
   } else {
     // Direct path: write the init-collected prefs through the unified writer.
-    await writePreferencesFile(getProjectGSDPreferencesPath(), prefillPrefs, ctx, {
+    await writePreferencesFile(projectPrefsPath, prefillPrefs, ctx, {
       scope: "project",
       defaultBody: buildInitPreferencesBody(),
       notifyOnSave: false,

--- a/src/resources/extensions/gsd/init-wizard.ts
+++ b/src/resources/extensions/gsd/init-wizard.ts
@@ -17,6 +17,8 @@ import { assertSafeDirectory } from "./validate-directory.js";
 import type { ProjectDetection, ProjectSignals } from "./detection.js";
 import { runSkillInstallStep } from "./skill-catalog.js";
 import { generateCodebaseMap, writeCodebaseMap } from "./codebase-generator.js";
+import { handlePrefsWizard, writePreferencesFile } from "./commands-prefs-wizard.js";
+import { getProjectGSDPreferencesPath } from "./preferences.js";
 
 // ─── Types ──────────────────────────────────────────────────────────────────────
 
@@ -233,7 +235,41 @@ export async function showProjectInit(
   }
 
   // ── Step 9: Bootstrap .gsd/ ────────────────────────────────────────────────
-  bootstrapGsdDirectory(basePath, prefs, signals);
+  // Create directory + context.md, then route preferences through the unified
+  // writer (commands-prefs-wizard.writePreferencesFile) so init and the prefs
+  // wizard share one serializer. Optional follow-up step lets the user open
+  // the full prefs wizard with their init answers pre-populated, surfacing
+  // every configurable preference instead of just the init-wizard subset.
+  bootstrapGsdDirectoryStructure(basePath, signals);
+  const prefillPrefs = mapInitPrefsToWizardShape(prefs);
+
+  // ── Step 9b: Optional full-prefs review ────────────────────────────────────
+  const reviewChoice = await showNextAction(ctx, {
+    title: "GSD — Review All Preferences (Optional)",
+    summary: [
+      "Open the full preferences wizard now? It includes models, timeouts,",
+      "budget, notifications, and skills — all pre-filled with your answers.",
+      "",
+      "Skip if you just want sensible defaults; you can always run /gsd prefs project later.",
+    ],
+    actions: [
+      { id: "skip", label: "Skip — use defaults", description: "Save preferences and continue", recommended: true },
+      { id: "review", label: "Open full wizard", description: "Tweak any category before saving" },
+    ],
+    notYetMessage: "Run /gsd init when ready.",
+  });
+
+  if (reviewChoice === "review") {
+    // The wizard handles its own write via writePreferencesFile internally.
+    await handlePrefsWizard(ctx, "project", prefillPrefs);
+  } else {
+    // Direct path: write the init-collected prefs through the unified writer.
+    await writePreferencesFile(getProjectGSDPreferencesPath(), prefillPrefs, ctx, {
+      scope: "project",
+      defaultBody: buildInitPreferencesBody(),
+      notifyOnSave: false,
+    });
+  }
 
   // Initialize SQLite database so GSD starts in full-capability mode (#3880).
   // Without this, isDbAvailable() returns false and GSD enters degraded
@@ -453,21 +489,19 @@ async function customizeAdvancedPrefs(
 
 // ─── Bootstrap ──────────────────────────────────────────────────────────────────
 
-function bootstrapGsdDirectory(
-  basePath: string,
-  prefs: ProjectPreferences,
-  signals: ProjectSignals,
-): void {
+/**
+ * Create .gsd/ directory structure and seed CONTEXT.md.
+ *
+ * Preferences are written separately by the caller via the unified
+ * writePreferencesFile helper so init and the prefs wizard share one path.
+ */
+function bootstrapGsdDirectoryStructure(basePath: string, signals: ProjectSignals): void {
   // Final safety check before writing any files
   assertSafeDirectory(basePath);
 
   const gsd = gsdRoot(basePath);
   mkdirSync(join(gsd, "milestones"), { recursive: true });
   mkdirSync(join(gsd, "runtime"), { recursive: true });
-
-  // Write PREFERENCES.md from wizard answers
-  const preferencesContent = buildPreferencesFile(prefs);
-  writeFileSync(join(gsd, "PREFERENCES.md"), preferencesContent, "utf-8");
 
   // Seed CONTEXT.md with detected project signals
   const contextContent = buildContextSeed(signals);
@@ -476,60 +510,49 @@ function bootstrapGsdDirectory(
   }
 }
 
-function buildPreferencesFile(prefs: ProjectPreferences): string {
-  const lines: string[] = ["---"];
-  lines.push("version: 1");
-  lines.push(`mode: ${prefs.mode}`);
+/**
+ * Map init wizard's typed ProjectPreferences to the prefs-wizard's
+ * Record<string, unknown> shape, matching the keys serializePreferencesToFrontmatter
+ * expects (mode, git.{isolation,main_branch,auto_push}, verification_commands, etc.).
+ *
+ * Exported for testing; init-wizard uses it inline.
+ */
+export function mapInitPrefsToWizardShape(prefs: ProjectPreferences): Record<string, unknown> {
+  const out: Record<string, unknown> = {
+    mode: prefs.mode,
+    git: {
+      isolation: prefs.gitIsolation,
+      main_branch: prefs.mainBranch,
+      auto_push: prefs.autoPush,
+    },
+  };
 
-  // Git preferences
-  lines.push("git:");
-  lines.push(`  isolation: ${prefs.gitIsolation}`);
-  lines.push(`  main_branch: ${prefs.mainBranch}`);
-  lines.push(`  auto_push: ${prefs.autoPush}`);
-
-  // Verification commands
   if (prefs.verificationCommands.length > 0) {
-    lines.push("verification_commands:");
-    for (const cmd of prefs.verificationCommands) {
-      lines.push(`  - "${cmd}"`);
-    }
+    out.verification_commands = prefs.verificationCommands;
   }
-
-  // Custom instructions
   if (prefs.customInstructions.length > 0) {
-    lines.push("custom_instructions:");
-    for (const inst of prefs.customInstructions) {
-      lines.push(`  - "${inst.replace(/"/g, '\\"')}"`);
-    }
+    out.custom_instructions = prefs.customInstructions;
   }
-
-  // Token profile (only if non-default)
   if (prefs.tokenProfile !== "balanced") {
-    lines.push(`token_profile: ${prefs.tokenProfile}`);
+    out.token_profile = prefs.tokenProfile;
   }
-
-  // Phase skips
   if (prefs.skipResearch) {
-    lines.push("phases:");
-    lines.push("  skip_research: true");
+    out.phases = { skip_research: true };
   }
 
-  // Defaults for wizard-generated files
-  lines.push("always_use_skills: []");
-  lines.push("prefer_skills: []");
-  lines.push("avoid_skills: []");
-  lines.push("skill_rules: []");
+  return out;
+}
 
-  lines.push("---");
-  lines.push("");
-  lines.push("# GSD Project Preferences");
-  lines.push("");
-  lines.push("Generated by `/gsd init`. Edit directly or use `/gsd prefs project` to modify.");
-  lines.push("");
-  lines.push("See `~/.gsd/agent/extensions/gsd/docs/preferences-reference.md` for full field documentation.");
-  lines.push("");
-
-  return lines.join("\n");
+function buildInitPreferencesBody(): string {
+  return [
+    "",
+    "# GSD Project Preferences",
+    "",
+    "Generated by `/gsd init`. Edit directly or use `/gsd prefs project` to modify.",
+    "",
+    "See `~/.gsd/agent/extensions/gsd/docs/preferences-reference.md` for full field documentation.",
+    "",
+  ].join("\n");
 }
 
 function buildContextSeed(signals: ProjectSignals): string | null {

--- a/src/resources/extensions/gsd/tests/init-prefs-routing.test.ts
+++ b/src/resources/extensions/gsd/tests/init-prefs-routing.test.ts
@@ -122,3 +122,69 @@ test("writePreferencesFile — falls back to default body for new files", async 
     rmSync(tmp, { recursive: true, force: true });
   }
 });
+
+// ─── Regression tests from #4457 codex adversarial review ──────────────────
+
+test("init — Step 9b shape: 'not_yet' option is recognized as defer (#4457 review)", async () => {
+  // The init wizard relies on showNextAction always appending a `not_yet` action
+  // and mapping Escape to it. The Step 9b code must explicitly handle `not_yet`
+  // as defer (return without bootstrapping or persisting prefs). This test
+  // documents the contract — it doesn't drive the full wizard, but it locks in
+  // that "not_yet" is the canonical defer signal so a future refactor can't
+  // silently drop the explicit branch.
+  const { showNextAction } = await import("../../shared/tui.ts") as { showNextAction: unknown };
+  assert.equal(typeof showNextAction, "function");
+
+  // Read the source to assert Step 9b explicitly handles not_yet — a static
+  // smoke test cheaper than spinning up the full wizard with a mocked ctx.
+  const src = readFileSync(
+    new URL("../init-wizard.ts", import.meta.url),
+    "utf-8",
+  );
+  assert.match(
+    src,
+    /reviewChoice === "not_yet"[\s\S]*?return \{ completed: false, bootstrapped: false \}/,
+    "init Step 9b must short-circuit on not_yet without writing preferences",
+  );
+});
+
+test("init — preferences path is basePath-derived, not cwd-derived (#4457 review)", async () => {
+  // If basePath !== process.cwd(), preferences must still write to
+  // join(gsdRoot(basePath), "PREFERENCES.md"), not the cwd-derived path.
+  // Static check: the post-#4457-review code constructs the path from gsdRoot(basePath).
+  const src = readFileSync(
+    new URL("../init-wizard.ts", import.meta.url),
+    "utf-8",
+  );
+  assert.match(
+    src,
+    /projectPrefsPath\s*=\s*join\(gsdRoot\(basePath\),\s*"PREFERENCES\.md"\)/,
+    "init must derive the project preferences path from basePath",
+  );
+  // And neither write site should call getProjectGSDPreferencesPath() (which
+  // resolves from process.cwd()).
+  assert.doesNotMatch(
+    src,
+    /getProjectGSDPreferencesPath\s*\(/,
+    "init must not use the cwd-derived getProjectGSDPreferencesPath()",
+  );
+});
+
+test("handlePrefsWizard — accepts pathOverride to target a non-cwd location", async () => {
+  // The wizard's signature must support pathOverride so /gsd init can route
+  // both the review and skip branches to the basePath-derived path.
+  const { handlePrefsWizard } = await import("../commands-prefs-wizard.ts");
+  assert.equal(handlePrefsWizard.length >= 2, true);
+  // Read source to confirm the opts.pathOverride wiring exists — calling
+  // handlePrefsWizard end-to-end requires a full ExtensionCommandContext
+  // mock, which is heavier than this contract check warrants.
+  const src = readFileSync(
+    new URL("../commands-prefs-wizard.ts", import.meta.url),
+    "utf-8",
+  );
+  assert.match(
+    src,
+    /opts\?\.pathOverride[\s\S]*?\?\?[\s\S]*?(getProjectGSDPreferencesPath|getGlobalGSDPreferencesPath)/,
+    "handlePrefsWizard must honor opts.pathOverride before falling back to scope-derived path",
+  );
+});

--- a/src/resources/extensions/gsd/tests/init-prefs-routing.test.ts
+++ b/src/resources/extensions/gsd/tests/init-prefs-routing.test.ts
@@ -1,0 +1,124 @@
+// GSD — /gsd init → unified preferences-write routing tests.
+//
+// Verifies the refactor that routes init's preferences write through the same
+// writePreferencesFile helper used by handlePrefsWizard, and that the typed
+// ProjectPreferences shape maps correctly into the wizard's
+// Record<string, unknown> shape.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { mapInitPrefsToWizardShape } from "../init-wizard.ts";
+import { writePreferencesFile } from "../commands-prefs-wizard.ts";
+
+test("mapInitPrefsToWizardShape — full roundtrip with all fields", () => {
+  const out = mapInitPrefsToWizardShape({
+    mode: "team",
+    gitIsolation: "branch",
+    mainBranch: "develop",
+    verificationCommands: ["npm test", "npm run lint"],
+    customInstructions: ["Use TypeScript strict mode", "Always write tests"],
+    tokenProfile: "quality",
+    skipResearch: true,
+    autoPush: false,
+  });
+
+  assert.equal(out.mode, "team");
+  assert.deepEqual(out.git, { isolation: "branch", main_branch: "develop", auto_push: false });
+  assert.deepEqual(out.verification_commands, ["npm test", "npm run lint"]);
+  assert.deepEqual(out.custom_instructions, ["Use TypeScript strict mode", "Always write tests"]);
+  assert.equal(out.token_profile, "quality");
+  assert.deepEqual(out.phases, { skip_research: true });
+});
+
+test("mapInitPrefsToWizardShape — omits defaults to keep YAML clean", () => {
+  const out = mapInitPrefsToWizardShape({
+    mode: "solo",
+    gitIsolation: "worktree",
+    mainBranch: "main",
+    verificationCommands: [],
+    customInstructions: [],
+    tokenProfile: "balanced",
+    skipResearch: false,
+    autoPush: true,
+  });
+
+  // tokenProfile=balanced is the default — should not be serialized.
+  assert.equal(out.token_profile, undefined);
+  // skipResearch=false is the default — phases should not appear.
+  assert.equal(out.phases, undefined);
+  // Empty arrays should not be serialized.
+  assert.equal(out.verification_commands, undefined);
+  assert.equal(out.custom_instructions, undefined);
+});
+
+test("writePreferencesFile — writes valid frontmatter from prefill", async () => {
+  const tmp = mkdtempSync(join(tmpdir(), "gsd-init-prefs-routing-"));
+  const path = join(tmp, "PREFERENCES.md");
+
+  try {
+    const prefs = mapInitPrefsToWizardShape({
+      mode: "solo",
+      gitIsolation: "worktree",
+      mainBranch: "main",
+      verificationCommands: ["npm test"],
+      customInstructions: [],
+      tokenProfile: "balanced",
+      skipResearch: false,
+      autoPush: true,
+    });
+
+    await writePreferencesFile(path, prefs, null, { scope: "project" });
+
+    const content = readFileSync(path, "utf-8");
+    assert.match(content, /^---/);
+    assert.match(content, /mode: solo/);
+    assert.match(content, /git:/);
+    assert.match(content, /isolation: worktree/);
+    assert.match(content, /main_branch: main/);
+    assert.match(content, /auto_push: true/);
+    assert.match(content, /verification_commands:/);
+    assert.match(content, /- npm test/);
+    // version: 1 is added by writePreferencesFile if missing
+    assert.match(content, /version: 1/);
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("writePreferencesFile — preserves existing markdown body", async () => {
+  const tmp = mkdtempSync(join(tmpdir(), "gsd-init-prefs-routing-"));
+  const path = join(tmp, "PREFERENCES.md");
+  const customBody = "\n# My Custom Notes\n\nUser-edited content here.\n";
+
+  try {
+    // Seed file with frontmatter + custom body
+    writeFileSync(path, `---\nmode: solo\nversion: 1\n---${customBody}`, "utf-8");
+
+    await writePreferencesFile(path, { mode: "team", version: 1 }, null);
+
+    const content = readFileSync(path, "utf-8");
+    assert.match(content, /mode: team/);
+    assert.match(content, /My Custom Notes/);
+    assert.match(content, /User-edited content here/);
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("writePreferencesFile — falls back to default body for new files", async () => {
+  const tmp = mkdtempSync(join(tmpdir(), "gsd-init-prefs-routing-"));
+  const path = join(tmp, "PREFERENCES.md");
+  const initBody = "\n# Init body marker\n";
+
+  try {
+    await writePreferencesFile(path, { mode: "solo" }, null, { defaultBody: initBody });
+    const content = readFileSync(path, "utf-8");
+    assert.match(content, /Init body marker/);
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Closes #4453. Routes /gsd init's preferences write through the same writePreferencesFile helper used by the prefs wizard. Eliminates duplicated YAML serializer (init's buildPreferencesFile removed). Adds optional 'Open full wizard' step in init that calls handlePrefsWizard with init answers as prefill — surfacing every preference category to first-run users. 5 new tests. tsc clean. 87/87 existing tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional "Review All Preferences" step during project setup.
  * Preferences wizard accepts pre-populated values and supports explicit path override for where preferences are saved.

* **Improvements**
  * Centralized preference file writing with versioning, preserving existing markdown body and optional save notifications.
  * Init flow now maps initial settings into the unified preferences format and defers bootstrapping when review is skipped.

* **Tests**
  * Added tests validating init routing, mapping, file writing, and preservation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->