### PR TITLE
fix(install): surface err.cause in RTK fetch-failure log

### DIFF
--- a/scripts/install.js
+++ b/scripts/install.js
@@ -400,10 +400,24 @@ async function installRtk() {
     printStep('RTK installed', `v${RTK_VERSION}`)
   } catch (err) {
     stopSpinner()
-    printWarn('RTK', err.message)
+    printWarn('RTK', describeFetchError(err))
   } finally {
     rmSync(tempRoot, { recursive: true, force: true })
   }
+}
+
+// Surface the underlying cause when Node's native fetch throws a generic
+// "fetch failed" for pre-response network errors (DNS, connect, TLS,
+// socket). Without this, CI logs show only the bare message and every
+// network-failure class collapses to a single indistinguishable line.
+function describeFetchError(err) {
+  const base = err?.message || String(err)
+  const cause = err?.cause
+  if (!cause) return base
+  const code = cause.code || cause.errno
+  const causeMsg = cause.message || ''
+  const detail = code ? `${code}${causeMsg && causeMsg !== code ? ` — ${causeMsg}` : ''}` : causeMsg
+  return detail ? `${base} (${detail})` : base
 }
 
 // ── Step: Link workspace packages (postinstall from tarball) ───────────────


### PR DESCRIPTION
## Summary

- RTK install catch block in \`scripts/install.js\` previously logged only \`err.message\`, collapsing every class of pre-response fetch failure (DNS, connect, TLS, socket) to the opaque line \`⚠ RTK: fetch failed\`
- Add \`describeFetchError\` helper that appends \`err.cause.code\` and \`err.cause.message\` when present
- CI logs now print e.g. \`RTK: fetch failed (ENOTFOUND — getaddrinfo ENOTFOUND release-assets.githubusercontent.com)\` — failure class visible at a glance

## Motivation

PR #4785 hit a \`rtk-portability (macos, macos-15)\` failure where sibling runners on the same PR SHA downloaded the same URL successfully. The log line \`⚠ RTK: fetch failed\` offered zero signal about whether it was DNS, TLS, connect-level, or timeout. With this change, the same failure would print the underlying \`cause.code\`, making runner-side transients distinguishable from real outages.

## Test plan

- [x] Manual verification of \`describeFetchError\` against 5 error shapes:
  - undici \`{ cause: { code: 'ENOTFOUND', message: '…' } }\` → \`fetch failed (ENOTFOUND — getaddrinfo ENOTFOUND …)\`
  - \`{ cause: { code: 'ECONNREFUSED', message: 'connect ECONNREFUSED …' } }\` → \`fetch failed (ECONNREFUSED — connect ECONNREFUSED …)\`
  - Plain \`Error('download failed (404)')\` with no cause → \`download failed (404)\` (unchanged)
  - \`{ cause: { message: 'unexpected' } }\` with no code → \`fetch failed (unexpected)\`
  - \`{ cause: { errno: -3008 } }\` → \`fetch failed (-3008)\`
- [ ] CI runs on this branch

Closes #4852

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error reporting for RTK download failures to include detailed diagnostic information about network and system errors, providing clearer insights into what caused installation issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->