### PR TITLE
feat: add gsd_exec sandboxed tool execution with context-mode support

### DIFF
--- a/src/resources/extensions/gsd/bootstrap/exec-tools.ts
+++ b/src/resources/extensions/gsd/bootstrap/exec-tools.ts
@@ -7,6 +7,8 @@ import { Type } from "@sinclair/typebox";
 import type { ExtensionAPI } from "@gsd/pi-coding-agent";
 
 import { executeGsdExec } from "../tools/exec-tool.js";
+import { executeExecSearch } from "../tools/exec-search-tool.js";
+import { executeResume } from "../tools/resume-tool.js";
 import { loadEffectiveGSDPreferences } from "../preferences.js";
 import { logWarning } from "../workflow-logger.js";
 
@@ -52,6 +54,54 @@ export function registerExecTools(pi: ExtensionAPI): void {
       return executeGsdExec(params as Parameters<typeof executeGsdExec>[0], {
         baseDir: process.cwd(),
         preferences: prefs?.preferences ?? null,
+      });
+    },
+  });
+
+  pi.registerTool({
+    name: "gsd_exec_search",
+    label: "Search gsd_exec History",
+    description:
+      "List prior gsd_exec runs (most recent first) from .gsd/exec/*.meta.json. Useful for " +
+      "rediscovering the stdout_path of an earlier run without re-executing it. Read-only.",
+    promptSnippet: "Search prior gsd_exec runs by substring, runtime, or failing-only filter",
+    promptGuidelines: [
+      "Use this before re-running an expensive analysis — the prior run's stdout file may still answer.",
+      "The preview shows the trailing ~300 chars of stdout; read stdout_path for the full transcript.",
+    ],
+    parameters: Type.Object({
+      query: Type.Optional(Type.String({ description: "Substring matched against id and purpose (case-insensitive)." })),
+      runtime: Type.Optional(
+        Type.Union([Type.Literal("bash"), Type.Literal("node"), Type.Literal("python")], {
+          description: "Restrict to one runtime.",
+        }),
+      ),
+      failing_only: Type.Optional(Type.Boolean({ description: "Only non-zero exit codes and timeouts." })),
+      limit: Type.Optional(Type.Number({ description: "Max results (default 20, cap 200)", minimum: 1, maximum: 200 })),
+    }),
+    async execute(_toolCallId, params, _signal, _onUpdate, _ctx) {
+      return executeExecSearch(params as Parameters<typeof executeExecSearch>[0], {
+        baseDir: process.cwd(),
+      });
+    },
+  });
+
+  pi.registerTool({
+    name: "gsd_resume",
+    label: "Resume (Read Snapshot)",
+    description:
+      "Return the contents of .gsd/last-snapshot.md — a ≤2 KB digest of top memories, recent " +
+      "gsd_exec runs, and active context, written automatically on session_before_compact. Use " +
+      "this after compaction or session resume to re-orient quickly.",
+    promptSnippet: "Read the pre-compaction snapshot to re-orient after context loss",
+    promptGuidelines: [
+      "Call this right after a session resumes if you feel you've lost durable context.",
+      "The snapshot is a summary — use memory_query or gsd_exec_search for detail.",
+    ],
+    parameters: Type.Object({}),
+    async execute(_toolCallId, params, _signal, _onUpdate, _ctx) {
+      return executeResume(params as Parameters<typeof executeResume>[0], {
+        baseDir: process.cwd(),
       });
     },
   });

--- a/src/resources/extensions/gsd/bootstrap/exec-tools.ts
+++ b/src/resources/extensions/gsd/bootstrap/exec-tools.ts
@@ -1,0 +1,58 @@
+// GSD2 — Exec (context-mode) tool registration.
+//
+// Exposes the `gsd_exec` tool over MCP. Opt-in: disabled unless
+// `context_mode.enabled: true` is set in preferences.
+
+import { Type } from "@sinclair/typebox";
+import type { ExtensionAPI } from "@gsd/pi-coding-agent";
+
+import { executeGsdExec } from "../tools/exec-tool.js";
+import { loadEffectiveGSDPreferences } from "../preferences.js";
+import { logWarning } from "../workflow-logger.js";
+
+export function registerExecTools(pi: ExtensionAPI): void {
+  pi.registerTool({
+    name: "gsd_exec",
+    label: "Exec (Sandboxed)",
+    description:
+      "Run a short script (bash/node/python) in a subprocess. Full stdout/stderr persist to " +
+      ".gsd/exec/<id>.{stdout,stderr,meta.json}; only a short digest returns in context. Use " +
+      "this instead of reading many files or emitting large tool outputs — e.g. have the script " +
+      "count/grep/summarize and log the finding. Opt-in via preferences.context_mode.enabled.",
+    promptSnippet:
+      "Run a bash/node/python script in a sandbox; full output is saved to disk and only a digest returns",
+    promptGuidelines: [
+      "Prefer gsd_exec for analyses that would otherwise read >3 files or produce large tool output.",
+      "Write scripts that log the finding (counts, matches, summaries) rather than raw dumps.",
+      "The digest is the last ~300 chars of stdout — size your log output accordingly.",
+      "Need the full output? Read the stdout_path returned in details (file on local disk).",
+    ],
+    parameters: Type.Object({
+      runtime: Type.Union(
+        [Type.Literal("bash"), Type.Literal("node"), Type.Literal("python")],
+        { description: "Interpreter: bash (-c), node (-e), or python3 (-c)." },
+      ),
+      script: Type.String({ description: "Script body. Keep output small (log the finding, not the data)." }),
+      purpose: Type.Optional(Type.String({ description: "Short label recorded in meta.json for later review." })),
+      timeout_ms: Type.Optional(
+        Type.Number({
+          description: "Per-invocation timeout (ms). Capped at 600000. Default from preferences.",
+          minimum: 1_000,
+          maximum: 600_000,
+        }),
+      ),
+    }),
+    async execute(_toolCallId, params, _signal, _onUpdate, _ctx) {
+      let prefs: Awaited<ReturnType<typeof loadEffectiveGSDPreferences>> | null = null;
+      try {
+        prefs = loadEffectiveGSDPreferences();
+      } catch (err) {
+        logWarning("tool", `gsd_exec could not load preferences: ${err instanceof Error ? err.message : String(err)}`);
+      }
+      return executeGsdExec(params as Parameters<typeof executeGsdExec>[0], {
+        baseDir: process.cwd(),
+        preferences: prefs?.preferences ?? null,
+      });
+    },
+  });
+}

--- a/src/resources/extensions/gsd/bootstrap/register-extension.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-extension.ts
@@ -8,6 +8,7 @@ import type { GSDEcosystemBeforeAgentStartHandler } from "../ecosystem/gsd-exten
 import { loadEcosystemExtensions } from "../ecosystem/loader.js";
 import { registerDbTools } from "./db-tools.js";
 import { registerDynamicTools } from "./dynamic-tools.js";
+import { registerExecTools } from "./exec-tools.js";
 import { registerJournalTools } from "./journal-tools.js";
 import { registerMemoryTools } from "./memory-tools.js";
 import { registerQueryTools } from "./query-tools.js";
@@ -100,6 +101,7 @@ export function registerGsdExtension(pi: ExtensionAPI): void {
     ["journal-tools", () => registerJournalTools(pi)],
     ["query-tools", () => registerQueryTools(pi)],
     ["memory-tools", () => registerMemoryTools(pi)],
+    ["exec-tools", () => registerExecTools(pi)],
     ["shortcuts", () => registerShortcuts(pi)],
     ["hooks", () => registerHooks(pi, ecosystemHandlers)],
     ["ecosystem", () => {

--- a/src/resources/extensions/gsd/bootstrap/register-hooks.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-hooks.ts
@@ -225,6 +225,41 @@ export function registerHooks(
     }));
   });
 
