### PR TITLE
fix(search): gate native web_search on api shape, not provider ID (#4478)

### DIFF
--- a/docs/dev/ADR-012-provider-id-vs-api-shape.md
+++ b/docs/dev/ADR-012-provider-id-vs-api-shape.md
@@ -1,0 +1,76 @@
+# ADR-012: Provider Identity vs. API Shape
+
+**Status:** Accepted
+**Date:** 2026-04-19
+**Author:** Jeremy (@jeremymcs)
+**Related:** ADR-005 (multi-model provider tool strategy), Issue #4478, Issue #4384
+**Prior art:** PR #2235 (doctor-side Brave warning fix — did not touch native-search)
+
+## Context
+
+A GSD model is described by two independent fields:
+
+- **`provider`** — a transport / credential identifier. Examples: `anthropic`, `claude-code`, `anthropic-vertex`, `amazon-bedrock`, `vercel-ai-gateway`, `openai`, `azure`, `openrouter`, `groq`, `github-copilot`, `google`, `google-vertex`, `google-gemini-cli`.
+- **`api`** — the wire protocol the request is serialized as. Registered today in `packages/pi-ai/src/providers/register-builtins.ts`: `anthropic-messages`, `anthropic-vertex`, `openai-completions`, `openai-responses`, `azure-openai-responses`, `openai-codex-responses`, `google-generative-ai`, `google-gemini-cli`, `google-vertex`, `bedrock-converse-stream`, `mistral-conversations`.
+
+These are **not the same thing**. Many providers serve genuine Anthropic/OpenAI/Google models over the vendor's own wire protocol: Claude Code OAuth and Anthropic-on-Vertex both speak the Anthropic Messages shape; Vercel AI Gateway fronts multiple wire protocols; Azure/Codex/OpenRouter all speak OpenAI-shaped protocols; Gemini on Vertex speaks Gemini-shaped protocols.
+
+### Observed failure (#4478)
+
+`src/resources/extensions/search-the-web/native-search.ts` gated Anthropic-native web-search behavior on `model.provider === "anthropic"`. Claude Pro/Max subscribers authenticated via Claude Code OAuth (provider `claude-code`, api `anthropic-messages`) therefore:
+
+1. Got the "Set `BRAVE_API_KEY` or use an Anthropic model" warning spammed on every `model_select` event.
+2. Did **not** receive native `web_search_20250305` tool injection.
+3. Had no functional web search unless they paid for a Brave API key that GSD did not actually need.
+
+The same class of bug would bite OpenAI-Responses features gated on `provider === "openai"` (missing Azure, Codex, Copilot, OpenRouter) and Gemini features gated on `provider === "google"` (missing Vertex, Gemini CLI).
+
+## Decision
+
+**Gate API-shape-dependent behavior on `model.api`, not `model.provider`.**
+
+API-shape-dependent behavior includes anything that assumes a specific wire protocol, tool-schema shape, streaming event format, message-array schema, or provider-native tool identifier (`web_search_20250305`, `web_search_preview`, `google_search`, etc.).
+
+Use the shared predicates in `packages/pi-ai/src/providers/api-family.ts`:
+
+- `isAnthropicApi(model)` — `anthropic-messages` | `anthropic-vertex`
+- `isOpenAIApi(model)` — `openai-completions` | `openai-responses` | `azure-openai-responses` | `openai-codex-responses`
+- `isGeminiApi(model)` — `google-generative-ai` | `google-gemini-cli` | `google-vertex`
+- `isBedrockApi(model)` — `bedrock-converse-stream`
+
+The helpers are re-exported from `@gsd/pi-ai` for use across the monorepo.
+
+### When `provider` comparison is still correct
+
+A small set of call sites legitimately keys on `provider`. These are **not** gated on API shape:
+
+- **Per-transport credential resolution** (`env-api-keys.ts`, `web-runtime-env-api-keys.ts`). Each provider has its own env var.
+- **Per-transport doctor checks** (`doctor-providers.ts`). Each transport verifies different things (OAuth vs key vs ADC).
+- **Fallback-source targeting** (`retry-handler.ts` — "only fall back *from* plain `anthropic` *to* `claude-code`"). The rule is transport-specific by design.
+- **Model-registry canonical-provider tiebreakers** (`auto-model-selection.ts`). Same canonical model may appear under multiple transports; plain `anthropic` is the tiebreaker.
+- **Display labels / onboarding copy** (`onboarding.ts`). Surface-only, no behavior impact.
+
+These sites are enumerated in the allowlist at `src/tests/provider-equality-allowlist.test.ts`.
+
+### Guardrail
+
+`src/tests/provider-equality-allowlist.test.ts` greps the tree for `model.provider === "<known-transport>"` and asserts every hit is in an explicit file allowlist. A new provider-equality check fails CI unless the author (a) uses an `isXxxApi` helper instead, or (b) adds the site to the allowlist with rationale.
+
+## Consequences
+
+### Positive
+
+- Fixes #4478 and every symmetric instance before it lands.
+- Claude Pro/Max users on Claude Code OAuth get functional native web search with no keys.
+- Anthropic-on-Vertex and Vercel-AI-Gateway Anthropic routes also gain native web search for free.
+- Adding a new Anthropic-fronting transport (e.g. a future Bedrock Messages route) requires zero changes to API-shape-gated code — only registering the new `api` value if it differs.
+
+### Caveats
+
+- **Vertex-side tool support.** `isAnthropicApi` includes `anthropic-vertex`. Whether Google Cloud has enabled `web_search_20250305` on its Anthropic-on-Vertex surface is an external dependency. The SDK is transparent; if Vertex rejects the tool type at the API layer, we'll surface a 400 rather than silent degradation. Users can opt out via `PREFER_BRAVE_SEARCH=1` or `search_provider: brave` in PREFERENCES.md.
+- **Bedrock excluded.** Bedrock Converse uses a different tool schema. Native web search on Bedrock is a separate effort, not in this ADR's scope.
+
+### Follow-ups
+
+- Issue #4384 (flat-rate provider classification) has the same root class; it can adopt `isAnthropicApi` / `isOpenAIApi` when it lands.
+- If `provider` is reused in a hot path where the helper's lookup cost matters, memoize per `Model` instance — but current use is in event handlers where the cost is irrelevant.

--- a/packages/pi-ai/src/index.ts
+++ b/packages/pi-ai/src/index.ts
@@ -8,6 +8,7 @@ export {
 	mapThinkingLevelToEffort,
 	supportsAdaptiveThinking,
 } from "./providers/anthropic-shared.js";
+export * from "./providers/api-family.js";
 export * from "./providers/provider-capabilities.js";
 export * from "./providers/register-builtins.js";
 export type { ProviderSwitchReport } from "./providers/transform-messages.js";

--- a/packages/pi-ai/src/providers/api-family.test.ts
+++ b/packages/pi-ai/src/providers/api-family.test.ts
@@ -1,0 +1,129 @@
+// gsd-2 / pi-ai: api-family predicate tests
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  isAnthropicApi,
+  isBedrockApi,
+  isGeminiApi,
+  isOpenAIApi,
+} from "./api-family.js";
+
+// Every api value registered via registerApiProvider() in register-builtins.ts.
+// Keep in sync with that file — the expectations below assert every api is
+// classified by exactly one family (except mistral, which is its own family
+// and belongs to none of the helpers).
+const ALL_REGISTERED_APIS = [
+  "anthropic-messages",
+  "anthropic-vertex",
+  "openai-completions",
+  "openai-responses",
+  "azure-openai-responses",
+  "openai-codex-responses",
+  "google-generative-ai",
+  "google-gemini-cli",
+  "google-vertex",
+  "bedrock-converse-stream",
+  "mistral-conversations",
+] as const;
+
+describe("isAnthropicApi", () => {
+  test("matches anthropic-messages and anthropic-vertex", () => {
+    assert.equal(isAnthropicApi({ api: "anthropic-messages" }), true);
+    assert.equal(isAnthropicApi({ api: "anthropic-vertex" }), true);
+  });
+
+  test("excludes bedrock-converse-stream (different tool schema)", () => {
+    assert.equal(isAnthropicApi({ api: "bedrock-converse-stream" }), false);
+  });
+
+  test("excludes every non-Anthropic registered api", () => {
+    const nonAnthropic = ALL_REGISTERED_APIS.filter(
+      (a) => a !== "anthropic-messages" && a !== "anthropic-vertex",
+    );
+    for (const api of nonAnthropic) {
+      assert.equal(isAnthropicApi({ api }), false, `api=${api}`);
+    }
+  });
+
+  test("tolerates null/undefined/missing api", () => {
+    assert.equal(isAnthropicApi(null), false);
+    assert.equal(isAnthropicApi(undefined), false);
+    assert.equal(isAnthropicApi({}), false);
+    assert.equal(isAnthropicApi({ api: "" }), false);
+  });
+});
+
+describe("isOpenAIApi", () => {
+  test("matches all OpenAI-shaped apis", () => {
+    for (const api of [
+      "openai-completions",
+      "openai-responses",
+      "azure-openai-responses",
+      "openai-codex-responses",
+    ]) {
+      assert.equal(isOpenAIApi({ api }), true, `api=${api}`);
+    }
+  });
+
+  test("excludes every non-OpenAI registered api", () => {
+    const nonOpenAI = ALL_REGISTERED_APIS.filter(
+      (a) =>
+        a !== "openai-completions" &&
+        a !== "openai-responses" &&
+        a !== "azure-openai-responses" &&
+        a !== "openai-codex-responses",
+    );
+    for (const api of nonOpenAI) {
+      assert.equal(isOpenAIApi({ api }), false, `api=${api}`);
+    }
+  });
+});
+
+describe("isGeminiApi", () => {
+  test("matches all Gemini-shaped apis", () => {
+    for (const api of ["google-generative-ai", "google-gemini-cli", "google-vertex"]) {
+      assert.equal(isGeminiApi({ api }), true, `api=${api}`);
+    }
+  });
+
+  test("excludes every non-Gemini registered api", () => {
+    const nonGemini = ALL_REGISTERED_APIS.filter(
+      (a) =>
+        a !== "google-generative-ai" &&
+        a !== "google-gemini-cli" &&
+        a !== "google-vertex",
+    );
+    for (const api of nonGemini) {
+      assert.equal(isGeminiApi({ api }), false, `api=${api}`);
+    }
+  });
+});
+
+describe("isBedrockApi", () => {
+  test("matches only bedrock-converse-stream", () => {
+    assert.equal(isBedrockApi({ api: "bedrock-converse-stream" }), true);
+    for (const api of ALL_REGISTERED_APIS.filter((a) => a !== "bedrock-converse-stream")) {
+      assert.equal(isBedrockApi({ api }), false, `api=${api}`);
+    }
+  });
+});
+
+describe("api-family exclusivity", () => {
+  test("every registered api belongs to exactly one family (or mistral = none)", () => {
+    for (const api of ALL_REGISTERED_APIS) {
+      const matches = [
+        isAnthropicApi({ api }),
+        isOpenAIApi({ api }),
+        isGeminiApi({ api }),
+        isBedrockApi({ api }),
+      ].filter(Boolean).length;
+      const expected = api === "mistral-conversations" ? 0 : 1;
+      assert.equal(
+        matches,
+        expected,
+        `api=${api} matched ${matches} families (expected ${expected})`,
+      );
+    }
+  });
+});

