### PR TITLE
feat(gsd): add GPT-5.5 Codex model support

### DIFF
--- a/packages/pi-ai/scripts/generate-models.ts
+++ b/packages/pi-ai/scripts/generate-models.ts
@@ -707,6 +707,10 @@ async function generateModels() {
 			candidate.contextWindow = 272000;
 			candidate.maxTokens = 128000;
 		}
+		if (candidate.provider === "openai" && candidate.id === "gpt-5.5") {
+			candidate.contextWindow = 400000;
+			candidate.maxTokens = 128000;
+		}
 		// Keep selected OpenRouter model metadata stable until upstream settles.
 		if (candidate.provider === "openrouter" && candidate.id === "moonshotai/kimi-k2.5") {
 			candidate.cost.input = 0.41;
@@ -942,6 +946,27 @@ async function generateModels() {
 		});
 	}
 
+	if (!allModels.some((m) => m.provider === "openai" && m.id === "gpt-5.5")) {
+		allModels.push({
+			id: "gpt-5.5",
+			name: "GPT-5.5",
+			api: "openai-responses",
+			baseUrl: "https://api.openai.com/v1",
+			provider: "openai",
+			reasoning: true,
+			input: ["text", "image"],
+			cost: {
+				// Tentative: announced 2026-04-23, API list price; confirm at GA.
+				input: 5,
+				output: 30,
+				cacheRead: 0.5,
+				cacheWrite: 0,
+			},
+			contextWindow: 400000,
+			maxTokens: 128000,
+		});
+	}
+
 	// OpenAI Codex (ChatGPT OAuth) models
 	// NOTE: These are not fetched from models.dev; we keep a small, explicit list to avoid aliases.
 	// Context window is based on observed server limits (400s above ~272k), not marketing numbers.
@@ -1031,6 +1056,19 @@ async function generateModels() {
 			input: ["text", "image"],
 			cost: { input: 2.5, output: 15, cacheRead: 0.25, cacheWrite: 0 },
 			contextWindow: CODEX_CONTEXT,
+			maxTokens: CODEX_MAX_TOKENS,
+		},
+		{
+			id: "gpt-5.5",
+			name: "GPT-5.5",
+			api: "openai-codex-responses",
+			provider: "openai-codex",
+			baseUrl: CODEX_BASE_URL,
+			reasoning: true,
+			input: ["text", "image"],
+			// Tentative cost: announced 2026-04-23 list price; confirm at API GA.
+			cost: { input: 5, output: 30, cacheRead: 0.5, cacheWrite: 0 },
+			contextWindow: 400000,
 			maxTokens: CODEX_MAX_TOKENS,
 		},
 		{

--- a/packages/pi-ai/scripts/generate-models.ts
+++ b/packages/pi-ai/scripts/generate-models.ts
@@ -708,7 +708,10 @@ async function generateModels() {
 			candidate.maxTokens = 128000;
 		}
 		if (candidate.provider === "openai" && candidate.id === "gpt-5.5") {
-			candidate.contextWindow = 400000;
+			// GPT-5.5 has a 1M context window.
+			// Keep max output aligned with existing GPT-5.x local constraints.
+			// Source: https://openai.com/index/introducing-gpt-5-5/
+			candidate.contextWindow = 1000000;
 			candidate.maxTokens = 128000;
 		}
 		// Keep selected OpenRouter model metadata stable until upstream settles.
@@ -956,13 +959,13 @@ async function generateModels() {
 			reasoning: true,
 			input: ["text", "image"],
 			cost: {
-				// Tentative: announced 2026-04-23, API list price; confirm at GA.
+				// Source: https://openai.com/api/pricing/
 				input: 5,
 				output: 30,
 				cacheRead: 0.5,
 				cacheWrite: 0,
 			},
-			contextWindow: 400000,
+			contextWindow: 1000000,
 			maxTokens: 128000,
 		});
 	}
