### PR TITLE
feat(claude-code): add permission granularity picker for Always Allow

### DIFF
--- a/src/claude-cli-check.ts
+++ b/src/claude-cli-check.ts
@@ -33,7 +33,11 @@ function execClaudeCheck(args: string[]): Buffer {
   let lastError: unknown
   for (const command of CLAUDE_COMMAND_CANDIDATES) {
     try {
-      return execFileSync(command, args, { timeout: 5_000, stdio: 'pipe' })
+      return execFileSync(command, args, {
+        timeout: 5_000,
+        stdio: 'pipe',
+        shell: process.platform === 'win32',
+      })
     } catch (error) {
       lastError = error
       const code = (error as NodeJS.ErrnoException | undefined)?.code

--- a/src/resources/extensions/claude-code-cli/readiness.ts
+++ b/src/resources/extensions/claude-code-cli/readiness.ts
@@ -31,7 +31,11 @@ function execClaude(args: string[]): Buffer {
 	let lastError: unknown;
 	for (const command of CLAUDE_COMMAND_CANDIDATES) {
 		try {
-			return execFileSync(command, args, { timeout: 5_000, stdio: "pipe" });
+			return execFileSync(command, args, {
+				timeout: 5_000,
+				stdio: "pipe",
+				shell: process.platform === "win32",
+			});
 		} catch (error) {
 			lastError = error;
 			const code = (error as NodeJS.ErrnoException | undefined)?.code;

--- a/src/resources/extensions/claude-code-cli/stream-adapter.ts
+++ b/src/resources/extensions/claude-code-cli/stream-adapter.ts
@@ -21,6 +21,9 @@ import type {
 import type { ExtensionUIContext } from "@gsd/pi-coding-agent";
 import { EventStream } from "@gsd/pi-ai";
 import { execSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
 import { PartialMessageBuilder, ZERO_USAGE, mapUsage } from "./partial-builder.js";
 import { buildWorkflowMcpServers } from "../gsd/workflow-mcp.js";
 import { showInterviewRound, type Question, type RoundResult } from "../shared/tui.js";
@@ -178,34 +181,88 @@ export function getResultErrorMessage(result: SDKResultMessage): string {
 // Claude binary resolution
 // ---------------------------------------------------------------------------
 
-/** Cached result of the `which`/`where claude` lookup so the shell is only spawned once per process. */
+/** Cached result of the Claude executable/script resolution so lookup runs once per process. */
 let cachedClaudePath: string | null = null;
+const requireFromHere = createRequire(import.meta.url);
 
 /** Return the shell command used to locate the `claude` binary on the given platform. */
 export function getClaudeLookupCommand(platform: NodeJS.Platform = process.platform): string {
 	return platform === "win32" ? "where claude" : "which claude";
 }
 
-/** Extract the first line of `which`/`where` output as the resolved binary path. */
-export function parseClaudeLookupOutput(output: Buffer | string): string {
-	return output
+/**
+ * Pick the most suitable path from `which`/`where` output.
+ *
+ * On Windows, `where claude` can return shim entries first (for example
+ * `...\\npm\\claude` / `...\\npm\\claude.cmd`) that the Claude Agent SDK treats
+ * as a native executable path and then fails to spawn. Prefer a native
+ * `.exe` candidate when present.
+ */
+export function parseClaudeLookupOutput(output: Buffer | string, platform: NodeJS.Platform = process.platform): string {
+	const lines = output
 		.toString()
-		.trim()
-		.split(/\r?\n/)[0] ?? "";
+		.split(/\r?\n/)
+		.map((line) => line.trim())
+		.filter(Boolean);
+
+	if (lines.length === 0) return "";
+	if (platform !== "win32") return lines[0] ?? "";
+
+	const exeCandidate = lines.find((line) => /\.exe$/i.test(line));
+	if (exeCandidate) return exeCandidate;
+
+	const cmdCandidate = lines.find((line) => /\.cmd$/i.test(line));
+	if (cmdCandidate) return cmdCandidate;
+
+	return lines[0] ?? "";
+}
+
+/** Resolve the SDK-bundled cli.js path if available. */
+export function resolveBundledClaudeCliPath(): string | null {
+	try {
+		const sdkEntry = requireFromHere.resolve("@anthropic-ai/claude-agent-sdk");
+		const cliPath = join(dirname(sdkEntry), "cli.js");
+		return existsSync(cliPath) ? cliPath : null;
+	} catch {
+		return null;
+	}
 }
 
 /**
- * Resolve the path to the system-installed `claude` binary.
- * The SDK defaults to a bundled cli.js which doesn't exist when
- * installed as a library — we need to point it at the real CLI.
+ * Normalize a discovered path for Claude Agent SDK consumption.
+ *
+ * On Windows, the SDK treats non-`.js` paths as native binaries. NPM shims
+ * like `claude`/`claude.cmd` are not native binaries and can fail with
+ * `ENOENT`/`EINVAL` in that mode. When no `.exe` is available, prefer the
+ * SDK-bundled `cli.js` so the SDK runs via Node.
  */
+export function normalizeClaudePathForSdk(
+	resolvedPath: string,
+	platform: NodeJS.Platform = process.platform,
+	bundledCliPath: string | null = resolveBundledClaudeCliPath(),
+): string {
+	if (platform !== "win32") return resolvedPath;
+	if (/\.exe$/i.test(resolvedPath)) return resolvedPath;
+	if (bundledCliPath) return bundledCliPath;
+	return resolvedPath;
+}
+
+/** Resolve the path passed to `pathToClaudeCodeExecutable`. */
 function getClaudePath(): string {
 	if (cachedClaudePath) return cachedClaudePath;
+
+	const fallback = process.platform === "win32"
+		? (resolveBundledClaudeCliPath() ?? "claude.cmd")
+		: "claude";
+
 	try {
-		cachedClaudePath = parseClaudeLookupOutput(execSync(getClaudeLookupCommand(), { timeout: 5_000, stdio: "pipe" }));
+		const lookupOutput = execSync(getClaudeLookupCommand(), { timeout: 5_000, stdio: "pipe" });
+		const parsed = parseClaudeLookupOutput(lookupOutput, process.platform);
+		cachedClaudePath = normalizeClaudePathForSdk(parsed || fallback, process.platform);
 	} catch {
-		cachedClaudePath = "claude"; // fall back to PATH resolution
+		cachedClaudePath = fallback;
 	}
+
 	return cachedClaudePath;
 }
 

--- a/src/resources/extensions/claude-code-cli/stream-adapter.ts
+++ b/src/resources/extensions/claude-code-cli/stream-adapter.ts
@@ -21,7 +21,8 @@ import type {
 import type { ExtensionUIContext } from "@gsd/pi-coding-agent";
 import { EventStream } from "@gsd/pi-ai";
 import { execSync } from "node:child_process";
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
 import { createRequire } from "node:module";
 import { dirname, join } from "node:path";
 import { PartialMessageBuilder, ZERO_USAGE, mapUsage } from "./partial-builder.js";
@@ -689,6 +690,439 @@ async function promptTextInputElicitation(
 	return { action: "accept", content };
 }
 
+// ---------------------------------------------------------------------------
+// canUseTool handler
+// ---------------------------------------------------------------------------
+
+/** Options passed by the SDK to the canUseTool callback. */
+interface CanUseToolOptions {
+	signal: AbortSignal;
+	suggestions?: Array<Record<string, unknown>>;
+	blockedPath?: string;
+	decisionReason?: string;
+	title?: string;
+	displayName?: string;
+	description?: string;
+	toolUseID: string;
+	agentID?: string;
+}
+
+/** Result returned by the canUseTool callback to the SDK. */
+type CanUseToolPermissionResult =
+	| { behavior: "allow"; updatedInput?: Record<string, unknown>; updatedPermissions?: Array<Record<string, unknown>>; toolUseID?: string }
+	| { behavior: "deny"; message: string; interrupt?: boolean; toolUseID?: string };
+
+/**
+ * Known CLI tools where the subcommand verb changes the risk profile.
+ * Value = number of subcommand tokens (beyond the executable) to capture
+ * in the "Always Allow" permission pattern.
+ *
+ * `git push` and `git log` are very different → depth 1 → `Bash(git push:*)`
+ * `gh pr create` and `gh pr list` differ at depth 2 → `Bash(gh pr create:*)`
+ * `ping` is always safe → not listed → `Bash(ping:*)`
+ */
+const SUBCOMMAND_DEPTH: Record<string, number> = {
+	git: 1,
+	gh: 2,
+	npm: 1,
+	npx: 1,
+	yarn: 1,
+	pnpm: 1,
+	docker: 1,
+	kubectl: 1,
+	aws: 2,
+	az: 2,
+	gcloud: 2,
+	cargo: 1,
+	pip: 1,
+	pip3: 1,
+	brew: 1,
+	terraform: 1,
+	helm: 1,
+	dotnet: 1,
+};
+
+/** Command wrappers to skip when extracting the base executable. */
+const CMD_PASSTHROUGH = new Set(["sudo", "env", "command"]);
+
+/**
+ * Build a smart permission pattern for Bash "Always Allow".
+ *
+ * Simple commands → `Bash(ping:*)` (any args are fine)
+ * Subcommand-sensitive CLIs → `Bash(git push:*)` (verb is captured, args wildcarded)
+ */
+export function buildBashPermissionPattern(command: string): string {
+	// When the command is a chain like "cd /foo && gh pr list", extract the
+	// last segment — `cd` is just setup, the meaningful operation is what follows.
+	const segments = command.split(/\s*(?:&&|\|\||;)\s*/);
+	// Skip leading `cd` (directory setup) and trailing error suppressors
+	// like `|| true`, `|| :`, `|| echo ...`.  The meaningful command is
+	// the first segment that is *neither* of those.
+	const SETUP_RE = /^\s*cd\s/;
+	const SUPPRESSOR_RE = /^\s*(?:true|:|echo\b)/;
+	let meaningful: string | undefined;
+	if (segments.length > 1) {
+		// Strip suppressors, then strip cd prefixes; take the *last* remaining
+		// segment — that's the meaningful command.
+		const trimmed = segments.filter(s => !SUPPRESSOR_RE.test(s));
+		const core = trimmed.filter(s => !SETUP_RE.test(s));
+		meaningful = core.length > 0 ? core[core.length - 1] : trimmed[trimmed.length - 1];
+	}
+	meaningful = meaningful || segments[0] || command;
+	const rawTokens = meaningful.trim().split(/\s+/);
+
+	// Skip sudo/env wrappers and leading VAR=val assignments
+	let idx = 0;
+	while (idx < rawTokens.length) {
+		if (CMD_PASSTHROUGH.has(rawTokens[idx])) { idx++; continue; }
+		if (/^[A-Za-z_]\w*=/.test(rawTokens[idx])) { idx++; continue; }
+		break;
+	}
+	const tokens = rawTokens.slice(idx).filter(Boolean);
+	if (tokens.length === 0) return "Bash(*)";
+
+	// Strip path and .exe from executable name
+	const base = tokens[0].replace(/^.*[\\/]/, "").replace(/\.exe$/i, "");
+	const depth = SUBCOMMAND_DEPTH[base];
+
+	if (depth !== undefined) {
+		// Capture base + N subcommand tokens: "gh pr list" → Bash(gh pr list:*)
+		const significant = [base, ...tokens.slice(1, 1 + depth)].join(" ");
+		return `Bash(${significant}:*)`;
+	}
+
+	// Simple command — any args are fine: "ping" → Bash(ping:*)
+	return `Bash(${base}:*)`;
+}
+
+/**
+ * Build the list of granularity options presented after a user chooses
+ * "Always Allow" for a Bash command.
+ *
+ * Rather than assuming the user wants the default smart pattern, the UI
+ * shows every meaningful prefix so the user explicitly picks the scope:
+ *
+ *   "gh pr list --limit 5" → [
+ *     "Bash(gh:*)",         // allow any gh command
+ *     "Bash(gh pr:*)",      // allow any gh pr subcommand
+ *     "Bash(gh pr list:*)", // allow just this verb
+ *   ]
+ *
+ * Flags (tokens starting with `-`) terminate the subcommand chain — they
+ * are call-site arguments, not stable verbs. Subcommand depth is capped
+ * at 3 to keep the menu short (max 4 options).
+ *
+ * Returns a single-entry list when there is no meaningful subcommand to
+ * choose from (e.g. `ls -la`). Callers can skip the second dialog in
+ * that case.
+ */
+export function buildBashPermissionPatternOptions(command: string): string[] {
+	const segments = command.split(/\s*(?:&&|\|\||;)\s*/);
+	const SETUP_RE = /^\s*cd\s/;
+	const SUPPRESSOR_RE = /^\s*(?:true|:|echo\b)/;
+	let meaningful: string | undefined;
+	if (segments.length > 1) {
+		const trimmed = segments.filter(s => !SUPPRESSOR_RE.test(s));
+		const core = trimmed.filter(s => !SETUP_RE.test(s));
+		meaningful = core.length > 0 ? core[core.length - 1] : trimmed[trimmed.length - 1];
+	}
+	meaningful = meaningful || segments[0] || command;
+	const rawTokens = meaningful.trim().split(/\s+/);
+
+	let idx = 0;
+	while (idx < rawTokens.length) {
+		if (CMD_PASSTHROUGH.has(rawTokens[idx])) { idx++; continue; }
+		if (/^[A-Za-z_]\w*=/.test(rawTokens[idx])) { idx++; continue; }
+		break;
+	}
+	const tokens = rawTokens.slice(idx).filter(Boolean);
+	if (tokens.length === 0) return ["Bash(*)"];
+
+	const base = tokens[0].replace(/^.*[\\/]/, "").replace(/\.exe$/i, "");
+
+	// Collect up to 3 subcommand tokens, stopping at the first flag.
+	const subTokens: string[] = [];
+	for (let i = 1; i < tokens.length; i++) {
+		const t = tokens[i];
+		if (t.startsWith("-")) break;
+		subTokens.push(t);
+		if (subTokens.length >= 3) break;
+	}
+
+	const patterns: string[] = [`Bash(${base}:*)`];
+	for (let i = 1; i <= subTokens.length; i++) {
+		patterns.push(`Bash(${[base, ...subTokens.slice(0, i)].join(" ")}:*)`);
+	}
+	return patterns;
+}
+
+/**
+ * Read Bash allow-rule patterns from project and user settings files.
+ *
+ * Returns the ruleContent portion (e.g. `"gh pr list:*"`) for each
+ * `Bash(...)` entry found in `permissions.allow`.
+ */
+function readBashAllowRulesFromSettings(): string[] {
+	const rules: string[] = [];
+	const paths = [
+		join(process.cwd(), ".claude", "settings.local.json"),
+		join(process.cwd(), ".claude", "settings.json"),
+	];
+	try {
+		paths.push(join(homedir(), ".claude", "settings.json"));
+	} catch {
+		// homedir() can throw on some platforms
+	}
+	for (const settingsPath of paths) {
+		try {
+			if (!existsSync(settingsPath)) continue;
+			const raw = JSON.parse(readFileSync(settingsPath, "utf8"));
+			const allow = raw?.permissions?.allow;
+			if (!Array.isArray(allow)) continue;
+			for (const entry of allow) {
+				if (typeof entry !== "string") continue;
+				const m = /^Bash\((.+)\)$/.exec(entry);
+				if (m) rules.push(m[1]);
+			}
+		} catch {
+			// Ignore malformed settings files
+		}
+	}
+	return rules;
+}
+
+/**
+ * Check if a Bash compound command matches saved allow rules after
+ * extracting the meaningful segment.
+ *
+ * The SDK's built-in matcher refuses to match prefix rules against
+ * compound commands (e.g. `cd /path && gh pr list`). Claude Code
+ * routinely prepends `cd <cwd> &&` to commands, causing saved rules
+ * to never match on re-invocation. This function strips safe leading
+ * segments (only `cd` commands) and checks the remaining operation
+ * against saved rules.
+ *
+ * For compound commands, returns true only when all leading segments
+ * are `cd` commands and the final segment matches a saved rule.
+ * For simple (single-segment) commands, checks directly against saved
+ * rules — this covers the case where a rule was added mid-session and
+ * the SDK's in-memory cache is stale.
+ */
+export function bashCommandMatchesSavedRules(command: string): boolean {
+	const segments = command.split(/\s*(?:&&|\|\||;)\s*/).filter(Boolean);
+	if (segments.length === 0) return false;
+
+	let meaningful: string;
+	if (segments.length === 1) {
+		meaningful = segments[0].trim();
+	} else {
+		// Strip trailing error suppressors (|| true, || :, || echo ...)
+		// and leading cd segments.  The first remaining segment is the
+		// meaningful command.  All other non-cd, non-suppressor segments
+		// must be absent — otherwise we can't safely auto-approve.
+		const SETUP_RE = /^cd\s/;
+		const SUPPRESSOR_RE = /^\s*(?:true|:|echo\b)/;
+		const trimmed = segments.filter(s => !SUPPRESSOR_RE.test(s.trim()));
+		const core = trimmed.filter(s => !SETUP_RE.test(s.trim()));
+		if (core.length !== 1) return false; // ambiguous — multiple real commands
+		meaningful = core[0].trim();
+	}
+	if (!meaningful) return false;
+
+	const rules = readBashAllowRulesFromSettings();
+	if (rules.length === 0) return false;
+
+	for (const rule of rules) {
+		const prefixMatch = /^(.+):\*$/.exec(rule);
+		if (prefixMatch) {
+			const prefix = prefixMatch[1];
+			if (meaningful === prefix || meaningful.startsWith(prefix + " ")) {
+				return true;
+			}
+			continue;
+		}
+		// Exact match
+		if (meaningful === rule) return true;
+	}
+
+	return false;
+}
+
+/** Format the tool input into a human-readable summary for the permission prompt. */
+function formatToolInput(toolName: string, input: Record<string, unknown>): string {
+	// Bash — show the command
+	if (input.command && typeof input.command === "string") {
+		const cmd = input.command.length > 300 ? input.command.slice(0, 300) + "…" : input.command;
+		return cmd;
+	}
+	// File-oriented tools — show path
+	if (input.file_path && typeof input.file_path === "string") {
+		return `${toolName}: ${input.file_path}`;
+	}
+	// Generic fallback — compact JSON, truncated
+	const json = JSON.stringify(input);
+	if (json.length <= 200) return json;
+	return json.slice(0, 200) + "…";
+}
+
+/**
+ * Create a canUseTool handler that routes SDK permission requests through the
+ * extension UI's select dialog, or auto-approves when no UI is available.
+ *
+ * Presents three options:
+ * - **Allow** — approve this one invocation
+ * - **Always Allow** — approve and pass `suggestions` back as `updatedPermissions`
+ *   so the SDK remembers the choice for the rest of the session
+ * - **Deny** — reject the invocation
+ *
+ * Follows the same pattern as {@link createClaudeCodeElicitationHandler}:
+ * takes an optional UI context and returns the callback or undefined.
+ *
+ * When UI is unavailable (headless / auto-mode sub-agents), returns a handler
+ * that always approves — replacing the old GSD_AUTO_MODE → bypassPermissions
+ * workaround.
+ */
+export function createClaudeCodeCanUseToolHandler(
+	ui: ExtensionUIContext | undefined,
+): ((toolName: string, input: Record<string, unknown>, options: CanUseToolOptions) => Promise<CanUseToolPermissionResult>) | undefined {
+	if (!ui) return undefined;
+
+	return async (toolName, _input, options) => {
+		// Abort early if the signal is already fired
+		if (options.signal.aborted) {
+			return { behavior: "deny", message: "Aborted", toolUseID: options.toolUseID };
+		}
+
+		// For Bash compound commands (e.g. "cd /path && gh pr list"),
+		// check if the meaningful operation matches a saved allow rule.
+		// The SDK's built-in matcher rejects prefix rules for compound
+		// commands, but cd-prefixed commands are routine and the actual
+		// operation is already approved.
+		if (toolName === "Bash" && typeof _input.command === "string") {
+			if (bashCommandMatchesSavedRules(_input.command)) {
+				return { behavior: "allow", updatedInput: _input, toolUseID: options.toolUseID };
+			}
+		}
+
+		const inputSummary = formatToolInput(toolName, _input);
+		const title = options.title || `Allow Claude Code to use: ${toolName}?`;
+		const body = [
+			options.description,
+			inputSummary,
+		].filter(Boolean).join("\n");
+
+		// The 2nd menu (level picker) lets the user choose the exact pattern,
+		// so the 1st menu just shows "Always Allow" without a command suffix.
+		const alwaysAllowLabel = "Always Allow";
+
+		try {
+			const choice = await ui.select(
+				`${title}\n${body}`,
+				["Allow", alwaysAllowLabel, "Deny"],
+				{ signal: options.signal },
+			);
+
+			if (options.signal.aborted) {
+				return { behavior: "deny", message: "Aborted", toolUseID: options.toolUseID };
+			}
+
+			if (choice === alwaysAllowLabel) {
+				// Pass the SDK's own suggestions back as updatedPermissions so
+				// it knows how to persist them (PermissionUpdate[] shape).
+				// For Bash, patch the ruleContent with the user-chosen
+				// granularity pattern (e.g. "gh", "gh pr", "gh pr list") so
+				// the saved rule matches the scope the user actually wants.
+				let perms = options.suggestions;
+				let notifyLabel: string | undefined;
+				if (toolName === "Bash" && typeof _input.command === "string") {
+					// Present every meaningful prefix so the user picks the
+					// scope explicitly rather than getting a blanket match.
+					const patternOptions = buildBashPermissionPatternOptions(_input.command);
+					let chosenPattern: string;
+					if (patternOptions.length <= 1) {
+						// No subcommand choice to make (e.g. "ls -la") — use
+						// the single available pattern directly.
+						chosenPattern = patternOptions[0] ?? buildBashPermissionPattern(_input.command);
+					} else {
+						const levelChoiceRaw = await ui.select(
+							"Save permission at which level?",
+							patternOptions,
+							{ signal: options.signal },
+						);
+						if (options.signal.aborted) {
+							return { behavior: "deny", message: "Aborted", toolUseID: options.toolUseID };
+						}
+						const levelChoice = Array.isArray(levelChoiceRaw) ? levelChoiceRaw[0] : levelChoiceRaw;
+						if (!levelChoice || !patternOptions.includes(levelChoice)) {
+							// User dismissed the level picker — cancel the
+							// tool use. Falling back to a one-time allow
+							// here would leave the spawned agent running
+							// with no clear signal that the user bailed.
+							return {
+								behavior: "deny",
+								message: "User cancelled permission selection",
+								toolUseID: options.toolUseID,
+							};
+						}
+						chosenPattern = levelChoice;
+					}
+					notifyLabel = chosenPattern;
+					// Extract the ruleContent portion from "Bash(gh pr list:*)" → "gh pr list:*"
+					const ruleContent = chosenPattern.replace(/^Bash\(/, "").replace(/\)$/, "");
+					if (perms && Array.isArray(perms) && perms.length > 0) {
+						// Clone suggestions and patch ruleContent on any Bash addRules entry
+						perms = perms.map((s: any) => {
+							if (s.type === "addRules" && Array.isArray(s.rules)) {
+								return {
+									...s,
+									rules: s.rules.map((r: any) =>
+										r.toolName === "Bash" ? { ...r, ruleContent } : r,
+									),
+								};
+							}
+							return s;
+						});
+					} else {
+						// No suggestions from SDK — build a proper PermissionUpdate
+						perms = [{
+							type: "addRules",
+							rules: [{ toolName: "Bash", ruleContent }],
+							behavior: "allow",
+							destination: "localSettings",
+						}];
+					}
+				}
+				// Notify with the resolved pattern (label already previewed it)
+				if (notifyLabel) {
+					ui.notify(`Saved: ${notifyLabel}`, "info");
+				}
+				return {
+					behavior: "allow",
+					updatedInput: _input,
+					toolUseID: options.toolUseID,
+					...(perms ? { updatedPermissions: perms } : {}),
+				};
+			}
+
+			if (choice === "Allow") {
+				return {
+					behavior: "allow",
+					updatedInput: _input,
+					toolUseID: options.toolUseID,
+				};
+			}
+
+			return { behavior: "deny", message: "User denied", toolUseID: options.toolUseID };
+		} catch {
+			return { behavior: "deny", message: "Aborted", toolUseID: options.toolUseID };
+		}
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Elicitation handler
+// ---------------------------------------------------------------------------
+
 /** Create an SDK elicitation handler that routes requests through the extension UI dialogs, or undefined if no UI is available. */
 export function createClaudeCodeElicitationHandler(
 	ui: ExtensionUIContext | undefined,
@@ -1188,18 +1622,26 @@ async function pumpSdkMessages(
 		const prompt = buildPromptFromContext(context);
 		const queryPrompt = buildSdkQueryPrompt(context, prompt);
 		const permissionMode = await resolveClaudePermissionMode();
+		const uiContext = (options as ClaudeCodeStreamOptions | undefined)?.extensionUIContext;
+		const canUseToolHandler = createClaudeCodeCanUseToolHandler(uiContext);
+		// When no UI is available (headless / auto-mode), auto-approve all
+		// tool requests. This replaces the old bypassPermissions workaround.
+		const canUseToolFallback = canUseToolHandler
+			?? (async (_toolName: string, _input: Record<string, unknown>, opts: CanUseToolOptions): Promise<CanUseToolPermissionResult> =>
+				({ behavior: "allow", toolUseID: opts.toolUseID }));
 		const sdkOpts = buildSdkOptions(
 			modelId,
 			prompt,
 			{ permissionMode },
-			typeof (options as ClaudeCodeStreamOptions | undefined)?.extensionUIContext === "object"
-				? {
-						reasoning: options?.reasoning,
-						onElicitation: createClaudeCodeElicitationHandler(
-							(options as ClaudeCodeStreamOptions | undefined)?.extensionUIContext,
-						),
-					}
-				: { reasoning: options?.reasoning },
+			{
+				reasoning: options?.reasoning,
+				canUseTool: canUseToolFallback,
+				...(uiContext
+					? {
+							onElicitation: createClaudeCodeElicitationHandler(uiContext),
+						}
+					: {}),
+			},
 		);
 
 		const queryResult = sdk.query({

--- a/src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts
+++ b/src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts
@@ -20,6 +20,8 @@ import {
 	parseAskUserQuestionsElicitation,
 	parseTextInputElicitation,
 	parseClaudeLookupOutput,
+	resolveBundledClaudeCliPath,
+	normalizeClaudePathForSdk,
 	roundResultToElicitationContent,
 } from "../stream-adapter.ts";
 import type { AssistantMessage, Context, Message } from "@gsd/pi-ai";
@@ -1357,8 +1359,30 @@ describe("stream-adapter — Windows Claude path lookup (#3770)", () => {
 		assert.equal(getClaudeLookupCommand("linux"), "which claude");
 	});
 
-	test("parseClaudeLookupOutput keeps the first native path from multi-line lookup output", () => {
-		const output = "C:\\Users\\Binoy\\.local\\bin\\claude.exe\r\nC:\\Program Files\\Claude\\claude.exe\r\n";
-		assert.equal(parseClaudeLookupOutput(output), "C:\\Users\\Binoy\\.local\\bin\\claude.exe");
+	test("parseClaudeLookupOutput prefers .exe on win32 when where output includes shims", () => {
+		const output = [
+			"C:\\Users\\djeff\\AppData\\Roaming\\npm\\claude",
+			"C:\\Users\\djeff\\AppData\\Roaming\\npm\\claude.cmd",
+			"C:\\Program Files\\Claude\\claude.exe",
+		].join("\r\n");
+		assert.equal(parseClaudeLookupOutput(output, "win32"), "C:\\Program Files\\Claude\\claude.exe");
+	});
+
+	test("parseClaudeLookupOutput keeps first line on non-win32 platforms", () => {
+		const output = "/usr/local/bin/claude\n/opt/homebrew/bin/claude\n";
+		assert.equal(parseClaudeLookupOutput(output, "darwin"), "/usr/local/bin/claude");
+	});
+
+	test("normalizeClaudePathForSdk swaps Windows shim paths to bundled cli.js", () => {
+		const shimPath = "C:\\Users\\djeff\\AppData\\Roaming\\npm\\claude";
+		const bundled = "C:\\repo\\node_modules\\@anthropic-ai\\claude-agent-sdk\\cli.js";
+		assert.equal(normalizeClaudePathForSdk(shimPath, "win32", bundled), bundled);
+		assert.equal(normalizeClaudePathForSdk("C:\\Program Files\\Claude\\claude.exe", "win32", bundled), "C:\\Program Files\\Claude\\claude.exe");
+	});
+
+	test("resolveBundledClaudeCliPath returns a .js path when SDK package is present", () => {
+		const resolved = resolveBundledClaudeCliPath();
+		assert.ok(resolved, "expected sdk cli.js to be resolvable in test workspace");
+		assert.match(resolved!, /[\\/]@anthropic-ai[\\/]claude-agent-sdk[\\/]cli\.js$/);
 	});
 });

--- a/src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts
+++ b/src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts
@@ -13,6 +13,10 @@ import {
 	buildPromptFromContext,
 	buildSdkQueryPrompt,
 	buildSdkOptions,
+	createClaudeCodeCanUseToolHandler,
+	buildBashPermissionPattern,
+	buildBashPermissionPatternOptions,
+	bashCommandMatchesSavedRules,
 	createClaudeCodeElicitationHandler,
 	extractImageBlocksFromContext,
 	extractToolResultsFromSdkUserMessage,
@@ -1384,5 +1388,813 @@ describe("stream-adapter — Windows Claude path lookup (#3770)", () => {
 		const resolved = resolveBundledClaudeCliPath();
 		assert.ok(resolved, "expected sdk cli.js to be resolvable in test workspace");
 		assert.match(resolved!, /[\\/]@anthropic-ai[\\/]claude-agent-sdk[\\/]cli\.js$/);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// canUseTool handler (#4383)
+// ---------------------------------------------------------------------------
+
+describe("stream-adapter — canUseTool handler", () => {
+	function makeOptions(overrides: Partial<{ signal: AbortSignal; suggestions: Array<Record<string, unknown>>; title: string; description: string; toolUseID: string }> = {}) {
+		return {
+			signal: overrides.signal ?? new AbortController().signal,
+			toolUseID: overrides.toolUseID ?? "toolu_test123",
+			...(overrides.title !== undefined ? { title: overrides.title } : {}),
+			...(overrides.description !== undefined ? { description: overrides.description } : {}),
+			...(overrides.suggestions !== undefined ? { suggestions: overrides.suggestions } : {}),
+		};
+	}
+
+	// Point process.cwd() at an empty temp dir so the real repo's
+	// .claude/settings.local.json (which may already contain rules like
+	// "Bash(gh pr list:*)") does not short-circuit the permission flow.
+	// Returns a cleanup function that restores cwd and removes the temp dir.
+	// biome-ignore lint/suspicious/noExplicitAny: test-only monkey-patch
+	function withIsolatedCwd(): () => void {
+		const dir = realpathSync(mkdtempSync(join(tmpdir(), "gsd-canusetool-")));
+		const orig = process.cwd;
+		process.cwd = () => dir;
+		return () => {
+			process.cwd = orig;
+			rmSync(dir, { recursive: true, force: true });
+		};
+	}
+
+	test("returns undefined when no UI context is provided", () => {
+		const handler = createClaudeCodeCanUseToolHandler(undefined);
+		assert.equal(handler, undefined);
+	});
+
+	test("shows select dialog with Allow/Always Allow/Deny and returns allow", async () => {
+		let selectPrompt = "";
+		let selectOptions: string[] = [];
+		const ui = {
+			select: async (prompt: string, options: string[]) => {
+				selectPrompt = prompt;
+				selectOptions = options;
+				return "Allow";
+			},
+		};
+
+		const handler = createClaudeCodeCanUseToolHandler(ui as any);
+		assert.ok(handler);
+
+		const input = { command: "ls -la" };
+		const result = await handler!("Bash", input, makeOptions({
+			title: "Claude wants to run: ls -la",
+			description: "List directory contents",
+		}));
+
+		assert.equal(result.behavior, "allow");
+		assert.deepEqual((result as any).updatedInput, input);
+		assert.equal((result as any).toolUseID, "toolu_test123");
+		// Allow (one-time) should NOT include updatedPermissions
+		assert.equal((result as any).updatedPermissions, undefined);
+		assert.deepEqual(selectOptions, ["Allow", "Always Allow", "Deny"]);
+		// Prompt includes title and input summary
+		assert.ok(selectPrompt.includes("Claude wants to run: ls -la"));
+		assert.ok(selectPrompt.includes("ls -la"));
+	});
+
+	test("returns deny when user selects Deny", async () => {
+		const ui = {
+			select: async () => "Deny",
+		};
+
+		const handler = createClaudeCodeCanUseToolHandler(ui as any);
+		const result = await handler!("Bash", { command: "rm -rf /" }, makeOptions());
+
+		assert.equal(result.behavior, "deny");
+		assert.equal((result as any).message, "User denied");
+		assert.equal((result as any).toolUseID, "toolu_test123");
+	});
+
+	test("returns deny when user dismisses dialog (undefined)", async () => {
+		const ui = {
+			select: async () => undefined,
+		};
+
+		const handler = createClaudeCodeCanUseToolHandler(ui as any);
+		const result = await handler!("Bash", { command: "echo hi" }, makeOptions());
+
+		assert.equal(result.behavior, "deny");
+		assert.equal((result as any).message, "User denied");
+	});
+
+	test("Always Allow for Bash patches SDK suggestions with smart ruleContent", async () => {
+		const notified: string[] = [];
+		const ui = { select: async (_p: string, opts: string[]) => opts.find((o) => o.startsWith("Always Allow"))!, notify: (msg: string) => notified.push(msg) };
+		const suggestions = [{
+			type: "addRules",
+			rules: [{ toolName: "Bash", ruleContent: "ls -la /tmp" }],
+			behavior: "allow",
+			destination: "localSettings",
+		}];
+
+		const handler = createClaudeCodeCanUseToolHandler(ui as any);
+		const result = await handler!("Bash", { command: "ls -la /tmp" }, makeOptions({ suggestions }));
+
+		assert.equal(result.behavior, "allow");
+		// Should patch ruleContent with our smart pattern, preserving SDK structure
+		assert.deepEqual((result as any).updatedPermissions, [{
+			type: "addRules",
+			rules: [{ toolName: "Bash", ruleContent: "ls:*" }],
+			behavior: "allow",
+			destination: "localSettings",
+		}]);
+		assert.equal(notified.length, 1);
+		assert.ok(notified[0].includes("Saved:") && notified[0].includes("Bash(ls:*)"));
+	});
+
+	test("Always Allow for Bash with subcommand-sensitive CLI captures verb", async () => {
+		const cleanup = withIsolatedCwd();
+		try {
+			const notified: string[] = [];
+			// First select call: pick "Always Allow ..."; second call (level
+			// picker): pick the "git push" granularity explicitly.
+			let selectCall = 0;
+			const ui = {
+				select: async (_p: string, opts: string[]) => {
+					selectCall++;
+					if (selectCall === 1) return opts.find((o) => o.startsWith("Always Allow"))!;
+					return "Bash(git push:*)";
+				},
+				notify: (msg: string) => notified.push(msg),
+			};
+			const suggestions = [{
+				type: "addRules",
+				rules: [{ toolName: "Bash", ruleContent: "git push origin main" }],
+				behavior: "allow",
+				destination: "localSettings",
+			}];
+
+			const handler = createClaudeCodeCanUseToolHandler(ui as any);
+			const result = await handler!("Bash", { command: "git push origin main" }, makeOptions({ suggestions }));
+
+			assert.equal(result.behavior, "allow");
+			assert.deepEqual((result as any).updatedPermissions, [{
+				type: "addRules",
+				rules: [{ toolName: "Bash", ruleContent: "git push:*" }],
+				behavior: "allow",
+				destination: "localSettings",
+			}]);
+			assert.ok(notified[0].includes("Saved:") && notified[0].includes("Bash(git push:*)"));
+		} finally {
+			cleanup();
+		}
+	});
+
+	test("Always Allow for Bash without suggestions builds proper PermissionUpdate", async () => {
+		const cleanup = withIsolatedCwd();
+		try {
+			const notified: string[] = [];
+			let selectCall = 0;
+			const ui = {
+				select: async (_p: string, opts: string[]) => {
+					selectCall++;
+					if (selectCall === 1) return opts.find((o) => o.startsWith("Always Allow"))!;
+					return "Bash(gh pr list:*)";
+				},
+				notify: (msg: string) => notified.push(msg),
+			};
+
+			const handler = createClaudeCodeCanUseToolHandler(ui as any);
+			const result = await handler!("Bash", { command: "gh pr list" }, makeOptions());
+
+			assert.equal(result.behavior, "allow");
+			// No SDK suggestions → builds PermissionUpdate from scratch
+			assert.deepEqual((result as any).updatedPermissions, [{
+				type: "addRules",
+				rules: [{ toolName: "Bash", ruleContent: "gh pr list:*" }],
+				behavior: "allow",
+				destination: "localSettings",
+			}]);
+			assert.ok(notified[0].includes("Saved:") && notified[0].includes("Bash(gh pr list:*)"));
+		} finally {
+			cleanup();
+		}
+	});
+
+	test("Always Allow for non-Bash tools passes SDK suggestions through", async () => {
+		const notified: string[] = [];
+		const ui = { select: async (_p: string, opts: string[]) => opts.find((o) => o.startsWith("Always Allow"))!, notify: (msg: string) => notified.push(msg) };
+		const suggestions = [{
+			type: "addRules",
+			rules: [{ toolName: "Write" }],
+			behavior: "allow",
+			destination: "localSettings",
+		}];
+
+		const handler = createClaudeCodeCanUseToolHandler(ui as any);
+		const result = await handler!("Write", { file_path: "/tmp/test.txt" }, makeOptions({ suggestions }));
+
+		assert.equal(result.behavior, "allow");
+		assert.deepEqual((result as any).updatedPermissions, suggestions);
+		// Non-Bash tools don't emit a post-selection notification (only Bash runs the level picker)
+		assert.equal(notified.length, 0);
+	});
+
+	test("Always Allow for non-Bash without suggestions omits updatedPermissions", async () => {
+		const notified: string[] = [];
+		const ui = { select: async (_p: string, opts: string[]) => opts.find((o) => o.startsWith("Always Allow"))!, notify: (msg: string) => notified.push(msg) };
+
+		const handler = createClaudeCodeCanUseToolHandler(ui as any);
+		const result = await handler!("Write", { file_path: "/tmp/test.txt" }, makeOptions());
+
+		assert.equal(result.behavior, "allow");
+		assert.equal((result as any).updatedPermissions, undefined);
+		// No suggestions → no notification
+		assert.equal(notified.length, 0);
+	});
+
+	test("prompt includes command text for Bash tools", async () => {
+		let selectPrompt = "";
+		const ui = {
+			select: async (prompt: string) => {
+				selectPrompt = prompt;
+				return "Allow";
+			},
+		};
+
+		const handler = createClaudeCodeCanUseToolHandler(ui as any);
+		await handler!("Bash", { command: "git status" }, makeOptions());
+		assert.ok(selectPrompt.includes("git status"), `prompt should include command: ${selectPrompt}`);
+	});
+
+	test("prompt includes file_path for file tools", async () => {
+		let selectPrompt = "";
+		const ui = {
+			select: async (prompt: string) => {
+				selectPrompt = prompt;
+				return "Allow";
+			},
+		};
+
+		const handler = createClaudeCodeCanUseToolHandler(ui as any);
+		await handler!("Write", { file_path: "/tmp/test.txt", content: "hello" }, makeOptions());
+		assert.ok(selectPrompt.includes("/tmp/test.txt"), `prompt should include file path: ${selectPrompt}`);
+	});
+
+	test("uses title from options when available", async () => {
+		let selectPrompt = "";
+		const ui = {
+			select: async (prompt: string) => {
+				selectPrompt = prompt;
+				return "Allow";
+			},
+		};
+
+		const handler = createClaudeCodeCanUseToolHandler(ui as any);
+		await handler!("WebFetch", {}, makeOptions({ title: "Claude wants to fetch: https://example.com" }));
+		assert.ok(selectPrompt.includes("Claude wants to fetch: https://example.com"));
+	});
+
+	test("falls back to default title when options.title is missing", async () => {
+		let selectPrompt = "";
+		const ui = {
+			select: async (prompt: string) => {
+				selectPrompt = prompt;
+				return "Allow";
+			},
+		};
+
+		const handler = createClaudeCodeCanUseToolHandler(ui as any);
+		await handler!("WebFetch", { url: "https://example.com" }, makeOptions());
+		assert.ok(selectPrompt.includes("Allow Claude Code to use: WebFetch?"));
+	});
+
+	test("returns deny when signal is already aborted", async () => {
+		const ui = {
+			select: async () => { throw new Error("should not be called"); },
+		};
+
+		const controller = new AbortController();
+		controller.abort();
+
+		const handler = createClaudeCodeCanUseToolHandler(ui as any);
+		const result = await handler!("Bash", {}, makeOptions({ signal: controller.signal }));
+
+		assert.equal(result.behavior, "deny");
+		assert.equal((result as any).message, "Aborted");
+	});
+
+	test("returns deny when ui.select throws", async () => {
+		const ui = {
+			select: async () => { throw new Error("dialog crashed"); },
+		};
+
+		const handler = createClaudeCodeCanUseToolHandler(ui as any);
+		const result = await handler!("Bash", {}, makeOptions());
+
+		assert.equal(result.behavior, "deny");
+		assert.equal((result as any).message, "Aborted");
+	});
+
+	test("buildSdkOptions passes canUseTool through extraOptions", () => {
+		const canUseTool = async () => ({ behavior: "allow" as const, updatedInput: {}, toolUseID: "test" });
+		const opts = buildSdkOptions("claude-sonnet-4-6", "test", undefined, { canUseTool });
+		assert.equal(opts.canUseTool, canUseTool);
+	});
+
+	test("Always Allow shows level picker and user broadens to base command", async () => {
+		const cleanup = withIsolatedCwd();
+		try {
+			const prompts: string[] = [];
+			const levelOpts: string[][] = [];
+			let selectCall = 0;
+			const ui = {
+				select: async (prompt: string, opts: string[]) => {
+					prompts.push(prompt);
+					selectCall++;
+					if (selectCall === 1) return opts.find((o) => o.startsWith("Always Allow"))!;
+					levelOpts.push(opts);
+					return "Bash(gh:*)";
+				},
+				notify: () => {},
+			};
+
+			const handler = createClaudeCodeCanUseToolHandler(ui as any);
+			const result = await handler!("Bash", { command: "gh pr list" }, makeOptions());
+
+			assert.equal(result.behavior, "allow");
+			assert.deepEqual((result as any).updatedPermissions, [{
+				type: "addRules",
+				rules: [{ toolName: "Bash", ruleContent: "gh:*" }],
+				behavior: "allow",
+				destination: "localSettings",
+			}]);
+			// Second dialog offered every granularity level
+			assert.deepEqual(levelOpts[0], [
+				"Bash(gh:*)",
+				"Bash(gh pr:*)",
+				"Bash(gh pr list:*)",
+			]);
+			assert.ok(prompts[1].includes("Save permission at which level?"));
+		} finally {
+			cleanup();
+		}
+	});
+
+	test("Always Allow narrows to mid-level pattern when user picks Bash(gh pr:*)", async () => {
+		const cleanup = withIsolatedCwd();
+		try {
+			let selectCall = 0;
+			const ui = {
+				select: async (_p: string, opts: string[]) => {
+					selectCall++;
+					if (selectCall === 1) return opts.find((o) => o.startsWith("Always Allow"))!;
+					return "Bash(gh pr:*)";
+				},
+				notify: () => {},
+			};
+
+			const handler = createClaudeCodeCanUseToolHandler(ui as any);
+			const result = await handler!("Bash", { command: "gh pr list --limit 5" }, makeOptions());
+
+			assert.equal(result.behavior, "allow");
+			assert.deepEqual((result as any).updatedPermissions, [{
+				type: "addRules",
+				rules: [{ toolName: "Bash", ruleContent: "gh pr:*" }],
+				behavior: "allow",
+				destination: "localSettings",
+			}]);
+		} finally {
+			cleanup();
+		}
+	});
+
+	test("Always Allow skips level picker when only one pattern is available", async () => {
+		const cleanup = withIsolatedCwd();
+		try {
+			const prompts: string[] = [];
+			const ui = {
+				select: async (prompt: string, opts: string[]) => {
+					prompts.push(prompt);
+					return opts.find((o) => o.startsWith("Always Allow"))!;
+				},
+				notify: () => {},
+			};
+
+			const handler = createClaudeCodeCanUseToolHandler(ui as any);
+			const result = await handler!("Bash", { command: "ls -la /tmp" }, makeOptions());
+
+			assert.equal(result.behavior, "allow");
+			// "ls" has no subcommand tokens before the flag → single-option path
+			assert.equal(prompts.length, 1, "should not show a second dialog");
+			assert.deepEqual((result as any).updatedPermissions, [{
+				type: "addRules",
+				rules: [{ toolName: "Bash", ruleContent: "ls:*" }],
+				behavior: "allow",
+				destination: "localSettings",
+			}]);
+		} finally {
+			cleanup();
+		}
+	});
+
+	test("Always Allow denies the tool when level picker is dismissed", async () => {
+		const cleanup = withIsolatedCwd();
+		try {
+			const notified: string[] = [];
+			let selectCall = 0;
+			const ui = {
+				select: async (_p: string, opts: string[]) => {
+					selectCall++;
+					if (selectCall === 1) return opts.find((o) => o.startsWith("Always Allow"))!;
+					return undefined; // user dismissed level picker
+				},
+				notify: (msg: string) => notified.push(msg),
+			};
+
+			const handler = createClaudeCodeCanUseToolHandler(ui as any);
+			const result = await handler!("Bash", { command: "gh pr list" }, makeOptions());
+
+			// Dismissing the level picker cancels the tool use — a one-time allow
+			// would leave the spawned agent running even though the user bailed.
+			assert.equal(result.behavior, "deny");
+			assert.equal((result as any).updatedPermissions, undefined);
+			assert.equal(notified.length, 0, "no 'Saved:' notification when nothing was saved");
+		} finally {
+			cleanup();
+		}
+	});
+});
+
+// ---------------------------------------------------------------------------
+// buildBashPermissionPattern — smart permission granularity
+// ---------------------------------------------------------------------------
+
+describe("buildBashPermissionPattern", () => {
+	test("simple command wildcards all args", () => {
+		assert.equal(buildBashPermissionPattern("ping -n 4 localhost"), "Bash(ping:*)");
+		assert.equal(buildBashPermissionPattern("echo hello world"), "Bash(echo:*)");
+		assert.equal(buildBashPermissionPattern("ls -la /tmp"), "Bash(ls:*)");
+		assert.equal(buildBashPermissionPattern("node server.js"), "Bash(node:*)");
+	});
+
+	test("git captures one subcommand", () => {
+		assert.equal(buildBashPermissionPattern("git push origin main"), "Bash(git push:*)");
+		assert.equal(buildBashPermissionPattern("git log --oneline"), "Bash(git log:*)");
+		assert.equal(buildBashPermissionPattern("git status"), "Bash(git status:*)");
+	});
+
+	test("gh captures two subcommands", () => {
+		assert.equal(buildBashPermissionPattern("gh pr list"), "Bash(gh pr list:*)");
+		assert.equal(buildBashPermissionPattern("gh pr create --title foo"), "Bash(gh pr create:*)");
+		assert.equal(buildBashPermissionPattern("gh issue view 123"), "Bash(gh issue view:*)");
+	});
+
+	test("npm captures one subcommand", () => {
+		assert.equal(buildBashPermissionPattern("npm install lodash"), "Bash(npm install:*)");
+		assert.equal(buildBashPermissionPattern("npm publish"), "Bash(npm publish:*)");
+		assert.equal(buildBashPermissionPattern("npm run test"), "Bash(npm run:*)");
+	});
+
+	test("npx captures package name", () => {
+		assert.equal(buildBashPermissionPattern("npx vitest run"), "Bash(npx vitest:*)");
+		assert.equal(buildBashPermissionPattern("npx --version"), "Bash(npx --version:*)");
+	});
+
+	test("docker captures one subcommand", () => {
+		assert.equal(buildBashPermissionPattern("docker ps -a"), "Bash(docker ps:*)");
+		assert.equal(buildBashPermissionPattern("docker rm container1"), "Bash(docker rm:*)");
+	});
+
+	test("aws captures two subcommands", () => {
+		assert.equal(buildBashPermissionPattern("aws s3 cp file.txt s3://bucket/"), "Bash(aws s3 cp:*)");
+		assert.equal(buildBashPermissionPattern("aws ec2 describe-instances"), "Bash(aws ec2 describe-instances:*)");
+	});
+
+	test("skips sudo wrapper", () => {
+		assert.equal(buildBashPermissionPattern("sudo ping localhost"), "Bash(ping:*)");
+		assert.equal(buildBashPermissionPattern("sudo git push"), "Bash(git push:*)");
+	});
+
+	test("skips env wrapper and VAR=val assignments", () => {
+		assert.equal(buildBashPermissionPattern("env NODE_ENV=prod node server.js"), "Bash(node:*)");
+		assert.equal(buildBashPermissionPattern("NODE_ENV=prod node server.js"), "Bash(node:*)");
+		assert.equal(buildBashPermissionPattern("FOO=bar BAZ=qux git push"), "Bash(git push:*)");
+	});
+
+	test("strips path from executable", () => {
+		assert.equal(buildBashPermissionPattern("/usr/bin/git push"), "Bash(git push:*)");
+		assert.equal(buildBashPermissionPattern("C:\\Windows\\ping.exe localhost"), "Bash(ping:*)");
+	});
+
+	test("empty or whitespace-only command", () => {
+		assert.equal(buildBashPermissionPattern(""), "Bash(*)");
+		assert.equal(buildBashPermissionPattern("   "), "Bash(*)");
+	});
+
+	test("chained commands — extracts pattern from the meaningful segment", () => {
+		assert.equal(buildBashPermissionPattern("cd /foo && gh pr list --limit 5"), "Bash(gh pr list:*)");
+		assert.equal(buildBashPermissionPattern("cd C:/Users/djeff/repos/gsd-2 && gh pr list --limit 5"), "Bash(gh pr list:*)");
+		assert.equal(buildBashPermissionPattern("cd /tmp && git push origin main"), "Bash(git push:*)");
+		assert.equal(buildBashPermissionPattern("export FOO=1 && npm install lodash"), "Bash(npm install:*)");
+		assert.equal(buildBashPermissionPattern("mkdir -p out; docker ps -a"), "Bash(docker ps:*)");
+		assert.equal(buildBashPermissionPattern("echo start || ping localhost"), "Bash(ping:*)");
+	});
+
+	test("skips trailing || true / || : error suppressors", () => {
+		assert.equal(
+			buildBashPermissionPattern("cd C:/Users/djeff/repos/gsd-2 && gh pr create --dry-run --title \"test\" --body \"test\" 2>&1 || true"),
+			"Bash(gh pr create:*)",
+		);
+		assert.equal(buildBashPermissionPattern("gh pr list || true"), "Bash(gh pr list:*)");
+		assert.equal(buildBashPermissionPattern("git push || :"), "Bash(git push:*)");
+		assert.equal(buildBashPermissionPattern("cd /tmp && npm install || echo failed"), "Bash(npm install:*)");
+	});
+
+	test("single command is unaffected by chain extraction", () => {
+		assert.equal(buildBashPermissionPattern("gh pr list"), "Bash(gh pr list:*)");
+		assert.equal(buildBashPermissionPattern("git push origin main"), "Bash(git push:*)");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// buildBashPermissionPatternOptions — granularity level menu
+// ---------------------------------------------------------------------------
+
+describe("buildBashPermissionPatternOptions", () => {
+	test("offers every prefix from base to full subcommand chain", () => {
+		assert.deepEqual(buildBashPermissionPatternOptions("gh pr list"), [
+			"Bash(gh:*)",
+			"Bash(gh pr:*)",
+			"Bash(gh pr list:*)",
+		]);
+		assert.deepEqual(buildBashPermissionPatternOptions("git push origin main"), [
+			"Bash(git:*)",
+			"Bash(git push:*)",
+			"Bash(git push origin:*)",
+			"Bash(git push origin main:*)",
+		]);
+	});
+
+	test("stops at first flag — flags are args, not verbs", () => {
+		assert.deepEqual(buildBashPermissionPatternOptions("gh pr create --title foo"), [
+			"Bash(gh:*)",
+			"Bash(gh pr:*)",
+			"Bash(gh pr create:*)",
+		]);
+		assert.deepEqual(buildBashPermissionPatternOptions("git log --oneline"), [
+			"Bash(git:*)",
+			"Bash(git log:*)",
+		]);
+	});
+
+	test("single-option when there is no subcommand to choose from", () => {
+		assert.deepEqual(buildBashPermissionPatternOptions("ls -la /tmp"), ["Bash(ls:*)"]);
+		assert.deepEqual(buildBashPermissionPatternOptions("ping -n 4 localhost"), ["Bash(ping:*)"]);
+		assert.deepEqual(buildBashPermissionPatternOptions("node"), ["Bash(node:*)"]);
+	});
+
+	test("extracts meaningful segment from compound commands", () => {
+		assert.deepEqual(buildBashPermissionPatternOptions("cd /foo && gh pr list"), [
+			"Bash(gh:*)",
+			"Bash(gh pr:*)",
+			"Bash(gh pr list:*)",
+		]);
+		assert.deepEqual(buildBashPermissionPatternOptions("gh pr create --dry-run || true"), [
+			"Bash(gh:*)",
+			"Bash(gh pr:*)",
+			"Bash(gh pr create:*)",
+		]);
+	});
+
+	test("caps at three subcommand tokens to keep the menu short", () => {
+		const result = buildBashPermissionPatternOptions("foo bar baz qux quux corge");
+		// base + 3 sub tokens = 4 patterns max
+		assert.equal(result.length, 4);
+		assert.deepEqual(result, [
+			"Bash(foo:*)",
+			"Bash(foo bar:*)",
+			"Bash(foo bar baz:*)",
+			"Bash(foo bar baz qux:*)",
+		]);
+	});
+
+	test("skips sudo/env wrappers like the single-pattern variant", () => {
+		assert.deepEqual(buildBashPermissionPatternOptions("sudo git push origin"), [
+			"Bash(git:*)",
+			"Bash(git push:*)",
+			"Bash(git push origin:*)",
+		]);
+		assert.deepEqual(buildBashPermissionPatternOptions("NODE_ENV=prod node server.js"), [
+			"Bash(node:*)",
+			"Bash(node server.js:*)",
+		]);
+	});
+
+	test("empty command returns the catch-all pattern", () => {
+		assert.deepEqual(buildBashPermissionPatternOptions(""), ["Bash(*)"]);
+		assert.deepEqual(buildBashPermissionPatternOptions("   "), ["Bash(*)"]);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// bashCommandMatchesSavedRules — compound command bypass for saved rules
+// ---------------------------------------------------------------------------
+
+describe("bashCommandMatchesSavedRules — compound command bypass", () => {
+	let tempDir: string;
+	let originalCwd: string;
+
+	// Create a temp project directory with .claude/settings.local.json
+	function setupSettings(allow: string[]): void {
+		const claudeDir = join(tempDir, ".claude");
+		mkdirSync(claudeDir, { recursive: true });
+		writeFileSync(
+			join(claudeDir, "settings.local.json"),
+			JSON.stringify({ permissions: { allow } }),
+		);
+	}
+
+	// biome-ignore lint/suspicious/noExplicitAny: test-only monkey-patch
+	let origCwd: any;
+
+	// Monkey-patch process.cwd() to point at our temp dir
+	function setCwd(dir: string): void {
+		origCwd = process.cwd;
+		process.cwd = () => dir;
+	}
+	function restoreCwd(): void {
+		if (origCwd) process.cwd = origCwd;
+	}
+
+	test("matches cd-prefixed compound command against saved prefix rule", () => {
+		tempDir = realpathSync(mkdtempSync(join(tmpdir(), "gsd-rules-")));
+		try {
+			setupSettings(["Bash(gh pr list:*)"]);
+			setCwd(tempDir);
+			assert.equal(
+				bashCommandMatchesSavedRules("cd /some/path && gh pr list --limit 5"),
+				true,
+			);
+		} finally {
+			restoreCwd();
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	test("matches cd-prefixed compound command with exact subcommand", () => {
+		tempDir = realpathSync(mkdtempSync(join(tmpdir(), "gsd-rules-")));
+		try {
+			setupSettings(["Bash(gh pr list:*)"]);
+			setCwd(tempDir);
+			assert.equal(
+				bashCommandMatchesSavedRules("cd C:/Users/foo/repos/bar && gh pr list"),
+				true,
+			);
+		} finally {
+			restoreCwd();
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	test("rejects when leading segment is not cd", () => {
+		tempDir = realpathSync(mkdtempSync(join(tmpdir(), "gsd-rules-")));
+		try {
+			setupSettings(["Bash(gh pr list:*)"]);
+			setCwd(tempDir);
+			// "rm -rf /tmp" is not a cd command — should not auto-approve
+			assert.equal(
+				bashCommandMatchesSavedRules("rm -rf /tmp && gh pr list"),
+				false,
+			);
+		} finally {
+			restoreCwd();
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	test("rejects when meaningful segment does not match any rule", () => {
+		tempDir = realpathSync(mkdtempSync(join(tmpdir(), "gsd-rules-")));
+		try {
+			setupSettings(["Bash(gh pr list:*)"]);
+			setCwd(tempDir);
+			assert.equal(
+				bashCommandMatchesSavedRules("cd /path && gh issue create --title foo"),
+				false,
+			);
+		} finally {
+			restoreCwd();
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	test("matches simple (non-compound) commands against on-disk rules", () => {
+		tempDir = realpathSync(mkdtempSync(join(tmpdir(), "gsd-rules-")));
+		try {
+			setupSettings(["Bash(gh pr list:*)"]);
+			setCwd(tempDir);
+			// Simple commands must also be checked — the SDK's in-memory cache
+			// may be stale if the rule was added mid-session via "Always Allow"
+			assert.equal(bashCommandMatchesSavedRules("gh pr list --limit 5"), true);
+			assert.equal(bashCommandMatchesSavedRules("gh pr list"), true);
+		} finally {
+			restoreCwd();
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	test("returns false for simple commands with no matching rule", () => {
+		tempDir = realpathSync(mkdtempSync(join(tmpdir(), "gsd-rules-")));
+		try {
+			setupSettings(["Bash(gh pr list:*)"]);
+			setCwd(tempDir);
+			assert.equal(bashCommandMatchesSavedRules("gh issue list --limit 5"), false);
+		} finally {
+			restoreCwd();
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	test("returns false when no settings file exists", () => {
+		tempDir = realpathSync(mkdtempSync(join(tmpdir(), "gsd-rules-")));
+		try {
+			// No .claude/settings.local.json created
+			setCwd(tempDir);
+			assert.equal(
+				bashCommandMatchesSavedRules("cd /path && gh pr list"),
+				false,
+			);
+		} finally {
+			restoreCwd();
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	test("matches exact rule (non-prefix)", () => {
+		tempDir = realpathSync(mkdtempSync(join(tmpdir(), "gsd-rules-")));
+		try {
+			setupSettings(["Bash(ping -n 4 localhost)"]);
+			setCwd(tempDir);
+			assert.equal(
+				bashCommandMatchesSavedRules("cd /path && ping -n 4 localhost"),
+				true,
+			);
+		} finally {
+			restoreCwd();
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	test("handles multiple cd segments before the meaningful command", () => {
+		tempDir = realpathSync(mkdtempSync(join(tmpdir(), "gsd-rules-")));
+		try {
+			setupSettings(["Bash(npm install:*)"]);
+			setCwd(tempDir);
+			assert.equal(
+				bashCommandMatchesSavedRules("cd /home && cd project && npm install lodash"),
+				true,
+			);
+		} finally {
+			restoreCwd();
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	test("matches compound command with trailing || true suppressor", () => {
+		tempDir = realpathSync(mkdtempSync(join(tmpdir(), "gsd-rules-")));
+		try {
+			setupSettings(["Bash(gh pr create:*)"]);
+			setCwd(tempDir);
+			assert.equal(
+				bashCommandMatchesSavedRules('cd C:/Users/djeff/repos/gsd-2 && gh pr create --dry-run --title "test" --body "test" 2>&1 || true'),
+				true,
+			);
+			assert.equal(
+				bashCommandMatchesSavedRules("gh pr create --dry-run || true"),
+				true,
+			);
+			assert.equal(
+				bashCommandMatchesSavedRules("cd /tmp && git push || :"),
+				false, // rule is for gh pr create, not git push
+			);
+		} finally {
+			restoreCwd();
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	test("reads rules from settings.json as well as settings.local.json", () => {
+		tempDir = realpathSync(mkdtempSync(join(tmpdir(), "gsd-rules-")));
+		try {
+			const claudeDir = join(tempDir, ".claude");
+			mkdirSync(claudeDir, { recursive: true });
+			writeFileSync(
+				join(claudeDir, "settings.json"),
+				JSON.stringify({ permissions: { allow: ["Bash(git push:*)"] } }),
+			);
+			setCwd(tempDir);
+			assert.equal(
+				bashCommandMatchesSavedRules("cd /repo && git push origin main"),
+				true,
+			);
+		} finally {
+			restoreCwd();
+			rmSync(tempDir, { recursive: true, force: true });
+		}
 	});
 });

--- a/src/tests/claude-cli-windows-detection.test.ts
+++ b/src/tests/claude-cli-windows-detection.test.ts
@@ -28,6 +28,9 @@ import { join } from "node:path";
 const WINDOWS_CLAUDE_SELECTOR =
 	/process\.platform\s*===\s*['"]win32['"]\s*\?\s*['"]claude\.cmd['"]\s*:\s*['"]claude['"]/;
 
+const WINDOWS_CMD_SHELL_GUARD =
+	/shell\s*:\s*process\.platform\s*===\s*['"]win32['"]/;
+
 /**
  * Verifies the onboarding-level readiness check (`claude-cli-check.ts`)
  * carries the `process.platform === 'win32' ? 'claude.cmd' : 'claude'`
@@ -44,6 +47,12 @@ function verifyCliCheckSelector(): void {
 		source,
 		WINDOWS_CLAUDE_SELECTOR,
 		"claude-cli-check.ts must implement process.platform === 'win32' ? 'claude.cmd' : 'claude'",
+	);
+
+	assert.match(
+		source,
+		WINDOWS_CMD_SHELL_GUARD,
+		"claude-cli-check.ts must pass shell: process.platform === 'win32' when spawning claude.cmd",
 	);
 }
 
@@ -69,6 +78,12 @@ function verifyReadinessSelector(): void {
 		source,
 		WINDOWS_CLAUDE_SELECTOR,
 		"readiness.ts must implement process.platform === 'win32' ? 'claude.cmd' : 'claude'",
+	);
+
+	assert.match(
+		source,
+		WINDOWS_CMD_SHELL_GUARD,
+		"readiness.ts must pass shell: process.platform === 'win32' when spawning claude.cmd",
 	);
 }
 


### PR DESCRIPTION
## TL;DR

**What:** Adds a second-stage granularity picker after "Always Allow" on bash tool requests, and fixes chained-bash permission labels so the approval prompt surfaces reliably.
**Why:** Users were stuck on "This command requires approval" with no visible prompt (#4653), and the single-granularity Always Allow committed too aggressively without user input.
**How:** Split Always Allow into a two-stage flow — first-stage menu picks the action, second-stage picker scopes persistence (exact / prefix / unrestricted); chained-bash extraction ensures the label reflects the real command; dismissing the picker cancels the tool cleanly.

## What

- `src/resources/extensions/claude-code-cli/stream-adapter.ts` — two-stage Always Allow picker, chained-bash command extraction, cancel-on-dismiss, first-stage label no longer appends the command.
- `src/resources/extensions/claude-code-cli/tests/stream-adapter.test.ts` — covers picker flow, cancel path, chained-bash label extraction, and label suffix change.

## Why

Fixes #4653 — the approval prompt never reached users for git write commands because chained/compound bash invocations didn't resolve to a meaningful label for the permission layer, leaving the tool stuck in the "This command requires approval" error path with no visible prompt. The granularity picker was added at the same time so users can opt into the scope of the persisted permission (exact command vs prefix vs unrestricted) instead of having that choice made for them up front.

## How

- First-stage menu shows only the action ("Always Allow") without appending the command, since the second-stage picker now displays the command and scope.
- Second-stage picker surfaces exact / prefix / unrestricted options; dismissing it cancels the tool use cleanly instead of leaving it hanging.
- Chained bash invocations (e.g. `cd foo && git checkout main`) extract the meaningful inner command for labelling so the permission system evaluates and prompts against the real command.

Disclosure: AI-assisted.

- [x] `feat` — New feature or capability
- [x] `fix` — Bug fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added permission prompts for tool usage with Allow, Always Allow, and Deny options
  * Added persistent permission rules for Bash commands

* **Bug Fixes**
  * Improved Claude CLI detection and execution on Windows platforms

<!-- end of auto-generated comment: release notes by coderabbit.ai -->