### PR TITLE
fix(knowledge): scope + budget milestone KNOWLEDGE injection

### DIFF
--- a/src/resources/extensions/gsd/auto-prompts.ts
+++ b/src/resources/extensions/gsd/auto-prompts.ts
@@ -515,6 +515,43 @@ export async function inlineKnowledgeScoped(
 }
 
 /**
+ * Budget-capped knowledge inline for milestone-level prompt assembly.
+ *
+ * Addresses issue #4719: the six milestone-phase prompts (research-milestone,
+ * plan-milestone, complete-slice, complete-milestone, validate-milestone,
+ * reassess-roadmap) previously injected the full KNOWLEDGE.md (~226KB for a
+ * real project) on every invocation. This helper scopes by caller-supplied
+ * keywords and caps the payload at `maxChars` (default 30,000 chars).
+ *
+ * Returns null when no KNOWLEDGE.md exists or no entries match any keyword.
+ */
+export async function inlineKnowledgeBudgeted(
+  base: string,
+  keywords: string[],
+  options?: { maxChars?: number },
+): Promise<string | null> {
+  const maxChars = options?.maxChars ?? 30_000;
+
+  const knowledgePath = resolveGsdRootFile(base, "KNOWLEDGE");
+  if (!existsSync(knowledgePath)) return null;
+
+  const content = await loadFile(knowledgePath);
+  if (!content) return null;
+
+  const { queryKnowledge } = await import("./context-store.js");
+  const scoped = await queryKnowledge(content, keywords);
+  if (!scoped) return null;
+
+  const trimmed = scoped.trim();
+  const truncated =
+    trimmed.length > maxChars
+      ? `${trimmed.slice(0, maxChars)}\n\n[...truncated ${trimmed.length - maxChars} chars; rerun with narrower scope if needed]`
+      : trimmed;
+
+  return `### Project Knowledge (scoped)\nSource: \`${relGsdRootFile("KNOWLEDGE")}\`\n\n${truncated}`;
+}
+
+/**
  * Inline a roadmap excerpt for a specific slice.
  * Reads full roadmap, extracts minimal excerpt with header + predecessor + target row.
  * Returns null if roadmap doesn't exist or slice not found.
@@ -1095,7 +1132,8 @@ export async function buildResearchMilestonePrompt(mid: string, midTitle: string
   if (requirementsInline) inlined.push(requirementsInline);
   const decisionsInline = await inlineDecisionsFromDb(base, mid);
   if (decisionsInline) inlined.push(decisionsInline);
-  const knowledgeInlineRM = await inlineGsdRootFile(base, "knowledge.md", "Project Knowledge");
+  // Scoped + budgeted — see issue #4719
+  const knowledgeInlineRM = await inlineKnowledgeBudgeted(base, extractKeywords(midTitle));
   if (knowledgeInlineRM) inlined.push(knowledgeInlineRM);
   inlined.push(inlineTemplate("research", "Research"));
 
@@ -1156,7 +1194,8 @@ export async function buildPlanMilestonePrompt(mid: string, midTitle: string, ba
     );
     inlined.push(queueInline);
   }
-  const knowledgeInlinePM = await inlineGsdRootFile(base, "knowledge.md", "Project Knowledge");
+  // Scoped + budgeted — see issue #4719
+  const knowledgeInlinePM = await inlineKnowledgeBudgeted(base, extractKeywords(midTitle));
   if (knowledgeInlinePM) inlined.push(knowledgeInlinePM);
   inlined.push(inlineTemplate("roadmap", "Roadmap"));
   if (inlineLevel === "full") {
@@ -1655,7 +1694,7 @@ export async function buildExecuteTaskPrompt(
 }
 
 export async function buildCompleteSlicePrompt(
-  mid: string, _midTitle: string, sid: string, sTitle: string, base: string, level?: InlineLevel,
+  mid: string, midTitle: string, sid: string, sTitle: string, base: string, level?: InlineLevel,
 ): Promise<string> {
   const inlineLevel = level ?? resolveInlineLevel();
 
@@ -1675,7 +1714,12 @@ export async function buildCompleteSlicePrompt(
     const requirementsInline = await inlineRequirementsFromDb(base, mid, sid, inlineLevel);
     if (requirementsInline) inlined.push(requirementsInline);
   }
-  const knowledgeInlineCS = await inlineGsdRootFile(base, "knowledge.md", "Project Knowledge");
+  // Scoped + budgeted — see issue #4719. Slice context is richer than
+  // milestone context at complete-slice time, so combine both title sources.
+  const knowledgeInlineCS = await inlineKnowledgeBudgeted(
+    base,
+    [...extractKeywords(midTitle), ...extractKeywords(sTitle)],
+  );
   if (knowledgeInlineCS) inlined.push(knowledgeInlineCS);
 
   // Inline all task summaries for this slice
@@ -1778,7 +1822,8 @@ export async function buildCompleteMilestonePrompt(
     const projectInline = await inlineProjectFromDb(base);
     if (projectInline) inlined.push(projectInline);
   }
-  const knowledgeInlineCM = await inlineGsdRootFile(base, "knowledge.md", "Project Knowledge");
+  // Scoped + budgeted — see issue #4719
+  const knowledgeInlineCM = await inlineKnowledgeBudgeted(base, extractKeywords(midTitle));
   if (knowledgeInlineCM) inlined.push(knowledgeInlineCM);
   // Inline milestone context file (milestone-level, not GSD root)
   const contextPath = resolveMilestoneFile(base, mid, "CONTEXT");
@@ -1914,7 +1959,8 @@ export async function buildValidateMilestonePrompt(
     const projectInline = await inlineProjectFromDb(base);
     if (projectInline) inlined.push(projectInline);
   }
-  const knowledgeInline = await inlineGsdRootFile(base, "knowledge.md", "Project Knowledge");
+  // Scoped + budgeted — see issue #4719
+  const knowledgeInline = await inlineKnowledgeBudgeted(base, extractKeywords(midTitle));
   if (knowledgeInline) inlined.push(knowledgeInline);
   // Inline milestone context file
   const contextPath = resolveMilestoneFile(base, mid, "CONTEXT");
@@ -2099,7 +2145,8 @@ export async function buildReassessRoadmapPrompt(
     const decisionsInline = await inlineDecisionsFromDb(base, mid, undefined, inlineLevel);
     if (decisionsInline) inlined.push(decisionsInline);
   }
-  const knowledgeInlineRA = await inlineGsdRootFile(base, "knowledge.md", "Project Knowledge");
+  // Scoped + budgeted — see issue #4719
+  const knowledgeInlineRA = await inlineKnowledgeBudgeted(base, extractKeywords(midTitle));
   if (knowledgeInlineRA) inlined.push(knowledgeInlineRA);
 
   const inlinedContext = capPreamble(`## Inlined Context (preloaded — do not re-read these files)\n\n${inlined.join("\n\n---\n\n")}`);

--- a/src/resources/extensions/gsd/auto-prompts.ts
+++ b/src/resources/extensions/gsd/auto-prompts.ts
@@ -530,7 +530,12 @@ export async function inlineKnowledgeBudgeted(
   keywords: string[],
   options?: { maxChars?: number },
 ): Promise<string | null> {
-  const maxChars = options?.maxChars ?? 30_000;
+  const DEFAULT_MAX_CHARS = 30_000;
+  const HARD_MAX_CHARS = 100_000;
+  const raw = Number(options?.maxChars ?? DEFAULT_MAX_CHARS);
+  const maxChars = Number.isFinite(raw)
+    ? Math.max(0, Math.min(Math.floor(raw), HARD_MAX_CHARS))
+    : DEFAULT_MAX_CHARS;
 
   const knowledgePath = resolveGsdRootFile(base, "KNOWLEDGE");
   if (!existsSync(knowledgePath)) return null;

--- a/src/resources/extensions/gsd/context-store.ts
+++ b/src/resources/extensions/gsd/context-store.ts
@@ -211,7 +211,13 @@ export function queryProject(): string | null {
 
 /**
  * Filter KNOWLEDGE.md sections by keyword matching.
- * Uses H2 sections, matches keywords case-insensitively against:
+ *
+ * Structure-adaptive (issue #4719): files that organise entries as H3 items
+ * under one or more H2 topics are filtered at H3 granularity. Files with only
+ * H2 topic headers (no H3) fall back to H2-level filtering for backwards
+ * compatibility.
+ *
+ * Matches keywords case-insensitively against:
  * 1. Section header text
  * 2. First paragraph of section content (up to first blank line or next heading)
  *
@@ -220,7 +226,7 @@ export function queryProject(): string | null {
  *
  * @param content - Full KNOWLEDGE.md content
  * @param keywords - Keywords to match (case-insensitive)
- * @returns Concatenated matching sections with H2 headers, or empty string
+ * @returns Concatenated matching sections with their original heading prefix, or empty string
  */
 export async function queryKnowledge(content: string, keywords: string[]): Promise<string> {
   if (!content || keywords.length === 0) return '';
@@ -228,10 +234,15 @@ export async function queryKnowledge(content: string, keywords: string[]): Promi
   // Lazy import to avoid circular dependency
   const { extractAllSections } = await import('./files.js');
 
-  const sections = extractAllSections(content, 2);
+  // Prefer H3 granularity when available; fall back to H2 for H2-only files.
+  // This prevents single-H2-with-many-H3 layouts from returning the entire
+  // file on a keyword match against the H2 header or its first paragraph.
+  const h3Sections = extractAllSections(content, 3);
+  const useH3 = h3Sections.size > 0;
+  const sections = useH3 ? h3Sections : extractAllSections(content, 2);
   if (sections.size === 0) return '';
+  const prefix = useH3 ? '###' : '##';
 
-  // Normalize keywords for case-insensitive matching
   const normalizedKeywords = keywords.map(k => k.toLowerCase());
 
   const matchingSections: string[] = [];
@@ -240,16 +251,15 @@ export async function queryKnowledge(content: string, keywords: string[]): Promi
     // Extract first paragraph: everything up to first blank line or next heading
     const firstParagraph = body.split(/\n\s*\n|\n#/)[0] || '';
 
-    // Check if any keyword matches header or first paragraph
     const headerLower = header.toLowerCase();
     const paragraphLower = firstParagraph.toLowerCase();
 
     const matches = normalizedKeywords.some(kw =>
-      headerLower.includes(kw) || paragraphLower.includes(kw)
+      headerLower.includes(kw) || paragraphLower.includes(kw),
     );
 
     if (matches) {
-      matchingSections.push(`## ${header}\n\n${body}`);
+      matchingSections.push(`${prefix} ${header}\n\n${body}`);
     }
   }
 

--- a/src/resources/extensions/gsd/context-store.ts
+++ b/src/resources/extensions/gsd/context-store.ts
@@ -243,7 +243,14 @@ export async function queryKnowledge(content: string, keywords: string[]): Promi
   if (sections.size === 0) return '';
   const prefix = useH3 ? '###' : '##';
 
-  const normalizedKeywords = keywords.map(k => k.toLowerCase());
+  // Trim, lowercase, drop empties, and de-dupe so callers can pass raw
+  // user-provided strings without risking empty-string / whitespace matches.
+  const normalizedKeywords = [...new Set(
+    keywords
+      .map(k => k.trim().toLowerCase())
+      .filter(k => k.length > 0),
+  )];
+  if (normalizedKeywords.length === 0) return '';
 
   const matchingSections: string[] = [];
 

--- a/src/resources/extensions/gsd/prompt-cache-optimizer.ts
+++ b/src/resources/extensions/gsd/prompt-cache-optimizer.ts
@@ -55,6 +55,10 @@ const SEMI_STATIC_LABELS = new Set([
   "prior-summaries",
   "project-context",
   "overrides",
+  // KNOWLEDGE is milestone-scoped (stable within a session), so it belongs
+  // in the cacheable prefix. See issue #4719.
+  "knowledge",
+  "project-knowledge",
 ]);
 
 /** Labels that change per-task */

--- a/src/resources/extensions/gsd/tests/context-store.test.ts
+++ b/src/resources/extensions/gsd/tests/context-store.test.ts
@@ -627,4 +627,83 @@ Integration tests mock external services.
 
     assert.strictEqual(result, '', 'empty content returns empty string');
   });
