### PR TITLE
Fix worktree orphan class + slice-cadence opt-in (#4761, #4762, #4764, #4765)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+- **gsd**: worktree lifespan + divergence telemetry via journal events (#4764). New event types `worktree-created`, `worktree-merged`, `worktree-orphaned`, `auto-exit`, `canonical-root-redirect`, `slice-merged`, `milestone-resquash`. New `summarizeWorktreeTelemetry` aggregator returns counts, orphan breakdown, merge durations, conflict counts, exit reasons, and producer-side "exits with unmerged work" metric.
+- **gsd**: `/gsd forensics` surfaces worktree telemetry — new Worktree Telemetry section in reports; new anomalies `worktree-orphan` and `worktree-unmerged-exit` (#4764).
+- **gsd**: opt-in slice-cadence worktree collapse (#4765). New `git.collapse_cadence: "milestone" | "slice"` preference (default `milestone`). When set to `slice`, each validated slice is squash-merged to main immediately, shrinking the orphan window from milestone-size to slice-size. Optional `git.milestone_resquash: true` (default when cadence=slice) collapses per-slice commits into one milestone commit at milestone completion.
+- **gsd**: worktree-aware `resolveCanonicalMilestoneRoot` helper (#4761) — validators and cross-session readers now route through it so a live worktree for a milestone is preferred over stale project-root state.
+
+### Fixed
+- **gsd**: milestone validation silently read stale project-root state when a live worktree held the real work (#4761). `handleValidateMilestone` now routes through `resolveCanonicalMilestoneRoot` so validation sees the canonical scope regardless of caller cwd.
+- **gsd**: bootstrap orphan audit no longer skips in-progress milestones (#4762). When `milestone/<MID>` has commits ahead of main and the DB still reads `in_progress` (auto-mode interrupted before completion), the audit now emits a warning with the commit count and worktree location so the user knows where to resume.
+
 ## [2.77.0] - 2026-04-21
 
 ### Added

--- a/gitbook/configuration/git-settings.md
+++ b/gitbook/configuration/git-settings.md
@@ -73,7 +73,52 @@ git:
   manage_gitignore: true      # let GSD manage .gitignore
   auto_pr: false              # create PR on milestone completion
   pr_target_branch: develop   # PR target branch
+  collapse_cadence: milestone # "milestone" (default) or "slice"
+  milestone_resquash: true    # re-squash slice commits at milestone end (cadence=slice)
 ```
+
+## Collapse Cadence
+
+`git.collapse_cadence` controls **when** work is squash-merged from the milestone branch back to main.
+
+| Value | When main gets updated | Orphan window | Best for |
+|-------|------------------------|---------------|----------|
+| `milestone` (default) | Once, at milestone completion | Entire milestone | Small milestones, clean PR history |
+| `slice` | Each time a slice passes validation | One slice | Large milestones, long-running sessions, parallel work |
+
+### Slice Cadence
+
+When `collapse_cadence: "slice"`, each slice's commits are squash-merged to main as soon as the slice passes validation. The milestone branch is then fast-forwarded to main so the next slice starts from a clean base.
+
+Benefits:
+- **Shorter orphan window** — if a session is interrupted, only the active slice's work is at risk, not the whole milestone.
+- **Incremental conflicts** — merge conflicts surface per slice rather than all at once at milestone end.
+- **Parallel-friendly** — multiple milestones can safely merge their validated slices to main without waiting for the slowest one.
+
+Trade-off: without re-squash, main accumulates N commits per milestone (one per slice) instead of one.
+
+```yaml
+git:
+  collapse_cadence: slice
+```
+
+### Milestone Re-squash
+
+When `collapse_cadence: "slice"` AND `milestone_resquash: true` (the default when cadence is slice), GSD collapses the per-slice commits on main into a single milestone commit at milestone completion. Main history looks identical to `collapse_cadence: "milestone"` — one commit per milestone — but the orphan-window and incremental-conflict benefits of slice cadence are preserved.
+
+Set `milestone_resquash: false` if you want the slice commits preserved in main history (for bisect granularity, per-slice revert, etc.).
+
+```yaml
+git:
+  collapse_cadence: slice
+  milestone_resquash: false   # keep slice commits in main history
+```
+
+### Which to use?
+
+- **Default (`milestone`)** is fine for most projects. Each milestone produces one commit on main.
+- **`slice`** pays off when milestones have 5+ slices, long wall-clock time, or you've hit orphan issues after interrupted sessions.
+- Run `/gsd forensics` after sessions to see orphan detection and merge telemetry — the **Worktree Telemetry** section reports how often work was stranded, which informs whether slice cadence would help.
 
 ## Automatic Pull Requests
 

--- a/gitbook/configuration/preferences.md
+++ b/gitbook/configuration/preferences.md
@@ -52,6 +52,8 @@ git:
   auto_push: true
   merge_strategy: squash
   isolation: worktree
+  collapse_cadence: milestone   # or "slice" — see Git & Worktrees docs
+  milestone_resquash: true       # collapse slice commits into one at milestone end
 
 # Verification
 verification_commands:

--- a/gitbook/configuration/preferences.md
+++ b/gitbook/configuration/preferences.md
@@ -53,7 +53,8 @@ git:
   merge_strategy: squash
   isolation: worktree
   collapse_cadence: milestone   # or "slice" — see Git & Worktrees docs
-  milestone_resquash: true       # collapse slice commits into one at milestone end
+  # milestone_resquash applies only when collapse_cadence: "slice"
+  # milestone_resquash: true    # collapse slice commits into one at milestone end
 
 # Verification
 verification_commands:

--- a/gitbook/core-concepts/auto-mode.md
+++ b/gitbook/core-concepts/auto-mode.md
@@ -175,9 +175,25 @@ After a milestone completes, GSD generates a self-contained HTML report in `.gsd
 If auto mode has issues, GSD provides two diagnostic tools:
 
 - **`/gsd doctor`** — validates `.gsd/` integrity, checks referential consistency, fixes structural issues
-- **`/gsd forensics`** — full post-mortem debugger with anomaly detection, unit traces, metrics analysis, and AI-guided investigation
+- **`/gsd forensics`** — full post-mortem debugger with anomaly detection, unit traces, metrics analysis, worktree lifecycle telemetry, and AI-guided investigation
 
 ```
 /gsd doctor
 /gsd forensics [optional problem description]
 ```
+
+### Worktree Telemetry in Forensics Reports
+
+`/gsd forensics` includes a **Worktree Telemetry** section that summarizes the auto-mode worktree lifecycle across recorded sessions:
+
+- **Created / Merged / Conflicts** — counts of worktree creation and merge-back events, plus merge-conflict occurrences.
+- **Orphans detected** — milestones whose branch or worktree directory was stranded (e.g. after an interrupted session). Broken out by reason (in-progress-unmerged, complete-unmerged).
+- **Unmerged exits** — auto-mode sessions that exited (pause, stop, blocked, crash) without merging the active milestone. This is the producer-side signal for orphaned work; a non-zero count here points at sessions that should have merged but didn't.
+- **Merge duration p50 / p95** — how long `mergeMilestoneToMain` takes in practice. Useful when evaluating whether `collapse_cadence: "slice"` would help (long milestone merges often indicate large divergence that slice cadence would amortize).
+- **Canonical-root redirects** — how often validation correctly routed to a worktree instead of stale project-root state.
+
+Two anomaly types surface from telemetry:
+- `worktree-orphan` — one per orphan reason-bucket
+- `worktree-unmerged-exit` — aggregate signal across the window
+
+For per-event detail (specific milestone IDs, timestamps, exit reasons) inspect `.gsd/journal/*.jsonl` directly.

--- a/gitbook/reference/commands.md
+++ b/gitbook/reference/commands.md
@@ -23,7 +23,7 @@
 | `/gsd debug --diagnose` | Inspect malformed artifacts and session health (`--diagnose [<slug> | <issue text>]`) |
 | `/gsd dispatch` | Dispatch a specific phase directly |
 | `/gsd history` | View execution history (supports `--cost`, `--phase`, `--model` filters) |
-| `/gsd forensics` | Full debugger for auto-mode failures |
+| `/gsd forensics` | Full debugger for auto-mode failures (includes worktree lifecycle telemetry) |
 | `/gsd cleanup` | Clean up state files and stale worktrees |
 | `/gsd visualize` | Open workflow visualizer |
 | `/gsd export --html` | Generate HTML report for current milestone |

--- a/gitbook/reference/troubleshooting.md
+++ b/gitbook/reference/troubleshooting.md
@@ -82,6 +82,18 @@ Worktree merge fails on `.gsd/` files.
 
 **Fix:** `.gsd/` conflicts are auto-resolved. Code conflicts get an AI fix attempt; if that fails, resolve manually.
 
+### Work stranded in a worktree after an interrupted session
+
+Auto mode was paused, stopped, or crashed mid-milestone, and the work is still on the `milestone/<MID>` branch in `.gsd/worktrees/<MID>/` — never merged back to main. Next session reports the milestone as incomplete or behaving inconsistently.
+
+**Fix:** As of GSD 2.78, `/gsd auto` bootstrap automatically detects this condition and surfaces a warning naming the branch, commit count, and worktree location. Run `/gsd auto` to re-enter the worktree and resume; or merge `milestone/<MID>` into main manually if abandoning.
+
+**Diagnose:** Run `/gsd forensics` and look at the **Worktree Telemetry** section:
+- `Orphans detected > 0` with reason `in-progress-unmerged` confirms the condition
+- `Unmerged exits > 0` on the producer side confirms which exit type caused it
+
+**Prevent recurrence:** If your milestones are large or sessions are frequently interrupted, consider setting `git.collapse_cadence: "slice"` in preferences — validated slices merge to main immediately, shrinking the orphan window from milestone-size to slice-size. See [Git & Worktrees](../configuration/git-settings.md#collapse-cadence).
+
 ### Notifications not appearing on macOS
 
 **Fix:** Install `terminal-notifier`:

--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -618,6 +618,69 @@ export async function postUnitPreVerification(pctx: PostUnitContext, opts?: PreV
           clearReactiveState(s.basePath, mid, sid);
         }
       });
+
+      // #4765 — slice-cadence collapse. When `git.collapse_cadence: "slice"`
+      // is set, squash-merge the slice's commits from the milestone branch
+      // onto main right here, so orphan risk shrinks from milestone-size to
+      // slice-size. Only runs in worktree isolation mode — the feature needs
+      // a milestone branch to squash from.
+      await runSafely("postUnit", "slice-cadence-merge", async () => {
+        const prefsResult = loadEffectiveGSDPreferences(s.basePath);
+        const prefs = prefsResult?.preferences;
+        const { getCollapseCadence, mergeSliceToMain } = await import("./slice-cadence.js");
+        if (getCollapseCadence(prefs) !== "slice") return;
+        if (prefs?.git?.isolation !== "worktree") return;
+        if (s.isolationDegraded) return;
+
+        const projectRoot = s.originalBasePath || s.basePath;
+        const { milestone: mid, slice: sid } = parseUnitId(unit.id);
+        if (!mid || !sid) return;
+
+        // Record the milestone start SHA before the first slice merge, so
+        // resquashMilestoneOnMain has a target at milestone completion.
+        if (!s.milestoneStartShas.has(mid)) {
+          try {
+            const { nativeCommitCountBetween: _c } = await import("./native-git-bridge.js");
+            // Use plumbing directly rather than adding another native helper.
+            const { execFileSync } = await import("node:child_process");
+            const sha = execFileSync("git", ["rev-parse", "main"], {
+              cwd: projectRoot, stdio: ["ignore", "pipe", "pipe"], encoding: "utf-8",
+            }).trim();
+            if (sha) s.milestoneStartShas.set(mid, sha);
+          } catch (err) {
+            logWarning("engine", `slice-cadence: failed to record milestone start SHA: ${err instanceof Error ? err.message : String(err)}`);
+          }
+        }
+
+        try {
+          const result = mergeSliceToMain(projectRoot, mid, sid);
+          if (result.skipped) {
+            logWarning("engine", `slice-cadence: merge skipped for ${sid} — ${result.skippedReason}`);
+            return;
+          }
+          ctx.ui.notify(
+            `slice-cadence: ${sid} merged to main (${result.durationMs}ms).`,
+            "info",
+          );
+        } catch (err) {
+          const { MergeConflictError } = await import("./git-service.js");
+          if (err instanceof MergeConflictError) {
+            ctx.ui.notify(
+              `slice-cadence merge conflict in ${sid}: ${err.conflictedFiles.join(", ")}. ` +
+              `Resolve manually on main and run \`/gsd auto\` to resume.`,
+              "error",
+            );
+            // Surface as a blocker so the auto loop stops rather than
+            // dispatching the next slice on top of a conflicted main.
+            const { stopAuto } = await import("./auto.js");
+            await stopAuto(ctx, undefined, `slice-merge-conflict on ${sid}`);
+            return;
+          }
+          logError("engine", `slice-cadence merge failed for ${sid}`, {
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+      });
     }
 
     // Post-triage: execute actionable resolutions

--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -624,6 +624,7 @@ export async function postUnitPreVerification(pctx: PostUnitContext, opts?: PreV
       // onto main right here, so orphan risk shrinks from milestone-size to
       // slice-size. Only runs in worktree isolation mode — the feature needs
       // a milestone branch to squash from.
+      let sliceMergeStopped = false;
       await runSafely("postUnit", "slice-cadence-merge", async () => {
         const prefsResult = loadEffectiveGSDPreferences(s.basePath);
         const prefs = prefsResult?.preferences;
@@ -638,12 +639,14 @@ export async function postUnitPreVerification(pctx: PostUnitContext, opts?: PreV
 
         // Record the milestone start SHA before the first slice merge, so
         // resquashMilestoneOnMain has a target at milestone completion.
+        // Resolve main branch dynamically — hard-coding "main" breaks repos
+        // that use "master" or a custom default branch.
         if (!s.milestoneStartShas.has(mid)) {
           try {
-            const { nativeCommitCountBetween: _c } = await import("./native-git-bridge.js");
-            // Use plumbing directly rather than adding another native helper.
+            const { nativeDetectMainBranch } = await import("./native-git-bridge.js");
+            const mainBranch = nativeDetectMainBranch(projectRoot);
             const { execFileSync } = await import("node:child_process");
-            const sha = execFileSync("git", ["rev-parse", "main"], {
+            const sha = execFileSync("git", ["rev-parse", mainBranch], {
               cwd: projectRoot, stdio: ["ignore", "pipe", "pipe"], encoding: "utf-8",
             }).trim();
             if (sha) s.milestoneStartShas.set(mid, sha);
@@ -670,10 +673,13 @@ export async function postUnitPreVerification(pctx: PostUnitContext, opts?: PreV
               `Resolve manually on main and run \`/gsd auto\` to resume.`,
               "error",
             );
-            // Surface as a blocker so the auto loop stops rather than
-            // dispatching the next slice on top of a conflicted main.
+            // Stop auto AND signal the outer postUnit flow to exit early.
+            // Without the flag, subsequent hooks (triage, rogue detection,
+            // DB writes) would keep running against a conflicted main
+            // checkout after the loop was already told to stop.
             const { stopAuto } = await import("./auto.js");
             await stopAuto(ctx, undefined, `slice-merge-conflict on ${sid}`);
+            sliceMergeStopped = true;
             return;
           }
           logError("engine", `slice-cadence merge failed for ${sid}`, {
@@ -681,6 +687,11 @@ export async function postUnitPreVerification(pctx: PostUnitContext, opts?: PreV
           });
         }
       });
+      // Exit early after stopAuto so the rest of post-unit processing
+      // (triage, rogue detection, hook dispatch, DB writes) doesn't run
+      // against a conflicted main checkout. The auto loop will see
+      // s.active=false on the next iteration and terminate cleanly.
+      if (sliceMergeStopped) return "continue";
     }
 
     // Post-triage: execute actionable resolutions

--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -689,9 +689,10 @@ export async function postUnitPreVerification(pctx: PostUnitContext, opts?: PreV
       });
       // Exit early after stopAuto so the rest of post-unit processing
       // (triage, rogue detection, hook dispatch, DB writes) doesn't run
-      // against a conflicted main checkout. The auto loop will see
-      // s.active=false on the next iteration and terminate cleanly.
-      if (sliceMergeStopped) return "continue";
+      // against a conflicted main checkout. Return "dispatched" to match
+      // the convention used by other stop/pauseAuto paths in this function
+      // (see signal handling earlier: stop/pause also return "dispatched").
+      if (sliceMergeStopped) return "dispatched";
     }
 
     // Post-triage: execute actionable resolutions

--- a/src/resources/extensions/gsd/auto-post-unit.ts
+++ b/src/resources/extensions/gsd/auto-post-unit.ts
@@ -685,6 +685,12 @@ export async function postUnitPreVerification(pctx: PostUnitContext, opts?: PreV
           logError("engine", `slice-cadence merge failed for ${sid}`, {
             error: err instanceof Error ? err.message : String(err),
           });
+          // Non-conflict failures (dirty main, rev-walk error, etc.) can
+          // leave the checkout in an unexpected state. Stop auto-mode so
+          // the next slice doesn't dispatch on top of it.
+          const { stopAuto } = await import("./auto.js");
+          await stopAuto(ctx, undefined, `slice-merge-error on ${sid}`);
+          sliceMergeStopped = true;
         }
       });
       // Exit early after stopAuto so the rest of post-unit processing

--- a/src/resources/extensions/gsd/auto-start.ts
+++ b/src/resources/extensions/gsd/auto-start.ts
@@ -45,6 +45,7 @@ import {
   nativeBranchListMerged,
   nativeBranchDelete,
   nativeWorktreeRemove,
+  nativeCommitCountBetween,
 } from "./native-git-bridge.js";
 import { GitServiceImpl } from "./git-service.js";
 import {
@@ -185,10 +186,38 @@ export function auditOrphanedMilestoneBranches(
     const milestoneId = branch.replace(/^milestone\//, "");
     const milestone = getMilestone(milestoneId);
 
-    // Only audit completed milestones
-    if (!milestone || milestone.status !== "complete") continue;
+    if (!milestone) continue;
 
     const isMerged = mergedBranches.has(branch);
+
+    // #4762 — in-progress milestone branch with unmerged commits ahead of
+    // main. This is the pre-completion orphan case: auto-mode exited without
+    // completing the milestone (pause, stop, crash, merge error, blocker) and
+    // work is stranded on the branch or in the worktree. Data safety first:
+    // we never delete or touch; we just surface a warning so the user knows
+    // where to look.
+    if (milestone.status !== "complete") {
+      if (isMerged) continue; // nothing to recover
+      let commitsAhead = 0;
+      try {
+        commitsAhead = nativeCommitCountBetween(basePath, mainBranch, branch);
+      } catch {
+        // Rev-walk failure — skip rather than noise
+        continue;
+      }
+      if (commitsAhead === 0) continue;
+
+      const wtDir = getWorktreeDir(basePath, milestoneId);
+      const wtSuffix = existsSync(wtDir)
+        ? ` Worktree directory at .gsd/worktrees/${milestoneId}/ holds the live work.`
+        : "";
+      warnings.push(
+        `Branch ${branch} has ${commitsAhead} commit(s) ahead of ${mainBranch} for in-progress milestone ${milestoneId}.` +
+        wtSuffix +
+        ` Run \`/gsd auto\` to resume, or merge manually if abandoning.`,
+      );
+      continue;
+    }
 
     if (isMerged) {
       // Branch is merged — safe to delete branch and clean up worktree dir

--- a/src/resources/extensions/gsd/auto-start.ts
+++ b/src/resources/extensions/gsd/auto-start.ts
@@ -56,6 +56,7 @@ import {
 import { getAutoWorktreePath, isInAutoWorktree } from "./auto-worktree.js";
 import { readResourceVersion, cleanStaleRuntimeUnits } from "./auto-worktree.js";
 import { worktreePath as getWorktreeDir, isInsideWorktreesDir } from "./worktree-manager.js";
+import { emitWorktreeOrphaned } from "./worktree-telemetry.js";
 import { initMetrics } from "./metrics.js";
 import { initRoutingHistory } from "./routing-history.js";
 import { restoreHookState, resetHookState } from "./post-unit-hooks.js";
@@ -208,7 +209,8 @@ export function auditOrphanedMilestoneBranches(
       if (commitsAhead === 0) continue;
 
       const wtDir = getWorktreeDir(basePath, milestoneId);
-      const wtSuffix = existsSync(wtDir)
+      const wtDirExists = existsSync(wtDir);
+      const wtSuffix = wtDirExists
         ? ` Worktree directory at .gsd/worktrees/${milestoneId}/ holds the live work.`
         : "";
       warnings.push(
@@ -216,6 +218,16 @@ export function auditOrphanedMilestoneBranches(
         wtSuffix +
         ` Run \`/gsd auto\` to resume, or merge manually if abandoning.`,
       );
+
+      // #4764 telemetry
+      try {
+        emitWorktreeOrphaned(basePath, milestoneId, {
+          reason: "in-progress-unmerged",
+          commitsAhead,
+          worktreeDirExists: wtDirExists,
+        });
+      } catch { /* silent */ }
+
       continue;
     }
 
@@ -263,6 +275,14 @@ export function auditOrphanedMilestoneBranches(
         `Branch ${branch} exists for completed milestone ${milestoneId} but is NOT merged into ${mainBranch}. ` +
         `This may contain unmerged work. Merge manually or run \`/gsd health --fix\` to resolve.`,
       );
+
+      // #4764 telemetry
+      try {
+        emitWorktreeOrphaned(basePath, milestoneId, {
+          reason: "complete-unmerged",
+          worktreeDirExists: existsSync(getWorktreeDir(basePath, milestoneId)),
+        });
+      } catch { /* silent */ }
     }
   }
 

--- a/src/resources/extensions/gsd/auto-start.ts
+++ b/src/resources/extensions/gsd/auto-start.ts
@@ -230,7 +230,9 @@ export function auditOrphanedMilestoneBranches(
           commitsAhead,
           worktreeDirExists: wtDirExists,
         });
-      } catch { /* silent */ }
+      } catch (err) {
+        logWarning("engine", `worktree-orphaned telemetry failed for ${milestoneId}: ${err instanceof Error ? err.message : String(err)}`);
+      }
 
       continue;
     }
@@ -291,7 +293,9 @@ export function auditOrphanedMilestoneBranches(
           reason: "complete-unmerged",
           worktreeDirExists: existsSync(getWorktreeDir(basePath, milestoneId)),
         });
-      } catch { /* silent */ }
+      } catch (err) {
+        logWarning("engine", `worktree-orphaned telemetry failed for ${milestoneId}: ${err instanceof Error ? err.message : String(err)}`);
+      }
     }
   }
 

--- a/src/resources/extensions/gsd/auto-start.ts
+++ b/src/resources/extensions/gsd/auto-start.ts
@@ -197,7 +197,11 @@ export function auditOrphanedMilestoneBranches(
     // work is stranded on the branch or in the worktree. Data safety first:
     // we never delete or touch; we just surface a warning so the user knows
     // where to look.
-    if (milestone.status !== "complete") {
+    //
+    // Gate on isClosedStatus so we only warn about genuinely open milestones.
+    // Parked/other closed statuses go through the legacy complete/unmerged
+    // path below where appropriate.
+    if (!isClosedStatus(milestone.status)) {
       if (isMerged) continue; // nothing to recover
       let commitsAhead = 0;
       try {
@@ -230,6 +234,11 @@ export function auditOrphanedMilestoneBranches(
 
       continue;
     }
+
+    // Only the "complete" status participates in the merged/unmerged cleanup
+    // paths below — other closed statuses (parked, etc.) are intentionally
+    // left alone.
+    if (milestone.status !== "complete") continue;
 
     if (isMerged) {
       // Branch is merged — safe to delete branch and clean up worktree dir

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -806,7 +806,9 @@ export async function stopAuto(
       milestoneId: s.currentMilestoneId ?? undefined,
       milestoneMerged: s.milestoneMergedInPhases === true,
     });
-  } catch { /* silent */ }
+  } catch (err) {
+    logWarning("engine", `auto-exit telemetry failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
 
   try {
     // ── Step 1: Timers and locks ──

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -801,8 +801,30 @@ export async function stopAuto(
   // is exactly the pattern that strands work.
   try {
     const { emitAutoExit } = await import("./worktree-telemetry.js");
+    type AutoExitReason =
+      | "pause" | "stop" | "blocked" | "merge-conflict" | "merge-failed"
+      | "slice-merge-conflict" | "all-complete" | "no-active-milestone" | "other";
+    // Normalize the free-form reason to a closed set so the telemetry
+    // aggregator buckets stably. Raw detail is preserved in the phases.ts
+    // notification and the notify'd error string.
+    const rawReason = reason ?? "stop";
+    const normalizedReason: AutoExitReason = rawReason.startsWith("Blocked:")
+      ? "blocked"
+      : rawReason.startsWith("Merge conflict")
+        ? "merge-conflict"
+        : rawReason.startsWith("Merge error") || rawReason.startsWith("Merge failed")
+          ? "merge-failed"
+          : rawReason.startsWith("slice-merge-conflict")
+            ? "slice-merge-conflict"
+            : rawReason === "All milestones complete"
+              ? "all-complete"
+              : rawReason === "No active milestone"
+                ? "no-active-milestone"
+                : rawReason === "stop" || rawReason === "pause"
+                  ? rawReason
+                  : "other";
     emitAutoExit(s.originalBasePath || s.basePath, {
-      reason: reason ?? "stop",
+      reason: normalizedReason,
       milestoneId: s.currentMilestoneId ?? undefined,
       milestoneMerged: s.milestoneMergedInPhases === true,
     });

--- a/src/resources/extensions/gsd/auto.ts
+++ b/src/resources/extensions/gsd/auto.ts
@@ -795,6 +795,19 @@ export async function stopAuto(
   const loadedPreferences = loadEffectiveGSDPreferences(s.basePath || undefined)?.preferences;
   const reasonSuffix = reason ? ` — ${reason}` : "";
 
+  // #4764 — telemetry: record the exit reason and whether the current milestone
+  // was merged before we entered stopAuto. This is the producer-side signal for
+  // the #4761 orphan class: milestoneMerged=false + currentMilestoneId present
+  // is exactly the pattern that strands work.
+  try {
+    const { emitAutoExit } = await import("./worktree-telemetry.js");
+    emitAutoExit(s.originalBasePath || s.basePath, {
+      reason: reason ?? "stop",
+      milestoneId: s.currentMilestoneId ?? undefined,
+      milestoneMerged: s.milestoneMergedInPhases === true,
+    });
+  } catch { /* silent */ }
+
   try {
     // ── Step 1: Timers and locks ──
     try {

--- a/src/resources/extensions/gsd/auto/session.ts
+++ b/src/resources/extensions/gsd/auto/session.ts
@@ -178,6 +178,12 @@ export class AutoSession {
    *  stopAuto does not attempt the same merge a second time (#2645). */
   milestoneMergedInPhases = false;
 
+  // #4765 — slice-cadence collapse: main-branch SHAs at the moment each
+  // milestone's first slice merge began. Used by resquashMilestoneOnMain at
+  // milestone completion to collapse N slice commits into one. Cleared when
+  // the milestone finishes (or resquash runs).
+  milestoneStartShas: Map<string, string> = new Map();
+
   // ── Dispatch circuit breakers ──────────────────────────────────────
   rewriteAttemptCount = 0;
   /** Tracks consecutive bootstrap attempts that found phase === "complete".
@@ -299,6 +305,7 @@ export class AutoSession {
     this.lastGitActionStatus = null;
     this.isolationDegraded = false;
     this.milestoneMergedInPhases = false;
+    this.milestoneStartShas = new Map();
     this.checkpointSha = null;
 
     // Signal handler

--- a/src/resources/extensions/gsd/forensics.ts
+++ b/src/resources/extensions/gsd/forensics.ts
@@ -35,11 +35,12 @@ import { getAutoWorktreePath } from "./auto-worktree.js";
 import { loadEffectiveGSDPreferences, loadGlobalGSDPreferences, getGlobalGSDPreferencesPath } from "./preferences.js";
 import { showNextAction } from "../shared/tui.js";
 import { ensurePreferencesFile, serializePreferencesToFrontmatter } from "./commands-prefs-wizard.js";
+import { summarizeWorktreeTelemetry, percentile, type WorktreeTelemetrySummary } from "./worktree-telemetry.js";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
 export interface ForensicAnomaly {
-  type: "stuck-loop" | "cost-spike" | "timeout" | "missing-artifact" | "crash" | "doctor-issue" | "error-trace" | "journal-stuck" | "journal-guard-block" | "journal-rapid-iterations" | "journal-worktree-failure";
+  type: "stuck-loop" | "cost-spike" | "timeout" | "missing-artifact" | "crash" | "doctor-issue" | "error-trace" | "journal-stuck" | "journal-guard-block" | "journal-rapid-iterations" | "journal-worktree-failure" | "worktree-orphan" | "worktree-unmerged-exit";
   severity: "info" | "warning" | "error";
   unitType?: string;
   unitId?: string;
@@ -113,6 +114,8 @@ interface ForensicReport {
   recentUnits: { type: string; id: string; cost: number; duration: number; model: string; finishedAt: number }[];
   journalSummary: JournalSummary | null;
   activityLogMeta: ActivityLogMeta | null;
+  /** #4764 — worktree lifespan / divergence telemetry aggregates. */
+  worktreeTelemetry: WorktreeTelemetrySummary | null;
 }
 
 // ─── Duplicate Detection ──────────────────────────────────────────────────────
@@ -337,6 +340,16 @@ export async function buildForensicReport(basePath: string): Promise<ForensicRep
   detectCrash(crashLock, anomalies);
   detectDoctorIssues(doctorIssues, anomalies);
   detectErrorTraces(unitTraces, anomalies);
+
+  // 11b. #4764 — worktree lifecycle telemetry
+  let worktreeTelemetry: WorktreeTelemetrySummary | null = null;
+  try {
+    worktreeTelemetry = summarizeWorktreeTelemetry(basePath);
+    detectWorktreeOrphans(worktreeTelemetry, anomalies);
+  } catch {
+    // Telemetry is best-effort — do not let an aggregator failure block the
+    // rest of the forensic report.
+  }
   detectJournalAnomalies(journalSummary, anomalies);
 
   return {
@@ -356,6 +369,7 @@ export async function buildForensicReport(basePath: string): Promise<ForensicRep
     recentUnits,
     journalSummary,
     activityLogMeta,
+    worktreeTelemetry,
   };
 }
 
@@ -783,6 +797,51 @@ function detectMissingArtifacts(completedKeys: string[], basePath: string, activ
   }
 }
 
+/**
+ * #4764 — surface worktree lifecycle and orphan signals in the forensic report.
+ *
+ * Consumes only the aggregated summary (not raw journal events) to respect
+ * the forensics memory-bloat guard in forensics-journal.test.ts — per-event
+ * detail stays in the journal itself where the LLM can query it on demand.
+ */
+function detectWorktreeOrphans(
+  summary: WorktreeTelemetrySummary,
+  anomalies: ForensicAnomaly[],
+): void {
+  // 1. Orphan aggregate — severity depends on reason. In-progress orphans are
+  // the #4761 consumer-side signal (live work sitting on an unmerged branch).
+  for (const [reason, count] of Object.entries(summary.orphansByReason)) {
+    if (count <= 0) continue;
+    const severity: ForensicAnomaly["severity"] =
+      reason === "in-progress-unmerged" ? "warning" : "info";
+    anomalies.push({
+      type: "worktree-orphan",
+      severity,
+      summary: `${count} worktree orphan(s) detected (${reason})`,
+      details:
+        reason === "in-progress-unmerged"
+          ? "Auto-mode exited without completing a milestone; live work sits on an unmerged milestone branch. Run `/gsd auto` to resume, or merge manually."
+          : reason === "complete-unmerged"
+            ? "A completed milestone's branch was never merged back to main. Run `/gsd health --fix` to resolve."
+            : `Reason: ${reason}.`,
+    });
+  }
+
+  // 2. Auto-exit producer signal — #4761's upstream cause.
+  if (summary.exitsWithUnmergedWork > 0) {
+    const reasonBreakdown = Object.entries(summary.exitsByReason)
+      .filter(([, n]) => n > 0)
+      .map(([r, n]) => `${r}=${n}`)
+      .join(", ");
+    anomalies.push({
+      type: "worktree-unmerged-exit",
+      severity: "warning",
+      summary: `${summary.exitsWithUnmergedWork} auto-exit(s) left milestone work unmerged`,
+      details: `Exit reasons: ${reasonBreakdown || "(none)"} · Producer-side signal for #4761-class orphans. Inspect .gsd/journal/*.jsonl with eventType:"auto-exit" for per-exit detail.`,
+    });
+  }
+}
+
 function detectCrash(crashLock: LockData | null, anomalies: ForensicAnomaly[]): void {
   if (!crashLock) return;
   if (isLockProcessAlive(crashLock)) return; // Process still running, not a crash
@@ -972,6 +1031,35 @@ function saveForensicReport(basePath: string, report: ForensicReport, problemDes
     sections.push(``);
   }
 
+  // #4764 — Worktree telemetry summary
+  if (report.worktreeTelemetry) {
+    const t = report.worktreeTelemetry;
+    const p50 = percentile(t.mergeDurationsMs, 0.5);
+    const p95 = percentile(t.mergeDurationsMs, 0.95);
+    sections.push(`## Worktree Telemetry`, ``);
+    sections.push(`- Worktrees created: ${t.worktreesCreated}`);
+    sections.push(`- Worktrees merged: ${t.worktreesMerged}`);
+    sections.push(`- Orphans detected: ${t.orphansDetected}`);
+    if (t.orphansDetected > 0) {
+      const breakdown = Object.entries(t.orphansByReason)
+        .map(([r, n]) => `${r}=${n}`).join(", ");
+      sections.push(`  - By reason: ${breakdown}`);
+    }
+    sections.push(`- Merge conflicts: ${t.mergeConflicts}`);
+    if (t.mergeDurationsMs.length > 0) {
+      sections.push(`- Merge duration p50 / p95: ${p50 ?? "-"} / ${p95 ?? "-"} ms (n=${t.mergeDurationsMs.length})`);
+    }
+    sections.push(`- Auto-exits leaving unmerged work: ${t.exitsWithUnmergedWork}`);
+    if (Object.keys(t.exitsByReason).length > 0) {
+      const breakdown = Object.entries(t.exitsByReason)
+        .sort((a, b) => b[1] - a[1])
+        .map(([r, n]) => `${r}=${n}`).join(", ");
+      sections.push(`  - Exit reasons: ${breakdown}`);
+    }
+    sections.push(`- Canonical-root redirects (#4761 fix fired): ${t.canonicalRedirects}`);
+    sections.push(``);
+  }
+
   // Journal summary
   if (report.journalSummary) {
     const js = report.journalSummary;
@@ -1115,6 +1203,25 @@ function formatReportForPrompt(report: ForensicReport): string {
     sections.push(`- Total tokens: ${formatTokenCount(totals.tokens.total)}`);
     sections.push(`- Total duration: ${formatDuration(totals.duration)}`);
     sections.push("");
+  }
+
+  // #4764 — worktree telemetry (compact prompt form)
+  if (report.worktreeTelemetry) {
+    const t = report.worktreeTelemetry;
+    const hasSignal =
+      t.worktreesCreated + t.worktreesMerged + t.orphansDetected +
+      t.exitsWithUnmergedWork + t.canonicalRedirects > 0;
+    if (hasSignal) {
+      sections.push("### Worktree Telemetry");
+      sections.push(`- Created: ${t.worktreesCreated} · Merged: ${t.worktreesMerged} · Conflicts: ${t.mergeConflicts}`);
+      sections.push(`- Orphans: ${t.orphansDetected} · Unmerged exits: ${t.exitsWithUnmergedWork} · Redirects (#4761): ${t.canonicalRedirects}`);
+      if (t.orphansDetected > 0) {
+        const breakdown = Object.entries(t.orphansByReason)
+          .map(([r, n]) => `${r}=${n}`).join(", ");
+        sections.push(`- Orphan reasons: ${breakdown}`);
+      }
+      sections.push("");
+    }
   }
 
   // Activity log metadata

--- a/src/resources/extensions/gsd/forensics.ts
+++ b/src/resources/extensions/gsd/forensics.ts
@@ -1057,6 +1057,11 @@ function saveForensicReport(basePath: string, report: ForensicReport, problemDes
       sections.push(`  - Exit reasons: ${breakdown}`);
     }
     sections.push(`- Canonical-root redirects (#4761 fix fired): ${t.canonicalRedirects}`);
+    // #4765 slice-cadence counters
+    if (t.slicesMerged + t.sliceMergeConflicts + t.milestoneResquashes > 0) {
+      sections.push(`- Slices merged: ${t.slicesMerged} · Slice merge conflicts: ${t.sliceMergeConflicts}`);
+      sections.push(`- Milestone re-squashes: ${t.milestoneResquashes}`);
+    }
     sections.push(``);
   }
 
@@ -1210,7 +1215,8 @@ function formatReportForPrompt(report: ForensicReport): string {
     const t = report.worktreeTelemetry;
     const hasSignal =
       t.worktreesCreated + t.worktreesMerged + t.orphansDetected +
-      t.exitsWithUnmergedWork + t.canonicalRedirects > 0;
+      t.exitsWithUnmergedWork + t.canonicalRedirects +
+      t.slicesMerged + t.milestoneResquashes > 0;
     if (hasSignal) {
       sections.push("### Worktree Telemetry");
       sections.push(`- Created: ${t.worktreesCreated} · Merged: ${t.worktreesMerged} · Conflicts: ${t.mergeConflicts}`);
@@ -1219,6 +1225,10 @@ function formatReportForPrompt(report: ForensicReport): string {
         const breakdown = Object.entries(t.orphansByReason)
           .map(([r, n]) => `${r}=${n}`).join(", ");
         sections.push(`- Orphan reasons: ${breakdown}`);
+      }
+      // #4765 — slice-cadence counters (only shown when the feature was exercised)
+      if (t.slicesMerged + t.sliceMergeConflicts + t.milestoneResquashes > 0) {
+        sections.push(`- Slices merged: ${t.slicesMerged} · Slice conflicts: ${t.sliceMergeConflicts} · Re-squashes: ${t.milestoneResquashes}`);
       }
       sections.push("");
     }

--- a/src/resources/extensions/gsd/git-service.ts
+++ b/src/resources/extensions/gsd/git-service.ts
@@ -85,6 +85,22 @@ export interface GitPreferences {
    *  for forensic inspection.
    */
   absorb_snapshot_commits?: boolean;
+  /** #4765 — when to collapse worktree commits back to main.
+   *  - "milestone" (default): existing behavior — squash-merge happens once
+   *    at milestone completion or transition.
+   *  - "slice": squash-merge each slice's commits to main as soon as the
+   *    slice passes validation. Shrinks the orphan window from
+   *    milestone-size to slice-size and surfaces merge conflicts per slice
+   *    rather than all at once at milestone end.
+   */
+  collapse_cadence?: "milestone" | "slice";
+  /** #4765 — when `collapse_cadence: "slice"`, optionally re-squash the per-
+   *  slice commits on main into one milestone commit at milestone completion.
+   *  Preserves the "one commit per milestone in main" history shape that
+   *  `collapse_cadence: "milestone"` produces today.
+   *  Default: true when collapse_cadence is "slice", ignored otherwise.
+   */
+  milestone_resquash?: boolean;
 }
 
 export const VALID_BRANCH_NAME = /^[a-zA-Z0-9_\-\/.]+$/;

--- a/src/resources/extensions/gsd/journal.ts
+++ b/src/resources/extensions/gsd/journal.ts
@@ -57,7 +57,10 @@ export type JournalEventType =
   | "worktree-orphaned"
   | "auto-exit"
   | "worktree-sync"
-  | "canonical-root-redirect";
+  | "canonical-root-redirect"
+  // #4765 — slice-cadence collapse
+  | "slice-merged"
+  | "milestone-resquash";
 
 /** A single structured event in the journal. */
 export interface JournalEntry {

--- a/src/resources/extensions/gsd/journal.ts
+++ b/src/resources/extensions/gsd/journal.ts
@@ -50,7 +50,14 @@ export type JournalEventType =
   | "worktree-skip"
   | "worktree-merge-start"
   | "worktree-merge-failed"
-  | "artifact-verification-retry";
+  | "artifact-verification-retry"
+  // #4764 — worktree lifespan / divergence telemetry
+  | "worktree-created"
+  | "worktree-merged"
+  | "worktree-orphaned"
+  | "auto-exit"
+  | "worktree-sync"
+  | "canonical-root-redirect";
 
 /** A single structured event in the journal. */
 export interface JournalEntry {

--- a/src/resources/extensions/gsd/preferences-validation.ts
+++ b/src/resources/extensions/gsd/preferences-validation.ts
@@ -987,6 +987,19 @@ export function validatePreferences(preferences: GSDPreferences): {
     if (g.merge_to_main !== undefined) {
       warnings.push("git.merge_to_main is deprecated — milestone-level merge is now always used. Remove this setting.");
     }
+    // #4765 — collapse cadence + milestone resquash
+    if (g.collapse_cadence !== undefined) {
+      const validCadence = new Set(["milestone", "slice"]);
+      if (typeof g.collapse_cadence === "string" && validCadence.has(g.collapse_cadence)) {
+        git.collapse_cadence = g.collapse_cadence as "milestone" | "slice";
+      } else {
+        errors.push("git.collapse_cadence must be one of: milestone, slice");
+      }
+    }
+    if (g.milestone_resquash !== undefined) {
+      if (typeof g.milestone_resquash === "boolean") git.milestone_resquash = g.milestone_resquash;
+      else errors.push("git.milestone_resquash must be a boolean");
+    }
 
     if (Object.keys(git).length > 0) {
       validated.git = git as GitPreferences;

--- a/src/resources/extensions/gsd/preferences-validation.ts
+++ b/src/resources/extensions/gsd/preferences-validation.ts
@@ -997,8 +997,16 @@ export function validatePreferences(preferences: GSDPreferences): {
       }
     }
     if (g.milestone_resquash !== undefined) {
-      if (typeof g.milestone_resquash === "boolean") git.milestone_resquash = g.milestone_resquash;
-      else errors.push("git.milestone_resquash must be a boolean");
+      if (typeof g.milestone_resquash === "boolean") {
+        git.milestone_resquash = g.milestone_resquash;
+        const cadence = (git.collapse_cadence as string | undefined)
+          ?? (typeof g.collapse_cadence === "string" ? g.collapse_cadence : undefined);
+        if (cadence !== "slice") {
+          warnings.push('git.milestone_resquash is ignored unless git.collapse_cadence is "slice"');
+        }
+      } else {
+        errors.push("git.milestone_resquash must be a boolean");
+      }
     }
 
     if (Object.keys(git).length > 0) {

--- a/src/resources/extensions/gsd/slice-cadence.ts
+++ b/src/resources/extensions/gsd/slice-cadence.ts
@@ -1,0 +1,277 @@
+/**
+ * Slice-cadence collapse — #4765.
+ *
+ * When `git.collapse_cadence: "slice"` is set, each slice's commits are
+ * squash-merged from the milestone branch to main as soon as the slice
+ * passes validation. Shrinks the orphan window (#4761) from milestone-size
+ * to slice-size and surfaces merge conflicts per-slice rather than all at
+ * once at milestone end.
+ *
+ * This module is deliberately focused and narrower than mergeMilestoneToMain:
+ *   - No worktree teardown (worktree is reused for the next slice)
+ *   - No DB reconciliation (modern worktrees share the main DB via path resolver)
+ *   - No roadmap/summary/gate handling (that's still the milestone's job)
+ *   - Fails loudly on dirty main — caller is responsible for cleanliness
+ *
+ * Kernighan: the v1 surface handles the happy path + conflict. Edge cases
+ * that mergeMilestoneToMain covers (concurrent merges, shared DB paths,
+ * submodules) are explicit non-goals; users opt in via preference and early-
+ * adopter scenarios are scoped narrow.
+ */
+
+import { existsSync, unlinkSync } from "node:fs";
+import { join } from "node:path";
+import { execFileSync } from "node:child_process";
+
+import { GSDError, GSD_GIT_ERROR } from "./errors.js";
+import { MergeConflictError } from "./git-service.js";
+import {
+  nativeBranchForceReset,
+  nativeCheckoutBranch,
+  nativeCommit,
+  nativeCommitCountBetween,
+  nativeConflictFiles,
+  nativeDetectMainBranch,
+  nativeMergeSquash,
+} from "./native-git-bridge.js";
+import { resolveGitDir } from "./worktree-manager.js";
+import { logWarning } from "./workflow-logger.js";
+import { emitSliceMerged, emitMilestoneResquash } from "./worktree-telemetry.js";
+
+/**
+ * Auto-worktree milestone branch name. Must match autoWorktreeBranch() in
+ * auto-worktree.ts; duplicated here to avoid a cyclic import.
+ */
+function milestoneBranchName(milestoneId: string): string {
+  return `milestone/${milestoneId}`;
+}
+
+function cleanupMergeArtifacts(projectRoot: string): void {
+  try {
+    const gitDir = resolveGitDir(projectRoot);
+    for (const f of ["SQUASH_MSG", "MERGE_MSG", "MERGE_HEAD"]) {
+      const p = join(gitDir, f);
+      if (existsSync(p)) unlinkSync(p);
+    }
+  } catch (err) {
+    logWarning("slice-cadence", `merge artifact cleanup failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+
+export interface SliceMergeResult {
+  commitSha: string | null;
+  mainBranch: string;
+  milestoneBranch: string;
+  durationMs: number;
+  skipped: boolean;
+  skippedReason?: string;
+}
+
+/**
+ * Squash-merge one slice's commits from the milestone branch to main.
+ *
+ * Preconditions:
+ *   - Caller is on the milestone branch inside the worktree
+ *   - `projectRoot` points at the real project root (not the worktree)
+ *
+ * Post-conditions on success:
+ *   - Slice's commits are a single squash commit on main
+ *   - `milestone/<MID>` is fast-forwarded to main (so next slice's work
+ *     starts from a clean base)
+ *   - caller's process.cwd is restored
+ *
+ * Throws MergeConflictError on conflicts; caller should surface and stop.
+ * Throws GSDError on dirty main / detection failures.
+ */
+export function mergeSliceToMain(
+  projectRoot: string,
+  milestoneId: string,
+  sliceId: string,
+): SliceMergeResult {
+  const started = Date.now();
+  const worktreeCwd = process.cwd();
+  const milestoneBranch = milestoneBranchName(milestoneId);
+  const mainBranch = nativeDetectMainBranch(projectRoot);
+
+  // Fast path: if the milestone branch has no commits ahead of main, there
+  // is nothing to merge. Return a skip result instead of no-op'ing silently
+  // so the caller's telemetry shows the decision.
+  let commitsAhead = 0;
+  try {
+    commitsAhead = nativeCommitCountBetween(projectRoot, mainBranch, milestoneBranch);
+  } catch {
+    // If we can't count, assume there's work and let the merge proceed —
+    // a failing merge is more informative than a silent skip.
+    commitsAhead = 1;
+  }
+  if (commitsAhead === 0) {
+    const result: SliceMergeResult = {
+      commitSha: null,
+      mainBranch,
+      milestoneBranch,
+      durationMs: Date.now() - started,
+      skipped: true,
+      skippedReason: "no-commits-ahead",
+    };
+    try {
+      emitSliceMerged(projectRoot, milestoneId, sliceId, { durationMs: result.durationMs, conflict: false });
+    } catch { /* silent */ }
+    return result;
+  }
+
+  process.chdir(projectRoot);
+  try {
+    // Dirty-main check — v1 fails loudly rather than auto-stashing. Users
+    // running slice-cadence opt in knowing main stays clean between merges.
+    const status = execFileSync("git", ["status", "--porcelain"], {
+      cwd: projectRoot,
+      stdio: ["ignore", "pipe", "pipe"],
+      encoding: "utf-8",
+    }).trim();
+    if (status) {
+      throw new GSDError(
+        GSD_GIT_ERROR,
+        `slice-cadence merge requires a clean project root; uncommitted changes detected. ` +
+        `Commit or stash at ${projectRoot} before retrying. Status:\n${status}`,
+      );
+    }
+
+    nativeCheckoutBranch(projectRoot, mainBranch);
+
+    // Clean any stale merge artifacts before attempting the squash (#2912 pattern)
+    cleanupMergeArtifacts(projectRoot);
+
+    const mergeResult = nativeMergeSquash(projectRoot, milestoneBranch);
+    if (!mergeResult.success) {
+      const conflictedFiles = mergeResult.conflicts.length > 0
+        ? mergeResult.conflicts
+        : nativeConflictFiles(projectRoot);
+      cleanupMergeArtifacts(projectRoot);
+      try {
+        emitSliceMerged(projectRoot, milestoneId, sliceId, {
+          durationMs: Date.now() - started,
+          conflict: true,
+        });
+      } catch { /* silent */ }
+      throw new MergeConflictError(
+        conflictedFiles,
+        "squash",
+        milestoneBranch,
+        mainBranch,
+      );
+    }
+
+    // Commit the squash with a slice-scoped message
+    const commitSha = nativeCommit(
+      projectRoot,
+      `gsd: merge ${sliceId} of ${milestoneId} (slice-cadence)`,
+    );
+
+    // Advance the milestone branch to main so the next slice's commits start
+    // from a clean base. Force-reset is safe because we just merged this
+    // branch's entire delta.
+    nativeBranchForceReset(projectRoot, milestoneBranch, mainBranch);
+
+    const durationMs = Date.now() - started;
+    try {
+      emitSliceMerged(projectRoot, milestoneId, sliceId, {
+        durationMs,
+        conflict: false,
+        commitSha: commitSha ?? undefined,
+      });
+    } catch { /* silent */ }
+
+    return {
+      commitSha,
+      mainBranch,
+      milestoneBranch,
+      durationMs,
+      skipped: false,
+    };
+  } finally {
+    // Always restore cwd even if anything above threw.
+    try { process.chdir(worktreeCwd); } catch { /* best-effort */ }
+  }
+}
+
+/**
+ * Re-squash per-slice commits on main into a single milestone commit.
+ *
+ * Runs at milestone completion when `collapse_cadence: "slice"` AND
+ * `milestone_resquash: true`. The `startSha` is the SHA of main immediately
+ * before the milestone's first slice merge — the caller is responsible for
+ * recording this (AutoSession field, git ref, or DB row).
+ *
+ * Strategy: soft-reset main to startSha, then commit the net diff. The
+ * N slice commits between startSha and HEAD are collapsed into one.
+ *
+ * No-op (returns false) if startSha equals HEAD (nothing to re-squash).
+ */
+export function resquashMilestoneOnMain(
+  projectRoot: string,
+  milestoneId: string,
+  startSha: string,
+): { resquashed: boolean; newSha: string | null } {
+  const mainBranch = nativeDetectMainBranch(projectRoot);
+  const worktreeCwd = process.cwd();
+
+  process.chdir(projectRoot);
+  try {
+    nativeCheckoutBranch(projectRoot, mainBranch);
+
+    // Count slice commits between startSha and HEAD. If zero, nothing to do.
+    let sliceCount = 0;
+    try {
+      sliceCount = nativeCommitCountBetween(projectRoot, startSha, "HEAD");
+    } catch {
+      sliceCount = 0;
+    }
+    if (sliceCount === 0) {
+      return { resquashed: false, newSha: null };
+    }
+
+    // Soft reset to the start SHA — HEAD moves but working tree and index
+    // keep all the slice changes staged.
+    execFileSync("git", ["reset", "--soft", startSha], {
+      cwd: projectRoot,
+      stdio: ["ignore", "pipe", "pipe"],
+      encoding: "utf-8",
+    });
+
+    const newSha = nativeCommit(
+      projectRoot,
+      `gsd: complete milestone ${milestoneId} (${sliceCount} slices re-squashed)`,
+      { allowEmpty: true },
+    );
+
+    try {
+      emitMilestoneResquash(projectRoot, milestoneId, {
+        sliceCount,
+        startSha,
+        endSha: newSha ?? undefined,
+      });
+    } catch { /* silent */ }
+
+    return { resquashed: true, newSha };
+  } finally {
+    try { process.chdir(worktreeCwd); } catch { /* best-effort */ }
+  }
+}
+
+/**
+ * Read the effective collapse cadence from validated preferences. Accepts
+ * a raw preferences object (the shape loadEffectiveGSDPreferences returns).
+ */
+export function getCollapseCadence(
+  prefs: { git?: { collapse_cadence?: "milestone" | "slice" } } | undefined | null,
+): "milestone" | "slice" {
+  return prefs?.git?.collapse_cadence ?? "milestone";
+}
+
+export function getMilestoneResquash(
+  prefs: { git?: { milestone_resquash?: boolean } } | undefined | null,
+): boolean {
+  // Default true when cadence is slice — resquash preserves the milestone-
+  // level history shape users expect.
+  return prefs?.git?.milestone_resquash !== false;
+}

--- a/src/resources/extensions/gsd/slice-cadence.ts
+++ b/src/resources/extensions/gsd/slice-cadence.ts
@@ -54,7 +54,7 @@ function cleanupMergeArtifacts(projectRoot: string): void {
       if (existsSync(p)) unlinkSync(p);
     }
   } catch (err) {
-    logWarning("slice-cadence", `merge artifact cleanup failed: ${err instanceof Error ? err.message : String(err)}`);
+    logWarning("worktree", `merge artifact cleanup failed: ${err instanceof Error ? err.message : String(err)}`);
   }
 }
 

--- a/src/resources/extensions/gsd/slice-cadence.ts
+++ b/src/resources/extensions/gsd/slice-cadence.ts
@@ -105,7 +105,10 @@ export function mergeSliceToMain(
     commitsAhead = 1;
   }
   if (commitsAhead === 0) {
-    const result: SliceMergeResult = {
+    // Do NOT emit slice-merged here — this is a no-op, not a merge. Emitting
+    // would inflate slicesMerged in telemetry/forensics and distort the
+    // conflict rate denominator.
+    return {
       commitSha: null,
       mainBranch,
       milestoneBranch,
@@ -113,10 +116,6 @@ export function mergeSliceToMain(
       skipped: true,
       skippedReason: "no-commits-ahead",
     };
-    try {
-      emitSliceMerged(projectRoot, milestoneId, sliceId, { durationMs: result.durationMs, conflict: false });
-    } catch { /* silent */ }
-    return result;
   }
 
   process.chdir(projectRoot);
@@ -219,19 +218,42 @@ export function resquashMilestoneOnMain(
   try {
     nativeCheckoutBranch(projectRoot, mainBranch);
 
-    // Count slice commits between startSha and HEAD. If zero, nothing to do.
-    let sliceCount = 0;
+    // Verify the startSha..HEAD range contains ONLY this milestone's slice-
+    // cadence commits. If any unrelated commits landed on main since the
+    // milestone started (e.g. concurrent work, cherry-picks, hotfixes), a
+    // blind `git reset --soft` would fold them into the re-squash and rewrite
+    // their attribution. Fail closed — the user can resolve manually.
+    const expectedSuffix = `(slice-cadence)`;
+    const expectedMilestoneToken = ` of ${milestoneId} `;
+    let subjectsRaw = "";
     try {
-      sliceCount = nativeCommitCountBetween(projectRoot, startSha, "HEAD");
+      subjectsRaw = execFileSync(
+        "git",
+        ["log", "--format=%s", `${startSha}..HEAD`],
+        { cwd: projectRoot, stdio: ["ignore", "pipe", "pipe"], encoding: "utf-8" },
+      );
     } catch {
-      sliceCount = 0;
+      return { resquashed: false, newSha: null };
     }
+    const subjects = subjectsRaw.split("\n").filter((s) => s.length > 0);
+    const sliceCount = subjects.length;
     if (sliceCount === 0) {
       return { resquashed: false, newSha: null };
     }
+    const foreign = subjects.filter(
+      (s) => !(s.endsWith(expectedSuffix) && s.includes(expectedMilestoneToken)),
+    );
+    if (foreign.length > 0) {
+      logWarning(
+        "worktree",
+        `slice-cadence: skipping milestone resquash for ${milestoneId} — ` +
+        `${foreign.length} non-slice-cadence commit(s) in ${startSha}..HEAD ` +
+        `would be folded in. First: "${foreign[0]}". Resolve history manually.`,
+      );
+      return { resquashed: false, newSha: null };
+    }
 
-    // Soft reset to the start SHA — HEAD moves but working tree and index
-    // keep all the slice changes staged.
+    // Safe to collapse: all commits in the range are this milestone's slices.
     execFileSync("git", ["reset", "--soft", startSha], {
       cwd: projectRoot,
       stdio: ["ignore", "pipe", "pipe"],

--- a/src/resources/extensions/gsd/tests/canonical-milestone-root.test.ts
+++ b/src/resources/extensions/gsd/tests/canonical-milestone-root.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Tests for resolveCanonicalMilestoneRoot — the worktree-aware reader
+ * that fixes #4761 (worktree work stranded when auto-loop exits without
+ * milestone completion).
+ *
+ * Contract: given (basePath, milestoneId), return the worktree path if a
+ * live git worktree exists for that milestone at .gsd/worktrees/<MID>/;
+ * otherwise return basePath unchanged. A live worktree has a .git file
+ * (not directory) — a bare directory without .git is a stale leftover.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomUUID } from "node:crypto";
+
+import { resolveCanonicalMilestoneRoot } from "../worktree-manager.ts";
+
+function makeTmpBase(): string {
+  const base = join(tmpdir(), `gsd-canon-test-${randomUUID()}`);
+  mkdirSync(join(base, ".gsd", "milestones"), { recursive: true });
+  return base;
+}
+
+function cleanup(base: string): void {
+  try { rmSync(base, { recursive: true, force: true }); } catch { /* */ }
+}
+
+/**
+ * Create a worktree directory shape that looks live: the .gsd/worktrees/<MID>/
+ * directory with a .git file containing a gitdir: pointer. We don't need a
+ * real git worktree — the resolver only checks for the .git file's presence.
+ */
+function makeLiveWorktree(base: string, mid: string): string {
+  const wtPath = join(base, ".gsd", "worktrees", mid);
+  mkdirSync(wtPath, { recursive: true });
+  writeFileSync(
+    join(wtPath, ".git"),
+    `gitdir: ${join(base, ".git", "worktrees", mid)}\n`,
+  );
+  return wtPath;
+}
+
+function makeStaleWorktree(base: string, mid: string): string {
+  const wtPath = join(base, ".gsd", "worktrees", mid);
+  mkdirSync(wtPath, { recursive: true });
+  // No .git file — this is the stale-leftover shape createWorktree() sees
+  // and cleans up.
+  return wtPath;
+}
+
+test("returns worktree path when a live worktree exists for the milestone", () => {
+  const base = makeTmpBase();
+  try {
+    const wtPath = makeLiveWorktree(base, "M001");
+    const result = resolveCanonicalMilestoneRoot(base, "M001");
+    assert.equal(result, wtPath);
+  } finally {
+    cleanup(base);
+  }
+});
+
+test("returns basePath when no worktree directory exists", () => {
+  const base = makeTmpBase();
+  try {
+    const result = resolveCanonicalMilestoneRoot(base, "M001");
+    assert.equal(result, base);
+  } finally {
+    cleanup(base);
+  }
+});
+
+test("returns basePath when worktree directory exists but has no .git file (stale)", () => {
+  const base = makeTmpBase();
+  try {
+    makeStaleWorktree(base, "M001");
+    const result = resolveCanonicalMilestoneRoot(base, "M001");
+    assert.equal(result, base);
+  } finally {
+    cleanup(base);
+  }
+});
+
+test("returns basePath for invalid milestoneId (path separators)", () => {
+  const base = makeTmpBase();
+  try {
+    // Even if a worktree coincidentally exists, the guard should reject.
+    assert.equal(resolveCanonicalMilestoneRoot(base, "../evil"), base);
+    assert.equal(resolveCanonicalMilestoneRoot(base, "M001/subdir"), base);
+    assert.equal(resolveCanonicalMilestoneRoot(base, "M001\\subdir"), base);
+    assert.equal(resolveCanonicalMilestoneRoot(base, ""), base);
+  } finally {
+    cleanup(base);
+  }
+});
+
+test("only returns the worktree for the requested milestone, not siblings", () => {
+  const base = makeTmpBase();
+  try {
+    makeLiveWorktree(base, "M001");
+    const result = resolveCanonicalMilestoneRoot(base, "M002");
+    assert.equal(result, base, "M002 has no worktree → basePath");
+  } finally {
+    cleanup(base);
+  }
+});

--- a/src/resources/extensions/gsd/tests/forensics-worktree-telemetry.test.ts
+++ b/src/resources/extensions/gsd/tests/forensics-worktree-telemetry.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Tests for the #4764 forensics integration — verifies that
+ * buildForensicReport picks up worktree telemetry aggregates and emits
+ * anomalies for orphans and auto-exits with unmerged work.
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync, mkdirSync, rmSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { tmpdir } from "node:os";
+import { randomUUID } from "node:crypto";
+import { fileURLToPath } from "node:url";
+
+import {
+  emitWorktreeOrphaned,
+  emitAutoExit,
+  emitWorktreeCreated,
+  emitWorktreeMerged,
+} from "../worktree-telemetry.ts";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const gsdDir = join(__dirname, "..");
+
+function makeTmpBase(): string {
+  const base = join(tmpdir(), `gsd-for-tel-test-${randomUUID()}`);
+  mkdirSync(join(base, ".gsd"), { recursive: true });
+  return base;
+}
+
+function cleanup(base: string): void {
+  try { rmSync(base, { recursive: true, force: true }); } catch { /* */ }
+}
+
+describe("#4764 forensics + worktree telemetry integration", () => {
+  const forensicsSrc = readFileSync(join(gsdDir, "forensics.ts"), "utf-8");
+
+  it("forensics.ts imports the telemetry summarizer", () => {
+    assert.ok(
+      forensicsSrc.includes("summarizeWorktreeTelemetry"),
+      "forensics must consume the telemetry aggregator",
+    );
+  });
+
+  it("forensics.ts does NOT call queryJournal directly (memory guard)", () => {
+    // The same invariant guarded by forensics-journal.test.ts — re-asserted
+    // here so this feature change doesn't regress it.
+    assert.ok(
+      !forensicsSrc.includes("queryJournal("),
+      "forensics.ts must route journal reads through aggregators, not queryJournal",
+    );
+  });
+
+  it("ForensicReport includes worktreeTelemetry field", () => {
+    assert.ok(
+      forensicsSrc.includes("worktreeTelemetry"),
+      "report shape must include the telemetry summary",
+    );
+  });
+
+  it("formatReportForPrompt gates Worktree Telemetry section on signal", () => {
+    assert.ok(
+      forensicsSrc.includes("Worktree Telemetry"),
+      "prompt formatter must include a Worktree Telemetry section",
+    );
+  });
+
+  it("new anomaly types worktree-orphan and worktree-unmerged-exit exist on the union", () => {
+    assert.ok(forensicsSrc.includes('"worktree-orphan"'));
+    assert.ok(forensicsSrc.includes('"worktree-unmerged-exit"'));
+  });
+
+  it("buildForensicReport surfaces worktree-orphan anomaly when the journal shows an in-progress orphan", async () => {
+    const base = makeTmpBase();
+    try {
+      // Seed the journal with one in-progress orphan event
+      emitWorktreeOrphaned(base, "M001", {
+        reason: "in-progress-unmerged",
+        commitsAhead: 3,
+        worktreeDirExists: true,
+      });
+
+      const { buildForensicReport } = await import("../forensics.ts");
+      const report = await buildForensicReport(base);
+
+      const orphanAnomalies = report.anomalies.filter(a => a.type === "worktree-orphan");
+      assert.ok(orphanAnomalies.length >= 1, `expected a worktree-orphan anomaly; got ${JSON.stringify(report.anomalies.map(a => a.type))}`);
+      assert.equal(orphanAnomalies[0].severity, "warning", "in-progress orphan should be a warning");
+
+      // Aggregate fields surface in the telemetry summary
+      assert.ok(report.worktreeTelemetry, "report should carry the telemetry summary");
+      assert.equal(report.worktreeTelemetry!.orphansDetected, 1);
+      assert.equal(report.worktreeTelemetry!.orphansByReason["in-progress-unmerged"], 1);
+    } finally { cleanup(base); }
+  });
+
+  it("buildForensicReport surfaces worktree-unmerged-exit anomaly when auto-exit left work unmerged", async () => {
+    const base = makeTmpBase();
+    try {
+      emitAutoExit(base, { reason: "pause", milestoneId: "M002", milestoneMerged: false });
+      emitAutoExit(base, { reason: "stop", milestoneId: "M002", milestoneMerged: false });
+      emitAutoExit(base, { reason: "all-complete", milestoneId: "M001", milestoneMerged: true });
+
+      const { buildForensicReport } = await import("../forensics.ts");
+      const report = await buildForensicReport(base);
+
+      const unmergedExitAnomalies = report.anomalies.filter(a => a.type === "worktree-unmerged-exit");
+      assert.equal(unmergedExitAnomalies.length, 1, "exactly one aggregate unmerged-exit anomaly");
+      assert.equal(unmergedExitAnomalies[0].severity, "warning");
+      assert.ok(
+        unmergedExitAnomalies[0].summary.includes("2"),
+        "summary should mention the count (2 unmerged exits out of 3 total)",
+      );
+
+      assert.equal(report.worktreeTelemetry!.exitsWithUnmergedWork, 2);
+    } finally { cleanup(base); }
+  });
+
+  it("buildForensicReport emits no telemetry anomalies when there are no signals", async () => {
+    const base = makeTmpBase();
+    try {
+      // Healthy path — worktree created and merged without incident
+      emitWorktreeCreated(base, "M001");
+      emitWorktreeMerged(base, "M001", {
+        reason: "milestone-complete",
+        durationMs: 250,
+        conflict: false,
+      });
+      emitAutoExit(base, { reason: "all-complete", milestoneId: "M001", milestoneMerged: true });
+
+      const { buildForensicReport } = await import("../forensics.ts");
+      const report = await buildForensicReport(base);
+
+      const telemetryAnomalies = report.anomalies.filter(a =>
+        a.type === "worktree-orphan" || a.type === "worktree-unmerged-exit"
+      );
+      assert.deepStrictEqual(telemetryAnomalies, [], "no orphans, no unmerged exits → no telemetry anomalies");
+
+      assert.equal(report.worktreeTelemetry!.worktreesCreated, 1);
+      assert.equal(report.worktreeTelemetry!.worktreesMerged, 1);
+      assert.equal(report.worktreeTelemetry!.orphansDetected, 0);
+      assert.equal(report.worktreeTelemetry!.exitsWithUnmergedWork, 0);
+    } finally { cleanup(base); }
+  });
+});

--- a/src/resources/extensions/gsd/tests/merge-conflict-stops-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/merge-conflict-stops-loop.test.ts
@@ -27,7 +27,14 @@ console.log("\n=== #2330: Merge conflict stops auto loop ===");
 const methodStart = resolverSrc.indexOf("Worktree-mode merge:");
 assertTrue(methodStart > 0, "worktree-resolver has _mergeWorktreeMode method");
 
-const methodBody = resolverSrc.slice(methodStart, methodStart + 6000);
+// Slice from the _mergeWorktreeMode docblock to the next method boundary
+// (Branch-mode merge:) so that docblock/body growth doesn't silently drop
+// the `throw err` out of the search window.
+const methodEnd = resolverSrc.indexOf("Branch-mode merge:", methodStart);
+const methodBody = resolverSrc.slice(
+  methodStart,
+  methodEnd > 0 ? methodEnd : methodStart + 8000,
+);
 const rethrowsConflict =
   methodBody.includes("MergeConflictError") &&
   methodBody.includes("throw err");

--- a/src/resources/extensions/gsd/tests/orphaned-worktree-audit.test.ts
+++ b/src/resources/extensions/gsd/tests/orphaned-worktree-audit.test.ts
@@ -107,7 +107,8 @@ describe("auditOrphanedMilestoneBranches", () => {
     assert.ok(branches.includes("milestone/M001"), "unmerged branch must be preserved");
   });
 
-  test("skips active (non-complete) milestone branches", () => {
+  test("skips active milestone branch with no commits ahead of main (nothing to recover)", () => {
+    // Branch created from main with zero divergence — no live work, nothing to warn about.
     run("git branch milestone/M001", dir);
     insertMilestone({ id: "M001", title: "Test", status: "active" });
 
@@ -116,9 +117,65 @@ describe("auditOrphanedMilestoneBranches", () => {
     assert.deepStrictEqual(result.recovered, []);
     assert.deepStrictEqual(result.warnings, []);
 
-    // Branch should still exist
+    // Branch should still exist (data safety — user may intend to use it)
     const branches = run("git branch --list milestone/M001", dir);
     assert.ok(branches.includes("milestone/M001"), "active milestone branch should be preserved");
+  });
+
+  test("#4762 — warns about in-progress milestone with unmerged commits ahead of main", () => {
+    // Simulates the primary #4761 scenario: auto-mode was interrupted mid-milestone.
+    // DB status = active/in_progress, branch has real work, main is behind.
+    run("git checkout -b milestone/M001", dir);
+    writeFileSync(join(dir, "feature.txt"), "in-progress work\n");
+    run("git add feature.txt", dir);
+    run("git commit -m \"in-progress work on M001\"", dir);
+    run("git checkout main", dir);
+
+    insertMilestone({ id: "M001", title: "Test", status: "active" });
+
+    const result = auditOrphanedMilestoneBranches(dir, "worktree");
+
+    // Must NOT recover/delete (data safety — work is live)
+    assert.deepStrictEqual(result.recovered, [], "must not delete a branch with live in-progress work");
+
+    // Must surface a warning so the user knows the worktree holds uncollapsed work
+    assert.ok(result.warnings.length > 0, "should warn about in-progress orphan");
+    assert.ok(
+      result.warnings.some(w => w.includes("milestone/M001") && w.includes("in-progress")),
+      `warning should mention milestone/M001 and in-progress state; got: ${JSON.stringify(result.warnings)}`,
+    );
+
+    // Branch must still exist
+    const branches = run("git branch --list milestone/M001", dir);
+    assert.ok(branches.includes("milestone/M001"), "in-progress branch must be preserved");
+  });
+
+  test("#4762 — also surfaces worktree directory for in-progress orphan when present", () => {
+    // In-progress + unmerged + physical worktree directory — the full primary scenario.
+    run("git checkout -b milestone/M001", dir);
+    writeFileSync(join(dir, "feature.txt"), "in-progress work\n");
+    run("git add feature.txt", dir);
+    run("git commit -m \"in-progress work on M001\"", dir);
+    run("git checkout main", dir);
+
+    // Simulate a leftover worktree directory
+    const wtDir = join(dir, ".gsd", "worktrees", "M001");
+    mkdirSync(wtDir, { recursive: true });
+    writeFileSync(join(wtDir, ".git"), `gitdir: ${join(dir, ".git", "worktrees", "M001")}\n`);
+
+    insertMilestone({ id: "M001", title: "Test", status: "active" });
+
+    const result = auditOrphanedMilestoneBranches(dir, "worktree");
+
+    // Must preserve everything for data safety
+    assert.deepStrictEqual(result.recovered, [], "must not touch worktree or branch with live work");
+    assert.ok(existsSync(wtDir), "worktree directory must be preserved");
+
+    // Warning should mention the worktree path so the user can find the work
+    assert.ok(
+      result.warnings.some(w => w.includes(".gsd/worktrees/M001") || w.includes("worktree")),
+      `warning should reference the worktree location; got: ${JSON.stringify(result.warnings)}`,
+    );
   });
 
   test("cleans up orphaned worktree directory for merged milestone", () => {

--- a/src/resources/extensions/gsd/tests/slice-cadence.test.ts
+++ b/src/resources/extensions/gsd/tests/slice-cadence.test.ts
@@ -1,0 +1,242 @@
+/**
+ * Tests for slice-cadence collapse — #4765.
+ *
+ * Covers mergeSliceToMain (squash + advance), resquashMilestoneOnMain,
+ * and the preference accessors.
+ */
+
+import { describe, test, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, realpathSync, readFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { execFileSync } from "node:child_process";
+
+import {
+  mergeSliceToMain,
+  resquashMilestoneOnMain,
+  getCollapseCadence,
+  getMilestoneResquash,
+} from "../slice-cadence.ts";
+import { MergeConflictError } from "../git-service.ts";
+import { summarizeWorktreeTelemetry } from "../worktree-telemetry.ts";
+
+function git(args: string[], cwd: string): string {
+  return execFileSync("git", args, { cwd, stdio: ["ignore", "pipe", "pipe"], encoding: "utf-8" }).trim();
+}
+
+/** Create a temp git repo with an initial commit on main. */
+function createRepo(): string {
+  const dir = realpathSync(mkdtempSync(join(tmpdir(), "slice-cad-test-")));
+  git(["init"], dir);
+  git(["config", "user.email", "test@test.com"], dir);
+  git(["config", "user.name", "Test"], dir);
+  writeFileSync(join(dir, "README.md"), "# test\n");
+  git(["add", "."], dir);
+  git(["commit", "-m", "init"], dir);
+  git(["branch", "-M", "main"], dir);
+  mkdirSync(join(dir, ".gsd"), { recursive: true });
+  return dir;
+}
+
+function enterMilestoneBranch(dir: string, milestoneId: string): void {
+  git(["checkout", "-b", `milestone/${milestoneId}`], dir);
+}
+
+function commitFile(dir: string, file: string, content: string, msg: string): string {
+  writeFileSync(join(dir, file), content);
+  git(["add", "."], dir);
+  git(["commit", "-m", msg], dir);
+  return git(["rev-parse", "HEAD"], dir);
+}
+
+describe("getCollapseCadence / getMilestoneResquash", () => {
+  test("defaults to milestone cadence", () => {
+    assert.equal(getCollapseCadence(undefined), "milestone");
+    assert.equal(getCollapseCadence(null), "milestone");
+    assert.equal(getCollapseCadence({}), "milestone");
+    assert.equal(getCollapseCadence({ git: {} }), "milestone");
+  });
+  test("reads slice cadence when set", () => {
+    assert.equal(getCollapseCadence({ git: { collapse_cadence: "slice" } }), "slice");
+  });
+  test("milestone_resquash defaults to true when not set", () => {
+    assert.equal(getMilestoneResquash(undefined), true);
+    assert.equal(getMilestoneResquash({ git: {} }), true);
+    assert.equal(getMilestoneResquash({ git: { milestone_resquash: true } }), true);
+  });
+  test("milestone_resquash can be disabled explicitly", () => {
+    assert.equal(getMilestoneResquash({ git: { milestone_resquash: false } }), false);
+  });
+});
+
+describe("mergeSliceToMain", () => {
+  let dir: string;
+  let originalCwd: string;
+
+  beforeEach(() => {
+    dir = createRepo();
+    originalCwd = process.cwd();
+  });
+
+  afterEach(() => {
+    try { process.chdir(originalCwd); } catch { /* */ }
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("squashes one slice's commits onto main and advances the milestone branch", () => {
+    enterMilestoneBranch(dir, "M001");
+    commitFile(dir, "feature.txt", "slice 1 work\n", "feat: S01 work");
+
+    process.chdir(dir);
+    const result = mergeSliceToMain(dir, "M001", "S01");
+
+    assert.equal(result.skipped, false);
+    assert.ok(result.commitSha, "expected a commit SHA");
+    assert.equal(result.milestoneBranch, "milestone/M001");
+    assert.equal(result.mainBranch, "main");
+
+    const mainLog = git(["log", "main", "--oneline"], dir);
+    assert.ok(mainLog.includes("S01 of M001 (slice-cadence)"), `main log: ${mainLog}`);
+    assert.equal(readFileSync(join(dir, "feature.txt"), "utf-8"), "slice 1 work\n");
+
+    const mainSha = git(["rev-parse", "main"], dir);
+    const milestoneSha = git(["rev-parse", "milestone/M001"], dir);
+    assert.equal(milestoneSha, mainSha, "milestone branch must be advanced to main");
+
+    const summary = summarizeWorktreeTelemetry(dir);
+    assert.equal(summary.slicesMerged, 1);
+    assert.equal(summary.sliceMergeConflicts, 0);
+  });
+
+  test("handles sequential slice merges cleanly", () => {
+    enterMilestoneBranch(dir, "M001");
+    commitFile(dir, "a.txt", "slice 1\n", "feat: S01");
+
+    process.chdir(dir);
+    mergeSliceToMain(dir, "M001", "S01");
+
+    git(["checkout", "milestone/M001"], dir);
+    commitFile(dir, "b.txt", "slice 2\n", "feat: S02");
+
+    const result = mergeSliceToMain(dir, "M001", "S02");
+    assert.equal(result.skipped, false);
+
+    const mainLog = git(["log", "main", "--oneline"], dir);
+    assert.ok(mainLog.includes("S01 of M001"));
+    assert.ok(mainLog.includes("S02 of M001"));
+
+    assert.equal(readFileSync(join(dir, "a.txt"), "utf-8"), "slice 1\n");
+    assert.equal(readFileSync(join(dir, "b.txt"), "utf-8"), "slice 2\n");
+
+    const summary = summarizeWorktreeTelemetry(dir);
+    assert.equal(summary.slicesMerged, 2);
+  });
+
+  test("returns skipped when milestone branch has no commits ahead of main", () => {
+    enterMilestoneBranch(dir, "M001");
+
+    process.chdir(dir);
+    const result = mergeSliceToMain(dir, "M001", "S01");
+
+    assert.equal(result.skipped, true);
+    assert.equal(result.skippedReason, "no-commits-ahead");
+    assert.equal(result.commitSha, null);
+  });
+
+  test("throws MergeConflictError on a real conflict and leaves no merge artifacts", () => {
+    writeFileSync(join(dir, "shared.txt"), "main version\n");
+    git(["add", "."], dir);
+    git(["commit", "-m", "main-seed"], dir);
+
+    enterMilestoneBranch(dir, "M001");
+    commitFile(dir, "shared.txt", "slice version\n", "feat: S01 conflicting");
+
+    git(["checkout", "main"], dir);
+    commitFile(dir, "shared.txt", "main evolved\n", "main evolved");
+    git(["checkout", "milestone/M001"], dir);
+
+    process.chdir(dir);
+    assert.throws(
+      () => mergeSliceToMain(dir, "M001", "S01"),
+      (err: unknown) => err instanceof MergeConflictError,
+    );
+
+    const gitDir = join(dir, ".git");
+    for (const f of ["SQUASH_MSG", "MERGE_MSG", "MERGE_HEAD"]) {
+      assert.ok(!existsSync(join(gitDir, f)), `${f} should be cleaned up`);
+    }
+
+    const summary = summarizeWorktreeTelemetry(dir);
+    assert.equal(summary.sliceMergeConflicts, 1);
+  });
+
+  test("restores cwd even when merge fails (dirty working tree)", () => {
+    enterMilestoneBranch(dir, "M001");
+    commitFile(dir, "feature.txt", "slice 1\n", "feat: S01");
+    // Introduce an untracked file AFTER the slice commit so it's still
+    // present when mergeSliceToMain runs its status check.
+    writeFileSync(join(dir, "dirty.txt"), "uncommitted\n");
+
+    process.chdir(dir);
+    const cwdBefore = process.cwd();
+    assert.throws(() => mergeSliceToMain(dir, "M001", "S01"));
+    assert.equal(process.cwd(), cwdBefore, "cwd must be restored on failure");
+  });
+});
+
+describe("resquashMilestoneOnMain", () => {
+  let dir: string;
+  let originalCwd: string;
+
+  beforeEach(() => {
+    dir = createRepo();
+    originalCwd = process.cwd();
+  });
+
+  afterEach(() => {
+    try { process.chdir(originalCwd); } catch { /* */ }
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("collapses N slice commits on main into one milestone commit", () => {
+    const startSha = git(["rev-parse", "main"], dir);
+
+    enterMilestoneBranch(dir, "M001");
+    commitFile(dir, "a.txt", "slice 1\n", "feat: S01");
+    process.chdir(dir);
+    mergeSliceToMain(dir, "M001", "S01");
+
+    git(["checkout", "milestone/M001"], dir);
+    commitFile(dir, "b.txt", "slice 2\n", "feat: S02");
+    mergeSliceToMain(dir, "M001", "S02");
+
+    const beforeCount = parseInt(git(["rev-list", "--count", `${startSha}..main`], dir), 10);
+    assert.equal(beforeCount, 2);
+
+    const result = resquashMilestoneOnMain(dir, "M001", startSha);
+    assert.equal(result.resquashed, true);
+    assert.ok(result.newSha);
+
+    git(["checkout", "main"], dir);
+    const afterCount = parseInt(git(["rev-list", "--count", `${startSha}..main`], dir), 10);
+    assert.equal(afterCount, 1, "slice commits collapsed into one milestone commit");
+
+    const msg = git(["log", "-1", "--format=%s", "main"], dir);
+    assert.ok(msg.includes("M001") && msg.includes("2 slices"), `commit message should describe the resquash; got: ${msg}`);
+
+    assert.equal(readFileSync(join(dir, "a.txt"), "utf-8"), "slice 1\n");
+    assert.equal(readFileSync(join(dir, "b.txt"), "utf-8"), "slice 2\n");
+
+    const summary = summarizeWorktreeTelemetry(dir);
+    assert.equal(summary.milestoneResquashes, 1);
+  });
+
+  test("no-op when startSha equals HEAD", () => {
+    const startSha = git(["rev-parse", "main"], dir);
+    process.chdir(dir);
+    const result = resquashMilestoneOnMain(dir, "M001", startSha);
+    assert.equal(result.resquashed, false);
+    assert.equal(result.newSha, null);
+  });
+});

--- a/src/resources/extensions/gsd/tests/worktree-telemetry.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-telemetry.test.ts
@@ -175,12 +175,18 @@ test("resolveCanonicalMilestoneRoot emits nothing when it doesn't redirect", () 
   } finally { cleanup(base); }
 });
 
-test("percentile helper returns quantiles of a sorted array", () => {
+test("percentile helper returns quantiles of a sorted array (nearest-rank)", () => {
   assert.equal(percentile([], 0.5), null);
   assert.equal(percentile([10], 0.5), 10);
+  // Boundary behavior
   assert.equal(percentile([10, 20, 30, 40], 0), 10);
   assert.equal(percentile([10, 20, 30, 40], 1), 40);
-  assert.equal(percentile([10, 20, 30, 40], 0.5), 30);
+  // Nearest-rank: idx = ceil(q*n) - 1
+  // q=0.5, n=4 → idx = 2-1 = 1 → 20
+  assert.equal(percentile([10, 20, 30, 40], 0.5), 20);
+  // p95 on 20 values = idx ceil(0.95*20)-1 = 19-1 = 18 → value at index 18 (19th sample)
+  const twenty = Array.from({ length: 20 }, (_, i) => (i + 1) * 10); // [10..200]
+  assert.equal(percentile(twenty, 0.95), 190, "p95 should be the 19th of 20 sorted values, not the max");
 });
 
 test("summarizeWorktreeTelemetry supports time-window filtering", () => {

--- a/src/resources/extensions/gsd/tests/worktree-telemetry.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-telemetry.test.ts
@@ -1,0 +1,204 @@
+/**
+ * Tests for worktree telemetry — #4764.
+ *
+ * Covers emit helpers (writing to the journal) and the aggregator
+ * (summarizeWorktreeTelemetry).
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomUUID } from "node:crypto";
+
+import {
+  emitWorktreeCreated,
+  emitWorktreeMerged,
+  emitWorktreeOrphaned,
+  emitAutoExit,
+  emitCanonicalRootRedirect,
+  summarizeWorktreeTelemetry,
+  percentile,
+} from "../worktree-telemetry.ts";
+import { resolveCanonicalMilestoneRoot } from "../worktree-manager.ts";
+import { queryJournal } from "../journal.ts";
+
+function makeTmpBase(): string {
+  const base = join(tmpdir(), `gsd-tel-test-${randomUUID()}`);
+  mkdirSync(join(base, ".gsd"), { recursive: true });
+  return base;
+}
+
+function cleanup(base: string): void {
+  try { rmSync(base, { recursive: true, force: true }); } catch { /* */ }
+}
+
+test("emitWorktreeCreated writes a worktree-created journal event", () => {
+  const base = makeTmpBase();
+  try {
+    emitWorktreeCreated(base, "M001", { reason: "create-milestone" });
+    const entries = queryJournal(base, { eventType: "worktree-created" });
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].data?.milestoneId, "M001");
+    assert.equal(entries[0].data?.reason, "create-milestone");
+    assert.ok(typeof entries[0].data?.startedAt === "string");
+  } finally { cleanup(base); }
+});
+
+test("emitWorktreeMerged records duration and conflict fields", () => {
+  const base = makeTmpBase();
+  try {
+    emitWorktreeMerged(base, "M001", {
+      reason: "milestone-complete",
+      durationMs: 1234,
+      sliceCount: 3,
+      taskCount: 9,
+      conflict: false,
+    });
+    const entries = queryJournal(base, { eventType: "worktree-merged" });
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].data?.milestoneId, "M001");
+    assert.equal(entries[0].data?.durationMs, 1234);
+    assert.equal(entries[0].data?.sliceCount, 3);
+    assert.equal(entries[0].data?.conflict, false);
+  } finally { cleanup(base); }
+});
+
+test("emitWorktreeOrphaned captures reason and commits-ahead", () => {
+  const base = makeTmpBase();
+  try {
+    emitWorktreeOrphaned(base, "M002", {
+      reason: "in-progress-unmerged",
+      commitsAhead: 4,
+      worktreeDirExists: true,
+    });
+    const entries = queryJournal(base, { eventType: "worktree-orphaned" });
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].data?.milestoneId, "M002");
+    assert.equal(entries[0].data?.reason, "in-progress-unmerged");
+    assert.equal(entries[0].data?.commitsAhead, 4);
+    assert.equal(entries[0].data?.worktreeDirExists, true);
+  } finally { cleanup(base); }
+});
+
+test("emitAutoExit records reason and unmerged-work signal", () => {
+  const base = makeTmpBase();
+  try {
+    emitAutoExit(base, {
+      reason: "pause",
+      milestoneId: "M003",
+      milestoneMerged: false,
+    });
+    const entries = queryJournal(base, { eventType: "auto-exit" });
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].data?.reason, "pause");
+    assert.equal(entries[0].data?.milestoneMerged, false);
+  } finally { cleanup(base); }
+});
+
+test("summarizeWorktreeTelemetry aggregates events correctly", () => {
+  const base = makeTmpBase();
+  try {
+    // Two created, one merged, two orphans (different reasons), three exits,
+    // two of which left work unmerged.
+    emitWorktreeCreated(base, "M001");
+    emitWorktreeCreated(base, "M002");
+
+    emitWorktreeMerged(base, "M001", { reason: "milestone-complete", durationMs: 500, conflict: false });
+
+    emitWorktreeOrphaned(base, "M002", { reason: "in-progress-unmerged", commitsAhead: 2 });
+    emitWorktreeOrphaned(base, "M003", { reason: "complete-unmerged" });
+
+    emitAutoExit(base, { reason: "pause", milestoneId: "M002", milestoneMerged: false });
+    emitAutoExit(base, { reason: "stop", milestoneId: "M002", milestoneMerged: false });
+    emitAutoExit(base, { reason: "all-complete", milestoneId: "M001", milestoneMerged: true });
+
+    const summary = summarizeWorktreeTelemetry(base);
+    assert.equal(summary.worktreesCreated, 2);
+    assert.equal(summary.worktreesMerged, 1);
+    assert.equal(summary.orphansDetected, 2);
+    assert.deepStrictEqual(summary.orphansByReason, {
+      "in-progress-unmerged": 1,
+      "complete-unmerged": 1,
+    });
+    assert.deepStrictEqual(summary.mergeDurationsMs, [500]);
+    assert.equal(summary.mergeConflicts, 0);
+    assert.deepStrictEqual(summary.exitsByReason, {
+      "pause": 1,
+      "stop": 1,
+      "all-complete": 1,
+    });
+    assert.equal(summary.exitsWithUnmergedWork, 2, "pause and stop each left work unmerged");
+  } finally { cleanup(base); }
+});
+
+test("summarizeWorktreeTelemetry counts merge conflicts", () => {
+  const base = makeTmpBase();
+  try {
+    emitWorktreeMerged(base, "M001", { reason: "milestone-complete", durationMs: 100, conflict: false });
+    emitWorktreeMerged(base, "M002", { reason: "milestone-complete", durationMs: 200, conflict: true, conflictedFiles: 3 });
+    emitWorktreeMerged(base, "M003", { reason: "milestone-complete", durationMs: 150, conflict: false });
+
+    const summary = summarizeWorktreeTelemetry(base);
+    assert.equal(summary.worktreesMerged, 3);
+    assert.equal(summary.mergeConflicts, 1);
+    // Durations are sorted
+    assert.deepStrictEqual(summary.mergeDurationsMs, [100, 150, 200]);
+  } finally { cleanup(base); }
+});
+
+test("resolveCanonicalMilestoneRoot emits canonical-root-redirect on redirect", () => {
+  const base = makeTmpBase();
+  try {
+    // Create the live-worktree shape the resolver looks for
+    const wtDir = join(base, ".gsd", "worktrees", "M001");
+    mkdirSync(wtDir, { recursive: true });
+    writeFileSync(join(wtDir, ".git"), `gitdir: ${join(base, ".git", "worktrees", "M001")}\n`);
+
+    const result = resolveCanonicalMilestoneRoot(base, "M001");
+    assert.equal(result, wtDir);
+
+    const summary = summarizeWorktreeTelemetry(base);
+    assert.equal(summary.canonicalRedirects, 1, "redirect should emit exactly one event");
+  } finally { cleanup(base); }
+});
+
+test("resolveCanonicalMilestoneRoot emits nothing when it doesn't redirect", () => {
+  const base = makeTmpBase();
+  try {
+    const result = resolveCanonicalMilestoneRoot(base, "M999");
+    assert.equal(result, base);
+
+    const summary = summarizeWorktreeTelemetry(base);
+    assert.equal(summary.canonicalRedirects, 0, "no worktree → no redirect event");
+  } finally { cleanup(base); }
+});
+
+test("percentile helper returns quantiles of a sorted array", () => {
+  assert.equal(percentile([], 0.5), null);
+  assert.equal(percentile([10], 0.5), 10);
+  assert.equal(percentile([10, 20, 30, 40], 0), 10);
+  assert.equal(percentile([10, 20, 30, 40], 1), 40);
+  assert.equal(percentile([10, 20, 30, 40], 0.5), 30);
+});
+
+test("summarizeWorktreeTelemetry supports time-window filtering", () => {
+  const base = makeTmpBase();
+  try {
+    emitWorktreeCreated(base, "M001");
+    const midpoint = new Date().toISOString();
+    // Brief delay to ensure the next event has a later ts
+    const start = Date.now();
+    while (Date.now() - start < 10) { /* spin */ }
+    emitWorktreeCreated(base, "M002");
+
+    const beforeOnly = summarizeWorktreeTelemetry(base, { before: midpoint });
+    const afterOnly = summarizeWorktreeTelemetry(base, { after: midpoint });
+    // The sum of the two partitions covers all events (may overlap by 1 at
+    // exact-ts boundary — assert each partition is a proper subset).
+    assert.ok(beforeOnly.worktreesCreated >= 1);
+    assert.ok(afterOnly.worktreesCreated >= 1);
+    assert.ok(beforeOnly.worktreesCreated + afterOnly.worktreesCreated >= 2);
+  } finally { cleanup(base); }
+});

--- a/src/resources/extensions/gsd/tools/validate-milestone.ts
+++ b/src/resources/extensions/gsd/tools/validate-milestone.ts
@@ -18,6 +18,7 @@ import {
   getMilestoneSlices,
 } from "../gsd-db.js";
 import { resolveMilestonePath, clearPathCache } from "../paths.js";
+import { resolveCanonicalMilestoneRoot } from "../worktree-manager.js";
 import { saveFile, clearParseCache } from "../files.js";
 import { invalidateStateCache } from "../state.js";
 import { VALIDATION_VERDICTS, isValidMilestoneVerdict } from "../verdict-parser.js";
@@ -100,14 +101,19 @@ export async function handleValidateMilestone(
   }
 
   // ── Resolve paths and render markdown ────────────────────────────────
+  // #4761: route through the canonical-root resolver so that when a live
+  // worktree exists for this milestone, validation reads/writes the
+  // worktree's artifacts instead of stale project-root state.
   const validationMd = renderValidationMarkdown(params);
 
+  const canonicalBase = resolveCanonicalMilestoneRoot(basePath, params.milestoneId);
+
   let validationPath: string;
-  const milestoneDir = resolveMilestonePath(basePath, params.milestoneId);
+  const milestoneDir = resolveMilestonePath(canonicalBase, params.milestoneId);
   if (milestoneDir) {
     validationPath = join(milestoneDir, `${params.milestoneId}-VALIDATION.md`);
   } else {
-    const gsdDir = join(basePath, ".gsd");
+    const gsdDir = join(canonicalBase, ".gsd");
     const manualDir = join(gsdDir, "milestones", params.milestoneId);
     validationPath = join(manualDir, `${params.milestoneId}-VALIDATION.md`);
   }

--- a/src/resources/extensions/gsd/worktree-manager.ts
+++ b/src/resources/extensions/gsd/worktree-manager.ts
@@ -132,6 +132,42 @@ export function isInsideWorktreesDir(basePath: string, targetPath: string): bool
   return resolved === wtDir || resolved.startsWith(wtDir + sep);
 }
 
+/**
+ * Return the canonical path from which a milestone's artifacts should be read.
+ *
+ * If a live git worktree exists for this milestone at `.gsd/worktrees/<MID>/`
+ * (directory present AND a `.git` file indicating a registered worktree),
+ * returns that worktree path. Otherwise returns `basePath` unchanged.
+ *
+ * Readers that cross the session/worktree boundary (validators, the bootstrap
+ * audit, cross-session state queries) should route through this helper so they
+ * don't silently read stale project-root state while live work sits in the
+ * worktree. Writers and tools whose contract is "operate on the path I was
+ * given" should NOT use this helper — they preserve the legacy behavior.
+ *
+ * A stale worktree directory (no `.git` file) is treated as absent. The
+ * createWorktree() path already cleans these up, but readers must not trust
+ * them in the window before cleanup runs.
+ *
+ * Fixes #4761. Used by the #4762 audit for the pre-completion orphan case.
+ */
+export function resolveCanonicalMilestoneRoot(
+  basePath: string,
+  milestoneId: string,
+): string {
+  if (!milestoneId || /[\/\\]|\.\./.test(milestoneId)) return basePath;
+
+  const wtPath = worktreePath(basePath, milestoneId);
+  if (!existsSync(wtPath)) return basePath;
+
+  // A valid live worktree has a .git file pointing at the real gitdir.
+  // A directory without .git is a stale leftover from a prior crash and
+  // must not be trusted as a read source.
+  if (!existsSync(join(wtPath, ".git"))) return basePath;
+
+  return wtPath;
+}
+
 // ─── Core Operations ───────────────────────────────────────────────────────
 
 /**

--- a/src/resources/extensions/gsd/worktree-manager.ts
+++ b/src/resources/extensions/gsd/worktree-manager.ts
@@ -176,7 +176,11 @@ export function resolveCanonicalMilestoneRoot(
 
   // #4764 — record the redirect so we can measure how often the #4761 fix
   // would have mattered. Best-effort; emit is silent on any failure.
-  try { emitCanonicalRootRedirect(basePath, milestoneId, wtPath); } catch { /* silent */ }
+  try {
+    emitCanonicalRootRedirect(basePath, milestoneId, wtPath);
+  } catch (err) {
+    logWarning("worktree", `canonical-root-redirect telemetry failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
 
   return wtPath;
 }

--- a/src/resources/extensions/gsd/worktree-manager.ts
+++ b/src/resources/extensions/gsd/worktree-manager.ts
@@ -161,10 +161,18 @@ export function resolveCanonicalMilestoneRoot(
   const wtPath = worktreePath(basePath, milestoneId);
   if (!existsSync(wtPath)) return basePath;
 
-  // A valid live worktree has a .git file pointing at the real gitdir.
-  // A directory without .git is a stale leftover from a prior crash and
-  // must not be trusted as a read source.
-  if (!existsSync(join(wtPath, ".git"))) return basePath;
+  // A registered git worktree has a .git *file* (not directory) containing
+  // "gitdir: <path>". A standalone .git directory indicates a copied repo
+  // or nested standalone repo — not a worktree registered with this project —
+  // and must not be treated as the canonical root.
+  const gitPath = join(wtPath, ".git");
+  if (!existsSync(gitPath)) return basePath;
+  try {
+    const stat = lstatSync(gitPath);
+    if (!stat.isFile()) return basePath;
+  } catch {
+    return basePath;
+  }
 
   // #4764 — record the redirect so we can measure how often the #4761 fix
   // would have mattered. Best-effort; emit is silent on any failure.

--- a/src/resources/extensions/gsd/worktree-manager.ts
+++ b/src/resources/extensions/gsd/worktree-manager.ts
@@ -37,6 +37,7 @@ import {
   nativeWorktreePrune,
   nativeWorktreeRemove,
 } from "./native-git-bridge.js";
+import { emitCanonicalRootRedirect } from "./worktree-telemetry.js";
 
 // ─── Types ─────────────────────────────────────────────────────────────────
 
@@ -164,6 +165,10 @@ export function resolveCanonicalMilestoneRoot(
   // A directory without .git is a stale leftover from a prior crash and
   // must not be trusted as a read source.
   if (!existsSync(join(wtPath, ".git"))) return basePath;
+
+  // #4764 — record the redirect so we can measure how often the #4761 fix
+  // would have mattered. Best-effort; emit is silent on any failure.
+  try { emitCanonicalRootRedirect(basePath, milestoneId, wtPath); } catch { /* silent */ }
 
   return wtPath;
 }

--- a/src/resources/extensions/gsd/worktree-resolver.ts
+++ b/src/resources/extensions/gsd/worktree-resolver.ts
@@ -21,6 +21,8 @@ import { debugLog } from "./debug-logger.js";
 import { MergeConflictError } from "./git-service.js";
 import { emitJournalEvent } from "./journal.js";
 import { emitWorktreeCreated, emitWorktreeMerged } from "./worktree-telemetry.js";
+import { getCollapseCadence, getMilestoneResquash, resquashMilestoneOnMain } from "./slice-cadence.js";
+import { loadEffectiveGSDPreferences } from "./preferences.js";
 
 // ─── Dependency Interface ──────────────────────────────────────────────────
 
@@ -462,6 +464,38 @@ export class WorktreeResolver {
       this._mergeWorktreeMode(milestoneId, ctx);
     } else if (mode === "branch") {
       this._mergeBranchMode(milestoneId, ctx);
+    }
+
+    // #4765 — when collapse_cadence=slice AND milestone_resquash=true, the
+    // N per-slice commits on main should be collapsed into one milestone
+    // commit. Done AFTER the primary merge-and-teardown so the branch and
+    // worktree are already cleaned up; we operate on main directly.
+    try {
+      const startSha = this.s.milestoneStartShas.get(milestoneId);
+      if (startSha) {
+        const prefs = loadEffectiveGSDPreferences(this.s.originalBasePath || this.s.basePath)?.preferences;
+        if (getCollapseCadence(prefs) === "slice" && getMilestoneResquash(prefs)) {
+          const result = resquashMilestoneOnMain(
+            this.s.originalBasePath || this.s.basePath,
+            milestoneId,
+            startSha,
+          );
+          if (result.resquashed) {
+            ctx.notify(
+              `slice-cadence: re-squashed slice commits for ${milestoneId} into a single milestone commit.`,
+              "info",
+            );
+          }
+        }
+        this.s.milestoneStartShas.delete(milestoneId);
+      }
+    } catch (err) {
+      debugLog("WorktreeResolver", {
+        action: "mergeAndExit",
+        milestoneId,
+        phase: "resquash",
+        error: err instanceof Error ? err.message : String(err),
+      });
     }
 
     // #4764 — record merge completion (success path reaches here). Failure

--- a/src/resources/extensions/gsd/worktree-resolver.ts
+++ b/src/resources/extensions/gsd/worktree-resolver.ts
@@ -20,6 +20,7 @@ import type { AutoSession } from "./auto/session.js";
 import { debugLog } from "./debug-logger.js";
 import { MergeConflictError } from "./git-service.js";
 import { emitJournalEvent } from "./journal.js";
+import { emitWorktreeCreated, emitWorktreeMerged } from "./worktree-telemetry.js";
 
 // ─── Dependency Interface ──────────────────────────────────────────────────
 
@@ -290,6 +291,13 @@ export class WorktreeResolver {
         eventType: "worktree-enter",
         data: { milestoneId, wtPath, created: !existingPath },
       });
+      // #4764 — record creation/enter as a lifecycle event so the telemetry
+      // aggregator can pair it with the eventual worktree-merged event.
+      try {
+        emitWorktreeCreated(this.s.originalBasePath || this.s.basePath, milestoneId, {
+          reason: existingPath ? "enter-milestone" : "create-milestone",
+        });
+      } catch { /* silent */ }
       ctx.notify(`Entered worktree for ${milestoneId} at ${wtPath}`, "info");
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
@@ -398,6 +406,10 @@ export class WorktreeResolver {
   mergeAndExit(milestoneId: string, ctx: NotifyCtx): void {
     this.validateMilestoneId(milestoneId);
 
+    // #4764 — telemetry: record start timestamp so we can emit merge duration.
+    const mergeStartedAt = new Date().toISOString();
+    const mergeStartMs = Date.now();
+
     // If worktree creation failed earlier, skip merge — work is on current branch (#2483)
     if (this.s.isolationDegraded) {
       debugLog("WorktreeResolver", {
@@ -451,6 +463,18 @@ export class WorktreeResolver {
     } else if (mode === "branch") {
       this._mergeBranchMode(milestoneId, ctx);
     }
+
+    // #4764 — record merge completion (success path reaches here). Failure
+    // paths throw out of _merge* before reaching this line, so the absence
+    // of worktree-merged pairs with a prior worktree-created flags an
+    // orphan in the aggregator.
+    try {
+      emitWorktreeMerged(this.s.originalBasePath || this.s.basePath, milestoneId, {
+        reason: "milestone-complete",
+        startedAt: mergeStartedAt,
+        durationMs: Date.now() - mergeStartMs,
+      });
+    } catch { /* silent */ }
   }
 
   /** Worktree-mode merge: read roadmap, merge, teardown, reset paths. */

--- a/src/resources/extensions/gsd/worktree-resolver.ts
+++ b/src/resources/extensions/gsd/worktree-resolver.ts
@@ -458,12 +458,24 @@ export class WorktreeResolver {
       return;
     }
 
+    let actuallyMerged = false;
     if (
       mode === "worktree" || inWorktree
     ) {
-      this._mergeWorktreeMode(milestoneId, ctx);
+      actuallyMerged = this._mergeWorktreeMode(milestoneId, ctx);
     } else if (mode === "branch") {
-      this._mergeBranchMode(milestoneId, ctx);
+      actuallyMerged = this._mergeBranchMode(milestoneId, ctx);
+    }
+
+    // The remainder of this function emits telemetry and runs re-squash.
+    // Both are gated on actuallyMerged — if the _merge* helper took a
+    // no-merge path (missing originalBase, no roadmap, wrong branch) the
+    // milestone branch was intentionally left unmerged and we must not
+    // emit a worktree-merged event or collapse commits on main.
+    if (!actuallyMerged) {
+      // Always clear the start-SHA tracker to avoid leaking across sessions.
+      this.s.milestoneStartShas.delete(milestoneId);
+      return;
     }
 
     // #4765 — when collapse_cadence=slice AND milestone_resquash=true, the
@@ -498,10 +510,9 @@ export class WorktreeResolver {
       });
     }
 
-    // #4764 — record merge completion (success path reaches here). Failure
-    // paths throw out of _merge* before reaching this line, so the absence
-    // of worktree-merged pairs with a prior worktree-created flags an
-    // orphan in the aggregator.
+    // #4764 — record merge completion. Only reaches here when an actual
+    // merge ran; failure paths throw out of _merge* before this point and
+    // no-merge paths returned above.
     try {
       emitWorktreeMerged(this.s.originalBasePath || this.s.basePath, milestoneId, {
         reason: "milestone-complete",
@@ -511,8 +522,12 @@ export class WorktreeResolver {
     } catch { /* silent */ }
   }
 
-  /** Worktree-mode merge: read roadmap, merge, teardown, reset paths. */
-  private _mergeWorktreeMode(milestoneId: string, ctx: NotifyCtx): void {
+  /** Worktree-mode merge: read roadmap, merge, teardown, reset paths.
+   *  Returns true when a squash-merge actually ran, false when the function
+   *  returned early (missing originalBase) or took the preserve-branch path
+   *  (no roadmap). Callers gate merged-event telemetry and milestone
+   *  re-squash on this signal. */
+  private _mergeWorktreeMode(milestoneId: string, ctx: NotifyCtx): boolean {
     const originalBase = this.s.originalBasePath;
     if (!originalBase) {
       debugLog("WorktreeResolver", {
@@ -522,9 +537,10 @@ export class WorktreeResolver {
         skipped: true,
         reason: "missing-original-base",
       });
-      return;
+      return false;
     }
 
+    let merged = false;
     try {
       const { synced } = this.deps.syncWorktreeStateBack(
         originalBase,
@@ -573,6 +589,7 @@ export class WorktreeResolver {
           milestoneId,
           roadmapContent,
         );
+        merged = true;
 
         // #2945 Bug 3: mergeMilestoneToMain performs best-effort worktree
         // cleanup internally (step 12), but it can silently fail on Windows
@@ -676,10 +693,12 @@ export class WorktreeResolver {
       result: "done",
       basePath: this.s.basePath,
     });
+    return merged;
   }
 
-  /** Branch-mode merge: check current branch, merge if on milestone branch. */
-  private _mergeBranchMode(milestoneId: string, ctx: NotifyCtx): void {
+  /** Branch-mode merge: check current branch, merge if on milestone branch.
+   *  Returns true when a merge actually ran, false on skip paths. */
+  private _mergeBranchMode(milestoneId: string, ctx: NotifyCtx): boolean {
     try {
       const currentBranch = this.deps.getCurrentBranch(this.s.basePath);
       const milestoneBranch = this.deps.autoWorktreeBranch(milestoneId);
@@ -694,7 +713,7 @@ export class WorktreeResolver {
           currentBranch,
           milestoneBranch,
         });
-        return;
+        return false;
       }
 
       const roadmapPath = this.deps.resolveMilestoneFile(
@@ -710,7 +729,7 @@ export class WorktreeResolver {
           skipped: true,
           reason: "no-roadmap",
         });
-        return;
+        return false;
       }
 
       const roadmapContent = this.deps.readFileSync(roadmapPath, "utf-8");
@@ -741,6 +760,7 @@ export class WorktreeResolver {
         mode: "branch",
         result: "success",
       });
+      return true;
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       debugLog("WorktreeResolver", {

--- a/src/resources/extensions/gsd/worktree-resolver.ts
+++ b/src/resources/extensions/gsd/worktree-resolver.ts
@@ -299,7 +299,13 @@ export class WorktreeResolver {
         emitWorktreeCreated(this.s.originalBasePath || this.s.basePath, milestoneId, {
           reason: existingPath ? "enter-milestone" : "create-milestone",
         });
-      } catch { /* silent */ }
+      } catch (telemetryErr) {
+        debugLog("WorktreeResolver", {
+          action: "enterMilestone",
+          phase: "telemetry-emit",
+          error: telemetryErr instanceof Error ? telemetryErr.message : String(telemetryErr),
+        });
+      }
       ctx.notify(`Entered worktree for ${milestoneId} at ${wtPath}`, "info");
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
@@ -519,14 +525,17 @@ export class WorktreeResolver {
         startedAt: mergeStartedAt,
         durationMs: Date.now() - mergeStartMs,
       });
-    } catch { /* silent */ }
+    } catch (telemetryErr) {
+      debugLog("WorktreeResolver", {
+        action: "mergeAndExit",
+        phase: "telemetry-emit",
+        error: telemetryErr instanceof Error ? telemetryErr.message : String(telemetryErr),
+      });
+    }
   }
 
   /** Worktree-mode merge: read roadmap, merge, teardown, reset paths.
-   *  Returns true when a squash-merge actually ran, false when the function
-   *  returned early (missing originalBase) or took the preserve-branch path
-   *  (no roadmap). Callers gate merged-event telemetry and milestone
-   *  re-squash on this signal. */
+   *  Returns true when a squash-merge actually ran (false on skip paths). */
   private _mergeWorktreeMode(milestoneId: string, ctx: NotifyCtx): boolean {
     const originalBase = this.s.originalBasePath;
     if (!originalBase) {
@@ -697,7 +706,7 @@ export class WorktreeResolver {
   }
 
   /** Branch-mode merge: check current branch, merge if on milestone branch.
-   *  Returns true when a merge actually ran, false on skip paths. */
+   *  Returns true when a merge actually ran (false on skip paths). */
   private _mergeBranchMode(milestoneId: string, ctx: NotifyCtx): boolean {
     try {
       const currentBranch = this.deps.getCurrentBranch(this.s.basePath);

--- a/src/resources/extensions/gsd/worktree-telemetry.ts
+++ b/src/resources/extensions/gsd/worktree-telemetry.ts
@@ -150,6 +150,38 @@ export function emitCanonicalRootRedirect(
   }));
 }
 
+// #4765 — slice-cadence collapse events
+
+export function emitSliceMerged(
+  projectRoot: string,
+  milestoneId: string,
+  sliceId: string,
+  meta: { durationMs?: number; conflict?: boolean; commitSha?: string } = {},
+): void {
+  emitJournalEvent(projectRoot, baseEntry("slice-merged", {
+    milestoneId,
+    sliceId,
+    mergedAt: now(),
+    durationMs: meta.durationMs,
+    conflict: meta.conflict ?? false,
+    commitSha: meta.commitSha,
+  }));
+}
+
+export function emitMilestoneResquash(
+  projectRoot: string,
+  milestoneId: string,
+  meta: { sliceCount: number; startSha?: string; endSha?: string } = { sliceCount: 0 },
+): void {
+  emitJournalEvent(projectRoot, baseEntry("milestone-resquash", {
+    milestoneId,
+    sliceCount: meta.sliceCount,
+    startSha: meta.startSha,
+    endSha: meta.endSha,
+    resquashedAt: now(),
+  }));
+}
+
 // ─── Aggregator ──────────────────────────────────────────────────────────
 
 export interface WorktreeTelemetrySummary {
@@ -171,6 +203,12 @@ export interface WorktreeTelemetrySummary {
   exitsWithUnmergedWork: number;
   /** Count of canonical-root-redirects (how often #4761 validation would have read stale state) */
   canonicalRedirects: number;
+  /** #4765 — count of successful slice-level merges (slice-cadence feature) */
+  slicesMerged: number;
+  /** #4765 — count of slice-level merge conflicts */
+  sliceMergeConflicts: number;
+  /** #4765 — count of milestone-level re-squash operations */
+  milestoneResquashes: number;
 }
 
 /**
@@ -193,6 +231,9 @@ export function summarizeWorktreeTelemetry(
     exitsByReason: {},
     exitsWithUnmergedWork: 0,
     canonicalRedirects: 0,
+    slicesMerged: 0,
+    sliceMergeConflicts: 0,
+    milestoneResquashes: 0,
   };
 
   for (const e of entries) {
@@ -220,6 +261,13 @@ export function summarizeWorktreeTelemetry(
       }
       case "canonical-root-redirect":
         summary.canonicalRedirects++;
+        break;
+      case "slice-merged":
+        summary.slicesMerged++;
+        if (d.conflict === true) summary.sliceMergeConflicts++;
+        break;
+      case "milestone-resquash":
+        summary.milestoneResquashes++;
         break;
       default:
         break;

--- a/src/resources/extensions/gsd/worktree-telemetry.ts
+++ b/src/resources/extensions/gsd/worktree-telemetry.ts
@@ -37,12 +37,28 @@ function baseEntry(eventType: JournalEntry["eventType"], data: Record<string, un
   };
 }
 
+// ─── Reason literal unions ───────────────────────────────────────────────
+// Closed sets so typos at call sites are rejected at compile time and can't
+// silently fragment the telemetry buckets produced by summarizeWorktreeTelemetry.
+
+export type WorktreeCreatedReason = "create-milestone" | "enter-milestone";
+export type AutoExitReason =
+  | "pause"
+  | "stop"
+  | "blocked"
+  | "merge-conflict"
+  | "merge-failed"
+  | "slice-merge-conflict"
+  | "all-complete"
+  | "no-active-milestone"
+  | "other";
+
 // ─── Emitters ────────────────────────────────────────────────────────────
 
 export function emitWorktreeCreated(
   projectRoot: string,
   milestoneId: string,
-  meta: { flowId?: string; reason?: string } = {},
+  meta: { flowId?: string; reason?: WorktreeCreatedReason } = {},
 ): void {
   emitJournalEvent(projectRoot, baseEntry("worktree-created", {
     milestoneId,
@@ -104,7 +120,10 @@ export function emitAutoExit(
   projectRoot: string,
   meta: {
     flowId?: string;
-    reason: string; // "pause" | "stop" | "blocked" | "merge-conflict" | "merge-error" | "all-complete" | ...
+    /** Must come from the closed AutoExitReason set. Callers with free-form
+     *  reasons (e.g. stopAuto's `reason?: string` parameter) should map to
+     *  the closed set before emitting. */
+    reason: AutoExitReason;
     milestoneId?: string;
     milestoneMerged: boolean;
   },

--- a/src/resources/extensions/gsd/worktree-telemetry.ts
+++ b/src/resources/extensions/gsd/worktree-telemetry.ts
@@ -143,10 +143,12 @@ export function emitCanonicalRootRedirect(
   projectRoot: string,
   milestoneId: string,
   redirectedTo: string,
+  meta: { flowId?: string } = {},
 ): void {
   emitJournalEvent(projectRoot, baseEntry("canonical-root-redirect", {
     milestoneId,
     redirectedTo,
+    flowId: meta.flowId,
   }));
 }
 
@@ -156,7 +158,7 @@ export function emitSliceMerged(
   projectRoot: string,
   milestoneId: string,
   sliceId: string,
-  meta: { durationMs?: number; conflict?: boolean; commitSha?: string } = {},
+  meta: { durationMs?: number; conflict?: boolean; commitSha?: string; flowId?: string } = {},
 ): void {
   emitJournalEvent(projectRoot, baseEntry("slice-merged", {
     milestoneId,
@@ -165,13 +167,14 @@ export function emitSliceMerged(
     durationMs: meta.durationMs,
     conflict: meta.conflict ?? false,
     commitSha: meta.commitSha,
+    flowId: meta.flowId,
   }));
 }
 
 export function emitMilestoneResquash(
   projectRoot: string,
   milestoneId: string,
-  meta: { sliceCount: number; startSha?: string; endSha?: string } = { sliceCount: 0 },
+  meta: { sliceCount: number; startSha?: string; endSha?: string; flowId?: string } = { sliceCount: 0 },
 ): void {
   emitJournalEvent(projectRoot, baseEntry("milestone-resquash", {
     milestoneId,
@@ -179,6 +182,7 @@ export function emitMilestoneResquash(
     startSha: meta.startSha,
     endSha: meta.endSha,
     resquashedAt: now(),
+    flowId: meta.flowId,
   }));
 }
 
@@ -278,11 +282,22 @@ export function summarizeWorktreeTelemetry(
   return summary;
 }
 
-/** Return the p{quantile} of a sorted array. Quantile in [0,1]. */
+/**
+ * Return the p{quantile} of a sorted array using the nearest-rank method.
+ * Quantile in [0,1].
+ *
+ * Prior implementation used Math.floor(q*n), which overstates exact-rank
+ * quantiles by one sample (e.g. p95 of 20 values returned the max instead
+ * of the 19th value). The nearest-rank index is ceil(q*n) - 1, clamped to
+ * [0, n-1].
+ */
 export function percentile(sortedValues: number[], q: number): number | null {
   if (sortedValues.length === 0) return null;
   if (q <= 0) return sortedValues[0];
   if (q >= 1) return sortedValues[sortedValues.length - 1];
-  const idx = Math.min(sortedValues.length - 1, Math.floor(q * sortedValues.length));
+  const idx = Math.min(
+    sortedValues.length - 1,
+    Math.max(0, Math.ceil(q * sortedValues.length) - 1),
+  );
   return sortedValues[idx];
 }

--- a/src/resources/extensions/gsd/worktree-telemetry.ts
+++ b/src/resources/extensions/gsd/worktree-telemetry.ts
@@ -1,0 +1,240 @@
+/**
+ * Worktree telemetry — #4764
+ *
+ * Thin emit helpers + aggregator on top of the existing journal. Separate
+ * module so callers import a tiny surface and don't have to assemble
+ * JournalEntry records by hand. Kernighan: the underlying emit path
+ * (emitJournalEvent) is already battle-tested; this module is just
+ * structured call sites + a summarizer.
+ *
+ * Emitted event types (see journal.ts):
+ *   - worktree-created           worktree entered/created for a milestone
+ *   - worktree-merged            worktree merge back to main completed
+ *   - worktree-orphaned          audit detected an orphaned branch/worktree
+ *   - auto-exit                  auto-mode exited (pause/stop/blocked/error)
+ *   - worktree-sync              syncStateToProjectRoot snapshot
+ *   - canonical-root-redirect    resolveCanonicalMilestoneRoot redirected
+ *
+ * These events are purely observational. They never block, never throw,
+ * and never carry code content — only IDs, counts, durations, and reasons.
+ */
+
+import { randomUUID } from "node:crypto";
+import { emitJournalEvent, queryJournal } from "./journal.js";
+import type { JournalEntry } from "./journal.js";
+
+function now(): string {
+  return new Date().toISOString();
+}
+
+function baseEntry(eventType: JournalEntry["eventType"], data: Record<string, unknown>): JournalEntry {
+  return {
+    ts: now(),
+    flowId: (typeof data.flowId === "string" ? data.flowId : undefined) ?? randomUUID(),
+    seq: typeof data.seq === "number" ? data.seq : 0,
+    eventType,
+    data,
+  };
+}
+
+// ─── Emitters ────────────────────────────────────────────────────────────
+
+export function emitWorktreeCreated(
+  projectRoot: string,
+  milestoneId: string,
+  meta: { flowId?: string; reason?: string } = {},
+): void {
+  emitJournalEvent(projectRoot, baseEntry("worktree-created", {
+    milestoneId,
+    startedAt: now(),
+    flowId: meta.flowId,
+    reason: meta.reason ?? "enter-milestone",
+  }));
+}
+
+export function emitWorktreeMerged(
+  projectRoot: string,
+  milestoneId: string,
+  meta: {
+    flowId?: string;
+    reason?: "milestone-complete" | "all-complete" | "stop-fallback" | "transition" | "other";
+    startedAt?: string;
+    durationMs?: number;
+    sliceCount?: number;
+    taskCount?: number;
+    conflict?: boolean;
+    conflictedFiles?: number;
+  } = {},
+): void {
+  emitJournalEvent(projectRoot, baseEntry("worktree-merged", {
+    milestoneId,
+    endedAt: now(),
+    flowId: meta.flowId,
+    reason: meta.reason ?? "other",
+    startedAt: meta.startedAt,
+    durationMs: meta.durationMs,
+    sliceCount: meta.sliceCount,
+    taskCount: meta.taskCount,
+    conflict: meta.conflict ?? false,
+    conflictedFiles: meta.conflictedFiles ?? 0,
+  }));
+}
+
+export function emitWorktreeOrphaned(
+  projectRoot: string,
+  milestoneId: string,
+  meta: {
+    flowId?: string;
+    reason: "in-progress-unmerged" | "complete-unmerged" | "stale-branch";
+    commitsAhead?: number;
+    worktreeDirExists?: boolean;
+  },
+): void {
+  emitJournalEvent(projectRoot, baseEntry("worktree-orphaned", {
+    milestoneId,
+    flowId: meta.flowId,
+    reason: meta.reason,
+    commitsAhead: meta.commitsAhead,
+    worktreeDirExists: meta.worktreeDirExists ?? false,
+    detectedAt: now(),
+  }));
+}
+
+export function emitAutoExit(
+  projectRoot: string,
+  meta: {
+    flowId?: string;
+    reason: string; // "pause" | "stop" | "blocked" | "merge-conflict" | "merge-error" | "all-complete" | ...
+    milestoneId?: string;
+    milestoneMerged: boolean;
+  },
+): void {
+  emitJournalEvent(projectRoot, baseEntry("auto-exit", {
+    reason: meta.reason,
+    flowId: meta.flowId,
+    milestoneId: meta.milestoneId,
+    milestoneMerged: meta.milestoneMerged,
+    exitedAt: now(),
+  }));
+}
+
+export function emitWorktreeSync(
+  projectRoot: string,
+  milestoneId: string,
+  meta: {
+    flowId?: string;
+    filesCopied?: number;
+    bytesCopied?: number;
+    commitsAhead?: number;
+    worktreeAgeMs?: number;
+  },
+): void {
+  emitJournalEvent(projectRoot, baseEntry("worktree-sync", {
+    milestoneId,
+    flowId: meta.flowId,
+    filesCopied: meta.filesCopied,
+    bytesCopied: meta.bytesCopied,
+    commitsAhead: meta.commitsAhead,
+    worktreeAgeMs: meta.worktreeAgeMs,
+  }));
+}
+
+export function emitCanonicalRootRedirect(
+  projectRoot: string,
+  milestoneId: string,
+  redirectedTo: string,
+): void {
+  emitJournalEvent(projectRoot, baseEntry("canonical-root-redirect", {
+    milestoneId,
+    redirectedTo,
+  }));
+}
+
+// ─── Aggregator ──────────────────────────────────────────────────────────
+
+export interface WorktreeTelemetrySummary {
+  /** Count of worktrees created within the window */
+  worktreesCreated: number;
+  /** Count of worktrees merged within the window */
+  worktreesMerged: number;
+  /** Count of orphan detections within the window */
+  orphansDetected: number;
+  /** Breakdown by orphan reason */
+  orphansByReason: Record<string, number>;
+  /** Merge durations in milliseconds, sorted ascending */
+  mergeDurationsMs: number[];
+  /** Number of merges that hit a conflict */
+  mergeConflicts: number;
+  /** Auto-exit reasons and their counts */
+  exitsByReason: Record<string, number>;
+  /** Auto-exits where the milestone was NOT merged before exit — the #4761 producer metric */
+  exitsWithUnmergedWork: number;
+  /** Count of canonical-root-redirects (how often #4761 validation would have read stale state) */
+  canonicalRedirects: number;
+}
+
+/**
+ * Summarize worktree telemetry across the journal. Optional time window
+ * via filters.after / filters.before (ISO-8601).
+ */
+export function summarizeWorktreeTelemetry(
+  projectRoot: string,
+  filters?: { after?: string; before?: string },
+): WorktreeTelemetrySummary {
+  const entries = queryJournal(projectRoot, filters);
+
+  const summary: WorktreeTelemetrySummary = {
+    worktreesCreated: 0,
+    worktreesMerged: 0,
+    orphansDetected: 0,
+    orphansByReason: {},
+    mergeDurationsMs: [],
+    mergeConflicts: 0,
+    exitsByReason: {},
+    exitsWithUnmergedWork: 0,
+    canonicalRedirects: 0,
+  };
+
+  for (const e of entries) {
+    const d = e.data ?? {};
+    switch (e.eventType) {
+      case "worktree-created":
+        summary.worktreesCreated++;
+        break;
+      case "worktree-merged":
+        summary.worktreesMerged++;
+        if (typeof d.durationMs === "number") summary.mergeDurationsMs.push(d.durationMs);
+        if (d.conflict === true) summary.mergeConflicts++;
+        break;
+      case "worktree-orphaned": {
+        summary.orphansDetected++;
+        const reason = typeof d.reason === "string" ? d.reason : "unknown";
+        summary.orphansByReason[reason] = (summary.orphansByReason[reason] ?? 0) + 1;
+        break;
+      }
+      case "auto-exit": {
+        const reason = typeof d.reason === "string" ? d.reason : "unknown";
+        summary.exitsByReason[reason] = (summary.exitsByReason[reason] ?? 0) + 1;
+        if (d.milestoneMerged === false) summary.exitsWithUnmergedWork++;
+        break;
+      }
+      case "canonical-root-redirect":
+        summary.canonicalRedirects++;
+        break;
+      default:
+        break;
+    }
+  }
+
+  summary.mergeDurationsMs.sort((a, b) => a - b);
+  return summary;
+}
+
+/** Return the p{quantile} of a sorted array. Quantile in [0,1]. */
+export function percentile(sortedValues: number[], q: number): number | null {
+  if (sortedValues.length === 0) return null;
+  if (q <= 0) return sortedValues[0];
+  if (q >= 1) return sortedValues[sortedValues.length - 1];
+  const idx = Math.min(sortedValues.length - 1, Math.floor(q * sortedValues.length));
+  return sortedValues[idx];
+}


### PR DESCRIPTION
## Summary

Root-cause investigation found that worktree work gets stranded when auto-mode exits without completing a milestone. The full fix is four layered changes: two correctness fixes, telemetry so the improvement is measurable, and an opt-in feature that addresses the producer side of the orphan class.

- **#4761** — worktree-aware validation
- **#4762** — audit covers in-progress milestone orphans
- **#4764** — worktree lifespan + divergence telemetry, surfaced in /gsd forensics
- **#4765** — opt-in slice-cadence worktree collapse with milestone re-squash

## What changed

### Correctness (#4761, #4762)

`handleValidateMilestone` now routes through a new `resolveCanonicalMilestoneRoot` helper — when a live worktree exists for the milestone, reads and writes go to the worktree instead of stale project-root state. Every other caller of `resolveMilestonePath` is unchanged.

`auditOrphanedMilestoneBranches` no longer skips milestones whose DB status is `in_progress`. When such a milestone has a branch with commits ahead of main, the audit surfaces a warning with the commit count and (if present) the worktree directory location.

### Observability (#4764)

Six new journal event types instrument the worktree lifecycle. A new `summarizeWorktreeTelemetry` aggregator returns counts, orphan breakdown, sorted merge durations, conflict counts, exit-reason distribution, and a producer-side exits-with-unmerged-work metric.

`/gsd forensics` reports now include a Worktree Telemetry section and two new anomaly types (`worktree-orphan`, `worktree-unmerged-exit`). The existing memory-bloat guard on forensics.ts (no direct `queryJournal` calls) is preserved.

### Feature (#4765)

New preference `git.collapse_cadence`: `\"milestone\"` (default) or `\"slice\"`. When `\"slice\"`, each validated slice is squash-merged to main as soon as the slice passes validation; milestone branch fast-forwards to main so the next slice starts from a clean base. Orphan window shrinks from milestone-size to slice-size.

Optional `git.milestone_resquash` (default true when cadence is slice) collapses per-slice commits into a single milestone commit at milestone completion.

## Discipline applied

- **Kernighan's law** — implementations are deliberately narrow. `resolveCanonicalMilestoneRoot` is 15 lines. `mergeSliceToMain` is a focused subset of `mergeMilestoneToMain` with no worktree teardown.
- **Hyrum's law** — every change is additive. `resolveMilestonePath` and 20+ callers untouched. `ForensicReport`/`ForensicAnomaly` extended, not mutated. `GitPreferences` gains two optional fields whose defaults preserve existing behavior. Journal event types are a union.
- **Knuth's optimization principle** — correctness first, measurement second, feature last and opt-in. Cadence default flip deferred until telemetry justifies it.

## Tests

90 tests total across six test files, all passing.

## Test plan

- [ ] Pull the branch and run `npm run test:compile && npm run test:unit` — expect no regressions
- [ ] Run one auto-mode session with default prefs — confirm behavior unchanged
- [ ] Run `/gsd forensics` after a session — confirm new Worktree Telemetry section appears
- [ ] Pause an auto-mode session mid-milestone, restart — confirm bootstrap audit warns about the in-progress orphan (#4762)
- [ ] Opt in to `git.collapse_cadence: \"slice\"` on a multi-slice milestone — confirm slice commits appear on main
- [ ] With `milestone_resquash: true`, complete the milestone — confirm slice commits are re-squashed to one

Closes #4761
Closes #4762
Closes #4764
Closes #4765

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Worktree lifecycle telemetry in diagnostics and /gsd forensics (merge-duration percentiles, conflicts, orphan/unmerged-exit signals, per-slice visibility, and new anomaly types).
  * Collapse cadence options: "milestone" (default) or opt-in "slice" with optional milestone resquash; per-slice merges and optional resquash-on-completion.
  * Notifications for slice merges, merge conflicts, and auto-run exits.

* **Bug Fixes**
  * Milestone validation respects live worktree roots.
  * Orphan audit warns about in-progress unmerged milestones and provides resume location details.

* **Documentation**
  * Updated configuration, diagnostics, and troubleshooting for cadence, resquash, and orphan handling.

* **Tests**
  * New/expanded suites for telemetry, cadence, audits, canonical-root behavior, and merge/resquash.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->