### PR TITLE
Sweep #4773: migrate 82 byte-slice tests to extractSourceRegion helper

### DIFF
--- a/src/resources/extensions/gsd/tests/artifacts-table-preserved-on-cache-invalidate.test.ts
+++ b/src/resources/extensions/gsd/tests/artifacts-table-preserved-on-cache-invalidate.test.ts
@@ -161,7 +161,7 @@ describe("cache.ts must not re-import clearArtifacts into invalidateAllCaches", 
   test("invalidateAllCaches does not call clearArtifacts", () => {
     const fnIdx = src.indexOf("function invalidateAllCaches");
     assert.ok(fnIdx !== -1);
-    const body = extractSourceRegion(src, "function invalidateAllCaches");
+    const body = extractSourceRegion(src, "function invalidateAllCaches", { fromIdx: fnIdx });
     assert.ok(
       !/\bclearArtifacts\s*\(/.test(body),
       "invalidateAllCaches must not call clearArtifacts() — it wipes the write-through store",

--- a/src/resources/extensions/gsd/tests/artifacts-table-preserved-on-cache-invalidate.test.ts
+++ b/src/resources/extensions/gsd/tests/artifacts-table-preserved-on-cache-invalidate.test.ts
@@ -22,6 +22,7 @@ import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 
 import { invalidateAllCaches } from "../cache.ts";
+import { extractSourceRegion } from "./test-helpers.ts";
 import {
   openDatabase,
   closeDatabase,
@@ -160,7 +161,7 @@ describe("cache.ts must not re-import clearArtifacts into invalidateAllCaches", 
   test("invalidateAllCaches does not call clearArtifacts", () => {
     const fnIdx = src.indexOf("function invalidateAllCaches");
     assert.ok(fnIdx !== -1);
-    const body = src.slice(fnIdx, fnIdx + 1000);
+    const body = extractSourceRegion(src, "function invalidateAllCaches");
     assert.ok(
       !/\bclearArtifacts\s*\(/.test(body),
       "invalidateAllCaches must not call clearArtifacts() — it wipes the write-through store",

--- a/src/resources/extensions/gsd/tests/auto-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-loop.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 
+import { extractSourceRegion } from "./test-helpers.ts";
 import {
   resolveAgentEnd,
   resolveAgentEndCancelled,
@@ -595,7 +596,7 @@ test("auto/phases.ts: selectAndApplyModel called exactly once and before updateP
   // Extract the runUnitPhase function body
   const fnStart = src.indexOf("export async function runUnitPhase");
   assert.ok(fnStart > 0, "runUnitPhase should exist in phases.ts");
-  const fnBody = src.slice(fnStart, fnStart + 16000);
+  const fnBody = extractSourceRegion(src, "export async function runUnitPhase");
 
   // selectAndApplyModel must appear exactly once
   const allOccurrences = [...fnBody.matchAll(/selectAndApplyModel\(/g)];
@@ -1538,9 +1539,7 @@ test("auto.ts startAuto dispatches through the UOK kernel wrapper with explicit 
   // Find the startAuto function body
   const fnIdx = src.indexOf("export async function startAuto");
   assert.ok(fnIdx > -1, "startAuto must exist in auto.ts");
-  const fnEnd = src.indexOf("\n// ─── ", fnIdx + 100);
-  const fnBlock =
-    fnEnd > -1 ? src.slice(fnIdx, fnEnd) : src.slice(fnIdx, fnIdx + 5000);
+  const fnBlock = extractSourceRegion(src, "export async function startAuto", "\n// ─── ");
   assert.ok(
     fnBlock.includes("runAutoLoopWithUok("),
     "startAuto must dispatch through runAutoLoopWithUok()",
@@ -1562,9 +1561,7 @@ test("startAuto calls selfHealRuntimeRecords before autoLoop (#1727)", { skip: "
   );
   const fnIdx = src.indexOf("export async function startAuto");
   assert.ok(fnIdx > -1, "startAuto must exist in auto.ts");
-  const fnEnd = src.indexOf("\n// ─── ", fnIdx + 100);
-  const fnBlock =
-    fnEnd > -1 ? src.slice(fnIdx, fnEnd) : src.slice(fnIdx, fnIdx + 5000);
+  const fnBlock = extractSourceRegion(src, "export async function startAuto", "\n// ─── ");
 
   // Both autoLoop call sites must be preceded by selfHealRuntimeRecords
   const healIdx = fnBlock.indexOf("selfHealRuntimeRecords");
@@ -1589,7 +1586,7 @@ test("startAuto guards against concurrent invocation (#2923)", () => {
   const fnIdx = src.indexOf("export async function startAuto");
   assert.ok(fnIdx > -1, "startAuto must exist in auto.ts");
   // The guard must appear before any other logic in the function body
-  const fnBody = src.slice(fnIdx, fnIdx + 500);
+  const fnBody = extractSourceRegion(src, "export async function startAuto");
   const activeGuard = fnBody.indexOf("if (s.active)");
   assert.ok(activeGuard > -1, "startAuto must check s.active to prevent concurrent auto-loops");
   const returnIdx = fnBody.indexOf("return;", activeGuard);

--- a/src/resources/extensions/gsd/tests/auto-remediate-slice-status.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-remediate-slice-status.test.ts
@@ -44,7 +44,9 @@ describe('auto-remediate stale slice status (#3673)', () => {
     assert.match(before, /try\s*\{/,
       'updateSliceStatus should be inside a try block');
 
-    const after = extractSourceRegion(source, 'updateSliceStatus(mid, sid');
+    // Bound the region to stop before the rogue fallback so /catch/ only
+    // matches this try block's catch, not an unrelated later one.
+    const after = extractSourceRegion(source, 'updateSliceStatus(mid, sid', 'rogues.push({');
     assert.match(after, /catch/,
       'try block should have a catch for fallback');
   });

--- a/src/resources/extensions/gsd/tests/auto-remediate-slice-status.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-remediate-slice-status.test.ts
@@ -15,6 +15,7 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
+import { extractSourceRegion } from "./test-helpers.ts";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -43,7 +44,7 @@ describe('auto-remediate stale slice status (#3673)', () => {
     assert.match(before, /try\s*\{/,
       'updateSliceStatus should be inside a try block');
 
-    const after = source.slice(updateIdx, updateIdx + 300);
+    const after = extractSourceRegion(source, 'updateSliceStatus(mid, sid');
     assert.match(after, /catch/,
       'try block should have a catch for fallback');
   });

--- a/src/resources/extensions/gsd/tests/auto-retry-mcp-churn-fixes.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-retry-mcp-churn-fixes.test.ts
@@ -108,7 +108,9 @@ describe("register-hooks: skip prepareWorkflowMcpForProject inside auto-worktree
   it("session_start hook is gated on isInAutoWorktree", () => {
     const idx = src.indexOf('pi.on("session_start"');
     assert.ok(idx !== -1, "session_start handler must exist");
-    const block = extractSourceRegion(src, 'pi.on("session_start"');
+    // Bound the extraction at the next pi.on(...) so adjacent handlers
+    // can't bleed into this handler's assertions.
+    const block = extractSourceRegion(src, 'pi.on("session_start"', 'pi.on("session_switch"');
     assert.ok(
       block.includes("isInAutoWorktree"),
       "session_start must consult isInAutoWorktree before preparing MCP",
@@ -122,7 +124,7 @@ describe("register-hooks: skip prepareWorkflowMcpForProject inside auto-worktree
   it("session_switch hook is gated on isInAutoWorktree", () => {
     const idx = src.indexOf('pi.on("session_switch"');
     assert.ok(idx !== -1, "session_switch handler must exist");
-    const block = extractSourceRegion(src, 'pi.on("session_switch"');
+    const block = extractSourceRegion(src, 'pi.on("session_switch"', 'pi.on("tool_call"');
     assert.ok(
       block.includes("isInAutoWorktree"),
       "session_switch must consult isInAutoWorktree before preparing MCP",

--- a/src/resources/extensions/gsd/tests/auto-retry-mcp-churn-fixes.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-retry-mcp-churn-fixes.test.ts
@@ -16,6 +16,7 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 
+import { extractSourceRegion } from "./test-helpers.ts";
 import {
   resetEvidence,
   getEvidence,
@@ -107,7 +108,7 @@ describe("register-hooks: skip prepareWorkflowMcpForProject inside auto-worktree
   it("session_start hook is gated on isInAutoWorktree", () => {
     const idx = src.indexOf('pi.on("session_start"');
     assert.ok(idx !== -1, "session_start handler must exist");
-    const block = src.slice(idx, idx + 2500);
+    const block = extractSourceRegion(src, 'pi.on("session_start"');
     assert.ok(
       block.includes("isInAutoWorktree"),
       "session_start must consult isInAutoWorktree before preparing MCP",
@@ -121,7 +122,7 @@ describe("register-hooks: skip prepareWorkflowMcpForProject inside auto-worktree
   it("session_switch hook is gated on isInAutoWorktree", () => {
     const idx = src.indexOf('pi.on("session_switch"');
     assert.ok(idx !== -1, "session_switch handler must exist");
-    const block = src.slice(idx, idx + 2500);
+    const block = extractSourceRegion(src, 'pi.on("session_switch"');
     assert.ok(
       block.includes("isInAutoWorktree"),
       "session_switch must consult isInAutoWorktree before preparing MCP",
@@ -192,7 +193,7 @@ describe("mcp-server workflow-tools: projectDir routing (Phase B root cause)", (
   it("projectDirParam is optional and documents the default", () => {
     const idx = src.indexOf("const projectDirParam");
     assert.ok(idx !== -1, "projectDirParam definition must exist");
-    const block = src.slice(idx, idx + 600);
+    const block = extractSourceRegion(src, "const projectDirParam");
     assert.ok(
       block.includes(".optional()"),
       "projectDirParam must be optional so the agent stops deliberating",
@@ -206,7 +207,7 @@ describe("mcp-server workflow-tools: projectDir routing (Phase B root cause)", (
   it("parseWorkflowArgs defaults projectDir to process.cwd() when omitted", () => {
     const idx = src.indexOf("function parseWorkflowArgs");
     assert.ok(idx !== -1, "parseWorkflowArgs must exist");
-    const block = src.slice(idx, idx + 1500);
+    const block = extractSourceRegion(src, "function parseWorkflowArgs");
     assert.ok(
       block.includes("parsed.projectDir ?? process.cwd()"),
       "parseWorkflowArgs must fall back to process.cwd() when projectDir is omitted",
@@ -216,7 +217,7 @@ describe("mcp-server workflow-tools: projectDir routing (Phase B root cause)", (
   it("validateProjectDir accepts external-state worktree paths via .gsd symlink target", () => {
     const idx = src.indexOf("function validateProjectDir");
     assert.ok(idx !== -1, "validateProjectDir must exist");
-    const block = src.slice(idx, idx + 2500);
+    const block = extractSourceRegion(src, "function validateProjectDir");
     assert.ok(
       block.includes("resolveExternalStateRoot"),
       "validateProjectDir must consult resolveExternalStateRoot for external-state layouts",
@@ -224,7 +225,7 @@ describe("mcp-server workflow-tools: projectDir routing (Phase B root cause)", (
 
     const helperIdx = src.indexOf("function resolveExternalStateRoot");
     assert.ok(helperIdx !== -1, "resolveExternalStateRoot helper must exist");
-    const helperBlock = src.slice(helperIdx, helperIdx + 600);
+    const helperBlock = extractSourceRegion(src, "function resolveExternalStateRoot");
     assert.ok(
       helperBlock.includes("realpathSync"),
       "resolveExternalStateRoot must use realpathSync to follow the symlink",
@@ -240,7 +241,7 @@ describe("mcp-server workflow-tools: projectDir routing (Phase B root cause)", (
     // milestone that has an auto-worktree at <projectRoot>/.gsd/worktrees/<MID>/,
     // tool writes must go to the worktree .gsd rather than the shared project .gsd.
     const parseIdx = src.indexOf("function parseWorkflowArgs");
-    const parseBlock = src.slice(parseIdx, parseIdx + 2500);
+    const parseBlock = extractSourceRegion(src, "function parseWorkflowArgs");
     assert.ok(
       parseBlock.includes("resolveActiveWorktreeBasePath"),
       "parseWorkflowArgs must consult resolveActiveWorktreeBasePath",
@@ -254,7 +255,7 @@ describe("mcp-server workflow-tools: projectDir routing (Phase B root cause)", (
   it("resolveActiveWorktreeBasePath checks .git presence to avoid hijacking stray directories", () => {
     const idx = src.indexOf("function resolveActiveWorktreeBasePath");
     assert.ok(idx !== -1, "resolveActiveWorktreeBasePath helper must exist");
-    const block = src.slice(idx, idx + 1200);
+    const block = extractSourceRegion(src, "function resolveActiveWorktreeBasePath");
     assert.ok(
       block.includes('existsSync(join(wtPath, ".git"))'),
       "resolveActiveWorktreeBasePath must verify a .git file exists in the worktree",
@@ -264,7 +265,7 @@ describe("mcp-server workflow-tools: projectDir routing (Phase B root cause)", (
   it("extractMilestoneId handles camelCase, snake_case, and short aliases", () => {
     const idx = src.indexOf("function extractMilestoneId");
     assert.ok(idx !== -1, "extractMilestoneId helper must exist");
-    const block = src.slice(idx, idx + 600);
+    const block = extractSourceRegion(src, "function extractMilestoneId");
     assert.ok(block.includes("milestoneId"), "must check milestoneId");
     assert.ok(block.includes("milestone_id"), "must check milestone_id");
     assert.ok(block.includes("mid"), "must check mid");

--- a/src/resources/extensions/gsd/tests/auto-start-clean-runtime-db-gated.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-start-clean-runtime-db-gated.test.ts
@@ -10,6 +10,7 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
+import { extractSourceRegion } from "./test-helpers.ts";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const sourceFile = join(__dirname, "..", "auto-start.ts");
@@ -37,7 +38,7 @@ describe("auto-start cleanStaleRuntimeUnits DB gating (#4663)", () => {
   test("cleanStaleRuntimeUnits predicate consults DB status when available", () => {
     const cleanIdx = source.indexOf("cleanStaleRuntimeUnits(");
     assert.ok(cleanIdx > -1);
-    const snippet = source.slice(cleanIdx, cleanIdx + 600);
+    const snippet = extractSourceRegion(source, "cleanStaleRuntimeUnits(");
     assert.match(
       snippet,
       /isDbAvailable\(\)/,
@@ -53,7 +54,7 @@ describe("auto-start cleanStaleRuntimeUnits DB gating (#4663)", () => {
   test("cleanStaleRuntimeUnits predicate still falls back to SUMMARY-file when DB unavailable", () => {
     const cleanIdx = source.indexOf("cleanStaleRuntimeUnits(");
     assert.ok(cleanIdx > -1);
-    const snippet = source.slice(cleanIdx, cleanIdx + 600);
+    const snippet = extractSourceRegion(source, "cleanStaleRuntimeUnits(");
     assert.match(
       snippet,
       /resolveMilestoneFile\(base,\s*mid,\s*["']SUMMARY["']\)/,

--- a/src/resources/extensions/gsd/tests/auto-start-cold-db-bootstrap.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-start-cold-db-bootstrap.test.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
-import { createTestContext } from "./test-helpers.ts";
+import {createTestContext, extractSourceRegion } from "./test-helpers.ts";
 
 const { assertTrue, report } = createTestContext();
 
@@ -13,7 +13,7 @@ console.log("\n=== #2841: cold DB opened before initial deriveState ===");
 const helperIdx = src.indexOf("async function openProjectDbIfPresent");
 assertTrue(helperIdx >= 0, "auto-start.ts defines a helper for pre-derive DB open (#2841)");
 
-const helperRegion = helperIdx >= 0 ? src.slice(helperIdx, helperIdx + 500) : "";
+const helperRegion = helperIdx >= 0 ? extractSourceRegion(src, "async function openProjectDbIfPresent") : "";
 assertTrue(
   helperRegion.includes("resolveProjectRootDbPath(basePath)"),
   "pre-derive DB helper resolves the project-root DB path (#2841)",

--- a/src/resources/extensions/gsd/tests/auto-start-model-capture.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-start-model-capture.test.ts
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
+import { extractSourceRegion } from "./test-helpers.ts";
 
 const sourcePath = join(import.meta.dirname, "..", "auto-start.ts");
 const source = readFileSync(sourcePath, "utf-8");
@@ -53,7 +54,7 @@ test("bootstrapAutoSession checks manual session override before preferences", (
   );
 
   // Preferred model should still be part of fallback resolution.
-  const snapshotBlock = source.slice(snapshotIdx, snapshotIdx + 400);
+  const snapshotBlock = extractSourceRegion(source, "const startModelSnapshot = manualSessionOverride");
   assert.ok(
     snapshotBlock.includes("validatedPreferredModel") || snapshotBlock.includes("preferredModel"),
     "startModelSnapshot must still consider preferredModel for built-in providers",
@@ -64,7 +65,7 @@ test("bootstrapAutoSession prioritizes current session model over PREFERENCES.md
   const snapshotIdx = source.indexOf("const startModelSnapshot = manualSessionOverride");
   assert.ok(snapshotIdx > -1, "auto-start.ts should build startModelSnapshot");
 
-  const snapshotBlock = source.slice(snapshotIdx, snapshotIdx + 500);
+  const snapshotBlock = extractSourceRegion(source, "const startModelSnapshot = manualSessionOverride");
   const currentIdx = snapshotBlock.indexOf("currentSessionModel");
   const preferredIdx = snapshotBlock.indexOf("validatedPreferredModel");
 
@@ -97,7 +98,7 @@ test("bootstrapAutoSession prefers session model over PREFERENCES.md when provid
   const preferredIdx = source.indexOf("const preferredModel = ");
   assert.ok(preferredIdx > -1, "auto-start.ts should build preferredModel");
 
-  const preferredBlock = source.slice(preferredIdx, preferredIdx + 200);
+  const preferredBlock = extractSourceRegion(source, "const preferredModel = ");
   assert.ok(
     preferredBlock.includes("sessionProviderIsCustom"),
     "preferredModel must be gated on sessionProviderIsCustom so PREFERENCES.md is skipped for custom providers",

--- a/src/resources/extensions/gsd/tests/auto-start-worktree-db-path.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-start-worktree-db-path.test.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
-import { createTestContext } from "./test-helpers.ts";
+import {createTestContext, extractSourceRegion } from "./test-helpers.ts";
 
 const { assertTrue, report } = createTestContext();
 
@@ -13,7 +13,7 @@ console.log("\n=== #3822: worktree bootstrap uses project DB path ===");
 const dbLifecycleIdx = src.indexOf("// ── DB lifecycle ──");
 assertTrue(dbLifecycleIdx > 0, "auto-start.ts has a DB lifecycle section");
 
-const dbLifecycleRegion = dbLifecycleIdx > 0 ? src.slice(dbLifecycleIdx, dbLifecycleIdx + 600) : "";
+const dbLifecycleRegion = dbLifecycleIdx > 0 ? extractSourceRegion(src, "// ── DB lifecycle ──") : "";
 
 assertTrue(
   dbLifecycleRegion.includes("const gsdDbPath = resolveProjectRootDbPath(s.basePath);"),

--- a/src/resources/extensions/gsd/tests/auto-thinking-restore.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-thinking-restore.test.ts
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
+import { extractSourceRegion } from "./test-helpers.ts";
 
 const autoSrc = readFileSync(join(import.meta.dirname, "..", "auto.ts"), "utf-8");
 const phasesSrc = readFileSync(join(import.meta.dirname, "..", "auto", "phases.ts"), "utf-8");
@@ -20,7 +21,7 @@ test("stopAuto restores original thinking level", () => {
 test("runUnitPhase threads captured thinking level into selectAndApplyModel", () => {
   const callIdx = phasesSrc.indexOf("deps.selectAndApplyModel(");
   assert.ok(callIdx > -1, "phases.ts should call selectAndApplyModel");
-  const callBlock = phasesSrc.slice(callIdx, callIdx + 600);
+  const callBlock = extractSourceRegion(phasesSrc, "deps.selectAndApplyModel(");
   assert.ok(
     callBlock.includes("s.autoModeStartThinkingLevel"),
     "runUnitPhase should pass autoModeStartThinkingLevel to selectAndApplyModel",
@@ -30,7 +31,7 @@ test("runUnitPhase threads captured thinking level into selectAndApplyModel", ()
 test("hook model override preserves captured thinking level", () => {
   const hookIdx = phasesSrc.indexOf("const hookModelOverride = sidecarItem?.model ?? iterData.hookModelOverride;");
   assert.ok(hookIdx > -1, "phases.ts should include hook model override handling");
-  const hookBlock = phasesSrc.slice(hookIdx, hookIdx + 600);
+  const hookBlock = extractSourceRegion(phasesSrc, "const hookModelOverride = sidecarItem?.model ?? iterData.hookModelOverride;");
   assert.ok(
     hookBlock.includes("pi.setThinkingLevel(s.autoModeStartThinkingLevel)"),
     "hook model override should re-apply captured thinking level after setModel",

--- a/src/resources/extensions/gsd/tests/auto-warning-noise-regression.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-warning-noise-regression.test.ts
@@ -70,7 +70,7 @@ test("isSamePath short-circuits ENOENT before logging a warning", () => {
   assert.ok(fnIdx !== -1, "isSamePath function exists");
 
   // Grab the function body (enough to cover the catch block).
-  const fnBody = extractSourceRegion(src, "function isSamePath");
+  const fnBody = extractSourceRegion(src, "function isSamePath", { fromIdx: fnIdx });
 
   const catchIdx = fnBody.indexOf("catch");
   assert.ok(catchIdx !== -1, "isSamePath has a catch block");
@@ -104,7 +104,7 @@ test("checkAutoStartAfterDiscuss guards DISCUSSION-MANIFEST.json unlink with exi
 
   // Everything from the comment to a short distance below should contain
   // the existsSync guard before the unlinkSync call.
-  const block = extractSourceRegion(src, "remove discussion manifest after auto-start");
+  const block = extractSourceRegion(src, "remove discussion manifest after auto-start", { fromIdx: cleanupIdx });
 
   const existsIdx = block.indexOf("existsSync(manifestPath)");
   const unlinkIdx = block.indexOf("unlinkSync(manifestPath)");

--- a/src/resources/extensions/gsd/tests/auto-warning-noise-regression.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-warning-noise-regression.test.ts
@@ -27,6 +27,7 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
 import { buildFlatRateContext } from "../auto-model-selection.ts";
+import { extractSourceRegion } from "./test-helpers.ts";
 
 // ─── Bug 2: this-binding regression ─────────────────────────────────────
 
@@ -69,7 +70,7 @@ test("isSamePath short-circuits ENOENT before logging a warning", () => {
   assert.ok(fnIdx !== -1, "isSamePath function exists");
 
   // Grab the function body (enough to cover the catch block).
-  const fnBody = src.slice(fnIdx, fnIdx + 600);
+  const fnBody = extractSourceRegion(src, "function isSamePath");
 
   const catchIdx = fnBody.indexOf("catch");
   assert.ok(catchIdx !== -1, "isSamePath has a catch block");
@@ -103,7 +104,7 @@ test("checkAutoStartAfterDiscuss guards DISCUSSION-MANIFEST.json unlink with exi
 
   // Everything from the comment to a short distance below should contain
   // the existsSync guard before the unlinkSync call.
-  const block = src.slice(cleanupIdx, cleanupIdx + 400);
+  const block = extractSourceRegion(src, "remove discussion manifest after auto-start");
 
   const existsIdx = block.indexOf("existsSync(manifestPath)");
   const unlinkIdx = block.indexOf("unlinkSync(manifestPath)");

--- a/src/resources/extensions/gsd/tests/bootstrap-derive-state-db-open.test.ts
+++ b/src/resources/extensions/gsd/tests/bootstrap-derive-state-db-open.test.ts
@@ -2,6 +2,7 @@ import { describe, test } from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
+import { extractSourceRegion } from "./test-helpers.ts";
 
 const systemContextSrc = readFileSync(
   join(import.meta.dirname, "..", "bootstrap", "system-context.ts"),
@@ -29,7 +30,7 @@ describe("bootstrap deriveState DB guards (#3844)", () => {
   test("register-hooks opens DB before deriveState in session_before_compact", () => {
     const compactIdx = registerHooksSrc.indexOf('pi.on("session_before_compact"');
     assert.ok(compactIdx > -1, "register-hooks should define session_before_compact");
-    const compactSection = registerHooksSrc.slice(compactIdx, compactIdx + 1600);
+    const compactSection = extractSourceRegion(registerHooksSrc, 'pi.on("session_before_compact"');
     const ensureIdx = compactSection.indexOf("ensureDbOpen()");
     const deriveIdx = compactSection.indexOf("deriveState(basePath)");
     assert.ok(ensureIdx > -1, "session_before_compact should call ensureDbOpen()");

--- a/src/resources/extensions/gsd/tests/complete-slice-verification-gate.test.ts
+++ b/src/resources/extensions/gsd/tests/complete-slice-verification-gate.test.ts
@@ -11,6 +11,7 @@ import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
 import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
+import { extractSourceRegion } from "./test-helpers.ts";
 
 const src = readFileSync(
   resolve(process.cwd(), 'src', 'resources', 'extensions', 'gsd', 'tools', 'complete-slice.ts'),
@@ -59,7 +60,7 @@ describe('complete-slice verification gate (#3580)', () => {
     const gateIdx = src.indexOf('BLOCKED_SIGNALS.test(')
     assert.ok(gateIdx !== -1)
 
-    const afterGate = src.slice(gateIdx, gateIdx + 500)
+    const afterGate = extractSourceRegion(src, 'BLOCKED_SIGNALS.test(')
     assert.ok(
       afterGate.includes('return { error:'),
       'blocked signal detection must return an error',

--- a/src/resources/extensions/gsd/tests/copy-planning-artifacts-samepath.test.ts
+++ b/src/resources/extensions/gsd/tests/copy-planning-artifacts-samepath.test.ts
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
+import { extractSourceRegion } from "./test-helpers.ts";
 
 test("copyPlanningArtifacts skips when source and destination .gsd resolve to the same path", () => {
   const srcPath = join(import.meta.dirname, "..", "auto-worktree.ts");
@@ -10,7 +11,7 @@ test("copyPlanningArtifacts skips when source and destination .gsd resolve to th
   const fnIdx = src.indexOf("function copyPlanningArtifacts");
   assert.ok(fnIdx !== -1, "copyPlanningArtifacts function exists");
 
-  const fnBody = src.slice(fnIdx, fnIdx + 2400);
+  const fnBody = extractSourceRegion(src, "function copyPlanningArtifacts");
 
   const guardIdx = fnBody.indexOf("if (isSamePath(srcGsd, dstGsd)) return;");
   const copyIdx = fnBody.indexOf("safeCopyRecursive(join(srcGsd, \"milestones\")");

--- a/src/resources/extensions/gsd/tests/discuss-slice-structured-questions.test.ts
+++ b/src/resources/extensions/gsd/tests/discuss-slice-structured-questions.test.ts
@@ -11,6 +11,7 @@ import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
 import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
+import { extractSourceRegion } from "./test-helpers.ts";
 
 const template = readFileSync(
   resolve(process.cwd(), 'src', 'resources', 'extensions', 'gsd', 'prompts', 'guided-discuss-slice.md'),
@@ -37,7 +38,7 @@ describe('discuss-slice structuredQuestionsAvailable template variable', () => {
     const falseIdx = template.indexOf('`{{structuredQuestionsAvailable}}` is `false`')
     assert.ok(falseIdx !== -1)
 
-    const afterFalse = template.slice(falseIdx, falseIdx + 300)
+    const afterFalse = extractSourceRegion(template, '`{{structuredQuestionsAvailable}}` is `false`')
     assert.ok(
       afterFalse.includes('plain text'),
       'when structuredQuestionsAvailable is false, questions should be in plain text',

--- a/src/resources/extensions/gsd/tests/discuss-tool-scope-leak.test.ts
+++ b/src/resources/extensions/gsd/tests/discuss-tool-scope-leak.test.ts
@@ -22,6 +22,7 @@ import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { DISCUSS_TOOLS_ALLOWLIST } from "../constants.ts";
+import { extractSourceRegion } from "./test-helpers.ts";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const guidedFlowSource = readFileSync(join(__dirname, "..", "guided-flow.ts"), "utf-8");
@@ -58,7 +59,7 @@ describe("#3616 — discuss tool scoping must not leak across sessions", () => {
 		);
 		const newSessionStart = agentSessionSource.indexOf("async newSession(options?:");
 		assert.ok(newSessionStart >= 0, "should find newSession");
-		const body = agentSessionSource.slice(newSessionStart, newSessionStart + 3000);
+		const body = extractSourceRegion(agentSessionSource, "async newSession(options?:");
 
 		// Both branches (cwd-changed and cwd-unchanged) must include extension tools
 		assert.ok(

--- a/src/resources/extensions/gsd/tests/double-merge-guard.test.ts
+++ b/src/resources/extensions/gsd/tests/double-merge-guard.test.ts
@@ -4,6 +4,7 @@ import { readFileSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { AutoSession } from "../auto/session.ts";
+import { extractSourceRegion } from "./test-helpers.ts";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -20,7 +21,7 @@ describe("double mergeAndExit guard (#2645)", () => {
     const completeIdx = phasesSrc.indexOf('state.phase === "complete"');
     assert.ok(completeIdx > 0, "phases.ts should have a 'complete' phase check");
 
-    const afterComplete = phasesSrc.slice(completeIdx, completeIdx + 600);
+    const afterComplete = extractSourceRegion(phasesSrc, 'state.phase === "complete"');
     const mergeIdx = afterComplete.indexOf("deps.resolver.mergeAndExit");
     const flagIdx = afterComplete.indexOf("s.milestoneMergedInPhases = true");
 
@@ -42,7 +43,7 @@ describe("double mergeAndExit guard (#2645)", () => {
     const allCompleteIdx = phasesSrc.indexOf("incomplete.length === 0");
     assert.ok(allCompleteIdx > 0, "phases.ts should have an all-milestones-complete check");
 
-    const afterAllComplete = phasesSrc.slice(allCompleteIdx, allCompleteIdx + 800);
+    const afterAllComplete = extractSourceRegion(phasesSrc, "incomplete.length === 0");
     const mergeIdx = afterAllComplete.indexOf("deps.resolver.mergeAndExit");
     const flagIdx = afterAllComplete.indexOf("s.milestoneMergedInPhases = true");
 
@@ -64,7 +65,7 @@ describe("double mergeAndExit guard (#2645)", () => {
     const step4Idx = autoSrc.indexOf("Step 4: Auto-worktree exit");
     assert.ok(step4Idx > 0, "auto.ts should have Step 4 worktree exit");
 
-    const step4Block = autoSrc.slice(step4Idx, step4Idx + 600);
+    const step4Block = extractSourceRegion(autoSrc, "Step 4: Auto-worktree exit");
     assert.ok(
       step4Block.includes("milestoneMergedInPhases"),
       "stopAuto Step 4 must check milestoneMergedInPhases before merging",

--- a/src/resources/extensions/gsd/tests/empty-content-abort-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/empty-content-abort-loop.test.ts
@@ -31,7 +31,7 @@ test("agent-end-recovery.ts does not pause on aborted messages with empty conten
   assert.ok(abortIdx > -1, "abort handler must exist in agent-end-recovery.ts");
 
   // Extract the region around the abort handler (enough to see the guard logic)
-  const abortRegion = source.slice(Math.max(0, abortIdx - 200), abortIdx + 600);
+  const abortRegion = extractSourceRegion(source, 'stopReason === "aborted"', { fromIdx: abortIdx });
 
   // Must check for empty content before pausing
   assert.ok(

--- a/src/resources/extensions/gsd/tests/empty-content-abort-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/empty-content-abort-loop.test.ts
@@ -13,6 +13,7 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
+import { extractSourceRegion } from "./test-helpers.ts";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const RECOVERY_PATH = join(__dirname, "..", "bootstrap", "agent-end-recovery.ts");
@@ -48,7 +49,7 @@ test("agent-end-recovery.ts routes empty-content aborted messages to resolveAgen
   assert.ok(abortIdx > -1, "abort handler must exist");
 
   // Get the full abort handling block (from the if to the next stopReason check or success path)
-  const afterAbort = source.slice(abortIdx, abortIdx + 800);
+  const afterAbort = extractSourceRegion(source, 'stopReason === "aborted"');
 
   // The abort block must have a code path that calls resolveAgentEnd (for empty-content case)
   assert.ok(
@@ -63,7 +64,7 @@ test("agent-end-recovery.ts checks for errorMessage presence in abort handler (#
   const abortIdx = source.indexOf('stopReason === "aborted"');
   assert.ok(abortIdx > -1, "abort handler must exist");
 
-  const abortRegion = source.slice(abortIdx, abortIdx + 600);
+  const abortRegion = extractSourceRegion(source, 'stopReason === "aborted"');
 
   // Fatal aborts should have error context (errorMessage field).
   // The handler should check for this to distinguish fatal from non-fatal aborts.

--- a/src/resources/extensions/gsd/tests/finalize-timeout-guard.test.ts
+++ b/src/resources/extensions/gsd/tests/finalize-timeout-guard.test.ts
@@ -16,7 +16,7 @@
  * isolated unit testing.
  */
 
-import { createTestContext } from "./test-helpers.ts";
+import {createTestContext, extractSourceRegion } from "./test-helpers.ts";
 import {
   withTimeout,
   FINALIZE_PRE_TIMEOUT_MS,
@@ -163,7 +163,7 @@ function getRunFinalizeBody(phasesSource: string): string {
   assertTrue(preVerIdx > 0, "postUnitPreVerification should appear in runFinalize");
 
   // The first withTimeout should wrap postUnitPreVerification (not postUnitPostVerification)
-  const firstWithTimeout = fnBody.slice(preTimeoutIdx, preTimeoutIdx + 200);
+  const firstWithTimeout = extractSourceRegion(fnBody, "withTimeout(");
   assertTrue(
     firstWithTimeout.includes("postUnitPreVerification"),
     "first withTimeout in runFinalize should wrap postUnitPreVerification",

--- a/src/resources/extensions/gsd/tests/forensics-hook-key-parse.test.ts
+++ b/src/resources/extensions/gsd/tests/forensics-hook-key-parse.test.ts
@@ -14,6 +14,7 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
+import { extractSourceRegion } from "./test-helpers.ts";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const gsdDir = join(__dirname, "..");
@@ -43,7 +44,7 @@ describe("forensics hook compound key parsing (#2826)", () => {
   it("detectMissingArtifacts delegates to splitCompletedKey", () => {
     const fnStart = forensicsSrc.indexOf("function detectMissingArtifacts(");
     assert.ok(fnStart !== -1, "detectMissingArtifacts must exist in forensics.ts");
-    const fnBody = forensicsSrc.slice(fnStart, fnStart + 1000);
+    const fnBody = extractSourceRegion(forensicsSrc, "function detectMissingArtifacts(");
     assert.ok(
       fnBody.includes("splitCompletedKey("),
       "detectMissingArtifacts must call splitCompletedKey() rather than inline the split logic",

--- a/src/resources/extensions/gsd/tests/idle-watchdog-stall-override.test.ts
+++ b/src/resources/extensions/gsd/tests/idle-watchdog-stall-override.test.ts
@@ -98,7 +98,11 @@ describe("#2527 Bug 2: null guard after async recovery prevents crash", () => {
 
     // The null guard must appear between the recovery call and the next
     // writeUnitRuntimeRecord that accesses s.currentUnit.startedAt
-    const afterRecovery = extractSourceRegion(TIMERS_SRC, 'recoverTimedOutUnit(ctx, pi, unitType, unitId, "idle"');
+    const afterRecovery = extractSourceRegion(
+      TIMERS_SRC,
+      'recoverTimedOutUnit(ctx, pi, unitType, unitId, "idle"',
+      { fromIdx: idleRecovery },
+    );
     assert.ok(
       afterRecovery.includes("if (!s.currentUnit) return"),
       "null guard for s.currentUnit must exist after idle recoverTimedOutUnit",

--- a/src/resources/extensions/gsd/tests/idle-watchdog-stall-override.test.ts
+++ b/src/resources/extensions/gsd/tests/idle-watchdog-stall-override.test.ts
@@ -18,6 +18,7 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { test, describe } from "node:test";
 import assert from "node:assert/strict";
+import { extractSourceRegion } from "./test-helpers.ts";
 
 const TIMERS_SRC = readFileSync(
   join(import.meta.dirname, "..", "auto-timers.ts"),
@@ -97,7 +98,7 @@ describe("#2527 Bug 2: null guard after async recovery prevents crash", () => {
 
     // The null guard must appear between the recovery call and the next
     // writeUnitRuntimeRecord that accesses s.currentUnit.startedAt
-    const afterRecovery = TIMERS_SRC.slice(idleRecovery, idleRecovery + 400);
+    const afterRecovery = extractSourceRegion(TIMERS_SRC, 'recoverTimedOutUnit(ctx, pi, unitType, unitId, "idle"');
     assert.ok(
       afterRecovery.includes("if (!s.currentUnit) return"),
       "null guard for s.currentUnit must exist after idle recoverTimedOutUnit",

--- a/src/resources/extensions/gsd/tests/import-done-milestones.test.ts
+++ b/src/resources/extensions/gsd/tests/import-done-milestones.test.ts
@@ -10,6 +10,7 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
+import { extractSourceRegion } from "./test-helpers.ts";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -30,7 +31,7 @@ describe('import done milestones as complete (#3699)', () => {
     // Find the all-done guard and verify it sets 'complete'
     const everyIdx = importerSrc.indexOf('roadmap.slices.every(s => s.done)');
     assert.ok(everyIdx > -1, 'all-slices-done check should exist');
-    const afterCheck = importerSrc.slice(everyIdx, everyIdx + 200);
+    const afterCheck = extractSourceRegion(importerSrc, 'roadmap.slices.every(s => s.done)');
     assert.match(afterCheck, /milestoneStatus\s*=\s*'complete'/,
       'should set milestoneStatus to complete when all slices are done');
   });

--- a/src/resources/extensions/gsd/tests/integration/all-milestones-complete-merge.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/all-milestones-complete-merge.test.ts
@@ -12,8 +12,8 @@
 
 import test from "node:test";
 import assert from "node:assert/strict";
+import { extractSourceRegion } from "../test-helpers.ts";
 import {
-import { extractSourceRegion } from "./test-helpers.ts";
   mkdtempSync,
   mkdirSync,
   rmSync,

--- a/src/resources/extensions/gsd/tests/integration/all-milestones-complete-merge.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/all-milestones-complete-merge.test.ts
@@ -13,6 +13,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import {
+import { extractSourceRegion } from "./test-helpers.ts";
   mkdtempSync,
   mkdirSync,
   rmSync,
@@ -115,7 +116,7 @@ test("auto-loop 'all milestones complete' path merges before stopping (#962)", (
     helperIdx > -1,
     "WorktreeResolver.mergeAndExit helper should exist",
   );
-  const helperBlock = resolverSrc.slice(helperIdx, helperIdx + 2600);
+  const helperBlock = extractSourceRegion(resolverSrc, "mergeAndExit(milestoneId");
   assert.ok(
     helperBlock.includes('mode === "worktree"') ||
       helperBlock.includes('mode: "worktree"'),

--- a/src/resources/extensions/gsd/tests/interactive-routing-bypass.test.ts
+++ b/src/resources/extensions/gsd/tests/interactive-routing-bypass.test.ts
@@ -8,6 +8,7 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
+import { extractSourceRegion } from "./test-helpers.ts";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -62,7 +63,7 @@ describe("interactive routing bypass (#3962)", () => {
     );
     // The function should check isAutoMode before routing synthesis
     const fnIdx = modelSelectionSrc.indexOf("function resolvePreferredModelConfig");
-    const fnBody = modelSelectionSrc.slice(fnIdx, fnIdx + 900);
+    const fnBody = extractSourceRegion(modelSelectionSrc, "function resolvePreferredModelConfig");
     assert.ok(
       fnBody.includes("isAutoMode"),
       "resolvePreferredModelConfig should accept isAutoMode parameter",
@@ -137,8 +138,13 @@ describe("model downgrade notifications always visible (#3962)", () => {
     const escalatedIdx = modelSelectionSrc.indexOf("if (escalated)");
     assert.ok(escalatedIdx > 0, "escalation block should exist");
 
-    // Get the block from "if (escalated)" to the next closing brace pattern
-    const block = modelSelectionSrc.slice(escalatedIdx, escalatedIdx + 400);
+    // Get the block from "if (escalated)" to the next distinctive marker
+    // (the capability-override loading that immediately follows).
+    const block = extractSourceRegion(
+      modelSelectionSrc,
+      "if (escalated)",
+      "// Load user capability overrides",
+    );
     assert.ok(
       block.includes("Tier escalation:"),
       "escalation block should contain the notification",

--- a/src/resources/extensions/gsd/tests/merge-conflict-stops-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/merge-conflict-stops-loop.test.ts
@@ -10,7 +10,7 @@
 
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { createTestContext } from "./test-helpers.ts";
+import {createTestContext, extractSourceRegion } from "./test-helpers.ts";
 
 const { assertTrue, report } = createTestContext();
 
@@ -58,7 +58,7 @@ const instanceofIdx = phasesSrc.indexOf("instanceof MergeConflictError");
 assertTrue(instanceofIdx > 0, "auto/phases.ts has instanceof MergeConflictError check");
 
 if (instanceofIdx > 0) {
-  const afterHandler = phasesSrc.slice(instanceofIdx, instanceofIdx + 500);
+  const afterHandler = extractSourceRegion(phasesSrc, "instanceof MergeConflictError");
   const stopsLoop =
     afterHandler.includes("stopAuto") ||
     afterHandler.includes('action: "break"') ||

--- a/src/resources/extensions/gsd/tests/native-git-bridge-exec-fallback.test.ts
+++ b/src/resources/extensions/gsd/tests/native-git-bridge-exec-fallback.test.ts
@@ -17,6 +17,7 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { execFileSync } from "node:child_process";
 import { nativeIsRepo, nativeCommit, nativeResetHard } from "../native-git-bridge.js";
+import { extractSourceRegion } from "./test-helpers.ts";
 
 // ─── Static analysis ──────────────────────────────────────────────────────
 // Verify the fallback paths of the three affected functions do not call the
@@ -28,7 +29,7 @@ const SRC_PATH = join(import.meta.dirname, "..", "native-git-bridge.ts");
 function extractFunctionBody(src: string, fnName: string): string {
   const idx = src.indexOf(`export function ${fnName}`);
   if (idx === -1) throw new Error(`${fnName} not found in source`);
-  return src.slice(idx, idx + 1500);
+  return extractSourceRegion(src, `export function ${fnName}`);
 }
 
 function hasRawExecSync(body: string): boolean {

--- a/src/resources/extensions/gsd/tests/parallel-research-dispatch.test.ts
+++ b/src/resources/extensions/gsd/tests/parallel-research-dispatch.test.ts
@@ -12,6 +12,7 @@ import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 
 import { resolveDispatch } from "../auto-dispatch.ts";
+import { extractSourceRegion } from "./test-helpers.ts";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -79,7 +80,7 @@ test("dispatch: parallel-research-slices requires 2+ slices", () => {
 
 test("dispatch: parallel-research-slices respects skip_research", () => {
   const ruleIdx = dispatchSrc.indexOf("parallel-research-slices");
-  const ruleBlock = dispatchSrc.slice(ruleIdx, ruleIdx + 500);
+  const ruleBlock = extractSourceRegion(dispatchSrc, "parallel-research-slices");
   assert.ok(
     ruleBlock.includes("skip_research") || dispatchSrc.slice(ruleIdx - 300, ruleIdx).includes("skip_research"),
     "rule should check skip_research preference",

--- a/src/resources/extensions/gsd/tests/parallel-research-dispatch.test.ts
+++ b/src/resources/extensions/gsd/tests/parallel-research-dispatch.test.ts
@@ -80,7 +80,9 @@ test("dispatch: parallel-research-slices requires 2+ slices", () => {
 
 test("dispatch: parallel-research-slices respects skip_research", () => {
   const ruleIdx = dispatchSrc.indexOf("parallel-research-slices");
-  const ruleBlock = extractSourceRegion(dispatchSrc, "parallel-research-slices");
+  // Pin to the located occurrence — if "parallel-research-slices" appears
+  // more than once in the source, fromIdx keeps the anchor deterministic.
+  const ruleBlock = extractSourceRegion(dispatchSrc, "parallel-research-slices", { fromIdx: ruleIdx });
   assert.ok(
     ruleBlock.includes("skip_research") || dispatchSrc.slice(ruleIdx - 300, ruleIdx).includes("skip_research"),
     "rule should check skip_research preference",

--- a/src/resources/extensions/gsd/tests/preferences-worktree-sync.test.ts
+++ b/src/resources/extensions/gsd/tests/preferences-worktree-sync.test.ts
@@ -12,6 +12,7 @@ import assert from "node:assert/strict";
 import { readFileSync, mkdtempSync, mkdirSync, writeFileSync, existsSync, readdirSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { extractSourceRegion } from "./test-helpers.ts";
 
 test("#2684: preferences files are NOT in ROOT_STATE_FILES (forward-only sync)", () => {
   const srcPath = join(import.meta.dirname, "..", "auto-worktree.ts");
@@ -49,7 +50,7 @@ test("copyPlanningArtifacts prefers canonical PREFERENCES.md with lowercase fall
   assert.ok(fnIdx !== -1, "copyPlanningArtifacts function exists");
 
   // Extract function body (up to the next top-level function)
-  const fnBody = src.slice(fnIdx, fnIdx + 2200);
+  const fnBody = extractSourceRegion(src, "function copyPlanningArtifacts");
 
   assert.ok(
     fnBody.includes("PROJECT_PREFERENCES_FILE") && fnBody.includes("LEGACY_PROJECT_PREFERENCES_FILE"),

--- a/src/resources/extensions/gsd/tests/prompt-step-ordering.test.ts
+++ b/src/resources/extensions/gsd/tests/prompt-step-ordering.test.ts
@@ -70,14 +70,21 @@ describe('register-extension _gsdEpipeGuard (#3696)', () => {
 
 describe('register-hooks session_before_compact (#3696)', () => {
   test('session_before_compact only checks isAutoActive', () => {
-    // Extract the session_before_compact handler
-    const compactIdx = registerHooksSrc.indexOf('session_before_compact');
+    // Anchor on the full registration token rather than the bare event name —
+    // prevents matching unrelated substring occurrences.
+    const compactIdx = registerHooksSrc.indexOf('pi.on("session_before_compact"');
     assert.ok(compactIdx > -1, 'session_before_compact hook should exist');
     // The first check in the handler should be isAutoActive(), not isAutoPaused().
     // Bound the region to this single handler — register-hooks.ts contains
     // multiple pi.on("session_before_compact") handlers and a later handler
     // legitimately references isAutoPaused.
-    const afterCompact = extractSourceRegion(registerHooksSrc, 'session_before_compact', 'pi.on("');
+    const afterCompact = extractSourceRegion(
+      registerHooksSrc,
+      'pi.on("session_before_compact"',
+      'pi.on("',
+      // NB: endAnchor search starts AFTER the startAnchor, so the next
+      // pi.on("... matches the subsequent handler rather than this one.
+    );
     assert.match(afterCompact, /isAutoActive\(\)/,
       'session_before_compact should check isAutoActive()');
     // Should NOT block compaction when paused

--- a/src/resources/extensions/gsd/tests/prompt-step-ordering.test.ts
+++ b/src/resources/extensions/gsd/tests/prompt-step-ordering.test.ts
@@ -13,6 +13,7 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
+import { extractSourceRegion } from "./test-helpers.ts";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -72,8 +73,11 @@ describe('register-hooks session_before_compact (#3696)', () => {
     // Extract the session_before_compact handler
     const compactIdx = registerHooksSrc.indexOf('session_before_compact');
     assert.ok(compactIdx > -1, 'session_before_compact hook should exist');
-    // The first check in the handler should be isAutoActive(), not isAutoPaused()
-    const afterCompact = registerHooksSrc.slice(compactIdx, compactIdx + 300);
+    // The first check in the handler should be isAutoActive(), not isAutoPaused().
+    // Bound the region to this single handler — register-hooks.ts contains
+    // multiple pi.on("session_before_compact") handlers and a later handler
+    // legitimately references isAutoPaused.
+    const afterCompact = extractSourceRegion(registerHooksSrc, 'session_before_compact', 'pi.on("');
     assert.match(afterCompact, /isAutoActive\(\)/,
       'session_before_compact should check isAutoActive()');
     // Should NOT block compaction when paused

--- a/src/resources/extensions/gsd/tests/queue-draft-detection.test.ts
+++ b/src/resources/extensions/gsd/tests/queue-draft-detection.test.ts
@@ -6,6 +6,7 @@ import { tmpdir } from "node:os";
 
 import { deriveState } from "../state.js";
 import { buildExistingMilestonesContext } from "../guided-flow.js";
+import { extractSourceRegion } from "./test-helpers.ts";
 
 describe('queue-draft-detection', () => {
   test('draft and context milestone detection', async () => {
@@ -68,7 +69,7 @@ describe('queue-draft-detection', () => {
 
       // both files: CONTEXT.md wins, no draft label
       const m003Idx = context.indexOf("M003:");
-      const m003Section = context.slice(m003Idx, m003Idx + 500);
+      const m003Section = extractSourceRegion(context, "M003:");
       assert.ok(
         m003Section.includes("**Context:**"),
         "M003 (both files) should use 'Context:' label (CONTEXT.md wins)",
@@ -84,7 +85,7 @@ describe('queue-draft-detection', () => {
 
       // neither file: no context section
       const m004Idx = context.indexOf("M004:");
-      const m004Section = context.slice(m004Idx, m004Idx + 500);
+      const m004Section = extractSourceRegion(context, "M004:");
       assert.ok(
         !m004Section.includes("**Context:**"),
         "M004 (neither file) should not have Context: label",

--- a/src/resources/extensions/gsd/tests/queued-discuss-fast-path.test.ts
+++ b/src/resources/extensions/gsd/tests/queued-discuss-fast-path.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
+import { extractSourceRegion } from "./test-helpers.ts";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -28,7 +29,7 @@ describe("queued-discuss-fast-path", () => {
     const fnStart = source.indexOf("async function dispatchDiscussForMilestone(");
     assert.ok(fnStart > 0, "dispatchDiscussForMilestone must exist");
     const fnEnd = source.indexOf("\nasync function ", fnStart + 1);
-    const fnBody = fnEnd > 0 ? source.slice(fnStart, fnEnd) : source.slice(fnStart, fnStart + 2000);
+    const fnBody = extractSourceRegion(source, "async function dispatchDiscussForMilestone(");
     assert.ok(
       fnBody.includes("fastPathInstruction"),
       "dispatchDiscussForMilestone must compute fastPathInstruction",
@@ -61,8 +62,7 @@ describe("queued-discuss-fast-path", () => {
     const source = guidedFlowSrc();
     const fnStart = source.indexOf("async function showDiscussQueuedMilestone(");
     assert.ok(fnStart > 0, "showDiscussQueuedMilestone must exist");
-    const fnEnd = source.indexOf("\nasync function ", fnStart + 1);
-    const fnBody = fnEnd > 0 ? source.slice(fnStart, fnEnd) : source.slice(fnStart, fnStart + 3000);
+    const fnBody = extractSourceRegion(source, "async function showDiscussQueuedMilestone(", "\nasync function ");
     assert.ok(
       fnBody.includes("hasDraft"),
       "showDiscussQueuedMilestone must check hasDraft",
@@ -81,8 +81,7 @@ describe("queued-discuss-fast-path", () => {
     const source = guidedFlowSrc();
     const fnStart = source.indexOf("async function showDiscussQueuedMilestone(");
     assert.ok(fnStart > 0, "showDiscussQueuedMilestone must exist");
-    const fnEnd = source.indexOf("\nasync function ", fnStart + 1);
-    const fnBody = fnEnd > 0 ? source.slice(fnStart, fnEnd) : source.slice(fnStart, fnStart + 3000);
+    const fnBody = extractSourceRegion(source, "async function showDiscussQueuedMilestone(", "\nasync function ");
     assert.ok(
       fnBody.includes("let fastPath = hasDraft"),
       "showDiscussQueuedMilestone must set fastPath = hasDraft so draft presence auto-enables fast path",

--- a/src/resources/extensions/gsd/tests/restore-tools-after-discuss.test.ts
+++ b/src/resources/extensions/gsd/tests/restore-tools-after-discuss.test.ts
@@ -13,6 +13,7 @@ import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
 import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
+import { extractSourceRegion } from "./test-helpers.ts";
 
 const src = readFileSync(
   resolve(process.cwd(), 'src', 'resources', 'extensions', 'gsd', 'guided-flow.ts'),
@@ -37,7 +38,7 @@ describe('restore tools after discuss flow scoping (#3628)', () => {
     assert.ok(discussCheck !== -1)
 
     // Look for savedTools assignment within the discuss block
-    const blockAfter = src.slice(discussCheck, discussCheck + 500)
+    const blockAfter = extractSourceRegion(src, 'if (unitType?.startsWith("discuss-"))')
     assert.ok(
       blockAfter.includes('savedTools = currentTools'),
       'savedTools must be assigned from currentTools inside the discuss block',
@@ -55,8 +56,10 @@ describe('restore tools after discuss flow scoping (#3628)', () => {
     const sendMsg = src.indexOf('triggerTurn: true', savedToolsAssign)
     assert.ok(sendMsg !== -1, 'discuss-flow sendMessage with triggerTurn must exist after savedTools capture')
 
-    // After sendMessage, savedTools should be restored via setActiveTools
-    const afterSend = src.slice(sendMsg, sendMsg + 500)
+    // After sendMessage, savedTools should be restored via setActiveTools.
+    // Use fromIdx to anchor at the discuss-flow sendMessage, not the first
+    // triggerTurn: true occurrence in the file.
+    const afterSend = extractSourceRegion(src, 'triggerTurn: true', { fromIdx: savedToolsAssign })
     assert.ok(
       afterSend.includes('if (savedTools)'),
       'savedTools restoration guard must exist after sendMessage',

--- a/src/resources/extensions/gsd/tests/sidecar-queue.test.ts
+++ b/src/resources/extensions/gsd/tests/sidecar-queue.test.ts
@@ -11,6 +11,7 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
+import { extractSourceRegion } from "./test-helpers.ts";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const SESSION_TS_PATH = join(__dirname, "..", "auto", "session.ts");
@@ -52,7 +53,7 @@ test("SidecarItem type is exported from session.ts", () => {
 test("SidecarItem has required kind field with hook/triage/quick-task union", () => {
   const source = getSessionTsSource();
   const ifaceIdx = source.indexOf("export interface SidecarItem");
-  const ifaceBlock = source.slice(ifaceIdx, ifaceIdx + 500);
+  const ifaceBlock = extractSourceRegion(source, "export interface SidecarItem");
   assert.ok(
     ifaceBlock.includes('"hook"') && ifaceBlock.includes('"triage"') && ifaceBlock.includes('"quick-task"'),
     "SidecarItem.kind must be a union of 'hook' | 'triage' | 'quick-task'",
@@ -77,7 +78,7 @@ test("AutoSession resets sidecarQueue in reset()", () => {
   const source = getSessionTsSource();
   const resetIdx = source.indexOf("reset(): void");
   assert.ok(resetIdx > -1, "AutoSession must have a reset() method");
-  const resetBlock = source.slice(resetIdx, resetIdx + 3000);
+  const resetBlock = extractSourceRegion(source, "reset(): void");
   assert.ok(
     resetBlock.includes("sidecarQueue"),
     "reset() must clear sidecarQueue",

--- a/src/resources/extensions/gsd/tests/slice-context-injection.test.ts
+++ b/src/resources/extensions/gsd/tests/slice-context-injection.test.ts
@@ -11,6 +11,7 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
+import { extractSourceRegion } from "./test-helpers.ts";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const autoPromptsPath = join(__dirname, "..", "auto-prompts.ts");
@@ -32,7 +33,7 @@ describe("slice CONTEXT.md injection into prompt builders (#3452)", () => {
       assert.ok(fnStart !== -1, `${builder} should exist in auto-prompts.ts`);
 
       // Get a reasonable chunk after the function start
-      const chunk = source.slice(fnStart, fnStart + 3000);
+      const chunk = extractSourceRegion(source, `export async function ${builder}`);
 
       // ADR-011: buildPlanSlicePrompt / buildRefineSlicePrompt now delegate to
       // a shared helper (renderSlicePrompt) that performs the slice CONTEXT
@@ -42,7 +43,7 @@ describe("slice CONTEXT.md injection into prompt builders (#3452)", () => {
         ? (() => {
             const helperStart = source.indexOf("async function renderSlicePrompt");
             assert.ok(helperStart !== -1, "renderSlicePrompt helper must exist");
-            return source.slice(helperStart, helperStart + 3000);
+            return extractSourceRegion(source, "async function renderSlicePrompt");
           })()
         : chunk;
 

--- a/src/resources/extensions/gsd/tests/smart-entry-draft.test.ts
+++ b/src/resources/extensions/gsd/tests/smart-entry-draft.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 
 import { deriveState } from "../state.js";
 import { resolveMilestoneFile } from "../paths.js";
+import { extractSourceRegion } from "./test-helpers.ts";
 
 let passed = 0;
 let failed = 0;
@@ -81,7 +82,7 @@ assert(
 
 // Check the branch has draft-aware menu options
 const branchIdx = guidedFlowSource.indexOf('state.phase === "needs-discussion"');
-const branchChunk = guidedFlowSource.slice(branchIdx, branchIdx + 4000);
+const branchChunk = extractSourceRegion(guidedFlowSource, 'state.phase === "needs-discussion"');
 
 assert(
   branchChunk.includes("discuss_draft"),

--- a/src/resources/extensions/gsd/tests/stop-auto-race-null-unit.test.ts
+++ b/src/resources/extensions/gsd/tests/stop-auto-race-null-unit.test.ts
@@ -13,7 +13,7 @@
 
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { createTestContext } from "./test-helpers.ts";
+import { createTestContext, extractSourceRegion } from "./test-helpers.ts";
 
 const { assertTrue, report } = createTestContext();
 
@@ -35,7 +35,7 @@ assertTrue(
 );
 
 // Extract the region from the closeout comment to the next section comment
-const closeoutRegion = phasesSrc.slice(closeoutIdx, closeoutIdx + 500);
+const closeoutRegion = extractSourceRegion(phasesSrc, closeoutComment);
 assertTrue(
   closeoutRegion.includes("if (s.currentUnit)"),
   "closeoutUnit call is guarded by `if (s.currentUnit)` check (#2939)",
@@ -52,7 +52,7 @@ assertTrue(
   "phases.ts contains the 'Zero tool-call guard' comment block",
 );
 
-const zeroToolRegion = phasesSrc.slice(zeroToolIdx, zeroToolIdx + 600);
+const zeroToolRegion = extractSourceRegion(phasesSrc, zeroToolComment);
 
 // The non-null assertion `s.currentUnit!.startedAt` must be replaced with
 // optional chaining `s.currentUnit?.startedAt`

--- a/src/resources/extensions/gsd/tests/subagent-model-dispatch.test.ts
+++ b/src/resources/extensions/gsd/tests/subagent-model-dispatch.test.ts
@@ -60,7 +60,7 @@ test("reactive_execution: subagent_model rejects empty string", () => {
 test("buildReactiveExecutePrompt: accepts subagentModel parameter", () => {
   const fnStart = promptsSrc.indexOf("export async function buildReactiveExecutePrompt");
   assert.ok(fnStart !== -1, "buildReactiveExecutePrompt should be exported");
-  const signature = extractSourceRegion(promptsSrc, "export async function buildReactiveExecutePrompt");
+  const signature = extractSourceRegion(promptsSrc, "export async function buildReactiveExecutePrompt", { fromIdx: fnStart });
   assert.ok(
     signature.includes("subagentModel"),
     "buildReactiveExecutePrompt should accept a subagentModel parameter",
@@ -70,7 +70,7 @@ test("buildReactiveExecutePrompt: accepts subagentModel parameter", () => {
 test("buildParallelResearchSlicesPrompt: accepts subagentModel parameter", () => {
   const fnStart = promptsSrc.indexOf("export async function buildParallelResearchSlicesPrompt");
   assert.ok(fnStart !== -1, "buildParallelResearchSlicesPrompt should be exported");
-  const signature = extractSourceRegion(promptsSrc, "export async function buildParallelResearchSlicesPrompt");
+  const signature = extractSourceRegion(promptsSrc, "export async function buildParallelResearchSlicesPrompt", { fromIdx: fnStart });
   assert.ok(
     signature.includes("subagentModel"),
     "buildParallelResearchSlicesPrompt should accept a subagentModel parameter",
@@ -80,7 +80,7 @@ test("buildParallelResearchSlicesPrompt: accepts subagentModel parameter", () =>
 test("buildGateEvaluatePrompt: accepts subagentModel parameter", () => {
   const fnStart = promptsSrc.indexOf("export async function buildGateEvaluatePrompt");
   assert.ok(fnStart !== -1, "buildGateEvaluatePrompt should be exported");
-  const signature = extractSourceRegion(promptsSrc, "export async function buildGateEvaluatePrompt");
+  const signature = extractSourceRegion(promptsSrc, "export async function buildGateEvaluatePrompt", { fromIdx: fnStart });
   assert.ok(
     signature.includes("subagentModel"),
     "buildGateEvaluatePrompt should accept a subagentModel parameter",
@@ -130,7 +130,7 @@ test("auto-dispatch: passes model to buildReactiveExecutePrompt", () => {
   // Find the reactive-execute dispatch rule
   const ruleStart = dispatchSrc.indexOf("reactive-execute (parallel dispatch)");
   assert.ok(ruleStart !== -1, "reactive-execute dispatch rule should exist");
-  const ruleBlock = extractSourceRegion(dispatchSrc, "reactive-execute (parallel dispatch)");
+  const ruleBlock = extractSourceRegion(dispatchSrc, "reactive-execute (parallel dispatch)", { fromIdx: ruleStart });
   assert.ok(
     ruleBlock.includes("subagent_model") || ruleBlock.includes("subagentModel"),
     "reactive-execute rule should resolve and pass the subagent model",
@@ -141,7 +141,7 @@ test("auto-dispatch: passes model to buildParallelResearchSlicesPrompt", () => {
   const callIdx = dispatchSrc.indexOf("buildParallelResearchSlicesPrompt(");
   assert.ok(callIdx !== -1, "buildParallelResearchSlicesPrompt call should exist");
   // The call site should pass a model argument (not just 4 args)
-  const callSite = extractSourceRegion(dispatchSrc, "buildParallelResearchSlicesPrompt(");
+  const callSite = extractSourceRegion(dispatchSrc, "buildParallelResearchSlicesPrompt(", { fromIdx: callIdx });
   assert.ok(
     callSite.includes("subagentModel") || callSite.includes("resolveModelWithFallbacksForUnit"),
     "buildParallelResearchSlicesPrompt call should include model argument",
@@ -151,7 +151,7 @@ test("auto-dispatch: passes model to buildParallelResearchSlicesPrompt", () => {
 test("auto-dispatch: passes model to buildGateEvaluatePrompt", () => {
   const callIdx = dispatchSrc.indexOf("buildGateEvaluatePrompt(");
   assert.ok(callIdx !== -1, "buildGateEvaluatePrompt call should exist");
-  const callSite = extractSourceRegion(dispatchSrc, "buildGateEvaluatePrompt(");
+  const callSite = extractSourceRegion(dispatchSrc, "buildGateEvaluatePrompt(", { fromIdx: callIdx });
   assert.ok(
     callSite.includes("subagentModel") || callSite.includes("resolveModelWithFallbacksForUnit"),
     "buildGateEvaluatePrompt call should include model argument",

--- a/src/resources/extensions/gsd/tests/subagent-model-dispatch.test.ts
+++ b/src/resources/extensions/gsd/tests/subagent-model-dispatch.test.ts
@@ -15,6 +15,7 @@ import { join, dirname } from "node:path";
 import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 import { validatePreferences } from "../preferences-validation.ts";
+import { extractSourceRegion } from "./test-helpers.ts";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const promptsSrc = readFileSync(join(__dirname, "..", "auto-prompts.ts"), "utf-8");
@@ -59,7 +60,7 @@ test("reactive_execution: subagent_model rejects empty string", () => {
 test("buildReactiveExecutePrompt: accepts subagentModel parameter", () => {
   const fnStart = promptsSrc.indexOf("export async function buildReactiveExecutePrompt");
   assert.ok(fnStart !== -1, "buildReactiveExecutePrompt should be exported");
-  const signature = promptsSrc.slice(fnStart, fnStart + 300);
+  const signature = extractSourceRegion(promptsSrc, "export async function buildReactiveExecutePrompt");
   assert.ok(
     signature.includes("subagentModel"),
     "buildReactiveExecutePrompt should accept a subagentModel parameter",
@@ -69,7 +70,7 @@ test("buildReactiveExecutePrompt: accepts subagentModel parameter", () => {
 test("buildParallelResearchSlicesPrompt: accepts subagentModel parameter", () => {
   const fnStart = promptsSrc.indexOf("export async function buildParallelResearchSlicesPrompt");
   assert.ok(fnStart !== -1, "buildParallelResearchSlicesPrompt should be exported");
-  const signature = promptsSrc.slice(fnStart, fnStart + 300);
+  const signature = extractSourceRegion(promptsSrc, "export async function buildParallelResearchSlicesPrompt");
   assert.ok(
     signature.includes("subagentModel"),
     "buildParallelResearchSlicesPrompt should accept a subagentModel parameter",
@@ -79,7 +80,7 @@ test("buildParallelResearchSlicesPrompt: accepts subagentModel parameter", () =>
 test("buildGateEvaluatePrompt: accepts subagentModel parameter", () => {
   const fnStart = promptsSrc.indexOf("export async function buildGateEvaluatePrompt");
   assert.ok(fnStart !== -1, "buildGateEvaluatePrompt should be exported");
-  const signature = promptsSrc.slice(fnStart, fnStart + 300);
+  const signature = extractSourceRegion(promptsSrc, "export async function buildGateEvaluatePrompt");
   assert.ok(
     signature.includes("subagentModel"),
     "buildGateEvaluatePrompt should accept a subagentModel parameter",
@@ -129,7 +130,7 @@ test("auto-dispatch: passes model to buildReactiveExecutePrompt", () => {
   // Find the reactive-execute dispatch rule
   const ruleStart = dispatchSrc.indexOf("reactive-execute (parallel dispatch)");
   assert.ok(ruleStart !== -1, "reactive-execute dispatch rule should exist");
-  const ruleBlock = dispatchSrc.slice(ruleStart, ruleStart + 1000);
+  const ruleBlock = extractSourceRegion(dispatchSrc, "reactive-execute (parallel dispatch)");
   assert.ok(
     ruleBlock.includes("subagent_model") || ruleBlock.includes("subagentModel"),
     "reactive-execute rule should resolve and pass the subagent model",
@@ -140,7 +141,7 @@ test("auto-dispatch: passes model to buildParallelResearchSlicesPrompt", () => {
   const callIdx = dispatchSrc.indexOf("buildParallelResearchSlicesPrompt(");
   assert.ok(callIdx !== -1, "buildParallelResearchSlicesPrompt call should exist");
   // The call site should pass a model argument (not just 4 args)
-  const callSite = dispatchSrc.slice(callIdx, callIdx + 300);
+  const callSite = extractSourceRegion(dispatchSrc, "buildParallelResearchSlicesPrompt(");
   assert.ok(
     callSite.includes("subagentModel") || callSite.includes("resolveModelWithFallbacksForUnit"),
     "buildParallelResearchSlicesPrompt call should include model argument",
@@ -150,7 +151,7 @@ test("auto-dispatch: passes model to buildParallelResearchSlicesPrompt", () => {
 test("auto-dispatch: passes model to buildGateEvaluatePrompt", () => {
   const callIdx = dispatchSrc.indexOf("buildGateEvaluatePrompt(");
   assert.ok(callIdx !== -1, "buildGateEvaluatePrompt call should exist");
-  const callSite = dispatchSrc.slice(callIdx, callIdx + 300);
+  const callSite = extractSourceRegion(dispatchSrc, "buildGateEvaluatePrompt(");
   assert.ok(
     callSite.includes("subagentModel") || callSite.includes("resolveModelWithFallbacksForUnit"),
     "buildGateEvaluatePrompt call should include model argument",

--- a/src/resources/extensions/gsd/tests/sync-worktree-skip-current.test.ts
+++ b/src/resources/extensions/gsd/tests/sync-worktree-skip-current.test.ts
@@ -34,14 +34,14 @@ describe('syncWorktreeStateBack skips current milestone (#3641)', () => {
     assert.ok(fnStart !== -1)
 
     // Get a reasonable portion of the function
-    const fnBlock = extractSourceRegion(src, 'function syncWorktreeStateBack(')
+    const fnBlock = extractSourceRegion(src, 'function syncWorktreeStateBack(', { fromIdx: fnStart })
 
     // Find the for loop iterating milestones
     const loopIdx = fnBlock.indexOf('for (const mid of wtMilestones)')
     assert.ok(loopIdx !== -1, 'milestone iteration loop must exist')
 
     // After the loop, there should be the skip guard
-    const loopBody = extractSourceRegion(fnBlock, 'for (const mid of wtMilestones)')
+    const loopBody = extractSourceRegion(fnBlock, 'for (const mid of wtMilestones)', { fromIdx: loopIdx })
     assert.ok(
       loopBody.includes('mid === milestoneId'),
       'mid === milestoneId skip guard must exist inside the milestone loop',
@@ -56,7 +56,7 @@ describe('syncWorktreeStateBack skips current milestone (#3641)', () => {
     const fnStart = src.indexOf('function syncWorktreeStateBack(')
     assert.ok(fnStart !== -1)
 
-    const fnBlock = extractSourceRegion(src, 'function syncWorktreeStateBack(')
+    const fnBlock = extractSourceRegion(src, 'function syncWorktreeStateBack(', { fromIdx: fnStart })
 
     assert.ok(
       fnBlock.includes('syncMilestoneDir('),

--- a/src/resources/extensions/gsd/tests/sync-worktree-skip-current.test.ts
+++ b/src/resources/extensions/gsd/tests/sync-worktree-skip-current.test.ts
@@ -13,6 +13,7 @@ import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
 import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
+import { extractSourceRegion } from "./test-helpers.ts";
 
 const src = readFileSync(
   resolve(process.cwd(), 'src', 'resources', 'extensions', 'gsd', 'auto-worktree.ts'),
@@ -33,14 +34,14 @@ describe('syncWorktreeStateBack skips current milestone (#3641)', () => {
     assert.ok(fnStart !== -1)
 
     // Get a reasonable portion of the function
-    const fnBlock = src.slice(fnStart, fnStart + 3000)
+    const fnBlock = extractSourceRegion(src, 'function syncWorktreeStateBack(')
 
     // Find the for loop iterating milestones
     const loopIdx = fnBlock.indexOf('for (const mid of wtMilestones)')
     assert.ok(loopIdx !== -1, 'milestone iteration loop must exist')
 
     // After the loop, there should be the skip guard
-    const loopBody = fnBlock.slice(loopIdx, loopIdx + 300)
+    const loopBody = extractSourceRegion(fnBlock, 'for (const mid of wtMilestones)')
     assert.ok(
       loopBody.includes('mid === milestoneId'),
       'mid === milestoneId skip guard must exist inside the milestone loop',
@@ -55,7 +56,7 @@ describe('syncWorktreeStateBack skips current milestone (#3641)', () => {
     const fnStart = src.indexOf('function syncWorktreeStateBack(')
     assert.ok(fnStart !== -1)
 
-    const fnBlock = src.slice(fnStart, fnStart + 3000)
+    const fnBlock = extractSourceRegion(src, 'function syncWorktreeStateBack(')
 
     assert.ok(
       fnBlock.includes('syncMilestoneDir('),

--- a/src/resources/extensions/gsd/tests/test-helpers.test.ts
+++ b/src/resources/extensions/gsd/tests/test-helpers.test.ts
@@ -103,6 +103,9 @@ test("waitForCondition returns the truthy value (not just true)", async () => {
     n++;
     return n >= 3 ? { ready: true, iteration: n } : null;
   }, { intervalMs: 5 });
+  // The helper only resolves when the condition returns a truthy value, so
+  // result cannot be null here. Assert it and narrow for the follow-ups.
+  assert.ok(result, "waitForCondition must resolve with a truthy value, not null");
   assert.equal(result.ready, true);
   assert.equal(result.iteration, 3);
 });

--- a/src/resources/extensions/gsd/tests/test-helpers.test.ts
+++ b/src/resources/extensions/gsd/tests/test-helpers.test.ts
@@ -129,3 +129,16 @@ test("findLine throws with preview when no line matches", () => {
     /First 10 lines/,
   );
 });
+
+test("findLine resets lastIndex between lines for /g regex patterns", () => {
+  // Without the reset, RegExp.test with /g flag stateful-advances lastIndex
+  // and can skip matches on subsequent calls. Verify the reset keeps
+  // per-line testing deterministic.
+  const output = "foo\nfoo\nfoo";
+  const globalRe = /foo/g;
+  const match = findLine(output, globalRe);
+  assert.equal(match.index, 0);
+  // Second call on the same pattern must also match — would fail without reset
+  const match2 = findLine(output, globalRe);
+  assert.equal(match2.index, 0);
+});

--- a/src/resources/extensions/gsd/tests/test-helpers.test.ts
+++ b/src/resources/extensions/gsd/tests/test-helpers.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Tests for test-helpers.ts — the source-inspection and timing helpers
+ * introduced in #4773 / #4774 to replace brittle fixed-byte slice and
+ * magic-number sleep patterns in the test suite.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { extractSourceRegion, waitForCondition, findLine } from "./test-helpers.ts";
+
+// ─── extractSourceRegion ──────────────────────────────────────────────────
+
+test("extractSourceRegion returns empty string when start anchor missing", () => {
+  assert.equal(extractSourceRegion("const x = 1;", "missing"), "");
+});
+
+test("extractSourceRegion uses explicit end anchor when provided", () => {
+  const src = "START_TOKEN\nbody line\nEND_TOKEN tail";
+  const region = extractSourceRegion(src, "START_TOKEN", "END_TOKEN");
+  assert.ok(region.includes("START_TOKEN"));
+  assert.ok(region.includes("body line"));
+  assert.ok(!region.includes("END_TOKEN"));
+});
+
+test("extractSourceRegion stops at next private method boundary", () => {
+  const src = [
+    "class Foo {",
+    "  private alpha(): void {",
+    "    const a = 1;",
+    "    someCall();",
+    "  }",
+    "",
+    "  private beta(): void {",
+    "    const b = 2;",
+    "  }",
+    "}",
+  ].join("\n");
+
+  // Anchor on alpha's declaration; helper should stop at the next
+  // private method (beta), not on alpha itself.
+  const region = extractSourceRegion(src, "private alpha");
+  assert.ok(region.includes("alpha"));
+  assert.ok(region.includes("someCall()"));
+  assert.ok(!region.includes("beta"));
+});
+
+test("extractSourceRegion stops at next top-level function", () => {
+  const src = [
+    "function alpha() {",
+    "  throw new Error('alpha');",
+    "}",
+    "",
+    "function beta() {",
+    "  return 2;",
+    "}",
+  ].join("\n");
+
+  const region = extractSourceRegion(src, "function alpha");
+  assert.ok(region.includes("throw new Error"));
+  assert.ok(!region.includes("beta"));
+});
+
+test("extractSourceRegion returns to end-of-source when no terminator found", () => {
+  const src = "just one line";
+  assert.equal(extractSourceRegion(src, "just"), "just one line");
+});
+
+// ─── waitForCondition ─────────────────────────────────────────────────────
+
+test("waitForCondition returns immediately when condition is true", async () => {
+  const result = await waitForCondition(() => true);
+  assert.equal(result, true);
+});
+
+test("waitForCondition waits and returns when condition becomes true", async () => {
+  let flipped = false;
+  setTimeout(() => { flipped = true; }, 30);
+  const result = await waitForCondition(() => flipped, { intervalMs: 5 });
+  assert.equal(result, true);
+});
+
+test("waitForCondition throws after timeout with description", async () => {
+  await assert.rejects(
+    waitForCondition(() => false, { timeoutMs: 50, intervalMs: 5, description: "the flag to flip" }),
+    /waiting for the flag to flip/i,
+  );
+});
+
+test("waitForCondition surfaces last error on timeout", async () => {
+  await assert.rejects(
+    waitForCondition(
+      () => { throw new Error("probe failed"); },
+      { timeoutMs: 30, intervalMs: 5, description: "probe" },
+    ),
+    /probe failed/,
+  );
+});
+
+test("waitForCondition returns the truthy value (not just true)", async () => {
+  let n = 0;
+  const result = await waitForCondition(() => {
+    n++;
+    return n >= 3 ? { ready: true, iteration: n } : null;
+  }, { intervalMs: 5 });
+  assert.equal(result.ready, true);
+  assert.equal(result.iteration, 3);
+});
+
+// ─── findLine ─────────────────────────────────────────────────────────────
+
+test("findLine locates a line by regex", () => {
+  const output = "header\nstatus: ok\nfooter";
+  const match = findLine(output, /^status:/);
+  assert.equal(match.index, 1);
+  assert.equal(match.text, "status: ok");
+});
+
+test("findLine locates a line by predicate", () => {
+  const output = "a\nb\nc";
+  const match = findLine(output, (l) => l === "b");
+  assert.equal(match.index, 1);
+  assert.equal(match.text, "b");
+});
+
+test("findLine throws with preview when no line matches", () => {
+  assert.throws(
+    () => findLine("a\nb\nc", /NOTFOUND/),
+    /First 10 lines/,
+  );
+});

--- a/src/resources/extensions/gsd/tests/test-helpers.ts
+++ b/src/resources/extensions/gsd/tests/test-helpers.ts
@@ -183,7 +183,13 @@ export function findLine(
 ): { index: number; text: string } {
   const lines = output.split("\n");
   const fn = predicate instanceof RegExp
-    ? (l: string) => predicate.test(l)
+    ? (l: string) => {
+        // RegExp.test is stateful when the pattern has /g or /y flags
+        // (maintains lastIndex across calls). Reset before each test so
+        // matches on different lines don't silently skip.
+        if (predicate.global || predicate.sticky) predicate.lastIndex = 0;
+        return predicate.test(l);
+      }
     : predicate;
   for (let i = 0; i < lines.length; i++) {
     if (fn(lines[i]!)) return { index: i, text: lines[i]! };

--- a/src/resources/extensions/gsd/tests/test-helpers.ts
+++ b/src/resources/extensions/gsd/tests/test-helpers.ts
@@ -59,3 +59,137 @@ export function createTestContext() {
 
   return { assertEq, assertTrue, assertMatch, assertNoMatch, report };
 }
+
+// ─── Source-inspection helpers ────────────────────────────────────────────────
+//
+// Replace brittle fixed-byte slice patterns like `src.slice(idx, idx + 6000)`
+// with structural boundary detection. See #4773, #4774.
+
+/**
+ * Extract a region of source between a start anchor and either an explicit
+ * end anchor or, if none is given, a set of reasonable structural
+ * terminators (next `private `/`export `/`function `/`class `/`interface `/
+ * `//` section separator). Falls back to end-of-source if none match.
+ *
+ * Use this instead of `src.slice(startIdx, startIdx + N)` when searching
+ * for patterns within a specific method or region — the start anchor is
+ * what the caller already has, and the end is determined by structure,
+ * not by a magic byte count that breaks under refactors.
+ *
+ * @param src        The source text.
+ * @param startAnchor Literal substring that marks the start of the region.
+ *                   Typically a function name, a section header comment, or
+ *                   a distinctive statement.
+ * @param endAnchor  Optional. Either a literal substring that marks the end,
+ *                   or `{ fromIdx: number }` to find the *next* occurrence
+ *                   of `startAnchor` at or after `fromIdx` (useful when the
+ *                   anchor appears multiple times and a positional search
+ *                   is required). When omitted, structural terminators are
+ *                   used.
+ *
+ * Returns the extracted region (including the start anchor), or an empty
+ * string if `startAnchor` is not found.
+ */
+export function extractSourceRegion(
+  src: string,
+  startAnchor: string,
+  endAnchor?: string | { fromIdx: number },
+): string {
+  const fromIdx = typeof endAnchor === "object" && endAnchor !== null
+    ? endAnchor.fromIdx
+    : 0;
+  const endLiteral = typeof endAnchor === "string" ? endAnchor : undefined;
+
+  const startIdx = src.indexOf(startAnchor, fromIdx);
+  if (startIdx < 0) return "";
+
+  if (endLiteral) {
+    const endIdx = src.indexOf(endLiteral, startIdx + startAnchor.length);
+    return endIdx > 0 ? src.slice(startIdx, endIdx) : src.slice(startIdx);
+  }
+
+  // Heuristic terminators — the next sibling declaration/section.
+  const terminators = [
+    "\n  private ",
+    "\n  public ",
+    "\n  protected ",
+    "\n  static ",
+    "\nexport function ",
+    "\nexport async function ",
+    "\nfunction ",
+    "\nasync function ",
+    "\nexport class ",
+    "\nclass ",
+    "\nexport interface ",
+    "\ninterface ",
+    "\n// ─", // section separator comments
+    "\n/** ", // next docblock
+  ];
+
+  let earliestEnd = -1;
+  for (const t of terminators) {
+    const idx = src.indexOf(t, startIdx + startAnchor.length);
+    if (idx > 0 && (earliestEnd < 0 || idx < earliestEnd)) earliestEnd = idx;
+  }
+
+  return earliestEnd > 0 ? src.slice(startIdx, earliestEnd) : src.slice(startIdx);
+}
+
+/**
+ * Poll `condition()` until it returns truthy or `timeoutMs` elapses.
+ * Returns the truthy value from `condition()`, or throws on timeout.
+ *
+ * Use this instead of `await new Promise(r => setTimeout(r, <magic-ms>))`
+ * when waiting for a state change that tests produce. The fixed-sleep
+ * pattern is flaky: too short → race; too long → slow tests.
+ *
+ * @param condition  Predicate. Returns truthy when done. May be async.
+ * @param opts.timeoutMs  Max total wait. Defaults to 2000ms.
+ * @param opts.intervalMs Poll interval. Defaults to 10ms.
+ * @param opts.description Included in the timeout error for debuggability.
+ */
+export async function waitForCondition<T>(
+  condition: () => T | Promise<T>,
+  opts: { timeoutMs?: number; intervalMs?: number; description?: string } = {},
+): Promise<T> {
+  const timeoutMs = opts.timeoutMs ?? 2000;
+  const intervalMs = opts.intervalMs ?? 10;
+  const deadline = Date.now() + timeoutMs;
+  let lastErr: unknown;
+  while (Date.now() < deadline) {
+    try {
+      const result = await condition();
+      if (result) return result;
+    } catch (e) {
+      lastErr = e;
+    }
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+  const desc = opts.description ?? "condition";
+  const errSuffix = lastErr instanceof Error ? ` (last error: ${lastErr.message})` : "";
+  throw new Error(`waitForCondition timed out after ${timeoutMs}ms waiting for ${desc}${errSuffix}`);
+}
+
+/**
+ * Find the first line in rendered output that matches a predicate. Returns
+ * the line's index and text, or throws if no line matches.
+ *
+ * Use this instead of `lines[N]` indexing when the N is positional and
+ * could shift under formatting changes.
+ */
+export function findLine(
+  output: string,
+  predicate: RegExp | ((line: string) => boolean),
+): { index: number; text: string } {
+  const lines = output.split("\n");
+  const fn = predicate instanceof RegExp
+    ? (l: string) => predicate.test(l)
+    : predicate;
+  for (let i = 0; i < lines.length; i++) {
+    if (fn(lines[i]!)) return { index: i, text: lines[i]! };
+  }
+  const preview = lines.slice(0, 10).join("\n");
+  throw new Error(
+    `findLine: no line matched. First 10 lines were:\n${preview}`,
+  );
+}

--- a/src/resources/extensions/gsd/tests/token-profile.test.ts
+++ b/src/resources/extensions/gsd/tests/token-profile.test.ts
@@ -128,7 +128,13 @@ test("profile: balanced profile skips research, reassess, and slice research (AD
 
 test("profile: quality profile skips research, slice research, and reassess (ADR-003)", () => {
   const qualityIdx = preferencesSrc.indexOf('case "quality":');
-  const qualityBlock = extractSourceRegion(preferencesSrc, 'case "quality":');
+  // preferencesSrc is concatenated from multiple modules — bound the region
+  // with the next case marker so the assertion stays tightly scoped.
+  const qualityBlock = extractSourceRegion(
+    preferencesSrc,
+    'case "quality":',
+    'case "burn-max":',
+  );
   assert.ok(qualityBlock.includes("skip_research: true"), "quality should skip research");
   assert.ok(qualityBlock.includes("skip_slice_research: true"), "quality should skip slice research");
   assert.ok(qualityBlock.includes("skip_reassess: true"), "quality should skip reassess");

--- a/src/resources/extensions/gsd/tests/token-profile.test.ts
+++ b/src/resources/extensions/gsd/tests/token-profile.test.ts
@@ -14,6 +14,7 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
+import { extractSourceRegion } from "./test-helpers.ts";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -127,7 +128,7 @@ test("profile: balanced profile skips research, reassess, and slice research (AD
 
 test("profile: quality profile skips research, slice research, and reassess (ADR-003)", () => {
   const qualityIdx = preferencesSrc.indexOf('case "quality":');
-  const qualityBlock = preferencesSrc.slice(qualityIdx, qualityIdx + 300);
+  const qualityBlock = extractSourceRegion(preferencesSrc, 'case "quality":');
   assert.ok(qualityBlock.includes("skip_research: true"), "quality should skip research");
   assert.ok(qualityBlock.includes("skip_slice_research: true"), "quality should skip slice research");
   assert.ok(qualityBlock.includes("skip_reassess: true"), "quality should skip reassess");

--- a/src/resources/extensions/gsd/tests/verify-artifact-tightened.test.ts
+++ b/src/resources/extensions/gsd/tests/verify-artifact-tightened.test.ts
@@ -15,6 +15,7 @@ import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
 import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
+import { extractSourceRegion } from "./test-helpers.ts";
 
 const src = readFileSync(
   resolve(process.cwd(), 'src', 'resources', 'extensions', 'gsd', 'auto-recovery.ts'),
@@ -28,7 +29,7 @@ describe('verifyExpectedArtifact legacy branch tightened (#3607)', () => {
     assert.ok(legacyIdx !== -1, 'LEGACY comment must exist')
 
     // Check the code within a reasonable window after the LEGACY comment
-    const legacyBlock = src.slice(legacyIdx, legacyIdx + 600)
+    const legacyBlock = extractSourceRegion(src, 'LEGACY: Pre-migration fallback')
 
     assert.ok(
       !legacyBlock.includes('hdRe'),
@@ -40,7 +41,7 @@ describe('verifyExpectedArtifact legacy branch tightened (#3607)', () => {
     const legacyIdx = src.indexOf('LEGACY: Pre-migration fallback')
     assert.ok(legacyIdx !== -1)
 
-    const legacyBlock = src.slice(legacyIdx, legacyIdx + 600)
+    const legacyBlock = extractSourceRegion(src, 'LEGACY: Pre-migration fallback')
 
     assert.ok(
       legacyBlock.includes('cbRe'),
@@ -58,7 +59,7 @@ describe('verifyExpectedArtifact legacy branch tightened (#3607)', () => {
     const legacyIdx = src.indexOf('LEGACY: Pre-migration fallback')
     assert.ok(legacyIdx !== -1)
 
-    const legacyBlock = src.slice(legacyIdx, legacyIdx + 1000)
+    const legacyBlock = extractSourceRegion(src, 'LEGACY: Pre-migration fallback')
 
     // The else branch: no plan file means cannot verify
     assert.ok(
@@ -71,7 +72,7 @@ describe('verifyExpectedArtifact legacy branch tightened (#3607)', () => {
     const legacyIdx = src.indexOf('LEGACY: Pre-migration fallback')
     assert.ok(legacyIdx !== -1)
 
-    const legacyBlock = src.slice(legacyIdx, legacyIdx + 1000)
+    const legacyBlock = extractSourceRegion(src, 'LEGACY: Pre-migration fallback')
 
     assert.ok(
       legacyBlock.includes('DB available but task row not found'),
@@ -80,7 +81,7 @@ describe('verifyExpectedArtifact legacy branch tightened (#3607)', () => {
 
     // The comment should be followed by a return false
     const commentIdx = legacyBlock.indexOf('DB available but task row not found')
-    const afterComment = legacyBlock.slice(commentIdx, commentIdx + 200)
+    const afterComment = extractSourceRegion(legacyBlock, 'DB available but task row not found')
     assert.ok(
       afterComment.includes('return false'),
       'missing task row when DB available must return false',

--- a/src/resources/extensions/gsd/tests/worktree-health-monorepo.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-health-monorepo.test.ts
@@ -8,7 +8,7 @@
 
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { createTestContext } from "./test-helpers.ts";
+import {createTestContext, extractSourceRegion } from "./test-helpers.ts";
 
 const { assertTrue, report } = createTestContext();
 
@@ -22,7 +22,7 @@ console.log("\n=== #2347: Worktree health check supports monorepos ===");
 const healthCheckIdx = src.indexOf("Worktree health check");
 assertTrue(healthCheckIdx > 0, "auto/phases.ts has worktree health check section");
 
-const healthCheckRegion = src.slice(healthCheckIdx, healthCheckIdx + 2000);
+const healthCheckRegion = extractSourceRegion(src, "Worktree health check");
 
 // ── Test 2: The check walks parent directories for project markers ──────
 

--- a/src/resources/extensions/gsd/tests/worktree-nested-git-safety.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-nested-git-safety.test.ts
@@ -13,7 +13,7 @@
 
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { createTestContext } from "./test-helpers.ts";
+import {createTestContext, extractSourceRegion } from "./test-helpers.ts";
 
 const { assertTrue, report } = createTestContext();
 
@@ -27,7 +27,7 @@ console.log("\n=== #2616: Worktree cleanup detects nested .git directories ===")
 const removeWorktreeIdx = src.indexOf("export function removeWorktree");
 assertTrue(removeWorktreeIdx > 0, "worktree-manager.ts exports removeWorktree");
 
-const fnBody = src.slice(removeWorktreeIdx, removeWorktreeIdx + 5000);
+const fnBody = extractSourceRegion(src, "export function removeWorktree");
 
 const detectsNestedGit =
   fnBody.includes("nested") && fnBody.includes(".git") ||

--- a/src/resources/extensions/gsd/tests/worktree-submodule-safety.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-submodule-safety.test.ts
@@ -8,7 +8,7 @@
 
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { createTestContext } from "./test-helpers.ts";
+import {createTestContext, extractSourceRegion } from "./test-helpers.ts";
 
 const { assertTrue, report } = createTestContext();
 
@@ -22,7 +22,7 @@ console.log("\n=== #2337: Worktree teardown preserves submodule state ===");
 const removeWorktreeIdx = src.indexOf("export function removeWorktree");
 assertTrue(removeWorktreeIdx > 0, "worktree-manager.ts exports removeWorktree");
 
-const fnBody = src.slice(removeWorktreeIdx, removeWorktreeIdx + 6000);
+const fnBody = extractSourceRegion(src, "export function removeWorktree");
 
 // ── Test 2: The function checks for submodules before force removal ─────
 

--- a/src/resources/extensions/gsd/tests/zombie-gsd-state.test.ts
+++ b/src/resources/extensions/gsd/tests/zombie-gsd-state.test.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
-import { createTestContext } from "./test-helpers.ts";
+import {createTestContext, extractSourceRegion } from "./test-helpers.ts";
 
 const { assertTrue, assertMatch, assertNoMatch, report } = createTestContext();
 
@@ -26,7 +26,7 @@ assertTrue(smartEntryIdx >= 0, "guided-flow.ts defines showSmartEntry");
 
 // Extract the region between showSmartEntry and the first showProjectInit call
 // This is where the init wizard gate lives.
-const afterSmartEntry = smartEntryIdx >= 0 ? guidedFlowSrc.slice(smartEntryIdx, smartEntryIdx + 3000) : "";
+const afterSmartEntry = smartEntryIdx >= 0 ? extractSourceRegion(guidedFlowSrc, "export async function showSmartEntry(") : "";
 
 // The gate must NOT be a bare `!existsSync(gsdRoot(basePath))` check.
 // It must also verify that bootstrap artifacts (PREFERENCES.md or milestones/) exist.
@@ -48,7 +48,7 @@ assertTrue(
 // Find the specific init wizard gate pattern — the detection preamble block.
 const detectionPreambleIdx = afterSmartEntry.indexOf("Detection preamble");
 const detectionRegion = detectionPreambleIdx >= 0
-  ? afterSmartEntry.slice(detectionPreambleIdx, detectionPreambleIdx + 600)
+  ? extractSourceRegion(afterSmartEntry, "Detection preamble")
   : afterSmartEntry.slice(0, 1500);
 
 // The gate condition must reference PREFERENCES.md or milestones (bootstrap artifacts)


### PR DESCRIPTION
## Summary

Migrates every fixed-byte-slice source-inspection test in the `gsd` test suite to the new `extractSourceRegion` helper, addressing [#4773](https://github.com/gsd-build/gsd-2/issues/4773) and establishing Phase 2 of [#4774](https://github.com/gsd-build/gsd-2/issues/4774).

The pattern \`src.slice(idx, idx + <N>)\` is brittle: any refactor that grows the target method past the window turns a passing test into a false failure or false pass. [#4769](https://github.com/gsd-build/gsd-2/pull/4769) surfaced one such case during CI; this PR sweeps the remaining 82 occurrences.

## Changes

### New helpers in \`tests/test-helpers.ts\`

- **\`extractSourceRegion(src, startAnchor, endAnchorOrFromIdx?)\`** — extracts a source region between a start anchor and either:
  - an explicit end-anchor substring, OR
  - a \`{fromIdx: number}\` positional hint (for Nth-occurrence searches), OR
  - heuristic structural terminators (next sibling function/class/docblock/section comment)
  Replaces \`src.slice(idx, idx + <N>)\` with a pattern that survives method-body growth.
- **\`waitForCondition(fn, opts)\`** — polling replacement for magic-number sleep waits. Future-facing; not used yet in this PR.
- **\`findLine(output, regexOrPredicate)\`** — content-matched line lookup. Future-facing; not used yet in this PR.

### Migration

- **82 byte-slice occurrences across 43 test files** migrated to \`extractSourceRegion\`.
- 78 of 82 cases matched by a mechanical script using nearest-\`indexOf\` anchor detection.
- 4 stragglers (multi-line \`indexOf\` calls, variable-based anchors) migrated manually.
- 3 source-inspection regressions surfaced during verification (positional Nth-occurrence searches that my first pass collapsed to first-occurrence); fixed with the \`{fromIdx}\` and explicit end-anchor forms.

## Discipline

- **Kernighan**: the helper is ~40 lines. Heuristic terminators cover the common structural cases without needing an AST parser. Failure mode is graceful (returns entire remaining source when no terminator matches, which is at worst no-worse than the byte-slice it replaces).
- **Hyrum**: \`extractSourceRegion\` is purely additive — no existing test behavior is altered unless the test is opted-in via migration. The \`{fromIdx}\` parameter preserves positional semantics for tests that needed it.
- **Not mass-migrated** (per #4774 Phase 1 classification work):
  - \`lines[N]\` on API return values (48 occurrences) — position IS the contract, not brittle
  - \`.length === N\` counts (73 occurrences) — overwhelmingly contractual test data
  - Cache-TTL \`setTimeout(r, 150)\` (6 occurrences) — removing would be a semantic change, deferred
  - Microtask \`setTimeout(r, 10)\` (25 occurrences in auto-loop.test.ts) — legitimate async ordering
  - \`src.includes(\"<identifier>\")\` (530 occurrences) — many contractual; per-site judgment

## Tests

- 13 new tests for the helpers themselves
- 106 tests across the related areas (worktree-telemetry, canonical-milestone-root, forensics, slice-cadence, validate-milestone, merge-conflict-stops-loop, silent-catch-diagnostics, test-helpers) pass
- Full \`npm run test:unit\`: zero new assertion failures from the migration

## Test plan

- [ ] \`npm install && npm run build:core\` — local build clean
- [ ] \`npm run test:unit\` — no new failures compared to \`origin/main\`
- [ ] Grep for \`.slice(.*, .* + \\d{3,})\` patterns in \`tests/\` — only non-source-inspection cases should remain

## Related

- Closes #4773
- Partially closes #4774 (Phase 2 helper infrastructure delivered; Phase 1/3/4 remain)
- Incidental: the \`merge-conflict-stops-loop.test.ts\` fix from #4769 is naturally absorbed by the helper here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a new test-utility suite covering source-region extraction, condition polling, and line-matching helpers.
  * Improved reliability across many tests by replacing brittle fixed-character slicing with anchor-aware region extraction, reducing flakiness and easing maintenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->