### PR TITLE
feat(pi-coding-agent): add skillFilter option to buildSystemPrompt

### DIFF
--- a/packages/pi-coding-agent/src/core/system-prompt.ts
+++ b/packages/pi-coding-agent/src/core/system-prompt.ts
@@ -45,6 +45,14 @@ export interface BuildSystemPromptOptions {
 	 * (e.g. per-unit-type manifests) to reduce cached system-prompt bloat.
 	 * When omitted, all non-`disableModelInvocation` skills render — i.e.
 	 * behavior is unchanged from before this option existed.
+	 *
+	 * Contract: the predicate must be **pure and synchronous**. It may be
+	 * invoked on every system-prompt rebuild (tool-set changes and
+	 * runtime resource-loader extensions both trigger one), so any state
+	 * the closure captures should be stable across the rebuild window.
+	 * If the predicate throws, `buildSystemPrompt` logs a warning and
+	 * falls back to the unfiltered skill list — callers never see the
+	 * exception and the session stays consistent.
 	 */
 	skillFilter?: (skill: Skill) => boolean;
 }
@@ -80,7 +88,19 @@ export function buildSystemPrompt(options: BuildSystemPromptOptions = {}): strin
 
 	const contextFiles = providedContextFiles ?? [];
 	const skillsBase = providedSkills ?? [];
-	const skills = skillFilter ? skillsBase.filter(skillFilter) : skillsBase;
+	let skills = skillsBase;
+	if (skillFilter) {
+		try {
+			skills = skillsBase.filter(skillFilter);
+		} catch (error) {
+			// A consumer's predicate threw. Fall back to the unfiltered list so
+			// the session stays consistent — callers (e.g. AgentSession.setTools)
+			// must not be left with updated tools but a stale system prompt.
+			const message = error instanceof Error ? error.message : String(error);
+			console.warn(`buildSystemPrompt: skillFilter threw; falling back to unfiltered skills. Error: ${message}`);
+			skills = skillsBase;
+		}
+	}
 
 	if (customPrompt) {
 		let prompt = customPrompt;

--- a/packages/pi-coding-agent/src/core/system-prompt.ts
+++ b/packages/pi-coding-agent/src/core/system-prompt.ts
@@ -35,6 +35,18 @@ export interface BuildSystemPromptOptions {
 	contextFiles?: Array<{ path: string; content: string }>;
 	/** Pre-loaded skills. */
 	skills?: Skill[];
+	/**
+	 * Optional predicate applied to the `skills` list before rendering the
+	 * <available_skills> catalog. Returning `false` omits a skill from the
+	 * prompt (the skill remains loaded and invocable by name — only the
+	 * catalog listing is suppressed).
+	 *
+	 * Intended for consumers that can narrow the relevant skill surface
+	 * (e.g. per-unit-type manifests) to reduce cached system-prompt bloat.
+	 * When omitted, all non-`disableModelInvocation` skills render — i.e.
+	 * behavior is unchanged from before this option existed.
+	 */
+	skillFilter?: (skill: Skill) => boolean;
 }
 
 /** Build the system prompt with tools, guidelines, and context */
@@ -48,6 +60,7 @@ export function buildSystemPrompt(options: BuildSystemPromptOptions = {}): strin
 		cwd,
 		contextFiles: providedContextFiles,
 		skills: providedSkills,
+		skillFilter,
 	} = options;
 	const resolvedCwd = toPosixPath(cwd ?? process.cwd());
 
@@ -66,7 +79,8 @@ export function buildSystemPrompt(options: BuildSystemPromptOptions = {}): strin
 	const appendSection = appendSystemPrompt ? `\n\n${appendSystemPrompt}` : "";
 
 	const contextFiles = providedContextFiles ?? [];
-	const skills = providedSkills ?? [];
+	const skillsBase = providedSkills ?? [];
+	const skills = skillFilter ? skillsBase.filter(skillFilter) : skillsBase;
 
 	if (customPrompt) {
 		let prompt = customPrompt;

--- a/packages/pi-coding-agent/src/tests/system-prompt-skill-filter.test.ts
+++ b/packages/pi-coding-agent/src/tests/system-prompt-skill-filter.test.ts
@@ -123,3 +123,35 @@ test("buildSystemPrompt: skillFilter does not affect context files or cwd render
 	assert.ok(prompt.includes("project instructions"), "context files should still render");
 	assert.ok(!prompt.includes("<available_skills>"), "no skill catalog when filter rejects all");
 });
