### PR TITLE
fix(models): discover openai-compatible providers + normalize think output

### DIFF
--- a/packages/pi-ai/src/providers/openai-completions.ts
+++ b/packages/pi-ai/src/providers/openai-completions.ts
@@ -39,6 +39,7 @@ import {
 	finalizeStream,
 	handleStreamError,
 } from "./openai-shared.js";
+import { ThinkTagParser } from "./think-tag-parser.js";
 import { transformMessagesWithReport } from "./transform-messages.js";
 
 /**
@@ -91,6 +92,7 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions", OpenA
 			stream.push({ type: "start", partial: output });
 
 			let currentBlock: TextContent | ThinkingContent | (ToolCall & { partialArgs?: string }) | null = null;
+			const thinkTagParser = new ThinkTagParser();
 			const blocks = output.content;
 			const blockIndex = () => blocks.length - 1;
 			const finishCurrentBlock = (block?: typeof currentBlock) => {
@@ -119,6 +121,55 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions", OpenA
 							partial: output,
 						});
 					}
+				}
+			};
+			const appendTextDelta = (delta: string) => {
+				if (!delta) return;
+				if (!currentBlock || currentBlock.type !== "text") {
+					finishCurrentBlock(currentBlock);
+					currentBlock = { type: "text", text: "" };
+					output.content.push(currentBlock);
+					stream.push({ type: "text_start", contentIndex: blockIndex(), partial: output });
+				}
+
+				if (currentBlock.type === "text") {
+					currentBlock.text += delta;
+					stream.push({
+						type: "text_delta",
+						contentIndex: blockIndex(),
+						delta,
+						partial: output,
+					});
+				}
+			};
+			const appendThinkingDelta = (delta: string) => {
+				if (!delta) return;
+				if (!currentBlock || currentBlock.type !== "thinking") {
+					finishCurrentBlock(currentBlock);
+					currentBlock = {
+						type: "thinking",
+						thinking: "",
+						thinkingSignature: "think-tag",
+					};
+					output.content.push(currentBlock);
+					stream.push({ type: "thinking_start", contentIndex: blockIndex(), partial: output });
+				}
+
+				if (currentBlock.type === "thinking") {
+					currentBlock.thinking += delta;
+					stream.push({
+						type: "thinking_delta",
+						contentIndex: blockIndex(),
+						delta,
+						partial: output,
+					});
+				}
+			};
+			const appendContentDelta = (delta: string) => {
+				const segments = thinkTagParser.consume(delta);
+				for (const segment of segments) {
+					if (segment.type === "thinking") appendThinkingDelta(segment.text);
+					else appendTextDelta(segment.text);
 				}
 			};
 
@@ -161,22 +212,7 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions", OpenA
 						choice.delta.content !== undefined &&
 						choice.delta.content.length > 0
 					) {
-						if (!currentBlock || currentBlock.type !== "text") {
-							finishCurrentBlock(currentBlock);
-							currentBlock = { type: "text", text: "" };
-							output.content.push(currentBlock);
-							stream.push({ type: "text_start", contentIndex: blockIndex(), partial: output });
-						}
-
-						if (currentBlock.type === "text") {
-							currentBlock.text += choice.delta.content;
-							stream.push({
-								type: "text_delta",
-								contentIndex: blockIndex(),
-								delta: choice.delta.content,
-								partial: output,
-							});
-						}
+						appendContentDelta(choice.delta.content);
 					}
 
 					// Some endpoints return reasoning in reasoning_content (llama.cpp),
@@ -274,6 +310,11 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions", OpenA
 						}
 					}
 				}
+			}
+
+			for (const segment of thinkTagParser.flush()) {
+				if (segment.type === "thinking") appendThinkingDelta(segment.text);
+				else appendTextDelta(segment.text);
 			}
 
 			finishCurrentBlock(currentBlock);

--- a/packages/pi-ai/src/providers/think-tag-parser.test.ts
+++ b/packages/pi-ai/src/providers/think-tag-parser.test.ts
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { ThinkTagParser } from "./think-tag-parser.js";
+
+describe("ThinkTagParser", () => {
+	it("keeps plain text untouched", () => {
+		const parser = new ThinkTagParser();
+		assert.deepEqual(parser.consume("hello world"), [{ type: "text", text: "hello world" }]);
+		assert.deepEqual(parser.flush(), []);
+	});
+
+	it("splits inline think tags into thinking segments", () => {
+		const parser = new ThinkTagParser();
+		const out = parser.consume("A<think>B</think>C");
+		assert.deepEqual(out, [
+			{ type: "text", text: "A" },
+			{ type: "thinking", text: "B" },
+			{ type: "text", text: "C" },
+		]);
+	});
+
+	it("handles tag boundaries across deltas", () => {
+		const parser = new ThinkTagParser();
+		const out1 = parser.consume("A<th");
+		const out2 = parser.consume("ink>B</thi");
+		const out3 = parser.consume("nk>C");
+		const out4 = parser.flush();
+		assert.deepEqual([...out1, ...out2, ...out3, ...out4], [
+			{ type: "text", text: "A" },
+			{ type: "thinking", text: "B" },
+			{ type: "text", text: "C" },
+		]);
+	});
+
+	it("flushes unclosed think blocks as thinking", () => {
+		const parser = new ThinkTagParser();
+		const out1 = parser.consume("A<think>partial");
+		const out2 = parser.flush();
+		assert.deepEqual([...out1, ...out2], [
+			{ type: "text", text: "A" },
+			{ type: "thinking", text: "partial" },
+		]);
+	});
+});

--- a/packages/pi-ai/src/providers/think-tag-parser.ts
+++ b/packages/pi-ai/src/providers/think-tag-parser.ts
@@ -1,0 +1,94 @@
+export type ThinkSegmentType = "text" | "thinking";
+
+export interface ThinkSegment {
+	type: ThinkSegmentType;
+	text: string;
+}
+
+interface ThinkTagParserState {
+	mode: ThinkSegmentType;
+	pending: string;
+}
+
+const OPEN_TAG = "<think>";
+const CLOSE_TAG = "</think>";
+
+function trailingPartialLength(text: string, token: string): number {
+	const max = Math.min(text.length, token.length - 1);
+	for (let len = max; len > 0; len--) {
+		if (token.startsWith(text.slice(-len))) return len;
+	}
+	return 0;
+}
+
+/**
+ * Stateful parser for streaming `<think>...</think>` wrappers emitted by some
+ * OpenAI-compatible providers. Converts tagged sections into logical
+ * text/thinking segments while handling chunk boundaries safely.
+ */
+export class ThinkTagParser {
+	private state: ThinkTagParserState = { mode: "text", pending: "" };
+
+	consume(delta: string): ThinkSegment[] {
+		this.state.pending += delta;
+		return this.drain(false);
+	}
+
+	flush(): ThinkSegment[] {
+		return this.drain(true);
+	}
+
+	private drain(flushAll: boolean): ThinkSegment[] {
+		const out: ThinkSegment[] = [];
+		const push = (type: ThinkSegmentType, text: string) => {
+			if (!text) return;
+			out.push({ type, text });
+		};
+
+		while (this.state.pending.length > 0) {
+			if (this.state.mode === "text") {
+				const openIdx = this.state.pending.indexOf(OPEN_TAG);
+				if (openIdx >= 0) {
+					push("text", this.state.pending.slice(0, openIdx));
+					this.state.pending = this.state.pending.slice(openIdx + OPEN_TAG.length);
+					this.state.mode = "thinking";
+					continue;
+				}
+
+				if (flushAll) {
+					push("text", this.state.pending);
+					this.state.pending = "";
+					break;
+				}
+
+				const keep = trailingPartialLength(this.state.pending, OPEN_TAG);
+				const safeEnd = Math.max(0, this.state.pending.length - keep);
+				push("text", this.state.pending.slice(0, safeEnd));
+				this.state.pending = this.state.pending.slice(safeEnd);
+				break;
+			}
+
+			const closeIdx = this.state.pending.indexOf(CLOSE_TAG);
+			if (closeIdx >= 0) {
+				push("thinking", this.state.pending.slice(0, closeIdx));
+				this.state.pending = this.state.pending.slice(closeIdx + CLOSE_TAG.length);
+				this.state.mode = "text";
+				continue;
+			}
+
+			if (flushAll) {
+				push("thinking", this.state.pending);
+				this.state.pending = "";
+				break;
+			}
+
+			const keep = trailingPartialLength(this.state.pending, CLOSE_TAG);
+			const safeEnd = Math.max(0, this.state.pending.length - keep);
+			push("thinking", this.state.pending.slice(0, safeEnd));
+			this.state.pending = this.state.pending.slice(safeEnd);
+			break;
+		}
+
+		return out;
+	}
+}

