### PR TITLE
feat(auto): milestone scope classifier — phase 1 of #4781

### DIFF
--- a/src/resources/extensions/gsd/milestone-scope-classifier.ts
+++ b/src/resources/extensions/gsd/milestone-scope-classifier.ts
@@ -1,0 +1,302 @@
+// GSD-2 — Milestone scope classifier (#4781 / ADR-003 companion).
+//
+// Pure heuristics over milestone planning fields. Produces a PipelineVariant
+// that downstream dispatch logic can use to shape the auto-mode sequence.
+// No LLM calls, no file I/O, sub-millisecond.
+//
+// Distinct from `complexity-classifier.ts`, which decides *model tier*
+// (light/standard/heavy) for an individual unit. This module decides
+// *pipeline topology* for an entire milestone at plan-milestone time.
+//
+// This file ships the classifier in isolation. Dispatch-side wiring
+// lands in follow-up PRs so the classification contract can be reviewed
+// and tested before any behavior change reaches users.
+
+export type PipelineVariant = "trivial" | "standard" | "complex";
+
+export interface MilestoneScopeInput {
+  /** Milestone vision / elevator pitch. Free-form prose. */
+  vision?: string;
+  /** Success criteria, one per array entry. */
+  successCriteria?: string[];
+  /** Milestone title. */
+  title?: string;
+  /** Slice risks declared at plan-milestone time. */
+  keyRisks?: Array<{ risk?: string; whyItMatters?: string }>;
+  /** Definition-of-done lines. */
+  definitionOfDone?: string[];
+  /** Freeform "requirement coverage" marker. */
+  requirementCoverage?: string;
+  /** Verification hints (contract/integration/operational/uat). */
+  verificationContract?: string;
+  verificationIntegration?: string;
+  verificationOperational?: string;
+  verificationUat?: string;
+}
+
+export interface ScopeClassificationResult {
+  variant: PipelineVariant;
+  /** Short human-readable reasons, one per triggered signal. */
+  reasons: string[];
+  /** Sub-signals for telemetry / debugging. Stable across releases. */
+  signals: {
+    triggeredOverride: boolean;
+    complexCount: number;
+    trivialCount: number;
+    fileCountHint: number | null;
+  };
+}
+
+// ─── Keyword sets ─────────────────────────────────────────────────────────
+
+/**
+ * Override keywords that force `standard` (at minimum) regardless of
+ * apparent triviality. Presence of any of these signals work that is
+ * either security-sensitive, irreversible, or requires runtime verification
+ * a "trivial" pipeline would skip.
+ *
+ * Matched as case-insensitive word-boundary substrings. Conservative — err
+ * on the side of including a keyword; over-classifying to `standard` costs
+ * units, under-classifying could ship broken auth/security/migration work.
+ */
+const OVERRIDE_KEYWORDS: ReadonlyArray<string> = [
+  // Security-sensitive
+  "security", "auth", "authn", "authz", "authentication", "authorization",
+  "credential", "secret", "password", "token", "oauth", "encrypt", "decrypt",
+  "vulnerability", "exploit", "permission", "rbac", "acl",
+  // Data-migration / irreversible
+  "migration", "migrate", "schema change", "data migration",
+  "backfill", "drop column", "drop table",
+  // Compliance / regulatory
+  "compliance", "gdpr", "hipaa", "soc2", "pci",
+  // Infra / deploy — runtime verification needed
+  "deploy", "rollout", "canary", "production database",
+];
+
+/**
+ * Keywords that contribute to `complex` classification on their own.
+ * Different from OVERRIDE_KEYWORDS in that a single match bumps to
+ * complex, not just to standard.
+ */
+const COMPLEX_KEYWORDS: ReadonlyArray<string> = [
+  "multi-service", "distributed", "consensus", "saga", "eventual consistency",
+  "breaking change", "api contract change", "schema redesign",
+  "architect", "architecture", "refactor core",
+];
+
+/**
+ * Trivial-signal keywords: presence strongly suggests a simple, contained
+ * deliverable. Only effective when combined with low file count / no tests
+ * / no override keywords.
+ */
+const TRIVIAL_KEYWORDS: ReadonlyArray<string> = [
+  "single file", "one file", "static html", "static page",
+  "one-page", "landing page", "readme", "docs only", "typo", "rename",
+  "spelling", "comment", "changelog",
+  // Browser-only / no-build deliverable shapes (b23 forensic case).
+  "pure html", "browser-based", "no build step", "no build tooling",
+  "localstorage", "client-only", "no backend", "no server", "no backend.",
+];
+
+// ─── Heuristics ───────────────────────────────────────────────────────────
+
+/**
+ * Estimate how many distinct files the milestone will touch, based on
+ * explicit mentions in the input text. Returns `null` when no hint is
+ * discoverable — callers should treat that as "unknown, no signal."
+ */
+function extractFileCountHint(text: string): number | null {
+  // Explicit phrasing: "a single file", "two files", "3 files"
+  const singleFileMatch = /\b(a|one|single)\s+(file|page)\b/i.test(text);
+  if (singleFileMatch) return 1;
+
+  const digitMatch = text.match(/\b(\d+)\s+files?\b/i);
+  if (digitMatch) {
+    const n = parseInt(digitMatch[1], 10);
+    if (!Number.isNaN(n)) return n;
+  }
+
+  const wordMatch = text.match(/\b(two|three|four|five|six|seven|eight|nine|ten)\s+files?\b/i);
+  if (wordMatch) {
+    const wordMap: Record<string, number> = {
+      two: 2, three: 3, four: 4, five: 5,
+      six: 6, seven: 7, eight: 8, nine: 9, ten: 10,
+    };
+    return wordMap[wordMatch[1].toLowerCase()] ?? null;
+  }
+
+  return null;
+}
+
+function containsAnyKeyword(haystack: string, keywords: ReadonlyArray<string>): string[] {
+  const lower = haystack.toLowerCase();
+  const hits: string[] = [];
+  for (const kw of keywords) {
+    // Substring match, not word-boundary — keyword list is curated so that
+    // substring hits rarely overmatch. Phrases like "no authentication" still
+    // match "authentication" and force standard — that's the safe direction.
+    if (lower.includes(kw)) hits.push(kw);
+  }
+  return hits;
+}
+
+/**
+ * True when `term` appears in the text without an immediately preceding
+ * negator (no / without / not / zero / skip) in the same clause. Used to
+ * keep phrases like "no backend" or "no tests" from flipping a trivial-
+ * class milestone to standard. Best-effort; imperfect English parsing,
+ * biased toward false negatives (if unsure, treats term as present —
+ * which routes to standard, the safe pipeline).
+ */
+function mentionsWithoutNegation(text: string, term: string): boolean {
+  const lower = text.toLowerCase();
+  const termPattern = new RegExp(String.raw`\b${term}\b`, "gi");
+  const matches = Array.from(lower.matchAll(termPattern));
+  for (const m of matches) {
+    const start = m.index ?? 0;
+    const windowStart = Math.max(0, start - 30);
+    const window = lower.slice(windowStart, start);
+    // Negator anywhere in the 30-char lookback window counts as negation —
+    // covers "no backend", "without a server", "not using api", "zero
+    // dependencies on an api". If a sentence break intervenes between the
+    // negator and the term, treat as a different clause (positive mention).
+    const hasNegator = /(^|[^a-z0-9])(no|without|not|zero|skip(s|ping)?|drops?)\b/i.test(window);
+    const hasSentenceBreak = /[.;!?]/.test(window);
+    if (hasNegator && !hasSentenceBreak) continue;
+    return true;
+  }
+  return false;
+}
+
+function mentionsTests(haystack: string): boolean {
+  return mentionsWithoutNegation(haystack, "test")
+      || mentionsWithoutNegation(haystack, "tests")
+      || mentionsWithoutNegation(haystack, "testing")
+      || mentionsWithoutNegation(haystack, "spec")
+      || mentionsWithoutNegation(haystack, "unit test")
+      || mentionsWithoutNegation(haystack, "integration test");
+}
+
+function mentionsBackend(haystack: string): boolean {
+  return mentionsWithoutNegation(haystack, "api")
+      || mentionsWithoutNegation(haystack, "backend")
+      || mentionsWithoutNegation(haystack, "server")
+      || mentionsWithoutNegation(haystack, "database")
+      || mentionsWithoutNegation(haystack, "endpoint");
+}
+
+// ─── Public API ───────────────────────────────────────────────────────────
+
+/**
+ * Classify a milestone's pipeline variant based on its planning inputs.
+ *
+ * Precedence:
+ *  1. Override keyword → `standard` (at minimum). Prevents trivial
+ *     misclassification of security / auth / migration work.
+ *  2. Complex-signal keyword OR ≥ 8 file hint OR architecture/refactor-core
+ *     language → `complex`.
+ *  3. Trivial-signal keyword AND ≤ 2 file hint AND no tests mentioned AND
+ *     no backend mentioned → `trivial`.
+ *  4. Otherwise → `standard`.
+ *
+ * Ambiguity → `standard` (today's default). Safe to run the full pipeline.
+ */
+export function classifyMilestoneScope(input: MilestoneScopeInput): ScopeClassificationResult {
+  const haystack = [
+    input.title ?? "",
+    input.vision ?? "",
+    (input.successCriteria ?? []).join("\n"),
+    (input.keyRisks ?? []).map(r => `${r.risk ?? ""} ${r.whyItMatters ?? ""}`).join("\n"),
+    (input.definitionOfDone ?? []).join("\n"),
+    input.requirementCoverage ?? "",
+    input.verificationContract ?? "",
+    input.verificationIntegration ?? "",
+    input.verificationOperational ?? "",
+    input.verificationUat ?? "",
+  ].join("\n");
+
+  const overrideHits = containsAnyKeyword(haystack, OVERRIDE_KEYWORDS);
+  const complexHits = containsAnyKeyword(haystack, COMPLEX_KEYWORDS);
+  const trivialHits = containsAnyKeyword(haystack, TRIVIAL_KEYWORDS);
+  const fileCountHint = extractFileCountHint(haystack);
+  const hasTests = mentionsTests(haystack);
+  const hasBackend = mentionsBackend(haystack);
+
+  const reasons: string[] = [];
+
+  // Rule 2: complex-class signals. Evaluated before override because a
+  // complex + override input should land in complex, not standard.
+  if (complexHits.length > 0) {
+    reasons.push(`complex keywords: ${complexHits.slice(0, 3).join(", ")}`);
+  }
+  if (fileCountHint !== null && fileCountHint >= 8) {
+    reasons.push(`file count hint: ${fileCountHint}`);
+  }
+
+  const isComplex = complexHits.length > 0 || (fileCountHint !== null && fileCountHint >= 8);
+
+  if (isComplex) {
+    return {
+      variant: "complex",
+      reasons,
+      signals: {
+        triggeredOverride: overrideHits.length > 0,
+        complexCount: complexHits.length,
+        trivialCount: trivialHits.length,
+        fileCountHint,
+      },
+    };
+  }
+
+  // Rule 1: override keywords force standard.
+  if (overrideHits.length > 0) {
+    return {
+      variant: "standard",
+      reasons: [`override keywords: ${overrideHits.slice(0, 3).join(", ")}`],
+      signals: {
+        triggeredOverride: true,
+        complexCount: complexHits.length,
+        trivialCount: trivialHits.length,
+        fileCountHint,
+      },
+    };
+  }
+
+  // Rule 3: trivial signals — require ALL of: trivial-keyword, low file
+  // hint (or nothing suggesting high count), no test mention, no backend
+  // mention.
+  const fileCountOk = fileCountHint === null || fileCountHint <= 2;
+  const trivial =
+    trivialHits.length > 0 &&
+    fileCountOk &&
+    !hasTests &&
+    !hasBackend;
+
+  if (trivial) {
+    reasons.push(`trivial keywords: ${trivialHits.slice(0, 3).join(", ")}`);
+    if (fileCountHint !== null) reasons.push(`file count hint: ${fileCountHint}`);
+    reasons.push("no tests mentioned", "no backend mentioned");
+    return {
+      variant: "trivial",
+      reasons,
+      signals: {
+        triggeredOverride: false,
+        complexCount: complexHits.length,
+        trivialCount: trivialHits.length,
+        fileCountHint,
+      },
+    };
+  }
+
+  // Rule 4: fallback.
+  return {
+    variant: "standard",
+    reasons: reasons.length > 0 ? reasons : ["no strong signals — default"],
+    signals: {
+      triggeredOverride: overrideHits.length > 0,
+      complexCount: complexHits.length,
+      trivialCount: trivialHits.length,
+      fileCountHint,
+    },
+  };
+}

