### PR TITLE
fix(resource-loader): use content hash instead of path+size for prompt refresh (#4787)

### DIFF
--- a/src/resource-loader.ts
+++ b/src/resource-loader.ts
@@ -127,17 +127,27 @@ function readManagedResourceManifest(agentDir: string): ManagedResourceManifest 
 }
 
 /**
- * Computes a lightweight content fingerprint of the bundled resources directory.
+ * Computes a content fingerprint of a resources directory (defaults to the
+ * bundled resourcesDir).
  *
- * Walks all files under resourcesDir and hashes their relative paths + sizes.
- * This catches same-version content changes (npm link dev workflow, hotfixes
- * within a release) without the cost of reading every file's contents.
+ * Walks all files under `rootDir` and hashes `${relativePath}:${sha256(contents)}`
+ * for each one. Using the file *contents* — not size — is what distinguishes
+ * this from the earlier implementation and closes #4787: a same-size edit
+ * (e.g. swapping one word for another word of the same byte length) produces
+ * a different file hash, bumps the aggregate fingerprint, and therefore
+ * triggers a full resync in `initResources`. The old path+size approach
+ * silently cached stale prompts across upgrades.
  *
- * ~1ms for a typical resources tree (~100 files) — just stat calls, no reads.
+ * Cost is ~1-2ms for a typical resources tree (~100 small .md files) —
+ * still negligible at startup. Files are streamed via `readFileSync` but
+ * bundled prompts are tiny so this is fine.
+ *
+ * Exported for unit tests and for callers that want to check a different
+ * directory (e.g. pre-install verification).
  */
-function computeResourceFingerprint(): string {
+export function computeResourceFingerprint(rootDir: string = resourcesDir): string {
   const entries: string[] = []
-  collectFileEntries(resourcesDir, resourcesDir, entries)
+  collectFileEntries(rootDir, rootDir, entries)
   entries.sort()
   return createHash('sha256').update(entries.join('\n')).digest('hex').slice(0, 16)
 }
@@ -150,8 +160,16 @@ function collectFileEntries(dir: string, root: string, out: string[]): void {
       collectFileEntries(fullPath, root, out)
     } else {
       const rel = relative(root, fullPath)
-      const size = statSync(fullPath).size
-      out.push(`${rel}:${size}`)
+      // Hash the file contents — see function doc for #4787 rationale.
+      let contentHash: string
+      try {
+        contentHash = createHash('sha256').update(readFileSync(fullPath)).digest('hex')
+      } catch {
+        // Unreadable file — fall back to a stable marker so the entry still
+        // contributes to the aggregate hash and future reads will re-hash.
+        contentHash = 'unreadable'
+      }
+      out.push(`${rel}:${contentHash}`)
     }
   }
 }
