### PR TITLE
fix(resource-loader): sync bundled skills to ~/.agents/skills/ on launch

### DIFF
--- a/src/resource-loader.ts
+++ b/src/resource-loader.ts
@@ -522,7 +522,7 @@ function pruneRemovedBundledExtensions(
  *
  * Inspectable: `ls ~/.gsd/agent/extensions/`
  */
-export function initResources(agentDir: string): void {
+export function initResources(agentDir: string, skillsDir: string = join(homedir(), '.agents', 'skills')): void {
   mkdirSync(agentDir, { recursive: true })
 
   const currentVersion = getBundledGsdVersion()
@@ -561,13 +561,7 @@ export function initResources(agentDir: string): void {
 
   syncResourceDir(bundledExtensionsDir, join(agentDir, 'extensions'))
   syncResourceDir(join(resourcesDir, 'agents'), join(agentDir, 'agents'))
-  // Skills are no longer force-synced here. Users install skills via the
-  // skills.sh CLI (`npx skills add <repo>`) into ~/.agents/skills/ which
-  // is the industry-standard Agent Skills ecosystem directory.
-  //
-  // Migration from the legacy ~/.gsd/agent/skills/ directory is handled
-  // above the manifest check so it runs on every launch (including retries
-  // after partial copy failures).
+  syncResourceDir(join(resourcesDir, 'skills'), skillsDir)
 
   // Sync GSD-WORKFLOW.md to agentDir as a fallback for when GSD_WORKFLOW_PATH
   // env var is not set (e.g. fork/dev builds, alternative entry points).

--- a/src/tests/resource-loader.test.ts
+++ b/src/tests/resource-loader.test.ts
@@ -110,7 +110,7 @@ test("initResources manifest tracks all bundled extension subdirectories includi
   const fakeAgentDir = join(tmp, "agent");
 
   try {
-    initResources(fakeAgentDir);
+    initResources(fakeAgentDir, join(tmp, "skills"));
 
     const manifestPath = join(fakeAgentDir, "managed-resources.json");
     assert.equal(existsSync(manifestPath), true, "managed-resources.json should exist after initResources");
@@ -146,7 +146,7 @@ test("initResources prunes stale top-level extension siblings next to bundled co
 
   t.after(() => { rmSync(tmp, { recursive: true, force: true }); });
 
-  initResources(fakeAgentDir);
+  initResources(fakeAgentDir, join(tmp, "skills"));
 
   const bundledPath = existsSync(bundledJsPath)
     ? bundledJsPath
@@ -170,7 +170,7 @@ test("initResources prunes stale top-level extension siblings next to bundled co
   manifest.contentHash = "force-resync";
   writeFileSync(manifestPath, JSON.stringify(manifest));
 
-  initResources(fakeAgentDir);
+  initResources(fakeAgentDir, join(tmp, "skills"));
 
   if (siblingWasBundled) {
     assert.equal(existsSync(staleSiblingPath), true, "bundled sibling should be restored during sync");
@@ -188,7 +188,7 @@ test("pruneRemovedBundledExtensions removes stale subdirectory extensions not in
 
   try {
     // First sync — seeds the agent dir and writes the manifest.
-    initResources(fakeAgentDir);
+    initResources(fakeAgentDir, join(tmp, "skills"));
 
     // Simulate a stale subdirectory extension left from a previous GSD version.
     // This mirrors the mcporter scenario: it was bundled before, synced to
@@ -215,7 +215,7 @@ test("pruneRemovedBundledExtensions removes stale subdirectory extensions not in
     writeFileSync(manifestPath, JSON.stringify(manifest));
 
     // Second sync — the bundle no longer contains mcporter/, so it must be pruned.
-    initResources(fakeAgentDir);
+    initResources(fakeAgentDir, join(tmp, "skills"));
 
     assert.equal(
       existsSync(staleExtDir),


### PR DESCRIPTION
## Linked issue

Closes #4507 (follow-up to #4505)

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Re-adds skill syncing in `initResources` so the 15 bundled skills from PR #4505 are copied to `~/.agents/skills/` on launch.

**Why:** The skills existed on disk but were never visible in dev builds because `resolveSkillReference` searches `~/.agents/skills/` first and the sync was removed before #4505 landed.

**How:** One-line restore of `syncResourceDir` targeting `~/.agents/skills/` (the primary ecosystem dir). Adds an optional `skillsDir` parameter to `initResources` so tests redirect the sync to a temp dir instead of the real `~/.agents/skills/`.

## Root cause

PR #4505 added 15 `SKILL.md` files to `src/resources/skills/` and registered them in `BUNDLED_SKILL_TRIGGERS`. However, `buildBundledSkillsTable()` in `system-context.ts` silently skips any skill where `resolveSkillReference` returns `unresolved`. `resolveSkillReference` searches `~/.agents/skills/`, `~/.claude/skills/`, and legacy `~/.gsd/agent/skills/` — but the bundled skills were never copied to any of those locations because the `initResources` skill sync had been removed (lines 564–570 before this fix) in favour of the `npx skills add` workflow.

## Changes

- **`src/resource-loader.ts`**: Adds `syncResourceDir(join(resourcesDir, 'skills'), skillsDir)` in `initResources`, matching the pattern already used for extensions and agents. Removes the stale comment that explained why skills were not synced. Adds optional `skillsDir` parameter (default `~/.agents/skills/`) so call sites can override in tests.
- **`src/tests/resource-loader.test.ts`**: Updates all 5 `initResources` call sites to pass `join(tmp, 'skills')`, preventing the sync from touching the real `~/.agents/skills/` during test runs.

## Test results

7031 passed, 1 failed (pre-existing `welcome-screen` failure unrelated to this change), 9 skipped — same baseline as `main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Skills are now automatically included in resource initialization and synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->