+
+  // ── Regression: issue #4719 — single-H2 with many H3 entries ──────────────
+  // A KNOWLEDGE.md structured as one top-level H2 with many H3 entries must
+  // filter at H3 granularity; otherwise one keyword match against the H2
+  // header or first paragraph returns the entire file.
+  test("single H2 with many H3 entries filters at H3 level (issue #4719)", async () => {
+    const singleH2Knowledge = `# Project Knowledge
+
+## Patterns
+
+### Database: prepared statements
+Always use prepared statements with SQLite.
+
+### API: versioned paths
+Use /v1/resource style versioning.
+
+### Testing: node:test
+Prefer node:test over external frameworks.
+
+### Deployment: blue-green
+Blue-green deployment for zero-downtime releases.
+`;
+
+    const result = await queryKnowledge(singleH2Knowledge, ['database']);
+
+    // Should include only the matching H3 entry, not the whole file
+    assert.match(result, /Database: prepared statements/, 'includes matching H3 entry');
+    assert.ok(
+      !result.includes('API: versioned paths'),
+      'does not include non-matching H3 entry',
+    );
+    assert.ok(
+      !result.includes('Testing: node:test'),
+      'does not include non-matching H3 entry',
+    );
+    assert.ok(
+      !result.includes('Deployment: blue-green'),
+      'does not include non-matching H3 entry',
+    );
+    // The returned payload must be dramatically smaller than the full content
+    assert.ok(
+      result.length < singleH2Knowledge.length / 2,
+      `scoped result (${result.length} chars) should be <50% of full content (${singleH2Knowledge.length} chars)`,
+    );
+  });
+
+  test("single H2 with H3 entries returns empty when no H3 matches (issue #4719)", async () => {
+    const singleH2Knowledge = `# Project Knowledge
+
+## Patterns
+
+### Database: prepared statements
+Always use prepared statements with SQLite.
+
+### API: versioned paths
+Use /v1/resource style versioning.
+`;
+
+    const result = await queryKnowledge(singleH2Knowledge, ['nonexistent']);
+
+    assert.strictEqual(result, '', 'no H3 match returns empty string');
+  });
+
+  test("falls back to H2 when no H3 headings exist at all", async () => {
+    // Backwards-compat: files with only H2 topic headers must still filter.
+    const h2OnlyKnowledge = `# Project Knowledge
+
+## Database Patterns
+Use prepared statements.
+
+## API Design
+REST with OpenAPI.
+`;
+
+    const result = await queryKnowledge(h2OnlyKnowledge, ['database']);
+
+    assert.match(result, /Database Patterns/, 'H2-only file falls back to H2 filtering');
+    assert.ok(!result.includes('API Design'), 'non-matching H2 section excluded');
+  });
 });