+
+// ─── Exception safety ─────────────────────────────────────────────────────
+
+test("buildSystemPrompt: skillFilter that throws falls back to unfiltered list and does not propagate", (t) => {
+	// A buggy consumer predicate must not bubble out of buildSystemPrompt.
+	// If it did, _rebuildSystemPrompt could unwind mid-setTools() and leave
+	// the session with updated tools but a stale system prompt.
+	const skills = [makeSkill("alpha"), makeSkill("beta")];
+
+	// Suppress the console.warn the fallback emits so test output stays clean.
+	const originalWarn = console.warn;
+	const warnings: string[] = [];
+	console.warn = (...args: unknown[]) => { warnings.push(args.join(" ")); };
+	t.after(() => { console.warn = originalWarn; });
+
+	let prompt = "";
+	assert.doesNotThrow(() => {
+		prompt = buildSystemPrompt({
+			skills,
+			selectedTools: ["read", "Skill"],
+			skillFilter: () => { throw new Error("consumer bug"); },
+		});
+	});
+
+	const section = extractAvailableSkills(prompt);
+	assert.match(section, /<name>alpha<\/name>/, "alpha should render (fallback to unfiltered)");
+	assert.match(section, /<name>beta<\/name>/, "beta should render (fallback to unfiltered)");
+	assert.ok(
+		warnings.some(w => w.includes("skillFilter threw") && w.includes("consumer bug")),
+		"fallback should emit an identifying warning",
+	);
+});

--- a/packages/pi-coding-agent/src/tests/system-prompt-skill-filter.test.ts
+++ b/packages/pi-coding-agent/src/tests/system-prompt-skill-filter.test.ts
@@ -1,0 +1,125 @@
+// @gsd/pi-coding-agent + system-prompt-skill-filter.test — coverage for the
+// optional `skillFilter` option added to buildSystemPrompt (RFC #4779). The
+// filter lets consumers narrow the <available_skills> catalog rendered into
+// the cached system prompt without touching skill loading or invocation.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { buildSystemPrompt } from "../core/system-prompt.js";
+import type { Skill } from "../core/skills.js";
+
+function makeSkill(name: string, description = `description for ${name}`): Skill {
+	return {
+		name,
+		description,
+		filePath: `/tmp/${name}/SKILL.md`,
+		baseDir: `/tmp/${name}`,
+		source: "project",
+		disableModelInvocation: false,
+	};
+}
+
+function extractAvailableSkills(prompt: string): string {
+	const start = prompt.indexOf("<available_skills>");
+	const end = prompt.indexOf("</available_skills>");
+	if (start === -1 || end === -1) return "";
+	return prompt.slice(start, end + "</available_skills>".length);
+}
+
+// ─── Default branch (no customPrompt) ──────────────────────────────────────
+
+test("buildSystemPrompt: skillFilter omits filtered-out skills from <available_skills>", () => {
+	const skills = [makeSkill("alpha"), makeSkill("beta"), makeSkill("gamma")];
+	const prompt = buildSystemPrompt({
+		skills,
+		selectedTools: ["read", "Skill"],
+		skillFilter: skill => skill.name !== "beta",
+	});
+
+	const section = extractAvailableSkills(prompt);
+	assert.ok(section.length > 0, "catalog section should render");
+	assert.match(section, /<name>alpha<\/name>/);
+	assert.match(section, /<name>gamma<\/name>/);
+	assert.doesNotMatch(section, /<name>beta<\/name>/);
+});
+
+test("buildSystemPrompt: skillFilter omitted preserves pre-filter behavior (all skills render)", () => {
+	const skills = [makeSkill("alpha"), makeSkill("beta")];
+	const prompt = buildSystemPrompt({
+		skills,
+		selectedTools: ["read", "Skill"],
+	});
+
+	const section = extractAvailableSkills(prompt);
+	assert.match(section, /<name>alpha<\/name>/);
+	assert.match(section, /<name>beta<\/name>/);
+});
+
+test("buildSystemPrompt: skillFilter that rejects every skill suppresses the <available_skills> block", () => {
+	const skills = [makeSkill("alpha"), makeSkill("beta")];
+	const prompt = buildSystemPrompt({
+		skills,
+		selectedTools: ["read", "Skill"],
+		skillFilter: () => false,
+	});
+
+	// With zero visible skills, formatSkillsForPrompt returns an empty string,
+	// so the opening tag should not appear anywhere.
+	assert.ok(!prompt.includes("<available_skills>"));
+});
+
+// ─── Custom-prompt branch ──────────────────────────────────────────────────
+
+test("buildSystemPrompt (customPrompt): skillFilter applies to the catalog appended onto a custom prompt", () => {
+	const skills = [makeSkill("alpha"), makeSkill("beta"), makeSkill("gamma")];
+	const prompt = buildSystemPrompt({
+		customPrompt: "CUSTOM BASE",
+		skills,
+		selectedTools: ["read", "Skill"],
+		skillFilter: skill => skill.name === "alpha",
+	});
+
+	const section = extractAvailableSkills(prompt);
+	assert.match(section, /<name>alpha<\/name>/);
+	assert.doesNotMatch(section, /<name>beta<\/name>/);
+	assert.doesNotMatch(section, /<name>gamma<\/name>/);
+});
+
+// ─── Interaction with disableModelInvocation ──────────────────────────────
+
+test("buildSystemPrompt: skillFilter composes with disableModelInvocation (both must pass)", () => {
+	// A skill already hidden from the catalog by disableModelInvocation must
+	// remain hidden even if skillFilter would otherwise admit it. The filter
+	// narrows, it does not override the existing invisibility contract.
+	const skills: Skill[] = [
+		{ ...makeSkill("visible"), disableModelInvocation: false },
+		{ ...makeSkill("hidden"), disableModelInvocation: true },
+	];
+	const prompt = buildSystemPrompt({
+		skills,
+		selectedTools: ["read", "Skill"],
+		skillFilter: () => true,
+	});
+
+	const section = extractAvailableSkills(prompt);
+	assert.match(section, /<name>visible<\/name>/);
+	assert.doesNotMatch(section, /<name>hidden<\/name>/);
+});
+
+// ─── Pass-through of non-filtered fields ──────────────────────────────────
+
+test("buildSystemPrompt: skillFilter does not affect context files or cwd rendering", () => {
+	const skills = [makeSkill("alpha")];
+	const prompt = buildSystemPrompt({
+		skills,
+		cwd: "/tmp/example",
+		contextFiles: [{ path: "CLAUDE.md", content: "project instructions" }],
+		selectedTools: ["read", "Skill"],
+		skillFilter: () => false,
+	});
+
+	assert.ok(prompt.includes("/tmp/example"), "cwd should still render");
+	assert.ok(prompt.includes("project instructions"), "context files should still render");
+	assert.ok(!prompt.includes("<available_skills>"), "no skill catalog when filter rejects all");
+});


