### PR TITLE
fix(safety): add file_change_allowlist to suppress false-positive unexpected-change warnings

### DIFF
--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -654,7 +654,7 @@ export async function postUnitPreVerification(pctx: PostUnitContext, opts?: PreV
             if (taskRow) {
               const expectedOutput = taskRow.expected_output ?? [];
               const plannedFiles = taskRow.files ?? [];
-              const audit = validateFileChanges(s.basePath, expectedOutput, plannedFiles);
+              const audit = validateFileChanges(s.basePath, expectedOutput, plannedFiles, safetyConfig.file_change_allowlist);
               if (audit && audit.violations.length > 0) {
                 const warnings = audit.violations.filter(v => v.severity === "warning");
                 for (const v of warnings) {

--- a/src/resources/extensions/gsd/preferences-types.ts
+++ b/src/resources/extensions/gsd/preferences-types.ts
@@ -383,6 +383,14 @@ export interface GSDPreferences {
     checkpoints?: boolean;
     auto_rollback?: boolean;
     timeout_scale_cap?: number;
+    /**
+     * Glob patterns for files that are always expected side-effects of any task.
+     * Files matching any pattern here are excluded from unexpected-change warnings.
+     * Supports standard glob syntax (e.g. `tracking/history/**`, `*.log`).
+     * Fixes #4385/#4436 — audit-trail snapshots, build artifacts, and other
+     * project-level secondary writes shouldn't require per-task declaration.
+     */
+    file_change_allowlist?: string[];
   };
 
 

--- a/src/resources/extensions/gsd/safety/file-change-validator.ts
+++ b/src/resources/extensions/gsd/safety/file-change-validator.ts
@@ -9,9 +9,15 @@
  * Copyright (c) 2026 Jeremy McSpadden <jeremy@fluxlabs.net>
  */
 
+import { createRequire } from "node:module";
 import { execFileSync } from "node:child_process";
 import { normalizePlannedFileReference } from "../files.js";
 import { logWarning } from "../workflow-logger.js";
+
+const _require = createRequire(import.meta.url);
+type PicomatchMatcher = (input: string) => boolean;
+type PicomatchFn = (pattern: string, opts?: { dot?: boolean }) => PicomatchMatcher;
+const picomatch = _require("picomatch") as PicomatchFn;
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -43,6 +49,7 @@ export function validateFileChanges(
   basePath: string,
   expectedOutput: string[],
   plannedFiles: string[],
+  fileChangeAllowlist: string[] = [],
 ): FileChangeAudit | null {
   const allExpected = new Set([...expectedOutput, ...plannedFiles]);
 
@@ -63,8 +70,12 @@ export function validateFileChanges(
     ),
   );
 
-  // Compute symmetric difference
-  const unexpectedFiles = projectFiles.filter(f => !normalizedExpected.has(f));
+  // Build allowlist matchers once (dot: true so patterns like `**/.hidden` work).
+  const allowlistMatchers = fileChangeAllowlist.map(p => picomatch(p, { dot: true }));
+  const isAllowlisted = (f: string) => allowlistMatchers.some(m => m(f));
+
+  // Compute symmetric difference, excluding allowlisted files
+  const unexpectedFiles = projectFiles.filter(f => !normalizedExpected.has(f) && !isAllowlisted(f));
   const missingFiles = [...normalizedExpected].filter(f => !projectFiles.includes(f));
 
   const violations: FileViolation[] = [];

--- a/src/resources/extensions/gsd/safety/safety-harness.ts
+++ b/src/resources/extensions/gsd/safety/safety-harness.ts
@@ -25,6 +25,8 @@ export interface SafetyHarnessConfig {
   checkpoints: boolean;
   auto_rollback: boolean;
   timeout_scale_cap: number;
+  /** Glob patterns for files excluded from unexpected-change warnings (#4385). */
+  file_change_allowlist: string[];
 }
 
 // ─── Defaults ───────────────────────────────────────────────────────────────
@@ -39,6 +41,7 @@ const DEFAULTS: SafetyHarnessConfig = {
   checkpoints: true,
   auto_rollback: false,
   timeout_scale_cap: 6,
+  file_change_allowlist: [],
 };
 
 // ─── Public API ─────────────────────────────────────────────────────────────
@@ -62,6 +65,9 @@ export function resolveSafetyHarnessConfig(
     checkpoints: typeof raw.checkpoints === "boolean" ? raw.checkpoints : DEFAULTS.checkpoints,
     auto_rollback: typeof raw.auto_rollback === "boolean" ? raw.auto_rollback : DEFAULTS.auto_rollback,
     timeout_scale_cap: typeof raw.timeout_scale_cap === "number" ? raw.timeout_scale_cap : DEFAULTS.timeout_scale_cap,
+    file_change_allowlist: Array.isArray(raw.file_change_allowlist)
+      ? (raw.file_change_allowlist as unknown[]).filter((p): p is string => typeof p === "string")
+      : DEFAULTS.file_change_allowlist,
   };
 }
 

--- a/src/resources/extensions/gsd/tests/file-change-validator.test.ts
+++ b/src/resources/extensions/gsd/tests/file-change-validator.test.ts
@@ -35,6 +35,44 @@ test("validateFileChanges works on repos with a single commit (no HEAD~1)", (t) 
   assert.deepEqual(audit.missingFiles, []);
 });
 
+test("validateFileChanges excludes allowlisted files from unexpected-change warnings", (t) => {
+  const base = mkdtempSync(join(tmpdir(), "gsd-file-change-validator-"));
+  t.after(() => rmSync(base, { recursive: true, force: true }));
+
+  mkdirSync(join(base, "tracking", "history"), { recursive: true });
+  git(base, "init");
+  git(base, "config", "user.email", "test@example.com");
+  git(base, "config", "user.name", "Test User");
+
+  writeFileSync(join(base, "src.ts"), "initial\n");
+  writeFileSync(join(base, "tracking", "history", "2026-04-20-snapshot.md"), "initial\n");
+  git(base, "add", ".");
+  git(base, "commit", "-m", "initial");
+
+  writeFileSync(join(base, "src.ts"), "updated\n");
+  writeFileSync(join(base, "tracking", "history", "2026-04-20-snapshot.md"), "updated\n");
+  git(base, "add", ".");
+  git(base, "commit", "-m", "update");
+
+  // Without allowlist: tracking/history snapshot is unexpected
+  const auditWithout = validateFileChanges(base, ["src.ts"], []);
+  assert.ok(auditWithout, "audit should be produced");
+  assert.ok(
+    auditWithout.unexpectedFiles.includes("tracking/history/2026-04-20-snapshot.md"),
+    "snapshot should be unexpected without allowlist",
+  );
+
+  // With glob allowlist: snapshot is excluded
+  const auditWith = validateFileChanges(base, ["src.ts"], [], ["tracking/history/**"]);
+  assert.ok(auditWith, "audit should be produced with allowlist");
+  assert.deepEqual(auditWith.unexpectedFiles, [], "no unexpected files when snapshot is allowlisted");
+  assert.equal(
+    auditWith.violations.filter(v => v.severity === "warning").length,
+    0,
+    "no warnings when all unexpected files are allowlisted",
+  );
+});
+
 test("validateFileChanges ignores inline descriptions in expected output paths", (t) => {
   const base = mkdtempSync(join(tmpdir(), "gsd-file-change-validator-"));
   t.after(() => rmSync(base, { recursive: true, force: true }));


### PR DESCRIPTION
## Summary

- Adds `safety_harness.file_change_allowlist: string[]` to PREFERENCES.md
- Files matching any glob pattern are excluded from unexpected-change warnings
- Fixes the 80-100% false-positive rate reported in #4385 (audit-trail snapshots, build artifacts, and other intentional secondary writes that aren't listed in the task plan)
- Uses `picomatch` (already a dependency) with `dot: true` so patterns like `**/.hidden` work

## Usage

```yaml
# PREFERENCES.md
safety_harness:
  file_change_allowlist:
    - "tracking/history/**"   # audit-trail snapshots
    - "*.log"                  # build/runtime logs
    - "coverage/**"            # test coverage reports
```

## Test plan

- [ ] New test: `validateFileChanges excludes allowlisted files from unexpected-change warnings` — creates a snapshot file, verifies it triggers without allowlist, verifies it's suppressed with `tracking/history/**`
- [ ] Existing tests: single-commit repo and inline-description tests unchanged

Closes #4385
Closes #4436

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a configurable allowlist to exclude files from unexpected-change warnings using glob pattern matching. Matching files will no longer trigger violation warnings.

* **Tests**
  * Added tests verifying that the allowlist correctly filters files and prevents warnings from being generated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->