### PR TITLE
fix(gsd): preserve session model and thinking in auto mode

### DIFF
--- a/src/resources/extensions/gsd/auto-model-selection.ts
+++ b/src/resources/extensions/gsd/auto-model-selection.ts
@@ -26,6 +26,14 @@ export interface ModelSelectionResult {
   appliedModel: Model<Api> | null;
 }
 
+function reapplyThinkingLevel(
+  pi: ExtensionAPI,
+  level: ReturnType<ExtensionAPI["getThinkingLevel"]> | null | undefined,
+): void {
+  if (!level) return;
+  pi.setThinkingLevel(level);
+}
+
 export function resolvePreferredModelConfig(
   unitType: string,
   autoModeStartModel: { provider: string; id: string; flatRateCtx?: FlatRateContext } | null,
@@ -84,6 +92,8 @@ export async function selectAndApplyModel(
   isAutoMode = true,
   /** Explicit /gsd model pin captured at bootstrap for long-running auto loops. */
   sessionModelOverride?: { provider: string; id: string } | null,
+  /** Thinking level captured at auto-mode start and re-applied after model swaps. */
+  autoModeStartThinkingLevel?: ReturnType<ExtensionAPI["getThinkingLevel"]> | null,
 ): Promise<ModelSelectionResult> {
   const uokFlags = resolveUokFlags(prefs);
   const effectiveSessionModelOverride = sessionModelOverride === undefined
@@ -349,6 +359,7 @@ export async function selectAndApplyModel(
       const ok = await pi.setModel(model, { persist: false });
       if (ok) {
         appliedModel = model;
+        reapplyThinkingLevel(pi, autoModeStartThinkingLevel);
 
         // ADR-005: Adjust active tool set for the selected model's provider capabilities.
         // Hard-filter incompatible tools, then let extensions override via adjust_tool_set hook.
@@ -416,10 +427,14 @@ export async function selectAndApplyModel(
         const byId = availableModels.find(m => m.id === autoModeStartModel.id);
         if (byId) {
           const fallbackOk = await pi.setModel(byId, { persist: false });
-          if (fallbackOk) appliedModel = byId;
+          if (fallbackOk) {
+            appliedModel = byId;
+            reapplyThinkingLevel(pi, autoModeStartThinkingLevel);
+          }
         }
       } else {
         appliedModel = startModel;
+        reapplyThinkingLevel(pi, autoModeStartThinkingLevel);
       }
     }
   }

--- a/src/resources/extensions/gsd/auto-start.ts
+++ b/src/resources/extensions/gsd/auto-start.ts
@@ -273,8 +273,8 @@ export async function bootstrapAutoSession(
   //
   // Precedence:
   // 1) Explicit session override via /gsd model (this session)
-  // 2) GSD model preferences from PREFERENCES.md (validated against live auth)
-  // 3) Current session model from settings/session restore (if provider ready)
+  // 2) Current session model from settings/session restore (if provider ready)
+  // 3) GSD model preferences from PREFERENCES.md (validated against live auth)
   //
   // This preserves #3517 defaults while honoring explicit runtime model
   // selection for subsequent /gsd runs in the same session.
@@ -314,11 +314,14 @@ export async function bootstrapAutoSession(
   }
   const sessionModelReady =
     ctx.model && ctx.modelRegistry.isProviderRequestReady(ctx.model.provider);
+  const currentSessionModel = (sessionModelReady && ctx.model)
+    ? { provider: ctx.model.provider, id: ctx.model.id }
+    : null;
+  const startThinkingSnapshot = pi.getThinkingLevel();
   const startModelSnapshot = manualSessionOverride
+    ?? currentSessionModel
     ?? validatedPreferredModel
-    ?? (sessionModelReady && ctx.model
-      ? { provider: ctx.model.provider, id: ctx.model.id }
-      : null);
+    ?? null;
 
   try {
     // Validate GSD_PROJECT_ID early so the user gets immediate feedback
@@ -664,8 +667,9 @@ export async function bootstrapAutoSession(
     s.pendingQuickTasks = [];
     s.currentUnit = null;
     s.currentMilestoneId = state.activeMilestone?.id ?? null;
-    s.originalModelId = ctx.model?.id ?? null;
-    s.originalModelProvider = ctx.model?.provider ?? null;
+    s.originalModelId = startModelSnapshot?.id ?? ctx.model?.id ?? null;
+    s.originalModelProvider = startModelSnapshot?.provider ?? ctx.model?.provider ?? null;
+    s.originalThinkingLevel = startThinkingSnapshot ?? null;
 
     // Register SIGTERM handler
     registerSigtermHandler(base);
@@ -779,6 +783,7 @@ export async function bootstrapAutoSession(
         id: startModelSnapshot.id,
       };
     }
+    s.autoModeStartThinkingLevel = startThinkingSnapshot ?? null;
     s.manualSessionModelOverride = manualSessionOverride ?? null;
 
     // Apply worker model override from parallel orchestrator (#worker-model).

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -969,7 +969,7 @@ export async function stopAuto(
       logWarning("engine", `file unlink failed: ${err instanceof Error ? err.message : String(err)}`, { file: "auto.ts" });
     }
 
-    // ── Step 13: Restore original model (before reset clears IDs) ──
+    // ── Step 13: Restore original model + thinking (before reset clears IDs) ──
     try {
       if (pi && ctx && s.originalModelId && s.originalModelProvider) {
         const original = ctx.modelRegistry.find(
@@ -977,6 +977,9 @@ export async function stopAuto(
           s.originalModelId,
         );
         if (original) await pi.setModel(original);
+      }
+      if (pi && s.originalThinkingLevel) {
+        pi.setThinkingLevel(s.originalThinkingLevel);
       }
     } catch (e) {
       debugLog("stop-cleanup-model", { error: e instanceof Error ? e.message : String(e) });

--- a/src/resources/extensions/gsd/auto/loop-deps.ts
+++ b/src/resources/extensions/gsd/auto/loop-deps.ts
@@ -213,6 +213,7 @@ export interface LoopDeps {
     retryContext?: { isRetry: boolean; previousTier?: string },
     isAutoMode?: boolean,
     sessionModelOverride?: { provider: string; id: string } | null,
+    autoModeStartThinkingLevel?: ReturnType<ExtensionAPI["getThinkingLevel"]> | null,
   ) => Promise<{
     routing: { tier: string; modelDowngraded: boolean } | null;
     appliedModel: { provider: string; id: string } | null;

--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -1471,6 +1471,7 @@ export async function runUnitPhase(
     sidecarItem ? undefined : { isRetry, previousTier },
     undefined,
     s.manualSessionModelOverride,
+    s.autoModeStartThinkingLevel,
   );
   s.currentUnitRouting =
     modelResult.routing as AutoSession["currentUnitRouting"];
@@ -1485,6 +1486,9 @@ export async function runUnitPhase(
     if (match) {
       const ok = await pi.setModel(match, { persist: false });
       if (ok) {
+        if (s.autoModeStartThinkingLevel) {
+          pi.setThinkingLevel(s.autoModeStartThinkingLevel);
+        }
         s.currentUnitModel = match as AutoSession["currentUnitModel"];
         ctx.ui.notify(`Hook model override: ${match.provider}/${match.id}`, "info");
       } else {

--- a/src/resources/extensions/gsd/auto/session.ts
+++ b/src/resources/extensions/gsd/auto/session.ts
@@ -17,7 +17,7 @@
  */
 
 import type { Api, Model } from "@gsd/pi-ai";
-import type { ExtensionCommandContext } from "@gsd/pi-coding-agent";
+import type { ExtensionAPI, ExtensionCommandContext } from "@gsd/pi-coding-agent";
 import type { GitServiceImpl } from "../git-service.js";
 import type { CaptureEntry } from "../captures.js";
 import type { BudgetAlertLevel } from "../auto-budget.js";
@@ -39,6 +39,8 @@ export interface StartModel {
   provider: string;
   id: string;
 }
+
+export type ThinkingLevelSnapshot = ReturnType<ExtensionAPI["getThinkingLevel"]>;
 
 export interface PendingVerificationRetry {
   unitId: string;
@@ -120,6 +122,8 @@ export class AutoSession {
   currentDispatchedModelId: string | null = null;
   originalModelId: string | null = null;
   originalModelProvider: string | null = null;
+  autoModeStartThinkingLevel: ThinkingLevelSnapshot | null = null;
+  originalThinkingLevel: ThinkingLevelSnapshot | null = null;
   lastBudgetAlertLevel: BudgetAlertLevel = 0;
 
   // ── Recovery ─────────────────────────────────────────────────────────────
@@ -241,6 +245,8 @@ export class AutoSession {
     this.currentDispatchedModelId = null;
     this.originalModelId = null;
     this.originalModelProvider = null;
+    this.autoModeStartThinkingLevel = null;
+    this.originalThinkingLevel = null;
     this.lastBudgetAlertLevel = 0;
 
     // Recovery

--- a/src/resources/extensions/gsd/complexity-classifier.ts
+++ b/src/resources/extensions/gsd/complexity-classifier.ts
@@ -32,11 +32,13 @@ export interface TaskMetadata {
 // ─── Unit Type → Default Tier Mapping ────────────────────────────────────────
 
 const UNIT_TYPE_TIERS: Record<string, ComplexityTier> = {
-  // Tier 1 — Light: structured summaries, completion, UAT
-  "complete-slice": "light",
+  // Tier 1 — Light: compact verification turns
   "run-uat": "light",
 
-  // Tier 2 — Standard: research, routine discussion
+  // Tier 2 — Standard: research, routine discussion, slice completion
+  // complete-slice can carry large inlined context; avoid routing it to the
+  // cheapest "light" model by default (#4520).
+  "complete-slice": "standard",
   "discuss-milestone": "standard",
   "discuss-slice": "standard",
   "research-milestone": "standard",

--- a/src/resources/extensions/gsd/tests/auto-model-selection.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-model-selection.test.ts
@@ -259,6 +259,18 @@ test("dynamic routing passes provider-qualified model keys to the router", () =>
   );
 });
 
+test("selectAndApplyModel re-applies captured thinking level after setModel success", () => {
+  const src = readFileSync(join(__dirname, "..", "auto-model-selection.ts"), "utf-8");
+  assert.ok(
+    src.includes("autoModeStartThinkingLevel?: ReturnType<ExtensionAPI[\"getThinkingLevel\"]> | null"),
+    "selectAndApplyModel should accept an autoModeStartThinkingLevel parameter",
+  );
+  assert.ok(
+    src.includes("reapplyThinkingLevel(pi, autoModeStartThinkingLevel)"),
+    "selectAndApplyModel should re-apply captured thinking level after model changes",
+  );
+});
+
 test("resolveModelId: anthropic wins over claude-code when session provider is not claude-code", () => {
   const availableModels = [
     { id: "claude-sonnet-4-6", provider: "claude-code" },

--- a/src/resources/extensions/gsd/tests/auto-start-model-capture.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-start-model-capture.test.ts
@@ -52,13 +52,27 @@ test("bootstrapAutoSession checks manual session override before preferences", (
     "manual override and preference fallback must be resolved before building startModelSnapshot",
   );
 
-  // The validated preferred model must still appear as one of the snapshot
-  // sources so PREFERENCES.md continues to win over a stale settings.json
-  // default for built-in providers.
+  // Preferred model should still be part of fallback resolution.
   const snapshotBlock = source.slice(snapshotIdx, snapshotIdx + 400);
   assert.ok(
     snapshotBlock.includes("validatedPreferredModel") || snapshotBlock.includes("preferredModel"),
     "startModelSnapshot must still consider preferredModel for built-in providers",
+  );
+});
+
+test("bootstrapAutoSession prioritizes current session model over PREFERENCES.md default", () => {
+  const snapshotIdx = source.indexOf("const startModelSnapshot = manualSessionOverride");
+  assert.ok(snapshotIdx > -1, "auto-start.ts should build startModelSnapshot");
+
+  const snapshotBlock = source.slice(snapshotIdx, snapshotIdx + 500);
+  const currentIdx = snapshotBlock.indexOf("currentSessionModel");
+  const preferredIdx = snapshotBlock.indexOf("validatedPreferredModel");
+
+  assert.ok(currentIdx > -1, "startModelSnapshot should include currentSessionModel");
+  assert.ok(preferredIdx > -1, "startModelSnapshot should include validatedPreferredModel");
+  assert.ok(
+    currentIdx < preferredIdx,
+    "startModelSnapshot should prefer currentSessionModel before validatedPreferredModel",
   );
 });
 
@@ -110,4 +124,20 @@ test("bootstrapAutoSession validates preferred model against live registry auth 
 
   const warningIdx = source.indexOf("is not configured; falling back to session default");
   assert.ok(warningIdx > -1, "auto-start.ts should warn when preferred model is unconfigured");
+});
+
+test("bootstrapAutoSession snapshots and persists thinking level for auto-mode lifecycle", () => {
+  const captureIdx = source.indexOf("const startThinkingSnapshot = pi.getThinkingLevel()");
+  assert.ok(captureIdx > -1, "auto-start.ts should snapshot thinking level at bootstrap start");
+
+  const originalThinkingIdx = source.indexOf("s.originalThinkingLevel = startThinkingSnapshot ?? null");
+  assert.ok(originalThinkingIdx > -1, "auto-start.ts should store originalThinkingLevel from snapshot");
+
+  const autoThinkingIdx = source.indexOf("s.autoModeStartThinkingLevel = startThinkingSnapshot ?? null");
+  assert.ok(autoThinkingIdx > -1, "auto-start.ts should store autoModeStartThinkingLevel from snapshot");
+
+  assert.ok(
+    captureIdx < originalThinkingIdx && captureIdx < autoThinkingIdx,
+    "thinking snapshot must be captured before session state assignment",
+  );
 });

--- a/src/resources/extensions/gsd/tests/auto-thinking-restore.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-thinking-restore.test.ts
@@ -1,0 +1,38 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const autoSrc = readFileSync(join(import.meta.dirname, "..", "auto.ts"), "utf-8");
+const phasesSrc = readFileSync(join(import.meta.dirname, "..", "auto", "phases.ts"), "utf-8");
+
+test("stopAuto restores original thinking level", () => {
+  assert.ok(
+    autoSrc.includes("if (pi && s.originalThinkingLevel)"),
+    "auto.ts should conditionally restore original thinking level in stopAuto",
+  );
+  assert.ok(
+    autoSrc.includes("pi.setThinkingLevel(s.originalThinkingLevel)"),
+    "auto.ts should call pi.setThinkingLevel with originalThinkingLevel",
+  );
+});
+
+test("runUnitPhase threads captured thinking level into selectAndApplyModel", () => {
+  const callIdx = phasesSrc.indexOf("deps.selectAndApplyModel(");
+  assert.ok(callIdx > -1, "phases.ts should call selectAndApplyModel");
+  const callBlock = phasesSrc.slice(callIdx, callIdx + 600);
+  assert.ok(
+    callBlock.includes("s.autoModeStartThinkingLevel"),
+    "runUnitPhase should pass autoModeStartThinkingLevel to selectAndApplyModel",
+  );
+});
+
+test("hook model override preserves captured thinking level", () => {
+  const hookIdx = phasesSrc.indexOf("const hookModelOverride = sidecarItem?.model ?? iterData.hookModelOverride;");
+  assert.ok(hookIdx > -1, "phases.ts should include hook model override handling");
+  const hookBlock = phasesSrc.slice(hookIdx, hookIdx + 600);
+  assert.ok(
+    hookBlock.includes("pi.setThinkingLevel(s.autoModeStartThinkingLevel)"),
+    "hook model override should re-apply captured thinking level after setModel",
+  );
+});

--- a/src/resources/extensions/gsd/tests/complexity-classifier.test.ts
+++ b/src/resources/extensions/gsd/tests/complexity-classifier.test.ts
@@ -21,9 +21,9 @@ test("tierOrdinal returns correct ordering", () => {
 
 // ─── Unit Type Classification ────────────────────────────────────────────────
 
-test("complete-slice classifies as light", () => {
+test("complete-slice classifies as standard", () => {
   const result = classifyUnitComplexity("complete-slice", "M001/S01", "/tmp/fake");
-  assert.equal(result.tier, "light");
+  assert.equal(result.tier, "standard");
 });
 
 test("run-uat classifies as light", () => {
@@ -145,7 +145,7 @@ test("budget pressure at 90% downgrades standard to light", () => {
   assert.equal(result.downgraded, true);
 });
 
-test("budget pressure at 90% downgrades light stays light", () => {
+test("budget pressure at 90% downgrades complete-slice standard to light", () => {
   const result = classifyUnitComplexity("complete-slice", "M001/S01", "/tmp/fake", 0.95);
   assert.equal(result.tier, "light");
 });


### PR DESCRIPTION
## Linked issue

Closes #4520

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Preserve active session model and thinking level across `/gsd auto` lifecycle, and prevent `complete-slice` from defaulting to the light routing tier.
**Why:** Auto-mode could prioritize preference-derived defaults over the active session model, never snapshot/restore thinking, and still downgrade completion turns to tiny models.
**How:** Reordered bootstrap model snapshot precedence, added thinking snapshot/restore wiring, re-applied captured thinking after `setModel`, and reclassified `complete-slice` to `standard`.

## What

- Updated `src/resources/extensions/gsd/auto-start.ts`:
  - capture `startThinkingSnapshot` at bootstrap start
  - reorder `startModelSnapshot` precedence to `manualSessionOverride ?? currentSessionModel ?? validatedPreferredModel`
  - initialize `originalModel*` from snapshot and persist `originalThinkingLevel` / `autoModeStartThinkingLevel`
- Updated `src/resources/extensions/gsd/auto/session.ts`:
  - added `autoModeStartThinkingLevel` and `originalThinkingLevel` state fields
  - reset lifecycle support for both fields
- Updated `src/resources/extensions/gsd/auto-model-selection.ts`:
  - added optional `autoModeStartThinkingLevel` parameter
  - re-apply captured thinking after successful `setModel` calls
- Updated `src/resources/extensions/gsd/auto/phases.ts`:
  - pass `s.autoModeStartThinkingLevel` into `selectAndApplyModel`
  - re-apply captured thinking after hook model overrides
- Updated `src/resources/extensions/gsd/auto/loop-deps.ts` type signature to thread the new optional parameter
- Updated `src/resources/extensions/gsd/auto.ts` stop cleanup to restore original thinking level alongside model restore
- Updated `src/resources/extensions/gsd/complexity-classifier.ts`:
  - classify `complete-slice` as `standard` (instead of `light`) to avoid routing completion turns to the smallest tier by default

## Why

Issue #4520 reports coupled regressions:
- auto bootstrap could choose a preference-derived model over the active session model
- thinking level was never snapshotted/restored, so model changes during auto could silently clobber user intent
- completion turns could still route to small light-tier models

This patch makes active session state authoritative unless there is an explicit `/gsd model` override, preserves thinking across auto-mode model transitions, and raises default routing class for `complete-slice`.

## How

- Bootstrap now computes:
  1. explicit `/gsd model` override
  2. current ready session model
  3. validated preference model fallback
- Thinking is captured once at bootstrap and carried through:
  - dispatch-time model changes (`selectAndApplyModel`)
  - hook overrides in `runUnitPhase`
  - stop-time restoration (`stopAuto`)
- Complexity defaults now treat `complete-slice` as `standard`.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

Targeted local verification run:
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/auto-start-model-capture.test.ts src/resources/extensions/gsd/tests/auto-model-selection.test.ts src/resources/extensions/gsd/tests/auto-thinking-restore.test.ts src/resources/extensions/gsd/tests/auto-session-encapsulation.test.ts src/resources/extensions/gsd/tests/complexity-classifier.test.ts`

## AI disclosure

- [x] This PR includes AI-assisted code (Codex). I reviewed the changes and validated with targeted regression tests.
