### PR TITLE
fix(deps): patch 3 transitive vulnerabilities via npm audit fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4602,9 +4602,9 @@
       }
     },
     "node_modules/basic-ftp": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.1.tgz",
-      "integrity": "sha512-0yaL8JdxTknKDILitVpfYfV2Ob6yb3udX/hK97M7I3jOeznBNxQPtVvTUtnhUkyHlxFWyr5Lvknmgzoc7jf+1Q==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.0.tgz",
+      "integrity": "sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -6249,9 +6249,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.12",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
-      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
+      "version": "4.12.14",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
+      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -7564,9 +7564,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
-      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
+      "integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {


### PR DESCRIPTION
## Summary

Lockfile-only update. `npm audit fix` patches three transitive vulnerabilities — one critical, one high, one moderate. `package.json` is unchanged.

| Package | Bump | Severity | Source dep | Advisory |
|---|---|---|---|---|
| protobufjs | 7.5.4 → 7.5.5 | **critical** | `@google/genai` | [GHSA-xq3m-2v4x-88gg](https://github.com/advisories/GHSA-xq3m-2v4x-88gg) — arbitrary code execution |
| basic-ftp | 5.2.1 → 5.3.0 | **high** | `proxy-agent` → `pac-proxy-agent` → `get-uri` | [GHSA-6v7q-wjvx-w8wg](https://github.com/advisories/GHSA-6v7q-wjvx-w8wg) (CRLF injection), [GHSA-rp42-5vxx-qpwr](https://github.com/advisories/GHSA-rp42-5vxx-qpwr) (DoS in `Client.list()`) |
| hono | 4.12.12 → 4.12.14 | moderate | `@modelcontextprotocol/sdk` (+ `@hono/node-server`) | [GHSA-458j-xx4x-4375](https://github.com/advisories/GHSA-458j-xx4x-4375) — JSX attribute HTML injection in SSR |

## Verification

- `npm audit` → 0 vulnerabilities (top-level, `web/`, `vscode-extension/` all clean)
- `npm run build` → clean
- `gsd --version` → `2.76.0`

## Test plan

- [ ] CI green
- [ ] Manual smoke: any gsd subcommand runs after install

## Note for maintainers (separate, not part of this PR)

While preparing this fix I noticed the repo's Dependabot alerts are disabled (`gh api repos/gsd-build/gsd-2/dependabot/alerts` → HTTP 403 "Dependabot alerts are disabled"). Enabling them would surface this class of advisory automatically rather than requiring a contributor to discover it via `npm audit`. Happy to draft a follow-up pre-discussion issue with a proposed CI security-audit workflow + `.github/dependabot.yml` if there's appetite.