### PR TITLE
fix(worktree-resolver): re-throw all errors, not just MergeConflictError

### DIFF
--- a/src/resources/extensions/gsd/tests/worktree-journal-events.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-journal-events.test.ts
@@ -190,7 +190,12 @@ describe("worktree journal events", () => {
     });
     const resolver = new WorktreeResolver(s, deps);
 
-    resolver.mergeAndExit("M001", makeNotifyCtx());
+    // Since #4380, mergeAndExit re-throws all errors after emitting the journal
+    // event and restoring state — callers must handle the throw.
+    assert.throws(
+      () => resolver.mergeAndExit("M001", makeNotifyCtx()),
+      /conflict in main/,
+    );
 
     const entries = readJournalEntries(tmp);
     const failed = entries.find(e => e.eventType === "worktree-merge-failed");

--- a/src/resources/extensions/gsd/tests/worktree-resolver.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-resolver.test.ts
@@ -577,9 +577,11 @@ test("mergeAndExit in worktree mode restores to project root on merge failure", 
   const ctx = makeNotifyCtx();
   const resolver = new WorktreeResolver(s, deps);
 
-  resolver.mergeAndExit("M001", ctx);
+  // Error propagates (#4380) — callers handle recovery. restoreToProjectRoot()
+  // still runs before re-throw so state is consistent for the caller.
+  assert.throws(() => resolver.mergeAndExit("M001", ctx), /conflict in main/);
 
-  assert.equal(s.basePath, "/project"); // error recovery — restored
+  assert.equal(s.basePath, "/project"); // error recovery — restored before re-throw
   assert.ok(
     ctx.messages.some(
       (m) => m.level === "warning" && m.msg.includes("conflict in main"),
@@ -607,7 +609,8 @@ test("mergeAndExit failure message tells user worktree and branch are preserved 
   const ctx = makeNotifyCtx();
   const resolver = new WorktreeResolver(s, deps);
 
-  resolver.mergeAndExit("M001", ctx);
+  // Error propagates (#4380) — notification is still emitted before re-throw
+  assert.throws(() => resolver.mergeAndExit("M001", ctx), /pathspec 'main' did not match/);
 
   const warning = ctx.messages.find((m) => m.level === "warning");
   assert.ok(warning, "a warning message is emitted");
@@ -643,7 +646,8 @@ test("mergeAndExit failure message references /gsd dispatch complete-milestone, 
   const ctx = makeNotifyCtx();
   const resolver = new WorktreeResolver(s, deps);
 
-  resolver.mergeAndExit("M001", ctx);
+  // Error propagates (#4380) — notification is still emitted before re-throw
+  assert.throws(() => resolver.mergeAndExit("M001", ctx), /dirty working tree/);
 
   const warning = ctx.messages.find((m) => m.level === "warning");
   assert.ok(warning, "a warning message is emitted");
@@ -709,7 +713,8 @@ test("mergeAndExit in branch mode handles merge failure gracefully", () => {
   const ctx = makeNotifyCtx();
   const resolver = new WorktreeResolver(s, deps);
 
-  resolver.mergeAndExit("M001", ctx);
+  // Error propagates (#4380) — notification is still emitted before re-throw
+  assert.throws(() => resolver.mergeAndExit("M001", ctx), /branch merge conflict/);
 
   assert.ok(
     ctx.messages.some(
@@ -1068,4 +1073,35 @@ test("mergeAndExit in none mode remains a no-op when NOT in a worktree (#2625)",
 
   assert.equal(findCalls(deps.calls, "mergeMilestoneToMain").length, 0,
     "must NOT merge when not in a worktree and mode is none");
+});
+
+// ─── #4380 — Non-MergeConflictError must not be swallowed ────────────────────
+
+test("mergeAndExit propagates non-MergeConflictError to caller (#4380)", () => {
+  // Regression test: previously the catch block in _mergeWorktreeMode only
+  // re-threw MergeConflictError. Permission errors, filesystem errors, and other
+  // non-conflict failures were swallowed silently, making broken states impossible
+  // to diagnose and preventing callers (phases.ts) from applying their own
+  // error-recovery logic.
+  const permissionError = new Error("EACCES: permission denied, open '/project/.git/SQUASH_MSG'");
+  const s = makeSession({
+    basePath: "/project/.gsd/worktrees/M001",
+    originalBasePath: "/project",
+  });
+  const deps = makeDeps({
+    isInAutoWorktree: () => true,
+    getIsolationMode: () => "worktree",
+    mergeMilestoneToMain: () => {
+      throw permissionError;
+    },
+  });
+  const ctx = makeNotifyCtx();
+  const resolver = new WorktreeResolver(s, deps);
+
+  // The error must propagate — callers need it to apply their own recovery logic
+  assert.throws(
+    () => resolver.mergeAndExit("M001", ctx),
+    (err: unknown) => err === permissionError,
+    "non-MergeConflictError must propagate to the caller, not be swallowed",
+  );
 });

--- a/src/resources/extensions/gsd/worktree-resolver.ts
+++ b/src/resources/extensions/gsd/worktree-resolver.ts
@@ -569,11 +569,13 @@ export class WorktreeResolver {
         }
       }
 
-      // Re-throw MergeConflictError so the auto loop can detect real code
-      // conflicts and stop instead of retrying forever (#2330).
-      if (err instanceof MergeConflictError) {
-        throw err;
-      }
+      // Restore state before re-throwing so callers always get a consistent
+      // session (#4380).
+      this.restoreToProjectRoot();
+      // Re-throw: MergeConflictError stops the auto loop (#2330); non-conflict
+      // errors (permission denied, filesystem failures) must also propagate so
+      // broken states are diagnosable (#4380).
+      throw err;
     }
 
     // Always restore basePath and rebuild — whether merge succeeded or failed
@@ -659,6 +661,8 @@ export class WorktreeResolver {
         error: msg,
       });
       ctx.notify(`Milestone merge failed (branch mode): ${msg}`, "warning");
+      // Re-throw all errors so callers can apply their own recovery logic (#4380).
+      throw err;
     }
   }
 
@@ -681,7 +685,13 @@ export class WorktreeResolver {
       currentMilestoneId,
       nextMilestoneId,
     });
-    this.mergeAndExit(currentMilestoneId, ctx);
+    try {
+      this.mergeAndExit(currentMilestoneId, ctx);
+    } catch {
+      // mergeAndExit already emitted a warning notification and restored state.
+      // Still enter the next milestone so the session can continue working
+      // rather than leaving the loop stuck with no active worktree.
+    }
     this.enterMilestone(nextMilestoneId, ctx);
   }
 }