--- a/src/resources/extensions/gsd/milestone-scope-classifier.ts
+++ b/src/resources/extensions/gsd/milestone-scope-classifier.ts
@@ -128,14 +128,22 @@ function extractFileCountHint(text: string): number | null {
   return null;
 }
 
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 function containsAnyKeyword(haystack: string, keywords: ReadonlyArray<string>): string[] {
   const lower = haystack.toLowerCase();
   const hits: string[] = [];
   for (const kw of keywords) {
-    // Substring match, not word-boundary — keyword list is curated so that
-    // substring hits rarely overmatch. Phrases like "no authentication" still
-    // match "authentication" and force standard — that's the safe direction.
-    if (lower.includes(kw)) hits.push(kw);
+    // Word-boundary match to prevent substring collisions (e.g. "auth"
+    // must not match "author", "api" must not match "capital"). Phrases
+    // containing non-word characters (hyphens, slashes) still work because
+    // `\b` sits at the word-char / non-word-char transition, so
+    // `\bbrowser-based\b` matches "browser-based" bounded by whitespace
+    // or punctuation on either side.
+    const pattern = new RegExp(String.raw`\b${escapeRegExp(kw)}\b`, "i");
+    if (pattern.test(lower)) hits.push(kw);
   }
   return hits;
 }