@@ -1066,7 +1069,10 @@ async function generateModels() {
 			baseUrl: CODEX_BASE_URL,
 			reasoning: true,
 			input: ["text", "image"],
-			// Tentative cost: announced 2026-04-23 list price; confirm at API GA.
+			// Official GPT-5.5 list price; Codex availability and 400K window are live.
+			// Sources:
+			// - https://openai.com/index/introducing-gpt-5-5/
+			// - https://openai.com/api/pricing/
 			cost: { input: 5, output: 30, cacheRead: 0.5, cacheWrite: 0 },
 			contextWindow: 400000,
 			maxTokens: CODEX_MAX_TOKENS,

--- a/packages/pi-ai/src/models.generated.test.ts
+++ b/packages/pi-ai/src/models.generated.test.ts
@@ -370,7 +370,9 @@ describe("spot-checks for models added in this regeneration", () => {
 		{ provider: "groq", id: "groq/compound-mini" },
 		{ provider: "huggingface", id: "zai-org/GLM-5.1" },
 		{ provider: "openai", id: "gpt-5.3-chat-latest" },
+		{ provider: "openai", id: "gpt-5.5", reasoning: true },
 		{ provider: "openai-codex", id: "gpt-5.4-mini", reasoning: true },
+		{ provider: "openai-codex", id: "gpt-5.5", reasoning: true },
 		{ provider: "mistral", id: "mistral-small-2603" },
 		{ provider: "zai", id: "glm-5.1" },
 	];
@@ -386,4 +388,20 @@ describe("spot-checks for models added in this regeneration", () => {
 			}
 		});
 	}
+});
+
+describe("GPT-5.5 availability", () => {
+	it("exposes GPT-5.5 through OpenAI API and OpenAI Codex providers", () => {
+		const apiModel = getModel("openai", "gpt-5.5" as any);
+		assert.ok(apiModel, "openai/gpt-5.5 should be present");
+		assert.equal(apiModel.contextWindow, 1000000);
+		assert.equal(apiModel.cost.input, 5);
+		assert.equal(apiModel.cost.output, 30);
+
+		const codexModel = getModel("openai-codex", "gpt-5.5" as any);
+		assert.ok(codexModel, "openai-codex/gpt-5.5 should be present");
+		assert.equal(codexModel.contextWindow, 400000);
+		assert.equal(codexModel.cost.input, 5);
+		assert.equal(codexModel.cost.output, 30);
+	});
 });

--- a/packages/pi-ai/src/models/generated/openai-codex.ts
+++ b/packages/pi-ai/src/models/generated/openai-codex.ts
@@ -140,6 +140,23 @@ export const OPENAI_CODEX_MODELS = {
 			contextWindow: 272000,
 			maxTokens: 128000,
 		} satisfies Model<"openai-codex-responses">,
