### PR TITLE
fix(gsd): align headless milestone bootstrap with interactive flow

### DIFF
--- a/src/resources/extensions/gsd/guided-flow.ts
+++ b/src/resources/extensions/gsd/guided-flow.ts
@@ -825,8 +825,13 @@ export async function showHeadlessMilestoneCreation(
   // Set pending auto start (auto-mode triggers on "Milestone X ready." via checkAutoStartAfterDiscuss)
   pendingAutoStartMap.set(basePath, { ctx, pi, basePath, milestoneId: nextId, createdAt: Date.now() });
 
-  // Dispatch — headless milestone creation is a planning activity
-  await dispatchWorkflow(pi, prompt, "gsd-run", ctx, "plan-milestone");
+  // Dispatch as discuss-milestone. The LLM writes PROJECT.md, REQUIREMENTS.md,
+  // and CONTEXT.md, then calls gsd_plan_milestone — this is semantically the
+  // discuss path, just non-interactive. Using "plan-milestone" here caused
+  // model/tool routing to skip discuss-flow tool scoping and
+  // `checkAutoStartAfterDiscuss` guardrails that rely on the
+  // "discuss-"-prefixed unitType.
+  await dispatchWorkflow(pi, prompt, "gsd-run", ctx, "discuss-milestone");
 }
 
 

--- a/src/resources/extensions/gsd/prompts/discuss-headless.md
+++ b/src/resources/extensions/gsd/prompts/discuss-headless.md
@@ -164,9 +164,18 @@ Preserve the specification's exact terminology, emphasis, and specific framing. 
 
 ### Ready-phrase pre-condition (NON-BYPASSABLE)
 
-Before emitting the ready phrase, verify in the CURRENT turn that you have written `.gsd/PROJECT.md`, `.gsd/REQUIREMENTS.md`, `{{contextPath}}`, and called `gsd_plan_milestone`. If any is missing, **STOP** — emit the missing tool calls in this same turn. The system rejects premature ready signals and retries are capped.
+Before emitting the ready phrase, verify in the CURRENT turn that you have:
 
-After writing the files, say exactly: "Milestone {{milestoneId}} ready." — nothing else. Auto-mode will start automatically.
+- [ ] Written `.gsd/PROJECT.md` (step 2)
+- [ ] Written `.gsd/REQUIREMENTS.md` (step 3)
+- [ ] Written `{{contextPath}}` (step 4)
+- [ ] Called `gsd_plan_milestone` (step 5)
+
+If ANY box is unchecked, **STOP**. Do NOT emit the ready phrase. Emit the missing tool calls in this same turn. The system detects missing artifacts and will reject premature ready signals — you will be asked again and retries are capped.
+
+Do not announce the ready phrase as something you are "about to" do. Do not narrate "now writing the files" as a substitute for actually writing them. The ready phrase is a post-write signal, not an intent signal.
+
+After completing steps 1–7 above, say exactly: "Milestone {{milestoneId}} ready." — nothing else. Auto-mode will start automatically.
 
 ### Multi-Milestone
 
@@ -240,9 +249,19 @@ For single-milestone projects, do NOT write this file.
 
 ### Ready-phrase pre-condition (NON-BYPASSABLE)
 
-Before emitting the ready phrase, verify in the CURRENT turn that you have written `.gsd/PROJECT.md`, `.gsd/REQUIREMENTS.md`, the primary `CONTEXT.md`, called `gsd_plan_milestone` for the primary milestone, and written `.gsd/DISCUSSION-MANIFEST.json` with `gates_completed === total`. If any is missing, **STOP** — emit the missing tool calls in this same turn. The system rejects premature ready signals and retries are capped.
+Before emitting the ready phrase, verify in the CURRENT turn that you have:
 
