### PR TITLE
feat(gsd-exec): add clean-root preflight gate + auto-stash to milestone completion

### DIFF
--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -126,6 +126,7 @@ import {
   formatTokenCount,
 } from "./metrics.js";
 import { setLogBasePath, logWarning, logError } from "./workflow-logger.js";
+import { preflightCleanRoot, postflightPopStash } from "./clean-root-preflight.js";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
@@ -1292,6 +1293,10 @@ function buildLoopDeps(): LoopDeps {
 
     // Journal
     emitJournalEvent: (entry: JournalEntry) => _emitJournalEvent(s.basePath, entry),
+
+    // Clean-root preflight gate (#2909)
+    preflightCleanRoot,
+    postflightPopStash,
   } as unknown as LoopDeps;
 }
 

--- a/src/resources/extensions/gsd/auto/loop-deps.ts
+++ b/src/resources/extensions/gsd/auto/loop-deps.ts
@@ -22,6 +22,7 @@ import type { CmuxLogLevel } from "../../cmux/index.js";
 import type { JournalEntry } from "../journal.js";
 import type { MergeReconcileResult } from "../auto-recovery.js";
 import type { UokTurnObserver } from "../uok/contracts.js";
+import type { PreflightResult } from "../clean-root-preflight.js";
 
 /**
  * Dependencies injected by the caller (auto.ts startAuto) so autoLoop
@@ -121,6 +122,18 @@ export interface LoopDeps {
     fileType: string,
   ) => string | null;
   reconcileMergeState: (basePath: string, ctx: ExtensionContext) => MergeReconcileResult;
+
+  // Clean-root preflight gate (#2909)
+  preflightCleanRoot: (
+    basePath: string,
+    milestoneId: string,
+    notify: (message: string, level: "info" | "warning" | "error") => void,
+  ) => PreflightResult;
+  postflightPopStash: (
+    basePath: string,
+    milestoneId: string,
+    notify: (message: string, level: "info" | "warning" | "error") => void,
+  ) => void;
 
   // Budget/context/secrets
   getLedger: () => unknown;

--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -545,6 +545,12 @@ export async function runPreDispatch(
     loopState.stuckRecoveryAttempts = 0;
 
     // Worktree lifecycle on milestone transition — merge current, enter next
+    // #2909: preflight — warn + stash dirty working tree before merge
+    const preflightTransition = deps.preflightCleanRoot(
+      s.originalBasePath || s.basePath,
+      s.currentMilestoneId!,
+      ctx.ui.notify.bind(ctx.ui),
+    );
     try {
       deps.resolver.mergeAndExit(s.currentMilestoneId!, ctx.ui);
     } catch (mergeErr) {
@@ -565,6 +571,14 @@ export async function runPreDispatch(
       );
       await deps.stopAuto(ctx, pi, `Merge error on milestone ${s.currentMilestoneId}: ${String(mergeErr)}`);
       return { action: "break", reason: "merge-failed" };
+    }
+    // #2909: postflight — restore stashed changes after successful merge
+    if (preflightTransition.stashPushed) {
+      deps.postflightPopStash(
+        s.originalBasePath || s.basePath,
+        s.currentMilestoneId!,
+        ctx.ui.notify.bind(ctx.ui),
+      );
     }
 
     // PR creation (auto_pr) is handled inside mergeMilestoneToMain (#2302)
@@ -644,6 +658,12 @@ export async function runPreDispatch(
     if (incomplete.length === 0 && state.registry.length > 0) {
       // All milestones complete — merge milestone branch before stopping
       if (s.currentMilestoneId) {
+        // #2909: preflight — warn + stash dirty working tree before merge
+        const preflightAllComplete = deps.preflightCleanRoot(
+          s.originalBasePath || s.basePath,
+          s.currentMilestoneId,
+          ctx.ui.notify.bind(ctx.ui),
+        );
         try {
           deps.resolver.mergeAndExit(s.currentMilestoneId, ctx.ui);
           // Prevent stopAuto from attempting the same merge (#2645)
@@ -664,6 +684,14 @@ export async function runPreDispatch(
           );
           await deps.stopAuto(ctx, pi, `Merge error on milestone ${s.currentMilestoneId}: ${String(mergeErr)}`);
           return { action: "break", reason: "merge-failed" };
+        }
+        // #2909: postflight — restore stashed changes after successful merge
+        if (preflightAllComplete.stashPushed) {
+          deps.postflightPopStash(
+            s.originalBasePath || s.basePath,
+            s.currentMilestoneId,
+            ctx.ui.notify.bind(ctx.ui),
+          );
         }
 
         // PR creation (auto_pr) is handled inside mergeMilestoneToMain (#2302)
@@ -758,6 +786,12 @@ export async function runPreDispatch(
   if (state.phase === "complete") {
     // Milestone merge on complete (before closeout so branch state is clean)
     if (s.currentMilestoneId) {
+      // #2909: preflight — warn + stash dirty working tree before merge
+      const preflightComplete = deps.preflightCleanRoot(
+        s.originalBasePath || s.basePath,
+        s.currentMilestoneId,
+        ctx.ui.notify.bind(ctx.ui),
+      );
       try {
         deps.resolver.mergeAndExit(s.currentMilestoneId, ctx.ui);
         // Prevent stopAuto from attempting the same merge (#2645)
@@ -778,6 +812,14 @@ export async function runPreDispatch(
         );
         await deps.stopAuto(ctx, pi, `Merge error on milestone ${s.currentMilestoneId}: ${String(mergeErr)}`);
         return { action: "break", reason: "merge-failed" };
+      }
+      // #2909: postflight — restore stashed changes after successful merge
+      if (preflightComplete.stashPushed) {
+        deps.postflightPopStash(
+          s.originalBasePath || s.basePath,
+          s.currentMilestoneId,
+          ctx.ui.notify.bind(ctx.ui),
+        );
       }
 
       // PR creation (auto_pr) is handled inside mergeMilestoneToMain (#2302)

--- a/src/resources/extensions/gsd/clean-root-preflight.ts
+++ b/src/resources/extensions/gsd/clean-root-preflight.ts
@@ -1,0 +1,111 @@
+/**
+ * clean-root-preflight.ts — Preflight gate for dirty working trees before milestone merges.
+ *
+ * #2909: Adds a fast-path git status check before milestone completion merges.
+ * When the working tree is dirty the user is warned and changes are auto-stashed
+ * so the merge can proceed cleanly.  After the merge completes, postflightPopStash
+ * restores the stashed changes.
+ *
+ * Design constraints (from Trek-e approval):
+ *  - Warn the user before stashing (no silent surprises)
+ *  - git stash push / git stash pop only — no custom stash management layer
+ *  - Stash/pop errors are logged but MUST NOT block the merge
+ *  - Fast-path status check — clean trees pay no extra cost
+ */
+
+import { execFileSync } from "node:child_process";
+import { GIT_NO_PROMPT_ENV } from "./git-constants.js";
+import { logWarning } from "./workflow-logger.js";
+import { nativeHasChanges } from "./native-git-bridge.js";
+
+export interface PreflightResult {
+  /** true when a stash was pushed and postflightPopStash should be called */
+  stashPushed: boolean;
+  /** human-readable summary of what happened (empty string for clean trees) */
+  summary: string;
+}
+
+/**
+ * Check the working tree for dirty files before a milestone merge.
+ *
+ * Clean tree path: O(1) — returns immediately with stashPushed=false.
+ *
+ * Dirty tree path:
+ *  1. Emits a warning notification via the provided `notify` callback.
+ *  2. Runs `git stash push --include-untracked -m "gsd-preflight-stash"`.
+ *  3. Returns stashPushed=true so the caller knows to call postflightPopStash.
+ *
+ * Any stash error is logged but does NOT throw — the merge proceeds regardless.
+ */
+export function preflightCleanRoot(
+  basePath: string,
+  milestoneId: string,
+  notify: (message: string, level: "info" | "warning" | "error") => void,
+): PreflightResult {
+  // Fast-path: clean tree — nothing to do
+  let isDirty = false;
+  try {
+    isDirty = nativeHasChanges(basePath);
+  } catch (err) {
+    // If the status check itself fails, treat as clean and let the merge decide
+    logWarning("preflight", `clean-root status check failed: ${err instanceof Error ? err.message : String(err)}`);
+    return { stashPushed: false, summary: "" };
+  }
+
+  if (!isDirty) {
+    return { stashPushed: false, summary: "" };
+  }
+
+  // Warn the user before stashing
+  const warnMsg = `Working tree has uncommitted changes before milestone ${milestoneId} merge. Auto-stashing to allow clean merge (stash will be restored after merge).`;
+  notify(warnMsg, "warning");
+
+  // Push the stash
+  try {
+    execFileSync("git", ["stash", "push", "--include-untracked", "-m", "gsd-preflight-stash"], {
+      cwd: basePath,
+      stdio: ["ignore", "pipe", "pipe"],
+      encoding: "utf-8",
+      env: GIT_NO_PROMPT_ENV,
+    });
+    return {
+      stashPushed: true,
+      summary: `Stashed uncommitted changes before merge (milestone ${milestoneId}).`,
+    };
+  } catch (err) {
+    // Stash failure is non-fatal — log and let the merge attempt proceed
+    const msg = `git stash push failed before merge of milestone ${milestoneId}: ${err instanceof Error ? err.message : String(err)}`;
+    logWarning("preflight", msg);
+    notify(`Auto-stash failed before milestone ${milestoneId} merge — proceeding anyway. ${msg}`, "warning");
+    return { stashPushed: false, summary: `stash-push-failed: ${msg}` };
+  }
+}
+
+/**
+ * Restore stashed changes after a milestone merge completes.
+ *
+ * Only called when preflightCleanRoot returned stashPushed=true.
+ * Any pop error (e.g. conflict) is logged and notified but does NOT throw —
+ * the merge already completed successfully.
+ */
+export function postflightPopStash(
+  basePath: string,
+  milestoneId: string,
+  notify: (message: string, level: "info" | "warning" | "error") => void,
+): void {
+  try {
+    execFileSync("git", ["stash", "pop"], {
+      cwd: basePath,
+      stdio: ["ignore", "pipe", "pipe"],
+      encoding: "utf-8",
+      env: GIT_NO_PROMPT_ENV,
+    });
+    notify(`Restored stashed changes after milestone ${milestoneId} merge.`, "info");
+  } catch (err) {
+    // Pop conflicts mean the merged code collides with the stashed changes.
+    // Log a warning — the user needs to resolve manually, but the merge succeeded.
+    const msg = `git stash pop failed after merge of milestone ${milestoneId}: ${err instanceof Error ? err.message : String(err)}. Run "git stash pop" manually to restore your changes.`;
+    logWarning("preflight", msg);
+    notify(msg, "warning");
+  }
+}

