### PR TITLE
test(gsd): remove DEAD_WEIGHT _resetExtractionState tautology (#4851)

### DIFF
--- a/src/resources/extensions/gsd/tests/memory-extractor.test.ts
+++ b/src/resources/extensions/gsd/tests/memory-extractor.test.ts
@@ -1,4 +1,4 @@
-import { parseMemoryResponse, _resetExtractionState, buildMemoryLLMCall } from '../memory-extractor.ts';
+import { parseMemoryResponse, buildMemoryLLMCall } from '../memory-extractor.ts';
 import {
   openDatabase,
   closeDatabase,
@@ -157,16 +157,6 @@ test('integration: mixed action lifecycle', () => {
   assert.deepStrictEqual(active[1].id, 'MEM002', 'MEM002 should rank second (0.88)');
 
   closeDatabase();
-});
-
-// ═══════════════════════════════════════════════════════════════════════════
-// memory-extractor: _resetExtractionState
-// ═══════════════════════════════════════════════════════════════════════════
-
-test('memory-extractor: reset extraction state', () => {
-  // Just verify it doesn't throw
-  _resetExtractionState();
-  assert.ok(true, '_resetExtractionState should not throw');
 });
 
 // ═══════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

Per #4851 section 1 (DEAD_WEIGHT), the `memory-extractor: reset extraction state` test called `_resetExtractionState()` and asserted `assert.ok(true)` — it passed regardless of implementation. No behaviour was under test.

- Removes the tautology test and now-unused `_resetExtractionState` import.
- Remaining 9 tests still exercise real behaviour (parse, validate, buildMemoryLLMCall).

This closes the `memory-extractor.test.ts` entry in #4851's DEAD_WEIGHT list. Other per-test entries in #4851 remain open; companion PRs #4876 / #4905 address separate portions.

## Test plan

- [x] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test src/resources/extensions/gsd/tests/memory-extractor.test.ts` — 9 pass, 0 fail

Refs #4851

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Simplified test suite by removing a regression test while preserving all tests for core functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->