### PR TITLE
fix(register-hooks): pass toolName from tool_execution_start event to markToolStart

### DIFF
--- a/src/resources/extensions/gsd/bootstrap/register-hooks.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-hooks.ts
@@ -483,7 +483,7 @@ export function registerHooks(
 
   pi.on("tool_execution_start", async (event) => {
     if (!isAutoActive()) return;
-    markToolStart(event.toolCallId);
+    markToolStart(event.toolCallId, event.toolName);
   });
 
   pi.on("tool_execution_end", async (event) => {

--- a/src/resources/extensions/gsd/tests/auto-wrapup-inflight-guard.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-wrapup-inflight-guard.test.ts
@@ -144,3 +144,26 @@ describe("#3512: pauseAuto and stopAuto must flush queued follow-up messages", (
     );
   });
 });
+
+describe("#4365: tool_execution_start hook must pass toolName to markToolStart", () => {
+  test("tool_execution_start handler passes event.toolName to markToolStart", () => {
+    // The tool_execution_start handler must forward toolName so that
+    // hasInteractiveToolInFlight() can correctly identify ask_user_questions
+    // and prevent the idle watchdog from firing during interactive tool calls.
+    const startMarker = 'pi.on("tool_execution_start", async (event) => {';
+    const endMarker = 'pi.on("tool_execution_end", async (event) => {';
+    const toolExecutionStartSection = registerHooksSrc.slice(
+      registerHooksSrc.indexOf(startMarker),
+      registerHooksSrc.indexOf(endMarker),
+    );
+
+    assert.ok(
+      toolExecutionStartSection.length > 0,
+      "Could not locate tool_execution_start handler section",
+    );
+    assert.ok(
+      toolExecutionStartSection.includes("markToolStart(event.toolCallId, event.toolName)"),
+      "tool_execution_start handler must pass event.toolName to markToolStart so hasInteractiveToolInFlight() works correctly",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- `pi.on("tool_execution_start")` handler was not extracting `toolName` from the event, passing `undefined` to `markToolStart()`
- `markToolStart()` stored `"unknown"` as the tool name
- `hasInteractiveToolInFlight()` never matched its allowlist, causing idle watchdog to fire during interactive tool calls
- Fixed by extracting `toolName` from the event object and passing it to `markToolStart()`
- Added unit test verifying `tool_execution_start` handler forwards `event.toolName` to `markToolStart`

Closes #4365

Generated with Claude Code
