### PR TITLE
fix(tui): expire stale escape prefixes

### DIFF
--- a/packages/pi-tui/src/__tests__/stdin-buffer.test.ts
+++ b/packages/pi-tui/src/__tests__/stdin-buffer.test.ts
@@ -40,4 +40,29 @@ describe("StdinBuffer", () => {
 		assert.deepEqual(received, ["\x1b[I", "\x1b[<35;20;5m"]);
 		assert.equal(buffer.getBuffer(), "");
 	});
+
+	it("flushes a stale incomplete escape prefix after the stale timeout", async () => {
+		const buffer = new StdinBuffer({ timeout: 5, staleTimeout: 10 });
+		const received: string[] = [];
+		buffer.on("data", (sequence) => received.push(sequence));
+
+		buffer.process("\x1b[");
+		await delay(25);
+
+		assert.deepEqual(received, ["\x1b["]);
+		assert.equal(buffer.getBuffer(), "");
+	});
+
+	it("still allows an incomplete escape prefix to complete before the stale timeout", async () => {
+		const buffer = new StdinBuffer({ timeout: 5, staleTimeout: 30 });
+		const received: string[] = [];
+		buffer.on("data", (sequence) => received.push(sequence));
+
+		buffer.process("\x1b[");
+		await delay(10);
+		buffer.process("I");
+
+		assert.deepEqual(received, ["\x1b[I"]);
+		assert.equal(buffer.getBuffer(), "");
+	});
 });

--- a/packages/pi-tui/src/stdin-buffer.ts
+++ b/packages/pi-tui/src/stdin-buffer.ts
@@ -229,6 +229,11 @@ export type StdinBufferOptions = {
 	 * After this time, the buffer is flushed even if incomplete
 	 */
 	timeout?: number;
+	/**
+	 * Maximum time to retain an incomplete escape prefix after the normal
+	 * sequence timeout has fired (default: 1000ms).
+	 */
+	staleTimeout?: number;
 };
 
 export type StdinBufferEventMap = {
@@ -243,13 +248,16 @@ export type StdinBufferEventMap = {
 export class StdinBuffer extends EventEmitter<StdinBufferEventMap> {
 	private buffer: string = "";
 	private timeout: ReturnType<typeof setTimeout> | null = null;
+	private staleTimeout: ReturnType<typeof setTimeout> | null = null;
 	private readonly timeoutMs: number;
+	private readonly staleTimeoutMs: number;
 	private pasteMode: boolean = false;
 	private pasteBuffer: string = "";
 
 	constructor(options: StdinBufferOptions = {}) {
 		super();
 		this.timeoutMs = options.timeout ?? 10;
+		this.staleTimeoutMs = options.staleTimeout ?? 1000;
 	}
 
 	public process(data: string | Buffer): void {
@@ -257,6 +265,10 @@ export class StdinBuffer extends EventEmitter<StdinBufferEventMap> {
 		if (this.timeout) {
 			clearTimeout(this.timeout);
 			this.timeout = null;
+		}
+		if (this.staleTimeout) {
+			clearTimeout(this.staleTimeout);
+			this.staleTimeout = null;
 		}
 
 		// Handle high-byte conversion (for compatibility with parseKeypress)
@@ -365,6 +377,16 @@ export class StdinBuffer extends EventEmitter<StdinBufferEventMap> {
 		// sequences do not get emitted as literal text on timeout.
 		// A lone ESC is still flushed so an actual Escape keypress is not lost.
 		if (this.buffer.length > 1 && this.buffer.startsWith(ESC) && isCompleteSequence(this.buffer) === "incomplete") {
+			if (!this.staleTimeout) {
+				this.staleTimeout = setTimeout(() => {
+					this.staleTimeout = null;
+					if (this.buffer.length > 0 && this.buffer.startsWith(ESC) && isCompleteSequence(this.buffer) === "incomplete") {
+						const stale = this.buffer;
+						this.buffer = "";
+						this.emit("data", stale);
+					}
+				}, this.staleTimeoutMs);
+			}
 			return [];
 		}
 
@@ -377,6 +399,10 @@ export class StdinBuffer extends EventEmitter<StdinBufferEventMap> {
 		if (this.timeout) {
 			clearTimeout(this.timeout);
 			this.timeout = null;
+		}
+		if (this.staleTimeout) {
+			clearTimeout(this.staleTimeout);
+			this.staleTimeout = null;
 		}
 		this.buffer = "";
 		this.pasteMode = false;


### PR DESCRIPTION
## Summary
- add a bounded stale timeout for incomplete escape prefixes in the TUI stdin buffer
- clear stale timers when new input arrives or the buffer is reset
- cover stale flush and completed-prefix behavior

Closes #4738

## Testing
- node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test packages/pi-tui/src/__tests__/stdin-buffer.test.ts