### PR TITLE
fix(gsd): thread modelRegistry + sessionContextWindow through dispatch (#4142)

### DIFF
--- a/src/resources/extensions/gsd/auto-direct-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-direct-dispatch.ts
@@ -28,6 +28,7 @@ import {
   buildReplanSlicePrompt,
 } from "./auto-prompts.js";
 import { loadEffectiveGSDPreferences } from "./preferences.js";
+import type { MinimalModelRegistry } from "./context-budget.js";
 import { pauseAuto } from "./auto.js";
 import {
   getWorkflowTransportSupportError,
@@ -104,7 +105,13 @@ export async function dispatchDirectPhase(
         }
         unitType = "plan-slice";
         unitId = `${mid}/${sid}`;
-        prompt = await buildPlanSlicePrompt(mid, midTitle, sid, sTitle, base);
+        prompt = await buildPlanSlicePrompt(
+          mid, midTitle, sid, sTitle, base, undefined,
+          {
+            sessionContextWindow: ctx.model?.contextWindow,
+            modelRegistry: ctx.modelRegistry as MinimalModelRegistry | undefined,
+          },
+        );
       } else {
         unitType = "plan-milestone";
         unitId = mid;
@@ -129,7 +136,13 @@ export async function dispatchDirectPhase(
       }
       unitType = "execute-task";
       unitId = `${mid}/${sid}/${tid}`;
-      prompt = await buildExecuteTaskPrompt(mid, sid, sTitle, tid, tTitle, base);
+      prompt = await buildExecuteTaskPrompt(
+        mid, sid, sTitle, tid, tTitle, base,
+        {
+          sessionContextWindow: ctx.model?.contextWindow,
+          modelRegistry: ctx.modelRegistry as MinimalModelRegistry | undefined,
+        },
+      );
       break;
     }
 

--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -12,6 +12,7 @@
 import type { GSDState } from "./types.js";
 import type { GSDPreferences } from "./preferences.js";
 import type { UatType } from "./files.js";
+import type { MinimalModelRegistry } from "./context-budget.js";
 import { loadFile, extractUatType, loadActiveOverrides } from "./files.js";
 import { isDbAvailable, getMilestoneSlices, getPendingGates, markAllGatesOmitted, getMilestone, updateMilestoneStatus } from "./gsd-db.js";
 import { isClosedStatus } from "./status-guards.js";
@@ -81,6 +82,10 @@ export interface DispatchContext {
   prefs: GSDPreferences | undefined;
   session?: import("./auto/session.js").AutoSession;
   structuredQuestionsAvailable?: "true" | "false";
+  /** Session model context window in tokens, forwarded to the budget engine's prompt builders. */
+  sessionContextWindow?: number;
+  /** Model registry forwarded to the budget engine so it can look up the configured executor model. */
+  modelRegistry?: MinimalModelRegistry;
 }
 
 export interface DispatchRule {
@@ -521,7 +526,7 @@ export const DISPATCH_RULES: DispatchRule[] = [
     // auto-heal without either adding an explicit `setSliceSketchFlag(..., false)`
     // call here or doing so inside the plan-slice tool handler.
     name: "refining → refine-slice",
-    match: async ({ state, mid, midTitle, basePath, prefs }) => {
+    match: async ({ state, mid, midTitle, basePath, prefs, sessionContextWindow, modelRegistry }) => {
       if (state.phase !== "refining") return null;
       if (!state.activeSlice) return missingSliceStop(mid, state.phase);
       const sid = state.activeSlice.id;
@@ -546,7 +551,7 @@ export const DISPATCH_RULES: DispatchRule[] = [
           unitId: `${mid}/${sid}`,
           prompt: await buildPlanSlicePrompt(
             mid, midTitle, sid, sTitle, basePath, undefined,
-            softScopeHint ? { softScopeHint } : undefined,
+            { ...(softScopeHint ? { softScopeHint } : {}), sessionContextWindow, modelRegistry },
           ),
         };
       }
@@ -554,13 +559,16 @@ export const DISPATCH_RULES: DispatchRule[] = [
         action: "dispatch",
         unitType: "refine-slice",
         unitId: `${mid}/${sid}`,
-        prompt: await buildRefineSlicePrompt(mid, midTitle, sid, sTitle, basePath),
+        prompt: await buildRefineSlicePrompt(
+          mid, midTitle, sid, sTitle, basePath, undefined,
+          { sessionContextWindow, modelRegistry },
+        ),
       };
     },
   },
   {
     name: "planning → plan-slice",
-    match: async ({ state, mid, midTitle, basePath }) => {
+    match: async ({ state, mid, midTitle, basePath, sessionContextWindow, modelRegistry }) => {
       if (state.phase !== "planning") return null;
       if (!state.activeSlice) return missingSliceStop(mid, state.phase);
       const sid = state.activeSlice!.id;
@@ -575,6 +583,8 @@ export const DISPATCH_RULES: DispatchRule[] = [
           sid,
           sTitle,
           basePath,
+          undefined,
+          { sessionContextWindow, modelRegistry },
         ),
       };
     },
@@ -635,7 +645,7 @@ export const DISPATCH_RULES: DispatchRule[] = [
   },
   {
     name: "executing → reactive-execute (parallel dispatch)",
-    match: async ({ state, mid, midTitle, basePath, prefs }) => {
+    match: async ({ state, mid, midTitle, basePath, prefs, sessionContextWindow, modelRegistry }) => {
       if (state.phase !== "executing" || !state.activeTask) return null;
       if (!state.activeSlice) return null; // fall through
 
@@ -726,6 +736,7 @@ export const DISPATCH_RULES: DispatchRule[] = [
             selected,
             basePath,
             subagentModel,
+            { sessionContextWindow, modelRegistry },
           ),
         };
       } catch (err) {
@@ -737,7 +748,7 @@ export const DISPATCH_RULES: DispatchRule[] = [
   },
   {
     name: "executing → execute-task (recover missing task plan → plan-slice)",
-    match: async ({ state, mid, midTitle, basePath }) => {
+    match: async ({ state, mid, midTitle, basePath, sessionContextWindow, modelRegistry }) => {
       if (state.phase !== "executing" || !state.activeTask) return null;
       if (!state.activeSlice) return missingSliceStop(mid, state.phase);
       const sid = state.activeSlice!.id;
@@ -761,6 +772,8 @@ export const DISPATCH_RULES: DispatchRule[] = [
             sid,
             sTitle,
             basePath,
+            undefined,
+            { sessionContextWindow, modelRegistry },
           ),
         };
       }
@@ -770,7 +783,7 @@ export const DISPATCH_RULES: DispatchRule[] = [
   },
   {
     name: "executing → execute-task",
-    match: async ({ state, mid, basePath }) => {
+    match: async ({ state, mid, basePath, sessionContextWindow, modelRegistry }) => {
       if (state.phase !== "executing" || !state.activeTask) return null;
       if (!state.activeSlice) return missingSliceStop(mid, state.phase);
       const sid = state.activeSlice!.id;
@@ -789,6 +802,7 @@ export const DISPATCH_RULES: DispatchRule[] = [
           tid,
           tTitle,
           basePath,
+          { sessionContextWindow, modelRegistry },
         ),
       };
     },

--- a/src/resources/extensions/gsd/auto-prompts.ts
+++ b/src/resources/extensions/gsd/auto-prompts.ts
@@ -23,7 +23,7 @@ import type { GSDPreferences } from "./preferences.js";
 import { getLoadedSkills, type Skill } from "@gsd/pi-coding-agent";
 import { join, basename } from "node:path";
 import { existsSync } from "node:fs";
-import { computeBudgets, resolveExecutorContextWindow, truncateAtSectionBoundary } from "./context-budget.js";
+import { computeBudgets, resolveExecutorContextWindow, truncateAtSectionBoundary, type MinimalModelRegistry } from "./context-budget.js";
 import { getPendingGates, getPendingGatesForTurn } from "./gsd-db.js";
 import {
   GATE_REGISTRY,
@@ -94,14 +94,19 @@ function capPreamble(preamble: string): string {
  * Uses the budget engine to compute task count ranges and inline context budgets
  * based on the configured executor model's context window.
  */
-function formatExecutorConstraints(): string {
+function formatExecutorConstraints(
+  sessionContextWindow?: number,
+  modelRegistry?: MinimalModelRegistry,
+): string {
   let windowTokens: number;
   try {
     const prefs = loadEffectiveGSDPreferences();
-    windowTokens = resolveExecutorContextWindow(undefined, prefs?.preferences);
+    windowTokens = resolveExecutorContextWindow(modelRegistry, prefs?.preferences, sessionContextWindow);
   } catch (e) {
     logWarning("prompt", `resolveExecutorContextWindow failed: ${(e as Error).message}`);
-    windowTokens = 200_000; // safe default
+    // Delegate to the budget engine without prefs (the path that just threw)
+    // so DEFAULT_CONTEXT_WINDOW stays the single source of truth.
+    windowTokens = resolveExecutorContextWindow(undefined, undefined, sessionContextWindow);
   }
   const budgets = computeBudgets(windowTokens);
   const { min, max } = budgets.taskCountRange;
@@ -1288,8 +1293,13 @@ async function renderSlicePrompt(options: {
   promptTemplate: "plan-slice" | "refine-slice";
   prependBlocks?: string[];
   extraVars?: Record<string, string>;
+  sessionContextWindow?: number;
+  modelRegistry?: MinimalModelRegistry;
 }): Promise<string> {
-  const { mid, sid, sTitle, base, level, promptTemplate, prependBlocks = [], extraVars = {} } = options;
+  const {
+    mid, sid, sTitle, base, level, promptTemplate, prependBlocks = [], extraVars = {},
+    sessionContextWindow, modelRegistry,
+  } = options;
 
   const roadmapPath = resolveMilestoneFile(base, mid, "ROADMAP");
   const roadmapRel = relMilestoneFile(base, mid, "ROADMAP");
@@ -1341,7 +1351,7 @@ async function renderSlicePrompt(options: {
   if (overridesInline) inlined.unshift(overridesInline);
 
   const inlinedContext = capPreamble(`## Inlined Context (preloaded — do not re-read these files)\n\n${inlined.join("\n\n---\n\n")}`);
-  const executorContextConstraints = formatExecutorConstraints();
+  const executorContextConstraints = formatExecutorConstraints(sessionContextWindow, modelRegistry);
   const outputRelPath = relSliceFile(base, mid, sid, "PLAN");
   const commitInstruction = "Do not commit — .gsd/ planning docs are managed externally and not tracked in git.";
 
@@ -1370,7 +1380,7 @@ async function renderSlicePrompt(options: {
 
 export async function buildPlanSlicePrompt(
   mid: string, _midTitle: string, sid: string, sTitle: string, base: string, level?: InlineLevel,
-  options?: { softScopeHint?: string },
+  options?: { softScopeHint?: string; sessionContextWindow?: number; modelRegistry?: MinimalModelRegistry },
 ): Promise<string> {
   const prependBlocks: string[] = [];
   // ADR-011: when the refining-phase dispatch rule gracefully downgrades to
@@ -1388,6 +1398,8 @@ export async function buildPlanSlicePrompt(
     level: level ?? resolveInlineLevel(),
     promptTemplate: "plan-slice",
     prependBlocks,
+    sessionContextWindow: options?.sessionContextWindow,
+    modelRegistry: options?.modelRegistry,
   });
 }
 
@@ -1400,6 +1412,7 @@ export async function buildPlanSlicePrompt(
  */
 export async function buildRefineSlicePrompt(
   mid: string, _midTitle: string, sid: string, sTitle: string, base: string, level?: InlineLevel,
+  options?: { sessionContextWindow?: number; modelRegistry?: MinimalModelRegistry },
 ): Promise<string> {
   // Pull the stored sketch scope from the DB — the hard constraint we plan within.
   let sketchScope = "";
@@ -1426,6 +1439,8 @@ export async function buildRefineSlicePrompt(
     promptTemplate: "refine-slice",
     prependBlocks,
     extraVars: { sketchScope },
+    sessionContextWindow: options?.sessionContextWindow,
+    modelRegistry: options?.modelRegistry,
   });
 }
 
@@ -1434,6 +1449,10 @@ export interface ExecuteTaskPromptOptions {
   level?: InlineLevel;
   /** Override carry-forward paths (dependency-based instead of order-based). */
   carryForwardPaths?: string[];
+  /** Session model context window in tokens, forwarded to the budget engine. */
+  sessionContextWindow?: number;
+  /** Model registry forwarded to the budget engine for executor-model lookup. */
+  modelRegistry?: MinimalModelRegistry;
 }
 
 export async function buildExecuteTaskPrompt(
@@ -1525,7 +1544,7 @@ export async function buildExecuteTaskPrompt(
 
   // Compute verification budget for the executor's context window (issue #707)
   const prefs = loadEffectiveGSDPreferences();
-  const contextWindow = resolveExecutorContextWindow(undefined, prefs?.preferences);
+  const contextWindow = resolveExecutorContextWindow(opts.modelRegistry, prefs?.preferences, opts.sessionContextWindow);
   const budgets = computeBudgets(contextWindow);
   const verificationBudget = `~${Math.round(budgets.verificationBudgetChars / 1000)}K chars`;
 
@@ -2101,6 +2120,7 @@ export async function buildReactiveExecutePrompt(
   mid: string, midTitle: string, sid: string, sTitle: string,
   readyTaskIds: string[], base: string,
   subagentModel?: string,
+  opts?: { sessionContextWindow?: number; modelRegistry?: MinimalModelRegistry },
 ): Promise<string> {
   const { loadSliceTaskIO, deriveTaskGraph, graphMetrics } = await import("./reactive-graph.js");
 
@@ -2142,7 +2162,11 @@ export async function buildReactiveExecutePrompt(
     // Build a full execute-task prompt with dependency-based carry-forward
     const taskPrompt = await buildExecuteTaskPrompt(
       mid, sid, sTitle, tid, tTitle, base,
-      { carryForwardPaths: depPaths },
+      {
+        carryForwardPaths: depPaths,
+        sessionContextWindow: opts?.sessionContextWindow,
+        modelRegistry: opts?.modelRegistry,
+      },
     );
 
     const modelSuffix = subagentModel ? ` with model: "${subagentModel}"` : "";

--- a/src/resources/extensions/gsd/auto/loop-deps.ts
+++ b/src/resources/extensions/gsd/auto/loop-deps.ts
@@ -16,7 +16,7 @@ import type {
   VerificationContext,
   VerificationResult,
 } from "../auto-verification.js";
-import type { DispatchAction } from "../auto-dispatch.js";
+import type { DispatchAction, DispatchContext } from "../auto-dispatch.js";
 import type { WorktreeResolver } from "../worktree-resolver.js";
 import type { CmuxLogLevel } from "../../cmux/index.js";
 import type { JournalEntry } from "../journal.js";
@@ -145,15 +145,7 @@ export interface LoopDeps {
   } | null>;
 
   // Dispatch
-  resolveDispatch: (dctx: {
-    basePath: string;
-    mid: string;
-    midTitle: string;
-    state: GSDState;
-    prefs: GSDPreferences | undefined;
-    session?: AutoSession;
-    structuredQuestionsAvailable?: "true" | "false";
-  }) => Promise<DispatchAction>;
+  resolveDispatch: (dctx: DispatchContext) => Promise<DispatchAction>;
   runPreDispatchHooks: (
     unitType: string,
     unitId: string,

--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -50,6 +50,7 @@ import { withTimeout, FINALIZE_PRE_TIMEOUT_MS, FINALIZE_POST_TIMEOUT_MS } from "
 import { getEligibleSlices } from "../slice-parallel-eligibility.js";
 import { startSliceParallel } from "../slice-parallel-orchestrator.js";
 import { isDbAvailable, getMilestoneSlices } from "../gsd-db.js";
+import type { MinimalModelRegistry } from "../context-budget.js";
 import { ensurePlanV2Graph } from "../uok/plan-v2.js";
 import { resolveUokFlags } from "../uok/flags.js";
 import { UokGateRunner } from "../uok/gate-runner.js";
@@ -857,6 +858,8 @@ export async function runDispatch(
     prefs,
     session: s,
     structuredQuestionsAvailable,
+    sessionContextWindow: ctx.model?.contextWindow,
+    modelRegistry: ctx.modelRegistry as MinimalModelRegistry | undefined,
   });
 
   if (dispatchResult.action === "stop") {

--- a/src/resources/extensions/gsd/tests/prompt-budget-enforcement.test.ts
+++ b/src/resources/extensions/gsd/tests/prompt-budget-enforcement.test.ts
@@ -1,13 +1,8 @@
 /**
  * Prompt budget enforcement tests — verifies that budget-aware prompt builders
- * truncate content at section boundaries and that plan-slice includes executor
- * context constraints.
- *
- * Tests:
- *   1. inlineDependencySummaries() truncates when budget is small, passes through when large
- *   2. plan-slice.md template includes {{executorContextConstraints}} placeholder
- *   3. Executor constraints formatting varies with context window size
- *   4. Different context windows produce different budget-constrained outputs
+ * truncate content at section boundaries, that plan-slice includes executor
+ * context constraints, and that prompt builders thread the real executor
+ * context window through to the budget engine (issue #4142).
  */
 
 import { describe, it, beforeEach, afterEach } from "node:test";
@@ -487,5 +482,134 @@ describe("prompt-budget: execute-task builder truncation pattern", () => {
       assert.ok(result.content.includes("[...truncated"), "should truncate when content exceeds 128K budget");
       assert.ok(result.droppedSections > 0, "should report dropped sections");
     }
+  });
+});
+
+// ─── Regression: prompt builders must thread modelRegistry + sessionContextWindow (issue #4142) ───
+//
+// `resolveExecutorContextWindow()` resolves the executor context window in 3
+// steps: (1) look up the configured executor model in `modelRegistry`, (2) fall
+// back to `sessionContextWindow`, (3) fall back to `DEFAULT_CONTEXT_WINDOW`
+// (200K). Before this fix, prompt-builder call sites passed `undefined` for
+// both knobs and always landed on Step 3 — even on 1M-token models. These
+// source-level assertions pin the wiring so future refactors cannot regress it.
+
+describe("prompt-budget: modelRegistry + sessionContextWindow wiring", () => {
+  const autoPromptsSrc = readFileSync(join(__dirname, "..", "auto-prompts.ts"), "utf-8");
+  const autoDispatchSrc = readFileSync(join(__dirname, "..", "auto-dispatch.ts"), "utf-8");
+  const autoDirectDispatchSrc = readFileSync(join(__dirname, "..", "auto-direct-dispatch.ts"), "utf-8");
+  const phasesSrc = readFileSync(join(__dirname, "..", "auto", "phases.ts"), "utf-8");
+
+  it("formatExecutorConstraints accepts and forwards both knobs", () => {
+    assert.match(
+      autoPromptsSrc,
+      /function formatExecutorConstraints\([^)]*sessionContextWindow[^)]*modelRegistry[^)]*\)/s,
+      "formatExecutorConstraints must accept sessionContextWindow and modelRegistry",
+    );
+    assert.match(
+      autoPromptsSrc,
+      /resolveExecutorContextWindow\(\s*modelRegistry\s*,\s*prefs\?\.preferences\s*,\s*sessionContextWindow/,
+      "formatExecutorConstraints must forward both to resolveExecutorContextWindow",
+    );
+  });
+
+  it("renderSlicePrompt options declare both knobs and forward to formatExecutorConstraints", () => {
+    assert.match(
+      autoPromptsSrc,
+      /async function renderSlicePrompt\(options:\s*\{[^}]*sessionContextWindow\?[^}]*modelRegistry\?/s,
+      "renderSlicePrompt options must declare both fields",
+    );
+    assert.match(
+      autoPromptsSrc,
+      /formatExecutorConstraints\(sessionContextWindow,\s*modelRegistry\)/,
+      "renderSlicePrompt must forward both to formatExecutorConstraints",
+    );
+  });
+
+  it("buildPlanSlicePrompt options declare both knobs and thread them into renderSlicePrompt", () => {
+    assert.match(
+      autoPromptsSrc,
+      /export async function buildPlanSlicePrompt\([\s\S]*?options\?:\s*\{[^}]*sessionContextWindow\?[^}]*modelRegistry\?/,
+      "buildPlanSlicePrompt options must declare both fields",
+    );
+    assert.match(
+      autoPromptsSrc,
+      /sessionContextWindow:\s*options\?\.sessionContextWindow,\s*modelRegistry:\s*options\?\.modelRegistry/,
+      "buildPlanSlicePrompt must forward both into renderSlicePrompt",
+    );
+  });
+
+  it("ExecuteTaskPromptOptions declares both knobs", () => {
+    assert.match(
+      autoPromptsSrc,
+      /interface ExecuteTaskPromptOptions\s*\{[^}]*sessionContextWindow\?[^}]*modelRegistry\?/s,
+      "ExecuteTaskPromptOptions must declare both fields",
+    );
+  });
+
+  it("buildExecuteTaskPrompt forwards opts.modelRegistry + opts.sessionContextWindow to resolveExecutorContextWindow", () => {
+    assert.match(
+      autoPromptsSrc,
+      /resolveExecutorContextWindow\(\s*opts\.modelRegistry\s*,\s*prefs\?\.preferences\s*,\s*opts\.sessionContextWindow/,
+      "buildExecuteTaskPrompt must forward both into resolveExecutorContextWindow",
+    );
+  });
+
+  it("buildReactiveExecutePrompt accepts opts and forwards to embedded buildExecuteTaskPrompt", () => {
+    assert.match(
+      autoPromptsSrc,
+      /export async function buildReactiveExecutePrompt\([\s\S]*?opts\?:\s*\{[^}]*sessionContextWindow\?[^}]*modelRegistry\?/,
+      "buildReactiveExecutePrompt must accept sessionContextWindow + modelRegistry",
+    );
+    assert.match(
+      autoPromptsSrc,
+      /sessionContextWindow:\s*opts\?\.sessionContextWindow,\s*modelRegistry:\s*opts\?\.modelRegistry/,
+      "buildReactiveExecutePrompt must forward both into the embedded buildExecuteTaskPrompt call",
+    );
+  });
+
+  it("DispatchContext declares both knobs", () => {
+    assert.match(
+      autoDispatchSrc,
+      /interface DispatchContext\s*\{[^}]*sessionContextWindow\?[^}]*modelRegistry\?/s,
+      "DispatchContext must declare both fields so dispatch rules can thread them",
+    );
+  });
+
+  it("DISPATCH_RULES destructure and forward both knobs at every prompt-builder call site", () => {
+    // Every plan-slice / execute-task / reactive-execute rule must destructure
+    // both names from its match context so new call sites can't silently drop them.
+    const matchLines = autoDispatchSrc.match(/match:\s*async\s*\(\{[^}]*sessionContextWindow[^}]*modelRegistry[^}]*\}/g) ?? [];
+    assert.ok(
+      matchLines.length >= 5,
+      `expected ≥5 dispatch rules destructuring both knobs, got ${matchLines.length}`,
+    );
+
+    const forwardCount = (autoDispatchSrc.match(/sessionContextWindow,\s*modelRegistry/g) ?? []).length;
+    assert.ok(
+      forwardCount >= 5,
+      `expected ≥5 forward sites of { sessionContextWindow, modelRegistry }, got ${forwardCount}`,
+    );
+  });
+
+  it("runDispatch populates both knobs from ctx.model / ctx.modelRegistry", () => {
+    assert.match(
+      phasesSrc,
+      /sessionContextWindow:\s*ctx\.model\?\.contextWindow/,
+      "runDispatch must populate sessionContextWindow from ctx.model?.contextWindow",
+    );
+    assert.match(
+      phasesSrc,
+      /modelRegistry:\s*ctx\.modelRegistry/,
+      "runDispatch must populate modelRegistry from ctx.modelRegistry",
+    );
+  });
+
+  it("dispatchDirectPhase forwards both knobs to buildPlanSlicePrompt and buildExecuteTaskPrompt", () => {
+    const passes = (autoDirectDispatchSrc.match(/sessionContextWindow:\s*ctx\.model\?\.contextWindow[\s\S]*?modelRegistry:\s*ctx\.modelRegistry/g) ?? []).length;
+    assert.ok(
+      passes >= 2,
+      `dispatchDirectPhase must forward the pair at both prompt-builder call sites (≥2), got ${passes}`,
+    );
   });
 });


### PR DESCRIPTION
## TL;DR

**What:** Thread `modelRegistry` and `sessionContextWindow` through the auto-mode dispatch chain so every prompt builder feeds `resolveExecutorContextWindow()` the real executor context window.
**Why:** Prompt-builder call sites passed `undefined` for both knobs and always fell back to the 200K `DEFAULT_CONTEXT_WINDOW`, even on 1M-token models — truncating budgets 5× too aggressively and capping planner task counts at 6 instead of 8.
**How:** Extend `DispatchContext` and `ExecuteTaskPromptOptions` with optional `sessionContextWindow` + `modelRegistry`, populate them once in `runDispatch` and `dispatchDirectPhase` from `ctx.model?.contextWindow` / `ctx.modelRegistry`, and forward through every prompt-builder call site. Pin the wiring with source-level regression tests.

## What

Seven files touched across the auto-mode dispatch/prompt chain:

- `src/resources/extensions/gsd/auto-dispatch.ts` — add `sessionContextWindow?` and `modelRegistry?: MinimalModelRegistry` to `DispatchContext`; destructure and forward both through the `refining`, `planning → plan-slice`, `executing → reactive-execute`, `executing → execute-task (recover)`, and `executing → execute-task` rules.
- `src/resources/extensions/gsd/auto-prompts.ts` — add optional `sessionContextWindow?` + `modelRegistry?` to `formatExecutorConstraints`, `renderSlicePrompt` options, `buildPlanSlicePrompt`, `buildRefineSlicePrompt`, `ExecuteTaskPromptOptions`, and `buildReactiveExecutePrompt`; forward into the two `resolveExecutorContextWindow` call sites.
- `src/resources/extensions/gsd/auto-direct-dispatch.ts` — pass `ctx.model?.contextWindow` + `ctx.modelRegistry` into `buildPlanSlicePrompt` and `buildExecuteTaskPrompt`.
- `src/resources/extensions/gsd/auto/phases.ts` — populate both fields in the `resolveDispatch` call in `runDispatch`.
- `src/resources/extensions/gsd/auto/loop-deps.ts` — swap the inline dispatch-context type in `LoopDeps.resolveDispatch` for the shared `DispatchContext` so the two stay in lockstep.
- `src/resources/extensions/gsd/tests/prompt-budget-enforcement.test.ts` — 9 source-level regression tests covering every call site (`formatExecutorConstraints`, `renderSlicePrompt`, `buildPlanSlicePrompt`, `ExecuteTaskPromptOptions`, `buildExecuteTaskPrompt`, `buildReactiveExecutePrompt`, `DispatchContext`, `DISPATCH_RULES`, `runDispatch`, `dispatchDirectPhase`).
- `CHANGELOG.md` — `[Unreleased]` entry.

## Why

`resolveExecutorContextWindow()` has a three-step resolution chain:

1. Look up the configured executor model (`preferences.models.execution`) in `modelRegistry`.
2. Fall back to the provided `sessionContextWindow`.
3. Fall back to `DEFAULT_CONTEXT_WINDOW` (200 000).

Before this change the only correct call site was `auto-timers.ts:277–279`, which passed both `ctx.modelRegistry` and `ctx.model?.contextWindow`. The two dispatch-chain sites in `auto-prompts.ts` (`formatExecutorConstraints` and the verification-budget block in `buildExecuteTaskPrompt`) passed `undefined` for both, so Step 3 always won. Effects on a 1M-token session:

- Task-count ceiling of 6 instead of 8 (wrong `taskCountRange.max`).
- Carry-forward truncation caps ≈5× too tight.
- Verification-budget strings quote the wrong window.
- Forensics-sized injections (~40KB) look like ~20% of the window instead of ~4%, amplifying truncation pressure elsewhere.

`auto-direct-dispatch.ts` (manual `/gsd dispatch`) and `buildReactiveExecutePrompt` (which embeds a full `buildExecuteTaskPrompt` per ready task) had the same gap.

Closes #4142

## How

**Full Fix C — thread both knobs through every call site.**

Alternatives considered:

- **Bump `DEFAULT_CONTEXT_WINDOW`** — a stopgap that hides the real bug and re-breaks for any model whose window differs from the new default.
- **Thread only `sessionContextWindow`** — better, but wrong when `preferences.models.execution` points to a non-session executor model; Step 1 must win in that case.
- **Thread both (chosen)** — matches what `auto-timers.ts` already does. Step 1 resolves the configured executor's real window; Step 2 catches the common case where no executor is explicitly configured; Step 3 becomes a true last-resort fallback.

Dispatch-chain wiring is one-way (down from `runDispatch` / `dispatchDirectPhase`), so the only surface area is a pair of optional fields on `DispatchContext` and `ExecuteTaskPromptOptions`, plus the pass-through destructuring. No public API changes; all new parameters are optional.

### Test strategy

The regression tests are source-level regex assertions (not a runtime harness). Rationale: the bug is a structural wiring gap, not a computation bug — runtime tests would need a full auto-mode fixture, and the thing we actually need to pin is that no future refactor silently drops the forwarding. The tests check:

- Every prompt-builder signature accepts both knobs.
- Every `resolveExecutorContextWindow` call forwards them.
- `DispatchContext` declares them.
- `DISPATCH_RULES` destructures them at ≥5 match sites.
- `runDispatch` and `dispatchDirectPhase` populate them from the live `ExtensionContext`.

## Notes for reviewers

- `#4148` (my earlier attempt, now superseded) and `#4169` both have merge conflicts and neither covers `buildReactiveExecutePrompt` or the current `renderSlicePrompt` shape. I'll close `#4148` once this is merged.
- `auto-timers.ts` is unchanged — it already resolves the window correctly.
- Worktree-verified: `npx tsc --noEmit -p tsconfig.extensions.json` exit 0; 108 tests green across `prompt-budget-enforcement`, `auto-prompts-fallback`, `context-budget`, `dispatch-missing-task-plans`, `execute-task-prompt-existing-artifact-guard`, `dispatch-guard`, `progressive-planning`, `subagent-model-dispatch`, `slice-context-injection`.

## Change type

- [ ] \`feat\` — New feature or capability
- [x] \`fix\` — Bug fix
- [ ] \`refactor\` — Code restructuring (no behavior change)
- [x] \`test\` — Adding or updating tests
- [ ] \`docs\` — Documentation only
- [ ] \`chore\` — Build, CI, or tooling changes

---

> This PR was generated with Claude (AI-assisted) per CONTRIBUTING.md disclosure requirement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed context window resolution to rely on session-specific values rather than a fixed fallback, improving prompt budget accuracy.

* **Improvements**
  * Threaded model/context information (session context window and model registry) throughout dispatch and prompt-building paths for more consistent budgeting and resource selection.

* **Tests**
  * Added regression tests to verify correct propagation of context window and model registry across prompt builders and dispatch logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->