### PR TITLE
fix(db): repair invalid quality_gates DDL and add artifact-retry journal event

### DIFF
--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -1928,6 +1928,20 @@ export async function runFinalize(
       debugLog("autoLoop", { phase: "sidecar-artifact-retry-skipped", iteration: ic.iteration });
     } else {
       // s.pendingVerificationRetry was set by postUnitPreVerification.
+      // Emit a dedicated journal event so forensics can distinguish bounded
+      // verification retries from genuine stuck-loop dispatch repetitions (#4540).
+      const retryInfo = s.pendingVerificationRetry;
+      deps.emitJournalEvent({
+        ts: new Date().toISOString(),
+        flowId: ic.flowId,
+        seq: ic.nextSeq(),
+        eventType: "artifact-verification-retry",
+        data: {
+          unitType: preUnitSnapshot?.type,
+          unitId: retryInfo?.unitId,
+          attempt: retryInfo?.attempt,
+        },
+      });
       // Continue the loop — next iteration will inject the retry context into the prompt.
       debugLog("autoLoop", { phase: "artifact-verification-retry", iteration: ic.iteration });
       return { action: "continue" };

--- a/src/resources/extensions/gsd/gsd-db.ts
+++ b/src/resources/extensions/gsd/gsd-db.ts
@@ -180,7 +180,7 @@ function openRawDb(path: string): unknown {
   return new Database(path);
 }
 
-const SCHEMA_VERSION = 21;
+const SCHEMA_VERSION = 22;
 
 function indexExists(db: DbAdapter, name: string): boolean {
   return !!db.prepare(
@@ -949,19 +949,24 @@ function migrateSchema(db: DbAdapter): void {
     }
 
     if (currentVersion < 12) {
+      // NOTE: The original DDL used COALESCE(task_id, '') in the PRIMARY KEY
+      // expression, which is invalid SQLite syntax and causes startup errors on
+      // DBs that migrate through v12. The corrected DDL uses
+      // task_id TEXT NOT NULL DEFAULT '' with a plain column list PK. DBs that
+      // were created with the broken DDL are repaired by the v22 migration below.
       db.exec(`
         CREATE TABLE IF NOT EXISTS quality_gates (
           milestone_id TEXT NOT NULL,
           slice_id TEXT NOT NULL,
           gate_id TEXT NOT NULL,
           scope TEXT NOT NULL DEFAULT 'slice',
-          task_id TEXT DEFAULT NULL,
+          task_id TEXT NOT NULL DEFAULT '',
           status TEXT NOT NULL DEFAULT 'pending',
           verdict TEXT NOT NULL DEFAULT '',
           rationale TEXT NOT NULL DEFAULT '',
           findings TEXT NOT NULL DEFAULT '',
           evaluated_at TEXT DEFAULT NULL,
-          PRIMARY KEY (milestone_id, slice_id, gate_id, COALESCE(task_id, '')),
+          PRIMARY KEY (milestone_id, slice_id, gate_id, task_id),
           FOREIGN KEY (milestone_id, slice_id) REFERENCES slices(milestone_id, id)
         )
       `);
@@ -1185,6 +1190,52 @@ function migrateSchema(db: DbAdapter): void {
       ensureColumn(db, "memories", "structured_fields", "ALTER TABLE memories ADD COLUMN structured_fields TEXT DEFAULT NULL");
       db.prepare("INSERT INTO schema_version (version, applied_at) VALUES (:version, :applied_at)").run({
         ":version": 21,
+        ":applied_at": new Date().toISOString(),
+      });
+    }
+
+    if (currentVersion < 22) {
+      // v22: Repair quality_gates tables that were created by the broken v12
+      // migration (which used COALESCE(task_id, '') as a PK expression — invalid
+      // SQLite DDL). Those DBs have task_id nullable (dflt_value NULL, notnull 0).
+      // Rebuild the table with the correct schema, migrating existing rows via
+      // COALESCE so no data is lost.
+      const qgInfo = db.prepare("PRAGMA table_info(quality_gates)").all() as Array<Record<string, unknown>>;
+      const taskIdCol = qgInfo.find((r) => r["name"] === "task_id");
+      const needsRepair = taskIdCol && (taskIdCol["notnull"] === 0 || taskIdCol["notnull"] === "0");
+      if (needsRepair) {
+        db.exec(`
+          CREATE TABLE quality_gates_new (
+            milestone_id TEXT NOT NULL,
+            slice_id TEXT NOT NULL,
+            gate_id TEXT NOT NULL,
+            scope TEXT NOT NULL DEFAULT 'slice',
+            task_id TEXT NOT NULL DEFAULT '',
+            status TEXT NOT NULL DEFAULT 'pending',
+            verdict TEXT NOT NULL DEFAULT '',
+            rationale TEXT NOT NULL DEFAULT '',
+            findings TEXT NOT NULL DEFAULT '',
+            evaluated_at TEXT DEFAULT NULL,
+            PRIMARY KEY (milestone_id, slice_id, gate_id, task_id),
+            FOREIGN KEY (milestone_id, slice_id) REFERENCES slices(milestone_id, id)
+          )
+        `);
+        db.exec(`
+          INSERT OR IGNORE INTO quality_gates_new
+            (milestone_id, slice_id, gate_id, scope, task_id, status, verdict, rationale, findings, evaluated_at)
+          SELECT milestone_id, slice_id, gate_id, scope, COALESCE(task_id, ''), status, verdict, rationale, findings, evaluated_at
+          FROM quality_gates
+        `);
+        db.exec("DROP TABLE quality_gates");
+        db.exec("ALTER TABLE quality_gates_new RENAME TO quality_gates");
+        db.exec("CREATE INDEX IF NOT EXISTS idx_quality_gates_pending ON quality_gates(milestone_id, slice_id, status)");
+      }
+      // Ensure scope column exists on quality_gates and assessments (guard
+      // against DBs that somehow lack it after a partial migration).
+      ensureColumn(db, "quality_gates", "scope", "ALTER TABLE quality_gates ADD COLUMN scope TEXT NOT NULL DEFAULT 'slice'");
+      ensureColumn(db, "assessments", "scope", "ALTER TABLE assessments ADD COLUMN scope TEXT NOT NULL DEFAULT ''");
+      db.prepare("INSERT INTO schema_version (version, applied_at) VALUES (:version, :applied_at)").run({
+        ":version": 22,
         ":applied_at": new Date().toISOString(),
       });
     }

--- a/src/resources/extensions/gsd/journal.ts
+++ b/src/resources/extensions/gsd/journal.ts
@@ -39,7 +39,8 @@ export type JournalEventType =
   | "worktree-create-failed"
   | "worktree-skip"
   | "worktree-merge-start"
-  | "worktree-merge-failed";
+  | "worktree-merge-failed"
+  | "artifact-verification-retry";
 
 /** A single structured event in the journal. */
 export interface JournalEntry {

--- a/src/resources/extensions/gsd/tests/complete-slice.test.ts
+++ b/src/resources/extensions/gsd/tests/complete-slice.test.ts
@@ -125,9 +125,9 @@ console.log('\n=== complete-slice: schema v6 migration ===');
 
   const adapter = _getAdapter()!;
 
-  // Verify schema version is current (v21 — ADR-013 structured_fields column)
+  // Verify schema version is current (v22 — quality_gates DDL fix)
   const versionRow = adapter.prepare('SELECT MAX(version) as v FROM schema_version').get();
-  assertEq(versionRow?.['v'], 21, 'schema version should be 21');
+  assertEq(versionRow?.['v'], 22, 'schema version should be 22');
 
   // Verify slices table has full_summary_md and full_uat_md columns
   const cols = adapter.prepare("PRAGMA table_info(slices)").all();

--- a/src/resources/extensions/gsd/tests/complete-task.test.ts
+++ b/src/resources/extensions/gsd/tests/complete-task.test.ts
@@ -109,9 +109,9 @@ console.log('\n=== complete-task: schema v5 migration ===');
 
   const adapter = _getAdapter()!;
 
-  // Verify schema version is current (v21 — ADR-013 structured_fields column)
+  // Verify schema version is current (v22 — quality_gates DDL fix)
   const versionRow = adapter.prepare('SELECT MAX(version) as v FROM schema_version').get();
-  assertEq(versionRow?.['v'], 21, 'schema version should be 21');
+  assertEq(versionRow?.['v'], 22, 'schema version should be 22');
 
   // Verify all 4 new tables exist
   const tables = adapter.prepare(

--- a/src/resources/extensions/gsd/tests/ensure-db-open.test.ts
+++ b/src/resources/extensions/gsd/tests/ensure-db-open.test.ts
@@ -389,7 +389,7 @@ describe('ensure-db-open', () => {
       assert.ok(db, 'adapter should be available after ensureDbOpen');
       assert.equal(
         db.prepare('SELECT MAX(version) as version FROM schema_version').get()?.version,
-        21,
+        22,
         'legacy DB should migrate to current schema version',
       );
 

--- a/src/resources/extensions/gsd/tests/escalation.test.ts
+++ b/src/resources/extensions/gsd/tests/escalation.test.ts
@@ -348,7 +348,7 @@ test("ADR-011 P2: schema v20 fresh DB has all escalation columns on tasks + sour
   assert.ok(decCols.includes("source"), "decisions table must have source column");
 
   const version = adapter.prepare("SELECT MAX(version) as v FROM schema_version").get();
-  assert.equal(version?.["v"], 21);
+  assert.equal(version?.["v"], 22);
 });
 
 test("ADR-011 P2: findUnappliedEscalationOverride returns null when escalation_pending=1 (still pending)", (t) => {

--- a/src/resources/extensions/gsd/tests/gsd-db.test.ts
+++ b/src/resources/extensions/gsd/tests/gsd-db.test.ts
@@ -99,7 +99,7 @@ describe('gsd-db', () => {
     // Check schema_version table
     const adapter = _getAdapter()!;
     const version = adapter.prepare('SELECT MAX(version) as version FROM schema_version').get();
-    assert.deepStrictEqual(version?.['version'], 21, 'schema version should be 21');
+    assert.deepStrictEqual(version?.['version'], 22, 'schema version should be 22');
 
     // Check tables exist by querying them
     const dRows = adapter.prepare('SELECT count(*) as cnt FROM decisions').get();

--- a/src/resources/extensions/gsd/tests/issue-4540-regressions.test.ts
+++ b/src/resources/extensions/gsd/tests/issue-4540-regressions.test.ts
@@ -1,0 +1,288 @@
+/**
+ * Regression tests for issue #4540:
+ *   Bug 1 — Invalid quality_gates migration bricks gsd.db
+ *   Bug 2 — Artifact retries emit no journal event, look like stuck loops
+ */
+import { describe, test, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { createRequire } from "node:module";
+
+import {
+  openDatabase,
+  closeDatabase,
+  insertGateRow,
+  getPendingGates,
+  _getAdapter,
+} from "../gsd-db.ts";
+
+import { emitJournalEvent, queryJournal } from "../journal.ts";
+
+const _require = createRequire(import.meta.url);
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+function tmpDb(): { dir: string; dbPath: string } {
+  const dir = mkdtempSync(join(tmpdir(), "gsd-4540-"));
+  return { dir, dbPath: join(dir, "gsd.db") };
+}
+
+function cleanup(dir: string): void {
+  try { rmSync(dir, { recursive: true, force: true }); } catch { /* ignore */ }
+}
+
+/**
+ * Builds a v12 database with the broken quality_gates DDL:
+ * task_id is nullable and there is no proper multi-column PK.
+ * This simulates a DB that was created before the v12 fix was applied.
+ */
+function createBrokenV12Db(dbPath: string): void {
+  const sqlite = _require("node:sqlite");
+  const db = new sqlite.DatabaseSync(dbPath);
+  db.exec("PRAGMA journal_mode=WAL");
+
+  db.exec(`CREATE TABLE schema_version (version INTEGER NOT NULL, applied_at TEXT NOT NULL)`);
+  db.prepare("INSERT INTO schema_version (version, applied_at) VALUES (?, ?)").run(12, "2025-01-01T00:00:00.000Z");
+
+  db.exec(`
+    CREATE TABLE decisions (
+      seq INTEGER PRIMARY KEY AUTOINCREMENT, id TEXT NOT NULL UNIQUE,
+      when_context TEXT NOT NULL DEFAULT '', scope TEXT NOT NULL DEFAULT '',
+      decision TEXT NOT NULL DEFAULT '', choice TEXT NOT NULL DEFAULT '',
+      rationale TEXT NOT NULL DEFAULT '', revisable TEXT NOT NULL DEFAULT '',
+      made_by TEXT NOT NULL DEFAULT 'agent', superseded_by TEXT DEFAULT NULL
+    );
+    CREATE VIEW active_decisions AS SELECT * FROM decisions WHERE superseded_by IS NULL;
+    CREATE TABLE requirements (
+      id TEXT PRIMARY KEY, class TEXT NOT NULL DEFAULT '', status TEXT NOT NULL DEFAULT '',
+      description TEXT NOT NULL DEFAULT '', why TEXT NOT NULL DEFAULT '',
+      source TEXT NOT NULL DEFAULT '', primary_owner TEXT NOT NULL DEFAULT '',
+      supporting_slices TEXT NOT NULL DEFAULT '', validation TEXT NOT NULL DEFAULT '',
+      notes TEXT NOT NULL DEFAULT '', full_content TEXT NOT NULL DEFAULT '',
+      superseded_by TEXT DEFAULT NULL
+    );
+    CREATE TABLE artifacts (
+      path TEXT PRIMARY KEY, artifact_type TEXT NOT NULL DEFAULT '',
+      milestone_id TEXT DEFAULT NULL, slice_id TEXT DEFAULT NULL, task_id TEXT DEFAULT NULL,
+      full_content TEXT NOT NULL DEFAULT '', imported_at TEXT NOT NULL DEFAULT ''
+    );
+    CREATE TABLE memories (
+      seq INTEGER PRIMARY KEY AUTOINCREMENT, id TEXT NOT NULL UNIQUE,
+      category TEXT NOT NULL, content TEXT NOT NULL, confidence REAL NOT NULL DEFAULT 0.8,
+      source_unit_type TEXT, source_unit_id TEXT, created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL, superseded_by TEXT DEFAULT NULL,
+      hit_count INTEGER NOT NULL DEFAULT 0,
+      scope TEXT NOT NULL DEFAULT 'project', tags TEXT NOT NULL DEFAULT '[]',
+      structured_fields TEXT DEFAULT NULL
+    );
+    CREATE TABLE memory_sources (
+      id TEXT PRIMARY KEY, kind TEXT NOT NULL DEFAULT '', path TEXT DEFAULT NULL,
+      imported_at TEXT NOT NULL DEFAULT '',
+      scope TEXT NOT NULL DEFAULT 'project', tags TEXT NOT NULL DEFAULT '[]'
+    );
+    CREATE TABLE memory_relations (
+      from_id TEXT NOT NULL, to_id TEXT NOT NULL, relation TEXT NOT NULL DEFAULT '',
+      PRIMARY KEY (from_id, to_id)
+    );
+    CREATE TABLE memory_processed_units (
+      unit_key TEXT PRIMARY KEY, activity_file TEXT, processed_at TEXT NOT NULL
+    );
+    CREATE TABLE milestones (
+      id TEXT PRIMARY KEY, title TEXT NOT NULL DEFAULT '', status TEXT NOT NULL DEFAULT 'active',
+      depends_on TEXT NOT NULL DEFAULT '[]', created_at TEXT NOT NULL DEFAULT '',
+      completed_at TEXT DEFAULT NULL, vision TEXT NOT NULL DEFAULT '',
+      success_criteria TEXT NOT NULL DEFAULT '[]', key_risks TEXT NOT NULL DEFAULT '[]',
+      proof_strategy TEXT NOT NULL DEFAULT '[]', verification_contract TEXT NOT NULL DEFAULT '',
+      verification_integration TEXT NOT NULL DEFAULT '',
+      verification_operational TEXT NOT NULL DEFAULT '', verification_uat TEXT NOT NULL DEFAULT '',
+      definition_of_done TEXT NOT NULL DEFAULT '[]', requirement_coverage TEXT NOT NULL DEFAULT '',
+      boundary_map_markdown TEXT NOT NULL DEFAULT ''
+    );
+    CREATE TABLE slices (
+      milestone_id TEXT NOT NULL, id TEXT NOT NULL, title TEXT NOT NULL DEFAULT '',
+      status TEXT NOT NULL DEFAULT 'pending', risk TEXT NOT NULL DEFAULT 'medium',
+      depends TEXT NOT NULL DEFAULT '[]', demo TEXT NOT NULL DEFAULT '',
+      created_at TEXT NOT NULL DEFAULT '', completed_at TEXT DEFAULT NULL,
+      full_summary_md TEXT NOT NULL DEFAULT '', full_uat_md TEXT NOT NULL DEFAULT '',
+      goal TEXT NOT NULL DEFAULT '', success_criteria TEXT NOT NULL DEFAULT '',
+      proof_level TEXT NOT NULL DEFAULT '', integration_closure TEXT NOT NULL DEFAULT '',
+      observability_impact TEXT NOT NULL DEFAULT '', sequence INTEGER DEFAULT 0,
+      replan_triggered_at TEXT DEFAULT NULL,
+      is_sketch INTEGER NOT NULL DEFAULT 0, sketch_scope TEXT NOT NULL DEFAULT '',
+      PRIMARY KEY (milestone_id, id), FOREIGN KEY (milestone_id) REFERENCES milestones(id)
+    );
+    CREATE TABLE tasks (
+      milestone_id TEXT NOT NULL, slice_id TEXT NOT NULL, id TEXT NOT NULL,
+      title TEXT NOT NULL DEFAULT '', status TEXT NOT NULL DEFAULT 'pending',
+      one_liner TEXT NOT NULL DEFAULT '', narrative TEXT NOT NULL DEFAULT '',
+      verification_result TEXT NOT NULL DEFAULT '',
+      escalation_pending INTEGER NOT NULL DEFAULT 0,
+      PRIMARY KEY (milestone_id, slice_id, id),
+      FOREIGN KEY (milestone_id, slice_id) REFERENCES slices(milestone_id, id)
+    );
+    CREATE TABLE assessments (
+      path TEXT PRIMARY KEY, milestone_id TEXT NOT NULL DEFAULT '',
+      slice_id TEXT DEFAULT NULL, task_id TEXT DEFAULT NULL,
+      status TEXT NOT NULL DEFAULT '', scope TEXT NOT NULL DEFAULT '',
+      full_content TEXT NOT NULL DEFAULT '', created_at TEXT NOT NULL DEFAULT '',
+      FOREIGN KEY (milestone_id) REFERENCES milestones(id)
+    );
+    CREATE TABLE replan_history (
+      id INTEGER PRIMARY KEY AUTOINCREMENT, milestone_id TEXT NOT NULL,
+      slice_id TEXT DEFAULT NULL, task_id TEXT DEFAULT NULL,
+      reason TEXT NOT NULL DEFAULT '', created_at TEXT NOT NULL DEFAULT ''
+    );
+    CREATE TABLE verification_evidence (
+      id INTEGER PRIMARY KEY AUTOINCREMENT, milestone_id TEXT NOT NULL DEFAULT '',
+      slice_id TEXT NOT NULL DEFAULT '', task_id TEXT NOT NULL DEFAULT '',
+      unit_type TEXT NOT NULL DEFAULT '', unit_id TEXT NOT NULL DEFAULT '',
+      evidence_type TEXT NOT NULL DEFAULT '', content TEXT NOT NULL DEFAULT '',
+      created_at TEXT NOT NULL DEFAULT '',
+      command TEXT NOT NULL DEFAULT '', verdict TEXT NOT NULL DEFAULT ''
+    );
+  `);
+
+  // Broken quality_gates: task_id nullable, no multi-column PK
+  db.exec(`
+    CREATE TABLE quality_gates (
+      milestone_id TEXT NOT NULL, slice_id TEXT NOT NULL, gate_id TEXT NOT NULL,
+      scope TEXT NOT NULL DEFAULT 'slice', task_id TEXT DEFAULT NULL,
+      status TEXT NOT NULL DEFAULT 'pending', verdict TEXT NOT NULL DEFAULT '',
+      rationale TEXT NOT NULL DEFAULT '', findings TEXT NOT NULL DEFAULT '',
+      evaluated_at TEXT DEFAULT NULL,
+      FOREIGN KEY (milestone_id, slice_id) REFERENCES slices(milestone_id, id)
+    )
+  `);
+
+  // Parent rows + gate row with NULL task_id
+  db.prepare("INSERT INTO milestones (id, title, status) VALUES (?, ?, ?)").run("M001", "Milestone 1", "active");
+  db.prepare("INSERT INTO slices (milestone_id, id, title, status, risk, depends) VALUES (?, ?, ?, ?, ?, ?)").run("M001", "S01", "Slice 1", "pending", "medium", "[]");
+  db.prepare("INSERT INTO quality_gates (milestone_id, slice_id, gate_id, scope, task_id, status) VALUES (?, ?, ?, ?, ?, ?)").run("M001", "S01", "Q3", "slice", null, "pending");
+
+  db.close();
+}
+
+// ─── Bug 1 tests ─────────────────────────────────────────────────────────────
+
+describe("Bug 1 — quality_gates migration repair (#4540)", () => {
+  let dir: string;
+  let dbPath: string;
+
+  beforeEach(() => {
+    ({ dir, dbPath } = tmpDb());
+  });
+
+  afterEach(() => {
+    closeDatabase();
+    cleanup(dir);
+  });
+
+  test("fresh DB: quality_gates task_id is NOT NULL with empty-string default", () => {
+    openDatabase(dbPath);
+    const adapter = _getAdapter()!;
+    const cols = adapter.prepare("PRAGMA table_info(quality_gates)").all() as Array<Record<string, unknown>>;
+    const col = cols.find((c) => c["name"] === "task_id");
+    assert.ok(col, "task_id column must exist");
+    assert.equal(col["notnull"], 1, "task_id must be NOT NULL");
+    assert.equal(col["dflt_value"], "''", "task_id default must be ''");
+  });
+
+  test("fresh DB: insertGateRow with no taskId stores '' and is idempotent", () => {
+    openDatabase(dbPath);
+    const adapter = _getAdapter()!;
+    adapter.prepare("INSERT OR IGNORE INTO milestones (id, title, status) VALUES (?, ?, ?)").run("M001", "Test", "active");
+    adapter.prepare("INSERT OR IGNORE INTO slices (milestone_id, id, title, status, risk, depends) VALUES (?, ?, ?, ?, ?, ?)").run("M001", "S01", "Slice", "pending", "medium", "[]");
+
+    insertGateRow({ milestoneId: "M001", sliceId: "S01", gateId: "Q3", scope: "slice" });
+    insertGateRow({ milestoneId: "M001", sliceId: "S01", gateId: "Q3", scope: "slice" });
+    const rows = getPendingGates("M001", "S01");
+    assert.equal(rows.length, 1);
+    assert.equal(rows[0].task_id, "");
+  });
+
+  test("v22 repair: broken v12 DB opens without error", () => {
+    createBrokenV12Db(dbPath);
+    assert.doesNotThrow(() => openDatabase(dbPath));
+  });
+
+  test("v22 repair: task_id becomes NOT NULL after healing broken v12 DB", () => {
+    createBrokenV12Db(dbPath);
+    openDatabase(dbPath);
+    const adapter = _getAdapter()!;
+    const cols = adapter.prepare("PRAGMA table_info(quality_gates)").all() as Array<Record<string, unknown>>;
+    const col = cols.find((c) => c["name"] === "task_id");
+    assert.ok(col, "task_id column must exist after repair");
+    assert.equal(col["notnull"], 1, "task_id must be NOT NULL after repair");
+  });
+
+  test("v22 repair: existing NULL task_id row is COALESCE'd to '' during repair", () => {
+    createBrokenV12Db(dbPath);
+    openDatabase(dbPath);
+    const adapter = _getAdapter()!;
+    const row = adapter.prepare(
+      "SELECT task_id FROM quality_gates WHERE milestone_id = 'M001' AND slice_id = 'S01' AND gate_id = 'Q3'"
+    ).get() as Record<string, unknown> | undefined;
+    assert.ok(row, "original gate row must survive the repair migration");
+    assert.equal(row["task_id"], "", "NULL task_id must be repaired to ''");
+  });
+
+  test("v22 repair: scope column present on quality_gates after open", () => {
+    openDatabase(dbPath);
+    const adapter = _getAdapter()!;
+    const cols = adapter.prepare("PRAGMA table_info(quality_gates)").all() as Array<Record<string, unknown>>;
+    assert.ok(cols.some((c) => c["name"] === "scope"), "quality_gates.scope must exist");
+  });
+
+  test("v22 repair: scope column present on assessments after open", () => {
+    openDatabase(dbPath);
+    const adapter = _getAdapter()!;
+    const cols = adapter.prepare("PRAGMA table_info(assessments)").all() as Array<Record<string, unknown>>;
+    assert.ok(cols.some((c) => c["name"] === "scope"), "assessments.scope must exist");
+  });
+});
+
+// ─── Bug 2 tests ─────────────────────────────────────────────────────────────
+
+describe("Bug 2 — artifact-verification-retry journal event (#4540)", () => {
+  test("emitJournalEvent accepts artifact-verification-retry event type", () => {
+    const basePath = mkdtempSync(join(tmpdir(), "gsd-journal-4540-"));
+    try {
+      mkdirSync(join(basePath, ".gsd"), { recursive: true });
+      emitJournalEvent(basePath, {
+        ts: new Date().toISOString(),
+        flowId: "flow-4540",
+        seq: 1,
+        eventType: "artifact-verification-retry",
+        data: { unitType: "plan-slice", unitId: "M001/S01", attempt: 1 },
+      });
+      const entries = queryJournal(basePath, { flowId: "flow-4540" });
+      assert.equal(entries.length, 1);
+      assert.equal(entries[0].eventType, "artifact-verification-retry");
+    } finally {
+      rmSync(basePath, { recursive: true, force: true });
+    }
+  });
+
+  test("artifact-verification-retry event carries attempt count", () => {
+    const basePath = mkdtempSync(join(tmpdir(), "gsd-journal-4540b-"));
+    try {
+      mkdirSync(join(basePath, ".gsd"), { recursive: true });
+      emitJournalEvent(basePath, {
+        ts: new Date().toISOString(),
+        flowId: "flow-4540b",
+        seq: 1,
+        eventType: "artifact-verification-retry",
+        data: { unitType: "exec-slice", unitId: "M002/S02", attempt: 2 },
+      });
+      const entries = queryJournal(basePath, { flowId: "flow-4540b", eventType: "artifact-verification-retry" });
+      assert.equal(entries.length, 1);
+      const payload = entries[0].data as Record<string, unknown>;
+      assert.equal(payload["attempt"], 2);
+      assert.equal(payload["unitId"], "M002/S02");
+    } finally {
+      rmSync(basePath, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/resources/extensions/gsd/tests/md-importer.test.ts
+++ b/src/resources/extensions/gsd/tests/md-importer.test.ts
@@ -363,7 +363,7 @@ test('md-importer: schema v1→v2 migration', () => {
   openDatabase(':memory:');
   const adapter = _getAdapter();
   const version = adapter?.prepare('SELECT MAX(version) as v FROM schema_version').get();
-  assert.deepStrictEqual(version?.v, 21, 'new DB should be at schema version 21');
+  assert.deepStrictEqual(version?.v, 22, 'new DB should be at schema version 22');
 
   // Artifacts table should exist
   const tableCheck = adapter?.prepare("SELECT count(*) as c FROM sqlite_master WHERE type='table' AND name='artifacts'").get();

--- a/src/resources/extensions/gsd/tests/memory-store.test.ts
+++ b/src/resources/extensions/gsd/tests/memory-store.test.ts
@@ -323,9 +323,9 @@ test('memory-store: schema includes memories table', () => {
   const viewCount = adapter.prepare('SELECT count(*) as cnt FROM active_memories').get();
   assert.deepStrictEqual(viewCount?.['cnt'], 0, 'active_memories view should exist');
 
-  // Verify schema version is 21 (ADR-013 structured_fields column included)
+  // Verify schema version is 22 (v22 quality_gates DDL fix included)
   const version = adapter.prepare('SELECT MAX(version) as v FROM schema_version').get();
-  assert.deepStrictEqual(version?.["v"], 21, 'schema version should be 21');
+  assert.deepStrictEqual(version?.["v"], 22, 'schema version should be 22');
 
   closeDatabase();
 });


### PR DESCRIPTION
## Why

Closes #4540

Two bugs that could brick `gsd.db` or mislead forensics:

**Bug 1 — Invalid SQLite DDL in v12 migration**

The original `quality_gates` `CREATE TABLE` in the v12 migration used `COALESCE(task_id, '')` as an expression inside the `PRIMARY KEY` clause. SQLite does not allow expressions (only column names) in table-level `PRIMARY KEY` definitions. Any DB migrating through schema v12 would fail to open with a "no such column" startup error.

**Bug 2 — Artifact retries invisible to forensics**

`postUnitPreVerification` set `s.pendingVerificationRetry` and returned `"retry"`, but no journal event was emitted. Forensics observed repeated dispatch of the same unit and reported it as a stuck loop when it was a bounded, intentional verification retry.

## What

- **`gsd-db.ts` v12 migration**: Replace `COALESCE(task_id, '')` expression PK with `task_id TEXT NOT NULL DEFAULT ''` + plain `PRIMARY KEY (milestone_id, slice_id, gate_id, task_id)`.
- **`gsd-db.ts` v22 repair migration**: Detect broken tables (task_id nullable), rebuild `quality_gates` via `COALESCE(task_id, '')` on existing rows, and ensure `scope` columns exist on `quality_gates` and `assessments`. Bump `SCHEMA_VERSION` to 22.
- **`journal.ts`**: Add `"artifact-verification-retry"` to `JournalEventType` union.
- **`auto/phases.ts`**: Emit `artifact-verification-retry` journal event (with `unitType`, `unitId`, `attempt`) in `runFinalize()` when `preResult === "retry"`.
- **`tests/issue-4540-regressions.test.ts`**: 9 regression tests (node:test + node:assert/strict) covering both bugs.
- **`tests/ensure-db-open.test.ts`**: Update expected schema version 21 → 22.

## Test plan

- [x] All 25 tests across gate-storage, ensure-db-open, and issue-4540-regressions pass
- [x] Fresh DB: `quality_gates.task_id` is `NOT NULL DEFAULT ''`
- [x] Broken v12 DB (nullable task_id) heals on open, existing rows preserved with COALESCE
- [x] `artifact-verification-retry` event round-trips through `emitJournalEvent` / `queryJournal`

🤖 Generated with [Claude Code](https://claude.com/claude-code)