### PR TITLE
feat(gsd): default context_mode to ON (opt-out via enabled:false)

### DIFF
--- a/src/resources/extensions/gsd/bootstrap/exec-tools.ts
+++ b/src/resources/extensions/gsd/bootstrap/exec-tools.ts
@@ -20,7 +20,8 @@ export function registerExecTools(pi: ExtensionAPI): void {
       "Run a short script (bash/node/python) in a subprocess. Full stdout/stderr persist to " +
       ".gsd/exec/<id>.{stdout,stderr,meta.json}; only a short digest returns in context. Use " +
       "this instead of reading many files or emitting large tool outputs — e.g. have the script " +
-      "count/grep/summarize and log the finding. Opt-in via preferences.context_mode.enabled.",
+      "count/grep/summarize and log the finding. Enabled by default; opt out via " +
+      "preferences.context_mode.enabled=false.",
     promptSnippet:
       "Run a bash/node/python script in a sandbox; full output is saved to disk and only a digest returns",
     promptGuidelines: [

--- a/src/resources/extensions/gsd/bootstrap/register-hooks.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-hooks.ts
@@ -234,8 +234,9 @@ export function registerHooks(
   pi.on("session_before_compact", async () => {
     try {
       const { loadEffectiveGSDPreferences } = await import("../preferences.js");
+      const { isContextModeEnabled } = await import("../preferences-types.js");
       const prefs = loadEffectiveGSDPreferences();
-      if (prefs?.preferences.context_mode?.enabled !== true) return;
+      if (!isContextModeEnabled(prefs?.preferences)) return;
       const { writeCompactionSnapshot } = await import("../compaction-snapshot.js");
       const { ensureDbOpen } = await import("./dynamic-tools.js");
       await ensureDbOpen();

--- a/src/resources/extensions/gsd/preferences-types.ts
+++ b/src/resources/extensions/gsd/preferences-types.ts
@@ -39,7 +39,7 @@ export interface ContextManagementConfig {
  * independent implementation — no upstream code is incorporated.
  */
 export interface ContextModeConfig {
-  /** Master switch. Default: false (opt-in). */
+  /** Master switch. Default: true (opt-out via `enabled: false`). */
   enabled?: boolean;
   /** Per-invocation timeout in milliseconds. Default: 30_000. Range: 1_000–600_000. */
   exec_timeout_ms?: number;
@@ -49,6 +49,15 @@ export interface ContextModeConfig {
   exec_digest_chars?: number;
   /** Environment variables forwarded to sandboxed processes (case-sensitive names). PATH and HOME are always forwarded. */
   exec_env_allowlist?: string[];
+}
+
+/**
+ * Resolve whether context-mode features (gsd_exec sandbox + compaction
+ * snapshot) should be active. Default is ON: missing config or missing
+ * `enabled` is treated as true. Only `enabled: false` disables.
+ */
+export function isContextModeEnabled(prefs: { context_mode?: ContextModeConfig } | null | undefined): boolean {
+  return prefs?.context_mode?.enabled !== false;
 }
 import type { GitHubSyncConfig } from "../github-sync/types.js";
 

--- a/src/resources/extensions/gsd/tests/exec-sandbox.test.ts
+++ b/src/resources/extensions/gsd/tests/exec-sandbox.test.ts
@@ -6,6 +6,7 @@ import { join } from 'node:path';
 
 import { EXEC_DEFAULTS, runExecSandbox, type ExecSandboxOptions } from '../exec-sandbox.ts';
 import { buildExecOptions, executeGsdExec } from '../tools/exec-tool.ts';
+import { isContextModeEnabled } from '../preferences-types.ts';
 
 function freshBase(): string {
   return mkdtempSync(join(tmpdir(), 'gsd-exec-test-'));
@@ -115,12 +116,42 @@ test('runExecSandbox: node runtime executes JS', async () => {
 
 // ── exec-tool executor ────────────────────────────────────────────────────
 
-test('executeGsdExec: blocked when context_mode.enabled is not set', async () => {
+test('executeGsdExec: runs by default when context_mode is unset', async () => {
   const base = freshBase();
   try {
     const result = await executeGsdExec(
-      { runtime: 'bash', script: 'echo hi' },
+      { runtime: 'bash', script: 'echo default-on-run' },
       { baseDir: base, preferences: {} },
+    );
+    assert.ok(!result.isError, 'should succeed with no preferences');
+    assert.equal(result.details.operation, 'gsd_exec');
+    assert.equal(result.details.exit_code, 0);
+    assert.ok(result.content[0].text.includes('default-on-run'));
+  } finally {
+    cleanup(base);
+  }
+});
+
+test('executeGsdExec: runs when preferences is null (fresh project)', async () => {
+  const base = freshBase();
+  try {
+    const result = await executeGsdExec(
+      { runtime: 'bash', script: 'echo null-prefs-run' },
+      { baseDir: base, preferences: null },
+    );
+    assert.ok(!result.isError, 'null preferences should not disable');
+    assert.ok(result.content[0].text.includes('null-prefs-run'));
+  } finally {
+    cleanup(base);
+  }
+});
+
+test('executeGsdExec: blocked only when context_mode.enabled=false', async () => {
+  const base = freshBase();
+  try {
+    const result = await executeGsdExec(
+      { runtime: 'bash', script: 'echo should-not-run' },
+      { baseDir: base, preferences: { context_mode: { enabled: false } } },
     );
     assert.equal(result.isError, true);
     assert.equal((result.details as { error?: string }).error, 'context_mode_disabled');
@@ -129,17 +160,15 @@ test('executeGsdExec: blocked when context_mode.enabled is not set', async () =>
   }
 });
 
-test('executeGsdExec: runs and returns digest when enabled', async () => {
+test('executeGsdExec: runs when enabled explicitly set to true', async () => {
   const base = freshBase();
   try {
     const result = await executeGsdExec(
-      { runtime: 'bash', script: 'echo enabled-run' },
+      { runtime: 'bash', script: 'echo explicit-on' },
       { baseDir: base, preferences: { context_mode: { enabled: true } } },
     );
-    assert.ok(!result.isError, 'should succeed');
-    assert.equal(result.details.operation, 'gsd_exec');
-    assert.equal(result.details.exit_code, 0);
-    assert.ok(result.content[0].text.includes('enabled-run'));
+    assert.ok(!result.isError);
+    assert.ok(result.content[0].text.includes('explicit-on'));
   } finally {
     cleanup(base);
   }
@@ -157,6 +186,15 @@ test('executeGsdExec: rejects empty script', async () => {
   } finally {
     cleanup(base);
   }
+});
+
+test('isContextModeEnabled: defaults to true; only explicit false disables', () => {
+  assert.equal(isContextModeEnabled(undefined), true, 'undefined prefs → on');
+  assert.equal(isContextModeEnabled(null), true, 'null prefs → on');
+  assert.equal(isContextModeEnabled({}), true, 'empty prefs → on');
+  assert.equal(isContextModeEnabled({ context_mode: {} }), true, 'empty block → on');
+  assert.equal(isContextModeEnabled({ context_mode: { enabled: true } }), true);
+  assert.equal(isContextModeEnabled({ context_mode: { enabled: false } }), false);
 });
 
 test('buildExecOptions: clamps out-of-range values to safe defaults', () => {

--- a/src/resources/extensions/gsd/tools/exec-tool.ts
+++ b/src/resources/extensions/gsd/tools/exec-tool.ts
@@ -11,7 +11,7 @@ import {
   type ExecSandboxRequest,
   type ExecSandboxResult,
 } from "../exec-sandbox.js";
-import type { ContextModeConfig } from "../preferences-types.js";
+import { isContextModeEnabled, type ContextModeConfig } from "../preferences-types.js";
 
 export interface ExecToolParams {
   runtime: ExecSandboxRequest["runtime"];
@@ -74,7 +74,7 @@ function clampNumber(value: unknown, fallback: number, min: number, max: number)
 }
 
 function isEnabled(prefs: ExecToolDeps["preferences"]): boolean {
-  return prefs?.context_mode?.enabled === true;
+  return isContextModeEnabled(prefs);
 }
 
 function disabledResult(): ToolExecutionResult {
@@ -83,8 +83,8 @@ function disabledResult(): ToolExecutionResult {
       {
         type: "text",
         text:
-          "gsd_exec is disabled. Set `context_mode.enabled: true` in .gsd/PREFERENCES.md to opt in " +
-          "to sandboxed tool-output execution.",
+          "gsd_exec is disabled by `context_mode.enabled: false` in preferences. Remove that " +
+          "override (or set it to true) to re-enable sandboxed tool-output execution.",
       },
     ],
     details: { operation: "gsd_exec", error: "context_mode_disabled" },

--- a/src/resources/extensions/gsd/tools/resume-tool.ts
+++ b/src/resources/extensions/gsd/tools/resume-tool.ts
@@ -27,7 +27,7 @@ export function executeResume(
           type: "text",
           text:
             "No snapshot found at .gsd/last-snapshot.md. The snapshot is written automatically " +
-            "on session_before_compact when context_mode.enabled=true.",
+            "on session_before_compact (enabled by default; set context_mode.enabled=false to opt out).",
         },
       ],
       details: { operation: "gsd_resume", found: false },


### PR DESCRIPTION
Summary:
- make context_mode default to enabled
- require explicit preferences.context_mode.enabled=false to disable
- update exec/resume descriptions and tests for default-on behavior

Source commit: 09e6089196f58f151df46bb3f1345823795d2bb8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Context-mode is now enabled by default. Previously it required explicit enablement; users can now disable it by setting `context_mode.enabled=false` in preferences.

* **Documentation**
  * Updated error messages and tool descriptions to reflect context-mode's new default-enabled status and disable instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->