### PR TITLE
fix(gsd): recover silent 'ready' signals and empty-intent turns in discuss flow

### DIFF
--- a/src/resources/extensions/gsd/bootstrap/agent-end-recovery.ts
+++ b/src/resources/extensions/gsd/bootstrap/agent-end-recovery.ts
@@ -1,7 +1,12 @@
 import type { ExtensionAPI, ExtensionContext } from "@gsd/pi-coding-agent";
 
 import { logWarning } from "../workflow-logger.js";
-import { checkAutoStartAfterDiscuss } from "../guided-flow.js";
+import {
+  checkAutoStartAfterDiscuss,
+  maybeHandleReadyPhraseWithoutFiles,
+  maybeHandleEmptyIntentTurn,
+  resetEmptyTurnCounter,
+} from "../guided-flow.js";
 import { getAutoDashboardData, getAutoModeStartModel, isAutoActive, pauseAuto, setCurrentDispatchedModelId } from "../auto.js";
 import { getNextFallbackModel, resolveModelWithFallbacksForUnit } from "../preferences.js";
 import { pauseAutoForProviderError } from "../provider-error-pause.js";
@@ -74,6 +79,20 @@ export async function handleAgentEnd(
     clearDiscussionFlowState();
     return;
   }
+
+  // #4573 — When the LLM emits "Milestone X ready." but the required files
+  // are missing, `checkAutoStartAfterDiscuss` returns false silently. Surface
+  // that and nudge the LLM to complete the writes before the user hits the
+  // downstream "All milestones complete" warning loop.
+  if (maybeHandleReadyPhraseWithoutFiles(event)) return;
+
+  // #4573 — Empty-turn recovery: if the LLM announced intent in prose but
+  // emitted no tool calls, nudge it to execute. Fires only when auto-mode is
+  // active or a discussion autostart is pending (non-auto interactive discuss
+  // is user-driven). Runs before `isAutoActive` early return so pending
+  // discussions (where isAutoActive may be false) still get recovered.
+  if (maybeHandleEmptyIntentTurn(event, isAutoActive())) return;
+
   if (!isAutoActive()) return;
   if (isSessionSwitchInFlight()) return;
 
