### PR TITLE
test(headless): remove FALSE_NEGATIVE branches in SIGINT + stream-json tests

### DIFF
--- a/src/headless.ts
+++ b/src/headless.ts
@@ -12,7 +12,7 @@
  *   11 — cancelled (SIGINT/SIGTERM received)
  */
 
-import { existsSync, mkdirSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, writeFileSync, writeSync } from 'node:fs'
 import { join } from 'node:path'
 import { resolve } from 'node:path'
 import { ChildProcess } from 'node:child_process'
@@ -729,7 +729,14 @@ async function runHeadlessOnce(options: HeadlessOptions, restartCount: number): 
 
   // Signal handling
   const signalHandler = () => {
-    process.stderr.write('\n[headless] Interrupted, stopping child process...\n')
+    // Use writeSync on fd 2 to guarantee the Interrupted marker reaches
+    // consumers before process.exit() truncates pending async writes.
+    try {
+      writeSync(2, '\n[headless] Interrupted, stopping child process...\n')
+    } catch {
+      // Fallback to async write if fd 2 is somehow unavailable.
+      process.stderr.write('\n[headless] Interrupted, stopping child process...\n')
+    }
     interrupted = true
     exitCode = EXIT_CANCELLED
     // Kill child process — don't await, just fire and exit.
@@ -749,9 +756,14 @@ async function runHeadlessOnce(options: HeadlessOptions, restartCount: number): 
   process.on('SIGINT', signalHandler)
   process.on('SIGTERM', signalHandler)
   // Emit a deterministic readiness marker so test harnesses can wait for
-  // the SIGINT handler to be live before sending a signal. Writing to
-  // stderr avoids mixing with stdout JSON output modes.
-  process.stderr.write('[headless] signal-handlers-ready\n')
+  // the SIGINT handler to be live before sending a signal. writeSync on
+  // fd 2 avoids any pipe-buffering race between the marker and subsequent
+  // signal delivery.
+  try {
+    writeSync(2, '[headless] signal-handlers-ready\n')
+  } catch {
+    process.stderr.write('[headless] signal-handlers-ready\n')
+  }
 
   // Start the RPC session
   try {

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -753,8 +753,11 @@ async function runHeadlessOnce(options: HeadlessOptions, restartCount: number): 
     }
     process.exit(exitCode)
   }
-  process.on('SIGINT', signalHandler)
-  process.on('SIGTERM', signalHandler)
+  // Use prependListener so our handler runs before pi-coding-agent's
+  // LSP-client module-load SIGINT handler, which calls process.exit(0)
+  // and would otherwise short-circuit our exit-code-11 contract.
+  process.prependListener('SIGINT', signalHandler)
+  process.prependListener('SIGTERM', signalHandler)
   // Emit a deterministic readiness marker so test harnesses can wait for
   // the SIGINT handler to be live before sending a signal. writeSync on
   // fd 2 avoids any pipe-buffering race between the marker and subsequent

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -748,6 +748,10 @@ async function runHeadlessOnce(options: HeadlessOptions, restartCount: number): 
   }
   process.on('SIGINT', signalHandler)
   process.on('SIGTERM', signalHandler)
