### PR TITLE
fix(gsd): require terminal milestone for doctor cleanup

### DIFF
--- a/src/resources/extensions/gsd/doctor-git-checks.ts
+++ b/src/resources/extensions/gsd/doctor-git-checks.ts
@@ -4,7 +4,7 @@ import { join, sep } from "node:path";
 import type { DoctorIssue, DoctorIssueCode } from "./doctor-types.js";
 import { loadFile } from "./files.js";
 import { parseRoadmap as parseLegacyRoadmap } from "./parsers-legacy.js";
-import { isDbAvailable, getMilestoneSlices } from "./gsd-db.js";
+import { isDbAvailable, getMilestone } from "./gsd-db.js";
 import { resolveMilestoneFile } from "./paths.js";
 import { deriveState, isMilestoneComplete } from "./state.js";
 import { listWorktrees, resolveGitDir, worktreesDir } from "./worktree-manager.js";
@@ -52,6 +52,22 @@ function isSameOrNestedPath(candidate: string, container: string): boolean {
     normalizedCandidate.startsWith(`${normalizedContainer}/`);
 }
 
+async function isCompletedMilestoneTerminal(basePath: string, milestoneId: string): Promise<boolean> {
+  const summaryPath = resolveMilestoneFile(basePath, milestoneId, "SUMMARY");
+  if (!summaryPath) return false;
+
+  if (isDbAvailable()) {
+    const milestone = getMilestone(milestoneId);
+    return !!milestone && milestone.status === "complete";
+  }
+
+  const roadmapPath = resolveMilestoneFile(basePath, milestoneId, "ROADMAP");
+  const roadmapContent = roadmapPath ? await loadFile(roadmapPath) : null;
+  if (!roadmapContent) return false;
+  const roadmap = parseLegacyRoadmap(roadmapContent);
+  return isMilestoneComplete(roadmap);
+}
+
 export async function checkGitHealth(
   basePath: string,
   issues: DoctorIssue[],
@@ -81,23 +97,9 @@ export async function checkGitHealth(
       // Extract milestone ID from branch name "milestone/M001" → "M001"
       const milestoneId = wt.branch.replace(/^milestone\//, "");
       const milestoneEntry = state.registry.find(m => m.id === milestoneId);
-
-      // Check if milestone is complete via roadmap
-      let isComplete = false;
-      if (milestoneEntry) {
-        if (isDbAvailable()) {
-          const dbSlices = getMilestoneSlices(milestoneId);
-          isComplete = dbSlices.length > 0 && dbSlices.every(s => s.status === "complete");
-        } else {
-          const roadmapPath = resolveMilestoneFile(basePath, milestoneId, "ROADMAP");
-          const roadmapContent = roadmapPath ? await loadFile(roadmapPath) : null;
-          if (roadmapContent) {
-            const roadmap = parseLegacyRoadmap(roadmapContent);
-            isComplete = isMilestoneComplete(roadmap);
-          }
-        }
-        // When DB unavailable and no roadmap, isComplete stays false
-      }
+      const isComplete = milestoneEntry
+        ? await isCompletedMilestoneTerminal(basePath, milestoneId)
+        : false;
 
       if (isComplete) {
         issues.push({
@@ -151,15 +153,9 @@ export async function checkGitHealth(
           const milestoneId = branch.replace(/^milestone\//, "");
           const roadmapPath = resolveMilestoneFile(basePath, milestoneId, "ROADMAP");
           let branchMilestoneComplete = false;
-          if (isDbAvailable()) {
-            const dbSlices = getMilestoneSlices(milestoneId);
-            branchMilestoneComplete = dbSlices.length > 0 && dbSlices.every(s => s.status === "complete");
-          } else {
-            const roadmapContent = roadmapPath ? await loadFile(roadmapPath) : null;
-            if (!roadmapContent) continue;
-            const roadmap = parseLegacyRoadmap(roadmapContent);
-            branchMilestoneComplete = isMilestoneComplete(roadmap);
-          }
+          const roadmapContent = roadmapPath ? await loadFile(roadmapPath) : null;
+          if (!roadmapContent) continue;
+          branchMilestoneComplete = await isCompletedMilestoneTerminal(basePath, milestoneId);
           if (branchMilestoneComplete) {
             issues.push({
               severity: "info",

--- a/src/resources/extensions/gsd/tests/integration/doctor-git-symlink-cwd.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/doctor-git-symlink-cwd.test.ts
@@ -44,6 +44,17 @@ Test
 ## Boundary Map
 _None_
 `);
+  writeFileSync(join(milestoneDir, "M001-SUMMARY.md"), `---
+id: M001
+title: "Test Milestone"
+status: complete
+completed_at: 2026-04-18T00:00:00Z
+---
+
+# M001: Test Milestone
+
+Completed.
+`);
 
   run("git add -A", dir);
   run("git commit -m \"add milestone\"", dir);

--- a/src/resources/extensions/gsd/tests/integration/doctor-git.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/doctor-git.test.ts
@@ -16,6 +16,7 @@ import { tmpdir } from "node:os";
 import { execSync } from "node:child_process";
 
 import { runGSDDoctor } from "../../doctor.ts";
+import { closeDatabase, insertMilestone, insertSlice, openDatabase } from "../../gsd-db.ts";
 function run(cmd: string, cwd: string): string {
   return execSync(cmd, { cwd, stdio: ["ignore", "pipe", "pipe"], encoding: "utf-8" }).trim();
 }
@@ -56,10 +57,62 @@ Test
 ## Boundary Map
 _None_
 `);
+  writeFileSync(join(msDir, "M001-SUMMARY.md"), `---
+id: M001
+title: "Test Milestone"
+status: complete
+completed_at: 2026-04-18T00:00:00Z
+---
+
+# M001: Test Milestone
+
+Completed.
+`);
 
   // Commit .gsd files
   run("git add -A", dir);
   run("git commit -m \"add milestone\"", dir);
+
+  return dir;
+}
+
+/** Create a repo whose slices are done but milestone closeout is still pending. */
+function createRepoWithSlicesDoneButNoMilestoneSummary(): string {
+  const dir = realpathSync(mkdtempSync(join(tmpdir(), "doc-git-test-")));
+  run("git init", dir);
+  run("git config user.email test@test.com", dir);
+  run("git config user.name Test", dir);
+
+  writeFileSync(join(dir, "README.md"), "# test\n");
+  run("git add .", dir);
+  run("git commit -m init", dir);
+  run("git branch -M main", dir);
+
+  const msDir = join(dir, ".gsd", "milestones", "M001");
+  mkdirSync(msDir, { recursive: true });
+  writeFileSync(join(msDir, "ROADMAP.md"), `---
+id: M001
+title: "Completing Milestone"
+---
+
+# M001: Completing Milestone
+
+## Vision
+Test
+
+## Success Criteria
+- Done
+
+## Slices
+- [x] **S01: Test slice** \`risk:low\` \`depends:[]\`
+  > After this: done
+
+## Boundary Map
+_None_
+`);
+
+  run("git add -A", dir);
+  run("git commit -m \"add completing milestone\"", dir);
 
   return dir;
 }
@@ -295,6 +348,31 @@ describe('doctor-git', async () => {
       const detect = await runGSDDoctor(dir, { isolationMode: "worktree" });
       const orphanIssues = detect.issues.filter(i => i.code === "orphaned_auto_worktree");
       assert.deepStrictEqual(orphanIssues.length, 0, "active worktree NOT flagged as orphaned");
+    });
+    } else {
+    }
+
+    // ─── Test 6b: completing-milestone worktree NOT flagged ────────────
+    if (process.platform !== "win32") {
+    test('completing-milestone worktree safety (DB-backed, no summary)', async () => {
+      const dir = createRepoWithSlicesDoneButNoMilestoneSummary();
+      cleanups.push(dir);
+
+      mkdirSync(join(dir, ".gsd", "worktrees"), { recursive: true });
+      run("git worktree add -b milestone/M001 .gsd/worktrees/M001", dir);
+
+      const dbPath = join(dir, ".gsd", "gsd.db");
+      assert.equal(openDatabase(dbPath), true, "opens gsd.db");
+      try {
+        insertMilestone({ id: "M001", title: "Completing Milestone", status: "active" });
+        insertSlice({ id: "S01", milestoneId: "M001", title: "Test slice", status: "complete", risk: "low", depends: [] });
+
+        const detect = await runGSDDoctor(dir, { isolationMode: "worktree" });
+        const orphanIssues = detect.issues.filter(i => i.code === "orphaned_auto_worktree");
+        assert.deepStrictEqual(orphanIssues.length, 0, "completing milestone NOT flagged as orphaned");
+      } finally {
+        closeDatabase();
+      }
     });
     } else {
     }


### PR DESCRIPTION
## Linked issue

Closes #4485

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Require terminal milestone evidence before doctor treats milestone worktrees or branches as stale.
**Why:** A milestone with completed slices can still be in closeout, so doctor should not clean its worktree until the milestone itself is complete.
**How:** Centralize terminal milestone detection around summary/DB milestone status and update doctor regression coverage, including the refreshed symlink-cwd fixture.

## What

This updates the GSD doctor git-health checks for milestone worktrees and milestone branches. Instead of treating all completed slice sets as enough evidence for cleanup, doctor now requires terminal milestone state before flagging a milestone worktree as orphaned or a milestone branch as stale.

The test coverage now includes:

1. Completed milestone fixtures with terminal summary evidence.
2. A DB-backed closeout case where slices are complete but the milestone itself is still active.
3. The symlink-cwd orphan cleanup regression fixture updated to represent a truly terminal milestone.

## Why

A milestone can have all slices marked complete while milestone closeout is still pending. In that state, the milestone worktree is still part of active workflow state and should not be cleaned up by `gsd doctor --fix`.

## How

The implementation adds a focused helper for terminal milestone detection. For DB-backed state, it checks the milestone row status. For file-backed state, it requires a summary artifact and then verifies the roadmap state. The existing cwd/worktree realpath-safe cleanup path remains intact after the refresh.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

Automated verification:

1. `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/integration/doctor-git.test.ts`
2. `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/integration/doctor-git-symlink-cwd.test.ts`
3. `npm run typecheck:extensions`
4. `npm run build`
5. `npm run secret-scan`

Manual verification:

1. Rebasing this PR onto current `main` showed the expected overlap with the symlink-cwd doctor cleanup path.
2. The conflict was resolved by preserving both behaviors: terminal milestone cleanup safety and realpath-safe cwd/worktree comparison.
3. The targeted doctor tests above passed after the refresh.

## AI disclosure

- [x] This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Centralized and more reliable milestone completion detection to avoid false positives when evaluating completed milestones.

* **Tests**
  * Added integration tests covering worktree scenarios with DB-backed milestone state and improved fixtures marking milestones as complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->