### PR TITLE
docs(contributing): ban source-grep tests + 72h review SLA + first-time contributor gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,12 @@ jobs:
           PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: bash scripts/require-tests.sh
 
+      - name: Reject source-grep tests
+        if: github.event_name == 'pull_request'
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: bash scripts/check-source-grep-tests.sh
+
   build:
     timeout-minutes: 15
     needs: detect-changes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,12 @@ Read [VISION.md](VISION.md) before contributing. It defines what GSD-2 is, what 
 3. **No issue? Create one first** for new features. Bug fixes for obvious problems can skip this step.
 4. **Architectural changes require an RFC.** If your change touches core systems (auto-mode, agent-core, orchestration), open an issue describing your approach and get approval before writing code. We use Architecture Decision Records (ADRs) for significant decisions.
 
+### First-time contributors
+
+We are not a fan of drive-by first-time contributions. If this is your first PR to GSD-2, you **must** open an issue first describing the problem or feature, wait for a maintainer response, and link the issue in your PR. First-time PRs that show up with no prior issue will be closed without review. This is not optional — it exists because triaging unsolicited code from unknown contributors is more expensive than the contribution is worth.
+
+Once you have one merged PR, this requirement no longer applies to you.
+
 ## Branching and commits
 
 Always work on a dedicated branch. Never push directly to `main`.
@@ -163,6 +169,12 @@ PRs go through automated review first, then human review. To help us review effi
 - Respond to review comments. If you disagree, explain why — discussion is welcome.
 - If your PR has been open for a while without review, ping in Discord. We're a small team and things slip.
 
+### 72-hour response policy
+
+Once a maintainer leaves review feedback, you have **72 hours** to respond — either with a code update, a question, or a comment explaining your timeline. We reserve the right to close PRs that go silent past 72 hours. Closed PRs can be reopened once you're ready to engage; we're not trying to throw away your work, we're trying to keep the review queue honest about what's actually moving.
+
+If you know you'll be unavailable, say so in the PR — a one-line "out until Monday" is enough to pause the clock.
+
 ### What reviewers verify
 
 Reading a diff is not the same as verifying a change. Our review standard is execution-based, not static-analysis-based.
@@ -174,6 +186,7 @@ Reading a diff is not the same as verifying a change. Our review standard is exe
 3. **Run the test suite** — run `npm test`. CI status is a signal, not a substitute for local verification.
 4. **Trace root cause for bug fixes** — confirm the diff addresses the root cause described in the issue, not just the symptom.
 5. **Check for a regression test** — bug fixes must include a test that would have caught the original bug. If it's absent, the fix is incomplete.
+6. **Reject source-grep tests** — any test that reads a source file with `readFileSync` (or equivalent) and asserts via regex/string match/AST inspection is not a test. Send it back. See "No source-grep tests" under Testing standards.
 
 Only after completing these steps should a reviewer make claims about correctness.
 
