### PR TITLE
test(gsd): use real metrics exports in budget-prediction (Closes #4840)

### DIFF
--- a/src/resources/extensions/gsd/tests/budget-prediction.test.ts
+++ b/src/resources/extensions/gsd/tests/budget-prediction.test.ts
@@ -1,220 +1,147 @@
 /**
- * Budget Prediction — unit tests for M004/S04.
+ * budget-prediction.test.ts — unit tests for budget prediction math
+ * (`getAverageCostPerUnitType`, `predictRemainingCost`) exported from
+ * `metrics.ts`.
  *
- * Tests prediction math, auto-downgrade logic, and dashboard integration.
- * Uses extracted pure functions (avoiding module import chain) and
- * source-level structural checks for dashboard/auto.ts integration.
+ * The previous version (PR #582, `972dd05f4`) re-implemented both
+ * functions inline, citing a `paths.js → @gsd/pi-coding-agent` import
+ * chain as the reason. That chain concern is no longer valid — the
+ * real exports import cleanly from `metrics.ts`. All 10 math tests
+ * were then exercising the test's own copy of the functions, not the
+ * product code. #4840 documented the false-coverage case.
+ *
+ * This rewrite imports the real functions, deletes the inline copies,
+ * drops the 3 source-grep tests (`metricsSrc.includes(...)`) and the
+ * 2 dashboard `includes` tests (dashboard integration should be a
+ * behaviour test against the dashboard builder, not a grep), and
+ * deletes the synthesized `downgrade:` test that exercised a local
+ * closure instead of product code. See #4784 / #4840.
  */
 
-import test from "node:test";
+import { describe, test } from "node:test";
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
-import { join, dirname } from "node:path";
-import { fileURLToPath } from "node:url";
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const metricsSrc = readFileSync(join(__dirname, "..", "metrics.ts"), "utf-8");
-const dashboardSrc = readFileSync(join(__dirname, "..", "auto-dashboard.ts"), "utf-8");
+import {
+  getAverageCostPerUnitType,
+  predictRemainingCost,
+} from "../metrics.ts";
+import type { UnitMetrics } from "../metrics.ts";
 
-// ─── Extract pure functions from metrics.ts source ────────────────────────
-// Can't import directly due to paths.js → @gsd/pi-coding-agent import chain.
-// Extract and evaluate the pure math functions.
+// ─── Fixture helper ───────────────────────────────────────────────────────
+// UnitMetrics has several required fields; this builder lets each test
+// specify only the fields that matter for the cost math.
 
-interface MockUnitMetrics {
-  type: string;
-  cost: number;
+function makeUnit(partial: Partial<UnitMetrics> & { type: string; cost: number }): UnitMetrics {
+  return {
+    id: "M001/S01/T01",
+    model: "test-model",
+    startedAt: 0,
+    finishedAt: 0,
+    tokens: { input: 0, output: 0, cache_creation: 0, cache_read: 0 } as UnitMetrics["tokens"],
+    toolCalls: 0,
+    assistantMessages: 0,
+    userMessages: 0,
+    ...partial,
+  };
 }
 
-// Re-implement the functions under test (verified against source below)
-function getAverageCostPerUnitType(units: MockUnitMetrics[]): Map<string, number> {
-  const sums = new Map<string, { total: number; count: number }>();
-  for (const u of units) {
-    const entry = sums.get(u.type) ?? { total: 0, count: 0 };
-    entry.total += u.cost;
-    entry.count += 1;
-    sums.set(u.type, entry);
-  }
-  const avgs = new Map<string, number>();
-  for (const [type, { total, count }] of sums) {
-    avgs.set(type, total / count);
-  }
-  return avgs;
-}
+describe("getAverageCostPerUnitType (metrics.ts)", () => {
+  test("returns correct averages per unit type", () => {
+    const units = [
+      makeUnit({ type: "execute-task", cost: 0.1 }),
+      makeUnit({ type: "execute-task", cost: 0.2 }),
+      makeUnit({ type: "plan-slice", cost: 0.05 }),
+      makeUnit({ type: "plan-slice", cost: 0.15 }),
+      makeUnit({ type: "complete-slice", cost: 0.08 }),
+    ];
+    const avgs = getAverageCostPerUnitType(units);
+    assert.ok(Math.abs(avgs.get("execute-task")! - 0.15) < 0.001, "execute-task avg");
+    assert.ok(Math.abs(avgs.get("plan-slice")! - 0.10) < 0.001, "plan-slice avg");
+    assert.ok(Math.abs(avgs.get("complete-slice")! - 0.08) < 0.001, "complete-slice avg");
+  });
 
-function predictRemainingCost(
-  avgCosts: Map<string, number>,
-  remainingUnits: string[],
-  fallbackAvg?: number,
-): number {
-  const allAvgs = [...avgCosts.values()];
-  const overallAvg = fallbackAvg ?? (allAvgs.length > 0 ? allAvgs.reduce((a, b) => a + b, 0) / allAvgs.length : 0);
-  let total = 0;
-  for (const unitType of remainingUnits) {
-    total += avgCosts.get(unitType) ?? overallAvg;
-  }
-  return total;
-}
+  test("returns empty map for empty input", () => {
+    assert.equal(getAverageCostPerUnitType([]).size, 0);
+  });
 
-// ═══════════════════════════════════════════════════════════════════════════
-// Source Verification — confirm our re-implementation matches
-// ═══════════════════════════════════════════════════════════════════════════
-
-test("source: metrics.ts exports getAverageCostPerUnitType", () => {
-  assert.ok(metricsSrc.includes("export function getAverageCostPerUnitType"), "should be exported");
+  test("single unit per type returns exact cost", () => {
+    const avgs = getAverageCostPerUnitType([makeUnit({ type: "execute-task", cost: 0.42 })]);
+    assert.ok(Math.abs(avgs.get("execute-task")! - 0.42) < 0.001);
+  });
 });
 
-test("source: metrics.ts exports predictRemainingCost", () => {
-  assert.ok(metricsSrc.includes("export function predictRemainingCost"), "should be exported");
+describe("predictRemainingCost (metrics.ts)", () => {
+  test("calculates remaining cost from known averages", () => {
+    const avgs = new Map([
+      ["execute-task", 0.15],
+      ["plan-slice", 0.10],
+      ["complete-slice", 0.08],
+    ]);
+    const remaining = ["execute-task", "execute-task", "complete-slice"];
+    const cost = predictRemainingCost(avgs, remaining);
+    // 2 × 0.15 + 0.08 = 0.38
+    assert.ok(Math.abs(cost - 0.38) < 0.001);
+  });
+
+  test("uses overall average for unknown unit types", () => {
+    const avgs = new Map([
+      ["execute-task", 0.10],
+      ["plan-slice", 0.20],
+    ]);
+    const remaining = ["execute-task", "unknown-type"];
+    // unknown: (0.10 + 0.20) / 2 = 0.15 → total 0.10 + 0.15 = 0.25
+    assert.ok(Math.abs(predictRemainingCost(avgs, remaining) - 0.25) < 0.001);
+  });
+
+  test("returns 0 for empty remaining list", () => {
+    const avgs = new Map([["execute-task", 0.15]]);
+    assert.equal(predictRemainingCost(avgs, []), 0);
+  });
+
+  test("uses fallback when no averages are known", () => {
+    const cost = predictRemainingCost(new Map(), ["execute-task", "plan-slice"], 0.10);
+    assert.ok(Math.abs(cost - 0.20) < 0.001);
+  });
+
+  test("returns 0 when no averages and no fallback", () => {
+    assert.equal(predictRemainingCost(new Map(), ["execute-task"]), 0);
+  });
 });
 
-test("source: getAverageCostPerUnitType uses Map<string, number>", () => {
-  assert.ok(
-    metricsSrc.includes("Map<string, number>") && metricsSrc.includes("getAverageCostPerUnitType"),
-    "should return Map<string, number>",
-  );
-});
+describe("end-to-end budget prediction (composes the real functions)", () => {
+  test("budget ceiling exceeded is detectable from real averages + projection", () => {
+    const units = [
+      makeUnit({ type: "execute-task", cost: 0.5 }),
+      makeUnit({ type: "execute-task", cost: 0.6 }),
+      makeUnit({ type: "plan-slice", cost: 0.3 }),
+      makeUnit({ type: "complete-slice", cost: 0.2 }),
+    ];
+    const totalSpent = units.reduce((sum, u) => sum + u.cost, 0); // 1.60
+    const avgs = getAverageCostPerUnitType(units);
+    const predicted = predictRemainingCost(avgs, [
+      "execute-task",
+      "execute-task",
+      "execute-task",
+    ]);
+    // avg execute-task = 0.55, predicted remaining = 3 × 0.55 = 1.65
+    // total = 1.60 + 1.65 = 3.25 > 2.50 ceiling
+    assert.ok(
+      totalSpent + predicted > 2.5,
+      "spent + predicted should exceed test ceiling",
+    );
+  });
 
-// ═══════════════════════════════════════════════════════════════════════════
-// Average Cost Per Unit Type
-// ═══════════════════════════════════════════════════════════════════════════
-
-test("avgCost: returns correct averages per unit type", () => {
-  const units: MockUnitMetrics[] = [
-    { type: "execute-task", cost: 0.10 },
-    { type: "execute-task", cost: 0.20 },
-    { type: "plan-slice", cost: 0.05 },
-    { type: "plan-slice", cost: 0.15 },
-    { type: "complete-slice", cost: 0.08 },
-  ];
-  const avgs = getAverageCostPerUnitType(units);
-  assert.ok(Math.abs(avgs.get("execute-task")! - 0.15) < 0.001, "execute-task avg should be 0.15");
-  assert.ok(Math.abs(avgs.get("plan-slice")! - 0.10) < 0.001, "plan-slice avg should be 0.10");
-  assert.ok(Math.abs(avgs.get("complete-slice")! - 0.08) < 0.001, "complete-slice avg should be 0.08");
-});
-
-test("avgCost: returns empty map for empty input", () => {
-  const avgs = getAverageCostPerUnitType([]);
-  assert.equal(avgs.size, 0);
-});
-
-test("avgCost: single unit per type returns exact cost", () => {
-  const avgs = getAverageCostPerUnitType([{ type: "execute-task", cost: 0.42 }]);
-  assert.ok(Math.abs(avgs.get("execute-task")! - 0.42) < 0.001);
-});
-
-// ═══════════════════════════════════════════════════════════════════════════
-// Predict Remaining Cost
-// ═══════════════════════════════════════════════════════════════════════════
-
-test("predict: calculates remaining cost from averages", () => {
-  const avgs = new Map([
-    ["execute-task", 0.15],
-    ["plan-slice", 0.10],
-    ["complete-slice", 0.08],
-  ]);
-  const remaining = ["execute-task", "execute-task", "complete-slice"];
-  const cost = predictRemainingCost(avgs, remaining);
-  assert.ok(Math.abs(cost - 0.38) < 0.001);
-});
-
-test("predict: uses overall average for unknown unit types", () => {
-  const avgs = new Map([
-    ["execute-task", 0.10],
-    ["plan-slice", 0.20],
-  ]);
-  const remaining = ["execute-task", "unknown-type"];
-  const cost = predictRemainingCost(avgs, remaining);
-  // unknown: (0.10 + 0.20) / 2 = 0.15 → total 0.10 + 0.15 = 0.25
-  assert.ok(Math.abs(cost - 0.25) < 0.001);
-});
-
-test("predict: returns 0 for empty remaining", () => {
-  const avgs = new Map([["execute-task", 0.15]]);
-  assert.equal(predictRemainingCost(avgs, []), 0);
-});
-
-test("predict: handles no averages with fallback", () => {
-  const avgs = new Map<string, number>();
-  const cost = predictRemainingCost(avgs, ["execute-task", "plan-slice"], 0.10);
-  assert.ok(Math.abs(cost - 0.20) < 0.001);
-});
-
-test("predict: handles no averages and no fallback", () => {
-  const avgs = new Map<string, number>();
-  const cost = predictRemainingCost(avgs, ["execute-task"]);
-  assert.equal(cost, 0);
-});
-
-// ═══════════════════════════════════════════════════════════════════════════
-// Dashboard Integration
-// ═══════════════════════════════════════════════════════════════════════════
-
-test("dashboard: AutoDashboardData includes projectedRemainingCost field", () => {
-  assert.ok(
-    dashboardSrc.includes("projectedRemainingCost"),
-    "AutoDashboardData should have projectedRemainingCost field",
-  );
-});
-
-test("dashboard: AutoDashboardData includes profileDowngraded field", () => {
-  assert.ok(
-    dashboardSrc.includes("profileDowngraded"),
-    "AutoDashboardData should have profileDowngraded field",
-  );
-});
-
-// ═══════════════════════════════════════════════════════════════════════════
-// Budget Prediction — End-to-End Math
-// ═══════════════════════════════════════════════════════════════════════════
-
-test("e2e: budget ceiling exceeded triggers downgrade prediction", () => {
-  const units: MockUnitMetrics[] = [
-    { type: "execute-task", cost: 0.50 },
-    { type: "execute-task", cost: 0.60 },
-    { type: "plan-slice", cost: 0.30 },
-    { type: "complete-slice", cost: 0.20 },
-  ];
-  const totalSpent = units.reduce((sum, u) => sum + u.cost, 0); // 1.60
-  const avgs = getAverageCostPerUnitType(units);
-  const remaining = ["execute-task", "execute-task", "execute-task"];
-  const predictedRemaining = predictRemainingCost(avgs, remaining);
-  const predictedTotal = totalSpent + predictedRemaining;
-  const budgetCeiling = 2.50;
-  assert.ok(predictedTotal > budgetCeiling, "should predict budget exhaustion");
-});
-
-test("e2e: budget ceiling not exceeded does not trigger", () => {
-  const units: MockUnitMetrics[] = [
-    { type: "execute-task", cost: 0.10 },
-    { type: "plan-slice", cost: 0.05 },
-  ];
-  const totalSpent = units.reduce((sum, u) => sum + u.cost, 0); // 0.15
-  const avgs = getAverageCostPerUnitType(units);
-  const remaining = ["execute-task", "complete-slice"];
-  const predictedRemaining = predictRemainingCost(avgs, remaining);
-  const predictedTotal = totalSpent + predictedRemaining;
-  const budgetCeiling = 5.00;
-  assert.ok(predictedTotal <= budgetCeiling, "should not predict budget exhaustion");
-});
-
-// ═══════════════════════════════════════════════════════════════════════════
-// Downgrade Logic
-// ═══════════════════════════════════════════════════════════════════════════
-
-test("downgrade: one-way per D048 — downgrade should not be reversible", () => {
-  // Simulate: first prediction triggers downgrade, second doesn't reverse it
-  let downgraded = false;
-
-  function checkDowngrade(predictedTotal: number, ceiling: number) {
-    if (!downgraded && predictedTotal > ceiling) {
-      downgraded = true;
-    }
-    // Never reverse — per D048
-  }
-
-  checkDowngrade(3.00, 2.50); // triggers
-  assert.ok(downgraded, "should downgrade when prediction exceeds ceiling");
-
-  checkDowngrade(1.50, 2.50); // doesn't reverse
-  assert.ok(downgraded, "should stay downgraded (one-way per D048)");
+  test("budget ceiling not exceeded when averages stay low", () => {
+    const units = [
+      makeUnit({ type: "execute-task", cost: 0.1 }),
+      makeUnit({ type: "plan-slice", cost: 0.05 }),
+    ];
+    const totalSpent = units.reduce((sum, u) => sum + u.cost, 0); // 0.15
+    const avgs = getAverageCostPerUnitType(units);
+    const predicted = predictRemainingCost(avgs, ["execute-task", "complete-slice"]);
+    assert.ok(
+      totalSpent + predicted <= 5.0,
+      "spent + predicted should stay under test ceiling",
+    );
+  });
 });

--- a/src/resources/extensions/gsd/tests/budget-prediction.test.ts
+++ b/src/resources/extensions/gsd/tests/budget-prediction.test.ts
@@ -37,7 +37,7 @@ function makeUnit(partial: Partial<UnitMetrics> & { type: string; cost: number }
     model: "test-model",
     startedAt: 0,
     finishedAt: 0,
-    tokens: { input: 0, output: 0, cache_creation: 0, cache_read: 0 } as UnitMetrics["tokens"],
+    tokens: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
     toolCalls: 0,
     assistantMessages: 0,
     userMessages: 0,


### PR DESCRIPTION
Test reimplemented the functions under test inline, citing a stale import-chain concern. All 10 math tests ran against the test's own copy. Imports now succeed cleanly; rewritten to exercise real exports. Drops source-grep + dashboard-grep + local-closure tests.

Closes #4840. Refs #4784.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for budget prediction and cost calculation functionality to improve validation accuracy of budget ceiling tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->