### PR TITLE
feat(pi-coding-agent): show auth mode alongside providers in /model

### DIFF
--- a/packages/pi-coding-agent/src/modes/interactive/components/__tests__/provider-display-name.test.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/components/__tests__/provider-display-name.test.ts
@@ -1,18 +1,28 @@
-// GSD-2 — Provider display name mapping tests
+// GSD-2 — Provider display name + auth badge tests
 import { test, describe } from "node:test";
 import assert from "node:assert/strict";
-import { providerDisplayName } from "../model-selector.js";
+import { providerAuthBadge, providerDisplayName } from "../model-selector.js";
 
 describe("providerDisplayName", () => {
-	test("renames 'anthropic' to 'anthropic-api'", () => {
-		assert.equal(providerDisplayName("anthropic"), "anthropic-api");
-	});
-
-	test("passes through unmapped providers unchanged", () => {
+	test("passes providers through unchanged", () => {
+		assert.equal(providerDisplayName("anthropic"), "anthropic");
 		assert.equal(providerDisplayName("claude-code"), "claude-code");
 		assert.equal(providerDisplayName("openai"), "openai");
 		assert.equal(providerDisplayName("bedrock"), "bedrock");
 		assert.equal(providerDisplayName("github-copilot"), "github-copilot");
 		assert.equal(providerDisplayName("openrouter"), "openrouter");
+	});
+});
+
+describe("providerAuthBadge", () => {
+	test("returns human-readable labels for each auth mode", () => {
+		assert.equal(providerAuthBadge("apiKey"), "API key");
+		assert.equal(providerAuthBadge("oauth"), "OAuth");
+		assert.equal(providerAuthBadge("externalCli"), "CLI");
+	});
+
+	test("returns empty string for 'none' and undefined", () => {
+		assert.equal(providerAuthBadge("none"), "");
+		assert.equal(providerAuthBadge(undefined), "");
 	});
 });

--- a/packages/pi-coding-agent/src/modes/interactive/components/footer.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/components/footer.ts
@@ -2,7 +2,7 @@ import { type Component, truncateToWidth, visibleWidth } from "@gsd/pi-tui";
 import type { AgentSession } from "../../../core/agent-session.js";
 import type { ReadonlyFooterDataProvider } from "../../../core/footer-data-provider.js";
 import { theme } from "../theme/theme.js";
-import { providerDisplayName } from "./model-selector.js";
+import { providerAuthBadge, providerDisplayName } from "./model-selector.js";
 
 /**
  * Sanitize text for display in a single-line status.
@@ -199,13 +199,22 @@ export class FooterComponent implements Component {
 				thinkingLevel === "off" ? `${modelName} • thinking off` : `${modelName} • ${thinkingLevel}`;
 		}
 
-		// Prepend the provider in parentheses if there are multiple providers and there's enough room
+		// Prepend the provider in parentheses if there are multiple providers and there's enough room.
+		// Include the auth mode so users can tell at a glance whether the active model is
+		// API-key-backed, OAuth-backed, or delegated to a third-party CLI.
 		let rightSide = rightSideWithoutProvider;
 		if (this.footerData.getAvailableProviderCount() > 1 && displayModel) {
-			rightSide = `(${providerDisplayName(displayModel.provider)}) ${rightSideWithoutProvider}`;
+			const authMode = this.session.modelRegistry.getProviderAuthMode(displayModel.provider);
+			const authLabel = providerAuthBadge(authMode);
+			const providerLabel = providerDisplayName(displayModel.provider);
+			const parenthetical = authLabel ? `${providerLabel} · ${authLabel}` : providerLabel;
+			rightSide = `(${parenthetical}) ${rightSideWithoutProvider}`;
 			if (statsLeftWidth + minPadding + visibleWidth(rightSide) > width) {
-				// Too wide, fall back
-				rightSide = rightSideWithoutProvider;
+				// Too wide: drop the auth suffix first, then fall back to no parenthetical.
+				rightSide = `(${providerLabel}) ${rightSideWithoutProvider}`;
+				if (statsLeftWidth + minPadding + visibleWidth(rightSide) > width) {
+					rightSide = rightSideWithoutProvider;
+				}
 			}
 		}
 

--- a/packages/pi-coding-agent/src/modes/interactive/components/model-selector.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/components/model-selector.ts
@@ -9,19 +9,32 @@ import {
 	Text,
 	type TUI,
 } from "@gsd/pi-tui";
-import type { ModelRegistry } from "../../../core/model-registry.js";
+import type { ModelRegistry, ProviderAuthMode } from "../../../core/model-registry.js";
 import type { SettingsManager } from "../../../core/settings-manager.js";
 import { theme } from "../theme/theme.js";
 import { DynamicBorder } from "./dynamic-border.js";
 import { keyHint } from "./keybinding-hints.js";
 
-/** Display names for providers in the model selector UI. */
-const PROVIDER_DISPLAY_NAMES: Record<string, string> = {
-	anthropic: "anthropic-api",
-};
-
 export function providerDisplayName(provider: string): string {
-	return PROVIDER_DISPLAY_NAMES[provider] ?? provider;
+	return provider;
+}
+
+/**
+ * Short, user-facing label for a provider's auth mode. Returned strings are
+ * suitable for use as a suffix/badge alongside the provider name.
+ * Returns an empty string for modes that don't need a badge (e.g. "none").
+ */
+export function providerAuthBadge(authMode?: ProviderAuthMode): string {
+	switch (authMode) {
+		case "apiKey":
+			return "API key";
+		case "oauth":
+			return "OAuth";
+		case "externalCli":
+			return "CLI";
+		default:
+			return "";
+	}
 }
 
 function formatTokenCount(count: number): string {
@@ -140,7 +153,8 @@ export class ModelSelectorComponent extends Container implements Focusable {
 			this.scopeHintText = new Text(this.getScopeHintText(), 0, 0);
 			this.addChild(this.scopeHintText);
 		} else {
-			const hintText = "Only showing models with configured API keys (see README for details)";
+			const hintText =
+				"Only showing models with configured credentials (API key, OAuth, or CLI). See README for details.";
 			this.addChild(new Text(theme.fg("warning", hintText), 0, 0));
 		}
 		this.addChild(new Spacer(1));
@@ -409,7 +423,12 @@ export class ModelSelectorComponent extends Container implements Focusable {
 
 			const ctx = formatTokenCount(item.model.contextWindow);
 			const ctxBadge = theme.fg("muted", `${ctx}`);
-			const providerBadge = theme.fg("muted", `[${providerDisplayName(item.provider)}]`);
+			const authMode = this.modelRegistry.getProviderAuthMode(item.provider);
+			const authLabel = providerAuthBadge(authMode);
+			const providerBadgeText = authLabel
+				? `[${providerDisplayName(item.provider)} · ${authLabel}]`
+				: `[${providerDisplayName(item.provider)}]`;
+			const providerBadge = theme.fg("muted", providerBadgeText);
 			const checkmark = isCurrent ? theme.fg("success", " ✓") : "";
 
 			let line: string;
@@ -445,7 +464,19 @@ export class ModelSelectorComponent extends Container implements Focusable {
 		const maxVisible = 12;
 
 		if (this.groupedRows.length === 0) {
-			this.listContainer.addChild(new Text(theme.fg("muted", "  No models available"), 0, 0));
+			this.listContainer.addChild(
+				new Text(theme.fg("muted", "  No providers configured."), 0, 0),
+			);
+			this.listContainer.addChild(
+				new Text(
+					theme.fg(
+						"muted",
+						"  Run /login (OAuth), set an API key, or install a CLI provider. See README.",
+					),
+					0,
+					0,
+				),
+			);
 			return;
 		}
 
@@ -467,11 +498,14 @@ export class ModelSelectorComponent extends Container implements Focusable {
 				// Provider group header — always unselectable
 				const providerLabel = theme.fg("borderAccent", providerDisplayName(row.provider));
 				const count = theme.fg("muted", ` (${row.count})`);
+				const authMode = this.modelRegistry.getProviderAuthMode(row.provider);
+				const authLabel = providerAuthBadge(authMode);
+				const authText = authLabel ? theme.fg("muted", ` · via ${authLabel}`) : "";
 				// Add blank line before header if not the very first visible row
 				if (i > startIndex) {
 					this.listContainer.addChild(new Text("", 0, 0));
 				}
-				this.listContainer.addChild(new Text(`  ${providerLabel}${count}`, 0, 0));
+				this.listContainer.addChild(new Text(`  ${providerLabel}${count}${authText}`, 0, 0));
 			} else {
 				// Model row
 				const isSelected = i === this.selectedGroupIndex;


### PR DESCRIPTION
## TL;DR

**What:** The `/model` picker now shows each provider's auth mode (API key / OAuth / CLI) instead of implying everything is API-key-backed.
**Why:** The old hint "Only showing models with configured API keys" was inaccurate — the registry already supports `apiKey | oauth | externalCli | none`, so users with `github-copilot` (OAuth) or `claude-code` (external CLI) saw misleading copy.
**How:** Add a generic `providerAuthBadge(authMode)` helper, retire the ad-hoc `anthropic → anthropic-api` rename, and thread auth-mode labels through the hint text, grouped headers, flat search badges, empty state, and footer parenthetical.

## What

Files touched (all in `packages/pi-coding-agent/src/modes/interactive/components/`):

- `model-selector.ts`
  - New `providerAuthBadge(authMode?: ProviderAuthMode): "API key" | "OAuth" | "CLI" | ""`.
  - `providerDisplayName` is now a pass-through (the `anthropic → anthropic-api` special case was redundant once auth mode is shown separately).
  - Hint text: "Only showing models with configured credentials (API key, OAuth, or CLI). See README for details."
  - Grouped headers: `claude-code (4) · via CLI`, `github-copilot (17) · via OAuth`, `anthropic (3) · via API key`.
  - Flat search badges: `[anthropic · API key]`.
  - Empty state upgraded from "No models available" to "No providers configured." + "Run /login (OAuth), set an API key, or install a CLI provider. See README."
- `footer.ts`
  - Right-side parenthetical: `(claude-code · CLI) claude-sonnet-4-6 • thinking` when width allows. Fallback chain on tight width: full → drop auth suffix → drop parenthetical entirely.
- `__tests__/provider-display-name.test.ts`
  - Updated for the new pass-through semantics and added `providerAuthBadge` coverage.

## Why

Users told us the `/model` hint was misleading: OAuth-based providers (GitHub Copilot, Google Gemini CLI, Google Antigravity) and external-CLI providers (Claude Code CLI) both appear in the picker, yet the hint claimed we were "only showing models with configured API keys". The ad-hoc `anthropic → anthropic-api` rename was the only signal distinguishing API-key Anthropic from other Claude delivery paths — inconsistent and limited to one provider.

This PR makes the auth separation explicit and consistent across every provider.

## How

`ModelRegistry.getProviderAuthMode(provider)` already returns `ProviderAuthMode`. The picker and footer now call it and feed the result through `providerAuthBadge()` to get a short user-facing label. No registry/API changes — this is purely a presentation layer improvement.

The footer keeps existing width-based truncation logic and adds one degradation step (drop auth suffix before dropping the whole parenthetical), preserving the model identity on narrow terminals.

Follow-up tracked separately: three surfaces (`provider-manager.ts:162`, `scoped-models-selector.ts:208`, `interactive-mode.ts:386`) still render bare provider names without the auth badge — those UIs are out of scope for this PR.

## Test plan

- [x] `npx tsc --noEmit` clean in `packages/pi-coding-agent`
- [x] `node --test` passes for the updated `provider-display-name.test.ts` (3 tests, 0 failures)
- [ ] Manual: `/model` picker shows `· via OAuth` / `· via CLI` / `· via API key` on group headers
- [ ] Manual: search mode shows `[provider · authLabel]` badges
- [ ] Manual: footer shows `(provider · authLabel)` when >1 provider configured, degrades gracefully at narrow widths

## Change type

- [x] `feat` — New user-facing clarity in the model picker & footer

## AI-assisted

Yes — AI-assisted (Claude Opus 4.7). Peer-reviewed via Codex CLI before commit; all findings addressed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Display authentication method (API key, OAuth, CLI) alongside provider names in the UI.
  * Footer now shows authentication mode indicator when multiple providers are available.
  * Improved responsive fallback behavior for narrow layouts.
  * Enhanced guidance messages when no providers are configured.

* **Tests**
  * Updated test coverage for provider display and authentication badge mapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->