@@ -239,6 +258,9 @@ export async function handleAgentEnd(
   // ── Success path ─────────────────────────────────────────────────────────
   try {
     resetRetryState(retryState);
+    // #4573 — Reset the empty-turn counter on any successful agent turn so
+    // transient stalls don't accumulate across independent units.
+    resetEmptyTurnCounter();
     resolveAgentEnd(event);
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);

--- a/src/resources/extensions/gsd/guided-flow.ts
+++ b/src/resources/extensions/gsd/guided-flow.ts
@@ -130,7 +130,19 @@ interface PendingAutoStartEntry {
   milestoneId: string; // the milestone being discussed
   step?: boolean; // preserve step mode through discuss → auto transition
   createdAt: number; // timestamp for staleness detection (#3274)
+  // #4573: counter for how many times the LLM emitted the ready phrase
+  // without writing the required artifacts. Cleared on entry delete/recreate.
+  readyRejectCount?: number;
 }
+
+// #4573: cap for how many times we nudge the LLM after a premature ready
+// phrase before giving up and asking the user to re-run /gsd.
+const MAX_READY_REJECTS = 2;
+
+// #4573: matches the canonical ready phrase the discuss prompt asks the LLM
+// to emit. Accepts any M-prefixed milestone ID (three digits + optional
+// suffix) with optional trailing punctuation.
+const READY_PHRASE_RE = /\bMilestone\s+M\d{3}[A-Z0-9-]*\s+ready\.?/i;
 
 const pendingAutoStartMap = new Map<string, PendingAutoStartEntry>();
 
@@ -276,6 +288,215 @@ export function checkAutoStartAfterDiscuss(): boolean {
   pendingAutoStartMap.delete(basePath);
   ctx.ui.notify(`Milestone ${milestoneId} ready.`, "success");
   startAutoDetached(ctx, pi, basePath, false, { step });
+  return true;
+}
+
+/**
+ * Extract the concatenated text content from an assistant message, whether it
+ * stores content as a string or as an array of text blocks.
+ */
+function extractAssistantText(msg: any): string {
+  if (!msg) return "";
+  const content = msg.content;
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  const parts: string[] = [];
+  for (const block of content) {
+    if (!block || typeof block !== "object") continue;
+    if (block.type === "text" && typeof block.text === "string") parts.push(block.text);
+  }
+  return parts.join("\n");
+}
+
+/**
+ * Return true if the assistant message contains any tool-use block.
+ */
+function hasToolUse(msg: any): boolean {
+  if (!msg) return false;
+  const content = msg.content;
+  if (!Array.isArray(content)) return false;
+  return content.some((b: any) => b && typeof b === "object" && (b.type === "tool_use" || b.type === "tool-use"));
+}
+
+/**
+ * #4573 — Detect and recover from the "ready phrase without files" failure mode.
+ *
+ * When the LLM emits "Milestone {{id}} ready." but has not written CONTEXT.md
+ * or ROADMAP.md, `checkAutoStartAfterDiscuss()` silently returns false and the
+ * next /gsd invocation loops into the "All milestones complete" warning.
+ *
+ * This function, called from `handleAgentEnd` after `checkAutoStartAfterDiscuss`
+ * returns false, pattern-matches the ready phrase on the last assistant message.
+ * If it fired AND neither CONTEXT.md nor ROADMAP.md exists, it:
+ *   1. Notifies the user that the signal was rejected.
+ *   2. Injects a system message via `pi.sendMessage(..., {triggerTurn:true})`
+ *      telling the LLM the signal was premature and to emit the writes now.
+ *   3. Caps at `MAX_READY_REJECTS` per-entry; beyond that, gives up and asks
+ *      the user to re-run /gsd.
+ *
+ * Returns true when a nudge (or give-up) was emitted, signaling the caller to
+ * skip `resolveAgentEnd`.
+ */
+export function maybeHandleReadyPhraseWithoutFiles(event: { messages: any[] }): boolean {
+  const entry = _getPendingAutoStart();
+  if (!entry) return false;
+  const { ctx, pi, basePath, milestoneId } = entry;
+
+  // Gate: last assistant message must contain the ready phrase
+  const lastMsg = event.messages[event.messages.length - 1];
+  const text = extractAssistantText(lastMsg);
+  if (!READY_PHRASE_RE.test(text)) return false;
+
+  // Gate: artifacts must still be missing — if they exist, the happy path
+  // already fired and we have nothing to do.
+  const contextFile = resolveMilestoneFile(basePath, milestoneId, "CONTEXT");
+  const roadmapFile = resolveMilestoneFile(basePath, milestoneId, "ROADMAP");
+  if (contextFile || roadmapFile) return false;
+
+  entry.readyRejectCount = (entry.readyRejectCount ?? 0) + 1;
+
+  if (entry.readyRejectCount > MAX_READY_REJECTS) {
+    // Give up: clear state and tell the user to re-run /gsd. Avoids an
+    // infinite nudge loop when the LLM never produces the writes.
+    pendingAutoStartMap.delete(basePath);
+    ctx.ui.notify(
+      `Milestone ${milestoneId}: LLM signaled "ready" ${entry.readyRejectCount} times without writing files. ` +
+      `Stopping auto-nudge. Run /gsd to try again.`,
+      "error",
+    );
+    return true;
+  }
+
+  ctx.ui.notify(
+    `Milestone ${milestoneId}: "ready" signal rejected — CONTEXT.md and ROADMAP.md are missing. Asking the LLM to complete the writes.`,
+    "warning",
+  );
+
+  const nudge =
+    `You emitted "Milestone ${milestoneId} ready." but neither ` +
+    `.gsd/milestones/${milestoneId}/${milestoneId}-CONTEXT.md nor ` +
+    `.gsd/milestones/${milestoneId}/${milestoneId}-ROADMAP.md exists on disk. ` +
+    `The ready phrase is a POST-WRITE signal and has been rejected. ` +
+    `In this turn: (1) write PROJECT.md, REQUIREMENTS.md, and the milestone ` +
+    `CONTEXT.md, (2) call gsd_plan_milestone, then (3) emit the ready phrase. ` +
+    `Do not describe these steps — execute them as tool calls. ` +
+    `This is retry ${entry.readyRejectCount}/${MAX_READY_REJECTS}; further ` +
+    `premature signals will clear the session.`;
+
+  try {
+    pi.sendMessage(
+      { customType: "gsd-ready-no-files", content: nudge, display: false },
+      { triggerTurn: true },
+    );
+  } catch (e) {
+    logWarning("guided", `ready-phrase nudge sendMessage failed: ${(e as Error).message}`);
+    return false;
+  }
+  return true;
+}
+
+/**
+ * #4573 — Detect and recover from the "announces tool, never calls it" stall.
+ *
+ * The LLM emits text like "I'll now write the CONTEXT.md file" but the turn
+ * ends with zero tool-use blocks. The harness has no post-turn tool-call
+ * validation, so the unit promise resolves and the user sees a stalled state.
+ *
+ * This function, called from `handleAgentEnd`, inspects the last assistant
+ * message. If ALL of the following are true, it injects a recovery message:
+ *   - Text-only (no tool-use blocks)
+ *   - Contains a commit-intent phrase ("I'll write", "I'll call", etc.)
+ *   - Auto-mode is active OR a discussion autostart is pending
+ *   - `emptyTurnRetryCount` is under the cap
+ *
+ * Per-handler state is held on the `PendingAutoStartEntry` when present, and
+ * on a module-level map otherwise. The counter resets on any successful
+ * tool-use turn via `resetEmptyTurnCounter`.
+ */
+const emptyTurnCounterByBase = new Map<string, number>();
+const MAX_EMPTY_TURN_RETRIES = 2;
+
+// Phrases that indicate the LLM is about to do something but has not yet.
+// Kept tight to avoid flagging legitimate narration like "I'll wait for your answer."
+const COMMIT_INTENT_RE =
+  /\b(?:I['’]ll|I will|Next,? I['’]ll|Now I['’]ll|Let me|I['’]m going to|I am going to)\s+(?:now\s+)?(?:write|create|call|invoke|update|add|make|run|execute|generate|produce|emit|compose|implement|save|apply|commit)\b/i;
+
+/**
+ * Reset the empty-turn counter for a basePath after a successful tool-use turn.
+ * Called from handleAgentEnd when the last message contains tool_use blocks.
+ */
+export function resetEmptyTurnCounter(basePath?: string): void {
+  if (basePath) emptyTurnCounterByBase.delete(basePath);
+  else emptyTurnCounterByBase.clear();
+}
+
+export function maybeHandleEmptyIntentTurn(
+  event: { messages: any[] },
+  isAuto: boolean,
+): boolean {
+  // Gate: only fire when there is system-driven work in flight. Interactive
+  // /gsd discuss (user-driven) produces legitimate text-only turns.
+  if (!isAuto && pendingAutoStartMap.size === 0) return false;
+
+  const lastMsg = event.messages[event.messages.length - 1];
+  if (!lastMsg) return false;
+  if (hasToolUse(lastMsg)) return false;
+
+  const text = extractAssistantText(lastMsg).trim();
+  if (!text) return false;
+
+  // Skip if the LLM is emitting the ready phrase — that is the ready-no-files
+  // path, handled by maybeHandleReadyPhraseWithoutFiles.
+  if (READY_PHRASE_RE.test(text)) return false;
+
+  // Skip if the LLM is clearly handing back to the user. Keep the heuristic
+  // tight: a trailing question mark on the last non-empty line is the common
+  // signal for "I asked the user a question and stopped."
+  const lines = text.split(/\r?\n/).map((l) => l.trim()).filter(Boolean);
+  const lastLine = lines[lines.length - 1] ?? "";
+  if (lastLine.endsWith("?")) return false;
+
+  // Must contain a commit-intent phrase — this is the stall we care about.
+  if (!COMMIT_INTENT_RE.test(text)) return false;
+
+  // Resolve the target basePath + pi for injection. Prefer the pending
+  // autostart entry (discuss flow); otherwise we cannot inject.
+  const entry = _getPendingAutoStart();
+  if (!entry) return false;
+  const { ctx, pi, basePath } = entry;
+
+  const count = (emptyTurnCounterByBase.get(basePath) ?? 0) + 1;
+  emptyTurnCounterByBase.set(basePath, count);
+
+  if (count > MAX_EMPTY_TURN_RETRIES) {
+    ctx.ui.notify(
+      `Empty-turn recovery: LLM announced intent ${count} times without calling any tool. ` +
+      `Stopping auto-nudge.`,
+      "error",
+    );
+    return false; // let the normal flow resolve/pause the unit
+  }
+
+  ctx.ui.notify(
+    `Empty-turn detected: LLM announced intent but called no tool. Prompting it to execute.`,
+    "info",
+  );
+
+  const nudge =
+    `Your last turn announced an action (e.g. "I'll write…" or "Let me call…") ` +
+    `but contained no tool call. The system records zero tool-use blocks for ` +
+    `that turn. Execute the announced action NOW as a tool call in this turn. ` +
+    `Do not describe it again. Retry ${count}/${MAX_EMPTY_TURN_RETRIES}.`;
+
+  try {
+    pi.sendMessage(
+      { customType: "gsd-empty-turn-recovery", content: nudge, display: false },
+      { triggerTurn: true },
+    );
+  } catch (e) {
+    logWarning("guided", `empty-turn nudge sendMessage failed: ${(e as Error).message}`);
+    return false;
+  }
   return true;
 }
 

--- a/src/resources/extensions/gsd/prompts/discuss-headless.md
+++ b/src/resources/extensions/gsd/prompts/discuss-headless.md
@@ -162,6 +162,10 @@ Preserve the specification's exact terminology, emphasis, and specific framing. 
 6. For each architectural or pattern decision, call `gsd_decision_save` — the tool auto-assigns IDs and regenerates `.gsd/DECISIONS.md` automatically.
 7. {{commitInstruction}}
 
+### Ready-phrase pre-condition (NON-BYPASSABLE)
+
+Before emitting the ready phrase, verify in the CURRENT turn that you have written `.gsd/PROJECT.md`, `.gsd/REQUIREMENTS.md`, `{{contextPath}}`, and called `gsd_plan_milestone`. If any is missing, **STOP** — emit the missing tool calls in this same turn. The system rejects premature ready signals and retries are capped.
+
 After writing the files, say exactly: "Milestone {{milestoneId}} ready." — nothing else. Auto-mode will start automatically.
 
 ### Multi-Milestone
@@ -233,6 +237,10 @@ For single-milestone projects, do NOT write this file.
 #### Phase 4: Finalize
 
 7. {{multiMilestoneCommitInstruction}}
+
+### Ready-phrase pre-condition (NON-BYPASSABLE)
+
+Before emitting the ready phrase, verify in the CURRENT turn that you have written `.gsd/PROJECT.md`, `.gsd/REQUIREMENTS.md`, the primary `CONTEXT.md`, called `gsd_plan_milestone` for the primary milestone, and written `.gsd/DISCUSSION-MANIFEST.json` with `gates_completed === total`. If any is missing, **STOP** — emit the missing tool calls in this same turn. The system rejects premature ready signals and retries are capped.
 
 After writing the files, say exactly: "Milestone {{milestoneId}} ready." — nothing else. Auto-mode will start automatically.
 

--- a/src/resources/extensions/gsd/prompts/discuss.md
+++ b/src/resources/extensions/gsd/prompts/discuss.md
@@ -339,7 +339,20 @@ These sections are in addition to whatever other context the discussion surfaced
 6. For each architectural or pattern decision made during discussion, call `gsd_decision_save` — the tool auto-assigns IDs and regenerates `.gsd/DECISIONS.md` automatically.
 7. {{commitInstruction}}
 
-After writing the files, say exactly: "Milestone {{milestoneId}} ready." — nothing else. Auto-mode will start automatically.
+### Ready-phrase pre-condition (NON-BYPASSABLE)
+
+Before emitting the ready phrase, verify in the CURRENT turn that you have:
+
+- [ ] Written `.gsd/PROJECT.md` (step 2)
+- [ ] Written `.gsd/REQUIREMENTS.md` (step 3)
+- [ ] Written `{{contextPath}}` (step 4)
+- [ ] Called `gsd_plan_milestone` (step 5)
+
+If ANY box is unchecked, **STOP**. Do NOT emit the ready phrase. Emit the missing tool calls in this same turn. The system detects missing artifacts and will reject premature ready signals — you will be asked again and retries are capped.
+
+Do not announce the ready phrase as something you are "about to" do. Do not narrate "now writing the files" as a substitute for actually writing them. The ready phrase is a post-write signal, not an intent signal.
+
+After completing steps 1–7 above, say exactly: "Milestone {{milestoneId}} ready." — nothing else. Auto-mode will start automatically.
 
 ### Multi-Milestone
 
@@ -418,6 +431,20 @@ For single-milestone projects, do NOT write this file — it is only for multi-m
 
 7. {{multiMilestoneCommitInstruction}}
 
-After writing the files, say exactly: "Milestone M001 ready." — nothing else. Auto-mode will start automatically.
+### Ready-phrase pre-condition (NON-BYPASSABLE)
+
+Before emitting the ready phrase, verify in the CURRENT turn that you have:
+
+- [ ] Written `.gsd/PROJECT.md` (Phase 1)
+- [ ] Written `.gsd/REQUIREMENTS.md` (Phase 1)
+- [ ] Written primary-milestone `CONTEXT.md` (Phase 2)
+- [ ] Called `gsd_plan_milestone` for the primary milestone (Phase 2)
+- [ ] Written `.gsd/DISCUSSION-MANIFEST.json` with `gates_completed === total` (Phase 3)
+
+If ANY box is unchecked, **STOP**. Do NOT emit the ready phrase. Emit the missing tool calls in this same turn. The system detects missing artifacts and will reject premature ready signals — you will be asked again and retries are capped.
+
+Do not announce the ready phrase as something you are "about to" do. Do not narrate "now writing the files" as a substitute for actually writing them. The ready phrase is a post-write signal, not an intent signal.
+
+After completing all phases above, say exactly: "Milestone M001 ready." — nothing else. Auto-mode will start automatically.
 
 {{inlinedTemplates}}

--- a/src/resources/extensions/gsd/tests/ready-phrase-no-files-4573.test.ts
+++ b/src/resources/extensions/gsd/tests/ready-phrase-no-files-4573.test.ts
@@ -1,0 +1,388 @@
+/**
+ * GSD-2 / guided-flow — regression tests for #4573
+ *
+ * Covers two recovery paths:
+ *   - maybeHandleReadyPhraseWithoutFiles: nudge when LLM emits
+ *     "Milestone M001 ready." without writing CONTEXT.md / ROADMAP.md
+ *   - maybeHandleEmptyIntentTurn: nudge when LLM narrates intent but
+ *     emits no tool-use blocks
+ */
+
+import { describe, test, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import {
+  setPendingAutoStart,
+  clearPendingAutoStart,
+  maybeHandleReadyPhraseWithoutFiles,
+  maybeHandleEmptyIntentTurn,
+  resetEmptyTurnCounter,
+} from "../guided-flow.ts";
+
+// ─── Test harness ──────────────────────────────────────────────────────────
+
+interface MockCapture {
+  notifies: Array<{ msg: string; level: string }>;
+  messages: Array<{ payload: any; options: any }>;
+}
+
+function mkCapture(): MockCapture {
+  return { notifies: [], messages: [] };
+}
+
+function mkCtx(cap: MockCapture): any {
+  return {
+    ui: {
+      notify: (msg: string, level: string) => {
+        cap.notifies.push({ msg, level });
+      },
+    },
+  };
+}
+
+function mkPi(cap: MockCapture, opts: { sendThrows?: boolean } = {}): any {
+  return {
+    sendMessage: (payload: any, options: any) => {
+      if (opts.sendThrows) throw new Error("send failed");
+      cap.messages.push({ payload, options });
+    },
+    setActiveTools: () => undefined,
+    getActiveTools: () => [],
+  };
+}
+
+function mkBase(): string {
+  const base = mkdtempSync(join(tmpdir(), "gsd-4573-"));
+  mkdirSync(join(base, ".gsd", "milestones", "M001"), { recursive: true });
+  return base;
+}
+
+function assistantMsg(text: string, opts: { toolUse?: boolean } = {}): any {
+  const content: any[] = [];
+  if (text) content.push({ type: "text", text });
+  if (opts.toolUse) content.push({ type: "tool_use", name: "whatever", input: {} });
+  return { role: "assistant", content };
+}
+
+// ─── ready-phrase recovery (Layer 2) ───────────────────────────────────────
+
+describe("#4573 maybeHandleReadyPhraseWithoutFiles", () => {
+  beforeEach(() => {
+    clearPendingAutoStart();
+    resetEmptyTurnCounter();
+  });
+
+  test("no pending entry → no-op", () => {
+    const cap = mkCapture();
+    const event = { messages: [assistantMsg("Milestone M001 ready.")] };
+    const handled = maybeHandleReadyPhraseWithoutFiles(event);
+    assert.equal(handled, false);
+    assert.equal(cap.messages.length, 0);
+  });
+
+  test("pending entry, ready phrase, no files → notify + sendMessage", () => {
+    const base = mkBase();
+    try {
+      const cap = mkCapture();
+      setPendingAutoStart(base, {
+        basePath: base,
+        milestoneId: "M001",
+        ctx: mkCtx(cap),
+        pi: mkPi(cap),
+      });
+      const handled = maybeHandleReadyPhraseWithoutFiles({
+        messages: [assistantMsg("Milestone M001 ready.")],
+      });
+      assert.equal(handled, true);
+      assert.equal(cap.messages.length, 1);
+      assert.equal(cap.messages[0].payload.customType, "gsd-ready-no-files");
+      assert.equal(cap.messages[0].options.triggerTurn, true);
+      assert.ok(
+        cap.notifies.some((n) => /rejected/.test(n.msg)),
+        "user notified about rejection",
+      );
+    } finally {
+      clearPendingAutoStart();
+    }
+  });
+
+  test("retry cap — after MAX_READY_REJECTS the nudge stops and entry clears", () => {
+    const base = mkBase();
+    try {
+      const cap = mkCapture();
+      setPendingAutoStart(base, {
+        basePath: base,
+        milestoneId: "M001",
+        ctx: mkCtx(cap),
+        pi: mkPi(cap),
+      });
+      const event = { messages: [assistantMsg("Milestone M001 ready.")] };
+
+      const first = maybeHandleReadyPhraseWithoutFiles(event);
+      const second = maybeHandleReadyPhraseWithoutFiles(event);
+      const third = maybeHandleReadyPhraseWithoutFiles(event); // > MAX
+
+      assert.equal(first, true);
+      assert.equal(second, true);
+      assert.equal(third, true); // still returns true (handled via give-up)
+      assert.equal(cap.messages.length, 2, "only 2 nudges sent (MAX_READY_REJECTS=2)");
+      assert.ok(
+        cap.notifies.some((n) => /Stopping auto-nudge/.test(n.msg)),
+        "gives up with error notify",
+      );
+
+      // After giving up, a fresh re-entry starts clean
+      const fourth = maybeHandleReadyPhraseWithoutFiles(event);
+      assert.equal(fourth, false, "pending entry was cleared — nothing to handle");
+    } finally {
+      clearPendingAutoStart();
+    }
+  });
+
+  test("files present → no nudge (happy path already fired)", () => {
+    const base = mkBase();
+    try {
+      writeFileSync(join(base, ".gsd", "milestones", "M001", "M001-CONTEXT.md"), "# ctx");
+      const cap = mkCapture();
+      setPendingAutoStart(base, {
+        basePath: base,
+        milestoneId: "M001",
+        ctx: mkCtx(cap),
+        pi: mkPi(cap),
+      });
+      const handled = maybeHandleReadyPhraseWithoutFiles({
+        messages: [assistantMsg("Milestone M001 ready.")],
+      });
+      assert.equal(handled, false);
+      assert.equal(cap.messages.length, 0);
+    } finally {
+      clearPendingAutoStart();
+    }
+  });
+
+  test("last message lacks ready phrase → no-op", () => {
+    const base = mkBase();
+    try {
+      const cap = mkCapture();
+      setPendingAutoStart(base, {
+        basePath: base,
+        milestoneId: "M001",
+        ctx: mkCtx(cap),
+        pi: mkPi(cap),
+      });
+      const handled = maybeHandleReadyPhraseWithoutFiles({
+        messages: [assistantMsg("Let me think about the slices first.")],
+      });
+      assert.equal(handled, false);
+      assert.equal(cap.messages.length, 0);
+    } finally {
+      clearPendingAutoStart();
+    }
+  });
+
+  test("fresh entry after give-up resets counter", () => {
+    const base = mkBase();
+    try {
+      const cap = mkCapture();
+      // First cycle: exhaust cap
+      setPendingAutoStart(base, {
+        basePath: base,
+        milestoneId: "M001",
+        ctx: mkCtx(cap),
+        pi: mkPi(cap),
+      });
+      const event = { messages: [assistantMsg("Milestone M001 ready.")] };
+      maybeHandleReadyPhraseWithoutFiles(event);
+      maybeHandleReadyPhraseWithoutFiles(event);
+      maybeHandleReadyPhraseWithoutFiles(event); // clears entry
+
+      // New /gsd run — re-seeds entry; counter must be 0 again
+      cap.messages.length = 0;
+      setPendingAutoStart(base, {
+        basePath: base,
+        milestoneId: "M001",
+        ctx: mkCtx(cap),
+        pi: mkPi(cap),
+      });
+      const handled = maybeHandleReadyPhraseWithoutFiles(event);
+      assert.equal(handled, true);
+      assert.equal(cap.messages.length, 1, "fresh entry fires nudge again");
+    } finally {
+      clearPendingAutoStart();
+    }
+  });
+});
+
+// ─── empty-turn recovery (Layer 3) ────────────────────────────────────────
+
+describe("#4573 maybeHandleEmptyIntentTurn", () => {
+  beforeEach(() => {
+    clearPendingAutoStart();
+    resetEmptyTurnCounter();
+  });
+
+  test("no pending entry + isAuto false → no-op (interactive discuss is user-driven)", () => {
+    const event = { messages: [assistantMsg("I'll write the CONTEXT.md now.")] };
+    const handled = maybeHandleEmptyIntentTurn(event, false);
+    assert.equal(handled, false);
+  });
+
+  test("text-only turn WITHOUT commit phrase → not flagged (legitimate text)", () => {
+    const base = mkBase();
+    try {
+      const cap = mkCapture();
+      setPendingAutoStart(base, {
+        basePath: base,
+        milestoneId: "M001",
+        ctx: mkCtx(cap),
+        pi: mkPi(cap),
+      });
+      const handled = maybeHandleEmptyIntentTurn(
+        { messages: [assistantMsg("Here is the roadmap preview — three slices.")] },
+        false,
+      );
+      assert.equal(handled, false);
+      assert.equal(cap.messages.length, 0);
+    } finally {
+      clearPendingAutoStart();
+    }
+  });
+
+  test("text-only turn ending in question → treated as user-handoff, not flagged", () => {
+    const base = mkBase();
+    try {
+      const cap = mkCapture();
+      setPendingAutoStart(base, {
+        basePath: base,
+        milestoneId: "M001",
+        ctx: mkCtx(cap),
+        pi: mkPi(cap),
+      });
+      const handled = maybeHandleEmptyIntentTurn(
+        { messages: [assistantMsg("Ready to write, or want to adjust?")] },
+        false,
+      );
+      assert.equal(handled, false);
+    } finally {
+      clearPendingAutoStart();
+    }
+  });
+
+  test("commit-intent phrase WITHOUT tool call → nudge fires", () => {
+    const base = mkBase();
+    try {
+      const cap = mkCapture();
+      setPendingAutoStart(base, {
+        basePath: base,
+        milestoneId: "M001",
+        ctx: mkCtx(cap),
+        pi: mkPi(cap),
+      });
+      const handled = maybeHandleEmptyIntentTurn(
+        { messages: [assistantMsg("I'll now write the CONTEXT.md file.")] },
+        false,
+      );
+      assert.equal(handled, true);
+      assert.equal(cap.messages.length, 1);
+      assert.equal(cap.messages[0].payload.customType, "gsd-empty-turn-recovery");
+    } finally {
+      clearPendingAutoStart();
+    }
+  });
+
+  test("commit-intent WITH tool-use block → not flagged", () => {
+    const base = mkBase();
+    try {
+      const cap = mkCapture();
+      setPendingAutoStart(base, {
+        basePath: base,
+        milestoneId: "M001",
+        ctx: mkCtx(cap),
+        pi: mkPi(cap),
+      });
+      const handled = maybeHandleEmptyIntentTurn(
+        { messages: [assistantMsg("I'll write the file now.", { toolUse: true })] },
+        false,
+      );
+      assert.equal(handled, false);
+      assert.equal(cap.messages.length, 0);
+    } finally {
+      clearPendingAutoStart();
+    }
+  });
+
+  test("ready phrase is NOT treated as empty-turn (handled by other recovery path)", () => {
+    const base = mkBase();
+    try {
+      const cap = mkCapture();
+      setPendingAutoStart(base, {
+        basePath: base,
+        milestoneId: "M001",
+        ctx: mkCtx(cap),
+        pi: mkPi(cap),
+      });
+      const handled = maybeHandleEmptyIntentTurn(
+        { messages: [assistantMsg("Milestone M001 ready.")] },
+        false,
+      );
+      assert.equal(handled, false);
+    } finally {
+      clearPendingAutoStart();
+    }
+  });
+
+  test("empty-turn retry cap — stops after MAX_EMPTY_TURN_RETRIES", () => {
+    const base = mkBase();
+    try {
+      const cap = mkCapture();
+      setPendingAutoStart(base, {
+        basePath: base,
+        milestoneId: "M001",
+        ctx: mkCtx(cap),
+        pi: mkPi(cap),
+      });
+      const event = { messages: [assistantMsg("I'll write the CONTEXT.md file.")] };
+
+      maybeHandleEmptyIntentTurn(event, false); // 1
+      maybeHandleEmptyIntentTurn(event, false); // 2
+      const third = maybeHandleEmptyIntentTurn(event, false); // > cap
+
+      assert.equal(cap.messages.length, 2, "only 2 nudges sent");
+      assert.equal(third, false, "after cap, no further injection");
+      assert.ok(
+        cap.notifies.some((n) => /Stopping auto-nudge/.test(n.msg)),
+        "user notified of give-up",
+      );
+    } finally {
+      clearPendingAutoStart();
+    }
+  });
+
+  test("resetEmptyTurnCounter clears state after a successful tool-use turn", () => {
+    const base = mkBase();
+    try {
+      const cap = mkCapture();
+      setPendingAutoStart(base, {
+        basePath: base,
+        milestoneId: "M001",
+        ctx: mkCtx(cap),
+        pi: mkPi(cap),
+      });
+      const event = { messages: [assistantMsg("I'll write the CONTEXT.md file.")] };
+
+      maybeHandleEmptyIntentTurn(event, false); // 1
+      maybeHandleEmptyIntentTurn(event, false); // 2 — at cap
+      resetEmptyTurnCounter(); // simulate a successful tool-use turn in between
+
+      cap.messages.length = 0;
+      const after = maybeHandleEmptyIntentTurn(event, false);
+      assert.equal(after, true, "counter reset — nudge fires again");
+      assert.equal(cap.messages.length, 1);
+    } finally {
+      clearPendingAutoStart();
+    }
+  });
+});

--- a/src/resources/extensions/gsd/tests/restore-tools-after-discuss.test.ts
+++ b/src/resources/extensions/gsd/tests/restore-tools-after-discuss.test.ts
@@ -45,9 +45,15 @@ describe('restore tools after discuss flow scoping (#3628)', () => {
   })
 
   it('savedTools is restored after sendMessage', () => {
-    // Find the sendMessage call
-    const sendMsg = src.indexOf('triggerTurn: true')
-    assert.ok(sendMsg !== -1, 'sendMessage with triggerTurn must exist')
+    // #4573: guided-flow.ts now contains multiple `triggerTurn: true` calls
+    // (ready-phrase and empty-turn recovery paths). The discuss-flow scoping
+    // sendMessage is the one that follows `savedTools = currentTools`, so
+    // anchor the search there rather than at the first `triggerTurn: true`.
+    const savedToolsAssign = src.indexOf('savedTools = currentTools')
+    assert.ok(savedToolsAssign !== -1, 'savedTools = currentTools must exist')
+
+    const sendMsg = src.indexOf('triggerTurn: true', savedToolsAssign)
+    assert.ok(sendMsg !== -1, 'discuss-flow sendMessage with triggerTurn must exist after savedTools capture')
 
     // After sendMessage, savedTools should be restored via setActiveTools
     const afterSend = src.slice(sendMsg, sendMsg + 500)


### PR DESCRIPTION
## TL;DR

**What:** Recover two silent failure modes in the discuss→auto-mode handoff: (a) LLM emits "Milestone X ready." without writing files, and (b) LLM narrates tool intent but never emits a tool call.
**Why:** Both produced confusing user experiences — stale-entry warning loops for (a), stalled sessions for (b). Fixes #4573.
**How:** Three-layer defense — prompt checklist + Gate-1 pattern-match nudge + empty-intent turn detector, all with retry caps and per-entry lifecycle.

Closes #4573

## What

Two related failure modes in `src/resources/extensions/gsd/`:

1. **Ready signal without files.** `checkAutoStartAfterDiscuss()` in `guided-flow.ts:187` gated on CONTEXT.md / ROADMAP.md existing (line 197) and silently returned `false` when missing. The phrase "Milestone M001 ready." is never pattern-matched in code — detection is purely artifact-based. When the LLM skipped writes, nothing fired and no one was told. Downstream: stale `pendingAutoStartMap` entry → "Discussion already in progress" (line 1376), or `consecutiveCompleteBootstraps` ceiling → "All milestones complete" warning at `auto-start.ts:546`.

2. **Empty-intent turn.** LLM emits prose like "I'll now write the CONTEXT.md file" but the turn ends with zero tool-use blocks. Turn finalizes at `agent_end` via `register-hooks.ts:169` → `resolveAgentEnd` at `agent-end-recovery.ts:339`. **Zero post-turn validation of tool-call presence** anywhere in the codebase. `system.md:212-214` actively encourages narration between tool calls. `auto-timers.ts:149` detects stalled *tool calls* but not stalled *turns*.

## How

Three-layer fix (peer-reviewed — 3 BLOCKERs resolved before implementation):

**Layer 1 — Prompts** (`discuss.md`, `discuss-headless.md`): Restructure the output phase with an explicit non-bypassable pre-condition checklist the LLM must satisfy before emitting the ready phrase. `system.md` untouched to avoid conflicting with existing narration guidance at lines 212-214.

**Layer 2 — Gate-1 feedback nudge** (`guided-flow.ts`): New exported `maybeHandleReadyPhraseWithoutFiles(event)` pattern-matches the canonical ready phrase on the last assistant message. If CONTEXT.md and ROADMAP.md are both absent, notify user + inject `pi.sendMessage({customType:"gsd-ready-no-files", triggerTurn:true})` telling the LLM the signal was premature. Retry counter lives on `PendingAutoStartEntry` (per-entry lifecycle — auto-clears on delete/recreate). Cap at 2, then gives up and asks the user to re-run `/gsd`.

**Layer 3 — Empty-intent turn detector** (`guided-flow.ts`): New exported `maybeHandleEmptyIntentTurn(event, isAuto)`. Gates on `isAuto || pendingAutoStartMap.size > 0` so interactive user-driven discuss is never flagged. Fires only when:
- No tool-use blocks in the last assistant message
- Non-empty text
- Not a ready phrase (handled by Layer 2)
- Last non-empty line does NOT end with `?` (treats trailing questions as legitimate user-handoff)
- Commit-intent phrase match (`I'll write`, `Let me call`, `Now I'll invoke`, etc.)

Dedicated `emptyTurnCounterByBase` map — does **not** touch the shared `retryState`. Cap at 2; `resetEmptyTurnCounter()` clears on any successful tool-use turn.

**Wiring** (`bootstrap/agent-end-recovery.ts`): Both handlers called in `handleAgentEnd` after the `checkAutoStartAfterDiscuss` happy path but before `isAutoActive()` return, so pending discussions are recovered even when auto isn't yet running. Success path resets empty-turn counter.

## Files changed

- `src/resources/extensions/gsd/bootstrap/agent-end-recovery.ts` (+24)
- `src/resources/extensions/gsd/guided-flow.ts` (+221)
- `src/resources/extensions/gsd/prompts/discuss.md` (+31)
- `src/resources/extensions/gsd/prompts/discuss-headless.md` (+8)
- `src/resources/extensions/gsd/tests/ready-phrase-no-files-4573.test.ts` (new, 14 tests)

## Test plan

- [x] `npx tsx --test ready-phrase-no-files-4573.test.ts` — 14/14 pass
- [x] `guided-flow-session-isolation.test.ts` — no regression
- [x] `draft-promotion.test.ts` — no regression (11 tests)
- [x] `auto-start-needs-discussion.test.ts` — no regression
- [x] `auto-warning-noise-regression.test.ts` — no regression
- [x] `tsc --noEmit` — clean
- [ ] Manual: run `/gsd` with gpt-5-3-codex, complete discussion, reply "write", verify nudge fires when LLM skips writes
- [ ] Manual: verify interactive discuss Phase 3 (multi-milestone option prompt) is NOT flagged as empty turn
- [ ] Manual: verify question-ending text turns are NOT flagged (user handoff)

## Non-goals

- Adding a Hard Rule forbidding narration — would conflict with `system.md:212-214`
- Per-model prompt branching for codex family — separate scope
- Rewriting `system.md:212-214` — carries regression risk across all unit types

## Peer review

Design went through a Codex peer review which surfaced 3 BLOCKERs (all resolved):

- **BLOCKER 1:** Layer 3 false positives on legitimate user-handoff turns → fixed with trailing-`?` heuristic + commit-intent-phrase requirement.
- **BLOCKER 2:** Layer 3 scope. Original plan gated on unit type, which doesn't distinguish user-driven vs system-driven. Now gates on `isAutoActive() || pendingAutoStartMap.size > 0`.
- **BLOCKER 3:** Recursion risk from `pi.sendMessage + triggerTurn:true`. Addressed with dedicated `emptyTurnCounterByBase` (separate from shared `retryState`) + hard cap at 2 + `resetEmptyTurnCounter()` on success.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery when milestone-ready messages occur without required project files; now nudges and caps retries.
  * Enhanced handling of auto-mode stalls where the assistant emits intent but performs no tool actions; adds nudges and retry limits.

* **New Features**
  * Added non-bypassable verification before emitting milestone-ready signals to ensure required artifacts and tool calls happened.

* **Tests**
  * Added regression tests covering the new recovery and verification behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->