### PR TITLE
fix(gsd): resolve templates dir from valid extension assets

### DIFF
--- a/src/resources/extensions/gsd/prompt-loader.ts
+++ b/src/resources/extensions/gsd/prompt-loader.ts
@@ -24,6 +24,35 @@ import { fileURLToPath } from "node:url";
 import { homedir } from "node:os";
 import { logWarning } from "./workflow-logger.js";
 
+type ExistsFn = (path: string) => boolean;
+
+function hasRequiredExtensionAssets(rootDir: string, exists: ExistsFn = existsSync): boolean {
+  return (
+    exists(join(rootDir, "prompts")) &&
+    exists(join(rootDir, "templates", "task-summary.md"))
+  );
+}
+
+export function resolveExtensionDirFromCandidates(
+  moduleDir: string,
+  agentGsdDir: string,
+  exists: ExistsFn = existsSync,
+): string {
+  const moduleUsable = hasRequiredExtensionAssets(moduleDir, exists);
+  const agentUsable = hasRequiredExtensionAssets(agentGsdDir, exists);
+
+  // Prefer the user-local extension tree when both are valid. This avoids
+  // leaking npm/global-install paths into prompts on Windows.
+  if (agentUsable) return agentGsdDir;
+  if (moduleUsable) return moduleDir;
+
+  // Degraded fallback: if required template is missing in both locations,
+  // keep previous behavior and prefer whichever still has prompts/.
+  if (exists(join(moduleDir, "prompts"))) return moduleDir;
+  if (exists(join(agentGsdDir, "prompts"))) return agentGsdDir;
+  return moduleDir;
+}
+
 /**
  * Resolve the GSD extension directory.
  *
@@ -36,15 +65,9 @@ import { logWarning } from "./workflow-logger.js";
  */
 function resolveExtensionDir(): string {
   const moduleDir = dirname(fileURLToPath(import.meta.url));
-  if (existsSync(join(moduleDir, "prompts"))) return moduleDir;
-
-  // Fallback: user-local agent directory
   const gsdHome = process.env.GSD_HOME || join(homedir(), ".gsd");
   const agentGsdDir = join(gsdHome, "agent", "extensions", "gsd");
-  if (existsSync(join(agentGsdDir, "prompts"))) return agentGsdDir;
-
-  // Last resort: return the module dir (warmCache will silently handle the miss)
-  return moduleDir;
+  return resolveExtensionDirFromCandidates(moduleDir, agentGsdDir);
 }
 
 const __extensionDir = resolveExtensionDir();

--- a/src/resources/extensions/gsd/tests/prompt-loader-extension-dir.test.ts
+++ b/src/resources/extensions/gsd/tests/prompt-loader-extension-dir.test.ts
@@ -1,0 +1,49 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { join } from "node:path";
+
+import { resolveExtensionDirFromCandidates } from "../prompt-loader.ts";
+
+function makeExists(paths: Set<string>): (path: string) => boolean {
+  return (path: string) => paths.has(path);
+}
+
+test("resolveExtensionDirFromCandidates prefers user-local dir when both trees are valid", () => {
+  const moduleDir = "/npm/global/gsd";
+  const agentDir = "/home/user/.gsd/agent/extensions/gsd";
+  const paths = new Set<string>([
+    join(moduleDir, "prompts"),
+    join(moduleDir, "templates", "task-summary.md"),
+    join(agentDir, "prompts"),
+    join(agentDir, "templates", "task-summary.md"),
+  ]);
+
+  const resolved = resolveExtensionDirFromCandidates(moduleDir, agentDir, makeExists(paths));
+  assert.equal(resolved, agentDir);
+});
+
+test("resolveExtensionDirFromCandidates rejects module dir missing task-summary template", () => {
+  const moduleDir = "/npm/global/gsd";
+  const agentDir = "/home/user/.gsd/agent/extensions/gsd";
+  const paths = new Set<string>([
+    join(moduleDir, "prompts"),
+    // Missing module templates/task-summary.md on purpose.
+    join(agentDir, "prompts"),
+    join(agentDir, "templates", "task-summary.md"),
+  ]);
+
+  const resolved = resolveExtensionDirFromCandidates(moduleDir, agentDir, makeExists(paths));
+  assert.equal(resolved, agentDir);
+});
+
+test("resolveExtensionDirFromCandidates falls back to prompts-only dir when neither tree is fully valid", () => {
+  const moduleDir = "/npm/global/gsd";
+  const agentDir = "/home/user/.gsd/agent/extensions/gsd";
+  const paths = new Set<string>([
+    join(moduleDir, "prompts"),
+    // Neither side has templates/task-summary.md.
+  ]);
+
+  const resolved = resolveExtensionDirFromCandidates(moduleDir, agentDir, makeExists(paths));
+  assert.equal(resolved, moduleDir);
+});


### PR DESCRIPTION
## Linked issue

Closes #4518

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Harden GSD extension path resolution so template paths in system prompts come from a valid extension tree.
**Why:** Windows/global-install sessions could inject a non-readable template path and fail execute-task with ENOENT before useful work.
**How:** Require both prompts/ and templates/task-summary.md for candidate validity, prefer the user-local extension tree when both are valid, and add regression tests.

## What

- Updated extension-directory resolution in `src/resources/extensions/gsd/prompt-loader.ts`.
- Added `hasRequiredExtensionAssets(...)` and `resolveExtensionDirFromCandidates(...)` to centralize candidate validation and preference logic.
- `resolveExtensionDir()` now resolves between module dir and `~/.gsd/agent/extensions/gsd` via the hardened selector.
- Added regression coverage in `src/resources/extensions/gsd/tests/prompt-loader-extension-dir.test.ts` for:
  - preferring user-local when both candidates are valid
  - rejecting module candidate missing `templates/task-summary.md`
  - degraded fallback when neither candidate has full assets

## Why

Issue #4518 reported auto-mode failures where the system prompt advertised an invalid absolute template path from a packaged/global install tree. The model then followed that path literally and failed reading `task-summary.md` with ENOENT. This change addresses the root cause by preventing invalid candidates from being selected and by preferring the user-local extension tree that actually contains runtime assets.

## How

- Candidate validity now requires both:
  - `prompts/`
  - `templates/task-summary.md`
- Selection priority is:
  1. user-local candidate (if fully valid)
  2. module candidate (if fully valid)
  3. degraded prompts-only fallback (previous behavior)
- Added focused unit tests around selection behavior to prevent regressions.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

Manual/targeted verification run:
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/prompt-loader-extension-dir.test.ts src/resources/extensions/gsd/tests/prompt-loader-working-directory.test.ts`

## AI disclosure

- [x] This PR includes AI-assisted code (Codex). I reviewed changes and validated behavior with targeted regression tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved extension directory resolution to prioritize user-local configurations over module defaults, enhancing system flexibility and configuration management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->