### PR TITLE
fix(web): surface terminal input failures

### DIFF
--- a/web/components/gsd/main-session-terminal.tsx
+++ b/web/components/gsd/main-session-terminal.tsx
@@ -103,13 +103,20 @@ export function MainSessionTerminal({ className, fontSize, projectCwd }: MainSes
     while (inputQueueRef.current.length > 0) {
       const data = inputQueueRef.current.shift()!
       try {
-        await authFetch(buildProjectPath("/api/bridge-terminal/input", projectCwd), {
+        const res = await authFetch(buildProjectPath("/api/bridge-terminal/input", projectCwd), {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ data }),
         })
+        if (!res.ok) {
+          if (res.status >= 500) inputQueueRef.current.unshift(data)
+          setConnectionState("error")
+          termRef.current?.writeln(`\r\nInput failed (${res.status}). Reconnect the terminal and retry.`)
+          break
+        }
       } catch {
         inputQueueRef.current.unshift(data)
+        setConnectionState("error")
         break
       }
     }

--- a/web/components/gsd/shell-terminal.tsx
+++ b/web/components/gsd/shell-terminal.tsx
@@ -162,13 +162,20 @@ function TerminalInstance({
     while (inputQueueRef.current.length > 0) {
       const data = inputQueueRef.current.shift()!
       try {
-        await authFetch(buildProjectPath("/api/terminal/input", projectCwd), {
+        const res = await authFetch(buildProjectPath("/api/terminal/input", projectCwd), {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ id: sessionId, data }),
         })
+        if (!res.ok) {
+          if (res.status >= 500) inputQueueRef.current.unshift(data)
+          onConnectionChangeRef.current(false)
+          termRef.current?.writeln(`\r\nInput failed (${res.status}). Reconnect the terminal and retry.`)
+          break
+        }
       } catch {
         inputQueueRef.current.unshift(data)
+        onConnectionChangeRef.current(false)
         break
       }
     }


### PR DESCRIPTION
## TL;DR

**What:** Handles non-OK terminal input POST responses instead of treating them as successful sends.
**Why:** Terminal keystrokes could be shifted off the queue and silently lost on `401`, `404`, or `503` responses.
**How:** Checks `res.ok`, marks the terminal disconnected/error, shows an inline terminal message, and requeues only server-side failures.

## What

Updates both main-session bridge terminal input and shell terminal input queue flushing.

## Why

`authFetch` resolves for non-OK HTTP responses, so the previous code only handled thrown network errors.

Closes #4730

## How

Each input POST now checks the returned response. Server errors keep the input queued; non-transient rejected input is dropped only after visible feedback.

## Test plan

- [ ] `npm --prefix web run lint` could not run locally: `eslint` is not installed in this checkout

## Change type checklist

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

AI-assisted contribution.