### PR TITLE
fix(pi-ai): round-trip reasoning_content for DeepSeek thinking mode

### DIFF
--- a/packages/pi-ai/src/providers/openai-completions.test.ts
+++ b/packages/pi-ai/src/providers/openai-completions.test.ts
@@ -1,0 +1,254 @@
+// DeepSeek reasoning_content round-trip.
+// Docs: https://api-docs.deepseek.com/guides/thinking_mode
+// Without this, DeepSeek returns 400: "The `reasoning_content` in the thinking mode must be passed back to the API."
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+
+import { convertMessages, getCompat } from "./openai-completions.js";
+import type { AssistantMessage, Context, Model } from "../types.js";
+
+function makeDeepseekModel(overrides: Partial<Model<"openai-completions">> = {}): Model<"openai-completions"> {
+	return {
+		id: "deepseek-v4-pro",
+		name: "DeepSeek V4 Pro",
+		api: "openai-completions",
+		provider: "deepseek",
+		baseUrl: "https://api.deepseek.com",
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 1_000_000,
+		maxTokens: 384_000,
+		...overrides,
+	} as Model<"openai-completions">;
+}
+
+function makeAssistantMsg(
+	content: AssistantMessage["content"],
+	overrides: Partial<AssistantMessage> = {},
+): AssistantMessage {
+	return {
+		role: "assistant",
+		content,
+		api: "openai-completions",
+		provider: "deepseek",
+		model: "deepseek-v4-pro",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: Date.now(),
+		...overrides,
+	};
+}
+
+describe("openai-completions: DeepSeek thinkingFormat auto-detection", () => {
+	test("baseUrl matching deepseek.com → thinkingFormat=deepseek", () => {
+		const compat = getCompat(makeDeepseekModel());
+		assert.equal(compat.thinkingFormat, "deepseek");
+	});
+
+	test("provider=deepseek → thinkingFormat=deepseek even without URL match", () => {
+		const compat = getCompat(makeDeepseekModel({ baseUrl: "https://example.com/v1" }));
+		assert.equal(compat.thinkingFormat, "deepseek");
+	});
+
+	test("explicit compat.thinkingFormat wins over auto-detect", () => {
+		const compat = getCompat(makeDeepseekModel({ compat: { thinkingFormat: "openai" } }));
+		assert.equal(compat.thinkingFormat, "openai");
+	});
+
+	test("unrelated URL/provider → thinkingFormat stays openai", () => {
+		const compat = getCompat(
+			makeDeepseekModel({
+				provider: "openai",
+				baseUrl: "https://api.openai.com",
+				id: "gpt-4",
+			}),
+		);
+		assert.equal(compat.thinkingFormat, "openai");
+	});
+});
+
+describe("openai-completions: convertMessages with thinkingFormat=deepseek", () => {
+	test("thinking + text → reasoning_content at top level, content preserved", () => {
+		const model = makeDeepseekModel();
+		const compat = getCompat(model);
+		const context: Context = {
+			messages: [
+				makeAssistantMsg([
+					{ type: "thinking", thinking: "Let me reason about this." },
+					{ type: "text", text: "The answer is 42." },
+				]),
+			],
+		};
+		const params = convertMessages(model, context, compat);
+		assert.equal(params.length, 1);
+		const asst = params[0] as any;
+		assert.equal(asst.role, "assistant");
+		assert.equal(asst.reasoning_content, "Let me reason about this.");
+		assert.ok(Array.isArray(asst.content));
+		assert.equal(asst.content[0].text, "The answer is 42.");
+	});
+
+	test("thinking + tool_calls (no text) → reasoning_content survives alongside tool_calls", () => {
+		const model = makeDeepseekModel();
+		const compat = getCompat(model);
+		const context: Context = {
+			messages: [
+				makeAssistantMsg([
+					{ type: "thinking", thinking: "I should call the search tool." },
+					{
+						type: "toolCall",
+						id: "call_abc123",
+						name: "search",
+						arguments: { query: "hello" },
+					},
+				]),
+				{
+					role: "toolResult",
+					toolCallId: "call_abc123",
+					toolName: "search",
+					content: [{ type: "text", text: "no results" }],
+					isError: false,
+					timestamp: Date.now(),
+				},
+			],
+		};
+		const params = convertMessages(model, context, compat);
+		const asst = params[0] as any;
+		assert.equal(asst.role, "assistant");
+		assert.equal(asst.reasoning_content, "I should call the search tool.");
+		assert.equal(asst.tool_calls.length, 1);
+		assert.equal(asst.tool_calls[0].id, "call_abc123");
+	});
+
+	test("multiple thinking blocks joined with newline", () => {
+		const model = makeDeepseekModel();
+		const compat = getCompat(model);
+		const context: Context = {
+			messages: [
+				makeAssistantMsg([
+					{ type: "thinking", thinking: "First thought." },
+					{ type: "thinking", thinking: "Second thought." },
+					{ type: "text", text: "Done." },
+				]),
+			],
+		};
+		const params = convertMessages(model, context, compat);
+		const asst = params[0] as any;
+		assert.equal(asst.reasoning_content, "First thought.\nSecond thought.");
+	});
+
+	test("empty / whitespace-only thinking blocks are filtered out", () => {
+		const model = makeDeepseekModel();
+		const compat = getCompat(model);
+		const context: Context = {
+			messages: [
+				makeAssistantMsg([
+					{ type: "thinking", thinking: "" },
+					{ type: "thinking", thinking: "   " },
+					{ type: "thinking", thinking: "Real thought." },
+					{ type: "text", text: "OK." },
+				]),
+			],
+		};
+		const params = convertMessages(model, context, compat);
+		const asst = params[0] as any;
+		assert.equal(asst.reasoning_content, "Real thought.");
+	});
+
+	test("no thinking blocks → reasoning_content is empty string (required by DeepSeek for tool_call turns)", () => {
+		const model = makeDeepseekModel();
+		const compat = getCompat(model);
+		const context: Context = {
+			messages: [makeAssistantMsg([{ type: "text", text: "Just text." }])],
+		};
+		const params = convertMessages(model, context, compat);
+		const asst = params[0] as any;
+		assert.equal(asst.reasoning_content, "");
+	});
+
+	test("tool_calls without thinking → reasoning_content is empty string (the 400-producing case)", () => {
+		const model = makeDeepseekModel();
+		const compat = getCompat(model);
+		const context: Context = {
+			messages: [
+				makeAssistantMsg([
+					{
+						type: "toolCall",
+						id: "call_xyz",
+						name: "search",
+						arguments: { query: "hi" },
+					},
+				]),
+				{
+					role: "toolResult",
+					toolCallId: "call_xyz",
+					toolName: "search",
+					content: [{ type: "text", text: "ok" }],
+					isError: false,
+					timestamp: Date.now(),
+				},
+			],
+		};
+		const params = convertMessages(model, context, compat);
+		const asst = params[0] as any;
+		assert.equal(asst.reasoning_content, "");
+		assert.equal(asst.tool_calls.length, 1);
+	});
+});
+
+describe("openai-completions: requiresThinkingAsText path unaffected by deepseek branch", () => {
+	test("thinkingFormat=openai + requiresThinkingAsText=true → thinking prefixed as text, no reasoning_content", () => {
+		const model = {
+			id: "some-model",
+			name: "Some Model",
+			api: "openai-completions",
+			provider: "custom",
+			baseUrl: "https://example.com/v1",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 100_000,
+			maxTokens: 8192,
+			compat: { requiresThinkingAsText: true, thinkingFormat: "openai" as const },
+		} as Model<"openai-completions">;
+		const compat = getCompat(model);
+		const context: Context = {
+			messages: [
+				{
+					role: "assistant",
+					content: [
+						{ type: "thinking", thinking: "reasoning here" },
+						{ type: "text", text: "answer" },
+					],
+					api: "openai-completions",
+					provider: "custom",
+					model: "some-model",
+					usage: {
+						input: 0,
+						output: 0,
+						cacheRead: 0,
+						cacheWrite: 0,
+						totalTokens: 0,
+						cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+					},
+					stopReason: "stop",
+					timestamp: Date.now(),
+				},
+			],
+		};
+		const params = convertMessages(model, context, compat);
+		const asst = params[0] as any;
+		assert.equal(asst.reasoning_content, undefined);
+		assert.ok(Array.isArray(asst.content));
+		assert.equal(asst.content[0].text, "reasoning here");
+		assert.equal(asst.content[1].text, "answer");
+	});
+});

