### PR TITLE
fix(gsd): preserve dynamic routing provider prefixes

### DIFF
--- a/src/resources/extensions/gsd/auto-model-selection.ts
+++ b/src/resources/extensions/gsd/auto-model-selection.ts
@@ -205,7 +205,7 @@ export async function selectAndApplyModel(
           budgetPct,
           taskMetadataForPolicy,
         );
-        const availableModelIds = routingEligibleModels.map(m => m.id);
+        const availableModelIds = routingEligibleModels.map(m => `${m.provider}/${m.id}`);
 
         // Escalate tier on retry when escalate_on_failure is enabled (default: true)
         if (

--- a/src/resources/extensions/gsd/model-router.ts
+++ b/src/resources/extensions/gsd/model-router.ts
@@ -279,8 +279,9 @@ export function scoreEligibleModels(
   capabilityOverrides?: Record<string, Partial<ModelCapabilities>>,
 ): Array<{ modelId: string; score: number }> {
   const scored = eligibleModelIds.map(modelId => {
-    const builtin = MODEL_CAPABILITY_PROFILES[modelId];
-    const override = capabilityOverrides?.[modelId];
+    const bareId = bareModelId(modelId);
+    const builtin = MODEL_CAPABILITY_PROFILES[bareId];
+    const override = capabilityOverrides?.[modelId] ?? capabilityOverrides?.[bareId];
     const profile: ModelCapabilities = builtin
       ? override ? { ...builtin, ...override } : builtin
       : { coding: 50, debugging: 50, research: 50, reasoning: 50, speed: 50, longContext: 50, instruction: 50 };
@@ -516,7 +517,7 @@ export function defaultRoutingConfig(): DynamicRoutingConfig {
 
 function getModelTier(modelId: string): ComplexityTier {
   // Strip provider prefix if present
-  const bareId = modelId.includes("/") ? modelId.split("/").pop()! : modelId;
+  const bareId = bareModelId(modelId);
 
   // Check exact match first
   if (MODEL_CAPABILITY_TIER[bareId]) return MODEL_CAPABILITY_TIER[bareId];
@@ -532,7 +533,7 @@ function getModelTier(modelId: string): ComplexityTier {
 
 /** Check if a model ID has a known capability tier mapping. (#2192) */
 function isKnownModel(modelId: string): boolean {
-  const bareId = modelId.includes("/") ? modelId.split("/").pop()! : modelId;
+  const bareId = bareModelId(modelId);
   if (MODEL_CAPABILITY_TIER[bareId]) return true;
   for (const knownId of Object.keys(MODEL_CAPABILITY_TIER)) {
     if (bareId.includes(knownId) || knownId.includes(bareId)) return true;
@@ -541,7 +542,7 @@ function isKnownModel(modelId: string): boolean {
 }
 
 function getModelCost(modelId: string): number {
-  const bareId = modelId.includes("/") ? modelId.split("/").pop()! : modelId;
+  const bareId = bareModelId(modelId);
 
   if (MODEL_COST_PER_1K_INPUT[bareId] !== undefined) {
     return MODEL_COST_PER_1K_INPUT[bareId];
@@ -554,6 +555,10 @@ function getModelCost(modelId: string): number {
 
   // Unknown cost — assume expensive to avoid routing to unknown cheap models
   return 999;
+}
+
+function bareModelId(modelId: string): string {
+  return modelId.includes("/") ? modelId.split("/").pop()! : modelId;
 }
 
 // ─── Tool Compatibility Filter (ADR-005 Phase 3) ───────────────────────────

--- a/src/resources/extensions/gsd/tests/auto-model-selection.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-model-selection.test.ts
@@ -247,6 +247,18 @@ test("model policy receives task metadata for requirement-vector decisions", () 
   );
 });
 
+test("dynamic routing passes provider-qualified model keys to the router", () => {
+  const src = readFileSync(join(__dirname, "..", "auto-model-selection.ts"), "utf-8");
+  assert.ok(
+    src.includes("routingEligibleModels.map(m => `${m.provider}/${m.id}`)"),
+    "selectAndApplyModel should preserve provider prefixes for dynamic routing candidates",
+  );
+  assert.ok(
+    !src.includes("routingEligibleModels.map(m => m.id)"),
+    "selectAndApplyModel must not strip providers before resolving tier_models",
+  );
+});
+
 test("resolveModelId: anthropic wins over claude-code when session provider is not claude-code", () => {
   const availableModels = [
     { id: "claude-sonnet-4-6", provider: "claude-code" },

--- a/src/resources/extensions/gsd/tests/model-router.test.ts
+++ b/src/resources/extensions/gsd/tests/model-router.test.ts
@@ -126,6 +126,43 @@ test("uses explicit tier_models when configured", () => {
   assert.equal(result.wasDowngraded, true);
 });
 
+test("preserves explicit provider-qualified tier_models when duplicate bare IDs exist", () => {
+  const config: DynamicRoutingConfig = {
+    ...defaultRoutingConfig(),
+    enabled: true,
+    capability_routing: false,
+    tier_models: {
+      light: "custom-openai/gpt-5.3-codex-spark",
+      standard: "custom-openai/gpt-5.4",
+    },
+  };
+  const providerModels = [
+    "openai-codex/gpt-5.4",
+    "custom-openai/gpt-5.4",
+    "openai-codex/gpt-5.3-codex-spark",
+    "custom-openai/gpt-5.3-codex-spark",
+    "custom-anthropic/claude-opus-4-7",
+  ];
+
+  const standard = resolveModelForComplexity(
+    makeClassification("standard"),
+    { primary: "custom-anthropic/claude-opus-4-7", fallbacks: [] },
+    config,
+    providerModels,
+  );
+  assert.equal(standard.modelId, "custom-openai/gpt-5.4");
+  assert.equal(standard.wasDowngraded, true);
+
+  const light = resolveModelForComplexity(
+    makeClassification("light"),
+    { primary: "custom-anthropic/claude-opus-4-7", fallbacks: [] },
+    config,
+    providerModels,
+  );
+  assert.equal(light.modelId, "custom-openai/gpt-5.3-codex-spark");
+  assert.equal(light.wasDowngraded, true);
+});
+
 // ─── Fallback chain construction ─────────────────────────────────────────────
 
 test("fallback chain includes configured primary as last resort", () => {
@@ -216,6 +253,19 @@ test("#2192: known model is still downgraded normally", () => {
 test("defaultRoutingConfig includes capability_routing: true", () => {
   const config = defaultRoutingConfig();
   assert.equal(config.capability_routing, true);
+});
+
+test("scoreEligibleModels uses bare capability profiles for provider-qualified IDs", () => {
+  const scored = scoreEligibleModels(
+    ["custom-openai/gpt-5.4", "custom-openai/gpt-5.3-codex-spark"],
+    { coding: 1 },
+  );
+
+  assert.equal(scored[0]?.modelId, "custom-openai/gpt-5.4");
+  assert.ok(
+    (scored[0]?.score ?? 0) > (scored[1]?.score ?? 0),
+    "provider-qualified IDs should still use the built-in bare model capability profile",
+  );
 });
 
 test("scoreModel computes weighted average of capability × requirement", () => {


### PR DESCRIPTION
## Linked issue

Closes #4462

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Preserves provider-qualified model IDs through dynamic routing tier selection.
**Why:** `tier_models` entries such as `custom-openai/gpt-5.4` could be reduced to bare `gpt-5.4`, letting later provider heuristics choose the wrong provider.
**How:** Pass provider/model keys into the router and normalize provider prefixes only when looking up tier, cost, and capability metadata.

## What

This updates GSD dynamic model routing so the candidate list keeps provider-qualified model keys like `custom-openai/gpt-5.4` instead of stripping them to bare IDs before tier selection.

It also updates capability scoring to use bare model IDs for built-in profile lookups while preserving the provider-qualified ID as the selected result.

Regression coverage now verifies:

- explicit provider-qualified `tier_models` win when duplicate bare model IDs exist on multiple providers
- provider-qualified candidates still use the correct built-in capability profiles
- `selectAndApplyModel()` passes provider-qualified keys into dynamic routing

## Why

Custom providers can expose the same model IDs as built-in providers. If dynamic routing drops the provider prefix too early, a user-configured `tier_models.standard: custom-openai/gpt-5.4` can become `gpt-5.4`, and final provider selection depends on current-provider heuristics rather than the explicit config.

## How

`selectAndApplyModel()` now builds routing candidates as `provider/model` keys. The router already strips provider prefixes for tier and cost lookup, and this PR extends that same normalization to capability profile lookup so capability-scored routing remains accurate.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

Automated verification:

1. `npm run build`
2. `npm run typecheck:extensions`
3. `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/model-router.test.ts src/resources/extensions/gsd/tests/auto-model-selection.test.ts`
4. `HOME=<empty temp home> npm run test:unit` — `6899 passed, 0 failed, 8 skipped`
5. `npm run secret-scan`

Additional integration note:

- `HOME=<empty temp home> npm run test:integration` was attempted, but the run became idle in `src/resources/extensions/async-jobs/await-tool.test.ts`. The same file also remained idle on clean `upstream/main` under the same local setup, after all assertions in that file had printed as passed, so this was treated as pre-existing integration harness behavior rather than a regression from this PR.

## AI disclosure

- [x] This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed model selection logic to consistently use provider-qualified identifiers during complexity classification.
  * Improved capability profile resolution with fallback support for both full and bare model identifiers.
  * Enhanced model eligibility matching to properly preserve provider context in routing decisions.
  * Refined model tier, cost, and recognition functions to use consistent identifier handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->