### PR TITLE
fix(db): surface structured error on SQLite open failure; add open-time provider fallback

### DIFF
--- a/src/resources/extensions/gsd/auto-start.ts
+++ b/src/resources/extensions/gsd/auto-start.ts
@@ -60,7 +60,7 @@ import { initRoutingHistory } from "./routing-history.js";
 import { restoreHookState, resetHookState } from "./post-unit-hooks.js";
 import { resetProactiveHealing, setLevelChangeCallback } from "./doctor-proactive.js";
 import { snapshotSkills } from "./skill-discovery.js";
-import { isDbAvailable, getMilestone, openDatabase } from "./gsd-db.js";
+import { isDbAvailable, getMilestone, openDatabase, getDbStatus } from "./gsd-db.js";
 import { hideFooter } from "./auto-dashboard.js";
 import {
   debugLog,
@@ -758,9 +758,22 @@ export async function bootstrapAutoSession(
     // call returns "db_unavailable", triggering artifact-retry which
     // re-dispatches the same task — producing an infinite loop (#2419).
     if (existsSync(gsdDbPath) && !isDbAvailable()) {
+      const dbStatus = getDbStatus();
+      const phaseHint = dbStatus.lastPhase === "open"
+        ? "The database file could not be opened"
+        : dbStatus.lastPhase === "initSchema"
+          ? "The database schema could not be initialized"
+          : dbStatus.lastPhase === "vacuum-recovery"
+            ? "Corruption recovery (VACUUM) failed"
+            : dbStatus.attempted
+              ? "The database could not be opened (phase unknown)"
+              : "The database provider could not be loaded";
+      const errorDetail = dbStatus.lastError ? ` (${dbStatus.lastError.message})` : "";
+      const providerHint = dbStatus.provider
+        ? ` Provider: ${dbStatus.provider}.`
+        : " No SQLite provider available — check Node >= 22 or install better-sqlite3.";
       ctx.ui.notify(
-        "SQLite database exists but failed to open. Auto-mode cannot proceed without a working database provider. " +
-          "Check for corrupt gsd.db or missing native SQLite bindings.",
+        `SQLite database exists but failed to open: ${gsdDbPath}. ${phaseHint}${errorDetail}.${providerHint}`,
         "error",
       );
       return releaseLockAndReturn();

--- a/src/resources/extensions/gsd/gsd-db.ts
+++ b/src/resources/extensions/gsd/gsd-db.ts
@@ -1334,8 +1334,12 @@ export function closeDatabase(): void {
     currentDb = null;
     currentPath = null;
     currentPid = 0;
-    _dbOpenAttempted = false;
   }
+  // Reset session-scoped state unconditionally so stale error info from a
+  // failed open doesn't persist into the next open attempt or status check.
+  _dbOpenAttempted = false;
+  _lastDbError = null;
+  _lastDbPhase = null;
 }
 
 /** Run a full VACUUM — call sparingly (e.g. after milestone completion). */

--- a/src/resources/extensions/gsd/gsd-db.ts
+++ b/src/resources/extensions/gsd/gsd-db.ts
@@ -1199,6 +1199,8 @@ let currentPath: string | null = null;
 let currentPid: number = 0;
 let _exitHandlerRegistered = false;
 let _dbOpenAttempted = false;
+let _lastDbError: Error | null = null;
+let _lastDbPhase: "open" | "initSchema" | "vacuum-recovery" | null = null;
 
 export function getDbProvider(): ProviderName | null {
   loadProvider();
@@ -1219,12 +1221,58 @@ export function wasDbOpenAttempted(): boolean {
   return _dbOpenAttempted;
 }
 
+export function getDbStatus(): {
+  available: boolean;
+  provider: ProviderName | null;
+  attempted: boolean;
+  lastError: Error | null;
+  lastPhase: "open" | "initSchema" | "vacuum-recovery" | null;
+} {
+  loadProvider();
+  return {
+    available: currentDb !== null,
+    provider: providerName,
+    attempted: _dbOpenAttempted,
+    lastError: _lastDbError,
+    lastPhase: _lastDbPhase,
+  };
+}
+
 export function openDatabase(path: string): boolean {
   _dbOpenAttempted = true;
   if (currentDb && currentPath !== path) closeDatabase();
   if (currentDb && currentPath === path) return true;
 
-  const rawDb = openRawDb(path);
+  // Reset error state only when a new open attempt is actually going to run.
+  _lastDbError = null;
+  _lastDbPhase = null;
+
+  let rawDb: unknown;
+  let fallbackProvider: ProviderName | null = null;
+  let fallbackModule: unknown = null;
+  try {
+    rawDb = openRawDb(path);
+  } catch (primaryErr) {
+    _lastDbPhase = "open";
+    _lastDbError = primaryErr instanceof Error ? primaryErr : new Error(String(primaryErr));
+    // node:sqlite loaded but failed to open this file — try better-sqlite3 as fallback.
+    if (providerName === "node:sqlite") {
+      try {
+        const mod = _require("better-sqlite3");
+        const Db = (mod && mod.default) ? mod.default : mod;
+        if (typeof Db === "function") {
+          rawDb = new Db(path);
+          fallbackProvider = "better-sqlite3";
+          fallbackModule = Db;
+          _lastDbError = null;
+          _lastDbPhase = null;
+        }
+      } catch {
+        // fallback unavailable; surface original error
+      }
+    }
+    if (!rawDb) throw primaryErr;
+  }
   if (!rawDb) return false;
 
   const adapter = createAdapter(rawDb);
@@ -1240,13 +1288,23 @@ export function openDatabase(path: string): boolean {
         initSchema(adapter, fileBacked);
         process.stderr.write("gsd-db: recovered corrupt database via VACUUM\n");
       } catch (retryErr) {
+        _lastDbPhase = "vacuum-recovery";
+        _lastDbError = retryErr instanceof Error ? retryErr : new Error(String(retryErr));
         try { adapter.close(); } catch (e) { logWarning("db", `close after VACUUM failed: ${(e as Error).message}`); }
         throw retryErr;
       }
     } else {
-      try { adapter.close(); } catch (e) { logWarning("db", `close after VACUUM failed: ${(e as Error).message}`); }
+      _lastDbPhase = "initSchema";
+      _lastDbError = err instanceof Error ? err : new Error(String(err));
+      try { adapter.close(); } catch (e) { logWarning("db", `close after initSchema failed: ${(e as Error).message}`); }
       throw err;
     }
+  }
+
+  // Commit fallback provider switch only after open + schema both succeeded.
+  if (fallbackProvider) {
+    providerName = fallbackProvider;
+    providerModule = fallbackModule;
   }
 
   currentDb = adapter;

--- a/src/resources/extensions/gsd/tests/gsd-db.test.ts
+++ b/src/resources/extensions/gsd/tests/gsd-db.test.ts
@@ -9,6 +9,7 @@ import {
   isDbAvailable,
   wasDbOpenAttempted,
   getDbProvider,
+  getDbStatus,
   insertDecision,
   getDecisionById,
   insertRequirement,
@@ -558,6 +559,92 @@ describe('gsd-db', () => {
       closeDatabase();
       // Must not throw
       assert.doesNotThrow(() => checkpointDatabase());
+    });
+  });
+
+  // ─── getDbStatus ───────────────────────────────────────────────────────────
+
+  describe('getDbStatus', () => {
+    test('getDbStatus: initial state before any open', () => {
+      closeDatabase();
+      const status = getDbStatus();
+      assert.strictEqual(status.available, false, 'available false before open');
+      assert.strictEqual(status.attempted, false, 'attempted false before open');
+      assert.strictEqual(status.lastError, null, 'lastError null before open');
+      assert.strictEqual(status.lastPhase, null, 'lastPhase null before open');
+    });
+
+    test('getDbStatus: available after successful open', () => {
+      openDatabase(':memory:');
+      const status = getDbStatus();
+      assert.strictEqual(status.available, true, 'available true after open');
+      assert.strictEqual(status.attempted, true, 'attempted true after open');
+      assert.ok(status.provider !== null, 'provider set after open');
+      assert.strictEqual(status.lastError, null, 'lastError null on success');
+      assert.strictEqual(status.lastPhase, null, 'lastPhase null on success');
+      closeDatabase();
+    });
+
+    test('getDbStatus: resets lastError/lastPhase after closeDatabase', () => {
+      // Simulate a failed open to set error state
+      const corruptPath = path.join(os.tmpdir(), `gsd-corrupt-${Date.now()}.db`);
+      fs.writeFileSync(corruptPath, Buffer.from('not a sqlite file at all!!!!!'));
+      try {
+        openDatabase(corruptPath);
+      } catch {
+        // expected
+      }
+      assert.ok(getDbStatus().lastError !== null, 'lastError set after failed open');
+
+      // closeDatabase should clear it even though no DB was opened
+      closeDatabase();
+      const status = getDbStatus();
+      assert.strictEqual(status.lastError, null, 'lastError cleared by closeDatabase');
+      assert.strictEqual(status.lastPhase, null, 'lastPhase cleared by closeDatabase');
+      assert.strictEqual(status.attempted, false, 'attempted reset by closeDatabase');
+      fs.unlinkSync(corruptPath);
+    });
+
+    test('getDbStatus: captures open-phase error on corrupt file', () => {
+      closeDatabase();
+      const corruptPath = path.join(os.tmpdir(), `gsd-corrupt-${Date.now()}.db`);
+      fs.writeFileSync(corruptPath, Buffer.from('not a sqlite file at all!!!!!'));
+      try {
+        openDatabase(corruptPath);
+      } catch {
+        // expected — both providers should reject a non-SQLite file
+      }
+      const status = getDbStatus();
+      if (!status.available) {
+        // open failed (expected in most environments)
+        assert.strictEqual(status.attempted, true, 'attempted true after failed open');
+        // provider may reject at raw-open level ("open") or at SQL init level ("initSchema")
+        assert.ok(
+          status.lastPhase === 'open' || status.lastPhase === 'initSchema',
+          `lastPhase should be "open" or "initSchema", got: ${status.lastPhase}`,
+        );
+        assert.ok(status.lastError instanceof Error, 'lastError is an Error');
+      }
+      // If somehow it succeeded (unlikely with garbage content), that's also fine
+      closeDatabase();
+      try { fs.unlinkSync(corruptPath); } catch { /* best effort */ }
+    });
+
+    test('getDbStatus: error state resets on next successful open', () => {
+      closeDatabase();
+      const corruptPath = path.join(os.tmpdir(), `gsd-corrupt-${Date.now()}.db`);
+      fs.writeFileSync(corruptPath, Buffer.from('not a sqlite file at all!!!!!'));
+      try { openDatabase(corruptPath); } catch { /* expected */ }
+      assert.ok(!getDbStatus().available, 'DB unavailable after corrupt open');
+
+      // Now open a valid in-memory DB — error state should clear
+      openDatabase(':memory:');
+      const status = getDbStatus();
+      assert.strictEqual(status.available, true, 'available after valid open');
+      assert.strictEqual(status.lastError, null, 'lastError cleared on successful open');
+      assert.strictEqual(status.lastPhase, null, 'lastPhase cleared on successful open');
+      closeDatabase();
+      try { fs.unlinkSync(corruptPath); } catch { /* best effort */ }
     });
   });
 


### PR DESCRIPTION
## Summary

- Adds `getDbStatus()` to `gsd-db.ts` returning `{ available, provider, attempted, lastError, lastPhase }` so callers can distinguish failure modes (open, initSchema, vacuum-recovery, no provider)
- Adds open-time provider fallback: if `node:sqlite` loads but fails to open a specific file, `better-sqlite3` is tried; provider globals are only committed after both raw open **and** `initSchema` succeed
- Error state reset in `openDatabase()` moved to after the early-return guards so a prior failure's error isn't wiped on a redundant same-path call
- `auto-start.ts` bootstrap gate replaces the hardcoded generic message with a specific one that includes the DB file path, failure phase, real error message, and provider info

## Test plan

- [ ] Bootstrap against a locked/corrupt `gsd.db` with `node:sqlite` present — confirm error message includes file path, phase (`"The database file could not be opened"`), and the real error text
- [ ] Bootstrap with `node:sqlite` present but DB unreadable and `better-sqlite3` available — confirm fallback succeeds silently and bootstrap proceeds
- [ ] Bootstrap with no SQLite provider at all — confirm `"The database provider could not be loaded"` message
- [ ] Bootstrap with a DB that fails `initSchema` — confirm `"The database schema could not be initialized"` message
- [ ] Normal bootstrap against a healthy DB — confirm no regression

Closes #4508

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved notifications when the app cannot access its database: messages now include the resolved DB path, phase-specific hints (open/schema/vacuum-recovery), optional error details, and clearer provider guidance.
  * More robust fallback and recovery handling so transient provider or initialization failures are better detected and surfaced.

* **New Features**
  * Added a status endpoint that reports current DB availability, provider, last error and phase.

* **Tests**
  * Added tests validating DB status reporting and error/cleanup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->