### PR TITLE
fix: blocklist account-unsupported models across auto restarts (#4513)

### DIFF
--- a/src/resources/extensions/gsd/auto-model-selection.ts
+++ b/src/resources/extensions/gsd/auto-model-selection.ts
@@ -18,6 +18,7 @@ import { getSessionModelOverride } from "./session-model-override.js";
 import { logWarning } from "./workflow-logger.js";
 import { resolveUokFlags } from "./uok/flags.js";
 import { applyModelPolicyFilter } from "./uok/model-policy.js";
+import { isModelBlocked } from "./blocked-models.js";
 
 export interface ModelSelectionResult {
   /** Routing metadata for metrics recording */
@@ -334,6 +335,18 @@ export async function selectAndApplyModel(
         attemptedPolicyEligible = true;
       }
 
+      // Skip models the provider has previously rejected for this account
+      // (issue #4513).  The block is persisted in .gsd/runtime/blocked-models.json
+      // so it survives /gsd auto restarts — without this, the same dead model
+      // gets reselected after every restart.
+      if (isModelBlocked(basePath, model.provider, model.id)) {
+        ctx.ui.notify(
+          `Skipping blocked model ${model.provider}/${model.id} (provider rejected it for this account).`,
+          "warning",
+        );
+        continue;
+      }
+
       // Warn if the ID is ambiguous across providers
       if (!modelId.includes("/")) {
         const providers = availableModels.filter(m => m.id === modelId).map(m => m.provider);
@@ -407,19 +420,29 @@ export async function selectAndApplyModel(
     // No model preference for this unit type — re-apply the model captured
     // at auto-mode start to prevent bleed from shared global settings.json (#650).
     const availableModels = ctx.modelRegistry.getAvailable();
-    const startModel = availableModels.find(
-      m => m.provider === autoModeStartModel.provider && m.id === autoModeStartModel.id,
-    );
-    if (startModel) {
-      const ok = await pi.setModel(startModel, { persist: false });
-      if (!ok) {
-        const byId = availableModels.find(m => m.id === autoModeStartModel.id);
-        if (byId) {
-          const fallbackOk = await pi.setModel(byId, { persist: false });
-          if (fallbackOk) appliedModel = byId;
+    const startBlocked = isModelBlocked(basePath, autoModeStartModel.provider, autoModeStartModel.id);
+    if (startBlocked) {
+      ctx.ui.notify(
+        `Auto-mode start model ${autoModeStartModel.provider}/${autoModeStartModel.id} is blocked for this account. Using current session model instead.`,
+        "warning",
+      );
+    } else {
+      const startModel = availableModels.find(
+        m => m.provider === autoModeStartModel.provider && m.id === autoModeStartModel.id,
+      );
+      if (startModel) {
+        const ok = await pi.setModel(startModel, { persist: false });
+        if (!ok) {
+          const byId = availableModels.find(
+            m => m.id === autoModeStartModel.id && !isModelBlocked(basePath, m.provider, m.id),
+          );
+          if (byId) {
+            const fallbackOk = await pi.setModel(byId, { persist: false });
+            if (fallbackOk) appliedModel = byId;
+          }
+        } else {
+          appliedModel = startModel;
         }
-      } else {
-        appliedModel = startModel;
       }
     }
   }

--- a/src/resources/extensions/gsd/blocked-models.ts
+++ b/src/resources/extensions/gsd/blocked-models.ts
@@ -1,0 +1,98 @@
+// GSD — Persistent per-project blocklist of provider/model pairs that the
+// provider has rejected at request time for account entitlement reasons.
+//
+// Lives at `.gsd/runtime/blocked-models.json` so the block survives /gsd auto
+// restarts.  Auto-mode model selection skips blocked entries; agent-end
+// recovery adds entries when a runtime rejection is classified as
+// `unsupported-model`.  See issue #4513.
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { gsdRoot } from "./paths.js";
+import { withFileLockSync } from "./file-lock.js";
+
+export interface BlockedModelEntry {
+  provider: string;
+  id: string;
+  reason: string;
+  blockedAt: number;
+}
+
+interface BlockedModelsFile {
+  version: 1;
+  blocked: BlockedModelEntry[];
+}
+
+function blockedModelsPath(basePath: string): string {
+  return join(gsdRoot(basePath), "runtime", "blocked-models.json");
+}
+
+function modelKey(provider: string, id: string): string {
+  return `${provider.toLowerCase()}/${id.toLowerCase()}`;
+}
+
+function readFileSafe(path: string): BlockedModelsFile {
+  if (!existsSync(path)) return { version: 1, blocked: [] };
+  try {
+    const raw = readFileSync(path, "utf-8");
+    const parsed = JSON.parse(raw) as Partial<BlockedModelsFile>;
+    if (!parsed || !Array.isArray(parsed.blocked)) {
+      return { version: 1, blocked: [] };
+    }
+    const blocked = parsed.blocked.filter(
+      (e): e is BlockedModelEntry =>
+        !!e && typeof e.provider === "string" && typeof e.id === "string",
+    );
+    return { version: 1, blocked };
+  } catch {
+    // Corrupted JSON: treat as empty so a bad file never blocks dispatch.
+    return { version: 1, blocked: [] };
+  }
+}
+
+export function loadBlockedModels(basePath: string): BlockedModelEntry[] {
+  return readFileSafe(blockedModelsPath(basePath)).blocked;
+}
+
+export function isModelBlocked(
+  basePath: string,
+  provider: string | undefined,
+  id: string | undefined,
+): boolean {
+  if (!provider || !id) return false;
+  const target = modelKey(provider, id);
+  return loadBlockedModels(basePath).some(
+    (e) => modelKey(e.provider, e.id) === target,
+  );
+}
+
+export function blockModel(
+  basePath: string,
+  provider: string,
+  id: string,
+  reason: string,
+): void {
+  const path = blockedModelsPath(basePath);
+  mkdirSync(dirname(path), { recursive: true });
+  // Ensure the file exists before we try to lock it — proper-lockfile requires
+  // the target path to exist (file-lock.ts falls through to an unlocked call
+  // otherwise).
+  if (!existsSync(path)) {
+    writeFileSync(path, JSON.stringify({ version: 1, blocked: [] }, null, 2) + "\n", "utf-8");
+  }
+  withFileLockSync(path, () => {
+    const current = readFileSafe(path);
+    const target = modelKey(provider, id);
+    if (current.blocked.some((e) => modelKey(e.provider, e.id) === target)) {
+      return;
+    }
+    const next: BlockedModelsFile = {
+      version: 1,
+      blocked: [
+        ...current.blocked,
+        { provider, id, reason, blockedAt: Date.now() },
+      ],
+    };
+    writeFileSync(path, JSON.stringify(next, null, 2) + "\n", "utf-8");
+  });
+}

--- a/src/resources/extensions/gsd/bootstrap/agent-end-recovery.ts
+++ b/src/resources/extensions/gsd/bootstrap/agent-end-recovery.ts
@@ -16,6 +16,7 @@ import {
   isTransient,
   type ErrorClass,
 } from "../error-classifier.js";
+import { blockModel, isModelBlocked } from "../blocked-models.js";
 
 const retryState = createRetryState();
 const MAX_NETWORK_RETRIES = 2;
@@ -123,6 +124,102 @@ export async function handleAgentEnd(
 
     // ── 1. Classify using rawErrorMsg to avoid prose false-positives ────
     const cls = classifyError(rawErrorMsg, explicitRetryAfterMs);
+
+    // ── 1a. Unsupported-model: provider rejected this model for the current
+    //        account/plan at request time (#4513).  Persist a block so the
+    //        same dead model isn't reselected on the next /gsd auto restart,
+    //        then try a fallback before pausing.
+    if (cls.kind === "unsupported-model") {
+      const dash = getAutoDashboardData();
+      const rejectedProvider = ctx.model?.provider;
+      const rejectedId = ctx.model?.id;
+      if (dash.basePath && rejectedProvider && rejectedId) {
+        try {
+          blockModel(dash.basePath, rejectedProvider, rejectedId, rawErrorMsg || "unsupported for account");
+          ctx.ui.notify(
+            `Blocked ${rejectedProvider}/${rejectedId} for this project — provider rejected it for the current account.`,
+            "warning",
+          );
+        } catch (err) {
+          const m = err instanceof Error ? err.message : String(err);
+          logWarning("bootstrap", `Failed to persist blocked model: ${m}`);
+        }
+      }
+
+      // Try configured fallback chain, skipping anything already blocked.
+      if (dash.currentUnit && dash.basePath) {
+        const modelConfig = resolveModelWithFallbacksForUnit(dash.currentUnit.type);
+        if (modelConfig && modelConfig.fallbacks.length > 0) {
+          const availableModels = ctx.modelRegistry.getAvailable();
+          let cursorModelId: string | undefined = ctx.model?.id;
+          while (true) {
+            const nextModelId = getNextFallbackModel(cursorModelId, modelConfig);
+            if (!nextModelId) break;
+            const candidate = resolveModelId(nextModelId, availableModels, ctx.model?.provider);
+            if (candidate && !isModelBlocked(dash.basePath, candidate.provider, candidate.id)) {
+              const ok = await pi.setModel(candidate, { persist: false });
+              if (ok) {
+                setCurrentDispatchedModelId({ provider: candidate.provider, id: candidate.id });
+                ctx.ui.notify(
+                  `Switched to fallback ${candidate.provider}/${candidate.id} after account entitlement rejection.`,
+                  "warning",
+                );
+                pi.sendMessage(
+                  { customType: "gsd-auto-timeout-recovery", content: "Continue execution.", display: false },
+                  { triggerTurn: true },
+                );
+                return;
+              }
+            }
+            cursorModelId = nextModelId;
+          }
+        }
+
+        // Fallback chain exhausted — try the auto-mode start model if it isn't
+        // the same one we just blocked and isn't itself blocked.
+        const sessionModel = getAutoModeStartModel();
+        if (
+          sessionModel &&
+          !(sessionModel.provider === rejectedProvider && sessionModel.id === rejectedId) &&
+          !isModelBlocked(dash.basePath, sessionModel.provider, sessionModel.id)
+        ) {
+          const startModel = ctx.modelRegistry
+            .getAvailable()
+            .find((m) => m.provider === sessionModel.provider && m.id === sessionModel.id);
+          if (startModel) {
+            const ok = await pi.setModel(startModel, { persist: false });
+            if (ok) {
+              setCurrentDispatchedModelId({ provider: startModel.provider, id: startModel.id });
+              ctx.ui.notify(
+                `Restored auto-mode start model ${startModel.provider}/${startModel.id} after entitlement rejection.`,
+                "warning",
+              );
+              pi.sendMessage(
+                { customType: "gsd-auto-timeout-recovery", content: "Continue execution.", display: false },
+                { triggerTurn: true },
+              );
+              return;
+            }
+          }
+        }
+      }
+
+      // No usable fallback — pause with a clearly named message.
+      const blockedLabel = rejectedProvider && rejectedId ? `${rejectedProvider}/${rejectedId}` : "current model";
+      const pauseDetail = `Model ${blockedLabel} blocked for this account${errorDetail}. Configure a different model and restart /gsd auto.`;
+      await pauseAutoForProviderError(ctx.ui, pauseDetail, () =>
+        pauseAuto(ctx, pi, {
+          message: pauseDetail,
+          category: "provider",
+          isTransient: false,
+        }),
+      {
+        isRateLimit: false,
+        isTransient: false,
+        retryAfterMs: 0,
+      });
+      return;
+    }
 
     // ── 1b. Defer to Core RetryHandler for most transient errors ────────
     // Core retries transient failures in-session after this handler.

--- a/src/resources/extensions/gsd/error-classifier.ts
+++ b/src/resources/extensions/gsd/error-classifier.ts
@@ -19,6 +19,7 @@ export type ErrorClass =
   | { kind: "stream";       retryAfterMs: number }
   | { kind: "connection";   retryAfterMs: number }
   | { kind: "model-error" }
+  | { kind: "unsupported-model" }
   | { kind: "permanent" }
   | { kind: "unknown" };
 
@@ -59,6 +60,18 @@ const CONNECTION_RE = /terminated|connection.?(?:refused|error)|other side close
 const STREAM_RE = /in JSON at position \d+|Unexpected end of JSON|SyntaxError.*JSON/i;
 const RESET_DELAY_RE = /reset in (\d+)s/i;
 
+// Provider-side model entitlement rejection: the SDK accepted the model switch,
+// but the provider refused at request time because the current account/plan/tier
+// cannot use that model.  Must match all three of: a model/deployment token,
+// a negative-entitlement indicator, and an account/plan/tier/subscription token.
+// Requiring all three keeps generic "account suspended" errors in `permanent`
+// (no model token) while catching the phrasings providers actually use.
+// See issue #4513.
+const UNSUPPORTED_MODEL_MODEL_RE = /\b(?:model|deployment)\b/i;
+const UNSUPPORTED_MODEL_INDICATOR_RE =
+  /\bnot support(?:ed|s)?\b|\bunsupported\b|\bnot available\b|\bunavailable\b|\bno access\b|\bdoes(?:n['’]t| not) (?:have access|support)\b|\bnot authori[sz]ed\b/i;
+const UNSUPPORTED_MODEL_SCOPE_RE = /\b(?:account|plan|tier|subscription)\b/i;
+
 /**
  * Classify an error message into one of the ErrorClass kinds.
  *
@@ -74,6 +87,19 @@ const RESET_DELAY_RE = /reset in (\d+)s/i;
 export function classifyError(errorMsg: string, retryAfterMs?: number): ErrorClass {
   const isPermanent = PERMANENT_RE.test(errorMsg);
   const isRateLimit = RATE_LIMIT_RE.test(errorMsg) || AFFORDABILITY_RE.test(errorMsg);
+  const isUnsupportedModel =
+    UNSUPPORTED_MODEL_MODEL_RE.test(errorMsg) &&
+    UNSUPPORTED_MODEL_INDICATOR_RE.test(errorMsg) &&
+    UNSUPPORTED_MODEL_SCOPE_RE.test(errorMsg);
+
+  // 0. Unsupported model (account/plan entitlement rejection) — checked before
+  //    `permanent` because PERMANENT_RE also matches /account/i and would
+  //    otherwise swallow these errors, blocking the blocklist-driven fallback.
+  //    Rate limit still wins when both patterns appear (a throttled account is
+  //    not an entitlement failure).
+  if (isUnsupportedModel && !isRateLimit) {
+    return { kind: "unsupported-model" };
+  }
 
   // 1. Permanent — but rate limit takes precedence
   if (isPermanent && !isRateLimit) {

--- a/src/resources/extensions/gsd/tests/blocked-models.test.ts
+++ b/src/resources/extensions/gsd/tests/blocked-models.test.ts
@@ -1,0 +1,98 @@
+// GSD — Tests for persistent blocked-models store (issue #4513)
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  blockModel,
+  isModelBlocked,
+  loadBlockedModels,
+} from "../blocked-models.ts";
+
+function mkBase(): string {
+  const base = mkdtempSync(join(tmpdir(), "gsd-blocked-models-"));
+  mkdirSync(join(base, ".gsd"), { recursive: true });
+  return base;
+}
+
+test("blocked-models: round-trip write and read", () => {
+  const base = mkBase();
+  try {
+    assert.equal(isModelBlocked(base, "openai-codex", "gpt-5.1-codex-max"), false);
+    blockModel(base, "openai-codex", "gpt-5.1-codex-max", "not supported for ChatGPT account");
+    assert.equal(isModelBlocked(base, "openai-codex", "gpt-5.1-codex-max"), true);
+
+    const entries = loadBlockedModels(base);
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].provider, "openai-codex");
+    assert.equal(entries[0].id, "gpt-5.1-codex-max");
+    assert.ok(entries[0].blockedAt > 0);
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("blocked-models: case-insensitive lookup", () => {
+  const base = mkBase();
+  try {
+    blockModel(base, "OpenAI-Codex", "GPT-5.1-Codex-Max", "reason");
+    assert.equal(isModelBlocked(base, "openai-codex", "gpt-5.1-codex-max"), true);
+    assert.equal(isModelBlocked(base, "OPENAI-CODEX", "GPT-5.1-CODEX-MAX"), true);
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("blocked-models: dedupes repeated blocks", () => {
+  const base = mkBase();
+  try {
+    blockModel(base, "openai-codex", "gpt-5", "first");
+    blockModel(base, "openai-codex", "gpt-5", "second");
+    blockModel(base, "openai-codex", "gpt-5", "third");
+    assert.equal(loadBlockedModels(base).length, 1);
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("blocked-models: corrupted JSON recovers to empty", () => {
+  const base = mkBase();
+  try {
+    const path = join(base, ".gsd", "runtime", "blocked-models.json");
+    mkdirSync(join(base, ".gsd", "runtime"), { recursive: true });
+    writeFileSync(path, "{not valid json", "utf-8");
+
+    assert.equal(loadBlockedModels(base).length, 0);
+    assert.equal(isModelBlocked(base, "any", "model"), false);
+
+    // A subsequent write should still succeed (overwrites the corrupt file).
+    blockModel(base, "openai-codex", "gpt-5", "reason");
+    assert.equal(loadBlockedModels(base).length, 1);
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("blocked-models: returns false for missing provider or id", () => {
+  const base = mkBase();
+  try {
+    blockModel(base, "openai-codex", "gpt-5", "reason");
+    assert.equal(isModelBlocked(base, undefined, "gpt-5"), false);
+    assert.equal(isModelBlocked(base, "openai-codex", undefined), false);
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("blocked-models: file created under .gsd/runtime/", () => {
+  const base = mkBase();
+  try {
+    blockModel(base, "openai-codex", "gpt-5", "reason");
+    assert.ok(existsSync(join(base, ".gsd", "runtime", "blocked-models.json")));
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});

--- a/src/resources/extensions/gsd/tests/provider-errors.test.ts
+++ b/src/resources/extensions/gsd/tests/provider-errors.test.ts
@@ -147,6 +147,49 @@ test("classifyError: rate limit takes precedence over auth keywords", () => {
   assert.ok(isTransient(result));
 });
 
+// ── unsupported-model: account/plan entitlement rejection (#4513) ──────────
+
+test("classifyError: Codex ChatGPT-account entitlement rejection is unsupported-model", () => {
+  const result = classifyError(
+    "The 'gpt-5.1-codex-max' model is not supported when using Codex with a ChatGPT account.",
+  );
+  assert.equal(result.kind, "unsupported-model");
+  assert.ok(!isTransient(result));
+});
+
+test("classifyError: 'model not available for this plan' is unsupported-model", () => {
+  const result = classifyError("This model is not available for your current plan.");
+  assert.equal(result.kind, "unsupported-model");
+});
+
+test("classifyError: 'account does not have access to model' is unsupported-model", () => {
+  const result = classifyError("Your account does not have access to the gpt-5 model.");
+  assert.equal(result.kind, "unsupported-model");
+});
+
+test("classifyError: 'tier does not support deployment' is unsupported-model", () => {
+  const result = classifyError("The free tier does not support this deployment.");
+  assert.equal(result.kind, "unsupported-model");
+});
+
+test("classifyError: 'account suspended' stays permanent (not unsupported-model)", () => {
+  const result = classifyError("Your account has been suspended. Contact support.");
+  assert.equal(result.kind, "permanent");
+});
+
+test("classifyError: 'invalid account' stays permanent", () => {
+  const result = classifyError("invalid account credentials");
+  assert.equal(result.kind, "permanent");
+});
+
+test("classifyError: rate limit on unsupported-model phrasing stays rate-limit", () => {
+  // A throttled account is not an entitlement failure.
+  const result = classifyError(
+    "429 rate limit — model not supported when using your account right now",
+  );
+  assert.equal(result.kind, "rate-limit");
+});
+
 // ── STREAM_RE: V8 JSON parse error variants (#2916) ────────────────────────
 
 test("classifyError: 'Expected comma/brace after property value in JSON' is transient stream", () => {


### PR DESCRIPTION
## Summary

Fixes #4513 — auto-mode reselects account-unsupported model after provider runtime rejection.

Provider-side entitlement rejections (e.g. `The 'gpt-5.1-codex-max' model is not supported when using Codex with a ChatGPT account.`) were classified as `permanent` because `PERMANENT_RE` matches `/account/i`. That bypassed fallback logic, paused auto-mode, and — crucially — left no record, so the next `/gsd auto` restart reselected the same dead model.

## Changes

- **`error-classifier.ts`** — new `unsupported-model` ErrorClass, checked **before** `permanent`. Three-token match: model/deployment + negative indicator + account/plan/tier/subscription. Rate-limit still wins when both match (a throttled account isn't an entitlement failure).
- **`blocked-models.ts` (new)** — persistent blocklist at `.gsd/runtime/blocked-models.json`. Uses existing `withFileLockSync` for concurrent-write safety. Recovers from corrupted JSON. Case-insensitive, dedupes, never-expire (manual clear = delete the file).
- **`auto-model-selection.ts`** — filters `modelsToTry` and the `autoModeStartModel` re-apply branch so blocked models are skipped at dispatch.
- **`bootstrap/agent-end-recovery.ts`** — new `unsupported-model` branch: persists the block, walks the fallback chain (skipping blocked), tries the auto-mode start model, pauses with a named message if nothing works.

## Tests

90/90 pass. 13 new cases:
- 7 classifier cases (Codex/OpenAI/plan/tier phrasings; negative guards for "account suspended" and "invalid account"; rate-limit-takes-precedence)
- 6 blocked-models cases (round-trip, case-insensitive, dedupe, corrupted-JSON recovery, missing-args guard, path correctness)

Includes the exact error string from the issue's forensic logs.

## Test plan

- [x] `npx tsx --test` on affected files — 90/90 pass
- [x] `npx tsc --noEmit` clean
- [ ] Manual: trigger unsupported-model error, confirm block persists to `.gsd/runtime/blocked-models.json` and survives `/gsd auto` restart

## Explicit non-goals (YAGNI)

- TTL / auto-expiry on blocked entries
- Unblock CLI command (manual JSON delete works)
- Cross-project global blocklist
- Telemetry event on block
- Provider-specific regex expansions beyond generic tokens

Happy to file these as follow-ups if desired.

## Peer review

Design was cross-validated via codex-peer-reviewer before implementation. Key concerns raised (concurrent writes, regex underfit) were addressed directly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added model blocking to prevent re-selection of previously unsupported models for your account.
  * Automatically attempts fallback models when the primary model is blocked.
  * Pauses auto-mode with configuration guidance when all configured models are blocked.

* **Tests**
  * Added comprehensive test coverage for model blocking behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->