### PR TITLE
feat(ci): dynamic system-specific verification checklists in pr-risk-check

### DIFF
--- a/scripts/pr-risk-check.mjs
+++ b/scripts/pr-risk-check.mjs
@@ -60,6 +60,41 @@ const TIER_EMOJI = {
   low:      '🟢',
 };
 
+// Maps each system label to the specific verification task a reviewer/agent should perform.
+const SYSTEM_CHECKS = {
+  'State Machine':     'test state persistence across a session restart',
+  'Agent Core':        'check for race conditions and loop exit paths in the agent loop',
+  'Auth/OAuth':        'verify auth token lifecycle (create, refresh, revoke)',
+  'Permissions':       'audit permission escalation paths and boundary enforcement',
+  'Auto Engine':       'validate auto-mode trigger conditions and loop termination',
+  'MCP Server/Client': 'confirm no breaking changes to RPC/MCP protocol compatibility',
+  'Native/Rust Tools': 'run native tool smoke tests and check FFI boundary safety',
+  'GSD Workflow':      'verify GSD workflow state transitions end-to-end',
+  'Tool System':       'verify tool call and response contracts are unchanged',
+  'AI Providers':      'confirm provider API contract and error handling are intact',
+  'Extension Registry':'check extension registration and lifecycle hooks',
+  'Session Management':'test session creation, restoration, and teardown',
+  'Extensions':        'verify extension event dispatch and hook ordering',
+  'Modes':             'test mode switching transitions and state isolation',
+  'Event System':      'confirm event emission ordering and listener cleanup',
+  'Node.js Bindings':  'run Node.js native binding smoke tests',
+  'Compaction':        'verify compaction does not drop or corrupt context',
+};
+
+/**
+ * Builds a single copy-paste prompt for a coding agent based on the actual
+ * flagged systems in this PR. Returns null if no actionable systems are found.
+ */
+function buildAgentPrompt(systemRisks) {
+  const relevant = systemRisks.filter(({ tier }) => tier === 'critical' || tier === 'high');
+  const checks = relevant.map(({ system }) => SYSTEM_CHECKS[system]).filter(Boolean);
+  if (checks.length === 0) return null;
+
+  const systemNames = relevant.map(({ system }) => system).join(', ');
+  const checkList = checks.map((c, i) => `${i + 1}) ${c}`).join('; ');
+  return `Review this PR for risks in: ${systemNames}. Verify: ${checkList}. Report all findings before I merge.`;
+}
+
 // ---------------------------------------------------------------------------
 // Parse FILE-SYSTEM-MAP.md
 // ---------------------------------------------------------------------------
@@ -269,17 +304,21 @@ function renderConsole(report) {
   }
 
   // Reviewer checklist