+		"gpt-5.5": {
+			id: "gpt-5.5",
+			name: "GPT-5.5",
+			api: "openai-codex-responses",
+			provider: "openai-codex",
+			baseUrl: "https://chatgpt.com/backend-api",
+			reasoning: true,
+			input: ["text", "image"],
+			cost: {
+				input: 5,
+				output: 30,
+				cacheRead: 0.5,
+				cacheWrite: 0,
+			},
+			contextWindow: 400000,
+			maxTokens: 128000,
+		} satisfies Model<"openai-codex-responses">,
 		"gpt-5.4-mini": {
 			id: "gpt-5.4-mini",
 			name: "GPT-5.4 Mini",

--- a/packages/pi-ai/src/models/generated/openai.ts
+++ b/packages/pi-ai/src/models/generated/openai.ts
@@ -514,6 +514,23 @@ export const OPENAI_MODELS = {
 			contextWindow: 272000,
 			maxTokens: 128000,
 		} satisfies Model<"openai-responses">,
+		"gpt-5.5": {
+			id: "gpt-5.5",
+			name: "GPT-5.5",
+			api: "openai-responses",
+			provider: "openai",
+			baseUrl: "https://api.openai.com/v1",
+			reasoning: true,
+			input: ["text", "image"],
+			cost: {
+				input: 5,
+				output: 30,
+				cacheRead: 0.5,
+				cacheWrite: 0,
+			},
+			contextWindow: 1000000,
+			maxTokens: 128000,
+		} satisfies Model<"openai-responses">,
 		"gpt-5.4-mini": {
 			id: "gpt-5.4-mini",
 			name: "GPT-5.4 mini",

--- a/packages/pi-coding-agent/src/core/model-registry-auth-mode.test.ts
+++ b/packages/pi-coding-agent/src/core/model-registry-auth-mode.test.ts
@@ -39,6 +39,10 @@ function findModel(registry: ModelRegistry, provider: string, id: string): Model
 	return registry.getAvailable().find((m) => m.provider === provider && m.id === id);
 }
 
+function availableModelIds(registry: ModelRegistry): Set<string> {
+	return new Set(registry.getAvailable().map((model) => `${model.provider}/${model.id}`));
+}
+
 function makeModel(provider: string, id: string, api: string): Model<Api> {
 	return {
 		id,
@@ -93,6 +97,22 @@ function createStreamSpy(): {
 // ─── Registration ─────────────────────────────────────────────────────────────
 
 describe("ModelRegistry authMode — registration", () => {
+	it("includes GPT-5.5 in the authenticated all-models menu backing list", () => {
+		const registry = createInMemoryRegistry({
+			openai: { type: "api_key", key: "sk-test" },
+			"openai-codex": {
+				type: "oauth",
+				access: "codex-access",
+				refresh: "codex-refresh",
+				expires: Date.now() + 60_000,
+			},
+		});
+
+		const ids = availableModelIds(registry);
+		assert.ok(ids.has("openai/gpt-5.5"), "all-models menu backing list should include openai/gpt-5.5");
+		assert.ok(ids.has("openai-codex/gpt-5.5"), "all-models menu backing list should include openai-codex/gpt-5.5");
+	});
+
 	it("registers externalCli provider with streamSimple and without apiKey/oauth", () => {
 		const registry = createRegistry();
 		const spy = createStreamSpy();

--- a/src/resources/extensions/gsd/model-cost-table.ts
+++ b/src/resources/extensions/gsd/model-cost-table.ts
@@ -57,6 +57,8 @@ export const BUNDLED_COST_TABLE: ModelCostEntry[] = [
   { id: "gpt-5.3-codex-spark", inputPer1k: 0.0003, outputPer1k: 0.0012, updatedAt: "2026-03-29" },
   { id: "gpt-5.4", inputPer1k: 0.005, outputPer1k: 0.02, updatedAt: "2026-03-29" },
   { id: "gpt-5.4-mini", inputPer1k: 0.00075, outputPer1k: 0.0045, updatedAt: "2026-04-18" },
+  // gpt-5.5 announced 2026-04-23; API not yet live — list price tentative, verify at GA.
+  { id: "gpt-5.5", inputPer1k: 0.005, outputPer1k: 0.03, updatedAt: "2026-04-23" },
 
   // Google
   { id: "gemini-2.0-flash", inputPer1k: 0.0001, outputPer1k: 0.0004, updatedAt: "2025-03-15" },

--- a/src/resources/extensions/gsd/model-cost-table.ts
+++ b/src/resources/extensions/gsd/model-cost-table.ts
@@ -57,7 +57,8 @@ export const BUNDLED_COST_TABLE: ModelCostEntry[] = [
   { id: "gpt-5.3-codex-spark", inputPer1k: 0.0003, outputPer1k: 0.0012, updatedAt: "2026-03-29" },
   { id: "gpt-5.4", inputPer1k: 0.005, outputPer1k: 0.02, updatedAt: "2026-03-29" },
   { id: "gpt-5.4-mini", inputPer1k: 0.00075, outputPer1k: 0.0045, updatedAt: "2026-04-18" },
-  // gpt-5.5 announced 2026-04-23; API not yet live — list price tentative, verify at GA.
+  // GPT-5.5 API list price, also used for live Codex OAuth routing.
+  // Source: https://openai.com/api/pricing/
   { id: "gpt-5.5", inputPer1k: 0.005, outputPer1k: 0.03, updatedAt: "2026-04-23" },
 
   // Google

--- a/src/resources/extensions/gsd/model-router.ts
+++ b/src/resources/extensions/gsd/model-router.ts
@@ -109,6 +109,7 @@ export const MODEL_CAPABILITY_TIER: Record<string, ComplexityTier> = {
   "gpt-5.2-codex": "heavy",
   "gpt-5.3-codex": "heavy",
   "gpt-5.4": "heavy",
+  "gpt-5.5": "heavy",
   "o1": "heavy",
   "o3": "heavy",
   "o4-mini": "heavy",
@@ -144,6 +145,7 @@ const MODEL_COST_PER_1K_INPUT: Record<string, number> = {
   "gpt-5.3-codex": 0.005,
   "gpt-5.3-codex-spark": 0.0003,
   "gpt-5.4": 0.005,
+  "gpt-5.5": 0.005,
   "o4-mini": 0.005,
   "o4-mini-deep-research": 0.005,
   "gemini-2.0-flash": 0.0001,
@@ -187,6 +189,7 @@ export const MODEL_CAPABILITY_PROFILES: Record<string, ModelCapabilities> = {
   "gpt-5.3-codex":                { coding: 94, debugging: 91, research: 74, reasoning: 89, speed: 50, longContext: 80, instruction: 89 },
   "gpt-5.3-codex-spark":          { coding: 68, debugging: 58, research: 42, reasoning: 52, speed: 90, longContext: 50, instruction: 74 },
   "gpt-5.4":                      { coding: 95, debugging: 92, research: 88, reasoning: 94, speed: 42, longContext: 88, instruction: 92 },
+  "gpt-5.5":                      { coding: 96, debugging: 93, research: 89, reasoning: 95, speed: 42, longContext: 90, instruction: 93 },
 
   // ── OpenAI o-series (reasoning-first) ──────────────────────────────────────
   "o1":                           { coding: 78, debugging: 82, research: 78, reasoning: 90, speed: 20, longContext: 65, instruction: 82 },

--- a/src/resources/extensions/gsd/model-router.ts
+++ b/src/resources/extensions/gsd/model-router.ts
@@ -189,6 +189,9 @@ export const MODEL_CAPABILITY_PROFILES: Record<string, ModelCapabilities> = {
   "gpt-5.3-codex":                { coding: 94, debugging: 91, research: 74, reasoning: 89, speed: 50, longContext: 80, instruction: 89 },
   "gpt-5.3-codex-spark":          { coding: 68, debugging: 58, research: 42, reasoning: 52, speed: 90, longContext: 50, instruction: 74 },
   "gpt-5.4":                      { coding: 95, debugging: 92, research: 88, reasoning: 94, speed: 42, longContext: 88, instruction: 92 },
+  // GPT-5.5 scores are relative to the existing gpt-5.4 profile and backed by
+  // OpenAI's 2026-04-23 published eval deltas across coding, tool use, and long context.
+  // Source: https://openai.com/index/introducing-gpt-5-5/
   "gpt-5.5":                      { coding: 96, debugging: 93, research: 89, reasoning: 95, speed: 42, longContext: 90, instruction: 93 },
 
   // ── OpenAI o-series (reasoning-first) ──────────────────────────────────────

--- a/src/resources/extensions/gsd/service-tier.ts
+++ b/src/resources/extensions/gsd/service-tier.ts
@@ -37,6 +37,7 @@ const SERVICE_TIER_SCOPE_NOTE = "Only affects gpt-5.4 models, regardless of prov
  *
  * See: https://github.com/gsd-build/gsd-2/issues/2546
  */
+// TODO: add "gpt-5.5" once API GA confirms service_tier support (announced 2026-04-23, API not yet live).
 const SERVICE_TIER_MODEL_PREFIXES = ["gpt-5.4"] as const;
 
 /**

--- a/src/resources/extensions/gsd/service-tier.ts
+++ b/src/resources/extensions/gsd/service-tier.ts
@@ -2,8 +2,8 @@
  * Service Tier — gating, status formatting, icon resolution, and
  * the /gsd fast command handler.
  *
- * Service tiers (priority/flex) are an OpenAI feature that only applies
- * to gpt-5.4 variants. This module centralizes the model-gating logic
+ * Service tiers (priority/flex) are an OpenAI feature that currently only
+ * applies to gpt-5.4 variants in GSD. This module centralizes the model-gating logic
  * so that icons, preferences, and the before_provider_request hook all
  * use a single source of truth.
  */
@@ -35,9 +35,11 @@ const SERVICE_TIER_SCOPE_NOTE = "Only affects gpt-5.4 models, regardless of prov
  * (set via CAPABILITY_PATCHES in packages/pi-ai/src/models.ts). When callers
  * have access to the full Model object, prefer reading capabilities directly.
  *
+ * GPT-5.5 is intentionally excluded until we verify its provider payload
+ * contract instead of assuming `service_tier` support.
+ *
  * See: https://github.com/gsd-build/gsd-2/issues/2546
  */
-// TODO: add "gpt-5.5" once API GA confirms service_tier support (announced 2026-04-23, API not yet live).
 const SERVICE_TIER_MODEL_PREFIXES = ["gpt-5.4"] as const;
 
 /**

--- a/src/resources/extensions/gsd/tests/model-cost-table.test.ts
+++ b/src/resources/extensions/gsd/tests/model-cost-table.test.ts
@@ -74,7 +74,7 @@ test("#2885: cost table includes openai-codex provider models", () => {
   const ids = BUNDLED_COST_TABLE.map(e => e.id);
   const codexModels = [
     "gpt-5.1", "gpt-5.1-codex-max", "gpt-5.1-codex-mini",
-    "gpt-5.2", "gpt-5.2-codex", "gpt-5.3-codex", "gpt-5.3-codex-spark", "gpt-5.4", "gpt-5.4-mini",
+    "gpt-5.2", "gpt-5.2-codex", "gpt-5.3-codex", "gpt-5.3-codex-spark", "gpt-5.4", "gpt-5.4-mini", "gpt-5.5",
   ];
   for (const model of codexModels) {
     assert.ok(ids.includes(model), `cost table should include openai-codex model "${model}"`);

--- a/src/resources/extensions/gsd/tests/model-cost-table.test.ts
+++ b/src/resources/extensions/gsd/tests/model-cost-table.test.ts
@@ -101,3 +101,11 @@ test("#2885: lookupModelCost returns costs for new models (not 999 fallback)", (
     assert.ok(entry.inputPer1k < 999, `${model} should have a real cost, not the 999 fallback`);
   }
 });
+
+test("gpt-5.5 uses official OpenAI list pricing", () => {
+  const entry = lookupModelCost("gpt-5.5");
+  assert.ok(entry, "lookupModelCost should find gpt-5.5");
+  assert.equal(entry.inputPer1k, 0.005);
+  assert.equal(entry.outputPer1k, 0.03);
+  assert.equal(entry.updatedAt, "2026-04-23");
+});

--- a/src/resources/extensions/gsd/tests/model-router.test.ts
+++ b/src/resources/extensions/gsd/tests/model-router.test.ts
@@ -382,7 +382,7 @@ test("#2885: openai-codex standard-tier models are recognized", () => {
 
 test("#2885: openai-codex heavy-tier models are recognized", () => {
   const config = { ...defaultRoutingConfig(), enabled: true };
-  const heavyModels = ["gpt-5", "gpt-5-pro", "gpt-5.1", "gpt-5.2", "gpt-5.2-codex", "gpt-5.3-codex", "gpt-5.4", "o4-mini", "o4-mini-deep-research"];
+  const heavyModels = ["gpt-5", "gpt-5-pro", "gpt-5.1", "gpt-5.2", "gpt-5.2-codex", "gpt-5.3-codex", "gpt-5.4", "gpt-5.5", "o4-mini", "o4-mini-deep-research"];
   for (const model of heavyModels) {
     const result = resolveModelForComplexity(
       makeClassification("heavy"),

--- a/src/resources/extensions/gsd/tests/service-tier.test.ts
+++ b/src/resources/extensions/gsd/tests/service-tier.test.ts
@@ -31,6 +31,10 @@ describe("supportsServiceTier", () => {
     assert.equal(supportsServiceTier("vibeproxy-openai/gpt-5.4"), true);
   });
 
+  test("returns false for gpt-5.5 until service_tier payload support is verified", () => {
+    assert.equal(supportsServiceTier("gpt-5.5"), false);
+  });
+
   test("returns false for provider-only identifier without gpt-5.4 model suffix", () => {
     assert.equal(supportsServiceTier("vibeproxy-openai"), false);
   });


### PR DESCRIPTION
## TL;DR

**What:** Adds GPT-5.5 support for both the OpenAI API provider and the OpenAI Codex OAuth provider, plus sourced pricing/routing metadata.
**Why:** GPT-5.5 is available in the current OpenAI/Codex surface and should resolve through the same model registry contracts as other GPT-5.x models.
**How:** Adds `openai/gpt-5.5` and `openai-codex/gpt-5.5` without changing the tool call or response contracts. `service_tier` remains excluded for GPT-5.5 until that separate payload parameter is verified.

Official sources:

- Announcement and capabilities: https://openai.com/index/introducing-gpt-5-5/
- API pricing: https://openai.com/api/pricing/
- System card: https://openai.com/index/gpt-5-5-system-card/

## What changed

| File | Change |
| ---- | ------ |
| `packages/pi-ai/scripts/generate-models.ts` | Adds sourced GPT-5.5 metadata for OpenAI API and Codex OAuth generation |
| `packages/pi-ai/src/models/generated/openai.ts` | Adds generated `openai/gpt-5.5` registry entry |
| `packages/pi-ai/src/models/generated/openai-codex.ts` | Adds generated `openai-codex/gpt-5.5` registry entry |
| `packages/pi-ai/src/models.generated.test.ts` | Verifies both GPT-5.5 provider entries are present with expected context and pricing |
| `src/resources/extensions/gsd/model-cost-table.ts` | Adds GPT-5.5 list pricing from OpenAI pricing page |
| `src/resources/extensions/gsd/model-router.ts` | Adds GPT-5.5 as heavy tier and cites OpenAI published eval deltas for the relative capability profile |
| `src/resources/extensions/gsd/service-tier.ts` | Removes stale TODO; explicitly excludes GPT-5.5 until `service_tier` payload compatibility is verified |
| `src/resources/extensions/gsd/tests/*.test.ts` | Extends model cost, router, and service-tier coverage |

## Risk handling from review

- **Model existence and pricing:** GPT-5.5 is now represented in both relevant provider registries with sourced pricing.
- **Context window:** OpenAI API uses the announced 1M context window; Codex OAuth keeps its 400K context window.
- **Tool contracts:** no provider request/response schemas were changed; this is registry/routing metadata only.
- **Capability profile:** retained as a relative profile against GPT-5.4, with an official eval source comment.
- **Service tier:** still excluded for GPT-5.5 because that is a separate request payload contract from model availability.

## Tests

```sh
node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test \
  packages/pi-ai/src/models.generated.test.ts \
  src/resources/extensions/gsd/tests/model-cost-table.test.ts \
  src/resources/extensions/gsd/tests/model-router.test.ts \
  src/resources/extensions/gsd/tests/service-tier.test.ts \
  src/resources/extensions/gsd/tests/capability-router.test.ts
```

Result: 216 passing, 0 failing.

## Pre-Ready checklist

- [x] Source model announcement and pricing from official OpenAI pages
- [x] Expose `openai/gpt-5.5` through the OpenAI API provider registry
- [x] Expose `openai-codex/gpt-5.5` through the Codex OAuth provider registry
- [x] Add tests for both provider entries and pricing
- [ ] Smoke test `gpt-5.5` through the `openai-codex` provider (ChatGPT OAuth path)
- [ ] Smoke test `gpt-5.5` through the `openai` provider with an API key

---

_This PR is AI-assisted per CONTRIBUTING.md §AI-assisted contributions._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * GPT-5.5 model is now available in OpenAI and Codex variants, expanding capabilities for complex workloads
  * Intelligent model routing system updated to automatically select GPT-5.5 based on task complexity and cost optimization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->