### PR TITLE
feat(ADR-006): revive v1.3 foundation & install infrastructure on current main

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,10 +22,8 @@
         "@mariozechner/jiti": "^2.6.2",
         "@mistralai/mistralai": "^1.14.1",
         "@modelcontextprotocol/sdk": "^1.27.1",
-        "@octokit/rest": "^22.0.1",
         "@silvia-odwyer/photon-node": "^0.3.4",
         "@sinclair/typebox": "^0.34.41",
-        "@types/mime-types": "^2.1.4",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "chalk": "^5.6.2",
@@ -33,12 +31,10 @@
         "diff": "^8.0.2",
         "extract-zip": "^2.0.1",
         "file-type": "^21.1.1",
-        "get-east-asian-width": "^1.3.0",
         "glob": "^13.0.1",
         "hosted-git-info": "^9.0.2",
         "ignore": "^7.0.5",
         "marked": "^15.0.12",
-        "mime-types": "^3.0.1",
         "minimatch": "^10.2.3",
         "openai": "^6.26.0",
         "picomatch": "^4.0.3",
@@ -50,8 +46,7 @@
         "sql.js": "^1.14.1",
         "strip-ansi": "^7.1.0",
         "undici": "^7.24.2",
-        "yaml": "^2.8.2",
-        "zod-to-json-schema": "^3.24.6"
+        "yaml": "^2.8.2"
       },
       "bin": {
         "gsd": "dist/loader.js",
@@ -61,6 +56,7 @@
       "devDependencies": {
         "@types/node": "^24.12.0",
         "@types/picomatch": "^4.0.2",
+        "@types/semver": "^7.7.1",
         "c8": "^11.0.0",
         "esbuild": "^0.25.12",
         "jiti": "^2.6.1",
@@ -2602,161 +2598,6 @@
         }
       }
     },
-    "node_modules/@octokit/auth-token": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-6.0.0.tgz",
-      "integrity": "sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@octokit/core": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.6.tgz",
-      "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/auth-token": "^6.0.0",
-        "@octokit/graphql": "^9.0.3",
-        "@octokit/request": "^10.0.6",
-        "@octokit/request-error": "^7.0.2",
-        "@octokit/types": "^16.0.0",
-        "before-after-hook": "^4.0.0",
-        "universal-user-agent": "^7.0.0"
-      },
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@octokit/endpoint": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-11.0.3.tgz",
-      "integrity": "sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag==",
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/types": "^16.0.0",
-        "universal-user-agent": "^7.0.2"
-      },
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@octokit/graphql": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-9.0.3.tgz",
-      "integrity": "sha512-grAEuupr/C1rALFnXTv6ZQhFuL1D8G5y8CN04RgrO4FIPMrtm+mcZzFG7dcBm+nq+1ppNixu+Jd78aeJOYxlGA==",
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/request": "^10.0.6",
-        "@octokit/types": "^16.0.0",
-        "universal-user-agent": "^7.0.0"
-      },
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@octokit/openapi-types": {
-      "version": "27.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-27.0.0.tgz",
-      "integrity": "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==",
-      "license": "MIT"
-    },
-    "node_modules/@octokit/plugin-paginate-rest": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-14.0.0.tgz",
-      "integrity": "sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw==",
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/types": "^16.0.0"
-      },
-      "engines": {
-        "node": ">= 20"
-      },
-      "peerDependencies": {
-        "@octokit/core": ">=6"
-      }
-    },
-    "node_modules/@octokit/plugin-request-log": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-6.0.0.tgz",
-      "integrity": "sha512-UkOzeEN3W91/eBq9sPZNQ7sUBvYCqYbrrD8gTbBuGtHEuycE4/awMXcYvx6sVYo7LypPhmQwwpUe4Yyu4QZN5Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 20"
-      },
-      "peerDependencies": {
-        "@octokit/core": ">=6"
-      }
-    },
-    "node_modules/@octokit/plugin-rest-endpoint-methods": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-17.0.0.tgz",
-      "integrity": "sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw==",
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/types": "^16.0.0"
-      },
-      "engines": {
-        "node": ">= 20"
-      },
-      "peerDependencies": {
-        "@octokit/core": ">=6"
-      }
-    },
-    "node_modules/@octokit/request": {
-      "version": "10.0.8",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.8.tgz",
-      "integrity": "sha512-SJZNwY9pur9Agf7l87ywFi14W+Hd9Jg6Ifivsd33+/bGUQIjNujdFiXII2/qSlN2ybqUHfp5xpekMEjIBTjlSw==",
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/endpoint": "^11.0.3",
-        "@octokit/request-error": "^7.0.2",
-        "@octokit/types": "^16.0.0",
-        "fast-content-type-parse": "^3.0.0",
-        "json-with-bigint": "^3.5.3",
-        "universal-user-agent": "^7.0.2"
-      },
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@octokit/request-error": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-7.1.0.tgz",
-      "integrity": "sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw==",
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/types": "^16.0.0"
-      },
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@octokit/rest": {
-      "version": "22.0.1",
-      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-22.0.1.tgz",
-      "integrity": "sha512-Jzbhzl3CEexhnivb1iQ0KJ7s5vvjMWcmRtq5aUsKmKDrRW6z3r84ngmiFKFvpZjpiU/9/S6ITPFRpn5s/3uQJw==",
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/core": "^7.0.6",
-        "@octokit/plugin-paginate-rest": "^14.0.0",
-        "@octokit/plugin-request-log": "^6.0.0",
-        "@octokit/plugin-rest-endpoint-methods": "^17.0.0"
-      },
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@octokit/types": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-16.0.0.tgz",
-      "integrity": "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==",
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/openapi-types": "^27.0.0"
-      }
-    },
     "node_modules/@phosphor-icons/react": {
       "version": "2.1.10",
       "resolved": "https://registry.npmjs.org/@phosphor-icons/react/-/react-2.1.10.tgz",
@@ -4340,6 +4181,7 @@
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@types/mime-types/-/mime-types-2.1.4.tgz",
       "integrity": "sha512-lfU4b34HOri+kAY5UheuFMWPDOI+OPceBSHZKp69gEyTL/mmJ4cnU6Y/rlme3UL3GyOn6Y42hyIEw0/q8sWx5w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -4402,6 +4244,13 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
       "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/sql.js": {
@@ -4610,12 +4459,6 @@
       "engines": {
         "node": ">=10.0.0"
       }
-    },
-    "node_modules/before-after-hook": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-4.0.0.tgz",
-      "integrity": "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==",
-      "license": "Apache-2.0"
     },
     "node_modules/bignumber.js": {
       "version": "9.3.1",
@@ -5651,22 +5494,6 @@
         "@types/yauzl": "^2.9.1"
       }
     },
-    "node_modules/fast-content-type-parse": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-3.0.0.tgz",
-      "integrity": "sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -6561,12 +6388,6 @@
       "dev": true,
       "license": "ISC",
       "optional": true
