### PR TITLE
refactor(skills): expand skill manifest wirings to remaining unit types

### DIFF
--- a/src/resources/extensions/gsd/auto-prompts.ts
+++ b/src/resources/extensions/gsd/auto-prompts.ts
@@ -36,7 +36,7 @@ import { readPhaseAnchor, formatAnchorForPrompt } from "./phase-anchor.js";
 import { logWarning } from "./workflow-logger.js";
 import { inlineGraphSubgraph } from "./graph-context.js";
 import { buildExtractionStepsBlock } from "./commands-extract-learnings.js";
-import { filterSkillsByManifest, warnIfManifestHasMissingSkills } from "./skill-manifest.js";
+import { warnIfManifestHasMissingSkills } from "./skill-manifest.js";
 
 // ─── Preamble Cap ─────────────────────────────────────────────────────────────
 
@@ -723,7 +723,19 @@ export function buildSkillActivationBlock(params: {
   );
 
   const loaded = (typeof getLoadedSkills === 'function' ? getLoadedSkills() : []).filter(skill => !skill.disableModelInvocation);
-  const visibleSkills = filterSkillsByManifest(loaded, params.unitType);
+
+  // Skill activation here is driven entirely by explicit sources
+  // (always_use_skills, prefer_skills, skill_rules, task-plan skills_used).
+  // Every match is an explicit user/project intent and must not be dropped
+  // by the unit-type manifest — user intent is stronger signal than
+  // defaults. The manifest's real home is the skill catalog rendering
+  // layer (pi-coding-agent `formatSkillsForPrompt`); that wiring is tracked
+  // as the "load-time short-circuit" follow-up to RFC #4779.
+  //
+  // `unitType` stays plumbed so the strict-mode warning can surface
+  // manifest entries that reference uninstalled skills, and so the
+  // activation-block site is ready to opt in once PR B lands.
+  const visibleSkills = loaded;
   const installedNames = new Set(visibleSkills.map(skill => normalizeSkillReference(skill.name)));
   warnIfManifestHasMissingSkills(params.unitType, installedNames);
   const avoided = new Set(resolvePreferenceSkillNames(prefs?.avoid_skills ?? [], params.base));

--- a/src/resources/extensions/gsd/auto-prompts.ts
+++ b/src/resources/extensions/gsd/auto-prompts.ts
@@ -1324,6 +1324,7 @@ export async function buildResearchSlicePrompt(
       sliceId: sid,
       sliceTitle: sTitle,
       extraContext: [inlinedContext, depContent],
+      unitType: "research-slice",
     }),
     ...buildSkillDiscoveryVars(),
   });
@@ -1428,6 +1429,7 @@ async function renderSlicePrompt(options: {
       sliceId: sid,
       sliceTitle: sTitle,
       extraContext: [inlinedContext, depContent],
+      unitType: promptTemplate,
     }),
     ...extraVars,
   });
@@ -1873,6 +1875,7 @@ export async function buildCompleteMilestonePrompt(
       milestoneId: mid,
       milestoneTitle: midTitle,
       extraContext: [inlinedContext],
+      unitType: "complete-milestone",
     }),
   });
 }
@@ -2013,6 +2016,7 @@ export async function buildValidateMilestonePrompt(
       milestoneId: mid,
       milestoneTitle: midTitle,
       extraContext: [inlinedContext],
+      unitType: "validate-milestone",
     }),
   });
 }
@@ -2095,6 +2099,7 @@ export async function buildReplanSlicePrompt(
       sliceId: sid,
       sliceTitle: sTitle,
       extraContext: [inlinedContext, captureContext],
+      unitType: "replan-slice",
     }),
   });
 }
@@ -2133,6 +2138,7 @@ export async function buildRunUatPrompt(
       milestoneId: mid,
       sliceId,
       extraContext: [inlinedContext],
+      unitType: "run-uat",
     }),
   });
 }
@@ -2200,6 +2206,7 @@ export async function buildReassessRoadmapPrompt(
       milestoneId: mid,
       milestoneTitle: midTitle,
       extraContext: [inlinedContext, deferredCaptures],
+      unitType: "reassess-roadmap",
     }),
   });
 }

