### PR TITLE
fix(error-classifier): classify stream idle timeout and context overflow as transient

### DIFF
--- a/src/resources/extensions/gsd/error-classifier.ts
+++ b/src/resources/extensions/gsd/error-classifier.ts
@@ -52,8 +52,14 @@ const RATE_LIMIT_RE = /rate.?limit|too many requests|429|hit your limit|usage li
 // OpenRouter affordability-style quota errors should be treated as transient
 // so core retry logic can lower maxTokens and continue in-session.
 const AFFORDABILITY_RE = /requires more credits|can only afford|insufficient credits|not enough credits|fewer max_tokens/i;
-const NETWORK_RE = /network|ECONNRESET|ETIMEDOUT|ECONNREFUSED|socket hang up|fetch failed|connection.*reset|dns|unexpected eof/i;
-const SERVER_RE = /internal server error|500|502|503|overloaded|server_error|api_error|service.?unavailable/i;
+// "Stream idle timeout" and "partial response received" are emitted by the SDK/harness
+// for mid-stream disconnects. Both indicate a transient network-level interruption.
+// See: https://github.com/gsd-build/gsd-2/issues/4558
+const NETWORK_RE = /network|ECONNRESET|ETIMEDOUT|ECONNREFUSED|socket hang up|fetch failed|connection.*reset|dns|unexpected eof|stream idle timeout|partial response received/i;
+// Context overflow errors (context window/length exceeded) should be treated as server-class
+// transient errors so auto-mode can retry with reduced budget or fall back to a larger-context model.
+// See: https://github.com/gsd-build/gsd-2/issues/4528
+const SERVER_RE = /internal server error|500|502|503|overloaded|server_error|api_error|service.?unavailable|context (?:window|length) exceed|context window exceed/i;
 // ECONNRESET/ECONNREFUSED are in NETWORK_RE (same-model retry first).
 const CONNECTION_RE = /terminated|connection.?(?:refused|error)|other side closed|EPIPE|network.?(?:is\s+)?unavailable|stream_exhausted(?:_without_result)?/i;
 // Catch-all for V8 JSON.parse errors: all modern variants end with "in JSON at position \d+".

--- a/src/resources/extensions/gsd/tests/provider-errors.test.ts
+++ b/src/resources/extensions/gsd/tests/provider-errors.test.ts
@@ -680,6 +680,47 @@ test("MAX_TRANSIENT_AUTO_RESUMES is at least 8 for sustained overload resilience
   );
 });
 
+// ── Stream idle timeout / partial response (#4558) ──────────────────────────
+
+test("classifyError: 'Stream idle timeout - partial response received' is transient network", () => {
+  const result = classifyError("API Error: Stream idle timeout - partial response received");
+  assert.ok(isTransient(result), "stream idle timeout must be transient");
+  assert.equal(result.kind, "network");
+  assert.ok("retryAfterMs" in result && result.retryAfterMs > 0);
+});
+
+test("classifyError: 'stream idle timeout' (lowercase) is transient network", () => {
+  const result = classifyError("stream idle timeout");
+  assert.ok(isTransient(result), "lowercase stream idle timeout must be transient");
+  assert.equal(result.kind, "network");
+});
+
+test("classifyError: 'partial response received' alone is transient network", () => {
+  const result = classifyError("partial response received");
+  assert.ok(isTransient(result), "partial response received must be transient");
+  assert.equal(result.kind, "network");
+});
+
+// ── Context overflow / context window exceeded (#4528) ───────────────────────
+
+test("classifyError: MiniMax context window error is transient server", () => {
+  const result = classifyError("400 invalid params, context window exceeds limit (2013)");
+  assert.ok(isTransient(result), "context window exceeded must be transient");
+  assert.equal(result.kind, "server");
+});
+
+test("classifyError: 'context length exceeded' is transient server", () => {
+  const result = classifyError("context length exceeded: max 128000 tokens");
+  assert.ok(isTransient(result), "context length exceeded must be transient");
+  assert.equal(result.kind, "server");
+});
+
+test("classifyError: 'context window' with 'exceed' is transient server", () => {
+  const result = classifyError("context window exceeded for this model");
+  assert.ok(isTransient(result), "context window exceeded must be transient");
+  assert.equal(result.kind, "server");
+});
+
 // ── agent-session retryable regex handles server_error (#1166) ──────────────
 
 test("agent-session retryable error regex matches server_error (underscore)", () => {


### PR DESCRIPTION
## Summary

- Adds `stream idle timeout` and `partial response received` to `NETWORK_RE` so mid-stream SDK disconnects are classified as `kind:"network"` (transient) instead of `kind:"unknown"`. Auto-mode now schedules an exponential-backoff resume instead of pausing indefinitely.
- Adds `context window exceed` and `context length exceed` patterns to `SERVER_RE` so provider context-overflow errors are classified as `kind:"server"` (transient) instead of `kind:"unknown"`. Auto-mode can now retry with reduced budget or fall back to a larger-context model.
- Adds regression tests for both new pattern groups in `provider-errors.test.ts`.

Closes #4558
Closes #4528

## Test plan
- [ ] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/provider-errors.test.ts` passes
- [ ] No regressions in existing provider-error classification tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error classification to recognize additional transient network interruption patterns, including stream timeouts and partial response scenarios, enabling smarter automatic retries.
  * Enhanced detection of context overflow errors as transient server failures for more reliable error handling.
  * Temporary failures are now properly identified and retried, reducing unnecessary failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->