### PR TITLE
test(voice): rewrite linux-ready under node:test harness (Closes #4809)

### DIFF
--- a/src/resources/extensions/voice/tests/linux-ready.test.ts
+++ b/src/resources/extensions/voice/tests/linux-ready.test.ts
@@ -5,120 +5,136 @@
  *   - diagnoseSounddeviceError branch ordering (ModuleNotFoundError must NOT
  *     match the portaudio branch, even though it contains "sounddevice")
  *   - ensureVoiceVenv auto-creation
- *   - linuxPython venv detection
+ *
+ * Previous version used `createTestContext()` + a top-level `main()` call —
+ * those don't register with `node --test`, so the file ran at import time
+ * but the test runner saw zero tests. CI reporter showed no output for
+ * this file. Rewrite uses `node:test` so results are collected properly.
+ * See #4809 / #4784.
  */
 
-import { createTestContext } from "../../gsd/tests/test-helpers.ts";
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+
 import { diagnoseSounddeviceError, ensureVoiceVenv } from "../linux-ready.ts";
 
-const { assertEq, assertTrue, report } = createTestContext();
+describe("diagnoseSounddeviceError (#2403 branch ordering)", () => {
+  test("ModuleNotFoundError with 'sounddevice' in message → missing-module", () => {
+    // The critical regression: the stderr string contains "sounddevice",
+    // so a naive branch-order check would match the portaudio branch
+    // first. Correct classification is missing-module.
+    const stderr =
+      "Traceback (most recent call last):\n" +
+      '  File "<string>", line 1, in <module>\n' +
+      "ModuleNotFoundError: No module named 'sounddevice'";
+    assert.equal(diagnoseSounddeviceError(stderr), "missing-module");
+  });
 
-function main(): void {
-	// ── diagnoseSounddeviceError ──────────────────────────────────────────
+  test("ImportError: No module named sounddevice → missing-module", () => {
+    assert.equal(
+      diagnoseSounddeviceError("ImportError: No module named sounddevice"),
+      "missing-module",
+    );
+  });
 
-	// The critical regression: "ModuleNotFoundError: No module named 'sounddevice'"
-	// contains the word "sounddevice", so the old code matched the portaudio branch.
-	console.log("\n=== diagnoseSounddeviceError: ModuleNotFoundError must return missing-module ===");
-	{
-		const stderr = "Traceback (most recent call last):\n  File \"<string>\", line 1, in <module>\nModuleNotFoundError: No module named 'sounddevice'";
-		assertEq(diagnoseSounddeviceError(stderr), "missing-module",
-			"ModuleNotFoundError for sounddevice should be 'missing-module', not 'missing-portaudio'");
-	}
+  test("PortAudio library not found → missing-portaudio", () => {
+    assert.equal(
+      diagnoseSounddeviceError("OSError: PortAudio library not found"),
+      "missing-portaudio",
+    );
+  });
 
-	console.log("\n=== diagnoseSounddeviceError: 'No module named sounddevice' variant ===");
-	{
-		const stderr = "ImportError: No module named sounddevice";
-		assertEq(diagnoseSounddeviceError(stderr), "missing-module",
-			"'No module' substring should return missing-module");
-	}
+  test("libportaudio.so.2 cannot open → missing-portaudio (lowercase variant)", () => {
+    assert.equal(
+      diagnoseSounddeviceError(
+        "OSError: libportaudio.so.2: cannot open shared object file: No such file or directory",
+      ),
+      "missing-portaudio",
+    );
+  });
 
-	console.log("\n=== diagnoseSounddeviceError: actual portaudio error ===");
-	{
-		const stderr = "OSError: PortAudio library not found";
-		assertEq(diagnoseSounddeviceError(stderr), "missing-portaudio",
-			"PortAudio library error should return missing-portaudio");
-	}
+  test("unrelated SyntaxError → unknown", () => {
+    assert.equal(
+      diagnoseSounddeviceError("SyntaxError: invalid syntax"),
+      "unknown",
+    );
+  });
 
-	console.log("\n=== diagnoseSounddeviceError: lowercase portaudio error ===");
-	{
-		const stderr = "OSError: libportaudio.so.2: cannot open shared object file: No such file or directory";
-		assertEq(diagnoseSounddeviceError(stderr), "missing-portaudio",
-			"lowercase portaudio error should return missing-portaudio");
-	}
+  test("empty stderr → unknown", () => {
+    assert.equal(diagnoseSounddeviceError(""), "unknown");
+  });
+});
 
-	console.log("\n=== diagnoseSounddeviceError: unrelated error ===");
-	{
-		const stderr = "SyntaxError: invalid syntax";
-		assertEq(diagnoseSounddeviceError(stderr), "unknown",
-			"unrelated error should return unknown");
-	}
+describe("ensureVoiceVenv", () => {
+  test("returns true without notifying when venv already exists", () => {
+    const notifications: string[] = [];
+    const result = ensureVoiceVenv({
+      notify: (msg) => notifications.push(msg),
+      exists: () => true,
+      execFile: (() => Buffer.from("")) as never,
+    });
+    assert.equal(result, true);
+    assert.equal(
+      notifications.length,
+      0,
+      "should not notify when venv already exists",
+    );
+  });
 
-	console.log("\n=== diagnoseSounddeviceError: empty stderr ===");
-	{
-		assertEq(diagnoseSounddeviceError(""), "unknown",
-			"empty stderr should return unknown");
-	}
+  test("creates venv and installs sounddevice+requests when venv missing", () => {
+    const notifications: string[] = [];
+    const commands: string[][] = [];
+    let existsCalled = false;
 
-	// ── ensureVoiceVenv ──────────────────────────────────────────────────
+    const result = ensureVoiceVenv({
+      notify: (msg) => notifications.push(msg),
+      exists: () => {
+        existsCalled = true;
+        return false;
+      },
+      execFile: ((cmd: string, args: string[]) => {
+        commands.push([cmd, ...args]);
+        return Buffer.from("");
+      }) as never,
+    });
 
-	console.log("\n=== ensureVoiceVenv: returns true when venv already exists ===");
-	{
-		const notifications: string[] = [];
-		const result = ensureVoiceVenv({
-			notify: (msg) => notifications.push(msg),
-			exists: () => true,
-			execFile: (() => Buffer.from("")) as any,
-		});
-		assertTrue(result, "should return true when venv exists");
-		assertEq(notifications.length, 0, "should not notify when venv exists");
-	}
+    assert.equal(result, true);
+    assert.ok(existsCalled, "should check if venv exists first");
+    assert.equal(commands.length, 2, "should run 2 commands (venv + pip)");
+    assert.equal(commands[0]![0], "python3", "first command is python3");
+    assert.ok(
+      commands[0]!.includes("-m") && commands[0]!.includes("venv"),
+      "first command creates the venv",
+    );
+    assert.ok(
+      commands[1]![0]!.endsWith("bin/pip"),
+      "second command is pip from the new venv",
+    );
+    assert.ok(commands[1]!.includes("sounddevice"), "pip installs sounddevice");
+    assert.ok(commands[1]!.includes("requests"), "pip installs requests");
+    assert.ok(
+      notifications[0]!.includes("one-time setup"),
+      "notifies user this is one-time setup",
+    );
+  });
 
-	console.log("\n=== ensureVoiceVenv: creates venv when missing ===");
-	{
-		const notifications: string[] = [];
-		const commands: string[][] = [];
-		let existsCalled = false;
+  test("returns false and emits an error notification when venv creation fails", () => {
+    const notifications: Array<{ msg: string; level?: string }> = [];
 
-		const result = ensureVoiceVenv({
-			notify: (msg) => notifications.push(msg),
-			exists: () => { existsCalled = true; return false; },
-			execFile: ((cmd: string, args: string[]) => {
-				commands.push([cmd, ...args]);
-				return Buffer.from("");
-			}) as any,
-		});
+    const result = ensureVoiceVenv({
+      notify: (msg, level) => notifications.push({ msg, level }),
+      exists: () => false,
+      execFile: (() => {
+        throw new Error("externally-managed-environment");
+      }) as never,
+    });
 
-		assertTrue(result, "should return true after venv creation");
-		assertTrue(existsCalled, "should check if venv exists");
-		assertEq(commands.length, 2, "should run 2 commands (venv + pip)");
-		assertTrue(commands[0][0] === "python3", "first command is python3");
-		assertTrue(commands[0].includes("-m") && commands[0].includes("venv"),
-			"first command creates venv");
-		assertTrue(commands[1][0].endsWith("bin/pip"), "second command is pip");
-		assertTrue(commands[1].includes("sounddevice"), "pip installs sounddevice");
-		assertTrue(commands[1].includes("requests"), "pip installs requests");
-		assertTrue(notifications[0].includes("one-time setup"),
-			"notifies about one-time setup");
-	}
-
-	console.log("\n=== ensureVoiceVenv: returns false and notifies on failure ===");
-	{
-		const notifications: Array<{ msg: string; level: string }> = [];
-
-		const result = ensureVoiceVenv({
-			notify: (msg, level) => notifications.push({ msg, level }),
-			exists: () => false,
-			execFile: (() => { throw new Error("externally-managed-environment"); }) as any,
-		});
-
-		assertTrue(!result, "should return false on failure");
-		const errorNotif = notifications.find(n => n.level === "error");
-		assertTrue(errorNotif !== undefined, "should emit error notification");
-		assertTrue(errorNotif!.msg.includes("python3 -m venv"),
-			"error message should suggest manual venv creation");
-	}
-
-	report();
-}
-
-main();
+    assert.equal(result, false);
+    const errorNotif = notifications.find((n) => n.level === "error");
+    assert.ok(errorNotif, "must emit an error notification on failure");
+    assert.ok(
+      errorNotif!.msg.includes("python3 -m venv"),
+      "error notification suggests manual venv creation",
+    );
+  });
+});


### PR DESCRIPTION
Previous file used createTestContext() + top-level main() — tests ran at import time rather than registering with node:test, so CI reporter showed nothing. Rewritten with describe/test. Same 9 cases, now visible to the runner.

Closes #4809. Refs #4784.