### PR TITLE
refactor(auto): lazy-load slice summaries in complete-milestone prompt (#4780)

### DIFF
--- a/src/resources/extensions/gsd/auto-prompts.ts
+++ b/src/resources/extensions/gsd/auto-prompts.ts
@@ -249,6 +249,75 @@ export async function inlineFileSmart(
 }
 
 /**
+ * Compact slice-summary excerpt for milestone-level closers (#4780).
+ *
+ * Emits the frontmatter fields + short body section heads rather than the
+ * full SUMMARY.md body, and keeps the source path in the header so the
+ * closer agent can Read the full file on demand when drafting LEARNINGS.
+ *
+ * Scope: designed for `buildCompleteMilestonePrompt`, which previously
+ * inlined the full SUMMARY per slice and routinely paid ~300–500K tokens
+ * per close when the narrative was never synthesized. Not used by
+ * `buildValidateMilestonePrompt` yet — validate needs fuller verification
+ * evidence; follow-up PR can extend or parameterize.
+ *
+ * If parsing fails (unrecognizable frontmatter, missing id, etc.) the
+ * function falls back to `inlineFile` so the closer loses no information.
+ */
+export async function buildSliceSummaryExcerpt(
+  absPath: string | null, relPath: string, sid: string,
+): Promise<string> {
+  const header = `### ${sid} Summary (excerpt)\nSource: \`${relPath}\``;
+  const content = absPath ? await loadFile(absPath) : null;
+  if (!content) {
+    return `${header}\n\n_(not found — file does not exist yet)_`;
+  }
+  try {
+    const s = parseSummary(content);
+    if (!s.frontmatter.id) {
+      // Unrecognizable — fall back to full file so no context is lost.
+      return `### ${sid} Summary\nSource: \`${relPath}\`\n\n${content.trim()}`;
+    }
+    const lines: string[] = [header, ""];
+    if (s.title) lines.push(`**Title:** ${s.title}`);
+    if (s.oneLiner) lines.push(`**One-liner:** ${s.oneLiner}`);
+    if (s.frontmatter.verification_result) {
+      lines.push(`**Verification:** \`${s.frontmatter.verification_result}\``);
+    }
+    lines.push(`**Blockers:** ${s.frontmatter.blocker_discovered ? "⚠️ blocker recorded — Read full summary" : "none"}`);
+    if (s.frontmatter.duration) lines.push(`**Duration:** ${s.frontmatter.duration}`);
+    if (s.frontmatter.provides.length > 0) lines.push(`**Provides:** ${s.frontmatter.provides.join("; ")}`);
+    if (s.frontmatter.affects.length > 0) lines.push(`**Affects:** ${s.frontmatter.affects.join("; ")}`);
+    if (s.frontmatter.key_decisions.length > 0) lines.push(`**Key decisions:** ${s.frontmatter.key_decisions.join("; ")}`);
+    if (s.frontmatter.patterns_established.length > 0) lines.push(`**Patterns established:** ${s.frontmatter.patterns_established.join("; ")}`);
+    if (s.frontmatter.key_files.length > 0) {
+      const files = s.frontmatter.key_files.slice(0, 8);
+      const more = s.frontmatter.key_files.length > files.length ? ` (+${s.frontmatter.key_files.length - files.length} more)` : "";
+      lines.push(`**Key files:** ${files.join(", ")}${more}`);
+    }
+
+    if (s.deviations && s.deviations.trim()) {
+      lines.push("", "#### Deviations", s.deviations.trim());
+    }
+    if (s.knownLimitations && s.knownLimitations.trim()) {
+      lines.push("", "#### Known limitations", s.knownLimitations.trim());
+    }
+    if (s.followUps && s.followUps.trim()) {
+      lines.push("", "#### Follow-ups", s.followUps.trim());
+    }
+
+    lines.push(
+      "",
+      `> **On-demand:** read \`${relPath}\` for the full "What Happened" narrative, integration notes, and detailed file-change list when drafting LEARNINGS, the Decision Re-evaluation table, or cross-slice synthesis.`,
+    );
+    return lines.join("\n");
+  } catch {
+    // Defensive — any parse failure falls back to full inline.
+    return `### ${sid} Summary\nSource: \`${relPath}\`\n\n${content.trim()}`;
+  }
+}
+
+/**
  * Load and inline dependency slice summaries (full content, not just paths).
  */
 export async function inlineDependencySummaries(
@@ -1835,12 +1904,22 @@ export async function buildCompleteMilestonePrompt(
     }
   }
   const seenSlices = new Set<string>();
+  const summaryRelPaths: string[] = [];
   for (const sid of sliceIds) {
     if (seenSlices.has(sid)) continue;
     seenSlices.add(sid);
     const summaryPath = resolveSliceFile(base, mid, sid, "SUMMARY");
     const summaryRel = relSliceFile(base, mid, sid, "SUMMARY");
-    inlined.push(await inlineFile(summaryPath, summaryRel, `${sid} Summary`));
+    summaryRelPaths.push(summaryRel);
+    // Compact excerpt instead of full inline (#4780). Closer Reads the
+    // full file on-demand when synthesizing LEARNINGS narrative.
+    inlined.push(await buildSliceSummaryExcerpt(summaryPath, summaryRel, sid));
+  }
+  if (summaryRelPaths.length > 0) {
+    const pathList = summaryRelPaths.map(p => `- \`${p}\``).join("\n");
+    inlined.push(
+      `### On-demand Slice Summaries\n\nExcerpted above. Read the full file for any slice when the excerpt's section heads don't carry enough narrative for the milestone summary you're drafting:\n\n${pathList}`,
+    );
   }
 
   // Inline root GSD files (skip for minimal — completion can read these if needed)

--- a/src/resources/extensions/gsd/auto-prompts.ts
+++ b/src/resources/extensions/gsd/auto-prompts.ts
@@ -296,14 +296,26 @@ export async function buildSliceSummaryExcerpt(
       lines.push(`**Key files:** ${files.join(", ")}${more}`);
     }
 
+    // Cap section bodies (coderabbit review on #4908): if any of these
+    // narrative sections balloon, excerpt mode still inflates and
+    // undermines the token-reduction goal. 800 chars (~200 tokens) is
+    // enough to carry intent; the closer agent Reads the full file when
+    // it needs richer context for LEARNINGS synthesis.
+    const SECTION_CAP_CHARS = 800;
+    const capSection = (body: string): string => {
+      const trimmed = body.trim();
+      if (trimmed.length <= SECTION_CAP_CHARS) return trimmed;
+      return `${trimmed.slice(0, SECTION_CAP_CHARS)}\n… (truncated — see full \`${relPath}\`)`;
+    };
+
     if (s.deviations && s.deviations.trim()) {
-      lines.push("", "#### Deviations", s.deviations.trim());
+      lines.push("", "#### Deviations", capSection(s.deviations));
     }
     if (s.knownLimitations && s.knownLimitations.trim()) {
-      lines.push("", "#### Known limitations", s.knownLimitations.trim());
+      lines.push("", "#### Known limitations", capSection(s.knownLimitations));
     }
     if (s.followUps && s.followUps.trim()) {
-      lines.push("", "#### Follow-ups", s.followUps.trim());
+      lines.push("", "#### Follow-ups", capSection(s.followUps));
     }
 
     lines.push(

--- a/src/resources/extensions/gsd/prompts/complete-milestone.md
+++ b/src/resources/extensions/gsd/prompts/complete-milestone.md
@@ -14,6 +14,8 @@ Preloaded context below — the roadmap, compact slice-summary excerpts, require
 
 Start with what the excerpts give you. Read full files when the section heads signal richer context you need.
 
+**On-demand Read ordering:** Complete all slice SUMMARY Reads you need for cross-slice synthesis, the Decision Re-evaluation table, and LEARNINGS **before** calling `gsd_complete_milestone` (step 10). Once that tool runs, the milestone is marked complete in the DB — running out of tool budget between step 10 and the LEARNINGS write (step 12) leaves the milestone committed without its LEARNINGS artifact.
+
 {{inlinedContext}}
 
 Then:

--- a/src/resources/extensions/gsd/prompts/complete-milestone.md
+++ b/src/resources/extensions/gsd/prompts/complete-milestone.md
@@ -10,7 +10,9 @@ Your working directory is `{{workingDirectory}}`. All file reads, writes, and sh
 
 All slices are done. You are closing out the milestone — verifying that the assembled work actually delivers the promised outcome, writing the milestone summary, and updating project state. The milestone summary is the final record. After you finish, the system merges the worktree back to the integration branch. If there are queued milestones, the next one starts its own research → plan → execute cycle from a clean slate — the milestone summary is how it learns what was already built.
 
-All relevant context has been preloaded below — the roadmap, all slice summaries, requirements, decisions, and project context are inlined. Start working immediately without re-reading these files.
+Preloaded context below — the roadmap, compact slice-summary excerpts, requirements, decisions, and project context. **Slice summaries are excerpts, not full files.** They include frontmatter fields, section heads (deviations, known limitations, follow-ups), and short narrative only. When drafting LEARNINGS, the Decision Re-evaluation table, or cross-slice narrative, Read the full slice SUMMARY.md files listed under "On-demand Slice Summaries" — do that selectively as needed, not preemptively.
+
+Start with what the excerpts give you. Read full files when the section heads signal richer context you need.
 
 {{inlinedContext}}
 

--- a/src/resources/extensions/gsd/tests/complete-milestone-excerpt.test.ts
+++ b/src/resources/extensions/gsd/tests/complete-milestone-excerpt.test.ts
@@ -1,0 +1,231 @@
+// GSD-2 — #4780: slice-summary excerpts replace full inlining in
+// buildCompleteMilestonePrompt. Verify (a) the excerpt helper emits
+// frontmatter fields + section heads + on-demand path, (b) the closer
+// prompt lists all slice SUMMARY paths under "On-demand Slice Summaries",
+// (c) regression on prompt size.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { buildSliceSummaryExcerpt, buildCompleteMilestonePrompt } from "../auto-prompts.ts";
+import { invalidateAllCaches } from "../cache.ts";
+
+// ─── Fixture helpers ──────────────────────────────────────────────────────
+
+function createBase(): string {
+  const base = mkdtempSync(join(tmpdir(), "gsd-cm-excerpt-"));
+  mkdirSync(join(base, ".gsd", "milestones", "M001", "slices", "S01", "tasks"), { recursive: true });
+  mkdirSync(join(base, ".gsd", "milestones", "M001", "slices", "S02", "tasks"), { recursive: true });
+  return base;
+}
+
+function cleanup(base: string): void {
+  rmSync(base, { recursive: true, force: true });
+}
+
+function writeRoadmap(base: string, content: string): void {
+  writeFileSync(join(base, ".gsd", "milestones", "M001", "M001-ROADMAP.md"), content);
+}
+
+function writeSummary(base: string, sid: string, content: string): void {
+  writeFileSync(
+    join(base, ".gsd", "milestones", "M001", "slices", sid, `${sid}-SUMMARY.md`),
+    content,
+  );
+}
+
+// A summary with enough body narrative that full inlining would balloon the
+// prompt. The excerpt should keep frontmatter + sections but drop the
+// "What Happened" narrative.
+function makeFatSummary(sid: string): string {
+  const narrativePara =
+    "The team discovered several subtle integration issues, traced them to the cache layer, and produced a patch set that threads the cache key through every call site. ".repeat(20);
+  return [
+    "---",
+    `id: ${sid}`,
+    "parent: M001",
+    "milestone: M001",
+    "provides:",
+    "  - compact slice-summary excerpts",
+    "  - on-demand read path registry",
+    "affects:",
+    "  - complete-milestone prompt builder",
+    "key_decisions:",
+    "  - use parseSummary for frontmatter extraction",
+    "  - fall back to full inline when frontmatter fails",
+    "patterns_established:",
+    "  - excerpt-first inlining for closer units",
+    "key_files:",
+    "  - src/resources/extensions/gsd/auto-prompts.ts",
+    "duration: 1h",
+    "verification_result: passed",
+    "completed_at: 2026-04-24",
+    "blocker_discovered: false",
+    "---",
+    "",
+    `# ${sid}: Slice summary`,
+    "**Short one-liner for the slice**",
+    "",
+    "## What Happened",
+    "",
+    narrativePara,
+    "",
+    "## Deviations",
+    "",
+    "Extended the excerpt helper scope at review time.",
+    "",
+    "## Known Limitations",
+    "",
+    "Does not yet cover validate-milestone — follow-up.",
+    "",
+    "## Follow-ups",
+    "",
+    "- Wire the same excerpt into buildValidateMilestonePrompt",
+  ].join("\n");
+}
+
+function makeRoadmap(): string {
+  return [
+    "# M001 Roadmap",
+    "## Slices",
+    "- [x] **S01: Excerpt helper** `risk:medium` `depends:[]`",
+    "- [x] **S02: Closer wiring** `risk:low` `depends:[S01]`",
+  ].join("\n");
+}
+
+// ─── buildSliceSummaryExcerpt unit tests ──────────────────────────────────
+
+test("#4780 excerpt: emits compact block with frontmatter fields + section heads", async (t) => {
+  const base = createBase();
+  t.after(() => cleanup(base));
+  invalidateAllCaches();
+
+  const absPath = join(base, ".gsd", "milestones", "M001", "slices", "S01", "S01-SUMMARY.md");
+  const relPath = ".gsd/milestones/M001/slices/S01/S01-SUMMARY.md";
+  writeSummary(base, "S01", makeFatSummary("S01"));
+
+  const out = await buildSliceSummaryExcerpt(absPath, relPath, "S01");
+
+  // Compact header with source path for on-demand Read
+  assert.match(out, /### S01 Summary \(excerpt\)/);
+  assert.match(out, /Source: `\.gsd\/milestones\/M001\/slices\/S01\/S01-SUMMARY\.md`/);
+
+  // Frontmatter fields surfaced
+  assert.match(out, /\*\*Title:\*\* S01: Slice summary/);
+  assert.match(out, /\*\*One-liner:\*\*/);
+  assert.match(out, /\*\*Verification:\*\* `passed`/);
+  assert.match(out, /\*\*Blockers:\*\* none/);
+  assert.match(out, /\*\*Provides:\*\* compact slice-summary excerpts;/);
+  assert.match(out, /\*\*Key decisions:\*\* use parseSummary/);
+  assert.match(out, /\*\*Patterns established:\*\* excerpt-first inlining/);
+
+  // Section heads included (body-section markdown), not whole sections inlined
+  assert.match(out, /#### Deviations/);
+  assert.match(out, /#### Known limitations/);
+  assert.match(out, /#### Follow-ups/);
+
+  // On-demand instruction present
+  assert.match(out, /On-demand.*read.*for the full "What Happened"/);
+
+  // Bulk narrative is NOT inlined — excerpt is meaningfully shorter than full
+  // A 20x-repeated paragraph produces ~2.5KB; excerpt should come in well under.
+  const fullSize = makeFatSummary("S01").length;
+  assert.ok(
+    out.length < fullSize * 0.6,
+    `excerpt length ${out.length} should be < 60% of full summary length ${fullSize}`,
+  );
+});
+
+test("#4780 excerpt: blocker_discovered=true surfaces prominent marker", async (t) => {
+  const base = createBase();
+  t.after(() => cleanup(base));
+  invalidateAllCaches();
+
+  const content = [
+    "---",
+    "id: S01",
+    "parent: M001",
+    "milestone: M001",
+    "blocker_discovered: true",
+    "---",
+    "# S01",
+    "**One-liner**",
+    "",
+    "## What Happened",
+    "content",
+  ].join("\n");
+  const absPath = join(base, ".gsd", "milestones", "M001", "slices", "S01", "S01-SUMMARY.md");
+  writeSummary(base, "S01", content);
+
+  const out = await buildSliceSummaryExcerpt(absPath, "rel", "S01");
+  assert.match(out, /Blockers:\*\* ⚠️ blocker recorded/);
+});
+
+test("#4780 excerpt: fall back to full inline when frontmatter is unrecognizable", async (t) => {
+  const base = createBase();
+  t.after(() => cleanup(base));
+  invalidateAllCaches();
+
+  // No frontmatter, no id — parser returns empty id, triggering fallback
+  const garbage = "# S99\n\nJust a wall of text with no frontmatter at all.\n";
+  const absPath = join(base, ".gsd", "milestones", "M001", "slices", "S01", "S99-SUMMARY.md");
+  writeFileSync(absPath, garbage);
+
+  const out = await buildSliceSummaryExcerpt(absPath, "rel/path.md", "S99");
+  // Full content preserved (no excerpt wrapper), no data-loss
+  assert.match(out, /Just a wall of text/);
+  assert.match(out, /### S99 Summary/);
+});
+
+test("#4780 excerpt: missing file reports not-found fallback", async (t) => {
+  const base = createBase();
+  t.after(() => cleanup(base));
+
+  const out = await buildSliceSummaryExcerpt(null, "rel/missing.md", "S42");
+  assert.match(out, /### S42 Summary \(excerpt\)/);
+  assert.match(out, /not found — file does not exist yet/);
+});
+
+// ─── buildCompleteMilestonePrompt integration test ─────────────────────────
+
+test("#4780 closer prompt: uses excerpts + lists on-demand slice SUMMARY paths", async (t) => {
+  const base = createBase();
+  t.after(() => cleanup(base));
+  invalidateAllCaches();
+
+  writeRoadmap(base, makeRoadmap());
+  writeSummary(base, "S01", makeFatSummary("S01"));
+  writeSummary(base, "S02", makeFatSummary("S02"));
+
+  const prompt = await buildCompleteMilestonePrompt("M001", "Test Milestone", base);
+
+  // Excerpt markers present for each slice
+  assert.match(prompt, /### S01 Summary \(excerpt\)/);
+  assert.match(prompt, /### S02 Summary \(excerpt\)/);
+
+  // On-demand path section exists with both slice paths
+  assert.match(prompt, /### On-demand Slice Summaries/);
+  assert.match(prompt, /S01-SUMMARY\.md/);
+  assert.match(prompt, /S02-SUMMARY\.md/);
+
+  // Fat narrative (the 20x-repeated paragraph) is NOT inlined
+  assert.ok(
+    !prompt.includes("threads the cache key through every call site."),
+    "closer prompt must not inline full 'What Happened' narrative after #4780",
+  );
+
+  // Prompt size is bounded — the two fat summaries' narratives alone would
+  // have exceeded ~4KB each. Post-fix closer prompt should be meaningfully
+  // smaller than their combined raw size.
+  const rawSize = makeFatSummary("S01").length + makeFatSummary("S02").length;
+  // Prompt includes roadmap, templates, and other inlines, so it may still
+  // be sizable — the guard is specifically that the fat narrative is gone.
+  // Use a soft bound: prompt - overhead should be less than 2x one summary.
+  assert.ok(
+    prompt.length < rawSize + 20_000,
+    `closer prompt length ${prompt.length} should be < raw summary size ${rawSize} + 20KB headroom`,
+  );
+});

--- a/src/resources/extensions/gsd/tests/complete-milestone-excerpt.test.ts
+++ b/src/resources/extensions/gsd/tests/complete-milestone-excerpt.test.ts
@@ -189,6 +189,38 @@ test("#4780 excerpt: missing file reports not-found fallback", async (t) => {
   assert.match(out, /not found — file does not exist yet/);
 });
 
+test("#4780 excerpt: section bodies are capped (coderabbit review)", async (t) => {
+  const base = createBase();
+  t.after(() => cleanup(base));
+  invalidateAllCaches();
+
+  // Long Follow-ups section (~4.8KB) would balloon the excerpt without
+  // the cap — regression coverage for the coderabbit finding on #4908.
+  const longFollowUps = "A verbose follow-up bullet that keeps restating the same point. ".repeat(60);
+  const content = [
+    "---",
+    "id: S01",
+    "parent: M001",
+    "milestone: M001",
+    "---",
+    "# S01: Test",
+    "**One-liner**",
+    "",
+    "## Follow-ups",
+    longFollowUps,
+  ].join("\n");
+  const absPath = join(base, ".gsd", "milestones", "M001", "slices", "S01", "S01-SUMMARY.md");
+  writeSummary(base, "S01", content);
+
+  const out = await buildSliceSummaryExcerpt(absPath, "rel/path.md", "S01");
+
+  assert.match(out, /\(truncated — see full `rel\/path\.md`\)/);
+  assert.ok(
+    out.length < 2000,
+    `excerpt length ${out.length} should be well under 2KB when one section hits the cap`,
+  );
+});
+
 // ─── buildCompleteMilestonePrompt integration test ─────────────────────────
 
 test("#4780 closer prompt: uses excerpts + lists on-demand slice SUMMARY paths", async (t) => {

--- a/src/resources/extensions/gsd/tests/validate-milestone.test.ts
+++ b/src/resources/extensions/gsd/tests/validate-milestone.test.ts
@@ -271,6 +271,7 @@ Test
     assert.match(prompt, /S01 Summary/i, "prompt should inline non-skipped slice summaries");
     assert.doesNotMatch(prompt, /### S02 Summary/i, "prompt should not inline skipped slice summaries");
     assert.doesNotMatch(prompt, /not found — file does not exist yet/i, "prompt should not emit skipped-slice missing-file placeholders");
+    assert.doesNotMatch(prompt, /S02-SUMMARY\.md/, "skipped slice must not appear in on-demand path list (#4780)");
   } finally {
     cleanup(base);
   }


### PR DESCRIPTION
## TL;DR

**What:** Replace full-inline slice `SUMMARY.md` content in `buildCompleteMilestonePrompt` with compact excerpts plus an on-demand path list the closer reads selectively.
**Why:** On the b23 forensic session, the single `complete-milestone` unit consumed **1.16M tokens / \$0.66 (20% of session cost)** to produce a ~65-line `M001-SUMMARY.md`. Per-slice SUMMARY bodies dominated that context but the closer rarely needed the full narrative — it needed frontmatter fields + section heads.
**How:** New `buildSliceSummaryExcerpt` helper uses `parseSummary` to emit a compact block (title, one-liner, verification, blockers, provides, affects, key_decisions, patterns, key_files, duration, section heads). Full narrative moves to on-demand via a listed-path block. Parse failure or missing `id` falls back to full inline — no data loss.

## What

- `src/resources/extensions/gsd/auto-prompts.ts`
  - New exported `buildSliceSummaryExcerpt(absPath, relPath, sid)` (+67 lines, adjacent to the existing `inlineFile*` helpers).
  - `buildCompleteMilestonePrompt` swaps the per-slice `inlineFile(...)` call for `buildSliceSummaryExcerpt(...)` and appends a new `### On-demand Slice Summaries` block listing every slice SUMMARY path so the closer can Read selectively.
- `src/resources/extensions/gsd/prompts/complete-milestone.md`
  - Preloaded-context language updated: slice summaries are excerpts, full Reads are on-demand when section heads signal richer context is needed.
- `src/resources/extensions/gsd/tests/complete-milestone-excerpt.test.ts` (new, 231 lines, 5 tests)
  - Behavior tests: frontmatter surfacing, blocker marker, unrecognized-frontmatter fallback, missing-file fallback, closer-prompt integration test that proves the fat narrative is excluded and all slice paths are listed for on-demand Read.

## Why

Closes #4780.

Peer review (Codex) on the RFC pinpointed `auto-prompts.ts` `buildCompleteMilestonePrompt` as the real inlining site, not `tools/complete-milestone.ts` (which is a DB-write + markdown-render handler with no prompt surface). This PR edits only the prompt-builder path.

The closer template consumes compact fields (`successCriteriaResults`, `keyDecisions`, `keyFiles`, `lessonsLearned`, `requirementOutcomes`) — all backed by `SummaryFrontmatter` which the excerpt surfaces directly. Fat narrative (`What Happened`, detailed file-change lists) is only needed when the closer drafts cross-slice synthesis, which it can still access on-demand via the listed SUMMARY paths.

## How

### Excerpt shape

```
### S01 Summary (excerpt)
Source: `.gsd/milestones/M001/slices/S01/S01-SUMMARY.md`

**Title:** ...
**One-liner:** ...
**Verification:** `passed`
**Blockers:** none
**Duration:** ...
**Provides:** ...
**Affects:** ...
**Key decisions:** ...
**Patterns established:** ...
**Key files:** ... (first 8, + "+N more" if truncated)

#### Deviations
<section content, only when non-empty>

#### Known limitations
<section content, only when non-empty>

#### Follow-ups
<section content, only when non-empty>

> On-demand: read `...` for the full "What Happened" narrative, integration notes, and detailed file-change list when drafting LEARNINGS, the Decision Re-evaluation table, or cross-slice synthesis.
```

### Safety invariants

- **No data loss on parse failure** — if `parseSummary` returns empty `id` (garbage frontmatter, unrecognized format), the helper falls back to full `inlineFile`-shape output.
- **No data loss on missing file** — reports "not found" in the same shape as existing helpers.
- **On-demand path always listed** — the closer knows exactly where to Read when it needs the full body.
- **Blocker marker is loud** — `blocker_discovered: true` surfaces "⚠️ blocker recorded — Read full summary" to avoid excerpting away the one field the closer must not miss.

### Scope

- `buildCompleteMilestonePrompt` only. `buildValidateMilestonePrompt` has the same inline pattern but needs fuller verification evidence (uses UAT-RESULT artifacts, VERIFY.json aggregates); follow-up PR can extend/parameterize the helper.
- No DB schema change, no tool change, no handler change.
- No coordination conflict with open PR #4768 (touches `auto-recovery.ts` + `prompts/complete-milestone.md` for a 1-line change — different text region than this PR's edit; rebase should be trivial for whichever lands second).

### Local verification

**New tests: 5/5 passing.** Broader sweep: **146/146 passing** across `complete-milestone-excerpt`, `complete-milestone`, `complete-milestone-false-merge`, `prompt-contracts`, `auto-recovery`, `validate-milestone*`, `integration/complete-milestone*`.

## Change type

- [x] `refactor` — Context compression in the closer prompt; no behavior change to tool dispatch, handlers, or artifact schemas

## Breaking changes

**Behavior change for complete-milestone unit's context shape:** the closer now receives slice summary excerpts instead of full bodies. In the common case the template fields are covered by excerpt frontmatter and outputs are unchanged. In the rare case where the closer would have relied on full narrative inline, it now Reads on-demand — same information, one tool call.

If the on-demand Read call pattern exposes closer-quality regressions in practice, the fallback branch (`parseSummary` failure → full inline) gives an immediate safety valve; follow-up PR can extend or parameterize the excerpt shape per manifest entry once #4782 lands.

AI-assisted PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Slice summaries now appear as compact excerpts with key metadata, conditional sections (deviations, limitations, follow-ups), and an explicit on-demand pointer to full slice narratives; a consolidated “On-demand Slice Summaries” list guides selective reads before milestone completion.

* **Bug Fixes**
  * Skipped slices are excluded from prompts and on-demand lists; missing or unparseable summaries yield clear fallback or not-found messages.

* **Tests**
  * Added tests for excerpt generation, prompt sizing, fallback behaviors, and skipped/missing-summary handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->