### PR TITLE
fix(key-manager): add claude-code as first-class LLM provider in PROVIDER_REGISTRY

### DIFF
--- a/src/resources/extensions/gsd/key-manager.ts
+++ b/src/resources/extensions/gsd/key-manager.ts
@@ -35,6 +35,12 @@ export interface ProviderInfo {
 export const PROVIDER_REGISTRY: ProviderInfo[] = [
   // LLM Providers
   { id: "anthropic",        label: "Anthropic (Claude)",      category: "llm", envVar: "ANTHROPIC_API_KEY",      prefixes: ["sk-ant-"], hasOAuth: true, dashboardUrl: "console.anthropic.com" },
+  // Claude Code CLI: routes through the local `claude` binary — no API key,
+  // authentication is handled by the CLI's own OAuth flow.
+  // Referenced by doctor-providers.ts, auto-model-selection.ts, and others;
+  // must be in the canonical registry so all consumers see the same catalog.
+  // See: https://github.com/gsd-build/gsd-2/issues/4541
+  { id: "claude-code",      label: "Claude Code CLI",         category: "llm",                                   hasOAuth: true },
   { id: "openai",           label: "OpenAI",                  category: "llm", envVar: "OPENAI_API_KEY",         prefixes: ["sk-"],     dashboardUrl: "platform.openai.com/api-keys" },
   { id: "github-copilot",   label: "GitHub Copilot",          category: "llm", envVar: "GITHUB_TOKEN",           hasOAuth: true },
   { id: "openai-codex",     label: "ChatGPT Plus/Pro (Codex)",category: "llm",                                   hasOAuth: true },

--- a/src/resources/extensions/gsd/tests/key-manager.test.ts
+++ b/src/resources/extensions/gsd/tests/key-manager.test.ts
@@ -143,6 +143,13 @@ test("PROVIDER_REGISTRY includes all major LLM providers", () => {
   assert.ok(ids.includes("groq"));
 });
 
+test("PROVIDER_REGISTRY includes claude-code as a first-class LLM provider (#4541)", () => {
+  const entry = PROVIDER_REGISTRY.find((p) => p.id === "claude-code");
+  assert.ok(entry, "claude-code must be in PROVIDER_REGISTRY");
+  assert.equal(entry!.category, "llm");
+  assert.ok(entry!.hasOAuth, "claude-code uses OAuth (CLI auth)");
+});
+
 test("PROVIDER_REGISTRY includes all tool/search providers", () => {
   const ids = PROVIDER_REGISTRY.map((p) => p.id);
   assert.ok(ids.includes("tavily"));


### PR DESCRIPTION
## Summary

`claude-code` was referenced by `doctor-providers.ts`, `auto-model-selection.ts`, and `setup-catalog.ts` (which contained a hard-coded `getLlmProviderIds()` workaround to inject it), but was absent from the canonical `PROVIDER_REGISTRY` in `key-manager.ts`.

This left GSD in a split-brain state: doctor and routing logic already handled Claude Code CLI, but registry-driven UI flows and provider-discovery code could not enumerate it as a valid LLM provider.

This PR adds a single canonical entry:
```ts
{ id: "claude-code", label: "Claude Code CLI", category: "llm", hasOAuth: true }
```

No other modules need to change — the downstream code already handles `claude-code` correctly once it appears in the registry.

Closes #4541

## Test plan
- [ ] `PROVIDER_REGISTRY.find(p => p.id === "claude-code")` returns a valid entry with `category: "llm"` and `hasOAuth: true`
- [ ] `PROVIDER_REGISTRY` IDs remain unique (no duplicates introduced)
- [ ] Existing key-manager tests continue to pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Claude Code CLI as a new LLM provider option with OAuth-based authentication.

* **Tests**
  * Added test coverage for the new provider configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->