### PR TITLE
fix(gsd): migrate legacy db before bootstrap indexes

### DIFF
--- a/src/resources/extensions/gsd/gsd-db.ts
+++ b/src/resources/extensions/gsd/gsd-db.ts
@@ -557,6 +557,12 @@ function initSchema(db: DbAdapter, fileBacked: boolean): void {
     `);
 
     db.exec("CREATE INDEX IF NOT EXISTS idx_memories_active ON memories(superseded_by)");
+
+    // Existing DBs may arrive here before migrateSchema() has added columns
+    // that fresh installs already have. Add only columns needed by bootstrap
+    // indexes so old DBs can open far enough for the normal migration chain.
+    ensureBootstrapIndexColumns(db);
+
     db.exec("CREATE INDEX IF NOT EXISTS idx_memories_scope ON memories(scope)");
     db.exec("CREATE INDEX IF NOT EXISTS idx_memory_sources_kind ON memory_sources(kind)");
     db.exec("CREATE INDEX IF NOT EXISTS idx_memory_sources_scope ON memory_sources(scope)");
@@ -663,6 +669,14 @@ export function isMemoriesFtsAvailable(db: DbAdapter): boolean {
 
 function ensureColumn(db: DbAdapter, table: string, column: string, ddl: string): void {
   if (!columnExists(db, table, column)) db.exec(ddl);
+}
+
+function ensureBootstrapIndexColumns(db: DbAdapter): void {
+  ensureColumn(db, "memories", "scope", `ALTER TABLE memories ADD COLUMN scope TEXT NOT NULL DEFAULT 'project'`);
+  ensureColumn(db, "memories", "tags", `ALTER TABLE memories ADD COLUMN tags TEXT NOT NULL DEFAULT '[]'`);
+  ensureColumn(db, "memory_sources", "scope", `ALTER TABLE memory_sources ADD COLUMN scope TEXT NOT NULL DEFAULT 'project'`);
+  ensureColumn(db, "memory_sources", "tags", `ALTER TABLE memory_sources ADD COLUMN tags TEXT NOT NULL DEFAULT '[]'`);
+  ensureColumn(db, "tasks", "escalation_pending", `ALTER TABLE tasks ADD COLUMN escalation_pending INTEGER NOT NULL DEFAULT 0`);
 }
 
 function migrateSchema(db: DbAdapter): void {

--- a/src/resources/extensions/gsd/tests/ensure-db-open.test.ts
+++ b/src/resources/extensions/gsd/tests/ensure-db-open.test.ts
@@ -10,7 +10,10 @@ import assert from 'node:assert/strict';
 import * as path from 'node:path';
 import * as os from 'node:os';
 import * as fs from 'node:fs';
-import { closeDatabase, isDbAvailable, getDecisionById } from '../gsd-db.ts';
+import { createRequire } from 'node:module';
+import { closeDatabase, isDbAvailable, getDecisionById, _getAdapter } from '../gsd-db.ts';
+
+const _require = createRequire(import.meta.url);
 
 function makeTmpDir(): string {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-ensure-db-'));
@@ -21,6 +24,263 @@ function cleanupDir(dir: string): void {
   try {
     fs.rmSync(dir, { recursive: true, force: true });
   } catch { /* swallow */ }
+}
+
+function createLegacyV15Db(dbPath: string): void {
+  const sqlite = _require('node:sqlite');
+  const db = new sqlite.DatabaseSync(dbPath);
+  db.exec('PRAGMA journal_mode=WAL');
+  db.exec(`
+    CREATE TABLE schema_version (
+      version INTEGER NOT NULL,
+      applied_at TEXT NOT NULL
+    );
+    INSERT INTO schema_version (version, applied_at) VALUES (15, '2026-01-01T00:00:00.000Z');
+
+    CREATE TABLE decisions (
+      seq INTEGER PRIMARY KEY AUTOINCREMENT,
+      id TEXT NOT NULL UNIQUE,
+      when_context TEXT NOT NULL DEFAULT '',
+      scope TEXT NOT NULL DEFAULT '',
+      decision TEXT NOT NULL DEFAULT '',
+      choice TEXT NOT NULL DEFAULT '',
+      rationale TEXT NOT NULL DEFAULT '',
+      revisable TEXT NOT NULL DEFAULT '',
+      made_by TEXT NOT NULL DEFAULT 'agent',
+      superseded_by TEXT DEFAULT NULL
+    );
+
+    CREATE TABLE requirements (
+      id TEXT PRIMARY KEY,
+      class TEXT NOT NULL DEFAULT '',
+      status TEXT NOT NULL DEFAULT '',
+      description TEXT NOT NULL DEFAULT '',
+      why TEXT NOT NULL DEFAULT '',
+      source TEXT NOT NULL DEFAULT '',
+      primary_owner TEXT NOT NULL DEFAULT '',
+      supporting_slices TEXT NOT NULL DEFAULT '',
+      validation TEXT NOT NULL DEFAULT '',
+      notes TEXT NOT NULL DEFAULT '',
+      full_content TEXT NOT NULL DEFAULT '',
+      superseded_by TEXT DEFAULT NULL
+    );
+
+    CREATE TABLE artifacts (
+      path TEXT PRIMARY KEY,
+      artifact_type TEXT NOT NULL DEFAULT '',
+      milestone_id TEXT DEFAULT NULL,
+      slice_id TEXT DEFAULT NULL,
+      task_id TEXT DEFAULT NULL,
+      full_content TEXT NOT NULL DEFAULT '',
+      imported_at TEXT NOT NULL DEFAULT ''
+    );
+
+    CREATE TABLE memories (
+      seq INTEGER PRIMARY KEY AUTOINCREMENT,
+      id TEXT NOT NULL UNIQUE,
+      category TEXT NOT NULL,
+      content TEXT NOT NULL,
+      confidence REAL NOT NULL DEFAULT 0.8,
+      source_unit_type TEXT,
+      source_unit_id TEXT,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      superseded_by TEXT DEFAULT NULL,
+      hit_count INTEGER NOT NULL DEFAULT 0
+    );
+
+    CREATE TABLE memory_processed_units (
+      unit_key TEXT PRIMARY KEY,
+      activity_file TEXT,
+      processed_at TEXT NOT NULL
+    );
+
+    CREATE TABLE milestones (
+      id TEXT PRIMARY KEY,
+      title TEXT NOT NULL DEFAULT '',
+      status TEXT NOT NULL DEFAULT 'active',
+      depends_on TEXT NOT NULL DEFAULT '[]',
+      created_at TEXT NOT NULL DEFAULT '',
+      completed_at TEXT DEFAULT NULL,
+      vision TEXT NOT NULL DEFAULT '',
+      success_criteria TEXT NOT NULL DEFAULT '[]',
+      key_risks TEXT NOT NULL DEFAULT '[]',
+      proof_strategy TEXT NOT NULL DEFAULT '[]',
+      verification_contract TEXT NOT NULL DEFAULT '',
+      verification_integration TEXT NOT NULL DEFAULT '',
+      verification_operational TEXT NOT NULL DEFAULT '',
+      verification_uat TEXT NOT NULL DEFAULT '',
+      definition_of_done TEXT NOT NULL DEFAULT '[]',
+      requirement_coverage TEXT NOT NULL DEFAULT '',
+      boundary_map_markdown TEXT NOT NULL DEFAULT ''
+    );
+
+    CREATE TABLE slices (
+      milestone_id TEXT NOT NULL,
+      id TEXT NOT NULL,
+      title TEXT NOT NULL DEFAULT '',
+      status TEXT NOT NULL DEFAULT 'pending',
+      risk TEXT NOT NULL DEFAULT 'medium',
+      depends TEXT NOT NULL DEFAULT '[]',
+      demo TEXT NOT NULL DEFAULT '',
+      created_at TEXT NOT NULL DEFAULT '',
+      completed_at TEXT DEFAULT NULL,
+      full_summary_md TEXT NOT NULL DEFAULT '',
+      full_uat_md TEXT NOT NULL DEFAULT '',
+      goal TEXT NOT NULL DEFAULT '',
+      success_criteria TEXT NOT NULL DEFAULT '',
+      proof_level TEXT NOT NULL DEFAULT '',
+      integration_closure TEXT NOT NULL DEFAULT '',
+      observability_impact TEXT NOT NULL DEFAULT '',
+      sequence INTEGER DEFAULT 0,
+      replan_triggered_at TEXT DEFAULT NULL,
+      PRIMARY KEY (milestone_id, id)
+    );
+
+    CREATE TABLE tasks (
+      milestone_id TEXT NOT NULL,
+      slice_id TEXT NOT NULL,
+      id TEXT NOT NULL,
+      title TEXT NOT NULL DEFAULT '',
+      status TEXT NOT NULL DEFAULT 'pending',
+      one_liner TEXT NOT NULL DEFAULT '',
+      narrative TEXT NOT NULL DEFAULT '',
+      verification_result TEXT NOT NULL DEFAULT '',
+      duration TEXT NOT NULL DEFAULT '',
+      completed_at TEXT DEFAULT NULL,
+      blocker_discovered INTEGER DEFAULT 0,
+      deviations TEXT NOT NULL DEFAULT '',
+      known_issues TEXT NOT NULL DEFAULT '',
+      key_files TEXT NOT NULL DEFAULT '[]',
+      key_decisions TEXT NOT NULL DEFAULT '[]',
+      full_summary_md TEXT NOT NULL DEFAULT '',
+      description TEXT NOT NULL DEFAULT '',
+      estimate TEXT NOT NULL DEFAULT '',
+      files TEXT NOT NULL DEFAULT '[]',
+      verify TEXT NOT NULL DEFAULT '',
+      inputs TEXT NOT NULL DEFAULT '[]',
+      expected_output TEXT NOT NULL DEFAULT '[]',
+      observability_impact TEXT NOT NULL DEFAULT '',
+      full_plan_md TEXT NOT NULL DEFAULT '',
+      sequence INTEGER DEFAULT 0,
+      PRIMARY KEY (milestone_id, slice_id, id)
+    );
+
+    CREATE TABLE verification_evidence (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      task_id TEXT NOT NULL DEFAULT '',
+      slice_id TEXT NOT NULL DEFAULT '',
+      milestone_id TEXT NOT NULL DEFAULT '',
+      command TEXT NOT NULL DEFAULT '',
+      exit_code INTEGER DEFAULT 0,
+      verdict TEXT NOT NULL DEFAULT '',
+      duration_ms INTEGER DEFAULT 0,
+      created_at TEXT NOT NULL DEFAULT ''
+    );
+
+    CREATE TABLE replan_history (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      milestone_id TEXT NOT NULL DEFAULT '',
+      slice_id TEXT DEFAULT NULL,
+      task_id TEXT DEFAULT NULL,
+      summary TEXT NOT NULL DEFAULT '',
+      previous_artifact_path TEXT DEFAULT NULL,
+      replacement_artifact_path TEXT DEFAULT NULL,
+      created_at TEXT NOT NULL DEFAULT ''
+    );
+
+    CREATE TABLE assessments (
+      path TEXT PRIMARY KEY,
+      milestone_id TEXT NOT NULL DEFAULT '',
+      slice_id TEXT DEFAULT NULL,
+      task_id TEXT DEFAULT NULL,
+      status TEXT NOT NULL DEFAULT '',
+      scope TEXT NOT NULL DEFAULT '',
+      full_content TEXT NOT NULL DEFAULT '',
+      created_at TEXT NOT NULL DEFAULT ''
+    );
+
+    CREATE TABLE quality_gates (
+      milestone_id TEXT NOT NULL,
+      slice_id TEXT NOT NULL,
+      gate_id TEXT NOT NULL,
+      scope TEXT NOT NULL DEFAULT 'slice',
+      task_id TEXT NOT NULL DEFAULT '',
+      status TEXT NOT NULL DEFAULT 'pending',
+      verdict TEXT NOT NULL DEFAULT '',
+      rationale TEXT NOT NULL DEFAULT '',
+      findings TEXT NOT NULL DEFAULT '',
+      evaluated_at TEXT DEFAULT NULL,
+      PRIMARY KEY (milestone_id, slice_id, gate_id, task_id)
+    );
+
+    CREATE TABLE slice_dependencies (
+      milestone_id TEXT NOT NULL,
+      slice_id TEXT NOT NULL,
+      depends_on_slice_id TEXT NOT NULL,
+      PRIMARY KEY (milestone_id, slice_id, depends_on_slice_id)
+    );
+
+    CREATE TABLE gate_runs (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      trace_id TEXT NOT NULL,
+      turn_id TEXT NOT NULL,
+      gate_id TEXT NOT NULL,
+      gate_type TEXT NOT NULL DEFAULT '',
+      unit_type TEXT DEFAULT NULL,
+      unit_id TEXT DEFAULT NULL,
+      milestone_id TEXT DEFAULT NULL,
+      slice_id TEXT DEFAULT NULL,
+      task_id TEXT DEFAULT NULL,
+      outcome TEXT NOT NULL DEFAULT 'pass',
+      failure_class TEXT NOT NULL DEFAULT 'none',
+      rationale TEXT NOT NULL DEFAULT '',
+      findings TEXT NOT NULL DEFAULT '',
+      attempt INTEGER NOT NULL DEFAULT 1,
+      max_attempts INTEGER NOT NULL DEFAULT 1,
+      retryable INTEGER NOT NULL DEFAULT 0,
+      evaluated_at TEXT NOT NULL DEFAULT ''
+    );
+
+    CREATE TABLE turn_git_transactions (
+      trace_id TEXT NOT NULL,
+      turn_id TEXT NOT NULL,
+      unit_type TEXT DEFAULT NULL,
+      unit_id TEXT DEFAULT NULL,
+      stage TEXT NOT NULL DEFAULT 'turn-start',
+      action TEXT NOT NULL DEFAULT 'status-only',
+      push INTEGER NOT NULL DEFAULT 0,
+      status TEXT NOT NULL DEFAULT 'ok',
+      error TEXT DEFAULT NULL,
+      metadata_json TEXT NOT NULL DEFAULT '{}',
+      updated_at TEXT NOT NULL DEFAULT '',
+      PRIMARY KEY (trace_id, turn_id, stage)
+    );
+
+    CREATE TABLE audit_events (
+      event_id TEXT PRIMARY KEY,
+      trace_id TEXT NOT NULL,
+      turn_id TEXT DEFAULT NULL,
+      caused_by TEXT DEFAULT NULL,
+      category TEXT NOT NULL,
+      type TEXT NOT NULL,
+      ts TEXT NOT NULL,
+      payload_json TEXT NOT NULL DEFAULT '{}'
+    );
+
+    CREATE TABLE audit_turn_index (
+      trace_id TEXT NOT NULL,
+      turn_id TEXT NOT NULL,
+      first_ts TEXT NOT NULL,
+      last_ts TEXT NOT NULL,
+      event_count INTEGER NOT NULL DEFAULT 0,
+      PRIMARY KEY (trace_id, turn_id)
+    );
+  `);
+  db.exec('PRAGMA wal_checkpoint(TRUNCATE)');
+  db.close();
+  try { fs.unlinkSync(`${dbPath}-wal`); } catch { /* may not exist */ }
+  try { fs.unlinkSync(`${dbPath}-shm`); } catch { /* may not exist */ }
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -101,6 +361,51 @@ describe('ensure-db-open', () => {
       assert.equal(process.cwd(), originalCwd, 'ensureDbOpen should not mutate process.cwd');
       assert.ok(isDbAvailable(), 'DB should be available after explicit open');
       assert.ok(getDecisionById('D777') !== null, 'explicit basePath DB should be opened');
+    } finally {
+      closeDatabase();
+      cleanupDir(tmpDir);
+    }
+  });
+
+  test('ensureDbOpen: migrates legacy v15 DB before bootstrap indexes touch new columns', async () => {
+    const tmpDir = makeTmpDir();
+    const gsdDir = path.join(tmpDir, '.gsd');
+    fs.mkdirSync(gsdDir, { recursive: true });
+    const dbPath = path.join(gsdDir, 'gsd.db');
+    createLegacyV15Db(dbPath);
+
+    try {
+      closeDatabase();
+    } catch { /* ok */ }
+
+    try {
+      const { ensureDbOpen } = await import('../bootstrap/dynamic-tools.ts');
+      const result = await ensureDbOpen(tmpDir);
+
+      assert.equal(result, true, 'legacy v15 DB should open and migrate');
+      assert.ok(isDbAvailable(), 'DB should be available after migrating v15');
+
+      const db = _getAdapter();
+      assert.ok(db, 'adapter should be available after ensureDbOpen');
+      assert.equal(
+        db.prepare('SELECT MAX(version) as version FROM schema_version').get()?.version,
+        20,
+        'legacy DB should migrate to current schema version',
+      );
+
+      const memoryColumns = new Set(db.prepare('PRAGMA table_info(memories)').all().map((row) => row.name));
+      const taskColumns = new Set(db.prepare('PRAGMA table_info(tasks)').all().map((row) => row.name));
+      assert.ok(memoryColumns.has('scope'), 'memory scope column should be present');
+      assert.ok(memoryColumns.has('tags'), 'memory tags column should be present');
+      assert.ok(taskColumns.has('escalation_pending'), 'task escalation_pending column should be present');
+      assert.ok(
+        db.prepare("SELECT 1 as present FROM sqlite_master WHERE type = 'index' AND name = 'idx_memories_scope'").get(),
+        'memory scope index should be created after migration-safe bootstrap',
+      );
+      assert.ok(
+        db.prepare("SELECT 1 as present FROM sqlite_master WHERE type = 'index' AND name = 'idx_tasks_escalation_pending'").get(),
+        'task escalation index should be created after migration-safe bootstrap',
+      );
     } finally {
       closeDatabase();
       cleanupDir(tmpDir);


### PR DESCRIPTION
## Linked issue

Closes #4500
Closes #4502

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Makes DB bootstrap tolerant of legacy schema-v15 databases before creating indexes that reference newer columns.
**Why:** Legacy projects can otherwise fail to open with `db_unavailable` before the migration chain reaches the current schema.
**How:** Backfill only the columns required by bootstrap indexes, then let the normal migrations advance the database to the current schema version.

## What

This updates the GSD extension database bootstrap path so older `gsd.db` files can open far enough for migrations to run. It adds a small pre-index compatibility step for legacy databases whose `memories` and `tasks` tables predate newer index columns.

It also adds a regression test that constructs a legacy v15 database fixture, calls `ensureDbOpen()`, and verifies the DB migrates to schema v20 with the expected columns and indexes present.

## Why

The fresh-schema path creates indexes for current-schema columns. For an existing v15 database, `CREATE TABLE IF NOT EXISTS` leaves older tables unchanged, so bootstrap could try to create `memories(scope)` or `tasks(escalation_pending)` indexes before migrations had added those columns. That failure made DB-backed tools return `db_unavailable` instead of completing migration.

## How

The fix keeps the normal migration chain as the source of truth. Before creating bootstrap indexes, it only ensures the columns those indexes need already exist. The later migrations remain idempotent and still record the schema-version progression.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

Automated verification:

1. `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/ensure-db-open.test.ts`
2. `npm run typecheck:extensions`
3. `npm run build`

Manual smoke:

1. Created a throwaway copy of a legacy schema-v15 GSD database.
2. Opened it through `ensureDbOpen()` using this branch.
3. Confirmed it migrated to schema version 20 and gained the required memory/task columns.

Broader suite note: `npm run test:unit` currently hits a local-preferences-sensitive routing guard failure that also reproduces on clean `upstream/main` in this environment, so it is not caused by this DB migration diff.

## AI disclosure

- [x] This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed database initialization to ensure compatibility with legacy database versions by properly adding required schema columns during startup, enabling seamless migration to the latest schema version.

* **Tests**
  * Added test coverage for legacy database migration and schema validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->