--- a/src/resources/extensions/gsd/tests/clean-root-preflight.test.ts
+++ b/src/resources/extensions/gsd/tests/clean-root-preflight.test.ts
@@ -1,0 +1,186 @@
+/**
+ * clean-root-preflight.test.ts — Regression tests for #2909.
+ *
+ * Tests that preflightCleanRoot warns + stashes on dirty trees,
+ * is a no-op on clean trees, and that postflightPopStash restores
+ * stashed changes after a merge.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, readFileSync, realpathSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { execSync } from "node:child_process";
+
+import { preflightCleanRoot, postflightPopStash } from "../clean-root-preflight.ts";
+
+function run(cmd: string, cwd: string): string {
+  return execSync(cmd, { cwd, stdio: ["ignore", "pipe", "pipe"], encoding: "utf-8" }).trim();
+}
+
+function createTempRepo(): string {
+  const dir = realpathSync(mkdtempSync(join(tmpdir(), "gsd-preflight-test-")));
+  run("git init", dir);
+  run("git config user.email test@example.com", dir);
+  run("git config user.name Test", dir);
+  writeFileSync(join(dir, "README.md"), "# test\n");
+  mkdirSync(join(dir, ".gsd"), { recursive: true });
+  writeFileSync(join(dir, ".gsd", "STATE.md"), "# State\n");
+  run("git add .", dir);
+  run("git commit -m init", dir);
+  run("git branch -M main", dir);
+  return dir;
+}
+
+// ── Clean tree: fast-path returns immediately without stashing ─────────────
+
+test("preflightCleanRoot — clean tree returns stashPushed=false and emits no notifications", () => {
+  const repo = createTempRepo();
+  try {
+    const notifications: Array<{ msg: string; level: string }> = [];
+    const result = preflightCleanRoot(repo, "M001", (msg, level) => {
+      notifications.push({ msg, level });
+    });
+
+    assert.equal(result.stashPushed, false, "stashPushed must be false for clean tree");
+    assert.equal(result.summary, "", "summary must be empty for clean tree");
+    assert.equal(notifications.length, 0, "no notifications on clean tree");
+
+    // Verify no stash was created
+    const stashList = run("git stash list", repo);
+    assert.equal(stashList, "", "no stash entry on clean tree");
+  } finally {
+    try { rmSync(repo, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 }); } catch { /* ignore */ }
+  }
+});
+
+// ── Dirty tree: warns, stashes, returns stashPushed=true ──────────────────
+
+test("preflightCleanRoot — dirty tree warns user and auto-stashes", () => {
+  const repo = createTempRepo();
+  try {
+    // Dirty an existing tracked file
+    writeFileSync(join(repo, "README.md"), "# locally modified\n");
+
+    const notifications: Array<{ msg: string; level: string }> = [];
+    const result = preflightCleanRoot(repo, "M002", (msg, level) => {
+      notifications.push({ msg, level });
+    });
+
+    assert.equal(result.stashPushed, true, "stashPushed must be true when tree was dirty");
+    assert.ok(result.summary.length > 0, "summary must be non-empty when stash was pushed");
+
+    // A warning notification must have been emitted before stashing
+    assert.ok(
+      notifications.some(n => n.level === "warning" && n.msg.includes("M002")),
+      "warning notification must mention the milestone ID",
+    );
+
+    // Working tree must now be clean (stash pushed)
+    const status = run("git status --porcelain", repo);
+    assert.equal(status, "", "working tree must be clean after stash push");
+
+    // The stash entry must exist
+    const stashList = run("git stash list", repo);
+    assert.ok(stashList.includes("gsd-preflight-stash"), "stash entry must be named gsd-preflight-stash");
+  } finally {
+    try { rmSync(repo, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 }); } catch { /* ignore */ }
+  }
+});
+
+// ── Untracked files are also stashed ─────────────────────────────────────
+
+test("preflightCleanRoot — untracked file triggers stash with --include-untracked", () => {
+  const repo = createTempRepo();
+  try {
+    // Add an untracked file
+    writeFileSync(join(repo, "untracked.ts"), "export const x = 1;\n");
+
+    const notifications: Array<{ msg: string; level: string }> = [];
+    const result = preflightCleanRoot(repo, "M003", (msg, level) => {
+      notifications.push({ msg, level });
+    });
+
+    assert.equal(result.stashPushed, true, "stashPushed must be true for untracked file");
+
+    const status = run("git status --porcelain", repo);
+    assert.equal(status, "", "working tree must be clean after stash push");
+  } finally {
+    try { rmSync(repo, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 }); } catch { /* ignore */ }
+  }
+});
+
+// ── postflightPopStash: restores stashed changes ──────────────────────────
+
+test("postflightPopStash — restores stashed changes and emits info notification", () => {
+  const repo = createTempRepo();
+  try {
+    // Dirty the working tree
+    writeFileSync(join(repo, "README.md"), "# stash me\n");
+
+    const preNotifications: Array<{ msg: string; level: string }> = [];
+    const preflight = preflightCleanRoot(repo, "M004", (msg, level) => {
+      preNotifications.push({ msg, level });
+    });
+    assert.equal(preflight.stashPushed, true, "preflight must have stashed");
+
+    // Simulate the merge (just a no-op commit here)
+    writeFileSync(join(repo, "merged.ts"), "export const merged = true;\n");
+    run("git add .", repo);
+    run('git commit -m "simulate merge"', repo);
+
+    const postNotifications: Array<{ msg: string; level: string }> = [];
+    postflightPopStash(repo, "M004", (msg, level) => {
+      postNotifications.push({ msg, level });
+    });
+
+    // The stashed README.md change must be restored
+    const content = readFileSync(join(repo, "README.md"), "utf-8");
+    assert.equal(content.replace(/\r\n/g, "\n"), "# stash me\n", "stashed file must be restored");
+
+    // An info notification must have been emitted
+    assert.ok(
+      postNotifications.some(n => n.level === "info" && n.msg.includes("M004")),
+      "info notification must mention milestone ID after pop",
+    );
+
+    // Stash list must be empty
+    const stashList = run("git stash list", repo);
+    assert.equal(stashList, "", "stash list must be empty after pop");
+  } finally {
+    try { rmSync(repo, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 }); } catch { /* ignore */ }
+  }
+});
+
+// ── Round-trip: preflight + merge + postflight preserves changes ──────────
+
+test("preflight + merge + postflight round-trip preserves uncommitted changes", () => {
+  const repo = createTempRepo();
+  try {
+    const originalContent = "# my local work\n";
+    writeFileSync(join(repo, "README.md"), originalContent);
+
+    // Preflight: stash
+    const preflight = preflightCleanRoot(repo, "M005", () => {});
+    assert.equal(preflight.stashPushed, true, "must have stashed");
+
+    // Merge: introduce a new file (no overlap with README.md)
+    writeFileSync(join(repo, "feature.ts"), "export const feature = true;\n");
+    run("git add feature.ts", repo);
+    run('git commit -m "feat: add feature"', repo);
+
+    // Postflight: pop stash
+    postflightPopStash(repo, "M005", () => {});
+
+    // README.md must still have our local content
+    const restored = readFileSync(join(repo, "README.md"), "utf-8");
+    assert.equal(restored.replace(/\r\n/g, "\n"), originalContent, "local changes must survive merge");
+
+    // feature.ts must also exist (the merge commit landed)
+    const featureContent = readFileSync(join(repo, "feature.ts"), "utf-8");
+    assert.ok(featureContent.includes("feature"), "merged feature must be present");
+  } finally {
+    try { rmSync(repo, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 }); } catch { /* ignore */ }
+  }
+});

