### PR TITLE
test(complete-task): rename misnamed schema section, assert against SCHEMA_VERSION

### DIFF
--- a/src/resources/extensions/gsd/gsd-db.ts
+++ b/src/resources/extensions/gsd/gsd-db.ts
@@ -180,7 +180,7 @@ function openRawDb(path: string): unknown {
   return new Database(path);
 }
 
-const SCHEMA_VERSION = 22;
+export const SCHEMA_VERSION = 22;
 
 function indexExists(db: DbAdapter, name: string): boolean {
   return !!db.prepare(

--- a/src/resources/extensions/gsd/tests/complete-task.test.ts
+++ b/src/resources/extensions/gsd/tests/complete-task.test.ts
@@ -14,6 +14,7 @@ import {
   getTask,
   getSliceTasks,
   insertVerificationEvidence,
+  SCHEMA_VERSION,
 } from '../gsd-db.ts';
 import { handleCompleteTask } from '../tools/complete-task.ts';
 
@@ -99,19 +100,22 @@ function makeValidParams() {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// complete-task: Schema v5 migration
+// complete-task: Fresh DB is migrated to the current schema version
 // ═══════════════════════════════════════════════════════════════════════════
 
-console.log('\n=== complete-task: schema v5 migration ===');
+console.log('\n=== complete-task: fresh DB migrates to current schema version ===');
 {
   const dbPath = tempDbPath();
   openDatabase(dbPath);
 
   const adapter = _getAdapter()!;
 
-  // Verify schema version is current (v22 — quality_gates DDL fix)
+  // Verify schema version matches the current source-of-truth constant.
+  // Asserting against SCHEMA_VERSION (not a hardcoded number) keeps this
+  // green across migration bumps while still catching a
+  // "fresh-DB-was-not-migrated" regression.
   const versionRow = adapter.prepare('SELECT MAX(version) as v FROM schema_version').get();
-  assertEq(versionRow?.['v'], 22, 'schema version should be 22');
+  assertEq(versionRow?.['v'], SCHEMA_VERSION, 'fresh DB should be migrated to current SCHEMA_VERSION');
 
   // Verify all 4 new tables exist
   const tables = adapter.prepare(


### PR DESCRIPTION
## What

- Rename `complete-task: Schema v5 migration` section, console log, and comment to `complete-task: fresh DB migrates to current schema version` — the assertion checks version 22, not v5.
- Export `SCHEMA_VERSION` from `gsd-db.ts` and use it in the assertion so the test stays green across migration bumps and actually verifies \"fresh DB was migrated to the current version\" instead of \"someone remembered to edit the magic number\".

## Why

Reported in batch-01 audit (\`/tmp/gsd-batch-01-audit.csv\`) and issue #4831: the section name claimed v5 while the body asserted 22 — misleading to readers and grep. The hardcoded literal also made this a Goodhart'd test that broke on every migration bump without catching a real regression.

## How

- \`src/resources/extensions/gsd/gsd-db.ts\`: add \`export\` to the existing \`SCHEMA_VERSION = 22\` constant. No runtime change.
- \`src/resources/extensions/gsd/tests/complete-task.test.ts\`: import \`SCHEMA_VERSION\`, rename the section, assert against the imported constant.

## Test plan

- [x] \`node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/complete-task.test.ts\` → 83 passed / 0 failed.

## Anti-regression

The assertion still catches the original bug (fresh-DB skipping migrations — version would be 0 or missing), it just no longer needs to be re-edited every schema bump.

Refs #4831, #4784