### PR TITLE
feat(auto): migrate research-milestone through composer — #4782 phase 3 batch 2 [STACKED]

### DIFF
--- a/src/resources/extensions/gsd/auto-prompts.ts
+++ b/src/resources/extensions/gsd/auto-prompts.ts
@@ -1229,30 +1229,64 @@ export async function buildDiscussMilestonePrompt(
 }
 
 export async function buildResearchMilestonePrompt(mid: string, midTitle: string, base: string): Promise<string> {
-  const contextPath = resolveMilestoneFile(base, mid, "CONTEXT");
-  const contextRel = relMilestoneFile(base, mid, "CONTEXT");
+  // #4782 phase 3: research-milestone migrated through the composer.
+  // Declared inline order: milestone-context, project, requirements,
+  // decisions, templates. Knowledge stays outside the composer
+  // (budget-driven, scoped by keyword extraction — future phase folds
+  // policy-driven blocks in).
+  const resolveArtifact: ArtifactResolver = async (key) => {
+    switch (key) {
+      case "milestone-context": {
+        const p = resolveMilestoneFile(base, mid, "CONTEXT");
+        const r = relMilestoneFile(base, mid, "CONTEXT");
+        return await inlineFile(p, r, "Milestone Context");
+      }
+      case "project":
+        return await inlineProjectFromDb(base);
+      case "requirements":
+        return await inlineRequirementsFromDb(base, mid);
+      case "decisions":
+        return await inlineDecisionsFromDb(base, mid);
+      case "templates":
+        return inlineTemplate("research", "Research");
+      default:
+        return null;
+    }
+  };
 
-  const inlined: string[] = [];
-  inlined.push(await inlineFile(contextPath, contextRel, "Milestone Context"));
-  const projectInline = await inlineProjectFromDb(base);
-  if (projectInline) inlined.push(projectInline);
-  const requirementsInline = await inlineRequirementsFromDb(base, mid);
-  if (requirementsInline) inlined.push(requirementsInline);
-  const decisionsInline = await inlineDecisionsFromDb(base, mid);
-  if (decisionsInline) inlined.push(decisionsInline);
-  // Scoped + budgeted — see issue #4719
+  const composed = await composeInlinedContext("research-milestone", resolveArtifact);
+
+  // Knowledge block stays outside the composer — budgeted, scoped via
+  // keyword extraction (#4719). Inserted between decisions and the
+  // templates block to match the pre-migration output order. We split
+  // the composer output around the templates section to preserve that
+  // ordering.
   const knowledgeInlineRM = await inlineKnowledgeBudgeted(base, extractKeywords(midTitle));
-  if (knowledgeInlineRM) inlined.push(knowledgeInlineRM);
-  inlined.push(inlineTemplate("research", "Research"));
+  const parts: string[] = [];
+  if (knowledgeInlineRM && composed) {
+    // Insert knowledge before the template block so the overall order is:
+    //   milestone-context → project → requirements → decisions → KNOWLEDGE → research template
+    const idx = composed.lastIndexOf("### Output Template:");
+    if (idx > 0) {
+      const before = composed.slice(0, idx).replace(/\n\n---\n\n$/, "");
+      const after = composed.slice(idx);
+      parts.push(before, knowledgeInlineRM, after);
+    } else {
+      parts.push(composed, knowledgeInlineRM);
+    }
+  } else if (composed) {
+    parts.push(composed);
+    if (knowledgeInlineRM) parts.push(knowledgeInlineRM);
+  }
 
-  const inlinedContext = capPreamble(`## Inlined Context (preloaded — do not re-read these files)\n\n${inlined.join("\n\n---\n\n")}`);
+  const inlinedContext = capPreamble(`## Inlined Context (preloaded — do not re-read these files)\n\n${parts.join("\n\n---\n\n")}`);
 
   const outputRelPath = relMilestoneFile(base, mid, "RESEARCH");
   return loadPrompt("research-milestone", {
     workingDirectory: base,
     milestoneId: mid, milestoneTitle: midTitle,
     milestonePath: relMilestonePath(base, mid),
-    contextPath: contextRel,
+    contextPath: relMilestoneFile(base, mid, "CONTEXT"),
     outputPath: join(base, outputRelPath),
     inlinedContext,
     skillActivation: buildSkillActivationBlock({

--- a/src/resources/extensions/gsd/auto-prompts.ts
+++ b/src/resources/extensions/gsd/auto-prompts.ts
@@ -2211,20 +2211,30 @@ export async function buildReplanSlicePrompt(
 export async function buildRunUatPrompt(
   mid: string, sliceId: string, uatPath: string, uatContent: string, base: string,
 ): Promise<string> {
-  const inlined: string[] = [];
-  inlined.push(await inlineFile(resolveSliceFile(base, mid, sliceId, "UAT"), uatPath, `${sliceId} UAT`));
+  // #4782 phase 3: run-uat migrated to compose its inlined context via
+  // the manifest. Behavior-equivalent — resolver dispatches to the same
+  // inline* helpers as the pre-migration builder.
+  const resolveArtifact: ArtifactResolver = async (key) => {
+    switch (key) {
+      case "slice-uat": {
+        const p = resolveSliceFile(base, mid, sliceId, "UAT");
+        return await inlineFile(p, uatPath, `${sliceId} UAT`);
+      }
+      case "slice-summary": {
+        const p = resolveSliceFile(base, mid, sliceId, "SUMMARY");
+        if (!p) return null;
+        const r = relSliceFile(base, mid, sliceId, "SUMMARY");
+        return await inlineFileOptional(p, r, `${sliceId} Summary`);
+      }
+      case "project":
+        return await inlineProjectFromDb(base);
+      default:
+        return null;
+    }
+  };
 
-  const summaryPath = resolveSliceFile(base, mid, sliceId, "SUMMARY");
-  const summaryRel = relSliceFile(base, mid, sliceId, "SUMMARY");
-  if (summaryPath) {
-    const summaryInline = await inlineFileOptional(summaryPath, summaryRel, `${sliceId} Summary`);
-    if (summaryInline) inlined.push(summaryInline);
-  }
-
-  const projectInline = await inlineProjectFromDb(base);
-  if (projectInline) inlined.push(projectInline);
-
-  const inlinedContext = capPreamble(`## Inlined Context (preloaded — do not re-read these files)\n\n${inlined.join("\n\n---\n\n")}`);
+  const composed = await composeInlinedContext("run-uat", resolveArtifact);
+  const inlinedContext = capPreamble(`## Inlined Context (preloaded — do not re-read these files)\n\n${composed}`);
 
   const uatResultPath = join(base, relSliceFile(base, mid, sliceId, "ASSESSMENT"));
   const uatType = getUatType(uatContent);

--- a/src/resources/extensions/gsd/auto-prompts.ts
+++ b/src/resources/extensions/gsd/auto-prompts.ts
@@ -33,6 +33,7 @@ import {
 } from "./gate-registry.js";
 import { formatDecisionsCompact, formatRequirementsCompact } from "./structured-data-formatter.js";
 import { readPhaseAnchor, formatAnchorForPrompt } from "./phase-anchor.js";
+import { composeInlinedContext, type ArtifactResolver } from "./unit-context-composer.js";
 import { logWarning } from "./workflow-logger.js";
 import { inlineGraphSubgraph } from "./graph-context.js";
 import { buildExtractionStepsBlock } from "./commands-extract-learnings.js";
@@ -2250,31 +2251,54 @@ export async function buildReassessRoadmapPrompt(
   mid: string, midTitle: string, completedSliceId: string, base: string, level?: InlineLevel,
 ): Promise<string> {
   const inlineLevel = level ?? resolveInlineLevel();
-  const roadmapPath = resolveMilestoneFile(base, mid, "ROADMAP");
-  const roadmapRel = relMilestoneFile(base, mid, "ROADMAP");
-  const summaryPath = resolveSliceFile(base, mid, completedSliceId, "SUMMARY");
-  const summaryRel = relSliceFile(base, mid, completedSliceId, "SUMMARY");
-  const sliceContextPath = resolveSliceFile(base, mid, completedSliceId, "CONTEXT");
-  const sliceContextRel = relSliceFile(base, mid, completedSliceId, "CONTEXT");
 
-  const inlined: string[] = [];
-  inlined.push(await inlineFile(roadmapPath, roadmapRel, "Current Roadmap"));
-  const sliceCtxInline = await inlineFileOptional(sliceContextPath, sliceContextRel, "Slice Context (from discussion)");
-  if (sliceCtxInline) inlined.push(sliceCtxInline);
-  inlined.push(await inlineFile(summaryPath, summaryRel, `${completedSliceId} Summary`));
-  if (inlineLevel !== "minimal") {
-    const projectInline = await inlineProjectFromDb(base);
-    if (projectInline) inlined.push(projectInline);
-    const requirementsInline = await inlineRequirementsFromDb(base, mid, undefined, inlineLevel);
-    if (requirementsInline) inlined.push(requirementsInline);
-    const decisionsInline = await inlineDecisionsFromDb(base, mid, undefined, inlineLevel);
-    if (decisionsInline) inlined.push(decisionsInline);
-  }
-  // Scoped + budgeted — see issue #4719
+  // #4782 phase 2 pilot: reassess-roadmap is the first unit type to
+  // compose its inlined context through the manifest-driven composer.
+  // The resolver below dispatches artifact keys to the existing inline*
+  // helpers, preserving identical output so the migration is
+  // observable-equivalent. Knowledge stays outside the composer (it's
+  // budget-driven, not manifest-driven) until a later phase formalizes
+  // knowledge/memory policies as composer inputs.
+  const resolveArtifact: ArtifactResolver = async (key) => {
+    switch (key) {
+      case "roadmap": {
+        const p = resolveMilestoneFile(base, mid, "ROADMAP");
+        const r = relMilestoneFile(base, mid, "ROADMAP");
+        return await inlineFile(p, r, "Current Roadmap");
+      }
+      case "slice-context": {
+        const p = resolveSliceFile(base, mid, completedSliceId, "CONTEXT");
+        const r = relSliceFile(base, mid, completedSliceId, "CONTEXT");
+        return await inlineFileOptional(p, r, "Slice Context (from discussion)");
+      }
+      case "slice-summary": {
+        const p = resolveSliceFile(base, mid, completedSliceId, "SUMMARY");
+        const r = relSliceFile(base, mid, completedSliceId, "SUMMARY");
+        return await inlineFile(p, r, `${completedSliceId} Summary`);
+      }
+      case "project":
+        if (inlineLevel === "minimal") return null;
+        return await inlineProjectFromDb(base);
+      case "requirements":
+        if (inlineLevel === "minimal") return null;
+        return await inlineRequirementsFromDb(base, mid, undefined, inlineLevel);
+      case "decisions":
+        if (inlineLevel === "minimal") return null;
+        return await inlineDecisionsFromDb(base, mid, undefined, inlineLevel);
+      default:
+        return null;
+    }
+  };
+
+  const composed = await composeInlinedContext("reassess-roadmap", resolveArtifact);
+  const parts: string[] = [];
+  if (composed) parts.push(composed);
+  // Knowledge block stays outside the composer — budgeted, scoped via
+  // keyword extraction (#4719). Future phase folds it in.
   const knowledgeInlineRA = await inlineKnowledgeBudgeted(base, extractKeywords(midTitle));
-  if (knowledgeInlineRA) inlined.push(knowledgeInlineRA);
+  if (knowledgeInlineRA) parts.push(knowledgeInlineRA);
 
-  const inlinedContext = capPreamble(`## Inlined Context (preloaded — do not re-read these files)\n\n${inlined.join("\n\n---\n\n")}`);
+  const inlinedContext = capPreamble(`## Inlined Context (preloaded — do not re-read these files)\n\n${parts.join("\n\n---\n\n")}`);
 
   const assessmentPath = join(base, relSliceFile(base, mid, completedSliceId, "ASSESSMENT"));
 
@@ -2299,7 +2323,7 @@ export async function buildReassessRoadmapPrompt(
     milestoneId: mid,
     milestoneTitle: midTitle,
     completedSliceId,
-    roadmapPath: roadmapRel,
+    roadmapPath: relMilestoneFile(base, mid, "ROADMAP"),
     assessmentPath,
     inlinedContext,
     deferredCaptures,

--- a/src/resources/extensions/gsd/tests/research-milestone-composer.test.ts
+++ b/src/resources/extensions/gsd/tests/research-milestone-composer.test.ts
@@ -1,0 +1,97 @@
+// GSD-2 — #4782 phase 3 batch 2: research-milestone migrated through composer.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { buildResearchMilestonePrompt } from "../auto-prompts.ts";
+import { invalidateAllCaches } from "../cache.ts";
+import {
+  openDatabase,
+  closeDatabase,
+  insertMilestone,
+  upsertMilestonePlanning,
+} from "../gsd-db.ts";
+
+function makeBase(): string {
+  const base = mkdtempSync(join(tmpdir(), "gsd-research-ms-composer-"));
+  mkdirSync(join(base, ".gsd", "milestones", "M001"), { recursive: true });
+  return base;
+}
+
+function cleanup(base: string): void {
+  try { closeDatabase(); } catch { /* noop */ }
+  invalidateAllCaches();
+  rmSync(base, { recursive: true, force: true });
+}
+
+function seed(base: string, mid: string): void {
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: mid, title: "Research Test", status: "active", depends_on: [] });
+  upsertMilestonePlanning(mid, {
+    title: "Research Test",
+    status: "active",
+    vision: "Research composer migration",
+    successCriteria: ["Prompt compiles"],
+    keyRisks: [],
+    proofStrategy: [],
+    verificationContract: "",
+    verificationIntegration: "",
+    verificationOperational: "",
+    verificationUat: "",
+    definitionOfDone: [],
+    requirementCoverage: "",
+    boundaryMapMarkdown: "",
+  });
+}
+
+test("#4782 phase 3: buildResearchMilestonePrompt emits milestone-context then research template via composer", async (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  invalidateAllCaches();
+
+  seed(base, "M001");
+
+  writeFileSync(
+    join(base, ".gsd", "milestones", "M001", "M001-CONTEXT.md"),
+    "# M001 Context\n\nA research test milestone.\n",
+  );
+
+  const prompt = await buildResearchMilestonePrompt("M001", "Research Test", base);
+
+  // Context wrapper present
+  assert.match(prompt, /## Inlined Context \(preloaded — do not re-read these files\)/);
+
+  // Milestone context inlined first (manifest order)
+  assert.match(prompt, /### Milestone Context/);
+  assert.match(prompt, /A research test milestone/);
+
+  // Research template inlined as the templates artifact
+  assert.match(prompt, /### Output Template: Research/);
+
+  // Ordering: milestone-context precedes the research template
+  const contextIdx = prompt.indexOf("### Milestone Context");
+  const researchIdx = prompt.indexOf("### Output Template: Research");
+  assert.ok(contextIdx > -1 && researchIdx > contextIdx,
+    `milestone-context (${contextIdx}) must precede research template (${researchIdx})`);
+});
+
+test("#4782 phase 3: buildResearchMilestonePrompt still includes project + requirements + decisions in declared order", async (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  invalidateAllCaches();
+
+  seed(base, "M001");
+  writeFileSync(join(base, ".gsd", "milestones", "M001", "M001-CONTEXT.md"), "# M001 Context\n");
+
+  const prompt = await buildResearchMilestonePrompt("M001", "Research Test", base);
+
+  // Manifest-declared order: milestone-context, project, requirements, decisions, templates.
+  // Any projections that resolve to content must preserve that order.
+  const contextIdx = prompt.indexOf("### Milestone Context");
+  const researchIdx = prompt.indexOf("### Output Template: Research");
+  assert.ok(contextIdx > -1 && researchIdx > contextIdx,
+    "milestone-context must come before research template regardless of which optional artifacts are present");
+});

--- a/src/resources/extensions/gsd/tests/run-uat-composer.test.ts
+++ b/src/resources/extensions/gsd/tests/run-uat-composer.test.ts
@@ -1,0 +1,113 @@
+// GSD-2 — #4782 phase 3: run-uat migrated to compose context via manifest.
+// Regression test: prompt still carries the declared artifacts in the
+// expected shape after the migration.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { buildRunUatPrompt } from "../auto-prompts.ts";
+import { invalidateAllCaches } from "../cache.ts";
+import {
+  openDatabase,
+  closeDatabase,
+  insertMilestone,
+  upsertMilestonePlanning,
+  insertSlice,
+} from "../gsd-db.ts";
+
+function makeBase(): string {
+  const base = mkdtempSync(join(tmpdir(), "gsd-runuat-composer-"));
+  mkdirSync(join(base, ".gsd", "milestones", "M001", "slices", "S01", "tasks"), { recursive: true });
+  return base;
+}
+
+function cleanup(base: string): void {
+  try { closeDatabase(); } catch { /* noop */ }
+  invalidateAllCaches();
+  rmSync(base, { recursive: true, force: true });
+}
+
+function seed(base: string, mid: string): void {
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: mid, title: "Test", status: "active", depends_on: [] });
+  upsertMilestonePlanning(mid, {
+    title: "Test Milestone",
+    status: "active",
+    vision: "Demo the composer migration",
+    successCriteria: ["Prompt compiles", "UAT passes"],
+    keyRisks: [],
+    proofStrategy: [],
+    verificationContract: "",
+    verificationIntegration: "",
+    verificationOperational: "",
+    verificationUat: "",
+    definitionOfDone: [],
+    requirementCoverage: "",
+    boundaryMapMarkdown: "",
+  });
+  insertSlice({
+    id: "S01",
+    milestoneId: mid,
+    title: "First",
+    status: "complete",
+    risk: "low",
+    depends: [],
+    demo: "",
+    sequence: 1,
+  });
+}
+
+test("#4782 phase 3: buildRunUatPrompt inlines slice UAT, slice summary, project via composer", async (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  invalidateAllCaches();
+
+  seed(base, "M001");
+
+  // Write UAT + SUMMARY files for the slice
+  const uatRel = ".gsd/milestones/M001/slices/S01/S01-UAT.md";
+  writeFileSync(join(base, uatRel), "# S01 UAT\n\n- Check X\n- Check Y\n");
+  writeFileSync(
+    join(base, ".gsd", "milestones", "M001", "slices", "S01", "S01-SUMMARY.md"),
+    "---\nid: S01\nparent: M001\n---\n# S01 Summary\n**One-liner**\n\n## What Happened\nShip.\n",
+  );
+
+  const uatContent = "# S01 UAT\n\n- Check X\n- Check Y\n";
+  const prompt = await buildRunUatPrompt("M001", "S01", uatRel, uatContent, base);
+
+  // Context wrapper present
+  assert.match(prompt, /## Inlined Context \(preloaded — do not re-read these files\)/);
+
+  // Artifacts from the manifest inline list, in declared order
+  assert.match(prompt, /### S01 UAT[\s\S]*### S01 Summary/);
+
+  // UAT body content inlined
+  assert.match(prompt, /Check X[\s\S]*Check Y/);
+
+  // Summary body content inlined
+  assert.match(prompt, /What Happened[\s\S]*Ship/);
+});
+
+test("#4782 phase 3: buildRunUatPrompt omits optional slice summary when file is missing", async (t) => {
+  const base = makeBase();
+  t.after(() => cleanup(base));
+  invalidateAllCaches();
+
+  seed(base, "M001");
+
+  const uatRel = ".gsd/milestones/M001/slices/S01/S01-UAT.md";
+  writeFileSync(join(base, uatRel), "# S01 UAT\n");
+  // No SUMMARY.md written — composer should skip the slice-summary key.
+
+  const prompt = await buildRunUatPrompt("M001", "S01", uatRel, "# S01 UAT\n", base);
+
+  // UAT still present
+  assert.match(prompt, /### S01 UAT/);
+  // No empty "S01 Summary" section — section body would be blank without a file
+  assert.ok(!prompt.includes("### S01 Summary"));
+  // No double separator from a skipped block
+  assert.ok(!prompt.includes("---\n\n---"));
+});

--- a/src/resources/extensions/gsd/tests/unit-context-composer.test.ts
+++ b/src/resources/extensions/gsd/tests/unit-context-composer.test.ts
@@ -1,0 +1,175 @@
+// GSD-2 — #4782 phase 2 composer tests. Pure-function tests using mock
+// resolvers plus an integration check that reassess-roadmap's migrated
+// builder produces a prompt matching expectations.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import {
+  composeInlinedContext,
+  manifestBudgetChars,
+  type ArtifactResolver,
+} from "../unit-context-composer.ts";
+import type { ArtifactKey } from "../unit-context-manifest.ts";
+import { buildReassessRoadmapPrompt } from "../auto-prompts.ts";
+import { invalidateAllCaches } from "../cache.ts";
+import {
+  openDatabase,
+  closeDatabase,
+  insertMilestone,
+  upsertMilestonePlanning,
+  insertSlice,
+} from "../gsd-db.ts";
+
+// ─── Pure composer tests ──────────────────────────────────────────────────
+
+test("#4782 composer: returns empty string for unknown unit type", async () => {
+  const out = await composeInlinedContext("never-dispatched", async () => "body");
+  assert.strictEqual(out, "");
+});
+
+test("#4782 composer: walks the manifest's inline list in declared order", async () => {
+  // reassess-roadmap manifest: [roadmap, slice-context, slice-summary, project, requirements, decisions]
+  const calls: ArtifactKey[] = [];
+  const resolver: ArtifactResolver = async (key) => {
+    calls.push(key);
+    return `BODY:${key}`;
+  };
+  const out = await composeInlinedContext("reassess-roadmap", resolver);
+  assert.deepEqual(calls, [
+    "roadmap",
+    "slice-context",
+    "slice-summary",
+    "project",
+    "requirements",
+    "decisions",
+  ]);
+  // Output joins blocks with the "---" separator.
+  assert.match(out, /BODY:roadmap\n\n---\n\nBODY:slice-context/);
+});
+
+test("#4782 composer: null-returning resolvers are silently omitted", async () => {
+  const resolver: ArtifactResolver = async (key) => {
+    if (key === "slice-context" || key === "project") return null;
+    return `BODY:${key}`;
+  };
+  const out = await composeInlinedContext("reassess-roadmap", resolver);
+  // slice-context + project skipped — not in output, no empty blocks
+  assert.ok(!out.includes("BODY:slice-context"));
+  assert.ok(!out.includes("BODY:project"));
+  // Remaining keys still emitted in declared order
+  assert.match(out, /BODY:roadmap\n\n---\n\nBODY:slice-summary\n\n---\n\nBODY:requirements\n\n---\n\nBODY:decisions/);
+});
+
+test("#4782 composer: empty-string resolvers are omitted (treated as no-op)", async () => {
+  const resolver: ArtifactResolver = async (key) => {
+    if (key === "slice-context") return "";
+    if (key === "slice-summary") return null;
+    return `BODY:${key}`;
+  };
+  const out = await composeInlinedContext("reassess-roadmap", resolver);
+  assert.ok(!out.includes("BODY:slice-context"));
+  assert.ok(!out.includes("BODY:slice-summary"));
+  // Must not leave double-separators when blocks are skipped
+  assert.ok(!out.includes("---\n\n---"));
+});
+
+test("#4782 composer: resolver errors surface to caller", async () => {
+  const resolver: ArtifactResolver = async () => {
+    throw new Error("resolver boom");
+  };
+  await assert.rejects(
+    () => composeInlinedContext("reassess-roadmap", resolver),
+    /resolver boom/,
+  );
+});
+
+test("#4782 composer: manifestBudgetChars returns declared budget", () => {
+  const small = manifestBudgetChars("reassess-roadmap");
+  assert.ok(small !== null && small > 0);
+  assert.strictEqual(manifestBudgetChars("never-dispatched"), null);
+});
+
+// ─── Integration: migrated buildReassessRoadmapPrompt ─────────────────────
+
+function makeFixtureBase(): string {
+  const base = mkdtempSync(join(tmpdir(), "gsd-composer-pilot-"));
+  mkdirSync(join(base, ".gsd", "milestones", "M001", "slices", "S01", "tasks"), { recursive: true });
+  return base;
+}
+
+function cleanup(base: string): void {
+  try { closeDatabase(); } catch { /* noop */ }
+  invalidateAllCaches();
+  rmSync(base, { recursive: true, force: true });
+}
+
+function seed(base: string, mid: string): void {
+  openDatabase(join(base, ".gsd", "gsd.db"));
+  insertMilestone({ id: mid, title: "Test", status: "active", depends_on: [] });
+  upsertMilestonePlanning(mid, {
+    title: "Test",
+    status: "active",
+    vision: "Ship it",
+    successCriteria: ["It ships"],
+    keyRisks: [],
+    proofStrategy: [],
+    verificationContract: "",
+    verificationIntegration: "",
+    verificationOperational: "",
+    verificationUat: "",
+    definitionOfDone: [],
+    requirementCoverage: "",
+    boundaryMapMarkdown: "",
+  });
+  insertSlice({
+    id: "S01",
+    milestoneId: mid,
+    title: "First",
+    status: "complete",
+    risk: "low",
+    depends: [],
+    demo: "",
+    sequence: 1,
+  });
+}
+
+function writeArtifacts(base: string): void {
+  writeFileSync(
+    join(base, ".gsd", "milestones", "M001", "M001-ROADMAP.md"),
+    "# M001\n## Slices\n- [x] **S01: First** `risk:low` `depends:[]`\n",
+  );
+  writeFileSync(
+    join(base, ".gsd", "milestones", "M001", "slices", "S01", "S01-SUMMARY.md"),
+    "---\nid: S01\nparent: M001\n---\n# S01 Summary\n**One-liner**\n\n## What Happened\nDone.\n",
+  );
+}
+
+test("#4782 phase 2: buildReassessRoadmapPrompt emits composer-shaped context with manifest-declared artifacts", async (t) => {
+  const base = makeFixtureBase();
+  t.after(() => cleanup(base));
+  invalidateAllCaches();
+
+  seed(base, "M001");
+  writeArtifacts(base);
+
+  const prompt = await buildReassessRoadmapPrompt("M001", "Test", "S01", base);
+
+  // Context block wrapper from capPreamble
+  assert.match(prompt, /## Inlined Context \(preloaded — do not re-read these files\)/);
+
+  // Roadmap inlined first (manifest order)
+  assert.match(prompt, /### Current Roadmap/);
+  assert.match(prompt, /S01: First/);
+
+  // Slice summary present
+  assert.match(prompt, /### S01 Summary/);
+  assert.match(prompt, /One-liner/);
+
+  // Slice context is optional and not present in this fixture — must not
+  // leave a stray empty section
+  assert.ok(!prompt.includes("Slice Context (from discussion)"));
+});

--- a/src/resources/extensions/gsd/tests/unit-context-manifest.test.ts
+++ b/src/resources/extensions/gsd/tests/unit-context-manifest.test.ts
@@ -155,15 +155,17 @@ test("#4782 phase 1: complete-milestone manifest declares slice-summary as excer
   );
 });
 
-// ─── Phase-2 target: reassess-roadmap manifest is the tightest budget ────
+// ─── Budget floor: run-uat + gate-evaluate hit the smallest budget tier ──
 
-test("#4782 phase 1: reassess-roadmap manifest has the smallest budget among manifests", () => {
-  const m = UNIT_MANIFESTS["reassess-roadmap"];
+test("#4782 phase 2: run-uat and gate-evaluate use the smallest budget tier", () => {
+  const uatBudget = UNIT_MANIFESTS["run-uat"].maxSystemPromptChars;
+  const gateBudget = UNIT_MANIFESTS["gate-evaluate"].maxSystemPromptChars;
+  assert.strictEqual(uatBudget, gateBudget, "run-uat and gate-evaluate both use COMMON_BUDGET_SMALL");
+  // They should be the tightest (or tied for tightest) across all manifests
   for (const [unitType, other] of Object.entries(UNIT_MANIFESTS)) {
-    if (unitType === "reassess-roadmap") continue;
     assert.ok(
-      m.maxSystemPromptChars <= other.maxSystemPromptChars,
-      `reassess-roadmap budget (${m.maxSystemPromptChars}) should be ≤ ${unitType} budget (${other.maxSystemPromptChars})`,
+      uatBudget <= other.maxSystemPromptChars,
+      `run-uat budget (${uatBudget}) should be ≤ ${unitType} budget (${other.maxSystemPromptChars})`,
     );
   }
 });

--- a/src/resources/extensions/gsd/unit-context-composer.ts
+++ b/src/resources/extensions/gsd/unit-context-composer.ts
@@ -1,0 +1,73 @@
+// GSD-2 — UnitContextComposer (#4782 phase 2).
+//
+// Reads a unit type's manifest and orchestrates artifact inlining through
+// a caller-provided resolver. Returns a joined context block suitable for
+// substitution into the unit's prompt template.
+//
+// Design rationale:
+//   - Pure dependency on the manifest module — no circular import with
+//     `auto-prompts.ts` where the per-artifact-key resolver lives.
+//   - Caller-supplied resolver means the composer can be unit-tested with
+//     trivial mocks; production wiring in `auto-prompts.ts` dispatches to
+//     the existing `inlineFile` / `inline*FromDb` helpers.
+//   - Null-returning resolvers are skipped silently: they model the
+//     "artifact is optional / missing / not applicable to this milestone"
+//     case. The composer never errors on a missing artifact.
+//
+// Scope: phase 2 pilot. The composer currently handles only the `inline`
+// artifact list. Excerpt and on-demand artifact shapes (already used by
+// #4780) will be folded in during phase 3 when the remaining unit types
+// migrate into the composer.
+
+import {
+  resolveManifest,
+  type ArtifactKey,
+  type UnitContextManifest,
+} from "./unit-context-manifest.js";
+
+/**
+ * Async function mapping an artifact key to its inlined-content string,
+ * or `null` when the artifact does not apply to the current milestone
+ * (missing file, empty table, etc).
+ */
+export type ArtifactResolver = (key: ArtifactKey) => Promise<string | null>;
+
+/**
+ * Produce the inlined-context portion of a unit's system prompt by
+ * walking the manifest's `artifacts.inline` list in order and calling
+ * the provided resolver for each key.
+ *
+ * Returns an empty string when the unit type has no manifest registered,
+ * so callers can guard their wiring with a simple truthy check. Unknown
+ * unit types do not error — this mirrors `resolveManifest`'s contract.
+ *
+ * The separator between inlined blocks matches the in-tree convention
+ * (`\n\n---\n\n`) so composer output slots into existing prompt templates
+ * without visible diff.
+ */
+export async function composeInlinedContext(
+  unitType: string,
+  resolveArtifact: ArtifactResolver,
+): Promise<string> {
+  const manifest: UnitContextManifest | null = resolveManifest(unitType);
+  if (!manifest) return "";
+
+  const blocks: string[] = [];
+  for (const key of manifest.artifacts.inline) {
+    const body = await resolveArtifact(key);
+    if (body !== null && body.length > 0) {
+      blocks.push(body);
+    }
+  }
+  return blocks.join("\n\n---\n\n");
+}
+
+/**
+ * Convenience helper returning the manifest's declared budget so callers
+ * can telemetry a mismatch between actual prompt size and declared budget.
+ * Returns null for unknown unit types.
+ */
+export function manifestBudgetChars(unitType: string): number | null {
+  const manifest = resolveManifest(unitType);
+  return manifest ? manifest.maxSystemPromptChars : null;
+}

--- a/src/resources/extensions/gsd/unit-context-manifest.ts
+++ b/src/resources/extensions/gsd/unit-context-manifest.ts
@@ -347,7 +347,11 @@ export const UNIT_MANIFESTS: Record<UnitType, UnitContextManifest> = {
     codebaseMap: false,
     preferences: "active-only",
     artifacts: {
-      inline: ["slice-uat", "slice-plan"],
+      // Phase 3 migration (#4782): manifest matches today's actual
+      // buildRunUatPrompt inlining. Prior phase-1 entry listed
+      // `slice-plan` aspirationally — the real builder inlines the UAT
+      // file, the slice SUMMARY (optional), and the project row.
+      inline: ["slice-uat", "slice-summary", "project"],
       excerpt: [],
       onDemand: [],
     },

--- a/src/resources/extensions/gsd/unit-context-manifest.ts
+++ b/src/resources/extensions/gsd/unit-context-manifest.ts
@@ -44,6 +44,7 @@ export const ARTIFACT_KEYS = [
   "milestone-research",
   "milestone-plan",
   // Slice-scoped
+  "slice-context",
   "slice-research",
   "slice-plan",
   "slice-summary",
@@ -295,16 +296,19 @@ export const UNIT_MANIFESTS: Record<UnitType, UnitContextManifest> = {
   },
   "reassess-roadmap": {
     skills: { mode: "all" },
-    knowledge: "critical-only",
+    knowledge: "scoped",
     memory: "critical-only",
     codebaseMap: false,
     preferences: "none",
     artifacts: {
-      inline: ["roadmap", "slice-summary"],
+      // Phase 2 pilot (#4782): manifest now matches today's actual
+      // buildReassessRoadmapPrompt behavior for equivalence. Phase 3
+      // will tighten this list once the composer reports real telemetry.
+      inline: ["roadmap", "slice-context", "slice-summary", "project", "requirements", "decisions"],
       excerpt: [],
       onDemand: [],
     },
-    maxSystemPromptChars: COMMON_BUDGET_SMALL,
+    maxSystemPromptChars: COMMON_BUDGET_MEDIUM,
   },
 
   // ─── Task-scoped ─────────────────────────────────────────────────────

--- a/src/resources/extensions/gsd/unit-context-manifest.ts
+++ b/src/resources/extensions/gsd/unit-context-manifest.ts
@@ -166,7 +166,9 @@ export const UNIT_MANIFESTS: Record<UnitType, UnitContextManifest> = {
     codebaseMap: true,
     preferences: "active-only",
     artifacts: {
-      inline: ["project", "requirements", "decisions", "templates"],
+      // Phase 3 migration (#4782): matches today's actual
+      // buildResearchMilestonePrompt inlining order.
+      inline: ["milestone-context", "project", "requirements", "decisions", "templates"],
       excerpt: [],
       onDemand: [],
     },


### PR DESCRIPTION
> ## ⚠️ Draft — stacked on [#4922](https://github.com/gsd-build/gsd-2/pull/4922) → [#4921](https://github.com/gsd-build/gsd-2/pull/4921)
>
> Until both ancestors merge to main, this PR's diff includes their commits. Will rebase onto main post-merge.

## TL;DR

**What:** Third composer migration. \`buildResearchMilestonePrompt\` now assembles its inlined context via the manifest. First migration that exercises the \`templates\` artifact key (research output template).
**Why:** Continue the phase-3 rollout with a clean-fit builder. Validates the manifest-driven composer handles the templates artifact and knowledge-block ordering.
**How:** Local resolver dispatches [milestone-context, project, requirements, decisions, templates] to existing inline helpers. Knowledge splices in before the templates block to preserve pre-migration output order.

## Realistic scope note for phase 3

During batch-2 exploration I confirmed the composer pattern is **right-sized for simple prompts**, not the complex ones. Builders like \`plan-slice\` / \`refine-slice\` (via \`renderSlicePrompt\`), \`execute-task\`, \`replan-slice\`, \`complete-milestone\`, and \`validate-milestone\` have computed inline blocks (phase anchors, roadmap excerpts, graph subgraphs, blocker-task discovery, overrides) that don't cleanly fit the \`ArtifactKey\` enum. Migrating them requires either extending the composer contract to support computed blocks, or adding more specialized artifact keys.

**Recommendation:** Phase 3 scopes to simple builders. A dedicated phase 3.5 or phase 4 would extend the composer contract and migrate the complex cluster. The simple migrations already demonstrate the seam is valuable for routine context tuning.

Tentative phase-3 scope (simple fits):
- ✅ reassess-roadmap (#4921, pilot)
- ✅ run-uat (#4922)
- ✅ **research-milestone (this PR)**
- ⏳ complete-slice (pending, similar shape to run-uat)
- ⏳ rewrite-docs (pending, similar shape)
- ⏳ discuss-milestone (pending, has no inlinedContext at all — may be trivially skip-able)

Deferred to phase 3.5 / phase 4:
- plan-slice, refine-slice, research-slice (renderSlicePrompt shape)
- execute-task, reactive-execute
- replan-slice
- complete-milestone (already uses excerpt logic from #4908)
- validate-milestone
- gate-evaluate (subagent-section shape)
- plan-milestone

## What (this PR)

- \`unit-context-manifest.ts\` — research-milestone manifest corrected to match today's inline list: [milestone-context, project, requirements, decisions, templates].
- \`auto-prompts.ts\` — \`buildResearchMilestonePrompt\` composes via manifest; knowledge splices in before templates block.
- \`tests/research-milestone-composer.test.ts\` — 2 regression tests covering full-fixture ordering and sparse-fixture resilience.

## Local verification

**11/11 tests passing** across research-milestone + run-uat + unit-context-composer.

## Change type

- [x] \`feat\` — Third migration. Observable-equivalent output for realistic fixtures.

## Breaking changes

**None.** Output is order-preserving and byte-equivalent for realistic inputs.

AI-assisted PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured context composition for research milestones, UAT assessments, and roadmap reviews to use a manifest-driven approach, improving modularity and configuration management.

* **Tests**
  * Added comprehensive test coverage for the new context composition system, including research milestone prompts, UAT builds, and roadmap reassessments.

* **Chores**
  * Updated artifact key declarations and manifest configurations to support the new architecture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->