### PR TITLE
fix(provider): wire anthropic claude-code migration

### DIFF
--- a/docs/dev/ADR-012-provider-id-vs-api-shape.md
+++ b/docs/dev/ADR-012-provider-id-vs-api-shape.md
@@ -48,6 +48,7 @@ A small set of call sites legitimately keys on `provider`. These are **not** gat
 - **Per-transport doctor checks** (`doctor-providers.ts`). Each transport verifies different things (OAuth vs key vs ADC).
 - **Fallback-source targeting** (`retry-handler.ts` — "only fall back *from* plain `anthropic` *to* `claude-code`"). The rule is transport-specific by design.
 - **Model-registry canonical-provider tiebreakers** (`auto-model-selection.ts`). Same canonical model may appear under multiple transports; plain `anthropic` is the tiebreaker.
+- **Default-provider migrations** (`provider-migrations.ts`). Moving persisted settings from the `anthropic` transport to the `claude-code` transport is intentionally provider-id specific.
 - **Display labels / onboarding copy** (`onboarding.ts`). Surface-only, no behavior impact.
 
 These sites are enumerated in the allowlist at `src/tests/provider-equality-allowlist.test.ts`.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -23,6 +23,7 @@ import { checkForUpdates } from './update-check.js'
 import { printHelp, printSubcommandHelp } from './help-text.js'
 import { applySecurityOverrides } from './security-overrides.js'
 import { validateConfiguredModel } from './startup-model-validation.js'
+import { migrateAnthropicDefaultToClaudeCode } from './provider-migrations.js'
 import {
   parseCliArgs,
   runWebCliBranch,
@@ -409,6 +410,14 @@ async function runHeadlessFromAuto(headlessArgs: string[]): Promise<never> {
   process.exit(0)
 }
 
+function flushPendingProviderRegistrations(resourceLoader: DefaultResourceLoader, modelRegistry: ModelRegistry): void {
+  const { runtime } = resourceLoader.getExtensions()
+  for (const { name, config } of runtime.pendingProviderRegistrations) {
+    modelRegistry.registerProvider(name, config)
+  }
+  runtime.pendingProviderRegistrations = []
+}
+
 // `gsd auto [args...]` — shorthand for `gsd headless auto [args...]` (#2732)
 // Without this, `gsd auto` falls through to the interactive TUI which hangs
 // when stdin/stdout are piped (non-TTY environments).
@@ -563,6 +572,13 @@ if (isPrintMode) {
   })
   await resourceLoader.reload()
   markStartup('resourceLoader.reload')
