### PR TITLE
test(security): run secret scan when tools exist

### DIFF
--- a/src/tests/secret-scan.test.ts
+++ b/src/tests/secret-scan.test.ts
@@ -2,17 +2,26 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
 import { writeFileSync, mkdtempSync, rmSync, mkdirSync } from "node:fs";
-import { join } from "node:path";
-import { tmpdir, platform } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
 
-// Secret scanner requires bash + POSIX grep — skip on Windows
-const isWindows = platform() === "win32";
+function hasCommand(command: string, args: string[], input?: string): boolean {
+  const result = spawnSync(command, args, { encoding: "utf-8", input });
+  return !result.error && (result.status ?? 1) === 0;
+}
 
-const projectRoot = join(
-  new URL(".", import.meta.url).pathname,
-  "..",
-  "..",
-);
+// Secret scanner requires bash, grep, and git. Skip only when the runtime
+// tools are unavailable; do not skip wholesale by operating system.
+const canRunSecretScan =
+  hasCommand("bash", ["--version"]) &&
+  hasCommand("grep", ["-E", "x"], "x\n") &&
+  hasCommand("git", ["--version"]);
+const secretScanSkip = canRunSecretScan
+  ? undefined
+  : "secret scanner requires bash, grep, and git in PATH";
+
+const projectRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
 const scanScript = join(projectRoot, "scripts", "secret-scan.sh");
 
 /**
@@ -26,24 +35,24 @@ function scanContent(
   const dir = mkdtempSync(join(tmpdir(), "secret-scan-test-"));
   try {
     // Initialize a git repo so `git diff --cached` works
-  spawnSync("git", ["init"], { cwd: dir });
-  spawnSync("git", ["config", "user.email", "test@test.com"], { cwd: dir });
-  spawnSync("git", ["config", "user.name", "Test"], { cwd: dir });
+    spawnSync("git", ["init"], { cwd: dir });
+    spawnSync("git", ["config", "user.email", "test@test.com"], { cwd: dir });
+    spawnSync("git", ["config", "user.name", "Test"], { cwd: dir });
 
-  // Write and stage the file
-  const filePath = join(dir, filename);
-  const parentDir = join(dir, ...filename.split("/").slice(0, -1));
-  if (filename.includes("/")) {
-    mkdirSync(parentDir, { recursive: true });
-  }
-  writeFileSync(filePath, content);
-  spawnSync("git", ["add", filename], { cwd: dir });
+    // Write and stage the file
+    const filePath = join(dir, filename);
+    const parentDir = join(dir, ...filename.split("/").slice(0, -1));
+    if (filename.includes("/")) {
+      mkdirSync(parentDir, { recursive: true });
+    }
+    writeFileSync(filePath, content);
+    spawnSync("git", ["add", filename], { cwd: dir });
 
-  const result = spawnSync("bash", [scanScript], {
-    cwd: dir,
-    encoding: "utf-8",
-    env: { ...process.env, TERM: "dumb" },
-  });
+    const result = spawnSync("bash", [scanScript], {
+      cwd: dir,
+      encoding: "utf-8",
+      env: { ...process.env, TERM: "dumb" },
+    });
 
     return {
       status: result.status ?? 1,
@@ -57,13 +66,13 @@ function scanContent(
 
 // ── Detection tests ──────────────────────────────────────────────────
 
-test("detects AWS access key", { skip: isWindows }, () => {
+test("detects AWS access key", { skip: secretScanSkip }, () => {
   const result = scanContent('const key = "AKIAIOSFODNN7EXAMPLE";');
   assert.equal(result.status, 1, `should fail: ${result.stdout}`);
   assert.match(result.stdout, /AWS Access Key/);
 });
 
-test("detects generic API key assignment", { skip: isWindows }, () => {
+test("detects generic API key assignment", { skip: secretScanSkip }, () => {
   const result = scanContent(
     'const api_key = "sk-abc123def456ghi789jkl012mno345pqr678";',
   );
@@ -71,19 +80,19 @@ test("detects generic API key assignment", { skip: isWindows }, () => {
   assert.match(result.stdout, /Generic API Key/i);
 });
 
-test("detects generic secret/password assignment", { skip: isWindows }, () => {
+test("detects generic secret/password assignment", { skip: secretScanSkip }, () => {
   const result = scanContent('password = "SuperSecretP@ssw0rd!2024"');
   assert.equal(result.status, 1, `should fail: ${result.stdout}`);
   assert.match(result.stdout, /SECRET DETECTED/);
 });
 
-test("detects private key header", { skip: isWindows }, () => {
+test("detects private key header", { skip: secretScanSkip }, () => {
   const result = scanContent("-----BEGIN RSA PRIVATE KEY-----\nMIIE...");
   assert.equal(result.status, 1, `should fail: ${result.stdout}`);
   assert.match(result.stdout, /Private Key/);
 });
 
-test("detects GitHub personal access token", { skip: isWindows }, () => {
+test("detects GitHub personal access token", { skip: secretScanSkip }, () => {
   const result = scanContent(
     'const token = "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklm";',
   );
@@ -91,7 +100,7 @@ test("detects GitHub personal access token", { skip: isWindows }, () => {
   assert.match(result.stdout, /GitHub Token/);
 });
 
-test("detects Stripe test key", { skip: isWindows }, () => {
+test("detects Stripe test key", { skip: secretScanSkip }, () => {
   // Use sk_test_ prefix to avoid GitHub push protection on sk_live_
   const stripeKey = ["sk", "test", "aAbBcCdDeFgHiJkLmNoPqRsT"].join("_");
   const result = scanContent(`const stripe = "${stripeKey}";`);
@@ -99,7 +108,7 @@ test("detects Stripe test key", { skip: isWindows }, () => {
   assert.match(result.stdout, /Stripe Key/);
 });
 
-test("detects database connection string", { skip: isWindows }, () => {
+test("detects database connection string", { skip: secretScanSkip }, () => {
   const result = scanContent(
     'const db = "postgres://user:pass@host:5432/mydb";',
   );
@@ -107,7 +116,7 @@ test("detects database connection string", { skip: isWindows }, () => {
   assert.match(result.stdout, /Database URL/);
 });
 
-test("detects Slack token", { skip: isWindows }, () => {
+test("detects Slack token", { skip: secretScanSkip }, () => {
   // Build token dynamically to avoid GitHub push protection
   const slackToken = ["xoxb", "000000000000", "0000000000000", "testfakevalue000"].join("-");
   const result = scanContent(`const token = "${slackToken}";`);
@@ -115,7 +124,7 @@ test("detects Slack token", { skip: isWindows }, () => {
   assert.match(result.stdout, /Slack Token/);
 });
 
-test("detects Google API key", { skip: isWindows }, () => {
+test("detects Google API key", { skip: secretScanSkip }, () => {
   const result = scanContent(
     'const key = "AIzaSyA1234567890abcdefghijklmnopqrstuvwx";',
   );
@@ -125,27 +134,27 @@ test("detects Google API key", { skip: isWindows }, () => {
 
 // ── Non-detection tests (should pass clean) ──────────────────────────
 
-test("allows environment variable references", { skip: isWindows }, () => {
+test("allows environment variable references", { skip: secretScanSkip }, () => {
   const result = scanContent("const key = process.env.API_KEY;");
   assert.equal(result.status, 0, `should pass: ${result.stdout}`);
 });
 
-test("allows empty strings", { skip: isWindows }, () => {
+test("allows empty strings", { skip: secretScanSkip }, () => {
   const result = scanContent('const password = "";');
   assert.equal(result.status, 0, `should pass: ${result.stdout}`);
 });
 
-test("allows placeholder values", { skip: isWindows }, () => {
+test("allows placeholder values", { skip: secretScanSkip }, () => {
   const result = scanContent('const api_key = "your-api-key-here";');
   assert.equal(result.status, 0, `should pass: ${result.stdout}`);
 });
 
-test("skips binary file extensions", { skip: isWindows }, () => {
+test("skips binary file extensions", { skip: secretScanSkip }, () => {
   const result = scanContent("AKIAIOSFODNN7EXAMPLE", "image.png");
   assert.equal(result.status, 0, `should pass (binary skip): ${result.stdout}`);
 });
 
-test("skips package-lock.json", { skip: isWindows }, () => {
+test("skips package-lock.json", { skip: secretScanSkip }, () => {
   const result = scanContent(
     '{"integrity": "sha512-AKIAIOSFODNN7EXAMPLE"}',
     "package-lock.json",
@@ -153,7 +162,7 @@ test("skips package-lock.json", { skip: isWindows }, () => {
   assert.equal(result.status, 0, `should pass (lockfile skip): ${result.stdout}`);
 });
 
-test("reports no files cleanly", { skip: isWindows }, (t) => {
+test("reports no files cleanly", { skip: secretScanSkip }, (t) => {
   const dir = mkdtempSync(join(tmpdir(), "secret-scan-empty-"));
   t.after(() => { rmSync(dir, { recursive: true, force: true }); });
 
@@ -168,7 +177,7 @@ test("reports no files cleanly", { skip: isWindows }, (t) => {
 
 // ── Multiple findings ────────────────────────────────────────────────
 
-test("reports multiple secrets in one file", { skip: isWindows }, () => {
+test("reports multiple secrets in one file", { skip: secretScanSkip }, () => {
   const stripeKey = ["sk", "test", "aAbBcCdDeFgHiJkLmNoPqRsT"].join("_");
   const content = [
     'const aws = "AKIAIOSFODNN7EXAMPLE";',
@@ -184,7 +193,7 @@ test("reports multiple secrets in one file", { skip: isWindows }, () => {
 
 // ── CI mode (--diff) ─────────────────────────────────────────────────
 
-test("CI mode scans diff against ref", { skip: isWindows }, (t) => {
+test("CI mode scans diff against ref", { skip: secretScanSkip }, (t) => {
   const dir = mkdtempSync(join(tmpdir(), "secret-scan-ci-"));
   t.after(() => { rmSync(dir, { recursive: true, force: true }); });
 


### PR DESCRIPTION
## Summary
- remove the blanket Windows skip from secret-scan tests
- gate tests by required runtime tools instead of OS name
- resolve the repo root with fileURLToPath for Windows-safe paths

Closes #4741

## Testing
- node --experimental-strip-types --test src/tests/secret-scan.test.ts