### PR TITLE
fix(gsd-db): move memories.scope index creation inside v18 migration guard

### DIFF
--- a/src/resources/extensions/gsd/gsd-db.ts
+++ b/src/resources/extensions/gsd/gsd-db.ts
@@ -559,18 +559,6 @@ function initSchema(db: DbAdapter, fileBacked: boolean): void {
 
     db.exec("CREATE INDEX IF NOT EXISTS idx_memories_active ON memories(superseded_by)");
 
-    // Existing DBs may arrive here before migrateSchema() has added columns
-    // that fresh installs already have. Add only columns needed by bootstrap
-    // indexes so old DBs can open far enough for the normal migration chain.
-    ensureBootstrapIndexColumns(db);
-
-    if (columnExists(db, "memories", "scope")) {
-      db.exec("CREATE INDEX IF NOT EXISTS idx_memories_scope ON memories(scope)");
-    }
-    db.exec("CREATE INDEX IF NOT EXISTS idx_memory_sources_kind ON memory_sources(kind)");
-    db.exec("CREATE INDEX IF NOT EXISTS idx_memory_sources_scope ON memory_sources(scope)");
-    db.exec("CREATE INDEX IF NOT EXISTS idx_memory_relations_from ON memory_relations(from_id)");
-    db.exec("CREATE INDEX IF NOT EXISTS idx_memory_relations_to ON memory_relations(to_id)");
     db.exec("CREATE INDEX IF NOT EXISTS idx_replan_history_milestone ON replan_history(milestone_id, created_at)");
 
     // v13 indexes — hot-path dispatch queries
@@ -588,9 +576,6 @@ function initSchema(db: DbAdapter, fileBacked: boolean): void {
     db.exec("CREATE INDEX IF NOT EXISTS idx_turn_git_tx_turn ON turn_git_transactions(trace_id, turn_id)");
     db.exec("CREATE INDEX IF NOT EXISTS idx_audit_events_trace ON audit_events(trace_id, ts)");
     db.exec("CREATE INDEX IF NOT EXISTS idx_audit_events_turn ON audit_events(trace_id, turn_id, ts)");
-    // ADR-011 Phase 2 — also created by the v17 migration; fresh installs
-    // skip migrations so the index must be created here too.
-    db.exec("CREATE INDEX IF NOT EXISTS idx_tasks_escalation_pending ON tasks(milestone_id, slice_id, escalation_pending)");
 
     db.exec(`CREATE VIEW IF NOT EXISTS active_decisions AS SELECT * FROM decisions WHERE superseded_by IS NULL`);
     db.exec(`CREATE VIEW IF NOT EXISTS active_requirements AS SELECT * FROM requirements WHERE superseded_by IS NULL`);
@@ -598,6 +583,17 @@ function initSchema(db: DbAdapter, fileBacked: boolean): void {
 
     const existing = db.prepare("SELECT count(*) as cnt FROM schema_version").get();
     if (existing && (existing["cnt"] as number) === 0) {
+      // Fresh install — all tables are created above with the full current schema,
+      // so it is safe to create all migration-specific indexes here.  For existing
+      // databases these indexes are created inside the individual migration guards
+      // in migrateSchema() after the corresponding columns have been added.
+      db.exec("CREATE INDEX IF NOT EXISTS idx_tasks_escalation_pending ON tasks(milestone_id, slice_id, escalation_pending)");
+      db.exec("CREATE INDEX IF NOT EXISTS idx_memories_scope ON memories(scope)");
+      db.exec("CREATE INDEX IF NOT EXISTS idx_memory_sources_kind ON memory_sources(kind)");
+      db.exec("CREATE INDEX IF NOT EXISTS idx_memory_sources_scope ON memory_sources(scope)");
+      db.exec("CREATE INDEX IF NOT EXISTS idx_memory_relations_from ON memory_relations(from_id)");
+      db.exec("CREATE INDEX IF NOT EXISTS idx_memory_relations_to ON memory_relations(to_id)");
+
       db.prepare(
         "INSERT INTO schema_version (version, applied_at) VALUES (:version, :applied_at)",
       ).run({
@@ -672,14 +668,6 @@ export function isMemoriesFtsAvailable(db: DbAdapter): boolean {
 
 function ensureColumn(db: DbAdapter, table: string, column: string, ddl: string): void {
   if (!columnExists(db, table, column)) db.exec(ddl);
-}
-
-function ensureBootstrapIndexColumns(db: DbAdapter): void {
-  ensureColumn(db, "memories", "scope", `ALTER TABLE memories ADD COLUMN scope TEXT NOT NULL DEFAULT 'project'`);
-  ensureColumn(db, "memories", "tags", `ALTER TABLE memories ADD COLUMN tags TEXT NOT NULL DEFAULT '[]'`);
-  ensureColumn(db, "memory_sources", "scope", `ALTER TABLE memory_sources ADD COLUMN scope TEXT NOT NULL DEFAULT 'project'`);
-  ensureColumn(db, "memory_sources", "tags", `ALTER TABLE memory_sources ADD COLUMN tags TEXT NOT NULL DEFAULT '[]'`);
-  ensureColumn(db, "tasks", "escalation_pending", `ALTER TABLE tasks ADD COLUMN escalation_pending INTEGER NOT NULL DEFAULT 0`);
 }
 
 function migrateSchema(db: DbAdapter): void {
@@ -1119,6 +1107,10 @@ function migrateSchema(db: DbAdapter): void {
           tags TEXT NOT NULL DEFAULT '[]'
         )
       `);
+      // If memory_sources already existed before v18 (created by an earlier
+      // version of initSchema that lacked scope/tags), add the missing columns.
+      ensureColumn(db, "memory_sources", "scope", `ALTER TABLE memory_sources ADD COLUMN scope TEXT NOT NULL DEFAULT 'project'`);
+      ensureColumn(db, "memory_sources", "tags", `ALTER TABLE memory_sources ADD COLUMN tags TEXT NOT NULL DEFAULT '[]'`);
       db.exec("CREATE INDEX IF NOT EXISTS idx_memories_scope ON memories(scope)");
       db.exec("CREATE INDEX IF NOT EXISTS idx_memory_sources_kind ON memory_sources(kind)");
       db.exec("CREATE INDEX IF NOT EXISTS idx_memory_sources_scope ON memory_sources(scope)");

--- a/src/resources/extensions/gsd/tests/gsd-db.test.ts
+++ b/src/resources/extensions/gsd/tests/gsd-db.test.ts
@@ -469,6 +469,301 @@ describe('gsd-db', () => {
     cleanup(dbPath);
   });
 
+  test('gsd-db: pre-v18 DB with memory_sources missing scope opens without crash (issue #4607)', () => {
+    // Regression: initSchema() ran CREATE INDEX on memories.scope and
+    // memory_sources.scope unconditionally, before the v18 migration adds those
+    // columns to existing rows.  Databases at schema v17 that had a
+    // memory_sources table without the scope column crashed on open with
+    // "no such column: scope".
+    // The fix moves those index statements inside the v18 migration guard so
+    // they only execute after the column already exists.
+    const dbPath = tempDbPath();
+    const legacyDb = openRawSqliteForTest(dbPath);
+
+    // Build a realistic v17 schema: full table set that existed before v18,
+    // with memory_sources present but missing the scope column that v18 adds.
+    legacyDb.exec(`
+      CREATE TABLE schema_version (
+        version INTEGER NOT NULL,
+        applied_at TEXT NOT NULL
+      );
+      INSERT INTO schema_version(version, applied_at) VALUES (17, '2026-01-01T00:00:00.000Z');
+
+      CREATE TABLE decisions (
+        seq INTEGER PRIMARY KEY AUTOINCREMENT,
+        id TEXT NOT NULL UNIQUE,
+        when_context TEXT NOT NULL DEFAULT '',
+        scope TEXT NOT NULL DEFAULT '',
+        decision TEXT NOT NULL DEFAULT '',
+        choice TEXT NOT NULL DEFAULT '',
+        rationale TEXT NOT NULL DEFAULT '',
+        revisable TEXT NOT NULL DEFAULT '',
+        made_by TEXT NOT NULL DEFAULT 'agent',
+        superseded_by TEXT DEFAULT NULL
+      );
+
+      CREATE TABLE requirements (
+        id TEXT PRIMARY KEY,
+        class TEXT NOT NULL DEFAULT '',
+        status TEXT NOT NULL DEFAULT '',
+        description TEXT NOT NULL DEFAULT '',
+        why TEXT NOT NULL DEFAULT '',
+        source TEXT NOT NULL DEFAULT '',
+        primary_owner TEXT NOT NULL DEFAULT '',
+        supporting_slices TEXT NOT NULL DEFAULT '',
+        validation TEXT NOT NULL DEFAULT '',
+        notes TEXT NOT NULL DEFAULT '',
+        full_content TEXT NOT NULL DEFAULT '',
+        superseded_by TEXT DEFAULT NULL
+      );
+
+      CREATE TABLE memories (
+        seq INTEGER PRIMARY KEY AUTOINCREMENT,
+        id TEXT NOT NULL UNIQUE,
+        category TEXT NOT NULL,
+        content TEXT NOT NULL,
+        confidence REAL NOT NULL DEFAULT 0.8,
+        source_unit_type TEXT,
+        source_unit_id TEXT,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL,
+        superseded_by TEXT DEFAULT NULL,
+        hit_count INTEGER NOT NULL DEFAULT 0
+      );
+
+      CREATE TABLE memory_processed_units (
+        unit_key TEXT PRIMARY KEY,
+        activity_file TEXT,
+        processed_at TEXT NOT NULL
+      );
+
+      -- memory_sources existed before v18 but lacked the scope column
+      CREATE TABLE memory_sources (
+        id TEXT PRIMARY KEY,
+        kind TEXT NOT NULL,
+        uri TEXT,
+        title TEXT,
+        content TEXT NOT NULL,
+        content_hash TEXT NOT NULL UNIQUE,
+        imported_at TEXT NOT NULL
+      );
+
+      CREATE TABLE milestones (
+        id TEXT PRIMARY KEY,
+        title TEXT NOT NULL DEFAULT '',
+        status TEXT NOT NULL DEFAULT 'active',
+        depends_on TEXT NOT NULL DEFAULT '[]',
+        created_at TEXT NOT NULL DEFAULT '',
+        completed_at TEXT DEFAULT NULL,
+        vision TEXT NOT NULL DEFAULT '',
+        success_criteria TEXT NOT NULL DEFAULT '[]',
+        key_risks TEXT NOT NULL DEFAULT '[]',
+        proof_strategy TEXT NOT NULL DEFAULT '[]',
+        verification_contract TEXT NOT NULL DEFAULT '',
+        verification_integration TEXT NOT NULL DEFAULT '',
+        verification_operational TEXT NOT NULL DEFAULT '',
+        verification_uat TEXT NOT NULL DEFAULT '',
+        definition_of_done TEXT NOT NULL DEFAULT '[]',
+        requirement_coverage TEXT NOT NULL DEFAULT '',
+        boundary_map_markdown TEXT NOT NULL DEFAULT ''
+      );
+
+      CREATE TABLE slices (
+        milestone_id TEXT NOT NULL,
+        id TEXT NOT NULL,
+        title TEXT NOT NULL DEFAULT '',
+        status TEXT NOT NULL DEFAULT 'pending',
+        risk TEXT NOT NULL DEFAULT 'medium',
+        depends TEXT NOT NULL DEFAULT '[]',
+        demo TEXT NOT NULL DEFAULT '',
+        created_at TEXT NOT NULL DEFAULT '',
+        completed_at TEXT DEFAULT NULL,
+        full_summary_md TEXT NOT NULL DEFAULT '',
+        full_uat_md TEXT NOT NULL DEFAULT '',
+        goal TEXT NOT NULL DEFAULT '',
+        success_criteria TEXT NOT NULL DEFAULT '',
+        proof_level TEXT NOT NULL DEFAULT '',
+        integration_closure TEXT NOT NULL DEFAULT '',
+        observability_impact TEXT NOT NULL DEFAULT '',
+        sequence INTEGER DEFAULT 0,
+        PRIMARY KEY (milestone_id, id)
+      );
+
+      CREATE TABLE tasks (
+        milestone_id TEXT NOT NULL,
+        slice_id TEXT NOT NULL,
+        id TEXT NOT NULL,
+        title TEXT NOT NULL DEFAULT '',
+        status TEXT NOT NULL DEFAULT 'pending',
+        one_liner TEXT NOT NULL DEFAULT '',
+        narrative TEXT NOT NULL DEFAULT '',
+        verification_result TEXT NOT NULL DEFAULT '',
+        duration TEXT NOT NULL DEFAULT '',
+        completed_at TEXT DEFAULT NULL,
+        blocker_discovered INTEGER DEFAULT 0,
+        deviations TEXT NOT NULL DEFAULT '',
+        known_issues TEXT NOT NULL DEFAULT '',
+        key_files TEXT NOT NULL DEFAULT '[]',
+        key_decisions TEXT NOT NULL DEFAULT '[]',
+        full_summary_md TEXT NOT NULL DEFAULT '',
+        description TEXT NOT NULL DEFAULT '',
+        estimate TEXT NOT NULL DEFAULT '',
+        files TEXT NOT NULL DEFAULT '[]',
+        verify TEXT NOT NULL DEFAULT '',
+        inputs TEXT NOT NULL DEFAULT '[]',
+        expected_output TEXT NOT NULL DEFAULT '[]',
+        observability_impact TEXT NOT NULL DEFAULT '',
+        full_plan_md TEXT NOT NULL DEFAULT '',
+        sequence INTEGER DEFAULT 0,
+        blocker_source TEXT NOT NULL DEFAULT '',
+        escalation_pending INTEGER NOT NULL DEFAULT 0,
+        escalation_awaiting_review INTEGER NOT NULL DEFAULT 0,
+        escalation_artifact_path TEXT DEFAULT NULL,
+        escalation_override_applied_at TEXT DEFAULT NULL,
+        PRIMARY KEY (milestone_id, slice_id, id)
+      );
+
+      CREATE TABLE replan_history (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        milestone_id TEXT NOT NULL DEFAULT '',
+        slice_id TEXT DEFAULT NULL,
+        task_id TEXT DEFAULT NULL,
+        summary TEXT NOT NULL DEFAULT '',
+        previous_artifact_path TEXT DEFAULT NULL,
+        replacement_artifact_path TEXT DEFAULT NULL,
+        full_content TEXT NOT NULL DEFAULT '',
+        created_at TEXT NOT NULL DEFAULT ''
+      );
+
+      CREATE TABLE quality_gates (
+        milestone_id TEXT NOT NULL,
+        slice_id TEXT NOT NULL,
+        gate_id TEXT NOT NULL,
+        scope TEXT NOT NULL DEFAULT 'slice',
+        task_id TEXT NOT NULL DEFAULT '',
+        status TEXT NOT NULL DEFAULT 'pending',
+        verdict TEXT NOT NULL DEFAULT '',
+        rationale TEXT NOT NULL DEFAULT '',
+        findings TEXT NOT NULL DEFAULT '',
+        evaluated_at TEXT DEFAULT NULL,
+        PRIMARY KEY (milestone_id, slice_id, gate_id, task_id)
+      );
+
+      CREATE TABLE verification_evidence (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        task_id TEXT NOT NULL DEFAULT '',
+        slice_id TEXT NOT NULL DEFAULT '',
+        milestone_id TEXT NOT NULL DEFAULT '',
+        command TEXT NOT NULL DEFAULT '',
+        exit_code INTEGER DEFAULT 0,
+        verdict TEXT NOT NULL DEFAULT '',
+        duration_ms INTEGER DEFAULT 0,
+        created_at TEXT NOT NULL DEFAULT ''
+      );
+
+      CREATE TABLE slice_dependencies (
+        milestone_id TEXT NOT NULL,
+        slice_id TEXT NOT NULL,
+        depends_on_slice_id TEXT NOT NULL,
+        PRIMARY KEY (milestone_id, slice_id, depends_on_slice_id)
+      );
+
+      CREATE TABLE gate_runs (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        trace_id TEXT NOT NULL,
+        turn_id TEXT NOT NULL,
+        gate_id TEXT NOT NULL,
+        gate_type TEXT NOT NULL DEFAULT '',
+        unit_type TEXT DEFAULT NULL,
+        unit_id TEXT DEFAULT NULL,
+        milestone_id TEXT DEFAULT NULL,
+        slice_id TEXT DEFAULT NULL,
+        task_id TEXT DEFAULT NULL,
+        outcome TEXT NOT NULL DEFAULT 'pass',
+        failure_class TEXT NOT NULL DEFAULT 'none',
+        rationale TEXT NOT NULL DEFAULT '',
+        findings TEXT NOT NULL DEFAULT '',
+        attempt INTEGER NOT NULL DEFAULT 1,
+        max_attempts INTEGER NOT NULL DEFAULT 1,
+        retryable INTEGER NOT NULL DEFAULT 0,
+        evaluated_at TEXT NOT NULL DEFAULT ''
+      );
+
+      CREATE TABLE turn_git_transactions (
+        trace_id TEXT NOT NULL,
+        turn_id TEXT NOT NULL,
+        unit_type TEXT DEFAULT NULL,
+        unit_id TEXT DEFAULT NULL,
+        stage TEXT NOT NULL DEFAULT 'turn-start',
+        action TEXT NOT NULL DEFAULT 'status-only',
+        push INTEGER NOT NULL DEFAULT 0,
+        status TEXT NOT NULL DEFAULT 'ok',
+        error TEXT DEFAULT NULL,
+        metadata_json TEXT NOT NULL DEFAULT '{}',
+        updated_at TEXT NOT NULL DEFAULT '',
+        PRIMARY KEY (trace_id, turn_id, stage)
+      );
+
+      CREATE TABLE audit_events (
+        event_id TEXT PRIMARY KEY,
+        trace_id TEXT NOT NULL,
+        turn_id TEXT DEFAULT NULL,
+        caused_by TEXT DEFAULT NULL,
+        category TEXT NOT NULL,
+        type TEXT NOT NULL,
+        ts TEXT NOT NULL,
+        payload_json TEXT NOT NULL DEFAULT '{}'
+      );
+
+      CREATE TABLE audit_turn_index (
+        trace_id TEXT NOT NULL,
+        turn_id TEXT NOT NULL,
+        first_ts TEXT NOT NULL,
+        last_ts TEXT NOT NULL,
+        event_count INTEGER NOT NULL DEFAULT 0,
+        PRIMARY KEY (trace_id, turn_id)
+      );
+
+      CREATE INDEX idx_memories_active ON memories(superseded_by);
+      CREATE INDEX idx_tasks_active ON tasks(milestone_id, slice_id, status);
+      CREATE INDEX idx_slices_active ON slices(milestone_id, status);
+      CREATE INDEX idx_milestones_status ON milestones(status);
+      CREATE INDEX idx_quality_gates_pending ON quality_gates(milestone_id, slice_id, status);
+      CREATE INDEX idx_verification_evidence_task ON verification_evidence(milestone_id, slice_id, task_id);
+      CREATE INDEX idx_slice_deps_target ON slice_dependencies(milestone_id, depends_on_slice_id);
+      CREATE INDEX idx_tasks_escalation_pending ON tasks(milestone_id, slice_id, escalation_pending);
+    `);
+    legacyDb.close();
+
+    // This must not throw — before the fix, initSchema() crashed with
+    // "no such column: scope" when it tried to CREATE INDEX on memory_sources.scope
+    // before the v18 migration had added that column.
+    assert.doesNotThrow(
+      () => openDatabase(dbPath),
+      'openDatabase must not throw on a v17 DB where memory_sources lacks scope',
+    );
+
+    const adapter = _getAdapter()!;
+
+    // After open+migrate, memories.scope must exist
+    const memCols = adapter.prepare('PRAGMA table_info(memories)').all().map((r) => r['name']);
+    assert.ok(memCols.includes('scope'), 'memories.scope must be present after migration');
+
+    // idx_memories_scope must be created by the v18 migration
+    const scopeIdx = adapter
+      .prepare("SELECT name FROM sqlite_master WHERE type='index' AND name='idx_memories_scope'")
+      .get();
+    assert.ok(scopeIdx, 'idx_memories_scope must exist after open on v17 DB');
+
+    // idx_memory_sources_scope must be created by the v18 migration
+    const srcScopeIdx = adapter
+      .prepare("SELECT name FROM sqlite_master WHERE type='index' AND name='idx_memory_sources_scope'")
+      .get();
+    assert.ok(srcScopeIdx, 'idx_memory_sources_scope must exist after open on v17 DB');
+
+    cleanup(dbPath);
+  });
+
   test('gsd-db: rowToTask tolerates legacy comma-separated task arrays', () => {
     openDatabase(':memory:');
 


### PR DESCRIPTION
## Summary
- `initSchema()` ran `CREATE INDEX IF NOT EXISTS` on `memories.scope`, `memory_sources.scope/kind`, `memory_relations.*`, and `tasks.escalation_pending` unconditionally, before the corresponding migrations (v17/v18/v20) had added those columns to existing databases
- Databases with schema < 17/18/20 crashed on open with "no such column: scope" (or similar)
- Removed the `ensureBootstrapIndexColumns` workaround and `columnExists` guard that were masking the root cause in `initSchema()`
- Moved all migration-specific index creation into the `if (cnt === 0)` fresh-install block in `initSchema()`, where all columns are guaranteed present on the freshly-created tables; for existing databases those indexes are already created inside the respective `migrateSchema()` version guards after the columns are added
- Added `ensureColumn` calls for `memory_sources.scope` and `memory_sources.tags` inside the v18 migration block to handle the case where `memory_sources` existed before those columns were introduced
- Added a regression test: a v17 DB with a `memory_sources` table lacking the `scope` column must open without crashing, and the indexes must be present after migration

Closes #4607

Generated with Claude Code
