### PR TITLE
fix(gsd): preserve slice parallel preferences

### DIFF
--- a/src/resources/extensions/gsd/preferences-validation.ts
+++ b/src/resources/extensions/gsd/preferences-validation.ts
@@ -697,6 +697,41 @@ export function validatePreferences(preferences: GSDPreferences): {
     }
   }
 
+  // ─── Slice Parallel Config ───────────────────────────────────────────────
+  if (preferences.slice_parallel !== undefined) {
+    if (typeof preferences.slice_parallel === "object" && preferences.slice_parallel !== null) {
+      const sp = preferences.slice_parallel as Record<string, unknown>;
+      const validSp: NonNullable<GSDPreferences["slice_parallel"]> = {};
+
+      if (sp.enabled !== undefined) {
+        if (typeof sp.enabled === "boolean") validSp.enabled = sp.enabled;
+        else errors.push("slice_parallel.enabled must be a boolean");
+      }
+
+      if (sp.max_workers !== undefined) {
+        const maxWorkers = typeof sp.max_workers === "number" ? sp.max_workers : Number(sp.max_workers);
+        if (Number.isFinite(maxWorkers) && maxWorkers >= 1 && maxWorkers <= 8) {
+          validSp.max_workers = Math.floor(maxWorkers);
+        } else {
+          errors.push("slice_parallel.max_workers must be a number between 1 and 8");
+        }
+      }
+
+      const knownSliceParallelKeys = new Set(["enabled", "max_workers"]);
+      for (const key of Object.keys(sp)) {
+        if (!knownSliceParallelKeys.has(key)) {
+          warnings.push(`unknown slice_parallel key "${key}" — ignored`);
+        }
+      }
+
+      if (Object.keys(validSp).length > 0) {
+        validated.slice_parallel = validSp;
+      }
+    } else {
+      errors.push("slice_parallel must be an object");
+    }
+  }
+
   // ─── Reactive Execution ─────────────────────────────────────────────────
   if (preferences.reactive_execution !== undefined) {
     if (typeof preferences.reactive_execution === "object" && preferences.reactive_execution !== null) {

--- a/src/resources/extensions/gsd/tests/preferences.test.ts
+++ b/src/resources/extensions/gsd/tests/preferences.test.ts
@@ -186,6 +186,45 @@ test("flat_rate_providers is a recognized preference key (no warning)", () => {
   );
 });
 
+test("slice_parallel preferences validate and pass through", () => {
+  const { preferences, errors, warnings } = validatePreferences({
+    slice_parallel: { enabled: true, max_workers: 8 },
+  });
+
+  assert.equal(errors.length, 0);
+  assert.equal(warnings.filter(w => w.includes("slice_parallel")).length, 0);
+  assert.deepEqual(preferences.slice_parallel, { enabled: true, max_workers: 8 });
+});
+
+test("slice_parallel rejects invalid values and warns on unknown keys", () => {
+  const { preferences, errors, warnings } = validatePreferences({
+    slice_parallel: {
+      enabled: "yes",
+      max_workers: 9,
+      future_mode: true,
+    },
+  } as any);
+
+  assert.ok(errors.some(e => e.includes("slice_parallel.enabled")), "should reject non-boolean enabled");
+  assert.ok(errors.some(e => e.includes("slice_parallel.max_workers")), "should reject max_workers outside 1..8");
+  assert.ok(warnings.some(w => w.includes('unknown slice_parallel key "future_mode"')));
+  assert.equal(preferences.slice_parallel, undefined);
+});
+
+test("slice_parallel numeric max_workers is bounded to 1..8", () => {
+  const low = validatePreferences({ slice_parallel: { max_workers: 1 } });
+  const high = validatePreferences({ slice_parallel: { max_workers: 8 } });
+  const tooLow = validatePreferences({ slice_parallel: { max_workers: 0 } });
+  const tooHigh = validatePreferences({ slice_parallel: { max_workers: 9 } });
+
+  assert.equal(low.errors.length, 0);
+  assert.equal(low.preferences.slice_parallel?.max_workers, 1);
+  assert.equal(high.errors.length, 0);
+  assert.equal(high.preferences.slice_parallel?.max_workers, 8);
+  assert.ok(tooLow.errors.some(e => e.includes("slice_parallel.max_workers")));
+  assert.ok(tooHigh.errors.some(e => e.includes("slice_parallel.max_workers")));
+});
+
 test("valid values pass through correctly", () => {
   const { preferences: p1 } = validatePreferences({ budget_enforcement: "halt" });
   assert.equal(p1.budget_enforcement, "halt");
@@ -597,6 +636,44 @@ test("loadEffectiveGSDPreferences preserves experimental prefs across global+pro
     assert.notEqual(loaded, null);
     assert.equal(loaded!.preferences.experimental?.rtk, true);
     assert.equal(loaded!.preferences.git?.isolation, "none");
+  } finally {
+    process.chdir(originalCwd);
+    if (originalGsdHome === undefined) delete process.env.GSD_HOME;
+    else process.env.GSD_HOME = originalGsdHome;
+    rmSync(tempProject, { recursive: true, force: true });
+    rmSync(tempGsdHome, { recursive: true, force: true });
+  }
+});
+
+test("loadEffectiveGSDPreferences exposes slice_parallel prefs to runtime callers", () => {
+  const originalCwd = process.cwd();
+  const originalGsdHome = process.env.GSD_HOME;
+  const tempProject = mkdtempSync(join(tmpdir(), "gsd-slice-parallel-project-"));
+  const tempGsdHome = mkdtempSync(join(tmpdir(), "gsd-slice-parallel-home-"));
+
+  try {
+    mkdirSync(join(tempProject, ".gsd"), { recursive: true });
+
+    writeFileSync(
+      join(tempProject, ".gsd", "PREFERENCES.md"),
+      [
+        "---",
+        "version: 1",
+        "slice_parallel:",
+        "  enabled: true",
+        "  max_workers: 3",
+        "---",
+      ].join("\n"),
+      "utf-8",
+    );
+
+    process.env.GSD_HOME = tempGsdHome;
+    process.chdir(tempProject);
+
+    const loaded = loadEffectiveGSDPreferences();
+    assert.notEqual(loaded, null);
+    assert.equal(loaded!.preferences.slice_parallel?.enabled, true);
+    assert.equal(loaded!.preferences.slice_parallel?.max_workers, 3);
   } finally {
     process.chdir(originalCwd);
     if (originalGsdHome === undefined) delete process.env.GSD_HOME;


### PR DESCRIPTION
## Linked issue

Closes #4546

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Preserves validated `slice_parallel` preferences.
**Why:** Users could enable slice-level parallel dispatch, but validation silently discarded the setting before runtime saw it.
**How:** Adds `slice_parallel` validation for supported fields and regression tests for direct validation plus effective preference loading.

## What

This adds validation support for the existing `slice_parallel` preference object in the GSD preference validator. The validator now preserves:

- `slice_parallel.enabled` when it is a boolean
- `slice_parallel.max_workers` when it is between 1 and 8

Unknown nested keys are reported as warnings and invalid values are rejected.

## Why

`slice_parallel` was already declared and runtime code already checked `prefs.slice_parallel.enabled`, but `validatePreferences()` never copied that object into the sanitized result. As a result, the feature could be configured but never activated.

## How

The fix mirrors the existing preference-validation style used for nearby nested preference groups. Tests now prove both the direct validator behavior and the `loadEffectiveGSDPreferences()` path that runtime callers use.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

Automated verification:

1. `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/preferences.test.ts`
2. `npm run build`
3. `npm run typecheck:extensions`
4. `npm run secret-scan`

Manual before/after proof:

1. Ran `validatePreferences({ version: 1, slice_parallel: { enabled: true, max_workers: 3 } })`.
2. Before fix: sanitized preferences only preserved `version` and silently dropped `slice_parallel`.
3. After fix: sanitized preferences preserve `slice_parallel: { enabled: true, max_workers: 3 }`.

## AI disclosure

- [x] This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `slice_parallel` preference configuration option for controlling parallel slicing behavior with customizable worker settings (1-8 workers).

* **Tests**
  * Added comprehensive test coverage for the new parallel slicing configuration, including validation and bounds checking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->