### PR TITLE
test(gsd): drop source-grep blocks from mixed-verdict batch-03 files (#4827)

### DIFF
--- a/src/resources/extensions/gsd/tests/interrupted-session-ui.test.ts
+++ b/src/resources/extensions/gsd/tests/interrupted-session-ui.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { randomUUID } from "node:crypto";
@@ -126,11 +126,8 @@ test("guided-flow stale paused-session scenario is suppressed when no resumable 
   }
 });
 
-test("guided-flow source uses step-aware resume and clears stale paused metadata without changing discuss handoff semantics", () => {
-  const source = readFileSync(join(import.meta.dirname, "..", "guided-flow.ts"), "utf-8");
-  assert.ok(source.includes('const interrupted = await assessInterruptedSession(basePath);'));
-  assert.ok(source.includes('resumeLabel = interrupted.pausedSession?.stepMode'));
-  assert.ok(source.includes('step: interrupted.pausedSession?.stepMode ?? false'));
-  assert.ok(source.includes('unlinkSync(join(gsdRoot(basePath), "runtime", "paused-session.json"))'));
-  assert.ok(source.includes('pendingAutoStartMap.set(basePath,'));
-});
+// Note: the prior source-grep test that scanned guided-flow.ts for five
+// string literals was removed under #4827. The invariants it encoded
+// (step-aware resume + stale paused-session cleanup + pendingAutoStartMap
+// side effect) should be covered by a runtime drive of guided-flow —
+// tracked as a follow-up.

--- a/src/resources/extensions/gsd/tests/mcp-client-security.test.ts
+++ b/src/resources/extensions/gsd/tests/mcp-client-security.test.ts
@@ -1,11 +1,18 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
 
 import {
   _buildMcpChildEnvForTest,
   _buildMcpTrustConfirmOptionsForTest,
 } from "../../mcp-client/index.ts";
