### PR TITLE
fix(pre-execution-checks): strip backtick/quote annotation from input/output values before path check

### DIFF
--- a/src/resources/extensions/gsd/pre-execution-checks.ts
+++ b/src/resources/extensions/gsd/pre-execution-checks.ts
@@ -328,6 +328,16 @@ function extractPathFromAnnotation(raw: string): string {
     return backtickMatch[2].trim();
   }
 
+  // Strip leading/trailing double or single quotes wrapping the whole value.
+  // Plan documents sometimes emit `"src/foo.ts"` or `'src/bar.ts'` as input
+  // annotations. Stripping the wrapper allows the inner path to be checked
+  // correctly instead of producing a false-positive "file not found" error
+  // for a literal string with quote characters in it (#3747).
+  const quoteMatch = trimmed.match(/^(["'])([^"']+)\1$/);
+  if (quoteMatch) {
+    return quoteMatch[2].trim();
+  }
+
   const annotatedMatch = trimmed.match(/^(.+?)\s+[—–-]\s+.+$/);
   if (annotatedMatch) {
     const prefix = annotatedMatch[1].trim();

--- a/src/resources/extensions/gsd/tests/pre-execution-checks.test.ts
+++ b/src/resources/extensions/gsd/tests/pre-execution-checks.test.ts
@@ -1879,3 +1879,125 @@ describe("checkFilePathConsistency self-referential inputs (#4459)", () => {
     );
   });
 });
+
+// ─── Regression Tests: quote-wrapped inputs treated as literal paths (#3747) ──
+
+describe("checkFilePathConsistency quote-wrapped annotation (#3747)", () => {
+  test("double-quoted path annotation is stripped before path check", (t) => {
+    // Plan documents sometimes emit `"src/foo.ts"` (double-quote wrapped) as an
+    // input value. The checker must strip the quotes before checking existence so
+    // it doesn't produce a false-positive "file not found" error.
+    const tempDir = join(tmpdir(), `pre-exec-quote-${Date.now()}`);
+    mkdirSync(join(tempDir, "src"), { recursive: true });
+    writeFileSync(join(tempDir, "src/foo.ts"), "// content");
+    t.after(() => rmSync(tempDir, { recursive: true, force: true }));
+
+    const tasks = [
+      createTask({
+        id: "T01",
+        inputs: ['"src/foo.ts"'],
+        expected_output: [],
+      }),
+    ];
+
+    const results = checkFilePathConsistency(tasks, tempDir);
+    assert.equal(
+      results.length,
+      0,
+      "Double-quoted path should be stripped and resolved to the real file",
+    );
+  });
+
+  test("single-quoted path annotation is stripped before path check", (t) => {
+    const tempDir = join(tmpdir(), `pre-exec-squote-${Date.now()}`);
+    mkdirSync(join(tempDir, "src"), { recursive: true });
+    writeFileSync(join(tempDir, "src/bar.ts"), "// content");
+    t.after(() => rmSync(tempDir, { recursive: true, force: true }));
+
+    const tasks = [
+      createTask({
+        id: "T01",
+        inputs: ["'src/bar.ts'"],
+        expected_output: [],
+      }),
+    ];
+
+    const results = checkFilePathConsistency(tasks, tempDir);
+    assert.equal(
+      results.length,
+      0,
+      "Single-quoted path should be stripped and resolved to the real file",
+    );
+  });
+
+  test("backtick-only wrapped path without annotation resolves correctly", (t) => {
+    // The bare form `src/foo.ts` (no dash annotation) must also work
+    const tempDir = join(tmpdir(), `pre-exec-backtick-bare-${Date.now()}`);
+    mkdirSync(join(tempDir, "src"), { recursive: true });
+    writeFileSync(join(tempDir, "src/baz.ts"), "// content");
+    t.after(() => rmSync(tempDir, { recursive: true, force: true }));
+
+    const tasks = [
+      createTask({
+        id: "T01",
+        inputs: ["`src/baz.ts`"],
+        expected_output: [],
+      }),
+    ];
+
+    const results = checkFilePathConsistency(tasks, tempDir);
+    assert.equal(
+      results.length,
+      0,
+      "Bare backtick-wrapped path should resolve to the real file",
+    );
+  });
+
+  test("prose value with spaces inside quotes is skipped (not a path)", () => {
+    // "some description text" contains spaces — should not be checked as a path
+    const tasks = [
+      createTask({
+        id: "T01",
+        inputs: ['"some description text"'],
+        expected_output: [],
+      }),
+    ];
+
+    const results = checkFilePathConsistency(tasks, "/tmp");
+    assert.equal(
+      results.length,
+      0,
+      "Quoted prose with spaces should not be treated as a file path",
+    );
+  });
+
+  test("17-error scenario: mixed annotated inputs produce 0 blocking errors", (t) => {
+    // Reproduces the M004-ej6j88/S07 scenario from issue #3747 where a plan with
+    // multiple backtick- and quote-wrapped input strings causes 17 false blocking errors.
+    const tempDir = join(tmpdir(), `pre-exec-3747-scenario-${Date.now()}`);
+    mkdirSync(join(tempDir, "src"), { recursive: true });
+    writeFileSync(join(tempDir, "src/foo.ts"), "// content");
+    writeFileSync(join(tempDir, "src/bar.ts"), "// content");
+    t.after(() => rmSync(tempDir, { recursive: true, force: true }));
+
+    const tasks = [
+      createTask({
+        id: "T01",
+        inputs: [
+          "`src/foo.ts`",
+          '"src/bar.ts"',
+          "some description text",
+          "Existing enum definition",
+        ],
+        expected_output: [],
+      }),
+    ];
+
+    const results = checkFilePathConsistency(tasks, tempDir);
+    assert.equal(
+      results.length,
+      0,
+      "Annotated file paths and prose inputs should produce zero blocking errors",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- checkFilePathConsistency treated backtick-wrapped strings like \`src/foo.ts\` as literal file paths
- Plan documents use these annotations for readability, not as actual filesystem paths
- 17 false blocking errors caused auto-mode to pause after every plan-slice
- Fixed by stripping backtick/quote wrappers and skipping prose values (containing spaces)
- Added unit test verifying annotated strings don't generate false path errors

Closes #3747

Generated with Claude Code
