### PR TITLE
fix(pi-agent-core): redact known secret shapes before persisting session log

### DIFF
--- a/packages/pi-coding-agent/src/core/redact-secrets.test.ts
+++ b/packages/pi-coding-agent/src/core/redact-secrets.test.ts
@@ -1,0 +1,76 @@
+// pi-coding-agent — unit tests for session-log secret redaction
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { redactSecrets } from "./redact-secrets.js";
+
+describe("redactSecrets", () => {
+	it("is a no-op on plain text with no secret markers", () => {
+		const input = "Hello world — this is just some prose with numbers 12345 and dashes - - -.";
+		assert.equal(redactSecrets(input), input);
+	});
+
+	it("redacts Anthropic keys before generic openai sk- pattern", () => {
+		const out = redactSecrets("key=sk-ant-api03-abcDEF1234567890abcDEF1234567890");
+		assert.equal(out, "key=[REDACTED:anthropic]");
+	});
+
+	it("redacts OpenAI sk- keys", () => {
+		const out = redactSecrets("OPENAI_API_KEY=sk-abcDEF1234567890abcDEF12");
+		assert.equal(out, "OPENAI_API_KEY=[REDACTED:openai]");
+	});
+
+	it("redacts LlamaCloud llx- keys", () => {
+		const out = redactSecrets("LLAMA_CLOUD_API_KEY=llx-abcDEF1234567890abcDEF1234567890");
+		assert.equal(out, "LLAMA_CLOUD_API_KEY=[REDACTED:llamacloud]");
+	});
+
+	it("redacts AWS access key ids", () => {
+		const out = redactSecrets("aws_access_key_id = AKIAIOSFODNN7EXAMPLE");
+		assert.equal(out, "aws_access_key_id = [REDACTED:aws-access-key]");
+	});
+
+	it("redacts GitHub personal/oauth/app/server/refresh tokens", () => {
+		const out = redactSecrets("token=ghp_abcdefghijklmnopqrstuvwxyz0123456789");
+		assert.equal(out, "token=[REDACTED:github-token]");
+	});
+
+	it("redacts Slack tokens", () => {
+		const out = redactSecrets("slack=xoxb-1234567890-abcdefghij");
+		assert.equal(out, "slack=[REDACTED:slack-token]");
+	});
+
+	it("redacts Google API keys", () => {
+		// Google API keys are exactly AIza + 35 chars (39 total).
+		const out = redactSecrets("key=AIzaSyA-1234567890abcdefghijklmnopqrstu");
+		assert.equal(out, "key=[REDACTED:google-api-key]");
+	});
+
+	it("redacts PEM private key blocks across newlines", () => {
+		const pem = [
+			"-----BEGIN RSA PRIVATE KEY-----",
+			"MIIEowIBAAKCAQEAabcDEF...",
+			"morekeymaterial==",
+			"-----END RSA PRIVATE KEY-----",
+		].join("\n");
+		const out = redactSecrets(`before\n${pem}\nafter`);
+		assert.equal(out, "before\n[REDACTED:pem-private-key]\nafter");
+	});
+
+	it("redacts multiple secrets in the same string", () => {
+		const out = redactSecrets(
+			"AZURE_CLIENT_SECRET: also llx-abcDEF1234567890abcDEF1234567890 and AKIAIOSFODNN7EXAMPLE",
+		);
+		assert.equal(
+			out,
+			"AZURE_CLIENT_SECRET: also [REDACTED:llamacloud] and [REDACTED:aws-access-key]",
+		);
+	});
+
+	it("does not redact short strings that merely contain sk- prose", () => {
+		// "sk-foo" is too short to match the openai pattern — must be 20+ chars.
+		const input = "the sk- prefix isn't always a secret";
+		assert.equal(redactSecrets(input), input);
+	});
+});

--- a/packages/pi-coding-agent/src/core/redact-secrets.test.ts
+++ b/packages/pi-coding-agent/src/core/redact-secrets.test.ts
@@ -16,9 +16,19 @@ describe("redactSecrets", () => {
 		assert.equal(out, "key=[REDACTED:anthropic]");
 	});
 
