### PR TITLE
feat(db): add external wait schema, types, and state tracking

### DIFF
--- a/src/resources/extensions/gsd/auto-dashboard.ts
+++ b/src/resources/extensions/gsd/auto-dashboard.ts
@@ -184,7 +184,7 @@ export function describeNextUnit(state: GSDState): { label: string; description:
     case "evaluating-gates":
       return { label: `Evaluate gates for ${sid}: ${sTitle}`, description: "Parallel quality gate assessment before execution." };
     case "awaiting-external":
-      return { label: `Awaiting external process for ${tid}: ${tTitle}`, description: "Task is waiting on an external job; probe will check status." };
+      return { label: `Awaiting external process for ${tid ?? "unknown"}: ${tTitle ?? "unknown task"}`, description: "Task is waiting on an external job; probe will check status." };
     default:
       return { label: "Continue", description: "Execute the next step." };
   }

--- a/src/resources/extensions/gsd/auto-dashboard.ts
+++ b/src/resources/extensions/gsd/auto-dashboard.ts
@@ -183,6 +183,8 @@ export function describeNextUnit(state: GSDState): { label: string; description:
       return { label: "Complete milestone", description: "Write milestone summary." };
     case "evaluating-gates":
       return { label: `Evaluate gates for ${sid}: ${sTitle}`, description: "Parallel quality gate assessment before execution." };
+    case "awaiting-external":
+      return { label: `Awaiting external process for ${tid}: ${tTitle}`, description: "Task is waiting on an external job; probe will check status." };
     default:
       return { label: "Continue", description: "Execute the next step." };
   }

