### PR TITLE
fix(search): classify Anthropic models by api, not literal provider string

### DIFF
--- a/src/resources/extensions/search-the-web/command-search-provider.ts
+++ b/src/resources/extensions/search-the-web/command-search-provider.ts
@@ -19,6 +19,7 @@ import {
   resolveSearchProvider,
   type SearchProviderPreference,
 } from './provider.js'
+import { isAnthropicApi } from './native-search.js'
 
 const VALID_PREFERENCES: SearchProviderPreference[] = ['tavily', 'brave', 'ollama', 'auto']
 
@@ -90,7 +91,7 @@ export function registerSearchProviderCommand(pi: ExtensionAPI): void {
 
       setSearchProviderPreference(chosen)
       const effective = resolveSearchProvider()
-      const isAnthropic = ctx.model?.provider === 'anthropic'
+      const isAnthropic = isAnthropicApi(ctx.model)
       const nativeNote = isAnthropic ? '\nNote: Native Anthropic web search is also active (automatic, no API key needed).' : ''
       ctx.ui.notify(
         `Search provider set to ${chosen}. Effective provider: ${effective ?? 'none (no API keys)'}${nativeNote}`,

--- a/src/resources/extensions/search-the-web/native-search.ts
+++ b/src/resources/extensions/search-the-web/native-search.ts
@@ -36,6 +36,43 @@ export function preferBraveSearch(): boolean {
   return process.env.PREFER_BRAVE_SEARCH === "1" || process.env.PREFER_BRAVE_SEARCH === "true";
 }
 
+/**
+ * True when the model is served by an Anthropic-compatible API, regardless of
+ * which transport carries the request. Match on `api` (semantic, transport-
+ * agnostic) so we correctly classify all provider names that front genuine
+ * Anthropic models — `"anthropic"` (canonical SDK), `"claude-code"` (Claude
+ * Code OAuth), `"anthropic-vertex"` (Anthropic via Google Vertex), etc.
+ *
+ * Critical distinction: `provider`/`api` fields are *authoritative when
+ * present*. We only fall back to a model-name prefix heuristic when neither
+ * is supplied (e.g. session-restore paths where the SDK doesn't pass the
+ * resolved Model object). This protects against the Copilot/Bedrock case
+ * (#444) where a `claude-*` model name is served by a non-Anthropic
+ * transport — those must NOT be classified as Anthropic.
+ *
+ * See #4478 for the bug this helper fixes.
+ */
+export function isAnthropicApi(
+  model: { api?: string; provider?: string; id?: string; name?: string } | undefined | null,
+): boolean {
+  if (!model) return false;
+  // Primary: api field is the semantic, transport-agnostic signal.
+  if (model.api === "anthropic-messages" || model.api === "anthropic-vertex") return true;
+  // Secondary: known provider names that front Anthropic models when api is
+  // absent from the event payload (some legacy paths populate provider only).
+  if (model.provider === "anthropic" || model.provider === "claude-code") return true;
+  // If api OR provider was specified but did NOT match the Anthropic set
+  // above, trust that signal — the model is not Anthropic-served. Don't
+  // fall back to model-name heuristic, because Copilot/Bedrock can serve
+  // claude-* models without using the Anthropic API (#444).
+  if (model.api !== undefined || model.provider !== undefined) return false;
+  // Last resort: no api/provider info at all. Match on model-name prefix.
+  const modelName = typeof model.id === "string" ? model.id
+    : typeof model.name === "string" ? model.name
+    : "";
+  return modelName.startsWith("claude-");
+}
+
 /** Minimal interface matching the subset of ExtensionAPI we use */
 export interface NativeSearchPI {
   on(event: string, handler: (...args: any[]) => any): void;
@@ -94,7 +131,7 @@ export function registerNativeSearchHooks(pi: NativeSearchPI): { getIsAnthropic:
   pi.on("model_select", async (event: any, ctx: any) => {
     modelSelectFired = true;
     const wasAnthropic = isAnthropicProvider;
-    isAnthropicProvider = event.model.provider === "anthropic";
+    isAnthropicProvider = isAnthropicApi(event.model);
 
     const hasBrave = !!process.env.BRAVE_API_KEY;
 
@@ -134,20 +171,22 @@ export function registerNativeSearchHooks(pi: NativeSearchPI): { getIsAnthropic:
     const payload = event.payload as Record<string, unknown>;
     if (!payload) return;
 
-    // Detect Anthropic provider. Use the model object from the event (most
-    // reliable — comes directly from the resolved Model), then fall back to
-    // the model_select flag, then to the model name heuristic (last resort).
-    // The model name heuristic is needed for session restores where
-    // modelsAreEqual suppresses model_select AND the SDK doesn't pass model.
-    const eventModel = event.model as { provider: string } | undefined;
+    // Detect Anthropic-served model. Use the resolved Model object from the
+    // event when available (most reliable), then fall back to the cached
+    // model_select state, then to a model-name heuristic on the payload as a
+    // last resort. The model-name fallback is needed for session restores
+    // where modelsAreEqual suppresses model_select AND the SDK doesn't pass
+    // the resolved Model. All paths route through `isAnthropicApi` so the
+    // classification stays consistent across transports (#4478).
+    const eventModel = event.model as { api?: string; provider?: string; id?: string; name?: string } | undefined;
     let isAnthropic: boolean;
-    if (eventModel?.provider) {
-      isAnthropic = eventModel.provider === "anthropic";
+    if (eventModel) {
+      isAnthropic = isAnthropicApi(eventModel);
     } else if (modelSelectFired) {
       isAnthropic = isAnthropicProvider;
     } else {
       const modelName = typeof payload.model === "string" ? payload.model : "";
-      isAnthropic = modelName.startsWith("claude-");
+      isAnthropic = isAnthropicApi({ id: modelName });
     }
     if (!isAnthropic) return;
 

--- a/src/tests/native-search.test.ts
+++ b/src/tests/native-search.test.ts
@@ -1013,3 +1013,138 @@ test("stripThinkingFromHistory handles string content (no array)", () => {
   stripThinkingFromHistory(messages);
   assert.equal(messages[1].content, "just a string");
 });
+
+// ─── Regression tests for #4478 ────────────────────────────────────────────
+// Provider classification must match on api/model-name, not on a literal
+// `provider === "anthropic"` string compare. Otherwise users on claude-code
+// OAuth (provider: "claude-code", api: "anthropic-messages") get the Brave
+// warning AND lose native web_search injection.
+
+test("#4478 isAnthropicApi recognizes claude-code provider with anthropic-messages api", async () => {
+  const { isAnthropicApi } = await import(
+    "../resources/extensions/search-the-web/native-search.ts"
+  );
+  assert.equal(
+    isAnthropicApi({ provider: "claude-code", api: "anthropic-messages", id: "claude-sonnet-4-6" }),
+    true,
+    "claude-code OAuth path must be classified as Anthropic",
+  );
+  assert.equal(
+    isAnthropicApi({ provider: "anthropic", api: "anthropic-messages", id: "claude-opus-4-7" }),
+    true,
+    "canonical anthropic provider must remain classified as Anthropic",
+  );
+  assert.equal(
+    isAnthropicApi({ provider: "anthropic-vertex", api: "anthropic-vertex", id: "claude-sonnet-4-6" }),
+    true,
+    "anthropic-vertex transport must be classified as Anthropic",
+  );
+  assert.equal(
+    isAnthropicApi({ provider: "openai", api: "openai-completions", id: "gpt-4o" }),
+    false,
+    "non-Anthropic providers must not be classified as Anthropic",
+  );
+  assert.equal(
+    isAnthropicApi(undefined),
+    false,
+    "undefined model must return false (no false positives on missing data)",
+  );
+  assert.equal(
+    isAnthropicApi({ id: "claude-sonnet-4-6" }),
+    true,
+    "model-name prefix fallback must work when api/provider are absent",
+  );
+  assert.equal(
+    isAnthropicApi({ id: "gpt-4o" }),
+    false,
+    "model-name fallback must reject non-Claude prefixes",
+  );
+});
+
+test("#4478 model_select for claude-code provider does NOT fire Brave warning", async () => {
+  const pi = createMockPI();
+  registerNativeSearchHooks(pi);
+
+  // Ensure no BRAVE_API_KEY in env for this assertion
+  const savedBrave = process.env.BRAVE_API_KEY;
+  delete process.env.BRAVE_API_KEY;
+
+  try {
+    await pi.fire("model_select", {
+      type: "model_select",
+      model: { provider: "claude-code", api: "anthropic-messages", id: "claude-sonnet-4-6" },
+      previousModel: undefined,
+      source: "set",
+    });
+
+    const warnings = pi.notifications.filter((n) => n.level === "warning");
+    assert.equal(
+      warnings.length,
+      0,
+      `claude-code provider should not trigger Brave warning. Got: ${JSON.stringify(warnings)}`,
+    );
+
+    const infos = pi.notifications.filter((n) => n.level === "info");
+    assert.ok(
+      infos.some((n) => n.message === "Native Anthropic web search active"),
+      "claude-code provider should emit 'Native Anthropic web search active' info notification",
+    );
+  } finally {
+    if (savedBrave !== undefined) process.env.BRAVE_API_KEY = savedBrave;
+  }
+});
+
+test("#4478 model_select for claude-code provider disables custom search tools", async () => {
+  const pi = createMockPI();
+  registerNativeSearchHooks(pi);
+
+  // Confirm tools start with custom search tools active
+  assert.ok(pi.getActiveTools().includes("search-the-web"));
+  assert.ok(pi.getActiveTools().includes("google_search"));
+
+  await pi.fire("model_select", {
+    type: "model_select",
+    model: { provider: "claude-code", api: "anthropic-messages", id: "claude-sonnet-4-6" },
+    previousModel: undefined,
+    source: "set",
+  });
+
+  const active = pi.getActiveTools();
+  for (const name of CUSTOM_SEARCH_TOOL_NAMES) {
+    assert.ok(
+      !active.includes(name),
+      `Custom search tool '${name}' should be disabled when claude-code (Anthropic-fronting) provider is active`,
+    );
+  }
+});
+
+test("#4478 before_provider_request injects native web_search for claude-code provider", async () => {
+  const pi = createMockPI();
+  registerNativeSearchHooks(pi);
+
+  // model_select first to populate isAnthropicProvider state
+  await pi.fire("model_select", {
+    type: "model_select",
+    model: { provider: "claude-code", api: "anthropic-messages", id: "claude-sonnet-4-6" },
+    previousModel: undefined,
+    source: "set",
+  });
+
+  const payload: Record<string, unknown> = {
+    model: "claude-sonnet-4-6",
+    tools: [{ name: "bash", type: "custom" }],
+  };
+
+  await pi.fire("before_provider_request", {
+    type: "before_provider_request",
+    model: { provider: "claude-code", api: "anthropic-messages", id: "claude-sonnet-4-6" },
+    payload,
+  });
+
+  const tools = payload.tools as any[];
+  const nativeTool = tools.find((t: any) => t.type === "web_search_20250305");
+  assert.ok(
+    nativeTool,
+    "Should inject web_search_20250305 tool for claude-code provider (anthropic-messages api)",
+  );
+});


### PR DESCRIPTION
## Linked issue

Closes #4478

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Replace `event.model.provider === "anthropic"` literal-string check at three sites in `search-the-web/` with a shared `isAnthropicApi(model)` helper that matches on `model.api` (semantic, transport-agnostic).
**Why:** Users on `claude-code` OAuth (and `anthropic-vertex`, etc.) were getting the Brave warning every model_select event AND losing native web_search injection — despite running genuine Anthropic models.
**How:** New helper exported from `native-search.ts`; `before_provider_request` and `command-search-provider`'s info note both route through it; preserves the #444 regression guard (Copilot/Bedrock serving `claude-*` models without the Anthropic API).

## What

Three files modified:

- `src/resources/extensions/search-the-web/native-search.ts` — adds `isAnthropicApi(model)` helper and uses it at `model_select` (line 97) and `before_provider_request` (line 145).
- `src/resources/extensions/search-the-web/command-search-provider.ts` — uses the same helper for the `/search-provider` info note (line 93).
- `src/tests/native-search.test.ts` — four regression tests for the `claude-code` provider path.

`src/resources/extensions/gsd/auto-model-selection.ts:492` also uses `provider === "anthropic"` but is intentional (canonical-provider tie-breaker for model selection); not changed.

## Why

Detailed bug analysis in #4478. Short version:

- `claude-code` provider (Claude Code OAuth — the recommended path for Claude Pro/Max subscribers) always pairs with `api: "anthropic-messages"` (verified across `claude-code-cli/index.ts:22`, `stream-adapter.ts:352/679/1075/1244`, `partial-builder.ts:185`).
- The literal `provider === "anthropic"` check at `native-search.ts:97` returns `false` for it, classifying Claude-subscription users as "not Anthropic."
- Consequence: Brave warning fires on every model_select event AND `web_search_20250305` injection at line 132+ is skipped — leaving these users with no web search at all unless they pay for `BRAVE_API_KEY`.
- The same wrong check is duplicated at `:145` (before_provider_request — has a model-name fallback that masked it but is still semantically wrong) and at `command-search-provider.ts:93` (info note after `/search-provider` switch).

The closely-related #2027 was fixed in PR #2235 by changing `doctor-providers.ts` (a separate startup-doctor code path); the bug in `native-search.ts` was not addressed there and continues to fire.

## How

**`isAnthropicApi(model)` helper, layered detection:**

1. **Primary** — `model.api === "anthropic-messages" || model.api === "anthropic-vertex"`. Semantic, transport-agnostic, correct for all current Anthropic-fronting transports.
2. **Secondary** — `model.provider === "anthropic" || model.provider === "claude-code"`. Catches legacy event payloads that populate `provider` but not `api`.
3. **Authoritative-when-present guard** — if `api` OR `provider` was supplied but didn't match the Anthropic set above, return `false` immediately. **Critically does not fall back to model-name heuristic in this case.** This protects #444's regression test: GitHub Copilot serving `claude-sonnet-4-6` is NOT Anthropic-served and must not be classified as such, even though the model name starts with `claude-`.
4. **Last resort** — only when neither `api` nor `provider` is supplied (session-restore paths where the SDK doesn't pass the resolved Model), match on `model.id` / `model.name` prefix `claude-*`. Mirrors the prefix heuristic that already existed inline in `before_provider_request`.

The helper is exported so `command-search-provider.ts` can share the classification logic — three call sites, one source of truth.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — search-the-web extension
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included — 4 regression tests for #4478 covering helper unit semantics, model_select Brave-warning suppression for claude-code, custom-search-tool disable for claude-code, and before_provider_request injection for claude-code.
- [x] Manual testing — verified that `npm run test:compile && node --import ./scripts/dist-test-resolve.mjs --test dist-test/src/tests/native-search.test.js` passes all 39 tests (35 pre-existing + 4 new) on the fix branch. Type-check (`npx tsc --noEmit --project tsconfig.extensions.json`) clean.
- [ ] No tests needed — explained above

**Critical regression coverage preserved:**
- Pre-existing test `before_provider_request does NOT inject for claude model on non-Anthropic provider` (Copilot serving claude-*) — still passes because the helper trusts present-but-non-matching `provider` signals.
- Pre-existing test `before_provider_request does NOT inject when event.model indicates non-Anthropic provider (no model_select)` (#444 regression for github-copilot) — still passes for the same reason.

## AI disclosure

- [x] This PR includes AI-assisted code — drafted with Claude Code (Opus 4.7); tests (unit + tsc) run locally and pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of Anthropic models for native web search functionality, with better support for different Anthropic API configurations.

* **Tests**
  * Added regression tests to verify Anthropic model detection and web search behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->