+  flushPendingProviderRegistrations(resourceLoader, modelRegistry)
+  migrateAnthropicDefaultToClaudeCode({
+    authStorage,
+    isClaudeCodeReady: modelRegistry.isProviderRequestReady('claude-code'),
+    settingsManager,
+    modelRegistry,
+  })
 
   const { session, extensionsResult, modelFallbackMessage } = await createAgentSession({
     authStorage,
@@ -719,6 +735,13 @@ const resourceLoadPromise = resourceLoader.reload()
 // Then await the resource promise before creating the agent session.
 await resourceLoadPromise
 markStartup('resourceLoader.reload')
+flushPendingProviderRegistrations(resourceLoader, modelRegistry)
+migrateAnthropicDefaultToClaudeCode({
+  authStorage,
+  isClaudeCodeReady: modelRegistry.isProviderRequestReady('claude-code'),
+  settingsManager,
+  modelRegistry,
+})
 
 const { session, extensionsResult, modelFallbackMessage: interactiveFallbackMsg } = await createAgentSession({
   authStorage,

--- a/src/provider-migrations.ts
+++ b/src/provider-migrations.ts
@@ -7,6 +7,25 @@ type AnthropicMigrationDeps = {
   env?: NodeJS.ProcessEnv
 }
 
+type MigrationModel = {
+  provider: string
+  id: string
+}
+
+type AnthropicDefaultMigrationDeps = {
+  authStorage: Pick<AuthStorage, "getCredentialsForProvider">
+  isClaudeCodeReady: boolean
+  settingsManager: {
+    getDefaultProvider(): string | undefined
+    getDefaultModel(): string | undefined
+    setDefaultModelAndProvider(provider: string, modelId: string): void
+  }
+  modelRegistry: {
+    getAvailable(): MigrationModel[]
+  }
+  env?: NodeJS.ProcessEnv
+}
+
 export function hasDirectAnthropicApiKey(
   authStorage: Pick<AuthStorage, "getCredentialsForProvider">,
   env: NodeJS.ProcessEnv = process.env,
@@ -31,4 +50,29 @@ export function shouldMigrateAnthropicToClaudeCode({
   }
 
   return !hasDirectAnthropicApiKey(authStorage, env)
+}
+
+export function migrateAnthropicDefaultToClaudeCode({
+  authStorage,
+  isClaudeCodeReady,
+  settingsManager,
+  modelRegistry,
+  env = process.env,
+}: AnthropicDefaultMigrationDeps): boolean {
+  const defaultProvider = settingsManager.getDefaultProvider()
+  if (!shouldMigrateAnthropicToClaudeCode({ authStorage, isClaudeCodeReady, defaultProvider, env })) {
+    return false
+  }
+
+  const defaultModel = settingsManager.getDefaultModel()
+  const target =
+    modelRegistry.getAvailable().find((model) => model.provider === "claude-code" && model.id === defaultModel) ||
+    modelRegistry.getAvailable().find((model) => model.provider === "claude-code")
+
+  if (!target) {
+    return false
+  }
+
+  settingsManager.setDefaultModelAndProvider(target.provider, target.id)
+  return true
 }

--- a/src/tests/provider-equality-allowlist.test.ts
+++ b/src/tests/provider-equality-allowlist.test.ts
@@ -84,6 +84,8 @@ const ALLOWED_FILES: Record<string, string> = {
   // `claude-code` when multiple transports serve the same model).
   "src/resources/extensions/gsd/auto-model-selection.ts":
     "canonical-provider tiebreakers (ADR-012)",
+  "src/provider-migrations.ts":
+    "transport-specific default-provider migration target (ADR-012)",
 
 };
 

--- a/src/tests/provider-migrations.test.ts
+++ b/src/tests/provider-migrations.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test"
 import assert from "node:assert/strict"
-import { hasDirectAnthropicApiKey, shouldMigrateAnthropicToClaudeCode } from "../provider-migrations.ts"
+import { hasDirectAnthropicApiKey, migrateAnthropicDefaultToClaudeCode, shouldMigrateAnthropicToClaudeCode } from "../provider-migrations.ts"
 
 function makeAuthStorage(credentials: unknown[]) {
   return {
@@ -74,4 +74,51 @@ test("shouldMigrateAnthropicToClaudeCode stays off for other providers", () => {
     }),
     false,
   )
+})
+
+test("migrateAnthropicDefaultToClaudeCode switches to matching claude-code model", () => {
+  let saved: { provider: string; modelId: string } | undefined
+  const migrated = migrateAnthropicDefaultToClaudeCode({
+    authStorage: makeAuthStorage([{ type: "oauth" }]) as any,
+    isClaudeCodeReady: true,
+    settingsManager: {
+      getDefaultProvider: () => "anthropic",
+      getDefaultModel: () => "claude-sonnet-4-6",
+      setDefaultModelAndProvider: (provider, modelId) => {
+        saved = { provider, modelId }
+      },
+    },
+    modelRegistry: {
+      getAvailable: () => [
+        { provider: "claude-code", id: "claude-sonnet-4-6" },
+        { provider: "openai", id: "gpt-5.4" },
+      ],
+    },
+    env: {} as NodeJS.ProcessEnv,
+  })
+
+  assert.equal(migrated, true)
+  assert.deepEqual(saved, { provider: "claude-code", modelId: "claude-sonnet-4-6" })
+})
+
+test("migrateAnthropicDefaultToClaudeCode does not switch without a claude-code model", () => {
+  let called = false
+  const migrated = migrateAnthropicDefaultToClaudeCode({
+    authStorage: makeAuthStorage([{ type: "oauth" }]) as any,
+    isClaudeCodeReady: true,
+    settingsManager: {
+      getDefaultProvider: () => "anthropic",
+      getDefaultModel: () => "claude-sonnet-4-6",
+      setDefaultModelAndProvider: () => {
+        called = true
+      },
+    },
+    modelRegistry: {
+      getAvailable: () => [{ provider: "openai", id: "gpt-5.4" }],
+    },
+    env: {} as NodeJS.ProcessEnv,
+  })
+
+  assert.equal(migrated, false)
+  assert.equal(called, false)
 })


### PR DESCRIPTION
## TL;DR

**What:** Wires Anthropic-to-Claude-Code default migration into CLI startup.
**Why:** The migration helper existed but was not called, so OAuth-only Anthropic defaults were not reconciled.
**How:** Flushes extension provider registrations before session creation, then migrates eligible defaults to an available `claude-code` model.

## What

Adds a tested `migrateAnthropicDefaultToClaudeCode()` helper and calls it during print and interactive startup after extension models are available.

## Why

Users with stale Anthropic OAuth credentials and a ready Claude Code provider should be moved away from an unusable `anthropic` default unless they have a direct Anthropic API key.

Closes #4729

## How

Startup now flushes pending extension provider registrations before session creation, runs the migration against the live model registry/settings, and then lets `createAgentSession()` continue with the reconciled default.

## Test plan

- [x] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/tests/provider-migrations.test.ts`

## Change type checklist

- [ ] `feat` — New feature or capability
- [x] `fix` — Bug fix
- [ ] `refactor` — Code restructuring (no behavior change)
- [x] `test` — Adding or updating tests
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, CI, or tooling changes

AI-assisted contribution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced provider registration handling during startup initialization
  * Added automatic migration capabilities for persisted provider settings

* **Tests**
  * Added tests for provider migration functionality

* **Documentation**
  * Updated architectural decision records documenting provider-specific migration logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->