### PR TITLE
test(gsd): rewrite parallel-research-dispatch as behaviour tests (#4784)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -270,6 +270,36 @@ const content = `
 
 Bug fixes must include a regression test that fails before the fix and passes after. Write the test first, confirm it fails, then apply the fix. See the `test-first-bugfix` skill.
 
+### Test behaviour, not source shape
+
+Tests must verify **behaviour**, not source text. Reading a source file with `readFileSync` and asserting on its contents (`.includes("identifier")`, `.slice(idx, idx + N)`, `extractSourceRegion(...)`, `lines[N]` positional indexing) is **forbidden for new tests** with two narrow exceptions:
+
+1. **Contractual content** — the file **is** the user-facing or agent-facing contract. Examples: prompt templates rendered to an LLM, markdown that ships to the user, fixture golden files. Assertions on *rendered output* (the string returned by a builder function) are allowed; assertions on the *raw template file* are allowed only when the template IS the output.
+2. **AST-level structural invariants** — when a structural invariant genuinely cannot be runtime-tested (e.g., "module X imports only modules from an allowlist"), use the TypeScript compiler API to parse and query the AST. String search is not a substitute.
+
+```typescript
+// ❌ WRONG — source-grep test. Passes when the identifier exists, fails when
+// it's renamed. Does not test behaviour.
+const src = readFileSync("../auto-dispatch.ts", "utf-8");
+test("dispatch rule requires 2+ slices", () => {
+  assert.ok(src.includes("researchReadySlices.length < 2"));
+});
+
+// ✅ CORRECT — behaviour test. Invokes the real function against a
+// fixture and asserts on what it returned.
+test("dispatch rule requires 2+ slices", async () => {
+  writeRoadmap(base, "M001", [{ id: "S01", title: "Alpha" }]); // only 1 slice
+  const action = await resolveDispatch({ basePath: base, mid: "M001", /* … */ });
+  if (action.action === "dispatch") {
+    assert.notEqual(action.unitId, "M001/parallel-research");
+  }
+});
+```
+
+**What about renames?** If a rename changes the user-visible behaviour, a behaviour test catches it. If a rename does *not* change behaviour, the test shouldn't care. Source-grep tests invert this: they fail on harmless renames and pass on broken reimplementations.
+
+**`extractSourceRegion`, `createTestContext.assertTrue` on grep results, and raw `<src>.includes(...)` patterns are being removed.** See [#4784](https://github.com/gsd-build/gsd-2/issues/4784). Do not add new ones.
+
 ## Local development
 
 ```bash

--- a/src/resources/extensions/gsd/tests/parallel-research-dispatch.test.ts
+++ b/src/resources/extensions/gsd/tests/parallel-research-dispatch.test.ts
@@ -1,168 +1,286 @@
 /**
- * Parallel research slices dispatch — structural tests.
+ * parallel-research-dispatch.test.ts — behaviour tests for the
+ * "planning (multiple slices need research) → parallel-research-slices"
+ * dispatch rule and its prompt builder.
  *
- * Verifies the dispatch rule and prompt builder exist with correct structure.
+ * These tests invoke the real functions (resolveDispatch,
+ * buildParallelResearchSlicesPrompt) against on-disk fixtures. They do
+ * not read source files and string-match identifiers.
+ *
+ * See #4784 for why the previous source-grep version of this file was
+ * replaced.
  */
 
-import test, { afterEach } from "node:test";
+// Point GSD_HOME at a throwaway directory *before* the prompt-loader
+// module is imported so templates resolve from the in-tree prompts/
+// directory instead of a developer's ~/.gsd/ copy (which may be a stale
+// cached version from a prior install — see #4784 fallout). Set via
+// globalThis assignment + dynamic import so the value is live at the
+// top-level of the loader module.
+process.env.GSD_HOME = process.env.GSD_HOME_TEST_OVERRIDE
+  ?? `/tmp/gsd-test-home-${process.pid}-${Date.now()}`;
+
+import { describe, test, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
-import { join, dirname } from "node:path";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { fileURLToPath } from "node:url";
 
-import { resolveDispatch } from "../auto-dispatch.ts";
-import { extractSourceRegion } from "./test-helpers.ts";
+const { resolveDispatch } = await import("../auto-dispatch.ts");
+const { buildParallelResearchSlicesPrompt } = await import("../auto-prompts.ts");
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
+type DispatchState = Parameters<typeof resolveDispatch>[0]["state"];
 
-const dispatchSrc = readFileSync(join(__dirname, "..", "auto-dispatch.ts"), "utf-8");
-const promptsSrc = readFileSync(join(__dirname, "..", "auto-prompts.ts"), "utf-8");
-const templatePath = join(__dirname, "..", "prompts", "parallel-research-slices.md");
-const templateSrc = readFileSync(templatePath, "utf-8");
-
-const tmpDirs: string[] = [];
-
-function makeTmpProject(): string {
-  const base = mkdtempSync(join(tmpdir(), "parallel-research-"));
-  tmpDirs.push(base);
-  const milestoneDir = join(base, ".gsd", "milestones", "M001");
+function writeRoadmap(
+  base: string,
+  mid: string,
+  slices: Array<{ id: string; title: string; done?: boolean; depends?: string[] }>,
+): void {
+  const milestoneDir = join(base, ".gsd", "milestones", mid);
   mkdirSync(milestoneDir, { recursive: true });
+  const lines = [
+    `# ${mid}: Parallel Research Milestone`,
+    "",
+    "**Vision:** Research-ready slices.",
+    "",
+    "**Success Criteria:**",
+    "- Research all slices",
+    "",
+    "## Slices",
+    "",
+  ];
+  for (const s of slices) {
+    const box = s.done ? "x" : " ";
+    const deps = s.depends ? `depends:[${s.depends.join(",")}]` : "depends:[]";
+    lines.push(`- [${box}] **${s.id}: ${s.title}** \`risk:low\` \`${deps}\``);
+  }
+  lines.push("", "## Boundary Map", "");
   writeFileSync(
-    join(milestoneDir, "M001-ROADMAP.md"),
-    [
-      "# M001: Parallel Research Milestone",
-      "",
-      "**Vision:** Research-ready slices.",
-      "",
-      "**Success Criteria:**",
-      "- Research both slices",
-      "",
-      "## Slices",
-      "",
-      "- [ ] **S01: Alpha** `risk:low` `depends:[]`",
-      "- [ ] **S02: Beta** `risk:low` `depends:[]`",
-      "",
-      "## Boundary Map",
-      "",
-    ].join("\n"),
+    join(milestoneDir, `${mid}-ROADMAP.md`),
+    lines.join("\n"),
     "utf-8",
   );
-  return base;
 }
 
