### PR TITLE
fix(gsd): add .mcp.json to ensureGitignore baseline

### DIFF
--- a/src/resources/extensions/gsd/gitignore.ts
+++ b/src/resources/extensions/gsd/gitignore.ts
@@ -48,6 +48,7 @@ const BASELINE_PATTERNS = [
   // ── GSD state directory (symlink to external storage) ──
   ".gsd",
   ".gsd-id",
+  ".mcp.json",
   ".bg-shell/",
 
   // ── OS junk ──
@@ -319,4 +320,3 @@ custom_instructions:
   writeFileSync(preferencesPath, template, "utf-8");
   return true;
 }
-

--- a/src/resources/extensions/gsd/tests/integration/git-service.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/git-service.test.ts
@@ -1235,6 +1235,7 @@ describe('git-service', async () => {
     const content = readFileSync(join(repo, ".gitignore"), "utf-8");
     const lines = content.split("\n").map(l => l.trim()).filter(l => l && !l.startsWith("#"));
     assert.ok(lines.includes(".gsd"), "ensureGitignore: .gitignore contains .gsd");
+    assert.ok(lines.includes(".mcp.json"), "ensureGitignore: .gitignore contains .mcp.json");
 
     // Idempotent — calling again doesn't add duplicates
     const modified2 = ensureGitignore(repo);

--- a/src/resources/extensions/gsd/tests/integration/gitignore-tracked-gsd.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/gitignore-tracked-gsd.test.ts
@@ -107,6 +107,7 @@ test("ensureGitignore does NOT add .gsd when .gsd/ has tracked files (#1364)", (
     // Other baseline patterns should still be present
     assert.ok(lines.includes(".DS_Store"), "Expected .DS_Store in .gitignore");
     assert.ok(lines.includes("node_modules/"), "Expected node_modules/ in .gitignore");
+    assert.ok(lines.includes(".mcp.json"), "Expected .mcp.json in .gitignore");
   } finally {
     cleanup(dir);
   }


### PR DESCRIPTION
## Summary
- add `.mcp.json` to `BASELINE_PATTERNS` so `ensureGitignore()` manages it automatically
- update integration assertions to verify `.mcp.json` is present in generated `.gitignore`

## Why
Project-local MCP config files are commonly local-only and should not be accidentally tracked.

Closes #4636

## Testing
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/integration/git-service.test.ts src/resources/extensions/gsd/tests/integration/gitignore-tracked-gsd.test.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * `.mcp.json` files are now automatically added to the baseline ignore patterns in a project's `.gitignore` file, ensuring they are properly excluded from version control by default.

* **Tests**
  * Integration tests have been updated to verify the `.mcp.json` pattern is correctly included in generated `.gitignore` files and remains consistent across multiple operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->