### PR TITLE
fix(gsd): exempt completed-task outputs from ordering checks (#4071)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -898,7 +898,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2615,7 +2614,6 @@
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.6.tgz",
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -2853,7 +2851,8 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-android-arm64": {
       "version": "4.59.0",
@@ -2867,7 +2866,8 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
       "version": "4.59.0",
@@ -2881,7 +2881,8 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-darwin-x64": {
       "version": "4.59.0",
@@ -2895,7 +2896,8 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
       "version": "4.59.0",
@@ -2909,7 +2911,8 @@
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
       "version": "4.59.0",
@@ -2923,7 +2926,8 @@
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
       "version": "4.59.0",
@@ -2937,7 +2941,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
       "version": "4.59.0",
@@ -2951,7 +2956,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
       "version": "4.59.0",
@@ -2965,7 +2971,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
       "version": "4.59.0",
@@ -2979,7 +2986,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
       "version": "4.59.0",
@@ -2993,7 +3001,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
       "version": "4.59.0",
@@ -3007,7 +3016,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
       "version": "4.59.0",
@@ -3021,7 +3031,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
       "version": "4.59.0",
@@ -3035,7 +3046,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
       "version": "4.59.0",
@@ -3049,7 +3061,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
       "version": "4.59.0",
@@ -3063,7 +3076,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
       "version": "4.59.0",
@@ -3077,7 +3091,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
       "version": "4.59.0",
@@ -3091,7 +3106,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
       "version": "4.59.0",
@@ -3105,7 +3121,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
       "version": "4.59.0",
@@ -3119,7 +3136,8 @@
       "optional": true,
       "os": [
         "openbsd"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
       "version": "4.59.0",
@@ -3133,7 +3151,8 @@
       "optional": true,
       "os": [
         "openharmony"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
       "version": "4.59.0",
@@ -3147,7 +3166,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
       "version": "4.59.0",
@@ -3161,7 +3181,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
       "version": "4.59.0",
@@ -3175,7 +3196,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
       "version": "4.59.0",
@@ -3189,7 +3211,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@sapphire/async-queue": {
       "version": "1.5.5",
@@ -4277,7 +4300,8 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/hosted-git-info": {
       "version": "3.0.5",
@@ -4348,7 +4372,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -4672,7 +4695,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5545,7 +5567,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -5716,6 +5737,7 @@
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12.0.0"
       },
@@ -6230,7 +6252,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
       "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -7089,6 +7110,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -7420,7 +7442,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7501,6 +7522,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -7678,7 +7700,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7688,7 +7709,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -7802,6 +7822,7 @@
       "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -8362,6 +8383,7 @@
       "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fdir": "^6.5.0",
         "picomatch": "^4.0.3"
@@ -8656,6 +8678,7 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8673,6 +8696,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8690,6 +8714,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8707,6 +8732,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8724,6 +8750,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8741,6 +8768,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8758,6 +8786,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8775,6 +8804,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8792,6 +8822,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8809,6 +8840,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8826,6 +8858,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8843,6 +8876,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8860,6 +8894,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8877,6 +8912,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8894,6 +8930,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8911,6 +8948,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8928,6 +8966,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8945,6 +8984,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8962,6 +9002,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8979,6 +9020,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8996,6 +9038,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9013,6 +9056,7 @@
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9030,6 +9074,7 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9047,6 +9092,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9064,6 +9110,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9081,6 +9128,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9092,6 +9140,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -9320,7 +9369,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/resources/extensions/gsd/pre-execution-checks.ts
+++ b/src/resources/extensions/gsd/pre-execution-checks.ts
@@ -388,13 +388,19 @@ function containsGlobPattern(candidate: string): boolean {
 
 /**
  * Build a set of files that will be created by tasks up to (but not including) taskIndex.
+ * Also includes outputs of completed tasks at any position — a completed task has already
+ * run and its outputs are available regardless of sequence position or disk state (#4071).
  * All paths are normalized for consistent comparison.
  */
 function getExpectedOutputsUpTo(tasks: TaskRow[], taskIndex: number): Set<string> {
   const outputs = new Set<string>();
-  for (let i = 0; i < taskIndex; i++) {
-    for (const file of tasks[i].expected_output) {
-      outputs.add(normalizeFilePath(file));
+  for (let i = 0; i < tasks.length; i++) {
+    const task = tasks[i];
+    // Include prior tasks (i < taskIndex) OR completed tasks at any position
+    if (i < taskIndex || task.status === "completed") {
+      for (const file of task.expected_output) {
+        outputs.add(normalizeFilePath(file));
+      }
     }
   }
   return outputs;
@@ -481,13 +487,18 @@ export function checkTaskOrdering(
   const results: PreExecutionCheckJSON[] = [];
 
   // Build map: normalized file → task index that creates it
-  const fileCreators = new Map<string, { taskId: string; index: number; originalPath: string }>();
+  const fileCreators = new Map<string, { taskId: string; index: number; originalPath: string; completed: boolean }>();
   for (let i = 0; i < tasks.length; i++) {
     const task = tasks[i];
     for (const file of task.expected_output) {
       const normalizedFile = normalizeFilePath(file);
       if (!fileCreators.has(normalizedFile)) {
-        fileCreators.set(normalizedFile, { taskId: task.id, index: i, originalPath: file });
+        fileCreators.set(normalizedFile, {
+          taskId: task.id,
+          index: i,
+          originalPath: file,
+          completed: task.status === "completed",
+        });
       }
     }
   }
@@ -511,7 +522,11 @@ export function checkTaskOrdering(
       const creator = fileCreators.get(normalizedFile);
       const absolutePath = resolve(basePath, normalizedFile);
       const existsOnDisk = existsSync(absolutePath);
-      if (creator && creator.index > i && !existsOnDisk) {
+      // Skip if the creating task has already completed — its output is available
+      // regardless of disk state (e.g. file was a temp artifact cleaned up after
+      // the task ran, or a replan introduced a new earlier-sequence task that
+      // reads this pre-execution output). (#4071)
+      if (creator && creator.index > i && !existsOnDisk && !creator.completed) {
         // Task reads file that is created later — impossible ordering
         results.push({
           category: "file",

--- a/src/resources/extensions/gsd/pre-execution-checks.ts
+++ b/src/resources/extensions/gsd/pre-execution-checks.ts
@@ -492,7 +492,8 @@ export function checkTaskOrdering(
     const task = tasks[i];
     for (const file of task.expected_output) {
       const normalizedFile = normalizeFilePath(file);
-      if (!fileCreators.has(normalizedFile)) {
+      const existing = fileCreators.get(normalizedFile);
+      if (!existing || (!existing.completed && task.status === "completed")) {
         fileCreators.set(normalizedFile, {
           taskId: task.id,
           index: i,

--- a/src/resources/extensions/gsd/tests/pre-execution-checks.test.ts
+++ b/src/resources/extensions/gsd/tests/pre-execution-checks.test.ts
@@ -1580,6 +1580,173 @@ describe("checkTaskOrdering directory inputs (#4446)", () => {
   });
 });
 
+// ─── Regression Tests: checkTaskOrdering false positive for pre-execution refs (#4071) ──
+
+describe("checkTaskOrdering false positive for pre-execution refs (#4071)", () => {
+  test("completed task at higher index does not trigger ordering violation for its outputs", () => {
+    // Scenario: after a replan, a completed task at higher array index has already
+    // created a file. A new earlier-sequence task reads that file. Since the
+    // completed task already ran, its output is available regardless of disk state.
+    // checkTaskOrdering must not flag this as a sequence violation.
+    const tasks = [
+      createTask({
+        id: "T_NEW",
+        sequence: 1,
+        status: "pending",
+        inputs: ["artifacts/setup.json"],
+        expected_output: [],
+      }),
+      createTask({
+        id: "T_SETUP",
+        sequence: 5,
+        status: "completed",
+        inputs: [],
+        expected_output: ["artifacts/setup.json"],
+      }),
+    ];
+
+    const results = checkTaskOrdering(tasks, "/tmp");
+    assert.equal(
+      results.length,
+      0,
+      "completed task outputs must not trigger ordering violations for earlier-sequence tasks that read them",
+    );
+  });
+
+  test("pending task at higher index still triggers ordering violation", () => {
+    // A PENDING task at higher index creating a file is a real violation.
+    // Only completed tasks get the exemption.
+    const tasks = [
+      createTask({
+        id: "T01",
+        sequence: 1,
+        status: "pending",
+        inputs: ["artifacts/output.json"],
+        expected_output: [],
+      }),
+      createTask({
+        id: "T02",
+        sequence: 5,
+        status: "pending",
+        inputs: [],
+        expected_output: ["artifacts/output.json"],
+      }),
+    ];
+
+    const results = checkTaskOrdering(tasks, "/tmp");
+    assert.equal(
+      results.length,
+      1,
+      "pending task at higher index must still be flagged as ordering violation",
+    );
+    assert.equal(results[0].blocking, true);
+    assert.ok(results[0].message.includes("T01"));
+    assert.ok(results[0].message.includes("T02"));
+    assert.ok(results[0].message.includes("sequence violation"));
+  });
+
+  test("completed task output exemption applies regardless of whether file exists on disk", (t) => {
+    // The completed-task exemption must work even when the file is not on disk
+    // (e.g., the file was a temporary artifact that was cleaned up after the task ran).
+    const tempDir = join(tmpdir(), `pre-exec-completed-task-${Date.now()}`);
+    mkdirSync(tempDir, { recursive: true });
+    t.after(() => rmSync(tempDir, { recursive: true, force: true }));
+
+    // File deliberately NOT created on disk — completed task ran in a prior session
+    const tasks = [
+      createTask({
+        id: "T_MAIN",
+        sequence: 0,
+        status: "pending",
+        inputs: ["generated/config.json"],
+        expected_output: [],
+      }),
+      createTask({
+        id: "T_INIT",
+        sequence: 10,
+        status: "completed",
+        inputs: [],
+        expected_output: ["generated/config.json"],
+      }),
+    ];
+
+    const results = checkTaskOrdering(tasks, tempDir);
+    assert.equal(
+      results.length,
+      0,
+      "completed task exemption must apply even when file is absent from disk",
+    );
+  });
+});
+
+describe("checkFilePathConsistency completed-task output exemption (#4071)", () => {
+  test("completed task at higher index does not cause false positive for file it produced", (t) => {
+    // Parallel to the checkTaskOrdering fix: checkFilePathConsistency also uses
+    // getExpectedOutputsUpTo which historically only looked at prior-index tasks.
+    // A completed task at a higher index has already run and its outputs are available.
+    const tempDir = join(tmpdir(), `pre-exec-fc-completed-${Date.now()}`);
+    mkdirSync(tempDir, { recursive: true });
+    t.after(() => rmSync(tempDir, { recursive: true, force: true }));
+
+    // File is NOT on disk — completed task ran in a prior session and file was cleaned
+    const tasks = [
+      createTask({
+        id: "T_MAIN",
+        sequence: 1,
+        status: "pending",
+        inputs: ["artifacts/config.json"],
+        expected_output: [],
+      }),
+      createTask({
+        id: "T_SETUP",
+        sequence: 10,
+        status: "completed",
+        inputs: [],
+        expected_output: ["artifacts/config.json"],
+      }),
+    ];
+
+    const results = checkFilePathConsistency(tasks, tempDir);
+    assert.equal(
+      results.length,
+      0,
+      "completed task at higher index should satisfy inputs of pending tasks that read its outputs",
+    );
+  });
+
+  test("pending task at higher index still causes a missing-file error", (t) => {
+    const tempDir = join(tmpdir(), `pre-exec-fc-pending-${Date.now()}`);
+    mkdirSync(tempDir, { recursive: true });
+    t.after(() => rmSync(tempDir, { recursive: true, force: true }));
+
+    const tasks = [
+      createTask({
+        id: "T01",
+        sequence: 1,
+        status: "pending",
+        inputs: ["artifacts/output.json"],
+        expected_output: [],
+      }),
+      createTask({
+        id: "T02",
+        sequence: 10,
+        status: "pending",
+        inputs: [],
+        expected_output: ["artifacts/output.json"],
+      }),
+    ];
+
+    const results = checkFilePathConsistency(tasks, tempDir);
+    assert.equal(
+      results.length,
+      1,
+      "pending task at higher index must still be flagged — the file is not available yet",
+    );
+    assert.equal(results[0].blocking, true);
+    assert.equal(results[0].target, "artifacts/output.json");
+  });
+});
+
 describe("checkFilePathConsistency self-referential inputs (#4459)", () => {
   test("input that is also in the same task's expected_output is not blocking when missing on disk", (t) => {
     const tempDir = join(tmpdir(), `pre-exec-self-output-${Date.now()}`);

--- a/src/resources/extensions/gsd/tests/pre-execution-checks.test.ts
+++ b/src/resources/extensions/gsd/tests/pre-execution-checks.test.ts
@@ -1645,6 +1645,54 @@ describe("checkTaskOrdering false positive for pre-execution refs (#4071)", () =
     assert.ok(results[0].message.includes("sequence violation"));
   });
 
+  test("pending-first then completed-later: completed replaces pending in fileCreators (#4572)", () => {
+    // Regression for CodeRabbit Major finding on PR #4572:
+    // fileCreators only stored the FIRST task for a given path. If a PENDING task at
+    // array index 1 was registered first, and a COMPLETED task at array index 2 also
+    // declared the same output path, the completed entry was discarded. Line ~529 then
+    // saw a pending creator with index > i and incorrectly fired a sequence violation
+    // for the reader at array index 0.
+    //
+    // Scenario: path first declared by pending task (index 1), then by completed task
+    // (index 2). Reader is at index 0. Without the fix a violation fires; with the fix
+    // the completed entry replaces the pending entry and grants the exemption.
+    const tasks = [
+      // array index 0 — reads the shared path
+      createTask({
+        id: "T_READER",
+        sequence: 1,
+        status: "pending",
+        inputs: ["shared/artifact.json"],
+        expected_output: [],
+      }),
+      // array index 1 — pending producer (visited first during map build)
+      createTask({
+        id: "T_PENDING_PRODUCER",
+        sequence: 5,
+        status: "pending",
+        inputs: [],
+        expected_output: ["shared/artifact.json"],
+      }),
+      // array index 2 — completed producer (visited second; must replace pending entry)
+      createTask({
+        id: "T_COMPLETED_PRODUCER",
+        sequence: 2,
+        status: "completed",
+        inputs: [],
+        expected_output: ["shared/artifact.json"],
+      }),
+    ];
+
+    // Without the fix: creator = T_PENDING_PRODUCER (index 1), !creator.completed && 1 > 0 → violation.
+    // With the fix:    creator = T_COMPLETED_PRODUCER (index 2), creator.completed → no violation.
+    const results = checkTaskOrdering(tasks, "/tmp");
+    assert.equal(
+      results.length,
+      0,
+      "completed producer must replace pending producer in fileCreators and suppress false violation",
+    );
+  });
+
   test("completed task output exemption applies regardless of whether file exists on disk", (t) => {
     // The completed-task exemption must work even when the file is not on disk
     // (e.g., the file was a temporary artifact that was cleaned up after the task ran).


### PR DESCRIPTION
## Summary

- `checkTaskOrdering` was flagging a false sequence violation when a pending task reads a file whose creator (in `expected_output`) is a **completed** task at a higher array index — even though that task already ran and its output is available
- `checkFilePathConsistency` had the same gap: `getExpectedOutputsUpTo` only collected outputs from lower-index tasks, missing completed tasks at higher positions
- Both functions now treat completed-task outputs as unconditionally available, regardless of disk state or sequence position

## Root Cause

After a replan, a completed task that ran earlier can appear at a higher array index (higher sequence) than a newly-planned pending task that needs its output. The `existsOnDisk` guard added in #3965 only protected pre-existing files — it still fired when the completed task's output was a temp artifact that was cleaned after it ran.

## Changes

- `pre-execution-checks.ts`: `fileCreators` map now tracks `completed: boolean` per entry; condition updated to `creator.index > i && !existsOnDisk && !creator.completed`
- `pre-execution-checks.ts`: `getExpectedOutputsUpTo` now includes outputs of completed tasks at any position
- `pre-execution-checks.test.ts`: 5 new regression tests (3 for `checkTaskOrdering`, 2 for `checkFilePathConsistency`)

## Test plan

- [x] `node:test` unit tests pass: `✔ 100 passed, 0 failed` in pre-execution-checks suite
- [x] Verified new tests fail without the fix (3 `checkTaskOrdering` + 2 `checkFilePathConsistency` failures)
- [x] `npx tsc --noEmit` clean
- [x] Full unit suite: no regressions in pre-execution-checks; pre-existing failures unchanged
- [x] Real ordering violations (pending creator at higher index) still detected

Closes #4071

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented false ordering violations by recognizing outputs from already-completed tasks so earlier tasks no longer report spurious sequence or missing-file errors.

* **Tests**
  * Added tests covering completed-task exemptions for ordering and file-path consistency, including scenarios with multiple creators and absent-on-disk outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->