### PR TITLE
test(gsd): remove inter-test coupling in doctor-proactive (no double escalation)

### DIFF
--- a/src/resources/extensions/gsd/tests/integration/doctor-proactive.test.ts
+++ b/src/resources/extensions/gsd/tests/integration/doctor-proactive.test.ts
@@ -161,11 +161,27 @@ describe('doctor-proactive', async () => {
     });
 
     test('escalation: no double escalation', () => {
-      // Don't reset — should already be escalated from previous test
+      // Self-contained: drive the escalated state from scratch in this test.
+      // Previously this relied on module-singleton state left over from the
+      // preceding 'escalation: at threshold' test, which silently broke under
+      // filtered/parallel/reordered runs (the fallback `shouldEscalate: false`
+      // path was satisfied by the wrong reason — see #4828).
+      resetProactiveHealing();
+      for (let i = 0; i < 5; i++) {
+        recordHealthSnapshot(0, 0, 0); // older clean snapshots
+      }
+      for (let i = 0; i < 5; i++) {
+        recordHealthSnapshot(2, 1, 0); // recent error snapshots → degrading trend
+      }
+      // First check: trigger escalation.
+      const first = checkHealEscalation(2, [{ code: "test", message: "test error", unitId: "M001/S01" }]);
+      assert.deepStrictEqual(first.shouldEscalate, true, "precondition: first call escalates");
+
+      // Second check: same session, must NOT double-escalate.
       recordHealthSnapshot(2, 0, 0);
       const result = checkHealEscalation(2, [{ code: "test", message: "test error", unitId: "M001/S01" }]);
       assert.deepStrictEqual(result.shouldEscalate, false, "no double escalation in same session");
-      assert.ok(result.reason.includes("already escalated"), "reason explains why no escalation");
+      assert.ok(result.reason.includes("already escalated"), `reason must explain no-re-escalation (got: ${result.reason})`);
     });
 
     test('escalation: deferred when improving', () => {


### PR DESCRIPTION
## What

Closes #4828 — the \`escalation: no double escalation\` test in \`doctor-proactive.test.ts\` relied on module-level singleton state left over from the previous test. Under filtering/reordering/parallelism the fallback \`shouldEscalate: false\` path silently passed for the wrong reason.

## Why

Kernighan + Goodhart: running green was satisfied while the intended invariant (no re-escalation once already escalated this session) was no longer checked. The issue called out option 1 (self-contain) or option 2 (inject state handle); option 1 is the minimal fix.

## How

Inside the test, replay the five-consecutive-errors + degrading-trend sequence that produces the escalated state, assert the first \`checkHealEscalation\` returns \`shouldEscalate: true\`, then assert the second call returns \`false\` with reason \`already escalated\`. No coupling to sibling tests.

## Test plan

- [x] Full file green (19/19).
- [x] The test passes in isolation: \`--test-name-pattern='no double escalation'\`.
- [ ] CI green.

Refs #4784.