### PR TITLE
fix(mcp): rename details to structuredContent across MCP handlers

### DIFF
--- a/packages/mcp-server/src/workflow-tools.test.ts
+++ b/packages/mcp-server/src/workflow-tools.test.ts
@@ -1238,10 +1238,13 @@ describe("workflow MCP tools", () => {
       });
       assert.match((gateResult as any).content[0].text as string, /Gate Q3 result saved/);
       // #4472: executor `details` must be adapted to MCP `structuredContent`
-      // so it survives the protocol transport intact.
+      // so it survives the protocol transport intact. Asserting property
+      // *absence* rather than `=== undefined` so a future regression that
+      // explicitly sets `details: undefined` (rather than removing it) still
+      // fails this contract test.
       assert.equal(
-        (gateResult as any).details,
-        undefined,
+        Object.prototype.hasOwnProperty.call(gateResult, "details"),
+        false,
         "executor `details` field must be stripped from MCP tool result",
       );
       assert.deepEqual(

--- a/packages/mcp-server/src/workflow-tools.test.ts
+++ b/packages/mcp-server/src/workflow-tools.test.ts
@@ -1237,6 +1237,18 @@ describe("workflow MCP tools", () => {
         findings: "No new attack surface was introduced.",
       });
       assert.match((gateResult as any).content[0].text as string, /Gate Q3 result saved/);
+      // #4472: executor `details` must be adapted to MCP `structuredContent`
+      // so it survives the protocol transport intact.
+      assert.equal(
+        (gateResult as any).details,
+        undefined,
+        "executor `details` field must be stripped from MCP tool result",
+      );
+      assert.deepEqual(
+        (gateResult as any).structuredContent,
+        { operation: "save_gate_result", gateId: "Q3", verdict: "pass" },
+        "executor details must be forwarded on the MCP `structuredContent` channel",
+      );
       const gateRows = _getAdapter()!.prepare(
         "SELECT status, verdict, rationale FROM quality_gates WHERE milestone_id = ? AND slice_id = ? AND gate_id = ?",
       ).all("M006", "S06", "Q3") as Array<Record<string, unknown>>;

--- a/packages/mcp-server/src/workflow-tools.test.ts
+++ b/packages/mcp-server/src/workflow-tools.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { mkdirSync, rmSync, writeFileSync, existsSync } from "node:fs";
+import { mkdirSync, rmSync, writeFileSync, readFileSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { randomUUID } from "node:crypto";
@@ -284,6 +284,136 @@ describe("workflow MCP tools", () => {
       assert.equal(parsed.sliceCount, 1);
       assert.equal(parsed.slices[0].id, "S01");
     } finally {
+      cleanup(base);
+    }
+  });
+
+  it("#4477 gsd_task_complete forwards every schema field to the executor (regression for destructure-rebuild bug class)", async () => {
+    // Locks in the class-fix from PR #4477 review: handleTaskComplete previously
+    // destructured args into a hand-listed set of fields and rebuilt the call
+    // payload, which silently dropped ADR-011's `escalation` field (and any
+    // future schema field added without updating the rebuild). The fix passes
+    // `args` through directly, matching the spread pattern of sibling
+    // handlers. This test verifies the contract by injecting a mock executor
+    // module that captures the args, calling gsd_task_complete with an
+    // `escalation` payload, and asserting the field reached the executor.
+    const base = makeTmpBase();
+    const capturePath = join(base, "captured-args.json");
+    const mockModulePath = join(base, "mock-executors.mjs");
+    const prevModule = process.env.GSD_WORKFLOW_EXECUTORS_MODULE;
+    const prevCapture = process.env.GSD_TEST_TASK_COMPLETE_CAPTURE_PATH;
+    try {
+      // Mock module: implements the WorkflowToolExecutors shape.
+      // executeTaskComplete writes its received args to disk for assertion.
+      // Other executors are no-op stubs to satisfy isWorkflowToolExecutors.
+      const mockSource = `
+import { writeFileSync } from "node:fs";
+
+const noop = async () => ({ content: [{ type: "text", text: "noop" }] });
+
+export const SUPPORTED_SUMMARY_ARTIFACT_TYPES = ["SUMMARY", "UAT", "CONTEXT", "PLAN"];
+export const executeMilestoneStatus = noop;
+export const executePlanMilestone = noop;
+export const executePlanSlice = noop;
+export const executeReplanSlice = noop;
+export const executeSliceComplete = noop;
+export const executeCompleteMilestone = noop;
+export const executeValidateMilestone = noop;
+export const executeReassessRoadmap = noop;
+export const executeSaveGateResult = noop;
+export const executeSummarySave = noop;
+
+export const executeTaskComplete = async (params, projectDir) => {
+  const capturePath = process.env.GSD_TEST_TASK_COMPLETE_CAPTURE_PATH;
+  if (capturePath) {
+    writeFileSync(capturePath, JSON.stringify({ params, projectDir }, null, 2));
+  }
+  return {
+    content: [{ type: "text", text: "mock task complete" }],
+    details: { taskId: params.taskId },
+  };
+};
+`;
+      writeFileSync(mockModulePath, mockSource, "utf-8");
+      process.env.GSD_WORKFLOW_EXECUTORS_MODULE = mockModulePath;
+      process.env.GSD_TEST_TASK_COMPLETE_CAPTURE_PATH = capturePath;
+
+      // Fresh import bypasses the cached workflowToolExecutorsPromise so the
+      // mock module is actually loaded for this test.
+      const { registerWorkflowTools: freshRegisterWorkflowTools } = await import(
+        `./workflow-tools.ts?escalation-test=${randomUUID()}`
+      );
+      const server = makeMockServer();
+      freshRegisterWorkflowTools(server as any);
+      const taskTool = server.tools.find((t) => t.name === "gsd_task_complete");
+      assert.ok(taskTool, "task tool should be registered");
+
+      // Mirrors the ADR-011 escalation schema: question + 2-4 options
+      // (each with id/label/tradeoffs) + recommendation + rationale +
+      // continueWithDefault flag.
+      const escalationPayload = {
+        question: "Should the auth flow use OAuth or PAT?",
+        options: [
+          { id: "A", label: "OAuth", tradeoffs: "Best UX; requires more setup." },
+          { id: "B", label: "PAT", tradeoffs: "Simpler; weaker rotation story." },
+        ],
+        recommendation: "A",
+        recommendationRationale: "Initial requirement implied multi-user; OAuth fits better.",
+        continueWithDefault: true,
+      };
+
+      await taskTool!.handler({
+        projectDir: base,
+        taskId: "T01",
+        sliceId: "S01",
+        milestoneId: "M001",
+        oneLiner: "Completed task with escalation",
+        narrative: "Did the work but flagged an ambiguity",
+        verification: "npm test",
+        escalation: escalationPayload,
+        verificationEvidence: [
+          { command: "npm test", exitCode: 0, verdict: "pass", durationMs: 1234 },
+        ],
+      });
+
+      assert.ok(existsSync(capturePath), "mock executor should have written captured args to disk");
+      const captured = JSON.parse(readFileSync(capturePath, "utf-8"));
+
+      // The handler resolves projectDir via realpathSync (security/symlink check),
+      // so on macOS where /var symlinks to /private/var, the captured path will
+      // be the realpath form. Normalize both sides.
+      assert.equal(captured.projectDir, realpathSync(base), "projectDir should be passed as second arg");
+      assert.deepEqual(
+        captured.params.escalation,
+        escalationPayload,
+        "escalation payload must reach the executor verbatim — regression guard for the destructure-rebuild bug class (#4477 review)",
+      );
+      // Spot-check a couple of other fields to ensure the spread pattern
+      // doesn't accidentally exclude the rest while including escalation.
+      assert.equal(captured.params.taskId, "T01", "taskId must be forwarded");
+      assert.equal(captured.params.milestoneId, "M001", "milestoneId must be forwarded");
+      assert.deepEqual(
+        captured.params.verificationEvidence,
+        [{ command: "npm test", exitCode: 0, verdict: "pass", durationMs: 1234 }],
+        "verificationEvidence must be forwarded (existing field)",
+      );
+      // Ensure no projectDir leak into params (it should be the second arg only).
+      assert.equal(
+        captured.params.projectDir,
+        undefined,
+        "projectDir must NOT appear in params — it's stripped via the spread destructure",
+      );
+    } finally {
+      if (prevModule === undefined) {
+        delete process.env.GSD_WORKFLOW_EXECUTORS_MODULE;
+      } else {
+        process.env.GSD_WORKFLOW_EXECUTORS_MODULE = prevModule;
+      }
+      if (prevCapture === undefined) {
+        delete process.env.GSD_TEST_TASK_COMPLETE_CAPTURE_PATH;
+      } else {
+        process.env.GSD_TEST_TASK_COMPLETE_CAPTURE_PATH = prevCapture;
+      }
       cleanup(base);
     }
   });

--- a/packages/mcp-server/src/workflow-tools.ts
+++ b/packages/mcp-server/src/workflow-tools.ts
@@ -642,9 +642,24 @@ function adaptExecutorResult(result: unknown): unknown {
   const r = result as Record<string, unknown>;
   if (!("details" in r)) return result;
   const { details, ...rest } = r;
-  const isPlainObject =
-    details !== null && typeof details === "object" && !Array.isArray(details);
-  return isPlainObject ? { ...rest, structuredContent: details } : rest;
+  return isPlainObject(details) ? { ...rest, structuredContent: details } : rest;
+}
+
+/**
+ * Strict plain-object guard. True only for object literals and
+ * `Object.create(null)` — not for `Date`, `URL`, `Map`, `Set`, class instances,
+ * or arrays. Used to gate `structuredContent` forwarding so the MCP transport
+ * receives only true JSON objects (the protocol contract).
+ *
+ * Mirrored in `src/mcp-server.ts` for the agent-tool registry path's
+ * structured-content gate. Keep both copies in sync if the contract definition
+ * needs to evolve. See #4477 review.
+ */
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (value === null || typeof value !== "object") return false;
+  if (Array.isArray(value)) return false;
+  const proto = Object.getPrototypeOf(value);
+  return proto === null || proto === Object.prototype;
 }
 
 async function runSerializedWorkflowOperation<T>(fn: () => Promise<T>): Promise<T> {

--- a/packages/mcp-server/src/workflow-tools.ts
+++ b/packages/mcp-server/src/workflow-tools.ts
@@ -627,6 +627,15 @@ function getWorkflowOpTimeoutMs(env: NodeJS.ProcessEnv = process.env): number {
  * channel for structured tool payloads — preserves the data for clients that
  * render from it (e.g. the save_gate_result renderer that reads gateId /
  * verdict). See #4472.
+ *
+ * Discard policy for non-plain-object `details`: the `isPlainObject` guard
+ * accepts the canonical case (a record literal) and intentionally drops bare
+ * primitives (string, number, boolean), bare arrays, and class instances /
+ * Date objects. This is deliberate — MCP `structuredContent` is specified as
+ * a JSON object; non-object payloads can't round-trip cleanly. No current
+ * executor returns a non-object `details`, so this never fires in practice.
+ * Future executors needing to return a primitive should wrap it
+ * (`details: { value: 42 }`) rather than relying on the discard.
  */
 function adaptExecutorResult(result: unknown): unknown {
   if (!result || typeof result !== "object") return result;
@@ -730,41 +739,15 @@ async function handleTaskComplete(
   args: Omit<z.infer<typeof taskCompleteSchema>, "projectDir">,
 ): Promise<unknown> {
   await enforceWorkflowWriteGate("gsd_task_complete", projectDir, args.milestoneId);
-  const {
-    taskId,
-    sliceId,
-    milestoneId,
-    oneLiner,
-    narrative,
-    verification,
-    deviations,
-    knownIssues,
-    keyFiles,
-    keyDecisions,
-    blockerDiscovered,
-    verificationEvidence,
-  } = args;
   const { executeTaskComplete } = await getWorkflowToolExecutors();
+  // Pass `args` through directly rather than destructure-then-rebuild. The
+  // previous implementation re-listed each field, which silently dropped
+  // schema fields that weren't in the rebuild list (e.g., ADR-011's
+  // `escalation` payload). The destructure-then-rebuild pattern is the bug
+  // class; matching the spread shape used by sibling handlers (handleSliceComplete,
+  // handleReplanSlice) eliminates the recurrence risk by construction.
   return adaptExecutorResult(
-    await runSerializedWorkflowOperation(() =>
-      executeTaskComplete(
-        {
-          taskId,
-          sliceId,
-          milestoneId,
-          oneLiner,
-          narrative,
-          verification,
-          deviations,
-          knownIssues,
-          keyFiles,
-          keyDecisions,
-          blockerDiscovered,
-          verificationEvidence,
-        },
-        projectDir,
-      ),
-    ),
+    await runSerializedWorkflowOperation(() => executeTaskComplete(args, projectDir)),
   );
 }
 

--- a/packages/mcp-server/src/workflow-tools.ts
+++ b/packages/mcp-server/src/workflow-tools.ts
@@ -617,6 +617,27 @@ function getWorkflowOpTimeoutMs(env: NodeJS.ProcessEnv = process.env): number {
   return parsed; // 0 disables the timeout
 }
 
+/**
+ * Adapt an executor `ToolExecutionResult` ({ content, details?, isError? }) to
+ * the MCP `CallToolResult` shape ({ content, structuredContent?, isError? }).
+ *
+ * MCP transports (including stdio) only serialize fields declared in the
+ * protocol, so a non-standard `details` field is silently dropped over the
+ * wire. Mirroring it into `structuredContent` — the protocol's supported
+ * channel for structured tool payloads — preserves the data for clients that
+ * render from it (e.g. the save_gate_result renderer that reads gateId /
+ * verdict). See #4472.
+ */
+function adaptExecutorResult(result: unknown): unknown {
+  if (!result || typeof result !== "object") return result;
+  const r = result as Record<string, unknown>;
+  if (!("details" in r)) return result;
+  const { details, ...rest } = r;
+  const isPlainObject =
+    details !== null && typeof details === "object" && !Array.isArray(details);
+  return isPlainObject ? { ...rest, structuredContent: details } : rest;
+}
+
 async function runSerializedWorkflowOperation<T>(fn: () => Promise<T>): Promise<T> {
   // The shared DB adapter and workflow log base path are process-global, so
   // workflow MCP mutations must not overlap within a single server process.
@@ -724,23 +745,25 @@ async function handleTaskComplete(
     verificationEvidence,
   } = args;
   const { executeTaskComplete } = await getWorkflowToolExecutors();
-  return runSerializedWorkflowOperation(() =>
-    executeTaskComplete(
-      {
-        taskId,
-        sliceId,
-        milestoneId,
-        oneLiner,
-        narrative,
-        verification,
-        deviations,
-        knownIssues,
-        keyFiles,
-        keyDecisions,
-        blockerDiscovered,
-        verificationEvidence,
-      },
-      projectDir,
+  return adaptExecutorResult(
+    await runSerializedWorkflowOperation(() =>
+      executeTaskComplete(
+        {
+          taskId,
+          sliceId,
+          milestoneId,
+          oneLiner,
+          narrative,
+          verification,
+          deviations,
+          knownIssues,
+          keyFiles,
+          keyDecisions,
+          blockerDiscovered,
+          verificationEvidence,
+        },
+        projectDir,
+      ),
     ),
   );
 }
@@ -752,7 +775,9 @@ async function handleSliceComplete(
   await enforceWorkflowWriteGate("gsd_slice_complete", projectDir, args.milestoneId);
   const { executeSliceComplete } = await getWorkflowToolExecutors();
   const { projectDir: _projectDir, ...params } = args;
-  return runSerializedWorkflowOperation(() => executeSliceComplete(params, projectDir));
+  return adaptExecutorResult(
+    await runSerializedWorkflowOperation(() => executeSliceComplete(params, projectDir)),
+  );
 }
 
 async function handleReplanSlice(
@@ -762,7 +787,9 @@ async function handleReplanSlice(
   await enforceWorkflowWriteGate("gsd_replan_slice", projectDir, args.milestoneId);
   const { executeReplanSlice } = await getWorkflowToolExecutors();
   const { projectDir: _projectDir, ...params } = args;
-  return runSerializedWorkflowOperation(() => executeReplanSlice(params, projectDir));
+  return adaptExecutorResult(
+    await runSerializedWorkflowOperation(() => executeReplanSlice(params, projectDir)),
+  );
 }
 
 async function handleCompleteMilestone(
@@ -772,7 +799,9 @@ async function handleCompleteMilestone(
   await enforceWorkflowWriteGate("gsd_complete_milestone", projectDir, args.milestoneId);
   const { executeCompleteMilestone } = await getWorkflowToolExecutors();
   const { projectDir: _projectDir, ...params } = args;
-  return runSerializedWorkflowOperation(() => executeCompleteMilestone(params, projectDir));
+  return adaptExecutorResult(
+    await runSerializedWorkflowOperation(() => executeCompleteMilestone(params, projectDir)),
+  );
 }
 
 async function handleValidateMilestone(
@@ -782,7 +811,9 @@ async function handleValidateMilestone(
   await enforceWorkflowWriteGate("gsd_validate_milestone", projectDir, args.milestoneId);
   const { executeValidateMilestone } = await getWorkflowToolExecutors();
   const { projectDir: _projectDir, ...params } = args;
-  return runSerializedWorkflowOperation(() => executeValidateMilestone(params, projectDir));
+  return adaptExecutorResult(
+    await runSerializedWorkflowOperation(() => executeValidateMilestone(params, projectDir)),
+  );
 }
 
 async function handleReassessRoadmap(
@@ -792,7 +823,9 @@ async function handleReassessRoadmap(
   await enforceWorkflowWriteGate("gsd_reassess_roadmap", projectDir, args.milestoneId);
   const { executeReassessRoadmap } = await getWorkflowToolExecutors();
   const { projectDir: _projectDir, ...params } = args;
-  return runSerializedWorkflowOperation(() => executeReassessRoadmap(params, projectDir));
+  return adaptExecutorResult(
+    await runSerializedWorkflowOperation(() => executeReassessRoadmap(params, projectDir)),
+  );
 }
 
 async function handleSaveGateResult(
@@ -802,7 +835,9 @@ async function handleSaveGateResult(
   await enforceWorkflowWriteGate("gsd_save_gate_result", projectDir, args.milestoneId);
   const { executeSaveGateResult } = await getWorkflowToolExecutors();
   const { projectDir: _projectDir, ...params } = args;
-  return runSerializedWorkflowOperation(() => executeSaveGateResult(params, projectDir));
+  return adaptExecutorResult(
+    await runSerializedWorkflowOperation(() => executeSaveGateResult(params, projectDir)),
+  );
 }
 
 async function ensureMilestoneDbRow(milestoneId: string): Promise<void> {
@@ -1384,7 +1419,9 @@ export function registerWorkflowTools(server: McpToolServer): void {
       const { projectDir, ...params } = parsed;
       await enforceWorkflowWriteGate("gsd_plan_milestone", projectDir, params.milestoneId);
       const { executePlanMilestone } = await getWorkflowToolExecutors();
-      return runSerializedWorkflowOperation(() => executePlanMilestone(params, projectDir));
+      return adaptExecutorResult(
+        await runSerializedWorkflowOperation(() => executePlanMilestone(params, projectDir)),
+      );
     },
   );
 
@@ -1397,7 +1434,9 @@ export function registerWorkflowTools(server: McpToolServer): void {
       const { projectDir, ...params } = parsed;
       await enforceWorkflowWriteGate("gsd_plan_slice", projectDir, params.milestoneId);
       const { executePlanSlice } = await getWorkflowToolExecutors();
-      return runSerializedWorkflowOperation(() => executePlanSlice(params, projectDir));
+      return adaptExecutorResult(
+        await runSerializedWorkflowOperation(() => executePlanSlice(params, projectDir)),
+      );
     },
   );
 
@@ -1598,8 +1637,10 @@ export function registerWorkflowTools(server: McpToolServer): void {
           `artifact_type must be one of: ${supportedArtifactTypes.join(", ")}`,
         );
       }
-      return runSerializedWorkflowOperation(() =>
-        executors.executeSummarySave({ milestone_id, slice_id, task_id, artifact_type, content }, projectDir),
+      return adaptExecutorResult(
+        await runSerializedWorkflowOperation(() =>
+          executors.executeSummarySave({ milestone_id, slice_id, task_id, artifact_type, content }, projectDir),
+        ),
       );
     },
   );
@@ -1636,7 +1677,9 @@ export function registerWorkflowTools(server: McpToolServer): void {
       // during pending-gate or queue-mode states.
       const { projectDir, milestoneId } = parseWorkflowArgs(milestoneStatusSchema, args);
       const { executeMilestoneStatus } = await getWorkflowToolExecutors();
-      return runSerializedWorkflowOperation(() => executeMilestoneStatus({ milestoneId }, projectDir));
+      return adaptExecutorResult(
+        await runSerializedWorkflowOperation(() => executeMilestoneStatus({ milestoneId }, projectDir)),
+      );
     },
   );
 

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -1,4 +1,21 @@
 /**
+ * Strict plain-object guard. True only for object literals and
+ * `Object.create(null)` — not for `Date`, `URL`, `Map`, `Set`, class instances,
+ * or arrays. Used to gate `structuredContent` forwarding so the MCP transport
+ * receives only true JSON objects (the protocol contract). See #4477 review.
+ *
+ * Mirrored in `packages/mcp-server/src/workflow-tools.ts` for the
+ * `adaptExecutorResult` adapter on the workflow path. Keep both copies in
+ * sync if the contract definition needs to evolve.
+ */
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (value === null || typeof value !== 'object') return false
+  if (Array.isArray(value)) return false
+  const proto = Object.getPrototypeOf(value)
+  return proto === null || proto === Object.prototype
+}
+
+/**
  * Minimal tool interface matching GSD's AgentTool shape.
  * Avoids a direct dependency on @gsd/pi-agent-core from this compiled module.
  *
@@ -133,12 +150,14 @@ export async function startMcpServer(options: {
       // channel. The protocol drops non-standard fields on the wire, so tools
       // that populate `details` for client-side renderers (e.g. save_gate_result)
       // would otherwise arrive empty on the other side. See #4472.
+      //
+      // Use a strict plain-object guard (prototype-chain check) rather than just
+      // `typeof === 'object' && !Array.isArray()` — Date, URL, Map, Set, and
+      // class instances would otherwise pass through and end up as
+      // `structuredContent`, violating the protocol's JSON-object contract.
+      // The mirror discipline applies in `workflow-tools.ts adaptExecutorResult`.
       const base: Record<string, unknown> = { content }
-      if (
-        result.details !== undefined
-        && result.details !== null
-        && !Array.isArray(result.details)
-      ) {
+      if (isPlainObject(result.details)) {
         base.structuredContent = result.details
       }
       if (result.isError === true) base.isError = true

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -121,7 +121,23 @@ export async function startMcpServer(options: {
         // by stringifying into a text block so clients see the payload.
         return { type: 'text' as const, text: JSON.stringify(block) }
       })
-      return { content }
+
+      // Forward a tool's runtime `details` field to MCP's `structuredContent`
+      // channel. The protocol drops non-standard fields on the wire, so tools
+      // that populate `details` for client-side renderers (e.g. save_gate_result)
+      // would otherwise arrive empty on the other side. See #4472.
+      const runtimeDetails = (result as { details?: unknown }).details
+      const runtimeIsError = (result as { isError?: unknown }).isError === true
+      const base: Record<string, unknown> = { content }
+      if (
+        runtimeDetails !== null
+        && typeof runtimeDetails === 'object'
+        && !Array.isArray(runtimeDetails)
+      ) {
+        base.structuredContent = runtimeDetails
+      }
+      if (runtimeIsError) base.isError = true
+      return base
     } catch (err: unknown) {
       // AbortError from a cancelled tool surfaces as a normal error — MCP
       // clients interpret `isError: true` as a failed call, which is the

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -1,6 +1,11 @@
 /**
  * Minimal tool interface matching GSD's AgentTool shape.
  * Avoids a direct dependency on @gsd/pi-agent-core from this compiled module.
+ *
+ * `details` and `isError` are optional fields that runtime tool implementations
+ * may populate. The MCP transport drops non-standard fields, so the wrapper at
+ * the call site mirrors `details` into `structuredContent` and forwards
+ * `isError` directly. See #4472.
  */
 export interface McpToolDef {
   name: string
@@ -13,6 +18,8 @@ export interface McpToolDef {
     onUpdate?: unknown,
   ): Promise<{
     content: Array<{ type: string; text?: string; data?: string; mimeType?: string }>
+    details?: Record<string, unknown>
+    isError?: boolean
   }>
 }
 
@@ -126,17 +133,15 @@ export async function startMcpServer(options: {
       // channel. The protocol drops non-standard fields on the wire, so tools
       // that populate `details` for client-side renderers (e.g. save_gate_result)
       // would otherwise arrive empty on the other side. See #4472.
-      const runtimeDetails = (result as { details?: unknown }).details
-      const runtimeIsError = (result as { isError?: unknown }).isError === true
       const base: Record<string, unknown> = { content }
       if (
-        runtimeDetails !== null
-        && typeof runtimeDetails === 'object'
-        && !Array.isArray(runtimeDetails)
+        result.details !== undefined
+        && result.details !== null
+        && !Array.isArray(result.details)
       ) {
-        base.structuredContent = runtimeDetails
+        base.structuredContent = result.details
       }
-      if (runtimeIsError) base.isError = true
+      if (result.isError === true) base.isError = true
       return base
     } catch (err: unknown) {
       // AbortError from a cancelled tool surfaces as a normal error — MCP

--- a/src/resources/extensions/claude-code-cli/stream-adapter.ts
+++ b/src/resources/extensions/claude-code-cli/stream-adapter.ts
@@ -905,6 +905,31 @@ function extractStructuredDetailsFromBlock(block: Record<string, unknown>): Reco
 	return undefined;
 }
 
+/**
+ * True for items that are MCP `structuredContent` pseudo-blocks living inside
+ * a tool-result `content[]` array. These blocks carry the structured payload
+ * (extracted separately by `extractStructuredDetailsFromBlock`) and must NOT
+ * leak into the visible content rendered to the user — otherwise the renderer
+ * stringifies the JSON pseudo-block and shows it next to the actual tool
+ * output. See PR #4477 review (CodeRabbit, post-fix-round).
+ */
+function isStructuredContentPseudoBlock(item: unknown): boolean {
+	if (!item || typeof item !== "object") return false;
+	const type = (item as Record<string, unknown>).type;
+	return type === "structuredContent" || type === "structured_content";
+}
+
+/**
+ * Strip `structuredContent` pseudo-blocks from a tool-result content array
+ * before normalization. The structured payload is extracted via the sibling
+ * `structuredContent` field (or a dedicated extractor pass on the raw block);
+ * the visible content path must not include the pseudo-block itself.
+ */
+function stripStructuredContentPseudoBlocks(content: unknown): unknown {
+	if (!Array.isArray(content)) return content;
+	return content.filter((item) => !isStructuredContentPseudoBlock(item));
+}
+
 /** Extract tool result payloads from an SDK synthetic user message, keyed by tool-use ID. */
 export function extractToolResultsFromSdkUserMessage(message: SDKUserMessage): Array<{
 	toolUseId: string;
@@ -928,7 +953,7 @@ export function extractToolResultsFromSdkUserMessage(message: SDKUserMessage): A
 		extracted.push({
 			toolUseId,
 			result: {
-				content: normalizeToolResultContent(block.content),
+				content: normalizeToolResultContent(stripStructuredContentPseudoBlocks(block.content)),
 				details: extractStructuredDetailsFromBlock(block),
 				isError: block.is_error === true,
 			},
@@ -944,7 +969,7 @@ export function extractToolResultsFromSdkUserMessage(message: SDKUserMessage): A
 				extracted.push({
 					toolUseId,
 					result: {
-						content: normalizeToolResultContent(toolResult.content),
+						content: normalizeToolResultContent(stripStructuredContentPseudoBlocks(toolResult.content)),
 						details: extractStructuredDetailsFromBlock(toolResult),
 						isError: toolResult.is_error === true,
 					},

--- a/src/resources/extensions/claude-code-cli/stream-adapter.ts
+++ b/src/resources/extensions/claude-code-cli/stream-adapter.ts
@@ -867,6 +867,39 @@ function normalizeToolResultContent(content: unknown): ExternalToolResultContent
 	return blocks.length > 0 ? blocks : [{ type: "text", text: "" }];
 }
 
+/**
+ * Extract a `details` payload from an MCP tool-result block.
+ *
+ * MCP's `CallToolResult` carries structured data in `structuredContent` — the
+ * protocol's supported channel for non-text payloads. Claude Code's synthetic
+ * user message may surface that field in one of two shapes depending on SDK
+ * version: as a sibling on the `mcp_tool_result` block itself, or as a
+ * dedicated content sub-block with `type: "structuredContent"`. Snake-case
+ * (`structured_content`) is accepted defensively in case a transport hop
+ * rewrites casing. All other shapes fall back to an empty object so callers
+ * can rely on `details` being present.
+ */
+function extractStructuredDetailsFromBlock(block: Record<string, unknown>): Record<string, unknown> {
+	const sibling = block.structuredContent ?? (block as Record<string, unknown>).structured_content;
+	if (sibling && typeof sibling === "object" && !Array.isArray(sibling)) {
+		return sibling as Record<string, unknown>;
+	}
+
+	if (Array.isArray(block.content)) {
+		for (const item of block.content) {
+			if (!item || typeof item !== "object") continue;
+			const sub = item as Record<string, unknown>;
+			if (sub.type !== "structuredContent" && sub.type !== "structured_content") continue;
+			const payload = sub.structuredContent ?? sub.structured_content ?? sub.data ?? sub.value;
+			if (payload && typeof payload === "object" && !Array.isArray(payload)) {
+				return payload as Record<string, unknown>;
+			}
+		}
+	}
+
+	return {};
+}
+
 /** Extract tool result payloads from an SDK synthetic user message, keyed by tool-use ID. */
 export function extractToolResultsFromSdkUserMessage(message: SDKUserMessage): Array<{
 	toolUseId: string;
@@ -891,7 +924,7 @@ export function extractToolResultsFromSdkUserMessage(message: SDKUserMessage): A
 			toolUseId,
 			result: {
 				content: normalizeToolResultContent(block.content),
-				details: {},
+				details: extractStructuredDetailsFromBlock(block),
 				isError: block.is_error === true,
 			},
 		});
@@ -907,7 +940,7 @@ export function extractToolResultsFromSdkUserMessage(message: SDKUserMessage): A
 					toolUseId,
 					result: {
 						content: normalizeToolResultContent(toolResult.content),
-						details: {},
+						details: extractStructuredDetailsFromBlock(toolResult),
 						isError: toolResult.is_error === true,
 					},
 				});

--- a/src/resources/extensions/claude-code-cli/stream-adapter.ts
+++ b/src/resources/extensions/claude-code-cli/stream-adapter.ts
@@ -879,7 +879,7 @@ function normalizeToolResultContent(content: unknown): ExternalToolResultContent
  * rewrites casing. All other shapes fall back to an empty object so callers
  * can rely on `details` being present.
  */
-function extractStructuredDetailsFromBlock(block: Record<string, unknown>): Record<string, unknown> {
+function extractStructuredDetailsFromBlock(block: Record<string, unknown>): Record<string, unknown> | undefined {
 	const sibling = block.structuredContent ?? (block as Record<string, unknown>).structured_content;
 	if (sibling && typeof sibling === "object" && !Array.isArray(sibling)) {
 		return sibling as Record<string, unknown>;
@@ -897,7 +897,12 @@ function extractStructuredDetailsFromBlock(block: Record<string, unknown>): Reco
 		}
 	}
 
-	return {};
+	// Return undefined (not {}) when no structured payload is present, matching
+	// the pre-#4477 contract where `details` was nullable. An empty-object
+	// sentinel is truthy and breaks downstream consumers that gate on
+	// `if (details)`. `undefined` matches the type of the field these results
+	// flow into (`Record<string, unknown> | undefined`).
+	return undefined;
 }
 
 /** Extract tool result payloads from an SDK synthetic user message, keyed by tool-use ID. */

--- a/src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts
+++ b/src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts
@@ -372,7 +372,10 @@ describe("stream-adapter — Claude Code external tool results", () => {
 				toolUseId: "tool-bash-1",
 				result: {
 					content: [{ type: "text", text: "line 1\nline 2" }],
-					details: {},
+					// extractStructuredDetailsFromBlock returns undefined when no
+					// structured payload exists, restoring the pre-#4477 nullable
+					// contract (#4477 review feedback).
+					details: undefined,
 					isError: false,
 				},
 			},
@@ -468,7 +471,9 @@ describe("stream-adapter — Claude Code external tool results", () => {
 				toolUseId: "tool-read-1",
 				result: {
 					content: [{ type: "text", text: "file contents" }],
-					details: {},
+					// undefined (not {}) per the restored nullable contract — see
+					// the analogous assertion in the tool_result test above.
+					details: undefined,
 					isError: true,
 				},
 			},

--- a/src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts
+++ b/src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts
@@ -379,6 +379,76 @@ describe("stream-adapter — Claude Code external tool results", () => {
 		]);
 	});
 
+	test("extractToolResultsFromSdkUserMessage reads structuredContent as a sibling field (#4472)", () => {
+		const message: SDKUserMessage = {
+			type: "user",
+			session_id: "sess-1",
+			parent_tool_use_id: "tool-mcp-1",
+			message: {
+				role: "user",
+				content: [
+					{
+						type: "mcp_tool_result",
+						tool_use_id: "tool-mcp-1",
+						content: [{ type: "text", text: "Gate Q3 result saved: verdict=pass" }],
+						is_error: false,
+						structuredContent: { gateId: "Q3", verdict: "pass" },
+					} as unknown as Record<string, unknown>,
+				],
+			},
+		};
+
+		const results = extractToolResultsFromSdkUserMessage(message);
+		assert.deepEqual(results[0].result.details, { gateId: "Q3", verdict: "pass" });
+	});
+
+	test("extractToolResultsFromSdkUserMessage reads structuredContent from a content sub-block (#4472)", () => {
+		const message: SDKUserMessage = {
+			type: "user",
+			session_id: "sess-1",
+			parent_tool_use_id: "tool-mcp-2",
+			message: {
+				role: "user",
+				content: [
+					{
+						type: "mcp_tool_result",
+						tool_use_id: "tool-mcp-2",
+						content: [
+							{ type: "text", text: "Gate Q4 result saved: verdict=flag" },
+							{ type: "structuredContent", structuredContent: { gateId: "Q4", verdict: "flag" } },
+						],
+						is_error: false,
+					} as unknown as Record<string, unknown>,
+				],
+			},
+		};
+
+		const results = extractToolResultsFromSdkUserMessage(message);
+		assert.deepEqual(results[0].result.details, { gateId: "Q4", verdict: "flag" });
+	});
+
+	test("extractToolResultsFromSdkUserMessage accepts snake_case structured_content defensively (#4472)", () => {
+		const message: SDKUserMessage = {
+			type: "user",
+			session_id: "sess-1",
+			parent_tool_use_id: "tool-mcp-3",
+			message: {
+				role: "user",
+				content: [
+					{
+						type: "mcp_tool_result",
+						tool_use_id: "tool-mcp-3",
+						content: [{ type: "text", text: "ok" }],
+						structured_content: { operation: "save_gate_result" },
+					} as unknown as Record<string, unknown>,
+				],
+			},
+		};
+
+		const results = extractToolResultsFromSdkUserMessage(message);
+		assert.deepEqual(results[0].result.details, { operation: "save_gate_result" });
+	});
+
 	test("extractToolResultsFromSdkUserMessage falls back to tool_use_result", () => {
 		const message: SDKUserMessage = {
 			type: "user",

--- a/src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts
+++ b/src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts
@@ -430,6 +430,66 @@ describe("stream-adapter — Claude Code external tool results", () => {
 		assert.deepEqual(results[0].result.details, { gateId: "Q4", verdict: "flag" });
 	});
 
+	test("#4477 extractToolResultsFromSdkUserMessage does NOT leak structuredContent pseudo-blocks into visible content", () => {
+		// Regression: when a content sub-block carries `type: "structuredContent"`,
+		// it carries the structured payload (extracted separately into `details`)
+		// and must NOT appear in the visible `content` array — otherwise the
+		// renderer stringifies the JSON pseudo-block and shows it next to the
+		// actual tool output. See PR #4477 review (CodeRabbit, post-fix-round).
+		const message: SDKUserMessage = {
+			type: "user",
+			session_id: "sess-1",
+			parent_tool_use_id: "tool-mcp-strip",
+			message: {
+				role: "user",
+				content: [
+					{
+						type: "mcp_tool_result",
+						tool_use_id: "tool-mcp-strip",
+						content: [
+							{ type: "text", text: "Gate Q5 result saved: verdict=pass" },
+							{ type: "structuredContent", structuredContent: { gateId: "Q5", verdict: "pass" } },
+							{ type: "text", text: "second visible line" },
+							// snake_case variant — also a pseudo-block; also must be stripped
+							{ type: "structured_content", structured_content: { extra: "data" } },
+						],
+						is_error: false,
+					} as unknown as Record<string, unknown>,
+				],
+			},
+		};
+
+		const results = extractToolResultsFromSdkUserMessage(message);
+		assert.equal(results.length, 1, "should extract one result");
+		const result = results[0].result;
+
+		// The structured payload IS extracted to `details`.
+		assert.deepEqual(result.details, { gateId: "Q5", verdict: "pass" });
+
+		// The visible content has the two text blocks but NEITHER pseudo-block.
+		const visibleTexts = result.content.map((c: any) => c.text);
+		assert.deepEqual(
+			visibleTexts,
+			["Gate Q5 result saved: verdict=pass", "second visible line"],
+			"visible content must include only the two text blocks; both structuredContent variants must be stripped",
+		);
+
+		// Belt-and-suspenders: assert no rendered text shows the JSON serialization
+		// of a pseudo-block. We don't check for bare keys like "gateId" or "verdict"
+		// because those are legitimate words in the gate-result message text. The
+		// regression signature would be a JSON-shaped substring that could only
+		// appear via stringification.
+		const allText = visibleTexts.join("\n");
+		assert.ok(
+			!allText.includes('"structuredContent"'),
+			"rendered content must not include the pseudo-block type marker as JSON text",
+		);
+		assert.ok(
+			!allText.includes('"structured_content"'),
+			"rendered content must not include the snake_case pseudo-block type marker as JSON text",
+		);
+	});
+
 	test("extractToolResultsFromSdkUserMessage accepts snake_case structured_content defensively (#4472)", () => {
 		const message: SDKUserMessage = {
 			type: "user",

--- a/src/resources/extensions/gsd/bootstrap/db-tools.ts
+++ b/src/resources/extensions/gsd/bootstrap/db-tools.ts
@@ -35,6 +35,19 @@ function registerAlias(pi: ExtensionAPI, toolDef: any, aliasName: string, canoni
   });
 }
 
+/**
+ * Read a tool result's structured payload, accommodating MCP's `details` →
+ * `structuredContent` rename (#4472, #4477). In-process executions still
+ * deliver the payload on `result.details`; MCP-routed executions deliver it
+ * on `result.structuredContent` (post `adaptExecutorResult` transform). All
+ * `renderResult` callbacks in this file route through this helper so a future
+ * field rename only needs to be applied in one place.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- result shape varies by tool
+function readDetails(result: any): any {
+  return result?.details ?? result?.structuredContent;
+}
+
 export function registerDbTools(pi: ExtensionAPI): void {
   // ─── gsd_decision_save (formerly gsd_save_decision) ─────────────────────
 
@@ -110,7 +123,7 @@ export function registerDbTools(pi: ExtensionAPI): void {
       return new Text(text, 0, 0);
     },
     renderResult(result: any, _options: any, theme: any) {
-      const d = result.details;
+      const d = readDetails(result);
       if (result.isError || d?.error) {
         return new Text(theme.fg("error", `Error: ${d?.error ?? "unknown"}`), 0, 0);
       }
@@ -188,7 +201,7 @@ export function registerDbTools(pi: ExtensionAPI): void {
       return new Text(text, 0, 0);
     },
     renderResult(result: any, _options: any, theme: any) {
-      const d = result.details;
+      const d = readDetails(result);
       if (result.isError || d?.error) {
         return new Text(theme.fg("error", `Error: ${d?.error ?? "unknown"}`), 0, 0);
       }
@@ -273,7 +286,7 @@ export function registerDbTools(pi: ExtensionAPI): void {
       return new Text(text, 0, 0);
     },
     renderResult(result: any, _options: any, theme: any) {
-      const d = result.details;
+      const d = readDetails(result);
       if (result.isError || d?.error) {
         return new Text(theme.fg("error", `Error: ${d?.error ?? "unknown"}`), 0, 0);
       }
@@ -322,7 +335,7 @@ export function registerDbTools(pi: ExtensionAPI): void {
       return new Text(text, 0, 0);
     },
     renderResult(result: any, _options: any, theme: any) {
-      const d = result.details;
+      const d = readDetails(result);
       if (result.isError || d?.error) {
         return new Text(theme.fg("error", `Error: ${d?.error ?? "unknown"}`), 0, 0);
       }
@@ -406,7 +419,7 @@ export function registerDbTools(pi: ExtensionAPI): void {
       return new Text(theme.fg("toolTitle", theme.bold("milestone_generate_id")), 0, 0);
     },
     renderResult(result: any, _options: any, theme: any) {
-      const d = result.details;
+      const d = readDetails(result);
       if (result.isError || d?.error) {
         return new Text(theme.fg("error", `Error: ${d?.error ?? "unknown"}`), 0, 0);
       }
@@ -1087,7 +1100,7 @@ export function registerDbTools(pi: ExtensionAPI): void {
      * `Error: Error: ...`.
      */
     renderResult(result: any, _options: any, theme: any) {
-      const d = result.details;
+      const d = readDetails(result);
       if (result.isError || d?.error) {
         const rawMsg = d?.error ?? result.content?.[0]?.text ?? "unknown";
         const msg = rawMsg.replace(/^\s*Error:\s*/i, "");

--- a/src/resources/extensions/gsd/bootstrap/db-tools.ts
+++ b/src/resources/extensions/gsd/bootstrap/db-tools.ts
@@ -1074,13 +1074,31 @@ export function registerDbTools(pi: ExtensionAPI): void {
       text += theme.fg("dim", ` → ${args.verdict ?? ""}`);
       return new Text(text, 0, 0);
     },
+    /**
+     * Render the save_gate_result tool output for the TUI.
+     *
+     * Prefers structured fields, but falls back to `content[0].text` when the
+     * structured payload is empty. Defensive: the structural fix on this
+     * branch plumbs `details` through MCP via `structuredContent`, but older
+     * hosts, a future handler that forgets `structuredContent`, or any drop
+     * of non-standard return fields would otherwise render as
+     * "undefined: undefined". Same fallback applies to error rendering, and
+     * we strip a leading `Error:` from the fallback text to avoid producing
+     * `Error: Error: ...`.
+     */
     renderResult(result: any, _options: any, theme: any) {
       const d = result.details;
       if (result.isError || d?.error) {
-        return new Text(theme.fg("error", `Error: ${d?.error ?? "unknown"}`), 0, 0);
+        const rawMsg = d?.error ?? result.content?.[0]?.text ?? "unknown";
+        const msg = rawMsg.replace(/^\s*Error:\s*/i, "");
+        return new Text(theme.fg("error", `Error: ${msg}`), 0, 0);
       }
-      const color = d?.verdict === "flag" ? "warning" : "success";
-      return new Text(theme.fg(color, `${d?.gateId}: ${d?.verdict}`), 0, 0);
+      if (!d?.gateId || !d?.verdict) {
+        const text = result.content?.[0]?.text ?? "Gate result saved";
+        return new Text(theme.fg("success", text), 0, 0);
+      }
+      const color = d.verdict === "flag" ? "warning" : "success";
+      return new Text(theme.fg(color, `${d.gateId}: ${d.verdict}`), 0, 0);
     },
   };
 

--- a/src/resources/extensions/gsd/tests/save-gate-result-render.test.ts
+++ b/src/resources/extensions/gsd/tests/save-gate-result-render.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Regression test suite for save_gate_result renderResult.
+ *
+ * Verifies that renderResult does not print "undefined: undefined" when
+ * `details` is empty, and that the error fallback does not produce a
+ * duplicated `Error: Error:` prefix when `content[0].text` already starts
+ * with `Error:`.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { registerDbTools } from '../bootstrap/db-tools.ts';
+
+function makeMockPi() {
+  const tools: any[] = [];
+  return {
+    registerTool: (tool: any) => tools.push(tool),
+    tools,
+  } as any;
+}
+
+const fakeTheme = {
+  fg: (_color: string, text: string) => text,
+  bold: (text: string) => text,
+};
+
+function getSaveGateResultTool() {
+  const pi = makeMockPi();
+  registerDbTools(pi);
+  const tool = pi.tools.find((t: any) => t.name === 'gsd_save_gate_result');
+  assert.ok(tool, 'gsd_save_gate_result should be registered');
+  return tool;
+}
+
+test('save_gate_result renderResult falls back to content text when details is empty', () => {
+  const tool = getSaveGateResultTool();
+  const result = {
+    content: [{ type: 'text', text: 'Gate Q3 result saved: verdict=pass' }],
+    details: {},
+    isError: false,
+  };
+  const rendered = tool.renderResult(result, {}, fakeTheme);
+  const text = String(rendered.content ?? rendered.text ?? rendered);
+  assert.ok(!text.includes('undefined'), `got: ${text}`);
+  assert.ok(
+    text.includes('Gate Q3') || text.includes('verdict=pass'),
+    `expected content summary — got: ${text}`,
+  );
+});
+
+test('save_gate_result renderResult uses structured details when present', () => {
+  const tool = getSaveGateResultTool();
+  const result = {
+    content: [{ type: 'text', text: 'Gate Q3 result saved: verdict=flag' }],
+    details: { operation: 'save_gate_result', gateId: 'Q3', verdict: 'flag' },
+    isError: false,
+  };
+  const rendered = tool.renderResult(result, {}, fakeTheme);
+  const text = String(rendered.content ?? rendered.text ?? rendered);
+  assert.ok(text.includes('Q3'), `got: ${text}`);
+  assert.ok(text.includes('flag'), `got: ${text}`);
+  assert.ok(!text.includes('undefined'), `got: ${text}`);
+});
+
+test('save_gate_result renderResult shows error from content when details.error is missing', () => {
+  const tool = getSaveGateResultTool();
+  const result = {
+    content: [{ type: 'text', text: 'Error: Invalid gateId "Z1"' }],
+    details: {},
+    isError: true,
+  };
+  const rendered = tool.renderResult(result, {}, fakeTheme);
+  const text = String(rendered.content ?? rendered.text ?? rendered);
+  assert.ok(
+    text.includes('Invalid gateId') || text.includes('Error'),
+    `got: ${text}`,
+  );
+  assert.ok(!text.includes('undefined'), `got: ${text}`);
+});
+
+test('save_gate_result renderResult does not duplicate Error: prefix', () => {
+  const tool = getSaveGateResultTool();
+  const result = {
+    content: [{ type: 'text', text: 'Error: Invalid gateId "Z1"' }],
+    details: {},
+    isError: true,
+  };
+  const rendered = tool.renderResult(result, {}, fakeTheme);
+  const text = String(rendered.content ?? rendered.text ?? rendered);
+  assert.ok(
+    !/Error:\s*Error:/i.test(text),
+    `expected a single Error: prefix — got: ${text}`,
+  );
+  assert.ok(text.includes('Invalid gateId'), `got: ${text}`);
+});


### PR DESCRIPTION
## Summary

- Renames `details` → `structuredContent` across all 10 executor-returning MCP handlers so results match the MCP spec, fixing client-side rendering for tools like `gsd_save_gate_result`.
- Forwards runtime `details` + `isError` through `src/mcp-server.ts` from the agent-tool registry path.
- Client-side `extractStructuredDetailsFromBlock` in `stream-adapter.ts` reads `structuredContent` from `mcp_tool_result` in both shapes (sibling field and `type:"structuredContent"` content sub-block), with snake_case fallback.
- Incorporates the narrow fix from #4474 and the CodeRabbit nitpick: `renderResult` in `db-tools.ts` falls back to `content[0].text` when `details` is empty, stripping a leading `Error:` so we never produce `Error: Error: ...`.

Supersedes #4474.

## Test plan

- [x] `packages/mcp-server` workflow-tools suite: 18/18 pass (includes new `gsd_save_gate_result` assertion verifying `structuredContent:{operation,gateId,verdict}` and no `details`).
- [x] New stream-adapter tests (3 shapes): pass.
- [x] New `save-gate-result-render.test.ts` (4 cases including duplicate-`Error:` pin): pass.
- [x] Main-package typecheck: clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents duplicated "Error:" prefixes in tool result messages.
  * Ensures gate result display falls back to readable text when structured fields are missing.
  * Tool responses now surface executor-provided structured payloads via a dedicated structuredContent field, omit non-plain details, and correctly propagate error flags.
* **Tests**
  * Added regression/unit tests for structured-data extraction, executor argument forwarding (verifying params vs. projectDir), and gate-result rendering/representation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Closes #4472.