-    },
-    "node_modules/json-with-bigint": {
-      "version": "3.5.7",
-      "resolved": "https://registry.npmjs.org/json-with-bigint/-/json-with-bigint-3.5.7.tgz",
-      "integrity": "sha512-7ei3MdAI5+fJPVnKlW77TKNKwQ5ppSzWvhPuSuINT/GYW9ZOC1eRKOuhV9yHG5aEsUPj9BBx5JIekkmoLHxZOw==",
-      "license": "MIT"
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -8510,12 +8331,6 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "license": "MIT"
-    },
-    "node_modules/universal-user-agent": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
-      "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==",
-      "license": "ISC"
     },
     "node_modules/universalify": {
       "version": "0.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
         "playwright": "^1.58.2",
         "proper-lockfile": "^4.1.2",
         "proxy-agent": "^6.5.0",
+        "semver": "^7.7.4",
         "sharp": "^0.34.5",
         "sql.js": "^1.14.1",
         "strip-ansi": "^7.1.0",

--- a/package.json
+++ b/package.json
@@ -109,10 +109,8 @@
     "@mariozechner/jiti": "^2.6.2",
     "@mistralai/mistralai": "^1.14.1",
     "@modelcontextprotocol/sdk": "^1.27.1",
-    "@octokit/rest": "^22.0.1",
     "@silvia-odwyer/photon-node": "^0.3.4",
     "@sinclair/typebox": "^0.34.41",
-    "@types/mime-types": "^2.1.4",
     "ajv": "^8.17.1",
     "ajv-formats": "^3.0.1",
     "chalk": "^5.6.2",
@@ -120,12 +118,10 @@
     "diff": "^8.0.2",
     "extract-zip": "^2.0.1",
     "file-type": "^21.1.1",
-    "get-east-asian-width": "^1.3.0",
     "glob": "^13.0.1",
     "hosted-git-info": "^9.0.2",
     "ignore": "^7.0.5",
     "marked": "^15.0.12",
-    "mime-types": "^3.0.1",
     "minimatch": "^10.2.3",
     "openai": "^6.26.0",
     "picomatch": "^4.0.3",
@@ -136,8 +132,7 @@
     "sql.js": "^1.14.1",
     "strip-ansi": "^7.1.0",
     "undici": "^7.24.2",
-    "yaml": "^2.8.2",
-    "zod-to-json-schema": "^3.24.6"
+    "yaml": "^2.8.2"
   },
   "devDependencies": {
     "@types/node": "^24.12.0",

--- a/package.json
+++ b/package.json
@@ -138,6 +138,7 @@
   "devDependencies": {
     "@types/node": "^24.12.0",
     "@types/picomatch": "^4.0.2",
+    "@types/semver": "^7.7.1",
     "c8": "^11.0.0",
     "esbuild": "^0.25.12",
     "jiti": "^2.6.1",

--- a/package.json
+++ b/package.json
@@ -128,6 +128,7 @@
     "playwright": "^1.58.2",
     "proper-lockfile": "^4.1.2",
     "proxy-agent": "^6.5.0",
+    "semver": "^7.7.4",
     "sharp": "^0.34.5",
     "sql.js": "^1.14.1",
     "strip-ansi": "^7.1.0",

--- a/packages/pi-coding-agent/src/core/extensions/extension-discovery.ts
+++ b/packages/pi-coding-agent/src/core/extensions/extension-discovery.ts
@@ -1,0 +1,119 @@
+import { existsSync, readFileSync, readdirSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+import { readManifest, readManifestFromEntryPath } from './extension-registry.js'
+
+function isExtensionFile(name: string): boolean {
+  return name.endsWith('.ts') || name.endsWith('.js')
+}
+
+/**
+ * Resolves the entry-point file(s) for a single extension directory.
+ *
+ * 1. If the directory contains a package.json with a `pi` manifest object,
+ *    the manifest is authoritative:
+ *    - `pi.extensions` array → resolve each entry relative to the directory.
+ *    - `pi: {}` (no extensions) → return empty (library opt-out, e.g. cmux).
+ * 2. Only when no `pi` manifest exists does it fall back to `index.ts` → `index.js`.
+ */
+export function resolveExtensionEntries(dir: string): string[] {
+  const packageJsonPath = join(dir, 'package.json')
+  if (existsSync(packageJsonPath)) {
+    try {
+      const pkg = JSON.parse(readFileSync(packageJsonPath, 'utf-8'))
+      if (pkg?.pi && typeof pkg.pi === 'object') {
+        // When a pi manifest exists, it is authoritative — don't fall through
+        // to index.ts/index.js auto-detection. This allows library directories
+        // (like cmux) to opt out by declaring "pi": {} with no extensions.
+        const declared = pkg.pi.extensions
+        if (!Array.isArray(declared) || declared.length === 0) {
+          return []
+        }
+        return declared
+          .filter((entry: unknown): entry is string => typeof entry === 'string')
+          .map((entry: string) => resolve(dir, entry))
+          .filter((entry: string) => existsSync(entry))
+      }
+    } catch {
+      // Ignore malformed manifests and fall back to index.ts/index.js discovery.
+    }
+  }
+
+  const indexTs = join(dir, 'index.ts')
+  if (existsSync(indexTs)) {
+    return [indexTs]
+  }
+
+  const indexJs = join(dir, 'index.js')
+  if (existsSync(indexJs)) {
+    return [indexJs]
+  }
+
+  return []
+}
+
+/**
+ * Discovers all extension entry-point paths under an extensions directory.
+ *
+ * - Top-level .ts/.js files are treated as standalone extension entry points.
+ * - Subdirectories are resolved via `resolveExtensionEntries()` (package.json →
+ *   pi.extensions, then index.ts/index.js fallback).
+ */
+export function discoverExtensionEntryPaths(extensionsDir: string): string[] {
+  if (!existsSync(extensionsDir)) {
+    return []
+  }
+
+  const discovered: string[] = []
+  for (const entry of readdirSync(extensionsDir, { withFileTypes: true })) {
+    const entryPath = join(extensionsDir, entry.name)
+
+    if ((entry.isFile() || entry.isSymbolicLink()) && isExtensionFile(entry.name)) {
+      discovered.push(entryPath)
+      continue
+    }
+
+    if (entry.isDirectory() || entry.isSymbolicLink()) {
+      discovered.push(...resolveExtensionEntries(entryPath))
+    }
+  }
+
+  return discovered
+}
+
+/**
+ * Merge bundled and installed extension entry paths.
+ * Installed extensions with the same manifest ID as a bundled extension take precedence (D-14).
+ * Loader stays dumb — receives a pre-merged path list (D-15).
+ */
+export function mergeExtensionEntryPaths(bundledPaths: string[], installedExtDir: string): string[] {
+  if (!existsSync(installedExtDir)) return bundledPaths
+
+  // Build map: manifest ID → entry paths for installed extensions
+  const installedById = new Map<string, string[]>()
+  for (const entry of readdirSync(installedExtDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue
+    const dir = join(installedExtDir, entry.name)
+    const manifest = readManifest(dir)
+    const entries = resolveExtensionEntries(dir)
+    if (manifest && entries.length > 0) {
+      installedById.set(manifest.id, entries)
+    }
+  }
+
+  if (installedById.size === 0) return bundledPaths
+
+  // Filter bundled paths: skip any whose manifest id is shadowed by installed
+  const merged: string[] = []
+  for (const entryPath of bundledPaths) {
+    const manifest = readManifestFromEntryPath(entryPath)
+    if (manifest && installedById.has(manifest.id)) continue // shadowed by installed
+    merged.push(entryPath)
+  }
+
+  // Append all installed entries
+  for (const entries of installedById.values()) {
+    merged.push(...entries)
+  }
+
+  return merged
+}

--- a/packages/pi-coding-agent/src/core/extensions/extension-registry.ts
+++ b/packages/pi-coding-agent/src/core/extensions/extension-registry.ts
@@ -1,0 +1,222 @@
+/**
+ * Extension Registry — manages manifest reading, registry persistence, and enable/disable state.
+ *
+ * Extensions without manifests always load (backwards compatible).
+ * A fresh install has an empty registry — all extensions enabled by default.
+ * The only way an extension stops loading is an explicit `gsd extensions disable <id>`.
+ */
+
+import { existsSync, mkdirSync, readFileSync, readdirSync, renameSync, writeFileSync } from "node:fs";
+import { getAgentDir } from "../../config.js";
+import { dirname, join } from "node:path";
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+export interface ExtensionManifest {
+  id: string;
+  name: string;
+  version: string;
+  description: string;
+  tier: "core" | "bundled" | "community";
+  requires: { platform: string };
+  provides?: {
+    tools?: string[];
+    commands?: string[];
+    hooks?: string[];
+    shortcuts?: string[];
+  };
+  dependencies?: {
+    extensions?: string[];
+    runtime?: string[];
+  };
+}
+
+export interface ExtensionRegistryEntry {
+  id: string;
+  enabled: boolean;
+  source: "bundled" | "user" | "project";
+  disabledAt?: string;
+  disabledReason?: string;
+  version?: string;           // From manifest, used for semver comparison
+  installedFrom?: string;     // Original specifier: npm package name, git URL, or local path
+  installType?: "npm" | "git" | "local";  // Explicit source type
+}
+
+export interface ExtensionRegistry {
+  version: 1;
+  entries: Record<string, ExtensionRegistryEntry>;
+}
+
+// ─── Validation ─────────────────────────────────────────────────────────────
+
+function isRegistry(data: unknown): data is ExtensionRegistry {
+  if (typeof data !== "object" || data === null) return false;
+  const obj = data as Record<string, unknown>;
+  return obj.version === 1 && typeof obj.entries === "object" && obj.entries !== null;
+}
+
+function isManifest(data: unknown): data is ExtensionManifest {
+  if (typeof data !== "object" || data === null) return false;
+  const obj = data as Record<string, unknown>;
+  return (
+    typeof obj.id === "string" &&
+    typeof obj.name === "string" &&
+    typeof obj.version === "string" &&
+    typeof obj.tier === "string"
+  );
+}
+
+// ─── Registry Path ──────────────────────────────────────────────────────────
+
+export function getRegistryPath(): string {
+  return join(dirname(getAgentDir()), "extensions", "registry.json");
+}
+
+// ─── Registry I/O ───────────────────────────────────────────────────────────
+
+function defaultRegistry(): ExtensionRegistry {
+  return { version: 1, entries: {} };
+}
+
+export function loadRegistry(): ExtensionRegistry {
+  const filePath = getRegistryPath();
+  try {
+    if (!existsSync(filePath)) return defaultRegistry();
+    const raw = readFileSync(filePath, "utf-8");
+    const parsed = JSON.parse(raw);
+    return isRegistry(parsed) ? parsed : defaultRegistry();
+  } catch {
+    return defaultRegistry();
+  }
+}
+
+export function saveRegistry(registry: ExtensionRegistry): void {
+  const filePath = getRegistryPath();
+  try {
+    mkdirSync(dirname(filePath), { recursive: true });
+    const tmp = filePath + ".tmp";
+    writeFileSync(tmp, JSON.stringify(registry, null, 2), "utf-8");
+    renameSync(tmp, filePath);
+  } catch {
+    // Non-fatal — don't let persistence failures break operation
+  }
+}
+
+// ─── Query ──────────────────────────────────────────────────────────────────
+
+/** Returns true if the extension is enabled (missing entries default to enabled). */
+export function isExtensionEnabled(registry: ExtensionRegistry, id: string): boolean {
+  const entry = registry.entries[id];
+  if (!entry) return true;
+  return entry.enabled;
+}
+
+// ─── Mutations ──────────────────────────────────────────────────────────────
+
+export function enableExtension(registry: ExtensionRegistry, id: string): void {
+  const entry = registry.entries[id];
+  if (entry) {
+    entry.enabled = true;
+    delete entry.disabledAt;
+    delete entry.disabledReason;
+  } else {
+    registry.entries[id] = { id, enabled: true, source: "bundled" };
+  }
+}
+
+/**
+ * Disable an extension. Returns an error string if the extension is core (cannot disable),
+ * or null on success.
+ */
+export function disableExtension(
+  registry: ExtensionRegistry,
+  id: string,
+  manifest: ExtensionManifest | null,
+  reason?: string,
+): string | null {
+  if (manifest?.tier === "core") {
+    return `Cannot disable "${id}" — it is a core extension.`;
+  }
+  const entry = registry.entries[id];
+  if (entry) {
+    entry.enabled = false;
+    entry.disabledAt = new Date().toISOString();
+    entry.disabledReason = reason;
+  } else {
+    registry.entries[id] = {
+      id,
+      enabled: false,
+      source: "bundled",
+      disabledAt: new Date().toISOString(),
+      disabledReason: reason,
+    };
+  }
+  return null;
+}
+
+// ─── Manifest Reading ───────────────────────────────────────────────────────
+
+/** Read extension-manifest.json from a directory. Returns null if missing or invalid. */
+export function readManifest(extensionDir: string): ExtensionManifest | null {
+  const manifestPath = join(extensionDir, "extension-manifest.json");
+  if (!existsSync(manifestPath)) return null;
+  try {
+    const raw = JSON.parse(readFileSync(manifestPath, "utf-8"));
+    return isManifest(raw) ? raw : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Given an entry path (e.g. `.../extensions/browser-tools/index.ts`),
+ * resolve the parent directory and read its manifest.
+ */
+export function readManifestFromEntryPath(entryPath: string): ExtensionManifest | null {
+  const dir = dirname(entryPath);
+  return readManifest(dir);
+}
+
+// ─── Discovery ──────────────────────────────────────────────────────────────
+
+/** Scan all subdirectories of extensionsDir for manifests. Returns a Map<id, manifest>. */
+export function discoverAllManifests(extensionsDir: string): Map<string, ExtensionManifest> {
+  const manifests = new Map<string, ExtensionManifest>();
+  if (!existsSync(extensionsDir)) return manifests;
+
+  for (const entry of readdirSync(extensionsDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const manifest = readManifest(join(extensionsDir, entry.name));
+    if (manifest) {
+      manifests.set(manifest.id, manifest);
+    }
+  }
+  return manifests;
+}
+
+/**
+ * Auto-populate registry entries for newly discovered extensions.
+ * Extensions already in the registry are left untouched.
+ */
+export function ensureRegistryEntries(extensionsDir: string): void {
+  const manifests = discoverAllManifests(extensionsDir);
+  if (manifests.size === 0) return;
+
+  const registry = loadRegistry();
+  let changed = false;
+
+  for (const [id, manifest] of manifests) {
+    if (!registry.entries[id]) {
+      registry.entries[id] = {
+        id,
+        enabled: true,
+        source: "bundled",
+      };
+      changed = true;
+    }
+  }
+
+  if (changed) {
+    saveRegistry(registry);
+  }
+}

--- a/packages/pi-coding-agent/src/core/extensions/loader.ts
+++ b/packages/pi-coding-agent/src/core/extensions/loader.ts
@@ -39,6 +39,7 @@ import { execCommand } from "../exec.js";
 import { getUntrustedExtensionPaths } from "./project-trust.js";
 export { isProjectTrusted, trustProject, getUntrustedExtensionPaths } from "./project-trust.js";
 import { registerToolCompatibility } from "../tools/tool-compatibility-registry.js";
+import { mergeExtensionEntryPaths } from "../../../../../src/extension-discovery.js";
 import type {
 	Extension,
 	ExtensionAPI,
@@ -1034,7 +1035,12 @@ export async function discoverAndLoadExtensions(
 
 	// 2. Global extensions: agentDir/extensions/
 	const globalExtDir = path.join(agentDir, "extensions");
-	addPaths(discoverExtensionsInDir(globalExtDir));
+	// 2b. Installed extensions: ~/.gsd/extensions/ merged with bundled (D-14, D-15)
+	// Discovery handles ID-based merge — loader stays dumb.
+	const installedExtDir = path.join(path.dirname(agentDir), "extensions");
+	const globalPaths = discoverExtensionsInDir(globalExtDir);
+	const mergedPaths = mergeExtensionEntryPaths(globalPaths, installedExtDir);
+	addPaths(mergedPaths);
 
 	// 3. Explicitly configured paths
 	for (const p of configuredPaths) {

--- a/packages/pi-coding-agent/src/core/extensions/loader.ts
+++ b/packages/pi-coding-agent/src/core/extensions/loader.ts
@@ -39,8 +39,8 @@ import { execCommand } from "../exec.js";
 import { getUntrustedExtensionPaths } from "./project-trust.js";
 export { isProjectTrusted, trustProject, getUntrustedExtensionPaths } from "./project-trust.js";
 import { registerToolCompatibility } from "../tools/tool-compatibility-registry.js";
-import { mergeExtensionEntryPaths } from "../../../../../src/extension-discovery.js";
-import { sortExtensionPaths } from "../../../../../src/extension-sort.js";
+import { mergeExtensionEntryPaths } from "./extension-discovery.js";
+import { sortExtensionPaths } from "./extension-sort.js";
 import type {
 	Extension,
 	ExtensionAPI,

--- a/packages/pi-coding-agent/src/core/extensions/loader.ts
+++ b/packages/pi-coding-agent/src/core/extensions/loader.ts
@@ -849,24 +849,21 @@ export async function loadExtensionFromFactory(
 /**
  * Load extensions from paths.
  *
- * Extensions are loaded in parallel to reduce wall-clock time (~30-50% faster
- * than sequential loading for I/O-bound jiti compilation).
+ * Paths are expected to be topologically sorted by caller (see sortExtensionPaths).
+ * Factories are awaited sequentially so a dependency's factory fully initializes
+ * (registers tools, commands, hooks on `pi`) before any dependent's factory runs.
  */
 export async function loadExtensions(paths: string[], cwd: string, eventBus?: EventBus): Promise<LoadExtensionsResult> {
 	const resolvedEventBus = eventBus ?? createEventBus();
 	const runtime = createExtensionRuntime();
 
-	const results = await Promise.all(
-		paths.map((extPath) => loadExtension(extPath, cwd, resolvedEventBus, runtime)),
-	);
-
 	const extensions: Extension[] = [];
 	const errors: Array<{ path: string; error: string }> = [];
 
-	for (let i = 0; i < results.length; i++) {
-		const { extension, error } = results[i];
+	for (const extPath of paths) {
+		const { extension, error } = await loadExtension(extPath, cwd, resolvedEventBus, runtime);
 		if (error) {
-			errors.push({ path: paths[i], error });
+			errors.push({ path: extPath, error });
 		} else if (extension) {
 			extensions.push(extension);
 		}

--- a/packages/pi-coding-agent/src/core/extensions/loader.ts
+++ b/packages/pi-coding-agent/src/core/extensions/loader.ts
@@ -40,6 +40,7 @@ import { getUntrustedExtensionPaths } from "./project-trust.js";
 export { isProjectTrusted, trustProject, getUntrustedExtensionPaths } from "./project-trust.js";
 import { registerToolCompatibility } from "../tools/tool-compatibility-registry.js";
 import { mergeExtensionEntryPaths } from "../../../../../src/extension-discovery.js";
+import { sortExtensionPaths } from "../../../../../src/extension-sort.js";
 import type {
 	Extension,
 	ExtensionAPI,
@@ -874,6 +875,7 @@ export async function loadExtensions(paths: string[], cwd: string, eventBus?: Ev
 	return {
 		extensions,
 		errors,
+		warnings: [],
 		runtime,
 	};
 }
@@ -1060,5 +1062,13 @@ export async function discoverAndLoadExtensions(
 		addPaths([resolved]);
 	}
 
-	return loadExtensions(allPaths, cwd, eventBus);
+	// Topological sort: ensure declared dependencies load first (D-06, D-07)
+	const { sortedPaths, warnings: sortWarnings } = sortExtensionPaths(allPaths)
+	// Emit warnings to stderr immediately — loader runs before ctx.ui is ready (D-08)
+	for (const w of sortWarnings) {
+		process.stderr.write(`[gsd] ${w.message}\n`)
+	}
+	const result = await loadExtensions(sortedPaths, cwd, eventBus)
+	result.warnings.push(...sortWarnings)
+	return result
 }

--- a/packages/pi-coding-agent/src/core/extensions/types.ts
+++ b/packages/pi-coding-agent/src/core/extensions/types.ts
@@ -1783,10 +1783,18 @@ export interface Extension {
 	lifecycleHooks: LifecycleHookMap;
 }
 
+/** Warning from extension dependency sort (missing deps, cycles). */
+export interface ExtensionLoadWarning {
+	declaringId: string;
+	missingId: string;
+	message: string;
+}
+
 /** Result of loading extensions. */
 export interface LoadExtensionsResult {
 	extensions: Extension[];
 	errors: Array<{ path: string; error: string }>;
+	warnings: ExtensionLoadWarning[];
 	/** Shared runtime - actions are throwing stubs until runner.initialize() */
 	runtime: ExtensionRuntime;
 }

--- a/packages/pi-coding-agent/src/core/resource-loader.ts
+++ b/packages/pi-coding-agent/src/core/resource-loader.ts
@@ -242,7 +242,7 @@ export class DefaultResourceLoader implements ResourceLoader {
 		this.systemPromptOverride = options.systemPromptOverride;
 		this.appendSystemPromptOverride = options.appendSystemPromptOverride;
 
-		this.extensionsResult = { extensions: [], errors: [], runtime: createExtensionRuntime() };
+		this.extensionsResult = { extensions: [], errors: [], warnings: [], runtime: createExtensionRuntime() };
 		this.skills = [];
 		this.skillDiagnostics = [];
 		this.prompts = [];

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -99,6 +99,18 @@ function printExtensionErrors(errors: ReadonlyArray<{ error: string }>): void {
 }
 
 /**
+ * Print extension load warnings (non-fatal, e.g. missing declared deps from
+ * the topological sort). Complements printExtensionErrors — fatal errors go
+ * there, advisory warnings go here.
+ */
+function printExtensionWarnings(warnings: ReadonlyArray<{ message: string }> | undefined): void {
+  if (!warnings) return
+  for (const w of warnings) {
+    process.stderr.write(`[gsd] Extension warning: ${w.message}\n`)
+  }
+}
+
+/**
  * Re-apply the validated model to the session when `createAgentSession()`
  * reports that it had to use a fallback. Prevents silently overriding the
  * persisted model of resumed conversations (#3534).
@@ -568,6 +580,7 @@ if (isPrintMode) {
   validateConfiguredModel(modelRegistry, settingsManager)
   await reapplyValidatedModelOnFallback(session, modelRegistry, settingsManager, modelFallbackMessage)
   printExtensionErrors(extensionsResult.errors)
+  printExtensionWarnings(extensionsResult.warnings)
 
   // Apply --model override if specified
   if (cliFlags.model) {
@@ -723,6 +736,7 @@ markStartup('createAgentSession')
 validateConfiguredModel(modelRegistry, settingsManager)
 await reapplyValidatedModelOnFallback(session, modelRegistry, settingsManager, interactiveFallbackMsg)
 printExtensionErrors(extensionsResult.errors)
+printExtensionWarnings(extensionsResult.warnings)
 
 // Restore scoped models from settings on startup.
 // The upstream InteractiveMode reads enabledModels from settings when /scoped-models is opened,

--- a/src/extension-discovery.ts
+++ b/src/extension-discovery.ts
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync, readdirSync } from 'node:fs'
 import { join, resolve } from 'node:path'
+import { readManifest, readManifestFromEntryPath } from './extension-registry.js'
 
 function isExtensionFile(name: string): boolean {
   return name.endsWith('.ts') || name.endsWith('.js')
@@ -77,4 +78,42 @@ export function discoverExtensionEntryPaths(extensionsDir: string): string[] {
   }
 
   return discovered
+}
+
+/**
+ * Merge bundled and installed extension entry paths.
+ * Installed extensions with the same manifest ID as a bundled extension take precedence (D-14).
+ * Loader stays dumb — receives a pre-merged path list (D-15).
+ */
+export function mergeExtensionEntryPaths(bundledPaths: string[], installedExtDir: string): string[] {
+  if (!existsSync(installedExtDir)) return bundledPaths
+
+  // Build map: manifest ID → entry paths for installed extensions
+  const installedById = new Map<string, string[]>()
+  for (const entry of readdirSync(installedExtDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue
+    const dir = join(installedExtDir, entry.name)
+    const manifest = readManifest(dir)
+    const entries = resolveExtensionEntries(dir)
+    if (manifest && entries.length > 0) {
+      installedById.set(manifest.id, entries)
+    }
+  }
+
+  if (installedById.size === 0) return bundledPaths
+
+  // Filter bundled paths: skip any whose manifest id is shadowed by installed
+  const merged: string[] = []
+  for (const entryPath of bundledPaths) {
+    const manifest = readManifestFromEntryPath(entryPath)
+    if (manifest && installedById.has(manifest.id)) continue // shadowed by installed
+    merged.push(entryPath)
+  }
+
+  // Append all installed entries
+  for (const entries of installedById.values()) {
+    merged.push(...entries)
+  }
+
+  return merged
 }

--- a/src/extension-registry.ts
+++ b/src/extension-registry.ts
@@ -37,6 +37,9 @@ export interface ExtensionRegistryEntry {
   source: "bundled" | "user" | "project";
   disabledAt?: string;
   disabledReason?: string;
+  version?: string;           // From manifest, used for semver comparison
+  installedFrom?: string;     // Original specifier: npm package name, git URL, or local path
+  installType?: "npm" | "git" | "local";  // Explicit source type
 }
 
 export interface ExtensionRegistry {

--- a/src/extension-sort.ts
+++ b/src/extension-sort.ts
@@ -1,0 +1,135 @@
+// GSD-2 — Extension Sort: Topological dependency ordering
+// Copyright (c) 2026 Jeremy McSpadden <jeremy@fluxlabs.net>
+
+import { readManifestFromEntryPath } from './extension-registry.js'
+
+export interface SortWarning {
+  declaringId: string
+  missingId: string
+  message: string
+}
+
+export interface SortResult {
+  sortedPaths: string[]
+  warnings: SortWarning[]
+}
+
+/**
+ * Sort extension entry paths in topological dependency-first order using Kahn's BFS algorithm.
+ *
+ * - Extensions without manifests are prepended in input order.
+ * - Missing dependencies produce a structured warning but do not block loading.
+ * - Cycles produce warnings; cycle participants are appended alphabetically.
+ * - Self-dependencies are silently ignored.
+ */
+export function sortExtensionPaths(paths: string[]): SortResult {
+  const warnings: SortWarning[] = []
+  const pathsWithoutId: string[] = []
+  const idToPath = new Map<string, string>()
+
+  // Step 1: Build ID map
+  for (const path of paths) {
+    const manifest = readManifestFromEntryPath(path)
+    if (!manifest) {
+      pathsWithoutId.push(path)
+    } else {
+      idToPath.set(manifest.id, path)
+    }
+  }
+
+  // Step 2: Build graph — inDegree and dependents adjacency
+  const inDegree = new Map<string, number>()
+  const dependents = new Map<string, string[]>() // dep → [ids that depend on dep]
+
+  for (const id of idToPath.keys()) {
+    if (!inDegree.has(id)) inDegree.set(id, 0)
+    if (!dependents.has(id)) dependents.set(id, [])
+  }
+
+  for (const [id, path] of idToPath) {
+    const manifest = readManifestFromEntryPath(path)
+    const deps = manifest?.dependencies?.extensions ?? []
+
+    for (const depId of deps) {
+      // Silently ignore self-deps
+      if (depId === id) continue
+
+      if (!idToPath.has(depId)) {
+        // Missing dependency — warn and skip edge
+        warnings.push({
+          declaringId: id,
+          missingId: depId,
+          message: `Extension '${id}' declares dependency '${depId}' which is not installed — loading anyway`,
+        })
+        continue
+      }
+
+      // Valid edge: id depends on depId → increment inDegree[id], add id to dependents[depId]
+      inDegree.set(id, (inDegree.get(id) ?? 0) + 1)
+      const depDependents = dependents.get(depId) ?? []
+      depDependents.push(id)
+      dependents.set(depId, depDependents)
+    }
+  }
+
+  // Step 3: Kahn's algorithm — start with nodes that have inDegree 0
+  const sorted: string[] = []
+  // Ready queue: IDs with inDegree 0, maintained in alphabetical order
+  const ready: string[] = [...idToPath.keys()]
+    .filter(id => inDegree.get(id) === 0)
+    .sort()
+
+  while (ready.length > 0) {
+    const id = ready.shift()!
+    sorted.push(idToPath.get(id)!)
+
+    const deps = dependents.get(id) ?? []
+    for (const depId of deps) {
+      const newDegree = (inDegree.get(depId) ?? 0) - 1
+      inDegree.set(depId, newDegree)
+      if (newDegree === 0) {
+        // Insert into ready queue maintaining alphabetical order
+        const insertIdx = ready.findIndex(r => r > depId)
+        if (insertIdx === -1) {
+          ready.push(depId)
+        } else {
+          ready.splice(insertIdx, 0, depId)
+        }
+      }
+    }
+  }
+
+  // Step 4: Cycle handling — any remaining IDs with inDegree > 0
+  const cycleIds = [...idToPath.keys()]
+    .filter(id => (inDegree.get(id) ?? 0) > 0)
+    .sort()
+
+  if (cycleIds.length > 0) {
+    const cycleSet = new Set(cycleIds)
+
+    for (const id of cycleIds) {
+      const path = idToPath.get(id)!
+      const manifest = readManifestFromEntryPath(path)
+      const deps = manifest?.dependencies?.extensions ?? []
+
+      for (const depId of deps) {
+        if (depId === id) continue
+        if (!cycleSet.has(depId)) continue
+
+        // Both id and depId are in cycle — emit warning
+        warnings.push({
+          declaringId: id,
+          missingId: depId,
+          message: `Extension '${id}' and '${depId}' form a dependency cycle — loading both anyway (alphabetical order)`,
+        })
+      }
+
+      sorted.push(path)
+    }
+  }
+
+  return {
+    sortedPaths: [...pathsWithoutId, ...sorted],
+    warnings,
+  }
+}

--- a/src/extension-sort.ts
+++ b/src/extension-sort.ts
@@ -48,7 +48,8 @@ export function sortExtensionPaths(paths: string[]): SortResult {
 
   for (const [id, path] of idToPath) {
     const manifest = readManifestFromEntryPath(path)
-    const deps = manifest?.dependencies?.extensions ?? []
+    const rawDeps = manifest?.dependencies?.extensions ?? []
+    const deps = Array.isArray(rawDeps) ? rawDeps : []
 
     for (const depId of deps) {
       // Silently ignore self-deps
@@ -110,7 +111,8 @@ export function sortExtensionPaths(paths: string[]): SortResult {
     for (const id of cycleIds) {
       const path = idToPath.get(id)!
       const manifest = readManifestFromEntryPath(path)
-      const deps = manifest?.dependencies?.extensions ?? []
+      const rawDeps = manifest?.dependencies?.extensions ?? []
+      const deps = Array.isArray(rawDeps) ? rawDeps : []
 
       for (const depId of deps) {
         if (depId === id) continue

--- a/src/extension-validator.ts
+++ b/src/extension-validator.ts
@@ -1,0 +1,177 @@
+// GSD-2 — Extension Package Format Validator
+// Copyright (c) 2026 Jeremy McSpadden <jeremy@fluxlabs.net>
+
+/**
+ * Install-time validator for GSD extension packages. Called by the install command
+ * (Phase 8) before writing files. Not called on bundled extensions — they are
+ * discovered at load time, not installed.
+ */
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export interface ValidationError {
+  code: string;    // "MISSING_GSD_MARKER" | "RESERVED_NAMESPACE" | "WRONG_DEP_FIELD"
+  message: string; // Human-readable, actionable
+  field?: string;  // e.g. "dependencies", "gsd.extension"
+}
+
+export interface ValidationWarning {
+  code: string;
+  message: string;
+}
+
+export interface ValidationResult {
+  valid: boolean;      // ALWAYS derived as errors.length === 0
+  errors: ValidationError[];
+  warnings: ValidationWarning[];
+}
+
+export interface ValidationOptions {
+  allowGsdNamespace?: boolean;  // Per D-05: --allow-gsd-namespace flag pass-through
+  extensionId?: string;         // The manifest ID to check against gsd.* namespace (per D-04)
+}
+
+// ─── Individual Check Functions ───────────────────────────────────────────────
+
+/**
+ * Per D-03: Check that pkg.gsd.extension === true with STRICT equality (not truthiness).
+ * Packages without this marker are not recognized as GSD extensions.
+ */
+export function checkInstallDiscriminator(pkg: unknown): ValidationError | null {
+  if (typeof pkg !== 'object' || pkg === null) {
+    return {
+      code: 'MISSING_GSD_MARKER',
+      message: 'package.json must declare "gsd": { "extension": true } to be recognized as a GSD extension.',
+      field: 'gsd.extension',
+    }
+  }
+
+  const obj = pkg as Record<string, unknown>
+  const gsd = obj.gsd
+
+  if (typeof gsd !== 'object' || gsd === null) {
+    return {
+      code: 'MISSING_GSD_MARKER',
+      message: 'package.json must declare "gsd": { "extension": true } to be recognized as a GSD extension.',
+      field: 'gsd.extension',
+    }
+  }
+
+  const gsdObj = gsd as Record<string, unknown>
+  if (gsdObj.extension !== true) {
+    return {
+      code: 'MISSING_GSD_MARKER',
+      message: 'package.json must declare "gsd": { "extension": true } to be recognized as a GSD extension.',
+      field: 'gsd.extension',
+    }
+  }
+
+  return null
+}
+
+/**
+ * Per D-04/D-05: Check that the extension ID does not use the reserved gsd.* namespace,
+ * unless allowGsdNamespace is explicitly set to true.
+ * Per D-06: Only checks extension manifest ID — not pkg.name.
+ */
+export function checkNamespaceReservation(extensionId: string, opts: ValidationOptions): ValidationError | null {
+  if (opts.allowGsdNamespace === true) {
+    return null
+  }
+
+  if (extensionId.startsWith('gsd.')) {
+    return {
+      code: 'RESERVED_NAMESPACE',
+      message: `Extension ID "${extensionId}" is reserved for GSD core extensions. Use a different namespace for community extensions (e.g., "my-tool" or "acme.my-tool"). To override: pass --allow-gsd-namespace (maintainers only).`,
+      field: 'extensionId',
+    }
+  }
+
+  return null
+}
+
+/**
+ * Per D-07/D-08/D-09/D-10: Scan both `dependencies` and `devDependencies` for @gsd/* packages.
+ * peerDependencies is the correct placement and is NOT flagged.
+ * Returns an error per violation naming the exact field and package.
+ */
+export function checkDependencyPlacement(pkg: unknown): ValidationError[] {
+  const errors: ValidationError[] = []
+
+  if (typeof pkg !== 'object' || pkg === null) {
+    return errors
+  }
+
+  const obj = pkg as Record<string, unknown>
+
+  const fieldsToCheck: Array<{ field: string; reason: string }> = [
+    {
+      field: 'dependencies',
+      reason: 'Extensions must not bundle GSD host packages — the host provides them at runtime.',
+    },
+    {
+      field: 'devDependencies',
+      reason: 'GSD host packages are provided by the host at runtime; listing them in devDependencies misrepresents the runtime contract.',
+    },
+  ]
+
+  for (const { field, reason } of fieldsToCheck) {
+    const deps = obj[field]
+    if (typeof deps !== 'object' || deps === null) continue
+
+    const depsObj = deps as Record<string, unknown>
+    for (const pkgName of Object.keys(depsObj)) {
+      if (pkgName.startsWith('@gsd/')) {
+        errors.push({
+          code: 'WRONG_DEP_FIELD',
+          message: `"${pkgName}" must not appear in "${field}". Move it to "peerDependencies". ${reason}`,
+          field,
+        })
+      }
+    }
+  }
+
+  return errors
+}
+
+// ─── Composite Validation ─────────────────────────────────────────────────────
+
+/**
+ * Run all validation checks for a GSD extension package.json.
+ * - If opts.extensionId is provided, runs namespace reservation check.
+ * - If opts.extensionId is not provided, skips namespace check and adds a warning.
+ * - valid is ALWAYS derived as errors.length === 0.
+ */
+export function validateExtensionPackage(pkg: unknown, opts: ValidationOptions = {}): ValidationResult {
+  const errors: ValidationError[] = []
+  const warnings: ValidationWarning[] = []
+
+  // Check 1: Install discriminator
+  const discriminatorError = checkInstallDiscriminator(pkg)
+  if (discriminatorError) {
+    errors.push(discriminatorError)
+  }
+
+  // Check 2: Namespace reservation (only if extensionId provided)
+  if (opts.extensionId !== undefined) {
+    const namespaceError = checkNamespaceReservation(opts.extensionId, opts)
+    if (namespaceError) {
+      errors.push(namespaceError)
+    }
+  } else {
+    warnings.push({
+      code: 'NAMESPACE_CHECK_SKIPPED',
+      message: 'No extensionId provided — namespace reservation check was skipped.',
+    })
+  }
+
+  // Check 3: Dependency placement
+  const depErrors = checkDependencyPlacement(pkg)
+  errors.push(...depErrors)
+
+  return {
+    valid: errors.length === 0,
+    errors,
+    warnings,
+  }
+}

--- a/src/resources/extensions/cmux/index.ts
+++ b/src/resources/extensions/cmux/index.ts
@@ -458,8 +458,8 @@ function extractSurfaceIds(value: unknown): string[] {
 export function initCmuxEventListeners(events: EventBus): void {
   events.on(CMUX_CHANNELS.SIDEBAR, (data) => {
     const event = data as CmuxSidebarEvent;
-    if (event.action === "sync" && event.preferences && event.state) {
-      syncCmuxSidebar(event.preferences as CmuxPreferences, event.state as CmuxState);
+    if (event.action === "sync" && event.state) {
+      syncCmuxSidebar(event.preferences as CmuxPreferences | undefined, event.state as CmuxState);
     }
     if (event.action === "clear") {
       clearCmuxSidebar(event.preferences as CmuxPreferences | undefined);

--- a/src/resources/extensions/cmux/index.ts
+++ b/src/resources/extensions/cmux/index.ts
@@ -2,8 +2,12 @@ import { execFileSync, spawn } from "node:child_process";
 import { existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { GSDPreferences } from "../gsd/preferences.js";
-import type { GSDState, Phase } from "../gsd/types.js";
+import { CMUX_CHANNELS, type CmuxSidebarEvent, type CmuxLogEvent, type CmuxPreferencesInput, type CmuxStateInput } from "../shared/cmux-events.js";
+import type { EventBus } from "@gsd/pi-coding-agent";
+
+type CmuxPreferences = CmuxPreferencesInput;
+type CmuxState = CmuxStateInput;
+type Phase = string;
 const DEFAULT_SOCKET_PATH = "/tmp/cmux.sock";
 const STATUS_KEY = "gsd";
 const lastSidebarSnapshots = new Map<string, string>();
@@ -52,7 +56,7 @@ export function detectCmuxEnvironment(
 }
 
 export function resolveCmuxConfig(
-  preferences: GSDPreferences | undefined,
+  preferences: CmuxPreferences | undefined,
   env: NodeJS.ProcessEnv = process.env,
   socketExists: (path: string) => boolean = existsSync,
   cliAvailable: () => boolean = isCmuxCliAvailable,
@@ -71,7 +75,7 @@ export function resolveCmuxConfig(
 }
 
 export function shouldPromptToEnableCmux(
-  preferences: GSDPreferences | undefined,
+  preferences: CmuxPreferences | undefined,
   env: NodeJS.ProcessEnv = process.env,
   socketExists: (path: string) => boolean = existsSync,
   cliAvailable: () => boolean = isCmuxCliAvailable,
@@ -113,7 +117,7 @@ export function emitOsc777Notification(title: string, body: string): void {
   process.stdout.write(`\x1b]777;notify;${safeTitle};${safeBody}\x07`);
 }
 
-export function buildCmuxStatusLabel(state: GSDState): string {
+export function buildCmuxStatusLabel(state: CmuxState): string {
   const parts: string[] = [];
   if (state.activeMilestone) parts.push(state.activeMilestone.id);
   if (state.activeSlice) parts.push(state.activeSlice.id);
@@ -125,7 +129,7 @@ export function buildCmuxStatusLabel(state: GSDState): string {
   return `${parts.join(" ")} · ${state.phase}`;
 }
 
-export function buildCmuxProgress(state: GSDState): CmuxSidebarProgress | null {
+export function buildCmuxProgress(state: CmuxState): CmuxSidebarProgress | null {
   const progress = state.progress;
   if (!progress) return null;
 
@@ -171,7 +175,7 @@ export class CmuxClient {
     this.config = config;
   }
 
-  static fromPreferences(preferences: GSDPreferences | undefined): CmuxClient {
+  static fromPreferences(preferences: CmuxPreferences | undefined): CmuxClient {
     return new CmuxClient(resolveCmuxConfig(preferences));
   }
 
@@ -372,7 +376,7 @@ export class CmuxClient {
   }
 }
 
-export function syncCmuxSidebar(preferences: GSDPreferences | undefined, state: GSDState): void {
+export function syncCmuxSidebar(preferences: CmuxPreferences | undefined, state: CmuxState): void {
   const client = CmuxClient.fromPreferences(preferences);
   const config = client.getConfig();
   if (!config.sidebar) return;
@@ -388,7 +392,7 @@ export function syncCmuxSidebar(preferences: GSDPreferences | undefined, state: 
   lastSidebarSnapshots.set(key, snapshot);
 }
 
-export function clearCmuxSidebar(preferences: GSDPreferences | undefined): void {
+export function clearCmuxSidebar(preferences: CmuxPreferences | undefined): void {
   const config = resolveCmuxConfig(preferences);
   if (!config.available || !config.cliAvailable) return;
   const client = new CmuxClient({ ...config, enabled: true, sidebar: true });
@@ -399,7 +403,7 @@ export function clearCmuxSidebar(preferences: GSDPreferences | undefined): void 
 }
 
 export function logCmuxEvent(
-  preferences: GSDPreferences | undefined,
+  preferences: CmuxPreferences | undefined,
   message: string,
   level: CmuxLogLevel = "info",
 ): void {
@@ -445,4 +449,25 @@ function extractSurfaceIds(value: unknown): string[] {
 
   visit(value);
   return Array.from(found);
+}
+
+/**
+ * Wire event subscriptions so cmux reacts to gsd events.
+ * Called by the gsd extension during registration, passing pi.events.
+ */
+export function initCmuxEventListeners(events: EventBus): void {
+  events.on(CMUX_CHANNELS.SIDEBAR, (data) => {
+    const event = data as CmuxSidebarEvent;
+    if (event.action === "sync" && event.preferences && event.state) {
+      syncCmuxSidebar(event.preferences as CmuxPreferences, event.state as CmuxState);
+    }
+    if (event.action === "clear") {
+      clearCmuxSidebar(event.preferences as CmuxPreferences | undefined);
+    }
+  });
+
+  events.on(CMUX_CHANNELS.LOG, (data) => {
+    const event = data as CmuxLogEvent;
+    logCmuxEvent(event.preferences as CmuxPreferences | undefined, event.message, event.level);
+  });
 }

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -1211,7 +1211,7 @@ function buildLoopDeps(pi: ExtensionAPI): LoopDeps {
     clearUnitTimeout,
     updateProgressWidget,
     ...cmux,
-    handleLostSessionLock: (ctx, lockStatus) => {
+    handleLostSessionLock: (ctx: ExtensionContext | undefined, lockStatus: SessionLockStatus | undefined) => {
       cmux.clearCmuxSidebar(loadEffectiveGSDPreferences()?.preferences);
       handleLostSessionLock(ctx, lockStatus);
     },

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -192,7 +192,18 @@ import {
 } from "./auto-supervisor.js";
 import { isDbAvailable, getMilestone } from "./gsd-db.js";
 import { countPendingCaptures } from "./captures.js";
-import { clearCmuxSidebar, logCmuxEvent, syncCmuxSidebar } from "../cmux/index.js";
+import { CMUX_CHANNELS, type CmuxLogLevel } from "../shared/cmux-events.js";
+
+function makeCmuxEmitters(pi: ExtensionAPI) {
+  return {
+    syncCmuxSidebar: (preferences: GSDPreferences | undefined, state: GSDState) =>
+      pi.events.emit(CMUX_CHANNELS.SIDEBAR, { action: "sync" as const, preferences, state }),
+    logCmuxEvent: (preferences: GSDPreferences | undefined, message: string, level?: CmuxLogLevel) =>
+      pi.events.emit(CMUX_CHANNELS.LOG, { preferences, message, level: level ?? "info" }),
+    clearCmuxSidebar: (preferences: GSDPreferences | undefined) =>
+      pi.events.emit(CMUX_CHANNELS.SIDEBAR, { action: "clear" as const, preferences }),
+  };
+}
 
 // ── Extracted modules ──────────────────────────────────────────────────────
 import { startUnitSupervision } from "./auto-timers.js";
@@ -701,7 +712,6 @@ function handleLostSessionLock(
   restoreProjectRootEnv();
   restoreMilestoneLockEnv();
   deregisterSigtermHandler();
-  clearCmuxSidebar(loadEffectiveGSDPreferences(s.basePath || undefined)?.preferences);
   const base = lockBase();
   const lockFilePath = base ? join(gsdRoot(base), "auto.lock") : "unknown";
   const recoverySuggestion = "\nTo recover, run: gsd doctor --fix";
@@ -942,12 +952,12 @@ export async function stopAuto(
 
     // ── Step 9: Cmux sidebar / event log ──
     try {
-      clearCmuxSidebar(loadedPreferences);
-      logCmuxEvent(
-        loadedPreferences,
-        `Auto-mode stopped${reasonSuffix || ""}.`,
-        reason?.startsWith("Blocked:") ? "warning" : "info",
-      );
+      pi?.events.emit(CMUX_CHANNELS.SIDEBAR, { action: "clear" as const, preferences: loadedPreferences });
+      pi?.events.emit(CMUX_CHANNELS.LOG, {
+        preferences: loadedPreferences,
+        message: `Auto-mode stopped${reasonSuffix || ""}.`,
+        level: reason?.startsWith("Blocked:") ? "warning" : "info",
+      });
     } catch (e) {
       debugLog("stop-cleanup-cmux", { error: e instanceof Error ? e.message : String(e) });
     }
@@ -1185,11 +1195,13 @@ function buildResolver(): WorktreeResolver {
  * Build the LoopDeps object from auto.ts private scope.
  * This bundles all private functions that autoLoop needs without exporting them.
  */
-function buildLoopDeps(): LoopDeps {
+function buildLoopDeps(pi: ExtensionAPI): LoopDeps {
   // Initialize the unified rule registry with converted dispatch rules.
   // Must happen before LoopDeps is assembled so facade functions
   // (resolveDispatch, runPreDispatchHooks, etc.) delegate to the registry.
   initRegistry(convertDispatchRules(DISPATCH_RULES));
+
+  const cmux = makeCmuxEmitters(pi);
 
   return {
     lockBase,
@@ -1198,8 +1210,11 @@ function buildLoopDeps(): LoopDeps {
     pauseAuto,
     clearUnitTimeout,
     updateProgressWidget,
-    syncCmuxSidebar,
-    logCmuxEvent,
+    ...cmux,
+    handleLostSessionLock: (ctx, lockStatus) => {
+      cmux.clearCmuxSidebar(loadEffectiveGSDPreferences()?.preferences);
+      handleLostSessionLock(ctx, lockStatus);
+    },
 
     // State and cache
     invalidateAllCaches,
@@ -1219,7 +1234,6 @@ function buildLoopDeps(): LoopDeps {
     // Session lock
     validateSessionLock: getSessionLockStatus,
     updateSessionLock,
-    handleLostSessionLock,
 
     // Milestone transition
     sendDesktopNotification,
@@ -1576,7 +1590,7 @@ export async function startAuto(
     await openProjectDbIfPresent(s.basePath);
     try {
       await rebuildState(s.basePath);
-      syncCmuxSidebar(loadEffectiveGSDPreferences(s.basePath || undefined)?.preferences, await deriveState(s.basePath));
+      pi.events.emit(CMUX_CHANNELS.SIDEBAR, { action: "sync" as const, preferences: loadEffectiveGSDPreferences(s.basePath || undefined)?.preferences, state: await deriveState(s.basePath) });
     } catch (e) {
       debugLog("resume-rebuild-state-failed", {
         error: e instanceof Error ? e.message : String(e),
@@ -1626,7 +1640,7 @@ export async function startAuto(
       "resuming",
       s.currentMilestoneId ?? "unknown",
     );
-    logCmuxEvent(loadEffectiveGSDPreferences(s.basePath || undefined)?.preferences, s.stepMode ? "Step-mode resumed." : "Auto-mode resumed.", "progress");
+    pi.events.emit(CMUX_CHANNELS.LOG, { preferences: loadEffectiveGSDPreferences(s.basePath || undefined)?.preferences, message: s.stepMode ? "Step-mode resumed." : "Auto-mode resumed.", level: "progress" });
 
     captureProjectRootEnv(s.originalBasePath || s.basePath);
     startAutoCommandPolling(s.basePath);
@@ -1634,7 +1648,7 @@ export async function startAuto(
       ctx,
       pi,
       s,
-      deps: buildLoopDeps(),
+      deps: buildLoopDeps(pi),
       runKernelLoop: runUokKernelLoop,
       runLegacyLoop: runLegacyAutoLoop,
     });
@@ -1664,12 +1678,12 @@ export async function startAuto(
 
   captureProjectRootEnv(s.originalBasePath || s.basePath);
   try {
-    syncCmuxSidebar(loadEffectiveGSDPreferences(s.basePath || undefined)?.preferences, await deriveState(s.basePath));
+    pi.events.emit(CMUX_CHANNELS.SIDEBAR, { action: "sync" as const, preferences: loadEffectiveGSDPreferences(s.basePath || undefined)?.preferences, state: await deriveState(s.basePath) });
   } catch (err) {
     // Best-effort only — sidebar sync must never block auto-mode startup
     logWarning("engine", `cmux sync failed: ${err instanceof Error ? err.message : String(err)}`, { file: "auto.ts" });
   }
-  logCmuxEvent(loadEffectiveGSDPreferences(s.basePath || undefined)?.preferences, requestedStepMode ? "Step-mode started." : "Auto-mode started.", "progress");
+  pi.events.emit(CMUX_CHANNELS.LOG, { preferences: loadEffectiveGSDPreferences(s.basePath || undefined)?.preferences, message: requestedStepMode ? "Step-mode started." : "Auto-mode started.", level: "progress" });
 
   startAutoCommandPolling(s.basePath);
 
@@ -1678,7 +1692,7 @@ export async function startAuto(
     ctx,
     pi,
     s,
-    deps: buildLoopDeps(),
+    deps: buildLoopDeps(pi),
     runKernelLoop: runUokKernelLoop,
     runLegacyLoop: runLegacyAutoLoop,
   });

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -1212,7 +1212,7 @@ function buildLoopDeps(pi: ExtensionAPI): LoopDeps {
     updateProgressWidget,
     ...cmux,
     handleLostSessionLock: (ctx: ExtensionContext | undefined, lockStatus: SessionLockStatus | undefined) => {
-      cmux.clearCmuxSidebar(loadEffectiveGSDPreferences()?.preferences);
+      cmux.clearCmuxSidebar(loadEffectiveGSDPreferences(s.basePath || undefined)?.preferences);
       handleLostSessionLock(ctx, lockStatus);
     },
 

--- a/src/resources/extensions/gsd/auto/loop-deps.ts
+++ b/src/resources/extensions/gsd/auto/loop-deps.ts
@@ -18,7 +18,7 @@ import type {
 } from "../auto-verification.js";
 import type { DispatchAction, DispatchContext } from "../auto-dispatch.js";
 import type { WorktreeResolver } from "../worktree-resolver.js";
-import type { CmuxLogLevel } from "../../cmux/index.js";
+import type { CmuxLogLevel } from "../../shared/cmux-events.js";
 import type { JournalEntry } from "../journal.js";
 import type { MergeReconcileResult } from "../auto-recovery.js";
 import type { UokTurnObserver } from "../uok/contracts.js";

--- a/src/resources/extensions/gsd/auto/types.ts
+++ b/src/resources/extensions/gsd/auto/types.ts
@@ -9,7 +9,7 @@ import type { ExtensionAPI, ExtensionContext } from "@gsd/pi-coding-agent";
 import type { AutoSession } from "./session.js";
 import type { GSDPreferences } from "../preferences.js";
 import type { GSDState } from "../types.js";
-import type { CmuxLogLevel } from "../../cmux/index.js";
+import type { CmuxLogLevel } from "../../shared/cmux-events.js";
 import type { LoopDeps } from "./loop-deps.js";
 
 /**

--- a/src/resources/extensions/gsd/bootstrap/register-extension.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-extension.ts
@@ -103,14 +103,17 @@ export function registerGsdExtension(pi: ExtensionAPI): void {
     ["memory-tools", () => registerMemoryTools(pi)],
     ["exec-tools", () => registerExecTools(pi)],
     ["shortcuts", () => registerShortcuts(pi)],
-    ["hooks", () => registerHooks(pi, ecosystemHandlers)],
+    // cmux-events runs before hooks so the dynamic-import microtask is queued
+    // as early as possible. cmux is a library (no pi), so gsd sets up the
+    // event listeners on its behalf using the shared event channel contract.
+    // Today no hook fires a CMUX_CHANNELS emit at registration time, but this
+    // ordering is defensive against future hooks that might.
     ["cmux-events", () => {
-      // cmux is a library (no pi), so gsd sets up the event listeners on its
-      // behalf using the shared event channel contract.
       void import("../../cmux/index.js").then(({ initCmuxEventListeners }) => {
         initCmuxEventListeners(pi.events);
       });
     }],
+    ["hooks", () => registerHooks(pi, ecosystemHandlers)],
     ["ecosystem", () => {
       void loadEcosystemExtensions(pi, ecosystemHandlers).catch((err) => {
         logWarning(

--- a/src/resources/extensions/gsd/bootstrap/register-extension.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-extension.ts
@@ -104,6 +104,13 @@ export function registerGsdExtension(pi: ExtensionAPI): void {
     ["exec-tools", () => registerExecTools(pi)],
     ["shortcuts", () => registerShortcuts(pi)],
     ["hooks", () => registerHooks(pi, ecosystemHandlers)],
+    ["cmux-events", () => {
+      // cmux is a library (no pi), so gsd sets up the event listeners on its
+      // behalf using the shared event channel contract.
+      void import("../../cmux/index.js").then(({ initCmuxEventListeners }) => {
+        initCmuxEventListeners(pi.events);
+      });
+    }],
     ["ecosystem", () => {
       void loadEcosystemExtensions(pi, ecosystemHandlers).catch((err) => {
         logWarning(

--- a/src/resources/extensions/gsd/bootstrap/register-extension.ts
+++ b/src/resources/extensions/gsd/bootstrap/register-extension.ts
@@ -16,6 +16,13 @@ import { registerHooks } from "./register-hooks.js";
 import { registerShortcuts } from "./register-shortcuts.js";
 import { writeCrashLog } from "./crash-log.js";
 import { logWarning } from "../workflow-logger.js";
+// Static import so cmux event listeners are registered synchronously during
+// extension bootstrap. Prior implementation used `void import().then()` which
+// queued listener registration as a microtask — any CMUX_CHANNELS emit fired
+// in the same event loop turn as registration (e.g. from a provider-error
+// session hook calling startAuto) would be silently dropped because Node's
+// EventEmitter does not buffer events for late subscribers.
+import { initCmuxEventListeners } from "../../cmux/index.js";
 
 export { writeCrashLog } from "./crash-log.js";
 
@@ -103,16 +110,10 @@ export function registerGsdExtension(pi: ExtensionAPI): void {
     ["memory-tools", () => registerMemoryTools(pi)],
     ["exec-tools", () => registerExecTools(pi)],
     ["shortcuts", () => registerShortcuts(pi)],
-    // cmux-events runs before hooks so the dynamic-import microtask is queued
-    // as early as possible. cmux is a library (no pi), so gsd sets up the
-    // event listeners on its behalf using the shared event channel contract.
-    // Today no hook fires a CMUX_CHANNELS emit at registration time, but this
-    // ordering is defensive against future hooks that might.
-    ["cmux-events", () => {
-      void import("../../cmux/index.js").then(({ initCmuxEventListeners }) => {
-        initCmuxEventListeners(pi.events);
-      });
-    }],
+    // cmux is a library (no pi), so gsd sets up the event listeners on its
+    // behalf using the shared event channel contract. Registration is
+    // synchronous — see the import comment above for the rationale.
+    ["cmux-events", () => initCmuxEventListeners(pi.events)],
     ["hooks", () => registerHooks(pi, ecosystemHandlers)],
     ["ecosystem", () => {
       void loadEcosystemExtensions(pi, ecosystemHandlers).catch((err) => {

--- a/src/resources/extensions/gsd/bootstrap/system-context.ts
+++ b/src/resources/extensions/gsd/bootstrap/system-context.ts
@@ -19,7 +19,6 @@ import { getActiveWorktreeName, getWorktreeOriginalCwd } from "../worktree-comma
 import { deriveState } from "../state.js";
 import { formatOverridesSection, formatShortcut, loadActiveOverrides, loadFile, parseContinue, parseSummary } from "../files.js";
 import { toPosixPath } from "../../shared/mod.js";
-import { markCmuxPromptShown, shouldPromptToEnableCmux } from "../../cmux/index.js";
 import { autoEnableCmuxPreferences } from "../commands-cmux.js";
 
 const gsdHome = process.env.GSD_HOME || join(homedir(), ".gsd");
@@ -99,6 +98,7 @@ export async function buildBeforeAgentStartResult(
     shortcutShell: formatShortcut("Ctrl+Alt+B"),
   });
   let loadedPreferences = loadEffectiveGSDPreferences();
+  const { markCmuxPromptShown, shouldPromptToEnableCmux } = await import("../../cmux/index.js");
   if (shouldPromptToEnableCmux(loadedPreferences?.preferences)) {
     markCmuxPromptShown();
     if (autoEnableCmuxPreferences()) {

--- a/src/resources/extensions/gsd/bootstrap/system-context.ts
+++ b/src/resources/extensions/gsd/bootstrap/system-context.ts
@@ -98,16 +98,20 @@ export async function buildBeforeAgentStartResult(
     shortcutShell: formatShortcut("Ctrl+Alt+B"),
   });
   let loadedPreferences = loadEffectiveGSDPreferences();
-  const { markCmuxPromptShown, shouldPromptToEnableCmux } = await import("../../cmux/index.js");
-  if (shouldPromptToEnableCmux(loadedPreferences?.preferences)) {
-    markCmuxPromptShown();
-    if (autoEnableCmuxPreferences()) {
-      loadedPreferences = loadEffectiveGSDPreferences();
-      ctx.ui.notify(
-        "cmux detected — auto-enabled. Run /gsd cmux off to disable.",
-        "info",
-      );
+  try {
+    const { markCmuxPromptShown, shouldPromptToEnableCmux } = await import("../../cmux/index.js");
+    if (shouldPromptToEnableCmux(loadedPreferences?.preferences)) {
+      markCmuxPromptShown();
+      if (autoEnableCmuxPreferences()) {
+        loadedPreferences = loadEffectiveGSDPreferences();
+        ctx.ui.notify(
+          "cmux detected — auto-enabled. Run /gsd cmux off to disable.",
+          "info",
+        );
+      }
     }
+  } catch (e) {
+    logWarning("bootstrap", `cmux prompt setup skipped: ${(e as Error).message}`);
   }
 
   let preferenceBlock = "";

--- a/src/resources/extensions/gsd/commands-cmux.ts
+++ b/src/resources/extensions/gsd/commands-cmux.ts
@@ -1,6 +1,5 @@
 import type { ExtensionCommandContext } from "@gsd/pi-coding-agent";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
-import { clearCmuxSidebar, CmuxClient, detectCmuxEnvironment, resolveCmuxConfig } from "../cmux/index.js";
 import { saveFile } from "./files.js";
 import {
   getProjectGSDPreferencesPath,
@@ -77,7 +76,9 @@ function resolveProjectPreferencesWritePath(): string {
   return loadProjectGSDPreferences()?.path ?? getProjectGSDPreferencesPath();
 }
 
-function formatCmuxStatus(): string {
+async function formatCmuxStatus(): Promise<string> {
+  const { CmuxClient, detectCmuxEnvironment, resolveCmuxConfig } =
+    await import("../cmux/index.js");
   const loaded = loadEffectiveGSDPreferences();
   const detected = detectCmuxEnvironment();
   const resolved = resolveCmuxConfig(loaded?.preferences);
@@ -103,7 +104,8 @@ function formatCmuxStatus(): string {
   ].join("\n");
 }
 
-function ensureCmuxAvailableForEnable(ctx: ExtensionCommandContext): boolean {
+async function ensureCmuxAvailableForEnable(ctx: ExtensionCommandContext): Promise<boolean> {
+  const { detectCmuxEnvironment } = await import("../cmux/index.js");
   const detected = detectCmuxEnvironment();
   if (detected.available) return true;
   ctx.ui.notify(
@@ -116,12 +118,12 @@ function ensureCmuxAvailableForEnable(ctx: ExtensionCommandContext): boolean {
 export async function handleCmux(args: string, ctx: ExtensionCommandContext): Promise<void> {
   const trimmed = args.trim();
   if (!trimmed || trimmed === "status") {
-    ctx.ui.notify(formatCmuxStatus(), "info");
+    ctx.ui.notify(await formatCmuxStatus(), "info");
     return;
   }
 
   if (trimmed === "on") {
-    if (!ensureCmuxAvailableForEnable(ctx)) return;
+    if (!await ensureCmuxAvailableForEnable(ctx)) return;
     await writeProjectCmuxPreferences(ctx, (prefs) => {
       prefs.cmux = {
         enabled: true,
@@ -142,6 +144,7 @@ export async function handleCmux(args: string, ctx: ExtensionCommandContext): Pr
     await writeProjectCmuxPreferences(ctx, (prefs) => {
       prefs.cmux = { ...((prefs.cmux as Record<string, unknown> | undefined) ?? {}), enabled: false };
     });
+    const { clearCmuxSidebar } = await import("../cmux/index.js");
     clearCmuxSidebar(effective);
     ctx.ui.notify("cmux integration disabled in project preferences.", "info");
     return;
@@ -151,7 +154,7 @@ export async function handleCmux(args: string, ctx: ExtensionCommandContext): Pr
   if (parts.length === 2 && ["notifications", "sidebar", "splits", "browser"].includes(parts[0]) && ["on", "off"].includes(parts[1])) {
     const feature = parts[0] as "notifications" | "sidebar" | "splits" | "browser";
     const enabled = parts[1] === "on";
-    if (enabled && !ensureCmuxAvailableForEnable(ctx)) return;
+    if (enabled && !await ensureCmuxAvailableForEnable(ctx)) return;
 
     await writeProjectCmuxPreferences(ctx, (prefs) => {
       const next = { ...((prefs.cmux as Record<string, unknown> | undefined) ?? {}) };
@@ -161,6 +164,7 @@ export async function handleCmux(args: string, ctx: ExtensionCommandContext): Pr
     });
 
     if (!enabled && feature === "sidebar") {
+      const { clearCmuxSidebar } = await import("../cmux/index.js");
       clearCmuxSidebar(loadEffectiveGSDPreferences()?.preferences);
     }
 

--- a/src/resources/extensions/gsd/commands-extensions.ts
+++ b/src/resources/extensions/gsd/commands-extensions.ts
@@ -11,6 +11,7 @@ import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, 
 import { dirname, join, resolve } from "node:path";
 import { homedir, tmpdir } from "node:os";
 import { execFileSync } from "node:child_process";
+import semver from "semver";
 
 const gsdHome = process.env.GSD_HOME || join(homedir(), ".gsd");
 
@@ -318,6 +319,134 @@ function handleUninstall(id: string | undefined, ctx: ExtensionCommandContext): 
   ctx.ui.notify(`Uninstalled "${id}". Restart GSD to deactivate.`, "info");
 }
 
+// ─── Update subcommand ───────────────────────────────────────────────────────
+
+async function getLatestNpmVersion(packageName: string): Promise<string | null> {
+  try {
+    const res = await fetch(`https://registry.npmjs.org/${packageName}/latest`, {
+      signal: AbortSignal.timeout(5000),
+    });
+    if (!res.ok) return null;
+    const data = await res.json() as { version?: string };
+    return data.version ?? null;
+  } catch {
+    return null;
+  }
+}
+
+async function handleUpdate(id: string | undefined, ctx: ExtensionCommandContext): Promise<void> {
+  const registry = loadRegistry();
+
+  if (id) {
+    // Update single extension (D-12)
+    await updateSingleExtension(id, registry, ctx);
+  } else {
+    // Update all installed extensions (D-11)
+    await updateAllExtensions(registry, ctx);
+  }
+}
+
+async function updateSingleExtension(
+  id: string,
+  registry: ExtensionRegistry,
+  ctx: ExtensionCommandContext,
+): Promise<void> {
+  const entry = registry.entries[id];
+
+  if (!entry || entry.source !== "user") {
+    ctx.ui.notify(
+      `Extension "${id}" not found in registry. Run /gsd extensions list to see installed extensions.`,
+      "warning",
+    );
+    return;
+  }
+
+  // Git and local installs: "reinstall to update" hint (D-10, D-12)
+  if (entry.installType !== "npm") {
+    const source = entry.installType ?? "unknown";
+    const hint = entry.installedFrom ? `gsd extensions install ${entry.installedFrom}` : `gsd extensions install <specifier>`;
+    ctx.ui.notify(
+      `"${id}" was installed from ${source}. Reinstall to update: ${hint}`,
+      "warning",
+    );
+    return;
+  }
+
+  // npm extension: check for newer version (D-09)
+  const current = entry.version ?? "0.0.0";
+  const packageName = entry.installedFrom;
+  if (!packageName) {
+    ctx.ui.notify(`"${id}" has no recorded install source. Reinstall manually.`, "warning");
+    return;
+  }
+
+  const latest = await getLatestNpmVersion(packageName);
+  if (!latest) {
+    ctx.ui.notify(`Could not fetch latest version for "${id}".`, "warning");
+    return;
+  }
+
+  if (semver.gt(latest, current)) {
+    ctx.ui.notify(`Updating "${id}": v${current} → v${latest}...`, "info");
+    await handleInstall(packageName, ctx);
+  } else {
+    ctx.ui.notify(`"${id}" is already at the latest version (v${current}).`, "info");
+  }
+}
+
+async function updateAllExtensions(
+  registry: ExtensionRegistry,
+  ctx: ExtensionCommandContext,
+): Promise<void> {
+  // Find all user-installed extensions
+  const userEntries = Object.values(registry.entries).filter(e => e.source === "user");
+
+  if (userEntries.length === 0) {
+    ctx.ui.notify("No user-installed extensions found. Use: gsd extensions install <package> to add one.", "warning");
+    return;
+  }
+
+  ctx.ui.notify(`Checking ${userEntries.length} installed extension(s) for updates...`, "info");
+
+  let updated = 0;
+  let skipped = 0;
+
+  for (const entry of userEntries) {
+    // Skip non-npm installs (D-11)
+    if (entry.installType !== "npm") {
+      const source = entry.installType ?? "unknown";
+      ctx.ui.notify(`  ${entry.id}: installed from ${source} — reinstall to update`, "info");
+      skipped++;
+      continue;
+    }
+
+    const current = entry.version ?? "0.0.0";
+    const packageName = entry.installedFrom;
+    if (!packageName) {
+      ctx.ui.notify(`  ${entry.id}: no recorded install source — skip`, "info");
+      skipped++;
+      continue;
+    }
+
+    const latest = await getLatestNpmVersion(packageName);
+    if (!latest) {
+      ctx.ui.notify(`  ${entry.id}: could not fetch latest version — skip`, "info");
+      skipped++;
+      continue;
+    }
+
+    if (semver.gt(latest, current)) {
+      ctx.ui.notify(`  ${entry.id}: v${current} → v${latest} (updating)`, "info");
+      await handleInstall(packageName, ctx);
+      updated++;
+    } else {
+      ctx.ui.notify(`  ${entry.id}: v${current} (already up to date)`, "info");
+    }
+  }
+
+  ctx.ui.notify(`Updated ${updated} extension(s). ${skipped} skipped (git/local — reinstall to update).`, "info");
+}
+
 // ─── Install subcommand ──────────────────────────────────────────────────────
 
 async function handleInstall(specifier: string | undefined, ctx: ExtensionCommandContext): Promise<void> {
@@ -490,6 +619,11 @@ export async function handleExtensions(args: string, ctx: ExtensionCommandContex
     return;
   }
 
+  if (subCmd === "update") {
+    await handleUpdate(parts[1], ctx);
+    return;
+  }
+
   ctx.ui.notify(
     `Unknown: /gsd extensions ${subCmd}. Usage: /gsd extensions [list|enable|disable|info|install|uninstall|update]`,
     "warning",
@@ -531,6 +665,19 @@ function handleList(ctx: ExtensionCommandContext): void {
       padRight(String(toolCount), 7) +
       String(cmdCount),
     );
+
+    // Show source indicator and install info for user-installed extensions
+    const regEntry = registry.entries[m.id];
+    if (regEntry?.source === "user") {
+      // Append [user] tag to the last line
+      const lastLine = lines[lines.length - 1];
+      lines[lines.length - 1] = lastLine + "      [user]";
+      if (regEntry.installedFrom) {
+        const typePrefix = regEntry.installType ? `${regEntry.installType}:` : "";
+        const versionSuffix = regEntry.version ? `@${regEntry.version}` : "";
+        lines.push(`  installed from: ${typePrefix}${regEntry.installedFrom}${versionSuffix}`);
+      }
+    }
 
     if (!enabled) {
       lines.push(`  ↳ gsd extensions enable ${m.id}`);
@@ -644,6 +791,16 @@ function handleInfo(id: string | undefined, ctx: ExtensionCommandContext): void 
   }
   if (entry?.disabledReason) {
     lines.push(`  Reason:      ${entry.disabledReason}`);
+  }
+
+  // Phase 8 fields for user-installed extensions (per UI-SPEC)
+  if (entry?.source === "user") {
+    if (entry.installedFrom) {
+      lines.push(`  Installed from: ${entry.installedFrom}`);
+    }
+    if (entry.installType) {
+      lines.push(`  Install type:   ${entry.installType}`);
+    }
   }
 
   if (manifest.provides) {

--- a/src/resources/extensions/gsd/commands-extensions.ts
+++ b/src/resources/extensions/gsd/commands-extensions.ts
@@ -249,6 +249,75 @@ function postInstallValidate(
   return extensionId;
 }
 
+// ─── Uninstall helpers ───────────────────────────────────────────────────────
+
+/**
+ * Scan installed extensions to find which ones depend on the target ID.
+ * Used for dependency warning on uninstall (D-06).
+ */
+function findDependents(targetId: string, installedExtDir: string): string[] {
+  const dependents: string[] = [];
+  if (!existsSync(installedExtDir)) return dependents;
+  for (const entry of readdirSync(installedExtDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const manifest = readManifest(join(installedExtDir, entry.name));
+    if (!manifest) continue;
+    if (manifest.dependencies?.extensions?.includes(targetId)) {
+      dependents.push(manifest.id);
+    }
+  }
+  return dependents;
+}
+
+function handleUninstall(id: string | undefined, ctx: ExtensionCommandContext): void {
+  if (!id) {
+    ctx.ui.notify("Usage: /gsd extensions uninstall <id>", "warning");
+    return;
+  }
+
+  const registry = loadRegistry();
+  const entry = registry.entries[id];
+
+  // Check if extension exists and is user-installed
+  if (!entry || entry.source !== "user") {
+    ctx.ui.notify(
+      `Extension "${id}" not found in registry. Run /gsd extensions list to see installed extensions.`,
+      "warning",
+    );
+    return;
+  }
+
+  const installedExtDir = getInstalledExtDir();
+  const extDir = join(installedExtDir, id);
+
+  // Check for dependents and warn (D-06: warn-then-proceed)
+  const dependents = findDependents(id, installedExtDir);
+  if (dependents.length > 0) {
+    ctx.ui.notify(
+      `Warning: the following installed extensions depend on "${id}": ${dependents.join(", ")}. Removing anyway.`,
+      "warning",
+    );
+  }
+
+  // Remove directory first, then registry entry (Pitfall 4 from RESEARCH.md)
+  // If rm fails, do NOT remove registry entry — leaves a recoverable state
+  try {
+    if (existsSync(extDir)) {
+      rmSync(extDir, { recursive: true, force: true });
+    }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    ctx.ui.notify(`Failed to remove extension directory for "${id}": ${msg}`, "error");
+    return; // Do NOT remove registry entry — directory still exists
+  }
+
+  // Remove registry entry (D-07)
+  delete registry.entries[id];
+  saveRegistry(registry);
+
+  ctx.ui.notify(`Uninstalled "${id}". Restart GSD to deactivate.`, "info");
+}
+
 // ─── Install subcommand ──────────────────────────────────────────────────────
 
 async function handleInstall(specifier: string | undefined, ctx: ExtensionCommandContext): Promise<void> {
@@ -413,6 +482,11 @@ export async function handleExtensions(args: string, ctx: ExtensionCommandContex
 
   if (subCmd === "install") {
     await handleInstall(parts[1], ctx);
+    return;
+  }
+
+  if (subCmd === "uninstall") {
+    handleUninstall(parts[1], ctx);
     return;
   }
 

--- a/src/resources/extensions/gsd/commands-extensions.ts
+++ b/src/resources/extensions/gsd/commands-extensions.ts
@@ -1,15 +1,16 @@
 /**
  * GSD Extensions Command — /gsd extensions
  *
- * Manage the extension registry: list, enable, disable, info.
+ * Manage the extension registry: list, enable, disable, info, install.
  * Self-contained — no imports outside the extensions tree (extensions are loaded
  * via jiti at runtime from ~/.gsd/agent/, not compiled by tsc).
  */
 
 import type { ExtensionCommandContext } from "@gsd/pi-coding-agent";
-import { existsSync, mkdirSync, readFileSync, readdirSync, renameSync, writeFileSync } from "node:fs";
-import { dirname, join } from "node:path";
-import { homedir } from "node:os";
+import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { homedir, tmpdir } from "node:os";
+import { execFileSync } from "node:child_process";
 
 const gsdHome = process.env.GSD_HOME || join(homedir(), ".gsd");
 
@@ -40,6 +41,9 @@ interface ExtensionRegistryEntry {
   source: "bundled" | "user" | "project";
   disabledAt?: string;
   disabledReason?: string;
+  version?: string;
+  installedFrom?: string;
+  installType?: "npm" | "git" | "local";
 }
 
 interface ExtensionRegistry {
@@ -112,6 +116,275 @@ function discoverManifests(): Map<string, ExtensionManifest> {
   return manifests;
 }
 
+function getInstalledExtDir(): string {
+  return join(gsdHome, "extensions");
+}
+
+// Source: derived from npm/git URL conventions (from RESEARCH.md)
+function detectInstallType(specifier: string): "npm" | "git" | "local" {
+  if (
+    specifier.startsWith("/") ||
+    specifier.startsWith("./") ||
+    specifier.startsWith("../") ||
+    specifier.startsWith("~/")
+  ) return "local";
+  if (
+    specifier.startsWith("git+") ||
+    specifier.startsWith("git://") ||
+    specifier.startsWith("github:") ||
+    specifier.startsWith("gitlab:") ||
+    specifier.startsWith("bitbucket:") ||
+    (specifier.startsWith("https://") && specifier.endsWith(".git")) ||
+    (specifier.startsWith("http://") && specifier.endsWith(".git"))
+  ) return "git";
+  return "npm";
+}
+
+// ─── Validation (mirrored from extension-validator.ts) ──────────────────────
+
+interface ValidationError {
+  code: string;
+  message: string;
+  field?: string;
+}
+
+interface ValidationResult {
+  valid: boolean;
+  errors: ValidationError[];
+}
+
+function validateExtensionPackage(pkg: unknown, opts: { extensionId?: string; allowGsdNamespace?: boolean } = {}): ValidationResult {
+  const errors: ValidationError[] = [];
+
+  // Check gsd.extension === true (strict)
+  if (typeof pkg !== "object" || pkg === null) {
+    errors.push({ code: "MISSING_GSD_MARKER", message: 'package.json must declare "gsd": { "extension": true } to be recognized as a GSD extension.', field: "gsd.extension" });
+  } else {
+    const obj = pkg as Record<string, unknown>;
+    const gsd = obj.gsd;
+    if (typeof gsd !== "object" || gsd === null || (gsd as Record<string, unknown>).extension !== true) {
+      errors.push({ code: "MISSING_GSD_MARKER", message: 'package.json must declare "gsd": { "extension": true } to be recognized as a GSD extension.', field: "gsd.extension" });
+    }
+  }
+
+  // Check namespace reservation
+  if (opts.extensionId && opts.extensionId.startsWith("gsd.") && opts.allowGsdNamespace !== true) {
+    errors.push({ code: "RESERVED_NAMESPACE", message: `Extension ID "${opts.extensionId}" is reserved for GSD core extensions. Use a different namespace for community extensions.`, field: "extensionId" });
+  }
+
+  // Check dependency placement
+  if (typeof pkg === "object" && pkg !== null) {
+    const obj = pkg as Record<string, unknown>;
+    for (const field of ["dependencies", "devDependencies"] as const) {
+      const deps = obj[field];
+      if (typeof deps === "object" && deps !== null) {
+        for (const pkgName of Object.keys(deps as Record<string, unknown>)) {
+          if (pkgName.startsWith("@gsd/")) {
+            errors.push({ code: "WRONG_DEP_FIELD", message: `"${pkgName}" must not appear in "${field}". Move it to "peerDependencies".`, field });
+          }
+        }
+      }
+    }
+  }
+
+  return { valid: errors.length === 0, errors };
+}
+
+// ─── Post-install convergence ────────────────────────────────────────────────
+
+/**
+ * Post-install convergence: validate package, read manifest, write registry entry.
+ * All three install types (npm, git, local) call this after files are in place.
+ * Returns the extension ID on success, or null on failure (with error notified).
+ */
+function postInstallValidate(
+  destPath: string,
+  specifier: string,
+  installType: "npm" | "git" | "local",
+  ctx: ExtensionCommandContext,
+): string | null {
+  // Read package.json
+  const pkgJsonPath = join(destPath, "package.json");
+  if (!existsSync(pkgJsonPath)) {
+    ctx.ui.notify(`Cannot install "${specifier}": no package.json found.`, "error");
+    return null;
+  }
+  let pkgJson: Record<string, unknown>;
+  try {
+    pkgJson = JSON.parse(readFileSync(pkgJsonPath, "utf-8"));
+  } catch {
+    ctx.ui.notify(`Cannot install "${specifier}": malformed package.json.`, "error");
+    return null;
+  }
+
+  // Read extension-manifest.json for the ID
+  const manifest = readManifest(destPath);
+  const extensionId = manifest?.id;
+
+  // Validate
+  const validation = validateExtensionPackage(pkgJson, { extensionId });
+  if (!validation.valid) {
+    const msgs = validation.errors.map(e => e.message).join("\n");
+    ctx.ui.notify(`Cannot install "${specifier}": ${msgs}`, "error");
+    return null;
+  }
+
+  if (!manifest || !extensionId) {
+    ctx.ui.notify(`Cannot install "${specifier}": no extension-manifest.json with valid id found.`, "error");
+    return null;
+  }
+
+  // Write registry entry with source: "user" and Phase 8 fields
+  const registry = loadRegistry();
+  registry.entries[extensionId] = {
+    id: extensionId,
+    enabled: true,
+    source: "user",
+    version: manifest.version,
+    installedFrom: specifier,
+    installType,
+  };
+  saveRegistry(registry);
+
+  return extensionId;
+}
+
+// ─── Install subcommand ──────────────────────────────────────────────────────
+
+async function handleInstall(specifier: string | undefined, ctx: ExtensionCommandContext): Promise<void> {
+  if (!specifier) {
+    ctx.ui.notify("Usage: /gsd extensions install <npm-package|git-url|local-path>", "warning");
+    return;
+  }
+
+  const installType = detectInstallType(specifier);
+  const installedExtDir = getInstalledExtDir();
+  mkdirSync(installedExtDir, { recursive: true });
+
+  process.stderr.write(`Installing ${specifier}...\n`);
+
+  if (installType === "npm") {
+    installFromNpm(specifier, installedExtDir, ctx);
+  } else if (installType === "git") {
+    installFromGit(specifier, installedExtDir, ctx);
+  } else {
+    installFromLocal(specifier, installedExtDir, ctx);
+  }
+}
+
+function installFromNpm(specifier: string, installedExtDir: string, ctx: ExtensionCommandContext): void {
+  const packDir = mkdtempSync(join(tmpdir(), "gsd-install-"));
+  try {
+    // Step 1: npm pack to tmpdir (D-01, D-05)
+    execFileSync("npm", ["pack", specifier, "--pack-destination", packDir, "--ignore-scripts"], {
+      stdio: "pipe",
+      encoding: "utf-8",
+    });
+
+    // Step 2: Find the tarball
+    const tgzFile = readdirSync(packDir).find(f => f.endsWith(".tgz"));
+    if (!tgzFile) throw new Error("npm pack produced no tarball");
+
+    // Step 3: Extract via tar with --strip-components=1 (flat dir, no package/ wrapper)
+    const extractDir = join(packDir, "extracted");
+    mkdirSync(extractDir, { recursive: true });
+    execFileSync("tar", ["xzf", join(packDir, tgzFile), "-C", extractDir, "--strip-components=1"], { stdio: "pipe" });
+
+    // Step 4: Validate and get extension ID
+    const extensionId = postInstallValidate(extractDir, specifier, "npm", ctx);
+    if (!extensionId) {
+      return; // Error already notified
+    }
+
+    // Step 5: Move to final destination
+    const destPath = join(installedExtDir, extensionId);
+    if (existsSync(destPath)) {
+      rmSync(destPath, { recursive: true, force: true });
+    }
+    renameSync(extractDir, destPath);
+
+    // Step 6: Re-read manifest for version display
+    const manifest = readManifest(destPath);
+    const version = manifest?.version ?? "unknown";
+    ctx.ui.notify(`Installed "${extensionId}" v${version}. Restart GSD to activate.`, "info");
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    ctx.ui.notify(`Failed to install "${specifier}": ${msg}`, "error");
+  } finally {
+    rmSync(packDir, { recursive: true, force: true });
+  }
+}
+
+function installFromGit(gitUrl: string, installedExtDir: string, ctx: ExtensionCommandContext): void {
+  // Clone into temp dir, validate, then rename to real ID (D-02)
+  const tmpDir = join(installedExtDir, `__installing-${Date.now()}`);
+  try {
+    execFileSync("git", ["clone", "--depth=1", gitUrl, tmpDir], { stdio: "pipe" });
+
+    // Remove .git directory — not needed after clone
+    const dotGit = join(tmpDir, ".git");
+    if (existsSync(dotGit)) {
+      rmSync(dotGit, { recursive: true, force: true });
+    }
+
+    const extensionId = postInstallValidate(tmpDir, gitUrl, "git", ctx);
+    if (!extensionId) {
+      rmSync(tmpDir, { recursive: true, force: true });
+      return;
+    }
+
+    const destPath = join(installedExtDir, extensionId);
+    if (existsSync(destPath)) {
+      rmSync(destPath, { recursive: true, force: true });
+    }
+    renameSync(tmpDir, destPath);
+
+    const manifest = readManifest(destPath);
+    const version = manifest?.version ?? "unknown";
+    ctx.ui.notify(`Installed "${extensionId}" v${version}. Restart GSD to activate.`, "info");
+  } catch (err) {
+    if (existsSync(tmpDir)) rmSync(tmpDir, { recursive: true, force: true });
+    const msg = err instanceof Error ? err.message : String(err);
+    ctx.ui.notify(`Failed to install "${gitUrl}": ${msg}`, "error");
+  }
+}
+
+function installFromLocal(localPath: string, installedExtDir: string, ctx: ExtensionCommandContext): void {
+  // Resolve path and copy (not symlink) per D-03
+  const sourcePath = resolve(localPath.startsWith("~/") ? join(homedir(), localPath.slice(2)) : localPath);
+
+  if (!existsSync(sourcePath)) {
+    ctx.ui.notify(`Cannot install "${localPath}": path does not exist.`, "error");
+    return;
+  }
+
+  // Copy to temp dir first, validate, then rename
+  const tmpDir = join(installedExtDir, `__installing-${Date.now()}`);
+  try {
+    cpSync(sourcePath, tmpDir, { recursive: true });
+
+    const extensionId = postInstallValidate(tmpDir, localPath, "local", ctx);
+    if (!extensionId) {
+      rmSync(tmpDir, { recursive: true, force: true });
+      return;
+    }
+
+    const destPath = join(installedExtDir, extensionId);
+    if (existsSync(destPath)) {
+      rmSync(destPath, { recursive: true, force: true });
+    }
+    renameSync(tmpDir, destPath);
+
+    const manifest = readManifest(destPath);
+    const version = manifest?.version ?? "unknown";
+    ctx.ui.notify(`Installed "${extensionId}" v${version}. Restart GSD to activate.`, "info");
+  } catch (err) {
+    if (existsSync(tmpDir)) rmSync(tmpDir, { recursive: true, force: true });
+    const msg = err instanceof Error ? err.message : String(err);
+    ctx.ui.notify(`Failed to install "${localPath}": ${msg}`, "error");
+  }
+}
+
 // ─── Command Handler ────────────────────────────────────────────────────────
 
 export async function handleExtensions(args: string, ctx: ExtensionCommandContext): Promise<void> {
@@ -138,8 +411,13 @@ export async function handleExtensions(args: string, ctx: ExtensionCommandContex
     return;
   }
 
+  if (subCmd === "install") {
+    await handleInstall(parts[1], ctx);
+    return;
+  }
+
   ctx.ui.notify(
-    `Unknown: /gsd extensions ${subCmd}. Usage: /gsd extensions [list|enable|disable|info]`,
+    `Unknown: /gsd extensions ${subCmd}. Usage: /gsd extensions [list|enable|disable|info|install|uninstall|update]`,
     "warning",
   );
 }

--- a/src/resources/extensions/gsd/commands-extensions.ts
+++ b/src/resources/extensions/gsd/commands-extensions.ts
@@ -133,13 +133,18 @@ function readManifest(dir: string): ExtensionManifest | null {
 }
 
 function discoverManifests(): Map<string, ExtensionManifest> {
-  const extDir = getAgentExtensionsDir();
   const manifests = new Map<string, ExtensionManifest>();
-  if (!existsSync(extDir)) return manifests;
-  for (const entry of readdirSync(extDir, { withFileTypes: true })) {
-    if (!entry.isDirectory() && !entry.isSymbolicLink()) continue;
-    const m = readManifest(join(extDir, entry.name));
-    if (m) manifests.set(m.id, m);
+  // Scan both bundled/agent dir and user-installed dir so CLI (list/info/
+  // enable/disable) sees the same set the loader will merge at runtime.
+  // Bundled entries are scanned first so user-installed IDs override on collision.
+  const dirs = [getAgentExtensionsDir(), getInstalledExtDir()];
+  for (const extDir of dirs) {
+    if (!existsSync(extDir)) continue;
+    for (const entry of readdirSync(extDir, { withFileTypes: true })) {
+      if (!entry.isDirectory() && !entry.isSymbolicLink()) continue;
+      const m = readManifest(join(extDir, entry.name));
+      if (m) manifests.set(m.id, m);
+    }
   }
   return manifests;
 }
@@ -221,16 +226,28 @@ function validateExtensionPackage(pkg: unknown, opts: { extensionId?: string; al
 // ─── Post-install convergence ────────────────────────────────────────────────
 
 /**
- * Post-install convergence: validate package, read manifest, write registry entry.
- * All three install types (npm, git, local) call this after files are in place.
- * Returns the extension ID on success, or null on failure (with error notified).
+ * Allowed characters for an extension id when used as a path segment.
+ * Rejects anything that could enable traversal or escape (slashes, "..", backslashes).
+ */
+const SAFE_EXTENSION_ID_RE = /^[A-Za-z0-9._-]+$/;
+
+function isSafeExtensionId(id: string): boolean {
+  if (!id || id === "." || id === "..") return false;
+  if (id.includes("/") || id.includes("\\") || id.includes("..")) return false;
+  return SAFE_EXTENSION_ID_RE.test(id);
+}
+
+/**
+ * Post-install convergence: validate package and read manifest.
+ * Returns the (validated) extension ID and manifest on success, or null on failure.
+ * Caller is responsible for writing the registry entry *after* the final commit
+ * rename succeeds so a failed move doesn't leave a dangling registry entry.
  */
 function postInstallValidate(
   destPath: string,
   specifier: string,
-  installType: "npm" | "git" | "local",
   ctx: ExtensionCommandContext,
-): string | null {
+): { id: string; manifest: ExtensionManifest } | null {
   // Read package.json
   const pkgJsonPath = join(destPath, "package.json");
   if (!existsSync(pkgJsonPath)) {
@@ -262,12 +279,32 @@ function postInstallValidate(
     return null;
   }
 
-  // Write registry entry with source: "user" and Phase 8 fields.
-  // Wrap in withRegistryLock so concurrent installs serialize rather than
-  // trample each other's entries.
+  // The id from the manifest is used as a path segment under installedExtDir.
+  // Reject unsafe ids before the caller performs any path joins.
+  if (!isSafeExtensionId(extensionId)) {
+    ctx.ui.notify(
+      `Cannot install "${specifier}": extension id "${extensionId}" contains unsafe characters (allowed: alphanumerics, ".", "-", "_").`,
+      "error",
+    );
+    return null;
+  }
+
+  return { id: extensionId, manifest };
+}
+
+/**
+ * Write the registry entry for a freshly-installed extension. Called after the
+ * final destination commit succeeds so a failed rename can't leave a stale entry.
+ */
+function writeInstalledRegistryEntry(
+  id: string,
+  manifest: ExtensionManifest,
+  specifier: string,
+  installType: "npm" | "git" | "local",
+): void {
   withRegistryLock((registry) => {
-    registry.entries[extensionId] = {
-      id: extensionId,
+    registry.entries[id] = {
+      id,
       enabled: true,
       source: "user",
       version: manifest.version,
@@ -275,8 +312,6 @@ function postInstallValidate(
       installType,
     };
   });
-
-  return extensionId;
 }
 
 // ─── Uninstall helpers ───────────────────────────────────────────────────────
@@ -536,7 +571,11 @@ async function handleInstall(specifier: string | undefined, ctx: ExtensionComman
 }
 
 function installFromNpm(specifier: string, installedExtDir: string, ctx: ExtensionCommandContext): void {
+  // packDir holds the tarball in tmpdir(). The *extractDir* is staged inside
+  // installedExtDir so the final renameSync to destPath stays on a single
+  // filesystem (avoids EXDEV when tmpdir() and ~/.gsd live on different mounts).
   const packDir = mkdtempSync(join(tmpdir(), "gsd-install-"));
+  let extractDir: string | null = null;
   try {
     // Step 1: npm pack to tmpdir (D-01, D-05)
     execFileSync("npm", ["pack", specifier, "--pack-destination", packDir, "--ignore-scripts"], {
@@ -548,32 +587,34 @@ function installFromNpm(specifier: string, installedExtDir: string, ctx: Extensi
     const tgzFile = readdirSync(packDir).find(f => f.endsWith(".tgz"));
     if (!tgzFile) throw new Error("npm pack produced no tarball");
 
-    // Step 3: Extract via tar with --strip-components=1 (flat dir, no package/ wrapper)
-    const extractDir = join(packDir, "extracted");
-    mkdirSync(extractDir, { recursive: true });
+    // Step 3: Extract via tar into a staging dir *inside* installedExtDir
+    extractDir = mkdtempSync(join(installedExtDir, "tmp-npm-"));
     execFileSync("tar", ["xzf", join(packDir, tgzFile), "-C", extractDir, "--strip-components=1"], { stdio: "pipe" });
 
     // Step 4: Validate and get extension ID
-    const extensionId = postInstallValidate(extractDir, specifier, "npm", ctx);
-    if (!extensionId) {
+    const validated = postInstallValidate(extractDir, specifier, ctx);
+    if (!validated) {
       return; // Error already notified
     }
 
-    // Step 5: Move to final destination
-    const destPath = join(installedExtDir, extensionId);
+    // Step 5: Move to final destination — same filesystem as extractDir
+    const destPath = join(installedExtDir, validated.id);
     if (existsSync(destPath)) {
       rmSync(destPath, { recursive: true, force: true });
     }
     renameSync(extractDir, destPath);
+    extractDir = null; // Successfully moved; skip cleanup
 
-    // Step 6: Re-read manifest for version display
-    const manifest = readManifest(destPath);
-    const version = manifest?.version ?? "unknown";
-    ctx.ui.notify(`Installed "${extensionId}" v${version}. Restart GSD to activate.`, "info");
+    // Step 6: Commit the registry entry only after the rename succeeds.
+    writeInstalledRegistryEntry(validated.id, validated.manifest, specifier, "npm");
+    ctx.ui.notify(`Installed "${validated.id}" v${validated.manifest.version ?? "unknown"}. Restart GSD to activate.`, "info");
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     ctx.ui.notify(`Failed to install "${specifier}": ${msg}`, "error");
   } finally {
+    if (extractDir && existsSync(extractDir)) {
+      try { rmSync(extractDir, { recursive: true, force: true }); } catch { /* best-effort */ }
+    }
     rmSync(packDir, { recursive: true, force: true });
   }
 }
@@ -590,21 +631,20 @@ function installFromGit(gitUrl: string, installedExtDir: string, ctx: ExtensionC
       rmSync(dotGit, { recursive: true, force: true });
     }
 
-    const extensionId = postInstallValidate(tmpDir, gitUrl, "git", ctx);
-    if (!extensionId) {
+    const validated = postInstallValidate(tmpDir, gitUrl, ctx);
+    if (!validated) {
       rmSync(tmpDir, { recursive: true, force: true });
       return;
     }
 
-    const destPath = join(installedExtDir, extensionId);
+    const destPath = join(installedExtDir, validated.id);
     if (existsSync(destPath)) {
       rmSync(destPath, { recursive: true, force: true });
     }
     renameSync(tmpDir, destPath);
 
-    const manifest = readManifest(destPath);
-    const version = manifest?.version ?? "unknown";
-    ctx.ui.notify(`Installed "${extensionId}" v${version}. Restart GSD to activate.`, "info");
+    writeInstalledRegistryEntry(validated.id, validated.manifest, gitUrl, "git");
+    ctx.ui.notify(`Installed "${validated.id}" v${validated.manifest.version ?? "unknown"}. Restart GSD to activate.`, "info");
   } catch (err) {
     if (existsSync(tmpDir)) rmSync(tmpDir, { recursive: true, force: true });
     const msg = err instanceof Error ? err.message : String(err);
@@ -626,21 +666,20 @@ function installFromLocal(localPath: string, installedExtDir: string, ctx: Exten
   try {
     cpSync(sourcePath, tmpDir, { recursive: true });
 
-    const extensionId = postInstallValidate(tmpDir, localPath, "local", ctx);
-    if (!extensionId) {
+    const validated = postInstallValidate(tmpDir, localPath, ctx);
+    if (!validated) {
       rmSync(tmpDir, { recursive: true, force: true });
       return;
     }
 
-    const destPath = join(installedExtDir, extensionId);
+    const destPath = join(installedExtDir, validated.id);
     if (existsSync(destPath)) {
       rmSync(destPath, { recursive: true, force: true });
     }
     renameSync(tmpDir, destPath);
 
-    const manifest = readManifest(destPath);
-    const version = manifest?.version ?? "unknown";
-    ctx.ui.notify(`Installed "${extensionId}" v${version}. Restart GSD to activate.`, "info");
+    writeInstalledRegistryEntry(validated.id, validated.manifest, localPath, "local");
+    ctx.ui.notify(`Installed "${validated.id}" v${validated.manifest.version ?? "unknown"}. Restart GSD to activate.`, "info");
   } catch (err) {
     if (existsSync(tmpDir)) rmSync(tmpDir, { recursive: true, force: true });
     const msg = err instanceof Error ? err.message : String(err);

--- a/src/resources/extensions/gsd/commands-extensions.ts
+++ b/src/resources/extensions/gsd/commands-extensions.ts
@@ -11,6 +11,7 @@ import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, 
 import { dirname, join, resolve } from "node:path";
 import { homedir, tmpdir } from "node:os";
 import { execFileSync } from "node:child_process";
+import { lockSync, unlockSync } from "proper-lockfile";
 import semver from "semver";
 
 const gsdHome = process.env.GSD_HOME || join(homedir(), ".gsd");
@@ -85,6 +86,32 @@ function saveRegistry(registry: ExtensionRegistry): void {
     writeFileSync(tmp, JSON.stringify(registry, null, 2), "utf-8");
     renameSync(tmp, filePath);
   } catch { /* non-fatal */ }
+}
+
+/**
+ * Run a registry load → mutate → save transaction under a cross-process lock.
+ * Prevents two concurrent `gsd extensions install/uninstall/update` invocations
+ * from trampling each other's registry mutations.
+ *
+ * Uses proper-lockfile.lockSync against the registry path. Directory is created
+ * first so locking works on fresh installs. Lock is always released via finally.
+ */
+function withRegistryLock<T>(mutate: (registry: ExtensionRegistry) => T): T {
+  const filePath = getRegistryPath();
+  mkdirSync(dirname(filePath), { recursive: true });
+  // lockSync requires the file to exist — ensure it does before acquiring.
+  if (!existsSync(filePath)) {
+    writeFileSync(filePath, JSON.stringify({ version: 1, entries: {} }, null, 2), "utf-8");
+  }
+  lockSync(filePath, { retries: { retries: 5, minTimeout: 50, maxTimeout: 500 } });
+  try {
+    const registry = loadRegistry();
+    const result = mutate(registry);
+    saveRegistry(registry);
+    return result;
+  } finally {
+    try { unlockSync(filePath); } catch { /* lock may already be gone */ }
+  }
 }
 
 function isEnabled(registry: ExtensionRegistry, id: string): boolean {
@@ -235,17 +262,19 @@ function postInstallValidate(
     return null;
   }
 
-  // Write registry entry with source: "user" and Phase 8 fields
-  const registry = loadRegistry();
-  registry.entries[extensionId] = {
-    id: extensionId,
-    enabled: true,
-    source: "user",
-    version: manifest.version,
-    installedFrom: specifier,
-    installType,
-  };
-  saveRegistry(registry);
+  // Write registry entry with source: "user" and Phase 8 fields.
+  // Wrap in withRegistryLock so concurrent installs serialize rather than
+  // trample each other's entries.
+  withRegistryLock((registry) => {
+    registry.entries[extensionId] = {
+      id: extensionId,
+      enabled: true,
+      source: "user",
+      version: manifest.version,
+      installedFrom: specifier,
+      installType,
+    };
+  });
 
   return extensionId;
 }
@@ -276,46 +305,56 @@ function handleUninstall(id: string | undefined, ctx: ExtensionCommandContext): 
     return;
   }
 
-  const registry = loadRegistry();
-  const entry = registry.entries[id];
+  // Hold the registry lock for the entire uninstall transaction so a concurrent
+  // install can't add or re-enable `id` while we're in the middle of removing it.
+  const result = withRegistryLock((registry) => {
+    const entry = registry.entries[id];
 
-  // Check if extension exists and is user-installed
-  if (!entry || entry.source !== "user") {
-    ctx.ui.notify(
-      `Extension "${id}" not found in registry. Run /gsd extensions list to see installed extensions.`,
-      "warning",
-    );
+    // Check if extension exists and is user-installed
+    if (!entry || entry.source !== "user") {
+      return { ok: false as const, reason: "not-found" as const };
+    }
+
+    const installedExtDir = getInstalledExtDir();
+    const extDir = join(installedExtDir, id);
+
+    // Check for dependents and warn (D-06: warn-then-proceed)
+    const dependents = findDependents(id, installedExtDir);
+
+    // Remove directory first, then registry entry (Pitfall 4 from RESEARCH.md)
+    // If rm fails, do NOT remove registry entry — leaves a recoverable state
+    try {
+      if (existsSync(extDir)) {
+        rmSync(extDir, { recursive: true, force: true });
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return { ok: false as const, reason: "rm-failed" as const, msg };
+    }
+
+    // Remove registry entry (D-07)
+    delete registry.entries[id];
+    return { ok: true as const, dependents };
+  });
+
+  if (!result.ok) {
+    if (result.reason === "not-found") {
+      ctx.ui.notify(
+        `Extension "${id}" not found in registry. Run /gsd extensions list to see installed extensions.`,
+        "warning",
+      );
+    } else if (result.reason === "rm-failed") {
+      ctx.ui.notify(`Failed to remove extension directory for "${id}": ${result.msg}`, "error");
+    }
     return;
   }
 
-  const installedExtDir = getInstalledExtDir();
-  const extDir = join(installedExtDir, id);
-
-  // Check for dependents and warn (D-06: warn-then-proceed)
-  const dependents = findDependents(id, installedExtDir);
-  if (dependents.length > 0) {
+  if (result.dependents.length > 0) {
     ctx.ui.notify(
-      `Warning: the following installed extensions depend on "${id}": ${dependents.join(", ")}. Removing anyway.`,
+      `Warning: the following installed extensions depend on "${id}": ${result.dependents.join(", ")}. Removed anyway.`,
       "warning",
     );
   }
-
-  // Remove directory first, then registry entry (Pitfall 4 from RESEARCH.md)
-  // If rm fails, do NOT remove registry entry — leaves a recoverable state
-  try {
-    if (existsSync(extDir)) {
-      rmSync(extDir, { recursive: true, force: true });
-    }
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    ctx.ui.notify(`Failed to remove extension directory for "${id}": ${msg}`, "error");
-    return; // Do NOT remove registry entry — directory still exists
-  }
-
-  // Remove registry entry (D-07)
-  delete registry.entries[id];
-  saveRegistry(registry);
-
   ctx.ui.notify(`Uninstalled "${id}". Restart GSD to deactivate.`, "info");
 }
 
@@ -374,9 +413,23 @@ async function updateSingleExtension(
 
   // npm extension: check for newer version (D-09)
   const current = entry.version ?? "0.0.0";
-  const packageName = entry.installedFrom;
-  if (!packageName) {
+  const specifier = entry.installedFrom;
+  if (!specifier) {
     ctx.ui.notify(`"${id}" has no recorded install source. Reinstall manually.`, "warning");
+    return;
+  }
+
+  // Split npm specifier into name + optional pin.
+  // Scoped (`@scope/name[@version]`) vs unscoped (`name[@version]`).
+  const { name: packageName, pin } = parseNpmSpecifier(specifier);
+
+  // Pinned installs: the user explicitly requested a specific version. Don't
+  // silently upgrade past the pin — tell them to re-install with a new pin.
+  if (pin) {
+    ctx.ui.notify(
+      `"${id}" was installed with a pinned version (${pin}). To update, run: gsd extensions install ${packageName}@<new-version>`,
+      "info",
+    );
     return;
   }
 
@@ -392,6 +445,18 @@ async function updateSingleExtension(
   } else {
     ctx.ui.notify(`"${id}" is already at the latest version (v${current}).`, "info");
   }
+}
+
+/**
+ * Parse an npm specifier into its package name and optional version pin.
+ * Handles scoped (`@scope/name[@version]`) and unscoped (`name[@version]`).
+ */
+function parseNpmSpecifier(specifier: string): { name: string; pin: string | null } {
+  const isScoped = specifier.startsWith("@");
+  const searchFrom = isScoped ? specifier.indexOf("/") + 1 : 0;
+  const atIdx = specifier.indexOf("@", searchFrom);
+  if (atIdx === -1) return { name: specifier, pin: null };
+  return { name: specifier.slice(0, atIdx), pin: specifier.slice(atIdx + 1) };
 }
 
 async function updateAllExtensions(
@@ -699,21 +764,22 @@ function handleEnable(id: string | undefined, ctx: ExtensionCommandContext): voi
     return;
   }
 
-  const registry = loadRegistry();
-  if (isEnabled(registry, id)) {
+  const alreadyEnabled = withRegistryLock((registry) => {
+    if (isEnabled(registry, id)) return true;
+    const entry = registry.entries[id];
+    if (entry) {
+      entry.enabled = true;
+      delete entry.disabledAt;
+      delete entry.disabledReason;
+    } else {
+      registry.entries[id] = { id, enabled: true, source: "bundled" };
+    }
+    return false;
+  });
+  if (alreadyEnabled) {
     ctx.ui.notify(`Extension "${id}" is already enabled.`, "info");
     return;
   }
-
-  const entry = registry.entries[id];
-  if (entry) {
-    entry.enabled = true;
-    delete entry.disabledAt;
-    delete entry.disabledReason;
-  } else {
-    registry.entries[id] = { id, enabled: true, source: "bundled" };
-  }
-  saveRegistry(registry);
   ctx.ui.notify(`Enabled "${id}". Restart GSD to activate.`, "info");
 }
 
@@ -736,27 +802,28 @@ function handleDisable(id: string | undefined, reason: string, ctx: ExtensionCom
     return;
   }
 
-  const registry = loadRegistry();
-  if (!isEnabled(registry, id)) {
+  const alreadyDisabled = withRegistryLock((registry) => {
+    if (!isEnabled(registry, id)) return true;
+    const entry = registry.entries[id];
+    if (entry) {
+      entry.enabled = false;
+      entry.disabledAt = new Date().toISOString();
+      entry.disabledReason = reason || undefined;
+    } else {
+      registry.entries[id] = {
+        id,
+        enabled: false,
+        source: "bundled",
+        disabledAt: new Date().toISOString(),
+        disabledReason: reason || undefined,
+      };
+    }
+    return false;
+  });
+  if (alreadyDisabled) {
     ctx.ui.notify(`Extension "${id}" is already disabled.`, "info");
     return;
   }
-
-  const entry = registry.entries[id];
-  if (entry) {
-    entry.enabled = false;
-    entry.disabledAt = new Date().toISOString();
-    entry.disabledReason = reason || undefined;
-  } else {
-    registry.entries[id] = {
-      id,
-      enabled: false,
-      source: "bundled",
-      disabledAt: new Date().toISOString(),
-      disabledReason: reason || undefined,
-    };
-  }
-  saveRegistry(registry);
   ctx.ui.notify(`Disabled "${id}". Restart GSD to deactivate.`, "info");
 }
 

--- a/src/resources/extensions/gsd/notifications.ts
+++ b/src/resources/extensions/gsd/notifications.ts
@@ -4,7 +4,6 @@
 import { execFileSync } from "node:child_process";
 import type { NotificationPreferences } from "./types.js";
 import { loadEffectiveGSDPreferences } from "./preferences.js";
-import { CmuxClient, emitOsc777Notification, resolveCmuxConfig } from "../cmux/index.js";
 import { sendRemoteNotification } from "../remote-questions/notify.js";
 
 export type NotifyLevel = "info" | "success" | "warning" | "error";
@@ -39,20 +38,22 @@ export function sendDesktopNotification(
 
   if (!shouldSendDesktopNotification(kind, loaded?.notifications)) return;
 
-  const cmux = resolveCmuxConfig(loaded);
-  if (cmux.notifications) {
-    const delivered = CmuxClient.fromPreferences(loaded).notify(title, message);
-    if (delivered) return;
-    emitOsc777Notification(title, message);
-  }
+  void import("../cmux/index.js").then(({ CmuxClient, emitOsc777Notification, resolveCmuxConfig }) => {
+    const cmux = resolveCmuxConfig(loaded);
+    if (cmux.notifications) {
+      const delivered = CmuxClient.fromPreferences(loaded).notify(title, message);
+      if (delivered) return;
+      emitOsc777Notification(title, message);
+    }
 
-  try {
-    const command = buildDesktopNotificationCommand(process.platform, title, message, level);
-    if (!command) return;
-    execFileSync(command.file, command.args, { timeout: 3000, stdio: "ignore" });
-  } catch {
-    // Non-fatal — desktop notifications are best-effort
-  }
+    try {
+      const command = buildDesktopNotificationCommand(process.platform, title, message, level);
+      if (!command) return;
+      execFileSync(command.file, command.args, { timeout: 3000, stdio: "ignore" });
+    } catch {
+      // Non-fatal — desktop notifications are best-effort
+    }
+  });
 }
 
 export function shouldSendDesktopNotification(

--- a/src/resources/extensions/gsd/notifications.ts
+++ b/src/resources/extensions/gsd/notifications.ts
@@ -38,14 +38,25 @@ export function sendDesktopNotification(
 
   if (!shouldSendDesktopNotification(kind, loaded?.notifications)) return;
 
-  void import("../cmux/index.js").then(({ CmuxClient, emitOsc777Notification, resolveCmuxConfig }) => {
-    const cmux = resolveCmuxConfig(loaded);
-    if (cmux.notifications) {
-      const delivered = CmuxClient.fromPreferences(loaded).notify(title, message);
-      if (delivered) return;
-      emitOsc777Notification(title, message);
+  // cmux delivery and desktop delivery are independent — if cmux import or
+  // delivery fails, we must still attempt the native desktop notification.
+  const runCmux = async () => {
+    try {
+      const { CmuxClient, emitOsc777Notification, resolveCmuxConfig } = await import("../cmux/index.js");
+      const cmux = resolveCmuxConfig(loaded);
+      if (cmux.notifications) {
+        const delivered = CmuxClient.fromPreferences(loaded).notify(title, message);
+        if (delivered) return true;
+        emitOsc777Notification(title, message);
+      }
+    } catch {
+      // cmux unavailable — fall through to desktop notification
     }
+    return false;
+  };
 
+  void runCmux().then((deliveredByCmux) => {
+    if (deliveredByCmux) return;
     try {
       const command = buildDesktopNotificationCommand(process.platform, title, message, level);
       if (!command) return;
@@ -53,7 +64,7 @@ export function sendDesktopNotification(
     } catch {
       // Non-fatal — desktop notifications are best-effort
     }
-  });
+  }).catch(() => {});
 }
 
 export function shouldSendDesktopNotification(

--- a/src/resources/extensions/gsd/tests/cmux.test.ts
+++ b/src/resources/extensions/gsd/tests/cmux.test.ts
@@ -14,7 +14,7 @@ import {
   shouldPromptToEnableCmux,
 } from "../../cmux/index.ts";
 import { autoEnableCmuxPreferences } from "../commands-cmux.ts";
-import type { GSDState } from "../types.ts";
+import type { CmuxStateInput } from "../../shared/cmux-events.ts";
 
 test("detectCmuxEnvironment requires workspace, surface, and socket", () => {
   const detected = detectCmuxEnvironment(
@@ -146,15 +146,11 @@ describe("autoEnableCmuxPreferences", () => {
 });
 
 test("buildCmuxStatusLabel and progress prefer deepest active unit", () => {
-  const state: GSDState = {
-    activeMilestone: { id: "M001", title: "Milestone" },
-    activeSlice: { id: "S02", title: "Slice" },
-    activeTask: { id: "T03", title: "Task" },
+  const state: CmuxStateInput = {
+    activeMilestone: { id: "M001" },
+    activeSlice: { id: "S02" },
+    activeTask: { id: "T03" },
     phase: "executing",
-    recentDecisions: [],
-    blockers: [],
-    nextAction: "Keep going",
-    registry: [],
     progress: {
       milestones: { done: 0, total: 1 },
       slices: { done: 1, total: 3 },

--- a/src/resources/extensions/gsd/tests/milestone-transition-state-rebuild.test.ts
+++ b/src/resources/extensions/gsd/tests/milestone-transition-state-rebuild.test.ts
@@ -85,8 +85,10 @@ test("auto.ts buildLoopDeps wires rebuildState", () => {
     "utf-8",
   );
 
-  // rebuildState should be in the LoopDeps object literal
-  const buildLoopDepsIdx = autoSrc.indexOf("function buildLoopDeps()");
+  // rebuildState should be in the LoopDeps object literal.
+  // Match the signature prefix so the test survives future param changes
+  // (e.g. the DECOUPLE-02 change from `()` to `(pi: ExtensionAPI)`).
+  const buildLoopDepsIdx = autoSrc.indexOf("function buildLoopDeps(");
   assert.ok(buildLoopDepsIdx > 0, "buildLoopDeps function should exist");
 
   const afterBuild = autoSrc.slice(buildLoopDepsIdx);

--- a/src/resources/extensions/gsd/tests/workflow-mcp.test.ts
+++ b/src/resources/extensions/gsd/tests/workflow-mcp.test.ts
@@ -180,6 +180,11 @@ test("detectWorkflowMcpLaunchConfig resolves the bundled server relative to the 
 test("workflow MCP launch config reaches mutation tools over stdio", async () => {
   const projectRoot = mkdtempSync(join(tmpdir(), "gsd-workflow-transport-"));
   mkdirSync(join(projectRoot, ".gsd"), { recursive: true });
+  // Isolate the spawned MCP server from the developer's real ~/.gsd so it
+  // can't pick up a configured Discord/Slack/Telegram channel from global
+  // PREFERENCES.md and route ask_user_questions through a remote adapter
+  // instead of MCP elicitation.
+  const isolatedGsdHome = mkdtempSync(join(tmpdir(), "gsd-workflow-home-"));
 
   const launch = detectWorkflowMcpLaunchConfig(projectRoot, {});
   assert.ok(launch, "expected a workflow MCP launch config");
@@ -219,7 +224,14 @@ test("workflow MCP launch config reaches mutation tools over stdio", async () =>
   const transport = new StdioClientTransport({
     command: launch.command,
     args: launch.args,
-    env: { ...process.env, ...launch.env } as Record<string, string>,
+    env: {
+      ...process.env,
+      ...launch.env,
+      GSD_HOME: isolatedGsdHome,
+      DISCORD_BOT_TOKEN: "",
+      SLACK_BOT_TOKEN: "",
+      TELEGRAM_BOT_TOKEN: "",
+    } as Record<string, string>,
     cwd: launch.cwd,
     stderr: "pipe",
   });
@@ -345,12 +357,14 @@ test("workflow MCP launch config reaches mutation tools over stdio", async () =>
   } finally {
     await client.close().catch(() => {});
     rmSync(projectRoot, { recursive: true, force: true });
+    rmSync(isolatedGsdHome, { recursive: true, force: true });
   }
 });
 
 test("workflow MCP ask_user_questions uses stdio elicitation round-trip", async () => {
   const projectRoot = mkdtempSync(join(tmpdir(), "gsd-workflow-elicit-"));
   mkdirSync(join(projectRoot, ".gsd"), { recursive: true });
+  const isolatedGsdHome = mkdtempSync(join(tmpdir(), "gsd-workflow-home-"));
 
   const launch = detectWorkflowMcpLaunchConfig(projectRoot, {});
   assert.ok(launch, "expected a workflow MCP launch config");
@@ -381,7 +395,14 @@ test("workflow MCP ask_user_questions uses stdio elicitation round-trip", async 
   const transport = new StdioClientTransport({
     command: launch.command,
     args: launch.args,
-    env: { ...process.env, ...launch.env } as Record<string, string>,
+    env: {
+      ...process.env,
+      ...launch.env,
+      GSD_HOME: isolatedGsdHome,
+      DISCORD_BOT_TOKEN: "",
+      SLACK_BOT_TOKEN: "",
+      TELEGRAM_BOT_TOKEN: "",
+    } as Record<string, string>,
     cwd: launch.cwd,
     stderr: "pipe",
   });
@@ -432,6 +453,8 @@ test("workflow MCP ask_user_questions uses stdio elicitation round-trip", async 
     );
   } finally {
     await client.close();
+    rmSync(projectRoot, { recursive: true, force: true });
+    rmSync(isolatedGsdHome, { recursive: true, force: true });
   }
 });
 

--- a/src/resources/extensions/shared/cmux-events.ts
+++ b/src/resources/extensions/shared/cmux-events.ts
@@ -1,0 +1,59 @@
+// GSD-2 — Shared cmux event channel contracts
+// Copyright (c) 2026 Jeremy McSpadden <jeremy@fluxlabs.net>
+
+/**
+ * Neutral event channel module for gsd<->cmux IPC.
+ * Both gsd and cmux import from here — neither imports the other directly.
+ * Per ADR-006 Phase 0: event-based decoupling.
+ */
+
+export const CMUX_CHANNELS = {
+  SIDEBAR: "cmux:sidebar",
+  LOG: "cmux:log",
+  LIFECYCLE: "cmux:lifecycle",
+} as const;
+
+/** Migrated from cmux/index.ts (D-07) — shared by both gsd and cmux. */
+export type CmuxLogLevel = "info" | "progress" | "success" | "warning" | "error";
+
+// ── Structural types (D-05): cmux defines only what it needs ──
+
+export interface CmuxPreferencesInput {
+  cmux?: {
+    enabled?: boolean;
+    notifications?: boolean;
+    sidebar?: boolean;
+    splits?: boolean;
+    browser?: boolean;
+  };
+}
+
+export interface CmuxStateInput {
+  phase: string;
+  activeMilestone?: { id: string };
+  activeSlice?: { id: string };
+  activeTask?: { id: string };
+  progress?: {
+    milestones: { done: number; total: number };
+    slices?: { done: number; total: number };
+    tasks?: { done: number; total: number };
+  };
+}
+
+// ── Event payloads ──
+
+export interface CmuxSidebarEvent {
+  action: "sync" | "clear";
+  preferences?: CmuxPreferencesInput;
+  state?: CmuxStateInput;
+}
+
+export interface CmuxLogEvent {
+  preferences?: CmuxPreferencesInput;
+  message: string;
+  level: CmuxLogLevel;
+}
+
+export interface CmuxLifecycleEvent {
+  action: "markPromptShown";
+}

--- a/src/resources/extensions/shared/rtk-session-stats.ts
+++ b/src/resources/extensions/shared/rtk-session-stats.ts
@@ -2,7 +2,6 @@ import { spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
-import { gsdRoot } from "../gsd/paths.js";
 import { formatTokenCount } from "./format-utils.js";
 import { buildRtkEnv, isRtkEnabled, resolveRtkBinaryPath } from "./rtk.js";
 
@@ -46,7 +45,7 @@ interface BaselineStore {
 let cachedSummary: { at: number; binaryPath: string; summary: RtkGainSummary | null } | null = null;
 
 function getRuntimeDir(basePath: string): string {
-  return join(gsdRoot(basePath), "runtime");
+  return join(basePath, ".gsd", "runtime");
 }
 
 function getBaselinesPath(basePath: string): string {

--- a/src/tests/extension-discovery.test.ts
+++ b/src/tests/extension-discovery.test.ts
@@ -1,9 +1,12 @@
+// GSD-2 — Extension Discovery Tests
+// Copyright (c) 2026 Jeremy McSpadden <jeremy@fluxlabs.net>
+
 import test, { describe } from 'node:test'
 import assert from 'node:assert/strict'
 import { mkdirSync, writeFileSync, rmSync } from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
-import { resolveExtensionEntries, discoverExtensionEntryPaths } from '../extension-discovery.ts'
+import { resolveExtensionEntries, discoverExtensionEntryPaths, mergeExtensionEntryPaths } from '../extension-discovery.ts'
 
 function makeTempDir(): string {
   const dir = join(tmpdir(), `ext-discovery-test-${Date.now()}-${Math.random().toString(36).slice(2)}`)
@@ -96,5 +99,109 @@ describe('discoverExtensionEntryPaths', () => {
     assert.equal(paths.length, 1, 'should discover my-ext but skip cmux')
     assert.ok(paths[0].includes('my-ext'))
     assert.ok(!paths.some(p => p.includes('cmux')), 'cmux should not be discovered')
+  })
+})
+
+describe('mergeExtensionEntryPaths', () => {
+  function makeManifest(id: string): string {
+    return JSON.stringify({ id, name: id, version: '1.0.0', description: 'test', tier: 'bundled', requires: { platform: 'node' } })
+  }
+
+  test('returns bundledPaths unchanged when installedExtDir does not exist', (t) => {
+    const nonExistent = join(tmpdir(), `nonexistent-${Date.now()}`)
+    const bundled = ['/fake/path/ext-a/index.ts']
+    const result = mergeExtensionEntryPaths(bundled, nonExistent)
+    assert.deepEqual(result, bundled)
+  })
+
+  test('returns bundledPaths unchanged when installedExtDir is empty', (t) => {
+    const installedDir = join(tmpdir(), `installed-empty-${Date.now()}`)
+    t.after(() => rmSync(installedDir, { recursive: true, force: true }))
+    mkdirSync(installedDir, { recursive: true })
+    const bundled = ['/fake/path/ext-a/index.ts']
+    const result = mergeExtensionEntryPaths(bundled, installedDir)
+    assert.deepEqual(result, bundled)
+  })
+
+  test('appends installed extension entries to bundled paths when IDs differ', (t) => {
+    const root = join(tmpdir(), `installed-additive-${Date.now()}`)
+    t.after(() => rmSync(root, { recursive: true, force: true }))
+
+    // Create installed extension with different ID
+    const installedDir = join(root, 'installed')
+    const newExtDir = join(installedDir, 'new-extension')
+    mkdirSync(newExtDir, { recursive: true })
+    writeFileSync(join(newExtDir, 'extension-manifest.json'), makeManifest('new-extension'))
+    writeFileSync(join(newExtDir, 'index.ts'), 'export default function() {}')
+
+    const bundled = ['/fake/bundled/ext-a/index.ts']
+    const result = mergeExtensionEntryPaths(bundled, installedDir)
+
+    assert.equal(result.length, 2, 'should have 1 bundled + 1 installed')
+    assert.ok(result.includes('/fake/bundled/ext-a/index.ts'), 'bundled entry should be preserved')
+    assert.ok(result.some(p => p.includes('new-extension')), 'installed extension should be appended')
+  })
+
+  test('removes bundled entry when installed extension has same manifest ID (LOADER-02 precedence)', (t) => {
+    const root = join(tmpdir(), `installed-shadow-${Date.now()}`)
+    t.after(() => rmSync(root, { recursive: true, force: true }))
+
+    // Create bundled extension (just a fake entry path pointing to a real location with manifest)
+    const bundledDir = join(root, 'bundled')
+    const bundledExtDir = join(bundledDir, 'my-ext')
+    mkdirSync(bundledExtDir, { recursive: true })
+    writeFileSync(join(bundledExtDir, 'extension-manifest.json'), makeManifest('my-ext'))
+    writeFileSync(join(bundledExtDir, 'index.ts'), 'export default function() {}')
+    const bundledEntryPath = join(bundledExtDir, 'index.ts')
+
+    // Create installed extension with same ID
+    const installedDir = join(root, 'installed')
+    const installedExtDir = join(installedDir, 'my-ext-installed')
+    mkdirSync(installedExtDir, { recursive: true })
+    writeFileSync(join(installedExtDir, 'extension-manifest.json'), makeManifest('my-ext'))
+    writeFileSync(join(installedExtDir, 'index.ts'), 'export default function() {}')
+
+    const result = mergeExtensionEntryPaths([bundledEntryPath], installedDir)
+
+    assert.equal(result.length, 1, 'only one entry: installed takes precedence over bundled')
+    assert.ok(!result.includes(bundledEntryPath), 'bundled entry should be excluded')
+    assert.ok(result.some(p => p.includes('my-ext-installed')), 'installed entry should be present')
+  })
+
+  test('handles multiple installed extensions, some shadowing, some additive', (t) => {
+    const root = join(tmpdir(), `installed-mixed-${Date.now()}`)
+    t.after(() => rmSync(root, { recursive: true, force: true }))
+
+    // Create two bundled extensions
+    const bundledDir = join(root, 'bundled')
+    const bundledExtA = join(bundledDir, 'ext-a')
+    const bundledExtB = join(bundledDir, 'ext-b')
+    mkdirSync(bundledExtA, { recursive: true })
+    mkdirSync(bundledExtB, { recursive: true })
+    writeFileSync(join(bundledExtA, 'extension-manifest.json'), makeManifest('ext-a'))
+    writeFileSync(join(bundledExtA, 'index.ts'), 'export default function() {}')
+    writeFileSync(join(bundledExtB, 'extension-manifest.json'), makeManifest('ext-b'))
+    writeFileSync(join(bundledExtB, 'index.ts'), 'export default function() {}')
+    const bundledPathA = join(bundledExtA, 'index.ts')
+    const bundledPathB = join(bundledExtB, 'index.ts')
+
+    // Create installed extensions: one shadows ext-a, one is new
+    const installedDir = join(root, 'installed')
+    const installedExtA = join(installedDir, 'ext-a-installed')
+    const installedExtNew = join(installedDir, 'ext-new')
+    mkdirSync(installedExtA, { recursive: true })
+    mkdirSync(installedExtNew, { recursive: true })
+    writeFileSync(join(installedExtA, 'extension-manifest.json'), makeManifest('ext-a'))
+    writeFileSync(join(installedExtA, 'index.ts'), 'export default function() {}')
+    writeFileSync(join(installedExtNew, 'extension-manifest.json'), makeManifest('ext-new'))
+    writeFileSync(join(installedExtNew, 'index.ts'), 'export default function() {}')
+
+    const result = mergeExtensionEntryPaths([bundledPathA, bundledPathB], installedDir)
+
+    assert.equal(result.length, 3, 'ext-b preserved, ext-a-installed and ext-new added')
+    assert.ok(!result.includes(bundledPathA), 'bundled ext-a should be shadowed')
+    assert.ok(result.includes(bundledPathB), 'bundled ext-b should be preserved')
+    assert.ok(result.some(p => p.includes('ext-a-installed')), 'installed ext-a should replace bundled')
+    assert.ok(result.some(p => p.includes('ext-new')), 'new installed ext should be added')
   })
 })

--- a/src/tests/extension-discovery.test.ts
+++ b/src/tests/extension-discovery.test.ts
@@ -81,6 +81,22 @@ describe('resolveExtensionEntries', () => {
 })
 
 describe('discoverExtensionEntryPaths', () => {
+  test('falls back to index.ts detection when extension directory has malformed package.json', (t) => {
+    const root = makeTempDir()
+    t.after(() => rmSync(root, { recursive: true, force: true }))
+
+    const extDir = join(root, 'malformed-ext')
+    mkdirSync(extDir)
+    // Write deliberately invalid JSON — resolveExtensionEntries catches the parse error and falls through
+    writeFileSync(join(extDir, 'package.json'), '{ "pi": { INVALID')
+    writeFileSync(join(extDir, 'index.ts'), 'export default function() {}')
+
+    const paths = discoverExtensionEntryPaths(root)
+    assert.equal(paths.length, 1, 'should discover the extension via index.ts fallback')
+    assert.ok(paths[0].includes('malformed-ext'), 'discovered path should be from malformed-ext')
+    assert.ok(paths[0].endsWith('index.ts'), 'should have fallen back to index.ts')
+  })
+
   test('skips library directories with pi: {} opt-out', (t) => {
     const root = makeTempDir()
     t.after(() => rmSync(root, { recursive: true, force: true }));
@@ -166,6 +182,39 @@ describe('mergeExtensionEntryPaths', () => {
     assert.equal(result.length, 1, 'only one entry: installed takes precedence over bundled')
     assert.ok(!result.includes(bundledEntryPath), 'bundled entry should be excluded')
     assert.ok(result.some(p => p.includes('my-ext-installed')), 'installed entry should be present')
+  })
+
+  test('silently skips installed extension with corrupt/unreadable manifest (invalid JSON)', (t) => {
+    const root = join(tmpdir(), `installed-corrupt-manifest-${Date.now()}`)
+    t.after(() => rmSync(root, { recursive: true, force: true }))
+
+    const installedDir = join(root, 'installed')
+    const corruptExtDir = join(installedDir, 'corrupt-ext')
+    mkdirSync(corruptExtDir, { recursive: true })
+    // Write deliberately invalid JSON to extension-manifest.json
+    writeFileSync(join(corruptExtDir, 'extension-manifest.json'), '{ "id": "corrupt-ext" INVALID JSON')
+    writeFileSync(join(corruptExtDir, 'index.ts'), 'export default function() {}')
+
+    const bundled = ['/fake/bundled/ext-a/index.ts']
+    const result = mergeExtensionEntryPaths(bundled, installedDir)
+
+    assert.deepEqual(result, bundled, 'corrupt manifest should be silently skipped, bundled paths unchanged')
+  })
+
+  test('skips installed extension directory with no index.ts/index.js even if manifest is valid', (t) => {
+    const root = join(tmpdir(), `installed-no-entries-${Date.now()}`)
+    t.after(() => rmSync(root, { recursive: true, force: true }))
+
+    const installedDir = join(root, 'installed')
+    const emptyExtDir = join(installedDir, 'empty-ext')
+    mkdirSync(emptyExtDir, { recursive: true })
+    // Valid manifest but no index.ts/index.js
+    writeFileSync(join(emptyExtDir, 'extension-manifest.json'), makeManifest('empty-ext'))
+
+    const bundled = ['/fake/bundled/ext-a/index.ts']
+    const result = mergeExtensionEntryPaths(bundled, installedDir)
+
+    assert.deepEqual(result, bundled, 'extension with no entry files should be skipped even if manifest is valid')
   })
 
   test('handles multiple installed extensions, some shadowing, some additive', (t) => {

--- a/src/tests/extension-sort.test.ts
+++ b/src/tests/extension-sort.test.ts
@@ -193,4 +193,123 @@ describe('sortExtensionPaths', () => {
     const bIdx = result.sortedPaths.indexOf(pathB)
     assert.ok(aIdx < bIdx, 'A must be before B (dependency order)')
   })
+
+  test('Test 9: string deps instead of array — treated as empty, no crash, extension in output', (t) => {
+    const dir = makeTempDir()
+    t.after(() => rmSync(dir, { recursive: true, force: true }))
+
+    const extDir = join(dir, 'bad.deps')
+    mkdirSync(extDir, { recursive: true })
+    writeFileSync(join(extDir, 'extension-manifest.json'), JSON.stringify({
+      id: 'bad.deps', name: 'bad.deps', version: '1.0.0',
+      description: 'test', tier: 'bundled', requires: { platform: 'node' },
+      dependencies: { extensions: 'not-an-array' }
+    }))
+    writeFileSync(join(extDir, 'index.ts'), 'export default function() {}')
+    const pathBadDeps = join(extDir, 'index.ts')
+
+    const result = sortExtensionPaths([pathBadDeps])
+
+    assert.equal(result.warnings.length, 0, 'no warnings expected for string deps')
+    assert.equal(result.sortedPaths.length, 1, 'extension still in output')
+    assert.ok(result.sortedPaths.includes(pathBadDeps), 'pathBadDeps in output')
+  })
+
+  test('Test 10: null deps — treated as empty, no crash, extension in output', (t) => {
+    const dir = makeTempDir()
+    t.after(() => rmSync(dir, { recursive: true, force: true }))
+
+    const extDir = join(dir, 'null.deps')
+    mkdirSync(extDir, { recursive: true })
+    writeFileSync(join(extDir, 'extension-manifest.json'), JSON.stringify({
+      id: 'null.deps', name: 'null.deps', version: '1.0.0',
+      description: 'test', tier: 'bundled', requires: { platform: 'node' },
+      dependencies: { extensions: null }
+    }))
+    writeFileSync(join(extDir, 'index.ts'), 'export default function() {}')
+    const pathNullDeps = join(extDir, 'index.ts')
+
+    const result = sortExtensionPaths([pathNullDeps])
+
+    assert.equal(result.warnings.length, 0, 'no warnings expected for null deps')
+    assert.equal(result.sortedPaths.length, 1, 'extension still in output')
+    assert.ok(result.sortedPaths.includes(pathNullDeps), 'pathNullDeps in output')
+  })
+
+  test('Test 11: numeric deps — treated as empty, no crash, extension in output', (t) => {
+    const dir = makeTempDir()
+    t.after(() => rmSync(dir, { recursive: true, force: true }))
+
+    const extDir = join(dir, 'num.deps')
+    mkdirSync(extDir, { recursive: true })
+    writeFileSync(join(extDir, 'extension-manifest.json'), JSON.stringify({
+      id: 'num.deps', name: 'num.deps', version: '1.0.0',
+      description: 'test', tier: 'bundled', requires: { platform: 'node' },
+      dependencies: { extensions: 42 }
+    }))
+    writeFileSync(join(extDir, 'index.ts'), 'export default function() {}')
+    const pathNumDeps = join(extDir, 'index.ts')
+
+    const result = sortExtensionPaths([pathNumDeps])
+
+    assert.equal(result.warnings.length, 0, 'no warnings expected for numeric deps')
+    assert.equal(result.sortedPaths.length, 1, 'extension still in output')
+    assert.ok(result.sortedPaths.includes(pathNumDeps), 'pathNumDeps in output')
+  })
+
+  test('Test 12: chain with missing middle — A depends on B, B depends on missing C', (t) => {
+    const dir = makeTempDir()
+    t.after(() => rmSync(dir, { recursive: true, force: true }))
+
+    const pathA = makeExtension(dir, 'chain.mid.a', ['chain.mid.b'])
+    const pathB = makeExtension(dir, 'chain.mid.b', ['chain.mid.c']) // C is not installed
+
+    const result = sortExtensionPaths([pathA, pathB])
+
+    // Missing dep warning for B→C
+    assert.equal(result.warnings.length, 1, 'one missing dep warning for B→C')
+    assert.equal(result.warnings[0].declaringId, 'chain.mid.b')
+    assert.equal(result.warnings[0].missingId, 'chain.mid.c')
+
+    // No cycle warning
+    const hasCycleWarning = result.warnings.some(w => w.message.includes('form a dependency cycle'))
+    assert.ok(!hasCycleWarning, 'no cycle warning expected')
+
+    // Both A and B in output
+    assert.equal(result.sortedPaths.length, 2)
+    assert.ok(result.sortedPaths.includes(pathA), 'pathA in output')
+    assert.ok(result.sortedPaths.includes(pathB), 'pathB in output')
+
+    // B before A (B is a dependency of A)
+    const aIdx = result.sortedPaths.indexOf(pathA)
+    const bIdx = result.sortedPaths.indexOf(pathB)
+    assert.ok(bIdx < aIdx, 'B must appear before A')
+  })
+
+  test('Test 13: duplicate dependency declarations — A declares B twice, no double-counting', (t) => {
+    const dir = makeTempDir()
+    t.after(() => rmSync(dir, { recursive: true, force: true }))
+
+    const pathB = makeExtension(dir, 'dup.b')
+    const pathA = makeExtension(dir, 'dup.a', ['dup.b', 'dup.b'])
+
+    const result = sortExtensionPaths([pathA, pathB])
+
+    // B before A
+    assert.equal(result.sortedPaths.length, 2)
+    const aIdx = result.sortedPaths.indexOf(pathA)
+    const bIdx = result.sortedPaths.indexOf(pathB)
+    assert.ok(bIdx < aIdx, 'B must appear before A')
+
+    // No cycle warning
+    const hasCycleWarning = result.warnings.some(w => w.message.includes('form a dependency cycle'))
+    assert.ok(!hasCycleWarning, 'no cycle warning expected for duplicate deps')
+  })
+
+  test('Test 14: empty paths array — returns empty result with no warnings', (_t) => {
+    const result = sortExtensionPaths([])
+
+    assert.equal(result.warnings.length, 0, 'no warnings for empty input')
+    assert.equal(result.sortedPaths.length, 0, 'no paths in output')
+  })
 })

--- a/src/tests/extension-sort.test.ts
+++ b/src/tests/extension-sort.test.ts
@@ -1,0 +1,196 @@
+// GSD-2 — Extension Sort Tests
+// Copyright (c) 2026 Jeremy McSpadden <jeremy@fluxlabs.net>
+
+import test, { describe } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdirSync, writeFileSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { sortExtensionPaths } from '../extension-sort.ts'
+
+function makeTempDir(): string {
+  const dir = join(tmpdir(), `ext-sort-test-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+  mkdirSync(dir, { recursive: true })
+  return dir
+}
+
+function makeExtension(baseDir: string, id: string, deps?: string[]): string {
+  const extDir = join(baseDir, id)
+  mkdirSync(extDir, { recursive: true })
+  const manifest = {
+    id,
+    name: id,
+    version: '1.0.0',
+    description: 'test extension',
+    tier: 'bundled',
+    requires: { platform: 'node' },
+    ...(deps && deps.length > 0 ? { dependencies: { extensions: deps } } : {}),
+  }
+  writeFileSync(join(extDir, 'extension-manifest.json'), JSON.stringify(manifest))
+  writeFileSync(join(extDir, 'index.ts'), `export default function() {}`)
+  return join(extDir, 'index.ts')
+}
+
+describe('sortExtensionPaths', () => {
+  test('Test 1: no deps — returns alphabetically sorted by ID, zero warnings', (t) => {
+    const dir = makeTempDir()
+    t.after(() => rmSync(dir, { recursive: true, force: true }))
+
+    const pathC = makeExtension(dir, 'test.c')
+    const pathA = makeExtension(dir, 'test.a')
+    const pathB = makeExtension(dir, 'test.b')
+
+    const result = sortExtensionPaths([pathC, pathA, pathB])
+
+    assert.equal(result.warnings.length, 0, 'no warnings expected')
+    assert.equal(result.sortedPaths.length, 3)
+    // A before B before C
+    const ids = result.sortedPaths.map(p => {
+      const parts = p.split('/')
+      return parts[parts.length - 2]
+    })
+    assert.deepEqual(ids, ['test.a', 'test.b', 'test.c'])
+  })
+
+  test('Test 2: linear chain — B depends on A, A appears before B', (t) => {
+    const dir = makeTempDir()
+    t.after(() => rmSync(dir, { recursive: true, force: true }))
+
+    const pathA = makeExtension(dir, 'chain.a')
+    const pathB = makeExtension(dir, 'chain.b', ['chain.a'])
+
+    const result = sortExtensionPaths([pathB, pathA])
+
+    assert.equal(result.warnings.length, 0, 'no warnings expected')
+    assert.equal(result.sortedPaths.length, 2)
+    const aIdx = result.sortedPaths.indexOf(pathA)
+    const bIdx = result.sortedPaths.indexOf(pathB)
+    assert.ok(aIdx < bIdx, 'A must appear before B')
+  })
+
+  test('Test 3: diamond — D depends on B and C; B and C depend on A → A first, B/C alphabetically, then D', (t) => {
+    const dir = makeTempDir()
+    t.after(() => rmSync(dir, { recursive: true, force: true }))
+
+    const pathA = makeExtension(dir, 'diamond.a')
+    const pathB = makeExtension(dir, 'diamond.b', ['diamond.a'])
+    const pathC = makeExtension(dir, 'diamond.c', ['diamond.a'])
+    const pathD = makeExtension(dir, 'diamond.d', ['diamond.b', 'diamond.c'])
+
+    const result = sortExtensionPaths([pathD, pathC, pathB, pathA])
+
+    assert.equal(result.warnings.length, 0, 'no warnings expected')
+    assert.equal(result.sortedPaths.length, 4)
+    const sorted = result.sortedPaths
+    const aIdx = sorted.indexOf(pathA)
+    const bIdx = sorted.indexOf(pathB)
+    const cIdx = sorted.indexOf(pathC)
+    const dIdx = sorted.indexOf(pathD)
+
+    assert.ok(aIdx < bIdx, 'A must be before B')
+    assert.ok(aIdx < cIdx, 'A must be before C')
+    assert.ok(bIdx < dIdx, 'B must be before D')
+    assert.ok(cIdx < dIdx, 'C must be before D')
+    assert.ok(bIdx < cIdx, 'B before C alphabetically')
+  })
+
+  test('Test 4: missing dep — warns with correct format, extension still in output', (t) => {
+    const dir = makeTempDir()
+    t.after(() => rmSync(dir, { recursive: true, force: true }))
+
+    const pathA = makeExtension(dir, 'test.a', ['gsd.nonexistent'])
+
+    const result = sortExtensionPaths([pathA])
+
+    assert.equal(result.sortedPaths.length, 1, 'A still in output')
+    assert.ok(result.sortedPaths.includes(pathA), 'pathA in sorted output')
+    assert.equal(result.warnings.length, 1, 'one warning for missing dep')
+    const w = result.warnings[0]
+    assert.equal(w.declaringId, 'test.a')
+    assert.equal(w.missingId, 'gsd.nonexistent')
+    assert.equal(w.message, "Extension 'test.a' declares dependency 'gsd.nonexistent' which is not installed — loading anyway")
+  })
+
+  test('Test 5: cycle — A depends on B, B depends on A → both loaded, cycle warnings emitted, appended alphabetically', (t) => {
+    const dir = makeTempDir()
+    t.after(() => rmSync(dir, { recursive: true, force: true }))
+
+    const pathA = makeExtension(dir, 'cycle.a', ['cycle.b'])
+    const pathB = makeExtension(dir, 'cycle.b', ['cycle.a'])
+
+    const result = sortExtensionPaths([pathA, pathB])
+
+    assert.equal(result.sortedPaths.length, 2, 'both extensions in output')
+    assert.ok(result.sortedPaths.includes(pathA), 'pathA in output')
+    assert.ok(result.sortedPaths.includes(pathB), 'pathB in output')
+    assert.ok(result.warnings.length > 0, 'cycle warnings emitted')
+    const hasCycleWarning = result.warnings.some(w => w.message.includes('form a dependency cycle'))
+    assert.ok(hasCycleWarning, 'cycle warning with correct format')
+    // Appended alphabetically: cycle.a before cycle.b
+    const aIdx = result.sortedPaths.indexOf(pathA)
+    const bIdx = result.sortedPaths.indexOf(pathB)
+    assert.ok(aIdx < bIdx, 'cycle participants appended alphabetically')
+  })
+
+  test('Test 6: self-dep — A declares dependency on itself → no warning, A still in output', (t) => {
+    const dir = makeTempDir()
+    t.after(() => rmSync(dir, { recursive: true, force: true }))
+
+    const pathA = makeExtension(dir, 'self.a', ['self.a'])
+
+    const result = sortExtensionPaths([pathA])
+
+    assert.equal(result.sortedPaths.length, 1, 'A still in output')
+    assert.ok(result.sortedPaths.includes(pathA), 'pathA in output')
+    assert.equal(result.warnings.length, 0, 'no warnings for self-dep')
+  })
+
+  test('Test 7: no manifest — paths without extension-manifest.json prepended in input order, zero warnings', (t) => {
+    const dir = makeTempDir()
+    t.after(() => rmSync(dir, { recursive: true, force: true }))
+
+    // Create two paths without manifests
+    const noManifestA = join(dir, 'no-manifest-a', 'index.ts')
+    const noManifestB = join(dir, 'no-manifest-b', 'index.ts')
+    mkdirSync(join(dir, 'no-manifest-a'), { recursive: true })
+    mkdirSync(join(dir, 'no-manifest-b'), { recursive: true })
+    writeFileSync(noManifestA, 'export default function() {}')
+    writeFileSync(noManifestB, 'export default function() {}')
+
+    const result = sortExtensionPaths([noManifestA, noManifestB])
+
+    assert.equal(result.warnings.length, 0, 'no warnings expected')
+    assert.equal(result.sortedPaths.length, 2)
+    // Input order preserved
+    assert.equal(result.sortedPaths[0], noManifestA)
+    assert.equal(result.sortedPaths[1], noManifestB)
+  })
+
+  test('Test 8: mixed — no-manifest paths first (input order), then topologically sorted manifest paths', (t) => {
+    const dir = makeTempDir()
+    t.after(() => rmSync(dir, { recursive: true, force: true }))
+
+    // No-manifest paths
+    const noManifestX = join(dir, 'no-manifest-x', 'index.ts')
+    mkdirSync(join(dir, 'no-manifest-x'), { recursive: true })
+    writeFileSync(noManifestX, 'export default function() {}')
+
+    // Manifest paths: B depends on A
+    const pathA = makeExtension(dir, 'mixed.a')
+    const pathB = makeExtension(dir, 'mixed.b', ['mixed.a'])
+
+    // Input order: noManifestX, pathB (dependent), pathA (dependency)
+    const result = sortExtensionPaths([noManifestX, pathB, pathA])
+
+    assert.equal(result.warnings.length, 0, 'no warnings expected')
+    assert.equal(result.sortedPaths.length, 3)
+
+    // no-manifest first
+    assert.equal(result.sortedPaths[0], noManifestX, 'no-manifest path must be first')
+
+    // then dependency-ordered manifests: A before B
+    const aIdx = result.sortedPaths.indexOf(pathA)
+    const bIdx = result.sortedPaths.indexOf(pathB)
+    assert.ok(aIdx < bIdx, 'A must be before B (dependency order)')
+  })
+})

--- a/src/tests/extension-sort.test.ts
+++ b/src/tests/extension-sort.test.ts
@@ -4,7 +4,7 @@
 import test, { describe } from 'node:test'
 import assert from 'node:assert/strict'
 import { mkdirSync, writeFileSync, rmSync } from 'node:fs'
-import { join } from 'node:path'
+import { join, basename, dirname } from 'node:path'
 import { tmpdir } from 'node:os'
 import { sortExtensionPaths } from '../extension-sort.ts'
 
@@ -45,10 +45,7 @@ describe('sortExtensionPaths', () => {
     assert.equal(result.warnings.length, 0, 'no warnings expected')
     assert.equal(result.sortedPaths.length, 3)
     // A before B before C
-    const ids = result.sortedPaths.map(p => {
-      const parts = p.split('/')
-      return parts[parts.length - 2]
-    })
+    const ids = result.sortedPaths.map(p => basename(dirname(p)))
     assert.deepEqual(ids, ['test.a', 'test.b', 'test.c'])
   })
 

--- a/src/tests/extension-validator.test.ts
+++ b/src/tests/extension-validator.test.ts
@@ -1,0 +1,159 @@
+// GSD-2 — Extension Validator Tests
+// Copyright (c) 2026 Jeremy McSpadden <jeremy@fluxlabs.net>
+
+import test, { describe } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  checkInstallDiscriminator,
+  checkNamespaceReservation,
+  checkDependencyPlacement,
+  validateExtensionPackage,
+} from '../extension-validator.ts'
+
+describe('checkInstallDiscriminator', () => {
+  test('returns null for valid gsd.extension === true', () => {
+    const result = checkInstallDiscriminator({ gsd: { extension: true }, pi: { extensions: ['./index.ts'] } })
+    assert.equal(result, null)
+  })
+
+  test('returns error when gsd section is missing', () => {
+    const result = checkInstallDiscriminator({ pi: { extensions: ['./index.ts'] } })
+    assert.ok(result !== null)
+    assert.equal(result.code, 'MISSING_GSD_MARKER')
+    assert.equal(result.field, 'gsd.extension')
+  })
+
+  test('returns error when gsd.extension is number 1 (not boolean true)', () => {
+    const result = checkInstallDiscriminator({ gsd: { extension: 1 } })
+    assert.ok(result !== null)
+    assert.equal(result.code, 'MISSING_GSD_MARKER', 'strict === true check must reject numeric 1')
+  })
+
+  test("returns error when gsd.extension is string 'true'", () => {
+    const result = checkInstallDiscriminator({ gsd: { extension: 'true' } })
+    assert.ok(result !== null)
+    assert.equal(result.code, 'MISSING_GSD_MARKER', "strict === true check must reject string 'true'")
+  })
+
+  test('returns error for null input', () => {
+    const result = checkInstallDiscriminator(null)
+    assert.ok(result !== null)
+    assert.equal(result.code, 'MISSING_GSD_MARKER')
+  })
+})
+
+describe('checkNamespaceReservation', () => {
+  test('returns error for gsd. prefixed extension ID', () => {
+    const result = checkNamespaceReservation('gsd.my-tool', {})
+    assert.ok(result !== null)
+    assert.equal(result.code, 'RESERVED_NAMESPACE')
+    assert.ok(result.message.includes('gsd.my-tool'), 'error message should name the conflicting ID')
+  })
+
+  test('returns null when allowGsdNamespace is true', () => {
+    const result = checkNamespaceReservation('gsd.my-tool', { allowGsdNamespace: true })
+    assert.equal(result, null)
+  })
+
+  test('returns null for non-gsd namespace', () => {
+    const result = checkNamespaceReservation('acme.my-tool', {})
+    assert.equal(result, null)
+  })
+
+  test('returns null for bare extension ID', () => {
+    const result = checkNamespaceReservation('my-tool', {})
+    assert.equal(result, null)
+  })
+})
+
+describe('checkDependencyPlacement', () => {
+  test('returns error for @gsd/ package in dependencies', () => {
+    const errors = checkDependencyPlacement({ dependencies: { '@gsd/pi-coding-agent': '^2.0.0' } })
+    assert.equal(errors.length, 1)
+    assert.equal(errors[0].code, 'WRONG_DEP_FIELD')
+    assert.ok(errors[0].message.includes('@gsd/pi-coding-agent'), 'message must name exact package')
+    assert.ok(errors[0].message.includes('dependencies'), 'message must name exact field')
+    assert.ok(errors[0].message.includes('peerDependencies'), 'message must suggest the fix')
+    assert.equal(errors[0].field, 'dependencies')
+  })
+
+  test('returns error for @gsd/ package in devDependencies', () => {
+    const errors = checkDependencyPlacement({ devDependencies: { '@gsd/pi-ai': '^1.0.0' } })
+    assert.equal(errors.length, 1)
+    assert.equal(errors[0].code, 'WRONG_DEP_FIELD')
+    assert.ok(errors[0].message.includes('@gsd/pi-ai'), 'message must name exact package')
+    assert.ok(errors[0].message.includes('devDependencies'), 'message must name exact field')
+    assert.equal(errors[0].field, 'devDependencies')
+  })
+
+  test('does not flag @gsd/ in peerDependencies', () => {
+    const errors = checkDependencyPlacement({ peerDependencies: { '@gsd/pi-coding-agent': '>=2.50.0' } })
+    assert.equal(errors.length, 0, 'peerDependencies is the correct placement — must not be flagged')
+  })
+
+  test('returns multiple errors for violations in both dependencies and devDependencies', () => {
+    const errors = checkDependencyPlacement({
+      dependencies: { '@gsd/pi-coding-agent': '^2.0.0' },
+      devDependencies: { '@gsd/pi-ai': '^1.0.0' },
+    })
+    assert.equal(errors.length, 2)
+    const fields = errors.map(e => e.field)
+    assert.ok(fields.includes('dependencies'))
+    assert.ok(fields.includes('devDependencies'))
+  })
+
+  test('does not flag non-gsd packages', () => {
+    const errors = checkDependencyPlacement({ dependencies: { 'lodash': '^4.0.0' } })
+    assert.equal(errors.length, 0)
+  })
+
+  test('handles missing dependency fields', () => {
+    const errors = checkDependencyPlacement({})
+    assert.equal(errors.length, 0)
+  })
+})
+
+describe('validateExtensionPackage', () => {
+  test('returns valid for conforming package', () => {
+    const result = validateExtensionPackage(
+      { gsd: { extension: true }, peerDependencies: { '@gsd/pi-coding-agent': '>=2.50.0' } },
+      { extensionId: 'acme.browser' }
+    )
+    assert.equal(result.valid, true)
+    assert.deepEqual(result.errors, [])
+    assert.deepEqual(result.warnings, [])
+  })
+
+  test('aggregates errors from multiple checks', () => {
+    const result = validateExtensionPackage(
+      { dependencies: { '@gsd/pi-ai': '^1.0.0' } },
+      { extensionId: 'gsd.bad' }
+    )
+    assert.equal(result.valid, false)
+    // Expects at least: MISSING_GSD_MARKER + RESERVED_NAMESPACE + WRONG_DEP_FIELD
+    assert.ok(result.errors.length >= 3, `expected >= 3 errors, got ${result.errors.length}: ${JSON.stringify(result.errors.map(e => e.code))}`)
+    const codes = result.errors.map(e => e.code)
+    assert.ok(codes.includes('MISSING_GSD_MARKER'))
+    assert.ok(codes.includes('RESERVED_NAMESPACE'))
+    assert.ok(codes.includes('WRONG_DEP_FIELD'))
+  })
+
+  test('valid is always errors.length === 0', () => {
+    const validPkg = { gsd: { extension: true } }
+    const validResult = validateExtensionPackage(validPkg, { extensionId: 'acme.tool' })
+    assert.equal(validResult.valid, true)
+    assert.equal(validResult.errors.length, 0)
+
+    const invalidPkg = { gsd: { extension: 1 } }
+    const invalidResult = validateExtensionPackage(invalidPkg, { extensionId: 'acme.tool' })
+    assert.equal(invalidResult.valid, false)
+    assert.ok(invalidResult.errors.length > 0)
+  })
+
+  test('adds warning when extensionId is not provided', () => {
+    const result = validateExtensionPackage({ gsd: { extension: true } }, {})
+    assert.equal(result.valid, true)
+    assert.equal(result.warnings.length, 1)
+    assert.equal(result.warnings[0].code, 'NAMESPACE_CHECK_SKIPPED')
+  })
+})

--- a/src/tests/extension-validator.test.ts
+++ b/src/tests/extension-validator.test.ts
@@ -40,6 +40,25 @@ describe('checkInstallDiscriminator', () => {
     assert.ok(result !== null)
     assert.equal(result.code, 'MISSING_GSD_MARKER')
   })
+
+  test('returns error when gsd.extension is undefined', () => {
+    const result = checkInstallDiscriminator({ gsd: {} })
+    assert.ok(result !== null)
+    assert.equal(result.code, 'MISSING_GSD_MARKER')
+    assert.equal(result.field, 'gsd.extension')
+  })
+
+  test('returns error when gsd is an array (not object)', () => {
+    const result = checkInstallDiscriminator({ gsd: ['extension'] })
+    assert.ok(result !== null)
+    assert.equal(result.code, 'MISSING_GSD_MARKER')
+  })
+
+  test('returns error when input is a string (not object)', () => {
+    const result = checkInstallDiscriminator('{"gsd":{"extension":true}}')
+    assert.ok(result !== null)
+    assert.equal(result.code, 'MISSING_GSD_MARKER')
+  })
 })
 
 describe('checkNamespaceReservation', () => {
@@ -111,6 +130,21 @@ describe('checkDependencyPlacement', () => {
     const errors = checkDependencyPlacement({})
     assert.equal(errors.length, 0)
   })
+
+  test('returns empty errors when dependencies is a string instead of object', () => {
+    const errors = checkDependencyPlacement({ dependencies: '@gsd/pi-coding-agent' })
+    assert.equal(errors.length, 0, 'string in dependencies field should be gracefully skipped')
+  })
+
+  test('returns empty errors when dependencies is null', () => {
+    const errors = checkDependencyPlacement({ dependencies: null })
+    assert.equal(errors.length, 0, 'null dependencies should be gracefully skipped')
+  })
+
+  test('returns empty errors when dependencies is an array', () => {
+    const errors = checkDependencyPlacement({ dependencies: ['@gsd/pi-coding-agent'] })
+    assert.equal(errors.length, 0, 'array in dependencies field should be gracefully skipped')
+  })
 })
 
 describe('validateExtensionPackage', () => {
@@ -155,5 +189,15 @@ describe('validateExtensionPackage', () => {
     assert.equal(result.valid, true)
     assert.equal(result.warnings.length, 1)
     assert.equal(result.warnings[0].code, 'NAMESPACE_CHECK_SKIPPED')
+  })
+})
+
+describe('edge cases — field types', () => {
+  test('does not flag @gsd/ package nested in sub-object of dependencies (only top-level keys matter)', () => {
+    // The checker iterates Object.keys(deps) — a sub-object value is a value, not a key name
+    const errors = checkDependencyPlacement({
+      dependencies: { nested: { '@gsd/foo': '1.0' } },
+    })
+    assert.equal(errors.length, 0, 'nested @gsd/ in a sub-object value should not be flagged')
   })
 })

--- a/src/tests/welcome-screen.test.ts
+++ b/src/tests/welcome-screen.test.ts
@@ -43,10 +43,20 @@ test('renders version', () => {
   assert.ok(out.includes('Get Shit Done'), 'brand name missing')
 })
 
-test('renders GSD project state or fallback hint', () => {
+test('renders GSD project state or fallback hint', (t) => {
   // Model/provider intentionally removed from the welcome screen — they live
   // in the persistent footer. Without .gsd/STATE.md present the welcome
   // should surface the "No active GSD project" fallback instead.
+  // chdir into an empty tmp dir so the fallback path is actually exercised
+  // regardless of what the repo we're running from has in .gsd/.
+  const tmp = mkdtempSync(join(tmpdir(), 'gsd-welcome-fallback-'))
+  const origCwd = process.cwd()
+  process.chdir(tmp)
+  t.after(() => {
+    process.chdir(origCwd)
+    rmSync(tmp, { recursive: true, force: true })
+  })
+
   const out = strip(capture({ version: '1.0.0', modelName: 'claude-opus-4-6', provider: 'Anthropic' }))
   assert.ok(
     out.includes('No active GSD project') || /Active\s+M\d+/.test(out),


### PR DESCRIPTION
## TL;DR

**What:** Revives ADR-006 v1.3 (extension install infrastructure + dependency decoupling + topological loader) on current main. 19 commits supersede the stale PRs #3030 and #3036.
**Why:** PR #3030 stalled 24 days behind 1,726 commits of main drift and PR #3036 was closed stale 2026-04-20 — ADR-006 v1.3 code was fully written and tested but never actually merged, blocking v1.4+ entirely.
**How:** Cherry-picked the 19 commits from `feat/extension-install-infrastructure` onto current main, resolving ~35 conflict markers across hotspot files (`gsd/auto.ts`, `gsd/commands-cmux.ts`, `bootstrap/system-context.ts`, `cmux/index.ts`, `bootstrap/register-extension.ts`, `packages/pi-coding-agent/src/core/extensions/loader.ts`), preserving all main-branch evolution (runAutoLoopWithUok, error-handled bootstrap registrations, enhanced session-lock logging).

## What

Revives ADR-006 milestone v1.3 by landing 19 commits on current main across 4 logical phases:

- **Phase 6 — Dependency Decoupling** (5 commits)
  - `src/resources/extensions/shared/cmux-events.ts` (new) — typed event contract module
  - `src/resources/extensions/shared/rtk-session-stats.ts` — remove reverse `shared→gsd` import
  - `src/resources/extensions/gsd/auto.ts` + `auto/types.ts` + `auto/loop-deps.ts` — replace static cmux imports with `makeCmuxEmitters(pi)` factory + `pi.events.emit(CMUX_CHANNELS.XXX, ...)`
  - `src/resources/extensions/gsd/commands-cmux.ts` + `bootstrap/system-context.ts` + `notifications.ts` — replace static cmux imports with dynamic `await import()`
  - `src/resources/extensions/cmux/index.ts` — remove `gsd→cmux` imports, use structural types from `shared/cmux-events.ts`
  - `src/resources/extensions/gsd/bootstrap/register-extension.ts` — wire `initCmuxEventListeners(pi.events)` via dynamic import
  - `package.json` — remove 4 misplaced root deps (`@octokit/rest`, `mime-types`, `@types/mime-types`, `get-east-asian-width`, `zod-to-json-schema`) that belong in workspace packages (NOTE: main already removed these; commit is effectively a no-op but kept for atomicity)

- **Phase 7 — Extension Validator** (2 commits)
  - `src/extension-validator.ts` (new) — validates `gsd.extension: true` marker, namespace reservation (`gsd.*` reserved), peerDependency enforcement rules
  - `src/tests/extension-validator.test.ts` (new) — 19 test cases

- **Phase 8 — Install Infrastructure** (5 commits + 1 chore)
  - `src/extension-registry.ts` + `src/extension-discovery.ts` — `source: \"installed\"` registry field + `mergeExtensionEntryPaths()` for installed-overrides-bundled
  - `packages/pi-coding-agent/src/core/extensions/loader.ts` — thread merge through loader, adds `~/.gsd/extensions/` discovery path
  - `src/resources/extensions/gsd/commands-extensions.ts` — `gsd extensions install/uninstall/update` subcommands supporting npm, git, and local sources with mandatory `--ignore-scripts`
  - `package.json` devDep: `@types/semver`

- **Phase 9 — Topological Loader** (5 commits)
  - `src/extension-sort.ts` (new) — Kahn's algorithm with alphabetical tie-breaking + cycle detection
  - `packages/pi-coding-agent/src/core/extensions/loader.ts` — wire `sortExtensionPaths()` into the load pipeline
  - `ExtensionLoadWarning` type + `warnings[]` on `LoadExtensionsResult` for actionable missing-dep warnings
  - `src/tests/extension-sort.test.ts` (new) — topology + cycle + tie-break coverage

## Why

Forensic investigation (`.planning/forensics/report-20260422-phase10-missing.md`) revealed:

- **PR #3030** (the v1.3 foundation) — created 2026-03-29, last activity 2026-04-20, still OPEN but 1,726 commits behind main. Mergeability: UNKNOWN.
- **PR #3036** (Phase 10 google-search extraction pilot) — CLOSED 2026-04-20 by @trek-e citing stale-PR policy (\"no contributor response in 3+ weeks\").
- **Planning docs** (`PROJECT.md`, `MILESTONES.md`, `RETROSPECTIVE.md`) were claiming v1.3 \"Shipped: 2026-03-29\" — written based on local branch state without verifying upstream merge. Corrected in the same change window (local-only; `.planning/` is gitignored).

ADR-006 #2995 defines 7 milestones (v1.3 → v1.9) for GSD2 modularization. v1.3 is the foundation everything else depends on. Without it merged:

- Cannot start v1.4 Tier 1 extraction (8-11 extensions needing the install infrastructure)
- Cannot address the 269,566-LOC core extension
- Cannot shrink the 885 MB `node_modules` (ADR target: ~450 MB)
- Cannot hit the ~0.4s cold-start target

This PR unblocks all of the above by landing v1.3 on current main in a scope small enough to review within the staleness window.

Refs #2995 (ADR-006)
Supersedes #3030 (stale foundation PR)
Relates to #3036 (closed Phase 10 pilot; will be re-opened as part of v1.4 once this lands)

## How

Rather than rebasing `feat/extension-install-infrastructure` across 1,726 commits of main drift (which would have produced 26 sequential conflict rounds, most on hotspot files `gsd/auto.ts` at 316 commits in 90 days and `gsd/commands-extensions.ts` at 98 commits), the work was **cherry-picked commit-by-commit** onto a new branch off current main. Conflicts were resolved preserving all main-branch evolution:

- **`gsd/auto.ts` (5 conflict regions):** converted new main-side `syncCmuxSidebar` / `logCmuxEvent` / `clearCmuxSidebar` direct calls to `pi.events.emit(CMUX_CHANNELS.XXX, ...)` pattern; preserved `runAutoLoopWithUok`, `captureProjectRootEnv`, `startAutoCommandPolling`, `logWarning`; passed `pi` through to `buildLoopDeps(pi)`.
- **`commands-cmux.ts` (2 conflicts):** preserved new `resolveProjectPreferencesWritePath` helper + `writeFileSync` import needed by `autoEnableCmuxPreferences`; adopted DECOUPLE-02's async/dynamic-import pattern for `formatCmuxStatus`.
- **`bootstrap/system-context.ts` (2 conflicts):** preserved main's `loadPrompt` templating args + `let loadedPreferences` mutability; added dynamic cmux import for `markCmuxPromptShown` / `shouldPromptToEnableCmux`.
- **`notifications.ts` (1 conflict):** preserved new `sendRemoteNotification` import; dropped now-unused static cmux imports (body already uses dynamic import).
- **`cmux/index.ts` (1 conflict):** dropped gsd imports in favor of structural types; skipped stale `promisify`/`execFileAsync` re-addition (main already cleaned it up).
- **`register-extension.ts` (1 conflict):** kept main's error-handled `nonCriticalRegistrations` array; added `\"cmux-events\"` entry for dynamic listener init.
- **`loader.ts` (1 conflict):** additive — kept both `registerToolCompatibility` and new `mergeExtensionEntryPaths` imports.
- **`package.json` (1 conflict):** kept current `version: 2.77.0`; the 4 deps DECOUPLE-04 wanted removed were already gone on main.

Also applied two trailing fixups from the original branch:
- `fix: add explicit types for handleLostSessionLock arrow params` (arrow fn params needed explicit `ExtensionContext | undefined` / `SessionLockStatus | undefined` after decoupling)
- `fix: update cmux test to use CmuxStateInput type instead of GSDState` (structural types require structural test fixtures)

### Verification

- **Typecheck:** clean on `tsconfig.extensions.json`, `tsconfig.resources.json`, `tsconfig.json`
- **Tests:** 70/70 pass across `extension-validator.test.ts`, `extension-discovery.test.ts`, `extension-sort.test.ts`, `cmux.test.ts`

### Change type

- [x] `feat` — New feature or capability (extension install/uninstall/update, topological loader, event decoupling)
- [x] `test` — Adding or updating tests (validator + sort + discovery)
- [x] `chore` — Build, CI, or tooling changes (`@types/semver`, dep cleanup)

### Breaking changes

None — all changes are additive or internal refactors. The `gsd extensions install/uninstall/update` commands are new. The topological loader preserves existing load order when no dependency graph is declared, and adds actionable warnings (non-fatal) when dependencies are missing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Install, uninstall, and update extensions (npm/git/local) with validation, registry tracking, and user-facing install info; unified CMUX event channels with immediate sidebar/log lifecycle integration.

* **Bug Fixes**
  * Installed extensions now shadow bundled ones; extension load ordering is deterministic with warnings for missing deps and cycles surfaced at startup.

* **Chores**
  * Dependency updates: added semver and types; removed several unused packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->