### PR TITLE
fix(gsd): require DB status or success SUMMARY for milestone skip

### DIFF
--- a/src/resources/extensions/gsd/auto-start.ts
+++ b/src/resources/extensions/gsd/auto-start.ts
@@ -61,6 +61,7 @@ import { restoreHookState, resetHookState } from "./post-unit-hooks.js";
 import { resetProactiveHealing, setLevelChangeCallback } from "./doctor-proactive.js";
 import { snapshotSkills } from "./skill-discovery.js";
 import { isDbAvailable, getMilestone, openDatabase, getDbStatus } from "./gsd-db.js";
+import { isClosedStatus } from "./status-guards.js";
 
 import {
   debugLog,
@@ -419,15 +420,28 @@ export async function bootstrapAutoSession(
     // Invalidate caches before initial state derivation
     invalidateAllCaches();
 
-    // Clean stale runtime unit files for completed milestones (#887)
-    cleanStaleRuntimeUnits(
-      gsdRoot(base),
-      (mid) => !!resolveMilestoneFile(base, mid, "SUMMARY"),
-    );
-
     // Open the project-root DB before deriveState so DB-backed state
     // derivation (queue-order, task status) works on a cold start (#2841).
+    // Must happen before cleanStaleRuntimeUnits so the cleanup predicate can
+    // consult DB status and avoid clearing runtime units for milestones that
+    // only have a failure-path SUMMARY on disk (#4663).
     await openProjectDbIfPresent(base);
+
+    // Clean stale runtime unit files for completed milestones (#887).
+    // DB-authoritative: when DB is available, require DB status to be closed
+    // before clearing runtime units. A SUMMARY file alone is no longer
+    // trusted as proof of completion (#4663). Fall back to SUMMARY-file
+    // presence only when DB is unavailable (legacy/pre-migration).
+    cleanStaleRuntimeUnits(
+      gsdRoot(base),
+      (mid) => {
+        if (isDbAvailable()) {
+          const row = getMilestone(mid);
+          return !!row && isClosedStatus(row.status);
+        }
+        return !!resolveMilestoneFile(base, mid, "SUMMARY");
+      },
+    );
 
     // ── Orphaned milestone branch audit ──
     // Catches completed milestones whose teardown (merge + branch delete)

--- a/src/resources/extensions/gsd/dispatch-guard.ts
+++ b/src/resources/extensions/gsd/dispatch-guard.ts
@@ -3,10 +3,29 @@
 import { resolveMilestoneFile } from "./paths.js";
 import { findMilestoneIds } from "./guided-flow.js";
 import { parseUnitId } from "./unit-id.js";
-import { isDbAvailable, getMilestoneSlices } from "./gsd-db.js";
+import { isDbAvailable, getMilestoneSlices, getMilestone } from "./gsd-db.js";
 import { parseRoadmap } from "./parsers-legacy.js";
 import { isClosedStatus } from "./status-guards.js";
 import { readFileSync } from "node:fs";
+
+/**
+ * Detect failure-path milestone SUMMARY content (#4663 sibling to #4658).
+ * A failure SUMMARY must not let the dispatch guard treat an active
+ * milestone as complete. The markers mirror those produced by
+ * writeBlockerPlaceholder and the "verification FAILED" retry path.
+ *
+ * This is intentionally a minimal local detector so this fix does not
+ * depend on PR #4660's `classifyMilestoneSummaryContent`. It can migrate
+ * to the shared classifier once that lands.
+ */
+function isFailureMilestoneSummary(content: string): boolean {
+  return (
+    /(?:^|\n)\s*#\s*BLOCKER\b/i.test(content) ||
+    /auto-mode recovery failed/i.test(content) ||
+    /verification\s+failed/i.test(content) ||
+    /\bnot complete\b/i.test(content)
+  );
+}
 
 const SLICE_DISPATCH_TYPES = new Set([
   "research-slice",
@@ -47,7 +66,30 @@ export function getPriorSliceCompletionBlocker(
 
   for (const mid of milestoneIds) {
     if (resolveMilestoneFile(base, mid, "PARKED")) continue;
-    if (resolveMilestoneFile(base, mid, "SUMMARY")) continue;
+
+    // DB/SUMMARY completion check (#4663 sibling to #4658).
+    // Prior behavior treated any SUMMARY file on disk as proof of milestone
+    // completion, which is wrong when the SUMMARY is a failure-path report
+    // (verification FAILED, blocker placeholder, etc.). Resolve as follows:
+    //   1. When DB is available and status is closed → skip (authoritative).
+    //   2. When SUMMARY exists but looks like a failure/blocker report →
+    //      do not short-circuit; fall through to the slice-level check so
+    //      the guard can still block dependents of an active milestone.
+    //   3. Otherwise (SUMMARY without failure markers) → skip. Preserves
+    //      the #1716 contract where a completed milestone with unchecked
+    //      remediation slices is still treated as done.
+    const summaryPath = resolveMilestoneFile(base, mid, "SUMMARY");
+    if (isDbAvailable()) {
+      const milestoneRow = getMilestone(mid);
+      if (milestoneRow && isClosedStatus(milestoneRow.status)) continue;
+    }
+    if (summaryPath) {
+      let summaryContent: string | null = null;
+      try { summaryContent = readFileSync(summaryPath, "utf-8"); } catch { /* ignore */ }
+      if (!summaryContent || !isFailureMilestoneSummary(summaryContent)) {
+        continue;
+      }
+    }
 
     // Normalised slice list from DB or file fallback
     type NormSlice = { id: string; done: boolean; depends: string[] };

--- a/src/resources/extensions/gsd/tests/auto-start-clean-runtime-db-gated.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-start-clean-runtime-db-gated.test.ts
@@ -1,0 +1,63 @@
+// GSD-2 auto-start regression test: cleanStaleRuntimeUnits is DB-gated (#4663)
+//
+// Source-level structural check that the stale-runtime-cleanup predicate in
+// auto-start.ts consults DB status when available instead of treating a
+// SUMMARY-file on disk as proof of milestone completion. Pairs with #4658 /
+// PR #4660 fix in auto-dispatch + auto-recovery.
+
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const sourceFile = join(__dirname, "..", "auto-start.ts");
+
+describe("auto-start cleanStaleRuntimeUnits DB gating (#4663)", () => {
+  const source = readFileSync(sourceFile, "utf-8");
+
+  test("imports isClosedStatus for DB-status check", () => {
+    assert.match(
+      source,
+      /import\s*\{\s*isClosedStatus\s*\}\s*from\s*["']\.\/status-guards/,
+    );
+  });
+
+  test("cleanStaleRuntimeUnits is called after openProjectDbIfPresent", () => {
+    const openDbIdx = source.indexOf("await openProjectDbIfPresent(base)");
+    assert.ok(openDbIdx > -1, "openProjectDbIfPresent should be called in auto-start");
+    const cleanIdx = source.indexOf("cleanStaleRuntimeUnits(", openDbIdx);
+    assert.ok(
+      cleanIdx > -1,
+      "cleanStaleRuntimeUnits must run AFTER openProjectDbIfPresent so predicate can consult DB",
+    );
+  });
+
+  test("cleanStaleRuntimeUnits predicate consults DB status when available", () => {
+    const cleanIdx = source.indexOf("cleanStaleRuntimeUnits(");
+    assert.ok(cleanIdx > -1);
+    const snippet = source.slice(cleanIdx, cleanIdx + 600);
+    assert.match(
+      snippet,
+      /isDbAvailable\(\)/,
+      "predicate must branch on DB availability",
+    );
+    assert.match(
+      snippet,
+      /isClosedStatus\(/,
+      "predicate must check DB status via isClosedStatus",
+    );
+  });
+
+  test("cleanStaleRuntimeUnits predicate still falls back to SUMMARY-file when DB unavailable", () => {
+    const cleanIdx = source.indexOf("cleanStaleRuntimeUnits(");
+    assert.ok(cleanIdx > -1);
+    const snippet = source.slice(cleanIdx, cleanIdx + 600);
+    assert.match(
+      snippet,
+      /resolveMilestoneFile\(base,\s*mid,\s*["']SUMMARY["']\)/,
+      "legacy FS-fallback branch should still use SUMMARY file presence",
+    );
+  });
+});

--- a/src/resources/extensions/gsd/tests/dispatch-guard-summary-db-mismatch.test.ts
+++ b/src/resources/extensions/gsd/tests/dispatch-guard-summary-db-mismatch.test.ts
@@ -1,0 +1,77 @@
+// GSD-2 dispatch-guard regression test: SUMMARY/DB mismatch fail-closed behavior (#4663)
+//
+// Sibling bug to #4658 / PR #4660. A failure-path SUMMARY file on disk
+// must not let the cross-milestone dispatch guard treat an "active"
+// milestone as complete. DB status is authoritative when available.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { getPriorSliceCompletionBlocker } from "../dispatch-guard.ts";
+import { openDatabase, closeDatabase, insertMilestone, insertSlice } from "../gsd-db.ts";
+
+function setupRepo(): string {
+  const repo = mkdtempSync(join(tmpdir(), "gsd-dispatch-guard-4663-"));
+  mkdirSync(join(repo, ".gsd"), { recursive: true });
+  openDatabase(join(repo, ".gsd", "gsd.db"));
+  return repo;
+}
+
+function teardownRepo(repo: string): void {
+  closeDatabase();
+  rmSync(repo, { recursive: true, force: true });
+}
+
+test("#4663: dispatch guard blocks when prior milestone has failure SUMMARY but DB is still active", (t) => {
+  const repo = setupRepo();
+  t.after(() => teardownRepo(repo));
+
+  mkdirSync(join(repo, ".gsd", "milestones", "M002"), { recursive: true });
+  mkdirSync(join(repo, ".gsd", "milestones", "M003"), { recursive: true });
+
+  // M002: DB says active with a pending slice, but a failure SUMMARY exists on disk.
+  insertMilestone({ id: "M002", title: "Previous", status: "active" });
+  insertSlice({ id: "S01", milestoneId: "M002", title: "Pending", status: "pending", depends: [] });
+
+  insertMilestone({ id: "M003", title: "Current", status: "active" });
+  insertSlice({ id: "S01", milestoneId: "M003", title: "First", status: "pending", depends: [] });
+
+  writeFileSync(join(repo, ".gsd", "milestones", "M002", "M002-ROADMAP.md"), "# M002\n");
+  writeFileSync(join(repo, ".gsd", "milestones", "M003", "M003-ROADMAP.md"), "# M003\n");
+  writeFileSync(
+    join(repo, ".gsd", "milestones", "M002", "M002-SUMMARY.md"),
+    "# M002 Summary\nverification FAILED — not complete.\n",
+  );
+
+  // Before #4663: SUMMARY presence short-circuited the loop and M002 was skipped,
+  // allowing M003/S01 to dispatch. After: DB status is consulted and M002 still blocks.
+  assert.equal(
+    getPriorSliceCompletionBlocker(repo, "main", "plan-slice", "M003/S01"),
+    "Cannot dispatch plan-slice M003/S01: earlier slice M002/S01 is not complete.",
+  );
+});
+
+test("#4663: dispatch guard allows dispatch when prior milestone has SUMMARY and DB is complete", (t) => {
+  const repo = setupRepo();
+  t.after(() => teardownRepo(repo));
+
+  mkdirSync(join(repo, ".gsd", "milestones", "M002"), { recursive: true });
+  mkdirSync(join(repo, ".gsd", "milestones", "M003"), { recursive: true });
+
+  insertMilestone({ id: "M002", title: "Previous", status: "complete" });
+  insertSlice({ id: "S01", milestoneId: "M002", title: "Done", status: "complete", depends: [] });
+
+  insertMilestone({ id: "M003", title: "Current", status: "active" });
+  insertSlice({ id: "S01", milestoneId: "M003", title: "First", status: "pending", depends: [] });
+
+  writeFileSync(join(repo, ".gsd", "milestones", "M002", "M002-ROADMAP.md"), "# M002\n");
+  writeFileSync(join(repo, ".gsd", "milestones", "M003", "M003-ROADMAP.md"), "# M003\n");
+  writeFileSync(join(repo, ".gsd", "milestones", "M002", "M002-SUMMARY.md"), "# M002 Summary\nDone.\n");
+
+  assert.equal(
+    getPriorSliceCompletionBlocker(repo, "main", "plan-slice", "M003/S01"),
+    null,
+  );
+});


### PR DESCRIPTION
## Linked issue

Closes #4663

- [x] I have linked an issue above.

---

## TL;DR

**What:** Stop the cross-milestone dispatch guard and auto-start runtime-cleanup from treating any SUMMARY file on disk as proof of milestone completion.
**Why:** Failure-path SUMMARY reports (verification FAILED, blocker placeholders) could let later milestones dispatch prematurely and could clear runtime units for still-active milestones — the same #4658 bug class that PR #4660 fixed in dispatch and recovery.
**How:** Skip a milestone only when DB status is closed, or when the SUMMARY exists and is not a failure-path report. Move `cleanStaleRuntimeUnits` after DB open and gate its predicate on DB status.

## What

- `src/resources/extensions/gsd/dispatch-guard.ts`
- `src/resources/extensions/gsd/auto-start.ts`
- Regression tests:
  - `src/resources/extensions/gsd/tests/dispatch-guard-summary-db-mismatch.test.ts`
  - `src/resources/extensions/gsd/tests/auto-start-clean-runtime-db-gated.test.ts`

## Why

#4658 showed that a failure-path SUMMARY could be read as a completion signal in `auto-dispatch.ts` / `auto-recovery.ts`. PR #4660 fixed those two paths but two sibling sites still encoded the same wrong inference:

1. `dispatch-guard.ts:50` (old behavior): `if (resolveMilestoneFile(base, mid, "SUMMARY")) continue;` fired before the DB check. A failure SUMMARY on an active milestone let cross-milestone dispatches proceed out of order.
2. `auto-start.ts:423-426` (old behavior): `cleanStaleRuntimeUnits` ran before DB open and used SUMMARY-file presence as its completion predicate. A failure SUMMARY could clear runtime unit files for an active milestone.

Issue #4663 catalogs the investigation and rules out the state.ts paths as FS-fallback-only.

## How

**dispatch-guard.ts**
- Skip a prior milestone only when (a) DB is available and `isClosedStatus(getMilestone(mid).status)`, or (b) a SUMMARY exists and is not a failure-path report.
- New local `isFailureMilestoneSummary(content)` detects `# BLOCKER`, `auto-mode recovery failed`, `verification FAILED`, and `not complete` markers. Intentionally local to avoid coupling this PR to PR #4660's `classifyMilestoneSummaryContent`; can migrate to the shared classifier once that lands.
- Preserves the #1716 contract: a milestone with a success SUMMARY and unchecked remediation slices in DB is still skipped.

**auto-start.ts**
- Move `cleanStaleRuntimeUnits` to run after `openProjectDbIfPresent`.
- Predicate now returns `isClosedStatus(getMilestone(mid).status)` when DB is available, falling back to SUMMARY-file presence only in legacy / pre-migration projects.

## Change type

- [x] `fix` — Bug fix
- [x] `test` — Adding or updating tests

## Scope

- [x] `gsd extension` — GSD workflow

## Breaking changes

- [x] No breaking changes

## Test plan

- [x] New/updated tests included
- [x] Manual testing — steps described below

Targeted tests run locally:

```
node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --test \
  src/resources/extensions/gsd/tests/dispatch-guard-summary-db-mismatch.test.ts \
  src/resources/extensions/gsd/tests/auto-start-clean-runtime-db-gated.test.ts \
  src/resources/extensions/gsd/tests/dispatch-guard.test.ts \
  src/resources/extensions/gsd/tests/dispatch-guard-closed-status.test.ts
```

Result: 20 passed, 0 failed. Includes the preserved #1716 test (success SUMMARY + pending DB remediation slices → still skipped).

Type check on `tsconfig.extensions.json` reports only pre-existing errors in unrelated files; `dispatch-guard.ts` and `auto-start.ts` type-check clean.

## AI disclosure

- [x] This PR was drafted with AI assistance. All behavior changes are covered by regression tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved milestone completion status detection by prioritizing database records over file-based checks, with fallback support for unavailable databases.
  * Enhanced failure pattern recognition in milestone summaries to accurately identify incomplete or blocked states, preventing invalid task dispatches.

* **Tests**
  * Added regression tests verifying database-gated cleanup logic and milestone status mismatch handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->