### PR TITLE
test(bg-shell): migrate session-cleanup sleeps to waitForCondition

### DIFF
--- a/src/tests/bg-shell-session-cleanup.test.ts
+++ b/src/tests/bg-shell-session-cleanup.test.ts
@@ -7,6 +7,7 @@ import {
 	cleanupSessionProcesses,
 	processes,
 } from "../resources/extensions/bg-shell/process-manager.ts";
+import { waitForCondition } from "../resources/extensions/gsd/tests/test-helpers.ts";
 
 function isPidAlive(pid: number | undefined): boolean {
 	if (!pid || pid <= 0) return false;
@@ -41,16 +42,25 @@ test("cleanupSessionProcesses reaps only session-scoped processes from the previ
 		ownerSessionFile: "session-b",
 	});
 
-	await new Promise((resolve) => setTimeout(resolve, 150));
-	assert.equal(isPidAlive(owned.proc.pid), true, "owned process should be alive before cleanup");
-	assert.equal(isPidAlive(persistent.proc.pid), true, "persistent process should be alive before cleanup");
-	assert.equal(isPidAlive(foreign.proc.pid), true, "foreign process should be alive before cleanup");
+	// Poll until all three spawned children are live — no magic sleeps.
+	await waitForCondition(
+		() =>
+			isPidAlive(owned.proc.pid) &&
+			isPidAlive(persistent.proc.pid) &&
+			isPidAlive(foreign.proc.pid),
+		{ timeoutMs: 5_000, description: "all three spawned children to be alive" },
+	);
 
 	const removed = await cleanupSessionProcesses("session-a", { graceMs: 200 });
 	assert.deepEqual(removed.sort(), [owned.id], "only the session-scoped process should be reaped");
 
-	await new Promise((resolve) => setTimeout(resolve, 150));
-	assert.equal(isPidAlive(owned.proc.pid), false, "owned process should be terminated");
+	// Poll until the reaped child has actually exited. Foreign + persistent stay
+	// alive by contract — any point after cleanupSessionProcesses returned is a
+	// valid observation window for them.
+	await waitForCondition(() => !isPidAlive(owned.proc.pid), {
+		timeoutMs: 5_000,
+		description: "owned (session-a) process to exit after cleanup",
+	});
 	assert.equal(isPidAlive(persistent.proc.pid), true, "persistent process should survive cleanup");
 	assert.equal(isPidAlive(foreign.proc.pid), true, "foreign process should survive cleanup");
 	assert.equal(processes.get(owned.id)?.persistAcrossSessions, false);


### PR DESCRIPTION
## What

Migrate `src/tests/bg-shell-session-cleanup.test.ts` off hand-rolled
`setTimeout(150)` polling onto the shared `waitForCondition` helper.

## Why

Per #4813: the 150ms wait before the liveness check is race-prone —
too short on a loaded CI runner to let all three spawned children
boot, too long on a fast one to let them be reliably alive before the
grace window. The 150ms wait after cleanup has the inverse problem:
it's overkill on fast runners and insufficient on slow ones.

`waitForCondition` polls the actual signal (PID alive / dead) with a
5s ceiling and ~10ms granularity. The test is now event-driven and
drops from ~500ms wall-clock to ~40ms on a fast machine.

## How

- Import `waitForCondition` from the shared test-helpers module.
- Replace the "all three alive" gate and the "owned dead" gate with
  polled predicates on `isPidAlive(proc.pid)`.
- Persistent / foreign processes are asserted directly — the
  cleanup contract guarantees they are untouched, so no poll is
  needed.

## Test plan

- [x] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/tests/bg-shell-session-cleanup.test.ts` — pass
- [x] Anti-regression: dropped the `!bg.persistAcrossSessions` guard
  in `process-manager.ts` → test fails (`removed` contains both ids).
  Reverted.

Refs #4813, #4784.