### PR TITLE
fix(gsd): resolve dotted-stem TypeScript imports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1414,6 +1414,16 @@
         "global-agent": "^3.0.0"
       }
     },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",

--- a/src/resources/extensions/gsd/post-execution-checks.ts
+++ b/src/resources/extensions/gsd/post-execution-checks.ts
@@ -18,8 +18,9 @@ import { resolve, dirname, join, extname } from "node:path";
 import type { TaskRow } from "./gsd-db.ts";
 
 const CODE_EXTENSION_ORDER = [".ts", ".tsx", ".mts", ".cts", ".js", ".jsx", ".mjs", ".cjs"];
+const TYPESCRIPT_EXTENSIONS = new Set([".ts", ".tsx", ".mts", ".cts"]);
+const JAVASCRIPT_RUNTIME_EXTENSIONS = new Set([".js", ".jsx", ".mjs", ".cjs"]);
 const CODE_EXTENSIONS = new Set(CODE_EXTENSION_ORDER);
-const TS_ESM_EXTENSIONS = new Set([".js", ".jsx", ".mjs", ".cjs"]);
 const TS_ESM_EXTENSION_FALLBACKS = new Map<string, string[]>([
   [".js", [".ts", ".tsx", ".js", ".jsx"]],
   [".jsx", [".tsx", ".jsx"]],
@@ -69,7 +70,7 @@ const SEALED_NON_CODE_EXTENSIONS = new Set([
 ]);
 
 function isCodeFile(file: string): boolean {
-  return CODE_EXTENSIONS.has(extname(file));
+  return CODE_EXTENSIONS.has(extname(file).toLowerCase());
 }
 
 // ─── Result Types ────────────────────────────────────────────────────────────
@@ -191,7 +192,7 @@ export function resolveImportPath(
   // If the import already has an explicit extension, check it as-is first.
   // For known sealed extensions, a miss stays missing. Unknown dotted suffixes
   // such as `.test-utils` are treated as part of the TypeScript stem (#4659).
-  const explicitExt = extname(importPath);
+  const explicitExt = extname(importPath).toLowerCase();
   if (explicitExt !== "") {
     const directPath = resolve(sourceDir, importPath);
     if (existsSync(directPath)) {
@@ -203,9 +204,9 @@ export function resolveImportPath(
     // `./missing.css.ts`. Unknown dotted suffixes are sealed by default, with a
     // narrow allowlist for common TS module stems such as `route.server`.
     if (
-      (CODE_EXTENSIONS.has(explicitExt) && !TS_ESM_EXTENSIONS.has(explicitExt))
+      TYPESCRIPT_EXTENSIONS.has(explicitExt)
       || SEALED_NON_CODE_EXTENSIONS.has(explicitExt)
-      || (!TS_ESM_EXTENSIONS.has(explicitExt) && !DOTTED_STEM_FALLBACK_EXTENSIONS.has(explicitExt))
+      || (!JAVASCRIPT_RUNTIME_EXTENSIONS.has(explicitExt) && !DOTTED_STEM_FALLBACK_EXTENSIONS.has(explicitExt))
     ) {
       return { exists: false, resolvedPath: null };
     }
@@ -214,18 +215,9 @@ export function resolveImportPath(
   // Handle TypeScript ESM convention: .js imports resolve to .ts files
   // e.g., import './types.js' -> ./types.ts
   let normalizedPath = importPath;
-  if (importPath.endsWith(".js")) {
-    normalizedPath = importPath.slice(0, -3);
-    extensions = TS_ESM_EXTENSION_FALLBACKS.get(".js") ?? extensions;
-  } else if (importPath.endsWith(".jsx")) {
-    normalizedPath = importPath.slice(0, -4);
-    extensions = TS_ESM_EXTENSION_FALLBACKS.get(".jsx") ?? extensions;
-  } else if (importPath.endsWith(".mjs")) {
-    normalizedPath = importPath.slice(0, -4);
-    extensions = TS_ESM_EXTENSION_FALLBACKS.get(".mjs") ?? extensions;
-  } else if (importPath.endsWith(".cjs")) {
-    normalizedPath = importPath.slice(0, -4);
-    extensions = TS_ESM_EXTENSION_FALLBACKS.get(".cjs") ?? extensions;
+  if (JAVASCRIPT_RUNTIME_EXTENSIONS.has(explicitExt)) {
+    normalizedPath = importPath.slice(0, -explicitExt.length);
+    extensions = TS_ESM_EXTENSION_FALLBACKS.get(explicitExt) ?? extensions;
   }
 
   // Try the normalized path with common extensions
@@ -260,10 +252,7 @@ export function checkImportResolution(
   const results: PostExecutionCheckJSON[] = [];
 
   // Get files from key_files
-  const filesToCheck = taskRow.key_files.filter((f) => {
-    const ext = extname(f);
-    return [".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"].includes(ext);
-  });
+  const filesToCheck = taskRow.key_files.filter(isCodeFile);
 
   for (const file of filesToCheck) {
     const absolutePath = resolve(basePath, file);

--- a/src/resources/extensions/gsd/post-execution-checks.ts
+++ b/src/resources/extensions/gsd/post-execution-checks.ts
@@ -17,6 +17,61 @@ import { existsSync, readFileSync } from "node:fs";
 import { resolve, dirname, join, extname } from "node:path";
 import type { TaskRow } from "./gsd-db.ts";
 
+const CODE_EXTENSION_ORDER = [".ts", ".tsx", ".mts", ".cts", ".js", ".jsx", ".mjs", ".cjs"];
+const CODE_EXTENSIONS = new Set(CODE_EXTENSION_ORDER);
+const TS_ESM_EXTENSIONS = new Set([".js", ".jsx", ".mjs", ".cjs"]);
+const TS_ESM_EXTENSION_FALLBACKS = new Map<string, string[]>([
+  [".js", [".ts", ".tsx", ".js", ".jsx"]],
+  [".jsx", [".tsx", ".jsx"]],
+  [".mjs", [".mts", ".mjs"]],
+  [".cjs", [".cts", ".cjs"]],
+]);
+const DOTTED_STEM_FALLBACK_EXTENSIONS = new Set([
+  ".client",
+  ".server",
+  ".spec",
+  ".stories",
+  ".test",
+  ".test-utils",
+  ".webhook",
+]);
+const SEALED_NON_CODE_EXTENSIONS = new Set([
+  ".css",
+  ".scss",
+  ".sass",
+  ".less",
+  ".styl",
+  ".png",
+  ".jpg",
+  ".jpeg",
+  ".gif",
+  ".svg",
+  ".webp",
+  ".avif",
+  ".ico",
+  ".bmp",
+  ".woff",
+  ".woff2",
+  ".ttf",
+  ".otf",
+  ".eot",
+  ".json",
+  ".jsonc",
+  ".yaml",
+  ".yml",
+  ".toml",
+  ".md",
+  ".mdx",
+  ".txt",
+  ".html",
+  ".xml",
+  ".wasm",
+]);
+
+function isCodeFile(file: string): boolean {
+  return CODE_EXTENSIONS.has(extname(file));
+}
+
 // ─── Result Types ────────────────────────────────────────────────────────────
 
 export interface PostExecutionCheckJSON {
@@ -131,13 +186,11 @@ export function resolveImportPath(
   basePath: string
 ): { exists: boolean; resolvedPath: string | null } {
   const sourceDir = dirname(resolve(basePath, sourceFile));
-  const extensions = [".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"];
+  let extensions = CODE_EXTENSION_ORDER;
 
   // If the import already has an explicit extension, check it as-is first.
-  // This correctly resolves asset imports like .css, .scss, images, fonts
-  // without requiring each extension to be enumerated (issue #4411). We only
-  // do this when the import carries an extension so that extensionless module
-  // imports still flow through the TS ESM convention and index-file resolvers.
+  // For known sealed extensions, a miss stays missing. Unknown dotted suffixes
+  // such as `.test-utils` are treated as part of the TypeScript stem (#4659).
   const explicitExt = extname(importPath);
   if (explicitExt !== "") {
     const directPath = resolve(sourceDir, importPath);
@@ -145,29 +198,15 @@ export function resolveImportPath(
       return { exists: true, resolvedPath: directPath };
     }
 
-    // Known concrete extensions that should NOT fall through to code-shadow
-    // probing when missing. This preserves the "missing.css must stay missing"
-    // guarantee while still allowing dotted module stems like ./route.server
-    // to resolve as ./route.server.ts.
-    const nonFallbackExtensions = new Set([
-      ".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs",
-      ".json", ".css", ".scss", ".sass", ".less", ".styl",
-      ".svg", ".png", ".jpg", ".jpeg", ".gif", ".webp", ".avif", ".ico", ".bmp",
-      ".woff", ".woff2", ".ttf", ".otf", ".eot",
-    ]);
-    const runtimeFallbackExtensions = new Set([".js", ".jsx", ".mjs", ".cjs"]);
-    const dottedStemFallbackExtensions = new Set([".server", ".client", ".webhook"]);
-
+    // Known code extensions and known asset/data extensions are explicit file
+    // requests. Do not let `./missing.css` accidentally resolve to
+    // `./missing.css.ts`. Unknown dotted suffixes are sealed by default, with a
+    // narrow allowlist for common TS module stems such as `route.server`.
     if (
-      explicitExt !== "" &&
-      !runtimeFallbackExtensions.has(explicitExt) &&
-      !nonFallbackExtensions.has(explicitExt) &&
-      !dottedStemFallbackExtensions.has(explicitExt)
+      (CODE_EXTENSIONS.has(explicitExt) && !TS_ESM_EXTENSIONS.has(explicitExt))
+      || SEALED_NON_CODE_EXTENSIONS.has(explicitExt)
+      || (!TS_ESM_EXTENSIONS.has(explicitExt) && !DOTTED_STEM_FALLBACK_EXTENSIONS.has(explicitExt))
     ) {
-      return { exists: false, resolvedPath: null };
-    }
-
-    if (nonFallbackExtensions.has(explicitExt) && !runtimeFallbackExtensions.has(explicitExt)) {
       return { exists: false, resolvedPath: null };
     }
   }
@@ -177,12 +216,16 @@ export function resolveImportPath(
   let normalizedPath = importPath;
   if (importPath.endsWith(".js")) {
     normalizedPath = importPath.slice(0, -3);
+    extensions = TS_ESM_EXTENSION_FALLBACKS.get(".js") ?? extensions;
   } else if (importPath.endsWith(".jsx")) {
     normalizedPath = importPath.slice(0, -4);
+    extensions = TS_ESM_EXTENSION_FALLBACKS.get(".jsx") ?? extensions;
   } else if (importPath.endsWith(".mjs")) {
     normalizedPath = importPath.slice(0, -4);
+    extensions = TS_ESM_EXTENSION_FALLBACKS.get(".mjs") ?? extensions;
   } else if (importPath.endsWith(".cjs")) {
     normalizedPath = importPath.slice(0, -4);
+    extensions = TS_ESM_EXTENSION_FALLBACKS.get(".cjs") ?? extensions;
   }
 
   // Try the normalized path with common extensions
@@ -359,8 +402,7 @@ export function checkCrossTaskSignatures(
 
   for (const task of priorTasks) {
     for (const file of task.key_files) {
-      const ext = extname(file);
-      if (![".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"].includes(ext)) continue;
+      if (!isCodeFile(file)) continue;
 
       const absolutePath = resolve(basePath, file);
       if (!existsSync(absolutePath)) continue;
@@ -382,8 +424,7 @@ export function checkCrossTaskSignatures(
   // Extract function calls/references from current task's key_files
   // and check they match prior definitions
   for (const file of taskRow.key_files) {
-    const ext = extname(file);
-    if (![".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"].includes(ext)) continue;
+    if (!isCodeFile(file)) continue;
 
     const absolutePath = resolve(basePath, file);
     if (!existsSync(absolutePath)) continue;
@@ -446,8 +487,7 @@ export function checkPatternConsistency(
   const results: PostExecutionCheckJSON[] = [];
 
   for (const file of taskRow.key_files) {
-    const ext = extname(file);
-    if (![".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"].includes(ext)) continue;
+    if (!isCodeFile(file)) continue;
 
     const absolutePath = resolve(basePath, file);
     if (!existsSync(absolutePath)) continue;

--- a/src/resources/extensions/gsd/tests/post-execution-checks.test.ts
+++ b/src/resources/extensions/gsd/tests/post-execution-checks.test.ts
@@ -328,6 +328,79 @@ describe("resolveImportPath", () => {
     assert.ok(storiesResult.resolvedPath?.endsWith("Button.stories.tsx"));
   });
 
+  test("resolves test and spec dotted stems without treating the suffix as sealed", (t) => {
+    const dir = mkdtempSync(join(tmpdir(), "post-exec-test-dotted-spec-"));
+    t.after(() => rmSync(dir, { recursive: true, force: true }));
+    mkdirSync(join(dir, "src"), { recursive: true });
+    writeFileSync(join(dir, "src", "Widget.test.ts"), "export {};");
+    writeFileSync(join(dir, "src", "Widget.spec.ts"), "export {};");
+    writeFileSync(join(dir, "src", "main.ts"), "");
+
+    const testResult = resolveImportPath("./Widget.test", "src/main.ts", dir);
+    assert.ok(testResult.exists, "dotted .test stem should resolve");
+    assert.ok(testResult.resolvedPath?.endsWith("Widget.test.ts"));
+
+    const specResult = resolveImportPath("./Widget.spec", "src/main.ts", dir);
+    assert.ok(specResult.exists, "dotted .spec stem should resolve");
+    assert.ok(specResult.resolvedPath?.endsWith("Widget.spec.ts"));
+  });
+
+  test("resolves explicit TypeScript declaration and module extensions", (t) => {
+    const dir = mkdtempSync(join(tmpdir(), "post-exec-test-ts-exts-"));
+    t.after(() => rmSync(dir, { recursive: true, force: true }));
+    mkdirSync(join(dir, "src"), { recursive: true });
+    writeFileSync(join(dir, "src", "types.d.ts"), "export interface Types {}");
+    writeFileSync(join(dir, "src", "runtime.mts"), "export {};");
+    writeFileSync(join(dir, "src", "runtime.cts"), "export {};");
+    writeFileSync(join(dir, "src", "main.ts"), "");
+
+    const declarationResult = resolveImportPath("./types.d.ts", "src/main.ts", dir);
+    assert.ok(declarationResult.exists, "explicit .d.ts import should resolve directly");
+    assert.ok(declarationResult.resolvedPath?.endsWith("types.d.ts"));
+
+    const mtsResult = resolveImportPath("./runtime.mts", "src/main.ts", dir);
+    assert.ok(mtsResult.exists, "explicit .mts import should resolve directly");
+    assert.ok(mtsResult.resolvedPath?.endsWith("runtime.mts"));
+
+    const ctsResult = resolveImportPath("./runtime.cts", "src/main.ts", dir);
+    assert.ok(ctsResult.exists, "explicit .cts import should resolve directly");
+    assert.ok(ctsResult.resolvedPath?.endsWith("runtime.cts"));
+  });
+
+  test("resolves JavaScript module imports to TypeScript module siblings", (t) => {
+    const dir = mkdtempSync(join(tmpdir(), "post-exec-test-ts-module-exts-"));
+    t.after(() => rmSync(dir, { recursive: true, force: true }));
+    mkdirSync(join(dir, "src"), { recursive: true });
+    writeFileSync(join(dir, "src", "esm.mts"), "export {};");
+    writeFileSync(join(dir, "src", "common.cts"), "export {};");
+    writeFileSync(join(dir, "src", "main.ts"), "");
+
+    const esmResult = resolveImportPath("./esm.mjs", "src/main.ts", dir);
+    assert.ok(esmResult.exists, ".mjs import should resolve to .mts sibling");
+    assert.ok(esmResult.resolvedPath?.endsWith("esm.mts"));
+
+    const commonResult = resolveImportPath("./common.cjs", "src/main.ts", dir);
+    assert.ok(commonResult.exists, ".cjs import should resolve to .cts sibling");
+    assert.ok(commonResult.resolvedPath?.endsWith("common.cts"));
+  });
+
+  test("missing explicit TypeScript and asset extensions do not match code shadows", (t) => {
+    const dir = mkdtempSync(join(tmpdir(), "post-exec-test-sealed-exts-"));
+    t.after(() => rmSync(dir, { recursive: true, force: true }));
+    mkdirSync(join(dir, "src"), { recursive: true });
+    writeFileSync(join(dir, "src", "missing.mts.ts"), "export {};");
+    writeFileSync(join(dir, "src", "missing.CSS.ts"), "export {};");
+    writeFileSync(join(dir, "src", "main.ts"), "");
+
+    const mtsResult = resolveImportPath("./missing.mts", "src/main.ts", dir);
+    assert.ok(!mtsResult.exists, "missing explicit .mts import should stay missing");
+    assert.equal(mtsResult.resolvedPath, null);
+
+    const cssResult = resolveImportPath("./missing.CSS", "src/main.ts", dir);
+    assert.ok(!cssResult.exists, "missing asset import should be case-insensitively sealed");
+    assert.equal(cssResult.resolvedPath, null);
+  });
+
   // Non-code explicit extensions must not fall through to code-extension
   // shadows: a missing ./missing.css must stay unresolved even if a stray
   // ./missing.css.ts happens to exist.

--- a/src/resources/extensions/gsd/tests/post-execution-checks.test.ts
+++ b/src/resources/extensions/gsd/tests/post-execution-checks.test.ts
@@ -290,6 +290,44 @@ describe("resolveImportPath", () => {
     assert.ok(result.resolvedPath?.endsWith("types.ts"));
   });
 
+  test("resolves .mjs and .cjs imports to TS module siblings", (t) => {
+    const dir = mkdtempSync(join(tmpdir(), "post-exec-test-ts-module-"));
+    t.after(() => rmSync(dir, { recursive: true, force: true }));
+    mkdirSync(join(dir, "src"), { recursive: true });
+    writeFileSync(join(dir, "src", "esm.mts"), "export {};");
+    writeFileSync(join(dir, "src", "common.cts"), "export = {};");
+    writeFileSync(join(dir, "src", "main.ts"), "");
+
+    const esmResult = resolveImportPath("./esm.mjs", "src/main.ts", dir);
+    assert.ok(esmResult.exists);
+    assert.ok(esmResult.resolvedPath?.endsWith("esm.mts"));
+
+    const cjsResult = resolveImportPath("./common.cjs", "src/main.ts", dir);
+    assert.ok(cjsResult.exists);
+    assert.ok(cjsResult.resolvedPath?.endsWith("common.cts"));
+  });
+
+  test("resolves dotted-stem TypeScript import without extension", (t) => {
+    const dir = mkdtempSync(join(tmpdir(), "post-exec-test-dotted-stem-"));
+    t.after(() => rmSync(dir, { recursive: true, force: true }));
+    mkdirSync(join(dir, "src", "lib"), { recursive: true });
+    writeFileSync(join(dir, "src", "lib", "test-helpers.test-utils.ts"), "export {};");
+    writeFileSync(join(dir, "src", "Button.stories.tsx"), "export {};");
+    writeFileSync(join(dir, "src", "main.ts"), "");
+
+    const helperResult = resolveImportPath(
+      "./lib/test-helpers.test-utils",
+      "src/main.ts",
+      dir
+    );
+    assert.ok(helperResult.exists, "dotted helper stem should resolve");
+    assert.ok(helperResult.resolvedPath?.endsWith("test-helpers.test-utils.ts"));
+
+    const storiesResult = resolveImportPath("./Button.stories", "src/main.ts", dir);
+    assert.ok(storiesResult.exists, "dotted stories stem should resolve");
+    assert.ok(storiesResult.resolvedPath?.endsWith("Button.stories.tsx"));
+  });
+
   // Non-code explicit extensions must not fall through to code-extension
   // shadows: a missing ./missing.css must stay unresolved even if a stray
   // ./missing.css.ts happens to exist.
@@ -654,6 +692,28 @@ describe("checkCrossTaskSignatures", () => {
       rmSync(tempDir, { recursive: true, force: true });
     }
   });
+
+  test("checks signatures in .mts and .cts key files", (t) => {
+    const dir = mkdtempSync(join(tmpdir(), "post-exec-test-signature-mts-"));
+    t.after(() => rmSync(dir, { recursive: true, force: true }));
+    mkdirSync(join(dir, "src"), { recursive: true });
+    writeFileSync(
+      join(dir, "src", "utils.mts"),
+      "export function parse(value: string): string { return value; }"
+    );
+    writeFileSync(
+      join(dir, "src", "api.cts"),
+      "export function parse(value: number): string { return String(value); }"
+    );
+
+    const priorTask = createTask({ id: "T01", key_files: ["src/utils.mts"] });
+    const currentTask = createTask({ id: "T02", key_files: ["src/api.cts"] });
+
+    const results = checkCrossTaskSignatures(currentTask, [priorTask], dir);
+    assert.equal(results.length, 1);
+    assert.equal(results[0].target, "parse");
+    assert.ok(results[0].message.includes("parameters"));
+  });
 });
 
 // ─── Pattern Consistency Tests ───────────────────────────────────────────────
@@ -724,6 +784,23 @@ describe("checkPatternConsistency", () => {
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }
+  });
+
+  test("checks patterns in .mts key files", (t) => {
+    const dir = mkdtempSync(join(tmpdir(), "post-exec-test-pattern-mts-"));
+    t.after(() => rmSync(dir, { recursive: true, force: true }));
+    writeFileSync(
+      join(dir, "api.mts"),
+      `async function getData(): Promise<string> {
+        const result = await fetch('/api');
+        return result.text().then(t => t.toUpperCase());
+      }`
+    );
+
+    const task = createTask({ id: "T01", key_files: ["api.mts"] });
+    const results = checkPatternConsistency(task, [], dir);
+
+    assert.equal(results.filter((r) => r.message.includes("async")).length, 1);
   });
 
   test("passes when naming is consistent (camelCase only)", () => {

--- a/src/resources/extensions/gsd/tests/post-execution-checks.test.ts
+++ b/src/resources/extensions/gsd/tests/post-execution-checks.test.ts
@@ -730,6 +730,39 @@ describe("checkCrossTaskSignatures", () => {
     }
   });
 
+  test("checks .mts and .cts key files with the shared code-extension set", () => {
+    tempDir = join(tmpdir(), `post-exec-test-${Date.now()}`);
+    mkdirSync(tempDir, { recursive: true });
+    mkdirSync(join(tempDir, "src"), { recursive: true });
+    writeFileSync(
+      join(tempDir, "src", "utils.mts"),
+      "export function serialize(value: string): string { return value; }"
+    );
+    writeFileSync(
+      join(tempDir, "src", "api.cts"),
+      "export function serialize(value: number): string { return String(value); }"
+    );
+
+    try {
+      const priorTask = createTask({
+        id: "T01",
+        key_files: ["src/utils.mts"],
+      });
+      const currentTask = createTask({
+        id: "T02",
+        key_files: ["src/api.cts"],
+      });
+
+      const results = checkCrossTaskSignatures(currentTask, [priorTask], tempDir);
+      assert.equal(results.length, 1);
+      assert.equal(results[0].category, "signature");
+      assert.equal(results[0].target, "serialize");
+      assert.ok(results[0].message.includes("parameters"));
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
   test("handles multiple prior tasks", () => {
     tempDir = join(tmpdir(), `post-exec-test-${Date.now()}`);
     mkdirSync(tempDir, { recursive: true });
@@ -859,21 +892,26 @@ describe("checkPatternConsistency", () => {
     }
   });
 
-  test("checks patterns in .mts key files", (t) => {
-    const dir = mkdtempSync(join(tmpdir(), "post-exec-test-pattern-mts-"));
-    t.after(() => rmSync(dir, { recursive: true, force: true }));
+  test("checks .mts key files for pattern consistency", () => {
+    tempDir = join(tmpdir(), `post-exec-test-${Date.now()}`);
+    mkdirSync(tempDir, { recursive: true });
     writeFileSync(
-      join(dir, "api.mts"),
+      join(tempDir, "api.mts"),
       `async function getData(): Promise<string> {
         const result = await fetch('/api');
         return result.text().then(t => t.toUpperCase());
       }`
     );
 
-    const task = createTask({ id: "T01", key_files: ["api.mts"] });
-    const results = checkPatternConsistency(task, [], dir);
-
-    assert.equal(results.filter((r) => r.message.includes("async")).length, 1);
+    try {
+      const task = createTask({ id: "T01", key_files: ["api.mts"] });
+      const results = checkPatternConsistency(task, [], tempDir);
+      const asyncResults = results.filter((r) => r.message.includes("async"));
+      assert.equal(asyncResults.length, 1);
+      assert.equal(asyncResults[0].category, "pattern");
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
   });
 
   test("passes when naming is consistent (camelCase only)", () => {


### PR DESCRIPTION
## Linked issue

Closes #4659

- [x] I have linked an issue above. I understand that PRs without a linked issue will be closed without review.

---

## TL;DR

**What:** Allows post-execution import checks to resolve dotted-stem and compound TypeScript files imported without an extension.
**Why:** Valid imports like `./helpers.test-utils`, `./Widget.spec`, and JS-family imports to `.mts`/`.cts` siblings were treated as missing or under-tested.
**How:** Keeps known asset/data and explicit TypeScript extensions sealed, lowercases extension classification, and lets unknown dotted suffixes continue through the normal TypeScript resolver.

## What

This updates the GSD extension post-execution import resolver and its regression tests.

The resolver still checks explicit file imports as-is first. If the direct path is missing, known sealed extensions such as CSS, JSON, images, fonts, and explicit TypeScript extensions stay unresolved. Unknown dotted suffixes such as `.test-utils`, `.test`, `.spec`, or `.stories` now flow through to the normal TypeScript extension resolution path.

The extension set now also includes `.mts` and `.cts`, and JS-family imports such as `.mjs` and `.cjs` can resolve to TypeScript module siblings.

## Why

`path.extname()` reports the final dotted segment of an extensionless TypeScript stem as an extension. That made valid imports such as `./test-helpers.test-utils` fail the post-execution check even when `test-helpers.test-utils.ts` existed and the project's real TypeScript/test tooling resolved it correctly.

## How

The fix separates TypeScript source extensions, JavaScript runtime extensions, and sealed non-code extensions. JS-family imports still support the existing TypeScript ESM convention, known assets still avoid accidental code-shadow matches, and unknown dotted stems can now resolve to sibling TypeScript files.

Review feedback follow-up added explicit coverage for `.test`, `.spec`, `.d.ts`, `.mts`, `.cts`, `.mjs` to `.mts`, `.cjs` to `.cts`, and case-insensitive sealed asset handling.

## Change type

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

## Scope

- [ ] `pi-tui` — Terminal UI
- [ ] `pi-ai` — AI/LLM layer
- [ ] `pi-agent-core` — Agent orchestration
- [ ] `pi-coding-agent` — Coding agent
- [x] `gsd extension` — GSD workflow
- [ ] `native` — Native bindings
- [ ] `ci/build` — Workflows, scripts, config

## Breaking changes

- [x] No breaking changes
- [ ] Yes — described above

## Test plan

- [x] CI passes
- [x] New/updated tests included
- [x] Manual testing — steps described above
- [ ] No tests needed — explained above

Automated verification:

1. `npm run build`
2. `npm run typecheck:extensions`
3. `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/post-execution-checks.test.ts`
4. `npm run secret-scan -- --diff upstream/main`

Manual smoke covered by the targeted resolver cases above: dotted stems now resolve to TypeScript siblings, JS-family module imports resolve to `.mts`/`.cts` siblings, and missing asset or explicit TypeScript imports still do not match accidental code-extension shadows.

## AI disclosure

- [x] This PR includes AI-assisted code — prepared with Codex and verified as described in the test plan above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Import resolution tightened: explicit non-code/data extensions are now treated as sealed (no fallthrough), explicit JS runtime imports normalize to their TS-family siblings, and probing for code files is limited to recognized code extensions.

* **Tests**
  * Unit tests expanded to cover dotted filename stems, explicit TS/JS extension cases, mapping between JS/TS siblings, and sealed/missing resolution scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->