### PR TITLE
fix(gsd): skip dashboard git log outside repos

### DIFF
--- a/src/resources/extensions/gsd/auto-dashboard.ts
+++ b/src/resources/extensions/gsd/auto-dashboard.ts
@@ -18,6 +18,7 @@ import { getCurrentBranch } from "./worktree.js";
 import { getActiveHook } from "./post-unit-hooks.js";
 import { getLedger, getProjectTotals } from "./metrics.js";
 import { getErrorMessage } from "./error-utils.js";
+import { nativeIsRepo } from "./native-git-bridge.js";
 import {
   resolveMilestoneFile,
   resolveSliceFile,
@@ -336,6 +337,10 @@ let lastCommitFetchedAt = 0;
 
 function refreshLastCommit(basePath: string): void {
   try {
+    if (!nativeIsRepo(basePath)) {
+      cachedLastCommit = null;
+      return;
+    }
     const raw = execFileSync("git", ["log", "-1", "--format=%cr|%s"], {
       cwd: basePath,
       encoding: "utf-8",
@@ -349,10 +354,12 @@ function refreshLastCommit(basePath: string): void {
         message: raw.slice(sep + 1),
       };
     }
-    lastCommitFetchedAt = Date.now();
   } catch (err) {
     // Non-fatal — just skip last commit display
+    cachedLastCommit = null;
     logWarning("dashboard", `operation failed: ${err instanceof Error ? err.message : String(err)}`);
+  } finally {
+    lastCommitFetchedAt = Date.now();
   }
 }
 
@@ -362,6 +369,23 @@ function getLastCommit(basePath: string): { timeAgo: string; message: string } |
     refreshLastCommit(basePath);
   }
   return cachedLastCommit;
+}
+
+export function _resetLastCommitCacheForTests(): void {
+  cachedLastCommit = null;
+  lastCommitFetchedAt = 0;
+}
+
+export function _refreshLastCommitForTests(basePath: string): void {
+  refreshLastCommit(basePath);
+}
+
+export function _getLastCommitForTests(basePath: string): { timeAgo: string; message: string } | null {
+  return getLastCommit(basePath);
+}
+
+export function _getLastCommitFetchedAtForTests(): number {
+  return lastCommitFetchedAt;
 }
 
 // ─── Footer Factory ───────────────────────────────────────────────────────────

--- a/src/resources/extensions/gsd/tests/auto-dashboard.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-dashboard.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { execFileSync } from "node:child_process";
 
 import {
   unitVerb,
@@ -15,6 +16,10 @@ import {
   getWidgetMode,
   cycleWidgetMode,
   _resetWidgetModeForTests,
+  _resetLastCommitCacheForTests,
+  _refreshLastCommitForTests,
+  _getLastCommitForTests,
+  _getLastCommitFetchedAtForTests,
 } from "../auto-dashboard.ts";
 
 const autoSource = readFileSync(join(process.cwd(), "src", "resources", "extensions", "gsd", "auto.ts"), "utf-8");
@@ -213,6 +218,50 @@ test("auto progress widget renders RTK savings under the footer stats line", () 
   assert.match(dashboardSource, /formatRtkSavingsLabel/);
   assert.match(dashboardSource, /getRtkSessionSavings\(accessors\.getBasePath\(\), sessionId\)/);
   assert.match(dashboardSource, /lines\.push\(rightAlign\("", theme\.fg\("dim", cachedRtkLabel\), width\)\);/);
+});
+
+test("last commit refresh backs off cleanly when base path is not a git repo", (t) => {
+  const dir = makeTempDir("non-git");
+  mkdirSync(dir, { recursive: true });
+
+  t.after(() => {
+    cleanup(dir);
+    _resetLastCommitCacheForTests();
+  });
+
+  _resetLastCommitCacheForTests();
+  _refreshLastCommitForTests(dir);
+
+  assert.equal(_getLastCommitForTests(dir), null);
+  assert.ok(
+    _getLastCommitFetchedAtForTests() > 0,
+    "non-git refresh should still advance fetchedAt to avoid render-loop retries",
+  );
+});
+
+test("last commit refresh still returns commit info for a valid git repo", (t) => {
+  const dir = makeTempDir("git");
+  mkdirSync(dir, { recursive: true });
+
+  execFileSync("git", ["init", "-b", "main"], { cwd: dir, stdio: "pipe" });
+  execFileSync("git", ["config", "user.name", "GSD Test"], { cwd: dir, stdio: "pipe" });
+  execFileSync("git", ["config", "user.email", "gsd@example.com"], { cwd: dir, stdio: "pipe" });
+  writeFileSync(join(dir, "README.md"), "hello\n", "utf-8");
+  execFileSync("git", ["add", "README.md"], { cwd: dir, stdio: "pipe" });
+  execFileSync("git", ["commit", "-m", "test: seed dashboard repo"], { cwd: dir, stdio: "pipe" });
+
+  t.after(() => {
+    cleanup(dir);
+    _resetLastCommitCacheForTests();
+  });
+
+  _resetLastCommitCacheForTests();
+  _refreshLastCommitForTests(dir);
+
+  const lastCommit = _getLastCommitForTests(dir);
+  assert.ok(lastCommit, "git repo should produce last commit metadata");
+  assert.match(lastCommit!.message, /test: seed dashboard repo/);
+  assert.ok(lastCommit!.timeAgo.length > 0, "relative time should be populated");
 });
 
 // ─── extractUatSliceId ───────────────────────────────────────────────────