--- a/packages/pi-coding-agent/src/core/model-discovery.test.ts
+++ b/packages/pi-coding-agent/src/core/model-discovery.test.ts
@@ -5,6 +5,7 @@ import {
 	getDefaultTTL,
 	getDiscoverableProviders,
 	getDiscoveryAdapter,
+	supportsDiscoveryForApi,
 } from "./model-discovery.js";
 
 // ─── getDiscoveryAdapter ─────────────────────────────────────────────────────
@@ -50,6 +51,12 @@ describe("getDiscoveryAdapter", () => {
 		const adapter = getDiscoveryAdapter("unknown-provider");
 		assert.equal(adapter.provider, "unknown-provider");
 		assert.equal(adapter.supportsDiscovery, false);
+	});
+
+	it("returns OpenAI-style adapter for unknown provider with OpenAI-compatible API", () => {
+		const adapter = getDiscoveryAdapter("my-proxy", ["openai-completions"]);
+		assert.equal(adapter.provider, "my-proxy");
+		assert.equal(adapter.supportsDiscovery, true);
 	});
 
 	it("static adapter fetchModels returns empty array", async () => {
@@ -121,5 +128,17 @@ describe("DISCOVERY_TTLS", () => {
 			assert.equal(typeof value, "number");
 			assert.ok(value > 0);
 		}
+	});
+});
+
+describe("supportsDiscoveryForApi", () => {
+	it("returns true for OpenAI-compatible APIs", () => {
+		assert.equal(supportsDiscoveryForApi("openai-completions"), true);
+		assert.equal(supportsDiscoveryForApi("openai-responses"), true);
+	});
+
+	it("returns false for non-discoverable APIs", () => {
+		assert.equal(supportsDiscoveryForApi("anthropic-messages"), false);
+		assert.equal(supportsDiscoveryForApi(undefined), false);
 	});
 });

--- a/packages/pi-coding-agent/src/core/model-discovery.ts
+++ b/packages/pi-coding-agent/src/core/model-discovery.ts
@@ -26,6 +26,14 @@ export interface ProviderDiscoveryAdapter {
 	fetchModels(apiKey: string, baseUrl?: string): Promise<DiscoveredModel[]>;
 }
 
