### PR TITLE
fix(gsd): return blocked on stuck needs-remediation (#4506)

### DIFF
--- a/src/resources/extensions/gsd/state.ts
+++ b/src/resources/extensions/gsd/state.ts
@@ -613,12 +613,30 @@ async function handleAllSlicesDone(
   const validationTerminal = validationContent ? isValidationTerminal(validationContent) : false;
   const verdict = validationContent ? extractVerdict(validationContent) : undefined;
 
-  if (!validationTerminal || verdict === 'needs-remediation') {
+  if (!validationTerminal) {
     return {
       activeMilestone, activeSlice: null, activeTask: null,
       phase: 'validating-milestone',
       recentDecisions: [], blockers: [],
       nextAction: `Validate milestone ${activeMilestone.id} before completion.`,
+      registry, requirements,
+      progress: { milestones: milestoneProgress, slices: sliceProgress },
+    };
+  }
+
+  // All roadmap slices are done (enforced by caller) and verdict is
+  // needs-remediation — remediation cannot progress without new slices.
+  // Return blocked instead of re-dispatching validate-milestone (#4506).
+  if (verdict === 'needs-remediation') {
+    return {
+      activeMilestone, activeSlice: null, activeTask: null,
+      phase: 'blocked',
+      recentDecisions: [],
+      blockers: [
+        `Milestone ${activeMilestone.id} validation verdict is needs-remediation but all slices are complete. ` +
+          `Add remediation slices via gsd_reassess_roadmap or override the verdict manually.`,
+      ],
+      nextAction: `Resolve ${activeMilestone.id} remediation before proceeding.`,
       registry, requirements,
       progress: { milestones: milestoneProgress, slices: sliceProgress },
     };
@@ -1450,9 +1468,11 @@ export async function _deriveStateImpl(basePath: string): Promise<GSDState> {
       total: activeRoadmap.slices.length,
     };
 
-    // Force re-validation when verdict is needs-remediation — remediation slices
-    // may have completed since the stale validation was written (#3596).
-    if (!validationTerminal || verdict === 'needs-remediation') {
+    // Force re-validation when VALIDATION.md is absent or non-terminal —
+    // remediation slices may have completed since the stale validation was
+    // written (#3596). But needs-remediation with all slices done is a dead
+    // end — return blocked to avoid an infinite dispatch loop (#4506).
+    if (!validationTerminal) {
       return {
         activeMilestone,
         activeSlice: null,
@@ -1461,6 +1481,27 @@ export async function _deriveStateImpl(basePath: string): Promise<GSDState> {
         recentDecisions: [],
         blockers: [],
         nextAction: `Validate milestone ${activeMilestone.id} before completion.`,
+        registry,
+        requirements,
+        progress: {
+          milestones: milestoneProgress,
+          slices: sliceProgress,
+        },
+      };
+    }
+
+    if (verdict === 'needs-remediation') {
+      return {
+        activeMilestone,
+        activeSlice: null,
+        activeTask: null,
+        phase: 'blocked',
+        recentDecisions: [],
+        blockers: [
+          `Milestone ${activeMilestone.id} validation verdict is needs-remediation but all slices are complete. ` +
+            `Add remediation slices via gsd_reassess_roadmap or override the verdict manually.`,
+        ],
+        nextAction: `Resolve ${activeMilestone.id} remediation before proceeding.`,
         registry,
         requirements,
         progress: {

--- a/src/resources/extensions/gsd/tests/derive-state-db.test.ts
+++ b/src/resources/extensions/gsd/tests/derive-state-db.test.ts
@@ -694,6 +694,48 @@ describe('derive-state-db', async () => {
     }
   });
 
+  // ─── Test 14b: needs-remediation + all slices done → blocked (#4506) ──
+  test('derive-state-db: needs-remediation with all slices done returns blocked (#4506)', async () => {
+    const base = createFixtureBase();
+    try {
+      const doneRoadmap = `# M001: Stuck Remediation
+
+**Vision:** Test needs-remediation loop guard.
+
+## Slices
+
+- [x] **S01: Done Slice** \`risk:low\` \`depends:[]\`
+  > After this: Done.
+`;
+      writeFile(base, 'milestones/M001/M001-ROADMAP.md', doneRoadmap);
+      writeFile(base, 'milestones/M001/M001-VALIDATION.md',
+        '---\nverdict: needs-remediation\nremediation_round: 1\n---\n\n# Validation\nNeeds fixes.');
+
+      invalidateStateCache();
+      const fileState = await _deriveStateImpl(base);
+
+      openDatabase(':memory:');
+      insertMilestone({ id: 'M001', title: 'Stuck Remediation', status: 'active' });
+      insertSlice({ id: 'S01', milestoneId: 'M001', title: 'Done Slice', status: 'complete', risk: 'low', depends: [] });
+
+      invalidateStateCache();
+      const dbState = await deriveStateFromDb(base);
+
+      assert.deepStrictEqual(dbState.phase, 'blocked', 'remediation-stuck-db: phase is blocked');
+      assert.deepStrictEqual(dbState.phase, fileState.phase, 'remediation-stuck-db: phase matches filesystem');
+      assert.deepStrictEqual(dbState.activeMilestone?.id, 'M001', 'remediation-stuck-db: activeMilestone is M001');
+      assert.ok(
+        dbState.blockers.some(b => b.includes('needs-remediation') && b.includes('M001')),
+        'remediation-stuck-db: blocker message mentions milestone and verdict',
+      );
+
+      closeDatabase();
+    } finally {
+      closeDatabase();
+      cleanup(base);
+    }
+  });
+
   // ─── Test 15: Completing-milestone — terminal validation, no summary ──
   test('derive-state-db: completing-milestone via DB', async () => {
     const base = createFixtureBase();

--- a/src/resources/extensions/gsd/tests/derive-state-helpers.test.ts
+++ b/src/resources/extensions/gsd/tests/derive-state-helpers.test.ts
@@ -446,8 +446,8 @@ describe('derive-state-helpers', () => {
     }
   });
 
-  // ─── handleAllSlicesDone: needs-remediation re-triggers validation ──
-  test('handleAllSlicesDone: needs-remediation verdict triggers validating-milestone', async () => {
+  // ─── handleAllSlicesDone: needs-remediation + all slices done → blocked (#4506) ──
+  test('handleAllSlicesDone: needs-remediation with all slices done returns blocked', async () => {
     const base = createFixtureBase();
     try {
       const doneRoadmap = `# M001: Remediation Test\n\n**Vision:** Test.\n\n## Slices\n\n- [x] **S01: Done** \`risk:low\` \`depends:[]\`\n  > Done.\n`;
@@ -462,8 +462,12 @@ describe('derive-state-helpers', () => {
       invalidateStateCache();
       const state = await deriveStateFromDb(base);
 
-      assert.equal(state.phase, 'validating-milestone', 'remediation: phase is validating-milestone');
-      assert.equal(state.activeMilestone?.id, 'M001', 'remediation: activeMilestone is M001');
+      assert.equal(state.phase, 'blocked', 'remediation-stuck: phase is blocked (no infinite re-dispatch)');
+      assert.equal(state.activeMilestone?.id, 'M001', 'remediation-stuck: activeMilestone is M001');
+      assert.ok(
+        state.blockers.some(b => b.includes('needs-remediation') && b.includes('M001')),
+        'remediation-stuck: blocker message mentions milestone and verdict',
+      );
     } finally {
       closeDatabase();
       cleanup(base);

--- a/src/resources/extensions/gsd/tests/validate-milestone.test.ts
+++ b/src/resources/extensions/gsd/tests/validate-milestone.test.ts
@@ -177,16 +177,22 @@ test("deriveState returns completing-milestone when VALIDATION exists with termi
   }
 });
 
-test("deriveState treats needs-remediation as non-terminal — re-enters validating-milestone (#832)", async () => {
+test("deriveState returns blocked when needs-remediation has no incomplete slices (#4506)", async () => {
   const base = makeTmpBase();
   try {
     writeRoadmap(base, "M001", ALL_DONE_ROADMAP);
     writeValidation(base, "M001", "---\nverdict: needs-remediation\nremediation_round: 0\n---\n\n# Validation\nNeeds fixes.");
 
     const state = await deriveState(base);
-    // needs-remediation routes back to validating-milestone for re-validation
-    assert.equal(state.phase, "validating-milestone");
+    // All slices done + needs-remediation → blocked (prevents infinite
+    // validate-milestone dispatch loop). Previously returned
+    // validating-milestone, which caused #4506.
+    assert.equal(state.phase, "blocked");
     assert.equal(state.activeMilestone?.id, "M001");
+    assert.ok(
+      state.blockers.some(b => b.includes("needs-remediation") && b.includes("M001")),
+      "blocker message should mention milestone and verdict",
+    );
   } finally {
     cleanup(base);
   }


### PR DESCRIPTION
## Summary
- Splits the `!validationTerminal || verdict === 'needs-remediation'` condition in both derivation paths (`handleAllSlicesDone` DB-path at state.ts:616 and the markdown-path at state.ts:1455).
- When all slices are complete and verdict is `needs-remediation`, returns `phase: 'blocked'` with a blocker directing the user to `gsd_reassess_roadmap` or manual verdict override — instead of infinitely re-dispatching `validate-milestone`.
- Stateless fix: `blocked` re-derives identically every iteration, so the loop terminates cleanly without relying on the ephemeral in-memory `pauseAuto()` from PR #4176.

Fixes #4506.

## Background
When `validate-milestone` writes `verdict: needs-remediation` but the agent cannot add remediation slices (e.g., environmental blocker), the state machine previously re-entered `validating-milestone` every iteration. PR #4176 added `pauseAuto()` in `auto-verification.ts`, but `s.paused` is in-memory on `AutoSession` and is cleared by `reset()` — so the loop reappears after re-derivation. This PR fixes the root cause in `state.ts`.

## Test plan
- [x] Updated existing `needs-remediation` assertions in `derive-state-helpers.test.ts`, `derive-state-db.test.ts`, and `validate-milestone.test.ts` to expect the new `blocked` behavior.
- [x] Added a parallel DB-path test (`#4506`) asserting `blocked` + blocker message.
- [x] Structural regression test `needs-remediation-revalidation.test.ts` (#3670) still passes — registry-loop guard pattern intact.
- [x] `tsc --noEmit` clean.
- [x] 229 affected tests pass (derive-state, validate-milestone, remediation-completion-guard, state-machine-full-walkthrough, state-machine-edge-cases, validate-milestone-stuck-guard, reassess-handler).

## Follow-ups (not in this PR)
- Simplify `auto-verification.ts:142-158` — the `pauseAuto()` path is now mostly redundant since `state.ts` owns loop prevention. Firing it is harmless (one-time gate-persist + notify) but can be cleaned up.