--- a/packages/pi-ai/src/providers/api-family.ts
+++ b/packages/pi-ai/src/providers/api-family.ts
@@ -1,0 +1,57 @@
+// gsd-2 / pi-ai: API-shape family predicates
+//
+// Rule (see docs/dev/ADR-012-provider-id-vs-api-shape.md):
+//   Gate API-shape-dependent behavior (tool schemas, request payload shape,
+//   streaming format) on `model.api`, never on `model.provider`.
+//   `provider` is a credential/transport identifier that varies by vendor
+//   routing (e.g. `anthropic`, `claude-code`, `anthropic-vertex`,
+//   `amazon-bedrock`, `vercel-ai-gateway`) even when the wire protocol is
+//   identical.
+
+/** Minimal shape — any object with an optional `api` string works. */
+type HasApi = { api?: string } | null | undefined;
+
+/**
+ * True for any transport that speaks the Anthropic Messages wire protocol:
+ * direct Anthropic, Claude Code OAuth, Anthropic-on-Vertex, Vercel AI Gateway
+ * Anthropic routes, etc.
+ *
+ * Excludes Bedrock-hosted Claude — Bedrock Converse uses a different tool
+ * schema and is matched by `isBedrockApi` instead.
+ */
+export function isAnthropicApi(model: HasApi): boolean {
+  const api = model?.api;
+  return api === "anthropic-messages" || api === "anthropic-vertex";
+}
+
+/**
+ * True for any transport that speaks an OpenAI-shaped wire protocol:
+ * Chat Completions, Responses, Azure-hosted Responses, Codex-hosted Responses.
+ */
+export function isOpenAIApi(model: HasApi): boolean {
+  const api = model?.api;
+  return (
+    api === "openai-completions" ||
+    api === "openai-responses" ||
+    api === "azure-openai-responses" ||
+    api === "openai-codex-responses"
+  );
+}
+
+/**
+ * True for any transport that speaks a Google Gemini wire protocol:
+ * Generative AI REST, Gemini CLI, Vertex AI.
+ */
+export function isGeminiApi(model: HasApi): boolean {
+  const api = model?.api;
+  return (
+    api === "google-generative-ai" ||
+    api === "google-gemini-cli" ||
+    api === "google-vertex"
+  );
+}
+
+/** True for AWS Bedrock Converse transports. */
+export function isBedrockApi(model: HasApi): boolean {
+  return model?.api === "bedrock-converse-stream";
+}

