### PR TITLE
feat(auto): UnitContextManifest schema + data + CI guard — phase 1 of #4782

### DIFF
--- a/src/resources/extensions/gsd/tests/unit-context-manifest.test.ts
+++ b/src/resources/extensions/gsd/tests/unit-context-manifest.test.ts
@@ -1,0 +1,169 @@
+// GSD-2 — #4782 phase 1: schema tests + CI coverage guard for manifests.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  ARTIFACT_KEYS,
+  KNOWN_UNIT_TYPES,
+  UNIT_MANIFESTS,
+  resolveManifest,
+  type ArtifactKey,
+  type SkillsPolicy,
+  type UnitContextManifest,
+} from "../unit-context-manifest.ts";
+
+// ─── Coverage: every known unit type has a manifest ──────────────────────
+
+test("#4782 phase 1: every KNOWN_UNIT_TYPES entry has a UNIT_MANIFESTS entry", () => {
+  for (const unitType of KNOWN_UNIT_TYPES) {
+    assert.ok(
+      UNIT_MANIFESTS[unitType],
+      `unit type "${unitType}" is declared in KNOWN_UNIT_TYPES but has no manifest`,
+    );
+  }
+});
+
+test("#4782 phase 1: every UNIT_MANIFESTS entry corresponds to a known unit type", () => {
+  const known = new Set<string>(KNOWN_UNIT_TYPES as readonly string[]);
+  for (const unitType of Object.keys(UNIT_MANIFESTS)) {
+    assert.ok(
+      known.has(unitType),
+      `manifest entry "${unitType}" is not in KNOWN_UNIT_TYPES — add it there or remove the manifest`,
+    );
+  }
+});
+
+// ─── Coverage: every unitType stringly-typed in auto-dispatch.ts is known ─
+
+test("#4782 phase 1: every unitType string in auto-dispatch.ts has a manifest", () => {
+  // Source-only coverage check — read the dispatcher and enumerate its
+  // unitType literals. This is a CI guard against manifest drift: if a
+  // new dispatch rule is added without a corresponding manifest entry,
+  // this test fails loudly. Read-only check of source text; the cheapest
+  // way to enumerate declared unit types without running the dispatcher.
+  // allow-source-grep: enumerate unitType literals for CI coverage guard
+  const __dirname = dirname(fileURLToPath(import.meta.url));
+  const dispatchSrc = readFileSync(join(__dirname, "..", "auto-dispatch.ts"), "utf-8");
+  const matches = Array.from(dispatchSrc.matchAll(/unitType:\s*"([^"]+)"/g));
+  const seen = new Set<string>();
+  for (const m of matches) {
+    const t = m[1];
+    if (!t) continue;
+    seen.add(t);
+  }
+  const missing: string[] = [];
+  for (const t of seen) {
+    if (!UNIT_MANIFESTS[t as keyof typeof UNIT_MANIFESTS]) {
+      missing.push(t);
+    }
+  }
+  assert.deepEqual(missing, [], `unit types dispatched in auto-dispatch.ts but missing from UNIT_MANIFESTS: ${missing.join(", ")}`);
+});
+
+// ─── Shape: every manifest conforms to the schema invariants ──────────────
+
+test("#4782 phase 1: every manifest's artifacts reference known ArtifactKey values", () => {
+  const validKeys = new Set<string>(ARTIFACT_KEYS as readonly string[]);
+  for (const [unitType, manifest] of Object.entries(UNIT_MANIFESTS)) {
+    const all: ArtifactKey[] = [
+      ...manifest.artifacts.inline,
+      ...manifest.artifacts.excerpt,
+      ...manifest.artifacts.onDemand,
+    ];
+    for (const key of all) {
+      assert.ok(
+        validKeys.has(key),
+        `manifest "${unitType}" references unknown artifact key "${key}"`,
+      );
+    }
+  }
+});
+
+test("#4782 phase 1: no manifest has the same artifact key in inline AND excerpt (mutually exclusive)", () => {
+  for (const [unitType, manifest] of Object.entries(UNIT_MANIFESTS)) {
+    const inline = new Set<string>(manifest.artifacts.inline as readonly string[]);
+    const clashes = (manifest.artifacts.excerpt as readonly string[]).filter(k => inline.has(k));
+    assert.deepEqual(
+      clashes,
+      [],
+      `manifest "${unitType}" has overlapping inline+excerpt artifact keys: ${clashes.join(", ")}. Pick one.`,
+    );
+  }
+});
+
+test("#4782 phase 1: every manifest has a positive maxSystemPromptChars", () => {
+  for (const [unitType, manifest] of Object.entries(UNIT_MANIFESTS)) {
+    assert.ok(
+      typeof manifest.maxSystemPromptChars === "number" && manifest.maxSystemPromptChars > 0,
+      `manifest "${unitType}" has invalid maxSystemPromptChars: ${manifest.maxSystemPromptChars}`,
+    );
+  }
+});
+
+test("#4782 phase 1: skills policy shapes are valid discriminated-union members", () => {
+  for (const [unitType, manifest] of Object.entries(UNIT_MANIFESTS)) {
+    const p = manifest.skills as SkillsPolicy;
+    switch (p.mode) {
+      case "none":
+      case "all":
+        break;
+      case "allowlist":
+        assert.ok(
+          Array.isArray(p.skills) && p.skills.every(s => typeof s === "string"),
+          `manifest "${unitType}" has allowlist policy with invalid skills[]`,
+        );
+        break;
+      default: {
+        const _exhaustive: never = p;
+        void _exhaustive;
+        assert.fail(`manifest "${unitType}" has unrecognized skills.mode`);
+      }
+    }
+  }
+});
+
+// ─── Lookup helper ────────────────────────────────────────────────────────
+
+test("#4782 phase 1: resolveManifest returns null for an unknown unit type", () => {
+  assert.strictEqual(resolveManifest("never-dispatched-unit-type"), null);
+});
+
+test("#4782 phase 1: resolveManifest returns a manifest for every known unit type", () => {
+  for (const unitType of KNOWN_UNIT_TYPES) {
+    const m = resolveManifest(unitType);
+    assert.ok(m, `resolveManifest("${unitType}") should return a manifest`);
+    // Identity check — the helper should return the exact object, not a copy.
+    assert.strictEqual(m, UNIT_MANIFESTS[unitType]);
+  }
+});
+
+// ─── Phase-2 target: complete-milestone manifest reflects #4780's excerpt shape ─
+
+test("#4782 phase 1: complete-milestone manifest declares slice-summary as excerpt (matches #4780)", () => {
+  const m = UNIT_MANIFESTS["complete-milestone"];
+  assert.ok(
+    m.artifacts.excerpt.includes("slice-summary"),
+    "complete-milestone should declare slice-summary as excerpt (alignment with #4780)",
+  );
+  assert.ok(
+    !m.artifacts.inline.includes("slice-summary"),
+    "complete-milestone should NOT declare slice-summary as inline — that was the #4780 bloat",
+  );
+});
+
+// ─── Phase-2 target: reassess-roadmap manifest is the tightest budget ────
+
+test("#4782 phase 1: reassess-roadmap manifest has the smallest budget among manifests", () => {
+  const m = UNIT_MANIFESTS["reassess-roadmap"];
+  for (const [unitType, other] of Object.entries(UNIT_MANIFESTS)) {
+    if (unitType === "reassess-roadmap") continue;
+    assert.ok(
+      m.maxSystemPromptChars <= other.maxSystemPromptChars,
+      `reassess-roadmap budget (${m.maxSystemPromptChars}) should be ≤ ${unitType} budget (${other.maxSystemPromptChars})`,
+    );
+  }
+});

