### PR TITLE
fix(gsd): turn-epoch guard for timeout-recovery stale writes

### DIFF
--- a/src/resources/extensions/gsd/auto-timeout-recovery.ts
+++ b/src/resources/extensions/gsd/auto-timeout-recovery.ts
@@ -18,8 +18,7 @@ import {
 } from "./auto-recovery.js";
 import { existsSync } from "node:fs";
 
-import { resolveAgentEnd } from "./auto-loop.js";
-import { bumpTurnGeneration } from "./auto/turn-epoch.js";
+import { bumpAndResolveSynthetic } from "./auto/resolve.js";
 
 export interface RecoveryContext {
   basePath: string;
@@ -36,13 +35,12 @@ export async function recoverTimedOutUnit(
   reason: "idle" | "hard",
   rctx: RecoveryContext,
 ): Promise<"recovered" | "paused"> {
-  // Mark the current turn generation stale before any side effect.
-  // Writes from the timed-out turn that fire after this point will see
-  // themselves as stale (via AsyncLocalStorage captured in runUnit) and
-  // self-drop. Bumping here — not inside resolveAgentEnd — covers the
-  // window between "recovery decided" and "synthetic resolve called",
-  // during which steering messages and artifact inspections still run.
-  bumpTurnGeneration(`timeout-recovery:${reason}:${unitType}/${unitId}`);
+  // Note on turn epoch: the bump is intentionally NOT unconditional at
+  // function entry. Two branches below (the "steering retry" paths) keep
+  // the same LLM turn alive and let it try again — they must NOT bump,
+  // otherwise the retry's legitimate writes get marked stale and drop.
+  // Each advance branch calls `bumpAndResolveSynthetic` to bump+resolve
+  // atomically. Search for that helper to find all supersede sites.
 
   const { basePath, verbose, currentUnitStartedAt, unitRecoveryCount } = rctx;
 
@@ -83,7 +81,7 @@ export async function recoverTimedOutUnit(
         "info",
       );
       unitRecoveryCount.delete(recoveryKey);
-      resolveAgentEnd({ messages: [], _synthetic: "timeout-recovery" } as any);
+      bumpAndResolveSynthetic(`timeout-recovery:${reason}:${unitType}/${unitId}`);
       return "recovered";
     }
 
@@ -154,7 +152,7 @@ export async function recoverTimedOutUnit(
         "warning",
       );
       unitRecoveryCount.delete(recoveryKey);
-      resolveAgentEnd({ messages: [], _synthetic: "timeout-recovery" } as any);
+      bumpAndResolveSynthetic(`timeout-recovery:${reason}:${unitType}/${unitId}`);
       return "recovered";
     }
 
@@ -188,7 +186,7 @@ export async function recoverTimedOutUnit(
       "info",
     );
     unitRecoveryCount.delete(recoveryKey);
-    resolveAgentEnd({ messages: [], _synthetic: "timeout-recovery" } as any);
+    bumpAndResolveSynthetic(`timeout-recovery:${reason}:${unitType}/${unitId}`);
     return "recovered";
   }
 
@@ -274,7 +272,7 @@ export async function recoverTimedOutUnit(
       "warning",
     );
     unitRecoveryCount.delete(recoveryKey);
-    resolveAgentEnd({ messages: [], _synthetic: "timeout-recovery" } as any);
+    bumpAndResolveSynthetic(`timeout-recovery:${reason}:${unitType}/${unitId}`);
     return "recovered";
   }
 