--- a/src/resources/extensions/gsd/workflow-logger.ts
+++ b/src/resources/extensions/gsd/workflow-logger.ts
@@ -58,7 +58,8 @@ export type LogComponent =
   | "memory-embeddings" // Memory layer embedding generation
   | "memory-ingest"     // Memory layer ingestion pipeline
   | "memory-backfill"   // ADR-013: decisions->memories backfill
-  | "context-mode";    // Context-mode exec sandbox and compaction snapshot
+  | "context-mode"     // Context-mode exec sandbox and compaction snapshot
+  | "preflight";       // Clean-root preflight gate at milestone completion
 
 export interface LogEntry {
   ts: string;


### PR DESCRIPTION
## Why

Before milestone completion merges, a dirty working tree could cause the squash merge to fail or produce confusing output. Users with intentional uncommitted changes would lose context or see an unexplained failure.

This is the approved implementation of #2909: a preflight gate that warns the user and auto-stashes before each `mergeAndExit` call, then restores the stash after the merge completes.

Closes #2909

## What changed

- **`clean-root-preflight.ts`** (new): `preflightCleanRoot()` and `postflightPopStash()`. Fast-path `nativeHasChanges` check — clean trees pay no extra cost. Dirty trees get a warning notification then `git stash push --include-untracked`. After merge, `git stash pop` restores. All errors logged + notified but never block the merge.
- **`auto/loop-deps.ts`**: Added `preflightCleanRoot` and `postflightPopStash` to `LoopDeps` interface.
- **`auto/phases.ts`**: Integrated preflight/postflight at all three `mergeAndExit` call sites (milestone transition, all-milestones-complete terminal, phase-complete terminal).
- **`auto.ts`**: Wired up the new deps in `buildLoopDeps()`.
- **`tests/clean-root-preflight.test.ts`** (new): 5 regression tests using `node:test` + `node:assert/strict`.

## Test plan

- [x] `preflightCleanRoot` — clean tree: returns `stashPushed=false`, no notifications, no stash created
- [x] `preflightCleanRoot` — dirty tracked file: warns user, stashes, `stashPushed=true`
- [x] `preflightCleanRoot` — untracked file: stashed via `--include-untracked`
- [x] `postflightPopStash` — restores stashed changes, emits info notification
- [x] Round-trip: preflight + merge + postflight preserves uncommitted changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)