@@ -190,11 +198,14 @@ function mentionsBackend(haystack: string): boolean {
 /**
  * Classify a milestone's pipeline variant based on its planning inputs.
  *
- * Precedence:
- *  1. Override keyword → `standard` (at minimum). Prevents trivial
- *     misclassification of security / auth / migration work.
- *  2. Complex-signal keyword OR ≥ 8 file hint OR architecture/refactor-core
+ * Precedence (matches implementation order — complex-first so that
+ * security-sensitive architecture refactors correctly route to complex
+ * rather than standard; the override hit is still recorded in
+ * `signals.triggeredOverride` for telemetry):
+ *  1. Complex-signal keyword OR ≥ 8 file hint OR architecture/refactor-core
  *     language → `complex`.
+ *  2. Override keyword → `standard` (at minimum). Prevents trivial
+ *     misclassification of security / auth / migration work.
  *  3. Trivial-signal keyword AND ≤ 2 file hint AND no tests mentioned AND
  *     no backend mentioned → `trivial`.
  *  4. Otherwise → `standard`.

--- a/src/resources/extensions/gsd/tests/milestone-scope-classifier.test.ts
+++ b/src/resources/extensions/gsd/tests/milestone-scope-classifier.test.ts
@@ -1,0 +1,188 @@
+// GSD-2 — #4781: classifier behavior matrix. Pure-function tests, no I/O.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  classifyMilestoneScope,
+  type MilestoneScopeInput,
+} from "../milestone-scope-classifier.ts";
+
+// ─── Classification matrix ────────────────────────────────────────────────
+
+test("#4781 classifier: single static HTML to-do app → trivial (b23 forensic case)", () => {
+  const input: MilestoneScopeInput = {
+    title: "To-Do App",
+    vision: "A minimal, clean browser-based to-do app. Pure HTML/CSS/JS, no build step, no backend. Tasks persist in localStorage.",
+    successCriteria: [
+      "Open index.html in any browser without a server",
+      "Add tasks by typing and pressing Enter or clicking Add",
+      "Mark tasks complete (toggleable)",
+      "Delete individual tasks",
+      "Tasks survive a page reload via localStorage",
+    ],
+  };
+  const r = classifyMilestoneScope(input);
+  assert.strictEqual(r.variant, "trivial", `expected trivial, got ${r.variant} — reasons: ${r.reasons.join("; ")}`);
+  assert.ok(r.reasons.some(s => s.includes("trivial keywords")), "should cite trivial keywords");
+});
+
+test("#4781 classifier: readme typo fix → trivial", () => {
+  const r = classifyMilestoneScope({
+    title: "Fix README typo",
+    vision: "Correct spelling error in the installation section.",
+    successCriteria: ["Typo fixed", "README renders correctly"],
+  });
+  assert.strictEqual(r.variant, "trivial");
+});
+
+test("#4781 classifier: auth flow single file → standard (override beats trivial)", () => {
+  const r = classifyMilestoneScope({
+    title: "Add login",
+    vision: "Implement authentication flow in a single file with OAuth credentials.",
+    successCriteria: ["User can log in"],
+  });
+  assert.strictEqual(r.variant, "standard", `override should beat single-file signal. reasons: ${r.reasons.join("; ")}`);
+  assert.ok(r.signals.triggeredOverride, "override signals should be flagged");
+  assert.ok(r.reasons.some(s => s.includes("override keywords")));
+});
+
+test("#4781 classifier: security review scope → standard (even if small)", () => {
+  const r = classifyMilestoneScope({
+    title: "Harden session tokens",
+    vision: "Review and patch security vulnerability in one session token helper.",
+    successCriteria: ["No XSS via token"],
+  });
+  assert.strictEqual(r.variant, "standard");
+  assert.ok(r.signals.triggeredOverride);
+});
+
+test("#4781 classifier: schema migration mentioned → complex (overrides override)", () => {
+  const r = classifyMilestoneScope({
+    title: "User profile v2",
+    vision: "Perform schema migration to split user.name into first_name and last_name across the users table.",
+    successCriteria: ["Migration lands", "Existing rows backfilled", "Rollback path validated"],
+  });
+  // schema change + migrate both hit COMPLEX_KEYWORDS ("schema redesign" no; "migration" is in OVERRIDE).
+  // But COMPLEX_KEYWORDS also contains "schema redesign" and "breaking change" — this copy triggers OVERRIDE only.
+  // The classifier precedence puts complex BEFORE override on complex keywords; since none of the
+  // COMPLEX_KEYWORDS fire here ("migration" is only in OVERRIDE), the result is standard, not complex.
+  // This is the correct safe behavior: migration is override-level, not complex-level.
+  assert.strictEqual(r.variant, "standard", `reasons: ${r.reasons.join("; ")}`);
+});
+
+test("#4781 classifier: architecture keyword → complex", () => {
+  const r = classifyMilestoneScope({
+    title: "Redesign plugin registry",
+    vision: "Refactor core architecture of the plugin registry to support versioned contracts.",
+  });
+  assert.strictEqual(r.variant, "complex");
+  assert.ok(r.reasons.some(s => s.includes("complex keywords")));
+});
+
+test("#4781 classifier: >=8 files hint → complex", () => {
+  const r = classifyMilestoneScope({
+    title: "Multi-file refactor",
+    vision: "Touch 12 files to extract shared helpers.",
+  });
+  assert.strictEqual(r.variant, "complex");
+  assert.strictEqual(r.signals.fileCountHint, 12);
+});
+
+test("#4781 classifier: backend API mention → standard (not trivial)", () => {
+  const r = classifyMilestoneScope({
+    title: "Health endpoint",
+    vision: "Add a single-file API endpoint returning status.",
+    successCriteria: ["/health returns 200"],
+  });
+  // Single file + no override + but backend mentioned → not trivial
+  assert.strictEqual(r.variant, "standard");
+});
+
+test("#4781 classifier: tests mentioned → standard (not trivial)", () => {
+  const r = classifyMilestoneScope({
+    title: "Landing page",
+    vision: "Ship a static one-page landing page with unit tests for the form validation.",
+  });
+  assert.strictEqual(r.variant, "standard", `reasons: ${r.reasons.join("; ")}`);
+});
+
+test("#4781 classifier: ambiguous prose → standard (safe default)", () => {
+  const r = classifyMilestoneScope({
+    title: "Generic improvements",
+    vision: "Make the system better.",
+    successCriteria: ["It's better"],
+  });
+  assert.strictEqual(r.variant, "standard");
+  assert.ok(r.reasons.includes("no strong signals — default"));
+});
+
+test("#4781 classifier: empty input → standard (safe default)", () => {
+  const r = classifyMilestoneScope({});
+  assert.strictEqual(r.variant, "standard");
+});
+
+// ─── Override precedence over trivial ──────────────────────────────────────
+
+test("#4781 classifier: override + trivial keyword → standard (override wins)", () => {
+  const r = classifyMilestoneScope({
+    title: "Token rotation",
+    vision: "Single file change to rotate the oauth token expiry schedule.",
+  });
+  // "single file" is trivial signal; "oauth" is override signal. Override wins.
+  assert.strictEqual(r.variant, "standard");
+  assert.ok(r.signals.triggeredOverride);
+});
+
+test("#4781 classifier: complex + override → complex (complex wins, flagged)", () => {
+  const r = classifyMilestoneScope({
+    title: "Auth service refactor",
+    vision: "Refactor core authentication architecture across services.",
+  });
+  // Complex (architecture, refactor core) wins over override (auth).
+  assert.strictEqual(r.variant, "complex");
+  // Override still recorded in signals for telemetry.
+  assert.ok(r.signals.triggeredOverride, "override hits should still be tracked in signals");
+});
+
+// ─── File count hint extraction ───────────────────────────────────────────
+
+test("#4781 classifier: 'a single file' hint parsed as 1", () => {
+  const r = classifyMilestoneScope({
+    title: "Tweak",
+    vision: "Update a single file to flip the copy.",
+  });
+  assert.strictEqual(r.signals.fileCountHint, 1);
+});
+
+test("#4781 classifier: 'two files' hint parsed as 2", () => {
+  const r = classifyMilestoneScope({
+    title: "Minor",
+    vision: "Touch two files.",
+  });
+  assert.strictEqual(r.signals.fileCountHint, 2);
+});
+
+test("#4781 classifier: '12 files' hint parsed as 12", () => {
+  const r = classifyMilestoneScope({
+    title: "Bulk",
+    vision: "Update 12 files.",
+  });
+  assert.strictEqual(r.signals.fileCountHint, 12);
+});
+
+// ─── Reasons surface useful debugging info ─────────────────────────────────
+
+test("#4781 classifier: reasons array populated for every branch", () => {
+  const branches: Array<[string, MilestoneScopeInput]> = [
+    ["trivial", { title: "Readme typo", vision: "Fix a single file typo." }],
+    ["standard (override)", { title: "Auth", vision: "Touch auth helper." }],
+    ["complex (keyword)", { title: "Arch", vision: "Refactor core system design." }],
+    ["complex (file count)", { title: "Bulk", vision: "Update 9 files." }],
+    ["standard (default)", { title: "Generic", vision: "General work." }],
+  ];
+  for (const [label, input] of branches) {
+    const r = classifyMilestoneScope(input);
+    assert.ok(r.reasons.length > 0, `${label}: reasons must not be empty`);
+  }
+});

--- a/src/resources/extensions/gsd/tests/milestone-scope-classifier.test.ts
+++ b/src/resources/extensions/gsd/tests/milestone-scope-classifier.test.ts
@@ -57,17 +57,16 @@ test("#4781 classifier: security review scope → standard (even if small)", () 
   assert.ok(r.signals.triggeredOverride);
 });
 
-test("#4781 classifier: schema migration mentioned → complex (overrides override)", () => {
+test("#4781 classifier: schema migration mentioned → standard (override-level signal)", () => {
   const r = classifyMilestoneScope({
     title: "User profile v2",
     vision: "Perform schema migration to split user.name into first_name and last_name across the users table.",
     successCriteria: ["Migration lands", "Existing rows backfilled", "Rollback path validated"],
   });
-  // schema change + migrate both hit COMPLEX_KEYWORDS ("schema redesign" no; "migration" is in OVERRIDE).
-  // But COMPLEX_KEYWORDS also contains "schema redesign" and "breaking change" — this copy triggers OVERRIDE only.
-  // The classifier precedence puts complex BEFORE override on complex keywords; since none of the
-  // COMPLEX_KEYWORDS fire here ("migration" is only in OVERRIDE), the result is standard, not complex.
-  // This is the correct safe behavior: migration is override-level, not complex-level.
+  // "migration" / "migrate" / "backfill" are OVERRIDE_KEYWORDS, not
+  // COMPLEX_KEYWORDS — migration is override-level (forces at least
+  // `standard`), not complex-level. Safe behavior: migrations need the
+  // full standard pipeline but not the extra ceremony of complex.
   assert.strictEqual(r.variant, "standard", `reasons: ${r.reasons.join("; ")}`);
 });
 


### PR DESCRIPTION
## TL;DR

**What:** New pure-function `classifyMilestoneScope(input) → { variant, reasons, signals }` that returns a `trivial | standard | complex` pipeline variant from a milestone's planning inputs. No dispatcher wiring yet.
**Why:** Forensic b23 session burned 16 units / \$5.12 / 5.68M tokens for a single static HTML to-do app — a classic trivial-scope milestone that ran through the full pipeline. Before any dispatcher can safely downshift pipelines, the classification contract itself needs to land with tests and a review window.
**How:** Deterministic keyword + heuristic scoring over title/vision/successCriteria/risks/DoD. Negation-aware ("no backend", "without a server" don't count as backend mentions). Override signals (auth/security/migration/compliance/irreversible-deploy) force at least `standard` to keep trivial misclassification from touching sensitive work.

## What

- `src/resources/extensions/gsd/milestone-scope-classifier.ts` (new, 302 lines)
  - `classifyMilestoneScope(input): { variant, reasons, signals }` — pure, deterministic, sub-millisecond.
  - `MilestoneScopeInput` — shape matches fields available at plan-milestone time (title, vision, successCriteria, keyRisks, definitionOfDone, requirementCoverage, verification hints).
  - Keyword sets: `OVERRIDE_KEYWORDS`, `COMPLEX_KEYWORDS`, `TRIVIAL_KEYWORDS`, curated to minimize overreach. Substring-based — comments explain why word-boundary regex would under-match compound phrases.
  - Negation window: "no backend" / "without a server" / "not using api" do not count as backend or test mentions. Sentence breaks reset the window (different clause).
- `src/resources/extensions/gsd/tests/milestone-scope-classifier.test.ts` (new, 188 lines, 17 tests)
  - b23 forensic case → trivial
  - Readme typo → trivial
  - Auth flow in one file → standard (override beats trivial)
  - Security review → standard
  - Schema migration → standard (migration is override-level, not complex-level)
  - Architecture keyword → complex
  - ≥8 file-count hint → complex
  - Backend API mention → standard (not trivial)
  - Tests mention → standard (not trivial)
  - Ambiguous prose / empty input → standard (safe default)
  - Override + trivial precedence
  - Complex + override precedence (complex wins, override flagged in signals)
  - File-count extraction for "a single file", "two files", "12 files"
  - `reasons[]` populated for every classification branch

## Why

Closes #4781 (phase 1). Related: #4782 (architecture) which will subsume pipeline variants into `UnitContextManifest`.

Peer review (Codex, earlier in the thread on the RFC) flagged a correction that shaped this PR: `complexity-classifier.ts` is the **wrong** home for this. That module decides *model tier* (light/standard/heavy) for individual units. Pipeline *topology* for an entire milestone is a different axis and belongs in its own module that hooks upstream of roadmap creation. This PR respects that separation — new file, new concern, no touching `complexity-classifier.ts`.

## How

### Classification precedence

1. **Complex signals** — complex-keyword match OR file-count-hint ≥ 8 → `complex`. Wins over override so security-sensitive architecture refactors route correctly.
2. **Override signals** — auth/security/credential/migration/compliance/irreversible-deploy keywords → `standard` (at minimum). Prevents trivial misclassification of sensitive work.
3. **Trivial signals** — trivial keyword match AND file-count-hint ≤ 2 (or unknown) AND no non-negated backend mention AND no non-negated test mention → `trivial`.
4. **Fallback** — `standard`.

### Phase-2 wiring (future PR — NOT in this diff)

- Consume the classification at dispatch time (most likely in `auto-start.ts` or the `plan-milestone` path).
- For `trivial` variant: skip `research-slice` and `validate-milestone` rules.
- For `complex` variant: add extra verification / design-review hooks if desired.
- Surface classification + reasons in `.gsd/metrics.json` and dashboard so users can override when the heuristic misses.

Gating this PR on just the classifier means:
- The contract is reviewable in isolation.
- The test matrix is complete before any behavior change ships.
- Follow-up PRs can land variant-specific wirings independently without conflict or rollback coupling.

### Scope

- Pure function, no file I/O, no DB access, no LLM calls.
- No callers in the existing codebase yet. No behavior change.
- Follows the #4779 two-PR pattern (resolver landed in #4788, wirings expanded in #4874).

### Local verification

**17/17 classifier tests passing.** No existing tests affected — the module is new and has no callers yet, so I skipped the broader sweep since there's no reachable regression surface.

## Change type

- [x] `feat` — New module, no existing behavior changes

## Breaking changes

**None.** No callers of the new classifier exist yet. Phase-2 wiring PRs will document breaking-behavior deltas explicitly if the dispatch pipeline changes for existing users.

AI-assisted PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced milestone scope classifier: auto-categorizes milestones as trivial, standard, or complex using keyword signals, extracted file-count hints, and negation-aware detection of tests/backend mentions; includes precedence rules and returns human-readable reasons and signal indicators.

* **Tests**
  * Added thorough tests covering classification outcomes, file-count extraction, negation handling, precedence behavior, and reason/signal reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->