### PR TITLE
fix(skills): quote SKILL.md description values containing ': '

### DIFF
--- a/src/resources/skills/verify-before-complete/SKILL.md
+++ b/src/resources/skills/verify-before-complete/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: verify-before-complete
-description: Block completion claims until verification evidence has been produced in the current message. Use before marking a task/slice/milestone complete, before creating a commit or PR, before saying "it works" or "tests pass", and any time you are about to claim work is done. The rule is: evidence before claims, always — running the verification must happen now, not "earlier in the session". Fresh output or no claim.
+description: "Block completion claims until verification evidence has been produced in the current message. Use before marking a task/slice/milestone complete, before creating a commit or PR, before saying \"it works\" or \"tests pass\", and any time you are about to claim work is done. The rule is: evidence before claims, always — running the verification must happen now, not \"earlier in the session\". Fresh output or no claim."
 ---
 
 <objective>

--- a/src/resources/skills/write-docs/SKILL.md
+++ b/src/resources/skills/write-docs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: write-docs
-description: Collaborative document authoring workflow for proposals, technical specs, decision docs, README sections, ADRs, and long-form prose that must work for fresh readers. Use when asked to "write the docs", "draft a proposal", "write a spec", "write an RFC", "write the README", or when a document needs to be understandable by someone without this session's context. Three stages: gather context, iterate on structure, reader-test for a stranger.
+description: "Collaborative document authoring workflow for proposals, technical specs, decision docs, README sections, ADRs, and long-form prose that must work for fresh readers. Use when asked to \"write the docs\", \"draft a proposal\", \"write a spec\", \"write an RFC\", \"write the README\", or when a document needs to be understandable by someone without this session's context. Three stages: gather context, iterate on structure, reader-test for a stranger."
 ---
 
 <objective>


### PR DESCRIPTION
## Summary

- Two shipped skills failed to load because their frontmatter `description:` value was a plain YAML scalar containing `: ` (colon-space), which `yaml.parse` rejects as a nested mapping.
- Wrapped the affected descriptions in double quotes (escaping internal `"`) so the frontmatter parses cleanly.

Fixes #4593

## Test plan

- [x] `yaml.parse` on the fixed frontmatter returns the expected `name` / `description` for both skills
- [ ] Launch the CLI and confirm `[Skill issues]` no longer lists `verify-before-complete` or `write-docs`
- [ ] Invoke each skill via `/verify-before-complete` / `/write-docs` to confirm it loads and is callable

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Fixed description formatting in skill documentation to ensure proper parsing and consistent display across the platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->