### PR TITLE
fix(gsd): honor models.json keys in provider doctor

### DIFF
--- a/src/resources/extensions/gsd/doctor-providers.ts
+++ b/src/resources/extensions/gsd/doctor-providers.ts
@@ -11,7 +11,7 @@
  *   - Optional search/tool integrations (Brave, Tavily, Jina, Context7)
  */
 
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { delimiter, join } from "node:path";
 import { AuthStorage } from "@gsd/pi-coding-agent";
 import { getEnvApiKey } from "@gsd/pi-ai";
@@ -72,7 +72,8 @@ function modelToProviderId(model: string): string | null {
 
   // Explicit provider prefix (e.g. "openrouter/deepseek-r1")
   if (model.includes("/")) {
-    const prefix = model.split("/")[0].toLowerCase();
+    const rawPrefix = model.split("/")[0];
+    const prefix = rawPrefix.toLowerCase();
     // Map known prefixes to registry IDs
     const prefixMap: Record<string, string> = {
       "anthropic-vertex": "anthropic-vertex",
@@ -86,6 +87,7 @@ function modelToProviderId(model: string): string | null {
       "github-copilot": "github-copilot",
     };
     if (prefixMap[prefix]) return prefixMap[prefix];
+    return rawPrefix;
   }
 
   const lower = model.toLowerCase();
@@ -145,7 +147,7 @@ function collectConfiguredModelProviders(): Set<string> {
 
 interface KeyLookup {
   found: boolean;
-  source: "auth.json" | "env" | "none";
+  source: "auth.json" | "env" | "models.json" | "none";
   backedOff: boolean;
 }
 
@@ -189,6 +191,33 @@ function isCliBinaryInPath(providerId: string): boolean {
   }
 
   return pathDirs.some(dir => executableNames.some(name => existsSync(join(dir, name))));
+}
+
+function modelsJsonPaths(): string[] {
+  const home = process.env.HOME ?? "~";
+  return [
+    join(home, ".gsd", "agent", "models.json"),
+    // Keep parity with custom-provider discovery during auto bootstrap.
+    join(home, ".pi", "agent", "models.json"),
+  ];
+}
+
+function hasModelsJsonApiKey(providerId: string): boolean {
+  for (const path of modelsJsonPaths()) {
+    if (!existsSync(path)) continue;
+    try {
+      const parsed = JSON.parse(readFileSync(path, "utf-8")) as {
+        providers?: Record<string, { apiKey?: unknown }>;
+      };
+      const apiKey = parsed.providers?.[providerId]?.apiKey;
+      if (typeof apiKey === "string" && apiKey.trim().length > 0) {
+        return true;
+      }
+    } catch {
+      // Malformed models.json should not break the dashboard health check.
+    }
+  }
+  return false;
 }
 
 function resolveKey(providerId: string): KeyLookup {
@@ -239,6 +268,10 @@ function resolveKey(providerId: string): KeyLookup {
   // (e.g., search providers like Brave, Tavily; tool providers like Jina, Context7)
   if (info?.envVar && process.env[info.envVar]) {
     return { found: true, source: "env", backedOff: false };
+  }
+
+  if (hasModelsJsonApiKey(providerId)) {
+    return { found: true, source: "models.json", backedOff: false };
   }
 
   return { found: false, source: "none", backedOff: false };

--- a/src/resources/extensions/gsd/tests/doctor-providers.test.ts
+++ b/src/resources/extensions/gsd/tests/doctor-providers.test.ts
@@ -327,6 +327,88 @@ test("runProviderChecks ignores empty placeholder keys in auth.json", () => {
   rmSync(tmpHome, { recursive: true, force: true });
 });
 
+test("runProviderChecks detects custom provider keys from models.json", () => {
+  const tmpHome = realpathSync(mkdtempSync(join(tmpdir(), "gsd-providers-custom-home-")));
+  const repo = realpathSync(mkdtempSync(join(tmpdir(), "gsd-providers-custom-repo-")));
+  const agentDir = join(tmpHome, ".gsd", "agent");
+  mkdirSync(agentDir, { recursive: true });
+  mkdirSync(join(repo, ".gsd"), { recursive: true });
+
+  writeFileSync(
+    join(repo, ".gsd", "PREFERENCES.md"),
+    [
+      "---",
+      "models:",
+      "  execution:",
+      "    model: custom-model",
+      "    provider: custom-provider",
+      "---",
+      "",
+    ].join("\n"),
+  );
+  writeFileSync(join(agentDir, "models.json"), JSON.stringify({
+    providers: {
+      "custom-provider": {
+        api: "openai-completions",
+        apiKey: "x",
+        baseUrl: "https://example.invalid/v1",
+        models: [{ id: "custom-model", name: "Custom Model" }],
+      },
+    },
+  }));
+
+  withEnv({
+    HOME: tmpHome,
+    CUSTOM_PROVIDER_API_KEY: undefined,
+    PATH: tmpHome,
+  }, () => {
+    withCwd(repo, () => {
+      const results = runProviderChecks();
+      const custom = results.find(r => r.name === "custom-provider");
+      assert.ok(custom, "custom provider result should exist");
+      assert.equal(custom!.status, "ok", "models.json apiKey should satisfy custom provider auth");
+      assert.ok(custom!.message.includes("models.json"), "should report models.json source");
+      assert.equal(summariseProviderIssues(results), null, "custom models.json key should not raise dashboard warning");
+    });
+  });
+
+  rmSync(repo, { recursive: true, force: true });
+  rmSync(tmpHome, { recursive: true, force: true });
+});
+
+test("runProviderChecks reports missing custom provider key without models.json apiKey", () => {
+  const tmpHome = realpathSync(mkdtempSync(join(tmpdir(), "gsd-providers-custom-missing-home-")));
+  const repo = realpathSync(mkdtempSync(join(tmpdir(), "gsd-providers-custom-missing-repo-")));
+  mkdirSync(join(repo, ".gsd"), { recursive: true });
+
+  writeFileSync(
+    join(repo, ".gsd", "PREFERENCES.md"),
+    [
+      "---",
+      "models:",
+      "  execution: custom-provider/custom-model",
+      "---",
+      "",
+    ].join("\n"),
+  );
+
+  withEnv({
+    HOME: tmpHome,
+    CUSTOM_PROVIDER_API_KEY: undefined,
+    PATH: tmpHome,
+  }, () => {
+    withCwd(repo, () => {
+      const results = runProviderChecks();
+      const custom = results.find(r => r.name === "custom-provider");
+      assert.ok(custom, "provider-qualified custom model should be checked");
+      assert.equal(custom!.status, "error", "missing custom provider key should still be reported");
+    });
+  });
+
+  rmSync(repo, { recursive: true, force: true });
+  rmSync(tmpHome, { recursive: true, force: true });
+});
+
 // ─── runProviderChecks — cross-provider routing ──────────────────────────────
 
 test("runProviderChecks reports ok for Anthropic when GitHub Copilot env var is set", () => {
@@ -517,7 +599,7 @@ test("runProviderChecks reports ok for Google via google-gemini-cli auth.json (#
 
   // google-gemini-cli OAuth in auth.json (no google API key)
   const authData = {
-    "google-gemini-cli": { type: "oauth", apiKey: "ya29.gemini-cli-token", expires: Date.now() + 3_600_000 },
+    "google-gemini-cli": { type: "oauth", expires: Date.now() + 3_600_000 },
   };
   writeFileSync(join(agentDir, "auth.json"), JSON.stringify(authData));
 


### PR DESCRIPTION
## Linked issue

Closes #4509

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Provider doctor now recognizes custom provider credentials stored in `models.json`.
**Why:** The dashboard could show a false `key missing` warning even though runtime model resolution could use the custom provider successfully.
**How:** The provider check now reads non-empty provider `apiKey` values from `models.json` and treats unknown `provider/model` prefixes as custom provider IDs.

## What

This updates the GSD provider health check so required custom providers can be satisfied by the same local `models.json` credential source used by runtime model resolution. It also adds regression coverage for both object-form provider preferences and provider-qualified custom model strings.

The touched test file also replaces an older secret-looking OAuth fixture with a neutral fixture shape so the staged secret scan can pass cleanly.

## Why

Custom providers can be configured entirely through `models.json`. Before this change, the dashboard/provider doctor only checked `auth.json` and environment variables, so it could report a missing key for a provider that was actually runnable.

## How

The fix keeps the doctor check lightweight and local-only:

- infer unknown `provider/model` prefixes as custom provider IDs instead of dropping them
- check `models.json` provider entries for a non-empty `apiKey`
- report `models.json` as the credential source when that local config satisfies the provider
- preserve the existing missing-key behavior when no custom provider key is present

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

Automated verification:

1. `npm run build`
2. `npm run typecheck:extensions`
3. `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/doctor-providers.test.ts`
4. `npm run secret-scan`

Manual before/after proof:

1. Added regression coverage for a custom provider configured through `models.json`.
2. Before the implementation change, the new custom-provider cases failed with a missing-key/error result.
3. After the implementation change, the same focused test file passes and the dashboard summary is clear for the configured custom provider.

Broader suite note:

`npm run test:unit` was also attempted. It currently fails in `flat-rate-routing-guard.test.ts` under my local global preference setup, and the same failing scope reproduces on clean `upstream/main`; this PR does not introduce that failure.

## AI disclosure

- [x] This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API credential detection now includes support for agent configuration files (models.json) in user home directories.
  * Improved model identifier parsing for values containing “/”: unknown prefixes are preserved and known prefixes map correctly.

* **Tests**
  * Added tests covering custom provider detection from agent config and repository preferences; updated cross-provider routing test scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->