### PR TITLE
fix(mcp): add 10-minute timeout to ask_user_questions and secure_env_collect elicitation

### DIFF
--- a/packages/mcp-server/src/mcp-server.test.ts
+++ b/packages/mcp-server/src/mcp-server.test.ts
@@ -20,6 +20,7 @@ import {
   buildAskUserQuestionsElicitRequest,
   createMcpServer,
   formatAskUserQuestionsElicitResult,
+  withElicitTimeout,
 } from './server.js';
 import { MAX_EVENTS } from './types.js';
 import type { ManagedSession, CostAccumulator, PendingBlocker } from './types.js';
@@ -744,5 +745,34 @@ describe('createMcpServer tool registration', () => {
         },
       }),
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// withElicitTimeout
+// ---------------------------------------------------------------------------
+
+describe('withElicitTimeout', () => {
+  it('resolves with the promise value when it settles before the timeout', async () => {
+    const result = await withElicitTimeout(Promise.resolve(42), 'test', 5000);
+    assert.equal(result, 42);
+  });
+
+  it('rejects with a timeout error when the promise does not settle in time', async () => {
+    const never = new Promise<never>(() => {});
+    await assert.rejects(
+      () => withElicitTimeout(never, 'ask_user_questions', 1),
+      (err: Error) => {
+        assert.ok(err.message.includes('ask_user_questions'));
+        assert.ok(err.message.includes('timed out'));
+        return true;
+      },
+    );
+  });
+
+  it('clears the timer when the promise resolves (no dangling timer)', async () => {
+    const start = Date.now();
+    await withElicitTimeout(Promise.resolve('done'), 'test', 50);
+    assert.ok(Date.now() - start < 40, 'should not wait for the timeout');
   });
 });

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -35,6 +35,28 @@ const MCP_PKG = '@modelcontextprotocol/sdk';
 const SERVER_NAME = 'gsd';
 const SERVER_VERSION = '2.53.0';
 
+/** User-interaction timeout — generous but bounded so elicitation can't hang indefinitely (#4586). */
+const ELICIT_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
+
+/**
+ * Race a promise against a timeout. Rejects with a typed error on timeout so
+ * callers can return a specific MCP error response rather than hanging.
+ */
+async function withElicitTimeout<T>(promise: Promise<T>, label: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(
+      () => reject(new Error(`${label} timed out after ${ELICIT_TIMEOUT_MS / 60000} minutes — no user response received`)),
+      ELICIT_TIMEOUT_MS,
+    );
+  });
+  try {
+    return await Promise.race([promise, timeout]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Tool result helpers
 // ---------------------------------------------------------------------------
@@ -569,7 +591,10 @@ export async function createMcpServer(sessionManager: SessionManager): Promise<{
           // tryRemoteQuestions() (e.g. env var was cleared) — fall through to local.
         }
 
-        const elicitation = await server.server.elicitInput(buildAskUserQuestionsElicitRequest(questions));
+        const elicitation = await withElicitTimeout(
+          server.server.elicitInput(buildAskUserQuestionsElicitRequest(questions)),
+          'ask_user_questions',
+        );
         if (elicitation.action !== 'accept' || !elicitation.content) {
           return textContent('ask_user_questions was cancelled before receiving a response');
         }
@@ -645,14 +670,17 @@ export async function createMcpServer(sessionManager: SessionManager): Promise<{
         }
 
         // (3) Elicit input from the MCP client
-        const elicitation = await server.server.elicitInput({
-          message: `Enter values for ${pendingKeys.length} environment variable(s). Values are written directly to the project and never shown to the AI.`,
-          requestedSchema: {
-            type: 'object',
-            properties,
-            required,
-          },
-        });
+        const elicitation = await withElicitTimeout(
+          server.server.elicitInput({
+            message: `Enter values for ${pendingKeys.length} environment variable(s). Values are written directly to the project and never shown to the AI.`,
+            requestedSchema: {
+              type: 'object',
+              properties,
+              required,
+            },
+          }),
+          'secure_env_collect',
+        );
 
         if (elicitation.action !== 'accept' || !elicitation.content) {
           return textContent('secure_env_collect was cancelled by user.');

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -41,13 +41,19 @@ const ELICIT_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
 /**
  * Race a promise against a timeout. Rejects with a typed error on timeout so
  * callers can return a specific MCP error response rather than hanging.
+ *
+ * @param timeoutMs - override for testing; defaults to ELICIT_TIMEOUT_MS
  */
-async function withElicitTimeout<T>(promise: Promise<T>, label: string): Promise<T> {
+export async function withElicitTimeout<T>(
+  promise: Promise<T>,
+  label: string,
+  timeoutMs = ELICIT_TIMEOUT_MS,
+): Promise<T> {
   let timer: ReturnType<typeof setTimeout> | undefined;
   const timeout = new Promise<never>((_, reject) => {
     timer = setTimeout(
-      () => reject(new Error(`${label} timed out after ${ELICIT_TIMEOUT_MS / 60000} minutes — no user response received`)),
-      ELICIT_TIMEOUT_MS,
+      () => reject(new Error(`${label} timed out after ${timeoutMs / 60000} minutes — no user response received`)),
+      timeoutMs,
     );
   });
   try {


### PR DESCRIPTION
## Summary

- `elicitInput` calls in `ask_user_questions` and `secure_env_collect` had no timeout
- When the user doesn't respond, these tools hung indefinitely — blocking the CONTEXT write-gate and any caller awaiting the response
- Added `withElicitTimeout()` helper that races the elicitation promise against a 10-minute deadline
- On timeout, returns an MCP error response so the caller can surface the blockage rather than stalling

## Implementation

```ts
const ELICIT_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes

async function withElicitTimeout<T>(promise: Promise<T>, label: string): Promise<T>
```

The timeout is generous enough for normal human interaction (10 min), but bounded so the CONTEXT write-gate doesn't block forever.

## Test plan

- [ ] Verify `ask_user_questions` returns an error response when the timeout fires instead of hanging
- [ ] Verify `secure_env_collect` similarly times out cleanly
- [ ] Happy path unaffected: normal responses resolve well within the timeout

Closes #4586

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Interactive tools that request user input now enforce a 10-minute timeout, preventing indefinite hangs from unresponsive users and enabling faster error recovery instead of blocking indefinitely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->