### PR TITLE
test(gsd): fix silent-catch brace counter and drop arbitrary savings baselines (#4836)

### DIFF
--- a/src/resources/extensions/gsd/tests/silent-catch-diagnostics.test.ts
+++ b/src/resources/extensions/gsd/tests/silent-catch-diagnostics.test.ts
@@ -6,6 +6,21 @@
  * Two tests:
  * 1. Auto-mode files must have zero empty catch blocks (fully migrated).
  * 2. All GSD files must not use raw stderr/console in catch blocks.
+ *
+ * ──────────────────────────────────────────────────────────────────────────
+ * Implementation note — why we do not naïvely scan for catch blocks with a
+ * regex plus a brace counter.
+ *
+ * A naïve counter that increments/decrements on raw `{`/`}` characters
+ * silently miscounts when those characters appear inside string literals,
+ * template literals, regex literals, or comments — producing both false
+ * positives (claiming an empty catch when the body is not actually empty)
+ * and false negatives (walking past the real close and failing to flag a
+ * genuinely silent catch). See #4836.
+ *
+ * The fix is to strip strings/templates/regex/comments to neutral whitespace
+ * *before* running the structural scan. We don't need a full TypeScript
+ * parser — we just need the brace depth to reflect actual syntactic braces.
  */
 
 import { describe, test } from "node:test";
@@ -125,50 +140,235 @@ function getGsdSourceFiles(): string[] {
 }
 
 /**
+ * Strip string literals (single/double/template), regex literals, and
+ * comments from TypeScript source, replacing their contents with
+ * neutral characters ('X' for token bodies, ' ' for comments) while
+ * preserving line structure so reported line numbers still match the
+ * original source.
+ *
+ * This is a best-effort lexer, not a full TypeScript parser. It handles:
+ *  - // line comments
+ *  - \/* block comments *\/
+ *  - "double" and 'single' quoted strings (including backslash escapes)
+ *  - `template literals` including ${…} interpolations
+ *  - /regex/ literals, heuristically distinguished from division by
+ *    inspecting the last non-whitespace token
+ *
+ * What it does NOT do: parse JSX, full TS type syntax, or nested generics.
+ * None of that matters for brace-depth correctness in catch-block scanning.
+ */
+function stripLiteralsAndComments(src: string): string {
+  const out: string[] = new Array(src.length);
+  let i = 0;
+  // Track last non-whitespace, non-neutralized char to decide whether '/'
+  // is a regex literal (after `(`, `,`, `=`, `!`, `?`, `:`, `&`, `|`, `;`,
+  // `{`, `}`, `[`, newline, or start-of-file) or a division operator.
+  let prevSignificant = "";
+
+  function copy(from: number, to: number): void {
+    for (let k = from; k < to; k++) out[k] = src[k];
+  }
+
+  function neutralize(from: number, to: number, keepNewlines = true): void {
+    for (let k = from; k < to; k++) {
+      const ch = src[k];
+      out[k] = ch === "\n" && keepNewlines ? "\n" : ch === "\r" ? "\r" : " ";
+    }
+  }
+
+  // Template-literal depth stack: when we enter ${ inside a template we push
+  // onto a stack so the matching '}' closes the interpolation, not a JS block.
+  const templateStack: number[] = [];
+
+  while (i < src.length) {
+    const ch = src[i];
+    const next = src[i + 1];
+
+    // Line comment
+    if (ch === "/" && next === "/") {
+      const start = i;
+      while (i < src.length && src[i] !== "\n") i++;
+      neutralize(start, i);
+      continue;
+    }
+    // Block comment
+    if (ch === "/" && next === "*") {
+      const start = i;
+      i += 2;
+      while (i < src.length && !(src[i] === "*" && src[i + 1] === "/")) i++;
+      i = Math.min(src.length, i + 2);
+      neutralize(start, i);
+      continue;
+    }
+    // String literal — single or double
+    if (ch === '"' || ch === "'") {
+      const quote = ch;
+      const start = i;
+      i++;
+      while (i < src.length && src[i] !== quote) {
+        if (src[i] === "\\" && i + 1 < src.length) { i += 2; continue; }
+        if (src[i] === "\n") break; // unterminated line — bail gracefully
+        i++;
+      }
+      if (src[i] === quote) i++;
+      neutralize(start, i);
+      prevSignificant = "x"; // literal counts as value
+      continue;
+    }
+    // Template literal
+    if (ch === "`") {
+      const start = i;
+      i++;
+      while (i < src.length && src[i] !== "`") {
+        if (src[i] === "\\" && i + 1 < src.length) { i += 2; continue; }
+        if (src[i] === "$" && src[i + 1] === "{") {
+          // Neutralize everything up to but not including the `${`
+          neutralize(start, i);
+          // Copy `${` as-is, then recurse by tracking depth in templateStack
+          out[i] = "$"; out[i + 1] = "{";
+          i += 2;
+          templateStack.push(1);
+          // Return to the outer loop to scan the interpolation normally
+          prevSignificant = "{";
+          // resume main loop
+          // We break out of the inner string scan so the outer scanner handles
+          // the `${…}` body, and re-enters template scanning when it sees `}`
+          // that closes the interpolation.
+          break;
+        }
+        i++;
+      }
+      if (src[i] === "`") {
+        neutralize(start, i + 1);
+        i++;
+        prevSignificant = "x";
+      }
+      continue;
+    }
+    // Regex literal heuristic — '/' starts a regex only if prevSignificant
+    // is one of the contexts where a value is expected.
+    if (ch === "/") {
+      const regexContexts = new Set([
+        "", "(", ",", "=", "!", "?", ":", "&", "|", ";", "{", "}", "[", "\n", "+", "-", "*", "%", "<", ">", "~", "^",
+      ]);
+      if (regexContexts.has(prevSignificant)) {
+        const start = i;
+        i++;
+        let inClass = false;
+        while (i < src.length) {
+          const c = src[i];
+          if (c === "\\" && i + 1 < src.length) { i += 2; continue; }
+          if (c === "[") inClass = true;
+          else if (c === "]") inClass = false;
+          else if (c === "/" && !inClass) { i++; break; }
+          else if (c === "\n") break;
+          i++;
+        }
+        // Consume flags (i, g, m, s, u, y, d)
+        while (i < src.length && /[a-z]/.test(src[i])) i++;
+        neutralize(start, i);
+        prevSignificant = "x";
+        continue;
+      }
+    }
+    // Inside a template interpolation — check if this `}` closes it
+    if (ch === "}" && templateStack.length > 0) {
+      const depth = templateStack[templateStack.length - 1];
+      if (depth === 1) {
+        templateStack.pop();
+        out[i] = "}"; // keep it for balance
+        i++;
+        prevSignificant = "}";
+        // Resume template-literal scanning from after the `}`
+        const start = i;
+        while (i < src.length && src[i] !== "`") {
+          if (src[i] === "\\" && i + 1 < src.length) { i += 2; continue; }
+          if (src[i] === "$" && src[i + 1] === "{") {
+            neutralize(start, i);
+            out[i] = "$"; out[i + 1] = "{";
+            i += 2;
+            templateStack.push(1);
+            break;
+          }
+          i++;
+        }
+        if (src[i] === "`") {
+          neutralize(start, i + 1);
+          i++;
+          prevSignificant = "x";
+        }
+        continue;
+      } else {
+        templateStack[templateStack.length - 1] = depth - 1;
+      }
+    } else if (ch === "{" && templateStack.length > 0) {
+      templateStack[templateStack.length - 1] += 1;
+    }
+
+    // Regular char — keep as-is
+    out[i] = ch;
+    if (!/\s/.test(ch)) prevSignificant = ch;
+    i++;
+  }
+
+  // Fill any undefined positions (can happen if we bailed mid-string)
+  for (let k = 0; k < src.length; k++) {
+    if (out[k] === undefined) out[k] = src[k] === "\n" ? "\n" : " ";
+  }
+  return out.join("");
+}
+
+/**
  * Scan a file for empty catch blocks — catches whose body contains
  * only whitespace and/or comments but no executable statements.
+ *
+ * Operates on the stripped source so string/template/regex/comment
+ * contents can't fool the brace counter (#4836).
  */
 function findEmptyCatches(filePath: string): Array<{ line: number; text: string }> {
   const content = readFileSync(filePath, "utf-8");
-  const lines = content.split("\n");
+  const stripped = stripLiteralsAndComments(content);
+  const origLines = content.split("\n");
+  const strippedLines = stripped.split("\n");
   const results: Array<{ line: number; text: string }> = [];
+  const catchHead = /(?<![A-Za-z0-9_$])catch\s*(\([^)]*\))?\s*\{/;
 
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i];
+  for (let i = 0; i < strippedLines.length; i++) {
+    const stripLine = strippedLines[i];
+    const m = stripLine.match(catchHead);
+    if (!m) continue;
 
-    // Match catch block opening
-    if (!/\}\s*catch\s*(\([^)]*\))?\s*\{/.test(line)) continue;
-
-    // Inline single-line catch: } catch { ... }
-    const inlineMatch = line.match(/\}\s*catch\s*(\([^)]*\))?\s*\{(.*)\}\s*;?\s*$/);
+    // Inline single-line catch: catch { ... }
+    const inlineMatch = stripLine.match(/(?<![A-Za-z0-9_$])catch\s*(\([^)]*\))?\s*\{([^{}]*)\}\s*;?\s*$/);
     if (inlineMatch) {
       const body = inlineMatch[2].trim();
-      const stripped = body.replace(/\/\*.*?\*\//g, "").replace(/\/\/.*/g, "").trim();
-      if (!stripped) {
-        results.push({ line: i + 1, text: line.trim() });
+      if (!body) {
+        results.push({ line: i + 1, text: origLines[i].trim() });
       }
       continue;
     }
 
-    // Multi-line catch — scan until matching }
-    let j = i + 1;
+    // Multi-line catch — walk the stripped source character-by-character,
+    // tracking real brace depth. Starts at 1 (the `{` we just saw).
+    // Compute absolute offset of the opening brace on this line.
+    const braceColOnLine = stripLine.indexOf("{", stripLine.indexOf("catch"));
+    if (braceColOnLine < 0) continue;
+    let absOffset = 0;
+    for (let k = 0; k < i; k++) absOffset += strippedLines[k].length + 1;
+    absOffset += braceColOnLine + 1; // first char after `{`
+
     let depth = 1;
-    const bodyLines: string[] = [];
-    while (j < lines.length && depth > 0) {
-      for (const ch of lines[j]) {
-        if (ch === "{") depth++;
-        else if (ch === "}") depth--;
-      }
-      bodyLines.push(lines[j].trim());
-      j++;
+    let bodyEnd = absOffset;
+    while (bodyEnd < stripped.length && depth > 0) {
+      const c = stripped[bodyEnd];
+      if (c === "{") depth++;
+      else if (c === "}") depth--;
+      if (depth === 0) break;
+      bodyEnd++;
     }
-
-    const meaningful = bodyLines.slice(0, -1).filter(
-      (l) => l && !l.startsWith("//") && !l.startsWith("/*") && !l.startsWith("*") && l !== "}",
-    );
-
-    if (meaningful.length === 0) {
-      results.push({ line: i + 1, text: line.trim() });
+    const bodyText = stripped.slice(absOffset, bodyEnd).trim();
+    if (bodyText === "") {
+      results.push({ line: i + 1, text: origLines[i].trim() });
     }
   }
 
@@ -178,51 +378,146 @@ function findEmptyCatches(filePath: string): Array<{ line: number; text: string 
 /**
  * Scan a file for catch blocks that use raw process.stderr.write or
  * console.error/warn instead of workflow-logger.
+ *
+ * Operates on the stripped source so a catch body that contains (say) a
+ * string literal mentioning "console.error" is not flagged (#4836).
  */
 function findRawStderrCatches(filePath: string): Array<{ line: number; text: string }> {
   const content = readFileSync(filePath, "utf-8");
-  const lines = content.split("\n");
+  const stripped = stripLiteralsAndComments(content);
+  const origLines = content.split("\n");
+  const strippedLines = stripped.split("\n");
   const results: Array<{ line: number; text: string }> = [];
+  const catchHead = /(?<![A-Za-z0-9_$])catch\s*(\([^)]*\))?\s*\{/;
 
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i];
-    if (!/\}\s*catch\s*(\([^)]*\))?\s*\{/.test(line)) continue;
+  for (let i = 0; i < strippedLines.length; i++) {
+    const stripLine = strippedLines[i];
+    if (!catchHead.test(stripLine)) continue;
 
-    // Inline single-line catch
-    const inlineMatch = line.match(/\}\s*catch\s*(\([^)]*\))?\s*\{(.*)\}\s*;?\s*$/);
+    const inlineMatch = stripLine.match(/(?<![A-Za-z0-9_$])catch\s*(\([^)]*\))?\s*\{([^{}]*)\}\s*;?\s*$/);
     if (inlineMatch) {
       const body = inlineMatch[2];
       if (!LOGGER_PATTERNS.some((p) => p.test(body))) {
         if (/process\.stderr\.write/.test(body) || /console\.(error|warn)/.test(body)) {
-          results.push({ line: i + 1, text: line.trim() });
+          results.push({ line: i + 1, text: origLines[i].trim() });
         }
       }
       continue;
     }
 
-    // Multi-line catch
-    let j = i + 1;
-    let depth = 1;
-    const bodyLines: string[] = [];
-    while (j < lines.length && depth > 0) {
-      for (const ch of lines[j]) {
-        if (ch === "{") depth++;
-        else if (ch === "}") depth--;
-      }
-      bodyLines.push(lines[j]);
-      j++;
-    }
+    const braceColOnLine = stripLine.indexOf("{", stripLine.indexOf("catch"));
+    if (braceColOnLine < 0) continue;
+    let absOffset = 0;
+    for (let k = 0; k < i; k++) absOffset += strippedLines[k].length + 1;
+    absOffset += braceColOnLine + 1;
 
-    const bodyText = bodyLines.slice(0, -1).join("\n");
+    let depth = 1;
+    let bodyEnd = absOffset;
+    while (bodyEnd < stripped.length && depth > 0) {
+      const c = stripped[bodyEnd];
+      if (c === "{") depth++;
+      else if (c === "}") depth--;
+      if (depth === 0) break;
+      bodyEnd++;
+    }
+    const bodyText = stripped.slice(absOffset, bodyEnd);
     if (!LOGGER_PATTERNS.some((p) => p.test(bodyText))) {
       if (/process\.stderr\.write/.test(bodyText) || /console\.(error|warn)/.test(bodyText)) {
-        results.push({ line: i + 1, text: line.trim() });
+        results.push({ line: i + 1, text: origLines[i].trim() });
       }
     }
   }
 
   return results;
 }
