### PR TITLE
test(gsd): deprecate extractSourceRegion + drop its toy-fixture tests (Closes #4834)

### DIFF
--- a/src/resources/extensions/gsd/tests/test-helpers.test.ts
+++ b/src/resources/extensions/gsd/tests/test-helpers.test.ts
@@ -1,70 +1,21 @@
 /**
- * Tests for test-helpers.ts — the source-inspection and timing helpers
- * introduced in #4773 / #4774 to replace brittle fixed-byte slice and
- * magic-number sleep patterns in the test suite.
+ * Tests for test-helpers.ts — the timing helpers (waitForCondition,
+ * findLine) used to replace magic-number sleeps and positional line
+ * indexing in the test suite.
+ *
+ * The `extractSourceRegion` helper (introduced in #4773/#4774) is
+ * deliberately NOT tested here. It is the source-grep antipattern that
+ * #4784 names as the root problem; tests against toy fixtures only
+ * legitimize the pattern without validating behaviour. Its test cases
+ * were removed as part of #4834 — callers are being migrated to
+ * behaviour tests one file at a time, after which the helper is slated
+ * for deletion.
  */
 
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { extractSourceRegion, waitForCondition, findLine } from "./test-helpers.ts";
-
-// ─── extractSourceRegion ──────────────────────────────────────────────────
-
-test("extractSourceRegion returns empty string when start anchor missing", () => {
-  assert.equal(extractSourceRegion("const x = 1;", "missing"), "");
-});
-
-test("extractSourceRegion uses explicit end anchor when provided", () => {
-  const src = "START_TOKEN\nbody line\nEND_TOKEN tail";
-  const region = extractSourceRegion(src, "START_TOKEN", "END_TOKEN");
-  assert.ok(region.includes("START_TOKEN"));
-  assert.ok(region.includes("body line"));
-  assert.ok(!region.includes("END_TOKEN"));
-});
-
-test("extractSourceRegion stops at next private method boundary", () => {
-  const src = [
-    "class Foo {",
-    "  private alpha(): void {",
-    "    const a = 1;",
-    "    someCall();",
-    "  }",
-    "",
-    "  private beta(): void {",
-    "    const b = 2;",
-    "  }",
-    "}",
-  ].join("\n");
-
-  // Anchor on alpha's declaration; helper should stop at the next
-  // private method (beta), not on alpha itself.
-  const region = extractSourceRegion(src, "private alpha");
-  assert.ok(region.includes("alpha"));
-  assert.ok(region.includes("someCall()"));
-  assert.ok(!region.includes("beta"));
-});
-
-test("extractSourceRegion stops at next top-level function", () => {
-  const src = [
-    "function alpha() {",
-    "  throw new Error('alpha');",
-    "}",
-    "",
-    "function beta() {",
-    "  return 2;",
-    "}",
-  ].join("\n");
-
-  const region = extractSourceRegion(src, "function alpha");
-  assert.ok(region.includes("throw new Error"));
-  assert.ok(!region.includes("beta"));
-});
-
-test("extractSourceRegion returns to end-of-source when no terminator found", () => {
-  const src = "just one line";
-  assert.equal(extractSourceRegion(src, "just"), "just one line");
-});
+import { waitForCondition, findLine } from "./test-helpers.ts";
 
 // ─── waitForCondition ─────────────────────────────────────────────────────
 

--- a/src/resources/extensions/gsd/tests/test-helpers.ts
+++ b/src/resources/extensions/gsd/tests/test-helpers.ts
@@ -60,21 +60,34 @@ export function createTestContext() {
   return { assertEq, assertTrue, assertMatch, assertNoMatch, report };
 }
 
-// ─── Source-inspection helpers ────────────────────────────────────────────────
+// ─── Source-inspection helpers (DEPRECATED — do not add new callers) ──────────
 //
-// Replace brittle fixed-byte slice patterns like `src.slice(idx, idx + 6000)`
-// with structural boundary detection. See #4773, #4774.
+// `extractSourceRegion` was introduced in #4773 / #4774 as a more-durable
+// replacement for hand-rolled `src.slice(idx, idx + N)` patterns. Issue
+// #4784 surfaced that the helper is the wrong target: its use case —
+// testing that an identifier or phrase exists in production source text
+// — is the source-grep antipattern that causes false coverage in the
+// first place. Tests should exercise behaviour (call the function,
+// assert on its return value or observable effects) rather than check
+// whether specific identifier strings remain in source.
+//
+// CONTRIBUTING.md forbids new callers of this helper. Existing callers
+// are being migrated one file at a time; the helper is slated for
+// removal once the last caller is converted.
+//
+// Do not add new callers. If you are tempted to, file an issue
+// describing the behavioural invariant you want to test and we will
+// find a runtime assertion instead.
 
 /**
+ * @deprecated Use a real behaviour test against the function under
+ *   inspection instead. See #4784 and CONTRIBUTING.md > "Test behaviour,
+ *   not source shape". No new callers.
+ *
  * Extract a region of source between a start anchor and either an explicit
  * end anchor or, if none is given, a set of reasonable structural
  * terminators (next `private `/`export `/`function `/`class `/`interface `/
  * `//` section separator). Falls back to end-of-source if none match.
- *
- * Use this instead of `src.slice(startIdx, startIdx + N)` when searching
- * for patterns within a specific method or region — the start anchor is
- * what the caller already has, and the end is determined by structure,
- * not by a magic byte count that breaks under refactors.
  *
  * @param src        The source text.
  * @param startAnchor Literal substring that marks the start of the region.


### PR DESCRIPTION
Deprecate the source-grep helper introduced in #4773/#4774 and drop its 5 toy-fixture tests. Keep the 9 waitForCondition/findLine tests (those helpers replace real antipatterns). Existing 43 callers remain functional while being migrated one file at a time.

Closes #4834. Refs #4784.