--- a/src/resources/extensions/gsd/unit-context-manifest.ts
+++ b/src/resources/extensions/gsd/unit-context-manifest.ts
@@ -1,0 +1,391 @@
+// GSD-2 — UnitContextManifest (#4782 phase 1).
+//
+// Declarative description of what context each auto-mode unit type needs
+// in its system prompt. Establishes the contract that later phases will
+// use to drive a single composeSystemPromptForUnit() — replacing the
+// per-unit-type branching currently spread across `auto-prompts.ts`.
+//
+// **Phase 1 ships the type + the data + a CI coverage guard.** It adds
+// zero wiring — no caller reads a manifest yet. Every unit type gets a
+// manifest that describes today's behavior as faithfully as possible, so
+// when the composer lands in phase 2 the migration can proceed manifest-
+// by-manifest without behavior change.
+//
+// Phased rollout tracking:
+//   - Phase 1 (this PR): schema + manifests + coverage test.
+//   - Phase 2: add composeSystemPromptForUnit(); migrate one low-risk
+//     unit type (e.g. reassess-roadmap) as the pilot.
+//   - Phase 3: migrate remaining unit types, tighten manifests per
+//     empirical usage, introduce skipWhen predicates absorbing the
+//     reassess opt-in gate from #4778.
+//   - Phase 4: introduce pipeline variants as declared sequences,
+//     absorbing the scope-classifier gates from #4781.
+//
+// Naming:
+//   - Artifact keys are STABLE strings (not paths). Path resolution is
+//     the composer's job; manifests describe intent, not disk layout.
+//   - Char budgets are nominal — blown budgets log a telemetry event,
+//     they do not truncate or error (the composer decides fallback).
+
+// ─── Artifact registry ────────────────────────────────────────────────────
+
+/**
+ * Stable identifiers for every artifact class a unit might inline, excerpt,
+ * or reference on-demand. Adding a new artifact class requires (a) a key
+ * here, (b) path/body resolution in the composer, and (c) updates to any
+ * manifest that should surface it.
+ */
+export const ARTIFACT_KEYS = [
+  // Milestone-scoped
+  "roadmap",
+  "milestone-context",
+  "milestone-summary",
+  "milestone-validation",
+  "milestone-research",
+  "milestone-plan",
+  // Slice-scoped
+  "slice-research",
+  "slice-plan",
+  "slice-summary",
+  "slice-uat",
+  "slice-assessment",
+  // Task-scoped
+  "task-plan",
+  "task-summary",
+  "prior-task-summaries",
+  "dependency-summaries",
+  // Project-scoped
+  "requirements",
+  "decisions",
+  "project",
+  "templates",
+] as const;
+
+export type ArtifactKey = typeof ARTIFACT_KEYS[number];
+
+// ─── Policy types ─────────────────────────────────────────────────────────
+
+/**
+ * Skill catalog policy. `all` preserves today's default: the full catalog
+ * is stamped into the prompt. `allowlist` narrows to the named skills.
+ * `none` suppresses the catalog entirely.
+ *
+ * The allowlist mode pairs with `skill-manifest.ts` (#4779) — entries
+ * there are the source of truth for "which skills are dispatched for a
+ * unit type"; this manifest carries the policy shape so the composer
+ * can unify the two surfaces in phase 2.
+ */
+export type SkillsPolicy =
+  | { readonly mode: "none" }
+  | { readonly mode: "all" }
+  | { readonly mode: "allowlist"; readonly skills: readonly string[] };
+
+/** Knowledge block policy — see `bootstrap/system-context.ts` loadKnowledgeBlock. */
+export type KnowledgePolicy = "none" | "critical-only" | "scoped" | "full";
+
+/** Memory store policy — see `bootstrap/system-context.ts` loadMemoryBlock. */
+export type MemoryPolicy = "none" | "critical-only" | "prompt-relevant";
+
+/** Preferences block policy. */
+export type PreferencesPolicy = "none" | "active-only" | "full";
+
+// ─── Manifest ─────────────────────────────────────────────────────────────
+
+export interface UnitContextManifest {
+  /** Skills catalog shape to surface. */
+  readonly skills: SkillsPolicy;
+  /** Knowledge block policy. */
+  readonly knowledge: KnowledgePolicy;
+  /** Memory store policy. */
+  readonly memory: MemoryPolicy;
+  /** Whether CODEBASE.md is inlined. */
+  readonly codebaseMap: boolean;
+  /** Preferences block policy. */
+  readonly preferences: PreferencesPolicy;
+  /** Artifact handling: inline (full body), excerpt (compact), or on-demand (path only). */
+  readonly artifacts: {
+    readonly inline: readonly ArtifactKey[];
+    readonly excerpt: readonly ArtifactKey[];
+    readonly onDemand: readonly ArtifactKey[];
+  };
+  /**
+   * Nominal upper bound for composer-generated system prompt size, in
+   * characters. Phase 2 composer logs telemetry when a unit exceeds its
+   * budget; truncation is not enforced. Set conservatively — today's
+   * observed maxima come from `complete-milestone` (~1.2M tokens cached;
+   * ~4.8M chars) and `validate-milestone` (~300K tokens; ~1.2M chars).
+   */
+  readonly maxSystemPromptChars: number;
+}
+
+// ─── Manifests ────────────────────────────────────────────────────────────
+
+// Phase 1 policy: every manifest encodes today's behavior. Skills = "all"
+// unless the unit type was already narrowed via the existing skill-manifest
+// resolver (#4779). Memory/knowledge policies reflect the defaults in
+// `bootstrap/system-context.ts`. Artifact classifications follow what
+// `auto-prompts.ts` inlines today for each unit type.
+
+const COMMON_BUDGET_LARGE = 1_500_000;  // ~400K tokens
+const COMMON_BUDGET_MEDIUM = 750_000;   // ~200K tokens
+const COMMON_BUDGET_SMALL = 250_000;    // ~65K tokens
+
+/**
+ * Canonical unit types handled by auto-mode dispatch. The coverage test
+ * enumerates these against `UNIT_MANIFESTS` to catch manifest drift when
+ * a new unit type lands.
+ */
+export const KNOWN_UNIT_TYPES = [
+  "research-milestone",
+  "plan-milestone",
+  "discuss-milestone",
+  "validate-milestone",
+  "complete-milestone",
+  "research-slice",
+  "plan-slice",
+  "refine-slice",
+  "replan-slice",
+  "complete-slice",
+  "reassess-roadmap",
+  "execute-task",
+  "reactive-execute",
+  "run-uat",
+  "gate-evaluate",
+  "rewrite-docs",
+] as const;
+
+export type UnitType = typeof KNOWN_UNIT_TYPES[number];
+
+export const UNIT_MANIFESTS: Record<UnitType, UnitContextManifest> = {
+  // ─── Milestone-scoped ────────────────────────────────────────────────
+  "research-milestone": {
+    skills: { mode: "all" },
+    knowledge: "full",
+    memory: "prompt-relevant",
+    codebaseMap: true,
+    preferences: "active-only",
+    artifacts: {
+      inline: ["project", "requirements", "decisions", "templates"],
+      excerpt: [],
+      onDemand: [],
+    },
+    maxSystemPromptChars: COMMON_BUDGET_MEDIUM,
+  },
+  "plan-milestone": {
+    skills: { mode: "all" },
+    knowledge: "full",
+    memory: "prompt-relevant",
+    codebaseMap: true,
+    preferences: "active-only",
+    artifacts: {
+      inline: ["project", "requirements", "decisions", "milestone-research", "templates"],
+      excerpt: [],
+      onDemand: [],
+    },
+    maxSystemPromptChars: COMMON_BUDGET_LARGE,
+  },
+  "discuss-milestone": {
+    skills: { mode: "all" },
+    knowledge: "full",
+    memory: "prompt-relevant",
+    codebaseMap: true,
+    preferences: "active-only",
+    artifacts: {
+      inline: ["project", "requirements", "decisions", "milestone-context", "templates"],
+      excerpt: [],
+      onDemand: [],
+    },
+    maxSystemPromptChars: COMMON_BUDGET_MEDIUM,
+  },
+  "validate-milestone": {
+    skills: { mode: "all" },
+    knowledge: "scoped",
+    memory: "prompt-relevant",
+    codebaseMap: false,
+    preferences: "active-only",
+    artifacts: {
+      inline: ["roadmap", "slice-summary", "slice-uat", "requirements", "decisions", "templates"],
+      excerpt: [],
+      onDemand: [],
+    },
+    maxSystemPromptChars: COMMON_BUDGET_LARGE,
+  },
+  "complete-milestone": {
+    skills: { mode: "all" },
+    knowledge: "scoped",
+    memory: "prompt-relevant",
+    codebaseMap: false,
+    preferences: "active-only",
+    artifacts: {
+      // #4780 landed slice-summary as excerpt for this unit; phase 2 of
+      // the architecture will read this manifest as the source of truth
+      // and retire the special-case wiring in auto-prompts.ts.
+      inline: ["roadmap", "milestone-context", "requirements", "decisions", "project", "templates"],
+      excerpt: ["slice-summary"],
+      onDemand: ["slice-summary"],
+    },
+    maxSystemPromptChars: COMMON_BUDGET_MEDIUM,
+  },
+
+  // ─── Slice-scoped ────────────────────────────────────────────────────
+  "research-slice": {
+    skills: { mode: "all" },
+    knowledge: "full",
+    memory: "prompt-relevant",
+    codebaseMap: true,
+    preferences: "active-only",
+    artifacts: {
+      inline: ["roadmap", "milestone-research", "dependency-summaries", "templates"],
+      excerpt: [],
+      onDemand: [],
+    },
+    maxSystemPromptChars: COMMON_BUDGET_MEDIUM,
+  },
+  "plan-slice": {
+    skills: { mode: "all" },
+    knowledge: "full",
+    memory: "prompt-relevant",
+    codebaseMap: true,
+    preferences: "active-only",
+    artifacts: {
+      inline: ["roadmap", "slice-research", "dependency-summaries", "requirements", "decisions", "templates"],
+      excerpt: [],
+      onDemand: [],
+    },
+    maxSystemPromptChars: COMMON_BUDGET_LARGE,
+  },
+  "refine-slice": {
+    skills: { mode: "all" },
+    knowledge: "scoped",
+    memory: "prompt-relevant",
+    codebaseMap: true,
+    preferences: "active-only",
+    artifacts: {
+      inline: ["slice-plan", "slice-research", "dependency-summaries", "templates"],
+      excerpt: [],
+      onDemand: [],
+    },
+    maxSystemPromptChars: COMMON_BUDGET_MEDIUM,
+  },
+  "replan-slice": {
+    skills: { mode: "all" },
+    knowledge: "scoped",
+    memory: "prompt-relevant",
+    codebaseMap: true,
+    preferences: "active-only",
+    artifacts: {
+      inline: ["slice-plan", "slice-research", "dependency-summaries", "prior-task-summaries", "templates"],
+      excerpt: [],
+      onDemand: [],
+    },
+    maxSystemPromptChars: COMMON_BUDGET_MEDIUM,
+  },
+  "complete-slice": {
+    skills: { mode: "all" },
+    knowledge: "scoped",
+    memory: "prompt-relevant",
+    codebaseMap: false,
+    preferences: "active-only",
+    artifacts: {
+      inline: ["slice-plan", "slice-research", "prior-task-summaries", "requirements", "templates"],
+      excerpt: [],
+      onDemand: [],
+    },
+    maxSystemPromptChars: COMMON_BUDGET_LARGE,
+  },
+  "reassess-roadmap": {
+    skills: { mode: "all" },
+    knowledge: "critical-only",
+    memory: "critical-only",
+    codebaseMap: false,
+    preferences: "none",
+    artifacts: {
+      inline: ["roadmap", "slice-summary"],
+      excerpt: [],
+      onDemand: [],
+    },
+    maxSystemPromptChars: COMMON_BUDGET_SMALL,
+  },
+
+  // ─── Task-scoped ─────────────────────────────────────────────────────
+  "execute-task": {
+    skills: { mode: "all" },
+    knowledge: "scoped",
+    memory: "prompt-relevant",
+    codebaseMap: true,
+    preferences: "active-only",
+    artifacts: {
+      inline: ["task-plan", "slice-plan", "prior-task-summaries", "templates"],
+      excerpt: [],
+      onDemand: ["slice-research"],
+    },
+    maxSystemPromptChars: COMMON_BUDGET_LARGE,
+  },
+  "reactive-execute": {
+    skills: { mode: "all" },
+    knowledge: "scoped",
+    memory: "prompt-relevant",
+    codebaseMap: true,
+    preferences: "active-only",
+    artifacts: {
+      inline: ["slice-plan", "prior-task-summaries", "templates"],
+      excerpt: [],
+      onDemand: ["slice-research"],
+    },
+    maxSystemPromptChars: COMMON_BUDGET_LARGE,
+  },
+
+  // ─── Ancillary units ─────────────────────────────────────────────────
+  "run-uat": {
+    skills: { mode: "all" },
+    knowledge: "critical-only",
+    memory: "critical-only",
+    codebaseMap: false,
+    preferences: "active-only",
+    artifacts: {
+      inline: ["slice-uat", "slice-plan"],
+      excerpt: [],
+      onDemand: [],
+    },
+    maxSystemPromptChars: COMMON_BUDGET_SMALL,
+  },
+  "gate-evaluate": {
+    skills: { mode: "all" },
+    knowledge: "critical-only",
+    memory: "critical-only",
+    codebaseMap: false,
+    preferences: "active-only",
+    artifacts: {
+      inline: ["slice-plan", "prior-task-summaries"],
+      excerpt: [],
+      onDemand: [],
+    },
+    maxSystemPromptChars: COMMON_BUDGET_SMALL,
+  },
+  "rewrite-docs": {
+    skills: { mode: "all" },
+    knowledge: "scoped",
+    memory: "prompt-relevant",
+    codebaseMap: true,
+    preferences: "active-only",
+    artifacts: {
+      inline: ["project", "requirements", "decisions", "templates"],
+      excerpt: [],
+      onDemand: [],
+    },
+    maxSystemPromptChars: COMMON_BUDGET_MEDIUM,
+  },
+};
+
+// ─── Lookup helper ────────────────────────────────────────────────────────
+
+/**
+ * Return the manifest for a unit type, or null when the type is unknown.
+ *
+ * Callers MUST treat null as "fall through to today's default behavior"
+ * rather than erroring — unknown unit types may be experimental and
+ * should not crash the composer.
+ */
+export function resolveManifest(unitType: string): UnitContextManifest | null {
+  return (UNIT_MANIFESTS as Record<string, UnitContextManifest>)[unitType] ?? null;
+}


