### PR TITLE
fix(pi-coding-agent): preserve subagent tool list when --tools uses casing or extension names

### DIFF
--- a/packages/pi-coding-agent/src/cli/args.test.ts
+++ b/packages/pi-coding-agent/src/cli/args.test.ts
@@ -1,0 +1,44 @@
+// Regression tests for #4479: subagents launching with empty tools list when
+// --tools includes capitalized built-in names or extension/MCP tool names.
+
+import test, { describe } from "node:test";
+import assert from "node:assert/strict";
+import { parseArgs } from "./args.js";
+
+describe("#4479 — --tools parsing", () => {
+	test("matches built-in names case-insensitively", () => {
+		const args = parseArgs(["--tools", "Read,Bash,Edit,Write"]);
+		assert.deepEqual(args.tools, ["read", "bash", "edit", "write"]);
+		assert.equal(args.extraToolNames, undefined);
+	});
+
+	test("preserves lowercase built-in names unchanged", () => {
+		const args = parseArgs(["--tools", "read,bash"]);
+		assert.deepEqual(args.tools, ["read", "bash"]);
+		assert.equal(args.extraToolNames, undefined);
+	});
+
+	test("defers unrecognized names as extraToolNames (likely extension/MCP)", () => {
+		const args = parseArgs(["--tools", "read,gsd_complete_task,browser_navigate"]);
+		assert.deepEqual(args.tools, ["read"]);
+		assert.deepEqual(args.extraToolNames, ["gsd_complete_task", "browser_navigate"]);
+	});
+
+	test("normalizes only the built-in match; extras keep original casing", () => {
+		const args = parseArgs(["--tools", "Read,GSD_Complete_Task"]);
+		assert.deepEqual(args.tools, ["read"]);
+		assert.deepEqual(args.extraToolNames, ["GSD_Complete_Task"]);
+	});
+
+	test("filters empty entries from comma-separated list", () => {
+		const args = parseArgs(["--tools", "read,,bash, , "]);
+		assert.deepEqual(args.tools, ["read", "bash"]);
+		assert.equal(args.extraToolNames, undefined);
+	});
+
+	test("only-extension-tools input yields empty tools but populated extras", () => {
+		const args = parseArgs(["--tools", "gsd_complete_task"]);
+		assert.deepEqual(args.tools, []);
+		assert.deepEqual(args.extraToolNames, ["gsd_complete_task"]);
+	});
+});

