### PR TITLE
fix(gsd): promote CONTEXT-DRAFT.md in gsd_summary_save tool path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **gsd**: promote `CONTEXT-DRAFT.md` to final `CONTEXT.md` in the `gsd_summary_save` tool path (#4442)
+
 ## [2.75.0] - 2026-04-15
 
 ### Added

--- a/src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts
@@ -11,6 +11,7 @@ import {
   _getAdapter,
   insertGateRow,
 } from "../gsd-db.ts";
+import { markDepthVerified, clearDiscussionFlowState } from "../bootstrap/write-gate.ts";
 import {
   executeCompleteMilestone,
   executePlanMilestone,
@@ -640,6 +641,102 @@ test("executeReplanSlice rewrites pending tasks and renders replan artifacts", a
     ).get("M006", "S06", "T08") as Record<string, unknown> | undefined;
     assert.equal(updatedTask?.title, "Pending task (updated)");
     assert.equal(insertedTask?.title, "Remediation task");
+  } finally {
+    closeDatabase();
+    cleanup(base);
+  }
+});
+
+test("executeSummarySave removes sibling CONTEXT-DRAFT when writing milestone CONTEXT (#4442)", async () => {
+  const base = makeTmpBase();
+  try {
+    openTestDb(base);
+    markDepthVerified("M001", base);
+
+    const milestoneDir = join(base, ".gsd", "milestones", "M001");
+    mkdirSync(milestoneDir, { recursive: true });
+    const draftPath = join(milestoneDir, "M001-CONTEXT-DRAFT.md");
+    writeFileSync(draftPath, "# Draft\n\nincremental notes");
+    assert.ok(existsSync(draftPath), "precondition: draft exists");
+
+    const result = await inProjectDir(base, () => executeSummarySave({
+      milestone_id: "M001",
+      artifact_type: "CONTEXT",
+      content: "# Context\n\nfinal discussion output",
+    }, base));
+
+    assert.equal(result.details.operation, "save_summary");
+    assert.equal(result.details.artifact_type, "CONTEXT");
+
+    const contextPath = join(milestoneDir, "M001-CONTEXT.md");
+    assert.ok(existsSync(contextPath), "CONTEXT.md should be written");
+    assert.equal(
+      existsSync(draftPath),
+      false,
+      "CONTEXT-DRAFT.md should be removed after final CONTEXT.md is written",
+    );
+  } finally {
+    clearDiscussionFlowState();
+    closeDatabase();
+    cleanup(base);
+  }
+});
+
+test("executeSummarySave removes sibling CONTEXT-DRAFT when writing slice CONTEXT (#4442)", async () => {
+  const base = makeTmpBase();
+  try {
+    openTestDb(base);
+
+    const sliceDir = join(base, ".gsd", "milestones", "M001", "slices", "S01");
+    mkdirSync(sliceDir, { recursive: true });
+    const draftPath = join(sliceDir, "S01-CONTEXT-DRAFT.md");
+    writeFileSync(draftPath, "# Slice Draft\n\nincremental slice notes");
+    assert.ok(existsSync(draftPath), "precondition: slice draft exists");
+
+    const result = await inProjectDir(base, () => executeSummarySave({
+      milestone_id: "M001",
+      slice_id: "S01",
+      artifact_type: "CONTEXT",
+      content: "# Slice Context\n\nfinal slice output",
+    }, base));
+
+    assert.equal(result.details.operation, "save_summary");
+    assert.equal(result.details.artifact_type, "CONTEXT");
+
+    const contextPath = join(sliceDir, "S01-CONTEXT.md");
+    assert.ok(existsSync(contextPath), "slice CONTEXT.md should be written");
+    assert.equal(
+      existsSync(draftPath),
+      false,
+      "slice CONTEXT-DRAFT.md should be removed after final CONTEXT.md is written",
+    );
+  } finally {
+    closeDatabase();
+    cleanup(base);
+  }
+});
+
+test("executeSummarySave leaves sibling CONTEXT-DRAFT intact for non-CONTEXT artifacts (#4442)", async () => {
+  const base = makeTmpBase();
+  try {
+    openTestDb(base);
+
+    const milestoneDir = join(base, ".gsd", "milestones", "M001");
+    mkdirSync(milestoneDir, { recursive: true });
+    const draftPath = join(milestoneDir, "M001-CONTEXT-DRAFT.md");
+    writeFileSync(draftPath, "# Draft\n\nstill in progress");
+
+    const result = await inProjectDir(base, () => executeSummarySave({
+      milestone_id: "M001",
+      artifact_type: "RESEARCH",
+      content: "# Research\n\nresearch notes",
+    }, base));
+
+    assert.equal(result.details.artifact_type, "RESEARCH");
+    assert.ok(
+      existsSync(draftPath),
+      "CONTEXT-DRAFT.md must survive RESEARCH/SUMMARY/ASSESSMENT writes",
+    );
   } finally {
     closeDatabase();
     cleanup(base);

--- a/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
+++ b/src/resources/extensions/gsd/tools/workflow-tool-executors.ts
@@ -10,6 +10,8 @@ import {
 } from "../gsd-db.js";
 import { GATE_REGISTRY } from "../gate-registry.js";
 import { saveArtifactToDb } from "../db-writer.js";
+import { resolveMilestoneFile, resolveSliceFile } from "../paths.js";
+import { unlinkSync } from "node:fs";
 import type { CompleteMilestoneParams } from "./complete-milestone.js";
 import { handleCompleteMilestone } from "./complete-milestone.js";
 import { handleCompleteTask } from "./complete-task.js";
@@ -103,6 +105,18 @@ export async function executeSummarySave(
       },
       basePath,
     );
+
+    if (params.artifact_type === "CONTEXT" && !params.task_id) {
+      try {
+        const draftFile = params.slice_id
+          ? resolveSliceFile(basePath, params.milestone_id, params.slice_id, "CONTEXT-DRAFT")
+          : resolveMilestoneFile(basePath, params.milestone_id, "CONTEXT-DRAFT");
+        if (draftFile) unlinkSync(draftFile);
+      } catch (e) {
+        logWarning("tool", `CONTEXT-DRAFT.md unlink failed: ${(e as Error).message}`);
+      }
+    }
+
     return {
       content: [{ type: "text", text: `Saved ${params.artifact_type} artifact to ${relativePath}` }],
       details: { operation: "save_summary", path: relativePath, artifact_type: params.artifact_type },


### PR DESCRIPTION
## TL;DR

**What:** Promote the sibling `CONTEXT-DRAFT.md` to the final `CONTEXT.md` inside the `gsd_summary_save` tool path itself.
**Why:** The cleanup only lived in the guided-flow auto-start hook — direct tool calls left stale drafts behind and confused downstream state/preflight logic.
**How:** After a successful `saveArtifactToDb(...)` in `executeSummarySave`, when `artifact_type === "CONTEXT"` and `task_id` is absent, unlink the sibling `CONTEXT-DRAFT.md` (milestone or slice scope).

Closes #4442

## What

- `src/resources/extensions/gsd/tools/workflow-tool-executors.ts` — add 12-line inline cleanup in `executeSummarySave` after the artifact is saved. Imports `resolveMilestoneFile`/`resolveSliceFile` from `../paths.js` and `unlinkSync` from `node:fs`. Gated on `artifact_type === "CONTEXT" && !params.task_id` (task-level CONTEXT has no draft sibling).
- `src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts` — three new regression tests (`node:test`):
  1. Milestone CONTEXT removes sibling `Mxxx-CONTEXT-DRAFT.md` (uses `markDepthVerified` / `clearDiscussionFlowState` to cross the write-gate realistically).
  2. Slice CONTEXT removes sibling `Sxx-CONTEXT-DRAFT.md`.
  3. Negative case: writing `RESEARCH` leaves any existing draft intact.
- `CHANGELOG.md` — `[Unreleased] ### Fixed` entry.

Not touched:
- `guided-flow.ts` — the existing `checkAutoStartAfterDiscuss` cleanup stays as a defensive fallback, per the issue's recommendation.
- Prompts — the text already promises overwrite/replacement; it is now truthful across both code paths.

## Why

Issue #4442 (High Priority bug): the prompts in `prompts/discuss.md`, `prompts/queue.md`, `prompts/guided-discuss-milestone.md`, and `prompts/guided-discuss-slice.md` tell the agent to persist incremental drafts with `gsd_summary_save` (`artifact_type: "CONTEXT-DRAFT"`) and later finalize with `gsd_summary_save` (`artifact_type: "CONTEXT"`), and promise that the draft gets overwritten/deleted. That promise only held if the write happened through `checkAutoStartAfterDiscuss` in `guided-flow.ts:204-212`. A direct `gsd_summary_save` call — e.g. from a non-guided path or a subsequent tool invocation — left `Mxxx-CONTEXT-DRAFT.md` or `Sxx-CONTEXT-DRAFT.md` on disk. Downstream consumers (`state.ts`) detect drafts by file presence, so a stale draft could re-trigger `needs-discussion` classification, pause auto-mode, or warn incorrectly.

This fix moves the invariant to the tool contract so it holds regardless of caller.

## How

Inside `executeSummarySave`, after `await saveArtifactToDb(...)` returns successfully:

```ts
if (params.artifact_type === "CONTEXT" && !params.task_id) {
  try {
    const draftFile = params.slice_id
      ? resolveSliceFile(basePath, params.milestone_id, params.slice_id, "CONTEXT-DRAFT")
      : resolveMilestoneFile(basePath, params.milestone_id, "CONTEXT-DRAFT");
    if (draftFile) unlinkSync(draftFile);
  } catch (e) {
    logWarning("tool", `CONTEXT-DRAFT.md unlink failed: ${(e as Error).message}`);
  }
}
```

Design notes:
- **Scope gate on `!params.task_id`.** Task-level CONTEXT artifacts have no `-DRAFT` sibling; without this guard, writing a task-level CONTEXT would erroneously unlink the slice's draft.
- **No shared helper.** Duplicated with `guided-flow.ts:264-269` on purpose — two call sites with a three-line idiom don't justify a helper, and keeping the logic inline makes the contract visible where the tool runs.
- **DB row for `CONTEXT-DRAFT`.** Left in place, matching the existing guided-flow behavior. `state.ts` derives draft presence from disk (`resolveMilestoneFile(..., "CONTEXT-DRAFT")`), so the disk unlink is what matters.
- **Shrinkage-guard interaction.** `saveArtifactToDb` (`db-writer.ts:694`) may preserve an existing on-disk CONTEXT when the new content is <50% of the existing file. In that path the save still succeeds and the draft is still superseded semantically, so promoting the draft is correct.
- **Error path.** If `saveArtifactToDb` throws, the outer catch runs and the draft is untouched — no partial promotion.

## Test plan

- [x] `npx tsx --test src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts` — 15/15 passing (3 new).
- [x] `npx tsx src/resources/extensions/gsd/tests/draft-promotion.test.ts` — 11/11 (existing guided-flow path unaffected).
- [x] `npx tsx --test src/resources/extensions/gsd/tests/gsd-tools.test.ts` — 9/9.
- [x] `npx tsc --noEmit` — clean.
- [x] `npm run build` — succeeds.

## AI assistance

This PR was prepared with AI assistance (Claude). Code, tests, and design decisions were reviewed by the author.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Draft context files are now automatically removed after finalizing context saves, ensuring clean file management in the workflow.

* **Tests**
  * Added integration tests to verify draft file cleanup behavior for milestone and slice context saves.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->