### PR TITLE
fix(gsd): flush dirListCache at agent_end before artifact checks

### DIFF
--- a/src/resources/extensions/gsd/bootstrap/agent-end-recovery.ts
+++ b/src/resources/extensions/gsd/bootstrap/agent-end-recovery.ts
@@ -7,6 +7,7 @@ import {
   maybeHandleEmptyIntentTurn,
   resetEmptyTurnCounter,
 } from "../guided-flow.js";
+import { clearPathCache } from "../paths.js";
 import { getAutoDashboardData, getAutoModeStartModel, isAutoActive, pauseAuto, setCurrentDispatchedModelId } from "../auto.js";
 import { getNextFallbackModel, resolveModelWithFallbacksForUnit } from "../preferences.js";
 import { pauseAutoForProviderError } from "../provider-error-pause.js";
@@ -76,6 +77,16 @@ export async function handleAgentEnd(
   event: { messages: any[] },
   ctx: ExtensionContext,
 ): Promise<void> {
+  // #4648 — Invalidate the directory-listing cache before any artifact-existence
+  // checks. The LLM may have written milestone files (CONTEXT.md, ROADMAP.md,
+  // PROJECT.md, REQUIREMENTS.md) via tool calls during the turn that just
+  // ended. `paths.ts` caches readdir() results without a TTL, so without this
+  // flush, `resolveMilestoneFile` returns the pre-write listing and the guards
+  // below (`checkAutoStartAfterDiscuss` and `maybeHandleReadyPhraseWithoutFiles`)
+  // falsely report files as missing — producing a spurious "ready signal
+  // rejected" loop even though the files are on disk.
+  clearPathCache();
+
   if (checkAutoStartAfterDiscuss()) {
     clearDiscussionFlowState();
     return;

--- a/src/resources/extensions/gsd/tests/stale-dirlistcache-4648.test.ts
+++ b/src/resources/extensions/gsd/tests/stale-dirlistcache-4648.test.ts
@@ -1,0 +1,112 @@
+/**
+ * GSD-2 / agent-end-recovery — regression tests for #4648
+ *
+ * Covers the stale `dirListCache` bug where `maybeHandleReadyPhraseWithoutFiles`
+ * (and `checkAutoStartAfterDiscuss`) falsely reported milestone artifacts as
+ * missing, because the directory-listing cache in `paths.ts` was populated
+ * before the LLM wrote the files during the same turn.
+ *
+ * The fix invalidates the cache at the top of `handleAgentEnd`, before any
+ * artifact-existence check runs.
+ */
+
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  mkdtempSync,
+  mkdirSync,
+  rmSync,
+  writeFileSync,
+  readFileSync,
+} from "node:fs";
+import { join, dirname } from "node:path";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
+
+import { resolveMilestoneFile } from "../paths.ts";
+import { clearPathCache } from "../paths.ts";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const AGENT_END_RECOVERY_PATH = join(
+  __dirname,
+  "..",
+  "bootstrap",
+  "agent-end-recovery.ts",
+);
+
+function mkBase(): string {
+  const base = mkdtempSync(join(tmpdir(), "gsd-4648-"));
+  mkdirSync(join(base, ".gsd", "milestones", "M001"), { recursive: true });
+  return base;
+}
+
+describe("#4648 stale dirListCache — behavioral", () => {
+  test("resolveMilestoneFile returns stale null until clearPathCache runs", () => {
+    const base = mkBase();
+    try {
+      clearPathCache();
+
+      // Prime the cache: directory exists but is empty at this point.
+      assert.equal(
+        resolveMilestoneFile(base, "M001", "CONTEXT"),
+        null,
+        "empty dir → null",
+      );
+
+      // Simulate the LLM writing CONTEXT.md during the turn.
+      writeFileSync(
+        join(base, ".gsd", "milestones", "M001", "M001-CONTEXT.md"),
+        "# M001 Context\n",
+      );
+
+      // Without a cache flush the resolver still reports null — this is the bug.
+      assert.equal(
+        resolveMilestoneFile(base, "M001", "CONTEXT"),
+        null,
+        "stale cache returns null even though the file exists on disk",
+      );
+
+      // The fix: clearPathCache() — after which the resolver finds the file.
+      clearPathCache();
+      const resolved = resolveMilestoneFile(base, "M001", "CONTEXT");
+      assert.ok(
+        resolved && /M001-CONTEXT\.md$/.test(resolved),
+        `after clearPathCache, resolver finds the file (got: ${resolved})`,
+      );
+    } finally {
+      clearPathCache();
+      rmSync(base, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("#4648 agent-end-recovery wiring", () => {
+  test("handleAgentEnd invalidates the path cache before the discuss guards", () => {
+    const source = readFileSync(AGENT_END_RECOVERY_PATH, "utf-8");
+
+    assert.ok(
+      /import\s*\{\s*clearPathCache\s*\}\s*from\s*"\.\.\/paths\.js"/.test(source),
+      "agent-end-recovery.ts must import clearPathCache from ../paths.js",
+    );
+
+    const fnStart = source.indexOf("export async function handleAgentEnd");
+    assert.ok(fnStart > -1, "handleAgentEnd must exist");
+
+    const checkIdx = source.indexOf("checkAutoStartAfterDiscuss(", fnStart);
+    const clearIdx = source.indexOf("clearPathCache(", fnStart);
+    const readyIdx = source.indexOf(
+      "maybeHandleReadyPhraseWithoutFiles(",
+      fnStart,
+    );
+
+    assert.ok(clearIdx > -1, "handleAgentEnd must call clearPathCache");
+    assert.ok(
+      clearIdx < checkIdx,
+      "clearPathCache must run before checkAutoStartAfterDiscuss so the guard sees fresh disk state",
+    );
+    assert.ok(
+      clearIdx < readyIdx,
+      "clearPathCache must run before maybeHandleReadyPhraseWithoutFiles",
+    );
+  });
+});


### PR DESCRIPTION
## TL;DR

**What:** Clear the `paths.ts` directory-listing cache at the top of `handleAgentEnd`, before any artifact-existence check runs.
**Why:** Stale cache caused the guided-flow guards to falsely report milestone files as missing, producing a spurious "ready signal rejected" loop even though the LLM had just written them on disk. Closes #4648.
**How:** One import + one call at the top of `handleAgentEnd`, plus a behavioral test that reproduces the stale-cache scenario and a structural test that pins the call ordering.

## What

- `src/resources/extensions/gsd/bootstrap/agent-end-recovery.ts` — import `clearPathCache` from `../paths.js` and invoke it at the top of `handleAgentEnd`, before `checkAutoStartAfterDiscuss` and `maybeHandleReadyPhraseWithoutFiles`.
- `src/resources/extensions/gsd/tests/stale-dirlistcache-4648.test.ts` — new regression test file with two tests:
  1. Behavioral: primes the cache with an empty dir listing, writes a CONTEXT.md, shows the resolver still returns `null` (the bug), calls `clearPathCache()`, shows it now finds the file (the fix).
  2. Structural: asserts `handleAgentEnd` imports `clearPathCache` and invokes it before the two guard functions, so future edits can't silently regress the ordering.

## Why

Reported in #4648 by an independent user (exact call chain identified in the issue). The LLM writes `M###-CONTEXT.md` and `M###-ROADMAP.md` via tool calls during the discuss turn. `paths.ts:103-125` caches `readdir()` results in `dirListCache` with no TTL and no invalidation on write. When `handleAgentEnd` fires at the end of that same turn, the guards run through `resolveMilestoneFile` → `resolveFile` → `cachedReaddir` and get the pre-write (empty) listing back. Both files are reported as missing even though they exist on disk. The ready-phrase nudge fires, the LLM retries, same stale-cache result, and after `MAX_READY_REJECTS` the session gives up.

The same code path affects `checkAutoStartAfterDiscuss`, which the existing test suite (`ready-phrase-no-files-4573.test.ts`) did not catch because it mocks file existence via real `writeFileSync` before the cache is populated — masking the stale-cache condition.

Every other write-critical site in the codebase already calls `clearPathCache()` (db-writer.ts, workflow-reconcile.ts, markdown-renderer.ts, complete-milestone.ts). `handleAgentEnd` was the missing call site.

## How

Placement: top of `handleAgentEnd` — a single invalidation point that both guards inherit, rather than per-function flushes. This avoids the subtle ordering issue where clearing only inside `maybeHandleReadyPhraseWithoutFiles` would still let `checkAutoStartAfterDiscuss` (which runs first) see stale data, converting the bug from "bad loop" to "silent no-op on first turn, works on second."

Alternatives considered:
- Per-function `clearPathCache()` in each guard: rejected — scatters the flush and requires every future guard to remember it.
- Invalidation in `paths.ts` on filesystem writes: rejected — `paths.ts` doesn't observe writes; wiring that up is a larger change and out of scope for this bug fix.
- Flip `||` to `&&` at `guided-flow.ts:354`: rejected — peer reviewed and confirmed current `||` semantics are intentional (discuss produces CONTEXT, plan produces ROADMAP; either alone should satisfy the guard).

## Change type

- [x] `fix` — Bug fix

## Testing

- New behavioral test reproduces the stale-cache bug without mocking the resolver.
- New structural test pins the import and call ordering in `handleAgentEnd`.
- Full suite locally: `stale-dirlistcache-4648.test.ts`, `ready-phrase-no-files-4573.test.ts`, `agent-end-retry.test.ts` — 23/23 passing.
- `npm run build` passes.

## AI-assisted contribution

This PR was AI-assisted. Root cause investigation used multiple parallel debugging agents; the stale-cache diagnosis was independently corroborated by the issue reporter in #4648. Fix placement and test strategy were peer-reviewed before implementation.

Closes #4648