+  // Context-mode snapshot: write .gsd/last-snapshot.md before compaction so
+  // agents can call gsd_resume (or Read the file) to re-orient. Opt-in via
+  // preferences.context_mode.enabled. Runs after the auto-cancel handler
+  // above — if that one returned cancel:true, pi still fires us but the
+  // compaction won't actually happen; the snapshot is still useful then,
+  // since auto may pause and resume later.
+  pi.on("session_before_compact", async () => {
+    try {
+      const { loadEffectiveGSDPreferences } = await import("../preferences.js");
+      const prefs = loadEffectiveGSDPreferences();
+      if (prefs?.preferences.context_mode?.enabled !== true) return;
+      const { writeCompactionSnapshot } = await import("../compaction-snapshot.js");
+      const { ensureDbOpen } = await import("./dynamic-tools.js");
+      await ensureDbOpen();
+      const basePath = process.cwd();
+      let activeContext: string | null = null;
+      try {
+        const state = await deriveState(basePath);
+        if (state.activeMilestone && state.activeSlice && state.activeTask) {
+          activeContext =
+            `Active: ${state.activeMilestone.id} / ${state.activeSlice.id} / ${state.activeTask.id}` +
+            (state.activeTask.title ? ` — ${state.activeTask.title}` : "");
+        }
+      } catch {
+        /* non-fatal */
+      }
+      writeCompactionSnapshot(basePath, { activeContext });
+    } catch (err) {
+      safetyLogWarning(
+        "context-mode",
+        `failed to write compaction snapshot: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  });
+
   pi.on("session_shutdown", async (_event, ctx: ExtensionContext) => {
     if (isParallelActive()) {
       try {

--- a/src/resources/extensions/gsd/compaction-snapshot.ts
+++ b/src/resources/extensions/gsd/compaction-snapshot.ts
@@ -1,0 +1,164 @@
+// GSD Compaction Snapshot — writes a ≤2 KB markdown digest of durable
+// project state before the session context is compacted. On resume, an
+// agent can `gsd_resume` (or Read .gsd/last-snapshot.md) to re-orient
+// without re-deriving the same memories.
+//
+// Inspired by mksglu/context-mode. Independent implementation.
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { getActiveMemoriesRanked, type Memory } from "./memory-store.js";
+import { listExecHistory, type ExecHistoryEntry } from "./exec-history.js";
+
+export const DEFAULT_SNAPSHOT_BYTES = 2048;
+export const SNAPSHOT_FILENAME = "last-snapshot.md";
+
+export interface SnapshotSources {
+  memories: Memory[];
+  execHistory: ExecHistoryEntry[];
+  generatedAt: Date;
+  /** Optional free-form context string (e.g. active unit id). */
+  activeContext?: string | null;
+}
+
+export interface BuildSnapshotOptions {
+  /** Hard cap in bytes (UTF-8). Default 2048. */
+  maxBytes?: number;
+  /** Memory count cap before truncation (default 6). */
+  maxMemories?: number;
+  /** Exec history cap (default 5). */
+  maxExec?: number;
+}
+
+/**
+ * Build a priority-tiered markdown snapshot. Pure — no I/O. Tiers:
+ *   1. Active context (if any)
+ *   2. Top memories by rank
+ *   3. Recent exec runs (failures highlighted)
+ * The result is guaranteed to be <= opts.maxBytes (truncated with an
+ * ellipsis marker if necessary).
+ */
+export function buildSnapshot(sources: SnapshotSources, opts: BuildSnapshotOptions = {}): string {
+  const maxBytes = opts.maxBytes ?? DEFAULT_SNAPSHOT_BYTES;
+  const maxMemories = opts.maxMemories ?? 6;
+  const maxExec = opts.maxExec ?? 5;
+
+  const lines: string[] = [];
+  lines.push(`# GSD context snapshot (${sources.generatedAt.toISOString()})`);
+  lines.push("");
+
+  if (sources.activeContext && sources.activeContext.trim().length > 0) {
+    lines.push("## Active context");
+    lines.push(sources.activeContext.trim());
+    lines.push("");
+  }
+
+  const memories = sources.memories.slice(0, maxMemories);
+  if (memories.length > 0) {
+    lines.push("## Top project memories");
+    for (const memory of memories) {
+      lines.push(`- [${memory.id}] (${memory.category}) ${memory.content.trim()}`);
+    }
+    lines.push("");
+  }
+
+  const exec = sources.execHistory.slice(0, maxExec);
+  if (exec.length > 0) {
+    lines.push("## Recent gsd_exec runs");
+    for (const entry of exec) {
+      const status = entry.timed_out
+        ? "timeout"
+        : entry.exit_code === null
+          ? "exit:null"
+          : `exit:${entry.exit_code}`;
+      const purpose = entry.purpose ? ` — ${entry.purpose}` : "";
+      lines.push(`- [${entry.id}] ${entry.runtime} ${status}${purpose}`);
+    }
+    lines.push("");
+  }
+
+  if (memories.length === 0 && exec.length === 0 && !sources.activeContext) {
+    lines.push("_No durable memories, active context, or exec history to surface._");
+  }
+
+  return enforceByteCap(lines.join("\n").trimEnd(), maxBytes);
+}
+
+function enforceByteCap(input: string, maxBytes: number): string {
+  if (Buffer.byteLength(input, "utf-8") <= maxBytes) return input;
+  const marker = "\n…[truncated]";
+  const markerBytes = Buffer.byteLength(marker, "utf-8");
+  const budget = Math.max(0, maxBytes - markerBytes);
+  // Walk backwards until the trimmed string fits. utf-8 is variable-width;
+  // naive char slicing is safe for ASCII but may split a multi-byte char.
+  // Guard by decoding the trimmed Buffer and relying on the replacement-char
+  // fallback in TextDecoder (implicit via toString).
+  const buf = Buffer.from(input, "utf-8").subarray(0, budget);
+  return `${buf.toString("utf-8")}${marker}`;
+}
+
+export interface WriteSnapshotOptions extends BuildSnapshotOptions {
+  activeContext?: string | null;
+  now?: () => Date;
+}
+
+export interface WriteSnapshotResult {
+  path: string;
+  bytes: number;
+  memories: number;
+  execRuns: number;
+}
+
+export function writeCompactionSnapshot(
+  baseDir: string,
+  opts: WriteSnapshotOptions = {},
+): WriteSnapshotResult {
+  const memories = safeGetMemories();
+  const execHistory = safeListExec(baseDir);
+  const content = buildSnapshot(
+    {
+      memories,
+      execHistory,
+      generatedAt: (opts.now ?? (() => new Date()))(),
+      activeContext: opts.activeContext ?? null,
+    },
+    opts,
+  );
+  const gsdDir = resolve(baseDir, ".gsd");
+  if (!existsSync(gsdDir)) mkdirSync(gsdDir, { recursive: true });
+  const path = resolve(gsdDir, SNAPSHOT_FILENAME);
+  writeFileSync(path, `${content}\n`, "utf-8");
+  return {
+    path,
+    bytes: Buffer.byteLength(content, "utf-8"),
+    memories: memories.length,
+    execRuns: execHistory.length,
+  };
+}
+
+export function readCompactionSnapshot(baseDir: string): string | null {
+  const path = resolve(baseDir, ".gsd", SNAPSHOT_FILENAME);
+  if (!existsSync(path)) return null;
+  try {
+    return readFileSync(path, "utf-8");
+  } catch {
+    return null;
+  }
+}
+
+function safeGetMemories(): Memory[] {
+  try {
+    return getActiveMemoriesRanked(12);
+  } catch {
+    return [];
+  }
+}
+
+function safeListExec(baseDir: string): ExecHistoryEntry[] {
+  try {
+    return listExecHistory(baseDir);
+  } catch {
+    return [];
+  }
+}

--- a/src/resources/extensions/gsd/compaction-snapshot.ts
+++ b/src/resources/extensions/gsd/compaction-snapshot.ts
@@ -128,10 +128,11 @@ export function writeCompactionSnapshot(
   const gsdDir = resolve(baseDir, ".gsd");
   if (!existsSync(gsdDir)) mkdirSync(gsdDir, { recursive: true });
   const path = resolve(gsdDir, SNAPSHOT_FILENAME);
-  writeFileSync(path, `${content}\n`, "utf-8");
+  const finalContent = `${content}\n`;
+  writeFileSync(path, finalContent, "utf-8");
   return {
     path,
-    bytes: Buffer.byteLength(content, "utf-8"),
+    bytes: Buffer.byteLength(finalContent, "utf-8"),
     memories: memories.length,
     execRuns: execHistory.length,
   };

--- a/src/resources/extensions/gsd/exec-history.ts
+++ b/src/resources/extensions/gsd/exec-history.ts
@@ -1,0 +1,143 @@
+// GSD Exec History — read-side helpers for the exec sandbox.
+//
+// Pure I/O: scans `.gsd/exec/*.meta.json` under a base directory and
+// returns lightweight records. Used by the gsd_exec_search tool and
+// any future compaction-snapshot enrichment.
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+export interface ExecHistoryEntry {
+  id: string;
+  runtime: "bash" | "node" | "python" | string;
+  purpose: string | null;
+  started_at: string;
+  finished_at: string;
+  duration_ms: number;
+  exit_code: number | null;
+  signal: string | null;
+  timed_out: boolean;
+  stdout_bytes: number;
+  stderr_bytes: number;
+  stdout_truncated: boolean;
+  stderr_truncated: boolean;
+  stdout_path: string;
+  stderr_path: string;
+  meta_path: string;
+}
+
+export interface ExecSearchOptions {
+  /** Case-insensitive needle matched against purpose. Empty string matches all. */
+  query?: string;
+  /** Restrict to this runtime. */
+  runtime?: ExecHistoryEntry["runtime"];
+  /** Include only entries with exit_code !== 0 || timed_out. */
+  failing_only?: boolean;
+  /** Return at most N entries, most recent first. Default 20, cap 200. */
+  limit?: number;
+}
+
+export interface ExecSearchHit {
+  entry: ExecHistoryEntry;
+  /** Tail of stdout (first 300 chars) — cheap to read, useful for disambiguation. */
+  digest_preview?: string;
+}
+
+function listMetaFiles(baseDir: string): string[] {
+  const dir = resolve(baseDir, ".gsd", "exec");
+  try {
+    return readdirSync(dir)
+      .filter((name) => name.endsWith(".meta.json"))
+      .map((name) => join(dir, name));
+  } catch {
+    return [];
+  }
+}
+
+function safeReadMeta(path: string): ExecHistoryEntry | null {
+  try {
+    const raw = readFileSync(path, "utf-8");
+    const parsed = JSON.parse(raw) as Partial<ExecHistoryEntry>;
+    if (typeof parsed.id !== "string" || typeof parsed.runtime !== "string") return null;
+    return {
+      id: parsed.id,
+      runtime: parsed.runtime,
+      purpose: typeof parsed.purpose === "string" ? parsed.purpose : null,
+      started_at: typeof parsed.started_at === "string" ? parsed.started_at : "",
+      finished_at: typeof parsed.finished_at === "string" ? parsed.finished_at : "",
+      duration_ms: typeof parsed.duration_ms === "number" ? parsed.duration_ms : 0,
+      exit_code: typeof parsed.exit_code === "number" ? parsed.exit_code : null,
+      signal: typeof parsed.signal === "string" ? parsed.signal : null,
+      timed_out: parsed.timed_out === true,
+      stdout_bytes: typeof parsed.stdout_bytes === "number" ? parsed.stdout_bytes : 0,
+      stderr_bytes: typeof parsed.stderr_bytes === "number" ? parsed.stderr_bytes : 0,
+      stdout_truncated: parsed.stdout_truncated === true,
+      stderr_truncated: parsed.stderr_truncated === true,
+      stdout_path: typeof parsed.stdout_path === "string" ? parsed.stdout_path : "",
+      stderr_path: typeof parsed.stderr_path === "string" ? parsed.stderr_path : "",
+      meta_path: path,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function listExecHistory(baseDir: string): ExecHistoryEntry[] {
+  const metas = listMetaFiles(baseDir)
+    .map((path) => {
+      let mtime = 0;
+      try {
+        mtime = statSync(path).mtimeMs;
+      } catch {
+        /* ignore */
+      }
+      const entry = safeReadMeta(path);
+      return entry ? { entry, mtime } : null;
+    })
+    .filter((value): value is { entry: ExecHistoryEntry; mtime: number } => value !== null);
+  metas.sort((a, b) => b.mtime - a.mtime);
+  return metas.map((m) => m.entry);
+}
+
+function matchesFilters(entry: ExecHistoryEntry, opts: ExecSearchOptions): boolean {
+  if (opts.runtime && entry.runtime !== opts.runtime) return false;
+  if (opts.failing_only) {
+    const failed = entry.timed_out || (entry.exit_code !== 0 && entry.exit_code !== null);
+    if (!failed) return false;
+  }
+  const query = (opts.query ?? "").trim().toLowerCase();
+  if (!query) return true;
+  const haystack = `${entry.id} ${entry.purpose ?? ""}`.toLowerCase();
+  return haystack.includes(query);
+}
+
+function readDigestPreview(entry: ExecHistoryEntry, maxChars: number): string | undefined {
+  if (!entry.stdout_path || maxChars <= 0) return undefined;
+  try {
+    const text = readFileSync(entry.stdout_path, "utf-8");
+    const trimmed = text.trimEnd();
+    return trimmed.length <= maxChars ? trimmed : trimmed.slice(trimmed.length - maxChars);
+  } catch {
+    return undefined;
+  }
+}
+
+export function searchExecHistory(
+  baseDir: string,
+  opts: ExecSearchOptions = {},
+): ExecSearchHit[] {
+  const limit = clampLimit(opts.limit, 20, 200);
+  const entries = listExecHistory(baseDir);
+  const filtered = entries.filter((entry) => matchesFilters(entry, opts));
+  return filtered.slice(0, limit).map((entry) => ({
+    entry,
+    digest_preview: readDigestPreview(entry, 300),
+  }));
+}
+
+function clampLimit(value: unknown, fallback: number, max: number): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) return fallback;
+  if (value < 1) return 1;
+  if (value > max) return max;
+  return Math.floor(value);
+}

--- a/src/resources/extensions/gsd/exec-history.ts
+++ b/src/resources/extensions/gsd/exec-history.ts
@@ -4,7 +4,7 @@
 // returns lightweight records. Used by the gsd_exec_search tool and
 // any future compaction-snapshot enrichment.
 
-import { readdirSync, readFileSync, statSync } from "node:fs";
+import { closeSync, openSync, readdirSync, readFileSync, readSync, statSync } from "node:fs";
 import { join, resolve } from "node:path";
 
 export interface ExecHistoryEntry {
@@ -114,9 +114,19 @@ function matchesFilters(entry: ExecHistoryEntry, opts: ExecSearchOptions): boole
 function readDigestPreview(entry: ExecHistoryEntry, maxChars: number): string | undefined {
   if (!entry.stdout_path || maxChars <= 0) return undefined;
   try {
-    const text = readFileSync(entry.stdout_path, "utf-8");
-    const trimmed = text.trimEnd();
-    return trimmed.length <= maxChars ? trimmed : trimmed.slice(trimmed.length - maxChars);
+    const size = statSync(entry.stdout_path).size;
+    if (size === 0) return undefined;
+    const readBytes = Math.min(size, maxChars * 4); // 4 bytes/char upper bound for UTF-8
+    const buf = Buffer.allocUnsafe(readBytes);
+    const fd = openSync(entry.stdout_path, "r");
+    try {
+      const bytesRead = readSync(fd, buf, 0, readBytes, Math.max(0, size - readBytes));
+      const text = buf.subarray(0, bytesRead).toString("utf-8");
+      const trimmed = text.trimEnd();
+      return trimmed.length <= maxChars ? trimmed : trimmed.slice(trimmed.length - maxChars);
+    } finally {
+      closeSync(fd);
+    }
   } catch {
     return undefined;
   }

--- a/src/resources/extensions/gsd/exec-history.ts
+++ b/src/resources/extensions/gsd/exec-history.ts
@@ -73,8 +73,8 @@ function safeReadMeta(path: string): ExecHistoryEntry | null {
       stderr_bytes: typeof parsed.stderr_bytes === "number" ? parsed.stderr_bytes : 0,
       stdout_truncated: parsed.stdout_truncated === true,
       stderr_truncated: parsed.stderr_truncated === true,
-      stdout_path: typeof parsed.stdout_path === "string" ? parsed.stdout_path : "",
-      stderr_path: typeof parsed.stderr_path === "string" ? parsed.stderr_path : "",
+      stdout_path: path.replace(/\.meta\.json$/, ".stdout"),
+      stderr_path: path.replace(/\.meta\.json$/, ".stderr"),
       meta_path: path,
     };
   } catch {

--- a/src/resources/extensions/gsd/exec-sandbox.ts
+++ b/src/resources/extensions/gsd/exec-sandbox.ts
@@ -1,0 +1,310 @@
+// GSD Exec Sandbox — tool-output sandboxing for sub-sessions.
+//
+// Runs a script in a subprocess and persists stdout/stderr to
+// `.gsd/exec/<id>.{stdout,stderr,meta.json}`. Only a short digest is
+// returned to the calling agent's context, keeping large outputs
+// (e.g. Playwright snapshots, issue dumps) out of the window.
+//
+// Inspired by mksglu/context-mode (Elastic License 2.0). Independent
+// implementation — no upstream code incorporated.
+
+import { spawn } from "node:child_process";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { randomUUID } from "node:crypto";
+import { resolve } from "node:path";
+
+export interface ExecSandboxRequest {
+  /** Interpreter to use. */
+  runtime: "bash" | "node" | "python";
+  /** Script body. Executed via the runtime's -c equivalent. */
+  script: string;
+  /** Optional purpose/label recorded in meta.json. */
+  purpose?: string;
+  /** Per-invocation timeout in ms. Clamped to `clamp_timeout_ms`. */
+  timeout_ms?: number;
+}
+
+export interface ExecSandboxOptions {
+  /** Project root. stdout/stderr persist under `<baseDir>/.gsd/exec/`. */
+  baseDir: string;
+  /** Absolute upper bound for the timeout. */
+  clamp_timeout_ms: number;
+  /** Default timeout if request omits one. */
+  default_timeout_ms: number;
+  /** Cap on persisted stdout bytes. Further output is truncated with a marker. */
+  stdout_cap_bytes: number;
+  /** Cap on persisted stderr bytes. */
+  stderr_cap_bytes: number;
+  /** Number of trailing stdout chars returned as the digest. */
+  digest_chars: number;
+  /** Env var allowlist (case-sensitive). PATH/HOME always forwarded. */
+  env_allowlist: readonly string[];
+  /** Optional override of process.env for tests. */
+  env?: NodeJS.ProcessEnv;
+  /** Optional override for the current time (tests). */
+  now?: () => Date;
+  /** Optional override for id generation (tests). */
+  generateId?: () => string;
+}
+
+export interface ExecSandboxResult {
+  id: string;
+  runtime: ExecSandboxRequest["runtime"];
+  exit_code: number | null;
+  signal: NodeJS.Signals | null;
+  timed_out: boolean;
+  duration_ms: number;
+  stdout_bytes: number;
+  stderr_bytes: number;
+  stdout_truncated: boolean;
+  stderr_truncated: boolean;
+  stdout_path: string;
+  stderr_path: string;
+  meta_path: string;
+  digest: string;
+}
+
+const ALWAYS_FORWARD_ENV = ["PATH", "HOME"] as const;
+
+export const EXEC_DEFAULTS = {
+  clampTimeoutMs: 600_000,
+  defaultTimeoutMs: 30_000,
+  stdoutCapBytes: 1_048_576,
+  stderrCapBytes: 262_144,
+  digestChars: 300,
+  envAllowlist: [
+    "LANG",
+    "LC_ALL",
+    "TERM",
+    "TZ",
+    "SHELL",
+    "USER",
+    "LOGNAME",
+    "TMPDIR",
+    "NODE_OPTIONS",
+    "PYTHONPATH",
+    "PYTHONIOENCODING",
+  ] as const,
+} as const;
+
+function buildChildEnv(opts: ExecSandboxOptions): NodeJS.ProcessEnv {
+  const source = opts.env ?? process.env;
+  const out: NodeJS.ProcessEnv = {};
+  const allowed = new Set<string>([...ALWAYS_FORWARD_ENV, ...opts.env_allowlist]);
+  for (const key of allowed) {
+    const value = source[key];
+    if (typeof value === "string") out[key] = value;
+  }
+  return out;
+}
+
+function clampTimeout(request: ExecSandboxRequest, opts: ExecSandboxOptions): number {
+  const requested = typeof request.timeout_ms === "number" && Number.isFinite(request.timeout_ms)
+    ? Math.floor(request.timeout_ms)
+    : opts.default_timeout_ms;
+  if (requested < 1) return 1;
+  if (requested > opts.clamp_timeout_ms) return opts.clamp_timeout_ms;
+  return requested;
+}
+
+function resolveCommand(runtime: ExecSandboxRequest["runtime"]): { cmd: string; args: string[] } {
+  switch (runtime) {
+    case "bash":
+      return { cmd: "bash", args: ["-c"] };
+    case "node":
+      return { cmd: process.execPath, args: ["-e"] };
+    case "python":
+      return { cmd: "python3", args: ["-c"] };
+  }
+}
+
+function tail(buf: Buffer, chars: number): string {
+  if (chars <= 0) return "";
+  const text = buf.toString("utf-8");
+  return text.length <= chars ? text : text.slice(text.length - chars);
+}
+
+/**
+ * Run a script in a subprocess, capture stdout/stderr to files under
+ * `.gsd/exec/<id>.{stdout,stderr,meta.json}`, and return an `ExecSandboxResult`
+ * containing the digest plus metadata.
+ *
+ * Errors from spawn failures resolve (not reject) with `exit_code=null`.
+ * The function is pure with respect to its inputs — no global state beyond
+ * filesystem writes under `baseDir`.
+ */
+export function runExecSandbox(
+  request: ExecSandboxRequest,
+  opts: ExecSandboxOptions,
+): Promise<ExecSandboxResult> {
+  return new Promise((resolveP) => {
+    const id = (opts.generateId ?? defaultGenerateId)();
+    const now = (opts.now ?? (() => new Date()))();
+    const execDir = resolve(opts.baseDir, ".gsd", "exec");
+    if (!existsSync(execDir)) mkdirSync(execDir, { recursive: true });
+    const stdoutPath = resolve(execDir, `${id}.stdout`);
+    const stderrPath = resolve(execDir, `${id}.stderr`);
+    const metaPath = resolve(execDir, `${id}.meta.json`);
+
+    const timeoutMs = clampTimeout(request, opts);
+    const { cmd, args } = resolveCommand(request.runtime);
+    const env = buildChildEnv(opts);
+
+    const started = Date.now();
+    let child;
+    try {
+      child = spawn(cmd, [...args, request.script], {
+        cwd: opts.baseDir,
+        env,
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+    } catch (err) {
+      const duration = Date.now() - started;
+      const message = err instanceof Error ? err.message : String(err);
+      writeFileSync(stdoutPath, "");
+      writeFileSync(stderrPath, `spawn error: ${message}\n`);
+      const result: ExecSandboxResult = {
+        id,
+        runtime: request.runtime,
+        exit_code: null,
+        signal: null,
+        timed_out: false,
+        duration_ms: duration,
+        stdout_bytes: 0,
+        stderr_bytes: Buffer.byteLength(`spawn error: ${message}\n`),
+        stdout_truncated: false,
+        stderr_truncated: false,
+        stdout_path: stdoutPath,
+        stderr_path: stderrPath,
+        meta_path: metaPath,
+        digest: `[spawn error: ${message}]`,
+      };
+      writeMeta(metaPath, result, request, now);
+      resolveP(result);
+      return;
+    }
+
+    const stdoutChunks: Buffer[] = [];
+    const stderrChunks: Buffer[] = [];
+    let stdoutBytes = 0;
+    let stderrBytes = 0;
+    let stdoutTruncated = false;
+    let stderrTruncated = false;
+
+    child.stdout?.on("data", (chunk: Buffer) => {
+      const remaining = opts.stdout_cap_bytes - stdoutBytes;
+      if (remaining <= 0) {
+        stdoutTruncated = true;
+        return;
+      }
+      if (chunk.length <= remaining) {
+        stdoutChunks.push(chunk);
+        stdoutBytes += chunk.length;
+      } else {
+        stdoutChunks.push(chunk.subarray(0, remaining));
+        stdoutBytes += remaining;
+        stdoutTruncated = true;
+      }
+    });
+    child.stderr?.on("data", (chunk: Buffer) => {
+      const remaining = opts.stderr_cap_bytes - stderrBytes;
+      if (remaining <= 0) {
+        stderrTruncated = true;
+        return;
+      }
+      if (chunk.length <= remaining) {
+        stderrChunks.push(chunk);
+        stderrBytes += chunk.length;
+      } else {
+        stderrChunks.push(chunk.subarray(0, remaining));
+        stderrBytes += remaining;
+        stderrTruncated = true;
+      }
+    });
+
+    let timedOut = false;
+    const timer = setTimeout(() => {
+      timedOut = true;
+      child.kill("SIGKILL");
+    }, timeoutMs);
+    timer.unref?.();
+
+    const finalize = (exitCode: number | null, signal: NodeJS.Signals | null) => {
+      clearTimeout(timer);
+      const duration = Date.now() - started;
+      const stdoutBuf = Buffer.concat(stdoutChunks);
+      const stderrBuf = Buffer.concat(stderrChunks);
+      const stdoutSuffix = stdoutTruncated ? "\n[truncated: stdout cap reached]\n" : "";
+      const stderrSuffix = stderrTruncated ? "\n[truncated: stderr cap reached]\n" : "";
+      writeFileSync(stdoutPath, Buffer.concat([stdoutBuf, Buffer.from(stdoutSuffix, "utf-8")]));
+      writeFileSync(stderrPath, Buffer.concat([stderrBuf, Buffer.from(stderrSuffix, "utf-8")]));
+
+      const digestBody = tail(stdoutBuf, opts.digest_chars);
+      const digest =
+        digestBody.length > 0
+          ? digestBody
+          : timedOut
+            ? "[no stdout — timed out]"
+            : stderrBuf.length > 0
+              ? `[no stdout — tail of stderr]\n${tail(stderrBuf, opts.digest_chars)}`
+              : "[no output]";
+
+      const result: ExecSandboxResult = {
+        id,
+        runtime: request.runtime,
+        exit_code: exitCode,
+        signal,
+        timed_out: timedOut,
+        duration_ms: duration,
+        stdout_bytes: stdoutBytes,
+        stderr_bytes: stderrBytes,
+        stdout_truncated: stdoutTruncated,
+        stderr_truncated: stderrTruncated,
+        stdout_path: stdoutPath,
+        stderr_path: stderrPath,
+        meta_path: metaPath,
+        digest,
+      };
+      writeMeta(metaPath, result, request, now);
+      resolveP(result);
+    };
+
+    child.on("error", (err) => {
+      const message = err instanceof Error ? err.message : String(err);
+      stderrChunks.push(Buffer.from(`child error: ${message}\n`, "utf-8"));
+      stderrBytes += Buffer.byteLength(`child error: ${message}\n`);
+    });
+    child.on("close", (code, signal) => finalize(code, signal));
+  });
+}
+
+function defaultGenerateId(): string {
+  return randomUUID();
+}
+
+function writeMeta(
+  path: string,
+  result: ExecSandboxResult,
+  request: ExecSandboxRequest,
+  now: Date,
+): void {
+  const meta = {
+    id: result.id,
+    runtime: result.runtime,
+    purpose: request.purpose ?? null,
+    script_chars: request.script.length,
+    started_at: now.toISOString(),
+    finished_at: new Date(now.getTime() + result.duration_ms).toISOString(),
+    exit_code: result.exit_code,
+    signal: result.signal,
+    timed_out: result.timed_out,
+    duration_ms: result.duration_ms,
+    stdout_bytes: result.stdout_bytes,
+    stderr_bytes: result.stderr_bytes,
+    stdout_truncated: result.stdout_truncated,
+    stderr_truncated: result.stderr_truncated,
+    stdout_path: result.stdout_path,
+    stderr_path: result.stderr_path,
+  };
+  writeFileSync(path, `${JSON.stringify(meta, null, 2)}\n`);
+}

--- a/src/resources/extensions/gsd/exec-sandbox.ts
+++ b/src/resources/extensions/gsd/exec-sandbox.ts
@@ -149,6 +149,7 @@ export function runExecSandbox(
     const timeoutMs = clampTimeout(request, opts);
     const { cmd, args } = resolveCommand(request.runtime);
     const env = buildChildEnv(opts);
+    const useProcessGroup = process.platform !== "win32";
 
     const started = Date.now();
     let child;
@@ -157,6 +158,7 @@ export function runExecSandbox(
         cwd: opts.baseDir,
         env,
         stdio: ["ignore", "pipe", "pipe"],
+        ...(useProcessGroup ? { detached: true } : {}),
       });
     } catch (err) {
       const duration = Date.now() - started;
@@ -225,7 +227,15 @@ export function runExecSandbox(
     let timedOut = false;
     const timer = setTimeout(() => {
       timedOut = true;
-      child.kill("SIGKILL");
+      if (useProcessGroup && child.pid != null) {
+        try {
+          process.kill(-child.pid, "SIGKILL");
+        } catch {
+          child.kill("SIGKILL");
+        }
+      } else {
+        child.kill("SIGKILL");
+      }
     }, timeoutMs);
     timer.unref?.();
 

--- a/src/resources/extensions/gsd/exec-sandbox.ts
+++ b/src/resources/extensions/gsd/exec-sandbox.ts
@@ -271,8 +271,14 @@ export function runExecSandbox(
 
     child.on("error", (err) => {
       const message = err instanceof Error ? err.message : String(err);
-      stderrChunks.push(Buffer.from(`child error: ${message}\n`, "utf-8"));
-      stderrBytes += Buffer.byteLength(`child error: ${message}\n`);
+      const line = `child error: ${message}\n`;
+      const remaining = opts.stderr_cap_bytes - stderrBytes;
+      if (remaining > 0) {
+        const chunk = Buffer.from(line, "utf-8").subarray(0, remaining);
+        stderrChunks.push(chunk);
+        stderrBytes += chunk.length;
+        if (chunk.length < Buffer.byteLength(line, "utf-8")) stderrTruncated = true;
+      }
     });
     child.on("close", (code, signal) => finalize(code, signal));
   });

--- a/src/resources/extensions/gsd/preferences-types.ts
+++ b/src/resources/extensions/gsd/preferences-types.ts
@@ -28,6 +28,28 @@ export interface ContextManagementConfig {
   compaction_threshold_percent?: number;  // default: 0.70, range: 0.5-0.95
   tool_result_max_chars?: number;         // default: 800, range: 200-10000
 }
+
+/**
+ * Opt-in tool-output sandboxing for sub-sessions. When enabled, the gsd_exec
+ * MCP tool runs scripts in an isolated subprocess and returns only a short
+ * digest to the calling agent's context window; full stdout/stderr persist
+ * in the project memory store and can be retrieved by id later.
+ *
+ * Inspired by mksglu/context-mode (Elastic License 2.0). This is an
+ * independent implementation — no upstream code is incorporated.
+ */
+export interface ContextModeConfig {
+  /** Master switch. Default: false (opt-in). */
+  enabled?: boolean;
+  /** Per-invocation timeout in milliseconds. Default: 30_000. Range: 1_000–600_000. */
+  exec_timeout_ms?: number;
+  /** Cap on persisted stdout bytes per invocation. Default: 1_048_576 (1 MiB). Range: 4_096–16_777_216. */
+  exec_stdout_cap_bytes?: number;
+  /** Number of trailing stdout characters returned in the digest. Default: 300. Range: 0–4_000. */
+  exec_digest_chars?: number;
+  /** Environment variables forwarded to sandboxed processes (case-sensitive names). PATH and HOME are always forwarded. */
+  exec_env_allowlist?: string[];
+}
 import type { GitHubSyncConfig } from "../github-sync/types.js";
 
 // ─── Workflow Modes ──────────────────────────────────────────────────────────
@@ -117,6 +139,7 @@ export const KNOWN_PREFERENCE_KEYS = new Set<string>([
   "flat_rate_providers",
   "language",
   "context_window_override",
+  "context_mode",
 ]);
 
 /** Canonical list of all dispatch unit types. */
@@ -300,6 +323,12 @@ export interface GSDPreferences {
    */
   context_window_override?: number;
   context_management?: ContextManagementConfig;
+  /**
+   * Tool-output sandboxing via gsd_exec. Keeps sub-session context windows
+   * clean by running scripts in a subprocess and only surfacing a short
+   * digest. See `ContextModeConfig`. Default: disabled.
+   */
+  context_mode?: ContextModeConfig;
   token_profile?: TokenProfile;
   phases?: PhaseSkipPreferences;
   auto_visualize?: boolean;

--- a/src/resources/extensions/gsd/preferences-validation.ts
+++ b/src/resources/extensions/gsd/preferences-validation.ts
@@ -644,6 +644,50 @@ export function validatePreferences(preferences: GSDPreferences): {
     }
   }
 
+  // ─── Context Mode (gsd_exec sandbox) ────────────────────────────────────
+  if (preferences.context_mode !== undefined) {
+    if (typeof preferences.context_mode === "object" && preferences.context_mode !== null) {
+      const cmode = preferences.context_mode as unknown as Record<string, unknown>;
+      const validCmode: Record<string, unknown> = {};
+
+      if (cmode.enabled !== undefined) {
+        if (typeof cmode.enabled === "boolean") validCmode.enabled = cmode.enabled;
+        else errors.push("context_mode.enabled must be a boolean");
+      }
+      if (cmode.exec_timeout_ms !== undefined) {
+        const t = cmode.exec_timeout_ms;
+        if (typeof t === "number" && t >= 1000 && t <= 600_000) validCmode.exec_timeout_ms = Math.floor(t);
+        else errors.push("context_mode.exec_timeout_ms must be a number between 1000 and 600000");
+      }
+      if (cmode.exec_stdout_cap_bytes !== undefined) {
+        const b = cmode.exec_stdout_cap_bytes;
+        if (typeof b === "number" && b >= 4096 && b <= 16_777_216) validCmode.exec_stdout_cap_bytes = Math.floor(b);
+        else errors.push("context_mode.exec_stdout_cap_bytes must be a number between 4096 and 16777216");
+      }
+      if (cmode.exec_digest_chars !== undefined) {
+        const c = cmode.exec_digest_chars;
+        if (typeof c === "number" && c >= 0 && c <= 4000) validCmode.exec_digest_chars = Math.floor(c);
+        else errors.push("context_mode.exec_digest_chars must be a number between 0 and 4000");
+      }
+      if (cmode.exec_env_allowlist !== undefined) {
+        if (
+          Array.isArray(cmode.exec_env_allowlist) &&
+          cmode.exec_env_allowlist.every((v) => typeof v === "string" && /^[A-Z_][A-Z0-9_]*$/i.test(v))
+        ) {
+          validCmode.exec_env_allowlist = cmode.exec_env_allowlist;
+        } else {
+          errors.push("context_mode.exec_env_allowlist must be an array of valid env var names");
+        }
+      }
+
+      if (Object.keys(validCmode).length > 0) {
+        validated.context_mode = validCmode as any;
+      }
+    } else {
+      errors.push("context_mode must be an object");
+    }
+  }
+
   // ─── Parallel Config ────────────────────────────────────────────────────
   if (preferences.parallel && typeof preferences.parallel === "object") {
     const p = preferences.parallel as unknown as Record<string, unknown>;

--- a/src/resources/extensions/gsd/tests/compaction-snapshot.test.ts
+++ b/src/resources/extensions/gsd/tests/compaction-snapshot.test.ts
@@ -1,0 +1,123 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  buildSnapshot,
+  readCompactionSnapshot,
+  writeCompactionSnapshot,
+  DEFAULT_SNAPSHOT_BYTES,
+} from '../compaction-snapshot.ts';
+import { closeDatabase, openDatabase } from '../gsd-db.ts';
+import { createMemory } from '../memory-store.ts';
+import { executeResume } from '../tools/resume-tool.ts';
+
+function freshBase(): string {
+  return mkdtempSync(join(tmpdir(), 'gsd-snap-'));
+}
+
+function cleanup(dir: string): void {
+  rmSync(dir, { recursive: true, force: true });
+}
+
+test('buildSnapshot: renders memories, exec history, and active context', () => {
+  const snap = buildSnapshot({
+    generatedAt: new Date('2026-04-20T12:00:00.000Z'),
+    activeContext: 'M001 / S01 / T01 — wire gsd_exec',
+    memories: [
+      { id: 'MEM001', category: 'gotcha', content: 'FTS5 needs Porter tokenizer', confidence: 0.9,
+        source_unit_type: null, source_unit_id: null, created_at: '', updated_at: '',
+        superseded_by: null, hit_count: 0, scope: 'project', seq: 1, tags: [], structured_fields: null },
+    ],
+    execHistory: [
+      {
+        id: 'abc',
+        runtime: 'bash',
+        purpose: 'count TODOs',
+        started_at: '', finished_at: '', duration_ms: 10,
+        exit_code: 0, signal: null, timed_out: false,
+        stdout_bytes: 1, stderr_bytes: 0, stdout_truncated: false, stderr_truncated: false,
+        stdout_path: '/tmp/abc.stdout', stderr_path: '/tmp/abc.stderr', meta_path: '/tmp/abc.meta.json',
+      },
+    ],
+  });
+  assert.match(snap, /Active context/);
+  assert.match(snap, /M001 \/ S01 \/ T01/);
+  assert.match(snap, /FTS5 needs Porter tokenizer/);
+  assert.match(snap, /\[abc\] bash exit:0 — count TODOs/);
+});
+
+test('buildSnapshot: enforces the byte cap with a truncation marker', () => {
+  const longMemories = Array.from({ length: 50 }, (_v, i) => ({
+    id: `MEM${String(i).padStart(3, '0')}`,
+    category: 'gotcha',
+    content: 'x'.repeat(200),
+    confidence: 0.8,
+    source_unit_type: null,
+    source_unit_id: null,
+    created_at: '',
+    updated_at: '',
+    superseded_by: null,
+    hit_count: 0,
+    scope: 'project',
+    seq: i,
+    tags: [] as string[],
+    structured_fields: null,
+  }));
+  const snap = buildSnapshot(
+    { generatedAt: new Date(), memories: longMemories, execHistory: [] },
+    { maxBytes: 512, maxMemories: 50 },
+  );
+  assert.ok(Buffer.byteLength(snap, 'utf-8') <= 512, 'should respect cap');
+  assert.match(snap, /\[truncated\]/, 'should include truncation marker');
+});
+
+test('buildSnapshot: handles empty state with an explanatory placeholder', () => {
+  const snap = buildSnapshot({ generatedAt: new Date(), memories: [], execHistory: [] });
+  assert.match(snap, /_No durable memories/);
+  assert.ok(Buffer.byteLength(snap, 'utf-8') <= DEFAULT_SNAPSHOT_BYTES);
+});
+
+test('writeCompactionSnapshot + readCompactionSnapshot + executeResume: end-to-end', () => {
+  const base = freshBase();
+  try {
+    openDatabase(':memory:');
+    createMemory({ category: 'architecture', content: 'Single-writer DB through gsd-db.ts', confidence: 0.95 });
+    createMemory({ category: 'convention', content: 'Prefer typed helpers over raw SQL', confidence: 0.9 });
+
+    const out = writeCompactionSnapshot(base, { activeContext: 'M099 resume check' });
+    assert.ok(out.path.endsWith('last-snapshot.md'));
+    assert.ok(out.bytes > 0);
+    assert.equal(out.memories, 2);
+
+    const contents = readCompactionSnapshot(base);
+    assert.ok(contents);
+    assert.match(contents!, /Single-writer DB through gsd-db\.ts/);
+    assert.match(contents!, /M099 resume check/);
+
+    const tool = executeResume({}, { baseDir: base });
+    assert.ok(!tool.isError);
+    assert.equal(tool.details.found, true);
+    assert.match(tool.content[0].text, /Single-writer DB through gsd-db\.ts/);
+
+    // also verify the file content matches (without trailing newline)
+    const raw = readFileSync(out.path, 'utf-8');
+    assert.ok(raw.endsWith('\n'));
+  } finally {
+    closeDatabase();
+    cleanup(base);
+  }
+});
+
+test('executeResume: reports friendly empty state when no snapshot exists', () => {
+  const base = freshBase();
+  try {
+    const result = executeResume({}, { baseDir: base });
+    assert.equal(result.details.found, false);
+    assert.match(result.content[0].text, /No snapshot found/);
+  } finally {
+    cleanup(base);
+  }
+});

--- a/src/resources/extensions/gsd/tests/exec-history.test.ts
+++ b/src/resources/extensions/gsd/tests/exec-history.test.ts
@@ -1,0 +1,124 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { listExecHistory, searchExecHistory } from '../exec-history.ts';
+import { executeExecSearch } from '../tools/exec-search-tool.ts';
+
+function freshBase(): string {
+  return mkdtempSync(join(tmpdir(), 'gsd-exec-history-'));
+}
+
+function cleanup(dir: string): void {
+  rmSync(dir, { recursive: true, force: true });
+}
+
+function writeRun(base: string, id: string, overrides: Record<string, unknown> = {}): void {
+  const dir = join(base, '.gsd', 'exec');
+  mkdirSync(dir, { recursive: true });
+  const stdoutPath = join(dir, `${id}.stdout`);
+  const stderrPath = join(dir, `${id}.stderr`);
+  const metaPath = join(dir, `${id}.meta.json`);
+  writeFileSync(stdoutPath, (overrides.stdout as string | undefined) ?? `stdout for ${id}\n`);
+  writeFileSync(stderrPath, '');
+  writeFileSync(
+    metaPath,
+    JSON.stringify({
+      id,
+      runtime: 'bash',
+      purpose: `purpose for ${id}`,
+      started_at: '2026-04-20T12:00:00.000Z',
+      finished_at: '2026-04-20T12:00:00.100Z',
+      duration_ms: 100,
+      exit_code: 0,
+      signal: null,
+      timed_out: false,
+      stdout_bytes: 12,
+      stderr_bytes: 0,
+      stdout_truncated: false,
+      stderr_truncated: false,
+      stdout_path: stdoutPath,
+      stderr_path: stderrPath,
+      ...overrides,
+    }),
+  );
+}
+
+test('listExecHistory: returns empty list when .gsd/exec missing', () => {
+  const base = freshBase();
+  try {
+    assert.deepEqual(listExecHistory(base), []);
+  } finally {
+    cleanup(base);
+  }
+});
+
+test('listExecHistory: skips malformed meta files', () => {
+  const base = freshBase();
+  try {
+    const dir = join(base, '.gsd', 'exec');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, 'bad.meta.json'), '{not-json');
+    writeRun(base, 'ok-1');
+    const list = listExecHistory(base);
+    assert.equal(list.length, 1);
+    assert.equal(list[0]!.id, 'ok-1');
+  } finally {
+    cleanup(base);
+  }
+});
+
+test('searchExecHistory: filters by query, runtime, and failing_only', () => {
+  const base = freshBase();
+  try {
+    writeRun(base, 'playwright-run', { purpose: 'playwright snapshot' });
+    writeRun(base, 'grep-run', { purpose: 'grep TODOs' });
+    writeRun(base, 'failing-run', { exit_code: 1, purpose: 'boom' });
+    writeRun(base, 'node-run', { runtime: 'node', purpose: 'dedupe' });
+
+    const playwrightHits = searchExecHistory(base, { query: 'playwright' });
+    assert.equal(playwrightHits.length, 1);
+    assert.equal(playwrightHits[0]!.entry.id, 'playwright-run');
+
+    const failingHits = searchExecHistory(base, { failing_only: true });
+    assert.equal(failingHits.length, 1);
+    assert.equal(failingHits[0]!.entry.id, 'failing-run');
+
+    const nodeHits = searchExecHistory(base, { runtime: 'node' });
+    assert.equal(nodeHits.length, 1);
+    assert.equal(nodeHits[0]!.entry.runtime, 'node');
+
+    const unlimited = searchExecHistory(base, {});
+    assert.equal(unlimited.length, 4);
+  } finally {
+    cleanup(base);
+  }
+});
+
+test('executeExecSearch: returns helpful empty-state message when no matches', () => {
+  const base = freshBase();
+  try {
+    const result = executeExecSearch({ query: 'missing' }, { baseDir: base });
+    assert.ok(!result.isError);
+    assert.match(result.content[0].text, /No prior gsd_exec runs/);
+  } finally {
+    cleanup(base);
+  }
+});
+
+test('executeExecSearch: includes stdout_path and preview in details', () => {
+  const base = freshBase();
+  try {
+    writeRun(base, 'summary-run', { stdout: 'found 42 TODOs\n' });
+    const result = executeExecSearch({ query: 'summary' }, { baseDir: base });
+    const details = result.details as { results: Array<{ id: string; stdout_path: string }> };
+    assert.equal(details.results.length, 1);
+    assert.equal(details.results[0]!.id, 'summary-run');
+    assert.match(details.results[0]!.stdout_path, /summary-run\.stdout$/);
+    assert.match(result.content[0].text, /found 42 TODOs/);
+  } finally {
+    cleanup(base);
+  }
+});

--- a/src/resources/extensions/gsd/tests/exec-sandbox.test.ts
+++ b/src/resources/extensions/gsd/tests/exec-sandbox.test.ts
@@ -1,0 +1,172 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { EXEC_DEFAULTS, runExecSandbox, type ExecSandboxOptions } from '../exec-sandbox.ts';
+import { buildExecOptions, executeGsdExec } from '../tools/exec-tool.ts';
+
+function freshBase(): string {
+  return mkdtempSync(join(tmpdir(), 'gsd-exec-test-'));
+}
+
+function cleanup(dir: string): void {
+  rmSync(dir, { recursive: true, force: true });
+}
+
+function baseOpts(base: string, overrides: Partial<ExecSandboxOptions> = {}): ExecSandboxOptions {
+  return {
+    baseDir: base,
+    clamp_timeout_ms: EXEC_DEFAULTS.clampTimeoutMs,
+    default_timeout_ms: 10_000,
+    stdout_cap_bytes: 1_024,
+    stderr_cap_bytes: 1_024,
+    digest_chars: 120,
+    env_allowlist: EXEC_DEFAULTS.envAllowlist,
+    ...overrides,
+  };
+}
+
+test('runExecSandbox: captures stdout, persists artifacts, returns digest', async () => {
+  const base = freshBase();
+  try {
+    const result = await runExecSandbox(
+      { runtime: 'bash', script: 'echo hello world' },
+      baseOpts(base),
+    );
+    assert.equal(result.exit_code, 0);
+    assert.equal(result.timed_out, false);
+    assert.ok(result.digest.includes('hello world'), `digest should contain stdout: ${result.digest}`);
+    assert.ok(result.stdout_path.startsWith(join(base, '.gsd', 'exec')), 'stdout path under .gsd/exec');
+    assert.equal(readFileSync(result.stdout_path, 'utf-8').trim(), 'hello world');
+    const meta = JSON.parse(readFileSync(result.meta_path, 'utf-8')) as Record<string, unknown>;
+    assert.equal(meta.runtime, 'bash');
+    assert.equal(meta.exit_code, 0);
+  } finally {
+    cleanup(base);
+  }
+});
+
+test('runExecSandbox: enforces stdout cap and marks truncation', async () => {
+  const base = freshBase();
+  try {
+    const result = await runExecSandbox(
+      // Emit far more than the cap so truncation triggers.
+      { runtime: 'bash', script: 'head -c 8000 /dev/urandom | base64' },
+      baseOpts(base, { stdout_cap_bytes: 256 }),
+    );
+    assert.equal(result.stdout_truncated, true, 'should mark stdout truncated');
+    assert.ok(result.stdout_bytes <= 256, `stdout_bytes within cap (got ${result.stdout_bytes})`);
+    const stdout = readFileSync(result.stdout_path, 'utf-8');
+    assert.ok(stdout.endsWith('[truncated: stdout cap reached]\n'), 'truncation marker appended');
+  } finally {
+    cleanup(base);
+  }
+});
+
+test('runExecSandbox: enforces timeout and surfaces timed_out', async () => {
+  const base = freshBase();
+  try {
+    const started = Date.now();
+    const result = await runExecSandbox(
+      { runtime: 'bash', script: 'sleep 10' },
+      baseOpts(base, { default_timeout_ms: 150, clamp_timeout_ms: 150 }),
+    );
+    const elapsed = Date.now() - started;
+    assert.equal(result.timed_out, true);
+    assert.ok(elapsed < 5_000, `should return well before 10s (took ${elapsed}ms)`);
+  } finally {
+    cleanup(base);
+  }
+});
+
+test('runExecSandbox: forwards only allowlisted env vars', async () => {
+  const base = freshBase();
+  try {
+    const result = await runExecSandbox(
+      { runtime: 'bash', script: 'echo PATH=$PATH SECRET=$GSD_TEST_SECRET' },
+      baseOpts(base, {
+        env_allowlist: [],
+        env: { PATH: '/usr/bin:/bin', HOME: '/tmp', GSD_TEST_SECRET: 'should-be-blocked' },
+      }),
+    );
+    const stdout = readFileSync(result.stdout_path, 'utf-8');
+    assert.ok(stdout.includes('PATH=/usr/bin:/bin'), 'PATH forwarded');
+    assert.ok(!stdout.includes('should-be-blocked'), 'non-allowlisted var blocked');
+  } finally {
+    cleanup(base);
+  }
+});
+
+test('runExecSandbox: node runtime executes JS', async () => {
+  const base = freshBase();
+  try {
+    const result = await runExecSandbox(
+      { runtime: 'node', script: 'console.log("node-ok:" + (1+2))' },
+      baseOpts(base),
+    );
+    assert.equal(result.exit_code, 0);
+    assert.ok(result.digest.includes('node-ok:3'));
+  } finally {
+    cleanup(base);
+  }
+});
+
+// ── exec-tool executor ────────────────────────────────────────────────────
+
+test('executeGsdExec: blocked when context_mode.enabled is not set', async () => {
+  const base = freshBase();
+  try {
+    const result = await executeGsdExec(
+      { runtime: 'bash', script: 'echo hi' },
+      { baseDir: base, preferences: {} },
+    );
+    assert.equal(result.isError, true);
+    assert.equal((result.details as { error?: string }).error, 'context_mode_disabled');
+  } finally {
+    cleanup(base);
+  }
+});
+
+test('executeGsdExec: runs and returns digest when enabled', async () => {
+  const base = freshBase();
+  try {
+    const result = await executeGsdExec(
+      { runtime: 'bash', script: 'echo enabled-run' },
+      { baseDir: base, preferences: { context_mode: { enabled: true } } },
+    );
+    assert.ok(!result.isError, 'should succeed');
+    assert.equal(result.details.operation, 'gsd_exec');
+    assert.equal(result.details.exit_code, 0);
+    assert.ok(result.content[0].text.includes('enabled-run'));
+  } finally {
+    cleanup(base);
+  }
+});
+
+test('executeGsdExec: rejects empty script', async () => {
+  const base = freshBase();
+  try {
+    const result = await executeGsdExec(
+      { runtime: 'bash', script: '   ' },
+      { baseDir: base, preferences: { context_mode: { enabled: true } } },
+    );
+    assert.equal(result.isError, true);
+    assert.equal((result.details as { error?: string }).error, 'invalid_params');
+  } finally {
+    cleanup(base);
+  }
+});
+
+test('buildExecOptions: clamps out-of-range values to safe defaults', () => {
+  const opts = buildExecOptions('/tmp/base', {
+    enabled: true,
+    exec_timeout_ms: 999_999_999,
+    exec_stdout_cap_bytes: 1,
+    exec_digest_chars: -20,
+  });
+  assert.equal(opts.default_timeout_ms, EXEC_DEFAULTS.clampTimeoutMs, 'timeout clamped to upper bound');
+  assert.equal(opts.stdout_cap_bytes, 4_096, 'stdout cap clamped to floor');
+  assert.equal(opts.digest_chars, 0, 'digest chars clamped to floor');
+});

--- a/src/resources/extensions/gsd/tools/exec-search-tool.ts
+++ b/src/resources/extensions/gsd/tools/exec-search-tool.ts
@@ -1,0 +1,81 @@
+// GSD Exec Search Tool — lists and filters prior gsd_exec runs.
+//
+// Scans .gsd/exec/*.meta.json and returns a ranked summary so agents can
+// re-discover past runs without re-executing. Read-only; no DB writes.
+
+import { searchExecHistory, type ExecSearchOptions } from "../exec-history.js";
+
+export interface ExecSearchToolParams {
+  query?: string;
+  runtime?: "bash" | "node" | "python";
+  failing_only?: boolean;
+  limit?: number;
+}
+
+export interface ToolExecutionResult {
+  content: Array<{ type: "text"; text: string }>;
+  details: Record<string, unknown>;
+  isError?: boolean;
+}
+
+export function executeExecSearch(
+  params: ExecSearchToolParams,
+  opts: { baseDir: string },
+): ToolExecutionResult {
+  const searchOpts: ExecSearchOptions = {
+    query: typeof params.query === "string" ? params.query : undefined,
+    runtime: params.runtime,
+    failing_only: params.failing_only === true,
+    limit: typeof params.limit === "number" ? params.limit : undefined,
+  };
+  const hits = searchExecHistory(opts.baseDir, searchOpts);
+
+  if (hits.length === 0) {
+    return {
+      content: [{ type: "text", text: "No prior gsd_exec runs match those filters." }],
+      details: { operation: "gsd_exec_search", matches: 0 },
+    };
+  }
+
+  const lines: string[] = [`Found ${hits.length} exec run(s), most recent first:`];
+  for (const hit of hits) {
+    const e = hit.entry;
+    const status = formatStatus(e);
+    const purpose = e.purpose ? ` — ${e.purpose}` : "";
+    const truncated = e.stdout_truncated ? " (stdout truncated)" : "";
+    lines.push(
+      `- [${e.id}] ${e.runtime} ${status} ${e.duration_ms}ms${truncated}${purpose}`,
+      `    stdout: ${e.stdout_path}`,
+    );
+    if (hit.digest_preview) {
+      const preview = hit.digest_preview.replace(/\n/g, "\n      ");
+      lines.push(`    preview:\n      ${preview}`);
+    }
+  }
+
+  return {
+    content: [{ type: "text", text: lines.join("\n") }],
+    details: {
+      operation: "gsd_exec_search",
+      matches: hits.length,
+      results: hits.map((hit) => ({
+        id: hit.entry.id,
+        runtime: hit.entry.runtime,
+        exit_code: hit.entry.exit_code,
+        timed_out: hit.entry.timed_out,
+        duration_ms: hit.entry.duration_ms,
+        purpose: hit.entry.purpose,
+        stdout_path: hit.entry.stdout_path,
+        stderr_path: hit.entry.stderr_path,
+        meta_path: hit.entry.meta_path,
+      })),
+    },
+  };
+}
+
+function formatStatus(entry: { exit_code: number | null; timed_out: boolean; signal: string | null }): string {
+  if (entry.timed_out) return "timeout";
+  if (entry.signal) return `signal:${entry.signal}`;
+  if (entry.exit_code === null) return "exit:null";
+  return `exit:${entry.exit_code}`;
+}

--- a/src/resources/extensions/gsd/tools/exec-tool.ts
+++ b/src/resources/extensions/gsd/tools/exec-tool.ts
@@ -1,0 +1,183 @@
+// GSD Exec Tool — executor for the gsd_exec MCP tool.
+//
+// Thin wrapper around exec-sandbox.ts that reads effective options from
+// the project preferences (context_mode block) and formats the result
+// for MCP return.
+
+import {
+  EXEC_DEFAULTS,
+  runExecSandbox,
+  type ExecSandboxOptions,
+  type ExecSandboxRequest,
+  type ExecSandboxResult,
+} from "../exec-sandbox.js";
+import type { ContextModeConfig } from "../preferences-types.js";
+
+export interface ExecToolParams {
+  runtime: ExecSandboxRequest["runtime"];
+  script: string;
+  purpose?: string;
+  timeout_ms?: number;
+}
+
+export interface ToolExecutionResult {
+  content: Array<{ type: "text"; text: string }>;
+  details: Record<string, unknown>;
+  isError?: boolean;
+}
+
+export interface ExecToolDeps {
+  baseDir: string;
+  preferences: { context_mode?: ContextModeConfig } | null;
+  /** Optional override for testing. */
+  run?: (req: ExecSandboxRequest, opts: ExecSandboxOptions) => Promise<ExecSandboxResult>;
+  now?: () => Date;
+  generateId?: () => string;
+}
+
+export function buildExecOptions(
+  baseDir: string,
+  cfg: ContextModeConfig | undefined,
+  extras?: Pick<ExecSandboxOptions, "env" | "now" | "generateId">,
+): ExecSandboxOptions {
+  const allowlist = Array.isArray(cfg?.exec_env_allowlist) ? cfg!.exec_env_allowlist! : EXEC_DEFAULTS.envAllowlist;
+  const stdoutCap = clampNumber(
+    cfg?.exec_stdout_cap_bytes,
+    EXEC_DEFAULTS.stdoutCapBytes,
+    4_096,
+    16_777_216,
+  );
+  const defaultTimeout = clampNumber(
+    cfg?.exec_timeout_ms,
+    EXEC_DEFAULTS.defaultTimeoutMs,
+    1_000,
+    EXEC_DEFAULTS.clampTimeoutMs,
+  );
+  const digestChars = clampNumber(cfg?.exec_digest_chars, EXEC_DEFAULTS.digestChars, 0, 4_000);
+  return {
+    baseDir,
+    clamp_timeout_ms: EXEC_DEFAULTS.clampTimeoutMs,
+    default_timeout_ms: defaultTimeout,
+    stdout_cap_bytes: stdoutCap,
+    stderr_cap_bytes: EXEC_DEFAULTS.stderrCapBytes,
+    digest_chars: digestChars,
+    env_allowlist: allowlist,
+    ...extras,
+  };
+}
+
+function clampNumber(value: unknown, fallback: number, min: number, max: number): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) return fallback;
+  if (value < min) return min;
+  if (value > max) return max;
+  return Math.floor(value);
+}
+
+function isEnabled(prefs: ExecToolDeps["preferences"]): boolean {
+  return prefs?.context_mode?.enabled === true;
+}
+
+function disabledResult(): ToolExecutionResult {
+  return {
+    content: [
+      {
+        type: "text",
+        text:
+          "gsd_exec is disabled. Set `context_mode.enabled: true` in .gsd/PREFERENCES.md to opt in " +
+          "to sandboxed tool-output execution.",
+      },
+    ],
+    details: { operation: "gsd_exec", error: "context_mode_disabled" },
+    isError: true,
+  };
+}
+
+function paramError(message: string): ToolExecutionResult {
+  return {
+    content: [{ type: "text", text: `Error: ${message}` }],
+    details: { operation: "gsd_exec", error: "invalid_params", detail: message },
+    isError: true,
+  };
+}
+
+export async function executeGsdExec(
+  params: ExecToolParams,
+  deps: ExecToolDeps,
+): Promise<ToolExecutionResult> {
+  if (!isEnabled(deps.preferences)) return disabledResult();
+
+  const runtime = params.runtime;
+  if (runtime !== "bash" && runtime !== "node" && runtime !== "python") {
+    return paramError(`invalid runtime "${String(runtime)}" — must be bash | node | python`);
+  }
+  const script = typeof params.script === "string" ? params.script : "";
+  if (script.trim().length === 0) {
+    return paramError("script is required and must be a non-empty string");
+  }
+  if (script.length > 200_000) {
+    return paramError("script exceeds the 200 KB length limit");
+  }
+
+  const opts = buildExecOptions(
+    deps.baseDir,
+    deps.preferences?.context_mode,
+    { now: deps.now, generateId: deps.generateId },
+  );
+  const run = deps.run ?? runExecSandbox;
+
+  try {
+    const result = await run(
+      {
+        runtime,
+        script,
+        ...(typeof params.purpose === "string" ? { purpose: params.purpose } : {}),
+        ...(typeof params.timeout_ms === "number" ? { timeout_ms: params.timeout_ms } : {}),
+      },
+      opts,
+    );
+    return formatResult(result);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      content: [{ type: "text", text: `Error: gsd_exec failed — ${message}` }],
+      details: { operation: "gsd_exec", error: message },
+      isError: true,
+    };
+  }
+}
+
+function formatResult(result: ExecSandboxResult): ToolExecutionResult {
+  const headerLines = [
+    `gsd_exec[${result.id}] runtime=${result.runtime} exit=${formatExit(result)} duration=${result.duration_ms}ms`,
+    `  stdout: ${result.stdout_bytes}B${result.stdout_truncated ? " (truncated)" : ""} → ${result.stdout_path}`,
+    `  stderr: ${result.stderr_bytes}B${result.stderr_truncated ? " (truncated)" : ""} → ${result.stderr_path}`,
+  ];
+  const summary = `${headerLines.join("\n")}\n--- digest ---\n${result.digest}`.trimEnd();
+  return {
+    content: [{ type: "text", text: summary }],
+    details: {
+      operation: "gsd_exec",
+      id: result.id,
+      runtime: result.runtime,
+      exit_code: result.exit_code,
+      signal: result.signal,
+      timed_out: result.timed_out,
+      duration_ms: result.duration_ms,
+      stdout_bytes: result.stdout_bytes,
+      stderr_bytes: result.stderr_bytes,
+      stdout_truncated: result.stdout_truncated,
+      stderr_truncated: result.stderr_truncated,
+      stdout_path: result.stdout_path,
+      stderr_path: result.stderr_path,
+      meta_path: result.meta_path,
+    },
+    isError: result.timed_out || (result.exit_code !== 0 && result.exit_code !== null),
+  };
+}
+
+function formatExit(result: ExecSandboxResult): string {
+  if (result.timed_out) return "timeout";
+  if (result.signal) return `signal:${result.signal}`;
+  if (result.exit_code === null) return "null";
+  return String(result.exit_code);
+}

--- a/src/resources/extensions/gsd/tools/exec-tool.ts
+++ b/src/resources/extensions/gsd/tools/exec-tool.ts
@@ -171,7 +171,7 @@ function formatResult(result: ExecSandboxResult): ToolExecutionResult {
       stderr_path: result.stderr_path,
       meta_path: result.meta_path,
     },
-    isError: result.timed_out || result.signal !== null || (result.exit_code !== 0 && result.exit_code !== null),
+    isError: result.timed_out || result.signal !== null || result.exit_code !== 0,
   };
 }
 

--- a/src/resources/extensions/gsd/tools/exec-tool.ts
+++ b/src/resources/extensions/gsd/tools/exec-tool.ts
@@ -114,7 +114,7 @@ export async function executeGsdExec(
   if (script.trim().length === 0) {
     return paramError("script is required and must be a non-empty string");
   }
-  if (script.length > 200_000) {
+  if (Buffer.byteLength(script, "utf8") > 200_000) {
     return paramError("script exceeds the 200 KB length limit");
   }
 
@@ -171,7 +171,7 @@ function formatResult(result: ExecSandboxResult): ToolExecutionResult {
       stderr_path: result.stderr_path,
       meta_path: result.meta_path,
     },
-    isError: result.timed_out || (result.exit_code !== 0 && result.exit_code !== null),
+    isError: result.timed_out || result.signal !== null || (result.exit_code !== 0 && result.exit_code !== null),
   };
 }
 

--- a/src/resources/extensions/gsd/tools/resume-tool.ts
+++ b/src/resources/extensions/gsd/tools/resume-tool.ts
@@ -1,0 +1,40 @@
+// GSD Resume Tool — returns the contents of .gsd/last-snapshot.md so
+// agents can re-orient after compaction or session resume without
+// re-deriving project memory state.
+
+import { readCompactionSnapshot } from "../compaction-snapshot.js";
+
+export interface ResumeToolParams {
+  /** Ignored — reserved for future variant (e.g. dated snapshots). */
+  _variant?: string;
+}
+
+export interface ToolExecutionResult {
+  content: Array<{ type: "text"; text: string }>;
+  details: Record<string, unknown>;
+  isError?: boolean;
+}
+
+export function executeResume(
+  _params: ResumeToolParams,
+  opts: { baseDir: string },
+): ToolExecutionResult {
+  const snapshot = readCompactionSnapshot(opts.baseDir);
+  if (snapshot == null) {
+    return {
+      content: [
+        {
+          type: "text",
+          text:
+            "No snapshot found at .gsd/last-snapshot.md. The snapshot is written automatically " +
+            "on session_before_compact when context_mode.enabled=true.",
+        },
+      ],
+      details: { operation: "gsd_resume", found: false },
+    };
+  }
+  return {
+    content: [{ type: "text", text: snapshot }],
+    details: { operation: "gsd_resume", found: true, bytes: Buffer.byteLength(snapshot, "utf-8") },
+  };
+}

--- a/src/resources/extensions/gsd/workflow-logger.ts
+++ b/src/resources/extensions/gsd/workflow-logger.ts
@@ -57,7 +57,8 @@ export type LogComponent =
   | "ecosystem"     // GSD ecosystem extension loader and dispatch
   | "memory-embeddings" // Memory layer embedding generation
   | "memory-ingest"     // Memory layer ingestion pipeline
-  | "memory-backfill";  // ADR-013: decisions->memories backfill
+  | "memory-backfill"   // ADR-013: decisions->memories backfill
+  | "context-mode";    // Context-mode exec sandbox and compaction snapshot
 
 export interface LogEntry {
   ts: string;

--- a/src/resources/extensions/gsd/workflow-mcp.ts
+++ b/src/resources/extensions/gsd/workflow-mcp.ts
@@ -23,6 +23,7 @@ export interface WorkflowCapabilityOptions {
 const MCP_WORKFLOW_TOOL_SURFACE = new Set([
   "ask_user_questions",
   "gsd_decision_save",
+  "gsd_exec",
   "gsd_complete_milestone",
   "gsd_complete_task",
   "gsd_complete_slice",

--- a/src/resources/extensions/gsd/workflow-mcp.ts
+++ b/src/resources/extensions/gsd/workflow-mcp.ts
@@ -24,6 +24,8 @@ const MCP_WORKFLOW_TOOL_SURFACE = new Set([
   "ask_user_questions",
   "gsd_decision_save",
   "gsd_exec",
+  "gsd_exec_search",
+  "gsd_resume",
   "gsd_complete_milestone",
   "gsd_complete_task",
   "gsd_complete_slice",


### PR DESCRIPTION
## Linked issue

Closes #<!-- issue number — required -->

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Implement `gsd_exec` — a sandboxed subprocess executor that runs bash/node/python scripts and persists full output to disk while returning only a short digest to the agent context.

**Why:** Enables agents to run analyses (grep, count, summarize) without bloating the context window with large tool outputs or requiring multiple file reads.

**How:** New exec-sandbox module spawns child processes with environment allowlisting, enforces timeouts and output caps, persists artifacts to `.gsd/exec/`, and provides search/resume tools for retrieving prior runs.

## What

Added opt-in context-mode tool execution infrastructure:

- **`exec-sandbox.ts`** — Core subprocess executor with:
  - Support for bash, node, python runtimes
  - Configurable timeouts (clamped to 600s max) and output caps (1 MB stdout, 256 KB stderr)
  - Environment variable allowlisting (PATH, HOME always forwarded; others configurable)
  - Artifact persistence: `.gsd/exec/<id>.{stdout,stderr,meta.json}`
  - Digest generation: last ~300 chars of stdout (or stderr tail if no stdout)

- **`exec-tool.ts`** — MCP tool wrapper that:
  - Reads effective options from `preferences.context_mode` block
  - Validates script length (≤200 KB) and runtime
  - Formats results for agent consumption
  - Disabled by default; requires `context_mode.enabled: true`

- **`exec-history.ts`** — Read-side helpers for:
  - Scanning `.gsd/exec/*.meta.json` to list prior runs
  - Filtering by query, runtime, or failure status
  - Returning lightweight `ExecHistoryEntry` records with optional stdout preview

- **`exec-search-tool.ts`** — `gsd_exec_search` MCP tool to:
  - Rediscover prior runs without re-executing
  - Filter by substring, runtime, or failing-only
  - Return paths and previews for disambiguation

- **`compaction-snapshot.ts`** — Session snapshot writer that:
  - Builds ≤2 KB markdown digest of project state before compaction
  - Includes top memories, recent exec runs, and active context
  - Enforces byte cap with truncation marker

- **`resume-tool.ts`** — `gsd_resume` MCP tool to:
  - Return contents of `.gsd/last-snapshot.md`
  - Allow agents to re-orient after session resume

- **`bootstrap/exec-tools.ts`** — Tool registration with:
  - `gsd_exec`, `gsd_exec_search`, `gsd_resume` MCP tool definitions
  - Prompt guidelines for effective usage

- **`bootstrap/register-hooks.ts`** — Session hook for:
  - Writing compaction snapshot before context compaction
  - Opt-in via `context_mode.enabled`

- **Preference validation** — Added `ContextModeConfig` schema with:
  - `enabled` (boolean, default false)
  - `exec_timeout_ms` (1000–600000, default 30000)
  - `exec_stdout_cap_bytes` (4096–16777216, default 1 MB)
  - `exec_digest_chars` (0–4000, default 300)
  - `exec_env_allowlist` (string array, defaults to LANG, LC_ALL, TERM, TZ, SHELL, USER, LOGNAME, TMPDIR, NODE_OPTIONS, PYTHONPATH, PYTHONIOENCODING)

- **Comprehensive test suite** covering:
  - Sandbox execution, output capture, truncation, timeouts
  - Environment filtering
  - Tool parameter validation and error handling
  - Exec history search and filtering
  - Snapshot building, byte capping, and file I/O
  - End-to-end resume flow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds three user tools: run sandboxed scripts (with timeouts/output caps), search past runs, and retrieve the latest project snapshot for resuming work.
  * Introduces "context mode" preferences to enable/disable execution and configure timeouts, output caps, digest length, and env allowlist.
  * Snapshots are generated during compaction and stored for later resume/read.

* **Tests**
  * Adds end-to-end tests for sandboxed execution, exec-history search, and snapshot generation/reading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->