### PR TITLE
fix(claude-code-cli,mcp-server,mcp-client): globally unblock tools & close silent-failure gaps

### DIFF
--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -13,6 +13,7 @@
 
 import { readFile, readdir, stat } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
+import { spawn } from 'node:child_process';
 import { z } from 'zod';
 import type { SessionManager } from './session-manager.js';
 import { isRemoteConfigured, tryRemoteQuestions } from './remote-questions.js';
@@ -44,6 +45,27 @@ const ELICIT_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
  *
  * @param timeoutMs - override for testing; defaults to ELICIT_TIMEOUT_MS
  */
+/**
+ * Default child-process runner used by secure_env_collect to push secrets
+ * into `vercel env add` / `npx convex env set`. Previously `applySecrets`
+ * was called without an `execFn`, so vercel/convex destinations silently
+ * dropped every collected key. This restores the write path.
+ */
+function defaultExecFn(
+  cmd: string,
+  args: string[],
+): Promise<{ code: number; stderr: string }> {
+  return new Promise((res) => {
+    const child = spawn(cmd, args, { stdio: ['pipe', 'pipe', 'pipe'] });
+    let stderr = '';
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk.toString('utf8');
+    });
+    child.on('error', (err) => res({ code: 1, stderr: err.message }));
+    child.on('close', (code) => res({ code: code ?? 1, stderr }));
+  });
+}
+
 export async function withElicitTimeout<T>(
   promise: Promise<T>,
   label: string,
@@ -737,6 +759,7 @@ export async function createMcpServer(sessionManager: SessionManager): Promise<{
         const { applied, errors } = await applySecrets(provided, resolvedDestination, {
           envFilePath: resolvedEnvPath,
           environment,
+          execFn: defaultExecFn,
         });
 
         // (7) Build result — NEVER include secret values

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -40,12 +40,6 @@ const SERVER_VERSION = '2.53.0';
 const ELICIT_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
 
 /**
- * Race a promise against a timeout. Rejects with a typed error on timeout so
- * callers can return a specific MCP error response rather than hanging.
- *
- * @param timeoutMs - override for testing; defaults to ELICIT_TIMEOUT_MS
- */
-/**
  * Default child-process runner used by secure_env_collect to push secrets
  * into `vercel env add` / `npx convex env set`. Previously `applySecrets`
  * was called without an `execFn`, so vercel/convex destinations silently
@@ -56,7 +50,11 @@ function defaultExecFn(
   args: string[],
 ): Promise<{ code: number; stderr: string }> {
   return new Promise((res) => {
-    const child = spawn(cmd, args, { stdio: ['pipe', 'pipe', 'pipe'] });
+    // stdin: ignore — avoids hanging if the child ever prompts interactively.
+    // stdout: ignore — consumer only cares about stderr + exit code, and an
+    //   un-drained pipe deadlocks once the kernel buffer (~64KB) fills.
+    // stderr: pipe — captured below for error surfacing.
+    const child = spawn(cmd, args, { stdio: ['ignore', 'ignore', 'pipe'] });
     let stderr = '';
     child.stderr.on('data', (chunk) => {
       stderr += chunk.toString('utf8');
@@ -66,6 +64,12 @@ function defaultExecFn(
   });
 }
 
+/**
+ * Race a promise against a timeout. Rejects with a typed error on timeout so
+ * callers can return a specific MCP error response rather than hanging.
+ *
+ * @param timeoutMs - override for testing; defaults to ELICIT_TIMEOUT_MS
+ */
 export async function withElicitTimeout<T>(
   promise: Promise<T>,
   label: string,

--- a/src/resources/extensions/claude-code-cli/stream-adapter.ts
+++ b/src/resources/extensions/claude-code-cli/stream-adapter.ts
@@ -723,7 +723,7 @@ export async function resolveClaudePermissionMode(
 		);
 		return "bypassPermissions";
 	}
-	return "acceptEdits";
+	return "bypassPermissions";
 }
 
 // NOTE: These helpers intentionally mirror @gsd/pi-ai anthropic-shared
@@ -783,21 +783,25 @@ export function buildSdkOptions(
 ): Record<string, unknown> {
 	const { reasoning, ...sdkExtraOptions } = extraOptions;
 	const mcpServers = buildWorkflowMcpServers();
-	const permissionMode = overrides?.permissionMode ?? "acceptEdits";
-	const disallowedTools = ["AskUserQuestion"];
-	// Pre-authorize the safe built-ins and every registered workflow MCP
-	// server's tools. `acceptEdits` mode (the interactive default) only
-	// auto-approves file edits — Read/Glob/Grep, basic shell inspection, and
-	// every `mcp__gsd-workflow__*` call still surface as "This command
-	// requires approval" and block GSD actions (#4099).
+	const permissionMode = overrides?.permissionMode ?? "bypassPermissions";
+	// Globally unblock all tools. Users reported that the `acceptEdits` default
+	// plus a narrow allowlist silently declined most Bash/Agent/WebFetch calls
+	// when `extensionUIContext` wasn't threaded through. Default to
+	// bypassPermissions and an empty disallow list so every tool — including
+	// `AskUserQuestion` and every `mcp__*` workflow tool — is auto-approved.
+	// Opt back into gated mode with GSD_CLAUDE_CODE_PERMISSION_MODE=acceptEdits.
+	const disallowedTools: string[] = [];
 	const allowedTools = [
 		"Read",
 		"Write",
 		"Edit",
 		"Glob",
 		"Grep",
-		"Bash(ls:*)",
-		"Bash(pwd)",
+		"Bash",
+		"Agent",
+		"WebFetch",
+		"WebSearch",
+		"AskUserQuestion",
 		...(mcpServers ? Object.keys(mcpServers).map((serverName) => `mcp__${serverName}__*`) : []),
 	];
 	const supportsAdaptive = modelSupportsAdaptiveThinking(modelId);

--- a/src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts
+++ b/src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts
@@ -695,15 +695,18 @@ describe("stream-adapter — session persistence (#2859)", () => {
 			assert.equal(srv.env.GSD_CLI_PATH, "/tmp/gsd");
 			assert.equal(srv.env.GSD_PERSIST_WRITE_GATE_STATE, "1");
 			assert.equal(srv.env.GSD_WORKFLOW_PROJECT_ROOT, "/tmp/project");
-			assert.deepEqual(options.disallowedTools, ["AskUserQuestion"]);
+			assert.deepEqual(options.disallowedTools, []);
 			assert.deepEqual(options.allowedTools, [
 				"Read",
 				"Write",
 				"Edit",
 				"Glob",
 				"Grep",
-				"Bash(ls:*)",
-				"Bash(pwd)",
+				"Bash",
+				"Agent",
+				"WebFetch",
+				"WebSearch",
+				"AskUserQuestion",
 				"mcp__gsd-workflow__*",
 			]);
 		} finally {
@@ -715,7 +718,7 @@ describe("stream-adapter — session persistence (#2859)", () => {
 		}
 	});
 
-	test("buildSdkOptions disables AskUserQuestion for custom workflow MCP server names", () => {
+	test("buildSdkOptions auto-approves every tool for custom workflow MCP server names", () => {
 		const prev = {
 			GSD_WORKFLOW_MCP_COMMAND: process.env.GSD_WORKFLOW_MCP_COMMAND,
 			GSD_WORKFLOW_MCP_NAME: process.env.GSD_WORKFLOW_MCP_NAME,
@@ -733,15 +736,18 @@ describe("stream-adapter — session persistence (#2859)", () => {
 			const options = buildSdkOptions("claude-sonnet-4-20250514", "test");
 			const mcpServers = options.mcpServers as Record<string, any>;
 			assert.ok(mcpServers?.["custom-workflow"], "expected custom workflow server config");
-			assert.deepEqual(options.disallowedTools, ["AskUserQuestion"]);
+			assert.deepEqual(options.disallowedTools, []);
 			assert.deepEqual(options.allowedTools, [
 				"Read",
 				"Write",
 				"Edit",
 				"Glob",
 				"Grep",
-				"Bash(ls:*)",
-				"Bash(pwd)",
+				"Bash",
+				"Agent",
+				"WebFetch",
+				"WebSearch",
+				"AskUserQuestion",
 				"mcp__custom-workflow__*",
 			]);
 		} finally {
@@ -779,9 +785,9 @@ describe("stream-adapter — session persistence (#2859)", () => {
 			const mcpServers = (options as any).mcpServers;
 			if (mcpServers) {
 				assert.ok(mcpServers["gsd-workflow"], "if present, must be gsd-workflow");
-				assert.deepEqual((options as any).disallowedTools, ["AskUserQuestion"]);
+				assert.deepEqual((options as any).disallowedTools, []);
 			} else {
-				assert.deepEqual((options as any).disallowedTools, ["AskUserQuestion"]);
+				assert.deepEqual((options as any).disallowedTools, []);
 			}
 			rmSync(emptyDir, { recursive: true, force: true });
 		} finally {
@@ -828,7 +834,7 @@ describe("stream-adapter — session persistence (#2859)", () => {
 			assert.equal(srv.env.GSD_CLI_PATH, "/tmp/gsd");
 			assert.equal(srv.env.GSD_PERSIST_WRITE_GATE_STATE, "1");
 			assert.equal(srv.env.GSD_WORKFLOW_PROJECT_ROOT, resolvedRepoDir);
-			assert.deepEqual(options.disallowedTools, ["AskUserQuestion"]);
+			assert.deepEqual(options.disallowedTools, []);
 		} finally {
 			process.chdir(originalCwd);
 			rmSync(repoDir, { recursive: true, force: true });
@@ -1219,14 +1225,14 @@ describe("stream-adapter — permission mode (F10)", () => {
 		}
 	}
 
-	test("buildSdkOptions defaults to acceptEdits (#4383)", () => {
+	test("buildSdkOptions defaults to bypassPermissions (globally unblocks all tools)", () => {
 		clearWorkflowMcpEnv();
 		const opts = buildSdkOptions("claude-sonnet-4-6", "test");
-		assert.equal(opts.permissionMode, "acceptEdits");
+		assert.equal(opts.permissionMode, "bypassPermissions");
 		assert.equal(
 			opts.allowDangerouslySkipPermissions,
-			false,
-			"allowDangerouslySkipPermissions must be false when permissionMode is acceptEdits",
+			true,
+			"allowDangerouslySkipPermissions must be true when permissionMode is bypassPermissions",
 		);
 	});
 
@@ -1241,9 +1247,9 @@ describe("stream-adapter — permission mode (F10)", () => {
 		);
 	});
 
-	test("resolveClaudePermissionMode defaults to acceptEdits when no env var is set (#4383)", async () => {
+	test("resolveClaudePermissionMode defaults to bypassPermissions when no env var is set (globally unblocks all tools)", async () => {
 		const mode = await resolveClaudePermissionMode({});
-		assert.equal(mode, "acceptEdits");
+		assert.equal(mode, "bypassPermissions");
 	});
 
 	test("resolveClaudePermissionMode honours the GSD_CLAUDE_CODE_PERMISSION_MODE env override", async () => {

--- a/src/resources/extensions/mcp-client/auth.ts
+++ b/src/resources/extensions/mcp-client/auth.ts
@@ -37,7 +37,18 @@ export type McpHttpAuthConfig = McpHttpAuthHeaders & McpHttpOAuthConfig;
 function resolveEnvValue(value: string): string {
 	return value.replace(
 		/\$\{([^}]+)\}/g,
-		(_match, varName) => process.env[varName] ?? "",
+		(_match, varName) => {
+			const resolved = process.env[varName];
+			if (resolved === undefined || resolved === "") {
+				// eslint-disable-next-line no-console
+				console.warn(
+					`[mcp-client auth] Environment variable "${varName}" referenced in MCP server config is unset. ` +
+					`Requests will go out with a malformed header and the remote server will likely reject them with 401.`,
+				);
+				return "";
+			}
+			return resolved;
+		},
 	);
 }
 


### PR DESCRIPTION
## TL;DR

**What:** Fix three independent silent-failure paths that caused users to report "all tools aren't working."
**Why:** Defaults and guards silently swallowed failures instead of either succeeding or surfacing errors.
**How:** Flip claude-code-cli permission mode to `bypassPermissions`, wire a real execFn into `secure_env_collect`, and warn on unresolved `${VAR}` headers in the MCP client.

Closes #4725

## What

Three scoped fixes across the provider + MCP stack:

| File | Change |
|---|---|
| `src/resources/extensions/claude-code-cli/stream-adapter.ts` | Default `permissionMode` → `bypassPermissions`; empty `disallowedTools`; expand `allowedTools` to cover Bash/Agent/WebFetch/WebSearch/AskUserQuestion |
| `src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts` | Update expectations (71 tests still pass) |
| `packages/mcp-server/src/server.ts` | Add `defaultExecFn` via `node:child_process.spawn` and thread into `applySecrets` for vercel/convex destinations |
| `src/resources/extensions/mcp-client/auth.ts` | Warn on stderr when a `${VAR}` in HTTP header config is unset (instead of silently emitting `Authorization: Bearer `) |

## Why

Investigation of widespread "tools not working" reports (three parallel explore agents + Codex peer review) found three independent silent-failure gaps:

1. **claude-code-cli:** `acceptEdits` default + narrow allowlist silently declined most Bash/Agent/WebFetch calls when `extensionUIContext` wasn't threaded through (stream-adapter.ts:1094-1103). `AskUserQuestion` was hard-blocked via `disallowedTools`.
2. **secure_env_collect:** server.ts:737 called `applySecrets` without `execFn`, so the vercel/convex branch at env-writer.ts:151 was never entered — every key collected from the user was silently discarded.
3. **mcp-client auth:** `resolveEnvValue` returned empty string for unset `${VAR}`, producing malformed `Authorization: Bearer ` headers → opaque 401s.

## How

**Permission mode.** `resolveClaudePermissionMode({})` now returns `bypassPermissions`. The `GSD_CLAUDE_CODE_PERMISSION_MODE` env override still works (`acceptEdits` / `default` / `plan`). Headless behavior (#4657) is unchanged. `allowedTools` gains Bash/Agent/WebFetch/WebSearch/AskUserQuestion so the allowlist is sensible if a user opts back into gated mode.

**execFn.** Added `defaultExecFn` at top of server.ts that wraps `spawn` into the `(cmd, args) => Promise<{code, stderr}>` shape `applySecrets` expects. Threaded into the `applySecrets` call inside the `secure_env_collect` handler. No behavior change for dotenv destination.

**Env var warning.** `resolveEnvValue` now logs to stderr on unresolved/empty `${VAR}`. Config behavior unchanged (still returns empty string) — this just makes the failure visible.

## Security note

This changes the default permission mode to `bypassPermissions` for all interactive Claude Code provider runs. Matches the intent behind "globally unblock tools" and matches headless behavior already in place (#4657). Users wanting gated behavior can export `GSD_CLAUDE_CODE_PERMISSION_MODE=acceptEdits`.

## Test plan

- [x] `npm test` in `packages/mcp-server/` — 60/60 pass
- [x] `node --test` on `src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts` — 71/71 pass
- [x] `npx tsc --noEmit` — clean
- [ ] Manual: run `claude-code` provider and verify Bash / WebFetch / Agent invocations auto-approve
- [ ] Manual: `secure_env_collect` with `destination: "vercel"` writes a key
- [ ] Manual: configure an MCP server with `headers: { Authorization: "Bearer ${MISSING_VAR}" }` and verify the stderr warning fires

## Change type

- [x] `fix` — Bug fix

## Out of scope

- OAuth browser redirect flow (needs new infra — token persistence, browser opener)
- `server_tool_use` / `web_search_tool_result` text-degradation (pi 0.67.2 upstream removed content types)
- `gsd_memory_graph` mode=build placeholder (feature gap)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restored secret application for destinations that perform writes via external commands.

* **Improvements**
  * Broadened default tool auto-approval to enable more agent capabilities by default.
  * Added warnings when auth configuration references unset environment variables.

* **Tests**
  * Updated permission-related tests to reflect the new default permission behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->