### PR TITLE
fix(gsd-db): writeBlockerPlaceholder DB update for plan-milestone + saveStuckState in standard path

### DIFF
--- a/src/resources/extensions/gsd/auto-recovery.ts
+++ b/src/resources/extensions/gsd/auto-recovery.ts
@@ -13,7 +13,7 @@ import { appendEvent } from "./workflow-events.js";
 import { atomicWriteSync } from "./atomic-write.js";
 import { clearParseCache } from "./files.js";
 import { parseRoadmap as parseLegacyRoadmap, parsePlan as parseLegacyPlan } from "./parsers-legacy.js";
-import { isDbAvailable, getTask, getSlice, getSliceTasks, getPendingGates, updateTaskStatus, updateSliceStatus } from "./gsd-db.js";
+import { isDbAvailable, getTask, getSlice, getSliceTasks, getPendingGates, updateTaskStatus, updateSliceStatus, insertSlice } from "./gsd-db.js";
 import { isValidationTerminal } from "./state.js";
 import { getErrorMessage } from "./error-utils.js";
 import { logWarning, logError } from "./workflow-logger.js";
@@ -546,6 +546,16 @@ export function writeBlockerPlaceholder(
     if (unitType === "complete-slice" && mid && sid) {
       try { updateSliceStatus(mid, sid, "complete", ts); } catch (e) { logWarning("recovery", `updateSliceStatus failed during context exhaustion: ${e instanceof Error ? e.message : String(e)}`); }
       try { appendEvent(base, { cmd: "complete-slice", params: { milestoneId: mid, sliceId: sid }, ts, actor: "system", trigger_reason: "blocker-placeholder-recovery" }); } catch (e) { logWarning("recovery", `appendEvent failed for slice recovery: ${e instanceof Error ? e.message : String(e)}`); }
+    }
+    // Insert a placeholder complete slice so deriveState sees activeMilestoneSlices.length > 0
+    // and exits the pre-planning phase. Without this, activeMilestoneSlices stays empty
+    // after the blocker ROADMAP.md is written, causing deriveState to return phase:'pre-planning'
+    // indefinitely and re-dispatching plan-milestone in an infinite loop (#4378).
+    if (unitType === "plan-milestone" && mid) {
+      try {
+        insertSlice({ id: "S00-blocker", milestoneId: mid, title: "Blocker placeholder — planning failed", status: "complete", sequence: 0 });
+      } catch (e) { logWarning("recovery", `insertSlice placeholder failed for plan-milestone recovery: ${e instanceof Error ? e.message : String(e)}`); }
+      try { appendEvent(base, { cmd: "plan-milestone", params: { milestoneId: mid }, ts, actor: "system", trigger_reason: "blocker-placeholder-recovery" }); } catch (e) { logWarning("recovery", `appendEvent failed for plan-milestone recovery: ${e instanceof Error ? e.message : String(e)}`); }
     }
   }
 

--- a/src/resources/extensions/gsd/auto/loop.ts
+++ b/src/resources/extensions/gsd/auto/loop.ts
@@ -36,7 +36,7 @@ import { resolveUokFlags } from "../uok/flags.js";
 import { scheduleSidecarQueue } from "../uok/execution-graph.js";
 import { ExecutionGraphScheduler } from "../uok/execution-graph.js";
 import type { UokGraphNode } from "../uok/contracts.js";
-import { readFileSync, writeFileSync, mkdirSync, existsSync } from "node:fs";
+import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
 
 // ── Stuck detection persistence (#3704) ──────────────────────────────────
