### PR TITLE
fix(gsd): strip stray backticks from annotated inputs

### DIFF
--- a/src/resources/extensions/gsd/pre-execution-checks.ts
+++ b/src/resources/extensions/gsd/pre-execution-checks.ts
@@ -325,7 +325,12 @@ function extractPathFromAnnotation(raw: string): string {
 
   const annotatedMatch = trimmed.match(/^(.+?)\s+[—–-]\s+.+$/);
   if (annotatedMatch) {
-    return annotatedMatch[1].trim();
+    const prefix = annotatedMatch[1].trim();
+    const prefixBacktickMatch = prefix.match(/`([^`]+)`/);
+    if (prefixBacktickMatch && looksLikePathOrUrl(prefixBacktickMatch[1].trim())) {
+      return prefixBacktickMatch[1].trim();
+    }
+    return prefix.replace(/`/g, "").trim();
   }
 
   // Fallback: scan all backticked tokens and return the first one that looks

--- a/src/resources/extensions/gsd/tests/pre-exec-backtick-strip.test.ts
+++ b/src/resources/extensions/gsd/tests/pre-exec-backtick-strip.test.ts
@@ -30,6 +30,20 @@ describe('normalizeFilePath backtick stripping (#3649)', () => {
     assert.equal(normalizeFilePath('``src/foo.ts`` (current state)'), 'src/foo.ts')
   })
 
+  it('strips stray backticks from dash-annotated bare paths (#4550)', () => {
+    assert.equal(
+      normalizeFilePath('.gsd/KNOWLEDGE.md` — append-only S05 lessons section'),
+      '.gsd/KNOWLEDGE.md',
+    )
+  })
+
+  it('prefers a backticked path inside a dash-annotated prefix (#4550)', () => {
+    assert.equal(
+      normalizeFilePath('Input `src/foo.ts` — current state'),
+      'src/foo.ts',
+    )
+  })
+
   it('strips backticks even when mixed with other normalization', () => {
     assert.equal(normalizeFilePath('`./src//bar.ts`'), 'src/bar.ts')
   })


### PR DESCRIPTION
## Linked issue

Closes #4550

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Strips stray backticks from dash-annotated pre-exec input paths.
**Why:** A single unpaired backtick could make an existing file look missing and block dispatch.
**How:** Normalizes the annotated-prefix branch in `extractPathFromAnnotation` and adds regression coverage for the failing input shape.

## What

This updates the GSD pre-execution path annotation extractor so the `path — description` branch cannot return a path containing stray backticks. It also prefers a real backticked path token when the annotated prefix contains prose plus an inline path.

## Why

Planner output can produce inputs like `.gsd/KNOWLEDGE.md\` — append-only section`. The previous extractor returned `.gsd/KNOWLEDGE.md\` from that annotated prefix, so `existsSync` checked the wrong filename and blocked auto-mode even though the file existed.

## How

The annotated-prefix branch now:

1. Checks whether the prefix contains a path-like backticked token and returns that token when present.
2. Otherwise strips all backticks from the prefix before downstream path normalization.

The regression tests cover both the original stray-backtick shape and a prose-prefix shape with an inline backticked path.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

Automated verification:

1. `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/pre-execution-checks.test.ts src/resources/extensions/gsd/tests/pre-exec-backtick-strip.test.ts`
2. `npm run build`
3. `npm run typecheck:extensions`
4. `npm run secret-scan`

Manual before/after proof:

1. Ran `normalizeFilePath` against `.gsd/KNOWLEDGE.md\` — append-only S05 lessons section`.
2. Before fix: returned `.gsd/KNOWLEDGE.md\``.
3. After fix: returns `.gsd/KNOWLEDGE.md`.

## AI disclosure

- [x] This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file path extraction from annotated text containing backticks and dashes. Backticked paths are now correctly prioritized and extracted, with extraneous backticks removed.

* **Tests**
  * Added regression tests for path extraction handling with backtick-enclosed paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->