### PR TITLE
fix(gsd): exempt task's own output from pre-exec input check (#4459)

### DIFF
--- a/src/resources/extensions/gsd/pre-execution-checks.ts
+++ b/src/resources/extensions/gsd/pre-execution-checks.ts
@@ -456,7 +456,7 @@ export function checkFilePathConsistency(
           category: "file",
           target: file,
           passed: false,
-          message: `Task ${task.id} references '${file}' which doesn't exist and isn't created by prior tasks`,
+          message: `Task ${task.id} references '${file}' which doesn't exist and isn't created by prior or same-task outputs`,
           blocking: true,
         });
       }

--- a/src/resources/extensions/gsd/pre-execution-checks.ts
+++ b/src/resources/extensions/gsd/pre-execution-checks.ts
@@ -403,10 +403,13 @@ function getExpectedOutputsUpTo(tasks: TaskRow[], taskIndex: number): Set<string
 /**
  * Check that all files referenced in task.inputs either:
  *   1. Exist on disk, OR
- *   2. Are in a prior task's expected_output
+ *   2. Are in a prior task's expected_output, OR
+ *   3. Are in the current task's own expected_output — the task produces them,
+ *      so they don't need to pre-exist (#4459, mirroring the exemption #3626
+ *      introduced for task.files).
  *
- * task.files ("files likely touched") is excluded — it intentionally includes
- * files the task will create, so they don't need to pre-exist (#3626).
+ * task.files ("files likely touched") is excluded entirely from this check —
+ * it intentionally includes files the task will create (#3626).
  *
  * All paths are normalized before comparison to ensure ./src/a.ts matches src/a.ts.
  */