-  if (risk === 'critical') {
-    console.log('⚠️  Reviewer checklist for CRITICAL changes:');
-    console.log('  • Test state persistence across session restart');
-    console.log('  • Verify auth token lifecycle (create, refresh, revoke)');
-    console.log('  • Check for race conditions in agent loop');
-    console.log('  • Ensure no breaking changes to RPC protocol');
-  } else if (risk === 'high') {
-    console.log('⚠️  Reviewer checklist for HIGH-risk changes:');
-    console.log('  • Run full integration test suite');
-    console.log('  • Verify tool call/response contracts unchanged');
-    console.log('  • Check extension event dispatch still works');
+  if (risk === 'critical' || risk === 'high') {
+    const label = risk === 'critical' ? 'CRITICAL' : 'HIGH-risk';
+    console.log(`⚠️  Reviewer checklist for ${label} changes:`);
+    for (const { system } of systemRisks.filter(r => r.tier === 'critical' || r.tier === 'high')) {
+      const check = SYSTEM_CHECKS[system];
+      if (check) console.log(`  • [${system}] ${check}`);
+    }
+    const prompt = buildAgentPrompt(systemRisks);
+    if (prompt) {
+      console.log('');
+      console.log('  Ask your coding agent before submitting:');
+      console.log(`  "${prompt}"`);
+      console.log('');
+      console.log('  Have a Codex subscription? Run: codex review --adversarial');
+    }
   }
 
   console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n');
@@ -329,10 +368,25 @@ function renderGitHubSummary(report) {
     lines.push('');
   }
 
-  if (risk === 'critical') {
-    lines.push('> ⚠️ **Critical risk** — please verify: state persistence, auth token lifecycle, agent loop race conditions, RPC protocol compatibility.');
-  } else if (risk === 'high') {
-    lines.push('> ⚠️ **High risk** — please run full integration tests and verify tool/extension contracts.');
+  if (risk === 'critical' || risk === 'high') {
+    const label = risk === 'critical' ? '🔴 Critical' : '🟠 High';
+    const flagged = systemRisks.filter(r => r.tier === 'critical' || r.tier === 'high');
+    lines.push(`> ⚠️ **${label} risk** — the following systems require verification before merge:`);
+    lines.push('>');
+    for (const { system, tier } of flagged) {
+      const check = SYSTEM_CHECKS[system];
+      if (check) lines.push(`> - ${TIER_EMOJI[tier]} **${system}**: ${check}`);
+    }
+    const prompt = buildAgentPrompt(systemRisks);
+    if (prompt) {
+      lines.push('>');
+      lines.push('> **Ask your coding agent to verify before submitting:**');
+      lines.push('> ```');
+      lines.push(`> ${prompt}`);
+      lines.push('> ```');
+      lines.push('>');
+      lines.push('> 💡 **Have a Codex subscription?** Get an independent second opinion: `codex review --adversarial`');
+    }
   }
 
   return lines.join('\n');


### PR DESCRIPTION
## Linked issue

Closes #4612

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Replace static hardcoded reviewer checklists in `scripts/pr-risk-check.mjs` with dynamic, system-specific verification tasks driven by whatever systems the risk checker actually flagged.
**Why:** The old text always listed the same steps regardless of what the PR touched, making the checklist noise rather than signal.
**How:** Add a `SYSTEM_CHECKS` map and `buildAgentPrompt()` function; update both `renderConsole` and `renderGitHubSummary` to iterate only the flagged systems and emit contextual checks plus a copy-paste agent prompt.

## What

`scripts/pr-risk-check.mjs` — the CI/local PR risk checker that analyses changed files and posts a risk summary as a GitHub PR comment and to the terminal.

- **`SYSTEM_CHECKS` map** — 17 entries covering every critical/high-risk system label the checker can produce. Each maps to a single actionable verification string.
- **`buildAgentPrompt(systemRisks)`** — filters to critical/high-tier systems and assembles a ready-to-paste one-liner for a coding agent.
- **`renderConsole` update** — terminal checklist now iterates only the flagged systems, prints the generated agent prompt, and adds a `codex review --adversarial` tip.
- **`renderGitHubSummary` update** — PR comment renders a per-system bullet list with tier emoji and a fenced code block containing the agent prompt.

## Why

The previous implementation emitted the same boilerplate on every critical or high-risk PR regardless of which systems were actually touched. Reviewers receiving irrelevant instructions skim or ignore them, defeating the purpose of the risk check.

## How

`SYSTEM_CHECKS` is a plain object literal consulted by both `buildAgentPrompt` and the two render functions. Adding coverage for a new system label is a single line. `buildAgentPrompt` is a pure function — it filters the `systemRisks` array already produced by the existing analysis logic and returns null when there is nothing actionable.

## Change type

- [x] `feat` — New feature or capability
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [x] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes

## Test plan

Manual verification: run the script against a branch touching Auth/OAuth and MCP files; confirm console output lists only those system checks and the agent prompt names only those systems. Repeat for a low-risk branch and confirm no checklist is emitted.

## AI disclosure

- [x] This PR includes AI-assisted code — drafted with Claude (Sonnet 4.6). The `SYSTEM_CHECKS` entries, `buildAgentPrompt` logic, and render-function changes were reviewed against the existing script structure before committing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced internal PR verification workflow with improved system checking and reporting capabilities.

*Note: This release contains internal improvements with no user-facing changes.*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->