### PR TITLE
fix(gsd): normalize doctor worktree cwd paths

### DIFF
--- a/src/resources/extensions/gsd/doctor-git-checks.ts
+++ b/src/resources/extensions/gsd/doctor-git-checks.ts
@@ -36,6 +36,22 @@ function isDoctorArtifactOnly(dirPath: string): boolean {
   }
 }
 
+function normalizePathForComparison(path: string): string {
+  const resolved = existsSync(path) ? realpathSync(path) : path;
+  const normalized = resolved
+    .replaceAll("\\", "/")
+    .replace(/^\/\/\?\//, "")
+    .replace(/\/+$/, "");
+  return process.platform === "win32" ? normalized.toLowerCase() : normalized;
+}
+
+function isSameOrNestedPath(candidate: string, container: string): boolean {
+  const normalizedCandidate = normalizePathForComparison(candidate);
+  const normalizedContainer = normalizePathForComparison(container);
+  return normalizedCandidate === normalizedContainer ||
+    normalizedCandidate.startsWith(`${normalizedContainer}/`);
+}
+
 export async function checkGitHealth(
   basePath: string,
   issues: DoctorIssue[],
@@ -98,8 +114,13 @@ export async function checkGitHealth(
           // pattern in removeWorktree() (#1946). Without this, git cannot
           // remove the worktree and the doctor enters a deadlock where it
           // detects the orphan every run but never cleans it up.
-          const cwd = process.cwd();
-          if (wt.path === cwd || cwd.startsWith(wt.path + sep)) {
+          let cwd = basePath;
+          try {
+            cwd = process.cwd();
+          } catch {
+            cwd = basePath;
+          }
+          if (isSameOrNestedPath(cwd, wt.path)) {
             try {
               process.chdir(basePath);
             } catch {

--- a/src/resources/extensions/gsd/tests/integration/doctor-git-symlink-cwd.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/doctor-git-symlink-cwd.test.ts
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import { execSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+
+import { runGSDDoctor } from "../../doctor.ts";
+
+function run(cmd: string, cwd: string): string {
+  return execSync(cmd, { cwd, stdio: ["ignore", "pipe", "pipe"], encoding: "utf-8" }).trim();
+}
+
+function createRepoWithCompletedMilestone(): string {
+  const dir = realpathSync(mkdtempSync(join(tmpdir(), "doc-git-symlink-cwd-")));
+  run("git init", dir);
+  run("git config user.email test@test.com", dir);
+  run("git config user.name Test", dir);
+
+  writeFileSync(join(dir, "README.md"), "# test\n");
+  run("git add .", dir);
+  run("git commit -m init", dir);
+  run("git branch -M main", dir);
+
+  const milestoneDir = join(dir, ".gsd", "milestones", "M001");
+  mkdirSync(milestoneDir, { recursive: true });
+  writeFileSync(join(milestoneDir, "ROADMAP.md"), `---
+id: M001
+title: "Test Milestone"
+---
+
+# M001: Test Milestone
+
+## Vision
+Test
+
+## Success Criteria
+- Done
+
+## Slices
+- [x] **S01: Test slice** \`risk:low\` \`depends:[]\`
+  > After this: done
+
+## Boundary Map
+_None_
+`);
+
+  run("git add -A", dir);
+  run("git commit -m \"add milestone\"", dir);
+
+  return dir;
+}
+
+test("doctor removes orphaned milestone worktree when cwd uses a symlink alias", { skip: process.platform === "win32" }, async (t) => {
+  const previousCwd = process.cwd();
+  const dir = createRepoWithCompletedMilestone();
+  const alias = join(tmpdir(), `doc-git-alias-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+
+  t.after(() => {
+    try { process.chdir(previousCwd); } catch { process.chdir(tmpdir()); }
+    rmSync(alias, { recursive: true, force: true });
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  mkdirSync(join(dir, ".gsd", "worktrees"), { recursive: true });
+  run("git worktree add -b milestone/M001 .gsd/worktrees/M001", dir);
+
+  symlinkSync(dir, alias);
+  process.chdir(join(alias, ".gsd", "worktrees", "M001"));
+
+  const fixed = await runGSDDoctor(dir, { fix: true, isolationMode: "worktree" });
+  assert.ok(
+    fixed.fixesApplied.some(f => f.includes("removed orphaned worktree")),
+    `removes orphaned worktree even when cwd uses a symlink alias (got: ${JSON.stringify(fixed.fixesApplied)})`,
+  );
+
+  const wtList = run("git worktree list", dir);
+  assert.ok(!wtList.includes("milestone/M001"), "worktree removed after symlink-cwd fix");
+});


### PR DESCRIPTION
## Linked issue

Closes #4487

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Normalize doctor cwd/worktree path comparisons before removing orphaned milestone worktrees.
**Why:** A symlinked cwd alias can hide that the process is actually inside the worktree that doctor is trying to remove.
**How:** Resolve existing paths through `realpathSync` before same-or-nested checks, then cover the behavior with an isolated symlink-cwd regression test.

## What

This updates the GSD doctor git-health cleanup path for completed milestone worktrees. The cleanup path now compares normalized real paths before deciding whether it must `chdir` out of a worktree prior to removal.

It also adds a focused integration regression that creates a completed milestone worktree, enters it through a symlink alias, and verifies that doctor removes the orphaned worktree successfully.

## Why

The previous check compared `process.cwd()` and the git worktree path lexically. If one path came through a symlink alias and the other came from git as the real path, doctor could miss that cwd was inside the target worktree and then fail to remove it.

## How

The fix adds a small path-normalization helper that resolves existing paths, normalizes separators, trims trailing slashes, and performs a same-or-nested comparison on the normalized values. If `process.cwd()` is unavailable, the existing safe fallback remains to use the project base path.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [ ] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

Automated verification:

1. `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/integration/doctor-git-symlink-cwd.test.ts`
2. `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/integration/doctor-git.test.ts`
3. `npm run typecheck:extensions`
4. `npm run secret-scan`

Build note:

- `npm run build` was attempted on this branch and failed in `packages/pi-ai` with the existing `AnthropicEffort` / `xhigh` type error.
- The same `npm run build` failure reproduced on clean `upstream/main` at `a44b82572`, so it is not caused by this PR's GSD doctor diff.

Manual verification:

1. Created a temporary git repo with a completed milestone and a `milestone/M001` worktree.
2. Entered that worktree through a symlink alias.
3. Ran the doctor fix path and confirmed the worktree was removed.

Before fix: doctor could miss that cwd was inside the target worktree when the paths differed only by symlink resolution.

After fix: doctor normalizes the paths, changes directory out of the target worktree, and removes it successfully.

## AI disclosure

- [x] This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced worktree detection to reliably identify orphaned worktrees across different operating systems and when accessing directories through symlink aliases.

* **Tests**
  * Added integration test validating proper removal of orphaned worktrees when the current working directory is accessed via symlink, ensuring cross-platform consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->