+
+// Note: four source-grep tests that scanned `mcp-client/index.ts` for
+// Map<> shapes, catch-block structure, and closeAll body were removed
+// under #4827. They encoded implementation shape rather than behaviour —
+// any refactor (extracted helper, different Map key type, rearranged
+// cleanup order) broke the greps without a real regression. Runtime
+// coverage of connectServer/closeAll with a mocked failing transport
+// is tracked as a follow-up.
 
 test("MCP stdio child env only includes safe inherited keys plus explicit config env", () => {
   const previousSecret = process.env.SECRET_MCP_TEST_TOKEN;
@@ -37,40 +44,4 @@ test("MCP stdio trust confirmation is abort-aware", () => {
 
   assert.equal(options.timeout, 120_000);
   assert.equal(options.signal, controller.signal);
-});
-
-test("MCP client uses a single in-flight connection per canonical server", () => {
-  const source = readFileSync(new URL("../../mcp-client/index.ts", import.meta.url), "utf8");
-
-  assert.match(source, /const pendingConnections = new Map<string, Promise<Client>>\(\)/);
-  assert.match(source, /const pending = pendingConnections\.get\(config\.name\)/);
-  assert.match(source, /pendingConnections\.set\(config\.name, connectionPromise\)/);
-  assert.match(source, /pendingConnections\.delete\(config\.name\)/);
-  assert.match(source, /env: config\.env \?\? \{\}/);
-});
-
-test("MCP stdio trust is persisted only after a successful connection", () => {
-  const source = readFileSync(new URL("../../mcp-client/index.ts", import.meta.url), "utf8");
-  const connectIndex = source.indexOf("await client.connect(transport");
-  const trustIndex = source.indexOf("trustedStdioServers.add(approvedTrustKey)");
-
-  assert.ok(connectIndex > -1, "connectServer should await client.connect");
-  assert.ok(trustIndex > connectIndex, "trust should be recorded after client.connect succeeds");
-  assert.doesNotMatch(source, /assertTrustedStdioServer[\s\S]*trustedStdioServers\.add\(trustKey\)/);
-});
-
-test("MCP client closes transports after failed connection attempts", () => {
-  const source = readFileSync(new URL("../../mcp-client/index.ts", import.meta.url), "utf8");
-
-  assert.match(source, /catch \(err\) \{[\s\S]*await transport\.close\(\)/);
-  assert.match(source, /catch \(err\) \{[\s\S]*await client\.close\(\)/);
-  assert.match(source, /catch \(err\) \{[\s\S]*throw err/);
-});
-
-test("MCP client clears process-local trust and closes transports on session cleanup", () => {
-  const source = readFileSync(new URL("../../mcp-client/index.ts", import.meta.url), "utf8");
-
-  assert.match(source, /async function closeAll\(\)[\s\S]*await conn\.transport\.close\(\)/);
-  assert.match(source, /async function closeAll\(\)[\s\S]*pendingConnections\.clear\(\)/);
-  assert.match(source, /async function closeAll\(\)[\s\S]*trustedStdioServers\.clear\(\)/);
 });

--- a/src/resources/extensions/gsd/tests/native-git-bridge-exec-fallback.test.ts
+++ b/src/resources/extensions/gsd/tests/native-git-bridge-exec-fallback.test.ts
@@ -17,56 +17,13 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { execFileSync } from "node:child_process";
 import { nativeIsRepo, nativeCommit, nativeResetHard } from "../native-git-bridge.js";
-import { extractSourceRegion } from "./test-helpers.ts";
 
-// ─── Static analysis ──────────────────────────────────────────────────────
-// Verify the fallback paths of the three affected functions do not call the
-// raw execSync() string-command variant. Replacing all execFileSync( tokens
-// first ensures we match only the bare execSync( form.
-
-const SRC_PATH = join(import.meta.dirname, "..", "native-git-bridge.ts");
-
-function extractFunctionBody(src: string, fnName: string): string {
-  const idx = src.indexOf(`export function ${fnName}`);
-  if (idx === -1) throw new Error(`${fnName} not found in source`);
-  return extractSourceRegion(src, `export function ${fnName}`);
-}
-
-function hasRawExecSync(body: string): boolean {
-  const withoutFileSync = body.replace(/execFileSync\(/g, "__FILESYNC__");
-  return withoutFileSync.includes("execSync(");
-}
-
-describe("native-git-bridge #4180: fallback paths use execFileSync not execSync", () => {
-  const src = readFileSync(SRC_PATH, "utf-8");
-
-  test("nativeIsRepo fallback does not use raw execSync", () => {
-    const body = extractFunctionBody(src, "nativeIsRepo");
-    assert.equal(
-      hasRawExecSync(body),
-      false,
-      "nativeIsRepo fallback must use execFileSync to avoid cmd.exe PATH failures on Windows",
-    );
-  });
-
-  test("nativeCommit fallback does not use raw execSync", () => {
-    const body = extractFunctionBody(src, "nativeCommit");
-    assert.equal(
-      hasRawExecSync(body),
-      false,
-      "nativeCommit fallback must use execFileSync to avoid cmd.exe PATH failures on Windows",
-    );
-  });
-
-  test("nativeResetHard fallback does not use raw execSync", () => {
-    const body = extractFunctionBody(src, "nativeResetHard");
-    assert.equal(
-      hasRawExecSync(body),
-      false,
-      "nativeResetHard fallback must use execFileSync to avoid cmd.exe PATH failures on Windows",
-    );
-  });
-});
+// Note: prior static-analysis tests that scanned native-git-bridge.ts for
+// the raw shell-spawn pattern were removed under #4827 — the integration
+// tests below already exercise the fallback path end-to-end with the native
+// module disabled (GSD_ENABLE_NATIVE_GSD_GIT unset). Any cmd.exe PATH
+// regression on Windows surfaces through a real fallback failure, not a
+// grep miss in source text.
 
 // ─── Integration tests ────────────────────────────────────────────────────
 // Verify correct runtime behaviour through the fallback path (native module


### PR DESCRIPTION
## What

Closes #4827 — three batch-03 files where real runtime coverage is already present but a minority of tests fell back to source-grep.

## Why

The grep tests encode implementation shape rather than behaviour (Goodhart). They break on any refactor without catching a real regression, and the sibling runtime tests in each file cover the invariant.

## How

- \`native-git-bridge-exec-fallback.test.ts\` — drop the 3 static-analysis tests. 6 runtime tests remain and exercise the fallback path end to end with the native module disabled.
- \`mcp-client-security.test.ts\` — drop the 4 regex scans on \`mcp-client/index.ts\`. 2 real helper-invocation unit tests remain.
- \`interrupted-session-ui.test.ts\` — drop the 5-literal source-grep on \`guided-flow.ts\`. 3 real \`assessInterruptedSession\` fixture tests remain.

## Test plan

- [x] All 11 remaining tests pass locally.
- [ ] CI green.

## Follow-up

- Runtime coverage of \`connectServer\` / \`closeAll\` with a mocked failing transport (mcp-client-security).
- Runtime drive of \`guided-flow\` observing \`pendingAutoStartMap.set\` side effect (interrupted-session-ui).

Filing as separate tracking issue.

Refs #4784.