### PR TITLE
fix(pi-coding-agent): apply redaction before file entry serialization

### DIFF
--- a/packages/pi-coding-agent/src/core/session-manager.test.ts
+++ b/packages/pi-coding-agent/src/core/session-manager.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { describe, it, afterEach } from "node:test";
-import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
@@ -95,6 +95,35 @@ describe("SessionManager secret redaction on persistence", () => {
 		assert.ok(
 			contents.includes("[REDACTED:llamacloud]"),
 			"redaction placeholder must appear in persisted JSONL",
+		);
+	});
+
+	it("scrubs secrets from JSONL rewritten by _rewriteFile() during migration", () => {
+		// Write a v1 session file (no id/parentId on entries) containing a secret.
+		// setSessionFile() will detect version < 3, run migration, and call _rewriteFile()
+		// which previously serialised entries without passing them through redaction.
+		dir = mkdtempSync(join(tmpdir(), "gsd-session-rewrite-redact-test-"));
+		const leakedKey = "sk-ant-api03-abcDEF1234567890abcDEF1234567890xYz";
+		const v1Header = JSON.stringify({ type: "session", version: 1, id: "test-session-id", timestamp: new Date().toISOString(), cwd: dir });
+		const v1UserMsg = JSON.stringify({ type: "message", message: { role: "user", content: [{ type: "text", text: `secret: ${leakedKey}` }] } });
+		const v1AssistantMsg = JSON.stringify({ type: "message", message: { role: "assistant", content: [{ type: "text", text: "ok" }], usage: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0, total: 2, cost: { total: 0 } } } });
+		const sessionFile = join(dir, "test-session.jsonl");
+		writeFileSync(sessionFile, [v1Header, v1UserMsg, v1AssistantMsg].join("\n") + "\n", "utf8");
+
+		// Loading this file triggers migrateToCurrentVersion() which returns true (v1 → v3),
+		// causing _rewriteFile() to rewrite the file. The bug: _rewriteFile() called
+		// JSON.stringify(e) without redaction, so the secret would survive on disk.
+		const manager = SessionManager.create(dir, dir);
+		manager.setSessionFile(sessionFile);
+
+		const contents = readFileSync(sessionFile, "utf8");
+		assert.ok(
+			!contents.includes(leakedKey),
+			"raw secret must not appear in JSONL rewritten by _rewriteFile()",
+		);
+		assert.ok(
+			contents.includes("[REDACTED:anthropic]"),
+			"redaction placeholder must appear in JSONL rewritten by _rewriteFile()",
 		);
 	});
 });

--- a/packages/pi-coding-agent/src/core/session-manager.ts
+++ b/packages/pi-coding-agent/src/core/session-manager.ts
@@ -959,7 +959,7 @@ export class SessionManager {
 
 	private _rewriteFile(): void {
 		if (!this.persist || !this.sessionFile) return;
-		const content = `${this.fileEntries.map((e) => JSON.stringify(e)).join("\n")}\n`;
+		const content = `${this.fileEntries.map((e) => JSON.stringify(prepareForPersistence(e, this.blobStore))).join("\n")}\n`;
 		let release: (() => void) | undefined;
 		try {
 			release = tryAcquireLockSync(this.sessionFile);


### PR DESCRIPTION
## Summary
- `_rewriteFile()` was calling `JSON.stringify` on file entries without first applying the redaction funnel
- Sensitive values (API keys, secrets) matching redaction patterns could leak into serialized output whenever `_rewriteFile()` was triggered (e.g. after schema migration or branch rewrite)
- Now applies existing `prepareForPersistence()` (which calls `redactSecrets()`) to each entry before serialization, consistent with the existing `_persist()` path
- Added unit test verifying secrets are redacted in serialized output when `_rewriteFile()` is triggered via migration

Closes #4589

Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Session files now ensure secrets are properly redacted before being saved to disk, protecting sensitive information in session data storage.

* **Tests**
  * Added test coverage for secret redaction behavior during session file migration and rewriting operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