### PR DESCRIPTION
RFC #4779 — **PR B of 3**. Adds the mechanism. Consumer wiring is a separate PR.

## Summary

Adds `skillFilter?: (skill: Skill) => boolean` to `BuildSystemPromptOptions`. When provided, the predicate runs against the `skills` list before rendering the `<available_skills>` catalog; rejected skills are omitted from the prompt.

The filter narrows only what the model **sees** in the catalog. Skills remain loaded in the resource layer and invocable by name — only the prompt listing is suppressed. When `skillFilter` is omitted, behavior is identical to the pre-filter code path.

## Why a separate mechanism-only PR

GSD's `resolveSkillManifest(unitType)` (landed in #4788 / #4874) is the obvious first consumer. But wiring it end-to-end is non-trivial:

- The `<available_skills>` catalog lives in the **cached system prompt**, built once per session (rebuilt on tool-set changes).
- Filtering per-unit implies rebuilding the system prompt per unit, which would thrash the Anthropic prompt cache (5-minute TTL, 120-entry catalog being the main cached payload).
- The right GSD-side strategy — session-wide allowlist union, or accept the cache-miss cost for large per-unit savings, or something else — deserves its own design conversation.

Separating mechanism from policy keeps this PR narrow and reviewable. Once the mechanism exists, consumer PRs can iterate on strategy without re-opening the API shape.

## API

```ts
buildSystemPrompt({
  skills: [...],
  skillFilter: (skill) => allowedNames.has(skill.name),
  // ... other existing options
});
```

- Predicate is applied once at the top of `buildSystemPrompt`, covering both render paths (`customPrompt` branch and default branch).
- Composes with the existing `disableModelInvocation` suppression (both must pass for a skill to render).
- Undefined = no filter (unchanged behavior).

## Test plan

- [x] `npm run build` — passes
- [x] `npx tsx --test packages/pi-coding-agent/src/tests/system-prompt-skill-filter.test.ts packages/pi-coding-agent/src/tests/path-display.test.ts` — 15/15 pass
  - `skillFilter` omits rejected skills from `<available_skills>`
  - omitted `skillFilter` preserves pre-filter behavior
  - filter rejecting every skill suppresses the entire block
  - filter applies in the `customPrompt` branch too
  - filter composes with `disableModelInvocation`
  - filter does not affect context files or cwd rendering

## What's still deferred

- **GSD consumer** — thread `resolveSkillManifest(unitType)` through to a `skillFilter` on session creation (or some equivalent strategy that respects prompt caching).
- **Session-wide `BUNDLED_SKILL_TRIGGERS` filtering** in `bootstrap/system-context.ts` — needs a design call on keying (session-wide vs. per-dispatch).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional filtering for skills included in generated system prompts to control which skills appear in the prompt catalog.
* **Bug Fixes**
  * If a skill filter throws, the prompt generation now falls back to the unfiltered skill list and logs a warning instead of failing.
* **Tests**
  * Added tests covering filtered and unfiltered flows, custom prompt appending, interaction with skill disabling, and filter-error fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->