--- a/src/resources/extensions/gsd/worktree-resolver.ts
+++ b/src/resources/extensions/gsd/worktree-resolver.ts
@@ -687,10 +687,13 @@ export class WorktreeResolver {
     });
     try {
       this.mergeAndExit(currentMilestoneId, ctx);
-    } catch {
-      // mergeAndExit already emitted a warning notification and restored state.
-      // Still enter the next milestone so the session can continue working
-      // rather than leaving the loop stuck with no active worktree.
+    } catch (err) {
+      // mergeAndExit emits a warning and restores state when it fails during
+      // merge/cleanup. But if it throws before recovery runs (e.g., in
+      // validateMilestoneId or emitJournalEvent), basePath won't be restored
+      // to projectRoot — re-throw so we don't enter the next milestone with
+      // the current one unmerged.
+      if (this.s.basePath !== this.projectRoot) throw err;
     }
     this.enterMilestone(nextMilestoneId, ctx);
   }


### PR DESCRIPTION
## Summary
- `worktree-resolver.js` catch blocks in `_mergeWorktreeMode` and `_mergeBranchMode` only re-threw `MergeConflictError`, silently swallowing permission errors, timeouts, and filesystem failures
- Critical failures were lost, making broken worktree states impossible to diagnose and preventing callers in `phases.ts` from applying their non-conflict error-recovery logic
- Now re-throws all errors after logging, journal event, user notification, and `restoreToProjectRoot()` so session state is always consistent for the caller
- `mergeAndEnterNext` gains a local try/catch so merge failures don't prevent the next milestone from being entered (preserving its existing behavior)
- Added unit test verifying non-`MergeConflictError` propagates to caller

Closes #4380

Generated with Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling during merge operations to properly restore session state when failures occur.
  * Enhanced error propagation to ensure non-merge-related errors are correctly communicated to users.
  * Warning notifications now appropriately emitted before merge operation failures.

* **Tests**
  * Added regression tests for merge failure scenarios.
  * Updated tests to verify proper error handling and state restoration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->