### PR TITLE
fix(gsd): clear HARD BLOCK when write-gate state file is deleted

### DIFF
--- a/src/resources/extensions/gsd/bootstrap/write-gate.ts
+++ b/src/resources/extensions/gsd/bootstrap/write-gate.ts
@@ -117,9 +117,21 @@ function normalizeWriteGateSnapshot(value: unknown): WriteGateSnapshot {
   };
 }
 
+const EMPTY_SNAPSHOT: WriteGateSnapshot = {
+  verifiedDepthMilestones: [],
+  activeQueuePhase: false,
+  pendingGateId: null,
+};
+
 export function loadWriteGateSnapshot(basePath: string = process.cwd()): WriteGateSnapshot {
   const path = writeGateSnapshotPath(basePath);
-  if (!existsSync(path)) return currentWriteGateSnapshot();
+  if (!existsSync(path)) {
+    // When persist mode is active and the file has been deleted, treat it as a
+    // full state reset so deleting the file clears the HARD BLOCK gate.
+    // In non-persist mode the file is never written, so fall back to in-memory.
+    if (shouldPersistWriteGateSnapshot()) return EMPTY_SNAPSHOT;
+    return currentWriteGateSnapshot();
+  }
   try {
     return normalizeWriteGateSnapshot(JSON.parse(readFileSync(path, "utf-8")));
   } catch {

--- a/src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-tool-executors.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { mkdirSync, rmSync, readFileSync, existsSync, writeFileSync } from "node:fs";
+import { mkdirSync, rmSync, readFileSync, existsSync, writeFileSync, unlinkSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { randomUUID } from "node:crypto";
@@ -11,7 +11,7 @@ import {
   _getAdapter,
   insertGateRow,
 } from "../gsd-db.ts";
-import { markDepthVerified, clearDiscussionFlowState } from "../bootstrap/write-gate.ts";
+import { markDepthVerified, clearDiscussionFlowState, loadWriteGateSnapshot } from "../bootstrap/write-gate.ts";
 import {
   executeCompleteMilestone,
   executePlanMilestone,
@@ -738,6 +738,69 @@ test("executeSummarySave leaves sibling CONTEXT-DRAFT intact for non-CONTEXT art
       "CONTEXT-DRAFT.md must survive RESEARCH/SUMMARY/ASSESSMENT writes",
     );
   } finally {
+    closeDatabase();
+    cleanup(base);
+  }
+});
+
+test("executeSummarySave CONTEXT HARD BLOCK clears after write-gate state file is deleted (#4343)", async () => {
+  const base = makeTmpBase();
+  const originalEnv = process.env.GSD_PERSIST_WRITE_GATE_STATE;
+  process.env.GSD_PERSIST_WRITE_GATE_STATE = "1";
+  try {
+    openTestDb(base);
+    clearDiscussionFlowState();
+
+    // First call: CONTEXT artifact without depth verification → HARD BLOCK
+    const blocked = await inProjectDir(base, () => executeSummarySave({
+      milestone_id: "M001",
+      artifact_type: "CONTEXT",
+      content: "# Context\n\ncontent",
+    }, base));
+    assert.equal(blocked.isError, true, "should be blocked without depth verification");
+    assert.match(
+      blocked.content[0].text,
+      /HARD BLOCK/,
+      "blocked result should mention HARD BLOCK",
+    );
+
+    // Verify the state file was written (persist mode is active)
+    const stateFilePath = join(base, ".gsd", "runtime", "write-gate-state.json");
+    // The state file may or may not exist at this point (block doesn't write state).
+    // Write a fake state file simulating stale persisted block state.
+    mkdirSync(join(base, ".gsd", "runtime"), { recursive: true });
+    writeFileSync(stateFilePath, JSON.stringify({
+      verifiedDepthMilestones: [],
+      activeQueuePhase: false,
+      pendingGateId: "depth_verification_M001",
+    }));
+
+    // User deletes the state file to reset the block
+    unlinkSync(stateFilePath);
+    assert.ok(!existsSync(stateFilePath), "state file deleted");
+
+    // The snapshot loaded after deletion should be clean (no pending gate, no block)
+    const snapshot = loadWriteGateSnapshot(base);
+    assert.equal(snapshot.pendingGateId, null, "pendingGateId should be null after file deletion");
+    assert.deepEqual(snapshot.verifiedDepthMilestones, [], "verifiedDepthMilestones should be empty after file deletion");
+
+    // Depth-verify and re-attempt: should succeed after deletion clears stale state
+    markDepthVerified("M001", base);
+
+    const unblocked = await inProjectDir(base, () => executeSummarySave({
+      milestone_id: "M001",
+      artifact_type: "CONTEXT",
+      content: "# Context\n\nfinal content",
+    }, base));
+    assert.equal(unblocked.isError, undefined, "should not be blocked after depth verification");
+    assert.equal(unblocked.details.operation, "save_summary");
+  } finally {
+    if (originalEnv === undefined) {
+      delete process.env.GSD_PERSIST_WRITE_GATE_STATE;
+    } else {
+      process.env.GSD_PERSIST_WRITE_GATE_STATE = originalEnv;
+    }
+    clearDiscussionFlowState();
     closeDatabase();
     cleanup(base);
   }

--- a/src/resources/extensions/gsd/tests/write-gate.test.ts
+++ b/src/resources/extensions/gsd/tests/write-gate.test.ts
@@ -11,6 +11,10 @@
 
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import { mkdirSync, writeFileSync, unlinkSync, existsSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { randomUUID } from 'node:crypto';
 import {
   isDepthConfirmationAnswer,
   shouldBlockContextWrite,
@@ -20,8 +24,10 @@ import {
   markDepthVerified,
   isMilestoneDepthVerified,
   shouldBlockContextArtifactSave,
+  shouldBlockContextArtifactSaveInSnapshot,
   clearDiscussionFlowState,
   resetWriteGateState,
+  loadWriteGateSnapshot,
 } from '../bootstrap/write-gate.ts';
 
 // ─── Scenario 1: Blocks CONTEXT.md write during discussion without depth verification (absolute path) ──
@@ -487,4 +493,62 @@ test('write-gate: isDepthConfirmationAnswer falls back to (Recommended) match wi
     false,
     'should reject non-Recommended via fallback',
   );
+});
+
+// ─── Scenario 29: loadWriteGateSnapshot returns clean state when persist file deleted (#4343) ──
+
+test('write-gate: loadWriteGateSnapshot returns empty default when persist file is deleted (#4343)', () => {
+  const base = join(tmpdir(), `gsd-write-gate-4343-${randomUUID()}`);
+  mkdirSync(join(base, '.gsd', 'runtime'), { recursive: true });
+  const stateFilePath = join(base, '.gsd', 'runtime', 'write-gate-state.json');
+  const originalEnv = process.env.GSD_PERSIST_WRITE_GATE_STATE;
+
+  try {
+    process.env.GSD_PERSIST_WRITE_GATE_STATE = '1';
+
+    // Write a state file with a pending gate and verified milestone
+    writeFileSync(stateFilePath, JSON.stringify({
+      verifiedDepthMilestones: ['M001'],
+      activeQueuePhase: false,
+      pendingGateId: 'depth_verification_M001',
+    }));
+    assert.ok(existsSync(stateFilePath), 'precondition: state file exists');
+
+    // While file exists, snapshot reflects its contents
+    const beforeDeletion = loadWriteGateSnapshot(base);
+    assert.strictEqual(beforeDeletion.pendingGateId, 'depth_verification_M001', 'pending gate from file');
+    assert.deepEqual(beforeDeletion.verifiedDepthMilestones, ['M001'], 'verified milestones from file');
+
+    // User deletes the state file to clear the HARD BLOCK
+    unlinkSync(stateFilePath);
+    assert.ok(!existsSync(stateFilePath), 'state file deleted');
+
+    // After deletion in persist mode, snapshot should be clean (not stale in-memory)
+    const afterDeletion = loadWriteGateSnapshot(base);
+    assert.strictEqual(afterDeletion.pendingGateId, null, 'pendingGateId cleared after file deletion');
+    assert.deepEqual(afterDeletion.verifiedDepthMilestones, [], 'verifiedDepthMilestones cleared after file deletion');
+    assert.strictEqual(afterDeletion.activeQueuePhase, false, 'activeQueuePhase cleared after file deletion');
+
+    // The CONTEXT artifact block check must also resolve to unblocked after deletion+verification
+    // (simulate the re-verify flow users would do: delete → depth verify → save)
+    const stillBlocked = shouldBlockContextArtifactSaveInSnapshot(afterDeletion, 'CONTEXT', 'M001', null);
+    assert.strictEqual(stillBlocked.block, true, 'still blocked without new depth verification');
+
+    const verifiedSnapshot = {
+      ...afterDeletion,
+      verifiedDepthMilestones: ['M001'],
+    };
+    const unblocked = shouldBlockContextArtifactSaveInSnapshot(verifiedSnapshot, 'CONTEXT', 'M001', null);
+    assert.strictEqual(unblocked.block, false, 'unblocked after fresh depth verification');
+  } finally {
+    if (originalEnv === undefined) {
+      delete process.env.GSD_PERSIST_WRITE_GATE_STATE;
+    } else {
+      process.env.GSD_PERSIST_WRITE_GATE_STATE = originalEnv;
+    }
+    clearDiscussionFlowState();
+    try {
+      rmSync(base, { recursive: true, force: true });
+    } catch { /* swallow */ }
+  }
 });


### PR DESCRIPTION
## Summary

- `loadWriteGateSnapshot` fell back to stale in-memory state when the persisted write-gate state file was deleted, leaving the `gsd_summary_save` CONTEXT artifact HARD BLOCK active even after the user deleted the state file
- Fixed by returning an explicit empty snapshot (no pending gate, no verified milestones) when persist mode (`GSD_PERSIST_WRITE_GATE_STATE=1`) is active but the file doesn't exist — making file deletion a proper state reset
- Non-persist mode (default) is unchanged: still uses in-memory state since the file is never written in that mode
- Added unit test (scenario 29 in write-gate.test.ts) covering the before/after behavior

## Root cause

`src/resources/extensions/gsd/bootstrap/write-gate.ts` → `loadWriteGateSnapshot`: when the state file doesn't exist and persist mode is active, the function returned `currentWriteGateSnapshot()` (in-memory) instead of a clean default. The in-memory `verifiedDepthMilestones` Set was empty, so `shouldBlockContextArtifactSaveInSnapshot` always blocked CONTEXT saves — deletion had no effect.

## Test plan

- [x] `write-gate.test.ts` — new scenario 29: verifies snapshot is clean (not stale in-memory) after file deletion in persist mode
- [x] All 30 write-gate unit tests pass
- [x] 570/570 GSD integration tests pass
- [x] Unit suite: 4449 pass (all pre-existing failures unchanged)

Closes #4343

🤖 Generated with [Claude Code](https://claude.com/claude-code)