### PR TITLE
fix(gsd): resolve /gsd onboarding wizard module from deployed package root

### DIFF
--- a/src/onboarding.ts
+++ b/src/onboarding.ts
@@ -57,6 +57,11 @@ type PicoModule = {
   reset: (s: string) => string
 }
 
+interface RunOnboardingOptions {
+  /** Show logo + intro banner. Disable when onboarding is launched inside an active TUI session. */
+  showIntro?: boolean
+}
+
 // ─── Constants ────────────────────────────────────────────────────────────────
 
 const TOOL_KEYS: ToolKeyConfig[] = [
@@ -246,7 +251,10 @@ export function shouldRunOnboarding(authStorage: AuthStorage, settingsDefaultPro
  * All steps are skippable. All errors are recoverable.
  * Writes status to stderr during execution.
  */
-export async function runOnboarding(authStorage: AuthStorage): Promise<void> {
+export async function runOnboarding(
+  authStorage: AuthStorage,
+  opts: RunOnboardingOptions = {},
+): Promise<void> {
   let p: ClackModule
   let pc: PicoModule
   try {
@@ -258,8 +266,10 @@ export async function runOnboarding(authStorage: AuthStorage): Promise<void> {
   }
 
   // ── Intro ─────────────────────────────────────────────────────────────────
-  process.stderr.write(renderLogo(pc.cyan))
-  p.intro(pc.bold('Welcome to GSD — let\'s get you set up'))
+  if (opts.showIntro !== false) {
+    process.stderr.write(renderLogo(pc.cyan))
+    p.intro(pc.bold('Welcome to GSD — let\'s get you set up'))
+  }
 
   const completedSteps: string[] = []
 

--- a/src/resources/extensions/gsd/commands/handlers/onboarding.ts
+++ b/src/resources/extensions/gsd/commands/handlers/onboarding.ts
@@ -39,7 +39,10 @@ const AUTH_FILE_PATH = join(
  * compile time; the path resolves correctly at runtime via dist/onboarding.js.
  */
 type FirstRunWizardModule = {
-  runOnboarding: (storage: AuthStorage) => Promise<void>
+  runOnboarding: (
+    storage: AuthStorage,
+    opts?: { showIntro?: boolean },
+  ) => Promise<void>
   runLlmStep: (...args: unknown[]) => Promise<unknown>
   runWebSearchStep: (...args: unknown[]) => Promise<unknown>
   runRemoteQuestionsStep: (...args: unknown[]) => Promise<unknown>
@@ -126,7 +129,7 @@ async function runWholeWizard(ctx: ExtensionCommandContext, fromStep?: Onboardin
     )
   }
   const { runOnboarding } = await loadFirstRunWizard()
-  await runOnboarding(authStorage)
+  await runOnboarding(authStorage, { showIntro: false })
 }
 
 async function runSingleStep(ctx: ExtensionCommandContext, stepId: OnboardingStepId): Promise<void> {

--- a/src/resources/extensions/gsd/commands/handlers/onboarding.ts
+++ b/src/resources/extensions/gsd/commands/handlers/onboarding.ts
@@ -7,7 +7,8 @@
 import type { ExtensionCommandContext } from "@gsd/pi-coding-agent"
 import { AuthStorage } from "@gsd/pi-coding-agent"
 import { homedir } from "node:os"
-import { join } from "node:path"
+import { dirname, join, resolve } from "node:path"
+import { pathToFileURL } from "node:url"
 import {
   ONBOARDING_STEPS,
   isValidStepId,
@@ -45,8 +46,37 @@ type FirstRunWizardModule = {
   runToolKeysStep: (...args: unknown[]) => Promise<unknown>
 }
 async function loadFirstRunWizard(): Promise<FirstRunWizardModule> {
-  const specifier = "../../../../../onboarding.js"
-  return (await import(/* @vite-ignore */ specifier)) as FirstRunWizardModule
+  const candidates: string[] = []
+
+  // Primary deployed path: loader sets GSD_PKG_ROOT (gsd package root).
+  if (process.env.GSD_PKG_ROOT) {
+    candidates.push(pathToFileURL(join(process.env.GSD_PKG_ROOT, "dist", "onboarding.js")).href)
+  }
+
+  // Fallback: derive package root from process entry (typically dist/loader.js).
+  // This keeps /gsd onboarding resilient if GSD_PKG_ROOT is absent.
+  const argvEntry = process.argv[1]
+  if (argvEntry) {
+    const pkgRootFromArgv = resolve(dirname(argvEntry), "..")
+    candidates.push(pathToFileURL(join(pkgRootFromArgv, "dist", "onboarding.js")).href)
+  }
+
+  // Source-tree/dev fallback (works in dist/resources/... and ts test loaders).
+  candidates.push("../../../../../onboarding.js")
+
+  let lastError: unknown = null
+  for (const specifier of candidates) {
+    try {
+      return (await import(/* @vite-ignore */ specifier)) as FirstRunWizardModule
+    } catch (err) {
+      lastError = err
+    }
+  }
+
+  const reason = lastError instanceof Error ? lastError.message : String(lastError)
+  throw new Error(
+    `[gsd] Failed to load onboarding wizard module. Tried: ${candidates.join(", ")}. Last error: ${reason}`,
+  )
 }
 
 interface ParsedArgs {

--- a/src/resources/extensions/gsd/tests/onboarding-handler-loader.test.ts
+++ b/src/resources/extensions/gsd/tests/onboarding-handler-loader.test.ts
@@ -1,0 +1,41 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+
+test("onboarding handler resolves wizard module from deployed runtime paths", () => {
+  const source = readFileSync(
+    join(import.meta.dirname, "..", "commands", "handlers", "onboarding.ts"),
+    "utf-8",
+  )
+
+  assert.match(
+    source,
+    /process\.env\.GSD_PKG_ROOT/,
+    "handler should probe GSD_PKG_ROOT for deployed dist\/onboarding.js",
+  )
+
+  assert.match(
+    source,
+    /process\.argv\[1\]/,
+    "handler should fall back to argv-derived package root when env is missing",
+  )
+
+  assert.match(
+    source,
+    /candidates\.push\("\.\.\/\.\.\/\.\.\/\.\.\/\.\.\/onboarding\.js"\)/,
+    "handler must keep the relative source\/dist fallback",
+  )
+
+  assert.match(
+    source,
+    /for \(const specifier of candidates\)/,
+    "handler should try candidates in order",
+  )
+
+  assert.match(
+    source,
+    /Failed to load onboarding wizard module/,
+    "handler should throw a diagnostic error when no candidate resolves",
+  )
+})

--- a/src/tests/onboarding-reentry-no-double-header.test.ts
+++ b/src/tests/onboarding-reentry-no-double-header.test.ts
@@ -1,0 +1,34 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+
+test("re-entry onboarding suppresses duplicate intro/header rendering", () => {
+  const onboardingSource = readFileSync(
+    join(import.meta.dirname, "..", "onboarding.ts"),
+    "utf-8",
+  )
+
+  assert.match(
+    onboardingSource,
+    /interface RunOnboardingOptions[\s\S]*showIntro\?: boolean/,
+    "runOnboarding should accept a showIntro option",
+  )
+
+  assert.match(
+    onboardingSource,
+    /if \(opts\.showIntro !== false\)[\s\S]*renderLogo\(pc\.cyan\)[\s\S]*p\.intro\(/,
+    "runOnboarding should gate logo/intro rendering behind showIntro",
+  )
+
+  const handlerSource = readFileSync(
+    join(import.meta.dirname, "..", "resources", "extensions", "gsd", "commands", "handlers", "onboarding.ts"),
+    "utf-8",
+  )
+
+  assert.match(
+    handlerSource,
+    /runOnboarding\(authStorage, \{ showIntro: false \}\)/,
+    "re-entry onboarding handler must suppress onboarding intro/header",
+  )
+})


### PR DESCRIPTION
## Summary
Fixes `/gsd onboarding` runtime import failures when the deployed extension tries to load `../../../../../onboarding.js` but that file does not exist under `~/.gsd`.

## What changed
- Update `src/resources/extensions/gsd/commands/handlers/onboarding.ts` to resolve onboarding module from multiple runtime-safe candidates, in order:
  1. `$GSD_PKG_ROOT/dist/onboarding.js`
  2. `process.argv[1]`-derived package root + `/dist/onboarding.js`
  3. existing relative fallback `../../../../../onboarding.js`
- Keep explicit diagnostic error that reports tried candidates when all resolution attempts fail.
- Add regression test: `src/resources/extensions/gsd/tests/onboarding-handler-loader.test.ts`.

## Validation
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/onboarding-handler-loader.test.ts`
- `npx tsc --noEmit -p tsconfig.resources.json`

Both pass locally.

## Context
This addresses the runtime error:
`Cannot find module '/Users/.../.gsd/onboarding.js' imported from .../commands/handlers/onboarding.js`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Onboarding wizard now supports optional configuration to control intro banner display, enabling flexible and context-aware presentation across different application scenarios and integration points

* **Tests**
  * Added test coverage for onboarding module loading with multiple fallback mechanisms and error handling
  * Added test coverage for re-entry onboarding behavior to ensure proper suppression of intro banner on subsequent wizard invocations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->