--- a/src/resources/extensions/gsd/tests/knowledge.test.ts
+++ b/src/resources/extensions/gsd/tests/knowledge.test.ts
@@ -15,7 +15,7 @@ import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync, realpathSy
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { GSD_ROOT_FILES, resolveGsdRootFile } from '../paths.ts';
-import { inlineGsdRootFile } from '../auto-prompts.ts';
+import { inlineGsdRootFile, inlineKnowledgeBudgeted } from '../auto-prompts.ts';
 import { appendKnowledge } from '../files.ts';
 import { loadKnowledgeBlock } from '../bootstrap/system-context.ts';
 
@@ -245,6 +245,93 @@ test('loadKnowledgeBlock: reports globalSizeKb above 4KB threshold', () => {
 
   const result = loadKnowledgeBlock(gsdHome, cwd);
   assert.ok(result.globalSizeKb > 4, `expected > 4KB, got ${result.globalSizeKb}`);
+
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+// ─── inlineKnowledgeBudgeted — issue #4719 ─────────────────────────────────
+// Milestone-phase prompts must not inject the full KNOWLEDGE.md. The budgeted
+// helper scopes by milestone-level keywords and caps the injected size.
+
+test('inlineKnowledgeBudgeted: returns scoped H3 entries for single-H2 file', async () => {
+  const tmp = realpathSync(mkdtempSync(join(tmpdir(), 'gsd-knowledge-')));
+  const gsdDir = join(tmp, '.gsd');
+  mkdirSync(gsdDir, { recursive: true });
+
+  const content = `# Project Knowledge
+
+## Patterns
+
+### Database: prepared statements
+Always use prepared statements with SQLite.
+
+### API: versioned paths
+Use /v1/resource style versioning.
+
+### Testing: node:test
+Prefer node:test over external frameworks.
+`;
+  writeFileSync(join(gsdDir, 'KNOWLEDGE.md'), content);
+
+  const result = await inlineKnowledgeBudgeted(tmp, ['database']);
+  assert.ok(result !== null, 'should return content');
+  assert.ok(result!.includes('Database: prepared statements'), 'includes matching H3');
+  assert.ok(!result!.includes('API: versioned paths'), 'excludes non-matching H3');
+
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+test('inlineKnowledgeBudgeted: caps payload below budget for large files', async () => {
+  const tmp = realpathSync(mkdtempSync(join(tmpdir(), 'gsd-knowledge-')));
+  const gsdDir = join(tmp, '.gsd');
+  mkdirSync(gsdDir, { recursive: true });
+
+  // Build a 200KB KNOWLEDGE with 500 H3 entries all matching 'shared'
+  const entries = Array.from({ length: 500 }, (_, i) =>
+    `### Entry ${i}: shared topic\n${'filler text '.repeat(30)}\n`,
+  ).join('\n');
+  const content = `# Project Knowledge\n\n## Patterns\n\n${entries}`;
+  writeFileSync(join(gsdDir, 'KNOWLEDGE.md'), content);
+
+  const BUDGET_CHARS = 30_000;
+  const result = await inlineKnowledgeBudgeted(tmp, ['shared'], { maxChars: BUDGET_CHARS });
+  assert.ok(result !== null, 'should return content');
+  // Allow some overhead for header formatting, but must stay close to budget
+  assert.ok(
+    result!.length <= BUDGET_CHARS + 500,
+    `payload ${result!.length} chars should be <= budget ${BUDGET_CHARS} (+overhead)`,
+  );
+  // Far smaller than the raw file
+  assert.ok(
+    result!.length < content.length / 4,
+    `payload should be much smaller than full content (${content.length} chars)`,
+  );
+
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+test('inlineKnowledgeBudgeted: returns null when no KNOWLEDGE.md exists', async () => {
+  const tmp = realpathSync(mkdtempSync(join(tmpdir(), 'gsd-knowledge-')));
+  const gsdDir = join(tmp, '.gsd');
+  mkdirSync(gsdDir, { recursive: true });
+
+  const result = await inlineKnowledgeBudgeted(tmp, ['database']);
+  assert.strictEqual(result, null);
+
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+test('inlineKnowledgeBudgeted: returns null when no entries match', async () => {
+  const tmp = realpathSync(mkdtempSync(join(tmpdir(), 'gsd-knowledge-')));
+  const gsdDir = join(tmp, '.gsd');
+  mkdirSync(gsdDir, { recursive: true });
+  writeFileSync(
+    join(gsdDir, 'KNOWLEDGE.md'),
+    '# Project Knowledge\n\n## Patterns\n\n### Database\nuse it\n',
+  );
+
+  const result = await inlineKnowledgeBudgeted(tmp, ['nonexistent']);
+  assert.strictEqual(result, null);
 
   rmSync(tmp, { recursive: true, force: true });
 });

--- a/src/resources/extensions/gsd/tests/knowledge.test.ts
+++ b/src/resources/extensions/gsd/tests/knowledge.test.ts
@@ -306,6 +306,11 @@ test('inlineKnowledgeBudgeted: caps payload below budget for large files', async
     result!.length < content.length / 4,
     `payload should be much smaller than full content (${content.length} chars)`,
   );
+  assert.match(
+    result!,
+    /\[\.\.\.truncated \d+ chars; rerun with narrower scope if needed\]/,
+    'should include truncation note when budget is exceeded',
+  );
 
   rmSync(tmp, { recursive: true, force: true });
 });

--- a/src/resources/extensions/gsd/tests/prompt-cache-optimizer.test.ts
+++ b/src/resources/extensions/gsd/tests/prompt-cache-optimizer.test.ts
@@ -64,6 +64,18 @@ describe("prompt-cache-optimizer: classifySection", () => {
     assert.equal(classifySection("overrides"), "semi-static");
   });
 
+  // Regression: issue #4719 — KNOWLEDGE falls through to dynamic default.
+  // Knowledge content is reused across all tasks within a milestone, so it
+  // must be classified as semi-static to qualify for prefix caching when the
+  // cache optimizer is wired into the prompt path.
+  it("classifies knowledge as semi-static (issue #4719)", () => {
+    assert.equal(classifySection("knowledge"), "semi-static");
+  });
+
+  it("classifies project-knowledge as semi-static (issue #4719)", () => {
+    assert.equal(classifySection("project-knowledge"), "semi-static");
+  });
+
   it("classifies task-plan as dynamic", () => {
     assert.equal(classifySection("task-plan"), "dynamic");
   });


### PR DESCRIPTION
## Summary

- `queryKnowledge()` is now structure-adaptive — filters at H3 when any H3 headings exist, falls back to H2 for H2-only files (backwards-compatible)
- New `inlineKnowledgeBudgeted()` helper; 6 milestone-phase prompt builders (research / plan / complete-slice / complete-milestone / validate / reassess) now scope by milestone/slice title keywords and cap payload at 30KB
- `"knowledge"` / `"project-knowledge"` added to `SEMI_STATIC_LABELS` so the cache optimizer classifies them correctly

## Root cause — three compounding bugs

For a project with KNOWLEDGE.md structured as one `## Patterns` H2 containing 357 H3 entries (~226 KB), each milestone invocation wasted ~56K tokens × 6 phases = ~336K tokens, triggering compaction.

1. **`context-store.ts`** — `extractAllSections(content, 2)` splits at H2. With one H2 and many H3 entries, a keyword match against the H2 header or the first paragraph returned the entire file. **Fix:** prefer H3 granularity when H3 headings exist; fall back to H2 otherwise.

2. **`auto-prompts.ts`** — six milestone-phase builders used `inlineGsdRootFile(base, "knowledge.md", "Project Knowledge")` with no scoping and no budget. **Fix:** new `inlineKnowledgeBudgeted(base, keywords, { maxChars })` helper built on `queryKnowledge`, with a 30KB default cap and a truncation note when exceeded.

3. **`prompt-cache-optimizer.ts`** — `"knowledge"` was not in `SEMI_STATIC_LABELS`, so it fell through to the `"dynamic"` default. The optimizer is exported but not currently wired into prompt assembly, so this fix is classification correctness for when it is wired up.

## Rubber-duck findings worth noting

The forensics report's suggested fix for bug #2 was "use `extractAllSections(content, 3)`" — that would break users whose KNOWLEDGE.md uses H2-per-topic structure with no H3 headings (empty Map → zero knowledge injected). The structure-adaptive approach preserves that layout.

## Test plan

- [x] New regression test: single H2 with many H3 entries filters at H3 level (`context-store.test.ts`)
- [x] New backwards-compat test: H2-only files still filter at H2
- [x] New cache-classification tests: `knowledge` and `project-knowledge` → semi-static (`prompt-cache-optimizer.test.ts`)
- [x] New budget-helper tests: scoped H3 return, 30KB cap honored on 200KB file, null when no match (`knowledge.test.ts`)
- [x] Full test suite run: `7281 passed` with my changes vs `7272 passed` on main — **zero new failures, +9 new passing tests**
- [x] `npx tsc --noEmit` (root + extensions): zero errors

Closes #4719

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Knowledge inlining now scopes content by extracted keywords, enforces a configurable character budget, and omits empty knowledge sections when no scoped content matches.
  * Milestone and slice prompts now receive and use scoped keywords to limit injected knowledge.

* **Bug Fixes**
  * Improved knowledge-section extraction to prefer finer headings (H3) and preserve original heading levels.
  * Prompt caching treats knowledge sections as semi-static for better cacheability.

* **Tests**
  * Added tests covering scoped filtering, budgeted inlining, heading-granularity behavior, and caching classification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->