### PR TITLE
feat(auto): compose reassess-roadmap context from manifest — #4782 phase 2

### DIFF
--- a/src/resources/extensions/gsd/auto-prompts.ts
+++ b/src/resources/extensions/gsd/auto-prompts.ts
@@ -33,6 +33,7 @@ import {
 } from "./gate-registry.js";
 import { formatDecisionsCompact, formatRequirementsCompact } from "./structured-data-formatter.js";
 import { readPhaseAnchor, formatAnchorForPrompt } from "./phase-anchor.js";
+import { composeInlinedContext, type ArtifactResolver } from "./unit-context-composer.js";
 import { logWarning } from "./workflow-logger.js";
 import { inlineGraphSubgraph } from "./graph-context.js";
 import { buildExtractionStepsBlock } from "./commands-extract-learnings.js";
@@ -2250,31 +2251,54 @@ export async function buildReassessRoadmapPrompt(
   mid: string, midTitle: string, completedSliceId: string, base: string, level?: InlineLevel,
 ): Promise<string> {
   const inlineLevel = level ?? resolveInlineLevel();
-  const roadmapPath = resolveMilestoneFile(base, mid, "ROADMAP");
-  const roadmapRel = relMilestoneFile(base, mid, "ROADMAP");
-  const summaryPath = resolveSliceFile(base, mid, completedSliceId, "SUMMARY");
-  const summaryRel = relSliceFile(base, mid, completedSliceId, "SUMMARY");
-  const sliceContextPath = resolveSliceFile(base, mid, completedSliceId, "CONTEXT");
-  const sliceContextRel = relSliceFile(base, mid, completedSliceId, "CONTEXT");
 
-  const inlined: string[] = [];
-  inlined.push(await inlineFile(roadmapPath, roadmapRel, "Current Roadmap"));
-  const sliceCtxInline = await inlineFileOptional(sliceContextPath, sliceContextRel, "Slice Context (from discussion)");
-  if (sliceCtxInline) inlined.push(sliceCtxInline);
-  inlined.push(await inlineFile(summaryPath, summaryRel, `${completedSliceId} Summary`));
-  if (inlineLevel !== "minimal") {
-    const projectInline = await inlineProjectFromDb(base);
-    if (projectInline) inlined.push(projectInline);
-    const requirementsInline = await inlineRequirementsFromDb(base, mid, undefined, inlineLevel);
-    if (requirementsInline) inlined.push(requirementsInline);
-    const decisionsInline = await inlineDecisionsFromDb(base, mid, undefined, inlineLevel);
-    if (decisionsInline) inlined.push(decisionsInline);
-  }
-  // Scoped + budgeted — see issue #4719
+  // #4782 phase 2 pilot: reassess-roadmap is the first unit type to
+  // compose its inlined context through the manifest-driven composer.
+  // The resolver below dispatches artifact keys to the existing inline*
+  // helpers, preserving identical output so the migration is
+  // observable-equivalent. Knowledge stays outside the composer (it's
+  // budget-driven, not manifest-driven) until a later phase formalizes
+  // knowledge/memory policies as composer inputs.
+  const resolveArtifact: ArtifactResolver = async (key) => {
+    switch (key) {
+      case "roadmap": {
+        const p = resolveMilestoneFile(base, mid, "ROADMAP");
+        const r = relMilestoneFile(base, mid, "ROADMAP");
+        return await inlineFile(p, r, "Current Roadmap");
+      }
+      case "slice-context": {
+        const p = resolveSliceFile(base, mid, completedSliceId, "CONTEXT");
+        const r = relSliceFile(base, mid, completedSliceId, "CONTEXT");
+        return await inlineFileOptional(p, r, "Slice Context (from discussion)");
+      }
+      case "slice-summary": {
+        const p = resolveSliceFile(base, mid, completedSliceId, "SUMMARY");
+        const r = relSliceFile(base, mid, completedSliceId, "SUMMARY");
+        return await inlineFile(p, r, `${completedSliceId} Summary`);
+      }
+      case "project":
+        if (inlineLevel === "minimal") return null;
+        return await inlineProjectFromDb(base);
+      case "requirements":
+        if (inlineLevel === "minimal") return null;
+        return await inlineRequirementsFromDb(base, mid, undefined, inlineLevel);
+      case "decisions":
+        if (inlineLevel === "minimal") return null;
+        return await inlineDecisionsFromDb(base, mid, undefined, inlineLevel);
+      default:
+        return null;
+    }
+  };
+
+  const composed = await composeInlinedContext("reassess-roadmap", resolveArtifact);
+  const parts: string[] = [];
+  if (composed) parts.push(composed);
+  // Knowledge block stays outside the composer — budgeted, scoped via
+  // keyword extraction (#4719). Future phase folds it in.
   const knowledgeInlineRA = await inlineKnowledgeBudgeted(base, extractKeywords(midTitle));
-  if (knowledgeInlineRA) inlined.push(knowledgeInlineRA);
+  if (knowledgeInlineRA) parts.push(knowledgeInlineRA);
 
-  const inlinedContext = capPreamble(`## Inlined Context (preloaded — do not re-read these files)\n\n${inlined.join("\n\n---\n\n")}`);
+  const inlinedContext = capPreamble(`## Inlined Context (preloaded — do not re-read these files)\n\n${parts.join("\n\n---\n\n")}`);
 
   const assessmentPath = join(base, relSliceFile(base, mid, completedSliceId, "ASSESSMENT"));
 
@@ -2299,7 +2323,7 @@ export async function buildReassessRoadmapPrompt(
     milestoneId: mid,
     milestoneTitle: midTitle,
     completedSliceId,
-    roadmapPath: roadmapRel,
+    roadmapPath: relMilestoneFile(base, mid, "ROADMAP"),
     assessmentPath,
     inlinedContext,
     deferredCaptures,

--- a/src/resources/extensions/gsd/tests/unit-context-composer.test.ts
+++ b/src/resources/extensions/gsd/tests/unit-context-composer.test.ts
@@ -1,0 +1,175 @@
+// GSD-2 — #4782 phase 2 composer tests. Pure-function tests using mock
+// resolvers plus an integration check that reassess-roadmap's migrated
+// builder produces a prompt matching expectations.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import {
+  composeInlinedContext,
+  manifestBudgetChars,
+  type ArtifactResolver,
+} from "../unit-context-composer.ts";
+import type { ArtifactKey } from "../unit-context-manifest.ts";
+import { buildReassessRoadmapPrompt } from "../auto-prompts.ts";
+import { invalidateAllCaches } from "../cache.ts";
+import {
+  openDatabase,
+  closeDatabase,
+  insertMilestone,
+  upsertMilestonePlanning,
+  insertSlice,
+} from "../gsd-db.ts";
+
+// ─── Pure composer tests ──────────────────────────────────────────────────
+
+test("#4782 composer: returns empty string for unknown unit type", async () => {
+  const out = await composeInlinedContext("never-dispatched", async () => "body");
+  assert.strictEqual(out, "");
+});
+
+test("#4782 composer: walks the manifest's inline list in declared order", async () => {
+  // reassess-roadmap manifest: [roadmap, slice-context, slice-summary, project, requirements, decisions]
+  const calls: ArtifactKey[] = [];
+  const resolver: ArtifactResolver = async (key) => {
+    calls.push(key);
+    return `BODY:${key}`;
+  };
+  const out = await composeInlinedContext("reassess-roadmap", resolver);
+  assert.deepEqual(calls, [
+    "roadmap",
+    "slice-context",
+    "slice-summary",
+    "project",
+    "requirements",
+    "decisions",
+  ]);
+  // Output joins blocks with the "---" separator.
+  assert.match(out, /BODY:roadmap\n\n---\n\nBODY:slice-context/);
+});
+
+test("#4782 composer: null-returning resolvers are silently omitted", async () => {
+  const resolver: ArtifactResolver = async (key) => {
+    if (key === "slice-context" || key === "project") return null;
+    return `BODY:${key}`;
+  };
+  const out = await composeInlinedContext("reassess-roadmap", resolver);
+  // slice-context + project skipped — not in output, no empty blocks
+  assert.ok(!out.includes("BODY:slice-context"));
+  assert.ok(!out.includes("BODY:project"));
+  // Remaining keys still emitted in declared order
+  assert.match(out, /BODY:roadmap\n\n---\n\nBODY:slice-summary\n\n---\n\nBODY:requirements\n\n---\n\nBODY:decisions/);
+});
+
+test("#4782 composer: empty-string resolvers are omitted (treated as no-op)", async () => {
+  const resolver: ArtifactResolver = async (key) => {
+    if (key === "slice-context") return "";
+    if (key === "slice-summary") return null;
+    return `BODY:${key}`;
+  };
+  const out = await composeInlinedContext("reassess-roadmap", resolver);
+  assert.ok(!out.includes("BODY:slice-context"));
+  assert.ok(!out.includes("BODY:slice-summary"));
+  // Must not leave double-separators when blocks are skipped
+  assert.ok(!out.includes("---\n\n---"));
+});
+
+test("#4782 composer: resolver errors surface to caller", async () => {
+  const resolver: ArtifactResolver = async () => {
+    throw new Error("resolver boom");
+  };
+  await assert.rejects(
+    () => composeInlinedContext("reassess-roadmap", resolver),
+    /resolver boom/,
+  );
+});
+
+test("#4782 composer: manifestBudgetChars returns declared budget", () => {
+  const small = manifestBudgetChars("reassess-roadmap");
+  assert.ok(small !== null && small > 0);
+  assert.strictEqual(manifestBudgetChars("never-dispatched"), null);
+});
+
+// ─── Integration: migrated buildReassessRoadmapPrompt ─────────────────────
+
+function makeFixtureBase(): string {
+  const base = mkdtempSync(join(tmpdir(), "gsd-composer-pilot-"));
+  mkdirSync(join(base, ".gsd", "milestones", "M001", "slices", "S01", "tasks"), { recursive: true });
+  return base;
+}
+
+function cleanup(base: string): void {
+  try { closeDatabase(); } catch { /* noop */ }
+  invalidateAllCaches();
+  rmSync(base, { recursive: true, force: true });
+}
+
+function seed(base: string, mid: string): void {
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: mid, title: "Test", status: "active", depends_on: [] });
+  upsertMilestonePlanning(mid, {
+    title: "Test",
+    status: "active",
+    vision: "Ship it",
+    successCriteria: ["It ships"],
+    keyRisks: [],
+    proofStrategy: [],
+    verificationContract: "",
+    verificationIntegration: "",
+    verificationOperational: "",
+    verificationUat: "",
+    definitionOfDone: [],
+    requirementCoverage: "",
+    boundaryMapMarkdown: "",
+  });
+  insertSlice({
+    id: "S01",
+    milestoneId: mid,
+    title: "First",
+    status: "complete",
+    risk: "low",
+    depends: [],
+    demo: "",
+    sequence: 1,
+  });
+}
+
+function writeArtifacts(base: string): void {
+  writeFileSync(
+    join(base, ".gsd", "milestones", "M001", "M001-ROADMAP.md"),
+    "# M001\n## Slices\n- [x] **S01: First** `risk:low` `depends:[]`\n",
+  );
+  writeFileSync(
+    join(base, ".gsd", "milestones", "M001", "slices", "S01", "S01-SUMMARY.md"),
+    "---\nid: S01\nparent: M001\n---\n# S01 Summary\n**One-liner**\n\n## What Happened\nDone.\n",
+  );
+}
+
+test("#4782 phase 2: buildReassessRoadmapPrompt emits composer-shaped context with manifest-declared artifacts", async (t) => {
+  const base = makeFixtureBase();
+  t.after(() => cleanup(base));
+  invalidateAllCaches();
+
+  seed(base, "M001");
+  writeArtifacts(base);
+
+  const prompt = await buildReassessRoadmapPrompt("M001", "Test", "S01", base);
+
+  // Context block wrapper from capPreamble
+  assert.match(prompt, /## Inlined Context \(preloaded — do not re-read these files\)/);
+
+  // Roadmap inlined first (manifest order)
+  assert.match(prompt, /### Current Roadmap/);
+  assert.match(prompt, /S01: First/);
+
+  // Slice summary present
+  assert.match(prompt, /### S01 Summary/);
+  assert.match(prompt, /One-liner/);
+
+  // Slice context is optional and not present in this fixture — must not
+  // leave a stray empty section
+  assert.ok(!prompt.includes("Slice Context (from discussion)"));
+});

--- a/src/resources/extensions/gsd/tests/unit-context-manifest.test.ts
+++ b/src/resources/extensions/gsd/tests/unit-context-manifest.test.ts
@@ -155,15 +155,17 @@ test("#4782 phase 1: complete-milestone manifest declares slice-summary as excer
   );
 });
 
-// ─── Phase-2 target: reassess-roadmap manifest is the tightest budget ────
+// ─── Budget floor: run-uat + gate-evaluate hit the smallest budget tier ──
 
-test("#4782 phase 1: reassess-roadmap manifest has the smallest budget among manifests", () => {
-  const m = UNIT_MANIFESTS["reassess-roadmap"];
+test("#4782 phase 2: run-uat and gate-evaluate use the smallest budget tier", () => {
+  const uatBudget = UNIT_MANIFESTS["run-uat"].maxSystemPromptChars;
+  const gateBudget = UNIT_MANIFESTS["gate-evaluate"].maxSystemPromptChars;
+  assert.strictEqual(uatBudget, gateBudget, "run-uat and gate-evaluate both use COMMON_BUDGET_SMALL");
+  // They should be the tightest (or tied for tightest) across all manifests
   for (const [unitType, other] of Object.entries(UNIT_MANIFESTS)) {
-    if (unitType === "reassess-roadmap") continue;
     assert.ok(
-      m.maxSystemPromptChars <= other.maxSystemPromptChars,
-      `reassess-roadmap budget (${m.maxSystemPromptChars}) should be ≤ ${unitType} budget (${other.maxSystemPromptChars})`,
+      uatBudget <= other.maxSystemPromptChars,
+      `run-uat budget (${uatBudget}) should be ≤ ${unitType} budget (${other.maxSystemPromptChars})`,
     );
   }
 });

--- a/src/resources/extensions/gsd/unit-context-composer.ts
+++ b/src/resources/extensions/gsd/unit-context-composer.ts
@@ -1,0 +1,73 @@
+// GSD-2 — UnitContextComposer (#4782 phase 2).
+//
+// Reads a unit type's manifest and orchestrates artifact inlining through
+// a caller-provided resolver. Returns a joined context block suitable for
+// substitution into the unit's prompt template.
+//
+// Design rationale:
+//   - Pure dependency on the manifest module — no circular import with
+//     `auto-prompts.ts` where the per-artifact-key resolver lives.
+//   - Caller-supplied resolver means the composer can be unit-tested with
+//     trivial mocks; production wiring in `auto-prompts.ts` dispatches to
+//     the existing `inlineFile` / `inline*FromDb` helpers.
+//   - Null-returning resolvers are skipped silently: they model the
+//     "artifact is optional / missing / not applicable to this milestone"
+//     case. The composer never errors on a missing artifact.
+//
+// Scope: phase 2 pilot. The composer currently handles only the `inline`
+// artifact list. Excerpt and on-demand artifact shapes (already used by
+// #4780) will be folded in during phase 3 when the remaining unit types
+// migrate into the composer.
+
+import {
+  resolveManifest,
+  type ArtifactKey,
+  type UnitContextManifest,
+} from "./unit-context-manifest.js";
+
+/**
+ * Async function mapping an artifact key to its inlined-content string,
+ * or `null` when the artifact does not apply to the current milestone
+ * (missing file, empty table, etc).
+ */
+export type ArtifactResolver = (key: ArtifactKey) => Promise<string | null>;
+
+/**
+ * Produce the inlined-context portion of a unit's system prompt by
+ * walking the manifest's `artifacts.inline` list in order and calling
+ * the provided resolver for each key.
+ *
+ * Returns an empty string when the unit type has no manifest registered,
+ * so callers can guard their wiring with a simple truthy check. Unknown
+ * unit types do not error — this mirrors `resolveManifest`'s contract.
+ *
+ * The separator between inlined blocks matches the in-tree convention
+ * (`\n\n---\n\n`) so composer output slots into existing prompt templates
+ * without visible diff.
+ */
+export async function composeInlinedContext(
+  unitType: string,
+  resolveArtifact: ArtifactResolver,
+): Promise<string> {
+  const manifest: UnitContextManifest | null = resolveManifest(unitType);
+  if (!manifest) return "";
+
+  const blocks: string[] = [];
+  for (const key of manifest.artifacts.inline) {
+    const body = await resolveArtifact(key);
+    if (body !== null && body.length > 0) {
+      blocks.push(body);
+    }
+  }
+  return blocks.join("\n\n---\n\n");
+}
+
+/**
+ * Convenience helper returning the manifest's declared budget so callers
+ * can telemetry a mismatch between actual prompt size and declared budget.
+ * Returns null for unknown unit types.
+ */
+export function manifestBudgetChars(unitType: string): number | null {
+  const manifest = resolveManifest(unitType);
+  return manifest ? manifest.maxSystemPromptChars : null;
+}

--- a/src/resources/extensions/gsd/unit-context-manifest.ts
+++ b/src/resources/extensions/gsd/unit-context-manifest.ts
@@ -44,6 +44,7 @@ export const ARTIFACT_KEYS = [
   "milestone-research",
   "milestone-plan",
   // Slice-scoped
+  "slice-context",
   "slice-research",
   "slice-plan",
   "slice-summary",
@@ -295,16 +296,19 @@ export const UNIT_MANIFESTS: Record<UnitType, UnitContextManifest> = {
   },
   "reassess-roadmap": {
     skills: { mode: "all" },
-    knowledge: "critical-only",
+    knowledge: "scoped",
     memory: "critical-only",
     codebaseMap: false,
     preferences: "none",
     artifacts: {
-      inline: ["roadmap", "slice-summary"],
+      // Phase 2 pilot (#4782): manifest now matches today's actual
+      // buildReassessRoadmapPrompt behavior for equivalence. Phase 3
+      // will tighten this list once the composer reports real telemetry.
+      inline: ["roadmap", "slice-context", "slice-summary", "project", "requirements", "decisions"],
       excerpt: [],
       onDemand: [],
     },
-    maxSystemPromptChars: COMMON_BUDGET_SMALL,
+    maxSystemPromptChars: COMMON_BUDGET_MEDIUM,
   },
 
   // ─── Task-scoped ─────────────────────────────────────────────────────


### PR DESCRIPTION
## TL;DR

**What:** First migration through the manifest-driven composer. `buildReassessRoadmapPrompt` now assembles its inlined context by reading `UNIT_MANIFESTS["reassess-roadmap"]` and dispatching artifact keys to a local resolver.
**Why:** Phase 1 (#4920) landed the manifest schema with zero callers. Phase 2 is the pilot — prove the composer pattern works on the smallest, safest unit type before migrating the rest.
**How:** New `unit-context-composer.ts` module with pure `composeInlinedContext(unitType, resolveArtifact)`. Builder supplies a resolver that dispatches each `ArtifactKey` to the existing `inlineFile` / `inline*FromDb` helpers — output is byte-equivalent to pre-migration behavior.

## What

- **New:** `src/resources/extensions/gsd/unit-context-composer.ts`
  - `composeInlinedContext(unitType, resolveArtifact)` — walks `UNIT_MANIFESTS[unitType].artifacts.inline` in declared order, joins non-empty resolver outputs with the in-tree `\n\n---\n\n` separator.
  - `ArtifactResolver` type — caller-owned async function mapping key → body string or null.
  - `manifestBudgetChars(unitType)` helper for later telemetry.
  - Returns `""` for unknown unit types — mirrors `resolveManifest`'s null-safe contract.
- **Modified:** `src/resources/extensions/gsd/unit-context-manifest.ts`
  - Added `slice-context` to `ARTIFACT_KEYS` (reassess optionally inlines discussion CONTEXT.md).
  - Extended `reassess-roadmap` manifest to reflect today's actual builder behavior: `inline: ["roadmap", "slice-context", "slice-summary", "project", "requirements", "decisions"]`. Budget bumped from `SMALL` to `MEDIUM` to match footprint.
- **Modified:** `src/resources/extensions/gsd/auto-prompts.ts`
  - `buildReassessRoadmapPrompt` delegates its inlined-context build through `composeInlinedContext`. Local resolver switches on the artifact key and calls the existing inline helpers.
  - Knowledge inlining (`inlineKnowledgeBudgeted`) stays in the builder, joined after the composer-produced block — knowledge/memory policy will move into the composer in a later phase.
- **New tests:** `src/resources/extensions/gsd/tests/unit-context-composer.test.ts` (175 lines, 7 tests)
  - Unit: composer walks manifest in declared order, skips null/empty, preserves the separator contract, surfaces resolver errors, returns `""` for unknown types, reports budget correctly.
  - Integration: `buildReassessRoadmapPrompt` with the migrated composer emits expected sections; optional `slice-context` correctly omitted when absent (no stray empty block).
- **Modified tests:** `src/resources/extensions/gsd/tests/unit-context-manifest.test.ts`
  - Dropped the phase-1 "reassess has smallest budget" assertion (invalidated by manifest expansion). Replaced with a check that `run-uat` and `gate-evaluate` tie for the `COMMON_BUDGET_SMALL` tier.

## Why

Part of #4782. Follows the phase-1 PR #4920 which shipped the schema + data + CI guard with zero wiring.

### Why reassess-roadmap as the pilot

Codex-era review flagged that `auto-prompts.ts` is already the implicit composer — phase 2's job is to formalize that seam without breaking any user-visible behavior. Picking reassess-roadmap minimizes blast radius:

- Smallest inline surface (3 always + 3 conditional artifacts)
- Already gated by preference (#4778), so a regression affects fewer users
- No overlap with in-flight PRs (#4908 / #4911 / #4912 touched `auto-prompts.ts` but landed before this branch cut)
- Equivalence is easy to verify — the inline list is short enough to snapshot end-to-end

### Why knowledge stays outside the composer

`inlineKnowledgeBudgeted` is budget-driven (keyword extraction) not manifest-driven. Folding it into the composer requires adding a knowledge/memory policy surface to the resolver contract — larger design question out of scope for the pilot. Every migrated builder will continue to handle knowledge the same way until a dedicated phase addresses it.

## How

### Composer contract

```ts
export type ArtifactResolver = (key: ArtifactKey) => Promise<string | null>;

export async function composeInlinedContext(
  unitType: string,
  resolveArtifact: ArtifactResolver,
): Promise<string>;
```

- Walks `manifest.artifacts.inline` in declared order.
- Calls `resolveArtifact(key)` for each key.
- Skips null/empty results silently.
- Joins with `"\n\n---\n\n"`.
- Returns `""` for unknown unit types.

### Migrated builder shape

```ts
const resolveArtifact: ArtifactResolver = async (key) => {
  switch (key) {
    case "roadmap": return await inlineFile(roadmapPath, roadmapRel, "Current Roadmap");
    case "slice-context": return await inlineFileOptional(sliceContextPath, sliceContextRel, "Slice Context (from discussion)");
    case "slice-summary": return await inlineFile(summaryPath, summaryRel, `${completedSliceId} Summary`);
    case "project": if (inlineLevel === "minimal") return null; return await inlineProjectFromDb(base);
    case "requirements": if (inlineLevel === "minimal") return null; return await inlineRequirementsFromDb(base, mid, undefined, inlineLevel);
    case "decisions": if (inlineLevel === "minimal") return null; return await inlineDecisionsFromDb(base, mid, undefined, inlineLevel);
    default: return null;
  }
};

const composed = await composeInlinedContext("reassess-roadmap", resolveArtifact);
```

Output is byte-equivalent to the pre-migration builder for realistic milestones. `inlineLevel` filtering stays in the resolver (phase 3 will decide whether to fold it into the manifest or keep it imperative).

### Safe fallbacks

- Unknown unit type → composer returns `""`, builder still emits its wrapper header + knowledge block (degrades to no inlined context, not crash).
- Missing artifact (e.g. no SUMMARY file) → resolver returns null, composer skips silently.
- Resolver throws → composer re-throws; same surface as today's errors.

### Scope

- **reassess-roadmap only.** Phase 3 migrates the remaining 15 unit types.
- No changes to dispatch rules, handlers, or artifact schemas.
- No new DB columns, no migration.

### Local verification

**33/33 tests passing** across `unit-context-composer`, `unit-context-manifest`, `reassess-detection`, `reassess-prompt`, `reassess-default-optin`.

## Change type

- [x] `feat` — New composer module + first migration. Observable-equivalent output for all current users.

## Breaking changes

**None.** Reassess-roadmap prompt content and structure are unchanged for realistic inputs. The composer is introduced as a seam — future phases will tighten manifests per unit type with explicit breaking-change notes when behavior deltas ship.

AI-assisted PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced roadmap reassessment with expanded context sources and improved artifact integration.
  * Introduced flexible context composition system for extensions.

* **Tests**
  * Added comprehensive test suites validating context composition and artifact handling.
  * Updated manifest validation tests for architecture consistency.

* **Refactor**
  * Refactored prompt construction to use modular context composition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->