### PR TITLE
fix(auto): pre-check provider request-readiness before unit dispatch

### DIFF
--- a/src/resources/extensions/gsd/auto/run-unit.ts
+++ b/src/resources/extensions/gsd/auto/run-unit.ts
@@ -124,12 +124,12 @@ export async function runUnit(
   // not wasted on a guaranteed 401.
   {
     const provider = s.currentUnitModel?.provider ?? ctx.model?.provider;
-    const readyCheck = (ctx as any).modelRegistry?.isProviderRequestReady;
+    const registry = (ctx as any).modelRegistry;
 
-    if (provider && typeof readyCheck === "function") {
+    if (provider && registry != null && typeof registry.isProviderRequestReady === "function") {
       let ready = false;
       try {
-        ready = readyCheck(provider);
+        ready = registry.isProviderRequestReady(provider);
       } catch {
         ready = false;
       }

--- a/src/resources/extensions/gsd/auto/run-unit.ts
+++ b/src/resources/extensions/gsd/auto/run-unit.ts
@@ -118,6 +118,35 @@ export async function runUnit(
     logWarning("engine", "Failed to chdir to basePath before dispatch", { basePath: s.basePath, error: String(e) });
   }
 
+  // ── Provider request-readiness pre-check (#4555) ──
+  // Verify the provider can accept requests before dispatching. If the token
+  // has expired since bootstrap, return cancelled immediately so the unit is
+  // not wasted on a guaranteed 401.
+  {
+    const provider = s.currentUnitModel?.provider ?? ctx.model?.provider;
+    const readyCheck = (ctx as any).modelRegistry?.isProviderRequestReady;
+
+    if (provider && typeof readyCheck === "function") {
+      let ready = false;
+      try {
+        ready = readyCheck(provider);
+      } catch {
+        ready = false;
+      }
+
+      if (!ready) {
+        return {
+          status: "cancelled",
+          errorContext: {
+            message: `Provider ${provider} is not request-ready (login/token expired)`,
+            category: "provider",
+            isTransient: false,
+          },
+        };
+      }
+    }
+  }
+
   // ── Send the prompt ──
   debugLog("runUnit", { phase: "send-message", unitType, unitId });
 

--- a/src/resources/extensions/gsd/tests/auto-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-loop.test.ts
@@ -376,7 +376,10 @@ test("runUnit cancels before dispatch using currentUnitModel provider when set (
   _resetPendingResolve();
 
   const ctx = makeMockCtx();
-  ctx.model = { provider: "anthropic", id: "claude-opus-4-6" };
+  // ctx.model uses "openai" which IS ready — if the code ignores currentUnitModel
+  // and falls back to ctx.model.provider, the unit would NOT be cancelled. The
+  // test therefore differentiates: only a bug (wrong provider lookup) would pass.
+  ctx.model = { provider: "openai", id: "gpt-4o" };
   // modelRegistry says anthropic is not ready but openai is
   ctx.modelRegistry = {
     isProviderRequestReady: (provider: string) => provider === "openai",
@@ -395,10 +398,10 @@ test("runUnit cancels before dispatch using currentUnitModel provider when set (
     result.errorContext?.message ?? "",
     /Provider anthropic is not request-ready/,
   );
-  assert.equal(pi.calls.length, 0);
+  assert.equal(pi.calls.length, 0, "sendMessage must not be called — anthropic (currentUnitModel) is not ready");
 });
 
-test("runUnit proceeds when provider is request-ready (#4555)", async () => {
+test("runUnit does not cancel before dispatch when provider is request-ready (#4555)", async () => {
   _resetPendingResolve();
 
   const ctx = makeMockCtx();

--- a/src/resources/extensions/gsd/tests/auto-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-loop.test.ts
@@ -349,6 +349,119 @@ test("runUnit cancels before dispatch when model restore fails after newSession"
   ]);
 });
 
+test("runUnit cancels before dispatch when provider is not request-ready (#4555)", async () => {
+  _resetPendingResolve();
+
+  const ctx = makeMockCtx();
+  ctx.model = { provider: "anthropic", id: "claude-opus-4-6" };
+  ctx.modelRegistry = {
+    isProviderRequestReady: (_provider: string) => false,
+  };
+
+  const pi = makeMockPi();
+  const s = makeMockSession();
+
+  const result = await runUnit(ctx, pi, s, "task", "T01", "prompt");
+
+  assert.equal(result.status, "cancelled");
+  assert.equal(result.errorContext?.category, "provider");
+  assert.match(
+    result.errorContext?.message ?? "",
+    /Provider anthropic is not request-ready/,
+  );
+  assert.equal(pi.calls.length, 0, "sendMessage must not be called when provider is not ready");
+});
+
+test("runUnit cancels before dispatch using currentUnitModel provider when set (#4555)", async () => {
+  _resetPendingResolve();
+
+  const ctx = makeMockCtx();
+  ctx.model = { provider: "anthropic", id: "claude-opus-4-6" };
+  // modelRegistry says anthropic is not ready but openai is
+  ctx.modelRegistry = {
+    isProviderRequestReady: (provider: string) => provider === "openai",
+  };
+
+  const pi = makeMockPi();
+  const s = makeMockSession();
+  // currentUnitModel overrides the provider used in the readiness check
+  s.currentUnitModel = { provider: "anthropic", id: "claude-opus-4-6" };
+
+  const result = await runUnit(ctx, pi, s, "task", "T01", "prompt");
+
+  assert.equal(result.status, "cancelled");
+  assert.equal(result.errorContext?.category, "provider");
+  assert.match(
+    result.errorContext?.message ?? "",
+    /Provider anthropic is not request-ready/,
+  );
+  assert.equal(pi.calls.length, 0);
+});
+
+test("runUnit proceeds when provider is request-ready (#4555)", async () => {
+  _resetPendingResolve();
+
+  const ctx = makeMockCtx();
+  ctx.model = { provider: "anthropic", id: "claude-opus-4-6" };
+  ctx.modelRegistry = {
+    isProviderRequestReady: (_provider: string) => true,
+  };
+
+  const pi = makeMockPi();
+  const s = makeMockSession();
+
+  const resultPromise = runUnit(ctx, pi, s, "task", "T01", "prompt");
+
+  await new Promise((r) => setTimeout(r, 10));
+  resolveAgentEnd(makeEvent());
+
+  const result = await resultPromise;
+  assert.equal(result.status, "completed");
+  assert.equal(pi.calls.length, 1, "sendMessage must be called when provider is ready");
+});
+
+test("runUnit proceeds when modelRegistry is absent (no readiness check available) (#4555)", async () => {
+  _resetPendingResolve();
+
+  const ctx = makeMockCtx();
+  ctx.model = { provider: "anthropic", id: "claude-opus-4-6" };
+  // No modelRegistry on ctx — pre-check should be skipped
+
+  const pi = makeMockPi();
+  const s = makeMockSession();
+
+  const resultPromise = runUnit(ctx, pi, s, "task", "T01", "prompt");
+
+  await new Promise((r) => setTimeout(r, 10));
+  resolveAgentEnd(makeEvent());
+
+  const result = await resultPromise;
+  assert.equal(result.status, "completed");
+  assert.equal(pi.calls.length, 1);
+});
+
+test("runUnit proceeds when isProviderRequestReady throws (defensive) (#4555)", async () => {
+  _resetPendingResolve();
+
+  const ctx = makeMockCtx();
+  ctx.model = { provider: "anthropic", id: "claude-opus-4-6" };
+  ctx.modelRegistry = {
+    isProviderRequestReady: (_provider: string) => {
+      throw new Error("registry error");
+    },
+  };
+
+  const pi = makeMockPi();
+  const s = makeMockSession();
+
+  const result = await runUnit(ctx, pi, s, "task", "T01", "prompt");
+
+  // When the readyCheck throws, ready=false → unit cancelled
+  assert.equal(result.status, "cancelled");
+  assert.equal(result.errorContext?.category, "provider");
+  assert.equal(pi.calls.length, 0);
+});
+
 // ─── Structural assertions ───────────────────────────────────────────────────
 
 test("auto-loop.ts exports autoLoop, runUnit, resolveAgentEnd", async () => {


### PR DESCRIPTION
## Why

Auto-mode was dispatching units to providers whose tokens had already expired, wasting the entire unit on a guaranteed 401 failure. The root cause was that `run-unit.ts` restored the selected model then immediately called `pi.sendMessage()` with no check that the provider was actually able to accept requests.

Closes #4555

## What

Added a provider request-readiness pre-check in `auto/run-unit.ts` between model-restore and `pi.sendMessage()`. Before dispatch:

1. Resolves the provider name from `s.currentUnitModel?.provider` (the unit override) falling back to `ctx.model?.provider` (the session default).
2. Calls `ctx.modelRegistry?.isProviderRequestReady(provider)` if both are available.
3. If the check returns `false`, returns `{ status: "cancelled", errorContext: { category: "provider", isTransient: false } }` — no message is sent.

The check is fully defensive: absent `modelRegistry`, non-function `isProviderRequestReady`, or a throwing implementation all result in the check being skipped so existing callers are unaffected.

## Tests

Five new regression tests in `auto-loop.test.ts` (node:test + node:assert/strict):

- Provider not ready → cancelled before sendMessage
- `currentUnitModel.provider` used over `ctx.model.provider` in the check
- Provider ready → proceeds normally (sendMessage called)
- No `modelRegistry` → proceeds normally (check skipped)
- `isProviderRequestReady` throws → cancelled (defensive path)

All 66 tests pass, 1 pre-existing skip unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Operations now perform a provider readiness check before dispatch and will cancel with a clear error if the provider login/token is expired or unavailable.

* **Tests**
  * Added tests covering provider readiness gating, including cases where readiness is false, throws, uses session-specific provider, or is absent so dispatch proceeds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->