-After writing the files, say exactly: "Milestone {{milestoneId}} ready." — nothing else. Auto-mode will start automatically.
+- [ ] Written `.gsd/PROJECT.md`
+- [ ] Written `.gsd/REQUIREMENTS.md`
+- [ ] Written the primary milestone `CONTEXT.md`
+- [ ] Called `gsd_plan_milestone` for the primary milestone
+- [ ] Written `.gsd/DISCUSSION-MANIFEST.json` with `gates_completed === total`
+
+If ANY box is unchecked, **STOP**. Do NOT emit the ready phrase. Emit the missing tool calls in this same turn. The system detects missing artifacts and will reject premature ready signals — you will be asked again and retries are capped.
+
+Do not announce the ready phrase as something you are "about to" do. Do not narrate "now writing the files" as a substitute for actually writing them. The ready phrase is a post-write signal, not an intent signal.
+
+After completing every step above, say exactly: "Milestone {{milestoneId}} ready." — nothing else. Auto-mode will start automatically.
 
 ## Critical Rules
 

--- a/src/resources/extensions/gsd/tests/headless-milestone-parity.test.ts
+++ b/src/resources/extensions/gsd/tests/headless-milestone-parity.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Regression tests for the headless vs interactive milestone-bootstrap divergence.
+ *
+ * Two defects were covered here:
+ *   1. `showHeadlessMilestoneCreation` dispatched with `unitType: "plan-milestone"`
+ *      instead of `"discuss-milestone"`. The `discuss-` prefix drives tool
+ *      scoping (`guided-flow.ts:583`) and enables the `checkAutoStartAfterDiscuss`
+ *      guardrails — routing through `plan-milestone` bypassed them even
+ *      though headless is semantically a discuss flow.
+ *   2. The `discuss-headless.md` ready-phrase pre-condition was a prose
+ *      sentence, so models that treated it as advisory could skip ahead to
+ *      the ready phrase without actually writing the artifacts. The checkbox
+ *      format from `discuss.md` has lower abstraction cost and is harder to
+ *      rationalize past.
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const GUIDED_FLOW_PATH = join(__dirname, "..", "guided-flow.ts");
+const DISCUSS_HEADLESS_PATH = join(__dirname, "..", "prompts", "discuss-headless.md");
+
+function getGuidedFlowSource(): string {
+  return readFileSync(GUIDED_FLOW_PATH, "utf-8");
+}
+
+function getHeadlessPromptSource(): string {
+  return readFileSync(DISCUSS_HEADLESS_PATH, "utf-8");
+}
+
+describe("headless milestone bootstrap — parity with interactive flow", () => {
+  test("showHeadlessMilestoneCreation dispatches as discuss-milestone, not plan-milestone", () => {
+    const source = getGuidedFlowSource();
+    const fnStart = source.indexOf("export async function showHeadlessMilestoneCreation");
+    assert.ok(fnStart > -1, "showHeadlessMilestoneCreation must exist");
+
+    // Scope: from the function start to the next top-level export (or EOF).
+    const nextExport = source.indexOf("\nexport ", fnStart + 1);
+    const fnBody = source.slice(fnStart, nextExport === -1 ? source.length : nextExport);
+
+    // Match only the actual dispatchWorkflow call — comments in the body
+    // may mention "plan-milestone" as part of the fix rationale.
+    const dispatchMatches = [...fnBody.matchAll(/dispatchWorkflow\([^)]*,\s*"([^"]+)"\s*\)/g)];
+    assert.strictEqual(
+      dispatchMatches.length,
+      1,
+      `expected exactly one dispatchWorkflow call, found ${dispatchMatches.length}`,
+    );
+    assert.strictEqual(
+      dispatchMatches[0][1],
+      "discuss-milestone",
+      `showHeadlessMilestoneCreation must dispatch as "discuss-milestone" so tool scoping and discuss-flow guardrails apply; got "${dispatchMatches[0][1]}"`,
+    );
+  });
+
+  test("discuss-headless single-milestone pre-condition uses the non-bypassable checkbox format", () => {
+    const source = getHeadlessPromptSource();
+    const section = source.split("### Multi-Milestone")[0];
+    assert.ok(
+      /### Ready-phrase pre-condition \(NON-BYPASSABLE\)/.test(section),
+      "single-milestone ready-phrase section must be present",
+    );
+    // All four required artifacts must appear as checkboxes, not a prose list.
+    for (const artifact of [
+      "`.gsd/PROJECT.md`",
+      "`.gsd/REQUIREMENTS.md`",
+      "`{{contextPath}}`",
+      "`gsd_plan_milestone`",
+    ]) {
+      assert.ok(
+        new RegExp(`- \\[ \\] [A-Za-z]+ ${artifact.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`).test(section),
+        `single-milestone pre-condition must include a checkbox for ${artifact}`,
+      );
+    }
+    assert.ok(
+      /If ANY box is unchecked, \*\*STOP\*\*/.test(section),
+      "single-milestone pre-condition must include the 'If ANY box is unchecked, STOP' sentinel",
+    );
+    assert.ok(
+      /Do not announce the ready phrase as something you are "about to" do/.test(section),
+      "single-milestone pre-condition must include the 'do not announce intent' guard",
+    );
+  });
+
+  test("discuss-headless multi-milestone pre-condition uses the non-bypassable checkbox format", () => {
+    const source = getHeadlessPromptSource();
+    const multiIdx = source.indexOf("### Multi-Milestone");
+    assert.ok(multiIdx > -1, "multi-milestone section must be present");
+    const multiSection = source.slice(multiIdx);
+
+    assert.ok(
+      /### Ready-phrase pre-condition \(NON-BYPASSABLE\)/.test(multiSection),
+      "multi-milestone ready-phrase section must be present",
+    );
+    for (const artifact of [
+      "`.gsd/PROJECT.md`",
+      "`.gsd/REQUIREMENTS.md`",
+      "`gsd_plan_milestone`",
+      "`.gsd/DISCUSSION-MANIFEST.json`",
+    ]) {
+      const escaped = artifact.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      assert.ok(
+        new RegExp(`- \\[ \\] [\\s\\S]*?${escaped}`).test(multiSection),
+        `multi-milestone pre-condition must include a checkbox referencing ${artifact}`,
+      );
+    }
+    assert.ok(
+      /gates_completed === total/.test(multiSection),
+      "multi-milestone pre-condition must still enforce gates_completed === total",
+    );
+  });
+});


