### PR TITLE
fix(search): narrow native web_search to providers that accept it (#4492 regression)

### DIFF
--- a/src/resources/extensions/search-the-web/command-search-provider.ts
+++ b/src/resources/extensions/search-the-web/command-search-provider.ts
@@ -8,7 +8,7 @@
  * All provider logic lives in provider.ts (S01) — this is pure UI wiring.
  */
 
-import { isAnthropicApi } from '@gsd/pi-ai'
+import { supportsNativeWebSearch } from './native-search.js'
 import type { ExtensionAPI } from '@gsd/pi-coding-agent'
 import type { AutocompleteItem } from '@gsd/pi-tui'
 import {
@@ -91,9 +91,10 @@ export function registerSearchProviderCommand(pi: ExtensionAPI): void {
 
       setSearchProviderPreference(chosen)
       const effective = resolveSearchProvider()
-      // Gate on api (#4478 / ADR-012): covers claude-code, anthropic-vertex, and
-      // other Anthropic-fronting transports — not just the plain `anthropic` provider.
-      const isAnthropic = isAnthropicApi(ctx.model)
+      // Gate on api shape + provider allowlist: the info note must match the
+      // actual runtime behavior in native-search.ts. Claude served via copilot
+      // / minimax / kimi is anthropic-shaped but does NOT run native search.
+      const isAnthropic = supportsNativeWebSearch(ctx.model)
       const nativeNote = isAnthropic ? '\nNote: Native Anthropic web search is also active (automatic, no API key needed).' : ''
       ctx.ui.notify(
         `Search provider set to ${chosen}. Effective provider: ${effective ?? 'none (no API keys)'}${nativeNote}`,

--- a/src/resources/extensions/search-the-web/native-search.ts
+++ b/src/resources/extensions/search-the-web/native-search.ts
@@ -18,6 +18,41 @@ export const CUSTOM_SEARCH_TOOL_NAMES = ["search-the-web", "search_and_read", "g
 const THINKING_TYPES = new Set(["thinking", "redacted_thinking"]);
 
 /**
+ * Providers whose Anthropic-Messages endpoint is known to accept the native
+ * `web_search_20250305` server tool. Anthropic-shaped transports NOT in this
+ * set (github-copilot, minimax, kimi-coding, opencode, vercel-ai-gateway,
+ * etc.) route Claude or Claude-compatible models through the Messages API
+ * but do NOT expose the server-side search tool — injecting it yields a
+ * 400 "unsupported_value" from their endpoints (regression from #4492).
+ *
+ * Keep this allowlist tight — err on the side of custom/Brave search rather
+ * than a runtime 400. Add a provider here only after confirming its endpoint
+ * accepts the tool type.
+ */
+const NATIVE_WEB_SEARCH_PROVIDERS = new Set([
+  "anthropic",
+  "claude-code",
+  "anthropic-vertex",
+  "vercel-ai-gateway",
+]);
+
+/**
+ * True when the model is an Anthropic-shaped transport AND the provider is
+ * known to accept the native `web_search_20250305` tool. Gate both on api
+ * shape (#4478 / ADR-012) and on provider identity (#444 regression guard
+ * and #4492 scope correction) — provider-level discrimination is legitimate
+ * per ADR-012 for credential/behavior differences that api shape can't
+ * express.
+ */
+export function supportsNativeWebSearch(
+  model: { api?: string; provider?: string } | null | undefined
+): boolean {
+  if (!isAnthropicApi(model)) return false;
+  const provider = model?.provider;
+  return typeof provider === "string" && NATIVE_WEB_SEARCH_PROVIDERS.has(provider);
+}
+
+/**
  * Maximum number of native web searches allowed per session (agent unit).
  * The Anthropic API's `max_uses` is per-request — it resets on each API call.
  * When `pause_turn` triggers a resubmit, the model gets a fresh budget.
@@ -95,10 +130,11 @@ export function registerNativeSearchHooks(pi: NativeSearchPI): { getIsAnthropic:
   pi.on("model_select", async (event: any, ctx: any) => {
     modelSelectFired = true;
     const wasAnthropic = isAnthropicProvider;
-    // Gate on `api` not `provider` (#4478 / ADR-012): covers claude-code OAuth,
-    // anthropic-vertex, and Vercel-gateway-hosted Anthropic — all serve the
-    // Messages API and accept the native web_search tool.
-    isAnthropicProvider = isAnthropicApi(event.model);
+    // Gate on api shape AND provider allowlist: direct Anthropic, claude-code
+    // OAuth, and anthropic-vertex accept `web_search_20250305`; copilot /
+    // minimax / kimi / opencode route Claude-compat models through the same
+    // wire protocol but reject the server-side tool (#4492 regression).
+    isAnthropicProvider = supportsNativeWebSearch(event.model);
 
     const hasBrave = !!process.env.BRAVE_API_KEY;
 
@@ -145,17 +181,17 @@ export function registerNativeSearchHooks(pi: NativeSearchPI): { getIsAnthropic:
     // modelsAreEqual suppresses model_select AND the SDK doesn't pass model.
     const eventModel = event.model as { provider?: string; api?: string } | undefined;
     let isAnthropic: boolean;
-    if (eventModel?.api) {
-      // Preferred path: gate on wire protocol (#4478 / ADR-012).
-      isAnthropic = isAnthropicApi(eventModel);
-    } else if (eventModel?.provider) {
-      // Fallback for event shapes that carry provider but not api — only plain
-      // `anthropic` maps unambiguously without the api field. Other Anthropic
-      // transports will arrive via the modelSelectFired or model-name branch.
-      isAnthropic = eventModel.provider === "anthropic";
+    if (eventModel?.api || eventModel?.provider) {
+      // Preferred path: gate on api shape + provider allowlist. Both fields
+      // are authoritative when present — do NOT fall back to the model-name
+      // heuristic, which would misclassify copilot-served Claude as Anthropic
+      // (#444 regression) or minimax-served Claude-compat as Anthropic (#4492).
+      isAnthropic = supportsNativeWebSearch(eventModel);
     } else if (modelSelectFired) {
       isAnthropic = isAnthropicProvider;
     } else {
+      // Last resort: session-restore paths where the SDK doesn't pass model.
+      // The model-name prefix is best-effort and assumes direct Anthropic.
       const modelName = typeof payload.model === "string" ? payload.model : "";
       isAnthropic = modelName.startsWith("claude-");
     }

--- a/src/tests/native-search.test.ts
+++ b/src/tests/native-search.test.ts
@@ -152,10 +152,17 @@ test("before_provider_request does NOT inject for claude model on non-Anthropic 
   const pi = createMockPI();
   registerNativeSearchHooks(pi);
 
-  // GitHub Copilot (or Bedrock, etc.) serving a claude model
+  // GitHub Copilot (or Bedrock, etc.) serving a claude model.
+  // Critical: runtime model objects from copilot carry api: "anthropic-messages"
+  // because copilot routes through packages/pi-ai/src/providers/anthropic.ts.
+  // The earlier fixture omitted `api` and masked the #4492 regression.
   await pi.fire("model_select", {
     type: "model_select",
-    model: { provider: "copilot", name: "claude-sonnet-4-6" },
+    model: {
+      provider: "github-copilot",
+      api: "anthropic-messages",
+      name: "claude-sonnet-4-6",
+    },
     previousModel: undefined,
     source: "set",
   });
@@ -195,7 +202,13 @@ test("before_provider_request does NOT inject when event.model indicates non-Ant
   const result = await pi.fire("before_provider_request", {
     type: "before_provider_request",
     payload,
-    model: { provider: "github-copilot", id: "claude-sonnet-4-6" },
+    // Copilot-served claude carries api: "anthropic-messages" at runtime —
+    // include it so the test actually exercises the #4492 code path.
+    model: {
+      provider: "github-copilot",
+      api: "anthropic-messages",
+      id: "claude-sonnet-4-6",
+    },
   });
 
   assert.equal(result, undefined, "Should not modify payload when event.model says non-Anthropic");
@@ -204,6 +217,76 @@ test("before_provider_request does NOT inject when event.model indicates non-Ant
   assert.ok(
     !tools.some((t: any) => t.type === "web_search_20250305"),
     "web_search_20250305 must NOT be present for Copilot"
+  );
+});
+
+// ─── Issue #4492 regression: anthropic-shaped transports without native search ──
+
+test("before_provider_request does NOT inject for github-copilot + claude-haiku-4.5 (#4492 regression)", async () => {
+  // Reproduces the original report: provider=github-copilot, model=claude-haiku-4.5
+  // carries api: "anthropic-messages" at runtime (copilot routes through
+  // packages/pi-ai/src/providers/anthropic.ts). The #4492 change to gate on api
+  // shape alone regressed this and caused every request to fail with
+  // 400 "The use of the web search tool is not supported.".
+  const pi = createMockPI();
+  registerNativeSearchHooks(pi);
+
+  await pi.fire("model_select", {
+    type: "model_select",
+    model: {
+      provider: "github-copilot",
+      api: "anthropic-messages",
+      name: "claude-haiku-4.5",
+    },
+    previousModel: undefined,
+    source: "set",
+  });
+
+  const payload: Record<string, unknown> = {
+    model: "claude-haiku-4.5",
+    tools: [{ name: "bash", type: "custom" }],
+  };
+
+  const result = await pi.fire("before_provider_request", {
+    type: "before_provider_request",
+    payload,
+    model: {
+      provider: "github-copilot",
+      api: "anthropic-messages",
+      id: "claude-haiku-4.5",
+    },
+  });
+
+  assert.equal(result, undefined, "Should not modify payload for github-copilot + claude-haiku-4.5");
+  const tools = payload.tools as any[];
+  assert.ok(
+    !tools.some((t: any) => t.type === "web_search_20250305"),
+    "web_search_20250305 must NOT be injected for github-copilot — endpoint rejects it"
+  );
+});
+
+test("before_provider_request does NOT inject for minimax (anthropic-shaped, no native search)", async () => {
+  // MiniMax M2.x declares api: "anthropic-messages" but its endpoint does not
+  // accept web_search_20250305 — same regression class as github-copilot.
+  const pi = createMockPI();
+  registerNativeSearchHooks(pi);
+
+  const payload: Record<string, unknown> = {
+    model: "MiniMax-M2.5",
+    tools: [{ name: "bash", type: "custom" }],
+  };
+
+  const result = await pi.fire("before_provider_request", {
+    type: "before_provider_request",
+    payload,
+    model: { provider: "minimax", api: "anthropic-messages", id: "MiniMax-M2.5" },
+  });
+
+  assert.equal(result, undefined, "Should not modify payload for minimax");
+  const tools = payload.tools as any[];
+  assert.ok(
+    !tools.some((t: any) => t.type === "web_search_20250305"),
+    "web_search_20250305 must NOT be injected for minimax"
   );
 });
 

--- a/src/tests/provider-equality-allowlist.test.ts
+++ b/src/tests/provider-equality-allowlist.test.ts
@@ -85,11 +85,6 @@ const ALLOWED_FILES: Record<string, string> = {
   "src/resources/extensions/gsd/auto-model-selection.ts":
     "canonical-provider tiebreakers (ADR-012)",
 
-  // native-search.ts fallback branch: when event.model lacks `api`, the plain
-  // `anthropic` provider is the only transport we can disambiguate by
-  // provider alone. Documented inline.
-  "src/resources/extensions/search-the-web/native-search.ts":
-    "api-less event fallback; primary path uses isAnthropicApi (ADR-012)",
 };
 
 function shouldScan(path: string): boolean {


### PR DESCRIPTION
## Summary

PR #4492 widened the native Anthropic `web_search_20250305` injection gate from `provider === "anthropic"` to `isAnthropicApi(model)`. That correctly captured Claude Code OAuth and Anthropic-on-Vertex, but it also swept in every other transport that routes Claude or Claude-compat models through the Anthropic Messages wire protocol without supporting the server-side search tool.

Result: **every request fails with** `400 unsupported_value: The use of the web search tool is not supported.` on:

- `github-copilot` + any `claude-*` model (the original report — reproduced with `claude-haiku-4.5`)
- `minimax`, `minimax-cn` + MiniMax M2.x (`api: "anthropic-messages"`, endpoint has no `web_search_20250305`)
- `kimi-coding` + k2p5 / kimi-k2-thinking
- `opencode`, `opencode-go`

All of these route through `packages/pi-ai/src/providers/anthropic.ts` (see the `model.provider === "github-copilot"` branches at `:82` and `:148`) and therefore carry `api: "anthropic-messages"` at runtime.

## Fix

Replace the single api-shape gate with a two-condition check: `isAnthropicApi(model)` **AND** `model.provider ∈ NATIVE_WEB_SEARCH_PROVIDERS`.

```ts
const NATIVE_WEB_SEARCH_PROVIDERS = new Set([
  "anthropic",        // direct Anthropic API
  "claude-code",      // Claude Code OAuth (Pro/Max subscribers)
  "anthropic-vertex", // Anthropic on Google Cloud Vertex
  "vercel-ai-gateway",// documented pass-through to Anthropic
]);
```

Per **ADR-012**, provider-level discrimination is legitimate when the distinction is behavioral (endpoint accepts a given tool type) rather than wire-protocol-shaped. The allowlist makes the *why* explicit — add a provider only after confirming its endpoint accepts `web_search_20250305`.

## Changes

- **`src/resources/extensions/search-the-web/native-search.ts`** — new exported `supportsNativeWebSearch(model)` helper. Both call sites (`model_select`, `before_provider_request`) now use it. The `provider === "anthropic"` fallback branch in `before_provider_request` is subsumed by the helper.
- **`src/resources/extensions/search-the-web/command-search-provider.ts`** — `/search-provider` info note uses the same helper so "Native Anthropic web search is also active" no longer misleadingly appears for copilot+claude.
- **`src/tests/native-search.test.ts`** —
  - Two existing Copilot regression tests (lines 151, 184) had fixtures missing `api: "anthropic-messages"` and therefore hit the `eventModel?.provider` fallback branch — they never actually exercised the code path the #444 guard was supposed to protect. **Fixed fixtures.**
  - Added two new regression tests: `github-copilot` + `claude-haiku-4.5` (the original report) and `minimax` + `MiniMax-M2.5`.
- **`src/tests/provider-equality-allowlist.test.ts`** — drop the stale `native-search.ts` entry. The file no longer uses provider-string-equality; `supportsNativeWebSearch` encapsulates it via `Set.has`.

## Test plan

- [x] `npm run test:compile && node --import ./scripts/dist-test-resolve.mjs --test dist-test/src/tests/native-search.test.js` — 42/42 pass (38 pre-existing + 2 fixed + 2 new).
- [x] Same for `provider-equality-allowlist.test.js` — 2/2 pass (hits + no-stale-entries).
- [x] #4478 regressions from PR #4492 still covered: `claude-code` OAuth, `anthropic-vertex`, `vercel-ai-gateway` all still inject; `amazon-bedrock` still skipped.
- [ ] Manual: run `/gsd auto` under `github-copilot` + `claude-haiku-4.5`, confirm no 400 and Brave/custom search remains available.

## References

- Fixes the runtime regression introduced by #4492 (which fixed #4478).
- Preserves the #444 Copilot guard that #4492 unintentionally dropped.
- Honors **ADR-012** (`docs/dev/ADR-012-provider-id-vs-api-shape.md`) — provider equality is allowed for behavioral distinctions, and `supportsNativeWebSearch` makes the intent explicit.

Peer-reviewed via Codex CLI before implementation.