--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -830,7 +830,7 @@ export const DISPATCH_RULES: DispatchRule[] = [
 
         try { appendFileSync(logPath, JSON.stringify({ ts: new Date().toISOString(), event: "probe", command: pollWhileCommand, exitCode, stdout: stdout.slice(0, 500), killed }) + "\n"); } catch (logErr) { logWarning("dispatch", `Failed to write external wait log: ${logErr instanceof Error ? logErr.message : String(logErr)}`); }
 
-        if (killed) {
+        if (killed || exitCode === null) {
           incrementProbeFailureCount(mid, sid, tid);
           const updated = getExternalWait(mid, sid, tid);
           if (updated && (updated.probe_failure_count as number) >= 3) {
@@ -839,7 +839,9 @@ export const DISPATCH_RULES: DispatchRule[] = [
             invalidateStateCache();
             return {
               action: "stop" as const,
-              reason: `Probe for ${tid} timed out 3 times. Escalating to manual attention.`,
+              reason: killed
+                ? `Probe for ${tid} timed out 3 times. Escalating to manual attention.`
+                : `Probe for ${tid} failed to invoke 3 times. Escalating to manual attention.`,
               level: "warning" as const,
             };
           }
@@ -859,13 +861,40 @@ export const DISPATCH_RULES: DispatchRule[] = [
 
         if (successCheck) {
           try {
-            const scResult = await new Promise<{ exitCode: number | null; stdout: string; stderr: string }>((resolve) => {
+            const scResult = await new Promise<{ exitCode: number | null; killed: boolean; stdout: string; stderr: string; invokeError?: string }>((resolve) => {
               exec(successCheck, { timeout: 30000, shell: probeShell }, (err, scStdout, scStderr) => {
-                if (err) resolve({ exitCode: (err as any).code ?? 1, stdout: scStdout || "", stderr: scStderr || "" });
-                else resolve({ exitCode: 0, stdout: scStdout || "", stderr: scStderr || "" });
+                if (err) {
+                  const errCode = (err as any).code;
+                  const isInvocationFailure = errCode == null || (typeof errCode === "string");
+                  resolve({
+                    exitCode: typeof errCode === "number" ? errCode : null,
+                    killed: !!(err as any).killed,
+                    stdout: scStdout || "",
+                    stderr: scStderr || "",
+                    invokeError: isInvocationFailure ? (err.message || String(err)) : undefined,
+                  });
+                } else {
+                  resolve({ exitCode: 0, killed: false, stdout: scStdout || "", stderr: scStderr || "" });
+                }
               });
             });
-            try { appendFileSync(logPath, JSON.stringify({ ts: new Date().toISOString(), event: "successCheck", exitCode: scResult.exitCode, stdout: scResult.stdout.slice(0, 500) }) + "\n"); } catch (logErr) { logWarning("dispatch", `Failed to write external wait log: ${logErr instanceof Error ? logErr.message : String(logErr)}`); }
+            try { appendFileSync(logPath, JSON.stringify({ ts: new Date().toISOString(), event: "successCheck", exitCode: scResult.exitCode, stdout: scResult.stdout.slice(0, 500), invokeError: scResult.invokeError }) + "\n"); } catch (logErr) { logWarning("dispatch", `Failed to write external wait log: ${logErr instanceof Error ? logErr.message : String(logErr)}`); }
+            if (scResult.invokeError) {
+              // Invocation failure (missing binary, shell error) — treat as probe failure, don't resolve the wait
+              incrementProbeFailureCount(mid, sid, tid);
+              const updated = getExternalWait(mid, sid, tid);
+              if (updated && (updated.probe_failure_count as number) >= 3) {
+                updateTaskStatus(mid, sid, tid, "manual-attention");
+                updateExternalWaitStatus(mid, sid, tid, "timed-out");
+                invalidateStateCache();
+                return {
+                  action: "stop" as const,
+                  reason: `Success check for ${tid} failed to invoke 3 times: ${scResult.invokeError}. Escalating to manual attention.`,
+                  level: "warning" as const,
+                };
+              }
+              return { action: "sleep" as const, durationMs: computeMinPoll(), matchedRule: "awaiting-external → probe" };
+            }
             if (scResult.exitCode !== 0) {
               jobSucceeded = false;
               failureContext = `Exit code: ${scResult.exitCode}\nStderr: ${scResult.stderr.slice(0, 1000)}`;

--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -821,7 +821,8 @@ export const DISPATCH_RULES: DispatchRule[] = [
         const { exitCode, killed, stdout } = await new Promise<{ exitCode: number | null; killed: boolean; stdout: string }>((resolve) => {
           exec(pollWhileCommand, { timeout: probeTimeoutMs, shell: probeShell }, (err, stdout, _stderr) => {
             if (err) {
-              resolve({ exitCode: (err as any).code ?? null, killed: !!(err as any).killed, stdout: stdout || "" });
+              const rawCode = (err as any).code;
+              resolve({ exitCode: typeof rawCode === "number" ? rawCode : null, killed: !!(err as any).killed, stdout: stdout || "" });
             } else {
               resolve({ exitCode: 0, killed: false, stdout: stdout || "" });
             }

--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -14,7 +14,9 @@ import type { GSDPreferences } from "./preferences.js";
 import type { UatType } from "./files.js";
 import type { MinimalModelRegistry } from "./context-budget.js";
 import { loadFile, extractUatType, loadActiveOverrides } from "./files.js";
-import { isDbAvailable, getMilestoneSlices, getPendingGates, markAllGatesOmitted, getMilestone, updateMilestoneStatus } from "./gsd-db.js";
+import { isDbAvailable, getMilestoneSlices, getPendingGates, markAllGatesOmitted, getMilestone, updateMilestoneStatus, getExternalWait, incrementProbeFailureCount, updateExternalWaitStatus, resetProbeFailureCount, getAllWaitingExternalWaits, updateTaskStatus } from "./gsd-db.js";
+import { exec } from "node:child_process";
+import { invalidateStateCache } from "./state.js";
 import { isClosedStatus } from "./status-guards.js";
 import { extractVerdict, isAcceptableUatVerdict } from "./verdict-parser.js";
 
@@ -30,7 +32,12 @@ import {
   buildSliceFileName,
 } from "./paths.js";
 import { parseRoadmap } from "./parsers-legacy.js";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync, appendFileSync } from "node:fs";
+
+/** Platform-appropriate shell for probe commands. Unix → /bin/sh, Windows → %COMSPEC% or cmd.exe. */
+const probeShell = process.platform === "win32"
+  ? (process.env.COMSPEC || "cmd.exe")
+  : "/bin/sh";
 import { logWarning, logError } from "./workflow-logger.js";
 import { join } from "node:path";
 import { hasImplementationArtifacts } from "./auto-recovery.js";
@@ -75,7 +82,8 @@ export type DispatchAction =
       matchedRule?: string;
     }
   | { action: "stop"; reason: string; level: "info" | "warning" | "error"; matchedRule?: string }
-  | { action: "skip"; matchedRule?: string };
+  | { action: "skip"; matchedRule?: string }
+  | { action: "sleep"; durationMs: number; matchedRule?: string };
 
 export interface DispatchContext {
   basePath: string;
@@ -732,6 +740,174 @@ export const DISPATCH_RULES: DispatchRule[] = [
           basePath,
         ),
       };
+    },
+  },
+  {
+    name: "awaiting-external → probe",
+    match: async (ctx) => {
+      const { state, mid, basePath } = ctx;
+      if (state.phase !== "awaiting-external") return null;
+      if (!state.activeTask || !state.activeSlice) return null;
+
+      const sid = state.activeSlice.id;
+      const tid = state.activeTask.id;
+      const waitRow = getExternalWait(mid, sid, tid);
+
+      if (!waitRow) {
+        return {
+          action: "stop" as const,
+          reason: `Task ${tid} has status "awaiting-external" but no external_waits record. Run /gsd doctor to diagnose.`,
+          level: "warning" as const,
+        };
+      }
+
+      const pollWhileCommand = waitRow.poll_while_command as string;
+      const pollIntervalMs = (waitRow.poll_interval_ms as number) || 60000;
+      const slicePath = resolveSlicePath(basePath, mid, sid);
+      if (!slicePath) {
+        logWarning("dispatch", `Cannot resolve slice path for ${mid}/${sid} — escalating ${tid} to manual attention.`);
+        updateTaskStatus(mid, sid, tid, "manual-attention");
+        updateExternalWaitStatus(mid, sid, tid, "timed-out");
+        invalidateStateCache();
+        return { action: "stop" as const, reason: `Cannot resolve slice path for ${mid}/${sid}/${tid}. Escalating to manual attention.`, level: "warning" as const };
+      }
+      const tasksDir = join(slicePath, "tasks");
+      const logPath = join(tasksDir, `${tid}-EXTERNAL-WAIT.log`);
+
+      // ── Timeout check (before probe execution) ────────────────────
+      const registeredAt = waitRow.registered_at as string;
+      const timeoutMs = (waitRow.timeout_ms as number) || 86400000;
+      if (Date.now() > Date.parse(registeredAt) + timeoutMs) {
+        const onTimeout = (waitRow.on_timeout as string) || "manual-attention";
+        updateExternalWaitStatus(mid, sid, tid, "timed-out");
+        try { appendFileSync(logPath, JSON.stringify({ ts: new Date().toISOString(), event: "timeout", registeredAt, timeoutMs, onTimeout }) + "\n"); } catch (logErr) { logWarning("dispatch", `Failed to write external wait log: ${logErr instanceof Error ? logErr.message : String(logErr)}`); }
+
+        if (onTimeout === "resume-with-failure") {
+          updateTaskStatus(mid, sid, tid, "executing");
+          invalidateStateCache();
+          const contextHint = (waitRow.context_hint as string) || "";
+          if (ctx.session) {
+            ctx.session.pendingExternalResume = `**EXTERNAL WAIT TIMED OUT — RESUMING WITH FAILURE**\n\nThe external process timed out after ${timeoutMs}ms (registered ${registeredAt}).${contextHint ? `\n\nContext from registration: ${contextHint}` : ""}\n\nThe onTimeout policy is "resume-with-failure" — investigate the timeout, adjust parameters if needed, and either retry or escalate.`;
+          }
+          return { action: "skip" as const };
+        }
+
+        // Default: manual-attention
+        updateTaskStatus(mid, sid, tid, "manual-attention");
+        invalidateStateCache();
+        return { action: "stop" as const, reason: `External wait for ${tid} timed out (registered ${registeredAt}, timeout ${timeoutMs}ms). Escalating to manual attention.`, level: "warning" as const };
+      }
+
+      // ── JSON probe spec existence check (R228) ────────────────────
+      const probeSpecPath = join(tasksDir, `${tid}-EXTERNAL-WAIT.json`);
+      if (!existsSync(probeSpecPath)) {
+        updateTaskStatus(mid, sid, tid, "manual-attention");
+        updateExternalWaitStatus(mid, sid, tid, "timed-out");
+        invalidateStateCache();
+        return { action: "stop" as const, reason: `Task ${tid} has external_waits DB row but no ${tid}-EXTERNAL-WAIT.json probe spec. Escalating to manual attention.`, level: "warning" as const };
+      }
+
+      // ── Helper: compute min pollInterval across all waiting waits ──
+      const computeMinPoll = (): number => {
+        const allWaiting = getAllWaitingExternalWaits(mid);
+        const candidate = allWaiting.length > 0
+          ? Math.min(...allWaiting.map(w => (w.poll_interval_ms as number) || 60000))
+          : pollIntervalMs;
+        return Math.max(1000, candidate);
+      };
+
+      const probeTimeoutMs = Math.max(30000, Math.min(pollIntervalMs, 120000));
+      try {
+        const { exitCode, killed, stdout } = await new Promise<{ exitCode: number | null; killed: boolean; stdout: string }>((resolve) => {
+          exec(pollWhileCommand, { timeout: probeTimeoutMs, shell: probeShell }, (err, stdout, _stderr) => {
+            if (err) {
+              resolve({ exitCode: (err as any).code ?? null, killed: !!(err as any).killed, stdout: stdout || "" });
+            } else {
+              resolve({ exitCode: 0, killed: false, stdout: stdout || "" });
+            }
+          });
+        });
+
+        try { appendFileSync(logPath, JSON.stringify({ ts: new Date().toISOString(), event: "probe", command: pollWhileCommand, exitCode, stdout: stdout.slice(0, 500), killed }) + "\n"); } catch (logErr) { logWarning("dispatch", `Failed to write external wait log: ${logErr instanceof Error ? logErr.message : String(logErr)}`); }
+
+        if (killed) {
+          incrementProbeFailureCount(mid, sid, tid);
+          const updated = getExternalWait(mid, sid, tid);
+          if (updated && (updated.probe_failure_count as number) >= 3) {
+            updateTaskStatus(mid, sid, tid, "manual-attention");
+            updateExternalWaitStatus(mid, sid, tid, "timed-out");
+            invalidateStateCache();
+            return {
+              action: "stop" as const,
+              reason: `Probe for ${tid} timed out 3 times. Escalating to manual attention.`,
+              level: "warning" as const,
+            };
+          }
+          return { action: "sleep" as const, durationMs: computeMinPoll(), matchedRule: "awaiting-external → probe" };
+        }
+
+        if (exitCode === 0) {
+          resetProbeFailureCount(mid, sid, tid);
+          return { action: "sleep" as const, durationMs: computeMinPoll(), matchedRule: "awaiting-external → probe" };
+        }
+
+        // ── Non-zero exit = done — execute successCheck if present ──
+        const successCheck = waitRow.success_check as string | null;
+        const contextHint = (waitRow.context_hint as string) || "";
+        let jobSucceeded = true;
+        let failureContext = "";
+
+        if (successCheck) {
+          try {
+            const scResult = await new Promise<{ exitCode: number | null; stdout: string; stderr: string }>((resolve) => {
+              exec(successCheck, { timeout: 30000, shell: probeShell }, (err, scStdout, scStderr) => {
+                if (err) resolve({ exitCode: (err as any).code ?? 1, stdout: scStdout || "", stderr: scStderr || "" });
+                else resolve({ exitCode: 0, stdout: scStdout || "", stderr: scStderr || "" });
+              });
+            });
+            try { appendFileSync(logPath, JSON.stringify({ ts: new Date().toISOString(), event: "successCheck", exitCode: scResult.exitCode, stdout: scResult.stdout.slice(0, 500) }) + "\n"); } catch (logErr) { logWarning("dispatch", `Failed to write external wait log: ${logErr instanceof Error ? logErr.message : String(logErr)}`); }
+            if (scResult.exitCode !== 0) {
+              jobSucceeded = false;
+              failureContext = `Exit code: ${scResult.exitCode}\nStderr: ${scResult.stderr.slice(0, 1000)}`;
+            }
+          } catch (scErr) {
+            jobSucceeded = false;
+            failureContext = `successCheck exec error: ${scErr instanceof Error ? scErr.message : String(scErr)}`;
+          }
+        }
+
+        // ── State transition: awaiting-external → executing ────────
+        updateTaskStatus(mid, sid, tid, "executing");
+        updateExternalWaitStatus(mid, sid, tid, "resolved");
+        resetProbeFailureCount(mid, sid, tid);
+        invalidateStateCache();
+
+        if (ctx.session) {
+          if (jobSucceeded) {
+            ctx.session.pendingExternalResume = `**EXTERNAL WAIT RESOLVED — TASK RESUMING**\n\nThe external process you submitted has completed successfully.${contextHint ? `\n\nContext from registration: ${contextHint}` : ""}\n\nContinue with the task.`;
+          } else {
+            ctx.session.pendingExternalResume = `**EXTERNAL WAIT RESOLVED — JOB FAILED**\n\nThe external process completed but the success check failed.${contextHint ? `\n\nContext from registration: ${contextHint}` : ""}\n\nFailure details:\n${failureContext}\n\nInvestigate the failure, adjust parameters if needed, and either fix the issue or escalate.`;
+          }
+        }
+
+        return { action: "skip" as const };
+      } catch (execErr) {
+        try { appendFileSync(logPath, JSON.stringify({ ts: new Date().toISOString(), event: "probe-error", error: execErr instanceof Error ? execErr.message : String(execErr) }) + "\n"); } catch (logErr) { logWarning("dispatch", `Failed to write external wait log: ${logErr instanceof Error ? logErr.message : String(logErr)}`); }
+
+        incrementProbeFailureCount(mid, sid, tid);
+        const updated = getExternalWait(mid, sid, tid);
+        if (updated && (updated.probe_failure_count as number) >= 3) {
+          updateTaskStatus(mid, sid, tid, "manual-attention");
+          updateExternalWaitStatus(mid, sid, tid, "timed-out");
+          invalidateStateCache();
+          return {
+            action: "stop" as const,
+            reason: `Probe for ${tid} failed 3 times: ${execErr instanceof Error ? execErr.message : String(execErr)}`,
+            level: "warning" as const,
+          };
+        }
+        return { action: "sleep" as const, durationMs: computeMinPoll(), matchedRule: "awaiting-external → probe" };
+      }
     },
   },
   {

--- a/src/resources/extensions/gsd/auto/loop.ts
+++ b/src/resources/extensions/gsd/auto/loop.ts
@@ -432,6 +432,15 @@ export async function autoLoop(
         if (dispatch.action === "skip") {
           continue;
         }
+        if (dispatch.action === "sleep") {
+          // Chunked sleep: poll s.active every 1s so pause/stop is responsive
+          const sleepMs = dispatch.durationMs;
+          const start = Date.now();
+          while (Date.now() - start < sleepMs && s.active) {
+            await new Promise(r => setTimeout(r, Math.min(1000, sleepMs - (Date.now() - start))));
+          }
+          continue;
+        }
 
         // dispatch.action === "dispatch"
         const step = dispatch.step!;

--- a/src/resources/extensions/gsd/auto/loop.ts
+++ b/src/resources/extensions/gsd/auto/loop.ts
@@ -430,6 +430,7 @@ export async function autoLoop(
           break;
         }
         if (dispatch.action === "skip") {
+          finishTurn("skipped");
           continue;
         }
         if (dispatch.action === "sleep") {
@@ -439,6 +440,7 @@ export async function autoLoop(
           while (Date.now() - start < sleepMs && s.active) {
             await new Promise(r => setTimeout(r, Math.min(1000, sleepMs - (Date.now() - start))));
           }
+          finishTurn("skipped");
           continue;
         }
 

--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -945,6 +945,23 @@ export async function runDispatch(
     return { action: "break", reason: "dispatch-stop" };
   }
 
+  if (dispatchResult.action === "sleep") {
+    deps.emitJournalEvent({
+      ts: new Date().toISOString(), flowId: ic.flowId, seq: ic.nextSeq(),
+      eventType: "dispatch-sleep",
+      rule: dispatchResult.matchedRule,
+      data: { durationMs: dispatchResult.durationMs },
+    });
+    // Interruptible sleep: poll s.active every 1s so the loop wakes
+    // promptly when auto-mode is stopped instead of sleeping the full duration.
+    const sleepMs = dispatchResult.durationMs;
+    const start = Date.now();
+    while (Date.now() - start < sleepMs && s.active) {
+      await new Promise(r => setTimeout(r, Math.min(1000, sleepMs - (Date.now() - start))));
+    }
+    return { action: "continue" };
+  }
+
   if (dispatchResult.action !== "dispatch") {
     // Non-dispatch action (e.g. "skip") — re-derive state
     await new Promise((r) => setImmediate(r));
@@ -1471,6 +1488,8 @@ export async function runUnitPhase(
     finalPrompt = `**VERIFICATION FAILED — AUTO-FIX ATTEMPT ${retryCtx.attempt}**\n\nThe verification gate ran after your previous attempt and found failures. Fix these issues before completing the task.\n\n${capped}\n\n---\n\n${finalPrompt}`;
   }
 
+  const hadCrashRecovery = !!s.pendingCrashRecovery;
+  const hadExternalResume = !!s.pendingExternalResume;
   if (s.pendingCrashRecovery) {
     const capped =
       s.pendingCrashRecovery.length > MAX_RECOVERY_CHARS
@@ -1479,7 +1498,19 @@ export async function runUnitPhase(
         : s.pendingCrashRecovery;
     finalPrompt = `${capped}\n\n---\n\n${finalPrompt}`;
     s.pendingCrashRecovery = null;
-  } else if ((s.unitDispatchCount.get(dispatchKey) ?? 0) > 1) {
+  }
+
+  if (s.pendingExternalResume) {
+    const cappedExt =
+      s.pendingExternalResume.length > MAX_RECOVERY_CHARS
+        ? s.pendingExternalResume.slice(0, MAX_RECOVERY_CHARS) +
+          "\n\n[...external resume context truncated]"
+        : s.pendingExternalResume;
+    finalPrompt = `${cappedExt}\n\n---\n\n${finalPrompt}`;
+    s.pendingExternalResume = null;
+  }
+
+  if (!hadCrashRecovery && !hadExternalResume && (s.unitDispatchCount.get(dispatchKey) ?? 0) > 1) {
     const diagnostic = deps.getDeepDiagnostic(s.basePath);
     if (diagnostic) {
       const cappedDiag =

--- a/src/resources/extensions/gsd/auto/session.ts
+++ b/src/resources/extensions/gsd/auto/session.ts
@@ -137,6 +137,7 @@ export class AutoSession {
 
   // ── Recovery ─────────────────────────────────────────────────────────────
   pendingCrashRecovery: string | null = null;
+  pendingExternalResume: string | null = null;
   pendingVerificationRetry: PendingVerificationRetry | null = null;
   readonly verificationRetryCount = new Map<string, number>();
   pausedSessionFile: string | null = null;
@@ -283,6 +284,7 @@ export class AutoSession {
 
     // Recovery
     this.pendingCrashRecovery = null;
+    this.pendingExternalResume = null;
     this.pendingVerificationRetry = null;
     this.verificationRetryCount.clear();
     this.pausedSessionFile = null;

--- a/src/resources/extensions/gsd/dev-workflow-engine.ts
+++ b/src/resources/extensions/gsd/dev-workflow-engine.ts
@@ -48,6 +48,8 @@ export function bridgeDispatchAction(da: DispatchAction): EngineDispatchAction {
       };
     case "skip":
       return { action: "skip" };
+    case "sleep":
+      return { action: "sleep", durationMs: da.durationMs };
   }
 }
 

--- a/src/resources/extensions/gsd/engine-types.ts
+++ b/src/resources/extensions/gsd/engine-types.ts
@@ -42,7 +42,8 @@ export interface DisplayMetadata {
 export type EngineDispatchAction =
   | { action: "dispatch"; step: StepContract }
   | { action: "stop"; reason: string; level: "info" | "warning" | "error" }
-  | { action: "skip" };
+  | { action: "skip" }
+  | { action: "sleep"; durationMs: number };
 
 /** Outcome of reconciling state after a step completes. */
 export interface ReconcileResult {

--- a/src/resources/extensions/gsd/gsd-db.ts
+++ b/src/resources/extensions/gsd/gsd-db.ts
@@ -180,7 +180,7 @@ function openRawDb(path: string): unknown {
   return new Database(path);
 }
 
-export const SCHEMA_VERSION = 22;
+export const SCHEMA_VERSION = 23;
 
 function indexExists(db: DbAdapter, name: string): boolean {
   return !!db.prepare(
@@ -556,6 +556,27 @@ function initSchema(db: DbAdapter, fileBacked: boolean): void {
         PRIMARY KEY (trace_id, turn_id)
       )
     `);
+
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS external_waits (
+        milestone_id TEXT NOT NULL,
+        slice_id TEXT NOT NULL,
+        task_id TEXT NOT NULL,
+        status TEXT NOT NULL DEFAULT 'waiting',
+        poll_while_command TEXT NOT NULL,
+        success_check TEXT,
+        poll_interval_ms INTEGER NOT NULL DEFAULT 30000,
+        timeout_ms INTEGER NOT NULL DEFAULT 86400000,
+        context_hint TEXT,
+        on_timeout TEXT NOT NULL DEFAULT 'manual-attention',
+        probe_failure_count INTEGER NOT NULL DEFAULT 0,
+        registered_at TEXT NOT NULL,
+        resolved_at TEXT,
+        PRIMARY KEY (milestone_id, slice_id, task_id),
+        FOREIGN KEY (milestone_id, slice_id, task_id) REFERENCES tasks(milestone_id, slice_id, id) ON DELETE CASCADE
+      )
+    `);
+    db.exec("CREATE INDEX IF NOT EXISTS idx_external_waits_milestone_status ON external_waits(milestone_id, status)");
 
     db.exec("CREATE INDEX IF NOT EXISTS idx_memories_active ON memories(superseded_by)");
 
@@ -1232,6 +1253,34 @@ function migrateSchema(db: DbAdapter): void {
       });
     }
 
+    if (currentVersion < 23) {
+      // External process wait mechanism (#4340): table for tracking long-running
+      // external processes (SLURM jobs, CI pipelines) that auto-mode should poll.
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS external_waits (
+          milestone_id TEXT NOT NULL,
+          slice_id TEXT NOT NULL,
+          task_id TEXT NOT NULL,
+          status TEXT NOT NULL DEFAULT 'waiting',
+          poll_while_command TEXT NOT NULL,
+          success_check TEXT,
+          poll_interval_ms INTEGER NOT NULL DEFAULT 30000,
+          timeout_ms INTEGER NOT NULL DEFAULT 86400000,
+          context_hint TEXT,
+          on_timeout TEXT NOT NULL DEFAULT 'manual-attention',
+          probe_failure_count INTEGER NOT NULL DEFAULT 0,
+          registered_at TEXT NOT NULL,
+          resolved_at TEXT,
+          PRIMARY KEY (milestone_id, slice_id, task_id),
+          FOREIGN KEY (milestone_id, slice_id, task_id) REFERENCES tasks(milestone_id, slice_id, id) ON DELETE CASCADE
+        )
+      `);
+      db.exec("CREATE INDEX IF NOT EXISTS idx_external_waits_milestone_status ON external_waits(milestone_id, status)");
+      db.prepare("INSERT INTO schema_version (version, applied_at) VALUES (:version, :applied_at)").run({
+        ":version": 23,
+        ":applied_at": new Date().toISOString(),
+      });
+    }
     db.exec("COMMIT");
   } catch (err) {
     db.exec("ROLLBACK");
@@ -2624,6 +2673,92 @@ export function getSliceTaskCounts(milestoneId: string, sliceId: string): { tota
   ).get({ ":mid": milestoneId, ":sid": sliceId });
   if (!row) return { total: 0, done: 0, pending: 0 };
   return { total: (row["total"] as number) ?? 0, done: (row["done"] as number) ?? 0, pending: (row["pending"] as number) ?? 0 };
+}
+
+// ─── External Waits ──────────────────────────────────────────────────────
+
+/** Retrieve the external_waits row for a specific task, or null if none exists. */
+export function getExternalWait(milestoneId: string, sliceId: string, taskId: string): Record<string, unknown> | null {
+  if (!currentDb) return null;
+  const row = currentDb.prepare(
+    "SELECT * FROM external_waits WHERE milestone_id = :mid AND slice_id = :sid AND task_id = :tid",
+  ).get({ ":mid": milestoneId, ":sid": sliceId, ":tid": taskId });
+  return row ?? null;
+}
+
+/** Insert (or replace) an external_waits row with full probe configuration. */
+export function insertExternalWait(
+  milestoneId: string,
+  sliceId: string,
+  taskId: string,
+  pollWhileCommand: string,
+  opts?: {
+    successCheck?: string;
+    pollIntervalMs?: number;
+    timeoutMs?: number;
+    contextHint?: string;
+    onTimeout?: string;
+  },
+): void {
+  if (!currentDb) throw new GSDError(GSD_STALE_STATE, "gsd-db: No database open");
+  const o = opts ?? {};
+  currentDb.prepare(
+    `INSERT OR REPLACE INTO external_waits
+       (milestone_id, slice_id, task_id, poll_while_command, success_check,
+        poll_interval_ms, timeout_ms, context_hint, on_timeout,
+        status, probe_failure_count, registered_at)
+     VALUES (:mid, :sid, :tid, :cmd, :sc, :pi, :tm, :ch, :ot, 'waiting', 0, :ra)`,
+  ).run({
+    ":mid": milestoneId,
+    ":sid": sliceId,
+    ":tid": taskId,
+    ":cmd": pollWhileCommand,
+    ":sc": o.successCheck ?? null,
+    ":pi": o.pollIntervalMs ?? 30000,
+    ":tm": o.timeoutMs ?? 86400000,
+    ":ch": o.contextHint ?? null,
+    ":ot": o.onTimeout ?? "manual-attention",
+    ":ra": new Date().toISOString(),
+  });
+}
+
+/** Increment the probe_failure_count for a specific external wait. */
+export function incrementProbeFailureCount(milestoneId: string, sliceId: string, taskId: string): void {
+  if (!currentDb) return;
+  currentDb.prepare(
+    "UPDATE external_waits SET probe_failure_count = probe_failure_count + 1 WHERE milestone_id = :mid AND slice_id = :sid AND task_id = :tid",
+  ).run({ ":mid": milestoneId, ":sid": sliceId, ":tid": taskId });
+}
+
+/** Update the status (and optionally resolved_at) for a specific external wait. */
+export function updateExternalWaitStatus(
+  milestoneId: string,
+  sliceId: string,
+  taskId: string,
+  status: string,
+  resolvedAt?: string,
+): void {
+  if (!currentDb) throw new GSDError(GSD_STALE_STATE, "gsd-db: No database open");
+  const ra = resolvedAt ?? (status === "resolved" || status === "timed-out" ? new Date().toISOString() : null);
+  currentDb.prepare(
+    "UPDATE external_waits SET status = :status, resolved_at = :ra WHERE milestone_id = :mid AND slice_id = :sid AND task_id = :tid",
+  ).run({ ":status": status, ":ra": ra, ":mid": milestoneId, ":sid": sliceId, ":tid": taskId });
+}
+
+/** Reset the probe_failure_count to 0 for a specific external wait. */
+export function resetProbeFailureCount(milestoneId: string, sliceId: string, taskId: string): void {
+  if (!currentDb) return;
+  currentDb.prepare(
+    "UPDATE external_waits SET probe_failure_count = 0 WHERE milestone_id = :mid AND slice_id = :sid AND task_id = :tid",
+  ).run({ ":mid": milestoneId, ":sid": sliceId, ":tid": taskId });
+}
+
+/** Get all external_waits rows with status='waiting' for a given milestone. */
+export function getAllWaitingExternalWaits(milestoneId: string): Record<string, unknown>[] {
+  if (!currentDb) return [];
+  return currentDb.prepare(
+    "SELECT * FROM external_waits WHERE milestone_id = :mid AND status = 'waiting'",
+  ).all({ ":mid": milestoneId }) as Record<string, unknown>[];
 }
 
 // ─── Slice Dependencies (junction table) ─────────────────────────────────

--- a/src/resources/extensions/gsd/gsd-db.ts
+++ b/src/resources/extensions/gsd/gsd-db.ts
@@ -2677,16 +2677,34 @@ export function getSliceTaskCounts(milestoneId: string, sliceId: string): { tota
 
 // ─── External Waits ──────────────────────────────────────────────────────
 
+/** Typed row shape for the external_waits table. */
+export interface ExternalWaitRow {
+  milestone_id: string;
+  slice_id: string;
+  task_id: string;
+  status: string;
+  poll_while_command: string;
+  success_check: string | null;
+  poll_interval_ms: number;
+  timeout_ms: number;
+  context_hint: string | null;
+  on_timeout: string;
+  probe_failure_count: number;
+  registered_at: string;
+  resolved_at: string | null;
+}
+
 /** Retrieve the external_waits row for a specific task, or null if none exists. */
-export function getExternalWait(milestoneId: string, sliceId: string, taskId: string): Record<string, unknown> | null {
+export function getExternalWait(milestoneId: string, sliceId: string, taskId: string): ExternalWaitRow | null {
   if (!currentDb) return null;
   const row = currentDb.prepare(
     "SELECT * FROM external_waits WHERE milestone_id = :mid AND slice_id = :sid AND task_id = :tid",
-  ).get({ ":mid": milestoneId, ":sid": sliceId, ":tid": taskId });
+  ).get({ ":mid": milestoneId, ":sid": sliceId, ":tid": taskId }) as ExternalWaitRow | undefined;
   return row ?? null;
 }
 
-/** Insert (or replace) an external_waits row with full probe configuration. */
+/** Insert an external_waits row with full probe configuration.
+ *  Rejects re-registration of a row that has already resolved/timed-out. */
 export function insertExternalWait(
   milestoneId: string,
   sliceId: string,
@@ -2702,6 +2720,19 @@ export function insertExternalWait(
 ): void {
   if (!currentDb) throw new GSDError(GSD_STALE_STATE, "gsd-db: No database open");
   const o = opts ?? {};
+  if (o.pollIntervalMs !== undefined && o.pollIntervalMs <= 0) {
+    throw new GSDError(GSD_STALE_STATE, "insertExternalWait: invalid pollIntervalMs — must be positive");
+  }
+  if (o.timeoutMs !== undefined && o.timeoutMs <= 0) {
+    throw new GSDError(GSD_STALE_STATE, "insertExternalWait: invalid timeoutMs — must be positive");
+  }
+  // Guard: don't silently clobber a resolved/timed-out row — that erases history
+  const existing = currentDb.prepare(
+    "SELECT status FROM external_waits WHERE milestone_id = :mid AND slice_id = :sid AND task_id = :tid",
+  ).get({ ":mid": milestoneId, ":sid": sliceId, ":tid": taskId }) as { status: string } | undefined;
+  if (existing && (existing.status === "resolved" || existing.status === "timed-out")) {
+    throw new GSDError(GSD_STALE_STATE, `insertExternalWait: cannot re-register — existing row has terminal status '${existing.status}'`);
+  }
   currentDb.prepare(
     `INSERT OR REPLACE INTO external_waits
        (milestone_id, slice_id, task_id, poll_while_command, success_check,
@@ -2724,18 +2755,21 @@ export function insertExternalWait(
 
 /** Increment the probe_failure_count for a specific external wait. */
 export function incrementProbeFailureCount(milestoneId: string, sliceId: string, taskId: string): void {
-  if (!currentDb) return;
+  if (!currentDb) throw new GSDError(GSD_STALE_STATE, "gsd-db: No database open");
   currentDb.prepare(
     "UPDATE external_waits SET probe_failure_count = probe_failure_count + 1 WHERE milestone_id = :mid AND slice_id = :sid AND task_id = :tid",
   ).run({ ":mid": milestoneId, ":sid": sliceId, ":tid": taskId });
 }
+
+/** Valid external wait status values. */
+export type ExternalWaitStatus = "waiting" | "resolved" | "timed-out" | "failed";
 
 /** Update the status (and optionally resolved_at) for a specific external wait. */
 export function updateExternalWaitStatus(
   milestoneId: string,
   sliceId: string,
   taskId: string,
-  status: string,
+  status: ExternalWaitStatus,
   resolvedAt?: string,
 ): void {
   if (!currentDb) throw new GSDError(GSD_STALE_STATE, "gsd-db: No database open");
@@ -2747,18 +2781,18 @@ export function updateExternalWaitStatus(
 
 /** Reset the probe_failure_count to 0 for a specific external wait. */
 export function resetProbeFailureCount(milestoneId: string, sliceId: string, taskId: string): void {
-  if (!currentDb) return;
+  if (!currentDb) throw new GSDError(GSD_STALE_STATE, "gsd-db: No database open");
   currentDb.prepare(
     "UPDATE external_waits SET probe_failure_count = 0 WHERE milestone_id = :mid AND slice_id = :sid AND task_id = :tid",
   ).run({ ":mid": milestoneId, ":sid": sliceId, ":tid": taskId });
 }
 
 /** Get all external_waits rows with status='waiting' for a given milestone. */
-export function getAllWaitingExternalWaits(milestoneId: string): Record<string, unknown>[] {
+export function getAllWaitingExternalWaits(milestoneId: string): ExternalWaitRow[] {
   if (!currentDb) return [];
   return currentDb.prepare(
     "SELECT * FROM external_waits WHERE milestone_id = :mid AND status = 'waiting'",
-  ).all({ ":mid": milestoneId }) as Record<string, unknown>[];
+  ).all({ ":mid": milestoneId }) as unknown as ExternalWaitRow[];
 }
 
 // ─── Slice Dependencies (junction table) ─────────────────────────────────
@@ -3008,6 +3042,24 @@ export function reconcileWorktreeDb(
           FROM wt.tasks w
           LEFT JOIN tasks m ON m.milestone_id = w.milestone_id AND m.slice_id = w.slice_id AND m.id = w.id
         `).run());
+
+        // Merge external_waits — worktree may predate this table, guard with table_info check.
+        // Uses INSERT OR REPLACE keyed on (milestone_id, slice_id, task_id) PK.
+        // FK ON DELETE CASCADE ties rows to tasks, so this runs after the tasks merge.
+        const wtExternalWaitsInfo = adapter.prepare("PRAGMA wt.table_info('external_waits')").all();
+        if (wtExternalWaitsInfo.length > 0) {
+          countChanges(adapter.prepare(`
+            INSERT OR REPLACE INTO external_waits (
+              milestone_id, slice_id, task_id, status, poll_while_command, success_check,
+              poll_interval_ms, timeout_ms, context_hint, on_timeout,
+              probe_failure_count, registered_at, resolved_at
+            )
+            SELECT milestone_id, slice_id, task_id, status, poll_while_command, success_check,
+                   poll_interval_ms, timeout_ms, context_hint, on_timeout,
+                   probe_failure_count, registered_at, resolved_at
+            FROM wt.external_waits
+          `).run());
+        }
 
         // Merge memories — keep worktree-learned insights
         merged.memories = countChanges(adapter.prepare(`
@@ -3701,6 +3753,7 @@ export function restoreManifest(manifest: StateManifest): void {
 
   transaction(() => {
     // Clear engine tables (order matters for foreign-key-like consistency)
+    db.exec("DELETE FROM external_waits");
     db.exec("DELETE FROM verification_evidence");
     db.exec("DELETE FROM tasks");
     db.exec("DELETE FROM slices");
@@ -3772,6 +3825,25 @@ export function restoreManifest(manifest: StateManifest): void {
         t.escalation_artifact_path ?? null,
         t.escalation_override_applied_at ?? null,
       );
+    }
+
+    // Restore external_waits (after tasks due to FK constraint)
+    if (manifest.external_waits?.length) {
+      const ewStmt = db.prepare(
+        `INSERT INTO external_waits (
+          milestone_id, slice_id, task_id, status, poll_while_command, success_check,
+          poll_interval_ms, timeout_ms, context_hint, on_timeout,
+          probe_failure_count, registered_at, resolved_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      );
+      for (const ew of manifest.external_waits) {
+        ewStmt.run(
+          ew.milestone_id, ew.slice_id, ew.task_id, ew.status,
+          ew.poll_while_command, ew.success_check,
+          ew.poll_interval_ms, ew.timeout_ms, ew.context_hint, ew.on_timeout,
+          ew.probe_failure_count, ew.registered_at, ew.resolved_at,
+        );
+      }
     }
 
     // Restore decisions (ADR-011 P2: include source so escalation decisions survive)

--- a/src/resources/extensions/gsd/journal.ts
+++ b/src/resources/extensions/gsd/journal.ts
@@ -60,7 +60,8 @@ export type JournalEventType =
   | "canonical-root-redirect"
   // #4765 — slice-cadence collapse
   | "slice-merged"
-  | "milestone-resquash";
+  | "milestone-resquash"
+  | "dispatch-sleep";
 
 /** A single structured event in the journal. */
 export interface JournalEntry {

--- a/src/resources/extensions/gsd/state.ts
+++ b/src/resources/extensions/gsd/state.ts
@@ -960,6 +960,22 @@ export async function deriveStateFromDb(basePath: string): Promise<GSDState> {
 
   const activeTask: ActiveRef = { id: activeTaskRow.id, title: activeTaskRow.title };
 
+  // ── External wait check ──────────────────────────────────────────
+  // If the active task's status is "awaiting-external", the task is waiting
+  // on an external process (SLURM job, CI pipeline, etc.). Return this phase
+  // so the dispatch rule can run the probe command. Per D026, state derivation
+  // reads only the task status string — the external_waits table is queried
+  // only by the dispatch rule when it needs the probe spec.
+  if (activeTaskRow.status === "awaiting-external") {
+    return {
+      activeMilestone, activeSlice, activeTask,
+      phase: 'awaiting-external', recentDecisions: [], blockers: [],
+      nextAction: `Task ${activeTask.id} is awaiting external process. Probe will check status.`,
+      registry, requirements,
+      progress: { milestones: milestoneProgress, slices: sliceProgress, tasks: taskProgress },
+    };
+  }
+
   const tasksDir = resolveTasksDir(basePath, activeMilestone.id, activeSlice.id);
   if (tasksDir && existsSync(tasksDir) && tasks.length > 0) {
     const allFiles = readdirSync(tasksDir).filter(f => f.endsWith(".md"));

--- a/src/resources/extensions/gsd/tests/complete-slice.test.ts
+++ b/src/resources/extensions/gsd/tests/complete-slice.test.ts
@@ -125,9 +125,9 @@ console.log('\n=== complete-slice: schema v6 migration ===');
 
   const adapter = _getAdapter()!;
 
-  // Verify schema version is current (v22 — quality_gates DDL fix)
+  // Verify schema version is current (v23 — external_waits table)
   const versionRow = adapter.prepare('SELECT MAX(version) as v FROM schema_version').get();
-  assertEq(versionRow?.['v'], 22, 'schema version should be 22');
+  assertEq(versionRow?.['v'], 23, 'schema version should be 23');
 
   // Verify slices table has full_summary_md and full_uat_md columns
   const cols = adapter.prepare("PRAGMA table_info(slices)").all();

--- a/src/resources/extensions/gsd/tests/ensure-db-open.test.ts
+++ b/src/resources/extensions/gsd/tests/ensure-db-open.test.ts
@@ -389,7 +389,7 @@ describe('ensure-db-open', () => {
       assert.ok(db, 'adapter should be available after ensureDbOpen');
       assert.equal(
         db.prepare('SELECT MAX(version) as version FROM schema_version').get()?.version,
-        22,
+        23,
         'legacy DB should migrate to current schema version',
       );
 

--- a/src/resources/extensions/gsd/tests/escalation.test.ts
+++ b/src/resources/extensions/gsd/tests/escalation.test.ts
@@ -348,7 +348,7 @@ test("ADR-011 P2: schema v20 fresh DB has all escalation columns on tasks + sour
   assert.ok(decCols.includes("source"), "decisions table must have source column");
 
   const version = adapter.prepare("SELECT MAX(version) as v FROM schema_version").get();
-  assert.equal(version?.["v"], 22);
+  assert.equal(version?.["v"], 23);
 });
 
 test("ADR-011 P2: findUnappliedEscalationOverride returns null when escalation_pending=1 (still pending)", (t) => {

--- a/src/resources/extensions/gsd/tests/external-wait-state-dispatch.test.ts
+++ b/src/resources/extensions/gsd/tests/external-wait-state-dispatch.test.ts
@@ -1,0 +1,473 @@
+/**
+ * external-wait-state-dispatch.test.ts — Integration tests for M006/S01:
+ * external_waits DB table, awaiting-external state derivation, and probe
+ * dispatch rule (sleep/skip/stop actions).
+ *
+ * Uses real DB and real child_process.exec probes — no mocks.
+ *
+ * Requirements verified: R212, R217, R218, R233
+ */
+
+import { describe, test, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// ── DB layer ──────────────────────────────────────────────────────────────
+import {
+  openDatabase,
+  closeDatabase,
+  insertMilestone,
+  insertSlice,
+  insertTask,
+  updateTaskStatus,
+  getExternalWait,
+  incrementProbeFailureCount,
+} from "../gsd-db.ts";
+
+// ── State derivation ──────────────────────────────────────────────────────
+import { deriveStateFromDb, invalidateStateCache } from "../state.ts";
+
+// ── Dispatch ─────────────────────────────────────────────────────────────
+import { resolveDispatch } from "../auto-dispatch.ts";
+import type { DispatchContext } from "../auto-dispatch.ts";
+
+// ── Status guards ─────────────────────────────────────────────────────────
+import { isClosedStatus } from "../status-guards.ts";
+
+// ── Cache invalidation ───────────────────────────────────────────────────
+import { clearPathCache } from "../paths.ts";
+import { invalidateAllCaches } from "../cache.ts";
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Fixture Helpers
+// ═══════════════════════════════════════════════════════════════════════════
+
+let base: string;
+
+function createFixture(): { basePath: string; cleanup: () => void } {
+  base = mkdtempSync(join(tmpdir(), "gsd-ext-wait-"));
+  const gsdDir = join(base, ".gsd");
+  const m001Dir = join(gsdDir, "milestones", "M001");
+  const s01Dir = join(m001Dir, "slices", "S01");
+  const s01Tasks = join(s01Dir, "tasks");
+
+  mkdirSync(s01Tasks, { recursive: true });
+
+  writeFileSync(
+    join(m001Dir, "M001-CONTEXT.md"),
+    "# M001: External Wait Test\n\n## Purpose\nTest external wait flow.\n",
+  );
+
+  writeFileSync(
+    join(m001Dir, "M001-ROADMAP.md"),
+    [
+      "# M001: External Wait Test",
+      "",
+      "## Vision",
+      "Validate awaiting-external phase.",
+      "",
+      "## Success Criteria",
+      "- External wait flow works",
+      "",
+      "## Slices",
+      "",
+      "- [ ] **S01: Test** `risk:low` `depends:[]`",
+      "  - After this: External wait tested.",
+      "",
+      "## Boundary Map",
+      "",
+      "| From | To | Produces | Consumes |",
+      "|------|----|----------|----------|",
+      "| S01 | terminal | result | nothing |",
+    ].join("\n"),
+  );
+
+  writeFileSync(
+    join(s01Dir, "S01-PLAN.md"),
+    [
+      "# S01: Test",
+      "",
+      "**Goal:** test external waits",
+      "",
+      "## Tasks",
+      "",
+      "- [ ] **T01: Test** `est:30m`",
+      "  - Do: test",
+      "  - Verify: tests pass",
+    ].join("\n"),
+  );
+
+  writeFileSync(join(s01Tasks, "T01-PLAN.md"), "# T01: Test\n\n## Steps\n1. test\n");
+
+  openDatabase(join(gsdDir, "gsd.db"));
+  insertMilestone({ id: "M001", title: "External Wait Test", status: "active" });
+  insertSlice({ id: "S01", milestoneId: "M001", title: "Test", status: "in_progress" });
+  insertTask({ id: "T01", sliceId: "S01", milestoneId: "M001", title: "Test", status: "pending" });
+
+  return {
+    basePath: base,
+    cleanup: () => {
+      try { closeDatabase(); } catch { /* may not be open */ }
+      if (base) rmSync(base, { recursive: true, force: true });
+    },
+  };
+}
+
+function buildDispatchCtx(
+  basePath: string,
+  mid: string,
+  stateOverrides: Partial<import("../types.ts").GSDState> = {},
+): DispatchContext {
+  return {
+    basePath,
+    mid,
+    midTitle: `${mid} Test`,
+    state: {
+      activeMilestone: { id: mid, title: `${mid} Test` },
+      activeSlice: null,
+      activeTask: null,
+      phase: "executing",
+      recentDecisions: [],
+      blockers: [],
+      nextAction: "",
+      registry: [],
+      requirements: { active: 0, validated: 0, deferred: 0, outOfScope: 0, blocked: 0, total: 0 },
+      progress: { milestones: { done: 0, total: 1 } },
+      ...stateOverrides,
+    },
+    prefs: undefined,
+  };
+}
+
+// Helper: write a minimal T##-EXTERNAL-WAIT.json probe spec so the dispatch
+// rule's existence check (R228) doesn't short-circuit to manual-attention.
+function writeProbeSpec(
+  basePath: string,
+  mid: string,
+  sid: string,
+  tid: string,
+  pollWhileCommand: string,
+): void {
+  const tasksDir = join(basePath, ".gsd", "milestones", mid, "slices", sid, "tasks");
+  mkdirSync(tasksDir, { recursive: true });
+  writeFileSync(
+    join(tasksDir, `${tid}-EXTERNAL-WAIT.json`),
+    JSON.stringify({ pollWhileCommand, pollIntervalMs: 30000, timeoutMs: 86400000 }),
+  );
+}
+
+// Raw DB access for test fixture setup (no insertExternalWait export in gsd-db)
+// Use node:sqlite (built-in since Node 22) — no npm dependency needed
+import { DatabaseSync } from "node:sqlite";
+
+let rawDb: InstanceType<typeof DatabaseSync> | null = null;
+
+function getRawDb(basePath: string): InstanceType<typeof DatabaseSync> {
+  if (!rawDb) {
+    rawDb = new DatabaseSync(join(basePath, ".gsd", "gsd.db"));
+  }
+  return rawDb;
+}
+
+function insertExternalWaitRow(
+  basePath: string,
+  opts: {
+    milestoneId: string;
+    sliceId: string;
+    taskId: string;
+    pollWhileCommand: string;
+    pollIntervalMs?: number;
+    timeoutMs?: number;
+    probeFailureCount?: number;
+  },
+): void {
+  const db = getRawDb(basePath);
+  db.prepare(
+    `INSERT INTO external_waits
+       (milestone_id, slice_id, task_id, status, poll_while_command, poll_interval_ms,
+        timeout_ms, probe_failure_count, registered_at)
+     VALUES (:mid, :sid, :tid, 'waiting', :cmd, :poll, :timeout, :failCount, :now)`,
+  ).run({
+    mid: opts.milestoneId,
+    sid: opts.sliceId,
+    tid: opts.taskId,
+    cmd: opts.pollWhileCommand,
+    poll: opts.pollIntervalMs ?? 30000,
+    timeout: opts.timeoutMs ?? 86400000,
+    failCount: opts.probeFailureCount ?? 0,
+    now: new Date().toISOString(),
+  });
+}
+
+function setProbeFailureCount(
+  basePath: string,
+  mid: string,
+  sid: string,
+  tid: string,
+  count: number,
+): void {
+  const db = getRawDb(basePath);
+  db.prepare(
+    "UPDATE external_waits SET probe_failure_count = :count WHERE milestone_id = :mid AND slice_id = :sid AND task_id = :tid",
+  ).run({ count, mid, sid, tid });
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Tests
+// ═══════════════════════════════════════════════════════════════════════════
+
+afterEach(() => {
+  try { rawDb?.close(); rawDb = null; } catch { /* ignore */ }
+  try { closeDatabase(); } catch { /* may not be open */ }
+  if (base) {
+    rmSync(base, { recursive: true, force: true });
+    base = "";
+  }
+});
+
+beforeEach(() => {
+  invalidateStateCache();
+  invalidateAllCaches();
+  clearPathCache();
+});
+
+// ── 1. external_waits DB table ───────────────────────────────────────────
+
+describe("external_waits DB table", () => {
+  test("table exists after migration", () => {
+    const { basePath } = createFixture();
+    const db = getRawDb(basePath);
+    const row = db.prepare(
+      "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'external_waits'",
+    ).get() as { name: string } | undefined;
+    assert.ok(row, "external_waits table should exist");
+    assert.equal(row.name, "external_waits");
+  });
+
+  test("insert and read round-trip via getExternalWait", () => {
+    const { basePath } = createFixture();
+    insertExternalWaitRow(basePath, {
+      milestoneId: "M001",
+      sliceId: "S01",
+      taskId: "T01",
+      pollWhileCommand: "echo hello",
+      pollIntervalMs: 5000,
+      timeoutMs: 60000,
+      probeFailureCount: 0,
+    });
+
+    const row = getExternalWait("M001", "S01", "T01");
+    assert.ok(row, "should return a row");
+    assert.equal(row.milestone_id, "M001");
+    assert.equal(row.slice_id, "S01");
+    assert.equal(row.task_id, "T01");
+    assert.equal(row.poll_while_command, "echo hello");
+    assert.equal(row.poll_interval_ms, 5000);
+    assert.equal(row.timeout_ms, 60000);
+    assert.equal(row.probe_failure_count, 0);
+    assert.equal(row.status, "waiting");
+  });
+
+  test("incrementProbeFailureCount increments by 1", () => {
+    const { basePath } = createFixture();
+    insertExternalWaitRow(basePath, {
+      milestoneId: "M001",
+      sliceId: "S01",
+      taskId: "T01",
+      pollWhileCommand: "echo test",
+      probeFailureCount: 0,
+    });
+
+    incrementProbeFailureCount("M001", "S01", "T01");
+    const row = getExternalWait("M001", "S01", "T01");
+    assert.ok(row);
+    assert.equal(row.probe_failure_count, 1);
+
+    // Increment again
+    incrementProbeFailureCount("M001", "S01", "T01");
+    const row2 = getExternalWait("M001", "S01", "T01");
+    assert.ok(row2);
+    assert.equal(row2.probe_failure_count, 2);
+  });
+
+  test("isClosedStatus('awaiting-external') returns false", () => {
+    assert.equal(isClosedStatus("awaiting-external"), false);
+  });
+});
+
+// ── 2. State derivation with awaiting-external ──────────────────────────
+
+describe("state derivation with awaiting-external", () => {
+  test("happy path — task with awaiting-external status yields phase awaiting-external", async () => {
+    const { basePath } = createFixture();
+    updateTaskStatus("M001", "S01", "T01", "awaiting-external");
+    invalidateStateCache();
+    invalidateAllCaches();
+    clearPathCache();
+
+    const state = await deriveStateFromDb(basePath);
+    assert.equal(state.phase, "awaiting-external");
+    assert.ok(state.activeTask);
+    assert.equal(state.activeTask.id, "T01");
+  });
+
+  test("no external_waits row needed for state derivation", async () => {
+    const { basePath } = createFixture();
+    // Set status but do NOT insert external_waits row
+    updateTaskStatus("M001", "S01", "T01", "awaiting-external");
+    invalidateStateCache();
+    invalidateAllCaches();
+    clearPathCache();
+
+    const state = await deriveStateFromDb(basePath);
+    // State derivation only reads task status, not external_waits table (D026)
+    assert.equal(state.phase, "awaiting-external");
+  });
+
+  test("completed task does not yield awaiting-external phase", async () => {
+    const { basePath } = createFixture();
+    updateTaskStatus("M001", "S01", "T01", "complete");
+    invalidateStateCache();
+    invalidateAllCaches();
+    clearPathCache();
+
+    const state = await deriveStateFromDb(basePath);
+    assert.notEqual(state.phase, "awaiting-external");
+    // With all tasks complete, should be summarizing
+    assert.equal(state.phase, "summarizing");
+  });
+});
+
+// ── 3. Dispatch rule probe execution ────────────────────────────────────
+
+describe("dispatch rule probe execution", () => {
+  test("exit 0 (still running) → sleep action", async () => {
+    const { basePath } = createFixture();
+    updateTaskStatus("M001", "S01", "T01", "awaiting-external");
+    insertExternalWaitRow(basePath, {
+      milestoneId: "M001",
+      sliceId: "S01",
+      taskId: "T01",
+      pollWhileCommand: "exit 0",
+      pollIntervalMs: 15000,
+    });
+    writeProbeSpec(basePath, "M001", "S01", "T01", "exit 0");
+    invalidateAllCaches();
+
+    const ctx = buildDispatchCtx(basePath, "M001", {
+      phase: "awaiting-external",
+      activeSlice: { id: "S01", title: "Test" },
+      activeTask: { id: "T01", title: "Test" },
+    });
+
+    const result = await resolveDispatch(ctx);
+    assert.equal(result.action, "sleep");
+    if (result.action === "sleep") {
+      assert.equal(result.durationMs, 15000);
+    }
+  });
+
+  test("exit non-zero (done) → skip action", async () => {
+    const { basePath } = createFixture();
+    updateTaskStatus("M001", "S01", "T01", "awaiting-external");
+    insertExternalWaitRow(basePath, {
+      milestoneId: "M001",
+      sliceId: "S01",
+      taskId: "T01",
+      pollWhileCommand: "exit 1",
+    });
+    writeProbeSpec(basePath, "M001", "S01", "T01", "exit 1");
+    invalidateAllCaches();
+
+    const ctx = buildDispatchCtx(basePath, "M001", {
+      phase: "awaiting-external",
+      activeSlice: { id: "S01", title: "Test" },
+      activeTask: { id: "T01", title: "Test" },
+    });
+
+    const result = await resolveDispatch(ctx);
+    assert.equal(result.action, "skip");
+  });
+
+  // Slow test: uses `sleep 35` to trigger the 30s probe timeout. ~35s runtime.
+  // Skip in fast CI with FAST_CI=1 env var.
+  const skipSlow = process.env.FAST_CI === "1";
+  test("probe timeout increments failure count", { timeout: 40000, skip: skipSlow }, async () => {
+    const { basePath } = createFixture();
+    updateTaskStatus("M001", "S01", "T01", "awaiting-external");
+    insertExternalWaitRow(basePath, {
+      milestoneId: "M001",
+      sliceId: "S01",
+      taskId: "T01",
+      pollWhileCommand: "sleep 35",
+      pollIntervalMs: 10000,
+      probeFailureCount: 0,
+    });
+    writeProbeSpec(basePath, "M001", "S01", "T01", "sleep 35");
+    invalidateAllCaches();
+
+    const ctx = buildDispatchCtx(basePath, "M001", {
+      phase: "awaiting-external",
+      activeSlice: { id: "S01", title: "Test" },
+      activeTask: { id: "T01", title: "Test" },
+    });
+
+    const result = await resolveDispatch(ctx);
+    // With count going from 0 → 1, should NOT stop (threshold is 3)
+    assert.equal(result.action, "sleep");
+
+    // Verify failure count was incremented
+    const row = getExternalWait("M001", "S01", "T01");
+    assert.ok(row);
+    assert.equal(row.probe_failure_count, 1);
+  });
+
+  // Slow test: uses `sleep 35` to trigger the 30s probe timeout. ~35s runtime.
+  test("3-strike escalation → stop action", { timeout: 40000, skip: skipSlow }, async () => {
+    const { basePath } = createFixture();
+    updateTaskStatus("M001", "S01", "T01", "awaiting-external");
+    insertExternalWaitRow(basePath, {
+      milestoneId: "M001",
+      sliceId: "S01",
+      taskId: "T01",
+      pollWhileCommand: "sleep 35",
+      pollIntervalMs: 10000,
+      probeFailureCount: 2, // Already at 2, timeout will push to 3
+    });
+    writeProbeSpec(basePath, "M001", "S01", "T01", "sleep 35");
+    invalidateAllCaches();
+
+    const ctx = buildDispatchCtx(basePath, "M001", {
+      phase: "awaiting-external",
+      activeSlice: { id: "S01", title: "Test" },
+      activeTask: { id: "T01", title: "Test" },
+    });
+
+    const result = await resolveDispatch(ctx);
+    assert.equal(result.action, "stop");
+    if (result.action === "stop") {
+      assert.match(result.reason, /3 times/);
+    }
+  });
+
+  test("no external_waits row → stop action", async () => {
+    const { basePath } = createFixture();
+    updateTaskStatus("M001", "S01", "T01", "awaiting-external");
+    // Do NOT insert external_waits row
+    invalidateAllCaches();
+
+    const ctx = buildDispatchCtx(basePath, "M001", {
+      phase: "awaiting-external",
+      activeSlice: { id: "S01", title: "Test" },
+      activeTask: { id: "T01", title: "Test" },
+    });
+
+    const result = await resolveDispatch(ctx);
+    assert.equal(result.action, "stop");
+    if (result.action === "stop") {
+      assert.match(result.reason, /no external_waits record/);
+    }
+  });
+});

--- a/src/resources/extensions/gsd/tests/external-wait-state-dispatch.test.ts
+++ b/src/resources/extensions/gsd/tests/external-wait-state-dispatch.test.ts
@@ -24,6 +24,8 @@ import {
   updateTaskStatus,
   getExternalWait,
   incrementProbeFailureCount,
+  insertExternalWait,
+  _getAdapter,
 } from "../gsd-db.ts";
 
 // ── State derivation ──────────────────────────────────────────────────────
@@ -158,60 +160,19 @@ function writeProbeSpec(
   );
 }
 
-// Raw DB access for test fixture setup (no insertExternalWait export in gsd-db)
-// Use node:sqlite (built-in since Node 22) — no npm dependency needed
-import { DatabaseSync } from "node:sqlite";
-
-let rawDb: InstanceType<typeof DatabaseSync> | null = null;
-
-function getRawDb(basePath: string): InstanceType<typeof DatabaseSync> {
-  if (!rawDb) {
-    rawDb = new DatabaseSync(join(basePath, ".gsd", "gsd.db"));
-  }
-  return rawDb;
-}
-
-function insertExternalWaitRow(
-  basePath: string,
-  opts: {
-    milestoneId: string;
-    sliceId: string;
-    taskId: string;
-    pollWhileCommand: string;
-    pollIntervalMs?: number;
-    timeoutMs?: number;
-    probeFailureCount?: number;
-  },
-): void {
-  const db = getRawDb(basePath);
-  db.prepare(
-    `INSERT INTO external_waits
-       (milestone_id, slice_id, task_id, status, poll_while_command, poll_interval_ms,
-        timeout_ms, probe_failure_count, registered_at)
-     VALUES (:mid, :sid, :tid, 'waiting', :cmd, :poll, :timeout, :failCount, :now)`,
-  ).run({
-    mid: opts.milestoneId,
-    sid: opts.sliceId,
-    tid: opts.taskId,
-    cmd: opts.pollWhileCommand,
-    poll: opts.pollIntervalMs ?? 30000,
-    timeout: opts.timeoutMs ?? 86400000,
-    failCount: opts.probeFailureCount ?? 0,
-    now: new Date().toISOString(),
-  });
-}
-
+// Helper: pre-set probe_failure_count via adapter (bypasses production helper
+// which only increments by 1) — used by 3-strike test to avoid 90s of real timeouts.
 function setProbeFailureCount(
-  basePath: string,
   mid: string,
   sid: string,
   tid: string,
   count: number,
 ): void {
-  const db = getRawDb(basePath);
+  const db = _getAdapter();
+  if (!db) throw new Error("setProbeFailureCount: no DB open");
   db.prepare(
     "UPDATE external_waits SET probe_failure_count = :count WHERE milestone_id = :mid AND slice_id = :sid AND task_id = :tid",
-  ).run({ count, mid, sid, tid });
+  ).run({ ":count": count, ":mid": mid, ":sid": sid, ":tid": tid });
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -219,7 +180,6 @@ function setProbeFailureCount(
 // ═══════════════════════════════════════════════════════════════════════════
 
 afterEach(() => {
-  try { rawDb?.close(); rawDb = null; } catch { /* ignore */ }
   try { closeDatabase(); } catch { /* may not be open */ }
   if (base) {
     rmSync(base, { recursive: true, force: true });
@@ -237,8 +197,9 @@ beforeEach(() => {
 
 describe("external_waits DB table", () => {
   test("table exists after migration", () => {
-    const { basePath } = createFixture();
-    const db = getRawDb(basePath);
+    createFixture();
+    const db = _getAdapter();
+    assert.ok(db, "DB adapter should be open");
     const row = db.prepare(
       "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'external_waits'",
     ).get() as { name: string } | undefined;
@@ -247,15 +208,10 @@ describe("external_waits DB table", () => {
   });
 
   test("insert and read round-trip via getExternalWait", () => {
-    const { basePath } = createFixture();
-    insertExternalWaitRow(basePath, {
-      milestoneId: "M001",
-      sliceId: "S01",
-      taskId: "T01",
-      pollWhileCommand: "echo hello",
+    createFixture();
+    insertExternalWait("M001", "S01", "T01", "echo hello", {
       pollIntervalMs: 5000,
       timeoutMs: 60000,
-      probeFailureCount: 0,
     });
 
     const row = getExternalWait("M001", "S01", "T01");
@@ -271,14 +227,8 @@ describe("external_waits DB table", () => {
   });
 
   test("incrementProbeFailureCount increments by 1", () => {
-    const { basePath } = createFixture();
-    insertExternalWaitRow(basePath, {
-      milestoneId: "M001",
-      sliceId: "S01",
-      taskId: "T01",
-      pollWhileCommand: "echo test",
-      probeFailureCount: 0,
-    });
+    createFixture();
+    insertExternalWait("M001", "S01", "T01", "echo test");
 
     incrementProbeFailureCount("M001", "S01", "T01");
     const row = getExternalWait("M001", "S01", "T01");
@@ -346,11 +296,7 @@ describe("dispatch rule probe execution", () => {
   test("exit 0 (still running) → sleep action", async () => {
     const { basePath } = createFixture();
     updateTaskStatus("M001", "S01", "T01", "awaiting-external");
-    insertExternalWaitRow(basePath, {
-      milestoneId: "M001",
-      sliceId: "S01",
-      taskId: "T01",
-      pollWhileCommand: "exit 0",
+    insertExternalWait("M001", "S01", "T01", "exit 0", {
       pollIntervalMs: 15000,
     });
     writeProbeSpec(basePath, "M001", "S01", "T01", "exit 0");
@@ -372,12 +318,7 @@ describe("dispatch rule probe execution", () => {
   test("exit non-zero (done) → skip action", async () => {
     const { basePath } = createFixture();
     updateTaskStatus("M001", "S01", "T01", "awaiting-external");
-    insertExternalWaitRow(basePath, {
-      milestoneId: "M001",
-      sliceId: "S01",
-      taskId: "T01",
-      pollWhileCommand: "exit 1",
-    });
+    insertExternalWait("M001", "S01", "T01", "exit 1");
     writeProbeSpec(basePath, "M001", "S01", "T01", "exit 1");
     invalidateAllCaches();
 
@@ -397,13 +338,8 @@ describe("dispatch rule probe execution", () => {
   test("probe timeout increments failure count", { timeout: 40000, skip: skipSlow }, async () => {
     const { basePath } = createFixture();
     updateTaskStatus("M001", "S01", "T01", "awaiting-external");
-    insertExternalWaitRow(basePath, {
-      milestoneId: "M001",
-      sliceId: "S01",
-      taskId: "T01",
-      pollWhileCommand: "sleep 35",
+    insertExternalWait("M001", "S01", "T01", "sleep 35", {
       pollIntervalMs: 10000,
-      probeFailureCount: 0,
     });
     writeProbeSpec(basePath, "M001", "S01", "T01", "sleep 35");
     invalidateAllCaches();
@@ -428,14 +364,11 @@ describe("dispatch rule probe execution", () => {
   test("3-strike escalation → stop action", { timeout: 40000, skip: skipSlow }, async () => {
     const { basePath } = createFixture();
     updateTaskStatus("M001", "S01", "T01", "awaiting-external");
-    insertExternalWaitRow(basePath, {
-      milestoneId: "M001",
-      sliceId: "S01",
-      taskId: "T01",
-      pollWhileCommand: "sleep 35",
+    insertExternalWait("M001", "S01", "T01", "sleep 35", {
       pollIntervalMs: 10000,
-      probeFailureCount: 2, // Already at 2, timeout will push to 3
     });
+    // Pre-set failure count to 2 so one timeout pushes to 3
+    setProbeFailureCount("M001", "S01", "T01", 2);
     writeProbeSpec(basePath, "M001", "S01", "T01", "sleep 35");
     invalidateAllCaches();
 

--- a/src/resources/extensions/gsd/tests/gsd-db.test.ts
+++ b/src/resources/extensions/gsd/tests/gsd-db.test.ts
@@ -99,7 +99,7 @@ describe('gsd-db', () => {
     // Check schema_version table
     const adapter = _getAdapter()!;
     const version = adapter.prepare('SELECT MAX(version) as version FROM schema_version').get();
-    assert.deepStrictEqual(version?.['version'], 22, 'schema version should be 22');
+    assert.deepStrictEqual(version?.['version'], 23, 'schema version should be 23');
 
     // Check tables exist by querying them
     const dRows = adapter.prepare('SELECT count(*) as cnt FROM decisions').get();

--- a/src/resources/extensions/gsd/tests/md-importer.test.ts
+++ b/src/resources/extensions/gsd/tests/md-importer.test.ts
@@ -363,7 +363,7 @@ test('md-importer: schema v1→v2 migration', () => {
   openDatabase(':memory:');
   const adapter = _getAdapter();
   const version = adapter?.prepare('SELECT MAX(version) as v FROM schema_version').get();
-  assert.deepStrictEqual(version?.v, 22, 'new DB should be at schema version 22');
+  assert.deepStrictEqual(version?.v, 23, 'new DB should be at schema version 23');
 
   // Artifacts table should exist
   const tableCheck = adapter?.prepare("SELECT count(*) as c FROM sqlite_master WHERE type='table' AND name='artifacts'").get();

--- a/src/resources/extensions/gsd/tests/memory-store.test.ts
+++ b/src/resources/extensions/gsd/tests/memory-store.test.ts
@@ -323,9 +323,9 @@ test('memory-store: schema includes memories table', () => {
   const viewCount = adapter.prepare('SELECT count(*) as cnt FROM active_memories').get();
   assert.deepStrictEqual(viewCount?.['cnt'], 0, 'active_memories view should exist');
 
-  // Verify schema version is 22 (v22 quality_gates DDL fix included)
+  // Verify schema version is 23 (v23 external_waits table)
   const version = adapter.prepare('SELECT MAX(version) as v FROM schema_version').get();
-  assert.deepStrictEqual(version?.["v"], 22, 'schema version should be 22');
+  assert.deepStrictEqual(version?.["v"], 23, 'schema version should be 23');
 
   closeDatabase();
 });

--- a/src/resources/extensions/gsd/tests/schema-v23-external-waits.test.ts
+++ b/src/resources/extensions/gsd/tests/schema-v23-external-waits.test.ts
@@ -13,6 +13,7 @@ import assert from "node:assert/strict";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
 
 import {
   openDatabase,
@@ -122,5 +123,138 @@ describe("Schema v23: external_waits table", () => {
     assert.equal(row.context_hint, "SLURM job 12345");
     assert.equal(row.on_timeout, "resume-with-failure");
     assert.equal(row.status, "waiting");
+  });
+
+  test("v22 → v23 migration creates external_waits table on reopen", () => {
+    tmpDir = mkdtempSync(join(tmpdir(), "gsd-v23-migrate-"));
+    const dbPath = join(tmpDir, "gsd.db");
+
+    // Step 1: Create a minimal v22 DB using raw sqlite (simulates a pre-v23 DB)
+    const rawDb = new DatabaseSync(dbPath);
+    rawDb.exec("PRAGMA journal_mode=WAL");
+    rawDb.exec("PRAGMA foreign_keys=ON");
+    rawDb.exec(`
+      CREATE TABLE schema_version (
+        version INTEGER PRIMARY KEY,
+        applied_at TEXT NOT NULL
+      )
+    `);
+    // Stamp as v22 — all migrations < 23 are "already applied"
+    for (let v = 1; v <= 22; v++) {
+      rawDb.prepare("INSERT INTO schema_version (version, applied_at) VALUES (?, ?)").run(v, new Date().toISOString());
+    }
+    // Create minimal prerequisite tables needed for FK references
+    rawDb.exec(`
+      CREATE TABLE milestones (
+        id TEXT PRIMARY KEY,
+        title TEXT NOT NULL DEFAULT '',
+        status TEXT NOT NULL DEFAULT 'pre-planning',
+        depends_on TEXT DEFAULT '[]',
+        created_at TEXT DEFAULT (datetime('now')),
+        completed_at TEXT,
+        vision TEXT DEFAULT '',
+        success_criteria TEXT DEFAULT '[]',
+        key_risks TEXT DEFAULT '[]',
+        proof_strategy TEXT DEFAULT '[]',
+        verification_contract TEXT DEFAULT '',
+        verification_integration TEXT DEFAULT '',
+        verification_operational TEXT DEFAULT '',
+        verification_uat TEXT DEFAULT '',
+        definition_of_done TEXT DEFAULT '[]',
+        requirement_coverage TEXT DEFAULT '',
+        boundary_map_markdown TEXT DEFAULT ''
+      )
+    `);
+    rawDb.exec(`
+      CREATE TABLE slices (
+        milestone_id TEXT NOT NULL,
+        id TEXT NOT NULL,
+        title TEXT NOT NULL DEFAULT '',
+        status TEXT NOT NULL DEFAULT 'pending',
+        risk TEXT DEFAULT 'medium',
+        depends TEXT DEFAULT '[]',
+        demo TEXT DEFAULT '',
+        created_at TEXT DEFAULT (datetime('now')),
+        completed_at TEXT,
+        full_summary_md TEXT DEFAULT '',
+        full_uat_md TEXT DEFAULT '',
+        goal TEXT DEFAULT '',
+        success_criteria TEXT DEFAULT '',
+        proof_level TEXT DEFAULT '',
+        integration_closure TEXT DEFAULT '',
+        observability_impact TEXT DEFAULT '',
+        sequence INTEGER DEFAULT 0,
+        replan_triggered_at TEXT,
+        is_sketch INTEGER DEFAULT 0,
+        sketch_scope TEXT DEFAULT '',
+        PRIMARY KEY (milestone_id, id)
+      )
+    `);
+    rawDb.exec(`
+      CREATE TABLE tasks (
+        milestone_id TEXT NOT NULL,
+        slice_id TEXT NOT NULL,
+        id TEXT NOT NULL,
+        title TEXT NOT NULL DEFAULT '',
+        status TEXT NOT NULL DEFAULT 'pending',
+        one_liner TEXT DEFAULT '',
+        narrative TEXT DEFAULT '',
+        verification_result TEXT DEFAULT '',
+        duration TEXT DEFAULT '',
+        completed_at TEXT,
+        blocker_discovered INTEGER DEFAULT 0,
+        deviations TEXT DEFAULT '',
+        known_issues TEXT DEFAULT '',
+        key_files TEXT DEFAULT '[]',
+        key_decisions TEXT DEFAULT '[]',
+        full_summary_md TEXT DEFAULT '',
+        description TEXT DEFAULT '',
+        estimate TEXT DEFAULT '',
+        files TEXT DEFAULT '[]',
+        verify TEXT DEFAULT '',
+        inputs TEXT DEFAULT '[]',
+        expected_output TEXT DEFAULT '[]',
+        observability_impact TEXT DEFAULT '',
+        full_plan_md TEXT DEFAULT '',
+        sequence INTEGER DEFAULT 0,
+        blocker_source TEXT DEFAULT '',
+        escalation_pending INTEGER DEFAULT 0,
+        escalation_awaiting_review INTEGER DEFAULT 0,
+        escalation_artifact_path TEXT,
+        escalation_override_applied_at TEXT,
+        PRIMARY KEY (milestone_id, slice_id, id)
+      )
+    `);
+    // v22 has no external_waits table — that's the point of this test
+    rawDb.close();
+
+    // Step 2: Reopen through GSD's openDatabase, which should trigger migration
+    openDatabase(dbPath);
+    const db = _getAdapter()!;
+    assert.ok(db, "DB should be open");
+
+    // Step 3: Verify external_waits table was created by migration
+    const tableInfo = db.prepare(
+      "SELECT name FROM sqlite_master WHERE type='table' AND name='external_waits'"
+    ).get() as { name: string } | undefined;
+    assert.ok(tableInfo, "external_waits table should exist after v22→v23 migration");
+
+    // Verify columns
+    const columns = db.prepare("PRAGMA table_info(external_waits)").all() as Array<{ name: string }>;
+    const colNames = columns.map(c => c.name);
+    assert.ok(colNames.includes("poll_while_command"), "should have poll_while_command column");
+    assert.ok(!colNames.includes("check_command"), "should NOT have old check_command column");
+
+    // Verify schema_version was bumped to 23
+    const vRow = db.prepare(
+      "SELECT version FROM schema_version WHERE version = 23"
+    ).get() as { version: number } | undefined;
+    assert.ok(vRow, "schema_version should contain v23 after migration");
+
+    // Verify index exists
+    const idx = db.prepare(
+      "SELECT name FROM sqlite_master WHERE type='index' AND name='idx_external_waits_milestone_status'"
+    ).get() as { name: string } | undefined;
+    assert.ok(idx, "idx_external_waits_milestone_status should exist after migration");
   });
 });

--- a/src/resources/extensions/gsd/tests/schema-v23-external-waits.test.ts
+++ b/src/resources/extensions/gsd/tests/schema-v23-external-waits.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Schema v23 migration test: external_waits table.
+ *
+ * Verifies:
+ * 1. Fresh DB creation includes the external_waits table with correct columns
+ * 2. The poll_while_command column exists (renamed from check_command)
+ * 3. A pre-v23 DB (stamped at v22) successfully migrates to v23
+ * 4. Index idx_external_waits_milestone_status exists
+ */
+
+import { describe, test, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  openDatabase,
+  closeDatabase,
+  _getAdapter,
+} from "../gsd-db.ts";
+
+let tmpDir: string;
+
+afterEach(() => {
+  try { closeDatabase(); } catch { /* may not be open */ }
+  if (tmpDir) {
+    rmSync(tmpDir, { recursive: true, force: true });
+    tmpDir = "";
+  }
+});
+
+describe("Schema v23: external_waits table", () => {
+  test("fresh DB has external_waits table with poll_while_command column", () => {
+    tmpDir = mkdtempSync(join(tmpdir(), "gsd-v23-"));
+    const dbPath = join(tmpDir, "gsd.db");
+
+    openDatabase(dbPath);
+    const db = _getAdapter()!;
+    assert.ok(db, "DB should be open");
+
+    // Verify table exists
+    const tableInfo = db.prepare(
+      "SELECT name FROM sqlite_master WHERE type='table' AND name='external_waits'"
+    ).get() as { name: string } | undefined;
+    assert.ok(tableInfo, "external_waits table should exist");
+
+    // Verify columns
+    const columns = db.prepare("PRAGMA table_info(external_waits)").all() as Array<{ name: string }>;
+    const colNames = columns.map(c => c.name);
+
+    assert.ok(colNames.includes("poll_while_command"), "should have poll_while_command column");
+    assert.ok(colNames.includes("success_check"), "should have success_check column");
+    assert.ok(colNames.includes("poll_interval_ms"), "should have poll_interval_ms column");
+    assert.ok(colNames.includes("timeout_ms"), "should have timeout_ms column");
+    assert.ok(colNames.includes("status"), "should have status column");
+    assert.ok(colNames.includes("probe_failure_count"), "should have probe_failure_count column");
+    assert.ok(colNames.includes("on_timeout"), "should have on_timeout column");
+    assert.ok(colNames.includes("context_hint"), "should have context_hint column");
+    assert.ok(colNames.includes("registered_at"), "should have registered_at column");
+    assert.ok(colNames.includes("resolved_at"), "should have resolved_at column");
+
+    // Verify the old column name does NOT exist
+    assert.ok(!colNames.includes("check_command"), "should NOT have old check_command column");
+  });
+
+  test("v23 schema version is recorded", () => {
+    tmpDir = mkdtempSync(join(tmpdir(), "gsd-v23-ver-"));
+    const dbPath = join(tmpDir, "gsd.db");
+
+    openDatabase(dbPath);
+    const db = _getAdapter()!;
+
+    const row = db.prepare(
+      "SELECT version FROM schema_version WHERE version = 23"
+    ).get() as { version: number } | undefined;
+    assert.ok(row, "schema_version should contain v23");
+    assert.equal(row.version, 23);
+  });
+
+  test("idx_external_waits_milestone_status index exists", () => {
+    tmpDir = mkdtempSync(join(tmpdir(), "gsd-v23-idx-"));
+    const dbPath = join(tmpDir, "gsd.db");
+
+    openDatabase(dbPath);
+    const db = _getAdapter()!;
+
+    const idx = db.prepare(
+      "SELECT name FROM sqlite_master WHERE type='index' AND name='idx_external_waits_milestone_status'"
+    ).get() as { name: string } | undefined;
+    assert.ok(idx, "idx_external_waits_milestone_status index should exist");
+  });
+
+  test("insertExternalWait + getExternalWait round-trip with poll_while_command", async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), "gsd-v23-rt-"));
+    const dbPath = join(tmpDir, "gsd.db");
+
+    openDatabase(dbPath);
+    const db = _getAdapter()!;
+
+    // Insert prerequisite rows
+    db.prepare("INSERT INTO milestones (id, title, status) VALUES ('M001', 'Test', 'active')").run();
+    db.prepare("INSERT INTO slices (milestone_id, id, title, status) VALUES ('M001', 'S01', 'Test', 'in_progress')").run();
+    db.prepare("INSERT INTO tasks (milestone_id, slice_id, id, title, status) VALUES ('M001', 'S01', 'T01', 'Test', 'executing')").run();
+
+    // Use the DB function directly
+    const { insertExternalWait, getExternalWait } = await import("../gsd-db.ts");
+    insertExternalWait("M001", "S01", "T01", "squeue -j 12345 | grep -c 12345", {
+      successCheck: "sacct -j 12345 --format=ExitCode",
+      pollIntervalMs: 60000,
+      timeoutMs: 3600000,
+      contextHint: "SLURM job 12345",
+      onTimeout: "resume-with-failure",
+    });
+
+    const row = getExternalWait("M001", "S01", "T01");
+    assert.ok(row, "should retrieve inserted external wait");
+    assert.equal(row.poll_while_command, "squeue -j 12345 | grep -c 12345");
+    assert.equal(row.success_check, "sacct -j 12345 --format=ExitCode");
+    assert.equal(row.poll_interval_ms, 60000);
+    assert.equal(row.timeout_ms, 3600000);
+    assert.equal(row.context_hint, "SLURM job 12345");
+    assert.equal(row.on_timeout, "resume-with-failure");
+    assert.equal(row.status, "waiting");
+  });
+});

--- a/src/resources/extensions/gsd/types.ts
+++ b/src/resources/extensions/gsd/types.ts
@@ -23,7 +23,8 @@ export type Phase =
   | "escalating-task"
   | "complete"
   | "paused"
-  | "blocked";
+  | "blocked"
+  | "awaiting-external";
 export type ContinueStatus = "in_progress" | "interrupted" | "compacted";
 
 // ─── Roadmap (Milestone-level) ─────────────────────────────────────────────

--- a/src/resources/extensions/gsd/workflow-manifest.ts
+++ b/src/resources/extensions/gsd/workflow-manifest.ts
@@ -5,6 +5,7 @@ import {
   type MilestoneRow,
   type SliceRow,
   type TaskRow,
+  type ExternalWaitRow,
 } from "./gsd-db.js";
 import type { Decision } from "./types.js";
 import { atomicWriteSync } from "./atomic-write.js";
@@ -12,6 +13,8 @@ import { readFileSync, existsSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
 
 // ─── Manifest Types ──────────────────────────────────────────────────────
+
+export { type ExternalWaitRow } from "./gsd-db.js";
 
 export interface VerificationEvidenceRow {
   id: number;
@@ -33,6 +36,7 @@ export interface StateManifest {
   tasks: TaskRow[];
   decisions: Decision[];
   verification_evidence: VerificationEvidenceRow[];
+  external_waits?: ExternalWaitRow[];
 }
 
 // ─── helpers ─────────────────────────────────────────────────────────────
@@ -183,6 +187,27 @@ export function snapshotState(): StateManifest {
     created_at: r["created_at"] as string,
   }));
 
+  // Snapshot external_waits — table may not exist in older DBs
+  let external_waits: ExternalWaitRow[] = [];
+  try {
+    const rawWaits = db.prepare("SELECT * FROM external_waits ORDER BY milestone_id, slice_id, task_id").all() as Record<string, unknown>[];
+    external_waits = rawWaits.map((r) => ({
+      milestone_id: r["milestone_id"] as string,
+      slice_id: r["slice_id"] as string,
+      task_id: r["task_id"] as string,
+      status: r["status"] as string,
+      poll_while_command: r["poll_while_command"] as string,
+      success_check: (r["success_check"] as string) ?? null,
+      poll_interval_ms: toNumeric(r["poll_interval_ms"], 30000) as number,
+      timeout_ms: toNumeric(r["timeout_ms"], 86400000) as number,
+      context_hint: (r["context_hint"] as string) ?? null,
+      on_timeout: (r["on_timeout"] as string) ?? "manual-attention",
+      probe_failure_count: toNumeric(r["probe_failure_count"], 0) as number,
+      registered_at: r["registered_at"] as string,
+      resolved_at: (r["resolved_at"] as string) ?? null,
+    }));
+  } catch { /* table doesn't exist in pre-v23 DBs */ }
+
   const result: StateManifest = {
     version: 1,
     exported_at: new Date().toISOString(),
@@ -191,6 +216,7 @@ export function snapshotState(): StateManifest {
     tasks,
     decisions,
     verification_evidence,
+    ...(external_waits.length ? { external_waits } : {}),
   };
 
   return result;

--- a/src/resources/extensions/gsd/workflow-manifest.ts
+++ b/src/resources/extensions/gsd/workflow-manifest.ts
@@ -206,7 +206,11 @@ export function snapshotState(): StateManifest {
       registered_at: r["registered_at"] as string,
       resolved_at: (r["resolved_at"] as string) ?? null,
     }));
-  } catch { /* table doesn't exist in pre-v23 DBs */ }
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    if (!msg.includes("no such table")) throw e;
+    /* table doesn't exist in pre-v23 DBs — safe to ignore */
+  }
 
   const result: StateManifest = {
     version: 1,


### PR DESCRIPTION
## Summary

Split 1/3 of #4655 — DB schema and state machine integration only, no exec surface.

- Schema v23 migration adds `external_waits` table with indexed lookup by `(milestone_id, status)`
- New `awaiting-external` phase type and `sleep` dispatch action for the auto-loop
- State derivation, journal event types, session state, and dashboard display labels
- Phase carry-forward logic for resuming after external completion

**No shell execution, no tool registration, no user-facing docs** — those land in #4792 and #4793.

## Files (16)

| Group | Files |
|-------|-------|
| Schema + DB | `gsd-db.ts` (+137) |
| Types | `types.ts`, `engine-types.ts`, `journal.ts` |
| State machine | `state.ts`, `auto/session.ts`, `auto/loop.ts`, `auto/phases.ts` |
| Dashboard | `auto-dashboard.ts` |
| Tests (schema migration) | `schema-v23-external-waits.test.ts` (new), `external-wait-state-dispatch.test.ts` (new) |
| Tests (version bumps) | `gsd-db.test.ts`, `ensure-db-open.test.ts`, `escalation.test.ts`, `md-importer.test.ts`, `memory-store.test.ts` |

## Test plan

- [ ] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/schema-v23-external-waits.test.ts`
- [ ] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/external-wait-state-dispatch.test.ts`
- [ ] Existing test suites pass with updated schema version assertions

Merge order: **this** → #4792 → #4793. Supersedes #4655.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for waiting on external jobs: probe-based polling with interruptible backoff ("sleep"), timeouts, failure-count escalation, and automatic resume messaging
  * New "awaiting-external" phase/label to surface tasks paused for external work
  * External-wait records persisted and included in state snapshots/manifest exports
* **Documentation**
  * New user guide describing external-process waiting and probe semantics
* **Tests**
  * Updated tests to expect DB schema v23 and many new integration tests for the external-wait/probe flow
<!-- end of auto-generated comment: release notes by coderabbit.ai -->