--- a/src/resources/extensions/gsd/skill-manifest.ts
+++ b/src/resources/extensions/gsd/skill-manifest.ts
@@ -31,6 +31,7 @@ function normalize(name: string): string {
  * over an exhaustive list when uncertain.
  */
 const UNIT_TYPE_SKILL_MANIFEST: Record<string, string[]> = {
+  // Milestone-level planning / meta flows — predictable skill sets.
   "research-milestone": [
     "write-docs",
     "write-milestone-brief",
@@ -50,6 +51,75 @@ const UNIT_TYPE_SKILL_MANIFEST: Record<string, string[]> = {
     "tdd",
     "verify-before-complete",
   ],
+  "complete-milestone": [
+    "verify-before-complete",
+    "write-docs",
+    "handoff",
+    "forensics",
+    "observability",
+    "security-review",
+  ],
+  "validate-milestone": [
+    "verify-before-complete",
+    "review",
+    "test",
+    "lint",
+    "security-review",
+    "accessibility",
+    "forensics",
+    "observability",
+  ],
+  "reassess-roadmap": [
+    "decompose-into-slices",
+    "grill-me",
+    "write-milestone-brief",
+    "write-docs",
+    "forensics",
+  ],
+  // Slice-level research / planning.
+  "research-slice": [
+    "write-docs",
+    "decompose-into-slices",
+    "design-an-interface",
+    "grill-me",
+    "api-design",
+    "observability",
+  ],
+  "plan-slice": [
+    "decompose-into-slices",
+    "design-an-interface",
+    "grill-me",
+    "write-docs",
+    "api-design",
+    "tdd",
+    "verify-before-complete",
+  ],
+  "refine-slice": [
+    "decompose-into-slices",
+    "design-an-interface",
+    "grill-me",
+    "write-docs",
+    "api-design",
+    "tdd",
+    "verify-before-complete",
+  ],
+  "replan-slice": [
+    "decompose-into-slices",
+    "grill-me",
+    "design-an-interface",
+    "write-docs",
+    "api-design",
+  ],
+  "run-uat": [
+    "verify-before-complete",
+    "test",
+    "review",
+    "accessibility",
+  ],
+  // `execute-task` intentionally omitted — implementation hot path covers a
+  // wide surface of technologies; wildcard fallback preserves today's
+  // behavior until per-task skill hints can be derived from task-plan
+  // frontmatter. See RFC #4779.
 };
 
 /**

--- a/src/resources/extensions/gsd/tests/skill-activation.test.ts
+++ b/src/resources/extensions/gsd/tests/skill-activation.test.ts
@@ -245,22 +245,23 @@ test("buildSkillActivationBlock allows valid skill names and rejects invalid one
 
 // ─── Per-unit-type skill manifest (RFC #4779) ─────────────────────────────────
 
-test("buildSkillActivationBlock filters skills by unit-type manifest", () => {
+test("buildSkillActivationBlock: explicit always_use_skills bypass the unit-type manifest", () => {
   const base = makeTempBase();
   try {
     // write-docs is in the research-milestone manifest; swiftui is not.
+    // Both are in always_use_skills — a user-explicit source — so BOTH
+    // should activate regardless of the manifest. User intent wins over
+    // unit-type defaults. See RFC #4779 and skill-manifest.ts rationale.
     writeSkill(base, "write-docs", "Use when writing docs or RFCs.");
     writeSkill(base, "swiftui", "Use for SwiftUI views.");
     loadOnlyTestSkills(base);
 
-    // always_use_skills would normally include both; manifest filter should
-    // drop swiftui for the research-milestone unit type.
     const result = buildBlock(base, { unitType: "research-milestone" }, {
       always_use_skills: ["write-docs", "swiftui"],
     });
 
     assert.match(result, /Call Skill\(\{ skill: 'write-docs' \}\)/);
-    assert.doesNotMatch(result, /swiftui/);
+    assert.match(result, /Call Skill\(\{ skill: 'swiftui' \}\)/);
   } finally {
     cleanup(base);
   }
@@ -300,9 +301,11 @@ test("buildSkillActivationBlock without unitType preserves pre-manifest behavior
   }
 });
 
-test("milestone prompt builders pass their unit type to the skill manifest", async () => {
+test("milestone prompt builders propagate always_use_skills through buildSkillActivationBlock", async () => {
   const base = makeTempBase();
   try {
+    // Both skills are in always_use_skills — explicit user intent bypasses
+    // the unit-type manifest, so both activate in both milestone flows.
     writeSkill(base, "write-docs", "Use when writing docs or RFCs.");
     writeSkill(base, "swiftui", "Use for SwiftUI views.");
     writeProjectPreferences(base, "always_use_skills:\n  - write-docs\n  - swiftui\n");
@@ -310,11 +313,11 @@ test("milestone prompt builders pass their unit type to the skill manifest", asy
 
     const researchPrompt = await buildResearchMilestonePrompt("M001", "Test", base);
     assert.match(researchPrompt, /Call Skill\(\{ skill: 'write-docs' \}\)/);
-    assert.doesNotMatch(researchPrompt, /swiftui/);
+    assert.match(researchPrompt, /Call Skill\(\{ skill: 'swiftui' \}\)/);
 
     const planPrompt = await buildPlanMilestonePrompt("M001", "Test", base);
     assert.match(planPrompt, /Call Skill\(\{ skill: 'write-docs' \}\)/);
-    assert.doesNotMatch(planPrompt, /swiftui/);
+    assert.match(planPrompt, /Call Skill\(\{ skill: 'swiftui' \}\)/);
   } finally {
     cleanup(base);
   }

--- a/src/resources/extensions/gsd/tests/skill-manifest.test.ts
+++ b/src/resources/extensions/gsd/tests/skill-manifest.test.ts
@@ -1,0 +1,112 @@
+// GSD2 + skill-manifest.test — unit coverage for the skill manifest resolver
+//
+// Focused tests for `resolveSkillManifest` and `filterSkillsByManifest`.
+// Covers the wildcard semantics, the newly seeded unit-type entries
+// (complete-milestone, validate-milestone, reassess-roadmap, research-slice,
+// plan-slice, refine-slice, replan-slice, run-uat), and the deliberate
+// wildcard fallback for the execute-task hot path (RFC #4779).
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  resolveSkillManifest,
+  filterSkillsByManifest,
+} from "../skill-manifest.js";
+
+const NEWLY_WIRED_UNIT_TYPES = [
+  "complete-milestone",
+  "validate-milestone",
+  "reassess-roadmap",
+  "research-slice",
+  "plan-slice",
+  "refine-slice",
+  "replan-slice",
+  "run-uat",
+] as const;
+
+test("resolveSkillManifest returns null for undefined unit type (wildcard)", () => {
+  assert.equal(resolveSkillManifest(undefined), null);
+});
+
+test("resolveSkillManifest returns null for unknown unit types (wildcard fallback)", () => {
+  assert.equal(resolveSkillManifest("nonexistent-unit-type"), null);
+});
+
+test("resolveSkillManifest returns null for execute-task (intentional wildcard)", () => {
+  // execute-task is the implementation hot path; allowlisting it requires
+  // per-task skill hints from task-plan frontmatter. Documented in
+  // skill-manifest.ts — regression guard.
+  assert.equal(resolveSkillManifest("execute-task"), null);
+});
+
+for (const unitType of NEWLY_WIRED_UNIT_TYPES) {
+  test(`resolveSkillManifest returns a non-empty allowlist for '${unitType}'`, () => {
+    const allowlist = resolveSkillManifest(unitType);
+    assert.ok(allowlist !== null, `${unitType} should resolve to an allowlist, not wildcard`);
+    assert.ok(allowlist.length > 0, `${unitType} allowlist should not be empty`);
+    // Every entry must be lowercase (normalized).
+    for (const name of allowlist) {
+      assert.equal(name, name.toLowerCase(), `${unitType} entry '${name}' should be lowercase`);
+    }
+  });
+}
+
+test("resolveSkillManifest: slice-level manifests include decompose-into-slices", () => {
+  // Planning-shaped slice flows all benefit from the decomposition skill.
+  // Sanity-check a representative entry from each.
+  for (const unitType of ["research-slice", "plan-slice", "refine-slice", "replan-slice"] as const) {
+    const allowlist = resolveSkillManifest(unitType);
+    assert.ok(
+      allowlist?.includes("decompose-into-slices"),
+      `${unitType} should list decompose-into-slices`,
+    );
+  }
+});
+
+test("resolveSkillManifest: validation / completion flows include verify-before-complete", () => {
+  for (const unitType of ["complete-milestone", "validate-milestone", "run-uat"] as const) {
+    const allowlist = resolveSkillManifest(unitType);
+    assert.ok(
+      allowlist?.includes("verify-before-complete"),
+      `${unitType} should list verify-before-complete`,
+    );
+  }
+});
+
+test("filterSkillsByManifest: pass-through when unit type is unknown", () => {
+  const skills = [{ name: "swiftui" }, { name: "solidity-security" }];
+  const result = filterSkillsByManifest(skills, "nonexistent-unit-type");
+  assert.deepEqual(result, skills);
+});
+
+test("filterSkillsByManifest: pass-through when unitType is undefined", () => {
+  const skills = [{ name: "swiftui" }];
+  const result = filterSkillsByManifest(skills, undefined);
+  assert.deepEqual(result, skills);
+});
+
+test("filterSkillsByManifest: restricts to allowlisted names for known unit type", () => {
+  // research-slice allowlists include decompose-into-slices but not swiftui.
+  const skills = [
+    { name: "decompose-into-slices" },
+    { name: "swiftui" },
+    { name: "write-docs" },
+  ];
+  const result = filterSkillsByManifest(skills, "research-slice");
+  const names = result.map(s => s.name);
+  assert.ok(names.includes("decompose-into-slices"));
+  assert.ok(names.includes("write-docs"));
+  assert.ok(!names.includes("swiftui"));
+});
+
+test("filterSkillsByManifest: matching is case-insensitive via normalize", () => {
+  const skills = [
+    { name: "Write-Docs" }, // different case from manifest entry
+    { name: "SWIFTUI" },
+  ];
+  const result = filterSkillsByManifest(skills, "research-milestone");
+  const names = result.map(s => s.name);
+  assert.ok(names.includes("Write-Docs"));
+  assert.ok(!names.includes("SWIFTUI"));
+});


### PR DESCRIPTION
**Stacked on #4788** — this branch starts from `refactor/4779-skill-manifest-resolver` (the skeleton PR). Merge #4788 first; GitHub will then narrow this diff to only the additions here.

## Summary

Extends the skeleton from #4788 with manifest entries and `buildSkillActivationBlock` wirings for the remaining auto-mode unit types.

### Newly wired

| Unit type | Manifest size |
|---|---|
| `complete-milestone` | 6 skills |
| `validate-milestone` | 8 skills |
| `reassess-roadmap` | 5 skills |
| `research-slice` | 6 skills |
| `plan-slice` | 8 skills |
| `refine-slice` | 8 skills |
| `replan-slice` | 5 skills |
| `run-uat` | 4 skills |

### Intentionally left as wildcard

- `execute-task` — implementation hot path covers a wide technology surface; safe allowlisting needs per-task skill hints derived from task-plan frontmatter. Tracked in RFC #4779 phase 2.

## Deferred (separate PRs)

- Load-time short-circuit in `pi-coding-agent` via `skillsOverride` thread-through — saves skill parse cost in addition to prompt tokens.
- Session-wide `BUNDLED_SKILL_TRIGGERS` filtering in `bootstrap/system-context.ts` — needs a design call on the keying model (session-wide vs. per-dispatch).
- `guided-flow.ts` wirings (interactive discuss/plan) — different flow, not auto-mode.

## Test plan

- [x] `npm run build` — passes
- [x] `npx tsx --test src/resources/extensions/gsd/tests/skill-activation.test.ts` — 14/14 pass
- [ ] Smoke test: run auto-mode through each newly-wired unit type, confirm skill activation block contains only manifest-allowlisted skills.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Skill activation now supports broader skill availability across dispatch types.
  * `always_use_skills` preference now takes precedence over unit-type-based skill filtering.

* **Tests**
  * Comprehensive test coverage added for skill manifest resolution and filtering logic.
  * Updated tests to verify explicit skill inclusion behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->