### PR TITLE
fix(vscode): handle sidebar action commands

### DIFF
--- a/vscode-extension/src/sidebar.ts
+++ b/vscode-extension/src/sidebar.ts
@@ -152,11 +152,20 @@ export class GsdSidebarProvider implements vscode.WebviewViewProvider {
 				case "toggleFollowUpMode":
 					await vscode.commands.executeCommand("gsd.toggleFollowUpMode");
 					break;
-				case "showHistory":
-					await vscode.commands.executeCommand("gsd.showHistory");
-					break;
-			}
-		});
+					case "showHistory":
+						await vscode.commands.executeCommand("gsd.showHistory");
+						break;
+					case "fixProblemsInFile":
+						await vscode.commands.executeCommand("gsd.fixProblemsInFile");
+						break;
+					case "selectApprovalMode":
+						await vscode.commands.executeCommand("gsd.selectApprovalMode");
+						break;
+					default:
+						vscode.window.showWarningMessage(`Unknown GSD sidebar command: ${msg.command}`);
+						break;
+				}
+			});
 
 		// Periodic refresh while connected (for token stats)
 		this.refreshTimer = setInterval(() => {


### PR DESCRIPTION
## TL;DR

**What:** Handles sidebar commands emitted by the rendered UI.
**Why:** `Fix Errs` and approval-mode clicks previously no-op'd without feedback.
**How:** Adds command cases for `fixProblemsInFile` and `selectApprovalMode`, plus a warning for unknown sidebar commands.

## What

Updates the VS Code sidebar webview message switch.

## Why

The UI already emitted these commands, and matching extension commands were registered, but the sidebar bridge never forwarded them.

Closes #4739

## How

The sidebar now executes `gsd.fixProblemsInFile` and `gsd.selectApprovalMode` for those webview messages. Unknown commands surface a warning instead of failing silently.

## Test plan

- [ ] `npm --prefix vscode-extension run build` could not complete locally because the checkout is missing the `vscode` type dependency/resolution

## Change type checklist

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

AI-assisted contribution.