-afterEach(() => {
-  for (const dir of tmpDirs) {
-    try {
-      rmSync(dir, { recursive: true, force: true });
-    } catch {
-      // Best-effort cleanup only.
-    }
-  }
-  tmpDirs.length = 0;
-});
+function baseState(activeSliceId = "S01", activeSliceTitle = "Alpha"): DispatchState {
+  return {
+    phase: "planning",
+    activeMilestone: { id: "M001", title: "Parallel Research Milestone", status: "active" },
+    activeSlice: { id: activeSliceId, title: activeSliceTitle },
+    activeTask: null,
+    registry: [],
+    blockers: [],
+  } as unknown as DispatchState;
+}
 
-// ─── Dispatch rule ────────────────────────────────────────────────────────
+describe("parallel-research-slices dispatch rule", () => {
+  let base: string;
 
-test("dispatch: parallel-research-slices rule exists", () => {
-  assert.ok(
-    dispatchSrc.includes("parallel-research-slices"),
-    "dispatch table should have parallel-research-slices rule",
-  );
-});
-
-test("dispatch: parallel-research-slices requires 2+ slices", () => {
-  assert.ok(
-    dispatchSrc.includes("researchReadySlices.length < 2"),
-    "rule should require at least 2 slices for parallel dispatch",
-  );
-});
-
-test("dispatch: parallel-research-slices respects skip_research", () => {
-  const ruleIdx = dispatchSrc.indexOf("parallel-research-slices");
-  // Pin to the located occurrence — if "parallel-research-slices" appears
-  // more than once in the source, fromIdx keeps the anchor deterministic.
-  const ruleBlock = extractSourceRegion(dispatchSrc, "parallel-research-slices", { fromIdx: ruleIdx });
-  assert.ok(
-    ruleBlock.includes("skip_research") || dispatchSrc.slice(ruleIdx - 300, ruleIdx).includes("skip_research"),
-    "rule should check skip_research preference",
-  );
-});
-
-// ─── Prompt builder ───────────────────────────────────────────────────────
-
-test("prompt: buildParallelResearchSlicesPrompt exported", () => {
-  assert.ok(
-    promptsSrc.includes("export async function buildParallelResearchSlicesPrompt"),
-    "buildParallelResearchSlicesPrompt should be exported",
-  );
-});
-
-test("prompt: builds per-slice subagent prompts", () => {
-  assert.ok(
-    promptsSrc.includes("buildResearchSlicePrompt"),
-    "parallel prompt builder should delegate to per-slice research prompts",
-  );
-});
-
-// ─── Template ─────────────────────────────────────────────────────────────
-
-test("template: parallel-research-slices.md has required variables", () => {
-  assert.ok(templateSrc.includes("{{sliceCount}}"), "template should use sliceCount");
-  assert.ok(templateSrc.includes("{{mid}}"), "template should use mid");
-  assert.ok(templateSrc.includes("{{subagentPrompts}}"), "template should use subagentPrompts");
-});
-
-test("#4068: template: parallel-research-slices retry cap prevents infinite subagent loop", () => {
-  // The template must cap retries at 1 ("retry it once") and instruct the
-  // agent to write a BLOCKER note on the second failure rather than looping.
-  // Without this, a timing-out subagent causes the orchestrating agent to
-  // retry indefinitely (issue #4068 / #4355).
-  assert.ok(
-    templateSrc.includes("once") || templateSrc.includes("one retry") || templateSrc.match(/retry.{0,20}once/),
-    "template should cap subagent retries at one",
-  );
-  assert.ok(
-    templateSrc.toLowerCase().includes("blocker"),
-    "template should instruct writing a BLOCKER note instead of infinite retries",
-  );
-  assert.ok(
-    !templateSrc.match(/re-run it individually\s*\n/),
-    "template must not have unbounded re-run instruction without a retry cap",
-  );
-});
-
-// ─── Validate milestone prompt ────────────────────────────────────────────
-
-test("template: validate-milestone uses parallel reviewers", () => {
-  const validateSrc = readFileSync(join(__dirname, "..", "prompts", "validate-milestone.md"), "utf-8");
-  assert.ok(
-    validateSrc.includes("Reviewer A") && validateSrc.includes("Reviewer B") && validateSrc.includes("Reviewer C"),
-    "validate-milestone should dispatch 3 parallel reviewers",
-  );
-});
-
-test("resolveDispatch prefers parallel research when multiple slices are ready", async () => {
-  const base = makeTmpProject();
-
-  const action = await resolveDispatch({
-    basePath: base,
-    mid: "M001",
-    midTitle: "Parallel Research Milestone",
-    state: {
-      phase: "planning",
-      activeMilestone: { id: "M001", title: "Parallel Research Milestone", status: "active" },
-      activeSlice: { id: "S01", title: "Alpha" },
-      activeTask: null,
-      registry: [],
-      blockers: [],
-    } as any,
-    prefs: undefined,
+  beforeEach(() => {
+    base = mkdtempSync(join(tmpdir(), "parallel-research-"));
   });
 
-  assert.equal(action.action, "dispatch");
-  if (action.action === "dispatch") {
-    assert.equal(action.unitType, "research-slice");
-    assert.equal(action.unitId, "M001/parallel-research");
-  }
+  afterEach(() => {
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  test("dispatches parallel research when 2+ slices need research", async () => {
+    writeRoadmap(base, "M001", [
+      { id: "S01", title: "Alpha" },
+      { id: "S02", title: "Beta" },
+    ]);
+
+    const action = await resolveDispatch({
+      basePath: base,
+      mid: "M001",
+      midTitle: "Parallel Research Milestone",
+      state: baseState(),
+      prefs: undefined,
+    });
+
+    assert.equal(action.action, "dispatch");
+    if (action.action === "dispatch") {
+      assert.equal(action.unitType, "research-slice");
+      assert.equal(action.unitId, "M001/parallel-research");
+    }
+  });
+
+  test("does not dispatch parallel research with only one ready slice", async () => {
+    writeRoadmap(base, "M001", [{ id: "S01", title: "Alpha" }]);
+
+    const action = await resolveDispatch({
+      basePath: base,
+      mid: "M001",
+      midTitle: "Parallel Research Milestone",
+      state: baseState(),
+      prefs: undefined,
+    });
+
+    if (action.action === "dispatch") {
+      assert.notEqual(action.unitId, "M001/parallel-research");
+    }
+  });
+
+  test("does not dispatch parallel research when skip_research is set", async () => {
+    writeRoadmap(base, "M001", [
+      { id: "S01", title: "Alpha" },
+      { id: "S02", title: "Beta" },
+    ]);
+
+    const action = await resolveDispatch({
+      basePath: base,
+      mid: "M001",
+      midTitle: "Parallel Research Milestone",
+      state: baseState(),
+      prefs: { phases: { skip_research: true } } as never,
+    });
+
+    if (action.action === "dispatch") {
+      assert.notEqual(action.unitId, "M001/parallel-research");
+    }
+  });
+
+  test("does not dispatch parallel research when skip_slice_research is set", async () => {
+    writeRoadmap(base, "M001", [
+      { id: "S01", title: "Alpha" },
+      { id: "S02", title: "Beta" },
+    ]);
+
+    const action = await resolveDispatch({
+      basePath: base,
+      mid: "M001",
+      midTitle: "Parallel Research Milestone",
+      state: baseState(),
+      prefs: { phases: { skip_slice_research: true } } as never,
+    });
+
+    if (action.action === "dispatch") {
+      assert.notEqual(action.unitId, "M001/parallel-research");
+    }
+  });
+
+  test("does not dispatch when a PARALLEL-BLOCKER placeholder exists (#4414)", async () => {
+    writeRoadmap(base, "M001", [
+      { id: "S01", title: "Alpha" },
+      { id: "S02", title: "Beta" },
+    ]);
+    const milestoneDir = join(base, ".gsd", "milestones", "M001");
+    writeFileSync(
+      join(milestoneDir, "M001-PARALLEL-BLOCKER.md"),
+      "# Parallel research escalated\nPrevious dispatch failed; need per-slice fallback.\n",
+      "utf-8",
+    );
+
+    const action = await resolveDispatch({
+      basePath: base,
+      mid: "M001",
+      midTitle: "Parallel Research Milestone",
+      state: baseState(),
+      prefs: undefined,
+    });
+
+    if (action.action === "dispatch") {
+      assert.notEqual(action.unitId, "M001/parallel-research");
+    }
+  });
+
+  test("excludes slices that already have a RESEARCH file (falls back to <2)", async () => {
+    writeRoadmap(base, "M001", [
+      { id: "S01", title: "Alpha" },
+      { id: "S02", title: "Beta" },
+    ]);
+    // S01 already has research → only S02 remains → <2 ready → no parallel dispatch
+    const s01Dir = join(base, ".gsd", "milestones", "M001", "slices", "S01");
+    mkdirSync(s01Dir, { recursive: true });
+    writeFileSync(
+      join(s01Dir, "S01-RESEARCH.md"),
+      "# Research\n",
+      "utf-8",
+    );
+
+    const action = await resolveDispatch({
+      basePath: base,
+      mid: "M001",
+      midTitle: "Parallel Research Milestone",
+      state: baseState(),
+      prefs: undefined,
+    });
+
+    if (action.action === "dispatch") {
+      assert.notEqual(action.unitId, "M001/parallel-research");
+    }
+  });
+});
+
+describe("buildParallelResearchSlicesPrompt", () => {
+  let base: string;
+
+  beforeEach(() => {
+    base = mkdtempSync(join(tmpdir(), "parallel-research-prompt-"));
+    mkdirSync(join(base, ".gsd", "milestones", "M001"), { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  test("renders slice count and every slice title into the prompt", async () => {
+    const prompt = await buildParallelResearchSlicesPrompt(
+      "M001",
+      "Parallel Research Milestone",
+      [
+        { id: "S01", title: "Alpha slice title" },
+        { id: "S02", title: "Beta slice title" },
+        { id: "S03", title: "Gamma slice title" },
+      ],
+      base,
+    );
+
+    assert.match(prompt, /3/, "prompt should include slice count 3");
+    assert.match(prompt, /Alpha slice title/);
+    assert.match(prompt, /Beta slice title/);
+    assert.match(prompt, /Gamma slice title/);
+  });
+
+  test("#4068: prompt caps subagent retries at one and instructs writing a BLOCKER on second failure", async () => {
+    // Regression for infinite-retry loop (#4068 / #4355 / #4570). A correct
+    // fix must both cap retries AND instruct the agent to escalate to a
+    // BLOCKER note on the second failure.
+    const prompt = await buildParallelResearchSlicesPrompt(
+      "M001",
+      "Parallel Research Milestone",
+      [
+        { id: "S01", title: "Alpha" },
+        { id: "S02", title: "Beta" },
+      ],
+      base,
+    );
+
+    // Cap: the rendered prompt must bound retries. The exact phrasing
+    // can drift; the semantic requirement is "retry at most once".
+    assert.match(
+      prompt,
+      /\bonce\b|one retry|retry.{0,30}once/i,
+      "rendered prompt should cap retries to one",
+    );
+
+    // Escalation: on second failure the agent must write a BLOCKER
+    // rather than loop.
+    assert.match(
+      prompt,
+      /blocker/i,
+      "rendered prompt should instruct writing a BLOCKER on repeated failure",
+    );
+
+    // Anti-pattern: the unbounded "re-run it individually" instruction
+    // that caused the original infinite loop must not appear on its own.
+    // (It is allowed when paired with a retry bound — e.g.
+    // "retry it **once** individually" — so match the unbounded form
+    // explicitly.)
+    assert.doesNotMatch(
+      prompt,
+      /re-run it individually(?!.*\bonce\b)/i,
+      "rendered prompt must not contain the unbounded re-run instruction",
+    );
+  });
 });

--- a/src/resources/extensions/gsd/tests/parallel-research-dispatch.test.ts
+++ b/src/resources/extensions/gsd/tests/parallel-research-dispatch.test.ts
@@ -11,7 +11,7 @@
  * replaced.
  */
 
-import { describe, test, beforeEach, afterEach } from "node:test";
+import { describe, test, beforeEach, afterEach, after } from "node:test";
 import assert from "node:assert/strict";
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
@@ -23,9 +23,21 @@ import { tmpdir } from "node:os";
 // ~/.gsd/ copy (which may be a stale cached version from a prior
 // install — see #4784 fallout). Static imports above are hoisted, so
 // `tmpdir` and `join` are already available at this point; the dynamic
-// imports below observe the value we set here.
+// imports below observe the value we set here. The previous value is
+// captured and restored in an after() hook to avoid leaking module-scope
+// env mutation into other suites if the runner ever moves to a shared
+// process model.
+const previousGsdHome = process.env.GSD_HOME;
 process.env.GSD_HOME = process.env.GSD_HOME_TEST_OVERRIDE
   ?? join(tmpdir(), `gsd-test-home-${process.pid}-${Date.now()}`);
+
+after(() => {
+  if (previousGsdHome === undefined) {
+    delete process.env.GSD_HOME;
+  } else {
+    process.env.GSD_HOME = previousGsdHome;
+  }
+});
 
 const { resolveDispatch } = await import("../auto-dispatch.ts");
 const { buildParallelResearchSlicesPrompt } = await import("../auto-prompts.ts");
@@ -65,9 +77,10 @@ function writeRoadmap(
 
 function assertNotParallelResearchDispatch(
   action: Awaited<ReturnType<typeof resolveDispatch>>,
+  mid = "M001",
 ): void {
   if (action.action === "dispatch") {
-    assert.notEqual(action.unitId, "M001/parallel-research");
+    assert.notEqual(action.unitId, `${mid}/parallel-research`);
   }
 }
 

--- a/src/resources/extensions/gsd/tests/parallel-research-dispatch.test.ts
+++ b/src/resources/extensions/gsd/tests/parallel-research-dispatch.test.ts
@@ -63,6 +63,14 @@ function writeRoadmap(
   );
 }
 
+function assertNotParallelResearchDispatch(
+  action: Awaited<ReturnType<typeof resolveDispatch>>,
+): void {
+  if (action.action === "dispatch") {
+    assert.notEqual(action.unitId, "M001/parallel-research");
+  }
+}
+
 function baseState(activeSliceId = "S01", activeSliceTitle = "Alpha"): DispatchState {
   return {
     phase: "planning",
@@ -117,9 +125,7 @@ describe("parallel-research-slices dispatch rule", () => {
       prefs: undefined,
     });
 
-    if (action.action === "dispatch") {
-      assert.notEqual(action.unitId, "M001/parallel-research");
-    }
+    assertNotParallelResearchDispatch(action);
   });
 
   test("does not dispatch parallel research when skip_research is set", async () => {
@@ -136,9 +142,7 @@ describe("parallel-research-slices dispatch rule", () => {
       prefs: { phases: { skip_research: true } } as never,
     });
 
-    if (action.action === "dispatch") {
-      assert.notEqual(action.unitId, "M001/parallel-research");
-    }
+    assertNotParallelResearchDispatch(action);
   });
 
   test("does not dispatch parallel research when skip_slice_research is set", async () => {
@@ -155,9 +159,7 @@ describe("parallel-research-slices dispatch rule", () => {
       prefs: { phases: { skip_slice_research: true } } as never,
     });
 
-    if (action.action === "dispatch") {
-      assert.notEqual(action.unitId, "M001/parallel-research");
-    }
+    assertNotParallelResearchDispatch(action);
   });
 
   test("does not dispatch when a PARALLEL-BLOCKER placeholder exists (#4414)", async () => {
@@ -180,9 +182,7 @@ describe("parallel-research-slices dispatch rule", () => {
       prefs: undefined,
     });
 
-    if (action.action === "dispatch") {
-      assert.notEqual(action.unitId, "M001/parallel-research");
-    }
+    assertNotParallelResearchDispatch(action);
   });
 
   test("excludes slices that already have a RESEARCH file (falls back to <2)", async () => {
@@ -207,9 +207,7 @@ describe("parallel-research-slices dispatch rule", () => {
       prefs: undefined,
     });
 
-    if (action.action === "dispatch") {
-      assert.notEqual(action.unitId, "M001/parallel-research");
-    }
+    assertNotParallelResearchDispatch(action);
   });
 });
 
@@ -257,11 +255,14 @@ describe("buildParallelResearchSlicesPrompt", () => {
       base,
     );
 
-    // Cap: the rendered prompt must bound retries. The exact phrasing
-    // can drift; the semantic requirement is "retry at most once".
+    // Cap: the rendered prompt must bound retries. "once" alone is too
+    // permissive — the word appears for unrelated reasons across a ~10KB
+    // rendered prompt — so the pattern must require retry-context
+    // pairing: either "retry ... once" within 30 chars, or the phrase
+    // "one retry", or "retry it once".
     assert.match(
       prompt,
-      /\bonce\b|one retry|retry.{0,30}once/i,
+      /\bone retry\b|retry[^.?!]{0,30}\bonce\b|retry it \*{0,2}once/i,
       "rendered prompt should cap retries to one",
     );
 

--- a/src/resources/extensions/gsd/tests/parallel-research-dispatch.test.ts
+++ b/src/resources/extensions/gsd/tests/parallel-research-dispatch.test.ts
@@ -152,7 +152,7 @@ describe("parallel-research-slices dispatch rule", () => {
       mid: "M001",
       midTitle: "Parallel Research Milestone",
       state: baseState(),
-      prefs: { phases: { skip_research: true } } as never,
+      prefs: { phases: { skip_research: true } } as Parameters<typeof resolveDispatch>[0]["prefs"],
     });
 
     assertNotParallelResearchDispatch(action);
@@ -169,7 +169,7 @@ describe("parallel-research-slices dispatch rule", () => {
       mid: "M001",
       midTitle: "Parallel Research Milestone",
       state: baseState(),
-      prefs: { phases: { skip_slice_research: true } } as never,
+      prefs: { phases: { skip_slice_research: true } } as Parameters<typeof resolveDispatch>[0]["prefs"],
     });
 
     assertNotParallelResearchDispatch(action);

--- a/src/resources/extensions/gsd/tests/parallel-research-dispatch.test.ts
+++ b/src/resources/extensions/gsd/tests/parallel-research-dispatch.test.ts
@@ -11,20 +11,21 @@
  * replaced.
  */
 
-// Point GSD_HOME at a throwaway directory *before* the prompt-loader
-// module is imported so templates resolve from the in-tree prompts/
-// directory instead of a developer's ~/.gsd/ copy (which may be a stale
-// cached version from a prior install — see #4784 fallout). Set via
-// globalThis assignment + dynamic import so the value is live at the
-// top-level of the loader module.
-process.env.GSD_HOME = process.env.GSD_HOME_TEST_OVERRIDE
-  ?? `/tmp/gsd-test-home-${process.pid}-${Date.now()}`;
-
 import { describe, test, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+
+// Point GSD_HOME at a throwaway directory *before* the prompt-loader
+// module is imported (via the dynamic imports below) so templates
+// resolve from the in-tree prompts/ directory instead of a developer's
+// ~/.gsd/ copy (which may be a stale cached version from a prior
+// install — see #4784 fallout). Static imports above are hoisted, so
+// `tmpdir` and `join` are already available at this point; the dynamic
+// imports below observe the value we set here.
+process.env.GSD_HOME = process.env.GSD_HOME_TEST_OVERRIDE
+  ?? join(tmpdir(), `gsd-test-home-${process.pid}-${Date.now()}`);
 
 const { resolveDispatch } = await import("../auto-dispatch.ts");
 const { buildParallelResearchSlicesPrompt } = await import("../auto-prompts.ts");
@@ -274,12 +275,12 @@ describe("buildParallelResearchSlicesPrompt", () => {
 
     // Anti-pattern: the unbounded "re-run it individually" instruction
     // that caused the original infinite loop must not appear on its own.
-    // (It is allowed when paired with a retry bound — e.g.
-    // "retry it **once** individually" — so match the unbounded form
-    // explicitly.)
+    // The negative lookahead is bounded to the surrounding 100
+    // characters so a later unrelated "once" elsewhere in the prompt
+    // cannot falsely satisfy the "paired with a retry bound" exception.
     assert.doesNotMatch(
       prompt,
-      /re-run it individually(?!.*\bonce\b)/i,
+      /re-run it individually(?![\s\S]{0,100}\bonce\b)/i,
       "rendered prompt must not contain the unbounded re-run instruction",
     );
   });

--- a/src/resources/extensions/gsd/tests/parallel-research-dispatch.test.ts
+++ b/src/resources/extensions/gsd/tests/parallel-research-dispatch.test.ts
@@ -235,7 +235,11 @@ describe("buildParallelResearchSlicesPrompt", () => {
       base,
     );
 
-    assert.match(prompt, /3/, "prompt should include slice count 3");
+    assert.match(
+      prompt,
+      /\b3\b[^.\n]{0,40}\bslices?\b/i,
+      "prompt should include slice count 3 in slice context",
+    );
     assert.match(prompt, /Alpha slice title/);
     assert.match(prompt, /Beta slice title/);
     assert.match(prompt, /Gamma slice title/);
@@ -267,10 +271,13 @@ describe("buildParallelResearchSlicesPrompt", () => {
     );
 
     // Escalation: on second failure the agent must write a BLOCKER
-    // rather than loop.
+    // rather than loop. Bare /blocker/i is too permissive — require
+    // retry/failure context within the same sentence so a stray
+    // "blocker" elsewhere in the ~10KB prompt cannot satisfy the
+    // assertion.
     assert.match(
       prompt,
-      /blocker/i,
+      /blocker[^.?!]{0,100}(second|retry|fail)|(second|retry|fail)[^.?!]{0,100}blocker/i,
       "rendered prompt should instruct writing a BLOCKER on repeated failure",
     );
 


### PR DESCRIPTION
Rewrites `src/resources/extensions/gsd/tests/parallel-research-dispatch.test.ts` to test behaviour by invoking real functions against fixtures, instead of readFileSync + src.includes source-grep. Adds CONTRIBUTING.md section forbidding new source-grep tests. Refs #4784.

## Summary

- 8 behaviour tests replace 10 source-grep tests
- dispatch rule: invokes resolveDispatch against fixtures, asserts DispatchAction
- prompt builder: calls buildParallelResearchSlicesPrompt, asserts on rendered output
- #4068 regression now asserts rendered prompt contains retry cap AND BLOCKER instruction
- CONTRIBUTING.md "Test behaviour, not source shape" section forbids future source-grep tests

## Bug found during development

The #4068 test initially failed because `~/.gsd/agent/extensions/gsd/prompts/parallel-research-slices.md` on a developer machine was the stale pre-#4570 770-byte version without the retry cap. The module-level prompt cache resolved it in preference to the in-tree template. The test now uses GSD_HOME override + dynamic import to isolate. A follow-up issue with full RCA on the stale-prompt propagation will be filed.

## Test plan

- [x] Local: 8/8 tests pass regardless of ~/.gsd state
- [x] Typecheck: no new errors
- [ ] CI passes
- [ ] CodeRabbit review addressed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Converted structural checks into behavior-oriented integration tests to validate end-to-end dispatch and prompt behavior.
  * Expanded coverage for parallel-dispatch rules and suppression conditions (skip flags, blockers, existing per-slice artifacts) and verified retry/escalation messaging.
  * Improved isolation and on-disk fixture setup for more reliable, realistic test scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->