### PR TITLE
fix(claude-code-cli): headless auto-mode permission default to bypassPermissions

### DIFF
--- a/src/resources/extensions/claude-code-cli/stream-adapter.ts
+++ b/src/resources/extensions/claude-code-cli/stream-adapter.ts
@@ -702,6 +702,12 @@ export function makeAbortedMessage(model: string, lastTextContent: string): Assi
  * Set `GSD_CLAUDE_CODE_PERMISSION_MODE` to `bypassPermissions` to restore
  * the old always-approve behaviour, or to `default` / `plan` for stricter
  * modes.
+ *
+ * When `GSD_HEADLESS=1` is set (auto-mode / non-interactive runs), the
+ * default flips to `bypassPermissions` because there is no UI to approve
+ * permission dialogs — `acceptEdits` would hang verification commands like
+ * `npx tsc --noEmit` or `npx vitest run` indefinitely (#4657). Explicit
+ * overrides still win, so users can opt back into `acceptEdits` in headless.
  */
 export async function resolveClaudePermissionMode(
 	env: NodeJS.ProcessEnv = process.env,
@@ -709,6 +715,12 @@ export async function resolveClaudePermissionMode(
 	const override = env.GSD_CLAUDE_CODE_PERMISSION_MODE?.trim();
 	if (override === "bypassPermissions" || override === "acceptEdits" || override === "default" || override === "plan") {
 		return override;
+	}
+	if (env.GSD_HEADLESS === "1") {
+		console.warn(
+			"[claude-code-cli] Headless mode detected (GSD_HEADLESS=1): defaulting permissionMode to 'bypassPermissions' so verification Bash commands can run. Set GSD_CLAUDE_CODE_PERMISSION_MODE=acceptEdits to opt out.",
+		);
+		return "bypassPermissions";
 	}
 	return "acceptEdits";
 }

--- a/src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts
+++ b/src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts
@@ -1258,6 +1258,27 @@ describe("stream-adapter — permission mode (F10)", () => {
 			`expected bypass or acceptEdits, got ${mode}`,
 		);
 	});
+
+	test("resolveClaudePermissionMode flips to bypassPermissions when GSD_HEADLESS=1 (#4657)", async () => {
+		const originalWarn = console.warn;
+		console.warn = () => {};
+		try {
+			const env = { GSD_HEADLESS: "1" } as NodeJS.ProcessEnv;
+			const mode = await resolveClaudePermissionMode(env);
+			assert.equal(mode, "bypassPermissions");
+		} finally {
+			console.warn = originalWarn;
+		}
+	});
+
+	test("resolveClaudePermissionMode: explicit override wins over GSD_HEADLESS=1", async () => {
+		const env = {
+			GSD_HEADLESS: "1",
+			GSD_CLAUDE_CODE_PERMISSION_MODE: "acceptEdits",
+		} as NodeJS.ProcessEnv;
+		const mode = await resolveClaudePermissionMode(env);
+		assert.equal(mode, "acceptEdits");
+	});
 });
 
 describe("stream-adapter — Windows Claude path lookup (#3770)", () => {


### PR DESCRIPTION
## TL;DR

**What:** In headless auto-mode, resolveClaudePermissionMode now defaults to 'bypassPermissions' instead of 'acceptEdits'.
**Why:** 'acceptEdits' surfaces permission dialogs (#4383), but there's no UI in headless, so verification Bash commands hang. Explicit env overrides still win.
**How:** Check GSD_HEADLESS=1 before returning default, add auditable warning log, add regression tests.

## Summary

- When `GSD_HEADLESS=1` is set (auto-mode dispatches with this env var), default permission mode is now `bypassPermissions` so verification commands (npx tsc, npx vitest, npm run) can execute without UI approval
- Interactive mode keeps `acceptEdits` to surface permission dialogs (#4383)
- Explicit `GSD_CLAUDE_CODE_PERMISSION_MODE` env override still takes precedence in both modes — users can force `acceptEdits` in headless if they want
- Added console.warn when headless bypass activates so the relaxation is auditable in logs
- Added two regression tests: headless flip + override precedence

Closes #4657
Closes #4666

## Test plan

- [x] Type check: `npx tsc --noEmit` passes
- [x] Stream-adapter tests: all 69 pass, including 2 new headless cases
- [x] Focused change: only 2 files, single commit
- [x] No behavior change for interactive users (acceptEdits still default there)
- [x] Explicit overrides still take precedence (GSD_CLAUDE_CODE_PERMISSION_MODE wins over GSD_HEADLESS)