@@ -269,6 +282,42 @@ const content = `
 ### Test-first for bug fixes
 
 Bug fixes must include a regression test that fails before the fix and passes after. Write the test first, confirm it fails, then apply the fix. See the `test-first-bugfix` skill.
+
+### No source-grep tests
+
+A test must execute the code under test. Reading a source file with `readFileSync` (or any equivalent) and asserting against its contents with regex, string matching, or AST inspection is **not a test** — it asserts that the code was *written a certain way*, not that it *behaves correctly*. This is pure Goodhart's Law: the metric (test count, coverage) gets satisfied while the actual property (correctness) is untouched.
+
+```typescript
+// ❌ WRONG — source-grep test. Passes if the string exists, regardless of behavior.
+test("handles null input", () => {
+  const source = readFileSync("src/parser.ts", "utf8");
+  assert.match(source, /if \(input === null\)/);
+});
+
+// ❌ WRONG — same anti-pattern with AST or string includes.
+test("exports the function", () => {
+  const source = readFileSync("src/index.ts", "utf8");
+  assert.ok(source.includes("export function parse"));
+});
+
+// ✅ CORRECT — import the code and exercise it.
+import { parse } from "../src/parser.ts";
+test("handles null input", () => {
+  assert.equal(parse(null), undefined);
+});
+```
+
+PRs containing source-grep tests will be sent back. CI enforces this via `scripts/check-source-grep-tests.sh` (wired into the `lint` job) — it scans changed test files for `readFileSync` / `readFile` calls whose path argument points into `src/` or `packages/`. If the code under test is genuinely hard to invoke (e.g., a build script, a CLI entry point), invoke it as a subprocess and assert on its real output — not on its source text.
+
+The narrow exception: tests that legitimately verify *file structure* as the actual product (e.g., a code generator's output, a config-file linter, a script that produces a manifest). In those cases the file contents *are* the behavior. Opt out with a same-line or preceding-line marker:
+
+```typescript
+// allow-source-grep: this test verifies the codegen output, which IS the product
+const generated = readFileSync("packages/codegen/dist/manifest.ts", "utf8");
+assert.match(generated, /export const ROUTES =/);
+```
+
+The reason becomes part of the diff and is visible at review. If you're not sure whether your case qualifies, it doesn't.
 
 ## Local development
 

--- a/scripts/check-source-grep-tests.sh
+++ b/scripts/check-source-grep-tests.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# GSD-2 — Reject source-grep tests
+# Copyright (c) 2026 Jeremy McSpadden <jeremy@fluxlabs.net>
+#
+# Fails CI if a PR adds or modifies a test file that reads a source file with
+# readFileSync / readFile / fs.promises.readFile and asserts against its text
+# (regex, includes, match). See "No source-grep tests" in CONTRIBUTING.md.
+#
+# Escape hatch: add `// allow-source-grep: <reason>` on or directly above the
+# offending line. The reason becomes part of the diff and is visible at review.
+
+set -euo pipefail
+
+if [ -n "${PR_BASE_SHA:-}" ]; then
+  BASE="$PR_BASE_SHA"
+elif [ -n "${PUSH_BEFORE_SHA:-}" ]; then
+  BASE="$PUSH_BEFORE_SHA"
+else
+  BASE="origin/main"
+fi
+
+# --- Find added/modified test files in the diff ---
+CHANGED=$(git diff --name-only --diff-filter=AM "$BASE" HEAD 2>/dev/null \
+  || git diff --name-only --diff-filter=AM HEAD~1)
+
+TEST_FILES=$(echo "$CHANGED" \
+  | grep -E '\.(test|spec)\.(ts|mts|mjs|js|cjs)$' \
+  || true)
+
+if [ -z "$TEST_FILES" ]; then
+  echo "✓ No test files changed — source-grep check does not apply"
+  exit 0
+fi
+
+# --- Pattern: readFileSync / readFile / fs.promises.readFile applied to a
+#     path containing src/ or packages/ — i.e., reading source as text. ---
+#
+# Matches:
+#   readFileSync("src/foo.ts", ...)
+#   readFileSync(`packages/x/src/y.ts`, ...)
+#   await readFile(join(__dirname, "../src/parser.ts"), ...)
+#   fs.promises.readFile("packages/...", ...)
+#
+# Does NOT match arbitrary readFileSync of fixtures, JSON, etc.
+READ_SOURCE_RE='(readFileSync|readFile|fs\.promises\.readFile)[[:space:]]*\([^)]*(src/|packages/)[^)]*\.(ts|mts|mjs|js|cjs|tsx|jsx)'
+
+OFFENDERS=""
+
+while IFS= read -r FILE; do
+  [ -z "$FILE" ] && continue
+  [ ! -f "$FILE" ] && continue
+
+  # grep with line numbers; allow opt-out via marker on the same line OR the
+  # immediately preceding line.
+  while IFS=: read -r LINENO MATCH; do
+    [ -z "$LINENO" ] && continue
+
+    # Same-line escape hatch
+    if echo "$MATCH" | grep -q 'allow-source-grep:'; then
+      continue
+    fi
+
+    # Previous-line escape hatch
+    PREV_LINE=$((LINENO - 1))
+    if [ "$PREV_LINE" -gt 0 ]; then
+      PREV=$(sed -n "${PREV_LINE}p" "$FILE")
+      if echo "$PREV" | grep -q 'allow-source-grep:'; then
+        continue
+      fi
+    fi
+
+    OFFENDERS+="${FILE}:${LINENO}: ${MATCH}"$'\n'
+  done < <(grep -nE "$READ_SOURCE_RE" "$FILE" || true)
+done <<< "$TEST_FILES"
+
+if [ -n "$OFFENDERS" ]; then
+  echo "──────────────────────────────────────────────────────"
+  echo "✗ FAILED: Source-grep test pattern detected"
+  echo "──────────────────────────────────────────────────────"
+  echo ""
+  echo "These test files read a source file as text. A test must execute"
+  echo "the code under test, not assert on its source string."
+  echo ""
+  printf '%s' "$OFFENDERS" | sed 's/^/  /'
+  echo ""
+  echo "See \"No source-grep tests\" in CONTRIBUTING.md."
+  echo ""
+  echo "If this is a legitimate exception (code generator, file-structure"
+  echo "linter, manifest producer), add on or directly above the line:"
+  echo "    // allow-source-grep: <one-line reason>"
+  exit 1
+fi
+
+echo "✓ No source-grep test patterns in changed test files"


