### PR TITLE
test(pi-tui): tighten secure-mode mask + remove markdown-trim escape (partial #4796)

### DIFF
--- a/packages/pi-tui/src/components/__tests__/input.test.ts
+++ b/packages/pi-tui/src/components/__tests__/input.test.ts
@@ -37,11 +37,27 @@ describe("Input", () => {
 		const input = new Input();
 		input.secure = true;
 		input.focused = true;
-		input.handleInput("secret123");
+		const SECRET = "secret123";
+		input.handleInput(SECRET);
 
 		const line = input.render(40)[0] ?? "";
-		assert.ok(!line.includes("secret123"), "rendered line must not expose raw secret text");
-		assert.ok(line.includes("*********"), "rendered line should include masked characters");
+		// Previous assertion was `line.includes("*********")` — a literal
+		// 9-star string that silently goes stale if SECRET is renamed to
+		// a different length (#4796). Match any run of asterisks and
+		// assert its length covers the secret.
+		assert.ok(
+			!line.includes(SECRET),
+			"rendered line must not expose raw secret text",
+		);
+		const maskMatch = line.match(/\*+/);
+		assert.ok(
+			maskMatch,
+			`rendered line must include masked characters, got: ${JSON.stringify(line)}`,
+		);
+		assert.ok(
+			maskMatch[0].length >= SECRET.length,
+			`mask must cover at least the secret length (${SECRET.length}), got ${maskMatch[0].length} asterisks`,
+		);
 	});
 
 	it("maps kitty keypad digits to text instead of inserting private-use glyphs", () => {

--- a/packages/pi-tui/src/components/__tests__/markdown-maxlines.test.ts
+++ b/packages/pi-tui/src/components/__tests__/markdown-maxlines.test.ts
@@ -69,7 +69,14 @@ test("Markdown trims trailing empty lines", () => {
 	const text = "Some text\n\n";
 	const md = new Markdown(text, 0, 0, noopTheme());
 	const lines = md.render(80);
-	// Last line should not be empty (trailing empties are trimmed)
+	// Previous assertion was `lastLine.trim().length > 0 || lines.length === 1`
+	// — the `|| lines.length === 1` disjunction trivially passed for any
+	// single-line render, so a regression that returned `['']` still
+	// passed (#4796). Assert the trim invariant directly.
+	assert.ok(lines.length > 0, "render must produce at least one line");
 	const lastLine = lines[lines.length - 1];
-	assert.ok(lastLine.trim().length > 0 || lines.length === 1, "trailing empty lines should be trimmed");
+	assert.ok(
+		lastLine.trim().length > 0,
+		`last line must have visible content after trim, got: ${JSON.stringify(lastLine)}`,
+	);
 });


### PR DESCRIPTION
Two fixes: secure-mode 9-star literal → regex /\\*+/ with length check. Markdown trim `|| lines.length === 1` disjunction removed (trivially passed for `['']`). Rest of #4796 follow-up.

Refs #4784.