### PR TITLE
fix(run-unit): discard late-resolving newSession() after timeout to prevent root cwd tool runtime

### DIFF
--- a/packages/pi-coding-agent/src/core/agent-session-abort-order.test.ts
+++ b/packages/pi-coding-agent/src/core/agent-session-abort-order.test.ts
@@ -14,8 +14,9 @@ describe("#4243 — abort() must be called before _disconnectFromAgent()", () =>
 		const newSessionStart = source.indexOf("async newSession(options?:");
 		assert.ok(newSessionStart >= 0, "should find newSession method");
 
-		// Get a window that includes the abort/disconnect section
-		const window = source.slice(newSessionStart, newSessionStart + 1200);
+		// Get a window that includes the abort/disconnect section.
+		// Use 2000 chars to accommodate guard checks inserted between the two calls.
+		const window = source.slice(newSessionStart, newSessionStart + 2000);
 
 		// Find the abort and _disconnectFromAgent calls
 		const abortIdx = window.indexOf("await this.abort();");

--- a/packages/pi-coding-agent/src/core/agent-session.ts
+++ b/packages/pi-coding-agent/src/core/agent-session.ts
@@ -1568,6 +1568,8 @@ export class AgentSession {
 	async newSession(options?: {
 		parentSession?: string;
 		setup?: (sessionManager: SessionManager) => Promise<void>;
+		/** See ExtensionCommandContext.newSession for docs (#3731). */
+		abortSignal?: AbortSignal;
 	}): Promise<boolean> {
 		const previousSessionFile = this.sessionFile;
 
@@ -1587,6 +1589,15 @@ export class AgentSession {
 	// message_end/agent_end events fire and the #4216 finalization code
 	// can run before we unsubscribe from the event bus.
 	await this.abort();
+
+		// #3731: If the caller aborted (e.g. runUnit() timed out and restored cwd to
+		// project root), discard this session before capturing process.cwd() and
+		// rebuilding the tool runtime. Without this check, the late newSession()
+		// would rebuild tools with root cwd, breaking worktree isolation.
+		if (options?.abortSignal?.aborted) {
+			return false;
+		}
+
 	this._disconnectFromAgent();
 	this.agent.reset();
 		// Update cwd to current process directory — auto-mode may have chdir'd

--- a/packages/pi-coding-agent/src/core/extensions/runner.ts
+++ b/packages/pi-coding-agent/src/core/extensions/runner.ts
@@ -164,6 +164,8 @@ export type ExtensionErrorListener = (error: ExtensionError) => void;
 export type NewSessionHandler = (options?: {
 	parentSession?: string;
 	setup?: (sessionManager: SessionManager) => Promise<void>;
+	/** See ExtensionCommandContext.newSession for docs (#3731). */
+	abortSignal?: AbortSignal;
 }) => Promise<{ cancelled: boolean }>;
 
 export type ForkHandler = (entryId: string) => Promise<{ cancelled: boolean }>;

--- a/packages/pi-coding-agent/src/core/extensions/types.ts
+++ b/packages/pi-coding-agent/src/core/extensions/types.ts
@@ -303,6 +303,11 @@ export interface ExtensionCommandContext extends ExtensionContext {
 	newSession(options?: {
 		parentSession?: string;
 		setup?: (sessionManager: SessionManager) => Promise<void>;
+		/** When aborted before the session is fully configured, newSession() returns
+		 *  early without rebuilding the tool runtime. Used by runUnit() to discard
+		 *  a late-resolving newSession() after the session-creation timeout fires,
+		 *  preventing the tool runtime from being rebuilt with the wrong cwd (#3731). */
+		abortSignal?: AbortSignal;
 	}): Promise<{ cancelled: boolean }>;
 
 	/** Fork from a specific entry, creating a new session file. */
@@ -1747,6 +1752,8 @@ export interface ExtensionCommandContextActions {
 	newSession: (options?: {
 		parentSession?: string;
 		setup?: (sessionManager: SessionManager) => Promise<void>;
+		/** See ExtensionCommandContext.newSession for docs (#3731). */
+		abortSignal?: AbortSignal;
 	}) => Promise<{ cancelled: boolean }>;
 	fork: (entryId: string) => Promise<{ cancelled: boolean }>;
 	navigateTree: (

--- a/src/resources/extensions/gsd/auto/run-unit.ts
+++ b/src/resources/extensions/gsd/auto/run-unit.ts
@@ -42,16 +42,25 @@ export async function runUnit(
   let sessionResult: { cancelled: boolean };
   let sessionTimeoutHandle: ReturnType<typeof setTimeout> | undefined;
   const mySessionSwitchGeneration = ++sessionSwitchGeneration;
+  // #3731: Cancellation controller for newSession(). When the session-creation
+  // timeout fires, we abort this controller so that the still-in-flight
+  // newSession() discards itself after await this.abort() completes, preventing
+  // it from capturing the (now-root) process.cwd() and rebuilding the tool
+  // runtime with the wrong cwd.
+  const sessionAbortController = new AbortController();
   _setSessionSwitchInFlight(true);
   try {
-    const sessionPromise = s.cmdCtx!.newSession().finally(() => {
+    const sessionPromise = s.cmdCtx!.newSession({ abortSignal: sessionAbortController.signal }).finally(() => {
       if (sessionSwitchGeneration === mySessionSwitchGeneration) {
         _setSessionSwitchInFlight(false);
       }
     });
     const timeoutPromise = new Promise<{ cancelled: true }>((resolve) => {
       sessionTimeoutHandle = setTimeout(
-        () => resolve({ cancelled: true }),
+        () => {
+          sessionAbortController.abort();
+          resolve({ cancelled: true });
+        },
         NEW_SESSION_TIMEOUT_MS,
       );
     });

--- a/src/resources/extensions/gsd/tests/auto-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-loop.test.ts
@@ -35,12 +35,15 @@ function makeMockSession(opts?: {
   newSessionDelayMs?: number;
   onNewSessionStart?: (session: any) => void;
   onNewSessionSettle?: (session: any) => void;
+  /** Called after the delay with the aborted state of any passed abortSignal.
+   *  Used to verify that runUnit passes an aborted signal on late resolution (#3731). */
+  onSignalCheck?: (aborted: boolean) => void;
 }) {
   const session = {
     active: true,
     verbose: false,
     cmdCtx: {
-      newSession: () => {
+      newSession: (options?: { abortSignal?: AbortSignal }) => {
         opts?.onNewSessionStart?.(session);
         if (opts?.newSessionThrows) {
           return Promise.reject(new Error(opts.newSessionThrows));
@@ -50,11 +53,17 @@ function makeMockSession(opts?: {
         if (delay > 0) {
           return new Promise<{ cancelled: boolean }>((res) =>
             setTimeout(() => {
+              // Simulate AgentSession.newSession() checking abortSignal after
+              // its internal async work (abort()) completes — this is where the
+              // real code captures process.cwd() and rebuilds the tool runtime.
+              // If the signal is aborted, the real code discards the session.
+              opts?.onSignalCheck?.(options?.abortSignal?.aborted ?? false);
               opts?.onNewSessionSettle?.(session);
               res(result);
             }, delay),
           );
         }
+        opts?.onSignalCheck?.(options?.abortSignal?.aborted ?? false);
         opts?.onNewSessionSettle?.(session);
         return Promise.resolve(result);
       },
@@ -463,6 +472,65 @@ test("runUnit proceeds when isProviderRequestReady throws (defensive) (#4555)", 
   assert.equal(result.status, "cancelled");
   assert.equal(result.errorContext?.category, "provider");
   assert.equal(pi.calls.length, 0);
+});
+
+test("late-resolving newSession() after timeout receives aborted signal so tool runtime is not configured with root cwd (#3731)", async () => {
+  // When newSession() times out in runUnit(), auto-mode restores cwd to project
+  // root. If newSession() later resolves, it must NOT use process.cwd() to
+  // configure the tool runtime (which would give it root cwd, not worktree cwd).
+  //
+  // The fix: runUnit creates an AbortController, aborts it on timeout, and passes
+  // the signal to newSession(). AgentSession.newSession() checks the signal after
+  // its internal await this.abort() completes and returns early (discards) if aborted.
+  //
+  // This test uses mock.timers to control timing precisely.
+  _resetPendingResolve();
+  mock.timers.enable();
+
+  try {
+    let abortedWhenLateSessionSettled: boolean | null = null;
+
+    // newSession mock simulates AgentSession.newSession() behavior:
+    // after an internal delay (representing await this.abort()), it checks the
+    // abortSignal — that's where the real code would capture process.cwd() and
+    // call _buildRuntime. If aborted, the real code must discard the session.
+    const s = makeMockSession({
+      newSessionDelayMs: 200_000, // longer than NEW_SESSION_TIMEOUT_MS (120s)
+      onSignalCheck: (aborted) => {
+        abortedWhenLateSessionSettled = aborted;
+      },
+    });
+
+    const ctx = makeMockCtx();
+    const pi = makeMockPi();
+
+    const resultPromise = runUnit(ctx, pi, s, "task", "T01", "prompt");
+
+    // Tick past the 120s NEW_SESSION_TIMEOUT_MS — runUnit returns cancelled
+    mock.timers.tick(121_000);
+    await Promise.resolve();
+
+    const result = await resultPromise;
+    assert.equal(result.status, "cancelled", "runUnit must return cancelled on session timeout");
+
+    // Tick past the delayed newSession (200s total) — the late newSession resolves
+    mock.timers.tick(80_000);
+    // Drain microtask queue so the .finally() and setTimeout callbacks run
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // The key assertion: when the late newSession() resolves, runUnit must have
+    // passed an aborted AbortSignal. Without the fix, no signal is passed and
+    // abortedWhenLateSessionSettled would be false (or null, if signal not passed at all).
+    assert.equal(
+      abortedWhenLateSessionSettled,
+      true,
+      "runUnit must pass an aborted AbortSignal to newSession() when it resolves after the session-creation timeout (#3731). " +
+      "Without this, AgentSession.newSession() captures root process.cwd() and rebuilds the tool runtime with wrong cwd.",
+    );
+  } finally {
+    mock.timers.reset();
+  }
 });
 
 // ─── Structural assertions ───────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- When newSession() timed out in runUnit(), cwd was restored to project root
- newSession() eventually resolved and configured tool runtime with root cwd, breaking worktree isolation
- Agent file operations landed in root repo instead of milestone worktree
- Fixed with cancellation flag: runUnit() creates an AbortController, aborts it on timeout, passes signal to newSession()
- AgentSession.newSession() checks abortSignal after its internal await abort() and returns early (discards) if aborted
- Added unit test verifying late resolution does not configure tool runtime after timeout

Closes #3731

Generated with Claude Code
