### PR TITLE
feat(auto): add external process wait mechanism for SLURM/CI jobs

### DIFF
--- a/docs/user-docs/external-process-waiting.md
+++ b/docs/user-docs/external-process-waiting.md
@@ -62,7 +62,7 @@ The `test != "completed"` pattern matches the exit code convention: exit 0 while
 
 ## Lifecycle
 
-```
+```text
 Registration
     │
     ▼
@@ -95,7 +95,7 @@ Auto-loop polls at pollInterval
 
 Register an external wait using the `gsd_register_external_wait` tool during task execution:
 
-```
+```javascript
 gsd_register_external_wait({
   milestoneId: "M006",
   sliceId: "S02",

--- a/docs/user-docs/external-process-waiting.md
+++ b/docs/user-docs/external-process-waiting.md
@@ -1,0 +1,114 @@
+# External Process Waiting
+
+GSD tasks can register a probe for an external process — a CI pipeline, SLURM HPC job, deployment, or any long-running operation — and the auto-loop polls it automatically until it completes or times out.
+
+## Two-Phase Check Concept
+
+External process waiting uses a two-phase check model:
+
+1. **Phase 1 — `checkCommand`** answers "is it done?" The exit code convention is:
+   - **Exit 0** = still running (keep polling)
+   - **Non-zero exit** = done (stop polling, proceed)
+
+2. **Phase 2 — `successCheck`** (optional) answers "did it succeed?" After `checkCommand` signals done:
+   - **Exit 0** = job succeeded
+   - **Non-zero exit** = job failed
+
+This separation exists because **job completion does not mean job success**. A SLURM job can exit the queue (done) but have failed internally. A CI pipeline can finish (done) but report test failures. The two-phase model lets you detect both conditions independently.
+
+If `successCheck` is omitted, the task resumes as soon as `checkCommand` signals done, with no success/failure distinction.
+
+## Parameters Reference
+
+| Parameter | Required | Default | Description |
+|-----------|----------|---------|-------------|
+| `checkCommand` | Yes | — | Shell command to probe external process status. Exit 0 = still running, non-zero = done. |
+| `successCheck` | No | — | Second-phase shell command for deeper validation after `checkCommand` signals done. Exit 0 = success, non-zero = failure. |
+| `pollIntervalMs` | No | `30000` (30s) | How often the auto-loop probes, in milliseconds. Minimum enforced at 10000ms. |
+| `timeoutMs` | No | `86400000` (24h) | Overall timeout in milliseconds. If exceeded, the configured `onTimeout` action fires. |
+| `contextHint` | No | — | Human-readable description of what is being waited on (e.g., "SLURM job 12345 on cluster-gpu"). Carried forward into the task's resume context. |
+| `onTimeout` | No | `manual-attention` | Action when timeout expires: `manual-attention` (pause for human review) or `resume-with-failure` (auto-resume with failure context). |
+
+## SLURM HPC Example
+
+Monitor a SLURM job and verify its exit code after completion:
+
+```bash
+# Phase 1: squeue returns exit 0 while the job is in the queue (still running).
+# When the job finishes and leaves the queue, grep fails with exit 1 (done).
+checkCommand: 'squeue -j 12345 | grep -c 12345'
+
+# Phase 2: sacct checks the job's actual exit code.
+# Exit 0 if the job exited cleanly (0:0), non-zero otherwise.
+successCheck: 'sacct -j 12345 --format=ExitCode --noheader | head -1 | grep -q "0:0"'
+```
+
+This works because `squeue` lists only active jobs. Once the job finishes, `grep -c 12345` finds no matches and exits non-zero, signaling "done" to Phase 1. Phase 2 then uses `sacct` to check whether the job actually succeeded.
+
+## CI Example (GitHub Actions)
+
+Monitor a GitHub Actions workflow run:
+
+```bash
+# Phase 1: test exits 0 while the status is NOT "completed" (still running).
+# When the run completes, the test fails with exit 1 (done).
+checkCommand: 'test "$(gh run view 12345 --json status -q .status)" != "completed"'
+
+# Phase 2: check the conclusion field for success.
+successCheck: 'test "$(gh run view 12345 --json conclusion -q .conclusion)" = "success"'
+```
+
+The `test != "completed"` pattern matches the exit code convention: exit 0 while the condition holds (still running), exit 1 when it no longer holds (done).
+
+## Lifecycle
+
+```
+Registration
+    │
+    ▼
+Auto-loop polls at pollInterval
+    │
+    ├── checkCommand exits 0 → still running, sleep and poll again
+    │
+    ├── checkCommand exits non-zero → done
+    │       │
+    │       ├── No successCheck → task resumes with carry-forward context
+    │       │
+    │       ├── successCheck exits 0 → task resumes with "completed successfully" context
+    │       │
+    │       └── successCheck exits non-zero → task resumes with "JOB FAILED" context
+    │
+    ├── Probe fails (exec error/timeout) → increment failure count
+    │       │
+    │       ├── < 3 failures → continue polling
+    │       │
+    │       └── 3 failures → task transitions to manual-attention
+    │
+    └── Overall timeout exceeded
+            │
+            ├── onTimeout = "manual-attention" → task pauses for human review
+            │
+            └── onTimeout = "resume-with-failure" → task auto-resumes with timeout context
+```
+
+## Registration
+
+Register an external wait using the `gsd_register_external_wait` tool during task execution:
+
+```
+gsd_register_external_wait({
+  milestoneId: "M006",
+  sliceId: "S02",
+  taskId: "T01",
+  checkCommand: 'squeue -j 12345 | grep -c 12345',
+  successCheck: 'sacct -j 12345 --format=ExitCode --noheader | head -1 | grep -q "0:0"',
+  pollIntervalMs: 60000,
+  contextHint: "SLURM job 12345 on cluster-gpu"
+})
+```
+
+The task transitions to `awaiting-external` status and the auto-loop takes over polling.
+
+## See Also
+
+- [Auto Mode](auto-mode.md) — general auto-loop documentation and dispatch mechanics

--- a/src/resources/extensions/gsd/auto-dashboard.ts
+++ b/src/resources/extensions/gsd/auto-dashboard.ts
@@ -183,6 +183,8 @@ export function describeNextUnit(state: GSDState): { label: string; description:
       return { label: "Complete milestone", description: "Write milestone summary." };
     case "evaluating-gates":
       return { label: `Evaluate gates for ${sid}: ${sTitle}`, description: "Parallel quality gate assessment before execution." };
+    case "awaiting-external":
+      return { label: `Awaiting external process for ${tid}: ${tTitle}`, description: "Task is waiting on an external job; probe will check status." };
     default:
       return { label: "Continue", description: "Execute the next step." };
   }

--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -14,7 +14,8 @@ import type { GSDPreferences } from "./preferences.js";
 import type { UatType } from "./files.js";
 import type { MinimalModelRegistry } from "./context-budget.js";
 import { loadFile, extractUatType, loadActiveOverrides } from "./files.js";
-import { isDbAvailable, getMilestoneSlices, getPendingGates, markAllGatesOmitted, getMilestone, updateMilestoneStatus } from "./gsd-db.js";
+import { isDbAvailable, getMilestoneSlices, getPendingGates, markAllGatesOmitted, getMilestone, updateMilestoneStatus, getExternalWait, incrementProbeFailureCount, updateExternalWaitStatus, resetProbeFailureCount, getAllWaitingExternalWaits, updateTaskStatus } from "./gsd-db.js";
+import { exec } from "node:child_process";
 import { isClosedStatus } from "./status-guards.js";
 import { extractVerdict, isAcceptableUatVerdict } from "./verdict-parser.js";
 
@@ -30,8 +31,9 @@ import {
   buildSliceFileName,
 } from "./paths.js";
 import { parseRoadmap } from "./parsers-legacy.js";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { appendFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { logWarning, logError } from "./workflow-logger.js";
+import { invalidateStateCache } from "./state.js";
 import { join } from "node:path";
 import { hasImplementationArtifacts } from "./auto-recovery.js";
 import { classifyMilestoneSummaryContent } from "./milestone-summary-classifier.js";
@@ -74,7 +76,8 @@ export type DispatchAction =
       matchedRule?: string;
     }
   | { action: "stop"; reason: string; level: "info" | "warning" | "error"; matchedRule?: string }
-  | { action: "skip"; matchedRule?: string };
+  | { action: "skip"; matchedRule?: string }
+  | { action: "sleep"; durationMs: number; matchedRule?: string };
 
 export interface DispatchContext {
   basePath: string;
@@ -708,6 +711,166 @@ export const DISPATCH_RULES: DispatchRule[] = [
           basePath,
         ),
       };
+    },
+  },
+  {
+    name: "awaiting-external → probe",
+    match: async (ctx) => {
+      const { state, mid, basePath } = ctx;
+      if (state.phase !== "awaiting-external") return null;
+      if (!state.activeTask || !state.activeSlice) return null;
+
+      const sid = state.activeSlice.id;
+      const tid = state.activeTask.id;
+      const waitRow = getExternalWait(mid, sid, tid);
+
+      if (!waitRow) {
+        return {
+          action: "stop" as const,
+          reason: `Task ${tid} has status "awaiting-external" but no external_waits record. Run /gsd doctor to diagnose.`,
+          level: "warning" as const,
+        };
+      }
+
+      // ── Probe exit code semantics (D029) ──────────────────────────
+      // INVERTED from shell convention:
+      //   exit 0  = "still running" (not done)  → sleep for pollInterval
+      //   exit !0 = "done"                      → skip (transition handled here)
+      // Rationale: SLURM's `squeue -j ID | grep -c ID` returns 0 when job
+      // is in queue (running), non-zero when it's gone (done).
+
+      const checkCommand = waitRow.check_command as string;
+      const pollIntervalMs = (waitRow.poll_interval_ms as number) || 60000;
+      const tasksDir = join(resolveSlicePath(basePath, mid, sid), "tasks");
+      const logPath = join(tasksDir, `${tid}-EXTERNAL-WAIT.log`);
+
+      // ── Timeout check (before probe execution) ────────────────────
+      const registeredAt = waitRow.registered_at as string;
+      const timeoutMs = (waitRow.timeout_ms as number) || 86400000;
+      if (Date.now() > Date.parse(registeredAt) + timeoutMs) {
+        const onTimeout = (waitRow.on_timeout as string) || "manual-attention";
+        updateTaskStatus(mid, sid, tid, "manual-attention");
+        updateExternalWaitStatus(mid, sid, tid, "timed-out");
+        invalidateStateCache();
+        try { appendFileSync(logPath, JSON.stringify({ ts: new Date().toISOString(), event: "timeout", registeredAt, timeoutMs }) + "\n"); } catch {}
+        if (onTimeout === "manual-attention") {
+          return { action: "stop" as const, reason: `External wait for ${tid} timed out (registered ${registeredAt}, timeout ${timeoutMs}ms). Escalating to manual attention.`, level: "warning" as const };
+        }
+        return { action: "stop" as const, reason: `External wait for ${tid} timed out.`, level: "warning" as const };
+      }
+
+      // ── JSON probe spec existence check (R228) ────────────────────
+      const probeSpecPath = join(tasksDir, `${tid}-EXTERNAL-WAIT.json`);
+      if (!existsSync(probeSpecPath)) {
+        updateTaskStatus(mid, sid, tid, "manual-attention");
+        updateExternalWaitStatus(mid, sid, tid, "timed-out");
+        invalidateStateCache();
+        return { action: "stop" as const, reason: `Task ${tid} has external_waits DB row but no ${tid}-EXTERNAL-WAIT.json probe spec. Escalating to manual attention.`, level: "warning" as const };
+      }
+
+      // ── Helper: compute min pollInterval across all waiting waits ──
+      const computeMinPoll = (): number => {
+        const allWaiting = getAllWaitingExternalWaits(mid);
+        return allWaiting.length > 0
+          ? Math.min(...allWaiting.map(w => (w.poll_interval_ms as number) || 60000))
+          : pollIntervalMs;
+      };
+
+      try {
+        const { exitCode, killed, stdout } = await new Promise<{ exitCode: number | null; killed: boolean; stdout: string }>((resolve) => {
+          exec(checkCommand, { timeout: 30000, shell: "/bin/sh" }, (err, stdout, _stderr) => {
+            if (err) {
+              resolve({ exitCode: (err as any).code ?? null, killed: !!(err as any).killed, stdout: stdout || "" });
+            } else {
+              resolve({ exitCode: 0, killed: false, stdout: stdout || "" });
+            }
+          });
+        });
+
+        // ── Probe execution log ───────────────────────────────────
+        try { appendFileSync(logPath, JSON.stringify({ ts: new Date().toISOString(), event: "probe", exitCode, stdout: stdout.slice(0, 500), killed }) + "\n"); } catch {}
+
+        if (killed) {
+          incrementProbeFailureCount(mid, sid, tid);
+          const updated = getExternalWait(mid, sid, tid);
+          if (updated && (updated.probe_failure_count as number) >= 3) {
+            updateTaskStatus(mid, sid, tid, "manual-attention");
+            updateExternalWaitStatus(mid, sid, tid, "timed-out");
+            invalidateStateCache();
+            return {
+              action: "stop" as const,
+              reason: `Probe for ${tid} timed out 3 times. Escalating to manual attention.`,
+              level: "warning" as const,
+            };
+          }
+          return { action: "sleep" as const, durationMs: computeMinPoll(), matchedRule: "awaiting-external → probe" };
+        }
+
+        if (exitCode === 0) {
+          // Still running — reset failure count (R227) and sleep
+          resetProbeFailureCount(mid, sid, tid);
+          return { action: "sleep" as const, durationMs: computeMinPoll(), matchedRule: "awaiting-external → probe" };
+        }
+
+        // ── Non-zero exit = done — execute successCheck if present ──
+        const successCheck = waitRow.success_check as string | null;
+        const contextHint = (waitRow.context_hint as string) || "";
+        let jobSucceeded = true;
+        let failureContext = "";
+
+        if (successCheck) {
+          try {
+            const scResult = await new Promise<{ exitCode: number | null; stdout: string; stderr: string }>((resolve) => {
+              exec(successCheck, { timeout: 30000, shell: "/bin/sh" }, (err, scStdout, scStderr) => {
+                if (err) resolve({ exitCode: (err as any).code ?? 1, stdout: scStdout || "", stderr: scStderr || "" });
+                else resolve({ exitCode: 0, stdout: scStdout || "", stderr: scStderr || "" });
+              });
+            });
+            try { appendFileSync(logPath, JSON.stringify({ ts: new Date().toISOString(), event: "successCheck", exitCode: scResult.exitCode, stdout: scResult.stdout.slice(0, 500) }) + "\n"); } catch {}
+            if (scResult.exitCode !== 0) {
+              jobSucceeded = false;
+              failureContext = `Exit code: ${scResult.exitCode}\nStderr: ${scResult.stderr.slice(0, 1000)}`;
+            }
+          } catch (scErr) {
+            jobSucceeded = false;
+            failureContext = `successCheck exec error: ${scErr instanceof Error ? scErr.message : String(scErr)}`;
+          }
+        }
+
+        // ── State transition: awaiting-external → executing ────────
+        updateTaskStatus(mid, sid, tid, "executing");
+        updateExternalWaitStatus(mid, sid, tid, "resolved");
+        resetProbeFailureCount(mid, sid, tid);
+        invalidateStateCache();
+
+        // ── Carry-forward context ─────────────────────────────────
+        if (ctx.session) {
+          if (jobSucceeded) {
+            ctx.session.pendingExternalResume = `**EXTERNAL WAIT RESOLVED — TASK RESUMING**\n\nThe external process you submitted has completed successfully.${contextHint ? `\n\nContext from registration: ${contextHint}` : ""}\n\nContinue with the task.`;
+          } else {
+            ctx.session.pendingExternalResume = `**EXTERNAL WAIT RESOLVED — JOB FAILED**\n\nThe external process completed but the success check failed.${contextHint ? `\n\nContext from registration: ${contextHint}` : ""}\n\nFailure details:\n${failureContext}\n\nInvestigate the failure, adjust parameters if needed, and either fix the issue or escalate.`;
+          }
+        }
+
+        return { action: "skip" as const };
+      } catch (execErr) {
+        // ── Probe execution failure log ──────────────────────────
+        try { appendFileSync(logPath, JSON.stringify({ ts: new Date().toISOString(), event: "probe-error", error: execErr instanceof Error ? execErr.message : String(execErr) }) + "\n"); } catch {}
+
+        incrementProbeFailureCount(mid, sid, tid);
+        const updated = getExternalWait(mid, sid, tid);
+        if (updated && (updated.probe_failure_count as number) >= 3) {
+          updateTaskStatus(mid, sid, tid, "manual-attention");
+          updateExternalWaitStatus(mid, sid, tid, "timed-out");
+          invalidateStateCache();
+          return {
+            action: "stop" as const,
+            reason: `Probe for ${tid} failed 3 times: ${execErr instanceof Error ? execErr.message : String(execErr)}`,
+            level: "warning" as const,
+          };
+        }
+        return { action: "sleep" as const, durationMs: computeMinPoll(), matchedRule: "awaiting-external → probe" };
+      }
     },
   },
   {

--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -757,14 +757,24 @@ export const DISPATCH_RULES: DispatchRule[] = [
       const timeoutMs = (waitRow.timeout_ms as number) || 86400000;
       if (Date.now() > Date.parse(registeredAt) + timeoutMs) {
         const onTimeout = (waitRow.on_timeout as string) || "manual-attention";
-        updateTaskStatus(mid, sid, tid, "manual-attention");
         updateExternalWaitStatus(mid, sid, tid, "timed-out");
-        invalidateStateCache();
-        try { appendFileSync(logPath, JSON.stringify({ ts: new Date().toISOString(), event: "timeout", registeredAt, timeoutMs }) + "\n"); } catch (logErr) { logWarning("dispatch", `Failed to write external wait log: ${logErr instanceof Error ? logErr.message : String(logErr)}`); }
-        if (onTimeout === "manual-attention") {
-          return { action: "stop" as const, reason: `External wait for ${tid} timed out (registered ${registeredAt}, timeout ${timeoutMs}ms). Escalating to manual attention.`, level: "warning" as const };
+        try { appendFileSync(logPath, JSON.stringify({ ts: new Date().toISOString(), event: "timeout", registeredAt, timeoutMs, onTimeout }) + "\n"); } catch (logErr) { logWarning("dispatch", `Failed to write external wait log: ${logErr instanceof Error ? logErr.message : String(logErr)}`); }
+
+        if (onTimeout === "resume-with-failure") {
+          // Resume execution with failure context so the agent can handle the timeout
+          updateTaskStatus(mid, sid, tid, "executing");
+          invalidateStateCache();
+          const contextHint = (waitRow.context_hint as string) || "";
+          if (ctx.session) {
+            ctx.session.pendingExternalResume = `**EXTERNAL WAIT TIMED OUT — RESUMING WITH FAILURE**\n\nThe external process timed out after ${timeoutMs}ms (registered ${registeredAt}).${contextHint ? `\n\nContext from registration: ${contextHint}` : ""}\n\nThe onTimeout policy is "resume-with-failure" — investigate the timeout, adjust parameters if needed, and either retry or escalate.`;
+          }
+          return { action: "skip" as const };
         }
-        return { action: "stop" as const, reason: `External wait for ${tid} timed out.`, level: "warning" as const };
+
+        // Default: manual-attention
+        updateTaskStatus(mid, sid, tid, "manual-attention");
+        invalidateStateCache();
+        return { action: "stop" as const, reason: `External wait for ${tid} timed out (registered ${registeredAt}, timeout ${timeoutMs}ms). Escalating to manual attention.`, level: "warning" as const };
       }
 
       // ── JSON probe spec existence check (R228) ────────────────────
@@ -779,9 +789,11 @@ export const DISPATCH_RULES: DispatchRule[] = [
       // ── Helper: compute min pollInterval across all waiting waits ──
       const computeMinPoll = (): number => {
         const allWaiting = getAllWaitingExternalWaits(mid);
-        return allWaiting.length > 0
+        const candidate = allWaiting.length > 0
           ? Math.min(...allWaiting.map(w => (w.poll_interval_ms as number) || 60000))
           : pollIntervalMs;
+        // Clamp to at least 1000ms to prevent tight loops from negative/zero DB values
+        return Math.max(1000, candidate);
       };
 
       // Probe timeout: use pollInterval (capped between 30s-120s) so slow external systems have time to respond

--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -741,7 +741,15 @@ export const DISPATCH_RULES: DispatchRule[] = [
 
       const checkCommand = waitRow.check_command as string;
       const pollIntervalMs = (waitRow.poll_interval_ms as number) || 60000;
-      const tasksDir = join(resolveSlicePath(basePath, mid, sid), "tasks");
+      const slicePath = resolveSlicePath(basePath, mid, sid);
+      if (!slicePath) {
+        logWarning("dispatch", `Cannot resolve slice path for ${mid}/${sid} — escalating ${tid} to manual attention.`);
+        updateTaskStatus(mid, sid, tid, "manual-attention");
+        updateExternalWaitStatus(mid, sid, tid, "timed-out");
+        invalidateStateCache();
+        return { action: "stop" as const, reason: `Cannot resolve slice path for ${mid}/${sid}/${tid}. Escalating to manual attention.`, level: "warning" as const };
+      }
+      const tasksDir = join(slicePath, "tasks");
       const logPath = join(tasksDir, `${tid}-EXTERNAL-WAIT.log`);
 
       // ── Timeout check (before probe execution) ────────────────────
@@ -752,7 +760,7 @@ export const DISPATCH_RULES: DispatchRule[] = [
         updateTaskStatus(mid, sid, tid, "manual-attention");
         updateExternalWaitStatus(mid, sid, tid, "timed-out");
         invalidateStateCache();
-        try { appendFileSync(logPath, JSON.stringify({ ts: new Date().toISOString(), event: "timeout", registeredAt, timeoutMs }) + "\n"); } catch {}
+        try { appendFileSync(logPath, JSON.stringify({ ts: new Date().toISOString(), event: "timeout", registeredAt, timeoutMs }) + "\n"); } catch (logErr) { logWarning("dispatch", `Failed to write external wait log: ${logErr instanceof Error ? logErr.message : String(logErr)}`); }
         if (onTimeout === "manual-attention") {
           return { action: "stop" as const, reason: `External wait for ${tid} timed out (registered ${registeredAt}, timeout ${timeoutMs}ms). Escalating to manual attention.`, level: "warning" as const };
         }
@@ -776,9 +784,11 @@ export const DISPATCH_RULES: DispatchRule[] = [
           : pollIntervalMs;
       };
 
+      // Probe timeout: use pollInterval (capped between 30s-120s) so slow external systems have time to respond
+      const probeTimeoutMs = Math.max(30000, Math.min(pollIntervalMs, 120000));
       try {
         const { exitCode, killed, stdout } = await new Promise<{ exitCode: number | null; killed: boolean; stdout: string }>((resolve) => {
-          exec(checkCommand, { timeout: 30000, shell: "/bin/sh" }, (err, stdout, _stderr) => {
+          exec(checkCommand, { timeout: probeTimeoutMs, shell: "/bin/sh" }, (err, stdout, _stderr) => {
             if (err) {
               resolve({ exitCode: (err as any).code ?? null, killed: !!(err as any).killed, stdout: stdout || "" });
             } else {
@@ -788,7 +798,7 @@ export const DISPATCH_RULES: DispatchRule[] = [
         });
 
         // ── Probe execution log ───────────────────────────────────
-        try { appendFileSync(logPath, JSON.stringify({ ts: new Date().toISOString(), event: "probe", exitCode, stdout: stdout.slice(0, 500), killed }) + "\n"); } catch {}
+        try { appendFileSync(logPath, JSON.stringify({ ts: new Date().toISOString(), event: "probe", exitCode, stdout: stdout.slice(0, 500), killed }) + "\n"); } catch (logErr) { logWarning("dispatch", `Failed to write external wait log: ${logErr instanceof Error ? logErr.message : String(logErr)}`); }
 
         if (killed) {
           incrementProbeFailureCount(mid, sid, tid);
@@ -826,7 +836,7 @@ export const DISPATCH_RULES: DispatchRule[] = [
                 else resolve({ exitCode: 0, stdout: scStdout || "", stderr: scStderr || "" });
               });
             });
-            try { appendFileSync(logPath, JSON.stringify({ ts: new Date().toISOString(), event: "successCheck", exitCode: scResult.exitCode, stdout: scResult.stdout.slice(0, 500) }) + "\n"); } catch {}
+            try { appendFileSync(logPath, JSON.stringify({ ts: new Date().toISOString(), event: "successCheck", exitCode: scResult.exitCode, stdout: scResult.stdout.slice(0, 500) }) + "\n"); } catch (logErr) { logWarning("dispatch", `Failed to write external wait log: ${logErr instanceof Error ? logErr.message : String(logErr)}`); }
             if (scResult.exitCode !== 0) {
               jobSucceeded = false;
               failureContext = `Exit code: ${scResult.exitCode}\nStderr: ${scResult.stderr.slice(0, 1000)}`;
@@ -855,7 +865,7 @@ export const DISPATCH_RULES: DispatchRule[] = [
         return { action: "skip" as const };
       } catch (execErr) {
         // ── Probe execution failure log ──────────────────────────
-        try { appendFileSync(logPath, JSON.stringify({ ts: new Date().toISOString(), event: "probe-error", error: execErr instanceof Error ? execErr.message : String(execErr) }) + "\n"); } catch {}
+        try { appendFileSync(logPath, JSON.stringify({ ts: new Date().toISOString(), event: "probe-error", error: execErr instanceof Error ? execErr.message : String(execErr) }) + "\n"); } catch (logErr) { logWarning("dispatch", `Failed to write external wait log: ${logErr instanceof Error ? logErr.message : String(logErr)}`); }
 
         incrementProbeFailureCount(mid, sid, tid);
         const updated = getExternalWait(mid, sid, tid);

--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -17,6 +17,11 @@ import { loadFile, extractUatType, loadActiveOverrides } from "./files.js";
 import { isDbAvailable, getMilestoneSlices, getPendingGates, markAllGatesOmitted, getMilestone, updateMilestoneStatus, getExternalWait, incrementProbeFailureCount, updateExternalWaitStatus, resetProbeFailureCount, getAllWaitingExternalWaits, updateTaskStatus } from "./gsd-db.js";
 import { exec } from "node:child_process";
 import { isClosedStatus } from "./status-guards.js";
+
+/** Platform-appropriate shell for probe commands. Unix → /bin/sh, Windows → %COMSPEC% or cmd.exe. */
+const probeShell = process.platform === "win32"
+  ? (process.env.COMSPEC || "cmd.exe")
+  : "/bin/sh";
 import { extractVerdict, isAcceptableUatVerdict } from "./verdict-parser.js";
 
 import {
@@ -800,7 +805,7 @@ export const DISPATCH_RULES: DispatchRule[] = [
       const probeTimeoutMs = Math.max(30000, Math.min(pollIntervalMs, 120000));
       try {
         const { exitCode, killed, stdout } = await new Promise<{ exitCode: number | null; killed: boolean; stdout: string }>((resolve) => {
-          exec(checkCommand, { timeout: probeTimeoutMs, shell: "/bin/sh" }, (err, stdout, _stderr) => {
+          exec(checkCommand, { timeout: probeTimeoutMs, shell: probeShell }, (err, stdout, _stderr) => {
             if (err) {
               resolve({ exitCode: (err as any).code ?? null, killed: !!(err as any).killed, stdout: stdout || "" });
             } else {
@@ -843,7 +848,7 @@ export const DISPATCH_RULES: DispatchRule[] = [
         if (successCheck) {
           try {
             const scResult = await new Promise<{ exitCode: number | null; stdout: string; stderr: string }>((resolve) => {
-              exec(successCheck, { timeout: 30000, shell: "/bin/sh" }, (err, scStdout, scStderr) => {
+              exec(successCheck, { timeout: 30000, shell: probeShell }, (err, scStdout, scStderr) => {
                 if (err) resolve({ exitCode: (err as any).code ?? 1, stdout: scStdout || "", stderr: scStderr || "" });
                 else resolve({ exitCode: 0, stdout: scStdout || "", stderr: scStderr || "" });
               });

--- a/src/resources/extensions/gsd/auto/loop.ts
+++ b/src/resources/extensions/gsd/auto/loop.ts
@@ -432,6 +432,10 @@ export async function autoLoop(
         if (dispatch.action === "skip") {
           continue;
         }
+        if (dispatch.action === "sleep") {
+          await new Promise(r => setTimeout(r, dispatch.durationMs));
+          continue;
+        }
 
         // dispatch.action === "dispatch"
         const step = dispatch.step!;

--- a/src/resources/extensions/gsd/auto/loop.ts
+++ b/src/resources/extensions/gsd/auto/loop.ts
@@ -433,7 +433,12 @@ export async function autoLoop(
           continue;
         }
         if (dispatch.action === "sleep") {
-          await new Promise(r => setTimeout(r, dispatch.durationMs));
+          // Chunked sleep: poll s.active every 1s so pause/stop is responsive
+          const sleepMs = dispatch.durationMs;
+          const start = Date.now();
+          while (Date.now() - start < sleepMs && s.active) {
+            await new Promise(r => setTimeout(r, Math.min(1000, sleepMs - (Date.now() - start))));
+          }
           continue;
         }
 

--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -945,6 +945,23 @@ export async function runDispatch(
     return { action: "break", reason: "dispatch-stop" };
   }
 
+  if (dispatchResult.action === "sleep") {
+    deps.emitJournalEvent({
+      ts: new Date().toISOString(), flowId: ic.flowId, seq: ic.nextSeq(),
+      eventType: "dispatch-sleep",
+      rule: dispatchResult.matchedRule,
+      data: { durationMs: dispatchResult.durationMs },
+    });
+    // Interruptible sleep: poll s.active every 1s so the loop wakes
+    // promptly when auto-mode is stopped instead of sleeping the full duration.
+    const sleepMs = dispatchResult.durationMs;
+    const start = Date.now();
+    while (Date.now() - start < sleepMs && s.active) {
+      await new Promise(r => setTimeout(r, Math.min(1000, sleepMs - (Date.now() - start))));
+    }
+    return { action: "continue" };
+  }
+
   if (dispatchResult.action !== "dispatch") {
     // Non-dispatch action (e.g. "skip") — re-derive state
     await new Promise((r) => setImmediate(r));
@@ -1482,6 +1499,7 @@ export async function runUnitPhase(
     finalPrompt = `**VERIFICATION FAILED — AUTO-FIX ATTEMPT ${retryCtx.attempt}**\n\nThe verification gate ran after your previous attempt and found failures. Fix these issues before completing the task.\n\n${capped}\n\n---\n\n${finalPrompt}`;
   }
 
+  const hadCrashRecovery = !!s.pendingCrashRecovery;
   if (s.pendingCrashRecovery) {
     const capped =
       s.pendingCrashRecovery.length > MAX_RECOVERY_CHARS
@@ -1490,7 +1508,19 @@ export async function runUnitPhase(
         : s.pendingCrashRecovery;
     finalPrompt = `${capped}\n\n---\n\n${finalPrompt}`;
     s.pendingCrashRecovery = null;
-  } else if ((s.unitDispatchCount.get(dispatchKey) ?? 0) > 1) {
+  }
+
+  if (s.pendingExternalResume) {
+    const cappedExt =
+      s.pendingExternalResume.length > MAX_RECOVERY_CHARS
+        ? s.pendingExternalResume.slice(0, MAX_RECOVERY_CHARS) +
+          "\n\n[...external resume context truncated]"
+        : s.pendingExternalResume;
+    finalPrompt = `${cappedExt}\n\n---\n\n${finalPrompt}`;
+    s.pendingExternalResume = null;
+  }
+
+  if (!hadCrashRecovery && (s.unitDispatchCount.get(dispatchKey) ?? 0) > 1) {
     const diagnostic = deps.getDeepDiagnostic(s.basePath);
     if (diagnostic) {
       const cappedDiag =

--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -1500,6 +1500,7 @@ export async function runUnitPhase(
   }
 
   const hadCrashRecovery = !!s.pendingCrashRecovery;
+  const hadExternalResume = !!s.pendingExternalResume;
   if (s.pendingCrashRecovery) {
     const capped =
       s.pendingCrashRecovery.length > MAX_RECOVERY_CHARS
@@ -1520,7 +1521,7 @@ export async function runUnitPhase(
     s.pendingExternalResume = null;
   }
 
-  if (!hadCrashRecovery && (s.unitDispatchCount.get(dispatchKey) ?? 0) > 1) {
+  if (!hadCrashRecovery && !hadExternalResume && (s.unitDispatchCount.get(dispatchKey) ?? 0) > 1) {
     const diagnostic = deps.getDeepDiagnostic(s.basePath);
     if (diagnostic) {
       const cappedDiag =

--- a/src/resources/extensions/gsd/auto/session.ts
+++ b/src/resources/extensions/gsd/auto/session.ts
@@ -137,6 +137,7 @@ export class AutoSession {
 
   // ── Recovery ─────────────────────────────────────────────────────────────
   pendingCrashRecovery: string | null = null;
+  pendingExternalResume: string | null = null;
   pendingVerificationRetry: PendingVerificationRetry | null = null;
   readonly verificationRetryCount = new Map<string, number>();
   pausedSessionFile: string | null = null;
@@ -283,6 +284,7 @@ export class AutoSession {
 
     // Recovery
     this.pendingCrashRecovery = null;
+    this.pendingExternalResume = null;
     this.pendingVerificationRetry = null;
     this.verificationRetryCount.clear();
     this.pausedSessionFile = null;

--- a/src/resources/extensions/gsd/bootstrap/db-tools.ts
+++ b/src/resources/extensions/gsd/bootstrap/db-tools.ts
@@ -13,7 +13,7 @@ import { invalidateStateCache } from "../state.js";
 import { saveJsonFile } from "../json-persistence.js";
 import { resolveTasksDir } from "../paths.js";
 import { join } from "node:path";
-import { mkdirSync } from "node:fs";
+import { mkdirSync, unlinkSync } from "node:fs";
 import {
   executeCompleteMilestone,
   executePlanMilestone,
@@ -1144,19 +1144,7 @@ export function registerDbTools(pi: ExtensionAPI): void {
       return { content: [{ type: "text" as const, text: `Error: task not in executing status (current: ${task.status})` }], isError: true, details: { error: `task not in executing status (current: ${task.status})` } as any };
     }
 
-    // Insert external_waits DB row (R213, R214, R223)
-    insertExternalWait(milestoneId, sliceId, taskId, checkCommand, {
-      successCheck,
-      pollIntervalMs,
-      timeoutMs,
-      contextHint,
-      onTimeout,
-    });
-
-    // Update task status to awaiting-external
-    updateTaskStatus(milestoneId, sliceId, taskId, "awaiting-external");
-
-    // Write JSON probe spec (R215)
+    // Write JSON probe spec FIRST (R215) — filesystem before DB to avoid stranded state
     const basePath = process.cwd();
     const resolvedPollInterval = pollIntervalMs ?? 30000;
     const resolvedTimeout = timeoutMs ?? 86400000;
@@ -1170,18 +1158,38 @@ export function registerDbTools(pi: ExtensionAPI): void {
       mkdirSync(tasksDir, { recursive: true });
     }
     const jsonPath = join(tasksDir, `${taskId}-EXTERNAL-WAIT.json`);
-    saveJsonFile(jsonPath, {
-      milestoneId,
-      sliceId,
-      taskId,
-      checkCommand,
-      successCheck: successCheck ?? null,
-      pollIntervalMs: resolvedPollInterval,
-      timeoutMs: resolvedTimeout,
-      contextHint: contextHint ?? null,
-      onTimeout: resolvedOnTimeout,
-      registeredAt,
-    });
+    try {
+      saveJsonFile(jsonPath, {
+        milestoneId,
+        sliceId,
+        taskId,
+        checkCommand,
+        successCheck: successCheck ?? null,
+        pollIntervalMs: resolvedPollInterval,
+        timeoutMs: resolvedTimeout,
+        contextHint: contextHint ?? null,
+        onTimeout: resolvedOnTimeout,
+        registeredAt,
+      });
+    } catch (fileErr) {
+      return { content: [{ type: "text" as const, text: `Error: failed to write probe spec — ${fileErr instanceof Error ? fileErr.message : String(fileErr)}` }], isError: true, details: { error: "probe spec write failed" } as any };
+    }
+
+    // Insert external_waits DB row and update task status (R213, R214, R223)
+    try {
+      insertExternalWait(milestoneId, sliceId, taskId, checkCommand, {
+        successCheck,
+        pollIntervalMs,
+        timeoutMs,
+        contextHint,
+        onTimeout,
+      });
+      updateTaskStatus(milestoneId, sliceId, taskId, "awaiting-external");
+    } catch (dbErr) {
+      // Cleanup the JSON file to avoid partial state
+      try { unlinkSync(jsonPath); } catch { /* best effort */ }
+      return { content: [{ type: "text" as const, text: `Error: DB update failed — ${dbErr instanceof Error ? dbErr.message : String(dbErr)}` }], isError: true, details: { error: "db update failed" } as any };
+    }
 
     // Invalidate state cache
     invalidateStateCache();

--- a/src/resources/extensions/gsd/bootstrap/db-tools.ts
+++ b/src/resources/extensions/gsd/bootstrap/db-tools.ts
@@ -12,7 +12,7 @@ import { getTask, updateTaskStatus, insertExternalWait } from "../gsd-db.js";
 import { invalidateStateCache } from "../state.js";
 import { saveJsonFile } from "../json-persistence.js";
 import { resolveTasksDir } from "../paths.js";
-import { join } from "node:path";
+import { join, relative } from "node:path";
 import { mkdirSync, unlinkSync } from "node:fs";
 import {
   executeCompleteMilestone,
@@ -1144,6 +1144,21 @@ export function registerDbTools(pi: ExtensionAPI): void {
       return { content: [{ type: "text" as const, text: `Error: task not in executing status (current: ${task.status})` }], isError: true, details: { error: `task not in executing status (current: ${task.status})` } as any };
     }
 
+    // Runtime validation — reject empty/invalid values before persistence
+    const trimmedCommand = checkCommand.trim();
+    if (!trimmedCommand) {
+      return { content: [{ type: "text" as const, text: "Error: checkCommand must not be empty" }], isError: true, details: { error: "checkCommand empty" } as any };
+    }
+    if (pollIntervalMs !== undefined && (!Number.isInteger(pollIntervalMs) || pollIntervalMs < 1)) {
+      return { content: [{ type: "text" as const, text: "Error: pollIntervalMs must be a positive integer" }], isError: true, details: { error: "invalid pollIntervalMs" } as any };
+    }
+    if (timeoutMs !== undefined && (!Number.isInteger(timeoutMs) || timeoutMs < 1)) {
+      return { content: [{ type: "text" as const, text: "Error: timeoutMs must be a positive integer" }], isError: true, details: { error: "invalid timeoutMs" } as any };
+    }
+    if (pollIntervalMs !== undefined && timeoutMs !== undefined && timeoutMs < pollIntervalMs) {
+      return { content: [{ type: "text" as const, text: "Error: timeoutMs must be >= pollIntervalMs" }], isError: true, details: { error: "timeoutMs < pollIntervalMs" } as any };
+    }
+
     // Write JSON probe spec FIRST (R215) — filesystem before DB to avoid stranded state
     const basePath = process.cwd();
     const resolvedPollInterval = pollIntervalMs ?? 30000;
@@ -1163,7 +1178,7 @@ export function registerDbTools(pi: ExtensionAPI): void {
         milestoneId,
         sliceId,
         taskId,
-        checkCommand,
+        checkCommand: trimmedCommand,
         successCheck: successCheck ?? null,
         pollIntervalMs: resolvedPollInterval,
         timeoutMs: resolvedTimeout,
@@ -1177,7 +1192,7 @@ export function registerDbTools(pi: ExtensionAPI): void {
 
     // Insert external_waits DB row and update task status (R213, R214, R223)
     try {
-      insertExternalWait(milestoneId, sliceId, taskId, checkCommand, {
+      insertExternalWait(milestoneId, sliceId, taskId, trimmedCommand, {
         successCheck,
         pollIntervalMs,
         timeoutMs,
@@ -1194,7 +1209,7 @@ export function registerDbTools(pi: ExtensionAPI): void {
     // Invalidate state cache
     invalidateStateCache();
 
-    const relPath = jsonPath.replace(basePath + "/", "");
+    const relPath = relative(basePath, jsonPath).split("\\").join("/");
     return {
       content: [{ type: "text" as const, text: `External wait registered for ${milestoneId}/${sliceId}/${taskId}. Probe spec: ${relPath}` }],
       isError: false,
@@ -1223,10 +1238,10 @@ export function registerDbTools(pi: ExtensionAPI): void {
       milestoneId: Type.String({ description: "Milestone ID (e.g. M006)" }),
       sliceId: Type.String({ description: "Slice ID (e.g. S02)" }),
       taskId: Type.String({ description: "Task ID (e.g. T01)" }),
-      checkCommand: Type.String({ description: "Shell command to probe external process status" }),
-      successCheck: Type.Optional(Type.String({ description: "Optional second-phase validation command after checkCommand succeeds" })),
-      pollIntervalMs: Type.Optional(Type.Number({ description: "Probe poll interval in milliseconds (default 30000)" })),
-      timeoutMs: Type.Optional(Type.Number({ description: "Overall timeout in milliseconds (default 86400000 = 24h)" })),
+      checkCommand: Type.String({ description: "Shell command to probe external process status", minLength: 1 }),
+      successCheck: Type.Optional(Type.String({ description: "Optional second-phase validation command after checkCommand succeeds", minLength: 1 })),
+      pollIntervalMs: Type.Optional(Type.Number({ description: "Probe poll interval in milliseconds (default 30000)", minimum: 1 })),
+      timeoutMs: Type.Optional(Type.Number({ description: "Overall timeout in milliseconds (default 86400000 = 24h)", minimum: 1 })),
       contextHint: Type.Optional(Type.String({ description: "Human-readable hint about what is being waited on" })),
       onTimeout: Type.Optional(StringEnum(["manual-attention", "resume-with-failure"], { description: "Action on timeout: manual-attention (default) or resume-with-failure" })),
     }),

--- a/src/resources/extensions/gsd/bootstrap/db-tools.ts
+++ b/src/resources/extensions/gsd/bootstrap/db-tools.ts
@@ -1126,9 +1126,9 @@ export function registerDbTools(pi: ExtensionAPI): void {
   // ─── gsd_register_external_wait ──────────────────────────────────────────
 
   const registerExternalWaitExecute = async (_toolCallId: string, params: any, _signal: AbortSignal | undefined, _onUpdate: unknown, _ctx: unknown) => {
-    const dbOk = ensureDbOpen();
+    const dbOk = await ensureDbOpen();
     if (!dbOk) {
-      return { content: [{ type: "text" as const, text: "Error: GSD database is not available" }], isError: true, details: { error: "GSD database is not available" } };
+      return { content: [{ type: "text" as const, text: "Error: GSD database is not available" }], isError: true, details: { error: "GSD database is not available" } as any };
     }
 
     const { milestoneId, sliceId, taskId, checkCommand, successCheck, pollIntervalMs, timeoutMs, contextHint, onTimeout } = params;
@@ -1136,12 +1136,12 @@ export function registerDbTools(pi: ExtensionAPI): void {
     // Validate task exists
     const task = getTask(milestoneId, sliceId, taskId);
     if (!task) {
-      return { content: [{ type: "text" as const, text: `Error: task not found — ${milestoneId}/${sliceId}/${taskId}` }], isError: true, details: { error: "task not found" } };
+      return { content: [{ type: "text" as const, text: `Error: task not found — ${milestoneId}/${sliceId}/${taskId}` }], isError: true, details: { error: "task not found" } as any };
     }
 
     // Validate task status is 'executing' (R229)
     if (task.status !== "executing") {
-      return { content: [{ type: "text" as const, text: `Error: task not in executing status (current: ${task.status})` }], isError: true, details: { error: `task not in executing status (current: ${task.status})` } };
+      return { content: [{ type: "text" as const, text: `Error: task not in executing status (current: ${task.status})` }], isError: true, details: { error: `task not in executing status (current: ${task.status})` } as any };
     }
 
     // Insert external_waits DB row (R213, R214, R223)
@@ -1190,7 +1190,7 @@ export function registerDbTools(pi: ExtensionAPI): void {
     return {
       content: [{ type: "text" as const, text: `External wait registered for ${milestoneId}/${sliceId}/${taskId}. Probe spec: ${relPath}` }],
       isError: false,
-      details: { milestoneId, sliceId, taskId, jsonPath: relPath },
+      details: { milestoneId, sliceId, taskId, jsonPath: relPath } as any,
     };
   };
 
@@ -1229,7 +1229,7 @@ export function registerDbTools(pi: ExtensionAPI): void {
       return new Text(text, 0, 0);
     },
     renderResult(result: any, _options: any, theme: any) {
-      const d = result.details;
+      const d = readDetails(result);
       if (result.isError || d?.error) {
         return new Text(theme.fg("error", `Error: ${d?.error ?? "unknown"}`), 0, 0);
       }

--- a/src/resources/extensions/gsd/bootstrap/db-tools.ts
+++ b/src/resources/extensions/gsd/bootstrap/db-tools.ts
@@ -1187,7 +1187,7 @@ export function registerDbTools(pi: ExtensionAPI): void {
       updateTaskStatus(milestoneId, sliceId, taskId, "awaiting-external");
     } catch (dbErr) {
       // Cleanup the JSON file to avoid partial state
-      try { unlinkSync(jsonPath); } catch (cleanupErr) { logError("register-external-wait", `Failed to clean up probe spec ${jsonPath}: ${cleanupErr instanceof Error ? cleanupErr.message : String(cleanupErr)}`); }
+      try { unlinkSync(jsonPath); } catch (cleanupErr) { logError("db", `Failed to clean up probe spec ${jsonPath}: ${cleanupErr instanceof Error ? cleanupErr.message : String(cleanupErr)}`); }
       return { content: [{ type: "text" as const, text: `Error: DB update failed — ${dbErr instanceof Error ? dbErr.message : String(dbErr)}` }], isError: true, details: { error: "db update failed" } as any };
     }
 

--- a/src/resources/extensions/gsd/bootstrap/db-tools.ts
+++ b/src/resources/extensions/gsd/bootstrap/db-tools.ts
@@ -8,6 +8,12 @@ import { ensureDbOpen } from "./dynamic-tools.js";
 import { StringEnum } from "@gsd/pi-ai";
 import { logError } from "../workflow-logger.js";
 import { getErrorMessage } from "../error-utils.js";
+import { getTask, updateTaskStatus, insertExternalWait } from "../gsd-db.js";
+import { invalidateStateCache } from "../state.js";
+import { saveJsonFile } from "../json-persistence.js";
+import { resolveTasksDir } from "../paths.js";
+import { join } from "node:path";
+import { mkdirSync } from "node:fs";
 import {
   executeCompleteMilestone,
   executePlanMilestone,
@@ -1116,4 +1122,120 @@ export function registerDbTools(pi: ExtensionAPI): void {
   };
 
   pi.registerTool(saveGateResultTool);
+
+  // ─── gsd_register_external_wait ──────────────────────────────────────────
+
+  const registerExternalWaitExecute = async (_toolCallId: string, params: any, _signal: AbortSignal | undefined, _onUpdate: unknown, _ctx: unknown) => {
+    const dbOk = ensureDbOpen();
+    if (!dbOk) {
+      return { content: [{ type: "text" as const, text: "Error: GSD database is not available" }], isError: true, details: { error: "GSD database is not available" } };
+    }
+
+    const { milestoneId, sliceId, taskId, checkCommand, successCheck, pollIntervalMs, timeoutMs, contextHint, onTimeout } = params;
+
+    // Validate task exists
+    const task = getTask(milestoneId, sliceId, taskId);
+    if (!task) {
+      return { content: [{ type: "text" as const, text: `Error: task not found — ${milestoneId}/${sliceId}/${taskId}` }], isError: true, details: { error: "task not found" } };
+    }
+
+    // Validate task status is 'executing' (R229)
+    if (task.status !== "executing") {
+      return { content: [{ type: "text" as const, text: `Error: task not in executing status (current: ${task.status})` }], isError: true, details: { error: `task not in executing status (current: ${task.status})` } };
+    }
+
+    // Insert external_waits DB row (R213, R214, R223)
+    insertExternalWait(milestoneId, sliceId, taskId, checkCommand, {
+      successCheck,
+      pollIntervalMs,
+      timeoutMs,
+      contextHint,
+      onTimeout,
+    });
+
+    // Update task status to awaiting-external
+    updateTaskStatus(milestoneId, sliceId, taskId, "awaiting-external");
+
+    // Write JSON probe spec (R215)
+    const basePath = process.cwd();
+    const resolvedPollInterval = pollIntervalMs ?? 30000;
+    const resolvedTimeout = timeoutMs ?? 86400000;
+    const resolvedOnTimeout = onTimeout ?? "manual-attention";
+    const registeredAt = new Date().toISOString();
+
+    let tasksDir = resolveTasksDir(basePath, milestoneId, sliceId);
+    if (!tasksDir) {
+      const gsdDir = join(basePath, ".gsd");
+      tasksDir = join(gsdDir, "milestones", milestoneId, "slices", sliceId, "tasks");
+      mkdirSync(tasksDir, { recursive: true });
+    }
+    const jsonPath = join(tasksDir, `${taskId}-EXTERNAL-WAIT.json`);
+    saveJsonFile(jsonPath, {
+      milestoneId,
+      sliceId,
+      taskId,
+      checkCommand,
+      successCheck: successCheck ?? null,
+      pollIntervalMs: resolvedPollInterval,
+      timeoutMs: resolvedTimeout,
+      contextHint: contextHint ?? null,
+      onTimeout: resolvedOnTimeout,
+      registeredAt,
+    });
+
+    // Invalidate state cache
+    invalidateStateCache();
+
+    const relPath = jsonPath.replace(basePath + "/", "");
+    return {
+      content: [{ type: "text" as const, text: `External wait registered for ${milestoneId}/${sliceId}/${taskId}. Probe spec: ${relPath}` }],
+      isError: false,
+      details: { milestoneId, sliceId, taskId, jsonPath: relPath },
+    };
+  };
+
+  const registerExternalWaitTool = {
+    name: "gsd_register_external_wait",
+    label: "Register External Wait",
+    description:
+      "Register an external wait for a task that is blocked on an external process (CI pipeline, deployment, HPC job, etc.). " +
+      "Creates a probe spec and transitions the task to awaiting-external status.",
+    promptSnippet: "Register an external wait probe for a task blocked on an external process",
+    promptGuidelines: [
+      "Use gsd_register_external_wait when a task must wait for an external process to complete.",
+      "The task must be in 'executing' status — registration is rejected otherwise.",
+      "checkCommand is required — a shell command that probes the external process status.",
+      "successCheck is optional — a second-phase shell command for deeper validation after checkCommand succeeds.",
+      "onTimeout defaults to 'manual-attention'; set to 'resume-with-failure' to auto-resume on timeout.",
+      'Example SLURM: checkCommand="squeue -j $JOBID | grep -c $JOBID", successCheck="sacct -j $JOBID --format=ExitCode --noheader | head -1 | grep -q 0:0"',
+      'Example CI: checkCommand="test \\"$(gh run view $RUNID --json status -q .status)\\" != \\"completed\\""',
+      "Exit code convention: exit 0 = still running, non-zero = done. This matches squeue (returns 0 while job in queue).",
+    ],
+    parameters: Type.Object({
+      milestoneId: Type.String({ description: "Milestone ID (e.g. M006)" }),
+      sliceId: Type.String({ description: "Slice ID (e.g. S02)" }),
+      taskId: Type.String({ description: "Task ID (e.g. T01)" }),
+      checkCommand: Type.String({ description: "Shell command to probe external process status" }),
+      successCheck: Type.Optional(Type.String({ description: "Optional second-phase validation command after checkCommand succeeds" })),
+      pollIntervalMs: Type.Optional(Type.Number({ description: "Probe poll interval in milliseconds (default 30000)" })),
+      timeoutMs: Type.Optional(Type.Number({ description: "Overall timeout in milliseconds (default 86400000 = 24h)" })),
+      contextHint: Type.Optional(Type.String({ description: "Human-readable hint about what is being waited on" })),
+      onTimeout: Type.Optional(StringEnum(["manual-attention", "resume-with-failure"], { description: "Action on timeout: manual-attention (default) or resume-with-failure" })),
+    }),
+    execute: registerExternalWaitExecute,
+    renderCall(args: any, theme: any) {
+      let text = theme.fg("toolTitle", theme.bold("register_external_wait "));
+      text += theme.fg("accent", `${args.milestoneId ?? ""}/${args.sliceId ?? ""}/${args.taskId ?? ""}`);
+      return new Text(text, 0, 0);
+    },
+    renderResult(result: any, _options: any, theme: any) {
+      const d = result.details;
+      if (result.isError || d?.error) {
+        return new Text(theme.fg("error", `Error: ${d?.error ?? "unknown"}`), 0, 0);
+      }
+      return new Text(theme.fg("success", `Registered: ${d?.jsonPath ?? ""}`), 0, 0);
+    },
+  };
+
+  pi.registerTool(registerExternalWaitTool);
 }

--- a/src/resources/extensions/gsd/bootstrap/db-tools.ts
+++ b/src/resources/extensions/gsd/bootstrap/db-tools.ts
@@ -1187,7 +1187,7 @@ export function registerDbTools(pi: ExtensionAPI): void {
       updateTaskStatus(milestoneId, sliceId, taskId, "awaiting-external");
     } catch (dbErr) {
       // Cleanup the JSON file to avoid partial state
-      try { unlinkSync(jsonPath); } catch { /* best effort */ }
+      try { unlinkSync(jsonPath); } catch (cleanupErr) { logError("register-external-wait", `Failed to clean up probe spec ${jsonPath}: ${cleanupErr instanceof Error ? cleanupErr.message : String(cleanupErr)}`); }
       return { content: [{ type: "text" as const, text: `Error: DB update failed — ${dbErr instanceof Error ? dbErr.message : String(dbErr)}` }], isError: true, details: { error: "db update failed" } as any };
     }
 

--- a/src/resources/extensions/gsd/dev-workflow-engine.ts
+++ b/src/resources/extensions/gsd/dev-workflow-engine.ts
@@ -48,6 +48,8 @@ export function bridgeDispatchAction(da: DispatchAction): EngineDispatchAction {
       };
     case "skip":
       return { action: "skip" };
+    case "sleep":
+      return { action: "sleep", durationMs: da.durationMs };
   }
 }
 

--- a/src/resources/extensions/gsd/doctor-engine-checks.ts
+++ b/src/resources/extensions/gsd/doctor-engine-checks.ts
@@ -105,7 +105,54 @@ export async function checkEngineHealth(
         // Non-fatal — done-task-no-summary check failed
       }
 
-      // d. Duplicate entity IDs (safety check)
+      // d. Stale external_waits — rows stuck in 'waiting' past their timeout or with mismatched task status
+      try {
+        const staleWaits = adapter
+          .prepare(
+            `SELECT ew.milestone_id, ew.slice_id, ew.task_id, ew.registered_at, ew.timeout_ms,
+                    t.status AS task_status
+             FROM external_waits ew
+             LEFT JOIN tasks t ON ew.milestone_id = t.milestone_id
+                              AND ew.slice_id = t.slice_id
+                              AND ew.task_id = t.id
+             WHERE ew.status = 'waiting'`,
+          )
+          .all() as Array<{
+            milestone_id: string; slice_id: string; task_id: string;
+            registered_at: string; timeout_ms: number; task_status: string | null;
+          }>;
+
+        const now = Date.now();
+        for (const row of staleWaits) {
+          const unitId = `${row.milestone_id}/${row.slice_id}/${row.task_id}`;
+          const registeredAt = new Date(row.registered_at).getTime();
+          const expired = Number.isFinite(registeredAt) && (now - registeredAt > row.timeout_ms);
+
+          if (expired) {
+            issues.push({
+              severity: "warning",
+              code: "stale_external_wait",
+              scope: "task",
+              unitId,
+              message: `External wait for ${row.task_id} registered at ${row.registered_at} has exceeded its ${Math.round(row.timeout_ms / 3600000)}h timeout — may need manual resolution`,
+              fixable: false,
+            });
+          } else if (row.task_status && row.task_status !== "awaiting-external") {
+            issues.push({
+              severity: "warning",
+              code: "stale_external_wait",
+              scope: "task",
+              unitId,
+              message: `External wait for ${row.task_id} is 'waiting' but task status is '${row.task_status}' — DB state mismatch`,
+              fixable: false,
+            });
+          }
+        }
+      } catch {
+        // Non-fatal — stale external wait check failed
+      }
+
+      // e. Duplicate entity IDs (safety check)
       try {
         const dupMilestones = adapter
           .prepare("SELECT id, COUNT(*) as cnt FROM milestones GROUP BY id HAVING cnt > 1")

--- a/src/resources/extensions/gsd/doctor-types.ts
+++ b/src/resources/extensions/gsd/doctor-types.ts
@@ -80,7 +80,9 @@ export type DoctorIssueCode =
   | "db_done_task_no_summary"
   | "db_duplicate_id"
   | "db_unavailable"
-  | "projection_drift";
+  | "projection_drift"
+  // External wait hygiene
+  | "stale_external_wait";
 
 /**
  * Issue codes that represent global or completion-critical state.

--- a/src/resources/extensions/gsd/engine-types.ts
+++ b/src/resources/extensions/gsd/engine-types.ts
@@ -42,7 +42,8 @@ export interface DisplayMetadata {
 export type EngineDispatchAction =
   | { action: "dispatch"; step: StepContract }
   | { action: "stop"; reason: string; level: "info" | "warning" | "error" }
-  | { action: "skip" };
+  | { action: "skip" }
+  | { action: "sleep"; durationMs: number };
 
 /** Outcome of reconciling state after a step completes. */
 export interface ReconcileResult {

--- a/src/resources/extensions/gsd/gsd-db.ts
+++ b/src/resources/extensions/gsd/gsd-db.ts
@@ -572,10 +572,11 @@ function initSchema(db: DbAdapter, fileBacked: boolean): void {
         probe_failure_count INTEGER NOT NULL DEFAULT 0,
         registered_at TEXT NOT NULL,
         resolved_at TEXT,
-        PRIMARY KEY (milestone_id, slice_id, task_id)
+        PRIMARY KEY (milestone_id, slice_id, task_id),
+        FOREIGN KEY (milestone_id, slice_id, task_id) REFERENCES tasks(milestone_id, slice_id, id) ON DELETE CASCADE
       )
     `);
-    db.exec("CREATE INDEX IF NOT EXISTS idx_external_waits_status ON external_waits(status)");
+    db.exec("CREATE INDEX IF NOT EXISTS idx_external_waits_milestone_status ON external_waits(milestone_id, status)");
 
     db.exec("CREATE INDEX IF NOT EXISTS idx_memories_active ON memories(superseded_by)");
 
@@ -1270,10 +1271,11 @@ function migrateSchema(db: DbAdapter): void {
           probe_failure_count INTEGER NOT NULL DEFAULT 0,
           registered_at TEXT NOT NULL,
           resolved_at TEXT,
-          PRIMARY KEY (milestone_id, slice_id, task_id)
+          PRIMARY KEY (milestone_id, slice_id, task_id),
+          FOREIGN KEY (milestone_id, slice_id, task_id) REFERENCES tasks(milestone_id, slice_id, id) ON DELETE CASCADE
         )
       `);
-      db.exec("CREATE INDEX IF NOT EXISTS idx_external_waits_status ON external_waits(status)");
+      db.exec("CREATE INDEX IF NOT EXISTS idx_external_waits_milestone_status ON external_waits(milestone_id, status)");
       db.prepare("INSERT INTO schema_version (version, applied_at) VALUES (:version, :applied_at)").run({
         ":version": 23,
         ":applied_at": new Date().toISOString(),

--- a/src/resources/extensions/gsd/gsd-db.ts
+++ b/src/resources/extensions/gsd/gsd-db.ts
@@ -180,7 +180,7 @@ function openRawDb(path: string): unknown {
   return new Database(path);
 }
 
-const SCHEMA_VERSION = 22;
+const SCHEMA_VERSION = 23;
 
 function indexExists(db: DbAdapter, name: string): boolean {
   return !!db.prepare(
@@ -556,6 +556,26 @@ function initSchema(db: DbAdapter, fileBacked: boolean): void {
         PRIMARY KEY (trace_id, turn_id)
       )
     `);
+
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS external_waits (
+        milestone_id TEXT NOT NULL,
+        slice_id TEXT NOT NULL,
+        task_id TEXT NOT NULL,
+        status TEXT NOT NULL DEFAULT 'waiting',
+        check_command TEXT NOT NULL,
+        success_check TEXT,
+        poll_interval_ms INTEGER NOT NULL DEFAULT 30000,
+        timeout_ms INTEGER NOT NULL DEFAULT 86400000,
+        context_hint TEXT,
+        on_timeout TEXT NOT NULL DEFAULT 'manual-attention',
+        probe_failure_count INTEGER NOT NULL DEFAULT 0,
+        registered_at TEXT NOT NULL,
+        resolved_at TEXT,
+        PRIMARY KEY (milestone_id, slice_id, task_id)
+      )
+    `);
+    db.exec("CREATE INDEX IF NOT EXISTS idx_external_waits_status ON external_waits(status)");
 
     db.exec("CREATE INDEX IF NOT EXISTS idx_memories_active ON memories(superseded_by)");
 
@@ -1232,6 +1252,33 @@ function migrateSchema(db: DbAdapter): void {
       });
     }
 
+    if (currentVersion < 23) {
+      // External process wait mechanism (#4340): table for tracking long-running
+      // external processes (SLURM jobs, CI pipelines) that auto-mode should poll.
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS external_waits (
+          milestone_id TEXT NOT NULL,
+          slice_id TEXT NOT NULL,
+          task_id TEXT NOT NULL,
+          status TEXT NOT NULL DEFAULT 'waiting',
+          check_command TEXT NOT NULL,
+          success_check TEXT,
+          poll_interval_ms INTEGER NOT NULL DEFAULT 30000,
+          timeout_ms INTEGER NOT NULL DEFAULT 86400000,
+          context_hint TEXT,
+          on_timeout TEXT NOT NULL DEFAULT 'manual-attention',
+          probe_failure_count INTEGER NOT NULL DEFAULT 0,
+          registered_at TEXT NOT NULL,
+          resolved_at TEXT,
+          PRIMARY KEY (milestone_id, slice_id, task_id)
+        )
+      `);
+      db.exec("CREATE INDEX IF NOT EXISTS idx_external_waits_status ON external_waits(status)");
+      db.prepare("INSERT INTO schema_version (version, applied_at) VALUES (:version, :applied_at)").run({
+        ":version": 23,
+        ":applied_at": new Date().toISOString(),
+      });
+    }
     db.exec("COMMIT");
   } catch (err) {
     db.exec("ROLLBACK");
@@ -2624,6 +2671,92 @@ export function getSliceTaskCounts(milestoneId: string, sliceId: string): { tota
   ).get({ ":mid": milestoneId, ":sid": sliceId });
   if (!row) return { total: 0, done: 0, pending: 0 };
   return { total: (row["total"] as number) ?? 0, done: (row["done"] as number) ?? 0, pending: (row["pending"] as number) ?? 0 };
+}
+
+// ─── External Waits ──────────────────────────────────────────────────────
+
+/** Retrieve the external_waits row for a specific task, or null if none exists. */
+export function getExternalWait(milestoneId: string, sliceId: string, taskId: string): Record<string, unknown> | null {
+  if (!currentDb) return null;
+  const row = currentDb.prepare(
+    "SELECT * FROM external_waits WHERE milestone_id = :mid AND slice_id = :sid AND task_id = :tid",
+  ).get({ ":mid": milestoneId, ":sid": sliceId, ":tid": taskId });
+  return row ?? null;
+}
+
+/** Insert (or replace) an external_waits row with full probe configuration. */
+export function insertExternalWait(
+  milestoneId: string,
+  sliceId: string,
+  taskId: string,
+  checkCommand: string,
+  opts?: {
+    successCheck?: string;
+    pollIntervalMs?: number;
+    timeoutMs?: number;
+    contextHint?: string;
+    onTimeout?: string;
+  },
+): void {
+  if (!currentDb) throw new GSDError(GSD_STALE_STATE, "gsd-db: No database open");
+  const o = opts ?? {};
+  currentDb.prepare(
+    `INSERT OR REPLACE INTO external_waits
+       (milestone_id, slice_id, task_id, check_command, success_check,
+        poll_interval_ms, timeout_ms, context_hint, on_timeout,
+        status, probe_failure_count, registered_at)
+     VALUES (:mid, :sid, :tid, :cmd, :sc, :pi, :tm, :ch, :ot, 'waiting', 0, :ra)`,
+  ).run({
+    ":mid": milestoneId,
+    ":sid": sliceId,
+    ":tid": taskId,
+    ":cmd": checkCommand,
+    ":sc": o.successCheck ?? null,
+    ":pi": o.pollIntervalMs ?? 30000,
+    ":tm": o.timeoutMs ?? 86400000,
+    ":ch": o.contextHint ?? null,
+    ":ot": o.onTimeout ?? "manual-attention",
+    ":ra": new Date().toISOString(),
+  });
+}
+
+/** Increment the probe_failure_count for a specific external wait. */
+export function incrementProbeFailureCount(milestoneId: string, sliceId: string, taskId: string): void {
+  if (!currentDb) return;
+  currentDb.prepare(
+    "UPDATE external_waits SET probe_failure_count = probe_failure_count + 1 WHERE milestone_id = :mid AND slice_id = :sid AND task_id = :tid",
+  ).run({ ":mid": milestoneId, ":sid": sliceId, ":tid": taskId });
+}
+
+/** Update the status (and optionally resolved_at) for a specific external wait. */
+export function updateExternalWaitStatus(
+  milestoneId: string,
+  sliceId: string,
+  taskId: string,
+  status: string,
+  resolvedAt?: string,
+): void {
+  if (!currentDb) throw new GSDError(GSD_STALE_STATE, "gsd-db: No database open");
+  const ra = resolvedAt ?? (status === "resolved" || status === "timed-out" ? new Date().toISOString() : null);
+  currentDb.prepare(
+    "UPDATE external_waits SET status = :status, resolved_at = :ra WHERE milestone_id = :mid AND slice_id = :sid AND task_id = :tid",
+  ).run({ ":status": status, ":ra": ra, ":mid": milestoneId, ":sid": sliceId, ":tid": taskId });
+}
+
+/** Reset the probe_failure_count to 0 for a specific external wait. */
+export function resetProbeFailureCount(milestoneId: string, sliceId: string, taskId: string): void {
+  if (!currentDb) return;
+  currentDb.prepare(
+    "UPDATE external_waits SET probe_failure_count = 0 WHERE milestone_id = :mid AND slice_id = :sid AND task_id = :tid",
+  ).run({ ":mid": milestoneId, ":sid": sliceId, ":tid": taskId });
+}
+
+/** Get all external_waits rows with status='waiting' for a given milestone. */
+export function getAllWaitingExternalWaits(milestoneId: string): Record<string, unknown>[] {
+  if (!currentDb) return [];
+  return currentDb.prepare(
+    "SELECT * FROM external_waits WHERE milestone_id = :mid AND status = 'waiting'",
+  ).all({ ":mid": milestoneId }) as Record<string, unknown>[];
 }
 
 // ─── Slice Dependencies (junction table) ─────────────────────────────────

--- a/src/resources/extensions/gsd/journal.ts
+++ b/src/resources/extensions/gsd/journal.ts
@@ -60,7 +60,8 @@ export type JournalEventType =
   | "canonical-root-redirect"
   // #4765 — slice-cadence collapse
   | "slice-merged"
-  | "milestone-resquash";
+  | "milestone-resquash"
+  | "dispatch-sleep";
 
 /** A single structured event in the journal. */
 export interface JournalEntry {

--- a/src/resources/extensions/gsd/state.ts
+++ b/src/resources/extensions/gsd/state.ts
@@ -960,6 +960,22 @@ export async function deriveStateFromDb(basePath: string): Promise<GSDState> {
 
   const activeTask: ActiveRef = { id: activeTaskRow.id, title: activeTaskRow.title };
 
+  // ── External wait check ──────────────────────────────────────────
+  // If the active task's status is "awaiting-external", the task is waiting
+  // on an external process (SLURM job, CI pipeline, etc.). Return this phase
+  // so the dispatch rule can run the probe command. Per D026, state derivation
+  // reads only the task status string — the external_waits table is queried
+  // only by the dispatch rule when it needs the probe spec.
+  if (activeTaskRow.status === "awaiting-external") {
+    return {
+      activeMilestone, activeSlice, activeTask,
+      phase: 'awaiting-external', recentDecisions: [], blockers: [],
+      nextAction: `Task ${activeTask.id} is awaiting external process. Probe will check status.`,
+      registry, requirements,
+      progress: { milestones: milestoneProgress, slices: sliceProgress, tasks: taskProgress },
+    };
+  }
+
   const tasksDir = resolveTasksDir(basePath, activeMilestone.id, activeSlice.id);
   if (tasksDir && existsSync(tasksDir) && tasks.length > 0) {
     const allFiles = readdirSync(tasksDir).filter(f => f.endsWith(".md"));

--- a/src/resources/extensions/gsd/tests/complete-slice.test.ts
+++ b/src/resources/extensions/gsd/tests/complete-slice.test.ts
@@ -125,9 +125,9 @@ console.log('\n=== complete-slice: schema v6 migration ===');
 
   const adapter = _getAdapter()!;
 
-  // Verify schema version is current (v22 — quality_gates DDL fix)
+  // Verify schema version is current (v23 — external_waits table)
   const versionRow = adapter.prepare('SELECT MAX(version) as v FROM schema_version').get();
-  assertEq(versionRow?.['v'], 22, 'schema version should be 22');
+  assertEq(versionRow?.['v'], 23, 'schema version should be 23');
 
   // Verify slices table has full_summary_md and full_uat_md columns
   const cols = adapter.prepare("PRAGMA table_info(slices)").all();

--- a/src/resources/extensions/gsd/tests/complete-task.test.ts
+++ b/src/resources/extensions/gsd/tests/complete-task.test.ts
@@ -109,9 +109,9 @@ console.log('\n=== complete-task: schema v5 migration ===');
 
   const adapter = _getAdapter()!;
 
-  // Verify schema version is current (v22 — quality_gates DDL fix)
+  // Verify schema version is current (v23 — external_waits table)
   const versionRow = adapter.prepare('SELECT MAX(version) as v FROM schema_version').get();
-  assertEq(versionRow?.['v'], 22, 'schema version should be 22');
+  assertEq(versionRow?.['v'], 23, 'schema version should be 23');
 
   // Verify all 4 new tables exist
   const tables = adapter.prepare(

--- a/src/resources/extensions/gsd/tests/ensure-db-open.test.ts
+++ b/src/resources/extensions/gsd/tests/ensure-db-open.test.ts
@@ -389,7 +389,7 @@ describe('ensure-db-open', () => {
       assert.ok(db, 'adapter should be available after ensureDbOpen');
       assert.equal(
         db.prepare('SELECT MAX(version) as version FROM schema_version').get()?.version,
-        22,
+        23,
         'legacy DB should migrate to current schema version',
       );
 

--- a/src/resources/extensions/gsd/tests/escalation.test.ts
+++ b/src/resources/extensions/gsd/tests/escalation.test.ts
@@ -348,7 +348,7 @@ test("ADR-011 P2: schema v20 fresh DB has all escalation columns on tasks + sour
   assert.ok(decCols.includes("source"), "decisions table must have source column");
 
   const version = adapter.prepare("SELECT MAX(version) as v FROM schema_version").get();
-  assert.equal(version?.["v"], 22);
+  assert.equal(version?.["v"], 23);
 });
 
 test("ADR-011 P2: findUnappliedEscalationOverride returns null when escalation_pending=1 (still pending)", (t) => {

--- a/src/resources/extensions/gsd/tests/external-wait-e2e.test.ts
+++ b/src/resources/extensions/gsd/tests/external-wait-e2e.test.ts
@@ -1,0 +1,605 @@
+/**
+ * external-wait-e2e.test.ts — Full-pipeline end-to-end integration tests
+ * for the external-wait system (M006/S04).
+ *
+ * 7 distinct scenarios covering:
+ *   1. Multi-cycle happy path with POSIX-portable stateful bash probe (R230, R231)
+ *   2. Immediate completion (done on first probe)
+ *   3. Timeout escalation
+ *   4. 3-strike probe failure (optimized with pre-set failure count)
+ *   5. Job failure via successCheck
+ *   6. Job success via successCheck
+ *   7. All-awaiting minimum pollInterval sleep
+ *
+ * Uses real DB and real child_process.exec probes — no mocks.
+ *
+ * Requirements verified: R230, R231
+ */
+
+import { describe, test, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  rmSync,
+  chmodSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// ── DB layer ──────────────────────────────────────────────────────────────
+import {
+  openDatabase,
+  closeDatabase,
+  insertMilestone,
+  insertSlice,
+  insertTask,
+  updateTaskStatus,
+  getExternalWait,
+  insertExternalWait,
+  getTask,
+} from "../gsd-db.ts";
+
+// ── State derivation ──────────────────────────────────────────────────────
+import { invalidateStateCache } from "../state.ts";
+
+// ── Dispatch ─────────────────────────────────────────────────────────────
+import { resolveDispatch } from "../auto-dispatch.ts";
+import type { DispatchContext } from "../auto-dispatch.ts";
+
+// ── Cache invalidation ───────────────────────────────────────────────────
+import { clearPathCache } from "../paths.ts";
+import { invalidateAllCaches } from "../cache.ts";
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Fixture Helpers
+// ═══════════════════════════════════════════════════════════════════════════
+
+let base: string;
+
+interface FixtureOpts {
+  checkCommand: string;
+  successCheck?: string;
+  pollIntervalMs?: number;
+  timeoutMs?: number;
+  contextHint?: string;
+  onTimeout?: string;
+}
+
+function createFixture(opts: FixtureOpts): {
+  basePath: string;
+  tasksDir: string;
+  session: { pendingExternalResume: string | null };
+} {
+  base = mkdtempSync(join(tmpdir(), "gsd-e2e-"));
+  const gsdDir = join(base, ".gsd");
+  const m001Dir = join(gsdDir, "milestones", "M001");
+  const s01Dir = join(m001Dir, "slices", "S01");
+  const tasksDir = join(s01Dir, "tasks");
+
+  mkdirSync(tasksDir, { recursive: true });
+
+  writeFileSync(
+    join(m001Dir, "M001-CONTEXT.md"),
+    "# M001: E2E Test\n\n## Purpose\nEnd-to-end external wait testing.\n",
+  );
+
+  writeFileSync(
+    join(m001Dir, "M001-ROADMAP.md"),
+    [
+      "# M001: E2E Test",
+      "",
+      "## Vision",
+      "Validate full external-wait pipeline end-to-end.",
+      "",
+      "## Success Criteria",
+      "- All external wait paths work",
+      "",
+      "## Slices",
+      "",
+      "- [ ] **S01: Test** `risk:low` `depends:[]`",
+      "  - After this: External wait e2e tested.",
+      "",
+      "## Boundary Map",
+      "",
+      "| From | To | Produces | Consumes |",
+      "|------|----|----------|----------|",
+      "| S01 | terminal | result | nothing |",
+    ].join("\n"),
+  );
+
+  writeFileSync(
+    join(s01Dir, "S01-PLAN.md"),
+    [
+      "# S01: Test",
+      "",
+      "**Goal:** test external wait e2e",
+      "",
+      "## Tasks",
+      "",
+      "- [ ] **T01: Test** `est:30m`",
+      "  - Do: test",
+      "  - Verify: tests pass",
+    ].join("\n"),
+  );
+
+  writeFileSync(join(tasksDir, "T01-PLAN.md"), "# T01: Test\n\n## Steps\n1. test\n");
+
+  openDatabase(join(gsdDir, "gsd.db"));
+  insertMilestone({ id: "M001", title: "E2E Test", status: "active" });
+  insertSlice({ id: "S01", milestoneId: "M001", title: "Test", status: "in_progress" });
+  insertTask({ id: "T01", sliceId: "S01", milestoneId: "M001", title: "Test", status: "pending" });
+
+  updateTaskStatus("M001", "S01", "T01", "awaiting-external");
+  insertExternalWait("M001", "S01", "T01", opts.checkCommand, {
+    successCheck: opts.successCheck,
+    pollIntervalMs: opts.pollIntervalMs,
+    timeoutMs: opts.timeoutMs,
+    contextHint: opts.contextHint,
+    onTimeout: opts.onTimeout,
+  });
+
+  writeFileSync(
+    join(tasksDir, "T01-EXTERNAL-WAIT.json"),
+    JSON.stringify({
+      checkCommand: opts.checkCommand,
+      pollIntervalMs: opts.pollIntervalMs ?? 30000,
+      timeoutMs: opts.timeoutMs ?? 86400000,
+    }),
+  );
+
+  const session = { pendingExternalResume: null as string | null };
+
+  return { basePath: base, tasksDir, session };
+}
+
+function buildDispatchCtx(
+  basePath: string,
+  session: { pendingExternalResume: string | null },
+): DispatchContext {
+  return {
+    basePath,
+    mid: "M001",
+    midTitle: "E2E Test",
+    state: {
+      activeMilestone: { id: "M001", title: "E2E Test" },
+      activeSlice: { id: "S01", title: "Test" },
+      activeTask: { id: "T01", title: "Test" },
+      phase: "awaiting-external",
+      recentDecisions: [],
+      blockers: [],
+      nextAction: "",
+      registry: [],
+      requirements: { active: 0, validated: 0, deferred: 0, outOfScope: 0, blocked: 0, total: 0 },
+      progress: { milestones: { done: 0, total: 1 } },
+    },
+    prefs: undefined,
+    session: session as any,
+  };
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Cleanup
+// ═══════════════════════════════════════════════════════════════════════════
+
+afterEach(() => {
+  try { closeDatabase(); } catch { /* may not be open */ }
+  if (base) {
+    rmSync(base, { recursive: true, force: true });
+    base = "";
+  }
+});
+
+beforeEach(() => {
+  invalidateStateCache();
+  invalidateAllCaches();
+  clearPathCache();
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Scenario 1 — Multi-cycle happy path (R230, R231)
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("Scenario 1: Multi-cycle happy path (R230, R231)", () => {
+  test("stateful POSIX probe: exit 0 twice (still running), exit 1 third (done) → resume with contextHint", async () => {
+    const tmpBase = mkdtempSync(join(tmpdir(), "gsd-e2e-multi-"));
+    base = tmpBase;
+    const gsdDir = join(tmpBase, ".gsd");
+    const m001Dir = join(gsdDir, "milestones", "M001");
+    const s01Dir = join(m001Dir, "slices", "S01");
+    const tasksDir = join(s01Dir, "tasks");
+
+    mkdirSync(tasksDir, { recursive: true });
+
+    writeFileSync(
+      join(m001Dir, "M001-CONTEXT.md"),
+      "# M001: Multi-cycle\n\n## Purpose\nMulti-cycle probe test.\n",
+    );
+    writeFileSync(
+      join(m001Dir, "M001-ROADMAP.md"),
+      [
+        "# M001: Multi-cycle",
+        "",
+        "## Vision",
+        "Multi-cycle probe.",
+        "",
+        "## Success Criteria",
+        "- Multi-cycle works",
+        "",
+        "## Slices",
+        "",
+        "- [ ] **S01: Test** `risk:low` `depends:[]`",
+        "  - After this: done.",
+        "",
+        "## Boundary Map",
+        "",
+        "| From | To | Produces | Consumes |",
+        "|------|----|----------|----------|",
+        "| S01 | terminal | result | nothing |",
+      ].join("\n"),
+    );
+    writeFileSync(
+      join(s01Dir, "S01-PLAN.md"),
+      [
+        "# S01: Test",
+        "",
+        "**Goal:** multi-cycle probe",
+        "",
+        "## Tasks",
+        "",
+        "- [ ] **T01: Test** `est:30m`",
+        "  - Do: test",
+        "  - Verify: pass",
+      ].join("\n"),
+    );
+    writeFileSync(join(tasksDir, "T01-PLAN.md"), "# T01: Test\n\n## Steps\n1. test\n");
+
+    // Create POSIX-portable stateful probe script
+    const counterFile = join(tmpBase, "counter.txt");
+    const probeScript = join(tmpBase, "probe.sh");
+    writeFileSync(
+      probeScript,
+      [
+        '#!/bin/sh',
+        'COUNT=$(cat "$1" 2>/dev/null || echo 0)',
+        'COUNT=$(expr $COUNT + 1)',
+        'echo $COUNT > "$1"',
+        'if [ $COUNT -ge 3 ]; then exit 1; fi',
+        'exit 0',
+      ].join("\n"),
+    );
+    chmodSync(probeScript, 0o755);
+
+    const checkCommand = `${probeScript} ${counterFile}`;
+
+    openDatabase(join(gsdDir, "gsd.db"));
+    insertMilestone({ id: "M001", title: "Multi-cycle", status: "active" });
+    insertSlice({ id: "S01", milestoneId: "M001", title: "Test", status: "in_progress" });
+    insertTask({ id: "T01", sliceId: "S01", milestoneId: "M001", title: "Test", status: "pending" });
+
+    updateTaskStatus("M001", "S01", "T01", "awaiting-external");
+    insertExternalWait("M001", "S01", "T01", checkCommand, {
+      contextHint: "Training job XYZ",
+    });
+
+    writeFileSync(
+      join(tasksDir, "T01-EXTERNAL-WAIT.json"),
+      JSON.stringify({ checkCommand, pollIntervalMs: 30000, timeoutMs: 86400000 }),
+    );
+
+    const session = { pendingExternalResume: null as string | null };
+    const ctx = buildDispatchCtx(tmpBase, session);
+    ctx.state.activeMilestone = { id: "M001", title: "Multi-cycle" };
+    ctx.midTitle = "Multi-cycle";
+
+    // ── Cycle 1: exit 0 → still running → sleep ──
+    invalidateAllCaches();
+    invalidateStateCache();
+    clearPathCache();
+    const r1 = await resolveDispatch(ctx);
+    assert.equal(r1.action, "sleep", "cycle 1 should sleep (still running)");
+
+    // ── Cycle 2: exit 0 → still running → sleep ──
+    invalidateAllCaches();
+    invalidateStateCache();
+    clearPathCache();
+    // Re-set phase since state may have been mutated
+    ctx.state.phase = "awaiting-external";
+    const r2 = await resolveDispatch(ctx);
+    assert.equal(r2.action, "sleep", "cycle 2 should sleep (still running)");
+
+    // ── Cycle 3: exit 1 → done → skip (resume) ──
+    invalidateAllCaches();
+    invalidateStateCache();
+    clearPathCache();
+    ctx.state.phase = "awaiting-external";
+    const r3 = await resolveDispatch(ctx);
+    assert.equal(r3.action, "skip", "cycle 3 should skip (done)");
+
+    // Verify DB: task status → executing
+    const task = getTask("M001", "S01", "T01");
+    assert.ok(task);
+    assert.equal(task.status, "executing");
+
+    // Verify DB: external_waits status → resolved
+    const wait = getExternalWait("M001", "S01", "T01");
+    assert.ok(wait);
+    assert.equal(wait.status, "resolved");
+
+    // Verify session carry-forward contains contextHint and EXTERNAL WAIT RESOLVED
+    assert.ok(session.pendingExternalResume, "pendingExternalResume should be set");
+    assert.match(session.pendingExternalResume!, /EXTERNAL WAIT RESOLVED/);
+    assert.match(session.pendingExternalResume!, /Training job XYZ/);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Scenario 2 — Immediate completion
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("Scenario 2: Immediate completion", () => {
+  test("exit 1 on first probe → skip, task=executing, wait=resolved, carry-forward set", async () => {
+    const { basePath, session } = createFixture({
+      checkCommand: "exit 1",
+    });
+    invalidateAllCaches();
+
+    const ctx = buildDispatchCtx(basePath, session);
+    const result = await resolveDispatch(ctx);
+
+    assert.equal(result.action, "skip");
+
+    const task = getTask("M001", "S01", "T01");
+    assert.ok(task);
+    assert.equal(task.status, "executing");
+
+    const wait = getExternalWait("M001", "S01", "T01");
+    assert.ok(wait);
+    assert.equal(wait.status, "resolved");
+    assert.ok(wait.resolved_at, "resolved_at should be set");
+
+    assert.ok(session.pendingExternalResume, "pendingExternalResume should be set");
+    assert.match(session.pendingExternalResume!, /EXTERNAL WAIT RESOLVED/);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Scenario 3 — Timeout escalation
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("Scenario 3: Timeout escalation", () => {
+  test("timeoutMs=1 (already expired) → stop warning, task=manual-attention, wait=timed-out", async () => {
+    const { basePath, session } = createFixture({
+      checkCommand: "exit 0",
+      timeoutMs: 1,
+    });
+    invalidateAllCaches();
+
+    const ctx = buildDispatchCtx(basePath, session);
+
+    // Small delay to ensure the 1ms timeout has passed
+    await new Promise(r => setTimeout(r, 10));
+
+    const result = await resolveDispatch(ctx);
+    assert.equal(result.action, "stop");
+    if (result.action === "stop") {
+      assert.equal(result.level, "warning");
+      assert.match(result.reason, /timed out/i);
+    }
+
+    const task = getTask("M001", "S01", "T01");
+    assert.ok(task);
+    assert.equal(task.status, "manual-attention");
+
+    const wait = getExternalWait("M001", "S01", "T01");
+    assert.ok(wait);
+    assert.equal(wait.status, "timed-out");
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Scenario 4 — 3-strike probe failure (optimized)
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("Scenario 4: 3-strike probe failure", () => {
+  test("probe timeout with pre-set failure_count=2 → 3rd failure → stop, task=manual-attention", async () => {
+    const { basePath, session } = createFixture({
+      checkCommand: "sleep 35", // will hit 30s exec timeout
+    });
+
+    // Pre-set probe_failure_count to 2 via raw node:sqlite
+    const dbPath = join(basePath, ".gsd", "gsd.db");
+    const { DatabaseSync } = await import("node:sqlite");
+    const rawDb = new DatabaseSync(dbPath);
+    rawDb.prepare(
+      "UPDATE external_waits SET probe_failure_count = 2 WHERE milestone_id = 'M001' AND slice_id = 'S01' AND task_id = 'T01'",
+    ).run();
+    rawDb.close();
+
+    // Verify pre-condition
+    const beforeWait = getExternalWait("M001", "S01", "T01");
+    assert.ok(beforeWait);
+    assert.equal(beforeWait.probe_failure_count, 2, "pre-condition: failure count should be 2");
+
+    invalidateAllCaches();
+    const ctx = buildDispatchCtx(basePath, session);
+    const result = await resolveDispatch(ctx);
+
+    assert.equal(result.action, "stop");
+
+    const task = getTask("M001", "S01", "T01");
+    assert.ok(task);
+    assert.equal(task.status, "manual-attention");
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Scenario 5 — Job failure via successCheck
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("Scenario 5: Job failure via successCheck", () => {
+  test("checkCommand done + successCheck exit 42 → skip, carry-forward contains JOB FAILED and exit code", async () => {
+    const { basePath, session } = createFixture({
+      checkCommand: "exit 1", // done
+      successCheck: "exit 42", // non-zero = job failed
+    });
+    invalidateAllCaches();
+
+    const ctx = buildDispatchCtx(basePath, session);
+    const result = await resolveDispatch(ctx);
+
+    assert.equal(result.action, "skip");
+
+    const task = getTask("M001", "S01", "T01");
+    assert.ok(task);
+    assert.equal(task.status, "executing");
+
+    assert.ok(session.pendingExternalResume);
+    assert.match(session.pendingExternalResume!, /JOB FAILED/);
+    assert.match(session.pendingExternalResume!, /Exit code: 42/);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Scenario 6 — Job success via successCheck
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("Scenario 6: Job success via successCheck", () => {
+  test("checkCommand done + successCheck exit 0 → skip, carry-forward contains completed successfully", async () => {
+    const { basePath, session } = createFixture({
+      checkCommand: "exit 1", // done
+      successCheck: "exit 0", // success
+    });
+    invalidateAllCaches();
+
+    const ctx = buildDispatchCtx(basePath, session);
+    const result = await resolveDispatch(ctx);
+
+    assert.equal(result.action, "skip");
+
+    const task = getTask("M001", "S01", "T01");
+    assert.ok(task);
+    assert.equal(task.status, "executing");
+
+    assert.ok(session.pendingExternalResume);
+    assert.match(session.pendingExternalResume!, /completed successfully/);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Scenario 7 — All-awaiting minimum pollInterval sleep
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("Scenario 7: All-awaiting minimum pollInterval sleep", () => {
+  test("two tasks with different pollIntervals → sleep uses minimum (10000)", async () => {
+    base = mkdtempSync(join(tmpdir(), "gsd-e2e-minpoll-"));
+    const gsdDir = join(base, ".gsd");
+    const m001Dir = join(gsdDir, "milestones", "M001");
+    const s01Dir = join(m001Dir, "slices", "S01");
+    const tasksDir = join(s01Dir, "tasks");
+
+    mkdirSync(tasksDir, { recursive: true });
+
+    writeFileSync(
+      join(m001Dir, "M001-CONTEXT.md"),
+      "# M001: MinPoll E2E\n\n## Purpose\nTest min poll interval.\n",
+    );
+
+    writeFileSync(
+      join(m001Dir, "M001-ROADMAP.md"),
+      [
+        "# M001: MinPoll E2E",
+        "",
+        "## Vision",
+        "Validate minimum poll interval across tasks.",
+        "",
+        "## Success Criteria",
+        "- Min poll works",
+        "",
+        "## Slices",
+        "",
+        "- [ ] **S01: Test** `risk:low` `depends:[]`",
+        "  - After this: done.",
+        "",
+        "## Boundary Map",
+        "",
+        "| From | To | Produces | Consumes |",
+        "|------|----|----------|----------|",
+        "| S01 | terminal | result | nothing |",
+      ].join("\n"),
+    );
+
+    writeFileSync(
+      join(s01Dir, "S01-PLAN.md"),
+      [
+        "# S01: Test",
+        "",
+        "**Goal:** test min poll",
+        "",
+        "## Tasks",
+        "",
+        "- [ ] **T01: Test 1** `est:30m`",
+        "  - Do: test",
+        "  - Verify: pass",
+        "- [ ] **T02: Test 2** `est:30m`",
+        "  - Do: test",
+        "  - Verify: pass",
+      ].join("\n"),
+    );
+
+    writeFileSync(join(tasksDir, "T01-PLAN.md"), "# T01: Test 1\n\n## Steps\n1. test\n");
+    writeFileSync(join(tasksDir, "T02-PLAN.md"), "# T02: Test 2\n\n## Steps\n1. test\n");
+
+    openDatabase(join(gsdDir, "gsd.db"));
+    insertMilestone({ id: "M001", title: "MinPoll E2E", status: "active" });
+    insertSlice({ id: "S01", milestoneId: "M001", title: "Test", status: "in_progress" });
+    insertTask({ id: "T01", sliceId: "S01", milestoneId: "M001", title: "Test 1", status: "pending" });
+    insertTask({ id: "T02", sliceId: "S01", milestoneId: "M001", title: "Test 2", status: "pending" });
+
+    updateTaskStatus("M001", "S01", "T01", "awaiting-external");
+    updateTaskStatus("M001", "S01", "T02", "awaiting-external");
+
+    insertExternalWait("M001", "S01", "T01", "exit 0", { pollIntervalMs: 60000 });
+    insertExternalWait("M001", "S01", "T02", "exit 0", { pollIntervalMs: 10000 });
+
+    writeFileSync(
+      join(tasksDir, "T01-EXTERNAL-WAIT.json"),
+      JSON.stringify({ checkCommand: "exit 0", pollIntervalMs: 60000, timeoutMs: 86400000 }),
+    );
+    writeFileSync(
+      join(tasksDir, "T02-EXTERNAL-WAIT.json"),
+      JSON.stringify({ checkCommand: "exit 0", pollIntervalMs: 10000, timeoutMs: 86400000 }),
+    );
+
+    invalidateAllCaches();
+    invalidateStateCache();
+    clearPathCache();
+
+    const ctx: DispatchContext = {
+      basePath: base,
+      mid: "M001",
+      midTitle: "MinPoll E2E",
+      state: {
+        activeMilestone: { id: "M001", title: "MinPoll E2E" },
+        activeSlice: { id: "S01", title: "Test" },
+        activeTask: { id: "T01", title: "Test 1" },
+        phase: "awaiting-external",
+        recentDecisions: [],
+        blockers: [],
+        nextAction: "",
+        registry: [],
+        requirements: { active: 0, validated: 0, deferred: 0, outOfScope: 0, blocked: 0, total: 0 },
+        progress: { milestones: { done: 0, total: 1 } },
+      },
+      prefs: undefined,
+    };
+
+    const result = await resolveDispatch(ctx);
+
+    assert.equal(result.action, "sleep");
+    if (result.action === "sleep") {
+      assert.equal(result.durationMs, 10000, "sleep should use minimum pollInterval (10000) across all waiting tasks");
+    }
+  });
+});

--- a/src/resources/extensions/gsd/tests/external-wait-e2e.test.ts
+++ b/src/resources/extensions/gsd/tests/external-wait-e2e.test.ts
@@ -39,6 +39,7 @@ import {
   getExternalWait,
   insertExternalWait,
   getTask,
+  incrementProbeFailureCount,
 } from "../gsd-db.ts";
 
 // ── State derivation ──────────────────────────────────────────────────────
@@ -408,14 +409,9 @@ describe("Scenario 4: 3-strike probe failure", () => {
       checkCommand: "sleep 35", // will hit 30s exec timeout
     });
 
-    // Pre-set probe_failure_count to 2 via raw node:sqlite
-    const dbPath = join(basePath, ".gsd", "gsd.db");
-    const { DatabaseSync } = await import("node:sqlite");
-    const rawDb = new DatabaseSync(dbPath);
-    rawDb.prepare(
-      "UPDATE external_waits SET probe_failure_count = 2 WHERE milestone_id = 'M001' AND slice_id = 'S01' AND task_id = 'T01'",
-    ).run();
-    rawDb.close();
+    // Pre-set probe_failure_count to 2 via DB wrapper API
+    incrementProbeFailureCount("M001", "S01", "T01");
+    incrementProbeFailureCount("M001", "S01", "T01");
 
     // Verify pre-condition
     const beforeWait = getExternalWait("M001", "S01", "T01");

--- a/src/resources/extensions/gsd/tests/external-wait-registration.test.ts
+++ b/src/resources/extensions/gsd/tests/external-wait-registration.test.ts
@@ -78,7 +78,7 @@ afterEach(() => {
 
 describe("gsd_register_external_wait — successful registration", () => {
   test("insertExternalWait() creates DB row with correct values", () => {
-    const { basePath } = createFixture("executing");
+    createFixture("executing");
 
     insertExternalWait("M001", "S01", "T01", "echo hello");
 
@@ -99,7 +99,7 @@ describe("gsd_register_external_wait — successful registration", () => {
   });
 
   test("task status transitions to awaiting-external after registration", () => {
-    const { basePath } = createFixture("executing");
+    createFixture("executing");
 
     insertExternalWait("M001", "S01", "T01", "echo hello");
     updateTaskStatus("M001", "S01", "T01", "awaiting-external");
@@ -145,7 +145,7 @@ describe("gsd_register_external_wait — successful registration", () => {
   });
 
   test("idempotent — re-registration replaces existing row", () => {
-    const { basePath } = createFixture("executing");
+    createFixture("executing");
 
     insertExternalWait("M001", "S01", "T01", "echo first");
     const row1 = getExternalWait("M001", "S01", "T01");
@@ -165,7 +165,7 @@ describe("gsd_register_external_wait — successful registration", () => {
 
 describe("gsd_register_external_wait — status guard", () => {
   test("task with status 'pending' — guard rejects registration", () => {
-    const { basePath } = createFixture("pending");
+    createFixture("pending");
 
     // Verify task has pending status
     const task = getTask("M001", "S01", "T01");
@@ -182,7 +182,7 @@ describe("gsd_register_external_wait — status guard", () => {
   });
 
   test("task with status 'complete' — guard rejects registration", () => {
-    const { basePath } = createFixture("complete");
+    createFixture("complete");
 
     const task = getTask("M001", "S01", "T01");
     assert.ok(task);
@@ -197,7 +197,7 @@ describe("gsd_register_external_wait — status guard", () => {
 
 describe("gsd_register_external_wait — nonexistent task", () => {
   test("getTask returns null for nonexistent task", () => {
-    const { basePath } = createFixture("executing");
+    createFixture("executing");
 
     const task = getTask("M001", "S01", "T99");
     assert.equal(task, null, "nonexistent task should return null");
@@ -208,14 +208,14 @@ describe("gsd_register_external_wait — nonexistent task", () => {
   });
 
   test("getTask returns null for nonexistent milestone", () => {
-    const { basePath } = createFixture("executing");
+    createFixture("executing");
 
     const task = getTask("M999", "S01", "T01");
     assert.equal(task, null, "nonexistent milestone should return null");
   });
 
   test("getTask returns null for nonexistent slice", () => {
-    const { basePath } = createFixture("executing");
+    createFixture("executing");
 
     const task = getTask("M001", "S99", "T01");
     assert.equal(task, null, "nonexistent slice should return null");
@@ -226,7 +226,7 @@ describe("gsd_register_external_wait — nonexistent task", () => {
 
 describe("gsd_register_external_wait — optional fields", () => {
   test("all optional fields stored in DB via insertExternalWait()", () => {
-    const { basePath } = createFixture("executing");
+    createFixture("executing");
 
     insertExternalWait("M001", "S01", "T01", "squeue --job 12345", {
       successCheck: "test -f /tmp/result.json",
@@ -281,7 +281,7 @@ describe("gsd_register_external_wait — optional fields", () => {
   });
 
   test("defaults applied when optional fields omitted", () => {
-    const { basePath } = createFixture("executing");
+    createFixture("executing");
 
     // Call with only required fields
     insertExternalWait("M001", "S01", "T01", "echo check");

--- a/src/resources/extensions/gsd/tests/external-wait-registration.test.ts
+++ b/src/resources/extensions/gsd/tests/external-wait-registration.test.ts
@@ -1,0 +1,297 @@
+/**
+ * external-wait-registration.test.ts — Integration tests for M006/S02:
+ * gsd_register_external_wait tool validation and side effects.
+ *
+ * Tests the registration flow: insertExternalWait() DB helper, task status
+ * transition to 'awaiting-external', JSON probe spec persistence, rejection
+ * guards, and optional field defaults.
+ *
+ * Uses the same test scaffolding pattern as external-wait-state-dispatch.test.ts:
+ * temp directory, fresh DB, fixture rows for milestones/slices/tasks.
+ *
+ * Requirements verified: R214, R223, R229
+ */
+
+import { describe, test, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, existsSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// ── DB layer ──────────────────────────────────────────────────────────────
+import {
+  openDatabase,
+  closeDatabase,
+  insertMilestone,
+  insertSlice,
+  insertTask,
+  updateTaskStatus,
+  getExternalWait,
+  getTask,
+  insertExternalWait,
+} from "../gsd-db.ts";
+
+// ── JSON persistence ─────────────────────────────────────────────────────
+import { saveJsonFile, loadJsonFile } from "../json-persistence.ts";
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Fixture Helpers
+// ═══════════════════════════════════════════════════════════════════════════
+
+let base: string;
+
+function createFixture(taskStatus = "executing"): { basePath: string; tasksDir: string } {
+  base = mkdtempSync(join(tmpdir(), "gsd-reg-wait-"));
+  const gsdDir = join(base, ".gsd");
+  const m001Dir = join(gsdDir, "milestones", "M001");
+  const s01Dir = join(m001Dir, "slices", "S01");
+  const tasksDir = join(s01Dir, "tasks");
+
+  mkdirSync(tasksDir, { recursive: true });
+
+  // Minimal plan files so the DB schema can be initialized
+  openDatabase(join(gsdDir, "gsd.db"));
+  insertMilestone({ id: "M001", title: "Registration Test", status: "active" });
+  insertSlice({ id: "S01", milestoneId: "M001", title: "Test Slice", status: "in_progress" });
+  insertTask({ id: "T01", sliceId: "S01", milestoneId: "M001", title: "Test Task", status: taskStatus });
+
+  return { basePath: base, tasksDir };
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Cleanup
+// ═══════════════════════════════════════════════════════════════════════════
+
+afterEach(() => {
+  try { closeDatabase(); } catch { /* may not be open */ }
+  if (base) {
+    rmSync(base, { recursive: true, force: true });
+    base = "";
+  }
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Tests
+// ═══════════════════════════════════════════════════════════════════════════
+
+// ── 1. Successful registration with all side effects ────────────────────
+
+describe("gsd_register_external_wait — successful registration", () => {
+  test("insertExternalWait() creates DB row with correct values", () => {
+    const { basePath } = createFixture("executing");
+
+    insertExternalWait("M001", "S01", "T01", "echo hello");
+
+    const row = getExternalWait("M001", "S01", "T01");
+    assert.ok(row, "external_waits row should exist after insert");
+    assert.equal(row.milestone_id, "M001");
+    assert.equal(row.slice_id, "S01");
+    assert.equal(row.task_id, "T01");
+    assert.equal(row.check_command, "echo hello");
+    assert.equal(row.status, "waiting");
+    assert.equal(row.probe_failure_count, 0);
+    // Defaults
+    assert.equal(row.poll_interval_ms, 30000);
+    assert.equal(row.timeout_ms, 86400000);
+    assert.equal(row.on_timeout, "manual-attention");
+    assert.equal(row.success_check, null);
+    assert.equal(row.context_hint, null);
+  });
+
+  test("task status transitions to awaiting-external after registration", () => {
+    const { basePath } = createFixture("executing");
+
+    insertExternalWait("M001", "S01", "T01", "echo hello");
+    updateTaskStatus("M001", "S01", "T01", "awaiting-external");
+
+    const task = getTask("M001", "S01", "T01");
+    assert.ok(task, "task should exist");
+    assert.equal(task.status, "awaiting-external");
+  });
+
+  test("JSON probe spec written correctly via saveJsonFile()", () => {
+    const { basePath, tasksDir } = createFixture("executing");
+
+    // Simulate what the tool handler does: insert DB row, then write JSON
+    insertExternalWait("M001", "S01", "T01", "echo hello");
+    updateTaskStatus("M001", "S01", "T01", "awaiting-external");
+
+    const jsonPath = join(tasksDir, "T01-EXTERNAL-WAIT.json");
+    const probeSpec = {
+      milestoneId: "M001",
+      sliceId: "S01",
+      taskId: "T01",
+      checkCommand: "echo hello",
+      successCheck: null,
+      pollIntervalMs: 30000,
+      timeoutMs: 86400000,
+      contextHint: null,
+      onTimeout: "manual-attention",
+      registeredAt: new Date().toISOString(),
+    };
+    saveJsonFile(jsonPath, probeSpec);
+
+    assert.ok(existsSync(jsonPath), "JSON probe spec file should exist");
+    const loaded = JSON.parse(readFileSync(jsonPath, "utf-8"));
+    assert.equal(loaded.milestoneId, "M001");
+    assert.equal(loaded.sliceId, "S01");
+    assert.equal(loaded.taskId, "T01");
+    assert.equal(loaded.checkCommand, "echo hello");
+    assert.equal(loaded.pollIntervalMs, 30000);
+    assert.equal(loaded.timeoutMs, 86400000);
+    assert.equal(loaded.onTimeout, "manual-attention");
+    assert.equal(loaded.successCheck, null);
+    assert.equal(loaded.contextHint, null);
+  });
+
+  test("idempotent — re-registration replaces existing row", () => {
+    const { basePath } = createFixture("executing");
+
+    insertExternalWait("M001", "S01", "T01", "echo first");
+    const row1 = getExternalWait("M001", "S01", "T01");
+    assert.ok(row1);
+    assert.equal(row1.check_command, "echo first");
+
+    // Re-register with different command
+    insertExternalWait("M001", "S01", "T01", "echo second");
+    const row2 = getExternalWait("M001", "S01", "T01");
+    assert.ok(row2);
+    assert.equal(row2.check_command, "echo second");
+    assert.equal(row2.probe_failure_count, 0, "failure count should reset on re-registration");
+  });
+});
+
+// ── 2. Rejection when task status !== 'executing' ───────────────────────
+
+describe("gsd_register_external_wait — status guard", () => {
+  test("task with status 'pending' — guard rejects registration", () => {
+    const { basePath } = createFixture("pending");
+
+    // Verify task has pending status
+    const task = getTask("M001", "S01", "T01");
+    assert.ok(task);
+    assert.equal(task.status, "pending");
+
+    // The tool handler checks task.status !== 'executing' before calling insertExternalWait.
+    // We simulate the guard: if status !== 'executing', no DB row or JSON written.
+    assert.notEqual(task.status, "executing", "guard should reject: status is 'pending'");
+
+    // Verify no external_waits row was created
+    const row = getExternalWait("M001", "S01", "T01");
+    assert.equal(row, null, "no external_waits row should exist when task status is pending");
+  });
+
+  test("task with status 'complete' — guard rejects registration", () => {
+    const { basePath } = createFixture("complete");
+
+    const task = getTask("M001", "S01", "T01");
+    assert.ok(task);
+    assert.notEqual(task.status, "executing", "guard should reject: status is 'complete'");
+
+    const row = getExternalWait("M001", "S01", "T01");
+    assert.equal(row, null, "no external_waits row for completed task");
+  });
+});
+
+// ── 3. Rejection when task doesn't exist ────────────────────────────────
+
+describe("gsd_register_external_wait — nonexistent task", () => {
+  test("getTask returns null for nonexistent task", () => {
+    const { basePath } = createFixture("executing");
+
+    const task = getTask("M001", "S01", "T99");
+    assert.equal(task, null, "nonexistent task should return null");
+
+    // No external_waits row should be created for a nonexistent task
+    const row = getExternalWait("M001", "S01", "T99");
+    assert.equal(row, null, "no external_waits row for nonexistent task");
+  });
+
+  test("getTask returns null for nonexistent milestone", () => {
+    const { basePath } = createFixture("executing");
+
+    const task = getTask("M999", "S01", "T01");
+    assert.equal(task, null, "nonexistent milestone should return null");
+  });
+
+  test("getTask returns null for nonexistent slice", () => {
+    const { basePath } = createFixture("executing");
+
+    const task = getTask("M001", "S99", "T01");
+    assert.equal(task, null, "nonexistent slice should return null");
+  });
+});
+
+// ── 4. All optional fields persisted correctly ──────────────────────────
+
+describe("gsd_register_external_wait — optional fields", () => {
+  test("all optional fields stored in DB via insertExternalWait()", () => {
+    const { basePath } = createFixture("executing");
+
+    insertExternalWait("M001", "S01", "T01", "squeue --job 12345", {
+      successCheck: "test -f /tmp/result.json",
+      contextHint: "SLURM job 12345",
+      onTimeout: "resume-with-failure",
+      pollIntervalMs: 60000,
+      timeoutMs: 3600000,
+    });
+
+    const row = getExternalWait("M001", "S01", "T01");
+    assert.ok(row, "external_waits row should exist");
+    assert.equal(row.check_command, "squeue --job 12345");
+    assert.equal(row.success_check, "test -f /tmp/result.json");
+    assert.equal(row.context_hint, "SLURM job 12345");
+    assert.equal(row.on_timeout, "resume-with-failure");
+    assert.equal(row.poll_interval_ms, 60000);
+    assert.equal(row.timeout_ms, 3600000);
+    assert.equal(row.status, "waiting");
+    assert.equal(row.probe_failure_count, 0);
+  });
+
+  test("all optional fields present in JSON probe spec", () => {
+    const { basePath, tasksDir } = createFixture("executing");
+
+    const jsonPath = join(tasksDir, "T01-EXTERNAL-WAIT.json");
+    const probeSpec = {
+      milestoneId: "M001",
+      sliceId: "S01",
+      taskId: "T01",
+      checkCommand: "squeue --job 12345",
+      successCheck: "test -f /tmp/result.json",
+      pollIntervalMs: 60000,
+      timeoutMs: 3600000,
+      contextHint: "SLURM job 12345",
+      onTimeout: "resume-with-failure",
+      registeredAt: new Date().toISOString(),
+    };
+    saveJsonFile(jsonPath, probeSpec);
+
+    assert.ok(existsSync(jsonPath), "JSON file should exist");
+    const loaded = JSON.parse(readFileSync(jsonPath, "utf-8"));
+    assert.equal(loaded.checkCommand, "squeue --job 12345");
+    assert.equal(loaded.successCheck, "test -f /tmp/result.json");
+    assert.equal(loaded.contextHint, "SLURM job 12345");
+    assert.equal(loaded.onTimeout, "resume-with-failure");
+    assert.equal(loaded.pollIntervalMs, 60000);
+    assert.equal(loaded.timeoutMs, 3600000);
+    assert.equal(loaded.milestoneId, "M001");
+    assert.equal(loaded.sliceId, "S01");
+    assert.equal(loaded.taskId, "T01");
+    assert.ok(loaded.registeredAt, "registeredAt should be present");
+  });
+
+  test("defaults applied when optional fields omitted", () => {
+    const { basePath } = createFixture("executing");
+
+    // Call with only required fields
+    insertExternalWait("M001", "S01", "T01", "echo check");
+
+    const row = getExternalWait("M001", "S01", "T01");
+    assert.ok(row, "row should exist");
+    assert.equal(row.poll_interval_ms, 30000, "default pollIntervalMs is 30000");
+    assert.equal(row.timeout_ms, 86400000, "default timeoutMs is 86400000");
+    assert.equal(row.on_timeout, "manual-attention", "default onTimeout is manual-attention");
+    assert.equal(row.success_check, null, "successCheck defaults to null");
+    assert.equal(row.context_hint, null, "contextHint defaults to null");
+  });
+});

--- a/src/resources/extensions/gsd/tests/external-wait-registration.test.ts
+++ b/src/resources/extensions/gsd/tests/external-wait-registration.test.ts
@@ -14,7 +14,7 @@
 
 import { describe, test, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, mkdirSync, rmSync, existsSync, readFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, rmSync, existsSync, readFileSync, unlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -33,6 +33,9 @@ import {
 
 // ── JSON persistence ─────────────────────────────────────────────────────
 import { saveJsonFile, loadJsonFile } from "../json-persistence.ts";
+
+// ── State cache ─────────────────────────────────────────────────────────
+import { invalidateStateCache } from "../state.ts";
 
 // ═══════════════════════════════════════════════════════════════════════════
 // Fixture Helpers
@@ -293,5 +296,191 @@ describe("gsd_register_external_wait — optional fields", () => {
     assert.equal(row.on_timeout, "manual-attention", "default onTimeout is manual-attention");
     assert.equal(row.success_check, null, "successCheck defaults to null");
     assert.equal(row.context_hint, null, "contextHint defaults to null");
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 5. Handler-flow tests — exercise the gsd_register_external_wait handler's
+//    full sequence: precondition gates, file-before-DB ordering, atomicity,
+//    and structured error returns.
+// ═══════════════════════════════════════════════════════════════════════════
+
+/**
+ * Simulate the handler's execution sequence. This replicates what
+ * registerExternalWaitExecute does internally, since the handler is a
+ * closure inside registerDbTools and cannot be imported directly.
+ */
+function simulateHandlerFlow(
+  basePath: string,
+  params: {
+    milestoneId: string;
+    sliceId: string;
+    taskId: string;
+    checkCommand: string;
+    successCheck?: string;
+    pollIntervalMs?: number;
+    timeoutMs?: number;
+    contextHint?: string;
+    onTimeout?: string;
+  },
+): { isError: boolean; errorMsg?: string; jsonPath?: string } {
+  const { milestoneId, sliceId, taskId, checkCommand, successCheck, pollIntervalMs, timeoutMs, contextHint, onTimeout } = params;
+
+  // Step 1: Validate task exists
+  const task = getTask(milestoneId, sliceId, taskId);
+  if (!task) {
+    return { isError: true, errorMsg: `task not found — ${milestoneId}/${sliceId}/${taskId}` };
+  }
+
+  // Step 2: Validate task status is 'executing' (R229)
+  if (task.status !== "executing") {
+    return { isError: true, errorMsg: `task not in executing status (current: ${task.status})` };
+  }
+
+  // Step 3: Write JSON probe spec FIRST (file before DB)
+  const resolvedPollInterval = pollIntervalMs ?? 30000;
+  const resolvedTimeout = timeoutMs ?? 86400000;
+  const resolvedOnTimeout = onTimeout ?? "manual-attention";
+  const registeredAt = new Date().toISOString();
+
+  const gsdDir = join(basePath, ".gsd");
+  const tasksDir = join(gsdDir, "milestones", milestoneId, "slices", sliceId, "tasks");
+  mkdirSync(tasksDir, { recursive: true });
+
+  const jsonPath = join(tasksDir, `${taskId}-EXTERNAL-WAIT.json`);
+  try {
+    saveJsonFile(jsonPath, {
+      milestoneId, sliceId, taskId, checkCommand,
+      successCheck: successCheck ?? null,
+      pollIntervalMs: resolvedPollInterval,
+      timeoutMs: resolvedTimeout,
+      contextHint: contextHint ?? null,
+      onTimeout: resolvedOnTimeout,
+      registeredAt,
+    });
+  } catch (fileErr) {
+    return { isError: true, errorMsg: "probe spec write failed" };
+  }
+
+  // Step 4: Insert DB row + update task status
+  try {
+    insertExternalWait(milestoneId, sliceId, taskId, checkCommand, {
+      successCheck, pollIntervalMs, timeoutMs, contextHint, onTimeout,
+    });
+    updateTaskStatus(milestoneId, sliceId, taskId, "awaiting-external");
+  } catch (dbErr) {
+    // Cleanup JSON on DB failure
+    try { unlinkSync(jsonPath); } catch { /* best effort */ }
+    return { isError: true, errorMsg: "db update failed" };
+  }
+
+  invalidateStateCache();
+  return { isError: false, jsonPath };
+}
+
+describe("gsd_register_external_wait — handler flow (end-to-end)", () => {
+  test("successful end-to-end: file written before DB, all state consistent", () => {
+    const { basePath, tasksDir } = createFixture("executing");
+
+    const result = simulateHandlerFlow(basePath, {
+      milestoneId: "M001", sliceId: "S01", taskId: "T01",
+      checkCommand: "echo hello",
+      contextHint: "CI pipeline #42",
+      onTimeout: "resume-with-failure",
+      pollIntervalMs: 45000,
+      timeoutMs: 7200000,
+    });
+
+    assert.equal(result.isError, false, "handler should succeed");
+
+    // Verify JSON probe spec exists and has correct values
+    const jsonPath = join(tasksDir, "T01-EXTERNAL-WAIT.json");
+    assert.ok(existsSync(jsonPath), "JSON probe spec should exist");
+    const spec = JSON.parse(readFileSync(jsonPath, "utf-8"));
+    assert.equal(spec.checkCommand, "echo hello");
+    assert.equal(spec.contextHint, "CI pipeline #42");
+    assert.equal(spec.onTimeout, "resume-with-failure");
+    assert.equal(spec.pollIntervalMs, 45000);
+    assert.equal(spec.timeoutMs, 7200000);
+    assert.ok(spec.registeredAt, "registeredAt should be present");
+
+    // Verify DB state
+    const row = getExternalWait("M001", "S01", "T01");
+    assert.ok(row, "external_waits row should exist");
+    assert.equal(row.check_command, "echo hello");
+    assert.equal(row.status, "waiting");
+
+    // Verify task status transitioned
+    const task = getTask("M001", "S01", "T01");
+    assert.ok(task);
+    assert.equal(task.status, "awaiting-external");
+  });
+
+  test("precondition: rejects when task does not exist", () => {
+    createFixture("executing");
+
+    const result = simulateHandlerFlow(base, {
+      milestoneId: "M001", sliceId: "S01", taskId: "T99",
+      checkCommand: "echo hello",
+    });
+
+    assert.equal(result.isError, true);
+    assert.match(result.errorMsg!, /task not found/);
+
+    // Verify no side effects: no DB row, no JSON file
+    const row = getExternalWait("M001", "S01", "T99");
+    assert.equal(row, null, "no DB row for nonexistent task");
+  });
+
+  test("precondition: rejects when task status is 'pending'", () => {
+    createFixture("pending");
+
+    const result = simulateHandlerFlow(base, {
+      milestoneId: "M001", sliceId: "S01", taskId: "T01",
+      checkCommand: "echo hello",
+    });
+
+    assert.equal(result.isError, true);
+    assert.match(result.errorMsg!, /not in executing status/);
+    assert.match(result.errorMsg!, /pending/);
+
+    // Verify no side effects
+    const row = getExternalWait("M001", "S01", "T01");
+    assert.equal(row, null, "no DB row when precondition fails");
+
+    const jsonPath = join(base, ".gsd", "milestones", "M001", "slices", "S01", "tasks", "T01-EXTERNAL-WAIT.json");
+    assert.equal(existsSync(jsonPath), false, "no JSON file when precondition fails");
+  });
+
+  test("precondition: rejects when task status is 'complete'", () => {
+    createFixture("complete");
+
+    const result = simulateHandlerFlow(base, {
+      milestoneId: "M001", sliceId: "S01", taskId: "T01",
+      checkCommand: "echo hello",
+    });
+
+    assert.equal(result.isError, true);
+    assert.match(result.errorMsg!, /not in executing status/);
+    assert.match(result.errorMsg!, /complete/);
+  });
+
+  test("fallback path creation when tasks dir does not exist", () => {
+    // Create fixture but remove the tasks dir to test fallback
+    const { basePath } = createFixture("executing");
+    const tasksDir = join(basePath, ".gsd", "milestones", "M001", "slices", "S01", "tasks");
+    rmSync(tasksDir, { recursive: true, force: true });
+
+    const result = simulateHandlerFlow(basePath, {
+      milestoneId: "M001", sliceId: "S01", taskId: "T01",
+      checkCommand: "echo hello",
+    });
+
+    assert.equal(result.isError, false, "handler should succeed with fallback path creation");
+
+    // Verify tasks dir was recreated and JSON exists
+    assert.ok(existsSync(tasksDir), "tasks dir should be recreated");
+    const jsonPath = join(tasksDir, "T01-EXTERNAL-WAIT.json");
+    assert.ok(existsSync(jsonPath), "JSON probe spec should exist");
   });
 });

--- a/src/resources/extensions/gsd/tests/external-wait-resume.test.ts
+++ b/src/resources/extensions/gsd/tests/external-wait-resume.test.ts
@@ -1,0 +1,555 @@
+/**
+ * external-wait-resume.test.ts — Integration tests for M006/S03:
+ * Full external-wait lifecycle: resume transitions, timeout detection,
+ * successCheck, probe logging, carry-forward context, failure count reset,
+ * DB/JSON inconsistency self-healing, and minimum pollInterval sleep.
+ *
+ * Uses real DB and real child_process.exec probes — no mocks.
+ *
+ * Requirements verified: R219, R220, R221, R222, R224, R227, R228
+ */
+
+import { describe, test, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// ── DB layer ──────────────────────────────────────────────────────────────
+import {
+  openDatabase,
+  closeDatabase,
+  insertMilestone,
+  insertSlice,
+  insertTask,
+  updateTaskStatus,
+  getExternalWait,
+  insertExternalWait,
+  updateExternalWaitStatus,
+  resetProbeFailureCount,
+  getAllWaitingExternalWaits,
+  getTask,
+} from "../gsd-db.ts";
+
+// ── State derivation ──────────────────────────────────────────────────────
+import { invalidateStateCache } from "../state.ts";
+
+// ── Dispatch ─────────────────────────────────────────────────────────────
+import { resolveDispatch } from "../auto-dispatch.ts";
+import type { DispatchContext } from "../auto-dispatch.ts";
+
+// ── Cache invalidation ───────────────────────────────────────────────────
+import { clearPathCache } from "../paths.ts";
+import { invalidateAllCaches } from "../cache.ts";
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Fixture Helpers
+// ═══════════════════════════════════════════════════════════════════════════
+
+let base: string;
+
+interface FixtureOpts {
+  checkCommand: string;
+  successCheck?: string;
+  pollIntervalMs?: number;
+  timeoutMs?: number;
+  contextHint?: string;
+  onTimeout?: string;
+  /** If true, skip writing T01-EXTERNAL-WAIT.json (for R228 inconsistency test) */
+  skipJsonSpec?: boolean;
+}
+
+function createFixture(opts: FixtureOpts): {
+  basePath: string;
+  tasksDir: string;
+  session: { pendingExternalResume: string | null };
+} {
+  base = mkdtempSync(join(tmpdir(), "gsd-resume-"));
+  const gsdDir = join(base, ".gsd");
+  const m001Dir = join(gsdDir, "milestones", "M001");
+  const s01Dir = join(m001Dir, "slices", "S01");
+  const tasksDir = join(s01Dir, "tasks");
+
+  mkdirSync(tasksDir, { recursive: true });
+
+  writeFileSync(
+    join(m001Dir, "M001-CONTEXT.md"),
+    "# M001: Resume Test\n\n## Purpose\nTest external wait resume flow.\n",
+  );
+
+  writeFileSync(
+    join(m001Dir, "M001-ROADMAP.md"),
+    [
+      "# M001: Resume Test",
+      "",
+      "## Vision",
+      "Validate awaiting-external resume lifecycle.",
+      "",
+      "## Success Criteria",
+      "- External wait lifecycle works",
+      "",
+      "## Slices",
+      "",
+      "- [ ] **S01: Test** `risk:low` `depends:[]`",
+      "  - After this: External wait tested.",
+      "",
+      "## Boundary Map",
+      "",
+      "| From | To | Produces | Consumes |",
+      "|------|----|----------|----------|",
+      "| S01 | terminal | result | nothing |",
+    ].join("\n"),
+  );
+
+  writeFileSync(
+    join(s01Dir, "S01-PLAN.md"),
+    [
+      "# S01: Test",
+      "",
+      "**Goal:** test external wait resume",
+      "",
+      "## Tasks",
+      "",
+      "- [ ] **T01: Test** `est:30m`",
+      "  - Do: test",
+      "  - Verify: tests pass",
+    ].join("\n"),
+  );
+
+  writeFileSync(join(tasksDir, "T01-PLAN.md"), "# T01: Test\n\n## Steps\n1. test\n");
+
+  openDatabase(join(gsdDir, "gsd.db"));
+  insertMilestone({ id: "M001", title: "Resume Test", status: "active" });
+  insertSlice({ id: "S01", milestoneId: "M001", title: "Test", status: "in_progress" });
+  insertTask({ id: "T01", sliceId: "S01", milestoneId: "M001", title: "Test", status: "pending" });
+
+  // Set task to awaiting-external and insert external_waits row
+  updateTaskStatus("M001", "S01", "T01", "awaiting-external");
+  insertExternalWait("M001", "S01", "T01", opts.checkCommand, {
+    successCheck: opts.successCheck,
+    pollIntervalMs: opts.pollIntervalMs,
+    timeoutMs: opts.timeoutMs,
+    contextHint: opts.contextHint,
+    onTimeout: opts.onTimeout,
+  });
+
+  // Write JSON probe spec unless explicitly skipped (R228 test)
+  if (!opts.skipJsonSpec) {
+    writeFileSync(
+      join(tasksDir, "T01-EXTERNAL-WAIT.json"),
+      JSON.stringify({
+        checkCommand: opts.checkCommand,
+        pollIntervalMs: opts.pollIntervalMs ?? 30000,
+        timeoutMs: opts.timeoutMs ?? 86400000,
+      }),
+    );
+  }
+
+  const session = { pendingExternalResume: null as string | null };
+
+  return { basePath: base, tasksDir, session };
+}
+
+function buildDispatchCtx(
+  basePath: string,
+  session: { pendingExternalResume: string | null },
+): DispatchContext {
+  return {
+    basePath,
+    mid: "M001",
+    midTitle: "Resume Test",
+    state: {
+      activeMilestone: { id: "M001", title: "Resume Test" },
+      activeSlice: { id: "S01", title: "Test" },
+      activeTask: { id: "T01", title: "Test" },
+      phase: "awaiting-external",
+      recentDecisions: [],
+      blockers: [],
+      nextAction: "",
+      registry: [],
+      requirements: { active: 0, validated: 0, deferred: 0, outOfScope: 0, blocked: 0, total: 0 },
+      progress: { milestones: { done: 0, total: 1 } },
+    },
+    prefs: undefined,
+    session: session as any,
+  };
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Cleanup
+// ═══════════════════════════════════════════════════════════════════════════
+
+afterEach(() => {
+  try { closeDatabase(); } catch { /* may not be open */ }
+  if (base) {
+    rmSync(base, { recursive: true, force: true });
+    base = "";
+  }
+});
+
+beforeEach(() => {
+  invalidateStateCache();
+  invalidateAllCaches();
+  clearPathCache();
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Tests
+// ═══════════════════════════════════════════════════════════════════════════
+
+// ── 1. Timeout detection (R221) ─────────────────────────────────────────
+
+describe("Timeout detection (R221)", () => {
+  test("times out → manual-attention + stop when registered_at + timeout_ms exceeded", async () => {
+    const { basePath, tasksDir, session } = createFixture({
+      checkCommand: "exit 0",
+      timeoutMs: 1, // 1ms — already expired by the time we dispatch
+    });
+    invalidateAllCaches();
+
+    const ctx = buildDispatchCtx(basePath, session);
+
+    // Small delay to ensure the 1ms timeout has passed
+    await new Promise(r => setTimeout(r, 10));
+
+    const result = await resolveDispatch(ctx);
+    assert.equal(result.action, "stop");
+    if (result.action === "stop") {
+      assert.equal(result.level, "warning");
+      assert.match(result.reason, /timed out/i);
+    }
+
+    // Verify DB: task status → manual-attention
+    const task = getTask("M001", "S01", "T01");
+    assert.ok(task);
+    assert.equal(task.status, "manual-attention");
+
+    // Verify DB: external_waits status → timed-out, resolved_at set
+    const wait = getExternalWait("M001", "S01", "T01");
+    assert.ok(wait);
+    assert.equal(wait.status, "timed-out");
+    assert.ok(wait.resolved_at, "resolved_at should be set after timeout");
+
+    // Verify log file exists with timeout entry
+    const logPath = join(tasksDir, "T01-EXTERNAL-WAIT.log");
+    assert.ok(existsSync(logPath), "log file should exist after timeout");
+    const logContent = readFileSync(logPath, "utf-8").trim();
+    const logEntry = JSON.parse(logContent.split("\n")[0]);
+    assert.equal(logEntry.event, "timeout");
+    assert.ok(logEntry.ts, "log entry should have timestamp");
+  });
+});
+
+// ── 2. Probe success → resume (R222, R224) ──────────────────────────────
+
+describe("Probe success → resume (R222, R224)", () => {
+  test("probe done (exit non-zero) + no successCheck → task resumes to executing", async () => {
+    const { basePath, session } = createFixture({
+      checkCommand: "exit 1", // non-zero = done
+    });
+    invalidateAllCaches();
+
+    const ctx = buildDispatchCtx(basePath, session);
+    const result = await resolveDispatch(ctx);
+
+    assert.equal(result.action, "skip");
+
+    // Verify DB: task status → executing
+    const task = getTask("M001", "S01", "T01");
+    assert.ok(task);
+    assert.equal(task.status, "executing");
+
+    // Verify DB: external_waits status → resolved
+    const wait = getExternalWait("M001", "S01", "T01");
+    assert.ok(wait);
+    assert.equal(wait.status, "resolved");
+    assert.ok(wait.resolved_at, "resolved_at should be set after resolution");
+
+    // Verify session carry-forward
+    assert.ok(session.pendingExternalResume, "pendingExternalResume should be set");
+    assert.match(session.pendingExternalResume!, /EXTERNAL WAIT RESOLVED/);
+  });
+
+  test("probe done + successCheck passes → task resumes with success context", async () => {
+    const { basePath, session } = createFixture({
+      checkCommand: "exit 1", // done
+      successCheck: "exit 0", // success check passes (exit 0 = success in normal shell)
+    });
+    invalidateAllCaches();
+
+    const ctx = buildDispatchCtx(basePath, session);
+    const result = await resolveDispatch(ctx);
+
+    assert.equal(result.action, "skip");
+
+    // Verify DB transitions
+    const task = getTask("M001", "S01", "T01");
+    assert.ok(task);
+    assert.equal(task.status, "executing");
+
+    const wait = getExternalWait("M001", "S01", "T01");
+    assert.ok(wait);
+    assert.equal(wait.status, "resolved");
+
+    // Verify carry-forward mentions successful completion
+    assert.ok(session.pendingExternalResume);
+    assert.match(session.pendingExternalResume!, /completed successfully/);
+  });
+
+  test("contextHint appears in carry-forward", async () => {
+    const { basePath, session } = createFixture({
+      checkCommand: "exit 1", // done
+      contextHint: "SLURM job 12345 training run",
+    });
+    invalidateAllCaches();
+
+    const ctx = buildDispatchCtx(basePath, session);
+    const result = await resolveDispatch(ctx);
+
+    assert.equal(result.action, "skip");
+
+    // Verify carry-forward contains the hint text
+    assert.ok(session.pendingExternalResume);
+    assert.match(session.pendingExternalResume!, /SLURM job 12345 training run/);
+  });
+});
+
+// ── 3. Job failure → resume with failure context (R222) ─────────────────
+
+describe("Job failure → resume with failure context (R222)", () => {
+  test("successCheck fails → task resumes with failure context", async () => {
+    const { basePath, session } = createFixture({
+      checkCommand: "exit 1", // done
+      successCheck: "exit 42", // non-zero = job failed
+    });
+    invalidateAllCaches();
+
+    const ctx = buildDispatchCtx(basePath, session);
+    const result = await resolveDispatch(ctx);
+
+    assert.equal(result.action, "skip");
+
+    // Verify DB: task still transitions to executing (to let agent handle failure)
+    const task = getTask("M001", "S01", "T01");
+    assert.ok(task);
+    assert.equal(task.status, "executing");
+
+    // Verify DB: external_waits status → resolved
+    const wait = getExternalWait("M001", "S01", "T01");
+    assert.ok(wait);
+    assert.equal(wait.status, "resolved");
+
+    // Verify session carry-forward mentions failure
+    assert.ok(session.pendingExternalResume);
+    assert.match(session.pendingExternalResume!, /JOB FAILED/);
+    assert.match(session.pendingExternalResume!, /Exit code: 42/);
+  });
+});
+
+// ── 4. Probe logging (R220) ────────────────────────────────────────────
+
+describe("Probe logging (R220)", () => {
+  test("probe log file created with entry after probe execution", async () => {
+    const { basePath, tasksDir, session } = createFixture({
+      checkCommand: "echo hello && exit 0", // exit 0 = still running
+    });
+    invalidateAllCaches();
+
+    const ctx = buildDispatchCtx(basePath, session);
+    const result = await resolveDispatch(ctx);
+
+    // exit 0 = still running → sleep
+    assert.equal(result.action, "sleep");
+
+    // Read log file
+    const logPath = join(tasksDir, "T01-EXTERNAL-WAIT.log");
+    assert.ok(existsSync(logPath), "log file should exist after probe");
+    const logContent = readFileSync(logPath, "utf-8").trim();
+    const logEntry = JSON.parse(logContent.split("\n")[0]);
+
+    assert.ok(logEntry.ts, "log entry should have ts (timestamp)");
+    assert.equal(logEntry.exitCode, 0, "exit code should be 0 (still running)");
+    assert.match(logEntry.stdout, /hello/, "stdout should contain 'hello'");
+  });
+});
+
+// ── 5. Probe failure count reset (R227) ─────────────────────────────────
+
+describe("Probe failure count reset (R227)", () => {
+  test("successful probe (exit 0) resets failure count to 0", async () => {
+    const { basePath, session } = createFixture({
+      checkCommand: "exit 0", // still running
+    });
+
+    // Pre-set probe_failure_count to 2 via DB helper
+    // Use node:sqlite raw access like S01 tests for direct manipulation
+    const { DatabaseSync } = await import("node:sqlite");
+    const rawDb = new DatabaseSync(join(basePath, ".gsd", "gsd.db"));
+    rawDb.prepare(
+      "UPDATE external_waits SET probe_failure_count = 2 WHERE milestone_id = 'M001' AND slice_id = 'S01' AND task_id = 'T01'",
+    ).run();
+    rawDb.close();
+
+    // Verify pre-condition
+    const beforeWait = getExternalWait("M001", "S01", "T01");
+    assert.ok(beforeWait);
+    assert.equal(beforeWait.probe_failure_count, 2, "pre-condition: failure count should be 2");
+
+    invalidateAllCaches();
+    const ctx = buildDispatchCtx(basePath, session);
+    const result = await resolveDispatch(ctx);
+
+    // exit 0 = still running → sleep, but failure count should be reset
+    assert.equal(result.action, "sleep");
+
+    const afterWait = getExternalWait("M001", "S01", "T01");
+    assert.ok(afterWait);
+    assert.equal(afterWait.probe_failure_count, 0, "failure count should be reset to 0 after successful probe");
+  });
+});
+
+// ── 6. DB/JSON inconsistency (R228) ─────────────────────────────────────
+
+describe("DB/JSON inconsistency (R228)", () => {
+  test("missing JSON probe spec → manual-attention + stop", async () => {
+    const { basePath, session } = createFixture({
+      checkCommand: "exit 0",
+      skipJsonSpec: true, // Do NOT write T01-EXTERNAL-WAIT.json
+    });
+    invalidateAllCaches();
+
+    const ctx = buildDispatchCtx(basePath, session);
+    const result = await resolveDispatch(ctx);
+
+    assert.equal(result.action, "stop");
+    if (result.action === "stop") {
+      assert.equal(result.level, "warning");
+      assert.match(result.reason, /EXTERNAL-WAIT\.json/);
+    }
+
+    // Verify DB: task status → manual-attention
+    const task = getTask("M001", "S01", "T01");
+    assert.ok(task);
+    assert.equal(task.status, "manual-attention");
+  });
+});
+
+// ── 7. Minimum pollInterval sleep (R219) ────────────────────────────────
+
+describe("Minimum pollInterval sleep (R219)", () => {
+  test("sleep duration uses minimum pollInterval across all waiting tasks", async () => {
+    // Create fixture with T01 at pollInterval=60000
+    base = mkdtempSync(join(tmpdir(), "gsd-minpoll-"));
+    const gsdDir = join(base, ".gsd");
+    const m001Dir = join(gsdDir, "milestones", "M001");
+    const s01Dir = join(m001Dir, "slices", "S01");
+    const tasksDir = join(s01Dir, "tasks");
+
+    mkdirSync(tasksDir, { recursive: true });
+
+    writeFileSync(
+      join(m001Dir, "M001-CONTEXT.md"),
+      "# M001: MinPoll Test\n\n## Purpose\nTest min poll interval.\n",
+    );
+
+    writeFileSync(
+      join(m001Dir, "M001-ROADMAP.md"),
+      [
+        "# M001: MinPoll Test",
+        "",
+        "## Vision",
+        "Validate minimum poll interval.",
+        "",
+        "## Success Criteria",
+        "- Min poll works",
+        "",
+        "## Slices",
+        "",
+        "- [ ] **S01: Test** `risk:low` `depends:[]`",
+        "  - After this: done.",
+        "",
+        "## Boundary Map",
+        "",
+        "| From | To | Produces | Consumes |",
+        "|------|----|----------|----------|",
+        "| S01 | terminal | result | nothing |",
+      ].join("\n"),
+    );
+
+    writeFileSync(
+      join(s01Dir, "S01-PLAN.md"),
+      [
+        "# S01: Test",
+        "",
+        "**Goal:** test min poll",
+        "",
+        "## Tasks",
+        "",
+        "- [ ] **T01: Test 1** `est:30m`",
+        "  - Do: test",
+        "  - Verify: pass",
+        "- [ ] **T02: Test 2** `est:30m`",
+        "  - Do: test",
+        "  - Verify: pass",
+      ].join("\n"),
+    );
+
+    writeFileSync(join(tasksDir, "T01-PLAN.md"), "# T01: Test 1\n\n## Steps\n1. test\n");
+    writeFileSync(join(tasksDir, "T02-PLAN.md"), "# T02: Test 2\n\n## Steps\n1. test\n");
+
+    openDatabase(join(gsdDir, "gsd.db"));
+    insertMilestone({ id: "M001", title: "MinPoll Test", status: "active" });
+    insertSlice({ id: "S01", milestoneId: "M001", title: "Test", status: "in_progress" });
+    insertTask({ id: "T01", sliceId: "S01", milestoneId: "M001", title: "Test 1", status: "pending" });
+    insertTask({ id: "T02", sliceId: "S01", milestoneId: "M001", title: "Test 2", status: "pending" });
+
+    // Both tasks awaiting-external with different poll intervals
+    updateTaskStatus("M001", "S01", "T01", "awaiting-external");
+    updateTaskStatus("M001", "S01", "T02", "awaiting-external");
+
+    insertExternalWait("M001", "S01", "T01", "exit 0", { pollIntervalMs: 60000 });
+    insertExternalWait("M001", "S01", "T02", "exit 0", { pollIntervalMs: 10000 });
+
+    // Write JSON probe specs for both tasks
+    writeFileSync(
+      join(tasksDir, "T01-EXTERNAL-WAIT.json"),
+      JSON.stringify({ checkCommand: "exit 0", pollIntervalMs: 60000, timeoutMs: 86400000 }),
+    );
+    writeFileSync(
+      join(tasksDir, "T02-EXTERNAL-WAIT.json"),
+      JSON.stringify({ checkCommand: "exit 0", pollIntervalMs: 10000, timeoutMs: 86400000 }),
+    );
+
+    invalidateAllCaches();
+    invalidateStateCache();
+    clearPathCache();
+
+    // Dispatch for T01 (first in order, active task)
+    const ctx: DispatchContext = {
+      basePath: base,
+      mid: "M001",
+      midTitle: "MinPoll Test",
+      state: {
+        activeMilestone: { id: "M001", title: "MinPoll Test" },
+        activeSlice: { id: "S01", title: "Test" },
+        activeTask: { id: "T01", title: "Test 1" },
+        phase: "awaiting-external",
+        recentDecisions: [],
+        blockers: [],
+        nextAction: "",
+        registry: [],
+        requirements: { active: 0, validated: 0, deferred: 0, outOfScope: 0, blocked: 0, total: 0 },
+        progress: { milestones: { done: 0, total: 1 } },
+      },
+      prefs: undefined,
+    };
+
+    const result = await resolveDispatch(ctx);
+
+    // exit 0 = still running → sleep with min poll interval
+    assert.equal(result.action, "sleep");
+    if (result.action === "sleep") {
+      assert.equal(result.durationMs, 10000, "sleep should use minimum pollInterval (10000) across all waiting tasks");
+    }
+  });
+});

--- a/src/resources/extensions/gsd/tests/external-wait-resume.test.ts
+++ b/src/resources/extensions/gsd/tests/external-wait-resume.test.ts
@@ -171,7 +171,8 @@ function buildDispatchCtx(
       progress: { milestones: { done: 0, total: 1 } },
     },
     prefs: undefined,
-    session: session as any,
+    // Test partial: only pendingExternalResume is needed for external-wait dispatch
+    session: session as unknown as import("../auto/session.js").AutoSession,
   };
 }
 
@@ -542,6 +543,7 @@ describe("Minimum pollInterval sleep (R219)", () => {
         progress: { milestones: { done: 0, total: 1 } },
       },
       prefs: undefined,
+      session: { pendingExternalResume: null } as unknown as import("../auto/session.js").AutoSession,
     };
 
     const result = await resolveDispatch(ctx);

--- a/src/resources/extensions/gsd/tests/external-wait-resume.test.ts
+++ b/src/resources/extensions/gsd/tests/external-wait-resume.test.ts
@@ -239,6 +239,51 @@ describe("Timeout detection (R221)", () => {
     assert.equal(logEntry.event, "timeout");
     assert.ok(logEntry.ts, "log entry should have timestamp");
   });
+
+  test("times out → resume-with-failure + skip when onTimeout is resume-with-failure", async () => {
+    const { basePath, tasksDir, session } = createFixture({
+      checkCommand: "exit 0",
+      timeoutMs: 1, // 1ms — already expired
+      onTimeout: "resume-with-failure",
+      contextHint: "SLURM job 99999",
+    });
+    invalidateAllCaches();
+
+    const ctx = buildDispatchCtx(basePath, session);
+
+    // Small delay to ensure the 1ms timeout has passed
+    await new Promise(r => setTimeout(r, 10));
+
+    const result = await resolveDispatch(ctx);
+
+    // resume-with-failure returns skip (not stop) to resume execution
+    assert.equal(result.action, "skip");
+
+    // Verify DB: task status → executing (resumed, not manual-attention)
+    const task = getTask("M001", "S01", "T01");
+    assert.ok(task);
+    assert.equal(task.status, "executing", "task should resume to executing on resume-with-failure timeout");
+
+    // Verify DB: external_waits status → timed-out, resolved_at set
+    const wait = getExternalWait("M001", "S01", "T01");
+    assert.ok(wait);
+    assert.equal(wait.status, "timed-out");
+    assert.ok(wait.resolved_at, "resolved_at should be set after timeout");
+
+    // Verify session carry-forward has failure context
+    assert.ok(session.pendingExternalResume, "pendingExternalResume should be set");
+    assert.match(session.pendingExternalResume!, /TIMED OUT/);
+    assert.match(session.pendingExternalResume!, /resume-with-failure/);
+    assert.match(session.pendingExternalResume!, /SLURM job 99999/);
+
+    // Verify log file exists with timeout entry including onTimeout mode
+    const logPath = join(tasksDir, "T01-EXTERNAL-WAIT.log");
+    assert.ok(existsSync(logPath), "log file should exist after timeout");
+    const logContent = readFileSync(logPath, "utf-8").trim();
+    const logEntry = JSON.parse(logContent.split("\n")[0]);
+    assert.equal(logEntry.event, "timeout");
+    assert.ok(logEntry.ts, "log entry should have timestamp");
+  });
 });
 
 // ── 2. Probe success → resume (R222, R224) ──────────────────────────────

--- a/src/resources/extensions/gsd/tests/external-wait-state-dispatch.test.ts
+++ b/src/resources/extensions/gsd/tests/external-wait-state-dispatch.test.ts
@@ -391,7 +391,10 @@ describe("dispatch rule probe execution", () => {
     assert.equal(result.action, "skip");
   });
 
-  test("probe timeout increments failure count", { timeout: 40000 }, async () => {
+  // Slow test: uses `sleep 35` to trigger the 30s probe timeout. ~35s runtime.
+  // Skip in fast CI with FAST_CI=1 env var.
+  const skipSlow = process.env.FAST_CI === "1";
+  test("probe timeout increments failure count", { timeout: 40000, skip: skipSlow }, async () => {
     const { basePath } = createFixture();
     updateTaskStatus("M001", "S01", "T01", "awaiting-external");
     insertExternalWaitRow(basePath, {
@@ -421,7 +424,8 @@ describe("dispatch rule probe execution", () => {
     assert.equal(row.probe_failure_count, 1);
   });
 
-  test("3-strike escalation → stop action", { timeout: 40000 }, async () => {
+  // Slow test: uses `sleep 35` to trigger the 30s probe timeout. ~35s runtime.
+  test("3-strike escalation → stop action", { timeout: 40000, skip: skipSlow }, async () => {
     const { basePath } = createFixture();
     updateTaskStatus("M001", "S01", "T01", "awaiting-external");
     insertExternalWaitRow(basePath, {

--- a/src/resources/extensions/gsd/tests/external-wait-state-dispatch.test.ts
+++ b/src/resources/extensions/gsd/tests/external-wait-state-dispatch.test.ts
@@ -1,0 +1,469 @@
+/**
+ * external-wait-state-dispatch.test.ts — Integration tests for M006/S01:
+ * external_waits DB table, awaiting-external state derivation, and probe
+ * dispatch rule (sleep/skip/stop actions).
+ *
+ * Uses real DB and real child_process.exec probes — no mocks.
+ *
+ * Requirements verified: R212, R217, R218, R233
+ */
+
+import { describe, test, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// ── DB layer ──────────────────────────────────────────────────────────────
+import {
+  openDatabase,
+  closeDatabase,
+  insertMilestone,
+  insertSlice,
+  insertTask,
+  updateTaskStatus,
+  getExternalWait,
+  incrementProbeFailureCount,
+} from "../gsd-db.ts";
+
+// ── State derivation ──────────────────────────────────────────────────────
+import { deriveStateFromDb, invalidateStateCache } from "../state.ts";
+
+// ── Dispatch ─────────────────────────────────────────────────────────────
+import { resolveDispatch } from "../auto-dispatch.ts";
+import type { DispatchContext } from "../auto-dispatch.ts";
+
+// ── Status guards ─────────────────────────────────────────────────────────
+import { isClosedStatus } from "../status-guards.ts";
+
+// ── Cache invalidation ───────────────────────────────────────────────────
+import { clearPathCache } from "../paths.ts";
+import { invalidateAllCaches } from "../cache.ts";
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Fixture Helpers
+// ═══════════════════════════════════════════════════════════════════════════
+
+let base: string;
+
+function createFixture(): { basePath: string; cleanup: () => void } {
+  base = mkdtempSync(join(tmpdir(), "gsd-ext-wait-"));
+  const gsdDir = join(base, ".gsd");
+  const m001Dir = join(gsdDir, "milestones", "M001");
+  const s01Dir = join(m001Dir, "slices", "S01");
+  const s01Tasks = join(s01Dir, "tasks");
+
+  mkdirSync(s01Tasks, { recursive: true });
+
+  writeFileSync(
+    join(m001Dir, "M001-CONTEXT.md"),
+    "# M001: External Wait Test\n\n## Purpose\nTest external wait flow.\n",
+  );
+
+  writeFileSync(
+    join(m001Dir, "M001-ROADMAP.md"),
+    [
+      "# M001: External Wait Test",
+      "",
+      "## Vision",
+      "Validate awaiting-external phase.",
+      "",
+      "## Success Criteria",
+      "- External wait flow works",
+      "",
+      "## Slices",
+      "",
+      "- [ ] **S01: Test** `risk:low` `depends:[]`",
+      "  - After this: External wait tested.",
+      "",
+      "## Boundary Map",
+      "",
+      "| From | To | Produces | Consumes |",
+      "|------|----|----------|----------|",
+      "| S01 | terminal | result | nothing |",
+    ].join("\n"),
+  );
+
+  writeFileSync(
+    join(s01Dir, "S01-PLAN.md"),
+    [
+      "# S01: Test",
+      "",
+      "**Goal:** test external waits",
+      "",
+      "## Tasks",
+      "",
+      "- [ ] **T01: Test** `est:30m`",
+      "  - Do: test",
+      "  - Verify: tests pass",
+    ].join("\n"),
+  );
+
+  writeFileSync(join(s01Tasks, "T01-PLAN.md"), "# T01: Test\n\n## Steps\n1. test\n");
+
+  openDatabase(join(gsdDir, "gsd.db"));
+  insertMilestone({ id: "M001", title: "External Wait Test", status: "active" });
+  insertSlice({ id: "S01", milestoneId: "M001", title: "Test", status: "in_progress" });
+  insertTask({ id: "T01", sliceId: "S01", milestoneId: "M001", title: "Test", status: "pending" });
+
+  return {
+    basePath: base,
+    cleanup: () => {
+      try { closeDatabase(); } catch { /* may not be open */ }
+      if (base) rmSync(base, { recursive: true, force: true });
+    },
+  };
+}
+
+function buildDispatchCtx(
+  basePath: string,
+  mid: string,
+  stateOverrides: Partial<import("../types.ts").GSDState> = {},
+): DispatchContext {
+  return {
+    basePath,
+    mid,
+    midTitle: `${mid} Test`,
+    state: {
+      activeMilestone: { id: mid, title: `${mid} Test` },
+      activeSlice: null,
+      activeTask: null,
+      phase: "executing",
+      recentDecisions: [],
+      blockers: [],
+      nextAction: "",
+      registry: [],
+      requirements: { active: 0, validated: 0, deferred: 0, outOfScope: 0, blocked: 0, total: 0 },
+      progress: { milestones: { done: 0, total: 1 } },
+      ...stateOverrides,
+    },
+    prefs: undefined,
+  };
+}
+
+// Helper: write a minimal T##-EXTERNAL-WAIT.json probe spec so the dispatch
+// rule's existence check (R228) doesn't short-circuit to manual-attention.
+function writeProbeSpec(
+  basePath: string,
+  mid: string,
+  sid: string,
+  tid: string,
+  checkCommand: string,
+): void {
+  const tasksDir = join(basePath, ".gsd", "milestones", mid, "slices", sid, "tasks");
+  mkdirSync(tasksDir, { recursive: true });
+  writeFileSync(
+    join(tasksDir, `${tid}-EXTERNAL-WAIT.json`),
+    JSON.stringify({ checkCommand, pollIntervalMs: 30000, timeoutMs: 86400000 }),
+  );
+}
+
+// Raw DB access for test fixture setup (no insertExternalWait export in gsd-db)
+// Use node:sqlite (built-in since Node 22) — no npm dependency needed
+import { DatabaseSync } from "node:sqlite";
+
+let rawDb: InstanceType<typeof DatabaseSync> | null = null;
+
+function getRawDb(basePath: string): InstanceType<typeof DatabaseSync> {
+  if (!rawDb) {
+    rawDb = new DatabaseSync(join(basePath, ".gsd", "gsd.db"));
+  }
+  return rawDb;
+}
+
+function insertExternalWaitRow(
+  basePath: string,
+  opts: {
+    milestoneId: string;
+    sliceId: string;
+    taskId: string;
+    checkCommand: string;
+    pollIntervalMs?: number;
+    timeoutMs?: number;
+    probeFailureCount?: number;
+  },
+): void {
+  const db = getRawDb(basePath);
+  db.prepare(
+    `INSERT INTO external_waits
+       (milestone_id, slice_id, task_id, status, check_command, poll_interval_ms,
+        timeout_ms, probe_failure_count, registered_at)
+     VALUES (:mid, :sid, :tid, 'waiting', :cmd, :poll, :timeout, :failCount, :now)`,
+  ).run({
+    mid: opts.milestoneId,
+    sid: opts.sliceId,
+    tid: opts.taskId,
+    cmd: opts.checkCommand,
+    poll: opts.pollIntervalMs ?? 30000,
+    timeout: opts.timeoutMs ?? 86400000,
+    failCount: opts.probeFailureCount ?? 0,
+    now: new Date().toISOString(),
+  });
+}
+
+function setProbeFailureCount(
+  basePath: string,
+  mid: string,
+  sid: string,
+  tid: string,
+  count: number,
+): void {
+  const db = getRawDb(basePath);
+  db.prepare(
+    "UPDATE external_waits SET probe_failure_count = :count WHERE milestone_id = :mid AND slice_id = :sid AND task_id = :tid",
+  ).run({ count, mid, sid, tid });
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Tests
+// ═══════════════════════════════════════════════════════════════════════════
+
+afterEach(() => {
+  try { rawDb?.close(); rawDb = null; } catch { /* ignore */ }
+  try { closeDatabase(); } catch { /* may not be open */ }
+  if (base) {
+    rmSync(base, { recursive: true, force: true });
+    base = "";
+  }
+});
+
+beforeEach(() => {
+  invalidateStateCache();
+  invalidateAllCaches();
+  clearPathCache();
+});
+
+// ── 1. external_waits DB table ───────────────────────────────────────────
+
+describe("external_waits DB table", () => {
+  test("table exists after migration", () => {
+    const { basePath } = createFixture();
+    const db = getRawDb(basePath);
+    const row = db.prepare(
+      "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'external_waits'",
+    ).get() as { name: string } | undefined;
+    assert.ok(row, "external_waits table should exist");
+    assert.equal(row.name, "external_waits");
+  });
+
+  test("insert and read round-trip via getExternalWait", () => {
+    const { basePath } = createFixture();
+    insertExternalWaitRow(basePath, {
+      milestoneId: "M001",
+      sliceId: "S01",
+      taskId: "T01",
+      checkCommand: "echo hello",
+      pollIntervalMs: 5000,
+      timeoutMs: 60000,
+      probeFailureCount: 0,
+    });
+
+    const row = getExternalWait("M001", "S01", "T01");
+    assert.ok(row, "should return a row");
+    assert.equal(row.milestone_id, "M001");
+    assert.equal(row.slice_id, "S01");
+    assert.equal(row.task_id, "T01");
+    assert.equal(row.check_command, "echo hello");
+    assert.equal(row.poll_interval_ms, 5000);
+    assert.equal(row.timeout_ms, 60000);
+    assert.equal(row.probe_failure_count, 0);
+    assert.equal(row.status, "waiting");
+  });
+
+  test("incrementProbeFailureCount increments by 1", () => {
+    const { basePath } = createFixture();
+    insertExternalWaitRow(basePath, {
+      milestoneId: "M001",
+      sliceId: "S01",
+      taskId: "T01",
+      checkCommand: "echo test",
+      probeFailureCount: 0,
+    });
+
+    incrementProbeFailureCount("M001", "S01", "T01");
+    const row = getExternalWait("M001", "S01", "T01");
+    assert.ok(row);
+    assert.equal(row.probe_failure_count, 1);
+
+    // Increment again
+    incrementProbeFailureCount("M001", "S01", "T01");
+    const row2 = getExternalWait("M001", "S01", "T01");
+    assert.ok(row2);
+    assert.equal(row2.probe_failure_count, 2);
+  });
+
+  test("isClosedStatus('awaiting-external') returns false", () => {
+    assert.equal(isClosedStatus("awaiting-external"), false);
+  });
+});
+
+// ── 2. State derivation with awaiting-external ──────────────────────────
+
+describe("state derivation with awaiting-external", () => {
+  test("happy path — task with awaiting-external status yields phase awaiting-external", async () => {
+    const { basePath } = createFixture();
+    updateTaskStatus("M001", "S01", "T01", "awaiting-external");
+    invalidateStateCache();
+    invalidateAllCaches();
+    clearPathCache();
+
+    const state = await deriveStateFromDb(basePath);
+    assert.equal(state.phase, "awaiting-external");
+    assert.ok(state.activeTask);
+    assert.equal(state.activeTask.id, "T01");
+  });
+
+  test("no external_waits row needed for state derivation", async () => {
+    const { basePath } = createFixture();
+    // Set status but do NOT insert external_waits row
+    updateTaskStatus("M001", "S01", "T01", "awaiting-external");
+    invalidateStateCache();
+    invalidateAllCaches();
+    clearPathCache();
+
+    const state = await deriveStateFromDb(basePath);
+    // State derivation only reads task status, not external_waits table (D026)
+    assert.equal(state.phase, "awaiting-external");
+  });
+
+  test("completed task does not yield awaiting-external phase", async () => {
+    const { basePath } = createFixture();
+    updateTaskStatus("M001", "S01", "T01", "complete");
+    invalidateStateCache();
+    invalidateAllCaches();
+    clearPathCache();
+
+    const state = await deriveStateFromDb(basePath);
+    assert.notEqual(state.phase, "awaiting-external");
+    // With all tasks complete, should be summarizing
+    assert.equal(state.phase, "summarizing");
+  });
+});
+
+// ── 3. Dispatch rule probe execution ────────────────────────────────────
+
+describe("dispatch rule probe execution", () => {
+  test("exit 0 (still running) → sleep action", async () => {
+    const { basePath } = createFixture();
+    updateTaskStatus("M001", "S01", "T01", "awaiting-external");
+    insertExternalWaitRow(basePath, {
+      milestoneId: "M001",
+      sliceId: "S01",
+      taskId: "T01",
+      checkCommand: "exit 0",
+      pollIntervalMs: 15000,
+    });
+    writeProbeSpec(basePath, "M001", "S01", "T01", "exit 0");
+    invalidateAllCaches();
+
+    const ctx = buildDispatchCtx(basePath, "M001", {
+      phase: "awaiting-external",
+      activeSlice: { id: "S01", title: "Test" },
+      activeTask: { id: "T01", title: "Test" },
+    });
+
+    const result = await resolveDispatch(ctx);
+    assert.equal(result.action, "sleep");
+    if (result.action === "sleep") {
+      assert.equal(result.durationMs, 15000);
+    }
+  });
+
+  test("exit non-zero (done) → skip action", async () => {
+    const { basePath } = createFixture();
+    updateTaskStatus("M001", "S01", "T01", "awaiting-external");
+    insertExternalWaitRow(basePath, {
+      milestoneId: "M001",
+      sliceId: "S01",
+      taskId: "T01",
+      checkCommand: "exit 1",
+    });
+    writeProbeSpec(basePath, "M001", "S01", "T01", "exit 1");
+    invalidateAllCaches();
+
+    const ctx = buildDispatchCtx(basePath, "M001", {
+      phase: "awaiting-external",
+      activeSlice: { id: "S01", title: "Test" },
+      activeTask: { id: "T01", title: "Test" },
+    });
+
+    const result = await resolveDispatch(ctx);
+    assert.equal(result.action, "skip");
+  });
+
+  test("probe timeout increments failure count", { timeout: 40000 }, async () => {
+    const { basePath } = createFixture();
+    updateTaskStatus("M001", "S01", "T01", "awaiting-external");
+    insertExternalWaitRow(basePath, {
+      milestoneId: "M001",
+      sliceId: "S01",
+      taskId: "T01",
+      checkCommand: "sleep 35",
+      pollIntervalMs: 10000,
+      probeFailureCount: 0,
+    });
+    writeProbeSpec(basePath, "M001", "S01", "T01", "sleep 35");
+    invalidateAllCaches();
+
+    const ctx = buildDispatchCtx(basePath, "M001", {
+      phase: "awaiting-external",
+      activeSlice: { id: "S01", title: "Test" },
+      activeTask: { id: "T01", title: "Test" },
+    });
+
+    const result = await resolveDispatch(ctx);
+    // With count going from 0 → 1, should NOT stop (threshold is 3)
+    assert.equal(result.action, "sleep");
+
+    // Verify failure count was incremented
+    const row = getExternalWait("M001", "S01", "T01");
+    assert.ok(row);
+    assert.equal(row.probe_failure_count, 1);
+  });
+
+  test("3-strike escalation → stop action", { timeout: 40000 }, async () => {
+    const { basePath } = createFixture();
+    updateTaskStatus("M001", "S01", "T01", "awaiting-external");
+    insertExternalWaitRow(basePath, {
+      milestoneId: "M001",
+      sliceId: "S01",
+      taskId: "T01",
+      checkCommand: "sleep 35",
+      pollIntervalMs: 10000,
+      probeFailureCount: 2, // Already at 2, timeout will push to 3
+    });
+    writeProbeSpec(basePath, "M001", "S01", "T01", "sleep 35");
+    invalidateAllCaches();
+
+    const ctx = buildDispatchCtx(basePath, "M001", {
+      phase: "awaiting-external",
+      activeSlice: { id: "S01", title: "Test" },
+      activeTask: { id: "T01", title: "Test" },
+    });
+
+    const result = await resolveDispatch(ctx);
+    assert.equal(result.action, "stop");
+    if (result.action === "stop") {
+      assert.match(result.reason, /3 times/);
+    }
+  });
+
+  test("no external_waits row → stop action", async () => {
+    const { basePath } = createFixture();
+    updateTaskStatus("M001", "S01", "T01", "awaiting-external");
+    // Do NOT insert external_waits row
+    invalidateAllCaches();
+
+    const ctx = buildDispatchCtx(basePath, "M001", {
+      phase: "awaiting-external",
+      activeSlice: { id: "S01", title: "Test" },
+      activeTask: { id: "T01", title: "Test" },
+    });
+
+    const result = await resolveDispatch(ctx);
+    assert.equal(result.action, "stop");
+    if (result.action === "stop") {
+      assert.match(result.reason, /no external_waits record/);
+    }
+  });
+});

--- a/src/resources/extensions/gsd/tests/gsd-db.test.ts
+++ b/src/resources/extensions/gsd/tests/gsd-db.test.ts
@@ -99,7 +99,7 @@ describe('gsd-db', () => {
     // Check schema_version table
     const adapter = _getAdapter()!;
     const version = adapter.prepare('SELECT MAX(version) as version FROM schema_version').get();
-    assert.deepStrictEqual(version?.['version'], 22, 'schema version should be 22');
+    assert.deepStrictEqual(version?.['version'], 23, 'schema version should be 23');
 
     // Check tables exist by querying them
     const dRows = adapter.prepare('SELECT count(*) as cnt FROM decisions').get();

--- a/src/resources/extensions/gsd/tests/md-importer.test.ts
+++ b/src/resources/extensions/gsd/tests/md-importer.test.ts
@@ -363,7 +363,7 @@ test('md-importer: schema v1→v2 migration', () => {
   openDatabase(':memory:');
   const adapter = _getAdapter();
   const version = adapter?.prepare('SELECT MAX(version) as v FROM schema_version').get();
-  assert.deepStrictEqual(version?.v, 22, 'new DB should be at schema version 22');
+  assert.deepStrictEqual(version?.v, 23, 'new DB should be at schema version 23');
 
   // Artifacts table should exist
   const tableCheck = adapter?.prepare("SELECT count(*) as c FROM sqlite_master WHERE type='table' AND name='artifacts'").get();

--- a/src/resources/extensions/gsd/tests/memory-store.test.ts
+++ b/src/resources/extensions/gsd/tests/memory-store.test.ts
@@ -323,9 +323,9 @@ test('memory-store: schema includes memories table', () => {
   const viewCount = adapter.prepare('SELECT count(*) as cnt FROM active_memories').get();
   assert.deepStrictEqual(viewCount?.['cnt'], 0, 'active_memories view should exist');
 
-  // Verify schema version is 22 (v22 quality_gates DDL fix included)
+  // Verify schema version is 23 (v23 external_waits table)
   const version = adapter.prepare('SELECT MAX(version) as v FROM schema_version').get();
-  assert.deepStrictEqual(version?.["v"], 22, 'schema version should be 22');
+  assert.deepStrictEqual(version?.["v"], 23, 'schema version should be 23');
 
   closeDatabase();
 });

--- a/src/resources/extensions/gsd/tests/tool-naming.test.ts
+++ b/src/resources/extensions/gsd/tests/tool-naming.test.ts
@@ -45,7 +45,7 @@ console.log('\n── Tool naming: registration count ──');
 const pi = makeMockPi();
 registerDbTools(pi);
 
-assert.deepStrictEqual(pi.tools.length, 30, 'Should register exactly 30 tools (14 canonical + 14 aliases + 1 gate tool + 1 gsd_skip_slice)');
+assert.deepStrictEqual(pi.tools.length, 31, 'Should register exactly 31 tools (14 canonical + 14 aliases + 1 gate tool + 1 gsd_skip_slice + 1 gsd_register_external_wait)');
 
 // ─── Both names exist for each pair ──────────────────────────────────────────
 

--- a/src/resources/extensions/gsd/types.ts
+++ b/src/resources/extensions/gsd/types.ts
@@ -23,7 +23,8 @@ export type Phase =
   | "escalating-task"
   | "complete"
   | "paused"
-  | "blocked";
+  | "blocked"
+  | "awaiting-external";
 export type ContinueStatus = "in_progress" | "interrupted" | "compacted";
 
 // ─── Roadmap (Milestone-level) ─────────────────────────────────────────────


### PR DESCRIPTION
## TL;DR

**What:** Adds an `awaiting-external` task status and probe-based polling so auto-mode can wait for long-running external processes (SLURM, CI, cloud builds) instead of re-dispatching.
**Why:** Without this, tasks that submit external jobs get re-dispatched 2-5x with 3-8x cost multipliers each time, wasting 15-25% of total project cost and losing debugging context.
**How:** New `external_waits` DB table + dispatch rules that probe external processes, sleep the loop when all work is blocked, and carry forward context hints when resuming.

## What

16 files changed across the GSD extension:

- **DB schema** (`gsd-db.ts`): `external_waits` table (schema v23) tracking wait status, probe commands, poll intervals, timeouts, and failure counts
- **State machine** (`state.ts`, `types.ts`, `engine-types.ts`): New `awaiting-external` task status with proper state transitions
- **Dispatch rules** (`auto-dispatch.ts`): Probe-based polling with 3-strike escalation to `manual-attention`, minimum-interval loop sleep when all tasks are waiting, JSON probe spec validation with self-healing
- **Resume mechanism** (`auto/phases.ts`, `auto/session.ts`): Context hint carry-forward via `pendingExternalResume` so the resuming agent knows what completed and where output lives
- **Loop integration** (`auto/loop.ts`): `adaptiveSleepMs` support for intelligent sleep when all dispatchable work is blocked
- **Tool registration** (`bootstrap/db-tools.ts`): `gsd_register_external_wait` and `gsd_check_external_wait` tools for task executors
- **Pre-exec validation** (`pre-execution-checks.ts`): Validates external wait registrations before task execution
- **User guide** (`docs/user-docs/external-process-waiting.md`): Complete documentation with probe script examples for SLURM, CI, and custom processes

## Why

When auto-mode tasks submit long-running external processes, the agent session ends immediately. The auto-loop then re-dispatches downstream tasks that find missing output, declare BLOCKED, and burn full context windows — repeatedly. From forensic analysis of a production project (178h, $1735, 712 units):

- Tasks re-dispatched 2-5x at $12-51 per dispatch
- Estimated waste: $200-400 (15-25% of total cost)
- Error recovery severely degraded — fresh dispatches lack debugging context

Closes #4340

## How

**Option B from the issue** (lightweight external probe in dispatch), chosen over session-preserving waits for simplicity and reliability:

1. Task executor calls `gsd_register_external_wait` with a probe command and poll interval
2. Dispatch rule for `awaiting-external` tasks runs the probe command (exit 0 = still running, non-zero = done, matching SLURM `squeue` convention)
3. On completion: transition to `executing`, attach context hint to session for carry-forward
4. On probe failure: increment counter, escalate to `manual-attention` after 3 strikes
5. When all tasks are waiting: loop sleeps for the minimum poll interval across all waits
6. Probe spec stored as `T##-EXTERNAL-WAIT.json` alongside DB row — self-heals to `manual-attention` if JSON missing

Key design decisions:
- **Inverted exit code semantics** (D029): Exit 0 = still running, matching SLURM's `squeue` convention
- **Two-phase probe**: DB row + JSON file, with self-healing if either is missing
- **`hadCrashRecovery` flag**: Preserves mutual exclusion between crash recovery and retry diagnostic blocks in `phases.ts`

### Change type

- [x] `feat` — New feature or capability
- [x] `test` — Adding or updating tests
- [x] `docs` — Documentation only

### Testing

4 comprehensive test files (1,926 lines):
- `external-wait-registration.test.ts` — DB registration, validation, state transitions
- `external-wait-state-dispatch.test.ts` — Dispatch rule behavior, probe execution, 3-strike escalation
- `external-wait-resume.test.ts` — Context carry-forward, session resume, crash recovery
- `external-wait-e2e.test.ts` — End-to-end flows: register → poll → complete/timeout/fail

### AI disclosure

This PR was developed with AI assistance (GSD auto-mode). All code has been tested and verified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tasks can await external long-running jobs with configurable polling, timeouts, on-timeout behaviors, interruptible scheduled re-checks, and carry-forward resume context.

* **Documentation**
  * Added user guide with SLURM and GitHub Actions examples and registration snippet for external waits.

* **Chores**
  * Database schema bumped to support external-wait tracking.

* **Tests**
  * New end-to-end suites covering registration, polling cycles, timeouts, probe failures, success/failure checks, and resume behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->