+
+// ── Self-tests for the scanner — prove the brace counter is now robust ──
+
+describe("silent-catch scanner — string/template/comment robustness (#4836)", () => {
+  test("ignores '{' and '}' inside string literals", () => {
+    const src = [
+      'try { foo(); } catch {',
+      '  const s = "}"; // closing brace in a string must not end the block',
+      '  doSomething(s);',
+      '}',
+    ].join("\n");
+    const stripped = stripLiteralsAndComments(src);
+    // After stripping, the string "}" must be replaced with neutral chars,
+    // so naive brace counting on the *stripped* source terminates at the
+    // real closing brace, not at the in-string '}'.
+    const catchIdx = stripped.indexOf("catch");
+    const openIdx = stripped.indexOf("{", catchIdx);
+    let depth = 1, end = openIdx + 1;
+    while (end < stripped.length && depth > 0) {
+      if (stripped[end] === "{") depth++;
+      else if (stripped[end] === "}") depth--;
+      if (depth === 0) break;
+      end++;
+    }
+    assert.equal(depth, 0, "scanner must terminate on the real closing brace");
+    // And the body must contain `doSomething(s)` — i.e. we didn't stop early.
+    assert.ok(stripped.slice(openIdx + 1, end).includes("doSomething"));
+  });
+
+  test("ignores '{' inside template literal interpolations at the outer level", () => {
+    // The inner `${x}` is an interpolation — its braces are real, and the
+    // scanner must treat them as balanced (neither opening nor stranding
+    // the catch block).
+    const src = [
+      'try { foo(); } catch {',
+      '  const t = `x=${x + 1}`;',
+      '  doSomething(t);',
+      '}',
+    ].join("\n");
+    const stripped = stripLiteralsAndComments(src);
+    const catchIdx = stripped.indexOf("catch");
+    const openIdx = stripped.indexOf("{", catchIdx);
+    let depth = 1, end = openIdx + 1;
+    while (end < stripped.length && depth > 0) {
+      if (stripped[end] === "{") depth++;
+      else if (stripped[end] === "}") depth--;
+      if (depth === 0) break;
+      end++;
+    }
+    assert.equal(depth, 0, "scanner must balance template interpolation braces");
+    assert.ok(stripped.slice(openIdx + 1, end).includes("doSomething"));
+  });
+
+  test("ignores '{' and '}' inside block comments", () => {
+    const src = [
+      'try { foo(); } catch {',
+      '  /* stray } brace in a comment */',
+      '  doSomething();',
+      '}',
+    ].join("\n");
+    const stripped = stripLiteralsAndComments(src);
+    // The comment body must be neutralized — no residual '}' from it.
+    const openIdx = stripped.indexOf("{", stripped.indexOf("catch"));
+    let depth = 1, end = openIdx + 1;
+    while (end < stripped.length && depth > 0) {
+      if (stripped[end] === "{") depth++;
+      else if (stripped[end] === "}") depth--;
+      if (depth === 0) break;
+      end++;
+    }
+    assert.equal(depth, 0);
+    assert.ok(stripped.slice(openIdx + 1, end).includes("doSomething"));
+  });
+
+  test("does not flag a catch whose body contains only a string mentioning console.error", () => {
+    // If the catch body is `const x = "console.error(foo)"` then we should
+    // NOT flag it as a raw-stderr violation.
+    const src = [
+      'try { foo(); } catch {',
+      '  const x = "console.error(foo)";',
+      '  void x;',
+      '}',
+    ].join("\n");
+    const stripped = stripLiteralsAndComments(src);
+    assert.ok(!/console\.(error|warn)/.test(stripped),
+      "stripped body must not contain console.error after string neutralization");
+  });
+});
 
 describe("workflow-logger coverage (#3348)", () => {
   test("no empty catch blocks remain in migrated files", () => {

--- a/src/resources/extensions/gsd/tests/structured-data-formatter.test.ts
+++ b/src/resources/extensions/gsd/tests/structured-data-formatter.test.ts
@@ -271,96 +271,12 @@ describe("structured-data-formatter: measureSavings", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Realistic token savings measurement
+// Removed: "decisions/requirements/task-plan saves 30%+ vs markdown" tests.
+//
+// These tests compared the compact formatters against hand-crafted markdown
+// fixtures chosen by the test author. Any baseline picked to demonstrate
+// savings is circular — it proves nothing about real-world token overhead
+// relative to what the app actually emits. See #4836. A proper savings-drift
+// harness (measured against captured real inputs, tracked as a regression
+// metric over time) is tracked as a follow-up.
 // ---------------------------------------------------------------------------
-
-describe("structured-data-formatter: realistic savings", () => {
-  it("decisions compact format saves 30%+ vs markdown table", () => {
-    const decisions = [sampleDecision, sampleDecision2];
-
-    // Simulate a typical markdown table
-    const markdownTable = [
-      "| ID   | When       | Scope        | Decision                | Choice                 | Rationale                | Revisable |",
-      "|------|------------|--------------|-------------------------|------------------------|--------------------------|-----------|",
-      "| D001 | M001/S01   | architecture | Use SQLite for storage  | WAL mode, single-writer | Built-in, no external deps | yes       |",
-      "| D002 | M001/S02   | testing      | Unit test all parsers   | node:test framework    | Fast, zero-dependency    | no        |",
-    ].join("\n");
-
-    const compactOutput = formatDecisionsCompact(decisions);
-    const savings = measureSavings(compactOutput, markdownTable);
-    assert.ok(
-      savings >= 30,
-      `expected >=30% savings, got ${savings.toFixed(1)}%`,
-    );
-  });
-
-  it("requirements compact format saves 30%+ vs markdown sections", () => {
-    const requirements = [sampleRequirement, sampleRequirement2];
-
-    // Simulate verbose markdown format with all fields
-    const markdownSections = [
-      "## R001",
-      "",
-      "- **Class:** functional",
-      "- **Status:** active",
-      "- **Description:** Response latency < 200ms for API endpoints",
-      "- **Why:** Critical for user experience",
-      "- **Source:** architecture review",
-      "- **Primary Owner:** S01",
-      "- **Supporting Slices:** S02, S03",
-      "- **Validation:** Load test confirms P99 < 200ms",
-      "- **Notes:** Monitor in production",
-      "",
-      "## R002",
-      "",
-      "- **Class:** non-functional",
-      "- **Status:** active",
-      "- **Description:** Data consistency across writes",
-      "- **Why:** Prevents data loss",
-      "- **Source:** data team review",
-      "- **Primary Owner:** S02",
-      "- **Supporting Slices:** S01",
-      "- **Validation:** Integration test suite",
-      "- **Notes:** Requires WAL mode",
-    ].join("\n");
-
-    const compactOutput = formatRequirementsCompact(requirements);
-    const savings = measureSavings(compactOutput, markdownSections);
-    assert.ok(
-      savings >= 30,
-      `expected >=30% savings, got ${savings.toFixed(1)}%`,
-    );
-  });
-
-  it("task plan compact format saves 30%+ vs markdown sections", () => {
-    const tasks = [sampleTaskDone, sampleTaskPending];
-
-    // Simulate verbose markdown task format
-    const markdownTasks = [
-      "## T01 - Database schema",
-      "",
-      "- **Status:** Done",
-      "- **Estimate:** 30m",
-      "- **Description:** Create tables for decisions and requirements",
-      "- **Files:**",
-      "  - src/db.ts",
-      "  - src/schema.ts",
-      "",
-      "## T02 - API endpoints",
-      "",
-      "- **Status:** Pending",
-      "- **Estimate:** 1h",
-      "- **Description:** REST endpoints for CRUD operations",
-      "- **Files:**",
-      "  - src/api.ts",
-      "- **Verify:** npm test",
-    ].join("\n");
-
-    const compactOutput = formatTaskPlanCompact(tasks);
-    const savings = measureSavings(compactOutput, markdownTasks);
-    assert.ok(
-      savings >= 30,
-      `expected >=30% savings, got ${savings.toFixed(1)}%`,
-    );
-  });
-});


### PR DESCRIPTION
## What

Closes #4836.

1. `silent-catch-diagnostics.test.ts` — replace the raw-byte brace counter with a token-aware scanner that neutralises string / template / regex / comment contents before counting braces.
2. `structured-data-formatter.test.ts` — delete three "compact saves 30%+ vs markdown" tests whose baselines were hand-authored by the test author (circular).

## Why

**silent-catch** — the previous counter treated *every* `{` and `}` as a real brace, so:
- a `}` inside a string literal ended the catch body early → the scanner judged the body "empty" and flagged a false positive, OR
- a `{` inside a comment pushed depth past the real close → the scanner walked into the next function and missed a genuinely silent catch (false negative).

The fix strips string / template-literal / regex / `//` / `/* */` content to neutral whitespace, preserves newline structure so reported line numbers still match, then runs the same structural scan. Four new self-tests prove the scanner now survives each literal form.

**structured-data-formatter savings** — `savings >= 30%` against a hand-chosen markdown fixture is a tautology: any baseline can be selected to make compact win. Deleted the three tests; a proper savings-drift harness measured against real captured inputs is a follow-up. The remaining ~25 tests exercise real formatter behaviour and still pass.

## How

- `stripLiteralsAndComments()` — best-effort lexer (line/block comments, single/double/backtick strings with `${…}` interpolation, regex literals disambiguated by the previous-significant-token heuristic).
- `findEmptyCatches` and `findRawStderrCatches` now scan the stripped source; report line numbers still come from the original.
- New self-tests cover `}` inside strings, interpolated templates, block comments, and a string that mentions `console.error`.

## Test plan

- [x] `node --test dist-test/src/resources/extensions/gsd/tests/silent-catch-diagnostics.test.js` → 7 pass
- [x] `node --test dist-test/src/resources/extensions/gsd/tests/structured-data-formatter.test.js` → 24 pass
- [x] Real migrated files still show zero empty catches / zero raw-stderr catches under the new scanner.

Refs #4784