### PR TITLE
fix(gsd): handle symlinked gsd stash pathspec

### DIFF
--- a/src/resources/extensions/gsd/auto-worktree.ts
+++ b/src/resources/extensions/gsd/auto-worktree.ts
@@ -238,6 +238,14 @@ function clearProjectRootStateFiles(basePath: string, milestoneId: string): void
   }
 }
 
+function isProjectGsdSymlink(basePath: string): boolean {
+  try {
+    return lstatSyncFn(join(basePath, ".gsd")).isSymbolicLink();
+  } catch {
+    return false;
+  }
+}
+
 // ─── Build Artifact Auto-Resolve ─────────────────────────────────────────────
 
 /** Patterns for machine-generated build artifacts that can be safely
@@ -1675,12 +1683,19 @@ export function mergeMilestoneToMain(
       // CONTEXT files into the stash. If stash pop later fails, those files
       // are permanently trapped in the stash entry and lost on the next
       // stash push or drop.
+      //
+      // When `.gsd` itself is a symlink, Git rejects pathspecs below it
+      // ("beyond a symbolic link"). In that layout, exclude the whole symlink
+      // and keep stashing real project files that could block the merge.
+      const stashPathspecs = isProjectGsdSymlink(originalBasePath_)
+        ? [".", ":(exclude).gsd"]
+        : [":(exclude).gsd/milestones"];
       execFileSync(
         "git",
         [
           "stash", "push", "--include-untracked",
           "-m", `gsd: pre-merge stash for ${milestoneId}`,
-          "--", ":(exclude).gsd/milestones",
+          "--", ...stashPathspecs,
         ],
         { cwd: originalBasePath_, stdio: ["ignore", "pipe", "pipe"], encoding: "utf-8" },
       );

--- a/src/resources/extensions/gsd/tests/stash-queued-context-files.test.ts
+++ b/src/resources/extensions/gsd/tests/stash-queued-context-files.test.ts
@@ -21,6 +21,8 @@ import {
   existsSync,
   readFileSync,
   realpathSync,
+  symlinkSync,
+  lstatSync,
 } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
@@ -74,6 +76,20 @@ function createTempRepo(): string {
   run("git commit -m init", dir);
   run("git branch -M main", dir);
   return dir;
+}
+
+function createTempRepoWithSymlinkedGsd(): { repo: string; stateDir: string } {
+  const repo = realpathSync(mkdtempSync(join(tmpdir(), "wt-symlink-stash-test-")));
+  const stateDir = realpathSync(mkdtempSync(join(tmpdir(), "wt-symlink-state-")));
+  run("git init", repo);
+  run("git config user.email test@test.com", repo);
+  run("git config user.name Test", repo);
+  writeFileSync(join(repo, "README.md"), "# test\n");
+  symlinkSync(stateDir, join(repo, ".gsd"));
+  run("git add README.md", repo);
+  run("git commit -m init", repo);
+  run("git branch -M main", repo);
+  return { repo, stateDir };
 }
 
 function makeRoadmap(
@@ -256,6 +272,44 @@ test("#2505: mergeMilestoneToMain preserves queued CONTEXT files (not swept into
     }
   } finally {
     rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("#2505: pre-merge stash handles symlinked .gsd without traversing it", () => {
+  const { repo, stateDir } = createTempRepoWithSymlinkedGsd();
+  try {
+    const wtPath = createAutoWorktree(repo, "M016");
+    const normalizedPath = wtPath.replaceAll("\\", "/");
+    const worktreeName = normalizedPath.split("/").pop() || "M016";
+    const sliceBranch = `slice/${worktreeName}/S01`;
+    run(`git checkout -b "${sliceBranch}"`, wtPath);
+    writeFileSync(join(wtPath, "app.ts"), "export const app = true;\n");
+    run("git add app.ts", wtPath);
+    run('git commit -m "add app feature"', wtPath);
+    run("git checkout milestone/M016", wtPath);
+    run(`git merge --no-ff "${sliceBranch}" -m "merge S01"`, wtPath);
+
+    const queuedDir = join(stateDir, "milestones", "M017");
+    mkdirSync(queuedDir, { recursive: true });
+    writeFileSync(join(queuedDir, "M017-CONTEXT.md"), "# M017: Queued\n");
+
+    // Trigger the pre-merge stash with both tracked and untracked project files.
+    writeFileSync(join(repo, "README.md"), "# test\n\nDirty change.\n");
+    writeFileSync(join(repo, "local-note.txt"), "local scratch\n");
+
+    const result = mergeMilestoneToMain(repo, "M016", makeRoadmap("M016", "App Feature", [
+      { id: "S01", title: "Feature" },
+    ]));
+
+    assert.ok(result.commitMessage.includes("GSD-Milestone: M016"), "merge should succeed");
+    assert.ok(existsSync(join(repo, "app.ts")), "milestone code merged to main");
+    assert.equal(lstatSync(join(repo, ".gsd")).isSymbolicLink(), true, ".gsd symlink remains in place");
+    assert.ok(existsSync(join(queuedDir, "M017-CONTEXT.md")), "queued context remains in external state");
+    assert.equal(readFileSync(join(repo, "README.md"), "utf-8").replace(/\r\n/g, "\n"), "# test\n\nDirty change.\n");
+    assert.equal(readFileSync(join(repo, "local-note.txt"), "utf-8"), "local scratch\n");
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+    rmSync(stateDir, { recursive: true, force: true });
   }
 });
 


### PR DESCRIPTION
## Linked issue

Closes #4481

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Handles symlinked `.gsd` directories during the pre-merge stash used by milestone squash merges.
**Why:** Git rejects pathspecs below a symlink, so the existing `.gsd/milestones` exclusion can fail before the merge starts.
**How:** Detect symlinked `.gsd` at the project root and exclude the whole symlink from the stash pathspec while preserving the existing narrower exclusion for normal directories.

## What

This updates `mergeMilestoneToMain()` so the pre-merge stash pathspec changes only when the project-root `.gsd` entry is a symlink.

For normal projects, the stash still excludes `.gsd/milestones` to avoid trapping queued milestone context files. For symlinked external-state projects, the stash excludes `.gsd` itself because Git refuses to traverse pathspecs below that symlink.

A regression test now builds a temporary repo with symlinked `.gsd`, a queued milestone context in external state, dirty tracked project content, and an untracked project file. The merge must succeed, keep the `.gsd` symlink in place, preserve queued context, and restore the local project changes after the stash pop.

## Why

When `.gsd` points at external state, this command shape fails before the squash merge can proceed:

```shell
git stash push --include-untracked -m "gsd: pre-merge stash for M###" -- :(exclude).gsd/milestones
fatal: pathspec ':(exclude,prefix:0).gsd/milestones' is beyond a symbolic link
```

That leaves auto-mode stopped at milestone completion even though the milestone branch/worktree is preserved for manual recovery.

## How

The implementation adds a small symlink check around the project-root `.gsd` entry:

- symlinked `.gsd`: use `-- . :(exclude).gsd`
- normal `.gsd` directory: keep `-- :(exclude).gsd/milestones`

This keeps the existing queued-context protection intact while avoiding the symlink traversal that Git rejects.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [ ] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

Automated verification:

1. `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/stash-queued-context-files.test.ts` — 4 passed
2. `npm run typecheck:extensions`
3. `npm run secret-scan`

Build note:

- `npm run build` was attempted on this branch and failed in `packages/pi-ai` with the existing `AnthropicEffort` / `xhigh` type error.
- The same `npm run build` failure reproduced on clean `upstream/main` at `a44b82572`, so it is not caused by this PR's `gsd` extension diff.

Manual verification:

1. Reproduced the Git behavior with a symlinked `.gsd`: excluding `.gsd/milestones` fails with `beyond a symbolic link`.
2. Verified that excluding `.gsd` itself in the symlink layout keeps `.gsd` in place while stashing unrelated project-root changes.

## AI disclosure

- [x] This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved failures in milestone merges when the project state directory is configured as a symlink, which was causing pathspec errors during the merge operation.

* **Tests**
  * Added regression test coverage for milestone merge operations with symlinked project directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->