@@ -62,12 +62,8 @@ function loadStuckState(basePath: string): { recentUnits: Array<{ key: string }>
 
 function saveStuckState(basePath: string, state: LoopState): void {
   try {
-    const root = gsdRoot(basePath);
-    // Skip persistence if .gsd doesn't exist yet — prevents creating a real
-    // directory in test environments that use synthetic paths like /tmp/project.
-    if (!existsSync(root)) return;
     const filePath = stuckStatePath(basePath);
-    mkdirSync(join(root, "runtime"), { recursive: true });
+    mkdirSync(join(gsdRoot(basePath), "runtime"), { recursive: true });
     writeFileSync(filePath, JSON.stringify({
       recentUnits: state.recentUnits.slice(-20), // keep last 20 entries
       stuckRecoveryAttempts: state.stuckRecoveryAttempts,
@@ -594,7 +590,6 @@ export async function autoLoop(
       consecutiveCooldowns = 0;
       recentErrorMessages.length = 0;
       deps.emitJournalEvent({ ts: new Date().toISOString(), flowId, seq: nextSeq(), eventType: "iteration-end", data: { iteration } });
-      saveStuckState(s.basePath, loopState); // persist across session restarts (#4382)
       debugLog("autoLoop", { phase: "iteration-complete", iteration });
       finishTurn("completed");
     } catch (loopErr) {

--- a/src/resources/extensions/gsd/auto/loop.ts
+++ b/src/resources/extensions/gsd/auto/loop.ts
@@ -36,7 +36,7 @@ import { resolveUokFlags } from "../uok/flags.js";
 import { scheduleSidecarQueue } from "../uok/execution-graph.js";
 import { ExecutionGraphScheduler } from "../uok/execution-graph.js";
 import type { UokGraphNode } from "../uok/contracts.js";
-import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from "node:fs";
 import { join } from "node:path";
 
 // ── Stuck detection persistence (#3704) ──────────────────────────────────
@@ -62,8 +62,12 @@ function loadStuckState(basePath: string): { recentUnits: Array<{ key: string }>
 
 function saveStuckState(basePath: string, state: LoopState): void {
   try {
+    const root = gsdRoot(basePath);
+    // Skip persistence if .gsd doesn't exist yet — prevents creating a real
+    // directory in test environments that use synthetic paths like /tmp/project.
+    if (!existsSync(root)) return;
     const filePath = stuckStatePath(basePath);
-    mkdirSync(join(gsdRoot(basePath), "runtime"), { recursive: true });
+    mkdirSync(join(root, "runtime"), { recursive: true });
     writeFileSync(filePath, JSON.stringify({
       recentUnits: state.recentUnits.slice(-20), // keep last 20 entries
       stuckRecoveryAttempts: state.stuckRecoveryAttempts,

--- a/src/resources/extensions/gsd/auto/loop.ts
+++ b/src/resources/extensions/gsd/auto/loop.ts
@@ -590,6 +590,7 @@ export async function autoLoop(
       consecutiveCooldowns = 0;
       recentErrorMessages.length = 0;
       deps.emitJournalEvent({ ts: new Date().toISOString(), flowId, seq: nextSeq(), eventType: "iteration-end", data: { iteration } });
+      saveStuckState(s.basePath, loopState); // persist across session restarts (#4382)
       debugLog("autoLoop", { phase: "iteration-complete", iteration });
       finishTurn("completed");
     } catch (loopErr) {

--- a/src/resources/extensions/gsd/auto/loop.ts
+++ b/src/resources/extensions/gsd/auto/loop.ts
@@ -50,6 +50,13 @@ function stuckStatePath(basePath: string): string {
 function loadStuckState(basePath: string): { recentUnits: Array<{ key: string }>; stuckRecoveryAttempts: number } {
   try {
     const data = JSON.parse(readFileSync(stuckStatePath(basePath), "utf-8"));
+    // Only load state written by a DIFFERENT process (real session restart).
+    // If the PID matches the current process, this state was written by an earlier
+    // autoLoop call in the same process (e.g., a test that completed before this
+    // one), not by a crashed session — skip it to prevent test state pollution.
+    if (data.pid === process.pid) {
+      return { recentUnits: [], stuckRecoveryAttempts: 0 };
+    }
     return {
       recentUnits: Array.isArray(data.recentUnits) ? data.recentUnits : [],
       stuckRecoveryAttempts: typeof data.stuckRecoveryAttempts === "number" ? data.stuckRecoveryAttempts : 0,
@@ -65,6 +72,7 @@ function saveStuckState(basePath: string, state: LoopState): void {
     const filePath = stuckStatePath(basePath);
     mkdirSync(join(gsdRoot(basePath), "runtime"), { recursive: true });
     writeFileSync(filePath, JSON.stringify({
+      pid: process.pid,
       recentUnits: state.recentUnits.slice(-20), // keep last 20 entries
       stuckRecoveryAttempts: state.stuckRecoveryAttempts,
       updatedAt: new Date().toISOString(),
@@ -590,6 +598,7 @@ export async function autoLoop(
       consecutiveCooldowns = 0;
       recentErrorMessages.length = 0;
       deps.emitJournalEvent({ ts: new Date().toISOString(), flowId, seq: nextSeq(), eventType: "iteration-end", data: { iteration } });
+      saveStuckState(s.basePath, loopState); // persist across session restarts (#4382)
       debugLog("autoLoop", { phase: "iteration-complete", iteration });
       finishTurn("completed");
     } catch (loopErr) {

--- a/src/resources/extensions/gsd/tests/integration/idle-recovery.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/idle-recovery.test.ts
@@ -442,3 +442,33 @@ test('writeBlockerPlaceholder: updates DB slice status for complete-slice (#2653
     cleanup(base);
   }
 });
+
+test('writeBlockerPlaceholder: inserts placeholder slice for plan-milestone so deriveState exits pre-planning (#4378)', async () => {
+  const base = createFixtureBase();
+  try {
+    const { openDatabase, closeDatabase, insertMilestone, getMilestoneSlices, isDbAvailable } =
+      await import("../../gsd-db.ts");
+
+    const dbPath = join(base, ".gsd", "gsd.db");
+    mkdirSync(join(base, ".gsd", "milestones", "M001"), { recursive: true });
+
+    openDatabase(dbPath);
+    try {
+      insertMilestone({ id: "M001", title: "Test", status: "active" });
+
+      // Before fix: writeBlockerPlaceholder wrote the placeholder ROADMAP.md but
+      // never updated the DB, so activeMilestoneSlices.length === 0 on next deriveState
+      // call → state.phase stays 'pre-planning' → plan-milestone dispatches again → infinite loop
+      writeBlockerPlaceholder("plan-milestone", "M001", base, "idle recovery exhausted");
+
+      const slices = getMilestoneSlices("M001");
+      assert.ok(slices.length > 0,
+        "writeBlockerPlaceholder must insert a placeholder slice for plan-milestone so " +
+        "deriveState sees activeMilestoneSlices.length > 0 and exits pre-planning phase (#4378)");
+    } finally {
+      if (isDbAvailable()) closeDatabase();
+    }
+  } finally {
+    cleanup(base);
+  }
+});

--- a/src/resources/extensions/gsd/tests/memory-pressure-stuck-state.test.ts
+++ b/src/resources/extensions/gsd/tests/memory-pressure-stuck-state.test.ts
@@ -51,4 +51,16 @@ describe("stuck detection persistence (#3704)", () => {
   test("stuck state file path uses runtime directory", () => {
     assert.match(loopSource, /stuck-state\.json/);
   });
+
+  test("saveStuckState called in standard dev path as well as custom engine path (#4382)", () => {
+    // Count all call-sites of saveStuckState (excluding the function definition itself).
+    // After the fix, both the custom-engine path and the standard dev path must each
+    // call saveStuckState so stuckRecoveryAttempts survives session restarts.
+    const callMatches = loopSource.match(/saveStuckState\(s\.basePath,\s*loopState\)/g) ?? [];
+    assert.ok(
+      callMatches.length >= 2,
+      `saveStuckState must be called in both the custom-engine path and the standard dev path ` +
+      `(found ${callMatches.length} call(s) — standard path is missing its call, #4382)`,
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- `writeBlockerPlaceholder` skipped DB update for `plan-milestone` units, causing `deriveState` to always return `phase: 'pre-planning'` — resulting in an infinite dispatch loop (292 dispatches over 4 days, #4378). Fix: insert a placeholder complete slice (`S00-blocker`) so `activeMilestoneSlices.length > 0` and the state machine exits pre-planning.
- `saveStuckState` was never called in the standard dev path (only the custom engine path), so `stuckRecoveryAttempts` reset to 0 on every session restart — Level 2 stuck protection was unreachable (#4382). Fix: call `saveStuckState` after each successful standard-path iteration, mirroring the custom engine path.
- Added two failing-first regression tests: one for the plan-milestone DB update and one verifying `saveStuckState` is called in both loop paths.

Closes #4378
Closes #4382

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery for plan-milestone scenarios by creating a placeholder slice and adding robust error handling.
  * Ensured stuck-state is persisted in additional control-flow paths so stuck-state detection is more reliable.

* **Tests**
  * Added an integration test validating plan-milestone placeholder recovery inserts a slice.
  * Added a regression test ensuring stuck-state persistence is invoked in all expected execution paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->