### PR TITLE
test(auto): verify provider recovery reset behavior

### DIFF
--- a/src/resources/extensions/gsd/bootstrap/provider-error-resume.ts
+++ b/src/resources/extensions/gsd/bootstrap/provider-error-resume.ts
@@ -12,6 +12,8 @@ type AutoResumeSnapshot = Pick<AutoDashboardData, "active" | "paused" | "stepMod
 
 export interface ProviderErrorResumeDeps {
   getSnapshot(): AutoResumeSnapshot;
+  resetTransientRetryState(): void;
+  resetSessionTimeoutState(): void;
   startAuto(
     ctx: ExtensionCommandContext,
     pi: ExtensionAPI,
@@ -23,6 +25,8 @@ export interface ProviderErrorResumeDeps {
 
 const defaultDeps: ProviderErrorResumeDeps = {
   getSnapshot: () => getAutoDashboardData(),
+  resetTransientRetryState,
+  resetSessionTimeoutState,
   startAuto,
 };
 
@@ -47,8 +51,8 @@ export async function resumeAutoAfterProviderDelay(
   // Reset retry counters before restarting — without this, counters
   // accumulate across pause/resume cycles and permanently lock out
   // auto-resume after their respective MAX thresholds.
-  resetTransientRetryState();
-  resetSessionTimeoutState();
+  deps.resetTransientRetryState();
+  deps.resetSessionTimeoutState();
 
   await deps.startAuto(
     ctx as ExtensionCommandContext,

--- a/src/resources/extensions/gsd/tests/provider-errors.test.ts
+++ b/src/resources/extensions/gsd/tests/provider-errors.test.ts
@@ -404,6 +404,8 @@ test("resumeAutoAfterProviderDelay restarts paused auto-mode from the recorded b
         stepMode: true,
         basePath: "/tmp/project",
       }),
+      resetTransientRetryState: () => {},
+      resetSessionTimeoutState: () => {},
       startAuto: async (_ctx, _pi, base, verboseMode, options) => {
         startCalls.push({ base, verboseMode, step: options?.step });
       },
@@ -428,6 +430,8 @@ test("resumeAutoAfterProviderDelay does not double-start when auto-mode is alrea
         stepMode: false,
         basePath: "/tmp/project",
       }),
+      resetTransientRetryState: () => {},
+      resetSessionTimeoutState: () => {},
       startAuto: async () => {
         startCalls += 1;
       },
@@ -458,6 +462,8 @@ test("resumeAutoAfterProviderDelay leaves auto paused when no base path is avail
         stepMode: false,
         basePath: "",
       }),
+      resetTransientRetryState: () => {},
+      resetSessionTimeoutState: () => {},
       startAuto: async () => {
         startCalls += 1;
       },
@@ -471,6 +477,39 @@ test("resumeAutoAfterProviderDelay leaves auto paused when no base path is avail
       message: "Provider error recovery delay elapsed, but no paused auto-mode base path was available. Leaving auto-mode paused.",
       level: "warning",
     },
+  ]);
+});
+
+test("resumeAutoAfterProviderDelay resets provider retry state before restarting auto-mode", async () => {
+  const calls: string[] = [];
+
+  const result = await resumeAutoAfterProviderDelay(
+    {} as any,
+    { ui: { notify() {} } } as any,
+    {
+      getSnapshot: () => ({
+        active: false,
+        paused: true,
+        stepMode: false,
+        basePath: "/tmp/project",
+      }),
+      resetTransientRetryState: () => {
+        calls.push("reset-transient");
+      },
+      resetSessionTimeoutState: () => {
+        calls.push("reset-session-timeout");
+      },
+      startAuto: async () => {
+        calls.push("start-auto");
+      },
+    },
+  );
+
+  assert.equal(result, "resumed");
+  assert.deepEqual(calls, [
+    "reset-transient",
+    "reset-session-timeout",
+    "start-auto",
   ]);
 });
 
@@ -564,31 +603,6 @@ test("resetTransientRetryState is exported from agent-end-recovery.ts", () => {
   assert.ok(
     src.includes("export function resetTransientRetryState"),
     "agent-end-recovery.ts must export resetTransientRetryState for provider-error-resume.ts",
-  );
-});
-
-test("provider-error-resume.ts calls resetTransientRetryState before startAuto", () => {
-  const src = readFileSync(join(__dirname, "..", "bootstrap", "provider-error-resume.ts"), "utf-8");
-  assert.ok(
-    src.includes("resetTransientRetryState"),
-    "provider-error-resume.ts must import and call resetTransientRetryState",
-  );
-  // Ensure reset is called BEFORE startAuto — order matters
-  const resetIdx = src.indexOf("resetTransientRetryState()");
-  const startIdx = src.indexOf("await deps.startAuto(");
-  assert.ok(
-    resetIdx !== -1 && startIdx !== -1 && resetIdx < startIdx,
-    "resetTransientRetryState() must be called before deps.startAuto()",
-  );
-  // Session timeout counter must also be reset before startAuto
-  assert.ok(
-    src.includes("resetSessionTimeoutState"),
-    "provider-error-resume.ts must import and call resetSessionTimeoutState",
-  );
-  const sessionResetIdx = src.indexOf("resetSessionTimeoutState()");
-  assert.ok(
-    sessionResetIdx !== -1 && startIdx !== -1 && sessionResetIdx < startIdx,
-    "resetSessionTimeoutState() must be called before deps.startAuto()",
   );
 });
 


### PR DESCRIPTION
## Summary
- make provider auto-resume reset hooks injectable for behavior testing
- assert retry/session-timeout reset order before auto-mode restarts
- remove the provider-resume source-string reset-order test

Closes #4736

## Testing
- node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/provider-errors.test.ts