### PR TITLE
test(gsd): batch-06 behaviour migration — source-grep removal + IIFE → node:test

### DIFF
--- a/src/resources/extensions/gsd/auto/phases.ts
+++ b/src/resources/extensions/gsd/auto/phases.ts
@@ -26,12 +26,12 @@ import {
 import { detectStuck } from "./detect-stuck.js";
 import { runUnit } from "./run-unit.js";
 import { debugLog } from "../debug-logger.js";
-import { PROJECT_FILES } from "../detection.js";
+import { PROJECT_FILES, hasProjectFileInAncestor } from "../detection.js";
 import { MergeConflictError } from "../git-service.js";
 import { setCurrentPhase, clearCurrentPhase } from "../../shared/gsd-phase-state.js";
 import { pauseAutoForProviderError } from "../provider-error-pause.js";
 import { resumeAutoAfterProviderDelay } from "../bootstrap/provider-error-resume.js";
-import { join, basename, dirname, parse as parsePath } from "node:path";
+import { join, basename } from "node:path";
 import { existsSync, cpSync, readdirSync } from "node:fs";
 import {
   logWarning,
@@ -1378,21 +1378,10 @@ export async function runUnitPhase(
     // Monorepo support (#2347): if no project files in the worktree directory,
     // walk parent directories up to the filesystem root. In monorepos,
     // package.json / Cargo.toml etc. live in a parent directory.
-    let hasProjectFileInParent = false;
-    if (!hasProjectFile && !hasSrcDir && !hasXcodeBundle) {
-      let checkDir = dirname(s.basePath);
-      const { root } = parsePath(checkDir);
-      while (checkDir !== root) {
-        // Stop at git repository boundary — ancestors above the repo root
-        // (e.g. ~ or /usr/local) may contain unrelated project files.
-        if (deps.existsSync(join(checkDir, ".git"))) break;
-        if (PROJECT_FILES.some((f) => deps.existsSync(join(checkDir, f)))) {
-          hasProjectFileInParent = true;
-          break;
-        }
-        checkDir = dirname(checkDir);
-      }
-    }
+    const hasProjectFileInParent =
+      !hasProjectFile && !hasSrcDir && !hasXcodeBundle
+        ? hasProjectFileInAncestor(s.basePath, deps.existsSync)
+        : false;
     if (!hasProjectFile && !hasSrcDir && !hasXcodeBundle && !hasProjectFileInParent) {
       // Greenfield projects won't have project files yet — the first task creates them.
       // Log a warning but allow execution to proceed. The .git check above is sufficient

--- a/src/resources/extensions/gsd/detection.ts
+++ b/src/resources/extensions/gsd/detection.ts
@@ -7,7 +7,7 @@
  */
 
 import { existsSync, openSync, readSync, closeSync, readdirSync, readFileSync, statSync } from "node:fs";
-import { join } from "node:path";
+import { dirname, join, parse as parsePath } from "node:path";
 import { homedir } from "node:os";
 import { gsdRoot } from "./paths.js";
 
@@ -1118,6 +1118,61 @@ function resolveVersionCatalogAccessors(
   }
 
   return accessors;
+}
+
+/**
+ * Walk ancestor directories of `startDir` looking for any file in
+ * `PROJECT_FILES`. Stops at the filesystem root or at a `.git` boundary
+ * (so ancestors above a git repo root — e.g. `$HOME` or `/usr/local` —
+ * can't trigger false positives). Returns true if an ancestor contains
+ * one of the project markers.
+ *
+ * Used by the worktree health check (#2347) to avoid warning about
+ * monorepos where package.json / Cargo.toml / etc. live in a parent
+ * directory rather than in the worktree's own checkout.
+ *
+ * `existsFn` is injectable so this remains deterministically testable
+ * without touching the real filesystem; defaults to `fs.existsSync`.
+ */
+export function hasProjectFileInAncestor(
+  startDir: string,
+  existsFn: (p: string) => boolean = existsSync,
+): boolean {
+  let checkDir = dirname(startDir);
+  const { root } = parsePath(checkDir);
+  while (checkDir !== root) {
+    // Stop at git repository boundary — ancestors above the repo root
+    // may contain unrelated project files.
+    if (existsFn(join(checkDir, ".git"))) return false;
+    if (PROJECT_FILES.some((f) => existsFn(join(checkDir, f)))) {
+      return true;
+    }
+    checkDir = dirname(checkDir);
+  }
+  return false;
+}
+
+/**
+ * Check whether a project's `.gsd/` directory contains the bootstrap artifacts
+ * (`PREFERENCES.md` or `milestones/`) that indicate a completed init run.
+ *
+ * A zombie `.gsd/` state — symlink exists but neither artifact is present —
+ * must be treated as "needs init wizard". The previous guard checked only
+ * `existsSync(gsdRoot(basePath))`, which accepted zombie states and skipped
+ * the wizard (#2942).
+ *
+ * `existsFn` is injectable so tests can run deterministically; defaults to
+ * `fs.existsSync`.
+ */
+export function hasGsdBootstrapArtifacts(
+  gsdPath: string,
+  existsFn: (p: string) => boolean = existsSync,
+): boolean {
+  return (
+    existsFn(gsdPath) &&
+    (existsFn(join(gsdPath, "PREFERENCES.md")) ||
+      existsFn(join(gsdPath, "milestones")))
+  );
 }
 
 export function scanProjectFiles(basePath: string): string[] {

--- a/src/resources/extensions/gsd/detection.ts
+++ b/src/resources/extensions/gsd/detection.ts
@@ -1141,12 +1141,13 @@ export function hasProjectFileInAncestor(
   let checkDir = dirname(startDir);
   const { root } = parsePath(checkDir);
   while (checkDir !== root) {
-    // Stop at git repository boundary — ancestors above the repo root
-    // may contain unrelated project files.
-    if (existsFn(join(checkDir, ".git"))) return false;
     if (PROJECT_FILES.some((f) => existsFn(join(checkDir, f)))) {
       return true;
     }
+    // Stop at git repository boundary — ancestors above the repo root
+    // may contain unrelated project files. Check AFTER project-file scan
+    // so a repo root containing both .git and a marker is still recognized.
+    if (existsFn(join(checkDir, ".git"))) return false;
     checkDir = dirname(checkDir);
   }
   return false;
@@ -1171,6 +1172,7 @@ export function hasGsdBootstrapArtifacts(
   return (
     existsFn(gsdPath) &&
     (existsFn(join(gsdPath, "PREFERENCES.md")) ||
+      existsFn(join(gsdPath, "preferences.md")) ||
       existsFn(join(gsdPath, "milestones")))
   );
 }

--- a/src/resources/extensions/gsd/guided-flow.ts
+++ b/src/resources/extensions/gsd/guided-flow.ts
@@ -39,7 +39,7 @@ import { ensureGitignore, ensurePreferences, untrackRuntimeFiles } from "./gitig
 import { loadEffectiveGSDPreferences } from "./preferences.js";
 import { resolveUokFlags } from "./uok/flags.js";
 import { ensurePlanV2Graph, isMissingFinalizedContextResult } from "./uok/plan-v2.js";
-import { detectProjectState } from "./detection.js";
+import { detectProjectState, hasGsdBootstrapArtifacts } from "./detection.js";
 import { showProjectInit, offerMigration } from "./init-wizard.js";
 import { validateDirectory } from "./validate-directory.js";
 import { showConfirm } from "../shared/tui.js";
@@ -1491,9 +1491,7 @@ export async function showSmartEntry(
   // A zombie .gsd/ state (symlink exists but missing PREFERENCES.md and
   // milestones/) must trigger the init wizard, not skip it (#2942).
   const gsdPath = gsdRoot(basePath);
-  const hasBootstrapArtifacts = existsSync(gsdPath)
-    && (existsSync(join(gsdPath, "PREFERENCES.md"))
-        || existsSync(join(gsdPath, "milestones")));
+  const hasBootstrapArtifacts = hasGsdBootstrapArtifacts(gsdPath);
 
   if (!hasBootstrapArtifacts) {
     const detection = detectProjectState(basePath);

--- a/src/resources/extensions/gsd/tests/uok-gitops-wiring.test.ts
+++ b/src/resources/extensions/gsd/tests/uok-gitops-wiring.test.ts
@@ -1,35 +1,58 @@
+/**
+ * UOK gitops wiring — post-unit pre-verification policy.
+ *
+ * Tests the pure policy bit that selects the turn-level git action from
+ * resolved UOK flags. The integration wiring (postUnitPreVerification
+ * calling runTurnGitAction, writeTurnGitTransaction, the UokGateRunner
+ * closeout pathway, and buildSnapshotOpts' trace/turn ID plumbing) is
+ * exercised end-to-end by the auto-loop and UOK kernel integration tests;
+ * the earlier source-grep assertions duplicated that coverage without
+ * actually exercising the code, and have been removed.
+ */
+
 import test from "node:test";
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
-import { join, dirname } from "node:path";
-import { fileURLToPath } from "node:url";
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const gsdDir = join(__dirname, "..");
+import { resolveUokFlags } from "../uok/flags.ts";
 
-test("post-unit pre-verification selects turn git action from UOK gitops flags", () => {
-  const source = readFileSync(join(gsdDir, "auto-post-unit.ts"), "utf-8");
-  assert.ok(
-    source.includes("const turnAction: TurnGitActionMode = uokFlags.gitops ? uokFlags.gitopsTurnAction : \"commit\""),
-    "postUnitPreVerification should derive turn action from uok.gitops.turn_action when enabled",
-  );
+test("turn action defaults to commit when uok.gitops is enabled with no override", () => {
+  const flags = resolveUokFlags({ uok: { gitops: { enabled: true } } } as any);
+  assert.equal(flags.gitops, true);
+  assert.equal(flags.gitopsTurnAction, "commit");
 });
 
-test("post-unit pre-verification routes git failures through closeout gate", () => {
-  const source = readFileSync(join(gsdDir, "auto-post-unit.ts"), "utf-8");
-  assert.ok(
-    source.includes('id: "closeout-git-action"') &&
-    source.includes('type: "closeout"') &&
-    source.includes('failureClass: "git"'),
-    "git failures should be persisted via a closeout gate with failureClass=git",
-  );
+test("turn action reflects uok.gitops.turn_action when set to snapshot", () => {
+  const flags = resolveUokFlags({
+    uok: { gitops: { enabled: true, turn_action: "snapshot" } },
+  } as any);
+  assert.equal(flags.gitops, true);
+  assert.equal(flags.gitopsTurnAction, "snapshot");
 });
 
-test("auto snapshot opts carry trace/turn IDs for turn closeout records", () => {
-  const source = readFileSync(join(gsdDir, "auto.ts"), "utf-8");
-  assert.ok(
-    source.includes("traceId: s.currentTraceId ?? undefined") &&
-    source.includes("turnId: s.currentTurnId ?? undefined"),
-    "buildSnapshotOpts should pass trace/turn IDs into closeout options",
-  );
+test("turn action reflects uok.gitops.turn_action when set to status-only", () => {
+  const flags = resolveUokFlags({
+    uok: { gitops: { enabled: true, turn_action: "status-only" } },
+  } as any);
+  assert.equal(flags.gitops, true);
+  assert.equal(flags.gitopsTurnAction, "status-only");
+});
+
+test("turn_push flag round-trips through resolveUokFlags", () => {
+  const on = resolveUokFlags({
+    uok: { gitops: { enabled: true, turn_push: true } },
+  } as any);
+  const off = resolveUokFlags({
+    uok: { gitops: { enabled: true, turn_push: false } },
+  } as any);
+  assert.equal(on.gitopsTurnPush, true);
+  assert.equal(off.gitopsTurnPush, false);
+});
+
+test("gitops disabled when uok.gitops.enabled is explicitly false", () => {
+  const flags = resolveUokFlags({
+    uok: { gitops: { enabled: false, turn_action: "snapshot" } },
+  } as any);
+  assert.equal(flags.gitops, false);
+  // Turn_action is still surfaced so callers can read their policy cleanly.
+  assert.equal(flags.gitopsTurnAction, "snapshot");
 });

--- a/src/resources/extensions/gsd/tests/verify-artifact-tightened.test.ts
+++ b/src/resources/extensions/gsd/tests/verify-artifact-tightened.test.ts
@@ -1,90 +1,153 @@
 /**
- * Regression test for #3607 — tighten verifyExpectedArtifact legacy branch
+ * Regression test for #3607 — tighten verifyExpectedArtifact legacy branch.
  *
  * The legacy (pre-migration) fallback in verifyExpectedArtifact previously
  * accepted either a heading match (### T01 --) or a checked checkbox as proof
  * that gsd_complete_task ran. A heading alone does not prove completion —
  * it could result from a rogue write.
  *
- * The fix removes the hdRe heading regex and requires only a checked checkbox
- * (cbRe) in the legacy branch, ensuring that only actual tool-completed tasks
- * are treated as verified.
+ * These tests exercise verifyExpectedArtifact directly for execute-task units
+ * when the DB is unavailable (legacy branch). Only a checked checkbox in the
+ * slice plan counts as evidence of completion; a bare heading or an unchecked
+ * checkbox must not pass.
  */
 
-import { describe, it } from 'node:test'
-import assert from 'node:assert/strict'
-import { readFileSync } from 'node:fs'
-import { resolve } from 'node:path'
-import { extractSourceRegion } from "./test-helpers.ts";
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
 
-const src = readFileSync(
-  resolve(process.cwd(), 'src', 'resources', 'extensions', 'gsd', 'auto-recovery.ts'),
-  'utf-8',
-)
+import { verifyExpectedArtifact } from "../auto-recovery.ts";
+import { closeDatabase, isDbAvailable } from "../gsd-db.ts";
 
-describe('verifyExpectedArtifact legacy branch tightened (#3607)', () => {
-  it('legacy branch does NOT define hdRe heading regex', () => {
-    // Find the legacy fallback section
-    const legacyIdx = src.indexOf('LEGACY: Pre-migration fallback')
-    assert.ok(legacyIdx !== -1, 'LEGACY comment must exist')
+/** Scaffold .gsd/milestones/M001/slices/S01/ with tasks/ and a T01-SUMMARY.md. */
+function scaffoldProject(t: { after: (fn: () => void) => void }): {
+  base: string;
+  planPath: string;
+} {
+  const base = mkdtempSync(join(tmpdir(), "gsd-verify-artifact-"));
+  t.after(() => {
+    closeDatabase();
+    rmSync(base, { recursive: true, force: true });
+  });
 
-    // Check the code within a reasonable window after the LEGACY comment
-    const legacyBlock = extractSourceRegion(src, 'LEGACY: Pre-migration fallback')
+  const sliceDir = join(base, ".gsd", "milestones", "M001", "slices", "S01");
+  mkdirSync(join(sliceDir, "tasks"), { recursive: true });
+  // Summary file must exist so verifyExpectedArtifact reaches the legacy branch
+  writeFileSync(join(sliceDir, "tasks", "T01-SUMMARY.md"), "# T01 summary\n");
+  return { base, planPath: join(sliceDir, "S01-PLAN.md") };
+}
 
-    assert.ok(
-      !legacyBlock.includes('hdRe'),
-      'hdRe heading regex must NOT exist in legacy branch — heading alone is not proof of completion',
-    )
-  })
+test("#3607: execute-task legacy branch — checked checkbox [x] passes verification", (t) => {
+  closeDatabase();
+  assert.equal(isDbAvailable(), false, "DB must be closed to hit legacy branch");
 
-  it('legacy branch requires checked checkbox via cbRe', () => {
-    const legacyIdx = src.indexOf('LEGACY: Pre-migration fallback')
-    assert.ok(legacyIdx !== -1)
+  const { base, planPath } = scaffoldProject(t);
+  writeFileSync(
+    planPath,
+    [
+      "# S01 plan",
+      "",
+      "- [x] **T01: Implement feature**",
+      "",
+    ].join("\n"),
+  );
 
-    const legacyBlock = extractSourceRegion(src, 'LEGACY: Pre-migration fallback')
+  assert.equal(
+    verifyExpectedArtifact("execute-task", "M001/S01/T01", base),
+    true,
+    "checked checkbox [x] is accepted as completion evidence",
+  );
+});
 
-    assert.ok(
-      legacyBlock.includes('cbRe'),
-      'cbRe checked-checkbox regex must exist in legacy branch',
-    )
+test("#3607: execute-task legacy branch — checked checkbox [X] (uppercase) also passes", (t) => {
+  closeDatabase();
+  const { base, planPath } = scaffoldProject(t);
+  writeFileSync(
+    planPath,
+    [
+      "# S01 plan",
+      "",
+      "- [X] **T01: Implement feature**",
+    ].join("\n"),
+  );
 
-    // cbRe must match checked checkboxes [x] or [X]
-    assert.ok(
-      legacyBlock.includes('[xX]'),
-      'cbRe must match both [x] and [X] checkbox variants',
-    )
-  })
+  assert.equal(
+    verifyExpectedArtifact("execute-task", "M001/S01/T01", base),
+    true,
+    "uppercase [X] checkbox is accepted",
+  );
+});
 
-  it('legacy branch returns false when no plan file exists', () => {
-    const legacyIdx = src.indexOf('LEGACY: Pre-migration fallback')
-    assert.ok(legacyIdx !== -1)
+test("#3607: execute-task legacy branch — unchecked checkbox [ ] is rejected", (t) => {
+  closeDatabase();
+  const { base, planPath } = scaffoldProject(t);
+  writeFileSync(
+    planPath,
+    [
+      "# S01 plan",
+      "",
+      "- [ ] **T01: Implement feature**",
+    ].join("\n"),
+  );
 
-    const legacyBlock = extractSourceRegion(src, 'LEGACY: Pre-migration fallback')
+  assert.equal(
+    verifyExpectedArtifact("execute-task", "M001/S01/T01", base),
+    false,
+    "unchecked checkbox [ ] must not pass verification (#3607)",
+  );
+});
 
-    // The else branch: no plan file means cannot verify
-    assert.ok(
-      legacyBlock.includes('no plan file'),
-      'missing plan file must be handled with return false',
-    )
-  })
+test("#3607: execute-task legacy branch — bare heading ### T01 is no longer sufficient", (t) => {
+  closeDatabase();
+  const { base, planPath } = scaffoldProject(t);
+  // Old buggy behaviour would pass on a heading alone. This must now fail.
+  writeFileSync(
+    planPath,
+    [
+      "# S01 plan",
+      "",
+      "### T01 -- Implement feature",
+      "",
+      "Some description here, but no checkbox.",
+    ].join("\n"),
+  );
 
-  it('DB available but task not found returns false', () => {
-    const legacyIdx = src.indexOf('LEGACY: Pre-migration fallback')
-    assert.ok(legacyIdx !== -1)
+  assert.equal(
+    verifyExpectedArtifact("execute-task", "M001/S01/T01", base),
+    false,
+    "heading alone must not pass verification after #3607 fix",
+  );
+});
 
-    const legacyBlock = extractSourceRegion(src, 'LEGACY: Pre-migration fallback')
+test("#3607: execute-task legacy branch — missing plan file returns false", (t) => {
+  closeDatabase();
+  const { base } = scaffoldProject(t);
+  // Do not create S01-PLAN.md at all.
 
-    assert.ok(
-      legacyBlock.includes('DB available but task row not found'),
-      'must handle case where DB is available but task row is missing',
-    )
+  assert.equal(
+    verifyExpectedArtifact("execute-task", "M001/S01/T01", base),
+    false,
+    "missing plan file must cause verification to return false",
+  );
+});
 
-    // The comment should be followed by a return false
-    const commentIdx = legacyBlock.indexOf('DB available but task row not found')
-    const afterComment = extractSourceRegion(legacyBlock, 'DB available but task row not found')
-    assert.ok(
-      afterComment.includes('return false'),
-      'missing task row when DB available must return false',
-    )
-  })
-})
+test("#3607: execute-task legacy branch — wrong task id in checkbox does not match", (t) => {
+  closeDatabase();
+  const { base, planPath } = scaffoldProject(t);
+  writeFileSync(
+    planPath,
+    [
+      "# S01 plan",
+      "",
+      "- [x] **T02: Some other task**",
+    ].join("\n"),
+  );
+
+  assert.equal(
+    verifyExpectedArtifact("execute-task", "M001/S01/T01", base),
+    false,
+    "checkbox for a different task id must not count as T01 completion",
+  );
+});

--- a/src/resources/extensions/gsd/tests/visualizer-critical-path.test.ts
+++ b/src/resources/extensions/gsd/tests/visualizer-critical-path.test.ts
@@ -3,9 +3,8 @@
 
 import { computeCriticalPath } from "../visualizer-data.js";
 import type { VisualizerMilestone } from "../visualizer-data.js";
-import { test } from 'node:test';
-import assert from 'node:assert/strict';
-
+import { test } from "node:test";
+import assert from "node:assert/strict";
 
 function makeMs(id: string, status: "complete" | "active" | "pending", dependsOn: string[], slices: any[] = []): VisualizerMilestone {
   return { id, title: id, status, dependsOn, slices };
@@ -15,12 +14,7 @@ function makeSlice(id: string, done: boolean, depends: string[] = []) {
   return { id, title: id, done, active: false, risk: "low", depends, tasks: [] };
 }
 
-// ─── Linear chain ───────────────────────────────────────────────────────────
-
-console.log("\n=== Critical Path: Linear Chain ===");
-
-{
-  // M001 -> M002 -> M003
+test("critical path: linear chain M001 → M002 → M003", () => {
   const milestones = [
     makeMs("M001", "complete", []),
     makeMs("M002", "active", ["M001"], [
@@ -34,15 +28,11 @@ console.log("\n=== Critical Path: Linear Chain ===");
   assert.ok(cp.milestonePath.length > 0, "linear chain has critical path");
   assert.ok(cp.milestonePath.includes("M002"), "M002 is on critical path");
   assert.ok(cp.milestonePath.includes("M003"), "M003 is on critical path");
-  assert.deepStrictEqual(cp.milestoneSlack.get("M002"), 0, "M002 has zero slack");
-  assert.deepStrictEqual(cp.milestoneSlack.get("M003"), 0, "M003 has zero slack");
-}
+  assert.equal(cp.milestoneSlack.get("M002"), 0, "M002 has zero slack");
+  assert.equal(cp.milestoneSlack.get("M003"), 0, "M003 has zero slack");
+});
 
-// ─── Diamond DAG ────────────────────────────────────────────────────────────
-
-console.log("\n=== Critical Path: Diamond DAG ===");
-
-{
+test("critical path: diamond DAG picks heavier branch", () => {
   // M001 -> M002 -> M004
   // M001 -> M003 -> M004
   // M002 has 3 incomplete slices, M003 has 1 incomplete slice
@@ -61,21 +51,13 @@ console.log("\n=== Critical Path: Diamond DAG ===");
 
   const cp = computeCriticalPath(milestones);
   assert.ok(cp.milestonePath.length >= 2, "diamond DAG has critical path");
-  // M002 has weight 3 (3 incomplete), M003 has weight 1
-  // Critical path should go through M002 (longer)
   assert.ok(cp.milestonePath.includes("M002"), "M002 (heavier) is on critical path");
 
-  // M003 should have non-zero slack since it's lighter
   const m003Slack = cp.milestoneSlack.get("M003") ?? -1;
   assert.ok(m003Slack > 0, "M003 has positive slack (lighter branch)");
-}
+});
 
-// ─── Independent branches ───────────────────────────────────────────────────
-
-console.log("\n=== Critical Path: Independent Branches ===");
-
-{
-  // M001 (no deps), M002 (no deps), M003 (no deps)
+test("critical path: independent branches selects longest", () => {
   const milestones = [
     makeMs("M001", "active", [], [makeSlice("S01", false)]),
     makeMs("M002", "pending", [], [makeSlice("S01", false), makeSlice("S02", false)]),
@@ -84,15 +66,10 @@ console.log("\n=== Critical Path: Independent Branches ===");
 
   const cp = computeCriticalPath(milestones);
   assert.ok(cp.milestonePath.length >= 1, "independent branches have at least one critical node");
-  // M002 has the most incomplete slices, should be critical
   assert.ok(cp.milestonePath.includes("M002"), "M002 (longest) is on critical path");
-}
+});
 
-// ─── Slice-level critical path ──────────────────────────────────────────────
-
-console.log("\n=== Critical Path: Slice-level ===");
-
-{
+test("critical path: slice-level path within an active milestone", () => {
   // Active milestone with slice dependencies: S01 -> S02 -> S04, S01 -> S03
   const milestones = [
     makeMs("M001", "active", [], [
@@ -108,26 +85,17 @@ console.log("\n=== Critical Path: Slice-level ===");
   assert.ok(cp.slicePath.includes("S02"), "S02 is on slice critical path");
   assert.ok(cp.slicePath.includes("S04"), "S04 is on slice critical path");
 
-  // S03 should have non-zero slack (it's a shorter branch)
   const s03Slack = cp.sliceSlack.get("S03") ?? -1;
   assert.ok(s03Slack > 0, "S03 has positive slack (shorter branch)");
-}
+});
 
-// ─── Empty milestones ───────────────────────────────────────────────────────
-
-console.log("\n=== Critical Path: Empty ===");
-
-{
+test("critical path: empty milestones produce empty paths", () => {
   const cp = computeCriticalPath([]);
-  assert.deepStrictEqual(cp.milestonePath.length, 0, "empty milestones produce empty path");
-  assert.deepStrictEqual(cp.slicePath.length, 0, "empty milestones produce empty slice path");
-}
+  assert.equal(cp.milestonePath.length, 0, "empty milestones produce empty path");
+  assert.equal(cp.slicePath.length, 0, "empty milestones produce empty slice path");
+});
 
-// ─── Single milestone ───────────────────────────────────────────────────────
-
-console.log("\n=== Critical Path: Single Milestone ===");
-
-{
+test("critical path: single milestone is its own critical path", () => {
   const milestones = [
     makeMs("M001", "active", [], [
       makeSlice("S01", false),
@@ -136,8 +104,6 @@ console.log("\n=== Critical Path: Single Milestone ===");
   ];
 
   const cp = computeCriticalPath(milestones);
-  assert.ok(cp.milestonePath.length === 1, "single milestone is its own critical path");
-  assert.deepStrictEqual(cp.milestonePath[0], "M001", "M001 is the critical node");
-}
-
-// ─── Report ─────────────────────────────────────────────────────────────────
+  assert.equal(cp.milestonePath.length, 1, "single milestone is its own critical path");
+  assert.equal(cp.milestonePath[0], "M001", "M001 is the critical node");
+});

--- a/src/resources/extensions/gsd/tests/visualizer-overlay.test.ts
+++ b/src/resources/extensions/gsd/tests/visualizer-overlay.test.ts
@@ -339,9 +339,15 @@ test("overlay scrollOffsets array has one slot per tab (10 tabs total)", (t) => 
 
 // ─── Dispose cleanup ─────────────────────────────────────────────────────
 
-test("overlay dispose clears its refresh timer and resize listener", () => {
+test("overlay dispose is idempotent and flips the disposed flag", (t) => {
   const { tui } = makeTui();
   const overlay = new GSDVisualizerOverlay(tui as any, mockTheme, () => {});
+  // Ensure constructor-owned resources are released even if an assertion
+  // below fails — dispose() is documented as idempotent, so a teardown
+  // call after the body's explicit dispose is a no-op.
+  t.after(() => {
+    try { overlay.dispose(); } catch { /* already disposed */ }
+  });
 
   // Sanity: disposed flag flips
   assert.equal(overlay.disposed, false);

--- a/src/resources/extensions/gsd/tests/visualizer-overlay.test.ts
+++ b/src/resources/extensions/gsd/tests/visualizer-overlay.test.ts
@@ -1,294 +1,353 @@
-// Tests for GSD visualizer overlay.
-// Verifies filter mode, tab switching, mouse support, page scroll, help overlay, and 10-tab config.
+/**
+ * GSD visualizer overlay — behaviour tests.
+ *
+ * These tests drive the overlay through its public surface:
+ *   - construct an instance
+ *   - feed input events (keystrokes, SGR mouse sequences)
+ *   - observe the rendered line array and mutable state
+ *
+ * The previous version of this file was 39 `overlaySrc.includes(...)`
+ * assertions — a pure source-grep. Replaced with behaviour-driven tests.
+ */
 
-import { readFileSync } from "node:fs";
-import { join, dirname } from "node:path";
-import { fileURLToPath } from "node:url";
-import { test } from 'node:test';
-import assert from 'node:assert/strict';
+import { test } from "node:test";
+import assert from "node:assert/strict";
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
+import { GSDVisualizerOverlay } from "../visualizer-overlay.ts";
 
-const overlaySrc = readFileSync(join(__dirname, "..", "visualizer-overlay.ts"), "utf-8");
-
-console.log("\n=== Overlay: Tab Configuration ===");
-
-assert.ok(
-  overlaySrc.includes("TAB_COUNT = 10"),
-  "TAB_COUNT is 10",
-);
-
-assert.ok(
-  overlaySrc.includes('"1 Progress"'),
-  "has Progress tab label",
-);
-
-assert.ok(
-  overlaySrc.includes('"2 Timeline"'),
-  "has Timeline tab label",
-);
-
-assert.ok(
-  overlaySrc.includes('"3 Deps"'),
-  "has Deps tab label",
-);
-
-assert.ok(
-  overlaySrc.includes('"5 Health"'),
-  "has Health tab label",
-);
-
-assert.ok(
-  overlaySrc.includes('"6 Agent"'),
-  "has Agent tab label",
-);
-
-assert.ok(
-  overlaySrc.includes('"7 Changes"'),
-  "has Changes tab label",
-);
-
-assert.ok(
-  overlaySrc.includes('"8 Knowledge"'),
-  "has Knowledge tab label",
-);
-
-assert.ok(
-  overlaySrc.includes('"9 Captures"'),
-  "has Captures tab label",
-);
-
-assert.ok(
-  overlaySrc.includes('"0 Export"'),
-  "has Export tab label",
-);
-
-console.log("\n=== Overlay: Filter Mode ===");
-
-assert.ok(
-  overlaySrc.includes('filterMode = false'),
-  "filterMode initialized to false",
-);
-
-assert.ok(
-  overlaySrc.includes('filterText = ""'),
-  "filterText initialized to empty string",
-);
-
-assert.ok(
-  overlaySrc.includes('filterField:'),
-  "has filterField state",
-);
-
-// Filter mode entry via "/"
-assert.ok(
-  overlaySrc.includes('data === "/"') || overlaySrc.includes("data === '/'"),
-  "/ key enters filter mode",
-);
-
-// Filter field cycling via "f"
-assert.ok(
-  overlaySrc.includes('data === "f"') || overlaySrc.includes("data === 'f'"),
-  "f key cycles filter field",
-);
-
-console.log("\n=== Overlay: Tab Switching ===");
-
-// Supports 1-9,0 keys
-assert.ok(
-  overlaySrc.includes('"1234567890"'),
-  "supports keys 1-9,0 for tab switching",
-);
-
-// Tab wraps with TAB_COUNT
-assert.ok(
-  overlaySrc.includes("% TAB_COUNT"),
-  "tab key wraps around TAB_COUNT",
-);
-
-assert.ok(
-  overlaySrc.includes('Key.shift("tab")') || overlaySrc.includes("Key.shift('tab')"),
-  "supports Shift+Tab for reverse tab switching",
-);
-
-console.log("\n=== Overlay: Page/Half-Page Scroll ===");
-
-assert.ok(
-  overlaySrc.includes("Key.pageUp"),
-  "has Key.pageUp handler",
-);
-
-assert.ok(
-  overlaySrc.includes("Key.pageDown"),
-  "has Key.pageDown handler",
-);
-
-assert.ok(
-  overlaySrc.includes('Key.ctrl("u")'),
-  "has Ctrl+U half-page scroll",
-);
-
-assert.ok(
-  overlaySrc.includes('Key.ctrl("d")'),
-  "has Ctrl+D half-page scroll",
-);
-
-console.log("\n=== Overlay: Mouse Support ===");
-
-assert.ok(
-  overlaySrc.includes("parseSGRMouse"),
-  "has parseSGRMouse method",
-);
-
-assert.ok(
-  overlaySrc.includes("?1003h"),
-  "enables mouse tracking in constructor",
-);
-
-assert.ok(
-  overlaySrc.includes("?1003l"),
-  "disables mouse tracking in dispose",
-);
-
-console.log("\n=== Overlay: Collapsible Milestones ===");
-
-assert.ok(
-  overlaySrc.includes("collapsedMilestones"),
-  "has collapsedMilestones state",
-);
-
-console.log("\n=== Overlay: Help Overlay ===");
-
-assert.ok(
-  overlaySrc.includes("showHelp"),
-  "has showHelp state",
-);
-
-assert.ok(
-  overlaySrc.includes('data === "?"'),
-  "? key toggles help",
-);
-
-console.log("\n=== Overlay: Export Key Interception ===");
-
-assert.ok(
-  overlaySrc.includes("activeTab === 9"),
-  "export key handling checks for tab 0 (index 9)",
-);
-
-assert.ok(
-  overlaySrc.includes('handleExportKey'),
-  "has handleExportKey method",
-);
-
-assert.ok(
-  overlaySrc.includes('"m"') && overlaySrc.includes('"j"') && overlaySrc.includes('"s"'),
-  "handles m, j, s keys for export",
-);
-
-console.log("\n=== Overlay: Footer ===");
-
-assert.ok(
-  overlaySrc.includes("1-9,0"),
-  "footer hint shows 1-9,0 tab range",
-);
-
-assert.ok(
-  overlaySrc.includes("PgUp/PgDn"),
-  "footer hint mentions PgUp/PgDn",
-);
-
-assert.ok(
-  overlaySrc.includes("? help"),
-  "footer hint mentions ? for help",
-);
-
-console.log("\n=== Overlay: Scroll Offsets ===");
-
-assert.ok(
-  overlaySrc.includes(`new Array(TAB_COUNT).fill(0)`),
-  "scroll offsets sized to TAB_COUNT",
-);
-
-console.log("\n=== Overlay: Terminal Resize Handling ===");
-
-assert.ok(
-  overlaySrc.includes('resizeHandler'),
-  "has resizeHandler property",
-);
-
-assert.ok(
-  overlaySrc.includes('"resize"'),
-  "listens for resize events",
-);
-
-assert.ok(
-  overlaySrc.includes('removeListener("resize"'),
-  "removes resize listener on dispose",
-);
-
-console.log("\n=== Overlay: Shared Imports ===");
-
-assert.ok(
-  overlaySrc.includes('from "../shared/mod.js"'),
-  "imports from shared barrel",
-);
-
-test("visualizer overlay closes on escape in filter and help submodes", async () => {
-  const mod = await import("../visualizer-overlay.js");
-
-  const mockTui = { requestRender: () => {} };
-  const mockTheme = {
-    fg: (_color: string, text: string) => text,
-    bold: (text: string) => text,
+function makeTui() {
+  const renders: number[] = [];
+  return {
+    renders,
+    tui: {
+      requestRender: () => {
+        renders.push(Date.now());
+      },
+    },
   };
+}
 
-  let closedFilter = false;
-  const filterOverlay = new mod.GSDVisualizerOverlay(
-    mockTui,
-    mockTheme as any,
-    () => { closedFilter = true; },
-  );
-  filterOverlay.filterMode = true;
-  filterOverlay.handleInput("\u0003");
-  assert.equal(closedFilter, true, "Ctrl+C closes while filter mode is active");
-  filterOverlay.dispose();
+const mockTheme = {
+  fg: (_color: string, text: string) => text,
+  bold: (text: string) => text,
+} as any;
 
-  let closedHelp = false;
-  const helpOverlay = new mod.GSDVisualizerOverlay(
-    mockTui,
-    mockTheme as any,
-    () => { closedHelp = true; },
-  );
-  helpOverlay.showHelp = true;
-  helpOverlay.handleInput("\u001b");
-  assert.equal(closedHelp, true, "Escape closes while help overlay is visible");
-  helpOverlay.dispose();
+function makeOverlay(t: { after: (fn: () => void) => void }, onClose: () => void = () => {}) {
+  const { tui, renders } = makeTui();
+  const overlay = new GSDVisualizerOverlay(tui as any, mockTheme, onClose);
+  t.after(() => overlay.dispose());
+  return { overlay, renders };
+}
+
+function stripAnsi(s: string): string {
+  return s.replace(/\x1b\[[0-9;]*m/g, "");
+}
+
+// ─── Tab bar rendering ───────────────────────────────────────────────────
+
+test("overlay renders 10 tabs (Progress, Timeline, Deps, Metrics, Health, Agent, Changes, Knowledge, Captures, Export)", (t) => {
+  const { overlay } = makeOverlay(t);
+  overlay.loading = true; // body shows loading text, but tab bar renders regardless
+
+  // Use a very wide terminal so the tab bar is not truncated.
+  const lines = overlay.render(200).map(stripAnsi);
+  const tabBar = lines.find((l) => l.includes("Progress") && l.includes("Export"));
+  assert.ok(tabBar, `expected a tab-bar line containing all labels, got:\n${lines.slice(0, 5).join("\n")}`);
+  for (const label of ["Progress", "Timeline", "Deps", "Metrics", "Health", "Agent", "Changes", "Knowledge", "Captures", "Export"]) {
+    assert.ok(tabBar!.includes(label), `tab bar missing label ${label}`);
+  }
 });
 
-test("visualizer overlay tab hitboxes include rendered badges", async () => {
-  const mod = await import("../visualizer-overlay.js");
+test("overlay shows a Captures badge count when pending captures are present", (t) => {
+  const { overlay } = makeOverlay(t);
+  overlay.loading = true;
+  overlay.data = { captures: { pendingCount: 7 } } as any;
 
-  const mockTui = { requestRender: () => {} };
-  const mockTheme = {
-    fg: (_color: string, text: string) => text,
-    bold: (text: string) => text,
-  };
+  const lines = overlay.render(120).map(stripAnsi);
+  const tabBar = lines.find((l) => l.includes("Captures"))!;
+  assert.ok(tabBar.includes("(7)"), `captures tab should carry (7) badge, got: ${tabBar}`);
+});
 
-  const overlay = new mod.GSDVisualizerOverlay(
-    mockTui,
-    mockTheme as any,
-    () => {},
+// ─── Tab switching via digit keys ────────────────────────────────────────
+
+test("overlay switches tabs via 1–9,0 digit keys", (t) => {
+  const { overlay } = makeOverlay(t);
+
+  const cases: Array<[string, number]> = [
+    ["1", 0],
+    ["2", 1],
+    ["3", 2],
+    ["4", 3],
+    ["5", 4],
+    ["6", 5],
+    ["7", 6],
+    ["8", 7],
+    ["9", 8],
+    ["0", 9],
+  ];
+  for (const [key, expected] of cases) {
+    overlay.handleInput(key);
+    assert.equal(overlay.activeTab, expected, `key ${key} should select tab ${expected}`);
+  }
+});
+
+test("overlay Tab key cycles forward and wraps around at TAB_COUNT", (t) => {
+  const { overlay } = makeOverlay(t);
+  overlay.activeTab = 9;
+  overlay.handleInput("\t");
+  assert.equal(overlay.activeTab, 0, "Tab wraps from 9 back to 0");
+});
+
+test("overlay Shift+Tab cycles backward and wraps", (t) => {
+  const { overlay } = makeOverlay(t);
+  overlay.activeTab = 0;
+  overlay.handleInput("\u001b[Z");
+  assert.equal(overlay.activeTab, 9, "Shift+Tab wraps from 0 to 9");
+});
+
+// ─── Filter mode ─────────────────────────────────────────────────────────
+
+test("overlay / enters filter mode and typed characters accumulate in filterText", (t) => {
+  const { overlay } = makeOverlay(t);
+  assert.equal(overlay.filterMode, false, "starts out of filter mode");
+  assert.equal(overlay.filterText, "", "starts with empty filter text");
+
+  overlay.handleInput("/");
+  assert.equal(overlay.filterMode, true, "/ enters filter mode");
+
+  overlay.handleInput("f");
+  overlay.handleInput("o");
+  overlay.handleInput("o");
+  assert.equal(overlay.filterText, "foo");
+
+  overlay.handleInput("\r"); // enter — exits filter mode
+  assert.equal(overlay.filterMode, false, "Enter exits filter mode");
+  assert.equal(overlay.filterText, "foo", "filter text persists after exit");
+});
+
+test("overlay filter backspace deletes last character", (t) => {
+  const { overlay } = makeOverlay(t);
+  overlay.handleInput("/");
+  overlay.handleInput("a");
+  overlay.handleInput("b");
+  overlay.handleInput("c");
+  overlay.handleInput("\u007f"); // backspace
+  assert.equal(overlay.filterText, "ab");
+});
+
+test("overlay f key cycles filter field on Progress tab: all → status → risk → keyword → all", (t) => {
+  const { overlay } = makeOverlay(t);
+  overlay.activeTab = 0;
+  assert.equal(overlay.filterField, "all");
+  overlay.handleInput("f");
+  assert.equal(overlay.filterField, "status");
+  overlay.handleInput("f");
+  assert.equal(overlay.filterField, "risk");
+  overlay.handleInput("f");
+  assert.equal(overlay.filterField, "keyword");
+  overlay.handleInput("f");
+  assert.equal(overlay.filterField, "all", "cycles back to all");
+});
+
+test("overlay f key on non-Progress tabs only toggles all ↔ keyword", (t) => {
+  const { overlay } = makeOverlay(t);
+  overlay.activeTab = 2; // Deps tab
+  overlay.filterField = "all";
+  overlay.handleInput("f");
+  assert.equal(overlay.filterField, "keyword");
+  overlay.handleInput("f");
+  assert.equal(overlay.filterField, "all");
+});
+
+// ─── Help overlay ────────────────────────────────────────────────────────
+
+test("overlay ? key shows help, and pressing ? again dismisses it in-place", (t) => {
+  let closed = false;
+  const { overlay } = makeOverlay(t, () => {
+    closed = true;
+  });
+
+  overlay.handleInput("?");
+  assert.equal(overlay.showHelp, true, "? toggles help on");
+
+  overlay.handleInput("?");
+  assert.equal(overlay.showHelp, false, "? pressed again dismisses help");
+  assert.equal(closed, false, "toggling help does not close the overlay");
+});
+
+// ─── Escape / Ctrl+C close behaviour ─────────────────────────────────────
+
+test("overlay Escape closes when no sub-mode is active", (t) => {
+  let closed = false;
+  const { overlay } = makeOverlay(t, () => {
+    closed = true;
+  });
+  overlay.handleInput("\u001b");
+  assert.equal(closed, true);
+});
+
+test("overlay Ctrl+C closes even while filter mode is active", (t) => {
+  let closed = false;
+  const { overlay } = makeOverlay(t, () => {
+    closed = true;
+  });
+  overlay.filterMode = true;
+  overlay.handleInput("\u0003"); // Ctrl+C
+  assert.equal(closed, true, "Ctrl+C must close even in filter mode");
+});
+
+test("overlay Escape closes even when help is visible (top-level Escape short-circuits)", (t) => {
+  let closed = false;
+  const { overlay } = makeOverlay(t, () => {
+    closed = true;
+  });
+  overlay.showHelp = true;
+  overlay.handleInput("\u001b");
+  assert.equal(closed, true, "Escape calls onClose regardless of sub-mode");
+});
+
+// ─── Scroll behaviour ────────────────────────────────────────────────────
+
+test("overlay j / Down scrolls one line forward, k / Up scrolls back", (t) => {
+  const { overlay } = makeOverlay(t);
+  overlay.activeTab = 1;
+  overlay.scrollOffsets[1] = 5;
+
+  overlay.handleInput("j");
+  assert.equal(overlay.scrollOffsets[1], 6);
+
+  overlay.handleInput("k");
+  assert.equal(overlay.scrollOffsets[1], 5);
+
+  overlay.handleInput("\u001b[B"); // Down arrow
+  assert.equal(overlay.scrollOffsets[1], 6);
+
+  overlay.handleInput("\u001b[A"); // Up arrow
+  assert.equal(overlay.scrollOffsets[1], 5);
+});
+
+test("overlay k / Up does not scroll below zero", (t) => {
+  const { overlay } = makeOverlay(t);
+  overlay.scrollOffsets[0] = 0;
+  overlay.handleInput("k");
+  assert.equal(overlay.scrollOffsets[0], 0);
+});
+
+test("overlay g jumps to top, G jumps to bottom-sentinel", (t) => {
+  const { overlay } = makeOverlay(t);
+  overlay.scrollOffsets[0] = 50;
+  overlay.handleInput("g");
+  assert.equal(overlay.scrollOffsets[0], 0);
+  overlay.handleInput("G");
+  assert.ok(overlay.scrollOffsets[0] >= 100, "G sets a large offset sentinel");
+});
+
+test("overlay Ctrl+U / Ctrl+D scroll half-page", (t) => {
+  const { overlay } = makeOverlay(t);
+  overlay.scrollOffsets[0] = 100;
+  overlay.handleInput("\u0004"); // Ctrl+D
+  assert.ok(
+    overlay.scrollOffsets[0] > 100,
+    `Ctrl+D should move forward, got ${overlay.scrollOffsets[0]}`,
   );
+  const afterDown = overlay.scrollOffsets[0];
+  overlay.handleInput("\u0015"); // Ctrl+U
+  assert.ok(
+    overlay.scrollOffsets[0] < afterDown,
+    "Ctrl+U should move backward",
+  );
+});
+
+test("overlay PageUp / PageDown scroll one viewport", (t) => {
+  const { overlay } = makeOverlay(t);
+  overlay.scrollOffsets[0] = 50;
+  overlay.handleInput("\u001b[6~"); // Page Down
+  assert.ok(overlay.scrollOffsets[0] > 50);
+  const after = overlay.scrollOffsets[0];
+  overlay.handleInput("\u001b[5~"); // Page Up
+  assert.ok(overlay.scrollOffsets[0] < after);
+});
+
+// ─── Mouse wheel + click ─────────────────────────────────────────────────
+
+test("overlay SGR mouse wheel up/down scrolls active tab", (t) => {
+  const { overlay } = makeOverlay(t);
+  overlay.scrollOffsets[0] = 20;
+  // SGR mouse wheel down: button 65
+  overlay.handleInput("\u001b[<65;10;10M");
+  assert.equal(overlay.scrollOffsets[0], 23, "wheel-down scrolls +3");
+  // Wheel up: button 64
+  overlay.handleInput("\u001b[<64;10;10M");
+  assert.equal(overlay.scrollOffsets[0], 20, "wheel-up scrolls −3");
+});
+
+test("overlay click on Captures tab badge selects that tab", (t) => {
+  const { overlay } = makeOverlay(t);
   overlay.loading = true;
   overlay.data = { captures: { pendingCount: 3 } } as any;
 
   const lines = overlay.render(120);
-  const tabLine = lines.find((line: string) => line.includes("Captures") && line.includes("(3)"));
+  const tabLine = lines.find((line) => line.includes("Captures") && line.includes("(3)"))!;
   assert.ok(tabLine, "rendered tab bar includes captures badge");
-  const plain = tabLine!.replace(/\x1b\[[0-9;]*m/g, "");
+  const plain = stripAnsi(tabLine);
   const badgeColumn = plain.indexOf("(3)") + 2;
-  overlay.handleInput(`\x1b[<0;${badgeColumn};2M`);
+  overlay.handleInput(`\u001b[<0;${badgeColumn};2M`);
   assert.equal(overlay.activeTab, 8, "clicking the badge area selects the captures tab");
+});
+
+// ─── Collapse state on Progress tab ──────────────────────────────────────
+
+test("overlay exposes collapsedMilestones set for Progress-tab collapse tracking", (t) => {
+  const { overlay } = makeOverlay(t);
+  assert.ok(overlay.collapsedMilestones instanceof Set);
+  assert.equal(overlay.collapsedMilestones.size, 0);
+});
+
+// ─── Loading state rendering ─────────────────────────────────────────────
+
+test("overlay renders a Loading… marker when no data is loaded yet", (t) => {
+  const { overlay } = makeOverlay(t);
+  overlay.loading = true;
+
+  const lines = overlay.render(120).map(stripAnsi);
+  assert.ok(
+    lines.some((l) => l.includes("Loading")),
+    "expected Loading… indicator in render output",
+  );
+});
+
+// ─── Footer hint ─────────────────────────────────────────────────────────
+
+test("overlay footer hint mentions tab navigation, filter, scroll, and help", (t) => {
+  const { overlay } = makeOverlay(t);
+  overlay.loading = true;
+
+  const lines = overlay.render(120).map(stripAnsi).join("\n");
+  assert.ok(lines.includes("1-9,0"), "footer shows 1-9,0 tab range hint");
+  assert.ok(lines.includes("PgUp/PgDn") || lines.includes("PgUp"), "footer mentions PgUp/PgDn");
+  assert.ok(lines.includes("? help"), "footer mentions ? help");
+  assert.ok(lines.includes("/"), "footer mentions / for filter");
+});
+
+// ─── Scroll offsets array is sized to TAB_COUNT ──────────────────────────
+
+test("overlay scrollOffsets array has one slot per tab (10 tabs total)", (t) => {
+  const { overlay } = makeOverlay(t);
+  assert.equal(overlay.scrollOffsets.length, 10, "scrollOffsets sized to TAB_COUNT=10");
+  assert.ok(overlay.scrollOffsets.every((n: number) => n === 0), "initialized to zero");
+});
+
+// ─── Dispose cleanup ─────────────────────────────────────────────────────
+
+test("overlay dispose clears its refresh timer and resize listener", () => {
+  const { tui } = makeTui();
+  const overlay = new GSDVisualizerOverlay(tui as any, mockTheme, () => {});
+
+  // Sanity: disposed flag flips
+  assert.equal(overlay.disposed, false);
+  overlay.dispose();
+  assert.equal(overlay.disposed, true);
+
+  // Calling dispose again is safe (no throw)
   overlay.dispose();
 });

--- a/src/resources/extensions/gsd/tests/worker-model-override.test.ts
+++ b/src/resources/extensions/gsd/tests/worker-model-override.test.ts
@@ -1,48 +1,56 @@
 /**
  * Worker model override — tests for parallel.worker_model preference.
  *
- * Verifies validation, resolveParallelConfig pass-through, and type definitions.
+ * Verifies validation accepts/rejects values and that resolveParallelConfig
+ * passes worker_model through from the raw preferences object.
  */
 
 import test from "node:test";
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
-import { join, dirname } from "node:path";
-import { fileURLToPath } from "node:url";
-
-const __dirname = dirname(fileURLToPath(import.meta.url));
-
-const typesSrc = readFileSync(join(__dirname, "..", "types.ts"), "utf-8");
-const validationSrc = readFileSync(join(__dirname, "..", "preferences-validation.ts"), "utf-8");
-const preferencesSrc = readFileSync(join(__dirname, "..", "preferences.ts"), "utf-8");
-
-// ─── Type definition ──────────────────────────────────────────────────────
-
-test("ParallelConfig includes worker_model optional field", () => {
-  assert.ok(
-    typesSrc.includes("worker_model?: string"),
-    "ParallelConfig should have optional worker_model field",
-  );
-});
-
-// ─── Validation ───────────────────────────────────────────────────────────
+import { validatePreferences } from "../preferences-validation.ts";
+import { resolveParallelConfig } from "../preferences.ts";
 
 test("validatePreferences accepts valid worker_model string", () => {
+  const { preferences, errors } = validatePreferences({
+    parallel: { enabled: true, worker_model: "claude-3-5-sonnet" },
+  } as any);
+  assert.equal(errors.length, 0, `no errors expected, got ${JSON.stringify(errors)}`);
+  assert.equal(preferences.parallel?.worker_model, "claude-3-5-sonnet");
+});
+
+test("validatePreferences rejects empty worker_model with explicit error", () => {
+  const { errors } = validatePreferences({
+    parallel: { enabled: true, worker_model: "" },
+  } as any);
   assert.ok(
-    validationSrc.includes("p.worker_model"),
-    "validation should check parallel.worker_model",
-  );
-  assert.ok(
-    validationSrc.includes('parallel.worker_model must be a non-empty string'),
-    "validation should reject invalid worker_model",
+    errors.some((e) => e.includes("parallel.worker_model") && e.includes("non-empty")),
+    `expected error mentioning parallel.worker_model, got ${JSON.stringify(errors)}`,
   );
 });
 
-// ─── resolveParallelConfig ────────────────────────────────────────────────
-
-test("resolveParallelConfig passes through worker_model", () => {
+test("validatePreferences rejects non-string worker_model", () => {
+  const { errors } = validatePreferences({
+    parallel: { enabled: true, worker_model: 42 },
+  } as any);
   assert.ok(
-    preferencesSrc.includes("worker_model: prefs?.parallel?.worker_model"),
-    "resolveParallelConfig should pass through worker_model",
+    errors.some((e) => e.includes("parallel.worker_model")),
+    `expected error mentioning parallel.worker_model, got ${JSON.stringify(errors)}`,
   );
+});
+
+test("resolveParallelConfig passes worker_model through", () => {
+  const cfg = resolveParallelConfig({
+    parallel: { enabled: true, worker_model: "opus-4.7" },
+  } as any);
+  assert.equal(cfg.worker_model, "opus-4.7");
+});
+
+test("resolveParallelConfig leaves worker_model undefined when absent", () => {
+  const cfg = resolveParallelConfig({ parallel: { enabled: true } } as any);
+  assert.equal(cfg.worker_model, undefined);
+});
+
+test("resolveParallelConfig handles undefined prefs (worker_model undefined)", () => {
+  const cfg = resolveParallelConfig(undefined);
+  assert.equal(cfg.worker_model, undefined);
 });

--- a/src/resources/extensions/gsd/tests/worktree-db.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-db.test.ts
@@ -1,8 +1,8 @@
-import { test } from 'node:test';
-import assert from 'node:assert/strict';
-import * as fs from 'node:fs';
-import * as path from 'node:path';
-import * as os from 'node:os';
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
 import {
   openDatabase,
   closeDatabase,
@@ -17,197 +17,180 @@ import {
   _getAdapter,
   copyWorktreeDb,
   reconcileWorktreeDb,
-} from '../gsd-db.ts';
+} from "../gsd-db.ts";
 
-
-// ═══════════════════════════════════════════════════════════════════════════
-// Helpers
-// ═══════════════════════════════════════════════════════════════════════════
+// ─── Helpers ──────────────────────────────────────────────────────────────
 
 function tempDir(): string {
-  return fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-wt-test-'));
-}
-
-function cleanup(...dirs: string[]): void {
-  closeDatabase();
-  for (const dir of dirs) {
-    try {
-      fs.rmSync(dir, { recursive: true, force: true });
-    } catch {
-      // best effort
-    }
-  }
+  return fs.mkdtempSync(path.join(os.tmpdir(), "gsd-wt-test-"));
 }
 
 function seedMainDb(dbPath: string): void {
   openDatabase(dbPath);
   insertDecision({
-    id: 'D001',
-    when_context: '2025-01-01',
-    scope: 'M001/S01',
-    decision: 'Use SQLite',
-    choice: 'node:sqlite',
-    rationale: 'Built-in',
-    revisable: 'yes',
-    made_by: 'agent',
+    id: "D001",
+    when_context: "2025-01-01",
+    scope: "M001/S01",
+    decision: "Use SQLite",
+    choice: "node:sqlite",
+    rationale: "Built-in",
+    revisable: "yes",
+    made_by: "agent",
     superseded_by: null,
   });
   insertRequirement({
-    id: 'R001',
-    class: 'functional',
-    status: 'active',
-    description: 'Must store decisions',
-    why: 'Core feature',
-    source: 'design',
-    primary_owner: 'S01',
-    supporting_slices: '',
-    validation: 'test',
-    notes: '',
-    full_content: 'Full requirement text',
+    id: "R001",
+    class: "functional",
+    status: "active",
+    description: "Must store decisions",
+    why: "Core feature",
+    source: "design",
+    primary_owner: "S01",
+    supporting_slices: "",
+    validation: "test",
+    notes: "",
+    full_content: "Full requirement text",
     superseded_by: null,
   });
   insertArtifact({
-    path: 'docs/arch.md',
-    artifact_type: 'plan',
-    milestone_id: 'M001',
+    path: "docs/arch.md",
+    artifact_type: "plan",
+    milestone_id: "M001",
     slice_id: null,
     task_id: null,
-    full_content: 'Architecture document',
+    full_content: "Architecture document",
   });
 }
 
-// ═══════════════════════════════════════════════════════════════════════════
-// copyWorktreeDb tests
-// ═══════════════════════════════════════════════════════════════════════════
+function registerCleanup(t: { after: (fn: () => void) => void }, ...dirs: string[]) {
+  t.after(() => {
+    closeDatabase();
+    for (const dir of dirs) {
+      try {
+        fs.rmSync(dir, { recursive: true, force: true });
+      } catch {
+        // best effort
+      }
+    }
+  });
+}
 
-console.log('\n=== worktree-db: copyWorktreeDb ===');
+// ─── copyWorktreeDb ───────────────────────────────────────────────────────
 
-// Test: copies DB file and data is queryable
-{
+test("copyWorktreeDb copies DB file and data is queryable", (t) => {
   const srcDir = tempDir();
   const destDir = tempDir();
-  const srcDb = path.join(srcDir, 'gsd.db');
-  const destDb = path.join(destDir, 'nested', 'gsd.db');
+  registerCleanup(t, srcDir, destDir);
+
+  const srcDb = path.join(srcDir, "gsd.db");
+  const destDb = path.join(destDir, "nested", "gsd.db");
 
   seedMainDb(srcDb);
   closeDatabase();
 
   const result = copyWorktreeDb(srcDb, destDb);
-  assert.ok(result === true, 'copyWorktreeDb returns true on success');
-  assert.ok(fs.existsSync(destDb), 'dest DB file exists after copy');
+  assert.equal(result, true, "copyWorktreeDb returns true on success");
+  assert.ok(fs.existsSync(destDb), "dest DB file exists after copy");
 
-  // Open the copy and verify data is queryable
   openDatabase(destDb);
-  const d = getDecisionById('D001');
-  assert.ok(d !== null, 'decision queryable in copied DB');
-  assert.deepStrictEqual(d?.choice, 'node:sqlite', 'decision data preserved in copy');
+  const d = getDecisionById("D001");
+  assert.ok(d !== null, "decision queryable in copied DB");
+  assert.equal(d?.choice, "node:sqlite", "decision data preserved in copy");
 
-  const r = getRequirementById('R001');
-  assert.ok(r !== null, 'requirement queryable in copied DB');
-  assert.deepStrictEqual(r?.description, 'Must store decisions', 'requirement data preserved in copy');
+  const r = getRequirementById("R001");
+  assert.ok(r !== null, "requirement queryable in copied DB");
+  assert.equal(r?.description, "Must store decisions", "requirement data preserved in copy");
+});
 
-  cleanup(srcDir, destDir);
-}
-
-// Test: skips -wal and -shm files
-{
+test("copyWorktreeDb skips -wal and -shm files", (t) => {
   const srcDir = tempDir();
   const destDir = tempDir();
-  const srcDb = path.join(srcDir, 'gsd.db');
-  const destDb = path.join(destDir, 'gsd.db');
+  registerCleanup(t, srcDir, destDir);
+
+  const srcDb = path.join(srcDir, "gsd.db");
+  const destDb = path.join(destDir, "gsd.db");
 
   seedMainDb(srcDb);
   closeDatabase();
 
-  // Create fake WAL/SHM files
-  fs.writeFileSync(srcDb + '-wal', 'fake wal data');
-  fs.writeFileSync(srcDb + '-shm', 'fake shm data');
+  fs.writeFileSync(srcDb + "-wal", "fake wal data");
+  fs.writeFileSync(srcDb + "-shm", "fake shm data");
 
   copyWorktreeDb(srcDb, destDb);
 
-  assert.ok(fs.existsSync(destDb), 'DB file copied');
-  assert.ok(!fs.existsSync(destDb + '-wal'), 'WAL file NOT copied');
-  assert.ok(!fs.existsSync(destDb + '-shm'), 'SHM file NOT copied');
+  assert.ok(fs.existsSync(destDb), "DB file copied");
+  assert.ok(!fs.existsSync(destDb + "-wal"), "WAL file NOT copied");
+  assert.ok(!fs.existsSync(destDb + "-shm"), "SHM file NOT copied");
+});
 
-  cleanup(srcDir, destDir);
-}
-
-// Test: returns false when source doesn't exist (no throw)
-{
+test("copyWorktreeDb returns false when source doesn't exist", (t) => {
   const destDir = tempDir();
-  const result = copyWorktreeDb('/nonexistent/path/gsd.db', path.join(destDir, 'gsd.db'));
-  assert.deepStrictEqual(result, false, 'returns false for missing source');
-  cleanup(destDir);
-}
+  registerCleanup(t, destDir);
 
-// Test: creates dest directory if needed
-{
+  const result = copyWorktreeDb("/nonexistent/path/gsd.db", path.join(destDir, "gsd.db"));
+  assert.equal(result, false, "returns false for missing source");
+});
+
+test("copyWorktreeDb creates deeply nested dest directories", (t) => {
   const srcDir = tempDir();
   const destDir = tempDir();
-  const srcDb = path.join(srcDir, 'gsd.db');
-  const deepDest = path.join(destDir, 'a', 'b', 'c', 'gsd.db');
+  registerCleanup(t, srcDir, destDir);
+
+  const srcDb = path.join(srcDir, "gsd.db");
+  const deepDest = path.join(destDir, "a", "b", "c", "gsd.db");
 
   seedMainDb(srcDb);
   closeDatabase();
 
   const result = copyWorktreeDb(srcDb, deepDest);
-  assert.ok(result === true, 'copyWorktreeDb succeeds with nested dest');
-  assert.ok(fs.existsSync(deepDest), 'DB file created at deeply nested path');
+  assert.equal(result, true, "copyWorktreeDb succeeds with nested dest");
+  assert.ok(fs.existsSync(deepDest), "DB file created at deeply nested path");
+});
 
-  cleanup(srcDir, destDir);
-}
+// ─── reconcileWorktreeDb ──────────────────────────────────────────────────
 
-// ═══════════════════════════════════════════════════════════════════════════
-// reconcileWorktreeDb tests
-// ═══════════════════════════════════════════════════════════════════════════
-
-console.log('\n=== worktree-db: reconcileWorktreeDb ===');
-
-// Test: merges new decisions from worktree into main
-{
+test("reconcileWorktreeDb merges new decisions from worktree into main", (t) => {
   const mainDir = tempDir();
   const wtDir = tempDir();
-  const mainDb = path.join(mainDir, 'gsd.db');
-  const wtDb = path.join(wtDir, 'gsd.db');
+  registerCleanup(t, mainDir, wtDir);
 
-  // Seed main with D001
+  const mainDb = path.join(mainDir, "gsd.db");
+  const wtDb = path.join(wtDir, "gsd.db");
+
   seedMainDb(mainDb);
   closeDatabase();
 
-  // Copy to worktree, add D002 in worktree
   copyWorktreeDb(mainDb, wtDb);
   openDatabase(wtDb);
   insertDecision({
-    id: 'D002',
-    when_context: '2025-02-01',
-    scope: 'M001/S02',
-    decision: 'Use WAL mode',
-    choice: 'WAL',
-    rationale: 'Performance',
-    revisable: 'yes',
-    made_by: 'agent',
+    id: "D002",
+    when_context: "2025-02-01",
+    scope: "M001/S02",
+    decision: "Use WAL mode",
+    choice: "WAL",
+    rationale: "Performance",
+    revisable: "yes",
+    made_by: "agent",
     superseded_by: null,
   });
   closeDatabase();
 
-  // Re-open main and reconcile
   openDatabase(mainDb);
   const result = reconcileWorktreeDb(mainDb, wtDb);
 
-  assert.ok(result.decisions > 0, 'decisions merged count > 0');
-  const d2 = getDecisionById('D002');
-  assert.ok(d2 !== null, 'D002 from worktree now in main');
-  assert.deepStrictEqual(d2?.choice, 'WAL', 'D002 data correct after merge');
+  assert.ok(result.decisions > 0, "decisions merged count > 0");
+  const d2 = getDecisionById("D002");
+  assert.ok(d2 !== null, "D002 from worktree now in main");
+  assert.equal(d2?.choice, "WAL", "D002 data correct after merge");
+});
 
-  cleanup(mainDir, wtDir);
-}
-
-// Test: merges new requirements from worktree into main
-{
+test("reconcileWorktreeDb merges new requirements from worktree into main", (t) => {
   const mainDir = tempDir();
   const wtDir = tempDir();
-  const mainDb = path.join(mainDir, 'gsd.db');
-  const wtDb = path.join(wtDir, 'gsd.db');
+  registerCleanup(t, mainDir, wtDir);
+
+  const mainDb = path.join(mainDir, "gsd.db");
+  const wtDb = path.join(wtDir, "gsd.db");
 
   seedMainDb(mainDb);
   closeDatabase();
@@ -215,17 +198,17 @@ console.log('\n=== worktree-db: reconcileWorktreeDb ===');
 
   openDatabase(wtDb);
   insertRequirement({
-    id: 'R002',
-    class: 'non-functional',
-    status: 'active',
-    description: 'Must be fast',
-    why: 'UX',
-    source: 'design',
-    primary_owner: 'S02',
-    supporting_slices: '',
-    validation: 'benchmark',
-    notes: '',
-    full_content: 'Performance requirement',
+    id: "R002",
+    class: "non-functional",
+    status: "active",
+    description: "Must be fast",
+    why: "UX",
+    source: "design",
+    primary_owner: "S02",
+    supporting_slices: "",
+    validation: "benchmark",
+    notes: "",
+    full_content: "Performance requirement",
     superseded_by: null,
   });
   closeDatabase();
@@ -233,20 +216,19 @@ console.log('\n=== worktree-db: reconcileWorktreeDb ===');
   openDatabase(mainDb);
   const result = reconcileWorktreeDb(mainDb, wtDb);
 
-  assert.ok(result.requirements > 0, 'requirements merged count > 0');
-  const r2 = getRequirementById('R002');
-  assert.ok(r2 !== null, 'R002 from worktree now in main');
-  assert.deepStrictEqual(r2?.description, 'Must be fast', 'R002 data correct after merge');
+  assert.ok(result.requirements > 0, "requirements merged count > 0");
+  const r2 = getRequirementById("R002");
+  assert.ok(r2 !== null, "R002 from worktree now in main");
+  assert.equal(r2?.description, "Must be fast", "R002 data correct after merge");
+});
 
-  cleanup(mainDir, wtDir);
-}
-
-// Test: merges new artifacts from worktree into main
-{
+test("reconcileWorktreeDb merges new artifacts from worktree into main", (t) => {
   const mainDir = tempDir();
   const wtDir = tempDir();
-  const mainDb = path.join(mainDir, 'gsd.db');
-  const wtDb = path.join(wtDir, 'gsd.db');
+  registerCleanup(t, mainDir, wtDir);
+
+  const mainDb = path.join(mainDir, "gsd.db");
+  const wtDb = path.join(wtDir, "gsd.db");
 
   seedMainDb(mainDb);
   closeDatabase();
@@ -254,133 +236,120 @@ console.log('\n=== worktree-db: reconcileWorktreeDb ===');
 
   openDatabase(wtDb);
   insertArtifact({
-    path: 'docs/api.md',
-    artifact_type: 'reference',
-    milestone_id: 'M001',
-    slice_id: 'S01',
-    task_id: 'T01',
-    full_content: 'API documentation',
+    path: "docs/api.md",
+    artifact_type: "reference",
+    milestone_id: "M001",
+    slice_id: "S01",
+    task_id: "T01",
+    full_content: "API documentation",
   });
   closeDatabase();
 
   openDatabase(mainDb);
   const result = reconcileWorktreeDb(mainDb, wtDb);
 
-  assert.ok(result.artifacts > 0, 'artifacts merged count > 0');
+  assert.ok(result.artifacts > 0, "artifacts merged count > 0");
   const adapter = _getAdapter()!;
-  const row = adapter.prepare('SELECT * FROM artifacts WHERE path = ?').get('docs/api.md');
-  assert.ok(row !== null, 'artifact from worktree now in main');
-  assert.deepStrictEqual(row?.['artifact_type'], 'reference', 'artifact data correct after merge');
+  const row = adapter.prepare("SELECT * FROM artifacts WHERE path = ?").get("docs/api.md");
+  assert.ok(row !== null, "artifact from worktree now in main");
+  assert.equal((row as any)["artifact_type"], "reference", "artifact data correct after merge");
+});
 
-  cleanup(mainDir, wtDir);
-}
-
-// Test: detects conflicts (same PK, different content in both DBs)
-{
+test("reconcileWorktreeDb detects conflicts and applies worktree-wins policy", (t) => {
   const mainDir = tempDir();
   const wtDir = tempDir();
-  const mainDb = path.join(mainDir, 'gsd.db');
-  const wtDb = path.join(wtDir, 'gsd.db');
+  registerCleanup(t, mainDir, wtDir);
 
-  // Seed main with D001
+  const mainDb = path.join(mainDir, "gsd.db");
+  const wtDb = path.join(wtDir, "gsd.db");
+
   seedMainDb(mainDb);
   closeDatabase();
   copyWorktreeDb(mainDb, wtDb);
 
-  // Modify D001 in main
   openDatabase(mainDb);
-  const mainAdapter = _getAdapter()!;
-  mainAdapter.prepare(
+  _getAdapter()!.prepare(
     `UPDATE decisions SET choice = 'better-sqlite3' WHERE id = 'D001'`,
   ).run();
   closeDatabase();
 
-  // Modify D001 in worktree differently
   openDatabase(wtDb);
-  const wtAdapter = _getAdapter()!;
-  wtAdapter.prepare(
+  _getAdapter()!.prepare(
     `UPDATE decisions SET choice = 'sql.js' WHERE id = 'D001'`,
   ).run();
   closeDatabase();
 
-  // Reconcile
   openDatabase(mainDb);
   const result = reconcileWorktreeDb(mainDb, wtDb);
 
-  assert.ok(result.conflicts.length > 0, 'conflicts detected');
+  assert.ok(result.conflicts.length > 0, "conflicts detected");
   assert.ok(
-    result.conflicts.some(c => c.includes('D001')),
-    'conflict mentions D001',
+    result.conflicts.some((c) => c.includes("D001")),
+    "conflict mentions D001",
   );
 
-  // Worktree-wins: D001 should now have worktree's value
-  const d1 = getDecisionById('D001');
-  assert.deepStrictEqual(d1?.choice, 'sql.js', 'worktree wins on conflict (INSERT OR REPLACE)');
+  const d1 = getDecisionById("D001");
+  assert.equal(d1?.choice, "sql.js", "worktree wins on conflict (INSERT OR REPLACE)");
+});
 
-  cleanup(mainDir, wtDir);
-}
-
-// Test: handles missing worktree DB gracefully
-{
+test("reconcileWorktreeDb handles missing worktree DB gracefully", (t) => {
   const mainDir = tempDir();
-  const mainDb = path.join(mainDir, 'gsd.db');
+  registerCleanup(t, mainDir);
 
+  const mainDb = path.join(mainDir, "gsd.db");
   seedMainDb(mainDb);
 
-  const result = reconcileWorktreeDb(mainDb, '/nonexistent/worktree.db');
-  assert.deepStrictEqual(result.decisions, 0, 'no decisions merged for missing worktree DB');
-  assert.deepStrictEqual(result.requirements, 0, 'no requirements merged for missing worktree DB');
-  assert.deepStrictEqual(result.artifacts, 0, 'no artifacts merged for missing worktree DB');
-  assert.deepStrictEqual(result.conflicts.length, 0, 'no conflicts for missing worktree DB');
+  const result = reconcileWorktreeDb(mainDb, "/nonexistent/worktree.db");
+  assert.equal(result.decisions, 0, "no decisions merged for missing worktree DB");
+  assert.equal(result.requirements, 0, "no requirements merged for missing worktree DB");
+  assert.equal(result.artifacts, 0, "no artifacts merged for missing worktree DB");
+  assert.equal(result.conflicts.length, 0, "no conflicts for missing worktree DB");
+});
 
-  cleanup(mainDir);
-}
-
-// Test: path with spaces works
-{
+test("reconcileWorktreeDb handles paths containing spaces", (t) => {
   const baseDir = tempDir();
-  const mainDir = path.join(baseDir, 'main dir');
-  const wtDir = path.join(baseDir, 'worktree dir');
+  registerCleanup(t, baseDir);
+
+  const mainDir = path.join(baseDir, "main dir");
+  const wtDir = path.join(baseDir, "worktree dir");
   fs.mkdirSync(mainDir, { recursive: true });
   fs.mkdirSync(wtDir, { recursive: true });
 
-  const mainDb = path.join(mainDir, 'gsd.db');
-  const wtDb = path.join(wtDir, 'gsd.db');
+  const mainDb = path.join(mainDir, "gsd.db");
+  const wtDb = path.join(wtDir, "gsd.db");
 
   seedMainDb(mainDb);
   closeDatabase();
   copyWorktreeDb(mainDb, wtDb);
 
-  // Add a decision in worktree
   openDatabase(wtDb);
   insertDecision({
-    id: 'D003',
-    when_context: '2025-03-01',
-    scope: 'M001/S03',
-    decision: 'Path spaces test',
-    choice: 'yes',
-    rationale: 'Robustness',
-    revisable: 'no',
-    made_by: 'agent',
+    id: "D003",
+    when_context: "2025-03-01",
+    scope: "M001/S03",
+    decision: "Path spaces test",
+    choice: "yes",
+    rationale: "Robustness",
+    revisable: "no",
+    made_by: "agent",
     superseded_by: null,
   });
   closeDatabase();
 
   openDatabase(mainDb);
   const result = reconcileWorktreeDb(mainDb, wtDb);
-  assert.ok(result.decisions > 0, 'reconciliation works with spaces in path');
-  const d3 = getDecisionById('D003');
-  assert.ok(d3 !== null, 'D003 merged from worktree with spaces in path');
+  assert.ok(result.decisions > 0, "reconciliation works with spaces in path");
+  const d3 = getDecisionById("D003");
+  assert.ok(d3 !== null, "D003 merged from worktree with spaces in path");
+});
 
-  cleanup(baseDir);
-}
-
-// Test: main DB is usable after reconciliation (DETACH cleanup verified)
-{
+test("reconcileWorktreeDb leaves main DB usable after DETACH", (t) => {
   const mainDir = tempDir();
   const wtDir = tempDir();
-  const mainDb = path.join(mainDir, 'gsd.db');
-  const wtDb = path.join(wtDir, 'gsd.db');
+  registerCleanup(t, mainDir, wtDir);
+
+  const mainDb = path.join(mainDir, "gsd.db");
+  const wtDb = path.join(wtDir, "gsd.db");
 
   seedMainDb(mainDb);
   closeDatabase();
@@ -389,92 +358,78 @@ console.log('\n=== worktree-db: reconcileWorktreeDb ===');
   openDatabase(mainDb);
   reconcileWorktreeDb(mainDb, wtDb);
 
-  // Verify main DB is still fully usable after DETACH
-  assert.ok(isDbAvailable(), 'DB still available after reconciliation');
+  assert.ok(isDbAvailable(), "DB still available after reconciliation");
 
   insertDecision({
-    id: 'D099',
-    when_context: '2025-12-01',
-    scope: 'test',
-    decision: 'Post-reconcile insert',
-    choice: 'works',
-    rationale: 'Verify DETACH cleanup',
-    revisable: 'no',
-    made_by: 'agent',
+    id: "D099",
+    when_context: "2025-12-01",
+    scope: "test",
+    decision: "Post-reconcile insert",
+    choice: "works",
+    rationale: "Verify DETACH cleanup",
+    revisable: "no",
+    made_by: "agent",
     superseded_by: null,
   });
 
-  const d99 = getDecisionById('D099');
-  assert.ok(d99 !== null, 'can insert and query after reconciliation');
-  assert.deepStrictEqual(d99?.choice, 'works', 'post-reconcile data correct');
+  const d99 = getDecisionById("D099");
+  assert.ok(d99 !== null, "can insert and query after reconciliation");
+  assert.equal(d99?.choice, "works", "post-reconcile data correct");
 
-  // Verify no "wt" database still attached
+  // Verify wt database is detached
   const adapter = _getAdapter()!;
   let wtAccessible = false;
   try {
-    adapter.prepare('SELECT count(*) FROM wt.decisions').get();
+    adapter.prepare("SELECT count(*) FROM wt.decisions").get();
     wtAccessible = true;
   } catch {
     // Expected — wt should be detached
   }
-  assert.ok(!wtAccessible, 'wt database is detached after reconciliation');
+  assert.ok(!wtAccessible, "wt database is detached after reconciliation");
+});
 
-  cleanup(mainDir, wtDir);
-}
-
-// Test: reconcile with empty worktree DB (no new rows, no conflicts)
-{
+test("reconcileWorktreeDb is a no-op when DBs are identical", (t) => {
   const mainDir = tempDir();
   const wtDir = tempDir();
-  const mainDb = path.join(mainDir, 'gsd.db');
-  const wtDb = path.join(wtDir, 'gsd.db');
+  registerCleanup(t, mainDir, wtDir);
+
+  const mainDb = path.join(mainDir, "gsd.db");
+  const wtDb = path.join(wtDir, "gsd.db");
 
   seedMainDb(mainDb);
   closeDatabase();
   copyWorktreeDb(mainDb, wtDb);
 
-  // Don't modify the worktree DB at all — reconcile the identical copy
   openDatabase(mainDb);
   const result = reconcileWorktreeDb(mainDb, wtDb);
 
-  // Should still report counts for the existing rows (INSERT OR REPLACE touches them)
-  assert.ok(result.conflicts.length === 0, 'no conflicts when DBs are identical');
-  assert.ok(isDbAvailable(), 'DB usable after no-change reconciliation');
+  assert.equal(result.conflicts.length, 0, "no conflicts when DBs are identical");
+  assert.ok(isDbAvailable(), "DB usable after no-change reconciliation");
+});
 
-  cleanup(mainDir, wtDir);
-}
-
-// Test: reconcileWorktreeDb must NOT downgrade milestone status complete→active (#4372)
-{
+test("reconcileWorktreeDb does not downgrade milestone status complete→active (#4372)", (t) => {
   const mainDir = tempDir();
   const wtDir = tempDir();
-  const mainDb = path.join(mainDir, 'gsd.db');
-  const wtDb = path.join(wtDir, 'gsd.db');
+  registerCleanup(t, mainDir, wtDir);
 
-  // Seed main with a milestone already marked complete
+  const mainDb = path.join(mainDir, "gsd.db");
+  const wtDb = path.join(wtDir, "gsd.db");
+
   seedMainDb(mainDb);
   const mainAdapter = _getAdapter()!;
-  insertMilestone({ id: 'M-COMP', title: 'Completed Milestone', status: 'complete' });
-  // Manually mark completed_at so it's a realistic complete record
+  insertMilestone({ id: "M-COMP", title: "Completed Milestone", status: "complete" });
   mainAdapter.prepare(`UPDATE milestones SET completed_at = '2025-06-01T00:00:00.000Z' WHERE id = 'M-COMP'`).run();
   closeDatabase();
 
-  // Copy to worktree — the worktree has the milestone as 'active' (stale / older snapshot)
   copyWorktreeDb(mainDb, wtDb);
   openDatabase(wtDb);
-  const wtAdapter = _getAdapter()!;
-  wtAdapter.prepare(`UPDATE milestones SET status = 'active', completed_at = NULL WHERE id = 'M-COMP'`).run();
+  _getAdapter()!.prepare(`UPDATE milestones SET status = 'active', completed_at = NULL WHERE id = 'M-COMP'`).run();
   closeDatabase();
 
-  // Reconcile: main should win and keep 'complete'
   openDatabase(mainDb);
   reconcileWorktreeDb(mainDb, wtDb);
 
-  const m = getMilestone('M-COMP');
-  assert.ok(m !== null, 'milestone M-COMP still exists after reconcile');
-  assert.strictEqual(m!.status, 'complete', 'complete milestone must not be downgraded to active by stale worktree');
-
-  cleanup(mainDir, wtDir);
-}
-
-// ─── Final Report ──────────────────────────────────────────────────────────
+  const m = getMilestone("M-COMP");
+  assert.ok(m !== null, "milestone M-COMP still exists after reconcile");
+  assert.equal(m!.status, "complete", "complete milestone must not be downgraded to active by stale worktree");
+});

--- a/src/resources/extensions/gsd/tests/worktree-db.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-db.test.ts
@@ -127,7 +127,8 @@ test("copyWorktreeDb returns false when source doesn't exist", (t) => {
   const destDir = tempDir();
   registerCleanup(t, destDir);
 
-  const result = copyWorktreeDb("/nonexistent/path/gsd.db", path.join(destDir, "gsd.db"));
+  const missingSrc = path.join(destDir, "missing", "gsd.db");
+  const result = copyWorktreeDb(missingSrc, path.join(destDir, "gsd.db"));
   assert.equal(result, false, "returns false for missing source");
 });
 
@@ -251,7 +252,10 @@ test("reconcileWorktreeDb merges new artifacts from worktree into main", (t) => 
   assert.ok(result.artifacts > 0, "artifacts merged count > 0");
   const adapter = _getAdapter()!;
   const row = adapter.prepare("SELECT * FROM artifacts WHERE path = ?").get("docs/api.md");
-  assert.ok(row !== null, "artifact from worktree now in main");
+  // Statement#get returns undefined (not null) when no row matches, so use
+  // loose inequality to catch both — strict `!== null` would silently let a
+  // missing artifact row pass this assertion.
+  assert.ok(row != null, "artifact from worktree now in main");
   assert.equal((row as any)["artifact_type"], "reference", "artifact data correct after merge");
 });
 
@@ -299,7 +303,8 @@ test("reconcileWorktreeDb handles missing worktree DB gracefully", (t) => {
   const mainDb = path.join(mainDir, "gsd.db");
   seedMainDb(mainDb);
 
-  const result = reconcileWorktreeDb(mainDb, "/nonexistent/worktree.db");
+  const missingWt = path.join(mainDir, "missing-worktree.db");
+  const result = reconcileWorktreeDb(mainDb, missingWt);
   assert.equal(result.decisions, 0, "no decisions merged for missing worktree DB");
   assert.equal(result.requirements, 0, "no requirements merged for missing worktree DB");
   assert.equal(result.artifacts, 0, "no artifacts merged for missing worktree DB");

--- a/src/resources/extensions/gsd/tests/worktree-health-monorepo.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-health-monorepo.test.ts
@@ -1,73 +1,109 @@
 /**
  * worktree-health-monorepo.test.ts — #2347
  *
- * The worktree health check in auto/phases.ts falsely rejects monorepos
- * where package.json (or other project markers) is in a parent directory.
- * This test verifies that the health check walks parent directories.
+ * The worktree health check previously rejected monorepos where the
+ * project markers (package.json, Cargo.toml, etc.) live in a parent
+ * directory rather than in the worktree's own checkout. The fix extracts
+ * the parent-walk into `hasProjectFileInAncestor` in detection.ts; these
+ * tests exercise that helper directly over a synthetic filesystem.
+ *
+ * Assertions cover:
+ *   - a parent directory with a project marker is detected
+ *   - the walk stops at a `.git` boundary so ancestors above the repo root
+ *     (e.g. $HOME) cannot cause false positives
+ *   - returns false when no ancestor has a marker
+ *   - works for nested worktree layouts (monorepo/worktree/...)
  */
 
-import { readFileSync } from "node:fs";
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
-import {createTestContext, extractSourceRegion } from "./test-helpers.ts";
+import { tmpdir } from "node:os";
 
-const { assertTrue, report } = createTestContext();
+import { hasProjectFileInAncestor } from "../detection.ts";
 
-const srcPath = join(import.meta.dirname, "..", "auto", "phases.ts");
-const src = readFileSync(srcPath, "utf-8");
+function makeTempRoot(t: { after: (fn: () => void) => void }): string {
+  const dir = mkdtempSync(join(tmpdir(), "gsd-monorepo-health-"));
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+  return dir;
+}
 
-console.log("\n=== #2347: Worktree health check supports monorepos ===");
+test("#2347: parent directory containing package.json is detected", (t) => {
+  const root = makeTempRoot(t);
+  const worktree = join(root, "packages", "app");
+  mkdirSync(worktree, { recursive: true });
+  writeFileSync(join(root, "package.json"), "{}");
 
-// ── Test 1: The health check region exists ──────────────────────────────
+  assert.equal(
+    hasProjectFileInAncestor(worktree),
+    true,
+    "monorepo package.json in parent should be detected",
+  );
+});
 
-const healthCheckIdx = src.indexOf("Worktree health check");
-assertTrue(healthCheckIdx > 0, "auto/phases.ts has worktree health check section");
+test("#2347: parent with Cargo.toml is detected (not just JS ecosystems)", (t) => {
+  const root = makeTempRoot(t);
+  const worktree = join(root, "crates", "foo");
+  mkdirSync(worktree, { recursive: true });
+  writeFileSync(join(root, "Cargo.toml"), "[workspace]\n");
 
-const healthCheckRegion = extractSourceRegion(src, "Worktree health check");
+  assert.equal(hasProjectFileInAncestor(worktree), true);
+});
 
-// ── Test 2: The check walks parent directories for project markers ──────
+test("#2347: walk stops at .git boundary (no false positive from grandparent)", (t) => {
+  const root = makeTempRoot(t);
+  // Layout:
+  //   root/package.json       ← must NOT trigger (above .git)
+  //   root/repo/.git          ← repo boundary
+  //   root/repo/worktree/     ← start dir (no markers)
+  writeFileSync(join(root, "package.json"), "{}");
+  const repo = join(root, "repo");
+  mkdirSync(join(repo, ".git"), { recursive: true });
+  const worktree = join(repo, "worktree");
+  mkdirSync(worktree, { recursive: true });
 
-// The fix should check parent directories for project files, not just s.basePath.
-// Look for patterns like: walking up directories, dirname, parent, or a helper
-// function that checks ancestors.
-const checksParentDirs =
-  healthCheckRegion.includes("dirname") ||
-  healthCheckRegion.includes("parent") ||
-  healthCheckRegion.includes("ancestor") ||
-  healthCheckRegion.includes("walk") ||
-  // Or a helper function that's called with the base path
-  /hasProjectFileInAncestor|findProjectRoot|checkParent/i.test(healthCheckRegion);
+  assert.equal(
+    hasProjectFileInAncestor(worktree),
+    false,
+    "grandparent package.json above the .git boundary must be ignored",
+  );
+});
 
-assertTrue(
-  checksParentDirs,
-  "Health check should walk parent directories for project markers (monorepo support) (#2347)",
-);
+test("#2347: returns false when no ancestor has a marker", (t) => {
+  const root = makeTempRoot(t);
+  const worktree = join(root, "empty", "nested", "deep");
+  mkdirSync(worktree, { recursive: true });
 
-// ── Test 3: The parent walk stops at a .git boundary ──────────────────
+  assert.equal(hasProjectFileInAncestor(worktree), false);
+});
 
-// The parent directory walk must not escape the git repository root.
-// Without this guard, ancestor directories like ~ or /usr/local that
-// happen to contain package.json would cause false positive health checks.
-const hasGitBoundary = healthCheckRegion.includes('.git') &&
-  (healthCheckRegion.includes('break') || healthCheckRegion.includes('stop'));
+test("#2347: detects marker in immediate parent of the worktree", (t) => {
+  const root = makeTempRoot(t);
+  const parent = join(root, "monorepo");
+  const worktree = join(parent, "svc");
+  mkdirSync(worktree, { recursive: true });
+  writeFileSync(join(parent, "go.mod"), "module x\n");
 
-assertTrue(
-  hasGitBoundary,
-  "Parent directory walk must stop at .git repository boundary to prevent false positives",
-);
+  assert.equal(hasProjectFileInAncestor(worktree), true);
+});
 
-// ── Test 4: The greenfield warning should only trigger when no parent has markers ─
+test("#2347: existsFn injection allows deterministic testing without real FS", () => {
+  // Simulate a layout: /a/b/c (start) → /a/b has pyproject.toml; nothing has .git.
+  const existsFn = (p: string) =>
+    p === "/a/b/pyproject.toml";
 
-// The original code was:
-//   const hasProjectFile = PROJECT_FILES.some((f) => deps.existsSync(join(s.basePath, f)));
-// The fix should check parents too, so the greenfield warning only fires
-// when NO ancestor directory has project markers either.
-const hasParentCheck = healthCheckRegion.includes("parent") ||
-  healthCheckRegion.includes("dirname") ||
-  /ancestor|walk.*up/i.test(healthCheckRegion);
+  assert.equal(hasProjectFileInAncestor("/a/b/c", existsFn), true);
+});
 
-assertTrue(
-  hasParentCheck,
-  "Greenfield check should consider parent directories before warning (#2347)",
-);
+test("#2347: existsFn injection — .git stops the walk before a marker ancestor", () => {
+  // /a has package.json, but /a/b has .git — walk from /a/b/c must stop at /a/b.
+  const existsFn = (p: string) =>
+    p === "/a/package.json" || p === "/a/b/.git";
 
-report();
+  assert.equal(
+    hasProjectFileInAncestor("/a/b/c", existsFn),
+    false,
+    "walk must stop at the .git boundary before reaching /a/package.json",
+  );
+});

--- a/src/resources/extensions/gsd/tests/worktree-nested-git-safety.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-nested-git-safety.test.ts
@@ -6,96 +6,98 @@
  * (mode 160000) without a .gitmodules entry, so the worktree cleanup destroys
  * the only copy of those object databases — causing permanent data loss.
  *
- * This test verifies that removeWorktree detects nested .git directories
- * (orphaned gitlinks) and absorbs or removes them before cleanup so files
- * are tracked as regular content instead of unreachable gitlink pointers.
+ * These tests exercise findNestedGitDirs directly against a synthetic
+ * filesystem layout to verify that nested .git *directories* are detected
+ * (while .git *files* — legitimate worktree pointers — are not), and that
+ * non-project directories (node_modules, .gsd, target, etc.) are skipped.
  */
 
-import { readFileSync } from "node:fs";
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
-import {createTestContext, extractSourceRegion } from "./test-helpers.ts";
+import { tmpdir } from "node:os";
 
-const { assertTrue, report } = createTestContext();
+import { findNestedGitDirs } from "../worktree-manager.ts";
 
-const srcPath = join(import.meta.dirname, "..", "worktree-manager.ts");
-const src = readFileSync(srcPath, "utf-8");
+function makeRoot(t: { after: (fn: () => void) => void }): string {
+  const dir = mkdtempSync(join(tmpdir(), "gsd-nested-git-"));
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+  return dir;
+}
 
-console.log("\n=== #2616: Worktree cleanup detects nested .git directories ===");
+test("#2616: findNestedGitDirs detects a nested repo at the top level", (t) => {
+  const root = makeRoot(t);
 
-// ── Test 1: removeWorktree scans for nested .git directories ─────────
+  // Simulate a scaffolded project at root/scaffolded with its own .git *directory*.
+  const scaffolded = join(root, "scaffolded");
+  mkdirSync(join(scaffolded, ".git", "objects"), { recursive: true });
+  writeFileSync(join(scaffolded, "package.json"), "{}");
 
-const removeWorktreeIdx = src.indexOf("export function removeWorktree");
-assertTrue(removeWorktreeIdx > 0, "worktree-manager.ts exports removeWorktree");
+  const found = findNestedGitDirs(root);
+  assert.ok(
+    found.includes(scaffolded),
+    `expected ${scaffolded} in findNestedGitDirs output, got ${JSON.stringify(found)}`,
+  );
+});
 
-const fnBody = extractSourceRegion(src, "export function removeWorktree");
+test("#2616: findNestedGitDirs ignores .git files (worktree pointers)", (t) => {
+  const root = makeRoot(t);
 
-const detectsNestedGit =
-  fnBody.includes("nested") && fnBody.includes(".git") ||
-  fnBody.includes("gitlink") ||
-  fnBody.includes("160000") ||
-  fnBody.includes("findNestedGitDirs") ||
-  fnBody.includes("nestedGitDirs");
+  // A worktree or submodule has a .git *file*, not a directory. This is legitimate.
+  const sub = join(root, "legit-worktree");
+  mkdirSync(sub, { recursive: true });
+  writeFileSync(join(sub, ".git"), "gitdir: /elsewhere/.git/worktrees/x\n");
 
-assertTrue(
-  detectsNestedGit,
-  "removeWorktree detects nested .git directories or gitlinks (#2616)",
-);
+  const found = findNestedGitDirs(root);
+  assert.ok(
+    !found.includes(sub),
+    `.git file (worktree pointer) must not be flagged as a nested repo; got ${JSON.stringify(found)}`,
+  );
+});
 
-// ── Test 2: A helper function exists to find nested .git directories ──
+test("#2616: findNestedGitDirs skips excluded directories (node_modules, .gsd, target)", (t) => {
+  const root = makeRoot(t);
 
-const hasNestedGitHelper =
-  src.includes("findNestedGitDirs") ||
-  src.includes("detectNestedGitDirs") ||
-  src.includes("scanNestedGit") ||
-  src.includes("absorbNestedGit") ||
-  src.includes("nestedGitDirs");
+  // All three of these contain a .git *directory*, but the scan must skip them.
+  for (const excluded of ["node_modules", ".gsd", "target"]) {
+    const inside = join(root, excluded, "vendored-pkg");
+    mkdirSync(join(inside, ".git"), { recursive: true });
+  }
 
-assertTrue(
-  hasNestedGitHelper,
-  "worktree-manager has a helper to find nested .git directories (#2616)",
-);
+  const found = findNestedGitDirs(root);
+  assert.equal(
+    found.length,
+    0,
+    `excluded directories must be skipped, got ${JSON.stringify(found)}`,
+  );
+});
 
-// ── Test 3: Nested .git dirs are absorbed or removed before cleanup ───
+test("#2616: findNestedGitDirs finds deeply nested repos", (t) => {
+  const root = makeRoot(t);
+  const deep = join(root, "a", "b", "c", "scaffolded");
+  mkdirSync(join(deep, ".git"), { recursive: true });
 
-const absorbsOrRemoves =
-  fnBody.includes("absorb") ||
-  fnBody.includes("rmSync") && fnBody.includes("nested") ||
-  (fnBody.includes("nestedGitDirs") || fnBody.includes("findNestedGitDirs")) &&
-    (fnBody.includes("rm") || fnBody.includes("absorb") || fnBody.includes("remove"));
+  const found = findNestedGitDirs(root);
+  assert.ok(
+    found.includes(deep),
+    `expected deep path ${deep} in output, got ${JSON.stringify(found)}`,
+  );
+});
 
-assertTrue(
-  absorbsOrRemoves,
-  "removeWorktree absorbs or removes nested .git dirs before cleanup (#2616)",
-);
+test("#2616: findNestedGitDirs does not recurse into a found nested repo", (t) => {
+  const root = makeRoot(t);
 
-// ── Test 4: A warning is logged when nested .git dirs are found ───────
+  // Outer scaffolded dir has .git; inside, a further sub-repo also has .git.
+  const outer = join(root, "outer");
+  mkdirSync(join(outer, ".git"), { recursive: true });
+  const inner = join(outer, "inner");
+  mkdirSync(join(inner, ".git"), { recursive: true });
 
-const warnsAboutNestedGit =
-  fnBody.includes("nested") && fnBody.includes("logWarning") ||
-  fnBody.includes("gitlink") && fnBody.includes("logWarning") ||
-  fnBody.includes("scaffold") && fnBody.includes("logWarning");
-
-assertTrue(
-  warnsAboutNestedGit,
-  "removeWorktree warns when nested .git directories are detected (#2616)",
-);
-
-// ── Test 5: The findNestedGitDirs helper correctly identifies nested repos ──
-// Verify the helper scans subdirectories but skips .gsd/, node_modules/, .git/
-
-const helperBody = src.includes("findNestedGitDirs")
-  ? src.slice(src.indexOf("findNestedGitDirs"))
-  : "";
-
-const skipsExcludedDirs =
-  helperBody.includes("node_modules") ||
-  helperBody.includes(".gsd") ||
-  helperBody.includes("skip") ||
-  helperBody.includes("exclude");
-
-assertTrue(
-  skipsExcludedDirs,
-  "findNestedGitDirs skips node_modules and other excluded directories (#2616)",
-);
-
-report();
+  const found = findNestedGitDirs(root);
+  assert.ok(found.includes(outer), "outer repo is detected");
+  assert.ok(
+    !found.includes(inner),
+    "must not recurse into the outer nested repo (stops at first hit)",
+  );
+});

--- a/src/resources/extensions/gsd/tests/worktree-sync-overwrite-loop.test.ts
+++ b/src/resources/extensions/gsd/tests/worktree-sync-overwrite-loop.test.ts
@@ -10,14 +10,10 @@
  *
  * 2. completed-units.json is not forward-synced from project root to
  *    worktree, so the worktree never learns about already-completed units.
- *
- * Covers:
- *   - syncProjectRootToWorktree does NOT overwrite existing worktree files
- *   - syncProjectRootToWorktree copies files missing from the worktree
- *   - completed-units.json is forward-synced from project root to worktree
- *   - completed-units.json sync uses force:true (project root is authoritative)
  */
 
+import { test } from "node:test";
+import assert from "node:assert/strict";
 import {
   mkdtempSync,
   mkdirSync,
@@ -30,9 +26,6 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 
 import { syncProjectRootToWorktree } from "../auto-worktree.ts";
-import { createTestContext } from "./test-helpers.ts";
-
-const { assertTrue, assertEq, report } = createTestContext();
 
 function createBase(name: string): string {
   const base = mkdtempSync(join(tmpdir(), `gsd-wt-1886-${name}-`));
@@ -40,165 +33,124 @@ function createBase(name: string): string {
   return base;
 }
 
-function cleanup(base: string): void {
-  rmSync(base, { recursive: true, force: true });
+function registerBases(
+  t: { after: (fn: () => void) => void },
+  ...dirs: string[]
+): void {
+  t.after(() => {
+    for (const d of dirs) {
+      rmSync(d, { recursive: true, force: true });
+    }
+  });
 }
 
-async function main(): Promise<void> {
-  // ─── 1. Worktree VALIDATION.md must NOT be overwritten by project root ──
-  console.log(
-    "\n=== 1. #1886: worktree VALIDATION.md preserved (not overwritten) ===",
+test("#1886: worktree VALIDATION.md is not overwritten by project root sync", (t) => {
+  const mainBase = createBase("main");
+  const wtBase = createBase("wt");
+  registerBases(t, mainBase, wtBase);
+
+  // Project root has an older CONTEXT but no VALIDATION
+  const prM004 = join(mainBase, ".gsd", "milestones", "M004");
+  mkdirSync(prM004, { recursive: true });
+  writeFileSync(join(prM004, "M004-CONTEXT.md"), "# old context");
+
+  // Worktree has CONTEXT + VALIDATION (written by validate-milestone)
+  const wtM004 = join(wtBase, ".gsd", "milestones", "M004");
+  mkdirSync(wtM004, { recursive: true });
+  writeFileSync(join(wtM004, "M004-CONTEXT.md"), "# worktree context");
+  writeFileSync(
+    join(wtM004, "M004-VALIDATION.md"),
+    "verdict: pass\nremediation_round: 1",
   );
-  {
-    const mainBase = createBase("main");
-    const wtBase = createBase("wt");
 
-    try {
-      // Project root has an older CONTEXT but no VALIDATION
-      const prM004 = join(mainBase, ".gsd", "milestones", "M004");
-      mkdirSync(prM004, { recursive: true });
-      writeFileSync(join(prM004, "M004-CONTEXT.md"), "# old context");
+  syncProjectRootToWorktree(mainBase, wtBase, "M004");
 
-      // Worktree has CONTEXT + VALIDATION (written by validate-milestone)
-      const wtM004 = join(wtBase, ".gsd", "milestones", "M004");
-      mkdirSync(wtM004, { recursive: true });
-      writeFileSync(join(wtM004, "M004-CONTEXT.md"), "# worktree context");
-      writeFileSync(
-        join(wtM004, "M004-VALIDATION.md"),
-        "verdict: pass\nremediation_round: 1",
-      );
-
-      syncProjectRootToWorktree(mainBase, wtBase, "M004");
-
-      // VALIDATION.md must still exist in worktree
-      assertTrue(
-        existsSync(join(wtM004, "M004-VALIDATION.md")),
-        "#1886: VALIDATION.md still exists after sync",
-      );
-      assertEq(
-        readFileSync(join(wtM004, "M004-VALIDATION.md"), "utf-8"),
-        "verdict: pass\nremediation_round: 1",
-        "#1886: VALIDATION.md content preserved",
-      );
-
-      // CONTEXT.md should NOT be overwritten — worktree version is authoritative
-      assertEq(
-        readFileSync(join(wtM004, "M004-CONTEXT.md"), "utf-8"),
-        "# worktree context",
-        "#1886: existing worktree CONTEXT.md not overwritten",
-      );
-    } finally {
-      cleanup(mainBase);
-      cleanup(wtBase);
-    }
-  }
-
-  // ─── 2. Missing files ARE still copied from project root ────────────────
-  console.log("\n=== 2. #1886: missing worktree files still copied ===");
-  {
-    const mainBase = createBase("main");
-    const wtBase = createBase("wt");
-
-    try {
-      const prM004 = join(mainBase, ".gsd", "milestones", "M004");
-      mkdirSync(prM004, { recursive: true });
-      writeFileSync(join(prM004, "M004-CONTEXT.md"), "# from project root");
-      writeFileSync(join(prM004, "M004-ROADMAP.md"), "# roadmap");
-
-      // Worktree has no M004 directory at all
-      syncProjectRootToWorktree(mainBase, wtBase, "M004");
-
-      assertTrue(
-        existsSync(join(wtBase, ".gsd", "milestones", "M004", "M004-CONTEXT.md")),
-        "#1886: missing CONTEXT.md copied from project root",
-      );
-      assertTrue(
-        existsSync(join(wtBase, ".gsd", "milestones", "M004", "M004-ROADMAP.md")),
-        "#1886: missing ROADMAP.md copied from project root",
-      );
-    } finally {
-      cleanup(mainBase);
-      cleanup(wtBase);
-    }
-  }
-
-  // ─── 3. completed-units.json forward-synced from project root ───────────
-  console.log(
-    "\n=== 3. #1886: completed-units.json forward-synced to worktree ===",
+  assert.ok(
+    existsSync(join(wtM004, "M004-VALIDATION.md")),
+    "VALIDATION.md still exists after sync",
   );
-  {
-    const mainBase = createBase("main");
-    const wtBase = createBase("wt");
-
-    try {
-      // Project root has completed units (authoritative after crash recovery)
-      writeFileSync(
-        join(mainBase, ".gsd", "completed-units.json"),
-        JSON.stringify(["validate-milestone/M004"]),
-      );
-
-      // Worktree has empty completed-units
-      writeFileSync(
-        join(wtBase, ".gsd", "completed-units.json"),
-        JSON.stringify([]),
-      );
-
-      syncProjectRootToWorktree(mainBase, wtBase, "M004");
-
-      const wtCompleted = JSON.parse(
-        readFileSync(join(wtBase, ".gsd", "completed-units.json"), "utf-8"),
-      );
-      assertEq(
-        wtCompleted,
-        ["validate-milestone/M004"],
-        "#1886: completed-units.json synced from project root (force:true)",
-      );
-    } finally {
-      cleanup(mainBase);
-      cleanup(wtBase);
-    }
-  }
-
-  // ─── 4. completed-units.json: no-op when project root has no file ───────
-  console.log(
-    "\n=== 4. #1886: completed-units.json no-op when missing in project root ===",
+  assert.equal(
+    readFileSync(join(wtM004, "M004-VALIDATION.md"), "utf-8"),
+    "verdict: pass\nremediation_round: 1",
+    "VALIDATION.md content preserved",
   );
-  {
-    const mainBase = createBase("main");
-    const wtBase = createBase("wt");
+  assert.equal(
+    readFileSync(join(wtM004, "M004-CONTEXT.md"), "utf-8"),
+    "# worktree context",
+    "existing worktree CONTEXT.md not overwritten",
+  );
+});
 
-    try {
-      // Project root milestone dir must exist for sync to run
-      const prM004 = join(mainBase, ".gsd", "milestones", "M004");
-      mkdirSync(prM004, { recursive: true });
+test("#1886: missing worktree files are still copied from project root", (t) => {
+  const mainBase = createBase("main");
+  const wtBase = createBase("wt");
+  registerBases(t, mainBase, wtBase);
 
-      // No completed-units.json in project root
-      // Worktree has its own
-      writeFileSync(
-        join(wtBase, ".gsd", "completed-units.json"),
-        JSON.stringify(["some-unit/M001"]),
-      );
+  const prM004 = join(mainBase, ".gsd", "milestones", "M004");
+  mkdirSync(prM004, { recursive: true });
+  writeFileSync(join(prM004, "M004-CONTEXT.md"), "# from project root");
+  writeFileSync(join(prM004, "M004-ROADMAP.md"), "# roadmap");
 
-      syncProjectRootToWorktree(mainBase, wtBase, "M004");
+  syncProjectRootToWorktree(mainBase, wtBase, "M004");
 
-      const wtCompleted = JSON.parse(
-        readFileSync(join(wtBase, ".gsd", "completed-units.json"), "utf-8"),
-      );
-      assertEq(
-        wtCompleted,
-        ["some-unit/M001"],
-        "#1886: worktree completed-units.json untouched when project root has none",
-      );
-    } finally {
-      cleanup(mainBase);
-      cleanup(wtBase);
-    }
-  }
+  assert.ok(
+    existsSync(join(wtBase, ".gsd", "milestones", "M004", "M004-CONTEXT.md")),
+    "missing CONTEXT.md copied from project root",
+  );
+  assert.ok(
+    existsSync(join(wtBase, ".gsd", "milestones", "M004", "M004-ROADMAP.md")),
+    "missing ROADMAP.md copied from project root",
+  );
+});
 
-  report();
-}
+test("#1886: completed-units.json is forward-synced to worktree", (t) => {
+  const mainBase = createBase("main");
+  const wtBase = createBase("wt");
+  registerBases(t, mainBase, wtBase);
 
-main().catch((error) => {
-  console.error(error);
-  process.exit(1);
+  writeFileSync(
+    join(mainBase, ".gsd", "completed-units.json"),
+    JSON.stringify(["validate-milestone/M004"]),
+  );
+  writeFileSync(
+    join(wtBase, ".gsd", "completed-units.json"),
+    JSON.stringify([]),
+  );
+
+  syncProjectRootToWorktree(mainBase, wtBase, "M004");
+
+  const wtCompleted = JSON.parse(
+    readFileSync(join(wtBase, ".gsd", "completed-units.json"), "utf-8"),
+  );
+  assert.deepEqual(
+    wtCompleted,
+    ["validate-milestone/M004"],
+    "completed-units.json synced from project root (force:true)",
+  );
+});
+
+test("#1886: worktree completed-units.json untouched when project root has none", (t) => {
+  const mainBase = createBase("main");
+  const wtBase = createBase("wt");
+  registerBases(t, mainBase, wtBase);
+
+  // Project root milestone dir must exist for sync to run
+  const prM004 = join(mainBase, ".gsd", "milestones", "M004");
+  mkdirSync(prM004, { recursive: true });
+
+  writeFileSync(
+    join(wtBase, ".gsd", "completed-units.json"),
+    JSON.stringify(["some-unit/M001"]),
+  );
+
+  syncProjectRootToWorktree(mainBase, wtBase, "M004");
+
+  const wtCompleted = JSON.parse(
+    readFileSync(join(wtBase, ".gsd", "completed-units.json"), "utf-8"),
+  );
+  assert.deepEqual(
+    wtCompleted,
+    ["some-unit/M001"],
+    "worktree completed-units.json untouched when project root has none",
+  );
 });

--- a/src/resources/extensions/gsd/tests/zombie-gsd-state.test.ts
+++ b/src/resources/extensions/gsd/tests/zombie-gsd-state.test.ts
@@ -1,97 +1,81 @@
-import { readFileSync } from "node:fs";
+/**
+ * zombie-gsd-state.test.ts — #2942
+ *
+ * A partially initialized `.gsd/` (symlink exists but neither `PREFERENCES.md`
+ * nor `milestones/` is present) previously caused the init-wizard gate in
+ * `showSmartEntry` to be skipped. The fix introduces
+ * `hasGsdBootstrapArtifacts`, which requires at least one bootstrap artifact
+ * to be present before treating the project as initialized.
+ *
+ * These tests exercise that helper directly over synthetic filesystems and
+ * injected predicates — replacing the old source-grep assertions that only
+ * verified the function's *text* shape.
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
+import { tmpdir } from "node:os";
 
-import {createTestContext, extractSourceRegion } from "./test-helpers.ts";
+import { hasGsdBootstrapArtifacts } from "../detection.ts";
 
-const { assertTrue, assertMatch, assertNoMatch, report } = createTestContext();
+function makeGsdDir(t: { after: (fn: () => void) => void }): string {
+  const dir = mkdtempSync(join(tmpdir(), "gsd-zombie-state-"));
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+  return dir;
+}
 
-// ─── #2942: Zombie .gsd state skips init wizard ─────────────────────────────
-//
-// A partially initialized .gsd/ (symlink exists but no PREFERENCES.md or
-// milestones/) causes the init wizard gate in showSmartEntry to be skipped,
-// resulting in an uninitialized project session.
+test("#2942: missing .gsd/ directory entirely → treated as un-bootstrapped", () => {
+  assert.equal(
+    hasGsdBootstrapArtifacts("/nonexistent/path/does/not/exist/.gsd"),
+    false,
+  );
+});
 
-console.log("\n=== #2942: zombie .gsd state must not skip init wizard ===");
+test("#2942: zombie .gsd/ (empty directory) must NOT count as bootstrapped", (t) => {
+  const gsd = makeGsdDir(t);
+  // Only the directory exists — neither PREFERENCES.md nor milestones/
+  assert.equal(
+    hasGsdBootstrapArtifacts(gsd),
+    false,
+    "an empty .gsd/ is a zombie state — init wizard must still run",
+  );
+});
 
-// ── guided-flow.ts — init wizard gate must check bootstrap completeness ──
+test("#2942: .gsd/ with PREFERENCES.md counts as bootstrapped", (t) => {
+  const gsd = makeGsdDir(t);
+  writeFileSync(join(gsd, "PREFERENCES.md"), "# prefs\n");
+  assert.equal(hasGsdBootstrapArtifacts(gsd), true);
+});
 
-const guidedFlowSrc = readFileSync(
-  join(import.meta.dirname, "..", "guided-flow.ts"),
-  "utf-8",
-);
+test("#2942: .gsd/ with milestones/ directory counts as bootstrapped", (t) => {
+  const gsd = makeGsdDir(t);
+  mkdirSync(join(gsd, "milestones"));
+  assert.equal(hasGsdBootstrapArtifacts(gsd), true);
+});
 
-// Find the showSmartEntry function
-const smartEntryIdx = guidedFlowSrc.indexOf("export async function showSmartEntry(");
-assertTrue(smartEntryIdx >= 0, "guided-flow.ts defines showSmartEntry");
+test("#2942: both artifacts present → bootstrapped", (t) => {
+  const gsd = makeGsdDir(t);
+  writeFileSync(join(gsd, "PREFERENCES.md"), "# prefs\n");
+  mkdirSync(join(gsd, "milestones"));
+  assert.equal(hasGsdBootstrapArtifacts(gsd), true);
+});
 
-// Extract the region between showSmartEntry and the first showProjectInit call
-// This is where the init wizard gate lives.
-const afterSmartEntry = smartEntryIdx >= 0 ? extractSourceRegion(guidedFlowSrc, "export async function showSmartEntry(") : "";
+test("#2942: injected existsFn — zombie via predicate is rejected", () => {
+  // Only the .gsd/ directory exists; artifacts are missing.
+  const existsFn = (p: string) => p === "/proj/.gsd";
+  assert.equal(hasGsdBootstrapArtifacts("/proj/.gsd", existsFn), false);
+});
 
-// The gate must NOT be a bare `!existsSync(gsdRoot(basePath))` check.
-// It must also verify that bootstrap artifacts (PREFERENCES.md or milestones/) exist.
-assertTrue(
-  afterSmartEntry.includes("PREFERENCES.md") || afterSmartEntry.includes("PREFERENCES"),
-  "init wizard gate checks for PREFERENCES.md, not just .gsd/ existence (#2942)",
-);
+test("#2942: injected existsFn — PREFERENCES.md alone is enough", () => {
+  const existsFn = (p: string) =>
+    p === "/proj/.gsd" || p === "/proj/.gsd/PREFERENCES.md";
+  assert.equal(hasGsdBootstrapArtifacts("/proj/.gsd", existsFn), true);
+});
 
-assertTrue(
-  afterSmartEntry.includes("milestones"),
-  "init wizard gate checks for milestones/ directory, not just .gsd/ existence (#2942)",
-);
-
-// The init wizard should be shown when .gsd/ exists but has no bootstrap artifacts.
-// The old code was: if (!existsSync(gsdRoot(basePath))) { ... showProjectInit ... }
-// The fix should use a compound check so zombie states trigger the wizard.
-// Verify we no longer have the bare existence check as the sole gate.
-
-// Find the specific init wizard gate pattern — the detection preamble block.
-const detectionPreambleIdx = afterSmartEntry.indexOf("Detection preamble");
-const detectionRegion = detectionPreambleIdx >= 0
-  ? extractSourceRegion(afterSmartEntry, "Detection preamble")
-  : afterSmartEntry.slice(0, 1500);
-
-// The gate condition must reference PREFERENCES.md or milestones (bootstrap artifacts)
-assertMatch(
-  detectionRegion,
-  /PREFERENCES\.md|milestones/,
-  "detection preamble gate references bootstrap artifacts, not just directory existence (#2942)",
-);
-
-// ── auto-start.ts — milestones/ dir creation must not be dead code ──────────
-
-console.log("\n=== #2942: auto-start milestones/ bootstrap not dead code ===");
-
-const autoStartSrc = readFileSync(
-  join(import.meta.dirname, "..", "auto-start.ts"),
-  "utf-8",
-);
-
-// After ensureGsdSymlink, the code that creates milestones/ must check for
-// the milestones directory specifically (not .gsd/ which ensureGsdSymlink already created).
-const symlinkIdx = autoStartSrc.indexOf("ensureGsdSymlink(base)");
-assertTrue(symlinkIdx >= 0, "auto-start.ts calls ensureGsdSymlink(base)");
-
-const afterSymlink = symlinkIdx >= 0
-  ? autoStartSrc.slice(symlinkIdx, autoStartSrc.indexOf("Initialize GitServiceImpl", symlinkIdx))
-  : "";
-
-// The milestones bootstrap must check milestones path, not gsdDir
-// Old (dead) code: if (!existsSync(gsdDir)) { mkdirSync(join(gsdDir, "milestones"), ...) }
-// Fixed code should check: if (!existsSync(milestonesPath)) or similar
-assertTrue(
-  afterSymlink.includes("milestones") && afterSymlink.includes("mkdirSync"),
-  "auto-start.ts creates milestones/ directory after ensureGsdSymlink (#2942)",
-);
-
-// The guard for milestones/ creation should NOT be `!existsSync(gsdDir)` —
-// that's dead code since ensureGsdSymlink already created gsdDir.
-// It should check for the milestones/ dir directly.
-const mkdirRegion = afterSymlink.slice(0, afterSymlink.indexOf("mkdirSync") + 200);
-assertMatch(
-  mkdirRegion,
-  /existsSync\([^)]*milestones/,
-  "milestones bootstrap checks milestones path existence, not .gsd/ (#2942)",
-);
-
-report();
+test("#2942: injected existsFn — milestones/ alone is enough", () => {
+  const existsFn = (p: string) =>
+    p === "/proj/.gsd" || p === "/proj/.gsd/milestones";
+  assert.equal(hasGsdBootstrapArtifacts("/proj/.gsd", existsFn), true);
+});


### PR DESCRIPTION
## Summary

- Replaces eight batch-06 source-grep tests with behaviour coverage that drives the real module through its public surface (#4821). Two named helpers were extracted from `detection.ts` (`hasProjectFileInAncestor`, `hasGsdBootstrapArtifacts`) so the gate logic in `runUnitPhase` and `showSmartEntry` can be exercised without standing up the full session machinery. No behaviour change.
- Migrates three batch-06 tests from top-level IIFE / custom `createTestContext` + `report()` flows to `node:test` `test("...", (t) => {...})` with `t.after(cleanup)` (#4822). Per-scenario pass/fail reporting and deterministic cleanup; same coverage.

## Test plan

- [x] `node --import ./src/resources/extensions/gsd/tests/resolve-ts.mjs --experimental-strip-types --test` on all 13 modified test files — 85/85 pass
- [x] `tsc --noEmit` clean
- [ ] CI green on PR

Closes #4821
Closes #4822

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated monorepo detection logic by extracting shared helper functions for improved code maintainability.
  * Reorganized ancestor directory traversal to prevent false positives across repository boundaries.

* **Tests**
  * Expanded test coverage with behavioral unit tests replacing source-code inspection patterns.
  * Improved test suite organization and consistency across detection, validation, and worktree scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->