### PR TITLE
fix(mcp): reject empty required strings across workflow tool schemas

### DIFF
--- a/packages/mcp-server/src/workflow-tools.test.ts
+++ b/packages/mcp-server/src/workflow-tools.test.ts
@@ -386,6 +386,111 @@ describe("workflow MCP tools", () => {
     }
   });
 
+  it("gsd_plan_milestone rejects empty slice fields up front with all violations", async () => {
+    const base = makeTmpBase();
+    try {
+      const server = makeMockServer();
+      registerWorkflowTools(server as any);
+      const milestoneTool = server.tools.find((t) => t.name === "gsd_plan_milestone");
+      assert.ok(milestoneTool, "milestone planning tool should be registered");
+
+      let caught: unknown;
+      try {
+        await milestoneTool!.handler({
+          projectDir: base,
+          milestoneId: "M001",
+          title: "Workflow MCP planning",
+          vision: "Plan milestone over MCP.",
+          slices: [
+            {
+              sliceId: "S01",
+              title: "Bridge planning",
+              risk: "medium",
+              depends: [],
+              demo: "Milestone plan persists through MCP.",
+              goal: "Persist roadmap state.",
+              successCriteria: "",
+              proofLevel: "",
+              integrationClosure: "   ",
+              observabilityImpact: "",
+            },
+          ],
+        });
+      } catch (err) {
+        caught = err;
+      }
+      assert.ok(caught, "empty slice fields should be rejected");
+      const message = caught instanceof Error ? caught.message : String(caught);
+      for (const field of ["successCriteria", "proofLevel", "integrationClosure", "observabilityImpact"]) {
+        assert.ok(
+          message.includes(field),
+          `parse error should mention ${field}, got: ${message}`,
+        );
+      }
+    } finally {
+      cleanup(base);
+    }
+  });
+
+  it("gsd_plan_milestone requires sketchScope when isSketch=true and skips heavy fields", async () => {
+    const base = makeTmpBase();
+    try {
+      const server = makeMockServer();
+      registerWorkflowTools(server as any);
+      const milestoneTool = server.tools.find((t) => t.name === "gsd_plan_milestone");
+      assert.ok(milestoneTool, "milestone planning tool should be registered");
+
+      let caught: unknown;
+      try {
+        await milestoneTool!.handler({
+          projectDir: base,
+          milestoneId: "M001",
+          title: "Sketch milestone",
+          vision: "Sketch first, refine later.",
+          slices: [
+            {
+              sliceId: "S01",
+              title: "Sketch slice",
+              risk: "low",
+              depends: [],
+              demo: "Stub demo.",
+              goal: "Stub goal.",
+              isSketch: true,
+              sketchScope: "",
+            },
+          ],
+        });
+      } catch (err) {
+        caught = err;
+      }
+      assert.ok(caught, "empty sketchScope should be rejected when isSketch=true");
+      const message = caught instanceof Error ? caught.message : String(caught);
+      assert.ok(message.includes("sketchScope"), `expected sketchScope error, got: ${message}`);
+
+      const sketchResult = await milestoneTool!.handler({
+        projectDir: base,
+        milestoneId: "M001",
+        title: "Sketch milestone",
+        vision: "Sketch first, refine later.",
+        slices: [
+          {
+            sliceId: "S01",
+            title: "Sketch slice",
+            risk: "low",
+            depends: [],
+            demo: "Stub demo.",
+            goal: "Stub goal.",
+            isSketch: true,
+            sketchScope: "Defer heavy planning fields until refine-slice.",
+          },
+        ],
+      });
+      assert.match((sketchResult as any).content[0].text as string, /Planned milestone M001/);
+    } finally {
+      cleanup(base);
+    }
+  });
+
   it("gsd_requirement_save opens the DB before inline requirement writes", async () => {
     const base = makeTmpBase();
     try {

--- a/packages/mcp-server/src/workflow-tools.test.ts
+++ b/packages/mcp-server/src/workflow-tools.test.ts
@@ -386,6 +386,156 @@ describe("workflow MCP tools", () => {
     }
   });
 
+  it("other workflow tools reject empty required strings at the schema layer", async () => {
+    const base = makeTmpBase();
+    try {
+      const server = makeMockServer();
+      registerWorkflowTools(server as any);
+
+      const expectRejection = async (toolName: string, args: Record<string, unknown>, expectedField: string) => {
+        const tool = server.tools.find((t) => t.name === toolName);
+        assert.ok(tool, `${toolName} should be registered`);
+        let caught: unknown;
+        try {
+          await tool!.handler(args);
+        } catch (err) {
+          caught = err;
+        }
+        assert.ok(caught, `${toolName} should reject empty ${expectedField}`);
+        const message = caught instanceof Error ? caught.message : String(caught);
+        assert.ok(
+          message.includes(expectedField),
+          `${toolName} error should mention ${expectedField}, got: ${message}`,
+        );
+      };
+
+      // Empty sliceId top-level
+      await expectRejection("gsd_plan_slice", {
+        projectDir: base,
+        milestoneId: "M001",
+        sliceId: "",
+        goal: "Persist slice plan.",
+        tasks: [],
+      }, "sliceId");
+
+      // Empty task verify inside tasks array
+      await expectRejection("gsd_plan_slice", {
+        projectDir: base,
+        milestoneId: "M001",
+        sliceId: "S01",
+        goal: "Persist slice plan.",
+        tasks: [
+          {
+            taskId: "T01",
+            title: "Add bridge",
+            description: "Implement bridge.",
+            estimate: "15m",
+            files: ["src/x.ts"],
+            verify: "",
+            inputs: ["ROADMAP.md"],
+            expectedOutput: ["S01-PLAN.md"],
+          },
+        ],
+      }, "verify");
+
+      // Empty element inside files[] array
+      await expectRejection("gsd_plan_slice", {
+        projectDir: base,
+        milestoneId: "M001",
+        sliceId: "S01",
+        goal: "Persist slice plan.",
+        tasks: [
+          {
+            taskId: "T01",
+            title: "Add bridge",
+            description: "Implement bridge.",
+            estimate: "15m",
+            files: ["src/x.ts", "   "],
+            verify: "node --test",
+            inputs: ["ROADMAP.md"],
+            expectedOutput: ["S01-PLAN.md"],
+          },
+        ],
+      }, "files");
+
+      // Empty milestoneId on gsd_plan_task
+      await expectRejection("gsd_plan_task", {
+        projectDir: base,
+        milestoneId: "",
+        sliceId: "S01",
+        taskId: "T01",
+        title: "t",
+        description: "d",
+        estimate: "1m",
+        files: [],
+        verify: "v",
+        inputs: [],
+        expectedOutput: [],
+      }, "milestoneId");
+
+      // Empty observabilityImpact explicitly rejected (optional-but-non-empty)
+      await expectRejection("gsd_plan_task", {
+        projectDir: base,
+        milestoneId: "M001",
+        sliceId: "S01",
+        taskId: "T01",
+        title: "t",
+        description: "d",
+        estimate: "1m",
+        files: [],
+        verify: "v",
+        inputs: [],
+        expectedOutput: [],
+        observabilityImpact: "   ",
+      }, "observabilityImpact");
+
+      // Empty assessment on gsd_reassess_roadmap
+      await expectRejection("gsd_reassess_roadmap", {
+        projectDir: base,
+        milestoneId: "M001",
+        completedSliceId: "S01",
+        verdict: "roadmap-confirmed",
+        assessment: "",
+        sliceChanges: { modified: [], added: [], removed: [] },
+      }, "assessment");
+
+      // Empty keyRisks[i].risk on gsd_plan_milestone top-level arrays
+      await expectRejection("gsd_plan_milestone", {
+        projectDir: base,
+        milestoneId: "M001",
+        title: "T",
+        vision: "V",
+        slices: [],
+        keyRisks: [{ risk: "", whyItMatters: "because." }],
+      }, "risk");
+
+      // Empty blockerDescription on gsd_replan_slice
+      await expectRejection("gsd_replan_slice", {
+        projectDir: base,
+        milestoneId: "M001",
+        sliceId: "S01",
+        blockerTaskId: "T01",
+        blockerDescription: "",
+        whatChanged: "x",
+        updatedTasks: [],
+        removedTaskIds: [],
+      }, "blockerDescription");
+
+      // Empty milestoneId on gsd_task_complete
+      await expectRejection("gsd_task_complete", {
+        projectDir: base,
+        taskId: "T01",
+        sliceId: "S01",
+        milestoneId: "",
+        oneLiner: "ol",
+        narrative: "n",
+        verification: "v",
+      }, "milestoneId");
+    } finally {
+      cleanup(base);
+    }
+  });
+
   it("gsd_plan_milestone rejects empty slice fields up front with all violations", async () => {
     const base = makeTmpBase();
     try {

--- a/packages/mcp-server/src/workflow-tools.ts
+++ b/packages/mcp-server/src/workflow-tools.ts
@@ -817,27 +817,58 @@ const projectDirParam = z
   .optional()
   .describe("Optional. Omit this field — the server defaults to its current working directory, which is already the correct project or worktree root.");
 
+const nonEmptyString = (field: string) =>
+  z.string().trim().min(1, `${field} must be a non-empty string`);
+
+// Matches the executor's `isNonEmptyString` (trim + length>0) so Zod rejects
+// empty/whitespace fields at parse time. Without this, MCP callers pass "" for
+// the heavy planning fields, Zod accepts it, and the executor rejects one
+// field per call — forcing the agent into a retry loop to discover every gap.
+const planMilestoneSliceSchema = z.object({
+  sliceId: nonEmptyString("sliceId"),
+  title: nonEmptyString("title"),
+  risk: nonEmptyString("risk"),
+  depends: z.array(z.string()),
+  demo: nonEmptyString("demo"),
+  goal: nonEmptyString("goal"),
+  // ADR-011: heavy planning fields are optional for sketch slices; required for full slices.
+  successCriteria: z.string().optional(),
+  proofLevel: z.string().optional(),
+  integrationClosure: z.string().optional(),
+  observabilityImpact: z.string().optional(),
+  // ADR-011 sketch-then-refine fields.
+  isSketch: z.boolean().optional().describe("ADR-011: true marks this slice as a sketch awaiting refine-slice expansion"),
+  sketchScope: z.string().optional().describe("ADR-011: 2-3 sentence scope boundary, required when isSketch=true"),
+}).superRefine((slice, ctx) => {
+  if (slice.isSketch === true) {
+    if (typeof slice.sketchScope !== "string" || slice.sketchScope.trim().length === 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["sketchScope"],
+        message: "sketchScope must be a non-empty string when isSketch is true",
+      });
+    }
+    return;
+  }
+  const required = ["successCriteria", "proofLevel", "integrationClosure", "observabilityImpact"] as const;
+  for (const field of required) {
+    const value = slice[field];
+    if (typeof value !== "string" || value.trim().length === 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: [field],
+        message: `${field} must be a non-empty string`,
+      });
+    }
+  }
+});
+
 const planMilestoneParams = {
   projectDir: projectDirParam,
-  milestoneId: z.string().describe("Milestone ID (e.g. M001)"),
-  title: z.string().describe("Milestone title"),
-  vision: z.string().describe("Milestone vision"),
-  slices: z.array(z.object({
-    sliceId: z.string(),
-    title: z.string(),
-    risk: z.string(),
-    depends: z.array(z.string()),
-    demo: z.string(),
-    goal: z.string(),
-    // ADR-011: heavy planning fields are optional for sketch slices; required for full slices.
-    successCriteria: z.string().optional(),
-    proofLevel: z.string().optional(),
-    integrationClosure: z.string().optional(),
-    observabilityImpact: z.string().optional(),
-    // ADR-011 sketch-then-refine fields.
-    isSketch: z.boolean().optional().describe("ADR-011: true marks this slice as a sketch awaiting refine-slice expansion"),
-    sketchScope: z.string().optional().describe("ADR-011: 2-3 sentence scope boundary, required when isSketch=true"),
-  })).describe("Planned slices for the milestone"),
+  milestoneId: nonEmptyString("milestoneId").describe("Milestone ID (e.g. M001)"),
+  title: nonEmptyString("title").describe("Milestone title"),
+  vision: nonEmptyString("vision").describe("Milestone vision"),
+  slices: z.array(planMilestoneSliceSchema).describe("Planned slices for the milestone"),
   status: z.string().optional().describe("Milestone status"),
   dependsOn: z.array(z.string()).optional().describe("Milestone dependencies"),
   successCriteria: z.array(z.string()).optional().describe("Top-level success criteria bullets"),

--- a/packages/mcp-server/src/workflow-tools.ts
+++ b/packages/mcp-server/src/workflow-tools.ts
@@ -820,6 +820,18 @@ const projectDirParam = z
 const nonEmptyString = (field: string) =>
   z.string().trim().min(1, `${field} must be a non-empty string`);
 
+// Optional non-empty string: accepts omitted/undefined but rejects "" or
+// whitespace. Mirrors executor guards of the form
+// `value !== undefined && !isNonEmptyString(value)` — e.g. plan-task's
+// observabilityImpact. Do not preprocess "" to undefined; the executor
+// treats them differently.
+const optionalNonEmptyString = (field: string) => nonEmptyString(field).optional();
+
+// Array of non-empty strings. Mirrors executor guards that call
+// `validateStringArray` or `arr.some((item) => !isNonEmptyString(item))`.
+const nonEmptyStringArray = (field: string) =>
+  z.array(nonEmptyString(`${field}[]`));
+
 // Matches the executor's `isNonEmptyString` (trim + length>0) so Zod rejects
 // empty/whitespace fields at parse time. Without this, MCP callers pass "" for
 // the heavy planning fields, Zod accepts it, and the executor rejects one
@@ -873,13 +885,13 @@ const planMilestoneParams = {
   dependsOn: z.array(z.string()).optional().describe("Milestone dependencies"),
   successCriteria: z.array(z.string()).optional().describe("Top-level success criteria bullets"),
   keyRisks: z.array(z.object({
-    risk: z.string(),
-    whyItMatters: z.string(),
+    risk: nonEmptyString("risk"),
+    whyItMatters: nonEmptyString("whyItMatters"),
   })).optional().describe("Structured risk entries"),
   proofStrategy: z.array(z.object({
-    riskOrUnknown: z.string(),
-    retireIn: z.string(),
-    whatWillBeProven: z.string(),
+    riskOrUnknown: nonEmptyString("riskOrUnknown"),
+    retireIn: nonEmptyString("retireIn"),
+    whatWillBeProven: nonEmptyString("whatWillBeProven"),
   })).optional().describe("Structured proof strategy entries"),
   verificationContract: z.string().optional(),
   verificationIntegration: z.string().optional(),
@@ -893,19 +905,19 @@ const planMilestoneSchema = z.object(planMilestoneParams);
 
 const planSliceParams = {
   projectDir: projectDirParam,
-  milestoneId: z.string().describe("Milestone ID (e.g. M001)"),
-  sliceId: z.string().describe("Slice ID (e.g. S01)"),
-  goal: z.string().describe("Slice goal"),
+  milestoneId: nonEmptyString("milestoneId").describe("Milestone ID (e.g. M001)"),
+  sliceId: nonEmptyString("sliceId").describe("Slice ID (e.g. S01)"),
+  goal: nonEmptyString("goal").describe("Slice goal"),
   tasks: z.array(z.object({
-    taskId: z.string(),
-    title: z.string(),
-    description: z.string(),
-    estimate: z.string(),
-    files: z.array(z.string()),
-    verify: z.string(),
-    inputs: z.array(z.string()),
-    expectedOutput: z.array(z.string()),
-    observabilityImpact: z.string().optional(),
+    taskId: nonEmptyString("taskId"),
+    title: nonEmptyString("title"),
+    description: nonEmptyString("description"),
+    estimate: nonEmptyString("estimate"),
+    files: nonEmptyStringArray("files"),
+    verify: nonEmptyString("verify"),
+    inputs: nonEmptyStringArray("inputs"),
+    expectedOutput: nonEmptyStringArray("expectedOutput"),
+    observabilityImpact: optionalNonEmptyString("observabilityImpact"),
   })).describe("Planned tasks for the slice"),
   successCriteria: z.string().optional(),
   proofLevel: z.string().optional(),
@@ -916,8 +928,8 @@ const planSliceSchema = z.object(planSliceParams);
 
 const completeMilestoneParams = {
   projectDir: projectDirParam,
-  milestoneId: z.string().describe("Milestone ID (e.g. M001)"),
-  title: z.string().describe("Milestone title"),
+  milestoneId: nonEmptyString("milestoneId").describe("Milestone ID (e.g. M001)"),
+  title: nonEmptyString("title").describe("Milestone title"),
   oneLiner: z.string().describe("One-sentence summary of what the milestone achieved"),
   narrative: z.string().describe("Detailed narrative of what happened during the milestone"),
   verificationPassed: z.boolean().describe("Must be true after milestone verification succeeds"),
@@ -934,7 +946,7 @@ const completeMilestoneSchema = z.object(completeMilestoneParams);
 
 const validateMilestoneParams = {
   projectDir: projectDirParam,
-  milestoneId: z.string().describe("Milestone ID (e.g. M001)"),
+  milestoneId: nonEmptyString("milestoneId").describe("Milestone ID (e.g. M001)"),
   verdict: z.enum(["pass", "needs-attention", "needs-remediation"]).describe("Validation verdict"),
   remediationRound: z.number().describe("Remediation round (0 for first validation)"),
   successCriteriaChecklist: z.string().describe("Markdown checklist of success criteria with evidence"),
@@ -948,8 +960,8 @@ const validateMilestoneParams = {
 const validateMilestoneSchema = z.object(validateMilestoneParams);
 
 const roadmapSliceChangeSchema = z.object({
-  sliceId: z.string(),
-  title: z.string(),
+  sliceId: nonEmptyString("sliceId"),
+  title: nonEmptyString("title"),
   risk: z.string().optional(),
   depends: z.array(z.string()).optional(),
   demo: z.string().optional(),
@@ -957,10 +969,10 @@ const roadmapSliceChangeSchema = z.object({
 
 const reassessRoadmapParams = {
   projectDir: projectDirParam,
-  milestoneId: z.string().describe("Milestone ID (e.g. M001)"),
-  completedSliceId: z.string().describe("Slice ID that just completed"),
-  verdict: z.string().describe("Assessment verdict such as roadmap-confirmed or roadmap-adjusted"),
-  assessment: z.string().describe("Assessment text explaining the roadmap decision"),
+  milestoneId: nonEmptyString("milestoneId").describe("Milestone ID (e.g. M001)"),
+  completedSliceId: nonEmptyString("completedSliceId").describe("Slice ID that just completed"),
+  verdict: nonEmptyString("verdict").describe("Assessment verdict such as roadmap-confirmed or roadmap-adjusted"),
+  assessment: nonEmptyString("assessment").describe("Assessment text explaining the roadmap decision"),
   sliceChanges: z.object({
     modified: z.array(roadmapSliceChangeSchema),
     added: z.array(roadmapSliceChangeSchema),
@@ -983,14 +995,14 @@ const saveGateResultSchema = z.object(saveGateResultParams);
 
 const replanSliceParams = {
   projectDir: projectDirParam,
-  milestoneId: z.string().describe("Milestone ID (e.g. M001)"),
-  sliceId: z.string().describe("Slice ID (e.g. S01)"),
-  blockerTaskId: z.string().describe("Task ID that discovered the blocker"),
-  blockerDescription: z.string().describe("Description of the blocker"),
-  whatChanged: z.string().describe("Summary of what changed in the plan"),
+  milestoneId: nonEmptyString("milestoneId").describe("Milestone ID (e.g. M001)"),
+  sliceId: nonEmptyString("sliceId").describe("Slice ID (e.g. S01)"),
+  blockerTaskId: nonEmptyString("blockerTaskId").describe("Task ID that discovered the blocker"),
+  blockerDescription: nonEmptyString("blockerDescription").describe("Description of the blocker"),
+  whatChanged: nonEmptyString("whatChanged").describe("Summary of what changed in the plan"),
   updatedTasks: z.array(z.object({
-    taskId: z.string(),
-    title: z.string(),
+    taskId: nonEmptyString("taskId"),
+    title: nonEmptyString("title"),
     description: z.string(),
     estimate: z.string(),
     files: z.array(z.string()),
@@ -1005,8 +1017,8 @@ const replanSliceSchema = z.object(replanSliceParams);
 
 const sliceCompleteParams = {
   projectDir: projectDirParam,
-  sliceId: z.string().describe("Slice ID (e.g. S01)"),
-  milestoneId: z.string().describe("Milestone ID (e.g. M001)"),
+  sliceId: nonEmptyString("sliceId").describe("Slice ID (e.g. S01)"),
+  milestoneId: nonEmptyString("milestoneId").describe("Milestone ID (e.g. M001)"),
   sliceTitle: z.string().describe("Title of the slice"),
   oneLiner: z.string().describe("One-line summary of what the slice accomplished"),
   narrative: z.string().describe("Detailed narrative of what happened across all tasks"),
@@ -1101,17 +1113,17 @@ const milestoneGenerateIdSchema = z.object(milestoneGenerateIdParams);
 
 const planTaskParams = {
   projectDir: projectDirParam,
-  milestoneId: z.string().describe("Milestone ID (e.g. M001)"),
-  sliceId: z.string().describe("Slice ID (e.g. S01)"),
-  taskId: z.string().describe("Task ID (e.g. T01)"),
-  title: z.string().describe("Task title"),
-  description: z.string().describe("Task description / steps block"),
-  estimate: z.string().describe("Task estimate"),
+  milestoneId: nonEmptyString("milestoneId").describe("Milestone ID (e.g. M001)"),
+  sliceId: nonEmptyString("sliceId").describe("Slice ID (e.g. S01)"),
+  taskId: nonEmptyString("taskId").describe("Task ID (e.g. T01)"),
+  title: nonEmptyString("title").describe("Task title"),
+  description: nonEmptyString("description").describe("Task description / steps block"),
+  estimate: nonEmptyString("estimate").describe("Task estimate"),
   files: z.array(z.string()).describe("Files likely touched"),
-  verify: z.string().describe("Verification command or block"),
+  verify: nonEmptyString("verify").describe("Verification command or block"),
   inputs: z.array(z.string()).describe("Input files or references"),
   expectedOutput: z.array(z.string()).describe("Expected output files or artifacts"),
-  observabilityImpact: z.string().optional().describe("Task observability impact"),
+  observabilityImpact: optionalNonEmptyString("observabilityImpact").describe("Task observability impact"),
 };
 const planTaskSchema = z.object(planTaskParams);
 
@@ -1125,9 +1137,9 @@ const skipSliceSchema = z.object(skipSliceParams);
 
 const taskCompleteParams = {
   projectDir: projectDirParam,
-  taskId: z.string().describe("Task ID (e.g. T01)"),
-  sliceId: z.string().describe("Slice ID (e.g. S01)"),
-  milestoneId: z.string().describe("Milestone ID (e.g. M001)"),
+  taskId: nonEmptyString("taskId").describe("Task ID (e.g. T01)"),
+  sliceId: nonEmptyString("sliceId").describe("Slice ID (e.g. S01)"),
+  milestoneId: nonEmptyString("milestoneId").describe("Milestone ID (e.g. M001)"),
   oneLiner: z.string().describe("One-line summary of what was accomplished"),
   narrative: z.string().describe("Detailed narrative of what happened during the task"),
   verification: z.string().describe("What was verified and how"),


### PR DESCRIPTION
## Summary

Workflow MCP tool schemas declared required string fields as plain `z.string()`, which accepts `""` and whitespace. Downstream executors then reject empties one at a time via `isNonEmptyString`. Agents ended up in retry loops, discovering each missing field one round at a time.

This PR tightens every confirmed mismatch so Zod aggregates all violations into a single parse error, using `.trim().min(1, ...)` to match `isNonEmptyString` semantics exactly.

Closes #4489.

## Scope

Added helpers: `nonEmptyString`, `nonEmptyStringArray`, `optionalNonEmptyString`.

Fields tightened (schema loose → executor strict intersection only):

| Tool | Fields |
|---|---|
| `gsd_plan_milestone` top-level | `milestoneId`, `title`, `vision` |
| `gsd_plan_milestone` slice | `sliceId`, `title`, `risk`, `demo`, `goal`; heavy fields via `superRefine` (ADR-011 sketch-aware); `sketchScope` when `isSketch=true` |
| `gsd_plan_milestone` nested | `keyRisks[].risk`, `keyRisks[].whyItMatters`, `proofStrategy[].{riskOrUnknown,retireIn,whatWillBeProven}` |
| `gsd_plan_slice` | `milestoneId`, `sliceId`, `goal`; per-task `taskId`, `title`, `description`, `estimate`, `verify`; `files[]`, `inputs[]`, `expectedOutput[]` element-level non-empty; `observabilityImpact` optional-but-non-empty |
| `gsd_plan_task` | `milestoneId`, `sliceId`, `taskId`, `title`, `description`, `estimate`, `verify`; `observabilityImpact` optional-but-non-empty |
| `gsd_replan_slice` | `milestoneId`, `sliceId`, `blockerTaskId`, `blockerDescription`, `whatChanged`; per-updatedTask `taskId`, `title` |
| `gsd_slice_complete` | `sliceId`, `milestoneId` |
| `gsd_complete_milestone` | `milestoneId`, `title` |
| `gsd_complete_task` | `taskId`, `sliceId`, `milestoneId` |
| `gsd_validate_milestone` | `milestoneId` |
| `gsd_reassess_roadmap` | `milestoneId`, `completedSliceId`, `verdict`, `assessment`; nested `sliceChanges.modified/added[].{sliceId,title}` |

## Left intentionally loose

Narrative / markdown fields with no executor guard (so no observed retry loop): `oneLiner`, `narrative`, `verification`, `uatContent`, `successCriteriaChecklist`, `sliceDeliveryAudit`, `crossSliceIntegration`, `requirementCoverage`, `verdictRationale`, `saveGateResult.rationale`, `summarySave.content`, decision/requirement save fields, skip-slice, milestone-status, journal-query, reopen-*.

## Semantics preserved

- `optionalNonEmptyString` is `z.string().trim().min(1).optional()` — `undefined` is allowed, `""`/whitespace is rejected. Mirrors executor checks of the form `value !== undefined && !isNonEmptyString(value)`. No `""`→`undefined` coercion.
- `nonEmptyStringArray` validates each element, matching `validateStringArray` / `some(!isNonEmptyString)` patterns.
- ADR-011 sketch-then-refine: `planMilestoneSliceSchema` uses `superRefine` so `isSketch=true` requires `sketchScope` (and skips heavy fields), otherwise requires all four heavy fields.

## Test plan

Added to `packages/mcp-server/src/workflow-tools.test.ts`:
- `gsd_plan_milestone` rejects empty heavy-field slice with all 4 violations in one error.
- `gsd_plan_milestone` requires `sketchScope` when `isSketch=true`; accepts sketch slices with scope and no heavy fields.
- Parametrized test covering rejection across: `gsd_plan_slice` scalars, `gsd_plan_slice` `files[]` element, `gsd_plan_task` scalars, `gsd_plan_task` optional `observabilityImpact`, `gsd_reassess_roadmap`, `gsd_plan_milestone` nested `keyRisks`, `gsd_replan_slice`, `gsd_task_complete`.

- [x] `npx tsc --noEmit -p packages/mcp-server/tsconfig.json`
- [x] 25/25 tests pass in `packages/mcp-server/src/workflow-tools.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened input validation across planning and task tools to reject empty/whitespace fields, enforce non-empty arrays/entries, and apply conditional requirements for sketch vs. non-sketch slices.
* **Tests**
  * Added tests covering schema validation failures, collective reporting of slice-field errors, and acceptance of valid sketch inputs (including required sketchScope).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->