### PR TITLE
test(pi-coding-agent): replace magic-sleep waits with deterministic primitives (Closes #4798)

### DIFF
--- a/packages/pi-coding-agent/src/core/lsp/lsp-integration.test.ts
+++ b/packages/pi-coding-agent/src/core/lsp/lsp-integration.test.ts
@@ -315,8 +315,19 @@ test("LSP integration: typescript-language-server", async (t) => {
 			textDocument: { uri: mathUri, languageId: "typescript", version: 1, text: mathContent },
 		});
 
-		// Give the server time to index
-		await new Promise((r) => setTimeout(r, 3000));
+		// Poll for a published diagnostics notification on main.ts, which
+		// is the observable signal that TypeScript has finished indexing
+		// the opened file. Previous magic-sleep (3000ms) was too short on
+		// slow CI machines and wasteful on fast ones (#4798).
+		const INDEX_DEADLINE_MS = 15_000;
+		const indexDeadline = Date.now() + INDEX_DEADLINE_MS;
+		while (Date.now() < indexDeadline) {
+			const diags = lsp
+				.getNotifications("textDocument/publishDiagnostics")
+				.filter((n) => (n.params as { uri: string }).uri === mainUri);
+			if (diags.length > 0) break;
+			await new Promise((r) => setTimeout(r, 50));
+		}
 
 		// ---- Hover ----
 		await t.test("hover on 'add' call", async () => {
@@ -381,8 +392,28 @@ test("LSP integration: typescript-language-server", async (t) => {
 
 		// ---- Diagnostics (published via notification) ----
 		await t.test("diagnostics for type error", async () => {
-			// Wait a bit more for diagnostics to arrive
-			await new Promise((r) => setTimeout(r, 2000));
+			// Poll for the specific type-error diagnostic on main.ts
+			// instead of sleeping a fixed 2s. tsserver pushes diagnostics
+			// incrementally — we need to wait until at least one diag
+			// contains a type-error signal, not just any diag.
+			const DIAG_DEADLINE_MS = 10_000;
+			const diagDeadline = Date.now() + DIAG_DEADLINE_MS;
+			while (Date.now() < diagDeadline) {
+				const candidates = lsp
+					.getNotifications("textDocument/publishDiagnostics")
+					.filter((n) => (n.params as { uri: string }).uri === mainUri)
+					.flatMap(
+						(n) => (n.params as { diagnostics: Array<{ message: string }> }).diagnostics,
+					);
+				if (
+					candidates.some(
+						(d) => d.message.includes("not assignable") || d.message.includes("Type"),
+					)
+				) {
+					break;
+				}
+				await new Promise((r) => setTimeout(r, 50));
+			}
 
 			const diagNotifications = lsp.getNotifications("textDocument/publishDiagnostics");
 			const mainDiags = diagNotifications.filter(

--- a/packages/pi-coding-agent/src/core/retry-handler.test.ts
+++ b/packages/pi-coding-agent/src/core/retry-handler.test.ts
@@ -281,7 +281,11 @@ describe("RetryHandler — long-context entitlement 429 (#2803)", () => {
 			assert.equal(result, true, "retry should be initiated");
 
 			handler.abortRetry();
-			await new Promise((resolve) => setTimeout(resolve, 10));
+			// Yield the microtask queue so any synchronous continuation
+			// scheduled by abortRetry() settles before we assert. This is
+			// deterministic — no magic-sleep dependency (#4798 / #4784).
+			await Promise.resolve();
+			await Promise.resolve();
 
 			assert.equal(continueFn.mock.calls.length, 0, "cancelled retry must not continue after explicit abort");
 			const endEvents = emittedEvents.filter((e) => e.type === "auto_retry_end");

--- a/packages/pi-coding-agent/src/modes/interactive/components/dynamic-border.test.ts
+++ b/packages/pi-coding-agent/src/modes/interactive/components/dynamic-border.test.ts
@@ -37,26 +37,32 @@ describe("DynamicBorder spinner", () => {
 		border.stopSpinner();
 	});
 
-	it("triggers standalone render when no external render occurred recently", async () => {
-		const border = new DynamicBorder((s) => s);
-		const tui = makeTUI();
+	it("triggers standalone render when no external render occurred recently", () => {
+		mock.timers.enable({ apis: ["setInterval"], now: 0 });
+		try {
+			const border = new DynamicBorder((s) => s);
+			const tui = makeTUI();
 
-		// Set lastExternalRender to a time well in the past
-		const anyBorder = border as any;
-		anyBorder.lastExternalRender = 0;
+			// Set lastExternalRender to a time well in the past
+			const anyBorder = border as any;
+			anyBorder.lastExternalRender = 0;
 
-		border.startSpinner(tui as any, (s) => s);
-		const initialCount = tui.renderCount;
+			border.startSpinner(tui as any, (s) => s);
+			const initialCount = tui.renderCount;
 
-		// Wait for one spinner tick (200ms interval + buffer)
-		await new Promise((r) => setTimeout(r, 250));
+			// Advance exactly one spinner interval (200ms). With mocked timers
+			// this is deterministic — no flake under CI load.
+			mock.timers.tick(200);
 
-		assert.ok(
-			tui.renderCount > initialCount,
-			"spinner should trigger requestRender when no recent external render",
-		);
+			assert.ok(
+				tui.renderCount > initialCount,
+				"spinner should trigger requestRender after one 200ms interval when no recent external render",
+			);
 
-		border.stopSpinner();
+			border.stopSpinner();
+		} finally {
+			mock.timers.reset();
+		}
 	});
 
 	it("updates lastExternalRender on each render() call", () => {


### PR DESCRIPTION
3 files, 3 different primitives: mock.timers for spinner interval, Promise.resolve microtask yield for retry-handler, observable-signal polling for LSP. Each replaces a wall-clock wait with something deterministic.

Closes #4798. Refs #4784.