### PR TITLE
fix(validate): also flag @gsd/* in devDependencies, not just dependencies

### DIFF
--- a/src/resources/extensions/gsd/commands-extensions.ts
+++ b/src/resources/extensions/gsd/commands-extensions.ts
@@ -179,11 +179,14 @@ export function validateExtensionPackage(packageDir: string): ValidationResult {
     }
   }
 
-  // (c) @gsd/* packages must be in peerDependencies, not dependencies (D-12c)
-  const deps = (pkg.dependencies as Record<string, unknown> | undefined) ?? {};
-  for (const dep of Object.keys(deps)) {
-    if (dep.startsWith("@gsd/")) {
-      errors.push(`"${dep}" must be in peerDependencies, not dependencies`);
+  // (c) @gsd/* packages must be in peerDependencies, not dependencies/devDependencies (D-12c)
+  // Mirrors validateExtensionManifest below and extension-validator.ts:checkDependencyPlacement.
+  for (const field of ["dependencies", "devDependencies"] as const) {
+    const deps = (pkg[field] as Record<string, unknown> | undefined) ?? {};
+    for (const dep of Object.keys(deps)) {
+      if (dep.startsWith("@gsd/")) {
+        errors.push(`"${dep}" must be in peerDependencies, not ${field}`);
+      }
     }
   }
 

--- a/src/resources/extensions/gsd/tests/validate-extension-package.test.ts
+++ b/src/resources/extensions/gsd/tests/validate-extension-package.test.ts
@@ -114,6 +114,28 @@ test("validateExtensionPackage: @gsd/* in dependencies (not peerDependencies) re
   assert.ok(result.errors.some(e => e.includes("@gsd/pi-coding-agent")), `Expected error about @gsd/ dep, got: ${JSON.stringify(result.errors)}`);
 });
 
+test("validateExtensionPackage: @gsd/* in devDependencies returns error", (t) => {
+  const dir = makeTempDir();
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+
+  writeIndexTs(dir);
+  writePackageJson(dir, {
+    name: "@gsd-extensions/test",
+    version: "1.0.0",
+    gsd: { extension: true },
+    pi: { extensions: ["./index.ts"] },
+    peerDependencies: { "@gsd/pi-coding-agent": "*" },
+    devDependencies: { "@gsd/pi-tui": "^2.0.0" },
+  });
+
+  const result = validateExtensionPackage(dir);
+  assert.equal(result.valid, false);
+  assert.ok(
+    result.errors.some(e => e.includes("@gsd/pi-tui") && e.includes("devDependencies")),
+    `Expected error about @gsd/ in devDependencies, got: ${JSON.stringify(result.errors)}`,
+  );
+});
+
 test("validateExtensionPackage: missing package.json returns error", (t) => {
   const dir = makeTempDir();
   t.after(() => rmSync(dir, { recursive: true, force: true }));


### PR DESCRIPTION
## Why

Follow-up to #4696. Reviewer noted that the new public \`validateExtensionPackage(packageDir)\` only inspected \`pkg.dependencies\` for \`@gsd/*\` entries, while sibling validators (\`validateExtensionManifest\` in the same file, and \`extension-validator.ts:checkDependencyPlacement\`) inspect both \`dependencies\` and \`devDependencies\`.

The fix was pushed to the #4696 branch as commit \`f247b4ac\` at 20:30:44 (5 min before the merge), but the merge of #4696 at 20:35:43 stopped at \`b9fc6ba1\` and didn't pick it up — likely a race between my push and the maintainer's merge queue.

## What

- \`commands-extensions.ts\`: inspect both \`dependencies\` and \`devDependencies\` in the same loop, with a field-aware error message.
- \`validate-extension-package.test.ts\`: regression test for \`@gsd/*\` in \`devDependencies\`.

A malicious or careless extension could otherwise pin \`@gsd/pi-coding-agent\` in \`devDependencies\` and bypass the peer-dependency intent (which exists to prevent multiple incompatible \`@gsd/*\` copies at install time).

## Test plan

- [x] \`npm run test:unit\`: 7331 passed / 0 failed (was 7330; +1 for the new devDeps regression test)
- [x] \`npx tsc --noEmit\` clean
- [ ] CI green

## Refs

- #4696 (parent — Phase 10 google-search extraction pilot, merged \`50aabfd14\`)
- #4694 (grandparent — v1.3 foundation, merged \`c3f06c719\`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Extension package validation now checks additional dependency fields with improved, field-specific error messages indicating the exact location of invalid entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->