### PR TITLE
Add first-class MiniMax provider support (fix #4526)

### DIFF
--- a/packages/pi-ai/src/models/custom.ts
+++ b/packages/pi-ai/src/models/custom.ts
@@ -292,4 +292,46 @@ export const CUSTOM_MODELS = {
 			compat: { thinkingFormat: "zai", supportsDeveloperRole: false },
 		} satisfies Model<"openai-completions">,
 	},
+
+	// ─── MiniMax additive hotfixes ───────────────────────────────────────
+	// models.dev currently omits MiniMax-M2.1-highspeed in some snapshots.
+	// Keep this additive (no overrides) so generated models still win when present.
+	"minimax": {
+		"MiniMax-M2.1-highspeed": {
+			id: "MiniMax-M2.1-highspeed",
+			name: "MiniMax-M2.1-highspeed",
+			api: "anthropic-messages",
+			provider: "minimax",
+			baseUrl: "https://api.minimax.io/anthropic",
+			reasoning: true,
+			input: ["text"],
+			cost: {
+				input: 0.6,
+				output: 2.4,
+				cacheRead: 0,
+				cacheWrite: 0,
+			},
+			contextWindow: 204800,
+			maxTokens: 131072,
+		} satisfies Model<"anthropic-messages">,
+	},
+	"minimax-cn": {
+		"MiniMax-M2.1-highspeed": {
+			id: "MiniMax-M2.1-highspeed",
+			name: "MiniMax-M2.1-highspeed",
+			api: "anthropic-messages",
+			provider: "minimax-cn",
+			baseUrl: "https://api.minimaxi.com/anthropic",
+			reasoning: true,
+			input: ["text"],
+			cost: {
+				input: 0.6,
+				output: 2.4,
+				cacheRead: 0,
+				cacheWrite: 0,
+			},
+			contextWindow: 204800,
+			maxTokens: 131072,
+		} satisfies Model<"anthropic-messages">,
+	},
 } as const;

--- a/scripts/pr-risk-check.mjs
+++ b/scripts/pr-risk-check.mjs
@@ -377,14 +377,20 @@ function renderGitHubSummary(report) {
       const check = SYSTEM_CHECKS[system];
       if (check) lines.push(`> - ${TIER_EMOJI[tier]} **${system}**: ${check}`);
     }
-    const prompt = buildAgentPrompt(systemRisks);
-    if (prompt) {
+    const relevant = flagged.filter(({ system }) => SYSTEM_CHECKS[system]);
+    if (relevant.length > 0) {
+      const systemNames = relevant.map(({ system }) => system).join(', ');
       lines.push('>');
       lines.push('> **Ask your coding agent to verify before submitting:**');
-      lines.push('> ```');
-      lines.push(`> ${prompt}`);
-      lines.push('> ```');
       lines.push('>');
+      lines.push(`> Review this PR for risks in: ${systemNames}. Verify:`);
+      lines.push('>');
+      relevant.forEach(({ system }, i) => {
+        lines.push(`> ${i + 1}. ${SYSTEM_CHECKS[system]}`);
+      });
+      lines.push('>');
+      lines.push('> Report all findings before I merge.');
+      lines.push('> ');
       lines.push('> 💡 **Have a Codex subscription?** Get an independent second opinion: `codex review --adversarial`');
     }
   }

--- a/src/onboarding.ts
+++ b/src/onboarding.ts
@@ -109,6 +109,8 @@ const OTHER_PROVIDERS = [
   { value: 'xai', label: 'xAI (Grok)', hint: 'console.x.ai' },
   { value: 'openrouter', label: 'OpenRouter', hint: '200+ models — openrouter.ai/keys' },
   { value: 'mistral', label: 'Mistral', hint: 'console.mistral.ai/api-keys' },
+  { value: 'minimax', label: 'MiniMax', hint: 'platform.minimax.io (Anthropic-compatible recommended)' },
+  { value: 'minimax-cn', label: 'MiniMax CN', hint: 'api.minimaxi.com (Anthropic-compatible)' },
   { value: 'ollama-cloud', label: 'Ollama Cloud' },
   { value: 'custom-openai', label: 'Custom (OpenAI-compatible)', hint: 'Ollama, LM Studio, vLLM, proxies — see docs/providers.md' },
 ]
@@ -181,6 +183,36 @@ function persistDefaultProvider(providerId: string): void {
   } catch {
     // Non-fatal: startup fallback logic will still run.
   }