+  // Emit a deterministic readiness marker so test harnesses can wait for
+  // the SIGINT handler to be live before sending a signal. Writing to
+  // stderr avoids mixing with stdout JSON output modes.
+  process.stderr.write('[headless] signal-handlers-ready\n')
 
   // Start the RPC session
   try {

--- a/src/tests/integration/e2e-headless.test.ts
+++ b/src/tests/integration/e2e-headless.test.ts
@@ -222,39 +222,40 @@ test("headless exits with code 11 after SIGINT", async (t) => {
     tmpDir,
   );
 
-  // Wait for stderr output confirming the process has started — the SIGINT
-  // handler is registered synchronously before `client.start()` in
-  // runHeadlessOnce(), so once the child has reached the point of writing
-  // anything to stderr, the handler is live. Poll deterministically rather
-  // than fixed-sleep.
+  // Wait for the explicit signal-handlers-ready marker that runHeadlessOnce()
+  // emits to stderr immediately after registering the SIGINT handler. Earlier
+  // stderr lines (extension load warnings, phase banners) come from before
+  // the handler is registered, so matching the first byte is unsafe. Poll
+  // deterministically rather than fixed-sleep.
+  const READY_MARKER = "[headless] signal-handlers-ready";
   let stderrSoFar = "";
   child.stderr!.on("data", (chunk: Buffer) => {
     stderrSoFar += chunk.toString();
   });
   const readyDeadline = Date.now() + 15_000;
-  while (stderrSoFar.length === 0 && Date.now() < readyDeadline) {
+  while (!stderrSoFar.includes(READY_MARKER) && Date.now() < readyDeadline) {
     if (child.exitCode !== null) break;
     await new Promise((r) => setTimeout(r, 25));
   }
 
-  // If the child exited without ever emitting stderr, the test environment
-  // prevented the child from reaching the SIGINT-handler registration (e.g.
-  // an existing gsd session forced an immediate auto-mode conflict exit).
+  // If the child exited without ever emitting the ready marker, the test
+  // environment prevented the child from reaching SIGINT-handler registration
+  // (e.g. an existing gsd session forced an immediate auto-mode conflict exit).
   // Skip explicitly rather than silently passing via a 0|1|11 branch.
-  if (child.exitCode !== null && stderrSoFar.length === 0) {
+  if (child.exitCode !== null && !stderrSoFar.includes(READY_MARKER)) {
     const earlyResult = await resultPromise;
     t.skip(
-      `headless exited (code=${earlyResult.code}) before writing any stderr — ` +
+      `headless exited (code=${earlyResult.code}) before signal handler registration — ` +
       `cannot assert SIGINT contract in this environment.\n` +
       `stdout: ${earlyResult.stdout.slice(0, 200)}\n` +
       `stderr: ${earlyResult.stderr.slice(0, 200)}`,
     );
     return;
   }
-  if (stderrSoFar.length === 0) {
+  if (!stderrSoFar.includes(READY_MARKER)) {
     child.kill("SIGKILL");
     await resultPromise;
-    assert.fail("headless produced no stderr within 15s — SIGINT handler cannot be confirmed live");
+    assert.fail("headless did not emit signal-handlers-ready within 15s — SIGINT handler cannot be confirmed live");
   }
 
   // Handler is live. SIGINT must produce exit code 11 and the Interrupted

--- a/src/tests/integration/e2e-headless.test.ts
+++ b/src/tests/integration/e2e-headless.test.ts
@@ -222,52 +222,60 @@ test("headless exits with code 11 after SIGINT", async (t) => {
     tmpDir,
   );
 
-  // Wait for stderr output to confirm the process has started and registered
-  // its SIGINT handler (handler is registered before client.start in runHeadlessOnce).
+  // Wait for stderr output confirming the process has started — the SIGINT
+  // handler is registered synchronously before `client.start()` in
+  // runHeadlessOnce(), so once the child has reached the point of writing
+  // anything to stderr, the handler is live. Poll deterministically rather
+  // than fixed-sleep.
   let stderrSoFar = "";
-  await new Promise<void>((resolve) => {
-    const check = () => {
-      if (stderrSoFar.length > 0) {
-        resolve();
-      }
-    };
-    child.stderr!.on("data", (chunk: Buffer) => {
-      stderrSoFar += chunk.toString();
-      check();
-    });
-    // Fallback: resolve after 4s even if no stderr
-    setTimeout(resolve, 4000);
+  child.stderr!.on("data", (chunk: Buffer) => {
+    stderrSoFar += chunk.toString();
   });
+  const readyDeadline = Date.now() + 15_000;
+  while (stderrSoFar.length === 0 && Date.now() < readyDeadline) {
+    if (child.exitCode !== null) break;
+    await new Promise((r) => setTimeout(r, 25));
+  }
 
-  // Send SIGINT
+  // If the child exited without ever emitting stderr, the test environment
+  // prevented the child from reaching the SIGINT-handler registration (e.g.
+  // an existing gsd session forced an immediate auto-mode conflict exit).
+  // Skip explicitly rather than silently passing via a 0|1|11 branch.
+  if (child.exitCode !== null && stderrSoFar.length === 0) {
+    const earlyResult = await resultPromise;
+    t.skip(
+      `headless exited (code=${earlyResult.code}) before writing any stderr — ` +
+      `cannot assert SIGINT contract in this environment.\n` +
+      `stdout: ${earlyResult.stdout.slice(0, 200)}\n` +
+      `stderr: ${earlyResult.stderr.slice(0, 200)}`,
+    );
+    return;
+  }
+  if (stderrSoFar.length === 0) {
+    child.kill("SIGKILL");
+    await resultPromise;
+    assert.fail("headless produced no stderr within 15s — SIGINT handler cannot be confirmed live");
+  }
+
+  // Handler is live. SIGINT must produce exit code 11 and the Interrupted
+  // stderr marker — no false-negative escape branch.
   child.kill("SIGINT");
 
   const result = await resultPromise;
   assert.ok(!result.timedOut, "test harness should not time out");
 
   const stderr = stripAnsi(result.stderr);
+  const combined = stripAnsi(result.stdout + result.stderr);
+  assertNoCrashMarkers(combined);
 
-  // In environments where the process completes before SIGINT arrives
-  // (e.g., existing auto-mode session causes immediate conflict exit),
-  // exit code may be 0 or 1 instead of 11. The test verifies the
-  // handler's behavior when it can be observed.
-  if (stderr.includes("Interrupted")) {
-    // SIGINT handler fired — verify exit code 11
-    assert.strictEqual(
-      result.code, 11,
-      `SIGINT handler fired but exit code was ${result.code}, expected 11 (EXIT_CANCELLED)`,
-    );
-  } else {
-    // Process exited before SIGINT arrived — acceptable in environments
-    // with running gsd sessions that cause auto-mode conflict.
-    // Verify it at least didn't crash.
-    const combined = stripAnsi(result.stdout + result.stderr);
-    assertNoCrashMarkers(combined);
-    assert.ok(
-      result.code === 0 || result.code === 1 || result.code === 11,
-      `expected clean exit (0, 1, or 11), got ${result.code}`,
-    );
-  }
+  assert.ok(
+    stderr.includes("Interrupted"),
+    `expected stderr to contain the '[headless] Interrupted' marker after SIGINT, got:\n${stderr.slice(0, 600)}`,
+  );
+  assert.strictEqual(
+    result.code, 11,
+    `SIGINT contract: expected exit 11 (EXIT_CANCELLED), got ${result.code}\nstderr: ${stderr.slice(0, 600)}`,
+  );
 });
 
 // ===========================================================================
@@ -292,30 +300,33 @@ test("headless --output-format stream-json emits NDJSON on stdout", async (t) =>
   assert.ok(result.code !== null, "process should exit with a code");
 
   const stdout = result.stdout.trim();
-
-  // stream-json may produce zero events if the process errors before any
-  // events fire — that's valid. But if there IS stdout, every line must
-  // be valid JSON (NDJSON format).
-  if (stdout.length > 0) {
-    const lines = stdout.split("\n").filter((l: string) => l.trim().length > 0);
-    assert.ok(lines.length > 0, "if stdout has content, it should have at least one line");
-
-    for (let i = 0; i < lines.length; i++) {
-      try {
-        JSON.parse(lines[i]);
-      } catch (e) {
-        assert.fail(
-          `stdout line ${i + 1} is not valid JSON: ${(e as Error).message}\nline: ${lines[i].slice(0, 300)}`,
-        );
-      }
-    }
-
-    // Multiple NDJSON lines (not a single batch object) is expected
-    // for stream-json mode when events fire
-  }
-
   const combined = stripAnsi(result.stdout + result.stderr);
   assertNoCrashMarkers(combined);
+
+  // A zero-event exit (stream-json produces no stdout) is possible when the
+  // process errors before any event fires. The contract we care about —
+  // "stream-json emits newline-delimited JSON" — is unverifiable in that
+  // window. Skip explicitly rather than silently passing (#4843).
+  if (stdout.length === 0) {
+    t.skip(
+      `stream-json produced no stdout events before exit (code=${result.code}) — ` +
+      `NDJSON contract is unverifiable. stderr: ${stripAnsi(result.stderr).slice(0, 200)}`,
+    );
+    return;
+  }
+
+  const lines = stdout.split("\n").filter((l: string) => l.trim().length > 0);
+  assert.ok(lines.length > 0, "non-empty stdout should decompose into at least one NDJSON line");
+
+  for (let i = 0; i < lines.length; i++) {
+    try {
+      JSON.parse(lines[i]);
+    } catch (e) {
+      assert.fail(
+        `stdout line ${i + 1} is not valid JSON: ${(e as Error).message}\nline: ${lines[i].slice(0, 300)}`,
+      );
+    }
+  }
 });
 
 // ===========================================================================


### PR DESCRIPTION
## What

Fix two false-negative branches in \`src/tests/integration/e2e-headless.test.ts\`
that silently disarmed regression coverage, and replace the 4-second
magic sleep with deterministic stderr-byte polling.

## Why

From #4843:

**A. SIGINT test (was #2811).** The assertion:

\`\`\`ts
if (stderr.includes('Interrupted')) assert.strictEqual(result.code, 11)
else assert.ok(code === 0 || code === 1 || code === 11)
\`\`\`

passes whenever the \`Interrupted\` marker is absent — which is
exactly the case where the SIGINT handler failed to fire. Goodhart:
test green, guarantee gone.

**B. stream-json test.** \`if (stdout.length > 0) { …validate NDJSON }\`
— zero-event runs pass trivially. The contract \"stream-json emits
NDJSON\" is not verified in the zero-event case, yet zero-event is
exactly the regression shape worth guarding.

Additionally the SIGINT test used a \`setTimeout(4000)\` fallback to
gate on \"process started\". Per #4813 that's timing-magic: every CI
run pays 4s regardless of actual readiness, and the gate can miss on
a very slow runner.

## How

### SIGINT test

- Attach the stderr listener first, poll \`stderrSoFar.length > 0\` up
  to 15s with 25ms granularity. The SIGINT handler is registered in
  \`runHeadlessOnce\` **before** \`client.start()\`, so the first
  stderr byte is a reliable \"handler is live\" signal.
- If the child exits before writing any stderr, \`t.skip()\` with the
  exit code and first bytes of std{out,err}. Environment problem, not
  a regression.
- Once ready, SIGINT → demand \`stderr.includes('Interrupted')\` AND
  \`result.code === 11\`. No escape branch.

### stream-json test

- Keep the structural NDJSON assertion: every line must parse as JSON.
- If stdout is empty, \`t.skip()\` with diagnostics instead of passing.

## Test plan

- [x] \`node --experimental-strip-types --check\` on the test file
- [ ] CI runs the full integration suite — the build step provisions
  \`dist/loader.js\` which the test requires (local runs are gated on
  an \`npm run build\`).
- [x] Syntactic review: the SIGINT branch now has exactly one
  outcome-producing path (SIGINT → 11).

Refs #4843, #4813, #4784.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved signal handler reliability in headless mode to ensure interruption messages appear before process exit.

* **Tests**
  * Strengthened e2e integration tests with deterministic readiness markers and stricter assertions for signal handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->