### PR DESCRIPTION
## TL;DR

**What:** Dispatch `showHeadlessMilestoneCreation` as `discuss-milestone` (not `plan-milestone`) and port the interactive checkbox ready-phrase pre-condition into `discuss-headless.md` for both single- and multi-milestone sections.
**Why:** Headless bootstrap was skipping artifact writes and emitting the ready phrase prematurely because (a) wrong unitType routed through the planning model pool and bypassed discuss-flow signals, and (b) the prose pre-condition was easy for models to treat as advisory.
**How:** One-line dispatch change + two prompt pre-condition sections rewritten in checkbox form, mirroring `discuss.md:342-353`.

## What

- `src/resources/extensions/gsd/guided-flow.ts` — `showHeadlessMilestoneCreation` now dispatches with `unitType: "discuss-milestone"`. Comment explains why (headless is semantically discuss, just non-interactive).
- `src/resources/extensions/gsd/prompts/discuss-headless.md` — both `### Ready-phrase pre-condition (NON-BYPASSABLE)` sections (single- and multi-milestone) rewritten from prose to checkbox format. Checkboxes enumerate each required artifact; the `If ANY box is unchecked, STOP` sentinel and the `do not announce intent` guard are both imported verbatim from `discuss.md`.
- `src/resources/extensions/gsd/tests/headless-milestone-parity.test.ts` — new structural test pinning the dispatch unitType and the checkbox format, so future edits can't silently drift.

## Why

Agent-5's investigation into a milestone-bootstrap loop found two structural gaps in the headless path versus the interactive path:

