### PR TITLE
test(pi-tui): mock.timers for stdin-buffer; SGR semantic parser for overlay-layout

### DIFF
--- a/packages/pi-tui/src/__tests__/overlay-layout.test.ts
+++ b/packages/pi-tui/src/__tests__/overlay-layout.test.ts
@@ -1,4 +1,16 @@
 // pi-tui — Overlay Layout Tests (backdrop dimming)
+//
+// These tests previously coupled to literal ANSI escape bytes
+// (`\x1b[2m`, `\x1b[38;5;240m`) and would break if the palette index or
+// SGR spelling changed despite identical rendered output — Goodhart's law:
+// the test measures escape codes, not dimming.
+//
+// We now parse the SGR escape codes into a semantic style state and assert
+// on the visible contract: the covered-but-outside-overlay region is dim,
+// has a non-default foreground (so the eye can distinguish foreground from
+// background), and does not paint the terminal background (so user themes
+// are preserved). The overlay content itself is reachable via plain-text
+// lookup after stripping ANSI.
 
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
@@ -16,8 +28,107 @@ function makeEntry(
 	};
 }
 
+/**
+ * Parse a line's ANSI SGR state immediately before the first occurrence of a
+ * target substring in the rendered (ANSI-stripped) text. Walks `\x1b[...m`
+ * sequences left-to-right, maintaining a running state so we can ask what
+ * the terminal is doing when it reaches the target glyphs.
+ *
+ * Semantic fields:
+ *   - dim:    SGR 2 active and not reset by SGR 22 / 0
+ *   - fg:     foreground: "default" | "set" | the raw numeric parameters
+ *   - bg:     background: "default" | "set"
+ */
+type SgrState = { dim: boolean; fg: "default" | "set"; bg: "default" | "set" };
+
+function sgrStateAtGlyph(line: string, targetGlyph: string): SgrState {
+	const state: SgrState = { dim: false, fg: "default", bg: "default" };
+	// Walk codes and visible chars, tracking visible-glyph position.
+	let visibleSeen = "";
+	let i = 0;
+	while (i < line.length) {
+		if (line[i] === "\x1b" && line[i + 1] === "[") {
+			// Read until final byte in 0x40-0x7E
+			let j = i + 2;
+			while (j < line.length) {
+				const c = line.charCodeAt(j);
+				if (c >= 0x40 && c <= 0x7e) break;
+				j++;
+			}
+			const final = line[j];
+			if (final === "m") {
+				const paramString = line.slice(i + 2, j);
+				applySgr(state, paramString);
+			}
+			i = j + 1;
+			continue;
+		}
+		// Skip other escape sequences (OSC hyperlinks etc) conservatively:
+		// if we ever hit a non-SGR escape, just step past the ESC.
+		if (line[i] === "\x1b") {
+			i++;
+			continue;
+		}
+		visibleSeen += line[i];
+		if (visibleSeen.endsWith(targetGlyph)) {
+			// We've just consumed the last char of targetGlyph — return the
+			// state that was in effect for the whole match.
+			return state;
+		}
+		i++;
+	}
+	throw new Error(`Target glyph ${JSON.stringify(targetGlyph)} not found in line`);
+}
+
+function applySgr(state: SgrState, paramString: string): void {
+	// Empty params == reset
+	const parts = paramString === "" ? ["0"] : paramString.split(";");
+	let k = 0;
+	while (k < parts.length) {
+		const n = parts[k] === "" ? 0 : Number(parts[k]);
+		if (n === 0) {
+			state.dim = false;
+			state.fg = "default";
+			state.bg = "default";
+		} else if (n === 2) {
+			state.dim = true;
+		} else if (n === 22) {
+			state.dim = false;
+		} else if (n === 39) {
+			state.fg = "default";
+		} else if (n === 49) {
+			state.bg = "default";
+		} else if ((n >= 30 && n <= 37) || (n >= 90 && n <= 97)) {
+			state.fg = "set";
+		} else if ((n >= 40 && n <= 47) || (n >= 100 && n <= 107)) {
+			state.bg = "set";
+		} else if (n === 38) {
+			state.fg = "set";
+			// Skip colour-model parameters: 38;5;N or 38;2;R;G;B
+			if (parts[k + 1] === "5") {
+				k += 2;
+			} else if (parts[k + 1] === "2") {
+				k += 4;
+			}
+		} else if (n === 48) {
+			state.bg = "set";
+			if (parts[k + 1] === "5") {
+				k += 2;
+			} else if (parts[k + 1] === "2") {
+				k += 4;
+			}
+		}
+		k++;
+	}
+}
+
+function stripAnsi(line: string): string {
+	// Remove CSI sequences. Good enough for these tests.
+	return line.replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, "");
+}
+
 describe("compositeOverlays — backdrop", () => {
-	it("dims base lines when backdrop is true", () => {
+	it("dims base lines outside the overlay when backdrop is true", () => {
 		const base = ["hello world", "second line"];
 		const overlay = makeEntry(["OVERLAY"], {
 			width: 7,
@@ -27,14 +138,17 @@ describe("compositeOverlays — backdrop", () => {
 
 		const result = compositeOverlays(base, [overlay], 20, 20, 2);
 
-		// All base lines in viewport should contain dim escape (\x1b[2m)
-		// The overlay line itself is composited on top, but underlying lines get dimmed
-		const dimmedLine = result.find((l) => l.includes("second line"));
-		assert.ok(dimmedLine, "should have a line containing 'second line'");
-		assert.ok(dimmedLine.includes("\x1b[2m"), "base line should be dimmed");
+		// "second line" is below the overlay (which is anchored top-left with
+		// a single visible row), so every glyph of that text should be
+		// rendered with the dim attribute active.
+		const line = result.find((l) => stripAnsi(l).includes("second line"));
+		assert.ok(line, "should have a line containing 'second line'");
+
+		const state = sgrStateAtGlyph(line, "second line");
+		assert.equal(state.dim, true, "base line should be dimmed (SGR 2)");
 	});
 
-	it("backdrop uses gray foreground for dimming", () => {
+	it("backdrop applies a non-default foreground colour and leaves background untouched", () => {
 		const base = ["hello world", "second line"];
 		const overlay = makeEntry(["OV"], {
 			width: 2,
@@ -44,11 +158,16 @@ describe("compositeOverlays — backdrop", () => {
 
 		const result = compositeOverlays(base, [overlay], 20, 20, 2);
 
-		// Check a non-overlay line for backdrop codes (dim + gray fg, no bg)
-		const line = result.find((l) => l.includes("second line"));
+		const line = result.find((l) => stripAnsi(l).includes("second line"));
 		assert.ok(line, "should have a line containing 'second line'");
-		assert.ok(line.includes("\x1b[38;5;240m"), "backdrop should set gray foreground");
-		assert.ok(!line.includes("\x1b[48;"), "backdrop should not set background color");
+
+		const state = sgrStateAtGlyph(line, "second line");
+		assert.equal(state.fg, "set", "backdrop must set a foreground colour");
+		assert.equal(
+			state.bg,
+			"default",
+			"backdrop must not paint a background (preserves user's terminal theme)",
+		);
 	});
 
 	it("does not dim when backdrop is false/absent", () => {
@@ -60,10 +179,11 @@ describe("compositeOverlays — backdrop", () => {
 
 		const result = compositeOverlays(base, [overlay], 20, 20, 2);
 
-		// Lines not covered by overlay should remain undimmed
-		const secondLine = result.find((l) => l.includes("second line"));
-		assert.ok(secondLine, "should have a line containing 'second line'");
-		assert.ok(!secondLine.includes("\x1b[2m"), "base line should not be dimmed");
+		const line = result.find((l) => stripAnsi(l).includes("second line"));
+		assert.ok(line, "should have a line containing 'second line'");
+
+		const state = sgrStateAtGlyph(line, "second line");
+		assert.equal(state.dim, false, "base line should not be dimmed when no backdrop");
 	});
 
 	it("overlay content renders on top of dimmed background", () => {
@@ -76,7 +196,10 @@ describe("compositeOverlays — backdrop", () => {
 
 		const result = compositeOverlays(base, [overlay], 10, 10, 1);
 
-		// The first line should contain the overlay text
-		assert.ok(result[0].includes("XX"), "overlay text should be composited");
+		// Find the row that (after stripping styling) contains the overlay
+		// text. We don't use positional `result[0]` so the test survives if
+		// the row ordering changes.
+		const overlayRow = result.find((l) => stripAnsi(l).includes("XX"));
+		assert.ok(overlayRow, "overlay text should be composited into some rendered row");
 	});
 });

--- a/packages/pi-tui/src/__tests__/stdin-buffer.test.ts
+++ b/packages/pi-tui/src/__tests__/stdin-buffer.test.ts
@@ -1,29 +1,49 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
-import { setTimeout as delay } from "node:timers/promises";
 
 import { StdinBuffer } from "../stdin-buffer.js";
 
+// These tests use node:test's mock.timers to advance virtual time.
+// They previously relied on wall-clock delays (delay(20), delay(150))
+// racing the OS scheduler. On Windows the default setTimeout resolution is
+// ~15.6ms, so a real-time delay of 20ms sometimes fired only one of two
+// pending timers — hence the flake referenced in issue #4795.
+//
+// By mocking setTimeout/clearTimeout we control exactly when the buffer's
+// sequence timeout and stale timeout fire, eliminating scheduler-induced
+// flake and making the tests deterministic on every platform.
+
 describe("StdinBuffer", () => {
-	it("flushes a lone Escape keypress", async () => {
+	it("flushes a lone Escape keypress after the sequence timeout", (t) => {
+		t.mock.timers.enable({ apis: ["setTimeout"] });
 		const buffer = new StdinBuffer({ timeout: 5 });
 		const received: string[] = [];
 		buffer.on("data", (sequence) => received.push(sequence));
 
 		buffer.process("\x1b");
-		await delay(20);
+
+		// Before the timeout fires the lone ESC is still buffered.
+		assert.deepEqual(received, []);
+		assert.equal(buffer.getBuffer(), "\x1b");
+
+		// Advance past the sequence timeout.
+		t.mock.timers.tick(5);
 
 		assert.deepEqual(received, ["\x1b"]);
 		assert.equal(buffer.getBuffer(), "");
 	});
 
-	it("keeps split CSI focus and mouse sequences buffered until completion", async () => {
+	it("keeps split CSI focus and mouse sequences buffered until completion", (t) => {
+		t.mock.timers.enable({ apis: ["setTimeout"] });
 		const buffer = new StdinBuffer({ timeout: 5 });
 		const received: string[] = [];
 		buffer.on("data", (sequence) => received.push(sequence));
 
 		buffer.process("\x1b[");
-		await delay(20);
+		// Even after the normal timeout elapses, an incomplete CSI prefix must
+		// remain buffered (not emitted as literal text) so split escape
+		// sequences stay intact.
+		t.mock.timers.tick(5);
 		assert.deepEqual(received, []);
 		assert.equal(buffer.getBuffer(), "\x1b[");
 
@@ -32,7 +52,7 @@ describe("StdinBuffer", () => {
 		assert.equal(buffer.getBuffer(), "");
 
 		buffer.process("\x1b[<35;20;");
-		await delay(20);
+		t.mock.timers.tick(5);
 		assert.deepEqual(received, ["\x1b[I"]);
 		assert.equal(buffer.getBuffer(), "\x1b[<35;20;");
 
@@ -41,27 +61,36 @@ describe("StdinBuffer", () => {
 		assert.equal(buffer.getBuffer(), "");
 	});
 
-	it("flushes a stale incomplete escape prefix after the stale timeout", async () => {
-		// Timers must exceed Windows setTimeout resolution (~15.6ms) so the
-		// sequence timeout + stale timeout both fire within the delay window.
+	it("flushes a stale incomplete escape prefix after the stale timeout", (t) => {
+		t.mock.timers.enable({ apis: ["setTimeout"] });
 		const buffer = new StdinBuffer({ timeout: 20, staleTimeout: 40 });
 		const received: string[] = [];
 		buffer.on("data", (sequence) => received.push(sequence));
 
 		buffer.process("\x1b[");
-		await delay(150);
+
+		// Sequence timeout: keeps the incomplete prefix buffered and starts
+		// the stale timer.
+		t.mock.timers.tick(20);
+		assert.deepEqual(received, []);
+		assert.equal(buffer.getBuffer(), "\x1b[");
+
+		// Stale timer fires — prefix is emitted as-is.
+		t.mock.timers.tick(40);
 
 		assert.deepEqual(received, ["\x1b["]);
 		assert.equal(buffer.getBuffer(), "");
 	});
 
-	it("still allows an incomplete escape prefix to complete before the stale timeout", async () => {
+	it("still allows an incomplete escape prefix to complete before the stale timeout", (t) => {
+		t.mock.timers.enable({ apis: ["setTimeout"] });
 		const buffer = new StdinBuffer({ timeout: 5, staleTimeout: 30 });
 		const received: string[] = [];
 		buffer.on("data", (sequence) => received.push(sequence));
 
 		buffer.process("\x1b[");
-		await delay(10);
+		// Advance past the sequence timeout (but not the stale timeout).
+		t.mock.timers.tick(10);
 		buffer.process("I");
 
 		assert.deepEqual(received, ["\x1b[I"]);


### PR DESCRIPTION
Closes #4795. Refs #4784.

## What
Replace wall-clock `delay(N)` in `stdin-buffer.test.ts` with `t.mock.timers`, and swap literal-ANSI-byte assertions in `overlay-layout.test.ts` for a tiny SGR parser that asserts semantic style state (`dim`, `fg`, `bg`).

## Why
Both files were on the #4784 source-grep / magic-coupling antipattern list. `stdin-buffer.test.ts` raced the OS scheduler (Windows setTimeout resolution ~15.6ms — flake confessed in a code comment). `overlay-layout.test.ts` asserted on raw escape bytes (`\x1b[2m`, `\x1b[38;5;240m`), so a palette or SGR-spelling change with identical rendering would fail the tests (Goodhart).

## How
- **stdin-buffer**: `t.mock.timers.enable({ apis: ['setTimeout'] })` + `tick(N)`. Test time 227ms -> 2ms, zero scheduler flake.
- **overlay-layout**: inline `sgrStateAtGlyph()` walks `\x1b[...m` codes and returns `{ dim, fg, bg }` state when the target glyph is reached. Assertions state the contract (dim active, non-default foreground, background untouched) instead of exact byte strings. Parser is test-scoped; no production refactor needed.

## Test plan
- [x] `node --test packages/pi-tui/dist/__tests__/stdin-buffer.test.js` — 4/4 green, 2ms total
- [x] `node --test packages/pi-tui/dist/__tests__/overlay-layout.test.js` — 4/4 green
- [x] Full pi-tui suite (72 tests) — all green
- [x] TDD red/green: neutering `flush()`'s incomplete-prefix guard fails the split-CSI test; neutering `dimFn` to identity fails the foreground-colour test. Both restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)