### PR TITLE
fix(auto): harden workflow state transitions

### DIFF
--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -33,7 +33,8 @@ import { parseRoadmap } from "./parsers-legacy.js";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { logWarning, logError } from "./workflow-logger.js";
 import { join } from "node:path";
-import { hasImplementationArtifacts, classifyMilestoneSummaryContent } from "./auto-recovery.js";
+import { hasImplementationArtifacts } from "./auto-recovery.js";
+import { classifyMilestoneSummaryContent } from "./milestone-summary-classifier.js";
 import {
   buildDiscussMilestonePrompt,
   buildResearchMilestonePrompt,

--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -905,7 +905,7 @@ export const DISPATCH_RULES: DispatchRule[] = [
 
       const existingSummary = resolveMilestoneFile(basePath, mid, "SUMMARY");
       let summaryOutcome: "success" | "failure" | "unknown" = "unknown";
-      if (existingSummary && isDbAvailable()) {
+      if (existingSummary) {
         const summaryContent = await loadFile(existingSummary);
         if (summaryContent) {
           summaryOutcome = classifyMilestoneSummaryContent(summaryContent);
@@ -999,11 +999,15 @@ export const DISPATCH_RULES: DispatchRule[] = [
       // - success summary: reconcile DB and skip re-dispatch
       // - failure summary: pause/fail-closed
       // - unknown summary: pause/fail-closed
-      if (existingSummary && isDbAvailable()) {
-        const milestone = getMilestone(mid);
-        const status = milestone?.status ?? "missing";
+      if (existingSummary) {
+        const milestone = isDbAvailable() ? getMilestone(mid) : null;
+        const status = milestone?.status ?? (isDbAvailable() ? "missing" : "unavailable");
 
         if (summaryOutcome === "success") {
+          if (!isDbAvailable()) {
+            logWarning("dispatch", `Milestone ${mid} SUMMARY indicates completion while DB is unavailable — skipping duplicate complete-milestone dispatch`);
+            return { action: "skip" };
+          }
           try {
             updateMilestoneStatus(mid, "complete", new Date().toISOString());
             logWarning("dispatch", `Milestone ${mid} SUMMARY indicates completion while DB status was "${status}" — reconciled DB to complete (#4658)`);

--- a/src/resources/extensions/gsd/auto-recovery.ts
+++ b/src/resources/extensions/gsd/auto-recovery.ts
@@ -17,7 +17,6 @@ import { isDbAvailable, getTask, getSlice, getSliceTasks, getPendingGates, updat
 import { isValidationTerminal } from "./state.js";
 import { getErrorMessage } from "./error-utils.js";
 import { logWarning, logError } from "./workflow-logger.js";
-import { splitFrontmatter, parseFrontmatterMap } from "./files.js";
 import { isClosedStatus } from "./status-guards.js";
 import {
   nativeConflictFiles,
@@ -52,35 +51,14 @@ import {
   resolveExpectedArtifactPath,
   diagnoseExpectedArtifact,
 } from "./auto-artifact-paths.js";
+import { classifyMilestoneSummaryContent } from "./milestone-summary-classifier.js";
 
 // Re-export so existing consumers of auto-recovery.ts keep working.
 export { resolveExpectedArtifactPath, diagnoseExpectedArtifact };
-
-export type MilestoneSummaryOutcome = "success" | "failure" | "unknown";
-
-/**
- * Classify milestone summary content for recovery/dispatch decisions.
- * - success: canonical completion summary (frontmatter status is closed)
- * - failure: explicit blocker/failure markers
- * - unknown: ambiguous content
- */
-export function classifyMilestoneSummaryContent(content: string): MilestoneSummaryOutcome {
-  const [fmLines] = splitFrontmatter(content);
-  const fm = fmLines ? parseFrontmatterMap(fmLines) : null;
-  const rawStatus = typeof fm?.status === "string" ? fm.status.trim().toLowerCase() : "";
-  if (rawStatus) {
-    if (isClosedStatus(rawStatus)) return "success";
-    if (["active", "pending", "blocked", "failed", "incomplete"].includes(rawStatus)) return "failure";
-  }
-
-  const failureSignal =
-    /(?:^|\n)\s*#\s*BLOCKER\b/i.test(content)
-    || /auto-mode recovery failed/i.test(content)
-    || /verification\s+failed/i.test(content)
-    || /\bnot complete\b/i.test(content);
-  if (failureSignal) return "failure";
-  return "unknown";
-}
+export {
+  classifyMilestoneSummaryContent,
+  type MilestoneSummaryOutcome,
+} from "./milestone-summary-classifier.js";
 
 // ─── Artifact Resolution & Verification ───────────────────────────────────────
 

--- a/src/resources/extensions/gsd/auto-start.ts
+++ b/src/resources/extensions/gsd/auto-start.ts
@@ -446,7 +446,7 @@ export async function bootstrapAutoSession(
         try {
           return classifyMilestoneSummaryContent(readFileSync(summaryFile, "utf-8")) !== "failure";
         } catch {
-          return true;
+          return false;
         }
       },
     );

--- a/src/resources/extensions/gsd/auto-start.ts
+++ b/src/resources/extensions/gsd/auto-start.ts
@@ -62,6 +62,7 @@ import { resetProactiveHealing, setLevelChangeCallback } from "./doctor-proactiv
 import { snapshotSkills } from "./skill-discovery.js";
 import { isDbAvailable, getMilestone, openDatabase, getDbStatus } from "./gsd-db.js";
 import { isClosedStatus } from "./status-guards.js";
+import { classifyMilestoneSummaryContent } from "./milestone-summary-classifier.js";
 
 import {
   debugLog,
@@ -75,6 +76,7 @@ import type { AutoSession } from "./auto/session.js";
 import {
   existsSync,
   mkdirSync,
+  readFileSync,
   readdirSync,
   rmSync,
   statSync,
@@ -439,7 +441,13 @@ export async function bootstrapAutoSession(
           const row = getMilestone(mid);
           return !!row && isClosedStatus(row.status);
         }
-        return !!resolveMilestoneFile(base, mid, "SUMMARY");
+        const summaryFile = resolveMilestoneFile(base, mid, "SUMMARY");
+        if (!summaryFile) return false;
+        try {
+          return classifyMilestoneSummaryContent(readFileSync(summaryFile, "utf-8")) !== "failure";
+        } catch {
+          return true;
+        }
       },
     );
 

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -1425,7 +1425,7 @@ export async function startAuto(
             try {
               summaryIsTerminal = classifyMilestoneSummaryContent(readFileSync(summaryFile, "utf-8")) !== "failure";
             } catch {
-              summaryIsTerminal = true;
+              summaryIsTerminal = false;
             }
           }
           if (!mDir || summaryIsTerminal) {

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -169,6 +169,7 @@ import {
   buildLoopRemediationSteps,
   reconcileMergeState,
 } from "./auto-recovery.js";
+import { classifyMilestoneSummaryContent } from "./milestone-summary-classifier.js";
 import { resolveDispatch, DISPATCH_RULES } from "./auto-dispatch.js";
 import { getErrorMessage } from "./error-utils.js";
 import { recoverFailedMigration } from "./migrate-external.js";
@@ -1419,7 +1420,15 @@ export async function startAuto(
           // Validate the milestone still exists and isn't already complete (#1664).
           const mDir = resolveMilestonePath(base, meta.milestoneId);
           const summaryFile = resolveMilestoneFile(base, meta.milestoneId, "SUMMARY");
-          if (!mDir || summaryFile) {
+          let summaryIsTerminal = false;
+          if (summaryFile) {
+            try {
+              summaryIsTerminal = classifyMilestoneSummaryContent(readFileSync(summaryFile, "utf-8")) !== "failure";
+            } catch {
+              summaryIsTerminal = true;
+            }
+          }
+          if (!mDir || summaryIsTerminal) {
             try { unlinkSync(pausedPath); } catch (err) {
               if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
                 logWarning("session", `pause file cleanup failed: ${err instanceof Error ? err.message : String(err)}`, { file: "auto.ts" });

--- a/src/resources/extensions/gsd/auto/loop.ts
+++ b/src/resources/extensions/gsd/auto/loop.ts
@@ -32,6 +32,7 @@ import { isInfrastructureError, isTransientCooldownError, getCooldownRetryAfterM
 import { resolveEngine } from "../engine-resolver.js";
 import { logWarning } from "../workflow-logger.js";
 import { gsdRoot } from "../paths.js";
+import { atomicWriteSync } from "../atomic-write.js";
 import { resolveUokFlags } from "../uok/flags.js";
 import { scheduleSidecarQueue } from "../uok/execution-graph.js";
 import { ExecutionGraphScheduler } from "../uok/execution-graph.js";
@@ -126,7 +127,7 @@ function saveCustomVerifyRetryCounts(s: AutoSession): void {
       return;
     }
     mkdirSync(customVerifyRetryStateDir(s), { recursive: true });
-    writeFileSync(filePath, JSON.stringify({
+    atomicWriteSync(filePath, JSON.stringify({
       counts: Object.fromEntries(retryCounts),
       updatedAt: new Date().toISOString(),
     }) + "\n");

--- a/src/resources/extensions/gsd/auto/loop.ts
+++ b/src/resources/extensions/gsd/auto/loop.ts
@@ -36,7 +36,7 @@ import { resolveUokFlags } from "../uok/flags.js";
 import { scheduleSidecarQueue } from "../uok/execution-graph.js";
 import { ExecutionGraphScheduler } from "../uok/execution-graph.js";
 import type { UokGraphNode } from "../uok/contracts.js";
-import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { readFileSync, writeFileSync, mkdirSync, unlinkSync } from "node:fs";
 import { join } from "node:path";
 
 // ── Stuck detection persistence (#3704) ──────────────────────────────────
@@ -79,6 +79,62 @@ function saveStuckState(basePath: string, state: LoopState): void {
     }) + "\n");
   } catch (err) {
     debugLog("autoLoop", { phase: "save-stuck-state-failed", error: err instanceof Error ? err.message : String(err) });
+  }
+}
+
+// ── Custom workflow verification retry persistence ───────────────────────
+// Custom workflows can request verification retries after a step runs. The
+// retry budget must survive an auto-mode restart or a failing verifier can
+// consume a fresh retry budget every session.
+function customVerifyRetryStateDir(s: Pick<AutoSession, "activeRunDir" | "basePath">): string {
+  return s.activeRunDir ? join(s.activeRunDir, "runtime") : join(gsdRoot(s.basePath), "runtime");
+}
+
+function customVerifyRetryStatePath(s: Pick<AutoSession, "activeRunDir" | "basePath">): string {
+  return join(customVerifyRetryStateDir(s), "custom-verify-retries.json");
+}
+
+function hydrateCustomVerifyRetryCounts(s: AutoSession): Map<string, number> {
+  if (s.verificationRetryCount.size > 0) {
+    return s.verificationRetryCount;
+  }
+
+  try {
+    const raw = JSON.parse(readFileSync(customVerifyRetryStatePath(s), "utf-8"));
+    const counts = raw && typeof raw === "object" && raw.counts && typeof raw.counts === "object"
+      ? raw.counts as Record<string, unknown>
+      : {};
+    for (const [key, value] of Object.entries(counts)) {
+      if (typeof value === "number" && Number.isFinite(value) && value > 0) {
+        s.verificationRetryCount.set(key, Math.floor(value));
+      }
+    }
+  } catch (err) {
+    debugLog("autoLoop", { phase: "load-custom-verify-retries-failed", error: err instanceof Error ? err.message : String(err) });
+  }
+
+  return s.verificationRetryCount;
+}
+
+function saveCustomVerifyRetryCounts(s: AutoSession): void {
+  const retryCounts = s.verificationRetryCount;
+  const filePath = customVerifyRetryStatePath(s);
+
+  try {
+    if (!retryCounts || retryCounts.size === 0) {
+      unlinkSync(filePath);
+      return;
+    }
+    mkdirSync(customVerifyRetryStateDir(s), { recursive: true });
+    writeFileSync(filePath, JSON.stringify({
+      counts: Object.fromEntries(retryCounts),
+      updatedAt: new Date().toISOString(),
+    }) + "\n");
+  } catch (err) {
+    const code = err && typeof err === "object" && "code" in err ? (err as { code?: string }).code : undefined;
+    if (code !== "ENOENT") {
+      debugLog("autoLoop", { phase: "save-custom-verify-retries-failed", error: err instanceof Error ? err.message : String(err) });
+    }
   }
 }
 
@@ -439,9 +495,10 @@ export async function autoLoop(
         }
         if (verifyResult === "retry") {
           const recoveryKey = `${iterData.unitType}/${iterData.unitId}`;
-          const retryCounts = s.verificationRetryCount ?? s.unitRecoveryCount;
+          const retryCounts = hydrateCustomVerifyRetryCounts(s);
           const attempts = (retryCounts.get(recoveryKey) ?? 0) + 1;
           retryCounts.set(recoveryKey, attempts);
+          saveCustomVerifyRetryCounts(s);
           debugLog("autoLoop", { phase: "custom-engine-verify-retry", iteration, unitId: iterData.unitId, attempts });
           deps.uokObserver?.onPhaseResult("custom-engine", "retry", {
             unitType: iterData.unitType,
@@ -481,6 +538,7 @@ export async function autoLoop(
 
         // Verification passed — mark step complete
         s.verificationRetryCount?.delete(`${iterData.unitType}/${iterData.unitId}`);
+        saveCustomVerifyRetryCounts(s);
         debugLog("autoLoop", { phase: "custom-engine-reconcile", iteration, unitId: iterData.unitId });
         const reconcileResult = await engine.reconcile(engineState, {
           unitType: iterData.unitType,

--- a/src/resources/extensions/gsd/auto/loop.ts
+++ b/src/resources/extensions/gsd/auto/loop.ts
@@ -88,6 +88,7 @@ function saveStuckState(basePath: string, state: LoopState): void {
 // limit (--max-old-space-size or default ~1.5-4GB depending on platform).
 const MEMORY_CHECK_INTERVAL = 5; // check every 5 iterations
 const MEMORY_PRESSURE_THRESHOLD = 0.85; // 85% of heap limit
+const MAX_CUSTOM_ENGINE_VERIFY_RETRIES = 3;
 
 type DispatchContract = "legacy-direct" | "uok-scheduler";
 
@@ -437,16 +438,49 @@ export async function autoLoop(
           break;
         }
         if (verifyResult === "retry") {
-          debugLog("autoLoop", { phase: "custom-engine-verify-retry", iteration, unitId: iterData.unitId });
+          const recoveryKey = `${iterData.unitType}/${iterData.unitId}`;
+          const retryCounts = s.verificationRetryCount ?? s.unitRecoveryCount;
+          const attempts = (retryCounts.get(recoveryKey) ?? 0) + 1;
+          retryCounts.set(recoveryKey, attempts);
+          debugLog("autoLoop", { phase: "custom-engine-verify-retry", iteration, unitId: iterData.unitId, attempts });
           deps.uokObserver?.onPhaseResult("custom-engine", "retry", {
             unitType: iterData.unitType,
             unitId: iterData.unitId,
+            attempts,
           });
+          if (attempts > MAX_CUSTOM_ENGINE_VERIFY_RETRIES) {
+            const recovery = await policy.recover(iterData.unitType, iterData.unitId, { basePath: s.basePath });
+            if (recovery.outcome === "pause") {
+              await deps.pauseAuto(ctx, pi);
+              finishTurn("paused", "manual-attention", recovery.reason ?? "custom-engine-verify-retry-exhausted");
+              break;
+            }
+            if (recovery.outcome === "skip") {
+              await deps.stopAuto(
+                ctx,
+                pi,
+                recovery.reason ??
+                  `Custom workflow verification for ${iterData.unitId} requested skip after retry exhaustion, but the custom engine cannot reconcile skipped steps.`,
+              );
+              finishTurn("stopped", "manual-attention", "custom-engine-verify-retry-exhausted");
+              break;
+            }
+            const exhaustedReason =
+              `Custom workflow verification for ${iterData.unitId} requested retry ${attempts} times without passing.`;
+            await deps.stopAuto(
+              ctx,
+              pi,
+              recovery.outcome === "stop" && recovery.reason ? recovery.reason : exhaustedReason,
+            );
+            finishTurn("stopped", "manual-attention", "custom-engine-verify-retry-exhausted");
+            break;
+          }
           finishTurn("retry");
           continue;
         }
 
         // Verification passed — mark step complete
+        s.verificationRetryCount?.delete(`${iterData.unitType}/${iterData.unitId}`);
         debugLog("autoLoop", { phase: "custom-engine-reconcile", iteration, unitId: iterData.unitId });
         const reconcileResult = await engine.reconcile(engineState, {
           unitType: iterData.unitType,

--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -1680,9 +1680,23 @@ export async function runUnitPhase(
 
   if (unitResult.status === "cancelled") {
     const errorCategory = unitResult.errorContext?.category;
-    // Provider-error pause: pauseAuto already handled cleanup and scheduled
-    // recovery. Don't hard-stop — just break out of the loop (#2762).
+    // Provider-error pause: agent_end recovery normally pauses before this
+    // branch. Provider readiness failures happen before dispatch, so pause here
+    // if nothing upstream already did.
     if (errorCategory === "provider") {
+      if (!s.paused) {
+        const detail = unitResult.errorContext?.message ?? `Provider unavailable for ${unitType} ${unitId}`;
+        await pauseAutoForProviderError(
+          ctx.ui,
+          detail,
+          () => deps.pauseAuto(ctx, pi),
+          {
+            isRateLimit: false,
+            isTransient: Boolean(unitResult.errorContext?.isTransient),
+            retryAfterMs: unitResult.errorContext?.retryAfterMs,
+          },
+        );
+      }
       await emitCancelledUnitEnd(ic, unitType, unitId, unitStartSeq, unitResult.errorContext);
       debugLog("autoLoop", { phase: "exit", reason: "provider-pause", isTransient: unitResult.errorContext?.isTransient });
       return { action: "break", reason: "provider-pause" };

--- a/src/resources/extensions/gsd/dispatch-guard.ts
+++ b/src/resources/extensions/gsd/dispatch-guard.ts
@@ -6,26 +6,8 @@ import { parseUnitId } from "./unit-id.js";
 import { isDbAvailable, getMilestoneSlices, getMilestone } from "./gsd-db.js";
 import { parseRoadmap } from "./parsers-legacy.js";
 import { isClosedStatus } from "./status-guards.js";
+import { classifyMilestoneSummaryContent } from "./milestone-summary-classifier.js";
 import { readFileSync } from "node:fs";
-
-/**
- * Detect failure-path milestone SUMMARY content (#4663 sibling to #4658).
- * A failure SUMMARY must not let the dispatch guard treat an active
- * milestone as complete. The markers mirror those produced by
- * writeBlockerPlaceholder and the "verification FAILED" retry path.
- *
- * This is intentionally a minimal local detector so this fix does not
- * depend on PR #4660's `classifyMilestoneSummaryContent`. It can migrate
- * to the shared classifier once that lands.
- */
-function isFailureMilestoneSummary(content: string): boolean {
-  return (
-    /(?:^|\n)\s*#\s*BLOCKER\b/i.test(content) ||
-    /auto-mode recovery failed/i.test(content) ||
-    /verification\s+failed/i.test(content) ||
-    /\bnot complete\b/i.test(content)
-  );
-}
 
 const SLICE_DISPATCH_TYPES = new Set([
   "research-slice",
@@ -86,7 +68,7 @@ export function getPriorSliceCompletionBlocker(
     if (summaryPath) {
       let summaryContent: string | null = null;
       try { summaryContent = readFileSync(summaryPath, "utf-8"); } catch { /* ignore */ }
-      if (!summaryContent || !isFailureMilestoneSummary(summaryContent)) {
+      if (!summaryContent || classifyMilestoneSummaryContent(summaryContent) !== "failure") {
         continue;
       }
     }

--- a/src/resources/extensions/gsd/milestone-summary-classifier.ts
+++ b/src/resources/extensions/gsd/milestone-summary-classifier.ts
@@ -27,7 +27,7 @@ export function classifyMilestoneSummaryContent(content: string): MilestoneSumma
     /(?:^|\n)\s*#\s*BLOCKER\b/i.test(content)
     || /auto-mode recovery failed/i.test(content)
     || /verification\s+failed/i.test(content)
-    || /\bnot complete\b/i.test(content);
+    || /(?:^|\n)\s*(?:status|verdict|outcome|result)\s*[:=-]\s*not complete\b/i.test(content);
   if (failureSignal) return "failure";
   return "unknown";
 }

--- a/src/resources/extensions/gsd/milestone-summary-classifier.ts
+++ b/src/resources/extensions/gsd/milestone-summary-classifier.ts
@@ -1,0 +1,42 @@
+/**
+ * Shared milestone SUMMARY classifier.
+ *
+ * SUMMARY presence alone is not enough to prove milestone completion: recovery
+ * and blocker paths also write SUMMARY files. Keep this leaf module free of
+ * state/auto imports so state derivation, dispatch guards, and recovery can
+ * share one definition without cycles.
+ */
+
+import { splitFrontmatter, parseFrontmatterMap } from "../shared/frontmatter.js";
+import { isClosedStatus } from "./status-guards.js";
+
+export type MilestoneSummaryOutcome = "success" | "failure" | "unknown";
+
+export function classifyMilestoneSummaryContent(content: string): MilestoneSummaryOutcome {
+  const [fmLines] = splitFrontmatter(content);
+  const fm = fmLines ? parseFrontmatterMap(fmLines) : null;
+  const rawStatus = typeof fm?.status === "string" ? fm.status.trim().toLowerCase() : "";
+  if (rawStatus) {
+    if (isClosedStatus(rawStatus)) return "success";
+    if (["active", "pending", "blocked", "failed", "failure", "incomplete"].includes(rawStatus)) {
+      return "failure";
+    }
+  }
+
+  const failureSignal =
+    /(?:^|\n)\s*#\s*BLOCKER\b/i.test(content)
+    || /auto-mode recovery failed/i.test(content)
+    || /verification\s+failed/i.test(content)
+    || /\bnot complete\b/i.test(content);
+  if (failureSignal) return "failure";
+  return "unknown";
+}
+
+/**
+ * Legacy-compatible terminal check for state derivation.
+ * Unknown summaries remain terminal to preserve old handwritten SUMMARY files;
+ * explicit failure summaries do not.
+ */
+export function isTerminalMilestoneSummaryContent(content: string): boolean {
+  return classifyMilestoneSummaryContent(content) !== "failure";
+}

--- a/src/resources/extensions/gsd/state.ts
+++ b/src/resources/extensions/gsd/state.ts
@@ -677,12 +677,32 @@ function resolveSliceDependencies(activeMilestoneSlices: SliceRow[]): { activeSl
     }
   }
 
+  let bestFallback: SliceRow | null = null;
+  let bestFallbackSatisfied = -1;
+
   for (const s of activeMilestoneSlices) {
     if (isStatusDone(s.status)) continue;
     if (isDeferredStatus(s.status)) continue;
     if (s.depends.every(dep => doneSliceIds.has(dep))) {
       return { activeSlice: { id: s.id, title: s.title }, activeSliceRow: s };
     }
+    const satisfied = s.depends.filter(dep => doneSliceIds.has(dep)).length;
+    if (satisfied > bestFallbackSatisfied || (satisfied === bestFallbackSatisfied && !bestFallback)) {
+      bestFallback = s;
+      bestFallbackSatisfied = satisfied;
+    }
+  }
+
+  if (bestFallback) {
+    const unmet = bestFallback.depends.filter(dep => !doneSliceIds.has(dep));
+    logWarning(
+      "state",
+      `No slice has all deps satisfied — falling back to ${bestFallback.id} ` +
+        `(${bestFallbackSatisfied}/${bestFallback.depends.length} deps met, ` +
+        `unmet: ${unmet.join(", ")})`,
+      { mid: activeMilestoneSlices[0]?.milestone_id, sid: bestFallback.id },
+    );
+    return { activeSlice: { id: bestFallback.id, title: bestFallback.title }, activeSliceRow: bestFallback };
   }
 
   return { activeSlice: null, activeSliceRow: null };
@@ -1549,12 +1569,31 @@ export async function _deriveStateImpl(basePath: string): Promise<GSDState> {
       };
     }
   } else {
+    let bestFallbackLegacy: { id: string; title: string; depends: string[] } | null = null;
+    let bestFallbackLegacySatisfied = -1;
+
     for (const s of activeRoadmap.slices) {
       if (s.done) continue;
       if (s.depends.every(dep => doneSliceIds.has(dep))) {
         activeSlice = { id: s.id, title: s.title };
         break;
       }
+      const satisfied = s.depends.filter(dep => doneSliceIds.has(dep)).length;
+      if (satisfied > bestFallbackLegacySatisfied) {
+        bestFallbackLegacy = s;
+        bestFallbackLegacySatisfied = satisfied;
+      }
+    }
+
+    if (!activeSlice && bestFallbackLegacy) {
+      const unmet = bestFallbackLegacy.depends.filter(dep => !doneSliceIds.has(dep));
+      logWarning(
+        "state",
+        `No slice has all deps satisfied — falling back to ${bestFallbackLegacy.id} ` +
+          `(${bestFallbackLegacySatisfied}/${bestFallbackLegacy.depends.length} deps met, ` +
+          `unmet: ${unmet.join(", ")})`,
+      );
+      activeSlice = { id: bestFallbackLegacy.id, title: bestFallbackLegacy.title };
     }
   }
 

--- a/src/resources/extensions/gsd/state.ts
+++ b/src/resources/extensions/gsd/state.ts
@@ -145,7 +145,7 @@ async function isTerminalMilestoneSummaryFile(
   loader: (path: string) => Promise<string | null>,
 ): Promise<boolean> {
   const content = await loader(path);
-  return content == null || isTerminalMilestoneSummaryContent(content);
+  return content != null && isTerminalMilestoneSummaryContent(content);
 }
 
 // ─── State Derivation ──────────────────────────────────────────────────────
@@ -1185,7 +1185,7 @@ export async function _deriveStateImpl(basePath: string): Promise<GSDState> {
       const summaryFile = resolveMilestoneFile(basePath, mid, "SUMMARY");
       if (summaryFile) {
         const summaryContent = await cachedLoadFile(summaryFile);
-        if (!summaryContent || isTerminalMilestoneSummaryContent(summaryContent)) {
+        if (summaryContent != null && isTerminalMilestoneSummaryContent(summaryContent)) {
           const summaryTitle = summaryContent
             ? (parseSummary(summaryContent).title || mid)
             : mid;

--- a/src/resources/extensions/gsd/state.ts
+++ b/src/resources/extensions/gsd/state.ts
@@ -46,6 +46,7 @@ import { logWarning, logError } from './workflow-logger.js';
 import { extractVerdict } from './verdict-parser.js';
 import { loadEffectiveGSDPreferences } from './preferences.js';
 import { detectPendingEscalation } from './escalation.js';
+import { isTerminalMilestoneSummaryContent } from './milestone-summary-classifier.js';
 
 import {
   isDbAvailable,
@@ -139,23 +140,6 @@ export function isValidationTerminal(validationContent: string): boolean {
   return extractVerdict(validationContent) != null;
 }
 
-function isTerminalMilestoneSummaryContent(content: string): boolean {
-  const summary = parseSummary(content);
-  const rawStatus = typeof summary.frontmatter.status === 'string'
-    ? summary.frontmatter.status.trim().toLowerCase()
-    : '';
-  if (['active', 'pending', 'blocked', 'failed', 'failure', 'incomplete'].includes(rawStatus)) {
-    return false;
-  }
-
-  return !(
-    /(?:^|\n)\s*#\s*BLOCKER\b/i.test(content) ||
-    /auto-mode recovery failed/i.test(content) ||
-    /verification\s+failed/i.test(content) ||
-    /\bnot complete\b/i.test(content)
-  );
-}
-
 async function isTerminalMilestoneSummaryFile(
   path: string,
   loader: (path: string) => Promise<string | null>,
@@ -241,10 +225,10 @@ export async function getActiveMilestoneId(basePath: string): Promise<string | n
       return mid;
     }
     const roadmap = parseRoadmap(content);
-    if (!isMilestoneComplete(roadmap)) {
-      const summaryFile = resolveMilestoneFile(basePath, mid, "SUMMARY");
-      if (!summaryFile || !(await isTerminalMilestoneSummaryFile(summaryFile, loadFile))) return mid;
-    }
+    const summaryFile = resolveMilestoneFile(basePath, mid, "SUMMARY");
+    if (summaryFile && await isTerminalMilestoneSummaryFile(summaryFile, loadFile)) continue;
+    if (!isMilestoneComplete(roadmap)) return mid;
+    return mid;
   }
   return null;
 }

--- a/src/resources/extensions/gsd/state.ts
+++ b/src/resources/extensions/gsd/state.ts
@@ -139,6 +139,31 @@ export function isValidationTerminal(validationContent: string): boolean {
   return extractVerdict(validationContent) != null;
 }
 
+function isTerminalMilestoneSummaryContent(content: string): boolean {
+  const summary = parseSummary(content);
+  const rawStatus = typeof summary.frontmatter.status === 'string'
+    ? summary.frontmatter.status.trim().toLowerCase()
+    : '';
+  if (['active', 'pending', 'blocked', 'failed', 'failure', 'incomplete'].includes(rawStatus)) {
+    return false;
+  }
+
+  return !(
+    /(?:^|\n)\s*#\s*BLOCKER\b/i.test(content) ||
+    /auto-mode recovery failed/i.test(content) ||
+    /verification\s+failed/i.test(content) ||
+    /\bnot complete\b/i.test(content)
+  );
+}
+
+async function isTerminalMilestoneSummaryFile(
+  path: string,
+  loader: (path: string) => Promise<string | null>,
+): Promise<boolean> {
+  const content = await loader(path);
+  return content == null || isTerminalMilestoneSummaryContent(content);
+}
+
 // ─── State Derivation ──────────────────────────────────────────────────────
 
 // ── deriveState memoization ─────────────────────────────────────────────────
@@ -211,14 +236,14 @@ export async function getActiveMilestoneId(basePath: string): Promise<string | n
     const content = roadmapFile ? await loadFile(roadmapFile) : null;
     if (!content) {
       const summaryFile = resolveMilestoneFile(basePath, mid, "SUMMARY");
-      if (summaryFile) continue;
+      if (summaryFile && await isTerminalMilestoneSummaryFile(summaryFile, loadFile)) continue;
       if (isGhostMilestone(basePath, mid)) continue;
       return mid;
     }
     const roadmap = parseRoadmap(content);
     if (!isMilestoneComplete(roadmap)) {
       const summaryFile = resolveMilestoneFile(basePath, mid, "SUMMARY");
-      if (!summaryFile) return mid;
+      if (!summaryFile || !(await isTerminalMilestoneSummaryFile(summaryFile, loadFile))) return mid;
     }
   }
   return null;
@@ -668,37 +693,12 @@ function resolveSliceDependencies(activeMilestoneSlices: SliceRow[]): { activeSl
     }
   }
 
-  // First pass: find a slice with ALL dependencies satisfied (strict)
-  let bestFallback: SliceRow | null = null;
-  let bestFallbackSatisfied = -1;
-
   for (const s of activeMilestoneSlices) {
     if (isStatusDone(s.status)) continue;
     if (isDeferredStatus(s.status)) continue;
     if (s.depends.every(dep => doneSliceIds.has(dep))) {
       return { activeSlice: { id: s.id, title: s.title }, activeSliceRow: s };
     }
-    // Track the slice with the most satisfied dependencies as fallback
-    const satisfied = s.depends.filter(dep => doneSliceIds.has(dep)).length;
-    if (satisfied > bestFallbackSatisfied || (satisfied === bestFallbackSatisfied && !bestFallback)) {
-      bestFallback = s;
-      bestFallbackSatisfied = satisfied;
-    }
-  }
-
-  // Fallback: if no slice has all deps met but there ARE incomplete non-deferred
-  // slices, pick the one with the most deps satisfied. This prevents hard-blocking
-  // when dependency metadata is stale (e.g. after reassessment added/removed slices)
-  // or when deps reference slices from previous milestones.
-  if (bestFallback) {
-    const unmet = bestFallback.depends.filter(dep => !doneSliceIds.has(dep));
-    logWarning("state",
-      `No slice has all deps satisfied — falling back to ${bestFallback.id} ` +
-      `(${bestFallbackSatisfied}/${bestFallback.depends.length} deps met, ` +
-      `unmet: ${unmet.join(", ")})`,
-      { mid: activeMilestoneSlices[0]?.milestone_id, sid: bestFallback.id },
-    );
-    return { activeSlice: { id: bestFallback.id, title: bestFallback.title }, activeSliceRow: bestFallback };
   }
 
   return { activeSlice: null, activeSliceRow: null };
@@ -1160,7 +1160,7 @@ export async function _deriveStateImpl(basePath: string): Promise<GSDState> {
     const rc = rf ? await cachedLoadFile(rf) : null;
     if (!rc) {
       const sf = resolveMilestoneFile(basePath, mid, "SUMMARY");
-      if (sf) completeMilestoneIds.add(mid);
+      if (sf && await isTerminalMilestoneSummaryFile(sf, cachedLoadFile)) completeMilestoneIds.add(mid);
       continue;
     }
     const rmap = parseRoadmap(rc);
@@ -1169,11 +1169,11 @@ export async function _deriveStateImpl(basePath: string): Promise<GSDState> {
       // Summary is the terminal artifact — if it exists, the milestone is
       // complete even when roadmap checkboxes weren't ticked (#864).
       const sf = resolveMilestoneFile(basePath, mid, "SUMMARY");
-      if (sf) completeMilestoneIds.add(mid);
+      if (sf && await isTerminalMilestoneSummaryFile(sf, cachedLoadFile)) completeMilestoneIds.add(mid);
       continue;
     }
     const sf = resolveMilestoneFile(basePath, mid, "SUMMARY");
-    if (sf) completeMilestoneIds.add(mid);
+    if (sf && await isTerminalMilestoneSummaryFile(sf, cachedLoadFile)) completeMilestoneIds.add(mid);
   }
 
   // Phase 2: Build registry using cached roadmaps (no re-parsing or re-reading)
@@ -1201,12 +1201,14 @@ export async function _deriveStateImpl(basePath: string): Promise<GSDState> {
       const summaryFile = resolveMilestoneFile(basePath, mid, "SUMMARY");
       if (summaryFile) {
         const summaryContent = await cachedLoadFile(summaryFile);
-        const summaryTitle = summaryContent
-          ? (parseSummary(summaryContent).title || mid)
-          : mid;
-        registry.push({ id: mid, title: summaryTitle, status: 'complete' });
-        completeMilestoneIds.add(mid);
-        continue;
+        if (!summaryContent || isTerminalMilestoneSummaryContent(summaryContent)) {
+          const summaryTitle = summaryContent
+            ? (parseSummary(summaryContent).title || mid)
+            : mid;
+          registry.push({ id: mid, title: summaryTitle, status: 'complete' });
+          completeMilestoneIds.add(mid);
+          continue;
+        }
       }
       // Ghost milestone (only META.json, no CONTEXT/ROADMAP/SUMMARY) — skip entirely
       if (isGhostMilestone(basePath, mid)) continue;
@@ -1262,7 +1264,7 @@ export async function _deriveStateImpl(basePath: string): Promise<GSDState> {
       // needs-remediation is terminal but requires re-validation (#3596)
       const needsRevalidation = !validationTerminal || verdict === 'needs-remediation';
 
-      if (summaryFile) {
+      if (summaryFile && await isTerminalMilestoneSummaryFile(summaryFile, cachedLoadFile)) {
         // Summary exists → milestone is complete regardless of validation state.
         // The summary is the terminal artifact (#864).
         registry.push({ id: mid, title, status: 'complete' });
@@ -1288,7 +1290,7 @@ export async function _deriveStateImpl(basePath: string): Promise<GSDState> {
       // Roadmap slices not all checked — but if a summary exists, the milestone
       // is still complete. The summary is the terminal artifact (#864).
       const summaryFile = resolveMilestoneFile(basePath, mid, "SUMMARY");
-      if (summaryFile) {
+      if (summaryFile && await isTerminalMilestoneSummaryFile(summaryFile, cachedLoadFile)) {
         registry.push({ id: mid, title, status: 'complete' });
       } else if (!activeMilestoneFound) {
         // Check milestone-level dependencies before promoting to active.
@@ -1563,32 +1565,12 @@ export async function _deriveStateImpl(basePath: string): Promise<GSDState> {
       };
     }
   } else {
-    let bestFallbackLegacy: { id: string; title: string; depends: string[] } | null = null;
-    let bestFallbackLegacySatisfied = -1;
-
     for (const s of activeRoadmap.slices) {
       if (s.done) continue;
       if (s.depends.every(dep => doneSliceIds.has(dep))) {
         activeSlice = { id: s.id, title: s.title };
         break;
       }
-      // Track best fallback
-      const satisfied = s.depends.filter(dep => doneSliceIds.has(dep)).length;
-      if (satisfied > bestFallbackLegacySatisfied) {
-        bestFallbackLegacy = s;
-        bestFallbackLegacySatisfied = satisfied;
-      }
-    }
-
-    // Fallback: if no slice has all deps met, pick the one with the most deps satisfied
-    if (!activeSlice && bestFallbackLegacy) {
-      const unmet = bestFallbackLegacy.depends.filter(dep => !doneSliceIds.has(dep));
-      logWarning("state",
-        `No slice has all deps satisfied — falling back to ${bestFallbackLegacy.id} ` +
-        `(${bestFallbackLegacySatisfied}/${bestFallbackLegacy.depends.length} deps met, ` +
-        `unmet: ${unmet.join(", ")})`,
-      );
-      activeSlice = { id: bestFallbackLegacy.id, title: bestFallbackLegacy.title };
     }
   }
 

--- a/src/resources/extensions/gsd/tests/auto-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-loop.test.ts
@@ -849,6 +849,45 @@ test("autoLoop exits on terminal complete state", async (t) => {
   );
 });
 
+test("autoLoop pauses when provider readiness cancels before dispatch", async () => {
+  _resetPendingResolve();
+
+  const notifications: Array<{ message: string; level?: string }> = [];
+  const ctx = makeMockCtx();
+  ctx.ui.setStatus = () => {};
+  ctx.ui.notify = (message: string, level?: string) => {
+    notifications.push({ message, level });
+  };
+  ctx.model = { provider: "anthropic", id: "claude-opus-4-6" };
+  ctx.modelRegistry = {
+    getProviderAuthMode: () => "api-key",
+    isProviderRequestReady: () => false,
+  };
+
+  const pi = makeMockPi();
+  const s = makeLoopSession();
+  const deps = makeMockDeps({
+    selectAndApplyModel: async () => ({
+      routing: null,
+      appliedModel: { provider: "anthropic", id: "claude-opus-4-6" },
+    }),
+  });
+
+  await autoLoop(ctx, pi, s, deps);
+
+  assert.equal(pi.calls.length, 0, "provider readiness cancellation must not dispatch a message");
+  assert.ok(deps.callLog.includes("pauseAuto"), "provider readiness cancellation should pause auto-mode");
+  assert.ok(!deps.callLog.includes("stopAuto"), "provider readiness cancellation should not hard-stop auto-mode");
+  assert.ok(
+    !deps.callLog.includes("postUnitPreVerification"),
+    "post-unit verification must not run after pre-dispatch provider cancellation",
+  );
+  assert.ok(
+    notifications.some(n => /Provider anthropic is not request-ready/.test(n.message)),
+    "provider pause should notify with the readiness failure",
+  );
+});
+
 test("autoLoop passes structured session-lock failure details to the handler", async () => {
   _resetPendingResolve();
 

--- a/src/resources/extensions/gsd/tests/custom-engine-loop-integration.test.ts
+++ b/src/resources/extensions/gsd/tests/custom-engine-loop-integration.test.ts
@@ -542,6 +542,104 @@ describe("Custom engine loop integration", () => {
     assert.equal(finalGraph.steps[0]?.status, "active", "failed verification must not reconcile the step complete");
   });
 
+  it("persists custom verification retry budget across a session restart", async () => {
+    _resetPendingResolve();
+
+    const runDir = makeTmpDir();
+    const graph = makeGraph([makeStep({ id: "retry-step" })], "retry-restart");
+    writeGraph(runDir, graph);
+    writeFileSync(join(runDir, "DEFINITION.yaml"), stringify({
+      version: 1,
+      name: "retry-restart",
+      steps: [{
+        id: "retry-step",
+        name: "retry-step",
+        prompt: "Do retry-step",
+        produces: "retry-step/output.md",
+        verify: { policy: "shell-command", command: "exit 1" },
+      }],
+    }));
+
+    const ctx1 = makeMockCtx();
+    const pi1 = makeMockPi();
+    const s1 = makeLoopSession({
+      activeEngineId: "custom",
+      activeRunDir: runDir,
+      basePath: runDir,
+    });
+    const deps1 = makeMockDeps();
+    const resolver1 = setInterval(() => {
+      resolveAgentEnd({ messages: [{ role: "assistant" }] });
+      if (pi1.calls.length >= 2) {
+        s1.active = false;
+      }
+    }, 25);
+    let timeout1: NodeJS.Timeout | undefined;
+    try {
+      await Promise.race([
+        autoLoop(ctx1, pi1, s1, deps1),
+        new Promise((_, reject) =>
+          timeout1 = setTimeout(() => {
+            s1.active = false;
+            resolveAgentEnd({ messages: [{ role: "assistant" }] });
+            reject(new Error(
+              `first autoLoop did not pause after two retry attempts; calls=${pi1.calls.length}; log=${deps1.callLog.join(",")}`,
+            ));
+          }, 3_000),
+        ),
+      ]);
+    } finally {
+      clearInterval(resolver1);
+      if (timeout1) clearTimeout(timeout1);
+    }
+    assert.equal(pi1.calls.length, 2, "first session should consume two retry attempts");
+    assert.equal(
+      deps1.callLog.some((e: string) => e.startsWith("stopAuto:")),
+      false,
+      "first session should stop because the session deactivated, not because retry budget exhausted",
+    );
+
+    _resetPendingResolve();
+    const ctx2 = makeMockCtx();
+    const pi2 = makeMockPi();
+    const s2 = makeLoopSession({
+      activeEngineId: "custom",
+      activeRunDir: runDir,
+      basePath: runDir,
+    });
+    const deps2 = makeMockDeps({
+      stopAuto: async (_ctx, _pi, reason) => {
+        deps2.callLog.push(`stopAuto:${reason ?? "no-reason"}`);
+        s2.active = false;
+      },
+    });
+    const resolver2 = setInterval(() => {
+      resolveAgentEnd({ messages: [{ role: "assistant" }] });
+    }, 25);
+    let timeout2: NodeJS.Timeout | undefined;
+    try {
+      await Promise.race([
+        autoLoop(ctx2, pi2, s2, deps2),
+        new Promise((_, reject) =>
+          timeout2 = setTimeout(() => {
+            s2.active = false;
+            resolveAgentEnd({ messages: [{ role: "assistant" }] });
+            reject(new Error(
+              `second autoLoop did not stop after persisted retry exhaustion; calls=${pi2.calls.length}; log=${deps2.callLog.join(",")}`,
+            ));
+          }, 3_000),
+        ),
+      ]);
+    } finally {
+      clearInterval(resolver2);
+      if (timeout2) clearTimeout(timeout2);
+    }
+
+    assert.equal(pi2.calls.length, 2, "second session should exhaust after attempts 3 and 4");
+    const stopEntry = deps2.callLog.find((e: string) => e.startsWith("stopAuto:"));
+    assert.match(stopEntry ?? "", /requested retry 4 times without passing/);
+  });
+
   it("GRAPH.yaml step stays pending when session deactivates before reconcile", async () => {
     _resetPendingResolve();
 

--- a/src/resources/extensions/gsd/tests/custom-engine-loop-integration.test.ts
+++ b/src/resources/extensions/gsd/tests/custom-engine-loop-integration.test.ts
@@ -481,6 +481,67 @@ describe("Custom engine loop integration", () => {
     );
   });
 
+  it("stops custom workflow after repeated verification retries", async () => {
+    _resetPendingResolve();
+
+    const runDir = makeTmpDir();
+    const graph = makeGraph([makeStep({ id: "retry-step" })], "retry-exhaustion");
+    writeGraph(runDir, graph);
+    writeFileSync(join(runDir, "DEFINITION.yaml"), stringify({
+      version: 1,
+      name: "retry-exhaustion",
+      steps: [{
+        id: "retry-step",
+        name: "retry-step",
+        prompt: "Do retry-step",
+        produces: "retry-step/output.md",
+        verify: { policy: "shell-command", command: "exit 1" },
+      }],
+    }));
+
+    const ctx = makeMockCtx();
+    const pi = makeMockPi();
+    const s = makeLoopSession({
+      activeEngineId: "custom",
+      activeRunDir: runDir,
+      basePath: runDir,
+    });
+    const deps = makeMockDeps({
+      stopAuto: async (_ctx, _pi, reason) => {
+        deps.callLog.push(`stopAuto:${reason ?? "no-reason"}`);
+        s.active = false;
+      },
+    });
+
+    const resolver = setInterval(() => {
+      resolveAgentEnd({ messages: [{ role: "assistant" }] });
+    }, 25);
+    let timeout: NodeJS.Timeout | undefined;
+    try {
+      await Promise.race([
+        autoLoop(ctx, pi, s, deps),
+        new Promise((_, reject) =>
+          timeout = setTimeout(() => {
+            s.active = false;
+            resolveAgentEnd({ messages: [{ role: "assistant" }] });
+            reject(new Error(
+              `autoLoop did not stop after verification retry exhaustion; calls=${pi.calls.length}; log=${deps.callLog.join(",")}`,
+            ));
+          }, 3_000),
+        ),
+      ]);
+    } finally {
+      clearInterval(resolver);
+      if (timeout) clearTimeout(timeout);
+    }
+
+    assert.equal(pi.calls.length, 4, "verification retry should be capped after four dispatched attempts");
+    const stopEntry = deps.callLog.find((e: string) => e.startsWith("stopAuto:"));
+    assert.match(stopEntry ?? "", /requested retry 4 times without passing/);
+    const finalGraph = readGraph(runDir);
+    assert.equal(finalGraph.steps[0]?.status, "active", "failed verification must not reconcile the step complete");
+  });
+
   it("GRAPH.yaml step stays pending when session deactivates before reconcile", async () => {
     _resetPendingResolve();
 

--- a/src/resources/extensions/gsd/tests/derive-state-db.test.ts
+++ b/src/resources/extensions/gsd/tests/derive-state-db.test.ts
@@ -616,9 +616,10 @@ describe('derive-state-db', async () => {
       invalidateStateCache();
       const dbState = await deriveStateFromDb(base);
 
-      assert.deepStrictEqual(dbState.phase, 'blocked', 'blocked-db: phase is blocked when circular deps have no eligible slice');
+      // With partial-dep fallback, circular deps no longer block — fallback picks first eligible slice
+      assert.deepStrictEqual(dbState.phase, 'planning', 'blocked-db: phase is planning (fallback picks a slice)');
       assert.deepStrictEqual(dbState.phase, fileState.phase, 'blocked-db: phase matches filesystem');
-      assert.deepStrictEqual(dbState.activeSlice, null, 'blocked-db: activeSlice remains unset when deps are unmet');
+      assert.ok(dbState.activeSlice !== null, 'blocked-db: activeSlice is set via fallback');
 
       closeDatabase();
     } finally {

--- a/src/resources/extensions/gsd/tests/derive-state-db.test.ts
+++ b/src/resources/extensions/gsd/tests/derive-state-db.test.ts
@@ -616,10 +616,9 @@ describe('derive-state-db', async () => {
       invalidateStateCache();
       const dbState = await deriveStateFromDb(base);
 
-      // With partial-dep fallback, circular deps no longer block — fallback picks first eligible slice
-      assert.deepStrictEqual(dbState.phase, 'planning', 'blocked-db: phase is planning (fallback picks a slice)');
+      assert.deepStrictEqual(dbState.phase, 'blocked', 'blocked-db: phase is blocked when circular deps have no eligible slice');
       assert.deepStrictEqual(dbState.phase, fileState.phase, 'blocked-db: phase matches filesystem');
-      assert.ok(dbState.activeSlice !== null, 'blocked-db: activeSlice is set via fallback');
+      assert.deepStrictEqual(dbState.activeSlice, null, 'blocked-db: activeSlice remains unset when deps are unmet');
 
       closeDatabase();
     } finally {

--- a/src/resources/extensions/gsd/tests/derive-state.test.ts
+++ b/src/resources/extensions/gsd/tests/derive-state.test.ts
@@ -446,9 +446,8 @@ Continue from step 2.
 
       const state2 = await deriveState(base2);
 
-      // With partial-dep fallback, S01 is picked despite unmet dep on S99
-      assert.deepStrictEqual(state2.phase, 'planning', 'blocked-B: phase is planning (fallback picks S01)');
-      assert.deepStrictEqual(state2.activeSlice?.id, 'S01', 'blocked-B: activeSlice is S01 via fallback');
+      assert.deepStrictEqual(state2.phase, 'blocked', 'blocked-B: phase is blocked when all slice deps are unmet');
+      assert.deepStrictEqual(state2.activeSlice, null, 'blocked-B: no activeSlice is selected with unmet deps');
     } finally {
       cleanup(base2);
     }

--- a/src/resources/extensions/gsd/tests/derive-state.test.ts
+++ b/src/resources/extensions/gsd/tests/derive-state.test.ts
@@ -431,7 +431,7 @@ Continue from step 2.
       cleanup(base1);
     }
 
-    // Case B: S01 depends on nonexistent S99 → truly blocked
+    // Case B: S01 depends on nonexistent S99 -> fallback picks best available slice
     const base2 = createFixtureBase();
     try {
       writeRoadmap(base2, 'M001', `# M001: Test Milestone
@@ -446,8 +446,8 @@ Continue from step 2.
 
       const state2 = await deriveState(base2);
 
-      assert.deepStrictEqual(state2.phase, 'blocked', 'blocked-B: phase is blocked when all slice deps are unmet');
-      assert.deepStrictEqual(state2.activeSlice, null, 'blocked-B: no activeSlice is selected with unmet deps');
+      assert.deepStrictEqual(state2.phase, 'planning', 'blocked-B: phase is planning (fallback picks S01)');
+      assert.deepStrictEqual(state2.activeSlice?.id, 'S01', 'blocked-B: activeSlice is S01 via fallback');
     } finally {
       cleanup(base2);
     }

--- a/src/resources/extensions/gsd/tests/dispatch-complete-milestone-guard.test.ts
+++ b/src/resources/extensions/gsd/tests/dispatch-complete-milestone-guard.test.ts
@@ -55,9 +55,9 @@ describe("completing-milestone dispatch guard (#4324)", () => {
 
     const classifyCall = source.indexOf("classifyMilestoneSummaryContent", summaryGuard);
     assert.ok(classifyCall > -1, "SUMMARY mismatch handling should classify summary content");
-    const dbGateBeforeClassify = source.lastIndexOf("existingSummary && isDbAvailable()", classifyCall);
+    const dbGateBeforeClassify = source.indexOf("existingSummary && isDbAvailable()", summaryGuard);
     assert.ok(
-      dbGateBeforeClassify < summaryGuard,
+      dbGateBeforeClassify === -1 || dbGateBeforeClassify > classifyCall,
       "SUMMARY classification must not be gated on DB availability",
     );
 

--- a/src/resources/extensions/gsd/tests/dispatch-complete-milestone-guard.test.ts
+++ b/src/resources/extensions/gsd/tests/dispatch-complete-milestone-guard.test.ts
@@ -55,6 +55,11 @@ describe("completing-milestone dispatch guard (#4324)", () => {
 
     const classifyCall = source.indexOf("classifyMilestoneSummaryContent", summaryGuard);
     assert.ok(classifyCall > -1, "SUMMARY mismatch handling should classify summary content");
+    const dbGateBeforeClassify = source.lastIndexOf("existingSummary && isDbAvailable()", classifyCall);
+    assert.ok(
+      dbGateBeforeClassify < summaryGuard,
+      "SUMMARY classification must not be gated on DB availability",
+    );
 
     const reconcileCall = source.indexOf('updateMilestoneStatus(mid, "complete"', summaryGuard);
     assert.ok(reconcileCall > -1, "successful SUMMARY should reconcile DB to complete");

--- a/src/resources/extensions/gsd/tests/dispatch-guard.test.ts
+++ b/src/resources/extensions/gsd/tests/dispatch-guard.test.ts
@@ -255,6 +255,31 @@ test("dispatch guard skips completed milestone with SUMMARY even if it has unche
   );
 });
 
+test("dispatch guard does not skip failed milestone SUMMARY without blocker prose", (t) => {
+  const repo = setupRepo();
+  t.after(() => teardownRepo(repo));
+
+  mkdirSync(join(repo, ".gsd", "milestones", "M001"), { recursive: true });
+  mkdirSync(join(repo, ".gsd", "milestones", "M002"), { recursive: true });
+
+  insertMilestone({ id: "M001", title: "Previous" });
+  insertSlice({ id: "S01", milestoneId: "M001", title: "Core", status: "complete", depends: [], sequence: 1 });
+  insertSlice({ id: "S02", milestoneId: "M001", title: "Unfinished", status: "pending", depends: ["S01"], sequence: 2 });
+
+  insertMilestone({ id: "M002", title: "Current" });
+  insertSlice({ id: "S01", milestoneId: "M002", title: "Start", status: "pending", depends: [], sequence: 1 });
+
+  writeFileSync(join(repo, ".gsd", "milestones", "M001", "M001-ROADMAP.md"), "# M001\n");
+  writeFileSync(join(repo, ".gsd", "milestones", "M001", "M001-SUMMARY.md"),
+    "---\nstatus: failed\n---\n# M001 Summary\nRecovery stopped.\n");
+  writeFileSync(join(repo, ".gsd", "milestones", "M002", "M002-ROADMAP.md"), "# M002\n");
+
+  assert.equal(
+    getPriorSliceCompletionBlocker(repo, "main", "plan-slice", "M002/S01"),
+    "Cannot dispatch plan-slice M002/S01: earlier slice M001/S02 is not complete.",
+  );
+});
+
 test("dispatch guard works without git repo", (t) => {
   const repo = setupRepo();
   t.after(() => teardownRepo(repo));

--- a/src/resources/extensions/gsd/tests/milestone-summary-classifier.test.ts
+++ b/src/resources/extensions/gsd/tests/milestone-summary-classifier.test.ts
@@ -1,0 +1,30 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { classifyMilestoneSummaryContent } from "../milestone-summary-classifier.ts";
+
+test("milestone SUMMARY classifier treats explicit failed status as failure", () => {
+  assert.equal(
+    classifyMilestoneSummaryContent([
+      "---",
+      "status: failed",
+      "---",
+      "",
+      "# M001 Summary",
+      "Recovery stopped.",
+    ].join("\n")),
+    "failure",
+  );
+});
+
+test("milestone SUMMARY classifier does not treat historical not-complete prose as failure", () => {
+  assert.equal(
+    classifyMilestoneSummaryContent([
+      "# M001 Summary",
+      "",
+      "This milestone was previously not complete, now resolved.",
+    ].join("\n")),
+    "unknown",
+  );
+});
+

--- a/src/resources/extensions/gsd/tests/state-machine-full-walkthrough.test.ts
+++ b/src/resources/extensions/gsd/tests/state-machine-full-walkthrough.test.ts
@@ -835,9 +835,9 @@ describe("state-machine-full-walkthrough", () => {
       assert.ok(state.blockers.length > 0, "should have blockers");
     });
 
-    test("no eligible slice (all deps unmet) → blocked", async () => {
+    test("no eligible slice (all deps unmet) → fallback picks slice with most deps satisfied", async () => {
       const base = createFixtureBase();
-      // S01 depends on S00 which doesn't exist — do not dispatch a doomed slice.
+      // S01 depends on S00 which doesn't exist — fallback picks S01 anyway
       writeRoadmap(base, "M001", [
         "# M001: Test Milestone",
         "",
@@ -851,8 +851,9 @@ describe("state-machine-full-walkthrough", () => {
       invalidateStateCache();
       const state = await deriveState(base);
 
-      assert.equal(state.phase, "blocked");
-      assert.equal(state.activeSlice, null);
+      // With partial-dep fallback, S01 is picked despite unmet dep on S00
+      assert.equal(state.phase, "planning");
+      assert.equal(state.activeSlice?.id, "S01");
     });
   });
 

--- a/src/resources/extensions/gsd/tests/state-machine-full-walkthrough.test.ts
+++ b/src/resources/extensions/gsd/tests/state-machine-full-walkthrough.test.ts
@@ -13,6 +13,7 @@ import {
   isValidationTerminal,
   isGhostMilestone,
   invalidateStateCache,
+  getActiveMilestoneId,
 } from "../state.ts";
 import {
   openDatabase,
@@ -688,6 +689,7 @@ describe("state-machine-full-walkthrough", () => {
 
       assert.equal(state.phase, "completing-milestone");
       assert.equal(state.registry[0]?.status, "active");
+      assert.equal(await getActiveMilestoneId(base), "M001");
     });
   });
 

--- a/src/resources/extensions/gsd/tests/state-machine-full-walkthrough.test.ts
+++ b/src/resources/extensions/gsd/tests/state-machine-full-walkthrough.test.ts
@@ -667,6 +667,28 @@ describe("state-machine-full-walkthrough", () => {
       assert.notEqual(state.phase, "completing-milestone", "should be complete, not completing");
       assert.equal(state.phase, "complete");
     });
+
+    test("failure-path milestone SUMMARY is not terminal completion", async () => {
+      const base = createFixtureBase();
+      writeRoadmap(base, "M001", doneSliceRoadmap());
+      writeMilestoneValidation(base, "M001", "pass");
+      const dir = join(base, ".gsd", "milestones", "M001");
+      writeFileSync(join(dir, "M001-SUMMARY.md"), [
+        "---",
+        "status: failed",
+        "---",
+        "",
+        "# BLOCKER",
+        "",
+        "auto-mode recovery failed; milestone is not complete.",
+      ].join("\n"));
+      invalidateStateCache();
+
+      const state = await deriveState(base);
+
+      assert.equal(state.phase, "completing-milestone");
+      assert.equal(state.registry[0]?.status, "active");
+    });
   });
 
   // ═══════════════════════════════════════════════════════════════════════════
@@ -811,9 +833,9 @@ describe("state-machine-full-walkthrough", () => {
       assert.ok(state.blockers.length > 0, "should have blockers");
     });
 
-    test("no eligible slice (all deps unmet) → fallback picks slice with most deps satisfied", async () => {
+    test("no eligible slice (all deps unmet) → blocked", async () => {
       const base = createFixtureBase();
-      // S01 depends on S00 which doesn't exist — fallback picks S01 anyway
+      // S01 depends on S00 which doesn't exist — do not dispatch a doomed slice.
       writeRoadmap(base, "M001", [
         "# M001: Test Milestone",
         "",
@@ -827,9 +849,8 @@ describe("state-machine-full-walkthrough", () => {
       invalidateStateCache();
       const state = await deriveState(base);
 
-      // With partial-dep fallback, S01 is picked despite unmet dep on S00
-      assert.equal(state.phase, "planning");
-      assert.equal(state.activeSlice?.id, "S01");
+      assert.equal(state.phase, "blocked");
+      assert.equal(state.activeSlice, null);
     });
   });
 


### PR DESCRIPTION
## TL;DR
**What:** Hardens auto-mode workflow/state-machine transitions around provider readiness, failure summaries, custom workflow retries, and blocked slice dependencies.  
**Why:** These edge cases could silently drop auto-mode into a misleading terminal state or retry forever.  
**How:** Adds fail-closed checks in state derivation/dispatch, pauses provider readiness cancellations, caps custom verification retries, and removes unsafe dependency fallback dispatch.

## What
- Pause auto-mode when provider readiness cancels before any unit is dispatched.
- Treat explicit failure-path milestone SUMMARY files as non-terminal in filesystem state derivation and dispatch guards.
- Cap custom workflow verification retries and stop after exhaustion instead of looping indefinitely.
- Keep milestones blocked when every incomplete slice has unmet dependencies instead of selecting a doomed fallback slice.
- Adds regression coverage across auto-loop, custom engine integration, derive-state DB/filesystem paths, and full state-machine walkthroughs.

## Why
The workflow review found four places where state transitions were internally inconsistent: cancellation could break without pausing, failure artifacts could be promoted as completion, custom verification retry had no budget, and dependency fallback produced a later dispatch-time stop instead of a clear blocked state.

## How
- `runUnitPhase` now invokes the provider pause helper for pre-dispatch provider readiness cancellations when the session is not already paused.
- `state.ts` classifies terminal vs failure milestone summaries before using SUMMARY presence as completion evidence.
- `auto-dispatch.ts` classifies existing SUMMARY files even when DB is unavailable and fail-closes on failure/unknown summaries.
- `auto/loop.ts` tracks custom verification retries in `verificationRetryCount` and calls policy recovery once the budget is exhausted.
- Slice dependency resolution now returns blocked when no slice has all dependencies satisfied.

## Issue Drafts
### 1. Provider readiness cancellation exits auto-mode without pausing
**Problem:** `runUnit` can return a provider-category cancellation before dispatch when a provider is not request-ready. The loop treated provider cancellations as already paused, so this pre-dispatch path could break without setting pause/stop state.  
**Expected:** Provider readiness cancellation should pause auto-mode and notify the user before exiting the loop.  
**Acceptance:** Add a regression where provider readiness fails before `sendMessage`; assert no dispatch, `pauseAuto` runs, and post-unit verification does not run.

### 2. Failure-path milestone SUMMARY can be treated as terminal completion
**Problem:** Filesystem fallback used SUMMARY presence as terminal completion evidence, including blocker/recovery-failure summaries. Dispatch mismatch handling also only classified SUMMARY content when DB was available.  
**Expected:** Explicit failure summaries should keep the milestone active/completing and should never promote completion.  
**Acceptance:** Failure SUMMARY content/frontmatter is non-terminal in state derivation; dispatch fail-closes on failure/unknown summaries regardless of DB availability.

### 3. Custom workflow verification retry has no exhaustion path
**Problem:** Custom engine `verify() === "retry"` bypassed the normal stuck/recovery budget, so a permanently failing verification command could retry indefinitely.  
**Expected:** Custom workflow verification retry should have a bounded budget and invoke recovery/stop when exhausted.  
**Acceptance:** A shell-command verification that always exits non-zero stops after the configured retry budget and does not reconcile the step complete.

### 4. Slice dependency fallback dispatches work with unmet dependencies
**Problem:** When every incomplete slice had unmet dependencies, state derivation picked a best-effort fallback slice. Dispatch guard later rejected it, converting a blocked state into a dispatch-time stop.  
**Expected:** State derivation should report `blocked` when no slice is dependency-eligible.  
**Acceptance:** DB and filesystem derivation both return `blocked` with no active slice for circular or missing slice dependencies.

## Tests
- `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/auto-loop.test.ts src/resources/extensions/gsd/tests/custom-engine-loop-integration.test.ts src/resources/extensions/gsd/tests/state-machine-full-walkthrough.test.ts src/resources/extensions/gsd/tests/derive-state.test.ts src/resources/extensions/gsd/tests/derive-state-db.test.ts src/resources/extensions/gsd/tests/dispatch-complete-milestone-guard.test.ts`  
  - 202 passed, 1 skipped
- `npm run typecheck:extensions`  
  - Fails in this worktree before changed files due missing linked workspace package types such as `@gsd/pi-coding-agent`, `@gsd/pi-tui`, and `@gsd/native`.

## AI Assistance
This PR was authored with AI assistance and manually reviewed/tested before submission.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes / Behavior Changes**
  * DB-unavailable milestone reconciliation now marks status unavailable and safely skips DB updates; successful SUMMARY paths short-circuit when DB is down.
  * Added persisted retry limits (max 3) for verification attempts and recovery when exhausted; retry counts survive restarts.
  * Provider readiness errors now pause auto-mode resumably.
  * Milestone completion/resumption/dispatch uses SUMMARY content classification (not just file presence); unmet dependencies now block progression.

* **Tests**
  * New/updated tests for provider pauses, retry-exhaustion, summary-driven blocking, and dependency resolution changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->