### PR TITLE
test(browser-tools): replace brace-walking source extraction with test-only exports (#4807)

### DIFF
--- a/src/resources/extensions/browser-tools/tests/browser-tools-integration.test.mjs
+++ b/src/resources/extensions/browser-tools/tests/browser-tools-integration.test.mjs
@@ -12,76 +12,25 @@
 import { describe, it, before, after } from "node:test";
 import assert from "node:assert/strict";
 import { chromium } from "playwright";
-import { readFileSync } from "node:fs";
-import { resolve, dirname } from "node:path";
+import { dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const ROOT = resolve(__dirname, "..");
 
 // ---------------------------------------------------------------------------
-// Source extraction — get the IIFE strings we need for injection
+// Source loading — import the IIFE builders directly via jiti.
+// The test-only named exports in tools/intent.ts and tools/forms.ts exist
+// exactly so this test can call the real, in-tree builders. No brace
+// walking, no regex stripping — a refactor of the signatures just updates
+// the import surface, not the test.
 // ---------------------------------------------------------------------------
 
-// 1. EVALUATE_HELPERS_SOURCE — exported constant, extract via jiti
 import { createRequire } from "node:module";
 const require = createRequire(import.meta.url);
 const jiti = require("jiti")(__dirname, { interopDefault: true, debug: false });
 const { EVALUATE_HELPERS_SOURCE } = jiti("../evaluate-helpers.ts");
-
-// 2. Intent scoring — module-private buildIntentScoringScript.
-//    Extract the function from source, wrap it, and eval to get the builder.
-const intentSource = readFileSync(resolve(ROOT, "tools/intent.ts"), "utf-8");
-
-function extractBuildIntentScoringScript() {
-  // Match the function body: starts with "function buildIntentScoringScript"
-  // and returns a template literal string. We extract up to the matching closing brace.
-  const startMarker = "function buildIntentScoringScript(intent: string, scope?: string): string {";
-  const startIdx = intentSource.indexOf(startMarker);
-  if (startIdx === -1) throw new Error("Could not find buildIntentScoringScript in intent.ts");
-
-  // Walk from start, counting braces to find the end
-  let depth = 0;
-  let foundFirst = false;
-  let endIdx = startIdx;
-  for (let i = startIdx; i < intentSource.length; i++) {
-    if (intentSource[i] === "{") { depth++; foundFirst = true; }
-    if (intentSource[i] === "}") depth--;
-    if (foundFirst && depth === 0) { endIdx = i + 1; break; }
-  }
-
-  let fnBody = intentSource.slice(startIdx, endIdx);
-  // Strip TypeScript type annotations
-  fnBody = fnBody.replace(/\(intent:\s*string,\s*scope\?:\s*string\):\s*string/, "(intent, scope)");
-  return new Function("return " + fnBody)();
-}
-
-const buildIntentScoringScript = extractBuildIntentScoringScript();
-
-// 3. Form analysis — module-private buildFormAnalysisScript.
-const formsSource = readFileSync(resolve(ROOT, "tools/forms.ts"), "utf-8");
-
-function extractBuildFormAnalysisScript() {
-  const startMarker = "function buildFormAnalysisScript(selector?: string): string {";
-  const startIdx = formsSource.indexOf(startMarker);
-  if (startIdx === -1) throw new Error("Could not find buildFormAnalysisScript in forms.ts");
-
-  let depth = 0;
-  let foundFirst = false;
-  let endIdx = startIdx;
-  for (let i = startIdx; i < formsSource.length; i++) {
-    if (formsSource[i] === "{") { depth++; foundFirst = true; }
-    if (formsSource[i] === "}") depth--;
-    if (foundFirst && depth === 0) { endIdx = i + 1; break; }
-  }
-
-  let fnBody = formsSource.slice(startIdx, endIdx);
-  // Strip TypeScript type annotation
-  fnBody = fnBody.replace(/\(selector\?:\s*string\):\s*string/, "(selector)");
-  return new Function("return " + fnBody)();
-}
-
-const buildFormAnalysisScript = extractBuildFormAnalysisScript();
+const { buildIntentScoringScript } = jiti("../tools/intent.ts");
+const { buildFormAnalysisScript } = jiti("../tools/forms.ts");
 
 // ---------------------------------------------------------------------------
 // Browser lifecycle

--- a/src/resources/extensions/browser-tools/tools/forms.ts
+++ b/src/resources/extensions/browser-tools/tools/forms.ts
@@ -46,7 +46,11 @@ interface FormAnalysisResult {
  * Runs inside page.evaluate(). Finds the target form, inventories all fields
  * with full label resolution, and returns a structured result.
  */
-function buildFormAnalysisScript(selector?: string): string {
+// Exported for tests only (see tests/browser-tools-integration.test.mjs).
+// Keep this function treated as module-private for production call sites —
+// the only legitimate external caller is the Playwright-driven integration
+// suite that needs to evaluate the returned IIFE against real DOM.
+export function buildFormAnalysisScript(selector?: string): string {
 	// We return a string that will be evaluated in the page context.
 	// This avoids serialization issues with passing functions.
 	return `(() => {

--- a/src/resources/extensions/browser-tools/tools/intent.ts
+++ b/src/resources/extensions/browser-tools/tools/intent.ts
@@ -37,7 +37,11 @@ type Intent = (typeof INTENTS)[number];
  * Uses window.__pi utilities (injected via addInitScript) for element
  * metadata — no inline redeclarations.
  */
-function buildIntentScoringScript(intent: string, scope?: string): string {
+// Exported for tests only (see tests/browser-tools-integration.test.mjs).
+// Keep this function treated as module-private for production call sites —
+// the only legitimate external caller is the Playwright-driven integration
+// suite that needs to evaluate the returned IIFE against real DOM.
+export function buildIntentScoringScript(intent: string, scope?: string): string {
 	const scopeSelector = JSON.stringify(scope ?? null);
 
 	return `(() => {


### PR DESCRIPTION
## What

Closes #4807.

Replaces the fragile brace-walking / regex-stripping source extraction in `browser-tools-integration.test.mjs` with direct jiti imports of two new test-only named exports:

- `export function buildIntentScoringScript(...)` in `tools/intent.ts`
- `export function buildFormAnalysisScript(...)` in `tools/forms.ts`

## Why

The integration suite previously reimported two module-private functions by:

1. Reading `tools/intent.ts` / `tools/forms.ts` as text.
2. Locating a hard-coded `startMarker` string (full TypeScript signature).
3. Walking brace depth character-by-character to find the closing `}`.
4. Regex-stripping the TypeScript type annotations.
5. `new Function("return " + body)()`.

Failure modes:

- Adding a default parameter, generic, or return-type annotation broke the `startMarker` match → `throw new Error("Could not find buildIntentScoringScript in intent.ts")` at import time → all 45 Playwright tests fail.
- Template literals containing `}` inside the function body could confuse the brace walker.
- The regex strip silently breaks if the signature gains generics; eval may succeed but the hoisted function no longer matches production.

The fix keeps both functions module-private at the call-site level (production callers in `intent.ts` and `forms.ts` are unchanged) while exposing a named export the test can import via jiti — same mechanism already used for `EVALUATE_HELPERS_SOURCE`.

## How

- Added a banner comment above each function explaining the export is test-only.
- Removed the brace walker, marker lookup, regex stripper, and `new Function` trampoline from the test (net −49 lines).
- Test imports now: `const { buildIntentScoringScript } = jiti("../tools/intent.ts")`.

## Verification

`node --test src/resources/extensions/browser-tools/tests/browser-tools-integration.test.mjs` → 45 pass / 0 fail (2.3s).

Refs #4784