### PR TITLE
fix(gsd): parallel-research timeout no longer causes infinite dispatch loop

### DIFF
--- a/src/resources/extensions/gsd/auto-recovery.ts
+++ b/src/resources/extensions/gsd/auto-recovery.ts
@@ -268,11 +268,26 @@ export function verifyExpectedArtifact(
   // RESEARCH file. Without this, resolveExpectedArtifactPath returns null and
   // the retry/escalation machinery silently re-dispatches forever.
   //
+  // #4068: Also treat a PARALLEL-BLOCKER placeholder as a terminal completion
+  // so that timeout-recovery can write the blocker, have verifyExpectedArtifact
+  // return true, and let the dispatch loop advance past this unit.  Without
+  // this, the blocker is written but verification still returns false, the unit
+  // is never cleared from unitDispatchCount, and on the next iteration the
+  // dispatch rule (which correctly skips parallel-research when PARALLEL-BLOCKER
+  // exists) returns null — leaving the loop stuck re-deriving indefinitely.
+  //
   // NOTE: this predicate mirrors the dispatch rule at
   // auto-dispatch.ts parallel-research-slices — keep the two in sync.
   if (unitType === "research-slice" && unitId.endsWith("/parallel-research")) {
     const { milestone: mid } = parseUnitId(unitId);
     if (!mid) return false;
+
+    // #4068: PARALLEL-BLOCKER written by timeout-recovery is a terminal state.
+    const blockerPath = resolveExpectedArtifactPath(unitType, unitId, base);
+    if (blockerPath && existsSync(blockerPath)) {
+      return true;
+    }
+
     const roadmapFile = resolveMilestoneFile(base, mid, "ROADMAP");
     if (!roadmapFile || !existsSync(roadmapFile)) {
       logWarning("recovery", `verify-fail ${unitType} ${unitId}: roadmap missing`);

--- a/src/resources/extensions/gsd/prompts/parallel-research-slices.md
+++ b/src/resources/extensions/gsd/prompts/parallel-research-slices.md
@@ -15,8 +15,11 @@ Dispatch ALL slices simultaneously using the `subagent` tool in **parallel mode*
 1. Call `subagent` with `tasks: [...]` containing one entry per slice below
 2. Wait for ALL subagents to complete
 3. Verify each slice's RESEARCH file was written (check the `.gsd/{{mid}}/` directory)
-4. If any subagent failed to write its RESEARCH file, re-run it individually
-5. Report which slices completed research and which (if any) failed
+4. If a subagent failed to write its RESEARCH file, retry it **once** individually
+5. If it fails a second time, write a partial RESEARCH file for that slice with a `## BLOCKER` section explaining the failure — do NOT retry again
+6. Report which slices completed research and which (if any) needed a blocker note
+
+**Important**: Each failed slice gets exactly one retry. After that, write the blocker and move on. Never retry the same slice more than once.
 
 ## Subagent Prompts
 

--- a/src/resources/extensions/gsd/tests/auto-recovery.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-recovery.test.ts
@@ -775,6 +775,55 @@ test("#4414: parallel-research sentinel path does not collide with RESEARCH suff
   }
 });
 
+test("#4068: verifyExpectedArtifact parallel-research treats PARALLEL-BLOCKER as terminal completion", () => {
+  // Regression: when a parallel-research unit times out and the timeout-recovery
+  // machinery writes a PARALLEL-BLOCKER placeholder, verifyExpectedArtifact must
+  // return true so the dispatch loop can advance.  Previously it only returned
+  // true when every slice had a RESEARCH file — meaning a timeout always left
+  // verifyExpectedArtifact returning false, the unit was never cleared from
+  // unitDispatchCount, and the dispatch rule re-fired on the next iteration
+  // (infinite loop, issue #4068 / #4355).
+  const base = makeTmpBase();
+  try {
+    // Write a minimal roadmap
+    writeFileSync(
+      join(base, ".gsd", "milestones", "M001", "M001-ROADMAP.md"),
+      [
+        "# M001: Timeout Test",
+        "",
+        "## Slices",
+        "",
+        "- [ ] **S01: Alpha** `risk:low` `depends:[]`",
+        "- [ ] **S02: Beta** `risk:low` `depends:[]`",
+        "",
+      ].join("\n"),
+      "utf-8",
+    );
+
+    // No RESEARCH files written — subagents timed out
+    clearParseCache();
+    invalidateAllCaches();
+
+    // Simulate timeout-recovery writing the PARALLEL-BLOCKER placeholder
+    const blockerPath = resolveExpectedArtifactPath("research-slice", "M001/parallel-research", base);
+    assert.ok(blockerPath, "PARALLEL-BLOCKER path must resolve for parallel-research unit");
+    writeFileSync(blockerPath!, "# BLOCKER — timeout recovery\n\n**Reason**: hard timeout.\n", "utf-8");
+
+    clearParseCache();
+    invalidateAllCaches();
+
+    // After blocker is written, verifyExpectedArtifact must return true
+    // so the dispatch loop treats this unit as complete and moves on.
+    assert.equal(
+      verifyExpectedArtifact("research-slice", "M001/parallel-research", base),
+      true,
+      "#4068: PARALLEL-BLOCKER on disk must satisfy verifyExpectedArtifact so the loop does not re-dispatch",
+    );
+  } finally {
+    cleanup(base);
+  }
+});
+
 test("#4414: verifyExpectedArtifact parallel-research succeeds when all research-ready slices have RESEARCH", () => {
   const base = makeTmpBase();
   try {

--- a/src/resources/extensions/gsd/tests/parallel-research-dispatch.test.ts
+++ b/src/resources/extensions/gsd/tests/parallel-research-dispatch.test.ts
@@ -110,6 +110,25 @@ test("template: parallel-research-slices.md has required variables", () => {
   assert.ok(templateSrc.includes("{{subagentPrompts}}"), "template should use subagentPrompts");
 });
 
+test("#4068: template: parallel-research-slices retry cap prevents infinite subagent loop", () => {
+  // The template must cap retries at 1 ("retry it once") and instruct the
+  // agent to write a BLOCKER note on the second failure rather than looping.
+  // Without this, a timing-out subagent causes the orchestrating agent to
+  // retry indefinitely (issue #4068 / #4355).
+  assert.ok(
+    templateSrc.includes("once") || templateSrc.includes("one retry") || templateSrc.match(/retry.{0,20}once/),
+    "template should cap subagent retries at one",
+  );
+  assert.ok(
+    templateSrc.toLowerCase().includes("blocker"),
+    "template should instruct writing a BLOCKER note instead of infinite retries",
+  );
+  assert.ok(
+    !templateSrc.match(/re-run it individually\s*\n/),
+    "template must not have unbounded re-run instruction without a retry cap",
+  );
+});
+
 // ─── Validate milestone prompt ────────────────────────────────────────────
 
 test("template: validate-milestone uses parallel reviewers", () => {


### PR DESCRIPTION
## Summary

- **Root cause 1 (#4068):** `verifyExpectedArtifact` for `research-slice / {mid}/parallel-research` only returned `true` when every slice had a RESEARCH file. After timeout-recovery wrote a `PARALLEL-BLOCKER` placeholder, verification still returned `false`, the unit was never cleared from `unitDispatchCount`, and the dispatch loop re-derived the same stuck unit indefinitely. Fixed by also returning `true` when `PARALLEL-BLOCKER` exists on disk.
- **Root cause 2 (#4355):** The `parallel-research-slices` prompt template had an unbounded `"re-run it individually"` instruction for failed subagents — no retry cap. A timing-out subagent caused the orchestrating agent to loop internally without ever terminating. Fixed by capping retries at one and instructing the agent to write a `BLOCKER` note instead of retrying again.

## Files changed

- `src/resources/extensions/gsd/auto-recovery.ts` — `verifyExpectedArtifact` parallel-research branch: check for PARALLEL-BLOCKER before walking slice RESEARCH files
- `src/resources/extensions/gsd/prompts/parallel-research-slices.md` — one-shot retry cap + BLOCKER instruction replaces unbounded re-run
- `src/resources/extensions/gsd/tests/auto-recovery.test.ts` — regression test: PARALLEL-BLOCKER satisfies `verifyExpectedArtifact`
- `src/resources/extensions/gsd/tests/parallel-research-dispatch.test.ts` — regression test: template has retry cap and BLOCKER instruction

## Test plan

- [ ] `#4068: verifyExpectedArtifact parallel-research treats PARALLEL-BLOCKER as terminal completion` passes
- [ ] `#4068: template: parallel-research-slices retry cap prevents infinite subagent loop` passes
- [ ] All existing `#4414` parallel-research tests continue to pass (35 pass, 0 fail across related files)
- [ ] Normal parallel research completion (all slices write RESEARCH) still verifies correctly

Closes #4068
Closes #4355

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Parallel research recovery mechanism now enforces a single-retry policy for failed research slices.
  * System generates failure documentation instead of continuous retry loops when recovery fails after one retry.

* **Documentation**
  * Updated execution protocol to document single-retry constraints and failure documentation requirements for parallel research operations.

* **Tests**
  * Added regression tests verifying parallel research failure handling and blocker documentation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->