### PR DESCRIPTION
## TL;DR

**What:** New `unit-context-manifest.ts` declaring the schema for what context each auto-mode unit type needs in its system prompt. 16 manifests (one per known unit type). CI guard that fails if a new dispatch rule lands without a matching manifest.
**Why:** Fix #4 / #2 / #3 / #1 each patched a specific bloat point; a single manifest-driven composer will retire the per-unit-type branches spread across `auto-prompts.ts` and make future context tuning a data edit, not a code edit. This PR establishes the contract so later phases can migrate unit types without behavior change.
**How:** Types + data + tests. No wiring — zero callers. Phase 1 manifests reflect today's behavior faithfully, so phase-2 migration is observable-equivalent at each step.

## What

- `src/resources/extensions/gsd/unit-context-manifest.ts` (new, 391 lines)
  - `ARTIFACT_KEYS` — 19 stable identifiers for artifact classes a unit might inline, excerpt, or reference on-demand.
  - `SkillsPolicy` discriminated union (`none` | `all` | `allowlist`), aligned with the existing `skill-manifest.ts` (#4779).
  - `KnowledgePolicy` / `MemoryPolicy` / `PreferencesPolicy` string unions, aligned with `bootstrap/system-context.ts` behavior.
  - `UnitContextManifest` interface with per-unit `maxSystemPromptChars` budget cap for telemetry.
  - `KNOWN_UNIT_TYPES` — 16 canonical unit types.
  - `UNIT_MANIFESTS` — one manifest per unit type.
  - `resolveManifest(unitType)` — null-safe lookup; unknown types fall through to today's behavior.
- `src/resources/extensions/gsd/tests/unit-context-manifest.test.ts` (new, 169 lines, 11 tests)
  - Bidirectional coverage (`KNOWN_UNIT_TYPES` ↔ `UNIT_MANIFESTS`)
  - Source-grep coverage guard (annotated `// allow-source-grep:` per the #4791 exception clause): every `unitType` string literal in `auto-dispatch.ts` must have a manifest entry
  - Schema invariants: valid artifact keys, mutually-exclusive inline/excerpt, positive budgets, valid skills-policy discriminants
  - Lookup helper round-trip + null-safety
  - Alignment assertions: `complete-milestone` manifest declares `slice-summary` as excerpt (matches #4780); `reassess-roadmap` carries the tightest budget

## Why

Part of #4782. Peer review (Codex) on the RFC confirmed `auto-prompts.ts` is already the implicit composer — formalizing the seam here turns future context tuning into a data edit rather than a hunt across a hotspot file.

### Phased rollout

1. **Phase 1 (this PR):** schema + manifests + CI guard. Zero wiring, zero callers, zero behavior change.
2. **Phase 2:** new `composeSystemPromptForUnit()` reading from manifests. Migrate one low-risk unit type (likely `reassess-roadmap` — smallest surface) as pilot. Behavior equivalence enforced by snapshot tests.
3. **Phase 3:** migrate remaining unit types. Introduce `skipWhen` predicates absorbing the #4778 reassess opt-in gate.
4. **Phase 4:** pipeline variants as declared manifests, absorbing the scope-classifier gates from #4781 phase 2 (#4912).

Each phase is independently revertible. Phase 2 failures don't touch phase 1's contract; phase 1's CI guard protects against drift during the rollout.

### Alignment with already-shipped work

- **#4779 skill manifest** — `SkillsPolicy.allowlist.skills` mirrors the existing skill-manifest shape. Phase 2 composer will consume both surfaces.
- **#4780 complete-milestone excerpts (#4908 pending)** — `UNIT_MANIFESTS["complete-milestone"].artifacts.excerpt` contains `slice-summary`, matching the behavior that #4780 ships. Test asserts this alignment.
- **#4778 reassess opt-in** — the `skipWhen` predicate envisioned in phase 3 absorbs this guard into a manifest entry rather than a dispatch-side special case.
- **#4781 pipeline variants (#4911 + #4912)** — phase 4 pipeline-variant manifests subsume the trivial-gate branches.

## How

### Manifest shape per unit type

Phase 1 manifests match today's observed behavior:

```ts
"complete-milestone": {
  skills: { mode: "all" },
  knowledge: "scoped",
  memory: "prompt-relevant",
  codebaseMap: false,
  preferences: "active-only",
  artifacts: {
    inline: ["roadmap", "milestone-context", "requirements", "decisions", "project", "templates"],
    excerpt: ["slice-summary"],            // ← aligns with #4780
    onDemand: ["slice-summary"],
  },
  maxSystemPromptChars: 750_000,
}
```

### What's deferred to later phases

- **SkipPredicate schema.** Phase 3 introduces predicates after #4778's reassess-opt-in becomes the concrete first use case. Adding the schema prematurely would over-constrain the design.
- **Pipeline variants.** Phase 4 introduces a second enum layer (variant × unit-type) once phase 3's composer proves the single-tier manifest model.
- **Manifest merging.** No composition / inheritance yet — every manifest is complete and standalone. If this becomes painful during phase 2 migration, we'll add it with concrete data.

### Local verification

**11/11 manifest tests passing.** Zero existing tests affected — no callers of the new module.

## Change type

- [x] `feat` — New module, no existing behavior changes

## Breaking changes

**None.** No callers exist. Phase-2+ wiring PRs will explicitly call out any observable behavior deltas.

AI-assisted PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive validation test suite checking manifest consistency, schema invariants, artifact configuration integrity, and policy enforcement across all unit types.

* **Chores**
  * Introduced declarative manifest system establishing per-unit configuration records for artifact handling, knowledge and memory policies, and system-level resource budgets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->