### PR TITLE
fix(gsd): render save_gate_result correctly under MCP execution

### DIFF
--- a/src/resources/extensions/gsd/bootstrap/db-tools.ts
+++ b/src/resources/extensions/gsd/bootstrap/db-tools.ts
@@ -1070,6 +1070,19 @@ export function registerDbTools(pi: ExtensionAPI): void {
       text += theme.fg("dim", ` → ${args.verdict ?? ""}`);
       return new Text(text, 0, 0);
     },
+    /**
+     * Render the save_gate_result tool output for the TUI.
+     *
+     * Falls back to `content[0].text` when `details` is empty — which happens
+     * under MCP external tool execution because the MCP protocol doesn't carry
+     * non-standard return fields (Claude Code's stream adapter drops `details`).
+     * Without the fallback, the renderer prints "undefined: undefined" instead
+     * of the gate verdict. The same fallback applies to error rendering when
+     * `details.error` is missing.
+     *
+     * Tracked broader fix: plumb `details` through MCP via `structuredContent`
+     * (issue #4472).
+     */
     renderResult(result: any, _options: any, theme: any) {
       const d = result.details;
       if (result.isError || d?.error) {

--- a/src/resources/extensions/gsd/bootstrap/db-tools.ts
+++ b/src/resources/extensions/gsd/bootstrap/db-tools.ts
@@ -1073,10 +1073,19 @@ export function registerDbTools(pi: ExtensionAPI): void {
     renderResult(result: any, _options: any, theme: any) {
       const d = result.details;
       if (result.isError || d?.error) {
-        return new Text(theme.fg("error", `Error: ${d?.error ?? "unknown"}`), 0, 0);
+        const msg = d?.error ?? result.content?.[0]?.text ?? "unknown";
+        return new Text(theme.fg("error", `Error: ${msg}`), 0, 0);
       }
-      const color = d?.verdict === "flag" ? "warning" : "success";
-      return new Text(theme.fg(color, `${d?.gateId}: ${d?.verdict}`), 0, 0);
+      // Under MCP external tool execution, `details` is stripped to `{}`
+      // because MCP doesn't serialize non-standard return fields. Fall back
+      // to the human-readable summary from `content` instead of printing
+      // `undefined: undefined`.
+      if (!d?.gateId || !d?.verdict) {
+        const text = result.content?.[0]?.text ?? "Gate result saved";
+        return new Text(theme.fg("success", text), 0, 0);
+      }
+      const color = d.verdict === "flag" ? "warning" : "success";
+      return new Text(theme.fg(color, `${d.gateId}: ${d.verdict}`), 0, 0);
     },
   };
 

--- a/src/resources/extensions/gsd/tests/save-gate-result-render.test.ts
+++ b/src/resources/extensions/gsd/tests/save-gate-result-render.test.ts
@@ -1,13 +1,23 @@
-// Regression: save_gate_result renderResult must not print "undefined: undefined"
-// when `details` is stripped to `{}`. This happens under MCP external tool
-// execution — the MCP protocol doesn't carry non-standard return fields, so
-// Claude Code's adapter drops `details`. renderResult must fall back to the
-// human-readable summary from `content[0].text` instead.
+/**
+ * Regression test suite for save_gate_result renderResult under MCP execution.
+ *
+ * Verifies that renderResult does not print "undefined: undefined" when
+ * `details` is stripped to `{}`. This happens under MCP external tool
+ * execution because the MCP protocol doesn't carry non-standard return
+ * fields, so Claude Code's adapter drops `details`. renderResult must fall
+ * back to the human-readable summary from `content[0].text` instead.
+ *
+ * Cases covered:
+ *   - empty `details` falls back to content summary
+ *   - structured details render with proper field values
+ *   - error text surfaces when `details.error` is missing
+ */
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { registerDbTools } from '../bootstrap/db-tools.ts';
 
+/** Construct a minimal Pi-like object with a tool registry, for use in tests. */
 function makeMockPi() {
   const tools: any[] = [];
   return {
@@ -21,6 +31,7 @@ const fakeTheme = {
   bold: (text: string) => text,
 };
 
+/** Register db-tools against a mock Pi and return the gsd_save_gate_result tool. */
 function getSaveGateResultTool() {
   const pi = makeMockPi();
   registerDbTools(pi);

--- a/src/resources/extensions/gsd/tests/save-gate-result-render.test.ts
+++ b/src/resources/extensions/gsd/tests/save-gate-result-render.test.ts
@@ -1,0 +1,79 @@
+// Regression: save_gate_result renderResult must not print "undefined: undefined"
+// when `details` is stripped to `{}`. This happens under MCP external tool
+// execution — the MCP protocol doesn't carry non-standard return fields, so
+// Claude Code's adapter drops `details`. renderResult must fall back to the
+// human-readable summary from `content[0].text` instead.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { registerDbTools } from '../bootstrap/db-tools.ts';
+
+function makeMockPi() {
+  const tools: any[] = [];
+  return {
+    registerTool: (tool: any) => tools.push(tool),
+    tools,
+  } as any;
+}
+
+const fakeTheme = {
+  fg: (_color: string, text: string) => text,
+  bold: (text: string) => text,
+};
+
+function getSaveGateResultTool() {
+  const pi = makeMockPi();
+  registerDbTools(pi);
+  const tool = pi.tools.find((t: any) => t.name === 'gsd_save_gate_result');
+  assert.ok(tool, 'gsd_save_gate_result should be registered');
+  return tool;
+}
+
+test('save_gate_result renderResult falls back to content text when details is empty', () => {
+  const tool = getSaveGateResultTool();
+  const result = {
+    content: [{ type: 'text', text: 'Gate Q3 result saved: verdict=pass' }],
+    details: {},
+    isError: false,
+  };
+  const rendered = tool.renderResult(result, {}, fakeTheme);
+  const text = String(rendered.content ?? rendered.text ?? rendered);
+  assert.ok(
+    !text.includes('undefined'),
+    `rendered output must not contain "undefined" — got: ${text}`,
+  );
+  assert.ok(
+    text.includes('Gate Q3') || text.includes('verdict=pass'),
+    `rendered output should show the content summary — got: ${text}`,
+  );
+});
+
+test('save_gate_result renderResult uses structured details when present', () => {
+  const tool = getSaveGateResultTool();
+  const result = {
+    content: [{ type: 'text', text: 'Gate Q3 result saved: verdict=flag' }],
+    details: { operation: 'save_gate_result', gateId: 'Q3', verdict: 'flag' },
+    isError: false,
+  };
+  const rendered = tool.renderResult(result, {}, fakeTheme);
+  const text = String(rendered.content ?? rendered.text ?? rendered);
+  assert.ok(text.includes('Q3'), `expected Q3 in output — got: ${text}`);
+  assert.ok(text.includes('flag'), `expected flag in output — got: ${text}`);
+  assert.ok(!text.includes('undefined'), `got: ${text}`);
+});
+
+test('save_gate_result renderResult shows error from content when details.error is missing', () => {
+  const tool = getSaveGateResultTool();
+  const result = {
+    content: [{ type: 'text', text: 'Error: Invalid gateId "Z1"' }],
+    details: {},
+    isError: true,
+  };
+  const rendered = tool.renderResult(result, {}, fakeTheme);
+  const text = String(rendered.content ?? rendered.text ?? rendered);
+  assert.ok(
+    text.includes('Invalid gateId') || text.includes('Error'),
+    `expected error text surfaced — got: ${text}`,
+  );
+  assert.ok(!text.includes('undefined'), `got: ${text}`);
+});


### PR DESCRIPTION
## Linked issue

Closes #4472

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Fall back to `content[0].text` when `details` is empty so `save_gate_result` renders the gate verdict instead of `undefined: undefined` under MCP.
**Why:** MCP's stream adapter strips non-standard return fields, so the renderer's `d?.gateId` / `d?.verdict` reads come back undefined when gsd-pi runs as an MCP server driven by Claude Code.
**How:** In the `save_gate_result` renderResult, fall back to the human-readable summary in `content[0].text` when `details` is empty, and use that same content for error rendering when `details.error` is missing.

## What

Narrow patch to the `save_gate_result` tool's `renderResult` path. Adds a fallback that reads the tool result's `content[0].text` when `details` arrives empty (as it does through the MCP transport), plus the matching error-path fallback.

## Why

When gsd-pi runs as an MCP server driven by Claude Code, tool return `details` is stripped to `{}` by the stream adapter because MCP doesn't carry non-standard return fields through the protocol. The `save_gate_result` renderResult read `d?.gateId` / `d?.verdict` with no fallback, printing "undefined: undefined" in the TUI.

## How

Fall back to the human-readable summary in `content[0].text` when `details` is empty, and fall back to that same content for errors when `details.error` is missing.

This is a narrow patch for the visible regression. A broader fix to plumb `details` through MCP via `structuredContent` should follow (tracked in #4472).

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [x] Manual testing — reproduced `undefined: undefined` render under MCP execution pre-fix; verified correct verdict/rationale render post-fix with the same gsd_save_gate_result call.
- [ ] No tests needed — explained above

## AI disclosure

- [x] This PR includes AI-assisted code — drafted with Claude Code (Opus 4.7); tests (unit + tsc) run locally and pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved gate result rendering: errors now prefer detailed error info and fall back to human-readable text when details are missing; success rendering also gracefully falls back to summary text when structured details are absent.

* **Tests**
  * Added regression tests to verify rendering avoids "undefined" and correctly displays fallback and structured-detail cases across success and error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->