### PR TITLE
fix(gsd-extension): default permission mode to acceptEdits to prevent silent tool denial

### DIFF
--- a/src/resources/extensions/claude-code-cli/stream-adapter.ts
+++ b/src/resources/extensions/claude-code-cli/stream-adapter.ts
@@ -692,18 +692,16 @@ export function makeAbortedMessage(model: string, lastTextContent: string): Assi
 /**
  * Resolve the Claude Code permission mode for the current run.
  *
- * GSD subagents run underneath a host Claude Code session the user has
- * already consented to, and their work (edits, shell inspection, MCP calls)
- * spans the full workflow toolset. Defaulting the inner SDK to
- * `bypassPermissions` avoids per-tool approval prompts that offer no
- * meaningful safety beyond what the host session and the subagent prompts
- * already enforce. `GSD_CLAUDE_CODE_PERMISSION_MODE` lets security-conscious
- * users opt into a stricter mode (`acceptEdits`, `default`, `plan`).
+ * Defaults to `acceptEdits`, which auto-approves file reads/edits but
+ * surfaces a permission dialog for dangerous operations (e.g. general Bash,
+ * Agent, WebFetch). This prevents tools outside the allowlist from being
+ * silently denied — the SDK emits an `extension_ui_request` event so the
+ * user sees a prompt instead of a silent refusal that Claude Code mistakes
+ * for user rejection (#4383).
  *
- * Tradeoff: bypass means a prompt-injection payload read from an untrusted
- * file could trigger tool calls without a second gate. Accepted for GSD
- * because the workflow is explicit user intent and the alternative
- * (#4099) is continuous approval fatigue that blocks real work.
+ * Set `GSD_CLAUDE_CODE_PERMISSION_MODE` to `bypassPermissions` to restore
+ * the old always-approve behaviour, or to `default` / `plan` for stricter
+ * modes.
  */
 export async function resolveClaudePermissionMode(
 	env: NodeJS.ProcessEnv = process.env,
@@ -712,7 +710,7 @@ export async function resolveClaudePermissionMode(
 	if (override === "bypassPermissions" || override === "acceptEdits" || override === "default" || override === "plan") {
 		return override;
 	}
-	return "bypassPermissions";
+	return "acceptEdits";
 }
 
 // NOTE: These helpers intentionally mirror @gsd/pi-ai anthropic-shared
@@ -772,7 +770,7 @@ export function buildSdkOptions(
 ): Record<string, unknown> {
 	const { reasoning, ...sdkExtraOptions } = extraOptions;
 	const mcpServers = buildWorkflowMcpServers();
-	const permissionMode = overrides?.permissionMode ?? "bypassPermissions";
+	const permissionMode = overrides?.permissionMode ?? "acceptEdits";
 	const disallowedTools = ["AskUserQuestion"];
 	// Pre-authorize the safe built-ins and every registered workflow MCP
 	// server's tools. `acceptEdits` mode (the interactive default) only

--- a/src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts
+++ b/src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts
@@ -1216,11 +1216,15 @@ describe("stream-adapter — permission mode (F10)", () => {
 		}
 	}
 
-	test("buildSdkOptions defaults to bypassPermissions for backwards compatibility", () => {
+	test("buildSdkOptions defaults to acceptEdits (#4383)", () => {
 		clearWorkflowMcpEnv();
 		const opts = buildSdkOptions("claude-sonnet-4-6", "test");
-		assert.equal(opts.permissionMode, "bypassPermissions");
-		assert.equal(opts.allowDangerouslySkipPermissions, true);
+		assert.equal(opts.permissionMode, "acceptEdits");
+		assert.equal(
+			opts.allowDangerouslySkipPermissions,
+			false,
+			"allowDangerouslySkipPermissions must be false when permissionMode is acceptEdits",
+		);
 	});
 
 	test("buildSdkOptions respects explicit acceptEdits override", () => {
@@ -1232,6 +1236,11 @@ describe("stream-adapter — permission mode (F10)", () => {
 			false,
 			"allowDangerouslySkipPermissions must be false for non-bypass modes",
 		);
+	});
+
+	test("resolveClaudePermissionMode defaults to acceptEdits when no env var is set (#4383)", async () => {
+		const mode = await resolveClaudePermissionMode({});
+		assert.equal(mode, "acceptEdits");
 	});
 
 	test("resolveClaudePermissionMode honours the GSD_CLAUDE_CODE_PERMISSION_MODE env override", async () => {


### PR DESCRIPTION
## Why

Closes #4383

`resolveClaudePermissionMode()` defaulted to `"bypassPermissions"`, which sets `allowDangerouslySkipPermissions: true` on the SDK query. The `allowedTools` list permits only `Read`, `Write`, `Edit`, `Glob`, `Grep`, `Bash(ls:*)`, `Bash(pwd)`, and `mcp__gsd-workflow__*`. When Claude Code attempted any tool not on that list (e.g. general `Bash`, `Agent`, `WebFetch`), the call was silently denied — no `extension_ui_request` event was emitted, no permission dialog shown, and Claude Code interpreted the denial as user refusal.

## What

- Changed the default return value of `resolveClaudePermissionMode()` from `"bypassPermissions"` to `"acceptEdits"` — auto-approves file reads/edits but prompts for dangerous operations
- Updated the `buildSdkOptions()` fallback for `overrides?.permissionMode` from `"bypassPermissions"` to `"acceptEdits"` for consistency
- Updated the JSDoc comment on `resolveClaudePermissionMode()` to reflect the new default and document the escape hatch (`GSD_CLAUDE_CODE_PERMISSION_MODE=bypassPermissions`)
- Updated the existing F10 test (`buildSdkOptions defaults to bypassPermissions`) to assert `acceptEdits` and `allowDangerouslySkipPermissions: false`
- Added regression test: `resolveClaudePermissionMode({})` returns `"acceptEdits"` when no env var is set

## Test plan

- [ ] `npm run test:unit` passes (stream-adapter F10 suite: `buildSdkOptions defaults to acceptEdits (#4383)` and `resolveClaudePermissionMode defaults to acceptEdits when no env var is set (#4383)`)
- [ ] `GSD_CLAUDE_CODE_PERMISSION_MODE=bypassPermissions` still restores old behaviour (covered by existing override test)
- [ ] Tools outside the allowlist (e.g. `WebFetch`) now surface a permission prompt instead of being silently denied