### PR TITLE
fix(gsd-exec): inject pre-exec gate failure context into re-dispatched plan-slice prompt

### DIFF
--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -568,15 +568,28 @@ export const DISPATCH_RULES: DispatchRule[] = [
   },
   {
     name: "planning → plan-slice",
-    match: async ({ state, mid, midTitle, basePath, sessionContextWindow, modelRegistry }) => {
+    match: async ({ state, mid, midTitle, basePath, sessionContextWindow, modelRegistry, session }) => {
       if (state.phase !== "planning") return null;
       if (!state.activeSlice) return missingSliceStop(mid, state.phase);
       const sid = state.activeSlice!.id;
       const sTitle = state.activeSlice!.title;
+      // #4551: Consume any persisted pre-exec failure for this slice so the
+      // re-dispatched prompt includes the exact blocked references. Clear the
+      // field immediately after reading to prevent stale context leaking into
+      // a later, unrelated plan-slice run.
+      const unitId = `${mid}/${sid}`;
+      let priorPreExecFailure: { blockingFindings: string[]; verdictExcerpt: string } | undefined;
+      if (session?.lastPreExecFailure?.unitId === unitId) {
+        priorPreExecFailure = {
+          blockingFindings: session.lastPreExecFailure.blockingFindings,
+          verdictExcerpt: session.lastPreExecFailure.verdictExcerpt,
+        };
+        session.lastPreExecFailure = null;
+      }
       return {
         action: "dispatch",
         unitType: "plan-slice",
-        unitId: `${mid}/${sid}`,
+        unitId,
         prompt: await buildPlanSlicePrompt(
           mid,
           midTitle,
@@ -584,7 +597,7 @@ export const DISPATCH_RULES: DispatchRule[] = [
           sTitle,
           basePath,
           undefined,
-          { sessionContextWindow, modelRegistry },
+          { sessionContextWindow, modelRegistry, priorPreExecFailure },
         ),
       };
     },

--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -1134,6 +1134,15 @@ export async function postUnitPostVerification(pctx: PostUnitContext): Promise<"
             `Pre-execution checks failed: ${blockingCount} blocking issue${blockingCount === 1 ? "" : "s"} found\n${details}${suffix}${evidenceNote}`,
             "error",
           );
+          // Persist failure context so the next plan-slice re-dispatch can inject
+          // it into the prompt and break the infinite loop (#4551).
+          s.lastPreExecFailure = {
+            unitId: currentUnit.id,
+            blockingFindings: blockingChecks.map(
+              c => `[${c.category}] ${c.target}: ${c.message}`,
+            ),
+            verdictExcerpt: `status=${result.status}; ${blockingCount} blocking issue${blockingCount === 1 ? "" : "s"} detected`,
+          };
           preExecPauseNeeded = true;
         } else if (result.status === "warn") {
           ctx.ui.notify(
@@ -1142,6 +1151,14 @@ export async function postUnitPostVerification(pctx: PostUnitContext): Promise<"
           );
           // Strict mode: treat warnings as blocking
           if (prefs?.enhanced_verification_strict === true) {
+            const warnChecks = result.checks.filter(c => !c.passed);
+            s.lastPreExecFailure = {
+              unitId: currentUnit.id,
+              blockingFindings: warnChecks.map(
+                c => `[${c.category}] ${c.target}: ${c.message}`,
+              ),
+              verdictExcerpt: `status=${result.status} (strict mode); ${warnChecks.length} warning${warnChecks.length === 1 ? "" : "s"} treated as blocking`,
+            };
             preExecPauseNeeded = true;
           }
         }

--- a/src/resources/extensions/gsd/auto-prompts.ts
+++ b/src/resources/extensions/gsd/auto-prompts.ts
@@ -1380,7 +1380,18 @@ async function renderSlicePrompt(options: {
 
 export async function buildPlanSlicePrompt(
   mid: string, _midTitle: string, sid: string, sTitle: string, base: string, level?: InlineLevel,
-  options?: { softScopeHint?: string; sessionContextWindow?: number; modelRegistry?: MinimalModelRegistry },
+  options?: {
+    softScopeHint?: string;
+    sessionContextWindow?: number;
+    modelRegistry?: MinimalModelRegistry;
+    /** Failure context from a prior pre-exec gate run (#4551). When present, a
+     *  "Fix these specific issues" section is appended so the LLM addresses the
+     *  exact problems instead of producing an identical plan that fails again. */
+    priorPreExecFailure?: {
+      blockingFindings: string[];
+      verdictExcerpt: string;
+    };
+  },
 ): Promise<string> {
   const prependBlocks: string[] = [];
   // ADR-011: when the refining-phase dispatch rule gracefully downgrades to
@@ -1391,6 +1402,22 @@ export async function buildPlanSlicePrompt(
     prependBlocks.push(
       `## Prior Sketch Scope (soft hint — non-binding)\n\n${options.softScopeHint.trim()}\n\n` +
       `This scope was captured during an earlier progressive-planning pass that was later disabled. Treat it as context only — you may plan beyond it if the work genuinely requires more scope. Do NOT treat this as a hard boundary.`,
+    );
+  }
+  // #4551: inject pre-exec failure context so the re-dispatched plan-slice
+  // addresses the exact blocked references rather than reproducing the same plan.
+  if (options?.priorPreExecFailure) {
+    const { blockingFindings, verdictExcerpt } = options.priorPreExecFailure;
+    const findingsList = blockingFindings.length > 0
+      ? blockingFindings.map(f => `- ${f}`).join("\n")
+      : "- (no specific findings recorded)";
+    prependBlocks.push(
+      `## Fix these specific issues from the prior pre-exec check\n\n` +
+      `The previous plan-slice attempt was blocked by pre-execution validation.\n` +
+      `Gate verdict: ${verdictExcerpt}\n\n` +
+      `Blocked references that must be resolved in this plan:\n${findingsList}\n\n` +
+      `Revise the plan so that every reference listed above is satisfied before execution begins. ` +
+      `Do not reproduce the same file paths, package names, or task ordering that caused these failures.`,
     );
   }
   return renderSlicePrompt({

--- a/src/resources/extensions/gsd/auto/session.ts
+++ b/src/resources/extensions/gsd/auto/session.ts
@@ -64,6 +64,15 @@ export interface SidecarItem {
   captureId?: string;
 }
 
+export interface PreExecFailure {
+  /** Milestone/slice that failed (e.g. "M001/S02"). */
+  unitId: string;
+  /** Verbatim blocking check strings from the failed gate run. */
+  blockingFindings: string[];
+  /** Condensed gate verdict excerpt for context (status + rationale). */
+  verdictExcerpt: string;
+}
+
 // ─── Constants ───────────────────────────────────────────────────────────────
 
 export const MAX_UNIT_DISPATCHES = 3;
@@ -149,14 +158,7 @@ export class AutoSession {
    * Cleared after it has been consumed (injected into the prompt) to avoid
    * stale context bleeding into unrelated slices.
    */
-  lastPreExecFailure: {
-    /** Milestone/slice that failed (e.g. "M001/S02"). */
-    unitId: string;
-    /** Verbatim blocking check strings from the failed gate run. */
-    blockingFindings: string[];
-    /** Condensed gate verdict excerpt for context (status + rationale). */
-    verdictExcerpt: string;
-  } | null = null;
+  lastPreExecFailure: PreExecFailure | null = null;
 
   // ── Tool invocation errors (#2883) ──────────────────────────────────
   /** Set when a GSD tool execution ends with isError due to malformed/truncated

--- a/src/resources/extensions/gsd/auto/session.ts
+++ b/src/resources/extensions/gsd/auto/session.ts
@@ -139,6 +139,25 @@ export class AutoSession {
   // ── Sidecar queue ─────────────────────────────────────────────────────
   sidecarQueue: SidecarItem[] = [];
 
+  // ── Pre-exec gate failure context (#4551) ───────────────────────────
+  /**
+   * Persisted when a pre-execution gate fails on a plan-slice or refine-slice
+   * unit. The planning → plan-slice dispatch rule reads this field and injects
+   * the failure details into the next re-dispatch prompt so the LLM can fix the
+   * specific issues instead of producing an identical plan.
+   *
+   * Cleared after it has been consumed (injected into the prompt) to avoid
+   * stale context bleeding into unrelated slices.
+   */
+  lastPreExecFailure: {
+    /** Milestone/slice that failed (e.g. "M001/S02"). */
+    unitId: string;
+    /** Verbatim blocking check strings from the failed gate run. */
+    blockingFindings: string[];
+    /** Condensed gate verdict excerpt for context (status + rationale). */
+    verdictExcerpt: string;
+  } | null = null;
+
   // ── Tool invocation errors (#2883) ──────────────────────────────────
   /** Set when a GSD tool execution ends with isError due to malformed/truncated
    *  JSON arguments. Checked by postUnitPreVerification to break retry loops. */
@@ -267,6 +286,7 @@ export class AutoSession {
     this.sidecarQueue = [];
     this.rewriteAttemptCount = 0;
     this.consecutiveCompleteBootstraps = 0;
+    this.lastPreExecFailure = null;
     this.lastToolInvocationError = null;
     this.lastGitActionFailure = null;
     this.lastGitActionStatus = null;

--- a/src/resources/extensions/gsd/tests/pre-exec-gate-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/pre-exec-gate-loop.test.ts
@@ -1,0 +1,272 @@
+/**
+ * pre-exec-gate-loop.test.ts — Regression tests for #4551.
+ *
+ * Verifies that when a pre-execution gate fails on a plan-slice unit:
+ *   1. `s.lastPreExecFailure` is populated on the AutoSession with the blocking
+ *      findings and a verdict excerpt.
+ *   2. The `planning → plan-slice` dispatch rule reads that field and injects a
+ *      "Fix these specific issues" section into the prompt.
+ *   3. The field is cleared (consumed) after the prompt is built so that stale
+ *      context does not bleed into an unrelated future plan-slice run.
+ *   4. When the failure belongs to a *different* unit ID, the dispatch rule
+ *      does NOT inject the stale context into the prompt.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { AutoSession } from "../auto/session.ts";
+import { resolveDispatch } from "../auto-dispatch.ts";
+import type { DispatchContext } from "../auto-dispatch.ts";
+import { buildPlanSlicePrompt } from "../auto-prompts.ts";
+import {
+  openDatabase,
+  closeDatabase,
+  insertMilestone,
+  insertSlice,
+  insertTask,
+} from "../gsd-db.ts";
+import { deriveStateFromDb } from "../state.ts";
+import { _clearGsdRootCache } from "../paths.ts";
+import { invalidateAllCaches } from "../cache.ts";
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeTempBase(): string {
+  const base = mkdtempSync(join(tmpdir(), "gsd-4551-"));
+  mkdirSync(join(base, ".gsd", "milestones", "M001", "slices", "S01"), { recursive: true });
+  mkdirSync(join(base, ".gsd", "milestones", "M001", "slices", "S01", "tasks"), { recursive: true });
+  return base;
+}
+
+function seedPlanningState(base: string): void {
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: "M001", title: "Test Milestone", status: "active" });
+  insertSlice({
+    id: "S01",
+    milestoneId: "M001",
+    title: "Core Slice",
+    status: "pending",
+    risk: "medium",
+    depends: [],
+    demo: "demo",
+    sequence: 1,
+    isSketch: false,
+  });
+  // Write minimal ROADMAP so state derivation doesn't error
+  writeFileSync(
+    join(base, ".gsd", "milestones", "M001", "M001-ROADMAP.md"),
+    "# Roadmap\n",
+  );
+}
+
+function cleanup(base: string, originalCwd: string): void {
+  try { closeDatabase(); } catch { /* noop */ }
+  try { process.chdir(originalCwd); } catch { /* noop */ }
+  try { rmSync(base, { recursive: true, force: true }); } catch { /* noop */ }
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+test("#4551: AutoSession.lastPreExecFailure defaults to null", () => {
+  const s = new AutoSession();
+  assert.equal(s.lastPreExecFailure, null, "lastPreExecFailure must start null");
+});
+
+test("#4551: AutoSession.reset() clears lastPreExecFailure", () => {
+  const s = new AutoSession();
+  s.lastPreExecFailure = {
+    unitId: "M001/S01",
+    blockingFindings: ["[file] src/foo.ts: file not found"],
+    verdictExcerpt: "status=fail; 1 blocking issue detected",
+  };
+  s.reset();
+  assert.equal(s.lastPreExecFailure, null, "reset() must clear lastPreExecFailure");
+});
+
+test("#4551: buildPlanSlicePrompt injects fix section when priorPreExecFailure provided", async (t) => {
+  const originalCwd = process.cwd();
+  const base = makeTempBase();
+  t.after(() => cleanup(base, originalCwd));
+
+  seedPlanningState(base);
+  process.chdir(base);
+  _clearGsdRootCache();
+  invalidateAllCaches();
+
+  const prompt = await buildPlanSlicePrompt(
+    "M001", "Test Milestone", "S01", "Core Slice", base,
+    undefined,
+    {
+      priorPreExecFailure: {
+        blockingFindings: [
+          "[file] src/utils/helper.ts: file not found",
+          "[package] nonexistent-pkg: package not found on npm",
+        ],
+        verdictExcerpt: "status=fail; 2 blocking issues detected",
+      },
+    },
+  );
+
+  assert.ok(
+    prompt.includes("Fix these specific issues from the prior pre-exec check"),
+    "prompt must contain the fix section heading",
+  );
+  assert.ok(
+    prompt.includes("src/utils/helper.ts: file not found"),
+    "prompt must include the specific file finding",
+  );
+  assert.ok(
+    prompt.includes("nonexistent-pkg: package not found on npm"),
+    "prompt must include the specific package finding",
+  );
+  assert.ok(
+    prompt.includes("status=fail; 2 blocking issues detected"),
+    "prompt must include the verdict excerpt",
+  );
+});
+
+test("#4551: buildPlanSlicePrompt with no priorPreExecFailure does NOT include fix section", async (t) => {
+  const originalCwd = process.cwd();
+  const base = makeTempBase();
+  t.after(() => cleanup(base, originalCwd));
+
+  seedPlanningState(base);
+  process.chdir(base);
+  _clearGsdRootCache();
+  invalidateAllCaches();
+
+  const prompt = await buildPlanSlicePrompt(
+    "M001", "Test Milestone", "S01", "Core Slice", base,
+    undefined,
+    { /* no priorPreExecFailure */ },
+  );
+
+  assert.ok(
+    !prompt.includes("Fix these specific issues from the prior pre-exec check"),
+    "prompt must NOT include the fix section when no failure context is given",
+  );
+});
+
+test("#4551: dispatch rule injects failure context and clears session field", async (t) => {
+  const originalCwd = process.cwd();
+  const base = makeTempBase();
+  t.after(() => cleanup(base, originalCwd));
+
+  seedPlanningState(base);
+  // Write a RESEARCH file so the dispatch rule skips research-slice and reaches
+  // plan-slice (which is the phase we're testing).
+  writeFileSync(
+    join(base, ".gsd", "milestones", "M001", "slices", "S01", "S01-RESEARCH.md"),
+    "# Research\n",
+  );
+  process.chdir(base);
+  _clearGsdRootCache();
+  invalidateAllCaches();
+
+  const state = await deriveStateFromDb(base);
+  assert.equal(state.phase, "planning", "state must be in planning phase");
+
+  const session = new AutoSession();
+  session.basePath = base;
+  session.active = true;
+  session.lastPreExecFailure = {
+    unitId: "M001/S01",
+    blockingFindings: ["[file] src/missing.ts: file not found"],
+    verdictExcerpt: "status=fail; 1 blocking issue detected",
+  };
+
+  const ctx: DispatchContext = {
+    basePath: base,
+    mid: "M001",
+    midTitle: "Test Milestone",
+    state,
+    prefs: { phases: { reassess_after_slice: false, skip_research: true } } as any,
+    session,
+  };
+
+  const result = await resolveDispatch(ctx);
+  assert.equal(result.action, "dispatch", "must dispatch a unit");
+  if (result.action !== "dispatch") throw new Error("unreachable");
+  assert.equal(result.unitType, "plan-slice", "must be a plan-slice unit");
+
+  // The fix section must appear in the prompt
+  assert.ok(
+    result.prompt.includes("Fix these specific issues from the prior pre-exec check"),
+    "dispatched prompt must include the fix section",
+  );
+  assert.ok(
+    result.prompt.includes("src/missing.ts: file not found"),
+    "dispatched prompt must include the specific blocking finding",
+  );
+
+  // Field must be cleared after consumption
+  assert.equal(
+    session.lastPreExecFailure,
+    null,
+    "lastPreExecFailure must be cleared after being consumed by the dispatch rule",
+  );
+});
+
+test("#4551: dispatch rule does NOT inject stale failure for a different slice", async (t) => {
+  const originalCwd = process.cwd();
+  const base = makeTempBase();
+  t.after(() => cleanup(base, originalCwd));
+
+  seedPlanningState(base);
+  // Write a RESEARCH file so dispatch reaches plan-slice, making the assertion
+  // about the prompt meaningful (we can check it's a plan-slice prompt without
+  // the fix section rather than a research-slice prompt without it).
+  writeFileSync(
+    join(base, ".gsd", "milestones", "M001", "slices", "S01", "S01-RESEARCH.md"),
+    "# Research\n",
+  );
+  process.chdir(base);
+  _clearGsdRootCache();
+  invalidateAllCaches();
+
+  const state = await deriveStateFromDb(base);
+
+  const session = new AutoSession();
+  session.basePath = base;
+  session.active = true;
+  // Failure belongs to a different slice (S02), not the active one (S01)
+  session.lastPreExecFailure = {
+    unitId: "M001/S02",
+    blockingFindings: ["[file] src/other.ts: file not found"],
+    verdictExcerpt: "status=fail; 1 blocking issue detected",
+  };
+
+  const ctx: DispatchContext = {
+    basePath: base,
+    mid: "M001",
+    midTitle: "Test Milestone",
+    state,
+    prefs: { phases: { reassess_after_slice: false, skip_research: true } } as any,
+    session,
+  };
+
+  const result = await resolveDispatch(ctx);
+  assert.equal(result.action, "dispatch");
+  if (result.action !== "dispatch") throw new Error("unreachable");
+
+  // The stale fix section must NOT appear
+  assert.ok(
+    !result.prompt.includes("Fix these specific issues from the prior pre-exec check"),
+    "prompt must NOT include fix section for a mismatched unit ID",
+  );
+  assert.ok(
+    !result.prompt.includes("src/other.ts"),
+    "prompt must NOT include findings from a different slice",
+  );
+
+  // Field must remain untouched (not consumed)
+  assert.notEqual(
+    session.lastPreExecFailure,
+    null,
+    "lastPreExecFailure must NOT be cleared when unit IDs don't match",
+  );
+});


### PR DESCRIPTION
## Why

Fixes the infinite dispatch loop described in #4551.

When a `plan-slice` unit completed and the pre-execution gate failed (bad file
references, missing packages, impossible task ordering), `auto-post-unit.ts`
paused auto-mode and wrote the evidence JSON — but never attached the failure
details to any state. On resume, the `planning → plan-slice` dispatch rule
called `buildPlanSlicePrompt` with no failure context, so the LLM saw the
same prompt, produced the same plan, and the gate failed again indefinitely.

## What changed

| File | Change |
|---|---|
| `auto/session.ts` | Added `lastPreExecFailure` field (blocking findings + verdict excerpt + unit ID) and cleared it in `reset()` |
| `auto-post-unit.ts` | On `status === "fail"` (and strict-mode `warn`), populate `s.lastPreExecFailure` before calling `pauseAuto` |
| `auto-prompts.ts` | `buildPlanSlicePrompt` accepts optional `priorPreExecFailure` option; when present, prepends a `## Fix these specific issues from the prior pre-exec check` section listing each blocked reference verbatim |
| `auto-dispatch.ts` | `planning → plan-slice` rule reads `session.lastPreExecFailure` (matching unit ID only), passes it to `buildPlanSlicePrompt`, then clears the field so stale context cannot bleed into a later unrelated slice |
| `tests/pre-exec-gate-loop.test.ts` | 6 regression tests using `node:test` + `node:assert/strict` |

## Test plan

- [x] `#4551: AutoSession.lastPreExecFailure defaults to null`
- [x] `#4551: AutoSession.reset() clears lastPreExecFailure`
- [x] `#4551: buildPlanSlicePrompt injects fix section when priorPreExecFailure provided`
- [x] `#4551: buildPlanSlicePrompt with no priorPreExecFailure does NOT include fix section`
- [x] `#4551: dispatch rule injects failure context and clears session field`
- [x] `#4551: dispatch rule does NOT inject stale failure for a different slice`

All 6 pass (`node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/pre-exec-gate-loop.test.ts`).

Closes #4551

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced planning to reference findings from prior pre-execution checks, automatically carrying blocking issues into subsequent planning steps for more targeted guidance
  * Pre-execution failure context is now persisted at the session level and cleared appropriately to prevent reusing stale data

* **Tests**
  * Added comprehensive regression test suite validating pre-execution failure handling, session persistence, and correct planning dispatch behavior under various failure scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->