-	it("redacts OpenAI sk- keys", () => {
+	it("redacts legacy OpenAI sk- keys", () => {
 		const out = redactSecrets("OPENAI_API_KEY=sk-abcDEF1234567890abcDEF12");
 		assert.equal(out, "OPENAI_API_KEY=[REDACTED:openai]");
+	});
+
+	it("redacts OpenAI project sk-proj- keys with hyphens/underscores in body", () => {
+		const out = redactSecrets("OPENAI_API_KEY=sk-proj-AbCd_1234-EfGh_5678-IjKl_9012");
+		assert.equal(out, "OPENAI_API_KEY=[REDACTED:openai]");
+	});
+
+	it("redacts OpenAI admin sk-admin- keys", () => {
+		const out = redactSecrets("OPENAI_ADMIN_KEY=sk-admin-AbCd1234EfGh5678IjKl9012");
+		assert.equal(out, "OPENAI_ADMIN_KEY=[REDACTED:openai]");
 	});
 
 	it("redacts LlamaCloud llx- keys", () => {

--- a/packages/pi-coding-agent/src/core/redact-secrets.ts
+++ b/packages/pi-coding-agent/src/core/redact-secrets.ts
@@ -1,0 +1,54 @@
+// pi-coding-agent — secret redaction for session log persistence
+//
+// Called by prepareForPersistence() in session-manager.ts on every string
+// before it lands in the JSONL transcript. Replaces well-known secret shapes
+// with [REDACTED:<kind>] placeholders so credentials pasted by the user or
+// read from .env-style files never persist to disk.
+//
+// Pattern selection bias: high-specificity shapes only. Loose patterns
+// (e.g. FOO_SECRET=...) produce too many false positives in docs and code
+// samples and are intentionally excluded.
+
+interface SecretPattern {
+	kind: string;
+	regex: RegExp;
+}
+
+// Order matters: more-specific patterns first (sk-ant- before generic sk-).
+const PATTERNS: readonly SecretPattern[] = [
+	{ kind: "anthropic", regex: /sk-ant-[A-Za-z0-9_-]{20,}/g },
+	{ kind: "llamacloud", regex: /llx-[A-Za-z0-9_-]{20,}/g },
+	{ kind: "openai", regex: /sk-[A-Za-z0-9]{20,}/g },
+	{ kind: "aws-access-key", regex: /\b(?:AKIA|ASIA|AROA)[0-9A-Z]{16}\b/g },
+	{ kind: "github-token", regex: /\bgh[pousr]_[A-Za-z0-9]{30,}\b/g },
+	{ kind: "slack-token", regex: /\bxox[baprs]-[A-Za-z0-9-]{10,}\b/g },
+	{ kind: "google-api-key", regex: /\bAIza[0-9A-Za-z_-]{35}\b/g },
+	{
+		kind: "pem-private-key",
+		regex: /-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----/g,
+	},
+];
+
+export function redactSecrets(input: string): string {
+	// Short-circuit: skip regex work on strings with no plausible secret markers.
+	// Cheap heuristic — if none of these substrings are present, no pattern can match.
+	if (
+		!input.includes("sk-") &&
+		!input.includes("llx-") &&
+		!input.includes("AKIA") &&
+		!input.includes("ASIA") &&
+		!input.includes("AROA") &&
+		!input.includes("gh") &&
+		!input.includes("xox") &&
+		!input.includes("AIza") &&
+		!input.includes("PRIVATE KEY")
+	) {
+		return input;
+	}
+
+	let out = input;
+	for (const { kind, regex } of PATTERNS) {
+		out = out.replace(regex, `[REDACTED:${kind}]`);
+	}
+	return out;
+}

--- a/packages/pi-coding-agent/src/core/redact-secrets.ts
+++ b/packages/pi-coding-agent/src/core/redact-secrets.ts
@@ -18,7 +18,11 @@ interface SecretPattern {
 const PATTERNS: readonly SecretPattern[] = [
 	{ kind: "anthropic", regex: /sk-ant-[A-Za-z0-9_-]{20,}/g },
 	{ kind: "llamacloud", regex: /llx-[A-Za-z0-9_-]{20,}/g },
-	{ kind: "openai", regex: /sk-[A-Za-z0-9]{20,}/g },
+	// Covers all three official OpenAI key shapes: legacy `sk-…`, project `sk-proj-…`,
+	// and admin `sk-admin-…`. Hyphens and underscores appear inside real project keys
+	// so the remainder class must allow them. `sk-ant-` is matched earlier by the
+	// anthropic pattern and already replaced by the time this runs.
+	{ kind: "openai", regex: /sk-(?:proj-|admin-)?[A-Za-z0-9_-]{20,}/g },
 	{ kind: "aws-access-key", regex: /\b(?:AKIA|ASIA|AROA)[0-9A-Z]{16}\b/g },
 	{ kind: "github-token", regex: /\bgh[pousr]_[A-Za-z0-9]{30,}\b/g },
 	{ kind: "slack-token", regex: /\bxox[baprs]-[A-Za-z0-9-]{10,}\b/g },

--- a/packages/pi-coding-agent/src/core/session-manager.test.ts
+++ b/packages/pi-coding-agent/src/core/session-manager.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { describe, it, afterEach } from "node:test";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
@@ -61,5 +61,40 @@ describe("SessionManager usage totals", () => {
 			cacheWrite: 0,
 			cost: 0,
 		});
+	});
+});
+
+describe("SessionManager secret redaction on persistence", () => {
+	let dir: string;
+
+	afterEach(() => {
+		if (dir) {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("scrubs known secret shapes from JSONL on disk", () => {
+		dir = mkdtempSync(join(tmpdir(), "gsd-session-redact-test-"));
+		const manager = SessionManager.create(dir, dir);
+
+		const leakedKey = "llx-abcDEF1234567890abcDEF1234567890";
+		manager.appendMessage({
+			role: "user",
+			content: [{ type: "text", text: `here is my key: ${leakedKey}` }],
+		} as any);
+		// Persistence is gated on an assistant message being present.
+		manager.appendMessage(makeAssistantMessage(1, 1, 0, 0, 0));
+
+		const sessionFile = manager.getSessionFile();
+		assert.ok(sessionFile, "session file should be set");
+		const contents = readFileSync(sessionFile!, "utf8");
+		assert.ok(
+			!contents.includes(leakedKey),
+			"raw secret must not appear in persisted JSONL",
+		);
+		assert.ok(
+			contents.includes("[REDACTED:llamacloud]"),
+			"redaction placeholder must appear in persisted JSONL",
+		);
 	});
 });

--- a/packages/pi-coding-agent/src/core/session-manager.ts
+++ b/packages/pi-coding-agent/src/core/session-manager.ts
@@ -26,6 +26,7 @@ import {
 	createCustomMessage,
 } from "./messages.js";
 import { BlobStore, externalizeImageData, isBlobRef, resolveImageData } from "./blob-store.js";
+import { redactSecrets } from "./redact-secrets.js";
 
 /** Inline concurrency limiter to cap parallel async operations. */
 function pLimit(concurrency: number) {
@@ -499,15 +500,18 @@ function prepareForPersistence(obj: unknown, blobStore: BlobStore, key?: string)
 	if (obj === null || obj === undefined) return obj;
 
 	if (typeof obj === "string") {
-		if (obj.length > MAX_PERSIST_CHARS) {
-			// Cryptographic signatures must be preserved exactly or cleared entirely
-			if (key === "thinkingSignature" || key === "thoughtSignature" || key === "textSignature") {
+		// Cryptographic signatures must be preserved byte-exact — never redact or truncate
+		// their contents, only the oversize-clear path below handles them.
+		const isSignature = key === "thinkingSignature" || key === "thoughtSignature" || key === "textSignature";
+		const redacted = isSignature ? obj : redactSecrets(obj);
+		if (redacted.length > MAX_PERSIST_CHARS) {
+			if (isSignature) {
 				return "";
 			}
 			const limit = Math.max(0, MAX_PERSIST_CHARS - TRUNCATION_NOTICE.length);
-			return `${truncateString(obj, limit)}${TRUNCATION_NOTICE}`;
+			return `${truncateString(redacted, limit)}${TRUNCATION_NOTICE}`;
 		}
-		return obj;
+		return redacted;
 	}
 
 	if (Array.isArray(obj)) {


### PR DESCRIPTION
## Summary

- Secrets pasted by the user or read from `.env`-style files currently persist to the session JSONL in cleartext (confirmed locally: an `llx-…` key and an Azure client secret sitting in a transcript).
- Add a conservative redactor that runs inside `prepareForPersistence()` — the single funnel every persisted string passes through in `session-manager.ts`. One insertion covers user prompts, tool inputs, tool results, and model output uniformly.
- Patterns are high-specificity only (Anthropic `sk-ant-`, OpenAI `sk-`, LlamaCloud `llx-`, AWS `AKIA/ASIA/AROA`, GitHub `gh[pousr]_`, Slack `xox[baprs]-`, Google `AIza`, PEM private key blocks). Loose env-var shapes are intentionally excluded to keep false positives out of docs and code samples.

## Design notes

- Cryptographic signature fields (`thinkingSignature`, `thoughtSignature`, `textSignature`) are skipped to preserve byte-exact persistence.
- Short-circuit heuristic (substring scan) avoids regex work on the overwhelming majority of strings that cannot contain a matching secret.
- Replacement format: \`[REDACTED:<kind>]\`.
- In-memory conversation is unchanged — only the on-disk transcript is scrubbed.

## Out of scope

- Scrubbing pre-existing JSONL files. That is an operator concern (a one-off sweep over \`~/.claude/projects/\`) and shouldn't ride in a code PR.
- Configurable user-defined patterns. Can be added later if needed.

## Test plan

- [x] \`npm run build\` in \`packages/pi-coding-agent\` — clean.
- [x] New unit tests: \`packages/pi-coding-agent/src/core/redact-secrets.test.ts\` — one case per pattern, multi-match, and no-op-on-clean-text.
- [x] New integration test in \`session-manager.test.ts\` — persists a user message containing an \`llx-…\` key, reads the JSONL back, asserts the raw secret is absent and \`[REDACTED:llamacloud]\` is present.
- [x] \`npx tsx --test\` on both files — 14/14 pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic secret redaction now protects sensitive information in session logs. API keys, tokens (GitHub, Slack, etc.), and private keys are automatically masked before persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->