### PR TITLE
fix(install): link @gsd-build/mcp-server workspace package

### DIFF
--- a/scripts/link-workspace-packages.cjs
+++ b/scripts/link-workspace-packages.cjs
@@ -34,6 +34,7 @@ const packageMap = {
   'pi-coding-agent': { scope: '@gsd', name: 'pi-coding-agent' },
   'pi-tui': { scope: '@gsd', name: 'pi-tui' },
   'rpc-client': { scope: '@gsd-build', name: 'rpc-client' },
+  'mcp-server': { scope: '@gsd-build', name: 'mcp-server' },
 }
 
 for (const scopeDir of Object.values(scopeDirs)) {


### PR DESCRIPTION
## Summary
- Adds `mcp-server` to `packageMap` in `scripts/link-workspace-packages.cjs` so postinstall creates `node_modules/@gsd-build/mcp-server → packages/mcp-server`.

## Problem
On globally-installed tarballs, runtime `import("@gsd-build/mcp-server")` (e.g. the graph rebuild in `complete-slice.ts:433`) failed with:

```
Cannot find package '@gsd-build/mcp-server' imported from ~/.gsd/agent/extensions/gsd/tools/complete-slice.js
```

The tarball ships `packages/mcp-server/` (via the `files` field) and validate-pack even checks for `packages/mcp-server/dist/cli.js`, but the postinstall link script only mapped `rpc-client` under `@gsd-build`, never `mcp-server`. Monorepo source installs were unaffected because npm workspaces auto-creates the symlink.

The graph-rebuild call is wrapped in a try/catch and logged as `non-fatal`, so slice completion still succeeded — users just lost post-slice graph rebuilds silently.

## Fix
One-line addition to `packageMap`. The existing script logic (symlink or cpSync fallback for Windows) handles the rest.

## Test plan
- [x] Ran updated script against a global install — `@gsd-build/mcp-server` symlink created correctly.
- [x] Confirmed `packages/mcp-server/dist/index.js` exports `buildGraph`, `writeGraph`, `resolveGsdRoot`.
- [x] Monorepo dev install unaffected (npm workspaces already provides the symlink).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a new workspace package to the linking configuration, enabling proper resolution of internal dependencies during build setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->