--- a/packages/pi-coding-agent/src/core/extensions/runner.ts
+++ b/packages/pi-coding-agent/src/core/extensions/runner.ts
@@ -686,7 +686,10 @@ export class ExtensionRunner {
 		return currentMessages;
 	}
 
-	async emitBeforeProviderRequest(payload: unknown, model?: { provider: string; id: string }): Promise<unknown> {
+	async emitBeforeProviderRequest(
+		payload: unknown,
+		model?: { provider: string; id: string; api?: string },
+	): Promise<unknown> {
 		let currentPayload = payload;
 
 		await this.invokeHandlers("before_provider_request", () => ({

--- a/packages/pi-coding-agent/src/core/extensions/types.ts
+++ b/packages/pi-coding-agent/src/core/extensions/types.ts
@@ -523,8 +523,8 @@ export interface ContextEvent {
 export interface BeforeProviderRequestEvent {
 	type: "before_provider_request";
 	payload: unknown;
-	/** The resolved model for this request (provider, id, etc.) */
-	model?: { provider: string; id: string };
+	/** The resolved model for this request (provider, id, api, etc.) */
+	model?: { provider: string; id: string; api?: string };
 }
 
 /** Fired after user submits prompt but before agent loop. */

--- a/packages/pi-coding-agent/src/core/retry-handler.ts
+++ b/packages/pi-coding-agent/src/core/retry-handler.ts
@@ -538,7 +538,10 @@ export class RetryHandler {
 		if (!currentModel) return false;
 
 		// Only attempt claude-code fallback when the current provider is anthropic.
-		// Other providers may produce similar error text but should not be rerouted.
+		// Transport-specific (ADR-012): intentionally keys on provider, not api —
+		// the fallback specifically reroutes the plain `anthropic` transport to
+		// the `claude-code` transport. Other Anthropic-fronting transports
+		// (anthropic-vertex, amazon-bedrock) must not be rerouted.
 		if (currentModel.provider !== "anthropic") return false;
 
 		// Find the same model ID under the claude-code provider

--- a/src/resources/extensions/gsd/auto-model-selection.ts
+++ b/src/resources/extensions/gsd/auto-model-selection.ts
@@ -488,7 +488,9 @@ export function resolveModelId<T extends { id: string; provider: string }>(
     if (providerMatch) return providerMatch;
   }
 
-  // Prefer "anthropic" as the canonical provider for Anthropic models
+  // Prefer "anthropic" as the canonical provider for Anthropic models.
+  // Transport-specific tiebreaker (ADR-012): intentionally keys on provider,
+  // not api — we want the plain Anthropic transport when multiple are available.
   const anthropicMatch = candidates.find(m => m.provider === "anthropic");
   if (anthropicMatch) return anthropicMatch;
 

--- a/src/resources/extensions/search-the-web/command-search-provider.ts
+++ b/src/resources/extensions/search-the-web/command-search-provider.ts
@@ -8,6 +8,7 @@
  * All provider logic lives in provider.ts (S01) — this is pure UI wiring.
  */
 
+import { isAnthropicApi } from '@gsd/pi-ai'
 import type { ExtensionAPI } from '@gsd/pi-coding-agent'
 import type { AutocompleteItem } from '@gsd/pi-tui'
 import {
@@ -90,7 +91,9 @@ export function registerSearchProviderCommand(pi: ExtensionAPI): void {
 
       setSearchProviderPreference(chosen)
       const effective = resolveSearchProvider()
-      const isAnthropic = ctx.model?.provider === 'anthropic'
+      // Gate on api (#4478 / ADR-012): covers claude-code, anthropic-vertex, and
+      // other Anthropic-fronting transports — not just the plain `anthropic` provider.
+      const isAnthropic = isAnthropicApi(ctx.model)
       const nativeNote = isAnthropic ? '\nNote: Native Anthropic web search is also active (automatic, no API key needed).' : ''
       ctx.ui.notify(
         `Search provider set to ${chosen}. Effective provider: ${effective ?? 'none (no API keys)'}${nativeNote}`,

--- a/src/resources/extensions/search-the-web/native-search.ts
+++ b/src/resources/extensions/search-the-web/native-search.ts
@@ -5,6 +5,7 @@
  * the heavy tool-registration modules.
  */
 
+import { isAnthropicApi } from "@gsd/pi-ai";
 import { resolveSearchProviderFromPreferences } from "../gsd/preferences.js";
 
 /** Tool names for the Brave-backed custom search tools */
@@ -94,7 +95,10 @@ export function registerNativeSearchHooks(pi: NativeSearchPI): { getIsAnthropic:
   pi.on("model_select", async (event: any, ctx: any) => {
     modelSelectFired = true;
     const wasAnthropic = isAnthropicProvider;
-    isAnthropicProvider = event.model.provider === "anthropic";
+    // Gate on `api` not `provider` (#4478 / ADR-012): covers claude-code OAuth,
+    // anthropic-vertex, and Vercel-gateway-hosted Anthropic — all serve the
+    // Messages API and accept the native web_search tool.
+    isAnthropicProvider = isAnthropicApi(event.model);
 
     const hasBrave = !!process.env.BRAVE_API_KEY;
 
@@ -139,9 +143,15 @@ export function registerNativeSearchHooks(pi: NativeSearchPI): { getIsAnthropic:
     // the model_select flag, then to the model name heuristic (last resort).
     // The model name heuristic is needed for session restores where
     // modelsAreEqual suppresses model_select AND the SDK doesn't pass model.
-    const eventModel = event.model as { provider: string } | undefined;
+    const eventModel = event.model as { provider?: string; api?: string } | undefined;
     let isAnthropic: boolean;
-    if (eventModel?.provider) {
+    if (eventModel?.api) {
+      // Preferred path: gate on wire protocol (#4478 / ADR-012).
+      isAnthropic = isAnthropicApi(eventModel);
+    } else if (eventModel?.provider) {
+      // Fallback for event shapes that carry provider but not api — only plain
+      // `anthropic` maps unambiguously without the api field. Other Anthropic
+      // transports will arrive via the modelSelectFired or model-name branch.
       isAnthropic = eventModel.provider === "anthropic";
     } else if (modelSelectFired) {
       isAnthropic = isAnthropicProvider;

--- a/src/tests/native-search.test.ts
+++ b/src/tests/native-search.test.ts
@@ -1014,6 +1014,37 @@ test("stripThinkingFromHistory handles string content (no array)", () => {
   assert.equal(messages[1].content, "just a string");
 });
 
+// ─── #4478 session-restore edge: model_select suppressed (same model) ──────
+
+test("#4478 claude-code session restore with model_select suppressed still injects native search", async () => {
+  // Regression: when a session is restored and the restored model equals the
+  // active model, `modelsAreEqual` suppresses `model_select`. The
+  // before_provider_request handler must still detect Anthropic via the
+  // event.model object's `api` field — not fall through to the narrower
+  // `provider === "anthropic"` fallback which misses claude-code.
+  const pi = createMockPI();
+  registerNativeSearchHooks(pi);
+
+  // NO model_select fired — simulates restore-with-same-model.
+  const payload: Record<string, unknown> = {
+    model: "claude-sonnet-4-6",
+    tools: [{ name: "bash", type: "custom" }],
+  };
+
+  const result = await pi.fire("before_provider_request", {
+    type: "before_provider_request",
+    payload,
+    // Full Model object carrying `api` — matches what the runner forwards at runtime.
+    model: { provider: "claude-code", id: "claude-sonnet-4-6", api: "anthropic-messages" },
+  });
+
+  const tools = ((result as any)?.tools ?? payload.tools) as any[];
+  assert.ok(
+    tools.some((t) => t.type === "web_search_20250305"),
+    "Should inject native web_search on claude-code restore even with model_select suppressed",
+  );
+});
+
 // ─── #4478 regression: Anthropic-fronting transports inject native search ───
 
 test("#4478 claude-code OAuth provider injects native web_search", async () => {

--- a/src/tests/native-search.test.ts
+++ b/src/tests/native-search.test.ts
@@ -77,7 +77,7 @@ test("before_provider_request injects web_search for claude models", async () =>
   // Confirm Anthropic provider via model_select before request
   await pi.fire("model_select", {
     type: "model_select",
-    model: { provider: "anthropic", name: "claude-sonnet-4-6" },
+    model: { provider: "anthropic", api: "anthropic-messages", name: "claude-sonnet-4-6" },
     previousModel: undefined,
     source: "set",
   });
@@ -220,7 +220,7 @@ test("before_provider_request DOES inject when event.model indicates Anthropic p
   const result = await pi.fire("before_provider_request", {
     type: "before_provider_request",
     payload,
-    model: { provider: "anthropic", id: "claude-sonnet-4-6" },
+    model: { provider: "anthropic", id: "claude-sonnet-4-6", api: "anthropic-messages" },
   });
 
   const tools = ((result as any)?.tools ?? payload.tools) as any[];
@@ -236,7 +236,7 @@ test("before_provider_request does not double-inject", async () => {
 
   await pi.fire("model_select", {
     type: "model_select",
-    model: { provider: "anthropic", name: "claude-opus-4-6" },
+    model: { provider: "anthropic", api: "anthropic-messages", name: "claude-opus-4-6" },
     previousModel: undefined,
     source: "set",
   });
@@ -262,7 +262,7 @@ test("before_provider_request creates tools array if missing", async () => {
 
   await pi.fire("model_select", {
     type: "model_select",
-    model: { provider: "anthropic", name: "claude-haiku-4-5" },
+    model: { provider: "anthropic", api: "anthropic-messages", name: "claude-haiku-4-5" },
     previousModel: undefined,
     source: "set",
   });
@@ -308,7 +308,7 @@ test("model_select disables Brave tools when Anthropic + no BRAVE_API_KEY", asyn
 
   await pi.fire("model_select", {
     type: "model_select",
-    model: { provider: "anthropic", name: "claude-sonnet-4-6" },
+    model: { provider: "anthropic", api: "anthropic-messages", name: "claude-sonnet-4-6" },
     previousModel: undefined,
     source: "set",
   });
@@ -334,7 +334,7 @@ test("model_select disables all custom search tools when Anthropic even with BRA
 
   await pi.fire("model_select", {
     type: "model_select",
-    model: { provider: "anthropic", name: "claude-sonnet-4-6" },
+    model: { provider: "anthropic", api: "anthropic-messages", name: "claude-sonnet-4-6" },
     previousModel: undefined,
     source: "set",
   });
@@ -360,7 +360,7 @@ test("model_select re-enables Brave tools when switching away from Anthropic", a
   // First: select Anthropic — disables Brave tools
   await pi.fire("model_select", {
     type: "model_select",
-    model: { provider: "anthropic", name: "claude-sonnet-4-6" },
+    model: { provider: "anthropic", api: "anthropic-messages", name: "claude-sonnet-4-6" },
     previousModel: undefined,
     source: "set",
   });
@@ -388,7 +388,7 @@ test("model_select shows 'Native Anthropic web search active' for Anthropic prov
 
   await pi.fire("model_select", {
     type: "model_select",
-    model: { provider: "anthropic", name: "claude-sonnet-4-6" },
+    model: { provider: "anthropic", api: "anthropic-messages", name: "claude-sonnet-4-6" },
     previousModel: undefined,
     source: "set",
   });
@@ -463,7 +463,7 @@ test("before_provider_request removes Brave tools from payload when no BRAVE_API
 
   await pi.fire("model_select", {
     type: "model_select",
-    model: { provider: "anthropic", name: "claude-sonnet-4-6" },
+    model: { provider: "anthropic", api: "anthropic-messages", name: "claude-sonnet-4-6" },
     previousModel: undefined,
     source: "set",
   });
@@ -508,7 +508,7 @@ test("before_provider_request removes all custom search tools from payload even 
 
   await pi.fire("model_select", {
     type: "model_select",
-    model: { provider: "anthropic", name: "claude-sonnet-4-6" },
+    model: { provider: "anthropic", api: "anthropic-messages", name: "claude-sonnet-4-6" },
     previousModel: undefined,
     source: "set",
   });
@@ -554,7 +554,7 @@ test("model_select re-enable does not duplicate Brave tools across toggle cycles
   // Cycle 1: Anthropic disables Brave tools
   await pi.fire("model_select", {
     type: "model_select",
-    model: { provider: "anthropic", name: "claude-sonnet-4-6" },
+    model: { provider: "anthropic", api: "anthropic-messages", name: "claude-sonnet-4-6" },
     previousModel: undefined,
     source: "set",
   });
@@ -576,7 +576,7 @@ test("model_select re-enable does not duplicate Brave tools across toggle cycles
   // Cycle 2: Anthropic again
   await pi.fire("model_select", {
     type: "model_select",
-    model: { provider: "anthropic", name: "claude-sonnet-4-6" },
+    model: { provider: "anthropic", api: "anthropic-messages", name: "claude-sonnet-4-6" },
     previousModel: { provider: "openai", name: "gpt-4o" },
     source: "set",
   });
@@ -627,7 +627,7 @@ test("model_select suppresses 'Native search active' notification on session res
 
   await pi.fire("model_select", {
     type: "model_select",
-    model: { provider: "anthropic", name: "claude-sonnet-4-6" },
+    model: { provider: "anthropic", api: "anthropic-messages", name: "claude-sonnet-4-6" },
     previousModel: undefined,
     source: "restore",  // session restore, not user action
   });
@@ -647,7 +647,7 @@ test("model_select DOES show notification on explicit user set", async () => {
 
   await pi.fire("model_select", {
     type: "model_select",
-    model: { provider: "anthropic", name: "claude-sonnet-4-6" },
+    model: { provider: "anthropic", api: "anthropic-messages", name: "claude-sonnet-4-6" },
     previousModel: undefined,
     source: "set",
   });
@@ -666,7 +666,7 @@ test("session search budget: max_uses decreases as history accumulates search re
 
   await pi.fire("model_select", {
     type: "model_select",
-    model: { provider: "anthropic", name: "claude-sonnet-4-6" },
+    model: { provider: "anthropic", api: "anthropic-messages", name: "claude-sonnet-4-6" },
     previousModel: undefined,
     source: "set",
   });
@@ -724,7 +724,7 @@ test("session search budget: reduces max_uses when close to limit", async () => 
 
   await pi.fire("model_select", {
     type: "model_select",
-    model: { provider: "anthropic", name: "claude-sonnet-4-6" },
+    model: { provider: "anthropic", api: "anthropic-messages", name: "claude-sonnet-4-6" },
     previousModel: undefined,
     source: "set",
   });
@@ -766,7 +766,7 @@ test("session search budget: omits web_search tool when budget exhausted", async
 
   await pi.fire("model_select", {
     type: "model_select",
-    model: { provider: "anthropic", name: "claude-sonnet-4-6" },
+    model: { provider: "anthropic", api: "anthropic-messages", name: "claude-sonnet-4-6" },
     previousModel: undefined,
     source: "set",
   });
@@ -808,7 +808,7 @@ test("session search budget: resets on session_start", async () => {
 
   await pi.fire("model_select", {
     type: "model_select",
-    model: { provider: "anthropic", name: "claude-sonnet-4-6" },
+    model: { provider: "anthropic", api: "anthropic-messages", name: "claude-sonnet-4-6" },
     previousModel: undefined,
     source: "set",
   });
@@ -861,7 +861,7 @@ test("session search budget: survives context compaction (high-water mark)", asy
 
   await pi.fire("model_select", {
     type: "model_select",
-    model: { provider: "anthropic", name: "claude-sonnet-4-6" },
+    model: { provider: "anthropic", api: "anthropic-messages", name: "claude-sonnet-4-6" },
     previousModel: undefined,
     source: "set",
   });
@@ -1012,4 +1012,123 @@ test("stripThinkingFromHistory handles string content (no array)", () => {
   // Should not throw — string content is skipped
   stripThinkingFromHistory(messages);
   assert.equal(messages[1].content, "just a string");
+});
+
+// ─── #4478 regression: Anthropic-fronting transports inject native search ───
+
+test("#4478 claude-code OAuth provider injects native web_search", async () => {
+  const pi = createMockPI();
+  registerNativeSearchHooks(pi);
+
+  await pi.fire("model_select", {
+    type: "model_select",
+    model: { provider: "claude-code", api: "anthropic-messages", name: "claude-sonnet-4-6" },
+    previousModel: undefined,
+    source: "set",
+  });
+
+  // Must NOT emit the spammy Brave warning
+  const warning = pi.notifications.find((n) => n.level === "warning");
+  assert.equal(warning, undefined, "Should not emit Brave warning for claude-code provider");
+
+  // Must disable custom search tools
+  assert.ok(!pi.getActiveTools().includes("search-the-web"), "Brave tools disabled on claude-code");
+
+  const payload: Record<string, unknown> = {
+    model: "claude-sonnet-4-6-20250514",
+    tools: [{ name: "bash", type: "custom" }],
+  };
+  const result = await pi.fire("before_provider_request", {
+    type: "before_provider_request",
+    payload,
+    model: { provider: "claude-code", id: "claude-sonnet-4-6", api: "anthropic-messages" },
+  });
+  const tools = ((result as any)?.tools ?? payload.tools) as any[];
+  assert.ok(
+    tools.some((t) => t.type === "web_search_20250305"),
+    "Should inject native web_search for claude-code",
+  );
+});
+
+test("#4478 anthropic-vertex provider injects native web_search", async () => {
+  const pi = createMockPI();
+  registerNativeSearchHooks(pi);
+
+  await pi.fire("model_select", {
+    type: "model_select",
+    model: { provider: "anthropic-vertex", api: "anthropic-vertex", name: "claude-sonnet-4-6" },
+    previousModel: undefined,
+    source: "set",
+  });
+
+  const payload: Record<string, unknown> = {
+    model: "claude-sonnet-4-6",
+    tools: [{ name: "bash", type: "custom" }],
+  };
+  const result = await pi.fire("before_provider_request", {
+    type: "before_provider_request",
+    payload,
+    model: { provider: "anthropic-vertex", id: "claude-sonnet-4-6", api: "anthropic-vertex" },
+  });
+  const tools = ((result as any)?.tools ?? payload.tools) as any[];
+  assert.ok(
+    tools.some((t) => t.type === "web_search_20250305"),
+    "Should inject native web_search for anthropic-vertex",
+  );
+});
+
+test("#4478 vercel-ai-gateway with anthropic-messages api injects native web_search", async () => {
+  const pi = createMockPI();
+  registerNativeSearchHooks(pi);
+
+  await pi.fire("model_select", {
+    type: "model_select",
+    model: { provider: "vercel-ai-gateway", api: "anthropic-messages", name: "anthropic/claude-sonnet-4-6" },
+    previousModel: undefined,
+    source: "set",
+  });
+
+  const payload: Record<string, unknown> = {
+    model: "anthropic/claude-sonnet-4-6",
+    tools: [{ name: "bash", type: "custom" }],
+  };
+  const result = await pi.fire("before_provider_request", {
+    type: "before_provider_request",
+    payload,
+    model: { provider: "vercel-ai-gateway", id: "anthropic/claude-sonnet-4-6", api: "anthropic-messages" },
+  });
+  const tools = ((result as any)?.tools ?? payload.tools) as any[];
+  assert.ok(
+    tools.some((t) => t.type === "web_search_20250305"),
+    "Vercel-gateway Anthropic route should inject native web_search (same wire protocol)",
+  );
+});
+
+test("#4478 amazon-bedrock provider does NOT inject (different tool schema)", async () => {
+  const pi = createMockPI();
+  registerNativeSearchHooks(pi);
+
+  await pi.fire("model_select", {
+    type: "model_select",
+    model: { provider: "amazon-bedrock", api: "bedrock-converse-stream", name: "claude-sonnet-4-6" },
+    previousModel: undefined,
+    source: "set",
+  });
+
+  const payload: Record<string, unknown> = {
+    model: "anthropic.claude-sonnet-4-6",
+    tools: [{ name: "bash", type: "custom" }],
+  };
+  const result = await pi.fire("before_provider_request", {
+    type: "before_provider_request",
+    payload,
+    model: { provider: "amazon-bedrock", id: "claude-sonnet-4-6", api: "bedrock-converse-stream" },
+  });
+
+  assert.equal(result, undefined, "Should not modify payload for Bedrock (different tool schema)");
+  const tools = payload.tools as any[];
+  assert.ok(
+    !tools.some((t) => t.type === "web_search_20250305"),
+    "web_search_20250305 must NOT be injected into Bedrock requests",
+  );
 });

--- a/src/tests/provider-equality-allowlist.test.ts
+++ b/src/tests/provider-equality-allowlist.test.ts
@@ -1,0 +1,175 @@
+// gsd-2: provider-equality guardrail test (ADR-012)
+//
+// Purpose: prevent regressions of bug class #4478 — gating API-shape-dependent
+// behavior on `model.provider === "<transport>"` instead of `model.api`.
+//
+// Rule (see docs/dev/ADR-012-provider-id-vs-api-shape.md):
+//   Source files must either gate API-shape behavior through the shared
+//   helpers in @gsd/pi-ai (isAnthropicApi / isOpenAIApi / isGeminiApi /
+//   isBedrockApi), OR be present in the allowlist below with a justified
+//   `reason` — one of a small set of legitimate transport-specific use cases.
+//
+// When this test fails, you have two options:
+//   1. Replace the `model.provider === "x"` check with an isXxxApi() call
+//      from @gsd/pi-ai. This is the default answer.
+//   2. If your check really is transport-specific (credential resolution,
+//      transport-only fallback targeting, display labels, etc.), add the
+//      file path to ALLOWED_FILES below with a short reason.
+//
+// Scope: `.ts` source files under `src/` and `packages/`. Excludes tests
+// (*.test.ts), scripts (generate-models, etc.), node_modules, .worktrees,
+// dist, and documentation (*.md).
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join, relative, sep } from "node:path";
+
+const REPO_ROOT = new URL("../..", import.meta.url).pathname;
+
+// Transports known to be confusable with API shape. Extend this list as new
+// Anthropic-/OpenAI-/Gemini-fronting transports are added to the codebase.
+const KNOWN_TRANSPORTS = [
+  "anthropic",
+  "openai",
+  "google",
+  "claude-code",
+  "anthropic-vertex",
+  "amazon-bedrock",
+  "azure",
+  "copilot",
+  "github-copilot",
+  "openrouter",
+  "groq",
+  "vercel-ai-gateway",
+];
+
+// Any `.provider === "x"` or `.provider !== "x"` where x is a known transport.
+const PROVIDER_EQ_RE = new RegExp(
+  String.raw`\.provider\s*(?:===|!==)\s*["'](?:` +
+    KNOWN_TRANSPORTS.join("|") +
+    String.raw`)["']`,
+);
+
+// Legitimate transport-specific sites. Each entry is a repo-relative POSIX
+// path plus a one-line justification. Update ADR-012's "When `provider`
+// comparison is still correct" section when adding to this list.
+const ALLOWED_FILES: Record<string, string> = {
+  // Fallback source is the plain `anthropic` transport (routes to claude-code).
+  "packages/pi-coding-agent/src/core/retry-handler.ts":
+    "transport-specific fallback source (ADR-012)",
+
+  // Claude-Code-specific SDK hooks (OAuth prep, streaming buffer sizing).
+  "packages/pi-coding-agent/src/core/sdk.ts":
+    "claude-code-specific SDK behavior",
+  "packages/pi-coding-agent/src/modes/interactive/controllers/chat-controller.ts":
+    "claude-code-specific streaming UI",
+  "packages/pi-coding-agent/src/modes/interactive/components/assistant-message.ts":
+    "claude-code-specific message rendering",
+
+  // GitHub Copilot transport-specific request/auth transforms.
+  "packages/pi-ai/src/utils/oauth/github-copilot.ts":
+    "github-copilot OAuth-specific model shaping",
+  "packages/pi-ai/src/providers/openai-shared.ts":
+    "github-copilot-specific header injection",
+  "packages/pi-ai/src/providers/anthropic.ts":
+    "github-copilot-specific header injection on Anthropic transport",
+
+  // Transport-specific model-ID quirks (OpenRouter Anthropic IDs, OpenAI
+  // custom-model-ID length cap, Copilot-specific headers).
+  "packages/pi-ai/src/providers/openai-completions.ts":
+    "transport-specific model-ID and header handling",
+
+  // Model-registry canonical-provider tiebreakers (prefer plain `anthropic` /
+  // `claude-code` when multiple transports serve the same model).
+  "src/resources/extensions/gsd/auto-model-selection.ts":
+    "canonical-provider tiebreakers (ADR-012)",
+
+  // native-search.ts fallback branch: when event.model lacks `api`, the plain
+  // `anthropic` provider is the only transport we can disambiguate by
+  // provider alone. Documented inline.
+  "src/resources/extensions/search-the-web/native-search.ts":
+    "api-less event fallback; primary path uses isAnthropicApi (ADR-012)",
+};
+
+function shouldScan(path: string): boolean {
+  if (!path.endsWith(".ts")) return false;
+  if (path.endsWith(".test.ts")) return false;
+  if (path.endsWith(".d.ts")) return false;
+  const parts = path.split(sep);
+  if (parts.includes("node_modules")) return false;
+  if (parts.includes(".worktrees")) return false;
+  if (parts.includes("dist")) return false;
+  if (parts.includes("build")) return false;
+  if (parts.includes("scripts")) return false;
+  if (parts.includes("tests")) return false;
+  if (parts.includes("__tests__")) return false;
+  return true;
+}
+
+function walk(dir: string, out: string[]): void {
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    if (entry === "node_modules" || entry === ".worktrees" || entry === "dist" || entry === "build") continue;
+    const full = join(dir, entry);
+    let stat;
+    try {
+      stat = statSync(full);
+    } catch {
+      continue;
+    }
+    if (stat.isDirectory()) {
+      walk(full, out);
+    } else if (shouldScan(full)) {
+      out.push(full);
+    }
+  }
+}
+
+function collectHits(): string[] {
+  const files: string[] = [];
+  walk(join(REPO_ROOT, "src"), files);
+  walk(join(REPO_ROOT, "packages"), files);
+
+  const hits: string[] = [];
+  for (const abs of files) {
+    const rel = relative(REPO_ROOT, abs).split(sep).join("/");
+    const contents = readFileSync(abs, "utf8");
+    if (PROVIDER_EQ_RE.test(contents)) hits.push(rel);
+  }
+  return hits.sort();
+}
+
+test("ADR-012: provider-equality checks are allowlisted or use isXxxApi helpers", () => {
+  const hits = collectHits();
+  const unauthorized = hits.filter((p) => !(p in ALLOWED_FILES));
+
+  if (unauthorized.length > 0) {
+    const lines = unauthorized.map((p) => `  - ${p}`).join("\n");
+    assert.fail(
+      `New \`model.provider === "<transport>"\` check(s) detected in:\n${lines}\n\n` +
+        `Rule (ADR-012): gate API-shape-dependent behavior on \`model.api\` via\n` +
+        `isAnthropicApi / isOpenAIApi / isGeminiApi / isBedrockApi from @gsd/pi-ai.\n\n` +
+        `If the check really is transport-specific (credentials, fallback source,\n` +
+        `display labels, etc.), add the file to ALLOWED_FILES in this test with a\n` +
+        `one-line reason and update ADR-012's allowlist section.`,
+    );
+  }
+});
+
+test("ADR-012: no stale entries in ALLOWED_FILES", () => {
+  const hits = new Set(collectHits());
+  const stale = Object.keys(ALLOWED_FILES).filter((p) => !hits.has(p));
+  assert.deepEqual(
+    stale,
+    [],
+    `ALLOWED_FILES has entries that no longer contain provider-equality checks:\n` +
+      stale.map((p) => `  - ${p}`).join("\n") +
+      `\nRemove them to keep the allowlist honest.`,
+  );
+});


### PR DESCRIPTION
## Summary
- Fixes #4478. Claude Pro/Max users on Claude Code OAuth (and Anthropic-on-Vertex, Vercel AI Gateway Anthropic routes) now get native `web_search_20250305` injection and no longer see the spammy "Set BRAVE_API_KEY" warning on every `model_select`.
- Scope elevated from the single symptom to the bug class: gating API-shape-dependent behavior on `model.provider` instead of `model.api`. Adds shared `isAnthropicApi` / `isOpenAIApi` / `isGeminiApi` / `isBedrockApi` helpers in `@gsd/pi-ai`, documents the rule as ADR-012, and adds a CI guardrail test.
- Includes regression tests for `claude-code`, `anthropic-vertex`, `vercel-ai-gateway`, and `amazon-bedrock` (the last must NOT inject — different tool schema).

## Changes
- **New** `packages/pi-ai/src/providers/api-family.ts` — transport-agnostic api-shape predicates, re-exported from `@gsd/pi-ai`.
- **New** `docs/dev/ADR-012-provider-id-vs-api-shape.md` — rationale, rule, allowlist of legitimate `provider`-equality sites.
- **New** `src/tests/provider-equality-allowlist.test.ts` — guardrail fails CI on any new `model.provider === "<transport>"` gate outside the allowlist.
- **Fix** `src/resources/extensions/search-the-web/native-search.ts` (model_select + before_provider_request) and `command-search-provider.ts` — now gate on `isAnthropicApi(model)`.
- **Type** `BeforeProviderRequestEvent.model` widened with optional `api?: string` (runtime already passed it; only the public type was narrow).
- **Docs** annotated three subtle legitimate sites (retry-handler fallback source, auto-model-selection tiebreaker, native-search api-less fallback) with ADR-012 references.

## External caveat
`isAnthropicApi` matches `anthropic-vertex`. Whether Google Cloud has enabled `web_search_20250305` on its Anthropic-on-Vertex surface is an external dependency; if Vertex rejects the tool type we'll surface a 400. Users can opt out via `PREFER_BRAVE_SEARCH=1` or `search_provider: brave` in PREFERENCES.md.

## Test plan
- [x] `npm run test:unit` — 6977 pass, 0 new failures (1 unrelated pre-existing welcome-screen flake on main).
- [x] `packages/pi-ai/.../api-family.test.ts` — 10/10 pass, enumerates every registered `api` value from `register-builtins.ts`.
- [x] `src/tests/native-search.test.ts` — 39/39 pass (35 existing + 4 new #4478 regressions).
- [x] `src/tests/provider-equality-allowlist.test.ts` — 2/2 pass (hits + no-stale-entries).
- [ ] Manual: authenticate via Claude Code OAuth, run `/gsd auto` under a per-phase model config, confirm no Brave warning and that `web_search_20250305` appears in the Anthropic request payload.

## Follow-ups
- #4384 (flat-rate provider classification) can adopt these helpers.
- Pre-existing `packages/pi-ai/src/providers/anthropic-shared.ts` TS2322 error (`xhigh` thinking effort) breaks `build:pi` without `--noEmitOnError false`; unrelated but worth a separate fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detection now uses model API shape to more accurately enable native Anthropic search and related UI hints.

* **Bug Fixes**
  * More reliable web-search behavior across Anthropic-fronting transports; prevents incorrect tool injections for incompatible transports.

* **Tests**
  * Added tests validating API-family classification and enforce allowable provider-based comparisons.

* **Documentation**
  * Added ADR documenting API-shape vs provider guidance and the enforcement policy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->