@@ -219,7 +237,7 @@ function makeTreeWritable(dirPath: string): void {
  * 3. Copies source into destination.
  * 4. Makes the result writable for the next upgrade cycle.
  */
-function syncResourceDir(srcDir: string, destDir: string): void {
+export function syncResourceDir(srcDir: string, destDir: string): void {
   makeTreeWritable(destDir)
   if (existsSync(srcDir)) {
     pruneStaleSiblingFiles(srcDir, destDir)

--- a/src/tests/resource-loader-content-hash.test.ts
+++ b/src/tests/resource-loader-content-hash.test.ts
@@ -1,0 +1,83 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+/**
+ * Regression test for gsd-build/gsd-2 #4787.
+ *
+ * Background: `computeResourceFingerprint` previously hashed the relative
+ * file path + file size only. Same-byte-length edits to bundled prompt
+ * templates (e.g. the #4570 retry-cap fix to parallel-research-slices.md)
+ * slipped through the fingerprint gate in `initResources`, so existing
+ * installs silently kept serving the stale cached copy from
+ * `~/.gsd/agent/extensions/gsd/prompts/`.
+ *
+ * The fix hashes file CONTENTS (sha256) instead of just size — any edit,
+ * regardless of length, produces a different fingerprint and triggers a
+ * resync on next launch.
+ */
+
+test("computeResourceFingerprint detects same-size content edits (#4787)", async (t) => {
+  const { computeResourceFingerprint } = await import("../resource-loader.ts");
+
+  const tmp = mkdtempSync(join(tmpdir(), "gsd-fingerprint-content-"));
+  t.after(() => { rmSync(tmp, { recursive: true, force: true }); });
+
+  const dirA = join(tmp, "bundled-a");
+  const dirB = join(tmp, "bundled-b");
+  mkdirSync(join(dirA, "prompts"), { recursive: true });
+  mkdirSync(join(dirB, "prompts"), { recursive: true });
+
+  // Same byte length (32 bytes each), different content — mirrors the
+  // real-world #4787 scenario where a hotfix edit keeps the file size
+  // stable but changes load-bearing instructions.
+  const contentA = "retry subagent once then BLOCKER"; // 32 bytes
+  const contentB = "retry subagent forever never stp"; // 32 bytes
+  assert.equal(Buffer.byteLength(contentA), Buffer.byteLength(contentB));
+
+  writeFileSync(join(dirA, "prompts", "foo.md"), contentA);
+  writeFileSync(join(dirB, "prompts", "foo.md"), contentB);
+
+  const hashA = computeResourceFingerprint(dirA);
+  const hashB = computeResourceFingerprint(dirB);
+
+  assert.notEqual(
+    hashA,
+    hashB,
+    "same-size, different-content trees must yield different fingerprints",
+  );
+});
+
+test("syncResourceDir overwrites same-size stale content on refresh (#4787)", async (t) => {
+  const { syncResourceDir } = await import("../resource-loader.ts");
+
+  const tmp = mkdtempSync(join(tmpdir(), "gsd-sync-samesize-"));
+  t.after(() => { rmSync(tmp, { recursive: true, force: true }); });
+
+  const bundled = join(tmp, "bundled", "prompts");
+  const installed = join(tmp, "installed", "prompts");
+  mkdirSync(bundled, { recursive: true });
+  mkdirSync(installed, { recursive: true });
+
+  // Bundled (new): the post-#4570 fix template
+  const newContent = "retry subagent once then BLOCKER";
+  // Installed (stale): pre-#4570 template with the same byte length
+  const staleContent = "retry subagent forever never stp";
+  assert.equal(Buffer.byteLength(newContent), Buffer.byteLength(staleContent));
+
+  writeFileSync(join(bundled, "parallel-research-slices.md"), newContent);
+  writeFileSync(join(installed, "parallel-research-slices.md"), staleContent);
+
+  // syncResourceDir always force-copies; this guards that the copy path
+  // itself overwrites regardless of size.
+  syncResourceDir(join(tmp, "bundled"), join(tmp, "installed"));
+
+  const actual = readFileSync(join(installed, "parallel-research-slices.md"), "utf-8");
+  assert.equal(
+    actual,
+    newContent,
+    "installed prompt must be overwritten with bundled content even when sizes match",
+  );
+});


### PR DESCRIPTION
## Summary

`computeResourceFingerprint` in `src/resource-loader.ts` hashed only `${relativePath}:${fileSize}` per file. Any same-byte-length edit to a bundled prompt produced an unchanged aggregate fingerprint, so `initResources` took the early-return fast path and never overwrote the stale copy in `~/.gsd/agent/extensions/gsd/prompts/` on existing installs. That silently regressed the retry cap added in PR #4570 (commit `585267c0d`) to `parallel-research-slices.md` — the fix for the #4068 / #4355 infinite-retry loop — for any user whose manifest hash happened to match the new path+size hash.

The fix: hash file **contents** (SHA-256) instead of file size. Any edit — same length or not — now bumps the fingerprint, trips the gate, and triggers the full `syncResourceDir` resync that `cpSync --force` uses to overwrite stale files.

## Why path+size was insufficient

Concrete #4787 scenario: swap 32 bytes of prompt text for 32 different bytes.

**Before (path+size):**
```
entry = "prompts/foo.md:32"          # identical across old and new
fingerprint = sha256(all entries)     # unchanged
→ manifest.contentHash === fingerprint → early return, no sync
```

**After (content SHA-256):**
```
entry_old = "prompts/foo.md:a7f3…"   # hash of old bytes
entry_new = "prompts/foo.md:e94d…"   # hash of new bytes
fingerprint = sha256(all entries)     # differs
→ mismatch → syncResourceDir → cpSync --force → stale copy overwritten
```

Cost: ~1-2 ms for a typical bundled tree (~100 small .md files) — imperceptible at startup.

## Affected files

- `src/resource-loader.ts` — `computeResourceFingerprint` now SHA-256s file contents; exported (parameterized by root dir) alongside `syncResourceDir` so tests can drive them directly.
- `src/tests/resource-loader-content-hash.test.ts` — new regression coverage (red/green for #4787).

## Blame

- PR #4570 (commit `585267c0d`, @trek-e) shipped the load-bearing template edit (retry-cap in `parallel-research-slices.md`) without verifying propagation — the underlying fingerprint was size-based, so the fix never landed on existing installs whose manifest already matched the pre-#4570 path+size hash.
- The fingerprint primitive itself predates #4570 and has always been size-based; #4570 just made the consequence user-visible.

## Test plan

- [x] New test `computeResourceFingerprint detects same-size content edits (#4787)` — two trees with identical file sizes but different contents must produce different fingerprints. RED on current tree, GREEN after this patch.
- [x] New test `syncResourceDir overwrites same-size stale content on refresh (#4787)` — guards the underlying copy path against same-size stale content.
- [x] `npm run test:compile` succeeds.
- [x] `npx tsc --noEmit --project tsconfig.extensions.json` — clean.
- [x] Resource-loader adjacent tests all pass: `src/tests/resource-loader.test.ts`, `resource-loader-conflicts.test.ts`, `resource-sync-staleness.test.ts`, plus the new `resource-loader-content-hash.test.ts` — 23/23 passing.
- [x] Full `npm run test:unit`: 7465 passed / 44 failed / 10 skipped. The 44 failures are unchanged pre-existing environmental failures in this worktree (baseline on `origin/main` = 46, of which 2 were my intentional RED tests; 46 − 2 = 44 post-fix).

Closes #4787

🤖 Generated with [Claude Code](https://claude.com/claude-code)