### PR TITLE
Fix #4809: migrate linux-ready.test.ts from custom harness to node:test

### DIFF
--- a/src/resources/extensions/voice/tests/linux-ready.test.ts
+++ b/src/resources/extensions/voice/tests/linux-ready.test.ts
@@ -8,117 +8,134 @@
  *   - linuxPython venv detection
  */
 
-import { createTestContext } from "../../gsd/tests/test-helpers.ts";
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
 import { diagnoseSounddeviceError, ensureVoiceVenv } from "../linux-ready.ts";
 
-const { assertEq, assertTrue, report } = createTestContext();
+// ─── diagnoseSounddeviceError ──────────────────────────────────────────
 
-function main(): void {
-	// ── diagnoseSounddeviceError ──────────────────────────────────────────
+describe("linux-ready", () => {
+  describe("diagnoseSounddeviceError", () => {
+    test("ModuleNotFoundError must return missing-module", () => {
+      // The critical regression: "ModuleNotFoundError: No module named 'sounddevice'"
+      // contains the word "sounddevice", so the old code matched the portaudio branch.
+      const stderr = "Traceback (most recent call last):\n  File \"<string>\", line 1, in <module>\nModuleNotFoundError: No module named 'sounddevice'";
+      assert.strictEqual(
+        diagnoseSounddeviceError(stderr),
+        "missing-module",
+        "ModuleNotFoundError for sounddevice should be 'missing-module', not 'missing-portaudio'",
+      );
+    });
 
-	// The critical regression: "ModuleNotFoundError: No module named 'sounddevice'"
-	// contains the word "sounddevice", so the old code matched the portaudio branch.
-	console.log("\n=== diagnoseSounddeviceError: ModuleNotFoundError must return missing-module ===");
-	{
-		const stderr = "Traceback (most recent call last):\n  File \"<string>\", line 1, in <module>\nModuleNotFoundError: No module named 'sounddevice'";
-		assertEq(diagnoseSounddeviceError(stderr), "missing-module",
-			"ModuleNotFoundError for sounddevice should be 'missing-module', not 'missing-portaudio'");
-	}
+    test("'No module named sounddevice' variant", () => {
+      const stderr = "ImportError: No module named sounddevice";
+      assert.strictEqual(
+        diagnoseSounddeviceError(stderr),
+        "missing-module",
+        "'No module' substring should return missing-module",
+      );
+    });
 
-	console.log("\n=== diagnoseSounddeviceError: 'No module named sounddevice' variant ===");
-	{
-		const stderr = "ImportError: No module named sounddevice";
-		assertEq(diagnoseSounddeviceError(stderr), "missing-module",
-			"'No module' substring should return missing-module");
-	}
+    test("actual portaudio error", () => {
+      const stderr = "OSError: PortAudio library not found";
+      assert.strictEqual(
+        diagnoseSounddeviceError(stderr),
+        "missing-portaudio",
+        "PortAudio library error should return missing-portaudio",
+      );
+    });
 
-	console.log("\n=== diagnoseSounddeviceError: actual portaudio error ===");
-	{
-		const stderr = "OSError: PortAudio library not found";
-		assertEq(diagnoseSounddeviceError(stderr), "missing-portaudio",
-			"PortAudio library error should return missing-portaudio");
-	}
+    test("lowercase portaudio error", () => {
+      const stderr = "OSError: libportaudio.so.2: cannot open shared object file: No such file or directory";
+      assert.strictEqual(
+        diagnoseSounddeviceError(stderr),
+        "missing-portaudio",
+        "lowercase portaudio error should return missing-portaudio",
+      );
+    });
 
-	console.log("\n=== diagnoseSounddeviceError: lowercase portaudio error ===");
-	{
-		const stderr = "OSError: libportaudio.so.2: cannot open shared object file: No such file or directory";
-		assertEq(diagnoseSounddeviceError(stderr), "missing-portaudio",
-			"lowercase portaudio error should return missing-portaudio");
-	}
+    test("unrelated error returns unknown", () => {
+      const stderr = "SyntaxError: invalid syntax";
+      assert.strictEqual(
+        diagnoseSounddeviceError(stderr),
+        "unknown",
+        "unrelated error should return unknown",
+      );
+    });
 
-	console.log("\n=== diagnoseSounddeviceError: unrelated error ===");
-	{
-		const stderr = "SyntaxError: invalid syntax";
-		assertEq(diagnoseSounddeviceError(stderr), "unknown",
-			"unrelated error should return unknown");
-	}
+    test("empty stderr returns unknown", () => {
+      assert.strictEqual(
+        diagnoseSounddeviceError(""),
+        "unknown",
+        "empty stderr should return unknown",
+      );
+    });
+  });
 
-	console.log("\n=== diagnoseSounddeviceError: empty stderr ===");
-	{
-		assertEq(diagnoseSounddeviceError(""), "unknown",
-			"empty stderr should return unknown");
-	}
+  // ─── ensureVoiceVenv ──────────────────────────────────────────────────
 
-	// ── ensureVoiceVenv ──────────────────────────────────────────────────
+  describe("ensureVoiceVenv", () => {
+    test("returns true when venv already exists", () => {
+      const notifications: string[] = [];
+      const result = ensureVoiceVenv({
+        notify: (msg) => notifications.push(msg),
+        exists: () => true,
+        execFile: (() => Buffer.from("")) as any,
+      });
+      assert.ok(result, "should return true when venv exists");
+      assert.strictEqual(notifications.length, 0, "should not notify when venv exists");
+    });
 
-	console.log("\n=== ensureVoiceVenv: returns true when venv already exists ===");
-	{
-		const notifications: string[] = [];
-		const result = ensureVoiceVenv({
-			notify: (msg) => notifications.push(msg),
-			exists: () => true,
-			execFile: (() => Buffer.from("")) as any,
-		});
-		assertTrue(result, "should return true when venv exists");
-		assertEq(notifications.length, 0, "should not notify when venv exists");
-	}
+    test("creates venv when missing", () => {
+      const notifications: string[] = [];
+      const commands: string[][] = [];
+      let existsCalled = false;
 
-	console.log("\n=== ensureVoiceVenv: creates venv when missing ===");
-	{
-		const notifications: string[] = [];
-		const commands: string[][] = [];
-		let existsCalled = false;
+      const result = ensureVoiceVenv({
+        notify: (msg) => notifications.push(msg),
+        exists: () => { existsCalled = true; return false; },
+        execFile: ((cmd: string, args: string[]) => {
+          commands.push([cmd, ...args]);
+          return Buffer.from("");
+        }) as any,
+      });
 
-		const result = ensureVoiceVenv({
-			notify: (msg) => notifications.push(msg),
-			exists: () => { existsCalled = true; return false; },
-			execFile: ((cmd: string, args: string[]) => {
-				commands.push([cmd, ...args]);
-				return Buffer.from("");
-			}) as any,
-		});
+      assert.ok(result, "should return true after venv creation");
+      assert.ok(existsCalled, "should check if venv exists");
+      assert.strictEqual(commands.length, 2, "should run 2 commands (venv + pip)");
+      assert.ok(commands[0][0] === "python3", "first command is python3");
+      assert.ok(
+        commands[0].includes("-m") && commands[0].includes("venv"),
+        "first command creates venv",
+      );
+      assert.ok(
+        commands[1][0].endsWith("bin/pip"),
+        "second command is pip",
+      );
+      assert.ok(commands[1].includes("sounddevice"), "pip installs sounddevice");
+      assert.ok(commands[1].includes("requests"), "pip installs requests");
+      assert.ok(
+        notifications[0].includes("one-time setup"),
+        "notifies about one-time setup",
+      );
+    });
 
-		assertTrue(result, "should return true after venv creation");
-		assertTrue(existsCalled, "should check if venv exists");
-		assertEq(commands.length, 2, "should run 2 commands (venv + pip)");
-		assertTrue(commands[0][0] === "python3", "first command is python3");
-		assertTrue(commands[0].includes("-m") && commands[0].includes("venv"),
-			"first command creates venv");
-		assertTrue(commands[1][0].endsWith("bin/pip"), "second command is pip");
-		assertTrue(commands[1].includes("sounddevice"), "pip installs sounddevice");
-		assertTrue(commands[1].includes("requests"), "pip installs requests");
-		assertTrue(notifications[0].includes("one-time setup"),
-			"notifies about one-time setup");
-	}
+    test("returns false and notifies on failure", () => {
+      const notifications: Array<{ msg: string; level: string }> = [];
 
-	console.log("\n=== ensureVoiceVenv: returns false and notifies on failure ===");
-	{
-		const notifications: Array<{ msg: string; level: string }> = [];
+      const result = ensureVoiceVenv({
+        notify: (msg, level) => notifications.push({ msg, level }),
+        exists: () => false,
+        execFile: (() => { throw new Error("externally-managed-environment"); }) as any,
+      });
 
-		const result = ensureVoiceVenv({
-			notify: (msg, level) => notifications.push({ msg, level }),
-			exists: () => false,
-			execFile: (() => { throw new Error("externally-managed-environment"); }) as any,
-		});
-
-		assertTrue(!result, "should return false on failure");
-		const errorNotif = notifications.find(n => n.level === "error");
-		assertTrue(errorNotif !== undefined, "should emit error notification");
-		assertTrue(errorNotif!.msg.includes("python3 -m venv"),
-			"error message should suggest manual venv creation");
-	}
-
-	report();
-}
-
-main();
+      assert.ok(!result, "should return false on failure");
+      const errorNotif = notifications.find(n => n.level === "error");
+      assert.ok(errorNotif !== undefined, "should emit error notification");
+      assert.ok(
+        errorNotif!.msg.includes("python3 -m venv"),
+        "error message should suggest manual venv creation",
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Migrates `linux-ready.test.ts` from the custom test harness (`createTestContext` from `test-helpers.ts`) to Node.js built-in `node:test` (`describe`, `test`) and `node:assert/strict` (`assert`).

## Background

The original test file used a custom harness (`createTestContext`) with manual `main()` invocation and `report()` calls. This was not discoverable by CI, which relies on `node:test` for test collection.

## Changes

- Replace `import { createTestContext } from "../../gsd/tests/test-helpers.ts"` with `import { describe, test } from "node:test"` and `import assert from "node:assert/strict"`
- Replace `assertEq(actual, expected, msg)` → `assert.strictEqual(actual, expected, msg)`
- Replace `assertTrue(condition, msg)` → `assert.ok(condition, msg)`
- Remove `console.log` diagnostic output (handled by node:test reporter)
- Wrap tests in `describe("linux-ready")` → `describe("diagnoseSounddeviceError")` / `describe("ensureVoiceVenv")` → `test(...)` blocks
- Remove `main()` / `report()` pattern entirely

Closes #4809


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Internal test infrastructure migrated to Node's built-in testing framework with all existing test scenarios preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->