### PR TITLE
test(ci): include package tests in default suite

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "test:coverage": "c8 --reporter=text --reporter=lcov --exclude=\"src/resources/extensions/gsd/tests/**\" --exclude=\"src/tests/**\" --exclude=\"scripts/**\" --exclude=\"native/**\" --exclude=\"node_modules/**\" --check-coverage --statements=40 --lines=40 --branches=20 --functions=20 node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --experimental-test-isolation=process --test src/resources/extensions/gsd/tests/*.test.ts src/resources/extensions/gsd/tests/*.test.mjs src/tests/*.test.ts src/resources/extensions/shared/tests/*.test.ts",
     "test:integration": "node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test \"src/tests/integration/*.test.ts\" \"src/resources/extensions/gsd/tests/integration/*.test.ts\" \"src/resources/extensions/async-jobs/*.test.ts\" \"src/resources/extensions/browser-tools/tests/*.test.mjs\"",
     "pretest": "npm run typecheck:extensions",
-    "test": "npm run test:unit && npm run test:integration",
+    "test": "npm run test:unit && npm run test:integration && npm run test:packages",
     "test:smoke": "node --experimental-strip-types tests/smoke/run.ts",
     "test:fixtures": "node --experimental-strip-types tests/fixtures/run.ts",
     "test:fixtures:record": "node scripts/with-env.mjs GSD_FIXTURE_MODE=record -- node --experimental-strip-types tests/fixtures/record.ts",


### PR DESCRIPTION
## TL;DR

**What:** Adds `test:packages` to the root `npm test` command.
**Why:** Package tests were outside the primary test gate.
**How:** Extends the root script to run unit, integration, then package tests.

## What

Updates the root `package.json` `test` script so workspace package tests run as part of the default suite.

## Why

The repo has package-level test coverage under `packages/`, but the primary `npm test` gate only ran root unit and integration tests.

Closes #4731

## How

The script now runs:

`npm run test:unit && npm run test:integration && npm run test:packages`

## Test plan

- [x] Verified `npm pkg get scripts.test scripts.test:packages` shows the expected script wiring
- [ ] Full `npm test` not run locally because dependencies are missing in this checkout (`esbuild` was not installed during review)

## Change type checklist

- [ ] `feat` — New feature or capability
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

AI-assisted contribution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended test execution to include an additional test suite in the test workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->