### PR TITLE
refactor(auto): execute ADR-003 §4 — reassess-roadmap opt-in + plan-slice JIT preamble (#4778)

### DIFF
--- a/docs/dev/ADR-003-pipeline-simplification.md
+++ b/docs/dev/ADR-003-pipeline-simplification.md
@@ -200,16 +200,16 @@ For the same 4-slice, 3-task milestone:
 
 **Quality impact:** For most slices, the mechanical summary is sufficient — it aggregates structured frontmatter fields (provides, requires, affects, key_files, key_decisions, patterns_established) from task summaries. For complex slices with important narrative context, the LLM fallback preserves quality.
 
-#### 4. Eliminate reassess-roadmap (make opt-in)
+#### 4. Eliminate reassess-roadmap (make opt-in) — **IMPLEMENTED (#4778)**
 
 **Current:** After every slice completion, a reassess-roadmap session re-reads the ROADMAP and slice summary, then almost always writes "roadmap is fine."
 
 **New:** Reassessment is eliminated by default. The plan-slice agent for the next slice serves as the natural reassessment point — it reads the ROADMAP and prior slice summaries, and can adjust its plan if the ground has shifted.
 
 **What changes:**
-- The reassess-roadmap dispatch rule fires only when the `reassess_after_slice` preference is enabled (default: off, was effectively always-on).
-- The plan-slice prompt gains a reassessment preamble: "Before planning this slice, verify that the roadmap's assumptions still hold given prior slice summaries. If the remaining roadmap needs adjustment, modify it before proceeding."
-- The `checkNeedsReassessment()` function in auto-prompts.ts becomes a preference gate, not a mandatory check.
+- The reassess-roadmap dispatch rule fires only when the `reassess_after_slice` preference is enabled (default: off, was effectively always-on). **Landed:** `auto-dispatch.ts` now defaults `reassess_after_slice` to `false`. Opt-in via explicit `true` or the `burn-max` profile.
+- The plan-slice prompt gains a reassessment preamble: "Before planning this slice, verify that the roadmap's assumptions still hold given prior slice summaries. If the remaining roadmap needs adjustment, modify it before proceeding." **Landed:** `prompts/plan-slice.md` `### Verify Roadmap Assumptions (JIT Reassessment — ADR-003 §4)` with explicit `gsd_reassess_roadmap` tool-call guidance and "bias strongly toward roadmap is fine" instruction.
+- The `checkNeedsReassessment()` function in auto-prompts.ts becomes a preference gate, not a mandatory check. **Landed:** gated by `reassess_after_slice` (default false) in the dispatch rule; function signature unchanged.
 
 **Token savings:** ~1 session per completed non-final slice × (N-1) slices minus those already skipped. For a 4-slice milestone under quality profile: 3 sessions × 12–37K tokens = 36–111K tokens.
 

--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -89,6 +89,18 @@ export interface DispatchContext {
   modelRegistry?: MinimalModelRegistry;
 }
 
+type ReassessmentChecker = typeof checkNeedsReassessment;
+
+let reassessmentChecker: ReassessmentChecker = checkNeedsReassessment;
+
+export function setReassessmentCheckerForTest(checker: ReassessmentChecker): () => void {
+  const previous = reassessmentChecker;
+  reassessmentChecker = checker;
+  return () => {
+    reassessmentChecker = previous;
+  };
+}
+
 export interface DispatchRule {
   /** Human-readable name for debugging and test identification */
   name: string;
@@ -346,7 +358,7 @@ export const DISPATCH_RULES: DispatchRule[] = [
       // burn-max profile) when you want the dedicated reassess session.
       const reassessEnabled = prefs?.phases?.reassess_after_slice ?? false;
       if (!reassessEnabled) return null;
-      const needsReassess = await checkNeedsReassessment(basePath, mid, state);
+      const needsReassess = await reassessmentChecker(basePath, mid, state);
       if (!needsReassess) return null;
       return {
         action: "dispatch",

--- a/src/resources/extensions/gsd/auto-dispatch.ts
+++ b/src/resources/extensions/gsd/auto-dispatch.ts
@@ -338,9 +338,13 @@ export const DISPATCH_RULES: DispatchRule[] = [
     name: "reassess-roadmap (post-completion)",
     match: async ({ state, mid, midTitle, basePath, prefs }) => {
       if (prefs?.phases?.skip_reassess) return null;
-      // Default reassess_after_slice to true — reassessment after slice completion
-      // is essential for roadmap integrity. Opt-out via explicit `false`.
-      const reassessEnabled = prefs?.phases?.reassess_after_slice ?? true;
+      // Default reassess_after_slice to false per ADR-003 §4 — most reassess
+      // units conclude "roadmap is fine" and burn a session for no change.
+      // The plan-slice prompt now carries a reassessment preamble so the
+      // next slice's planner does JIT roadmap verification at zero extra
+      // cost. Opt-in via explicit `reassess_after_slice: true` (e.g.
+      // burn-max profile) when you want the dedicated reassess session.
+      const reassessEnabled = prefs?.phases?.reassess_after_slice ?? false;
       if (!reassessEnabled) return null;
       const needsReassess = await checkNeedsReassessment(basePath, mid, state);
       if (!needsReassess) return null;

--- a/src/resources/extensions/gsd/docs/preferences-reference.md
+++ b/src/resources/extensions/gsd/docs/preferences-reference.md
@@ -159,7 +159,7 @@ Setting `prefer_skills: []` does **not** disable skill discovery — it just mea
 
 - `phases`: fine-grained control over which phases run. Usually set by `token_profile`, but can be overridden. Keys:
   - `skip_research`: boolean — skip milestone-level research. Default: `false`.
-  - `reassess_after_slice`: boolean — run roadmap reassessment after each completed slice. Default: `true`.
+  - `reassess_after_slice`: boolean — run a dedicated roadmap-reassessment unit after each completed slice. Default: `false` (per ADR-003 §4). The plan-slice agent for the next slice performs JIT reassessment via a prompt preamble at zero additional token cost; a dedicated reassess session is opt-in. Set to `true` (e.g. via the `burn-max` profile) if you want the explicit session.
   - `skip_reassess`: boolean — force-disable roadmap reassessment even if `reassess_after_slice` is enabled. Default: `false`.
   - `skip_slice_research`: boolean — skip per-slice research. Default: `false`.
 

--- a/src/resources/extensions/gsd/prompts/plan-slice.md
+++ b/src/resources/extensions/gsd/prompts/plan-slice.md
@@ -20,9 +20,22 @@ Pay particular attention to **Forward Intelligence** sections — they contain h
 
 You have full tool access. Before decomposing, explore the relevant code to ground your plan in reality.
 
-### Verify Roadmap Assumptions
+### Verify Roadmap Assumptions (JIT Reassessment — ADR-003 §4)
 
-Check prior slice summaries (inlined above as dependency summaries, if present). If prior slices discovered constraints, changed approaches, or flagged fragility, adjust your plan accordingly. The roadmap description may be stale — verify it against the current codebase state.
+Before planning this slice, verify that the roadmap's assumptions still hold given prior slice summaries. Check inlined dependency summaries (below) for discovered constraints, changed approaches, or flagged fragility.
+
+**If the remaining roadmap needs adjustment, modify it before proceeding:**
+
+- If a downstream slice's title/demo/dependencies are now wrong, call `gsd_reassess_roadmap` with the corrected `sliceChanges.modified` entry.
+- If new work surfaced that deserves its own slice, add it via `sliceChanges.added`.
+- If a downstream slice is now redundant or out of scope, remove it via `sliceChanges.removed`.
+- **Bias strongly toward "roadmap is fine."** Most slice completions produce no structural change. Only adjust when there is concrete evidence a downstream slice is wrong — not speculative concern. Over-reassessment is costlier than a later mid-slice replan.
+
+Completed slices are immutable: never modify or remove a slice whose status is complete.
+
+Then proceed with planning this slice against the (possibly updated) roadmap.
+
+The roadmap description may be stale — verify it against the current codebase state.
 
 ### Explore Slice Scope
 

--- a/src/resources/extensions/gsd/tests/reassess-default-optin.test.ts
+++ b/src/resources/extensions/gsd/tests/reassess-default-optin.test.ts
@@ -5,12 +5,18 @@
 
 import test from "node:test";
 import assert from "node:assert/strict";
-import { mkdirSync, rmSync } from "node:fs";
+import { mkdirSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { randomUUID } from "node:crypto";
 
-import { DISPATCH_RULES, type DispatchContext } from "../auto-dispatch.ts";
+import {
+  DISPATCH_RULES,
+  setReassessmentCheckerForTest,
+  type DispatchAction,
+  type DispatchContext,
+} from "../auto-dispatch.ts";
+import { resolveProfileDefaults } from "../preferences-models.ts";
 import type { GSDState } from "../types.ts";
 import type { GSDPreferences } from "../preferences.ts";
 
@@ -42,57 +48,85 @@ function reassessRule() {
   return rule!;
 }
 
-test("ADR-003 §4: reassess-roadmap does NOT dispatch when prefs is undefined (new default)", async (t) => {
+const guardCases: Array<{ name: string; prefs: GSDPreferences | undefined; message?: string }> = [
+  {
+    name: "prefs is undefined (new default)",
+    prefs: undefined,
+    message: "default behavior must be opt-in — no prefs means no reassess dispatch",
+  },
+  {
+    name: "prefs.phases is undefined",
+    prefs: {} as GSDPreferences,
+  },
+  {
+    name: "phases.reassess_after_slice is explicitly false",
+    prefs: { phases: { reassess_after_slice: false } } as unknown as GSDPreferences,
+  },
+  {
+    name: "phases.skip_reassess is true (short-circuit guard preserved)",
+    prefs: { phases: { skip_reassess: true, reassess_after_slice: true } } as unknown as GSDPreferences,
+    message: "skip_reassess must win over reassess_after_slice",
+  },
+];
+
+for (const { name, prefs, message } of guardCases) {
+  test(`ADR-003 §4: reassess-roadmap does NOT dispatch when ${name}`, async (t) => {
+    const base = makeIsolatedBase();
+    t.after(() => { try { rmSync(base, { recursive: true, force: true }); } catch {} });
+
+    let checkerCalls = 0;
+    const restoreChecker = setReassessmentCheckerForTest(async () => {
+      checkerCalls++;
+      return { sliceId: "S01" };
+    });
+    t.after(restoreChecker);
+
+    const result = await reassessRule().match(makeCtx(prefs, base));
+    assert.strictEqual(result, null, message);
+    assert.strictEqual(checkerCalls, 0, "preference guards must short-circuit before reassessment detection");
+  });
+}
+
+test("ADR-003 §4: reassess-roadmap opt-in path dispatches after reassessment detection", async (t) => {
   const base = makeIsolatedBase();
   t.after(() => { try { rmSync(base, { recursive: true, force: true }); } catch {} });
 
-  const result = await reassessRule().match(makeCtx(undefined, base));
-  assert.strictEqual(result, null, "default behavior must be opt-in — no prefs means no reassess dispatch");
-});
+  const checkerCalls: Array<{ basePath: string; mid: string; activeSliceId: string | undefined }> = [];
+  const restoreChecker = setReassessmentCheckerForTest(async (checkerBase, checkerMid, state) => {
+    checkerCalls.push({ basePath: checkerBase, mid: checkerMid, activeSliceId: state.activeSlice?.id });
+    return { sliceId: "S01" };
+  });
+  t.after(restoreChecker);
 
-test("ADR-003 §4: reassess-roadmap does NOT dispatch when prefs.phases is undefined", async (t) => {
-  const base = makeIsolatedBase();
-  t.after(() => { try { rmSync(base, { recursive: true, force: true }); } catch {} });
-
-  const result = await reassessRule().match(makeCtx({} as GSDPreferences, base));
-  assert.strictEqual(result, null);
-});
-
-test("ADR-003 §4: reassess-roadmap does NOT dispatch when phases.reassess_after_slice is explicitly false", async (t) => {
-  const base = makeIsolatedBase();
-  t.after(() => { try { rmSync(base, { recursive: true, force: true }); } catch {} });
-
-  const prefs = { phases: { reassess_after_slice: false } } as unknown as GSDPreferences;
-  const result = await reassessRule().match(makeCtx(prefs, base));
-  assert.strictEqual(result, null);
-});
-
-test("ADR-003 §4: reassess-roadmap does NOT dispatch when phases.skip_reassess is true (short-circuit guard preserved)", async (t) => {
-  const base = makeIsolatedBase();
-  t.after(() => { try { rmSync(base, { recursive: true, force: true }); } catch {} });
-
-  // skip_reassess should short-circuit even if reassess_after_slice is true
-  const prefs = {
-    phases: { skip_reassess: true, reassess_after_slice: true },
-  } as unknown as GSDPreferences;
-  const result = await reassessRule().match(makeCtx(prefs, base));
-  assert.strictEqual(result, null, "skip_reassess must win over reassess_after_slice");
-});
-
-test("ADR-003 §4: reassess-roadmap opt-in path passes the preference guards (reaches checkNeedsReassessment)", async (t) => {
-  const base = makeIsolatedBase();
-  t.after(() => { try { rmSync(base, { recursive: true, force: true }); } catch {} });
-
-  // With reassess_after_slice=true and no completed slices on disk,
-  // checkNeedsReassessment returns null (no last-completed slice found).
-  // The guard-level behavior we want to assert is that the match function
-  // does not short-circuit at the preference gate — it proceeds to the
-  // detection helper, which in this fixture returns null because nothing
-  // has been completed yet. A null result here is equally compatible with
-  // "guard rejected" and "detection found nothing", so we can only
-  // assert the function returns null without crashing. The no-pref test
-  // above proves the default behavior; this test proves opt-in is wired.
   const prefs = { phases: { reassess_after_slice: true } } as unknown as GSDPreferences;
-  const result = await reassessRule().match(makeCtx(prefs, base));
-  assert.strictEqual(result, null);
+  const result: DispatchAction | null = await reassessRule().match(makeCtx(prefs, base));
+
+  assert.deepStrictEqual(checkerCalls, [{ basePath: base, mid: "M001", activeSliceId: "S01" }]);
+  assert.ok(result, "opt-in path should return a dispatch action when reassessment is needed");
+  assert.strictEqual(result.action, "dispatch");
+  if (result.action !== "dispatch") assert.fail("expected dispatch action");
+  assert.strictEqual(result.unitType, "reassess-roadmap");
+  assert.strictEqual(result.unitId, "M001/S01");
+  assert.match(result.prompt, /reassess/i);
+});
+
+test("ADR-003 §4: burn-max profile opts into dedicated reassess-roadmap dispatch", () => {
+  const defaults = resolveProfileDefaults("burn-max");
+  assert.strictEqual(defaults.phases?.reassess_after_slice, true);
+  assert.strictEqual(defaults.phases?.skip_reassess, false);
+});
+
+test("ADR-003 §4: plan-slice prompt and MCP tool agree on reassess sliceChanges shape", () => {
+  const planSlicePrompt = readFileSync(new URL("../prompts/plan-slice.md", import.meta.url), "utf8");
+  assert.match(planSlicePrompt, /gsd_reassess_roadmap/);
+  assert.match(planSlicePrompt, /sliceChanges\.modified/);
+  assert.match(planSlicePrompt, /sliceChanges\.added/);
+  assert.match(planSlicePrompt, /sliceChanges\.removed/);
+
+  const dbToolsSource = readFileSync(new URL("../bootstrap/db-tools.ts", import.meta.url), "utf8");
+  assert.match(dbToolsSource, /name:\s*"gsd_reassess_roadmap"/);
+  assert.match(dbToolsSource, /sliceChanges:\s*Type\.Object/);
+  assert.match(dbToolsSource, /modified:\s*Type\.Array/);
+  assert.match(dbToolsSource, /added:\s*Type\.Array/);
+  assert.match(dbToolsSource, /removed:\s*Type\.Array/);
 });

--- a/src/resources/extensions/gsd/tests/reassess-default-optin.test.ts
+++ b/src/resources/extensions/gsd/tests/reassess-default-optin.test.ts
@@ -1,0 +1,98 @@
+// GSD-2 — ADR-003 §4 behavior contract: reassess-roadmap is opt-in.
+// Companion to (eventually replacing) the source-grep assertions in
+// token-profile.test.ts. This file verifies the dispatch rule's guard
+// behavior directly rather than inspecting source text.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { randomUUID } from "node:crypto";
+
+import { DISPATCH_RULES, type DispatchContext } from "../auto-dispatch.ts";
+import type { GSDState } from "../types.ts";
+import type { GSDPreferences } from "../preferences.ts";
+
+const REASSESS_RULE_NAME = "reassess-roadmap (post-completion)";
+
+function makeIsolatedBase(): string {
+  const base = join(tmpdir(), `gsd-reassess-default-${randomUUID()}`);
+  mkdirSync(join(base, ".gsd", "milestones", "M001", "slices", "S01", "tasks"), { recursive: true });
+  return base;
+}
+
+function makeCtx(prefs: GSDPreferences | undefined, basePath: string): DispatchContext {
+  const state: GSDState = {
+    phase: "executing",
+    activeMilestone: { id: "M001", title: "Test" },
+    activeSlice: { id: "S01", title: "First" },
+    activeTask: null,
+    recentDecisions: [],
+    blockers: [],
+    nextAction: "",
+    registry: [{ id: "M001", title: "Test", status: "active" }],
+  };
+  return { basePath, mid: "M001", midTitle: "Test", state, prefs };
+}
+
+function reassessRule() {
+  const rule = DISPATCH_RULES.find(r => r.name === REASSESS_RULE_NAME);
+  assert.ok(rule, `dispatch rule "${REASSESS_RULE_NAME}" must exist`);
+  return rule!;
+}
+
+test("ADR-003 §4: reassess-roadmap does NOT dispatch when prefs is undefined (new default)", async (t) => {
+  const base = makeIsolatedBase();
+  t.after(() => { try { rmSync(base, { recursive: true, force: true }); } catch {} });
+
+  const result = await reassessRule().match(makeCtx(undefined, base));
+  assert.strictEqual(result, null, "default behavior must be opt-in — no prefs means no reassess dispatch");
+});
+
+test("ADR-003 §4: reassess-roadmap does NOT dispatch when prefs.phases is undefined", async (t) => {
+  const base = makeIsolatedBase();
+  t.after(() => { try { rmSync(base, { recursive: true, force: true }); } catch {} });
+
+  const result = await reassessRule().match(makeCtx({} as GSDPreferences, base));
+  assert.strictEqual(result, null);
+});
+
+test("ADR-003 §4: reassess-roadmap does NOT dispatch when phases.reassess_after_slice is explicitly false", async (t) => {
+  const base = makeIsolatedBase();
+  t.after(() => { try { rmSync(base, { recursive: true, force: true }); } catch {} });
+
+  const prefs = { phases: { reassess_after_slice: false } } as unknown as GSDPreferences;
+  const result = await reassessRule().match(makeCtx(prefs, base));
+  assert.strictEqual(result, null);
+});
+
+test("ADR-003 §4: reassess-roadmap does NOT dispatch when phases.skip_reassess is true (short-circuit guard preserved)", async (t) => {
+  const base = makeIsolatedBase();
+  t.after(() => { try { rmSync(base, { recursive: true, force: true }); } catch {} });
+
+  // skip_reassess should short-circuit even if reassess_after_slice is true
+  const prefs = {
+    phases: { skip_reassess: true, reassess_after_slice: true },
+  } as unknown as GSDPreferences;
+  const result = await reassessRule().match(makeCtx(prefs, base));
+  assert.strictEqual(result, null, "skip_reassess must win over reassess_after_slice");
+});
+
+test("ADR-003 §4: reassess-roadmap opt-in path passes the preference guards (reaches checkNeedsReassessment)", async (t) => {
+  const base = makeIsolatedBase();
+  t.after(() => { try { rmSync(base, { recursive: true, force: true }); } catch {} });
+
+  // With reassess_after_slice=true and no completed slices on disk,
+  // checkNeedsReassessment returns null (no last-completed slice found).
+  // The guard-level behavior we want to assert is that the match function
+  // does not short-circuit at the preference gate — it proceeds to the
+  // detection helper, which in this fixture returns null because nothing
+  // has been completed yet. A null result here is equally compatible with
+  // "guard rejected" and "detection found nothing", so we can only
+  // assert the function returns null without crashing. The no-pref test
+  // above proves the default behavior; this test proves opt-in is wired.
+  const prefs = { phases: { reassess_after_slice: true } } as unknown as GSDPreferences;
+  const result = await reassessRule().match(makeCtx(prefs, base));
+  assert.strictEqual(result, null);
+});


### PR DESCRIPTION
## TL;DR

**What:** Flip `phases.reassess_after_slice` to default `false`; add a JIT reassessment preamble to the plan-slice prompt so the next slice's planner does roadmap verification inline.
**Why:** ADR-003 §4 was already decided but only partially implemented — the preference existed, the default was wrong, and the plan-slice preamble was missing. Forensic session data (see #4778) showed 2 of 16 auto-mode units were no-op reassess dispatches burning ~\$0.36 / ~250K cached tokens for zero roadmap mutation.
**How:** One-line default flip in `auto-dispatch.ts`; new "Verify Roadmap Assumptions (JIT Reassessment — ADR-003 §4)" section in `prompts/plan-slice.md` instructing the planner to call `gsd_reassess_roadmap` when evidence warrants, with an explicit "bias strongly toward 'roadmap is fine.'" caveat.

## What

- `src/resources/extensions/gsd/auto-dispatch.ts` — reassess-roadmap dispatch rule defaults `reassess_after_slice` to `false` (was `?? true`). Comment points at ADR-003 §4 and the new preamble.
- `src/resources/extensions/gsd/prompts/plan-slice.md` — new JIT reassessment section under "Verify Roadmap Assumptions" that teaches the planner to call `gsd_reassess_roadmap` with `sliceChanges.modified / added / removed` when a downstream slice is genuinely off, reinforces the completed-slice immutability invariant, and biases strongly toward "roadmap is fine."
- `docs/dev/ADR-003-pipeline-simplification.md` — §4 marked **IMPLEMENTED** with landed-behavior notes.
- `src/resources/extensions/gsd/docs/preferences-reference.md` — `reassess_after_slice` default documented as `false` with ADR-003 pointer. (Other user-facing docs at `docs/user-docs/configuration.md:274` and the zh-CN mirror were already ADR-aligned and needed no change.)
- `src/resources/extensions/gsd/tests/reassess-default-optin.test.ts` — five new behavior tests (no source-grep) covering undefined prefs, empty phases object, explicit false, skip_reassess short-circuit, and opt-in wiring.

## Why

Closes #4778. Supersedes #4786.

During review of #4786 (which proposed a second heuristic preference `skip_clean_reassess` that parses the slice SUMMARY), it surfaced that `docs/dev/ADR-003-pipeline-simplification.md` §4 already prescribes the correct fix:

> The reassess-roadmap dispatch rule fires only when the `reassess_after_slice` preference is enabled (default: off, was effectively always-on).
> The plan-slice prompt gains a reassessment preamble...

The preference existed but the default in `auto-dispatch.ts` was still `?? true`, and the preamble was never written. Layering a second preference on top would have created two overlapping knobs with subtly different semantics. This PR executes the already-reviewed ADR directly.

**Token impact on the forensic b23-class session:** the two no-op reassess units (S01, S02) no longer fire → ~\$0.36 / ~250K cached tokens reclaimed per such session at zero quality cost. `burn-max` profile continues to opt in explicitly.

## How

### Default flip

`auto-dispatch.ts` guard order unchanged:

```ts
if (prefs?.phases?.skip_reassess) return null;
const reassessEnabled = prefs?.phases?.reassess_after_slice ?? false;  // was ?? true
if (!reassessEnabled) return null;
```

- Out-of-the-box: reassess does **not** dispatch. The plan-slice preamble absorbs the JIT responsibility.
- `burn-max` profile keeps its explicit `reassess_after_slice: true` — unchanged. Users who want the dedicated reassess session opt in via this profile or the preference directly.
- Other profiles (`budget`, `balanced`, `quality`) all already set `skip_reassess: true` — unchanged.

### Plan-slice preamble

The preamble distinguishes three outcomes the planner can act on:
- Downstream slice title/demo/deps wrong → `sliceChanges.modified`
- New work surfaced that deserves a slice → `sliceChanges.added`
- Downstream slice now redundant → `sliceChanges.removed`
- Otherwise → proceed. **Bias strongly toward "roadmap is fine."**

Completed-slice immutability is called out explicitly to prevent the planner from editing frozen artifacts.

### Tests

`tests/reassess-default-optin.test.ts` uses `DISPATCH_RULES` directly and isolated tmpdir bases — real behavior, not source inspection. Designed to remain correct after #4791 retires the source-grep assertions in `token-profile.test.ts`.

Ran locally: **111/111 passing** across `reassess-default-optin`, `reassess-detection`, `token-profile`, `pre-exec-gate-loop`, `progressive-planning`, `prefs-wizard-coverage`, `prompt-contracts`, `plan-slice-prompt`.

## Change type

- [x] `refactor` — Behavior change (default flip) + prompt-contract change, no new surface area

## Breaking changes

**Behavior change for users with no token_profile and no explicit `phases.reassess_after_slice`:** reassess-roadmap no longer fires automatically. Roadmap adjustment responsibility moves to the next slice's planner (which already has richer context). Documented in ADR-003 §4 and `preferences-reference.md`. Users who want the previous behavior: set `phases.reassess_after_slice: true` in `PREFERENCES.md` or switch to the `burn-max` profile.

AI-assisted PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Roadmap reassessment after slice is now disabled by default; enable via explicit preference or the burn-max profile.

* **Documentation**
  * Updated preference reference and planning prompts with new reassessment behavior and just-in-time validation guidance.

* **Tests**
  * Added test suite validating reassessment dispatch gating and profile defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->