### PR TITLE
test(web-vscode): add executable smoke coverage

### DIFF
--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -80,6 +80,10 @@ Automatic checkpoints are created at the start of each agent turn. Use **Discard
 
 The **Activity** panel shows a real-time log of every tool the agent executes — Read, Write, Edit, Bash, Grep, Glob — with status icons (running/success/error), duration, and click-to-open for file operations.
 
+### Plan View
+
+The **Plan** panel shows the agent's current plan as a dedicated tree view. Use **GSD: Clear Plan View** from the Command Palette to clear the displayed plan.
+
 ### Sessions
 
 The **Sessions** panel lists all past sessions for the current workspace. Click any session to switch to it. The current session is highlighted green. Sessions persist to disk automatically.
@@ -128,6 +132,7 @@ When the agent needs input (questions, confirmations, selections), VS Code dialo
 - **Conversation History** — full message viewer with tool calls, thinking blocks, search, and fork-from-here
 - **Slash Command Completion** — type `/` for auto-complete of `/gsd` commands
 - **File Decorations** — "G" badge on agent-modified files in the Explorer
+- **Plan View** — dedicated panel for the agent's current plan
 - **Bash Terminal** — dedicated terminal for agent shell output
 - **Context Window Warning** — notification when context exceeds threshold
 - **Progress Notifications** — optional notification with cancel button (off by default)
@@ -160,6 +165,7 @@ When the agent needs input (questions, confirmations, selections), VS Code dialo
 | **GSD: Fork Session** | | Fork from a previous message |
 | **GSD: Fix Problems in File** | | Send file diagnostics to agent |
 | **GSD: Fix All Problems** | | Send workspace errors to agent |
+| **GSD: Clear Plan View** | | Clear the current plan panel |
 | **GSD: Commit Agent Changes** | | Git commit modified files |
 | **GSD: Create Branch** | | Create branch for agent work |
 | **GSD: Show Agent Diff** | | View git diff |

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -286,6 +286,10 @@
         {
           "id": "gsd-activity",
           "name": "Activity"
+        },
+        {
+          "id": "gsd-plan",
+          "name": "Plan"
         }
       ]
     },
@@ -400,6 +404,7 @@
   "scripts": {
     "build": "tsc",
     "watch": "tsc --watch",
+    "test": "node --experimental-strip-types --test \"test/*.test.ts\"",
     "package": "vsce package",
     "publish": "vsce publish"
   },

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -15,12 +15,14 @@ import { GsdDiagnosticBridge } from "./diagnostics.js";
 import { GsdLineDecorationManager } from "./line-decorations.js";
 import { GsdGitIntegration } from "./git-integration.js";
 import { GsdPermissionManager } from "./permissions.js";
+import { GsdPlanViewerProvider } from "./plan-viewer.js";
 
 let client: GsdClient | undefined;
 let sidebarProvider: GsdSidebarProvider | undefined;
 let fileDecorations: GsdFileDecorationProvider | undefined;
 let sessionTreeProvider: GsdSessionTreeProvider | undefined;
 let activityFeedProvider: GsdActivityFeedProvider | undefined;
+let planViewerProvider: GsdPlanViewerProvider | undefined;
 let changeTracker: GsdChangeTracker | undefined;
 let scmProvider: GsdScmProvider | undefined;
 let diagnosticBridge: GsdDiagnosticBridge | undefined;
@@ -138,6 +140,14 @@ export function activate(context: vscode.ExtensionContext): void {
 	context.subscriptions.push(
 		activityFeedProvider,
 		vscode.window.registerTreeDataProvider(GsdActivityFeedProvider.viewId, activityFeedProvider),
+	);
+
+	// -- Plan view ----------------------------------------------------------
+
+	planViewerProvider = new GsdPlanViewerProvider(client);
+	context.subscriptions.push(
+		planViewerProvider,
+		vscode.window.registerTreeDataProvider(GsdPlanViewerProvider.viewId, planViewerProvider),
 	);
 
 	// -- Change tracker & SCM provider -------------------------------------
@@ -921,6 +931,12 @@ export function activate(context: vscode.ExtensionContext): void {
 	context.subscriptions.push(
 		vscode.commands.registerCommand("gsd.clearDiagnostics", () => {
 			diagnosticBridge?.clearFindings();
+		}),
+	);
+
+	context.subscriptions.push(
+		vscode.commands.registerCommand("gsd.clearPlan", () => {
+			planViewerProvider?.clear();
 		}),
 	);
 

--- a/vscode-extension/test/manifest.test.ts
+++ b/vscode-extension/test/manifest.test.ts
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+function readText(relativePath: string): string {
+	return readFileSync(join(root, relativePath), "utf8");
+}
+
+function readPackage(): {
+	contributes: {
+		commands: Array<{ command: string }>;
+		configuration: {
+			properties: Record<string, unknown>;
+		};
+	};
+	scripts: Record<string, string>;
+} {
+	return JSON.parse(readText("package.json"));
+}
+
+test("contributed commands are registered by the extension entrypoint", () => {
+	const pkg = readPackage();
+	const extensionSource = readText("src/extension.ts");
+	const contributed = pkg.contributes.commands.map((entry) => entry.command);
+	const registered = new Set(
+		[...extensionSource.matchAll(/registerCommand\(\s*["']([^"']+)["']/g)].map((match) => match[1]),
+	);
+
+	for (const command of contributed) {
+		assert.ok(registered.has(command), `${command} must be registered in src/extension.ts`);
+	}
+});
+
+test("GSDClient launches the configured binary in RPC mode with a controlled cwd", () => {
+	const clientSource = readText("src/gsd-client.ts");
+
+	assert.match(clientSource, /spawn\(this\.binaryPath,\s*\[\s*["']--mode["'],\s*["']rpc["']\s*\]/);
+	assert.match(clientSource, /cwd:\s*this\.cwd/);
+});
+
+test("approval mode contributes settings and executable commands", () => {
+	const pkg = readPackage();
+	const extensionSource = readText("src/extension.ts");
+	const permissionsSource = readText("src/permissions.ts");
+
+	assert.ok(pkg.contributes.configuration.properties["gsd.approvalMode"]);
+	assert.match(extensionSource, /registerCommand\(\s*["']gsd\.cycleApprovalMode["']/);
+	assert.match(extensionSource, /registerCommand\(\s*["']gsd\.selectApprovalMode["']/);
+	assert.match(permissionsSource, /getConfiguration\(["']gsd["']\)\.get<ApprovalMode>\(["']approvalMode["']/);
+	assert.match(permissionsSource, /update\(["']approvalMode["']/);
+});

--- a/web/package.json
+++ b/web/package.json
@@ -8,7 +8,8 @@
     "build": "next build --webpack",
     "start": "next start",
     "start:standalone": "node .next/standalone/web/server.js",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "test": "node --experimental-strip-types --test \"lib/__tests__/*.test.ts\""
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.1",


### PR DESCRIPTION
## Summary
- add package-level Node test scripts for the web and VS Code packages
- add VS Code manifest/source smoke tests for command registration, GSDClient launch wiring, and approval-mode commands
- wire the contributed Plan view and clearPlan command so the manifest command is executable

Closes #4737

## Testing
- npm --prefix web test
- npm --prefix vscode-extension test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Plan" view panel to the VS Code extension UI
  * Added command to clear the plan viewer

* **Tests**
  * Introduced test suite for extension configuration validation and consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->