### PR DESCRIPTION
## Linked issue

Closes #4483

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Skips the dashboard last-commit lookup when the dashboard base path is not a git repository.
**Why:** The dashboard could repeatedly run `git log` outside a repo, producing noisy non-fatal warnings.
**How:** Check repo status before the lookup, clear the cached commit on failure/non-repo paths, and always advance the refresh timestamp so failures back off.

## What

This updates the auto dashboard's last-commit cache refresh path. Before running `git log -1 --format=%cr|%s`, the dashboard now verifies that the base path is a git repository.

The change also clears stale cached last-commit data on non-repo/error paths and advances the refresh timestamp in a `finally` block so the dashboard does not retry the same failing lookup on every render interval.

Regression tests cover both sides:

- non-git directories return no last-commit data and still advance the refresh timestamp
- valid git repositories still render last-commit metadata

## Why

When the dashboard base path is not a git repository, the current lookup logs repeated warnings like:

```shell
[gsd:dashboard] WARN: operation failed: Command failed: git log -1 --format=%cr|%s
fatal: not a git repository (or any of the parent directories): .git
```

The warning is non-fatal, but repeated noise can hide real auto-mode warnings and makes the dashboard feel broken in non-git contexts.

## How

The implementation uses the existing native git repo check before running the last-commit command. If the path is not a repo, it returns `null` for the footer's last-commit data and records that the refresh was attempted.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [x] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [ ] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

Automated verification:

1. `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/auto-dashboard.test.ts` — 29 passed
2. `npm run typecheck:extensions`
3. `npm run secret-scan`

Build note:

- `npm run build` was attempted on this branch and failed in `packages/pi-ai` with the existing `AnthropicEffort` / `xhigh` type error.
- The same `npm run build` failure reproduced on clean `upstream/main` at `a44b82572`, so it is not caused by this PR's dashboard diff.

Manual verification:

1. Confirmed current upstream attempts the last-commit `git log` without checking repo status first.
2. Confirmed the new test covers the non-git path and the valid-repo path.

## AI disclosure

- [x] This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of non-git repositories to prevent unnecessary refresh operations and reduce processing overhead
  * Enhanced cache management to avoid redundant repository metadata processing

* **Tests**
  * Added test coverage for non-git directory scenarios
  * Added test coverage for git repository metadata retrieval and timestamp handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->