@@ -419,6 +422,7 @@ export function checkFilePathConsistency(
   for (let i = 0; i < tasks.length; i++) {
     const task = tasks[i];
     const priorOutputs = getExpectedOutputsUpTo(tasks, i);
+    const ownOutputs = new Set<string>(task.expected_output.map(normalizeFilePath));
     const filesToCheck = [...task.inputs];
 
     for (const file of filesToCheck) {
@@ -436,18 +440,18 @@ export function checkFilePathConsistency(
 
       // Check if file is in prior expected outputs (priorOutputs already normalized)
       const inPriorOutputs = priorOutputs.has(normalizedFile);
+      const inOwnOutputs = ownOutputs.has(normalizedFile);
 
       // Directory inputs are satisfied when something produces a file beneath
       // them — either a prior task or the current task itself.
       let directorySatisfied = false;
-      if (!existsOnDisk && !inPriorOutputs && isDirectoryReference(file)) {
-        const sameTaskOutputs = task.expected_output.map(normalizeFilePath);
+      if (!existsOnDisk && !inPriorOutputs && !inOwnOutputs && isDirectoryReference(file)) {
         directorySatisfied =
           anyOutputUnderDirectory(normalizedFile, priorOutputs) ||
-          anyOutputUnderDirectory(normalizedFile, sameTaskOutputs);
+          anyOutputUnderDirectory(normalizedFile, ownOutputs);
       }
 
-      if (!existsOnDisk && !inPriorOutputs && !directorySatisfied) {
+      if (!existsOnDisk && !inPriorOutputs && !inOwnOutputs && !directorySatisfied) {
         results.push({
           category: "file",
           target: file,

--- a/src/resources/extensions/gsd/tests/pre-execution-checks.test.ts
+++ b/src/resources/extensions/gsd/tests/pre-execution-checks.test.ts
@@ -1579,3 +1579,69 @@ describe("checkTaskOrdering directory inputs (#4446)", () => {
     );
   });
 });
+
+describe("checkFilePathConsistency self-referential inputs (#4459)", () => {
+  test("input that is also in the same task's expected_output is not blocking when missing on disk", (t) => {
+    const tempDir = join(tmpdir(), `pre-exec-self-output-${Date.now()}`);
+    mkdirSync(tempDir, { recursive: true });
+    t.after(() => rmSync(tempDir, { recursive: true, force: true }));
+
+    const tasks = [
+      createTask({
+        id: "T02",
+        sequence: 0,
+        inputs: ["src/components/email/SnoozePopover.jsx"],
+        expected_output: ["src/components/email/SnoozePopover.jsx"],
+      }),
+    ];
+
+    const results = checkFilePathConsistency(tasks, tempDir);
+    assert.deepEqual(
+      results,
+      [],
+      "File declared as both input and expected_output of the same task should not block — the task itself produces it",
+    );
+  });
+
+  test("input missing from disk, missing from prior outputs, and missing from own expected_output still blocks", (t) => {
+    const tempDir = join(tmpdir(), `pre-exec-self-output-missing-${Date.now()}`);
+    mkdirSync(tempDir, { recursive: true });
+    t.after(() => rmSync(tempDir, { recursive: true, force: true }));
+
+    const tasks = [
+      createTask({
+        id: "T02",
+        sequence: 0,
+        inputs: ["src/components/email/SnoozePopover.jsx"],
+        expected_output: ["src/other/unrelated.jsx"],
+      }),
+    ];
+
+    const results = checkFilePathConsistency(tasks, tempDir);
+    assert.equal(results.length, 1, "Genuinely missing input should still be reported");
+    assert.equal(results[0].blocking, true);
+    assert.equal(results[0].target, "src/components/email/SnoozePopover.jsx");
+  });
+
+  test("self-output exemption matches across path normalization (./ prefix)", (t) => {
+    const tempDir = join(tmpdir(), `pre-exec-self-output-norm-${Date.now()}`);
+    mkdirSync(tempDir, { recursive: true });
+    t.after(() => rmSync(tempDir, { recursive: true, force: true }));
+
+    const tasks = [
+      createTask({
+        id: "T02",
+        sequence: 0,
+        inputs: ["./src/generated.ts"],
+        expected_output: ["src/generated.ts"],
+      }),
+    ];
+
+    const results = checkFilePathConsistency(tasks, tempDir);
+    assert.deepEqual(
+      results,
+      [],
+      "./src/generated.ts and src/generated.ts should compare equal after normalization",
+    );
+  });
+});


### PR DESCRIPTION
## TL;DR

**What:** Stop `checkFilePathConsistency` from blocking a task that lists the same new file in both its own `inputs` and its own `expected_output`.
**Why:** Auto-mode stuck-loops on a legitimate plan shape — the task that would create the file is the one being gated, so the file is never produced.
**How:** Exempt files that appear in the current task's own `expected_output` from the pre-existence check, mirroring the exemption #3626 introduced for `task.files`.

## What

`src/resources/extensions/gsd/pre-execution-checks.ts`
- `checkFilePathConsistency` now builds an `ownOutputs` Set once per task from the current task's normalized `expected_output`.
- A task input that hits `ownOutputs` is treated as satisfied (produced by the task itself) and does not fall through to the blocking-failure report.
- The directory-input branch (#4446) now reuses the same Set instead of rebuilding a parallel `sameTaskOutputs` array.
- Docstring updated to list all three "satisfied" paths (on disk / prior output / same-task output) and the Provenance of each.

`src/resources/extensions/gsd/tests/pre-execution-checks.test.ts`
- New `describe("checkFilePathConsistency self-referential inputs (#4459)")` block with three regression tests:
  - Basic case: input ∩ same-task expected_output, file missing on disk → no failure.
  - Guardrail: genuinely missing input (not in any output) still blocks.
  - Normalization: `./src/generated.ts` input matches `src/generated.ts` in the same task's expected_output.

## Why

Reported in #4459 as the sibling bug that #3626 / #3713 did not cover.

`getExpectedOutputsUpTo(tasks, i)` builds its satisfying set from tasks with index `< i`, so a file declared as both an input to and an output of the same task was treated as a missing prior input. That is self-contradictory: the task in question is the one that creates the file.

When the check fired, auto-mode paused with `Task TNN references '...' which doesn't exist and isn't created by prior tasks`. The only in-band workaround was a manual `touch` of the expected path — there was no self-recovery.

`#3626` already exempted `task.files` for the same class of false-positive; this change applies the same reasoning to `task.inputs` when the planner (legitimately or not) declares a self-output as an input. `checkTaskOrdering` is unaffected — for self-outputs the file's creator index equals the reader index, so the existing `creator.index > i` guard was already correct.

Closes #4459.

## How

Minimal change in `checkFilePathConsistency`:

1. **Per-task set:** once per task, build `ownOutputs = new Set<string>(task.expected_output.map(normalizeFilePath))`. Same shape as the existing `priorOutputs` set, so the two lookups compose naturally.
2. **New guard:** before the blocking branch, compute `inOwnOutputs = ownOutputs.has(normalizedFile)` and add it to the satisfied-conditions vector. The blocking branch now requires `!existsOnDisk && !inPriorOutputs && !inOwnOutputs && !directorySatisfied`.
3. **Directory branch consolidation:** the directory-input branch from #4446 used to allocate a fresh `sameTaskOutputs` array per checked file. It now reuses `ownOutputs` — identical semantics, one allocation per task instead of per input.
4. **Docstring:** now enumerates all three "satisfied" paths and attributes each exemption to its originating issue (`#3626` for `task.files`, `#4459` for same-task self-outputs).

Test plan (written test-first):
- Regression test reproduces the #4459 scenario from the issue (`SnoozePopover.jsx` in both `inputs` and `expected_output`, not on disk). Red before the fix, green after.
- Guardrail test confirms the check still blocks for genuinely missing inputs that are not in any output.
- Normalization test confirms the exemption matches across `./` prefix normalization so it cannot be bypassed or spuriously fail on normalized-vs-raw mismatches.

## Change type checklist

- [ ] `feat`
- [x] `fix`
- [ ] `refactor`
- [ ] `test`
- [ ] `docs`
- [ ] `chore`

## AI-assisted disclosure

This PR is AI-assisted (Claude). Code, tests, and this description were reviewed and approved by the author before pushing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Pre-execution file-path validation now treats inputs produced by the same task as satisfied (including normalized path variants), preventing false blocking failures; error messaging updated to reference "prior or same-task outputs". The task's runtime file list is excluded from this check.

* **Tests**
  * Added tests covering self-referential input/output and normalization cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->