### PR TITLE
fix(security): harden project-controlled surfaces

### DIFF
--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -113,15 +113,15 @@ These tools use the same GSD workflow handlers as the native in-process tool pat
 
 ### Interactive tools
 
-The packaged server now exposes `ask_user_questions` through MCP form elicitation. This keeps the existing GSD answer payload shape while allowing Claude Code CLI and other elicitation-capable clients to surface structured user choices.
+The packaged server exposes `ask_user_questions` through MCP form elicitation. This keeps the existing GSD answer payload shape while allowing Claude Code CLI and other elicitation-capable clients to surface structured user choices.
 
-`secure_env_collect` is still not exposed by this package. That path needs MCP URL elicitation or an equivalent secure bridge because secrets should not flow through form elicitation.
+The packaged server also exposes `secure_env_collect` through MCP form elicitation. Secret values are written directly to the selected destination and are not included in tool output. For dotenv writes, `envFilePath` must resolve inside the validated project directory; parent traversal and symlink escapes are rejected.
 
 Current support boundary:
 
 - when running inside the GSD monorepo checkout, the MCP server auto-discovers the shared workflow executor module
 - outside the monorepo, set `GSD_WORKFLOW_EXECUTORS_MODULE` to an importable `workflow-tool-executors` module path if you want the mutation tools enabled
-- `ask_user_questions` requires an MCP client that supports form elicitation
+- `ask_user_questions` and `secure_env_collect` require an MCP client that supports form elicitation
 - session/read tools do not depend on this bridge
 
 If the executor bridge cannot be loaded, workflow mutation calls will fail with a precise configuration error instead of silently degrading.

