### PR TITLE
fix(auto): keep footer identical between normal and auto mode

### DIFF
--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -107,7 +107,6 @@ import {
   updateProgressWidget as _updateProgressWidget,
   updateSliceProgressCache,
   unitVerb,
-  hideFooter,
   describeNextUnit,
 } from "./auto-dashboard.js";
 import { existsSync, unlinkSync } from "node:fs";

--- a/src/resources/extensions/gsd/auto-start.ts
+++ b/src/resources/extensions/gsd/auto-start.ts
@@ -61,7 +61,7 @@ import { restoreHookState, resetHookState } from "./post-unit-hooks.js";
 import { resetProactiveHealing, setLevelChangeCallback } from "./doctor-proactive.js";
 import { snapshotSkills } from "./skill-discovery.js";
 import { isDbAvailable, getMilestone, openDatabase, getDbStatus } from "./gsd-db.js";
-import { hideFooter } from "./auto-dashboard.js";
+
 import {
   debugLog,
   enableDebug,
@@ -824,9 +824,6 @@ export async function bootstrapAutoSession(
     }
 
     ctx.ui.setStatus("gsd-auto", s.stepMode ? "next" : "auto");
-    ctx.ui.setFooter(hideFooter);
-    // Hide gsd-health during AUTO — gsd-progress is the single source of truth
-    // for last-commit / cost / health signal while auto is running.
     ctx.ui.setWidget("gsd-health", undefined);
     const modeLabel = s.stepMode ? "Step-mode" : "Auto-mode";
     const pendingCount = (state.registry ?? []).filter(

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -182,7 +182,6 @@ import {
   unitVerb,
   formatAutoElapsed as _formatAutoElapsed,
   formatWidgetTokens,
-  hideFooter,
   type WidgetStateAccessors,
 } from "./auto-dashboard.js";
 import {
@@ -706,7 +705,6 @@ function handleLostSessionLock(
   );
   ctx?.ui.setStatus("gsd-auto", undefined);
   ctx?.ui.setWidget("gsd-progress", undefined);
-  ctx?.ui.setFooter(undefined);
   if (ctx) initHealthWidget(ctx);
 }
 
@@ -742,7 +740,6 @@ function cleanupAfterLoopExit(ctx: ExtensionContext): void {
   if (!s.paused) {
     ctx.ui.setStatus("gsd-auto", undefined);
     ctx.ui.setWidget("gsd-progress", undefined);
-    ctx.ui.setFooter(undefined);
     initHealthWidget(ctx);
   }
 
@@ -1018,7 +1015,6 @@ export async function stopAuto(
     // UI cleanup
     ctx?.ui.setStatus("gsd-auto", undefined);
     ctx?.ui.setWidget("gsd-progress", undefined);
-    ctx?.ui.setFooter(undefined);
     if (ctx) initHealthWidget(ctx);
     restoreProjectRootEnv();
     restoreMilestoneLockEnv();
@@ -1121,7 +1117,6 @@ export async function pauseAuto(
   s.verificationRetryCount.clear();
   ctx?.ui.setStatus("gsd-auto", "paused");
   ctx?.ui.setWidget("gsd-progress", undefined);
-  ctx?.ui.setFooter(undefined);
   if (ctx) initHealthWidget(ctx);
   const resumeCmd = s.stepMode ? "/gsd next" : "/gsd auto";
   ctx?.ui.notify(
@@ -1509,7 +1504,7 @@ export async function startAuto(
     registerSigtermHandler(lockBase());
 
     ctx.ui.setStatus("gsd-auto", s.stepMode ? "next" : "auto");
-    ctx.ui.setFooter(hideFooter);
+    ctx.ui.setWidget("gsd-health", undefined);
     ctx.ui.notify(
       s.stepMode ? "Step-mode resumed." : "Auto-mode resumed.",
       "info",

--- a/src/resources/extensions/gsd/bootstrap/register-hooks.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-hooks.ts
@@ -18,7 +18,7 @@ import { loadToolApiKeys } from "../commands-config.js";
 import { loadFile, saveFile, formatContinue } from "../files.js";
 import { deriveState } from "../state.js";
 import { getAutoDashboardData, isAutoActive, isAutoPaused, markToolEnd, markToolStart, recordToolInvocationError } from "../auto.js";
-import { hideFooter } from "../auto-dashboard.js";
+
 import { isParallelActive, shutdownParallel } from "../parallel-orchestrator.js";
 import { checkToolCallLoop, resetToolCallLoopGuard } from "./tool-call-loop-guard.js";
 import { saveActivityLog } from "../activity-log.js";
@@ -48,7 +48,9 @@ export function registerHooks(
     initNotificationStore(process.cwd());
     installNotifyInterceptor(ctx);
     initNotificationWidget(ctx);
-    initHealthWidget(ctx);
+    if (!isAutoActive()) {
+      initHealthWidget(ctx);
+    }
     resetWriteGateState();
     resetToolCallLoopGuard();
     resetAskUserQuestionsCache();
@@ -90,7 +92,7 @@ export function registerHooks(
     }
     loadToolApiKeys();
     if (isAutoActive()) {
-      ctx.ui.setFooter(hideFooter);
+      ctx.ui.setWidget("gsd-health", undefined);
     }
   });
 
@@ -113,7 +115,7 @@ export function registerHooks(
     }
     loadToolApiKeys();
     if (isAutoActive()) {
-      ctx.ui.setFooter(hideFooter);
+      ctx.ui.setWidget("gsd-health", undefined);
     }
   });
 

--- a/src/resources/extensions/gsd/health-widget.ts
+++ b/src/resources/extensions/gsd/health-widget.ts
@@ -108,6 +108,7 @@ export function initHealthWidget(ctx: ExtensionContext): void {
     let data = initialData;
     let cachedLines: string[] | undefined;
     let refreshInFlight = false;
+    let isDisposed = false;
 
     const refresh = async () => {
       if (refreshInFlight) return;
@@ -115,7 +116,7 @@ export function initHealthWidget(ctx: ExtensionContext): void {
       try {
         data = loadHealthWidgetData(basePath);
         cachedLines = undefined;
-        _tui.requestRender();
+        if (!isDisposed) _tui.requestRender();
       } catch { /* non-fatal */ } finally {
         refreshInFlight = false;
       }
@@ -140,6 +141,7 @@ export function initHealthWidget(ctx: ExtensionContext): void {
       },
       invalidate(): void { cachedLines = undefined; cachedWidth = undefined; },
       dispose(): void {
+        isDisposed = true;
         clearInterval(refreshTimer);
       },
     };

--- a/src/resources/extensions/gsd/tests/session-start-footer.test.ts
+++ b/src/resources/extensions/gsd/tests/session-start-footer.test.ts
@@ -1,19 +1,15 @@
 /**
  * session-start-footer.test.ts
  *
- * Verifies that register-hooks.ts suppresses the built-in footer by calling
- * ctx.ui.setFooter(hideFooter) in both session_start and session_switch when
- * isAutoActive() is true.
+ * Verifies that register-hooks.ts suppresses the gsd-health widget (not the
+ * built-in footer) when isAutoActive() is true, and that setFooter is never
+ * called by the extension in either session_start or session_switch.
  *
  * Testing strategy:
- *   Two layers:
- *   1. Source-code regression guard: ensures the guard and setFooter call are
- *      structurally present in register-hooks.ts for both event handlers.
- *      (node:test does not support mock.module without --experimental-test-module-mocks,
- *       so structural analysis is the correct approach here.)
+ *   1. Source-code regression guards: structural checks on register-hooks.ts.
  *   2. Behavioral integration test: fires the live session_start handler with a
- *      fake ctx when isAutoActive() is false (its default at test time) and
- *      confirms setFooter is NOT called — verifying the guard is conditional.
+ *      fake ctx when isAutoActive() is false (default) and confirms neither
+ *      setFooter nor setWidget("gsd-health") is called.
  *
  * Relates to #4314.
  */
@@ -35,16 +31,14 @@ const HOOKS_SOURCE = readFileSync(
 
 // ─── Source-code regression guards ──────────────────────────────────────────
 
-test("register-hooks.ts imports hideFooter from auto-dashboard", () => {
+test("register-hooks.ts does NOT import hideFooter", () => {
   assert.ok(
-    HOOKS_SOURCE.includes('import { hideFooter } from "../auto-dashboard.js"') ||
-    HOOKS_SOURCE.includes("import { hideFooter } from '../auto-dashboard.js'"),
-    "register-hooks.ts must import hideFooter from auto-dashboard.js",
+    !HOOKS_SOURCE.includes("hideFooter"),
+    "register-hooks.ts must not reference hideFooter — footer is no longer swapped in auto mode",
   );
 });
 
-test("session_start handler calls ctx.ui.setFooter(hideFooter) when isAutoActive()", () => {
-  // Locate the session_start handler body (up to the next pi.on call)
+test("session_start handler guards initHealthWidget with !isAutoActive()", () => {
   const sessionStartIdx = HOOKS_SOURCE.indexOf('"session_start"');
   assert.ok(sessionStartIdx > -1, "session_start handler must exist");
 
@@ -58,20 +52,23 @@ test("session_start handler calls ctx.ui.setFooter(hideFooter) when isAutoActive
     "session_start handler must call isAutoActive()",
   );
   assert.ok(
-    sessionStartBody.includes("ctx.ui.setFooter(hideFooter)"),
-    "session_start handler must call ctx.ui.setFooter(hideFooter)",
+    sessionStartBody.includes("initHealthWidget"),
+    "session_start handler must reference initHealthWidget",
+  );
+  assert.ok(
+    !sessionStartBody.includes("setFooter"),
+    "session_start handler must NOT call setFooter",
   );
 
-  // Guard must wrap the setFooter call
   const guardIdx = sessionStartBody.indexOf("isAutoActive()");
-  const setFooterIdx = sessionStartBody.indexOf("ctx.ui.setFooter(hideFooter)");
+  const healthIdx = sessionStartBody.indexOf("initHealthWidget");
   assert.ok(
-    guardIdx < setFooterIdx,
-    "isAutoActive() guard must appear before ctx.ui.setFooter(hideFooter) in session_start",
+    guardIdx < healthIdx,
+    "isAutoActive() guard must appear before initHealthWidget in session_start",
   );
 });
 
-test("session_switch handler calls ctx.ui.setFooter(hideFooter) when isAutoActive()", () => {
+test("session_switch handler suppresses gsd-health when isAutoActive()", () => {
   const sessionSwitchIdx = HOOKS_SOURCE.indexOf('"session_switch"');
   assert.ok(sessionSwitchIdx > -1, "session_switch handler must exist");
 
@@ -85,21 +82,18 @@ test("session_switch handler calls ctx.ui.setFooter(hideFooter) when isAutoActiv
     "session_switch handler must call isAutoActive()",
   );
   assert.ok(
-    sessionSwitchBody.includes("ctx.ui.setFooter(hideFooter)"),
-    "session_switch handler must call ctx.ui.setFooter(hideFooter)",
+    sessionSwitchBody.includes('setWidget("gsd-health", undefined)'),
+    "session_switch handler must call setWidget(\"gsd-health\", undefined) when auto is active",
   );
-
-  const guardIdx = sessionSwitchBody.indexOf("isAutoActive()");
-  const setFooterIdx = sessionSwitchBody.indexOf("ctx.ui.setFooter(hideFooter)");
   assert.ok(
-    guardIdx < setFooterIdx,
-    "isAutoActive() guard must appear before ctx.ui.setFooter(hideFooter) in session_switch",
+    !sessionSwitchBody.includes("setFooter"),
+    "session_switch handler must NOT call setFooter",
   );
 });
 
-// ─── Behavioral test: setFooter NOT called when auto-mode is inactive ────────
+// ─── Behavioral test: neither setFooter nor health suppression when auto inactive ─
 
-test("session_start does NOT call setFooter when isAutoActive() is false (default)", async (t) => {
+test("session_start does NOT call setFooter or suppress gsd-health when isAutoActive() is false", async (t) => {
   const dir = join(
     tmpdir(),
     `gsd-footer-test-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
@@ -114,6 +108,7 @@ test("session_start does NOT call setFooter when isAutoActive() is false (defaul
   });
 
   let setFooterCallCount = 0;
+  let healthWidgetHideCount = 0;
 
   const handlers = new Map<string, (event: unknown, ctx: any) => Promise<void> | void>();
   const pi = {
@@ -137,17 +132,14 @@ test("session_start does NOT call setFooter when isAutoActive() is false (defaul
       },
       setWorkingMessage: () => {},
       onTerminalInput: () => () => {},
-      setWidget: () => {},
+      setWidget: (key: string, value: unknown) => {
+        if (key === "gsd-health" && value === undefined) healthWidgetHideCount++;
+      },
     },
     sessionManager: { getSessionId: () => null },
     model: null,
   } as any);
 
-  // isAutoActive() is false at test time (no auto session started),
-  // so setFooter must not be called.
-  assert.equal(
-    setFooterCallCount,
-    0,
-    "setFooter must NOT be called when isAutoActive() returns false",
-  );
+  assert.equal(setFooterCallCount, 0, "setFooter must NOT be called when isAutoActive() is false");
+  assert.equal(healthWidgetHideCount, 0, "gsd-health must NOT be hidden when isAutoActive() is false");
 });


### PR DESCRIPTION
## Summary

- Removes all `setFooter(hideFooter)` calls so the built-in 2-line footer is unchanged during `/gsd auto`
- Guards `initHealthWidget` with `!isAutoActive()` in `session_start` to stop health widget re-appearing on every auto dispatch
- Explicitly suppresses `gsd-health` on `session_start`, `session_switch`, and resume paths when auto is active
- Removes dead `hideFooter` import from `auto-post-unit.ts`
- Rewrites `session-start-footer.test.ts` to assert new behavior

Closes #4580

## Test plan

- [ ] Start `/gsd auto` — verify footer looks identical to normal mode
- [ ] Observe no "System OK | Budget" row appearing below the editor during auto
- [ ] Stop/pause/resume auto — verify footer remains stable throughout
- [ ] Run `session-start-footer.test.ts` — all 4 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Switched AUTO-mode UI control from footer-based to widget-based health management; health widget now initialized only when AUTO is inactive.

* **Bug Fixes**
  * Prevented health widget from requesting renders after it has been disposed.

* **Tests**
  * Updated tests to assert the new widget-based suppression behavior and to ensure no footer manipulation occurs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->