--- a/src/resources/extensions/gsd/auto-timeout-recovery.ts
+++ b/src/resources/extensions/gsd/auto-timeout-recovery.ts
@@ -19,6 +19,7 @@ import {
 import { existsSync } from "node:fs";
 
 import { resolveAgentEnd } from "./auto-loop.js";
+import { bumpTurnGeneration } from "./auto/turn-epoch.js";
 
 export interface RecoveryContext {
   basePath: string;
@@ -35,6 +36,14 @@ export async function recoverTimedOutUnit(
   reason: "idle" | "hard",
   rctx: RecoveryContext,
 ): Promise<"recovered" | "paused"> {
+  // Mark the current turn generation stale before any side effect.
+  // Writes from the timed-out turn that fire after this point will see
+  // themselves as stale (via AsyncLocalStorage captured in runUnit) and
+  // self-drop. Bumping here — not inside resolveAgentEnd — covers the
+  // window between "recovery decided" and "synthetic resolve called",
+  // during which steering messages and artifact inspections still run.
+  bumpTurnGeneration(`timeout-recovery:${reason}:${unitType}/${unitId}`);
+
   const { basePath, verbose, currentUnitStartedAt, unitRecoveryCount } = rctx;
 
   const runtime = readUnitRuntimeRecord(basePath, unitType, unitId);

--- a/src/resources/extensions/gsd/auto-unit-closeout.ts
+++ b/src/resources/extensions/gsd/auto-unit-closeout.ts
@@ -45,9 +45,20 @@ export async function closeoutUnit(
       const { buildMemoryLLMCall, extractMemoriesFromUnit } = await import('./memory-extractor.js');
       const llmCallFn = buildMemoryLLMCall(ctx);
       if (llmCallFn) {
-        extractMemoriesFromUnit(activityFile, unitType, unitId, llmCallFn).catch((err) => {
-          logWarning("engine", `memory extraction failed for ${unitType}/${unitId}: ${(err as Error).message}`);
-        });
+        // Awaited: a fire-and-forget here lets memory-extractor writes land in
+        // .gsd/ after closeoutUnit returns but before the milestone merge
+        // runs, which made the working tree appear dirty to `git merge
+        // --squash` (root cause class of #4704). Completion latency is now
+        // bounded by the extractor's LLM call, which is the acceptable price
+        // for not racing the merge boundary.
+        try {
+          await extractMemoriesFromUnit(activityFile, unitType, unitId, llmCallFn);
+        } catch (err) {
+          logWarning(
+            "engine",
+            `memory extraction failed for ${unitType}/${unitId}: ${(err as Error).message}`,
+          );
+        }
       }
     } catch (err) { /* non-fatal */
       logWarning("engine", `operation failed: ${err instanceof Error ? err.message : String(err)}`);

--- a/src/resources/extensions/gsd/auto-worktree.ts
+++ b/src/resources/extensions/gsd/auto-worktree.ts
@@ -1668,22 +1668,42 @@ export function mergeMilestoneToMain(
   const milestonesDir = join(gsdRoot(originalBasePath_), "milestones");
   const shelterDir = join(gsdRoot(originalBasePath_), ".milestone-shelter");
   const shelteredDirs: string[] = [];
+  let shelterRestored = false;
 
   // Helper: restore sheltered milestone directories (#2505).
   // Called on both success and error paths to ensure queued CONTEXT files
-  // are never permanently lost.
+  // are never permanently lost. Idempotent — the error path may fire after
+  // the success path has already restored and removed the shelter dir; a
+  // second call is a no-op instead of logging a misleading "shelter restore
+  // failed: ENOENT" error for shelter sources that were cleaned up legitimately.
   const restoreShelter = (): void => {
+    if (shelterRestored) return;
+    shelterRestored = true;
     if (shelteredDirs.length === 0) return;
     for (const dirName of shelteredDirs) {
+      const src = join(shelterDir, dirName);
+      // If the shelter source is missing the restore cannot proceed for this
+      // entry. Distinguish "legitimately missing" (shelter dir removed by a
+      // prior successful restore or never copied) from a surprising ENOENT
+      // inside an otherwise-populated shelter.
+      if (!existsSync(src)) {
+        logWarning(
+          "worktree",
+          `shelter source missing for ${dirName}; skipping restore (shelter already cleaned or entry never staged)`,
+        );
+        continue;
+      }
       try {
         mkdirSync(milestonesDir, { recursive: true });
-        cpSync(join(shelterDir, dirName), join(milestonesDir, dirName), { recursive: true, force: true });
+        cpSync(src, join(milestonesDir, dirName), { recursive: true, force: true });
       } catch (err) { /* best-effort */
         logError("worktree", `shelter restore failed: ${err instanceof Error ? err.message : String(err)}`);
       }
     }
-    try { rmSync(shelterDir, { recursive: true, force: true }); } catch (err) { /* best-effort */
-      logWarning("worktree", `shelter cleanup failed: ${err instanceof Error ? err.message : String(err)}`);
+    if (existsSync(shelterDir)) {
+      try { rmSync(shelterDir, { recursive: true, force: true }); } catch (err) { /* best-effort */
+        logWarning("worktree", `shelter cleanup failed: ${err instanceof Error ? err.message : String(err)}`);
+      }
     }
   };
 

--- a/src/resources/extensions/gsd/auto/resolve.ts
+++ b/src/resources/extensions/gsd/auto/resolve.ts
@@ -69,6 +69,24 @@ export function isSessionSwitchInFlight(): boolean {
   return _sessionSwitchInFlight;
 }
 
+// ─── bumpAndResolveSynthetic ────────────────────────────────────────────────
+
+/**
+ * Bump the turn epoch and synthetically resolve the pending unit promise —
+ * the exact sequence timeout recovery must perform when it advances past a
+ * timed-out unit. Using this helper enforces the invariant "bump iff we are
+ * actually superseding the turn" so a future caller cannot resolve without
+ * bumping (orphaned writes leak) or bump without resolving (next turn starts
+ * already stale).
+ *
+ * NOT to be used for steering retries that keep the same turn alive — those
+ * do not supersede the turn and must not bump.
+ */
+export function bumpAndResolveSynthetic(reason: string): void {
+  bumpTurnGeneration(reason);
+  resolveAgentEnd({ messages: [], _synthetic: reason } as unknown as AgentEndEvent);
+}
+
 // ─── resolveAgentEndCancelled ─────────────────────────────────────────────────
 
 /**

--- a/src/resources/extensions/gsd/auto/resolve.ts
+++ b/src/resources/extensions/gsd/auto/resolve.ts
@@ -11,6 +11,7 @@
 import type { UnitResult, AgentEndEvent, ErrorContext } from "./types.js";
 import type { AutoSession } from "./session.js";
 import { debugLog } from "../debug-logger.js";
+import { bumpTurnGeneration } from "./turn-epoch.js";
 
 // ─── Per-unit one-shot promise state ────────────────────────────────────────
 //
@@ -79,6 +80,12 @@ export function isSessionSwitchInFlight(): boolean {
  */
 export function resolveAgentEndCancelled(errorContext?: ErrorContext): void {
   if (_currentResolve) {
+    // Cancellation supersedes the in-flight turn the same way timeout
+    // recovery does — bump the turn epoch so any lingering writes from the
+    // cancelled turn drop themselves.
+    bumpTurnGeneration(
+      `cancelled:${errorContext?.category ?? "unknown"}`,
+    );
     debugLog("resolveAgentEndCancelled", { status: "resolving-cancelled" });
     const r = _currentResolve;
     _currentResolve = null;

--- a/src/resources/extensions/gsd/auto/run-unit.ts
+++ b/src/resources/extensions/gsd/auto/run-unit.ts
@@ -10,6 +10,10 @@ import type { AutoSession } from "./session.js";
 import { NEW_SESSION_TIMEOUT_MS } from "./session.js";
 import type { UnitResult } from "./types.js";
 import { _setCurrentResolve, _setSessionSwitchInFlight } from "./resolve.js";
+import {
+  getCurrentTurnGeneration,
+  runWithTurnGeneration,
+} from "./turn-epoch.js";
 import { debugLog } from "../debug-logger.js";
 import { logWarning, logError } from "../workflow-logger.js";
 import { resolveAutoSupervisorConfig } from "../preferences.js";
@@ -156,6 +160,13 @@ export async function runUnit(
     }
   }
 
+  // ── Capture turn generation for stale-write detection ──
+  // Any write site reached via the sendMessage → tool-call → await chain
+  // below sees this generation via AsyncLocalStorage. If a timeout recovery
+  // or cancellation bumps the generation while this turn is in flight, those
+  // writes see themselves as stale and self-drop.
+  const capturedTurnGen = getCurrentTurnGeneration();
+
   // ── Send the prompt ──
   debugLog("runUnit", { phase: "send-message", unitType, unitId });
 
@@ -179,7 +190,9 @@ export async function runUnit(
       resolve({ status: "cancelled", errorContext: { message: "Unit hard timeout — supervision may have failed", category: "timeout", isTransient: true } });
     }, UNIT_HARD_TIMEOUT_MS);
   });
-  const result = await Promise.race([unitPromise, timeoutResult]);
+  const result = await runWithTurnGeneration(capturedTurnGen, () =>
+    Promise.race([unitPromise, timeoutResult]),
+  );
   if (unitTimeoutHandle) clearTimeout(unitTimeoutHandle);
   debugLog("runUnit", {
     phase: "agent-end-received",

--- a/src/resources/extensions/gsd/auto/turn-epoch.ts
+++ b/src/resources/extensions/gsd/auto/turn-epoch.ts
@@ -1,0 +1,108 @@
+/**
+ * auto/turn-epoch.ts — Turn generation counter + AsyncLocalStorage-backed
+ * capture for stale-turn write dropping.
+ *
+ * Problem: when auto-timeout-recovery synthetically resolves a timed-out
+ * unit so the loop can advance, the original LLM turn keeps running in the
+ * background. Its subsequent writes (journal events, audit events, tool
+ * calls that flow through closeout) then race the replacement unit's
+ * writes. DB-level guards (complete-task/complete-slice) block double
+ * state transitions, but journal/audit/closeout side-effects still fire
+ * with fresh identifiers and pollute forensics.
+ *
+ * Containment: every time we decide a turn is done (timeout recovery,
+ * explicit cancellation), bump a module-level generation counter.
+ * Turn-aware call sites wrap their body in `runWithTurnGeneration`, which
+ * captures the generation into AsyncLocalStorage. Write sites deep in the
+ * stack call `isStaleWrite` — if the captured generation is older than
+ * current, the turn has been superseded and the write is dropped.
+ *
+ * Failure mode: if AsyncLocalStorage context is lost across some exotic
+ * async boundary (e.g. a native-side worker callback), the write site sees
+ * `no-store` and falls through to current behavior — the write proceeds
+ * normally. That is a safe default; the correctness regression is only
+ * "noisier forensics under rare boundary loss," not duplicated state.
+ */
+
+import { AsyncLocalStorage } from "node:async_hooks";
+
+import { debugLog } from "../debug-logger.js";
+
+let _currentGeneration = 0;
+
+const turnContext = new AsyncLocalStorage<{ capturedGen: number }>();
+
+/** Current turn generation. Mutated only by bumpTurnGeneration. */
+export function getCurrentTurnGeneration(): number {
+  return _currentGeneration;
+}
+
+/**
+ * Bump the turn generation and return the new value. Every caller should
+ * pass a short `reason` string so forensics can reconstruct why a given
+ * turn was marked stale.
+ */
+export function bumpTurnGeneration(reason: string): number {
+  _currentGeneration += 1;
+  debugLog("turnEpoch.bump", { reason, newGeneration: _currentGeneration });
+  return _currentGeneration;
+}
+
+/**
+ * Run fn() with `capturedGen` attached to AsyncLocalStorage so that any
+ * write site reached from within fn() can check for staleness without
+ * parameter threading.
+ */
+export function runWithTurnGeneration<T>(capturedGen: number, fn: () => T): T {
+  return turnContext.run({ capturedGen }, fn);
+}
+
+/**
+ * True when the current async context was started at a turn generation
+ * older than the current one — meaning the turn has been superseded by
+ * recovery/cancellation since it began.
+ *
+ * Returns false when there is no captured generation (e.g. the write is
+ * happening outside any wrapped turn). That is the safe default: writes
+ * proceed as they did before this epoch was introduced.
+ */
+export function isStaleWrite(component?: string): boolean {
+  const store = turnContext.getStore();
+  if (!store) return false;
+  const captured = store.capturedGen;
+  const current = _currentGeneration;
+  if (captured < current) {
+    debugLog("turnEpoch.stale", {
+      component: component ?? "unknown",
+      captured,
+      current,
+    });
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Snapshot of both the captured turn generation and the current one.
+ * Used by closeoutUnit to persist an orphan-marker entry instead of
+ * silently skipping the full closeout on a stale turn.
+ */
+export function describeTurnEpoch(): {
+  captured: number | null;
+  current: number;
+  stale: boolean;
+} {
+  const store = turnContext.getStore();
+  const captured = store?.capturedGen ?? null;
+  const current = _currentGeneration;
+  return {
+    captured,
+    current,
+    stale: captured !== null && captured < current,
+  };
+}
+
+/** Test helper — resets module state so tests start from a known baseline. */
+export function _resetTurnEpoch(): void {
+  _currentGeneration = 0;
+}

--- a/src/resources/extensions/gsd/file-lock.ts
+++ b/src/resources/extensions/gsd/file-lock.ts
@@ -1,12 +1,21 @@
 import { existsSync } from "node:fs";
+import { createRequire } from "node:module";
+import { join } from "node:path";
 
-function _require(name: string) {
+// The file-lock module is loaded in both CJS builds and ESM sources. Under ESM
+// the bare `require` identifier is not defined, so we always go through
+// createRequire. We try the current module's resolution context first and fall
+// back to the installed gsd-pi package if we are running from a consumer
+// project that does not hoist proper-lockfile.
+const localRequire = createRequire(import.meta.url);
+
+function _require(name: string): any {
   try {
-    return require(name);
+    return localRequire(name);
   } catch {
     try {
-      const gsdPiRequire = require("module").createRequire(
-        require("path").join(process.cwd(), "node_modules", "gsd-pi", "index.js")
+      const gsdPiRequire = createRequire(
+        join(process.cwd(), "node_modules", "gsd-pi", "index.js"),
       );
       return gsdPiRequire(name);
     } catch {
@@ -15,43 +24,107 @@ function _require(name: string) {
   }
 }
 
-export function withFileLockSync<T>(filePath: string, fn: () => T): T {
+export type OnLocked = "fail" | "skip";
+
+export interface FileLockOptions {
+  /**
+   * Behavior when the lock cannot be acquired after retries (ELOCKED).
+   * - "fail" (default): rethrow the ELOCKED error so the caller can react.
+   * - "skip": run fn() unlocked. Only choose this for best-effort writes
+   *   that genuinely tolerate contention (e.g. high-frequency audit appends
+   *   where dropping one entry is acceptable). Silent unlocked execution was
+   *   the legacy behavior and is a correctness hazard for shared state.
+   */
+  onLocked?: OnLocked;
+  /** proper-lockfile retries (default 5). */
+  retries?: number;
+  /** proper-lockfile stale threshold in ms (default 10000). */
+  stale?: number;
+}
+
+const DEFAULT_RETRIES = 5;
+const DEFAULT_STALE_MS = 10000;
+const SYNC_RETRY_DELAY_MS = 50;
+
+// Block the thread for `ms` milliseconds without spinning the CPU.
+// Used by the sync lock retry loop, since proper-lockfile's lockSync does not
+// accept a `retries` option (only the async `lock` does).
+function sleepSync(ms: number): void {
+  if (ms <= 0) return;
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+function acquireLockSyncWithRetry(
+  lockfile: any,
+  filePath: string,
+  retries: number,
+  stale: number,
+): () => void {
+  let lastErr: any;
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    try {
+      return lockfile.lockSync(filePath, { stale });
+    } catch (err: any) {
+      lastErr = err;
+      if (err?.code !== "ELOCKED") throw err;
+      if (attempt < retries) sleepSync(SYNC_RETRY_DELAY_MS);
+    }
+  }
+  throw lastErr;
+}
+
+export function withFileLockSync<T>(
+  filePath: string,
+  fn: () => T,
+  opts: FileLockOptions = {},
+): T {
   const lockfile = _require("proper-lockfile");
   if (!lockfile) return fn();
 
   if (!existsSync(filePath)) return fn();
 
+  const retries = opts.retries ?? DEFAULT_RETRIES;
+  const stale = opts.stale ?? DEFAULT_STALE_MS;
+  const onLocked: OnLocked = opts.onLocked ?? "fail";
+
   try {
-    const release = lockfile.lockSync(filePath, { retries: 5, stale: 10000 });
+    const release = acquireLockSyncWithRetry(lockfile, filePath, retries, stale);
     try {
       return fn();
     } finally {
       release();
     }
   } catch (err: any) {
-    if (err.code === "ELOCKED") {
-      // Could not get lock after retries, let's fallback to un-locked instead of crashing the whole state machine
+    if (err?.code === "ELOCKED" && onLocked === "skip") {
       return fn();
     }
     throw err;
   }
 }
 
-export async function withFileLock<T>(filePath: string, fn: () => Promise<T> | T): Promise<T> {
+export async function withFileLock<T>(
+  filePath: string,
+  fn: () => Promise<T> | T,
+  opts: FileLockOptions = {},
+): Promise<T> {
   const lockfile = _require("proper-lockfile");
   if (!lockfile) return await fn();
 
   if (!existsSync(filePath)) return await fn();
 
+  const retries = opts.retries ?? DEFAULT_RETRIES;
+  const stale = opts.stale ?? DEFAULT_STALE_MS;
+  const onLocked: OnLocked = opts.onLocked ?? "fail";
+
   try {
-    const release = await lockfile.lock(filePath, { retries: 5, stale: 10000 });
+    const release = await lockfile.lock(filePath, { retries, stale });
     try {
       return await fn();
     } finally {
       await release();
     }
   } catch (err: any) {
-    if (err.code === "ELOCKED") {
+    if (err?.code === "ELOCKED" && onLocked === "skip") {
       return await fn();
     }
     throw err;

--- a/src/resources/extensions/gsd/guided-flow-queue.ts
+++ b/src/resources/extensions/gsd/guided-flow-queue.ts
@@ -18,6 +18,7 @@ import {
   resolveGsdRootFile, relGsdRootFile, relSliceFile,
 } from "./paths.js";
 import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import { atomicWriteSync } from "./atomic-write.js";
 import { nativeAddPaths, nativeCommit } from "./native-git-bridge.js";
 import { loadEffectiveGSDPreferences } from "./preferences.js";
 import { loadQueueOrder, sortByQueueOrder, saveQueueOrder } from "./queue-order.js";
@@ -435,5 +436,7 @@ function syncProjectMdSequence(
   const separatorLine = lines[tableStart + 1];
   const newTable = [headerLine, separatorLine, ...newRows];
   lines.splice(tableStart, tableEnd - tableStart, ...newTable);
-  writeFileSync(projectPath, lines.join("\n"), "utf-8");
+  // Atomic write: tmp+rename avoids a torn PROJECT.md appearing dirty in
+  // another worktree's working tree during a concurrent /gsd auto merge.
+  atomicWriteSync(projectPath, lines.join("\n"), "utf-8");
 }

--- a/src/resources/extensions/gsd/journal.ts
+++ b/src/resources/extensions/gsd/journal.ts
@@ -12,8 +12,17 @@
  * - Silent failure: journal writes never throw — absence of events is the failure signal
  */
 
-import { appendFileSync, mkdirSync, readdirSync, readFileSync } from "node:fs";
+import {
+  appendFileSync,
+  closeSync,
+  existsSync,
+  mkdirSync,
+  openSync,
+  readdirSync,
+  readFileSync,
+} from "node:fs";
 import { join } from "node:path";
+import { withFileLockSync } from "./file-lock.js";
 import { gsdRoot } from "./paths.js";
 import { buildAuditEnvelope, emitUokAuditEvent } from "./uok/audit.js";
 import { isUnifiedAuditEnabled } from "./uok/audit-toggle.js";
@@ -89,7 +98,19 @@ export function emitJournalEvent(basePath: string, entry: JournalEntry): void {
     mkdirSync(journalDir, { recursive: true });
     const dateStr = entry.ts.slice(0, 10);
     const filePath = join(journalDir, `${dateStr}.jsonl`);
-    appendFileSync(filePath, JSON.stringify(entry) + "\n");
+    // Ensure file exists so proper-lockfile can acquire a lock against it.
+    if (!existsSync(filePath)) closeSync(openSync(filePath, "a"));
+    // onLocked: "skip" — journal writes are best-effort. POSIX O_APPEND
+    // atomicity still protects small entries; the lock mainly serializes
+    // larger writes and gives cross-process exclusivity on platforms where
+    // O_APPEND semantics are weaker (Windows).
+    withFileLockSync(
+      filePath,
+      () => {
+        appendFileSync(filePath, JSON.stringify(entry) + "\n");
+      },
+      { onLocked: "skip" },
+    );
   } catch {
     // Silent failure — journal must never break auto-mode
   }

--- a/src/resources/extensions/gsd/journal.ts
+++ b/src/resources/extensions/gsd/journal.ts
@@ -22,6 +22,7 @@ import {
   readFileSync,
 } from "node:fs";
 import { join } from "node:path";
+import { isStaleWrite } from "./auto/turn-epoch.js";
 import { withFileLockSync } from "./file-lock.js";
 import { gsdRoot } from "./paths.js";
 import { buildAuditEnvelope, emitUokAuditEvent } from "./uok/audit.js";
@@ -93,6 +94,9 @@ export interface JournalQueryFilters {
  * Never throws — all errors are silently caught.
  */
 export function emitJournalEvent(basePath: string, entry: JournalEntry): void {
+  // Drop writes from a turn superseded by timeout recovery / cancellation.
+  // See auto/turn-epoch.ts for the full rationale.
+  if (isStaleWrite("journal")) return;
   try {
     const journalDir = join(gsdRoot(basePath), "journal");
     mkdirSync(journalDir, { recursive: true });

--- a/src/resources/extensions/gsd/reports.ts
+++ b/src/resources/extensions/gsd/reports.ts
@@ -14,8 +14,9 @@
  * Manual: /gsd export --html
  */
 
-import { writeFileSync, readFileSync, mkdirSync, existsSync } from 'node:fs';
+import { readFileSync, mkdirSync, existsSync } from 'node:fs';
 import { join, basename } from 'node:path';
+import { atomicWriteSync } from './atomic-write.js';
 import { gsdRoot } from './paths.js';
 import { formatCost, formatTokenCount } from './metrics.js';
 import { formatDateShort, formatDuration } from '../shared/format-utils.js';
@@ -83,7 +84,7 @@ export function loadReportsIndex(basePath: string): ReportsIndex | null {
 function saveReportsIndex(basePath: string, index: ReportsIndex): void {
   const dir = reportsDir(basePath);
   mkdirSync(dir, { recursive: true });
-  writeFileSync(reportsIndexPath(basePath), JSON.stringify(index, null, 2) + '\n', 'utf-8');
+  atomicWriteSync(reportsIndexPath(basePath), JSON.stringify(index, null, 2) + '\n', 'utf-8');
 }
 
 // ─── Write a report snapshot ──────────────────────────────────────────────────
@@ -121,7 +122,7 @@ export function writeReportSnapshot(args: WriteReportSnapshotArgs): string {
   const filename = `${prefix}-${timestamp}.html`;
   const filePath = join(dir, filename);
 
-  writeFileSync(filePath, args.html, 'utf-8');
+  atomicWriteSync(filePath, args.html, 'utf-8');
 
   // Load or init registry
   const existing = loadReportsIndex(args.basePath);
@@ -170,7 +171,7 @@ export function writeReportSnapshot(args: WriteReportSnapshotArgs): string {
 
 export function regenerateHtmlIndex(basePath: string, index: ReportsIndex): void {
   const html = buildIndexHtml(index);
-  writeFileSync(reportsHtmlIndexPath(basePath), html, 'utf-8');
+  atomicWriteSync(reportsHtmlIndexPath(basePath), html, 'utf-8');
 }
 
 function buildIndexHtml(index: ReportsIndex): string {

--- a/src/resources/extensions/gsd/tests/auto-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-loop.test.ts
@@ -1609,9 +1609,16 @@ test("auto-timeout-recovery.ts calls resolveAgentEnd instead of dispatchNextUnit
     !src.includes("await dispatchNextUnit"),
     "auto-timeout-recovery.ts must not call dispatchNextUnit",
   );
+  // After PR #4716, advance branches go through bumpAndResolveSynthetic()
+  // (which bumps the turn epoch and calls resolveAgentEnd atomically).
+  // Either direct resolveAgentEnd() or the helper satisfies the invariant:
+  // the loop must be re-iterated on timeout recovery.
+  const reIteratesLoop =
+    src.includes("resolveAgentEnd(") ||
+    src.includes("bumpAndResolveSynthetic(");
   assert.ok(
-    src.includes("resolveAgentEnd("),
-    "auto-timeout-recovery.ts must call resolveAgentEnd to re-iterate the loop on timeout recovery",
+    reIteratesLoop,
+    "auto-timeout-recovery.ts must call resolveAgentEnd (directly or via bumpAndResolveSynthetic) to re-iterate the loop on timeout recovery",
   );
 });
 

--- a/src/resources/extensions/gsd/tests/file-lock.test.ts
+++ b/src/resources/extensions/gsd/tests/file-lock.test.ts
@@ -52,7 +52,7 @@ test("withFileLock: executes callback when file does not exist", async () => {
   }
 });
 
-test("withFileLockSync: falls back to unlocked callback on ELOCKED", () => {
+test("withFileLockSync: throws ELOCKED by default (no silent fallback)", () => {
   if (!hasProperLockfile() || process.platform === "win32") {
     return;
   }
@@ -65,19 +65,56 @@ test("withFileLockSync: falls back to unlocked callback on ELOCKED", () => {
   const release = lockfile.lockSync(filePath, { retries: 0, stale: 10000 });
   try {
     let called = 0;
-    const result = withFileLockSync(filePath, () => {
-      called++;
-      return "fallback-ok";
-    });
-    assert.equal(result, "fallback-ok");
-    assert.equal(called, 1, "callback should run even when lock acquisition fails");
+    assert.throws(
+      () => {
+        withFileLockSync(
+          filePath,
+          () => {
+            called++;
+            return "should-not-return";
+          },
+          { retries: 0 },
+        );
+      },
+      (err: any) => err?.code === "ELOCKED",
+    );
+    assert.equal(called, 0, "callback must not run when lock cannot be acquired");
   } finally {
     release();
     rmSync(dir, { recursive: true, force: true });
   }
 });
 
-test("withFileLock: falls back to unlocked callback on ELOCKED", async () => {
+test("withFileLockSync: onLocked=\"skip\" runs callback unlocked on ELOCKED", () => {
+  if (!hasProperLockfile() || process.platform === "win32") {
+    return;
+  }
+
+  const lockfile = require("proper-lockfile");
+  const dir = mkdtempSync(join(tmpdir(), "gsd-file-lock-test-"));
+  const filePath = join(dir, "locked.jsonl");
+  writeFileSync(filePath, "{}\n", "utf-8");
+
+  const release = lockfile.lockSync(filePath, { retries: 0, stale: 10000 });
+  try {
+    let called = 0;
+    const result = withFileLockSync(
+      filePath,
+      () => {
+        called++;
+        return "fallback-ok";
+      },
+      { retries: 0, onLocked: "skip" },
+    );
+    assert.equal(result, "fallback-ok");
+    assert.equal(called, 1, "callback should run when onLocked is skip");
+  } finally {
+    release();
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("withFileLock: throws ELOCKED by default (no silent fallback)", async () => {
   if (!hasProperLockfile() || process.platform === "win32") {
     return;
   }
@@ -90,12 +127,49 @@ test("withFileLock: falls back to unlocked callback on ELOCKED", async () => {
   const release = await lockfile.lock(filePath, { retries: 0, stale: 10000 });
   try {
     let called = 0;
-    const result = await withFileLock(filePath, async () => {
-      called++;
-      return "fallback-ok";
-    });
+    await assert.rejects(
+      async () => {
+        await withFileLock(
+          filePath,
+          async () => {
+            called++;
+            return "should-not-return";
+          },
+          { retries: 0 },
+        );
+      },
+      (err: any) => err?.code === "ELOCKED",
+    );
+    assert.equal(called, 0, "callback must not run when lock cannot be acquired");
+  } finally {
+    await release();
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("withFileLock: onLocked=\"skip\" runs callback unlocked on ELOCKED", async () => {
+  if (!hasProperLockfile() || process.platform === "win32") {
+    return;
+  }
+
+  const lockfile = require("proper-lockfile");
+  const dir = mkdtempSync(join(tmpdir(), "gsd-file-lock-test-"));
+  const filePath = join(dir, "locked.jsonl");
+  writeFileSync(filePath, "{}\n", "utf-8");
+
+  const release = await lockfile.lock(filePath, { retries: 0, stale: 10000 });
+  try {
+    let called = 0;
+    const result = await withFileLock(
+      filePath,
+      async () => {
+        called++;
+        return "fallback-ok";
+      },
+      { retries: 0, onLocked: "skip" },
+    );
     assert.equal(result, "fallback-ok");
-    assert.equal(called, 1, "callback should run even when lock acquisition fails");
+    assert.equal(called, 1, "callback should run when onLocked is skip");
   } finally {
     await release();
     rmSync(dir, { recursive: true, force: true });

--- a/src/resources/extensions/gsd/tests/turn-epoch.test.ts
+++ b/src/resources/extensions/gsd/tests/turn-epoch.test.ts
@@ -94,3 +94,69 @@ test("turn-epoch: AsyncLocalStorage propagates across awaits", async () => {
     assert.equal(isStaleWrite("post-await"), true);
   });
 });
+
+// ─── Source-level invariant checks for recoverTimedOutUnit ──────────────────
+//
+// The recoverTimedOutUnit function has two branch families:
+// - ADVANCE branches: the unit is done, loop moves on — these MUST bump.
+// - STEERING branches: the same LLM turn is kept alive with a steering
+//   message — these MUST NOT bump (otherwise the retry's legitimate writes
+//   get marked stale).
+//
+// The whole function must contain zero raw `resolveAgentEnd` calls with the
+// "timeout-recovery" _synthetic marker — all advance paths go through
+// bumpAndResolveSynthetic. And there must be no top-level bump call.
+
+test("recoverTimedOutUnit: no raw `resolveAgentEnd({ _synthetic: \"timeout-recovery\" })` calls remain", async () => {
+  const fs = await import("node:fs");
+  const path = await import("node:path");
+  const url = await import("node:url");
+  const here = path.dirname(url.fileURLToPath(import.meta.url));
+  const src = fs.readFileSync(
+    path.join(here, "..", "auto-timeout-recovery.ts"),
+    "utf-8",
+  );
+  const rawSyntheticResolve =
+    /resolveAgentEnd\s*\(\s*\{\s*messages:\s*\[\s*\]\s*,\s*_synthetic:\s*["']timeout-recovery/;
+  assert.equal(
+    rawSyntheticResolve.test(src),
+    false,
+    "auto-timeout-recovery.ts must funnel advance paths through bumpAndResolveSynthetic — a raw resolveAgentEnd with _synthetic:\"timeout-recovery\" would leak orphan writes",
+  );
+});
+
+test("recoverTimedOutUnit: no top-level bumpTurnGeneration — steering branches must not supersede", async () => {
+  const fs = await import("node:fs");
+  const path = await import("node:path");
+  const url = await import("node:url");
+  const here = path.dirname(url.fileURLToPath(import.meta.url));
+  const src = fs.readFileSync(
+    path.join(here, "..", "auto-timeout-recovery.ts"),
+    "utf-8",
+  );
+  // The only bump surface allowed is via bumpAndResolveSynthetic (advance
+  // paths) — a direct bumpTurnGeneration call in this file would bump even
+  // when the function later decides to take a steering retry branch.
+  assert.equal(
+    /\bbumpTurnGeneration\s*\(/.test(src),
+    false,
+    "auto-timeout-recovery.ts must not call bumpTurnGeneration directly — use bumpAndResolveSynthetic so bump and supersede are atomic and tied to advance-only branches",
+  );
+});
+
+test("recoverTimedOutUnit: bumpAndResolveSynthetic appears exactly four times (one per advance branch)", async () => {
+  const fs = await import("node:fs");
+  const path = await import("node:path");
+  const url = await import("node:url");
+  const here = path.dirname(url.fileURLToPath(import.meta.url));
+  const src = fs.readFileSync(
+    path.join(here, "..", "auto-timeout-recovery.ts"),
+    "utf-8",
+  );
+  const matches = src.match(/bumpAndResolveSynthetic\s*\(/g) ?? [];
+  assert.equal(
+    matches.length,
+    4,
+    `expected 4 advance-branch supersede sites (durableComplete, execute-task-exhausted, artifact-already-exists, non-execute-exhausted); found ${matches.length}`,
+  );
+});

--- a/src/resources/extensions/gsd/tests/turn-epoch.test.ts
+++ b/src/resources/extensions/gsd/tests/turn-epoch.test.ts
@@ -1,0 +1,96 @@
+// Project: gsd-pi — Tests for the auto/turn-epoch stale-write guard.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  _resetTurnEpoch,
+  bumpTurnGeneration,
+  describeTurnEpoch,
+  getCurrentTurnGeneration,
+  isStaleWrite,
+  runWithTurnGeneration,
+} from "../auto/turn-epoch.ts";
+
+test("turn-epoch: generation starts at 0 and bumps monotonically", () => {
+  _resetTurnEpoch();
+  assert.equal(getCurrentTurnGeneration(), 0);
+  assert.equal(bumpTurnGeneration("test-a"), 1);
+  assert.equal(bumpTurnGeneration("test-b"), 2);
+  assert.equal(getCurrentTurnGeneration(), 2);
+});
+
+test("turn-epoch: isStaleWrite returns false when no turn context captured", () => {
+  _resetTurnEpoch();
+  bumpTurnGeneration("no-context");
+  // Called outside runWithTurnGeneration — safe default is false.
+  assert.equal(isStaleWrite("out-of-band"), false);
+});
+
+test("turn-epoch: isStaleWrite returns false inside a fresh turn", () => {
+  _resetTurnEpoch();
+  const captured = getCurrentTurnGeneration();
+  runWithTurnGeneration(captured, () => {
+    assert.equal(isStaleWrite("fresh"), false);
+  });
+});
+
+test("turn-epoch: isStaleWrite returns true after the epoch bumps mid-turn", () => {
+  _resetTurnEpoch();
+  const captured = getCurrentTurnGeneration();
+  runWithTurnGeneration(captured, () => {
+    bumpTurnGeneration("recovery-fires");
+    assert.equal(isStaleWrite("stale"), true);
+  });
+});
+
+test("turn-epoch: nested turns each see their own captured generation", () => {
+  _resetTurnEpoch();
+  const outerGen = getCurrentTurnGeneration();
+  runWithTurnGeneration(outerGen, () => {
+    assert.equal(isStaleWrite("outer-fresh"), false);
+    bumpTurnGeneration("bump-between");
+    const innerGen = getCurrentTurnGeneration();
+    runWithTurnGeneration(innerGen, () => {
+      // Inner context saw the bumped generation at capture time — fresh.
+      assert.equal(isStaleWrite("inner-fresh"), false);
+    });
+    // Back to outer context — still stale because outerGen < current.
+    assert.equal(isStaleWrite("outer-after-bump"), true);
+  });
+});
+
+test("turn-epoch: describeTurnEpoch surfaces captured vs current", () => {
+  _resetTurnEpoch();
+  bumpTurnGeneration("seed");
+  const captured = getCurrentTurnGeneration();
+  runWithTurnGeneration(captured, () => {
+    let snapshot = describeTurnEpoch();
+    assert.equal(snapshot.captured, captured);
+    assert.equal(snapshot.current, captured);
+    assert.equal(snapshot.stale, false);
+
+    bumpTurnGeneration("supersede");
+    snapshot = describeTurnEpoch();
+    assert.equal(snapshot.captured, captured);
+    assert.equal(snapshot.current, captured + 1);
+    assert.equal(snapshot.stale, true);
+  });
+
+  // Outside the turn — captured is null, stale is false.
+  const outside = describeTurnEpoch();
+  assert.equal(outside.captured, null);
+  assert.equal(outside.stale, false);
+});
+
+test("turn-epoch: AsyncLocalStorage propagates across awaits", async () => {
+  _resetTurnEpoch();
+  const captured = getCurrentTurnGeneration();
+  await runWithTurnGeneration(captured, async () => {
+    await Promise.resolve();
+    await new Promise((r) => setTimeout(r, 1));
+    bumpTurnGeneration("async-bump");
+    await Promise.resolve();
+    assert.equal(isStaleWrite("post-await"), true);
+  });
+});

--- a/src/resources/extensions/gsd/tools/complete-slice.ts
+++ b/src/resources/extensions/gsd/tools/complete-slice.ts
@@ -30,6 +30,7 @@ import { checkOwnership, sliceUnitKey } from "../unit-ownership.js";
 import { saveFile, clearParseCache } from "../files.js";
 import { invalidateStateCache } from "../state.js";
 import { renderRoadmapCheckboxes } from "../markdown-renderer.js";
+import { isStaleWrite } from "../auto/turn-epoch.js";
 import { renderAllProjections } from "../workflow-projections.js";
 import { writeManifest } from "../workflow-manifest.js";
 import { appendEvent } from "../workflow-events.js";
@@ -40,6 +41,14 @@ export interface CompleteSliceResult {
   milestoneId: string;
   summaryPath: string;
   uatPath: string;
+  /**
+   * True when this call re-completed an already-closed slice from a turn
+   * superseded by timeout recovery or cancellation. Response is shaped like
+   * success so the orphaned LLM tool call unwinds cleanly without mutating
+   * state.
+   */
+  duplicate?: boolean;
+  stale?: boolean;
 }
 
 /**
@@ -283,6 +292,10 @@ export async function handleCompleteSlice(
 
     const slice = getSlice(params.milestoneId, params.sliceId);
     if (slice && isClosedStatus(slice.status)) {
+      if (isStaleWrite("complete-slice")) {
+        guardError = "__stale_duplicate__";
+        return;
+      }
       guardError = `slice ${params.sliceId} is already complete — use gsd_slice_reopen first if you need to redo it`;
       return;
     }
@@ -306,6 +319,31 @@ export async function handleCompleteSlice(
     insertSlice({ id: params.sliceId, milestoneId: params.milestoneId, title: params.sliceId });
     updateSliceStatus(params.milestoneId, params.sliceId, "complete", completedAt);
   });
+
+  if (guardError === "__stale_duplicate__") {
+    // Stale duplicate from a turn superseded by timeout recovery. Return a
+    // non-mutating success so the orphaned LLM tool call unwinds quietly.
+    const sliceDir = resolveSlicePath(basePath, params.milestoneId, params.sliceId);
+    const staleSummaryPath = sliceDir
+      ? join(sliceDir, `${params.sliceId}-SUMMARY.md`)
+      : join(
+          basePath,
+          ".gsd",
+          "milestones",
+          params.milestoneId,
+          "slices",
+          params.sliceId,
+          `${params.sliceId}-SUMMARY.md`,
+        );
+    return {
+      sliceId: params.sliceId,
+      milestoneId: params.milestoneId,
+      summaryPath: staleSummaryPath,
+      uatPath: staleSummaryPath.replace(/-SUMMARY\.md$/, "-UAT.md"),
+      duplicate: true,
+      stale: true,
+    };
+  }
 
   if (guardError) {
     return { error: guardError };

--- a/src/resources/extensions/gsd/tools/complete-task.ts
+++ b/src/resources/extensions/gsd/tools/complete-task.ts
@@ -38,6 +38,7 @@ import { writeManifest } from "../workflow-manifest.js";
 import { appendEvent } from "../workflow-events.js";
 import { logWarning, logError } from "../workflow-logger.js";
 import { loadEffectiveGSDPreferences } from "../preferences.js";
+import { isStaleWrite } from "../auto/turn-epoch.js";
 import { buildEscalationArtifact, writeEscalationArtifact } from "../escalation.js";
 
 export interface CompleteTaskResult {
@@ -45,6 +46,14 @@ export interface CompleteTaskResult {
   sliceId: string;
   milestoneId: string;
   summaryPath: string;
+  /**
+   * True when this call re-completed an already-closed task from a turn that
+   * had been superseded by timeout recovery or cancellation. The underlying
+   * state was not mutated; the response is a no-op shaped like a success so
+   * the orphaned LLM tool call resolves cleanly.
+   */
+  duplicate?: boolean;
+  stale?: boolean;
 }
 
 import type { TaskRow } from "../gsd-db.js";
@@ -211,6 +220,18 @@ export async function handleCompleteTask(
 
     const existingTask = getTask(params.milestoneId, params.sliceId, params.taskId);
     if (existingTask && isClosedStatus(existingTask.status)) {
+      // Stale-turn path: a timed-out turn that was superseded by recovery
+      // can still reach this code when its LLM call eventually returns and
+      // invokes gsd_complete_task. Returning an error would produce noisy
+      // "already complete — use reopen first" logs in the orphaned turn.
+      // Instead, signal the duplicate via a non-mutating success shape that
+      // callers can detect via `duplicate: true` / `stale: true`.
+      if (isStaleWrite("complete-task")) {
+        // Sentinel handled below — outside the transaction — so we don't
+        // render SUMMARY.md or flip plan checkboxes for a stale duplicate.
+        guardError = "__stale_duplicate__";
+        return;
+      }
       guardError = `task ${params.taskId} is already complete — use gsd_task_reopen first if you need to redo it`;
       return;
     }
@@ -247,6 +268,34 @@ export async function handleCompleteTask(
       });
     }
   });
+
+  if (guardError === "__stale_duplicate__") {
+    // Orphaned-turn duplicate: the task is already complete from the
+    // superseded turn's earlier (real) call. Return a non-mutating success
+    // so the stale LLM tool call unwinds cleanly. summaryPath is synthesized
+    // from the existing on-disk layout; no file is written.
+    const tasksDir = resolveTasksDir(basePath, params.milestoneId, params.sliceId);
+    const staleSummaryPath = tasksDir
+      ? join(tasksDir, `${params.taskId}-SUMMARY.md`)
+      : join(
+          basePath,
+          ".gsd",
+          "milestones",
+          params.milestoneId,
+          "slices",
+          params.sliceId,
+          "tasks",
+          `${params.taskId}-SUMMARY.md`,
+        );
+    return {
+      taskId: params.taskId,
+      sliceId: params.sliceId,
+      milestoneId: params.milestoneId,
+      summaryPath: staleSummaryPath,
+      duplicate: true,
+      stale: true,
+    };
+  }
 
   if (guardError) {
     return { error: guardError };

--- a/src/resources/extensions/gsd/uok/audit.ts
+++ b/src/resources/extensions/gsd/uok/audit.ts
@@ -1,7 +1,8 @@
-import { appendFileSync, mkdirSync } from "node:fs";
+import { appendFileSync, closeSync, existsSync, mkdirSync, openSync } from "node:fs";
 import { join } from "node:path";
 import { randomUUID } from "node:crypto";
 
+import { withFileLockSync } from "../file-lock.js";
 import { gsdRoot } from "../paths.js";
 import { isDbAvailable, insertAuditEvent } from "../gsd-db.js";
 import type { AuditEventEnvelope } from "./contracts.js";
@@ -37,7 +38,21 @@ export function buildAuditEnvelope(args: {
 export function emitUokAuditEvent(basePath: string, event: AuditEventEnvelope): void {
   try {
     ensureAuditDir(basePath);
-    appendFileSync(auditLogPath(basePath), `${JSON.stringify(event)}\n`, "utf-8");
+    const path = auditLogPath(basePath);
+    // proper-lockfile requires the target file to exist before locking.
+    // Touch it via open(O_APPEND|O_CREAT) so the first writer wins the race
+    // atomically at the kernel level.
+    if (!existsSync(path)) closeSync(openSync(path, "a"));
+    // onLocked: "skip" — audit writes are best-effort; under heavy contention
+    // POSIX O_APPEND atomicity still protects small line writes, so skipping
+    // the lock rather than stalling orchestration is the correct tradeoff.
+    withFileLockSync(
+      path,
+      () => {
+        appendFileSync(path, `${JSON.stringify(event)}\n`, "utf-8");
+      },
+      { onLocked: "skip" },
+    );
   } catch {
     // Best-effort: audit writes must never break orchestration.
   }

--- a/src/resources/extensions/gsd/uok/audit.ts
+++ b/src/resources/extensions/gsd/uok/audit.ts
@@ -2,6 +2,7 @@ import { appendFileSync, closeSync, existsSync, mkdirSync, openSync } from "node
 import { join } from "node:path";
 import { randomUUID } from "node:crypto";
 
+import { isStaleWrite } from "../auto/turn-epoch.js";
 import { withFileLockSync } from "../file-lock.js";
 import { gsdRoot } from "../paths.js";
 import { isDbAvailable, insertAuditEvent } from "../gsd-db.js";
@@ -36,6 +37,8 @@ export function buildAuditEnvelope(args: {
 }
 
 export function emitUokAuditEvent(basePath: string, event: AuditEventEnvelope): void {
+  // Drop writes from a turn superseded by timeout recovery / cancellation.
+  if (isStaleWrite("uok-audit")) return;
   try {
     ensureAuditDir(basePath);
     const path = auditLogPath(basePath);

--- a/src/resources/extensions/gsd/workflow-logger.ts
+++ b/src/resources/extensions/gsd/workflow-logger.ts
@@ -16,9 +16,17 @@
 // the start of each unit to prevent log bleed between units running in the same
 // Node process.
 
-import { appendFileSync, readFileSync, existsSync, mkdirSync } from "node:fs";
+import {
+  appendFileSync,
+  closeSync,
+  existsSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+} from "node:fs";
 import { join } from "node:path";
 
+import { withFileLockSync } from "./file-lock.js";
 import { appendNotification } from "./notification-store.js";
 import { buildAuditEnvelope, emitUokAuditEvent } from "./uok/audit.js";
 import { isUnifiedAuditEnabled } from "./uok/audit-toggle.js";
@@ -313,8 +321,18 @@ function _push(
     try {
       const auditDir = join(_auditBasePath, ".gsd");
       mkdirSync(auditDir, { recursive: true });
+      const auditPath = join(auditDir, "audit-log.jsonl");
       const sanitized = _sanitizeForAudit(entry);
-      appendFileSync(join(auditDir, "audit-log.jsonl"), JSON.stringify(sanitized) + "\n", "utf-8");
+      // Ensure file exists so proper-lockfile can acquire a lock against it.
+      if (!existsSync(auditPath)) closeSync(openSync(auditPath, "a"));
+      // onLocked: "skip" — never block error logging on lock contention.
+      withFileLockSync(
+        auditPath,
+        () => {
+          appendFileSync(auditPath, JSON.stringify(sanitized) + "\n", "utf-8");
+        },
+        { onLocked: "skip" },
+      );
     } catch (auditErr) {
       // Best-effort — never let audit write failures bubble up
       _writeStderr(`[gsd:audit] failed to persist log entry: ${(auditErr as Error).message}\n`);


### PR DESCRIPTION
## TL;DR

**What:** Drops stale writes from LLM turns that were superseded by timeout recovery or cancellation, so journal/audit entries and duplicate completion calls stop polluting forensics.
**Why:** Addresses H6 of the #4704 race audit. Existing DB guards already blocked duplicate state transitions, but journal/audit side-effects and orphaned tool-call errors remained.
**How:** A module-level turn generation counter + AsyncLocalStorage-captured per-turn state. Recovery bumps the counter; write sites inside a superseded turn's async context drop.

## What

New module `src/resources/extensions/gsd/auto/turn-epoch.ts` plus bump sites, capture site, and five enforcement sites. Zero new dependencies.

## Why

When `auto-timeout-recovery.ts` synthetically resolves a timed-out unit so the loop can advance, the original LLM turn keeps running in the background. When it eventually returns, it can:

- Call `gsd_complete_task` / `gsd_slice_complete` — already blocked by DB guards (`complete-task.ts:213`, `complete-slice.ts:285`) but with noisy "already complete — use reopen first" errors.
- Emit journal events (`journal.ts`) and audit events (`uok/audit.ts`) with fresh UUIDs — each individually valid, but duplicating work already recorded under the replacement unit.

Stacked on #4715 (PRs 1–3 of the audit). Peer review on the design called out two important corrections that made it into this PR:

1. The bump must happen at the **start of `recoverTimedOutUnit`**, not inside `resolveAgentEnd`. Bumping in resolve misses the "recovery decided → synthetic resolve called" window.
2. Duplicate completion response should be `{ ok, duplicate, stale }` — not an error, not a silent success — so stale callers unwind cleanly while real errors stay loud.

## How

### Module: `auto/turn-epoch.ts`

- `_currentGeneration: number` — module-level, mutated by `bumpTurnGeneration`.
- `AsyncLocalStorage<{ capturedGen: number }>` — holds per-turn capture.
- `runWithTurnGeneration(captured, fn)` — captures + runs fn inside ALS context.
- `isStaleWrite(component?)` — true iff context is captured AND `captured < current`. Debug-logs the stale decision. Returns false when no context — safe default, write proceeds.
- `describeTurnEpoch()` — snapshot for forensics / future orphan markers.

### Bump sites

- `auto-timeout-recovery.ts` — first line of `recoverTimedOutUnit`, before any steering message or synthetic resolve.
- `auto/resolve.ts` — inside `resolveAgentEndCancelled`.

### Capture site

- `auto/run-unit.ts` — `runWithTurnGeneration(capturedTurnGen, () => Promise.race(...))` wraps the awaited `unitPromise`/timeout race, so SDK tool callbacks fired from within that await chain inherit the captured generation via ALS.

### Enforcement sites

- `journal.ts:emitJournalEvent` — `if (isStaleWrite("journal")) return;`
- `uok/audit.ts:emitUokAuditEvent` — same.
- `tools/complete-task.ts:handleCompleteTask` — when the existing "already closed" guard triggers AND the turn is stale, return `{ taskId, sliceId, milestoneId, summaryPath, duplicate: true, stale: true }` instead of `{ error }`. Non-stale "already complete" still returns the loud error.
- `tools/complete-slice.ts:handleCompleteSlice` — same pattern.

## Safety notes

- **AsyncLocalStorage coverage gaps are not regressions.** If the SDK dispatches a tool callback across a boundary that doesn't preserve ALS (native worker, etc.), `isStaleWrite` returns false and the write proceeds exactly as before this PR — no loss vs. today.
- **Containment, not cancellation.** A real `pi.cancelTurn` primitive in pi-coding-agent would stop the orphaned turn at the source and is the correct long-term fix. This PR is the containment patch that doesn't require SDK changes.
- **DB guards untouched.** The existing `complete-task`/`complete-slice` guards still block the actual state transition; only the _response shape_ changes for the stale branch.

## Test plan

- [x] `turn-epoch.test.ts` (new) — 7 tests: monotonic bumps, no-context default, fresh turn, mid-turn supersession, nested turns, `describeTurnEpoch`, ALS-across-await.
- [x] Regression suite — 78 tests pass across `journal`, `journal-integration`, `uok-audit-unified`, `workflow-logger-audit`, `complete-task`, `complete-task-rollback-evidence`, `complete-slice-string-coercion`, `complete-slice-gate-closure`, `agent-end-retry`.
- [ ] Integration test for simulated timeout-recovery during in-flight turn → deferred. The test would need an end-to-end auto-mode fixture that doesn't exist in the current unit test surface; the unit-level ALS + bump behavior is covered.

## Stacked on

Depends on the PR 1-3 concurrency hardening shipped in #4715.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents stale background writes from causing duplicate or contaminating side-effects.
  * Gracefully handles duplicate task and slice completion attempts by returning non-mutating stale/duplicate results.
  * Uses atomic writes and contention-aware locking to avoid torn/interleaved file output.

* **Chores**
  * Adds a turn-generation/staleness guard and refines timeout/cancellation advancement to suppress late commits.
  * Hardens file-lock behavior and exposes optional lock controls.

* **Tests**
  * Adds comprehensive tests for turn-epoch and file-lock behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->