--- a/packages/pi-ai/src/providers/openai-completions.ts
+++ b/packages/pi-ai/src/providers/openai-completions.ts
@@ -574,7 +574,17 @@ export function convertMessages(
 			const thinkingBlocks = msg.content.filter((b) => b.type === "thinking") as ThinkingContent[];
 			// Filter out empty thinking blocks to avoid API validation errors
 			const nonEmptyThinkingBlocks = thinkingBlocks.filter((b) => b.thinking && b.thinking.trim().length > 0);
-			if (nonEmptyThinkingBlocks.length > 0) {
+
+			// DeepSeek thinking-mode: every assistant turn in the request history must carry a
+			// top-level `reasoning_content` field — specifically required for turns with tool_calls,
+			// which otherwise produce `400 The reasoning_content in the thinking mode must be
+			// passed back to the API`. Set unconditionally (empty string when no thinking was produced).
+			// https://api-docs.deepseek.com/guides/thinking_mode
+			if (compat.thinkingFormat === "deepseek") {
+				(assistantMsg as any).reasoning_content = nonEmptyThinkingBlocks.map((b) => b.thinking).join("\n");
+			}
+
+			if (nonEmptyThinkingBlocks.length > 0 && compat.thinkingFormat !== "deepseek") {
 				if (compat.requiresThinkingAsText) {
 					// Convert thinking blocks to plain text (no tags to avoid model mimicking them)
 					const thinkingText = nonEmptyThinkingBlocks.map((b) => b.thinking).join("\n\n");
@@ -747,11 +757,12 @@ function mapStopReason(reason: ChatCompletionChunk.Choice["finish_reason"]): Sto
  * Provider takes precedence over URL-based detection since it's explicitly configured.
  * Returns a fully resolved OpenAICompletionsCompat object with all fields set.
  */
-function detectCompat(model: Model<"openai-completions">): Required<OpenAICompletionsCompat> {
+export function detectCompat(model: Model<"openai-completions">): Required<OpenAICompletionsCompat> {
 	const provider = model.provider;
 	const baseUrl = model.baseUrl;
 
 	const isZai = provider === "zai" || baseUrl.includes("api.z.ai");
+	const isDeepseek = provider === "deepseek" || baseUrl.includes("deepseek.com");
 
 	const isNonStandard =
 		provider === "cerebras" ||
@@ -759,7 +770,7 @@ function detectCompat(model: Model<"openai-completions">): Required<OpenAIComple
 		provider === "xai" ||
 		baseUrl.includes("api.x.ai") ||
 		baseUrl.includes("chutes.ai") ||
-		baseUrl.includes("deepseek.com") ||
+		isDeepseek ||
 		isZai ||
 		provider === "opencode" ||
 		baseUrl.includes("opencode.ai");
@@ -789,7 +800,7 @@ function detectCompat(model: Model<"openai-completions">): Required<OpenAIComple
 		requiresToolResultName: false,
 		requiresAssistantAfterToolResult: false,
 		requiresThinkingAsText: false,
-		thinkingFormat: isZai ? "zai" : "openai",
+		thinkingFormat: isZai ? "zai" : isDeepseek ? "deepseek" : "openai",
 		openRouterRouting: {},
 		vercelGatewayRouting: {},
 		supportsStrictMode: true,
@@ -800,7 +811,7 @@ function detectCompat(model: Model<"openai-completions">): Required<OpenAIComple
  * Get resolved compatibility settings for a model.
  * Uses explicit model.compat if provided, otherwise auto-detects from provider/URL.
  */
-function getCompat(model: Model<"openai-completions">): Required<OpenAICompletionsCompat> {
+export function getCompat(model: Model<"openai-completions">): Required<OpenAICompletionsCompat> {
 	const detected = detectCompat(model);
 	if (!model.compat) return detected;
 

--- a/packages/pi-ai/src/types.ts
+++ b/packages/pi-ai/src/types.ts
@@ -296,8 +296,12 @@ export interface OpenAICompletionsCompat {
 	requiresAssistantAfterToolResult?: boolean;
 	/** Whether thinking blocks must be converted to text blocks with <thinking> delimiters. Default: auto-detected from URL. */
 	requiresThinkingAsText?: boolean;
-	/** Format for reasoning/thinking parameter. "openai" uses reasoning_effort, "zai" uses thinking: { type: "enabled" }, "qwen" uses enable_thinking: boolean. Default: "openai". */
-	thinkingFormat?: "openai" | "zai" | "qwen";
+	/** Format for reasoning/thinking parameter and assistant-history round-trip.
+	 *  "openai" uses reasoning_effort (default);
+	 *  "zai" / "qwen" send enable_thinking: boolean on the request;
+	 *  "deepseek" additionally round-trips the prior turn's reasoning as a top-level `reasoning_content` field on every assistant message in the request history — DeepSeek's thinking-mode API requires this for tool_call turns, returning 400 otherwise (https://api-docs.deepseek.com/guides/thinking_mode).
+	 *  Default: "openai". */
+	thinkingFormat?: "openai" | "zai" | "qwen" | "deepseek";
 	/** OpenRouter-specific routing preferences. Only used when baseUrl points to OpenRouter. */
 	openRouterRouting?: OpenRouterRouting;
 	/** Vercel AI Gateway routing preferences. Only used when baseUrl points to Vercel AI Gateway. */


### PR DESCRIPTION
## Summary

- Fixes #4898 — DeepSeek v4 returning `400 The reasoning_content in the thinking mode must be passed back to the API` on multi-turn tool-call sessions.
- Adds `"deepseek"` to `OpenAICompletionsCompat.thinkingFormat` and a dedicated serialization branch that round-trips the prior turn's reasoning as a top-level `reasoning_content` field on every assistant message in the request history.
- Auto-detected from `provider === "deepseek"` or `baseUrl.includes("deepseek.com")`, so existing user configs pick it up without any opt-in.

## Why

DeepSeek's thinking-mode API requires that every assistant turn in the request history carries a top-level `reasoning_content` field — specifically required for turns with tool calls, which otherwise produce 400 ([docs](https://api-docs.deepseek.com/guides/thinking_mode)). Prior serialization only routed thinking blocks into the `requiresThinkingAsText` branch or a signature field (for llama.cpp/gpt-oss), so `reasoning_content` was never emitted on replay.

Verified end-to-end by instrumenting the outgoing payload during a failing session: every assistant message carried `reasoning_content` except the last tool-call turn (which had no prior thinking in the model's response). Empty string is accepted by the API and satisfies the "must be present" constraint.

## What changed

- `packages/pi-ai/src/types.ts` — extend `thinkingFormat` union with `"deepseek"` + updated JSDoc.
- `packages/pi-ai/src/providers/openai-completions.ts`:
  - `detectCompat` — auto-detect DeepSeek and set `thinkingFormat: "deepseek"`.
  - Serialization — new early branch: when `thinkingFormat === "deepseek"`, unconditionally set `(assistantMsg as any).reasoning_content` to joined thinking text (or empty string when no thinking). Skip the existing `requiresThinkingAsText` / signature branches for DeepSeek.
  - Export `detectCompat` and `getCompat` to enable direct unit tests.
- `packages/pi-ai/src/providers/openai-completions.test.ts` — new test file, 11 cases.

## Tests

11 new tests (all passing), covering:
- Auto-detection (baseUrl match, provider match, explicit override, negative case)
- Serialization: thinking + text / thinking + tool_calls / multiple thinking blocks / empty & whitespace-only filtered / no thinking → empty string / tool_calls without thinking → empty string (the specific 400-producing case from #4898)
- Regression guard: `requiresThinkingAsText` path unaffected by the new branch

Run: `cd packages/pi-ai && npx tsc -p tsconfig.json && node --test dist/providers/openai-completions.test.js`

## Test plan

- [x] 11 new unit tests pass
- [x] Existing pi-ai tests still pass (no regressions)
- [x] Verified live with deepseek-v4-pro in a multi-turn tool-call session — 400 no longer appears
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for DeepSeek's thinking mode within the OpenAI-completions provider layer
  * Implemented auto-detection of DeepSeek models to automatically configure reasoning handling

* **Tests**
  * Added comprehensive test suite validating DeepSeek thinking-mode behavior, including reasoning content preservation and compatibility with tool calls

<!-- end of auto-generated comment: release notes by coderabbit.ai -->