### PR TITLE
fix(cli): forward model override to auto headless

### DIFF
--- a/src/cli-web-branch.ts
+++ b/src/cli-web-branch.ts
@@ -97,6 +97,10 @@ export function parseCliArgs(argv: string[]): CliFlags {
   return flags
 }
 
+export function buildHeadlessAutoArgs(flags: Pick<CliFlags, 'messages' | 'model'>): string[] {
+  return flags.model ? ['--model', flags.model, ...flags.messages] : [...flags.messages]
+}
+
 export { getProjectSessionsDir } from './project-sessions.js'
 
 export function migrateLegacyFlatSessions(baseSessionsDir: string, projectSessionsDir: string): void {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -24,6 +24,7 @@ import { printHelp, printSubcommandHelp } from './help-text.js'
 import { applySecurityOverrides } from './security-overrides.js'
 import { validateConfiguredModel } from './startup-model-validation.js'
 import {
+  buildHeadlessAutoArgs,
   parseCliArgs,
   runWebCliBranch,
   migrateLegacyFlatSessions,
@@ -413,7 +414,7 @@ async function runHeadlessFromAuto(headlessArgs: string[]): Promise<never> {
 // Without this, `gsd auto` falls through to the interactive TUI which hangs
 // when stdin/stdout are piped (non-TTY environments).
 if (cliFlags.messages[0] === 'auto') {
-  await runHeadlessFromAuto(cliFlags.messages)
+  await runHeadlessFromAuto(buildHeadlessAutoArgs(cliFlags))
 }
 
 // Pi's tool bootstrap can mis-detect already-installed fd/rg on some systems

--- a/src/tests/parse-cli-args.test.ts
+++ b/src/tests/parse-cli-args.test.ts
@@ -3,7 +3,7 @@
 
 import test, { describe } from 'node:test'
 import assert from 'node:assert/strict'
-import { parseCliArgs } from '../cli-web-branch.ts'
+import { buildHeadlessAutoArgs, parseCliArgs } from '../cli-web-branch.ts'
 
 function parse(...args: string[]) {
   return parseCliArgs(['node', 'gsd', ...args])
@@ -22,6 +22,21 @@ describe('parseCliArgs — modes', () => {
 
   test('ignores unknown mode values', () => {
     assert.equal(parse('--mode', 'bogus').mode, undefined)
+  })
+})
+
+describe('buildHeadlessAutoArgs', () => {
+  test('preserves auto positional args without a model override', () => {
+    const args = buildHeadlessAutoArgs({ messages: ['auto', 'next'] })
+    assert.deepEqual(args, ['auto', 'next'])
+  })
+
+  test('forwards --model before auto positional args', () => {
+    const args = buildHeadlessAutoArgs({
+      model: 'claude-code/sonnet',
+      messages: ['auto', 'next'],
+    })
+    assert.deepEqual(args, ['--model', 'claude-code/sonnet', 'auto', 'next'])
   })
 })
 


### PR DESCRIPTION
## TL;DR

**What:** Preserves `--model` when `gsd auto` delegates to headless mode.
**Why:** The auto shorthand previously forwarded only positional messages, silently dropping the model override.
**How:** Builds synthetic headless args from parsed CLI flags and covers the helper with tests.

## What

Adds `buildHeadlessAutoArgs()` and uses it in the `gsd auto` branch.

## Why

`gsd auto --model provider/model` should run auto-mode with the requested model, not the default model.

Closes #4734

## How

The helper prepends `--model <value>` before the auto positional args when a model override was parsed.

## Test plan

- [x] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/tests/parse-cli-args.test.ts`

## Change type checklist

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

AI-assisted contribution.