### PR TITLE
feat: add skill component registry

### DIFF
--- a/src/resources/extensions/gsd/component-registry.ts
+++ b/src/resources/extensions/gsd/component-registry.ts
@@ -7,7 +7,7 @@
 
 import { existsSync, realpathSync } from 'node:fs';
 import { homedir } from 'node:os';
-import { isAbsolute, join, resolve, sep } from 'node:path';
+import { basename, isAbsolute, join, resolve, sep } from 'node:path';
 import {
 	ECOSYSTEM_PROJECT_SKILLS_DIR,
 	ECOSYSTEM_SKILLS_DIR,
@@ -34,19 +34,13 @@ export class ComponentRegistry {
 	private loadDiagnostics: ComponentDiagnostic[] = [];
 	private loaded = false;
 	private readonly cwd: string;
-	private readonly defaultLoadOptions: ComponentRegistryLoadOptions;
 	private readonly realPathSet = new Set<string>();
 
-	constructor(cwd = process.cwd(), options: ComponentRegistryLoadOptions = {}) {
+	constructor(cwd = process.cwd()) {
 		this.cwd = cwd;
-		this.defaultLoadOptions = { includeDefaults: true, skillPaths: [], ...options };
 	}
 
-	getCwd(): string {
-		return this.cwd;
-	}
-
-	load(options: ComponentRegistryLoadOptions = this.defaultLoadOptions): void {
+	load(options: ComponentRegistryLoadOptions = {}): void {
 		const includeDefaults = options.includeDefaults ?? true;
 		const skillPaths = options.skillPaths ?? [];
 		this.components.clear();
@@ -59,14 +53,13 @@ export class ComponentRegistry {
 			this.addSkillDir(resolve(this.cwd, ECOSYSTEM_PROJECT_SKILLS_DIR, 'skills'), 'project');
 
 			const legacyDir = join(homedir(), '.gsd', 'agent', 'skills');
-			const legacyMigrated = existsSync(join(legacyDir, '.migrated-to-agents'));
-			if (legacyDir !== ECOSYSTEM_SKILLS_DIR && existsSync(legacyDir) && !legacyMigrated) {
+			if (shouldLoadLegacySkillsDir(legacyDir, ECOSYSTEM_SKILLS_DIR)) {
 				this.addSkillDir(legacyDir, 'user');
 			}
 		}
 
 		for (const rawPath of skillPaths) {
-			const resolvedPath = this.resolveSkillPath(rawPath);
+			const resolvedPath = resolveComponentSkillPath(rawPath, this.cwd);
 			const source = this.getSkillPathSource(resolvedPath, includeDefaults);
 			this.addSkillDir(resolvedPath, source);
 		}
@@ -230,15 +223,6 @@ export class ComponentRegistry {
 		}
 	}
 
-	private resolveSkillPath(rawPath: string): string {
-		const expanded = rawPath === '~'
-			? homedir()
-			: rawPath.startsWith('~/')
-				? join(homedir(), rawPath.slice(2))
-				: rawPath;
-		return isAbsolute(expanded) ? expanded : resolve(this.cwd, expanded);
-	}
-
 	private getSkillPathSource(resolvedPath: string, includeDefaults: boolean): ComponentSource {
 		if (includeDefaults) return 'path';
 		if (isUnderPath(resolvedPath, ECOSYSTEM_SKILLS_DIR)) return 'user';
@@ -258,7 +242,7 @@ function skillToComponent(skill: Skill): Component {
 			description: skill.description,
 		},
 		spec: {
-			prompt: skill.filePath.split(sep).pop() || 'SKILL.md',
+			prompt: basename(skill.filePath),
 			disableModelInvocation: skill.disableModelInvocation,
 		},
 		dirPath: skill.baseDir,
@@ -276,15 +260,17 @@ function isUnderPath(target: string, root: string): boolean {
 	return target.startsWith(prefix);
 }
 
-let registry: ComponentRegistry | null = null;
-
-export function getComponentRegistry(cwd?: string): ComponentRegistry {
-	if (!registry || (cwd && cwd !== registry.getCwd())) {
-		registry = new ComponentRegistry(cwd);
-	}
-	return registry;
+export function resolveComponentSkillPath(rawPath: string, cwd: string, homeDir = homedir()): string {
+	const expanded = rawPath === '~'
+		? homeDir
+		: rawPath.startsWith('~/')
+			? join(homeDir, rawPath.slice(2))
+			: rawPath;
+	return isAbsolute(expanded) ? expanded : resolve(cwd, expanded);
 }
 
-export function resetComponentRegistry(): void {
-	registry = null;
+export function shouldLoadLegacySkillsDir(legacyDir: string, ecosystemDir: string): boolean {
+	return legacyDir !== ecosystemDir
+		&& existsSync(legacyDir)
+		&& !existsSync(join(legacyDir, '.migrated-to-agents'));
 }

--- a/src/resources/extensions/gsd/component-registry.ts
+++ b/src/resources/extensions/gsd/component-registry.ts
@@ -1,0 +1,290 @@
+/**
+ * Skill-only component registry.
+ *
+ * This slice intentionally limits the registry to skills. Agents, pipelines,
+ * marketplace, and runtime wiring land in later PRs.
+ */
+
+import { existsSync, realpathSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { isAbsolute, join, resolve, sep } from 'node:path';
+import {
+	ECOSYSTEM_PROJECT_SKILLS_DIR,
+	ECOSYSTEM_SKILLS_DIR,
+	loadSkillsFromDir,
+	type Skill,
+} from '@gsd/pi-coding-agent';
+import type {
+	Component,
+	ComponentDiagnostic,
+	ComponentFilter,
+	ComponentSource,
+	SkillSpec,
+} from './component-types.js';
+import { computeComponentId } from './component-types.js';
+import { scanComponentDir } from './component-loader.js';
+
+export interface ComponentRegistryLoadOptions {
+	includeDefaults?: boolean;
+	skillPaths?: string[];
+}
+
+export class ComponentRegistry {
+	private components = new Map<string, Component>();
+	private loadDiagnostics: ComponentDiagnostic[] = [];
+	private loaded = false;
+	private readonly cwd: string;
+	private readonly defaultLoadOptions: ComponentRegistryLoadOptions;
+	private readonly realPathSet = new Set<string>();
+
+	constructor(cwd = process.cwd(), options: ComponentRegistryLoadOptions = {}) {
+		this.cwd = cwd;
+		this.defaultLoadOptions = { includeDefaults: true, skillPaths: [], ...options };
+	}
+
+	getCwd(): string {
+		return this.cwd;
+	}
+
+	load(options: ComponentRegistryLoadOptions = this.defaultLoadOptions): void {
+		const includeDefaults = options.includeDefaults ?? true;
+		const skillPaths = options.skillPaths ?? [];
+		this.components.clear();
+		this.loadDiagnostics = [];
+		this.realPathSet.clear();
+		this.loaded = true;
+
+		if (includeDefaults) {
+			this.addSkillDir(ECOSYSTEM_SKILLS_DIR, 'user');
+			this.addSkillDir(resolve(this.cwd, ECOSYSTEM_PROJECT_SKILLS_DIR, 'skills'), 'project');
+
+			const legacyDir = join(homedir(), '.gsd', 'agent', 'skills');
+			const legacyMigrated = existsSync(join(legacyDir, '.migrated-to-agents'));
+			if (legacyDir !== ECOSYSTEM_SKILLS_DIR && existsSync(legacyDir) && !legacyMigrated) {
+				this.addSkillDir(legacyDir, 'user');
+			}
+		}
+
+		for (const rawPath of skillPaths) {
+			const resolvedPath = this.resolveSkillPath(rawPath);
+			const source = this.getSkillPathSource(resolvedPath, includeDefaults);
+			this.addSkillDir(resolvedPath, source);
+		}
+	}
+
+	reload(): void {
+		this.load();
+	}
+
+	ensureLoaded(): void {
+		if (!this.loaded) this.load();
+	}
+
+	get(id: string): Component | undefined {
+		this.ensureLoaded();
+		return this.components.get(id);
+	}
+
+	resolve(idOrName: string): Component | undefined {
+		this.ensureLoaded();
+		const exact = this.components.get(idOrName);
+		if (exact) return exact;
+		if (idOrName.includes(':')) return undefined;
+
+		const matches = Array.from(this.components.values()).filter(
+			component => component.metadata.name === idOrName,
+		);
+		return matches.length === 1 ? matches[0] : undefined;
+	}
+
+	list(filter: ComponentFilter = {}): Component[] {
+		this.ensureLoaded();
+		let results = Array.from(this.components.values());
+
+		if (filter.enabledOnly !== false) {
+			results = results.filter(component => component.enabled);
+		}
+		if (filter.kind) {
+			const kinds = Array.isArray(filter.kind) ? filter.kind : [filter.kind];
+			results = results.filter(component => kinds.includes(component.kind));
+		}
+		if (filter.source) {
+			const sources = Array.isArray(filter.source) ? filter.source : [filter.source];
+			results = results.filter(component => sources.includes(component.source));
+		}
+		if (filter.namespace !== undefined) {
+			results = results.filter(component => component.metadata.namespace === filter.namespace);
+		}
+		if (filter.tags && filter.tags.length > 0) {
+			results = results.filter(component =>
+				component.metadata.tags?.some(tag => filter.tags!.includes(tag)),
+			);
+		}
+		if (filter.search) {
+			const q = filter.search.toLowerCase();
+			results = results.filter(component =>
+				component.metadata.name.toLowerCase().includes(q)
+				|| component.metadata.description.toLowerCase().includes(q),
+			);
+		}
+
+		return results;
+	}
+
+	skills(): Component[] {
+		return this.list({ kind: 'skill' });
+	}
+
+	has(id: string): boolean {
+		this.ensureLoaded();
+		return this.components.has(id);
+	}
+
+	get size(): number {
+		this.ensureLoaded();
+		return this.components.size;
+	}
+
+	diagnostics(): ComponentDiagnostic[] {
+		return [...this.loadDiagnostics];
+	}
+
+	getDiagnostics(): ComponentDiagnostic[] {
+		return this.diagnostics();
+	}
+
+	register(component: Component): ComponentDiagnostic | undefined {
+		const existing = this.components.get(component.id);
+		if (existing) {
+			const diagnostic: ComponentDiagnostic = {
+				type: 'collision',
+				message: `component "${component.id}" collision`,
+				componentId: component.id,
+				path: component.filePath,
+				collision: {
+					name: component.metadata.name,
+					winnerPath: existing.filePath,
+					loserPath: component.filePath,
+					winnerSource: existing.source,
+					loserSource: component.source,
+				},
+			};
+			this.loadDiagnostics.push(diagnostic);
+			return diagnostic;
+		}
+
+		this.components.set(component.id, component);
+		return undefined;
+	}
+
+	setEnabled(id: string, enabled: boolean): boolean {
+		const component = this.components.get(id);
+		if (!component) return false;
+		component.enabled = enabled;
+		return true;
+	}
+
+	getSkillsForPrompt(): Skill[] {
+		return this.skills().map(component => ({
+			name: component.metadata.name,
+			description: component.metadata.description,
+			filePath: component.filePath,
+			baseDir: component.dirPath,
+			source: component.source,
+			disableModelInvocation: (component.spec as SkillSpec).disableModelInvocation === true,
+		}));
+	}
+
+	private addSkillDir(dir: string, source: ComponentSource): void {
+		this.addLegacySkills(loadSkillsFromDir({ dir, source: source === 'project' ? 'project' : 'user' }));
+
+		const componentResult = scanComponentDir(dir, source, 'skill');
+		this.loadDiagnostics.push(...componentResult.diagnostics);
+		for (const component of componentResult.components) {
+			if (component.format === 'component-yaml') this.register(component);
+		}
+	}
+
+	private addLegacySkills(result: ReturnType<typeof loadSkillsFromDir>): void {
+		this.loadDiagnostics.push(
+			...result.diagnostics.map(diagnostic => ({
+				type: diagnostic.type === 'collision' ? 'collision' as const : 'warning' as const,
+				message: diagnostic.message,
+				path: diagnostic.path,
+				collision: diagnostic.collision,
+			})),
+		);
+
+		for (const skill of result.skills) {
+			let realPath = skill.filePath;
+			try {
+				realPath = realpathSync(skill.filePath);
+			} catch {
+				// Keep original path when the file cannot be resolved.
+			}
+			if (this.realPathSet.has(realPath)) continue;
+
+			const component = skillToComponent(skill);
+			const diagnostic = this.register(component);
+			if (!diagnostic) this.realPathSet.add(realPath);
+		}
+	}
+
+	private resolveSkillPath(rawPath: string): string {
+		const expanded = rawPath === '~'
+			? homedir()
+			: rawPath.startsWith('~/')
+				? join(homedir(), rawPath.slice(2))
+				: rawPath;
+		return isAbsolute(expanded) ? expanded : resolve(this.cwd, expanded);
+	}
+
+	private getSkillPathSource(resolvedPath: string, includeDefaults: boolean): ComponentSource {
+		if (includeDefaults) return 'path';
+		if (isUnderPath(resolvedPath, ECOSYSTEM_SKILLS_DIR)) return 'user';
+		if (isUnderPath(resolvedPath, resolve(this.cwd, ECOSYSTEM_PROJECT_SKILLS_DIR, 'skills'))) {
+			return 'project';
+		}
+		return 'path';
+	}
+}
+
+function skillToComponent(skill: Skill): Component {
+	return {
+		id: computeComponentId(skill.name),
+		kind: 'skill',
+		metadata: {
+			name: skill.name,
+			description: skill.description,
+		},
+		spec: {
+			prompt: skill.filePath.split(sep).pop() || 'SKILL.md',
+			disableModelInvocation: skill.disableModelInvocation,
+		},
+		dirPath: skill.baseDir,
+		filePath: skill.filePath,
+		source: skill.source === 'user' || skill.source === 'project' ? skill.source : 'path',
+		format: 'skill-md',
+		enabled: true,
+	};
+}
+
+function isUnderPath(target: string, root: string): boolean {
+	const normalizedRoot = resolve(root);
+	if (target === normalizedRoot) return true;
+	const prefix = normalizedRoot.endsWith(sep) ? normalizedRoot : `${normalizedRoot}${sep}`;
+	return target.startsWith(prefix);
+}
+
+let registry: ComponentRegistry | null = null;
+
+export function getComponentRegistry(cwd?: string): ComponentRegistry {
+	if (!registry || (cwd && cwd !== registry.getCwd())) {
+		registry = new ComponentRegistry(cwd);
+	}
+	return registry;
+}
+
+export function resetComponentRegistry(): void {
+	registry = null;
+}

--- a/src/resources/extensions/gsd/tests/component-registry.test.ts
+++ b/src/resources/extensions/gsd/tests/component-registry.test.ts
@@ -10,10 +10,9 @@ import { tmpdir } from 'node:os';
 import { loadSkills } from '@gsd/pi-coding-agent';
 import {
 	ComponentRegistry,
-	getComponentRegistry,
-	resetComponentRegistry,
+	resolveComponentSkillPath,
+	shouldLoadLegacySkillsDir,
 } from '../component-registry.js';
-import type { Component } from '../component-types.js';
 
 let testDir: string;
 
@@ -23,7 +22,7 @@ function setupTestDir(): string {
 	return dir;
 }
 
-function writeSkill(dir: string, name: string, description: string): void {
+function writeSkill(dir: string, name: string, description: string, body = `Use ${name}.`): string {
 	const skillDir = join(dir, name);
 	mkdirSync(skillDir, { recursive: true });
 	writeFileSync(join(skillDir, 'SKILL.md'), `---
@@ -31,39 +30,41 @@ name: ${name}
 description: ${description}
 ---
 
-Use ${name}.
+${body}
 `, 'utf-8');
+	return join(skillDir, 'SKILL.md');
 }
 
-function createComponent(overrides: Partial<Component> = {}): Component {
-	return {
-		id: overrides.id ?? 'review',
-		kind: 'skill',
-		metadata: overrides.metadata ?? { name: 'review', description: 'Reviews code' },
-		spec: overrides.spec ?? { prompt: 'SKILL.md' },
-		dirPath: overrides.dirPath ?? join(testDir, 'review'),
-		filePath: overrides.filePath ?? join(testDir, 'review', 'SKILL.md'),
-		source: overrides.source ?? 'project',
-		format: overrides.format ?? 'skill-md',
-		enabled: overrides.enabled ?? true,
-	};
+function writeComponentSkill(dir: string, name: string, namespace?: string): void {
+	const skillDir = join(dir, name);
+	mkdirSync(skillDir, { recursive: true });
+	writeFileSync(join(skillDir, 'component.yaml'), `
+apiVersion: gsd/v1
+kind: skill
+metadata:
+  name: ${name}
+${namespace ? `  namespace: ${namespace}\n` : ''}  description: "New format skill"
+spec:
+  prompt: SKILL.md
+`, 'utf-8');
+	writeFileSync(join(skillDir, 'SKILL.md'), `Use ${name}.`, 'utf-8');
 }
 
 describe('ComponentRegistry (skills)', () => {
 	beforeEach(() => {
-		resetComponentRegistry();
 		testDir = setupTestDir();
 	});
 
 	afterEach(() => {
 		rmSync(testDir, { recursive: true, force: true });
-		resetComponentRegistry();
 	});
 
-	it('registers, lists, resolves, and disables skill components', () => {
-		const registry = new ComponentRegistry(testDir, { includeDefaults: false });
-		registry.load();
-		registry.register(createComponent());
+	it('loads, lists, resolves, and disables skills from real SKILL.md files', () => {
+		const skillsDir = join(testDir, '.agents', 'skills');
+		writeSkill(skillsDir, 'review', 'Reviews code');
+
+		const registry = new ComponentRegistry(testDir);
+		registry.load({ includeDefaults: false, skillPaths: [skillsDir] });
 
 		assert.strictEqual(registry.size, 1);
 		assert.strictEqual(registry.resolve('review')?.id, 'review');
@@ -73,30 +74,31 @@ describe('ComponentRegistry (skills)', () => {
 		assert.strictEqual(registry.list({ enabledOnly: false }).length, 1);
 	});
 
-	it('keeps first winner and records duplicate-name collisions', () => {
-		const registry = new ComponentRegistry(testDir, { includeDefaults: false });
-		registry.load();
-		registry.register(createComponent({ filePath: join(testDir, 'a', 'SKILL.md') }));
-		registry.register(createComponent({ filePath: join(testDir, 'b', 'SKILL.md') }));
+	it('keeps first loaded skill and records duplicate-name collisions from load()', () => {
+		const firstDir = join(testDir, 'first-skills');
+		const secondDir = join(testDir, 'second-skills');
+		const firstPath = writeSkill(firstDir, 'review', 'First review skill');
+		const secondPath = writeSkill(secondDir, 'review', 'Second review skill');
+
+		const registry = new ComponentRegistry(testDir);
+		registry.load({ includeDefaults: false, skillPaths: [firstDir, secondDir] });
 
 		assert.strictEqual(registry.size, 1);
-		assert.strictEqual(registry.diagnostics().length, 1);
-		assert.strictEqual(registry.diagnostics()[0].type, 'collision');
-		assert.strictEqual(registry.diagnostics()[0].collision?.winnerPath, join(testDir, 'a', 'SKILL.md'));
+		assert.strictEqual(registry.resolve('review')?.filePath, firstPath);
+		const collision = registry.diagnostics().find(diagnostic => diagnostic.type === 'collision');
+		assert.ok(collision);
+		assert.strictEqual(collision.collision?.winnerPath, firstPath);
+		assert.strictEqual(collision.collision?.loserPath, secondPath);
 	});
 
-	it('resolves namespace-qualified skills and rejects ambiguous shorthand', () => {
-		const registry = new ComponentRegistry(testDir, { includeDefaults: false });
-		registry.load();
-		registry.register(createComponent({
-			id: 'alpha:review',
-			metadata: { name: 'review', namespace: 'alpha', description: 'Alpha review' },
-		}));
-		registry.register(createComponent({
-			id: 'beta:review',
-			metadata: { name: 'review', namespace: 'beta', description: 'Beta review' },
-			filePath: join(testDir, 'beta', 'SKILL.md'),
-		}));
+	it('resolves namespace-qualified skills and rejects ambiguous shorthand from loaded components', () => {
+		const alphaDir = join(testDir, 'alpha-skills');
+		const betaDir = join(testDir, 'beta-skills');
+		writeComponentSkill(alphaDir, 'review', 'alpha');
+		writeComponentSkill(betaDir, 'review', 'beta');
+
+		const registry = new ComponentRegistry(testDir);
+		registry.load({ includeDefaults: false, skillPaths: [alphaDir, betaDir] });
 
 		assert.strictEqual(registry.resolve('alpha:review')?.id, 'alpha:review');
 		assert.strictEqual(registry.resolve('review'), undefined);
@@ -104,21 +106,10 @@ describe('ComponentRegistry (skills)', () => {
 
 	it('loads new-format skill components from explicit skill paths', () => {
 		const skillsDir = join(testDir, '.agents', 'skills');
-		const skillDir = join(skillsDir, 'new-review');
-		mkdirSync(skillDir, { recursive: true });
-		writeFileSync(join(skillDir, 'component.yaml'), `
-apiVersion: gsd/v1
-kind: skill
-metadata:
-  name: new-review
-  description: "New format skill"
-spec:
-  prompt: SKILL.md
-`, 'utf-8');
-		writeFileSync(join(skillDir, 'SKILL.md'), 'Use new-review.', 'utf-8');
+		writeComponentSkill(skillsDir, 'new-review');
 
-		const registry = new ComponentRegistry(testDir, { includeDefaults: false, skillPaths: [skillsDir] });
-		registry.load();
+		const registry = new ComponentRegistry(testDir);
+		registry.load({ includeDefaults: false, skillPaths: [skillsDir] });
 
 		assert.strictEqual(registry.skills().length, 1);
 		assert.strictEqual(registry.resolve('new-review')?.format, 'component-yaml');
@@ -134,8 +125,8 @@ spec:
 			includeDefaults: false,
 			skillPaths: [skillsDir],
 		}).skills;
-		const registry = new ComponentRegistry(testDir, { includeDefaults: false, skillPaths: [skillsDir] });
-		registry.load();
+		const registry = new ComponentRegistry(testDir);
+		registry.load({ includeDefaults: false, skillPaths: [skillsDir] });
 
 		assert.deepStrictEqual(
 			registry.getSkillsForPrompt().map(skill => ({
@@ -157,11 +148,27 @@ spec:
 		);
 	});
 
-	it('returns cwd-specific singletons without private-field casts', () => {
-		const first = getComponentRegistry(join(testDir, 'one'));
-		const second = getComponentRegistry(join(testDir, 'two'));
+	it('expands ~ and ~/ skill paths against the supplied home directory helper', () => {
+		const fakeHome = join(testDir, 'home');
 
-		assert.notStrictEqual(first, second);
-		assert.strictEqual(second.getCwd(), join(testDir, 'two'));
+		assert.strictEqual(resolveComponentSkillPath('~', testDir, fakeHome), fakeHome);
+		assert.strictEqual(
+			resolveComponentSkillPath('~/skills', testDir, fakeHome),
+			join(fakeHome, 'skills'),
+		);
+		assert.strictEqual(
+			resolveComponentSkillPath('relative-skills', testDir, fakeHome),
+			join(testDir, 'relative-skills'),
+		);
+	});
+
+	it('skips migrated legacy skill directories', () => {
+		const legacyDir = join(testDir, 'legacy', 'agent', 'skills');
+		mkdirSync(legacyDir, { recursive: true });
+		assert.strictEqual(shouldLoadLegacySkillsDir(legacyDir, join(testDir, '.agents', 'skills')), true);
+
+		writeFileSync(join(legacyDir, '.migrated-to-agents'), '', 'utf-8');
+		assert.strictEqual(shouldLoadLegacySkillsDir(legacyDir, join(testDir, '.agents', 'skills')), false);
+		assert.strictEqual(shouldLoadLegacySkillsDir(legacyDir, legacyDir), false);
 	});
 });

--- a/src/resources/extensions/gsd/tests/component-registry.test.ts
+++ b/src/resources/extensions/gsd/tests/component-registry.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Skill component registry tests.
+ */
+
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { loadSkills } from '@gsd/pi-coding-agent';
+import {
+	ComponentRegistry,
+	getComponentRegistry,
+	resetComponentRegistry,
+} from '../component-registry.js';
+import type { Component } from '../component-types.js';
+
+let testDir: string;
+
+function setupTestDir(): string {
+	const dir = join(tmpdir(), `gsd-component-registry-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+	mkdirSync(dir, { recursive: true });
+	return dir;
+}
+
+function writeSkill(dir: string, name: string, description: string): void {
+	const skillDir = join(dir, name);
+	mkdirSync(skillDir, { recursive: true });
+	writeFileSync(join(skillDir, 'SKILL.md'), `---
+name: ${name}
+description: ${description}
+---
+
+Use ${name}.
+`, 'utf-8');
+}
+
+function createComponent(overrides: Partial<Component> = {}): Component {
+	return {
+		id: overrides.id ?? 'review',
+		kind: 'skill',
+		metadata: overrides.metadata ?? { name: 'review', description: 'Reviews code' },
+		spec: overrides.spec ?? { prompt: 'SKILL.md' },
+		dirPath: overrides.dirPath ?? join(testDir, 'review'),
+		filePath: overrides.filePath ?? join(testDir, 'review', 'SKILL.md'),
+		source: overrides.source ?? 'project',
+		format: overrides.format ?? 'skill-md',
+		enabled: overrides.enabled ?? true,
+	};
+}
+
+describe('ComponentRegistry (skills)', () => {
+	beforeEach(() => {
+		resetComponentRegistry();
+		testDir = setupTestDir();
+	});
+
+	afterEach(() => {
+		rmSync(testDir, { recursive: true, force: true });
+		resetComponentRegistry();
+	});
+
+	it('registers, lists, resolves, and disables skill components', () => {
+		const registry = new ComponentRegistry(testDir, { includeDefaults: false });
+		registry.load();
+		registry.register(createComponent());
+
+		assert.strictEqual(registry.size, 1);
+		assert.strictEqual(registry.resolve('review')?.id, 'review');
+		assert.strictEqual(registry.list({ kind: 'skill' }).length, 1);
+		assert.strictEqual(registry.setEnabled('review', false), true);
+		assert.strictEqual(registry.list().length, 0);
+		assert.strictEqual(registry.list({ enabledOnly: false }).length, 1);
+	});
+
+	it('keeps first winner and records duplicate-name collisions', () => {
+		const registry = new ComponentRegistry(testDir, { includeDefaults: false });
+		registry.load();
+		registry.register(createComponent({ filePath: join(testDir, 'a', 'SKILL.md') }));
+		registry.register(createComponent({ filePath: join(testDir, 'b', 'SKILL.md') }));
+
+		assert.strictEqual(registry.size, 1);
+		assert.strictEqual(registry.diagnostics().length, 1);
+		assert.strictEqual(registry.diagnostics()[0].type, 'collision');
+		assert.strictEqual(registry.diagnostics()[0].collision?.winnerPath, join(testDir, 'a', 'SKILL.md'));
+	});
+
+	it('resolves namespace-qualified skills and rejects ambiguous shorthand', () => {
+		const registry = new ComponentRegistry(testDir, { includeDefaults: false });
+		registry.load();
+		registry.register(createComponent({
+			id: 'alpha:review',
+			metadata: { name: 'review', namespace: 'alpha', description: 'Alpha review' },
+		}));
+		registry.register(createComponent({
+			id: 'beta:review',
+			metadata: { name: 'review', namespace: 'beta', description: 'Beta review' },
+			filePath: join(testDir, 'beta', 'SKILL.md'),
+		}));
+
+		assert.strictEqual(registry.resolve('alpha:review')?.id, 'alpha:review');
+		assert.strictEqual(registry.resolve('review'), undefined);
+	});
+
+	it('loads new-format skill components from explicit skill paths', () => {
+		const skillsDir = join(testDir, '.agents', 'skills');
+		const skillDir = join(skillsDir, 'new-review');
+		mkdirSync(skillDir, { recursive: true });
+		writeFileSync(join(skillDir, 'component.yaml'), `
+apiVersion: gsd/v1
+kind: skill
+metadata:
+  name: new-review
+  description: "New format skill"
+spec:
+  prompt: SKILL.md
+`, 'utf-8');
+		writeFileSync(join(skillDir, 'SKILL.md'), 'Use new-review.', 'utf-8');
+
+		const registry = new ComponentRegistry(testDir, { includeDefaults: false, skillPaths: [skillsDir] });
+		registry.load();
+
+		assert.strictEqual(registry.skills().length, 1);
+		assert.strictEqual(registry.resolve('new-review')?.format, 'component-yaml');
+	});
+
+	it('matches legacy .agents/skills loading shape through getSkillsForPrompt', () => {
+		const skillsDir = join(testDir, '.agents', 'skills');
+		writeSkill(skillsDir, 'review', 'Reviews code');
+		writeSkill(skillsDir, 'security-audit', 'Checks security issues');
+
+		const current = loadSkills({
+			cwd: testDir,
+			includeDefaults: false,
+			skillPaths: [skillsDir],
+		}).skills;
+		const registry = new ComponentRegistry(testDir, { includeDefaults: false, skillPaths: [skillsDir] });
+		registry.load();
+
+		assert.deepStrictEqual(
+			registry.getSkillsForPrompt().map(skill => ({
+				name: skill.name,
+				description: skill.description,
+				filePath: skill.filePath,
+				baseDir: skill.baseDir,
+				source: skill.source,
+				disableModelInvocation: skill.disableModelInvocation,
+			})).sort((a, b) => a.name.localeCompare(b.name)),
+			current.map(skill => ({
+				name: skill.name,
+				description: skill.description,
+				filePath: skill.filePath,
+				baseDir: skill.baseDir,
+				source: skill.source,
+				disableModelInvocation: skill.disableModelInvocation,
+			})).sort((a, b) => a.name.localeCompare(b.name)),
+		);
+	});
+
+	it('returns cwd-specific singletons without private-field casts', () => {
+		const first = getComponentRegistry(join(testDir, 'one'));
+		const second = getComponentRegistry(join(testDir, 'two'));
+
+		assert.notStrictEqual(first, second);
+		assert.strictEqual(second.getCwd(), join(testDir, 'two'));
+	});
+});


### PR DESCRIPTION
## Summary

- Adds a skill-only ComponentRegistry stacked on #4089.
- Preserves existing skill discovery precedence and first-winner collision behavior.
- Adds the legacy .agents/skills migration test requested in review by comparing getSkillsForPrompt() with the current loadSkills() shape.
- Keeps agents, pipelines, marketplace, and runtime wiring out of this slice.

Stacked on #4089. Base branch codex/component-system-foundation-base mirrors the current #4089 head and should be retargeted to main after #4089 merges.

## Test plan

- node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/component-types.test.ts src/resources/extensions/gsd/tests/component-loader.test.ts src/resources/extensions/gsd/tests/component-registry.test.ts
- npm run typecheck:extensions
- npm run build