### PR DESCRIPTION
## TL;DR

**What:** Three CONTRIBUTING.md policy additions (no source-grep tests, 72h review-response SLA, first-time-contributor must-link-issue gate) plus a CI check that enforces the source-grep ban on changed test files.
**Why:** Source-grep tests are Goodhart's Law made executable — 10+ recent PRs add `readFileSync` + regex against source as "tests" that prove the code was *written* but not that it *works*. Review queue and contributor expectations also need explicit rules so reviewers can point at policy instead of re-arguing each time.
**How:** New `scripts/check-source-grep-tests.sh` (modeled on `scripts/require-tests.sh`) wired into the existing `lint` job, diff-scoped so existing offenders don't block unrelated work. Cleanup of pre-existing offenders tracked separately in #4789.

## What

- `CONTRIBUTING.md`
  - **No source-grep tests** subsection under Testing standards: defines the anti-pattern, gives wrong/right examples, documents the `// allow-source-grep: <reason>` escape hatch, and a tight exception clause for cases where file contents *are* the product (codegen, manifest linters).
  - **First-time contributors** subsection under Before you start: must open and link an issue before opening a PR; rule lifts after one merged PR.
  - **72-hour response policy** subsection under Review process: silent PRs past 72h after review feedback may be closed (and reopened); explicit pause-the-clock mechanism for known unavailability.
  - Reviewer checklist updated to call out source-grep rejection so reviewers can point at policy.
- `scripts/check-source-grep-tests.sh` — new bash check; scans test files added/modified in the diff for `(readFileSync|readFile|fs.promises.readFile)(...)` calls whose path argument contains `src/` or `packages/` and ends in a source-file extension. Honors a `// allow-source-grep: <reason>` marker on the same or preceding line.
- `.github/workflows/ci.yml` — invokes the new script from the existing `lint` job alongside `require-tests.sh`, using the same env-var-passing pattern (no untrusted GitHub-context interpolation into `run:`).

## Why

Source-grep tests passed code review unnoticed across multiple recent batches. Reviewers caught individual cases but had no policy to point at — so the same pattern kept landing. Codifying the rule + automating detection closes the loop. The 72h SLA and first-time gate are smaller adjacent governance wins picked up in the same pass.

Cleanup of the existing debt is intentionally **not** in this PR — it would block the policy landing on hundreds of file edits. Tracked in #4789.

## How

- The detection regex is intentionally narrow — it matches paths inside `src/` or `packages/` ending in source-file extensions, so tests reading JSON fixtures or markdown samples are unaffected.
- Diff-scoped (not repo-scoped) so the policy can land today without blocking the unrelated work in the existing 10+ offenders.
- Same `env:` pattern as `Require tests with source changes` — `PR_BASE_SHA` passed via env, never interpolated into the run script. No workflow-injection surface.
- Local sanity check: `bash scripts/check-source-grep-tests.sh` returns clean against this PR's own diff.

## Change type

- [x] `docs` — Documentation (CONTRIBUTING.md policy additions)
- [x] `ci` — CI/CD (new lint check, workflow wiring)

## Breaking changes

None for code. Behavioral change for contributors:
- New PRs from first-time contributors without a linked issue will be closed.
- New PRs adding source-grep test patterns will fail the `lint` job until rewritten or annotated.

Closes part of the workflow-tightening pass; cleanup of pre-existing source-grep offenders tracked in #4789.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contribution guidelines with stricter workflows for first-time contributors and maintainer response requirements.

* **Chores**
  * Enhanced CI pipeline with automated test quality validation to enforce higher testing standards across pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->