### PR TITLE
fix(gsd): avoid token hijacking in do router

### DIFF
--- a/src/resources/extensions/gsd/commands-do.ts
+++ b/src/resources/extensions/gsd/commands-do.ts
@@ -7,13 +7,13 @@
 
 import type { ExtensionAPI, ExtensionCommandContext } from "@gsd/pi-coding-agent";
 
-interface Route {
+export interface DoRoute {
   keywords: string[];
   command: string;
   acceptsArgs?: boolean;
 }
 
-const ROUTES: Route[] = [
+export const ROUTES: DoRoute[] = [
   { keywords: ["progress", "status", "dashboard", "how far", "where are we", "show me progress"], command: "status" },
   { keywords: ["auto", "autonomous", "run all", "keep going", "start auto", "run autonomously"], command: "auto", acceptsArgs: true },
   { keywords: ["stop", "halt", "abort"], command: "stop" },
@@ -44,17 +44,21 @@ const ROUTES: Route[] = [
   { keywords: ["debug", "debug session", "investigate", "troubleshoot", "diagnose issue"], command: "debug", acceptsArgs: true },
 ];
 
-interface MatchResult {
+export interface MatchResult {
   command: string;
   remainingArgs: string;
   score: number;
 }
 
-function escapeRegExp(value: string): string {
+interface CompiledRoute extends DoRoute {
+  patterns: Array<{ keyword: string; regex: RegExp }>;
+}
+
+export function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
-function keywordPattern(keyword: string, acceptsArgs: boolean): RegExp {
+export function keywordPattern(keyword: string, acceptsArgs: boolean): RegExp {
   const escaped = keyword
     .trim()
     .split(/\s+/)
@@ -65,13 +69,21 @@ function keywordPattern(keyword: string, acceptsArgs: boolean): RegExp {
     : new RegExp(`^${escaped}$`, "i");
 }
 
-function matchRoute(input: string): MatchResult | null {
+const COMPILED_ROUTES: CompiledRoute[] = ROUTES.map((route) => ({
+  ...route,
+  patterns: route.keywords.map((keyword) => ({
+    keyword,
+    regex: keywordPattern(keyword, route.acceptsArgs === true),
+  })),
+}));
+
+export function matchRoute(input: string): MatchResult | null {
   const trimmed = input.trim();
   let bestMatch: MatchResult | null = null;
 
-  for (const route of ROUTES) {
-    for (const keyword of route.keywords) {
-      const match = trimmed.match(keywordPattern(keyword, route.acceptsArgs === true));
+  for (const route of COMPILED_ROUTES) {
+    for (const { keyword, regex } of route.patterns) {
+      const match = trimmed.match(regex);
       if (match) {
         const score = keyword.length; // Longer match = higher confidence
         if (!bestMatch || score > bestMatch.score) {

--- a/src/resources/extensions/gsd/commands-do.ts
+++ b/src/resources/extensions/gsd/commands-do.ts
@@ -10,37 +10,38 @@ import type { ExtensionAPI, ExtensionCommandContext } from "@gsd/pi-coding-agent
 interface Route {
   keywords: string[];
   command: string;
+  acceptsArgs?: boolean;
 }
 
 const ROUTES: Route[] = [
-  { keywords: ["progress", "status", "dashboard", "how far", "where are we"], command: "status" },
-  { keywords: ["auto", "autonomous", "run all", "keep going", "start auto"], command: "auto" },
+  { keywords: ["progress", "status", "dashboard", "how far", "where are we", "show me progress"], command: "status" },
+  { keywords: ["auto", "autonomous", "run all", "keep going", "start auto", "run autonomously"], command: "auto", acceptsArgs: true },
   { keywords: ["stop", "halt", "abort"], command: "stop" },
   { keywords: ["pause", "break", "take a break"], command: "pause" },
-  { keywords: ["history", "past", "what happened", "previous"], command: "history" },
-  { keywords: ["doctor", "health", "diagnose", "check health"], command: "doctor" },
+  { keywords: ["history", "past", "what happened", "previous"], command: "history", acceptsArgs: true },
+  { keywords: ["doctor", "health", "diagnose", "check health"], command: "doctor", acceptsArgs: true },
   { keywords: ["clean up", "cleanup", "remove old", "prune", "tidy"], command: "cleanup" },
-  { keywords: ["export", "report", "share results"], command: "export" },
-  { keywords: ["ship", "pull request", "create pr", "open pr", "merge"], command: "ship" },
+  { keywords: ["export", "report", "share results"], command: "export", acceptsArgs: true },
+  { keywords: ["ship", "pull request", "create pr", "open pr", "merge"], command: "ship", acceptsArgs: true },
   { keywords: ["discuss", "talk about", "architecture", "design"], command: "discuss" },
   { keywords: ["undo", "revert", "rollback", "take back"], command: "undo" },
-  { keywords: ["skip", "skip task", "skip this"], command: "skip" },
+  { keywords: ["skip", "skip task", "skip this"], command: "skip", acceptsArgs: true },
   { keywords: ["queue", "reorder", "milestone order", "order milestones"], command: "queue" },
   { keywords: ["visualize", "viz", "graph", "chart", "show graph"], command: "visualize" },
-  { keywords: ["capture", "note", "idea", "thought", "remember"], command: "capture" },
+  { keywords: ["capture", "note", "idea", "thought", "remember"], command: "capture", acceptsArgs: true },
   { keywords: ["inspect", "database", "sqlite", "db state"], command: "inspect" },
-  { keywords: ["knowledge", "rule", "pattern", "lesson"], command: "knowledge" },
-  { keywords: ["session report", "session summary", "cost summary", "how much"], command: "session-report" },
+  { keywords: ["knowledge", "rule", "pattern", "lesson"], command: "knowledge", acceptsArgs: true },
+  { keywords: ["session report", "session summary", "cost summary", "how much"], command: "session-report", acceptsArgs: true },
   { keywords: ["backlog", "parking lot", "later", "someday"], command: "backlog" },
   { keywords: ["pr branch", "clean branch", "filter commits"], command: "pr-branch" },
-  { keywords: ["add tests", "write tests", "generate tests", "test coverage"], command: "add-tests" },
-  { keywords: ["next", "step", "next step", "what's next"], command: "next" },
-  { keywords: ["migrate", "migration", "convert", "upgrade"], command: "migrate" },
-  { keywords: ["steer", "change direction", "pivot", "redirect"], command: "steer" },
-  { keywords: ["park", "shelve", "set aside"], command: "park" },
-  { keywords: ["widget", "toggle widget"], command: "widget" },
-  { keywords: ["logs", "debug logs", "log files"], command: "logs" },
-  { keywords: ["debug", "debug session", "investigate", "troubleshoot", "diagnose issue"], command: "debug" },
+  { keywords: ["add tests", "write tests", "generate tests", "test coverage"], command: "add-tests", acceptsArgs: true },
+  { keywords: ["next", "step", "next step", "what's next"], command: "next", acceptsArgs: true },
+  { keywords: ["migrate", "migration", "convert", "upgrade"], command: "migrate", acceptsArgs: true },
+  { keywords: ["steer", "change direction", "pivot", "redirect"], command: "steer", acceptsArgs: true },
+  { keywords: ["park", "shelve", "set aside"], command: "park", acceptsArgs: true },
+  { keywords: ["widget", "toggle widget"], command: "widget", acceptsArgs: true },
+  { keywords: ["logs", "debug logs", "log files"], command: "logs", acceptsArgs: true },
+  { keywords: ["debug", "debug session", "investigate", "troubleshoot", "diagnose issue"], command: "debug", acceptsArgs: true },
 ];
 
 interface MatchResult {
@@ -49,18 +50,32 @@ interface MatchResult {
   score: number;
 }
 
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function keywordPattern(keyword: string, acceptsArgs: boolean): RegExp {
+  const escaped = keyword
+    .trim()
+    .split(/\s+/)
+    .map(escapeRegExp)
+    .join("\\s+");
+  return acceptsArgs
+    ? new RegExp(`^${escaped}(?:\\s+(.+))?$`, "i")
+    : new RegExp(`^${escaped}$`, "i");
+}
+
 function matchRoute(input: string): MatchResult | null {
-  const lower = input.toLowerCase();
+  const trimmed = input.trim();
   let bestMatch: MatchResult | null = null;
 
   for (const route of ROUTES) {
     for (const keyword of route.keywords) {
-      if (lower.includes(keyword)) {
+      const match = trimmed.match(keywordPattern(keyword, route.acceptsArgs === true));
+      if (match) {
         const score = keyword.length; // Longer match = higher confidence
         if (!bestMatch || score > bestMatch.score) {
-          // Strip the matched keyword from input to get remaining args
-          const idx = lower.indexOf(keyword);
-          const remaining = (input.slice(0, idx) + input.slice(idx + keyword.length)).trim();
+          const remaining = route.acceptsArgs === true ? (match[1] ?? "").trim() : "";
           bestMatch = { command: route.command, remainingArgs: remaining, score };
         }
       }

--- a/src/resources/extensions/gsd/tests/commands-do.test.ts
+++ b/src/resources/extensions/gsd/tests/commands-do.test.ts
@@ -1,92 +1,25 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-// ─── Mock dispatcher to capture routed commands ─────────────────────────
-
-let lastRouted: string | null = null;
-let lastQuick: string | null = null;
-
-const mockCtx = {
-  ui: {
-    notify: (_msg: string, _level: string) => {},
-  },
-} as any;
-
-// We test the keyword matching logic directly since the handler imports
-// the dispatcher dynamically (which requires the full extension runtime).
-
-// Inline the route-matching logic from commands-do.ts for unit testing.
-interface Route {
-  keywords: string[];
-  command: string;
-  acceptsArgs?: boolean;
-}
-
-const ROUTES: Route[] = [
-  { keywords: ["progress", "status", "dashboard", "how far", "where are we", "show me progress"], command: "status" },
-  { keywords: ["auto", "autonomous", "run all", "keep going", "start auto", "run autonomously"], command: "auto", acceptsArgs: true },
-  { keywords: ["stop", "halt", "abort"], command: "stop" },
-  { keywords: ["pause", "break", "take a break"], command: "pause" },
-  { keywords: ["history", "past", "what happened", "previous"], command: "history", acceptsArgs: true },
-  { keywords: ["doctor", "health", "diagnose", "check health"], command: "doctor", acceptsArgs: true },
-  { keywords: ["clean up", "cleanup", "remove old", "prune", "tidy"], command: "cleanup" },
-  { keywords: ["ship", "pull request", "create pr", "open pr", "merge"], command: "ship", acceptsArgs: true },
-  { keywords: ["discuss", "talk about", "architecture", "design"], command: "discuss" },
-  { keywords: ["undo", "revert", "rollback", "take back"], command: "undo" },
-  { keywords: ["skip", "skip task", "skip this"], command: "skip", acceptsArgs: true },
-  { keywords: ["visualize", "viz", "graph", "chart", "show graph"], command: "visualize" },
-  { keywords: ["capture", "note", "idea", "thought", "remember"], command: "capture", acceptsArgs: true },
-  { keywords: ["inspect", "database", "sqlite", "db state"], command: "inspect" },
-  { keywords: ["session report", "session summary", "cost summary", "how much"], command: "session-report", acceptsArgs: true },
-  { keywords: ["backlog", "parking lot", "later", "someday"], command: "backlog" },
-  { keywords: ["add tests", "write tests", "generate tests", "test coverage"], command: "add-tests", acceptsArgs: true },
-  { keywords: ["next", "step", "next step", "what's next"], command: "next", acceptsArgs: true },
-  { keywords: ["logs", "debug logs", "log files"], command: "logs", acceptsArgs: true },
-  { keywords: ["debug", "debug session", "investigate", "troubleshoot", "diagnose issue"], command: "debug", acceptsArgs: true },
-];
-
-interface MatchResult {
-  command: string;
-  remainingArgs: string;
-  score: number;
-}
-
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
-function keywordPattern(keyword: string, acceptsArgs: boolean): RegExp {
-  const escaped = keyword
-    .trim()
-    .split(/\s+/)
-    .map(escapeRegExp)
-    .join("\\s+");
-  return acceptsArgs
-    ? new RegExp(`^${escaped}(?:\\s+(.+))?$`, "i")
-    : new RegExp(`^${escaped}$`, "i");
-}
-
-function matchRoute(input: string): MatchResult | null {
-  const trimmed = input.trim();
-  let bestMatch: MatchResult | null = null;
-
-  for (const route of ROUTES) {
-    for (const keyword of route.keywords) {
-      const match = trimmed.match(keywordPattern(keyword, route.acceptsArgs === true));
-      if (match) {
-        const score = keyword.length;
-        if (!bestMatch || score > bestMatch.score) {
-          const remaining = route.acceptsArgs === true ? (match[1] ?? "").trim() : "";
-          bestMatch = { command: route.command, remainingArgs: remaining, score };
-        }
-      }
-    }
-  }
-
-  return bestMatch;
-}
+import { matchRoute, ROUTES } from "../commands-do.ts";
 
 // ─── Tests ──────────────────────────────────────────────────────────────
+
+test("/gsd do: tests use the canonical route table", () => {
+  const commands = new Set(ROUTES.map((route) => route.command));
+  for (const command of [
+    "export",
+    "queue",
+    "knowledge",
+    "pr-branch",
+    "migrate",
+    "steer",
+    "park",
+    "widget",
+  ]) {
+    assert.ok(commands.has(command), `expected canonical route table to include ${command}`);
+  }
+});
 
 test("/gsd do: routes exact progress intent to status", () => {
   const match = matchRoute("show me progress");
@@ -107,7 +40,7 @@ test("/gsd do: routes bare cleanup intent to cleanup", () => {
   assert.equal(match.remainingArgs, "");
 });
 
-test("/gsd do: does not route no-arg cleanup when sentence has extra words", () => {
+test("/gsd do: cleanup sentence stays a quick-task phrase instead of a partial cleanup command", () => {
   const match = matchRoute("clean up old branches");
   assert.equal(match, null);
 });
@@ -132,6 +65,11 @@ test("/gsd do: routes 'what is next' to next", () => {
 
 test("/gsd do: returns null for unrecognized input", () => {
   const match = matchRoute("florbinate the gizmo");
+  assert.equal(match, null);
+});
+
+test("/gsd do: full progress sentence stays a quick-task phrase", () => {
+  const match = matchRoute("How Far Along Are We on the mobile app");
   assert.equal(match, null);
 });
 

--- a/src/resources/extensions/gsd/tests/commands-do.test.ts
+++ b/src/resources/extensions/gsd/tests/commands-do.test.ts
@@ -7,6 +7,7 @@ import { matchRoute, ROUTES } from "../commands-do.ts";
 
 test("/gsd do: tests use the canonical route table", () => {
   const commands = new Set(ROUTES.map((route) => route.command));
+  const routeByCommand = new Map(ROUTES.map((route) => [route.command, route]));
   for (const command of [
     "export",
     "queue",
@@ -19,6 +20,13 @@ test("/gsd do: tests use the canonical route table", () => {
   ]) {
     assert.ok(commands.has(command), `expected canonical route table to include ${command}`);
   }
+
+  assert.equal(routeByCommand.get("cleanup")?.acceptsArgs, undefined);
+  assert.equal(routeByCommand.get("status")?.acceptsArgs, undefined);
+  assert.equal(routeByCommand.get("ship")?.acceptsArgs, true);
+  assert.equal(routeByCommand.get("debug")?.acceptsArgs, true);
+  assert.equal(routeByCommand.get("export")?.acceptsArgs, true);
+  assert.equal(routeByCommand.get("queue")?.acceptsArgs, undefined);
 });
 
 test("/gsd do: routes exact progress intent to status", () => {
@@ -49,12 +57,14 @@ test("/gsd do: routes 'create pr for milestone' to ship", () => {
   const match = matchRoute("create pr for milestone");
   assert.ok(match);
   assert.equal(match.command, "ship");
+  assert.equal(match.remainingArgs, "for milestone");
 });
 
 test("/gsd do: routes 'add tests for S03' to add-tests", () => {
   const match = matchRoute("add tests for S03");
   assert.ok(match);
   assert.equal(match.command, "add-tests");
+  assert.equal(match.remainingArgs, "for S03");
 });
 
 test("/gsd do: routes 'what is next' to next", () => {
@@ -85,18 +95,21 @@ test("/gsd do: routes debug troubleshooting intent to debug", () => {
   const match = matchRoute("debug this flaky oauth callback");
   assert.ok(match);
   assert.equal(match.command, "debug");
+  assert.equal(match.remainingArgs, "this flaky oauth callback");
 });
 
 test("/gsd do: keeps 'debug logs' routed to logs (longer keyword wins)", () => {
   const match = matchRoute("debug logs for today");
   assert.ok(match);
   assert.equal(match.command, "logs");
+  assert.equal(match.remainingArgs, "for today");
 });
 
 test("/gsd do: routes 'session report' to session-report", () => {
   const match = matchRoute("session report");
   assert.ok(match);
   assert.equal(match.command, "session-report");
+  assert.equal(match.remainingArgs, "");
 });
 
 test("/gsd do: routes 'diagnose issue' to debug (not doctor)", () => {
@@ -105,12 +118,14 @@ test("/gsd do: routes 'diagnose issue' to debug (not doctor)", () => {
   const match = matchRoute("diagnose issue with oauth callback");
   assert.ok(match);
   assert.equal(match.command, "debug");
+  assert.equal(match.remainingArgs, "with oauth callback");
 });
 
 test("/gsd do: routes 'investigate flaky test' to debug", () => {
   const match = matchRoute("investigate flaky test in CI");
   assert.ok(match);
   assert.equal(match.command, "debug");
+  assert.equal(match.remainingArgs, "flaky test in CI");
 });
 
 test("/gsd do: 'debug logs' keyword wins over bare 'debug' (longer keyword precedence)", () => {
@@ -118,12 +133,14 @@ test("/gsd do: 'debug logs' keyword wins over bare 'debug' (longer keyword prece
   const logsMatch = matchRoute("debug logs for the last run");
   assert.ok(logsMatch);
   assert.equal(logsMatch.command, "logs");
+  assert.equal(logsMatch.remainingArgs, "for the last run");
   assert.ok(logsMatch.score >= 10, `expected score >= 10, got ${logsMatch.score}`);
 
   // Bare 'debug' without 'logs' should still route to debug.
   const debugMatch = matchRoute("debug the payment timeout issue");
   assert.ok(debugMatch);
   assert.equal(debugMatch.command, "debug");
+  assert.equal(debugMatch.remainingArgs, "the payment timeout issue");
 });
 
 test("/gsd do: 'diagnose' alone routes to doctor (health check), not debug", () => {
@@ -131,6 +148,7 @@ test("/gsd do: 'diagnose' alone routes to doctor (health check), not debug", () 
   const match = matchRoute("diagnose my project");
   assert.ok(match);
   assert.equal(match.command, "doctor");
+  assert.equal(match.remainingArgs, "my project");
 });
 
 test("/gsd do: full task sentence falls back instead of token-routing to command", () => {

--- a/src/resources/extensions/gsd/tests/commands-do.test.ts
+++ b/src/resources/extensions/gsd/tests/commands-do.test.ts
@@ -19,29 +19,30 @@ const mockCtx = {
 interface Route {
   keywords: string[];
   command: string;
+  acceptsArgs?: boolean;
 }
 
 const ROUTES: Route[] = [
-  { keywords: ["progress", "status", "dashboard", "how far", "where are we"], command: "status" },
-  { keywords: ["auto", "autonomous", "run all", "keep going", "start auto"], command: "auto" },
+  { keywords: ["progress", "status", "dashboard", "how far", "where are we", "show me progress"], command: "status" },
+  { keywords: ["auto", "autonomous", "run all", "keep going", "start auto", "run autonomously"], command: "auto", acceptsArgs: true },
   { keywords: ["stop", "halt", "abort"], command: "stop" },
   { keywords: ["pause", "break", "take a break"], command: "pause" },
-  { keywords: ["history", "past", "what happened", "previous"], command: "history" },
-  { keywords: ["doctor", "health", "diagnose", "check health"], command: "doctor" },
+  { keywords: ["history", "past", "what happened", "previous"], command: "history", acceptsArgs: true },
+  { keywords: ["doctor", "health", "diagnose", "check health"], command: "doctor", acceptsArgs: true },
   { keywords: ["clean up", "cleanup", "remove old", "prune", "tidy"], command: "cleanup" },
-  { keywords: ["ship", "pull request", "create pr", "open pr", "merge"], command: "ship" },
+  { keywords: ["ship", "pull request", "create pr", "open pr", "merge"], command: "ship", acceptsArgs: true },
   { keywords: ["discuss", "talk about", "architecture", "design"], command: "discuss" },
   { keywords: ["undo", "revert", "rollback", "take back"], command: "undo" },
-  { keywords: ["skip", "skip task", "skip this"], command: "skip" },
+  { keywords: ["skip", "skip task", "skip this"], command: "skip", acceptsArgs: true },
   { keywords: ["visualize", "viz", "graph", "chart", "show graph"], command: "visualize" },
-  { keywords: ["capture", "note", "idea", "thought", "remember"], command: "capture" },
+  { keywords: ["capture", "note", "idea", "thought", "remember"], command: "capture", acceptsArgs: true },
   { keywords: ["inspect", "database", "sqlite", "db state"], command: "inspect" },
-  { keywords: ["session report", "session summary", "cost summary", "how much"], command: "session-report" },
+  { keywords: ["session report", "session summary", "cost summary", "how much"], command: "session-report", acceptsArgs: true },
   { keywords: ["backlog", "parking lot", "later", "someday"], command: "backlog" },
-  { keywords: ["add tests", "write tests", "generate tests", "test coverage"], command: "add-tests" },
-  { keywords: ["next", "step", "next step", "what's next"], command: "next" },
-  { keywords: ["logs", "debug logs", "log files"], command: "logs" },
-  { keywords: ["debug", "debug session", "investigate", "troubleshoot", "diagnose issue"], command: "debug" },
+  { keywords: ["add tests", "write tests", "generate tests", "test coverage"], command: "add-tests", acceptsArgs: true },
+  { keywords: ["next", "step", "next step", "what's next"], command: "next", acceptsArgs: true },
+  { keywords: ["logs", "debug logs", "log files"], command: "logs", acceptsArgs: true },
+  { keywords: ["debug", "debug session", "investigate", "troubleshoot", "diagnose issue"], command: "debug", acceptsArgs: true },
 ];
 
 interface MatchResult {
@@ -50,17 +51,32 @@ interface MatchResult {
   score: number;
 }
 
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function keywordPattern(keyword: string, acceptsArgs: boolean): RegExp {
+  const escaped = keyword
+    .trim()
+    .split(/\s+/)
+    .map(escapeRegExp)
+    .join("\\s+");
+  return acceptsArgs
+    ? new RegExp(`^${escaped}(?:\\s+(.+))?$`, "i")
+    : new RegExp(`^${escaped}$`, "i");
+}
+
 function matchRoute(input: string): MatchResult | null {
-  const lower = input.toLowerCase();
+  const trimmed = input.trim();
   let bestMatch: MatchResult | null = null;
 
   for (const route of ROUTES) {
     for (const keyword of route.keywords) {
-      if (lower.includes(keyword)) {
+      const match = trimmed.match(keywordPattern(keyword, route.acceptsArgs === true));
+      if (match) {
         const score = keyword.length;
         if (!bestMatch || score > bestMatch.score) {
-          const idx = lower.indexOf(keyword);
-          const remaining = (input.slice(0, idx) + input.slice(idx + keyword.length)).trim();
+          const remaining = route.acceptsArgs === true ? (match[1] ?? "").trim() : "";
           bestMatch = { command: route.command, remainingArgs: remaining, score };
         }
       }
@@ -72,23 +88,28 @@ function matchRoute(input: string): MatchResult | null {
 
 // ─── Tests ──────────────────────────────────────────────────────────────
 
-test("/gsd do: routes 'show me progress' to status", () => {
+test("/gsd do: routes exact progress intent to status", () => {
   const match = matchRoute("show me progress");
   assert.ok(match);
   assert.equal(match.command, "status");
 });
 
-test("/gsd do: routes 'run autonomously' to auto", () => {
+test("/gsd do: routes bare auto intent to auto", () => {
   const match = matchRoute("run autonomously");
   assert.ok(match);
   assert.equal(match.command, "auto");
 });
 
-test("/gsd do: routes 'clean up old branches' to cleanup", () => {
-  const match = matchRoute("clean up old branches");
+test("/gsd do: routes bare cleanup intent to cleanup", () => {
+  const match = matchRoute("clean up");
   assert.ok(match);
   assert.equal(match.command, "cleanup");
-  assert.equal(match.remainingArgs, "old branches");
+  assert.equal(match.remainingArgs, "");
+});
+
+test("/gsd do: does not route no-arg cleanup when sentence has extra words", () => {
+  const match = matchRoute("clean up old branches");
+  assert.equal(match, null);
 });
 
 test("/gsd do: routes 'create pr for milestone' to ship", () => {
@@ -129,13 +150,13 @@ test("/gsd do: routes debug troubleshooting intent to debug", () => {
 });
 
 test("/gsd do: keeps 'debug logs' routed to logs (longer keyword wins)", () => {
-  const match = matchRoute("show me debug logs for today");
+  const match = matchRoute("debug logs for today");
   assert.ok(match);
   assert.equal(match.command, "logs");
 });
 
 test("/gsd do: routes 'session report' to session-report", () => {
-  const match = matchRoute("show me the session report");
+  const match = matchRoute("session report");
   assert.ok(match);
   assert.equal(match.command, "session-report");
 });
@@ -172,4 +193,9 @@ test("/gsd do: 'diagnose' alone routes to doctor (health check), not debug", () 
   const match = matchRoute("diagnose my project");
   assert.ok(match);
   assert.equal(match.command, "doctor");
+});
+
+test("/gsd do: full task sentence falls back instead of token-routing to command", () => {
+  const match = matchRoute("review tickets on linear and update the ticket status as you work");
+  assert.equal(match, null);
 });


### PR DESCRIPTION
## Linked issue

Closes #4692

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Narrows `/gsd do` keyword routing so full task sentences are not token-scanned into unrelated slash commands.
**Why:** Natural-language tasks that mention words like `status` could be rewritten into no-arg commands and then fail with an Unknown warning.
**How:** Routes only exact keyword phrases, or prefix matches for commands that actually accept trailing arguments, using precompiled route patterns and canonical route tests.

## What

This updates the GSD extension `/gsd do` router and its regression tests.

The router now distinguishes between no-arg commands and commands that can accept additional text. No-arg commands such as `status`, `cleanup`, and `visualize` only route on exact command-intent phrases, while argument-capable commands such as `debug`, `ship`, `add-tests`, and `logs` can still receive trailing text when the phrase starts with their keyword.

The test now imports the canonical route table and matcher from `commands-do.ts` instead of copying the implementation into the test file.

## Why

The previous router matched keywords anywhere in the user text and appended the remaining words to the routed command. That meant a normal task sentence could accidentally become something like `/gsd status ...`, which the strict no-arg handler rejected as unknown.

## How

The route table records whether a command accepts trailing args. Keyword matching is anchored to the whole phrase or the beginning of the phrase instead of scanning every token inside a sentence. Route regexes are precompiled at module load, so matching does not rebuild every pattern on each `/gsd do` input.

Review feedback follow-up removed duplicated route logic from the test, added explicit canonical-route coverage, and pinned the product decision that phrases like `clean up old branches` remain quick-task phrases rather than partial no-arg command dispatches.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

Automated verification:

1. `npm run build`
2. `npm run typecheck:extensions`
3. `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/commands-do.test.ts`
4. `npm run secret-scan -- --diff upstream/main`

Manual smoke covered by the targeted route cases above: exact command phrases still route, argument-capable prefix phrases still preserve trailing text, and full task sentences mentioning route keywords now fall back instead of dispatching unrelated commands.

## AI disclosure

- [x] This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.
