### PR TITLE
fix(mcp-server): surface plan_milestone sketch/full slice requirement in tool schema

### DIFF
--- a/packages/mcp-server/src/workflow-tools.test.ts
+++ b/packages/mcp-server/src/workflow-tools.test.ts
@@ -712,6 +712,50 @@ export const executeTaskComplete = async (params, projectDir) => {
     }
   });
 
+  it("gsd_plan_milestone surfaces the full-vs-sketch conditional requirement in the tool schema", () => {
+    // Regression: the four heavy slice fields (successCriteria, proofLevel,
+    // integrationClosure, observabilityImpact) are Zod-optional so sketch
+    // slices can omit them, but they are required for every other slice. That
+    // conditional requirement is invisible in the JSON Schema `required`
+    // array — agents discovered it only by hitting a -32602 error mid-call.
+    // Each heavy field's `.describe()` now states the constraint; this test
+    // pins that so future edits can't silently strip it.
+    const server = makeMockServer();
+    registerWorkflowTools(server as any);
+    const milestoneTool = server.tools.find((t) => t.name === "gsd_plan_milestone");
+    assert.ok(milestoneTool, "milestone planning tool should be registered");
+
+    const slicesParam: any = milestoneTool!.params.slices;
+    assert.ok(slicesParam, "slices parameter must be present");
+    const element: any = slicesParam._def?.element;
+    assert.ok(element, "expected z.array element schema");
+
+    // Top-level slice description should state the conditional requirement.
+    const sliceDescription: string | undefined = element.description;
+    assert.ok(
+      sliceDescription && /isSketch/i.test(sliceDescription),
+      `slice schema should describe the isSketch conditional; got: ${sliceDescription}`,
+    );
+    for (const field of ["successCriteria", "proofLevel", "integrationClosure", "observabilityImpact"]) {
+      assert.ok(
+        sliceDescription!.includes(field),
+        `slice schema description should name ${field} as part of the full-slice contract`,
+      );
+    }
+
+    // Each heavy field should carry a field-level description that marks it
+    // REQUIRED unless isSketch=true.
+    const shape: Record<string, any> = element._def.shape;
+    assert.ok(shape, "expected to introspect slice object shape");
+    for (const field of ["successCriteria", "proofLevel", "integrationClosure", "observabilityImpact"] as const) {
+      const fieldDescription: string | undefined = shape[field]?.description;
+      assert.ok(
+        fieldDescription && /REQUIRED\s+unless\s+isSketch/i.test(fieldDescription),
+        `${field} description must state "REQUIRED unless isSketch=true"; got: ${fieldDescription}`,
+      );
+    }
+  });
+
   it("gsd_plan_milestone requires sketchScope when isSketch=true and skips heavy fields", async () => {
     const base = makeTmpBase();
     try {

--- a/packages/mcp-server/src/workflow-tools.ts
+++ b/packages/mcp-server/src/workflow-tools.ts
@@ -875,6 +875,17 @@ const nonEmptyStringArray = (field: string) =>
 // empty/whitespace fields at parse time. Without this, MCP callers pass "" for
 // the heavy planning fields, Zod accepts it, and the executor rejects one
 // field per call — forcing the agent into a retry loop to discover every gap.
+//
+// #4759 follow-up: the four heavy fields are Zod-optional because sketch
+// slices (isSketch=true) legitimately omit them, but they are REQUIRED for
+// every other slice. The conditional requirement is invisible in the JSON
+// Schema `required` array, so callers can only discover it from the
+// descriptions or by hitting the runtime superRefine below. The `.describe()`
+// calls below make that contract unmistakable in the tool schema sent to
+// agents; the superRefine enforces it at parse time.
+const HEAVY_FIELD_DESCRIBE = (field: string) =>
+  `${field} for this slice. REQUIRED unless isSketch=true (sketch slices defer this to refine-slice).`;
+
 const planMilestoneSliceSchema = z.object({
   sliceId: nonEmptyString("sliceId"),
   title: nonEmptyString("title"),
@@ -883,14 +894,16 @@ const planMilestoneSliceSchema = z.object({
   demo: nonEmptyString("demo"),
   goal: nonEmptyString("goal"),
   // ADR-011: heavy planning fields are optional for sketch slices; required for full slices.
-  successCriteria: z.string().optional(),
-  proofLevel: z.string().optional(),
-  integrationClosure: z.string().optional(),
-  observabilityImpact: z.string().optional(),
+  successCriteria: z.string().optional().describe(HEAVY_FIELD_DESCRIBE("successCriteria")),
+  proofLevel: z.string().optional().describe(HEAVY_FIELD_DESCRIBE("proofLevel")),
+  integrationClosure: z.string().optional().describe(HEAVY_FIELD_DESCRIBE("integrationClosure")),
+  observabilityImpact: z.string().optional().describe(HEAVY_FIELD_DESCRIBE("observabilityImpact")),
   // ADR-011 sketch-then-refine fields.
-  isSketch: z.boolean().optional().describe("ADR-011: true marks this slice as a sketch awaiting refine-slice expansion"),
+  isSketch: z.boolean().optional().describe("ADR-011: true marks this slice as a sketch awaiting refine-slice expansion. When true, successCriteria/proofLevel/integrationClosure/observabilityImpact may be omitted and sketchScope becomes required."),
   sketchScope: z.string().optional().describe("ADR-011: 2-3 sentence scope boundary, required when isSketch=true"),
-}).superRefine((slice, ctx) => {
+}).describe(
+  "Planned slice. For full slices (isSketch omitted or false): successCriteria, proofLevel, integrationClosure, and observabilityImpact are all required. For sketch slices (isSketch=true): those four fields may be omitted, but sketchScope is required.",
+).superRefine((slice, ctx) => {
   if (slice.isSketch === true) {
     if (typeof slice.sketchScope !== "string" || slice.sketchScope.trim().length === 0) {
       ctx.addIssue({


### PR DESCRIPTION
## TL;DR

**What:** Add REQUIRED-unless-isSketch language to the descriptions of the four heavy `plan_milestone` slice fields plus a top-level slice-schema description.
**Why:** The conditional requirement was invisible in the JSON Schema; agents discovered it only by hitting a `-32602 / code: "custom"` error mid-call and retrying, feeding a spurious loop alongside the stale-cache bug fixed in #4759.
**How:** Pure description change. Runtime enforcement via the existing `superRefine` is unchanged.

## What

- `packages/mcp-server/src/workflow-tools.ts` — new `HEAVY_FIELD_DESCRIBE` helper wraps each heavy slice field's `.describe()` with "REQUIRED unless isSketch=true". Top-level `.describe()` added to the slice schema stating the full-vs-sketch contract. `.describe()` on `isSketch` expanded to name the four heavy fields and `sketchScope` as conditional partners. `superRefine` body unchanged.
- `packages/mcp-server/src/workflow-tools.test.ts` — new test `gsd_plan_milestone surfaces the full-vs-sketch conditional requirement in the tool schema` introspects the registered tool and pins the descriptions so future edits can't silently strip them.

## Why

On full (non-sketch) slices, the four heavy fields `successCriteria`, `proofLevel`, `integrationClosure`, `observabilityImpact` are required. In the current schema they are declared `z.string().optional()` (because sketch slices legitimately omit them), with a `superRefine` enforcing non-empty at runtime when `isSketch !== true`. The requirement is correct but invisible — Zod serializes the schema into a JSON Schema where each field lands in the `required` array only if it is non-optional at the object level, so agents calling the tool never see these as required. They omit the fields, hit `-32602 Input validation error` with `path: ["slices", 0, "successCriteria"]` and `code: "custom"`, and are left to discover the contract through trial and error.

A full discriminated-union refactor would fix this at the JSON Schema level but would break the 3-valued `isSketch` semantics (`true` / `false` / `undefined`) that the extension executor relies on at `src/resources/extensions/gsd/tools/plan-milestone.ts:138-145` to preserve existing `is_sketch` state on re-plan via `ON CONFLICT`. That is a larger change requiring coordinated updates to the TypeBox schema, the executor, and the LLM prompts, and is out of scope for this bug fix.

This change makes the contract unmissable in the tool schema (which agents read) without touching any runtime behavior.

## How

Placement: descriptions only. `.describe()` output is included in the MCP tool schema surface that agents consume. The `superRefine` continues to enforce the constraint at parse time with field-level error messages.

Alternatives considered:
- Full `z.discriminatedUnion("isSketch", [...])`: rejected — requires callers to set `isSketch` explicitly and collapses the executor's 3-valued semantics.
- `z.string().min(1).optional()` on the heavy fields: rejected — still serializes as optional in the JSON Schema `required` array; no agent-visible signal.
- `z.union([sketchBranch, fullBranch])`: rejected — Zod union errors are not field-specific and would regress the existing "rejects empty slice fields up front with all violations" test.

## Change type

- [x] `fix` — Bug fix

## Testing

- New introspection test pins the descriptions (`workflow-tools.test.ts` — `surfaces the full-vs-sketch conditional requirement in the tool schema`).
- Full `workflow-tools.test.ts` suite: 27/27 passing (existing error-message assertions intact — `superRefine` behavior unchanged).
- `npm run build` passes.

## AI-assisted contribution

This PR was AI-assisted. The invisible-refinement root cause was identified during parallel debugging on the companion loop fix in #4759; the pragmatic description-only approach was chosen after peer review weighed a full discriminated-union refactor and concluded it would break the 3-valued `isSketch` executor semantics without a coordinated multi-file change.

Related: follow-up to #4759 (the milestone-bootstrap loop fix) — the two PRs address adjacent failure modes in the same flow.