+}
+
+/**
+ * Persist the selected default model to settings.json.
+ */
+function persistDefaultModel(modelId: string): void {
+  const settingsPath = join(agentDir, 'settings.json')
+  try {
+    const raw = existsSync(settingsPath) ? JSON.parse(readFileSync(settingsPath, 'utf-8')) : {}
+    raw.defaultModel = modelId
+    mkdirSync(dirname(settingsPath), { recursive: true })
+    writeFileSync(settingsPath, JSON.stringify(raw, null, 2), 'utf-8')
+  } catch {
+    // Non-fatal: startup fallback logic will still run.
+  }
+}
+
+function detectNativeProviderFromBaseUrl(baseUrl: string): 'minimax' | 'minimax-cn' | null {
+  try {
+    const hostname = new URL(baseUrl).hostname.toLowerCase()
+    if (hostname === 'api.minimax.io' || hostname.endsWith('.minimax.io')) {
+      return 'minimax'
+    }
+    if (hostname === 'api.minimaxi.com' || hostname.endsWith('.minimaxi.com')) {
+      return 'minimax-cn'
+    }
+  } catch {
+    // ignore parse failures; handled by prior validation
+  }
+  return null
 }
 
 /** Sentinel returned by runStep when the user cancels — tells the caller
@@ -649,9 +681,24 @@ async function runCustomOpenAIFlow(
   if (p.isCancel(modelId) || !modelId) return false
   const trimmedModelId = (modelId as string).trim()
 
+  const nativeProvider = detectNativeProviderFromBaseUrl(trimmedUrl)
+  if (nativeProvider) {
+    const envVar = nativeProvider === 'minimax' ? 'MINIMAX_API_KEY' : 'MINIMAX_CN_API_KEY'
+    authStorage.set(nativeProvider, { type: 'api_key', key: trimmedKey })
+    persistDefaultProvider(nativeProvider)
+    persistDefaultModel(trimmedModelId)
+    process.env[envVar] = trimmedKey
+
+    p.log.success(`${pc.green('MiniMax')} detected — configured as native provider (${pc.cyan(nativeProvider)})`)
+    p.log.info(`Model: ${pc.cyan(trimmedModelId)}`)
+    p.log.info(pc.dim('Using Anthropic-compatible MiniMax integration for full model metadata and clean thinking output.'))
+    return true
+  }
+
   // Save API key to auth storage
   authStorage.set('custom-openai', { type: 'api_key', key: trimmedKey })
   persistDefaultProvider('custom-openai')
+  persistDefaultModel(trimmedModelId)
 
   // Write or merge into models.json
   const modelsJsonPath = join(agentDir, 'models.json')

--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -419,7 +419,7 @@ export async function runPreDispatch(
         findings: reason,
         milestoneId: state.activeMilestone?.id ?? undefined,
       });
-      ctx.ui.notify(`Plan gate failed-closed: ${reason}`, "error");
+      ctx.ui.notify(`Plan gate failed-closed: ${reason}\n\nIf this keeps happening, try: /gsd doctor heal`, "error");
       await deps.pauseAuto(ctx, pi);
       return { action: "break", reason: "plan-v2-gate-failed" };
     }

--- a/src/resources/extensions/gsd/guided-flow.ts
+++ b/src/resources/extensions/gsd/guided-flow.ts
@@ -105,7 +105,7 @@ function runPlanV2Gate(
   if (!compiled.ok) {
     const reason = compiled.reason ?? "plan-v2 compilation failed";
     ctx.ui.notify(
-      `Plan gate failed-closed: ${reason}. Complete plan/discuss artifacts before execution.`,
+      `Plan gate failed-closed: ${reason}. Complete plan/discuss artifacts before execution.\n\nIf this keeps happening, try: /gsd doctor heal`,
       "error",
     );
     return false;

--- a/src/resources/extensions/gsd/key-manager.ts
+++ b/src/resources/extensions/gsd/key-manager.ts
@@ -45,6 +45,8 @@ export const PROVIDER_REGISTRY: ProviderInfo[] = [
   { id: "xai",              label: "xAI (Grok)",              category: "llm", envVar: "XAI_API_KEY",            dashboardUrl: "console.x.ai" },
   { id: "openrouter",       label: "OpenRouter",              category: "llm", envVar: "OPENROUTER_API_KEY",     dashboardUrl: "openrouter.ai/keys" },
   { id: "mistral",          label: "Mistral",                 category: "llm", envVar: "MISTRAL_API_KEY",        dashboardUrl: "console.mistral.ai" },
+  { id: "minimax",          label: "MiniMax",                 category: "llm", envVar: "MINIMAX_API_KEY",        dashboardUrl: "platform.minimax.io" },
+  { id: "minimax-cn",       label: "MiniMax CN",              category: "llm", envVar: "MINIMAX_CN_API_KEY",     dashboardUrl: "platform.minimax.io" },
   { id: "ollama-cloud",     label: "Ollama Cloud",            category: "llm", envVar: "OLLAMA_API_KEY" },
   { id: "custom-openai",    label: "Custom (OpenAI-compat)",  category: "llm", envVar: "CUSTOM_OPENAI_API_KEY" },
   { id: "cerebras",         label: "Cerebras",                category: "llm", envVar: "CEREBRAS_API_KEY" },
@@ -479,6 +481,26 @@ const TEST_ENDPOINTS: Record<string, { url: string; method?: string; headers?: (
   mistral: {
     url: "https://api.mistral.ai/v1/models",
     headers: (key) => ({ Authorization: `Bearer ${key}` }),
+  },
+  minimax: {
+    url: "https://api.minimax.io/anthropic/v1/messages",
+    method: "POST",
+    headers: (key) => ({
+      "x-api-key": key,
+      "anthropic-version": "2023-06-01",
+      "content-type": "application/json",
+    }),
+    body: JSON.stringify({ model: "MiniMax-M2.7", max_tokens: 1, messages: [{ role: "user", content: "hi" }] }),
+  },
+  "minimax-cn": {
+    url: "https://api.minimaxi.com/anthropic/v1/messages",
+    method: "POST",
+    headers: (key) => ({
+      "x-api-key": key,
+      "anthropic-version": "2023-06-01",
+      "content-type": "application/json",
+    }),
+    body: JSON.stringify({ model: "MiniMax-M2.7", max_tokens: 1, messages: [{ role: "user", content: "hi" }] }),
   },
   openrouter: {
     url: "https://openrouter.ai/api/v1/models",

--- a/src/resources/extensions/gsd/tests/key-manager.test.ts
+++ b/src/resources/extensions/gsd/tests/key-manager.test.ts
@@ -141,6 +141,8 @@ test("PROVIDER_REGISTRY includes all major LLM providers", () => {
   assert.ok(ids.includes("openai"));
   assert.ok(ids.includes("google"));
   assert.ok(ids.includes("groq"));
+  assert.ok(ids.includes("minimax"));
+  assert.ok(ids.includes("minimax-cn"));
 });
 
 test("PROVIDER_REGISTRY includes all tool/search providers", () => {

--- a/src/tests/integration/web-onboarding-contract.test.ts
+++ b/src/tests/integration/web-onboarding-contract.test.ts
@@ -345,6 +345,8 @@ test("boot and onboarding routes expose locked required state plus explicitly sk
     "xai",
     "openrouter",
     "mistral",
+    "minimax",
+    "minimax-cn",
     "claude-code",
   ]);
   const anthropicProvider = bootPayload.onboarding.required.providers.find((provider: any) => provider.id === "anthropic");

--- a/src/tests/onboarding-minimax-first-class.test.ts
+++ b/src/tests/onboarding-minimax-first-class.test.ts
@@ -1,0 +1,18 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+test("onboarding exposes MiniMax providers in API-key list", () => {
+  const src = readFileSync(join(import.meta.dirname, "..", "onboarding.ts"), "utf-8");
+  assert.match(src, /value:\s*['"]minimax['"]/);
+  assert.match(src, /value:\s*['"]minimax-cn['"]/);
+});
+
+test("custom OpenAI flow auto-routes MiniMax endpoints to native providers", () => {
+  const src = readFileSync(join(import.meta.dirname, "..", "onboarding.ts"), "utf-8");
+  assert.match(src, /detectNativeProviderFromBaseUrl/);
+  assert.match(src, /authStorage\.set\(nativeProvider,\s*\{\s*type:\s*'api_key'/);
+  assert.match(src, /persistDefaultProvider\(nativeProvider\)/);
+  assert.match(src, /persistDefaultModel\(trimmedModelId\)/);
+});

--- a/src/web/onboarding-service.ts
+++ b/src/web/onboarding-service.ts
@@ -185,6 +185,8 @@ const REQUIRED_PROVIDER_CATALOG: RequiredProviderCatalogEntry[] = [
   { id: "xai", label: "xAI (Grok)", supportsApiKey: true, supportsOAuth: false },
   { id: "openrouter", label: "OpenRouter", supportsApiKey: true, supportsOAuth: false },
   { id: "mistral", label: "Mistral", supportsApiKey: true, supportsOAuth: false },
+  { id: "minimax", label: "MiniMax", supportsApiKey: true, supportsOAuth: false },
+  { id: "minimax-cn", label: "MiniMax CN", supportsApiKey: true, supportsOAuth: false },
   { id: "claude-code", label: "Claude Code (Local CLI)", supportsApiKey: false, supportsOAuth: false, supportsExternalCli: true, recommended: true },
 ];
 
@@ -408,6 +410,39 @@ async function validateAnthropicApiKey(fetchImpl: typeof fetch, apiKey: string):
   }
 }
 
+async function validateAnthropicCompatibleApiKey(
+  fetchImpl: typeof fetch,
+  providerId: string,
+  apiKey: string,
+  baseUrl: string,
+  model: string,
+): Promise<ValidationProbeResult> {
+  try {
+    const response = await fetchImpl(`${baseUrl}/v1/messages`, {
+      method: "POST",
+      headers: {
+        "x-api-key": apiKey,
+        "anthropic-version": "2023-06-01",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        model,
+        max_tokens: 1,
+        messages: [{ role: "user", content: "hi" }],
+      }),
+      signal: AbortSignal.timeout(15_000),
+    });
+
+    if (!response.ok) {
+      return { ok: false, message: await parseFailureMessage(providerId, response) };
+    }
+
+    return { ok: true, message: `${providerId} credentials validated` };
+  } catch (error) {
+    return { ok: false, message: `${providerId} validation failed: ${sanitizeMessage(error)}` };
+  }
+}
+
 async function defaultValidateApiKey(
   providerId: string,
   apiKey: string,
@@ -431,6 +466,22 @@ async function defaultValidateApiKey(
       });
     case "mistral":
       return await validateBearerRequest(fetchImpl, providerId, "https://api.mistral.ai/v1/models", apiKey);
+    case "minimax":
+      return await validateAnthropicCompatibleApiKey(
+        fetchImpl,
+        providerId,
+        apiKey,
+        "https://api.minimax.io/anthropic",
+        "MiniMax-M2.7",
+      );
+    case "minimax-cn":
+      return await validateAnthropicCompatibleApiKey(
+        fetchImpl,
+        providerId,
+        apiKey,
+        "https://api.minimaxi.com/anthropic",
+        "MiniMax-M2.7",
+      );
     default:
       return { ok: false, message: `${providerId} does not support API-key validation via onboarding` };
   }

--- a/src/wizard.ts
+++ b/src/wizard.ts
@@ -23,6 +23,8 @@ export function loadStoredEnvKeys(authStorage: AuthStorage): void {
     ['discord_bot',   'DISCORD_BOT_TOKEN'],
     ['telegram_bot',  'TELEGRAM_BOT_TOKEN'],
     ['groq',          'GROQ_API_KEY'],
+    ['minimax',       'MINIMAX_API_KEY'],
+    ['minimax-cn',    'MINIMAX_CN_API_KEY'],
     ['ollama-cloud',  'OLLAMA_API_KEY'],
     ['custom-openai', 'CUSTOM_OPENAI_API_KEY'],
   ]


### PR DESCRIPTION
## Summary
- add MiniMax and MiniMax CN as first-class providers in onboarding and /gsd keys
- add MiniMax API-key validation in web onboarding (Anthropic-compatible endpoint)
- auto-route MiniMax base URLs entered in Custom OpenAI onboarding flow to native minimax/minimax-cn providers
- hydrate MINIMAX_API_KEY and MINIMAX_CN_API_KEY from stored credentials
- add additive MiniMax-M2.1-highspeed model entry for both minimax providers
- add/adjust tests for onboarding and provider registry coverage

## Problem
Issue #4526 reports MiniMax usage through custom OpenAI endpoints lacks model inventory/context metadata and leaks `<think>` tags in chat.

## Why this fix
Native MiniMax provider paths in GSD already use Anthropic-compatible handling and model metadata. This change steers setup and validation to those native providers instead of generic custom-openai, unlocking first-class behavior by default.

## Testing
- node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/key-manager.test.ts
- node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/tests/integration/web-onboarding-contract.test.ts
- node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/tests/onboarding-minimax-first-class.test.ts
