### PR TITLE
fix(gsd): Normalize auto prompt workingDirectory to POSIX

### DIFF
--- a/src/resources/extensions/gsd/auto-prompts.ts
+++ b/src/resources/extensions/gsd/auto-prompts.ts
@@ -36,6 +36,7 @@ import { readPhaseAnchor, formatAnchorForPrompt } from "./phase-anchor.js";
 import { logWarning } from "./workflow-logger.js";
 import { inlineGraphSubgraph } from "./graph-context.js";
 import { buildExtractionStepsBlock } from "./commands-extract-learnings.js";
+import { toPosixPath } from "../shared/mod.js";
 
 // ─── Preamble Cap ─────────────────────────────────────────────────────────────
 
@@ -1103,7 +1104,7 @@ export async function buildResearchMilestonePrompt(mid: string, midTitle: string
 
   const outputRelPath = relMilestoneFile(base, mid, "RESEARCH");
   return loadPrompt("research-milestone", {
-    workingDirectory: base,
+    workingDirectory: toPosixPath(base),
     milestoneId: mid, milestoneTitle: midTitle,
     milestonePath: relMilestonePath(base, mid),
     contextPath: contextRel,
@@ -1176,7 +1177,7 @@ export async function buildPlanMilestonePrompt(mid: string, midTitle: string, ba
   const researchOutputPath = join(base, relMilestoneFile(base, mid, "RESEARCH"));
   const secretsOutputPath = join(base, relMilestoneFile(base, mid, "SECRETS"));
   return loadPrompt("plan-milestone", {
-    workingDirectory: base,
+    workingDirectory: toPosixPath(base),
     milestoneId: mid, milestoneTitle: midTitle,
     milestonePath: relMilestonePath(base, mid),
     contextPath: contextRel,
@@ -1254,7 +1255,7 @@ export async function buildResearchSlicePrompt(
 
   const outputRelPath = relSliceFile(base, mid, sid, "RESEARCH");
   return loadPrompt("research-slice", {
-    workingDirectory: base,
+    workingDirectory: toPosixPath(base),
     milestoneId: mid, sliceId: sid, sliceTitle: sTitle,
     slicePath: relSlicePath(base, mid, sid),
     roadmapPath: roadmapRel,
@@ -1356,7 +1357,7 @@ async function renderSlicePrompt(options: {
   const commitInstruction = "Do not commit — .gsd/ planning docs are managed externally and not tracked in git.";
 
   return loadPrompt(promptTemplate, {
-    workingDirectory: base,
+    workingDirectory: toPosixPath(base),
     milestoneId: mid, sliceId: sid, sliceTitle: sTitle,
     slicePath: relSlicePath(base, mid, sid),
     roadmapPath: roadmapRel,
@@ -1627,7 +1628,7 @@ export async function buildExecuteTaskPrompt(
     overridesSection,
     runtimeContext,
     phaseAnchorSection,
-    workingDirectory: base,
+    workingDirectory: toPosixPath(base),
     milestoneId: mid, sliceId: sid, sliceTitle: sTitle, taskId: tid, taskTitle: tTitle,
     planPath: join(base, relSliceFile(base, mid, sid, "PLAN")),
     slicePath: relSlicePath(base, mid, sid),
@@ -1720,7 +1721,7 @@ export async function buildCompleteSlicePrompt(
   );
 
   return loadPrompt("complete-slice", {
-    workingDirectory: base,
+    workingDirectory: toPosixPath(base),
     milestoneId: mid, sliceId: sid, sliceTitle: sTitle,
     slicePath: sliceRel,
     roadmapPath: join(base, roadmapRel),
@@ -1800,7 +1801,7 @@ export async function buildCompleteMilestonePrompt(
   });
 
   return loadPrompt("complete-milestone", {
-    workingDirectory: base,
+    workingDirectory: toPosixPath(base),
     milestoneId: mid,
     milestoneTitle: midTitle,
     roadmapPath: roadmapRel,
@@ -1938,7 +1939,7 @@ export async function buildValidateMilestonePrompt(
   });
 
   return loadPrompt("validate-milestone", {
-    workingDirectory: base,
+    workingDirectory: toPosixPath(base),
     milestoneId: mid,
     milestoneTitle: midTitle,
     roadmapPath: roadmapOutputPath,
@@ -2016,7 +2017,7 @@ export async function buildReplanSlicePrompt(
   }
 
   return loadPrompt("replan-slice", {
-    workingDirectory: base,
+    workingDirectory: toPosixPath(base),
     milestoneId: mid,
     sliceId: sid,
     sliceTitle: sTitle,
@@ -2059,7 +2060,7 @@ export async function buildRunUatPrompt(
   const uatType = getUatType(uatContent);
 
   return loadPrompt("run-uat", {
-    workingDirectory: base,
+    workingDirectory: toPosixPath(base),
     milestoneId: mid,
     sliceId,
     uatPath,
@@ -2123,7 +2124,7 @@ export async function buildReassessRoadmapPrompt(
   const reassessCommitInstruction = "Do not commit — .gsd/ planning docs are managed externally and not tracked in git.";
 
   return loadPrompt("reassess-roadmap", {
-    workingDirectory: base,
+    workingDirectory: toPosixPath(base),
     milestoneId: mid,
     milestoneTitle: midTitle,
     completedSliceId,
@@ -2211,7 +2212,7 @@ export async function buildReactiveExecutePrompt(
   const inlinedTemplates = inlineTemplate("task-summary", "Task Summary");
 
   return loadPrompt("reactive-execute", {
-    workingDirectory: base,
+    workingDirectory: toPosixPath(base),
     milestoneId: mid,
     milestoneTitle: midTitle,
     sliceId: sid,
@@ -2371,7 +2372,7 @@ export async function buildGateEvaluatePrompt(
   }
 
   return loadPrompt("gate-evaluate", {
-    workingDirectory: base,
+    workingDirectory: toPosixPath(base),
     milestoneId: mid,
     milestoneTitle: midTitle,
     sliceId: sid,

--- a/src/resources/extensions/gsd/tests/auto-prompts-working-directory-path.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-prompts-working-directory-path.test.ts
@@ -21,6 +21,12 @@ function createWindowsStyleBase(): { root: string; base: string } {
   return { root, base };
 }
 
+function getRenderedWorkingDirectory(prompt: string): string {
+  const match = prompt.match(/working directory is `([^`]+)`/);
+  assert.ok(match, "prompt should render a workingDirectory value");
+  return match[1];
+}
+
 test("prompt builders normalize workingDirectory to POSIX paths at runtime", async () => {
   const { root, base } = createWindowsStyleBase();
   const normalizedBase = base.replaceAll("\\", "/");
@@ -34,14 +40,13 @@ test("prompt builders normalize workingDirectory to POSIX paths at runtime", asy
     ]);
 
     for (const prompt of prompts) {
-      assert.ok(
-        prompt.includes(`Your working directory is \`${normalizedBase}\`.`),
+      const workingDirectory = getRenderedWorkingDirectory(prompt);
+      assert.equal(
+        workingDirectory,
+        normalizedBase,
         "workingDirectory should be normalized to POSIX separators in rendered prompts",
       );
-      assert.ok(
-        !prompt.includes(`Your working directory is \`${base}\`.`),
-        "rendered prompts should not expose raw backslash paths",
-      );
+      assert.equal(workingDirectory.includes("\\"), false);
     }
   } finally {
     rmSync(root, { recursive: true, force: true });

--- a/src/resources/extensions/gsd/tests/auto-prompts-working-directory-path.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-prompts-working-directory-path.test.ts
@@ -1,0 +1,49 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync } from "node:fs";
+import { join, win32 } from "node:path";
+import { tmpdir } from "node:os";
+
+import {
+  buildPlanMilestonePrompt,
+  buildPlanSlicePrompt,
+  buildResearchMilestonePrompt,
+  buildResearchSlicePrompt,
+} from "../auto-prompts.ts";
+
+function createWindowsStyleBase(): { root: string; base: string } {
+  const root = mkdtempSync(join(tmpdir(), "gsd-auto-prompts-"));
+  const windowsSegment = win32.join("C:\\Users\\runner", "project");
+  const base = join(root, windowsSegment);
+  mkdirSync(join(base, ".gsd", "milestones", "M001", "slices", "S01"), {
+    recursive: true,
+  });
+  return { root, base };
+}
+
+test("prompt builders normalize workingDirectory to POSIX paths at runtime", async () => {
+  const { root, base } = createWindowsStyleBase();
+  const normalizedBase = base.replaceAll("\\", "/");
+
+  try {
+    const prompts = await Promise.all([
+      buildResearchMilestonePrompt("M001", "Test Milestone", base),
+      buildPlanMilestonePrompt("M001", "Test Milestone", base),
+      buildResearchSlicePrompt("M001", "Test Milestone", "S01", "Test Slice", base),
+      buildPlanSlicePrompt("M001", "Test Milestone", "S01", "Test Slice", base),
+    ]);
+
+    for (const prompt of prompts) {
+      assert.ok(
+        prompt.includes(`Your working directory is \`${normalizedBase}\`.`),
+        "workingDirectory should be normalized to POSIX separators in rendered prompts",
+      );
+      assert.ok(
+        !prompt.includes(`Your working directory is \`${base}\`.`),
+        "rendered prompts should not expose raw backslash paths",
+      );
+    }
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- normalize generated auto-prompt `workingDirectory` values to POSIX separators before persisting them
- add a focused regression test for Windows-style path input so downstream consumers see stable paths

## Testing
- node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/auto-prompts-working-directory-path.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved path handling to normalize working directory paths to a standard format for better cross-platform compatibility.

* **Tests**
  * Added tests to verify path normalization is applied consistently across the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->