### PR TITLE
fix(pi-coding-agent): prettify TUI tool-call headers and compact args

### DIFF
--- a/packages/pi-coding-agent/src/modes/interactive/components/__tests__/tool-execution.test.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/components/__tests__/tool-execution.test.ts
@@ -14,12 +14,13 @@ function renderTool(
 		isError: boolean;
 		details?: Record<string, unknown>;
 	},
+	toolDefinition?: { label?: string },
 ): string {
 	const component = new ToolExecutionComponent(
 		toolName,
 		args,
 		{},
-		undefined,
+		toolDefinition as any,
 		{ requestRender() {} } as any,
 	);
 	component.setExpanded(true);
@@ -35,12 +36,13 @@ function renderToolCollapsed(
 		isError: boolean;
 		details?: Record<string, unknown>;
 	},
+	toolDefinition?: { label?: string },
 ): string {
 	const component = new ToolExecutionComponent(
 		toolName,
 		args,
 		{},
-		undefined,
+		toolDefinition as any,
 		{ requestRender() {} } as any,
 	);
 	if (result) component.updateResult(result);
@@ -110,11 +112,55 @@ describe("ToolExecutionComponent", () => {
 			{ count: 3, enabled: true, label: "hello" },
 		);
 
-		assert.match(rendered, /some_unknown_tool/);
+		assert.match(rendered, /Some Unknown Tool/);
 		assert.match(rendered, /count=3/);
 		assert.match(rendered, /enabled=true/);
 		assert.match(rendered, /label="hello"/);
 		assert.doesNotMatch(rendered, /^\{$/m);
+	});
+
+	test("frame header prefers toolDefinition.label over raw tool name", () => {
+		const rendered = renderToolCollapsed(
+			"gsd_slice_complete",
+			{ sliceId: "S03" },
+			undefined,
+			{ label: "Complete Slice" },
+		);
+
+		assert.match(rendered, /Tool Complete Slice/);
+		assert.doesNotMatch(rendered, /gsd_slice_complete/);
+	});
+
+	test("frame header strips gsd_ prefix and title-cases when no label is registered", () => {
+		const rendered = renderToolCollapsed("gsd_requirement_update", { id: "R005" });
+
+		assert.match(rendered, /Tool Requirement Update/);
+		assert.doesNotMatch(rendered, /gsd_requirement_update/);
+	});
+
+	test("formatCompactArgs truncates long string values inline instead of dumping JSON", () => {
+		const longPath = "/Users/alice/.gsd/projects/4dce7b775013/worktrees/slice-S03-some-long-path-that-exceeds-limit";
+		const rendered = renderToolCollapsed("gsd_slice_complete", {
+			sliceId: "S03",
+			milestoneId: "M001",
+			worktree: longPath,
+		});
+
+		assert.match(rendered, /sliceId="S03"/);
+		assert.match(rendered, /milestoneId="M001"/);
+		assert.match(rendered, /worktree=".*…"/);
+		assert.doesNotMatch(rendered, /"sliceId":\s*"S03"/);
+	});
+
+	test("formatCompactArgs shows full string values when expanded", () => {
+		const longPath = "/Users/alice/.gsd/projects/4dce7b775013/worktrees/slice-S03-some-long-path-that-exceeds-limit";
+		const rendered = renderTool("gsd_slice_complete", {
+			sliceId: "S03",
+			worktree: longPath,
+		});
+
+		assert.match(rendered, new RegExp(longPath.replace(/\//g, "\\/")));
+		assert.doesNotMatch(rendered, /…/);
 	});
 
 	test("generic fallback truncates long output when collapsed", () => {

--- a/packages/pi-coding-agent/src/modes/interactive/components/tool-execution.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/components/tool-execution.ts
@@ -72,7 +72,7 @@ function parseMcpToolName(name: string): { server: string; tool: string } | null
  * prefix and converts snake_case to Title Case.
  */
 function prettifyToolName(name: string, label?: string): string {
-	if (label && label.trim().length > 0 && label !== name) return label;
+	if (label && label.trim().length > 0) return label;
 	const stripped = name.replace(/^gsd_/, "");
 	if (stripped.length === 0) return name;
 	return stripped

--- a/packages/pi-coding-agent/src/modes/interactive/components/tool-execution.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/components/tool-execution.ts
@@ -66,6 +66,21 @@ function parseMcpToolName(name: string): { server: string; tool: string } | null
 	return { server: rest.slice(0, delim), tool: rest.slice(delim + 2) };
 }
 
+/**
+ * Prettify a raw tool name for display. Prefers the registered `label`
+ * ("Complete Slice") when available; otherwise strips a leading `gsd_`
+ * prefix and converts snake_case to Title Case.
+ */
+function prettifyToolName(name: string, label?: string): string {
+	if (label && label.trim().length > 0 && label !== name) return label;
+	const stripped = name.replace(/^gsd_/, "");
+	if (stripped.length === 0) return name;
+	return stripped
+		.split("_")
+		.map((word) => (word.length === 0 ? word : word[0].toUpperCase() + word.slice(1)))
+		.join(" ");
+}
+
 type ToolFrameTone = "pending" | "success" | "error";
 
 function trimOuterBlankLines(lines: string[]): string[] {
@@ -131,15 +146,19 @@ function formatCompactArgs(args: unknown, expanded: boolean): string {
 
 	const allPrimitive = entries.every(([, value]) => {
 		const t = typeof value;
-		if (t === "number" || t === "boolean") return true;
-		if (t === "string") return (value as string).length <= COMPACT_ARG_VALUE_LIMIT;
-		return value == null;
+		return t === "number" || t === "boolean" || t === "string" || value == null;
 	});
 
 	if (allPrimitive) {
 		return entries
 			.map(([key, value]) => {
-				if (typeof value === "string") return `${key}=${JSON.stringify(value)}`;
+				if (typeof value === "string") {
+					const truncated =
+						!expanded && value.length > COMPACT_ARG_VALUE_LIMIT
+							? `${value.slice(0, COMPACT_ARG_VALUE_LIMIT - 1)}…`
+							: value;
+					return `${key}=${JSON.stringify(truncated)}`;
+				}
 				if (value == null) return `${key}=null`;
 				return `${key}=${String(value)}`;
 			})
@@ -526,7 +545,7 @@ export class ToolExecutionComponent extends Container {
 		const parsed = parseMcpToolName(this.toolName);
 		const frameLabel = parsed
 			? `Tool ${parsed.server}·${parsed.tool}`
-			: `Tool ${this.normalizedToolName || this.toolName || "unknown"}`;
+			: `Tool ${prettifyToolName(this.toolName, this.toolDefinition?.label) || "unknown"}`;
 		const framed = renderToolFrame(lines, frameWidth, {
 			label: frameLabel,
 			status: frameStatus,
@@ -1126,7 +1145,9 @@ export class ToolExecutionComponent extends Container {
 			// cleanly. GSD-registered MCP tools have already had their prefix
 			// stripped upstream in partial-builder.ts and won't reach this branch.
 			const parsed = parseMcpToolName(this.toolName);
-			const displayName = parsed ? parsed.tool : this.toolName;
+			const displayName = parsed
+				? parsed.tool
+				: prettifyToolName(this.toolName, this.toolDefinition?.label);
 			const serverPrefix = parsed ? theme.fg("muted", `${parsed.server}\u00b7`) : "";
 			text = serverPrefix + theme.fg("toolTitle", theme.bold(displayName));
 

--- a/packages/pi-coding-agent/src/modes/interactive/components/tool-execution.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/components/tool-execution.ts
@@ -589,12 +589,30 @@ export class ToolExecutionComponent extends Container {
 					}
 				} catch {
 					// Fall back to default on error
-					this.contentBox.addChild(new Text(theme.fg("toolTitle", theme.bold(this.toolName)), 0, 0));
+					this.contentBox.addChild(
+						new Text(
+							theme.fg(
+								"toolTitle",
+								theme.bold(prettifyToolName(this.toolName, this.toolDefinition?.label)),
+							),
+							0,
+							0,
+						),
+					);
 					customRendererHasContent = true;
 				}
 			} else {
-				// No custom renderCall, show tool name
-				this.contentBox.addChild(new Text(theme.fg("toolTitle", theme.bold(this.toolName)), 0, 0));
+				// No custom renderCall, show prettified tool name
+				this.contentBox.addChild(
+					new Text(
+						theme.fg(
+							"toolTitle",
+							theme.bold(prettifyToolName(this.toolName, this.toolDefinition?.label)),
+						),
+						0,
+						0,
+					),
+				);
 				customRendererHasContent = true;
 			}
 


### PR DESCRIPTION
## TL;DR

**What:** Clean up the interactive TUI so GSD tool-call frames show readable labels (\`Tool Complete Slice\`) instead of raw snake_case names (\`Tool gsd_complete_slice\`), and stop the generic-args renderer from dumping raw JSON the moment any string value exceeds 60 characters.
**Why:** The current output is noisy and hard to scan — raw tool identifiers leak into the UI, and a single long path (e.g. a worktree directory) forces the whole args object into a multi-line JSON blob.
**How:** Prefer each tool's registered \`label\` for display, fall back to stripping the \`gsd_\` prefix + Title-Casing snake_case when no label exists, and truncate long string values inline in \`formatCompactArgs\` instead of bailing to JSON.

## What

Single-file change in \`packages/pi-coding-agent/src/modes/interactive/components/tool-execution.ts\`:

1. New helper \`prettifyToolName(name, label?)\` — prefers registered \`label\`, otherwise strips \`gsd_\` prefix and converts \`snake_case\` → \`Title Case\`.
2. Frame-header label (line ~546) uses the helper with \`this.toolDefinition?.label\`.
3. Generic-body heading (line ~1148) uses the same helper, keeping the existing MCP-prefixed (\`mcp__server__tool\`) handling untouched.
4. \`formatCompactArgs\` no longer bails to JSON when a single string is longer than \`COMPACT_ARG_VALUE_LIMIT\` — it now truncates that value inline with an ellipsis and still produces the compact \`k=v, k=v\` form. Nested objects/arrays still fall through to the truncated JSON dump.

## Why

Every GSD tool already defines a human-readable \`label\` (\"Complete Slice\", \"Update Requirement\", \"Plan Slice\", …) but it was unused in the TUI — the frame was hard-coded to show the raw registered name. Separately, tools like \`gsd_complete_slice\` include long paths in their args, which flipped the compact-args formatter to a full-object JSON dump, producing visual noise that the user had to scroll through. This PR fixes both on the display side without touching tool registration or execution.

Closes #4776

## How

- Prettifier prefers \`toolDefinition.label\` when provided (the normal case for GSD tools); the snake_case/Title-Case path is only a safety net for tools without a label.
- MCP names continue to route through \`parseMcpToolName\` unchanged.
- \`formatCompactArgs\` now considers a value primitive for purposes of inline formatting regardless of string length; length handling moves to a per-value truncation step (\`value.slice(0, LIMIT - 1) + \"…\"\`) that respects the \`expanded\` flag so \`ctrl+r\` still shows full content.

## Test plan

- [ ] \`npx tsc --noEmit -p packages/pi-coding-agent/tsconfig.json\` — clean.
- [ ] Run interactive agent, trigger \`gsd_complete_slice\` → header reads \`Tool Complete Slice\`, args render as compact \`k=v\` with long paths truncated.
- [ ] Trigger \`gsd_requirement_update\` → header reads \`Tool Update Requirement\`; existing custom renderer for the body is unchanged.
- [ ] Trigger an MCP tool (\`mcp__server__tool\`) → header still reads \`Tool server·tool\`.
- [ ] Expand a tool-call with \`ctrl+r\` → long string values render untruncated.

## Notes

AI-assisted PR. No behavior change to tool registration, execution, or result handling — cosmetic/display-layer only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved tool-name display: prefers registered labels and converts raw identifiers (including stripping common prefixes) into Title Case for UI headers and fallbacks.
  * Enhanced argument visualization: treats strings as primitives for compact inline display and truncates long inline values with an ellipsis, while expanded views show full strings.

* **Tests**
  * Updated and added tests covering label preference, prefix stripping, title-casing, and collapsed/expanded argument rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->