### PR TITLE
fix(gsd): cascade skipped-slice status to its tasks (#4375)

### DIFF
--- a/src/resources/extensions/gsd/bootstrap/db-tools.ts
+++ b/src/resources/extensions/gsd/bootstrap/db-tools.ts
@@ -776,32 +776,22 @@ export function registerDbTools(pi: ExtensionAPI): void {
       };
     }
     try {
-      const { getSlice, updateSliceStatus } = await import("../gsd-db.js");
+      const { handleSkipSlice } = await import("../tools/skip-slice.js");
       const { invalidateStateCache } = await import("../state.js");
 
-      const slice = getSlice(params.milestoneId, params.sliceId);
-      if (!slice) {
+      const result = handleSkipSlice({
+        milestoneId: params.milestoneId,
+        sliceId: params.sliceId,
+        reason: params.reason,
+      });
+
+      if (result.error) {
         return {
-          content: [{ type: "text" as const, text: `Error: Slice ${params.sliceId} not found in milestone ${params.milestoneId}` }],
-          details: { operation: "skip_slice", error: "slice_not_found" } as any,
+          content: [{ type: "text" as const, text: `Error: ${result.error}` }],
+          details: { operation: "skip_slice", error: result.errorCode ?? "skip_failed" } as any,
         };
       }
 
-      if (slice.status === "complete" || slice.status === "done") {
-        return {
-          content: [{ type: "text" as const, text: `Error: Slice ${params.sliceId} is already complete — cannot skip.` }],
-          details: { operation: "skip_slice", error: "already_complete" } as any,
-        };
-      }
-
-      if (slice.status === "skipped") {
-        return {
-          content: [{ type: "text" as const, text: `Slice ${params.sliceId} is already skipped.` }],
-          details: { operation: "skip_slice", sliceId: params.sliceId, milestoneId: params.milestoneId } as any,
-        };
-      }
-
-      updateSliceStatus(params.milestoneId, params.sliceId, "skipped");
       invalidateStateCache();
 
       // Rebuild STATE.md so it reflects the skip immediately (#3477).
@@ -814,13 +804,21 @@ export function registerDbTools(pi: ExtensionAPI): void {
         logError("tool", `skip_slice rebuildState failed: ${(err as Error).message}`, { tool: "gsd_skip_slice" });
       }
 
+      const suffix = result.wasAlreadySkipped
+        ? result.tasksSkipped > 0
+          ? ` (already skipped; cascaded ${result.tasksSkipped} leftover task(s) to skipped).`
+          : " (already skipped; no pending tasks to cascade)."
+        : ` Cascaded ${result.tasksSkipped} task(s) to skipped. Auto-mode will advance past this slice.`;
+
       return {
-        content: [{ type: "text" as const, text: `Skipped slice ${params.sliceId} (${params.milestoneId}). Reason: ${params.reason ?? "User-directed skip"}. Auto-mode will advance past this slice.` }],
+        content: [{ type: "text" as const, text: `Skipped slice ${params.sliceId} (${params.milestoneId}). Reason: ${params.reason ?? "User-directed skip"}.${suffix}` }],
         details: {
           operation: "skip_slice",
           sliceId: params.sliceId,
           milestoneId: params.milestoneId,
           reason: params.reason,
+          tasksSkipped: result.tasksSkipped,
+          wasAlreadySkipped: result.wasAlreadySkipped,
         } as any,
       };
     } catch (err) {
@@ -838,12 +836,14 @@ export function registerDbTools(pi: ExtensionAPI): void {
     label: "Skip Slice",
     description:
       "Mark a slice as skipped so auto-mode advances past it without executing. " +
+      "Non-closed tasks within the slice are cascaded to skipped so milestone completion is not blocked by leftover pending tasks (#4375). " +
       "The slice data is preserved for reference. The state machine treats skipped slices like completed ones for dependency satisfaction.",
     promptSnippet: "Skip a GSD slice (mark as skipped, auto-mode will advance past it)",
     promptGuidelines: [
       "Use gsd_skip_slice when a slice should be bypassed — descoped, superseded, or no longer relevant.",
       "Cannot skip a slice that is already complete.",
       "Skipped slices satisfy downstream dependencies just like completed slices.",
+      "All pending/active tasks in the slice are cascaded to skipped; completed tasks are never downgraded.",
     ],
     parameters: Type.Object({
       sliceId: Type.String({ description: "Slice ID (e.g. S02)" }),

--- a/src/resources/extensions/gsd/bootstrap/db-tools.ts
+++ b/src/resources/extensions/gsd/bootstrap/db-tools.ts
@@ -788,7 +788,11 @@ export function registerDbTools(pi: ExtensionAPI): void {
       if (result.error) {
         return {
           content: [{ type: "text" as const, text: `Error: ${result.error}` }],
-          details: { operation: "skip_slice", error: result.errorCode ?? "skip_failed" } as any,
+          details: {
+            operation: "skip_slice",
+            error: result.error,
+            errorCode: result.errorCode ?? "skip_failed",
+          } as any,
         };
       }
 

--- a/src/resources/extensions/gsd/tests/skip-slice-cascades-tasks.test.ts
+++ b/src/resources/extensions/gsd/tests/skip-slice-cascades-tasks.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Regression test for #4375: gsd_skip_slice must cascade "skipped" status to
+ * all non-closed tasks in the slice.
+ *
+ * Without the cascade, executeCompleteMilestone's deep-task check finds
+ * pending tasks inside a skipped slice and refuses to complete the milestone,
+ * causing auto-mode to loop on complete-milestone until stuck-recovery aborts.
+ */
+
+import { describe, test, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import {
+  openDatabase,
+  closeDatabase,
+  insertMilestone,
+  insertSlice,
+  insertTask,
+  getSlice,
+  getSliceTasks,
+  updateSliceStatus,
+  updateTaskStatus,
+} from "../gsd-db.ts";
+import { handleSkipSlice } from "../tools/skip-slice.ts";
+
+describe("handleSkipSlice cascades skip to tasks (#4375)", () => {
+  let dir: string;
+  let dbPath: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "gsd-skip-cascade-"));
+    dbPath = join(dir, "test.db");
+    openDatabase(dbPath);
+    insertMilestone({ id: "M001", title: "Test", status: "active" });
+    insertSlice({ milestoneId: "M001", id: "S03", title: "Deferred", status: "pending", sequence: 3 });
+    insertTask({ milestoneId: "M001", sliceId: "S03", id: "T01", title: "task 1", status: "pending", sequence: 1 });
+    insertTask({ milestoneId: "M001", sliceId: "S03", id: "T02", title: "task 2", status: "active", sequence: 2 });
+    insertTask({ milestoneId: "M001", sliceId: "S03", id: "T03", title: "task 3", status: "pending", sequence: 3 });
+  });
+
+  afterEach(() => {
+    closeDatabase();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("sets slice to skipped and cascades pending/active tasks to skipped", () => {
+    const result = handleSkipSlice({ milestoneId: "M001", sliceId: "S03", reason: "deferred" });
+
+    assert.equal(result.error, undefined, `expected success, got error: ${result.error ?? ""}`);
+    assert.equal(result.sliceId, "S03");
+    assert.equal(result.milestoneId, "M001");
+    assert.equal(result.tasksSkipped, 3, "all three non-closed tasks should be cascaded");
+
+    const slice = getSlice("M001", "S03");
+    assert.equal(slice?.status, "skipped", "slice status must be skipped");
+
+    const tasks = getSliceTasks("M001", "S03");
+    for (const t of tasks) {
+      assert.equal(t.status, "skipped", `task ${t.id} must be skipped after cascade`);
+    }
+  });
+
+  test("does not downgrade already-closed tasks", () => {
+    updateTaskStatus("M001", "S03", "T01", "complete", new Date().toISOString());
+
+    const result = handleSkipSlice({ milestoneId: "M001", sliceId: "S03" });
+
+    assert.equal(result.error, undefined);
+    assert.equal(result.tasksSkipped, 2, "only the two non-closed tasks should be cascaded");
+
+    const tasks = getSliceTasks("M001", "S03");
+    const byId = new Map(tasks.map((t) => [t.id, t.status]));
+    assert.equal(byId.get("T01"), "complete", "completed task must not be downgraded");
+    assert.equal(byId.get("T02"), "skipped");
+    assert.equal(byId.get("T03"), "skipped");
+  });
+
+  test("re-running skip on an already-skipped slice heals leftover pending tasks (#4375 recovery)", () => {
+    const first = handleSkipSlice({ milestoneId: "M001", sliceId: "S03" });
+    assert.equal(first.error, undefined);
+    assert.equal(first.tasksSkipped, 3);
+
+    // Simulate historical inconsistent state: slice skipped but a task was
+    // later recreated or reset to pending by some migration/bug path.
+    updateTaskStatus("M001", "S03", "T01", "pending");
+
+    const second = handleSkipSlice({ milestoneId: "M001", sliceId: "S03" });
+    assert.equal(second.error, undefined, "re-running must succeed (no 'already skipped' hard error)");
+    assert.equal(second.tasksSkipped, 1, "only the leftover pending task should be cascaded");
+    assert.equal(second.wasAlreadySkipped, true);
+
+    const tasks = getSliceTasks("M001", "S03");
+    for (const t of tasks) {
+      assert.equal(t.status, "skipped", `task ${t.id} must be skipped after recovery`);
+    }
+  });
+
+  test("refuses to skip an already-complete slice", () => {
+    updateSliceStatus("M001", "S03", "complete");
+
+    const result = handleSkipSlice({ milestoneId: "M001", sliceId: "S03" });
+    assert.ok(result.error, "expected error when slice is already complete");
+    assert.match(result.error!, /already complete/i);
+    assert.equal(result.errorCode, "already_complete");
+  });
+
+  test("returns error for unknown slice", () => {
+    const result = handleSkipSlice({ milestoneId: "M001", sliceId: "S99" });
+    assert.ok(result.error);
+    assert.match(result.error!, /not found/i);
+    assert.equal(result.errorCode, "slice_not_found");
+  });
+});

--- a/src/resources/extensions/gsd/tests/skip-slice-cascades-tasks.test.ts
+++ b/src/resources/extensions/gsd/tests/skip-slice-cascades-tasks.test.ts
@@ -107,6 +107,15 @@ describe("handleSkipSlice cascades skip to tasks (#4375)", () => {
     assert.equal(result.errorCode, "already_complete");
   });
 
+  test("refuses to skip a slice in the legacy 'done' status", () => {
+    updateSliceStatus("M001", "S03", "done");
+
+    const result = handleSkipSlice({ milestoneId: "M001", sliceId: "S03" });
+    assert.ok(result.error, "expected error when slice is already done");
+    assert.match(result.error!, /already complete/i);
+    assert.equal(result.errorCode, "already_complete");
+  });
+
   test("returns error for unknown slice", () => {
     const result = handleSkipSlice({ milestoneId: "M001", sliceId: "S99" });
     assert.ok(result.error);

--- a/src/resources/extensions/gsd/tools/skip-slice.ts
+++ b/src/resources/extensions/gsd/tools/skip-slice.ts
@@ -1,0 +1,124 @@
+/**
+ * skip-slice handler — the core operation behind gsd_skip_slice.
+ *
+ * Marks a slice as skipped and cascades the skip to every non-closed task in
+ * that slice. Without the task cascade the deep-check in
+ * executeCompleteMilestone reports pending tasks inside the skipped slice and
+ * blocks milestone completion (see #4375).
+ *
+ * This function performs DB writes only. The MCP wrapper in
+ * bootstrap/db-tools.ts handles state-cache invalidation and STATE.md rebuild.
+ */
+
+import {
+  getSlice,
+  getSliceTasks,
+  transaction,
+  updateSliceStatus,
+  updateTaskStatus,
+} from "../gsd-db.js";
+import { isClosedStatus } from "../status-guards.js";
+
+/**
+ * Input parameters for {@link handleSkipSlice}.
+ *
+ * - `milestoneId` / `sliceId` identify the target slice.
+ * - `reason` is a free-form note surfaced in the MCP response; optional
+ *   because the caller (e.g. rethink flow) may not have a structured reason.
+ */
+export interface SkipSliceParams {
+  milestoneId: string;
+  sliceId: string;
+  reason?: string;
+}
+
+/**
+ * Stable machine-readable error codes for {@link SkipSliceResult.error}.
+ * Keep in sync with the wrapper in bootstrap/db-tools.ts.
+ */
+export type SkipSliceErrorCode = "slice_not_found" | "already_complete";
+
+/**
+ * Result of a {@link handleSkipSlice} call.
+ *
+ * - `tasksSkipped` — count of tasks whose status was cascaded to "skipped".
+ *   Zero is a valid success (slice had no non-closed tasks).
+ * - `wasAlreadySkipped` — true when the slice was in "skipped" status on
+ *   entry; callers can use this to distinguish first-skip from re-skip.
+ * - `error` / `errorCode` — set together for recoverable validation failures
+ *   (unknown slice, slice already complete). Both absent on success. DB
+ *   errors propagate as thrown exceptions and should be caught by the caller.
+ */
+export interface SkipSliceResult {
+  milestoneId: string;
+  sliceId: string;
+  tasksSkipped: number;
+  wasAlreadySkipped: boolean;
+  reason?: string;
+  error?: string;
+  errorCode?: SkipSliceErrorCode;
+}
+
+/**
+ * Mark a slice as "skipped" and cascade the skip to every non-closed task in
+ * that slice. Runs as a single transaction so slice status and task statuses
+ * are always consistent.
+ *
+ * Behaviour summary:
+ * - Unknown slice → returns {@link SkipSliceResult} with `error`.
+ * - Slice already complete/done → returns `error` (cannot un-complete).
+ * - Slice already skipped → still cascades leftover non-closed tasks
+ *   (heals inconsistent historical state from projects that ran older
+ *   versions before the #4375 cascade fix).
+ * - Tasks in closed status (complete/done/skipped) are never downgraded.
+ */
+export function handleSkipSlice(params: SkipSliceParams): SkipSliceResult {
+  const base: SkipSliceResult = {
+    milestoneId: params.milestoneId,
+    sliceId: params.sliceId,
+    tasksSkipped: 0,
+    wasAlreadySkipped: false,
+    reason: params.reason,
+  };
+
+  // ── Guards + DB writes inside a single transaction (prevents TOCTOU) ────
+  let guardError: string | null = null;
+  let guardCode: SkipSliceErrorCode | null = null;
+  let wasAlreadySkipped = false;
+  let tasksSkipped = 0;
+
+  transaction(() => {
+    const slice = getSlice(params.milestoneId, params.sliceId);
+    if (!slice) {
+      guardError = `Slice ${params.sliceId} not found in milestone ${params.milestoneId}`;
+      guardCode = "slice_not_found";
+      return;
+    }
+    if (slice.status === "complete" || slice.status === "done") {
+      guardError = `Slice ${params.sliceId} is already complete — cannot skip.`;
+      guardCode = "already_complete";
+      return;
+    }
+
+    wasAlreadySkipped = slice.status === "skipped";
+    if (!wasAlreadySkipped) {
+      updateSliceStatus(params.milestoneId, params.sliceId, "skipped");
+    }
+
+    // Cascade: mark every non-closed task as skipped so milestone completion
+    // doesn't trip the deep-task guard (#4375). Closed tasks (complete/done/
+    // skipped) are left untouched — we never downgrade.
+    const tasks = getSliceTasks(params.milestoneId, params.sliceId);
+    for (const task of tasks) {
+      if (!isClosedStatus(task.status)) {
+        updateTaskStatus(params.milestoneId, params.sliceId, task.id, "skipped");
+        tasksSkipped++;
+      }
+    }
+  });
+
+  if (guardError) {
+    return { ...base, error: guardError, errorCode: guardCode ?? undefined };
+  }
+  return { ...base, tasksSkipped, wasAlreadySkipped };
+}

--- a/src/resources/extensions/gsd/tools/skip-slice.ts
+++ b/src/resources/extensions/gsd/tools/skip-slice.ts
@@ -13,6 +13,7 @@
 import {
   getSlice,
   getSliceTasks,
+  isDbAvailable,
   transaction,
   updateSliceStatus,
   updateTaskStatus,
@@ -80,6 +81,14 @@ export function handleSkipSlice(params: SkipSliceParams): SkipSliceResult {
     wasAlreadySkipped: false,
     reason: params.reason,
   };
+
+  // Fail loudly on a closed DB so a `null` from getSlice() inside the
+  // transaction unambiguously means "slice not found", never "DB unavailable".
+  // The MCP wrapper in bootstrap/db-tools.ts runs ensureDbOpen() before calling
+  // this helper; this guard protects direct callers (tests, future code).
+  if (!isDbAvailable()) {
+    throw new Error("handleSkipSlice: GSD database is not available");
+  }
 
   // ── Guards + DB writes inside a single transaction (prevents TOCTOU) ────
   let guardError: string | null = null;


### PR DESCRIPTION
## TL;DR

**What:** Skipping a slice now cascades the skip to every non-closed task in that slice so milestone completion is no longer blocked by leftover pending tasks.
**Why:** Closes #4375 — auto mode gets stuck in a complete-milestone loop when any slice has been skipped, because the deep-task guard finds pending tasks inside the skipped slice.
**How:** Extract the skip flow into `tools/skip-slice.ts`, run all guards + slice write + task cascade inside one transaction, wire the wrapper in `bootstrap/db-tools.ts` to consume a stable `errorCode`, and add a regression test.

## What

- New `src/resources/extensions/gsd/tools/skip-slice.ts` — `handleSkipSlice(params)` runs guards, slice-status write, and task-cascade inside a single `transaction()`. Exports `SkipSliceParams`, `SkipSliceResult`, and a `SkipSliceErrorCode` union.
- Refactored `skipSliceExecute` in `src/resources/extensions/gsd/bootstrap/db-tools.ts` to delegate to the new handler and read the stable `errorCode` instead of regex-matching the error string. Removed the "already skipped" short-circuit so re-running the tool now heals inconsistent historical state. Tool description and `promptGuidelines` updated to document the cascade.
- New `src/resources/extensions/gsd/tests/skip-slice-cascades-tasks.test.ts` — five node:test regressions: cascade happy path, no-downgrade of already-closed tasks, recovery when re-running on an already-skipped slice, two error paths (already-complete slice, unknown slice).

## Why

`gsd_skip_slice` previously updated only the slice row. The deep-task validation in `executeCompleteMilestone` (tools/complete-milestone.ts:172-181) iterates every slice — including skipped ones — and fails milestone completion whenever any task is non-closed. Forensics in #4375 traced the symptom (auto mode looping on complete-milestone until stuck-recovery aborted) to this inconsistency: `slice.status = "skipped"` but tasks stayed `pending` or `active`.

The canonical fix is to keep the skipped slice and its tasks consistent. A skipped slice contains skipped work; never-executed tasks should not masquerade as pending.

Closes #4375.

## How

**Cascade under a transaction.** `handleSkipSlice` mirrors the pattern in `tools/complete-slice.ts` — all guards and writes live inside one `transaction(() => {...})` block so the slice status and task statuses are always consistent and TOCTOU-safe. `isClosedStatus` (status-guards.ts) is used to decide which tasks to touch, so `complete`, `done`, and already-`skipped` tasks are never downgraded.

**Stable error codes.** `SkipSliceResult` now carries an `errorCode: "slice_not_found" | "already_complete"` alongside the human-readable `error`. The MCP wrapper in `bootstrap/db-tools.ts` uses this directly instead of regex-matching on the error string.

**Recovery path.** The previous "already skipped" short-circuit meant projects that had already hit #4375 could not self-heal: the slice was skipped but its tasks stayed pending, and re-running the tool did nothing. The new handler always runs the cascade (also on an already-skipped slice) so users can recover by calling `gsd_skip_slice` again. The response message and details distinguish first-skip from recovery via `wasAlreadySkipped` + `tasksSkipped`.

**Scope.** I considered also relaxing the deep-task guard in `executeCompleteMilestone` for skipped slices as defense-in-depth, but kept the scope to the root cause per the "one concern per PR" guidance. The recovery path covers historical bad state.

## Testing

- `npx tsc --noEmit` — clean
- New regression: `tests/skip-slice-cascades-tasks.test.ts` — 5/5 pass
- Related tests still pass: `skip-slice-state-rebuild.test.ts`, `complete-milestone.test.ts`, `dispatch-complete-milestone-guard.test.ts`, `complete-slice.test.ts`, `tool-naming.test.ts`, `token-profile.test.ts`, `workflow-mcp.test.ts` (78 tests total, 0 fail)

## AI-assisted

This PR was drafted with AI assistance (Claude). The author reviewed the diff, rationale, and tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Skip action now reports whether the slice was already skipped and how many tasks were cascaded; success message varies accordingly.

* **Bug Fixes**
  * Skipping a slice reliably cascades "skipped" to non-closed/pending tasks while never downgrading completed tasks.
  * Clearer error responses when the slice is missing or already complete.

* **Tests**
  * Added tests covering cascade behavior, edge cases, and recovery scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->