### PR TITLE
fix(pi-ai): ensure tool function names non-empty for MiniMax (#4538)

### DIFF
--- a/packages/pi-ai/src/providers/anthropic-auth.test.ts
+++ b/packages/pi-ai/src/providers/anthropic-auth.test.ts
@@ -18,7 +18,7 @@ test("usesAnthropicBearerAuth covers Bearer-only Anthropic-compatible providers 
 test("createClient routes Bearer-auth providers through authToken (#3783)", () => {
 	const source = readFileSync(join(__dirname, "..", "..", "src", "providers", "anthropic.ts"), "utf-8");
 	assert.ok(
-		source.includes("const usesBearerAuth = usesAnthropicBearerAuth(model.provider);"),
+		source.includes("const usesBearerAuth = usesAnthropicBearerAuth(model.provider)"),
 		"createClient should derive auth mode from usesAnthropicBearerAuth",
 	);
 	assert.ok(

--- a/packages/pi-ai/src/providers/anthropic-shared.ts
+++ b/packages/pi-ai/src/providers/anthropic-shared.ts
@@ -654,9 +654,16 @@ export function processAnthropicStream(
 						// leaving content_block.name as "" here. Fall back to the tool list
 						// if available to avoid storing an empty name in history (#4538).
 						const rawName = event.content_block.name;
-						const resolvedName = rawName
-							? (isOAuthToken ? fromClaudeCodeName(rawName, context.tools) : rawName)
-							: (context.tools?.find(() => true)?.name ?? rawName);
+						let resolvedName: string;
+						if (rawName) {
+							resolvedName = isOAuthToken ? fromClaudeCodeName(rawName, context.tools) : rawName;
+						} else {
+							const fallbackName = context.tools?.[0]?.name ?? rawName;
+							if (fallbackName && fallbackName !== rawName) {
+								console.warn(`[anthropic-shared] Empty tool name in content_block_start (id=${event.content_block.id}); falling back to first tool: ${fallbackName}`);
+							}
+							resolvedName = fallbackName;
+						}
 						const block: Block = {
 							type: "toolCall",
 							id: event.content_block.id,

--- a/packages/pi-ai/src/providers/anthropic-shared.ts
+++ b/packages/pi-ai/src/providers/anthropic-shared.ts
@@ -339,10 +339,16 @@ export function convertMessages(
 						});
 					}
 				} else if (block.type === "toolCall") {
+					// Guard: never forward a tool_use block with an empty name.
+					// fine-grained-tool-streaming-2025-05-14 can cause the name to arrive
+					// as a delta on incompatible providers (e.g. MiniMax), leaving block.name
+					// as "". Re-sending that to MiniMax triggers error 2013 (#4538).
+					const toolName = isOAuthToken ? toClaudeCodeName(block.name) : block.name;
+					if (!toolName) continue;
 					blocks.push({
 						type: "tool_use",
 						id: block.id,
-						name: isOAuthToken ? toClaudeCodeName(block.name) : block.name,
+						name: toolName,
 						input: block.arguments ?? {},
 					});
 				} else if (block.type === "serverToolUse") {
@@ -643,12 +649,18 @@ export function processAnthropicStream(
 						output.content.push(block);
 						stream.push({ type: "thinking_start", contentIndex: output.content.length - 1, partial: output });
 					} else if (event.content_block.type === "tool_use") {
+						// Guard: some Anthropic-compatible providers (e.g. MiniMax with
+						// fine-grained-tool-streaming beta) stream the tool name as a delta,
+						// leaving content_block.name as "" here. Fall back to the tool list
+						// if available to avoid storing an empty name in history (#4538).
+						const rawName = event.content_block.name;
+						const resolvedName = rawName
+							? (isOAuthToken ? fromClaudeCodeName(rawName, context.tools) : rawName)
+							: (context.tools?.find(() => true)?.name ?? rawName);
 						const block: Block = {
 							type: "toolCall",
 							id: event.content_block.id,
-							name: isOAuthToken
-								? fromClaudeCodeName(event.content_block.name, context.tools)
-								: event.content_block.name,
+							name: resolvedName,
 							arguments: (event.content_block.input as Record<string, any>) ?? {},
 							partialJson: "",
 							index: event.index,

--- a/packages/pi-ai/src/providers/anthropic.ts
+++ b/packages/pi-ai/src/providers/anthropic.ts
@@ -110,8 +110,14 @@ async function createClient(
 		return { client, isOAuthToken: false };
 	}
 
-	// Skip beta headers for providers that don't support them (e.g., Alibaba Coding Plan)
-	const skipBetaHeaders = model.provider === "alibaba-coding-plan";
+	// Skip beta headers for providers that don't support fine-grained-tool-streaming.
+	// MiniMax and minimax-cn implement the beta by emitting empty tool names in
+	// content_block_start (name arrives as a delta instead), which corrupts conversation
+	// history and triggers MiniMax error 2013 on the next request (#4538).
+	const skipBetaHeaders =
+		model.provider === "alibaba-coding-plan" ||
+		model.provider === "minimax" ||
+		model.provider === "minimax-cn";
 	const betaFeatures = skipBetaHeaders ? [] : ["fine-grained-tool-streaming-2025-05-14"];
 	if (needsInterleavedBeta && !skipBetaHeaders) {
 		betaFeatures.push("interleaved-thinking-2025-05-14");
@@ -123,7 +129,7 @@ async function createClient(
 	const client = new AnthropicClass({
 		apiKey: usesBearerAuth ? null : apiKey,
 		authToken: usesBearerAuth ? apiKey : undefined,
-		baseURL: model.baseUrl,
+		baseURL: resolveAnthropicBaseUrl(model),
 		dangerouslyAllowBrowser: true,
 		defaultHeaders: mergeHeaders(
 			{

--- a/packages/pi-ai/src/providers/minimax-tool-name.test.ts
+++ b/packages/pi-ai/src/providers/minimax-tool-name.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Regression tests for MiniMax error 2013 "function name or parameters is empty" (#4538).
+ *
+ * Root cause: the `fine-grained-tool-streaming-2025-05-14` beta header is sent to
+ * MiniMax. MiniMax's Anthropic-compatible API implements this beta by streaming the
+ * tool name as a delta (empty string in `content_block_start`). The empty name gets
+ * stored in conversation history and sent back on the next request, causing MiniMax
+ * to return error 2013.
+ *
+ * Fix: exclude MiniMax (and minimax-cn) from the fine-grained-tool-streaming beta,
+ * same as alibaba-coding-plan. Also guard against storing empty tool names.
+ */
+import test, { describe } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { convertMessages } from "./anthropic-shared.js";
+import type { AssistantMessage } from "../types.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const source = readFileSync(join(__dirname, "anthropic.ts"), "utf-8");
+
+describe("MiniMax fine-grained-tool-streaming exclusion (#4538)", () => {
+	test("minimax is excluded from fine-grained-tool-streaming-2025-05-14 beta", () => {
+		// The skipBetaHeaders flag must include minimax so it never receives the
+		// fine-grained-tool-streaming beta that causes empty tool names.
+		assert.match(
+			source,
+			/skipBetaHeaders.*minimax/s,
+			"minimax must be included in skipBetaHeaders to suppress fine-grained-tool-streaming",
+		);
+	});
+
+	test("minimax-cn is excluded from fine-grained-tool-streaming-2025-05-14 beta", () => {
+		assert.match(
+			source,
+			/skipBetaHeaders.*minimax-cn/s,
+			"minimax-cn must be included in skipBetaHeaders to suppress fine-grained-tool-streaming",
+		);
+	});
+});
+
+describe("empty tool name guard in convertMessages (#4538)", () => {
+	// When fine-grained-tool-streaming causes a tool name to arrive as empty in
+	// content_block_start, we must not store '' in conversation history.
+	// convertMessages must skip tool_use blocks with empty/missing names.
+	const minimaxModel = {
+		id: "MiniMax-M2",
+		api: "anthropic-messages" as const,
+		provider: "minimax" as const,
+		baseUrl: "https://api.minimax.io/anthropic",
+		reasoning: true,
+		input: ["text"] as ["text"],
+		name: "MiniMax-M2",
+		cost: { input: 0.3, output: 1.2, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 196608,
+		maxTokens: 128000,
+	};
+
+	test("tool_use blocks with empty name are dropped from converted messages", () => {
+		const assistantMsg: AssistantMessage = {
+			role: "assistant",
+			content: [
+				{
+					type: "toolCall",
+					id: "toolu_01",
+					name: "",        // empty — the bug: fine-grained streaming left name as ""
+					arguments: { path: "/foo" },
+				},
+			],
+			api: "anthropic-messages",
+			provider: "minimax",
+			model: "MiniMax-M2",
+			usage: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0, totalTokens: 2, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } },
+			stopReason: "toolUse",
+			timestamp: Date.now(),
+		};
+
+		const messages = [assistantMsg];
+		const result = convertMessages(messages, minimaxModel, false, undefined);
+
+		// The assistant block with the empty-name toolCall must not appear in the output.
+		// If it does appear, its tool_use name must not be empty.
+		for (const param of result) {
+			if (param.role === "assistant" && Array.isArray(param.content)) {
+				for (const block of param.content) {
+					if ((block as any).type === "tool_use") {
+						assert.ok(
+							(block as any).name && (block as any).name.length > 0,
+							`tool_use block must never have an empty name; got: "${(block as any).name}"`,
+						);
+					}
+				}
+			}
+		}
+	});
+});


### PR DESCRIPTION
## TL;DR
**What:** Prevent MiniMax error 2013 ("function name or parameters is empty") by excluding MiniMax from the `fine-grained-tool-streaming-2025-05-14` beta header and adding defensive guards against empty tool names in conversation history.
**Why:** MiniMax's Anthropic-compatible API implements this beta by streaming tool names as deltas (empty in `content_block_start`). The empty name gets stored in history and re-sent to MiniMax, triggering error 2013.
**How:** Exclude `minimax` and `minimax-cn` from the beta (like `alibaba-coding-plan`), and add guards in `convertMessages` and `processAnthropicStream` to drop/recover empty tool names.

## What

- Add `minimax` and `minimax-cn` to `skipBetaHeaders` in `createClient` so `fine-grained-tool-streaming-2025-05-14` is never sent to MiniMax
- Add guard in `convertMessages`: skip `tool_use` blocks with empty `name` rather than forwarding them to MiniMax API
- Add guard in `processAnthropicStream`: recover from empty `content_block.name` by falling back to the tool list rather than storing `""` in history
- Fix `baseURL: model.baseUrl` → `baseURL: resolveAnthropicBaseUrl(model)` in main auth branch (missed in #4140)
- Fix `xhigh` effort type cast to satisfy SDK `OutputConfig.effort` type (pre-existing)
- Fix stale test assertion for `usesBearerAuth` string match (broke when `hasBearerAuthorizationHeader` was added)

## Why

Closes #4538

SDK upgrade from 0.73.x → 0.90.x in v2.76.0 changed how `fine-grained-tool-streaming-2025-05-14` is handled. MiniMax implements this beta by streaming the tool name as a delta; `content_block_start` arrives with `name: ""`. That empty name gets saved in `ToolCall.name`, and on the next multi-turn request MiniMax receives a `tool_use` block with an empty `name`, returning error 2013.

## How

`createClient` now excludes `minimax`/`minimax-cn` from the beta at the request level (primary fix). The defensive guards in `convertMessages` and `processAnthropicStream` are belt-and-suspenders protection for any other Anthropic-compatible provider that may have the same behavior.

## Knock-on effects checked

- `alibaba-coding-plan`: unchanged — still in `skipBetaHeaders`, no regression
- `github-copilot`: unchanged — has its own separate client path that already excluded the beta
- All other `anthropic-messages` providers: unchanged — still receive the beta as before
- `convertMessages` guard only applies to empty names: valid names pass through untouched
- `processAnthropicStream` guard: only triggers when `rawName` is falsy; otherwise uses existing logic

## Tests

- `packages/pi-ai/src/providers/minimax-tool-name.test.ts` — new regression tests:
  - `minimax is excluded from fine-grained-tool-streaming-2025-05-14 beta`
  - `minimax-cn is excluded from fine-grained-tool-streaming-2025-05-14 beta`
  - `tool_use blocks with empty name are dropped from converted messages`
- All 298 pi-ai unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of empty tool names to prevent forwarding incomplete tool calls
  * Improved MiniMax provider compatibility with tool streaming features
  * Enhanced message processing to properly resolve and validate tool names

* **Tests**
  * Added regression tests for MiniMax tool name handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->