### PR TITLE
refactor(auto): gate reassess-roadmap dispatch behind skip_clean_reassess preference (#4778)

### DIFF
--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -342,7 +342,7 @@ export const DISPATCH_RULES: DispatchRule[] = [
       // is essential for roadmap integrity. Opt-out via explicit `false`.
       const reassessEnabled = prefs?.phases?.reassess_after_slice ?? true;
       if (!reassessEnabled) return null;
-      const needsReassess = await checkNeedsReassessment(basePath, mid, state);
+      const needsReassess = await checkNeedsReassessment(basePath, mid, state, prefs);
       if (!needsReassess) return null;
       return {
         action: "dispatch",

--- a/src/resources/extensions/gsd/auto-prompts.ts
+++ b/src/resources/extensions/gsd/auto-prompts.ts
@@ -923,9 +923,12 @@ export async function getDependencyTaskSummaryPaths(
  * - No slices are completed
  * - The last completed slice already has an assessment file
  * - All slices are complete (milestone done — no point reassessing)
+ * - Preference `skip_clean_reassess` is true AND the slice SUMMARY signals
+ *   a structurally clean completion (see isSummaryCleanForSkip). Opt-in;
+ *   any parse ambiguity falls back to dispatch (#4778).
  */
 export async function checkNeedsReassessment(
-  base: string, mid: string, state: GSDState,
+  base: string, mid: string, state: GSDState, prefs?: GSDPreferences,
 ): Promise<{ sliceId: string } | null> {
   // DB primary path — fall through to file-based when DB has no data for this milestone
   try {
@@ -941,8 +944,9 @@ export async function checkNeedsReassessment(
         const hasAssessment = !!(assessmentFile && await loadFile(assessmentFile));
         if (hasAssessment) return null;
         const summaryFile = resolveSliceFile(base, mid, lastCompleted, "SUMMARY");
-        const hasSummary = !!(summaryFile && await loadFile(summaryFile));
-        if (!hasSummary) return null;
+        const summaryContent = summaryFile ? await loadFile(summaryFile) : null;
+        if (!summaryContent) return null;
+        if (prefs?.skip_clean_reassess && isSummaryCleanForSkip(summaryContent)) return null;
         return { sliceId: lastCompleted };
       }
     }
@@ -964,9 +968,64 @@ export async function checkNeedsReassessment(
   const hasAssess = !!(assessFile && await loadFile(assessFile));
   if (hasAssess) return null;
   const summFile = resolveSliceFile(base, mid, lastDone, "SUMMARY");
-  const hasSumm = !!(summFile && await loadFile(summFile));
-  if (!hasSumm) return null;
+  const summContent = summFile ? await loadFile(summFile) : null;
+  if (!summContent) return null;
+  if (prefs?.skip_clean_reassess && isSummaryCleanForSkip(summContent)) return null;
   return { sliceId: lastDone };
+}
+
+/**
+ * Return true when a slice SUMMARY signals a structurally clean completion
+ * that makes reassess-roadmap dispatch unnecessary. Gated behind the
+ * `skip_clean_reassess` preference — default behavior preserves today's
+ * always-dispatch. Conservative: returns false on any parse ambiguity.
+ *
+ * Clean requires ALL of:
+ *  - frontmatter `blocker_discovered` is false/absent
+ *  - frontmatter `key_decisions` empty or the sentinel "(none)"
+ *  - body contains no roadmap-change markers
+ *
+ * Body markers are matched as case-insensitive substrings. This is
+ * intentionally unconditional: negation phrases like "no scope expansion
+ * was required" will also mark the summary dirty and dispatch. That's the
+ * safe direction — over-dispatch costs a unit, missed dispatch risks a
+ * stale roadmap. If the marker list needs to grow, add conservative
+ * synonyms only; anything ambiguous should err toward dispatch.
+ */
+export function isSummaryCleanForSkip(content: string): boolean {
+  try {
+    const summary = parseSummary(content);
+    // Require a recognizable summary — empty/garbage content parses to an
+    // empty frontmatter, which must not count as "clean".
+    if (!summary.frontmatter.id) return false;
+    if (summary.frontmatter.blocker_discovered === true) return false;
+
+    const decisions = (summary.frontmatter.key_decisions ?? [])
+      .map(d => d.trim())
+      .filter(d => d.length > 0 && d.toLowerCase() !== "(none)");
+    if (decisions.length > 0) return false;
+
+    const ROADMAP_CHANGE_MARKERS = [
+      "add slice",
+      "added slice",
+      "remove slice",
+      "removed slice",
+      "new slice",
+      "scope expansion",
+      "scope change",
+      "scope widened",
+      "dependency discovered",
+      "added dependency",
+      "new dependency",
+    ];
+    const haystack = content.toLowerCase();
+    for (const marker of ROADMAP_CHANGE_MARKERS) {
+      if (haystack.includes(marker)) return false;
+    }
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 /**

--- a/src/resources/extensions/gsd/preferences-types.ts
+++ b/src/resources/extensions/gsd/preferences-types.ts
@@ -103,6 +103,7 @@ export const KNOWN_PREFERENCE_KEYS = new Set<string>([
   "skill_staleness_days",
   "auto_supervisor",
   "uat_dispatch",
+  "skip_clean_reassess",
   "unique_milestone_ids",
   "budget_ceiling",
   "budget_enforcement",
@@ -309,6 +310,13 @@ export interface GSDPreferences {
   skill_staleness_days?: number;  // Skills unused for N days get deprioritized (#599). 0 = disabled. Default: 60.
   auto_supervisor?: AutoSupervisorConfig;
   uat_dispatch?: boolean;
+  /**
+   * When true, skip the reassess-roadmap unit after a slice whose SUMMARY
+   * shows no blockers, no key decisions, and no roadmap-change markers in
+   * the body. Opt-in — default false preserves current always-dispatch
+   * behavior. Conservative: any parse ambiguity falls back to dispatch.
+   */
+  skip_clean_reassess?: boolean;
   unique_milestone_ids?: boolean;
   budget_ceiling?: number;
   budget_enforcement?: BudgetEnforcementMode;

--- a/src/resources/extensions/gsd/preferences.ts
+++ b/src/resources/extensions/gsd/preferences.ts
@@ -359,6 +359,7 @@ function mergePreferences(base: GSDPreferences, override: GSDPreferences): GSDPr
     skill_staleness_days: override.skill_staleness_days ?? base.skill_staleness_days,
     auto_supervisor: { ...(base.auto_supervisor ?? {}), ...(override.auto_supervisor ?? {}) },
     uat_dispatch: override.uat_dispatch ?? base.uat_dispatch,
+    skip_clean_reassess: override.skip_clean_reassess ?? base.skip_clean_reassess,
     unique_milestone_ids: override.unique_milestone_ids ?? base.unique_milestone_ids,
     budget_ceiling: override.budget_ceiling ?? base.budget_ceiling,
     budget_enforcement: override.budget_enforcement ?? base.budget_enforcement,

--- a/src/resources/extensions/gsd/tests/prefs-wizard-coverage.test.ts
+++ b/src/resources/extensions/gsd/tests/prefs-wizard-coverage.test.ts
@@ -16,6 +16,7 @@ const EXPOSED_OUTSIDE_WIZARD = new Set<string>([
   "version",          // auto-managed by writePreferencesFile
   "modelOverrides",   // advanced routing — edit PREFERENCES.md directly (not in KNOWN_PREFERENCE_KEYS)
   "context_mode",     // advanced sandbox config (gsd_exec + compaction) — enabled by default; edit PREFERENCES.md directly to tune timeouts/caps. Wizard coverage tracked separately.
+  "skip_clean_reassess", // opt-in power-user performance tuning (#4778) — skips reassess-roadmap dispatch when slice SUMMARY signals clean completion. Deliberately kept out of the wizard so novice users stay on safe defaults; power users edit PREFERENCES.md directly. Overlaps with ADR-003 §4's `phases.reassess_after_slice` — to be reconciled in a follow-up.
 ]);
 
 test("every KNOWN_PREFERENCE_KEYS entry is reachable from the wizard source", () => {

--- a/src/resources/extensions/gsd/tests/reassess-detection.test.ts
+++ b/src/resources/extensions/gsd/tests/reassess-detection.test.ts
@@ -5,9 +5,10 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { randomUUID } from "node:crypto";
 
-import { checkNeedsReassessment } from "../auto-prompts.ts";
+import { checkNeedsReassessment, isSummaryCleanForSkip } from "../auto-prompts.ts";
 import { invalidateAllCaches } from "../cache.ts";
 import type { GSDState } from "../types.ts";
+import type { GSDPreferences } from "../preferences-types.ts";
 
 function makeTmpBase(): string {
   const base = join(tmpdir(), `gsd-test-reassess-${randomUUID()}`);
@@ -28,6 +29,54 @@ function writeSummary(base: string, sid: string): void {
   writeFileSync(
     join(base, ".gsd", "milestones", "M001", "slices", sid, `${sid}-SUMMARY.md`),
     `---\nid: ${sid}\n---\n# ${sid} Summary\nDone.`,
+  );
+}
+
+function writeCleanSummary(base: string, sid: string): void {
+  writeFileSync(
+    join(base, ".gsd", "milestones", "M001", "slices", sid, `${sid}-SUMMARY.md`),
+    `---
+id: ${sid}
+parent: M001
+milestone: M001
+key_decisions:
+  - (none)
+verification_result: passed
+blocker_discovered: false
+---
+
+# ${sid}: Clean
+
+**One-liner.**
+
+## What Happened
+
+Nothing structural changed.
+`,
+  );
+}
+
+function writeDirtySummary(base: string, sid: string, body: string): void {
+  writeFileSync(
+    join(base, ".gsd", "milestones", "M001", "slices", sid, `${sid}-SUMMARY.md`),
+    `---
+id: ${sid}
+parent: M001
+milestone: M001
+key_decisions:
+  - (none)
+verification_result: passed
+blocker_discovered: false
+---
+
+# ${sid}: Dirty
+
+**One-liner.**
+
+## What Happened
+
+${body}
+`,
   );
 }
 
@@ -151,4 +200,101 @@ test("checkNeedsReassessment returns null when all slices are complete", async (
   } finally {
     cleanup(base);
   }
+});
+
+// ─── #4778: skip_clean_reassess preference gate ──────────────────────────
+
+const prefsOptIn: GSDPreferences = { skip_clean_reassess: true };
+const prefsOptOut: GSDPreferences = {};
+
+test("#4778 skips reassessment when preference is on and summary is clean", async () => {
+  const base = makeTmpBase();
+  try {
+    invalidateAllCaches();
+    writeRoadmap(base, ROADMAP_S01_DONE_S02_TODO);
+    writeCleanSummary(base, "S01");
+
+    const result = await checkNeedsReassessment(base, "M001", dummyState, prefsOptIn);
+    assert.strictEqual(result, null, "clean summary + opt-in → skip");
+  } finally {
+    cleanup(base);
+  }
+});
+
+test("#4778 dispatches when preference is off even on clean summary (default)", async () => {
+  const base = makeTmpBase();
+  try {
+    invalidateAllCaches();
+    writeRoadmap(base, ROADMAP_S01_DONE_S02_TODO);
+    writeCleanSummary(base, "S01");
+
+    const result = await checkNeedsReassessment(base, "M001", dummyState, prefsOptOut);
+    assert.deepStrictEqual(result, { sliceId: "S01" }, "opt-out (default) → always dispatch");
+  } finally {
+    cleanup(base);
+  }
+});
+
+test("#4778 dispatches when body contains roadmap-change marker despite opt-in", async () => {
+  const base = makeTmpBase();
+  try {
+    invalidateAllCaches();
+    writeRoadmap(base, ROADMAP_S01_DONE_S02_TODO);
+    writeDirtySummary(base, "S01", "During work we should add slice for a follow-up API.");
+
+    const result = await checkNeedsReassessment(base, "M001", dummyState, prefsOptIn);
+    assert.deepStrictEqual(result, { sliceId: "S01" }, "roadmap-change marker → dispatch");
+  } finally {
+    cleanup(base);
+  }
+});
+
+test("#4778 dispatches when blocker_discovered is true", async () => {
+  const base = makeTmpBase();
+  try {
+    invalidateAllCaches();
+    writeRoadmap(base, ROADMAP_S01_DONE_S02_TODO);
+    writeFileSync(
+      join(base, ".gsd", "milestones", "M001", "slices", "S01", "S01-SUMMARY.md"),
+      `---\nid: S01\nparent: M001\nmilestone: M001\nkey_decisions:\n  - (none)\nverification_result: passed\nblocker_discovered: true\n---\n\n# S01: Blocked\n\n**One-liner.**\n\n## What Happened\n\nHit a blocker.\n`,
+    );
+
+    const result = await checkNeedsReassessment(base, "M001", dummyState, prefsOptIn);
+    assert.deepStrictEqual(result, { sliceId: "S01" }, "blocker_discovered=true → dispatch");
+  } finally {
+    cleanup(base);
+  }
+});
+
+test("#4778 dispatches when key_decisions is non-empty", async () => {
+  const base = makeTmpBase();
+  try {
+    invalidateAllCaches();
+    writeRoadmap(base, ROADMAP_S01_DONE_S02_TODO);
+    writeFileSync(
+      join(base, ".gsd", "milestones", "M001", "slices", "S01", "S01-SUMMARY.md"),
+      `---\nid: S01\nparent: M001\nmilestone: M001\nkey_decisions:\n  - chose SQLite over Postgres for local storage\nverification_result: passed\nblocker_discovered: false\n---\n\n# S01: Decided\n\n**One-liner.**\n\n## What Happened\n\nMade a cross-slice decision.\n`,
+    );
+
+    const result = await checkNeedsReassessment(base, "M001", dummyState, prefsOptIn);
+    assert.deepStrictEqual(result, { sliceId: "S01" }, "non-empty key_decisions → dispatch");
+  } finally {
+    cleanup(base);
+  }
+});
+
+// ─── isSummaryCleanForSkip unit tests ────────────────────────────────────
+
+test("isSummaryCleanForSkip: clean summary → true", () => {
+  const content = `---\nid: S01\nparent: M001\nmilestone: M001\nkey_decisions:\n  - (none)\nblocker_discovered: false\n---\n\n# S01\n\n**x.**\n\n## What Happened\n\nclean.\n`;
+  assert.strictEqual(isSummaryCleanForSkip(content), true);
+});
+
+test("isSummaryCleanForSkip: 'dependency discovered' marker → false", () => {
+  const content = `---\nid: S01\nparent: M001\nmilestone: M001\nkey_decisions:\n  - (none)\nblocker_discovered: false\n---\n\n# S01\n\n**x.**\n\n## What Happened\n\nA new dependency discovered between S03 and S05.\n`;
+  assert.strictEqual(isSummaryCleanForSkip(content), false);
+});
+
+test("isSummaryCleanForSkip: garbage input → false (conservative)", () => {
+  assert.strictEqual(isSummaryCleanForSkip(""), false);
 });


### PR DESCRIPTION
## TL;DR

**What:** Add opt-in `skip_clean_reassess` preference that suppresses `reassess-roadmap` dispatch after a structurally clean slice completion.
**Why:** On small milestones, `reassess-roadmap` fires after every slice even when nothing changed — ~$0.18 and ~125K cached tokens per no-op dispatch (see #4778).
**How:** Gate the existing `checkNeedsReassessment` with a new `isSummaryCleanForSkip(SUMMARY)` check, driven by a preference flag. Default off → behavior unchanged.

## What

- `src/resources/extensions/gsd/preferences-types.ts` — add `skip_clean_reassess?: boolean` to `GSDPreferences` and `KNOWN_PREFERENCE_KEYS`
- `src/resources/extensions/gsd/preferences.ts` — merge support in `mergePreferences`
- `src/resources/extensions/gsd/auto-prompts.ts` — `checkNeedsReassessment` accepts `prefs`; new exported `isSummaryCleanForSkip(content)` helper
- `src/resources/extensions/gsd/auto-dispatch.ts` — thread `prefs` into the call site
- `src/resources/extensions/gsd/tests/reassess-detection.test.ts` — 8 new regression cases

## Why

Closes #4778.

Forensic session data in the issue showed 2 of 16 auto-mode units were no-op `reassess-roadmap` dispatches — empty `sliceChanges` and clean verdicts, pure overhead. The original RFC proposed guarding on the post-reassess `ASSESSMENT.md`; the issue comment corrects that (ASSESSMENT is the unit's output, not an input). The corrected signal lives in the slice `SUMMARY.md`, which exists before the reassess unit runs.

## How

`isSummaryCleanForSkip` returns `true` only when **all** hold:

1. Frontmatter `id` present (guards empty/garbage content)
2. Frontmatter `blocker_discovered` is false/absent
3. Frontmatter `key_decisions` is empty or only the `(none)` sentinel
4. Body contains none of (case-insensitive substring):
   `add slice`, `added slice`, `remove slice`, `removed slice`, `new slice`, `scope expansion`, `scope change`, `scope widened`, `dependency discovered`, `added dependency`, `new dependency`

Conservative by construction: any parse exception, missing fields, or marker match → dispatch. Negation phrases like "no scope expansion required" also dispatch — intentional, the safe direction (over-dispatch costs a unit; missed dispatch risks a stale roadmap). Documented in the JSDoc.

**Opt-in default** preserves today's behavior for everyone who doesn't set the preference. Users enable it in `.gsd/PREFERENCES.md`:

```yaml
skip_clean_reassess: true
```

Peer-reviewed via codex; concerns addressed (synonym markers added; negation-phrase tradeoff documented).

### Change type checklist

- [x] `refactor` — Behavior change under opt-in preference, no structural change to dispatch pipeline

### Tests

- 13/13 tests pass in `reassess-detection.test.ts` (5 existing + 8 new)
- 83 preferences tests unaffected
- Full `tsc --noEmit` clean

Stopgap per the issue — permanent answer is the `UnitContextManifest` architecture (#4782) where `skipWhen` predicates become declarative per unit type.

Closes #4778

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional preference to skip roadmap reassessment when a completed slice’s summary is confirmed clean (no blockers, no key decisions, no roadmap-change markers).
  * Reassessment logic now respects that preference and conditionally suppresses dispatch when summaries are deterministically clean.

* **Tests**
  * Added unit tests covering the new preference gate and summary-clean detection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->