### PR TITLE
test(remote-questions): drive real startCommandPolling via DI seam (partial #4806)

### DIFF
--- a/src/resources/extensions/remote-questions/manager.ts
+++ b/src/resources/extensions/remote-questions/manager.ts
@@ -15,33 +15,65 @@ import { sanitizeError } from "../shared/sanitize.js";
 const COMMAND_POLLING_INTERVAL_MS = 5000;
 
 /**
+ * Minimal adapter surface used by startCommandPolling. Just enough for
+ * the polling loop to invoke without pulling in the full
+ * TelegramAdapter in tests.
+ */
+export interface PollingAdapter {
+  pollAndHandleCommands: (basePath: string) => Promise<number>;
+}
+
+/**
+ * Optional dependency-injection seam for `startCommandPolling`. Production
+ * callers pass nothing; tests stub the config resolver, adapter
+ * constructor, and timer functions to exercise the real function
+ * without hitting the filesystem / env / real intervals. See #4806.
+ */
+export interface CommandPollingDeps {
+  resolveConfig?: () => ResolvedConfig | null;
+  createAdapter?: (config: ResolvedConfig, basePath: string) => PollingAdapter;
+  setIntervalFn?: typeof setInterval;
+  clearIntervalFn?: typeof clearInterval;
+}
+
+/**
  * Start background polling for incoming slash commands on the configured
  * remote channel. Only Telegram supports command polling — other channels
  * are no-ops that return an inert cleanup function immediately.
  *
  * @param basePath - Project root, forwarded to command handlers (e.g. /status).
  * @param intervalMs - Polling interval in milliseconds (default 5 s).
+ * @param deps - Test-only overrides. Omit in production.
  * @returns A cleanup function that stops the polling interval.
  */
 export function startCommandPolling(
   basePath: string,
   intervalMs = COMMAND_POLLING_INTERVAL_MS,
+  deps: CommandPollingDeps = {},
 ): () => void {
-  const config = resolveRemoteConfig();
+  const resolveConfig = deps.resolveConfig ?? resolveRemoteConfig;
+  const createAdapter =
+    deps.createAdapter ??
+    ((c: ResolvedConfig, b: string): PollingAdapter =>
+      new TelegramAdapter(c.token, c.channelId, b));
+  const setIntervalFn = deps.setIntervalFn ?? setInterval;
+  const clearIntervalFn = deps.clearIntervalFn ?? clearInterval;
+
+  const config = resolveConfig();
   if (!config || config.channel !== "telegram") {
     // Non-Telegram channels have no command polling support — return a no-op cleanup.
     return () => {};
   }
 
-  const adapter = new TelegramAdapter(config.token, config.channelId, basePath);
+  const adapter = createAdapter(config, basePath);
 
-  const timer = setInterval(() => {
+  const timer = setIntervalFn(() => {
     void adapter.pollAndHandleCommands(basePath).catch(() => {
       // Non-fatal: network hiccup or rate-limit — best-effort polling
     });
   }, intervalMs);
 
-  return () => clearInterval(timer);
+  return () => clearIntervalFn(timer);
 }
 
 interface ToolResult {

--- a/src/resources/extensions/remote-questions/tests/command-polling.test.ts
+++ b/src/resources/extensions/remote-questions/tests/command-polling.test.ts
@@ -1,18 +1,31 @@
 /**
- * Tests for startCommandPolling() background interval.
+ * Tests for the REAL `startCommandPolling()` background interval.
  *
- * Framework: node:test + node:assert/strict (CONTRIBUTING.md rules)
+ * Previous version of this file re-implemented `startCommandPolling`
+ * inline (as `makeStartCommandPolling`) and tested the re-implementation.
+ * The file header said exactly that: "Rather than importing the real
+ * startCommandPolling (which calls resolveRemoteConfig and hits the
+ * filesystem / env), we re-implement the same tiny function inline
+ * here using injected fakes." If the real function regressed (wrong
+ * channel gate, missing cleanup, wrong handler invocation), none of
+ * those tests would have failed. See #4806 / #4784.
  *
- * Covers:
- *   - startCommandPolling returns a cleanup function
- *   - Calling cleanup stops further poll invocations
- *   - When no remote channel is configured, a no-op cleanup is returned
+ * Rewrite uses the DI seam now exposed on `startCommandPolling`
+ * (`CommandPollingDeps`) to drive the real function with a stubbed
+ * config resolver, adapter factory, and timer pair.
  */
 
-import test from "node:test";
+import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 
-// ─── Minimal fake timer harness ───────────────────────────────────────────────
+import type { ResolvedConfig } from "../config.ts";
+import {
+  startCommandPolling,
+  type PollingAdapter,
+  type CommandPollingDeps,
+} from "../manager.ts";
+
+// ─── Fake timer harness ───────────────────────────────────────────────────────
 
 interface FakeTimer {
   id: number;
@@ -21,226 +34,223 @@ interface FakeTimer {
   cleared: boolean;
 }
 
-/**
- * Build a fake setInterval / clearInterval pair so tests never actually wait
- * for real time and do not depend on Node's timer subsystem firing order.
- */
 function makeFakeTimers(): {
-  fakeSetInterval: typeof setInterval;
-  fakeClearInterval: typeof clearInterval;
+  setIntervalFn: typeof setInterval;
+  clearIntervalFn: typeof clearInterval;
   timers: FakeTimer[];
   tick: () => void;
 } {
   const timers: FakeTimer[] = [];
   let nextId = 1;
 
-  const fakeSetInterval = (callback: () => void, _ms?: number, ..._args: unknown[]): ReturnType<typeof setInterval> => {
+  const setIntervalFn = ((callback: () => void, ms?: number): ReturnType<typeof setInterval> => {
     const timer: FakeTimer = {
       id: nextId++,
       callback,
-      intervalMs: _ms ?? 0,
+      intervalMs: ms ?? 0,
       cleared: false,
     };
     timers.push(timer);
     return timer.id as unknown as ReturnType<typeof setInterval>;
-  };
+  }) as unknown as typeof setInterval;
 
-  const fakeClearInterval = (id?: ReturnType<typeof clearInterval> | null): void => {
+  const clearIntervalFn = ((id?: ReturnType<typeof clearInterval> | null): void => {
     const timer = timers.find((t) => (t.id as unknown) === id);
     if (timer) timer.cleared = true;
-  };
+  }) as unknown as typeof clearInterval;
 
-  /** Fire all non-cleared timers once (simulates one interval tick). */
   const tick = (): void => {
     for (const timer of timers) {
       if (!timer.cleared) timer.callback();
     }
   };
 
-  return {
-    fakeSetInterval: fakeSetInterval as unknown as typeof setInterval,
-    fakeClearInterval: fakeClearInterval as unknown as typeof clearInterval,
-    timers,
-    tick,
-  };
+  return { setIntervalFn, clearIntervalFn, timers, tick };
 }
 
-// ─── Fake TelegramAdapter ────────────────────────────────────────────────────
+// ─── Config + adapter stubs ───────────────────────────────────────────────────
 
-function makeFakeAdapter(): {
-  pollCalls: number;
-  pollAndHandleCommands: (basePath: string) => Promise<number>;
-} {
-  let pollCalls = 0;
+function telegramConfig(): ResolvedConfig {
   return {
-    get pollCalls() { return pollCalls; },
+    channel: "telegram",
+    token: "fake-token",
+    channelId: "fake-channel-id",
+    timeoutMs: 60_000,
+    pollIntervalMs: 1_000,
+  } as ResolvedConfig;
+}
+
+function slackConfig(): ResolvedConfig {
+  return {
+    channel: "slack",
+    token: "fake-token",
+    channelId: "fake-channel-id",
+    timeoutMs: 60_000,
+    pollIntervalMs: 1_000,
+  } as ResolvedConfig;
+}
+
+function makeFakeAdapter(): PollingAdapter & { readonly pollCalls: number } {
+  let pollCalls = 0;
+  const adapter = {
+    get pollCalls(): number {
+      return pollCalls;
+    },
     async pollAndHandleCommands(_basePath: string): Promise<number> {
       pollCalls++;
       return 0;
     },
   };
+  return adapter;
 }
 
-// ─── Internal startCommandPolling factory (testable, no real I/O) ────────────
-//
-// Rather than importing the real startCommandPolling (which calls resolveRemoteConfig
-// and hits the filesystem / env), we re-implement the same tiny function inline
-// here using injected fakes. This keeps tests hermetic without mocking globals.
+// ─── Tests against the real startCommandPolling ───────────────────────────────
 
-function makeStartCommandPolling(
-  fakeSetInterval: typeof setInterval,
-  fakeClearInterval: typeof clearInterval,
-  adapterPollFn: (basePath: string) => Promise<number>,
-  isConfigured: boolean,
-  intervalMs = 5000,
-): (basePath: string) => () => void {
-  return function startCommandPolling(basePath: string): () => void {
-    if (!isConfigured) {
-      return () => {};
-    }
+describe("startCommandPolling (real function via DI seam)", () => {
+  it("returns a cleanup function for a Telegram config", () => {
+    const { setIntervalFn, clearIntervalFn } = makeFakeTimers();
+    const adapter = makeFakeAdapter();
 
-    const timer = fakeSetInterval(() => {
-      void adapterPollFn(basePath).catch(() => {});
-    }, intervalMs);
+    const deps: CommandPollingDeps = {
+      resolveConfig: () => telegramConfig(),
+      createAdapter: () => adapter,
+      setIntervalFn,
+      clearIntervalFn,
+    };
 
-    return () => fakeClearInterval(timer);
-  };
-}
+    const stop = startCommandPolling("/tmp/project", 5_000, deps);
+    assert.equal(typeof stop, "function", "must return a cleanup function");
+    stop();
+  });
 
-// ─── Tests ───────────────────────────────────────────────────────────────────
+  it("invokes the adapter's pollAndHandleCommands on each tick", async () => {
+    const { setIntervalFn, clearIntervalFn, tick } = makeFakeTimers();
+    const adapter = makeFakeAdapter();
 
-test("startCommandPolling: returns a cleanup function (callable without error)", () => {
-  const { fakeSetInterval, fakeClearInterval } = makeFakeTimers();
-  const adapter = makeFakeAdapter();
-  const startCommandPolling = makeStartCommandPolling(
-    fakeSetInterval,
-    fakeClearInterval,
-    adapter.pollAndHandleCommands.bind(adapter),
-    true,
-  );
+    const stop = startCommandPolling("/tmp/project", 5_000, {
+      resolveConfig: () => telegramConfig(),
+      createAdapter: () => adapter,
+      setIntervalFn,
+      clearIntervalFn,
+    });
 
-  const cleanup = startCommandPolling("/fake/project");
+    assert.equal(adapter.pollCalls, 0, "no poll before any tick");
 
-  assert.equal(typeof cleanup, "function", "Expected startCommandPolling to return a function");
-  // Calling cleanup must not throw
-  assert.doesNotThrow(() => cleanup(), "cleanup() must not throw");
-});
+    tick();
+    // Yield so the async adapter call settles before we assert.
+    await Promise.resolve();
+    await Promise.resolve();
+    assert.equal(adapter.pollCalls, 1, "one tick → one poll");
 
-test("startCommandPolling: interval fires the poll callback on tick", async () => {
-  const { fakeSetInterval, fakeClearInterval, tick } = makeFakeTimers();
-  const adapter = makeFakeAdapter();
-  const startCommandPolling = makeStartCommandPolling(
-    fakeSetInterval,
-    fakeClearInterval,
-    adapter.pollAndHandleCommands.bind(adapter),
-    true,
-  );
+    tick();
+    tick();
+    await Promise.resolve();
+    await Promise.resolve();
+    assert.equal(adapter.pollCalls, 3, "three ticks → three polls");
 
-  startCommandPolling("/fake/project");
+    stop();
+  });
 
-  // Before any tick, nothing polled yet
-  assert.equal(adapter.pollCalls, 0);
+  it("cleanup stops further polls", async () => {
+    const { setIntervalFn, clearIntervalFn, tick } = makeFakeTimers();
+    const adapter = makeFakeAdapter();
 
-  // One tick — the callback fires and schedules the async poll
-  tick();
+    const stop = startCommandPolling("/tmp/project", 5_000, {
+      resolveConfig: () => telegramConfig(),
+      createAdapter: () => adapter,
+      setIntervalFn,
+      clearIntervalFn,
+    });
 
-  // Allow the microtask queue to drain so the async poll promise resolves
-  await Promise.resolve();
+    tick();
+    await Promise.resolve();
+    await Promise.resolve();
+    const pollsBeforeStop = adapter.pollCalls;
+    assert.ok(pollsBeforeStop > 0, "at least one poll before stop");
 
-  assert.equal(adapter.pollCalls, 1, "Expected poll to be called after one tick");
-});
+    stop();
 
-test("startCommandPolling: cleanup stops further poll invocations", async () => {
-  const { fakeSetInterval, fakeClearInterval, timers, tick } = makeFakeTimers();
-  const adapter = makeFakeAdapter();
-  const startCommandPolling = makeStartCommandPolling(
-    fakeSetInterval,
-    fakeClearInterval,
-    adapter.pollAndHandleCommands.bind(adapter),
-    true,
-  );
+    tick();
+    tick();
+    await Promise.resolve();
+    await Promise.resolve();
+    assert.equal(
+      adapter.pollCalls,
+      pollsBeforeStop,
+      "no additional polls after stop() — cleared interval must stop ticking",
+    );
+  });
 
-  const cleanup = startCommandPolling("/fake/project");
+  it("returns a no-op when no remote channel is configured", () => {
+    const { setIntervalFn, clearIntervalFn, timers } = makeFakeTimers();
+    const adapter = makeFakeAdapter();
 
-  // Tick once to confirm polling works
-  tick();
-  await Promise.resolve();
-  assert.equal(adapter.pollCalls, 1, "Expected 1 poll after first tick");
+    const stop = startCommandPolling("/tmp/project", 5_000, {
+      resolveConfig: () => null,
+      createAdapter: () => adapter,
+      setIntervalFn,
+      clearIntervalFn,
+    });
 
-  // Call cleanup — marks the timer as cleared
-  cleanup();
+    assert.equal(typeof stop, "function", "still returns a function");
+    assert.equal(
+      timers.length,
+      0,
+      "no interval registered when config is absent",
+    );
+    assert.doesNotThrow(() => stop());
+  });
 
-  // Confirm the underlying timer was cleared
-  assert.equal(timers.length, 1, "Expected exactly one timer to have been registered");
-  assert.equal(timers[0].cleared, true, "Expected timer to be cleared after cleanup()");
+  it("returns a no-op for non-Telegram channels (e.g. Slack)", () => {
+    const { setIntervalFn, clearIntervalFn, timers } = makeFakeTimers();
+    const adapter = makeFakeAdapter();
+    let adapterCreated = false;
 
-  // Tick again — the cleared timer must NOT fire
-  tick();
-  await Promise.resolve();
-  assert.equal(adapter.pollCalls, 1, "Expected no additional polls after cleanup()");
-});
+    const stop = startCommandPolling("/tmp/project", 5_000, {
+      resolveConfig: () => slackConfig(),
+      createAdapter: () => {
+        adapterCreated = true;
+        return adapter;
+      },
+      setIntervalFn,
+      clearIntervalFn,
+    });
 
-test("startCommandPolling: calling cleanup twice is safe (no throw)", () => {
-  const { fakeSetInterval, fakeClearInterval } = makeFakeTimers();
-  const adapter = makeFakeAdapter();
-  const startCommandPolling = makeStartCommandPolling(
-    fakeSetInterval,
-    fakeClearInterval,
-    adapter.pollAndHandleCommands.bind(adapter),
-    true,
-  );
+    assert.equal(
+      timers.length,
+      0,
+      "no interval registered for non-Telegram channel",
+    );
+    assert.equal(
+      adapterCreated,
+      false,
+      "adapter must not be instantiated when channel is unsupported",
+    );
+    stop();
+  });
 
-  const cleanup = startCommandPolling("/fake/project");
+  it("does not surface adapter polling errors (best-effort)", async () => {
+    const { setIntervalFn, clearIntervalFn, tick } = makeFakeTimers();
+    const adapter: PollingAdapter = {
+      async pollAndHandleCommands(_basePath: string): Promise<number> {
+        throw new Error("network hiccup");
+      },
+    };
 
-  assert.doesNotThrow(() => {
-    cleanup();
-    cleanup();
-  }, "Calling cleanup twice must not throw");
-});
+    const stop = startCommandPolling("/tmp/project", 5_000, {
+      resolveConfig: () => telegramConfig(),
+      createAdapter: () => adapter,
+      setIntervalFn,
+      clearIntervalFn,
+    });
 
-test("startCommandPolling: returns no-op cleanup when no channel is configured", () => {
-  const { fakeSetInterval, fakeClearInterval, timers } = makeFakeTimers();
-  const adapter = makeFakeAdapter();
-  const startCommandPolling = makeStartCommandPolling(
-    fakeSetInterval,
-    fakeClearInterval,
-    adapter.pollAndHandleCommands.bind(adapter),
-    false, // not configured
-  );
+    // Tick must not throw; the `.catch(() => {})` in production code
+    // swallows the rejection so one bad network call doesn't crash
+    // the polling loop.
+    assert.doesNotThrow(() => tick());
+    await Promise.resolve();
+    await Promise.resolve();
 
-  const cleanup = startCommandPolling("/fake/project");
-
-  assert.equal(typeof cleanup, "function", "Expected a cleanup function even when not configured");
-  assert.equal(timers.length, 0, "Expected no timer to be registered when channel is not configured");
-
-  // The no-op cleanup must not throw
-  assert.doesNotThrow(() => cleanup(), "No-op cleanup must not throw");
-});
-
-test("startCommandPolling: poll errors are swallowed (best-effort)", async () => {
-  const { fakeSetInterval, fakeClearInterval, tick } = makeFakeTimers();
-
-  // Adapter that always rejects
-  let rejectCalls = 0;
-  const throwingPoll = async (_basePath: string): Promise<number> => {
-    rejectCalls++;
-    throw new Error("Simulated network error");
-  };
-
-  const startCommandPolling = makeStartCommandPolling(
-    fakeSetInterval,
-    fakeClearInterval,
-    throwingPoll,
-    true,
-  );
-
-  startCommandPolling("/fake/project");
-
-  // Ticking must not propagate the rejection — the interval is fire-and-forget
-  assert.doesNotThrow(() => tick(), "tick() must not throw even if poll rejects");
-
-  // Allow the rejected promise to settle without an unhandled rejection
-  await Promise.resolve();
-
-  assert.equal(rejectCalls, 1, "Expected poll to have been called once");
+    stop();
+  });
 });


### PR DESCRIPTION
Replace the inline reimplementation test with one that drives the REAL `startCommandPolling` through a minimal DI seam (`CommandPollingDeps`). 6 behaviour tests, all against the real function. Includes a new test that catches a class of regression the old reimplementation couldn't — asserting the adapter is NOT instantiated for non-Telegram channels.

Partial fix for #4806 — covers command-polling.test.ts. The other two files (ollama-chat-provider-stream, interview-preview layout constants) follow separately.

Refs #4784.