### PR TITLE
fix(gsd): improve Windows Claude CLI detection and readiness fallback (#4503)

### DIFF
--- a/src/resources/extensions/claude-code-cli/readiness.ts
+++ b/src/resources/extensions/claude-code-cli/readiness.ts
@@ -14,11 +14,17 @@ import { execFileSync } from "node:child_process";
 /**
  * Candidate executable names for the Claude Code CLI.
  *
+ * Keep the explicit win32 ternary selector for regression coverage (Issue #4424):
+ * Node's execFileSync must target `claude.cmd` directly on Windows.
+ */
+const CLAUDE_COMMAND = process.platform === "win32" ? "claude.cmd" : "claude";
+
+/**
  * Windows installs vary: some environments expose `claude.cmd` (npm shim),
  * others expose a `claude` shim on PATH (for example Git Bash wrappers).
  * Try both to avoid false "not installed" results in readiness checks.
  */
-const CLAUDE_COMMAND_CANDIDATES = process.platform === "win32" ? ["claude.cmd", "claude"] : ["claude"];
+const CLAUDE_COMMAND_CANDIDATES = process.platform === "win32" ? [CLAUDE_COMMAND, "claude"] : [CLAUDE_COMMAND];
 
 function execClaude(args: string[]): Buffer {
 	let lastError: unknown;

--- a/src/resources/extensions/claude-code-cli/readiness.ts
+++ b/src/resources/extensions/claude-code-cli/readiness.ts
@@ -12,15 +12,32 @@
 import { execFileSync } from "node:child_process";
 
 /**
- * Platform-correct binary name for the Claude Code CLI.
+ * Candidate executable names for the Claude Code CLI.
  *
- * On Windows, npm-global binaries are installed as `.cmd` shims and
- * `execFileSync` does not auto-resolve the extension — calling bare
- * `claude` would fail with ENOENT even when the CLI is installed and
- * authenticated. Mirrors the `NPM_COMMAND` pattern in
- * `src/resources/extensions/gsd/pre-execution-checks.ts`.
+ * Windows installs vary: some environments expose `claude.cmd` (npm shim),
+ * others expose a `claude` shim on PATH (for example Git Bash wrappers).
+ * Try both to avoid false "not installed" results in readiness checks.
  */
-const CLAUDE_COMMAND = process.platform === "win32" ? "claude.cmd" : "claude";
+const CLAUDE_COMMAND_CANDIDATES = process.platform === "win32" ? ["claude.cmd", "claude"] : ["claude"];
+
+function execClaude(args: string[]): Buffer {
+	let lastError: unknown;
+	for (const command of CLAUDE_COMMAND_CANDIDATES) {
+		try {
+			return execFileSync(command, args, { timeout: 5_000, stdio: "pipe" });
+		} catch (error) {
+			lastError = error;
+			const code = (error as NodeJS.ErrnoException | undefined)?.code;
+			// Windows Git Bash can surface `.cmd` spawn failures as EINVAL instead
+			// of ENOENT. Treat both as "try next candidate".
+			if (code === "ENOENT" || code === "EINVAL") {
+				continue;
+			}
+			throw error;
+		}
+	}
+	throw lastError ?? new Error(`Claude CLI executable not found (tried: ${CLAUDE_COMMAND_CANDIDATES.join(", ")})`);
+}
 
 let cachedBinaryPresent: boolean | null = null;
 let cachedAuthed: boolean | null = null;
@@ -38,7 +55,7 @@ function refreshCache(): void {
 
 	// Check binary presence
 	try {
-		execFileSync(CLAUDE_COMMAND, ["--version"], { timeout: 5_000, stdio: "pipe" });
+		execClaude(["--version"]);
 		cachedBinaryPresent = true;
 	} catch {
 		cachedBinaryPresent = false;
@@ -48,7 +65,7 @@ function refreshCache(): void {
 
 	// Check auth status — exit code 0 with non-error output means authenticated
 	try {
-		const output = execFileSync(CLAUDE_COMMAND, ["auth", "status"], { timeout: 5_000, stdio: "pipe" })
+		const output = execClaude(["auth", "status"])
 			.toString()
 			.toLowerCase();
 		// The CLI outputs "not logged in", "no credentials", or similar when unauthenticated

--- a/src/resources/extensions/gsd/doctor-providers.ts
+++ b/src/resources/extensions/gsd/doctor-providers.ts
@@ -12,7 +12,7 @@
  */
 
 import { existsSync } from "node:fs";
-import { join } from "node:path";
+import { delimiter, join } from "node:path";
 import { AuthStorage } from "@gsd/pi-coding-agent";
 import { getEnvApiKey } from "@gsd/pi-ai";
 import { loadEffectiveGSDPreferences } from "./preferences.js";
@@ -167,8 +167,28 @@ const CLI_BINARY_MAP: Record<string, string> = {
 function isCliBinaryInPath(providerId: string): boolean {
   const binary = CLI_BINARY_MAP[providerId];
   if (!binary) return false;
-  const pathDirs = (process.env.PATH ?? "").split(":");
-  return pathDirs.some(dir => dir && existsSync(join(dir, binary)));
+
+  const pathDirs = (process.env.PATH ?? "").split(delimiter).filter(Boolean);
+
+  // On Windows, command shims are commonly installed as .cmd/.exe/.bat/.com.
+  // Scan PATHEXT candidates in addition to the bare binary name.
+  const executableNames: string[] = [binary];
+  if (process.platform === "win32") {
+    const rawPathExt = process.env.PATHEXT
+      ?.split(";")
+      .map(ext => ext.trim())
+      .filter(Boolean) ?? [];
+    const normalizedPathExt = rawPathExt.map(ext =>
+      ext.startsWith(".") ? ext.toLowerCase() : `.${ext.toLowerCase()}`,
+    );
+    const defaultExt = [".exe", ".cmd", ".bat", ".com"];
+    for (const ext of [...normalizedPathExt, ...defaultExt]) {
+      const candidate = `${binary}${ext}`;
+      if (!executableNames.includes(candidate)) executableNames.push(candidate);
+    }
+  }
+
+  return pathDirs.some(dir => executableNames.some(name => existsSync(join(dir, name))));
 }
 
 function resolveKey(providerId: string): KeyLookup {

--- a/src/resources/extensions/gsd/tests/doctor-providers.test.ts
+++ b/src/resources/extensions/gsd/tests/doctor-providers.test.ts
@@ -15,7 +15,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync, realpathSync, chmodSync } from "node:fs";
-import { join } from "node:path";
+import { delimiter, join } from "node:path";
 import { tmpdir } from "node:os";
 
 import {
@@ -640,13 +640,45 @@ test("runProviderChecks reports ok for Anthropic via claude-code binary in PATH"
     COPILOT_GITHUB_TOKEN: undefined,
     GH_TOKEN: undefined,
     GITHUB_TOKEN: undefined,
-    PATH: `${binDir}:${process.env.PATH ?? ""}`,
+    PATH: `${binDir}${delimiter}${process.env.PATH ?? ""}`,
   }, () => {
     try {
       const results = runProviderChecks();
       const anthropic = results.find(r => r.name === "anthropic");
       assert.ok(anthropic, "anthropic result should exist");
       assert.equal(anthropic!.status, "ok", "should be ok when claude CLI binary is in PATH");
+      assert.ok(anthropic!.message.toLowerCase().includes("claude"), "should mention claude-code as source");
+    } finally {
+      rmSync(tmpHome, { recursive: true, force: true });
+    }
+  });
+});
+
+test("runProviderChecks detects claude.cmd in PATH on Windows (#4503)", { skip: process.platform !== "win32" }, () => {
+  const tmpHome = realpathSync(mkdtempSync(join(tmpdir(), "gsd-providers-cc-win-route-home-")));
+  const binDir = join(tmpHome, "bin");
+  mkdirSync(binDir, { recursive: true });
+
+  // On Windows, users commonly install Claude via a .cmd shim.
+  const fakeClaudeCmd = join(binDir, "claude.cmd");
+  writeFileSync(fakeClaudeCmd, "@echo off\r\necho mock\r\n");
+
+  withEnv({
+    HOME: tmpHome,
+    ANTHROPIC_API_KEY: undefined,
+    ANTHROPIC_OAUTH_TOKEN: undefined,
+    COPILOT_GITHUB_TOKEN: undefined,
+    GH_TOKEN: undefined,
+    GITHUB_TOKEN: undefined,
+    // Explicitly use ';' to mirror Windows PATH entries.
+    PATH: `${binDir};${process.env.PATH ?? ""}`,
+    PATHEXT: ".COM;.EXE;.BAT;.CMD",
+  }, () => {
+    try {
+      const results = runProviderChecks();
+      const anthropic = results.find(r => r.name === "anthropic");
+      assert.ok(anthropic, "anthropic result should exist");
+      assert.equal(anthropic!.status, "ok", "should be ok when claude.cmd is in PATH");
       assert.ok(anthropic!.message.toLowerCase().includes("claude"), "should mention claude-code as source");
     } finally {
       rmSync(tmpHome, { recursive: true, force: true });


### PR DESCRIPTION
## TL;DR

**What:** Improve Windows Claude CLI detection in provider doctor and add readiness fallback when `claude.cmd` spawn fails.
**Why:** Issue #4503 showed false negatives / launch failures on Windows environments where CLI resolution differs.
**How:** Updated provider doctor path detection logic + added readiness fallback behavior, with regression coverage for doctor providers.

## What

This PR includes:

- `src/resources/extensions/gsd/doctor-providers.ts`
  - expands Windows Claude CLI detection behavior for provider doctor checks.
- `src/resources/extensions/gsd/tests/doctor-providers.test.ts`
  - adds/updates regression tests covering the new detection behavior.
- `src/resources/extensions/claude-code-cli/readiness.ts`
  - adds fallback handling when `claude.cmd` spawn fails on Windows so readiness can still resolve via shim path.

## Why

Windows users could hit CLI detection/readiness edge-cases that caused provider doctor warnings or readiness failures despite Claude being available. This change tightens detection and fallback handling to address the #4503 failure mode.

Fixes #4503

## How

- Keep doctor checks resilient to Windows-specific executable resolution.
- Add explicit fallback path in claude-code readiness when `claude.cmd` invocation fails.
- Lock behavior with regression tests in the GSD doctor provider suite.

## Validation

- ✅ Dedicated branch used (`fix/issue-4503-claude-windows-path`)
- ✅ Conventional commits used
- ✅ Scope limited to issue-related files

## Change type checklist

- [x] `fix` — Bug fix
- [ ] `feat` — New feature or capability
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## AI-assisted

This PR was prepared with AI assistance.
