### PR TITLE
test(native): run full native suite from root

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "test:fixtures:record": "node scripts/with-env.mjs GSD_FIXTURE_MODE=record -- node --experimental-strip-types tests/fixtures/record.ts",
     "test:live": "node scripts/with-env.mjs GSD_LIVE_TESTS=1 -- node --experimental-strip-types tests/live/run.ts",
     "test:browser-tools": "node --test src/resources/extensions/browser-tools/tests/browser-tools-unit.test.cjs src/resources/extensions/browser-tools/tests/browser-tools-integration.test.mjs",
-    "test:native": "node --test packages/native/src/__tests__/grep.test.mjs",
+    "test:native": "npm run test -w @gsd/native",
     "test:secret-scan": "node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/tests/secret-scan.test.ts",
     "secret-scan": "node scripts/secret-scan.mjs",
     "secret-scan:install-hook": "node scripts/install-hooks.mjs",


### PR DESCRIPTION
## TL;DR

**What:** Makes root `test:native` delegate to the native workspace test script.
**Why:** The root command only ran the grep test and hid the rest of native coverage.
**How:** Replaces the single-file `node --test` command with `npm run test -w @gsd/native`.

## What

Updates the root `package.json` native test script.

## Why

The native package owns the complete native test suite. The root script should call that package script instead of selecting one test file.

Closes #4732

## How

Root `test:native` now delegates to `@gsd/native`.

## Test plan

- [x] Verified `npm pkg get scripts.test:native packages/native/scripts.test` shows the expected script wiring
- [ ] Full native suite not run locally because this environment is missing installed dependencies/build outputs

## Change type checklist

- [ ] `feat` — New feature or capability
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

AI-assisted contribution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated native package test execution workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->