### PR TITLE
fix(gsd): classify extra usage errors as rate limits

### DIFF
--- a/src/resources/extensions/gsd/error-classifier.ts
+++ b/src/resources/extensions/gsd/error-classifier.ts
@@ -47,7 +47,8 @@ const PERMANENT_RE = /auth|unauthorized|forbidden|invalid.*key|invalid.*api|bill
 // Include provider-specific quota-window phrasing like:
 // - "You've hit your limit"
 // - "usage limit" / "quota reached"
-const RATE_LIMIT_RE = /rate.?limit|too many requests|429|hit your limit|usage limit|quota (?:reached|hit)|limit.*resets?/i;
+// - "out of extra usage"
+const RATE_LIMIT_RE = /rate.?limit|too many requests|429|hit your limit|usage limit|out of extra usage|quota (?:reached|hit)|limit.*resets?/i;
 // OpenRouter affordability-style quota errors should be treated as transient
 // so core retry logic can lower maxTokens and continue in-session.
 const AFFORDABILITY_RE = /requires more credits|can only afford|insufficient credits|not enough credits|fewer max_tokens/i;

--- a/src/resources/extensions/gsd/tests/provider-errors.test.ts
+++ b/src/resources/extensions/gsd/tests/provider-errors.test.ts
@@ -45,6 +45,13 @@ test("classifyError treats usage-limit phrasing as transient rate-limit (#4373)"
   assert.equal(result.kind, "rate-limit");
 });
 
+test("classifyError treats extra-usage phrasing as transient rate-limit (#4397)", () => {
+  const result = classifyError("You are out of extra usage. Please wait before retrying.");
+  assert.ok(isTransient(result));
+  assert.equal(result.kind, "rate-limit");
+  assert.ok("retryAfterMs" in result && result.retryAfterMs === 60_000);
+});
+
 test("classifyError treats OpenRouter affordability errors as transient rate-limit class", () => {
   const result = classifyError(
     "402 This request requires more credits, or fewer max_tokens. You requested up to 32000 tokens, but can only afford 329.",


### PR DESCRIPTION
## Linked issue

Closes #4397

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Treat provider "extra usage" exhaustion messages as transient rate-limit errors.
**Why:** These quota-window failures were previously classified as unknown, causing auto-mode to pause instead of using the existing retry/fallback path.
**How:** Extend the GSD error classifier's rate-limit pattern and add a regression test for the reported phrasing.

## What

This updates the GSD extension error classifier so messages containing `out of extra usage` classify as `rate-limit` with the standard retry delay. It also adds coverage in the provider error tests to lock the behavior.

## Why

The reported provider error is a temporary quota-window condition. Leaving it as `unknown` makes auto-mode treat a retryable provider condition as an indefinite pause.

## How

The fix keeps the existing classifier structure and adds the missing quota-window phrase to `RATE_LIMIT_RE`. The regression asserts that the phrase is transient and returns the default 60 second rate-limit delay.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

Automated verification:

1. `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/provider-errors.test.ts`
2. `npm run build`
3. `npm run typecheck:extensions`
4. `npm run secret-scan`

Manual verification:

1. Ran the classifier directly against the reported `out of extra usage` phrasing.
2. Before the fix it returned `unknown` and non-transient.
3. After the fix it returns `rate-limit` and transient with the default retry delay.

## AI disclosure

- [x] This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error classification to recognize additional rate-limit error messages, improving error handling accuracy.

* **Tests**
  * Added test coverage for error classification scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->