### PR TITLE
fix(welcome-screen): truncate Active row text to prevent terminal overflow

### DIFF
--- a/src/tests/welcome-screen.test.ts
+++ b/src/tests/welcome-screen.test.ts
@@ -114,10 +114,12 @@ test('Active row truncates with ellipsis when milestone text overflows panel wid
     rmSync(tmp, { recursive: true, force: true })
   })
 
+  const columns = (process.stderr as any).columns as number
   const out = strip(capture({ version: '1.0.0' }))
   const activeLine = out.split('\n').find(l => /Active\s/.test(l))
   assert.ok(activeLine, 'Active row should be present')
   assert.ok(activeLine!.includes('…'), 'Active row should truncate long text with ellipsis')
+  assert.ok(activeLine!.length <= columns, `Active row length ${activeLine!.length} should not exceed terminal width ${columns}`)
 })
 
 test('Active row does not truncate short milestone text', (t) => {

--- a/src/tests/welcome-screen.test.ts
+++ b/src/tests/welcome-screen.test.ts
@@ -4,6 +4,9 @@
 
 import test from 'node:test'
 import assert from 'node:assert/strict'
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 
 import { printWelcomeScreen } from '../../dist/welcome-screen.js'
 
@@ -87,6 +90,56 @@ test('omits remote channel when not provided', () => {
   assert.ok(!out.includes('Discord'), 'should not show Discord when no remote')
   assert.ok(!out.includes('Slack'), 'should not show Slack when no remote')
   assert.ok(!out.includes('Telegram'), 'should not show Telegram when no remote')
+})
+
+test('Active row truncates with ellipsis when milestone text overflows panel width', (t) => {
+  const tmp = mkdtempSync(join(tmpdir(), 'gsd-welcome-test-'))
+  mkdirSync(join(tmp, '.gsd'))
+  writeFileSync(
+    join(tmp, '.gsd', 'STATE.md'),
+    [
+      '**Active Milestone:** M001: Todo App – Core add/complete/delete with localStorage persistence and offline sync support',
+      '**Phase:** evaluating-gates',
+      '**Active Slice:** S01: implement full persistence layer with IndexedDB fallback',
+    ].join('\n'),
+  )
+  const origCwd = process.cwd()
+  process.chdir(tmp)
+  const origColumns = (process.stderr as any).columns
+  ;(process.stderr as any).columns = 120
+
+  t.after(() => {
+    process.chdir(origCwd)
+    ;(process.stderr as any).columns = origColumns
+    rmSync(tmp, { recursive: true, force: true })
+  })
+
+  const out = strip(capture({ version: '1.0.0' }))
+  const activeLine = out.split('\n').find(l => /Active\s/.test(l))
+  assert.ok(activeLine, 'Active row should be present')
+  assert.ok(activeLine!.includes('…'), 'Active row should truncate long text with ellipsis')
+})
+
+test('Active row does not truncate short milestone text', (t) => {
+  const tmp = mkdtempSync(join(tmpdir(), 'gsd-welcome-test-'))
+  mkdirSync(join(tmp, '.gsd'))
+  writeFileSync(join(tmp, '.gsd', 'STATE.md'), '**Active Milestone:** M001: Short title\n')
+  const origCwd = process.cwd()
+  process.chdir(tmp)
+  const origColumns = (process.stderr as any).columns
+  ;(process.stderr as any).columns = 120
+
+  t.after(() => {
+    process.chdir(origCwd)
+    ;(process.stderr as any).columns = origColumns
+    rmSync(tmp, { recursive: true, force: true })
+  })
+
+  const out = strip(capture({ version: '1.0.0' }))
+  const activeLine = out.split('\n').find(l => /Active\s/.test(l))
+  assert.ok(activeLine, 'Active row should be present')
+  assert.ok(activeLine!.includes('M001: Short title'), 'short title should appear in full')
+  assert.ok(!activeLine!.includes('…'), 'short title should not be truncated')
 })
 
 test('separator lines extend to full terminal width on wide terminals', (t) => {

--- a/src/welcome-screen.ts
+++ b/src/welcome-screen.ts
@@ -118,7 +118,11 @@ export function printWelcomeScreen(opts: WelcomeScreenOptions): void {
   let line2 = ''
   if (state?.milestone) {
     const statusParts = [state.milestone, state.phase, state.slice].filter(Boolean)
-    line1 = `  Active     ${chalk.dim(statusParts.join(' · '))}`
+    const activePrefix = '  Active     '
+    const maxActiveLen = RIGHT_INNER - activePrefix.length - 1
+    let activeText = statusParts.join(' · ')
+    if (activeText.length > maxActiveLen) activeText = activeText.slice(0, maxActiveLen - 1) + '…'
+    line1 = `${activePrefix}${chalk.dim(activeText)}`
     line2 = state.nextAction
       ? `  Next       ${chalk.dim(state.nextAction)}`
       : ''


### PR DESCRIPTION
## TL;DR

**What:** Truncate the Active row text in the welcome screen when it exceeds the panel width.
**Why:** Long milestone/phase/slice strings overflow the right panel boundary in the terminal.
**How:** Measure available width, slice the joined string, and append `…` when over the limit.

## What

`src/welcome-screen.ts` — `printWelcomeScreen()`. The `statusParts.join(' · ')` string (milestone · phase · slice) is now capped at `RIGHT_INNER - prefix_length - 1` visible characters before being passed to `chalk.dim()`.

## Why

When a project has a long milestone title, the Active row renders past the right edge of the terminal panel, breaking the layout. The fixed 8-row structure makes wrapping impractical — truncation is the right fit for a single-line status display.

Closes #4616

## How

Calculate max content width from `RIGHT_INNER` minus the fixed prefix length (`  Active     ` = 13 chars). If the joined string exceeds that, slice and append `…`. No layout changes — the 8-row fixed structure is preserved.

---

### Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

### Test plan

- [ ] Run `gsd` in a project with a long milestone title — Active row truncates with `…`
- [ ] Short milestone titles still display in full
- [ ] Narrow terminal fallback (<70 cols) unaffected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rendering of the “Active” session line by constraining visible width and truncating with an ellipsis so status text no longer overflows the panel.

* **Tests**
  * Added unit tests validating truncated and non-truncated “Active” line behavior across different terminal widths and session content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->