--- a/packages/pi-coding-agent/src/cli/args.ts
+++ b/packages/pi-coding-agent/src/cli/args.ts
@@ -26,6 +26,12 @@ export interface Args {
 	sessionDir?: string;
 	models?: string[];
 	tools?: ToolName[];
+	/**
+	 * Tool names from --tools that did not match a built-in. These are
+	 * deferred to extension/MCP tool resolution after extensions register
+	 * their tools in the agent runtime.
+	 */
+	extraToolNames?: string[];
 	noTools?: boolean;
 	extensions?: string[];
 	noExtensions?: boolean;
@@ -103,18 +109,27 @@ export function parseArgs(args: string[], extensionFlags?: Map<string, { type: "
 		} else if (arg === "--no-tools") {
 			result.noTools = true;
 		} else if (arg === "--tools" && i + 1 < args.length) {
-			const toolNames = args[++i].split(",").map((s) => s.trim());
+			const toolNames = args[++i].split(",").map((s) => s.trim()).filter(Boolean);
+			// Built-in registry keys are lowercase. Match case-insensitively so that
+			// frontmatter like `tools: Read, Bash` resolves correctly.
+			const builtinByLower = new Map<string, ToolName>(
+				Object.keys(allTools).map((n) => [n.toLowerCase(), n as ToolName]),
+			);
 			const validTools: ToolName[] = [];
+			const extras: string[] = [];
 			for (const name of toolNames) {
-				if (name in allTools) {
-					validTools.push(name as ToolName);
+				const builtin = builtinByLower.get(name.toLowerCase());
+				if (builtin) {
+					validTools.push(builtin);
 				} else {
-					console.error(
-						chalk.yellow(`Warning: Unknown tool "${name}". Valid tools: ${Object.keys(allTools).join(", ")}`),
-					);
+					// Defer: this may be an extension/MCP-provided tool that has not
+					// been registered yet at parse time. Resolution happens after
+					// extensions load in AgentSession._buildRuntime.
+					extras.push(name);
 				}
 			}
 			result.tools = validTools;
+			if (extras.length > 0) result.extraToolNames = extras;
 		} else if (arg === "--thinking" && i + 1 < args.length) {
 			const level = args[++i];
 			if (isValidThinkingLevel(level)) {

--- a/packages/pi-coding-agent/src/core/sdk.ts
+++ b/packages/pi-coding-agent/src/core/sdk.ts
@@ -98,6 +98,16 @@ export interface CreateAgentSessionOptions {
 	tools?: Tool[];
 	/** Custom tools to register (in addition to built-in tools). */
 	customTools?: ToolDefinition[];
+	/**
+	 * Additional tool names to activate after extensions/MCP servers register.
+	 * Names that are not registered by any extension are silently ignored
+	 * by AgentSession.setActiveToolsByName.
+	 *
+	 * Used by --tools to forward names that don't match a built-in (likely
+	 * extension- or MCP-provided), so subagents whose frontmatter declares
+	 * extension tools don't end up with an empty tool list.
+	 */
+	extraActiveToolNames?: string[];
 
 	/** Resource loader. When omitted, DefaultResourceLoader is used. */
 	resourceLoader?: ResourceLoader;
@@ -311,9 +321,15 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 	const defaultActiveToolNames: ToolName[] = editMode === "hashline"
 		? ["hashline_read", "bash", "hashline_edit", "write", "lsp"]
 		: ["read", "bash", "edit", "write", "lsp"];
-	const initialActiveToolNames: ToolName[] = options.tools
+	const builtinActiveToolNames: ToolName[] = options.tools
 		? options.tools.map((t) => t.name).filter((n): n is ToolName => n in allTools)
 		: defaultActiveToolNames;
+	// Merge in extension/MCP tool names from --tools that didn't match a built-in.
+	// AgentSession.setActiveToolsByName silently drops names that aren't in the
+	// registry, so unknown names are harmless here.
+	const initialActiveToolNames: string[] = options.extraActiveToolNames
+		? [...builtinActiveToolNames, ...options.extraActiveToolNames]
+		: builtinActiveToolNames;
 
 	let agent: Agent;
 

--- a/packages/pi-coding-agent/src/main.ts
+++ b/packages/pi-coding-agent/src/main.ts
@@ -320,6 +320,10 @@ function buildSessionOptions(
 		options.tools = parsed.tools.map((name) => allTools[name]);
 	}
 
+	if (parsed.extraToolNames && parsed.extraToolNames.length > 0) {
+		options.extraActiveToolNames = parsed.extraToolNames;
+	}
+
 	return { options, cliThinkingFromModel };
 }
 


### PR DESCRIPTION
## Summary
- Subagents (spawned as child `pi` processes via `--tools <names>` from agent `.md` frontmatter) were launching with an empty tools array. Models then hallucinated tool names from training-data priors, producing visible `tool_use_error: No such tool available: read|bash|gsd_complete_task|browser_navigate`.
- Two parser bugs in `packages/pi-coding-agent/src/cli/args.ts`: case-sensitive built-in lookup dropped `Read`/`Bash`; extension/MCP tool names (`gsd_*`, `browser_*`) were rejected because `--tools` validation runs before extensions register.
- Fix: case-insensitive built-in match, and defer non-built-in names through a new `extraActiveToolNames` SDK option that gets merged into `initialActiveToolNames` after `AgentSession._buildRuntime` loads extensions.

## Files changed
- `packages/pi-coding-agent/src/cli/args.ts` — case-insensitive lookup; deferred `extraToolNames`
- `packages/pi-coding-agent/src/main.ts` — forward `extraToolNames` → `options.extraActiveToolNames`
- `packages/pi-coding-agent/src/core/sdk.ts` — declare option, merge into initial active tools
- `packages/pi-coding-agent/src/cli/args.test.ts` — 6 new regression tests

## Test plan
- [x] `tsc --noEmit` clean on `@gsd/pi-coding-agent`
- [x] `node --test` on `args.test.js`: 6/6 pass
- [x] `node --test` on existing `agent-session-tool-refresh` + `agent-session-renderable-tools`: 4/4 pass
- [x] Codex peer review: validated; no blocking issues
- [ ] Manual: spawn a subagent with capitalized frontmatter (`tools: Read, Bash`) and confirm the model receives a populated tool list

## Notes / follow-ups
Codex flagged one non-blocking UX regression: previously, `--tools Foo` printed a `Warning: Unknown tool "Foo"` for typos. With deferred resolution we can no longer warn at parse time. A follow-up should add a post-extension-load warning for extras that didn't resolve in the registry (cheap to add in `_refreshToolRegistry`). Out of scope for this PR.

Closes #4479

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive test coverage for CLI tool argument parsing, including case-insensitive matching and handling of unrecognized tool names.

* **Bug Fixes**
  * Improved tool argument parsing to support case-insensitive matching for built-in tools.
  * Enhanced support for extension and third-party tool names specified via the `--tools` CLI parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->