### PR TITLE
fix(file-change-validator): handle repos with single commit (no HEAD~1)

### DIFF
--- a/src/resources/extensions/gsd/safety/file-change-validator.ts
+++ b/src/resources/extensions/gsd/safety/file-change-validator.ts
@@ -100,7 +100,7 @@ function getChangedFilesFromLastCommit(basePath: string): string[] | null {
   try {
     const result = execFileSync(
       "git",
-      ["diff", "--name-only", "HEAD~1", "HEAD"],
+      ["diff-tree", "--no-commit-id", "-r", "--name-only", "HEAD"],
       { cwd: basePath, stdio: ["ignore", "pipe", "pipe"], encoding: "utf-8" },
     ).trim();
     return result ? result.split("\n").filter(Boolean) : [];

--- a/src/resources/extensions/gsd/safety/file-change-validator.ts
+++ b/src/resources/extensions/gsd/safety/file-change-validator.ts
@@ -100,7 +100,7 @@ function getChangedFilesFromLastCommit(basePath: string): string[] | null {
   try {
     const result = execFileSync(
       "git",
-      ["diff-tree", "--no-commit-id", "-r", "--name-only", "HEAD"],
+      ["diff-tree", "--root", "--no-commit-id", "-r", "--name-only", "HEAD"],
       { cwd: basePath, stdio: ["ignore", "pipe", "pipe"], encoding: "utf-8" },
     ).trim();
     return result ? result.split("\n").filter(Boolean) : [];

--- a/src/resources/extensions/gsd/tests/file-change-validator.test.ts
+++ b/src/resources/extensions/gsd/tests/file-change-validator.test.ts
@@ -15,6 +15,26 @@ function git(cwd: string, ...args: string[]): string {
   }).trim();
 }
 
+test("validateFileChanges works on repos with a single commit (no HEAD~1)", (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-file-change-validator-"));
+  t.after(() => rmSync(base, { recursive: true, force: true }));
+
+  git(base, "init");
+  git(base, "config", "user.email", "test@example.com");
+  git(base, "config", "user.name", "Test User");
+
+  writeFileSync(join(base, "foo.ts"), "export const x = 1;\n");
+  git(base, "add", ".");
+  git(base, "commit", "-m", "initial");
+
+  // With only one commit, HEAD~1 doesn't exist — this must not throw
+  const audit = validateFileChanges(base, ["foo.ts"], []);
+
+  assert.ok(audit, "audit should be produced for single-commit repo");
+  assert.deepEqual(audit.unexpectedFiles, []);
+  assert.deepEqual(audit.missingFiles, []);
+});
+
 test("validateFileChanges ignores inline descriptions in expected output paths", (t) => {
   const base = mkdtempSync(join(tmpdir(), "gsd-file-change-validator-"));
   t.after(() => rmSync(base, { recursive: true, force: true }));


### PR DESCRIPTION
## Summary
- `git diff --name-only HEAD~1 HEAD` fails with `fatal: ambiguous argument 'HEAD~1'` when a repo has only one commit
- Switched to `git diff-tree --no-commit-id -r --name-only HEAD` which correctly lists files changed in the HEAD commit regardless of history depth

## Test plan
- [ ] Verify file-change-validator no longer logs the `git diff failed` warning in worktrees initialized with a single commit
- [ ] Verify normal multi-commit repos still get correct changed file lists

🤖 Generated with [Claude Code](https://claude.com/claude-code)