### PR TITLE
test(auto-loop): delete while-keyword tautology

### DIFF
--- a/src/resources/extensions/gsd/tests/auto-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/auto-loop.test.ts
@@ -557,17 +557,6 @@ test("auto-loop.ts exports autoLoop, runUnit, resolveAgentEnd", async () => {
   );
 });
 
-test("auto/loop.ts contains a while keyword", () => {
-  const src = readFileSync(
-    resolve(import.meta.dirname, "..", "auto", "loop.ts"),
-    "utf-8",
-  );
-  assert.ok(
-    src.includes("while"),
-    "auto/loop.ts should contain a while keyword (loop or placeholder)",
-  );
-});
-
 test("auto/resolve.ts one-shot pattern: _currentResolve is nulled before calling resolver", () => {
   const src = readFileSync(
     resolve(import.meta.dirname, "..", "auto", "resolve.ts"),


### PR DESCRIPTION
## What

Delete the test `auto/loop.ts contains a while keyword` from
`src/resources/extensions/gsd/tests/auto-loop.test.ts`.

## Why

It is a tautology. `assert.ok(src.includes("while"))` passes for any
file that contains the word "while" anywhere — in a loop, in a
comment, in a string literal. It enforces nothing about runtime
behaviour and blocks refactors that rename a `while` to a `for` or
use an async iterator.

Explicitly flagged in the batch-00 audit (`/tmp/gsd-batch-00-audit.csv`)
and in the referenced mandate as deletable.

## How

Removed the 10-line test block. No imports became unused
(`readFileSync`, `resolve(import.meta.dirname, ...)` are retained
for other tests in the same file).

## Test plan

- [x] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/auto-loop.test.ts` → 67 pass / 1 skip (was 68 pass / 1 skip)

## Anti-regression

The dispatch, termination, and `resolveAgentEnd` behaviour is
covered by the remaining 67 tests in this file, which hit the
compiled runtime via `import("../auto-loop.js")`.

Refs #4841, #4784