### PR TITLE
fix(auto-worktree): stash fails on gitignored .gsd symlink

### DIFF
--- a/src/resources/extensions/gsd/auto-worktree.ts
+++ b/src/resources/extensions/gsd/auto-worktree.ts
@@ -238,14 +238,6 @@ function clearProjectRootStateFiles(basePath: string, milestoneId: string): void
   }
 }
 
-function isProjectGsdSymlink(basePath: string): boolean {
-  try {
-    return lstatSyncFn(join(basePath, ".gsd")).isSymbolicLink();
-  } catch {
-    return false;
-  }
-}
-
 // ─── Build Artifact Auto-Resolve ─────────────────────────────────────────────
 
 /** Patterns for machine-generated build artifacts that can be safely
@@ -1664,54 +1656,15 @@ export function mergeMilestoneToMain(
     }
   }
 
-  // 7. Stash any pre-existing dirty files so the squash merge is not
-  //    blocked by unrelated local changes (#2151).  clearProjectRootStateFiles
-  //    only removes untracked .gsd/ files; tracked dirty files elsewhere (e.g.
-  //    .planning/work-state.json with stash conflict markers) are invisible to
-  //    that cleanup but will cause `git merge --squash` to reject.
-  let stashed = false;
-  try {
-    const status = execFileSync("git", ["status", "--porcelain"], {
-      cwd: originalBasePath_,
-      stdio: ["ignore", "pipe", "pipe"],
-      encoding: "utf-8",
-    }).trim();
-    if (status) {
-      // Use --include-untracked to stash untracked files that would block
-      // the squash merge, but EXCLUDE .gsd/milestones/ (#2505).
-      // --include-untracked without exclusion sweeps queued milestone
-      // CONTEXT files into the stash. If stash pop later fails, those files
-      // are permanently trapped in the stash entry and lost on the next
-      // stash push or drop.
-      //
-      // When `.gsd` itself is a symlink, Git rejects pathspecs below it
-      // ("beyond a symbolic link"). In that layout, exclude the whole symlink
-      // and keep stashing real project files that could block the merge.
-      const stashPathspecs = isProjectGsdSymlink(originalBasePath_)
-        ? [".", ":(exclude).gsd"]
-        : [":(exclude).gsd/milestones"];
-      execFileSync(
-        "git",
-        [
-          "stash", "push", "--include-untracked",
-          "-m", `gsd: pre-merge stash for ${milestoneId}`,
-          "--", ...stashPathspecs,
-        ],
-        { cwd: originalBasePath_, stdio: ["ignore", "pipe", "pipe"], encoding: "utf-8" },
-      );
-      stashed = true;
-    }
-  } catch (err) {
-    // Stash failure is non-fatal — proceed without stash and let the merge
-    // report the dirty tree if it fails.
-    logWarning("worktree", `git stash failed: ${err instanceof Error ? err.message : String(err)}`);
-  }
-
-  // 7a. Shelter queued milestone directories before the squash merge (#2505).
+  // 7. Shelter queued milestone directories before the squash merge (#2505).
   // The milestone branch may contain copies of queued milestone dirs (via
   // copyPlanningArtifacts), so `git merge --squash` rejects when those same
   // files exist as untracked in the working tree. Temporarily move them to
   // a backup location, then restore after the merge+commit.
+  //
+  // MUST run BEFORE the pre-merge stash (step 7a) so `--include-untracked`
+  // does not sweep queued CONTEXT files into the stash. If stash pop later
+  // fails, files trapped inside the stash are permanently lost (#2505).
   const milestonesDir = join(gsdRoot(originalBasePath_), "milestones");
   const shelterDir = join(gsdRoot(originalBasePath_), ".milestone-shelter");
   const shelteredDirs: string[] = [];
@@ -1757,6 +1710,35 @@ export function mergeMilestoneToMain(
   } catch (err) {
     // Non-fatal — proceed with merge; untracked files may block it
     logWarning("worktree", `milestone shelter operation failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
+
+  // 7a. Stash pre-existing dirty files so the squash merge is not blocked by
+  //     unrelated local changes (#2151). Includes untracked files to handle
+  //     locally-added files that conflict with tracked files on the milestone
+  //     branch. Passing NO pathspec lets git skip gitignored paths silently;
+  //     adding an explicit pathspec trips a `git add`-style fatal on ignored
+  //     entries (e.g. a gitignored `.gsd` symlink under ADR-002) (#4573).
+  //     Queued CONTEXT files under `.gsd/milestones/*` are already sheltered
+  //     in step 7 above, so they won't be swept into the stash.
+  let stashed = false;
+  try {
+    const status = execFileSync("git", ["status", "--porcelain"], {
+      cwd: originalBasePath_,
+      stdio: ["ignore", "pipe", "pipe"],
+      encoding: "utf-8",
+    }).trim();
+    if (status) {
+      execFileSync(
+        "git",
+        ["stash", "push", "--include-untracked", "-m", `gsd: pre-merge stash for ${milestoneId}`],
+        { cwd: originalBasePath_, stdio: ["ignore", "pipe", "pipe"], encoding: "utf-8" },
+      );
+      stashed = true;
+    }
+  } catch (err) {
+    // Stash failure is non-fatal — proceed without stash and let the merge
+    // report the dirty tree if it fails.
+    logWarning("worktree", `git stash failed: ${err instanceof Error ? err.message : String(err)}`);
   }
 
   // 7b. Clean up stale merge state before attempting squash merge (#2912).

--- a/src/resources/extensions/gsd/tests/stash-queued-context-files.test.ts
+++ b/src/resources/extensions/gsd/tests/stash-queued-context-files.test.ts
@@ -378,3 +378,59 @@ test("#2505: back-to-back merges preserve queued CONTEXT files", () => {
     rmSync(repo, { recursive: true, force: true });
   }
 });
+
+// #4573: When `.gsd` is a gitignored symlink (ADR-002 layout) and the project
+// `.gitignore` contains `.gsd`, `git stash push --include-untracked -- <pathspec>`
+// fatals with "The following paths are ignored by one of your .gitignore files".
+// The prior tests used a symlinked `.gsd` but no `.gitignore`, so this failure
+// mode was invisible to CI. Fixture must include BOTH the symlink AND the
+// ignore rule to reproduce the bug on pre-fix code.
+test("#4573: gitignored .gsd symlink does not break pre-merge stash", () => {
+  const repo = realpathSync(mkdtempSync(join(tmpdir(), "wt-4573-ignored-symlink-")));
+  const stateDir = realpathSync(mkdtempSync(join(tmpdir(), "wt-4573-state-")));
+  try {
+    run("git init", repo);
+    run("git config user.email test@test.com", repo);
+    run("git config user.name Test", repo);
+    writeFileSync(join(repo, "README.md"), "# test\n");
+    // Matches what BASELINE_PATTERNS in gitignore.ts writes for real projects.
+    writeFileSync(join(repo, ".gitignore"), ".gsd\n.gsd-id\n");
+    symlinkSync(stateDir, join(repo, ".gsd"));
+    run("git add README.md .gitignore", repo);
+    run("git commit -m init", repo);
+    run("git branch -M main", repo);
+
+    const wtPath = createAutoWorktree(repo, "M001");
+    const worktreeName = wtPath.replaceAll("\\", "/").split("/").pop() || "M001";
+    const sliceBranch = `slice/${worktreeName}/S01`;
+    run(`git checkout -b "${sliceBranch}"`, wtPath);
+    writeFileSync(join(wtPath, "app.ts"), "export const app = true;\n");
+    run("git add app.ts", wtPath);
+    run('git commit -m "add feature"', wtPath);
+    run("git checkout milestone/M001", wtPath);
+    run(`git merge --no-ff "${sliceBranch}" -m "merge S01"`, wtPath);
+
+    // Dirty a tracked file so the pre-merge stash branch actually runs.
+    writeFileSync(join(repo, "README.md"), "# test\n\nDirty.\n");
+
+    const result = mergeMilestoneToMain(
+      repo,
+      "M001",
+      makeRoadmap("M001", "Feature", [{ id: "S01", title: "Feature" }]),
+    );
+
+    assert.ok(
+      result.commitMessage.includes("GSD-Milestone: M001"),
+      "merge must succeed despite gitignored .gsd symlink",
+    );
+    assert.ok(existsSync(join(repo, "app.ts")), "milestone code merged to main");
+    assert.equal(
+      lstatSync(join(repo, ".gsd")).isSymbolicLink(),
+      true,
+      ".gsd symlink remains in place",
+    );
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+    rmSync(stateDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

- Reorders steps 7 and 7a in `mergeMilestoneToMain` so the milestone shelter runs **before** the pre-merge stash.
- Drops the pathspec args from `git stash push`; keeps `--include-untracked` so the #2151 safety net still works.
- Deletes the now-unused `isProjectGsdSymlink` helper.
- Adds a regression test fixture that combines a symlinked `.gsd` with a `.gitignore` containing `.gsd` — the exact combo no existing fixture had.

Fixes #4600.

## Root cause (short version)

ADR-002 made `.gsd` a gitignored symlink. `ensureGitignore` writes `.gsd` to `.gitignore`. `git stash push --include-untracked -- <explicit-pathspec>` uses `git add` semantics, which reject gitignored entries with a fatal. Without an explicit pathspec, git silently skips ignored entries. The #2505 fix was supposed to drop `--include-untracked` entirely (per the test comment) but the implementation kept the flag and added pathspec exclusions instead, which in turn broke once the symlink layout landed.

## Test plan

- [x] `stash-queued-context-files.test.ts` — all 5 tests pass, including new `#4600` regression.
- [x] `stash-pop-gsd-conflict.test.ts` — `#2766` auto-resolve + manual-resolve still pass.
- [x] `auto-stash-merge.test.ts` (integration) — all green.
- [x] `auto-worktree-milestone-merge.test.ts` (integration) — all green; specifically `#1738 e2e: dirty tree is stashed before merge (#2151)` passes, confirming the safety net is preserved.
- [x] Empirical repro against a fresh repo with `.gsd` symlink + `.gitignore` containing `.gsd` — `git stash push --include-untracked` (no pathspec) succeeds; with pathspec it fatals. Verified the bug and fix at the git-command level.
- [ ] Run full `npm run test:unit` + `npm run test:integration` before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue with milestone merge operations in repositories where `.gsd` is configured as a gitignored symlink, ensuring the pre-merge stash workflow executes correctly without data loss.

* **Tests**
  * Added regression test to verify milestone merge operations work correctly when `.gsd` is a gitignored symlink.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->