+export const OPENAI_COMPAT_DISCOVERY_APIS = new Set([
+	"openai",
+	"openai-completions",
+	"openai-responses",
+	"openai-codex-responses",
+	"azure-openai-responses",
+]);
+
 /** Per-provider TTLs in milliseconds */
 export const DISCOVERY_TTLS: Record<string, number> = {
 	ollama: 5 * 60 * 1000, // 5 minutes (local, models change often)
@@ -53,9 +61,76 @@ async function fetchWithTimeout(url: string, options: RequestInit = {}, timeoutM
 
 const OPENAI_EXCLUDED_PREFIXES = ["embedding", "tts", "dall-e", "whisper", "text-embedding", "davinci", "babbage"];
 
+function asPositiveNumber(value: unknown): number | undefined {
+	if (typeof value === "number" && Number.isFinite(value) && value > 0) return value;
+	if (typeof value === "string") {
+		const n = Number.parseFloat(value);
+		if (Number.isFinite(n) && n > 0) return n;
+	}
+	return undefined;
+}
+
+function pickFirstPositiveNumber(record: Record<string, unknown>, keys: string[]): number | undefined {
+	for (const key of keys) {
+		const value = asPositiveNumber(record[key]);
+		if (value !== undefined) return value;
+	}
+	return undefined;
+}
+
+function discoverInputModalities(rawModel: Record<string, unknown>, id: string): Array<"text" | "image"> {
+	const directModalities = rawModel.input_modalities;
+	const capabilitiesModalities = (rawModel.capabilities as Record<string, unknown> | undefined)?.input_modalities;
+	const source = Array.isArray(directModalities)
+		? directModalities
+		: Array.isArray(capabilitiesModalities)
+			? capabilitiesModalities
+			: [];
+	const supportsImage = source.some((m) => typeof m === "string" && /image|vision/i.test(m))
+		|| /vision|image|omni|multimodal/i.test(id);
+	return supportsImage ? ["text", "image"] : ["text"];
+}
+
+function parseOpenAICompatibleModel(rawModel: Record<string, unknown>): DiscoveredModel | undefined {
+	const id = typeof rawModel.id === "string" ? rawModel.id : "";
+	if (!id) return undefined;
+	if (OPENAI_EXCLUDED_PREFIXES.some((prefix) => id.startsWith(prefix))) return undefined;
+
+	const contextWindow = pickFirstPositiveNumber(rawModel, [
+		"context_window",
+		"context_length",
+		"max_context_length",
+		"max_input_tokens",
+		"input_token_limit",
+		"max_model_len",
+	]);
+	const maxTokens = pickFirstPositiveNumber(rawModel, [
+		"max_output_tokens",
+		"output_token_limit",
+		"max_completion_tokens",
+		"max_tokens",
+	]);
+	const reasoning = rawModel.reasoning === true
+		|| rawModel.supports_reasoning === true
+		|| ((rawModel.capabilities as Record<string, unknown> | undefined)?.reasoning === true);
+
+	return {
+		id,
+		name: typeof rawModel.name === "string" && rawModel.name.length > 0 ? rawModel.name : id,
+		contextWindow,
+		maxTokens,
+		reasoning,
+		input: discoverInputModalities(rawModel, id),
+	};
+}
+
 class OpenAIDiscoveryAdapter implements ProviderDiscoveryAdapter {
-	provider = "openai";
+	provider: string;
 	supportsDiscovery = true;
+
+	constructor(provider: string) {
+		this.provider = provider;
+	}
 
 	async fetchModels(apiKey: string, baseUrl?: string): Promise<DiscoveredModel[]> {
 		const url = `${baseUrl ?? "https://api.openai.com"}/v1/models`;
@@ -67,14 +142,10 @@ class OpenAIDiscoveryAdapter implements ProviderDiscoveryAdapter {
 			throw new Error(`OpenAI models API returned ${response.status}: ${response.statusText}`);
 		}
 
-		const data = (await response.json()) as { data: Array<{ id: string; owned_by?: string }> };
-		return data.data
-			.filter((m) => !OPENAI_EXCLUDED_PREFIXES.some((prefix) => m.id.startsWith(prefix)))
-			.map((m) => ({
-				id: m.id,
-				name: m.id,
-				input: ["text" as const, "image" as const],
-			}));
+		const data = (await response.json()) as { data?: Array<Record<string, unknown>> };
+		return (data.data ?? [])
+			.map((m) => parseOpenAICompatibleModel(m))
+			.filter((m): m is DiscoveredModel => !!m);
 	}
 }
 
@@ -207,7 +278,7 @@ class StaticDiscoveryAdapter implements ProviderDiscoveryAdapter {
 // ─── Registry ────────────────────────────────────────────────────────────────
 
 const adapters: Record<string, ProviderDiscoveryAdapter> = {
-	openai: new OpenAIDiscoveryAdapter(),
+	openai: new OpenAIDiscoveryAdapter("openai"),
 	ollama: new OllamaDiscoveryAdapter(),
 	openrouter: new OpenRouterDiscoveryAdapter(),
 	google: new GoogleDiscoveryAdapter(),
@@ -220,8 +291,24 @@ const adapters: Record<string, ProviderDiscoveryAdapter> = {
 	mistral: new StaticDiscoveryAdapter("mistral"),
 };
 
-export function getDiscoveryAdapter(provider: string): ProviderDiscoveryAdapter {
-	return adapters[provider] ?? new StaticDiscoveryAdapter(provider);
+export function supportsDiscoveryForApi(api: string | undefined): boolean {
+	if (!api) return false;
+	return OPENAI_COMPAT_DISCOVERY_APIS.has(api);
+}
+
+export function getDiscoveryAdapter(provider: string, providerApis?: Iterable<string>): ProviderDiscoveryAdapter {
+	const known = adapters[provider];
+	if (known) return known;
+
+	if (providerApis) {
+		for (const api of providerApis) {
+			if (supportsDiscoveryForApi(api)) {
+				return new OpenAIDiscoveryAdapter(provider);
+			}
+		}
+	}
+
+	return new StaticDiscoveryAdapter(provider);
 }
 
 export function getDiscoverableProviders(): string[] {

--- a/packages/pi-coding-agent/src/core/model-registry-discovery.test.ts
+++ b/packages/pi-coding-agent/src/core/model-registry-discovery.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, it } from "node:test";
 import { AuthStorage } from "./auth-storage.js";
 import { ModelDiscoveryCache } from "./discovery-cache.js";
 import { getDefaultTTL, getDiscoverableProviders, getDiscoveryAdapter } from "./model-discovery.js";
+import { ModelRegistry } from "./model-registry.js";
 
 let testDir: string;
 
@@ -131,5 +132,76 @@ describe("Discovery TTL configuration", () => {
 		const defaultTTL = getDefaultTTL("default");
 		// Unknown providers should get the same TTL as the explicit "default" key
 		assert.equal(customTTL, defaultTTL);
+	});
+});
+
+describe("ModelRegistry discovery — OpenAI-compatible custom providers", () => {
+	it("discovers custom OpenAI-compatible providers and maps capability metadata", async () => {
+		const modelsPath = join(testDir, "models.json");
+		writeFileSync(
+			modelsPath,
+			JSON.stringify(
+				{
+					providers: {
+						"minimax-openai": {
+							baseUrl: "https://api.minimax.example",
+							apiKey: "minimax-test-key",
+							api: "openai-completions",
+							models: [{ id: "bootstrap-model" }],
+						},
+					},
+				},
+				null,
+				2,
+			),
+			"utf-8",
+		);
+
+		const prevFetch = globalThis.fetch;
+		let requestedUrl = "";
+		globalThis.fetch = (async (input: string | URL | Request) => {
+			requestedUrl = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+			return new Response(
+				JSON.stringify({
+					data: [
+						{
+							id: "MiniMax-M2.7-highspeed",
+							name: "MiniMax M2.7 Highspeed",
+							context_window: 165000,
+							max_output_tokens: 32768,
+							supports_reasoning: true,
+							input_modalities: ["text", "image"],
+						},
+					],
+				}),
+				{
+					status: 200,
+					headers: { "content-type": "application/json" },
+				},
+			);
+		}) as typeof globalThis.fetch;
+
+		try {
+			const registry = new ModelRegistry(AuthStorage.inMemory({}), modelsPath);
+			const results = await registry.discoverModels(["minimax-openai"]);
+
+			const discovery = results.find((r) => r.provider === "minimax-openai");
+			assert.ok(discovery, "discovery result should include custom provider");
+			assert.equal(discovery?.error, undefined, "custom provider discovery should succeed");
+			assert.equal(requestedUrl, "https://api.minimax.example/v1/models");
+
+			const discovered = registry
+				.getAllWithDiscovered()
+				.find((m) => m.provider === "minimax-openai" && m.id === "MiniMax-M2.7-highspeed");
+			assert.ok(discovered, "discovered model should be merged into model list");
+			assert.equal(discovered?.api, "openai-completions");
+			assert.equal(discovered?.baseUrl, "https://api.minimax.example");
+			assert.equal(discovered?.contextWindow, 165000);
+			assert.equal(discovered?.maxTokens, 32768);
+			assert.equal(discovered?.reasoning, true);
+			assert.deepEqual(discovered?.input, ["text", "image"]);
+		} finally {
+			globalThis.fetch = prevFetch;
+		}
 	});
 });

--- a/packages/pi-coding-agent/src/core/model-registry-discovery.test.ts
+++ b/packages/pi-coding-agent/src/core/model-registry-discovery.test.ts
@@ -137,13 +137,14 @@ describe("Discovery TTL configuration", () => {
 
 describe("ModelRegistry discovery — OpenAI-compatible custom providers", () => {
 	it("discovers custom OpenAI-compatible providers and maps capability metadata", async () => {
+		const providerName = `minimax-openai-${Date.now()}-${Math.random().toString(36).slice(2)}`;
 		const modelsPath = join(testDir, "models.json");
 		writeFileSync(
 			modelsPath,
 			JSON.stringify(
 				{
 					providers: {
-						"minimax-openai": {
+						[providerName]: {
 							baseUrl: "https://api.minimax.example",
 							apiKey: "minimax-test-key",
 							api: "openai-completions",
@@ -183,16 +184,18 @@ describe("ModelRegistry discovery — OpenAI-compatible custom providers", () =>
 
 		try {
 			const registry = new ModelRegistry(AuthStorage.inMemory({}), modelsPath);
-			const results = await registry.discoverModels(["minimax-openai"]);
+			// Guard against global cache leakage from prior test runs.
+			registry.getDiscoveryCache().clear(providerName);
+			const results = await registry.discoverModels([providerName]);
 
-			const discovery = results.find((r) => r.provider === "minimax-openai");
+			const discovery = results.find((r) => r.provider === providerName);
 			assert.ok(discovery, "discovery result should include custom provider");
 			assert.equal(discovery?.error, undefined, "custom provider discovery should succeed");
 			assert.equal(requestedUrl, "https://api.minimax.example/v1/models");
 
 			const discovered = registry
 				.getAllWithDiscovered()
-				.find((m) => m.provider === "minimax-openai" && m.id === "MiniMax-M2.7-highspeed");
+				.find((m) => m.provider === providerName && m.id === "MiniMax-M2.7-highspeed");
 			assert.ok(discovered, "discovered model should be merged into model list");
 			assert.equal(discovered?.api, "openai-completions");
 			assert.equal(discovered?.baseUrl, "https://api.minimax.example");

--- a/packages/pi-coding-agent/src/core/model-registry.ts
+++ b/packages/pi-coding-agent/src/core/model-registry.ts
@@ -29,7 +29,7 @@ import { getAgentDir } from "../config.js";
 import type { AuthStorage } from "./auth-storage.js";
 import { ModelDiscoveryCache } from "./discovery-cache.js";
 import type { DiscoveredModel, DiscoveryResult } from "./model-discovery.js";
-import { getDefaultTTL, getDiscoverableProviders, getDiscoveryAdapter } from "./model-discovery.js";
+import { getDefaultTTL, getDiscoverableProviders, getDiscoveryAdapter, supportsDiscoveryForApi } from "./model-discovery.js";
 import { clearConfigValueCache, resolveConfigValue, resolveHeaders } from "./resolve-config-value.js";
 import { isLocalModel } from "./local-model-check.js";
 
@@ -788,11 +788,12 @@ export class ModelRegistry {
 	 * Results are cached and merged into the registry (never overrides existing models).
 	 */
 	async discoverModels(providers?: string[]): Promise<DiscoveryResult[]> {
-		const targetProviders = providers ?? getDiscoverableProviders();
+		const targetProviders = providers ?? this.getAutoDiscoverableProviders();
 		const results: DiscoveryResult[] = [];
 
 		for (const providerName of targetProviders) {
-			const adapter = getDiscoveryAdapter(providerName);
+			const providerApis = this.getProviderApis(providerName);
+			const adapter = getDiscoveryAdapter(providerName, providerApis);
 			if (!adapter.supportsDiscovery) continue;
 
 			// Skip if cache is still fresh
@@ -812,8 +813,10 @@ export class ModelRegistry {
 				const apiKey = await this.authStorage.getApiKey(providerName);
 				if (!apiKey && !this.isProviderRequestReady(providerName)) continue;
 
-				const models = await adapter.fetchModels(apiKey ?? "", undefined);
-				this.discoveryCache.set(providerName, models);
+				const baseUrl = this.getProviderBaseUrl(providerName);
+				const models = await adapter.fetchModels(apiKey ?? "", baseUrl);
+				const ttlMs = this.getDiscoveryTtl(providerName, providerApis);
+				this.discoveryCache.set(providerName, models, ttlMs);
 				results.push({
 					provider: providerName,
 					models,
@@ -865,22 +868,95 @@ export class ModelRegistry {
 		const converted: Model<Api>[] = [];
 		for (const result of results) {
 			if (result.error) continue;
+			const providerDefaults = this.getDiscoveryProviderDefaults(result.provider);
 			for (const dm of result.models) {
 				converted.push({
 					id: dm.id,
 					name: dm.name ?? dm.id,
-					api: "openai" as Api,
+					api: providerDefaults.api,
 					provider: result.provider,
-					baseUrl: "",
+					baseUrl: providerDefaults.baseUrl,
 					reasoning: dm.reasoning ?? false,
-					input: dm.input ?? ["text"],
+					input: dm.input ?? providerDefaults.input,
 					cost: dm.cost ?? { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-					contextWindow: dm.contextWindow ?? 128000,
-					maxTokens: dm.maxTokens ?? 16384,
+					contextWindow: dm.contextWindow ?? providerDefaults.contextWindow,
+					maxTokens: dm.maxTokens ?? providerDefaults.maxTokens,
 				} as Model<Api>);
 			}
 		}
 		return converted;
+	}
+
+	private getProviderApis(provider: string): Set<string> {
+		const apis = new Set<string>();
+		for (const model of this.models) {
+			if (model.provider === provider && typeof model.api === "string" && model.api.length > 0) {
+				apis.add(model.api);
+			}
+		}
+
+		const providerConfig = this.registeredProviders.get(provider);
+		if (providerConfig?.api) apis.add(providerConfig.api);
+		for (const modelDef of providerConfig?.models ?? []) {
+			if (modelDef.api) apis.add(modelDef.api);
+		}
+		return apis;
+	}
+
+	private getAutoDiscoverableProviders(): string[] {
+		const discoverable = new Set<string>(getDiscoverableProviders());
+		for (const provider of new Set(this.models.map((m) => m.provider))) {
+			const apis = this.getProviderApis(provider);
+			for (const api of apis) {
+				if (supportsDiscoveryForApi(api)) {
+					discoverable.add(provider);
+					break;
+				}
+			}
+		}
+		return [...discoverable];
+	}
+
+	private getProviderBaseUrl(provider: string): string | undefined {
+		const fromModels = this.models.find((m) => m.provider === provider && typeof m.baseUrl === "string" && m.baseUrl.length > 0);
+		if (fromModels?.baseUrl) return fromModels.baseUrl;
+		return this.registeredProviders.get(provider)?.baseUrl;
+	}
+
+	private getDiscoveryProviderDefaults(provider: string): {
+		api: Api;
+		baseUrl: string;
+		input: ("text" | "image")[];
+		contextWindow: number;
+		maxTokens: number;
+	} {
+		const first = this.models.find((m) => m.provider === provider);
+		if (first) {
+			return {
+				api: first.api,
+				baseUrl: first.baseUrl,
+				input: first.input,
+				contextWindow: first.contextWindow,
+				maxTokens: first.maxTokens,
+			};
+		}
+
+		return {
+			api: "openai-completions",
+			baseUrl: this.registeredProviders.get(provider)?.baseUrl ?? "",
+			input: ["text"],
+			contextWindow: 128000,
+			maxTokens: 16384,
+		};
+	}
+
+	private getDiscoveryTtl(provider: string, providerApis: Set<string>): number {
+		for (const api of providerApis) {
+			if (supportsDiscoveryForApi(api)) {
+				return getDefaultTTL("openai");
+			}
+		}
+		return getDefaultTTL(provider);
 	}
 
 	/**

--- a/packages/pi-coding-agent/src/modes/interactive/components/provider-manager.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/components/provider-manager.ts
@@ -12,7 +12,7 @@ import {
 	type TUI,
 } from "@gsd/pi-tui";
 import type { AuthStorage } from "../../../core/auth-storage.js";
-import { getDiscoverableProviders } from "../../../core/model-discovery.js";
+import { getDiscoverableProviders, getDiscoveryAdapter } from "../../../core/model-discovery.js";
 import { providerDisplayName } from "./model-selector.js";
 import type { ModelRegistry } from "../../../core/model-registry.js";
 import { ModelsJsonWriter } from "../../../core/models-json-writer.js";
@@ -102,12 +102,21 @@ export class ProviderManagerComponent extends Container implements Focusable {
 
 		this.providers = Array.from(providerNames)
 			.sort()
-			.map((name) => ({
-				name,
-				hasAuth: this.authStorage.hasAuth(name),
-				supportsDiscovery: discoverableSet.has(name),
-				modelCount: providerModelCounts.get(name) ?? 0,
-			}));
+			.map((name) => {
+				const providerApis = new Set(
+					allModels
+						.filter((m) => m.provider === name)
+						.map((m) => m.api)
+						.filter((api): api is string => typeof api === "string" && api.length > 0),
+				);
+				return {
+					name,
+					hasAuth: this.authStorage.hasAuth(name),
+					supportsDiscovery:
+						discoverableSet.has(name) || getDiscoveryAdapter(name, providerApis).supportsDiscovery,
+					modelCount: providerModelCounts.get(name) ?? 0,
+				};
+			});
 		this.clampSelectedIndex();
 	}
 

--- a/src/resources/extensions/gsd/auto-model-selection.ts
+++ b/src/resources/extensions/gsd/auto-model-selection.ts
@@ -33,6 +33,14 @@ export interface PreferredModelConfig {
   source: "explicit" | "synthesized";
 }
 
+function reapplyThinkingLevel(
+  pi: ExtensionAPI,
+  level: ReturnType<ExtensionAPI["getThinkingLevel"]> | null | undefined,
+): void {
+  if (!level) return;
+  pi.setThinkingLevel(level);
+}
+
 export function resolvePreferredModelConfig(
   unitType: string,
   autoModeStartModel: { provider: string; id: string; flatRateCtx?: FlatRateContext } | null,
@@ -97,6 +105,8 @@ export async function selectAndApplyModel(
   isAutoMode = true,
   /** Explicit /gsd model pin captured at bootstrap for long-running auto loops. */
   sessionModelOverride?: { provider: string; id: string } | null,
+  /** Thinking level captured at auto-mode start and re-applied after model swaps. */
+  autoModeStartThinkingLevel?: ReturnType<ExtensionAPI["getThinkingLevel"]> | null,
 ): Promise<ModelSelectionResult> {
   const uokFlags = resolveUokFlags(prefs);
   const effectiveSessionModelOverride = sessionModelOverride === undefined
@@ -380,6 +390,7 @@ export async function selectAndApplyModel(
       const ok = await pi.setModel(model, { persist: false });
       if (ok) {
         appliedModel = model;
+        reapplyThinkingLevel(pi, autoModeStartThinkingLevel);
 
         // ADR-005: Adjust active tool set for the selected model's provider capabilities.
         // Hard-filter incompatible tools, then let extensions override via adjust_tool_set hook.
@@ -456,10 +467,14 @@ export async function selectAndApplyModel(
           );
           if (byId) {
             const fallbackOk = await pi.setModel(byId, { persist: false });
-            if (fallbackOk) appliedModel = byId;
+            if (fallbackOk) {
+              appliedModel = byId;
+              reapplyThinkingLevel(pi, autoModeStartThinkingLevel);
+            }
           }
         } else {
           appliedModel = startModel;
+          reapplyThinkingLevel(pi, autoModeStartThinkingLevel);
         }
       }
     }

--- a/src/resources/extensions/gsd/auto-start.ts
+++ b/src/resources/extensions/gsd/auto-start.ts
@@ -273,8 +273,8 @@ export async function bootstrapAutoSession(
   //
   // Precedence:
   // 1) Explicit session override via /gsd model (this session)
-  // 2) GSD model preferences from PREFERENCES.md (validated against live auth)
-  // 3) Current session model from settings/session restore (if provider ready)
+  // 2) Current session model from settings/session restore (if provider ready)
+  // 3) GSD model preferences from PREFERENCES.md (validated against live auth)
   //
   // This preserves #3517 defaults while honoring explicit runtime model
   // selection for subsequent /gsd runs in the same session.
@@ -314,11 +314,14 @@ export async function bootstrapAutoSession(
   }
   const sessionModelReady =
     ctx.model && ctx.modelRegistry.isProviderRequestReady(ctx.model.provider);
+  const currentSessionModel = (sessionModelReady && ctx.model)
+    ? { provider: ctx.model.provider, id: ctx.model.id }
+    : null;
+  const startThinkingSnapshot = pi.getThinkingLevel();
   const startModelSnapshot = manualSessionOverride
+    ?? currentSessionModel
     ?? validatedPreferredModel
-    ?? (sessionModelReady && ctx.model
-      ? { provider: ctx.model.provider, id: ctx.model.id }
-      : null);
+    ?? null;
 
   try {
     // Validate GSD_PROJECT_ID early so the user gets immediate feedback
@@ -664,8 +667,9 @@ export async function bootstrapAutoSession(
     s.pendingQuickTasks = [];
     s.currentUnit = null;
     s.currentMilestoneId = state.activeMilestone?.id ?? null;
-    s.originalModelId = ctx.model?.id ?? null;
-    s.originalModelProvider = ctx.model?.provider ?? null;
+    s.originalModelId = startModelSnapshot?.id ?? ctx.model?.id ?? null;
+    s.originalModelProvider = startModelSnapshot?.provider ?? ctx.model?.provider ?? null;
+    s.originalThinkingLevel = startThinkingSnapshot ?? null;
 
     // Register SIGTERM handler
     registerSigtermHandler(base);
@@ -779,6 +783,7 @@ export async function bootstrapAutoSession(
         id: startModelSnapshot.id,
       };
     }
+    s.autoModeStartThinkingLevel = startThinkingSnapshot ?? null;
     s.manualSessionModelOverride = manualSessionOverride ?? null;
 
     // Apply worker model override from parallel orchestrator (#worker-model).

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -969,7 +969,7 @@ export async function stopAuto(
       logWarning("engine", `file unlink failed: ${err instanceof Error ? err.message : String(err)}`, { file: "auto.ts" });
     }
 
-    // ── Step 13: Restore original model (before reset clears IDs) ──
+    // ── Step 13: Restore original model + thinking (before reset clears IDs) ──
     try {
       if (pi && ctx && s.originalModelId && s.originalModelProvider) {
         const original = ctx.modelRegistry.find(
@@ -977,6 +977,9 @@ export async function stopAuto(
           s.originalModelId,
         );
         if (original) await pi.setModel(original);
+      }
+      if (pi && s.originalThinkingLevel) {
+        pi.setThinkingLevel(s.originalThinkingLevel);
       }
     } catch (e) {
       debugLog("stop-cleanup-model", { error: e instanceof Error ? e.message : String(e) });

--- a/src/resources/extensions/gsd/auto/loop-deps.ts
+++ b/src/resources/extensions/gsd/auto/loop-deps.ts
@@ -213,6 +213,7 @@ export interface LoopDeps {
     retryContext?: { isRetry: boolean; previousTier?: string },
     isAutoMode?: boolean,
     sessionModelOverride?: { provider: string; id: string } | null,
+    autoModeStartThinkingLevel?: ReturnType<ExtensionAPI["getThinkingLevel"]> | null,
   ) => Promise<{
     routing: { tier: string; modelDowngraded: boolean } | null;
     appliedModel: { provider: string; id: string } | null;

--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -1471,6 +1471,7 @@ export async function runUnitPhase(
     sidecarItem ? undefined : { isRetry, previousTier },
     undefined,
     s.manualSessionModelOverride,
+    s.autoModeStartThinkingLevel,
   );
   s.currentUnitRouting =
     modelResult.routing as AutoSession["currentUnitRouting"];
@@ -1485,6 +1486,9 @@ export async function runUnitPhase(
     if (match) {
       const ok = await pi.setModel(match, { persist: false });
       if (ok) {
+        if (s.autoModeStartThinkingLevel) {
+          pi.setThinkingLevel(s.autoModeStartThinkingLevel);
+        }
         s.currentUnitModel = match as AutoSession["currentUnitModel"];
         ctx.ui.notify(`Hook model override: ${match.provider}/${match.id}`, "info");
       } else {

--- a/src/resources/extensions/gsd/auto/session.ts
+++ b/src/resources/extensions/gsd/auto/session.ts
@@ -17,7 +17,7 @@
  */
 
 import type { Api, Model } from "@gsd/pi-ai";
-import type { ExtensionCommandContext } from "@gsd/pi-coding-agent";
+import type { ExtensionAPI, ExtensionCommandContext } from "@gsd/pi-coding-agent";
 import type { GitServiceImpl } from "../git-service.js";
 import type { CaptureEntry } from "../captures.js";
 import type { BudgetAlertLevel } from "../auto-budget.js";
@@ -39,6 +39,8 @@ export interface StartModel {
   provider: string;
   id: string;
 }
+
+export type ThinkingLevelSnapshot = ReturnType<ExtensionAPI["getThinkingLevel"]>;
 
 export interface PendingVerificationRetry {
   unitId: string;
@@ -120,6 +122,8 @@ export class AutoSession {
   currentDispatchedModelId: string | null = null;
   originalModelId: string | null = null;
   originalModelProvider: string | null = null;
+  autoModeStartThinkingLevel: ThinkingLevelSnapshot | null = null;
+  originalThinkingLevel: ThinkingLevelSnapshot | null = null;
   lastBudgetAlertLevel: BudgetAlertLevel = 0;
 
   // ── Recovery ─────────────────────────────────────────────────────────────
@@ -241,6 +245,8 @@ export class AutoSession {
     this.currentDispatchedModelId = null;
     this.originalModelId = null;
     this.originalModelProvider = null;
+    this.autoModeStartThinkingLevel = null;
+    this.originalThinkingLevel = null;
     this.lastBudgetAlertLevel = 0;
 
     // Recovery

--- a/src/resources/extensions/gsd/complexity-classifier.ts
+++ b/src/resources/extensions/gsd/complexity-classifier.ts
@@ -32,11 +32,13 @@ export interface TaskMetadata {
 // ─── Unit Type → Default Tier Mapping ────────────────────────────────────────
 
 const UNIT_TYPE_TIERS: Record<string, ComplexityTier> = {
-  // Tier 1 — Light: structured summaries, completion, UAT
-  "complete-slice": "light",
+  // Tier 1 — Light: compact verification turns
   "run-uat": "light",
 
-  // Tier 2 — Standard: research, routine discussion
+  // Tier 2 — Standard: research, routine discussion, slice completion
+  // complete-slice can carry large inlined context; avoid routing it to the
+  // cheapest "light" model by default (#4520).
+  "complete-slice": "standard",
   "discuss-milestone": "standard",
   "discuss-slice": "standard",
   "research-milestone": "standard",

--- a/src/resources/extensions/gsd/tests/auto-model-selection.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-model-selection.test.ts
@@ -341,6 +341,18 @@ test("dynamic routing passes provider-qualified model keys to the router", () =>
   );
 });
 
+test("selectAndApplyModel re-applies captured thinking level after setModel success", () => {
+  const src = readFileSync(join(__dirname, "..", "auto-model-selection.ts"), "utf-8");
+  assert.ok(
+    src.includes("autoModeStartThinkingLevel?: ReturnType<ExtensionAPI[\"getThinkingLevel\"]> | null"),
+    "selectAndApplyModel should accept an autoModeStartThinkingLevel parameter",
+  );
+  assert.ok(
+    src.includes("reapplyThinkingLevel(pi, autoModeStartThinkingLevel)"),
+    "selectAndApplyModel should re-apply captured thinking level after model changes",
+  );
+});
+
 test("resolveModelId: anthropic wins over claude-code when session provider is not claude-code", () => {
   const availableModels = [
     { id: "claude-sonnet-4-6", provider: "claude-code" },

--- a/src/resources/extensions/gsd/tests/auto-start-model-capture.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-start-model-capture.test.ts
@@ -52,13 +52,27 @@ test("bootstrapAutoSession checks manual session override before preferences", (
     "manual override and preference fallback must be resolved before building startModelSnapshot",
   );
 
-  // The validated preferred model must still appear as one of the snapshot
-  // sources so PREFERENCES.md continues to win over a stale settings.json
-  // default for built-in providers.
+  // Preferred model should still be part of fallback resolution.
   const snapshotBlock = source.slice(snapshotIdx, snapshotIdx + 400);
   assert.ok(
     snapshotBlock.includes("validatedPreferredModel") || snapshotBlock.includes("preferredModel"),
     "startModelSnapshot must still consider preferredModel for built-in providers",
+  );
+});
+
+test("bootstrapAutoSession prioritizes current session model over PREFERENCES.md default", () => {
+  const snapshotIdx = source.indexOf("const startModelSnapshot = manualSessionOverride");
+  assert.ok(snapshotIdx > -1, "auto-start.ts should build startModelSnapshot");
+
+  const snapshotBlock = source.slice(snapshotIdx, snapshotIdx + 500);
+  const currentIdx = snapshotBlock.indexOf("currentSessionModel");
+  const preferredIdx = snapshotBlock.indexOf("validatedPreferredModel");
+
+  assert.ok(currentIdx > -1, "startModelSnapshot should include currentSessionModel");
+  assert.ok(preferredIdx > -1, "startModelSnapshot should include validatedPreferredModel");
+  assert.ok(
+    currentIdx < preferredIdx,
+    "startModelSnapshot should prefer currentSessionModel before validatedPreferredModel",
   );
 });
 
@@ -110,4 +124,20 @@ test("bootstrapAutoSession validates preferred model against live registry auth 
 
   const warningIdx = source.indexOf("is not configured; falling back to session default");
   assert.ok(warningIdx > -1, "auto-start.ts should warn when preferred model is unconfigured");
+});
+
+test("bootstrapAutoSession snapshots and persists thinking level for auto-mode lifecycle", () => {
+  const captureIdx = source.indexOf("const startThinkingSnapshot = pi.getThinkingLevel()");
+  assert.ok(captureIdx > -1, "auto-start.ts should snapshot thinking level at bootstrap start");
+
+  const originalThinkingIdx = source.indexOf("s.originalThinkingLevel = startThinkingSnapshot ?? null");
+  assert.ok(originalThinkingIdx > -1, "auto-start.ts should store originalThinkingLevel from snapshot");
+
+  const autoThinkingIdx = source.indexOf("s.autoModeStartThinkingLevel = startThinkingSnapshot ?? null");
+  assert.ok(autoThinkingIdx > -1, "auto-start.ts should store autoModeStartThinkingLevel from snapshot");
+
+  assert.ok(
+    captureIdx < originalThinkingIdx && captureIdx < autoThinkingIdx,
+    "thinking snapshot must be captured before session state assignment",
+  );
 });

--- a/src/resources/extensions/gsd/tests/auto-thinking-restore.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-thinking-restore.test.ts
@@ -1,0 +1,38 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const autoSrc = readFileSync(join(import.meta.dirname, "..", "auto.ts"), "utf-8");
+const phasesSrc = readFileSync(join(import.meta.dirname, "..", "auto", "phases.ts"), "utf-8");
+
+test("stopAuto restores original thinking level", () => {
+  assert.ok(
+    autoSrc.includes("if (pi && s.originalThinkingLevel)"),
+    "auto.ts should conditionally restore original thinking level in stopAuto",
+  );
+  assert.ok(
+    autoSrc.includes("pi.setThinkingLevel(s.originalThinkingLevel)"),
+    "auto.ts should call pi.setThinkingLevel with originalThinkingLevel",
+  );
+});
+
+test("runUnitPhase threads captured thinking level into selectAndApplyModel", () => {
+  const callIdx = phasesSrc.indexOf("deps.selectAndApplyModel(");
+  assert.ok(callIdx > -1, "phases.ts should call selectAndApplyModel");
+  const callBlock = phasesSrc.slice(callIdx, callIdx + 600);
+  assert.ok(
+    callBlock.includes("s.autoModeStartThinkingLevel"),
+    "runUnitPhase should pass autoModeStartThinkingLevel to selectAndApplyModel",
+  );
+});
+
+test("hook model override preserves captured thinking level", () => {
+  const hookIdx = phasesSrc.indexOf("const hookModelOverride = sidecarItem?.model ?? iterData.hookModelOverride;");
+  assert.ok(hookIdx > -1, "phases.ts should include hook model override handling");
+  const hookBlock = phasesSrc.slice(hookIdx, hookIdx + 600);
+  assert.ok(
+    hookBlock.includes("pi.setThinkingLevel(s.autoModeStartThinkingLevel)"),
+    "hook model override should re-apply captured thinking level after setModel",
+  );
+});

--- a/src/resources/extensions/gsd/tests/complexity-classifier.test.ts
+++ b/src/resources/extensions/gsd/tests/complexity-classifier.test.ts
@@ -21,9 +21,9 @@ test("tierOrdinal returns correct ordering", () => {
 
 // ─── Unit Type Classification ────────────────────────────────────────────────
 
-test("complete-slice classifies as light", () => {
+test("complete-slice classifies as standard", () => {
   const result = classifyUnitComplexity("complete-slice", "M001/S01", "/tmp/fake");
-  assert.equal(result.tier, "light");
+  assert.equal(result.tier, "standard");
 });
 
 test("run-uat classifies as light", () => {
@@ -145,7 +145,7 @@ test("budget pressure at 90% downgrades standard to light", () => {
   assert.equal(result.downgraded, true);
 });
 
-test("budget pressure at 90% downgrades light stays light", () => {
+test("budget pressure at 90% downgrades complete-slice standard to light", () => {
   const result = classifyUnitComplexity("complete-slice", "M001/S01", "/tmp/fake", 0.95);
   assert.equal(result.tier, "light");
 });


### PR DESCRIPTION
## Summary
- enable model discovery for custom providers that use OpenAI-compatible APIs
- use provider base URL during discovery and map discovered metadata (context window, max output tokens, reasoning, modalities)
- preserve provider API/base defaults when merging discovered models
- mark custom OpenAI-compatible providers as discoverable in Provider Manager
- normalize streamed `<think>...</think>` tags into internal thinking blocks so tags do not leak into visible chat text

## Tests
- node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test packages/pi-coding-agent/src/core/model-registry-discovery.test.ts packages/pi-coding-agent/src/core/model-discovery.test.ts packages/pi-ai/src/providers/think-tag-parser.test.ts

## Notes
- includes a new integration test for custom OpenAI-compatible provider discovery + capability mapping
- addresses #4526


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for thinking and reasoning content parsing in AI completions
  * Enabled model discovery for OpenAI-compatible custom providers
  * Preserved thinking level settings when using auto-mode

* **Improvements**  
  * Enhanced model discovery with improved metadata extraction and mapping
  * Better session model prioritization during auto-mode startup
  * Adjusted default complexity tier for large-context code units

<!-- end of auto-generated comment: release notes by coderabbit.ai -->