--- a/packages/mcp-server/src/env-writer.test.ts
+++ b/packages/mcp-server/src/env-writer.test.ts
@@ -3,7 +3,7 @@
 
 import { describe, it, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync, readFileSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, readFileSync, realpathSync, symlinkSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -14,6 +14,7 @@ import {
   applySecrets,
   isSafeEnvVarKey,
   isSupportedDeploymentEnvironment,
+  resolveProjectEnvFilePath,
   shellEscapeSingle,
 } from './env-writer.js';
 
@@ -179,6 +180,83 @@ describe('writeEnvKey', () => {
       );
     } finally {
       rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('does not follow symlinked env files when writing', async () => {
+    const tmp = makeTempDir('write');
+    const outside = makeTempDir('write-outside');
+    try {
+      const outsideEnv = join(outside, '.env');
+      writeFileSync(outsideEnv, 'SECRET=outside\n');
+      symlinkSync(outsideEnv, join(tmp, '.env'));
+
+      await assert.rejects(
+        () => writeEnvKey(join(tmp, '.env'), 'SECRET', 'inside'),
+        /ELOOP|symbolic link|symlink/i,
+      );
+      assert.equal(readFileSync(outsideEnv, 'utf8'), 'SECRET=outside\n');
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+      rmSync(outside, { recursive: true, force: true });
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveProjectEnvFilePath
+// ---------------------------------------------------------------------------
+
+describe('resolveProjectEnvFilePath', () => {
+  it('allows .env under the project root', () => {
+    const tmp = makeTempDir('env-path');
+    try {
+      assert.equal(resolveProjectEnvFilePath(tmp, '.env'), join(realpathSync.native(tmp), '.env'));
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects envFilePath outside the project root', () => {
+    const tmp = makeTempDir('env-path');
+    try {
+      assert.throws(
+        () => resolveProjectEnvFilePath(tmp, '../outside.env'),
+        /inside the project directory/,
+      );
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects symlinked parent directories that escape the project root', () => {
+    const tmp = makeTempDir('env-path');
+    const outside = makeTempDir('env-path-outside');
+    try {
+      symlinkSync(outside, join(tmp, 'linked-outside'), 'dir');
+      assert.throws(
+        () => resolveProjectEnvFilePath(tmp, 'linked-outside/.env'),
+        /inside the project directory/,
+      );
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+      rmSync(outside, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects existing env files that are symlinks outside the project root', () => {
+    const tmp = makeTempDir('env-path');
+    const outside = makeTempDir('env-path-outside');
+    try {
+      writeFileSync(join(outside, '.env'), 'SECRET=outside\n');
+      symlinkSync(join(outside, '.env'), join(tmp, '.env'));
+      assert.throws(
+        () => resolveProjectEnvFilePath(tmp, '.env'),
+        /inside the project directory/,
+      );
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+      rmSync(outside, { recursive: true, force: true });
     }
   });
 });

--- a/packages/mcp-server/src/env-writer.ts
+++ b/packages/mcp-server/src/env-writer.ts
@@ -5,9 +5,9 @@
 // destinations, and checking existing keys. Used by secure_env_collect
 // MCP tool. No TUI dependencies — pure filesystem + process.env operations.
 
-import { readFile, writeFile } from "node:fs/promises";
-import { existsSync, statSync } from "node:fs";
-import { resolve } from "node:path";
+import { open, readFile, rename, rm } from "node:fs/promises";
+import { constants, existsSync, lstatSync, realpathSync, statSync } from "node:fs";
+import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path";
 
 // ---------------------------------------------------------------------------
 // checkExistingEnvKeys
@@ -71,10 +71,19 @@ export async function writeEnvKey(filePath: string, key: string, value: string):
   if (typeof value !== "string") {
     throw new TypeError(`writeEnvKey expects a string value for key "${key}", got ${typeof value}`);
   }
+  assertWritableEnvFileTarget(filePath);
   let content = "";
   try {
-    content = await readFile(filePath, "utf8");
-  } catch {
+    const handle = await open(filePath, constants.O_RDONLY | constants.O_NOFOLLOW);
+    try {
+      content = await handle.readFile("utf8");
+    } finally {
+      await handle.close();
+    }
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+      throw err;
+    }
     content = "";
   }
   const escaped = value.replace(/\\/g, "\\\\").replace(/\n/g, "\\n").replace(/\r/g, "");
@@ -86,7 +95,42 @@ export async function writeEnvKey(filePath: string, key: string, value: string):
     if (content.length > 0 && !content.endsWith("\n")) content += "\n";
     content += `${line}\n`;
   }
-  await writeFile(filePath, content, "utf8");
+  const tempPath = join(
+    dirname(filePath),
+    `.${basename(filePath)}.${process.pid}.${Date.now()}.${Math.random().toString(16).slice(2)}.tmp`,
+  );
+  let handle: Awaited<ReturnType<typeof open>> | undefined;
+  try {
+    handle = await open(tempPath, constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL, 0o600);
+    await handle.writeFile(content, "utf8");
+    await handle.close();
+    handle = undefined;
+    assertWritableEnvFileTarget(filePath);
+    await rename(tempPath, filePath);
+  } catch (err) {
+    if (handle) {
+      try {
+        await handle.close();
+      } catch {
+        // Best-effort cleanup.
+      }
+    }
+    await rm(tempPath, { force: true }).catch(() => undefined);
+    throw err;
+  }
+}
+
+function assertWritableEnvFileTarget(filePath: string): void {
+  try {
+    if (lstatSync(filePath).isSymbolicLink()) {
+      throw new Error("Refusing to write symlinked env file");
+    }
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      return;
+    }
+    throw err;
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -99,6 +143,32 @@ export function isSafeEnvVarKey(key: string): boolean {
 
 export function isSupportedDeploymentEnvironment(env: string): boolean {
   return env === "development" || env === "preview" || env === "production";
+}
+
+function isWithinProjectRoot(projectRoot: string, candidatePath: string): boolean {
+  const rel = relative(projectRoot, candidatePath);
+  return rel === "" || (!rel.startsWith("..") && !isAbsolute(rel));
+}
+
+export function resolveProjectEnvFilePath(projectDir: string, envFilePath = ".env"): string {
+  const projectRoot = realpathSync.native(resolve(projectDir));
+  const candidate = resolve(projectRoot, envFilePath);
+  if (!isWithinProjectRoot(projectRoot, candidate)) {
+    throw new Error("envFilePath must resolve inside the project directory");
+  }
+  if (existsSync(candidate)) {
+    const targetRealPath = realpathSync.native(candidate);
+    if (isWithinProjectRoot(projectRoot, targetRealPath)) {
+      return candidate;
+    }
+    throw new Error("envFilePath must resolve inside the project directory");
+  }
+  const candidateParent = dirname(candidate);
+  const parentRealPath = realpathSync.native(candidateParent);
+  if (isWithinProjectRoot(projectRoot, parentRealPath)) {
+    return candidate;
+  }
+  throw new Error("envFilePath must resolve inside the project directory");
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -26,7 +26,7 @@ import { buildGraph, writeGraph, writeSnapshot, graphStatus, graphQuery, graphDi
 import { resolveGsdRoot } from './readers/paths.js';
 import { runDoctorLite } from './readers/doctor-lite.js';
 import { registerWorkflowTools, validateProjectDir } from './workflow-tools.js';
-import { applySecrets, checkExistingEnvKeys, detectDestination } from './env-writer.js';
+import { applySecrets, checkExistingEnvKeys, detectDestination, resolveProjectEnvFilePath } from './env-writer.js';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -689,7 +689,7 @@ export async function createMcpServer(sessionManager: SessionManager): Promise<{
 
       try {
         const resolvedProjectDir = validateProjectDir(projectDir);
-        const resolvedEnvPath = resolve(resolvedProjectDir, envFilePath ?? '.env');
+        const resolvedEnvPath = resolveProjectEnvFilePath(resolvedProjectDir, envFilePath ?? '.env');
 
         // (1) Check which keys already exist
         const allKeyNames = keys.map((k) => k.key);

--- a/src/resources/extensions/gsd/tests/mcp-client-security.test.ts
+++ b/src/resources/extensions/gsd/tests/mcp-client-security.test.ts
@@ -1,0 +1,76 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+import {
+  _buildMcpChildEnvForTest,
+  _buildMcpTrustConfirmOptionsForTest,
+} from "../../mcp-client/index.ts";
+
+test("MCP stdio child env only includes safe inherited keys plus explicit config env", () => {
+  const previousSecret = process.env.SECRET_MCP_TEST_TOKEN;
+  const previousPath = process.env.PATH;
+  try {
+    process.env.SECRET_MCP_TEST_TOKEN = "should-not-leak";
+    process.env.PATH = "/usr/bin";
+
+    const env = _buildMcpChildEnvForTest({
+      EXPLICIT_TOKEN: "${SECRET_MCP_TEST_TOKEN}",
+      PLAIN_VALUE: "ok",
+    });
+
+    assert.equal(env.PATH, "/usr/bin");
+    assert.equal(env.SECRET_MCP_TEST_TOKEN, undefined);
+    assert.equal(env.EXPLICIT_TOKEN, "should-not-leak");
+    assert.equal(env.PLAIN_VALUE, "ok");
+  } finally {
+    if (previousSecret === undefined) delete process.env.SECRET_MCP_TEST_TOKEN;
+    else process.env.SECRET_MCP_TEST_TOKEN = previousSecret;
+    if (previousPath === undefined) delete process.env.PATH;
+    else process.env.PATH = previousPath;
+  }
+});
+
+test("MCP stdio trust confirmation is abort-aware", () => {
+  const controller = new AbortController();
+  const options = _buildMcpTrustConfirmOptionsForTest(controller.signal);
+
+  assert.equal(options.timeout, 120_000);
+  assert.equal(options.signal, controller.signal);
+});
+
+test("MCP client uses a single in-flight connection per canonical server", () => {
+  const source = readFileSync(new URL("../../mcp-client/index.ts", import.meta.url), "utf8");
+
+  assert.match(source, /const pendingConnections = new Map<string, Promise<Client>>\(\)/);
+  assert.match(source, /const pending = pendingConnections\.get\(config\.name\)/);
+  assert.match(source, /pendingConnections\.set\(config\.name, connectionPromise\)/);
+  assert.match(source, /pendingConnections\.delete\(config\.name\)/);
+  assert.match(source, /env: config\.env \?\? \{\}/);
+});
+
+test("MCP stdio trust is persisted only after a successful connection", () => {
+  const source = readFileSync(new URL("../../mcp-client/index.ts", import.meta.url), "utf8");
+  const connectIndex = source.indexOf("await client.connect(transport");
+  const trustIndex = source.indexOf("trustedStdioServers.add(approvedTrustKey)");
+
+  assert.ok(connectIndex > -1, "connectServer should await client.connect");
+  assert.ok(trustIndex > connectIndex, "trust should be recorded after client.connect succeeds");
+  assert.doesNotMatch(source, /assertTrustedStdioServer[\s\S]*trustedStdioServers\.add\(trustKey\)/);
+});
+
+test("MCP client closes transports after failed connection attempts", () => {
+  const source = readFileSync(new URL("../../mcp-client/index.ts", import.meta.url), "utf8");
+
+  assert.match(source, /catch \(err\) \{[\s\S]*await transport\.close\(\)/);
+  assert.match(source, /catch \(err\) \{[\s\S]*await client\.close\(\)/);
+  assert.match(source, /catch \(err\) \{[\s\S]*throw err/);
+});
+
+test("MCP client clears process-local trust and closes transports on session cleanup", () => {
+  const source = readFileSync(new URL("../../mcp-client/index.ts", import.meta.url), "utf8");
+
+  assert.match(source, /async function closeAll\(\)[\s\S]*await conn\.transport\.close\(\)/);
+  assert.match(source, /async function closeAll\(\)[\s\S]*pendingConnections\.clear\(\)/);
+  assert.match(source, /async function closeAll\(\)[\s\S]*trustedStdioServers\.clear\(\)/);
+});

--- a/src/resources/extensions/mcp-client/index.ts
+++ b/src/resources/extensions/mcp-client/index.ts
@@ -11,7 +11,7 @@
  *   mcp_call      — Call a tool on an MCP server (lazy connect)
  */
 
-import type { ExtensionAPI } from "@gsd/pi-coding-agent";
+import type { ExtensionAPI, ExtensionContext } from "@gsd/pi-coding-agent";
 import {
 	truncateHead,
 	DEFAULT_MAX_BYTES,
@@ -33,6 +33,7 @@ import type { McpHttpAuthConfig } from "./auth.js";
 interface McpServerConfig {
 	name: string;
 	transport: "stdio" | "http" | "unknown";
+	sourcePath: string;
 	command?: string;
 	args?: string[];
 	env?: Record<string, string>;
@@ -58,8 +59,40 @@ interface ManagedConnection {
 // ─── Connection Manager ───────────────────────────────────────────────────────
 
 const connections = new Map<string, ManagedConnection>();
+const pendingConnections = new Map<string, Promise<Client>>();
 let configCache: McpServerConfig[] | null = null;
 const toolCache = new Map<string, McpToolSchema[]>();
+const trustedStdioServers = new Set<string>();
+
+const CHILD_ENV_ALLOWLIST = new Set([
+	"PATH",
+	"Path",
+	"HOME",
+	"USER",
+	"USERNAME",
+	"USERPROFILE",
+	"SHELL",
+	"TMPDIR",
+	"TEMP",
+	"TMP",
+	"SystemRoot",
+	"WINDIR",
+	"APPDATA",
+	"LOCALAPPDATA",
+	"XDG_CONFIG_HOME",
+	"XDG_CACHE_HOME",
+]);
+
+function stdioTrustKey(config: McpServerConfig): string {
+	return JSON.stringify({
+		name: config.name,
+		sourcePath: config.sourcePath,
+		command: config.command,
+		args: config.args ?? [],
+		cwd: config.cwd,
+		env: config.env ?? {},
+	});
+}
 
 function readConfigs(): McpServerConfig[] {
 	if (configCache) return configCache;
@@ -99,6 +132,7 @@ function readConfigs(): McpServerConfig[] {
 				servers.push({
 					name,
 					transport,
+					sourcePath: configPath,
 					...(hasCommand && {
 						command: config.command as string,
 						args: Array.isArray(config.args) ? (config.args as string[]) : undefined,
@@ -119,6 +153,54 @@ function readConfigs(): McpServerConfig[] {
 
 	configCache = servers;
 	return servers;
+}
+
+export function _buildMcpChildEnvForTest(configEnv: Record<string, string> | undefined): Record<string, string> {
+	const childEnv: Record<string, string> = {};
+	for (const key of CHILD_ENV_ALLOWLIST) {
+		const value = process.env[key];
+		if (typeof value === "string") childEnv[key] = value;
+	}
+	return {
+		...childEnv,
+		...(configEnv ? resolveEnv(configEnv) : {}),
+	};
+}
+
+export function _buildMcpTrustConfirmOptionsForTest(signal?: AbortSignal): { timeout: number; signal?: AbortSignal } {
+	return signal ? { timeout: 120_000, signal } : { timeout: 120_000 };
+}
+
+async function assertTrustedStdioServer(
+	config: McpServerConfig,
+	ctx?: ExtensionContext,
+	signal?: AbortSignal,
+): Promise<string | undefined> {
+	if (config.transport !== "stdio") return undefined;
+	const trustKey = stdioTrustKey(config);
+	if (trustedStdioServers.has(trustKey)) return undefined;
+
+	if (!ctx?.hasUI) {
+		throw new Error(
+			`MCP server "${config.name}" is a project-local stdio command from ${config.sourcePath}. ` +
+			"Run this from an interactive GSD session and approve the server before use.",
+		);
+	}
+
+	const commandLine = [config.command, ...(config.args ?? [])].filter(Boolean).join(" ");
+	const envKeys = Object.keys(config.env ?? {});
+	const envSummary = envKeys.length > 0
+		? `\n\nConfigured environment keys: ${envKeys.join(", ")}`
+		: "\n\nNo explicit environment keys configured.";
+	const approved = await ctx.ui.confirm(
+		`Trust MCP server "${config.name}"?`,
+		`Project config ${config.sourcePath} wants to start:\n\n${commandLine}${envSummary}\n\nOnly approve MCP servers you trust.`,
+		_buildMcpTrustConfirmOptionsForTest(signal),
+	);
+	if (!approved) {
+		throw new Error(`MCP server "${config.name}" was not approved by the user.`);
+	}
+	return trustKey;
 }
 
 function getServerConfig(name: string): McpServerConfig | undefined {
@@ -145,7 +227,7 @@ function resolveEnv(env: Record<string, string>): Record<string, string> {
 	return resolved;
 }
 
-async function getOrConnect(name: string, signal?: AbortSignal): Promise<Client> {
+async function getOrConnect(name: string, signal?: AbortSignal, ctx?: ExtensionContext): Promise<Client> {
 	const config = getServerConfig(name);
 	if (!config) throw new Error(`Unknown MCP server: "${name}". Use mcp_servers to list available servers.`);
 
@@ -154,14 +236,29 @@ async function getOrConnect(name: string, signal?: AbortSignal): Promise<Client>
 	const existing = connections.get(config.name);
 	if (existing) return existing.client;
 
+	const pending = pendingConnections.get(config.name);
+	if (pending) return pending;
+
+	const connectionPromise = connectServer(config, signal, ctx);
+	pendingConnections.set(config.name, connectionPromise);
+	try {
+		return await connectionPromise;
+	} finally {
+		pendingConnections.delete(config.name);
+	}
+}
+
+async function connectServer(config: McpServerConfig, signal?: AbortSignal, ctx?: ExtensionContext): Promise<Client> {
 	const client = new Client({ name: "gsd", version: "1.0.0" });
 	let transport: StdioClientTransport | StreamableHTTPClientTransport;
+	let approvedTrustKey: string | undefined;
 
 	if (config.transport === "stdio" && config.command) {
+		approvedTrustKey = await assertTrustedStdioServer(config, ctx, signal);
 		transport = new StdioClientTransport({
 			command: config.command,
 			args: config.args,
-			env: config.env ? { ...process.env, ...resolveEnv(config.env) } as Record<string, string> : undefined,
+			env: _buildMcpChildEnvForTest(config.env),
 			cwd: config.cwd,
 			stderr: "pipe",
 		});
@@ -179,9 +276,24 @@ async function getOrConnect(name: string, signal?: AbortSignal): Promise<Client>
 		throw new Error(`Server "${config.name}" has unsupported transport: ${config.transport}`);
 	}
 
-	await client.connect(transport, { signal, timeout: 30000 });
-	connections.set(config.name, { client, transport });
-	return client;
+	try {
+		await client.connect(transport, { signal, timeout: 30000 });
+		if (approvedTrustKey) trustedStdioServers.add(approvedTrustKey);
+		connections.set(config.name, { client, transport });
+		return client;
+	} catch (err) {
+		try {
+			await transport.close();
+		} catch {
+			// Best-effort cleanup after a failed or aborted connection attempt.
+		}
+		try {
+			await client.close();
+		} catch {
+			// Best-effort cleanup after a failed or aborted connection attempt.
+		}
+		throw err;
+	}
 }
 
 async function closeAll(): Promise<void> {
@@ -191,9 +303,16 @@ async function closeAll(): Promise<void> {
 		} catch {
 			// Best-effort cleanup
 		}
+		try {
+			await conn.transport.close();
+		} catch {
+			// Best-effort cleanup
+		}
 		connections.delete(name);
 	});
 	await Promise.allSettled(closing);
+	pendingConnections.clear();
+	trustedStdioServers.clear();
 	toolCache.clear();
 }
 
@@ -331,7 +450,7 @@ export default function (pi: ExtensionAPI) {
 			}),
 		}),
 
-		async execute(_id, params, signal) {
+		async execute(_id, params, signal, _onUpdate, ctx) {
 			try {
 				// Return cached tools if available
 				const cached = toolCache.get(params.server);
@@ -348,7 +467,7 @@ export default function (pi: ExtensionAPI) {
 					};
 				}
 
-				const client = await getOrConnect(params.server, signal);
+				const client = await getOrConnect(params.server, signal, ctx);
 				const result = await client.listTools(undefined, { signal, timeout: 30000 });
 				const tools: McpToolSchema[] = (result.tools ?? []).map((t) => ({
 					name: t.name,
@@ -423,9 +542,9 @@ export default function (pi: ExtensionAPI) {
 			),
 		}),
 
-		async execute(_id, params, signal) {
+		async execute(_id, params, signal, _onUpdate, ctx) {
 			try {
-				const client = await getOrConnect(params.server, signal);
+				const client = await getOrConnect(params.server, signal, ctx);
 				const result = await client.callTool(
 					{ name: params.tool, arguments: params.args ?? {} },
 					undefined,

--- a/src/tests/vscode-startup-security.test.ts
+++ b/src/tests/vscode-startup-security.test.ts
@@ -1,0 +1,15 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const extensionSource = readFileSync(join(process.cwd(), "vscode-extension", "src", "extension.ts"), "utf-8");
+
+test("VS Code startup uses inspected global/default config for binary path and auto-start", () => {
+  assert.match(extensionSource, /inspect<T>\(key\)/);
+  assert.match(extensionSource, /globalValue \?\? inspected\?\.defaultValue/);
+  assert.match(extensionSource, /binaryPath:\s*getTrustedConfigurationValue\("gsd",\s*"binaryPath",\s*"gsd"\)/);
+  assert.match(extensionSource, /autoStart:\s*getTrustedConfigurationValue\("gsd",\s*"autoStart",\s*false\)/);
+  assert.doesNotMatch(extensionSource, /config\.get<string>\("binaryPath"/);
+  assert.doesNotMatch(extensionSource, /config\.get<boolean>\("autoStart"/);
+});

--- a/src/tests/web-files-symlink.test.ts
+++ b/src/tests/web-files-symlink.test.ts
@@ -1,0 +1,45 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { resolveSecurePath } from "../../web/lib/secure-path.ts";
+
+test("web file API resolves normal project files under the canonical root", () => {
+  const root = mkdtempSync(join(tmpdir(), "gsd-web-root-"));
+  try {
+    writeFileSync(join(root, "inside.txt"), "inside");
+
+    assert.equal(resolveSecurePath("inside.txt", root), join(realpathSync.native(root), "inside.txt"));
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("web file API rejects symlinks that resolve outside the project root", () => {
+  const root = mkdtempSync(join(tmpdir(), "gsd-web-root-"));
+  const outside = mkdtempSync(join(tmpdir(), "gsd-web-outside-"));
+  try {
+    writeFileSync(join(outside, "secret.txt"), "secret");
+    symlinkSync(join(outside, "secret.txt"), join(root, "linked-secret.txt"));
+
+    assert.equal(resolveSecurePath("linked-secret.txt", root), null);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+    rmSync(outside, { recursive: true, force: true });
+  }
+});
+
+test("web file API rejects writes through symlinked parent directories outside root", () => {
+  const root = mkdtempSync(join(tmpdir(), "gsd-web-root-"));
+  const outside = mkdtempSync(join(tmpdir(), "gsd-web-outside-"));
+  try {
+    symlinkSync(outside, join(root, "linked-outside"), "dir");
+
+    assert.equal(resolveSecurePath("linked-outside/new.txt", root), null);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+    rmSync(outside, { recursive: true, force: true });
+  }
+});

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -28,6 +28,19 @@ let lineDecorations: GsdLineDecorationManager | undefined;
 let gitIntegration: GsdGitIntegration | undefined;
 let permissionManager: GsdPermissionManager | undefined;
 
+function getTrustedConfigurationValue<T>(section: string, key: string, fallback: T): T {
+	const config = vscode.workspace.getConfiguration(section);
+	const inspected = config.inspect<T>(key);
+	return inspected?.globalValue ?? inspected?.defaultValue ?? fallback;
+}
+
+export function resolveTrustedGsdStartupConfig(): { binaryPath: string; autoStart: boolean } {
+	return {
+		binaryPath: getTrustedConfigurationValue("gsd", "binaryPath", "gsd"),
+		autoStart: getTrustedConfigurationValue("gsd", "autoStart", false),
+	};
+}
+
 function requireConnected(): boolean {
 	if (!client?.isConnected) {
 		vscode.window.showWarningMessage("GSD agent is not running.");
@@ -42,8 +55,9 @@ function handleError(err: unknown, context: string): void {
 }
 
 export function activate(context: vscode.ExtensionContext): void {
+	const startupConfig = resolveTrustedGsdStartupConfig();
 	const config = vscode.workspace.getConfiguration("gsd");
-	const binaryPath = config.get<string>("binaryPath", "gsd");
+	const binaryPath = startupConfig.binaryPath;
 	const cwd = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath ?? process.cwd();
 
 	client = new GsdClient(binaryPath, cwd);
@@ -960,7 +974,7 @@ export function activate(context: vscode.ExtensionContext): void {
 
 	// -- Auto-start ---------------------------------------------------------
 
-	if (config.get<boolean>("autoStart", false)) {
+	if (startupConfig.autoStart) {
 		vscode.commands.executeCommand("gsd.start");
 	}
 }

--- a/web/app/api/files/route.ts
+++ b/web/app/api/files/route.ts
@@ -1,7 +1,8 @@
 import { existsSync, mkdirSync, readdirSync, readFileSync, renameSync, rmSync, statSync, writeFileSync } from "node:fs";
-import { join, resolve, relative, dirname, basename } from "node:path";
+import { join, dirname } from "node:path";
 
 import { requireProjectCwd } from "../../../../src/web/bridge-service.ts";
+import { resolveSecurePath } from "../../../lib/secure-path.ts";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -41,27 +42,6 @@ function getGsdRoot(projectCwd: string): string {
 
 function getRootForMode(mode: RootMode, projectCwd: string): string {
   return mode === "project" ? projectCwd : getGsdRoot(projectCwd);
-}
-
-/**
- * Validate and resolve a requested path against the given root directory.
- * Returns the resolved absolute path or null if the path is invalid.
- */
-function resolveSecurePath(requestedPath: string, root: string): string | null {
-  if (requestedPath.startsWith("/") || requestedPath.startsWith("\\")) {
-    return null;
-  }
-  if (requestedPath.includes("..")) {
-    return null;
-  }
-
-  const resolved = resolve(root, requestedPath);
-  const rel = relative(root, resolved);
-  if (rel.startsWith("..") || resolve(root, rel) !== resolved) {
-    return null;
-  }
-
-  return resolved;
 }
 
 function buildTree(dirPath: string, skipDirs?: Set<string>, depth = 0, maxDepth = Infinity): FileNode[] {

--- a/web/lib/secure-path.ts
+++ b/web/lib/secure-path.ts
@@ -1,0 +1,48 @@
+import { existsSync, realpathSync } from "node:fs";
+import { dirname, isAbsolute, relative, resolve } from "node:path";
+
+function isWithinRoot(rootRealPath: string, candidateRealPath: string): boolean {
+  const rel = relative(rootRealPath, candidateRealPath);
+  return rel === "" || (!rel.startsWith("..") && !isAbsolute(rel));
+}
+
+/**
+ * Validate and resolve a requested path against the given root directory.
+ * Returns the resolved absolute path or null if the path is invalid.
+ */
+export function resolveSecurePath(requestedPath: string, root: string, options: { mustExist?: boolean } = {}): string | null {
+  if (requestedPath.startsWith("/") || requestedPath.startsWith("\\")) {
+    return null;
+  }
+  if (requestedPath.includes("..")) {
+    return null;
+  }
+
+  let rootRealPath: string;
+  try {
+    rootRealPath = realpathSync.native(root);
+  } catch {
+    return null;
+  }
+
+  const resolved = resolve(rootRealPath, requestedPath);
+  const rel = relative(rootRealPath, resolved);
+  if (rel.startsWith("..") || isAbsolute(rel)) {
+    return null;
+  }
+
+  try {
+    if (existsSync(resolved)) {
+      const targetRealPath = realpathSync.native(resolved);
+      if (!isWithinRoot(rootRealPath, targetRealPath)) return null;
+    } else {
+      if (options.mustExist) return null;
+      const parentRealPath = realpathSync.native(dirname(resolved));
+      if (!isWithinRoot(rootRealPath, parentRealPath)) return null;
+    }
+  } catch {
+    return null;
+  }
+
+  return resolved;
+}


### PR DESCRIPTION
## Summary
- require interactive approval before starting project-configured MCP stdio servers and stop inheriting the full parent environment
- constrain secure env collection and web file operations to canonical project roots, including symlink traversal defenses
- ignore workspace-scoped VS Code startup settings for binary path and auto-start decisions

## Validation
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test packages/mcp-server/src/env-writer.test.ts src/resources/extensions/gsd/tests/mcp-client-security.test.ts src/tests/web-files-symlink.test.ts src/tests/vscode-startup-security.test.ts`
- `git diff --check`

## Notes
- `npm run typecheck:extensions` is currently blocked locally by unresolved internal packages such as `@gsd/pi-coding-agent`, which causes a repo-wide cascade of existing extension type errors.
- `npm run test:compile` is currently blocked locally because `node_modules/esbuild` is missing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Connection deduplication for concurrent calls to the same server.
  * Confirmation flow for local stdio servers; approvals are remembered.
  * New safe path resolver for web file requests.

* **Bug Fixes**
  * Stronger symlink/traversal protections and confined env-file resolution.
  * Atomic, permission-restricted writes when updating env files.
  * Child-process env now built from an allowlist (sanitized).

* **Documentation**
  * MCP docs updated to document secure_env_collect via form elicitation.

* **Tests**
  * Added coverage for symlink escapes, client lifecycle, and startup config.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->