### PR TITLE
feat(tui): render skill invocations in purple chat-frame style

### DIFF
--- a/packages/pi-coding-agent/src/modes/interactive/components/chat-frame.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/components/chat-frame.ts
@@ -2,7 +2,7 @@ import { truncateToWidth, visibleWidth } from "@gsd/pi-tui";
 import { theme } from "../theme/theme.js";
 import { formatTimestamp, type TimestampFormat } from "./timestamp.js";
 
-type FrameTone = "assistant" | "user" | "compaction";
+type FrameTone = "assistant" | "user" | "compaction" | "skill";
 
 function trimOuterBlankLines(lines: string[]): string[] {
 	let start = 0;
@@ -25,14 +25,14 @@ export function renderChatFrame(
 ): string[] {
 	const outerWidth = Math.max(20, width);
 	const contentWidth = Math.max(1, outerWidth - 2); // "│ " + content
+	const isPurple = opts.tone === "compaction" || opts.tone === "skill";
 	const borderColor =
 		opts.tone === "user"
 			? "border"
-			: opts.tone === "compaction"
+			: isPurple
 				? "customMessageLabel"
 				: "borderAccent";
-	const borderMuted =
-		opts.tone === "compaction" ? "customMessageLabel" : "borderMuted";
+	const borderMuted = isPurple ? "customMessageLabel" : "borderMuted";
 	const border = (s: string) => theme.fg(borderColor, s);
 	const leftRaw = `• ${opts.label}`;
 	const rightRaw =
@@ -47,7 +47,7 @@ export function renderChatFrame(
 	const labelColor =
 		opts.tone === "user"
 			? "border"
-			: opts.tone === "compaction"
+			: isPurple
 				? "customMessageLabel"
 				: "borderAccent";
 	const dashIdx = left.indexOf(" - ");
@@ -71,7 +71,7 @@ export function renderChatFrame(
 	const bodyColor =
 		opts.tone === "user"
 			? "userMessageText"
-			: opts.tone === "compaction"
+			: isPurple
 				? "customMessageText"
 				: "assistantMessageText";
 	const bodyLines = (sourceLines.length > 0 ? sourceLines : [""]).map((line) => {

--- a/packages/pi-coding-agent/src/modes/interactive/components/skill-invocation-message.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/components/skill-invocation-message.ts
@@ -1,55 +1,69 @@
-import { Box, Markdown, type MarkdownTheme, Text } from "@gsd/pi-tui";
+// GSD / pi-coding-agent — Skill invocation message component
+import { Container, Markdown, type MarkdownTheme, Text } from "@gsd/pi-tui";
 import type { ParsedSkillBlock } from "../../../core/agent-session.js";
 import { getMarkdownTheme, theme } from "../theme/theme.js";
+import { renderChatFrame } from "./chat-frame.js";
 import { editorKey } from "./keybinding-hints.js";
 
 /**
- * Component that renders a skill invocation message with collapsed/expanded state.
- * Uses same background color as custom messages for visual consistency.
- * Only renders the skill block itself - user message is rendered separately.
+ * Renders a skill invocation in the shared chat-frame style (top rule,
+ * `• skill - <name>` header, `│ ` body margin) with purple border/label
+ * matching compaction so it visually aligns with user/assistant messages.
  */
-export class SkillInvocationMessageComponent extends Box {
+export class SkillInvocationMessageComponent extends Container {
 	private expanded = false;
 	private skillBlock: ParsedSkillBlock;
 	private markdownTheme: MarkdownTheme;
 
 	constructor(skillBlock: ParsedSkillBlock, markdownTheme: MarkdownTheme = getMarkdownTheme()) {
-		super(1, 1, (t) => theme.bg("customMessageBg", t));
+		super();
 		this.skillBlock = skillBlock;
 		this.markdownTheme = markdownTheme;
-		this.updateDisplay();
+		this.rebuild();
 	}
 
 	setExpanded(expanded: boolean): void {
-		this.expanded = expanded;
-		this.updateDisplay();
+		if (this.expanded !== expanded) {
+			this.expanded = expanded;
+			this.rebuild();
+		}
 	}
 
 	override invalidate(): void {
 		super.invalidate();
-		this.updateDisplay();
+		this.rebuild();
 	}
 
-	private updateDisplay(): void {
+	private rebuild(): void {
 		this.clear();
 
 		if (this.expanded) {
-			// Expanded: label + skill name header + full content
-			const label = theme.fg("customMessageLabel", theme.bold("[skill]"));
-			this.addChild(new Text(label, 0, 0));
-			const header = `**${this.skillBlock.name}**\n\n`;
 			this.addChild(
-				new Markdown(header + this.skillBlock.content, 0, 0, this.markdownTheme, {
+				new Markdown(this.skillBlock.content, 0, 0, this.markdownTheme, {
 					color: (text: string) => theme.fg("customMessageText", text),
 				}),
 			);
 		} else {
-			// Collapsed: single line - [skill] name (hint to expand)
-			const line =
-				theme.fg("customMessageLabel", theme.bold("[skill]") + " ") +
-				theme.fg("customMessageText", this.skillBlock.name) +
-				theme.fg("dim", ` (${editorKey("expandTools")} to expand)`);
-			this.addChild(new Text(line, 0, 0));
+			this.addChild(
+				new Text(
+					theme.fg("dim", `(${editorKey("expandTools")} to expand)`),
+					0,
+					0,
+				),
+			);
 		}
+	}
+
+	override render(width: number): string[] {
+		const frameWidth = Math.max(20, width);
+		const contentWidth = Math.max(1, frameWidth - 4);
+		const lines = super.render(contentWidth);
+		const framed = renderChatFrame(lines, frameWidth, {
+			label: `skill - ${this.skillBlock.name}`,
+			tone: "skill",
+			timestampFormat: "date-time-iso",
+			showTimestamp: false,
+		});
+		return framed.length > 0 ? ["", ...framed] : framed;
 	}
 }

--- a/src/resources/extensions/gsd/safety/file-change-validator.ts
+++ b/src/resources/extensions/gsd/safety/file-change-validator.ts
@@ -100,7 +100,7 @@ function getChangedFilesFromLastCommit(basePath: string): string[] | null {
   try {
     const result = execFileSync(
       "git",
-      ["diff", "--name-only", "HEAD~1", "HEAD"],
+      ["diff-tree", "--no-commit-id", "-r", "--name-only", "HEAD"],
       { cwd: basePath, stdio: ["ignore", "pipe", "pipe"], encoding: "utf-8" },
     ).trim();
     return result ? result.split("\n").filter(Boolean) : [];

--- a/src/resources/extensions/gsd/safety/file-change-validator.ts
+++ b/src/resources/extensions/gsd/safety/file-change-validator.ts
@@ -100,7 +100,7 @@ function getChangedFilesFromLastCommit(basePath: string): string[] | null {
   try {
     const result = execFileSync(
       "git",
-      ["diff-tree", "--no-commit-id", "-r", "--name-only", "HEAD"],
+      ["diff-tree", "--root", "--no-commit-id", "-r", "--name-only", "HEAD"],
       { cwd: basePath, stdio: ["ignore", "pipe", "pipe"], encoding: "utf-8" },
     ).trim();
     return result ? result.split("\n").filter(Boolean) : [];

--- a/src/resources/extensions/gsd/tests/file-change-validator.test.ts
+++ b/src/resources/extensions/gsd/tests/file-change-validator.test.ts
@@ -15,6 +15,26 @@ function git(cwd: string, ...args: string[]): string {
   }).trim();
 }
 
+test("validateFileChanges works on repos with a single commit (no HEAD~1)", (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-file-change-validator-"));
+  t.after(() => rmSync(base, { recursive: true, force: true }));
+
+  git(base, "init");
+  git(base, "config", "user.email", "test@example.com");
+  git(base, "config", "user.name", "Test User");
+
+  writeFileSync(join(base, "foo.ts"), "export const x = 1;\n");
+  git(base, "add", ".");
+  git(base, "commit", "-m", "initial");
+
+  // With only one commit, HEAD~1 doesn't exist — this must not throw
+  const audit = validateFileChanges(base, ["foo.ts"], []);
+
+  assert.ok(audit, "audit should be produced for single-commit repo");
+  assert.deepEqual(audit.unexpectedFiles, []);
+  assert.deepEqual(audit.missingFiles, []);
+});
+
 test("validateFileChanges ignores inline descriptions in expected output paths", (t) => {
   const base = mkdtempSync(join(tmpdir(), "gsd-file-change-validator-"));
   t.after(() => rmSync(base, { recursive: true, force: true }));


### PR DESCRIPTION
## Summary
- Skill invocations now use the shared chat-frame (top rule, `• skill - <name>` header, `│ ` body margin) so they sit in the conversation flow consistently with user/assistant messages.
- Added a `skill` tone to `renderChatFrame` that shares compaction's purple border/label colors.
- Refactored `SkillInvocationMessageComponent` from `Box` to `Container`, rendering through the shared frame like `AssistantMessageComponent` / `CompactionSummaryMessageComponent`.

## Test plan
- [ ] Run the TUI and invoke a skill — verify the purple framed block renders with `• skill - <name>` header
- [ ] Toggle expand/collapse (ctrl+o) and confirm content switches correctly
- [ ] Visually compare against user/assistant frames for alignment parity

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "skill" tone styling to message frames for enhanced visual distinction.
  * Improved skill invocation message rendering with separate collapsed and expanded states.

* **Bug Fixes**
  * Fixed file change detection to work correctly with single-commit repositories.

* **Tests**
  * Added test coverage for single-commit repository scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->