### PR TITLE
fix(compaction): prevent degenerate summaries by fixing chunker/truncation mismatch (#4665)

### DIFF
--- a/packages/pi-coding-agent/src/core/compaction-orchestrator.ts
+++ b/packages/pi-coding-agent/src/core/compaction-orchestrator.ts
@@ -14,6 +14,7 @@ import type { AssistantMessage, Model } from "@gsd/pi-ai";
 import { isContextOverflow } from "@gsd/pi-ai";
 import {
 	type CompactionResult,
+	CompactionProducedNoSummaryError,
 	calculateContextTokens,
 	compact,
 	estimateContextTokens,
@@ -408,7 +409,13 @@ export class CompactionOrchestrator {
 				}, 100);
 			}
 		} catch (error) {
-			const errorMessage = getErrorMessage(error);
+			// Distinguish the "no usable summary" failure (issue #4665) so the UI
+			// can surface a clearer message than a generic compaction failure.
+			// Either way we drop the would-be compaction entry rather than writing
+			// an empty string to the session history.
+			const errorMessage = error instanceof CompactionProducedNoSummaryError
+				? `Compaction produced no usable summary — session history preserved as-is. (${error.message})`
+				: getErrorMessage(error);
 			this._deps.emit({
 				type: "auto_compaction_end",
 				result: undefined,

--- a/packages/pi-coding-agent/src/core/compaction-utils.test.ts
+++ b/packages/pi-coding-agent/src/core/compaction-utils.test.ts
@@ -3,7 +3,7 @@ import test from "node:test";
 
 import type { Message } from "@gsd/pi-ai";
 
-import { serializeConversation } from "./compaction/index.js";
+import { serializeConversation, truncateForSummary } from "./compaction/index.js";
 
 test("serializeConversation uses narrative role markers instead of chat-style delimiters (#4054)", () => {
 	const messages: Message[] = [
@@ -47,4 +47,71 @@ test("serializeConversation uses narrative role markers instead of chat-style de
 	assert.ok(!serialized.includes("[User]:"), "chat-style [User]: markers should not remain");
 	assert.ok(!serialized.includes("[Assistant]:"), "chat-style [Assistant]: markers should not remain");
 	assert.ok(!serialized.includes("[Tool result]:"), "chat-style [Tool result]: markers should not remain");
+});
+
+// ---------------------------------------------------------------------------
+// #4665 regression: head+tail truncation keeps verdicts/results
+// ---------------------------------------------------------------------------
+
+test("(#4665) truncateForSummary keeps both head AND tail — tail carries result/verdict text", () => {
+	// Construct a 10K-char fixture where the HEAD is "setup noise" and the TAIL
+	// contains a result line. The old head-only truncation would drop the tail
+	// and lose the result. The fix preserves both.
+	const head = "setup log line A\n".repeat(500); // ~8500 chars of setup
+	const tail = "RESULT: 258 passed, 0 failed. exit_code=0 commit=abc1234";
+	const input = head + tail;
+
+	const out = truncateForSummary(input, 2_000);
+
+	assert.ok(out.length < input.length, "must truncate when over cap");
+	assert.ok(out.includes("setup log line A"), "head content preserved");
+	assert.ok(out.includes("RESULT: 258 passed"), "tail content preserved (issue #4665)");
+	assert.match(out, /more characters truncated/, "emits an elision marker");
+});
+
+test("(#4665) truncateForSummary is a no-op when input is within the cap", () => {
+	const input = "short enough";
+	assert.equal(truncateForSummary(input, 2_000), input);
+});
+
+test("(#4665) serializeConversation caps large user content, not just tool results", () => {
+	// Pre-fix, only toolResult blocks were capped. A large user paste could
+	// still blow out the chunker's token math and the LLM's input budget.
+	const hugeUserText = "U".repeat(100_000);
+	const hugeAssistantText = "A".repeat(100_000);
+	const hugeToolResult = "T".repeat(100_000);
+
+	const messages: Message[] = [
+		{ role: "user", content: hugeUserText } as Message,
+		{
+			role: "assistant",
+			content: [{ type: "text", text: hugeAssistantText }],
+			api: "anthropic-messages",
+			provider: "anthropic",
+			model: "claude-sonnet-4-6",
+			usage: {
+				input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "stop",
+			timestamp: Date.now(),
+		} as Message,
+		{
+			role: "toolResult",
+			content: [{ type: "text", text: hugeToolResult }],
+			toolName: "Bash",
+			toolCallId: "tool-huge",
+		} as Message,
+	];
+
+	const serialized = serializeConversation(messages);
+
+	// Each block is truncated independently to TOOL_RESULT_MAX_CHARS plus the
+	// framing marker, so the serialized output should be a tiny fraction of
+	// the raw 300K chars of content.
+	assert.ok(
+		serialized.length < 10_000,
+		`serialized output should be small after capping all blocks, got ${serialized.length} chars`,
+	);
+	assert.match(serialized, /more characters truncated/, "truncation marker present");
 });

--- a/packages/pi-coding-agent/src/core/compaction/compaction.test.ts
+++ b/packages/pi-coding-agent/src/core/compaction/compaction.test.ts
@@ -9,7 +9,7 @@ import { describe, it, mock } from "node:test";
 import type { AgentMessage } from "@gsd/pi-agent-core";
 import type { Model, AssistantMessage } from "@gsd/pi-ai";
 
-import { generateSummary, estimateTokens, chunkMessages, isDegenerateSummary } from "./compaction.js";
+import { generateSummary, estimateTokens, chunkMessages, isDegenerateSummary, CompactionProducedNoSummaryError } from "./compaction.js";
 import { estimateSerializedTokens } from "./utils.js";
 
 // ---------------------------------------------------------------------------
@@ -458,6 +458,119 @@ describe("(#4665) degenerate summary guard", () => {
 		assert.ok(
 			mockComplete.mock.callCount() >= 3,
 			`expected at least 3 calls (first attempt, retry, second chunk), got ${mockComplete.mock.callCount()}`,
+		);
+	});
+
+	// -------------------------------------------------------------------------
+	// R1 — retry non-first chunks too + observable log when both attempts fail
+	// -------------------------------------------------------------------------
+
+	it("(R1) retries a degenerate NON-FIRST chunk before silently dropping it", async () => {
+		// Use a small model window to force exactly 2 chunks from 2 messages.
+		// Chunk 0 ok, chunk 1 degenerate on first try then real on retry.
+		// Chunk 1's recovered content must reach the final summary.
+		const messages: AgentMessage[] = [
+			makeBranchSummaryMessage(80_000),
+			makeBranchSummaryMessage(80_000),
+		];
+		const model = makeModel(100_000);
+		const reserveTokens = 16_384;
+
+		const CHUNK0_SUMMARY = "## Done\n- Chunk 0 real summary with enough length to clear the degenerate threshold of 100 characters — easily.";
+		const CHUNK1_RETRY_SUMMARY = "## Done\n- Chunk 1 recovered on retry — its content must appear in the final summary or the R1 fix regressed for non-first chunks.";
+
+		let callIndex = 0;
+		const responses = [
+			CHUNK0_SUMMARY,           // chunk 0
+			"empty conversation",     // chunk 1 first try → degenerate
+			CHUNK1_RETRY_SUMMARY,     // chunk 1 retry → real
+		];
+		const mockComplete = mock.fn(async () => {
+			const r = responses[Math.min(callIndex, responses.length - 1)];
+			callIndex++;
+			return makeFakeResponse(r);
+		});
+
+		const summary = await generateSummary(
+			messages,
+			model,
+			reserveTokens,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			mockComplete,
+		);
+
+		assert.equal(
+			mockComplete.mock.callCount(),
+			3,
+			"expected 3 calls: chunk 0 + chunk 1 initial + chunk 1 retry",
+		);
+		assert.ok(
+			summary.includes("recovered on retry"),
+			`final summary must include chunk 1's retry content (R1: non-first chunks must also retry), got: ${JSON.stringify(summary)}`,
+		);
+	});
+
+	// -------------------------------------------------------------------------
+	// R6 — empty output must not be silently written as a compaction entry
+	// -------------------------------------------------------------------------
+
+	it("(R6) throws CompactionProducedNoSummaryError when every chunk is degenerate AND no previousSummary", async () => {
+		const messages: AgentMessage[] = [
+			makeBranchSummaryMessage(80_000),
+			makeBranchSummaryMessage(80_000),
+		];
+		const model = makeModel(100_000);
+		const reserveTokens = 16_384;
+
+		// Every response is degenerate, both initial and retry attempts.
+		const mockComplete = mock.fn(async () => makeFakeResponse("empty conversation"));
+
+		await assert.rejects(
+			() => generateSummary(
+				messages,
+				model,
+				reserveTokens,
+				undefined,
+				undefined,
+				undefined,
+				undefined, // no previousSummary
+				mockComplete,
+			),
+			(err: unknown) => err instanceof CompactionProducedNoSummaryError,
+			"expected CompactionProducedNoSummaryError when all chunks degenerate and no previousSummary",
+		);
+	});
+
+	it("(R6) falls back to previousSummary when every chunk is degenerate", async () => {
+		const messages: AgentMessage[] = [
+			makeBranchSummaryMessage(80_000),
+			makeBranchSummaryMessage(80_000),
+		];
+		const model = makeModel(100_000);
+		const reserveTokens = 16_384;
+		const previousSummary =
+			"Previously-computed summary from the last compaction — deliberately long enough to clear the degenerate-output threshold.";
+
+		const mockComplete = mock.fn(async () => makeFakeResponse("empty conversation"));
+
+		const result = await generateSummary(
+			messages,
+			model,
+			reserveTokens,
+			undefined,
+			undefined,
+			undefined,
+			previousSummary,
+			mockComplete,
+		);
+
+		assert.equal(
+			result,
+			previousSummary,
+			"when all chunks degenerate, must fall back to previousSummary rather than return empty string",
 		);
 	});
 });

--- a/packages/pi-coding-agent/src/core/compaction/compaction.test.ts
+++ b/packages/pi-coding-agent/src/core/compaction/compaction.test.ts
@@ -9,7 +9,8 @@ import { describe, it, mock } from "node:test";
 import type { AgentMessage } from "@gsd/pi-agent-core";
 import type { Model, AssistantMessage } from "@gsd/pi-ai";
 
-import { generateSummary, estimateTokens, chunkMessages } from "./compaction.js";
+import { generateSummary, estimateTokens, chunkMessages, isDegenerateSummary } from "./compaction.js";
+import { estimateSerializedTokens } from "./utils.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -19,6 +20,39 @@ import { generateSummary, estimateTokens, chunkMessages } from "./compaction.js"
 function makeUserMessage(tokenCount: number): AgentMessage {
 	const text = "x".repeat(tokenCount * 4);
 	return { role: "user", content: text } as unknown as AgentMessage;
+}
+
+/**
+ * Create a tool-result message of approximately `rawTokenCount` uncapped tokens.
+ * Post-truncation, this estimates to ~500 tokens (TOOL_RESULT_MAX_CHARS / 4).
+ *
+ * Used to exercise the #4665 regression: before the fix, chunkMessages used
+ * estimateTokens (pre-truncation), so a 100K-token tool result forced its own
+ * chunk even though it serialized to ~500 tokens. After the fix, many tool
+ * results coalesce into a single chunk.
+ */
+function makeToolResultMessage(rawTokenCount: number): AgentMessage {
+	const text = "y".repeat(rawTokenCount * 4);
+	return {
+		role: "toolResult",
+		toolCallId: `call_${rawTokenCount}`,
+		content: [{ type: "text", text }],
+	} as unknown as AgentMessage;
+}
+
+/**
+ * Create a branch-summary message with a specific summary length. Summary
+ * messages are intentionally NOT truncated by the serializer (they're already
+ * concise), so this is the right tool to force chunking post-fix.
+ */
+function makeBranchSummaryMessage(approxTokens: number): AgentMessage {
+	const summary = "z".repeat(approxTokens * 4);
+	return {
+		role: "branchSummary",
+		summary,
+		fromId: "test",
+		timestamp: 0,
+	} as unknown as AgentMessage;
 }
 
 /** Create a mock model with a given context window. */
@@ -60,44 +94,96 @@ describe("chunkMessages", () => {
 	});
 
 	it("splits messages into multiple chunks when they exceed budget", () => {
+		// Use branchSummary messages — they aren't capped by the serializer, so
+		// their post-serialization size matches their raw size. Each 50k-token
+		// summary must get its own chunk under an 80k budget.
 		const messages: AgentMessage[] = [
-			makeUserMessage(50_000),
-			makeUserMessage(50_000),
-			makeUserMessage(50_000),
+			makeBranchSummaryMessage(50_000),
+			makeBranchSummaryMessage(50_000),
+			makeBranchSummaryMessage(50_000),
 		];
-		// Budget of 80k tokens means each 50k message gets its own chunk
-		// (or two fit together if budget allows)
 		const chunks = chunkMessages(messages, 80_000);
 		assert.ok(chunks.length > 1, `Expected multiple chunks, got ${chunks.length}`);
-		// All messages should be present across chunks
 		const totalMessages = chunks.reduce((sum, c) => sum + c.length, 0);
 		assert.equal(totalMessages, 3);
 	});
 
 	it("puts a single oversized message in its own chunk", () => {
-		const messages: AgentMessage[] = [
-			makeUserMessage(200_000), // Way over any reasonable budget
-		];
+		// Use branchSummary — not truncated by the serializer — to force the
+		// oversized-single-message path. A user message with the same raw size
+		// would cap to ~500 tokens and fit in any reasonable budget.
+		const messages: AgentMessage[] = [makeBranchSummaryMessage(200_000)];
 		const chunks = chunkMessages(messages, 80_000);
 		assert.equal(chunks.length, 1);
 		assert.equal(chunks[0].length, 1);
 	});
 
 	it("preserves message order across chunks", () => {
-		// Create messages with identifiable sizes
 		const messages: AgentMessage[] = [
-			makeUserMessage(30_000), // ~30k tokens
-			makeUserMessage(30_000),
-			makeUserMessage(30_000),
-			makeUserMessage(30_000),
+			makeBranchSummaryMessage(30_000),
+			makeBranchSummaryMessage(30_000),
+			makeBranchSummaryMessage(30_000),
+			makeBranchSummaryMessage(30_000),
 		];
 		const chunks = chunkMessages(messages, 50_000);
-		// Reconstruct original order
 		const flat = chunks.flat();
 		assert.equal(flat.length, 4);
 		for (let i = 0; i < flat.length; i++) {
 			assert.strictEqual(flat[i], messages[i], `Message ${i} should be in order`);
 		}
+	});
+
+	// ---------------------------------------------------------------------------
+	// #4665 regression: token estimation must reflect serializer truncation
+	// ---------------------------------------------------------------------------
+
+	it("(#4665) does not over-split when tool results dominate — they serialize to ~500 tokens", () => {
+		// Ten 100K-token tool results. Under the old pre-truncation estimator
+		// this would estimate to ~1M tokens and force 10+ tiny chunks. Under
+		// the new estimator each caps to ~500 tokens (TOOL_RESULT_MAX_CHARS/4),
+		// so 10 of them total ~5K tokens and fit in a single generous budget.
+		const messages: AgentMessage[] = Array.from({ length: 10 }, () =>
+			makeToolResultMessage(100_000),
+		);
+		const chunks = chunkMessages(messages, 50_000);
+		assert.equal(
+			chunks.length,
+			1,
+			"ten 100K-token tool results should coalesce into one chunk (cap=2000 chars → ~500 tokens each)",
+		);
+		assert.equal(chunks[0].length, 10);
+	});
+
+	it("(#4665) estimateSerializedTokens caps toolResult at TOOL_RESULT_MAX_CHARS/4", () => {
+		const huge = makeToolResultMessage(100_000);
+		const serialized = estimateSerializedTokens(huge);
+		const raw = estimateTokens(huge);
+		assert.ok(raw > 50_000, `raw estimator should report the real size, got ${raw}`);
+		assert.ok(
+			serialized < 1_000,
+			`serialized estimator should cap at ~500 tokens, got ${serialized}`,
+		);
+	});
+
+	it("(#4665) estimateSerializedTokens also caps large user content and assistant thinking", () => {
+		const hugeUser = makeUserMessage(50_000);
+		assert.ok(
+			estimateSerializedTokens(hugeUser) < 1_000,
+			"user content > cap must be truncated in the estimator",
+		);
+
+		// Assistant with a huge thinking block + huge text block
+		const hugeAssistant: AgentMessage = {
+			role: "assistant",
+			content: [
+				{ type: "thinking", thinking: "t".repeat(100_000) },
+				{ type: "text", text: "r".repeat(100_000) },
+			],
+		} as unknown as AgentMessage;
+		assert.ok(
+			estimateSerializedTokens(hugeAssistant) < 2_000,
+			"assistant thinking + text must each cap; total under 2x TOOL_RESULT_MAX_CHARS/4",
+		);
 	});
 });
 
@@ -107,18 +193,22 @@ describe("chunkMessages", () => {
 
 describe("generateSummary — chunked fallback (#2932)", () => {
 	it("calls _completeFn multiple times when messages exceed model context window", async () => {
-		// Arrange: 3 messages of ~80k tokens each = ~240k total, model has 200k window
+		// Use branchSummary messages — not capped by the serializer — so the
+		// chunker's post-truncation view matches the raw view. 3 × 80k summaries
+		// totalling 240k tokens must exceed a 200k context window.
 		const messages: AgentMessage[] = [
-			makeUserMessage(80_000),
-			makeUserMessage(80_000),
-			makeUserMessage(80_000),
+			makeBranchSummaryMessage(80_000),
+			makeBranchSummaryMessage(80_000),
+			makeBranchSummaryMessage(80_000),
 		];
 		const model = makeModel(200_000);
 		const reserveTokens = 16_384;
 
-		// Verify our test setup: messages really do exceed the model window
+		// Verify our test setup: messages really do exceed the model window.
+		// Use estimateSerializedTokens because that's what generateSummary uses
+		// for its "does this fit?" decision post-#4665.
 		let totalTokens = 0;
-		for (const m of messages) totalTokens += estimateTokens(m);
+		for (const m of messages) totalTokens += estimateSerializedTokens(m);
 		assert.ok(
 			totalTokens > model.contextWindow,
 			`Test setup: ${totalTokens} tokens should exceed ${model.contextWindow} context window`,
@@ -138,7 +228,12 @@ describe("generateSummary — chunked fallback (#2932)", () => {
 			} else {
 				calls.push("initial");
 			}
-			return makeFakeResponse("Summary of chunk");
+			// Return a non-degenerate summary (>100 chars). Short responses like
+			// "Summary of chunk" would trip the #4665 degenerate-output guard,
+			// which is exactly what we don't want to test here.
+			return makeFakeResponse(
+				"## Goal\nDetailed summary of this chunk describing the work completed, files touched, and decisions made. At least 100 characters so the degenerate guard does not trip.",
+			);
 		});
 
 		const summary = await generateSummary(
@@ -197,13 +292,14 @@ describe("generateSummary — chunked fallback (#2932)", () => {
 
 	it("passes previousSummary through chunked summarization", async () => {
 		const messages: AgentMessage[] = [
-			makeUserMessage(80_000),
-			makeUserMessage(80_000),
-			makeUserMessage(80_000),
+			makeBranchSummaryMessage(80_000),
+			makeBranchSummaryMessage(80_000),
+			makeBranchSummaryMessage(80_000),
 		];
 		const model = makeModel(200_000);
 		const reserveTokens = 16_384;
-		const previousSummary = "Previous session summary content";
+		const previousSummary =
+			"Previous session summary content — intentionally verbose enough to clear the degenerate-summary threshold so this test exercises the actual propagation path.";
 
 		const prompts: string[] = [];
 		const mockComplete = mock.fn(async (_model: any, context: any) => {
@@ -213,7 +309,9 @@ describe("generateSummary — chunked fallback (#2932)", () => {
 					? userMsg.content
 					: userMsg?.content?.[0]?.text ?? "";
 			prompts.push(text);
-			return makeFakeResponse("Chunk summary");
+			return makeFakeResponse(
+				"Chunk summary with sufficient length to clear the #4665 degenerate-output guard threshold of 100 characters — this must be longer.",
+			);
 		});
 
 		await generateSummary(
@@ -231,6 +329,135 @@ describe("generateSummary — chunked fallback (#2932)", () => {
 		assert.ok(
 			prompts[0].includes(previousSummary),
 			"First chunk should incorporate the previousSummary",
+		);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// #4665 regression — iterative chain must not propagate degenerate summaries
+// ---------------------------------------------------------------------------
+
+describe("(#4665) degenerate summary guard", () => {
+	it("isDegenerateSummary detects the known failure patterns", () => {
+		assert.equal(isDegenerateSummary(undefined), false);
+		assert.equal(isDegenerateSummary(""), true, "empty string is degenerate");
+		assert.equal(isDegenerateSummary("too short"), true, "short output is degenerate");
+		assert.equal(
+			isDegenerateSummary("The user asked me to summarize an empty conversation"),
+			true,
+			"known failure phrase 'empty conversation' is degenerate",
+		);
+		assert.equal(
+			isDegenerateSummary("No conversation to summarize"),
+			true,
+			"'no conversation to summarize' is degenerate",
+		);
+		assert.equal(
+			isDegenerateSummary(
+				"## Goal\nRefactor the compaction pipeline.\n## Done\n- Updated utils.ts\n- Added tests for #4665 regression path",
+			),
+			false,
+			"a real multi-section summary over 100 chars is not degenerate",
+		);
+	});
+
+	it("does not propagate a degenerate first-chunk summary forward (no 'preserve nothing' chain)", async () => {
+		// Force the chunked path with uncapped summary messages.
+		const messages: AgentMessage[] = [
+			makeBranchSummaryMessage(80_000),
+			makeBranchSummaryMessage(80_000),
+			makeBranchSummaryMessage(80_000),
+		];
+		const model = makeModel(200_000);
+		const reserveTokens = 16_384;
+
+		// Responses: chunk 0 returns degenerate ("empty conversation"). Chunks
+		// 1 and 2 return real summaries. Pre-fix behavior: the chunk-0 output
+		// is fed into UPDATE_SUMMARIZATION_PROMPT for chunks 1+, which says
+		// "PRESERVE all existing information" — so emptiness is preserved.
+		// Post-fix: the degenerate chunk-0 output must not become runningSummary.
+		let callIndex = 0;
+		const responses = [
+			"The user asked me to summarize an empty conversation.",
+			"## Done\n- Refactored the serializer to head+tail truncation.\n- Updated chunker to use post-serialization token estimate.",
+			"## Done\n- Added regression tests for #4665 including this propagation guard.\n- Verified isDegenerateSummary handles known failure patterns.",
+		];
+		const seenPrompts: string[] = [];
+		const mockComplete = mock.fn(async (_model: any, context: any) => {
+			const userMsg = context.messages?.[0];
+			const text =
+				typeof userMsg?.content === "string"
+					? userMsg.content
+					: userMsg?.content?.[0]?.text ?? "";
+			seenPrompts.push(text);
+			const response = responses[Math.min(callIndex, responses.length - 1)];
+			callIndex++;
+			return makeFakeResponse(response);
+		});
+
+		const summary = await generateSummary(
+			messages,
+			model,
+			reserveTokens,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			mockComplete,
+		);
+
+		// The returned summary must be one of the real chunk summaries — not
+		// the degenerate "empty conversation" output, and not an empty string.
+		assert.ok(
+			!isDegenerateSummary(summary),
+			`final summary should not be degenerate. got: ${JSON.stringify(summary)}`,
+		);
+		assert.ok(
+			summary.includes("Refactored") || summary.includes("regression tests"),
+			"final summary should carry real information from chunks 1 or 2",
+		);
+	});
+
+	it("retries the first chunk once with the initial prompt if the first pass is degenerate", async () => {
+		// Force chunked path with a single large chunk. Mock returns degenerate
+		// on the first call and a real summary on the retry.
+		const messages: AgentMessage[] = [
+			makeBranchSummaryMessage(80_000),
+			makeBranchSummaryMessage(80_000),
+		];
+		const model = makeModel(100_000); // small window forces chunking
+		const reserveTokens = 16_384;
+
+		const responses = [
+			"", // first attempt: empty string → degenerate
+			"## Goal\nReal summary produced on the retry pass after the initial pass came back empty — this should land as the running summary.",
+			"## Done\n- Added retry-on-degenerate-first-chunk behavior to the iterative summarizer so empty outputs don't poison the chain.",
+		];
+		let callIndex = 0;
+		const mockComplete = mock.fn(async () => {
+			const response = responses[Math.min(callIndex, responses.length - 1)];
+			callIndex++;
+			return makeFakeResponse(response);
+		});
+
+		const summary = await generateSummary(
+			messages,
+			model,
+			reserveTokens,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			mockComplete,
+		);
+
+		assert.ok(
+			!isDegenerateSummary(summary),
+			"final summary must not be degenerate after the retry took effect",
+		);
+		assert.ok(
+			mockComplete.mock.callCount() >= 3,
+			`expected at least 3 calls (first attempt, retry, second chunk), got ${mockComplete.mock.callCount()}`,
 		);
 	});
 });

--- a/packages/pi-coding-agent/src/core/compaction/compaction.ts
+++ b/packages/pi-coding-agent/src/core/compaction/compaction.ts
@@ -621,40 +621,80 @@ export async function generateSummary(
 
 		// Degenerate-summary guard (issue #4665). UPDATE_SUMMARIZATION_PROMPT says
 		// "PRESERVE all existing information" — so if a chunk summary is empty or
-		// near-empty, propagating it forward actively reinforces the emptiness for
-		// every subsequent chunk. Two-part guard:
-		//   1. Don't propagate a degenerate output forward as `runningSummary`.
-		//   2. If it's the FIRST chunk and it's degenerate, retry once with a
-		//      fresh (non-update) prompt by clearing runningSummary. This breaks
-		//      the poison chain at its source.
+		// near-empty, propagating it forward actively reinforces the emptiness
+		// for every subsequent chunk.
+		//
+		// Strategy per chunk:
+		//   1. If degenerate, retry once. For the FIRST chunk with no prior
+		//      context, retry with the initial prompt (undefined previousSummary)
+		//      to break the poison chain at its source. For later chunks, retry
+		//      with the same prompt state (runningSummary preserved) since the
+		//      first failure may have been transient.
+		//   2. If the retry is also degenerate, warn and continue WITHOUT
+		//      updating runningSummary — losing that chunk's content is still
+		//      preferable to propagating emptiness forward, but the drop is now
+		//      observable in logs.
 		if (isDegenerateSummary(chunkSummary)) {
-			if (i === 0 && runningSummary === undefined) {
-				// First chunk, no prior context — retry once with the initial prompt.
-				// (Passing `undefined` forces SUMMARIZATION_PROMPT instead of UPDATE.)
-				const retry = await singlePassSummary(
-					chunks[i],
-					model,
-					reserveTokens,
-					apiKey,
-					signal,
-					customInstructions,
-					undefined,
-					complete,
-				);
-				if (!isDegenerateSummary(retry)) {
-					runningSummary = retry;
-					continue;
-				}
+			const retryPreviousSummary = i === 0 && runningSummary === undefined
+				? undefined
+				: runningSummary;
+			const retry = await singlePassSummary(
+				chunks[i],
+				model,
+				reserveTokens,
+				apiKey,
+				signal,
+				customInstructions,
+				retryPreviousSummary,
+				complete,
+			);
+			if (!isDegenerateSummary(retry)) {
+				runningSummary = retry;
+				continue;
 			}
-			// Keep whatever non-degenerate runningSummary we already have; skip
-			// forward without poisoning the chain.
+			// Both attempts degenerate — log and skip without poisoning the chain.
+			// Using process.stderr directly so this doesn't require the logger
+			// dependency graph. Visible to operators reviewing compaction health.
+			process.stderr.write(
+				`[compaction] WARN: chunk ${i + 1}/${chunks.length} produced a degenerate summary on both attempts; dropping chunk content from summary.\n`,
+			);
 			continue;
 		}
 
 		runningSummary = chunkSummary;
 	}
 
-	return runningSummary ?? "";
+	// R6 (issue #4665 follow-up): if every chunk was degenerate and we have no
+	// runningSummary, do NOT silently return "" — the caller would write an
+	// empty compaction entry, destroying all context with no signal. Fall back
+	// to the original previousSummary if available; otherwise throw a named
+	// error so the compaction pipeline can skip appending the entry.
+	if (runningSummary === undefined) {
+		if (previousSummary !== undefined) {
+			process.stderr.write(
+				"[compaction] WARN: every chunk produced a degenerate summary; falling back to existing previousSummary.\n",
+			);
+			return previousSummary;
+		}
+		throw new CompactionProducedNoSummaryError(
+			`Compaction produced no usable summary: all ${chunks.length} chunk(s) were degenerate and no previousSummary was available.`,
+		);
+	}
+
+	return runningSummary;
+}
+
+/**
+ * Thrown when `generateSummary` could not produce any non-degenerate summary
+ * from the provided messages AND no previous summary was available to fall
+ * back to. Callers should catch this and skip writing a compaction entry
+ * rather than writing an empty string to the session history (issue #4665).
+ */
+export class CompactionProducedNoSummaryError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "CompactionProducedNoSummaryError";
+	}
 }
 
 /**

--- a/packages/pi-coding-agent/src/core/compaction/compaction.ts
+++ b/packages/pi-coding-agent/src/core/compaction/compaction.ts
@@ -16,6 +16,7 @@ import {
 	computeFileLists,
 	createFileOps,
 	createSummarizationMessage,
+	estimateSerializedTokens,
 	extractFileOpsFromMessage,
 	extractTextContent,
 	type FileOperations,
@@ -500,7 +501,13 @@ export function chunkMessages(messages: AgentMessage[], maxTokensPerChunk: numbe
 	let currentTokens = 0;
 
 	for (const msg of messages) {
-		const msgTokens = estimateTokens(msg);
+		// Use POST-truncation token estimate: serializeConversation caps every
+		// large content block to TOOL_RESULT_MAX_CHARS before sending to the LLM,
+		// so chunk sizing must reflect what the LLM will actually see. Using the
+		// pre-truncation `estimateTokens` here was the root cause of issue #4665:
+		// a single 400K-char tool result looked like 100K tokens but serialized
+		// to ~600 tokens, producing tens of tiny information-starved chunks.
+		const msgTokens = estimateSerializedTokens(msg);
 
 		if (currentChunk.length > 0 && currentTokens + msgTokens > maxTokensPerChunk) {
 			// Current chunk is full — start a new one
@@ -518,6 +525,39 @@ export function chunkMessages(messages: AgentMessage[], maxTokensPerChunk: numbe
 	}
 
 	return chunks;
+}
+
+// ============================================================================
+// Degenerate summary detection (issue #4665)
+// ============================================================================
+
+/**
+ * Heuristic: does this summary look like the "empty conversation" degenerate
+ * output that poisons the iterative UPDATE_SUMMARIZATION_PROMPT chain?
+ *
+ * The LLM occasionally returns short empty-sounding summaries when a chunk
+ * contains only truncated tool-call preambles without results. If the chain
+ * propagates this forward, every subsequent chunk is told to "PRESERVE all
+ * existing information" — which preserves the emptiness.
+ *
+ * Conservative match: an explicit substring hit OR length < 100 chars. We keep
+ * this deterministic (no fuzzy scoring) because fuzzy matching is where
+ * quality gates become flaky and hard to test.
+ *
+ * Exported for test access only.
+ */
+export function isDegenerateSummary(summary: string | undefined): boolean {
+	// undefined means "no summary was produced yet" (first chunk before any call)
+	// — not degenerate. Empty string IS degenerate: the LLM returned nothing.
+	if (summary === undefined) return false;
+	const lower = summary.toLowerCase();
+	if (lower.includes("empty conversation")) return true;
+	if (lower.includes("no conversation to summarize")) return true;
+	if (lower.includes("no messages to summarize")) return true;
+	// Length guard: any summary shorter than 100 chars is almost certainly
+	// degenerate for a multi-chunk pipeline.
+	if (summary.trim().length < 100) return true;
+	return false;
 }
 
 /** Type for the completion function, allowing injection for tests. */
@@ -545,10 +585,12 @@ export async function generateSummary(
 ): Promise<string> {
 	const complete = _completeFn ?? completeSimple;
 
-	// Estimate total tokens for the messages to summarize
+	// Estimate total tokens using the POST-truncation serializer view (issue #4665).
+	// serializeConversation caps large content blocks to TOOL_RESULT_MAX_CHARS
+	// before sending, so asking "does this fit in one pass?" must reflect that.
 	let totalTokens = 0;
 	for (const msg of currentMessages) {
-		totalTokens += estimateTokens(msg);
+		totalTokens += estimateSerializedTokens(msg);
 	}
 
 	// Overhead for the prompt framing, system prompt, and response budget
@@ -561,12 +603,12 @@ export async function generateSummary(
 		return singlePassSummary(currentMessages, model, reserveTokens, apiKey, signal, customInstructions, previousSummary, complete);
 	}
 
-	// Chunked fallback: split messages and iteratively summarize
+	// Chunked fallback: split messages and iteratively summarize.
 	const chunks = chunkMessages(currentMessages, maxInputTokens);
 	let runningSummary = previousSummary;
 
 	for (let i = 0; i < chunks.length; i++) {
-		runningSummary = await singlePassSummary(
+		const chunkSummary = await singlePassSummary(
 			chunks[i],
 			model,
 			reserveTokens,
@@ -576,9 +618,43 @@ export async function generateSummary(
 			runningSummary,
 			complete,
 		);
+
+		// Degenerate-summary guard (issue #4665). UPDATE_SUMMARIZATION_PROMPT says
+		// "PRESERVE all existing information" — so if a chunk summary is empty or
+		// near-empty, propagating it forward actively reinforces the emptiness for
+		// every subsequent chunk. Two-part guard:
+		//   1. Don't propagate a degenerate output forward as `runningSummary`.
+		//   2. If it's the FIRST chunk and it's degenerate, retry once with a
+		//      fresh (non-update) prompt by clearing runningSummary. This breaks
+		//      the poison chain at its source.
+		if (isDegenerateSummary(chunkSummary)) {
+			if (i === 0 && runningSummary === undefined) {
+				// First chunk, no prior context — retry once with the initial prompt.
+				// (Passing `undefined` forces SUMMARIZATION_PROMPT instead of UPDATE.)
+				const retry = await singlePassSummary(
+					chunks[i],
+					model,
+					reserveTokens,
+					apiKey,
+					signal,
+					customInstructions,
+					undefined,
+					complete,
+				);
+				if (!isDegenerateSummary(retry)) {
+					runningSummary = retry;
+					continue;
+				}
+			}
+			// Keep whatever non-degenerate runningSummary we already have; skip
+			// forward without poisoning the chain.
+			continue;
+		}
+
+		runningSummary = chunkSummary;
 	}
 
-	return runningSummary!;
+	return runningSummary ?? "";
 }
 
 /**

--- a/packages/pi-coding-agent/src/core/compaction/utils.ts
+++ b/packages/pi-coding-agent/src/core/compaction/utils.ts
@@ -3,8 +3,14 @@
  */
 
 import type { AgentMessage } from "@gsd/pi-agent-core";
-import type { Message } from "@gsd/pi-ai";
+import type { AssistantMessage, Message } from "@gsd/pi-ai";
 import { TOOL_RESULT_MAX_CHARS } from "../constants.js";
+
+// Head/tail split for head+tail truncation. Keeps first half + last half up to
+// TOOL_RESULT_MAX_CHARS total. Tool results and other large blocks put their
+// information-dense content (exit codes, verdicts, commit hashes, pass/fail
+// counts) at the tail — pure head-slicing discards that signal. See issue #4665.
+const HEAD_TAIL_HALF = Math.floor(TOOL_RESULT_MAX_CHARS / 2);
 import {
 	createBranchSummaryMessage,
 	createCompactionSummaryMessage,
@@ -189,13 +195,20 @@ export function createSummarizationMessage(promptText: string): [{ role: "user";
 // TOOL_RESULT_MAX_CHARS imported from ../constants.js
 
 /**
- * Truncate text to a maximum character length for summarization.
- * Keeps the beginning and appends a truncation marker.
+ * Truncate text to a maximum character length for summarization, keeping both
+ * the head AND the tail. The tail is where information density lives for tool
+ * output (exit codes, verdicts, pass/fail counts, commit hashes), so pure
+ * head-slicing produced degenerate summaries (see issue #4665).
+ *
+ * Exported for test access only.
  */
-function truncateForSummary(text: string, maxChars: number): string {
+export function truncateForSummary(text: string, maxChars: number): string {
 	if (text.length <= maxChars) return text;
-	const truncatedChars = text.length - maxChars;
-	return `${text.slice(0, maxChars)}\n\n[... ${truncatedChars} more characters truncated]`;
+	const half = Math.floor(maxChars / 2);
+	const head = text.slice(0, half);
+	const tail = text.slice(text.length - half);
+	const truncatedChars = text.length - (head.length + tail.length);
+	return `${head}\n\n[... ${truncatedChars} more characters truncated ...]\n\n${tail}`;
 }
 
 /**
@@ -203,11 +216,15 @@ function truncateForSummary(text: string, maxChars: number): string {
  * This prevents the model from treating it as a conversation to continue.
  * Call convertToLlm() first to handle custom message types.
  *
- * Tool results are truncated to keep the summarization request within
- * reasonable token budgets. Full content is not needed for summarization.
+ * Every content block with a character count above TOOL_RESULT_MAX_CHARS is
+ * head+tail truncated. The issue #4665 fix broadened this from tool-results-
+ * only to every block type — large user pastes, assistant thinking, tool-call
+ * args, and bashExecution-derived blocks also bloat summarization input if
+ * uncapped.
  */
 export function serializeConversation(messages: Message[]): string {
 	const parts: string[] = [];
+	const cap = TOOL_RESULT_MAX_CHARS;
 
 	for (const msg of messages) {
 		if (msg.role === "user") {
@@ -218,7 +235,7 @@ export function serializeConversation(messages: Message[]): string {
 							.filter((c): c is { type: "text"; text: string } => c.type === "text")
 							.map((c) => c.text)
 							.join("");
-			if (content) parts.push(`**User said:** ${content}`);
+			if (content) parts.push(`**User said:** ${truncateForSummary(content, cap)}`);
 		} else if (msg.role === "assistant") {
 			const textParts: string[] = [];
 			const thinkingParts: string[] = [];
@@ -239,13 +256,13 @@ export function serializeConversation(messages: Message[]): string {
 			}
 
 			if (thinkingParts.length > 0) {
-				parts.push(`**Assistant thinking:** ${thinkingParts.join("\n")}`);
+				parts.push(`**Assistant thinking:** ${truncateForSummary(thinkingParts.join("\n"), cap)}`);
 			}
 			if (textParts.length > 0) {
-				parts.push(`**Assistant responded:** ${textParts.join("\n")}`);
+				parts.push(`**Assistant responded:** ${truncateForSummary(textParts.join("\n"), cap)}`);
 			}
 			if (toolCalls.length > 0) {
-				parts.push(`**Assistant tool calls:** ${toolCalls.join("; ")}`);
+				parts.push(`**Assistant tool calls:** ${truncateForSummary(toolCalls.join("; "), cap)}`);
 			}
 		} else if (msg.role === "toolResult") {
 			const content = msg.content
@@ -253,12 +270,93 @@ export function serializeConversation(messages: Message[]): string {
 				.map((c) => c.text)
 				.join("");
 			if (content) {
-				parts.push(`**Tool result:** ${truncateForSummary(content, TOOL_RESULT_MAX_CHARS)}`);
+				parts.push(`**Tool result:** ${truncateForSummary(content, cap)}`);
 			}
 		}
 	}
 
 	return parts.join("\n\n");
+}
+
+// ============================================================================
+// Token estimation for post-serialization size
+// ============================================================================
+
+/**
+ * Estimate tokens for a message AFTER the summarization serializer will have
+ * capped its large content blocks. Use this when deciding chunk sizes for
+ * summarization — NOT when deciding whether to compact in the first place
+ * (that needs the real in-memory content size via `estimateTokens`).
+ *
+ * See issue #4665: the old chunker used real content size but the serializer
+ * truncated tool results to 2000 chars, so a single 400K-char tool result
+ * looked like 100K tokens (triggering tens of unnecessary chunks) but actually
+ * serialized to ~600 tokens.
+ *
+ * Colocated with `truncateForSummary` / `serializeConversation` so the two
+ * stay in sync — if the serialization cap changes, both functions pick it up
+ * from `TOOL_RESULT_MAX_CHARS`.
+ */
+export function estimateSerializedTokens(message: AgentMessage): number {
+	const cap = TOOL_RESULT_MAX_CHARS;
+	const capLen = (len: number) => Math.min(len, cap);
+	let chars = 0;
+
+	switch (message.role) {
+		case "user": {
+			const content = (message as { content: string | Array<{ type: string; text?: string }> }).content;
+			if (typeof content === "string") {
+				chars = capLen(content.length);
+			} else if (Array.isArray(content)) {
+				let total = 0;
+				for (const block of content) {
+					if (block.type === "text" && block.text) total += block.text.length;
+				}
+				chars = capLen(total);
+			}
+			return Math.ceil(chars / 4);
+		}
+		case "assistant": {
+			const assistant = message as AssistantMessage;
+			let textLen = 0;
+			let thinkingLen = 0;
+			let toolCallsLen = 0;
+			for (const block of assistant.content) {
+				if (block.type === "text") textLen += block.text.length;
+				else if (block.type === "thinking") thinkingLen += block.thinking.length;
+				else if (block.type === "toolCall") toolCallsLen += block.name.length + JSON.stringify(block.arguments).length;
+			}
+			chars = capLen(textLen) + capLen(thinkingLen) + capLen(toolCallsLen);
+			return Math.ceil(chars / 4);
+		}
+		case "custom":
+		case "toolResult": {
+			if (typeof message.content === "string") {
+				chars = capLen(message.content.length);
+			} else {
+				let textLen = 0;
+				let imageChars = 0;
+				for (const block of message.content) {
+					if (block.type === "text" && block.text) textLen += block.text.length;
+					if (block.type === "image") imageChars += 4800;
+				}
+				chars = capLen(textLen) + imageChars;
+			}
+			return Math.ceil(chars / 4);
+		}
+		case "bashExecution": {
+			chars = capLen(message.command.length + message.output.length);
+			return Math.ceil(chars / 4);
+		}
+		case "branchSummary":
+		case "compactionSummary": {
+			// Summary messages are already concise; don't truncate them.
+			chars = message.summary.length;
+			return Math.ceil(chars / 4);
+		}
+	}
+
+	return 0;
 }
 
 // ============================================================================


### PR DESCRIPTION
## TL;DR

**What:** Fix the three compounding bugs in the compaction pipeline that produced "The user asked me to summarize an empty conversation" on sessions with large tool outputs.
**Why:** Users lost all session context after compaction — the summarizer received truncated fragments lacking enough signal, and the iterative chain propagated the degenerate first-chunk summary through every subsequent chunk.
**How:** Make the chunker's token estimate match what the serializer actually sends, keep the tail of truncated content (not just the head), and add a guard that prevents degenerate chunk summaries from poisoning the `UPDATE_SUMMARIZATION_PROMPT` chain.

## What

Three files changed in `packages/pi-coding-agent/src/core/compaction/`:

### `utils.ts`
- `truncateForSummary` now keeps **head + tail** with an elision marker between (previously head-only). Tool output puts results/verdicts/exit codes at the tail — head-only truncation discarded the signal.
- Broadened the per-block cap inside `serializeConversation` to **every content type**: user content, assistant text/thinking, tool-call args, tool results. Pre-fix, only tool results were capped, so a large user paste could still bloat the summarization input and chunker math.
- Added `estimateSerializedTokens(message)` — colocated with the serializer so the cap policy stays in sync. Counts post-truncation characters.

### `compaction.ts`
- `chunkMessages` and `generateSummary`'s total-fits-in-one-pass check now use `estimateSerializedTokens`. A 400K-char tool result no longer looks like 100K tokens when the serializer will only send ~600.
- `estimateContextTokens` and the "should we compact?" trigger path **keep the real-content `estimateTokens`** so the compaction trigger remains accurate. Scoping this split was the trickiest part of the fix.
- Added `isDegenerateSummary` detector (conservative substring match + length < 100 chars) and a chunk-loop guard:
  - Degenerate chunk outputs are not propagated forward as `runningSummary`.
  - A degenerate **first** chunk triggers one retry with the initial prompt (clearing `runningSummary` so it uses `SUMMARIZATION_PROMPT` instead of `UPDATE_SUMMARIZATION_PROMPT`) before skipping.

## Why

Closes #4665.

Three compounding root causes, confirmed in the live code:

1. **Token estimation vs serialization mismatch.** `chunkMessages` (`compaction.ts:498`) called `estimateTokens` which counts `content.length / 4` on full content. But `serializeConversation` (`utils.ts:209`) truncates every tool result to `TOOL_RESULT_MAX_CHARS = 2000`. A single 400K-char tool result estimated at 100K tokens but actually serialized to ~600 tokens. The chunker over-split into many tiny information-starved chunks.

2. **Head-only truncation.** `truncateForSummary` at `utils.ts:195` used `text.slice(0, maxChars)`, discarding the tail where test run verdicts, pass/fail counts, exit codes, and commit hashes live.

3. **Empty first chunk poisons the chain.** `compaction.ts:569-580` passes `runningSummary` forward. At `compaction.ts:601`, `UPDATE_SUMMARIZATION_PROMPT` is selected when `previousSummary` is truthy — and that prompt explicitly says "PRESERVE all existing information". If chunk 0 produced a degenerate "empty conversation" summary, every subsequent chunk preserved nothing.

### Scope constraint that shaped the fix

`estimateTokens` has **two distinct semantic callers** (surfaced during investigation, confirmed by peer review):

| Caller | Purpose | Needs |
|---|---|---|
| `estimateContextTokens` (compaction.ts:161,174) / branch-summarization budget | "Should we compact?" / "Does this message fit our in-memory budget?" | **Real** content size |
| `chunkMessages` / `generateSummary` total | "Will this fit in one summarization pass?" | **Post-truncation** size |

Naively making `estimateTokens` always post-truncation would delay compaction firing — the agent would think context is smaller than it really is. The fix adds `estimateSerializedTokens` and routes only the summarization-pipeline callers through it.

## How

### Truncation — head + tail

```ts
export function truncateForSummary(text: string, maxChars: number): string {
    if (text.length <= maxChars) return text;
    const half = Math.floor(maxChars / 2);
    const head = text.slice(0, half);
    const tail = text.slice(text.length - half);
    const truncatedChars = text.length - (head.length + tail.length);
    return `${head}\n\n[... ${truncatedChars} more characters truncated ...]\n\n${tail}`;
}
```

### Chunker — post-truncation estimator

`chunkMessages` and `generateSummary`'s total check now call `estimateSerializedTokens(msg)` which applies the 2000-char cap to `toolResult`, user content, assistant text/thinking, tool-call args, and bashExecution output before counting.

### Iterative chain — two-part guard

```ts
if (isDegenerateSummary(chunkSummary)) {
    if (i === 0 && runningSummary === undefined) {
        // First chunk, no prior context — retry once with the initial prompt
        const retry = await singlePassSummary(chunks[i], ...., undefined, complete);
        if (!isDegenerateSummary(retry)) {
            runningSummary = retry;
            continue;
        }
    }
    continue;  // don't poison runningSummary
}
runningSummary = chunkSummary;
```

## Validation

- `npx tsc --noEmit -p tsconfig.json` — clean
- `npm run verify:workspace-coverage` — 7/7 packages covered
- `node --test packages/pi-coding-agent/dist/core/compaction/*.test.js packages/pi-coding-agent/dist/core/compaction-utils.test.js` — **17/17 pass**, including all new regression tests:
  - `truncateForSummary` keeps both head AND tail with result markers
  - `truncateForSummary` no-op when input within cap
  - `serializeConversation` caps every content type, not just tool results
  - `chunkMessages` does not over-split when tool results dominate
  - `estimateSerializedTokens` caps toolResult, user content, assistant thinking
  - `isDegenerateSummary` detects known failure patterns
  - Iterative chain does not propagate degenerate first-chunk summary
  - First-chunk retry produces non-degenerate final summary

Existing `chunkMessages` and `generateSummary` tests were updated to use `branchSummary` messages (intentionally not capped by the serializer) where they need to actually trigger chunking — user-message-based tests coalesce correctly under the new estimator, which is the point.

## Follow-on (not this PR)

Surfaced during investigation, filed as future work:

- `convertToLlm` (`messages.ts:154-221`) wraps `bashExecution`, `custom`, `branchSummary`, `compactionSummary` with additional markup, and `estimateTokens` counts pre-conversion shapes. A small secondary token-count discrepancy exists here. Does not block this fix.

## Change type checklist

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests (tests are part of the fix)
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Notes for reviewers

- **AI-assisted:** drafted with AI assistance. Peer-reviewed via codex for scope and approach. I can explain every line.
- **Deterministic degenerate detector** (conservative substring match + length threshold) — not fuzzy scoring. Keeps the guard testable.
- **Scope discipline:** the `estimateTokens` split is surgical. Every caller was traced and routed correctly. No test filter layer; no prompt rewording; no scope creep into `messages.ts` or other summarization sites.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for conversation compaction failures with clearer messaging and session history preservation.
  * Added safeguards to prevent empty or low-quality summaries during automatic conversation compaction.

* **Improvements**
  * Enhanced message truncation to intelligently preserve both the beginning and end of long messages.
  * Improved accuracy of message size estimation for better conversation management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->