### PR TITLE
fix(gsd-exec): derive artifact paths from meta file location, not JSON content

### DIFF
--- a/src/resources/extensions/gsd/tests/exec-history.test.ts
+++ b/src/resources/extensions/gsd/tests/exec-history.test.ts
@@ -122,3 +122,116 @@ test('executeExecSearch: includes stdout_path and preview in details', () => {
     cleanup(base);
   }
 });
+
+// ── Path traversal security tests (issue #4590) ───────────────────────────
+
+test('safeReadMeta: ignores malicious stdout_path in JSON, derives path from meta file location', () => {
+  // Arrange: write a .meta.json whose JSON content has a path-traversal value
+  // in stdout_path / stderr_path. The read-side must silently discard these
+  // and derive sibling paths from the actual .meta.json location instead.
+  const base = freshBase();
+  try {
+    const dir = join(base, '.gsd', 'exec');
+    mkdirSync(dir, { recursive: true });
+    const id = 'traversal-test-run';
+    const metaPath = join(dir, `${id}.meta.json`);
+    const stdoutPath = join(dir, `${id}.stdout`);
+    const stderrPath = join(dir, `${id}.stderr`);
+    // Write real sibling files so digest_preview can succeed.
+    writeFileSync(stdoutPath, 'legitimate stdout content\n');
+    writeFileSync(stderrPath, '');
+    // Write a meta.json that tries to point stdout_path outside the exec dir.
+    writeFileSync(
+      metaPath,
+      JSON.stringify({
+        id,
+        runtime: 'bash',
+        purpose: 'test run',
+        started_at: '2026-04-20T12:00:00.000Z',
+        finished_at: '2026-04-20T12:00:00.100Z',
+        duration_ms: 100,
+        exit_code: 0,
+        signal: null,
+        timed_out: false,
+        stdout_bytes: 24,
+        stderr_bytes: 0,
+        stdout_truncated: false,
+        stderr_truncated: false,
+        // These malicious values must NEVER be used as filesystem paths.
+        stdout_path: '../../etc/passwd',
+        stderr_path: '../../etc/shadow',
+      }),
+    );
+
+    const entries = listExecHistory(base);
+    assert.equal(entries.length, 1);
+    const entry = entries[0]!;
+
+    // stdout_path must be derived from the meta file location, not from JSON.
+    assert.equal(entry.stdout_path, stdoutPath,
+      `stdout_path must be a sibling of the meta file; got: ${entry.stdout_path}`);
+    assert.equal(entry.stderr_path, stderrPath,
+      `stderr_path must be a sibling of the meta file; got: ${entry.stderr_path}`);
+
+    // Verify neither traversal string leaked into the returned entry.
+    assert.ok(!entry.stdout_path.includes('..'),
+      `stdout_path must not contain path traversal sequences: ${entry.stdout_path}`);
+    assert.ok(!entry.stderr_path.includes('..'),
+      `stderr_path must not contain path traversal sequences: ${entry.stderr_path}`);
+    assert.ok(!entry.stdout_path.includes('etc/passwd'),
+      `stdout_path must not point to /etc/passwd: ${entry.stdout_path}`);
+  } finally {
+    cleanup(base);
+  }
+});
+
+test('searchExecHistory: digest_preview is read from derived sibling path, not JSON stdout_path', () => {
+  // Arrange: a .meta.json with a malicious stdout_path pointing to /etc/passwd.
+  // The digest_preview should be read from the real sibling .stdout file,
+  // not from the JSON-supplied path.
+  const base = freshBase();
+  try {
+    const dir = join(base, '.gsd', 'exec');
+    mkdirSync(dir, { recursive: true });
+    const id = 'preview-traversal-run';
+    const metaPath = join(dir, `${id}.meta.json`);
+    const stdoutPath = join(dir, `${id}.stdout`);
+    writeFileSync(stdoutPath, 'safe-sentinel-content\n');
+    writeFileSync(join(dir, `${id}.stderr`), '');
+    writeFileSync(
+      metaPath,
+      JSON.stringify({
+        id,
+        runtime: 'bash',
+        purpose: null,
+        started_at: '2026-04-20T12:00:00.000Z',
+        finished_at: '2026-04-20T12:00:00.100Z',
+        duration_ms: 50,
+        exit_code: 0,
+        signal: null,
+        timed_out: false,
+        stdout_bytes: 21,
+        stderr_bytes: 0,
+        stdout_truncated: false,
+        stderr_truncated: false,
+        // Attacker-controlled path — must be ignored.
+        stdout_path: '/etc/passwd',
+        stderr_path: '/etc/shadow',
+      }),
+    );
+
+    const hits = searchExecHistory(base, {});
+    assert.equal(hits.length, 1);
+    const hit = hits[0]!;
+
+    // The preview must come from the safe sibling, not /etc/passwd.
+    assert.ok(
+      hit.digest_preview?.includes('safe-sentinel-content'),
+      `digest_preview should contain safe-sentinel-content; got: ${hit.digest_preview}`,
+    );
+    // Ensure the entry paths are the derived ones.
+    assert.equal(hit.entry.stdout_path, stdoutPath);
+  } finally {
+    cleanup(base);
+  }
+});


### PR DESCRIPTION
## Summary
- \`stdout_path\` and \`stderr_path\` were trusted verbatim from \`.meta.json\` content, enabling path traversal to arbitrary filesystem locations
- Now derived as sibling files of the real \`.meta.json\` path using \`path.replace(/\.meta\.json\$/, '.stdout')\`
- Added unit tests verifying malicious path values (e.g. \`../../etc/passwd\`, \`/etc/passwd\`) are ignored and safe sibling paths are used instead

Closes #4590

Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for exec history metadata parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
