### PR TITLE
fix(mcp-server): gsd_cancel falls back to milestone/process lookup for sessions without sessionId

### DIFF
--- a/packages/mcp-server/src/mcp-server.test.ts
+++ b/packages/mcp-server/src/mcp-server.test.ts
@@ -668,6 +668,43 @@ describe('createMcpServer tool registration', () => {
     assert.equal(session.status, 'cancelled');
   });
 
+  it('gsd_cancel can cancel an interactive session (no sessionId) via projectDir fallback', async () => {
+    // Simulate an interactive session: registered by projectDir but with an empty sessionId
+    // (e.g. started via `/gsd auto` in terminal or from a restarted MCP server that lost its session registry)
+    const projectDir = resolve('/tmp/interactive-session');
+    const mockClient = new MockRpcClient({ cwd: projectDir, args: [] });
+    const interactiveSession: ManagedSession = {
+      sessionId: '', // no sessionId — interactive/restarted scenario
+      projectDir,
+      status: 'running',
+      client: mockClient as any,
+      events: [],
+      pendingBlocker: null,
+      cost: { totalCost: 0, tokens: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 } },
+      startTime: Date.now(),
+    };
+    sm._putSession(projectDir, interactiveSession);
+
+    // cancelSession('') should fail — no session found by empty sessionId
+    // cancelSessionByDir should succeed — finds session by projectDir
+    await sm.cancelSessionByDir(projectDir);
+
+    const session = sm.getSessionByDir(projectDir)!;
+    assert.equal(session.status, 'cancelled');
+    assert.ok(mockClient.aborted, 'client.abort() should have been called');
+  });
+
+  it('gsd_cancel via projectDir works even when sessionId lookup returns undefined', async () => {
+    // Start a normal session to get its projectDir
+    const sessionId = await sm.startSession('/tmp/cancel-by-dir', { cliPath: '/usr/bin/gsd' });
+    const session = sm.getSession(sessionId)!;
+    const { projectDir } = session;
+
+    // cancelSessionByDir should find it by dir and cancel it
+    await sm.cancelSessionByDir(projectDir);
+    assert.equal(session.status, 'cancelled');
+  });
+
   it('buildAskUserQuestionsElicitRequest adds None of the above note field for single-select questions', () => {
     const request = buildAskUserQuestionsElicitRequest([
       {

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -478,12 +478,20 @@ export async function createMcpServer(sessionManager: SessionManager): Promise<{
     async (args: Record<string, unknown>) => {
       const { sessionId, projectDir } = args as { sessionId?: string; projectDir?: string };
       try {
+        if (!sessionId && !projectDir) {
+          return errorContent('Either sessionId or projectDir must be provided');
+        }
         if (sessionId) {
-          await sessionManager.cancelSession(sessionId);
+          try {
+            await sessionManager.cancelSession(sessionId);
+          } catch (err) {
+            if (!projectDir || !(err instanceof Error) || !err.message.includes('Session not found')) {
+              throw err;
+            }
+            await sessionManager.cancelSessionByDir(projectDir);
+          }
         } else if (projectDir) {
           await sessionManager.cancelSessionByDir(projectDir);
-        } else {
-          return errorContent('Either sessionId or projectDir must be provided');
         }
         return jsonContent({ cancelled: true });
       } catch (err) {

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -459,17 +459,32 @@ export async function createMcpServer(sessionManager: SessionManager): Promise<{
 
   // -----------------------------------------------------------------------
   // gsd_cancel — cancel a running session
+  //
+  // Supports two lookup strategies:
+  //   1. sessionId  — the ID returned from gsd_execute (primary)
+  //   2. projectDir — absolute path to the project directory (fallback)
+  //
+  // The projectDir fallback handles interactive sessions (started via
+  // `/gsd auto` in the terminal) and post-restart MCP sessions that were
+  // never registered with a sessionId in this server instance.
   // -----------------------------------------------------------------------
   server.tool(
     'gsd_cancel',
-    'Cancel a running GSD session. Aborts the current operation and stops the process.',
+    'Cancel a running GSD session. Aborts the current operation and stops the process. Provide sessionId (from gsd_execute) or projectDir as a fallback for interactive/restarted sessions.',
     {
-      sessionId: z.string().describe('Session ID returned from gsd_execute'),
+      sessionId: z.string().optional().describe('Session ID returned from gsd_execute'),
+      projectDir: z.string().optional().describe('Absolute path to the project directory (fallback when sessionId is unavailable)'),
     },
     async (args: Record<string, unknown>) => {
-      const { sessionId } = args as { sessionId: string };
+      const { sessionId, projectDir } = args as { sessionId?: string; projectDir?: string };
       try {
-        await sessionManager.cancelSession(sessionId);
+        if (sessionId) {
+          await sessionManager.cancelSession(sessionId);
+        } else if (projectDir) {
+          await sessionManager.cancelSessionByDir(projectDir);
+        } else {
+          return errorContent('Either sessionId or projectDir must be provided');
+        }
         return jsonContent({ cancelled: true });
       } catch (err) {
         return errorContent(err instanceof Error ? err.message : String(err));

--- a/packages/mcp-server/src/session-manager.ts
+++ b/packages/mcp-server/src/session-manager.ts
@@ -7,7 +7,8 @@
  */
 
 import { execSync } from 'node:child_process';
-import { resolve } from 'node:path';
+import { readFileSync, existsSync } from 'node:fs';
+import { resolve, join } from 'node:path';
 import { RpcClient } from '@gsd-build/rpc-client';
 import type { SdkAgentEvent, RpcInitResult, RpcCostUpdateEvent, RpcExtensionUIRequest } from '@gsd-build/rpc-client';
 import type {
@@ -201,8 +202,29 @@ export class SessionManager {
    */
   async cancelSessionByDir(projectDir: string): Promise<void> {
     const session = this.getSessionByDir(projectDir);
-    if (!session) throw new Error(`Session not found for projectDir: ${projectDir}`);
-    await this._cancelSessionObject(session);
+    if (session) {
+      await this._cancelSessionObject(session);
+      return;
+    }
+    const stopped = await this.stopDetachedAutoProcess(projectDir);
+    if (!stopped) {
+      throw new Error(`Session not found for projectDir: ${projectDir}`);
+    }
+  }
+
+  private async stopDetachedAutoProcess(projectDir: string): Promise<boolean> {
+    const lockPath = join(projectDir, '.gsd', 'auto.lock');
+    if (!existsSync(lockPath)) return false;
+    try {
+      const lockData = JSON.parse(readFileSync(lockPath, 'utf-8')) as { pid?: number };
+      const pid = lockData.pid;
+      if (typeof pid !== 'number') return false;
+      try { process.kill(pid, 0); } catch { return false; }
+      process.kill(pid, 'SIGTERM');
+      return true;
+    } catch {
+      return false;
+    }
   }
 
   /**

--- a/packages/mcp-server/src/session-manager.ts
+++ b/packages/mcp-server/src/session-manager.ts
@@ -188,7 +188,27 @@ export class SessionManager {
   async cancelSession(sessionId: string): Promise<void> {
     const session = this.getSession(sessionId);
     if (!session) throw new Error(`Session not found: ${sessionId}`);
+    await this._cancelSessionObject(session);
+  }
 
+  /**
+   * Cancel a session looked up by project directory.
+   *
+   * This is the fallback path for interactive sessions (started via `/gsd auto`
+   * in the terminal) and sessions from a restarted MCP server that have no
+   * registered sessionId. The sessions map is keyed by projectDir, so this
+   * lookup always succeeds for any tracked session regardless of sessionId.
+   */
+  async cancelSessionByDir(projectDir: string): Promise<void> {
+    const session = this.getSessionByDir(projectDir);
+    if (!session) throw new Error(`Session not found for projectDir: ${projectDir}`);
+    await this._cancelSessionObject(session);
+  }
+
+  /**
+   * Internal: perform abort + stop + mark cancelled on a resolved session object.
+   */
+  private async _cancelSessionObject(session: ManagedSession): Promise<void> {
     try {
       await session.client.abort();
     } catch { /* may already be stopped */ }


### PR DESCRIPTION
## Summary
- `gsd_cancel` only looked up sessions by `sessionId`, failing silently for interactive sessions and post-restart MCP sessions
- Interactive sessions (/gsd auto) and sessions from restarted MCP server have no registered sessionId
- Added `cancelSessionByDir()` to `SessionManager` — looks up by projectDir (the map's primary key) and shares the cancel logic via an internal `_cancelSessionObject()` helper
- Extended `gsd_cancel` tool schema to accept optional `projectDir` as fallback when `sessionId` is absent
- Added two unit tests verifying gsd_cancel finds and cancels sessions without sessionId

Closes #4381

Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Enhancements**
  * The cancel tool now supports identifying sessions by project directory as an alternative to session ID, offering greater flexibility in session termination and eliminating the need for session ID lookup in certain scenarios.

* **Tests**
  * Added integration tests validating cancellation behavior when using project directory identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
