### PR TITLE
fix(init-wizard): create initial commit after git init

### DIFF
--- a/src/resources/extensions/gsd/init-wizard.ts
+++ b/src/resources/extensions/gsd/init-wizard.ts
@@ -10,7 +10,7 @@ import type { ExtensionAPI, ExtensionCommandContext } from "@gsd/pi-coding-agent
 import { existsSync, mkdirSync, writeFileSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { showNextAction } from "../shared/tui.js";
-import { nativeIsRepo, nativeInit } from "./native-git-bridge.js";
+import { nativeIsRepo, nativeInit, nativeAddAll, nativeCommit } from "./native-git-bridge.js";
 import { ensureGitignore, untrackRuntimeFiles } from "./gitignore.js";
 import { gsdRoot } from "./paths.js";
 import { assertSafeDirectory } from "./validate-directory.js";
@@ -74,6 +74,7 @@ export async function showProjectInit(
   }
 
   // ── Step 2: Git setup ──────────────────────────────────────────────────────
+  let didInitGit = false;
   if (!signals.isGitRepo) {
     const gitChoice = await showNextAction(ctx, {
       title: "GSD — Project Setup",
@@ -89,6 +90,7 @@ export async function showProjectInit(
 
     if (gitChoice === "init_git") {
       nativeInit(basePath, prefs.mainBranch);
+      didInitGit = true;
     }
   } else {
     // Auto-detect main branch from existing repo
@@ -294,6 +296,18 @@ export async function showProjectInit(
   // Ensure .gitignore
   ensureGitignore(basePath);
   untrackRuntimeFiles(basePath);
+
+  // Create initial commit so git log and git worktree work immediately (#4530).
+  // Without this, the branch is "unborn" (zero commits) and downstream operations
+  // like `git log` and `git worktree add` fail.
+  if (didInitGit) {
+    try {
+      nativeAddAll(basePath);
+      nativeCommit(basePath, "chore: init project");
+    } catch {
+      // Non-fatal — user can commit manually; don't block project init
+    }
+  }
 
   // Auto-generate codebase map for instant agent orientation
   try {

--- a/src/resources/extensions/gsd/tests/init-wizard.test.ts
+++ b/src/resources/extensions/gsd/tests/init-wizard.test.ts
@@ -178,6 +178,33 @@ test("init-wizard: multiple project files detected together", (t) => {
   }
 });
 
+// ─── Git init + initial commit regression (#4530) ───────────────────────────
+
+import { execFileSync } from "node:child_process";
+import { nativeInit, nativeAddAll, nativeCommit } from "../native-git-bridge.ts";
+
+test("init-wizard: nativeInit + nativeAddAll + nativeCommit produces a reachable HEAD (#4530)", (t) => {
+  // Regression: showProjectInit called nativeInit but never committed, leaving
+  // the branch unborn. git log and git worktree add both fail on zero-commit repos.
+  const dir = makeTempDir("git-init-commit");
+  t.after(() => { cleanup(dir); });
+
+  nativeInit(dir, "main");
+  execFileSync("git", ["config", "user.email", "test@test.com"], { cwd: dir });
+  execFileSync("git", ["config", "user.name", "Test"], { cwd: dir });
+  writeFileSync(join(dir, ".gitignore"), "*.log\n", "utf-8");
+
+  nativeAddAll(dir);
+  nativeCommit(dir, "chore: init project");
+
+  // git log must succeed (was: fatal: your current branch 'main' does not have any commits yet)
+  const subject = execFileSync("git", ["log", "-1", "--format=%s"], {
+    cwd: dir,
+    encoding: "utf-8",
+  }).trim();
+  assert.equal(subject, "chore: init project");
+});
+
 test("init-wizard: v1 with both .planning/ and .gsd/ prioritizes v2", (t) => {
   const dir = makeTempDir("both-v1-v2");
   try {


### PR DESCRIPTION
## Summary

- `nativeInit()` ran `git init` but never made an initial commit, leaving the branch in an "unborn" state (zero commits)
- `git log` and `git worktree add` both fail on a repo with zero commits, breaking the dashboard and auto-worktree creation immediately after `/gsd init`
- After `.gitignore` is written, stage all files and create `chore: init project` commit so the branch has a real HEAD

Closes #4530

## Test plan

- [ ] Run `/gsd init` on a directory with no git repo, choose to initialize git, complete wizard
- [ ] Verify no `fatal: your current branch 'main' does not have any commits yet` in dashboard
- [ ] Verify auto-worktree creation succeeds for the first milestone
- [ ] Verify existing repos (already have commits) are unaffected — `didInitGit` stays false

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Project initialization now creates an immediate initial commit when a new git repository is set up during the wizard; the operation is non-blocking and won’t interrupt project setup if it fails.

* **Tests**
  * Added a regression test to verify an initial commit is created and reachable after repository initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->