### PR TITLE
fix(auto): clear resolver on provider cancellation

### DIFF
--- a/src/resources/extensions/gsd/auto-loop.ts
+++ b/src/resources/extensions/gsd/auto-loop.ts
@@ -9,7 +9,7 @@
 
 export { autoLoop, runUokKernelLoop, runLegacyAutoLoop } from "./auto/loop.js";
 export { isInfrastructureError, INFRA_ERROR_CODES } from "./auto/infra-errors.js";
-export { resolveAgentEnd, resolveAgentEndCancelled, isSessionSwitchInFlight, _resetPendingResolve, _setActiveSession } from "./auto/resolve.js";
+export { resolveAgentEnd, resolveAgentEndCancelled, isSessionSwitchInFlight, _hasPendingResolveForTest, _resetPendingResolve, _setActiveSession } from "./auto/resolve.js";
 export { detectStuck } from "./auto/detect-stuck.js";
 export { runUnit } from "./auto/run-unit.js";
 export type { LoopDeps } from "./auto/loop-deps.js";

--- a/src/resources/extensions/gsd/auto/resolve.ts
+++ b/src/resources/extensions/gsd/auto/resolve.ts
@@ -122,6 +122,10 @@ export function _resetPendingResolve(): void {
   _sessionSwitchInFlight = false;
 }
 
+export function _hasPendingResolveForTest(): boolean {
+  return _currentResolve !== null;
+}
+
 /**
  * No-op for backward compatibility with tests that previously set the
  * active session. The module no longer holds a session reference.

--- a/src/resources/extensions/gsd/auto/run-unit.ts
+++ b/src/resources/extensions/gsd/auto/run-unit.ts
@@ -9,7 +9,7 @@ import type { ExtensionAPI, ExtensionContext } from "@gsd/pi-coding-agent";
 import type { AutoSession } from "./session.js";
 import { NEW_SESSION_TIMEOUT_MS } from "./session.js";
 import type { UnitResult } from "./types.js";
-import { _setCurrentResolve, _setSessionSwitchInFlight } from "./resolve.js";
+import { _clearCurrentResolve, _setCurrentResolve, _setSessionSwitchInFlight } from "./resolve.js";
 import {
   getCurrentTurnGeneration,
   runWithTurnGeneration,
@@ -148,6 +148,7 @@ export async function runUnit(
       }
 
       if (!ready) {
+        _clearCurrentResolve();
         return {
           status: "cancelled",
           errorContext: {

--- a/src/resources/extensions/gsd/tests/auto-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-loop.test.ts
@@ -10,6 +10,7 @@ import {
   autoLoop,
   detectStuck,
   _resetPendingResolve,
+  _hasPendingResolveForTest,
   _setActiveSession,
   isSessionSwitchInFlight,
   type UnitResult,
@@ -379,6 +380,7 @@ test("runUnit cancels before dispatch when provider is not request-ready (#4555)
     /Provider anthropic is not request-ready/,
   );
   assert.equal(pi.calls.length, 0, "sendMessage must not be called when provider is not ready");
+  assert.equal(_hasPendingResolveForTest(), false, "provider cancellation must clear the pending resolver");
 });
 
 test("runUnit cancels before dispatch using currentUnitModel provider when set (#4555)", async () => {


### PR DESCRIPTION
## TL;DR

**What:** Clears the pending auto-unit resolver when provider readiness cancels before dispatch.
**Why:** The cancellation path returned before sending a prompt but left the module-level resolver armed.
**How:** Calls `_clearCurrentResolve()` on provider-readiness cancellation and adds a regression assertion.

## What

Updates `runUnit()` provider-readiness cancellation and adds a test helper/assertion for pending resolver state.

## Why

A stale resolver can let a later agent-end/cancel event resolve an orphaned unit promise and confuse auto-loop state.

Closes #4735

## How

When the provider is not request-ready, `runUnit()` now clears the resolver before returning the structured cancellation result.

## Test plan

- [x] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/auto-loop.test.ts --test-name-pattern "provider is not request-ready"`

## Change type checklist

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

AI-assisted contribution.