### PR TITLE
fix(pre-execution-checks): require import keyword before from-clause to prevent prose false positives

### DIFF
--- a/src/resources/extensions/gsd/pre-execution-checks.ts
+++ b/src/resources/extensions/gsd/pre-execution-checks.ts
@@ -91,8 +91,13 @@ export function extractPackageReferences(description: string): string[] {
     }
   }
 
-  // require('pkg') or import from 'pkg' in code blocks
-  const importPattern = /(?:require\s*\(\s*['"]|from\s+['"])([a-zA-Z0-9@/_-]+)['"\)]/g;
+  // require('pkg') or `import ... from 'pkg'` in code blocks.
+  // The `from\s+['"]` branch MUST be preceded by an `import` keyword so that
+  // natural-language prose like `from "What's Next"` or `from 'master'` does
+  // not produce false package-existence failures.  Requiring the leading import
+  // keyword anchors the match to JavaScript/TypeScript syntax.
+  // See: https://github.com/gsd-build/gsd-2/issues/4388
+  const importPattern = /(?:require\s*\(\s*['"]|import\b[\s\S]*?\bfrom\s+['"])([a-zA-Z0-9@/_-]+)['"\)]/g;
   let importMatch: RegExpExecArray | null;
   while ((importMatch = importPattern.exec(description)) !== null) {
     // Skip relative imports and node builtins

--- a/src/resources/extensions/gsd/tests/pre-execution-checks.test.ts
+++ b/src/resources/extensions/gsd/tests/pre-execution-checks.test.ts
@@ -140,6 +140,25 @@ import type { Request } from 'express';
     assert.ok(packages.includes("typescript"));
     assert.ok(!packages.includes("-D"));
   });
+
+  // Regression tests for #4388: prose containing `from "..."` must not produce false-positive packages
+  test("does not treat prose 'from \"What's Next\"' as a package name (#4388)", () => {
+    const desc = 'Build the feature described from "What\'s Next" in the roadmap';
+    const packages = extractPackageReferences(desc);
+    assert.deepEqual(packages, [], `prose 'from "What\\'s Next"' must not produce package names, got: ${JSON.stringify(packages)}`);
+  });
+
+  test("does not treat prose \"from 'master'\" as a package name (#4388)", () => {
+    const desc = "Review changes from 'master' branch before merging";
+    const packages = extractPackageReferences(desc);
+    assert.deepEqual(packages, [], `prose "from 'master'" must not produce package names, got: ${JSON.stringify(packages)}`);
+  });
+
+  test("still extracts import statements in code blocks after #4388 fix", () => {
+    const desc = "```typescript\nimport express from 'express';\nimport { Router } from 'express';\n```";
+    const packages = extractPackageReferences(desc);
+    assert.ok(packages.includes("express"), "import...from in code blocks must still be recognized");
+  });
 });
 
 // ─── File Path Consistency Tests ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary

The `importPattern` regex in `extractPackageReferences` used `from\s+['"]` without requiring a preceding `import` keyword. Any English phrase like `from "What's Next"` or `from 'master'` matched, causing `What` or `master` to be extracted as npm package names. A subsequent `npm view What` returning 404 then paused auto-mode with a blocking pre-exec failure.

Fix: anchor the `from '...'` branch with `import\b[\s\S]*?\bfrom\s+['"]` so only JS/TS import statements match. The `require(...)` branch is unchanged.

Closes #4388

## Test plan
- [ ] `extractPackageReferences('Build from "What\'s Next" in roadmap')` returns `[]`
- [ ] `extractPackageReferences("from 'master' branch")` returns `[]`
- [ ] `extractPackageReferences("import express from 'express'")` still returns `['express']`
- [ ] All existing `extractPackageReferences` tests pass