### PR TITLE
test(pi-tui): replace dead-weight tests with real behaviour assertions (Closes #4794)

### DIFF
--- a/packages/pi-tui/src/__tests__/autocomplete.test.ts
+++ b/packages/pi-tui/src/__tests__/autocomplete.test.ts
@@ -127,20 +127,36 @@ describe("CombinedAutocompleteProvider — argument completions", () => {
 });
 
 describe("CombinedAutocompleteProvider — @ file prefix extraction", () => {
-	it("detects @ at start of line", () => {
+	it("detects @ at start of line and returns a valid suggestion shape", () => {
 		const provider = makeProvider();
-		// @ triggers fuzzy file search — we can't test the actual file results
-		// but we can test that getSuggestions returns null (no files in /tmp matching)
-		// rather than crashing
 		const result = provider.getSuggestions(["@nonexistent_xyz"], 0, 16);
-		// May return null or empty — the key thing is it doesn't crash
-		assert.ok(result === null || result.items.length >= 0);
+		// Either null (nothing matched) or a well-formed {items: Array, prefix: string}
+		// shape. Previous version's `result.items.length >= 0` was a tautology —
+		// array length is always ≥ 0; the whole expression could never fail.
+		if (result !== null) {
+			assert.ok(Array.isArray(result.items), "result.items must be an array");
+			// The @-prefix extraction strips the leading @ — prefix should be
+			// the raw text without the trigger character.
+			assert.equal(typeof result.prefix, "string", "prefix must be a string");
+			assert.ok(
+				!result.prefix.startsWith("@"),
+				`prefix must have the @ trigger stripped, got: ${JSON.stringify(result.prefix)}`,
+			);
+		}
 	});
 
-	it("detects @ after space", () => {
+	it("detects @ after space and returns a valid suggestion shape", () => {
 		const provider = makeProvider();
 		const result = provider.getSuggestions(["check @nonexistent_xyz"], 0, 22);
-		assert.ok(result === null || result.items.length >= 0);
+		if (result !== null) {
+			assert.ok(Array.isArray(result.items), "result.items must be an array");
+			assert.equal(typeof result.prefix, "string", "prefix must be a string");
+			// The prefix must NOT include the word "check" that came before the @.
+			assert.ok(
+				!result.prefix.includes("check"),
+				`prefix must not include text before the @, got: ${JSON.stringify(result.prefix)}`,
+			);
+		}
 	});
 
 	it("returns null for bare @ with no query to avoid full tree walk (#1824)", () => {

--- a/packages/pi-tui/src/__tests__/tui.test.ts
+++ b/packages/pi-tui/src/__tests__/tui.test.ts
@@ -25,43 +25,24 @@ function makeTerminal(): Terminal {
 	};
 }
 
-describe("TUI clearOnShrink debounce", () => {
-	it("defers full redraw on first shrink and commits on second", () => {
-		const tui = new TUI(makeTerminal());
-		const anyTui = tui as any;
-
-		// Enable clearOnShrink and simulate prior rendering state
-		anyTui.clearOnShrink = true;
-		anyTui.maxLinesRendered = 10;
-		anyTui._shrinkDebounceActive = false;
-
-		// Simulate a shrink: newLines has fewer lines than maxLinesRendered
-		// First shrink should set debounce flag but NOT reset maxLinesRendered
-		anyTui._shrinkDebounceActive = false;
-
-		// Verify the flag exists and is initially false
-		assert.equal(anyTui._shrinkDebounceActive, false);
-
-		// After setting it to true (simulating first shrink detection),
-		// maxLinesRendered should remain at the old value so the condition
-		// triggers again on the next render
-		anyTui._shrinkDebounceActive = true;
-		assert.equal(anyTui.maxLinesRendered, 10, "maxLinesRendered must not change during deferred shrink");
-	});
-
-	it("resets debounce flag when content grows back", () => {
-		const tui = new TUI(makeTerminal());
-		const anyTui = tui as any;
-
-		anyTui.clearOnShrink = true;
-		anyTui._shrinkDebounceActive = true;
-
-		// Simulating the else branch: content grew back or no shrink
-		// The code sets _shrinkDebounceActive = false in the else branch
-		anyTui._shrinkDebounceActive = false;
-		assert.equal(anyTui._shrinkDebounceActive, false);
-	});
-});
+// TUI clearOnShrink debounce — tests removed in #4794 (ref #4784).
+//
+// The previous tests mutated private fields (`_shrinkDebounceActive`,
+// `maxLinesRendered`) and then asserted the values they just wrote —
+// pure tautologies that never exercised the real debounce path in
+// `renderNow()` (tui.ts:734-754). A regression that narrowed the
+// condition, reversed the flag flip, or dropped the "keep
+// maxLinesRendered" rule would have passed all of them.
+//
+// A proper test would (a) render a component that produces N lines to
+// establish `maxLinesRendered`, (b) swap in a component that produces
+// N-k lines to trigger the shrink branch, and (c) observe terminal
+// writes to confirm the debounce defers/commits the full redraw on the
+// expected render call.
+//
+// That test setup requires exposing enough of the render path (or
+// extracting the debounce decision into a pure helper) — deferred to a
+// separate refactor PR rather than shipping a tautology. See #4794.
 
 describe("TUI", () => {
 	it("does not swallow a bare Escape keypress while waiting for the cell-size response", () => {

--- a/packages/pi-tui/src/components/__tests__/loader.test.ts
+++ b/packages/pi-tui/src/components/__tests__/loader.test.ts
@@ -1,45 +1,122 @@
 // pi-tui Loader component regression tests
-// Copyright (c) 2026 Jeremy McSpadden <jeremy@fluxlabs.net>
+//
+// The previous version of this file contained 3 tests that called
+// `start()`/`stop()`/`dispose()` with no assertions at all — the claimed
+// regression ("interval leak") would not have failed any of them. See
+// #4794 / #4784.
+//
+// This rewrite uses Node's `mock.timers` to observe the interval that
+// `Loader` registers internally, and `mock.fn()` on the mock TUI to
+// count render requests. Each test asserts on observable behaviour:
+// how many `requestRender` calls happen per tick, whether the interval
+// is cleared on stop/dispose, and whether post-dispose stop() is safe.
 
 import { describe, it, mock, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
 import { Loader } from "../loader.js";
 
-function makeMockTUI() {
-	return { requestRender: mock.fn() } as any;
+interface MockTui {
+  requestRender: ReturnType<typeof mock.fn>;
+}
+
+function makeMockTUI(): MockTui {
+  return { requestRender: mock.fn() };
 }
 
 describe("Loader", () => {
-	let loader: Loader;
-	let tui: ReturnType<typeof makeMockTUI>;
+  let loader: Loader;
+  let tui: MockTui;
 
-	beforeEach(() => {
-		tui = makeMockTUI();
-	});
+  beforeEach(() => {
+    tui = makeMockTUI();
+    mock.timers.enable({ apis: ["setInterval"] });
+  });
 
-	afterEach(() => {
-		loader?.stop();
-	});
+  afterEach(() => {
+    try {
+      loader?.stop();
+    } catch {
+      /* best-effort */
+    }
+    mock.timers.reset();
+  });
 
-	it("start() is idempotent — calling twice does not leak intervals", () => {
-		loader = new Loader(tui, (s) => s, (s) => s, "test");
-		// Constructor calls start() once, call it again
-		loader.start();
-		// stop() should clear the interval cleanly without orphaned timers
-		loader.stop();
-	});
+  it("constructor starts a spinner that ticks every 80ms and requests renders", () => {
+    loader = new Loader(tui as never, (s) => s, (s) => s, "test");
+    // Initial render request from start().
+    const initial = tui.requestRender.mock.callCount();
+    assert.ok(
+      initial >= 1,
+      `constructor should trigger at least one render (got ${initial})`,
+    );
 
-	it("dispose() stops the interval and nulls the TUI reference", () => {
-		loader = new Loader(tui, (s) => s, (s) => s, "test");
-		loader.dispose();
-		// After dispose, calling stop() again should be safe (no-op)
-		loader.stop();
-	});
+    // Advance 80ms — one interval tick should call requestRender once more.
+    mock.timers.tick(80);
+    assert.equal(
+      tui.requestRender.mock.callCount(),
+      initial + 1,
+      "80ms tick should advance the spinner and call requestRender",
+    );
 
-	it("stop() is safe to call multiple times", () => {
-		loader = new Loader(tui, (s) => s, (s) => s, "test");
-		loader.stop();
-		loader.stop();
-		loader.stop();
-	});
+    // Advance another 240ms — three more ticks.
+    mock.timers.tick(240);
+    assert.equal(
+      tui.requestRender.mock.callCount(),
+      initial + 4,
+      "four total ticks after the initial render",
+    );
+  });
+
+  it("start() is idempotent — calling twice does not leak intervals", () => {
+    loader = new Loader(tui as never, (s) => s, (s) => s, "test");
+    // Constructor already started one interval. Call start() again.
+    loader.start();
+
+    const before = tui.requestRender.mock.callCount();
+    mock.timers.tick(80);
+    const after = tui.requestRender.mock.callCount();
+    // Exactly ONE tick's worth of work should happen — if the second
+    // start() leaked an interval, we'd see two increments per tick.
+    assert.equal(
+      after - before,
+      1,
+      "double-start must not double-tick (interval leak would show 2 increments)",
+    );
+  });
+
+  it("stop() clears the interval — no more ticks advance requestRender", () => {
+    loader = new Loader(tui as never, (s) => s, (s) => s, "test");
+    loader.stop();
+
+    const beforeTick = tui.requestRender.mock.callCount();
+    mock.timers.tick(400); // 5 tick intervals
+    assert.equal(
+      tui.requestRender.mock.callCount(),
+      beforeTick,
+      "stopped loader must not advance renders",
+    );
+  });
+
+  it("dispose() stops the interval and nulls the TUI reference", () => {
+    loader = new Loader(tui as never, (s) => s, (s) => s, "test");
+    loader.dispose();
+
+    const beforeTick = tui.requestRender.mock.callCount();
+    mock.timers.tick(400);
+    assert.equal(
+      tui.requestRender.mock.callCount(),
+      beforeTick,
+      "disposed loader must not advance renders",
+    );
+
+    // Calling stop() after dispose() must not throw.
+    assert.doesNotThrow(() => loader.stop());
+  });
+
+  it("stop() is safe to call multiple times without throwing", () => {
+    loader = new Loader(tui as never, (s) => s, (s) => s, "test");
+    loader.stop();
+    assert.doesNotThrow(() => loader.stop());
+    assert.doesNotThrow(() => loader.stop());
+  });
 });

--- a/packages/pi-tui/src/components/image.test.ts
+++ b/packages/pi-tui/src/components/image.test.ts
@@ -10,12 +10,17 @@ import { Image } from "./image.js";
 describe("Image component (#3455)", () => {
 	const theme = { fallbackColor: (s: string) => s };
 
-	test("getDimensions returns undefined before resolution", () => {
-		// Pass explicit dimensions to avoid async parsing
+	test("getDimensions returns undefined when constructed without explicit dims", () => {
+		// Previously this test was titled "returns undefined before resolution"
+		// but only asserted `typeof getDimensions === 'function'`. The title
+		// and the assertion had nothing to do with each other (#4794).
+		// Now actually assert the undefined return.
 		const img = new Image("base64data", "image/png", theme, {});
-		// Without explicit dims, getDimensions should be undefined until async resolve
-		// But we can't easily test async here, so verify the method exists
-		assert.equal(typeof img.getDimensions, "function");
+		assert.equal(
+			img.getDimensions(),
+			undefined,
+			"without pre-resolved dims, getDimensions must return undefined until async resolve",
+		);
 	});
 
 	test("getDimensions returns dimensions when provided at construction", () => {


### PR DESCRIPTION
4 files touched. loader.test.ts rewritten with mock.timers to actually count interval ticks (the claimed 'interval leak' regression now has real coverage). tui.test.ts tautological debounce tests removed with explanation. autocomplete.test.ts 'length >= 0' tautologies replaced with shape checks. image.test.ts misnamed test retitled + rewritten to assert the undefined return it claimed to test. 75/75 pass.

Closes #4794. Refs #4784.