1. **Wrong unitType.** `dispatchWorkflow(..., "plan-milestone")` at `guided-flow.ts:829` meant:
   - `selectAndApplyModel` at `guided-flow.ts:528` routed the session as a planner (`models.planning`) instead of a discuss agent (`models.discuss`).
   - The `unitType.startsWith("discuss-")` guard at `guided-flow.ts:583` never fired, so discuss-flow tool scoping didn't apply.

   Headless is a discuss-flow variant — it just doesn't ask the user questions. The unit boundary is the same: scope discussion context, write PROJECT/REQUIREMENTS/CONTEXT, call `gsd_plan_milestone`, emit ready phrase. The correct unitType is `discuss-milestone`.

2. **Prose pre-condition.** The interactive prompt uses an explicit checklist with a non-bypassable sentinel:
   ```
   - [ ] Written `.gsd/PROJECT.md` (step 2)
   - [ ] Written `.gsd/REQUIREMENTS.md` (step 3)
   - [ ] Written `{{contextPath}}` (step 4)
   - [ ] Called `gsd_plan_milestone` (step 5)
   If ANY box is unchecked, **STOP**. …
   Do not announce the ready phrase as something you are "about to" do. …
   ```
   The headless prompt collapsed that into a single prose sentence. Models that treat the checklist as a "check this then move on" action are far less likely to skip ahead than models parsing a prose sentence for advisory obligations.

The combined effect was that headless runs emitted "Milestone M001 ready." without writing the artifacts, triggered `maybeHandleReadyPhraseWithoutFiles`, hit `MAX_READY_REJECTS`, and gave up — surfacing as the observed infinite loop in the bug report that also produced #4759.

## How

**Dispatch fix.** One-line change at `guided-flow.ts:829`. The `discuss-`-prefixed unitType is the only signal `guided-flow.ts:583-598` checks for tool scoping; everything else (`pendingAutoStartMap`, `checkAutoStartAfterDiscuss`, `maybeHandleReadyPhraseWithoutFiles`) keys off the pending-auto-start entry that `showHeadlessMilestoneCreation` already sets at `:826`.

**Prompt fix.** Ported the full `Ready-phrase pre-condition` section from `discuss.md:342-355` to `discuss-headless.md`'s single-milestone section, and a matching version with the manifest step for the multi-milestone section. Both sections retain the checkbox format, the `If ANY box is unchecked, STOP` sentinel, and the `Do not announce intent` guard.

Alternatives considered:
- **Rewrite the entire `discuss-headless.md`:** out of scope. The existing body (reflection → investigation → depth checklist → research → output phase) is working; only the pre-condition was structurally weak.
- **Add a mechanical gate like `write-gate.ts` but for PROJECT.md/REQUIREMENTS.md:** out of scope for this PR. Would be the correct long-term fix but requires coordinated changes across write-gate semantics, prompts, and doctor heal. Track separately if needed.
- **Unify `discuss.md` and `discuss-headless.md` into a single templated prompt:** out of scope. The two prompts legitimately diverge on user-interaction shape; unifying them is a larger DRY exercise that would pollute this bug fix.

## Change type

- [x] `fix` — Bug fix

## Testing

- New structural test `headless-milestone-parity.test.ts` pins the dispatch unitType and the checkbox format for both single- and multi-milestone sections.
- Adjacent suites (`ready-phrase-no-files-4573.test.ts`, `prompt-contracts.test.ts`, `discuss-tool-scoping.test.ts`): 63/63 passing — no regressions.
- `npm run build` passes.

## AI-assisted contribution

This PR was AI-assisted. The divergence was uncovered by an agent investigation into the bootstrap loop that produced #4759, #4760, and #4763. The dispatch fix is a mechanical one-liner; the prompt changes port an existing, battle-tested section from `discuss.md` into the headless counterpart without introducing novel language.

Related: #4759 (dirListCache flush), #4760 (plan_milestone schema discoverability), #4763 (execution-entry missing-CONTEXT recovery). These four PRs together address the milestone bootstrap failure chain.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed headless milestone creation to properly route through the discussion flow, ensuring consistent artifact generation and workflow behavior between interactive and headless modes.

* **Tests**
  * Added regression test suite to validate parity between interactive and headless milestone creation flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->